### PR TITLE
Remove `node.Full` interface

### DIFF
--- a/daemon/algod/api/server/lib/common.go
+++ b/daemon/algod/api/server/lib/common.go
@@ -43,7 +43,7 @@ type Routes []Route
 // ReqContext is passed to each of the handlers below via wrapCtx, allowing
 // handlers to interact with the node
 type ReqContext struct {
-	Node          node.Full
+	Node          *node.AlgorandFullNode
 	Log           logging.Logger
 	StaticDataDir string
 }

--- a/daemon/algod/api/server/router.go
+++ b/daemon/algod/api/server/router.go
@@ -106,7 +106,7 @@ func registerHandlers(router *mux.Router, prefix string, routes lib.Routes, ctx 
 }
 
 // NewRouter builds and returns a new router from routes
-func NewRouter(logger logging.Logger, node node.Full, apiToken string, staticFileDir string) *mux.Router {
+func NewRouter(logger logging.Logger, node *node.AlgorandFullNode, apiToken string, staticFileDir string) *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
 
 	// Middleware

--- a/daemon/algod/api/server/v1/handlers/handlers.go
+++ b/daemon/algod/api/server/v1/handlers/handlers.go
@@ -38,7 +38,7 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 )
 
-func nodeStatus(node node.Full) (res v1.NodeStatus, err error) {
+func nodeStatus(node *node.AlgorandFullNode) (res v1.NodeStatus, err error) {
 	stat, err := node.Status()
 	if err != nil {
 		return v1.NodeStatus{}, err

--- a/node/node.go
+++ b/node/node.go
@@ -72,32 +72,7 @@ func (status StatusReport) TimeSinceLastRound() time.Duration {
 	return time.Since(status.LastRoundTimestamp)
 }
 
-// Full is an interface representing a Full Algorand Node
-type Full interface {
-	GetSupply() basics.SupplyDetail
-	GetBalanceAndStatus(address basics.Address) (money basics.MicroAlgos, rewards basics.MicroAlgos, moneyWithoutPendingRewards basics.MicroAlgos, status basics.Status, round basics.Round, err error)
-	BroadcastSignedTxn(signed transactions.SignedTxn) (transactions.Txid, error)
-	ListTxns(address basics.Address, minRound basics.Round, maxRound basics.Round) ([]TxnWithStatus, error)
-	GetTransaction(address basics.Address, txID transactions.Txid, minRound basics.Round, maxRound basics.Round) (TxnWithStatus, bool)
-	GetPendingTransaction(txID transactions.Txid) (TxnWithStatus, bool)
-	SuggestedFee() basics.MicroAlgos
-	PoolStats() PoolStats
-	GetBlock(r basics.Round) (bookkeeping.Block, agreement.Certificate, error)
-	ExtendPeerList(args ...string)
-	LatestRound() basics.Round
-	WaitForRound(r basics.Round) chan struct{}
-	GetPendingTxnsFromPool() ([]transactions.SignedTxn, error)
-	Start()
-	Stop()
-	IsArchival() bool
-	Status() (StatusReport, error)
-	GenesisID() string
-	GenesisHash() crypto.Digest
-	Indexer() (*indexer.Indexer, error)
-	GetTransactionByID(txid transactions.Txid, rnd basics.Round) (TxnWithStatus, error)
-}
-
-// AlgorandFullNode is a concrete implementation of the Full interface
+// AlgorandFullNode specifies and implements a full Algorand node.
 type AlgorandFullNode struct {
 	nodeContextData
 

--- a/node/node.go
+++ b/node/node.go
@@ -380,6 +380,11 @@ func (node *AlgorandFullNode) getExistingPartHandle(filename string) (db.Accesso
 	return db.Accessor{}, err
 }
 
+// Ledger exposes the node's ledger handle to the algod API code
+func (node *AlgorandFullNode) Ledger() *data.Ledger {
+	return node.ledger
+}
+
 // GetSupply returns the current supply reported by the ledger
 func (node *AlgorandFullNode) GetSupply() basics.SupplyDetail {
 	latest := node.ledger.Latest()


### PR DESCRIPTION
`node.Full` is redundant with exported behavior of node.AlgorandFullNode.
If we find a reason to abstract full node behavior we can add it back. But right now it is a lot more direct to interact with `AlgorandFullNode` directly.

Also expose the `Ledger` for #155. Removing redundant wrappers will be part of that PR.
