### PR TITLE
Implement domain separation for LogicSig ed25519verify.

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -282,7 +282,7 @@ var sendCmd = &cobra.Command{
 			lsigFromArgs(&lsig)
 		}
 		if program != nil {
-			ph := transactions.HashProgram(program)
+			ph := logic.HashProgram(program)
 			pha := basics.Address(ph)
 			fromAddressResolved = pha.String()
 			programArgs = getProgramArgs()
@@ -823,7 +823,7 @@ var compileCmd = &cobra.Command{
 				}
 			}
 			if !signProgram {
-				pd := transactions.HashProgram(program)
+				pd := logic.HashProgram(program)
 				addr := basics.Address(pd)
 				fmt.Printf("%s: %s\n", fname, addr.String())
 			}

--- a/daemon/kmd/wallet/driver/sqlite.go
+++ b/daemon/kmd/wallet/driver/sqlite.go
@@ -33,6 +33,7 @@ import (
 	"github.com/algorand/go-algorand/daemon/kmd/config"
 	"github.com/algorand/go-algorand/daemon/kmd/wallet"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-codec/codec"
 )
@@ -1133,7 +1134,7 @@ func (sw *SQLiteWallet) SignProgram(data []byte, src crypto.Digest, pw []byte) (
 		return
 	}
 
-	progb := transactions.Program(data)
+	progb := logic.Program(data)
 	// Sign the transaction
 	sig := secrets.Sign(&progb)
 	stx = sig[:]
@@ -1267,7 +1268,7 @@ func (sw *SQLiteWallet) MultisigSignProgram(data []byte, src crypto.Digest, pk c
 
 		// Sign the transaction
 		from := src
-		progb := transactions.Program(data)
+		progb := logic.Program(data)
 		sig, err = crypto.MultisigSign(&progb, from, version, threshold, pks, *secrets)
 		return
 	}
