### PR TITLE
Brice/refactor make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ crypto/libsodium-fork/**/Makefile.in
 crypto/libsodium-fork/aclocal.m4
 crypto/libsodium-fork/build-aux/
 
+# Ignore libsodium files generated during ci process
+crypto/copies
+crypto/libs
+
 # Ignore vim backup and swap files
 *~
 *.swp

--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,3 @@ ci-deps:
 ci-build: buildsrc gen
 	mkdir -p $(SRCPATH)/tmp/node_pkgs/$(OS_TYPE)/$(ARCH) && \
 	PKG_ROOT=$(SRCPATH)/tmp/node_pkgs/$(OS_TYPE)/$(ARCH) NO_BUILD=True VARIATIONS=literally_anything scripts/build_packages.sh $(OS_TYPE)/$(ARCH)
-
-.EXPORT_ALL_VARIABLES:
-CGO_CFLAGS  = -I$(SRCPATH)/crypto/libs/$(OS_TYPE)/$(ARCH)/include
-CGO_LDFLAGS = $(SRCPATH)/crypto/libs/$(OS_TYPE)/$(ARCH)/lib/libsodium.a

--- a/Makefile
+++ b/Makefile
@@ -274,12 +274,16 @@ install: build
 ### TARGETS FOR CICD PROCESS
 
 ci-deps:
-	scripts/configure_dev.sh && \
+	scripts/configure_dev-deps.sh && \
 	scripts/check_deps.sh
 
 ci-buildsrc: crypto/lib/libsodium.a node_exporter NONGO_BIN $(ALGOD_API_SWAGGER_INJECT) $(KMD_API_SWAGGER_INJECT)
-	OS_TYPE=$(OS_TYPE) ARCH=$(ARCH) go install $(GOTRIMPATH) $(GOTAGS) $(GOBUILDMODE) -ldflags="$(GOLDFLAGS)" ./...
+	go install $(GOTRIMPATH) $(GOTAGS) $(GOBUILDMODE) -ldflags="$(GOLDFLAGS)" ./...
 
 ci-build: ci-buildsrc gen
 	mkdir -p $(SRCPATH)/tmp/$(OS_TYPE)/$(ARCH)/dev_pkg && \
 	PKG_ROOT=$(SRCPATH)/tmp/$(OS_TYPE)/$(ARCH)/dev_pkg scripts/dev_install.sh -p $(GOPATH1)/bin
+
+ci-package:
+	mkdir -p $(SRCPATH)/assets/node_pkgs/$(OS_TYPE)/$(ARCH) && \
+	PKG_ROOT=$(SRCPATH)/assets/node_pkgs/$(OS_TYPE)/$(ARCH) NO_BUILD=True VARIATIONS=literally_anything scripts/build_packages.sh $(OS_TYPE)/$(ARCH)

--- a/Makefile
+++ b/Makefile
@@ -277,13 +277,10 @@ ci-deps:
 	scripts/configure_dev-deps.sh && \
 	scripts/check_deps.sh
 
-ci-buildsrc: crypto/lib/libsodium.a node_exporter NONGO_BIN $(ALGOD_API_SWAGGER_INJECT) $(KMD_API_SWAGGER_INJECT)
-	go install $(GOTRIMPATH) $(GOTAGS) $(GOBUILDMODE) -ldflags="$(GOLDFLAGS)" ./...
+ci-build: buildsrc gen
+	mkdir -p $(SRCPATH)/tmp/node_pkgs/$(OS_TYPE)/$(ARCH) && \
+	PKG_ROOT=$(SRCPATH)/tmp/node_pkgs/$(OS_TYPE)/$(ARCH) NO_BUILD=True VARIATIONS=literally_anything scripts/build_packages.sh $(OS_TYPE)/$(ARCH)
 
