### PR TITLE
Move slow test to get executed on nightly builds

### DIFF
--- a/scripts/travis/run_tests.sh
+++ b/scripts/travis/run_tests.sh
@@ -9,7 +9,7 @@ if [ "${BUILD_TYPE}" = "integration" ]; then
     # Run short tests when doing pull requests; leave the long testing for nightly runs.
     if [[ "${TRAVIS_BRANCH}" =~ ^rel/nightly ]]; then
         SHORTTEST=
-    elif
+    else
         SHORTTEST=-short
     fi
     export SHORTTEST 

--- a/scripts/travis/run_tests.sh
+++ b/scripts/travis/run_tests.sh
@@ -6,10 +6,13 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 OS=$("${SCRIPTPATH}/../ostype.sh")
 
 if [ "${BUILD_TYPE}" = "integration" ]; then
-    # For now, disable long-running e2e tests on Travis
-    # (the ones that won't complete...)
-    SHORTTEST=-short
-    export SHORTTEST    
+    # Run short tests when doing pull requests; leave the long testing for nightly runs.
+    if [[ "${TRAVIS_BRANCH}" =~ ^rel/nightly ]]; then
+        SHORTTEST=
+    elif
+        SHORTTEST=-short
+    fi
+    export SHORTTEST 
     ./test/scripts/run_integration_tests.sh
 elif [ "${TRAVIS_EVENT_TYPE}" = "cron" ] || [[ "${TRAVIS_BRANCH}" =~ ^rel/ ]]; then
     if [[ "${OS}" != "darwin" ]]; then

--- a/test/e2e-go/features/auction/auctionCancel_test.go
+++ b/test/e2e-go/features/auction/auctionCancel_test.go
@@ -18,15 +18,18 @@ package auction
 
 import (
 	"path/filepath"
-	"testing"
 	"runtime"
-	
+	"testing"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/test/framework/fixtures"
 )
 
 func TestStartAndCancelAuctionNoBids(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 	t.Parallel()
 	r := require.New(t)
 	var fixture fixtures.AuctionFixture

--- a/test/e2e-go/features/auction/auctionErrors_test.go
+++ b/test/e2e-go/features/auction/auctionErrors_test.go
@@ -28,6 +28,9 @@ import (
 )
 
 func TestInvalidDeposit(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 	if runtime.GOOS == "darwin" {
 		t.Skip()
 	}
@@ -116,6 +119,9 @@ func TestInvalidDeposit(t *testing.T) {
 }
 
 func TestNoDepositAssociatedWithBid(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 	t.Parallel()
 	r := require.New(t)
 

--- a/test/e2e-go/features/auction/basicAuction_test.go
+++ b/test/e2e-go/features/auction/basicAuction_test.go
@@ -39,6 +39,9 @@ func TestStartAndEndAuctionNoBids(t *testing.T) {
 	if runtime.GOOS == "darwin" {
 		t.Skip()
 	}
+	if testing.Short() {
+		t.Skip()
+	}
 	t.Parallel()
 	r := require.New(t)
 	var fixture fixtures.AuctionFixture
@@ -75,6 +78,9 @@ func TestStartAndEndAuctionNoBids(t *testing.T) {
 
 func TestStartAndEndAuctionOneUserOneBid(t *testing.T) {
 	if runtime.GOOS == "darwin" {
+		t.Skip()
+	}
+	if testing.Short() {
 		t.Skip()
 	}
 	t.Parallel()

--- a/test/e2e-go/features/transactions/asset_test.go
+++ b/test/e2e-go/features/transactions/asset_test.go
@@ -19,9 +19,9 @@ package transactions
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
-	"runtime"
 
 	"github.com/stretchr/testify/require"
 
@@ -185,6 +185,9 @@ func TestAssetValidRounds(t *testing.T) {
 }
 
 func TestAssetConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 	t.Parallel()
 	a := require.New(t)
 
@@ -948,6 +951,9 @@ func TestAssetCreateWaitRestartDelete(t *testing.T) {
 }
 
 func TestAssetCreateWaitBalLookbackDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 	a, fixture, client, account0 := setupTestAndNetwork(t, "TwoNodes50EachTestShorterLookback.json")
 	defer fixture.Shutdown()
 


### PR DESCRIPTION

## Summary

Move some more test to be "slow tests", and modify short test condition so that we will run
the long tests on nightly builds only.
