### PR TITLE
Fix buildnumber.dat initialization

### DIFF
--- a/scripts/build/beta.sh
+++ b/scripts/build/beta.sh
@@ -14,10 +14,10 @@ git checkout rel/beta
 BUILD_NUMBER=
 if [ -e buildnumber.dat ]; then
     BUILD_NUMBER=$(cat ./buildnumber.dat)
+    BUILD_NUMBER=$((${BUILD_NUMBER} + 1))
 else
     BUILD_NUMBER=0
 fi
-BUILD_NUMBER=$((${BUILD_NUMBER} + 1))
 echo ${BUILD_NUMBER} > ./buildnumber.dat
 
 # Build before committing - the pre-commit checks can fail otherwise

--- a/scripts/build/nightly.sh
+++ b/scripts/build/nightly.sh
@@ -19,10 +19,10 @@ git merge origin/master -m "FI from master"
 BUILD_NUMBER=
 if [ -e buildnumber.dat ]; then
     BUILD_NUMBER=$(cat ./buildnumber.dat)
+    BUILD_NUMBER=$((${BUILD_NUMBER} + 1))
 else
     BUILD_NUMBER=0
 fi
-BUILD_NUMBER=$((${BUILD_NUMBER} + 1))
 echo ${BUILD_NUMBER} > ./buildnumber.dat
 
 git add ./genesistimestamp.dat ./buildnumber.dat

--- a/scripts/build/stable.sh
+++ b/scripts/build/stable.sh
@@ -13,10 +13,10 @@ git checkout rel/stable
 BUILD_NUMBER=
 if [ -e buildnumber.dat ]; then
     BUILD_NUMBER=$(cat ./buildnumber.dat)
+    BUILD_NUMBER=$((${BUILD_NUMBER} + 1))
 else
     BUILD_NUMBER=0
 fi
-BUILD_NUMBER=$((${BUILD_NUMBER} + 1))
 echo ${BUILD_NUMBER} > ./buildnumber.dat
 
 # Build before committing - the pre-commit checks can fail otherwise


### PR DESCRIPTION
Build scripts weren't allowing me to reset the patch version to zero