### PR TITLE
LogicSig Eval caching explicitly based on (protocol version, txid)

### DIFF
--- a/data/pools/lsigEvalCache.go
+++ b/data/pools/lsigEvalCache.go
@@ -1,0 +1,93 @@
+// Copyright (C) 2019 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package pools
+
+import (
+	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/protocol"
+)
+
+type lsigEvalSubcache struct {
+	they map[protocol.ConsensusVersion]map[transactions.Txid]error
+}
+
+func (les *lsigEvalSubcache) get(cvers protocol.ConsensusVersion, txid transactions.Txid) (err error, found bool) {
+	if les == nil || les.they == nil {
+		found = false
+		err = nil
+		return
+	}
+	var byvers map[transactions.Txid]error
+	byvers, found = les.they[cvers]
+	if !found {
+		return
+	}
+	err, found = byvers[txid]
+	return
+}
+
+func (les *lsigEvalSubcache) put(cvers protocol.ConsensusVersion, txid transactions.Txid, err error, size int) {
+	if les.they == nil {
+		les.they = make(map[protocol.ConsensusVersion]map[transactions.Txid]error, 2)
+	}
+	//var byvers map[transactions.Txid]error
+	byvers, found := les.they[cvers]
+	if !found {
+		byvers = make(map[transactions.Txid]error, size)
+		les.they[cvers] = byvers
+	}
+	byvers[txid] = err
+}
+
+func (les *lsigEvalSubcache) size() int {
+	sum := 0
+	for _, byvers := range les.they {
+		sum += len(byvers)
+	}
+	return sum
+}
+
+type lsigEvalCache struct {
+	cur  *lsigEvalSubcache
+	prev *lsigEvalSubcache
+	size int
+}
+
+func makeLsigEvalCache(poolSize int) *lsigEvalCache {
+	out := &lsigEvalCache{
+		cur:  new(lsigEvalSubcache),
+		prev: nil,
+		size: poolSize,
+	}
+	return out
+}
+
+func (lec *lsigEvalCache) get(cvers protocol.ConsensusVersion, txid transactions.Txid) (err error, found bool) {
+	err, found = lec.cur.get(cvers, txid)
+	if found {
+		return
+	}
+	return lec.prev.get(cvers, txid)
+}
+
+func (lec *lsigEvalCache) put(cvers protocol.ConsensusVersion, txid transactions.Txid, err error) {
+	lec.cur.put(cvers, txid, err, lec.size)
+	if lec.cur.size() > lec.size {
+		lec.prev = lec.cur
+		lec.cur = new(lsigEvalSubcache)
+	}
+}

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -30,6 +30,7 @@ import (
 	"github.com/algorand/go-algorand/ledger"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/logging/telemetryspec"
+	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/util/condvar"
 )
 
@@ -61,7 +62,7 @@ type TransactionPool struct {
 	rememberedTxids    map[transactions.Txid]transactions.SignedTxn
 
 	// result of logic.Eval()
-	lsigCache *statusCache
+	lsigCache *lsigEvalCache
 	lcmu      deadlock.RWMutex
 }
 
@@ -81,7 +82,7 @@ func MakeTransactionPool(ledger *ledger.Ledger, cfg config.Local) *TransactionPo
 		statusCache:     makeStatusCache(cfg.TxPoolSize),
 		logStats:        cfg.EnableAssembleStats,
 		expFeeFactor:    cfg.TxPoolExponentialIncreaseFactor,
-		lsigCache:       makeStatusCache(cfg.TxPoolSize),
+		lsigCache:       makeLsigEvalCache(cfg.TxPoolSize),
 	}
 	pool.cond.L = &pool.mu
 	pool.recomputeBlockEvaluator()
@@ -334,18 +335,17 @@ func (pool *TransactionPool) Verified(txn transactions.SignedTxn) bool {
 }
 
 // EvalOk for LogicSig Eval of a txn by txid, returns the SignedTxn, error string, and found.
