### PR TITLE
Generate docs for algokey.

### DIFF
--- a/cmd/algokey/main.go
+++ b/cmd/algokey/main.go
@@ -45,7 +45,7 @@ func init() {
 
 func main() {
 	// Hidden command to generate docs in a given directory
-	// goal generate-docs [path]
+	// algokey generate-docs [path]
 	if len(os.Args) == 3 && os.Args[1] == "generate-docs" {
 		err := doc.GenMarkdownTree(rootCmd, os.Args[2])
 		if err != nil {

--- a/cmd/algokey/main.go
+++ b/cmd/algokey/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
 )
 
 var rootCmd = &cobra.Command{
@@ -43,6 +44,17 @@ func init() {
 }
 
 func main() {
+	// Hidden command to generate docs in a given directory
+	// goal generate-docs [path]
+	if len(os.Args) == 3 && os.Args[1] == "generate-docs" {
+		err := doc.GenMarkdownTree(rootCmd, os.Args[2])
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
# Summary

Add generate-docs option to algokey, we need it for generating documentation markdown files.

## Test Plan

It works, I tried it!
