### PR TITLE
scripts: fix configure_dev.sh for linux

### DIFF
--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -14,9 +14,14 @@ function install_or_upgrade {
 }
 
 if [ "${OS}" = "linux" ]; then
+    if [ -z "$(dpkg -l sudo 2>/dev/null | grep ^ii)" ] ; then
+	apt-get update
+	apt-get -y install sudo
+    fi
+	    
     echo "deb [trusted=yes] https://dl.bintray.com/go-swagger/goswagger-debian ubuntu main" | sudo tee /etc/apt/sources.list.d/goswagger.list
     sudo apt-get update
-    sudo apt-get -y install libboost-all-dev expect jq swagger
+    sudo apt-get -y install libboost-all-dev expect jq swagger autoconf
 elif [ "${OS}" = "darwin" ]; then
     brew update
     brew tap caskroom/cask


### PR DESCRIPTION
## Summary
Fixing remaining work on #1.

I mentioned in the issue only `autoconf` was necessary in a _vanilla_ Ubuntu 18.02 desktop, but also confirmed what other used mentioned using the `golang` docker base image regarding  `sudo`.

Since the script assumed `sudo` was already installed, it basically checks if it isn't and run `apt-get` commands assuming the user is root (`id -u = 0` could be added too).

<s>Just in case, the `SUDO_INSTALLED` var is because the script is ran with `set -e`, so `dpkg` will fail if `sudo` isn't installed (this way, won't).</s> Changed this considering what @zeldovich mentioned.

## Test Plan
Easy way to check that works on `golang:1.12` (run dev script and also compile the tree):
`docker run -v $(pwd):/usr/src/go-algorand --rm golang:1.12 /bin/sh -c /usr/src/go-algorand/scripts/configure_dev.sh && make install`
Runs successfully.