### PR TITLE
Deprecate the FirstValidTime txn field inside LogicSig programs.

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -132,7 +132,6 @@ func init() {
 	compileCmd.Flags().StringVarP(&account, "account", "a", "", "Account address to sign the program (If not specified, uses default account)")
 
 	dryrunCmd.Flags().StringVarP(&txFilename, "txfile", "t", "", "transaction or transaction-group to test")
-	// dryrunCmd.Flags().Int64VarP(&timeStamp, "time-stamp", "S", 0, "unix time value for txn FirstValidTime (default now)")
 	dryrunCmd.Flags().StringVarP(&protoVersion, "proto", "P", "", "consensus protocol version id string")
 	dryrunCmd.MarkFlagRequired("txfile")
 }
@@ -918,7 +917,6 @@ var dryrunCmd = &cobra.Command{
 				Trace:      &sb,
 				TxnGroup:   txgroup,
 				GroupIndex: i,
-				// FirstValidTimeStamp: uint64(timeStamp),
 			}
 			pass, err := logic.Eval(txn.Lsig.Logic, ep)
 			// TODO: optionally include `inspect` output here?

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -132,7 +132,7 @@ func init() {
 	compileCmd.Flags().StringVarP(&account, "account", "a", "", "Account address to sign the program (If not specified, uses default account)")
 
 	dryrunCmd.Flags().StringVarP(&txFilename, "txfile", "t", "", "transaction or transaction-group to test")
-	dryrunCmd.Flags().Int64VarP(&timeStamp, "time-stamp", "S", 0, "unix time value for txn FirstValidTime (default now)")
+	// dryrunCmd.Flags().Int64VarP(&timeStamp, "time-stamp", "S", 0, "unix time value for txn FirstValidTime (default now)")
 	dryrunCmd.Flags().StringVarP(&protoVersion, "proto", "P", "", "consensus protocol version id string")
 	dryrunCmd.MarkFlagRequired("txfile")
 }
@@ -913,12 +913,12 @@ var dryrunCmd = &cobra.Command{
 			}
 			sb := strings.Builder{}
 			ep = logic.EvalParams{
-				Txn:                 &txn.SignedTxn,
-				Proto:               &proto,
-				Trace:               &sb,
-				TxnGroup:            txgroup,
-				GroupIndex:          i,
-				FirstValidTimeStamp: uint64(timeStamp),
+				Txn:        &txn.SignedTxn,
+				Proto:      &proto,
+				Trace:      &sb,
+				TxnGroup:   txgroup,
+				GroupIndex: i,
+				// FirstValidTimeStamp: uint64(timeStamp),
 			}
 			pass, err := logic.Eval(txn.Lsig.Logic, ep)
 			// TODO: optionally include `inspect` output here?

--- a/data/transactions/logic/README.md
+++ b/data/transactions/logic/README.md
@@ -133,7 +133,7 @@ Some of these have immediate data in the byte or bytes after the opcode.
 | 0 | Sender | []byte | 32 byte address |
 | 1 | Fee | uint64 | micro-Algos |
 | 2 | FirstValid | uint64 | round number |
-| 3 | FirstValidTime | uint64 | Seconds since 1970-01-01 00:00:00 UTC of block at FirstValid-1 |
+| 3 | FirstValidTime | uint64 | Causes program to fail; reserved for future use. |
 | 4 | LastValid | uint64 | round number |
 | 5 | Note | []byte |  |
 | 6 | Lease | []byte |  |
@@ -241,6 +241,6 @@ Current design and implementation limitations to be aware of.
 * TEAL cannot lookup balances of Algos or other assets. (Standard transaction accounting will apply after TEAL has run and authorized a transaction. A TEAL-approved transaction could still be invalid by other accounting rules just as a standard signed transaction could be invalid. e.g. I can't give away money I don't have.)
 * TEAL cannot access information in previous blocks. TEAL cannot access most information in other transactions in the current block. (TEAL can access fields of the transaction it is attached to and the transactions in an atomic transaction group.)
 * TEAL cannot know exactly what round the current transaction will commit in (but it is somewhere in FirstValid through LastValid).
-* TEAL cannot know exactly what time its transaction is committed. (`txn FirstValidTime` should be approximately the 'unix time' seconds since 1970-01-01 00:00:00 UTC of the block *before* FirstValid, but there are conditions in which this time may drift and slowly re-align to close to accurate time.)
+* TEAL cannot know exactly what time its transaction is committed.
 * TEAL cannot loop. Its branch instruction `bnz` "branch if not zero" can only branch forward so as to skip some code.
 * TEAL cannot recurse. There is no subroutine jump operation.

