### PR TITLE
Move travis to 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 go:
   - "1.12"
 go_import_path: github.com/algorand/go-algorand

--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -46,13 +46,6 @@ else
 fi
 export TIMESTAMP=${TIMESTAMP}
 
-# To ensure deterministic availability of testnet (stable) builds, prefix the packages
-# with "pending_" so updater will not detect the package before we rename it.
-GATE_PREFIX=""
-# if [[ "${CHANNEL}" = "stable" || "${CHANNEL}" = "nightly" ]]; then
-#     GATE_PREFIX="pending_"
-# fi
-
 VERSION_COMPONENTS=(${FULLVERSION//\./ })
 export BUILDNUMBER=${VERSION_COMPONENTS[2]}
 
@@ -106,30 +99,16 @@ for var in "${VARIATION_ARRAY[@]}"; do
         echo Building package for channel ${CHANNEL} to ${PLATFORM_ROOT}
 
         pushd ${PLATFORM_ROOT}
-        tar --exclude=tools -zcf ${PKG_ROOT}/${GATE_PREFIX}node_${CHANNEL}_${PKG_NAME}_${FULLVERSION}.tar.gz * >/dev/null 2>&1
+        tar --exclude=tools -zcf ${PKG_ROOT}/node_${CHANNEL}_${PKG_NAME}_${FULLVERSION}.tar.gz * >/dev/null 2>&1
         cd bin
-        tar -zcf ${PKG_ROOT}/${GATE_PREFIX}install_${CHANNEL}_${PKG_NAME}_${FULLVERSION}.tar.gz updater update.sh >/dev/null 2>&1
+        tar -zcf ${PKG_ROOT}/install_${CHANNEL}_${PKG_NAME}_${FULLVERSION}.tar.gz updater update.sh >/dev/null 2>&1
         if [ $? -ne 0 ]; then
             echo "Error creating tar file for package ${PLATFORM}.  Aborting..."
             exit 1
         fi
 
         cd ${PLATFORM_ROOT}/tools
-        tar -zcf ${PKG_ROOT}/${GATE_PREFIX}tools_${CHANNEL}_${PKG_NAME}_${FULLVERSION}.tar.gz * >/dev/null 2>&1
+        tar -zcf ${PKG_ROOT}/tools_${CHANNEL}_${PKG_NAME}_${FULLVERSION}.tar.gz * >/dev/null 2>&1
         popd
-
-        # If Linux package, build debian (deb) package as well
-        if [ $(scripts/ostype.sh) = "linux" ]; then
-            DEBTMP=$(mktemp -d 2>/dev/null || mktemp -d -t "debtmp")
-            trap "rm -rf ${DEBTMP}" 0
-            scripts/build_deb.sh ${ARCH} ${DEBTMP}
-            if [ $? -ne 0 ]; then
-                echo "Error building debian package for ${PLATFORM}.  Aborting..."
-                exit 1
-            fi
-            pushd ${DEBTMP}
-	    cp -p *.deb ${PKG_ROOT}/${GATE_PREFIX}algorand_${CHANNEL}_${PKG_NAME}_${FULLVERSION}.deb
-            popd
-        fi
     done
 done

--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -121,7 +121,7 @@ for var in "${VARIATION_ARRAY[@]}"; do
                 exit 1
             fi
             pushd ${DEBTMP}
-            cp -p *.deb ${PKG_ROOT}/${GATE_PREFIX}algorand_${CHANNEL}_${PKG_NAME}_${FULLVERSION}.deb
+            cp -p *.deb ${PKG_ROOT}/algorand_${CHANNEL}_${PKG_NAME}_${FULLVERSION}.deb
             popd
         fi
     done

--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -110,5 +110,19 @@ for var in "${VARIATION_ARRAY[@]}"; do
         cd ${PLATFORM_ROOT}/tools
         tar -zcf ${PKG_ROOT}/tools_${CHANNEL}_${PKG_NAME}_${FULLVERSION}.tar.gz * >/dev/null 2>&1
         popd
+
+        # If Linux package, build debian (deb) package as well
+        if [ ! -z "${BUILD_DEB}" && $(scripts/ostype.sh) = "linux" ]; then
+            DEBTMP=$(mktemp -d 2>/dev/null || mktemp -d -t "debtmp")
+            trap "rm -rf ${DEBTMP}" 0
+            scripts/build_deb.sh ${ARCH} ${DEBTMP}
+            if [ $? -ne 0 ]; then
+                echo "Error building debian package for ${PLATFORM}.  Aborting..."
+                exit 1
+            fi
+            pushd ${DEBTMP}
+            cp -p *.deb ${PKG_ROOT}/${GATE_PREFIX}algorand_${CHANNEL}_${PKG_NAME}_${FULLVERSION}.deb
+            popd
+        fi
     done
 done

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -100,6 +100,7 @@ make ${GOPATH}/src/github.com/algorand/go-algorand/crypto/lib/libsodium.a
 
 make build
 
+export BUILD_DEB=1
 scripts/build_packages.sh "${PLATFORM}"
 
 # Run RPM bulid in Centos7 Docker container


### PR DESCRIPTION
We want to start building and testing devnet (nightly) on Ubuntu 18.04 so we can move production to it after more testing.
Remove building of debian package - it's now done for release builds only.
Remove GATE_PREFIX - we'll use separate buckets for the same purpose.

NOTE: This will fail to install and run on CentOS due to an obsolete glibc version in CentOS.