### PR TITLE
Reject transactions with not-yet-protocol-enabled fields more quickly

### DIFF
--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -340,6 +340,9 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 	if !proto.SupportTransactionLeases && (tx.Lease != [32]byte{}) {
 		return fmt.Errorf("transaction tried to acquire lease %v but protocol does not support transaction leases", tx.Lease)
 	}
+	if !proto.SupportTxGroups && (tx.Group != crypto.Digest{}) {
+		return fmt.Errorf("transaction has group but groups not yet enabled")
+	}
 	return nil
 }
 

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -46,10 +46,6 @@ func TxnPool(s *transactions.SignedTxn, spec transactions.SpecialAddresses, prot
 		return errors.New("empty address")
 	}
 
-	if s.Sig != (crypto.Signature{}) && !s.Msig.Blank() {
-		return errors.New("signedtxn should only have one of Sig or Msig")
-	}
-
 	outCh := make(chan error, 1)
 	cx := asyncVerifyContext{s, outCh, &proto}
 	verificationPool.EnqueueBacklog(context.Background(), stxnAsyncVerify, &cx, nil)

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -136,6 +136,9 @@ func stxnVerifyCore(s *transactions.SignedTxn, proto *config.ConsensusParams) er
 // LogicSig checks that the signature is valid and that the program is basically well formed.
 // It does not evaluate the logic.
 func LogicSig(lsig *transactions.LogicSig, proto *config.ConsensusParams, stxn *transactions.SignedTxn) error {
+	if proto.LogicSigVersion == 0 {
+		return errors.New("LogicSig not enabled")
+	}
 	if len(lsig.Logic) == 0 {
 		return errors.New("LogicSig.Logic empty")
 	}

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -88,20 +88,6 @@ func stxnAsyncVerify(arg interface{}) interface{} {
 }
 
 func stxnVerifyCore(s *transactions.SignedTxn, proto *config.ConsensusParams) error {
-	// Check for non-empty fields that are not yet enabled
-	if !proto.Asset &&
-		((s.Txn.AssetConfigTxnFields != transactions.AssetConfigTxnFields{}) ||
-		(s.Txn.AssetTransferTxnFields != transactions.AssetTransferTxnFields{}) ||
-		(s.Txn.AssetFreezeTxnFields != transactions.AssetFreezeTxnFields{})) {
-		return errors.New("assets not yet enabled")
-	}
-	if !proto.SupportTxGroups && (s.Txn.Group != crypto.Digest{}) {
-		return errors.New("txn groups not yet enabled")
-	}
-	if !proto.SupportTransactionLeases && (s.Txn.Lease != [32]byte{}) {
-		return errors.New("leases not yet enabled")
-	}
-
 	numSigs := 0
 	hasSig := false
 	hasMsig := false

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -90,9 +90,9 @@ func stxnAsyncVerify(arg interface{}) interface{} {
 func stxnVerifyCore(s *transactions.SignedTxn, proto *config.ConsensusParams) error {
 	// Check for non-empty fields that are not yet enabled
 	if !proto.Asset &&
-		(s.Txn.AssetConfigTxnFields != transactions.AssetConfigTxnFields{}) ||
+		((s.Txn.AssetConfigTxnFields != transactions.AssetConfigTxnFields{}) ||
 		(s.Txn.AssetTransferTxnFields != transactions.AssetTransferTxnFields{}) ||
-		(s.Txn.AssetFreezeTxnFields != transactions.AssetFreezeTxnFields{}) {
+		(s.Txn.AssetFreezeTxnFields != transactions.AssetFreezeTxnFields{})) {
 		return errors.New("assets not yet enabled")
 	}
 	if !proto.SupportTxGroups && (s.Txn.Group != crypto.Digest{}) {

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -89,30 +89,17 @@ func stxnAsyncVerify(arg interface{}) interface{} {
 
 func stxnVerifyCore(s *transactions.SignedTxn, proto *config.ConsensusParams) error {
 	// Check for non-empty fields that are not yet enabled
-	if !proto.Asset {
-		reject := false
-		if (s.Txn.AssetConfigTxnFields != transactions.AssetConfigTxnFields{}) {
-			reject = true
-		}
-		if (s.Txn.AssetTransferTxnFields != transactions.AssetTransferTxnFields{}) {
-			reject = true
-		}
-		if (s.Txn.AssetFreezeTxnFields != transactions.AssetFreezeTxnFields{}) {
-			reject = true
-		}
-		if reject {
-			return errors.New("assets not yet enabled")
-		}
+	if !proto.Asset &&
+		(s.Txn.AssetConfigTxnFields != transactions.AssetConfigTxnFields{}) ||
+		(s.Txn.AssetTransferTxnFields != transactions.AssetTransferTxnFields{}) ||
+		(s.Txn.AssetFreezeTxnFields != transactions.AssetFreezeTxnFields{}) {
+		return errors.New("assets not yet enabled")
 	}
-	if !proto.SupportTxGroups {
-		if s.Txn.Group != (crypto.Digest{}) {
-			return errors.New("txn groups not yet enabled")
-		}
+	if !proto.SupportTxGroups && (s.Txn.Group != crypto.Digest{}) {
+		return errors.New("txn groups not yet enabled")
 	}
-	if !proto.SupportTransactionLeases {
-		if s.Txn.Lease != ([32]byte{}) {
-			return errors.New("leases not yet enabled")
-		}
+	if !proto.SupportTransactionLeases && (s.Txn.Lease != [32]byte{}) {
+		return errors.New("leases not yet enabled")
 	}
 
 	numSigs := 0

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -88,6 +88,33 @@ func stxnAsyncVerify(arg interface{}) interface{} {
 }
 
 func stxnVerifyCore(s *transactions.SignedTxn, proto *config.ConsensusParams) error {
+	// Check for non-empty fields that are not yet enabled
+	if !proto.Asset {
+		reject := false
+		if (s.Txn.AssetConfigTxnFields != transactions.AssetConfigTxnFields{}) {
+			reject = true
+		}
+		if (s.Txn.AssetTransferTxnFields != transactions.AssetTransferTxnFields{}) {
+			reject = true
+		}
+		if (s.Txn.AssetFreezeTxnFields != transactions.AssetFreezeTxnFields{}) {
+			reject = true
+		}
+		if reject {
+			return errors.New("assets not yet enabled")
+		}
+	}
+	if !proto.SupportTxGroups {
+		if s.Txn.Group != (crypto.Digest{}) {
+			return errors.New("txn groups not yet enabled")
+		}
+	}
+	if !proto.SupportTransactionLeases {
+		if s.Txn.Lease != ([32]byte{}) {
+			return errors.New("leases not yet enabled")
+		}
+	}
+
 	numSigs := 0
 	hasSig := false
 	hasMsig := false

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -467,23 +467,12 @@ func (eval *BlockEvaluator) transaction(txn transactions.SignedTxn, ad transacti
 			return TransactionInLedgerError{txn.ID()}
 		}
 
-		// Well-formed on its own?
-		err = txn.Txn.WellFormed(spec, eval.proto)
-		if err != nil {
-			return fmt.Errorf("transaction %v: malformed: %v", txn.ID(), err)
-		}
-
-		// Properly signed?
+		// Well-formed and signed properly?
 		if eval.txcache == nil || !eval.txcache.Verified(txn) {
 			err = verify.TxnPool(&txn, spec, eval.proto, eval.verificationPool)
 			if err != nil {
 				return fmt.Errorf("transaction %v: failed to verify: %v", txn.ID(), err)
 			}
-		}
-
-		// Verify that groups are supported.
-		if !txn.Txn.Group.IsZero() && !eval.proto.SupportTxGroups {
-			return fmt.Errorf("transaction groups not supported")
 		}
 
 		if !txn.Lsig.Blank() {

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -467,12 +467,23 @@ func (eval *BlockEvaluator) transaction(txn transactions.SignedTxn, ad transacti
 			return TransactionInLedgerError{txn.ID()}
 		}
 
-		// Well-formed and signed properly?
+		// Well-formed on its own?
+		err = txn.Txn.WellFormed(spec, eval.proto)
+		if err != nil {
+			return fmt.Errorf("transaction %v: malformed: %v", txn.ID(), err)
+		}
+
+		// Properly signed?
 		if eval.txcache == nil || !eval.txcache.Verified(txn) {
 			err = verify.TxnPool(&txn, spec, eval.proto, eval.verificationPool)
 			if err != nil {
 				return fmt.Errorf("transaction %v: failed to verify: %v", txn.ID(), err)
 			}
+		}
+
+		// Verify that groups are supported.
+		if !txn.Txn.Group.IsZero() && !eval.proto.SupportTxGroups {
+			return fmt.Errorf("transaction groups not supported")
 		}
 
 		if !txn.Lsig.Blank() {


### PR DESCRIPTION
Without this I believe there are similar partition issues to #387 if a user e.g. sends a transaction with an `LSig` prior to the protocol upgrade