--- a/data/transactions/logic/README_in.md
+++ b/data/transactions/logic/README_in.md
@@ -153,6 +153,6 @@ Current design and implementation limitations to be aware of.
 * TEAL cannot lookup balances of Algos or other assets. (Standard transaction accounting will apply after TEAL has run and authorized a transaction. A TEAL-approved transaction could still be invalid by other accounting rules just as a standard signed transaction could be invalid. e.g. I can't give away money I don't have.)
 * TEAL cannot access information in previous blocks. TEAL cannot access most information in other transactions in the current block. (TEAL can access fields of the transaction it is attached to and the transactions in an atomic transaction group.)
 * TEAL cannot know exactly what round the current transaction will commit in (but it is somewhere in FirstValid through LastValid).
-* TEAL cannot know exactly what time its transaction is committed. (`txn FirstValidTime` should be approximately the 'unix time' seconds since 1970-01-01 00:00:00 UTC of the block *before* FirstValid, but there are conditions in which this time may drift and slowly re-align to close to accurate time.)
+* TEAL cannot know exactly what time its transaction is committed.
 * TEAL cannot loop. Its branch instruction `bnz` "branch if not zero" can only branch forward so as to skip some code.
 * TEAL cannot recurse. There is no subroutine jump operation.

--- a/data/transactions/logic/TEAL_opcodes.md
+++ b/data/transactions/logic/TEAL_opcodes.md
@@ -339,7 +339,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 | 0 | Sender | []byte | 32 byte address |
 | 1 | Fee | uint64 | micro-Algos |
 | 2 | FirstValid | uint64 | round number |
-| 3 | FirstValidTime | uint64 | Seconds since 1970-01-01 00:00:00 UTC of block at FirstValid-1 |
+| 3 | FirstValidTime | uint64 | Causes program to fail; reserved for future use. |
 | 4 | LastValid | uint64 | round number |
 | 5 | Note | []byte |  |
 | 6 | Lease | []byte |  |
@@ -374,7 +374,7 @@ TypeEnum mapping:
 | 5 | afrz | AssetFreeze |
 
 
