### PR TITLE
Preallocate the payset to avoid dynamic resizing

### DIFF
--- a/data/bookkeeping/block.go
+++ b/data/bookkeeping/block.go
@@ -389,7 +389,7 @@ func MakeBlock(prev BlockHeader) Block {
 		logging.Base().Panicf("MakeBlock: next protocol %v not supported", upgradeState.CurrentProtocol)
 	}
 
-	emptyPayset := make(transactions.Payset, 0)
+	var emptyPayset transactions.Payset
 
 	timestamp := time.Now().Unix()
 	if prev.TimeStamp > 0 {

--- a/data/bookkeeping/block.go
+++ b/data/bookkeeping/block.go
@@ -548,7 +548,8 @@ func SignedTxnsToGroups(txns []transactions.SignedTxn) (res [][]transactions.Sig
 }
 
 // SignedTxnGroupsFlatten combines all groups into a flat slice of SignedTxns.
-func SignedTxnGroupsFlatten(txgroups [][]transactions.SignedTxn) (res []transactions.SignedTxn) {
+func SignedTxnGroupsFlatten(txgroups [][]transactions.SignedTxn, txnCount int) (res []transactions.SignedTxn) {
+	res = make([]transactions.SignedTxn, 0, txnCount)
 	for _, txgroup := range txgroups {
 		res = append(res, txgroup...)
 	}

--- a/data/bookkeeping/block.go
+++ b/data/bookkeeping/block.go
@@ -389,7 +389,7 @@ func MakeBlock(prev BlockHeader) Block {
 		logging.Base().Panicf("MakeBlock: next protocol %v not supported", upgradeState.CurrentProtocol)
 	}
 
-	var emptyPayset transactions.Payset
+	emptyPayset := make(transactions.Payset, 0)
 
 	timestamp := time.Now().Unix()
 	if prev.TimeStamp > 0 {

--- a/data/ledger.go
+++ b/data/ledger.go
@@ -317,9 +317,9 @@ func (l *Ledger) EnsureBlock(block *bookkeeping.Block, c agreement.Certificate) 
 
 // AssemblePayset adds transactions to a BlockEvaluator.
 func (l *Ledger) AssemblePayset(txpool *pools.TransactionPool, blk bookkeeping.BlockHeader, verificationPool execpool.BacklogPool, deadline time.Time) (eval *ledger.BlockEvaluator, stats telemetryspec.AssembleBlockStats, err error) {
-	pending := txpool.Pending()
+	pending, pendingTxCount := txpool.Pending()
 
-	eval, err = l.StartEvaluator(blk, len(pending), txpool, verificationPool)
+	eval, err = l.StartEvaluator(blk, pendingTxCount, txpool, verificationPool)
 	if err != nil {
 		return nil, stats, err
 	}

--- a/data/ledger_test.go
+++ b/data/ledger_test.go
@@ -163,16 +163,15 @@ func BenchmarkAssemblePayset(b *testing.B) {
 		}
 		b.StartTimer()
 		newEmptyBlk := bookkeeping.MakeBlock(prev)
-		eval, err := l.StartEvaluator(newEmptyBlk.BlockHeader, tp, backlogPool)
+		
+		deadline := time.Now().Add(time.Second)
+		_, stats,err := l.AssemblePayset(tp, newEmptyBlk.BlockHeader, backlogPool, deadline)
 		if err != nil {
 			b.Errorf("could not make proposals at round %d: could not start evaluator: %v", next, err)
 			return
 		}
-		var stats telemetryspec.AssembleBlockMetrics
-		deadline := time.Now().Add(time.Second)
-		stats.AssembleBlockStats = l.AssemblePayset(tp, eval, deadline)
 		b.StopTimer()
-		require.Equal(b, stats.AssembleBlockStats.StopReason, telemetryspec.AssembleBlockFull)
+		require.Equal(b, stats.StopReason, telemetryspec.AssembleBlockFull)
 		// the worst txn, with lower fee than the rest, should still be in the pool
 		_, _, found := tp.Lookup(worstTxID)
 		require.True(b, found)

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -496,11 +496,12 @@ func (pool *TransactionPool) recomputeBlockEvaluator() (stats telemetryspec.Proc
 	// get the transaction groups.
 	pool.pendingMu.RLock()
 	txgroups := pool.pendingTxGroups
+	txcount := len(pool.pendingTxids)
 	pool.pendingMu.RUnlock()
 
 	next := bookkeeping.MakeBlock(prev)
 	pool.numPendingWholeBlocks = 0
-	pool.pendingBlockEvaluator, err = pool.ledger.StartEvaluator(next.BlockHeader, len(txgroups), &alwaysVerifiedPool{pool}, nil)
+	pool.pendingBlockEvaluator, err = pool.ledger.StartEvaluator(next.BlockHeader, txcount, &alwaysVerifiedPool{pool}, nil)
 	if err != nil {
 		logging.Base().Warnf("TransactionPool.recomputeBlockEvaluator: cannot start evaluator: %v", err)
 		return

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -120,14 +120,14 @@ func (pool *TransactionPool) PendingTxIDs() []transactions.Txid {
 
 // Pending returns a list of transaction groups that should be proposed
 // in the next block, in order.
-func (pool *TransactionPool) Pending() [][]transactions.SignedTxn {
+func (pool *TransactionPool) Pending() (pendingTxn [][]transactions.SignedTxn, pendingTxnCount int) {
 	pool.pendingMu.RLock()
 	defer pool.pendingMu.RUnlock()
 	// note that this operation is safe for the sole reason that arrays in go are immutable.
 	// if the underlaying array need to be expanded, the actual underlaying array would need
 	// to be reallocated.
-	return pool.pendingTxGroups
-
+	pendingTxn, pendingTxnCount = pool.pendingTxGroups, len(pool.pendingTxids)
+	return
 }
 
 // rememberCommit() saves the changes added by remember to

--- a/data/pools/transactionPool_test.go
+++ b/data/pools/transactionPool_test.go
@@ -536,7 +536,7 @@ func TestRememberForget(t *testing.T) {
 		}
 	}
 
-	pending := transactionPool.Pending()
+	pending,_  := transactionPool.Pending()
 	numberOfTxns := numOfAccounts*numOfAccounts - numOfAccounts
 	require.Len(t, pending, numberOfTxns)
 
@@ -547,7 +547,7 @@ func TestRememberForget(t *testing.T) {
 	require.NoError(t, err)
 	transactionPool.OnNewBlock(blk.Block())
 
-	pending = transactionPool.Pending()
+	pending, _ = transactionPool.Pending()
 	require.Len(t, pending, 0)
 }
 
@@ -610,7 +610,7 @@ func TestCleanUp(t *testing.T) {
 		transactionPool.OnNewBlock(blk.Block())
 	}
 
-	pending := transactionPool.Pending()
+	pending, _ := transactionPool.Pending()
 	require.Zero(t, len(pending))
 	require.Zero(t, transactionPool.NumExpired(4))
 	require.Equal(t, issuedTransactions, transactionPool.NumExpired(5))
@@ -682,7 +682,7 @@ func TestFixOverflowOnNewBlock(t *testing.T) {
 			}
 		}
 	}
-	pending := transactionPool.Pending()
+	pending, _ := transactionPool.Pending()
 	require.Len(t, pending, savedTransactions)
 
 	secret := keypair()
@@ -718,7 +718,7 @@ func TestFixOverflowOnNewBlock(t *testing.T) {
 
 	transactionPool.OnNewBlock(block.Block())
 
-	pending = transactionPool.Pending()
+	pending, _ = transactionPool.Pending()
 	// only one transaction is missing
 	require.Len(t, pending, savedTransactions-1)
 }
@@ -822,7 +822,8 @@ func TestRemove(t *testing.T) {
 	}
 	signedTx := tx.Sign(secrets[0])
 	require.NoError(t, transactionPool.RememberOne(signedTx))
-	require.Equal(t, transactionPool.Pending(), [][]transactions.SignedTxn{[]transactions.SignedTxn{signedTx}})
+	pendingTxGrps, _ :=  transactionPool.Pending()
+	require.Equal(t, pendingTxGrps, [][]transactions.SignedTxn{[]transactions.SignedTxn{signedTx}})
 }
 
 func TestLogicSigOK(t *testing.T) {

--- a/data/pools/transactionPool_test.go
+++ b/data/pools/transactionPool_test.go
@@ -101,7 +101,7 @@ func newBlockEvaluator(t TestingT, l *ledger.Ledger) *ledger.BlockEvaluator {
 	require.NoError(t, err)
 
 	next := bookkeeping.MakeBlock(prev)
-	eval, err := l.StartEvaluator(next.BlockHeader, &alwaysVerifiedPool{}, nil)
+	eval, err := l.StartEvaluator(next.BlockHeader, 0, &alwaysVerifiedPool{}, nil)
 	require.NoError(t, err)
 
 	return eval

--- a/data/transactions/aggregates.go
+++ b/data/transactions/aggregates.go
@@ -53,5 +53,8 @@ func (payset Payset) Commit(flat bool) crypto.Digest {
 
 // ToBeHashed implements the crypto.Hashable interface
 func (payset Payset) ToBeHashed() (protocol.HashID, []byte) {
+	if len(payset) == 0 {
+		return protocol.PaysetFlat, protocol.Encode(nil)
+	}
 	return protocol.PaysetFlat, protocol.Encode(payset)
 }

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -691,18 +691,17 @@ func (eval *BlockEvaluator) GenerateBlock() (*ValidatedBlock, error) {
 }
 
 func (l *Ledger) eval(ctx context.Context, blk bookkeeping.Block, aux *evalAux, validate bool, txcache VerifiedTxnCache, executionPool execpool.BacklogPool) (stateDelta, evalAux, error) {
-	// Decode the payset to figure out the transaction groups.
-	paysetgroups, err := blk.DecodePaysetGroups()
-	if err != nil {
-		return stateDelta{}, evalAux{}, err
-	}
-
-	eval, err := startEvaluator(l, blk.BlockHeader, aux, validate, false, len(paysetgroups), txcache, executionPool)
+	eval, err := startEvaluator(l, blk.BlockHeader, aux, validate, false, len(blk.Payset), txcache, executionPool)
 	if err != nil {
 		return stateDelta{}, evalAux{}, err
 	}
 
 	// TODO: batch tx sig verification: ingest blk.Payset and output a list of ValidatedTx
+	// Decode the payset to figure out the transaction groups.
+	paysetgroups, err := blk.DecodePaysetGroups()
+	if err != nil {
+		return stateDelta{}, evalAux{}, err
+	}
 
 	for _, txgroup := range paysetgroups {
 		select {

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -690,13 +690,8 @@ func (eval *BlockEvaluator) GenerateBlock() (*ValidatedBlock, error) {
 	return &vb, nil
 }
 
-<<<<<<< HEAD
-func (l *Ledger) eval(ctx context.Context, blk bookkeeping.Block, aux *evalAux, validate bool, txcache VerifiedTxnCache, executionPool execpool.BacklogPool) (stateDelta, evalAux, error) {
-	eval, err := startEvaluator(l, blk.BlockHeader, aux, validate, false, len(blk.Payset), txcache, executionPool)
-=======
 func (l *Ledger) eval(ctx context.Context, blk bookkeeping.Block, aux *evalAux, validate bool, txcache VerifiedTxnCache, executionPool execpool.BacklogPool) (StateDelta, evalAux, error) {
-	eval, err := startEvaluator(l, blk.BlockHeader, aux, validate, false, txcache, executionPool)
->>>>>>> master
+	eval, err := startEvaluator(l, blk.BlockHeader, aux, validate, false, len(blk.Payset), txcache, executionPool)
 	if err != nil {
 		return StateDelta{}, evalAux{}, err
 	}

--- a/ledger/eval_test.go
+++ b/ledger/eval_test.go
@@ -56,7 +56,7 @@ func TestBlockEvaluator(t *testing.T) {
 	defer l.Close()
 
 	newBlock := bookkeeping.MakeBlock(genesisInitState.Block.BlockHeader)
-	eval, err := l.StartEvaluator(newBlock.BlockHeader, nil, backlogPool)
+	eval, err := l.StartEvaluator(newBlock.BlockHeader, 4, nil, backlogPool)
 	require.NoError(t, err)
 
 	genHash := genesisInitState.Block.BlockHeader.GenesisHash

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -90,7 +90,7 @@ func testGenerateInitState(t *testing.T, proto protocol.ConsensusVersion) (genes
 
 	incentivePoolBalanceAtGenesis := initAccounts[poolAddr].MicroAlgos
 	initialRewardsPerRound := incentivePoolBalanceAtGenesis.Raw / uint64(params.RewardsRateRefreshInterval)
-	emptyPayset := make(transactions.Payset, 0)
+	var emptyPayset transactions.Payset
 
 	initBlock := bookkeeping.Block{
 		BlockHeader: bookkeeping.BlockHeader{
@@ -152,7 +152,7 @@ func (l *Ledger) appendUnvalidatedSignedTx(t *testing.T, initAccounts map[basics
 	lastBlock, err := l.Block(l.Latest())
 	a.NoError(err, "could not get last block")
 
-	emptyPayset := make(transactions.Payset, 0)
+	var emptyPayset transactions.Payset
 
 	proto := config.Consensus[lastBlock.CurrentProtocol]
 	poolAddr := testPoolAddr
@@ -222,7 +222,7 @@ func TestLedgerBlockHeaders(t *testing.T) {
 	lastBlock, err := l.Block(l.Latest())
 	a.NoError(err, "could not get last block")
 
-	emptyPayset := make(transactions.Payset, 0)
+	var emptyPayset transactions.Payset
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	poolAddr := testPoolAddr
@@ -720,7 +720,7 @@ func testLedgerSingleTxApplyData(t *testing.T, version protocol.ConsensusVersion
 			}
 			poolBal, err := l.Lookup(l.Latest(), testPoolAddr)
 			a.NoError(err, "could not get incentive pool balance")
-			emptyPayset := make(transactions.Payset, 0)
+			var emptyPayset transactions.Payset
 			lastBlock, err := l.Block(l.Latest())
 			a.NoError(err, "could not get last block")
 

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -90,7 +90,7 @@ func testGenerateInitState(t *testing.T, proto protocol.ConsensusVersion) (genes
 
 	incentivePoolBalanceAtGenesis := initAccounts[poolAddr].MicroAlgos
 	initialRewardsPerRound := incentivePoolBalanceAtGenesis.Raw / uint64(params.RewardsRateRefreshInterval)
-	var emptyPayset transactions.Payset
+	emptyPayset := make(transactions.Payset, 0)
 
 	initBlock := bookkeeping.Block{
 		BlockHeader: bookkeeping.BlockHeader{
@@ -152,7 +152,7 @@ func (l *Ledger) appendUnvalidatedSignedTx(t *testing.T, initAccounts map[basics
 	lastBlock, err := l.Block(l.Latest())
 	a.NoError(err, "could not get last block")
 
-	var emptyPayset transactions.Payset
+	emptyPayset := make(transactions.Payset, 0)
 
 	proto := config.Consensus[lastBlock.CurrentProtocol]
 	poolAddr := testPoolAddr
@@ -222,7 +222,7 @@ func TestLedgerBlockHeaders(t *testing.T) {
 	lastBlock, err := l.Block(l.Latest())
 	a.NoError(err, "could not get last block")
 
-	var emptyPayset transactions.Payset
+	emptyPayset := make(transactions.Payset, 0)
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	poolAddr := testPoolAddr
@@ -720,7 +720,7 @@ func testLedgerSingleTxApplyData(t *testing.T, version protocol.ConsensusVersion
 			}
 			poolBal, err := l.Lookup(l.Latest(), testPoolAddr)
 			a.NoError(err, "could not get incentive pool balance")
-			var emptyPayset transactions.Payset
+			emptyPayset := make(transactions.Payset, 0)
 			lastBlock, err := l.Block(l.Latest())
 			a.NoError(err, "could not get last block")
 

--- a/node/impls.go
+++ b/node/impls.go
@@ -97,13 +97,12 @@ func (i *blockFactoryImpl) AssembleBlock(round basics.Round, deadline time.Time)
 
 	newEmptyBlk := bookkeeping.MakeBlock(prev)
 
-	eval, err := i.l.StartEvaluator(newEmptyBlk.BlockHeader, i.tp, i.verificationPool)
+	var stats telemetryspec.AssembleBlockMetrics
+	var eval *ledger.BlockEvaluator
+	eval, stats.AssembleBlockStats, err = i.l.AssemblePayset(i.tp, newEmptyBlk.BlockHeader, i.verificationPool, deadline)
 	if err != nil {
 		return nil, fmt.Errorf("could not make proposals at round %d: could not start evaluator: %v", round, err)
 	}
-
-	var stats telemetryspec.AssembleBlockMetrics
-	stats.AssembleBlockStats = i.l.AssemblePayset(i.tp, eval, deadline)
 
 	// Measure time here because we want to know how close to deadline we are
 	dt := time.Now().Sub(start)

--- a/node/node.go
+++ b/node/node.go
@@ -609,7 +609,8 @@ func (node *AlgorandFullNode) SuggestedFee() basics.MicroAlgos {
 // GetPendingTxnsFromPool returns a snapshot of every pending transactions from the node's transaction pool in a slice.
 // Transactions are sorted in decreasing order. If no transactions, returns an empty slice.
 func (node *AlgorandFullNode) GetPendingTxnsFromPool() ([]transactions.SignedTxn, error) {
-	return bookkeeping.SignedTxnGroupsFlatten(node.transactionPool.Pending()), nil
+	pendingTxnGroups, txnCount := node.transactionPool.Pending()
+	return bookkeeping.SignedTxnGroupsFlatten(pendingTxnGroups, txnCount), nil
 }
 
 // Reload participation keys from disk periodically

--- a/rpcs/txService.go
+++ b/rpcs/txService.go
@@ -188,7 +188,7 @@ func (txs *TxService) updateTxCache() (pendingTxGroups [][]transactions.SignedTx
 		// The txs.pool.Pending() function allocates a new array on every call. That means that the old
 		// array ( if being used ) is still valid. There is no risk of data race here since
 		// the txs.pendingTxGroups is a slice (hence a pointer to the array) and not the array itself.
-		txs.pendingTxGroups = txs.pool.Pending()
+		txs.pendingTxGroups, _ = txs.pool.Pending()
 		txs.lastUpdate = currentUnixTime
 	}
 	return txs.pendingTxGroups

--- a/rpcs/txSyncer.go
+++ b/rpcs/txSyncer.go
@@ -32,7 +32,7 @@ import (
 // PendingTxAggregate is a container of pending transactions
 type PendingTxAggregate interface {
 	PendingTxIDs() []transactions.Txid
-	Pending() [][]transactions.SignedTxn
+	Pending() (pendingTxnGroups [][]transactions.SignedTxn, pendingTxnCount int)
 }
 
 // TxSyncClient abstracts sync-ing pending transactions from a peer.


### PR DESCRIPTION
## About

The payset is the list of transactions that are included in a block.
During the block evaluation, we add the transactions, one at a time to that list.
This works correctly, however, not very efficient. Since arrays in GO are immutable, each time the array has to grow, it require a new array to be allocated, and the content need to be copied over.

Given that we know in advance the number of transactions that are needed, we should pre-allocate that.

## Metrics
When running S2 under heavy load, the BlockEvaluator::transactionGroup used to take 52.80s, out of them 7.1s spent on the growslice.
With this change while running the same scenario, BlockEvaluator::transactionGroup takes 56.36s, out of them 1.17s spent on the glowslice.