### PR TITLE
Allow asset creation transactions to be created while catching up.

### DIFF
--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -411,6 +411,15 @@ func (c *Client) MakeUnsignedAssetCreateTx(total uint64, defaultFrozen bool, man
 		return transactions.Transaction{}, errors.New("unknown consensus version")
 	}
 
+	// If assets are not yet enabled, lookup the base parameters to allow creating assets during catchup
+	if !cparams.Asset {
+		cparams, ok = c.consensus[protocol.ConsensusCurrentVersion]
+
+		if !ok {
+			return transactions.Transaction{}, errors.New("unknown consensus version")
+		}
+	}
+
 	if len(url) > cparams.MaxAssetURLBytes {
 		return tx, fmt.Errorf("asset url %s is too long (max %d bytes)", url, cparams.MaxAssetURLBytes)
 	}


### PR DESCRIPTION
## Summary

Allow creating assets while catching up by setting the asset parameters to the binary current version if the ledger hasn't caught up to that point yet.

## Current behavior
A strange error due to the consensus parameters not yet being initialized:
```
Cannot construct transaction: asset url my.token.url is too long (max 0 bytes)
```

## Testing
Made sure the command works
```
goal asset create --creator <address> --decimals 6 --asseturl "my.token.url" --unitname coin --name "my coin" --total 18446744073709551615 -o transaction.tx
```