### PR TITLE
Prevent nonparticipatory accounts (e.g. rewards pool) from going online

### DIFF
--- a/data/transactions/keyreg.go
+++ b/data/transactions/keyreg.go
@@ -46,6 +46,11 @@ func (keyreg KeyregTxnFields) apply(header Header, balances Balances, spec Speci
 		return err
 	}
 
+	// non-participatory accounts cannot be brought online (or offline)
+	if record.Status == basics.NotParticipating {
+		return fmt.Errorf("cannot change online/offline status of non-participating account %v", header.Sender)
+	}
+
 	// Update the registered keys and mark account as online (or, if the voting or selection keys are zero, offline)
 	record.VoteID = keyreg.VotePK
 	record.SelectionID = keyreg.SelectionPK


### PR DESCRIPTION
Add a check to keyreg transactions to prevent nonparticipatory accounts like the rewards pool from going online (or offline)