### PR TITLE
Add sqlite3 as a dependency

### DIFF
--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -52,6 +52,12 @@ check_deps() {
     then
         missing_dep shellcheck
     fi
+
+    # Don't print `sqlite3`s location.
+    if ! which sqlite3 > /dev/null
+    then
+        missing_dep sqlite3
+    fi
 }
 
 check_deps

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -32,7 +32,6 @@ elif [ "${OS}" = "darwin" ]; then
     install_or_upgrade autoconf
     install_or_upgrade automake
     install_or_upgrade shellcheck
-    install_or_upgrade sqlite
 fi
 
 "$SCRIPTPATH"/configure_dev-deps.sh

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -21,7 +21,7 @@ if [ "${OS}" = "linux" ]; then
     fi
 
     sudo apt-get update
-    sudo apt-get install -y libboost-all-dev expect jq autoconf shellcheck
+    sudo apt-get install -y libboost-all-dev expect jq autoconf shellcheck sqlite3
 elif [ "${OS}" = "darwin" ]; then
     brew update
     brew tap homebrew/cask
@@ -32,6 +32,7 @@ elif [ "${OS}" = "darwin" ]; then
     install_or_upgrade autoconf
     install_or_upgrade automake
     install_or_upgrade shellcheck
+    install_or_upgrade sqlite
 fi
 
 "$SCRIPTPATH"/configure_dev-deps.sh


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

When running `make`, `sqlite3` is used but was not included as a dependency in:
* `scripts/check_deps.sh`
* `scripts/configure_dev.sh`

## Test Plan

Ran `scripts/configure_dev.sh` and `make` on macOS and Ubuntu 18.04.

