### PR TITLE
Enforce required param  goal account marknonparticipating command

### DIFF
--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -180,6 +180,7 @@ func init() {
 
 	// markNonparticipatingCmd flags
 	markNonparticipatingCmd.Flags().StringVarP(&accountAddress, "address", "a", "", "Account address to change")
+	markNonparticipatingCmd.MarkFlagRequired("address")
 	markNonparticipatingCmd.Flags().Uint64VarP(&transactionFee, "fee", "f", 0, "The Fee to set on the status change transaction (defaults to suggested fee)")
 	markNonparticipatingCmd.Flags().Uint64VarP(&firstValid, "firstRound", "", 0, "")
 	markNonparticipatingCmd.Flags().Uint64VarP(&firstValid, "firstvalid", "", 0, "FirstValid for the status change transaction (0 for current)")

--- a/test/e2e-go/cli/goal/expect/goalCmdFlagsTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalCmdFlagsTest.exp
@@ -1,0 +1,43 @@
+#!/usr/bin/expect -f
+set err 0
+log_user 1
+
+proc TestGoalCommandLineFlags { CMD EXPECTED_RE } {
+    set PASSED 0
+    eval spawn $CMD
+    expect {
+        timeout { puts "goal asset create timed out"; exit 1 }
+        -re $EXPECTED_RE {set PASSED 1; close }
+    }
+    if { $PASSED == 0 } {
+        puts "'$CMD' did not show expected output"
+        puts "Expected regex:"
+        puts $EXPECTED_RE
+        puts "Actual:"
+        puts $expect_out(buffer)
+        exit 1
+    }
+}
+
+if { [catch {
+    puts "Part 1: Check --validrounds and --lastvalid options combination for 'goal asset' and 'goal account"
+
+    TestGoalCommandLineFlags "goal asset create --validrounds 0 --creator ABC --total 100" ".*can not be zero.*"
+    TestGoalCommandLineFlags "goal asset create --validrounds 1 --lastvalid 1 --creator ABC --total 100" "Only one of .* can be specified"
+
+    TestGoalCommandLineFlags "goal account changeonlinestatus --validRounds 0 --online" ".*validRounds has been deprecated.*"
+    TestGoalCommandLineFlags "goal account changeonlinestatus --firstRound 0 --online" ".*firstRound has been deprecated.*"
+    TestGoalCommandLineFlags "goal account changeonlinestatus --validRounds 0 --online" ".*can not be zero.*"
+    TestGoalCommandLineFlags "goal account changeonlinestatus --validrounds 0 --online" ".*can not be zero.*"
+    TestGoalCommandLineFlags "goal account changeonlinestatus --validRounds 0 --lastvalid 1 --online" "Only one of .* can be specified"
+    TestGoalCommandLineFlags "goal account changeonlinestatus --validrounds 0 --lastvalid 1 --online" "Only one of .* can be specified"
+
+    TestGoalCommandLineFlags "goal clerk send --validrounds 0 -a 1 -t ABC -f ABC" ".*can not be zero.*"
+    TestGoalCommandLineFlags "goal clerk send --validrounds 1 --lastvalid 1 -a 1 -t ABC -f ABC" "Only one of .* can be specified"
+
+    TestGoalCommandLineFlags "goal account marknonparticipating" ".*required flag.*\"address\" not set"
+
+} EXCEPTION ] } {
+    puts "ERROR in Goal Asset Tx Validity test: $EXCEPTION"
+    exit 1
+}

--- a/test/e2e-go/cli/goal/expect/goalTxValidityTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalTxValidityTest.exp
@@ -19,23 +19,6 @@ set NETWORK_TEMPLATE "$TEST_DATA_DIR/nettemplates/TwoNodes50Each.json"
 
 set FILE_COUNTER 1
 
-proc TestGoalCommandLineFlags { CMD EXPECTED_RE } {
-    set PASSED 0
-    eval spawn $CMD
-    expect {
-        timeout { puts "goal asset create timed out"; exit 1 }
-        -re $EXPECTED_RE {set PASSED 1; close }
-    }
-    if { $PASSED == 0 } {
-        puts "'$CMD' did not show expected output"
-        puts "Expected regex:"
-        puts $EXPECTED_RE
-        puts "Actual:"
-        puts $expect_out(buffer)
-        exit 1
-    }
-}
-
 proc TestLastValidInTx { CMD TX_FILE EXPECTED_LAST_VALID } {
     set PASSED 0
     set LAST_VALID 0
@@ -62,29 +45,6 @@ proc TestLastValidInTx { CMD TX_FILE EXPECTED_LAST_VALID } {
 }
 
 if { [catch {
-    puts "Part 1: Check --validrounds and --lastvalid options combination for 'goal asset' and 'goal account"
-
-    TestGoalCommandLineFlags "goal asset create --validrounds 0 --creator ABC --total 100" ".*can not be zero.*"
-    TestGoalCommandLineFlags "goal asset create --validrounds 1 --lastvalid 1 --creator ABC --total 100" "Only one of .* can be specified"
-
-    TestGoalCommandLineFlags "goal account changeonlinestatus --validRounds 0 --online" ".*validRounds has been deprecated.*"
-    TestGoalCommandLineFlags "goal account changeonlinestatus --firstRound 0 --online" ".*firstRound has been deprecated.*"
-    TestGoalCommandLineFlags "goal account changeonlinestatus --validRounds 0 --online" ".*can not be zero.*"
-    TestGoalCommandLineFlags "goal account changeonlinestatus --validrounds 0 --online" ".*can not be zero.*"
-    TestGoalCommandLineFlags "goal account changeonlinestatus --validRounds 0 --lastvalid 1 --online" "Only one of .* can be specified"
-    TestGoalCommandLineFlags "goal account changeonlinestatus --validrounds 0 --lastvalid 1 --online" "Only one of .* can be specified"
-
-    TestGoalCommandLineFlags "goal clerk send --validrounds 0 -a 1 -t ABC -f ABC" ".*can not be zero.*"
-    TestGoalCommandLineFlags "goal clerk send --validrounds 1 --lastvalid 1 -a 1 -t ABC -f ABC" "Only one of .* can be specified"
-
-} EXCEPTION ] } {
-    puts "ERROR in Goal Asset Tx Validity test: $EXCEPTION"
-    exit 1
-}
-
-if { [catch {
-    puts "Part 2: Check actual firstvalid and lastvalid values after TX creation"
-
     # Create network
     ::AlgorandGoal::StartNetwork $NETWORK_NAME $NETWORK_TEMPLATE $TEST_ALGO_DIR $TEST_ROOT_DIR
 


### PR DESCRIPTION
## Summary

Make `--address` param required for  `goal account marknonparticipating command`

## Test Plan

Now we have goalCmdFlagsTesx.exp suite for goal command line flags tests

