### PR TITLE
Log check/eval panics for telemetry

### DIFF
--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -181,8 +181,8 @@ func Eval(program []byte, params EvalParams) (pass bool, err error) {
 					errstr += sb.String()
 				}
 			}
-			logging.Base().Errorf("recovered panic in Eval: %s", errstr)
 			err = PanicError{x, errstr}
+			logging.Base().Errorf("recovered panic in Eval: %s", err)
 		}
 	}()
 	if (params.Proto == nil) || (params.Proto.LogicSigVersion == 0) {
@@ -262,8 +262,8 @@ func Check(program []byte, params EvalParams) (cost int, err error) {
 					errstr += sb.String()
 				}
 			}
-			logging.Base().Errorf("recovered panic in Check: %s", errstr)
 			err = PanicError{x, errstr}
+			logging.Base().Errorf("recovered panic in Check: %s", err)
 		}
 	}()
 	if (params.Proto == nil) || (params.Proto.LogicSigVersion == 0) {

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -38,6 +38,7 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -180,6 +181,7 @@ func Eval(program []byte, params EvalParams) (pass bool, err error) {
 					errstr += sb.String()
 				}
 			}
+			logging.Base().Errorf("recovered panic in Eval: %s", errstr)
 			err = PanicError{x, errstr}
 		}
 	}()
@@ -260,6 +262,7 @@ func Check(program []byte, params EvalParams) (cost int, err error) {
 					errstr += sb.String()
 				}
 			}
+			logging.Base().Errorf("recovered panic in Check: %s", errstr)
 			err = PanicError{x, errstr}
 		}
 	}()


### PR DESCRIPTION
We will want to know if/when these panics happen. Test coverage in `eval_test.go`'s `TestPanic`.