-ci-build: ci-buildsrc gen
-	mkdir -p $(SRCPATH)/tmp/$(OS_TYPE)/$(ARCH)/dev_pkg && \
-	PKG_ROOT=$(SRCPATH)/tmp/$(OS_TYPE)/$(ARCH)/dev_pkg scripts/dev_install.sh -p $(GOPATH1)/bin
-
-ci-package:
-	mkdir -p $(SRCPATH)/assets/node_pkgs/$(OS_TYPE)/$(ARCH) && \
-	PKG_ROOT=$(SRCPATH)/assets/node_pkgs/$(OS_TYPE)/$(ARCH) NO_BUILD=True VARIATIONS=literally_anything scripts/build_packages.sh $(OS_TYPE)/$(ARCH)
+.EXPORT_ALL_VARIABLES:
+CGO_CFLAGS  = -I$(SRCPATH)/crypto/libs/$(OS_TYPE)/$(ARCH)/include
+CGO_LDFLAGS = $(SRCPATH)/crypto/libs/$(OS_TYPE)/$(ARCH)/lib/libsodium.a

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ msgp: $(patsubst %,%/msgp_gen.go,$(MSGP_GENERATE))
 ALWAYS:
 
 # build our fork of libsodium, placing artifacts into crypto/lib/ and crypto/include/
-crypto/lib/libsodium.a:
+crypto/libs/$(OS_TYPE)/$(ARCH)/lib/libsodium.a:
 	mkdir -p crypto/copies/$(OS_TYPE)/$(ARCH)
 	cp -R crypto/libsodium-fork crypto/copies/$(OS_TYPE)/$(ARCH)/libsodium-fork
 	cd crypto/copies/$(OS_TYPE)/$(ARCH)/libsodium-fork && \
