### PR TITLE
Adjust LastValid of the pingpong transaction

### DIFF
--- a/shared/pingpong/pingpong.go
+++ b/shared/pingpong/pingpong.go
@@ -360,10 +360,13 @@ func constructTxn(from, to string, fee, amt, assetID uint64, client libgoal.Clie
 		if !cfg.Quiet {
 			fmt.Fprintf(os.Stdout, "Sending %d asset %d: %s -> %s\n", amt, assetID, from, to)
 		}
+		
 	}
 	if err != nil {
 		return
 	}
+	// adjust transaction duration for 5 rounds. That would prevent it from getting stuck in the transaction pool for too long.
+	txn.LastValid = txn.FirstValid + 5
 	return
 }
 


### PR DESCRIPTION
## Summary

Pingpong was constructing a transaction that would last 1000 rounds.
While these transaction are completely legit, they do not help us to measure the network ability to process transactions. Instead, these typically getting "stuck" in one of the intermediate transaction pools for a long time, and degrading the node's performance.

Dropping the LastValid from +1000 to +5 should help the nodes clear up their local transaction pool within 5 rounds, allowing faster iteration between testing periods.

