### PR TITLE
fix catchupsrv with latest algod

### DIFF
--- a/cmd/catchupsrv/main.go
+++ b/cmd/catchupsrv/main.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"flag"
 	"io/ioutil"
 	"net/http"
@@ -26,6 +27,7 @@ import (
 	"github.com/algorand/websocket"
 	"github.com/gorilla/mux"
 
+	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/rpcs"
@@ -63,8 +65,12 @@ func main() {
 		pathVars := mux.Vars(r)
 		genesisID := pathVars["genesisID"]
 
+		var rnd [10]byte
+		crypto.RandBytes(rnd[:])
+
 		requestHeader := make(http.Header)
 		requestHeader.Set(network.GenesisHeader, genesisID)
+		requestHeader.Set(network.NodeRandomHeader, base64.StdEncoding.EncodeToString(rnd[:]))
 		requestHeader.Set(network.ProtocolVersionHeader, "1")
 
 		conn, err := upgrader.Upgrade(w, r, requestHeader)


### PR DESCRIPTION
algod got stricter about requiring the X-Algorand-NodeRandom header

should fix #285