### PR TITLE
Created `test_release.sh` to test centos|fedora|ubuntu images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ stages:
     if: branch =~ /^rel\// AND type != pull_request
   - name: deploy
     if: branch =~ /^rel\// AND type != pull_request
+  - name: post_deploy
+    if: branch =~ /^rel\// AND type != pull_request
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -141,6 +141,11 @@ jobs:
       script:
         - scripts/travis/external_build.sh ./scripts/travis/deploy_packages.sh
 
+    - stage: post_deploy
+      os: linux
+      script:
+        - test/packages/test_release.sh
+
 # Don't rebuild libsodium every time
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ jobs:
     - name: External ARM64 Integration Test
     - name: External ARM Build
     - name: External ARM Deploy
+    - name: Test Release Builds
   include:
     - stage: build_commit
       os: linux
@@ -143,8 +144,13 @@ jobs:
 
     - stage: post_deploy
       os: linux
+      name: Test Release Builds
       script:
-        - test/packages/test_release.sh
+        - scripts/travis/test_release.sh
+      addons:
+        apt:
+          packages:
+            - awscli
 
 # Don't rebuild libsodium every time
 cache:

--- a/scripts/test_release.sh
+++ b/scripts/test_release.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+OS_LIST=(
+    centos:7
+    centos:8
+    fedora:28
+    ubuntu:16.04
+    ubuntu:18.04
+)
+
+FAILED=()
+RET_VALUE=0
+
+# We'll use this simple tokenized Dockerfile.
+# https://serverfault.com/a/72511
+IFS='' read -r -d '' TOKENIZED <<"EOF"
+FROM {{OS}}
+
+ENV DEBIAN_FRONTEND noninteractive
+{{PACMAN}}
+ADD https://algorand-releases.s3.us-east-1.amazonaws.com/channel/stable/install_stable_linux-amd64_2.0.1.tar.gz /tmp
+
+RUN \
+  set -eux; \
+  mkdir /opt/installer ; \
+  cd /opt/installer ; \
+  tar xvf /tmp/install*tar.gz ; \
+  ./update.sh -i -c stable -p /opt/algorand/node -d /opt/algorand/node/data -n ;
+
+WORKDIR /opt/algorand/node
+RUN ["./goal", "node", "start", "-d", "data"]
+EOF
+
+for item in ${OS_LIST[*]}
+do
+    # Install root certs.
+    # We use pattern substitution here (like sed).
+    # ${parameter/pattern/substitution}
+    if [[ $item =~ ubuntu ]]
+    then
+        WITH_PACMAN=$(echo -e "${TOKENIZED//\{\{PACMAN\}\}/RUN apt update && apt install -y ca-certificates}")
+    else
+        # CentOS/Fedora must have the updated root certs already installed.
+        WITH_PACMAN=$(echo -e "${TOKENIZED//\{\{PACMAN\}\}/}")
+    fi
+
+    # Finally, designate the OS and send the fully-formed Dockerfile to Docker.
+    echo -e "${WITH_PACMAN/\{\{OS\}\}/$item}" | docker build -t "$item" -
+
+    if ! docker run -it "$item" /bin/bash -c "/opt/algorand/node/algod -v"
+    then
+        RET_VALUE=1
+        FAILED+=("$item")
+    fi
+done
+
+if [ "${#FAILED[@]}" -gt 0 ]
+then
+    echo -e "\n$(tput setaf 1)[$0]$(tput sgr0) The following images have problems:"
+    for failed in ${FAILED[*]}
+    do
+        echo " - $failed"
+    done
+    echo
+fi
+
+exit $RET_VALUE
+

--- a/scripts/travis/test_release.sh
+++ b/scripts/travis/test_release.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# We need to chdir to where the Dockerfile resides so the Docker context is properly set.
+# Otherwise, Docker will look for the file to copied in `/var/lib/docker/tmp`, i.e.,
+#
+#       COPY install.sh .
+#
+
+pushd test/packages
+./test_release.sh
+popd
+

--- a/test/packages/install.sh
+++ b/test/packages/install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# This is currently used by `test_release.sh`.
+# It is copied into a docker image at build time
+# and then invoked at run time.
+
+while [ "$1" != "" ]; do
+    case "$1" in
+        -b)
+            shift
+            BUCKET="$1"
+            ;;
+        -c)
+            shift
+            CHANNEL="$1"
+            ;;
+        *)
+            echo "Unknown option" "$1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+curl --silent -L https://github.com/algorand/go-algorand-doc/blob/master/downloads/installers/linux_amd64/install_master_linux-amd64.tar.gz?raw=true | tar xzf -
+
+./update.sh -b "$BUCKET" -c "$CHANNEL" -i -p ~/node -d ~/node/data -n
+./node/algod -v
+

