### PR TITLE
[DRAFT DO NOT MERGE] Skip redundant crypto operations.

### DIFF
--- a/data/ledger.go
+++ b/data/ledger.go
@@ -351,7 +351,7 @@ func (l *Ledger) AssemblePayset(pool *pools.TransactionPool, eval *ledger.BlockE
 		for i, tx := range txgroup {
 			txgroupad[i].SignedTxn = tx
 		}
-		err := eval.TransactionGroup(txgroupad)
+		err := eval.TransactionGroup(txgroupad, true)
 		if err == ledger.ErrNoSpace {
 			stats.StopReason = telemetryspec.AssembleBlockFull
 			break

--- a/data/ledger_test.go
+++ b/data/ledger_test.go
@@ -149,7 +149,7 @@ func BenchmarkAssemblePayset(b *testing.B) {
 			if okcount == 0 {
 				worstTxID = signedTx.ID()
 			}
-			err := tp.Remember([]transactions.SignedTxn{signedTx})
+			err := tp.Remember([]transactions.SignedTxn{signedTx}, false)
 			if err != nil {
 				errcount++
 				b.Logf("(%d/%d) could not send [%d] %s -> [%d] %s: %s", errcount, okcount, sourcei, addresses[sourcei], desti, addresses[desti], err)

--- a/data/pools/transactionPool_test.go
+++ b/data/pools/transactionPool_test.go
@@ -167,7 +167,7 @@ func TestMinBalanceOK(t *testing.T) {
 		},
 	}
 	signedTx := tx.Sign(secrets[0])
-	require.NoError(t, transactionPool.RememberOne(signedTx))
+	require.NoError(t, transactionPool.RememberOne(signedTx, false))
 }
 
 func TestSenderGoesBelowMinBalance(t *testing.T) {
@@ -208,7 +208,7 @@ func TestSenderGoesBelowMinBalance(t *testing.T) {
 		},
 	}
 	signedTx := tx.Sign(secrets[0])
-	require.Error(t, transactionPool.RememberOne(signedTx))
+	require.Error(t, transactionPool.RememberOne(signedTx, false))
 }
 
 func TestSenderGoesBelowMinBalanceDueToAssets(t *testing.T) {
@@ -252,7 +252,7 @@ func TestSenderGoesBelowMinBalanceDueToAssets(t *testing.T) {
 		},
 	}
 	signedAssetTx := assetTx.Sign(secrets[0])
-	require.NoError(t, transactionPool.RememberOne(signedAssetTx))
+	require.NoError(t, transactionPool.RememberOne(signedAssetTx, false))
 
 	// sender goes below min
 	tx := transactions.Transaction{
@@ -271,7 +271,7 @@ func TestSenderGoesBelowMinBalanceDueToAssets(t *testing.T) {
 		},
 	}
 	signedTx := tx.Sign(secrets[0])
-	err := transactionPool.RememberOne(signedTx)
+	err := transactionPool.RememberOne(signedTx, false)
 	require.Error(t, err)
 	var returnedTxid, returnedAcct string
 	var returnedBal, returnedMin, numAssets uint64
@@ -320,7 +320,7 @@ func TestCloseAccount(t *testing.T) {
 		},
 	}
 	signedTx := closeTx.Sign(secrets[0])
-	require.NoError(t, transactionPool.RememberOne(signedTx))
+	require.NoError(t, transactionPool.RememberOne(signedTx, false))
 
 	// sender goes below min
 	tx := transactions.Transaction{
@@ -339,7 +339,7 @@ func TestCloseAccount(t *testing.T) {
 		},
 	}
 	signedTx2 := tx.Sign(secrets[0])
-	require.Error(t, transactionPool.RememberOne(signedTx2))
+	require.Error(t, transactionPool.RememberOne(signedTx2, false))
 }
 
 func TestCloseAccountWhileTxIsPending(t *testing.T) {
@@ -380,7 +380,7 @@ func TestCloseAccountWhileTxIsPending(t *testing.T) {
 		},
 	}
 	signedTx := tx.Sign(secrets[0])
