### PR TITLE
Created algocfg to provide cli access to config.json

### DIFF
--- a/cmd/algocfg/datadir.go
+++ b/cmd/algocfg/datadir.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2019 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+package main
+
+import "os"
+
+var dataDirs []string
+
+func resolveDataDir() string {
+	// Figure out what data directory to tell algod to use.
+	// If not specified on cmdline with '-d', look for default in environment.
+	var dir string
+	if len(dataDirs) > 0 {
+		dir = dataDirs[0]
+	}
+	if dir == "" {
+		dir = os.Getenv("ALGORAND_DATA")
+	}
+	return dir
+}
+
+func ensureFirstDataDir() string {
+	// Get the target data directory to work against,
+	// then handle the scenario where no data directory is provided.
+	dir := resolveDataDir()
+	if dir == "" {
+		reportErrorln(errorNoDataDirectory)
+	}
+	return dir
+}
+
+func ensureSingleDataDir() string {
+	if len(dataDirs) > 1 {
+		reportErrorln(errorOneDataDirSupported)
+	}
+	return ensureFirstDataDir()
+}
+
+func getDataDirs() (dirs []string) {
+	if len(dataDirs) == 0 {
+		reportErrorln(errorNoDataDirectory)
+	}
+	dirs = append(dirs, ensureFirstDataDir())
+	dirs = append(dirs, dataDirs[1:]...)
+	return
+}
+
+func onDataDirs(action func(dataDir string)) {
+	dirs := getDataDirs()
+	report := len(dirs) > 1
+
+	for _, dir := range dirs {
+		if report {
+			reportInfof(infoDataDir, dir)
+		}
+		action(dir)
+	}
+}
+

--- a/cmd/algocfg/getCommand.go
+++ b/cmd/algocfg/getCommand.go
@@ -1,0 +1,79 @@
+// Copyright (C) 2019 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+
+	"github.com/spf13/cobra"
+
+	"github.com/algorand/go-algorand/config"
+)
+
+var (
+	getParameterArg string
+)
+
+func init() {
+	getCmd.Flags().StringVarP(&getParameterArg, "parameter", "p", "", "Parameter to query")
+	getCmd.MarkFlagRequired("parameter")
+
+	rootCmd.AddCommand(getCmd)
+}
+
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Retrieve the current value for the specified parameter",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
+		anyError := false
+		onDataDirs(func(dataDir string) {
+			cfg, err := config.LoadConfigFromDisk(dataDir)
+			if err != nil {
+				reportWarnf("Error loading config file from '%s'", dataDir)
+				anyError = true
+				return
+			}
+
+			val, err := getObjectProperty(cfg, getParameterArg)
+			if err != nil {
+				reportWarnf("Error retrieving property '%s' - %s", getParameterArg, err)
+				anyError = true
+				return
+			}
+
+			fmt.Printf("%s", val)
+		})
+		if anyError {
+			os.Exit(1)
+		}
+	},
+}
+
+func getObjectProperty(object interface{}, property string) (ret interface{}, err error) {
+	v := reflect.ValueOf(object)
+	val := reflect.Indirect(v)
+	f := val.FieldByName(property)
+
+	if !f.IsValid() {
+		return object, fmt.Errorf("unknown property named '%s'", property)
+	}
+
+	return f.Interface(), nil
+}

