### PR TITLE
remove swagger-dependent build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ $(KMD_API_SWAGGER_INJECT): $(KMD_API_SWAGGER_SPEC)
 
 build: buildsrc gen
 
-buildsrc: $(SRCPATH)/crypto/lib/libsodium.a node_exporter NONGO_BIN deps $(ALGOD_API_SWAGGER_INJECT) $(KMD_API_SWAGGER_INJECT)
+buildsrc: $(SRCPATH)/crypto/lib/libsodium.a node_exporter NONGO_BIN deps
 	cd $(SRCPATH) && \
 		go install $(GOTAGS) -ldflags="$(GOLDFLAGS)" $(SOURCES)
 	cd $(SRCPATH) && \


### PR DESCRIPTION
We should not allow a maligned commit to go-swagger@master break our build. temporary stop gap while we figure out how to do this properly.

(go-swagger added go mod support on master five days ago, but removed a flag and changed behavior in the process)
