### PR TITLE
Faster external_build_printlog by using curl instead of aws cli

### DIFF
--- a/scripts/travis/external_build_printlog.sh
+++ b/scripts/travis/external_build_printlog.sh
@@ -25,7 +25,15 @@ while [ $SECONDS -lt $end ]; do
     aws s3 ls "${BUILD_LOG_PATH}"-"${LOG_SEQ}" ${NO_SIGN_REQUEST} 2> /dev/null > /dev/null
     if [ "$?" = "0" ]; then
         while true ; do
-            LOG_CHUNK=$(aws s3 cp "${BUILD_LOG_PATH}"-"${LOG_SEQ}" - ${NO_SIGN_REQUEST} 2> /dev/null)
+            if [ "${NO_SIGN_REQUEST}" == "--no-sign-request" ]; then
+                URL="${BUILD_LOG_PATH}-${LOG_SEQ}"
+                URL="${URL#s3://}"
+                URL="${URL/\//.s3.amazonaws.com/}"
+                URL="https://${URL}"
+                LOG_CHUNK=$(curl  --fail "${URL}" 2> /dev/null)
+            else
+                LOG_CHUNK=$(aws s3 cp "${BUILD_LOG_PATH}"-"${LOG_SEQ}" - ${NO_SIGN_REQUEST} 2> /dev/null)
+            fi
             if [ "$?" = "0" ]; then
                 echo "${LOG_CHUNK}"
                 ((LOG_SEQ++))


### PR DESCRIPTION
## Summary

The external_build_printlog.sh script was working correctly, but is a slow pace.
To some degree this is cause by the aws cli. Replacing this with curl improves the speed dramatically.

This is particularly useful when monitoring existing builds, as the script iterate thoughtout large number of files.

## Testing
The changes were tested manually, and seems to be working correctly.
