### PR TITLE
Redirect stdout of build log file to build release upload directory

### DIFF
--- a/scripts/release/build/stage/upload/task.sh
+++ b/scripts/release/build/stage/upload/task.sh
@@ -58,7 +58,7 @@ EOF
 # Note this file is scp'd in stage/upload.sh
 dpkg -l >> "${STATUSFILE}"
 gpg --clearsign "${STATUSFILE}"
-gzip "${STATUSFILE}".asc > "${HOME}"/node_pkg/"${STATUSFILE}".asc.gz
+gzip -c "${STATUSFILE}".asc > "${HOME}"/node_pkg/"${STATUSFILE}".asc.gz
 
 echo
 date "+build_release end UPLOAD stage %Y%m%d_%H%M%S"


### PR DESCRIPTION
Without the `-c` switch, the file redirected into `node_pkg/` was zero bytes.