### PR TITLE
Fix version in config file generated by goal cmd

### DIFF
--- a/cmd/goal/node.go
+++ b/cmd/goal/node.go
@@ -33,7 +33,6 @@ import (
 	"github.com/algorand/go-algorand/libgoal"
 	"github.com/algorand/go-algorand/nodecontrol"
 	"github.com/algorand/go-algorand/util"
-	"github.com/algorand/go-algorand/util/codecs"
 	"github.com/algorand/go-algorand/util/tokens"
 )
 
@@ -480,8 +479,7 @@ var createCmd = &cobra.Command{
 		}
 
 		// save config to destination
-		configDest := filepath.Join(newNodeDestination, "config.json")
-		err = codecs.SaveNonDefaultValuesToFile(configDest, localConfig, config.GetDefaultLocal(), nil, true)
+		err = localConfig.SaveToDisk(newNodeDestination)
 		if err != nil {
 			reportErrorf(errorNodeCreation, err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -731,6 +731,8 @@ func loadConfigFromFile(configFile string) (c Local, err error) {
 	}
 
 	// Migrate in case defaults were changed
+	// If a config file does not have version, it is assumed to be zero.
+	// All fields listed in migrate() might be changed if an actual value matches to default value from a previous version.
 	c, err = migrate(c)
 	return
 }


### PR DESCRIPTION
## Summary

Before the fix 'goal network create' generated config.json
without 'Version' field. That forces config loader to assume Version=0
and start migrations.
If BroadcastConnectionsLimit set to 0 (special value) it is overwritten by -1
that is a new parameter introduced in config v4.
BroadcastConnectionsLimit does not exist in v3 with assumed value 0 in migration.

## Test Plan

No tests
