### PR TITLE
Remove tput where not supported by terminal

### DIFF
--- a/docker/releases/build_releases.sh
+++ b/docker/releases/build_releases.sh
@@ -16,9 +16,11 @@
 #     ./build_releases.sh $name
 # done
 
-GREEN_FG=$(tput setaf 2)
-RED_FG=$(tput setaf 1)
-END_FG_COLOR=$(tput sgr0)
+if [ "${TERM}" != "" ]; then
+    GREEN_FG=$(tput setaf 2)
+    RED_FG=$(tput setaf 1)
+    END_FG_COLOR=$(tput sgr0)
+fi
 
 # Default to "mainnet".
 NAME=${1:-mainnet}

--- a/docker/releases/build_releases.sh
+++ b/docker/releases/build_releases.sh
@@ -16,11 +16,9 @@
 #     ./build_releases.sh $name
 # done
 
-if [ "${TERM}" != "" ]; then
-    GREEN_FG=$(tput setaf 2)
-    RED_FG=$(tput setaf 1)
-    END_FG_COLOR=$(tput sgr0)
-fi
+GREEN_FG=$(tput setaf 2 2>/dev/null)
+RED_FG=$(tput setaf 1 2>/dev/null)
+END_FG_COLOR=$(tput sgr0 2>/dev/null)
 
 # Default to "mainnet".
 NAME=${1:-mainnet}

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -13,11 +13,13 @@
 #
 # Examples: scripts/check_deps.sh
 
-GREEN_FG=$(tput setaf 2)
-RED_FG=$(tput setaf 1)
-TEAL_FG=$(tput setaf 6)
-YELLOW_FG=$(tput setaf 3)
-END_FG_COLOR=$(tput sgr0)
+if [ "${TERM}" != "" ]; then
+    GREEN_FG=$(tput setaf 2)
+    RED_FG=$(tput setaf 1)
+    TEAL_FG=$(tput setaf 6)
+    YELLOW_FG=$(tput setaf 3)
+    END_FG_COLOR=$(tput sgr0)
+fi
 
 GOPATH=$(go env GOPATH)
 export GOPATH

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -13,13 +13,11 @@
 #
 # Examples: scripts/check_deps.sh
 
-if [ "${TERM}" != "" ]; then
-    GREEN_FG=$(tput setaf 2)
-    RED_FG=$(tput setaf 1)
-    TEAL_FG=$(tput setaf 6)
-    YELLOW_FG=$(tput setaf 3)
-    END_FG_COLOR=$(tput sgr0)
-fi
+GREEN_FG=$(tput setaf 2 2>/dev/null)
+RED_FG=$(tput setaf 1 2>/dev/null)
+TEAL_FG=$(tput setaf 6 2>/dev/null)
+YELLOW_FG=$(tput setaf 3 2>/dev/null)
+END_FG_COLOR=$(tput sgr0 2>/dev/null)
 
 GOPATH=$(go env GOPATH)
 export GOPATH

--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -28,6 +28,14 @@ usage() {
     echo
 }
 
+if [ "${TERM}" != "" ]; then
+    GREEN_FG=$(tput setaf 2)
+    RED_FG=$(tput setaf 1)
+    TEAL_FG=$(tput setaf 6)
+    YELLOW_FG=$(tput setaf 3)
+    END_FG_COLOR=$(tput sgr0)
+fi
+
 while [ "$1" != "" ]; do
     case "$1" in
         -i)
@@ -40,7 +48,7 @@ while [ "$1" != "" ]; do
             exit 0
             ;;
         *)
-            echo "$(tput setaf 1)[ERROR]$(tput sgr0) Unknown option $1"
+            echo "${RED_FG}[ERROR]${END_FG_COLOR} Unknown option $1"
             usage
             exit 1
             ;;
@@ -67,7 +75,7 @@ do
                     echo "$FILE"
                 fi
             else
-                echo -e "\n$(tput setaf 2)$FILE$(tput sgr0)"
+                echo -e "\n${RED_FG}$FILE${END_FG_COLOR}"
                 <"$PROJECT_ROOT/$FILE" head -n "$NUMLINES"
                 echo
             fi

--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -28,13 +28,11 @@ usage() {
     echo
 }
 
-if [ "${TERM}" != "" ]; then
-    GREEN_FG=$(tput setaf 2)
-    RED_FG=$(tput setaf 1)
-    TEAL_FG=$(tput setaf 6)
-    YELLOW_FG=$(tput setaf 3)
-    END_FG_COLOR=$(tput sgr0)
-fi
+GREEN_FG=$(tput setaf 2 2>/dev/null)
+RED_FG=$(tput setaf 1 2>/dev/null)
+TEAL_FG=$(tput setaf 6 2>/dev/null)
+YELLOW_FG=$(tput setaf 3 2>/dev/null)
+END_FG_COLOR=$(tput sgr0 2>/dev/null)
 
 while [ "$1" != "" ]; do
     case "$1" in