-	require.NoError(t, transactionPool.RememberOne(signedTx))
+	require.NoError(t, transactionPool.RememberOne(signedTx, false))
 
 	// sender goes below min
 	closeTx := transactions.Transaction{
@@ -400,7 +400,7 @@ func TestCloseAccountWhileTxIsPending(t *testing.T) {
 		},
 	}
 	signedCloseTx := closeTx.Sign(secrets[0])
-	require.Error(t, transactionPool.RememberOne(signedCloseTx))
+	require.Error(t, transactionPool.RememberOne(signedCloseTx, false))
 }
 
 func TestClosingAccountBelowMinBalance(t *testing.T) {
@@ -443,7 +443,7 @@ func TestClosingAccountBelowMinBalance(t *testing.T) {
 		},
 	}
 	signedTx := closeTx.Sign(secrets[0])
-	require.Error(t, transactionPool.RememberOne(signedTx))
+	require.Error(t, transactionPool.RememberOne(signedTx, false))
 }
 
 func TestRecipientGoesBelowMinBalance(t *testing.T) {
@@ -484,7 +484,7 @@ func TestRecipientGoesBelowMinBalance(t *testing.T) {
 		},
 	}
 	signedTx := tx.Sign(secrets[0])
-	require.Error(t, transactionPool.RememberOne(signedTx))
+	require.Error(t, transactionPool.RememberOne(signedTx, false))
 }
 
 func TestRememberForget(t *testing.T) {
@@ -529,8 +529,8 @@ func TestRememberForget(t *testing.T) {
 				tx.Note[0] = byte(i)
 				tx.Note[1] = byte(j)
 				signedTx := tx.Sign(secrets[i])
-				transactionPool.RememberOne(signedTx)
-				err := eval.Transaction(signedTx, transactions.ApplyData{})
+				transactionPool.RememberOne(signedTx, false)
+				err := eval.Transaction(signedTx, transactions.ApplyData{}, false)
 				require.NoError(t, err)
 			}
 		}
@@ -593,7 +593,7 @@ func TestCleanUp(t *testing.T) {
 				tx.Note[0] = byte(i)
 				tx.Note[1] = byte(j)
 				signedTx := tx.Sign(secrets[i])
-				require.NoError(t, transactionPool.RememberOne(signedTx))
+				require.NoError(t, transactionPool.RememberOne(signedTx, false))
 				issuedTransactions++
 			}
 		}
@@ -677,7 +677,7 @@ func TestFixOverflowOnNewBlock(t *testing.T) {
 				}
 
 				signedTx := tx.Sign(secrets[i])
-				require.NoError(t, transactionPool.RememberOne(signedTx))
+				require.NoError(t, transactionPool.RememberOne(signedTx, false))
 				savedTransactions++
 			}
 		}
@@ -706,7 +706,7 @@ func TestFixOverflowOnNewBlock(t *testing.T) {
 	signedTx := tx.Sign(secrets[0])
 
 	blockEval := newBlockEvaluator(t, mockLedger)
-	err := blockEval.Transaction(signedTx, transactions.ApplyData{})
+	err := blockEval.Transaction(signedTx, transactions.ApplyData{}, false)
 	require.NoError(t, err)
 
 	// simulate this transaction was applied
@@ -762,7 +762,7 @@ func TestOverspender(t *testing.T) {
 	signedTx := tx.Sign(secrets[0])
 
 	// consume the transaction of allowed limit
-	require.Error(t, transactionPool.RememberOne(signedTx))
+	require.Error(t, transactionPool.RememberOne(signedTx, false))
 
 	// min transaction
 	minTx := transactions.Transaction{
@@ -781,7 +781,7 @@ func TestOverspender(t *testing.T) {
 		},
 	}
 	signedMinTx := minTx.Sign(secrets[0])
-	require.Error(t, transactionPool.RememberOne(signedMinTx))
+	require.Error(t, transactionPool.RememberOne(signedMinTx, false))
 }
 
 func TestRemove(t *testing.T) {
@@ -821,7 +821,7 @@ func TestRemove(t *testing.T) {
 		},
 	}
 	signedTx := tx.Sign(secrets[0])
-	require.NoError(t, transactionPool.RememberOne(signedTx))
+	require.NoError(t, transactionPool.RememberOne(signedTx, false))
 	require.Equal(t, transactionPool.Pending(), [][]transactions.SignedTxn{[]transactions.SignedTxn{signedTx}})
 }
 
