### PR TITLE
Allow closing deleted assets

### DIFF
--- a/data/transactions/asset.go
+++ b/data/transactions/asset.go
@@ -350,7 +350,7 @@ func (ct AssetTransferTxnFields) apply(header Header, balances Balances, spec Sp
 		}
 
 		// Fetch the destination balance record to check if we are
-		// closing out to the creator (and the asset still exists)
+		// closing out to the creator
 		dst, err := balances.Get(ct.AssetCloseTo, false)
 		if err != nil {
 			return err

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -183,6 +183,11 @@ func (qs *accountsDbQueries) lookupAssetCreator(assetIdx basics.AssetIndex) (add
 	err = db.Retry(func() error {
 		var buf []byte
 		err := qs.lookupAssetCreatorStmt.QueryRow(assetIdx).Scan(&buf)
+
+		if err == sql.ErrNoRows {
+			err = fmt.Errorf("asset %v does not exist or has been deleted", assetIdx)
+		}
+
 		if err != nil {
 			return err
 		}

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -185,7 +185,7 @@ func (qs *accountsDbQueries) lookupAssetCreator(assetIdx basics.AssetIndex) (add
 		err := qs.lookupAssetCreatorStmt.QueryRow(assetIdx).Scan(&buf)
 
 		if err == sql.ErrNoRows {
-			err = fmt.Errorf("asset %v does not exist or has been deleted", assetIdx)
+			err = fmt.Errorf("asset %d does not exist or has been deleted", assetIdx)
 		}
 
 		if err != nil {


### PR DESCRIPTION
I introduced a bug in #403 that makes it impossible to close an asset holding if the overall asset has been deleted. If an asset has been deleted, looking up its creator will fail. This is bad because now there is an unrecoverable minbalance, since the holding/account can never be closed.

This also uncovered a higher level issue: we want to allow people to close out assets to the creator, even if their asset holding is frozen. What does this mean for an asset that has been deleted, since that asset no longer has a creator? To resolve this, this PR assumes that it is OK to close out an asset holding if the amount is zero. I am sending an email to discuss this (also b/c it is protocol incompatible with current betanet).

I manually tested that this change allows closing out a zero asset holding for an asset that has been deleted.

Thanks to Sam Abbassi for noticing this.