### PR TITLE
Use a transaction's LastValid to expedite duplicate detection.

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -85,7 +85,7 @@ func MakeTransactionPool(ledger *ledger.Ledger, cfg config.Local) *TransactionPo
 		lsigCache:       makeLsigEvalCache(cfg.TxPoolSize),
 	}
 	pool.cond.L = &pool.mu
-	pool.recomputeBlockEvaluator(make(map[transactions.Txid]struct{}))
+	pool.recomputeBlockEvaluator(make(map[transactions.Txid]basics.Round))
 	return &pool
 }
 
@@ -479,7 +479,7 @@ func (pool *TransactionPool) addToPendingBlockEvaluator(txgroup []transactions.S
 // recomputeBlockEvaluator constructs a new BlockEvaluator and feeds all
 // in-pool transactions to it (removing any transactions that are rejected
 // by the BlockEvaluator).
-func (pool *TransactionPool) recomputeBlockEvaluator(committedTxIds map[transactions.Txid]struct{}) (stats telemetryspec.ProcessBlockMetrics) {
+func (pool *TransactionPool) recomputeBlockEvaluator(committedTxIds map[transactions.Txid]basics.Round) (stats telemetryspec.ProcessBlockMetrics) {
 	pool.pendingBlockEvaluator = nil
 
 	latest := pool.ledger.Latest()

--- a/ledger/cow.go
+++ b/ledger/cow.go
@@ -36,7 +36,7 @@ import (
 
 type roundCowParent interface {
 	lookup(basics.Address) (basics.AccountData, error)
-	isDup(basics.Round, transactions.Txid, txlease) (bool, error)
+	isDup(basics.Round, basics.Round, transactions.Txid, txlease) (bool, error)
 	txnCounter() uint64
 	getAssetCreator(assetIdx basics.AssetIndex) (basics.Address, error)
 }
@@ -53,8 +53,8 @@ type StateDelta struct {
 	// modified accounts
 	accts map[basics.Address]accountDelta
 
-	// new Txids for the txtail and TxnCounter
-	Txids map[transactions.Txid]struct{}
+	// new Txids for the txtail and TxnCounter, mapped to txn.LastValid
+	Txids map[transactions.Txid]basics.Round
 
 	// new txleases for the txtail mapped to expiration
 	txleases map[txlease]basics.Round
@@ -73,7 +73,7 @@ func makeRoundCowState(b roundCowParent, hdr bookkeeping.BlockHeader) *roundCowS
 		proto:        config.Consensus[hdr.CurrentProtocol],
 		mods: StateDelta{
 			accts:    make(map[basics.Address]accountDelta),
-			Txids:    make(map[transactions.Txid]struct{}),
+			Txids:    make(map[transactions.Txid]basics.Round),
 			txleases: make(map[txlease]basics.Round),
 			assets:   make(map[basics.AssetIndex]modifiedAsset),
 			hdr:      &hdr,
@@ -105,7 +105,7 @@ func (cb *roundCowState) lookup(addr basics.Address) (data basics.AccountData, e
 	return cb.lookupParent.lookup(addr)
 }
 
-func (cb *roundCowState) isDup(firstValid basics.Round, txid transactions.Txid, txl txlease) (bool, error) {
+func (cb *roundCowState) isDup(firstValid, lastValid basics.Round, txid transactions.Txid, txl txlease) (bool, error) {
 	_, present := cb.mods.Txids[txid]
 	if present {
 		return true, nil
@@ -118,7 +118,7 @@ func (cb *roundCowState) isDup(firstValid basics.Round, txid transactions.Txid, 
 		}
 	}
 
-	return cb.lookupParent.isDup(firstValid, txid, txl)
+	return cb.lookupParent.isDup(firstValid, lastValid, txid, txl)
 }
 
 func (cb *roundCowState) txnCounter() uint64 {
@@ -141,7 +141,7 @@ func (cb *roundCowState) put(addr basics.Address, old basics.AccountData, new ba
 }
 
 func (cb *roundCowState) addTx(txn transactions.Transaction) {
-	cb.mods.Txids[txn.ID()] = struct{}{}
+	cb.mods.Txids[txn.ID()] = txn.LastValid
 	cb.mods.txleases[txlease{sender: txn.Sender, lease: txn.Lease}] = txn.LastValid
 }
 
@@ -152,7 +152,7 @@ func (cb *roundCowState) child() *roundCowState {
 		proto:        cb.proto,
 		mods: StateDelta{
 			accts:    make(map[basics.Address]accountDelta),
-			Txids:    make(map[transactions.Txid]struct{}),
+			Txids:    make(map[transactions.Txid]basics.Round),
 			txleases: make(map[txlease]basics.Round),
 			assets:   make(map[basics.AssetIndex]modifiedAsset),
 			hdr:      cb.mods.hdr,
@@ -173,8 +173,8 @@ func (cb *roundCowState) commitToParent() {
 		}
 	}
 
-	for txid := range cb.mods.Txids {
-		cb.commitParent.mods.Txids[txid] = struct{}{}
+	for txid, lv := range cb.mods.Txids {
+		cb.commitParent.mods.Txids[txid] = lv
 	}
 	for txl, expires := range cb.mods.txleases {
 		cb.commitParent.mods.txleases[txl] = expires

--- a/ledger/cow_test.go
+++ b/ledger/cow_test.go
@@ -34,7 +34,7 @@ func (ml *mockLedger) lookup(addr basics.Address) (basics.AccountData, error) {
 	return ml.balanceMap[addr], nil
 }
 
-func (ml *mockLedger) isDup(firstValid basics.Round, txn transactions.Txid, txl txlease) (bool, error) {
+func (ml *mockLedger) isDup(firstValid, lastValid basics.Round, txn transactions.Txid, txl txlease) (bool, error) {
 	return false, nil
 }
 

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -77,8 +77,8 @@ func (x *roundCowBase) lookup(addr basics.Address) (basics.AccountData, error) {
 	return x.l.LookupWithoutRewards(x.rnd, addr)
 }
 
-func (x *roundCowBase) isDup(firstValid basics.Round, txid transactions.Txid, txl txlease) (bool, error) {
-	return x.l.isDup(x.proto, x.rnd+1, firstValid, x.rnd, txid, txl)
+func (x *roundCowBase) isDup(firstValid, lastValid basics.Round, txid transactions.Txid, txl txlease) (bool, error) {
+	return x.l.isDup(x.proto, x.rnd+1, firstValid, lastValid, txid, txl)
 }
 
 func (x *roundCowBase) txnCounter() uint64 {
@@ -481,7 +481,7 @@ func (eval *BlockEvaluator) transaction(txn transactions.SignedTxn, ad transacti
 
 		// Transaction already in the ledger?
 		txid := txn.ID()
-		dup, err := cow.isDup(txn.Txn.First(), txid, txlease{sender: txn.Txn.Sender, lease: txn.Txn.Lease})
+		dup, err := cow.isDup(txn.Txn.First(), txn.Txn.Last(), txid, txlease{sender: txn.Txn.Sender, lease: txn.Txn.Lease})
 		if err != nil {
 			return err
 		}

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -363,7 +363,7 @@ func (l *Ledger) Committed(currentProto config.ConsensusParams, txn transactions
 	defer l.trackerMu.RUnlock()
 	// do not check for whether lease would excluded this
 	txl := txlease{sender: txn.Txn.Sender}
-	return l.txTail.isDup(currentProto, l.Latest()+1, txn.Txn.First(), l.Latest(), txn.ID(), txl)
+	return l.txTail.isDup(currentProto, l.Latest()+1, txn.Txn.First(), txn.Txn.Last(), txn.ID(), txl)
 }
 
 func (l *Ledger) blockAux(rnd basics.Round) (bookkeeping.Block, evalAux, error) {


### PR DESCRIPTION
This is an alternative to #504. 