### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+crypto/libsodium-fork/* linguist-vendored


### PR DESCRIPTION
In particular, tell GitHub's language autodetection feature that
crypto/libsodium-fork/* is vendored code. This way GitHub will show go-algorand
as a Go project rather than a C project.
See https://github.com/github/linguist#vendored-code

Should fix issue #23 
Note that the change may take a day to take effect