### PR TITLE
Improved keyreg output on backend API

### DIFF
--- a/daemon/algod/api/server/v1/handlers/errors.go
+++ b/daemon/algod/api/server/v1/handlers/errors.go
@@ -25,6 +25,8 @@ var (
 	errFailedToParseAddress                = "failed to parse the address"
 	errFailedLookingUpLedger               = "failed to retrieve information from the ledger"
 	errTransactionNotFound                 = "couldn't find the required transaction in the required range"
+	errUnknownTransactionType              = "found a transaction with an unknown type"
+	errFailedToParseTransaction            = "failed to parse transaction"
 	errFailedLookingUpTransactionPool      = "failed to retrieve information from the transaction pool"
 	errBlockHashBeenDeletedArchival        = "this is a non-archival node and the requested block has been already deleted"
 	errFailedGettingInformationFromIndexer = "failed retrieving information from the indexer"

--- a/daemon/algod/api/server/v1/handlers/handlers.go
+++ b/daemon/algod/api/server/v1/handlers/handlers.go
@@ -56,10 +56,10 @@ func nodeStatus(node *node.AlgorandFullNode) (res v1.NodeStatus, err error) {
 }
 
 func txEncode(tx transactions.Transaction, ad transactions.ApplyData) (res v1.Transaction, err error) {
-	if tx.Type == protocol.PaymentTx {
+	switch tx.Type {
+	case protocol.PaymentTx:
 		return paymentTxEncode(tx, ad), nil
-	}
-	if tx.Type == protocol.KeyRegistrationTx {
+	case protocol.KeyRegistrationTx:
 		return keyregTxEncode(tx, ad), nil
 	}
 	return v1.Transaction{}, errors.New(errUnknownTransactionType)

--- a/daemon/algod/api/server/v1/handlers/handlers.go
+++ b/daemon/algod/api/server/v1/handlers/handlers.go
@@ -95,11 +95,11 @@ func paymentTxEncode(tx transactions.Transaction, ad transactions.ApplyData) v1.
 
 func keyregTxEncode(tx transactions.Transaction, ad transactions.ApplyData) v1.Transaction {
 	keyreg := v1.KeyregTransactionType{
-		VotePK:          KeyregTxnFields.VotePK[:],
-		SelectionPK:     KeyregTxnFields.SelectionPK[:],
-		VoteFirst:       uint64(KeyregTxnFields.VoteFirst),
-		VoteLast:        uint64(KeyregTxnFields.VoteLast),
-		VoteKeyDilution: KeyregTxnFields.VoteKeyDilution
+		VotePK:          tx.KeyregTxnFields.VotePK[:],
+		SelectionPK:     tx.KeyregTxnFields.SelectionPK[:],
+		VoteFirst:       uint64(tx.KeyregTxnFields.VoteFirst),
+		VoteLast:        uint64(tx.KeyregTxnFields.VoteLast),
+		VoteKeyDilution: tx.KeyregTxnFields.VoteKeyDilution,
 	}
 
 	return v1.Transaction{

--- a/daemon/algod/api/spec/v1/model.go
+++ b/daemon/algod/api/spec/v1/model.go
@@ -168,7 +168,15 @@ type Transaction struct {
 	// This is a list of all supported transactions.
 	// To add another one, create a struct with XXXTransactionType and embed it here.
 	// To prevent extraneous fields, all must have the "omitempty" tag.
+
+	// Payment contains the additional fields for a payment transaction.
+	//
+	// required: false
 	Payment *PaymentTransactionType `json:"payment,omitempty"`
+
+	// Keyreg contains the additional fields for a keyreg transaction.
+	//
+	// required: false
 	Keyreg  *KeyregTransactionType  `json:"keyreg,omitempty"`
 
 	// FromRewards is the amount of pending rewards applied to the From
@@ -230,27 +238,27 @@ type KeyregTransactionType struct {
 	// VotePK is the participation public key used in key registration transactions
 	//
 	// required: false
-	VotePK bytes `json:"votekey,omitempty"`
+	VotePK bytes `json:"votekey"`
 
 	// SelectionPK is the VRF public key used in key registration transactions
 	//
 	// required: false
-	SelectionPK bytes `json:"selkey,omitempty"`
+	SelectionPK bytes `json:"selkey"`
 
 	// VoteFirst is the first round this participation key is valid
 	//
 	// required: false
-	VoteFirst uint64 `json:"votefst,omitempty"`
+	VoteFirst uint64 `json:"votefst"`
 
 	// VoteLast is the last round this participation key is valid
 	//
 	// required: false
-	VoteLast uint64 `json:"votelst,omitempty"`
+	VoteLast uint64 `json:"votelst"`
 
 	// VoteKeyDilution is the dilution for the 2-level participation key
 	//
 	// required: false
-	VoteKeyDilution uint64 `json:"votekd,omitempty"`
+	VoteKeyDilution uint64 `json:"votekd"`
 }
 
 // TransactionList contains a list of transactions

--- a/daemon/algod/api/spec/v1/model.go
+++ b/daemon/algod/api/spec/v1/model.go
@@ -169,6 +169,7 @@ type Transaction struct {
 	// To add another one, create a struct with XXXTransactionType and embed it here.
 	// To prevent extraneous fields, all must have the "omitempty" tag.
 	Payment *PaymentTransactionType `json:"payment,omitempty"`
+	Keyreg  *KeyregTransactionType  `json:"keyreg,omitempty"`
 
 	// FromRewards is the amount of pending rewards applied to the From
 	// account as part of this transaction.
@@ -221,6 +222,35 @@ type PaymentTransactionType struct {
 	//
 	// required: false
 	CloseRewards uint64 `json:"closerewards"`
+}
+
+// KeyregTransactionType contains the additional fields for a keyreg Transaction
+// swagger:model KeyregTransactionType
+type KeyregTransactionType struct {
+	// VotePK is the participation public key used in key registration transactions
+	//
+	// required: false
+	VotePK bytes `json:"votekey,omitempty"`
+
+	// SelectionPK is the VRF public key used in key registration transactions
+	//
+	// required: false
+	SelectionPK bytes `json:"selkey,omitempty"`
+
+	// VoteFirst is the first round this participation key is valid
+	//
+	// required: false
+	VoteFirst uint64 `json:"votefst,omitempty"`
+
+	// VoteLast is the last round this participation key is valid
+	//
+	// required: false
+	VoteLast uint64 `json:"votelst,omitempty"`
+
+	// VoteKeyDilution is the dilution for the 2-level participation key
+	//
+	// required: false
+	VoteKeyDilution uint64 `json:"votekd,omitempty"`
 }
 
 // TransactionList contains a list of transactions


### PR DESCRIPTION
## Summary

This patch outputs the correct information of keyreg transactions.

Currently, keyreg tx's outputs a bogus `payment` sub-object.

## Test Plan

We compiled the code and launched a dev network. After executing:

`curl http://127.0.0.1:8080/v1/block/94154 -H "X-Algo-API-Token: #put-token-here#"` we get the expected values:

```
...
{
    "_id" : ObjectId("5d2f74fa26104a591b5fbc04"),
    "index" : 3225366,
    "txid" : "A2OMCBM7JTGVVXDJWYEP6OTBJCFGTGKRL7RYWVAOA2EPIDXGGZCA",
    "type" : "keyreg",
    "address" : "VJ6NE2QAWYS2JP7GFO3BMX5THTBZKT7GEHIG6GFZCMYSET6QU27G2PKOFU",
    "from_index" : 3,
    "fee" : 1000,
    "round" : 94154,
    "first_round" : 94153,
    "last_round" : 95153,
    "keyreg" : {
        "votekey" : "okryFvieL+YNRjJwSnxzl8BdL9rajZe6csjrhWNWCtc=",
        "selkey" : "xF1VTDoyWTqZKHpIkxDlLVjKaQnXuUerK3J7aniMHts=",
        "votefst" : 94150,
        "votelst" : 1500150,
        "votekd" : 10000
    },
    "timestamp" : 1560798075
}
...
```

With this modification, anyone can know if an account becomes online or offline too.

