### PR TITLE
Fix issue on macOS to make script portable

### DIFF
--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -2,7 +2,7 @@
 
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 LICENSE_LOCATION="$PROJECT_ROOT"/scripts/LICENSE_HEADER
-NUMLINES=$(wc -l "$LICENSE_LOCATION" | cut -d\  -f1)
+NUMLINES=$(< "$LICENSE_LOCATION" wc -l | tr -d ' ')
 LICENSE=$(sed "s/{DATE_Y}/$(date +"%Y")/" "$LICENSE_LOCATION")
 VERSIONED_GO_FILES=$(git ls-tree --full-tree --name-only -r HEAD | grep "\.go$")
 EXCLUDE=(


### PR DESCRIPTION
This was failing on macOS because the output of the `wc` command was being prepended with whitespace.  Piping it then to `cut` was returning an empty string.

https://stackoverflow.com/questions/30927590/wc-on-osx-return-includes-spaces