### PR TITLE
Stricter logic sig check

### DIFF
--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -198,7 +198,7 @@ func Eval(program []byte, params EvalParams) (pass bool, err error) {
 		err = errLogicSignNotSupported
 		return
 	}
-	if len(params.Txn.Lsig.Args) > EvalMaxArgs {
+	if params.Txn.Lsig.Args != nil && len(params.Txn.Lsig.Args) > EvalMaxArgs {
 		err = errTooManyArgs
 		return
 	}
@@ -232,7 +232,7 @@ func Eval(program []byte, params EvalParams) (pass bool, err error) {
 		if cx.stepCount > len(cx.program) {
 			return false, errLoopDetected
 		}
-		if params.Proto == nil || uint64(cx.cost) > params.Proto.LogicSigMaxCost {
+		if uint64(cx.cost) > params.Proto.LogicSigMaxCost {
 			return false, errCostTooHigh
 		}
 	}

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -44,6 +44,9 @@ import (
 // EvalMaxVersion is the max version we can interpret and run
 const EvalMaxVersion = 1
 
+// EvalMaxArgs is the maximum number of arguments to an LSig
+const EvalMaxArgs = 255
+
 // stackValue is the type for the operand stack.
 // Each stackValue is either a valid []byte value or a uint64 value.
 // If (.Bytes != nil) the stackValue is a []byte value, otherwise uint64 value.
@@ -172,6 +175,7 @@ func (pe PanicError) Error() string {
 var errLoopDetected = errors.New("loop detected")
 var errCostTooHigh = errors.New("LogicSigMaxCost exceded")
 var errLogicSignNotSupported = errors.New("LogicSig not supported")
+var errTooManyArgs = errors.New("LogicSig has too many arguments")
 
 // Eval checks to see if a transaction passes logic
 // A program passes succesfully if it finishes with one int element on the stack that is non-zero.
@@ -190,8 +194,12 @@ func Eval(program []byte, params EvalParams) (pass bool, err error) {
 			err = PanicError{x, errstr}
 		}
 	}()
-	if (params.Proto != nil) && (params.Proto.LogicSigVersion == 0) {
+	if (params.Proto == nil) || (params.Proto.LogicSigVersion == 0) {
 		err = errLogicSignNotSupported
+		return
+	}
+	if len(params.Txn.Lsig.Args) > EvalMaxArgs {
+		err = errTooManyArgs
 		return
 	}
 	var cx evalContext

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -212,7 +212,7 @@ func Eval(program []byte, params EvalParams) (pass bool, err error) {
 		cx.err = fmt.Errorf("program version %d greater than max supported version %d", version, EvalMaxVersion)
 		return false, cx.err
 	}
-	if (params.Proto == nil) || (version > params.Proto.LogicSigVersion) {
+	if version > params.Proto.LogicSigVersion {
 		cx.err = fmt.Errorf("program version %d greater than protocol supported version %d", version, params.Proto.LogicSigVersion)
 		return false, cx.err
 	}
@@ -288,7 +288,7 @@ func Check(program []byte, params EvalParams) (cost int, err error) {
 		err = fmt.Errorf("program version %d greater than max supported version %d", version, EvalMaxVersion)
 		return
 	}
-	if (params.Proto == nil) || (version > params.Proto.LogicSigVersion) {
+	if version > params.Proto.LogicSigVersion {
 		err = fmt.Errorf("program version %d greater than protocol supported version %d", version, params.Proto.LogicSigVersion)
 		return
 	}

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -212,7 +212,7 @@ func Eval(program []byte, params EvalParams) (pass bool, err error) {
 		cx.err = fmt.Errorf("program version %d greater than max supported version %d", version, EvalMaxVersion)
 		return false, cx.err
 	}
-	if (params.Proto != nil) && (version > params.Proto.LogicSigVersion) {
+	if (params.Proto == nil) || (version > params.Proto.LogicSigVersion) {
 		cx.err = fmt.Errorf("program version %d greater than protocol supported version %d", version, params.Proto.LogicSigVersion)
 		return false, cx.err
 	}
@@ -232,7 +232,7 @@ func Eval(program []byte, params EvalParams) (pass bool, err error) {
 		if cx.stepCount > len(cx.program) {
 			return false, errLoopDetected
 		}
-		if params.Proto != nil && uint64(cx.cost) > params.Proto.LogicSigMaxCost {
+		if params.Proto == nil || uint64(cx.cost) > params.Proto.LogicSigMaxCost {
 			return false, errCostTooHigh
 		}
 	}
@@ -274,7 +274,7 @@ func Check(program []byte, params EvalParams) (cost int, err error) {
 			err = PanicError{x, errstr}
 		}
 	}()
-	if (params.Proto != nil) && (params.Proto.LogicSigVersion == 0) {
+	if (params.Proto == nil) || (params.Proto.LogicSigVersion == 0) {
 		err = errLogicSignNotSupported
 		return
 	}
@@ -288,7 +288,7 @@ func Check(program []byte, params EvalParams) (cost int, err error) {
 		err = fmt.Errorf("program version %d greater than max supported version %d", version, EvalMaxVersion)
 		return
 	}
-	if (params.Proto != nil) && (version > params.Proto.LogicSigVersion) {
+	if (params.Proto == nil) || (version > params.Proto.LogicSigVersion) {
 		err = fmt.Errorf("program version %d greater than protocol supported version %d", version, params.Proto.LogicSigVersion)
 		return
 	}

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -35,6 +35,9 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 )
 
+var defaultEvalProto = config.ConsensusParams{LogicSigVersion: 1, LogicSigMaxCost: 20000}
+var defaultEvalParams = EvalParams{Proto: &defaultEvalProto, Trace: &strings.Builder{}, Txn: &transactions.SignedTxn{}}
+
 func TestTrivialMath(t *testing.T) {
 	t.Parallel()
 	program, err := AssembleString(`int 2
@@ -43,10 +46,10 @@ int 3
 int 5
 ==`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	pass, err := Eval(program, defaultEvalParams)
 	require.True(t, pass)
 	require.NoError(t, err)
 }
@@ -62,7 +65,7 @@ byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
 	txn.Lsig.Logic = program
 	txn.Lsig.Args = [][]byte{[]byte("=0\x97S\x85H\xe9\x91B\xfd\xdb;1\xf5Z\xaec?\xae\xf2I\x93\x08\x12\x94\xaa~\x06\x08\x849b")}
 	sb := strings.Builder{}
-	ep := EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb}
+	ep := EvalParams{Proto: &defaultEvalProto, Txn: &txn, Trace: &sb}
 	cost, err := Check(program, ep)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
@@ -119,7 +122,7 @@ func TestTLHC(t *testing.T) {
 	sb := strings.Builder{}
 	block := bookkeeping.Block{}
 	block.BlockHeader.Round = 999999
-	ep := EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb, Block: &block}
+	ep := EvalParams{Proto: &defaultEvalProto, Txn: &txn, Trace: &sb, Block: &block}
 	cost, err := Check(program, ep)
 	if err != nil {
 		t.Log(hex.EncodeToString(program))
@@ -138,7 +141,7 @@ func TestTLHC(t *testing.T) {
 	txn.Txn.Receiver = a2
 	txn.Txn.CloseRemainderTo = a2
 	sb = strings.Builder{}
-	ep = EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb, Block: &block}
+	ep = EvalParams{Proto: &defaultEvalProto, Txn: &txn, Trace: &sb, Block: &block}
 	pass, err = Eval(program, ep)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
@@ -151,7 +154,7 @@ func TestTLHC(t *testing.T) {
 	txn.Txn.CloseRemainderTo = a2
 	sb = strings.Builder{}
 	block.BlockHeader.Round = 1
-	ep = EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb, Block: &block}
+	ep = EvalParams{Proto: &defaultEvalProto, Txn: &txn, Trace: &sb, Block: &block}
 	pass, err = Eval(program, ep)
 	if pass {
 		t.Log(hex.EncodeToString(program))
@@ -164,7 +167,7 @@ func TestTLHC(t *testing.T) {
 	txn.Txn.CloseRemainderTo = a1
 	sb = strings.Builder{}
 	block.BlockHeader.Round = 999999
-	ep = EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb, Block: &block}
+	ep = EvalParams{Proto: &defaultEvalProto, Txn: &txn, Trace: &sb, Block: &block}
 	pass, err = Eval(program, ep)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
@@ -177,7 +180,7 @@ func TestTLHC(t *testing.T) {
 	txn.Lsig.Args = [][]byte{[]byte("=0\x97S\x85H\xe9\x91B\xfd\xdb;1\xf5Z\xaec?\xae\xf2I\x93\x08\x12\x94\xaa~\x06\x08\x849a")}
 	sb = strings.Builder{}
 	block.BlockHeader.Round = 1
-	ep = EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb, Block: &block}
+	ep = EvalParams{Proto: &defaultEvalProto, Txn: &txn, Trace: &sb, Block: &block}
 	pass, err = Eval(program, ep)
 	if pass {
 		t.Log(hex.EncodeToString(program))
@@ -196,7 +199,7 @@ int 0x12345678
 ==`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -248,7 +251,7 @@ btoi
 		txn.Lsig.Args[i] = make([]byte, 8)
 		binary.BigEndian.PutUint64(txn.Lsig.Args[i], v)
 	}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1},
+	pass, err := Eval(program, EvalParams{Proto: &defaultEvalProto,
 		Txn:      &txn,
 		Trace:    &sb,
 		Seed:     []byte(benchSeed),
@@ -270,7 +273,7 @@ itob
 ==`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -287,7 +290,7 @@ btoi
 ==`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -304,7 +307,7 @@ btoi
 ==`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -324,11 +327,11 @@ safe:
 int 1
 +`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -345,11 +348,11 @@ int 0x100000000
 pop
 int 1`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -367,11 +370,11 @@ int 0x1111111111111111
 pop
 int 1`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -389,11 +392,11 @@ int 0x222222222
 pop
 int 1`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -445,11 +448,11 @@ done:
 int 1                   // ret 1
 `)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -467,14 +470,14 @@ pop
 int 1`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	cost, err := Check(program, defaultEvalParams)
 	if err != nil {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
 	}
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -492,11 +495,11 @@ int 0
 pop
 int 1`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -511,11 +514,11 @@ func TestErr(t *testing.T) {
 	program, err := AssembleString(`err
 int 1`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -537,11 +540,11 @@ int 2
 int 4
 ==`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -557,11 +560,11 @@ int 0
 pop`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb = strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -576,11 +579,11 @@ func TestStackLeftover(t *testing.T) {
 int 1`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	cost, err := Check(program, defaultEvalParams)
 	require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb = strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -595,11 +598,11 @@ func TestStackBytesLeftover(t *testing.T) {
 	program, err := AssembleString(`byte 0x10101010`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	cost, err := Check(program, defaultEvalParams)
 	require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb = strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -616,11 +619,11 @@ int 1
 pop
 pop`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -635,14 +638,14 @@ func TestArgTooFar(t *testing.T) {
 	program, err := AssembleString(`arg_1
 btoi`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	//require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
 	var txn transactions.SignedTxn
 	txn.Lsig.Logic = program
 	txn.Lsig.Args = nil
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn})
+	pass, err := Eval(program, EvalParams{Proto: &defaultEvalProto, Trace: &sb, Txn: &txn})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -656,14 +659,14 @@ func TestIntcTooFar(t *testing.T) {
 	t.Parallel()
 	program, err := AssembleString(`intc_1`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	//require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
 	var txn transactions.SignedTxn
 	txn.Lsig.Logic = program
 	txn.Lsig.Args = nil
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn})
+	pass, err := Eval(program, EvalParams{Proto: &defaultEvalProto, Trace: &sb, Txn: &txn})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -678,14 +681,14 @@ func TestBytecTooFar(t *testing.T) {
 	program, err := AssembleString(`bytec_1
 btoi`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	//require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
 	var txn transactions.SignedTxn
 	txn.Lsig.Logic = program
 	txn.Lsig.Args = nil
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn})
+	pass, err := Eval(program, EvalParams{Proto: &defaultEvalProto, Trace: &sb, Txn: &txn})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -698,14 +701,14 @@ btoi`)
 func TestTxnBadField(t *testing.T) {
 	t.Parallel()
 	program := []byte{0x01, 0x31, 0x7f}
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	//require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
 	var txn transactions.SignedTxn
 	txn.Lsig.Logic = program
 	txn.Lsig.Args = nil
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn})
+	pass, err := Eval(program, EvalParams{Proto: &defaultEvalProto, Trace: &sb, Txn: &txn})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -718,7 +721,7 @@ func TestTxnBadField(t *testing.T) {
 func TestGtxnBadIndex(t *testing.T) {
 	t.Parallel()
 	program := []byte{0x01, 0x33, 0x1, 0x01}
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	//require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
@@ -727,7 +730,7 @@ func TestGtxnBadIndex(t *testing.T) {
 	txn.Lsig.Args = nil
 	txgroup := make([]transactions.SignedTxnWithAD, 1)
 	txgroup[0].SignedTxn = txn
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn, TxnGroup: txgroup})
+	pass, err := Eval(program, EvalParams{Proto: &defaultEvalProto, Trace: &sb, Txn: &txn, TxnGroup: txgroup})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -740,7 +743,7 @@ func TestGtxnBadIndex(t *testing.T) {
 func TestGtxnBadField(t *testing.T) {
 	t.Parallel()
 	program := []byte{0x01, 0x33, 0x0, 0x7f}
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	//require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
@@ -749,7 +752,7 @@ func TestGtxnBadField(t *testing.T) {
 	txn.Lsig.Args = nil
 	txgroup := make([]transactions.SignedTxnWithAD, 1)
 	txgroup[0].SignedTxn = txn
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn, TxnGroup: txgroup})
+	pass, err := Eval(program, EvalParams{Proto: &defaultEvalProto, Trace: &sb, Txn: &txn, TxnGroup: txgroup})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -762,14 +765,14 @@ func TestGtxnBadField(t *testing.T) {
 func TestGlobalBadField(t *testing.T) {
 	t.Parallel()
 	program := []byte{0x01, 0x32, 0x7f}
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	//require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
 	var txn transactions.SignedTxn
 	txn.Lsig.Logic = program
 	txn.Lsig.Args = nil
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn})
+	pass, err := Eval(program, EvalParams{Proto: &defaultEvalProto, Trace: &sb, Txn: &txn})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -794,7 +797,7 @@ int 9
 <
 &&`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	var txn transactions.SignedTxn
@@ -807,7 +810,7 @@ int 9
 		[]byte("aoeu4"),
 	}
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn})
+	pass, err := Eval(program, EvalParams{Proto: &defaultEvalProto, Trace: &sb, Txn: &txn})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -853,7 +856,7 @@ func TestGlobal(t *testing.T) {
 	}
 	program, err := AssembleString(globalTestProgram)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	var txn transactions.SignedTxn
@@ -992,7 +995,7 @@ func TestTxn(t *testing.T) {
 	}
 	program, err := AssembleString(testTxnProgramText)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	var txn transactions.SignedTxn
@@ -1035,7 +1038,7 @@ func TestTxn(t *testing.T) {
 	recs := make([]basics.BalanceRecord, 4)
 	recs[3].MicroAlgos.Raw = 4160
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn, GroupSenders: recs, GroupIndex: 3})
+	pass, err := Eval(program, EvalParams{Proto: &defaultEvalProto, Trace: &sb, Txn: &txn, GroupSenders: recs, GroupIndex: 3})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1099,7 +1102,7 @@ int 2
 &&`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	cost, err := Check(program, defaultEvalParams)
 	if err != nil {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1138,7 +1141,7 @@ int 2
 		txn.Txn.Note,
 	}
 	sb = strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn, TxnGroup: txgroup})
+	pass, err := Eval(program, EvalParams{Proto: &defaultEvalProto, Trace: &sb, Txn: &txn, TxnGroup: txgroup})
 	if !pass || err != nil {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1162,11 +1165,11 @@ int 0x300
 int 0x310
 ==`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1189,11 +1192,11 @@ byte 0xabbacafe
 load 0
 &&`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1266,11 +1269,11 @@ func TestCompares(t *testing.T) {
 	t.Parallel()
 	program, err := AssembleString(testCompareProgramText)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1292,11 +1295,11 @@ keccak256
 byte 0xc195eca25a6f4c82bfba0287082ddb0d602ae9230f9cf1f1a40b68f8e2c41567
 ==`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1322,11 +1325,11 @@ sha512_256
 byte 0x98D2C31612EA500279B6753E5F6E780CA63EBA8274049664DAD66A2565ED1D2A
 ==`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1349,11 +1352,11 @@ func TestStackUnderflow(t *testing.T) {
 	program, err := AssembleString(`int 1`)
 	program = append(program, 0x08) // +
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.Error(t, err) // Check should know the type stack was wrong
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1367,11 +1370,11 @@ func TestWrongStackTypeRuntime(t *testing.T) {
 	program, err := AssembleString(`int 1`)
 	require.NoError(t, err)
 	program = append(program, 0x01, 0x15) // sha256, len
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.Error(t, err) // Check should know the type stack was wrong
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1386,11 +1389,11 @@ func TestEqMismatch(t *testing.T) {
 int 1`)
 	require.NoError(t, err)
 	program = append(program, 0x12) // ==
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	//require.Error(t, err) // Check should know the type stack was wrong
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1405,11 +1408,11 @@ func TestNeqMismatch(t *testing.T) {
 int 1`)
 	require.NoError(t, err)
 	program = append(program, 0x13) // !=
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	//require.Error(t, err) // Check should know the type stack was wrong
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1424,11 +1427,11 @@ func TestWrongStackTypeRuntime2(t *testing.T) {
 int 1`)
 	require.NoError(t, err)
 	program = append(program, 0x08) // +
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.Error(t, err) // Check should know the type stack was wrong
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, _ := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, _ := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1447,11 +1450,11 @@ func TestIllegalOp(t *testing.T) {
 			break
 		}
 	}
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1467,11 +1470,11 @@ bnz done
 done:`)
 	require.NoError(t, err)
 	program = program[:len(program)-1]
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1488,12 +1491,12 @@ func TestShortBytecblock(t *testing.T) {
 	for i := 2; i < len(fullprogram); i++ {
 		program := fullprogram[:i]
 		t.Run(hex.EncodeToString(program), func(t *testing.T) {
-			cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+			cost, err := Check(program, defaultEvalParams)
 			require.Error(t, err)
 			isNotPanic(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+			pass, err := Eval(program, defaultEvalParams)
 			if pass {
 				t.Log(hex.EncodeToString(program))
 				t.Log(sb.String())
@@ -1515,12 +1518,12 @@ func TestShortBytecblock2(t *testing.T) {
 		t.Run(src, func(t *testing.T) {
 			program, err := hex.DecodeString(src)
 			require.NoError(t, err)
-			cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+			cost, err := Check(program, defaultEvalParams)
 			require.Error(t, err)
 			isNotPanic(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+			pass, err := Eval(program, defaultEvalParams)
 			if pass {
 				t.Log(hex.EncodeToString(program))
 				t.Log(sb.String())
@@ -1558,7 +1561,7 @@ func TestPanic(t *testing.T) {
 		}
 	}
 	sb := strings.Builder{}
-	_, err = Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	_, err = Check(program, defaultEvalParams)
 	require.Error(t, err)
 	if pe, ok := err.(PanicError); ok {
 		require.Equal(t, panicString, pe.PanicValue)
@@ -1568,7 +1571,7 @@ func TestPanic(t *testing.T) {
 		t.Errorf("expected PanicError object but got %T %#v", err, err)
 	}
 	sb = strings.Builder{}
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
+	pass, err := Eval(program, defaultEvalParams)
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1589,10 +1592,10 @@ func TestProgramTooNew(t *testing.T) {
 	t.Parallel()
 	var program [12]byte
 	vlen := binary.PutUvarint(program[:], EvalMaxVersion+1)
-	_, err := Check(program[:vlen], EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	_, err := Check(program[:vlen], defaultEvalParams)
 	require.Error(t, err)
 	isNotPanic(t, err)
-	pass, err := Eval(program[:vlen], EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	pass, err := Eval(program[:vlen], defaultEvalParams)
 	require.Error(t, err)
 	require.False(t, pass)
 	isNotPanic(t, err)
@@ -1602,10 +1605,10 @@ func TestInvalidVersion(t *testing.T) {
 	t.Parallel()
 	program, err := hex.DecodeString("ffffffffffffffffffffffff")
 	require.NoError(t, err)
-	_, err = Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	_, err = Check(program, defaultEvalParams)
 	require.Error(t, err)
 	isNotPanic(t, err)
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	pass, err := Eval(program, defaultEvalParams)
 	require.Error(t, err)
 	require.False(t, pass)
 	isNotPanic(t, err)
@@ -1639,10 +1642,10 @@ int 1`)
 	require.NoError(t, err)
 	require.Equal(t, program, canonicalProgramBytes)
 	program[7] = 3 // clobber the branch offset to be in the middle of the bytecblock
-	_, err = Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	_, err = Check(program, defaultEvalParams)
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "aligned"))
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	pass, err := Eval(program, defaultEvalParams)
 	require.Error(t, err)
 	require.False(t, pass)
 	isNotPanic(t, err)
@@ -1661,10 +1664,10 @@ int 1`)
 	require.NoError(t, err)
 	require.Equal(t, program, canonicalProgramBytes)
 	program[7] = 200 // clobber the branch offset to be beyond the end of the program
-	_, err = Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	_, err = Check(program, defaultEvalParams)
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "beyond end of program"))
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	pass, err := Eval(program, defaultEvalParams)
 	require.Error(t, err)
 	require.False(t, pass)
 	isNotPanic(t, err)
@@ -1683,10 +1686,10 @@ int 1`)
 	require.NoError(t, err)
 	require.Equal(t, program, canonicalProgramBytes)
 	program[6] = 0xff // clobber the branch offset
-	_, err = Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	_, err = Check(program, defaultEvalParams)
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "too large"))
-	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	pass, err := Eval(program, defaultEvalParams)
 	require.Error(t, err)
 	require.False(t, pass)
 	isNotPanic(t, err)
@@ -1704,10 +1707,10 @@ txn SenderBalance
 	require.NoError(t, err)
 	require.Equal(t, program, canonicalProgramBytes)
 
-	_, err = Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	_, err = Check(program, defaultEvalParams)
 	require.NoError(t, err)
 
-	params := EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, GroupSenders: make([]basics.BalanceRecord, 1), Txn: new(transactions.SignedTxn)}
+	params := EvalParams{Proto: &defaultEvalProto, GroupSenders: make([]basics.BalanceRecord, 1), Txn: new(transactions.SignedTxn)}
 	params.GroupSenders[0].MicroAlgos.Raw = bal
 	pass, err := Eval(program, params)
 	require.NoError(t, err)
@@ -1999,7 +2002,7 @@ int 142791994204213819
 func benchmarkBasicProgram(b *testing.B, source string) {
 	program, err := AssembleString(source)
 	require.NoError(b, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(b, err)
 	require.True(b, cost < 2000)
 	//b.Logf("%d bytes of program", len(program))
@@ -2007,7 +2010,7 @@ func benchmarkBasicProgram(b *testing.B, source string) {
 	b.ResetTimer()
 	sb := strings.Builder{} // Trace: &sb
 	for i := 0; i < b.N; i++ {
-		pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Seed: []byte(benchSeed), MoreSeed: []byte(benchMore)})
+		pass, err := Eval(program, EvalParams{Proto: &defaultEvalProto, Seed: []byte(benchSeed), MoreSeed: []byte(benchMore)})
 		if !pass {
 			b.Log(sb.String())
 		}
@@ -2024,7 +2027,7 @@ func benchmarkBasicProgram(b *testing.B, source string) {
 func benchmarkExpensiveProgram(b *testing.B, source string) {
 	program, err := AssembleString(source)
 	require.NoError(b, err)
-	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+	cost, err := Check(program, defaultEvalParams)
 	require.NoError(b, err)
 	require.True(b, cost > 1000)
 	//b.Logf("%d bytes of program", len(program))
@@ -2032,7 +2035,7 @@ func benchmarkExpensiveProgram(b *testing.B, source string) {
 	b.ResetTimer()
 	sb := strings.Builder{} // Trace: &sb
 	for i := 0; i < b.N; i++ {
-		pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+		pass, err := Eval(program, defaultEvalParams)
 		if !pass {
 			b.Log(sb.String())
 		}
@@ -2138,7 +2141,7 @@ ed25519verify`, pkStr))
 	txn.Lsig.Logic = program
 	txn.Lsig.Args = [][]byte{data[:], sig[:]}
 	sb := strings.Builder{}
-	ep := EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb}
+	ep := EvalParams{Proto: &defaultEvalProto, Txn: &txn, Trace: &sb}
 	pass, err := Eval(program, ep)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
@@ -2149,7 +2152,7 @@ ed25519verify`, pkStr))
 
 	// short sig will fail
 	txn.Lsig.Args[1] = sig[1:]
-	pass, err = Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn})
+	pass, err = Eval(program, EvalParams{Proto: &defaultEvalProto, Txn: &txn})
 	require.False(t, pass)
 	require.Error(t, err)
 	isNotPanic(t, err)
@@ -2160,7 +2163,7 @@ ed25519verify`, pkStr))
 	require.NoError(t, err)
 	txn.Lsig.Args = [][]byte{data1, sig[:]}
 	sb1 := strings.Builder{}
-	ep1 := EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb1}
+	ep1 := EvalParams{Proto: &defaultEvalProto, Txn: &txn, Trace: &sb1}
 	pass1, err := Eval(program, ep1)
 	require.False(t, pass1)
 	require.NoError(t, err)
@@ -2199,7 +2202,7 @@ ed25519verify`, pkStr))
 		txn.Lsig.Logic = programs[i]
 		txn.Lsig.Args = [][]byte{data[i][:], signatures[i][:]}
 		sb := strings.Builder{}
-		ep := EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb}
+		ep := EvalParams{Proto: &defaultEvalProto, Txn: &txn, Trace: &sb}
 		pass, err := Eval(programs[i], ep)
 		if !pass {
 			b.Log(hex.EncodeToString(programs[i]))
@@ -2232,7 +2235,7 @@ func BenchmarkCheckx5(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, program := range programs {
-			_, err = Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
+			_, err = Check(program, defaultEvalParams)
 			if err != nil {
 				require.NoError(b, err)
 			}

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -44,6 +44,35 @@ func defaultEvalParams() EvalParams {
 	return EvalParams{Proto: &proto, Trace: &strings.Builder{}, Txn: &transactions.SignedTxn{}}
 }
 
+func TestTooManyArgs(t *testing.T) {
+	t.Parallel()
+	program, err := AssembleString(`int 1`)
+	require.NoError(t, err)
+	var txn transactions.SignedTxn
+	txn.Lsig.Logic = program
+	args := [EvalMaxArgs+1][]byte{}
+	txn.Lsig.Args = args[:]
+	sb := strings.Builder{}
+	proto := defaultEvalProto()
+	pass, err := Eval(program, EvalParams{Proto: &proto, Trace: &sb, Txn: &txn})
+	require.Error(t, err)
+	require.False(t, pass)
+}
+
+func TestWrongProtoVersion(t *testing.T) {
+	t.Parallel()
+	program, err := AssembleString(`int 1`)
+	require.NoError(t, err)
+	var txn transactions.SignedTxn
+	txn.Lsig.Logic = program
+	sb := strings.Builder{}
+	proto := defaultEvalProto()
+	proto.LogicSigVersion = 0
+	pass, err := Eval(program, EvalParams{Proto: &proto, Trace: &sb, Txn: &txn})
+	require.Error(t, err)
+	require.False(t, pass)
+}
+
 func TestTrivialMath(t *testing.T) {
 	t.Parallel()
 	program, err := AssembleString(`int 2

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -43,10 +43,10 @@ int 3
 int 5
 ==`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
-	pass, err := Eval(program, EvalParams{})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.True(t, pass)
 	require.NoError(t, err)
 }
@@ -62,7 +62,7 @@ byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
 	txn.Lsig.Logic = program
 	txn.Lsig.Args = [][]byte{[]byte("=0\x97S\x85H\xe9\x91B\xfd\xdb;1\xf5Z\xaec?\xae\xf2I\x93\x08\x12\x94\xaa~\x06\x08\x849b")}
 	sb := strings.Builder{}
-	ep := EvalParams{Txn: &txn, Trace: &sb}
+	ep := EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb}
 	cost, err := Check(program, ep)
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
@@ -119,7 +119,7 @@ func TestTLHC(t *testing.T) {
 	sb := strings.Builder{}
 	block := bookkeeping.Block{}
 	block.BlockHeader.Round = 999999
-	ep := EvalParams{Txn: &txn, Trace: &sb, Block: &block}
+	ep := EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb, Block: &block}
 	cost, err := Check(program, ep)
 	if err != nil {
 		t.Log(hex.EncodeToString(program))
@@ -138,7 +138,7 @@ func TestTLHC(t *testing.T) {
 	txn.Txn.Receiver = a2
 	txn.Txn.CloseRemainderTo = a2
 	sb = strings.Builder{}
-	ep = EvalParams{Txn: &txn, Trace: &sb, Block: &block}
+	ep = EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb, Block: &block}
 	pass, err = Eval(program, ep)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
@@ -151,7 +151,7 @@ func TestTLHC(t *testing.T) {
 	txn.Txn.CloseRemainderTo = a2
 	sb = strings.Builder{}
 	block.BlockHeader.Round = 1
-	ep = EvalParams{Txn: &txn, Trace: &sb, Block: &block}
+	ep = EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb, Block: &block}
 	pass, err = Eval(program, ep)
 	if pass {
 		t.Log(hex.EncodeToString(program))
@@ -164,7 +164,7 @@ func TestTLHC(t *testing.T) {
 	txn.Txn.CloseRemainderTo = a1
 	sb = strings.Builder{}
 	block.BlockHeader.Round = 999999
-	ep = EvalParams{Txn: &txn, Trace: &sb, Block: &block}
+	ep = EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb, Block: &block}
 	pass, err = Eval(program, ep)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
@@ -177,7 +177,7 @@ func TestTLHC(t *testing.T) {
 	txn.Lsig.Args = [][]byte{[]byte("=0\x97S\x85H\xe9\x91B\xfd\xdb;1\xf5Z\xaec?\xae\xf2I\x93\x08\x12\x94\xaa~\x06\x08\x849a")}
 	sb = strings.Builder{}
 	block.BlockHeader.Round = 1
-	ep = EvalParams{Txn: &txn, Trace: &sb, Block: &block}
+	ep = EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb, Block: &block}
 	pass, err = Eval(program, ep)
 	if pass {
 		t.Log(hex.EncodeToString(program))
@@ -196,7 +196,7 @@ int 0x12345678
 ==`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -248,7 +248,7 @@ btoi
 		txn.Lsig.Args[i] = make([]byte, 8)
 		binary.BigEndian.PutUint64(txn.Lsig.Args[i], v)
 	}
-	pass, err := Eval(program, EvalParams{
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1},
 		Txn:      &txn,
 		Trace:    &sb,
 		Seed:     []byte(benchSeed),
@@ -270,7 +270,7 @@ itob
 ==`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -287,7 +287,7 @@ btoi
 ==`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -304,7 +304,7 @@ btoi
 ==`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -324,11 +324,11 @@ safe:
 int 1
 +`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -345,11 +345,11 @@ int 0x100000000
 pop
 int 1`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -367,11 +367,11 @@ int 0x1111111111111111
 pop
 int 1`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -389,11 +389,11 @@ int 0x222222222
 pop
 int 1`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -445,11 +445,11 @@ done:
 int 1                   // ret 1
 `)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -467,14 +467,14 @@ pop
 int 1`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	cost, err := Check(program, EvalParams{Trace: &sb})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if err != nil {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
 	}
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -492,11 +492,11 @@ int 0
 pop
 int 1`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -511,11 +511,11 @@ func TestErr(t *testing.T) {
 	program, err := AssembleString(`err
 int 1`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -537,11 +537,11 @@ int 2
 int 4
 ==`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -557,11 +557,11 @@ int 0
 pop`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	cost, err := Check(program, EvalParams{Trace: &sb})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb = strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -576,11 +576,11 @@ func TestStackLeftover(t *testing.T) {
 int 1`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	cost, err := Check(program, EvalParams{Trace: &sb})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb = strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -595,11 +595,11 @@ func TestStackBytesLeftover(t *testing.T) {
 	program, err := AssembleString(`byte 0x10101010`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	cost, err := Check(program, EvalParams{Trace: &sb})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb = strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -616,11 +616,11 @@ int 1
 pop
 pop`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -635,14 +635,14 @@ func TestArgTooFar(t *testing.T) {
 	program, err := AssembleString(`arg_1
 btoi`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	//require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
 	var txn transactions.SignedTxn
 	txn.Lsig.Logic = program
 	txn.Lsig.Args = nil
-	pass, err := Eval(program, EvalParams{Trace: &sb, Txn: &txn})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -656,14 +656,14 @@ func TestIntcTooFar(t *testing.T) {
 	t.Parallel()
 	program, err := AssembleString(`intc_1`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	//require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
 	var txn transactions.SignedTxn
 	txn.Lsig.Logic = program
 	txn.Lsig.Args = nil
-	pass, err := Eval(program, EvalParams{Trace: &sb, Txn: &txn})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -678,14 +678,14 @@ func TestBytecTooFar(t *testing.T) {
 	program, err := AssembleString(`bytec_1
 btoi`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	//require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
 	var txn transactions.SignedTxn
 	txn.Lsig.Logic = program
 	txn.Lsig.Args = nil
-	pass, err := Eval(program, EvalParams{Trace: &sb, Txn: &txn})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -698,14 +698,14 @@ btoi`)
 func TestTxnBadField(t *testing.T) {
 	t.Parallel()
 	program := []byte{0x01, 0x31, 0x7f}
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	//require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
 	var txn transactions.SignedTxn
 	txn.Lsig.Logic = program
 	txn.Lsig.Args = nil
-	pass, err := Eval(program, EvalParams{Trace: &sb, Txn: &txn})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -718,7 +718,7 @@ func TestTxnBadField(t *testing.T) {
 func TestGtxnBadIndex(t *testing.T) {
 	t.Parallel()
 	program := []byte{0x01, 0x33, 0x1, 0x01}
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	//require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
@@ -727,7 +727,7 @@ func TestGtxnBadIndex(t *testing.T) {
 	txn.Lsig.Args = nil
 	txgroup := make([]transactions.SignedTxnWithAD, 1)
 	txgroup[0].SignedTxn = txn
-	pass, err := Eval(program, EvalParams{Trace: &sb, Txn: &txn, TxnGroup: txgroup})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn, TxnGroup: txgroup})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -740,7 +740,7 @@ func TestGtxnBadIndex(t *testing.T) {
 func TestGtxnBadField(t *testing.T) {
 	t.Parallel()
 	program := []byte{0x01, 0x33, 0x0, 0x7f}
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	//require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
@@ -749,7 +749,7 @@ func TestGtxnBadField(t *testing.T) {
 	txn.Lsig.Args = nil
 	txgroup := make([]transactions.SignedTxnWithAD, 1)
 	txgroup[0].SignedTxn = txn
-	pass, err := Eval(program, EvalParams{Trace: &sb, Txn: &txn, TxnGroup: txgroup})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn, TxnGroup: txgroup})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -762,14 +762,14 @@ func TestGtxnBadField(t *testing.T) {
 func TestGlobalBadField(t *testing.T) {
 	t.Parallel()
 	program := []byte{0x01, 0x32, 0x7f}
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	//require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
 	var txn transactions.SignedTxn
 	txn.Lsig.Logic = program
 	txn.Lsig.Args = nil
-	pass, err := Eval(program, EvalParams{Trace: &sb, Txn: &txn})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -794,7 +794,7 @@ int 9
 <
 &&`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	var txn transactions.SignedTxn
@@ -807,7 +807,7 @@ int 9
 		[]byte("aoeu4"),
 	}
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb, Txn: &txn})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -853,7 +853,7 @@ func TestGlobal(t *testing.T) {
 	}
 	program, err := AssembleString(globalTestProgram)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	var txn transactions.SignedTxn
@@ -992,7 +992,7 @@ func TestTxn(t *testing.T) {
 	}
 	program, err := AssembleString(testTxnProgramText)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	var txn transactions.SignedTxn
@@ -1035,7 +1035,7 @@ func TestTxn(t *testing.T) {
 	recs := make([]basics.BalanceRecord, 4)
 	recs[3].MicroAlgos.Raw = 4160
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb, Txn: &txn, GroupSenders: recs, GroupIndex: 3})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn, GroupSenders: recs, GroupIndex: 3})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1099,7 +1099,7 @@ int 2
 &&`)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	cost, err := Check(program, EvalParams{Trace: &sb})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if err != nil {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1138,7 +1138,7 @@ int 2
 		txn.Txn.Note,
 	}
 	sb = strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb, Txn: &txn, TxnGroup: txgroup})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb, Txn: &txn, TxnGroup: txgroup})
 	if !pass || err != nil {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1162,11 +1162,11 @@ int 0x300
 int 0x310
 ==`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1189,11 +1189,11 @@ byte 0xabbacafe
 load 0
 &&`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1266,11 +1266,11 @@ func TestCompares(t *testing.T) {
 	t.Parallel()
 	program, err := AssembleString(testCompareProgramText)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1292,11 +1292,11 @@ keccak256
 byte 0xc195eca25a6f4c82bfba0287082ddb0d602ae9230f9cf1f1a40b68f8e2c41567
 ==`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1322,11 +1322,11 @@ sha512_256
 byte 0x98D2C31612EA500279B6753E5F6E780CA63EBA8274049664DAD66A2565ED1D2A
 ==`)
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1349,11 +1349,11 @@ func TestStackUnderflow(t *testing.T) {
 	program, err := AssembleString(`int 1`)
 	program = append(program, 0x08) // +
 	require.NoError(t, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.Error(t, err) // Check should know the type stack was wrong
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1367,11 +1367,11 @@ func TestWrongStackTypeRuntime(t *testing.T) {
 	program, err := AssembleString(`int 1`)
 	require.NoError(t, err)
 	program = append(program, 0x01, 0x15) // sha256, len
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.Error(t, err) // Check should know the type stack was wrong
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1386,11 +1386,11 @@ func TestEqMismatch(t *testing.T) {
 int 1`)
 	require.NoError(t, err)
 	program = append(program, 0x12) // ==
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	//require.Error(t, err) // Check should know the type stack was wrong
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1405,11 +1405,11 @@ func TestNeqMismatch(t *testing.T) {
 int 1`)
 	require.NoError(t, err)
 	program = append(program, 0x13) // !=
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	//require.Error(t, err) // Check should know the type stack was wrong
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1424,11 +1424,11 @@ func TestWrongStackTypeRuntime2(t *testing.T) {
 int 1`)
 	require.NoError(t, err)
 	program = append(program, 0x08) // +
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.Error(t, err) // Check should know the type stack was wrong
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, _ := Eval(program, EvalParams{Trace: &sb})
+	pass, _ := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1447,11 +1447,11 @@ func TestIllegalOp(t *testing.T) {
 			break
 		}
 	}
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1467,11 +1467,11 @@ bnz done
 done:`)
 	require.NoError(t, err)
 	program = program[:len(program)-1]
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.Error(t, err)
 	require.True(t, cost < 1000)
 	sb := strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1488,12 +1488,12 @@ func TestShortBytecblock(t *testing.T) {
 	for i := 2; i < len(fullprogram); i++ {
 		program := fullprogram[:i]
 		t.Run(hex.EncodeToString(program), func(t *testing.T) {
-			cost, err := Check(program, EvalParams{})
+			cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 			require.Error(t, err)
 			isNotPanic(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, EvalParams{Trace: &sb})
+			pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 			if pass {
 				t.Log(hex.EncodeToString(program))
 				t.Log(sb.String())
@@ -1515,12 +1515,12 @@ func TestShortBytecblock2(t *testing.T) {
 		t.Run(src, func(t *testing.T) {
 			program, err := hex.DecodeString(src)
 			require.NoError(t, err)
-			cost, err := Check(program, EvalParams{})
+			cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 			require.Error(t, err)
 			isNotPanic(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, EvalParams{Trace: &sb})
+			pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 			if pass {
 				t.Log(hex.EncodeToString(program))
 				t.Log(sb.String())
@@ -1558,7 +1558,7 @@ func TestPanic(t *testing.T) {
 		}
 	}
 	sb := strings.Builder{}
-	_, err = Check(program, EvalParams{Trace: &sb})
+	_, err = Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	require.Error(t, err)
 	if pe, ok := err.(PanicError); ok {
 		require.Equal(t, panicString, pe.PanicValue)
@@ -1568,7 +1568,7 @@ func TestPanic(t *testing.T) {
 		t.Errorf("expected PanicError object but got %T %#v", err, err)
 	}
 	sb = strings.Builder{}
-	pass, err := Eval(program, EvalParams{Trace: &sb})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Trace: &sb})
 	if pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())
@@ -1589,10 +1589,10 @@ func TestProgramTooNew(t *testing.T) {
 	t.Parallel()
 	var program [12]byte
 	vlen := binary.PutUvarint(program[:], EvalMaxVersion+1)
-	_, err := Check(program[:vlen], EvalParams{})
+	_, err := Check(program[:vlen], EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.Error(t, err)
 	isNotPanic(t, err)
-	pass, err := Eval(program[:vlen], EvalParams{})
+	pass, err := Eval(program[:vlen], EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.Error(t, err)
 	require.False(t, pass)
 	isNotPanic(t, err)
@@ -1602,10 +1602,10 @@ func TestInvalidVersion(t *testing.T) {
 	t.Parallel()
 	program, err := hex.DecodeString("ffffffffffffffffffffffff")
 	require.NoError(t, err)
-	_, err = Check(program, EvalParams{})
+	_, err = Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.Error(t, err)
 	isNotPanic(t, err)
-	pass, err := Eval(program, EvalParams{})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.Error(t, err)
 	require.False(t, pass)
 	isNotPanic(t, err)
@@ -1639,10 +1639,10 @@ int 1`)
 	require.NoError(t, err)
 	require.Equal(t, program, canonicalProgramBytes)
 	program[7] = 3 // clobber the branch offset to be in the middle of the bytecblock
-	_, err = Check(program, EvalParams{})
+	_, err = Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "aligned"))
-	pass, err := Eval(program, EvalParams{})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.Error(t, err)
 	require.False(t, pass)
 	isNotPanic(t, err)
@@ -1661,10 +1661,10 @@ int 1`)
 	require.NoError(t, err)
 	require.Equal(t, program, canonicalProgramBytes)
 	program[7] = 200 // clobber the branch offset to be beyond the end of the program
-	_, err = Check(program, EvalParams{})
+	_, err = Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "beyond end of program"))
-	pass, err := Eval(program, EvalParams{})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.Error(t, err)
 	require.False(t, pass)
 	isNotPanic(t, err)
@@ -1683,10 +1683,10 @@ int 1`)
 	require.NoError(t, err)
 	require.Equal(t, program, canonicalProgramBytes)
 	program[6] = 0xff // clobber the branch offset
-	_, err = Check(program, EvalParams{})
+	_, err = Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "too large"))
-	pass, err := Eval(program, EvalParams{})
+	pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.Error(t, err)
 	require.False(t, pass)
 	isNotPanic(t, err)
@@ -1704,10 +1704,10 @@ txn SenderBalance
 	require.NoError(t, err)
 	require.Equal(t, program, canonicalProgramBytes)
 
-	_, err = Check(program, EvalParams{})
+	_, err = Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(t, err)
 
-	params := EvalParams{GroupSenders: make([]basics.BalanceRecord, 1), Txn: new(transactions.SignedTxn)}
+	params := EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, GroupSenders: make([]basics.BalanceRecord, 1), Txn: new(transactions.SignedTxn)}
 	params.GroupSenders[0].MicroAlgos.Raw = bal
 	pass, err := Eval(program, params)
 	require.NoError(t, err)
@@ -1999,7 +1999,7 @@ int 142791994204213819
 func benchmarkBasicProgram(b *testing.B, source string) {
 	program, err := AssembleString(source)
 	require.NoError(b, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(b, err)
 	require.True(b, cost < 2000)
 	//b.Logf("%d bytes of program", len(program))
@@ -2007,7 +2007,7 @@ func benchmarkBasicProgram(b *testing.B, source string) {
 	b.ResetTimer()
 	sb := strings.Builder{} // Trace: &sb
 	for i := 0; i < b.N; i++ {
-		pass, err := Eval(program, EvalParams{Seed: []byte(benchSeed), MoreSeed: []byte(benchMore)})
+		pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Seed: []byte(benchSeed), MoreSeed: []byte(benchMore)})
 		if !pass {
 			b.Log(sb.String())
 		}
@@ -2024,7 +2024,7 @@ func benchmarkBasicProgram(b *testing.B, source string) {
 func benchmarkExpensiveProgram(b *testing.B, source string) {
 	program, err := AssembleString(source)
 	require.NoError(b, err)
-	cost, err := Check(program, EvalParams{})
+	cost, err := Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 	require.NoError(b, err)
 	require.True(b, cost > 1000)
 	//b.Logf("%d bytes of program", len(program))
@@ -2032,7 +2032,7 @@ func benchmarkExpensiveProgram(b *testing.B, source string) {
 	b.ResetTimer()
 	sb := strings.Builder{} // Trace: &sb
 	for i := 0; i < b.N; i++ {
-		pass, err := Eval(program, EvalParams{})
+		pass, err := Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 		if !pass {
 			b.Log(sb.String())
 		}
@@ -2138,7 +2138,7 @@ ed25519verify`, pkStr))
 	txn.Lsig.Logic = program
 	txn.Lsig.Args = [][]byte{data[:], sig[:]}
 	sb := strings.Builder{}
-	ep := EvalParams{Txn: &txn, Trace: &sb}
+	ep := EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb}
 	pass, err := Eval(program, ep)
 	if !pass {
 		t.Log(hex.EncodeToString(program))
@@ -2149,7 +2149,7 @@ ed25519verify`, pkStr))
 
 	// short sig will fail
 	txn.Lsig.Args[1] = sig[1:]
-	pass, err = Eval(program, EvalParams{Txn: &txn})
+	pass, err = Eval(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn})
 	require.False(t, pass)
 	require.Error(t, err)
 	isNotPanic(t, err)
@@ -2160,7 +2160,7 @@ ed25519verify`, pkStr))
 	require.NoError(t, err)
 	txn.Lsig.Args = [][]byte{data1, sig[:]}
 	sb1 := strings.Builder{}
-	ep1 := EvalParams{Txn: &txn, Trace: &sb1}
+	ep1 := EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb1}
 	pass1, err := Eval(program, ep1)
 	require.False(t, pass1)
 	require.NoError(t, err)
@@ -2199,7 +2199,7 @@ ed25519verify`, pkStr))
 		txn.Lsig.Logic = programs[i]
 		txn.Lsig.Args = [][]byte{data[i][:], signatures[i][:]}
 		sb := strings.Builder{}
-		ep := EvalParams{Txn: &txn, Trace: &sb}
+		ep := EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}, Txn: &txn, Trace: &sb}
 		pass, err := Eval(programs[i], ep)
 		if !pass {
 			b.Log(hex.EncodeToString(programs[i]))
@@ -2232,7 +2232,7 @@ func BenchmarkCheckx5(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, program := range programs {
-			_, err = Check(program, EvalParams{})
+			_, err = Check(program, EvalParams{Proto: &config.ConsensusParams{LogicSigVersion: 1}})
 			if err != nil {
 				require.NoError(b, err)
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

This PR contains two security fixes (Thanks @justicz!) .

* Although the size of logic sig is checked, but the way we calculate the size didn't capture the case that a malicious user putting a large number of args of empty byte array (In such case, each arg will be counted 0, but there are still bytes needed to encode them on the wire). This could cause DoS attacks. This PR implements a check that limits the number of args to logic sig to be at most 255.

* Add a check that rejects logicSig eval if the protocol version is earlier.

## Test Plan

Added unit tests in `eval_test.go` for these two cases.

