### PR TITLE
Fix travis release step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,12 @@ jobs:
       name: MacOS AMD64 Build
       script:
         - scripts/travis/build_test.sh
+    - # dummy stage for testing release packages.
+      script: scripts/travis/release_packages.sh
+      addons:
+        apt:
+          packages:
+            - python-dateutil
 
     - stage: build_release
       os: linux
@@ -139,6 +145,10 @@ jobs:
 
     - stage: release
       script: scripts/travis/release_packages.sh
+      addons:
+        apt:
+          packages:
+            - python-dateutil
 
 # Don't rebuild libsodium every time
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,12 +73,6 @@ jobs:
       name: MacOS AMD64 Build
       script:
         - scripts/travis/build_test.sh
-    - # dummy stage for testing release packages.
-      script: scripts/travis/release_packages.sh
-      addons:
-        apt:
-          packages:
-            - python-dateutil
 
     - stage: build_release
       os: linux


### PR DESCRIPTION
## Summary

When running the nightly release step on the nightly build, the following message is written to the travis log file:
```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
ImportError trying to import dateutil.parser.
Please install the python dateutil module:
$ sudo apt-get install python-dateutil
  or
$ sudo yum install python-dateutil
  or
$ pip install python-dateutil
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

Clearly, this is not the desired outcome. This PR add the python-dateutil to the deployment of this release machine prior to calling the release script.

See current output at : https://travis-ci.com/algorand/go-algorand/jobs/244413869
