### PR TITLE
Remove instances of tagging in our build process

### DIFF
--- a/scripts/build/beta.sh
+++ b/scripts/build/beta.sh
@@ -26,11 +26,3 @@ make
 git add -A
 git commit -m "Build ${BUILD_NUMBER}"
 git push
-
-TAG=rel/beta-$(scripts/compute_build_number.sh -f)
-if [ ! -z "${SIGNING_KEY_ADDR}" ]; then
-    git tag -s -u "${SIGNING_KEY_ADDR}" ${TAG} -m "Genesis Timestamp: $(cat ./genesistimestamp.dat)"
-else
-    git tag -a ${TAG} -m "Genesis Timestamp: $(cat ./genesistimestamp.dat)"
-fi
-git push origin ${TAG}

--- a/scripts/build/nightly.sh
+++ b/scripts/build/nightly.sh
@@ -29,9 +29,5 @@ git add ./genesistimestamp.dat ./buildnumber.dat
 git commit -m "Build ${BUILD_NUMBER} Data"
 git push
 
-TAG=rel/nightly-$(scripts/compute_build_number.sh -f)
-git tag -a ${TAG} -m "Genesis Timestamp: $(cat ./genesistimestamp.dat)"
-git push origin ${TAG}
-
 popd
 rm -rf ${REPO_DIR}

--- a/scripts/build/stable.sh
+++ b/scripts/build/stable.sh
@@ -25,11 +25,3 @@ make
 git add -A
 git commit -m "Build ${BUILD_NUMBER}"
 git push
-
-TAG=rel/stable-$(scripts/compute_build_number.sh -f)
-if [ ! -z "${SIGNING_KEY_ADDR}" ]; then
-    git tag -s -u "${SIGNING_KEY_ADDR}" ${TAG} -m "Genesis Timestamp: $(cat ./genesistimestamp.dat)"
-else
-    git tag -a ${TAG} -m "Genesis Timestamp: $(cat ./genesistimestamp.dat)"
-fi
-git push origin ${TAG}


### PR DESCRIPTION
## Summary

We don't want to be making tags anywhere in our automation. Our release process will take care of that. There is another script that makes tags in release/ci/tag.sh, but that doesn't seem to be being used anywhere.

## Test Plan

I will run a nightly build later today against this branch and see if any tags are made

