### PR TITLE
Enumerate all ledgers

### DIFF
--- a/daemon/kmd/kmd.go
+++ b/daemon/kmd/kmd.go
@@ -52,7 +52,7 @@ func Start(startConfig StartConfig) (died chan error, sock string, err error) {
 	}
 
 	// Initialize wallet drivers with the config
-	err = driver.InitWalletDrivers(kmdCfg)
+	err = driver.InitWalletDrivers(kmdCfg, startConfig.Log)
 	if err != nil {
 		return
 	}

--- a/daemon/kmd/wallet/driver/driver.go
+++ b/daemon/kmd/wallet/driver/driver.go
@@ -22,6 +22,7 @@ import (
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/daemon/kmd/config"
 	"github.com/algorand/go-algorand/daemon/kmd/wallet"
+	"github.com/algorand/go-algorand/logging"
 )
 
 var walletDrivers = map[string]Driver{
@@ -34,7 +35,7 @@ var walletDrivers = map[string]Driver{
 // initialize themselves from a Config, create a wallet with a name, ID,
 // and password, and fetch a wallet by ID.
 type Driver interface {
-	InitWithConfig(cfg config.KMDConfig) error
+	InitWithConfig(cfg config.KMDConfig, log logging.Logger) error
 	ListWalletMetadatas() ([]wallet.Metadata, error)
 	CreateWallet(name []byte, id []byte, pw []byte, mdk crypto.MasterDerivationKey) error
 	RenameWallet(newName []byte, id []byte, pw []byte) error
@@ -42,9 +43,9 @@ type Driver interface {
 }
 
 // InitWalletDrivers accepts a KMDConfig and uses it to initialize each driver
-func InitWalletDrivers(cfg config.KMDConfig) error {
+func InitWalletDrivers(cfg config.KMDConfig, log logging.Logger) error {
 	for _, driver := range walletDrivers {
-		err := driver.InitWithConfig(cfg)
+		err := driver.InitWithConfig(cfg, log)
 		if err != nil {
 			return err
 		}

--- a/daemon/kmd/wallet/driver/ledger.go
+++ b/daemon/kmd/wallet/driver/ledger.go
@@ -27,6 +27,7 @@ import (
 	"github.com/algorand/go-algorand/daemon/kmd/config"
 	"github.com/algorand/go-algorand/daemon/kmd/wallet"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -60,6 +61,7 @@ type LedgerWalletDriver struct {
 type LedgerWallet struct {
 	mu  deadlock.Mutex
 	dev LedgerUSB
+	log logging.Logger
 }
 
 // CreateWallet implements the Driver interface.  There is
@@ -85,8 +87,8 @@ func (lwd *LedgerWalletDriver) FetchWallet(id []byte) (w wallet.Wallet, err erro
 // InitWithConfig accepts a driver configuration.  Currently, the Ledger
 // driver does not have any configuration parameters.  However, we use
 // this to enumerate the USB devices.
-func (lwd *LedgerWalletDriver) InitWithConfig(cfg config.KMDConfig) error {
-	devs, err := LedgerEnumerate()
+func (lwd *LedgerWalletDriver) InitWithConfig(cfg config.KMDConfig, log logging.Logger) error {
+	devs, err := LedgerEnumerate(log)
 	if err != nil {
 		return err
 	}

--- a/daemon/kmd/wallet/driver/ledger_hid.go
+++ b/daemon/kmd/wallet/driver/ledger_hid.go
@@ -207,7 +207,7 @@ func LedgerEnumerate(log logging.Logger) ([]LedgerUSB, error) {
 		// Try to open the device
 		dev, err := info.Open()
 		if err != nil {
-			log.Warnf("enumerated but failed to open ledger %x", info.ProductID)
+			log.Warnf("enumerated but failed to open ledger %x: %v", info.ProductID, err)
 			continue
 		}
 

--- a/daemon/kmd/wallet/driver/ledger_hid.go
+++ b/daemon/kmd/wallet/driver/ledger_hid.go
@@ -21,21 +21,11 @@ import (
 	"fmt"
 
 	"github.com/karalabe/hid"
+
+	"github.com/algorand/go-algorand/logging"
 )
 
-// deviceID holds a vendor ID and product ID for a USB device
-type deviceID struct {
-	vendor  uint16
-	product uint16
-}
-
-// ledgerDeviceIDs contains the device IDs we're scanning for
-var ledgerDeviceIDs = [...]deviceID{
-	// Ledger Nano S
-	deviceID{0x2c97, 0x0001},
-	// Ledger Nano X
-	deviceID{0x2c97, 0x0004},
-}
+const ledgerVendorID = 0x2c97
 
 // LedgerUSB is a wrapper around a Ledger USB HID device, used to implement
 // the protocol used for sending messages to the application running on the
@@ -207,23 +197,32 @@ func (l *LedgerUSB) USBInfo() hid.DeviceInfo {
 }
 
 // LedgerEnumerate returns all of the Ledger devices connected to this machine.
-func LedgerEnumerate() ([]LedgerUSB, error) {
+func LedgerEnumerate(log logging.Logger) ([]LedgerUSB, error) {
 	if !hid.Supported() {
 		return nil, fmt.Errorf("HID not supported")
 	}
 
 	var devs []LedgerUSB
-	for _, did := range ledgerDeviceIDs {
-		for _, info := range hid.Enumerate(did.vendor, did.product) {
-			dev, err := info.Open()
-			if err != nil {
-				return nil, err
-			}
-
-			devs = append(devs, LedgerUSB{
-				hiddev: dev,
-			})
+	uniqueSerials := map[string]bool{}
+	for _, info := range hid.Enumerate(ledgerVendorID, 0) {
+		// Check if we've opened a device with this serial number already
+		// since sometimes we see duplicates
+		_, ok := uniqueSerials[info.Serial]
+		if ok {
+			continue
 		}
+		uniqueSerials[info.Serial] = true
+
+		// Try to open the device
+		dev, err := info.Open()
+		if err != nil {
+			log.Warnf("enumerated but failed to open ledger %x", info.ProductID)
+			continue
+		}
+
+		devs = append(devs, LedgerUSB{
+			hiddev: dev,
+		})
 	}
 
 	return devs, nil

--- a/daemon/kmd/wallet/driver/ledger_hid.go
+++ b/daemon/kmd/wallet/driver/ledger_hid.go
@@ -203,16 +203,7 @@ func LedgerEnumerate(log logging.Logger) ([]LedgerUSB, error) {
 	}
 
 	var devs []LedgerUSB
-	uniqueSerials := map[string]bool{}
 	for _, info := range hid.Enumerate(ledgerVendorID, 0) {
-		// Check if we've opened a device with this serial number already
-		// since sometimes we see duplicates
-		_, ok := uniqueSerials[info.Serial]
-		if ok {
-			continue
-		}
-		uniqueSerials[info.Serial] = true
-
 		// Try to open the device
 		dev, err := info.Open()
 		if err != nil {

--- a/daemon/kmd/wallet/driver/sqlite.go
+++ b/daemon/kmd/wallet/driver/sqlite.go
@@ -34,6 +34,7 @@ import (
 	"github.com/algorand/go-algorand/daemon/kmd/wallet"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/data/transactions/logic"
+	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-codec/codec"
 )
@@ -132,7 +133,7 @@ func msgpackDecode(b []byte, objptr interface{}) error {
 
 // InitWithConfig accepts a driver configuration so that the SQLite driver
 // knows where to read and write its wallet databases
-func (swd *SQLiteWalletDriver) InitWithConfig(cfg config.KMDConfig) error {
+func (swd *SQLiteWalletDriver) InitWithConfig(cfg config.KMDConfig, log logging.Logger) error {
 	swd.globalCfg = cfg
 	swd.sqliteCfg = cfg.DriverConfig.SQLiteWalletDriverConfig
 


### PR DESCRIPTION
Ledgers have lots of different product IDs. This PR enumerates all devices that appear to be manufactured by ledger.

This PR also only makes it a warning when a device fails to open. Before, when that would happen, all of kmd would crash since the wallet driver initialization would return an error. Instead, we just log an error to the log file now.

This PR does _not_ fix the issue where a ledger shows up twice. I thought about trying to fix that by checking `info.Interface` from https://godoc.org/github.com/karalabe/hid#DeviceInfo and deduping on that, but the docs indicate that `Interface` has platform specific behavior that I can't test easily.