### PR TITLE
GOAL2-653 deprecate IsRelay field in NodeConfig

### DIFF
--- a/cmd/netgoal/generate.go
+++ b/cmd/netgoal/generate.go
@@ -199,7 +199,10 @@ func generateNetworkTemplate(templateFilename string, wallets, relays, nodeHosts
 		newNode.NodeNameMatchRegex = ""
 		newNode.FractionApply = 0.0
 		newNode.Name = name
-		newNode.IsRelay = true
+		if newNode.NetAddress == "" {
+			// if not set by relayTemplate ensure that it is a relay
+			newNode.NetAddress = "0.0.0.0:4160"
+		}
 		newNode.Wallets = nil
 		host.Nodes = append(host.Nodes, newNode)
 		network.Hosts = append(network.Hosts, host)

--- a/cmd/netgoal/generate.go
+++ b/cmd/netgoal/generate.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"math/rand"
 	"os"
 	"regexp"
@@ -200,8 +201,7 @@ func generateNetworkTemplate(templateFilename string, wallets, relays, nodeHosts
 		newNode.FractionApply = 0.0
 		newNode.Name = name
 		if newNode.NetAddress == "" {
-			// if not set by relayTemplate ensure that it is a relay
-			newNode.NetAddress = "0.0.0.0:4160"
+			return errors.New("relay template did not set NetAddress")
 		}
 		newNode.Wallets = nil
 		host.Nodes = append(host.Nodes, newNode)

--- a/cmd/nodecfg/apply.go
+++ b/cmd/nodecfg/apply.go
@@ -132,7 +132,7 @@ func doApply(rootDir string, rootNodeDir, channel string, hostName string, dnsNa
 
 func hostNeedsDNSName(config remote.HostConfig) bool {
 	for _, node := range config.Nodes {
-		if node.IsRelay || node.EnableMetrics {
+		if node.IsRelay() || node.EnableMetrics {
 			return true
 		}
 	}

--- a/netdeploy/remote/deployedNetwork.go
+++ b/netdeploy/remote/deployedNetwork.go
@@ -422,7 +422,7 @@ func createHostSpec(host HostConfig, template cloudHost) (hostSpec cloudHostSpec
 	defaultConfig := config.GetDefaultLocal()
 	var port int
 	for _, node := range host.Nodes {
-		if node.IsRelay {
+		if node.IsRelay() {
 			relayCount++
 			port, err = extractPublicPort(node.NetAddress)
 			if err != nil {

--- a/netdeploy/remote/nodeConfig.go
+++ b/netdeploy/remote/nodeConfig.go
@@ -19,7 +19,7 @@ package remote
 // NodeConfig represents the configuration settings to apply to a single node running on a host
 type NodeConfig struct {
 	Name               string `json:",omitempty"`
-	IsRelay            bool
+	IsRelayDEPRECATED  bool   `json:"IsRelay,omitempty"` // The field still exists to parse any old serialized NodeConfig objects, but "IsRelay" should not be used.
 	Wallets            []NodeWalletData
 	NetAddress         string `json:",omitempty"`
 	APIEndpoint        string `json:",omitempty"`
@@ -44,4 +44,9 @@ type NodeConfig struct {
 	// AltConfigs have other values for NodeNameMatchRegex or FractionApply. Typically the root NodeConfig is the default template and AltConfig contains variations that match some regex or are applied randomly to some fraction.
 	// This should not be used recursively, but only one deep, a root and a list of alt configs.
 	AltConfigs []NodeConfig `json:",omitempty"`
+}
+
+// If we advertise to the world an address where we listen for gossip network connections, we are taking on the role of relay.
+func (nc NodeConfig) IsRelay() bool {
+	return nc.NetAddress != ""
 }

--- a/netdeploy/remote/nodeConfig.go
+++ b/netdeploy/remote/nodeConfig.go
@@ -19,7 +19,6 @@ package remote
 // NodeConfig represents the configuration settings to apply to a single node running on a host
 type NodeConfig struct {
 	Name               string `json:",omitempty"`
-	IsRelayDEPRECATED  bool   `json:"IsRelay,omitempty"` // The field still exists to parse any old serialized NodeConfig objects, but "IsRelay" should not be used.
 	Wallets            []NodeWalletData
 	NetAddress         string `json:",omitempty"`
 	APIEndpoint        string `json:",omitempty"`

--- a/netdeploy/remote/nodeConfig.go
+++ b/netdeploy/remote/nodeConfig.go
@@ -45,7 +45,8 @@ type NodeConfig struct {
 	AltConfigs []NodeConfig `json:",omitempty"`
 }
 
-// If we advertise to the world an address where we listen for gossip network connections, we are taking on the role of relay.
+// IsRelay returns true if the node is configured to be a relay
 func (nc NodeConfig) IsRelay() bool {
+	// If we advertise to the world an address where we listen for gossip network connections, we are taking on the role of relay.
 	return nc.NetAddress != ""
 }

--- a/netdeploy/remote/nodecfg/nodeDir.go
+++ b/netdeploy/remote/nodecfg/nodeDir.go
@@ -94,7 +94,7 @@ func (nd *nodeDir) configure(dnsName string) (err error) {
 	}
 	// Do this after reconciling the DNSBootstrap ID because we'll extract the network name
 	// from it (eg <network>.algoblah.network -> algoblah.network)
-	if err = nd.configureNetAddress(nd.NetAddress); err != nil {
+	if err = nd.configureNetAddress(); err != nil {
 		fmt.Fprintf(os.Stdout, "Error during configureNetAddress: %s\n", err)
 		return
 	}
@@ -137,16 +137,16 @@ func (nd *nodeDir) configureRelay(enable bool) (err error) {
 	return
 }
 
-func (nd *nodeDir) configureNetAddress(address string) (err error) {
+func (nd *nodeDir) configureNetAddress() (err error) {
 	if err = nd.ensureConfig(); err != nil {
 		return
 	}
-	fmt.Fprintf(os.Stdout, " - Assigning NetAddress: %s\n", address)
-	nd.config.NetAddress = address
-	if address != "" && address[0] == ':' && nd.IsRelay() {
+	fmt.Fprintf(os.Stdout, " - Assigning NetAddress: %s\n", nd.NetAddress)
+	nd.config.NetAddress = nd.NetAddress
+	if nd.IsRelay() && nd.NetAddress[0] == ':' {
 		fmt.Fprintf(os.Stdout, " - adding to relay addresses\n")
 		domainName := strings.Replace(nd.config.DNSBootstrapID, "<network>", string(nd.configurator.genesisData.Network), -1)
-		nd.configurator.addRelaySrv(domainName, address)
+		nd.configurator.addRelaySrv(domainName, nd.NetAddress)
 	}
 	err = nd.saveConfig()
 	return

--- a/netdeploy/remote/nodecfg/nodeDir.go
+++ b/netdeploy/remote/nodecfg/nodeDir.go
@@ -55,7 +55,7 @@ type nodeDir struct {
 //		* DeadlockOverride
 func (nd *nodeDir) configure(dnsName string) (err error) {
 	fmt.Fprintf(os.Stdout, "Configuring Node %s\n", nd.Name)
-	if err = nd.configureRelay(nd.IsRelay); err != nil {
+	if err = nd.configureRelay(nd.IsRelay()); err != nil {
 		fmt.Fprintf(os.Stdout, "Error during configureRelay: %s\n", err)
 		return
 	}
@@ -143,7 +143,7 @@ func (nd *nodeDir) configureNetAddress(address string) (err error) {
 	}
 	fmt.Fprintf(os.Stdout, " - Assigning NetAddress: %s\n", address)
 	nd.config.NetAddress = address
-	if address != "" && address[0] == ':' && nd.IsRelay {
+	if address != "" && address[0] == ':' && nd.IsRelay() {
 		fmt.Fprintf(os.Stdout, " - adding to relay addresses\n")
 		domainName := strings.Replace(nd.config.DNSBootstrapID, "<network>", string(nd.configurator.genesisData.Network), -1)
 		nd.configurator.addRelaySrv(domainName, address)


### PR DESCRIPTION
## Summary

Simplify NodeConfig struct. IsRelay is redundant, IsRelay() = nc.NetAddress != ""

## Test Plan

compilation plus unit tests

