### PR TITLE
Fix concurrent SQLite initialization

### DIFF
--- a/gen/generate.go
+++ b/gen/generate.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	//"runtime"
+	"runtime"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -125,9 +125,7 @@ func generateGenesisFiles(outDir string, protoVersion protocol.ConsensusVersion,
 
 	pendingWallets := make(chan genesisAllocation, len(allocation))
 
-	// temporary disable the concurrent execution, as it seems to create an issue with sqlite concurrently model.
-	// this should be removed once the undelying issue is resolved.
-	concurrentWalletGenerators := int(1) // runtime.NumCPU() * 2
+	concurrentWalletGenerators := runtime.NumCPU() * 2
 	errorsChannel := make(chan error, concurrentWalletGenerators)
 	verbosedOutput := make(chan string)
 	var creatingWalletsWaitGroup sync.WaitGroup

--- a/gen/generate_test.go
+++ b/gen/generate_test.go
@@ -1,0 +1,102 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package gen
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/algorand/go-algorand/data/account"
+	"github.com/algorand/go-algorand/util/db"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadMultiRootKeyConcurrent(t *testing.T) {
+	t.Skip() // skip in auto-test mode
+	a := require.New(t)
+	tempDir, err := ioutil.TempDir("", "loadkey-test-")
+	a.NoError(err)
+	defer os.RemoveAll(tempDir)
+
+	const numThreads = 100
+	var wg sync.WaitGroup
+	wg.Add(numThreads)
+
+	for i := 0; i < numThreads; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			wallet := filepath.Join(tempDir, fmt.Sprintf("wallet%d", idx+1))
+			rootDB, err := db.MakeErasableAccessor(wallet)
+			defer rootDB.Close()
+			a.NoError(err)
+			_, err = account.GenerateRoot(rootDB)
+			a.NoError(err)
+		}(i)
+	}
+
+	wg.Wait()
+
+	for r := 0; r < 1000; r++ {
+		var wg sync.WaitGroup
+		wg.Add(numThreads)
+		for i := 0; i < numThreads; i++ {
+			go func(idx int) {
+				defer wg.Done()
+				wallet := filepath.Join(tempDir, fmt.Sprintf("wallet%d", idx+1))
+				_, db, err := loadRootKey(wallet)
+				a.NoError(err)
+				db.Close()
+			}(i)
+		}
+		wg.Wait()
+	}
+}
+
+func TestLoadSingleRootKeyConcurrent(t *testing.T) {
+	t.Skip() // skip in auto-test mode
+	a := require.New(t)
+	tempDir, err := ioutil.TempDir("", "loadkey-test-")
+	a.NoError(err)
+	defer os.RemoveAll(tempDir)
+
+	wallet := filepath.Join(tempDir, "wallet1")
+	rootDB, err := db.MakeErasableAccessor(wallet)
+	a.NoError(err)
+	_, err = account.GenerateRoot(rootDB)
+	rootDB.Close()
+	a.NoError(err)
+
+	const numThreads = 10000
+	var wg sync.WaitGroup
+	wg.Add(numThreads)
+
+	for i := 0; i < numThreads; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			wallet := filepath.Join(tempDir, "wallet1")
+			_, db, err := loadRootKey(wallet)
+			a.NoError(err)
+			db.Close()
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
* SQLite init is not thread safe and mattn/go-sqlite3 does not care
* When open any db first time do it synchronously in order to make
  a nested sqlite3_initialize() the first call non-concurrently
* Re-enable mutli-threaded account generation
* Closes #846
