### PR TITLE
Add logging for the telemetry server connections

### DIFF
--- a/logging/log.go
+++ b/logging/log.go
@@ -154,7 +154,7 @@ type Logger interface {
 	AddHook(hook logrus.Hook)
 
 	EnableTelemetry(cfg TelemetryConfig) error
-	UpdateTelemetryURI(uri string) bool
+	UpdateTelemetryURI(uri string) error
 	GetTelemetryEnabled() bool
 	Metrics(category telemetryspec.Category, metrics telemetryspec.MetricDetails, details interface{})
 	Event(category telemetryspec.Category, identifier telemetryspec.Event)
@@ -372,12 +372,12 @@ func (l logger) EnableTelemetry(cfg TelemetryConfig) (err error) {
 	return EnableTelemetry(cfg, &l)
 }
 
-func (l logger) UpdateTelemetryURI(uri string) bool {
-	if l.loggerState.telemetry.hook.UpdateHookURI(uri) {
+func (l logger) UpdateTelemetryURI(uri string) (err error) {
+	err = l.loggerState.telemetry.hook.UpdateHookURI(uri)
+	if err == nil {
 		telemetryConfig.URI = uri
-		return true
 	}
-	return false
+	return
 }
 
 func (l logger) GetTelemetryEnabled() bool {

--- a/logging/telemetryhook.go
+++ b/logging/telemetryhook.go
@@ -199,7 +199,7 @@ func (hook *asyncTelemetryHook) UpdateHookURI(uri string) (err error) {
 	updated := false
 
 	if hook.wrappedHook == nil {
-		return fmt.Errorf("asyncTelemetryHook has not wrappedHook")
+		return fmt.Errorf("asyncTelemetryHook.wrappedHook is nil")
 	}
 
 	tfh, ok := hook.wrappedHook.(*telemetryFilteredHook)

--- a/logging/telemetryhook.go
+++ b/logging/telemetryhook.go
@@ -170,7 +170,6 @@ func createElasticHook(cfg TelemetryConfig) (hook logrus.Hook, err error) {
 	if err != nil {
 		return nil, err
 	}
-
 	hostName := cfg.getHostName()
 	hook, err = elogrus.NewElasticHook(client, hostName, cfg.MinLogLevel, cfg.ChainID)
 

--- a/tools/network/bootstrap.go
+++ b/tools/network/bootstrap.go
@@ -36,7 +36,7 @@ func ReadFromSRV(service string, protocol string, name string, fallbackDNSResolv
 		return
 	}
 
-	_, records, sysLookupErr := net.LookupSRV(service, "tcp", name)
+	_, records, sysLookupErr := net.LookupSRV(service, protocol, name)
 	if sysLookupErr != nil {
 		var resolver Resolver
 		// try to resolve the address. If it's an dotted-numbers format, it would return that right away.
@@ -48,7 +48,7 @@ func ReadFromSRV(service string, protocol string, name string, fallbackDNSResolv
 			log.Infof("ReadFromBootstrap: Failed to resolve fallback DNS resolver address '%s': %v; falling back to default fallback resolver address", fallbackDNSResolverAddress, err2)
 		}
 
-		_, records, err = resolver.LookupSRV(context.Background(), service, "tcp", name)
+		_, records, err = resolver.LookupSRV(context.Background(), service, protocol, name)
 		if err != nil {
 			err = fmt.Errorf("ReadFromBootstrap: DNS LookupSRV failed when using system resolver(%v) as well as via %s due to %v", sysLookupErr, resolver.EffectiveResolverDNS(), err)
 			return

--- a/tools/network/telemetryURIUpdateService.go
+++ b/tools/network/telemetryURIUpdateService.go
@@ -61,7 +61,10 @@ func (t *telemetryURIUpdater) Start() {
 			endpointURL := t.lookupTelemetryURL()
 
 			if endpointURL != nil && endpointURL.String() != t.log.GetTelemetryURI() {
-				t.log.UpdateTelemetryURI(endpointURL.String())
+				err := t.log.UpdateTelemetryURI(endpointURL.String())
+				if err != nil {
+					t.log.Warnf("Unable to update telemetry URI to '%s' : %v", endpointURL.String(), err)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

We had no logging for a failed connection to the telemetry server(s). As a result, a failed telemetry connection would go silently, and no one would get notified of the issue.

This change add a warning level log entry in case we were unable to create a network connection to the telemetry server.

## Solution
From a high-level perspective, the `UpdateHookURI` function now returns an error object instead of a bool. That allows the upstream caller to log the error ( if any ) to the log file via the logger.