### PR TITLE
Update brew tap for MacOS builds

### DIFF
--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -23,7 +23,7 @@ if [ "${OS}" = "linux" ]; then
     sudo apt-get -y install libboost-all-dev expect jq autoconf
 elif [ "${OS}" = "darwin" ]; then
     brew update
-    brew tap caskroom/cask
+    brew tap homebrew/cask-cask
     install_or_upgrade pkg-config
     install_or_upgrade boost
     install_or_upgrade jq

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -23,7 +23,7 @@ if [ "${OS}" = "linux" ]; then
     sudo apt-get -y install libboost-all-dev expect jq autoconf
 elif [ "${OS}" = "darwin" ]; then
     brew update
-    brew tap homebrew/cask-cask
+    brew tap homebrew/cask
     install_or_upgrade pkg-config
     install_or_upgrade boost
     install_or_upgrade jq


### PR DESCRIPTION
## Summary

On MacOS builds, the tooling chain was using the `caskroom/cask` tap. This tap is no longer available on GitHub, and was moved to `homebrew/cask`.

This change is required in order to make MacOS builds.
