### PR TITLE
Systemd service template

### DIFF
--- a/installer/algorand.service
+++ b/installer/algorand.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Algorand daemon
+Description=Algorand daemon for mainnet in /var/lib/algorand
 After=network.target
 
 [Service]

--- a/installer/algorand@.service
+++ b/installer/algorand@.service
@@ -1,13 +1,13 @@
 ## For some data directory $ALGORAND_DATA
 ##
 ## Setup:
-## ALGORAND_DATA=/var/lib/algorand_devnet2
+## ALGORAND_DATA=/var/lib/algorand_devnet
 ## sudo mkdir -p ${ALGORAND_DATA}
 ## sudo cp -p /var/lib/algorand/genesis/devnet/genesis.json ${ALGORAND_DATA}/genesis.json
 ## sudo cp -p /var/lib/algorand/system.json ${ALGORAND_DATA}/system.json
 ## sudo chown -R algorand ${ALGORAND_DATA}
 ##
-## systemd allows for config overrides is a .conf file under a directory named for the service. e.g.:
+## systemd allows for config overrides in a .conf file under a directory named for the service. e.g.:
 ##
 ## sudo mkdir -p /lib/systemd/system/algorand@$(systemd-escape ${ALGORAND_DATA}).service.d
 ## cat <<EOF>/lib/systemd/system/algorand@$(systemd-escape ${ALGORAND_DATA}).service.d/override.conf

--- a/installer/algorand@.service
+++ b/installer/algorand@.service
@@ -1,0 +1,38 @@
+## For some data directory $ALGORAND_DATA
+##
+## Setup:
+## ALGORAND_DATA=/var/lib/algorand_devnet2
+## sudo mkdir -p ${ALGORAND_DATA}
+## sudo cp -p /var/lib/algorand/genesis/devnet/genesis.json ${ALGORAND_DATA}/genesis.json
+## sudo cp -p /var/lib/algorand/system.json ${ALGORAND_DATA}/system.json
+## sudo chown -R algorand ${ALGORAND_DATA}
+##
+## systemd allows for config overrides is a .conf file under a directory named for the service. e.g.:
+##
+## sudo mkdir -p /lib/systemd/system/algorand@$(systemd-escape ${ALGORAND_DATA}).service.d
+## cat <<EOF>/lib/systemd/system/algorand@$(systemd-escape ${ALGORAND_DATA}).service.d/override.conf
+## [Service]
+## User=someuser
+## EOF
+##
+## sudo systemctl enable algorand@$(systemd-escape ${ALGORAND_DATA})
+## sudo systemctl start algorand@$(systemd-escape ${ALGORAND_DATA})
+
+
+[Unit]
+Description=Algorand daemon for %I
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/algod -d %I
+PIDFile=%I/algod.pid
+User=algorand
+Group=nogroup
+Restart=always
+RestartSec=5s
+ProtectSystem=full
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target
+DefaultInstance=-var-lib-algorand

--- a/installer/algorand@.service
+++ b/installer/algorand@.service
@@ -35,4 +35,3 @@ ProtectHome=true
 
 [Install]
 WantedBy=multi-user.target
-DefaultInstance=-var-lib-algorand

--- a/installer/algorand@.service
+++ b/installer/algorand@.service
@@ -1,9 +1,9 @@
 ## For some data directory $ALGORAND_DATA
 ##
 ## Setup:
-## ALGORAND_DATA=/var/lib/algorand_devnet
+## ALGORAND_DATA=/var/lib/algorand_testnet
 ## sudo mkdir -p ${ALGORAND_DATA}
-## sudo cp -p /var/lib/algorand/genesis/devnet/genesis.json ${ALGORAND_DATA}/genesis.json
+## sudo cp -p /var/lib/algorand/genesis/testnet/genesis.json ${ALGORAND_DATA}/genesis.json
 ## sudo cp -p /var/lib/algorand/system.json ${ALGORAND_DATA}/system.json
 ## sudo chown -R algorand ${ALGORAND_DATA}
 ##

--- a/installer/debian/postinst
+++ b/installer/debian/postinst
@@ -26,6 +26,7 @@ if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-decon
 		systemctl --system daemon-reload >/dev/null || true
 		if [ -n "$2" ]; then
 			_dh_action=restart
+			deb-systemd-invoke restart algorand@\* >/dev/null || true
 		else
 			_dh_action=start
 		fi

--- a/installer/debian/postrm
+++ b/installer/debian/postrm
@@ -4,6 +4,7 @@
 if [ "$1" = "remove" ]; then
 	if [ -x "/usr/bin/deb-systemd-helper" ]; then
 		deb-systemd-helper mask algorand.service >/dev/null || true
+		deb-systemd-helper mask algorand@\* >/dev/null || true
 	fi
 fi
 
@@ -11,6 +12,8 @@ if [ "$1" = "purge" ]; then
 	if [ -x "/usr/bin/deb-systemd-helper" ]; then
 		deb-systemd-helper purge algorand.service >/dev/null || true
 		deb-systemd-helper unmask algorand.service >/dev/null || true
+		deb-systemd-helper purge algorand@\* >/dev/null || true
+		deb-systemd-helper unmask algorand@\* >/dev/null || true
 	fi
 fi
 

--- a/installer/debian/prerm
+++ b/installer/debian/prerm
@@ -3,4 +3,5 @@
 ## cat /usr/share/debhelper/autoscripts/prerm-systemd-restart | sed -e s,#UNITFILES#,algorand.service,
 if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
 	deb-systemd-invoke stop algorand.service >/dev/null || true
