### PR TITLE
Improve error message: sender should be the manager

### DIFF
--- a/data/transactions/asset.go
+++ b/data/transactions/asset.go
@@ -152,7 +152,7 @@ func (cc AssetConfigTxnFields) apply(header Header, balances Balances, spec Spec
 	}
 
 	if params.Manager.IsZero() || (header.Sender != params.Manager) {
-		return fmt.Errorf("transaction issued by %v, manager key %v", header.Sender, params.Manager)
+		return fmt.Errorf("this transaction should be issued by the manager. It is issued by %v, manager key %v", header.Sender, params.Manager)
 	}
 
 	record, err := balances.Get(creator, false)


### PR DESCRIPTION
## Summary

The error message from this check is not helpful for the user.
HTTP 400 Bad Request: TransactionPool.Remember: transaction E7LZYUTGLAK6X3EK3PQ67UJLFWE7J7OXONXFQRBJSBGUD6MGIYPQ: transaction issued by 6OXBYHNBS2THHV7T7OGYYZ5SMOSLKYZC2XG2FMPHRJN633TQ4R3A7VTCMQ, manager key PKOMDVM7SPAX76O5SUSZAITBOH2NNFPPCRINSYUTPE3PW7DXJ44WJHJPWY
changing to:
HTTP 400 Bad Request: TransactionPool.Remember: transaction JQ4AVISTZQIBKGDFEIHPOJM55AGEVFS6XVENGOUL6YLK3LFQTLPQ: this transaction should be issued by the manager. It is issued by GRR4TBQF27XTTYKLYVO64MQHCMAT2FEQTCZI6RSJXNBPM5N3QD27UFYPDM, manager key 74KUZ4DS237IPOF4ZUCUU5TGCP4PKP3NXD64HEVKCXC5TMHOBIURJQUTDQ
