### PR TITLE
[GOAL2-314 GH-141] Fix kmd/swagger.json build warnings

### DIFF
--- a/daemon/kmd/api/api.go
+++ b/daemon/kmd/api/api.go
@@ -85,15 +85,20 @@ var supportedAPIVersions = []string{apiV1Tag}
 // The /versions endpoint is one of two non-versioned API endpoints, since its
 // response tells us which API versions are supported (the other is /swagger.json)
 func versionsHandler(w http.ResponseWriter, r *http.Request) {
-	// swagger:route GET /versions GetVersion
-	//
-	// Retrieves the current version
-	//
+	// swagger:operation GET /versions GetVersion
+	//---
+	//     Summary: Retrieves the current version
 	//     Produces:
 	//     - application/json
-	//     Schemes: http
+	//     Parameters:
+	//     - name: Versions Request
+	//       in: body
+	//       required: false
+	//       schema:
+	//         "$ref": "#/definitions/VersionsRequest"
 	//     Responses:
-	//		200: VersionsResponse
+	//       "200":
+	//         "$ref": "#/responses/VersionsResponse"
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	response := kmdapi.VersionsResponse{

--- a/daemon/kmd/api/v1/handlers.go
+++ b/daemon/kmd/api/v1/handlers.go
@@ -92,6 +92,12 @@ func getWalletsHandler(ctx reqContext, w http.ResponseWriter, r *http.Request) {
 	//    Description: Lists all of the wallets that kmd is aware of.
 	//    Produces:
 	//    - application/json
+	//    Parameters:
+	//    - name: List Wallet Request
+	//      in: body
+	//      required: false
+	//      schema:
+	//        "$ref": "#/definitions/ListWalletsRequest"
 	//    Responses:
 	//      "200":
 	//        "$ref": "#/responses/ListWalletsResponse"

--- a/daemon/kmd/lib/kmdapi/requests.go
+++ b/daemon/kmd/lib/kmdapi/requests.go
@@ -21,10 +21,14 @@ import (
 )
 
 // APIV1Request is the interface that all API V1 requests must satisfy
-type APIV1Request interface{}
+//
+// swagger:ignore
+type APIV1Request interface{} // we need to tell swagger to ignore due to bug (go-swagger/issues/1436)
 
 // APIV1RequestEnvelope is a common envelope that all API V1 requests must embed
-type APIV1RequestEnvelope struct {
+//
+// swagger:ignore
+type APIV1RequestEnvelope struct { // we need to tell swagger to ignore due to bug (go-swagger/issues/1436)
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 }
 


### PR DESCRIPTION
Fixes #141 

- Eliminates the following build warnings:
```
The swagger spec at "./swagger.json" showed up some valid but possibly unwanted constructs.
2019/07/11 11:42:06 See warnings below:
2019/07/11 11:42:06 - WARNING: definition "#/definitions/APIV1RequestEnvelope" is not used anywhere
2019/07/11 11:42:06 - WARNING: definition "#/definitions/VersionsRequest" is not used anywhere
2019/07/11 11:42:06 - WARNING: definition "#/definitions/ListWalletsRequest" is not used anywhere
2019/07/11 11:42:06 - WARNING: definition "#/definitions/APIV1Request" is not used anywhere
```
- tell swagger not to generate definitions for internal struct types
- make usage of certain requests explicit (and optional)