### PR TITLE
Decouple the AccountManager.DeleteOldKeys disk persistence execution

### DIFF
--- a/data/accountManager.go
+++ b/data/accountManager.go
@@ -17,6 +17,8 @@
 package data
 
 import (
+	"fmt"
+
 	"github.com/algorand/go-deadlock"
 
 	"github.com/algorand/go-algorand/config"
@@ -121,14 +123,25 @@ func (manager *AccountManager) AddParticipation(participation account.Participat
 // current round.
 func (manager *AccountManager) DeleteOldKeys(current basics.Round, proto config.ConsensusParams) {
 	manager.mu.Lock()
-	defer manager.mu.Unlock()
-
-	for _, part := range manager.partIntervals {
-		err := part.DeleteOldKeys(current, proto)
-		if err != nil {
+	pendingItems := make(map[string]<-chan error, len(manager.partIntervals))
+	func() {
+		defer manager.mu.Unlock()
+		for _, part := range manager.partIntervals {
+			// we pre-create the reported error string here, so that we won't need to have the participation key object if error is detected.
 			first, last := part.ValidInterval()
-			logging.Base().Warnf("AccountManager.DeleteOldKeys(%d): key for %s (%d-%d): %v",
-				current, part.Address().String(), first, last, err)
+			errString := fmt.Sprintf("AccountManager.DeleteOldKeys(%d): key for %s (%d-%d)",
+				current, part.Address().String(), first, last)
+			errCh := part.DeleteOldKeys(current, proto)
+
+			pendingItems[errString] = errCh
+		}
+	}()
+
+	// wait all all disk flushes, and report errors as they appear.
+	for errString, errCh := range pendingItems {
+		err := <-errCh
+		if err != nil {
+			logging.Base().Warnf("%s: %v", errString, err)
 		}
 	}
 }

--- a/gen/generate.go
+++ b/gen/generate.go
@@ -93,11 +93,11 @@ func GenerateGenesisFiles(genesisData GenesisData, outDir string, verbose bool) 
 		genesisData.RewardsPool = defaultPoolAddr
 	}
 
-	return generateGenesisFiles(outDir, proto, genesisData.NetworkName, genesisData.VersionModifier, allocation, genesisData.FirstPartKeyRound, genesisData.LastPartKeyRound, genesisData.FeeSink, genesisData.RewardsPool, genesisData.Comment, verbose)
+	return generateGenesisFiles(outDir, proto, genesisData.NetworkName, genesisData.VersionModifier, allocation, genesisData.FirstPartKeyRound, genesisData.LastPartKeyRound, genesisData.PartKeyDilution, genesisData.FeeSink, genesisData.RewardsPool, genesisData.Comment, verbose)
 }
 
 func generateGenesisFiles(outDir string, proto protocol.ConsensusVersion, netName string, schemaVersionModifier string,
-	allocation []genesisAllocation, firstWalletValid uint64, lastWalletValid uint64, feeSink, rewardsPool basics.Address, comment string, verbose bool) (err error) {
+	allocation []genesisAllocation, firstWalletValid uint64, lastWalletValid uint64, partKeyDilution uint64, feeSink, rewardsPool basics.Address, comment string, verbose bool) (err error) {
 
 	genesisAddrs := make(map[string]basics.Address)
 	records := make(map[string]basics.AccountData)
@@ -105,6 +105,9 @@ func generateGenesisFiles(outDir string, proto protocol.ConsensusVersion, netNam
 	params, ok := config.Consensus[proto]
 	if !ok {
 		return fmt.Errorf("protocol %s not supported", proto)
+	}
+	if partKeyDilution == 0 {
+		partKeyDilution = params.DefaultKeyDilution
 	}
 
 	// Sort account names alphabetically
@@ -162,7 +165,7 @@ func generateGenesisFiles(outDir string, proto protocol.ConsensusVersion, netNam
 					return
 				}
 
-				part, err = account.FillDBWithParticipationKeys(partDB, root.Address(), basics.Round(firstWalletValid), basics.Round(lastWalletValid), params.DefaultKeyDilution)
+				part, err = account.FillDBWithParticipationKeys(partDB, root.Address(), basics.Round(firstWalletValid), basics.Round(lastWalletValid), partKeyDilution)
 				if err != nil {
 					err = fmt.Errorf("could not generate new participation file %s: %v", pfilename, err)
 					os.Remove(pfilename)

--- a/gen/walletData.go
+++ b/gen/walletData.go
@@ -45,6 +45,7 @@ type GenesisData struct {
 	ConsensusProtocol protocol.ConsensusVersion
 	FirstPartKeyRound uint64
 	LastPartKeyRound  uint64
+	PartKeyDilution   uint64
 	Wallets           []WalletData
 	FeeSink           basics.Address
 	RewardsPool       basics.Address

--- a/libgoal/participation.go
+++ b/libgoal/participation.go
@@ -221,7 +221,11 @@ func (c *Client) InstallParticipationKeys(inputfile string) (part account.Partic
 	// disk blocks, but regardless of whether that works, we
 	// delete the input file.  The consensus protocol version
 	// is irrelevant for the maxuint64 round number we pass in.
-	partkey.DeleteOldKeys(basics.Round(math.MaxUint64), config.Consensus[protocol.ConsensusCurrentVersion])
+	errCh := partkey.DeleteOldKeys(basics.Round(math.MaxUint64), config.Consensus[protocol.ConsensusCurrentVersion])
+	err = <-errCh
+	if err != nil {
+		return
+	}
 	os.Remove(inputfile)
 
 	return newpartkey, newdbpath, nil

--- a/netdeploy/networkTemplate.go
+++ b/netdeploy/networkTemplate.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/algorand/go-algorand/config"
@@ -160,6 +161,11 @@ func loadTemplate(templateFile string) (NetworkTemplate, error) {
 		return template, err
 	}
 	defer f.Close()
+
+	if runtime.GOARCH == "arm" || runtime.GOARCH == "arm64" {
+		// for arm machines, use smaller key dilution
+		template.Genesis.PartKeyDilution = 100
+	}
 
 	err = loadTemplateFromReader(f, &template)
 	return template, err

--- a/scripts/travis/external_build.sh
+++ b/scripts/travis/external_build.sh
@@ -74,7 +74,6 @@ fi
 set +e
 # remove if it's already there, so the new build would replace it.
 aws s3 rm ${BUILD_COMPLETE_PATH} ${NO_SIGN_REQUEST}
-aws s3 rm ${BUILD_LOG_PATH}-1 ${NO_SIGN_REQUEST}
 
 set -e
 aws s3 cp ${BUILDID}.json ${BUILD_REQUEST_PATH} ${NO_SIGN_REQUEST}

--- a/scripts/travis/external_build.sh
+++ b/scripts/travis/external_build.sh
@@ -74,6 +74,7 @@ fi
 set +e
 # remove if it's already there, so the new build would replace it.
 aws s3 rm ${BUILD_COMPLETE_PATH} ${NO_SIGN_REQUEST}
+aws s3 rm ${BUILD_LOG_PATH}-1 ${NO_SIGN_REQUEST}
 
 set -e
 aws s3 cp ${BUILDID}.json ${BUILD_REQUEST_PATH} ${NO_SIGN_REQUEST}


### PR DESCRIPTION
## Summary

The agreement service is using the AccountManager.Keys to acquire the currently available participation keys. When doing that, a lock is being taken to synchronize the active participation accounts. In parallel, a DeleteOldKeys might also be called ( periodically ), in an attempt to delete the old keys. When doing that, the same lock is being taken as well.

The issue is that the update during the DeleteOldKeys might take a long time since it's accessing the disk. This would prevent the agreement service of moving forward ( which is undesirable ).

To work around this, I moved the key deletion so that it would be deleted in-memory with the lock, while allowing it to persist in the background. The deletion of the keys would still need to wait for all the key deletion to persist before it would go into the subsequent iteration, but that should no longer block the agreement service.

Second issue addressed in this PR is the keyDilution values. It appears that the cgo calls on arm64 are substantially slower compared to x86. As a result, the block generation of 10K signatures takes too long and triggers the deadlock detector. To work around that, I have overwritten the default consensus protocol value with 100 in case we're generating new network on ARM/ARM64. ( in practice, this functionality affects only tests since we won't be regenerating the mainnet )

## Stack dumps
```algod(18441) : panic: (*logrus.Entry) (0x12e01a0,0x40015a2690) [recovered]
4866algod(18441) : 	panic: (*logrus.Entry) (0x12e01a0,0x40015a2690)
4867algod(18441) : goroutine 237 [
4868algod(18441) : running]:
4869algod(18441) : github.com/algorand/go-algorand/logging.logger.Panic.func1(0x40000ba7d0, 0x4000010538)
4870algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/logging/log.go:254 +0xc8
4871algod(18441) : panic(0x12e01a0, 0x40015a2690)
4872algod(18441) : 	/usr/local/go/src/runtime/panic.go:522 +0x1a0
4873algod(18441) : github.com/sirupsen/logrus.Entry.log(0x40000ba780, 0x4001721380, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
4874algod(18441) : 	/home/ubuntu/go/pkg/mod/github.com/sirupsen/logrus@v1.0.5/entry.go:112 +0x380
4875algod(18441) : github.com/sirupsen/logrus.(*Entry).Panic(0x40015a2640, 0x4001131890, 0x1, 0x1)
4876algod(18441) : 	/home/ubuntu/go/pkg/mod/github.com/sirupsen/logrus@v1.0.5/entry.go:182 +0xf8
4877algod(18441) : github.com/algorand/go-algorand/logging.logger.Panic(0x40000ba7d0, 0x4000010538, 0x4001131890, 0x1, 0x1)
4878algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/logging/log.go:258 +0x128
4879algod(18441) : github.com/algorand/go-algorand/daemon/algod.setupDeadlockLogger.func1()
4880algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/daemon/algod/deadlockLogger.go:57 +0x270
4881algod(18441) : github.com/algorand/go-deadlock.lock(0x40017ac580, 0x173c800, 0x40002b0450, 0x0)
4882algod(18441) : 	/home/ubuntu/go/pkg/mod/github.com/algorand/go-deadlock@v0.0.0-20181221160745-78d8cb5e2759/deadlock.go:252 +
4883algod(18441) : 0x930
4884algod(18441) : github.com/algorand/go-deadlock.(*Mutex).Lock(0x40002b0450)
4885algod(18441) : 	/home/ubuntu/go/pkg/mod/github.com/algorand/go-deadlock@v0.0.0-20181221160745-78d8cb5e2759/deadlock.go:80 +0xd8
4886algod(18441) : github.com/algorand/go-algorand/data.(*AccountManager).Keys(0x40002b0450, 0x0, 0x0, 0x0)
4887algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/data/accountManager.go:54 +0x40
4888algod(18441) : github.com/algorand/go-algorand/agreement.asyncPseudonode.getParticipations(0x173c700, 0x4000570b10, 0x173dc80, 0x40005809e0, 0x1749020, 0x40002b0450, 0x17628a0, 0x4000570bd0, 0x176ca20, 0x400017c900, ...)
4889algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/agreement/pseudonode.go:238 +0x3c
4890algod(18441) : github.com/algorand/go-algorand/agreement.asyncPseudonode.makeProposalsTask(0x173c700, 0x4000570b10, 0x173dc80, 0x40005809e0, 0x1749020, 0x40002b0450, 0x17628a0, 0x4000570bd0, 0x176ca20, 0x400017c900, ...)
4891algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/agreement/pseudonode.go:186 +0x124
4892algod(18441) : github.com/algorand/go-algorand/agreement.asyncPseudonode.MakeProposals(0x173c700, 0x4000570b10, 0x173dc80, 0x40005809e0, 0x1749020, 0x40002b0450, 0x17628a0, 0x4000570bd0, 0x176ca20, 0x400017c900, ...)
4893algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/agreement/pseudonode.go:151 +0x70
4894algod(18441) : github.com/algorand/go-algorand/agreement.pseudonodeAction.do(0xc, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
4895algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/agreement/actions.go:308 +0x5dc
4896algod(18441) : github.com/algorand/go-algorand/agreement.(*Service).do(0x4000576800, 0x1752e20, 0x400055a900, 0x400087b280, 0x4, 0x4)
4897algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/agreement/service.go:230 +0x8c
4898algod(18441) : github.com/algorand/go-algorand/agreement.(*Service).demuxLoop(0x4000576800, 0x1752e20, 0x400055a900, 0x40001f48a0, 0x40001f4900, 0x40001f4960)
4899algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/agreement/service.go:144 +0xa0
4900algod(18441) : created by github.com/algorand/go-algorand/agreement.(*Service).Start
4901algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/agreement/service.go:127 +0x154
```

and 
```
algod(18441) : goroutine 245 [runnable]:
4699algod(18441) : github.com/algorand/go-algorand/crypto._Cfunc_crypto_sign_ed25519_seed_keypair(0x4001102860, 0x40011ad000, 0x4001102840, 0x0)
4700algod(18441) : 	_cgo_gotypes.go:84 +0x58
4701algod(18441) : github.com/algorand/go-algorand/crypto.ed25519GenerateKeySeed(...)
4702algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/crypto/curve25519.go:85
4703algod(18441) : github.com/algorand/go-algorand/crypto.ed25519GenerateKeyRNG(0x173c560, 0x294e220, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
4704algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/crypto/curve25519.go:81 +0x180
4705algod(18441) : github.com/algorand/go-algorand/crypto.(*OneTimeSignatureSecrets).DeleteBeforeFineGrained(0x40006e6000, 0x0, 0x2, 0x2710)
4706algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/crypto/onetimesig.go:371 +0x578
4707algod(18441) : github.com/algorand/go-algorand/data/account.Participation.DeleteOldKeys(0x48aae8ba87944ba8, 0xe12e4a71c6ced3d6, 0x5f6db185009c0209, 0x3bc71f1a69f6fd17, 0x40001f4420, 0x40006e6000, 0x0, 0x2dc6c0, 0x2710, 0x4000212180, ...)
4708algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/data/account/participation.go:90 +0x64
4709algod(18441) : github.com/algora
4710algod(18441) : nd/go-algorand/data.(*AccountManager).DeleteOldKeys(0x40002b0450, 0x2, 0x2710, 0x2328, 0x2710, 0x80, 0xf4240, 0x400, 0x3e8, 0x4000118270, ...)
4711algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/data/accountManager.go:127 +0x1cc
4712algod(18441) : github.com/algorand/go-algorand/node.(*AlgorandFullNode).oldKeyDeletionThread(0x4000088a80)
4713algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/node/node.go:742 +0x488
4714algod(18441) : created by github.com/algorand/go-algorand/node.(*AlgorandFullNode).Start
4715algod(18441) : 	/home/ubuntu/go/src/github.com/algorand/go-algorand/node/node.go:337 +0x398
```

see https://travis-ci.com/algorand/go-algorand/jobs/239490717 for more details.