### PR TITLE
Fix regression started in 0366cdaea

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -342,7 +342,7 @@ func PreloadConfigurableConsensusProtocols(dataDirectory string) (ConsensusProto
 	if err != nil {
 		if os.IsNotExist(err) {
 			// this file is not required, only optional. if it's missing, no harm is done.
-			return nil, nil
+			return Consensus, nil
 		}
 		return nil, err
 	}


### PR DESCRIPTION
## Make sure to default to Consensus if consensus.json is missing

## Summary
In 0366cdaea7491a57c11021a89b0862dbd169f9d7, we added a new function PreloadConfigurableConsensusProtocols, which was expected to return the consensus protocols. The function was not doing so in the case where the consensus.json file was missing, and was returning an empty structure. This wasn't affecting the unit testing, as they do not rely on this function on its own. However, libgoal needs that in order to correctly sign transactions.

## Test Plan

Test this change with libgoal applications, such as pingpong.
