### PR TITLE
[GOAL2-770] Print registration information in `goal account listpartkeys`

### DIFF
--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -783,8 +783,8 @@ var listParticipationKeysCmd = &cobra.Command{
 				if string(onlineAccountInfo.Participation.ParticipationPK) == string(votingBytes[:]) &&
 					(string(onlineAccountInfo.Participation.VRFPK) == string(vrfBytes[:])) &&
 					(onlineAccountInfo.Participation.VoteFirst == uint64(parts[fn].FirstValid)) &&
-					(onlineAccountInfo.Participation.VoteKeyDilution == uint64(parts[fn].KeyDilution)) &&
-					(onlineAccountInfo.Participation.VoteLast == uint64(parts[fn].LastValid)) {
+					(onlineAccountInfo.Participation.VoteLast == uint64(parts[fn].LastValid)) &&
+					(onlineAccountInfo.Participation.VoteKeyDilution == parts[fn].KeyDilution) {
 					onlineInfoStr = "yes"
 				} else {
 					onlineInfoStr = "no"


### PR DESCRIPTION
final PR in a chain of PRs for GOAL2-770
Predicated on #163. Once that is merged I will open this for review.
Fixes #148 

When offline:
```
$ goal account listpartkeys
Registered	Filename                                                                        	Parent address                                              	 First round	  Last round	   First key
unknown   	BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6Q.10000.10111.partkey        	BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4  	       10000	       10111	     29323.0
unknown   	BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4.666888.1000000.partkey	BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4  	      666888	     1000000	     69.7765
```

When online:
```
$ goal account listpartkeys
Registered	Filename                                                                        	Parent address                                              	 First round	  Last round	   First key
no        	BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6Q.10000.10111.partkey        	BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4  	       10000	       10111	     29323.0
yes       	BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4.666888.1000000.partkey	BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4  	      666888	     1000000	     69.7779
```