### PR TITLE
Fix goal asset transactions 

### DIFF
--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -365,12 +365,10 @@ func (c *Client) FillUnsignedTxTemplate(sender string, firstValid, numValidRound
 	parsedLastValid := basics.Round(firstValid + numValidRounds)
 	parsedFee := basics.MicroAlgos{Raw: fee}
 
-	tx.Header = transactions.Header{
-		Sender:     parsedAddr,
-		Fee:        parsedFee,
-		FirstValid: parsedFirstValid,
-		LastValid:  parsedLastValid,
-	}
+	tx.Header.Sender = parsedAddr
+	tx.Header.Fee = parsedFee
+	tx.Header.FirstValid = parsedFirstValid
+	tx.Header.LastValid = parsedLastValid
 
 	if cparams.SupportGenesisHash {
 		var genHash crypto.Digest


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

The current implementation of `FillUnsignedTxTemplate` will overwrite the txn's header, this will unset some fields of txn header such as `Note`. As a result, all the setters of the `Note` will be ineffective:
* https://github.com/algorand/go-algorand/blob/master/cmd/goal/asset.go#L221
* https://github.com/algorand/go-algorand/blob/master/cmd/goal/asset.go#L281
* https://github.com/algorand/go-algorand/blob/master/cmd/goal/asset.go#L362
*  https://github.com/algorand/go-algorand/blob/master/cmd/goal/asset.go#L436
* https://github.com/algorand/go-algorand/blob/master/cmd/goal/asset.go#L493

This PR change the implementation of `FillUnsignedTxTemplate` so that it didn't overwrite the entire txn header.

## Test Plan

All test passed. 
