### PR TITLE
Remove redundant liveness and duplicate checks in txHandler.

### DIFF
--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -274,44 +274,6 @@ func (handler *TxHandler) checkAlreadyCommitted(tx *txBacklogMsg) (processingDon
 		logging.Base().Debugf("txPool rejected transaction: %v", err)
 		return true
 	}
-
-	// build the transaction verification context
-	latest := handler.ledger.Latest()
-	latestHdr, err := handler.ledger.BlockHdr(latest)
-	if err != nil {
-		logging.Base().Warnf("Could not get header for previous block %v: %v", latest, err)
-		return true
-	}
-	tx.proto = config.Consensus[latestHdr.CurrentProtocol]
-	tx.spec.FeeSink = latestHdr.FeeSink
-	tx.spec.RewardsPool = latestHdr.RewardsPool
-
-	tc := transactions.ExplicitTxnContext{
-		ExplicitRound: latest + 1,
-		Proto:         tx.proto,
-		GenID:         handler.genesisID,
-		GenHash:       handler.genesisHash,
-	}
-
-	for _, txn := range tx.unverifiedTxGroup {
-		err = txn.Txn.Alive(tc)
-		if err != nil {
-			logging.Base().Debugf("Received a dead txn %s: %v", txn.ID(), err)
-			return true
-		}
-
-		committed, err := handler.ledger.Committed(tx.proto, txn)
-		if err != nil {
-			logging.Base().Errorf("Could not verify committed status of txn %v: %v", txn, err)
-			return true
-		}
-
-		if committed {
-			logging.Base().Debugf("Already confirmed tx %v", txn.ID())
-			return true
-		}
-	}
-
 	return false
 }
 

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -274,6 +274,18 @@ func (handler *TxHandler) checkAlreadyCommitted(tx *txBacklogMsg) (processingDon
 		logging.Base().Debugf("txPool rejected transaction: %v", err)
 		return true
 	}
+
+	// build the transaction verification context
+	latest := handler.ledger.Latest()
+	latestHdr, err := handler.ledger.BlockHdr(latest)
+	if err != nil {
+		logging.Base().Warnf("Could not get header for previous block %v: %v", latest, err)
+		return true
+	}
+	tx.proto = config.Consensus[latestHdr.CurrentProtocol]
+	tx.spec.FeeSink = latestHdr.FeeSink
+	tx.spec.RewardsPool = latestHdr.RewardsPool
+
 	return false
 }
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -356,16 +356,6 @@ func (l *Ledger) LatestCommitted() basics.Round {
 	return l.blockQ.latestCommitted()
 }
 
-// Committed uses the transaction tail tracker to check if txn already
-// appeared in a block.
-func (l *Ledger) Committed(currentProto config.ConsensusParams, txn transactions.SignedTxn) (bool, error) {
-	l.trackerMu.RLock()
-	defer l.trackerMu.RUnlock()
-	// do not check for whether lease would excluded this
-	txl := txlease{sender: txn.Txn.Sender}
-	return l.txTail.isDup(currentProto, l.Latest()+1, txn.Txn.First(), txn.Txn.Last(), txn.ID(), txl)
-}
-
 func (l *Ledger) blockAux(rnd basics.Round) (bookkeeping.Block, evalAux, error) {
 	return l.blockQ.getBlockAux(rnd)
 }


### PR DESCRIPTION
As of the transaction pool refactor, transactionPool.Test already performs
duplicate detection and transaction liveness checks.