### PR TITLE
catchupsrv: Support for downloading in subfolders

### DIFF
--- a/cmd/catchupsrv/README.md
+++ b/cmd/catchupsrv/README.md
@@ -1,23 +1,25 @@
-# How to use the catch up server 
+# How to use the catchup server 
 
- ## Online machine 
+The catchup server allow to download the blockchain into an airgapped machine, so that it is possible to run `algod` on the airgapped machine without access to the Internet.
 
- 1. Create a new folder `mkdir data`.
-2. Download all blocks from the relevant network. For example, to download from `testNet` with genesis `testnet-v31.0` run the following command 
+## Online machine: download the blockchain
+
+1. Create a new folder `mkdir data`.
+2. Download all blocks from the relevant network. For example, to download from `mainnet` with genesis `mainnet-v1.0` run the following command: 
     ```bash
-    ./catchupsrv -dir data -download -network testnet -genesis testnet-v31.0
+    catchupsrv -dir data -download -network mainnet -genesis mainnet-v1.0
     ```
-2. Copy the `data` dir to an airgapped machine using you favorite method
+2. Copy the `data` dir to an airgapped machine using you favorite method.
 
+## Offline (airgapped) machine 
 
- ## Offline (airgapped) machine 
-1. Run the catch server on some free port (e.g. 50000) and point it to your data dir
+1. Run the catchup server on some free port (e.g., 50000) and point it to your data dir:
     ```bash
-    ./catchupsrv -dir data -addr localhost:50000
+    catchupsrv -dir data -addr localhost:50000
     ```
-2. Run algod with following command. (where xx is your algorand data directory)
+2. Run `algod` with following command (where `xx` is your algorand data directory):
     ```bash
-    ./goal node start -d xx -p localhost:50000
+    goal node start -d xx -p localhost:50000
     ```
 
- now `algod` will catch up from the catch up server
+Now `algod` will catch up from the catchup server.

--- a/cmd/catchupsrv/download.go
+++ b/cmd/catchupsrv/download.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -33,6 +32,7 @@ import (
 	"sync/atomic"
 
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 	tools_network "github.com/algorand/go-algorand/tools/network"
 )
