### PR TITLE
Add --no-sig flag to goal clerk multisig sign

### DIFF
--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -94,7 +94,7 @@ const (
 	soFlagError     = "-s is not meaningful without -o"
 	infoRawTxIssued = "Raw transaction ID %s issued"
 	txPoolError     = "Transaction %s kicked out of local node pool: %s"
-	addrNoSigError  = "--address and --no-sig are mutually exclusive"
+	addrNoSigError  = "Exactly one of --address or --no-sig is required"
 	msigLookupError = "Could not lookup multisig preimage: %s"
 	msigParseError  = "Multisig preimage parsing error: %s"
 

--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -95,8 +95,8 @@ const (
 	infoRawTxIssued = "Raw transaction ID %s issued"
 	txPoolError     = "Transaction %s kicked out of local node pool: %s"
 	addrNoSigError  = "Exactly one of --address or --no-sig is required"
-	msigLookupError = "Could not lookup multisig preimage: %s"
-	msigParseError  = "Multisig preimage parsing error: %s"
+	msigLookupError = "Could not lookup multisig template: %s"
+	msigParseError  = "Multisig template parsing error: %s"
 
 	infoAutoFeeSet = "Automatically set fee to %d MicroAlgos"
 

--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -95,8 +95,8 @@ const (
 	infoRawTxIssued = "Raw transaction ID %s issued"
 	txPoolError     = "Transaction %s kicked out of local node pool: %s"
 	addrNoSigError  = "Exactly one of --address or --no-sig is required"
-	msigLookupError = "Could not lookup multisig template: %s"
-	msigParseError  = "Multisig template parsing error: %s"
+	msigLookupError = "Could not lookup multisig information: %s"
+	msigParseError  = "Multisig information parsing error: %s"
 
 	infoAutoFeeSet = "Automatically set fee to %d MicroAlgos"
 

--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -94,6 +94,9 @@ const (
 	soFlagError     = "-s is not meaningful without -o"
 	infoRawTxIssued = "Raw transaction ID %s issued"
 	txPoolError     = "Transaction %s kicked out of local node pool: %s"
+	addrNoSigError  = "--address and --no-sig are mutually exclusive"
+	msigLookupError = "Could not lookup multisig preimage: %s"
+	msigParseError  = "Multisig preimage parsing error: %s"
 
 	infoAutoFeeSet = "Automatically set fee to %d MicroAlgos"
 

--- a/cmd/goal/multisig.go
+++ b/cmd/goal/multisig.go
@@ -45,7 +45,7 @@ func init() {
 
 	addSigCmd.Flags().StringVarP(&txFilename, "tx", "t", "", "Partially-signed transaction file to add signature to")
 	addSigCmd.Flags().StringVarP(&addr, "address", "a", "", "Address of the key to sign with")
-	addSigCmd.Flags().BoolVarP(&noSig, "no-sig", "n", false, "Fill in the multisig struct with the preimage, but don't produce a signature")
+	addSigCmd.Flags().BoolVarP(&noSig, "no-sig", "n", false, "Fill in the transaction's multisig template with public keys and threshold information, but don't produce a signature")
 	addSigCmd.MarkFlagRequired("tx")
 
 	signProgramCmd.Flags().StringVarP(&programSource, "program", "p", "", "Program source to be compiled and signed")

--- a/cmd/goal/multisig.go
+++ b/cmd/goal/multisig.go
@@ -45,7 +45,7 @@ func init() {
 
 	addSigCmd.Flags().StringVarP(&txFilename, "tx", "t", "", "Partially-signed transaction file to add signature to")
 	addSigCmd.Flags().StringVarP(&addr, "address", "a", "", "Address of the key to sign with")
-	addSigCmd.Flags().BoolVarP(&noSig, "no-sig", "n", false, "Fill in the transaction's multisig template with public keys and threshold information, but don't produce a signature")
+	addSigCmd.Flags().BoolVarP(&noSig, "no-sig", "n", false, "Fill in the transaction's multisig field with public keys and threshold information, but don't produce a signature")
 	addSigCmd.MarkFlagRequired("tx")
 
 	signProgramCmd.Flags().StringVarP(&programSource, "program", "p", "", "Program source to be compiled and signed")

--- a/cmd/goal/multisig.go
+++ b/cmd/goal/multisig.go
@@ -34,6 +34,7 @@ import (
 var (
 	addr     string
 	msigAddr string
+	noSig    bool
 )
 
 func init() {
@@ -44,8 +45,8 @@ func init() {
 
 	addSigCmd.Flags().StringVarP(&txFilename, "tx", "t", "", "Partially-signed transaction file to add signature to")
 	addSigCmd.Flags().StringVarP(&addr, "address", "a", "", "Address of the key to sign with")
+	addSigCmd.Flags().BoolVarP(&noSig, "no-sig", "n", false, "Fill in the multisig struct with the preimage, but don't produce a signature")
 	addSigCmd.MarkFlagRequired("tx")
-	addSigCmd.MarkFlagRequired("address")
 
 	signProgramCmd.Flags().StringVarP(&programSource, "program", "p", "", "Program source to be compiled and signed")
 	signProgramCmd.Flags().StringVarP(&progByteFile, "program-bytes", "P", "", "Program binary to be signed")
@@ -76,10 +77,17 @@ var addSigCmd = &cobra.Command{
 	Long:  `Start a multisig, or add a signature to an existing multisig, for a given transaction`,
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
-
 		data, err := readFile(txFilename)
 		if err != nil {
 			reportErrorf(fileReadError, txFilename, err)
+		}
+
+		// --address and --no-sig are mutually exclusive, since if
+		// we're not signing we don't need an address
+		if addr == "" && !noSig {
+			reportErrorf(addrNoSigError)
+		} else if addr != "" && noSig {
+			reportErrorf(addrNoSigError)
 		}
 
 		dataDir := ensureSingleDataDir()
@@ -98,9 +106,21 @@ var addSigCmd = &cobra.Command{
 				reportErrorf(txDecodeError, txFilename, err)
 			}
 
-			msig, err := client.MultisigSignTransactionWithWallet(wh, pw, stxn.Txn, addr, stxn.Msig)
-			if err != nil {
-				reportErrorf(errorSigningTX, err)
+			var msig crypto.MultisigSig
+			if noSig {
+				multisigInfo, err := client.LookupMultisigAccount(wh, stxn.Txn.Sender.String())
+				if err != nil {
+					reportErrorf(msigLookupError, err)
+				}
+				msig, err = msigInfoToMsig(multisigInfo)
+				if err != nil {
+					reportErrorf(msigParseError, err)
+				}
+			} else {
+				msig, err = client.MultisigSignTransactionWithWallet(wh, pw, stxn.Txn, addr, stxn.Msig)
+				if err != nil {
+					reportErrorf(errorSigningTX, err)
+				}
 			}
 
 			// The following line makes stxn.cachedEncodingLen incorrect, but it's okay because we're just serializing it to a file
@@ -181,11 +201,11 @@ var signProgramCmd = &cobra.Command{
 			}
 			multisigInfo, err := client.LookupMultisigAccount(wh, msigAddr)
 			if err != nil {
-				reportErrorf("could not lookup multisig address", err)
+				reportErrorf(msigLookupError, err)
 			}
 			msig, err := msigInfoToMsig(multisigInfo)
 			if err != nil {
-				reportErrorf("internal err processing msig: %s", err)
+				reportErrorf(msigParseError, err)
 			}
 			lsig.Msig = msig
 		}


### PR DESCRIPTION
This PR adds a new flag, `--no-sig` to `goal clerk multisig sign` that will fill in an `Msig` for a particular multisig preimage on a transaction, but won't actually do any signing. This is necessary if all of the keys in the multisig are ledger hardware wallets (since ledgers don't store multisig preimages).