### PR TITLE
Fix failing unit test TestFetchBlockTimeout

### DIFF
--- a/rpcs/fetcher_test.go
+++ b/rpcs/fetcher_test.go
@@ -322,9 +322,9 @@ func TestFetchBlockTimeout(t *testing.T) {
 		peers:           makeDummyFetchers(false, false, 10*time.Second),
 		log:             logging.TestingLog(t),
 	}
+	start := time.Now()
 	ctx, cf := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cf()
-	start := time.Now()
 	_, _, client, err := fetcher.FetchBlock(ctx, basics.Round(1))
 	end := time.Now()
 	require.True(t, strings.Contains(err.Error(), context.DeadlineExceeded.Error()))


### PR DESCRIPTION
## Summary

Unit test was not measuring the time correctly.