### PR TITLE
Switch default genesis.json file to mainnet

### DIFF
--- a/scripts/compute_branch_release_network.sh
+++ b/scripts/compute_branch_release_network.sh
@@ -9,9 +9,9 @@ if [ -z "${NETWORK}" ]; then
     exit -1
 fi
 
-#if [ "${NETWORK}" = "testnet" ]; then
-#    echo "mainnet"
-#    exit 0
-#fi
+if [ "${NETWORK}" = "testnet" ]; then
+    echo "mainnet"
+    exit 0
+fi
 
 echo "${NETWORK}"


### PR DESCRIPTION
Once mainnet goes public, we want installs to default to running against mainnet.  TestNet will be a manual process.