### PR TITLE
Create a rate limiting transport

### DIFF
--- a/network/dialer.go
+++ b/network/dialer.go
@@ -28,6 +28,19 @@ type Dialer struct {
 	innerDialer net.Dialer
 }
 
+// makeRateLimitingDialer creates a rate limiting dialer that would limit the connections
+// according to the entries in the phonebook.
+func makeRateLimitingDialer(phonebook *MultiPhonebook) Dialer {
+	return Dialer{
+		phonebook: phonebook,
+		innerDialer: net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		},
+	}
+}
+
 // Dial connects to the address on the named network.
 // It waits if needed not to exceed connectionsRateLimitingCount.
 func (d *Dialer) Dial(network, address string) (net.Conn, error) {

--- a/network/dialer.go
+++ b/network/dialer.go
@@ -64,8 +64,13 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 		case <-time.After(waitTime):
 		}
 	}
-	conn, err := d.innerDialer.DialContext(ctx, network, address)
+	conn, err := d.innerDialContext(ctx, network, address)
 	d.phonebook.UpdateConnectionTime(address, provisionalTime)
 
 	return conn, err
+}
+
+func (d *Dialer) innerDialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	// this would be a good place to have the dnssec evaluated.
+	return d.innerDialer.DialContext(ctx, network, address)
 }

--- a/network/rateLimitingTransport.go
+++ b/network/rateLimitingTransport.go
@@ -1,0 +1,67 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"errors"
+	"net/http"
+	"time"
+)
+
+// rateLimitingTransport is the transport for execute a single HTTP transaction, obtaining the Response for a given Request.
+type rateLimitingTransport struct {
+	phonebook       *MultiPhonebook
+	innerTransport  *http.Transport
+	queueingTimeout time.Duration
+}
+
+// ErrConnectionQueueingTimeout indicates that we've exceeded the time allocated for
+// queueing the current request before the request attempt could be made.
+var ErrConnectionQueueingTimeout = errors.New("rateLimitingTransport: queueing timeout")
+
+// makeRateLimitingTransport creates a rate limiting http transport that would limit the requests rate
+// according to the entries in the phonebook.
+func makeRateLimitingTransport(phonebook *MultiPhonebook, queueingTimeout time.Duration) rateLimitingTransport {
+	defaultTransport := http.DefaultTransport.(*http.Transport)
+	return rateLimitingTransport{
+		phonebook:       phonebook,
+		innerTransport:  defaultTransport.Clone(),
+		queueingTimeout: queueingTimeout,
+	}
+}
+
+// RoundTrip connects to the address on the named network using the provided context.
+// It waits if needed not to exceed connectionsRateLimitingCount.
+func (r *rateLimitingTransport) RoundTrip(req *http.Request) (res *http.Response, err error) {
+	var waitTime time.Duration
+	var provisionalTime time.Time
+	queueingTimedOut := time.After(r.queueingTimeout)
+	for {
+		_, waitTime, provisionalTime = r.phonebook.GetConnectionWaitTime(req.Host)
+		if waitTime == 0 {
+			break // break out of the loop and proceed to the connection
+		}
+		select {
+		case <-time.After(waitTime):
+		case <-queueingTimedOut:
+			return nil, ErrConnectionQueueingTimeout
+		}
+	}
+	res, err = r.innerTransport.RoundTrip(req)
+	r.phonebook.UpdateConnectionTime(req.Host, provisionalTime)
+	return
+}

