### PR TITLE
Logicsig cache fix

### DIFF
--- a/data/pools/statusCache.go
+++ b/data/pools/statusCache.go
@@ -33,8 +33,8 @@ type statusCache struct {
 
 func makeStatusCache(sz int) *statusCache {
 	return &statusCache{
-		cur:  map[transactions.Txid]statusCacheEntry{},
-		prev: map[transactions.Txid]statusCacheEntry{},
+		cur:  make(map[transactions.Txid]statusCacheEntry, sz),
+		prev: make(map[transactions.Txid]statusCacheEntry, 0),
 		sz:   sz,
 	}
 }
@@ -52,11 +52,16 @@ func (sc *statusCache) check(txid transactions.Txid) (tx transactions.SignedTxn,
 func (sc *statusCache) put(tx transactions.SignedTxn, txErr string) {
 	if len(sc.cur) >= sc.sz {
 		sc.prev = sc.cur
-		sc.cur = map[transactions.Txid]statusCacheEntry{}
+		sc.cur = make(map[transactions.Txid]statusCacheEntry, sc.sz)
 	}
 
 	sc.cur[tx.ID()] = statusCacheEntry{
 		tx:    tx,
 		txErr: txErr,
 	}
+}
+
+func (sc *statusCache) clear() {
+	sc.cur = make(map[transactions.Txid]statusCacheEntry, sc.sz)
+	sc.prev = make(map[transactions.Txid]statusCacheEntry, 0)
 }

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -46,6 +46,7 @@ type TransactionPool struct {
 	statusCache            *statusCache
 	logStats               bool
 	expFeeFactor           uint64
+	poolProtocol           protocol.ConsensusVersion
 
 	// pendingMu protects pendingTxGroups and pendingTxids
 	pendingMu       deadlock.RWMutex


### PR DESCRIPTION
I'm pretty sure this fixes the logic sig cache in the TransactionPool.
My best guess at a test for this is to build a pool, submit a lsig txn to it, cause the block to roll over, and check that logic.Eval gets called again to re-validate the lsig txn. But this sounds like an annoyingly large amount of setup. Not sure if there's a better way.