### PR TITLE
Fail on algod startup if logging.config file has bad permissions

### DIFF
--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -161,6 +161,10 @@ func main() {
 		if err != nil {
 			fmt.Fprintln(os.Stdout, "error loading telemetry config", err)
 		}
+		if os.IsPermission(err) {
+			fmt.Fprintf(os.Stderr, "Permission error on accessing telemetry config: %v", err)
+			os.Exit(1)
+		}
 
 		// Apply telemetry override.
 		telemetryConfig.Enable = logging.TelemetryOverride(*telemetryOverride)


### PR DESCRIPTION
* This should prevent telemetry event loses on systems with
  invalid permissions on ~/.algorand/logging.config file
* Another possible workaround is to relax default config path mask in
  **cmd/goal/commands.go:ensureCacheDir** from 700 to 744.
  This is not implemented because of possible security risk.