### PR TITLE
Bugfix: Fix last relevant proposal period in agreement protocol.

### DIFF
--- a/THANKS.md
+++ b/THANKS.md
@@ -14,3 +14,4 @@ In no particular order:
 
 ### Bug Reports
 - Nanyan
+- xixisese

--- a/agreement/coservice.go
+++ b/agreement/coservice.go
@@ -44,8 +44,8 @@ type coserviceMonitor struct {
 }
 
 type coserviceListener interface {
-	inc(sum uint)
-	dec(sum uint)
+	inc(sum uint, state map[coserviceType]uint)
+	dec(sum uint, state map[coserviceType]uint)
 }
 
 func (m *coserviceMonitor) inc(t coserviceType) {
@@ -62,7 +62,7 @@ func (m *coserviceMonitor) inc(t coserviceType) {
 	m.c[t]++
 
 	if m.coserviceListener != nil {
-		m.coserviceListener.inc(m.sum())
+		m.coserviceListener.inc(m.sum(), m.c)
 	}
 }
 
@@ -83,7 +83,7 @@ func (m *coserviceMonitor) dec(t coserviceType) {
 	m.c[t]--
 
 	if m.coserviceListener != nil {
-		m.coserviceListener.dec(m.sum())
+		m.coserviceListener.dec(m.sum(), m.c)
 	}
 }
 

--- a/agreement/proposalStore.go
+++ b/agreement/proposalStore.go
@@ -374,7 +374,7 @@ func (store *proposalStore) lastRelevant(pv proposalValue) (p period, pinned boo
 	}
 
 	for per := range store.Relevant {
-		if per > p {
+		if per > p && store.Relevant[per] == pv {
 			p = per
 		}
 	}


### PR DESCRIPTION
When retrieving the last relevant period corresponding to a proposal-value, the
proposal store inside the agreement protocol does not properly check that the
particular period returned actually matches the passed-in proposal-value.
Instead, the proposal store returns the last period seen for *any*
proposal-value.

When the agreement state machine receives a proposal payload, the proposal store
checks whether this payload matches any proposal-value known to be relevant in
the current round.  If it does, the state machine tells the crypto verifier to
verify the new payload.

As an optimization, the proposal store in the state machine also tags the
payload with the last period in which it is relevant (and whether the matching
proposal-value is pinned).  The crypto verifier halts concurrent verification of
any payload from that period.  Separately, the proposal store does not attempt
to verify payloads more than once, caching past payloads it has pipelined.

For this optimization to be correct, the last relevant period must be correct;
otherwise, the network will permanently stall if the following occurs:

- In period p, the network observes a best proposal value of v, but it sees
  neither the payload B corresponding to v nor a threshold of soft-votes for
  B (seeing such a threshold pins B, preventing the crypto verifier from
  cancelling).

- An attacker is able to see B.

- In period p+1, the network attempts to agree on a new proposal value v'
  corresponding to the payload B'.

- After half of the network has received B' but has _not_ finished verifying it,
  the attacker sends this half the payload B.  This half will cancel
  verification of B' (since it erroneously associates B with period p+1) and
  will permanently ignore any future broadcasts of B' (which was cached in the
  proposal store).

- If the other half has already staged B', the network will stall permanently,
  since it will be unable to commit B'.

Fixes #710. Thanks to @xixisese for reporting this bug.