### PR TITLE
Add created asset index to txn status

### DIFF
--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -253,8 +253,8 @@ var createAssetCmd = &cobra.Command{
 				if err != nil {
 					reportErrorf(err.Error())
 				}
-				if txn.CreatedAssetIndex != 0 {
-					reportInfof("Created asset with asset index %d", txn.CreatedAssetIndex)
+				if txn.TransactionResults != nil && txn.TransactionResults.CreatedAssetIndex != 0 {
+					reportInfof("Created asset with asset index %d", txn.TransactionResults.CreatedAssetIndex)
 				}
 			}
 		} else {

--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -248,6 +248,14 @@ var createAssetCmd = &cobra.Command{
 				if err != nil {
 					reportErrorf(err.Error())
 				}
+				// Check if we know about the transaction yet
+				txn, err := client.PendingTransactionInformation(txid)
+				if err != nil {
+					reportErrorf(err.Error())
+				}
+				if txn.CreatedAssetIndex != 0 {
+					reportInfof("Created asset with asset index %d", txn.CreatedAssetIndex)
+				}
 			}
 		} else {
 			err = writeTxnToFile(client, sign, dataDir, walletName, tx, txFilename)

--- a/daemon/algod/api/server/v1/handlers/handlers.go
+++ b/daemon/algod/api/server/v1/handlers/handlers.go
@@ -247,7 +247,7 @@ func computeAssetIndexInPayset(tx node.TxnWithStatus, txnCounter uint64, payset 
 	}
 
 	// Count into block to get created asset index
-	return txnCounter + uint64(offset)
+	return txnCounter - uint64(len(payset)) + uint64(offset) + 1
 }
 
 // computeAssetIndexFromTxn returns the created asset index given a confirmed

--- a/daemon/algod/api/server/v1/handlers/handlers.go
+++ b/daemon/algod/api/server/v1/handlers/handlers.go
@@ -251,7 +251,8 @@ func computeAssetIndexInPayset(tx node.TxnWithStatus, txnCounter uint64, payset 
 }
 
 // computeAssetIndexFromTxn returns the created asset index given a confirmed
-// transaction whose confirmation block is available in the ledger
+// transaction whose confirmation block is available in the ledger. Note that
+// 0 is an invalid asset index (they start at 1).
 func computeAssetIndexFromTxn(tx node.TxnWithStatus, l *data.Ledger) (aidx uint64) {
 	// Must have ledger
 	if l == nil {

--- a/daemon/algod/api/server/v1/handlers/handlers.go
+++ b/daemon/algod/api/server/v1/handlers/handlers.go
@@ -746,6 +746,10 @@ func PendingTransactionInformation(ctx lib.ReqContext, w http.ResponseWriter, r 
 		}
 
 		responseTxs.TransactionResults = &v1.TransactionResults{
+			// This field will be omitted for transactions that did not
+			// create an asset (or for which we could not look up the block
+			// it was created in), because computeAssetIndexFromTxn will
+			// return 0 in that case.
 			CreatedAssetIndex: computeAssetIndexFromTxn(txn, ledger),
 		}
 

--- a/daemon/algod/api/spec/v1/model.go
+++ b/daemon/algod/api/spec/v1/model.go
@@ -315,10 +315,10 @@ type Transaction struct {
 	// required: false
 	ConfirmedRound uint64 `json:"round"`
 
-	// CreatedAssetIndex indicates the asset index of an asset created by this txn
+	// TransactionResults contains information about the side effects of a transaction
 	//
 	// required: false
-	CreatedAssetIndex uint64 `json:"createdasset,omitempty"`
+	TransactionResults *TransactionResults `json:"txresults,omitempty"`
 
 	// PoolError indicates the transaction was evicted from this node's transaction
 	// pool (if non-empty).  A non-empty PoolError does not guarantee that the
@@ -446,6 +446,15 @@ type KeyregTransactionType struct {
 	//
 	// required: false
 	VoteKeyDilution uint64 `json:"votekd"`
+}
+
+// TransactionResults contains information about the side effects of a transaction
+// swagger:model TransactionResults
+type TransactionResults struct {
+	// CreatedAssetIndex indicates the asset index of an asset created by this txn
+	//
+	// required: false
+	CreatedAssetIndex uint64 `json:"createdasset,omitempty"`
 }
 
 // AssetConfigTransactionType contains the additional fields for an asset config transaction

--- a/daemon/algod/api/spec/v1/model.go
+++ b/daemon/algod/api/spec/v1/model.go
@@ -315,6 +315,11 @@ type Transaction struct {
 	// required: false
 	ConfirmedRound uint64 `json:"round"`
 
+	// CreatedAssetIndex indicates the asset index of an asset created by this txn
+	//
+	// required: false
+	CreatedAssetIndex uint64 `json:"createdasset,omitempty"`
+
 	// PoolError indicates the transaction was evicted from this node's transaction
 	// pool (if non-empty).  A non-empty PoolError does not guarantee that the
 	// transaction will never be committed; other nodes may not have evicted the


### PR DESCRIPTION
This PR adds a new field to `v1.Transaction` called `TransactionResults`. This field is a struct containing `CreatedAssetIndex`, the index (if any) of an asset created by this transaction.

It computes the created asset index by looking up the block associated with the transaction if it was confirmed (and the correct type of transaction), computing the offset within that block, and adjusting based on `TxnCounter`.

Currently we're just returning this on a best-effort basis. If we don't have access to the block, we can't compute the created asset index based on just the transaction id.