### PR TITLE
ledger wallet API: support sending full tx msgpack to device

### DIFF
--- a/daemon/kmd/wallet/driver/ledger.go
+++ b/daemon/kmd/wallet/driver/ledger.go
@@ -33,6 +33,16 @@ import (
 const (
 	ledgerWalletDriverName    = "ledger"
 	ledgerWalletDriverVersion = 1
+
+	ledger_CLA                 = uint8(0x80)
+	ledger_INS_GET_PUBLIC_KEY  = uint8(0x03)
+	ledger_INS_SIGN_PAYMENT_V2 = uint8(0x04)
+	ledger_INS_SIGN_KEYREG_V2  = uint8(0x05)
+	ledger_INS_SIGN_MSGPACK    = uint8(0x08)
+	ledger_P1_FIRST            = uint8(0x00)
+	ledger_P1_MORE             = uint8(0x80)
+	ledger_P2_LAST             = uint8(0x00)
+	ledger_P2_MORE             = uint8(0x80)
 )
 
 var ledgerWalletSupportedTxs = []protocol.TxType{protocol.PaymentTx, protocol.KeyRegistrationTx}
@@ -133,7 +143,7 @@ func (lw *LedgerWallet) Metadata() (wallet.Metadata, error) {
 	info := lw.dev.USBInfo()
 	return wallet.Metadata{
 		ID:                    []byte(info.Path),
-		Name:                  []byte(fmt.Sprintf("%s %s (serial %s)", info.Manufacturer, info.Product, info.Serial)),
+		Name:                  []byte(fmt.Sprintf("%s %s (serial %s, path %s)", info.Manufacturer, info.Product, info.Serial, info.Path)),
 		DriverName:            ledgerWalletDriverName,
 		DriverVersion:         ledgerWalletDriverVersion,
 		SupportedTransactions: ledgerWalletSupportedTxs,
@@ -145,7 +155,7 @@ func (lw *LedgerWallet) ListKeys() ([]crypto.Digest, error) {
 	lw.mu.Lock()
 	defer lw.mu.Unlock()
 
-	reply, err := lw.dev.Exchange([]byte{0x80, 0x03, 0x00, 0x00, 0x00})
+	reply, err := lw.dev.Exchange([]byte{ledger_CLA, ledger_INS_GET_PUBLIC_KEY, 0x00, 0x00, 0x00})
 	if err != nil {
 		return nil, err
 	}
@@ -288,14 +298,75 @@ func (lw *LedgerWallet) signTransactionHelper(tx transactions.Transaction) (sig 
 	lw.mu.Lock()
 	defer lw.mu.Unlock()
 
+	sig, err = lw.sendTransactionMsgpack(tx)
+	if err == nil {
+		return
+	}
+
+	ledgerErr, ok := err.(LedgerUSBError)
+	if ok && ledgerErr == 0x6d00 {
+		// We tried to send a msgpack-encoded transaction to the device,
+		// but it doesn't support the new-style opcode, so fall back
+		// to old-style encoding.
+		sig, err = lw.sendTransactionOldStyle(tx)
+	}
+
+	return
+}
+
+func (lw *LedgerWallet) sendTransactionMsgpack(tx transactions.Transaction) (sig crypto.Signature, err error) {
+	var reply []byte
+
+	tosend := protocol.Encode(tx)
+	p1 := ledger_P1_FIRST
+	p2 := ledger_P2_MORE
+
+	// As a precaution, make sure that chunk + 5-byte APDU header
+	// fits in 8-bit length fields.
+	const chunkSize = 250
+
+	for p2 != ledger_P2_LAST {
+		var chunk []byte
+		if len(tosend) > chunkSize {
+			chunk = tosend[:chunkSize]
+		} else {
+			chunk = tosend
+			p2 = ledger_P2_LAST
+		}
+
+		var msg []byte
+		msg = append(msg, ledger_CLA, ledger_INS_SIGN_MSGPACK, p1, p2, uint8(len(chunk)))
+		msg = append(msg, chunk...)
+
+		reply, err = lw.dev.Exchange(msg)
+		if err != nil {
+			return
+		}
+
+		tosend = tosend[len(chunk):]
+		p1 = ledger_P1_MORE
+	}
+
+	if len(reply) > len(sig) {
+		// Error related to transaction decoding.
+		errmsg := string(reply[len(sig)+1:])
+		err = errors.New(errmsg)
+		return
+	}
+
+	copy(sig[:], reply)
+	return
+}
+
+func (lw *LedgerWallet) sendTransactionOldStyle(tx transactions.Transaction) (sig crypto.Signature, err error) {
 	var msg []byte
-	msg = append(msg, 0x80)
+	msg = append(msg, ledger_CLA)
 
 	switch tx.Type {
 	case protocol.PaymentTx:
-		msg = append(msg, 0x04)
+		msg = append(msg, ledger_INS_SIGN_PAYMENT_V2)
 	case protocol.KeyRegistrationTx:
-		msg = append(msg, 0x05)
+		msg = append(msg, ledger_INS_SIGN_KEYREG_V2)
 	default:
 		err = fmt.Errorf("transaction type %s not supported", tx.Type)
 		return

--- a/daemon/kmd/wallet/driver/ledger_hid.go
+++ b/daemon/kmd/wallet/driver/ledger_hid.go
@@ -36,7 +36,7 @@ type LedgerUSBError uint16
 
 // Error satisfies builtin interface `error`
 func (err LedgerUSBError) Error() string {
-	return fmt.Sprintf("unexpected status %x", err)
+	return fmt.Sprintf("Exchange: unexpected status 0x%x", err)
 }
 
 // Protocol reference:

--- a/daemon/kmd/wallet/driver/ledger_hid.go
+++ b/daemon/kmd/wallet/driver/ledger_hid.go
@@ -30,6 +30,15 @@ type LedgerUSB struct {
 	hiddev *hid.Device
 }
 
+// LedgerUSBError is a wrapper around the two-byte error code that the Ledger
+// protocol returns.
+type LedgerUSBError uint16
+
+// Error satisfies builtin interface `error`
+func (err LedgerUSBError) Error() string {
+	return fmt.Sprintf("unexpected status %x", err)
+}
+
 // Protocol reference:
 // https://github.com/LedgerHQ/blue-loader-python/blob/master/ledgerblue/comm.py (see HIDDongleHIDAPI)
 // https://github.com/LedgerHQ/blue-loader-python/blob/master/ledgerblue/ledgerWrapper.py (see wrapCommandAPDU)
@@ -172,7 +181,7 @@ func (l *LedgerUSB) Exchange(msg []byte) ([]byte, error) {
 		// See various hints about what the error status might mean in
 		// HIDDongleHIDAPI.exchange():
 		// https://github.com/LedgerHQ/blue-loader-python/blob/master/ledgerblue/comm.py
-		return nil, fmt.Errorf("Exchange: unexpected status %x", replyStat)
+		return nil, LedgerUSBError(replyStat)
 	}
 
 	return replyMsg, nil


### PR DESCRIPTION
This allows us to add support for additional transaction features (like
note fields or new asset transaction types) without having to keep
modifying kmd.  Fallback to older format of transaction encoding if the
Ledger device is running an old version of the Algorand app.