### PR TITLE
[GOAL2-782] Export DNS configuration

### DIFF
--- a/cmd/algons/dnsCmd.go
+++ b/cmd/algons/dnsCmd.go
@@ -215,6 +215,7 @@ func getClouldflareAuthCredentials() (email string, authKey string, err error) {
 	}
 	return
 }
+
 func getClouldflareCredentials() (zoneID string, email string, authKey string, err error) {
 	email, authKey, err = getClouldflareAuthCredentials()
 	if err != nil {

--- a/tools/network/cloudflare/zones.go
+++ b/tools/network/cloudflare/zones.go
@@ -1,0 +1,97 @@
+// Copyright (C) 2019 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package cloudflare
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+func getZonesRequest(authEmail, authKey string) (*http.Request, error) {
+	// construct the query
+	requestURI, err := url.Parse(cloudFlareURI)
+	if err != nil {
+		return nil, err
+	}
+	requestURI.Path = requestURI.Path + "zones"
+	request, err := http.NewRequest("GET", requestURI.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	addHeaders(request, authEmail, authKey)
+	return request, nil
+}
+
+// GetZonesResult is the JSON response for a DNS create request
+type GetZonesResult struct {
+	Success    bool                 `json:"success"`
+	Errors     []interface{}        `json:"errors"`
+	Messages   []interface{}        `json:"messages"`
+	Result     []GetZonesResultItem `json:"result"`
+	ResultInfo GetZonesResultPage   `json:"result_info"`
+}
+
+// GetZonesResultPage is the result of the response for the DNS create request
+type GetZonesResultPage struct {
+	Page       int `json:"page"`
+	PerPage    int `json:"per_page"`
+	TotalPages int `json:"total_pages"`
+	Count      int `json:"count"`
+	TotalCount int `json:"total_count"`
+}
+
+// GetZonesResultItem is the result of the response for the DNS create request
+type GetZonesResultItem struct {
+	ID                  string   `json:"id"`
+	Name                string   `json:"name"`
+	Status              string   `json:"status"`
+	Paused              bool     `json:"paused"`
+	Type                string   `json:"type"`
+	DevelopmentMode     int      `json:"development_mode"`
+	NameServers         []string `json:"name_servers"`
+	OriginalNameServers []string `json:"original_name_servers"`
+}
+
+func parseGetZonesResponse(response *http.Response) (*GetZonesResult, error) {
+	defer response.Body.Close()
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	var parsedReponse GetZonesResult
+	if err := json.Unmarshal(body, &parsedReponse); err != nil {
+		return nil, err
+	}
+	return &parsedReponse, nil
+}
+
+func exportZoneRequest(zoneID, authEmail, authKey string) (*http.Request, error) {
+	// construct the query
+	requestURI, err := url.Parse(cloudFlareURI)
+	if err != nil {
+		return nil, err
+	}
+	requestURI.Path = requestURI.Path + "zones/" + zoneID + "/dns_records/export"
+	request, err := http.NewRequest("GET", requestURI.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	addHeaders(request, authEmail, authKey)
+	return request, nil
+}


### PR DESCRIPTION
Add the following functionality to algons:

1. Export zone DNS settings in BIND format - 
usage: algons dns export -n algodev.network -z algodev.network.bind
or send the output directly to the terminal
usage: algons dns export -n algodev.network

2. List existing zones for the current account - 
usage: algons dns list zones
