### PR TITLE
Eliminate docker image warning

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -747,6 +747,10 @@ type Local struct {
 
 	// EnableRequestLogger enabled the logging of the incoming requests to the telemetry server.
 	EnableRequestLogger bool
+
+	// PeerConnectionsUpdateInterval defines the interval at which the peer connections information is being sent to the
+	// telemetry ( when enabled ). Defined in seconds.
+	PeerConnectionsUpdateInterval int
 }
 
 // Filenames of config files within the configdir (e.g. ~/.algorand)

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -87,6 +87,7 @@ var defaultLocalV5 = Local{
 	TxSyncIntervalSeconds:                 60,
 	TxSyncTimeoutSeconds:                  30,
 	TxSyncServeResponseSize:               1000000,
+	PeerConnectionsUpdateInterval:         3600,
 	// DO NOT MODIFY VALUES - New values may be added carefully - See WARNING at top of file
 }
 
@@ -138,6 +139,7 @@ var defaultLocalV4 = Local{
 	TxSyncIntervalSeconds:                 60,
 	TxSyncTimeoutSeconds:                  30,
 	TxSyncServeResponseSize:               1000000,
+
 	// DO NOT MODIFY VALUES - New values may be added carefully - See WARNING at top of file
 }
 
@@ -347,7 +349,10 @@ func migrate(cfg Local) (newCfg Local, err error) {
 		if newCfg.CatchupParallelBlocks == defaultLocalV4.CatchupParallelBlocks {
 			newCfg.CatchupParallelBlocks = defaultLocalV5.CatchupParallelBlocks
 		}
-		
+		if newCfg.PeerConnectionsUpdateInterval == defaultLocalV4.PeerConnectionsUpdateInterval {
+			newCfg.PeerConnectionsUpdateInterval = defaultLocalV5.PeerConnectionsUpdateInterval
+		}
+
 		newCfg.Version = 5
 	}
 

--- a/docker/releases/Dockerfile-stable
+++ b/docker/releases/Dockerfile-stable
@@ -1,7 +1,7 @@
 FROM ubuntu
 
 WORKDIR /root/install
-RUN apt update && apt install -y ca-certificates curl --no-install-recommends && \
+RUN apt-get update && apt-get install -y ca-certificates curl --no-install-recommends && \
     curl --silent -L https://github.com/algorand/go-algorand-doc/blob/master/downloads/installers/linux_amd64/install_master_linux-amd64.tar.gz?raw=true -o installer.tar.gz && \
     tar -xf installer.tar.gz && \
     ./update.sh -c stable -n -p ~/node -d ~/node/data -i && \

--- a/docker/releases/Dockerfile-stable-testnet
+++ b/docker/releases/Dockerfile-stable-testnet
@@ -1,7 +1,7 @@
 FROM ubuntu
 
 WORKDIR /root/install
-RUN apt update && apt install -y ca-certificates curl --no-install-recommends && \
+RUN apt-get update && apt-get install -y ca-certificates curl --no-install-recommends && \
     curl --silent -L https://github.com/algorand/go-algorand-doc/blob/master/downloads/installers/linux_amd64/install_master_linux-amd64.tar.gz?raw=true -o installer.tar.gz && \
     tar -xf installer.tar.gz && \
     ./update.sh -c stable -n -p ~/node -d ~/node/data -i -g testnet && \

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -44,5 +44,6 @@
     "TxPoolSize": 15000,
     "TxSyncIntervalSeconds": 60,
     "TxSyncServeResponseSize": 1000000,
-    "TxSyncTimeoutSeconds": 30
+    "TxSyncTimeoutSeconds": 30,
+    "PeerConnectionsUpdateInterval": 3600
 }

--- a/logging/telemetryspec/event.go
+++ b/logging/telemetryspec/event.go
@@ -253,3 +253,26 @@ type HTTPRequestDetails struct {
 	BodyLength   uint64 // The returned body length, in bytes
 	UserAgent    string // The user-agent string ( if any )
 }
