### PR TITLE
Limit the size of the pending transaction groups on the transaction pool

### DIFF
--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -83,7 +83,7 @@ var defaultLocalV4 = Local{
 	SuggestedFeeBlockHistory:              3,
 	SuggestedFeeSlidingWindowSize:         50,
 	TxPoolExponentialIncreaseFactor:       2,
-	TxPoolSize:                            50000,
+	TxPoolSize:                            15000,
 	TxSyncIntervalSeconds:                 60,
 	TxSyncTimeoutSeconds:                  30,
 	TxSyncServeResponseSize:               1000000,
@@ -282,6 +282,9 @@ func migrate(cfg Local) (newCfg Local, err error) {
 		}
 		if newCfg.AnnounceParticipationKey == defaultLocalV3.AnnounceParticipationKey {
 			newCfg.AnnounceParticipationKey = defaultLocalV4.AnnounceParticipationKey
+		}
+		if newCfg.TxPoolSize == defaultLocalV3.TxPoolSize {
+			newCfg.TxPoolSize = defaultLocalV4.TxPoolSize
 		}
 		if newCfg.PriorityPeers == nil {
 			newCfg.PriorityPeers = map[string]bool{}

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -41,7 +41,7 @@
     "SuggestedFeeBlockHistory": 3,
     "SuggestedFeeSlidingWindowSize": 50,
     "TxPoolExponentialIncreaseFactor": 2,
-    "TxPoolSize": 50000,
+    "TxPoolSize": 15000,
     "TxSyncIntervalSeconds": 60,
     "TxSyncServeResponseSize": 1000000,
     "TxSyncTimeoutSeconds": 30

--- a/test/testdata/configs/config-v4.json
+++ b/test/testdata/configs/config-v4.json
@@ -39,7 +39,7 @@
     "RunHosted": false,
     "SuggestedFeeBlockHistory": 3,
     "TxPoolExponentialIncreaseFactor": 2,
-    "TxPoolSize": 50000,
+    "TxPoolSize": 15000,
     "TxSyncIntervalSeconds": 60,
     "TxSyncTimeoutSeconds": 30,
     "TxSyncServeResponseSize": 1000000,


### PR DESCRIPTION
## Summary

Limit the size of the pending transaction groups on the transaction pool.
We've removed this limit during the evaluator integration, which could lead to slower worst-case scenario. Setting this number to 15K seems to cap the worst case scenario we've been seeing.

# Metrics

Setting this cap to 15K and running pingpong at full blast using regular payset transactions resulted in full blocks and block rate of 4.85