@@ -111,7 +111,7 @@ ALGOD_API_FILES := $(shell find daemon/algod/api/server/common daemon/algod/api/
 ALGOD_API_SWAGGER_INJECT := daemon/algod/api/server/lib/bundledSpecInject.go
 
 # Note that swagger.json requires the go-swagger dep.
-$(ALGOD_API_SWAGGER_SPEC): $(ALGOD_API_FILES) crypto/lib/libsodium.a
+$(ALGOD_API_SWAGGER_SPEC): $(ALGOD_API_FILES) crypto/libs/$(OS_TYPE)/$(ARCH)/lib/libsodium.a
 	cd daemon/algod/api && \
 		PATH=$(GOPATH1)/bin:$$PATH \
 		go generate ./...
@@ -125,7 +125,7 @@ KMD_API_FILES := $(shell find daemon/kmd/api/ -type f | grep -v $(KMD_API_SWAGGE
 KMD_API_SWAGGER_WRAPPER := kmdSwaggerWrappers.go
 KMD_API_SWAGGER_INJECT := daemon/kmd/lib/kmdapi/bundledSpecInject.go
 
-$(KMD_API_SWAGGER_SPEC): $(KMD_API_FILES) crypto/lib/libsodium.a
+$(KMD_API_SWAGGER_SPEC): $(KMD_API_FILES) crypto/libs/$(OS_TYPE)/$(ARCH)/lib/libsodium.a
 	cd daemon/kmd/lib/kmdapi && \
 		python genSwaggerWrappers.py $(KMD_API_SWAGGER_WRAPPER)
 	cd daemon/kmd && \
@@ -150,7 +150,7 @@ $(KMD_API_SWAGGER_INJECT): $(KMD_API_SWAGGER_SPEC) $(KMD_API_SWAGGER_SPEC).valid
 
 build: buildsrc gen
 
-buildsrc: crypto/lib/libsodium.a node_exporter NONGO_BIN deps $(ALGOD_API_SWAGGER_INJECT) $(KMD_API_SWAGGER_INJECT)
+buildsrc: crypto/libs/$(OS_TYPE)/$(ARCH)/lib/libsodium.a node_exporter NONGO_BIN deps $(ALGOD_API_SWAGGER_INJECT) $(KMD_API_SWAGGER_INJECT)
 	go install $(GOTRIMPATH) $(GOTAGS) $(GOBUILDMODE) -ldflags="$(GOLDFLAGS)" ./...
 
 SOURCES_RACE := github.com/algorand/go-algorand/cmd/kmd
@@ -279,4 +279,4 @@ ci-deps:
 
 ci-build: buildsrc gen
 	mkdir -p $(SRCPATH)/tmp/node_pkgs/$(OS_TYPE)/$(ARCH) && \
-	PKG_ROOT=$(SRCPATH)/tmp/node_pkgs/$(OS_TYPE)/$(ARCH) NO_BUILD=True VARIATIONS=literally_anything scripts/build_packages.sh $(OS_TYPE)/$(ARCH)
+	PKG_ROOT=$(SRCPATH)/tmp/node_pkgs/$(OS_TYPE)/$(ARCH) NO_BUILD=True VARIATIONS=$(OS_TYPE)/$(ARCH) scripts/build_packages.sh $(OS_TYPE)/$(ARCH)

--- a/cicd.yaml
+++ b/cicd.yaml
@@ -16,7 +16,7 @@ stages:
     configFilePath: scripts/configure_dev-deps.sh
     workDir: /go/src/github.com/algorand/go-algorand
     arch: amd64
-    target: ci-deps ci-build
+    target: ci-build
   build-linux-arm64:
   - task: shell.docker.Ensure
     image: algorand/go-algorand-linux
@@ -34,12 +34,12 @@ stages:
     image: algorand/go-algorand-linux
     workDir: /go/src/github.com/algorand/go-algorand
     arch: arm64v8
-    target: ci-deps ci-build
+    target: ci-build
   build-local:
   - task: shell.Make
-    target: fulltest
+    target: ci-deps fulltest
   - task: shell.Make
-    target: ci-deps ci-build
+    target: ci-build
   release:
   - task: release.notes.GenerateReleaseNotes
     releaseVersion: ${GO_ALGORAND_RELEASE_VERSION}

--- a/cicd.yaml
+++ b/cicd.yaml
@@ -1,4 +1,17 @@
 stages:
+  build-linux-amd64:
+  - task: docker.Make
+    image: centos-algo:7
+    arch: amd64
+    target: ci-deps ci-build ci-package
+  build-linux-arm64:
+  - task: docker.Make
+    image: centos-algo:7
+    arch: arm64v8
+    target: ci-deps ci-build ci-package
+  build-local:
+  - task: shell.Make
+    target: ci-deps ci-build ci-package
   release:
   - task: release.notes.GenerateReleaseNotes
     releaseVersion: ${GO_ALGORAND_RELEASE_VERSION}

--- a/cicd.yaml
+++ b/cicd.yaml
@@ -2,19 +2,32 @@ stages:
   build-linux-amd64:
   - task: docker.Make
     image: centos-algo:7
+    workDir: /go/src/github.com/algorand/go-algorand
     arch: amd64
-    target: ci-deps ci-build ci-package
+    target: fulltest
+  - task: docker.Make
+    image: centos-algo:7
+    workDir: /go/src/github.com/algorand/go-algorand
+    arch: amd64
+    target: ci-deps ci-build
   build-linux-arm64:
   - task: docker.Make
     image: centos-algo:7
+    workDir: /go/src/github.com/algorand/go-algorand
     arch: arm64v8
-    target: ci-deps ci-build ci-package
+    target: fulltest
+  - task: docker.Make
+    image: centos-algo:7
+    workDir: /go/src/github.com/algorand/go-algorand
+    arch: arm64v8
+    target: ci-deps ci-build
   build-local:
   - task: shell.Make
-    target: ci-deps ci-build ci-package
+    target: fulltest
+  - task: shell.Make
+    target: ci-deps ci-build
   release:
   - task: release.notes.GenerateReleaseNotes
     releaseVersion: ${GO_ALGORAND_RELEASE_VERSION}
     githubPatToken: ${GITHUB_PAT_TOKEN}
     githubRepoFullName: algorand/go-algorand
-

--- a/cicd.yaml
+++ b/cicd.yaml
@@ -1,23 +1,37 @@
 stages:
   build-linux-amd64:
+  - task: shell.docker.Ensure
+    image: algorand/go-algorand-linux
+    arch: amd64
+    dockerFilePath: docker/build/cicd.Dockerfile
+    configFilePath: scripts/configure_dev-deps.sh
   - task: docker.Make
-    image: centos-algo:7
+    image: algorand/go-algorand-linux
+    configFilePath: scripts/configure_dev-deps.sh
     workDir: /go/src/github.com/algorand/go-algorand
     arch: amd64
     target: fulltest
   - task: docker.Make
-    image: centos-algo:7
+    image: algorand/go-algorand-linux
+    configFilePath: scripts/configure_dev-deps.sh
     workDir: /go/src/github.com/algorand/go-algorand
     arch: amd64
     target: ci-deps ci-build
   build-linux-arm64:
+  - task: shell.docker.Ensure
+    image: algorand/go-algorand-linux
+    arch: arm64v8
+    dockerFilePath: docker/build/cicd.Dockerfile
+    configFilePath: scripts/configure_dev-deps.sh
   - task: docker.Make
-    image: centos-algo:7
+    configFilePath: scripts/configure_dev-deps.sh
+    image: algorand/go-algorand-linux
     workDir: /go/src/github.com/algorand/go-algorand
     arch: arm64v8
     target: fulltest
   - task: docker.Make
-    image: centos-algo:7
+    configFilePath: scripts/configure_dev-deps.sh
+    image: algorand/go-algorand-linux
     workDir: /go/src/github.com/algorand/go-algorand
     arch: arm64v8
     target: ci-deps ci-build

--- a/crypto/curve25519.go
+++ b/crypto/curve25519.go
@@ -17,8 +17,14 @@
 package crypto
 
 // #cgo CFLAGS: -Wall -std=c99
-// #cgo CFLAGS: -I${SRCDIR}/include
-// #cgo LDFLAGS: ${SRCDIR}/lib/libsodium.a
+// #cgo darwin,amd64 CFLAGS: -I${SRCDIR}/libs/darwin/amd64/include
+// #cgo darwin,amd64 LDFLAGS: ${SRCDIR}/libs/darwin/amd64/lib/libsodium.a
+// #cgo linux,amd64 CFLAGS: -I${SRCDIR}/libs/linux/amd64/include
+// #cgo linux,amd64 LDFLAGS: ${SRCDIR}/libs/linux/amd64/lib/libsodium.a
+// #cgo linux,arm64 CFLAGS: -I${SRCDIR}/libs/linux/arm64/include
+// #cgo linux,arm64 LDFLAGS: ${SRCDIR}/libs/linux/arm64/lib/libsodium.a
+// #cgo linux,arm CFLAGS: -I${SRCDIR}/libs/linux/arm/include
+// #cgo linux,arm LDFLAGS: ${SRCDIR}/libs/linux/arm/lib/libsodium.a
 // #include <stdint.h>
 // #include "sodium.h"
 import "C"

--- a/crypto/curve25519.go
+++ b/crypto/curve25519.go
@@ -17,6 +17,14 @@
 package crypto
 
 // #cgo CFLAGS: -Wall -std=c99
+// #cgo darwin,amd64 CFLAGS: -I${SRCDIR}/libs/darwin/amd64/include
+// #cgo darwin,amd64 LDFLAGS: ${SRCDIR}/libs/darwin/amd64/lib/libsodium.a
+// #cgo linux,amd64 CFLAGS: -I${SRCDIR}/libs/linux/amd64/include
+// #cgo linux,amd64 LDFLAGS: ${SRCDIR}/libs/linux/amd64/lib/libsodium.a
+// #cgo linux,arm64 CFLAGS: -I${SRCDIR}/libs/linux/arm64/include
+// #cgo linux,arm64 LDFLAGS: ${SRCDIR}/libs/linux/arm64/lib/libsodium.a
+// #cgo linux,arm CFLAGS: -I${SRCDIR}/libs/linux/arm/include
+// #cgo linux,arm LDFLAGS: ${SRCDIR}/libs/linux/arm/lib/libsodium.a
 // #include <stdint.h>
 // #include "sodium.h"
 import "C"

--- a/crypto/curve25519.go
+++ b/crypto/curve25519.go
@@ -17,14 +17,6 @@
 package crypto
 
 // #cgo CFLAGS: -Wall -std=c99
-// #cgo darwin,amd64 CFLAGS: -I${SRCDIR}/libs/darwin/amd64/include
-// #cgo darwin,amd64 LDFLAGS: ${SRCDIR}/libs/darwin/amd64/lib/libsodium.a
-// #cgo linux,amd64 CFLAGS: -I${SRCDIR}/libs/linux/amd64/include
-// #cgo linux,amd64 LDFLAGS: ${SRCDIR}/libs/linux/amd64/lib/libsodium.a
-// #cgo linux,arm64 CFLAGS: -I${SRCDIR}/libs/linux/arm64/include
-// #cgo linux,arm64 LDFLAGS: ${SRCDIR}/libs/linux/arm64/lib/libsodium.a
-// #cgo linux,arm CFLAGS: -I${SRCDIR}/libs/linux/arm/include
-// #cgo linux,arm LDFLAGS: ${SRCDIR}/libs/linux/arm/lib/libsodium.a
 // #include <stdint.h>
 // #include "sodium.h"
 import "C"

--- a/crypto/libsodium-fork/autogen.sh
+++ b/crypto/libsodium-fork/autogen.sh
@@ -32,5 +32,5 @@ fi
 
 $LIBTOOLIZE && \
 aclocal && \
-automake --add-missing --force-missing --include-deps && \
+automake $* --add-missing --force-missing --include-deps && \
 autoconf

--- a/crypto/vrf.go
+++ b/crypto/vrf.go
@@ -17,8 +17,10 @@
 package crypto
 
 // #cgo CFLAGS: -Wall -std=c99
-// #cgo CFLAGS: -I${SRCDIR}/include/
-// #cgo LDFLAGS: ${SRCDIR}/lib/libsodium.a
+// #cgo darwin,amd64 CFLAGS: -I${SRCDIR}/libs/darwin/amd64/include
+// #cgo darwin,amd64 LDFLAGS: ${SRCDIR}/libs/darwin/amd64/lib/libsodium.a
+// #cgo linux,amd64 CFLAGS: -I${SRCDIR}/libs/linux/amd64/include
+// #cgo linux,amd64 LDFLAGS: ${SRCDIR}/libs/linux/amd64/lib/libsodium.a
 // #include <stdint.h>
 // #include "sodium.h"
 import "C"

--- a/crypto/vrf.go
+++ b/crypto/vrf.go
@@ -21,6 +21,10 @@ package crypto
 // #cgo darwin,amd64 LDFLAGS: ${SRCDIR}/libs/darwin/amd64/lib/libsodium.a
 // #cgo linux,amd64 CFLAGS: -I${SRCDIR}/libs/linux/amd64/include
 // #cgo linux,amd64 LDFLAGS: ${SRCDIR}/libs/linux/amd64/lib/libsodium.a
+// #cgo linux,arm64 CFLAGS: -I${SRCDIR}/libs/linux/arm64/include
+// #cgo linux,arm64 LDFLAGS: ${SRCDIR}/libs/linux/arm64/lib/libsodium.a
+// #cgo linux,arm CFLAGS: -I${SRCDIR}/libs/linux/arm/include
+// #cgo linux,arm LDFLAGS: ${SRCDIR}/libs/linux/arm/lib/libsodium.a
 // #include <stdint.h>
 // #include "sodium.h"
 import "C"

--- a/crypto/vrf.go
+++ b/crypto/vrf.go
@@ -17,6 +17,14 @@
 package crypto
 
 // #cgo CFLAGS: -Wall -std=c99
+// #cgo darwin,amd64 CFLAGS: -I${SRCDIR}/libs/darwin/amd64/include
+// #cgo darwin,amd64 LDFLAGS: ${SRCDIR}/libs/darwin/amd64/lib/libsodium.a
+// #cgo linux,amd64 CFLAGS: -I${SRCDIR}/libs/linux/amd64/include
+// #cgo linux,amd64 LDFLAGS: ${SRCDIR}/libs/linux/amd64/lib/libsodium.a
+// #cgo linux,arm64 CFLAGS: -I${SRCDIR}/libs/linux/arm64/include
+// #cgo linux,arm64 LDFLAGS: ${SRCDIR}/libs/linux/arm64/lib/libsodium.a
+// #cgo linux,arm CFLAGS: -I${SRCDIR}/libs/linux/arm/include
+// #cgo linux,arm LDFLAGS: ${SRCDIR}/libs/linux/arm/lib/libsodium.a
 // #include <stdint.h>
 // #include "sodium.h"
 import "C"

--- a/crypto/vrf.go
+++ b/crypto/vrf.go
@@ -17,14 +17,6 @@
 package crypto
 
 // #cgo CFLAGS: -Wall -std=c99
-// #cgo darwin,amd64 CFLAGS: -I${SRCDIR}/libs/darwin/amd64/include
-// #cgo darwin,amd64 LDFLAGS: ${SRCDIR}/libs/darwin/amd64/lib/libsodium.a
-// #cgo linux,amd64 CFLAGS: -I${SRCDIR}/libs/linux/amd64/include
-// #cgo linux,amd64 LDFLAGS: ${SRCDIR}/libs/linux/amd64/lib/libsodium.a
-// #cgo linux,arm64 CFLAGS: -I${SRCDIR}/libs/linux/arm64/include
-// #cgo linux,arm64 LDFLAGS: ${SRCDIR}/libs/linux/arm64/lib/libsodium.a
-// #cgo linux,arm CFLAGS: -I${SRCDIR}/libs/linux/arm/include
-// #cgo linux,arm LDFLAGS: ${SRCDIR}/libs/linux/arm/lib/libsodium.a
 // #include <stdint.h>
 // #include "sodium.h"
 import "C"

--- a/docker/build/cicd.Dockerfile
+++ b/docker/build/cicd.Dockerfile
@@ -1,0 +1,26 @@
+ARG ARCH="amd64"
+
+FROM ${ARCH}/centos:7
+ENV GOLANG_VERSION 1.12
+ARG ARCH="amd64"
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum update -y && \
+    yum install -y autoconf wget awscli git gnupg2 nfs-utils python36 sqlite3 boost-devel expect jq libtool gcc-c++ libstdc++-devel libstdc++-static rpmdevtools createrepo rpm-sign bzip2 which ShellCheck
+WORKDIR /root
+RUN wget https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH%v*}.tar.gz \
+    && tar -xvf go${GOLANG_VERSION}.linux-${ARCH%v*}.tar.gz && \
+    mv go /usr/local
+ENV GOROOT=/usr/local/go \
+    GOPATH=$HOME/go
+RUN mkdir -p $GOPATH/src/github.com/algorand
+COPY . $GOPATH/src/github.com/algorand/go-algorand
+ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH \
+    BRANCH=${BRANCH} \
+    CHANNEL=${CHANNEL} \
+    BUILDCHANNEL=${BUILDCHANNEL} \
+    DEFAULTNETWORK=${DEFAULTNETWORK} \
+    FULLVERSION=${FULLVERSION} \
+    PKG_ROOT=${PKG_ROOT}
+WORKDIR $GOPATH/src/github.com/algorand/go-algorand
+RUN make ci-deps && make clean
+CMD ["/bin/bash"]

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -22,17 +22,7 @@ if [ "${OS}" = "linux" ]; then
         fi
         sudo apt-get update
         sudo apt-get install -y libboost-all-dev expect jq autoconf shellcheck
-    elif which yum > /dev/null; then
-        if ! which sudo > /dev/null
-        then
-            yum -y update
-            yum -y install sudo
-        fi
-        sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-        sudo yum update -y && \
-        sudo yum install -y autoconf wget awscli git gnupg2 nfs-utils python36 sqlite3 boost-devel expect jq libtool gcc-c++ libstdc++-devel libstdc++-static rpmdevtools createrepo rpm-sign bzip2 which ShellCheck
     fi
-
     
 elif [ "${OS}" = "darwin" ]; then
     brew update

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -14,16 +14,14 @@ function install_or_upgrade {
 }
 
 if [ "${OS}" = "linux" ]; then
-    if which apt-get > /dev/null; then
-        if ! which sudo > /dev/null
-        then
-            apt-get update
-            apt-get -y install sudo
-        fi
-        sudo apt-get update
-        sudo apt-get install -y libboost-all-dev expect jq autoconf shellcheck
+    if ! which sudo > /dev/null
+    then
+        apt-get update
+        apt-get -y install sudo
     fi
-    
+
+    sudo apt-get update
+    sudo apt-get install -y libboost-all-dev expect jq autoconf shellcheck
 elif [ "${OS}" = "darwin" ]; then
     brew update
     brew tap homebrew/cask

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -14,14 +14,26 @@ function install_or_upgrade {
 }
 
 if [ "${OS}" = "linux" ]; then
-    if ! which sudo > /dev/null
-    then
-        apt-get update
-        apt-get -y install sudo
+    if which apt-get > /dev/null; then
+        if ! which sudo > /dev/null
+        then
+            apt-get update
+            apt-get -y install sudo
+        fi
+        sudo apt-get update
+        sudo apt-get install -y libboost-all-dev expect jq autoconf shellcheck
+    elif which yum > /dev/null; then
+        if ! which sudo > /dev/null
+        then
+            yum -y update
+            yum -y install sudo
+        fi
+        sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+        sudo yum update -y && \
+        sudo yum install -y autoconf wget awscli git gnupg2 nfs-utils python36 sqlite3 boost-devel expect jq libtool gcc-c++ libstdc++-devel libstdc++-static rpmdevtools createrepo rpm-sign bzip2 which ShellCheck
     fi
 
-    sudo apt-get update
-    sudo apt-get install -y libboost-all-dev expect jq autoconf shellcheck
+    
 elif [ "${OS}" = "darwin" ]; then
     brew update
     brew tap homebrew/cask

--- a/scripts/release/build/rpm/build.sh
+++ b/scripts/release/build/rpm/build.sh
@@ -29,7 +29,6 @@ REPO_DIR=/root/go/src/github.com/algorand/go-algorand
 # Build!
 "${REPO_DIR}"/scripts/configure_dev-deps.sh
 cd "${REPO_DIR}"
-make crypto/lib/libsodium.a
 make build
 
 # Copy binaries to the host for use in the packaging stage.

--- a/scripts/travis/before_build.sh
+++ b/scripts/travis/before_build.sh
@@ -43,12 +43,12 @@ GOPATH=$(go env GOPATH)
 export GOPATH
 export GO111MODULE=on
 
-echo "Building libsodium-fork..."
-make crypto/lib/libsodium.a
-
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 OS=$("${SCRIPTPATH}"/../ostype.sh)
 ARCH=$("${SCRIPTPATH}"/../archtype.sh)
+
+echo "Building libsodium-fork..."
+make crypto/libs/${OS}/${ARCH}/lib/libsodium.a
 
 if [ "${OS}-${ARCH}" = "linux-arm" ]; then
     echo "Skipping running 'go vet'/gofmt/golint for arm builds"


### PR DESCRIPTION
## Summary

This is a PR to refactor our make file to make it more useful for our cicd process. Part of this was to refactor the libsodium-fork build so that it creates folders for different os/platforms so that our project's working directory can be shared between several different docker containers and systems at the same time. I also implemented two new targets to separate the concerns of gathering dependencies and building the project. This way our docker build process can execute the gathering deps target and our ci process can execute building artifacts.

## Test Plan

I tested that this works for a multi-platform build (it now creates artifacts for darwin/amd64, linux/amd64 and linux/arm64v8). I also attempted to verify that previous workflows of the related targets still work. I would like to have a lot of reviewers on this ticket verifying they can still use the scripts they've used previously, since the changes to libsodium could potentially affect some existing workflows that I missed.