--- a/test/packages/install.sh
+++ b/test/packages/install.sh
@@ -25,5 +25,7 @@ done
 curl --silent -L https://github.com/algorand/go-algorand-doc/blob/master/downloads/installers/linux_amd64/install_master_linux-amd64.tar.gz?raw=true | tar xzf -
 
 ./update.sh -b "$BUCKET" -c "$CHANNEL" -i -p ~/node -d ~/node/data -n
+
+echo "[$0] Testing: algod -v"
 ./node/algod -v
 

--- a/test/packages/test_release.sh
+++ b/test/packages/test_release.sh
@@ -73,15 +73,16 @@ EOF
             WITH_PACMAN=$(echo -e "${TOKENIZED//\{\{PACMAN\}\}/RUN yum install -y curl}")
         fi
 
-        # Finally, designate the OS and send the fully-formed Dockerfile to Docker.
         echo -e "$BLUE_FG[$0]$END_FG_COLOR Testing $item..."
 
-        # Note that we need to create a Dockerfile so the Docker context is properly set.
-        # Without this context, Docker will try to copy from /var/lib/docker/tmp and seems
-        # to do so because the Dockerfile is automatically generated.
+        # Note that we now create a Dockerfile so the Docker context is properly set.
+        # Without this context, Docker tried to COPY from /var/lib/docker/tmp and seemed
+        # to do so because the Dockerfile was being automatically generated, i.e.,
         #
-        # To get around this, we write the generated Dockerfile to disk, overwriting it with
-        # each subsequent iteration.
+        #       echo -e "..." | docker build -t foo -
+        #
+        # To avoid this, we now redirect the generated Dockerfile to disk, overwriting it
+        # with each subsequent iteration (and cleaning it up upon exit).
         #
         # Since we eventually want to move to storing the Dockerfiles, this seems like an
         # acceptable tradeoff.

--- a/test/packages/test_release.sh
+++ b/test/packages/test_release.sh
@@ -4,12 +4,12 @@ BLUE_FG=$(tput setaf 4)
 GREEN_FG=$(tput setaf 2)
 RED_FG=$(tput setaf 1)
 TEAL_FG=$(tput setaf 6)
-END_COLOR=$(tput sgr0)
+END_FG_COLOR=$(tput sgr0)
 
 if [[ ! "$AWS_ACCESS_KEY_ID" || ! "$AWS_SECRET_ACCESS_KEY" ]]
 then
-    echo -e "$RED_FG[$0]$END_COLOR Missing AWS credentials." \
-        "\nExport $GREEN_FG\$AWS_ACCESS_KEY_ID$END_COLOR and $GREEN_FG\$AWS_SECRET_ACCESS_KEY$END_COLOR before running this script." \
+    echo -e "$RED_FG[$0]$END_FG_COLOR Missing AWS credentials." \
+        "\nExport $GREEN_FG\$AWS_ACCESS_KEY_ID$END_FG_COLOR and $GREEN_FG\$AWS_SECRET_ACCESS_KEY$END_FG_COLOR before running this script." \
         "\nSee https://aws.amazon.com/blogs/security/wheres-my-secret-access-key/ to obtain creds."
     exit 1
 fi