+
+// PeerConnectionsEvent event
+const PeerConnectionsEvent Event = "PeerConnections"
+
+// PeersConnectionDetails contains details for PeerConnectionsEvent
+type PeersConnectionDetails struct {
+	IncomingPeers []PeerConnectionDetails
+	OutgoingPeers []PeerConnectionDetails
+}
+
+// PeerConnectionDetails contains details for PeerConnectionsEvent regarding a single peer ( either incoming or outgoing )
+type PeerConnectionDetails struct {
+	// Address is the IP address of the remote connected socket
+	Address string
+	// The HostName is the TelemetryGUID passed via the X-Algorand-TelId header during the http connection handshake.
+	HostName string
+	// InstanceName is the node-specific hashed instance name that was passed via X-Algorand-InstanceName header during the http connection handshake.
+	InstanceName string
+	// ConnectionDuration is the duration of the connection, in seconds.
+	ConnectionDuration uint
+	// Endpoint is the dialed-to address, for an outgoing connection. Not being used for incoming connection.
+	Endpoint string `json:",omitempty"`
+}

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1282,10 +1282,10 @@ func (wn *WebsocketNetwork) sendPeerConnectionsTelemetryStatus() {
 			ConnectionDuration: uint(now.Sub(peer.createTime).Seconds()),
 			HostName:           peer.TelemetryGUID,
 			InstanceName:       peer.InstanceName,
-			Endpoint:           peer.GetAddress(),
 		}
 		if peer.outgoing {
 			connDetail.Address = justHost(peer.conn.RemoteAddr().String())
+			connDetail.Endpoint = peer.GetAddress()
 			connectionDetails.OutgoingPeers = append(connectionDetails.OutgoingPeers, connDetail)
 		} else {
 			connDetail.Address = peer.OriginAddress()

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -317,6 +317,9 @@ type WebsocketNetwork struct {
 
 	requestsTracker *RequestTracker
 	requestsLogger  *RequestLogger
+
+	// lastPeerConnectionsSent is the last time the peer connections were sent ( or attempted to be sent ) to the telemetry server.
+	lastPeerConnectionsSent time.Time
 }
 
 type broadcastRequest struct {
@@ -516,6 +519,7 @@ func (wn *WebsocketNetwork) setup() {
 	wn.upgrader.ReadBufferSize = 4096
 	wn.upgrader.WriteBufferSize = 4096
 	wn.upgrader.EnableCompression = false
+	wn.lastPeerConnectionsSent = time.Now()
 	wn.router = mux.NewRouter()
 	wn.router.Handle(GossipNetworkPath, wn)
 	wn.requestsTracker = makeRequestsTracker(wn.router, wn.log, wn.config)
@@ -728,8 +732,10 @@ func (wn *WebsocketNetwork) ClearHandlers() {
 }
 
 func (wn *WebsocketNetwork) setHeaders(header http.Header) {
-	myTelemetryGUID := wn.log.GetTelemetryHostName()
-	header.Set(TelemetryIDHeader, myTelemetryGUID)
+	localTelemetryGUID := wn.log.GetTelemetryHostName()
+	localInstanceName := wn.log.GetInstanceName()
+	header.Set(TelemetryIDHeader, localTelemetryGUID)
+	header.Set(InstanceNameHeader, localInstanceName)
 	header.Set(ProtocolVersionHeader, ProtocolVersion)
 	header.Set(AddressHeader, wn.PublicAddress())
 	header.Set(NodeRandomHeader, wn.RandomID)
@@ -1250,7 +1256,44 @@ func (wn *WebsocketNetwork) meshThread() {
 		if request.done != nil {
 			close(request.done)
 		}
+
+		// send the currently connected peers information to the
+		// telemetry server; that would allow the telemetry server
+		// to construct a cross-node map of all the nodes interconnections.
+		wn.sendPeerConnectionsTelemetryStatus()
 	}
+}
+
+// sendPeerConnectionsTelemetryStatus sends a snapshot of the currently connected peers
+// to the telemetry server. Internally, it's using a timer to ensure that it would only
+// send the information once every hour ( configurable via PeerConnectionsUpdateInterval )
+func (wn *WebsocketNetwork) sendPeerConnectionsTelemetryStatus() {
+	now := time.Now()
+	if wn.lastPeerConnectionsSent.Add(time.Duration(wn.config.PeerConnectionsUpdateInterval)*time.Second).After(now) || wn.config.PeerConnectionsUpdateInterval <= 0 {
+		// it's not yet time to send the update.
+		return
+	}
+	wn.lastPeerConnectionsSent = now
+	var peers []*wsPeer
+	peers = wn.peerSnapshot(peers)
+	var connectionDetails telemetryspec.PeersConnectionDetails
+	for _, peer := range peers {
+		connDetail := telemetryspec.PeerConnectionDetails{
+			ConnectionDuration: uint(now.Sub(peer.createTime).Seconds()),
+			HostName:           peer.TelemetryGUID,
+			InstanceName:       peer.InstanceName,
+			Endpoint:           peer.GetAddress(),
+		}
+		if peer.outgoing {
+			connDetail.Address = justHost(peer.conn.RemoteAddr().String())
+			connectionDetails.OutgoingPeers = append(connectionDetails.OutgoingPeers, connDetail)
+		} else {
+			connDetail.Address = peer.OriginAddress()
+			connectionDetails.IncomingPeers = append(connectionDetails.IncomingPeers, connDetail)
+		}
+	}
+
+	wn.log.EventWithDetails(telemetryspec.Network, telemetryspec.PeerConnectionsEvent, connectionDetails)
 }
 
 // prioWeightRefreshTime controls how often we refresh the weights
@@ -1549,7 +1592,7 @@ func (wn *WebsocketNetwork) tryConnect(addr, gossipAddr string) {
 	}
 
 	peer := &wsPeer{wsPeerCore: wsPeerCore{net: wn, rootURL: addr}, conn: conn, outgoing: true, incomingMsgFilter: wn.incomingMsgFilter, createTime: time.Now()}
-	peer.TelemetryGUID = response.Header.Get(TelemetryIDHeader)
+	peer.TelemetryGUID, peer.InstanceName, _ = getCommonHeaders(response.Header)
 	peer.init(wn.config, wn.outgoingMessagesBufferSize)
 	wn.addPeer(peer)
 	localAddr, _ := wn.Address()
@@ -1559,7 +1602,7 @@ func (wn *WebsocketNetwork) tryConnect(addr, gossipAddr string) {
 			Address:      justHost(conn.RemoteAddr().String()),
 			HostName:     peer.TelemetryGUID,
 			Incoming:     false,
-			InstanceName: myInstanceName,
+			InstanceName: peer.InstanceName,
 		})
 
 	peers.Set(float64(wn.NumPeers()), nil)

--- a/test/testdata/configs/config-v5.json
+++ b/test/testdata/configs/config-v5.json
@@ -43,5 +43,6 @@
     "TxSyncIntervalSeconds": 60,
     "TxSyncTimeoutSeconds": 30,
     "TxSyncServeResponseSize": 1000000,
-    "SuggestedFeeSlidingWindowSize":  50
+    "SuggestedFeeSlidingWindowSize":  50,
+    "PeerConnectionsUpdateInterval": 3600
 }


### PR DESCRIPTION
## Eliminate docker image warning

Replace `apt` with `apt-get` in order to get rid of build warning message.