### PR TITLE
bugfix : compile correctly teal program that includes a base64 string which starts with double slash

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -775,10 +775,14 @@ func typecheck(expected, got StackType) bool {
 }
 
 func filterFieldsForLineComment(fields []string) []string {
+	prevField := ""
 	for i, s := range fields {
 		if strings.HasPrefix(s, "//") {
-			return fields[:i]
+			if prevField != "base64" && prevField != "b64" {
+				return fields[:i]
+			}
 		}
+		prevField = s
 	}
 	return fields
 }

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -243,10 +243,20 @@ bnz wat`
 func TestAssembleBase64(t *testing.T) {
 	text := `byte base64 //GWRM+yy3BCavBDXO/FYTNZ6o2Jai5edsMCBdDEz+0=
 byte base64 avGWRM+yy3BCavBDXO/FYTNZ6o2Jai5edsMCBdDEz//=
-==`
+//
+//text
+==
+int 1 //sometext
+&& //somemoretext
+==
+byte b64 //GWRM+yy3BCavBDXO/FYTNZ6o2Jai5edsMCBdDEz+8=
+byte b64 avGWRM+yy3BCavBDXO/FYTNZ6o2Jai5edsMCBdDEz//=
+==
+||`
 	program, err := AssembleString(text)
 	require.NoError(t, err)
-	require.NotNil(t, program)
+	s := hex.EncodeToString(program)
+	require.Equal(t, "01200101260320fff19644cfb2cb70426af0435cefc5613359ea8d896a2e5e76c30205d0c4cfed206af19644cfb2cb70426af0435cefc5613359ea8d896a2e5e76c30205d0c4cfff20fff19644cfb2cb70426af0435cefc5613359ea8d896a2e5e76c30205d0c4cfef2829122210122a291211", s)
 }
 
 func TestAssembleRejectUnkLabel(t *testing.T) {

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -240,6 +240,15 @@ bnz wat`
 	require.Nil(t, program)
 }
 
+func TestAssembleBase64(t *testing.T) {
+	text := `byte base64 //GWRM+yy3BCavBDXO/FYTNZ6o2Jai5edsMCBdDEz+0=
+byte base64 avGWRM+yy3BCavBDXO/FYTNZ6o2Jai5edsMCBdDEz//=
+==`
+	program, err := AssembleString(text)
+	require.NoError(t, err)
+	require.NotNil(t, program)
+}
+
 func TestAssembleRejectUnkLabel(t *testing.T) {
 	text := `int 1
 bnz nowhere`


### PR DESCRIPTION
## Summary
TEAL program that contains the following string would fail to compile:
```byte base64 //GWRM+yy3BCavBDXO/FYTNZ6o2Jai5edsMCBdDEz+0=```

because the `//` is interpreted incorrectly.

found during automated testing:
```
20200204_015800 :357 starting: ['e2e_subs/dynamic-fee-teal-test.sh', 'e2e_subs/e2e_teal.sh', 'e2e_subs/htlc-teal-test.sh', 'e2e_subs/keyreg-teal-test.sh', 'e2e_subs/limit-swap-test.sh', 'e2e_subs/periodic-teal-test.sh', 'e2e_subs/teal-split-test.sh']
20200204_015825 :100 starting e2e_subs/dynamic-fee-teal-test.sh
20200204_015825 :100 starting e2e_subs/e2e_teal.sh
20200204_015825 :100 starting e2e_subs/periodic-teal-test.sh
20200204_015825 :100 starting e2e_subs/limit-swap-test.sh
20200204_015825 :100 starting e2e_subs/keyreg-teal-test.sh
20200204_015825 :100 starting e2e_subs/teal-split-test.sh
20200204_015825 :100 starting e2e_subs/htlc-teal-test.sh
20200204_015828 :112 e2e_subs/e2e_teal.sh failed in 22.072922 seconds
whole log follows:
e2e_teal start 20200204_015825
+set -o pipefail
+export SHELLOPTS
+WALLET=F6E114D1AE9DA2680F28AE4A32EE33AD
+gcmd='goal -w F6E114D1AE9DA2680F28AE4A32EE33AD'
++goal -w F6E114D1AE9DA2680F28AE4A32EE33AD account list
++awk '{ print $3 }'
+ACCOUNT=ZAWSRKVGSAZEMIVPYIRTW6LHQ5GRUVF5D6XJBSA56CJH5L4J25T6UA5W7I
++goal -w F6E114D1AE9DA2680F28AE4A32EE33AD account new
++awk '{ print $6 }'
+ACCOUNTB=IW2N2VLGUBAMBJY3CPOIDILCTF46GGTHQZGCMAOLFS6WX23IWOAUDOARYA
++goal node status
++grep 'Last committed block:'
++awk '{ print $4 }'
+ROUND=1
+TIMEOUT_ROUND=8
+python /Users/travis/gopath/src/github.com/algorand/go-algorand/data/transactions/logic/tlhc.py --from ZAWSRKVGSAZEMIVPYIRTW6LHQ5GRUVF5D6XJBSA56CJH5L4J25T6UA5W7I --to IW2N2VLGUBAMBJY3CPOIDILCTF46GGTHQZGCMAOLFS6WX23IWOAUDOARYA --timeout-round 8
+cat /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/620015719/F6E114D1AE9DA2680F28AE4A32EE33AD/tlhc.teal
txn CloseRemainderTo
addr IW2N2VLGUBAMBJY3CPOIDILCTF46GGTHQZGCMAOLFS6WX23IWOAUDOARYA
==
txn Receiver
addr IW2N2VLGUBAMBJY3CPOIDILCTF46GGTHQZGCMAOLFS6WX23IWOAUDOARYA
==
&&
arg 0
len
int 32
==
&&
arg 0
sha256
byte base64 //GWRM+yy3BCavBDXO/FYTNZ6o2Jai5edsMCBdDEz+0=
==
&&
txn CloseRemainderTo
addr ZAWSRKVGSAZEMIVPYIRTW6LHQ5GRUVF5D6XJBSA56CJH5L4J25T6UA5W7I
==
txn Receiver
addr ZAWSRKVGSAZEMIVPYIRTW6LHQ5GRUVF5D6XJBSA56CJH5L4J25T6UA5W7I
==
&&
txn FirstValid
int 8
>
&&
||
txn Fee
int 1000000
<
&&++goal -w F6E114D1AE9DA2680F28AE4A32EE33AD clerk compile -n /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/620015719/F6E114D1AE9DA2680F28AE4A32EE33AD/tlhc.teal
++awk '{ print $2 }'
/Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/620015719/F6E114D1AE9DA2680F28AE4A32EE33AD/tlhc.teal: :15 need literal after 'byte base64'
+ACCOUNT_TLHC=
```