### PR TITLE
Disable failing e2e test

### DIFF
--- a/test/e2e-go/features/participation/onlineOfflineParticipation_test.go
+++ b/test/e2e-go/features/participation/onlineOfflineParticipation_test.go
@@ -18,7 +18,6 @@ package participation
 
 import (
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -97,12 +96,13 @@ func waitForAccountToProposeBlock(a *require.Assertions, fixture *fixtures.RestC
 }
 
 func TestNewAccountCanGoOnlineAndParticipate(t *testing.T) {
-	if runtime.GOOS == "darwin" {
+	/*if runtime.GOOS == "darwin" {
 		t.Skip()
 	}
 	if testing.Short() {
 		t.Skip()
-	}
+	}*/
+	t.Skip() // temporary disable the test since it's failing.
 
 	t.Parallel()
 	a := require.New(t)


### PR DESCRIPTION
## Solution

The TestNewAccountCanGoOnlineAndParticipate e2e test is failing, and causing our nightly build to fail. We need to take this offline so we can investigate and fix it separately.
