### PR TITLE
Validate "go get" output

### DIFF
--- a/scripts/configure_dev-deps.sh
+++ b/scripts/configure_dev-deps.sh
@@ -4,8 +4,7 @@ set -ex
 
 function install_go_module {
     local OUTPUT
-    GO111MODULE=off
-    OUTPUT=$(go get -u $1 2>&1)
+    OUTPUT=$(GO111MODULE=off go get -u $1 2>&1)
     if [ "${OUTPUT}" != "" ]; then
         echo "error: executing \"go get -u $1\" failed : ${OUTPUT}"
         exit 1

--- a/scripts/configure_dev-deps.sh
+++ b/scripts/configure_dev-deps.sh
@@ -2,6 +2,16 @@
 
 set -ex
 
-GO111MODULE=off go get -u golang.org/x/lint/golint
-GO111MODULE=off go get -u golang.org/x/tools/cmd/stringer
-GO111MODULE=off go get -u github.com/go-swagger/go-swagger/cmd/swagger
+function install_go_module {
+    local OUTPUT
+    GO111MODULE=off
+    OUTPUT=$(go get -u $1 2>&1)
+    if [ "${OUTPUT}" != "" ]; then
+        echo "error: executing \"go get -u $1\" failed : ${OUTPUT}"
+        exit 1
+    fi
+}
+
+install_go_module golang.org/x/lint/golint
+install_go_module golang.org/x/tools/cmd/stringer
+install_go_module github.com/go-swagger/go-swagger/cmd/swagger


### PR DESCRIPTION
## Summary

Running `go get -u <package name>` won't always return a non-zero error code when an error occur ( in particular, when the compilation of the downloaded package fails ).

That behavior prevents us from providing correct handing for that error case, and as a result we would fail the build down the road.

## Proposed Solution

The expected output on the success use case is always an empty string. By capturing the output and comparing it to an empty string ( in addition to existing error code testing ), we can detect build errors of downloaded components.