### PR TITLE
Use gomod

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,9 +2,7 @@ FROM ubuntu:18.04
 ENV GOLANG_VERSION 1.12
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt update && apt-get install -y git libboost-all-dev wget sqlite3 autoconf
-
-RUN apt-get -y install sudo tzdata bsdmainutils
+RUN apt update && apt-get install -y git libboost-all-dev wget sqlite3 autoconf sudo tzdata bsdmainutils
 
 WORKDIR /root
 RUN wget --quiet https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz && tar -xvf go${GOLANG_VERSION}.linux-amd64.tar.gz && mv go /usr/local

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,20 @@
 FROM ubuntu:18.04
 ENV GOLANG_VERSION 1.12
+ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt update && apt install -y git libboost-all-dev wget sqlite3 autoconf
+RUN apt update && apt-get install -y git libboost-all-dev wget sqlite3 autoconf
+
+RUN apt-get -y install sudo tzdata bsdmainutils
+
 WORKDIR /root
 RUN wget --quiet https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz && tar -xvf go${GOLANG_VERSION}.linux-amd64.tar.gz && mv go /usr/local
 ENV GOROOT /usr/local/go
-ENV GOPATH $HOME/go
+ENV GOPATH /go
+ENV GOBIN /go/bin
 ENV PATH   $GOPATH/bin:$GOROOT/bin:$PATH
 RUN mkdir -p $GOPATH/src/github.com/algorand
 WORKDIR $GOPATH/src/github.com/algorand
 RUN git clone https://github.com/algorand/go-algorand
 WORKDIR $GOPATH/src/github.com/algorand/go-algorand
-RUN apt-get -y install sudo
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get -y install tzdata
-RUN apt-get -y install bsdmainutils
-RUN git checkout master && scripts/configure_dev.sh && make
+RUN git checkout master && ./scripts/configure_dev.sh && make install
 ENTRYPOINT ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,5 +11,9 @@ RUN mkdir -p $GOPATH/src/github.com/algorand
 WORKDIR $GOPATH/src/github.com/algorand
 RUN git clone https://github.com/algorand/go-algorand
 WORKDIR $GOPATH/src/github.com/algorand/go-algorand
+RUN apt-get -y install sudo
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get -y install tzdata
+RUN apt-get -y install bsdmainutils
 RUN git checkout master && scripts/configure_dev.sh && make
 ENTRYPOINT ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:18.04
 ENV GOLANG_VERSION 1.12
 ENV DEBIAN_FRONTEND noninteractive
+ENV GO111MODULE=auto
 
 RUN apt update && apt-get install -y git libboost-all-dev wget sqlite3 autoconf sudo tzdata bsdmainutils
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,49 @@
+module github.com/algorand/go-algorand
+
+go 1.12
+
+require (
+	github.com/algorand/go-codec v0.0.0-20190416102211-17f33432a5ce
+	github.com/algorand/go-deadlock v0.0.0-20181221160745-78d8cb5e2759
+	github.com/algorand/websocket v0.0.0-20190604160558-8e576782c555
+	github.com/aws/aws-sdk-go v1.16.5
+	github.com/cpuguy83/go-md2man v1.0.8
+	github.com/davecgh/go-spew v1.1.1
+	github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018
+	github.com/dchest/siphash v1.2.1
+	github.com/fatih/color v1.7.0
+	github.com/gen2brain/beeep v0.0.0-20180718162406-4e430518395f
+	github.com/godbus/dbus v0.0.0-20181101234600-2ff6f7ffd60f
+	github.com/gofrs/flock v0.7.0
+	github.com/google/go-querystring v1.0.0
+	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e
+	github.com/gopherjs/gopherwasm v1.0.1
+	github.com/gorilla/context v1.1.1
+	github.com/gorilla/mux v1.6.2
+	github.com/gorilla/schema v1.0.2
+	github.com/inconshreveable/mousetrap v1.0.0
+	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+	github.com/jmoiron/sqlx v1.2.0
+	github.com/karalabe/hid v0.0.0-20181128192157-d815e0c1a2e2
+	github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329
+	github.com/mattn/go-colorable v0.0.9
+	github.com/mattn/go-isatty v0.0.4
+	github.com/mattn/go-sqlite3 v1.10.0
+	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
+	github.com/olivere/elastic v6.2.14+incompatible
+	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5
+	github.com/pkg/errors v0.8.0
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/russross/blackfriday v1.5.2
+	github.com/satori/go.uuid v1.2.0
+	github.com/sirupsen/logrus v1.0.5
+	github.com/spf13/cobra v0.0.3
+	github.com/spf13/pflag v1.0.3
+	github.com/stretchr/testify v1.2.2
+	golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9
+	golang.org/x/net v0.0.0-20190301231341-16b79f2e4e95
+	golang.org/x/sys v0.0.0-20181213200352-4d1cda033e06
+	gopkg.in/sohlich/elogrus.v3 v3.0.0-20180410122755-1fa29e2f2009
+	gopkg.in/toast.v1 v1.0.0-20180812000517-0a84660828b2
+	gopkg.in/yaml.v2 v2.2.2
+)


### PR DESCRIPTION

## Summary

 Get go mod support working.  The vendor'd go-websocket implementation is tripping up go mod, so  GO111MODULE=auto for now. 

https://github.com/algorand/go-algorand/issues/41

## Test Plan

Via dockerfile, build 

