### PR TITLE
Build merge scripts no longer need to run make.

### DIFF
--- a/scripts/build/beta.sh
+++ b/scripts/build/beta.sh
@@ -5,20 +5,10 @@ GOPATH=$(go env GOPATH)
 REPO_DIR=${GOPATH}/src/github.com/algorand/go-algorand
 cd ${REPO_DIR}
 
-# Run `make` to ensure `buildtools` is available
-make -j4
-
 # Flag that we want release handling of genesis files
 export RELEASE_GENESIS_PROCESS=true
 
 git checkout rel/beta
-
-# Disabled because we have static genesis files now
-#NETWORKS=("testnet" "mainnet")
-#for NETWORK in "${NETWORKS[@]}"; do
-#    ${GOPATH}/bin/buildtools genesis ensure --release -n ${NETWORK} --source ${REPO_DIR}/gen/${NETWORK}/genesis.json  --releasedir ${REPO_DIR}/installer/genesis
-#    git add ${REPO_DIR}/installer/genesis/${NETWORK}/*
-#done
 
 # Update version file for this build
 BUILD_NUMBER=

--- a/scripts/build/nightly.sh
+++ b/scripts/build/nightly.sh
@@ -3,9 +3,6 @@ set -e
 
 export GOPATH=$(go env GOPATH)
 
-# Run `make` to ensure `buildtools` is available
-make -j4
-
 # Flag that we want release handling of genesis files
 export RELEASE_GENESIS_PROCESS=true
 
@@ -17,11 +14,6 @@ pushd ${REPO_DIR}
 
 git checkout rel/nightly
 git merge origin/master -m "FI from master"
-
-# Disabled because we have static genesis files now
-#DEFAULTNETWORK="devnet"
-#${GOPATH}/bin/buildtools genesis ensure --release -n ${DEFAULTNETWORK} --source ${REPO_DIR}/gen/${DEFAULTNETWORK}/genesis.json  --releasedir ${REPO_DIR}/installer/genesis
-#git add ${REPO_DIR}/installer/genesis/${DEFAULTNETWORK}/*
 
 # Update version file for this build
 BUILD_NUMBER=

--- a/scripts/build/stable.sh
+++ b/scripts/build/stable.sh
@@ -4,20 +4,10 @@ set -ev
 GOPATH=$(go env GOPATH)
 REPO_DIR=$(pwd)
 
-# Run `make` to ensure `buildtools` is available
-make -j4
-
 # Flag that we want release handling of genesis files
 export RELEASE_GENESIS_PROCESS=true
 
 git checkout rel/stable
-
-# Disabled because we have static genesis files now
-#NETWORKS=("testnet" "mainnet")
-#for NETWORK in "${NETWORKS[@]}"; do
-#    ${GOPATH}/bin/buildtools genesis ensure --release -n ${NETWORK} --source ${REPO_DIR}/gen/${NETWORK}/genesis.json  --releasedir ${REPO_DIR}/installer/genesis
-#    git add ${REPO_DIR}/installer/genesis/${NETWORK}/*
-#done
 
 # Update version file for this build
 BUILD_NUMBER=


### PR DESCRIPTION
It looks like these scripts do not need to run "make", remove it to make the script easier / faster to run.
