### PR TITLE
Readme file changes: shorter lines, brew requirement and typo fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ make install
 #### test
 ```bash
 # unit tests
-make test 
+make test
 
 # integration tests
-make integration 
+make integration
 ```
 
 #### style and checks
@@ -73,10 +73,10 @@ directory will be initialized at `~/.algorand`. Start your node with
 ~/.algorand` to see activity. Refer to the [developer website][developer site
 url] for how to use the different tools.
 
-#### Providing your own data directory You can run a node out of other
-directories than `~/.algorand` and join networks other than mainnet. Just make a
-new directory and copy into it the `genesis.json` file for the network. For
-example:
+#### Providing your own data directory
+You can run a node out of other directories than `~/.algorand` and join networks
+other than mainnet. Just make a new directory and copy into it the
+`genesis.json` file for the network. For example:
 ```bash
 mkdir ~/testnet_data
 cp installer/genesis/testnet/genesis.json ~/testnet_data/genesis.json
@@ -105,21 +105,21 @@ daemons, as well as other tools and commands:
     locally by the node as well as parameters which must be agreed upon by the
     protocol.
   - `data` defines various types used throughout the codebase.
-	 - `basics` holds basic types such as MicroAlgos, account data, and
-           addresses.
-	 - `account` defines accounts, including "root" accounts (which can
-           spend money) and "participation" accounts (which can participate in
-           the agreement protocol).
-	 - `transactions` defines transactions that accounts can issue against
-           the Algorand state.  These include standard payments and also
-           participation key registration transactions.
-	 - `bookkeeping` defines blocks, which are batches of transactions
-           atomically committed to Algorand.
-	 - `pools` implements the transaction pool.  The transaction pool holds
-           transactions seen by a node in memory before they are proposed in a
-           block.
-	 - `committee` implements the credentials that authenticate a
-           participating account's membership in the agreement protocol.
+     - `basics` holds basic types such as MicroAlgos, account data, and
+       addresses.
+     - `account` defines accounts, including "root" accounts (which can
+       spend money) and "participation" accounts (which can participate in
+       the agreement protocol).
+     - `transactions` defines transactions that accounts can issue against
+       the Algorand state.  These include standard payments and also
+       participation key registration transactions.
+     - `bookkeeping` defines blocks, which are batches of transactions
+       atomically committed to Algorand.
+     - `pools` implements the transaction pool.  The transaction pool holds
+       transactions seen by a node in memory before they are proposed in a
+       block.
+     - `committee` implements the credentials that authenticate a
+       participating account's membership in the agreement protocol.
   - `ledger` ([README](ledger/README.md)) contains the Algorand Ledger state
     machine, which holds the sequence of blocks.  The Ledger executes the state
     transitions that result from applying these blocks.  It answers queries on
@@ -133,8 +133,8 @@ daemons, as well as other tools and commands:
     accepts connections from peers, sends point to point and broadcast messages,
     and receives messages routing them to various handler code
     (e.g. agreement/gossip/network.go registers three handlers).
-	 - `rpcs` contains the HTTP RPCs used by `algod` processes to query one
-           another.
+     - `rpcs` contains the HTTP RPCs used by `algod` processes to query one
+       another.
   - `agreement` ([README](agreement/README.md)) contains the agreement service,
     which implements Algorand's Byzantine Agreement protocol.  This protocol
     allows participating accounts to quickly confirm blocks in a fork-safe
@@ -148,20 +148,20 @@ daemons, as well as other tools and commands:
   - `daemon/algod` holds the `algod` daemon, which implements a participating
     node.  `algod` allows a node to participate in the agreement protocol,
     submit and confirm transactions, and view the state of the Algorand Ledger.
-         - `daemon/algod/api` ([README](daemon/algod/api/README.md)) is the REST
-           interface used for interactions with algod.
+     - `daemon/algod/api` ([README](daemon/algod/api/README.md)) is the REST
+       interface used for interactions with algod.
   - `daemon/kmd` ([README](daemon/kmd/README.md)) holds the `kmd` daemon.  This
     daemon allows a node to sign transactions.  Because `kmd` is separate from
     `algod`, `kmd` allows a user to sign transactions on an air-gapped computer.
-  
+
 The following packages allow developers to interface with the Algorand system:
 
   - `cmd` holds the primary commands defining entry points into the system.
-	 - `cmd/catchupsrv` ([README](cmd/catchupsrv/README.md)) is a tool to
-           assist with processing historic blocks on a new node.
+     - `cmd/catchupsrv` ([README](cmd/catchupsrv/README.md)) is a tool to
+       assist with processing historic blocks on a new node.
   - `libgoal` exports a Go interface useful for developers of Algorand clients.
   - `debug` holds secondary commands which assist developers during debugging.
