### PR TITLE
Add PeerConnections to network telemetry

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -747,6 +747,10 @@ type Local struct {
 
 	// EnableRequestLogger enabled the logging of the incoming requests to the telemetry server.
 	EnableRequestLogger bool
+
+	// PeerConnectionsUpdateInterval defines the interval at which the peer connections information is being sent to the
+	// telemetry ( when enabled ). Defined in seconds.
+	PeerConnectionsUpdateInterval int
 }
 
 // Filenames of config files within the configdir (e.g. ~/.algorand)

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -87,6 +87,7 @@ var defaultLocalV5 = Local{
 	TxSyncIntervalSeconds:                 60,
 	TxSyncTimeoutSeconds:                  30,
 	TxSyncServeResponseSize:               1000000,
+	PeerConnectionsUpdateInterval:         3600,
 	// DO NOT MODIFY VALUES - New values may be added carefully - See WARNING at top of file
 }
 
@@ -138,6 +139,7 @@ var defaultLocalV4 = Local{
 	TxSyncIntervalSeconds:                 60,
 	TxSyncTimeoutSeconds:                  30,
 	TxSyncServeResponseSize:               1000000,
+
 	// DO NOT MODIFY VALUES - New values may be added carefully - See WARNING at top of file
 }
 
@@ -347,7 +349,10 @@ func migrate(cfg Local) (newCfg Local, err error) {
 		if newCfg.CatchupParallelBlocks == defaultLocalV4.CatchupParallelBlocks {
 			newCfg.CatchupParallelBlocks = defaultLocalV5.CatchupParallelBlocks
 		}
-		
+		if newCfg.PeerConnectionsUpdateInterval == defaultLocalV4.PeerConnectionsUpdateInterval {
+			newCfg.PeerConnectionsUpdateInterval = defaultLocalV5.PeerConnectionsUpdateInterval
+		}
+
 		newCfg.Version = 5
 	}
 

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -44,5 +44,6 @@
     "TxPoolSize": 15000,
     "TxSyncIntervalSeconds": 60,
     "TxSyncServeResponseSize": 1000000,
-    "TxSyncTimeoutSeconds": 30
+    "TxSyncTimeoutSeconds": 30,
+    "PeerConnectionsUpdateInterval": 3600
 }

--- a/logging/telemetryspec/event.go
+++ b/logging/telemetryspec/event.go
@@ -253,3 +253,26 @@ type HTTPRequestDetails struct {
 	BodyLength   uint64 // The returned body length, in bytes
 	UserAgent    string // The user-agent string ( if any )
 }