@@ -1311,7 +1312,7 @@ func (sw *SQLiteWallet) MultisigSignProgram(data []byte, src crypto.Digest, pk c
 
 	// Sign the transaction, and merge the multisig into the partial
 	version, threshold, pks := partial.Preimage()
-	progb := transactions.Program(data)
+	progb := logic.Program(data)
 	msig2, err := crypto.MultisigSign(&progb, addr, version, threshold, pks, *secrets)
 	if err != nil {
 		return

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1154,16 +1154,16 @@ func opGlobal(cx *evalContext) {
 	cx.nextpc = cx.pc + 2
 }
 
-// LogicMsg is data meant to be signed and then verified
-// with the ed25519verify opcode.
-type LogicMsg struct {
+// Msg is data meant to be signed and then verified with the
+// ed25519verify opcode.
+type Msg struct {
 	_struct     struct{}      `codec:",omitempty,omitemptyarray"`
 	ProgramHash crypto.Digest `codec:"p"`
 	Data        []byte        `codec:"d"`
 }
 
 // ToBeHashed implements crypto.Hashable
-func (msg LogicMsg) ToBeHashed() (protocol.HashID, []byte) {
+func (msg Msg) ToBeHashed() (protocol.HashID, []byte) {
 	return protocol.ProgramData, append(msg.ProgramHash[:], msg.Data...)
 }
 
@@ -1186,7 +1186,7 @@ func opEd25519verify(cx *evalContext) {
 	}
 	copy(sig[:], cx.stack[prev].Bytes)
 
-	msg := LogicMsg{ProgramHash: cx.programHash, Data: cx.stack[pprev].Bytes}
+	msg := Msg{ProgramHash: cx.programHash, Data: cx.stack[pprev].Bytes}
 	if sv.Verify(msg, sig) {
 		cx.stack[pprev].Uint = 1
 	} else {

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -38,6 +38,7 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/protocol"
 )
 
 // EvalMaxVersion is the max version we can interpret and run
@@ -123,6 +124,8 @@ type evalContext struct {
 	// Ordered set of pc values that a branch could go to.
 	// If Check pc skips a target, the source branch was invalid!
 	branchTargets []int
+
+	programHash crypto.Digest
 }
 
 type opFunc func(cx *evalContext)
@@ -214,6 +217,7 @@ func Eval(program []byte, params EvalParams) (pass bool, err error) {
 	cx.EvalParams = params
 	cx.stack = make([]stackValue, 0, 10)
 	cx.program = program
+	cx.programHash = crypto.HashObj(Program(program))
 	for (cx.err == nil) && (cx.pc < len(cx.program)) {
 		cx.step()
 		cx.stepCount++
@@ -1150,6 +1154,19 @@ func opGlobal(cx *evalContext) {
 	cx.nextpc = cx.pc + 2
 }
 
+// LogicMsg is data meant to be signed and then verified
+// with the ed25519verify opcode.
+type LogicMsg struct {
+	_struct     struct{}      `codec:",omitempty,omitemptyarray"`
+	ProgramHash crypto.Digest `codec:"p"`
+	Data        []byte        `codec:"d"`
+}
+
+// ToBeHashed implements crypto.Hashable
+func (msg LogicMsg) ToBeHashed() (protocol.HashID, []byte) {
+	return protocol.ProgramData, append(msg.ProgramHash[:], msg.Data...)
+}
+
 func opEd25519verify(cx *evalContext) {
 	last := len(cx.stack) - 1 // index of PK
 	prev := last - 1          // index of signature
@@ -1169,7 +1186,8 @@ func opEd25519verify(cx *evalContext) {
 	}
 	copy(sig[:], cx.stack[prev].Bytes)
 
-	if sv.VerifyBytes(cx.stack[pprev].Bytes, sig) {
+	msg := LogicMsg{ProgramHash: cx.programHash, Data: cx.stack[pprev].Bytes}
+	if sv.Verify(msg, sig) {
 		cx.stack[pprev].Uint = 1
 	} else {
 		cx.stack[pprev].Uint = 0

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -2130,7 +2130,10 @@ arg 1
 addr %s
 ed25519verify`, pkStr))
 	require.NoError(t, err)
-	sig := c.SignBytes(data[:])
+	sig := c.Sign(LogicMsg{
+		ProgramHash: crypto.HashObj(Program(program)),
+		Data:        data[:],
+	})
 	var txn transactions.SignedTxn
 	txn.Lsig.Logic = program
 	txn.Lsig.Args = [][]byte{data[:], sig[:]}

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -2130,7 +2130,7 @@ arg 1
 addr %s
 ed25519verify`, pkStr))
 	require.NoError(t, err)
-	sig := c.Sign(LogicMsg{
+	sig := c.Sign(Msg{
 		ProgramHash: crypto.HashObj(Program(program)),
 		Data:        data[:],
 	})

--- a/data/transactions/logic/program.go
+++ b/data/transactions/logic/program.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
 
-package transactions
+package logic
 
 import (
 	"github.com/algorand/go-algorand/crypto"

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -172,7 +172,7 @@ func LogicSig(lsig *transactions.LogicSig, proto *config.ConsensusParams, stxn *
 	}
 	if numSigs == 0 {
 		// if the txn.Sender == hash(Logic) then this is a (potentially) valid operation on a contract-only account
-		program := transactions.Program(lsig.Logic)
+		program := logic.Program(lsig.Logic)
 		lhash := crypto.HashObj(&program)
 		if crypto.Digest(stxn.Txn.Sender) == lhash {
 			return nil
@@ -184,14 +184,14 @@ func LogicSig(lsig *transactions.LogicSig, proto *config.ConsensusParams, stxn *
 	}
 
 	if hasSig {
-		program := transactions.Program(lsig.Logic)
+		program := logic.Program(lsig.Logic)
 		if crypto.SignatureVerifier(stxn.Txn.Src()).Verify(&program, lsig.Sig) {
 			return nil
 		}
 		return errors.New("logic signature validation failed")
 	}
 	if hasMsig {
-		program := transactions.Program(lsig.Logic)
+		program := logic.Program(lsig.Logic)
 		if ok, _ := crypto.MultisigVerify(&program, crypto.Digest(stxn.Txn.Src()), lsig.Msig); ok {
 			return nil
 		}

--- a/protocol/hash.go
+++ b/protocol/hash.go
@@ -40,6 +40,7 @@ const (
 	PaysetFlat        HashID = "PF"
 	Payload           HashID = "PL"
 	Program           HashID = "Program"
+	ProgramData       HashID = "ProgData"
 	ProposerSeed      HashID = "PS"
 	Seed              HashID = "SD"
 	TestHashable      HashID = "TE"

--- a/test/e2e-go/kmd/e2e_kmd_wallet_keyops_test.go
+++ b/test/e2e-go/kmd/e2e_kmd_wallet_keyops_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/framework/fixtures"
 )
@@ -353,7 +354,7 @@ func TestSignProgram(t *testing.T) {
 	copy(sig[:], resp1.Signature)
 	require.NotEqual(t, sig, crypto.Signature{})
 
-	ph := transactions.Program(program)
+	ph := logic.Program(program)
 	require.True(t, secrets.SignatureVerifier.Verify(ph, sig))
 }
 

--- a/test/e2e-go/kmd/e2e_kmd_wallet_multisig_test.go
+++ b/test/e2e-go/kmd/e2e_kmd_wallet_multisig_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/framework/fixtures"
 )
@@ -278,7 +279,7 @@ func TestMultisigSignProgram(t *testing.T) {
 	err = protocol.Decode(resp3.Multisig, &msig)
 	require.NoError(t, err)
 
-	ok, err := crypto.MultisigVerify(transactions.Program(program), crypto.Digest(msigAddr), msig)
+	ok, err := crypto.MultisigVerify(logic.Program(program), crypto.Digest(msigAddr), msig)
 	require.NoError(t, err)
 	require.True(t, ok)
 }


### PR DESCRIPTION
Arguments passed to ed25519verify are now domain-separated with the
constant string "ProgData" and the hash of the running program.