### PR TITLE
Fix reward residue e2e test

### DIFF
--- a/test/e2e-go/features/participation/participationRewards_test.go
+++ b/test/e2e-go/features/participation/participationRewards_test.go
@@ -321,10 +321,16 @@ func TestRewardRateRecalculation(t *testing.T) {
 	if roundQueried != rewardRecalcRound-1 {
 		r.FailNow("got rewards pool balance on round %d but wanted the balance on round %d, failing out", rewardRecalcRound-1, roundQueried)
 	}
+	lastRoundBeforeRewardRecals, err := client.Block(rewardRecalcRound - 1)
+	r.NoError(err)
 	r.NoError(fixture.WaitForRoundWithTimeout(rewardRecalcRound))
 	blk, err = client.Block(rewardRecalcRound)
 	r.NoError(err)
-	r.Equal((balanceOfRewardsPool-minBal)/consensus.RewardsRateRefreshInterval, blk.RewardsRate)
+	if !consensus.PendingResidueRewards {
+		lastRoundBeforeRewardRecals.RewardsResidue = 0
+	}
+
+	r.Equalf((balanceOfRewardsPool-minBal-lastRoundBeforeRewardRecals.RewardsResidue)/consensus.RewardsRateRefreshInterval, blk.RewardsRate, "Mismatching (%d-%d-%d)/%d != %d @ round %d", balanceOfRewardsPool, minBal, lastRoundBeforeRewardRecals.RewardsResidue, consensus.RewardsRateRefreshInterval, blk.RewardsRate, lastRoundBeforeRewardRecals.Round)
 
 	curStatus, err = client.Status()
 	r.NoError(err)
@@ -338,10 +344,16 @@ func TestRewardRateRecalculation(t *testing.T) {
 	if roundQueried != rewardRecalcRound-1 {
 		r.FailNow("got rewards pool balance on round %d but wanted the balance on round %d, failing out", rewardRecalcRound-1, roundQueried)
 	}
+	lastRoundBeforeRewardRecals, err = client.Block(rewardRecalcRound - 1)
+	r.NoError(err)
+	consensus = config.Consensus[protocol.ConsensusVersion(lastRoundBeforeRewardRecals.CurrentProtocol)]
 	r.NoError(fixture.WaitForRoundWithTimeout(rewardRecalcRound))
 	blk, err = client.Block(rewardRecalcRound)
 	r.NoError(err)
-	r.Equal((balanceOfRewardsPool-minBal)/consensus.RewardsRateRefreshInterval, blk.RewardsRate)
+	if !consensus.PendingResidueRewards {
+		lastRoundBeforeRewardRecals.RewardsResidue = 0
+	}
+	r.Equal((balanceOfRewardsPool-minBal-lastRoundBeforeRewardRecals.RewardsResidue)/consensus.RewardsRateRefreshInterval, blk.RewardsRate)
 	// if the network keeps progressing without error,
 	// this shows the network is healthy and that we didn't panic
 	finalRound := rewardRecalcRound + uint64(5)


### PR DESCRIPTION
## Summary

The e2e unit test for the rewards residue fix would start failing once the fix would get enabled via a protocol upgrade. To prepare for that, I've updated the unit test so that it would work correctly on either scenarios.
