### PR TITLE
Rename TxGroup.Transactions to TxGroup.TxGroupHashes

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -493,7 +493,7 @@ var groupCmd = &cobra.Command{
 			}
 
 			txns = append(txns, txn)
-			group.Transactions = append(group.Transactions, crypto.HashObj(txn.Txn))
+			group.TxGroupHashes = append(group.TxGroupHashes, crypto.HashObj(txn.Txn))
 		}
 
 		var outData []byte

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -128,11 +128,11 @@ type ApplyData struct {
 type TxGroup struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	// Transactions specifies a list of transactions that must appear
+	// TxGroupHashes specifies a list of hashes of transactions that must appear
 	// together, sequentially, in a block in order for the group to be
 	// valid.  Each hash in the list is a hash of a transaction with
 	// the `Group` field omitted.
-	Transactions []crypto.Digest `codec:"txlist"`
+	TxGroupHashes []crypto.Digest `codec:"txlist"`
 }
 
 // ToBeHashed implements the crypto.Hashable interface.

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -410,12 +410,12 @@ func (eval *BlockEvaluator) transactionGroup(txgroup []transactions.SignedTxnWit
 			txWithoutGroup.Group = crypto.Digest{}
 			txWithoutGroup.ResetCaches()
 
-			group.Transactions = append(group.Transactions, crypto.HashObj(txWithoutGroup))
+			group.TxGroupHashes = append(group.TxGroupHashes, crypto.HashObj(txWithoutGroup))
 		}
 	}
 
 	// If we had a non-zero Group value, check that all group members are present.
-	if group.Transactions != nil {
+	if group.TxGroupHashes != nil {
 		if txgroup[0].SignedTxn.Txn.Group != crypto.HashObj(group) {
 			return fmt.Errorf("transactionGroup: incomplete group: %v != %v (%v)",
 				txgroup[0].SignedTxn.Txn.Group, crypto.HashObj(group), group)

--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -518,7 +518,7 @@ func (c *Client) GroupID(txgroup []transactions.Transaction) (gid crypto.Digest,
 			return
 		}
 
-		group.Transactions = append(group.Transactions, crypto.HashObj(tx))
+		group.TxGroupHashes = append(group.TxGroupHashes, crypto.HashObj(tx))
 	}
 
 	return crypto.HashObj(group), nil


### PR DESCRIPTION
## Summary

Rename TxGroup.Transactions to TxGroup.TxGroupHashes that appears to be a better name.

## Test Plan

Rely on existing tests.
