### PR TITLE
Minor: Use service-wide logger instead of logging.Base() in agreement

### DIFF
--- a/agreement/actions.go
+++ b/agreement/actions.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/logging/logspec"
 	"github.com/algorand/go-algorand/logging/telemetryspec"
 	"github.com/algorand/go-algorand/protocol"
@@ -312,7 +311,7 @@ func (a pseudonodeAction) do(ctx context.Context, s *Service) {
 		case errPseudonodeNoProposals:
 			// no participation keys, do nothing.
 		default:
-			logging.Base().Errorf("pseudonode.MakeProposals call failed %v", err)
+			s.log.Errorf("pseudonode.MakeProposals call failed %v", err)
 		}
 	case repropose:
 		logEvent := logspec.AgreementEvent{
@@ -336,7 +335,7 @@ func (a pseudonodeAction) do(ctx context.Context, s *Service) {
 			// do nothing
 		default:
 			// otherwise,
-			logging.Base().Errorf("pseudonode.MakeVotes call failed for reproposal(%v) %v", a.T, err)
+			s.log.Errorf("pseudonode.MakeVotes call failed for reproposal(%v) %v", a.T, err)
 		}
 	case attest:
 		logEvent := logspec.AgreementEvent{
@@ -360,7 +359,7 @@ func (a pseudonodeAction) do(ctx context.Context, s *Service) {
 			s.demux.prioritize(voteEvents)
 		default:
 			// otherwise,
-			logging.Base().Errorf("pseudonode.MakeVotes call failed(%v) %v", a.T, err)
+			s.log.Errorf("pseudonode.MakeVotes call failed(%v) %v", a.T, err)
 			fallthrough // just so that we would close the channel.
 		case errPseudonodeNoVotes:
 			// do nothing; we're closing the channel just to avoid leaving open channels, but it's not

--- a/agreement/actor.go
+++ b/agreement/actor.go
@@ -18,8 +18,6 @@ package agreement
 
 import (
 	"fmt"
-
-	"github.com/algorand/go-algorand/logging"
 )
 
 // An actor is a state machine which accepts events and returns sequences of actions.
@@ -89,12 +87,12 @@ func (l checkedActor) handle(r routerHandle, in event) []action {
 
 	for _, pre := range cerrpre {
 		if pre != nil {
-			logging.Base().Warnf("precondition call violation: %v", pre)
+			r.t.log.Warnf("precondition call violation: %v", pre)
 		}
 	}
 	for _, post := range cerrpost {
 		if post != nil {
-			logging.Base().Warnf("postcondition call violation: %v", post)
+			r.t.log.Warnf("postcondition call violation: %v", post)
 		}
 	}
 	//   for _, pre := range terrpre {

--- a/agreement/agreementtest/simulate.go
+++ b/agreement/agreementtest/simulate.go
@@ -189,7 +189,7 @@ func Simulate(dbname string, n basics.Round, roundDeadline time.Duration, ledger
 		Logger:         log,
 		Accessor:       accessor,
 		Clock:          stopwatch,
-		Network:        gossip.WrapNetwork(new(blackhole)),
+		Network:        gossip.WrapNetwork(new(blackhole), log),
 		Ledger:         ledger,
 		BlockFactory:   proposalFactory,
 		BlockValidator: proposalValidator,

--- a/agreement/fuzzer/fuzzer_test.go
+++ b/agreement/fuzzer/fuzzer_test.go
@@ -127,10 +127,11 @@ func (n *Fuzzer) initAgreementNode(nodeID int, filters ...NetworkFilterFactory) 
 		return false
 	}
 
+	logger := n.log.WithFields(logging.Fields{"Source": "service-" + strconv.Itoa(nodeID)})
 	n.agreementParams[nodeID] = agreement.Parameters{
-		Logger:                  n.log.WithFields(logging.Fields{"Source": "service-" + strconv.Itoa(nodeID)}),
+		Logger:                  logger,
 		Ledger:                  n.ledgers[nodeID],
-		Network:                 gossip.WrapNetwork(n.facades[nodeID]),
+		Network:                 gossip.WrapNetwork(n.facades[nodeID], logger),
 		KeyManager:              simpleKeyManager(n.accounts[nodeID : nodeID+1]),
 		BlockValidator:          n.blockValidator,
 		BlockFactory:            testBlockFactory{Owner: nodeID},
@@ -593,7 +594,7 @@ func (n *Fuzzer) CrashNode(nodeID int) {
 	n.facades[nodeID].ClearHandlers()
 	n.ledgers[nodeID].ClearNotifications()
 
-	n.agreementParams[nodeID].Network = gossip.WrapNetwork(n.facades[nodeID])
+	n.agreementParams[nodeID].Network = gossip.WrapNetwork(n.facades[nodeID], n.log)
 	n.agreements[nodeID] = agreement.MakeService(n.agreementParams[nodeID])
 
 	cadaverFilename := fmt.Sprintf("%v-%v", n.networkName, nodeID)

--- a/agreement/gossip/networkFull_test.go
+++ b/agreement/gossip/networkFull_test.go
@@ -84,7 +84,7 @@ func spinNetwork(t *testing.T, nodesCount int) ([]*networkImpl, []*messageCounte
 	networkImpls := []*networkImpl{}
 	msgCounters := []*messageCounter{}
 	for _, gossipNode := range gossipNodes {
-		networkImpl := WrapNetwork(gossipNode).(*networkImpl)
+		networkImpl := WrapNetwork(gossipNode, log).(*networkImpl)
 		networkImpls = append(networkImpls, networkImpl)
 		msgCounter := startMessageCounter(networkImpl)
 		msgCounters = append(msgCounters, msgCounter)

--- a/agreement/gossip/network_test.go
+++ b/agreement/gossip/network_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/algorand/go-deadlock"
 
+	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/protocol"
 )
@@ -323,7 +324,7 @@ func makewhiteholeNetwork(domain *whiteholeDomain) *whiteholeNetwork {
 
 func spinNetworkImpl(domain *whiteholeDomain) (whiteholeNet *whiteholeNetwork, counter *messageCounter) {
 	whiteholeNet = makewhiteholeNetwork(domain)
-	netImpl := WrapNetwork(whiteholeNet).(*networkImpl)
+	netImpl := WrapNetwork(whiteholeNet, logging.Base()).(*networkImpl)
 	counter = startMessageCounter(netImpl)
 	whiteholeNet.Start()
 	return

--- a/node/node.go
+++ b/node/node.go
@@ -237,7 +237,7 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookDir
 		Accessor:       crashAccess,
 		Clock:          timers.MakeMonotonicClock(time.Now()),
 		Local:          node.config,
-		Network:        gossip.WrapNetwork(node.net),
+		Network:        gossip.WrapNetwork(node.net, log),
 		Ledger:         agreementLedger,
 		BlockFactory:   blockFactory,
 		BlockValidator: blockValidator,
@@ -556,7 +556,7 @@ func (node *AlgorandFullNode) Status() (s StatusReport, err error) {
 	s.CatchupTime = node.syncer.SynchronizingTime()
 	s.HasSyncedSinceStartup = node.hasSyncedSinceStartup
 	s.StoppedAtUnsupportedRound = s.LastRound+1 == s.NextVersionRound && !s.NextVersionSupported
-		
+
 	return
 }
 


### PR DESCRIPTION
When I've been measuring votes processing performance I found usages of default `logging.Base()` near standard / preconfigured logger in some components of agreement service. This PR fixes it.