### PR TITLE
Fix typo in travis causing nightly build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ jobs:
       script:
         - scripts/travis/build_test.sh
     - # same stage, parallel job
-      name: External ARM64 Integration test
+      name: External ARM64 Integration Test
       os: linux
       env:
         - BUILD_TYPE: "external_build"


### PR DESCRIPTION
## Summary

Stupid typo. I used lower case instead of upper case.
The travis comparison is case sensetive.