### PR TITLE
fix filter for next round period 0 votes

### DIFF
--- a/agreement/voteAggregator.go
+++ b/agreement/voteAggregator.go
@@ -248,8 +248,13 @@ func voteFresh(proto protocol.ConsensusVersion, freshData freshnessData, vote un
 		return fmt.Errorf("filtered vote from bad round: player.Round=%v; vote.Round=%v", freshData.PlayerRound, vote.R.Round)
 	}
 
-	if freshData.PlayerRound+1 == vote.R.Round && (vote.R.Period > 0 || vote.R.Step > next) {
-		return fmt.Errorf("filtered future vote from bad period or step: player.Round=%v; vote.(Round,Period,Step)=(%v,%v,%v)", freshData.PlayerRound, vote.R.Round, vote.R.Period, vote.R.Step)
+	if freshData.PlayerRound+1 == vote.R.Round {
+		if (vote.R.Period > 0 || vote.R.Step > next) {
+			return fmt.Errorf("filtered future vote from bad period or step: player.Round=%v; vote.(Round,Period,Step)=(%v,%v,%v)", freshData.PlayerRound, vote.R.Round, vote.R.Period, vote.R.Step)
+		} else {
+			// pipeline votes from next round period 0
+			return nil
+		}
 	}
 
 	switch vote.R.Period {

--- a/agreement/voteAggregator.go
+++ b/agreement/voteAggregator.go
@@ -251,10 +251,9 @@ func voteFresh(proto protocol.ConsensusVersion, freshData freshnessData, vote un
 	if freshData.PlayerRound+1 == vote.R.Round {
 		if (vote.R.Period > 0 || vote.R.Step > next) {
 			return fmt.Errorf("filtered future vote from bad period or step: player.Round=%v; vote.(Round,Period,Step)=(%v,%v,%v)", freshData.PlayerRound, vote.R.Round, vote.R.Period, vote.R.Step)
-		} else {
-			// pipeline votes from next round period 0
-			return nil
 		}
+		// pipeline votes from next round period 0
+		return nil
 	}
 
 	switch vote.R.Period {


### PR DESCRIPTION
This fixes a deviation from the spec. Currently, the code
(accidentally) filters all votePresent and voteVerified events
from the next round, if myPlayer.Period is large. Instead,
whether we filter votes from the next round should not be a
function of current period. As specified in the spec, we allow
votes with vote.Round = player.Round + 1 and vote.Period == 0
and vote.Step = {propose,soft,cert,next}