### PR TITLE
Improve algons error logging

### DIFF
--- a/cmd/algons/dnsCmd.go
+++ b/cmd/algons/dnsCmd.go
@@ -203,7 +203,7 @@ func doAddDNS(from string, to string) (err error) {
 	} else {
 		recordType = "CNAME"
 	}
-	cloudflareDNS.SetDNSRecord(context.Background(), recordType, from, to, cloudflare.AutomaticTTL, priority, proxied)
+	err = cloudflareDNS.SetDNSRecord(context.Background(), recordType, from, to, cloudflare.AutomaticTTL, priority, proxied)
 
 	return
 }

--- a/tools/network/cloudflare/cloudflare.go
+++ b/tools/network/cloudflare/cloudflare.go
@@ -171,7 +171,10 @@ func (d *DNS) CreateDNSRecord(ctx context.Context, recordType string, name strin
 		return err
 	}
 	if parsedResponse.Success == false {
-		return fmt.Errorf("failed to create DNS record : %v", parsedResponse)
+		request, _ := createDNSRecordRequest(d.zoneID, d.authEmail, d.authKey, recordType, name, content, ttl, priority, proxied)
+		requestBody, _ := request.GetBody()
+		bodyBytes, _ := ioutil.ReadAll(requestBody)
+		return fmt.Errorf("failed to create DNS record. Request body = %s, parsed response : %#v", string(bodyBytes), parsedResponse)
 	}
 	return nil
 }
@@ -193,7 +196,10 @@ func (d *DNS) CreateSRVRecord(ctx context.Context, name string, target string, t
 		return err
 	}
 	if parsedResponse.Success == false {
-		return fmt.Errorf("failed to create SRV record : %v", parsedResponse)
+		request, _ := createSRVRecordRequest(d.zoneID, d.authEmail, d.authKey, name, service, protocol, weight, port, ttl, priority, target)
+		requestBody, _ := request.GetBody()
+		bodyBytes, _ := ioutil.ReadAll(requestBody)
+		return fmt.Errorf("failed to create SRV record. Request body = %s, parsed response : %#v", string(bodyBytes), parsedResponse)
 	}
 	return nil
 }
@@ -215,7 +221,10 @@ func (d *DNS) DeleteDNSRecord(ctx context.Context, recordID string) error {
 		return err
 	}
 	if parsedResponse.Success == false {
-		return fmt.Errorf("failed to delete DNS record : %v", parsedResponse)
+		request, _ := deleteDNSRecordRequest(d.zoneID, d.authEmail, d.authKey, recordID)
+		requestBody, _ := request.GetBody()
+		bodyBytes, _ := ioutil.ReadAll(requestBody)
+		return fmt.Errorf("failed to delete DNS record. Request body = %s, parsed response : %#v", string(bodyBytes), parsedResponse)
 	}
 	return nil
 }
@@ -295,7 +304,10 @@ func (c *Cred) GetZones(ctx context.Context) (zones []Zone, err error) {
 		return nil, err
 	}
 	if parsedResponse.Success == false {
-		return nil, fmt.Errorf("failed to retrieve zone records : %v", parsedResponse)
+		request, _ := getZonesRequest(c.authEmail, c.authKey)
+		requestBody, _ := request.GetBody()
+		bodyBytes, _ := ioutil.ReadAll(requestBody)
+		return nil, fmt.Errorf("failed to retrieve zone records. Request body = %s, parsed response : %#v", string(bodyBytes), parsedResponse)
 	}
 
 	for _, z := range parsedResponse.Result {

--- a/tools/network/cloudflare/cloudflare.go
+++ b/tools/network/cloudflare/cloudflare.go
@@ -236,9 +236,14 @@ func (d *DNS) UpdateDNSRecord(ctx context.Context, recordID string, recordType s
 	if err != nil {
 		return err
 	}
+
 	if parsedResponse.Success == false {
-		return fmt.Errorf("failed to update DNS record : %v", parsedResponse)
+		request, _ := updateDNSRecordRequest(d.zoneID, d.authEmail, d.authKey, recordType, recordID, name, content, ttl, priority, proxied)
+		requestBody, _ := request.GetBody()
+		bodyBytes, _ := ioutil.ReadAll(requestBody)
+		return fmt.Errorf("failed to update DNS record. Request body = %s, parsedResponse = %#v", string(bodyBytes), parsedResponse)
 	}
+
 	return nil
 }
 
@@ -259,7 +264,10 @@ func (d *DNS) UpdateSRVRecord(ctx context.Context, recordID string, name string,
 		return err
 	}
 	if parsedResponse.Success == false {
-		return fmt.Errorf("failed to update SRV record : %v", parsedResponse)
+		request, _ := updateSRVRecordRequest(d.zoneID, d.authEmail, d.authKey, recordID, name, service, protocol, weight, port, ttl, priority, target)
+		requestBody, _ := request.GetBody()
+		bodyBytes, _ := ioutil.ReadAll(requestBody)
+		return fmt.Errorf("failed to update SRV record. Request body = %s, parsedResponse = %#v", string(bodyBytes), parsedResponse)
 	}
 	return nil
 }


### PR DESCRIPTION
## Solution

Cloudflare seems to have some issue related to setting the ttl values. Regretfully, our algons tool doesn't provide feedback about what message was sent to the server, only that the cloudflare server has returned an error.

This change extend the textual error message to include the request body that was sent to the server, so that we can figure out if the request was valid or not.