### PR TITLE
Faster stringer implementation for Address

### DIFF
--- a/data/basics/address.go
+++ b/data/basics/address.go
@@ -82,6 +82,7 @@ func UnmarshalChecksumAddress(address string) (Address, error) {
 func (addr Address) String() string {
 	addrWithChecksum := make([]byte, crypto.DigestSize+checksumLength)
 	copy(addrWithChecksum[:crypto.DigestSize], addr[:])
+	// calling addr.GetChecksum() here takes 20ns more than just rolling it out, so we'll just repeat that code.
 	shortAddressHash := crypto.Hash(addr[:])
 	copy(addrWithChecksum[crypto.DigestSize:], shortAddressHash[len(shortAddressHash)-checksumLength:])
 	return base32Encoder.EncodeToString(addrWithChecksum)

--- a/data/basics/address.go
+++ b/data/basics/address.go
@@ -75,11 +75,15 @@ func UnmarshalChecksumAddress(address string) (Address, error) {
 	return short, nil
 }
 
+var base32Encoder = base32.StdEncoding.WithPadding(base32.NoPadding)
+
 // String returns a string representation of Address
 func (addr Address) String() string {
-	var addrWithChecksum []byte
-	addrWithChecksum = append(addr[:], addr.GetChecksum()...)
-	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(addrWithChecksum)
+	addrWithChecksum := make([]byte, crypto.DigestSize+checksumLength)
+	copy(addrWithChecksum[:crypto.DigestSize], addr[:])
+	shortAddressHash := crypto.Hash(addr[:])
+	copy(addrWithChecksum[crypto.DigestSize:], shortAddressHash[len(shortAddressHash)-checksumLength:])
+	return base32Encoder.EncodeToString(addrWithChecksum)
 }
 
 // MarshalText returns the address string as an array of bytes

--- a/data/basics/address.go
+++ b/data/basics/address.go
@@ -33,6 +33,8 @@ const (
 	checksumLength = 4
 )
 
+var base32Encoder = base32.StdEncoding.WithPadding(base32.NoPadding)
+
 // GetChecksum returns the checksum as []byte
 // Checksum in Algorand are the last 4 bytes of the shortAddress Hash. H(Address)[28:]
 func (addr Address) GetChecksum() []byte {
@@ -48,7 +50,8 @@ func (addr Address) GetUserAddress() string {
 
 // UnmarshalChecksumAddress tries to unmarshal the checksummed address string.
 func UnmarshalChecksumAddress(address string) (Address, error) {
-	decoded, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(address)
+	decoded, err := base32Encoder.DecodeString(address)
+
 	if err != nil {
 		return Address{}, fmt.Errorf("failed to decode address %s to base 32", address)
 	}
@@ -74,8 +77,6 @@ func UnmarshalChecksumAddress(address string) (Address, error) {
 
 	return short, nil
 }
-
-var base32Encoder = base32.StdEncoding.WithPadding(base32.NoPadding)
 
 // String returns a string representation of Address
 func (addr Address) String() string {

--- a/data/basics/address_test.go
+++ b/data/basics/address_test.go
@@ -107,3 +107,18 @@ func TestAddressMarshalUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, testob, nob)
 }
+
+func BenchmarkAddressFormatting(b *testing.B) {
+	addr := "J5YDZLPOHWB5O6MVRHNFGY4JXIQAYYM6NUJWPBSYBBIXH5ENQ4Z5LTJELU"
+	uaddr, err := UnmarshalChecksumAddress(addr)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		stringed := uaddr.String()
+		if len(stringed) == 0 {
+			break
+		}
+	}
+}

--- a/data/basics/address_test.go
+++ b/data/basics/address_test.go
@@ -122,3 +122,14 @@ func BenchmarkAddressFormatting(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkUnmarshalChecksumAddress(b *testing.B) {
+	addr := "J5YDZLPOHWB5O6MVRHNFGY4JXIQAYYM6NUJWPBSYBBIXH5ENQ4Z5LTJELU"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := UnmarshalChecksumAddress(addr)
+		if err != nil {
+			break
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Just make it faster. Nothing exciting going here.

## Benchmark Plan
Address.String():  550 ns / op -> 350 ns / op
UnmarshalChecksumAddress():  1116 ns / op -> 1001 ns / op
