### PR TITLE
linux/arm won't get updated via updater tool

### DIFF
--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -19,6 +19,8 @@ BUCKET=""
 GENESIS_NETWORK_DIR=""
 GENESIS_NETWORK_DIR_SPEC=""
 
+set -o pipefail
+
 # If someone set the environment variable asking us to cleanup
 # when we're done, install a trap to do so
 # We use an environment variable instead of an arg because
@@ -132,7 +134,7 @@ function validate_channel_specified() {
 }
 
 function determine_current_version() {
-    CURRENTVER="$(( ${BINDIR}/algod -v || echo 0 ) | head -n 1)"
+    CURRENTVER="$(( ${BINDIR}/algod -v 2>/dev/null || echo 0 ) | head -n 1)"
     echo Current Version = ${CURRENTVER}
 }
 
@@ -140,7 +142,7 @@ function check_for_update() {
     determine_current_version
     LATEST="$(${SCRIPTPATH}/updater ver check -c ${CHANNEL} ${BUCKET} | sed -n '2 p')"
     if [ $? -ne 0 ]; then
-        echo No remote updates found
+        echo "No remote updates found"
         return 1
     fi
 

--- a/util/s3/s3Helper.go
+++ b/util/s3/s3Helper.go
@@ -253,7 +253,7 @@ func (helper *Helper) UploadFiles(subFolder string, files []string) error {
 func (helper *Helper) GetPackageVersion(channel string, pkg string, specificVersion uint64) (maxVersion uint64, maxVersionName string, err error) {
 	osName := runtime.GOOS
 	arch := runtime.GOARCH
-	prefix := fmt.Sprintf("%s_%s_%s-%s", pkg, channel, osName, arch)
+	prefix := fmt.Sprintf("%s_%s_%s-%s_", pkg, channel, osName, arch)
 	return helper.GetPackageFilesVersion(channel, prefix, specificVersion)
 }
 


### PR DESCRIPTION
## Summary

linux/arm won't bet updated via updater tool.
The wrong package was downloaded ( arm64 instead of arm ), which prevents us from running the deployed node ( obviously ).

## Test Plan

Deploy the fix. Iteratively attempt to update.
