### PR TITLE
Shutdown kmd when test fixture is going down

### DIFF
--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -231,6 +231,8 @@ func (f *LibGoalFixture) Start() {
 	f.failOnError(err, "make libgoal client failed: %v")
 	f.LibGoalClient = client
 	f.NC = nodecontrol.MakeNodeController(f.binDir, f.network.PrimaryDataDir())
+	algodKmdPath, _ := filepath.Abs(filepath.Join(f.PrimaryDataDir(), libgoal.DefaultKMDDataDir))
+	f.NC.SetKMDDataDir(algodKmdPath)
 	f.clientPartKeys = make(map[string][]account.Participation)
 	f.importRootKeys(&f.LibGoalClient, f.PrimaryDataDir())
 }
@@ -263,6 +265,7 @@ func (f *LibGoalFixture) Shutdown() {
 
 // ShutdownImpl implements the Fixture.ShutdownImpl method
 func (f *LibGoalFixture) ShutdownImpl(preserveData bool) {
+	f.NC.StopKMD()
 	if preserveData {
 		f.network.Stop(f.binDir)
 	} else {


### PR DESCRIPTION
## Summary

When running our e2e test, the kmd process is being created with a TTL of 60 seconds. That's pretty reasonable. Unfortunately, we never ended up killing it when the test is over.

This lead to condition where we could have many copies of kmd in memory, where some conflicts around the lock file.

Given that it's not the scope of any of the non-kmd tests, I've added the killing of the KMD to the node fixture shutdown.