### PR TITLE
Fix fee increase in transaction pool

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -233,6 +233,16 @@ func (pool *TransactionPool) test(txgroup []transactions.SignedTxn) error {
 	// requires a flat MinTxnFee).
 	feePerByte = feePerByte * pool.feeThresholdMultiplier
 
+	// The threshold grows exponentially if there are multiple blocks
+	// pending in the pool.
+	if pool.numPendingWholeBlocks > 1 {
+		// golang has no convenient integer exponentiation, so we just
+		// do this in a loop
+		for i := 0; i < int(pool.numPendingWholeBlocks)-1; i++ {
+			feePerByte *= pool.expFeeFactor
+		}
+	}
+
 	for _, t := range txgroup {
 		feeThreshold := feePerByte * uint64(t.GetEncodedLength())
 		if t.Txn.Fee.Raw < feeThreshold {

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -233,15 +233,20 @@ func (pool *TransactionPool) test(txgroup []transactions.SignedTxn) error {
 	// requires a flat MinTxnFee).
 	feePerByte = feePerByte * pool.feeThresholdMultiplier
 
+	// The feePerByte should be bumped to 1 to make the exponentially
+	// threshold growing valid.
+	if (feePerByte == 0) && pool.numPendingWholeBlocks > 0 {
+		feePerByte = uint64(1)
+	}
+
 	// The threshold grows exponentially if there are multiple blocks
 	// pending in the pool.
-	if pool.numPendingWholeBlocks > 1 {
-		// golang has no convenient integer exponentiation, so we just
-		// do this in a loop
-		for i := 0; i < int(pool.numPendingWholeBlocks)-1; i++ {
-			feePerByte *= pool.expFeeFactor
-		}
+	// golang has no convenient integer exponentiation, so we just
+	// do this in a loop
+	for i := 0; i < int(pool.numPendingWholeBlocks)-1; i++ {
+		feePerByte *= pool.expFeeFactor
 	}
+
 
 	for _, t := range txgroup {
 		feeThreshold := feePerByte * uint64(t.GetEncodedLength())

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -235,7 +235,7 @@ func (pool *TransactionPool) test(txgroup []transactions.SignedTxn) error {
 
 	// The feePerByte should be bumped to 1 to make the exponentially
 	// threshold growing valid.
-	if (feePerByte == 0) && pool.numPendingWholeBlocks > 0 {
+	if feePerByte == 0 && pool.numPendingWholeBlocks > 0 {
 		feePerByte = uint64(1)
 	}
 
@@ -246,7 +246,6 @@ func (pool *TransactionPool) test(txgroup []transactions.SignedTxn) error {
 	for i := 0; i < int(pool.numPendingWholeBlocks)-1; i++ {
 		feePerByte *= pool.expFeeFactor
 	}
-
 
 	for _, t := range txgroup {
 		feeThreshold := feePerByte * uint64(t.GetEncodedLength())

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -235,7 +235,7 @@ func (pool *TransactionPool) test(txgroup []transactions.SignedTxn) error {
 
 	// The feePerByte should be bumped to 1 to make the exponentially
 	// threshold growing valid.
-	if feePerByte == 0 && pool.numPendingWholeBlocks > 0 {
+	if feePerByte == 0 && pool.numPendingWholeBlocks > 1 {
 		feePerByte = uint64(1)
 	}
 

--- a/shared/pingpong/accounts.go
+++ b/shared/pingpong/accounts.go
@@ -25,7 +25,7 @@ import (
 	"time"
 )
 
-func ensureAccounts(ac libgoal.Client, initCfg PpConfig) (accounts map[string]uint64,  cfg PpConfig, err error) {
+func ensureAccounts(ac libgoal.Client, initCfg PpConfig) (accounts map[string]uint64, cfg PpConfig, err error) {
 	accounts = make(map[string]uint64)
 	cfg = initCfg
 

--- a/shared/pingpong/pingpong.go
+++ b/shared/pingpong/pingpong.go
@@ -65,7 +65,7 @@ func fundAccounts(accounts map[string]uint64, client libgoal.Client, cfg PpConfi
 
 	// Fee of 0 will make cause the function to use the suggested one by network
 	fee := uint64(0)
-	minFund := cfg.MinAccountFunds+(cfg.MaxAmt+cfg.MaxFee)*cfg.TxnPerSec*uint64(math.Ceil(cfg.RefreshTime.Seconds()))
+	minFund := cfg.MinAccountFunds + (cfg.MaxAmt+cfg.MaxFee)*cfg.TxnPerSec*uint64(math.Ceil(cfg.RefreshTime.Seconds()))
 	for addr, balance := range accounts {
 		if balance < minFund {
 			toSend := minFund - balance


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

My previous PR #404  did a wrong change in transaction pool mechanism. The fee need to increase whenever the number of whole blocks in transaction pool increases (not only on receiving a new block). Otherwise, the transaction pool will leave DDoS opportunities.

