### PR TITLE
Better error case handling in database utils

### DIFF
--- a/agreement/service_test.go
+++ b/agreement/service_test.go
@@ -797,7 +797,7 @@ func setupAgreementWithValidator(t *testing.T, numNodes int, traceLevel traceLev
 
 	cleanupFn := func() {
 		for _, accessor := range dbAccessors {
-			defer accessor.Close()
+			accessor.Close()
 		}
 
 		if r := recover(); r != nil {

--- a/agreement/service_test.go
+++ b/agreement/service_test.go
@@ -796,8 +796,8 @@ func setupAgreementWithValidator(t *testing.T, numNodes int, traceLevel traceLev
 	}
 
 	cleanupFn := func() {
-		for _, accessor := range dbAccessors {
-			accessor.Close()
+		for idx := 0; idx < len(dbAccessors); idx++ {
+			dbAccessors[idx].Close()
 		}
 
 		if r := recover(); r != nil {

--- a/util/db/dbutil.go
+++ b/util/db/dbutil.go
@@ -89,11 +89,12 @@ func MakeErasableAccessor(dbfilename string) (Accessor, error) {
 }
 
 // runInitStatements executes initialization statements.
-func (db Accessor) runInitStatements() error {
+func (db *Accessor) runInitStatements() error {
 	for _, stmt := range initStatements {
 		_, err := db.Handle.Exec(stmt)
 		if err != nil {
 			db.Handle.Close()
+			db.Handle = nil
 			return err
 		}
 	}
@@ -114,7 +115,7 @@ func (db *Accessor) logger() logging.Logger {
 }
 
 // Close closes the connection.
-func (db Accessor) Close() {
+func (db *Accessor) Close() {
 	db.Handle.Close()
 	db.Handle = nil
 }


### PR DESCRIPTION
## Solution

Provide better handling for incorrect usage of the `Accessor` object.
In particular -  
1. The `func (db Accessor) Close()` function would now become a `func (db *Accessor) Close()`, so that the internal `Handle` variable would be cleared on the operating object.
1. In case of an initialization statement error, set the Handle to nil after closing the database object.