-FirstValidTime is actually the time of the round at FirstValid-1. Subtle implementation details make it much faster to serve details of an already completed round. `int` accepts the user friendly names for comparison to `txn TypeEnum`
+FirstValidTime causes the program to fail. The field is reserved for future use.
 
 ## global
 

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -491,7 +491,7 @@ const (
 	Fee
 	// FirstValid Transaction.FirstValid
 	FirstValid
-	// FirstValidTime Block[Transaction.FirstValid].TimeStamp
+	// FirstValidTime panic
 	FirstValidTime
 	// LastValid Transaction.LastValid
 	LastValid

--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -130,7 +130,7 @@ var opDocExtraList = []stringString{
 	{"intcblock", "`intcblock` loads following program bytes into an array of integer constants in the evaluator. These integer constants can be referred to by `intc` and `intc_*` which will push the value onto the stack. Subsequent calls to `intcblock` reset and replace the integer constants available to the script."},
 	{"bytecblock", "`bytecblock` loads the following program bytes into an array of byte string constants in the evaluator. These constants can be referred to by `bytec` and `bytec_*` which will push the value onto the stack. Subsequent calls to `bytecblock` reset and replace the bytes constants available to the script."},
 	{"*", "Overflow is an error condition which halts execution and fails the transaction. Full precision is available from `mulw`."},
-	{"txn", "FirstValidTime is actually the time of the round at FirstValid-1. Subtle implementation details make it much faster to serve details of an already completed round. `int` accepts the user friendly names for comparison to `txn TypeEnum`"},
+	{"txn", "FirstValidTime causes the program to fail. The field is reserved for future use."},
 	{"gtxn", "for notes on transaction fields available, see `txn`. If this transaction is _i_ in the group, `gtxn i field` is equivalent to `txn field`"},
 	{"btoi", "`btoi` panics if the input is longer than 8 bytes"},
 }
@@ -224,7 +224,7 @@ var txnFieldDocList = []stringString{
 	{"Sender", "32 byte address"},
 	{"Fee", "micro-Algos"},
 	{"FirstValid", "round number"},
-	{"FirstValidTime", "Seconds since 1970-01-01 00:00:00 UTC of block at FirstValid-1"},
+	{"FirstValidTime", "Causes program to fail; reserved for future use."},
 	{"LastValid", "round number"},
 	{"Receiver", "32 byte address"},
 	{"Amount", "micro-Algos"},

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -93,8 +93,6 @@ type EvalParams struct {
 	// GroupIndex should point to Txn within TxnGroup
 	GroupIndex int
 
-	// FirstValidTimeStamp uint64
-
 	Logger logging.Logger
 }
 
@@ -985,8 +983,6 @@ func (cx *evalContext) txnFieldToStack(txn *transactions.Transaction, field uint
 		sv.Uint = txn.Fee.Raw
 	case FirstValid:
 		sv.Uint = uint64(txn.FirstValid)
-	// case FirstValidTime:
-	// 	sv.Uint = cx.FirstValidTimeStamp
 	case LastValid:
 		sv.Uint = uint64(txn.LastValid)
 	case Note:

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -93,7 +93,7 @@ type EvalParams struct {
 	// GroupIndex should point to Txn within TxnGroup
 	GroupIndex int
 
-	FirstValidTimeStamp uint64
+	// FirstValidTimeStamp uint64
 
 	Logger logging.Logger
 }
@@ -985,8 +985,8 @@ func (cx *evalContext) txnFieldToStack(txn *transactions.Transaction, field uint
 		sv.Uint = txn.Fee.Raw
 	case FirstValid:
 		sv.Uint = uint64(txn.FirstValid)
-	case FirstValidTime:
-		sv.Uint = cx.FirstValidTimeStamp
+	// case FirstValidTime:
+	// 	sv.Uint = cx.FirstValidTimeStamp
 	case LastValid:
 		sv.Uint = uint64(txn.LastValid)
 	case Note:

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -957,7 +957,8 @@ int %s
 			txn.Txn.Type = tt
 			sb := strings.Builder{}
 			proto := defaultEvalProto()
-			pass, err := Eval(program, EvalParams{Proto: &proto, Trace: &sb, Txn: &txn, GroupIndex: 3, FirstValidTimeStamp: 210})
+			// pass, err := Eval(program, EvalParams{Proto: &proto, Trace: &sb, Txn: &txn, GroupIndex: 3, FirstValidTimeStamp: 210})
+			pass, err := Eval(program, EvalParams{Proto: &proto, Trace: &sb, Txn: &txn, GroupIndex: 3})
 			if !pass {
 				t.Log(hex.EncodeToString(program))
 				t.Log(sb.String())
@@ -997,10 +998,6 @@ int 1337
 &&
 txn FirstValid
 int 42
-==
-&&
-txn FirstValidTime
-int 210
 ==
 &&
 txn LastValid
@@ -1068,7 +1065,9 @@ func TestTxn(t *testing.T) {
 	t.Parallel()
 	for _, txnField := range TxnFieldNames {
 		if !strings.Contains(testTxnProgramText, txnField) {
-			t.Errorf("TestTxn missing field %v", txnField)
+			if txnField != FirstValidTime.String() {
+				t.Errorf("TestTxn missing field %v", txnField)
+			}
 		}
 	}
 	program, err := AssembleString(testTxnProgramText)
@@ -1113,7 +1112,8 @@ func TestTxn(t *testing.T) {
 	}
 	sb := strings.Builder{}
 	proto := defaultEvalProto()
-	pass, err := Eval(program, EvalParams{Proto: &proto, Trace: &sb, Txn: &txn, GroupIndex: 3, FirstValidTimeStamp: 210})
+	// pass, err := Eval(program, EvalParams{Proto: &proto, Trace: &sb, Txn: &txn, GroupIndex: 3, FirstValidTimeStamp: 210})
+	pass, err := Eval(program, EvalParams{Proto: &proto, Trace: &sb, Txn: &txn, GroupIndex: 3})
 	if !pass {
 		t.Log(hex.EncodeToString(program))
 		t.Log(sb.String())

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -957,7 +957,6 @@ int %s
 			txn.Txn.Type = tt
 			sb := strings.Builder{}
 			proto := defaultEvalProto()
-			// pass, err := Eval(program, EvalParams{Proto: &proto, Trace: &sb, Txn: &txn, GroupIndex: 3, FirstValidTimeStamp: 210})
 			pass, err := Eval(program, EvalParams{Proto: &proto, Trace: &sb, Txn: &txn, GroupIndex: 3})
 			if !pass {
 				t.Log(hex.EncodeToString(program))
@@ -1112,7 +1111,6 @@ func TestTxn(t *testing.T) {
 	}
 	sb := strings.Builder{}
 	proto := defaultEvalProto()
-	// pass, err := Eval(program, EvalParams{Proto: &proto, Trace: &sb, Txn: &txn, GroupIndex: 3, FirstValidTimeStamp: 210})
 	pass, err := Eval(program, EvalParams{Proto: &proto, Trace: &sb, Txn: &txn, GroupIndex: 3})
 	if !pass {
 		t.Log(hex.EncodeToString(program))

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -674,21 +674,12 @@ func (eval *BlockEvaluator) checkLogicSig(txn transactions.SignedTxn, txgroup []
 	if txn.Txn.FirstValid == 0 {
 		return errors.New("LogicSig does not work with FirstValid==0")
 	}
-	// TODO: enable in the future, once ledger lookback is fixed.
-	// hdr, err := eval.l.BlockHdr(basics.Round(txn.Txn.FirstValid - 1))
-	// if err != nil {
-	// 	return fmt.Errorf("could not fetch BlockHdr for FirstValid-1=%d (current=%d): %s", txn.Txn.FirstValid-1, eval.block.BlockHeader.Round, err)
-	// }
 	ep := logic.EvalParams{
 		Txn:        &txn,
 		Proto:      &eval.proto,
 		TxnGroup:   txgroup,
 		GroupIndex: groupIndex,
 	}
-	// if hdr.TimeStamp < 0 {
-	// 	return fmt.Errorf("cannot evaluate LogicSig before 1970 at TimeStamp %d", hdr.TimeStamp)
-	// }
-	// ep.FirstValidTimeStamp = uint64(hdr.TimeStamp)
 	pass, err := logic.Eval(txn.Lsig.Logic, ep)
 	if err != nil {
 		logicErrTotal.Inc(nil)

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -674,21 +674,21 @@ func (eval *BlockEvaluator) checkLogicSig(txn transactions.SignedTxn, txgroup []
 	if txn.Txn.FirstValid == 0 {
 		return errors.New("LogicSig does not work with FirstValid==0")
 	}
-	// TODO: move this into some lazy evaluator for the few scripts that actually use `txn FirstValidTime` ?
-	hdr, err := eval.l.BlockHdr(basics.Round(txn.Txn.FirstValid - 1))
-	if err != nil {
-		return fmt.Errorf("could not fetch BlockHdr for FirstValid-1=%d (current=%d): %s", txn.Txn.FirstValid-1, eval.block.BlockHeader.Round, err)
-	}
+	// TODO: enable in the future, once ledger lookback is fixed.
+	// hdr, err := eval.l.BlockHdr(basics.Round(txn.Txn.FirstValid - 1))
+	// if err != nil {
+	// 	return fmt.Errorf("could not fetch BlockHdr for FirstValid-1=%d (current=%d): %s", txn.Txn.FirstValid-1, eval.block.BlockHeader.Round, err)
+	// }
 	ep := logic.EvalParams{
 		Txn:        &txn,
 		Proto:      &eval.proto,
 		TxnGroup:   txgroup,
 		GroupIndex: groupIndex,
 	}
-	if hdr.TimeStamp < 0 {
-		return fmt.Errorf("cannot evaluate LogicSig before 1970 at TimeStamp %d", hdr.TimeStamp)
-	}
-	ep.FirstValidTimeStamp = uint64(hdr.TimeStamp)
+	// if hdr.TimeStamp < 0 {
+	// 	return fmt.Errorf("cannot evaluate LogicSig before 1970 at TimeStamp %d", hdr.TimeStamp)
+	// }
+	// ep.FirstValidTimeStamp = uint64(hdr.TimeStamp)
 	pass, err := logic.Eval(txn.Lsig.Logic, ep)
 	if err != nil {
 		logicErrTotal.Inc(nil)

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -101,7 +101,7 @@ const ConsensusV18 = ConsensusVersion(
 
 // ConsensusV19 points to 'final' spec commit for 2019 nov release
 const ConsensusV19 = ConsensusVersion(
-	"https://github.com/algorandfoundation/specs/tree/b336749d15497f065b465dae3c51e46a60104d37",
+	"https://github.com/algorandfoundation/specs/tree/0e196e82bfd6e327994bec373c4cc81bc878ef5c",
 )
 
 // ConsensusFuture is a protocol that should not appear in any production

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -101,7 +101,7 @@ const ConsensusV18 = ConsensusVersion(
 
 // ConsensusV19 points to 'final' spec commit for 2019 nov release
 const ConsensusV19 = ConsensusVersion(
-	"https://github.com/algorandfoundation/specs/tree/03ae4eac54f1325377d0a2df62b5ef7cc08c5e18",
+	"https://github.com/algorandfoundation/specs/tree/b336749d15497f065b465dae3c51e46a60104d37",
 )
 
 // ConsensusFuture is a protocol that should not appear in any production


### PR DESCRIPTION
The ledger currently guarantees storage of the last 1000 blocks.  Reads on
blocks with rounds older than this on non-archival nodes will intermittently
fail, which may potentially cause the consensus protocol to stall (by
introducing subjectivity into block evaluation).

As a temporary fix, this commit disables the FirstValidTime txn field within
LogicSig programs.