### PR TITLE
[GOAL2-770] rework an e2e rewards test to test more API functionality

### DIFF
--- a/daemon/algod/api/spec/v1/model.go
+++ b/daemon/algod/api/spec/v1/model.go
@@ -99,7 +99,7 @@ type Account struct {
 	// required: true
 	AmountWithoutPendingRewards uint64 `json:"amountwithoutpendingrewards"`
 
-	// Rewards indicates the total rewards of MicroAlgos the account has recieved
+	// Rewards indicates the total rewards of MicroAlgos the account has received, including pending rewards.
 	//
 	// required: true
 	Rewards uint64 `json:"rewards"`

--- a/test/e2e-go/features/participation/participationRewards_test.go
+++ b/test/e2e-go/features/participation/participationRewards_test.go
@@ -217,6 +217,7 @@ func TestRewardUnitThreshold(t *testing.T) {
 	tx, err := fixture.LibGoalClient.SendPaymentFromUnencryptedWallet(richAccount.Address, newAccount, txnFee, lessThanRewardUnit, nil)
 	r.NoError(err)
 	fixture.WaitForAllTxnsToConfirm(initialRound+uint64(10), map[string]string{tx.ID().String(): richAccount.Address})
+	initialBalanceNewAccount = lessThanRewardUnit
 
 	// wait for the client node to catch up to the same round as the fixture node
 	fixtureStatus, _ := fixture.LibGoalClient.Status()
@@ -228,15 +229,6 @@ func TestRewardUnitThreshold(t *testing.T) {
 	r.NoError(err)
 	client.WaitForRound(rewardRound)
 
-	txidsAndAddresses := make(map[string]string)
-	tx1, err := fixture.LibGoalClient.SendPaymentFromUnencryptedWallet(richAccount.Address, poorAccount, txnFee, amountRichAccountPokesWith, nil)
-	txidsAndAddresses[tx1.ID().String()] = richAccount.Address
-	r.NoError(err)
-	tx2, err := fixture.LibGoalClient.SendPaymentFromUnencryptedWallet(richAccount.Address, newAccount, txnFee, amountRichAccountPokesWith, nil)
-	r.NoError(err)
-	txidsAndAddresses[tx2.ID().String()] = richAccount.Address
-	fixture.WaitForAllTxnsToConfirm(rewardRound+uint64(10), txidsAndAddresses)
-
 	// wait for the client node to catch up to the same round as the fixture node
 	fixtureStatus, _ = fixture.LibGoalClient.Status()
 	_, err = client.WaitForRound(fixtureStatus.LastRound)
@@ -246,36 +238,54 @@ func TestRewardUnitThreshold(t *testing.T) {
 	updatedBalancePoorAccount, _ := client.AccountInformation(poorAccount)
 	updatedBalanceNewAccount, _ := client.AccountInformation(newAccount)
 	poorAccountDelta := updatedBalancePoorAccount.Amount - initialBalancePoorAccount
-	r.True(amountRichAccountPokesWith+initialBalancePoorAccount/rewardUnit <= poorAccountDelta, "non-empty account with balance > rewardunit (%d) should accrue rewards. started with %d, given %d, now has %d", rewardUnit, initialBalancePoorAccount, amountRichAccountPokesWith, updatedBalancePoorAccount.Amount)
-	r.True(initialBalancePoorAccount/rewardUnit <= updatedBalancePoorAccount.Rewards, "non-empty account with balance > rewardunit (%d) should accrue rewards. started with %d, given %d, now has %d, actual rewards %d", rewardUnit, initialBalancePoorAccount, amountRichAccountPokesWith, updatedBalancePoorAccount.Amount, updatedBalancePoorAccount.Rewards)
-
+	r.Truef(initialBalancePoorAccount/rewardUnit <= poorAccountDelta, "non-empty account with balance > rewardunit (%d) should accrue rewards. started with %d, given %d, now has %d. Expected %d", rewardUnit, initialBalancePoorAccount, amountRichAccountPokesWith, updatedBalancePoorAccount.Amount, amountRichAccountPokesWith+initialBalancePoorAccount/rewardUnit)
+	r.Truef(initialBalancePoorAccount/rewardUnit <= updatedBalancePoorAccount.Rewards, "non-empty account with balance > rewardunit (%d) should accrue rewards. started with %d, given %d, now has %d, actual rewards %d", rewardUnit, initialBalancePoorAccount, amountRichAccountPokesWith, updatedBalancePoorAccount.Amount, updatedBalancePoorAccount.Rewards)
+	r.Equal(initialBalancePoorAccount, updatedBalancePoorAccount.AmountWithoutPendingRewards, "amount without pending rewards should equal initial balance")
 	newAccountDelta := updatedBalanceNewAccount.Amount - initialBalanceNewAccount
-	r.Equal(newAccountDelta, updatedBalanceNewAccount.Amount, "empty account should have accrued no rewards")
-	// move 1 config.Protocol.RewardUnit to new account, wait for txn to confirm
+	r.Equal(uint64(0), newAccountDelta, "empty account should have accrued no rewards")
 
-	// after the last poke, the new account should have enough stake to get rewards.
+	// Test e2e REST API convenience computations
+	r.Equal(uint64(0), updatedBalanceNewAccount.PendingRewards, "empty account should have no pending rewards (e2e)")
+	r.Equal(uint64(0), updatedBalanceNewAccount.Rewards-updatedBalanceNewAccount.PendingRewards, "empty account should have no applied rewards (e2e)")
+	r.Truef(updatedBalancePoorAccount.PendingRewards >= initialBalancePoorAccount/rewardUnit, "poor account should have pending rewards (e2e)")
+	r.Equal(uint64(0), updatedBalancePoorAccount.Rewards-updatedBalancePoorAccount.PendingRewards, "poor account should have no applied rewards (e2e)")
+
+	// Poke poorAccount, so rewards are no longer pending.
+	txidsAndAddresses := make(map[string]string)
+	tx1, err := fixture.LibGoalClient.SendPaymentFromUnencryptedWallet(richAccount.Address, poorAccount, txnFee, amountRichAccountPokesWith, nil)
+	txidsAndAddresses[tx1.ID().String()] = richAccount.Address
+	r.NoError(err)
+
+	// Push newAccount balance above rewardUnit threshold.
+	tx2, err := fixture.LibGoalClient.SendPaymentFromUnencryptedWallet(richAccount.Address, newAccount, txnFee, amountRichAccountPokesWith, nil)
+	r.NoError(err)
+	txidsAndAddresses[tx2.ID().String()] = richAccount.Address
+	fixture.WaitForAllTxnsToConfirm(rewardRound+uint64(10), txidsAndAddresses)
+
+	// Now the new account should have enough stake to get rewards.
 	curStatus, _ = fixture.AlgodClient.Status()
 	rewardRound2, err := waitUntilRewards(t, &fixture, curStatus.LastRound)
 	r.NoError(err)
 	client.WaitForRound(rewardRound2)
 
-	// poke the new account again to trigger the computation
-	tx3, err := fixture.LibGoalClient.SendPaymentFromUnencryptedWallet(richAccount.Address, newAccount, txnFee, amountRichAccountPokesWith, nil)
-	txidsAndAddresses[tx3.ID().String()] = richAccount.Address
-	curStatus, _ = client.Status()
-	fixture.WaitForAllTxnsToConfirm(curStatus.LastRound+uint64(10), txidsAndAddresses)
-
-	// wait for the client node to catch up to the same round as the fixture node
-	fixtureStatus, _ = fixture.LibGoalClient.Status()
-	_, err = client.WaitForRound(fixtureStatus.LastRound)
-	r.NoError(err)
-
+	// Ensure that a reward for newAccount's one reward unit is now pending
 	latestBalanceNewAccount, _ := client.AccountInformation(newAccount)
+	r.Truef((initialBalanceNewAccount+amountRichAccountPokesWith)/rewardUnit >= 1, "new account needs at least one reward unit")
+	r.Truef(latestBalanceNewAccount.Amount >= initialBalanceNewAccount+(initialBalanceNewAccount+amountRichAccountPokesWith)/rewardUnit,
+		"account sent at least %d should have accrued rewards. started with %d, was bumped to %d, so increase should be more than the %d seen",
+		rewardUnit, initialBalanceNewAccount, rewardUnit-1, rewardUnit-1+amountRichAccountPokesWith, latestBalanceNewAccount.Amount)
 
-	r.True((rewardUnit-1+2*amountRichAccountPokesWith)+(rewardUnit-1+amountRichAccountPokesWith)/rewardUnit <= latestBalanceNewAccount.Amount,
-		"account sent at least %d should have accrued rewards. started with %d, was sent %d + 2* %d, so increase should be more than the %d seen",
-		rewardUnit, initialBalanceNewAccount, rewardUnit-1, amountRichAccountPokesWith, rewardUnit+amountRichAccountPokesWith) // first value was 0xf4242 second value was 0xf4246, account earned 4 microAlgos too many?
-	r.True((rewardUnit-1+amountRichAccountPokesWith)/rewardUnit <= latestBalanceNewAccount.Rewards, "The new account should have gained rewards as a result of funds transfer")
+	// newAccount rewards should be pending, because we didn't poke again
+	r.Equal(initialBalanceNewAccount+amountRichAccountPokesWith, latestBalanceNewAccount.AmountWithoutPendingRewards, "rewards should be pending")
+
+	// since we poked, previous rewards should no longer be pending for poor account
+	latestBalancePoorAccount, _ := client.AccountInformation(poorAccount)
+	r.Truef(latestBalancePoorAccount.AmountWithoutPendingRewards >= updatedBalancePoorAccount.Amount+amountRichAccountPokesWith, "rewards should have been applied")
+
+	// Test e2e REST API convenience computations
+	r.Truef(latestBalanceNewAccount.PendingRewards >= (initialBalanceNewAccount+amountRichAccountPokesWith)/rewardUnit, "new account should have pending rewards (e2e)")
+	r.Truef(latestBalancePoorAccount.Rewards-latestBalancePoorAccount.PendingRewards >= updatedBalancePoorAccount.Rewards, "poor account rewards should have been applied")
+
 }
 
 var defaultPoolAddr = basics.Address{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}


### PR DESCRIPTION
Also removes some extraneous account poking, clarifying the test.
This enables/qualifies PR #155 (refactor `Node.GetBalanceAndStatus`) which is in turn related to #148 (Update `goal listpartkeys` to indicate which part key is registered)