### PR TITLE
Fix TestDBConcurrencyRW test to run on Macs

### DIFF
--- a/util/db/dbutil_test.go
+++ b/util/db/dbutil_test.go
@@ -20,6 +20,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -206,7 +209,18 @@ func TestDBConcurrency(t *testing.T) {
 }
 
 func TestDBConcurrencyRW(t *testing.T) {
-	fn := fmt.Sprintf("/dev/shm/%s.%d.sqlite3", t.Name(), crypto.RandUint64())
+	dbFolder := "/dev/shm"
+	os := runtime.GOOS
+	if os == "darwin" {
+		var err error
+		dbFolder, err = ioutil.TempDir("", "TestDBConcurrencyRW")
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	fn := fmt.Sprintf("/%s.%d.sqlite3", t.Name(), crypto.RandUint64())
+	fn = filepath.Join(dbFolder, fn)
 	acc, err := MakeAccessor(fn, false, false)
 	require.NoError(t, err)
 


### PR DESCRIPTION
TestDBConcurrencyRW assumes `/dev/shm` device exists.  It doesn't on Mac, so use tmp folder in that case.