### PR TITLE
Better error handling for auctionStart.sh

### DIFF
--- a/test/scripts/auctionStart.sh
+++ b/test/scripts/auctionStart.sh
@@ -126,6 +126,10 @@ export PRIMARY_ACCOUNT=$(cat ${ALGOTESTDIR}/accountlist.out | ( while read accou
 do
     account_key=$(awk '{print $3}' <<< ${account})
     account_balance=$(awk '{print $4}' <<< ${account})
+    if [ "${account_balance}" = "[n/a]" ]; then
+        echo "ERROR: unable to retrieve available funds for account ${account_key}"
+        exit 1
+    fi
     if [[ ${max_balance} -lt ${account_balance} ]]; then
        max_balance=${account_balance}
        primary_account=${account_key}


### PR DESCRIPTION
## Summary

When running the auction tests on arm64, the auctionStart.sh script fails due to incorrect comparison of string "[n/a]" and max balance.
The source of the issue is yet to be found, but this PR addresses the script fail use case.
It adds an explicit test for "[n/a]" which is a legit `goal account list` output.
When this happen, we want to fail the auctionStart.sh while returning a proper error string.