### PR TITLE
Add extra asset description fields

### DIFF
--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -453,16 +453,28 @@ var listCmd = &cobra.Command{
 
 				unitName := "units"
 				assetName := ""
+				assetURL := ""
+				assetMetadata := ""
 				creatorInfo, err := client.AccountInformation(bal.Creator)
 				if err == nil {
 					params, ok := creatorInfo.AssetParams[aid]
 					if ok {
-						unitName = params.UnitName
-						assetName = fmt.Sprintf(", name %s", params.AssetName)
+						if params.UnitName != "" {
+							unitName = params.UnitName
+						}
+						if params.AssetName != "" {
+							assetName = fmt.Sprintf(", name %s", params.AssetName)
+						}
+						if params.URL != "" {
+							assetURL = fmt.Sprintf(", url %s", params.URL)
+						}
+						if params.MetadataHash != nil {
+							assetMetadata = fmt.Sprintf(", metadata %x", params.MetadataHash)
+						}
 					}
 				}
 
-				fmt.Printf("\t%20d %-8s (creator %s, ID %d%s%s)\n", bal.Amount, unitName, bal.Creator, aid, assetName, frozen)
+				fmt.Printf("\t%20d %-8s (creator %s, ID %d%s%s%s%s)\n", bal.Amount, unitName, bal.Creator, aid, assetName, assetURL, assetMetadata, frozen)
 			}
 		}
 	},

