### PR TITLE
Add `export SHELLOPTS` to teal tests.

### DIFF
--- a/test/scripts/e2e_subs/dynamic-fee-teal-test.sh
+++ b/test/scripts/e2e_subs/dynamic-fee-teal-test.sh
@@ -5,6 +5,7 @@ date '+dynamic-fee-teal-test start %Y%m%d_%H%M%S'
 set -e
 set -x
 set -o pipefail
+export SHELLOPTS
 
 WALLET=$1
 

--- a/test/scripts/e2e_subs/e2e_teal.sh
+++ b/test/scripts/e2e_subs/e2e_teal.sh
@@ -5,6 +5,7 @@ date '+e2e_teal start %Y%m%d_%H%M%S'
 set -e
 set -x
 set -o pipefail
+export SHELLOPTS
 
 WALLET=$1
 

--- a/test/scripts/e2e_subs/htlc-teal-test.sh
+++ b/test/scripts/e2e_subs/htlc-teal-test.sh
@@ -5,6 +5,7 @@ date '+htlc-teal-test start %Y%m%d_%H%M%S'
 set -e
 set -x
 set -o pipefail
+export SHELLOPTS
 
 WALLET=$1
 

--- a/test/scripts/e2e_subs/keyreg-teal-test.sh
+++ b/test/scripts/e2e_subs/keyreg-teal-test.sh
@@ -5,6 +5,7 @@ date '+keyreg-teal-test start %Y%m%d_%H%M%S'
 set -e
 set -x
 set -o pipefail
+export SHELLOPTS
 
 WALLET=$1
 

--- a/test/scripts/e2e_subs/limit-swap-test.sh
+++ b/test/scripts/e2e_subs/limit-swap-test.sh
@@ -4,6 +4,8 @@ date '+limit-swap-test start %Y%m%d_%H%M%S'
 
 set -e
 set -x
+set -o pipefail
+export SHELLOPTS
 
 WALLET=$1
 

--- a/test/scripts/e2e_subs/periodic-teal-test.sh
+++ b/test/scripts/e2e_subs/periodic-teal-test.sh
@@ -5,6 +5,7 @@ date '+periodic-teal-test start %Y%m%d_%H%M%S'
 set -e
 set -x
 set -o pipefail
+export SHELLOPTS
 
 WALLET=$1
 

--- a/test/scripts/e2e_subs/teal-split-test.sh
+++ b/test/scripts/e2e_subs/teal-split-test.sh
@@ -5,6 +5,7 @@ date '+teal-split-test start %Y%m%d_%H%M%S'
 set -e
 set -x
 set -o pipefail
+export SHELLOPTS
 
 WALLET=$1
 


### PR DESCRIPTION
## Summary

The TEAL e2e tests were not exporting the SHELLOPTS.
An error generated by a subshell would be not respecting the specified shell options.
This would, naturally, fix nothing other than early exit from a failing test.