### PR TITLE
Strip any defined remote repo from branch name when building

### DIFF
--- a/scripts/release/build/stage/setup/run.sh
+++ b/scripts/release/build/stage/setup/run.sh
@@ -4,8 +4,8 @@
 set -ex
 
 # Path(s) are relative to the root of the Jenkins workspace.
-INSTANCE=$(cat scripts/release/common/ec2/tmp/instance)
-BRANCH="$1"
+BRANCH=$(./scripts/release/util/check_remote.sh "$1")
+INSTANCE=$(cat ./scripts/release/common/ec2/tmp/instance)
 
 aws s3 cp s3://algorand-devops-misc/tools/gnupg2.2.9_centos7_amd64.tar.bz2 .
 scp -i ReleaseBuildInstanceKey.pem -o StrictHostKeyChecking=no -r scripts/release/common/setup.sh gnupg2.2.9_centos7_amd64.tar.bz2 ubuntu@"$INSTANCE":

--- a/scripts/release/util/check_remote.sh
+++ b/scripts/release/util/check_remote.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# When a Jenkins job watches multiple branches, the GIT_BRANCH env var can return "origin/rel/beta"
+# and the remote repo name must be # stripped from the front of the string.
+
+BRANCH="$1"
+
+for repo in $(git remote)
+do
+    pattern="$repo"/
+
+    if [[ "$BRANCH" =~ ^$pattern ]]
+    then
+        # Remove matching prefix.
+        echo "${BRANCH#$pattern}"
+        exit 0
+    fi
+done
+
+echo "$BRANCH"
+


### PR DESCRIPTION
When using a wildcard (*) character to watch multiple branches when
polling in Jenkins, the GIT_BRANCH environment variable will be
"origin/rel/beta" instead of just "rel/beta".  This breaks our tooling,
but a simple fix is this util which simply strips any matched remote
repo from the env var string value.