### PR TITLE
Accept API Token in Authorization Header

### DIFF
--- a/daemon/algod/api/server/lib/middlewares/auth.go
+++ b/daemon/algod/api/server/lib/middlewares/auth.go
@@ -74,6 +74,10 @@ func Auth(log logging.Logger, apiToken string) func(http.Handler) http.Handler {
 			// Handle debug route
 			// Grab the apiToken from the HTTP header
 			providedToken := []byte(r.Header.Get(TokenHeader))
+			if len(providedToken) == 0 {
+				// Accept tokens provided in a bearer token format.
+				providedToken = []byte(r.Header.Get("Authorization")[7:])
+			}
 			if route.GetName() == debugRouteName {
 				// For debug routes, we place the apiToken in the path itself
 				providedToken = []byte(mux.Vars(r)["apiToken"])

--- a/daemon/algod/api/server/lib/middlewares/auth.go
+++ b/daemon/algod/api/server/lib/middlewares/auth.go
@@ -76,7 +76,10 @@ func Auth(log logging.Logger, apiToken string) func(http.Handler) http.Handler {
 			providedToken := []byte(r.Header.Get(TokenHeader))
 			if len(providedToken) == 0 {
 				// Accept tokens provided in a bearer token format.
-				providedToken = []byte(r.Header.Get("Authorization")[7:])
+				authentication := strings.SplitN(r.Header.Get("Authorization"), " ", 2)
+				if len(authentication) == 2 && strings.EqualFold("Bearer", authentication[0]) {
+					providedToken = []byte(r.Header.Get("Authorization")[7:])
+				}
 			}
 			if route.GetName() == debugRouteName {
 				// For debug routes, we place the apiToken in the path itself

--- a/daemon/algod/api/server/lib/middlewares/auth.go
+++ b/daemon/algod/api/server/lib/middlewares/auth.go
@@ -78,7 +78,7 @@ func Auth(log logging.Logger, apiToken string) func(http.Handler) http.Handler {
 				// Accept tokens provided in a bearer token format.
 				authentication := strings.SplitN(r.Header.Get("Authorization"), " ", 2)
 				if len(authentication) == 2 && strings.EqualFold("Bearer", authentication[0]) {
-					providedToken = []byte(r.Header.Get("Authorization")[7:])
+					providedToken = []byte(authentication[1])
 				}
 			}
 			if route.GetName() == debugRouteName {

--- a/scripts/promote_stable.sh
+++ b/scripts/promote_stable.sh
@@ -39,5 +39,5 @@ CHANNEL="stable"
 ${S3CMD} ls s3://${S3_UPLOAD_BUCKET}/pending_ | grep _${CHANNEL}[_-] | awk '{ print $4 }' | while read line; do
     NEW_ARTIFACT_NAME=$(echo "$line" | sed -e 's/pending_//')
     echo "Rename ${line} => ${NEW_ARTIFACT_NAME}"
-    ${S3CMD} mv ${line} ${RENAMED}
+    ${S3CMD} mv ${line} ${NEW_ARTIFACT_NAME}
 done


### PR DESCRIPTION
## Summary

We have a metrics endpoint to provide prometheus style metrics, it also requires the `X-Algo-API-Token: <token>` header. Some tools which are able to consume this endpoint, like Telegraf, assume authorization tokens will be provided as bearer tokens, like `Authorization: Bearer <token>`. So this adds that as a fallback.

## Test Plan

Make sure both forms still work:
```
will@will-algorand:~$ curl http://localhost:10101/v1/status -H "Authorization: Bearer $(cat ~/.algorand/algod.token)"
{"lastRound":253920,"lastConsensusVersion":"https://github.com/algorandfoundation/specs/tree/5615adc36bad610c7f165fa2967f4ecfa75125f0","nextConsensusVersion":"https://github.com/algorandfoundation/specs/tree/5615adc36bad610c7f165fa2967f4ecfa75125f0","nextConsensusVersionRound":253921,"nextConsensusVersionSupported":true,"timeSinceLastRound":2006682505,"catchupTime":0}
will@will-algorand:~$ curl http://localhost:10101/v1/status -H "X-Algo-API-Token: $(cat ~/.algorand/algod.token)"
{"lastRound":253922,"lastConsensusVersion":"https://github.com/algorandfoundation/specs/tree/5615adc36bad610c7f165fa2967f4ecfa75125f0","nextConsensusVersion":"https://github.com/algorandfoundation/specs/tree/5615adc36bad610c7f165fa2967f4ecfa75125f0","nextConsensusVersionRound":253923,"nextConsensusVersionSupported":true,"timeSinceLastRound":3927344369,"catchupTime":0}
```