--- a/cmd/algocfg/getCommand.go
+++ b/cmd/algocfg/getCommand.go
@@ -45,7 +45,7 @@ var getCmd = &cobra.Command{
 		anyError := false
 		onDataDirs(func(dataDir string) {
 			cfg, err := config.LoadConfigFromDisk(dataDir)
-			if err != nil {
+			if err != nil && !os.IsNotExist(err) {
 				reportWarnf("Error loading config file from '%s'", dataDir)
 				anyError = true
 				return

--- a/cmd/algocfg/main.go
+++ b/cmd/algocfg/main.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	// Config
+	defaultDataDirValue := []string{""}
+	rootCmd.PersistentFlags().StringArrayVarP(&dataDirs, "datadir", "d", defaultDataDirValue, "Data directory for the node")
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "algocfg",
+	Short: "tool for inspecting and updating algod's config.json file",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.HelpFunc()(cmd, args)
+	},
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/cmd/algocfg/messages.go
+++ b/cmd/algocfg/messages.go
@@ -19,6 +19,6 @@ package main
 const (
 	// General
 	errorNoDataDirectory     = "Data directory not specified.  Please use -d or set $ALGORAND_DATA in your environment. Exiting."
-	errorOneDataDirSupported = "One one data directory can be specified for this command."
+	errorOneDataDirSupported = "Only one data directory can be specified for this command."
 	infoDataDir              = "[Data Directory: %s]"
 )

--- a/cmd/algocfg/messages.go
+++ b/cmd/algocfg/messages.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+const (
+	// General
+	errorNoDataDirectory     = "Data directory not specified.  Please use -d or set $ALGORAND_DATA in your environment. Exiting."
+	errorOneDataDirSupported = "One one data directory can be specified for this command."
+	infoDataDir              = "[Data Directory: %s]"
+)

--- a/cmd/algocfg/report.go
+++ b/cmd/algocfg/report.go
@@ -1,0 +1,49 @@
+// Copyright (C) 2019 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func reportInfoln(args ...interface{}) {
+	fmt.Println(args...)
+}
+
+func reportInfof(format string, args ...interface{}) {
+	fmt.Printf(format+"\n", args...)
+}
+
+func reportWarnln(args ...interface{}) {
+	fmt.Print("Warning: ")
+	fmt.Println(args...)
+}
+
+func reportWarnf(format string, args ...interface{}) {
+	fmt.Printf("Warning: "+format+"\n", args...)
+}
+
+func reportErrorln(args ...interface{}) {
+	fmt.Fprintln(os.Stderr, args...)
+	os.Exit(1)
+}
+
+func reportErrorf(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}
+

--- a/cmd/algocfg/resetCommand.go
+++ b/cmd/algocfg/resetCommand.go
@@ -1,0 +1,96 @@
+// Copyright (C) 2019 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+
+	"github.com/spf13/cobra"
+
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/util/codecs"
+)
+
+var (
+	resetParameterArg string
+)
+
+func init() {
+	resetCmd.Flags().StringVarP(&resetParameterArg, "parameter", "p", "", "Parameter to reset")
+	resetCmd.MarkFlagRequired("parameter")
+
+	rootCmd.AddCommand(resetCmd)
+}
+
+var resetCmd = &cobra.Command{
+	Use:   "reset",
+	Short: "Reset the specified parameter to its default (delete from config.json)",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
+		anyError := false
+		onDataDirs(func(dataDir string) {
+			cfg, err := config.LoadConfigFromDisk(dataDir)
+			if err != nil {
+				reportWarnf("Error loading config file from '%s'", dataDir)
+				anyError = true
+				return
+			}
+
+			defaults := config.GetDefaultLocal()
+			cfg, err = copyObjectProperty(cfg, defaults, resetParameterArg)
+			if err != nil {
+				reportWarnf("Error resetting property '%s' - %s", resetParameterArg, err)
+				anyError = true
+				return
+			}
+
+			file := filepath.Join(dataDir, config.ConfigFilename)
+			err = codecs.SaveNonDefaultValuesToFile(file, cfg, defaults, nil, true)
+			if err != nil {
+				reportWarnf("Error saving updated config file '%s' - %s", file, err)
+				anyError = true
+				return
+			}
+		})
+		if anyError {
+			os.Exit(1)
+		}
+	},
+}
+
+func copyObjectProperty(object config.Local, defaultObject config.Local, property string) (config.Local, error) {
+	v := reflect.ValueOf(&object)
+	f := v.Elem().FieldByName(property)
+
+	if !f.IsValid() {
+		return object, fmt.Errorf("unknown property named '%s'", property)
+	}
+
+	vDefault := reflect.ValueOf(defaultObject)
+	valDefault := reflect.Indirect(vDefault)
+	fDefault := valDefault.FieldByName(property)
+
+	if !fDefault.IsValid() {
+		return object, fmt.Errorf("unknown property named '%s'", property)
+	}
+
+	f.Set(fDefault)
+	return object, nil
+}

--- a/cmd/algocfg/resetCommand.go
+++ b/cmd/algocfg/resetCommand.go
@@ -47,7 +47,7 @@ var resetCmd = &cobra.Command{
 		anyError := false
 		onDataDirs(func(dataDir string) {
 			cfg, err := config.LoadConfigFromDisk(dataDir)
-			if err != nil {
+			if err != nil && !os.IsNotExist(err) {
 				reportWarnf("Error loading config file from '%s'", dataDir)
 				anyError = true
 				return

--- a/cmd/algocfg/setCommand.go
+++ b/cmd/algocfg/setCommand.go
@@ -1,0 +1,127 @@
+// Copyright (C) 2019 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/util/codecs"
+)
+
+var (
+	setParameterArg string
+	setValueArg string
+)
+
+func init() {
+	setCmd.Flags().StringVarP(&setParameterArg, "parameter", "p", "", "Parameter to update")
+	setCmd.Flags().StringVarP(&setValueArg, "value", "v", "", "Value to set")
+	setCmd.MarkFlagRequired("parameter")
+	setCmd.MarkFlagRequired("value")
+
+	rootCmd.AddCommand(setCmd)
+}
+
+var setCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Update the current value for the specified parameter",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
+		anyError := false
+		onDataDirs(func(dataDir string) {
+			cfg, err := config.LoadConfigFromDisk(dataDir)
+			if err != nil {
+				reportWarnf("Error loading config file from '%s'", dataDir)
+				anyError = true
+				return
+			}
+
+			cfg, err = setObjectProperty(cfg, setParameterArg, setValueArg)
+			if err != nil {
+				reportWarnf("Error setting property '%s' -> %s - %s", setParameterArg, setValueArg, err)
+				anyError = true
+				return
+			}
+
+			file := filepath.Join(dataDir, config.ConfigFilename)
+			err = codecs.SaveNonDefaultValuesToFile(file, cfg, config.GetDefaultLocal(), nil, true)
+			if err != nil {
+				reportWarnf("Error saving updated config file '%s' - %s", file, err)
+				anyError = true
+				return
+			}
+		})
+		if anyError {
+			os.Exit(1)
+		}
+	},
+}
+
+func setObjectProperty(object config.Local, property string, value string) (config.Local, error) {
+	v := reflect.ValueOf(&object)
+	f := v.Elem().FieldByName(property)
+
+	if !f.IsValid() {
+		return object, fmt.Errorf("unknown property named '%s'", property)
+	}
+
+	err := setFieldValue(f, value)
+	return object, err
+}
+
+func setFieldValue(field reflect.Value, value string) error {
+	switch k := field.Kind(); k {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		val, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return err
+		}
+		// NOTE: We do not enforce bitsize
+		field.SetInt(val)
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		val, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return err
+		}
+		// NOTE: We do not enforce bitsize
+		field.SetUint(val)
+
+	case reflect.String:
+		field.SetString(value)
+
+	case reflect.Float32, reflect.Float64:
+		val, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return err
+		}
+		// NOTE: We do not enforce bitsize
+		field.SetFloat(val)
+
+	default:
+		return fmt.Errorf("unsupported parameter type '%s' - unable to set value", k)
+	}
+
+	return nil
+}

