### PR TITLE
txpool: avoid rejecting transactions that race with OnNewBlock()

### DIFF
--- a/util/condvar/timedwait.go
+++ b/util/condvar/timedwait.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2019 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package condvar
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// TimedWait waits for sync.Cond c to be signaled, with a timeout.
+// If the condition is not signaled before timeout, TimedWait forces
+// a Broadcast() on c until this function returns.  This assumes a
+// (common) use of sync.Cond where stray signals are allowed, so
+// the extra Broadcast() introduced by this function isn't a problem.
+// This function does not indicate whether a timeout occurred or not;
+// the caller should check time.Now() as needed.
+func TimedWait(c *sync.Cond, timeout time.Duration) {
+	var done int32
+
+	go func() {
+		<-time.After(timeout)
+
+		for atomic.LoadInt32(&done) == 0 {
+			c.Broadcast()
+
+			// It is unlikely but possible that the parent
+			// thread hasn't gotten around to calling c.Wait()
+			// yet, so the c.Broadcast() did not wake it up.
+			// Sleep for a second and check again.
+			<-time.After(time.Second)
+		}
+	}()
+
+	c.Wait()
+	atomic.StoreInt32(&done, 1)
+}

--- a/util/condvar/timedwait_test.go
+++ b/util/condvar/timedwait_test.go
@@ -1,0 +1,84 @@
+// Copyright (C) 2019 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package condvar
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimedWaitSignal(t *testing.T) {
+	var m sync.Mutex
+	var signal bool
+	c := sync.NewCond(&m)
+
+	m.Lock()
+	defer m.Unlock()
+
+	go func() {
+		<-time.After(time.Second)
+		m.Lock()
+		defer m.Unlock()
+
+		c.Signal()
+		signal = true
+	}()
+
+	// If the signal doesn't get delivered, the test will time out.
+	TimedWait(c, 24*time.Hour)
+
+	// Make sure TimedWait() didn't return prematurely
+	require.True(t, signal)
+}
+
+func TestTimedWaitBroadcast(t *testing.T) {
+	var m sync.Mutex
+	var signal bool
+	c := sync.NewCond(&m)
+
+	m.Lock()
+	defer m.Unlock()
+
+	go func() {
+		<-time.After(time.Second)
+		m.Lock()
+		defer m.Unlock()
+
+		c.Broadcast()
+		signal = true
+	}()
+
+	// If the signal doesn't get delivered, the test will time out.
+	TimedWait(c, 24*time.Hour)
+
+	// Make sure TimedWait() didn't return prematurely
+	require.True(t, signal)
+}
+
+func TestTimedWaitTimeout(t *testing.T) {
+	var m sync.Mutex
+	c := sync.NewCond(&m)
+
+	m.Lock()
+	defer m.Unlock()
+
+	// If the timeout doesn't work, the test will time out.
+	TimedWait(c, time.Second)
+}

--- a/util/condvar/timedwait_test.go
+++ b/util/condvar/timedwait_test.go
@@ -22,10 +22,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-deadlock"
 )
 
 func TestTimedWaitSignal(t *testing.T) {
-	var m sync.Mutex
+	var m deadlock.Mutex
 	var signal bool
 	c := sync.NewCond(&m)
 
@@ -49,7 +51,7 @@ func TestTimedWaitSignal(t *testing.T) {
 }
 
 func TestTimedWaitBroadcast(t *testing.T) {
-	var m sync.Mutex
+	var m deadlock.Mutex
 	var signal bool
 	c := sync.NewCond(&m)
 
@@ -73,7 +75,7 @@ func TestTimedWaitBroadcast(t *testing.T) {
 }
 
 func TestTimedWaitTimeout(t *testing.T) {
-	var m sync.Mutex
+	var m deadlock.Mutex
 	c := sync.NewCond(&m)
 
 	m.Lock()


### PR DESCRIPTION
When a new block for round R shows up in the ledger, it may take a while
until the TransactionPool's OnNewBlock() is called.  Until that happens,
the pool rejects new transactions that are valid starting from round
R+1, because according to the pool, the next round will be R, and the
transaction isn't valid for that round yet.  However, the client that
issued the transaction may have already seen that the latest round is R
(if the client queried the ledger's Latest() round, through the REST API),
and it's just the txpool that hasn't gotten the OnNewBlock() callback yet.

This commit deals with this potential race condition, which might be
the reason for some non-deterministic test failures.