### PR TITLE
goal clerk inspect: more base32+checksum fixes

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -364,6 +364,7 @@ var inspectCmd = &cobra.Command{
 					reportErrorf(txDecodeError, txFilename, err)
 				}
 				fmt.Printf("%s[%d]\n%s\n\n", txFilename, count, string(protocol.EncodeJSON(sti)))
+				count++
 			}
 		}
 	},

--- a/cmd/goal/inspect.go
+++ b/cmd/goal/inspect.go
@@ -32,9 +32,9 @@ import (
 type inspectSignedTxn struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	Sig  crypto.Signature         `codec:"sig"`
-	Msig inspectMultisigSig       `codec:"msig"`
-	Txn  transactions.Transaction `codec:"txn"`
+	Sig  crypto.Signature   `codec:"sig"`
+	Msig inspectMultisigSig `codec:"msig"`
+	Txn  inspectTransaction `codec:"txn"`
 }
 
 // inspectMultisigSig is isomorphic to MultisigSig but uses different
@@ -52,32 +52,90 @@ type inspectMultisigSig struct {
 type inspectMultisigSubsig struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	Key basics.Address   `codec:"pk"`
+	Key checksumAddress  `codec:"pk"`
 	Sig crypto.Signature `codec:"s"`
 }
 
