### PR TITLE
Remove redundant logging

### DIFF
--- a/data/ledger.go
+++ b/data/ledger.go
@@ -341,24 +341,19 @@ func (*Ledger) AssemblePayset(pool *pools.TransactionPool, eval *ledger.BlockEva
 			break
 		}
 		if err != nil {
-			msg := fmt.Sprintf("Cannot add pending transaction to block: %v", err)
-
-			logAt := logging.Base().Warn
 
 			// GOAL2-255: Don't warn for common case of txn already being in ledger
 			switch err.(type) {
 			case ledger.TransactionInLedgerError:
-				logAt = logging.Base().Debug
 				stats.CommittedCount++
 			case transactions.MinFeeError:
-				logAt = logging.Base().Info
 				stats.InvalidCount++
+				logging.Base().Infof("Cannot add pending transaction to block: %v", err)
 			default:
-				// logAt = Warn
 				stats.InvalidCount++
+				logging.Base().Warnf("Cannot add pending transaction to block: %v", err)
 			}
 
-			logAt(msg)
 		} else {
 			for _, txn := range txgroup {
 				fee := txn.Txn.Fee.Raw
@@ -396,10 +391,9 @@ func (*Ledger) AssemblePayset(pool *pools.TransactionPool, eval *ledger.BlockEva
 				stats.TotalLength += uint64(encodedLen)
 			}
 		}
-
-		if stats.IncludedCount != 0 {
-			stats.AverageFee = totalFees / uint64(stats.IncludedCount)
-		}
+	}
+	if stats.IncludedCount != 0 {
+		stats.AverageFee = totalFees / uint64(stats.IncludedCount)
 	}
 	return
 }


### PR DESCRIPTION


## Summary

Avoid logging on TransactionInLedgerError, as it seems to be a normal operational usecase.
This change provide minor gains to the overall performance, especially targeting use cases when we have long transaction pool backlog.
