### PR TITLE
Don't panic in txpool on unknown protocol upgrade

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -232,6 +232,11 @@ func (pool *TransactionPool) Test(txgroup []transactions.SignedTxn) error {
 
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
+
+	if pool.pendingBlockEvaluator == nil {
+		return fmt.Errorf("Test: pendingBlockEvaluator is nil")
+	}
+
 	return pool.pendingBlockEvaluator.TestTransactionGroup(txgroup)
 }
 

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -516,6 +516,21 @@ func (pool *TransactionPool) recomputeBlockEvaluator(committedTxIds map[transact
 		return
 	}
 
+	// Process upgrade to see if we support the next protocol version
+	_, upgradeState, err := bookkeeping.ProcessUpgradeParams(prev)
+	if err != nil {
+		logging.Base().Warnf("TransactionPool.recomputeBlockEvaluator: error processing upgrade params for next round: %v", err)
+		return
+	}
+
+	// Ensure we know about the next protocol version (MakeBlock will panic
+	// if we don't, and we would rather stall locally than panic)
+	_, ok := config.Consensus[upgradeState.CurrentProtocol]
+	if !ok {
+		logging.Base().Warnf("TransactionPool.recomputeBlockEvaluator: next protocol version %v is not supported", upgradeState.CurrentProtocol)
+		return
+	}
+
 	next := bookkeeping.MakeBlock(prev)
 	pool.numPendingWholeBlocks = 0
 	pool.pendingBlockEvaluator, err = pool.ledger.StartEvaluator(next.BlockHeader, &alwaysVerifiedPool{pool}, nil)


### PR DESCRIPTION
The transaction pool currently panics when an unknown protocol upgrade occurs. We would prefer for the node to simply stall in this case (apparently we want to continue to be able to hit its HTTP API?)

The panic was occurring in `bookkeeping.MakeBlock`. I factored out the upgrade processing logic from `MakeBlock` to return errors instead. `MakeBlock` will still panic, but now we can check if we know about the next consensus version in the transaction pool before calling it.

Please be on the lookout for places where `pendingBlockEvaluator == nil` could cause a panic.