### PR TITLE
Remove libsodium make target from travis before_build script

### DIFF
--- a/scripts/travis/before_build.sh
+++ b/scripts/travis/before_build.sh
@@ -43,9 +43,6 @@ GOPATH=$(go env GOPATH)
 export GOPATH
 export GO111MODULE=on
 
-echo "Building libsodium-fork..."
-make crypto/lib/libsodium.a
-
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 OS=$("${SCRIPTPATH}"/../ostype.sh)
 ARCH=$("${SCRIPTPATH}"/../archtype.sh)


### PR DESCRIPTION
## Summary

Removing what appears to be an unnecessary call to the libsodium make target in a travis script

## Test Plan

I'm making a PR to run the travis job and seeing if the build still passes

