### PR TITLE
Bugfixes relating to goal node create

### DIFF
--- a/cmd/goal/node.go
+++ b/cmd/goal/node.go
@@ -405,7 +405,7 @@ func isValidIP(userInput string) bool {
 	if host == "" {
 		return false
 	}
-	return isValidIP(host)
+	return net.ParseIP(host) != nil
 }
 
 var createCmd = &cobra.Command{

--- a/cmd/goal/node.go
+++ b/cmd/goal/node.go
@@ -466,7 +466,7 @@ var createCmd = &cobra.Command{
 			reportErrorf(errorNodeCreation, "destination folder already exists")
 		}
 		destPath := filepath.Join(newNodeDestination, "genesis.json")
-		err = os.MkdirAll(newNodeDestination, 0666)
+		err = os.MkdirAll(newNodeDestination, 0766)
 		if err != nil {
 			reportErrorf(errorNodeCreation, "could not create destination folder")
 		}


### PR DESCRIPTION
## Summary

This PR proposes to fix a permissions error when using `goal node create` to copy `genesis.json` to a destination folder. Additionally, I noticed a bug in IP validation, so I fixed that along the way.

## Test Plan

Reproduced errors, then manually tested minimal fix to make errors stop reproducing. Filing ticket to write automated tests for this.

