### PR TITLE
Avoid upgrading boost on travis Mac builds

### DIFF
--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -26,7 +26,7 @@ elif [ "${OS}" = "darwin" ]; then
     brew update
     brew tap homebrew/cask
     install_or_upgrade pkg-config
-    install_or_upgrade boost@1.71
+    install_or_upgrade boost
     install_or_upgrade jq
     install_or_upgrade libtool
     install_or_upgrade autoconf

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -26,7 +26,7 @@ elif [ "${OS}" = "darwin" ]; then
     brew update
     brew tap homebrew/cask
     install_or_upgrade pkg-config
-    install_or_upgrade boost
+    install_or_upgrade boost@1.71
     install_or_upgrade jq
     install_or_upgrade libtool
     install_or_upgrade autoconf

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -56,6 +56,12 @@ if [ "${OS}" = "linux" ]; then
         sudo apt-get update -y
         sudo apt-get -y install sqlite3
     fi
+elif [ "${OS}" = "darwin" ]; then
+    # we don't want to upgrade boost if we already have it, as it will try to update
+    # other components.
+    brew update
+    brew tap homebrew/cask
+    brew pin boost || true
 fi
 
 "${SCRIPTPATH}/../configure_dev.sh"


### PR DESCRIPTION
## Summary

Boost version has changed, causing a new python3 to be installed. While there is nothing wrong here, the python3 symbolic link was not pointing to the newly installed due to some cask installation issue.

This change pin the boost version to the one we used to have, so that we can take and figure this issue offline.
