### PR TITLE
Increase size of StringSanitizer limits. Closes #579

### DIFF
--- a/logging/telemetryConfig.go
+++ b/logging/telemetryConfig.go
@@ -33,7 +33,6 @@ import (
 // TelemetryConfigFilename default file name for telemetry config "logging.config"
 var TelemetryConfigFilename = "logging.config"
 
-const ipv6AddressLength = 39
 const hostnameLength = 255
 
 // TelemetryOverride Determines whether an override value is set and what it's value is.

--- a/logging/telemetryConfig.go
+++ b/logging/telemetryConfig.go
@@ -34,6 +34,7 @@ import (
 var TelemetryConfigFilename = "logging.config"
 
 const ipv6AddressLength = 39
+const hostnameLength = 255
 
 // TelemetryOverride Determines whether an override value is set and what it's value is.
 // The first return value is whether an override variable is found, if it is, the second is the override value.
@@ -117,7 +118,7 @@ func (cfg TelemetryConfig) getInstanceName() string {
 // SanitizeTelemetryString applies sanitization rules and returns the sanitized string.
 func SanitizeTelemetryString(input string, maxParts int) string {
 	// Truncate to a reasonable size, allowing some undefined separator.
-	maxReasonableSize := maxParts*ipv6AddressLength + maxParts - 1
+	maxReasonableSize := maxParts*hostnameLength + maxParts - 1
 	if len(input) > maxReasonableSize {
 		input = input[:maxReasonableSize]
 	}

--- a/logging/telemetryConfig_test.go
+++ b/logging/telemetryConfig_test.go
@@ -100,10 +100,8 @@ func Test_SanitizeTelemetryString(t *testing.T) {
 
 	tests := []testcase{
 		{"2001:0db8:85a3:0000:0000:8a2e:0370:7334", "2001:0db8:85a3:0000:0000:8a2e:0370:7334", 1},
-		{"2001:0db8:85a3:0000:0000:8a2e:0370:7334:9999", "2001:0db8:85a3:0000:0000:8a2e:0370:7334", 1},
-		{"this.needs.to.be.truncated.because.it.is.way.too.long", "this.needs.to.be.truncated.because.it.i", 1},
-		{"this.needs.to.be.truncated.because.it.is.way.too.long:two-parts-can-be-bigger", "this.needs.to.be.truncated.because.it.is.way.too.long:two-parts-can-be-bigger", 2},
-		{"this.needs.to.be.truncated.because.it.is.way.too.long:two-parts-can-be-bigger-but-there-is-still-a-limit", "this.needs.to.be.truncated.because.it.is.way.too.long:two-parts-can-be-bigger-b", 2},
+		{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1},
+		{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

Node runners are using hostnames to identify their machines, so we need to increase the size allowed by the SanitizeString method.

## Test Plan

The unit test has been updated.