### PR TITLE
remove swagger-dependent build (#119)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ $(KMD_API_SWAGGER_INJECT): $(KMD_API_SWAGGER_SPEC)
 
 build: buildsrc gen
 
-buildsrc: $(SRCPATH)/crypto/lib/libsodium.a node_exporter NONGO_BIN deps $(ALGOD_API_SWAGGER_INJECT) $(KMD_API_SWAGGER_INJECT)
+buildsrc: $(SRCPATH)/crypto/lib/libsodium.a node_exporter NONGO_BIN deps
 	cd $(SRCPATH) && \
 		go install $(GOTAGS) -ldflags="$(GOLDFLAGS)" $(SOURCES)
 	cd $(SRCPATH) && \


### PR DESCRIPTION
temporary stop gap while we investigate how to make sure swagger does not break our build.

This is an infrastructure fix and should not be used to generate a new release.  Note the resultant binary will differ in that it won't have a swagger.json file to serve.