@@ -113,6 +113,8 @@ func blockURL(server string, blk uint64) string {
 }
 
 func fetchBlock(server string, blk uint64) error {
+	log := logging.Base()
+
 	fn := blockFullPath(blk)
 	_, err := os.Stat(fn)
 	if err == nil {
@@ -158,6 +160,8 @@ func fetchBlock(server string, blk uint64) error {
 }
 
 func fetcher(server string, wg *sync.WaitGroup) {
+	log := logging.Base()
+
 	for {
 		myBlock := atomic.AddUint64(&nextBlk, 1) - 1
 

--- a/cmd/catchupsrv/download.go
+++ b/cmd/catchupsrv/download.go
@@ -52,9 +52,8 @@ var nextBlk uint64
 func padLeftZeros(s string, n int) string {
 	if len(s) < n {
 		return strings.Repeat("0", n-len(s)) + s
-	} else {
-		return s
 	}
+	return s
 }
 
 // blockToString converts a block number into a base-36 number
@@ -68,9 +67,8 @@ func blockToString(blk uint64) string {
 func blockToFileName(blk uint64) string {
 	if *subfoldersFlag {
 		return padLeftZeros(blockToString(blk), lenBlockStr)
-	} else {
-		return blockToString(blk)
 	}
+	return blockToString(blk)
 }
 
 // stringToBlock converts a base-36 string into a block number
@@ -93,9 +91,8 @@ func blockToPath(blk uint64) string {
 			s[2:4],
 			s,
 		)
-	} else {
-		return blockToFileName(blk)
 	}
+	return blockToFileName(blk)
 }
 
 // stringBlockToPath is the same as blockToPath except it takes a (non-padded) base-36 block

--- a/cmd/catchupsrv/download.go
+++ b/cmd/catchupsrv/download.go
@@ -53,14 +53,19 @@ func padLeftZeros(s string, n int) string {
 	return strings.Repeat("0", n-len(s)) + s
 }
 
+// blockToString converts a block number into a base-36 number
+func blockToString(blk uint64) string {
+	return strconv.FormatUint(blk, 36)
+}
+
 // blockToFileName converts a block number into the filename in which it will be downloaded
 // When using subfolders, the string corresponding to the base-36 number padded with zeros
 // Otherwise it is just the base-36 number
 func blockToFileName(blk uint64) string {
 	if *subfoldersFlag {
-		return padLeftZeros(strconv.FormatUint(blk, 36), lenBlockStr)
+		return padLeftZeros(blockToString(blk), lenBlockStr)
 	} else {
-		return strconv.FormatUint(blk, 36)
+		return blockToString(blk)
 	}
 }
 
@@ -109,7 +114,7 @@ func blockFullPath(blk uint64) string {
 }
 
 func blockURL(server string, blk uint64) string {
-	return fmt.Sprintf("http://%s/v1/%s/block/%s", server, *genesisFlag, blockToFileName(blk))
+	return fmt.Sprintf("http://%s/v1/%s/block/%s", server, *genesisFlag, blockToString(blk))
 }
 
 func fetchBlock(server string, blk uint64) error {

--- a/cmd/catchupsrv/download.go
+++ b/cmd/catchupsrv/download.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -115,6 +116,7 @@ func fetchBlock(server string, blk uint64) error {
 	fn := blockFullPath(blk)
 	_, err := os.Stat(fn)
 	if err == nil {
+		log.Debugf("block %d already exists", blk)
 		return nil
 	}
 
@@ -122,7 +124,7 @@ func fetchBlock(server string, blk uint64) error {
 		return err
 	}
 
-	fmt.Printf("Fetching %d from %s..\n", blk, server)
+	log.Infof("fetching %d (%s) from %s..", blk, blockToFileName(blk), server)
 	resp, err := http.Get(blockURL(server, blk))
 	if err != nil {
 		return err
@@ -161,7 +163,7 @@ func fetcher(server string, wg *sync.WaitGroup) {
 
 		err := fetchBlock(server, myBlock)
 		if err != nil {
-			fmt.Printf("Fetching %d from %s: %v\n", myBlock, server, err)
+			log.Errorf("fetching %d (%s) from %s: %v", myBlock, blockToFileName(myBlock), server, err)
 			break
 		}
 	}

--- a/cmd/catchupsrv/download.go
+++ b/cmd/catchupsrv/download.go
@@ -74,12 +74,12 @@ func blockToFileName(blk uint64) string {
 }
 
 // stringToBlock converts a base-36 string into a block number
-func stringToBlock(s string) uint64 {
+func stringToBlock(s string) (uint64, error) {
 	blk, err := strconv.ParseUint(s, 36, 64)
 	if err != nil {
-		panic(err)
+		return 0, fmt.Errorf("invalid block string \"%s\": %v", s, err)
 	}
-	return blk
+	return blk, nil
 }
 
 // blockToPath converts a block number into the full path in which it will be downloaded
@@ -99,12 +99,12 @@ func blockToPath(blk uint64) string {
 }
 
 // stringBlockToPath is the same as blockToPath except it takes a (non-padded) base-36 block
-func stringBlockToPath(s string) string {
-	if *subfoldersFlag {
-		return blockToPath(stringToBlock(s))
-	} else {
-		return s
+func stringBlockToPath(s string) (string, error) {
+	blk, err := stringToBlock(s)
+	if err != nil {
+		return "", err
 	}
+	return blockToPath(blk), nil
 }
 
 // blockDir returns the root folder where all the blocks are stored

--- a/cmd/catchupsrv/download.go
+++ b/cmd/catchupsrv/download.go
@@ -37,7 +37,7 @@ import (
 	tools_network "github.com/algorand/go-algorand/tools/network"
 )
 
-const lenBlockStr = 6
+const minLenBlockStr = 6 // the minimum size of a block filename (after padding with zeros) when using subfolders
 
 var downloadFlag = flag.Bool("download", false, "Download blocks from an origin server")
 var serversFlag = flag.String("servers", "", "Semicolon-separated list of origin server addresses (host:port)")
@@ -66,7 +66,7 @@ func blockToString(blk uint64) string {
 // Otherwise it is just the base-36 number
 func blockToFileName(blk uint64) string {
 	if *subfoldersFlag {
-		return padLeftZeros(blockToString(blk), lenBlockStr)
+		return padLeftZeros(blockToString(blk), minLenBlockStr)
 	}
 	return blockToString(blk)
 }
@@ -87,8 +87,8 @@ func blockToPath(blk uint64) string {
 	if *subfoldersFlag {
 		s := blockToFileName(blk)
 		return path.Join(
-			s[0:2],
-			s[2:4],
+			s[0:(len(s)+2-minLenBlockStr)],
+			s[(len(s)+2-minLenBlockStr):(len(s)+4-minLenBlockStr)],
 			s,
 		)
 	}

--- a/cmd/catchupsrv/download.go
+++ b/cmd/catchupsrv/download.go
@@ -50,7 +50,11 @@ var nextBlk uint64
 
 // padLeftZeros pad the string s with zeros on the left to the length n
 func padLeftZeros(s string, n int) string {
-	return strings.Repeat("0", n-len(s)) + s
+	if len(s) < n {
+		return strings.Repeat("0", n-len(s)) + s
+	} else {
+		return s
+	}
 }
 
 // blockToString converts a block number into a base-36 number

--- a/cmd/catchupsrv/download_test.go
+++ b/cmd/catchupsrv/download_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestBlockToPath(t *testing.T) {
+	*subfoldersFlag = true
+	require.Equal(t, "00/00/000000", blockToPath(0))
+	require.Equal(t, "00/00/0000rs", blockToPath(1000))
+	require.Equal(t, "05/yc/05ycfo", blockToPath(10000500))
+	require.Equal(t, "4ll/2c/4ll2cic", blockToPath(10012300500))
+}
+
+func TestBlockToFileName(t *testing.T) {
+	*subfoldersFlag = true
+	require.Equal(t, "000000", blockToFileName(0))
+	require.Equal(t, "0000rs", blockToFileName(1000))
+	require.Equal(t, "05ycfo", blockToFileName(10000500))
+	require.Equal(t, "4ll2cic", blockToFileName(10012300500))
+
+	*subfoldersFlag = false
+	require.Equal(t, "0", blockToFileName(0))
+	require.Equal(t, "rs", blockToFileName(1000))
+	require.Equal(t, "5ycfo", blockToFileName(10000500))
+	require.Equal(t, "4ll2cic", blockToFileName(10012300500))
+}
+
+func TestBlockToString(t *testing.T) {
+	*subfoldersFlag = true
+	require.Equal(t, "0", blockToString(0))
+	require.Equal(t, "rs", blockToString(1000))
+	require.Equal(t, "5ycfo", blockToString(10000500))
+	require.Equal(t, "4ll2cic", blockToString(10012300500))
+
+	*subfoldersFlag = false
+	require.Equal(t, "0", blockToString(0))
+	require.Equal(t, "rs", blockToString(1000))
+	require.Equal(t, "5ycfo", blockToString(10000500))
+	require.Equal(t, "4ll2cic", blockToString(10012300500))
+}

--- a/cmd/catchupsrv/download_test.go
+++ b/cmd/catchupsrv/download_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 func TestBlockToPath(t *testing.T) {
-	*subfoldersFlag = true
 	require.Equal(t, "00/00/000000", blockToPath(0))
 	require.Equal(t, "00/00/0000rs", blockToPath(1000))
 	require.Equal(t, "05/yc/05ycfo", blockToPath(10000500))
@@ -14,27 +13,13 @@ func TestBlockToPath(t *testing.T) {
 }
 
 func TestBlockToFileName(t *testing.T) {
-	*subfoldersFlag = true
 	require.Equal(t, "000000", blockToFileName(0))
 	require.Equal(t, "0000rs", blockToFileName(1000))
 	require.Equal(t, "05ycfo", blockToFileName(10000500))
 	require.Equal(t, "4ll2cic", blockToFileName(10012300500))
-
-	*subfoldersFlag = false
-	require.Equal(t, "0", blockToFileName(0))
-	require.Equal(t, "rs", blockToFileName(1000))
-	require.Equal(t, "5ycfo", blockToFileName(10000500))
-	require.Equal(t, "4ll2cic", blockToFileName(10012300500))
 }
 
 func TestBlockToString(t *testing.T) {
-	*subfoldersFlag = true
-	require.Equal(t, "0", blockToString(0))
-	require.Equal(t, "rs", blockToString(1000))
-	require.Equal(t, "5ycfo", blockToString(10000500))
-	require.Equal(t, "4ll2cic", blockToString(10012300500))
-
-	*subfoldersFlag = false
 	require.Equal(t, "0", blockToString(0))
 	require.Equal(t, "rs", blockToString(1000))
 	require.Equal(t, "5ycfo", blockToString(10000500))

--- a/cmd/catchupsrv/main.go
+++ b/cmd/catchupsrv/main.go
@@ -23,11 +23,10 @@ import (
 	"path"
 	"strconv"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/algorand/websocket"
 	"github.com/gorilla/mux"
 
+	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/rpcs"
 )
@@ -38,6 +37,9 @@ var subfoldersFlag = flag.Bool("subfolders", false, "Organize downloaded blocks 
 
 func main() {
 	flag.Parse()
+
+	log := logging.Base()
+	log.SetLevel(logging.Info)
 
 	if *dirFlag == "" {
 		panic("Must specify -dir")

--- a/cmd/catchupsrv/main.go
+++ b/cmd/catchupsrv/main.go
@@ -18,11 +18,12 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"path"
 	"strconv"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/algorand/websocket"
 	"github.com/gorilla/mux"
@@ -96,7 +97,7 @@ func main() {
 			),
 		)
 		if err != nil {
-			fmt.Printf("%s %s: %v\n", r.Method, r.URL, err)
+			log.Infof("%s %s: %v", r.Method, r.URL, err)
 			http.NotFound(w, r)
 			return
 		}

--- a/cmd/catchupsrv/main.go
+++ b/cmd/catchupsrv/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"path"
 	"strconv"
 
 	"github.com/algorand/websocket"
@@ -32,6 +33,7 @@ import (
 
 var addrFlag = flag.String("addr", "127.0.0.1:4160", "Address to listen on")
 var dirFlag = flag.String("dir", "", "Directory containing catchup blocks")
+var subfoldersFlag = flag.Bool("subfolders", false, "Organize downloaded blocks in subfolders (if used, must be specified both when executed with and without -download)")
 
 func main() {
 	flag.Parse()
@@ -84,8 +86,15 @@ func main() {
 		roundStr := pathVars["round"]
 		genesisID := pathVars["genesisID"]
 
-		data, err := ioutil.ReadFile(fmt.Sprintf("%s/v%s/%s/block/%s",
-			*dirFlag, versionStr, genesisID, roundStr))
+		data, err := ioutil.ReadFile(
+			path.Join(
+				*dirFlag,
+				"v"+versionStr,
+				genesisID,
+				"block",
+				stringBlockToPath(roundStr),
+			),
+		)
 		if err != nil {
 			fmt.Printf("%s %s: %v\n", r.Method, r.URL, err)
 			http.NotFound(w, r)

--- a/cmd/catchupsrv/main.go
+++ b/cmd/catchupsrv/main.go
@@ -33,7 +33,6 @@ import (
 
 var addrFlag = flag.String("addr", "127.0.0.1:4160", "Address to listen on")
 var dirFlag = flag.String("dir", "", "Directory containing catchup blocks")
-var subfoldersFlag = flag.Bool("subfolders", false, "Organize downloaded blocks in subfolders (if used, must be specified both when executed with and without -download)")
 
 func main() {
 	flag.Parse()

--- a/cmd/catchupsrv/main.go
+++ b/cmd/catchupsrv/main.go
@@ -89,13 +89,20 @@ func main() {
 		roundStr := pathVars["round"]
 		genesisID := pathVars["genesisID"]
 
+		blkPath, err := stringBlockToPath(roundStr)
+		if err != nil {
+			log.Infof("%s %s: %v", r.Method, r.URL, err)
+			http.NotFound(w, r)
+			return
+		}
+
 		data, err := ioutil.ReadFile(
 			path.Join(
 				*dirFlag,
 				"v"+versionStr,
 				genesisID,
 				"block",
-				stringBlockToPath(roundStr),
+				blkPath,
 			),
 		)
 		if err != nil {


### PR DESCRIPTION
1. Support for downloading blocks in subfolders instead of downloading all the blocks in the same folder (option `-subfolders`)
2. Use of logrus for logging.