### PR TITLE
Set explicit IsRelay flag in netdeploy net to cloudspec converter

### DIFF
--- a/netdeploy/remote/deployedNetwork.go
+++ b/netdeploy/remote/deployedNetwork.go
@@ -366,6 +366,7 @@ type cloudHostSpec struct {
 	OutgoingPorts  string
 	IncomingPorts  string
 	ProtectedPorts string
+	IsRelay        bool
 	Configuration  cloudHostConfiguration
 }
 
@@ -494,6 +495,7 @@ func createHostSpec(host HostConfig, template cloudHost) (hostSpec cloudHostSpec
 	hostSpec.IncomingPorts = strings.Join(portList, ",")
 	hostSpec.ProtectedPorts = "22"
 	hostSpec.OutgoingPorts = "*"
+	hostSpec.IsRelay = relayCount > 0
 
 	rootStorage := computeRootStorage(nodeCount, relayCount)
 	ssdStorage := computeSSDStorage(nodeCount, relayCount)

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -60,7 +60,7 @@ if [ $MISSING -eq 0 ]
 then
     echo "$GREEN_FG[$0]$END_FG_COLOR Required dependencies installed."
 else
-    echo -e "$RED_FG[$0]$END_FG_COLOR Required dependencies missing. Run \`${TEAL_FG}./scripts/configure-dev.sh$END_FG_COLOR\` to install."
+    echo -e "$RED_FG[$0]$END_FG_COLOR Required dependencies missing. Run \`${TEAL_FG}./scripts/configure_dev.sh$END_FG_COLOR\` to install."
     exit 1
 fi
 


### PR DESCRIPTION
* There no way to determine relay or node in a cloudspec, algonet
  uses IncomingPorts != "" heuristic to filter out relays and set host role.
  This does not work well because in additional to NetAddress out nodes
  expose APIEndpoint and MetricsURI so that IncomingPorts contains some values even for nodes.
* Having IsRelay flag would allow mostly precise separation in test scenarios
  since relays sit on dedicated hosts.
* Corresponding change for algonet is coming.

* Minor: fixed configure_dev.sh script name in check_deps.sh error message.
