### PR TITLE
Fixing arm64 environment issues

### DIFF
--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -30,7 +30,7 @@ if [ "${OS}" = "linux" ]; then
         fi
         set -e
         sudo apt-get update -y
-        sudo apt-get -y install sqlite3
+        sudo apt-get -y install sqlite3 python3-venv libffi-dev libssl-dev
     fi
     if [[ "${ARCH}" = "arm" ]]; then
         sudo sh -c 'echo "CONF_SWAPSIZE=1024" > /etc/dphys-swapfile; dphys-swapfile setup; dphys-swapfile swapon'

--- a/scripts/travis/integration_test.sh
+++ b/scripts/travis/integration_test.sh
@@ -14,10 +14,14 @@ export BUILD_TYPE="integration"
 if [ "${USER}" = "travis" ]; then
     # we're running on a travis machine
     "${SCRIPTPATH}/build.sh" --make_debug
+    GOPATHBIN=$(go env GOPATH)/bin
+    export PATH=$PATH:$GOPATHBIN
     "${SCRIPTPATH}/travis_wait.sh" 90 "${SCRIPTPATH}/test.sh"
 else
     # we're running on an ephermal build machine
     "${SCRIPTPATH}/build.sh" --make_debug
+    GOPATHBIN=$(go env GOPATH)/bin
+    export PATH=$PATH:$GOPATHBIN    
     "${SCRIPTPATH}/test.sh"
 fi
 


### PR DESCRIPTION
## Summary
1) python3-venv libffi-dev libssl-dev
libffi-dev (and libssl-dev) are needed by the cryptography package builder for python in e2e_basic_start_stop.

2) exporting GOPATHBIN needed to run algotmpl in template e2e tests.

Explain the goal of this change and what problem it is solving.

## Test Plan
Run in travis
