### PR TITLE
Add custom cert/key option to dispenser

### DIFF
--- a/cmd/dispenser/server.go
+++ b/cmd/dispenser/server.go
@@ -37,6 +37,9 @@ import (
 
 var configFile = flag.String("config", "", "JSON configuration file")
 var autocertDir = flag.String("autocert", "", "Autocert cache directory")
+var listenPort = flag.Int("port", 443, "Port to listen for incoming connections")
+var httpsCert = flag.String("cert", "", "https certificate.pem file; mutually exclusive with autocert")
+var httpsKey = flag.String("key", "", "https key.pem file; mutually exclusive with autocert")
 var configMap map[string]dispenserSiteConfig
 
 var client map[string]libgoal.Client
@@ -253,17 +256,26 @@ func main() {
 		configMap[h] = cfg
 	}
 
-	cacheDir := *autocertDir
-	if cacheDir == "" {
-		cacheDir = os.Getenv("HOME") + "/.autocert"
+	useAutocert := false
+	if *autocertDir != "" || *httpsCert == "" || *httpsKey == "" {
+		useAutocert = true
 	}
 
-	m := autocert.Manager{
-		Prompt:     autocert.AcceptTOS,
-		HostPolicy: autocert.HostWhitelist(hosts...),
-		Cache:      autocert.DirCache(cacheDir),
-	}
+	if useAutocert {
+		cacheDir := *autocertDir
+		if cacheDir == "" {
+			cacheDir = os.Getenv("HOME") + "/.autocert"
+		}
 
-	go http.ListenAndServe(":80", m.HTTPHandler(nil))
-	log.Fatal(http.Serve(m.Listener(), nil))
+		m := autocert.Manager{
+			Prompt:     autocert.AcceptTOS,
+			HostPolicy: autocert.HostWhitelist(hosts...),
+			Cache:      autocert.DirCache(cacheDir),
+		}
+
+		go http.ListenAndServe(":80", m.HTTPHandler(nil))
+		log.Fatal(http.Serve(m.Listener(), nil))
+	} else {
+		log.Fatal(http.ListenAndServeTLS(fmt.Sprintf(":%d", *listenPort), *httpsCert, *httpsKey, nil))
+	}
 }


### PR DESCRIPTION
## Summary

The Let's Encrypt certificate is great, as it's very out-of-the-box solution.
However, out existing deployment is having a firewall, which needs to have a copy of the certificate. That's becoming an issue, since the firewall need a copy of the certificate every time the certificate is being renewed.

If we want to move to a permanent certificate, we need to have the dispenser running with that certificate. This code change allows to run the dispenser with a particular certificate.

## Test Plan

I tested that locally after hacking hosts file and grabbing a certificate manually.


