### PR TITLE
Promote test_release.sh so that it won't conflict with release testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,9 @@ jobs:
     - stage: deploy
       name: Ubuntu Deploy
       os: linux
-      script: scripts/travis/deploy_packages.sh
+      script:
+        - scripts/travis/deploy_packages.sh
+        - scripts/travis/test_release.sh
     - # same stage, parallel job
       name: MacOS Deploy
       os: osx
@@ -143,16 +145,6 @@ jobs:
             - awscli
       script:
         - scripts/travis/external_build.sh ./scripts/travis/deploy_packages.sh
-
-    - stage: post_deploy
-      os: linux
-      name: Test Release Builds
-      script:
-        - scripts/travis/test_release.sh
-      addons:
-        apt:
-          packages:
-            - awscli
 
 # Don't rebuild libsodium every time
 cache:


### PR DESCRIPTION
## Summary

Running deploy_test stage is currently done only after deploy stage is completed.
This typically takes two hours, as the ARM build slowing things down.
During that time, Jenkins might have already moved some of the tarballs to the passed directory.
( which would cause the test_release.sh script to fail. )

To work around that, we want to run the scripts immediately after uploading the tarballs to the s3.