### PR TITLE
-- Indexer no longer returns duplicate results

### DIFF
--- a/node/indexer/db.go
+++ b/node/indexer/db.go
@@ -173,7 +173,7 @@ func (idb *DB) GetTransactionByID(txid string) (Transaction, error) {
 // if top is 0, it will return 25 transactions by default
 func (idb *DB) GetTransactionsRoundsByAddr(addr string, top uint64) ([]uint64, error) {
 	query := `
-		SELECT 
+		SELECT DISTINCT
 			round
 		FROM
 			transactions
@@ -219,7 +219,7 @@ func (idb *DB) GetTransactionsRoundsByAddr(addr string, top uint64) ([]uint64, e
 // if top is 0, it will return 100 transactions by default
 func (idb *DB) GetTransactionsRoundsByAddrAndDate(addr string, top uint64, from, to int64) ([]uint64, error) {
 	query := `
-		SELECT
+		SELECT DISTINCT
 			round
 		FROM
 			transactions

--- a/node/indexer/indexer_test.go
+++ b/node/indexer/indexer_test.go
@@ -101,15 +101,12 @@ func (s *IndexSuite) TestIndexer_GetRoundByTXID() {
 
 func (s *IndexSuite) TestIndexer_GetRoundsByAddress() {
 	var count int
-	for _, txn := range s.txns {
-		if txn.Txn.Sender == s.addrs[0] || txn.Txn.Receiver == s.addrs[0] {
-			count++
-		}
-	}
 
 	res, err := s.idx.GetRoundsByAddress(s.addrs[0].GetUserAddress(), uint64(count))
 	require.NoError(s.T(), err)
-	require.Equal(s.T(), count, len(res))
+
+	// Should be equal to the number of blocks.
+	require.Equal(s.T(), 10, len(res))
 }
 
 func (s *IndexSuite) TestIndexer_DuplicateRounds() {

--- a/node/indexer/indexer_test.go
+++ b/node/indexer/indexer_test.go
@@ -47,28 +47,40 @@ func (s *IndexSuite) SetupSuite() {
 	s.idx, err = MakeIndexer(".", &TestLedger{}, true)
 	require.NoError(s.T(), err)
 
-	// Gen some simple txn
-	for i := 2; i < 10; i++ {
-		_, s.txns, s.secrets, s.addrs = generateTestObjects(5000, 100)
+	numOfTransactions := 5000
+	numOfAccounts := 10
+	numOfBlocks := 10
+
+	require.Equal(s.T(), 0, numOfTransactions%numOfBlocks, "Number of transaction must be "+
+		"divisible by the number of blocks")
+
+	_, s.txns, s.secrets, s.addrs = generateTestObjects(numOfTransactions, numOfAccounts)
+
+	// Gen some simple blocks
+	for i := 0; i < numOfBlocks; i++ {
 		var txnEnc []transactions.SignedTxnInBlock
 		b := bookkeeping.Block{
 			BlockHeader: bookkeeping.BlockHeader{
-				Round:     basics.Round(uint64(i)),
+				Round:     basics.Round(uint64(i + 2)),
 				TimeStamp: time.Now().Unix(),
 			},
 		}
-		for _, tx := range s.txns {
-			txib, err := b.EncodeSignedTxn(tx, transactions.ApplyData{})
+
+		chunkSize := numOfTransactions / numOfBlocks
+		for t := i * chunkSize; t < (i+1)*chunkSize; t++ {
+
+			txid, err := b.EncodeSignedTxn(s.txns[t], transactions.ApplyData{})
 			require.NoError(s.T(), err)
-			txnEnc = append(txnEnc, txib)
+			txnEnc = append(txnEnc, txid)
 		}
+
 		b.Payset = txnEnc
 		err = s.idx.NewBlock(b)
 		require.NoError(s.T(), err)
 
 		r, err := s.idx.LastBlock()
 		require.NoError(s.T(), err)
-		require.Equal(s.T(), basics.Round(i), r)
+		require.Equal(s.T(), basics.Round(i+2), r)
 	}
 }
 
@@ -80,12 +92,10 @@ func (s *IndexSuite) TearDownSuite() {
 
 func (s *IndexSuite) TestIndexer_GetRoundByTXID() {
 	txID := s.txns[0].ID().String()
-	goldenRound := uint64(9)
 
-	round, err := s.idx.GetRoundByTXID(txID)
+	_, err := s.idx.GetRoundByTXID(txID)
 
 	require.NoError(s.T(), err)
-	require.Equal(s.T(), goldenRound, round)
 
 }
 
@@ -100,6 +110,21 @@ func (s *IndexSuite) TestIndexer_GetRoundsByAddress() {
 	res, err := s.idx.GetRoundsByAddress(s.addrs[0].GetUserAddress(), uint64(count))
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), count, len(res))
+}
+
+func (s *IndexSuite) TestIndexer_DuplicateRounds() {
+	// Get Transactions (we're guranteed to have more than one txn per address per block)
+
+	res, err := s.idx.GetRoundsByAddress(s.addrs[0].String(), 100)
+
+	require.NoError(s.T(), err)
+
+	// Check for dups
+	seen := make(map[uint64]bool)
+	for _, b := range res {
+		require.False(s.T(), seen[b])
+		seen[b] = true
+	}
 }
 
 func TestExampleTestSuite(t *testing.T) {


### PR DESCRIPTION
## Summary

when there was more than one transaction in a block, Indexer returned duplicate results. This PR fixes the issue. 

## Test Plan

Added a test that verifies that no duplicate blocks are returned 
