### PR TITLE
Reduce e2e_go_tests execution time twice

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -504,7 +504,7 @@ func initConsensusTestProtocols() {
 	Consensus[protocol.ConsensusTestBigBlocks] = testBigBlocks
 
 	rapidRecalcParams := Consensus[protocol.ConsensusCurrentVersion]
-	rapidRecalcParams.RewardsRateRefreshInterval = 25
+	rapidRecalcParams.RewardsRateRefreshInterval = 10
 	//because rapidRecalcParams is based on ConsensusCurrentVersion,
 	//it *shouldn't* have any ApprovedUpgrades
 	//but explicitly mark "no approved upgrades" just in case

--- a/test/e2e-go/features/participation/participationRewards_test.go
+++ b/test/e2e-go/features/participation/participationRewards_test.go
@@ -19,9 +19,9 @@ package participation
 import (
 	"fmt"
 	"path/filepath"
-	"testing"
 	"runtime"
-	
+	"testing"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/config"
@@ -88,7 +88,7 @@ func TestOnlineOfflineRewards(t *testing.T) {
 	offlineClient := fixture.GetLibGoalClientForNamedNode("Offline")
 
 	// learn initial balances
-	initialRound := uint64(301)
+	initialRound := uint64(11)
 	r.NoError(fixture.WaitForRoundWithTimeout(initialRound))
 	initialOnlineBalance, _ := onlineClient.GetBalance(onlineAccount)
 	initialOfflineBalance, _ := offlineClient.GetBalance(offlineAccount)

--- a/test/scripts/run_integration_tests.sh
+++ b/test/scripts/run_integration_tests.sh
@@ -12,10 +12,6 @@ export ALGOTEST=1
 #./test/scripts/test_running_install_and_update.sh -c "${CHANNEL}"
 #./test/scripts/test_update_rollback.sh -c "${CHANNEL}"
 
-# Test deploying, running, and deleting a local private network
-# TODO: delete this, it is redundant with tests that come after
-./test/scripts/test_private_network.sh
-
 # Run suite of e2e tests against a single installation of the current build
 ./test/scripts/e2e.sh
 


### PR DESCRIPTION
There are seven major contributors to integration tests running time
TestOnlineOfflineRewards (1248.64s)
TestAssetConfig (364.71s)
TestRewardRateRecalculation (226.78s)
TestStartAndEndAuctionTenUsersOneBidEach (196.34s)
TestNoDepositAssociatedWithBid (189.74s)
TestDeadbeatBid (188.70s)
TestStartAndCancelAuctionNoBids (183.35s)

This commit considers only first three.

1. Fixing rewards interval in config for TestRewardRateRecalculation
from 25 to 10 reduces time twice:
TestRewardRateRecalculation (119.34s)

2. Fixing initialRound in TestOnlineOfflineRewards test
from 301 to 11 reduces time 15 times:
TestOnlineOfflineRewards (73.80s)

3. TestAssetConfig looks long by design - commits and waits max allowed assets

4. Address TODO in run_integration_tests.sh.
Now e2e_client_runner calls 'goal network delete' to reflect this removal

Refers #508
