### PR TITLE
Reorder protocol network tags into lexicographic order.

### DIFF
--- a/protocol/tags.go
+++ b/protocol/tags.go
@@ -20,7 +20,6 @@ package protocol
 // e.g., the agreement service can register to handle agreements with the Agreement tag.
 type Tag string
 
-
 // Tags, in lexicographic sort order of tag values to avoid duplicates.
 const (
 	UnknownMsgTag      Tag = "??"

--- a/protocol/tags.go
+++ b/protocol/tags.go
@@ -31,9 +31,9 @@ const (
 	ProposalPayloadTag Tag = "PP"
 	TxnTag             Tag = "TX"
 	UniCatchupReqTag   Tag = "UC"
-	UniCatchupResTag   Tag = "UT"
 	UniEnsBlockReqTag  Tag = "UE"
 	UniEnsBlockResTag  Tag = "US"
+	UniCatchupResTag   Tag = "UT"
 	VoteBundleTag      Tag = "VB"
 )
 

--- a/protocol/tags.go
+++ b/protocol/tags.go
@@ -20,7 +20,8 @@ package protocol
 // e.g., the agreement service can register to handle agreements with the Agreement tag.
 type Tag string
 
-// Tags, in lexicographic sort order to avoid duplicates.
+
+// Tags, in lexicographic sort order of tag values to avoid duplicates.
 const (
 	UnknownMsgTag      Tag = "??"
 	AgreementVoteTag   Tag = "AV"


### PR DESCRIPTION
## Summary

Reorder the tags in protocol/tags so that they stay in lexicographic order (to prevent duplicates).