### PR TITLE
Make template fee check <= instead of <

### DIFF
--- a/tools/teal/templates/atomic-swap.teal.tmpl
+++ b/tools/teal/templates/atomic-swap.teal.tmpl
@@ -16,7 +16,7 @@
 //  - TMPL_FEE: maximum fee used by the atomic swap transaction
 txn Fee
 int TMPL_FEE
-<
+<=
 txn TypeEnum
 int 1
 ==

--- a/tools/teal/templates/delegate-key-registration.teal.tmpl
+++ b/tools/teal/templates/delegate-key-registration.teal.tmpl
@@ -23,7 +23,7 @@ int 2
 ==
 txn Fee
 int TMPL_FEE
-<
+<=
 &&
 txn LastValid
 int TMPL_EXPIRE

--- a/tools/teal/templates/limit-order.teal.tmpl
+++ b/tools/teal/templates/limit-order.teal.tmpl
@@ -30,7 +30,7 @@ int 1
 &&
 txn Fee
 int TMPL_FEE
-<
+<=
 &&
 txn CloseRemainderTo
 addr TMPL_OWN

--- a/tools/teal/templates/periodic-payment-escrow.teal.tmpl
+++ b/tools/teal/templates/periodic-payment-escrow.teal.tmpl
@@ -21,7 +21,7 @@ int 1
 ==
 txn Fee
 int TMPL_FEE
-<
+<=
 &&
 txn FirstValid
 int TMPL_PERIOD

--- a/tools/teal/templates/split.teal.tmpl
+++ b/tools/teal/templates/split.teal.tmpl
@@ -25,7 +25,7 @@ int 1
 ==
 txn Fee
 int TMPL_FEE
-<
+<=
 &&
 global GroupSize
 int 2


### PR DESCRIPTION
I want to avoid the situation where someone sets `TMPL_FEE` equal to `MinFee` and the contract becomes unusable (because any transaction satisfying the program is necessarily invalid)