### PR TITLE
Update the makefile to skip the static linking when compiling on centos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,10 @@ GOTAGSLIST          := sqlite_unlock_notify sqlite_omit_load_extension
 ifeq ($(UNAME), Linux)
 EXTLDFLAGS := -static-libstdc++ -static-libgcc
 ifeq ($(ARCH), amd64)
+# the following predicate is abit misleading; it tests if we're not in centos.
+ifeq (,$(wildcard /etc/centos-release))
 EXTLDFLAGS  += -static
+endif
 GOTAGSLIST  += osusergo netgo static_build
 GOBUILDMODE := -buildmode pie
 endif


### PR DESCRIPTION
## Summary

Our build system is using Centos to compile the release binaries. 
Unfortunately, the static linking doesn't work there out of the box.
This change "undo" the static linking on the centos platform, which doesn't have the same cross-platform issue we've had when compiling using Ubuntu 18.04.