@@ -880,7 +880,7 @@ func TestLogicSigOK(t *testing.T) {
 			Logic: program,
 		},
 	}
-	require.NoError(t, transactionPool.RememberOne(signedTx))
+	require.NoError(t, transactionPool.RememberOne(signedTx, false))
 }
 
 func TestLogicSigReject(t *testing.T) {
@@ -941,7 +941,7 @@ func TestLogicSigReject(t *testing.T) {
 			Logic: program,
 		},
 	}
-	err = transactionPool.RememberOne(signedTx)
+	err = transactionPool.RememberOne(signedTx, false)
 	require.Error(t, err)
 }
 
@@ -1005,7 +1005,7 @@ func TestLogicSigCache(t *testing.T) {
 		},
 	}
 	transactionPool.lsigCache.put(protocol.ConsensusCurrentVersion, signedTx.ID(), nil)
-	err = transactionPool.RememberOne(signedTx)
+	err = transactionPool.RememberOne(signedTx, false)
 	require.NoError(t, err)
 }
 
@@ -1051,7 +1051,7 @@ func BenchmarkTransactionPoolRememberOne(b *testing.B) {
 			crypto.RandBytes(tx.Note)
 			signedTx := tx.Sign(secrets[i])
 			signedTransactions = append(signedTransactions, signedTx)
-			err := transactionPool.RememberOne(signedTx)
+			err := transactionPool.RememberOne(signedTx, false)
 			require.NoError(b, err)
 		}
 	}
@@ -1062,7 +1062,7 @@ func BenchmarkTransactionPoolRememberOne(b *testing.B) {
 
 	b.StartTimer()
 	for _, signedTx := range signedTransactions {
-		transactionPool.RememberOne(signedTx)
+		transactionPool.RememberOne(signedTx, false)
 	}
 }
 
@@ -1113,7 +1113,7 @@ func BenchmarkTransactionPoolPending(b *testing.B) {
 				tx.Note = make([]byte, 8, 8)
 				crypto.RandBytes(tx.Note)
 				signedTx := tx.Sign(secrets[i])
-				err := transactionPool.RememberOne(signedTx)
+				err := transactionPool.RememberOne(signedTx, false)
 				require.NoError(b, err)
 			}
 		}
