### PR TITLE
Explicitly disallow txns from zero address

### DIFF
--- a/crypto/curve25519_test.go
+++ b/crypto/curve25519_test.go
@@ -35,6 +35,16 @@ func TestSignVerifyEmptyMessage(t *testing.T) {
 	}
 }
 
+func TestVerifyZeros(t *testing.T) {
+	var pk SignatureVerifier
+	var sig Signature
+	for x := byte(0); x < 255; x++ {
+		if pk.verifyBytes([]byte{x}, sig) {
+			t.Errorf("Zero sig with zero pk successfully verified message %x", x)
+		}
+	}
+}
+
 func TestGenerateSignatureSecrets(t *testing.T) {
 	var s Seed
 	RandBytes(s[:])

--- a/crypto/curve25519_test.go
+++ b/crypto/curve25519_test.go
@@ -39,7 +39,7 @@ func TestVerifyZeros(t *testing.T) {
 	var pk SignatureVerifier
 	var sig Signature
 	for x := byte(0); x < 255; x++ {
-		if pk.verifyBytes([]byte{x}, sig) {
+		if pk.VerifyBytes([]byte{x}, sig) {
 			t.Errorf("Zero sig with zero pk successfully verified message %x", x)
 		}
 	}

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -341,6 +341,9 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 		// this check is just to be safe, but reaching here seems impossible, since it requires computing a preimage of rwpool
 		return fmt.Errorf("transaction from incentive pool is invalid")
 	}
+	if tx.Sender == (basics.Address{}) {
+		return fmt.Errorf("transaction cannot have zero sender")
+	}
 	if !proto.SupportTransactionLeases && (tx.Lease != [32]byte{}) {
 		return fmt.Errorf("transaction tried to acquire lease %v but protocol does not support transaction leases", tx.Lease)
 	}


### PR DESCRIPTION
Also add a test to confirm we don't accept a zero signature from a zero public key.

Max noticed that some ed25519 implementations (e.g., the reference Python implementation) accept zero signatures from zero public keys on 1 in 4 messages. Add a test to confirm this isn't true for our implementation. Also explicitly reject transactions with the zero address as the sender for defense-in-depth.