### PR TITLE
Kmd sign bytes

### DIFF
--- a/daemon/kmd/client/requests.go
+++ b/daemon/kmd/client/requests.go
@@ -117,6 +117,9 @@ func getPathAndMethod(req kmdapi.APIV1Request) (reqPath string, reqMethod string
 	case kmdapi.APIV1POSTKeyListRequest:
 		reqPath = "v1/key/list"
 		reqMethod = "POST"
+	case kmdapi.APIV1POSTDataSignRequest:
+		reqPath = "v1/data/sign"
+		reqMethod = "POST"
 	case kmdapi.APIV1POSTTransactionSignRequest:
 		reqPath = "v1/transaction/sign"
 		reqMethod = "POST"
@@ -131,6 +134,9 @@ func getPathAndMethod(req kmdapi.APIV1Request) (reqPath string, reqMethod string
 		reqMethod = "POST"
 	case kmdapi.APIV1POSTMultisigTransactionSignRequest:
 		reqPath = "v1/multisig/sign"
+		reqMethod = "POST"
+	case kmdapi.APIV1POSTMultisigDataSignRequest:
+		reqPath = "v1/multisig/signdata"
 		reqMethod = "POST"
 	case kmdapi.APIV1DELETEMultisigRequest:
 		reqPath = "v1/multisig"

--- a/daemon/kmd/client/wrappers.go
+++ b/daemon/kmd/client/wrappers.go
@@ -153,6 +153,20 @@ func (kcl KMDClient) MultisigSignTransaction(walletHandle, pw []byte, tx []byte,
 	return
 }
 
+// MultisigSignData wraps kmdapi.APIV1POSTMultisigDataSignRequest
+func (kcl KMDClient) MultisigSignData(walletHandle, pw []byte, addr string, data []byte, pk crypto.PublicKey, partial crypto.MultisigSig) (resp kmdapi.APIV1POSTMultisigDataSignResponse, err error) {
+	req := kmdapi.APIV1POSTMultisigDataSignRequest{
+		WalletHandleToken: string(walletHandle),
+		WalletPassword:    string(pw),
+		Data:              data,
+		Address:           addr,
+		PublicKey:         pk,
+		PartialMsig:       partial,
+	}
+	err = kcl.DoV1Request(req, &resp)
+	return
+}
+
 // RenewWalletHandle wraps kmdapi.APIV1POSTKeyListRequest
 func (kcl KMDClient) RenewWalletHandle(walletHandle []byte) (resp kmdapi.APIV1POSTWalletRenewResponse, err error) {
 	req := kmdapi.APIV1POSTWalletRenewRequest{
@@ -189,6 +203,18 @@ func (kcl KMDClient) SignTransaction(walletHandle, pw []byte, tx transactions.Tr
 		WalletHandleToken: string(walletHandle),
 		WalletPassword:    string(pw),
 		Transaction:       txBytes,
+	}
+	err = kcl.DoV1Request(req, &resp)
+	return
+}
+
+// SignData wraps kmdapi.APIV1POSTDataSignRequest
+func (kcl KMDClient) SignData(walletHandle, pw []byte, addr string, data []byte) (resp kmdapi.APIV1POSTDataSignResponse, err error) {
+	req := kmdapi.APIV1POSTDataSignRequest{
+		WalletHandleToken: string(walletHandle),
+		WalletPassword:    string(pw),
+		Data:              data,
+		Address:           addr,
 	}
 	err = kcl.DoV1Request(req, &resp)
 	return

--- a/daemon/kmd/lib/kmdapi/requests.go
+++ b/daemon/kmd/lib/kmdapi/requests.go
@@ -166,6 +166,18 @@ type APIV1POSTTransactionSignRequest struct {
 	WalletPassword string `json:"wallet_password"`
 }
 
+// APIV1POSTDataSignRequest is the request for `POST /v1/data/sign`
+//
+// swagger:model SignDataRequest
+type APIV1POSTDataSignRequest struct {
+	APIV1RequestEnvelope
+	WalletHandleToken string `json:"wallet_handle_token"`
+	Address           string `json:"address"`
+	// swagger:strfmt byte
+	Data           []byte `json:"data"`
+	WalletPassword string `json:"wallet_password"`
+}
+
 // APIV1POSTMultisigListRequest is the request for `POST /v1/multisig/list`
 //
 // swagger:model ListMultisigRequest
@@ -212,6 +224,20 @@ type APIV1POSTMultisigTransactionSignRequest struct {
 	WalletHandleToken string `json:"wallet_handle_token"`
 	// swagger:strfmt byte
 	Transaction    []byte             `json:"transaction"`
+	PublicKey      crypto.PublicKey   `json:"public_key"`
+	PartialMsig    crypto.MultisigSig `json:"partial_multisig"`
+	WalletPassword string             `json:"wallet_password"`
+}
+
+// APIV1POSTMultisigDataSignRequest is the request for `POST /v1/multisig/signdata`
+//
+// swagger:model SignDataMultisigRequest
+type APIV1POSTMultisigDataSignRequest struct {
+	APIV1RequestEnvelope
+	WalletHandleToken string `json:"wallet_handle_token"`
+	Address           string `json:"address"`
+	// swagger:strfmt byte
+	Data           []byte             `json:"data"`
 	PublicKey      crypto.PublicKey   `json:"public_key"`
 	PartialMsig    crypto.MultisigSig `json:"partial_multisig"`
 	WalletPassword string             `json:"wallet_password"`

--- a/daemon/kmd/lib/kmdapi/responses.go
+++ b/daemon/kmd/lib/kmdapi/responses.go
@@ -152,6 +152,15 @@ type APIV1POSTTransactionSignResponse struct {
 	SignedTransaction []byte `json:"signed_transaction"`
 }
 
+// APIV1POSTDataSignResponse is the repsonse to `POST /v1/data/sign`
+// friendly:SignDataResponse
+type APIV1POSTDataSignResponse struct {
+	APIV1ResponseEnvelope
+
+	// swagger:strfmt byte
+	Signature []byte `json:"sig"`
+}
+
 // APIV1POSTMultisigListResponse is the response to `POST /v1/multisig/list`
 // friendly:ListMultisigResponse
 type APIV1POSTMultisigListResponse struct {
@@ -184,6 +193,15 @@ type APIV1DELETEMultisigResponse struct {
 // APIV1POSTMultisigTransactionSignResponse is the response to `POST /v1/multisig/sign`
 // friendly:SignMultisigResponse
 type APIV1POSTMultisigTransactionSignResponse struct {
+	APIV1ResponseEnvelope
+
+	// swagger:strfmt byte
+	Multisig []byte `json:"multisig"`
+}
+
+// APIV1POSTMultisigDataSignResponse is the response to `POST /v1/multisig/signdata`
+// friendly:SignMultisigResponse
+type APIV1POSTMultisigDataSignResponse struct {
 	APIV1ResponseEnvelope
 
 	// swagger:strfmt byte

--- a/daemon/kmd/wallet/driver/ledger.go
+++ b/daemon/kmd/wallet/driver/ledger.go
@@ -341,6 +341,7 @@ func (lw *LedgerWallet) signDataHelper(data []byte) (sig crypto.Signature, err e
 	lw.mu.Lock()
 	defer lw.mu.Unlock()
 
+	// TODO: this is probably wrong and needs extending the client code on the device
 	reply, err := lw.dev.Exchange(data)
 	if err != nil {
 		return

--- a/daemon/kmd/wallet/driver/sqlite.go
+++ b/daemon/kmd/wallet/driver/sqlite.go
@@ -1112,6 +1112,40 @@ func (sw *SQLiteWallet) SignTransaction(tx transactions.Transaction, pw []byte) 
 	return
 }
 
+type rawHashBytes []byte
+
+func (rhb *rawHashBytes) ToBeHashed() (protocol.HashID, []byte) {
+	return protocol.HashID(""), []byte(*rhb)
+}
+
+// SignData signs the passed data for the src address
+func (sw *SQLiteWallet) SignData(data []byte, src crypto.Digest, pw []byte) (stx []byte, err error) {
+	// Check the password
+	err = sw.CheckPassword(pw)
+	if err != nil {
+		return
+	}
+
+	// Fetch the required key
+	sk, err := sw.fetchSecretKey(crypto.Digest(src))
+	if err != nil {
+		return
+	}
+
+	// Generate the signature secrets
+	secrets, err := crypto.SecretKeyToSignatureSecrets(sk)
+	if err != nil {
+		err = errSKToPK
+		return
+	}
+
+	hb := rawHashBytes(data)
+	// Sign the transaction
+	sig := secrets.Sign(&hb)
+	stx = sig[:]
+	return
+}
+
 // MultisigSignTransaction starts a multisig signature or adds a signature to a
 // partially signed multisig transaction signature of the passed transaction
 // using the key
@@ -1194,6 +1228,97 @@ func (sw *SQLiteWallet) MultisigSignTransaction(tx transactions.Transaction, pk 
 	// Sign the transaction, and merge the multisig into the partial
 	version, threshold, pks := partial.Preimage()
 	msig2, err := crypto.MultisigSign(tx, addr, version, threshold, pks, *secrets)
+	if err != nil {
+		return
+	}
+	sig, err = crypto.MultisigMerge(partial, msig2)
+	return
+}
+
+// MultisigSignData starts a multisig signature or adds a signature to a
+// partially signed multisig transaction signature of the passed transaction
+// using the key
+func (sw *SQLiteWallet) MultisigSignData(data []byte, src crypto.Digest, pk crypto.PublicKey, partial crypto.MultisigSig, pw []byte) (sig crypto.MultisigSig, err error) {
+	// Check the password
+	err = sw.CheckPassword(pw)
+	if err != nil {
+		return
+	}
+
+	if partial.Version == 0 && partial.Threshold == 0 && len(partial.Subsigs) == 0 {
+		// We weren't given a partial multisig, so create a new one
+
+		// Look up the preimage in the database
+		var pks []crypto.PublicKey
+		var version, threshold uint8
+		version, threshold, pks, err = sw.LookupMultisigPreimage(src)
+		if err != nil {
+			return
+		}
+
+		// Fetch the required secret key
+		var sk crypto.PrivateKey
+		sk, err = sw.fetchSecretKey(publicKeyToAddress(pk))
+		if err != nil {
+			return
+		}
+
+		// Convert the secret key to crypto.SignatureSecrets
+		var secrets *crypto.SignatureSecrets
+		secrets, err = crypto.SecretKeyToSignatureSecrets(sk)
+		if err != nil {
+			err = errSKToPK
+			return
+		}
+
+		// Sign the transaction
+		from := src
+		rhb := rawHashBytes(data)
+		sig, err = crypto.MultisigSign(&rhb, from, version, threshold, pks, *secrets)
+		return
+	}
+
+	// We were given a partial multisig, so add to it
+
+	// Check preimage matches tx src address
+	var addr crypto.Digest
+	addr, err = crypto.MultisigAddrGenWithSubsigs(partial.Version, partial.Threshold, partial.Subsigs)
+	if err != nil {
+		return
+	}
+	if addr != src {
+		err = errMsigWrongAddr
+		return
+	}
+
+	// Check that key is one of the ones in the preimage
+	err = errMsigWrongKey
+	for _, subsig := range partial.Subsigs {
+		if pk == subsig.Key {
+			err = nil
+			break
+		}
+	}
+	if err != nil {
+		return
+	}
+
+	// Fetch the required secret key
+	sk, err := sw.fetchSecretKey(publicKeyToAddress(pk))
+	if err != nil {
+		return
+	}
+
+	// Convert the secret key to crypto.SignatureSecrets
+	secrets, err := crypto.SecretKeyToSignatureSecrets(sk)
+	if err != nil {
+		return
+	}
+
+	// Sign the transaction, and merge the multisig into the partial
+	version, threshold, pks := partial.Preimage()
+	rhb := rawHashBytes(data)
+	msig2, err := crypto.MultisigSign(&rhb, addr, version, threshold, pks, *secrets)
 	if err != nil {
 		return
 	}

--- a/daemon/kmd/wallet/wallet.go
+++ b/daemon/kmd/wallet/wallet.go
@@ -54,6 +54,9 @@ type Wallet interface {
 	SignTransaction(tx transactions.Transaction, pw []byte) ([]byte, error)
 
 	MultisigSignTransaction(tx transactions.Transaction, pk crypto.PublicKey, partial crypto.MultisigSig, pw []byte) (crypto.MultisigSig, error)
+
+	SignData(data []byte, src crypto.Digest, pw []byte) ([]byte, error)
+	MultisigSignData(data []byte, src crypto.Digest, pk crypto.PublicKey, partial crypto.MultisigSig, pw []byte) (crypto.MultisigSig, error)
 }
 
 // Metadata represents high-level information about a wallet, like its name, id


### PR DESCRIPTION
## Summary

Allow KMD to sign arbitrary bytes so that in the future it can sign program bytecode blobs.

## Test Plan

Needs unit test coverage comparable to other API tests. TODO.