### PR TITLE
Cleanup evalAux

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -162,12 +162,9 @@ func (au *accountUpdates) loadFromDisk(l ledgerForTracker) error {
 		next := loaded + 1
 
 		blk, err := l.Block(next)
-		/*
-			blk, aux, err := l.blockAux(next)
-			if err != nil {
-				return err
-			}
-		*/
+		if err != nil {
+			return err
+		}
 
 		delta, err := l.trackerEvalVerified(blk)
 		if err != nil {

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -161,12 +161,15 @@ func (au *accountUpdates) loadFromDisk(l ledgerForTracker) error {
 	for loaded < latest {
 		next := loaded + 1
 
-		blk, aux, err := l.blockAux(next)
-		if err != nil {
-			return err
-		}
+		blk, err := l.Block(next)
+		/*
+			blk, aux, err := l.blockAux(next)
+			if err != nil {
+				return err
+			}
+		*/
 
-		delta, err := l.trackerEvalVerified(blk, aux)
+		delta, err := l.trackerEvalVerified(blk)
 		if err != nil {
 			return err
 		}

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -72,14 +72,6 @@ func (ml *mockLedgerForTracker) BlockHdr(rnd basics.Round) (bookkeeping.BlockHea
 	return ml.blocks[int(rnd)].block.BlockHeader, nil
 }
 
-func (ml *mockLedgerForTracker) blockAux(rnd basics.Round) (bookkeeping.Block, error) {
-	if rnd > ml.Latest() {
-		return bookkeeping.Block{}, fmt.Errorf("rnd %d out of bounds", rnd)
-	}
-
-	return ml.blocks[int(rnd)].block, nil
-}
-
 func (ml *mockLedgerForTracker) trackerDB() dbPair {
 	return ml.dbs
 }

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -49,7 +49,7 @@ func (ml *mockLedgerForTracker) Latest() basics.Round {
 	return basics.Round(len(ml.blocks)) - 1
 }
 
-func (ml *mockLedgerForTracker) trackerEvalVerified(blk bookkeeping.Block, aux evalAux) (StateDelta, error) {
+func (ml *mockLedgerForTracker) trackerEvalVerified(blk bookkeeping.Block) (StateDelta, error) {
 	delta := StateDelta{
 		hdr: &bookkeeping.BlockHeader{},
 	}
@@ -72,12 +72,12 @@ func (ml *mockLedgerForTracker) BlockHdr(rnd basics.Round) (bookkeeping.BlockHea
 	return ml.blocks[int(rnd)].block.BlockHeader, nil
 }
 
-func (ml *mockLedgerForTracker) blockAux(rnd basics.Round) (bookkeeping.Block, evalAux, error) {
+func (ml *mockLedgerForTracker) blockAux(rnd basics.Round) (bookkeeping.Block, error) {
 	if rnd > ml.Latest() {
-		return bookkeeping.Block{}, evalAux{}, fmt.Errorf("rnd %d out of bounds", rnd)
+		return bookkeeping.Block{}, fmt.Errorf("rnd %d out of bounds", rnd)
 	}
 
-	return ml.blocks[int(rnd)].block, ml.blocks[int(rnd)].aux, nil
+	return ml.blocks[int(rnd)].block, nil
 }
 
 func (ml *mockLedgerForTracker) trackerDB() dbPair {

--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -59,13 +59,6 @@ func (wl *wrappedLedger) BlockHdr(rnd basics.Round) (bookkeeping.BlockHeader, er
 	return wl.l.BlockHdr(rnd)
 }
 
-/*
-func (wl *wrappedLedger) blockAux(rnd basics.Round) (bookkeeping.Block, evalAux, error) {
-	wl.recordBlockQuery(rnd)
-	return wl.l.blockAux(rnd)
-}
-*/
-
 func (wl *wrappedLedger) trackerEvalVerified(blk bookkeeping.Block) (StateDelta, error) {
 	return wl.l.trackerEvalVerified(blk)
 }

--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -59,13 +59,15 @@ func (wl *wrappedLedger) BlockHdr(rnd basics.Round) (bookkeeping.BlockHeader, er
 	return wl.l.BlockHdr(rnd)
 }
 
+/*
 func (wl *wrappedLedger) blockAux(rnd basics.Round) (bookkeeping.Block, evalAux, error) {
 	wl.recordBlockQuery(rnd)
 	return wl.l.blockAux(rnd)
 }
+*/
 
-func (wl *wrappedLedger) trackerEvalVerified(blk bookkeeping.Block, aux evalAux) (StateDelta, error) {
-	return wl.l.trackerEvalVerified(blk, aux)
+func (wl *wrappedLedger) trackerEvalVerified(blk bookkeeping.Block) (StateDelta, error) {
+	return wl.l.trackerEvalVerified(blk)
 }
 
 func (wl *wrappedLedger) Latest() basics.Round {

--- a/ledger/blockdb.go
+++ b/ledger/blockdb.go
@@ -28,6 +28,7 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 )
 
+// 2019-12-15: removed column 'auxdata blob' from 'CREATE TABLE' statement. It was not explicitly removed from databases and may continue to exist with empty entries in some old databases.
 var blockSchema = []string{
 	`CREATE TABLE IF NOT EXISTS blocks (
 		rnd integer primary key,

--- a/ledger/blockdb.go
+++ b/ledger/blockdb.go
@@ -140,33 +140,6 @@ func blockGetCert(tx *sql.Tx, rnd basics.Round) (blk bookkeeping.Block, cert agr
 	return
 }
 
-/*
-func blockGetAux(tx *sql.Tx, rnd basics.Round) (blk bookkeeping.Block, aux evalAux, err error) {
-	var blkbuf []byte
-	var auxbuf []byte
-	err = tx.QueryRow("SELECT blkdata, auxdata FROM blocks WHERE rnd=?", rnd).Scan(&blkbuf, &auxbuf)
-	if err != nil {
-		if err == sql.ErrNoRows {
-			err = ErrNoEntry{Round: rnd}
-		}
-
-		return
-	}
-
-	err = protocol.Decode(blkbuf, &blk)
-	if err != nil {
-		return
-	}
-
-	err = protocol.Decode(auxbuf, &aux)
-	if err != nil {
-		return
-	}
-
-	return
-}
-*/
-
 func blockPut(tx *sql.Tx, blk bookkeeping.Block, cert agreement.Certificate) error {
 	var max sql.NullInt64
 	err := tx.QueryRow("SELECT MAX(rnd) FROM blocks").Scan(&max)

--- a/ledger/blockdb_test.go
+++ b/ledger/blockdb_test.go
@@ -32,7 +32,6 @@ import (
 func randomBlock(r basics.Round) blockEntry {
 	b := bookkeeping.Block{}
 	c := agreement.Certificate{}
-	a := evalAux{}
 
 	b.BlockHeader.Round = r
 	b.BlockHeader.TimeStamp = int64(crypto.RandUint64())
@@ -43,7 +42,6 @@ func randomBlock(r basics.Round) blockEntry {
 	return blockEntry{
 		block: b,
 		cert:  c,
-		aux:   a,
 	}
 }
 
@@ -52,7 +50,6 @@ func randomInitChain(proto protocol.ConsensusVersion, nblock int) []blockEntry {
 	for i := 0; i < nblock; i++ {
 		blkent := randomBlock(basics.Round(i))
 		blkent.cert = agreement.Certificate{}
-		blkent.aux = evalAux{}
 		blkent.block.CurrentProtocol = proto
 		res = append(res, blkent)
 	}
@@ -98,10 +95,12 @@ func checkBlockDB(t *testing.T, tx *sql.Tx, blocks []blockEntry) {
 		require.Equal(t, blk, blocks[rnd].block)
 		require.Equal(t, cert, blocks[rnd].cert)
 
-		blk, aux, err := blockGetAux(tx, rnd)
-		require.NoError(t, err)
-		require.Equal(t, blk, blocks[rnd].block)
-		require.Equal(t, aux, blocks[rnd].aux)
+		/*
+			blk, aux, err := blockGetAux(tx, rnd)
+			require.NoError(t, err)
+			require.Equal(t, blk, blocks[rnd].block)
+			require.Equal(t, aux, blocks[rnd].aux)
+		*/
 	}
 
 	_, err = blockGet(tx, basics.Round(len(blocks)))
@@ -156,7 +155,7 @@ func TestBlockDBAppend(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		blkent := randomBlock(basics.Round(len(blocks)))
-		err = blockPut(tx, blkent.block, blkent.cert, blkent.aux)
+		err = blockPut(tx, blkent.block, blkent.cert)
 		require.NoError(t, err)
 
 		blocks = append(blocks, blkent)

--- a/ledger/blockdb_test.go
+++ b/ledger/blockdb_test.go
@@ -94,13 +94,6 @@ func checkBlockDB(t *testing.T, tx *sql.Tx, blocks []blockEntry) {
 		require.NoError(t, err)
 		require.Equal(t, blk, blocks[rnd].block)
 		require.Equal(t, cert, blocks[rnd].cert)
-
-		/*
-			blk, aux, err := blockGetAux(tx, rnd)
-			require.NoError(t, err)
-			require.Equal(t, blk, blocks[rnd].block)
-			require.Equal(t, aux, blocks[rnd].aux)
-		*/
 	}
 
 	_, err = blockGet(tx, basics.Round(len(blocks)))

--- a/ledger/blockqueue.go
+++ b/ledger/blockqueue.go
@@ -302,24 +302,3 @@ func (bq *blockQueue) getBlockCert(r basics.Round) (blk bookkeeping.Block, cert 
 	err = updateErrNoEntry(err, lastCommitted, latest)
 	return
 }
-
-/*
-func (bq *blockQueue) getBlockAux(r basics.Round) (blk bookkeeping.Block, aux evalAux, err error) {
-	e, lastCommitted, latest, err := bq.checkEntry(r)
-	if e != nil {
-		return e.block, e.aux, nil
-	}
-
-	if err != nil {
-		return
-	}
-
-	err = bq.l.blockDBs.rdb.Atomic(func(tx *sql.Tx) error {
-		var err0 error
-		blk, aux, err0 = blockGetAux(tx, r)
-		return err0
-	})
-	err = updateErrNoEntry(err, lastCommitted, latest)
-	return
-}
-*/

--- a/ledger/blockqueue.go
+++ b/ledger/blockqueue.go
@@ -33,7 +33,6 @@ import (
 type blockEntry struct {
 	block bookkeeping.Block
 	cert  agreement.Certificate
-	aux   evalAux
 }
 
 type blockQueue struct {
@@ -92,7 +91,7 @@ func (bq *blockQueue) syncer() {
 
 		err := bq.l.blockDBs.wdb.Atomic(func(tx *sql.Tx) error {
 			for _, e := range workQ {
-				err0 := blockPut(tx, e.block, e.cert, e.aux)
+				err0 := blockPut(tx, e.block, e.cert)
 				if err0 != nil {
 					return err0
 				}
@@ -156,7 +155,7 @@ func (bq *blockQueue) latestCommitted() basics.Round {
 	return bq.lastCommitted
 }
 
-func (bq *blockQueue) putBlock(blk bookkeeping.Block, cert agreement.Certificate, aux evalAux) error {
+func (bq *blockQueue) putBlock(blk bookkeeping.Block, cert agreement.Certificate) error {
 	bq.mu.Lock()
 	defer bq.mu.Unlock()
 
@@ -183,7 +182,6 @@ func (bq *blockQueue) putBlock(blk bookkeeping.Block, cert agreement.Certificate
 	bq.q = append(bq.q, blockEntry{
 		block: blk,
 		cert:  cert,
-		aux:   aux,
 	})
 	bq.cond.Broadcast()
 	return nil
@@ -305,6 +303,7 @@ func (bq *blockQueue) getBlockCert(r basics.Round) (blk bookkeeping.Block, cert 
 	return
 }
 
+/*
 func (bq *blockQueue) getBlockAux(r basics.Round) (blk bookkeeping.Block, aux evalAux, err error) {
 	e, lastCommitted, latest, err := bq.checkEntry(r)
 	if e != nil {
@@ -323,3 +322,4 @@ func (bq *blockQueue) getBlockAux(r basics.Round) (blk bookkeeping.Block, aux ev
 	err = updateErrNoEntry(err, lastCommitted, latest)
 	return
 }
+*/

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -36,11 +36,6 @@ import (
 // ErrNoSpace indicates insufficient space for transaction in block
 var ErrNoSpace = errors.New("block does not have space for transaction")
 
-// evalAux is left after removing explicit reward claims,
-// in case we need this infrastructure in the future.
-type evalAux struct {
-}
-
 // VerifiedTxnCache captures the interface for a cache of previously
 // verified transactions.  This is expected to match the transaction
 // pool object.
@@ -158,8 +153,7 @@ func (cs *roundCowState) ConsensusParams() config.ConsensusParams {
 // BlockEvaluator represents an in-progress evaluation of a block
 // against the ledger.
 type BlockEvaluator struct {
-	state *roundCowState
-	//aux      *evalAux
+	state    *roundCowState
 	validate bool
 	generate bool
 	txcache  VerifiedTxnCache
@@ -199,12 +193,6 @@ func startEvaluator(l ledgerForEvaluator, hdr bookkeeping.BlockHeader, validate 
 		return nil, protocol.Error(hdr.CurrentProtocol)
 	}
 
-	/*
-		if aux == nil {
-			aux = &evalAux{}
-		}
-	*/
-
 	base := &roundCowBase{
 		l: l,
 		// round that lookups come from is previous block.  We validate
@@ -216,7 +204,6 @@ func startEvaluator(l ledgerForEvaluator, hdr bookkeeping.BlockHeader, validate 
 	}
 
 	eval := &BlockEvaluator{
-		//aux:              aux,
 		validate:         validate,
 		generate:         generate,
 		txcache:          txcache,
@@ -706,7 +693,6 @@ func (eval *BlockEvaluator) GenerateBlock() (*ValidatedBlock, error) {
 	vb := ValidatedBlock{
 		blk:   eval.block,
 		delta: eval.state.mods,
-		//aux:   *eval.aux,
 	}
 	return &vb, nil
 }
@@ -768,7 +754,6 @@ func (l *Ledger) Validate(ctx context.Context, blk bookkeeping.Block, txcache Ve
 	vb := ValidatedBlock{
 		blk:   blk,
 		delta: delta,
-		//aux:   aux,
 	}
 	return &vb, nil
 }
@@ -779,7 +764,6 @@ func (l *Ledger) Validate(ctx context.Context, blk bookkeeping.Block, txcache Ve
 type ValidatedBlock struct {
 	blk   bookkeeping.Block
 	delta StateDelta
-	//aux   evalAux
 }
 
 // Block returns the underlying Block for a ValidatedBlock.
@@ -795,6 +779,5 @@ func (vb ValidatedBlock) WithSeed(s committee.Seed) ValidatedBlock {
 	return ValidatedBlock{
 		blk:   newblock,
 		delta: vb.delta,
-		//aux:   vb.aux,
 	}
 }

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -99,6 +99,7 @@ func OpenLedger(
 
 	l.trackerDBs, l.blockDBs, err = openLedgerDB(dbPathPrefix, dbMem)
 	if err != nil {
+		err = fmt.Errorf("OpenLedger.openLedgerDB %v", err)
 		return nil, err
 	}
 
@@ -106,11 +107,13 @@ func OpenLedger(
 		return initBlocksDB(tx, l, []bookkeeping.Block{genesisInitState.Block}, isArchival)
 	})
 	if err != nil {
+		err = fmt.Errorf("OpenLedger.initBlocksDB %v", err)
 		return nil, err
 	}
 
 	l.blockQ, err = bqInit(l)
 	if err != nil {
+		err = fmt.Errorf("OpenLedger.bqInit %v", err)
 		return nil, err
 	}
 
@@ -132,6 +135,7 @@ func OpenLedger(
 
 	err = l.trackers.loadFromDisk(l)
 	if err != nil {
+		err = fmt.Errorf("OpenLedger.loadFromDisk %v", err)
 		return nil, err
 	}
 
@@ -207,6 +211,7 @@ func openLedgerDB(dbPathPrefix string, dbMem bool) (trackerDBs dbPair, blockDBs 
 func initBlocksDB(tx *sql.Tx, l *Ledger, initBlocks []bookkeeping.Block, isArchival bool) (err error) {
 	err = blockInit(tx, initBlocks)
 	if err != nil {
+		err = fmt.Errorf("initBlocksDB.blockInit %v", err)
 		return err
 	}
 
@@ -214,6 +219,7 @@ func initBlocksDB(tx *sql.Tx, l *Ledger, initBlocks []bookkeeping.Block, isArchi
 	if isArchival {
 		earliest, err := blockEarliest(tx)
 		if err != nil {
+			err = fmt.Errorf("initBlocksDB.blockEarliest %v", err)
 			return err
 		}
 
@@ -223,10 +229,12 @@ func initBlocksDB(tx *sql.Tx, l *Ledger, initBlocks []bookkeeping.Block, isArchi
 			l.log.Warnf("resetting blocks DB (earliest block is %v)", earliest)
 			err := blockResetDB(tx)
 			if err != nil {
+				err = fmt.Errorf("initBlocksDB.blockResetDB %v", err)
 				return err
 			}
 			err = blockInit(tx, initBlocks)
 			if err != nil {
+				err = fmt.Errorf("initBlocksDB.blockInit 2 %v", err)
 				return err
 			}
 		}
@@ -356,9 +364,11 @@ func (l *Ledger) LatestCommitted() basics.Round {
 	return l.blockQ.latestCommitted()
 }
 
-func (l *Ledger) blockAux(rnd basics.Round) (bookkeeping.Block, evalAux, error) {
+/*
+func (l *Ledger) blockAux(rnd basics.Round) (bookkeeping.Block, error) {
 	return l.blockQ.getBlockAux(rnd)
 }
+*/
 
 // Block returns the block for round rnd.
 func (l *Ledger) Block(rnd basics.Round) (blk bookkeeping.Block, err error) {
@@ -395,7 +405,7 @@ func (l *Ledger) BlockCert(rnd basics.Round) (blk bookkeeping.Block, cert agreem
 // is returned if this is not the expected next block number.
 func (l *Ledger) AddBlock(blk bookkeeping.Block, cert agreement.Certificate) error {
 	// passing nil as the verificationPool is ok since we've asking the evaluator to skip verification.
-	updates, aux, err := l.eval(context.Background(), blk, nil, false, nil, nil)
+	updates, err := l.eval(context.Background(), blk, false, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -403,7 +413,7 @@ func (l *Ledger) AddBlock(blk bookkeeping.Block, cert agreement.Certificate) err
 	vb := ValidatedBlock{
 		blk:   blk,
 		delta: updates,
-		aux:   aux,
+		//aux:   aux,
 	}
 
 	return l.AddValidatedBlock(vb, cert)
@@ -419,7 +429,7 @@ func (l *Ledger) AddValidatedBlock(vb ValidatedBlock, cert agreement.Certificate
 	l.trackerMu.Lock()
 	defer l.trackerMu.Unlock()
 
-	err := l.blockQ.putBlock(vb.blk, cert, vb.aux)
+	err := l.blockQ.putBlock(vb.blk, cert)
 	if err != nil {
 		return err
 	}
@@ -474,9 +484,9 @@ func (l *Ledger) trackerLog() logging.Logger {
 	return l.log
 }
 
-func (l *Ledger) trackerEvalVerified(blk bookkeeping.Block, aux evalAux) (StateDelta, error) {
+func (l *Ledger) trackerEvalVerified(blk bookkeeping.Block) (StateDelta, error) {
 	// passing nil as the verificationPool is ok since we've asking the evaluator to skip verification.
-	delta, _, err := l.eval(context.Background(), blk, &aux, false, nil, nil)
+	delta, err := l.eval(context.Background(), blk, false, nil, nil)
 	return delta, err
 }
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -364,12 +364,6 @@ func (l *Ledger) LatestCommitted() basics.Round {
 	return l.blockQ.latestCommitted()
 }
 
-/*
-func (l *Ledger) blockAux(rnd basics.Round) (bookkeeping.Block, error) {
-	return l.blockQ.getBlockAux(rnd)
-}
-*/
-
 // Block returns the block for round rnd.
 func (l *Ledger) Block(rnd basics.Round) (blk bookkeeping.Block, err error) {
 	return l.blockQ.getBlock(rnd)
@@ -413,7 +407,6 @@ func (l *Ledger) AddBlock(blk bookkeeping.Block, cert agreement.Certificate) err
 	vb := ValidatedBlock{
 		blk:   blk,
 		delta: updates,
-		//aux:   aux,
 	}
 
 	return l.AddValidatedBlock(vb, cert)

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -86,7 +86,6 @@ type ledgerForTracker interface {
 	Latest() basics.Round
 	Block(basics.Round) (bookkeeping.Block, error)
 	BlockHdr(basics.Round) (bookkeeping.BlockHeader, error)
-	//blockAux(basics.Round) (bookkeeping.Block, error)
 }
 
 type trackerRegistry struct {

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -81,12 +81,12 @@ type ledgerTracker interface {
 type ledgerForTracker interface {
 	trackerDB() dbPair
 	trackerLog() logging.Logger
-	trackerEvalVerified(bookkeeping.Block, evalAux) (StateDelta, error)
+	trackerEvalVerified(bookkeeping.Block) (StateDelta, error)
 
 	Latest() basics.Round
 	Block(basics.Round) (bookkeeping.Block, error)
 	BlockHdr(basics.Round) (bookkeeping.BlockHeader, error)
-	blockAux(basics.Round) (bookkeeping.Block, evalAux, error)
+	//blockAux(basics.Round) (bookkeeping.Block, error)
 }
 
 type trackerRegistry struct {


### PR DESCRIPTION
Simplify ledger data storage by removing 'evalAux' field which hasn't been used since before 1.0