### PR TITLE
Avoid starting the Telemetry service when logging is disabled

### DIFF
--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -162,6 +162,7 @@ func main() {
 	// Enable telemetry hook in daemon to send logs to cloud
 	// If ALGOTEST env variable is set, telemetry is disabled - allows disabling telemetry for tests
 	isTest := os.Getenv("ALGOTEST") != ""
+	remoteTelemetryEnabled := false
 	if !isTest {
 		telemetryConfig, err := logging.EnsureTelemetryConfig(&dataDir, genesis.ID())
 		if err != nil {
@@ -176,6 +177,7 @@ func main() {
 
 		// Apply telemetry override.
 		telemetryConfig.Enable = logging.TelemetryOverride(*telemetryOverride)
+		remoteTelemetryEnabled = telemetryConfig.Enable
 
 		if telemetryConfig.Enable || telemetryConfig.SendToLog {
 			// If session GUID specified, use it.
@@ -271,7 +273,7 @@ func main() {
 		cfgCopy.DNSBootstrapID = telemetryDNSBootstrapID
 
 		// If the telemetry URI is not set, periodically check SRV records for new telemetry URI
-		if log.GetTelemetryURI() == "" {
+		if remoteTelemetryEnabled && log.GetTelemetryURI() == "" {
 			network.StartTelemetryURIUpdateService(time.Minute, cfg, s.Genesis.Network, log, done)
 		}
 

--- a/cmd/algoh/main.go
+++ b/cmd/algoh/main.go
@@ -301,7 +301,7 @@ func initTelemetry(genesis bookkeeping.Genesis, log logging.Logger, dataDirector
 				}
 
 				// If the telemetry URI is not set, periodically check SRV records for new telemetry URI
-				if log.GetTelemetryURI() == "" {
+				if telemetryConfig.Enable && log.GetTelemetryURI() == "" {
 					network.StartTelemetryURIUpdateService(time.Minute, cfg, genesis.Network, log, abort)
 				}
 

--- a/cmd/algoh/main.go
+++ b/cmd/algoh/main.go
@@ -301,7 +301,7 @@ func initTelemetry(genesis bookkeeping.Genesis, log logging.Logger, dataDirector
 				}
 
 				// If the telemetry URI is not set, periodically check SRV records for new telemetry URI
-				if telemetryConfig.Enable && log.GetTelemetryURI() == "" {
+				if log.GetTelemetryURI() == "" {
 					network.StartTelemetryURIUpdateService(time.Minute, cfg, genesis.Network, log, abort)
 				}
 

--- a/logging/log.go
+++ b/logging/log.go
@@ -373,6 +373,9 @@ func (l logger) EnableTelemetry(cfg TelemetryConfig) (err error) {
 }
 
 func (l logger) UpdateTelemetryURI(uri string) (err error) {
+	if l.loggerState.telemetry.hook == nil {
+		return nil
+	}
 	err = l.loggerState.telemetry.hook.UpdateHookURI(uri)
 	if err == nil {
 		telemetryConfig.URI = uri


### PR DESCRIPTION
recent logging changes missed this