### PR TITLE
cmd/goal: allow stdin/stdout shell pipes

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -20,7 +20,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/algorand/go-algorand/crypto"
@@ -153,7 +152,7 @@ func writeTxnToFile(client libgoal.Client, signTx bool, dataDir string, walletNa
 	}
 
 	// Write the SignedTxn to the output file
-	return ioutil.WriteFile(filename, protocol.Encode(stxn), 0600)
+	return writeFile(filename, protocol.Encode(stxn), 0600)
 }
 
 var sendCmd = &cobra.Command{
@@ -247,7 +246,7 @@ var rawsendCmd = &cobra.Command{
 			rejectsFilename = txFilename + ".rej"
 		}
 
-		data, err := ioutil.ReadFile(txFilename)
+		data, err := readFile(txFilename)
 		if err != nil {
 			reportErrorf(fileReadError, txFilename, err)
 		}
@@ -358,7 +357,7 @@ var inspectCmd = &cobra.Command{
 	Short: "print a transaction file",
 	Run: func(cmd *cobra.Command, args []string) {
 		for _, txFilename := range args {
-			data, err := ioutil.ReadFile(txFilename)
+			data, err := readFile(txFilename)
 			if err != nil {
 				reportErrorf(fileReadError, txFilename, err)
 			}
@@ -391,7 +390,7 @@ var signCmd = &cobra.Command{
 	Long:  `Sign the passed transaction file, which may contain one or more transactions. If the infile and the outfile are the same, this overwrites the file with the new, signed data.`,
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
-		data, err := ioutil.ReadFile(txFilename)
+		data, err := readFile(txFilename)
 		if err != nil {
 			reportErrorf(fileReadError, txFilename, err)
 		}
@@ -420,7 +419,7 @@ var signCmd = &cobra.Command{
 
 			outData = append(outData, protocol.Encode(signedTxn)...)
 		}
-		err = ioutil.WriteFile(outFilename, outData, 0600)
+		err = writeFile(outFilename, outData, 0600)
 		if err != nil {
 			reportErrorf(fileWriteError, outFilename, err)
 		}

--- a/cmd/goal/commands.go
+++ b/cmd/goal/commands.go
@@ -452,3 +452,26 @@ func reportErrorf(format string, args ...interface{}) {
 	// log.Warnf(format, args...)
 	os.Exit(1)
 }
+
+// writeFile is a wrapper of ioutil.WriteFile which considers the special
+// case of stdout filename
+func writeFile(filename string, data []byte, perm os.FileMode) error {
+	var err error
+	if filename == stdoutFilenameValue {
+		// Write to Stdout
+		if _, err = os.Stdout.Write(data); err != nil {
+			return err
+		}
+		return nil
+	}
+	return ioutil.WriteFile(filename, data, 0600)
+}
+
+// readFile is a wrapper of ioutil.ReadFile which consniders the
+// special case of stdin filename
+func readFile(filename string) ([]byte, error) {
+	if filename == stdinFileNameValue {
+		return ioutil.ReadAll(os.Stdin)
+	}
+	return ioutil.ReadFile(filename)
+}

--- a/cmd/goal/commands.go
+++ b/cmd/goal/commands.go
@@ -464,7 +464,7 @@ func writeFile(filename string, data []byte, perm os.FileMode) error {
 		}
 		return nil
 	}
-	return ioutil.WriteFile(filename, data, 0600)
+	return ioutil.WriteFile(filename, data, perm)
 }
 
 // readFile is a wrapper of ioutil.ReadFile which consniders the

--- a/cmd/goal/commands.go
+++ b/cmd/goal/commands.go
@@ -442,13 +442,13 @@ func reportWarnf(format string, args ...interface{}) {
 }
 
 func reportErrorln(args ...interface{}) {
-	fmt.Println(args...)
+	fmt.Fprintln(os.Stderr, args...)
 	// log.Warnln(args...)
 	os.Exit(1)
 }
 
 func reportErrorf(format string, args ...interface{}) {
-	fmt.Printf(format+"\n", args...)
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
 	// log.Warnf(format, args...)
 	os.Exit(1)
 }

--- a/cmd/goal/common.go
+++ b/cmd/goal/common.go
@@ -18,6 +18,11 @@ package main
 
 import "github.com/spf13/cobra"
 
+const (
+	stdoutFilenameValue = "-"
+	stdinFileNameValue  = "-"
+)
+
 // validateNoPosArgsFn is a reusable cobra positional argument validation function
 // for generating proper error messages when commands see unexpected arguments when they expect no args.
 // We don't use cobra.NoArgs directly, in case we want to customize behavior later.

--- a/cmd/goal/multisig.go
+++ b/cmd/goal/multisig.go
@@ -64,7 +64,7 @@ var addSigCmd = &cobra.Command{
 	Long:  `Start a multisig, or add a signature to an existing multisig, for a given transaction`,
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
-		data, err := ioutil.ReadFile(txFilename)
+		data, err := readFile(txFilename)
 		if err != nil {
 			reportErrorf(fileReadError, txFilename, err)
 		}
@@ -96,7 +96,7 @@ var addSigCmd = &cobra.Command{
 			outData = append(outData, protocol.Encode(stxn)...)
 		}
 
-		err = ioutil.WriteFile(txFilename, outData, 0600)
+		err = writeFile(txFilename, outData, 0600)
 		if err != nil {
 			reportErrorf(fileWriteError, txFilename, err)
 		}
@@ -168,7 +168,7 @@ var mergeSigCmd = &cobra.Command{
 			mergedData = append(mergedData, protocol.Encode(txn)...)
 		}
 
-		err := ioutil.WriteFile(txFilename, mergedData, 0600)
+		err := writeFile(txFilename, mergedData, 0600)
 		if err != nil {
 			reportErrorf(fileWriteError, txFilename, err)
 		}

--- a/netdeploy/networkTemplate.go
+++ b/netdeploy/networkTemplate.go
@@ -72,7 +72,7 @@ func (t NetworkTemplate) createNodeDirectories(targetFolder string, binDir strin
 	nodeDirs = make(map[string]string)
 	getGenesisVerCmd := filepath.Join(binDir, "algod")
 	importKeysCmd := filepath.Join(binDir, "goal")
-	genesisVer, err := util.ExecAndCaptureOutput(getGenesisVerCmd, "-G", "-d", targetFolder)
+	genesisVer, _, err := util.ExecAndCaptureOutput(getGenesisVerCmd, "-G", "-d", targetFolder)
 	if err != nil {
 		return
 	}
@@ -137,7 +137,7 @@ func (t NetworkTemplate) createNodeDirectories(targetFolder string, binDir strin
 				return
 			}
 
-			_, err = util.ExecAndCaptureOutput(importKeysCmd, "account", "importrootkey", "-w", string(libgoal.UnencryptedWalletName), "-d", nodeDir)
+			_, _, err = util.ExecAndCaptureOutput(importKeysCmd, "account", "importrootkey", "-w", string(libgoal.UnencryptedWalletName), "-d", nodeDir)
 			if err != nil {
 				return
 			}

--- a/netdeploy/remote/nodecfg/nodeConfigurator.go
+++ b/netdeploy/remote/nodecfg/nodeConfigurator.go
@@ -213,7 +213,7 @@ func getClouldflareCredentials() (zoneID string, email string, authKey string, e
 }
 
 func importWalletFiles(importKeysCmd string, nodeDir string) error {
-	_, err := util.ExecAndCaptureOutput(importKeysCmd, "account", "importrootkey", "-d", nodeDir, "-u")
+	_, _, err := util.ExecAndCaptureOutput(importKeysCmd, "account", "importrootkey", "-d", nodeDir, "-u")
 	return err
 }
 


### PR DESCRIPTION
## Summary
Propose a solution for #83 

Notes:
- File reads and writes were abstracted to new functions. Since they're quite generic for `cmd`, they live on commands.go
- Depending on `filename`, it distinguishes using two different functions (Write vs WriteFile, ReadAll vs ReadFile). The functions WriteFile and ReadFile functions close the file (not sure would be quite right for std*, so read/wrote directly to os.Std*).
- Further checks can be added to see if stdin is being piped or attached to a prompt. Worth it?

## Test Plan
This can be tested doing something like the following:
`./goal clerk send -a 1 -t 52ZOFGOJR7A33SIJGOCSD7LTHJGB3JW26Y44D5THR25WIN2P5VGW2IUQMQ -o - -w unsafeWallet | ./goal clerk sign -i - -o - -w unsafeWallet | ./goal clerk inspect -`
Output:
```
-[0]
{
  "sig": "PFPpUVfFG83xyKBcBz4qqDgg/AaN6Me7TBE9in1JbYvME5eslgmM/loqEfGbs4vhyUYrpLD6bpFr2N/vGcbxDQ==",
  "txn": {
    "amt": 1,
    "fee": 1000,
    "fv": 609159,
    "gen": "mainnet-v1.0",
    "gh": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
    "lv": 610159,
    "note": "QIY+2fDk+6I=",
    "rcv": "52ZOFGOJR7A33SIJGOCSD7LTHJGB3JW26Y44D5THR25WIN2P5VGW2IUQMQ",
    "snd": "52ZOFGOJR7A33SIJGOCSD7LTHJGB3JW26Y44D5THR25WIN2P5VGW2IUQMQ",
    "type": "pay"
  }
}
```
Where `unsafeWallet` is an unencrypted wallet (to avoid the password prompt). The `-t addr` is dummy in this example. All affected commands use the same underlying new `readFile` and `writeFile` functions.

Curiously (not sure why), while doing this feature I ended up submitting a [tiny patch](https://github.com/golang/go/issues/33064) to the Go project for `ioutil.WriteFile()`.

