### PR TITLE
Only build/deploy a release when the commit is tagged.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ stages:
   - name: build_pr
     if: type = pull_request
   - name: build_release
-    if: branch =~ /^rel\// AND type != pull_request
+    if: tag IS present AND branch =~ /^rel\// AND type != pull_request
   - name: deploy
-    if: branch =~ /^rel\// AND type != pull_request
+    if: tag IS present AND branch =~ /^rel\// AND type != pull_request
 
 jobs:
   allow_failures:


### PR DESCRIPTION
We were building too many releases, need to make sure we only build tagged commits.