### PR TITLE
Make asset name, URL, unit name fields variable length

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -192,6 +192,15 @@ type ConsensusParams struct {
 	// max number of assets per account
 	MaxAssetsPerAccount int
 
+	// max length of asset name
+	MaxAssetNameBytes int
+
+	// max length of asset unit name
+	MaxAssetUnitNameBytes int
+
+	// max length of asset url
+	MaxAssetURLBytes int
+
 	// support sequential transaction counter TxnCounter
 	TxnCounter bool
 
@@ -425,6 +434,9 @@ func initConsensusProtocols() {
 	vFuture.LogicSigMaxSize = 1000
 	vFuture.LogicSigMaxCost = 20000
 	vFuture.MaxAssetsPerAccount = 1000
+	vFuture.MaxAssetNameBytes = 32
+	vFuture.MaxAssetUnitNameBytes = 8
+	vFuture.MaxAssetURLBytes = 32
 	vFuture.SupportTxGroups = true
 	vFuture.MaxTxGroupSize = 16
 	vFuture.SupportTransactionLeases = true

--- a/data/basics/userBalance.go
+++ b/data/basics/userBalance.go
@@ -192,14 +192,14 @@ type AssetParams struct {
 
 	// UnitName specifies a hint for the name of a unit of
 	// this asset.
-	UnitName [8]byte `codec:"un"`
+	UnitName string `codec:"un"`
 
 	// AssetName specifies a hint for the name of the asset.
-	AssetName [32]byte `codec:"an"`
+	AssetName string `codec:"an"`
 
 	// URL specifies a URL where more information about the asset can be
 	// retrieved
-	URL [32]byte `codec:"au"`
+	URL string `codec:"au"`
 
 	// MetadataHash specifies a commitment to some unspecified asset
 	// metadata. The format of this metadata is up to the application.

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -344,7 +344,7 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 		return fmt.Errorf("transaction asset unit name too big: %d > %d", len(tx.AssetConfigTxnFields.AssetParams.UnitName), proto.MaxAssetUnitNameBytes)
 	}
 	if len(tx.AssetConfigTxnFields.AssetParams.URL) > proto.MaxAssetURLBytes {
-		return fmt.Errorf("transaction asset unit name too big: %d > %d", len(tx.AssetConfigTxnFields.AssetParams.URL), proto.MaxAssetURLBytes)
+		return fmt.Errorf("transaction asset url too big: %d > %d", len(tx.AssetConfigTxnFields.AssetParams.URL), proto.MaxAssetURLBytes)
 	}
 	if tx.Sender == spec.RewardsPool {
 		// this check is just to be safe, but reaching here seems impossible, since it requires computing a preimage of rwpool

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -337,6 +337,15 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 	if len(tx.Note) > proto.MaxTxnNoteBytes {
 		return fmt.Errorf("transaction note too big: %d > %d", len(tx.Note), proto.MaxTxnNoteBytes)
 	}
+	if len(tx.AssetConfigTxnFields.AssetParams.AssetName) > proto.MaxAssetNameBytes {
+		return fmt.Errorf("transaction asset name too big: %d > %d", len(tx.AssetConfigTxnFields.AssetParams.AssetName), proto.MaxAssetNameBytes)
+	}
+	if len(tx.AssetConfigTxnFields.AssetParams.UnitName) > proto.MaxAssetUnitNameBytes {
+		return fmt.Errorf("transaction asset unit name too big: %d > %d", len(tx.AssetConfigTxnFields.AssetParams.UnitName), proto.MaxAssetUnitNameBytes)
+	}
+	if len(tx.AssetConfigTxnFields.AssetParams.URL) > proto.MaxAssetURLBytes {
+		return fmt.Errorf("transaction asset unit name too big: %d > %d", len(tx.AssetConfigTxnFields.AssetParams.URL), proto.MaxAssetURLBytes)
+	}
 	if tx.Sender == spec.RewardsPool {
 		// this check is just to be safe, but reaching here seems impossible, since it requires computing a preimage of rwpool
 		return fmt.Errorf("transaction from incentive pool is invalid")

--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -209,6 +209,38 @@ func TestArchivalRestart(t *testing.T) {
 	require.Equal(t, basics.Round(0), earliest)
 }
 
+func makeUnsignedAssetCreateTx(total uint64, defaultFrozen bool, manager string, reserve string, freeze string, clawback string, unitName string, assetName string, url string, metadataHash []byte) (transactions.Transaction, error) {
+	var tx transactions.Transaction
+	var err error
+
+	tx.Type = protocol.AssetConfigTx
+	tx.AssetParams = basics.AssetParams{
+		Total:         total,
+		DefaultFrozen: defaultFrozen,
+	}
+	tx.AssetParams.Manager, err = basics.UnmarshalChecksumAddress(manager)
+	if err != nil {
+		return tx, err
+	}
+	tx.AssetParams.Reserve, err = basics.UnmarshalChecksumAddress(reserve)
+	if err != nil {
+		return tx, err
+	}
+	tx.AssetParams.Freeze, err = basics.UnmarshalChecksumAddress(freeze)
+	if err != nil {
+		return tx, err
+	}
+	tx.AssetParams.Clawback, err = basics.UnmarshalChecksumAddress(clawback)
+	if err != nil {
+		return tx, err
+	}
+	tx.AssetParams.URL = url
+	copy(tx.AssetParams.MetadataHash[:], metadataHash)
+	tx.AssetParams.UnitName = unitName
+	tx.AssetParams.AssetName = assetName
+	return tx, nil
+}
+
 func TestArchivalAssets(t *testing.T) {
 	// Start in archival mode, add 2K blocks with asset txns, restart, ensure all
 	// assets are there in index unless they were deleted
@@ -261,7 +293,7 @@ func TestArchivalAssets(t *testing.T) {
 
 		// make a transaction that will create an asset
 		creatorEncoded := creators[i].String()
-		tx, err := client.MakeUnsignedAssetCreateTx(100, false, creatorEncoded, creatorEncoded, creatorEncoded, creatorEncoded, "m", "m", "", nil)
+		tx, err := makeUnsignedAssetCreateTx(100, false, creatorEncoded, creatorEncoded, creatorEncoded, creatorEncoded, "m", "m", "", nil)
 		require.NoError(t, err)
 		tx.Sender = creators[i]
 		createdAssetIdx := basics.AssetIndex(blk.BlockHeader.TxnCounter + 1)

--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -436,25 +436,36 @@ func (c *Client) MakeUnsignedAssetCreateTx(total uint64, defaultFrozen bool, man
 		}
 	}
 
-	if len(url) > len(tx.AssetParams.URL) {
+	// Get consensus params so we can get max field lengths
+	params, err := c.SuggestedParams()
+	if err != nil {
+		return transactions.Transaction{}, err
+	}
+
+	cparams, ok := config.Consensus[protocol.ConsensusVersion(params.ConsensusVersion)]
+	if !ok {
+		return transactions.Transaction{}, errors.New("unknown consensus version")
+	}
+
+	if len(url) > cparams.MaxAssetURLBytes {
 		return tx, fmt.Errorf("asset url %s is too long (max %d bytes)", url, len(tx.AssetParams.URL))
 	}
-	copy(tx.AssetParams.URL[:], []byte(url))
+	tx.AssetParams.URL = url
 
 	if len(metadataHash) > len(tx.AssetParams.MetadataHash) {
 		return tx, fmt.Errorf("asset metadata hash %x too long (max %d bytes)", metadataHash, len(tx.AssetParams.MetadataHash))
 	}
 	copy(tx.AssetParams.MetadataHash[:], metadataHash)
 
-	if len(unitName) > len(tx.AssetParams.UnitName) {
+	if len(unitName) > cparams.MaxAssetUnitNameBytes {
 		return tx, fmt.Errorf("asset unit name %s too long (max %d bytes)", unitName, len(tx.AssetParams.UnitName))
 	}
-	copy(tx.AssetParams.UnitName[:], []byte(unitName))
+	tx.AssetParams.UnitName = unitName
 
-	if len(assetName) > len(tx.AssetParams.AssetName) {
+	if len(assetName) > cparams.MaxAssetNameBytes {
 		return tx, fmt.Errorf("asset name %s too long (max %d bytes)", assetName, len(tx.AssetParams.AssetName))
 	}
-	copy(tx.AssetParams.AssetName[:], []byte(assetName))
+	tx.AssetParams.AssetName = assetName
 
 	return tx, nil
 }


### PR DESCRIPTION
Byte arrays don't make a ton of sense for these fields since we have to trim null bytes everywhere we want to display them. @rotemh 