### PR TITLE
Make ARM64 build mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ stages:
 
 jobs:
   allow_failures:
-    - name: External ARM64 Build
     - name: External ARM64 Deploy
     - name: External ARM64 Integration Test
     - name: External ARM Build


### PR DESCRIPTION
## Summary

So far, we've had the ARM64 build optional.
Now that we've fixed (most) of the building issues around it, It's time to make it mandatory to make sure we don't break it by accident.