### PR TITLE
telemetryhook gets stuck during shutdown

### DIFF
--- a/logging/telemetryhook.go
+++ b/logging/telemetryhook.go
@@ -146,6 +146,7 @@ func (hook *asyncTelemetryHook) Fire(entry *logrus.Entry) error {
 	select {
 	case <-hook.quit:
 		// telemetry quit
+		hook.wg.Done()
 	case hook.entries <- entry:
 	default:
 		hook.wg.Done()

--- a/logging/telemetryhook.go
+++ b/logging/telemetryhook.go
@@ -48,7 +48,25 @@ func createAsyncHookLevels(wrappedHook logrus.Hook, channelDepth uint, maxQueueD
 	}
 
 	go func() {
-		defer hook.wg.Done()
+		defer func() {
+			// flush the channel
+			moreEntries := true
+			for moreEntries {
+				select {
+				case entry := <-hook.entries:
+					hook.appendEntry(entry)
+				default:
+					moreEntries = false
+				}
+			}
+			for range hook.pending {
+				// The telemetry service is
+				// exiting. Un-wait for the left out
+				// messages.
+				hook.wg.Done()
+			}
+			hook.wg.Done()
+		}()
 
 		exit := false
 		for !exit {
@@ -126,6 +144,8 @@ func (hook *asyncTelemetryHook) waitForEventAndReady() bool {
 func (hook *asyncTelemetryHook) Fire(entry *logrus.Entry) error {
 	hook.wg.Add(1)
 	select {
+	case <-hook.quit:
+		// telemetry quit
 	case hook.entries <- entry:
 	default:
 		hook.wg.Done()


### PR DESCRIPTION

## Summary
When the elasticHook returns an error, asyncTelemetryHook will not change to ready state.
Consequently, the elements will get stuck in the channel and the buffer.
The waitGroup associated with these elements, will prevent the telemetry from quitting.
This PR stops waiting for these elements.