### PR TITLE
test all `goal ... -h`

### DIFF
--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -3,7 +3,6 @@ echo "######################################################################"
 echo "  E2E Tests"
 echo "######################################################################"
 set -e
-set -x
 
 # Suppress telemetry reporting for tests
 export ALGOTEST=1
@@ -60,16 +59,7 @@ pkill -u $(whoami) -x algod || true
 ${BINDIR}/algod -v
 ${BINDIR}/goal -v
 
-# Run all `goal ... -h` commands.
-# This will make sure they work and that there are no conflicting subcommand options.
-${BINDIR}/goal helptest > ${TEMPDIR}/helptest
-if bash -x -e ${TEMPDIR}/helptest > ${TEMPDIR}/helptest.out 2>&1; then
-    # ok
-    echo "helptest ok"
-else
-    cat ${TEMPDIR}/helptest.out
-    exit 1
-fi
+./test/scripts/goal_subcommand_sanity.sh
 
 export PATH=${BINDIR}:${PATH}
 export GOPATH=$(go env GOPATH)

--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -59,7 +59,7 @@ pkill -u $(whoami) -x algod || true
 ${BINDIR}/algod -v
 ${BINDIR}/goal -v
 
-./test/scripts/goal_subcommand_sanity.sh
+./test/scripts/goal_subcommand_sanity.sh "${BINDIR}" "${TEMPDIR}"
 
 export PATH=${BINDIR}:${PATH}
 export GOPATH=$(go env GOPATH)

--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -3,6 +3,7 @@ echo "######################################################################"
 echo "  E2E Tests"
 echo "######################################################################"
 set -e
+set -x
 
 # Suppress telemetry reporting for tests
 export ALGOTEST=1
@@ -58,6 +59,17 @@ pkill -u $(whoami) -x algod || true
 # check our install
 ${BINDIR}/algod -v
 ${BINDIR}/goal -v
+
+# Run all `goal ... -h` commands.
+# This will make sure they work and that there are no conflicting subcommand options.
+${BINDIR}/goal helptest > ${TEMPDIR}/helptest
+if bash -x -e ${TEMPDIR}/helptest > ${TEMPDIR}/helptest.out 2>&1; then
+    # ok
+    echo "helptest ok"
+else
+    cat ${TEMPDIR}/helptest.out
+    exit 1
+fi
 
 export PATH=${BINDIR}:${PATH}
 export GOPATH=$(go env GOPATH)

--- a/test/scripts/goal_subcommand_sanity.sh
+++ b/test/scripts/goal_subcommand_sanity.sh
@@ -3,8 +3,8 @@ echo "goal subcommand sanity check"
 set -e
 set -x
 
-BINDIR=$0
-TEMPDIR=$1
+BINDIR=$1
+TEMPDIR=$2
 
 # Run all `goal ... -h` commands.
 # This will make sure they work and that there are no conflicting subcommand options.

--- a/test/scripts/goal_subcommand_sanity.sh
+++ b/test/scripts/goal_subcommand_sanity.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+echo "goal subcommand sanity check"
+set -e
+set -x
+
+BINDIR=$0
+TEMPDIR=$1
+
+# Run all `goal ... -h` commands.
+# This will make sure they work and that there are no conflicting subcommand options.
+${BINDIR}/goal helptest > ${TEMPDIR}/helptest
+if bash -x -e ${TEMPDIR}/helptest > ${TEMPDIR}/helptest.out 2>&1; then
+    # ok
+    echo "goal subcommands ok"
+else
+    cat ${TEMPDIR}/helptest.out
+    exit 1
+fi


### PR DESCRIPTION
ensures no conflicting subcommand options
adds less than 2 seconds to test time

tested by adding a bogus subcommand option to goal and watching test fail, then backing that out