### PR TITLE
scripts: fix for multi-part GOPATH (with colons)

### DIFF
--- a/scripts/build_package.sh
+++ b/scripts/build_package.sh
@@ -59,7 +59,7 @@ mkdir ${PKG_ROOT}/bin
 # If you modify this list, also update this list in ./cmd/updater/update.sh backup_binaries()
 bin_files=("algocfg" "algod" "algoh" "algokey" "carpenter" "catchupsrv" "ddconfig.sh" "diagcfg" "find-nodes.sh" "goal" "kmd" "msgpacktool" "node_exporter" "update.sh" "updater" "COPYING")
 for bin in "${bin_files[@]}"; do
-    cp ${GOPATH}/bin/${bin} ${PKG_ROOT}/bin
+    cp ${GOPATH%%:*}/bin/${bin} ${PKG_ROOT}/bin
     if [ $? -ne 0 ]; then exit 1; fi
 done
 
@@ -113,7 +113,7 @@ echo "Staging tools package files"
 bin_files=("algons" "auctionconsole" "auctionmaster" "auctionminion" "coroner" "dispenser" "netgoal" "nodecfg" "pingpong" "cc_service" "cc_agent" "cc_client" "COPYING")
 mkdir -p ${TOOLS_ROOT}
 for bin in "${bin_files[@]}"; do
-    cp ${GOPATH}/bin/${bin} ${TOOLS_ROOT}
+    cp ${GOPATH%%:*}/bin/${bin} ${TOOLS_ROOT}
     if [ $? -ne 0 ]; then exit 1; fi
 done
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Currently `make install` fails when $GOPATH has a colon.  the build_release_local.sh script assumes $GOPATH is simply a directory.  But GOPATH is allowed to contain many directories separated by colons.  When that is the case `make install` fails with an error when build_release_local.sh attempts to copy files from $GOPATH.

This patch uses ${GOPATH%%:*} (the portion before the first ":"), rather than the entire $GOPATH. 
 This fixes `make install` (the only problem I've run into so far).  It would not surprise me to learn the same problem exists in other scripts.

## Test Plan

Without the patch, my local `make install` fails.  With the patch, it succeeds.


