### PR TITLE
[GOAL2-844] Re-enable go-swagger in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ $(KMD_API_SWAGGER_INJECT): $(KMD_API_SWAGGER_SPEC)
 
 build: buildsrc gen
 
-buildsrc: $(SRCPATH)/crypto/lib/libsodium.a node_exporter NONGO_BIN deps
+buildsrc: $(SRCPATH)/crypto/lib/libsodium.a node_exporter NONGO_BIN deps $(ALGOD_API_SWAGGER_INJECT) $(KMD_API_SWAGGER_INJECT)
 	cd $(SRCPATH) && \
 		go install $(GOTAGS) -ldflags="$(GOLDFLAGS)" $(SOURCES)
 	cd $(SRCPATH) && \

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -41,12 +41,6 @@ function check_deps() {
         echo "... stringer missing"
     fi
 
-    if [ ! -f "${GOPATH}/bin/swagger" ]; then
-        SWAGGER_MISSING=1
-        ANY_MISSING=1
-        echo "... swagger missing"
-    fi
-
     if [ ! -f "${GOPATH}/bin/dep" ]; then
         DEP_MISSING=1
         ANY_MISSING=1
@@ -75,14 +69,6 @@ if [ ${STRINGER_MISSING} -ne 0 ]; then
     if [ "$OK" = "y" ]; then
         echo "Installing stringer..."
         go get -u golang.org/x/tools/cmd/stringer
-    fi
-fi
-
-if [ ${SWAGGER_MISSING} -ne 0 ]; then
-    read -p "Install go-swagger (using go get) (y/N): " OK
-    if [ "$OK" = "y" ]; then
-        echo "Installing swagger..."
-        go get -u github.com/go-swagger/go-swagger/cmd/swagger
     fi
 fi
 

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -47,6 +47,13 @@ function check_deps() {
         echo "... dep missing"
     fi
 
+    if [ -f "${GOPATH}/bin/swagger" ]; then
+        SWAGGER_EXTRANEOUS=1
+        ANY_MISSING=1
+        echo "... GOPATH/bin/swagger extraneous"
+        echo "... Ensure that you have installed a release build of go-swagger with brew or deb, or with configure_dev.sh"
+    fi
+
     return ${ANY_MISSING}
 }
 
@@ -78,6 +85,11 @@ if [ ${DEP_MISSING} -ne 0 ]; then
         echo "Installing dep..."
         go get -u github.com/golang/dep/cmd/dep
     fi
+fi
+
+if [ ${SWAGGER_EXTRANEOUS} -ne 0 ]; then
+    echo "Removing GOPATH/bin/swagger..."
+    go clean -i github.com/go-swagger/go-swagger/cmd/swagger
 fi
 
 check_deps

--- a/scripts/configure_dev-deps.sh
+++ b/scripts/configure_dev-deps.sh
@@ -5,4 +5,3 @@ set -x
 go get -u golang.org/x/lint/golint
 go get -u github.com/golang/dep/cmd/dep
 go get -u golang.org/x/tools/cmd/stringer
-go get -u github.com/go-swagger/go-swagger/cmd/swagger

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -16,6 +16,9 @@ function install_or_upgrade {
 if [ "${OS}" = "linux" ]; then
     sudo apt-get update
     sudo apt-get -y install libboost-all-dev expect jq
+    echo "deb [trusted=yes] https://dl.bintray.com/go-swagger/goswagger-debian ubuntu main" | sudo tee -a /etc/apt/sources.list
+    sudo apt-get update
+    sudo apt-get -y install swagger
 elif [ "${OS}" = "darwin" ]; then
     brew update
     brew tap caskroom/cask
@@ -25,6 +28,8 @@ elif [ "${OS}" = "darwin" ]; then
     install_or_upgrade libtool
     install_or_upgrade autoconf
     install_or_upgrade automake
+    brew tap go-swagger/go-swagger
+    install_or_upgrade go-swagger
 fi
 
 ${SCRIPTPATH}/configure_dev-deps.sh

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -14,11 +14,9 @@ function install_or_upgrade {
 }
 
 if [ "${OS}" = "linux" ]; then
+    echo "deb [trusted=yes] https://dl.bintray.com/go-swagger/goswagger-debian ubuntu main" | sudo tee /etc/apt/sources.list.d/goswagger.list
     sudo apt-get update
-    sudo apt-get -y install libboost-all-dev expect jq
-    echo "deb [trusted=yes] https://dl.bintray.com/go-swagger/goswagger-debian ubuntu main" | sudo tee -a /etc/apt/sources.list
-    sudo apt-get update
-    sudo apt-get -y install swagger
+    sudo apt-get -y install libboost-all-dev expect jq swagger
 elif [ "${OS}" = "darwin" ]; then
     brew update
     brew tap caskroom/cask


### PR DESCRIPTION
We previously removed swagger build step due to change in swagger upstream master. Now, we pin build to specific swagger release version using brew and debian package. Reenables swagger build step.

I preferred this over go/vendoring because we use swagger as a build tool, not as an import dependency. 