### PR TITLE
Format numbers using number specifier

### DIFF
--- a/agreement/actions.go
+++ b/agreement/actions.go
@@ -226,7 +226,7 @@ func (a ensureAction) do(ctx context.Context, s *Service) {
 
 	if a.Payload.ve != nil {
 		logEvent.Type = logspec.RoundConcluded
-		s.log.with(logEvent).Infof("committed round %v with pre-validated block %v", a.Certificate.Round, a.Certificate.Proposal)
+		s.log.with(logEvent).Infof("committed round %d with pre-validated block %v", a.Certificate.Round, a.Certificate.Proposal)
 		s.log.EventWithDetails(telemetryspec.Agreement, telemetryspec.BlockAcceptedEvent, telemetryspec.BlockAcceptedEventDetails{
 			Address: a.Certificate.Proposal.OriginalProposer.String(),
 			Hash:    a.Certificate.Proposal.BlockDigest.String(),
@@ -237,11 +237,11 @@ func (a ensureAction) do(ctx context.Context, s *Service) {
 		block := a.Payload.Block
 		if !a.PayloadOk {
 			logEvent.Type = logspec.RoundWaiting
-			s.log.with(logEvent).Infof("round %v concluded without block for %v; waiting on ledger", a.Certificate.Round, a.Certificate.Proposal)
+			s.log.with(logEvent).Infof("round %d concluded without block for %v; waiting on ledger", a.Certificate.Round, a.Certificate.Proposal)
 			s.Ledger.EnsureDigest(a.Certificate, s.quit, s.voteVerifier)
 		} else {
 			logEvent.Type = logspec.RoundConcluded
-			s.log.with(logEvent).Infof("committed round %v with block %v", a.Certificate.Round, a.Certificate.Proposal)
+			s.log.with(logEvent).Infof("committed round %d with block %v", a.Certificate.Round, a.Certificate.Proposal)
 			s.log.EventWithDetails(telemetryspec.Agreement, telemetryspec.BlockAcceptedEvent, telemetryspec.BlockAcceptedEventDetails{
 				Address: a.Certificate.Proposal.OriginalProposer.String(),
 				Hash:    a.Certificate.Proposal.BlockDigest.String(),
@@ -252,7 +252,7 @@ func (a ensureAction) do(ctx context.Context, s *Service) {
 	}
 	logEventStart := logEvent
 	logEventStart.Type = logspec.RoundStart
-	s.log.with(logEventStart).Infof("finished round %v", a.Certificate.Round)
+	s.log.with(logEventStart).Infof("finished round %d", a.Certificate.Round)
 	s.tracer.timeR().StartRound(a.Certificate.Round + 1)
 	s.tracer.timeR().RecStep(0, propose, bottom)
 }

--- a/agreement/agreementtest/simulate.go
+++ b/agreement/agreementtest/simulate.go
@@ -218,7 +218,7 @@ func Simulate(dbname string, n basics.Round, roundDeadline time.Duration, ledger
 		select {
 		case <-ledger.Wait(r):
 		case <-deadlineCh:
-			return fmt.Errorf("agreementtest.Simulate: round %v failed to complete by the deadline (%v)", r, roundDeadline)
+			return fmt.Errorf("agreementtest.Simulate: round %d failed to complete by the deadline (%v)", r, roundDeadline)
 		}
 	}
 

--- a/agreement/agreementtest/simulate_test.go
+++ b/agreement/agreementtest/simulate_test.go
@@ -251,7 +251,7 @@ func (l *testLedger) EnsureBlock(e bookkeeping.Block, c agreement.Certificate) {
 
 	if _, ok := l.entries[e.Round()]; ok {
 		if l.entries[e.Round()].Digest() != e.Digest() {
-			err := fmt.Errorf("testLedger.EnsureBlock called with conflicting entries in round %v", e.Round())
+			err := fmt.Errorf("testLedger.EnsureBlock called with conflicting entries in round %d", e.Round())
 			panic(err)
 		}
 	}
@@ -274,7 +274,7 @@ func (l *testLedger) EnsureDigest(c agreement.Certificate, quit chan struct{}, v
 
 		if r < l.nextRound {
 			if l.entries[r].Digest() != c.Proposal.BlockDigest {
-				err := fmt.Errorf("testLedger.EnsureDigest called with conflicting entries in round %v", r)
+				err := fmt.Errorf("testLedger.EnsureDigest called with conflicting entries in round %d", r)
 				panic(err)
 			}
 			return true
@@ -291,7 +291,7 @@ func (l *testLedger) EnsureDigest(c agreement.Certificate, quit chan struct{}, v
 		return
 	case <-l.Wait(r):
 		if !consistencyCheck() {
-			err := fmt.Errorf("Wait channel fired without matching block in round %v", r)
+			err := fmt.Errorf("Wait channel fired without matching block in round %d", r)
 			panic(err)
 		}
 	}

--- a/agreement/common_test.go
+++ b/agreement/common_test.go
@@ -315,7 +315,7 @@ func (l *testLedger) EnsureBlock(e bookkeeping.Block, c Certificate) {
 
 	if _, ok := l.entries[e.Round()]; ok {
 		if l.entries[e.Round()].Digest() != e.Digest() {
-			err := fmt.Errorf("testLedger.EnsureBlock: called with conflicting entries in round %v", e.Round())
+			err := fmt.Errorf("testLedger.EnsureBlock: called with conflicting entries in round %d", e.Round())
 			panic(err)
 		}
 	}
@@ -326,7 +326,7 @@ func (l *testLedger) EnsureBlock(e bookkeeping.Block, c Certificate) {
 	if l.nextRound == e.Round() {
 		l.nextRound = e.Round() + 1
 	} else if l.nextRound < e.Round() {
-		err := fmt.Errorf("testLedger.EnsureBlock: attempted to write block in future round: %v < %v", l.nextRound, e.Round())
+		err := fmt.Errorf("testLedger.EnsureBlock: attempted to write block in future round: %d < %d", l.nextRound, e.Round())
 		panic(err)
 	}
 
@@ -341,7 +341,7 @@ func (l *testLedger) EnsureDigest(c Certificate, quit chan struct{}, verifier *A
 
 		if r < l.nextRound {
 			if l.entries[r].Digest() != c.Proposal.BlockDigest {
-				err := fmt.Errorf("testLedger.EnsureDigest called with conflicting entries in round %v", r)
+				err := fmt.Errorf("testLedger.EnsureDigest called with conflicting entries in round %d", r)
 				panic(err)
 			}
 			return true
@@ -358,7 +358,7 @@ func (l *testLedger) EnsureDigest(c Certificate, quit chan struct{}, verifier *A
 		return
 	case <-l.Wait(r):
 		if !consistencyCheck() {
-			err := fmt.Errorf("Wait channel fired without matching block in round %v", r)
+			err := fmt.Errorf("Wait channel fired without matching block in round %d", r)
 			panic(err)
 		}
 	}
@@ -383,7 +383,7 @@ type testAccountData struct {
 func makeProposalsTesting(accs testAccountData, round basics.Round, period period, factory BlockFactory, ledger Ledger) (ps []proposal, vs []vote) {
 	ve, err := factory.AssembleBlock(round, time.Now().Add(time.Minute))
 	if err != nil {
-		logging.Base().Errorf("Could not generate a proposal for round %v: %v", round, err)
+		logging.Base().Errorf("Could not generate a proposal for round %d: %v", round, err)
 		return nil, nil
 	}
 

--- a/agreement/demux.go
+++ b/agreement/demux.go
@@ -232,7 +232,7 @@ func (d *demux) next(s *Service, deadline time.Duration, fastDeadline time.Durat
 		fastDeadlineCh = s.Clock.TimeoutAt(fastDeadline)
 	}
 	if err != nil {
-		logging.Base().Errorf("could not get consensus parameters for round %v: %v", ParamsRound(currentRound), err)
+		logging.Base().Errorf("could not get consensus parameters for round %d: %v", ParamsRound(currentRound), err)
 	}
 
 	d.UpdateEventsQueue(eventQueueDemux, 0)
@@ -271,7 +271,7 @@ func (d *demux) next(s *Service, deadline time.Duration, fastDeadline time.Durat
 			Round: uint64(previousRound),
 		}
 
-		s.log.with(logEvent).Infof("agreement: round %v ended early due to concurrent write; next round is %v", previousRound, nextRound)
+		s.log.with(logEvent).Infof("agreement: round %d ended early due to concurrent write; next round is %d", previousRound, nextRound)
 		e = roundInterruptionEvent{Round: nextRound}
 		d.UpdateEventsQueue(eventQueueDemux, 1)
 		d.monitor.inc(demuxCoserviceType)

--- a/agreement/fuzzer/ledger_test.go
+++ b/agreement/fuzzer/ledger_test.go
@@ -206,7 +206,7 @@ func (l *testLedger) Seed(r basics.Round) (committee.Seed, error) {
 	defer l.mu.Unlock()
 
 	if r >= l.nextRound {
-		err := fmt.Errorf("Seed for round %v doesn't exists in ledger. Current ledger round is %v", r, l.nextRound-1)
+		err := fmt.Errorf("Seed for round %d doesn't exists in ledger. Current ledger round is %d", r, l.nextRound-1)
 		return committee.Seed{}, err
 	}
 
@@ -219,7 +219,7 @@ func (l *testLedger) LookupDigest(r basics.Round) (crypto.Digest, error) {
 	defer l.mu.Unlock()
 
 	if r >= l.nextRound {
-		err := fmt.Errorf("LookupDigest called on future round: %v >= %v! (this is probably a bug)", r, l.nextRound)
+		err := fmt.Errorf("LookupDigest called on future round: %d >= %d! (this is probably a bug)", r, l.nextRound)
 		panic(err)
 	}
 
@@ -231,7 +231,7 @@ func (l *testLedger) BalanceRecord(r basics.Round, a basics.Address) (basics.Bal
 	defer l.mu.Unlock()
 
 	if r >= l.nextRound {
-		err := fmt.Errorf("BalanceRecord called on future round: %v >= %v! (this is probably a bug)", r, l.nextRound)
+		err := fmt.Errorf("BalanceRecord called on future round: %d >= %d! (this is probably a bug)", r, l.nextRound)
 		panic(err)
 	}
 	return l.state[a], nil
@@ -242,7 +242,7 @@ func (l *testLedger) Circulation(r basics.Round) (basics.MicroAlgos, error) {
 	defer l.mu.Unlock()
 
 	if r >= l.nextRound {
-		err := fmt.Errorf("Circulation called on future round: %v >= %v! (this is probably a bug)", r, l.nextRound)
+		err := fmt.Errorf("Circulation called on future round: %d >= %d! (this is probably a bug)", r, l.nextRound)
 		panic(err)
 	}
 
@@ -263,7 +263,7 @@ func (l *testLedger) EnsureBlock(e bookkeeping.Block, c agreement.Certificate) {
 
 	if _, ok := l.entries[e.Round()]; ok {
 		if l.entries[e.Round()].Digest() != e.Digest() {
-			err := fmt.Errorf("testLedger.EnsureBlock: called with conflicting entries in round %v", e.Round())
+			err := fmt.Errorf("testLedger.EnsureBlock: called with conflicting entries in round %d", e.Round())
 			panic(err)
 		}
 	}
@@ -274,7 +274,7 @@ func (l *testLedger) EnsureBlock(e bookkeeping.Block, c agreement.Certificate) {
 	if l.nextRound == e.Round() {
 		l.nextRound = e.Round() + 1
 	} else if l.nextRound < e.Round() {
-		err := fmt.Errorf("testLedger.EnsureBlock: attempted to write block in future round: %v < %v", l.nextRound, e.Round())
+		err := fmt.Errorf("testLedger.EnsureBlock: attempted to write block in future round: %d < %d", l.nextRound, e.Round())
 		panic(err)
 	}
 
@@ -290,7 +290,7 @@ func (l *testLedger) EnsureDigest(c agreement.Certificate, quit chan struct{}, v
 
 		if r < l.nextRound {
 			if l.entries[r].Digest() != c.Proposal.BlockDigest {
-				err := fmt.Errorf("testLedger.EnsureDigest called with conflicting entries in round %v", r)
+				err := fmt.Errorf("testLedger.EnsureDigest called with conflicting entries in round %d", r)
 				panic(err)
 			}
 			return true

--- a/agreement/fuzzer/tests_test.go
+++ b/agreement/fuzzer/tests_test.go
@@ -66,7 +66,7 @@ func printResults(t *testing.T, r *RunResult) {
 		return
 	}
 	require.Truef(t, (r.PostRecoveryHighRound-r.PostRecoveryLowRound <= 1),
-		"Initial Rounds %v-%v\nPre Recovery Rounds %v-%v\nPost Recovery Rounds %v-%v",
+		"Initial Rounds %d-%d\nPre Recovery Rounds %d-%d\nPost Recovery Rounds %d-%d",
 		r.StartLowRound, r.StartHighRound,
 		r.PreRecoveryLowRound, r.PreRecoveryHighRound,
 		r.PostRecoveryLowRound, r.PostRecoveryHighRound,
@@ -79,7 +79,7 @@ func printResults(t *testing.T, r *RunResult) {
 	)
 	if r.PreRecoveryHighRound != r.PreRecoveryLowRound {
 		// network got disupted by the filters.
-		fmt.Printf("%v partitioned the network ( %v - %v ), but recovered correctly reaching round %d\n", t.Name(), r.PreRecoveryLowRound, r.PreRecoveryHighRound, r.PostRecoveryHighRound)
+		fmt.Printf("%v partitioned the network ( %d - %d ), but recovered correctly reaching round %d\n", t.Name(), r.PreRecoveryLowRound, r.PreRecoveryHighRound, r.PostRecoveryHighRound)
 	} else {
 		if r.PreRecoveryHighRound == r.StartLowRound {
 			fmt.Printf("%v stalled the network, and the network reached round %d\n", t.Name(), r.PostRecoveryHighRound)
@@ -112,7 +112,7 @@ func TestCircularNetworkTopology(t *testing.T) {
 	}
 	for i := range nodeCounts {
 		nodeCount := nodeCounts[i]
-		t.Run(fmt.Sprintf("TestCircularNetworkTopology-%v", nodeCount),
+		t.Run(fmt.Sprintf("TestCircularNetworkTopology-%d", nodeCount),
 			func(t *testing.T) {
 				nodes := nodeCount
 				topologyConfig := TopologyFilterConfig{
@@ -122,7 +122,7 @@ func TestCircularNetworkTopology(t *testing.T) {
 					topologyConfig.NodesConnection[i] = []int{(i + nodes - 1) % nodes, (i + 1) % nodes}
 				}
 				netConfig := &FuzzerConfig{
-					FuzzerName: fmt.Sprintf("circularNetworkTopology-%v", nodes),
+					FuzzerName: fmt.Sprintf("circularNetworkTopology-%d", nodes),
 					NodesCount: nodes,
 					Filters:    []NetworkFilterFactory{NetworkFilterFactory(MakeTopologyFilter(topologyConfig))},
 					LogLevel:   logging.Info,
@@ -491,7 +491,7 @@ func TestNetworkBandwidth(t *testing.T) {
 	}
 	for i := range nodeCounts {
 		nodeCount := nodeCounts[i]
-		t.Run(fmt.Sprintf("TestNetworkBandwidth-%v", nodeCount),
+		t.Run(fmt.Sprintf("TestNetworkBandwidth-%d", nodeCount),
 			func(t *testing.T) {
 				nodes := nodeCount
 				topologyConfig := TopologyFilterConfig{
@@ -518,7 +518,7 @@ func TestNetworkBandwidth(t *testing.T) {
 				}
 
 				netConfig := &FuzzerConfig{
-					FuzzerName:  fmt.Sprintf("networkBandwidth-%v", nodes),
+					FuzzerName:  fmt.Sprintf("networkBandwidth-%d", nodes),
 					NodesCount:  nodes + relayCounts,
 					OnlineNodes: onlineNodes,
 					Filters: []NetworkFilterFactory{
@@ -593,7 +593,7 @@ func TestUnstakedNetworkLinearGrowth(t *testing.T) {
 		statFilterFactory := MakeTrafficStatisticsFilterFactory(statConf)
 
 		netConfig := &FuzzerConfig{
-			FuzzerName:  fmt.Sprintf("networkUnstakedLinearGrowth-%v", nodes),
+			FuzzerName:  fmt.Sprintf("networkUnstakedLinearGrowth-%d", nodes),
 			NodesCount:  nodes + relayCount,
 			OnlineNodes: onlineNodes,
 			Filters: []NetworkFilterFactory{
@@ -704,7 +704,7 @@ func TestStakedNetworkQuadricGrowth(t *testing.T) {
 		statFilterFactory := MakeTrafficStatisticsFilterFactory(statConf)
 
 		netConfig := &FuzzerConfig{
-			FuzzerName:  fmt.Sprintf("stakedNetworkQuadricGrowth-%v", nodes),
+			FuzzerName:  fmt.Sprintf("stakedNetworkQuadricGrowth-%d", nodes),
 			NodesCount:  nodes + relayCount,
 			OnlineNodes: onlineNodes,
 			Filters: []NetworkFilterFactory{
@@ -810,7 +810,7 @@ func TestRegossipinngElimination(t *testing.T) {
 	}
 
 	netConfig := &FuzzerConfig{
-		FuzzerName:  fmt.Sprintf("networkRegossiping-baseline-%v", nodes),
+		FuzzerName:  fmt.Sprintf("networkRegossiping-baseline-%d", nodes),
 		NodesCount:  nodes + relayCounts,
 		OnlineNodes: onlineNodes,
 		Filters: []NetworkFilterFactory{
@@ -829,7 +829,7 @@ func TestRegossipinngElimination(t *testing.T) {
 	validator.Go(netConfig)
 
 	netConfig2 := &FuzzerConfig{
-		FuzzerName:  fmt.Sprintf("networkRegossiping-eliminated-regossip-%v", nodes),
+		FuzzerName:  fmt.Sprintf("networkRegossiping-eliminated-regossip-%d", nodes),
 		NodesCount:  nodes + relayCounts,
 		OnlineNodes: onlineNodes,
 		Filters: []NetworkFilterFactory{
@@ -910,7 +910,7 @@ func BenchmarkNetworkPerformance(b *testing.B) {
 		statFilterFactory := MakeTrafficStatisticsFilterFactory(statConf)
 
 		netConfig := &FuzzerConfig{
-			FuzzerName:  fmt.Sprintf("networkUnstakedLinearGrowth-%v", nodes),
+			FuzzerName:  fmt.Sprintf("networkUnstakedLinearGrowth-%d", nodes),
 			NodesCount:  nodes + relayCount,
 			OnlineNodes: onlineNodes,
 			Filters: []NetworkFilterFactory{

--- a/agreement/fuzzer/tests_test.go
+++ b/agreement/fuzzer/tests_test.go
@@ -79,12 +79,12 @@ func printResults(t *testing.T, r *RunResult) {
 	)
 	if r.PreRecoveryHighRound != r.PreRecoveryLowRound {
 		// network got disupted by the filters.
-		fmt.Printf("%v partitioned the network ( %v - %v ), but recovered correctly reaching round %v\n", t.Name(), r.PreRecoveryLowRound, r.PreRecoveryHighRound, r.PostRecoveryHighRound)
+		fmt.Printf("%v partitioned the network ( %v - %v ), but recovered correctly reaching round %d\n", t.Name(), r.PreRecoveryLowRound, r.PreRecoveryHighRound, r.PostRecoveryHighRound)
 	} else {
 		if r.PreRecoveryHighRound == r.StartLowRound {
-			fmt.Printf("%v stalled the network, and the network reached round %v\n", t.Name(), r.PostRecoveryHighRound)
+			fmt.Printf("%v stalled the network, and the network reached round %d\n", t.Name(), r.PostRecoveryHighRound)
 		} else {
-			fmt.Printf("%v did not partition the network, and the network reached round %v\n", t.Name(), r.PostRecoveryHighRound)
+			fmt.Printf("%v did not partition the network, and the network reached round %d\n", t.Name(), r.PostRecoveryHighRound)
 		}
 	}
 }*/

--- a/agreement/fuzzer/validator_test.go
+++ b/agreement/fuzzer/validator_test.go
@@ -83,12 +83,12 @@ func (v *Validator) CheckNetworkRecovery() {
 	)
 	if v.runResult.PreRecoveryHighRound != v.runResult.PreRecoveryLowRound {
 		// network got disupted by the filters.
-		fmt.Printf("%v partitioned the network ( %v - %v ), but recovered correctly reaching round %v\n", v.tb.Name(), v.runResult.PreRecoveryLowRound, v.runResult.PreRecoveryHighRound, v.runResult.PostRecoveryHighRound)
+		fmt.Printf("%v partitioned the network ( %v - %v ), but recovered correctly reaching round %d\n", v.tb.Name(), v.runResult.PreRecoveryLowRound, v.runResult.PreRecoveryHighRound, v.runResult.PostRecoveryHighRound)
 	} else {
 		if v.runResult.PreRecoveryHighRound == v.runResult.StartLowRound {
-			fmt.Printf("%v stalled the network, and the network reached round %v\n", v.tb.Name(), v.runResult.PostRecoveryHighRound)
+			fmt.Printf("%v stalled the network, and the network reached round %d\n", v.tb.Name(), v.runResult.PostRecoveryHighRound)
 		} else {
-			fmt.Printf("%v did not partition the network, and the network reached round %v\n", v.tb.Name(), v.runResult.PostRecoveryHighRound)
+			fmt.Printf("%v did not partition the network, and the network reached round %d\n", v.tb.Name(), v.runResult.PostRecoveryHighRound)
 		}
 	}
 }

--- a/agreement/fuzzer/validator_test.go
+++ b/agreement/fuzzer/validator_test.go
@@ -70,7 +70,7 @@ func (v *Validator) CheckNetworkRecovery() {
 		return
 	}
 	require.Truef(v.tb, (v.runResult.PostRecoveryHighRound-v.runResult.PostRecoveryLowRound <= 1),
-		"Initial Rounds %v-%v\nPre Recovery Rounds %v-%v\nPost Recovery Rounds %v-%v",
+		"Initial Rounds %d-%d\nPre Recovery Rounds %d-%d\nPost Recovery Rounds %d-%d",
 		v.runResult.StartLowRound, v.runResult.StartHighRound,
 		v.runResult.PreRecoveryLowRound, v.runResult.PreRecoveryHighRound,
 		v.runResult.PostRecoveryLowRound, v.runResult.PostRecoveryHighRound,
@@ -83,7 +83,7 @@ func (v *Validator) CheckNetworkRecovery() {
 	)
 	if v.runResult.PreRecoveryHighRound != v.runResult.PreRecoveryLowRound {
 		// network got disupted by the filters.
-		fmt.Printf("%v partitioned the network ( %v - %v ), but recovered correctly reaching round %d\n", v.tb.Name(), v.runResult.PreRecoveryLowRound, v.runResult.PreRecoveryHighRound, v.runResult.PostRecoveryHighRound)
+		fmt.Printf("%v partitioned the network ( %d - %d ), but recovered correctly reaching round %d\n", v.tb.Name(), v.runResult.PreRecoveryLowRound, v.runResult.PreRecoveryHighRound, v.runResult.PostRecoveryHighRound)
 	} else {
 		if v.runResult.PreRecoveryHighRound == v.runResult.StartLowRound {
 			fmt.Printf("%v stalled the network, and the network reached round %d\n", v.tb.Name(), v.runResult.PostRecoveryHighRound)

--- a/agreement/fuzzer/voteFilter_test.go
+++ b/agreement/fuzzer/voteFilter_test.go
@@ -111,7 +111,7 @@ func (n *VoteFilter) Eval(tag protocol.Tag, data []byte, direction string) bool 
 	}
 	if !included {
 		if n.config.DebugMessages {
-			fmt.Printf("VoteFilter(%s) service-%v : (%v,%v,%v) skipped. Rules (%v-%v, %v-%v, %v-%v)\n", direction, n.nodeID, uv.R.Round, uv.R.Period, uv.R.Step, n.config.IncludeMasks[0].StartRound, n.config.IncludeMasks[0].EndRound, n.config.IncludeMasks[0].StartPeriod, n.config.IncludeMasks[0].EndPeriod, n.config.IncludeMasks[0].StartStep, n.config.IncludeMasks[0].EndStep)
+			fmt.Printf("VoteFilter(%s) service-%v : (%d,%d,%d) skipped. Rules (%d-%d, %d-%d, %d-%d)\n", direction, n.nodeID, uv.R.Round, uv.R.Period, uv.R.Step, n.config.IncludeMasks[0].StartRound, n.config.IncludeMasks[0].EndRound, n.config.IncludeMasks[0].StartPeriod, n.config.IncludeMasks[0].EndPeriod, n.config.IncludeMasks[0].StartStep, n.config.IncludeMasks[0].EndStep)
 		}
 		return false
 	}
@@ -128,13 +128,13 @@ func (n *VoteFilter) Eval(tag protocol.Tag, data []byte, direction string) bool 
 
 	if excluded {
 		if n.config.DebugMessages {
-			fmt.Printf("VoteFilter(%s) service-%v : (%v,%v,%v) skipped\n", direction, n.nodeID, uv.R.Round, uv.R.Period, uv.R.Step)
+			fmt.Printf("VoteFilter(%s) service-%v : (%d,%d,%d) skipped\n", direction, n.nodeID, uv.R.Round, uv.R.Period, uv.R.Step)
 		}
 		return false
 	}
 
 	if n.config.DebugMessages {
-		fmt.Printf("VoteFilter(%s) service-%v : (%v,%v,%v) passed\n", direction, n.nodeID, uv.R.Round, uv.R.Period, uv.R.Step)
+		fmt.Printf("VoteFilter(%s) service-%v : (%d,%d,%d) passed\n", direction, n.nodeID, uv.R.Round, uv.R.Period, uv.R.Step)
 	}
 	return true
 }

--- a/agreement/proposal.go
+++ b/agreement/proposal.go
@@ -129,13 +129,13 @@ func deriveNewSeed(address basics.Address, vrf *crypto.VRFSecrets, rnd round, pe
 
 	cparams, err := ledger.ConsensusParams(ParamsRound(rnd))
 	if err != nil {
-		err = fmt.Errorf("failed to obtain consensus parameters in round %v: %v", ParamsRound(rnd), err)
+		err = fmt.Errorf("failed to obtain consensus parameters in round %d: %v", ParamsRound(rnd), err)
 		return
 	}
 	var alpha crypto.Digest
 	prevSeed, err := ledger.Seed(seedRound(rnd, cparams))
 	if err != nil {
-		reterr = fmt.Errorf("failed read seed of round %v: %v", seedRound(rnd, cparams), err)
+		reterr = fmt.Errorf("failed read seed of round %d: %v", seedRound(rnd, cparams), err)
 		return
 	}
 
@@ -162,7 +162,7 @@ func deriveNewSeed(address basics.Address, vrf *crypto.VRFSecrets, rnd round, pe
 		digrnd := rnd.SubSaturate(basics.Round(cparams.SeedLookback * cparams.SeedRefreshInterval))
 		oldDigest, err := ledger.LookupDigest(digrnd)
 		if err != nil {
-			reterr = fmt.Errorf("could not lookup old entry digest (for seed) from round %v: %v", digrnd, err)
+			reterr = fmt.Errorf("could not lookup old entry digest (for seed) from round %d: %v", digrnd, err)
 			return
 		}
 		input.History = oldDigest
@@ -176,19 +176,19 @@ func verifyNewSeed(p unauthenticatedProposal, ledger LedgerReader) error {
 	rnd := p.Round()
 	cparams, err := ledger.ConsensusParams(ParamsRound(rnd))
 	if err != nil {
-		return fmt.Errorf("failed to obtain consensus parameters in round %v: %v", ParamsRound(rnd), err)
+		return fmt.Errorf("failed to obtain consensus parameters in round %d: %v", ParamsRound(rnd), err)
 	}
 
 	balanceRound := balanceRound(rnd, cparams)
 	proposerRecord, err := ledger.BalanceRecord(balanceRound, value.OriginalProposer)
 	if err != nil {
-		return fmt.Errorf("failed to obtain balance record for address %v in round %v: %v", value.OriginalProposer, balanceRound, err)
+		return fmt.Errorf("failed to obtain balance record for address %v in round %d: %v", value.OriginalProposer, balanceRound, err)
 	}
 
 	var alpha crypto.Digest
 	prevSeed, err := ledger.Seed(seedRound(rnd, cparams))
 	if err != nil {
-		return fmt.Errorf("failed read seed of round %v: %v", seedRound(rnd, cparams), err)
+		return fmt.Errorf("failed read seed of round %d: %v", seedRound(rnd, cparams), err)
 	}
 
 	if value.OriginalPeriod == 0 {
@@ -214,7 +214,7 @@ func verifyNewSeed(p unauthenticatedProposal, ledger LedgerReader) error {
 		digrnd := rnd.SubSaturate(basics.Round(cparams.SeedLookback * cparams.SeedRefreshInterval))
 		oldDigest, err := ledger.LookupDigest(digrnd)
 		if err != nil {
-			return fmt.Errorf("could not lookup old entry digest (for seed) from round %v: %v", digrnd, err)
+			return fmt.Errorf("could not lookup old entry digest (for seed) from round %d: %v", digrnd, err)
 		}
 		input.History = oldDigest
 	}

--- a/agreement/proposalManager.go
+++ b/agreement/proposalManager.go
@@ -227,7 +227,7 @@ func (m *proposalManager) filterProposalVote(p player, r routerHandle, uv unauth
 	qe := voteFilterRequestEvent{RawVote: uv.R}
 	sawVote := r.dispatch(p, qe, proposalMachinePeriod, uv.R.Round, uv.R.Period, 0)
 	if sawVote.t() == voteFiltered {
-		return fmt.Errorf("proposalManager: filtered proposal-vote: sender %v had already sent a vote in round %v period %v", uv.R.Sender, uv.R.Round, uv.R.Period)
+		return fmt.Errorf("proposalManager: filtered proposal-vote: sender %v had already sent a vote in round %d period %d", uv.R.Sender, uv.R.Round, uv.R.Period)
 	}
 	return nil
 }
@@ -237,17 +237,17 @@ func proposalFresh(freshData freshnessData, vote unauthenticatedVote) error {
 	switch vote.R.Round {
 	case freshData.PlayerRound:
 		if freshData.PlayerPeriod != 0 && freshData.PlayerPeriod-1 > vote.R.Period {
-			return fmt.Errorf("filtered stale proposal: period %v - 1 > %v", freshData.PlayerPeriod, vote.R.Period)
+			return fmt.Errorf("filtered stale proposal: period %d - 1 > %d", freshData.PlayerPeriod, vote.R.Period)
 		}
 		if freshData.PlayerPeriod+1 < vote.R.Period {
-			return fmt.Errorf("filtered premature proposal: period %v + 1 < %v", freshData.PlayerPeriod, vote.R.Period)
+			return fmt.Errorf("filtered premature proposal: period %d + 1 < %d", freshData.PlayerPeriod, vote.R.Period)
 		}
 	case freshData.PlayerRound + 1:
 		if vote.R.Period != 0 {
-			return fmt.Errorf("filtered premature proposal from next round: period %v > 0", vote.R.Period)
+			return fmt.Errorf("filtered premature proposal from next round: period %d > 0", vote.R.Period)
 		}
 	default:
-		return fmt.Errorf("filtered proposal from bad round: p.Round=%v, vote.Round=%v", freshData.PlayerRound, vote.R.Round)
+		return fmt.Errorf("filtered proposal from bad round: p.Round=%d, vote.Round=%d", freshData.PlayerRound, vote.R.Round)
 	}
 	return nil
 }

--- a/agreement/proposalStore_test.go
+++ b/agreement/proposalStore_test.go
@@ -61,7 +61,7 @@ func TestBlockAssemblerPipeline(t *testing.T) {
 	round := player.Round
 	period := player.Period
 	testBlockFactory, err := factory.AssembleBlock(player.Round, time.Now().Add(time.Minute))
-	require.NoError(t, err, "Could not generate a proposal for round %v: %v", round, err)
+	require.NoError(t, err, "Could not generate a proposal for round %d: %v", round, err)
 
 	accountIndex := 0
 	proposal, _, _ := proposalForBlock(accounts.addresses[accountIndex], accounts.vrfs[accountIndex], testBlockFactory, period, ledger)
@@ -127,7 +127,7 @@ func TestBlockAssemblerBind(t *testing.T) {
 	player, _, accounts, factory, ledger := testSetup(0)
 
 	testBlockFactory, err := factory.AssembleBlock(player.Round, time.Now().Add(time.Minute))
-	require.NoError(t, err, "Could not generate a proposal for round %v: %v", player.Round, err)
+	require.NoError(t, err, "Could not generate a proposal for round %d: %v", player.Round, err)
 
 	accountIndex := 0
 
@@ -193,7 +193,7 @@ func TestBlockAssemblerAuthenticator(t *testing.T) {
 	player, _, accounts, factory, ledger := testSetup(0)
 
 	testBlockFactory, err := factory.AssembleBlock(player.Round, time.Now().Add(time.Minute))
-	require.NoError(t, err, "Could not generate a proposal for round %v: %v", player.Round, err)
+	require.NoError(t, err, "Could not generate a proposal for round %d: %v", player.Round, err)
 	accountIndex := 0
 	proposalPayload, _, _ := proposalForBlock(accounts.addresses[accountIndex], accounts.vrfs[accountIndex], testBlockFactory, player.Period, ledger)
 
@@ -257,7 +257,7 @@ func TestBlockAssemblerTrim(t *testing.T) {
 	player, _, accounts, factory, ledger := testSetup(0)
 
 	testBlockFactory, err := factory.AssembleBlock(player.Round, time.Now().Add(time.Minute))
-	require.NoError(t, err, "Could not generate a proposal for round %v: %v", player.Round, err)
+	require.NoError(t, err, "Could not generate a proposal for round %d: %v", player.Round, err)
 	accountIndex := 0
 	proposalPayload, _, _ := proposalForBlock(accounts.addresses[accountIndex], accounts.vrfs[accountIndex], testBlockFactory, player.Period, ledger)
 
@@ -329,7 +329,7 @@ func TestProposalStoreT(t *testing.T) {
 	player, _, accounts, factory, ledger := testSetup(0)
 
 	testBlockFactory, err := factory.AssembleBlock(player.Round, time.Now().Add(time.Minute))
-	require.NoError(t, err, "Could not generate a proposal for round %v: %v", player.Round, err)
+	require.NoError(t, err, "Could not generate a proposal for round %d: %v", player.Round, err)
 	accountIndex := 0
 	proposalPayload, proposalV, _ := proposalForBlock(accounts.addresses[accountIndex], accounts.vrfs[accountIndex], testBlockFactory, player.Period, ledger)
 
@@ -401,7 +401,7 @@ func TestProposalStoreUnderlying(t *testing.T) {
 	player, _, accounts, factory, ledger := testSetup(0)
 
 	testBlockFactory, err := factory.AssembleBlock(player.Round, time.Now().Add(time.Minute))
-	require.NoError(t, err, "Could not generate a proposal for round %v: %v", player.Round, err)
+	require.NoError(t, err, "Could not generate a proposal for round %d: %v", player.Round, err)
 	accountIndex := 0
 	proposalPayload, proposalV, _ := proposalForBlock(accounts.addresses[accountIndex], accounts.vrfs[accountIndex], testBlockFactory, player.Period, ledger)
 
@@ -463,7 +463,7 @@ func TestProposalStoreHandle(t *testing.T) {
 	proposalVoteEventBatch, proposalPayloadEventBatch, _ := generateProposalEvents(t, player, accounts, factory, ledger)
 
 	testBlockFactory, err := factory.AssembleBlock(player.Round, time.Now().Add(time.Minute))
-	require.NoError(t, err, "Could not generate a proposal for round %v: %v", player.Round, err)
+	require.NoError(t, err, "Could not generate a proposal for round %d: %v", player.Round, err)
 	accountIndex := 0
 	_, proposalV0, _ := proposalForBlock(accounts.addresses[accountIndex], accounts.vrfs[accountIndex], testBlockFactory, player.Period, ledger)
 	accountIndex++
@@ -645,7 +645,7 @@ func TestProposalStoreGetPinnedValue(t *testing.T) {
 	// create proposal Store
 	player, router, accounts, factory, ledger := testPlayerSetup()
 	testBlockFactory, err := factory.AssembleBlock(player.Round, time.Now().Add(time.Minute))
-	require.NoError(t, err, "Could not generate a proposal for round %v: %v", player.Round, err)
+	require.NoError(t, err, "Could not generate a proposal for round %d: %v", player.Round, err)
 	accountIndex := 0
 	// create a route handler for the proposal store
 	rHandle := routerHandle{

--- a/agreement/proposalTracker.go
+++ b/agreement/proposalTracker.go
@@ -208,7 +208,7 @@ type errProposalTrackerSenderDup struct {
 }
 
 func (err errProposalTrackerSenderDup) Error() string {
-	return fmt.Sprintf("proposalTracker: filtered vote: sender %v had already sent a vote in round %v period %v", err.Sender, err.Round, err.Period)
+	return fmt.Sprintf("proposalTracker: filtered vote: sender %v had already sent a vote in round %d period %d", err.Sender, err.Round, err.Period)
 
 }
 

--- a/agreement/proposal_test.go
+++ b/agreement/proposal_test.go
@@ -48,7 +48,7 @@ func testSetup(periodCount uint64) (player, rootRouter, testAccountData, testBlo
 func createProposalsTesting(accs testAccountData, round basics.Round, period period, factory BlockFactory, ledger Ledger) (ps []proposal, vs []vote) {
 	ve, err := factory.AssembleBlock(round, time.Now().Add(time.Minute))
 	if err != nil {
-		logging.Base().Errorf("Could not generate a proposal for round %v: %v", round, err)
+		logging.Base().Errorf("Could not generate a proposal for round %d: %v", round, err)
 		return nil, nil
 	}
 
@@ -119,7 +119,7 @@ func TestProposalFunctions(t *testing.T) {
 	round := player.Round
 	period := player.Period
 	ve, err := factory.AssembleBlock(player.Round, time.Now().Add(time.Minute))
-	require.NoError(t, err, "Could not generate a proposal for round %v: %v", round, err)
+	require.NoError(t, err, "Could not generate a proposal for round %d: %v", round, err)
 
 	validator := testBlockValidator{}
 
@@ -157,7 +157,7 @@ func TestProposalUnauthenticated(t *testing.T) {
 	round := player.Round
 	period := player.Period
 	testBlockFactory, err := factory.AssembleBlock(player.Round, time.Now().Add(time.Minute))
-	require.NoError(t, err, "Could not generate a proposal for round %v: %v", round, err)
+	require.NoError(t, err, "Could not generate a proposal for round %d: %v", round, err)
 
 	validator := testBlockValidator{}
 

--- a/agreement/pseudonode.go
+++ b/agreement/pseudonode.go
@@ -476,7 +476,7 @@ func (t pseudonodeProposalsTask) execute(verifier *AsyncVoteVerifier, quit chan 
 			ObjectRound:  uint64(vote.R.Round),
 			ObjectPeriod: uint64(vote.R.Period),
 		}
-		t.node.log.with(logEvent).Infof("pseudonode.makeProposals: proposal created for (%v, %v)", vote.R.Round, vote.R.Period)
+		t.node.log.with(logEvent).Infof("pseudonode.makeProposals: proposal created for (%d, %d)", vote.R.Round, vote.R.Period)
 		t.node.log.EventWithDetails(telemetryspec.Agreement, telemetryspec.BlockProposedEvent, telemetryspec.BlockProposedEventDetails{
 			Hash:    vote.R.Proposal.BlockDigest.String(),
 			Address: vote.R.Sender.String(),
@@ -484,7 +484,7 @@ func (t pseudonodeProposalsTask) execute(verifier *AsyncVoteVerifier, quit chan 
 			Period:  uint64(vote.R.Period),
 		})
 	}
-	t.node.log.Infof("pseudonode.makeProposals: %v proposals created for round %d, period %d", len(verifiedVotes), t.round, t.period)
+	t.node.log.Infof("pseudonode.makeProposals: %d proposals created for round %d, period %d", len(verifiedVotes), t.round, t.period)
 
 	for range verifiedVotes {
 		t.node.monitor.inc(pseudonodeCoserviceType)

--- a/agreement/pseudonode.go
+++ b/agreement/pseudonode.go
@@ -253,7 +253,7 @@ func (n asyncPseudonode) makeProposals(round basics.Round, period period, accoun
 	deadline := time.Now().Add(AssemblyTime)
 	ve, err := n.factory.AssembleBlock(round, deadline)
 	if err != nil {
-		n.log.Errorf("pseudonode.makeProposals: could not generate a proposal for round %v: %v", round, err)
+		n.log.Errorf("pseudonode.makeProposals: could not generate a proposal for round %d: %v", round, err)
 		return nil, nil
 	}
 
@@ -484,7 +484,7 @@ func (t pseudonodeProposalsTask) execute(verifier *AsyncVoteVerifier, quit chan 
 			Period:  uint64(vote.R.Period),
 		})
 	}
-	t.node.log.Infof("pseudonode.makeProposals: %v proposals created for round %v, period %v", len(verifiedVotes), t.round, t.period)
+	t.node.log.Infof("pseudonode.makeProposals: %v proposals created for round %d, period %d", len(verifiedVotes), t.round, t.period)
 
 	for range verifiedVotes {
 		t.node.monitor.inc(pseudonodeCoserviceType)

--- a/agreement/selector.go
+++ b/agreement/selector.go
@@ -64,19 +64,19 @@ func membership(l LedgerReader, addr basics.Address, r basics.Round, p period, s
 
 	record, err := l.BalanceRecord(balanceRound, addr)
 	if err != nil {
-		err = fmt.Errorf("Service.initializeVote (r=%v): Failed to obtain balance record for address %v in round %v: %v", r, addr, balanceRound, err)
+		err = fmt.Errorf("Service.initializeVote (r=%v): Failed to obtain balance record for address %v in round %d: %v", r, addr, balanceRound, err)
 		return
 	}
 
 	total, err := l.Circulation(balanceRound)
 	if err != nil {
-		err = fmt.Errorf("Service.initializeVote (r=%v): Failed to obtain total circulation in round %v: %v", r, balanceRound, err)
+		err = fmt.Errorf("Service.initializeVote (r=%v): Failed to obtain total circulation in round %d: %v", r, balanceRound, err)
 		return
 	}
 
 	seed, err := l.Seed(seedRound)
 	if err != nil {
-		err = fmt.Errorf("Service.initializeVote (r=%v): Failed to obtain seed in round %v: %v", r, seedRound, err)
+		err = fmt.Errorf("Service.initializeVote (r=%v): Failed to obtain seed in round %d: %v", r, seedRound, err)
 		return
 	}
 

--- a/agreement/selector.go
+++ b/agreement/selector.go
@@ -64,19 +64,19 @@ func membership(l LedgerReader, addr basics.Address, r basics.Round, p period, s
 
 	record, err := l.BalanceRecord(balanceRound, addr)
 	if err != nil {
-		err = fmt.Errorf("Service.initializeVote (r=%v): Failed to obtain balance record for address %v in round %d: %v", r, addr, balanceRound, err)
+		err = fmt.Errorf("Service.initializeVote (r=%d): Failed to obtain balance record for address %v in round %d: %v", r, addr, balanceRound, err)
 		return
 	}
 
 	total, err := l.Circulation(balanceRound)
 	if err != nil {
-		err = fmt.Errorf("Service.initializeVote (r=%v): Failed to obtain total circulation in round %d: %v", r, balanceRound, err)
+		err = fmt.Errorf("Service.initializeVote (r=%d): Failed to obtain total circulation in round %d: %v", r, balanceRound, err)
 		return
 	}
 
 	seed, err := l.Seed(seedRound)
 	if err != nil {
-		err = fmt.Errorf("Service.initializeVote (r=%v): Failed to obtain seed in round %d: %v", r, seedRound, err)
+		err = fmt.Errorf("Service.initializeVote (r=%d): Failed to obtain seed in round %d: %v", r, seedRound, err)
 		return
 	}
 

--- a/agreement/vote.go
+++ b/agreement/vote.go
@@ -100,14 +100,14 @@ func (uv unauthenticatedVote) verify(l LedgerReader) (vote, error) {
 		}
 		// The following check could apply to all steps, but it's sufficient to only check in the propose step.
 		if rv.Proposal.OriginalPeriod > rv.Period {
-			return vote{}, fmt.Errorf("unauthenticatedVote.verify: proposal-vote in period %v claims to repropose block from future period %v", rv.Period, rv.Proposal.OriginalPeriod)
+			return vote{}, fmt.Errorf("unauthenticatedVote.verify: proposal-vote in period %d claims to repropose block from future period %d", rv.Period, rv.Proposal.OriginalPeriod)
 		}
 		fallthrough
 	case soft:
 		fallthrough
 	case cert:
 		if rv.Proposal == bottom {
-			return vote{}, fmt.Errorf("unauthenticatedVote.verify: votes from step %v cannot validate bottom", rv.Step)
+			return vote{}, fmt.Errorf("unauthenticatedVote.verify: votes from step %d cannot validate bottom", rv.Step)
 		}
 	}
 
@@ -156,18 +156,18 @@ func makeVote(rv rawVote, voting crypto.OneTimeSigner, selection *crypto.VRFSecr
 		switch rv.Step {
 		case propose, soft, cert, late, redo:
 			if rv.Proposal == bottom {
-				logging.Base().Panicf("makeVote: votes from step %v cannot validate bottom", rv.Step)
+				logging.Base().Panicf("makeVote: votes from step %d cannot validate bottom", rv.Step)
 			}
 		case down:
 			if rv.Proposal != bottom {
-				logging.Base().Panicf("makeVote: votes from step %v must validate bottom", rv.Step)
+				logging.Base().Panicf("makeVote: votes from step %d must validate bottom", rv.Step)
 			}
 		}
 	} else {
 		switch rv.Step {
 		case propose, soft, cert:
 			if rv.Proposal == bottom {
-				logging.Base().Panicf("makeVote: votes from step %v cannot validate bottom", rv.Step)
+				logging.Base().Panicf("makeVote: votes from step %d cannot validate bottom", rv.Step)
 			}
 		}
 	}

--- a/agreement/voteAggregator.go
+++ b/agreement/voteAggregator.go
@@ -197,7 +197,7 @@ func (agg *voteAggregator) filterVote(proto protocol.ConsensusVersion, p player,
 	switch filterRes.t() {
 	case voteFilteredStep:
 		// we'll rebuild the filtered event later
-		return fmt.Errorf("voteAggregator: rejected vote: sender %v had already sent a vote in round %v period %v step %v", uv.R.Sender, uv.R.Round, uv.R.Period, uv.R.Step)
+		return fmt.Errorf("voteAggregator: rejected vote: sender %v had already sent a vote in round %d period %d step %d", uv.R.Sender, uv.R.Round, uv.R.Period, uv.R.Step)
 	case none:
 		return nil
 	}
@@ -234,10 +234,10 @@ func voteStepFresh(descr string, proto protocol.ConsensusVersion, mine, vote ste
 	}
 
 	if mine != 0 && mine-1 > vote {
-		return fmt.Errorf("filtered stale vote %s: step %v - 1 > %v", descr, mine, vote)
+		return fmt.Errorf("filtered stale vote %s: step %d - 1 > %d", descr, mine, vote)
 	}
 	if mine+1 < vote {
-		return fmt.Errorf("filtered premature vote %s: step %v + 1 < %v", descr, mine, vote)
+		return fmt.Errorf("filtered premature vote %s: step %d + 1 < %d", descr, mine, vote)
 	}
 
 	return nil
@@ -276,11 +276,11 @@ func voteFresh(proto protocol.ConsensusVersion, freshData freshnessData, vote un
 // bundleFresh determines whether a bundle satisfies freshness rules.
 func bundleFresh(freshData freshnessData, b unauthenticatedBundle) error {
 	if freshData.PlayerRound != b.Round {
-		return fmt.Errorf("filtered bundle from different round: round %v != %v", freshData.PlayerRound, b.Round)
+		return fmt.Errorf("filtered bundle from different round: round %d != %d", freshData.PlayerRound, b.Round)
 	}
 
 	if freshData.PlayerPeriod != 0 && freshData.PlayerPeriod-1 > b.Period {
-		return fmt.Errorf("filtered stale bundle: period %v >= %v", freshData.PlayerPeriod, b.Period)
+		return fmt.Errorf("filtered stale bundle: period %d >= %d", freshData.PlayerPeriod, b.Period)
 	}
 
 	return nil

--- a/agreement/voteTracker.go
+++ b/agreement/voteTracker.go
@@ -183,7 +183,7 @@ func (tracker *voteTracker) handle(r routerHandle, p player, e0 event) event {
 				// In order for this to be triggered, more than 75% of the vote for the given step need to vote for more than
 				// a single proposal. In that state, all the proposals become "above threshold". That's a serious issue, since
 				// it would compromise the honest node core assumption.
-				logging.Base().Panicf("too many equivocators for step %v: %v", e.Vote.R.Step, tracker.EquivocatorsCount)
+				logging.Base().Panicf("too many equivocators for step %d: %d", e.Vote.R.Step, tracker.EquivocatorsCount)
 			}
 
 			// decrease their weight from any block proposal they already

--- a/agreement/voteTrackerContract.go
+++ b/agreement/voteTrackerContract.go
@@ -61,7 +61,7 @@ func (c *voteTrackerContract) pre(p player, in0 event) (pre []error) {
 			c.Step = in.Vote.R.Step
 		} else {
 			if c.Step != in.Vote.R.Step {
-				pre = append(pre, fmt.Errorf("incoming event has step %v but expected step %v", in.Vote.R.Step, c.Step))
+				pre = append(pre, fmt.Errorf("incoming event has step %d but expected step %d", in.Vote.R.Step, c.Step))
 			}
 		}
 		return
@@ -82,15 +82,15 @@ func (c *voteTrackerContract) post(p player, in0, out0 event) (post []error) {
 		case none:
 		case softThreshold:
 			if in.Vote.R.Step != soft {
-				post = append(post, fmt.Errorf("incoming event has step %v but outgoing event has type softThreshold", in.Vote.R.Step))
+				post = append(post, fmt.Errorf("incoming event has step %d but outgoing event has type softThreshold", in.Vote.R.Step))
 			}
 		case certThreshold:
 			if in.Vote.R.Step != cert {
-				post = append(post, fmt.Errorf("incoming event has step %v but outgoing event has type certThreshold", in.Vote.R.Step))
+				post = append(post, fmt.Errorf("incoming event has step %d but outgoing event has type certThreshold", in.Vote.R.Step))
 			}
 		case nextThreshold:
 			if in.Vote.R.Step <= cert {
-				post = append(post, fmt.Errorf("incoming event has step %v but outgoing event has type nextThreshold", in.Vote.R.Step))
+				post = append(post, fmt.Errorf("incoming event has step %d but outgoing event has type nextThreshold", in.Vote.R.Step))
 			}
 		default:
 			post = append(post, fmt.Errorf("outgoing event has invalid type: %v", out0.t()))
@@ -115,10 +115,10 @@ func (c *voteTrackerContract) post(p player, in0, out0 event) (post []error) {
 
 		emptyBundle := len(out.Bundle.Votes) == 0
 		if (out.T == none) != emptyBundle {
-			post = append(post, fmt.Errorf("out.T must be none if and only if out.Bundle is empty, but out.T = %v while len(out.Bundle.Votes) = %v", out.T, len(out.Bundle.Votes)))
+			post = append(post, fmt.Errorf("out.T must be none if and only if out.Bundle is empty, but out.T = %v while len(out.Bundle.Votes) = %d", out.T, len(out.Bundle.Votes)))
 		}
 		if out.T != none && out.Proposal == bottom && out.Step < next {
-			post = append(post, fmt.Errorf("outgoing event has bottom proposal but step %v", out.Step))
+			post = append(post, fmt.Errorf("outgoing event has bottom proposal but step %d", out.Step))
 		}
 		return
 	case voteFilterRequest:


### PR DESCRIPTION
## Summary

Existing code was using `%v` to format numeric values. While that `%v` is a completely valid parameter, it could result in a recursive looping when a `fmt.Stringer` interface is being implemented on the argument.

Using `%d` eliminate this potential issue.