### PR TITLE
Disable the concurrent wallet generation

### DIFF
--- a/gen/generate.go
+++ b/gen/generate.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
+	//"runtime"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -124,7 +124,10 @@ func generateGenesisFiles(outDir string, protoVersion protocol.ConsensusVersion,
 	partKeyCreated := int64(0)
 
 	pendingWallets := make(chan genesisAllocation, len(allocation))
-	concurrentWalletGenerators := runtime.NumCPU() * 2
+
+	// temporary disable the concurrent execution, as it seems to create an issue with sqlite concurrently model.
+	// this should be removed once the undelying issue is resolved.
+	concurrentWalletGenerators := int(1) // runtime.NumCPU() * 2
 	errorsChannel := make(chan error, concurrentWalletGenerators)
 	verbosedOutput := make(chan string)
 	var creatingWalletsWaitGroup sync.WaitGroup


### PR DESCRIPTION
## Summary

In PR 68c29d277194569ae4aee622248e34432f2ccd76 we have added concurrent wallet generation to speed up the generation of wallets.
That was working fine.. Until we start seeing travis failures.

In this PR, I have set the concurrent goroutines count to 1, so that we won't run into these issues.
