### PR TITLE
Pingpong Asset Support

### DIFF
--- a/cmd/pingpong/runCmd.go
+++ b/cmd/pingpong/runCmd.go
@@ -235,7 +235,7 @@ var runCmd = &cobra.Command{
 		if numAsset <= 1000 {
 			cfg.NumAsset = numAsset
 		} else {
-			reportErrorf("Invalid number of asset: %v\n", numAsset)
+			reportErrorf("Invalid number of asset: %d, (valid number: 1 - 1000)\n", numAsset)
 		}
 
 		reportInfof("Preparing to initialize PingPong with config:\n")

--- a/cmd/pingpong/runCmd.go
+++ b/cmd/pingpong/runCmd.go
@@ -55,6 +55,7 @@ var randomNote bool
 var txnPerSec uint64
 var teal string
 var groupSize uint32
+var numAsset uint32
 
 func init() {
 	rootCmd.AddCommand(runCmd)
@@ -83,6 +84,7 @@ func init() {
 	runCmd.Flags().BoolVar(&randomNote, "randomnote", false, "generates a random byte array between 0-1024 bytes long")
 	runCmd.Flags().StringVar(&teal, "teal", "", "teal test scenario, can be light, normal, or heavy, this overrides --program")
 	runCmd.Flags().Uint32Var(&groupSize, "groupsize", 1, "The number of transactions in each group")
+	runCmd.Flags().Uint32Var(&numAsset, "numasset", 0, "The number of assets each account holds")
 }
 
 var runCmd = &cobra.Command{
@@ -230,11 +232,17 @@ var runCmd = &cobra.Command{
 			reportErrorf("Invalid group size: %v\n", groupSize)
 		}
 
+		if numAsset <= 1000 {
+			cfg.NumAsset = numAsset
+		} else {
+			reportErrorf("Invalid number of asset: %v\n", numAsset)
+		}
+
 		reportInfof("Preparing to initialize PingPong with config:\n")
 		cfg.Dump(os.Stdout)
 
 		// Initialize accounts if necessary
-		accounts, cfg, err := pingpong.PrepareAccounts(ac, cfg)
+		accounts, assetParams, cfg, err := pingpong.PrepareAccounts(ac, cfg)
 		if err != nil {
 			reportErrorf("Error preparing accounts for transfers: %v\n", err)
 		}
@@ -247,7 +255,7 @@ var runCmd = &cobra.Command{
 		cfg.Dump(os.Stdout)
 
 		// Kick off the real processing
-		pingpong.RunPingPong(context.Background(), ac, accounts, cfg)
+		pingpong.RunPingPong(context.Background(), ac, accounts, assetParams, cfg)
 	},
 }
 

--- a/shared/pingpong/accounts.go
+++ b/shared/pingpong/accounts.go
@@ -115,7 +115,7 @@ func ensureAccounts(ac libgoal.Client, initCfg PpConfig) (accounts map[string]ui
 	toCreate := int(cfg.NumAsset) - len(account.AssetParams)
 
 	// create assets in srcAccount
-	for i := 0; i < toCreate; i ++ {
+	for i := 0; i < toCreate; i++ {
 		var metaLen = 32
 		meta := make([]byte, metaLen, metaLen)
 		crypto.RandBytes(meta[:])
@@ -160,19 +160,19 @@ func ensureAccounts(ac libgoal.Client, initCfg PpConfig) (accounts map[string]ui
 	}
 	assetParams = account.AssetParams
 
-	for addr, _ := range accounts {
+	for addr := range accounts {
 		addrAccount, addrErr := ac.AccountInformation(cfg.SrcAccount)
 		if addrErr != nil {
 			fmt.Printf("Cannot lookup source account")
 			err = addrErr
 			return
 		}
-		for k, _ := range assetParams {
+		for k := range assetParams {
 			// if addr already opened this asset, skip
 			if _, ok := addrAccount.Assets[k]; ok {
 				continue
 			}
-   			// init asset k in addr
+			// init asset k in addr
 			tx, sendErr := ac.MakeUnsignedAssetSendTx(k, 0, addr, "", "")
 			if sendErr != nil {
 				fmt.Printf("Cannot initiate asset %v in account %v\n", k, addr)

--- a/shared/pingpong/accounts.go
+++ b/shared/pingpong/accounts.go
@@ -97,10 +97,8 @@ func ensureAccounts(ac libgoal.Client, initCfg PpConfig) (accounts map[string]ui
 		}
 	}
 
-	// Get wallet handle token
-	var h []byte
-	h, err = ac.GetUnencryptedWalletHandle()
-	if err != nil {
+	// return if we don't need to set up assets
+	if cfg.NumAsset == 0 {
 		return
 	}
 
@@ -109,6 +107,13 @@ func ensureAccounts(ac libgoal.Client, initCfg PpConfig) (accounts map[string]ui
 	if accountErr != nil {
 		fmt.Printf("Cannot lookup source account")
 		err = accountErr
+		return
+	}
+
+	// Get wallet handle token
+	var h []byte
+	h, err = ac.GetUnencryptedWalletHandle()
+	if err != nil {
 		return
 	}
 

--- a/shared/pingpong/config.go
+++ b/shared/pingpong/config.go
@@ -50,6 +50,7 @@ type PpConfig struct {
 	LogicArgs       [][]byte
 	GroupSize       uint32
 	NumAsset        uint32
+	MinAccountAsset uint64
 }
 
 // DefaultConfig object for Ping Pong
@@ -70,6 +71,7 @@ var DefaultConfig = PpConfig{
 	MinAccountFunds: 100000,
 	GroupSize:       1,
 	NumAsset:        0,
+	MinAccountAsset: 10000000,
 }
 
 // LoadConfigFromFile reads and loads Ping Pong configuration

--- a/shared/pingpong/config.go
+++ b/shared/pingpong/config.go
@@ -49,6 +49,7 @@ type PpConfig struct {
 	Program         []byte
 	LogicArgs       [][]byte
 	GroupSize       uint32
+	NumAsset        uint32
 }
 
 // DefaultConfig object for Ping Pong
@@ -68,6 +69,7 @@ var DefaultConfig = PpConfig{
 	RefreshTime:     10 * time.Second,
 	MinAccountFunds: 100000,
 	GroupSize:       1,
+	NumAsset:        0,
 }
 
 // LoadConfigFromFile reads and loads Ping Pong configuration

--- a/shared/pingpong/pingpong.go
+++ b/shared/pingpong/pingpong.go
@@ -19,6 +19,7 @@ package pingpong
 import (
 	"context"
 	"fmt"
+	v1 "github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
 	"math"
 	"math/rand"
 	"os"
@@ -30,10 +31,10 @@ import (
 	"github.com/algorand/go-algorand/libgoal"
 )
 
-// PrepareAccounts to set up accounts required for Ping Pong run
-func PrepareAccounts(ac libgoal.Client, initCfg PpConfig) (accounts map[string]uint64, cfg PpConfig, err error) {
+// PrepareAccounts to set up accounts and asset accounts required for Ping Pong run
+func PrepareAccounts(ac libgoal.Client, initCfg PpConfig) (accounts map[string]uint64, assetParams map[uint64]v1.AssetParams, cfg PpConfig, err error) {
 	cfg = initCfg
-	accounts, cfg, err = ensureAccounts(ac, cfg)
+	accounts, assetParams, cfg, err = ensureAccounts(ac, cfg)
 	if err != nil {
 		return
 	}
@@ -98,7 +99,7 @@ func listSufficientAccounts(accounts map[string]uint64, minimumAmount uint64, ex
 }
 
 // RunPingPong starts ping pong process
-func RunPingPong(ctx context.Context, ac libgoal.Client, accounts map[string]uint64, cfg PpConfig) {
+func RunPingPong(ctx context.Context, ac libgoal.Client, accounts map[string]uint64, assetParam map[uint64]v1.AssetParams, cfg PpConfig) {
 	// Infinite loop given:
 	//  - accounts -> map of accounts to include in transfers (including src account, which we don't want to use)
 	//  - cfg      -> configuration for how to proceed
@@ -136,7 +137,7 @@ func RunPingPong(ctx context.Context, ac libgoal.Client, accounts map[string]uin
 			fromList := listSufficientAccounts(accounts, cfg.MinAccountFunds+(cfg.MaxAmt+cfg.MaxFee)*2, cfg.SrcAccount)
 			toList := listSufficientAccounts(accounts, 0, cfg.SrcAccount)
 
-			sent, succeded, err := sendFromTo(fromList, toList, accounts, ac, cfg)
+			sent, succeded, err := sendFromTo(fromList, toList, accounts, assetParam, ac, cfg)
 			totalSent += sent
 			totalSucceeded += succeded
 			if err != nil {
@@ -169,7 +170,7 @@ func RunPingPong(ctx context.Context, ac libgoal.Client, accounts map[string]uin
 	}
 }
 
-func sendFromTo(fromList, toList []string, accounts map[string]uint64, client libgoal.Client, cfg PpConfig) (sentCount, successCount uint64, err error) {
+func sendFromTo(fromList, toList []string, accounts map[string]uint64, assetParams map[uint64]v1.AssetParams, client libgoal.Client, cfg PpConfig) (sentCount, successCount uint64, err error) {
 	amt := cfg.MaxAmt
 	fee := cfg.MaxFee
 
@@ -193,14 +194,12 @@ func sendFromTo(fromList, toList []string, accounts map[string]uint64, client li
 		var sendErr error
 		fromBalanceChange := int64(0)
 		toBalanceChange := int64(0)
+		if cfg.NumAsset > 0 {
+			amt = 0
+		}
 		if cfg.GroupSize == 1 {
-
-			if !cfg.Quiet {
-				fmt.Fprintf(os.Stdout, "Sending %d : %s -> %s\n", amt, from, to)
-			}
-
 			// Construct single txn
-			txn, consErr := constructTxn(from, to, fee, amt, client, cfg)
+			txn, consErr := constructTxn(from, to, fee, amt, assetParams, client, cfg)
 			if consErr != nil {
 				err = consErr
 				return
@@ -229,11 +228,11 @@ func sendFromTo(fromList, toList []string, accounts map[string]uint64, client li
 			for j := 0; j < int(cfg.GroupSize); j++ {
 				var txn transactions.Transaction
 				if j%2 == 0 {
-					txn, err = constructTxn(from, to, fee, amt, client, cfg)
+					txn, err = constructTxn(from, to, fee, amt, assetParams, client, cfg)
 					fromBalanceChange -= int64(txn.Fee.Raw + amt)
 					toBalanceChange += int64(amt)
 				} else {
-					txn, err = constructTxn(to, from, fee, amt, client, cfg)
+					txn, err = constructTxn(to, from, fee, amt, assetParams, client, cfg)
 					toBalanceChange -= int64(txn.Fee.Raw + amt)
 					fromBalanceChange += int64(amt)
 				}
@@ -304,7 +303,7 @@ func sendFromTo(fromList, toList []string, accounts map[string]uint64, client li
 	return
 }
 
-func constructTxn(from, to string, fee, amt uint64, client libgoal.Client, cfg PpConfig) (txn transactions.Transaction, err error) {
+func constructTxn(from, to string, fee, amt uint64, assetParams map[uint64]v1.AssetParams, client libgoal.Client, cfg PpConfig) (txn transactions.Transaction, err error) {
 	var noteField []byte
 	const pingpongTag = "pingpong"
 	const tagLen = uint32(len(pingpongTag))
@@ -320,7 +319,27 @@ func constructTxn(from, to string, fee, amt uint64, client libgoal.Client, cfg P
 	crypto.RandBytes(noteField[tagLen:])
 
 	// Construct payment transaction
-	txn, err = client.ConstructPayment(from, to, fee, amt, noteField[:], "", [32]byte{}, 0, 0)
+	if cfg.NumAsset == 0 {
+		txn, err = client.ConstructPayment(from, to, fee, amt, noteField[:], "", [32]byte{}, 0, 0)
+		if !cfg.Quiet {
+			fmt.Fprintf(os.Stdout, "Sending %d : %s -> %s\n", amt, from, to)
+		}
+	} else {
+		var assetID uint64
+		for k := range assetParams {
+			assetID = k
+			break
+		}
+		txn, err = client.MakeUnsignedAssetSendTx(assetID, amt, to, "", "")
+		if err != nil {
+			return
+		}
+		txn.Note = noteField[:]
+		txn, err = client.FillUnsignedTxTemplate(from, 0, 0, cfg.MaxFee, txn)
+		if !cfg.Quiet {
+			fmt.Fprintf(os.Stdout, "Sending %d asset %d: %s -> %s\n", 0, assetID, from, to)
+		}
+	}
 	if err != nil {
 		return
 	}

--- a/shared/pingpong/pingpong.go
+++ b/shared/pingpong/pingpong.go
@@ -65,7 +65,7 @@ func fundAccounts(accounts map[string]uint64, client libgoal.Client, cfg PpConfi
 
 	// Fee of 0 will make cause the function to use the suggested one by network
 	fee := uint64(0)
-	minFund := cfg.MinAccountFunds+(cfg.MaxAmt+cfg.MaxFee)*300
+	minFund := cfg.MinAccountFunds+(cfg.MaxAmt+cfg.MaxFee)*cfg.TxnPerSec*uint64(math.Ceil(cfg.RefreshTime.Seconds()))
 	for addr, balance := range accounts {
 		if balance < minFund {
 			toSend := minFund - balance

--- a/shared/pingpong/pingpong.go
+++ b/shared/pingpong/pingpong.go
@@ -19,13 +19,13 @@ package pingpong
 import (
 	"context"
 	"fmt"
-	v1 "github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
 	"math"
 	"math/rand"
 	"os"
 	"time"
 
 	"github.com/algorand/go-algorand/crypto"
+	v1 "github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/libgoal"
@@ -326,10 +326,16 @@ func constructTxn(from, to string, fee, amt uint64, assetParams map[uint64]v1.As
 		}
 	} else {
 		var assetID uint64
+		rindex := rand.Intn(len(assetParams))
+		i := 0
 		for k := range assetParams {
-			assetID = k
-			break
+			if i == rindex {
+				assetID = k
+				break
+			}
+			i++
 		}
+
 		txn, err = client.MakeUnsignedAssetSendTx(assetID, amt, to, "", "")
 		if err != nil {
 			return

--- a/test/commandandcontrol/cc_agent/component/pingPongComponent.go
+++ b/test/commandandcontrol/cc_agent/component/pingPongComponent.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	v1 "github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
 	"io/ioutil"
 	"time"
 
@@ -121,11 +122,12 @@ func (componentInstance *PingPongComponentInstance) startPingPong(cfg *pingpong.
 	log.Infof("Preparing to initialize PingPong with config: %+v\n", cfg)
 
 	var accounts map[string]uint64
+	var assetParams map[uint64]v1.AssetParams
 	var resultCfg pingpong.PpConfig
 
 	// Initialize accounts if necessary, this may take several attempts while previous transactions to settle
 	for i := 0; i < 10; i++ {
-		accounts, resultCfg, err = pingpong.PrepareAccounts(ac, *cfg)
+		accounts, assetParams, resultCfg, err = pingpong.PrepareAccounts(ac, *cfg)
 		if err == nil {
 			break
 		} else {
@@ -144,7 +146,7 @@ func (componentInstance *PingPongComponentInstance) startPingPong(cfg *pingpong.
 	componentInstance.ctx, componentInstance.cancelFunc = context.WithCancel(context.Background())
 
 	// Kick off the real processing
-	go pingpong.RunPingPong(componentInstance.ctx, ac, accounts, resultCfg)
+	go pingpong.RunPingPong(componentInstance.ctx, ac, accounts, assetParams, resultCfg)
 
 	return
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Add asset transaction support in Pingpong:

* add `--numasset` option to pingpong. When `numasset` is assigned (1 - 1000), pingpong will create `numasset` assets and init these assets in each account. Pingpong will then send asset transactions instead of normal payment transactions.

## Test Plan

Tested locally.
