### PR TITLE
Reduce lease test flakiness

### DIFF
--- a/test/e2e-go/features/transactions/lease_test.go
+++ b/test/e2e-go/features/transactions/lease_test.go
@@ -196,7 +196,7 @@ func TestOverlappingLeases(t *testing.T) {
 
 	// construct transactions for sending money to account1 and account2
 	// from same sender with identical lease, but different, overlapping ranges
-	tx1, err := client.ConstructPayment(account0, account1, 0, 1000000, nil, "", lease, basics.Round(leaseStart), basics.Round(leaseStart+10))
+	tx1, err := client.ConstructPayment(account0, account1, 0, 1000000, nil, "", lease, basics.Round(leaseStart), basics.Round(leaseStart+20))
 	a.NoError(err)
 
 	tx2, err := client.ConstructPayment(account0, account2, 0, 2000000, nil, "", lease, basics.Round(leaseStart), basics.Round(leaseStart+100))
@@ -235,17 +235,9 @@ func TestOverlappingLeases(t *testing.T) {
 	_, err = client.BroadcastTransaction(stx2)
 	a.Error(err)
 
-	// wait for us to be building leaseStart + 10, the last round where
-	// the first txn's lease is still valid
-	fixture.WaitForRoundWithTimeout(leaseStart + 9)
-
-	// submitting the second transaction should still fail
-	_, err = client.BroadcastTransaction(stx2)
-	a.Error(err)
-
-	// wait for us to be building leaseStart + 11, where the first txn's
+	// wait for us to be building leaseStart + 21, where the first txn's
 	// lease should have expired
-	fixture.WaitForRoundWithTimeout(leaseStart + 10)
+	fixture.WaitForRoundWithTimeout(leaseStart + 20)
 
 	// submitting the second transaction should succeed
 	_, err = client.BroadcastTransaction(stx2)


### PR DESCRIPTION
The new lease test is flaky. I removed a check that is inherently racy with block confirmation, and increased the window for another check to reduce its flakiness.