### PR TITLE
Force docker to use `root` as the user when running the instance

### DIFF
--- a/scripts/release/build/Jenkinsfile
+++ b/scripts/release/build/Jenkinsfile
@@ -11,9 +11,7 @@ pipeline {
     agent {
         dockerfile {
             filename 'scripts/release/common/docker/setup.Dockerfile'
-            /*
-            args '-v /etc/passwd:/etc/passwd'
-            */
+            args '-u root'
         }
     }
 

--- a/scripts/release/common/docker/setup.Dockerfile
+++ b/scripts/release/common/docker/setup.Dockerfile
@@ -1,5 +1,16 @@
+# Note that we're installing `awscli` from pip rather than from the apt repository because of
+# the following error message:
+#
+# upload failed: pkg/2.0.63803/build_status_dev_2.0.63803.asc.gz to s3://{upload_location}/build_status_dev_2.0.63803.asc.gz seek() takes 2 positional arguments but 3 were given
+#
+# Note that the error only seems to occur when there is a file to upload with zero bytes,
+# but just to be safe we'll still use pip to download and install.
+#
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=869194
+# https://github.com/boto/s3transfer/pull/102
+
 FROM ubuntu:18.04
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y awscli jq ssh
-#RUN adduser --uid $(grep jenkins /etc/passwd | awk -F: '{ print $3 }') ubuntu
-RUN adduser --uid 111 ubuntu
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y jq git python python-pip ssh && \
+    pip install awscli
 


### PR DESCRIPTION
By default, docker will use the root user, but the jenkins pipeline
docker plugin inexplicitly runs the instance under the permissions of
the user that launched the script that contains the docker command.