### PR TITLE
Optimize block assembly of previously included transactions

### DIFF
--- a/data/ledger.go
+++ b/data/ledger.go
@@ -324,7 +324,7 @@ func (l *Ledger) AssemblePayset(pool *pools.TransactionPool, eval *ledger.BlockE
 
 	// retrieve a list of all the previously known txid in the current round. We want to retrieve it here so we could avoid
 	// exercising the ledger read lock.
-	prevRoundTxIds := eval.GetRoundTxIds(l.Latest())
+	prevRoundTxIds := l.GetRoundTxIds(l.Latest())
 
 	for len(pending) > 0 {
 		txgroup := pending[0]

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -122,19 +122,11 @@ func (pool *TransactionPool) PendingTxIDs() []transactions.Txid {
 func (pool *TransactionPool) Pending() [][]transactions.SignedTxn {
 	pool.pendingMu.RLock()
 	defer pool.pendingMu.RUnlock()
+	// note that this operation is safe for the sole reason that arrays in go are immutable.
+	// if the underlaying array need to be expanded, the actual underlaying array would need
+	// to be reallocated.
+	return pool.pendingTxGroups
 
-	txgroups := make([][]transactions.SignedTxn, len(pool.pendingTxGroups))
-	i := 0
-	for _, txgroup := range pool.pendingTxGroups {
-		txgroupCopy := make([]transactions.SignedTxn, len(txgroup))
-		for j, tx := range txgroup {
-			txgroupCopy[j] = tx
-		}
-
-		txgroups[i] = txgroupCopy
-		i++
-	}
-	return txgroups
 }
 
 // rememberCommit() saves the changes added by remember to

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -101,5 +102,21 @@ func BenchmarkTxHandlerProcessDecoded(b *testing.B) {
 	b.StartTimer()
 	for _, signedTxn := range signedTransactions {
 		txHandler.processDecoded([]transactions.SignedTxn{signedTxn})
+	}
+}
+
+func BenchmarkTimeAfter(b *testing.B) {
+	b.StopTimer()
+	b.ResetTimer()
+	deadline := time.Now().Add(5 * time.Second)
+	after := 0
+	before := 0
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if time.Now().After(deadline) {
+			after++
+		} else {
+			before++
+		}
 	}
 }

--- a/ledger/cow.go
+++ b/ledger/cow.go
@@ -184,9 +184,11 @@ func (cb *roundCowState) commitToParent() {
 }
 
 func (cb *roundCowState) modifiedAccounts() []basics.Address {
-	var res []basics.Address
+	res := make([]basics.Address, len(cb.mods.accts))
+	i := 0
 	for addr := range cb.mods.accts {
-		res = append(res, addr)
+		res[i] = addr
+		i++
 	}
 	return res
 }

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -339,6 +339,11 @@ func (eval *BlockEvaluator) workaroundOverspentRewards(rewardPoolBalance basics.
 	return
 }
 
+// IsDup returns true if the transaction was included in the specified round.
+func (eval *BlockEvaluator) IsDup(txn transactions.SignedTxn, round basics.Round) (bool, error) {
+	return eval.l.isDup(eval.proto, basics.Round(0), round, round, txn.ID(), txlease{})
+}
+
 // Round returns the round number of the block being evaluated by the BlockEvaluator.
 func (eval *BlockEvaluator) Round() basics.Round {
 	return eval.block.Round()

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -185,6 +185,7 @@ type ledgerForEvaluator interface {
 	Lookup(basics.Round, basics.Address) (basics.AccountData, error)
 	Totals(basics.Round) (AccountTotals, error)
 	isDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, txlease) (bool, error)
+	getRoundTxIds(rnd basics.Round) (txMap map[transactions.Txid]bool)
 	LookupWithoutRewards(basics.Round, basics.Address) (basics.AccountData, error)
 	GetAssetCreatorForRound(basics.Round, basics.AssetIndex) (basics.Address, error)
 }
@@ -339,9 +340,9 @@ func (eval *BlockEvaluator) workaroundOverspentRewards(rewardPoolBalance basics.
 	return
 }
 
-// IsDup returns true if the transaction was included in the specified round.
-func (eval *BlockEvaluator) IsDup(txn transactions.SignedTxn, round basics.Round) (bool, error) {
-	return eval.l.isDup(eval.proto, basics.Round(0), round, round, txn.ID(), txlease{})
+// GetRoundTxIds returns a map of the transactions ids that we have for the given round
+func (eval *BlockEvaluator) GetRoundTxIds(round basics.Round) (txMap map[transactions.Txid]bool) {
+	return eval.l.getRoundTxIds(round)
 }
 
 // Round returns the round number of the block being evaluated by the BlockEvaluator.

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -185,7 +185,7 @@ type ledgerForEvaluator interface {
 	Lookup(basics.Round, basics.Address) (basics.AccountData, error)
 	Totals(basics.Round) (AccountTotals, error)
 	isDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, txlease) (bool, error)
-	getRoundTxIds(rnd basics.Round) (txMap map[transactions.Txid]bool)
+	GetRoundTxIds(rnd basics.Round) (txMap map[transactions.Txid]bool)
 	LookupWithoutRewards(basics.Round, basics.Address) (basics.AccountData, error)
 	GetAssetCreatorForRound(basics.Round, basics.AssetIndex) (basics.Address, error)
 }
@@ -338,11 +338,6 @@ func (eval *BlockEvaluator) workaroundOverspentRewards(rewardPoolBalance basics.
 	poolOld, err = eval.state.Get(eval.prevHeader.RewardsPool, true)
 
 	return
-}
-
-// GetRoundTxIds returns a map of the transactions ids that we have for the given round
-func (eval *BlockEvaluator) GetRoundTxIds(round basics.Round) (txMap map[transactions.Txid]bool) {
-	return eval.l.getRoundTxIds(round)
 }
 
 // Round returns the round number of the block being evaluated by the BlockEvaluator.

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -557,6 +557,14 @@ func (eval *BlockEvaluator) transaction(txn transactions.SignedTxn, ad transacti
 	// completely zero, which means the account will be deleted.)
 	rewardlvl := cow.rewardsLevel()
 	for _, addr := range cow.modifiedAccounts() {
+		// Skip FeeSink and RewardsPool MinBalance checks here.
+		// There's only two accounts, so space isn't an issue, and we don't
+		// expect them to have low balances, but if they do, it may cause
+		// surprises for every transaction.
+		if addr == spec.FeeSink || addr == spec.RewardsPool {
+			continue
+		}
+
 		data, err := cow.lookup(addr)
 		if err != nil {
 			return err
@@ -566,14 +574,6 @@ func (eval *BlockEvaluator) transaction(txn transactions.SignedTxn, ad transacti
 		// because the accounts DB can delete it.  Otherwise, we will
 		// enforce MinBalance.
 		if data.IsZero() {
-			continue
-		}
-
-		// Skip FeeSink and RewardsPool MinBalance checks here.
-		// There's only two accounts, so space isn't an issue, and we don't
-		// expect them to have low balances, but if they do, it may cause
-		// surprises for every transaction.
-		if addr == spec.FeeSink || addr == spec.RewardsPool {
 			continue
 		}
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -338,7 +338,7 @@ func (l *Ledger) isDup(currentProto config.ConsensusParams, current basics.Round
 }
 
 // returns a map of the transactions ids that we have for the given round
-func (l *Ledger) getRoundTxIds(rnd basics.Round) (txMap map[transactions.Txid]bool) {
+func (l *Ledger) GetRoundTxIds(rnd basics.Round) (txMap map[transactions.Txid]bool) {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()
 	return l.txTail.getRoundTxIds(rnd)

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -337,6 +337,13 @@ func (l *Ledger) isDup(currentProto config.ConsensusParams, current basics.Round
 	return l.txTail.isDup(currentProto, current, firstValid, lastValid, txid, txl)
 }
 
+// returns a map of the transactions ids that we have for the given round
+func (l *Ledger) getRoundTxIds(rnd basics.Round) (txMap map[transactions.Txid]bool) {
+	l.trackerMu.RLock()
+	defer l.trackerMu.RUnlock()
+	return l.txTail.getRoundTxIds(rnd)
+}
+
 // Latest returns the latest known block round added to the ledger.
 func (l *Ledger) Latest() basics.Round {
 	return l.blockQ.latest()

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -337,7 +337,7 @@ func (l *Ledger) isDup(currentProto config.ConsensusParams, current basics.Round
 	return l.txTail.isDup(currentProto, current, firstValid, lastValid, txid, txl)
 }
 
-// returns a map of the transactions ids that we have for the given round
+// GetRoundTxIds returns a map of the transactions ids that we have for the given round
 func (l *Ledger) GetRoundTxIds(rnd basics.Round) (txMap map[transactions.Txid]bool) {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()

--- a/ledger/txtail.go
+++ b/ledger/txtail.go
@@ -131,10 +131,6 @@ func (t *txTail) isDup(proto config.ConsensusParams, current basics.Round, first
 
 func (t *txTail) getRoundTxIds(rnd basics.Round) (txMap map[transactions.Txid]bool) {
 	rndtxs := t.recent[rnd].txids
-	if rndtxs == nil {
-		txMap = make(map[transactions.Txid]bool)
-		return
-	}
 	txMap = make(map[transactions.Txid]bool, len(rndtxs))
 	for txid := range rndtxs {
 		txMap[txid] = true

--- a/ledger/txtail.go
+++ b/ledger/txtail.go
@@ -128,3 +128,16 @@ func (t *txTail) isDup(proto config.ConsensusParams, current basics.Round, first
 
 	return false, nil
 }
+
+func (t *txTail) getRoundTxIds(rnd basics.Round) (txMap map[transactions.Txid]bool) {
+	rndtxs := t.recent[rnd].txids
+	if rndtxs == nil {
+		txMap = make(map[transactions.Txid]bool)
+		return
+	}
+	txMap = make(map[transactions.Txid]bool, len(rndtxs))
+	for txid := range rndtxs {
+		txMap[txid] = true
+	}
+	return
+}

--- a/logging/telemetryspec/metric.go
+++ b/logging/telemetryspec/metric.go
@@ -35,20 +35,21 @@ type MetricDetails interface {
 
 // AssembleBlockStats is the set of stats captured when we compute AssemblePayset
 type AssembleBlockStats struct {
-	StartCount     int
-	IncludedCount  int
-	InvalidCount   int
-	MinFee         uint64
-	MaxFee         uint64
-	AverageFee     uint64
-	MinLength      int
-	MaxLength      int
-	MinPriority    uint64
-	MaxPriority    uint64
-	CommittedCount int
-	StopReason     string
-	TotalLength    uint64
-	Nanoseconds    int64
+	StartCount          int
+	IncludedCount       int
+	InvalidCount        int
+	MinFee              uint64
+	MaxFee              uint64
+	AverageFee          uint64
+	MinLength           int
+	MaxLength           int
+	MinPriority         uint64
+	MaxPriority         uint64
+	CommittedCount      int
+	StopReason          string
+	TotalLength         uint64
+	EarlyCommittedCount uint64
+	Nanoseconds         int64
 }
 
 // AssembleBlockTimeout represents AssemblePayset exiting due to timeout


### PR DESCRIPTION
## Summary

Block assembly often get executed before the transactions from the previous round are cleared from the transactions pool.
Our existing implementation does detect these transactions and excludes them from the newly assembled proposal correctly, however, it does that with some undesired overhead.

This PR eliminate most of that overhead by taking the ledger lock *once*, acquiring the list of the transactions from the previous round, and using that list to filter out pending transactions.