--- a/test/packages/test_release.sh
+++ b/test/packages/test_release.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
-BLUE_FG=$(tput setaf 4)
-GREEN_FG=$(tput setaf 2)
-RED_FG=$(tput setaf 1)
-TEAL_FG=$(tput setaf 6)
-END_FG_COLOR=$(tput sgr0)
+if [ "${TERM}" != "" ]; then
+    BLUE_FG=$(tput setaf 4)
+    GREEN_FG=$(tput setaf 2)
+    RED_FG=$(tput setaf 1)
+    TEAL_FG=$(tput setaf 6)
+    END_FG_COLOR=$(tput sgr0)
+fi
 
 if [[ ! "$AWS_ACCESS_KEY_ID" || ! "$AWS_SECRET_ACCESS_KEY" ]]
 then

--- a/test/packages/test_release.sh
+++ b/test/packages/test_release.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 
-if [ "${TERM}" != "" ]; then
-    BLUE_FG=$(tput setaf 4)
-    GREEN_FG=$(tput setaf 2)
-    RED_FG=$(tput setaf 1)
-    TEAL_FG=$(tput setaf 6)
-    END_FG_COLOR=$(tput sgr0)
-fi
+GREEN_FG=$(tput setaf 2 2>/dev/null)
+RED_FG=$(tput setaf 1 2>/dev/null)
+TEAL_FG=$(tput setaf 6 2>/dev/null)
+YELLOW_FG=$(tput setaf 3 2>/dev/null)
+END_FG_COLOR=$(tput sgr0 2>/dev/null)
 
 if [[ ! "$AWS_ACCESS_KEY_ID" || ! "$AWS_SECRET_ACCESS_KEY" ]]
 then

--- a/test/packages/test_release.sh
+++ b/test/packages/test_release.sh
@@ -3,7 +3,7 @@
 GREEN_FG=$(tput setaf 2 2>/dev/null)
 RED_FG=$(tput setaf 1 2>/dev/null)
 TEAL_FG=$(tput setaf 6 2>/dev/null)
-YELLOW_FG=$(tput setaf 3 2>/dev/null)
+BLUE_FG=$(tput setaf 4 2>/dev/null)
 END_FG_COLOR=$(tput sgr0 2>/dev/null)
 
 if [[ ! "$AWS_ACCESS_KEY_ID" || ! "$AWS_SECRET_ACCESS_KEY" ]]

--- a/test/platform/test_linux_amd64_compatibility.sh
+++ b/test/platform/test_linux_amd64_compatibility.sh
@@ -3,7 +3,7 @@
 GREEN_FG=$(tput setaf 2 2>/dev/null)
 RED_FG=$(tput setaf 1 2>/dev/null)
 TEAL_FG=$(tput setaf 6 2>/dev/null)
-YELLOW_FG=$(tput setaf 3 2>/dev/null)
+BLUE_FG=$(tput setaf 4 2>/dev/null)
 END_FG_COLOR=$(tput sgr0 2>/dev/null)
 
 OS_LIST=(

--- a/test/platform/test_linux_amd64_compatibility.sh
+++ b/test/platform/test_linux_amd64_compatibility.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 
-if [ "${TERM}" != "" ]; then
-    BLUE_FG=$(tput setaf 4)
-    GREEN_FG=$(tput setaf 2)
-    RED_FG=$(tput setaf 1)
-    TEAL_FG=$(tput setaf 6)
-    END_FG_COLOR=$(tput sgr0)
-fi
+GREEN_FG=$(tput setaf 2 2>/dev/null)
+RED_FG=$(tput setaf 1 2>/dev/null)
+TEAL_FG=$(tput setaf 6 2>/dev/null)
+YELLOW_FG=$(tput setaf 3 2>/dev/null)
+END_FG_COLOR=$(tput sgr0 2>/dev/null)
 
 OS_LIST=(
     centos:7

--- a/test/platform/test_linux_amd64_compatibility.sh
+++ b/test/platform/test_linux_amd64_compatibility.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
-BLUE_FG=$(tput setaf 4)
-GREEN_FG=$(tput setaf 2)
-RED_FG=$(tput setaf 1)
-TEAL_FG=$(tput setaf 6)
-END_FG_COLOR=$(tput sgr0)
+if [ "${TERM}" != "" ]; then
+    BLUE_FG=$(tput setaf 4)
+    GREEN_FG=$(tput setaf 2)
+    RED_FG=$(tput setaf 1)
+    TEAL_FG=$(tput setaf 6)
+    END_FG_COLOR=$(tput sgr0)
+fi
 
 OS_LIST=(
     centos:7


### PR DESCRIPTION
## Solution

We were using the `tput` command to generate colors on terminal output. however, when there is no terminal attached, the `tput` command doesn't know how to format these coloring sequences.

This PR drops the error strings generated by `tput` as they have no value for us. When terminal is available, it would use the correct output. when it's not available, it will get silently ignored.