### PR TITLE
Make gracefull exit of a node that is waiting for WaitForBlock call

### DIFF
--- a/daemon/algod/api/server/lib/common.go
+++ b/daemon/algod/api/server/lib/common.go
@@ -43,8 +43,9 @@ type Routes []Route
 // ReqContext is passed to each of the handlers below via wrapCtx, allowing
 // handlers to interact with the node
 type ReqContext struct {
-	Node *node.AlgorandFullNode
-	Log  logging.Logger
+	Node     *node.AlgorandFullNode
+	Log      logging.Logger
+	Shutdown <-chan struct{}
 }
 
 // ErrorResponse sets the specified status code (should != 200), and fills in the

--- a/daemon/algod/api/server/router.go
+++ b/daemon/algod/api/server/router.go
@@ -106,7 +106,7 @@ func registerHandlers(router *mux.Router, prefix string, routes lib.Routes, ctx 
 }
 
 // NewRouter builds and returns a new router from routes
-func NewRouter(logger logging.Logger, node *node.AlgorandFullNode, apiToken string) *mux.Router {
+func NewRouter(logger logging.Logger, node *node.AlgorandFullNode, shutdown <-chan struct{}, apiToken string) *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
 
 	// Middleware
@@ -115,7 +115,7 @@ func NewRouter(logger logging.Logger, node *node.AlgorandFullNode, apiToken stri
 	router.Use(middlewares.CORS)
 
 	// Request Context
-	ctx := lib.ReqContext{Node: node, Log: logger}
+	ctx := lib.ReqContext{Node: node, Log: logger, Shutdown: shutdown}
 
 	// Registers /debug/pprof handler under root path and under /urlAuth path
 	// to support header or url-provided token.

--- a/daemon/algod/api/server/v1/handlers/errors.go
+++ b/daemon/algod/api/server/v1/handlers/errors.go
@@ -40,5 +40,6 @@ var (
 	errNoRoundsSpecified                   = "Indexer is not enabled, firstRound and lastRound must be specified"
 	errNoTxnSpecified                      = "no transaction ID was specified"
 	errTransactionNotFound                 = "couldn't find the required transaction in the required range"
+	errServiceShuttingDown                 = "operation aborted as server is shutting down"
 	errUnknownTransactionType              = "found a transaction with an unknown type"
 )

--- a/daemon/algod/api/server/v1/handlers/handlers.go
+++ b/daemon/algod/api/server/v1/handlers/handlers.go
@@ -419,6 +419,9 @@ func WaitForBlock(ctx lib.ReqContext, w http.ResponseWriter, r *http.Request) {
 	}
 
 	select {
+	case <-ctx.Shutdown:
+		lib.ErrorResponse(w, http.StatusInternalServerError, err, errServiceShuttingDown, ctx.Log)
+		return
 	case <-time.After(1 * time.Minute):
 	case <-ctx.Node.Ledger().Wait(basics.Round(queryRound + 1)):
 	}

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -55,9 +55,7 @@ type Server struct {
 	node                 *node.AlgorandFullNode
 	metricCollector      *metrics.MetricService
 	metricServiceStarted bool
-
-	stopping deadlock.Mutex
-	stopped  bool
+	stopping             chan struct{}
 }
 
 // Initialize creates a Node instance with applicable network services
@@ -178,9 +176,11 @@ func (s *Server) Start() {
 		os.Exit(1)
 	}
 
+	s.stopping = make(chan struct{})
+
 	// use the data dir as the static file dir (for our API server), there's
 	// no need to separate the two yet. This lets us serve the swagger.json file.
-	apiHandler := apiServer.NewRouter(s.log, s.node, apiToken)
+	apiHandler := apiServer.NewRouter(s.log, s.node, s.stopping, apiToken)
 
 	addr := cfg.EndpointAddress
 	if addr == "" {
@@ -201,8 +201,6 @@ func (s *Server) Start() {
 		ReadTimeout:  time.Duration(cfg.RestReadTimeoutSeconds) * time.Second,
 		WriteTimeout: time.Duration(cfg.RestWriteTimeoutSeconds) * time.Second,
 	}
-
-	defer s.Stop()
 
 	tcpListener := listener.(*net.TCPListener)
 	errChan := make(chan error, 1)
@@ -227,30 +225,26 @@ func (s *Server) Start() {
 	c := make(chan os.Signal)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 	signal.Ignore(syscall.SIGHUP)
-	go func() {
-		sig := <-c
+
+	fmt.Printf("Node running and accepting RPC requests over HTTP on port %v. Press Ctrl-C to exit\n", addr)
+	select {
+	case err := <-errChan:
+		if err != nil {
+			s.log.Warn(err)
+		} else {
+			s.log.Info("Node exited successfully")
+		}
+		s.Stop()
+	case sig := <-c:
 		fmt.Printf("Exiting on %v\n", sig)
 		s.Stop()
 		os.Exit(0)
-	}()
-
-	fmt.Printf("Node running and accepting RPC requests over HTTP on port %v. Press Ctrl-C to exit\n", addr)
-	err = <-errChan
-	if err != nil {
-		s.log.Warn(err)
-	} else {
-		s.log.Info("Node exited successfully")
 	}
 }
 
 // Stop initiates a graceful shutdown of the node by shutting down the network server.
 func (s *Server) Stop() {
-	s.stopping.Lock()
-	defer s.stopping.Unlock()
-
-	if s.stopped {
-		return
-	}
+	close(s.stopping)
 
 	// Attempt to log a shutdown event before we exit...
 	s.log.Event(telemetryspec.ApplicationState, telemetryspec.ShutdownEvent)
@@ -275,8 +269,6 @@ func (s *Server) Stop() {
 	os.Remove(s.pidFile)
 	os.Remove(s.netFile)
 	os.Remove(s.netListenFile)
-
-	s.stopped = true
 }
 
 // OverridePhonebook is used to replace the phonebook associated with

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -244,6 +244,8 @@ func (s *Server) Start() {
 
 // Stop initiates a graceful shutdown of the node by shutting down the network server.
 func (s *Server) Stop() {
+	// close the s.stopping, which would signal the rest api router that any pending commands
+	// should be aborted.
 	close(s.stopping)
 
 	// Attempt to log a shutdown event before we exit...


### PR DESCRIPTION
## Summary

Existing code would deadlocked during shutdown if the node was waiting for a round, as we're shutting the agreement service before closing the http handler.

This change is doing the following:
1. unifying the algod Stop functionality, so that there is no "race" condition there.
2. Passing the algod shutting-down signal down to the handler context, so that we can quickly abort pending operations.


typical travis failure example:

```algod(95113) : goroutine 1 [running]:
2552algod(95113) : github.com/algorand/go-algorand/daemon/algod.setupDeadlockLogger.func1()
2553algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/daemon/algod/deadlockLogger.go:51 +0x162
2554algod(95113) : github.com/algorand/go-deadlock.lock(0xc0006081a0, 0x5534ac0, 0xc0002301e8, 0xc000122500)
2555algod(95113) : 	/Users/travis/gopath/pkg/mod/github.com/algorand/go-deadlock@v0.0.0-20181221160745-78d8cb5e2759/deadlock.go:252 +0xa99
2556algod(95113) : github.com/algorand/go-deadlock.(*Mutex).Lock(0xc0002301e8)
2557algod(95113) : 	/Users/travis/gopath/pkg/mod/github.com/algorand/go-deadlock@v0.0.0-20181221160745-78d8cb5e2759/deadlock.go:80 +0xec
2558algod(95113) : github.com/algorand/go-algorand/daemon/algod.(*Server).Stop(0xc000230100)
2559algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/daemon/algod/server.go:248 +0x62
2560algod(95113) : github.com/algorand/go-algorand/daemon/algod.(*Server).Start(0xc000230100)
2561algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/daemon/algod/server.go:244 +0xfe2
2562algod(95113) : main.main()
2563algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/cmd/algod/main.go:316 +0x1786
2564algod(95113) : goroutine 25 [syscall]:
2565algod(95113) : os/signal.signal_recv(0x5543860)
2566algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/runtime/sigqueue.go:139 +0x9f
2567algod(95113) : os/signal.loop()
2568algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/os/signal/signal_unix.go:23 +0x30
2569algod(95113) : created by os/signal.init.0
2570algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/os/signal/signal_unix.go:29 +0x4f
2571algod(95113) : goroutine 100 [sync.Cond.Wait]:
2572algod(95113) : runtime.goparkunlock(...)
2573algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/runtime/proc.go:307
2574algod(95113) : sync.runtime_notifyListWait(0xc0000a0090, 0x24)
2575algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/runtime/sema.go:510 +0xf9
2576algod(95113) : sync.(*Cond).Wait(0xc0000a0080)
2577algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/sync/cond.go:56 +0x8e
2578algod(95113) : github.com/algorand/go-algorand/ledger.(*blockQueue).syncer(0xc000122230)
2579algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/ledger/blockqueue.go:81 +0x86
2580algod(95113) : created by github.com/algorand/go-algorand/ledger.bqInit
2581algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/ledger/blockqueue.go:64 +0x2c0
2582algod(95113) : goroutine 72 [select, 3 minutes]:
2583algod(95113) : database/sql.(*DB).connectionOpener(0xc00012c840, 0x554b860, 0xc0000a1940)
2584algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:1000 +0x140
2585algod(95113) : created by database/sql.OpenDB
2586algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:670 +0x2b4
2587algod(95113) : goroutine 73 [select, 3 minutes]:
2588algod(95113) : database/sql.(*DB).connectionResetter(0xc00012c840, 0x554b860, 0xc0000a1940)
2589algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:1013 +0x161
2590algod(95113) : created by database/sql.OpenDB
2591algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:671 +0x2ea
2592algod(95113) : goroutine 74 [select, 3 minutes]:
2593algod(95113) : database/sql.(*DB).connectionOpener(0xc000110240, 0x554b860, 0xc000071340)
2594algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:1000 +0x140
2595algod(95113) : created by database/sql.OpenDB
2596algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:670 +0x2b4
2597algod(95113) : goroutine 75 [select, 3 minutes]:
2598algod(95113) : database/sql.(*DB).connectionResetter(0xc000110240, 0x554b860, 0xc000071340)
2599algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:1013 +0x161
2600algod(95113) : created by database/sql.OpenDB
2601algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:671 +0x2ea
2602algod(95113) : goroutine 76 [select, 3 minutes]:
2603algod(95113) : database/sql.(*DB).connectionOpener(0xc000110fc0, 0x554b860, 0xc000071800)
2604algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:1000 +0x140
2605algod(95113) : created by database/sql.OpenDB
2606algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:670 +0x2b4
2607algod(95113) : goroutine 77 [select, 3 minutes]:
2608algod(95113) : database/sql.(*DB).connectionResetter(0xc000110fc0, 0x554b860, 0xc000071800)
2609algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:1013 +0x161
2610algod(95113) : created by database/sql.OpenDB
2611algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:671 +0x2ea
2612algod(95113) : goroutine 78 [select, 3 minutes]:
2613algod(95113) : database/sql.(*DB).connectionOpener(0xc000111200, 0x554b860, 0xc000284380)
2614algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:1000 +0x140
2615algod(95113) : created by database/sql.OpenDB
2616algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:670 +0x2b4
2617algod(95113) : goroutine 79 [select, 3 minutes]:
2618algod(95113) : database/sql.(*DB).connectionResetter(0xc000111200, 0x554b860, 0xc000284380)
2619algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:1013 +0x161
2620algod(95113) : created by database/sql.OpenDB
2621algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:671 +0x2ea
2622algod(95113) : goroutine 86 [sync.Cond.Wait]:
2623algod(95113) : runtime.goparkunlock(...)
2624algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/runtime/proc.go:307
2625algod(95113) : sync.runtime_notifyListWait(0xc000284850, 0x24)
2626algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/runtime/sema.go:510 +0xf9
2627algod(95113) : sync.(*Cond).Wait(0xc000284840)
2628algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/sync/cond.go:56 +0x8e
2629algod(95113) : github.com/algorand/go-algorand/ledger.(*blockNotifier).worker(0xc00007fb00)
2630algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/ledger/notifier.go:51 +0x7a
2631algod(95113) : created by github.com/algorand/go-algorand/ledger.(*blockNotifier).loadFromDisk
2632algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/ledger/notifier.go:87 +0x115
2633algod(95113) : goroutine 124 [select, 3 minutes]:
2634algod(95113) : database/sql.(*DB).connectionOpener(0xc00012c900, 0x554b860, 0xc0000a1700)
2635algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:1000 +0x140
2636algod(95113) : created by database/sql.OpenDB
2637algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:670 +0x2b4
2638algod(95113) : goroutine 125 [select, 3 minutes]:
2639algod(95113) : database/sql.(*DB).connectionResetter(0xc00012c900, 0x554b860, 0xc0000a1700)
2640algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:1013 +0x161
2641algod(95113) : created by database/sql.OpenDB
2642algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:671 +0x2ea
2643algod(95113) : goroutine 152 [select, 3 minutes]:
2644algod(95113) : database/sql.(*DB).connectionOpener(0xc00012cd80, 0x554b860, 0xc0000a1d00)
2645algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:1000 +0x140
2646algod(95113) : created by database/sql.OpenDB
2647algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:670 +0x2b4
2648algod(95113) : goroutine 153 [select, 3 minutes]:
2649algod(95113) : database/sql.(*DB).connectionResetter(0xc00012cd80, 0x554b860, 0xc0000a1d00)
2650algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:1013 +0x161
2651algod(95113) : created by database/sql.OpenDB
2652algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/database/sql/sql.go:671 +0x2ea
2653algod(95113) : goroutine 209 [select]:
2654algod(95113) : net/http.(*Server).Shutdown(0x5d88fa0, 0x554b8a0, 0xc000028128, 0x0, 0x0)
2655algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/net/http/server.go:2652 +0x297
2656algod(95113) : github.com/algorand/go-algorand/daemon/algod.(*Server).Stop(0xc000230100)
2657algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/daemon/algod/server.go:260 +0x189
2658algod(95113) : github.com/algorand/go-algorand/daemon/algod.(*Server).Start.func2(0xc0006ae120, 0xc000230100)
2659algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/daemon/algod/server.go:233 +0xf7
2660algod(95113) : created by github.com/algorand/go-algorand/daemon/algod.(*Server).Start
2661algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/daemon/algod/server.go:230 +0xda6
2662algod(95113) : goroutine 4983 [select]:
2663algod(95113) : github.com/algorand/go-algorand/daemon/algod/api/server/v1/handlers.WaitForBlock(0xc000203180, 0x5565b80, 0xc00008cfe0, 0x5548060, 0xc001070020, 0xc000230400)
2664algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/daemon/algod/api/server/v1/handlers/handlers.go:421 +0x22a
2665algod(95113) : github.com/algorand/go-algorand/daemon/algod/api/server.wrapCtx.func1(0x5548060, 0xc001070020, 0xc000230400)
2666algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/daemon/algod/api/server/router.go:86 +0x76
2667algod(95113) : net/http.HandlerFunc.ServeHTTP(0xc0006807e0, 0x5548060, 0xc001070020, 0xc000230400)
2668algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/net/http/server.go:1995 +0x52
2669algod(95113) : github.com/algorand/go-algorand/daemon/algod/api/server/lib/middlewares.CORS.func1(0x5548060, 0xc001070020, 0xc000230400)
2670algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/daemon/algod/api/server/lib/middlewares/cors.go:32 +0x397
2671algod(95113) : net/http.HandlerFunc.ServeHTTP(0xc001070000, 0x5548060, 0xc001070020, 0xc000230400)
2672algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/net/http/server.go:1995 +0x52
2673algod(95113) : github.com/algorand/go-algorand/daemon/algod/api/server/lib/middlewares.Auth.func1.1(0x5548060, 0xc001070020, 0xc000230400)
2674algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/daemon/algod/api/server/lib/middlewares/auth.go:98 +0x340
2675algod(95113) : net/http.HandlerFunc.ServeHTTP(0xc001084060, 0x5548060, 0xc001070020, 0xc000230400)
2676algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/net/http/server.go:1995 +0x52
2677algod(95113) : github.com/algorand/go-algorand/daemon/algod/api/server/lib/middlewares.Logger.func1.1(0x5548620, 0xc0002661c0, 0xc000230400)
2678algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/daemon/algod/api/server/lib/middlewares/logger.go:49 +0x158
2679algod(95113) : net/http.HandlerFunc.ServeHTTP(0xc001084090, 0x5548620, 0xc0002661c0, 0xc000230400)
2680algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/net/http/server.go:1995 +0x52
2681algod(95113) : github.com/gorilla/mux.(*Router).ServeHTTP(0xc0001d60e0, 0x5548620, 0xc0002661c0, 0xc000230400)
2682algod(95113) : 	/Users/travis/gopath/pkg/mod/github.com/gorilla/mux@v1.6.2/mux.go:162 +0x180
2683algod(95113) : net/http.serverHandler.ServeHTTP(0x5d88fa0, 0x5548620, 0xc0002661c0, 0xc000230a00)
2684algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/net/http/server.go:2774 +0xc5
2685algod(95113) : net/http.(*conn).serve(0xc000124d20, 0x554b860, 0xc00061fc80)
2686algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/net/http/server.go:1878 +0x808
2687algod(95113) : created by net/http.(*Server).Serve
2688algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/net/http/server.go:2884 +0x4c5
2689algod(95113) : goroutine 11825 [semacquire]:
2690algod(95113) : sync.runtime_SemacquireMutex(0xc0002301f4, 0x900000000)
2691algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/runtime/sema.go:71 +0x3d
2692algod(95113) : sync.(*Mutex).Lock(0xc0002301f0)
2693algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/sync/mutex.go:134 +0x149
2694algod(95113) : github.com/algorand/go-deadlock.lock.func1(0xc0006081a0, 0xc00074e1e0)
2695algod(95113) : 	/Users/travis/gopath/pkg/mod/github.com/algorand/go-deadlock@v0.0.0-20181221160745-78d8cb5e2759/deadlock.go:205 +0x35
2696algod(95113) : created by github.com/algorand/go-deadlock.lock
2697algod(95113) : 	/Users/travis/gopath/pkg/mod/github.com/algorand/go-deadlock@v0.0.0-20181221160745-78d8cb5e2759/deadlock.go:204 +0x13c
2698algod(95113) : 
2699algod(95113) : 
2700algod(95113) : 
2701algod(95113) : 
2702algod(95113) : 
2703algod(95113) : 
2704algod(95113) : 
2705algod(95113) : 
2706algod(95113) : panic: (*logrus.Entry) (0x51070e0,0xc00063cb90) [recovered]
2707algod(95113) : 	
2708algod(95113) : panic: (*logrus.Entry) (0x51070e0,0xc00063cb90)
2709algod(95113) : goroutine 1 [running]:
2710algod(95113) : github.com/algorand/go-algorand/logging.logger.Panic.func1(0xc0001225a0, 0xc0000aa098)
2711algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/logging/log.go:256 +0xd8
2712algod(95113) : panic(0x51070e0, 0xc00063cb90)
2713algod(95113) : 	/Users/travis/.gimme/versions/go1.12.darwin.amd64/src/runtime/panic.go:522 +0x1b5
2714algod(95113) : github.com/sirupsen/logrus.Entry.log(0xc000122550, 0xc000235050, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc000000000, ...)
2715algod(95113) : 	/Users/travis/gopath/pkg/mod/github.com/sirupsen/logrus@v1.0.5/entry.go:112 +0x42e
2716algod(95113) : github.com/sirupsen/logrus.(*Entry).Panic(0xc00063cb40, 0xc0006086c0, 0x1, 0x1)
2717algod(95113) : 	/Users/travis/gopath/pkg/mod/github.com/sirupsen/logrus@v1.0.5/entry.go:182 +0x16a
2718algod(95113) : github.com/algorand/go-algorand/logging.logger.Panic(0xc0001225a0, 0xc0000aa098, 0xc0006086c0, 0x1, 0x1)
2719algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/logging/log.go:260 +0x174
2720algod(95113) : github.com/algorand/go-algorand/daemon/algod.setupDeadlockLogger.func1()
2721algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/daemon/algod/deadlockLogger.go:57 +0x29a
2722algod(95113) : github.com/algorand/go-deadlock.lock(0xc0006081a0, 0x5534ac0, 0xc0002301e8, 0xc000122500)
2723algod(95113) : 	/Users/travis/gopath/pkg/mod/github.com/algorand/go-deadlock@v0.0.0-20181221160745-78d8cb5e2759/deadlock.go:252 +0xa99
2724algod(95113) : github.com/algorand/go-deadlock.(*Mutex).Lock(0xc0002301e8)
2725algod(95113) : 	/Users/travis/gopath/pkg/mod/github.com/algorand/go-deadlock@v0.0.0-20181221160745-78d8cb5e2759/deadlock.go:80 +0xec
2726algod(95113) : github.com/algorand/go-algorand/daemon/algod.(*Server).Stop(0xc000230100)
2727algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/daemon/algod/server.go:248 +0x62
2728algod(95113) : github.com/algorand/go-algorand/daemon/algod.(*Server).Start(0xc000230100)
2729algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/daemon/algod/server.go:244 +0xfe2
2730algod(95113) : main.main()
2731algod(95113) : 	/Users/travis/gopath/src/github.com/algorand/go-algorand/cmd/algod/main.go:316 +0x1786```