### PR TITLE
Eliminate docker image warning

### DIFF
--- a/docker/releases/Dockerfile-stable
+++ b/docker/releases/Dockerfile-stable
@@ -1,7 +1,7 @@
 FROM ubuntu
 
 WORKDIR /root/install
-RUN apt update && apt install -y ca-certificates curl --no-install-recommends && \
+RUN apt-get update && apt-get install -y ca-certificates curl --no-install-recommends && \
     curl --silent -L https://github.com/algorand/go-algorand-doc/blob/master/downloads/installers/linux_amd64/install_master_linux-amd64.tar.gz?raw=true -o installer.tar.gz && \
     tar -xf installer.tar.gz && \
     ./update.sh -c stable -n -p ~/node -d ~/node/data -i && \

--- a/docker/releases/Dockerfile-stable-testnet
+++ b/docker/releases/Dockerfile-stable-testnet
@@ -1,7 +1,7 @@
 FROM ubuntu
 
 WORKDIR /root/install
-RUN apt update && apt install -y ca-certificates curl --no-install-recommends && \
+RUN apt-get update && apt-get install -y ca-certificates curl --no-install-recommends && \
     curl --silent -L https://github.com/algorand/go-algorand-doc/blob/master/downloads/installers/linux_amd64/install_master_linux-amd64.tar.gz?raw=true -o installer.tar.gz && \
     tar -xf installer.tar.gz && \
     ./update.sh -c stable -n -p ~/node -d ~/node/data -i -g testnet && \


### PR DESCRIPTION
## Eliminate docker image warning

Replace `apt` with `apt-get` in order to get rid of build warning message.