### PR TITLE
Fix limit-order template

### DIFF
--- a/tools/teal/templates/limit-order.teal.tmpl
+++ b/tools/teal/templates/limit-order.teal.tmpl
@@ -1,4 +1,4 @@
-global GroupIndex
+txn GroupIndex
 int 0
 ==
 txn TypeEnum


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

`global GroupIndex` is illegal now. Thus, limit order template would not compile. This PR fixes this problem.

## Test Plan

will be end to end tested in the incoming limit order end to end test PR.