--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -74,6 +74,9 @@ const (
 	infoDataDir                      = "[Data Directory: %s]"
 	errLoadingConfig                 = "Error loading Config file from '%s': %v"
 
+	// Asset
+	malformedMetadataHash = "Cannot base64-decode metadata hash %s: %s"
+
 	// Clerk
 	infoTxIssued    = "Sent %d MicroAlgos from account %s to address %s, transaction ID: %s. Fee set to %d"
 	infoTxCommitted = "Transaction %s committed in round %d"

--- a/daemon/algod/api/server/v1/handlers/handlers.go
+++ b/daemon/algod/api/server/v1/handlers/handlers.go
@@ -145,7 +145,9 @@ func assetParams(creator basics.Address, params basics.AssetParams) v1.AssetPara
 	paramsModel.UnitName = strings.TrimRight(string(params.UnitName[:]), "\x00")
 	paramsModel.AssetName = strings.TrimRight(string(params.AssetName[:]), "\x00")
 	paramsModel.URL = strings.TrimRight(string(params.URL[:]), "\x00")
-	paramsModel.MetadataHash = params.MetadataHash[:]
+	if params.MetadataHash != [32]byte{} {
+		paramsModel.MetadataHash = params.MetadataHash[:]
+	}
 
 	if !params.Manager.IsZero() {
 		paramsModel.ManagerAddr = params.Manager.String()

--- a/daemon/algod/api/server/v1/handlers/handlers.go
+++ b/daemon/algod/api/server/v1/handlers/handlers.go
@@ -144,6 +144,8 @@ func assetParams(creator basics.Address, params basics.AssetParams) v1.AssetPara
 
 	paramsModel.UnitName = strings.TrimRight(string(params.UnitName[:]), "\x00")
 	paramsModel.AssetName = strings.TrimRight(string(params.AssetName[:]), "\x00")
+	paramsModel.URL = strings.TrimRight(string(params.URL[:]), "\x00")
+	paramsModel.MetadataHash = params.MetadataHash[:]
 
 	if !params.Manager.IsZero() {
 		paramsModel.ManagerAddr = params.Manager.String()

--- a/daemon/algod/api/spec/v1/model.go
+++ b/daemon/algod/api/spec/v1/model.go
@@ -196,6 +196,19 @@ type AssetParams struct {
 	// required: false
 	AssetName string `json:"assetname"`
 
+	// URL specifies a URL where more information about the asset can be
+	// retrieved
+	//
+	// required: false
+	URL string `json:"url"`
+
+	// MetadataHash specifies a commitment to some unspecified asset
+	// metadata. The format of this metadata is up to the application.
+	//
+	// required: false
+	// swagger:strfmt byte
+	MetadataHash []byte `json:"metadatahash"`
+
 	// ManagerAddr specifies the address used to manage the keys of this
 	// asset and to destroy it.
 	//

--- a/data/basics/userBalance.go
+++ b/data/basics/userBalance.go
@@ -189,6 +189,14 @@ type AssetParams struct {
 	// AssetName specifies a hint for the name of the asset.
 	AssetName [32]byte `codec:"an"`
 
+	// URL specifies a URL where more information about the asset can be
+	// retrieved
+	URL [32]byte `codec:"au"`
+
+	// MetadataHash specifies a commitment to some unspecified asset
+	// metadata. The format of this metadata is up to the application.
+	MetadataHash [32]byte `codec:"am"`
+
 	// Manager specifies an account that is allowed to change the
 	// non-zero addresses in this AssetParams.
 	Manager Address `codec:"m"`

--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -400,7 +400,7 @@ func (c *Client) FillUnsignedTxTemplate(sender string, firstValid, numValidRound
 //
 // Call FillUnsignedTxTemplate afterwards to fill out common fields in
 // the resulting transaction template.
-func (c *Client) MakeUnsignedAssetCreateTx(total uint64, defaultFrozen bool, manager string, reserve string, freeze string, clawback string, unitName string, assetName string) (transactions.Transaction, error) {
+func (c *Client) MakeUnsignedAssetCreateTx(total uint64, defaultFrozen bool, manager string, reserve string, freeze string, clawback string, unitName string, assetName string, url string, metadataHash []byte) (transactions.Transaction, error) {
 	var tx transactions.Transaction
 	var err error
 
@@ -437,6 +437,16 @@ func (c *Client) MakeUnsignedAssetCreateTx(total uint64, defaultFrozen bool, man
 			return tx, err
 		}
 	}
+
+	if len(url) > len(tx.AssetParams.URL) {
+		return tx, fmt.Errorf("asset url %s is too long (max %d bytes)", url, len(tx.AssetParams.URL))
+	}
+	copy(tx.AssetParams.URL[:], []byte(url))
+
+	if len(metadataHash) > len(tx.AssetParams.MetadataHash) {
+		return tx, fmt.Errorf("asset metadata hash %x too long (max %d bytes)", metadataHash, len(tx.AssetParams.MetadataHash))
+	}
+	copy(tx.AssetParams.MetadataHash[:], metadataHash)
 
 	if len(unitName) > len(tx.AssetParams.UnitName) {
 		return tx, fmt.Errorf("asset unit name %s too long (max %d bytes)", unitName, len(tx.AssetParams.UnitName))

--- a/test/e2e-go/features/transactions/asset_test.go
+++ b/test/e2e-go/features/transactions/asset_test.go
@@ -77,6 +77,9 @@ func TestAssetConfig(t *testing.T) {
 	clawback, err := client.GenerateAddress(wh)
 	a.NoError(err)
 
+	assetURL := "foo://bar"
+	assetMetadataHash := []byte("ISTHISTHEREALLIFEISTHISJUSTFANTA")
+
 	// Fund the manager, so it can issue transactions later on
 	_, err = client.SendPaymentFromUnencryptedWallet(account0, manager, 0, 10000000000, nil)
 	a.NoError(err)
@@ -94,7 +97,7 @@ func TestAssetConfig(t *testing.T) {
 		wh, err = client.GetUnencryptedWalletHandle()
 		a.NoError(err)
 
-		tx, err := client.MakeUnsignedAssetCreateTx(1+uint64(i), false, manager, reserve, freeze, clawback, fmt.Sprintf("test%d", i), fmt.Sprintf("testname%d", i))
+		tx, err := client.MakeUnsignedAssetCreateTx(1+uint64(i), false, manager, reserve, freeze, clawback, fmt.Sprintf("test%d", i), fmt.Sprintf("testname%d", i), assetURL, assetMetadataHash)
 		txid, err := helperFillSignBroadcast(client, wh, account0, tx, err)
 		a.NoError(err)
 		txids[txid] = account0
@@ -119,7 +122,7 @@ func TestAssetConfig(t *testing.T) {
 	a.NoError(err)
 
 	// Creating more assets should return an error
-	tx, err := client.MakeUnsignedAssetCreateTx(1, false, manager, reserve, freeze, clawback, fmt.Sprintf("toomany"), fmt.Sprintf("toomany"))
+	tx, err := client.MakeUnsignedAssetCreateTx(1, false, manager, reserve, freeze, clawback, fmt.Sprintf("toomany"), fmt.Sprintf("toomany"), assetURL, assetMetadataHash)
 	_, err = helperFillSignBroadcast(client, wh, account0, tx, err)
 	a.Error(err)
 
@@ -136,6 +139,8 @@ func TestAssetConfig(t *testing.T) {
 		a.Equal(cp.ReserveAddr, reserve)
 		a.Equal(cp.FreezeAddr, freeze)
 		a.Equal(cp.ClawbackAddr, clawback)
+		a.Equal(cp.MetadataHash, assetMetadataHash)
+		a.Equal(cp.URL, assetURL)
 	}
 
 	// re-generate wh, since this test takes a while and sometimes
@@ -313,7 +318,7 @@ func TestAssetInformation(t *testing.T) {
 	// Create some assets
 	txids := make(map[string]string)
 	for i := 0; i < 16; i++ {
-		tx, err := client.MakeUnsignedAssetCreateTx(1+uint64(i), false, manager, reserve, freeze, clawback, fmt.Sprintf("test%d", i), fmt.Sprintf("testname%d", i))
+		tx, err := client.MakeUnsignedAssetCreateTx(1+uint64(i), false, manager, reserve, freeze, clawback, fmt.Sprintf("test%d", i), fmt.Sprintf("testname%d", i), "foo://bar", nil)
 		txid, err := helperFillSignBroadcast(client, wh, account0, tx, err)
 		a.NoError(err)
 		txids[txid] = account0
@@ -393,12 +398,12 @@ func TestAssetSend(t *testing.T) {
 	// Create two assets: one with default-freeze, and one without default-freeze
 	txids := make(map[string]string)
 
-	tx, err := client.MakeUnsignedAssetCreateTx(100, false, manager, reserve, freeze, clawback, "nofreeze", "xx")
+	tx, err := client.MakeUnsignedAssetCreateTx(100, false, manager, reserve, freeze, clawback, "nofreeze", "xx", "foo://bar", nil)
 	txid, err := helperFillSignBroadcast(client, wh, account0, tx, err)
 	a.NoError(err)
 	txids[txid] = account0
 
-	tx, err = client.MakeUnsignedAssetCreateTx(100, true, manager, reserve, freeze, clawback, "frozen", "xx")
+	tx, err = client.MakeUnsignedAssetCreateTx(100, true, manager, reserve, freeze, clawback, "frozen", "xx", "foo://bar", nil)
 	txid, err = helperFillSignBroadcast(client, wh, account0, tx, err)
 	a.NoError(err)
 	txids[txid] = account0


### PR DESCRIPTION
This PR adds two optional fields to an asset's parameters:

`URL` points to somewhere with more information about the asset.
`MetadataHash` is a commitment to some metadata about the asset, in some unspecified format.

Each of these fields is stored internally in `AssetParams` as a `[32]byte`.