### PR TITLE
Make goal node state change commands systemd aware

### DIFF
--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -66,6 +66,7 @@ const (
 	errorNodeRunning                 = "Node must be stopped before writing APIToken"
 	errorNodeFailGenToken            = "Cannot generate API token: %s"
 	errorNodeCreation                = "Error during node creation: %v"
+	errorNodeManagedBySystemd        = "This node is managed by systemd, you must run the following command to make your desired state change to your node:\n\nsystemctl %s algorand.service"
 	errorKill                        = "Cannot kill node: %s"
 	errorCloningNode                 = "Error cloning the node: %s"
 	infoNodeCloned                   = "Node cloned successfully to: %s"

--- a/cmd/goal/node.go
+++ b/cmd/goal/node.go
@@ -107,6 +107,10 @@ var startCmd = &cobra.Command{
 			panic(err)
 		}
 		onDataDirs(func(dataDir string) {
+			if libgoal.AlgorandDaemonSystemdManaged(dataDir) {
+				reportErrorf(errorNodeManagedBySystemd, "start")
+			}
+
 			nc := nodecontrol.MakeNodeController(binDir, dataDir)
 			nodeArgs := nodecontrol.AlgodStartArgs{
 				PeerAddress:       peerDial,
@@ -153,6 +157,10 @@ var stopCmd = &cobra.Command{
 			panic(err)
 		}
 		onDataDirs(func(dataDir string) {
+			if libgoal.AlgorandDaemonSystemdManaged(dataDir) {
+				reportErrorf(errorNodeManagedBySystemd, "stop")
+			}
+
 			nc := nodecontrol.MakeNodeController(binDir, dataDir)
 
 			log.Info(infoTryingToStopNode)
@@ -177,6 +185,10 @@ var restartCmd = &cobra.Command{
 			panic(err)
 		}
 		onDataDirs(func(dataDir string) {
+			if libgoal.AlgorandDaemonSystemdManaged(dataDir) {
+				reportErrorf(errorNodeManagedBySystemd, "restart")
+			}
+
 			nc := nodecontrol.MakeNodeController(binDir, dataDir)
 
 			_, err = nc.GetAlgodPID()

--- a/installer/system.json
+++ b/installer/system.json
@@ -1,1 +1,4 @@
-{"shared_server":true}
+{
+    "shared_server":true,
+    "systemd_managed": true
+}

--- a/libgoal/system.go
+++ b/libgoal/system.go
@@ -26,7 +26,8 @@ import (
 type SystemConfig struct {
 	// SharedServer is true if this is a daemon on a multiuser system.
 	// If not shared, kmd and other files are often stored under $ALGORAND_DATA when otherwise they might go under $HOME/.algorand/
-	SharedServer bool `json:"shared_server,omitempty"`
+	SharedServer   bool `json:"shared_server,omitempty"`
+	SystemdManaged bool `json:"systemd_managed,omitempty"`
 }
 
 // map data dir to loaded config
@@ -71,4 +72,17 @@ func AlgorandDataIsPrivate(dataDir string) bool {
 		return true
 	}
 	return !sc.SharedServer
+}
+
+// AlgorandDaemonSystemdManaged returns true if the algod process for a given data dir is managed by systemd
+// if not, algod will be managed as an indivudal process for the dir
+func AlgorandDaemonSystemdManaged(dataDir string) bool {
+	if dataDir == "" {
+		return false
+	}
+	sc, err := ReadSystemConfig(dataDir)
+	if err != nil {
+		return false
+	}
+	return sc.SystemdManaged
 }

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -56,6 +56,87 @@ proc ::AlgorandGoal::Abort { ERROR } {
     exit 1
 }
 
+# Start the node
+proc ::AlgorandGoal::StartNode { TEST_ALGO_DIR {SYSTEMD_MANAGED ""} } {
+    set ::GLOBAL_TEST_ALGO_DIR $TEST_ALGO_DIR
+    set timeout 30
+
+    if { [catch {
+        puts "node start with $TEST_ALGO_DIR"
+        if { $SYSTEMD_MANAGED eq "" } {
+            spawn goal node start -d $TEST_ALGO_DIR
+            expect {
+                "^Algorand node successfully started!*" {puts "Node started successfully"; close}
+                exit 1
+            }
+        } else {
+            spawn goal node start -d $TEST_ALGO_DIR
+            expect {
+                timeout { close; ::AlgorandGoal::Abort "Timed out starting node" }
+                "^This node is managed by systemd, you must run the following command to make your desired state change to your node:*" { puts "Goal showed correct error message for systemd" ; close}
+                exit 1
+            }
+        }
+    } EXCEPTION] } {
+        puts "ERROR in StartNode: $EXCEPTION"
+        exit 1
+    }
+}
+
+# Stop the node
+proc ::AlgorandGoal::StopNode { TEST_ALGO_DIR {SYSTEMD_MANAGED ""} } {
+    set ::GLOBAL_TEST_ALGO_DIR $TEST_ALGO_DIR
+    set timeout 30
+
+    if { [catch {
+        puts "node stop with $TEST_ALGO_DIR"
+        if { $SYSTEMD_MANAGED eq "" } {
+            spawn goal node stop -d $TEST_ALGO_DIR
+            expect {
+                "^The node was successfully stopped.*" {puts "Node stopped successfully"; close}
+                exit 1
+            }
+        } else {
+            spawn goal node stop -d $TEST_ALGO_DIR
+            expect {
+                timeout { close; ::AlgorandGoal::Abort "Timed out starting node" }
+                "^This node is managed by systemd, you must run the following command to make your desired state change to your node:*" { puts "Goal showed correct error message for systemd" ; close}
+                exit 1
+            }
+        }
+    } EXCEPTION] } {
+        puts "ERROR in StopNode: $EXCEPTION"
+        exit 1
+    }
+}
+
+# Restart the node
+proc ::AlgorandGoal::RestartNode { TEST_ALGO_DIR {SYSTEMD_MANAGED ""} } {
+    set ::GLOBAL_TEST_ALGO_DIR $TEST_ALGO_DIR
+    set timeout 30
+
+    if { [catch {
+        puts "node restart with $TEST_ALGO_DIR"
+        if { $SYSTEMD_MANAGED eq "" } {
+            spawn goal node restart -d $TEST_ALGO_DIR
+            expect {
+                "^The node was successfully stopped.*Algorand node successfully started!*" {puts "Node restarted successfully"; close}
+                exit 1
+            }
+        } else {
+            spawn goal node restart -d $TEST_ALGO_DIR
+            expect {
+                timeout { close; ::AlgorandGoal::Abort "Timed out starting node" }
+                "^This node is managed by systemd, you must run the following command to make your desired state change to your node:*" { puts "Goal showed correct error message for systemd" ; close}
+                exit 1
+            }
+        }
+    } EXCEPTION] } {
+        puts "ERROR in StartNode: $EXCEPTION"
+        exit 1
+    }
+}
+
 # Start the network
 proc ::AlgorandGoal::StartNetwork { NETWORK_NAME NETWORK_TEMPLATE TEST_ALGO_DIR TEST_ROOT_DIR } {
     set ::GLOBAL_TEST_ALGO_DIR $TEST_ALGO_DIR

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -59,22 +59,21 @@ proc ::AlgorandGoal::Abort { ERROR } {
 # Start the node
 proc ::AlgorandGoal::StartNode { TEST_ALGO_DIR {SYSTEMD_MANAGED ""} } {
     set ::GLOBAL_TEST_ALGO_DIR $TEST_ALGO_DIR
-    set timeout 30
+    set timeout 15
 
     if { [catch {
         puts "node start with $TEST_ALGO_DIR"
         if { $SYSTEMD_MANAGED eq "" } {
             spawn goal node start -d $TEST_ALGO_DIR
             expect {
+                timeout { close; ::AlgorandGoal::Abort "Did not recieve appropriate message during node start" }
                 "^Algorand node successfully started!*" {puts "Node started successfully"; close}
-                exit 1
             }
         } else {
             spawn goal node start -d $TEST_ALGO_DIR
             expect {
-                timeout { close; ::AlgorandGoal::Abort "Timed out starting node" }
+                timeout { close; ::AlgorandGoal::Abort "Did not recieve appropriate message during node start" }
                 "^This node is managed by systemd, you must run the following command to make your desired state change to your node:*" { puts "Goal showed correct error message for systemd" ; close}
-                exit 1
             }
         }
     } EXCEPTION] } {
@@ -86,22 +85,21 @@ proc ::AlgorandGoal::StartNode { TEST_ALGO_DIR {SYSTEMD_MANAGED ""} } {
 # Stop the node
 proc ::AlgorandGoal::StopNode { TEST_ALGO_DIR {SYSTEMD_MANAGED ""} } {
     set ::GLOBAL_TEST_ALGO_DIR $TEST_ALGO_DIR
-    set timeout 30
+    set timeout 15
 
     if { [catch {
         puts "node stop with $TEST_ALGO_DIR"
         if { $SYSTEMD_MANAGED eq "" } {
             spawn goal node stop -d $TEST_ALGO_DIR
             expect {
-                "^The node was successfully stopped.*" {puts "Node stopped successfully"; close}
-                exit 1
+                timeout { close; ::AlgorandGoal::Abort "Did not recieve appropriate message during node stop" }
+                "*The node was successfully stopped.*" {puts "Node stopped successfully"; close}
             }
         } else {
             spawn goal node stop -d $TEST_ALGO_DIR
             expect {
-                timeout { close; ::AlgorandGoal::Abort "Timed out starting node" }
-                "^This node is managed by systemd, you must run the following command to make your desired state change to your node:*" { puts "Goal showed correct error message for systemd" ; close}
-                exit 1
+                timeout { close; ::AlgorandGoal::Abort "Did not recieve appropriate message during node stop" }
+                "*This node is managed by systemd, you must run the following command to make your desired state change to your node:*" { puts "Goal showed correct error message for systemd" ; close}
             }
         }
     } EXCEPTION] } {
@@ -120,19 +118,18 @@ proc ::AlgorandGoal::RestartNode { TEST_ALGO_DIR {SYSTEMD_MANAGED ""} } {
         if { $SYSTEMD_MANAGED eq "" } {
             spawn goal node restart -d $TEST_ALGO_DIR
             expect {
+                timeout { close; ::AlgorandGoal::Abort "Did not recieve appropriate message during node restart" }
                 "^The node was successfully stopped.*Algorand node successfully started!*" {puts "Node restarted successfully"; close}
-                exit 1
             }
         } else {
             spawn goal node restart -d $TEST_ALGO_DIR
             expect {
-                timeout { close; ::AlgorandGoal::Abort "Timed out starting node" }
+                timeout { close; ::AlgorandGoal::Abort "Did not recieve appropriate message during node restart" }
                 "^This node is managed by systemd, you must run the following command to make your desired state change to your node:*" { puts "Goal showed correct error message for systemd" ; close}
-                exit 1
             }
         }
     } EXCEPTION] } {
-        puts "ERROR in StartNode: $EXCEPTION"
+        puts "ERROR in RestartNode: $EXCEPTION"
         exit 1
     }
 }

--- a/test/e2e-go/cli/goal/expect/goalNodeSystemdTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalNodeSystemdTest.exp
@@ -1,0 +1,31 @@
+#!/usr/bin/expect -f
+#exp_internal 1
+set err 0
+log_user 1
+
+if { [catch {
+
+    source  goalExpectCommon.exp
+    set TEST_ALGO_DIR [lindex $argv 0]
+    set TEST_DATA_DIR [lindex $argv 1]
+
+    puts "TEST_ALGO_DIR: $TEST_ALGO_DIR"
+
+    spawn cp ../../../../testdata/configs/system-v0.json $TEST_ALGO_DIR/system.json
+
+    # Start node
+    ::AlgorandGoal::StartNode $TEST_ALGO_DIR True
+
+    # Restart node
+    ::AlgorandGoal::RestartNode $TEST_ALGO_DIR True
+
+    # Stop node
+    ::AlgorandGoal::StopNode $TEST_ALGO_DIR True
+
+    puts "Basic Goal Test Successful"
+
+    exit 0
+} EXCEPTION] } {
+    puts "ERROR in goalNodeStartSystemdTest: $EXCEPTION"
+    exit 1
+}

--- a/test/e2e-go/cli/goal/expect/goalNodeTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalNodeTest.exp
@@ -1,0 +1,45 @@
+#!/usr/bin/expect -f
+#exp_internal 1
+set err 0
+log_user 1
+
+if { [catch {
+
+    source  goalExpectCommon.exp
+    set TEST_ALGO_DIR [lindex $argv 0]
+    set TEST_DATA_DIR [lindex $argv 1]
+
+    puts "TEST_ALGO_DIR: $TEST_ALGO_DIR"
+    puts "TEST_DATA_DIR: $TEST_DATA_DIR"
+
+    set TIME_STAMP [clock seconds]
+
+    set TEST_ROOT_DIR $TEST_ALGO_DIR/root
+    set TEST_PRIMARY_NODE_DIR $TEST_ROOT_DIR/Primary/
+    set NETWORK_NAME test_net_expect_$TIME_STAMP
+    set NETWORK_TEMPLATE "$TEST_DATA_DIR/nettemplates/TwoNodes50Each.json"
+
+    # Create network
+    ::AlgorandGoal::StartNetwork $NETWORK_NAME $NETWORK_TEMPLATE $TEST_ALGO_DIR $TEST_ROOT_DIR
+
+    exec sleep 5
+
+    # Start node
+    ::AlgorandGoal::StartNode $TEST_PRIMARY_NODE_DIR
+
+    # Restart node
+    ::AlgorandGoal::RestartNode $TEST_PRIMARY_NODE_DIR
+
+    # Stop node
+    ::AlgorandGoal::StopNode $TEST_PRIMARY_NODE_DIR
+
+    # Shutdown the network
+    ::AlgorandGoal::StopNetwork $NETWORK_NAME $TEST_ALGO_DIR $TEST_ROOT_DIR
+
+    puts "Basic Goal Test Successful"
+
+    exit 0
+} EXCEPTION] } {
+    puts "ERROR in goalNodeStartSystemdTest: $EXCEPTION"
+    exit 1
+}

--- a/test/testdata/configs/system-v0.json
+++ b/test/testdata/configs/system-v0.json
@@ -1,0 +1,4 @@
+{
+  "systemd_managed": true,
+  "shared_server": true
+}


### PR DESCRIPTION
## Summary

I added a property to libgoal/system.go where we can set whether or not our algod process is managed by systemd. This adds the feature, but without automation for ensuring that the field is set to true on all systemd installs

## Test Plan

I ran it locally on OSX and linux and it appeared to work appropriately. Making a PR to ensure all integration tests are ran