### PR TITLE
Mark some of the slow e2e tests as such

### DIFF
--- a/scripts/travis/run_tests.sh
+++ b/scripts/travis/run_tests.sh
@@ -6,6 +6,10 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 OS=$("${SCRIPTPATH}/../ostype.sh")
 
 if [ "${BUILD_TYPE}" = "integration" ]; then
+    # For now, disable long-running e2e tests on Travis
+    # (the ones that won't complete...)
+    SHORTTEST=-short
+    export SHORTTEST    
     ./test/scripts/run_integration_tests.sh
 elif [ "${TRAVIS_EVENT_TYPE}" = "cron" ] || [[ "${TRAVIS_BRANCH}" =~ ^rel/ ]]; then
     if [[ "${OS}" != "darwin" ]]; then

--- a/test/e2e-go/features/auction/auctionErrors_test.go
+++ b/test/e2e-go/features/auction/auctionErrors_test.go
@@ -18,9 +18,9 @@ package auction
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
-	"runtime"
 
 	"github.com/stretchr/testify/require"
 
@@ -278,6 +278,9 @@ func unpartitionNetwork(fixture *fixtures.AuctionFixture, r *require.Assertions)
 
 func TestStartAndPartitionAuctionTenUsersTenBidsEach(t *testing.T) {
 	if runtime.GOOS == "darwin" {
+		t.Skip()
+	}
+	if testing.Short() {
 		t.Skip()
 	}
 	t.Parallel()

--- a/test/e2e-go/features/auction/basicAuction_test.go
+++ b/test/e2e-go/features/auction/basicAuction_test.go
@@ -18,8 +18,8 @@ package auction
 
 import (
 	"path/filepath"
-	"testing"
 	"runtime"
+	"testing"
 
 	"github.com/stretchr/testify/require"
 
@@ -141,6 +141,9 @@ func TestStartAndEndAuctionOneUserOneBid(t *testing.T) {
 
 func TestStartAndEndAuctionOneUserTenBids(t *testing.T) {
 	if runtime.GOOS == "darwin" {
+		t.Skip()
+	}
+	if testing.Short() {
 		t.Skip()
 	}
 	t.Parallel()

--- a/test/e2e-go/features/participation/participationRewards_test.go
+++ b/test/e2e-go/features/participation/participationRewards_test.go
@@ -133,6 +133,9 @@ func TestPartkeyOnlyRewards(t *testing.T) {
 	if runtime.GOOS == "darwin" {
 		t.Skip()
 	}
+	if testing.Short() {
+		t.Skip()
+	}
 	t.Parallel()
 	r := require.New(t)
 

--- a/test/e2e-go/features/transactions/sendReceive_test.go
+++ b/test/e2e-go/features/transactions/sendReceive_test.go
@@ -19,8 +19,8 @@ package transactions
 import (
 	"math/rand"
 	"path/filepath"
-	"testing"
 	"runtime"
+	"testing"
 
 	"github.com/stretchr/testify/require"
 
@@ -42,6 +42,9 @@ func GenerateRandomBytes(n int) []byte {
 // as they send each other money many times
 func TestAccountsCanSendMoney(t *testing.T) {
 	if runtime.GOOS == "darwin" {
+		t.Skip()
+	}
+	if testing.Short() {
 		t.Skip()
 	}
 	testAccountsCanSendMoney(t, filepath.Join("nettemplates", "TwoNodes50Each.json"))

--- a/test/scripts/e2e_go_tests.sh
+++ b/test/scripts/e2e_go_tests.sh
@@ -47,13 +47,6 @@ fi
 
 cd ${SRCROOT}/test/e2e-go
 
-# For now, disable long-running e2e tests on Travis
-# (the ones that won't complete...)
-SHORTTEST=
-if [ "${TRAVIS_BRANCH}" != "" ]; then
-    SHORTTEST=-short
-fi
-
 # If one or more -t <pattern> are specified, use go test -run <pattern> for each
 
 TESTPATTERNS=()


### PR DESCRIPTION
## Summary

Some of our e2e tests are taking a long time to execute. In favor of more rapid testing, I'm marking these are slow, so that it won't get executed on PR integration tests.


```
--- PASS: TestStartAndEndAuctionOneUserTenBids (201.27s)

--- PASS: TestStartAndPartitionAuctionTenUsersTenBidsEach (236.01s)

--- PASS: TestPartkeyOnlyRewards (1433.68s)

--- PASS: TestAccountsCanSendMoney (1106.63s)
```