+	deb-systemd-invoke stop algorand@\* >/dev/null || true
 fi

--- a/installer/rpm/algorand.spec
+++ b/installer/rpm/algorand.spec
@@ -7,10 +7,7 @@ License:       AGPL-3+
 Requires:      yum-cron
 Requires:      systemd
 Requires(pre): shadow-utils
-
-## Skip BuildRequires for now because we are building using rpmbuild
-## on an Ubuntu machine.
-# BuildRequires: golang >= 1.12
+BuildRequires: systemd-rpm-macros
 
 %define SRCDIR go-algorand-rpmbuild
 %define _buildshell /bin/bash
@@ -42,6 +39,7 @@ done
 
 mkdir -p %{buildroot}/lib/systemd/system
 install -m 644 ${REPO_DIR}/installer/algorand.service %{buildroot}/lib/systemd/system/algorand.service
+install -m 644 ${REPO_DIR}/installer/algorand@.service %{buildroot}/lib/systemd/system/algorand@.service
 
 mkdir -p %{buildroot}/etc/cron.hourly
 install -m 755 ${REPO_DIR}/installer/rpm/0yum-algorand-hourly.cron %{buildroot}/etc/cron.hourly/0yum-algorand-hourly.cron
@@ -89,39 +87,13 @@ fi
   /var/lib/algorand/genesis/mainnet/genesis.json
 %endif
 /lib/systemd/system/algorand.service
+/lib/systemd/system/algorand@.service
 %config(noreplace) /etc/cron.hourly/0yum-algorand-hourly.cron
 %config(noreplace) /etc/yum/yum-cron-algorand.conf
 /etc/pki/rpm-gpg/RPM-GPG-KEY-Algorand
 /usr/lib/algorand/yum.repos.d/algorand.repo
 
 %changelog
-
-## systemd macros from /usr/lib/rpm/macros.d/macros.systemd
-## copied here so we don't have to figure out how to install
-## this file on an Ubuntu build host.
-
-%define systemd_post() \
-if [ $1 -eq 1 ] ; then \
-        # Initial installation \
-        systemctl preset %{?*} >/dev/null 2>&1 || : \
-fi \
-%{nil}
-
-%define systemd_preun() \
-if [ $1 -eq 0 ] ; then \
-        # Package removal, not upgrade \
-        systemctl --no-reload disable %{?*} > /dev/null 2>&1 || : \
-        systemctl stop %{?*} > /dev/null 2>&1 || : \
-fi \
-%{nil}
-
-%define systemd_postun_with_restart() \
-systemctl daemon-reload >/dev/null 2>&1 || : \
-if [ $1 -ge 1 ] ; then \
-        # Package upgrade, not uninstall \
-        systemctl try-restart %{?*} >/dev/null 2>&1 || : \
-fi \
-%{nil}
 
 %pre
 getent passwd algorand >/dev/null || \

--- a/installer/rpm/algorand.spec
+++ b/installer/rpm/algorand.spec
@@ -106,6 +106,8 @@ chown -R algorand /var/lib/algorand
 
 %preun
 %systemd_preun algorand.service
+%systemd_preun algorand@*.service
 
 %postun
 %systemd_postun_with_restart algorand.service
+%systemd_postun_with_restart algorand@*.service

--- a/installer/rpm/algorand.spec
+++ b/installer/rpm/algorand.spec
@@ -7,7 +7,6 @@ License:       AGPL-3+
 Requires:      yum-cron
 Requires:      systemd
 Requires(pre): shadow-utils
-BuildRequires: systemd-rpm-macros
 
 %define SRCDIR go-algorand-rpmbuild
 %define _buildshell /bin/bash

--- a/installer/rpm/algorand.spec
+++ b/installer/rpm/algorand.spec
@@ -102,12 +102,12 @@ getent group nogroup >/dev/null || \
 
 %post
 chown -R algorand /var/lib/algorand
-%systemd_post algorand.service
+%systemd_post algorand
 
 %preun
-%systemd_preun algorand.service
-%systemd_preun algorand@*.service
+%systemd_preun algorand
+%systemd_preun algorand@*
 
 %postun
-%systemd_postun_with_restart algorand.service
-%systemd_postun_with_restart algorand@*.service
+%systemd_postun_with_restart algorand
+%systemd_postun_with_restart algorand@*

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -89,7 +89,7 @@ else
     #${GOPATH}/bin/buildtools genesis timestamp -f ${PKG_ROOT}/var/lib/algorand/genesis.json -t ${TIMESTAMP}
 fi
 
-systemd_files=("algorand.service")
+systemd_files=("algorand.service" "algorand@.service")
 mkdir -p ${PKG_ROOT}/lib/systemd/system
 for svc in "${systemd_files[@]}"; do
     cp installer/${svc} ${PKG_ROOT}/lib/systemd/system


### PR DESCRIPTION
## Summary

Add algorand@.service unit template into .deb and .rpm packages.

## Test Plan

For deb I hacked the algorand@.service file into an older install, enabled both the base algorand.service for mainnet and an algorand@... for devnet. Installed a newly build .deb and it restarted both daemons. (Tested on Ubuntu 18)
A couple rounds of installing new rpm packages on Centos7 demonstrated restarting both the main `algorand` service and an `algorand@...` instance.
