### PR TITLE
Make `goal asset config` work without creator, make `--manager` required

### DIFF
--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -100,6 +100,7 @@ func init() {
 	configAssetCmd.Flags().StringVar(&noteBase64, "noteb64", "", "Note (URL-base64 encoded)")
 	configAssetCmd.Flags().StringVarP(&noteText, "note", "n", "", "Note text (ignored if --noteb64 used also)")
 	configAssetCmd.Flags().BoolVarP(&noWaitAfterSend, "no-wait", "N", false, "Don't wait for transaction to commit")
+	configAssetCmd.MarkFlagRequired("manager")
 
 	sendAssetCmd.Flags().StringVar(&assetClawback, "clawback", "", "Address to issue a clawback transaction from (defaults to no clawback)")
 	sendAssetCmd.Flags().StringVar(&assetCreator, "creator", "", "Account address for asset creator")


### PR DESCRIPTION
`goal asset config` was currently failing with a cryptic error if `--assetid` was passed without a creator. This PR uses `creator` if it's there.

Also, `--manager` should be a required flag for `goal asset config`, so I changed that.