### PR TITLE
Added utils for testing release packages

### DIFF
--- a/scripts/release/util/check_sig.sh
+++ b/scripts/release/util/check_sig.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# shellcheck disable=2045
+
+if [ $# -eq 0 ]
+then
+    echo "Usage: $0 <DIRECTORY>"
+    exit 1
+fi
+
+GREEN_FG=$(tput setaf 2 2>/dev/null)
+RED_FG=$(tput setaf 1 2>/dev/null)
+END_FG_COLOR=$(tput sgr0 2>/dev/null)
+RETVAL=0
+
+pushd "$1" > /dev/null
+
+for file in $(ls ./*.{gz,deb,rpm})
+do
+    key_id=dev@algorand.com
+
+    # Check the filename extension.
+    if [ "${file##*.}" == "rpm" ]
+    then
+        key_id=rpm@algorand.com
+    fi
+
+    if ! gpg -u "$key_id" --verify "$file".sig "$file"
+    then
+        echo -e "$RED_FG[$0]$END_FG_COLOR Could not verify signature for $file"
+        RETVAL=1
+    fi
+done
+
+popd > /dev/null
+
+if [ $RETVAL -eq 0 ]
+then
+    echo -e "$GREEN_FG[$0]$END_FG_COLOR All signatures have been verified as good."
+fi
+
+exit $RETVAL
+

--- a/scripts/release/util/check_sig.sh
+++ b/scripts/release/util/check_sig.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=2045
 
-if [ $# -eq 0 ]
+if [ $# -ne 1 ]
 then
     echo "Usage: $0 <DIRECTORY>"
     exit 1

--- a/scripts/release/util/smoke_test.sh
+++ b/scripts/release/util/smoke_test.sh
@@ -5,7 +5,13 @@
 
 GREEN_FG=$(tput setaf 2 2>/dev/null)
 RED_FG=$(tput setaf 1 2>/dev/null)
+YELLOW_FG=$(tput setaf 3 2>/dev/null)
 END_FG_COLOR=$(tput sgr0 2>/dev/null)
+
+BRANCH=
+CHANNEL=stable
+HASH=
+RELEASE=
 
 while [ "$1" != "" ]; do
     case "$1" in
@@ -32,6 +38,12 @@ while [ "$1" != "" ]; do
     esac
     shift
 done
+
+if [ -z "$BRANCH" ] || [ -z "$HASH" ] || [ -z "$RELEASE" ]
+then
+    echo "$YELLOW_FG[Usage]$END_FG_COLOR $0 -b BRANCH -c CHANNEL -h HASH -r RELEASE"
+    exit 1
+fi
 
 echo "[$0] Testing: algod -v"
 if < /etc/os-release grep Ubuntu > /dev/null

--- a/scripts/release/util/smoke_test.sh
+++ b/scripts/release/util/smoke_test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# This is currently used by `test_package.sh`.
+# It is copied into a docker image at build time and then invoked at run time.
+
+GREEN_FG=$(tput setaf 2 2>/dev/null)
+RED_FG=$(tput setaf 1 2>/dev/null)
+END_FG_COLOR=$(tput sgr0 2>/dev/null)
+
+while [ "$1" != "" ]; do
+    case "$1" in
+        -b)
+            shift
+            BRANCH="$1"
+            ;;
+        -c)
+            shift
+            CHANNEL="$1"
+            ;;
+        -h)
+            shift
+            HASH="$1"
+            ;;
+        -r)
+            shift
+            RELEASE="$1"
+            ;;
+        *)
+            echo "Unknown option" "$1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+echo "[$0] Testing: algod -v"
+if < /etc/os-release grep Ubuntu > /dev/null
+then
+    dpkg -i ./*.deb
+else
+    yum install ./*.rpm -y
+fi
+
+STR=$(algod -v)
+SHORT_HASH=${HASH:0:8}
+
+# We're looking for a line that looks like the following:
+#
+#       2.0.4.stable [rel/stable] (commit #729b125a)
+#
+# Since we're passing in the full hash, we won't using the closing paren.
+# Use a regex over the multi-line string.
+if [[ "$STR" =~ .*"$RELEASE.$CHANNEL [$BRANCH] (commit #$SHORT_HASH)".* ]]
+then
+    echo "$GREEN_FG[$0]$END_FG_COLOR The result of \`algod -v\` is a correct match."
+    exit 0
+fi
+
+echo "$RED_FG[$0]$END_FG_COLOR The result of \`algod -v\` is an incorrect match."
+exit 1
+

--- a/scripts/release/util/test_package.sh
+++ b/scripts/release/util/test_package.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+# TODO: use `trap` instead of cleanup function?
+
+GREEN_FG=$(tput setaf 2 2>/dev/null)
+RED_FG=$(tput setaf 1 2>/dev/null)
+TEAL_FG=$(tput setaf 6 2>/dev/null)
+END_FG_COLOR=$(tput sgr0 2>/dev/null)
+
+# TODO: The following error happens on centos:8
+#
+# Error:
+#  Problem: conflicting requests
+#    - nothing provides yum-cron needed by algorand-2.0.4-1.x86_64
+# (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
+# smoke_test.sh: line 47: algod: command not found
+
+OS_LIST=(
+    centos:7
+#    centos:8
+    fedora:28
+    ubuntu:16.04
+    ubuntu:18.04
+)
+
+CHANNEL=stable
+FAILED=()
+
+while [ "$1" != "" ]; do
+    case "$1" in
+        -b)
+            shift
+            BRANCH="$1"
+            ;;
+        -c)
+            shift
+            CHANNEL="$1"
+            ;;
+        -h)
+            shift
+            HASH="$1"
+            ;;
+        -r)
+            shift
+            RELEASE="$1"
+            ;;
+        *)
+            echo "$RED_FG[$0]$END_FG_COLOR Unknown option $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+build_images () {
+    # We'll use this simple tokenized Dockerfile.
+    # https://serverfault.com/a/72511
+    IFS='' read -r -d '' TOKENIZED <<EOF
+FROM {{OS}}
+
+WORKDIR /root
+COPY pkg/* /root/
+COPY smoke_test.sh .
+CMD ["/bin/bash"]
+EOF
+
+    for item in ${OS_LIST[*]}
+    do
+        # Note: we eventually want to move to storing the Dockerfiles.
+        #
+        # Use pattern substitution here (like sed).
+        # ${parameter/pattern/substitution}
+        echo -e "${TOKENIZED/\{\{OS\}\}/$item}" > Dockerfile
+        if ! docker build -t "${item}-smoke-test" .
+        then
+            FAILED+=("$item")
+        fi
+    done
+}
+
+run_images () {
+    for item in ${OS_LIST[*]}
+    do
+        echo "$TEAL_FG[$0]$END_FG_COLOR Running ${item}-test..."
+        if ! docker run --rm --name algorand -t "${item}-smoke-test" bash smoke_test.sh -b "$BRANCH" -c "$CHANNEL" -h "$HASH" -r "$RELEASE"
+        then
+            FAILED+=("$item")
+        fi
+    done
+}
+
+cleanup() {
+    rm -f Dockerfile
+}
+
+check_failures() {
+    if [ "${#FAILED[@]}" -gt 0 ]
+    then
+        echo -e "\n$RED_FG[$0]$END_FG_COLOR The following images could not be $1:"
+
+        for failed in ${FAILED[*]}
+        do
+            echo " - $failed"
+        done
+
+        echo
+
+        cleanup
+        exit 1
+    fi
+}
+
+build_images
+check_failures built
+echo "$GREEN_FG[$0]$END_FG_COLOR Builds completed with no failures."
+
+run_images
+check_failures verified
+echo "$GREEN_FG[$0]$END_FG_COLOR Runs completed with no failures."
+
+cleanup
+

--- a/scripts/release/util/test_package.sh
+++ b/scripts/release/util/test_package.sh
@@ -5,6 +5,7 @@
 GREEN_FG=$(tput setaf 2 2>/dev/null)
 RED_FG=$(tput setaf 1 2>/dev/null)
 TEAL_FG=$(tput setaf 6 2>/dev/null)
+YELLOW_FG=$(tput setaf 3 2>/dev/null)
 END_FG_COLOR=$(tput sgr0 2>/dev/null)
 
 # TODO: The following error happens on centos:8
@@ -23,7 +24,10 @@ OS_LIST=(
     ubuntu:18.04
 )
 
+BRANCH=
 CHANNEL=stable
+HASH=
+RELEASE=
 FAILED=()
 
 while [ "$1" != "" ]; do
@@ -51,6 +55,12 @@ while [ "$1" != "" ]; do
     esac
     shift
 done
+
+if [ -z "$BRANCH" ] || [ -z "$HASH" ] || [ -z "$RELEASE" ]
+then
+    echo "$YELLOW_FG[Usage]$END_FG_COLOR $0 -b BRANCH -c CHANNEL -h HASH -r RELEASE"
+    exit 1
+fi
 
 build_images () {
     # We'll use this simple tokenized Dockerfile.


### PR DESCRIPTION
check_sig: Verify gpg signatures of build artifacts.

test_package: Verifies the packages were built from the correct branch
with the correct hash and verifies the test version release number.