+// inspectTransaction is isomorphic to Transaction but uses different
+// types to print public keys using algorand's address format in JSON.
+type inspectTransaction struct {
+	_struct struct{} `codec:",omitempty,omitemptyarray"`
+
+	Type protocol.TxType `codec:"type"`
+	inspectTxnHeader
+	transactions.KeyregTxnFields
+	inspectPaymentTxnFields
+}
+
+// inspectTxnHeader is isomorphic to Header but uses different
+// types to print public keys using algorand's address format in JSON.
+type inspectTxnHeader struct {
+	_struct struct{} `codec:",omitempty,omitemptyarray"`
+
+	Sender      checksumAddress   `codec:"snd"`
+	Fee         basics.MicroAlgos `codec:"fee"`
+	FirstValid  basics.Round      `codec:"fv"`
+	LastValid   basics.Round      `codec:"lv"`
+	Note        []byte            `codec:"note"`
+	GenesisID   string            `codec:"gen"`
+	GenesisHash crypto.Digest     `codec:"gh"`
+}
+
+// inspectPaymentTxnFields is isomorphic to Header but uses different
+// types to print public keys using algorand's address format in JSON.
+type inspectPaymentTxnFields struct {
+	_struct struct{} `codec:",omitempty,omitemptyarray"`
+
+	Receiver         checksumAddress   `codec:"rcv"`
+	Amount           basics.MicroAlgos `codec:"amt"`
+	CloseRemainderTo checksumAddress   `codec:"close"`
+}
+
+// checksumAddress is a checksummed address, for use with text encodings
+// like JSON.
+type checksumAddress basics.Address
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface
+func (a *checksumAddress) UnmarshalText(text []byte) error {
+	addr, err := basics.UnmarshalChecksumAddress(string(text))
+	if err != nil {
+		return err
+	}
+
+	*a = checksumAddress(addr)
+	return nil
+}
+
+// MarshalText implements the encoding.TextMarshaler interface
+func (a checksumAddress) MarshalText() (text []byte, err error) {
+	addr := basics.Address(a)
+	return []byte(addr.GetChecksumAddress().String()), nil
+}
+
 func inspectTxn(stxn transactions.SignedTxn) (sti inspectSignedTxn, err error) {
-	sti = txnToInspect(stxn)
-	if !reflect.DeepEqual(stxn, txnFromInspect(sti)) {
+	sti = stxnToInspect(stxn)
+	if !reflect.DeepEqual(stxn, stxnFromInspect(sti)) {
 		err = fmt.Errorf("non-idempotent transformation to inspectSignedTxn (DeepEqual)")
+		return
 	}
 	if !reflect.DeepEqual(protocol.Encode(sti), protocol.Encode(stxn)) {
 		err = fmt.Errorf("non-idempotent transformation to inspectSignedTxn (protocol.Encode)")
+		return
 	}
 	return
 }
 
-func txnToInspect(stxn transactions.SignedTxn) inspectSignedTxn {
+func stxnToInspect(stxn transactions.SignedTxn) inspectSignedTxn {
 	return inspectSignedTxn{
-		Txn:  stxn.Txn,
+		Txn:  txnToInspect(stxn.Txn),
 		Sig:  stxn.Sig,
 		Msig: msigToInspect(stxn.Msig),
 	}
 }
 
-func txnFromInspect(sti inspectSignedTxn) transactions.SignedTxn {
+func stxnFromInspect(sti inspectSignedTxn) transactions.SignedTxn {
 	return transactions.SignedTxn{
-		Txn:  sti.Txn,
+		Txn:  txnFromInspect(sti.Txn),
 		Sig:  sti.Sig,
 		Msig: msigFromInspect(sti.Msig),
 	}
@@ -92,7 +150,7 @@ func msigToInspect(msig crypto.MultisigSig) inspectMultisigSig {
 	for _, subsig := range msig.Subsigs {
 		res.Subsigs = append(res.Subsigs, inspectMultisigSubsig{
 			Sig: subsig.Sig,
-			Key: basics.Address(subsig.Key),
+			Key: checksumAddress(subsig.Key),
 		})
 	}
 
@@ -113,4 +171,46 @@ func msigFromInspect(msi inspectMultisigSig) crypto.MultisigSig {
 	}
 
 	return res
+}
+
+func txnToInspect(txn transactions.Transaction) inspectTransaction {
+	return inspectTransaction{
+		Type: txn.Type,
+		inspectTxnHeader: inspectTxnHeader{
+			Sender:      checksumAddress(txn.Sender),
+			Fee:         txn.Fee,
+			FirstValid:  txn.FirstValid,
+			LastValid:   txn.LastValid,
+			Note:        txn.Note,
+			GenesisID:   txn.GenesisID,
+			GenesisHash: txn.GenesisHash,
+		},
+		KeyregTxnFields: txn.KeyregTxnFields,
+		inspectPaymentTxnFields: inspectPaymentTxnFields{
+			Receiver:         checksumAddress(txn.Receiver),
+			Amount:           txn.Amount,
+			CloseRemainderTo: checksumAddress(txn.CloseRemainderTo),
+		},
+	}
+}
+
+func txnFromInspect(txi inspectTransaction) transactions.Transaction {
+	return transactions.Transaction{
+		Type: txi.Type,
+		Header: transactions.Header{
+			Sender:      basics.Address(txi.Sender),
+			Fee:         txi.Fee,
+			FirstValid:  txi.FirstValid,
+			LastValid:   txi.LastValid,
+			Note:        txi.Note,
+			GenesisID:   txi.GenesisID,
+			GenesisHash: txi.GenesisHash,
+		},
+		KeyregTxnFields: txi.KeyregTxnFields,
+		PaymentTxnFields: transactions.PaymentTxnFields{
+			Receiver:         basics.Address(txi.Receiver),
+			Amount:           txi.Amount,
+			CloseRemainderTo: basics.Address(txi.CloseRemainderTo),
+		},
+	}
 }

--- a/cmd/goal/inspect_test.go
+++ b/cmd/goal/inspect_test.go
@@ -1,0 +1,89 @@
+// Copyright (C) 2019 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/protocol"
+)
+
+func TestInspect(t *testing.T) {
+	var err error
+
+	var empty transactions.SignedTxn
+	_, err = inspectTxn(empty)
+	require.NoError(t, err)
+
+	var payment transactions.SignedTxn
+	crypto.RandBytes(payment.Sig[:])
+	payment.Txn.Type = protocol.PaymentTx
+	crypto.RandBytes(payment.Txn.Sender[:])
+	crypto.RandBytes(payment.Txn.Receiver[:])
+	payment.Txn.Fee.Raw = crypto.RandUint64()
+	payment.Txn.Amount.Raw = crypto.RandUint64()
+	payment.Txn.FirstValid = basics.Round(crypto.RandUint64())
+	payment.Txn.LastValid = basics.Round(crypto.RandUint64())
+	_, err = inspectTxn(payment)
+	require.NoError(t, err)
+
+	var keyreg transactions.SignedTxn
+	crypto.RandBytes(keyreg.Sig[:])
+	keyreg.Txn.Type = protocol.KeyRegistrationTx
+	crypto.RandBytes(keyreg.Txn.Sender[:])
+	keyreg.Txn.Fee.Raw = crypto.RandUint64()
+	keyreg.Txn.FirstValid = basics.Round(crypto.RandUint64())
+	keyreg.Txn.LastValid = basics.Round(crypto.RandUint64())
+	crypto.RandBytes(keyreg.Txn.VotePK[:])
+	crypto.RandBytes(keyreg.Txn.SelectionPK[:])
+	_, err = inspectTxn(keyreg)
+	require.NoError(t, err)
+
+	var full transactions.SignedTxn
+	crypto.RandBytes(full.Sig[:])
+	full.Msig.Version = uint8(crypto.RandUint64())
+	full.Msig.Threshold = uint8(crypto.RandUint64())
+	full.Msig.Subsigs = make([]crypto.MultisigSubsig, 2)
+	crypto.RandBytes(full.Msig.Subsigs[0].Key[:])
+	crypto.RandBytes(full.Msig.Subsigs[0].Sig[:])
+	crypto.RandBytes(full.Msig.Subsigs[1].Key[:])
+	crypto.RandBytes(full.Msig.Subsigs[1].Sig[:])
+	full.Txn.Type = protocol.UnknownTx
+	crypto.RandBytes(full.Txn.Sender[:])
+	full.Txn.Fee.Raw = crypto.RandUint64()
+	full.Txn.FirstValid = basics.Round(crypto.RandUint64())
+	full.Txn.LastValid = basics.Round(crypto.RandUint64())
+	full.Txn.Note = make([]byte, 256)
+	crypto.RandBytes(full.Txn.Note[:])
+	full.Txn.GenesisID = "testid"
+	crypto.RandBytes(full.Txn.GenesisHash[:])
+	crypto.RandBytes(full.Txn.VotePK[:])
+	crypto.RandBytes(full.Txn.SelectionPK[:])
+	full.Txn.VoteFirst = basics.Round(crypto.RandUint64())
+	full.Txn.VoteLast = basics.Round(crypto.RandUint64())
+	full.Txn.VoteKeyDilution = crypto.RandUint64()
+	full.Txn.Amount.Raw = crypto.RandUint64()
+	crypto.RandBytes(full.Txn.Receiver[:])
+	crypto.RandBytes(full.Txn.CloseRemainderTo[:])
+	_, err = inspectTxn(full)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Actually display the checksum for multisig PKs; also display txn Sender,
Receiver, and CloseRemainderTo using the same address encoding; and fix
the counter for displaying multiple txns in a file.