### PR TITLE
Fix concurrent access to wallet handles cache in goal

### DIFF
--- a/libgoal/lockedFile.go
+++ b/libgoal/lockedFile.go
@@ -1,0 +1,120 @@
+// Copyright (C) 2019 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package libgoal
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"syscall"
+	"time"
+)
+
+// Platform-dependant locker implementation
+// How to extend
+// 1. Create two new files locker.go and locker_platform.go
+// 2. Put appropriate build tags
+// 3. Move unixLocker implementation and `newLockedFile` method to locker.go
+// 4. Implement platform-specific locker in locker_platform.go
+// 5. Ensure `newLockedFile` sets platform-specific locker
+//    so that lockedFile.read and lockedFile.write work correctly
+
+type locker interface {
+	tryRLock(fd *os.File) error
+	tryLock(fd *os.File) error
+	unlock(fd *os.File) error
+}
+
+type unixLocker struct {
+}
+
+func (f *unixLocker) tryRLock(fd *os.File) error {
+	return syscall.Flock(int(fd.Fd()), syscall.LOCK_SH|syscall.LOCK_NB)
+}
+
+func (f *unixLocker) tryLock(fd *os.File) error {
+	return syscall.Flock(int(fd.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+}
+
+func (f *unixLocker) unlock(fd *os.File) error {
+	return syscall.Flock(int(fd.Fd()), syscall.LOCK_UN)
+}
+
+// lockedFile implementation
+// It uses non-blocking acquisition with repeats
+// and supposed to be platform-agnostic with appropriate locker implementation.
+// Each platform needs own specific `newLockedFile`
+const maxRepeats = 10
+const sleepInterval = 10 * time.Microsecond
+
+type lockedFile struct {
+	path   string
+	locker locker
+}
+
+func newLockedFile(path string) *lockedFile {
+	f := new(lockedFile)
+	f.path = path
+	f.locker = new(unixLocker)
+	return f
+}
+
+func (f *lockedFile) read() ([]byte, error) {
+	fd, err := os.Open(f.path)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+
+	lockFunc := func() error { return f.locker.tryRLock(fd) }
+	err = attemptLock(lockFunc)
+	if err != nil {
+		return nil, fmt.Errorf("Can't acquire lock for %s: %s", f.path, err.Error())
+	}
+	defer f.locker.unlock(fd)
+
+	return ioutil.ReadAll(fd)
+}
+
+func (f *lockedFile) write(data []byte, perm os.FileMode) error {
+	fd, err := os.OpenFile(f.path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+
+	lockFunc := func() error { return f.locker.tryLock(fd) }
+	err = attemptLock(lockFunc)
+	if err != nil {
+		return fmt.Errorf("Can't acquire lock for %s: %s", f.path, err.Error())
+	}
+	defer f.locker.unlock(fd)
+
+	_, err = fd.Write(data)
+	return err
+}
+
+func attemptLock(lockFunc func() error) error {
+	var savedError error
+	for repeatCounter := 0; repeatCounter < maxRepeats; repeatCounter++ {
+		if savedError = lockFunc(); savedError == nil {
+			break
+		}
+		time.Sleep(sleepInterval)
+	}
+	return savedError
+}


### PR DESCRIPTION
## Summary

* In rare cases (i.e. e2e tests run in parallel on the same network)
a race cond happens when accessing goal.cache/walletHandles.json file
* Introduce advisory locking on the mentioned file
* Implementation is extendable by implementing *locker* interface
  for specific platform and providing a new *newLockedFile* constructor.

## Test Plan

Low impact, rely on existing tests.
