### PR TITLE
Fix missing connection metadata

### DIFF
--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -163,10 +163,7 @@ func main() {
 		}
 
 		// Apply telemetry override.
-		hasOverride, override := logging.TelemetryOverride(*telemetryOverride)
-		if hasOverride {
-			telemetryConfig.Enable = override
-		}
+		telemetryConfig.Enable = logging.TelemetryOverride(*telemetryOverride)
 
 		if telemetryConfig.Enable {
 			// If session GUID specified, use it.

--- a/cmd/algoh/main.go
+++ b/cmd/algoh/main.go
@@ -286,10 +286,7 @@ func initTelemetry(genesisID string, log logging.Logger, dataDirectory string) {
 		}
 
 		// Apply telemetry override.
-		hasOverride, override := logging.TelemetryOverride(*telemetryOverride)
-		if hasOverride {
-			telemetryConfig.Enable = override
-		}
+		telemetryConfig.Enable = logging.TelemetryOverride(*telemetryOverride)
 
 		if telemetryConfig.Enable {
 			err = log.EnableTelemetry(telemetryConfig)

--- a/logging/log.go
+++ b/logging/log.go
@@ -52,7 +52,7 @@ type Level uint32
 // Create a general Base logger
 var (
 	baseLogger      Logger
-	telemetryConfig *TelemetryConfig
+	telemetryConfig TelemetryConfig
 )
 
 const (
@@ -91,7 +91,7 @@ func init() {
 	Init()
 }
 
-func initializeConfig(cfg *TelemetryConfig) {
+func initializeConfig(cfg TelemetryConfig) {
 	telemetryConfig = cfg
 }
 
@@ -375,23 +375,14 @@ func (l logger) GetTelemetryEnabled() bool {
 }
 
 func (l logger) GetTelemetrySession() string {
-	if telemetryConfig == nil {
-		return ""
-	}
 	return telemetryConfig.SessionGUID
 }
 
 func (l logger) GetTelemetryHostName() string {
-	if telemetryConfig == nil {
-		return ""
-	}
 	return telemetryConfig.getHostName()
 }
 
 func (l logger) GetInstanceName() string {
-	if telemetryConfig == nil {
-		return ""
-	}
 	return telemetryConfig.getInstanceName()
 }
 

--- a/logging/log.go
+++ b/logging/log.go
@@ -51,7 +51,8 @@ type Level uint32
 
 // Create a general Base logger
 var (
-	baseLogger Logger
+	baseLogger      Logger
+	telemetryConfig *TelemetryConfig
 )
 
 const (
@@ -88,6 +89,10 @@ func Init() {
 
 func init() {
 	Init()
+}
+
+func initializeConfig(cfg *TelemetryConfig) {
+	telemetryConfig = cfg
 }
 
 // Fields maps logrus fields
@@ -370,24 +375,24 @@ func (l logger) GetTelemetryEnabled() bool {
 }
 
 func (l logger) GetTelemetrySession() string {
-	if l.loggerState.telemetry == nil {
+	if telemetryConfig == nil {
 		return ""
 	}
-	return l.loggerState.telemetry.sessionGUID
+	return telemetryConfig.SessionGUID
 }
 
 func (l logger) GetTelemetryHostName() string {
-	if l.loggerState.telemetry == nil {
+	if telemetryConfig == nil {
 		return ""
 	}
-	return l.loggerState.telemetry.hostName
+	return telemetryConfig.getHostName()
 }
 
 func (l logger) GetInstanceName() string {
-	if l.loggerState.telemetry == nil {
+	if telemetryConfig == nil {
 		return ""
 	}
-	return l.loggerState.telemetry.instanceName
+	return telemetryConfig.getInstanceName()
 }
 
 func (l logger) Metrics(category telemetryspec.Category, metrics telemetryspec.MetricDetails, details interface{}) {

--- a/logging/telemetry.go
+++ b/logging/telemetry.go
@@ -85,7 +85,7 @@ func EnsureTelemetryConfigCreated(configDir *string, genesisID string) (Telemetr
 		configPath, err = config.GetConfigFilePath(loggingFilename)
 		if err != nil {
 			cfg := createTelemetryConfig()
-			initializeConfig(&cfg)
+			initializeConfig(cfg)
 			return createTelemetryConfig(), true, err
 		}
 	} else {
@@ -110,7 +110,7 @@ func EnsureTelemetryConfigCreated(configDir *string, genesisID string) (Telemetr
 	}
 	cfg.ChainID = fmt.Sprintf("%s-%s", ch, genesisID)
 
-	initializeConfig(&cfg)
+	initializeConfig(cfg)
 	return cfg, created, err
 }
 

--- a/logging/telemetry.go
+++ b/logging/telemetry.go
@@ -73,7 +73,6 @@ func makeTelemetryState(cfg TelemetryConfig, hookFactory hookFactory) (*telemetr
 // Cfg will always be valid.
 func EnsureTelemetryConfig(configDir *string, genesisID string) (TelemetryConfig, error) {
 	cfg, _, err := EnsureTelemetryConfigCreated(configDir, genesisID)
-	initializeConfig(&cfg)
 	return cfg, err
 }
 
@@ -85,6 +84,8 @@ func EnsureTelemetryConfigCreated(configDir *string, genesisID string) (Telemetr
 		var err error
 		configPath, err = config.GetConfigFilePath(loggingFilename)
 		if err != nil {
+			cfg := createTelemetryConfig()
+			initializeConfig(&cfg)
 			return createTelemetryConfig(), true, err
 		}
 	} else {
@@ -108,6 +109,8 @@ func EnsureTelemetryConfigCreated(configDir *string, genesisID string) (Telemetr
 		ch = "dev"
 	}
 	cfg.ChainID = fmt.Sprintf("%s-%s", ch, genesisID)
+
+	initializeConfig(&cfg)
 	return cfg, created, err
 }
 

--- a/logging/telemetry.go
+++ b/logging/telemetry.go
@@ -86,7 +86,7 @@ func EnsureTelemetryConfigCreated(configDir *string, genesisID string) (Telemetr
 		if err != nil {
 			cfg := createTelemetryConfig()
 			initializeConfig(cfg)
-			return createTelemetryConfig(), true, err
+			return cfg, true, err
 		}
 	} else {
 		configPath = filepath.Join(*configDir, loggingFilename)

--- a/logging/telemetry.go
+++ b/logging/telemetry.go
@@ -64,9 +64,6 @@ func makeTelemetryState(cfg TelemetryConfig, hookFactory hookFactory) (*telemetr
 	telemetry := &telemetryState{
 		history,
 		createAsyncHook(hook, 32, 100),
-		cfg.SessionGUID,
-		cfg.getHostName(),
-		cfg.getInstanceName(),
 	}
 	return telemetry, nil
 }
@@ -76,6 +73,7 @@ func makeTelemetryState(cfg TelemetryConfig, hookFactory hookFactory) (*telemetr
 // Cfg will always be valid.
 func EnsureTelemetryConfig(configDir *string, genesisID string) (TelemetryConfig, error) {
 	cfg, _, err := EnsureTelemetryConfigCreated(configDir, genesisID)
+	initializeConfig(&cfg)
 	return cfg, err
 }
 
@@ -154,8 +152,8 @@ func (t *telemetryState) logTelemetry(l logger, message string, details interfac
 	}
 
 	entry := l.entry.WithFields(Fields{
-		"session":      t.sessionGUID,
-		"instanceName": t.instanceName,
+		"session":      l.GetTelemetrySession(),
+		"instanceName": l.GetInstanceName(),
 	})
 	// Populate entry like logrus.entry.log() does
 	entry.Time = time.Now()

--- a/logging/telemetryCommon.go
+++ b/logging/telemetryCommon.go
@@ -38,9 +38,6 @@ type TelemetryOperation struct {
 type telemetryState struct {
 	history      *logBuffer
 	hook         *asyncTelemetryHook
-	sessionGUID  string
-	hostName     string
-	instanceName string
 }
 
 // TelemetryConfig represents the configuration of Telemetry logging

--- a/logging/telemetryConfig.go
+++ b/logging/telemetryConfig.go
@@ -117,7 +117,7 @@ func (cfg TelemetryConfig) getInstanceName() string {
 
 	// NOTE: We used to report HASH:DataDir but DataDir is Personally Identifiable Information (PII)
 	// So we're removing it entirely to avoid GDPR issues.
-	return fmt.Sprintf("%s:", pathHashStr[:16])
+	return fmt.Sprintf("%s", pathHashStr[:16])
 }
 
 func loadTelemetryConfig(path string) (TelemetryConfig, error) {

--- a/logging/telemetryConfig.go
+++ b/logging/telemetryConfig.go
@@ -100,7 +100,7 @@ func (cfg TelemetryConfig) Save(configPath string) error {
 // getHostName returns the HostName for telemetry (GUID:Name -- :Name is optional if blank)
 func (cfg TelemetryConfig) getHostName() string {
 	hostName := cfg.GUID
-	if len(cfg.Name) > 0 {
+	if cfg.Enable && len(cfg.Name) > 0 {
 		hostName += ":" + cfg.Name
 	}
 	return hostName
@@ -135,6 +135,6 @@ func loadTelemetryConfig(path string) (TelemetryConfig, error) {
 		}
 	}
 	cfg.FilePath = path
-	//cfg.Enable = telemetryOverride(cfg.Enable)
+	initializeConfig(cfg)
 	return cfg, err
 }

--- a/logging/telemetryConfig.go
+++ b/logging/telemetryConfig.go
@@ -38,18 +38,18 @@ func elasticsearchEndpoint() string {
 
 // TelemetryOverride Determines whether an override value is set and what it's value is.
 // The first return value is whether an override variable is found, if it is, the second is the override value.
-func TelemetryOverride(env string) (bool, bool) {
+func TelemetryOverride(env string) bool {
 	env = strings.ToLower(env)
 
 	if env == "1" || env == "true" {
-		return true, true
+		telemetryConfig.Enable = true
 	}
 
 	if env == "0" || env == "false" {
-		return true, false
+		telemetryConfig.Enable = false
 	}
 
-	return false, false
+	return telemetryConfig.Enable
 }
 
 // createTelemetryConfig creates a new TelemetryConfig structure with a generated GUID and the appropriate Telemetry endpoint.


### PR DESCRIPTION
# Summary

When telemetry is disabled connection information is incomplete when communicating with relay nodes.

## Test Plan

Before and after the fix, started a node with telemetry disabled and see that the error is reproduced and then fixed.

Missing metadata before fix:
![before_fix](https://user-images.githubusercontent.com/125509/61969312-3b8d6700-afa8-11e9-8854-7fb8dabdf76c.png)

Metadata after fix:
![after_fix](https://user-images.githubusercontent.com/125509/61969316-3d572a80-afa8-11e9-8fbc-b5ef1a1fd528.png)