--- a/network/rateLimitingTransport.go
+++ b/network/rateLimitingTransport.go
@@ -35,11 +35,19 @@ var ErrConnectionQueueingTimeout = errors.New("rateLimitingTransport: queueing t
 
 // makeRateLimitingTransport creates a rate limiting http transport that would limit the requests rate
 // according to the entries in the phonebook.
-func makeRateLimitingTransport(phonebook *MultiPhonebook, queueingTimeout time.Duration) rateLimitingTransport {
+func makeRateLimitingTransport(phonebook *MultiPhonebook, queueingTimeout time.Duration, dialer *Dialer) rateLimitingTransport {
 	defaultTransport := http.DefaultTransport.(*http.Transport)
 	return rateLimitingTransport{
-		phonebook:       phonebook,
-		innerTransport:  defaultTransport.Clone(),
+		phonebook: phonebook,
+		innerTransport: &http.Transport{
+			Proxy:                 defaultTransport.Proxy,
+			DialContext:           dialer.innerDialContext,
+			ForceAttemptHTTP2:     defaultTransport.ForceAttemptHTTP2,
+			MaxIdleConns:          defaultTransport.MaxIdleConns,
+			IdleConnTimeout:       defaultTransport.IdleConnTimeout,
+			TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
+			ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
+		},
 		queueingTimeout: queueingTimeout,
 	}
 }

--- a/network/rateLimitingTransport.go
+++ b/network/rateLimitingTransport.go
@@ -42,7 +42,6 @@ func makeRateLimitingTransport(phonebook *MultiPhonebook, queueingTimeout time.D
 		innerTransport: &http.Transport{
 			Proxy:                 defaultTransport.Proxy,
 			DialContext:           dialer.innerDialContext,
-			ForceAttemptHTTP2:     defaultTransport.ForceAttemptHTTP2,
 			MaxIdleConns:          defaultTransport.MaxIdleConns,
 			IdleConnTimeout:       defaultTransport.IdleConnTimeout,
 			TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -526,7 +526,7 @@ func (wn *WebsocketNetwork) GetPeers(options ...PeerOption) []Peer {
 func (wn *WebsocketNetwork) setup() {
 
 	wn.dialer = makeRateLimitingDialer(wn.phonebook)
-	wn.transport = makeRateLimitingTransport(wn.phonebook, 10*time.Second)
+	wn.transport = makeRateLimitingTransport(wn.phonebook, 10*time.Second, &wn.dialer)
 
 	wn.upgrader.ReadBufferSize = 4096
 	wn.upgrader.WriteBufferSize = 4096

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -327,7 +327,7 @@ type WebsocketNetwork struct {
 
 	// transport and dialer are customized to limit the number of
 	// connection in compliance with connectionsRateLimitingCount.
-	transport http.Transport
+	transport rateLimitingTransport
 	dialer    Dialer
 }
 
@@ -526,20 +526,8 @@ func (wn *WebsocketNetwork) GetPeers(options ...PeerOption) []Peer {
 
 func (wn *WebsocketNetwork) setup() {
 
-	wn.dialer.phonebook = wn.phonebook
-	// Parameter values similar to http.DefaultTransport
-	wn.dialer.innerDialer.Timeout = 30 * time.Second
-	wn.dialer.innerDialer.Timeout = 30 * time.Second
-	wn.dialer.innerDialer.KeepAlive = 30 * time.Second
-	wn.dialer.innerDialer.DualStack = true
-
-	// Parameter values similar to http.DefaultTransport
-	wn.transport.DialContext = wn.dialer.DialContext
-	wn.transport.Dial = wn.dialer.Dial
-	wn.transport.MaxIdleConns = 100
-	wn.transport.IdleConnTimeout = 90 * time.Second
-	wn.transport.TLSHandshakeTimeout = 10 * time.Second
-	wn.transport.ExpectContinueTimeout = 1 * time.Second
+	wn.dialer = makeRateLimitingDialer(wn.phonebook)
+	wn.transport = makeRateLimitingTransport(wn.phonebook, 10*time.Second)
 
 	wn.upgrader.ReadBufferSize = 4096
 	wn.upgrader.WriteBufferSize = 4096

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -37,7 +37,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	//"os"
 
 	"github.com/algorand/go-deadlock"
 	"github.com/algorand/websocket"


### PR DESCRIPTION
## Solution

Shant's previous implementation wasn't complete as the underlying go implementation for the http requests was re-using the same connection over and over. This implementation extend the previous one by using a http-level accounting for the various outgoing requests.