@@ -51,19 +51,17 @@ build_images () {
     # https://serverfault.com/a/72511
     IFS='' read -r -d '' TOKENIZED <<EOF
     FROM {{OS}}
-    WORKDIR /root/install
+
+    ENV AWS_ACCESS_KEY_ID=""
+    ENV AWS_SECRET_ACCESS_KEY=""
+
     {{PACMAN}}
 
-    ENV AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-    ENV AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+    WORKDIR ~
 
-    RUN curl --silent -L https://github.com/algorand/go-algorand-doc/blob/master/downloads/installers/linux_amd64/install_master_linux-amd64.tar.gz?raw=true | tar xzf - && \
-        ./update.sh -b $BUCKET -c $CHANNEL -n -p ~/node -d ~/node/data -i && \
-        cd .. && \
-        rm -rf install /var/lib/apt/lists/*
+    RUN curl --silent -L https://github.com/algorand/go-algorand-doc/blob/master/downloads/installers/linux_amd64/install_master_linux-amd64.tar.gz?raw=true | tar xzf -
 
-    WORKDIR /root/node
-    CMD ["/bin/bash"]
+    ENTRYPOINT ["./update.sh", "-n", "-p", "~/node", "-d", "~/node/data", "-i"]
 EOF
 
     for item in ${OS_LIST[*]}
@@ -73,14 +71,13 @@ EOF
         # ${parameter/pattern/substitution}
         if [[ $item =~ ubuntu ]]
         then
-            WITH_PACMAN=$(echo -e "${TOKENIZED//\{\{PACMAN\}\}/RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y curl ca-certificates --no-install-recommends}")
+            WITH_PACMAN=$(echo -e "${TOKENIZED//\{\{PACMAN\}\}/RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y curl}")
         else
-            # CentOS/Fedora must have the updated root certs already installed.
             WITH_PACMAN=$(echo -e "${TOKENIZED//\{\{PACMAN\}\}/RUN yum install -y curl}")
         fi
 
         # Finally, designate the OS and send the fully-formed Dockerfile to Docker.
-        echo -e "$BLUE_FG[$0]$END_COLOR Testing $item..."
+        echo -e "$BLUE_FG[$0]$END_FG_COLOR Testing $item..."
         if ! echo -e "${WITH_PACMAN/\{\{OS\}\}/$item}" | docker build -t "${item}-test" -
         then
             FAILED+=("$item")
@@ -91,8 +88,8 @@ EOF
 run_images () {
     for item in ${OS_LIST[*]}
     do
-        echo "$TEAL_FG[$0]$END_COLOR Running ${item}-test..."
-        if ! docker run -t "${item}-test" ./algod -v
+        echo "$TEAL_FG[$0]$END_FG_COLOR Running ${item}-test..."
+        if ! docker run --rm --name algorand -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" -t "${item}-test" -b "$BUCKET" -c "$CHANNEL"
         then
             FAILED+=("$item")
         fi
@@ -102,7 +99,7 @@ run_images () {
 check_failures() {
     if [ "${#FAILED[@]}" -gt 0 ]
     then
-        echo -e "\n$RED_FG[$0]$END_COLOR The following images could not be $1:"
+        echo -e "\n$RED_FG[$0]$END_FG_COLOR The following images could not be $1:"
 
         for failed in ${FAILED[*]}
         do
@@ -116,10 +113,11 @@ check_failures() {
 
 build_images
 check_failures built
+echo "$GREEN_FG[$0]$END_FG_COLOR Builds completed with no failures."
 
 run_images
 check_failures run
+echo "$GREEN_FG[$0]$END_FG_COLOR Runs completed with no failures."
 
-echo "$GREEN_FG[$0]$END_COLOR Tests completed with no failures."
 exit 0
 

--- a/test/packages/test_release.sh
+++ b/test/packages/test_release.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 
+BLUE_FG=$(tput setaf 4)
+GREEN_FG=$(tput setaf 2)
+RED_FG=$(tput setaf 1)
+END_COLOR=$(tput sgr0)
+
 if [[ ! "$AWS_ACCESS_KEY_ID" || ! "$AWS_SECRET_ACCESS_KEY" ]]
 then
-    echo -e "$(tput setaf 1)[$0]$(tput sgr0) Missing AWS credentials."
-    echo "Export $(tput setaf 2)\$AWS_ACCESS_KEY_ID$(tput sgr0) and $(tput setaf 2)\$AWS_SECRET_ACCESS_KEY$(tput sgr0) before running this script."
-    echo "See https://aws.amazon.com/blogs/security/wheres-my-secret-access-key/ to obtain creds."
+    echo -e "$RED_FG[$0]$END_COLOR Missing AWS credentials." \
+        "\nExport $GREEN_FG\$AWS_ACCESS_KEY_ID$END_COLOR and $GREEN_FG\$AWS_SECRET_ACCESS_KEY$END_COLOR before running this script." \
+        "\nSee https://aws.amazon.com/blogs/security/wheres-my-secret-access-key/ to obtain creds."
     exit 1
 fi
 
@@ -74,7 +79,7 @@ do
     fi
 
     # Finally, designate the OS and send the fully-formed Dockerfile to Docker.
-    echo -e "$(tput setaf 4)[$0]$(tput sgr0) Testing $item..."
+    echo -e "$BLUE_FG[$0]$END_COLOR Testing $item..."
     if ! echo -e "${WITH_PACMAN/\{\{OS\}\}/$item}" | docker build -t "$item" -
     then
         RET_VALUE=1
@@ -84,7 +89,7 @@ done
 
 if [ "${#FAILED[@]}" -gt 0 ]
 then
-    echo -e "\n$(tput setaf 1)[$0]$(tput sgr0) The following images have problems:"
+    echo -e "\n$RED_FG[$0]$END_COLOR The following images have problems:"
     for failed in ${FAILED[*]}
     do
         echo " - $failed"


### PR DESCRIPTION
For each supported OS, this script will download the installer and install algorand in a Docker image.  It will then run `algod -v` for a sanity test.  Any image that fails will be listed to `stdout` and a return value of 1 will be returned.

The supported OS are:
    centos:7
    centos:8
    fedora:28
    ubuntu:16.04
    ubuntu:18.04

This also passes the `shellcheck` linter.