--- a/cmd/algocfg/setCommand.go
+++ b/cmd/algocfg/setCommand.go
@@ -51,7 +51,7 @@ var setCmd = &cobra.Command{
 		anyError := false
 		onDataDirs(func(dataDir string) {
 			cfg, err := config.LoadConfigFromDisk(dataDir)
-			if err != nil {
+			if err != nil && !os.IsNotExist(err) {
 				reportWarnf("Error loading config file from '%s'", dataDir)
 				anyError = true
 				return

--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -19,7 +19,7 @@ package main
 const (
 	// General
 	errorNoDataDirectory     = "Data directory not specified.  Please use -d or set $ALGORAND_DATA in your environment. Exiting."
-	errorOneDataDirSupported = "One one data directory can be specified for this command."
+	errorOneDataDirSupported = "Only one data directory can be specified for this command."
 	errorRequestFail         = "Error processing command: %s"
 	errorGenesisIDFail       = "Error determining kmd folder (%s). Ensure the node is running in %s."
 	errorDirectoryNotExist   = "Specified directory '%s' does not exist."

--- a/installer/rpm/algorand.spec
+++ b/installer/rpm/algorand.spec
@@ -68,6 +68,7 @@ else
 fi
 
 %files
+/usr/bin/algocfg
 /usr/bin/algod
 /usr/bin/algoh
 /usr/bin/algokey

--- a/installer/rpm/algorand.spec
+++ b/installer/rpm/algorand.spec
@@ -27,7 +27,7 @@ This package provides an implementation of the Algorand protocol.
 mkdir -p %{buildroot}/usr/bin
 # NOTE: keep in sync with scripts/build_deb.sh bin_files
 # NOTE: keep in sync with %files section below
-for f in algod algoh algokey carpenter catchupsrv diagcfg goal kmd msgpacktool node_exporter; do
+for f in algocfg algod algoh algokey carpenter catchupsrv diagcfg goal kmd msgpacktool node_exporter; do
   install -m 755 ${GOPATH}/bin/${f} %{buildroot}/usr/bin/${f}
 done
 

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -47,7 +47,7 @@ mkdir -p ${PKG_ROOT}/usr/bin
 
 if [ "${VARIATION}" = "" ]; then
     # NOTE: keep in sync with installer/rpm/algorand.spec
-    bin_files=("algod" "algoh" "algokey" "carpenter" "catchupsrv" "diagcfg" "goal" "kmd" "msgpacktool" "node_exporter")
+    bin_files=("algocfg" "algod" "algoh" "algokey" "carpenter" "catchupsrv" "diagcfg" "goal" "kmd" "msgpacktool" "node_exporter")
 fi
 
 for bin in "${bin_files[@]}"; do

--- a/scripts/build_package.sh
+++ b/scripts/build_package.sh
@@ -57,7 +57,7 @@ DEFAULT_RELEASE_NETWORK=$(./scripts/compute_branch_release_network.sh "${DEFAULT
 mkdir ${PKG_ROOT}/bin
 
 # If you modify this list, also update this list in ./cmd/updater/update.sh backup_binaries()
-bin_files=("algod" "algoh" "algokey" "carpenter" "catchupsrv" "diagcfg" "find-nodes.sh" "goal" "kmd" "msgpacktool" "node_exporter" "update.sh" "updater" "COPYING")
+bin_files=("algocfg" "algod" "algoh" "algokey" "carpenter" "catchupsrv" "diagcfg" "find-nodes.sh" "goal" "kmd" "msgpacktool" "node_exporter" "update.sh" "updater" "COPYING")
 for bin in "${bin_files[@]}"; do
     cp ${GOPATH}/bin/${bin} ${PKG_ROOT}/bin
     if [ $? -ne 0 ]; then exit 1; fi

--- a/util/codecs/json.go
+++ b/util/codecs/json.go
@@ -162,7 +162,9 @@ func SaveNonDefaultValuesToFile(filename string, object, defaultObject interface
 	}
 	defer outFile.Close()
 	writer := bufio.NewWriter(outFile)
-	_, err = writer.WriteString(strings.Join(newFile, "\n"))
+	combined := strings.Join(newFile, "\n")
+	combined = strings.TrimRight(combined, "\r\n ")
+	_, err = writer.WriteString(combined)
 	if err == nil {
 		writer.Flush()
 	}


### PR DESCRIPTION
Adds `algocfg get|set|reset` commands to manipulate config.json
in a consistent and typesafe way.
Modified config.json is persisted minimally - only non-default
values are written.  Versioning is taken into account and migration
is performed as required.

This also includes a fix to SaveNonDefaultValuesToFile() which was
writing config.json files with a trailing empty line for each default
value that was skipped.