### PR TITLE
Fix reward residue e2e test

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -427,6 +427,7 @@ func initConsensusProtocols() {
 	v19.MaxTxGroupSize = 16
 	v19.SupportTransactionLeases = true
 	v19.SupportBecomeNonParticipatingTransactions = true
+	Consensus[protocol.ConsensusV19] = v19
 
 	// v18 can be upgraded to v19.
 	v18.ApprovedUpgrades[protocol.ConsensusV19] = true

--- a/config/config.go
+++ b/config/config.go
@@ -413,22 +413,27 @@ func initConsensusProtocols() {
 	Consensus[protocol.ConsensusV18] = v18
 
 	// v17 can be upgraded to v18.
-	// for now, I will leave this gated out.
-	// v17.ApprovedUpgrades[protocol.ConsensusV18] = true
+	v17.ApprovedUpgrades[protocol.ConsensusV18] = true
+
+	v19 := v18
+	v19.ApprovedUpgrades = map[protocol.ConsensusVersion]bool{}
+	v19.TxnCounter = true
+	v19.Asset = true
+	v19.LogicSigVersion = 1
+	v19.LogicSigMaxSize = 1000
+	v19.LogicSigMaxCost = 20000
+	v19.MaxAssetsPerAccount = 1000
+	v19.SupportTxGroups = true
+	v19.MaxTxGroupSize = 16
+	v19.SupportTransactionLeases = true
+	v19.SupportBecomeNonParticipatingTransactions = true
+
+	// v18 can be upgraded to v19.
+	v18.ApprovedUpgrades[protocol.ConsensusV19] = true
 
 	// ConsensusFuture is used to test features that are implemented
 	// but not yet released in a production protocol version.
-	vFuture := v18
-	vFuture.TxnCounter = true
-	vFuture.Asset = true
-	vFuture.LogicSigVersion = 1
-	vFuture.LogicSigMaxSize = 1000
-	vFuture.LogicSigMaxCost = 20000
-	vFuture.MaxAssetsPerAccount = 1000
-	vFuture.SupportTxGroups = true
-	vFuture.MaxTxGroupSize = 16
-	vFuture.SupportTransactionLeases = true
-	vFuture.SupportBecomeNonParticipatingTransactions = true
+	vFuture := v19
 	vFuture.ApprovedUpgrades = map[protocol.ConsensusVersion]bool{}
 	Consensus[protocol.ConsensusFuture] = vFuture
 }

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -99,6 +99,11 @@ const ConsensusV18 = ConsensusVersion(
 	"https://github.com/algorandfoundation/specs/tree/6c6bd668be0ab14098e51b37e806c509f7b7e31f",
 )
 
+// ConsensusV19 needs to be updated with actual spec
+const ConsensusV19 = ConsensusVersion(
+	"next",
+)
+
 // ConsensusFuture is a protocol that should not appear in any production
 // network, but is used to test features before they are released.
 const ConsensusFuture = ConsensusVersion(
@@ -111,7 +116,7 @@ const ConsensusFuture = ConsensusVersion(
 
 // ConsensusCurrentVersion is the latest version and should be used
 // when a specific version is not provided.
-const ConsensusCurrentVersion = ConsensusV17
+const ConsensusCurrentVersion = ConsensusV19
 
 // ConsensusTest0 is a version of ConsensusV0 used for testing
 // (it has different approved upgrade paths).

--- a/test/e2e-go/features/participation/participationRewards_test.go
+++ b/test/e2e-go/features/participation/participationRewards_test.go
@@ -321,10 +321,16 @@ func TestRewardRateRecalculation(t *testing.T) {
 	if roundQueried != rewardRecalcRound-1 {
 		r.FailNow("got rewards pool balance on round %d but wanted the balance on round %d, failing out", rewardRecalcRound-1, roundQueried)
 	}
+	lastRoundBeforeRewardRecals, err := client.Block(rewardRecalcRound - 1)
+	r.NoError(err)
 	r.NoError(fixture.WaitForRoundWithTimeout(rewardRecalcRound))
 	blk, err = client.Block(rewardRecalcRound)
 	r.NoError(err)
-	r.Equal((balanceOfRewardsPool-minBal)/consensus.RewardsRateRefreshInterval, blk.RewardsRate)
+	if !consensus.PendingResidueRewards {
+		lastRoundBeforeRewardRecals.RewardsResidue = 0
+	}
+
+	r.Equalf((balanceOfRewardsPool-minBal-lastRoundBeforeRewardRecals.RewardsResidue)/consensus.RewardsRateRefreshInterval, blk.RewardsRate, "Mismatching (%d-%d-%d)/%d != %d @ round %d", balanceOfRewardsPool, minBal, lastRoundBeforeRewardRecals.RewardsResidue, consensus.RewardsRateRefreshInterval, blk.RewardsRate, lastRoundBeforeRewardRecals.Round)
 
 	curStatus, err = client.Status()
 	r.NoError(err)
@@ -338,10 +344,16 @@ func TestRewardRateRecalculation(t *testing.T) {
 	if roundQueried != rewardRecalcRound-1 {
 		r.FailNow("got rewards pool balance on round %d but wanted the balance on round %d, failing out", rewardRecalcRound-1, roundQueried)
 	}
+	lastRoundBeforeRewardRecals, err = client.Block(rewardRecalcRound - 1)
+	r.NoError(err)
+	consensus = config.Consensus[protocol.ConsensusVersion(lastRoundBeforeRewardRecals.CurrentProtocol)]
 	r.NoError(fixture.WaitForRoundWithTimeout(rewardRecalcRound))
 	blk, err = client.Block(rewardRecalcRound)
 	r.NoError(err)
-	r.Equal((balanceOfRewardsPool-minBal)/consensus.RewardsRateRefreshInterval, blk.RewardsRate)
+	if !consensus.PendingResidueRewards {
+		lastRoundBeforeRewardRecals.RewardsResidue = 0
+	}
+	r.Equal((balanceOfRewardsPool-minBal-lastRoundBeforeRewardRecals.RewardsResidue)/consensus.RewardsRateRefreshInterval, blk.RewardsRate)
 	// if the network keeps progressing without error,
 	// this shows the network is healthy and that we didn't panic
 	finalRound := rewardRecalcRound + uint64(5)


### PR DESCRIPTION
## Summary

The e2e unit test for the rewards residue fix would start failing once the fix would get enabled via a protocol upgrade. To prepare for that, I've updated the unit test so that it would work correctly on either scenarios.

