### PR TITLE
Actively scan for ledgers, normalize names cross platform

### DIFF
--- a/daemon/kmd/wallet/driver/ledger.go
+++ b/daemon/kmd/wallet/driver/ledger.go
@@ -145,20 +145,20 @@ func (lwd *LedgerWalletDriver) scanWalletsLocked() error {
 		delete(lwd.wallets, deadPath)
 	}
 
-	// Add in new devices
+	// Add in new ledger wallets if they appear valid
 	for _, dev := range newDevs {
-		id := pathToID(dev.USBInfo().Path)
-		lwd.wallets[id] = &LedgerWallet{
+		newWallet := &LedgerWallet{
 			dev: dev,
 		}
-	}
 
-	// Check that each device responds to algorand app requests
-	for id, dev := range lwd.wallets {
-		_, err := dev.ListKeys()
+		// Check that device responds to Algorand app requests
+		_, err := newWallet.ListKeys()
 		if err != nil {
-			delete(lwd.wallets, id)
+			continue
 		}
+
+		id := pathToID(dev.USBInfo().Path)
+		lwd.wallets[id] = newWallet
 	}
 
 	return nil


### PR DESCRIPTION
On macOS, the names of the ledger wallets were insanely long.

Additionally, ledgers have been enumerating twice -- the second device shows up after the Algorand app is opened.

This PR:
- Normalizes the length of ledger wallet names by replacing the USB `info.Path` with its truncated hash
- Only enumerates devices that respond to the "list public key" command