### PR TITLE
Correct the log message entry

### DIFF
--- a/scripts/travis/travis_wait.sh
+++ b/scripts/travis/travis_wait.sh
@@ -55,9 +55,9 @@ travis_wait() {
   } || return 1
 
   if [ $result -eq 0 ]; then
-    echo -e "\n${ANSI_GREEN}The command \"$TRAVIS_CMD\" exited with $result.${ANSI_RESET}"
+    echo -e "\n${ANSI_GREEN}The command \"$cmd\" exited with $result.${ANSI_RESET}"
   else
-    echo -e "\n${ANSI_RED}The command \"$TRAVIS_CMD\" exited with $result.${ANSI_RESET}"
+    echo -e "\n${ANSI_RED}The command \"$cmd\" exited with $result.${ANSI_RESET}"
   fi
 
   echo -e "\n${ANSI_GREEN}Log:${ANSI_RESET}\n"


### PR DESCRIPTION
## Summary

When being used with travis directly, the message is valid and correct.
However, when invoked from our scripts, we want to have it emit the actual timed-command, rather then the travis-invoked script.
