### PR TITLE
Fix [GOAL2-909] - update.sh fails to expand archive

### DIFF
--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -138,7 +138,7 @@ function determine_current_version() {
 
 function check_for_update() {
     determine_current_version
-    LATEST="$(${SCRIPTPATH}/updater ver check -c ${CHANNEL} ${BUCKET})"
+    LATEST="$(${SCRIPTPATH}/updater ver check -c ${CHANNEL} ${BUCKET} | sed -n '2 p')"
     if [ $? -ne 0 ]; then
         echo No remote updates found
         return 1


### PR DESCRIPTION
Updated script to grab version from 2nd line of updater output.

Manually tested.