### PR TITLE
Implement dummy telemetry hook to safely perform operations on it

### DIFF
--- a/logging/log.go
+++ b/logging/log.go
@@ -373,9 +373,6 @@ func (l logger) EnableTelemetry(cfg TelemetryConfig) (err error) {
 }
 
 func (l logger) UpdateTelemetryURI(uri string) (err error) {
-	if l.loggerState.telemetry.hook == nil {
-		return nil
-	}
 	err = l.loggerState.telemetry.hook.UpdateHookURI(uri)
 	if err == nil {
 		telemetryConfig.URI = uri

--- a/logging/telemetry.go
+++ b/logging/telemetry.go
@@ -48,9 +48,7 @@ func EnableTelemetry(cfg TelemetryConfig, l *logger) (err error) {
 func enableTelemetryState(telemetry *telemetryState, l *logger) {
 	l.loggerState.telemetry = telemetry
 	// Hook our normal logging to send desired types to telemetry
-	if telemetry.hook != nil {
-		l.AddHook(telemetry.hook)
-	}
+	l.AddHook(telemetry.hook)
 	// Wrap current logger Output writer to capture history
 	l.setOutput(telemetry.wrapOutput(l.getOutput()))
 }
@@ -84,6 +82,8 @@ func makeTelemetryState(cfg TelemetryConfig, hookFactory hookFactory) (*telemetr
 			return nil, err
 		}
 		telemetry.hook = createAsyncHookLevels(hook, 32, 100, makeLevels(cfg.MinLogLevel))
+	} else {
+		telemetry.hook = new(dummyHook)
 	}
 	telemetry.sendToLog = cfg.SendToLog
 	return telemetry, nil
@@ -227,9 +227,7 @@ func (t *telemetryState) logTelemetry(l logger, message string, details interfac
 	if t.sendToLog {
 		entry.Info(message)
 	}
-	if t.hook != nil {
-		t.hook.Fire(entry)
-	}
+	t.hook.Fire(entry)
 }
 
 func (t *telemetryState) Close() {

--- a/logging/telemetryCommon.go
+++ b/logging/telemetryCommon.go
@@ -35,9 +35,20 @@ type TelemetryOperation struct {
 	pending        int32
 }
 
+type telemetryHook interface {
+	Fire(entry *logrus.Entry) error
+	Levels() []logrus.Level
+	Close()
+	Flush()
+	UpdateHookURI(uri string) (err error)
+
+	appendEntry(entry *logrus.Entry) bool
+	waitForEventAndReady() bool
+}
+
 type telemetryState struct {
 	history   *logBuffer
-	hook      *asyncTelemetryHook
+	hook      telemetryHook
 	sendToLog bool
 }
 
@@ -69,5 +80,8 @@ type asyncTelemetryHook struct {
 	ready         bool
 	urlUpdate     chan bool
 }
+
+// A dummy noop type to get rid of checks like telemetry.hook != nil
+type dummyHook struct{}
 
 type hookFactory func(cfg TelemetryConfig) (logrus.Hook, error)

--- a/logging/telemetryhook.go
+++ b/logging/telemetryhook.go
@@ -156,6 +156,27 @@ func (hook *asyncTelemetryHook) Flush() {
 	hook.wg.Wait()
 }
 
+func (hook *dummyHook) UpdateHookURI(uri string) (err error) {
+	return
+}
+func (hook *dummyHook) Levels() []logrus.Level {
+	return []logrus.Level{}
+}
+func (hook *dummyHook) Fire(entry *logrus.Entry) error {
+	return nil
+}
+func (hook *dummyHook) Close() {
+}
+func (hook *dummyHook) Flush() {
+}
+
+func (hook *dummyHook) appendEntry(entry *logrus.Entry) bool {
+	return true
+}
+func (hook *dummyHook) waitForEventAndReady() bool {
+	return true
+}
+
 func createElasticHook(cfg TelemetryConfig) (hook logrus.Hook, err error) {
 	// Returning an error here causes issues... need the hooks to be created even if the elastic hook fails so that
 	// things can recover later.


### PR DESCRIPTION
* The idea is have telemetry.hook always set.
  For telemetry disabled case this is a simple noop stub.
* Prevents crashes when calling hook.Close/Flush on private networks in case of errors

Testing: manual