### PR TITLE
Change account rest model to use a map of strings for assets.

### DIFF
--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -508,7 +508,7 @@ var listCmd = &cobra.Command{
 					}
 				}
 
-				fmt.Printf("\t%20s %-8s%s (creator %s, ID %d%s%s%s%s)\n", assetDecimalsFmt(bal.Amount, assetDecimals), unitName, decimalInfo, bal.Creator, aid, assetName, assetURL, assetMetadata, frozen)
+				fmt.Printf("\t%20s %-8s%s (creator %s, ID %s%s%s%s%s)\n", assetDecimalsFmt(bal.Amount, assetDecimals), unitName, decimalInfo, bal.Creator, aid, assetName, assetURL, assetMetadata, frozen)
 			}
 		}
 	},

--- a/cmd/goal/accountsList.go
+++ b/cmd/goal/accountsList.go
@@ -227,7 +227,7 @@ func (accountList *AccountsList) outputAccount(addr string, acctInfo v1.Account,
 	if len(acctInfo.AssetParams) > 0 {
 		fmt.Printf("\t[created assets:")
 		for curid, params := range acctInfo.AssetParams {
-			fmt.Printf(" %d (%d %s)", curid, params.Total, params.UnitName)
+			fmt.Printf(" %s (%d %s)", curid, params.Total, params.UnitName)
 		}
 		fmt.Printf("]")
 	}

--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -19,6 +19,7 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -193,8 +194,13 @@ func lookupAssetID(cmd *cobra.Command, creator string, client libgoal.Client) {
 
 	nmatch := 0
 	for id, params := range response.AssetParams {
+		i, err := strconv.ParseUint(id, 10, 64)
+		if err != nil {
+			reportErrorf("Asset IDs must be integer strings.", err)
+		}
+
 		if params.UnitName == assetUnitName {
-			assetID = id
+			assetID = i
 			nmatch++
 		}
 	}
@@ -629,9 +635,9 @@ var infoAssetCmd = &cobra.Command{
 			reportErrorf(errorRequestFail, err)
 		}
 
-		res := reserve.Assets[assetID]
+		res := reserve.Assets[string(assetID)]
 
-		fmt.Printf("Asset ID:         %d\n", assetID)
+		fmt.Printf("Asset ID:         %s\n", assetID)
 		fmt.Printf("Creator:          %s\n", params.Creator)
 		fmt.Printf("Asset name:       %s\n", params.AssetName)
 		fmt.Printf("Unit name:        %s\n", params.UnitName)

--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -637,7 +637,7 @@ var infoAssetCmd = &cobra.Command{
 
 		res := reserve.Assets[string(assetID)]
 
-		fmt.Printf("Asset ID:         %s\n", assetID)
+		fmt.Printf("Asset ID:         %d\n", assetID)
 		fmt.Printf("Creator:          %s\n", params.Creator)
 		fmt.Printf("Asset name:       %s\n", params.AssetName)
 		fmt.Printf("Unit name:        %s\n", params.UnitName)

--- a/daemon/algod/api/server/v1/handlers/handlers.go
+++ b/daemon/algod/api/server/v1/handlers/handlers.go
@@ -579,9 +579,9 @@ func AccountInformation(ctx lib.ReqContext, w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	var assets map[uint64]v1.AssetHolding
+	var assets map[string]v1.AssetHolding
 	if len(record.Assets) > 0 {
-		assets = make(map[uint64]v1.AssetHolding)
+		assets = make(map[string]v1.AssetHolding)
 		for curid, holding := range record.Assets {
 			var creator string
 			creatorAddr, err := myLedger.GetAssetCreator(curid)
@@ -592,7 +592,7 @@ func AccountInformation(ctx lib.ReqContext, w http.ResponseWriter, r *http.Reque
 				// longer fetch the creator
 				creator = ""
 			}
-			assets[uint64(curid)] = v1.AssetHolding{
+			assets[string(curid)] = v1.AssetHolding{
 				Creator: creator,
 				Amount:  holding.Amount,
 				Frozen:  holding.Frozen,
@@ -600,11 +600,11 @@ func AccountInformation(ctx lib.ReqContext, w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	var thisAssetParams map[uint64]v1.AssetParams
+	var thisAssetParams map[string]v1.AssetParams
 	if len(record.AssetParams) > 0 {
-		thisAssetParams = make(map[uint64]v1.AssetParams)
+		thisAssetParams = make(map[string]v1.AssetParams)
 		for idx, params := range record.AssetParams {
-			thisAssetParams[uint64(idx)] = assetParams(addr, params)
+			thisAssetParams[string(idx)] = assetParams(addr, params)
 		}
 	}
 

--- a/daemon/algod/api/spec/v1/model.go
+++ b/daemon/algod/api/spec/v1/model.go
@@ -146,7 +146,7 @@ type Account struct {
 	// NotParticipating - indicates that the associated account is neither a delegator nor a delegate.
 	//
 	// required: true
-	Status string `json:"status"`
+	Status string `json:"statuss"`
 
 	// Participation is the participation information currently associated with the account, if any.
 	// This field is optional and may not be set even if participation information is registered.
@@ -158,13 +158,13 @@ type Account struct {
 	// AssetParams specifies the parameters of assets created by this account.
 	//
 	// required: false
-	AssetParams map[uint64]AssetParams `json:"thisassettotal,omitempty"`
+	AssetParams map[string]AssetParams `json:"thisassettotal,omitempty"`
 
 	// Assets specifies the holdings of assets by this account,
 	// indexed by the asset ID.
 	//
 	// required: false
-	Assets map[uint64]AssetHolding `json:"assets,omitempty"`
+	Assets map[string]AssetHolding `json:"assets,omitempty"`
 }
 
 // Asset specifies both the unique identifier and the parameters for an asset

--- a/daemon/algod/api/spec/v1/model.go
+++ b/daemon/algod/api/spec/v1/model.go
@@ -146,7 +146,7 @@ type Account struct {
 	// NotParticipating - indicates that the associated account is neither a delegator nor a delegate.
 	//
 	// required: true
-	Status string `json:"statuss"`
+	Status string `json:"status"`
 
 	// Participation is the participation information currently associated with the account, if any.
 	// This field is optional and may not be set even if participation information is registered.

--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -493,7 +493,7 @@ func (c *Client) MakeUnsignedAssetConfigTx(creator string, index uint64, newMana
 			return tx, err
 		}
 
-		params, ok = current.AssetParams[index]
+		params, ok = current.AssetParams[string(index)]
 		if !ok {
 			return tx, fmt.Errorf("asset ID %d not found in account %s", index, creator)
 		}

--- a/shared/pingpong/accounts.go
+++ b/shared/pingpong/accounts.go
@@ -264,7 +264,7 @@ func prepareAssets(accounts map[string]uint64, client libgoal.Client, cfg PpConf
 				return
 			}
 			if !cfg.Quiet {
-				fmt.Printf("Fund %d asset %d to account %s\n", assetAmt, k, addr)
+				fmt.Printf("Fund %d asset %d to account %s\n", assetAmt, i, addr)
 			}
 			accounts[cfg.SrcAccount] -= tx.Fee.Raw
 		}

--- a/test/commandandcontrol/cc_agent/component/pingPongComponent.go
+++ b/test/commandandcontrol/cc_agent/component/pingPongComponent.go
@@ -122,7 +122,7 @@ func (componentInstance *PingPongComponentInstance) startPingPong(cfg *pingpong.
 	log.Infof("Preparing to initialize PingPong with config: %+v\n", cfg)
 
 	var accounts map[string]uint64
-	var assetParams map[uint64]v1.AssetParams
+	var assetParams map[string]v1.AssetParams
 	var resultCfg pingpong.PpConfig
 
 	// Initialize accounts if necessary, this may take several attempts while previous transactions to settle

--- a/test/e2e-go/features/transactions/asset_test.go
+++ b/test/e2e-go/features/transactions/asset_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -270,7 +271,10 @@ func TestAssetConfig(t *testing.T) {
 	a.Equal(len(info.AssetParams), config.Consensus[protocol.ConsensusFuture].MaxAssetsPerAccount)
 	var assets []assetIDParams
 	for idx, cp := range info.AssetParams {
-		assets = append(assets, assetIDParams{idx, cp})
+		var i uint64
+		i, err = strconv.ParseUint(idx, 10, 64)
+		a.NoError(err)
+		assets = append(assets, assetIDParams{i, cp})
 		a.Equal(cp.UnitName, fmt.Sprintf("test%d", cp.Total-1))
 		a.Equal(cp.AssetName, fmt.Sprintf("testname%d", cp.Total-1))
 		a.Equal(cp.ManagerAddr, manager)
@@ -336,31 +340,31 @@ func TestAssetConfig(t *testing.T) {
 		a.Equal(cp.UnitName, fmt.Sprintf("test%d", cp.Total-1))
 		a.Equal(cp.AssetName, fmt.Sprintf("testname%d", cp.Total-1))
 
-		if idx == assets[0].idx {
+		if idx == string(assets[0].idx) {
 			a.Equal(cp.ManagerAddr, account0)
 		} else {
 			a.Equal(cp.ManagerAddr, manager)
 		}
 
-		if idx == assets[1].idx {
+		if idx == string(assets[1].idx) {
 			a.Equal(cp.ReserveAddr, account0)
-		} else if idx == assets[4].idx {
+		} else if idx == string(assets[4].idx) {
 			a.Equal(cp.ReserveAddr, "")
 		} else {
 			a.Equal(cp.ReserveAddr, reserve)
 		}
 
-		if idx == assets[2].idx {
+		if idx == string(assets[2].idx) {
 			a.Equal(cp.FreezeAddr, account0)
-		} else if idx == assets[5].idx {
+		} else if idx == string(assets[5].idx) {
 			a.Equal(cp.FreezeAddr, "")
 		} else {
 			a.Equal(cp.FreezeAddr, freeze)
 		}
 
-		if idx == assets[3].idx {
+		if idx == string(assets[3].idx) {
 			a.Equal(cp.ClawbackAddr, account0)
-		} else if idx == assets[6].idx {
+		} else if idx == string(assets[6].idx) {
 			a.Equal(cp.ClawbackAddr, "")
 		} else {
 			a.Equal(cp.ClawbackAddr, clawback)
@@ -386,9 +390,13 @@ func TestAssetConfig(t *testing.T) {
 		wh, err = client.GetUnencryptedWalletHandle()
 		a.NoError(err)
 
-		tx, err := client.MakeUnsignedAssetDestroyTx(idx)
+		var i uint64
+		i, err = strconv.ParseUint(idx, 10, 64)
+		a.NoError(err)
+		tx, err := client.MakeUnsignedAssetDestroyTx(i)
+		a.NoError(err)
 		sender := manager
-		if idx == assets[0].idx {
+		if idx == string(assets[0].idx) {
 			sender = account0
 		}
 		txid, err := helperFillSignBroadcast(client, wh, sender, tx, err)


### PR DESCRIPTION
## Summary

The `map[uint64]AssetParam` types are impossible to represent with swagger, they are most likely being serialized to `map[string]AssetParam` anyway, so this makes that more explicit.

I'm not sure what unintended side effects this may have...

This fixes #739 