@@ -1191,7 +1191,7 @@ func BenchmarkTransactionPoolSteadyState(b *testing.B) {
 		// Fill up txpool
 		for len(poolTxnQueue) > 0 {
 			stx := poolTxnQueue[0]
-			err := transactionPool.RememberOne(stx)
+			err := transactionPool.RememberOne(stx, false)
 			if err == nil {
 				poolTxnQueue = poolTxnQueue[1:]
 				ledgerTxnQueue = append(ledgerTxnQueue, stx)
@@ -1207,7 +1207,7 @@ func BenchmarkTransactionPoolSteadyState(b *testing.B) {
 		eval := newBlockEvaluator(b, l)
 		for len(ledgerTxnQueue) > 0 {
 			stx := ledgerTxnQueue[0]
-			err := eval.Transaction(stx, transactions.ApplyData{})
+			err := eval.Transaction(stx, transactions.ApplyData{}, false)
 			if err == ledger.ErrNoSpace {
 				break
 			}

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -141,7 +141,7 @@ func (handler *TxHandler) backlogWorker() {
 			verifiedTxGroup := wi.unverifiedTxGroup
 
 			// save the transaction, if it has high enough fee and not already in the cache
-			err := handler.txPool.Remember(verifiedTxGroup)
+			err := handler.txPool.Remember(verifiedTxGroup, true)
 			if err != nil {
 				logging.Base().Debugf("could not remember tx: %v", err)
 				continue
@@ -184,7 +184,7 @@ func (handler *TxHandler) backlogWorker() {
 			verifiedTxGroup := wi.unverifiedTxGroup
 
 			// save the transaction, if it has high enough fee and not already in the cache
-			err := handler.txPool.Remember(verifiedTxGroup)
+			err := handler.txPool.Remember(verifiedTxGroup, true)
 			if err != nil {
 				logging.Base().Debugf("could not remember tx: %v", err)
 				continue
@@ -269,7 +269,7 @@ func (handler *TxHandler) checkAlreadyCommitted(tx *txBacklogMsg) (processingDon
 	logging.Base().Debugf("got a tx group with IDs %v", txids)
 
 	// do a quick test to check that this transaction could potentially be committed, to reject dup pending transactions
-	err := handler.txPool.Test(tx.unverifiedTxGroup)
+	err := handler.txPool.QuickTest(tx.unverifiedTxGroup)
 	if err != nil {
 		logging.Base().Debugf("txPool rejected transaction: %v", err)
 		return true
@@ -337,7 +337,7 @@ func (handler *TxHandler) processDecoded(unverifiedTxGroup []transactions.Signed
 	verifiedTxGroup := unverifiedTxGroup
 
 	// save the transaction, if it has high enough fee and not already in the cache
-	err := handler.txPool.Remember(verifiedTxGroup)
+	err := handler.txPool.Remember(verifiedTxGroup, true)
 	if err != nil {
 		logging.Base().Debugf("could not remember tx: %v", err)
 		return network.OutgoingMessage{}, true

--- a/ledger/eval_test.go
+++ b/ledger/eval_test.go
@@ -79,17 +79,17 @@ func TestBlockEvaluator(t *testing.T) {
 	st := transactions.SignedTxn{
 		Txn: txn,
 	}
-	err = eval.Transaction(st, transactions.ApplyData{})
+	err = eval.Transaction(st, transactions.ApplyData{}, false)
 	require.Error(t, err)
 
 	// Random signature should fail
 	crypto.RandBytes(st.Sig[:])
-	err = eval.Transaction(st, transactions.ApplyData{})
+	err = eval.Transaction(st, transactions.ApplyData{}, false)
 	require.Error(t, err)
 
 	// Correct signature should work
 	st = txn.Sign(keys[0])
-	err = eval.Transaction(st, transactions.ApplyData{})
+	err = eval.Transaction(st, transactions.ApplyData{}, false)
 	require.NoError(t, err)
 
 	selfTxn := transactions.Transaction{
@@ -106,7 +106,7 @@ func TestBlockEvaluator(t *testing.T) {
 			Amount:   basics.MicroAlgos{Raw: 100},
 		},
 	}
-	err = eval.Transaction(selfTxn.Sign(keys[2]), transactions.ApplyData{})
+	err = eval.Transaction(selfTxn.Sign(keys[2]), transactions.ApplyData{}, false)
 	require.NoError(t, err)
 
 	validatedBlock, err := eval.GenerateBlock()

--- a/node/node.go
+++ b/node/node.go
@@ -409,7 +409,7 @@ func (node *AlgorandFullNode) BroadcastSignedTxGroup(txgroup []transactions.Sign
 			return err
 		}
 	}
-	err = node.transactionPool.Remember(txgroup)
+	err = node.transactionPool.Remember(txgroup, false)
 	if err != nil {
 		node.log.Infof("rejected by local pool: %v - transaction group was %+v", err, txgroup)
 		return err


### PR DESCRIPTION
Don't merge this! I'd like to do this with a cleaner interface.

(I briefly tried using different unverified and verified txn types but stopped
because that change would be too large.)