### PR TITLE
[GOAL2-628] Updated configure_dev.sh to support building libsodium

### DIFF
--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -22,6 +22,9 @@ elif [ "${OS}" = "darwin" ]; then
     install_or_upgrade pkg-config
     install_or_upgrade boost
     install_or_upgrade jq
+    install_or_upgrade libtool
+    install_or_upgrade autoconf
+    install_or_upgrade automake
 fi
 
 ${SCRIPTPATH}/configure_dev-deps.sh


### PR DESCRIPTION
Added libtool, autoconf, and automake to configure_dev.sh which are required for building libsodium.