### PR TITLE
Revive the GATE_PREFIX variable in 'rel/stable' branch

### DIFF
--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -49,9 +49,9 @@ export TIMESTAMP=${TIMESTAMP}
 # To ensure deterministic availability of testnet (stable) builds, prefix the packages
 # with "pending_" so updater will not detect the package before we rename it.
 GATE_PREFIX=""
-# if [[ "${CHANNEL}" = "stable" || "${CHANNEL}" = "nightly" ]]; then
-#     GATE_PREFIX="pending_"
-# fi
+if [[ "${CHANNEL}" = "stable" ]]; then
+    GATE_PREFIX="pending_"
+fi
 
 VERSION_COMPONENTS=(${FULLVERSION//\./ })
 export BUILDNUMBER=${VERSION_COMPONENTS[2]}


### PR DESCRIPTION
`rel/stable` is still using the legacy release scripts. These scripts still push directly to `testnet-latest`, this PR re-introduces the `pending_` prefix temporarily until we can get the new mechanism released.

## Testing

Ran `VARIATIONS="base" ./scripts/build_packages.sh linux/amd64` locally with a custom `GATE_PREFIX` and observed that the prefix was applied to the resulting archives.