### PR TITLE
Move `dsign` functionality to goal

### DIFF
--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -127,10 +127,10 @@ const (
 	tealsignParseb64      = "failed to base64 decode data to sign: %v"
 	tealsignParseb32      = "failed to base32 decode data to sign: %v"
 	tealsignTxIDLsigReq   = "--sign-txid requires --lsig-txn"
-	tealsignSetArgLsigReq = "--set-lsig-arg requires --lsig-txn"
+	tealsignSetArgLsigReq = "--set-lsig-arg-idx requires --lsig-txn"
 	tealsignDataReq       = "need exactly one of --sign-txid, --data-file, --data-b64, or --data-b32"
 	tealsignInfoSig       = "Generated signature: %s"
-	tealsignTooManyArg    = "--set-lsig-arg too large, maximum of %d arguments"
+	tealsignTooManyArg    = "--set-lsig-arg-idx too large, maximum of %d arguments"
 	tealsignInfoWroteSig  = "Wrote signature for %s to LSig.Args[%d]"
 
 	// Wallet

--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -117,6 +117,22 @@ const (
 
 	multisigProgramCollision = "should have at most one of --program/-p | --program-bytes/-P | --lsig/-L"
 
+	tealsignMutKeyArgs    = "--with-keyfile and --with-account are mutually exclusive"
+	tealsignMutLsigArgs   = "Need exactly one of --contract-addr or --lsig-txn"
+	tealsignKeyfileFail   = "Failed to read keyfile: %v"
+	tealsignNoWithAcct    = "--with-account is not yet supported"
+	tealsignEmptyLogic    = "LogicSig must have non-empty program"
+	tealsignParseAddr     = "Failed to parse contract addr: %v"
+	tealsignParseData     = "Failed to parse data to sign: %v"
+	tealsignParseb64      = "failed to base64 decode data to sign: %v"
+	tealsignParseb32      = "failed to base32 decode data to sign: %v"
+	tealsignTxIDLsigReq   = "--sign-txid requires --lsig-txn"
+	tealsignSetArgLsigReq = "--set-lsig-arg requires --lsig-txn"
+	tealsignDataReq       = "need exactly one of --sign-txid, --data-file, --data-b64, or --data-b32"
+	tealsignInfoSig       = "Generated signature: %s"
+	tealsignTooManyArg    = "--set-lsig-arg too large, maximum of %d arguments"
+	tealsignInfoWroteSig  = "Wrote signature for %s to LSig.Args[%d]"
+
 	// Wallet
 	infoRecoveryPrompt           = "Please type your recovery mnemonic below, and hit return when you are done: "
 	infoChoosePasswordPrompt     = "Please choose a password for wallet '%s': "

--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -117,10 +117,10 @@ const (
 
 	multisigProgramCollision = "should have at most one of --program/-p | --program-bytes/-P | --lsig/-L"
 
-	tealsignMutKeyArgs    = "--with-keyfile and --with-account are mutually exclusive"
+	tealsignMutKeyArgs    = "--keyfile and --account are mutually exclusive"
 	tealsignMutLsigArgs   = "Need exactly one of --contract-addr or --lsig-txn"
 	tealsignKeyfileFail   = "Failed to read keyfile: %v"
-	tealsignNoWithAcct    = "--with-account is not yet supported"
+	tealsignNoWithAcct    = "--account is not yet supported"
 	tealsignEmptyLogic    = "LogicSig must have non-empty program"
 	tealsignParseAddr     = "Failed to parse contract addr: %v"
 	tealsignParseData     = "Failed to parse data to sign: %v"

--- a/cmd/goal/tealsign.go
+++ b/cmd/goal/tealsign.go
@@ -59,8 +59,14 @@ func init() {
 var tealsignCmd = &cobra.Command{
 	Use:   "tealsign",
 	Short: "Sign data to be verified in a TEAL program",
-	Long:  `Sign data to be verified in a TEAL program`,
-	Args:  validateNoPosArgsFn,
+	Long: `Sign data to be verified in a TEAL program.
+
+Data verified by the ed25519verify TEAL opcode must be domain separated. As part of this process, the signed payload includes the hash of the program logic. This hash must be specified. To do this, provide a transaction whose logic sig contains the program via --lsig-txn, or provide a contract address directly with --contract-addr. These options are mutually exclusive.
+
+Next, you must specify the data to be signed. When using --lsig-txn, you can use the --sign-txid flag to sign that transaction's txid. Alternatively, arbitrary data can be signed with the --data-file, --data-b64, or --data-b32 options. These options are mutually exclusive.
+
+The base64 encoding of the signature will always be printed to stdout. Optionally, when using --lsig-txn, you may specify that the signature be used as a TEAL argument for that transaction. Specify the argument index with the --set-lsig-arg-idx flag. The --lsig-txn file will be updated in place, and any existing argument at that index will be overwritten.`,
+	Args: validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, args []string) {
 		/*
 		 * First, fetch the key for signing

--- a/cmd/goal/tealsign.go
+++ b/cmd/goal/tealsign.go
@@ -45,15 +45,15 @@ var (
 func init() {
 	clerkCmd.AddCommand(tealsignCmd)
 
-	tealsignCmd.Flags().StringVarP(&keyFilename, "with-keyfile", "f", "", "algokey private key file to sign with")
-	tealsignCmd.Flags().StringVarP(&signerAcct, "with-account", "t", "", "address of account to sign with")
-	tealsignCmd.Flags().StringVarP(&lsigTxnFilename, "lsig-txn", "l", "", "transaction with logicsig to sign data for")
-	tealsignCmd.Flags().StringVarP(&contractAddr, "contract-addr", "c", "", "contract address to sign data for. not necessary if --lsig-txn is provided")
-	tealsignCmd.Flags().BoolVarP(&signTxID, "sign-txid", "s", false, "use the txid of --lsig-txn as the data to sign")
+	tealsignCmd.Flags().StringVar(&keyFilename, "keyfile", "", "algokey private key file to sign with")
+	tealsignCmd.Flags().StringVar(&signerAcct, "account", "", "address of account to sign with")
+	tealsignCmd.Flags().StringVar(&lsigTxnFilename, "lsig-txn", "", "transaction with logicsig to sign data for")
+	tealsignCmd.Flags().StringVar(&contractAddr, "contract-addr", "", "contract address to sign data for. not necessary if --lsig-txn is provided")
+	tealsignCmd.Flags().BoolVar(&signTxID, "sign-txid", false, "use the txid of --lsig-txn as the data to sign")
 	tealsignCmd.Flags().StringVar(&dataFile, "data-file", "", "data file to sign")
 	tealsignCmd.Flags().StringVar(&datab64, "data-b64", "", "base64 data to sign")
 	tealsignCmd.Flags().StringVar(&datab32, "data-b32", "", "base32 data to sign")
-	tealsignCmd.Flags().IntVarP(&setLsigArg, "set-lsig-arg", "a", -1, "if --lsig-txn is also specified, set this lsig arg to the raw signature bytes")
+	tealsignCmd.Flags().IntVar(&setLsigArg, "set-lsig-arg", -1, "if --lsig-txn is also specified, set this lsig arg to the raw signature bytes")
 }
 
 var tealsignCmd = &cobra.Command{
@@ -79,7 +79,7 @@ var tealsignCmd = &cobra.Command{
 			}
 		}
 
-		// --with-account not yet supported, coming in another PR
+		// --account not yet supported, coming in another PR
 		// (need to add kmd support for signing logicsig data)
 		if signerAcct != "" {
 			reportErrorf(tealsignNoWithAcct)

--- a/cmd/goal/tealsign.go
+++ b/cmd/goal/tealsign.go
@@ -53,7 +53,7 @@ func init() {
 	tealsignCmd.Flags().StringVar(&dataFile, "data-file", "", "Data file to sign")
 	tealsignCmd.Flags().StringVar(&datab64, "data-b64", "", "base64 data to sign")
 	tealsignCmd.Flags().StringVar(&datab32, "data-b32", "", "base32 data to sign")
-	tealsignCmd.Flags().IntVar(&setLsigArg, "set-lsig-arg-idx", -1, "If --lsig-txn is also specified, set the lsig arg at this index to the raw signature bytes. Overwrites any existing argument at this index. Updates --lsig-txn file in place. nil args will be prepended if necessary.")
+	tealsignCmd.Flags().IntVar(&setLsigArg, "set-lsig-arg-idx", -1, "If --lsig-txn is also specified, set the lsig arg at this index to the raw signature bytes. Overwrites any existing argument at this index. Updates --lsig-txn file in place. nil args will be appended until index is valid.")
 }
 
 var tealsignCmd = &cobra.Command{

--- a/cmd/goal/tealsign.go
+++ b/cmd/goal/tealsign.go
@@ -46,14 +46,14 @@ func init() {
 	clerkCmd.AddCommand(tealsignCmd)
 
 	tealsignCmd.Flags().StringVar(&keyFilename, "keyfile", "", "algokey private key file to sign with")
-	tealsignCmd.Flags().StringVar(&signerAcct, "account", "", "address of account to sign with")
-	tealsignCmd.Flags().StringVar(&lsigTxnFilename, "lsig-txn", "", "transaction with logicsig to sign data for")
-	tealsignCmd.Flags().StringVar(&contractAddr, "contract-addr", "", "contract address to sign data for. not necessary if --lsig-txn is provided")
-	tealsignCmd.Flags().BoolVar(&signTxID, "sign-txid", false, "use the txid of --lsig-txn as the data to sign")
-	tealsignCmd.Flags().StringVar(&dataFile, "data-file", "", "data file to sign")
+	tealsignCmd.Flags().StringVar(&signerAcct, "account", "", "Address of account to sign with")
+	tealsignCmd.Flags().StringVar(&lsigTxnFilename, "lsig-txn", "", "Transaction with logicsig to sign data for")
+	tealsignCmd.Flags().StringVar(&contractAddr, "contract-addr", "", "Contract address to sign data for. not necessary if --lsig-txn is provided")
+	tealsignCmd.Flags().BoolVar(&signTxID, "sign-txid", false, "Use the txid of --lsig-txn as the data to sign")
+	tealsignCmd.Flags().StringVar(&dataFile, "data-file", "", "Data file to sign")
 	tealsignCmd.Flags().StringVar(&datab64, "data-b64", "", "base64 data to sign")
 	tealsignCmd.Flags().StringVar(&datab32, "data-b32", "", "base32 data to sign")
-	tealsignCmd.Flags().IntVar(&setLsigArg, "set-lsig-arg", -1, "if --lsig-txn is also specified, set this lsig arg to the raw signature bytes")
+	tealsignCmd.Flags().IntVar(&setLsigArg, "set-lsig-arg-idx", -1, "If --lsig-txn is also specified, set the lsig arg at this index to the raw signature bytes. Overwrites any existing argument at this index. Updates --lsig-txn file in place. nil args will be prepended if necessary.")
 }
 
 var tealsignCmd = &cobra.Command{
@@ -184,7 +184,7 @@ var tealsignCmd = &cobra.Command{
 		}
 
 		/*
-		 * Sign the payload and print signature to stdout
+		 * Sign the payload
 		 */
 
 		signature := sec.Sign(logic.Msg{


### PR DESCRIPTION
This PR moves some of the `dsign` functionality into a new goal command, `goal clerk tealsign`.

Currently this command only supports signing using keyfiles as generated by `algokey`. The next thing to do is add support for signing with keys from `kmd`. I left that out of this PR, because I wanted to add a "sign data for logic" endpoint to `kmd` rather than export private keys just to make this work. That will come next.