+
+// PeerConnectionsEvent event
+const PeerConnectionsEvent Event = "PeerConnections"
+
+// PeersConnectionDetails contains details for PeerConnectionsEvent
+type PeersConnectionDetails struct {
+	IncomingPeers []PeerConnectionDetails
+	OutgoingPeers []PeerConnectionDetails
+}
+
+// PeerConnectionDetails contains details for PeerConnectionsEvent regarding a single peer ( either incoming or outgoing )
+type PeerConnectionDetails struct {
+	// Address is the IP address of the remote connected socket
+	Address string
+	// The HostName is the TelemetryGUID passed via the X-Algorand-TelId header during the http connection handshake.
+	HostName string
+	// InstanceName is the node-specific hashed instance name that was passed via X-Algorand-InstanceName header during the http connection handshake.
+	InstanceName string
+	// ConnectionDuration is the duration of the connection, in seconds.
+	ConnectionDuration uint
+	// Endpoint is the dialed-to address, for an outgoing connection. Not being used for incoming connection.
+	Endpoint string `json:",omitempty"`
+}

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1282,10 +1282,10 @@ func (wn *WebsocketNetwork) sendPeerConnectionsTelemetryStatus() {
 			ConnectionDuration: uint(now.Sub(peer.createTime).Seconds()),
 			HostName:           peer.TelemetryGUID,
 			InstanceName:       peer.InstanceName,
-			Endpoint:           peer.GetAddress(),
 		}
 		if peer.outgoing {
 			connDetail.Address = justHost(peer.conn.RemoteAddr().String())
+			connDetail.Endpoint = peer.GetAddress()
 			connectionDetails.OutgoingPeers = append(connectionDetails.OutgoingPeers, connDetail)
 		} else {
 			connDetail.Address = peer.OriginAddress()

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -317,6 +317,9 @@ type WebsocketNetwork struct {
 
 	requestsTracker *RequestTracker
 	requestsLogger  *RequestLogger
+
+	// lastPeerConnectionsSent is the last time the peer connections were sent ( or attempted to be sent ) to the telemetry server.
+	lastPeerConnectionsSent time.Time
 }
 
 type broadcastRequest struct {
@@ -516,6 +519,7 @@ func (wn *WebsocketNetwork) setup() {
 	wn.upgrader.ReadBufferSize = 4096
 	wn.upgrader.WriteBufferSize = 4096
 	wn.upgrader.EnableCompression = false
+	wn.lastPeerConnectionsSent = time.Now()
 	wn.router = mux.NewRouter()
 	wn.router.Handle(GossipNetworkPath, wn)
 	wn.requestsTracker = makeRequestsTracker(wn.router, wn.log, wn.config)
@@ -728,8 +732,10 @@ func (wn *WebsocketNetwork) ClearHandlers() {
 }
 
 func (wn *WebsocketNetwork) setHeaders(header http.Header) {
-	myTelemetryGUID := wn.log.GetTelemetryHostName()
-	header.Set(TelemetryIDHeader, myTelemetryGUID)
+	localTelemetryGUID := wn.log.GetTelemetryHostName()
+	localInstanceName := wn.log.GetInstanceName()
+	header.Set(TelemetryIDHeader, localTelemetryGUID)
+	header.Set(InstanceNameHeader, localInstanceName)
 	header.Set(ProtocolVersionHeader, ProtocolVersion)
 	header.Set(AddressHeader, wn.PublicAddress())
 	header.Set(NodeRandomHeader, wn.RandomID)
@@ -1250,7 +1256,44 @@ func (wn *WebsocketNetwork) meshThread() {
 		if request.done != nil {
 			close(request.done)
 		}
+
+		// send the currently connected peers information to the
+		// telemetry server; that would allow the telemetry server
+		// to construct a cross-node map of all the nodes interconnections.
+		wn.sendPeerConnectionsTelemetryStatus()
 	}
+}
+
+// sendPeerConnectionsTelemetryStatus sends a snapshot of the currently connected peers
+// to the telemetry server. Internally, it's using a timer to ensure that it would only
+// send the information once every hour ( configurable via PeerConnectionsUpdateInterval )
+func (wn *WebsocketNetwork) sendPeerConnectionsTelemetryStatus() {
+	now := time.Now()
+	if wn.lastPeerConnectionsSent.Add(time.Duration(wn.config.PeerConnectionsUpdateInterval)*time.Second).After(now) || wn.config.PeerConnectionsUpdateInterval <= 0 {
+		// it's not yet time to send the update.
+		return
+	}
+	wn.lastPeerConnectionsSent = now
+	var peers []*wsPeer
+	peers = wn.peerSnapshot(peers)
+	var connectionDetails telemetryspec.PeersConnectionDetails
+	for _, peer := range peers {
+		connDetail := telemetryspec.PeerConnectionDetails{
+			ConnectionDuration: uint(now.Sub(peer.createTime).Seconds()),
+			HostName:           peer.TelemetryGUID,
+			InstanceName:       peer.InstanceName,
+			Endpoint:           peer.GetAddress(),
+		}
+		if peer.outgoing {
+			connDetail.Address = justHost(peer.conn.RemoteAddr().String())
+			connectionDetails.OutgoingPeers = append(connectionDetails.OutgoingPeers, connDetail)
+		} else {
+			connDetail.Address = peer.OriginAddress()
+			connectionDetails.IncomingPeers = append(connectionDetails.IncomingPeers, connDetail)
+		}
+	}
+
+	wn.log.EventWithDetails(telemetryspec.Network, telemetryspec.PeerConnectionsEvent, connectionDetails)
 }
 
 // prioWeightRefreshTime controls how often we refresh the weights
@@ -1549,7 +1592,7 @@ func (wn *WebsocketNetwork) tryConnect(addr, gossipAddr string) {
 	}
 
 	peer := &wsPeer{wsPeerCore: wsPeerCore{net: wn, rootURL: addr}, conn: conn, outgoing: true, incomingMsgFilter: wn.incomingMsgFilter, createTime: time.Now()}
-	peer.TelemetryGUID = response.Header.Get(TelemetryIDHeader)
+	peer.TelemetryGUID, peer.InstanceName, _ = getCommonHeaders(response.Header)
 	peer.init(wn.config, wn.outgoingMessagesBufferSize)
 	wn.addPeer(peer)
 	localAddr, _ := wn.Address()
@@ -1559,7 +1602,7 @@ func (wn *WebsocketNetwork) tryConnect(addr, gossipAddr string) {
 			Address:      justHost(conn.RemoteAddr().String()),
 			HostName:     peer.TelemetryGUID,
 			Incoming:     false,
-			InstanceName: myInstanceName,
+			InstanceName: peer.InstanceName,
 		})
 
 	peers.Set(float64(wn.NumPeers()), nil)

--- a/test/testdata/configs/config-v5.json
+++ b/test/testdata/configs/config-v5.json
@@ -43,5 +43,6 @@
     "TxSyncIntervalSeconds": 60,
     "TxSyncTimeoutSeconds": 30,
     "TxSyncServeResponseSize": 1000000,
-    "SuggestedFeeSlidingWindowSize":  50
+    "SuggestedFeeSlidingWindowSize":  50,
+    "PeerConnectionsUpdateInterval": 3600
 }


### PR DESCRIPTION
## Add PeerConnections to network telemetry

Periodically, send a list of connected peers to the telemetry server.
That would allow us to construct a graph containing all the interconnections across our relays.

## Example output
```
{
  "_index": "tsachi1-tsachi1-v1",
  "_type": "log",
  "_id": "KwWx2m4BEU4xLqujn8Y5",
  "_version": 1,
  "_score": null,
  "_source": {
    "Host": "719db986-1341-4c14-83a6-45f586916183:R7",
    "@timestamp": "2019-12-06T10:11:43.112896193Z",
    "Message": "/Network/PeerConnections",
    "Data": {
      "details": {
        "IncomingPeers": [
          {
            "Address": "3.14.141.255",
            "HostName": "58322329-eed2-474b-82ad-f0e1376d1c4a:N14",
            "InstanceName": "SoOB6Cu7vdU1c/bB",
            "ConnectionDuration": 18236
          },
          {
            "Address": "3.14.141.255",
            "HostName": "58322329-eed2-474b-82ad-f0e1376d1c4a:N14",
            "InstanceName": "zIdiErWwnik+Wbba",
            "ConnectionDuration": 18236
          },
          {
            "Address": "3.15.29.251",
            "HostName": "b12b4a5a-0f15-49e4-8182-805480c18f20:N9",
            "InstanceName": "UPWMczdRjgtOEOUf",
            "ConnectionDuration": 18235
          },
          {
            "Address": "3.16.159.7",
            "HostName": "e8147b03-f13d-4071-81bf-27dd881eca03",
            "InstanceName": "4OX7hZ+orGbZDQIB",
            "ConnectionDuration": 18235
          },
          {
            "Address": "3.14.141.255",
            "HostName": "58322329-eed2-474b-82ad-f0e1376d1c4a:N14",
            "InstanceName": "iehr9zqMklxjwOMM",
            "ConnectionDuration": 18235
          },
          {
            "Address": "3.16.159.7",
            "HostName": "e8147b03-f13d-4071-81bf-27dd881eca03",
            "InstanceName": "H0mnPsvxH6UCERyx",
            "ConnectionDuration": 18235
          },
          {
            "Address": "3.16.159.7",
            "HostName": "e8147b03-f13d-4071-81bf-27dd881eca03",
            "InstanceName": "PbBQF1wwcWLmwOVI",
            "ConnectionDuration": 18235
          },
          {
            "Address": "13.58.183.246",
            "HostName": "b710a213-7484-40a6-a0a1-5b10bd250aa1:N7",
            "InstanceName": "kKsjiIK+IiDBj+7k",
            "ConnectionDuration": 18200
          },
          {
            "Address": "3.15.29.251",
            "HostName": "b12b4a5a-0f15-49e4-8182-805480c18f20:N9",
            "InstanceName": "YTcdHhSqtyWKU/di",
            "ConnectionDuration": 18235
          },
          {
            "Address": "3.16.30.125",
            "HostName": "87ae5e5b-a111-4e54-8563-ffc6ae1f1bb9",
            "InstanceName": "xUd7iP4UsV/PFrPQ",
            "ConnectionDuration": 18234
          },
          {
            "Address": "3.136.27.88",
            "HostName": "cdfc675e-6db9-49d9-8e96-a814859c1f14:N18",
            "InstanceName": "JBtbzz7RbDjAv67P",
            "ConnectionDuration": 18237
          },
          {
            "Address": "3.16.30.125",
            "HostName": "87ae5e5b-a111-4e54-8563-ffc6ae1f1bb9",
            "InstanceName": "lxO5yj804LNGDzSD",
            "ConnectionDuration": 18234
          },
          {
            "Address": "3.16.30.125",
            "HostName": "87ae5e5b-a111-4e54-8563-ffc6ae1f1bb9",
            "InstanceName": "36qzHZR9YsHitZo2",
            "ConnectionDuration": 18234
          },
          {
            "Address": "3.16.30.125",
            "HostName": "87ae5e5b-a111-4e54-8563-ffc6ae1f1bb9",
            "InstanceName": "AjlYVMwLNqOYDpM3",
            "ConnectionDuration": 18234
          },
          {
            "Address": "18.218.254.150",
            "HostName": "aac62b12-ce78-495b-ba60-fdc8de12eb3a",
            "InstanceName": "ELBTOQoY8K7PuEJ3",
            "ConnectionDuration": 18191
          },
          {
            "Address": "3.16.78.20",
            "HostName": "4946c496-4aa0-47f0-9b81-af29940cf473:N13",
            "InstanceName": "RxkTDCuG0GJeewCv",
            "ConnectionDuration": 18233
          },
          {
            "Address": "3.16.78.20",
            "HostName": "4946c496-4aa0-47f0-9b81-af29940cf473:N13",
            "InstanceName": "4bTID7NoWQr+WQjm",
            "ConnectionDuration": 18232
          },
          {
            "Address": "13.59.46.186",
            "HostName": "75c167cb-9a48-403a-9db8-23ae8e65a9b9:N12",
            "InstanceName": "hL1038rzzpZb8iFr",
            "ConnectionDuration": 18200
          },
          {
            "Address": "13.58.183.246",
            "HostName": "b710a213-7484-40a6-a0a1-5b10bd250aa1:N7",
            "InstanceName": "2gNQN5gE42EyKiMF",
            "ConnectionDuration": 18200
          },
          {
            "Address": "18.223.118.43",
            "HostName": "9313ba4f-1bb0-4943-930a-820cabecb675",
            "InstanceName": "EuYBw3zHrQtIScjd",
            "ConnectionDuration": 18187
          },
          {
            "Address": "13.59.46.186",
            "HostName": "75c167cb-9a48-403a-9db8-23ae8e65a9b9:N12",
            "InstanceName": "XYKkkqcJYWdARS/W",
            "ConnectionDuration": 18200
          },
          {
            "Address": "13.59.46.186",
            "HostName": "75c167cb-9a48-403a-9db8-23ae8e65a9b9:N12",
            "InstanceName": "26ys+txkcvHJJZDF",
            "ConnectionDuration": 18200
          },
          {
            "Address": "13.59.111.51",
            "HostName": "4ff7b8e7-6175-404e-a98d-9e19e452fd7a:N5",
            "InstanceName": "moSK2rJqjuUvDl/Z",
            "ConnectionDuration": 18200
          },
          {
            "Address": "13.58.183.246",
            "HostName": "b710a213-7484-40a6-a0a1-5b10bd250aa1:N7",
            "InstanceName": "FaT8qq6qfHkItnNU",
            "ConnectionDuration": 18199
          },
          {
            "Address": "13.58.183.246",
            "HostName": "b710a213-7484-40a6-a0a1-5b10bd250aa1:N7",
            "InstanceName": "mlAVD4MydK8yitWD",
            "ConnectionDuration": 18199
          },
          {
            "Address": "18.188.34.169",
            "HostName": "4ac5cfb2-388f-4dec-9bea-a02638bae6d3:N3",
            "InstanceName": "QijhhfUF4GiKFvlg",
            "ConnectionDuration": 18199
          },
          {
            "Address": "3.14.141.255",
            "HostName": "58322329-eed2-474b-82ad-f0e1376d1c4a:N14",
            "InstanceName": "/aqvDD8J+WYSw9Z6",
            "ConnectionDuration": 18236
          },
          {
            "Address": "3.14.141.255",
            "HostName": "58322329-eed2-474b-82ad-f0e1376d1c4a:N14",
            "InstanceName": "Xr4QgHmX054+FkHi",
            "ConnectionDuration": 18176
          },
          {
            "Address": "3.15.29.251",
            "HostName": "b12b4a5a-0f15-49e4-8182-805480c18f20:N9",
            "InstanceName": "ZmRrN9bzRHjDYXF+",
            "ConnectionDuration": 18175
          },
          {
            "Address": "18.217.14.17",
            "HostName": "1853e173-8121-4157-b376-6337b6b6e464",
            "InstanceName": "6JJTZwgHUotOpG8B",
            "ConnectionDuration": 18194
          },
          {
            "Address": "18.217.14.17",
            "HostName": "1853e173-8121-4157-b376-6337b6b6e464",
            "InstanceName": "BSiXcBsEghmYcaBE",
            "ConnectionDuration": 18193
          },
          {
            "Address": "18.217.14.17",
            "HostName": "1853e173-8121-4157-b376-6337b6b6e464",
            "InstanceName": "eFUggqiGH9qTtXjo",
            "ConnectionDuration": 18193
          },
          {
            "Address": "18.216.99.68",
            "HostName": "2264342a-be29-488d-b05c-5be14dfaa162",
            "InstanceName": "VL9GPUnSrBoieTJY",
            "ConnectionDuration": 18192
          },
          {
            "Address": "3.17.129.165",
            "HostName": "73b0f2c8-ecf0-4359-9dff-80c2597cfad1:R3",
            "InstanceName": "mtyorSbgFWVpwz1f",
            "ConnectionDuration": 18233
          },
          {
            "Address": "18.218.254.150",
            "HostName": "aac62b12-ce78-495b-ba60-fdc8de12eb3a",
            "InstanceName": "FxguPRHPyVJQwQnC",
            "ConnectionDuration": 18191
          },
          {
            "Address": "18.218.254.150",
            "HostName": "aac62b12-ce78-495b-ba60-fdc8de12eb3a",
            "InstanceName": "gYibHyANDW4tjxXV",
            "ConnectionDuration": 18190
          },
          {
            "Address": "18.218.121.100",
            "HostName": "102a8182-3049-46d6-ab39-bbfb9cfdb37f:R6",
            "InstanceName": "ufDNndG6RwNugYAr",
            "ConnectionDuration": 18190
          },
          {
            "Address": "18.217.246.245",
            "HostName": "59ba939a-7395-440a-bc22-13dd102235f9",
            "InstanceName": "r3UBpi5F1N2kuf1Z",
            "ConnectionDuration": 18190
          },
          {
            "Address": "18.217.246.245",
            "HostName": "59ba939a-7395-440a-bc22-13dd102235f9",
            "InstanceName": "iredYimhg/IfIeyw",
            "ConnectionDuration": 18190
          },
          {
            "Address": "18.218.47.99",
            "HostName": "b855ba22-01cf-4ad7-afc4-b3f8aa60eb40",
            "InstanceName": "nArjQoHoBV7id3qE",
            "ConnectionDuration": 18190
          },
          {
            "Address": "18.217.246.245",
            "HostName": "59ba939a-7395-440a-bc22-13dd102235f9",
            "InstanceName": "/ONiA2uQJ4Xrt6jg",
            "ConnectionDuration": 18190
          },
          {
            "Address": "18.222.146.25",
            "HostName": "945c7377-e4f9-416c-8280-b15a22f61d95",
            "InstanceName": "8KPBf0zwIgY4c/+/",
            "ConnectionDuration": 18187
          },
          {
            "Address": "18.222.146.25",
            "HostName": "945c7377-e4f9-416c-8280-b15a22f61d95",
            "InstanceName": "X8OPOeLan3bJvGd/",
            "ConnectionDuration": 18187
          },
          {
            "Address": "3.136.83.86",
            "HostName": "fe125e20-5e34-4eb5-9d36-f9805a413909",
            "InstanceName": "qibDzYuRMaKVRxEE",
            "ConnectionDuration": 18236
          },
          {
            "Address": "18.222.146.25",
            "HostName": "945c7377-e4f9-416c-8280-b15a22f61d95",
            "InstanceName": "mv1YZtmx4BGpY1fv",
            "ConnectionDuration": 18187
          },
          {
            "Address": "18.223.30.221",
            "HostName": "1c1b8245-fdc8-40f3-97c8-8bdc463209d7:N1",
            "InstanceName": "oy854UrdL5RFtsuJ",
            "ConnectionDuration": 18187
          },
          {
            "Address": "18.223.118.43",
            "HostName": "9313ba4f-1bb0-4943-930a-820cabecb675",
            "InstanceName": "Wvd2cVcdteJtXmlY",
            "ConnectionDuration": 18187
          },
          {
            "Address": "18.223.203.206",
            "HostName": "5242d8d0-1348-43cc-a102-a797acccbdf0:N15",
            "InstanceName": "wn/P2mW/eeTxPGyo",
            "ConnectionDuration": 18187
          },
          {
            "Address": "18.223.30.221",
            "HostName": "1c1b8245-fdc8-40f3-97c8-8bdc463209d7:N1",
            "InstanceName": "1mBgZ02a5HpfoDnr",
            "ConnectionDuration": 18187
          },
          {
            "Address": "18.223.203.206",
            "HostName": "5242d8d0-1348-43cc-a102-a797acccbdf0:N15",
            "InstanceName": "S/dF9/lqdew4VKDl",
            "ConnectionDuration": 18186
          },
          {
            "Address": "18.223.30.221",
            "HostName": "1c1b8245-fdc8-40f3-97c8-8bdc463209d7:N1",
            "InstanceName": "r1rlk27AD+doutBT",
            "ConnectionDuration": 18186
          },
          {
            "Address": "18.223.203.206",
            "HostName": "5242d8d0-1348-43cc-a102-a797acccbdf0:N15",
            "InstanceName": "S1dW9S+hoH04lPpJ",
            "ConnectionDuration": 18186
          },
          {
            "Address": "3.133.120.63",
            "HostName": "531bb09e-6fee-4da4-86b9-1c41e1f84e27:N11",
            "InstanceName": "1l/eitf9R144Hgq+",
            "ConnectionDuration": 18183
          },
          {
            "Address": "3.133.122.8",
            "HostName": "c784ab8e-83c7-4bf6-b958-4d4da3e83839:N16",
            "InstanceName": "1KWSIN9FDrKL9CHb",
            "ConnectionDuration": 18183
          },
          {
            "Address": "3.133.122.8",
            "HostName": "c784ab8e-83c7-4bf6-b958-4d4da3e83839:N16",
            "InstanceName": "oM8zWSNwVkWoWTsx",
            "ConnectionDuration": 18183
          },
          {
            "Address": "3.133.133.121",
            "HostName": "0292072f-8268-4e73-9522-f86733446c7a:N8",
            "InstanceName": "0pbl+uqLJjbhEoF8",
            "ConnectionDuration": 18182
          },
          {
            "Address": "3.133.133.121",
            "HostName": "0292072f-8268-4e73-9522-f86733446c7a:N8",
            "InstanceName": "5UlhC+Fn3rIaA7BQ",
            "ConnectionDuration": 18181
          },
          {
            "Address": "18.188.34.169",
            "HostName": "4ac5cfb2-388f-4dec-9bea-a02638bae6d3:N3",
            "InstanceName": "32oJFXCosDphTmJz",
            "ConnectionDuration": 18198
          },
          {
            "Address": "3.15.29.251",
            "HostName": "b12b4a5a-0f15-49e4-8182-805480c18f20:N9",
            "InstanceName": "u8uR3NUgEP1VAQrH",
            "ConnectionDuration": 18234
          },
          {
            "Address": "18.216.178.164",
            "HostName": "0bc32530-140b-4f8e-a707-b6df90bad311",
            "InstanceName": "HpZMeoprCxHBi+Is",
            "ConnectionDuration": 18194
          },
          {
            "Address": "3.136.158.174",
            "HostName": "bfb48a7c-c43f-4942-b486-f609c2ee7d78",
            "InstanceName": "6Ddc5bLtxdyQCCX8",
            "ConnectionDuration": 18239
          },
          {
            "Address": "18.188.6.227",
            "HostName": "c3d1380f-d56a-4ba3-96c9-9eb5841747ba",
            "InstanceName": "Juee+4l5wJeSvzTN",
            "ConnectionDuration": 18194
          }
        ],
        "OutgoingPeers": [
          {
            "Address": "18.219.182.231",
            "HostName": "6607bdec-1539-4ad7-8d55-9a1e12c36726:R5",
            "InstanceName": "/mF/cRo9y5UnKvhZ",
            "ConnectionDuration": 18239,
            "Endpoint": "r5.tsachi1.algodev.network:4560"
          },
          {
            "Address": "3.136.26.140",
            "HostName": "342dc701-c585-4ffc-b565-bffedaae312d:R1",
            "InstanceName": "YZOA73HRTka8SM0g",
            "ConnectionDuration": 18179,
            "Endpoint": "r1.tsachi1.algodev.network:4560"
          },
          {
            "Address": "18.218.121.100",
            "HostName": "102a8182-3049-46d6-ab39-bbfb9cfdb37f:R6",
            "InstanceName": "ufDNndG6RwNugYAr",
            "ConnectionDuration": 18179,
            "Endpoint": "r6.tsachi1.algodev.network:4560"
          },
          {
            "Address": "3.133.125.51",
            "HostName": "666814f0-6d31-41b8-89a3-d11ce42b078c:R8",
            "InstanceName": "WhqJNOqnmQpeECMs",
            "ConnectionDuration": 18179,
            "Endpoint": "r8.tsachi1.algodev.network:4560"
          }
        ]
      },
      "file": "telemetry.go",
      "function": "github.com/algorand/go-algorand/logging.(*telemetryState).logTelemetry",
      "instanceName": "7/xb5XDAJbadMRee",
      "line": 211,
      "name": ":4560",
      "session": ""
    },
    "Level": "INFO"
  },
  "fields": {
    "@timestamp": [
      "2019-12-06T10:11:43.112Z"
    ]
  },
  "highlight": {
    "Message": [
      "/@kibana-highlighted-field@Network@/kibana-highlighted-field@/PeerConnections"
    ]
  },
  "sort": [
    1575627103112
  ]
}
```