### PR TITLE
Replace old simple docker images with latest rel/stable

### DIFF
--- a/docker/releases/Dockerfile-stable
+++ b/docker/releases/Dockerfile-stable
@@ -4,7 +4,7 @@ WORKDIR /root/install
 RUN apt update && apt install -y ca-certificates curl --no-install-recommends && \
     curl --silent -L https://github.com/algorand/go-algorand-doc/blob/master/downloads/installers/linux_amd64/install_master_linux-amd64.tar.gz?raw=true -o installer.tar.gz && \
     tar -xf installer.tar.gz && \
-    ./update.sh -c stable-telem -n -p ~/node -d ~/node/data -i && \
+    ./update.sh -c stable -n -p ~/node -d ~/node/data -i && \
     cd .. && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf install

--- a/docker/releases/Dockerfile-stable-testnet
+++ b/docker/releases/Dockerfile-stable-testnet
@@ -1,0 +1,13 @@
+FROM ubuntu
+
+WORKDIR /root/install
+RUN apt update && apt install -y ca-certificates curl --no-install-recommends && \
+    curl --silent -L https://github.com/algorand/go-algorand-doc/blob/master/downloads/installers/linux_amd64/install_master_linux-amd64.tar.gz?raw=true -o installer.tar.gz && \
+    tar -xf installer.tar.gz && \
+    ./update.sh -c stable -n -p ~/node -d ~/node/data -i -g testnet && \
+    cd .. && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf install
+WORKDIR /root/node
+
+ENTRYPOINT ["/bin/bash"]

--- a/docker/releases/build_stable-testnet.sh
+++ b/docker/releases/build_stable-testnet.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# Need to log in to Docker desktop before docker push will succeed.
+# e.g. `docker login`
+# Log in account should be 'algorand'.
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+cd ${SCRIPTPATH}
+
+docker build -f Dockerfile-stable-testnet . -t algorand/testnet:latest
+docker push algorand/testnet:latest

--- a/docker/releases/build_stable.sh
+++ b/docker/releases/build_stable.sh
@@ -9,5 +9,5 @@ set -e
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 cd ${SCRIPTPATH}
 
-docker build -f Dockerfile-testnet . -t algorand/testnet-telem:latest
-docker push algorand/testnet-telem:latest
+docker build -f Dockerfile-stable . -t algorand/stable:latest
+docker push algorand/stable:latest


### PR DESCRIPTION
Updated our trivial docker images to simply be an install of the latest rel/stable release.