### PR TITLE
Two fixes to possible infinite recursion in ::AlgorandGoal::StopNetwork

### DIFF
--- a/data/ledger.go
+++ b/data/ledger.go
@@ -341,24 +341,19 @@ func (*Ledger) AssemblePayset(pool *pools.TransactionPool, eval *ledger.BlockEva
 			break
 		}
 		if err != nil {
-			msg := fmt.Sprintf("Cannot add pending transaction to block: %v", err)
-
-			logAt := logging.Base().Warn
 
 			// GOAL2-255: Don't warn for common case of txn already being in ledger
 			switch err.(type) {
 			case ledger.TransactionInLedgerError:
-				logAt = logging.Base().Debug
 				stats.CommittedCount++
 			case transactions.MinFeeError:
-				logAt = logging.Base().Info
 				stats.InvalidCount++
+				logging.Base().Infof("Cannot add pending transaction to block: %v", err)
 			default:
-				// logAt = Warn
 				stats.InvalidCount++
+				logging.Base().Warnf("Cannot add pending transaction to block: %v", err)
 			}
 
-			logAt(msg)
 		} else {
 			for _, txn := range txgroup {
 				fee := txn.Txn.Fee.Raw
@@ -396,10 +391,9 @@ func (*Ledger) AssemblePayset(pool *pools.TransactionPool, eval *ledger.BlockEva
 				stats.TotalLength += uint64(encodedLen)
 			}
 		}
-
-		if stats.IncludedCount != 0 {
-			stats.AverageFee = totalFees / uint64(stats.IncludedCount)
-		}
+	}
+	if stats.IncludedCount != 0 {
+		stats.AverageFee = totalFees / uint64(stats.IncludedCount)
 	}
 	return
 }

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -97,10 +97,18 @@ proc ::AlgorandGoal::StartNetwork { NETWORK_NAME NETWORK_TEMPLATE TEST_ALGO_DIR 
 # Stop the network
 proc ::AlgorandGoal::StopNetwork { NETWORK_NAME TEST_ALGO_DIR TEST_ROOT_DIR } {
     set timeout 60
+    set NETWORK_STOP_MESSAGE ""
     puts "Stopping network: $NETWORK_NAME"
     spawn goal network stop -d $TEST_ALGO_DIR -r $TEST_ROOT_DIR
     expect {
-        timeout { close; ::AlgorandGoal::Abort "Failed to shutdown network" }
+        timeout {
+	    close;
+	    puts "Failed to shutdown network"
+	    puts "GLOBAL_TEST_ALGO_DIR $::GLOBAL_TEST_ALGO_DIR"
+	    puts "GLOBAL_TEST_ROOT_DIR $::GLOBAL_TEST_ROOT_DIR"
+	    puts "GLOBAL_NETWORK_NAME $::GLOBAL_NETWORK_NAME"
+	    exit 1;
+	}
         "Network Stopped under*" {set NETWORK_STOP_MESSAGE $expect_out(buffer); close}
     }
     puts $NETWORK_STOP_MESSAGE

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -100,7 +100,6 @@ proc ::AlgorandGoal::StopNetwork { NETWORK_NAME TEST_ALGO_DIR TEST_ROOT_DIR } {
     set NETWORK_STOP_MESSAGE ""
     puts "Stopping network: $NETWORK_NAME"
     spawn goal network stop -d $TEST_ALGO_DIR -r $TEST_ROOT_DIR
-    set NETWORK_STOP_MESSAGE "";
     expect {
         timeout {
 	    close;


### PR DESCRIPTION
Fix 1:
::AlgorandGoal::Abort calls ::AlgorandGoal::StopNetwork.
::AlgorandGoal::StopNetwork calls ::AlgorandGoal::Abort when fails to close the network.
This may cause infinite recursion when the conditions are right (e.g. is failing to close the network).
Fix: StopNetwork does not call Abort. 

Fix 2:
In ::AlgorandGoal::StopNetwork, when the spawn command output does not match the "Network Stopped under*", then NETWORK_STOP_MESSAGE is not set. If the spawn command did not timeout, then the "puts $NETWORK_STOP_MESSAGE" statement is executed. This is an expect script exception.
When ::AlgorandGoal::StopNetwork is called from try/catch statement, the exception is caught, and ::AlgorandGoal::Abort is called, which calls ::AlgorandGoal::StopNetwork.
Fix: initialize the variable to empty string. 

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Explain the goal of this change and what problem it is solving.

## Test Plan

How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale.

