### PR TITLE
Fix failed teal test on arm64

### DIFF
--- a/test/scripts/e2e_teal.sh
+++ b/test/scripts/e2e_teal.sh
@@ -4,6 +4,7 @@ date '+e2e_teal start %Y%m%d_%H%M%S'
 
 set -e
 set -x
+export GOPATH=$(go env GOPATH)
 
 TEMPDIR=$(mktemp -d)
 trap "rm -rf $TEMPDIR" 0

--- a/test/scripts/limit-swap-test.sh
+++ b/test/scripts/limit-swap-test.sh
@@ -4,6 +4,7 @@ date '+limit-swap-test start %Y%m%d_%H%M%S'
 
 set -e
 set -x
+export GOPATH=$(go env GOPATH)
 
 TEMPDIR=$(mktemp -d)
 trap "rm -rf $TEMPDIR" 0

--- a/test/scripts/periodic-teal-test.sh
+++ b/test/scripts/periodic-teal-test.sh
@@ -4,6 +4,7 @@ date '+periodic-teal-test start %Y%m%d_%H%M%S'
 
 set -e
 set -x
+export GOPATH=$(go env GOPATH)
 
 TEMPDIR=$(mktemp -d)
 trap "rm -rf $TEMPDIR" 0

--- a/test/scripts/teal-split-test.sh
+++ b/test/scripts/teal-split-test.sh
@@ -4,6 +4,7 @@ date '+teal-split-test start %Y%m%d_%H%M%S'
 
 set -e
 set -x
+export GOPATH=$(go env GOPATH)
 
 TEMPDIR=$(mktemp -d)
 trap "rm -rf $TEMPDIR" 0


### PR DESCRIPTION
## Summary

teal testing was failing on arm64; had nothing to do with arm64. The GOPATH had to be configured.