### PR TITLE
[GOAL2-794] In goal, change all instances of --addr to --address

### DIFF
--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -97,20 +97,20 @@ func init() {
 	newCmd.Flags().BoolVarP(&defaultAccount, "default", "f", false, "Set this account as the default one")
 
 	// Delete account flag
-	deleteCmd.Flags().StringVarP(&accountAddress, "addr", "a", "", "Address of account to delete")
-	deleteCmd.MarkFlagRequired("addr")
+	deleteCmd.Flags().StringVarP(&accountAddress, "address", "a", "", "Address of account to delete")
+	deleteCmd.MarkFlagRequired("address")
 
 	// New Multisig account flag
 	newMultisigCmd.Flags().Uint8VarP(&threshold, "threshold", "T", 1, "Number of signatures required to spend from this address")
 	newMultisigCmd.MarkFlagRequired("threshold")
 
 	// Delete multisig account flag
-	deleteMultisigCmd.Flags().StringVarP(&accountAddress, "addr", "a", "", "Address of multisig account to delete")
-	deleteMultisigCmd.MarkFlagRequired("addr")
+	deleteMultisigCmd.Flags().StringVarP(&accountAddress, "address", "a", "", "Address of multisig account to delete")
+	deleteMultisigCmd.MarkFlagRequired("address")
 
 	// Lookup info for multisig account flag
-	infoMultisigCmd.Flags().StringVarP(&accountAddress, "addr", "a", "", "Address of multisig account to look up")
-	infoMultisigCmd.MarkFlagRequired("addr")
+	infoMultisigCmd.Flags().StringVarP(&accountAddress, "address", "a", "", "Address of multisig account to look up")
+	infoMultisigCmd.MarkFlagRequired("address")
 
 	// Balance flags
 	balanceCmd.Flags().StringVarP(&accountAddress, "address", "a", "", "Account address to retrieve balance (required)")

--- a/cmd/goal/multisig.go
+++ b/cmd/goal/multisig.go
@@ -39,9 +39,9 @@ func init() {
 	multisigCmd.AddCommand(mergeSigCmd)
 
 	addSigCmd.Flags().StringVarP(&txFilename, "tx", "t", "", "Partially-signed transaction file to add signature to")
-	addSigCmd.Flags().StringVarP(&addr, "addr", "a", "", "Address of the key to sign with")
+	addSigCmd.Flags().StringVarP(&addr, "address", "a", "", "Address of the key to sign with")
 	addSigCmd.MarkFlagRequired("tx")
-	addSigCmd.MarkFlagRequired("addr")
+	addSigCmd.MarkFlagRequired("address")
 
 	mergeSigCmd.Flags().StringVarP(&txFilename, "out", "o", "", "Output file for merged transactions")
 	mergeSigCmd.MarkFlagRequired("out")

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -209,7 +209,7 @@ proc ::AlgorandGoal::VerifyAccount { WALLET_NAME WALLET_PASSWORD ACCOUNT_ADDRESS
 
 # Delete an account
 proc ::AlgorandGoal::DeleteAccount { WALLET_NAME ACCOUNT_ADDRESS } {
-    spawn goal account delete --wallet $WALLET_NAME --addr $ACCOUNT_ADDRESS
+    spawn goal account delete --wallet $WALLET_NAME --address $ACCOUNT_ADDRESS
     expect {*}
 }
 
@@ -400,7 +400,7 @@ proc ::AlgorandGoal::CreateOneOfTwoMultisigForWallet { ADDRESS_1 ADDRESS_2 WALLE
 # Query info for a 1-of-2 multisig account, and verify
 proc ::AlgorandGoal::VerifyMultisigInfoForOneOfTwoMultisig { MULTISIG_ADDRESS ADDRESS_1 ADDRESS_2 WALLET_NAME TEST_PRIMARY_NODE_DIR } {
     if { [ catch {
-        spawn goal account multisig info --addr $MULTISIG_ADDRESS -d $TEST_PRIMARY_NODE_DIR -w $WALLET_NAME
+        spawn goal account multisig info --address $MULTISIG_ADDRESS -d $TEST_PRIMARY_NODE_DIR -w $WALLET_NAME
         expect {
             timeout { ::AlgorandGoal::Abort "Timed out querying info about multisig account $MULTISIG_ADDRESS"  }
             -re {Version: (\d+)\r\nThreshold: (\d+)\r\nPublic keys:\r\n  ([a-zA-Z0-9]+)\r\n  ([a-zA-Z0-9]+)\r\n} {
@@ -422,7 +422,7 @@ proc ::AlgorandGoal::VerifyMultisigInfoForOneOfTwoMultisig { MULTISIG_ADDRESS AD
 # Delete a multisig address
 proc ::AlgorandGoal::DeleteMultisigAccount { MULTISIG_ADDRESS TEST_PRIMARY_NODE_DIR } {
     if { [ catch {
-        spawn goal account multisig delete --addr $MULTISIG_ADDRESS -d $TEST_PRIMARY_NODE_DIR
+        spawn goal account multisig delete --address $MULTISIG_ADDRESS -d $TEST_PRIMARY_NODE_DIR
         expect {*}
     } EXCEPTION ] } {
        ::AlgorandGoal::Abort "ERROR in DeleteMultisigAccount: $EXCEPTION"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

A simple change: when specifying addresses to `goal`, sometimes the shorthand the argument was `addr`, and sometimes `address`. I searched for instances of `addr` and replaced them with `address`.

## Test Plan

Automated test suite.
