### PR TITLE
improve the details of algons error messages

### DIFF
--- a/tools/network/cloudflare/cloudflare.go
+++ b/tools/network/cloudflare/cloudflare.go
@@ -174,7 +174,7 @@ func (d *DNS) CreateDNSRecord(ctx context.Context, recordType string, name strin
 		request, _ := createDNSRecordRequest(d.zoneID, d.authEmail, d.authKey, recordType, name, content, ttl, priority, proxied)
 		requestBody, _ := request.GetBody()
 		bodyBytes, _ := ioutil.ReadAll(requestBody)
-		return fmt.Errorf("failed to create DNS record. Request body = %s, parsed response : %#v", string(bodyBytes), parsedResponse)
+		return fmt.Errorf("failed to create DNS record. Request url = '%v', body = %s, parsed response : %#v, response headers = %#v", request.URL, string(bodyBytes), parsedResponse, response.Header)
 	}
 	return nil
 }
@@ -199,7 +199,7 @@ func (d *DNS) CreateSRVRecord(ctx context.Context, name string, target string, t
 		request, _ := createSRVRecordRequest(d.zoneID, d.authEmail, d.authKey, name, service, protocol, weight, port, ttl, priority, target)
 		requestBody, _ := request.GetBody()
 		bodyBytes, _ := ioutil.ReadAll(requestBody)
-		return fmt.Errorf("failed to create SRV record. Request body = %s, parsed response : %#v", string(bodyBytes), parsedResponse)
+		return fmt.Errorf("failed to create SRV record. Request url = '%v', body = %s, parsedResponse = %#v, response headers = %#v", request.URL, string(bodyBytes), parsedResponse, response.Header)
 	}
 	return nil
 }
@@ -224,7 +224,7 @@ func (d *DNS) DeleteDNSRecord(ctx context.Context, recordID string) error {
 		request, _ := deleteDNSRecordRequest(d.zoneID, d.authEmail, d.authKey, recordID)
 		requestBody, _ := request.GetBody()
 		bodyBytes, _ := ioutil.ReadAll(requestBody)
-		return fmt.Errorf("failed to delete DNS record. Request body = %s, parsed response : %#v", string(bodyBytes), parsedResponse)
+		return fmt.Errorf("failed to delete DNS record. Request url = '%v', body = %s, parsedResponse = %#v, response headers = %#v", request.URL, string(bodyBytes), parsedResponse, response.Header)
 	}
 	return nil
 }
@@ -250,7 +250,7 @@ func (d *DNS) UpdateDNSRecord(ctx context.Context, recordID string, recordType s
 		request, _ := updateDNSRecordRequest(d.zoneID, d.authEmail, d.authKey, recordType, recordID, name, content, ttl, priority, proxied)
 		requestBody, _ := request.GetBody()
 		bodyBytes, _ := ioutil.ReadAll(requestBody)
-		return fmt.Errorf("failed to update DNS record. Request body = %s, parsedResponse = %#v", string(bodyBytes), parsedResponse)
+		return fmt.Errorf("failed to update DNS record. Request url = '%v', body = %s, parsedResponse = %#v, response headers = %#v", request.URL, string(bodyBytes), parsedResponse, response.Header)
 	}
 
 	return nil
@@ -276,7 +276,7 @@ func (d *DNS) UpdateSRVRecord(ctx context.Context, recordID string, name string,
 		request, _ := updateSRVRecordRequest(d.zoneID, d.authEmail, d.authKey, recordID, name, service, protocol, weight, port, ttl, priority, target)
 		requestBody, _ := request.GetBody()
 		bodyBytes, _ := ioutil.ReadAll(requestBody)
-		return fmt.Errorf("failed to update SRV record. Request body = %s, parsedResponse = %#v", string(bodyBytes), parsedResponse)
+		return fmt.Errorf("failed to update SRV record. Request url = '%v', body = %s, parsedResponse = %#v, response headers = %#v", request.URL, string(bodyBytes), parsedResponse, response.Header)
 	}
 	return nil
 }
@@ -307,7 +307,7 @@ func (c *Cred) GetZones(ctx context.Context) (zones []Zone, err error) {
 		request, _ := getZonesRequest(c.authEmail, c.authKey)
 		requestBody, _ := request.GetBody()
 		bodyBytes, _ := ioutil.ReadAll(requestBody)
-		return nil, fmt.Errorf("failed to retrieve zone records. Request body = %s, parsed response : %#v", string(bodyBytes), parsedResponse)
+		return nil, fmt.Errorf("failed to retrieve zone records. Request url = '%v', body = %s, parsedResponse = %#v, response headers = %#v", request.URL, string(bodyBytes), parsedResponse, response.Header)
 	}
 
 	for _, z := range parsedResponse.Result {


### PR DESCRIPTION
## Solution
Algons was giving feedback on failed DNS entries creation. However, that feedback was including only the returned message body. Per provider request, I'm extending this to include the entire response headers, so that we could give a concrete feedback.