### PR TITLE
relax StartNetwork regex

### DIFF
--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -70,7 +70,7 @@ proc ::AlgorandGoal::StartNetwork { NETWORK_NAME NETWORK_TEMPLATE TEST_ALGO_DIR 
         spawn goal network create --network $NETWORK_NAME --template $NETWORK_TEMPLATE --datadir $TEST_ALGO_DIR --rootdir $TEST_ROOT_DIR
         expect {
             timeout { close; ::AlgorandGoal::Abort "Timed out creating network" }
-            "^Network [a-z-A-Z0-9_]* created under.*" { puts "Network $NETWORK_NAME created" ; close  }
+            "^Network $NETWORK_NAME created under.*" { puts "Network $NETWORK_NAME created" ; close  }
             close
         }
 
@@ -79,7 +79,7 @@ proc ::AlgorandGoal::StartNetwork { NETWORK_NAME NETWORK_TEMPLATE TEST_ALGO_DIR 
         spawn goal network start -d $TEST_ALGO_DIR -r $TEST_ROOT_DIR
         expect {
             timeout { close; ::AlgorandGoal::Abort "Timed out starting network"  }
-            "*Network started under* { puts "Network $NETWORK_NAME started"  ;close  }
+            ".*Network started under.* { puts "Network $NETWORK_NAME started"  ;close  }
             close
         }
     } EXCEPTION ] } {
@@ -93,8 +93,8 @@ proc ::AlgorandGoal::StartNetwork { NETWORK_NAME NETWORK_TEMPLATE TEST_ALGO_DIR 
         spawn goal network status -d $TEST_ALGO_DIR -r $TEST_ROOT_DIR
         expect {
             timeout { close; ::AlgorandGoal::Abort "Timed out retrieving network status"  }
-            "*Error getting status*" { close; ::AlgorandGoal::Abort "error getting network status: $expect_out(buffer)""}
-            "^Network Started under*"   { puts "Network $NETWORK_NAME status ok"; close }
+            ".*Error getting status.*" { close; ::AlgorandGoal::Abort "error getting network status: $expect_out(buffer)""}
+            "^Network Started under.*"   { puts "Network $NETWORK_NAME status ok"; close }
             close
         }
         puts "StartNetwork complete"
@@ -118,7 +118,7 @@ proc ::AlgorandGoal::StopNetwork { NETWORK_NAME TEST_ALGO_DIR TEST_ROOT_DIR } {
 	      puts "GLOBAL_NETWORK_NAME $::GLOBAL_NETWORK_NAME"
 	      exit 1
 	    }
-        "Network Stopped under*" {set NETWORK_STOP_MESSAGE $expect_out(buffer); close}
+        "Network Stopped under.*" {set NETWORK_STOP_MESSAGE $expect_out(buffer); close}
     }
     puts $NETWORK_STOP_MESSAGE
 }

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -70,7 +70,7 @@ proc ::AlgorandGoal::StartNetwork { NETWORK_NAME NETWORK_TEMPLATE TEST_ALGO_DIR 
         spawn goal network create --network $NETWORK_NAME --template $NETWORK_TEMPLATE --datadir $TEST_ALGO_DIR --rootdir $TEST_ROOT_DIR
         expect {
             timeout { close; ::AlgorandGoal::Abort "Timed out creating network" }
-            "^Network $NETWORK_NAME created under*" { puts "Network $NETWORK_NAME created" ; close  }
+            "^Network [a-z-A-Z0-9_]* created under.*" { puts "Network $NETWORK_NAME created" ; close  }
             close
         }
 


### PR DESCRIPTION
## Summary

Some of our expect testing are failing, with what seems to be a timeout.
I suspect that the network creation wasn't detected correctly, so I'll try to relax the regex:
```goal_expect_test.go:154: err running 'ledgerTest.exp': exit status 1
1858            stdout: TEST_ALGO_DIR: /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/592190654/ledgerTest/algod
1859            TEST_DATA_DIR: /Users/travis/gopath/src/github.com/algorand/go-algorand/test/testdata
1860            network create test_net_expect_1578424681
1861            spawn goal network create --network test_net_expect_1578424681 --template /Users/travis/gopath/src/github.com/algorand/go-algorand/test/testdata/nettemplates/TwoNodes50Each.json --datadir /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/592190654/ledgerTest/algod --rootdir /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/592190654/ledgerTest/algod/root
1862            Created new rootkey: /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/592190654/ledgerTest/algod/root/Wallet1.rootkey
1863            Created new partkey: /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/592190654/ledgerTest/algod/root/Wallet1.0.3000000.partkey
1864            Created new rootkey: /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/592190654/ledgerTest/algod/root/Wallet2.rootkey
1865            Created new partkey: /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/592190654/ledgerTest/algod/root/Wallet2.0.3000000.partkey
1866            https://github.com/algorandfoundation/specs/tree/4a9db6a25595c6fd097cf9cc137cc83027787eaa 100000
1867            Network test_net_expect_1578424681 created under /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/592190654/ledgerTest/algod/root
1868            Aborting with Error: Timed out creating network
1869            GLOBAL_TEST_ALGO_DIR /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/592190654/ledgerTest/algod
1870            GLOBAL_TEST_ROOT_DIR /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/592190654/ledgerTest/algod/root
1871            GLOBAL_NETWORK_NAME test_net_expect_1578424681
1872            Stopping network: test_net_expect_1578424681
1873            spawn goal network stop -d /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/592190654/ledgerTest/algod -r /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/592190654/ledgerTest/algod/root
1874            Network Stopped under /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/592190654/ledgerTest/algod/root
1875            Network Stopped under /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/592190654/ledgerTest/algod/root```