### PR TITLE
Fix asset unit name display in goal account list

### DIFF
--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -487,10 +487,10 @@ var listCmd = &cobra.Command{
 				if err == nil {
 					params, ok := creatorInfo.AssetParams[aid]
 					if ok {
+						unitName = "units"
 						if params.UnitName != "" {
 							unitName = params.UnitName
 						}
-						unitName = "units"
 						if params.AssetName != "" {
 							assetName = fmt.Sprintf(", name %s", params.AssetName)
 						}


### PR DESCRIPTION
default value should be set before if statement, not after