### PR TITLE
Reduce execution time of expect tests

### DIFF
--- a/test/e2e-go/cli/goal/expect/goalCmdFlagsTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalCmdFlagsTest.exp
@@ -20,7 +20,6 @@ proc TestGoalCommandLineFlags { CMD EXPECTED_RE } {
 }
 
 if { [catch {
-    puts "Part 1: Check --validrounds and --lastvalid options combination for 'goal asset' and 'goal account"
 
     TestGoalCommandLineFlags "goal asset create --decimals 0 --validrounds 0 --creator ABC --total 100" ".*can not be zero.*"
     TestGoalCommandLineFlags "goal asset create --decimals 0 --validrounds 1 --lastvalid 1 --creator ABC --total 100" "Only one of .* can be specified"


### PR DESCRIPTION
    * CombinedOutput blocks on copying empty stderr stream from expect that
      causes at least 60 sec timeout for most of the tests
    * This implementation uses a temp time for stderr accumulation.
      In this case exec.Cmd does not run goroutines for reading child's actual stderr.
    * 655 sec (before) vs 205 sec (after)
