### PR TITLE
Disable the transaction pool logic signature cache

### DIFF
--- a/agreement/pseudonode.go
+++ b/agreement/pseudonode.go
@@ -251,6 +251,7 @@ func (n asyncPseudonode) getParticipations(procName string, round basics.Round) 
 // makeProposals creates a slice of block proposals for the given round and period.
 func (n asyncPseudonode) makeProposals(round basics.Round, period period, accounts []account.Participation) ([]proposal, []unauthenticatedVote) {
 	deadline := time.Now().Add(AssemblyTime)
+	n.log.Infof("makeProposals called")
 	ve, err := n.factory.AssembleBlock(round, deadline)
 	if err != nil {
 		n.log.Errorf("pseudonode.makeProposals: could not generate a proposal for round %v: %v", round, err)

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -472,7 +472,9 @@ func (*alwaysVerifiedPool) Verified(txn transactions.SignedTxn) bool {
 	return true
 }
 func (pool *alwaysVerifiedPool) EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (txfound bool, err error) {
-	return pool.pool.EvalOk(cvers, txid)
+	//return pool.pool.EvalOk(cvers, txid)
+	// disable the usage of the cache.
+	return false, nil
 }
 func (pool *alwaysVerifiedPool) EvalRemember(cvers protocol.ConsensusVersion, txid transactions.Txid, txErr error) {
 	pool.pool.EvalRemember(cvers, txid, txErr)

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -381,9 +381,15 @@ func (pool *TransactionPool) Verified(txn transactions.SignedTxn) bool {
 
 // EvalOk for LogicSig Eval of a txn by txid, returns the SignedTxn, error string, and found.
 func (pool *TransactionPool) EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (found bool, err error) {
+	// disable the usage of the cache for now.
+	return false, nil
+
+	// when we will want to bring it back, we should replace it with the following snippet:
+	/*
 	pool.lcmu.RLock()
 	defer pool.lcmu.RUnlock()
 	return pool.lsigCache.get(cvers, txid)
+	*/
 }
 
 // EvalRemember sets an error string from LogicSig Eval for some SignedTxn
@@ -472,9 +478,7 @@ func (*alwaysVerifiedPool) Verified(txn transactions.SignedTxn) bool {
 	return true
 }
 func (pool *alwaysVerifiedPool) EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (txfound bool, err error) {
-	//return pool.pool.EvalOk(cvers, txid)
-	// disable the usage of the cache.
-	return false, nil
+	return pool.pool.EvalOk(cvers, txid)
 }
 func (pool *alwaysVerifiedPool) EvalRemember(cvers protocol.ConsensusVersion, txid transactions.Txid, txErr error) {
 	pool.pool.EvalRemember(cvers, txid, txErr)

--- a/data/pools/transactionPool_test.go
+++ b/data/pools/transactionPool_test.go
@@ -946,6 +946,7 @@ func TestLogicSigReject(t *testing.T) {
 }
 
 func TestLogicSigCache(t *testing.T) {
+	t.Skip("Skipping TestLogicSigCache since we disabled the cache")
 	// hack in a cache entry that passes for a program that would reject
 	oparams := config.Consensus[protocol.ConsensusCurrentVersion]
 	params := oparams

--- a/node/impls.go
+++ b/node/impls.go
@@ -108,6 +108,7 @@ func (i *blockFactoryImpl) AssembleBlock(round basics.Round, deadline time.Time)
 	// Measure time here because we want to know how close to deadline we are
 	dt := time.Now().Sub(start)
 	stats.AssembleBlockStats.Nanoseconds = dt.Nanoseconds()
+	logging.Base().Infof("AssemblePayset: StopReason='%s', BlockSize=%d, IncludedCount=%d, Nanoseconds=%d", stats.AssembleBlockStats.StopReason, stats.AssembleBlockStats.TotalLength, stats.AssembleBlockStats.IncludedCount, stats.AssembleBlockStats.Nanoseconds)
 
 	lvb, err := eval.GenerateBlock()
 	if err != nil {


### PR DESCRIPTION
Disable the cache as a temporary workaround for a potential cache invalidation issue.