### PR TITLE
Test overlapping leases

### DIFF
--- a/test/e2e-go/features/transactions/lease_test.go
+++ b/test/e2e-go/features/transactions/lease_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/test/framework/fixtures"
 )
 
@@ -156,4 +157,104 @@ func TestLeaseTransactionsDifferentSender(t *testing.T) {
 	bal2, _ := fixture.GetBalanceAndRound(account3)
 	a.Equal(bal1, uint64(1000000))
 	a.Equal(bal2, uint64(2000000))
+}
+
+func TestOverlappingLeases(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+
+	var fixture fixtures.RestClientFixture
+	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50EachFuture.json"))
+	defer fixture.Shutdown()
+
+	client := fixture.LibGoalClient
+	accountList, err := fixture.GetWalletsSortedByBalance()
+	a.NoError(err)
+	account0 := accountList[0].Address
+	wh, err := client.GetUnencryptedWalletHandle()
+	a.NoError(err)
+
+	account1, err := client.GenerateAddress(wh)
+	a.NoError(err)
+
+	account2, err := client.GenerateAddress(wh)
+	a.NoError(err)
+
+	lease := [32]byte{1, 2, 3, 4}
+
+	_, curRound := fixture.GetBalanceAndRound(account0)
+	leaseStart := curRound
+
+	// first lease
+	// [xxxxxxx]oooooooo
+	// [xxxxxxxxxxxxx]oo
+	// second lease
+
+	// we will submit the first transaction, and ensure the second
+	// transaction isn't valid until the first transaction's lease
+	// has expired.
+
+	// construct transactions for sending money to account1 and account2
+	// from same sender with identical lease, but different, overlapping ranges
+	tx1, err := client.ConstructPayment(account0, account1, 0, 1000000, nil, "", lease, basics.Round(leaseStart), basics.Round(leaseStart+10))
+	a.NoError(err)
+
+	tx2, err := client.ConstructPayment(account0, account2, 0, 2000000, nil, "", lease, basics.Round(leaseStart), basics.Round(leaseStart+100))
+	a.NoError(err)
+
+	stx1, err := client.SignTransactionWithWallet(wh, nil, tx1)
+	a.NoError(err)
+
+	stx2, err := client.SignTransactionWithWallet(wh, nil, tx2)
+	a.NoError(err)
+
+	// submitting the first transaction should succeed
+	_, err = client.BroadcastTransaction(stx1)
+	a.NoError(err)
+
+	// submitting the second transaction should fail right away
+	_, err = client.BroadcastTransaction(stx2)
+	a.Error(err)
+
+	// wait for the first tx to confirm
+	txids := make(map[string]string)
+	txids[stx1.Txn.ID().String()] = account0
+	_, curRound = fixture.GetBalanceAndRound(account0)
+	confirmed := fixture.WaitForAllTxnsToConfirm(curRound+5, txids)
+	a.True(confirmed, "first lease txn confirmed")
+
+	// submitting the second transaction should still fail
+	_, err = client.BroadcastTransaction(stx2)
+	a.Error(err)
+
+	// wait for a round after the first txn was confirmed, but before its
+	// lease has expired
+	fixture.WaitForRoundWithTimeout(leaseStart + 7)
+
+	// submitting the second transaction should still fail
+	_, err = client.BroadcastTransaction(stx2)
+	a.Error(err)
+
+	// wait for us to be building leaseStart + 10, the last round where
+	// the first txn's lease is still valid
+	fixture.WaitForRoundWithTimeout(leaseStart + 9)
+
+	// submitting the second transaction should still fail
+	_, err = client.BroadcastTransaction(stx2)
+	a.Error(err)
+
+	// wait for us to be building leaseStart + 11, where the first txn's
+	// lease should have expired
+	fixture.WaitForRoundWithTimeout(leaseStart + 10)
+
+	// submitting the second transaction should succeed
+	_, err = client.BroadcastTransaction(stx2)
+	a.NoError(err)
+
+	// wait for the second tx to confirm
+	txids = make(map[string]string)
+	txids[stx2.Txn.ID().String()] = account0
+	_, curRound = fixture.GetBalanceAndRound(account0)
+	confirmed = fixture.WaitForAllTxnsToConfirm(curRound+5, txids)
+	a.True(confirmed, "second lease txn confirmed")
 }


### PR DESCRIPTION
This PR tests two transactions with leases that overlap, ensuring that the one with the longer lease validity period isn't valid until after the first lease validity period ends.