-  
+
 The `auction` package implements the Algorand auctions.
 
 The following packages contain tools to help Algorand developers deploy networks
@@ -174,13 +174,13 @@ of their own:
     automate a network of algod instances.
   - `components`
   - `netdeploy`
-  
+
 A number of packages provide utilities for the various components:
 
   - `logging` is a wrapper around `logrus`.
   - `util` contains a variety of utilities, including a codec, a sqlite wrapper,
     a goroutine pool, a timer interface, node metrics, and more.
-  
+
 `test` contains end-to-end tests for the above components.
 
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,30 @@ go-algorand
 ====================
 Algorand's official implementation in Go.
 
-Algorand is a permissionless, pure proof-of-stake blockchain that delivers decentralization, scalability, security, and transaction finality.
+Algorand is a permissionless, pure proof-of-stake blockchain that delivers
+decentralization, scalability, security, and transaction finality.
 
 ## Getting Started ##
 
-Our [developer website][developer site url] has the most up to date information about using and installing the algorand platform.
+Our [developer website][developer site url] has the most up to date information
+about using and installing the algorand platform.
 
 ## Building from source ##
 
-Development is done using the [Go Programming Language](https://golang.org/) version 1.12.x, and this document assumes that you have a functioning environment setup. If you need assistance setting up an environment please visit the [official Go documentation website](https://golang.org/doc/).
+Development is done using the [Go Programming Language](https://golang.org/)
+version 1.12.x, and this document assumes that you have a functioning
+environment setup. If you need assistance setting up an environment please visit
+the [official Go documentation website](https://golang.org/doc/).
 
 ### Linux / OSX ###
 
-We currently strive to support Debian based distributions with Ubuntu 18.04 being our official release target. Our core engineering team uses Linux and OSX, so both environments are well supported for development.
+We currently strive to support Debian based distributions with Ubuntu 18.04
+being our official release target. Our core engineering team uses Linux and OSX,
+so both environments are well supported for development.
+
+[Homebrew (brew)](https://brew.sh) must be installed before
+continuing. [Here](https://docs.brew.sh/Installation) are the installation
+requirements.
 
 Initial environment setup:
 ```bash
@@ -25,7 +36,8 @@ cd go-algorand
 ./scripts/configure_dev.sh
 ```
 
-At this point you are ready to build go-algorand. We use `make` and have a number of targets to automate common tasks.
+At this point you are ready to build go-algorand. We use `make` and have a
+number of targets to automate common tasks.
 
 #### build
 ```bash
@@ -55,16 +67,23 @@ make sanity
 
 ### Running a node
 
-Once the software is built you'll find binaries in `${GOPATH}/bin`, and a data directory will be initialized at `~/.algorand`. Start your node with `${GOPATH}/bin/goal node start -d ~/.algorand`, use `${GOPATH}/bin/carpenter -d ~/.algorand` to see activity. Refer to the [developer website][developer site url] for how to use the different tools.
+Once the software is built you'll find binaries in `${GOPATH}/bin`, and a data
+directory will be initialized at `~/.algorand`. Start your node with
+`${GOPATH}/bin/goal node start -d ~/.algorand`, use `${GOPATH}/bin/carpenter -d
+~/.algorand` to see activity. Refer to the [developer website][developer site
+url] for how to use the different tools.
 
-#### Providing your own data directory
-You can run a node out of other directories than `~/.algorand` and join networks other than mainnet. Just make a new directory and copy into it the `genesis.json` file for the network. For example:
+#### Providing your own data directory You can run a node out of other
+directories than `~/.algorand` and join networks other than mainnet. Just make a
+new directory and copy into it the `genesis.json` file for the network. For
+example:
 ```bash
 mkdir ~/testnet_data
 cp installer/genesis/testnet/genesis.json ~/testnet_data/genesis.json
 ${GOPATH}/bin/goal node start -d ~/testnet_data
 ```
-Genesis files for mainnet, testnet, and betanet can be found in `installer/genesis/`.
+Genesis files for mainnet, testnet, and betanet can be found in
+`installer/genesis/`.
 
 ## Contributing (Code, Documentation, Bugs, Etc) ##
 
@@ -75,52 +94,92 @@ Please refer to our [CONTRIBUTING](CONTRIBUTING.md) document.
 
 `go-algorand` is split into various subpackages.
 
-The following packages provide core functionality to the `algod` and `kmd` daemons, as well as other tools and commands:
+The following packages provide core functionality to the `algod` and `kmd`
+daemons, as well as other tools and commands:
 
-  - `crypto` contains the cryptographic constructions we're using for hashing, signatures, and VRFs. There are also some Algorand-specific details here about spending keys, protocols keys, one-time-use signing keys, and how they relate to each other.
-  - `config` holds configuration parameters.  These include parameters used locally by the node as well as parameters which must be agreed upon by the protocol.
+  - `crypto` contains the cryptographic constructions we're using for hashing,
+    signatures, and VRFs. There are also some Algorand-specific details here
+    about spending keys, protocols keys, one-time-use signing keys, and how they
+    relate to each other.
+  - `config` holds configuration parameters.  These include parameters used
+    locally by the node as well as parameters which must be agreed upon by the
+    protocol.
   - `data` defines various types used throughout the codebase.
-	 - `basics` holds basic types such as MicroAlgos, account data, and addresses.
-     - `account` defines accounts, including "root" accounts (which can spend money) and "participation" accounts (which can participate in the agreement protocol).
-	 - `transactions` defines transactions that accounts can issue against the Algorand state.  These include standard payments and also participation key registration transactions.
-	 - `bookkeeping` defines blocks, which are batches of transactions atomically committed to Algorand.
-	 - `pools` implements the transaction pool.  The transaction pool holds transactions seen by a node in memory before they are proposed in a block.
-	 - `committee` implements the credentials that authenticate a participating account's membership in the agreement protocol.
-  - `ledger` ([README](ledger/README.md)) contains the Algorand Ledger state machine, which holds the sequence of blocks.  The Ledger executes the state transitions that result from applying these blocks.  It answers queries on blocks (e.g., what transactions were in the last committed block?) and on accounts (e.g., what is my balance?).
-  - `protocol` declares constants used to identify protocol versions, tags for routing network messages, and prefixes for domain separation of cryptographic inputs.  It also implements the canonical encoder.
-  - `network` contains the code for participating in a mesh network based on websockets. Maintains connection to some number of peers, (optionally) accepts connections from peers, sends point to point and broadcast messages, and receives messages routing them to various handler code (e.g. agreement/gossip/network.go registers three handlers).
-     - `rpcs` contains the HTTP RPCs used by `algod` processes to query one another.
-  - `agreement` ([README](agreement/README.md)) contains the agreement service, which implements Algorand's Byzantine Agreement protocol.  This protocol allows participating accounts to quickly confirm blocks in a fork-safe manner, provided that sufficient account stake is correctly executing the protocol.
-  - `node` integrates the components above and handles initialization and shutdown.  It provides queries into these components.
+	 - `basics` holds basic types such as MicroAlgos, account data, and
+           addresses.
+	 - `account` defines accounts, including "root" accounts (which can
+           spend money) and "participation" accounts (which can participate in
+           the agreement protocol).
+	 - `transactions` defines transactions that accounts can issue against
+           the Algorand state.  These include standard payments and also
+           participation key registration transactions.
+	 - `bookkeeping` defines blocks, which are batches of transactions
+           atomically committed to Algorand.
+	 - `pools` implements the transaction pool.  The transaction pool holds
+           transactions seen by a node in memory before they are proposed in a
+           block.
+	 - `committee` implements the credentials that authenticate a
+           participating account's membership in the agreement protocol.
+  - `ledger` ([README](ledger/README.md)) contains the Algorand Ledger state
+    machine, which holds the sequence of blocks.  The Ledger executes the state
+    transitions that result from applying these blocks.  It answers queries on
+    blocks (e.g., what transactions were in the last committed block?) and on
+    accounts (e.g., what is my balance?).
+  - `protocol` declares constants used to identify protocol versions, tags for
+    routing network messages, and prefixes for domain separation of
+    cryptographic inputs.  It also implements the canonical encoder.
+  - `network` contains the code for participating in a mesh network based on
+    websockets. Maintains connection to some number of peers, (optionally)
+    accepts connections from peers, sends point to point and broadcast messages,
+    and receives messages routing them to various handler code
+    (e.g. agreement/gossip/network.go registers three handlers).
+	 - `rpcs` contains the HTTP RPCs used by `algod` processes to query one
+           another.
+  - `agreement` ([README](agreement/README.md)) contains the agreement service,
+    which implements Algorand's Byzantine Agreement protocol.  This protocol
+    allows participating accounts to quickly confirm blocks in a fork-safe
+    manner, provided that sufficient account stake is correctly executing the
+    protocol.
+  - `node` integrates the components above and handles initialization and
+    shutdown.  It provides queries into these components.
 
 `daemon` defines the two daemons which provide Algorand clients with services:
 
-  - `daemon/algod` holds the `algod` daemon, which implements a participating node.  `algod` allows a node to participate in the agreement protocol, submit and confirm transactions, and view the state of the Algorand Ledger.
-    - `daemon/algod/api` ([README](daemon/algod/api/README.md)) is the REST interface used for interactions with algod.
-  - `daemon/kmd` ([README](daemon/kmd/README.md)) holds the `kmd` daemon.  This daemon allows a node to sign transactions.  Because `kmd` is separate from `algod`, `kmd` allows a user to sign transactions on an air-gapped computer.
+  - `daemon/algod` holds the `algod` daemon, which implements a participating
+    node.  `algod` allows a node to participate in the agreement protocol,
+    submit and confirm transactions, and view the state of the Algorand Ledger.
+         - `daemon/algod/api` ([README](daemon/algod/api/README.md)) is the REST
+           interface used for interactions with algod.
+  - `daemon/kmd` ([README](daemon/kmd/README.md)) holds the `kmd` daemon.  This
+    daemon allows a node to sign transactions.  Because `kmd` is separate from
+    `algod`, `kmd` allows a user to sign transactions on an air-gapped computer.
   
 The following packages allow developers to interface with the Algorand system:
 
   - `cmd` holds the primary commands defining entry points into the system.
-    - `cmd/catchupsrv` ([README](cmd/catchupsrv/README.md)) is a tool to assist with processing historic blocks on a new node.
+	 - `cmd/catchupsrv` ([README](cmd/catchupsrv/README.md)) is a tool to
+           assist with processing historic blocks on a new node.
   - `libgoal` exports a Go interface useful for developers of Algorand clients.
   - `debug` holds secondary commands which assist developers during debugging.
   
 The `auction` package implements the Algorand auctions.
 
-The following packages contain tools to help Algorand developers deploy networks of their own:
+The following packages contain tools to help Algorand developers deploy networks
+of their own:
 
   - `nodecontrol`
   - `tools`
   - `docker`
-  - `commandandcontrol` ([README](commandandcontrol/README.md)) is a tool to automate a network of algod instances.
+  - `commandandcontrol` ([README](commandandcontrol/README.md)) is a tool to
+    automate a network of algod instances.
   - `components`
   - `netdeploy`
   
 A number of packages provide utilities for the various components:
 
   - `logging` is a wrapper around `logrus`.
-  - `util` contains a variety of utilities, including a codec, a sqlite wrapper, a goroutine pool, a timer interface, node metrics, and more.
+  - `util` contains a variety of utilities, including a codec, a sqlite wrapper,
+    a goroutine pool, a timer interface, node metrics, and more.
   
 `test` contains end-to-end tests for the above components.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We currently strive to support Debian based distributions with Ubuntu 18.04
 being our official release target. Our core engineering team uses Linux and OSX,
 so both environments are well supported for development.
 
-[Homebrew (brew)](https://brew.sh) must be installed before
+OSX only: [Homebrew (brew)](https://brew.sh) must be installed before
 continuing. [Here](https://docs.brew.sh/Installation) are the installation
 requirements.
 
@@ -170,7 +170,7 @@ of their own:
   - `nodecontrol`
   - `tools`
   - `docker`
-  - `commandandcontrol` ([README](commandandcontrol/README.md)) is a tool to
+  - `commandandcontrol` ([README](test/commandandcontrol/README.md)) is a tool to
     automate a network of algod instances.
   - `components`
   - `netdeploy`

--- a/daemon/algod/api/README.md
+++ b/daemon/algod/api/README.md
@@ -26,14 +26,14 @@ so that we can generate models without pointers. (This is more compatible with t
 current model we use. We may want to use pointers instead, eventually)
     - make sure you populate the `default` property in order to generate a model 
     without a pointer field
-- `go-swagger` does not support OpenAPI 3.0. It only supports OpenAI 2.0. There 
+- `go-swagger` does not support OpenAPI 3.0. It only supports OpenAPI 2.0. There 
 does not seem to be another tool that allows us to generate a swagger spec from 
 code. It may be worth writing our own, eventually.
 - `go-swagger` does not support embedded structs.
     - in fact, `go-swagger` is generally very strange. The source -> spec generation
      looks fairly immature. Here are some (undocumented) tips:
         - every `swagger:response` type must contain a single field (e.g. `Body` or 
-        `Payloard`) that is the actual data type you want to return. So the `response` 
+        `Payload`) that is the actual data type you want to return. So the `response` 
         type is a wrapper, which makes sense, except the clients that `go-swagger`
          generate automatically unwrap the underlying value. So this is very weird, 
          and undocumented.


### PR DESCRIPTION
README.md:
Made the lines 80 characters long to make reading easier from a text editor.
Added a statment about the brew/homebrow requirement before installation.

daemon/algod/api/README.md:
Fixed two typeos: OpenAI->OpenAPI and Payloard->Payload.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Explain the goal of this change and what problem it is solving.

## Test Plan

How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale.

