### PR TITLE
Update CatchupParallelBlocks to reduce the server load

### DIFF
--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -49,7 +49,7 @@ var defaultLocalV5 = Local{
 	PriorityPeers:                         map[string]bool{},
 	CadaverSizeTarget:                     1073741824,
 	CatchupFailurePeerRefreshRate:         10,
-	CatchupParallelBlocks:                 50,
+	CatchupParallelBlocks:                 16,
 	ConnectionsRateLimitingCount:          60,
 	ConnectionsRateLimitingWindowSeconds:  1,
 	DeadlockDetection:                     0,
@@ -344,6 +344,10 @@ func migrate(cfg Local) (newCfg Local, err error) {
 		if newCfg.TxPoolSize == defaultLocalV4.TxPoolSize {
 			newCfg.TxPoolSize = defaultLocalV5.TxPoolSize
 		}
+		if newCfg.CatchupParallelBlocks == defaultLocalV4.CatchupParallelBlocks {
+			newCfg.CatchupParallelBlocks = defaultLocalV5.CatchupParallelBlocks
+		}
+		
 		newCfg.Version = 5
 	}
 

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -6,7 +6,7 @@
     "BroadcastConnectionsLimit": -1,
     "CadaverSizeTarget": 1073741824,
     "CatchupFailurePeerRefreshRate": 10,
-    "CatchupParallelBlocks": 50,
+    "CatchupParallelBlocks": 16,
     "ConnectionsRateLimitingCount": 60,
     "ConnectionsRateLimitingWindowSeconds": 1,
     "DeadlockDetection": 0,

--- a/test/testdata/configs/config-v5.json
+++ b/test/testdata/configs/config-v5.json
@@ -6,7 +6,7 @@
     "BroadcastConnectionsLimit": -1,
     "CadaverSizeTarget": 1073741824,
     "CatchupFailurePeerRefreshRate": 10,
-    "CatchupParallelBlocks": 50,
+    "CatchupParallelBlocks": 16,
     "ConnectionsRateLimitingWindowSeconds": 1,
     "ConnectionsRateLimitingCount": 60,
     "DeadlockDetection": 0,


### PR DESCRIPTION
## Summary

Recent catchup test shown that we're hitting the rate limit too early.

Reducing the number of parallel catchup blocks seems to be an effective way to work around that.