### PR TITLE
Avoid revalidating confirmed transaction during block evaluator recomputation

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -85,7 +85,7 @@ func MakeTransactionPool(ledger *ledger.Ledger, cfg config.Local) *TransactionPo
 		lsigCache:       makeLsigEvalCache(cfg.TxPoolSize),
 	}
 	pool.cond.L = &pool.mu
-	pool.recomputeBlockEvaluator()
+	pool.recomputeBlockEvaluator(make(map[transactions.Txid]struct{}))
 	return &pool
 }
 
@@ -363,7 +363,7 @@ func (pool *TransactionPool) EvalRemember(cvers protocol.ConsensusVersion, txid 
 }
 
 // OnNewBlock excises transactions from the pool that are included in the specified Block or if they've expired
-func (pool *TransactionPool) OnNewBlock(block bookkeeping.Block) {
+func (pool *TransactionPool) OnNewBlock(block bookkeeping.Block, delta ledger.StateDelta) {
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
 	defer pool.cond.Broadcast()
@@ -372,21 +372,16 @@ func (pool *TransactionPool) OnNewBlock(block bookkeeping.Block) {
 	var knownCommitted uint
 	var unknownCommitted uint
 
-	payset, err := block.DecodePaysetFlat()
-	if err == nil {
-		pool.pendingMu.RLock()
-		for _, txad := range payset {
-			tx := txad.SignedTxn
-			txid := tx.ID()
-			_, ok := pool.pendingTxids[txid]
-			if ok {
-				knownCommitted++
-			} else {
-				unknownCommitted++
-			}
+	commitedTxids := delta.Txids()
+	pool.pendingMu.RLock()
+	for txid := range commitedTxids {
+		if _, ok := pool.pendingTxids[txid]; ok {
+			knownCommitted++
+		} else {
+			unknownCommitted++
 		}
-		pool.pendingMu.RUnlock()
 	}
+	pool.pendingMu.RUnlock()
 
 	if pool.pendingBlockEvaluator == nil || block.Round() >= pool.pendingBlockEvaluator.Round() {
 		// Adjust the pool fee threshold.  The rules are:
@@ -415,7 +410,7 @@ func (pool *TransactionPool) OnNewBlock(block bookkeeping.Block) {
 		// Recompute the pool by starting from the new latest block.
 		// This has the side-effect of discarding transactions that
 		// have been committed (or that are otherwise no longer valid).
-		stats = pool.recomputeBlockEvaluator()
+		stats = pool.recomputeBlockEvaluator(commitedTxids)
 	}
 
 	stats.KnownCommittedCount = knownCommitted
@@ -482,7 +477,7 @@ func (pool *TransactionPool) addToPendingBlockEvaluator(txgroup []transactions.S
 // recomputeBlockEvaluator constructs a new BlockEvaluator and feeds all
 // in-pool transactions to it (removing any transactions that are rejected
 // by the BlockEvaluator).
-func (pool *TransactionPool) recomputeBlockEvaluator() (stats telemetryspec.ProcessBlockMetrics) {
+func (pool *TransactionPool) recomputeBlockEvaluator(committedTxIds map[transactions.Txid]struct{}) (stats telemetryspec.ProcessBlockMetrics) {
 	pool.pendingBlockEvaluator = nil
 
 	latest := pool.ledger.Latest()
@@ -507,6 +502,12 @@ func (pool *TransactionPool) recomputeBlockEvaluator() (stats telemetryspec.Proc
 	pool.pendingMu.RUnlock()
 
 	for _, txgroup := range txgroups {
+		if len(txgroup) == 0 {
+			continue
+		}
+		if _, alreadyCommitted := committedTxIds[txgroup[0].ID()]; alreadyCommitted {
+			continue
+		}
 		err := pool.remember(txgroup)
 		if err != nil {
 			for _, tx := range txgroup {

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -475,7 +475,7 @@ func (au *accountUpdates) committedUpTo(rnd basics.Round) basics.Round {
 	return au.dbRound
 }
 
-func (au *accountUpdates) newBlock(blk bookkeeping.Block, delta stateDelta) {
+func (au *accountUpdates) newBlock(blk bookkeeping.Block, delta StateDelta) {
 	proto := config.Consensus[blk.CurrentProtocol]
 	rnd := blk.Round()
 

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -49,8 +49,8 @@ func (ml *mockLedgerForTracker) Latest() basics.Round {
 	return basics.Round(len(ml.blocks)) - 1
 }
 
-func (ml *mockLedgerForTracker) trackerEvalVerified(blk bookkeeping.Block, aux evalAux) (stateDelta, error) {
-	delta := stateDelta{
+func (ml *mockLedgerForTracker) trackerEvalVerified(blk bookkeeping.Block, aux evalAux) (StateDelta, error) {
+	delta := StateDelta{
 		hdr: &bookkeeping.BlockHeader{},
 	}
 	return delta, nil
@@ -219,7 +219,7 @@ func TestAcctUpdates(t *testing.T) {
 		blk.RewardsLevel = rewardLevel
 		blk.CurrentProtocol = protocol.ConsensusCurrentVersion
 
-		au.newBlock(blk, stateDelta{
+		au.newBlock(blk, StateDelta{
 			accts: updates,
 			hdr:   &blk.BlockHeader,
 		})

--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -64,7 +64,7 @@ func (wl *wrappedLedger) blockAux(rnd basics.Round) (bookkeeping.Block, evalAux,
 	return wl.l.blockAux(rnd)
 }
 
-func (wl *wrappedLedger) trackerEvalVerified(blk bookkeeping.Block, aux evalAux) (stateDelta, error) {
+func (wl *wrappedLedger) trackerEvalVerified(blk bookkeeping.Block, aux evalAux) (StateDelta, error) {
 	return wl.l.trackerEvalVerified(blk, aux)
 }
 

--- a/ledger/bulletin.go
+++ b/ledger/bulletin.go
@@ -86,7 +86,7 @@ func (b *bulletin) loadFromDisk(l ledgerForTracker) error {
 func (b *bulletin) close() {
 }
 
-func (b *bulletin) newBlock(blk bookkeeping.Block, delta stateDelta) {
+func (b *bulletin) newBlock(blk bookkeeping.Block, delta StateDelta) {
 }
 
 func (b *bulletin) committedUpTo(rnd basics.Round) basics.Round {

--- a/ledger/cow.go
+++ b/ledger/cow.go
@@ -45,10 +45,11 @@ type roundCowState struct {
 	lookupParent roundCowParent
 	commitParent *roundCowState
 	proto        config.ConsensusParams
-	mods         stateDelta
+	mods         StateDelta
 }
 
-type stateDelta struct {
+// StateDelta describes the delta between a given round to the previous round
+type StateDelta struct {
 	// modified accounts
 	accts map[basics.Address]accountDelta
 
@@ -65,12 +66,20 @@ type stateDelta struct {
 	hdr *bookkeeping.BlockHeader
 }
 
+// Txids returns the map fo the transactions Ids included
+func (st *StateDelta) Txids() map[transactions.Txid]struct{} {
+	if st.txids == nil {
+		return make(map[transactions.Txid]struct{})
+	}
+	return st.txids
+}
+
 func makeRoundCowState(b roundCowParent, hdr bookkeeping.BlockHeader) *roundCowState {
 	return &roundCowState{
 		lookupParent: b,
 		commitParent: nil,
 		proto:        config.Consensus[hdr.CurrentProtocol],
-		mods: stateDelta{
+		mods: StateDelta{
 			accts:    make(map[basics.Address]accountDelta),
 			txids:    make(map[transactions.Txid]struct{}),
 			txleases: make(map[txlease]basics.Round),
@@ -149,7 +158,7 @@ func (cb *roundCowState) child() *roundCowState {
 		lookupParent: cb,
 		commitParent: cb,
 		proto:        cb.proto,
-		mods: stateDelta{
+		mods: StateDelta{
 			accts:    make(map[basics.Address]accountDelta),
 			txids:    make(map[transactions.Txid]struct{}),
 			txleases: make(map[txlease]basics.Round),

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -685,10 +685,10 @@ func (eval *BlockEvaluator) GenerateBlock() (*ValidatedBlock, error) {
 	return &vb, nil
 }
 
-func (l *Ledger) eval(ctx context.Context, blk bookkeeping.Block, aux *evalAux, validate bool, txcache VerifiedTxnCache, executionPool execpool.BacklogPool) (stateDelta, evalAux, error) {
+func (l *Ledger) eval(ctx context.Context, blk bookkeeping.Block, aux *evalAux, validate bool, txcache VerifiedTxnCache, executionPool execpool.BacklogPool) (StateDelta, evalAux, error) {
 	eval, err := startEvaluator(l, blk.BlockHeader, aux, validate, false, txcache, executionPool)
 	if err != nil {
-		return stateDelta{}, evalAux{}, err
+		return StateDelta{}, evalAux{}, err
 	}
 
 	// TODO: batch tx sig verification: ingest blk.Payset and output a list of ValidatedTx
@@ -696,33 +696,33 @@ func (l *Ledger) eval(ctx context.Context, blk bookkeeping.Block, aux *evalAux, 
 	// Next, transactions
 	paysetgroups, err := blk.DecodePaysetGroups()
 	if err != nil {
-		return stateDelta{}, evalAux{}, err
+		return StateDelta{}, evalAux{}, err
 	}
 
 	for _, txgroup := range paysetgroups {
 		select {
 		case <-ctx.Done():
-			return stateDelta{}, evalAux{}, ctx.Err()
+			return StateDelta{}, evalAux{}, ctx.Err()
 		default:
 		}
 
 		err = eval.TransactionGroup(txgroup)
 		if err != nil {
-			return stateDelta{}, evalAux{}, err
+			return StateDelta{}, evalAux{}, err
 		}
 	}
 
 	// Finally, procees any pending end-of-block state changes
 	err = eval.endOfBlock()
 	if err != nil {
-		return stateDelta{}, evalAux{}, err
+		return StateDelta{}, evalAux{}, err
 	}
 
 	// If validating, do final block checks that depend on our new state
 	if validate {
 		err = eval.finalValidation()
 		if err != nil {
-			return stateDelta{}, evalAux{}, err
+			return StateDelta{}, evalAux{}, err
 		}
 	}
 
@@ -752,7 +752,7 @@ func (l *Ledger) Validate(ctx context.Context, blk bookkeeping.Block, txcache Ve
 // the work of applying the block's changes to the ledger state.
 type ValidatedBlock struct {
 	blk   bookkeeping.Block
-	delta stateDelta
+	delta StateDelta
 	aux   evalAux
 }
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -484,7 +484,7 @@ func (l *Ledger) trackerLog() logging.Logger {
 	return l.log
 }
 
-func (l *Ledger) trackerEvalVerified(blk bookkeeping.Block, aux evalAux) (stateDelta, error) {
+func (l *Ledger) trackerEvalVerified(blk bookkeeping.Block, aux evalAux) (StateDelta, error) {
 	// passing nil as the verificationPool is ok since we've asking the evaluator to skip verification.
 	delta, _, err := l.eval(context.Background(), blk, &aux, false, nil, nil)
 	return delta, err

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -38,7 +38,7 @@ func (mt *metricsTracker) loadFromDisk(l ledgerForTracker) error {
 func (mt *metricsTracker) close() {
 }
 
-func (mt *metricsTracker) newBlock(blk bookkeeping.Block, delta stateDelta) {
+func (mt *metricsTracker) newBlock(blk bookkeeping.Block, delta StateDelta) {
 	rnd := blk.Round()
 	mt.ledgerRound.Set(float64(rnd), map[string]string{})
 	mt.ledgerTransactionsTotal.Add(float64(len(blk.Payset)), map[string]string{})

--- a/ledger/time.go
+++ b/ledger/time.go
@@ -42,7 +42,7 @@ func (tt *timeTracker) loadFromDisk(l ledgerForTracker) error {
 func (tt *timeTracker) close() {
 }
 
-func (tt *timeTracker) newBlock(blk bookkeeping.Block, delta stateDelta) {
+func (tt *timeTracker) newBlock(blk bookkeeping.Block, delta StateDelta) {
 	rnd := blk.Round()
 	tt.timestamps[rnd] = delta.hdr.TimeStamp
 }

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -52,8 +52,8 @@ type ledgerTracker interface {
 	loadFromDisk(ledgerForTracker) error
 
 	// newBlock informs the tracker of a new block from round
-	// rnd and a given stateDelta as produced by BlockEvaluator.
-	newBlock(blk bookkeeping.Block, delta stateDelta)
+	// rnd and a given StateDelta as produced by BlockEvaluator.
+	newBlock(blk bookkeeping.Block, delta StateDelta)
 
 	// committedUpTo informs the tracker that the database has
 	// committed all blocks up to and including rnd to persistent
@@ -81,7 +81,7 @@ type ledgerTracker interface {
 type ledgerForTracker interface {
 	trackerDB() dbPair
 	trackerLog() logging.Logger
-	trackerEvalVerified(bookkeeping.Block, evalAux) (stateDelta, error)
+	trackerEvalVerified(bookkeeping.Block, evalAux) (StateDelta, error)
 
 	Latest() basics.Round
 	Block(basics.Round) (bookkeeping.Block, error)
@@ -108,7 +108,7 @@ func (tr *trackerRegistry) loadFromDisk(l ledgerForTracker) error {
 	return nil
 }
 
-func (tr *trackerRegistry) newBlock(blk bookkeeping.Block, delta stateDelta) {
+func (tr *trackerRegistry) newBlock(blk bookkeeping.Block, delta StateDelta) {
 	for _, lt := range tr.trackers {
 		lt.newBlock(blk, delta)
 	}

--- a/ledger/txtail.go
+++ b/ledger/txtail.go
@@ -79,7 +79,7 @@ func (t *txTail) loadFromDisk(l ledgerForTracker) error {
 func (t *txTail) close() {
 }
 
-func (t *txTail) newBlock(blk bookkeeping.Block, delta stateDelta) {
+func (t *txTail) newBlock(blk bookkeeping.Block, delta StateDelta) {
 	rnd := blk.Round()
 
 	if t.recent[rnd].txids != nil {

--- a/ledger/txtail.go
+++ b/ledger/txtail.go
@@ -88,7 +88,7 @@ func (t *txTail) newBlock(blk bookkeeping.Block, delta StateDelta) {
 	}
 
 	t.recent[rnd] = roundTxMembers{
-		txids:    delta.txids,
+		txids:    delta.Txids,
 		txleases: delta.txleases,
 		proto:    config.Consensus[blk.CurrentProtocol],
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -696,7 +696,7 @@ func (node *AlgorandFullNode) IsArchival() bool {
 }
 
 // OnNewBlock implements the BlockListener interface so we're notified after each block is written to the ledger
-func (node *AlgorandFullNode) OnNewBlock(block bookkeeping.Block) {
+func (node *AlgorandFullNode) OnNewBlock(block bookkeeping.Block, delta ledger.StateDelta) {
 	// Update fee tracker
 	node.feeTracker.ProcessBlock(block)
 

--- a/node/topAccountListener.go
+++ b/node/topAccountListener.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/ledger"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/logging/telemetryspec"
 	"github.com/algorand/go-algorand/protocol"
@@ -60,9 +61,9 @@ func (t *topAccountListener) init(balances basics.BalanceDetail) {
 }
 
 // BlockListener event, triggered when the ledger writes a new block.
-func (t *topAccountListener) OnNewBlock(b bookkeeping.Block) {
+func (t *topAccountListener) OnNewBlock(block bookkeeping.Block, delta ledger.StateDelta) {
 	// XXX revise for new ledger API
-	// t.update(b, balances)
+	// t.update(block, balances)
 
 	// If number of accounts after update is insufficient, do a full re-init
 	if len(t.accounts) < numTopAccounts {


### PR DESCRIPTION
## Summary

When OnNewBlock is called, we already know which transactions have been removed.
This PR attempted to avoid calling the "remember" function on these.

High level changes:

* On the notifier, store both the block and delta state objects.
* When sending OnNewBlock, send both block as well as the delta state
* Take advantage of the added information in the txpool's onnewblock->recomputeEvaluator by excluding transactions the we know we don't need.
