### PR TITLE
Update main.go

### DIFF
--- a/tools/teal/dkey/dsign/main.go
+++ b/tools/teal/dkey/dsign/main.go
@@ -62,7 +62,9 @@ func main() {
 		ddata, err := ioutil.ReadFile(os.Args[3])
 		failFast(err)
 
-		programbytes, err := logic.AssembleString(pdata)
+		programstr := fmt.Sprintf("%s", pdata)
+		
+		programbytes, err := logic.AssembleString(programstr)
 		failFast(err)
 
 		dsig := sec.Sign(logic.Msg{

--- a/tools/teal/dkey/dsign/main.go
+++ b/tools/teal/dkey/dsign/main.go
@@ -62,8 +62,11 @@ func main() {
 		ddata, err := ioutil.ReadFile(os.Args[3])
 		failFast(err)
 
+		programbytes, err := logic.AssembleString(pdata)
+		failFast(err)
+
 		dsig := sec.Sign(logic.Msg{
-			ProgramHash: crypto.HashObj(logic.Program(pdata)),
+			ProgramHash: crypto.HashObj(logic.Program(programbytes)),
 			Data:        ddata,
 		})
 

--- a/tools/teal/dkey/dsign/main.go
+++ b/tools/teal/dkey/dsign/main.go
@@ -62,7 +62,7 @@ func main() {
 		ddata, err := ioutil.ReadFile(os.Args[3])
 		failFast(err)
 
-		programstr := fmt.Sprintf("%s", pdata)
+		programstr := string(pdata)
 		
 		programbytes, err := logic.AssembleString(programstr)
 		failFast(err)


### PR DESCRIPTION
Program bytes are needed for the Sign function. It doesn't work with 4 parameters in this way since it doesn't verify when you call ed25519verify from teal. With this change, it does verify.
There is another issue I've noticed: when you pass a file as the data to sign, it is likely to have a special character in it, so the final signature includes this special character. I suggest making a string parameter version to avoid this problem.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Explain the goal of this change and what problem it is solving.

## Test Plan

How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale.

