### PR TITLE
goal listpartkeys display error

### DIFF
--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -859,7 +859,8 @@ var listParticipationKeysCmd = &cobra.Command{
 			if err == nil {
 				votingBytes := parts[fn].Voting.OneTimeSignatureVerifier
 				vrfBytes := parts[fn].VRF.PK
-				if string(onlineAccountInfo.Participation.ParticipationPK) == string(votingBytes[:]) &&
+				if onlineAccountInfo.Participation != nil &&
+					(string(onlineAccountInfo.Participation.ParticipationPK) == string(votingBytes[:])) &&
 					(string(onlineAccountInfo.Participation.VRFPK) == string(vrfBytes[:])) &&
 					(onlineAccountInfo.Participation.VoteFirst == uint64(parts[fn].FirstValid)) &&
 					(onlineAccountInfo.Participation.VoteLast == uint64(parts[fn].LastValid)) &&

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -21,6 +21,9 @@ namespace eval ::AlgorandGoal {
   namespace export GetLedgerSupply
   namespace export WaitForRound
   namespace export Report
+  namespace export ListParticipationKeys
+  namespace export AddParticipationKey
+  namespace export TakeAccountOnline
 
   # My Variables
    set version 1.0
@@ -669,6 +672,45 @@ proc ::AlgorandGoal::Report { TEST_PRIMARY_NODE_DIR } {
             -re {Last commited block: (\d+)} {puts "status check ok"}
         }
     } EXCEPTION ] } {
-    ::AlgorandGoal::Abort "ERROR in GetLedgerSupply: $EXCEPTION"
+    ::AlgorandGoal::Abort "ERROR in Report: $EXCEPTION"
     }
+}
+
+# List Participation keys
+proc ::AlgorandGoal::ListParticipationKeys { TEST_PRIMARY_NODE_DIR } {
+    if { [ catch {
+        spawn goal account listpartkeys -d $TEST_PRIMARY_NODE_DIR
+        expect {
+            timeout { ::AlgorandGoal::Abort "goal ListParticipationKeys timed out"  }
+            close
+        }
+    } EXCEPTION ] } {
+    ::AlgorandGoal::Abort "ERROR in ListParticipationKeys: $EXCEPTION"
+    }
+}
+
+# Add a participation key
+proc ::AlgorandGoal::AddParticipationKey { ADDRESS FIRST_ROUND LAST_ROUND TEST_PRIMARY_NODE_DIR } {
+    if { [ catch {
+        spawn goal account addpartkey --address $ADDRESS --roundFirstValid $FIRST_ROUND --roundLastValid $LAST_ROUND -d $TEST_PRIMARY_NODE_DIR
+        expect {
+            timeout { ::AlgorandGoal::Abort "goal AddParticipationKey timed out"  }
+            close
+        }
+    } EXCEPTION ] } {
+    ::AlgorandGoal::Abort "ERROR in AddParticipationKey: $EXCEPTION"
+    }
+}
+
+# Register online participation with a given account
+proc ::AlgorandGoal::TakeAccountOnline { ADDRESS FIRST_ROUND LAST_ROUND TEST_PRIMARY_NODE_DIR } {
+   if { [ catch {
+       spawn goal account changeonlinestatus --address $ADDRESS --firstvalid $FIRST_ROUND --lastvalid $LAST_ROUND -d datadir
+       expect {
+           timeout { ::AlgorandGoal::Abort "goal TakeAccountOnline timed out"  }
+           close
+       }
+   } EXCEPTION ] } {
+   ::AlgorandGoal::Abort "ERROR in TakeAccountOnline: $EXCEPTION"
+   }
 }

--- a/test/e2e-go/cli/goal/expect/listExpiredParticipationKeyTest.exp
+++ b/test/e2e-go/cli/goal/expect/listExpiredParticipationKeyTest.exp
@@ -1,0 +1,51 @@
+#!/usr/bin/expect -f
+
+set err 0
+log_user 1
+
+if { [catch {
+
+    source  goalExpectCommon.exp
+
+    set TEST_ALGO_DIR [lindex $argv 0]
+    set TEST_DATA_DIR [lindex $argv 1]
+
+    puts "TEST_ALGO_DIR: $TEST_ALGO_DIR"
+    puts "TEST_DATA_DIR: $TEST_DATA_DIR"
+
+    set TIME_STAMP [clock seconds]
+
+    set TEST_ROOT_DIR $TEST_ALGO_DIR/root
+    set TEST_PRIMARY_NODE_DIR $TEST_ROOT_DIR/Primary/
+    set NETWORK_NAME test_net_expect_$TIME_STAMP
+    set NETWORK_TEMPLATE "$TEST_DATA_DIR/nettemplates/ThreeNodesEvenDist.json"
+
+    exec cp $TEST_DATA_DIR/../../gen/devnet/genesis.json $TEST_ALGO_DIR
+
+    # Create network
+    ::AlgorandGoal::StartNetwork $NETWORK_NAME $NETWORK_TEMPLATE $TEST_ALGO_DIR $TEST_ROOT_DIR
+
+    set PRIMARY_WALLET_NAME unencrypted-default-wallet
+
+    set PRIMARY_ACCOUNT_ADDRESS [::AlgorandGoal::GetHighestFundedAccountForWallet $PRIMARY_WALLET_NAME  $TEST_PRIMARY_NODE_DIR]
+
+    # Register participation keys
+    set ROUND_FIRST_VALID 1
+    set KEY_EXPIRY_ROUND 10
+    ::AlgorandGoal::AddParticipationKey $PRIMARY_ACCOUNT_ADDRESS $ROUND_FIRST_VALID $KEY_EXPIRY_ROUND $TEST_PRIMARY_NODE_DIR
+    ::AlgorandGoal::TakeAccountOnline $PRIMARY_ACCOUNT_ADDRESS $ROUND_FIRST_VALID $KEY_EXPIRY_ROUND $TEST_PRIMARY_NODE_DIR
+
+    # Wait for expiry
+    ::AlgorandGoal::WaitForRound $KEY_EXPIRY_ROUND $TEST_PRIMARY_NODE_DIR
+
+    # List participation keys
+    ::AlgorandGoal::ListParticipationKeys $TEST_PRIMARY_NODE_DIR
+
+    # Clean up
+    ::AlgorandGoal::StopNetwork $NETWORK_NAME $TEST_ALGO_DIR $TEST_ROOT_DIR
+
+    exit 0
+
+} EXCEPTION ] } {
+   ::AlgorandGoal::Abort "ERROR in listExpiredParticipationKeyTest: $EXCEPTION"
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

This fixes a crash where `goal` attempts to dereference a `nil` `Participation` when attempting to display an expired participation key using `listpartkeys`. 

## Test Plan

This adds a test `.exp` for this case.

