### PR TITLE
Support re-run of ARM64 builds on travis

### DIFF
--- a/scripts/travis/external_build.sh
+++ b/scripts/travis/external_build.sh
@@ -74,6 +74,9 @@ fi
 set +e
 # remove if it's already there, so the new build would replace it.
 aws s3 rm ${BUILD_COMPLETE_PATH} ${NO_SIGN_REQUEST}
+# delete the first log for this build task. The build host would
+# delete any n+1 log file before creating the n-th log file.
+aws s3 rm ${BUILD_LOG_PATH}-1 ${NO_SIGN_REQUEST}
 
 set -e
 aws s3 cp ${BUILDID}.json ${BUILD_REQUEST_PATH} ${NO_SIGN_REQUEST}


### PR DESCRIPTION

## Summary

Current implementation was reading the entire log files for the given task once a task has started.
The problem is that it might display the log files from the previous iteration, as they remain on the S3 bucket.

To resolve that-
1. Before creating the new task, we need to delete the *first* log file. ( if it's there )
2. Before creating any of the log files, we need to delete the *subsequent* log file. ( if there is such ) 