-func (pool *TransactionPool) EvalOk(txid transactions.Txid) (txErr string, found bool) {
+func (pool *TransactionPool) EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (err error, found bool) {
 	pool.lcmu.RLock()
 	defer pool.lcmu.RUnlock()
-	_, txErr, found = pool.lsigCache.check(txid)
-	return
+	return pool.lsigCache.get(cvers, txid)
 }
 
 // EvalRemember sets an error string from LogicSig Eval for some SignedTxn
-func (pool *TransactionPool) EvalRemember(tx transactions.SignedTxn, errString string) {
+func (pool *TransactionPool) EvalRemember(cvers protocol.ConsensusVersion, txid transactions.Txid, err error) {
 	pool.lcmu.Lock()
 	defer pool.lcmu.Unlock()
-	pool.lsigCache.put(tx, errString)
+	pool.lsigCache.put(cvers, txid, err)
 }
 
 // OnNewBlock excises transactions from the pool that are included in the specified Block or if they've expired
@@ -429,11 +429,11 @@ type alwaysVerifiedPool struct {
 func (*alwaysVerifiedPool) Verified(txn transactions.SignedTxn) bool {
 	return true
 }
-func (pool *alwaysVerifiedPool) EvalOk(txid transactions.Txid) (errStr string, found bool) {
-	return pool.pool.EvalOk(txid)
+func (pool *alwaysVerifiedPool) EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (txErr error, found bool) {
+	return pool.pool.EvalOk(cvers, txid)
 }
-func (pool *alwaysVerifiedPool) EvalRemember(txn transactions.SignedTxn, errStr string) {
-	pool.pool.EvalRemember(txn, errStr)
+func (pool *alwaysVerifiedPool) EvalRemember(cvers protocol.ConsensusVersion, txid transactions.Txid, txErr error) {
+	pool.pool.EvalRemember(cvers, txid, txErr)
 }
 
 func (pool *TransactionPool) addToPendingBlockEvaluatorOnce(txgroup []transactions.SignedTxn) error {

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -335,7 +335,7 @@ func (pool *TransactionPool) Verified(txn transactions.SignedTxn) bool {
 }
 
 // EvalOk for LogicSig Eval of a txn by txid, returns the SignedTxn, error string, and found.
-func (pool *TransactionPool) EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (err error, found bool) {
+func (pool *TransactionPool) EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (found bool, err error) {
 	pool.lcmu.RLock()
 	defer pool.lcmu.RUnlock()
 	return pool.lsigCache.get(cvers, txid)
@@ -429,7 +429,7 @@ type alwaysVerifiedPool struct {
 func (*alwaysVerifiedPool) Verified(txn transactions.SignedTxn) bool {
 	return true
 }
-func (pool *alwaysVerifiedPool) EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (txErr error, found bool) {
+func (pool *alwaysVerifiedPool) EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (txfound bool, err error) {
 	return pool.pool.EvalOk(cvers, txid)
 }
 func (pool *alwaysVerifiedPool) EvalRemember(cvers protocol.ConsensusVersion, txid transactions.Txid, txErr error) {

--- a/data/pools/transactionPool_test.go
+++ b/data/pools/transactionPool_test.go
@@ -1004,7 +1004,7 @@ func TestLogicSigCache(t *testing.T) {
 			Logic: program,
 		},
 	}
-	transactionPool.lsigCache.put(signedTx, "")
+	transactionPool.lsigCache.put(protocol.ConsensusCurrentVersion, signedTx.ID(), nil)
 	err = transactionPool.RememberOne(signedTx)
 	require.NoError(t, err)
 }

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -47,7 +47,7 @@ type evalAux struct {
 // pool object.
 type VerifiedTxnCache interface {
 	Verified(txn transactions.SignedTxn) bool
-	EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (txErr error, found bool)
+	EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (found bool, txErr error)
 	EvalRemember(cvers protocol.ConsensusVersion, txid transactions.Txid, err error)
 }
 
@@ -503,7 +503,7 @@ func (eval *BlockEvaluator) transaction(txn transactions.SignedTxn, ad transacti
 
 		needCheckLsig := !txn.Lsig.Blank()
 		if needCheckLsig {
-			txErr, found := eval.txcache.EvalOk(eval.block.CurrentProtocol, txid)
+			found, txErr := eval.txcache.EvalOk(eval.block.CurrentProtocol, txid)
 			if found {
 				if txErr == nil {
 					needCheckLsig = false

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -47,8 +47,8 @@ type evalAux struct {
 // pool object.
 type VerifiedTxnCache interface {
 	Verified(txn transactions.SignedTxn) bool
-	EvalOk(txid transactions.Txid) (txErr string, found bool)
-	EvalRemember(tx transactions.SignedTxn, errString string)
+	EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (txErr error, found bool)
+	EvalRemember(cvers protocol.ConsensusVersion, txid transactions.Txid, err error)
 }
 
 type roundCowBase struct {
@@ -503,22 +503,22 @@ func (eval *BlockEvaluator) transaction(txn transactions.SignedTxn, ad transacti
 
 		needCheckLsig := !txn.Lsig.Blank()
 		if needCheckLsig {
-			errStr, found := eval.txcache.EvalOk(txid)
+			txErr, found := eval.txcache.EvalOk(eval.block.CurrentProtocol, txid)
 			if found {
-				if errStr == "" {
+				if txErr == nil {
 					needCheckLsig = false
 				} else {
-					return errors.New(errStr)
+					return txErr
 				}
 			}
 		}
 		if needCheckLsig {
 			err = eval.checkLogicSig(txn, txgroup, groupIndex)
 			if err != nil {
-				eval.txcache.EvalRemember(txn, err.Error())
+				eval.txcache.EvalRemember(eval.block.CurrentProtocol, txid, err)
 				return err
 			}
-			eval.txcache.EvalRemember(txn, "")
+			eval.txcache.EvalRemember(eval.block.CurrentProtocol, txid, nil)
 		}
 	}
 

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -123,8 +123,8 @@ type DummyVerifiedTxnCache struct{}
 func (x DummyVerifiedTxnCache) Verified(txn transactions.SignedTxn) bool {
 	return false
 }
-func (x DummyVerifiedTxnCache) EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (err error, found bool) {
-	return nil, false
+func (x DummyVerifiedTxnCache) EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (found bool, err error) {
+	return false, nil
 }
 func (x DummyVerifiedTxnCache) EvalRemember(cvers protocol.ConsensusVersion, txid transactions.Txid, err error) {
 }

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -123,10 +123,10 @@ type DummyVerifiedTxnCache struct{}
 func (x DummyVerifiedTxnCache) Verified(txn transactions.SignedTxn) bool {
 	return false
 }
-func (x DummyVerifiedTxnCache) EvalOk(txid transactions.Txid) (errStr string, found bool) {
-	return "", false
+func (x DummyVerifiedTxnCache) EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (err error, found bool) {
+	return nil, false
 }
-func (x DummyVerifiedTxnCache) EvalRemember(txn transactions.SignedTxn, errStr string) {
+func (x DummyVerifiedTxnCache) EvalRemember(cvers protocol.ConsensusVersion, txid transactions.Txid, err error) {
 }
 
 func (l *Ledger) appendUnvalidated(blk bookkeeping.Block) error {


### PR DESCRIPTION
alternative to #428 where protocol version is part of the cache key. I think this is probably simpler and more correct.