### PR TITLE
Update Dockerfile for our official docker image

### DIFF
--- a/docker/releases/build_releases.sh
+++ b/docker/releases/build_releases.sh
@@ -49,15 +49,10 @@ build_image () {
     IFS='' read -r -d '' DOCKERFILE <<EOF
     FROM ubuntu
 
-    WORKDIR /root/install
     RUN apt-get update && apt-get install -y ca-certificates curl --no-install-recommends && \
         curl --silent -L https://github.com/algorand/go-algorand-doc/blob/master/downloads/installers/linux_amd64/install_master_linux-amd64.tar.gz?raw=true | tar xzf - && \
-        ./update.sh -c stable -n -p ~/node -d ~/node/data -i $NETWORK && \
-        cd .. && \
-        rm -rf install /var/lib/apt/lists/*
+        ./update.sh -c stable -n -p ~/node -d ~/node/data -i $NETWORK
     WORKDIR /root/node
-
-    ENTRYPOINT ["/bin/bash"]
 EOF
 
     if ! echo "$DOCKERFILE" | docker build -t algorand/"$NAME":latest -


### PR DESCRIPTION
Removing `ENTRYPOINT` makes the image more flexible.

```
docker run -it algorand/stable
docker run -it algorand/stable /bin/bash
docker run algorand/stable ./algod -v
docker run algorand/stable cat /etc/passwd
```

In addition, the `install` directory was cruft, and I didn't see any reason to remove any repo listings (`/var/lib/apt/lists/*`).