### PR TITLE
Make raw block msgpack bytes available to local API

### DIFF
--- a/daemon/algod/api/server/v1/handlers/errors.go
+++ b/daemon/algod/api/server/v1/handlers/errors.go
@@ -24,6 +24,7 @@ var (
 	errFailedRetrievingNodeStatus          = "failed retrieving node status"
 	errFailedRetrievingAsset               = "failed to retrieve asset information"
 	errFailedParsingRoundNumber            = "failed to parse the round number"
+	errFailedParsingRawOption              = "failed to parse the raw option"
 	errFailedParsingMaxAssetsToList        = "failed to parse max assets, must be between %d and %d"
 	errFailedParsingAssetIdx               = "failed to parse asset index"
 	errFailedToGetAssetCreator             = "failed to retrieve asset creator from the ledger"

--- a/daemon/algod/api/server/v1/handlers/handlers.go
+++ b/daemon/algod/api/server/v1/handlers/handlers.go
@@ -39,6 +39,7 @@ import (
 	"github.com/algorand/go-algorand/ledger"
 	"github.com/algorand/go-algorand/node"
 	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/rpcs"
 )
 
 func nodeStatus(node *node.AlgorandFullNode) (res v1.NodeStatus, err error) {
@@ -1179,6 +1180,12 @@ func GetBlock(ctx lib.ReqContext, w http.ResponseWriter, r *http.Request) {
 	//         minimum: 0
 	//         required: true
 	//         description: The round from which to fetch block information.
+	//       - name: raw
+	//         in: query
+	//         type: integer
+	//         format: int64
+	//         required: false
+	//         description: Return raw msgpack block bytes
 	//     Responses:
 	//       200:
 	//         "$ref": '#/responses/BlockResponse'
@@ -1196,6 +1203,33 @@ func GetBlock(ctx lib.ReqContext, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// raw msgpack option:
+	rawstr := r.FormValue("raw")
+	if rawstr != "" {
+		rawint, err := strconv.ParseUint(rawstr, 10, 64)
+		if err != nil {
+			lib.ErrorResponse(w, http.StatusBadRequest, err, errFailedParsingRawOption, ctx.Log)
+			return
+		}
+		if rawint != 0 {
+			blockbytes, err := rpcs.RawBlockBytes(ctx.Node.Ledger(), basics.Round(queryRound))
+			if err != nil {
+				lib.ErrorResponse(w, http.StatusInternalServerError, err, errFailedLookingUpLedger, ctx.Log)
+				return
+			}
+			w.Header().Set("Content-Type", rpcs.LedgerResponseContentType)
+			w.Header().Set("Content-Length", strconv.Itoa(len(blockbytes)))
+			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(blockbytes)
+			if err != nil {
+				ctx.Log.Warnf("algod failed to write an object to the response stream: %v", err)
+			}
+			return
+		}
+	}
+
+	// decoded json-reencoded default:
 	ledger := ctx.Node.Ledger()
 	b, c, err := ledger.BlockCert(basics.Round(queryRound))
 	if err != nil {

--- a/rpcs/httpFetcher.go
+++ b/rpcs/httpFetcher.go
@@ -104,7 +104,7 @@ func (hf *HTTPFetcher) GetBlockBytes(ctx context.Context, r basics.Round) (data 
 	// TODO: Temporarily allow old and new content types so we have time for lazy upgrades
 	// Remove this 'old' string after next release.
 	const ledgerResponseContentTypeOld = "application/algorand-block-v1"
-	if contentTypes[0] != ledgerResponseContentType && contentTypes[0] != ledgerResponseContentTypeOld {
+	if contentTypes[0] != LedgerResponseContentType && contentTypes[0] != ledgerResponseContentTypeOld {
 		hf.log.Warnf("http block fetcher response has an invalid content type : %s", contentTypes[0])
 		response.Body.Close()
 		return nil, fmt.Errorf("http block fetcher invalid content type '%s'", contentTypes[0])


### PR DESCRIPTION
To endpoint `/v1/block/{N}` add `?raw=1` to return msgpack bytes with full data.
Uses the same payload preparation as catchup block fetching code.

TODO: maybe should add an end-to-end test to fetch a block from both catchup endpoint and local API endpoint and check that they're the same bytes.