### PR TITLE
[GOAL2-761] WsFetcherService::handleNetworkMsg telemetry event becomes level Info, was level Warn

### DIFF
--- a/rpcs/wsFetcherService.go
+++ b/rpcs/wsFetcherService.go
@@ -38,7 +38,7 @@ func (fs *WsFetcherService) handleNetworkMsg(msg network.IncomingMessage) (out n
 	f := fs.fetchers[msg.Tag]
 	fs.mu.RUnlock()
 	if f == nil {
-		fs.log.Warnf("WsFetcherService: no fetcher registered for tag (%v)", msg.Tag)
+		fs.log.Infof("WsFetcherService: no fetcher registered for tag (%v)", msg.Tag)
 		return
 	}
 	return f.HandleNetworkMsg(msg)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

I noticed this task in the emailed list of pre-sprint-resumption tasks: downgrade the event in question to `Info` from `Warn`.

## Test Plan

Automated tests.

