### PR TITLE
Add error logging for getting a cached wallet handle

### DIFF
--- a/cmd/goal/commands.go
+++ b/cmd/goal/commands.go
@@ -449,6 +449,8 @@ func getWalletHandleMaybePassword(dataDir string, walletName string, getPassword
 		return token, nil, nil
 	}
 
+	reportInfof("Failed to get cached wallet handle: %v", err)
+
 	// Assume any errors were "wrong password" errors, until we have actual
 	// API error codes
 	pw = ensurePasswordForWallet(walletName)


### PR DESCRIPTION
Needed to debug 'Couldn't read password: inappropriate ioctl for device' error message in tests
