### PR TITLE
TEAL: allow bnz to the end of program

### DIFF
--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -248,6 +248,18 @@ bnz nowhere`
 	require.Nil(t, program)
 }
 
+func TestAssembleJumpToTheEnd(t *testing.T) {
+	text := `intcblock 1
+intc 0
+intc 0
+bnz done
+done:`
+	program, err := AssembleString(text)
+	require.NoError(t, err)
+	require.Equal(t, 9, len(program))
+	require.Equal(t, []byte("\x01\x20\x01\x01\x22\x22\x40\x00\x00"), program)
+}
+
 func TestAssembleDisassemble(t *testing.T) {
 	// Specifically constructed program text that should be recreated by Disassemble()
 	// TODO: disassemble to int/byte psuedo-ops instead of raw intcblock/bytecblock/intc/bytec

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -940,7 +940,7 @@ func checkBnz(cx *evalContext) int {
 	}
 	cx.nextpc = cx.pc + 3
 	target := cx.nextpc + int(offset)
-	if target >= len(cx.program) {
+	if target > len(cx.program) {
 		cx.err = errors.New("bnz target beyond end of program")
 		return 1
 	}

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -1600,6 +1600,23 @@ done:`)
 	isNotPanic(t, err)
 }
 
+func TestShortProgramTrue(t *testing.T) {
+	t.Parallel()
+	program, err := AssembleString(`intcblock 1
+intc 0
+intc 0
+bnz done
+done:`)
+	require.NoError(t, err)
+	cost, err := Check(program, defaultEvalParams(nil, nil))
+	require.NoError(t, err)
+	require.True(t, cost < 1000)
+	sb := strings.Builder{}
+	pass, err := Eval(program, defaultEvalParams(&sb, nil))
+	require.NoError(t, err)
+	require.True(t, pass)
+}
+
 func TestShortBytecblock(t *testing.T) {
 	t.Parallel()
 	fullprogram, err := AssembleString(`bytecblock 0x123456 0xababcdcd`)


### PR DESCRIPTION
## Summary

* The following TEAL code is valid now:
int 1
int 1
bnz done
done:

* This allows jumping to the end similar to 'return 1' statement
in high level languages

## Test Plan

Assembler and Eval tests added.
