### PR TITLE
Allow ddconfig to work on old installations which don't have algocfg

### DIFF
--- a/scripts/ddconfig.sh
+++ b/scripts/ddconfig.sh
@@ -18,6 +18,22 @@ function DisableAndExit() {
     exit 0
 }
 
+function PrintEndpointAddress() {
+  if [[ -f "$1/algocfg" ]]; then
+    echo $($1/algocfg get -p EndpointAddress -d "$2")
+  else
+    echo $(cat $2/config.json|grep EndpointAddress|cut -f 4 -d\")
+  fi
+}
+
+function SetEndpointAddress() {
+  if [[ -f "$1/algocfg" ]]; then
+    $($1/algocfg set -p EndpointAddress -d "$2" -v "$3")
+  else
+    $(sed -i -e 's/.*EndpointAddress.*/    "EndpointAddress": "'"$3"'","/' "$2/config.json")
+  fi
+}
+
 DATADIR=
 PORT=
 HOSTNAME=
@@ -77,7 +93,7 @@ if [[ -z "${DATADIR}" || -z "${HOSTNAME}" || -z "${APIKEY}" ]]; then
     ShowSyntaxAndExit
 fi
 
-ENDPOINT=$(${SCRIPTPATH}/algocfg get -p EndpointAddress -d "$DATADIR")
+ENDPOINT="$(PrintEndpointAddress $SCRIPTPATH $DATADIR)"
 ADDRESS=$(echo ${ENDPOINT} | grep -o "[0-9\.]*:" | tr -d ":")
 
 if [[ -z "${PORT}" ]]; then
@@ -105,7 +121,7 @@ fi
 
 ${SCRIPTPATH}/diagcfg metric disable -d "${DATADIR}"
 
-${SCRIPTPATH}/algocfg set -p EndpointAddress -d "$DATADIR" -v "${ADDRESS}:${PORT}"
+SetEndpointAddress $SCRIPTPATH $DATADIR "${ADDRESS}:${PORT}"
 
 ${SCRIPTPATH}/goal node stop -d ${DATADIR}
 pkill node_exporter || true


### PR DESCRIPTION
## Summary

ddconfig.sh depends on algocfg, which is unavailable for current stable releases, use an alternative method if needed.

## Test Plan

Ran this test program to verify the new functions:
```bash
#!/usr/bin/env bash

set -e

function PrintEndpointAddress() {
  if [[ -f "$1/algocfg" ]]; then
    echo $($1/algocfg get -p EndpointAddress -d "$2")
  else
    echo $(cat $2/config.json|grep EndpointAddress|cut -f 4 -d\")
  fi
}


function SetEndpointAddress() {
  if [[ -f "$1/algocfg" ]]; then
    $($1/algocfg set -p EndpointAddress -d "$2" -v "$3")
  else
    $(sed -i -e 's/.*EndpointAddress.*/    "EndpointAddress": "'"$3"'",/' "$2/config.json")
  fi
}

# algocfg not available
SetEndpointAddress ~/ ~/.algorand "1.2.3.4:test"
ENDPOINT=$(PrintEndpointAddress ~/ ~/.algorand)
echo $ENDPOINT

# algocfg available
SetEndpointAddress ~/go/bin ~/.algorand "127.0.0.1:10101"
ENDPOINT=$(PrintEndpointAddress ~/go/bin ~/.algorand)
echo $ENDPOINT
```

```console
$ bash test.sh 
1.2.3.4:test
127.0.0.1:10101
```
