### PR TITLE
fix ledger ErrNoEntry issue due to sqlite

### DIFF
--- a/util/db/dbutil.go
+++ b/util/db/dbutil.go
@@ -212,8 +212,6 @@ func URI(filename string, readOnly bool, memory bool) string {
 	}
 	if memory {
 		uri += "&mode=memory"
-	}
-	if readOnly || memory {
 		uri += "&cache=shared"
 	}
 	return uri


### PR DESCRIPTION
We see unexpected behavior when we have 1 thread doing inserts, and 2 threads doing selects of recently-inserted rows. One of the threads doing selects will get sql.ErrNoRows even though it is querying a row that was already committed by an insert.

The issue might be that shared-cache connections provide serializability but not strict serializability; see:

    http://mailinglists.sqlite.org/cgi-bin/mailman/private/sqlite-users/2019-June/084813.html

As a workaround, stop using shared caches in sqlite. The shared cache isn't that important for our workload, and I can't reproduce the ledger bug when running in a no-shared-cache configuration.

By using private caches (no shared cache), we also maintain the performance optimization of allowing concurrent reads and writes (and, specifically, TestDBConcurrency passes).