### PR TITLE
Add semantic version output flag to updater

### DIFF
--- a/cmd/updater/versionCmd.go
+++ b/cmd/updater/versionCmd.go
@@ -80,7 +80,7 @@ var checkCmd = &cobra.Command{
 			if semanticOutput {
 				major, minor, patch, err := s3.GetVersionPartsFromVersion(version)
 				if err != nil {
-					exitErrorf( "Problem converting '%d' to a semantic version string: %v", version, err)
+					exitErrorf("Problem converting '%d' to a semantic version string: %v", version, err)
 				}
 				fmt.Fprintf(os.Stdout, "%d.%d.%d\n", major, minor, patch)
 			} else {

--- a/util/s3/s3Helper.go
+++ b/util/s3/s3Helper.go
@@ -323,15 +323,16 @@ func GetVersionFromName(name string) (version uint64, err error) {
 	return
 }
 
+// GetVersionPartsFromVersion converts the merged version number back into parts.
 func GetVersionPartsFromVersion(version uint64) (major uint64, minor uint64, patch uint64, err error) {
 	val := version
 
 	if val < 1<<32 {
-		err = errors.New("Versions below 1.0.0 not supported.")
+		err = errors.New("versions below 1.0.0 not supported")
 		return
 	}
 
-	modVal := uint64(1<<16)
+	modVal := uint64(1 << 16)
 
 	patch = val % modVal
 	val >>= 16

--- a/util/s3/s3Helper.go
+++ b/util/s3/s3Helper.go
@@ -326,7 +326,7 @@ func GetVersionFromName(name string) (version uint64, err error) {
 func GetVersionPartsFromVersion(version uint64) (major uint64, minor uint64, patch uint64, err error) {
 	val := version
 
-	if val < 2^32 {
+	if val < 1<<32 {
 		err = errors.New("Versions below 1.0.0 not supported.")
 		return
 	}

--- a/util/s3/s3Helper.go
+++ b/util/s3/s3Helper.go
@@ -332,11 +332,9 @@ func GetVersionPartsFromVersion(version uint64) (major uint64, minor uint64, pat
 		return
 	}
 
-	modVal := uint64(1 << 16)
-
-	patch = val % modVal
+	patch = val & 0xffff
 	val >>= 16
-	minor = val % modVal
+	minor = val & 0xffff
 	val >>= 16
 	major = val
 	return

--- a/util/s3/s3Helper.go
+++ b/util/s3/s3Helper.go
@@ -322,3 +322,21 @@ func GetVersionFromName(name string) (version uint64, err error) {
 	}
 	return
 }
+
+func GetVersionPartsFromVersion(version uint64) (major uint64, minor uint64, patch uint64, err error) {
+	val := version
+
+	if val < 2^32 {
+		err = errors.New("Versions below 1.0.0 not supported.")
+		return
+	}
+
+	modVal := uint64(1<<16)
+
+	patch = val % modVal
+	val >>= 16
+	minor = val % modVal
+	val >>= 16
+	major = val
+	return
+}

--- a/util/s3/s3Helper_test.go
+++ b/util/s3/s3Helper_test.go
@@ -189,13 +189,13 @@ func TestGetVersionFromName(t *testing.T) {
 		version  string
 		expected uint64
 	}
-	tests := []args {
-		args{name: "test 1 (major)", version: "_1.0.0", expected: 1 * 1<<32 },
-		args{name: "test 2 (major)", version: "_2.0.0", expected: 2 * 1<<32 },
-		args{name: "test 3 (minor)", version: "_1.1.0", expected: 1 * 1<<32 + 1 * 1<<16 },
-		args{name: "test 4 (minor)", version: "_1.2.0", expected: 1 * 1<<32 + 2 * 1<<16 },
-		args{name: "test 5 (patch)", version: "_1.0.1", expected: 1 * 1<<32 + 1 },
-		args{name: "test 6 (patch)", version: "_1.0.2", expected: 1 * 1<<32 + 2 },
+	tests := []args{
+		args{name: "test 1 (major)", version: "_1.0.0", expected: 1 * 1 << 32},
+		args{name: "test 2 (major)", version: "_2.0.0", expected: 2 * 1 << 32},
+		args{name: "test 3 (minor)", version: "_1.1.0", expected: 1*1<<32 + 1*1<<16},
+		args{name: "test 4 (minor)", version: "_1.2.0", expected: 1*1<<32 + 2*1<<16},
+		args{name: "test 5 (patch)", version: "_1.0.1", expected: 1*1<<32 + 1},
+		args{name: "test 6 (patch)", version: "_1.0.2", expected: 1*1<<32 + 2},
 	}
 
 	for _, test := range tests {
@@ -213,13 +213,13 @@ func TestGetPartsFromVersion(t *testing.T) {
 		expMinor uint64
 		expPatch uint64
 	}
-	tests := []args {
-		args{name: "test 1 (major)", version: 1 * 1<<32, expMajor: 1, expMinor: 0, expPatch: 0 },
-		args{name: "test 2 (major)", version: 2 * 1<<32, expMajor: 2, expMinor: 0, expPatch: 0 },
-		args{name: "test 3 (minor)", version: 1 * 1<<32 + 1 * 1<<16, expMajor: 1, expMinor: 1, expPatch: 0 },
-		args{name: "test 4 (minor)", version: 1 * 1<<32 + 2 * 1<<16, expMajor: 1, expMinor: 2, expPatch: 0 },
-		args{name: "test 5 (patch)", version: 1 * 1<<32 + 1, expMajor: 1, expMinor: 0, expPatch: 1 },
-		args{name: "test 6 (patch)", version: 1 * 1<<32 + 2, expMajor: 1, expMinor: 0, expPatch: 2 },
+	tests := []args{
+		args{name: "test 1 (major)", version: 1 * 1 << 32, expMajor: 1, expMinor: 0, expPatch: 0},
+		args{name: "test 2 (major)", version: 2 * 1 << 32, expMajor: 2, expMinor: 0, expPatch: 0},
+		args{name: "test 3 (minor)", version: 1*1<<32 + 1*1<<16, expMajor: 1, expMinor: 1, expPatch: 0},
+		args{name: "test 4 (minor)", version: 1*1<<32 + 2*1<<16, expMajor: 1, expMinor: 2, expPatch: 0},
+		args{name: "test 5 (patch)", version: 1*1<<32 + 1, expMajor: 1, expMinor: 0, expPatch: 1},
+		args{name: "test 6 (patch)", version: 1*1<<32 + 2, expMajor: 1, expMinor: 0, expPatch: 2},
 	}
 
 	for _, test := range tests {

--- a/util/s3/s3Helper_test.go
+++ b/util/s3/s3Helper_test.go
@@ -190,12 +190,12 @@ func TestGetVersionFromName(t *testing.T) {
 		expected uint64
 	}
 	tests := []args{
-		args{name: "test 1 (major)", version: "_1.0.0", expected: 1 * 1 << 32},
-		args{name: "test 2 (major)", version: "_2.0.0", expected: 2 * 1 << 32},
-		args{name: "test 3 (minor)", version: "_1.1.0", expected: 1*1<<32 + 1*1<<16},
-		args{name: "test 4 (minor)", version: "_1.2.0", expected: 1*1<<32 + 2*1<<16},
-		args{name: "test 5 (patch)", version: "_1.0.1", expected: 1*1<<32 + 1},
-		args{name: "test 6 (patch)", version: "_1.0.2", expected: 1*1<<32 + 2},
+		{name: "test 1 (major)", version: "_1.0.0", expected: 1 * 1 << 32},
+		{name: "test 2 (major)", version: "_2.0.0", expected: 2 * 1 << 32},
+		{name: "test 3 (minor)", version: "_1.1.0", expected: 1*1<<32 + 1*1<<16},
+		{name: "test 4 (minor)", version: "_1.2.0", expected: 1*1<<32 + 2*1<<16},
+		{name: "test 5 (patch)", version: "_1.0.1", expected: 1*1<<32 + 1},
+		{name: "test 6 (patch)", version: "_1.0.2", expected: 1*1<<32 + 2},
 	}
 
 	for _, test := range tests {
@@ -214,12 +214,12 @@ func TestGetPartsFromVersion(t *testing.T) {
 		expPatch uint64
 	}
 	tests := []args{
-		args{name: "test 1 (major)", version: 1 * 1 << 32, expMajor: 1, expMinor: 0, expPatch: 0},
-		args{name: "test 2 (major)", version: 2 * 1 << 32, expMajor: 2, expMinor: 0, expPatch: 0},
-		args{name: "test 3 (minor)", version: 1*1<<32 + 1*1<<16, expMajor: 1, expMinor: 1, expPatch: 0},
-		args{name: "test 4 (minor)", version: 1*1<<32 + 2*1<<16, expMajor: 1, expMinor: 2, expPatch: 0},
-		args{name: "test 5 (patch)", version: 1*1<<32 + 1, expMajor: 1, expMinor: 0, expPatch: 1},
-		args{name: "test 6 (patch)", version: 1*1<<32 + 2, expMajor: 1, expMinor: 0, expPatch: 2},
+		{name: "test 1 (major)", version: 1 * 1 << 32, expMajor: 1, expMinor: 0, expPatch: 0},
+		{name: "test 2 (major)", version: 2 * 1 << 32, expMajor: 2, expMinor: 0, expPatch: 0},
+		{name: "test 3 (minor)", version: 1*1<<32 + 1*1<<16, expMajor: 1, expMinor: 1, expPatch: 0},
+		{name: "test 4 (minor)", version: 1*1<<32 + 2*1<<16, expMajor: 1, expMinor: 2, expPatch: 0},
+		{name: "test 5 (patch)", version: 1*1<<32 + 1, expMajor: 1, expMinor: 0, expPatch: 1},
+		{name: "test 6 (patch)", version: 1*1<<32 + 2, expMajor: 1, expMinor: 0, expPatch: 2},
 	}
 
 	for _, test := range tests {

--- a/util/s3/s3Helper_test.go
+++ b/util/s3/s3Helper_test.go
@@ -229,4 +229,7 @@ func TestGetPartsFromVersion(t *testing.T) {
 		require.Equal(t, test.expMinor, actualMinor, test.name)
 		require.Equal(t, test.expPatch, actualPatch, test.name)
 	}
+
+	_, _, _, err := GetVersionPartsFromVersion(1<<32 - 1)
+	require.Error(t, err, "Versions less than 1.0.0 should not be parsed.")
 }


### PR DESCRIPTION
## Summary

`updater ver check -c stable` outputs a machine readable number that can conveniently be used in scripts, like `4294967323`. It would be nice to have a human readable form as well, so this adds a `--semantic` flag for printing the semantic version. 

## Test Plan

Added some unit tests and ran the command.

```bash
$ updater ver check -c stable
Checking for files matching: 'channel/stable/node_stable_linux-amd64' in bucket algorand-releases
4294967323
$ updater ver check -c stable -s
Checking for files matching: 'channel/stable/node_stable_linux-amd64' in bucket algorand-releases
1.0.27
```