### PR TITLE
Improve algorelay error message

### DIFF
--- a/cmd/algorelay/relayCmd.go
+++ b/cmd/algorelay/relayCmd.go
@@ -97,6 +97,7 @@ func loadRelays(file string) []eb.Relay {
 	var relays []eb.Relay
 	err := codecs.LoadObjectFromFile(file, &relays)
 	if err != nil {
+		err = fmt.Errorf("Unable to load relays file - %v", err)
 		panic(makeExitError(1, err.Error()))
 	}
 	return relays


### PR DESCRIPTION
## Summary

When a corrupted json file is provided, we output the json parser error string directly.
There is nothing wrong with that, but given some context around that error could help the user understanding what is the context of the error.