### PR TITLE
Fix transaction id capture in goalExpectCommon

### DIFF
--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -278,7 +278,7 @@ proc ::AlgorandGoal::AccountTransfer { FROM_WALLET_NAME FROM_WALLET_PASSWORD FRO
         expect {
             timeout { close; ::AlgorandGoal::Abort "Timed out transfering funds"  }
             "Please enter the password for wallet '$FROM_WALLET_NAME':" { send "$FROM_WALLET_PASSWORD\r" }
-            -re {[A-Z0-9]{52}} {set TRANSACTION_ID $expect_out(0,string); close }
+            -re {transaction ID: [A-Z0-9]{52}} {set TRANSACTION_ID $expect_out(0,string); close }
         }
     } EXCEPTION ] } {
        ::AlgorandGoal::Abort "ERROR in AccountTransfer: $EXCEPTION"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

In `goalExpectCommon.exp`,  `AccountTransfer` will return a wrong transaction ID since the regex didn't capture the current output that `goal clerk send` emits.

Currently, `goal clerk send` output something like:

```
Sent 300000 MicroAlgos from account IFQPDFV6QDMXVU3RQDJI2BEE5IWDBA47YEMYAQQJ3624MB5AQJE3KVD66A to address OXKZL5ZWMQJJWQG57WWSBKKMQHDNQC6MNO3J54SF2B4LZ3VTUMFDKYJXQI, transaction ID: 4GU2OOBWWH4KNYL6H6D3GZD7QLYXZIMGE564JPT2QRHZKDA2AIUQ. Fee set to 1000
```
This PR fixes the regex.


## Test Plan

Tested locally.
