### PR TITLE
Remove the phonebook from the node

### DIFF
--- a/agreement/gossip/networkFull_test.go
+++ b/agreement/gossip/networkFull_test.go
@@ -64,7 +64,7 @@ func spinNetwork(t *testing.T, nodesCount int) ([]*networkImpl, []*messageCounte
 	for nodeIdx := 0; nodeIdx < nodesCount; nodeIdx++ {
 		phonebooks[nodeIdx] = network.MakePhonebook(cfg.ConnectionsRateLimitingCount,
 			time.Duration(cfg.ConnectionsRateLimitingWindowSeconds)*time.Second)
-		gossipNode, err := network.NewWebsocketGossipNode(log.With("node", nodeIdx), cfg, phonebooks[nodeIdx], "go-test-agreement-network-genesis", config.Devtestnet)
+		gossipNode, err := network.NewWebsocketGossipNode(log.With("node", nodeIdx), cfg, nodesAddresses, "go-test-agreement-network-genesis", config.Devtestnet)
 		if err != nil {
 			t.Fatalf("fail making ws node: %v", err)
 		}
@@ -75,11 +75,7 @@ func spinNetwork(t *testing.T, nodesCount int) ([]*networkImpl, []*messageCounte
 		gossipNodes = append(gossipNodes, gossipNode)
 	}
 
-	for nodeIdx, gossipNode := range gossipNodes {
-		others := []string{}
-		others = append(others, nodesAddresses[nodeIdx+1:]...)
-		phonebooks[nodeIdx].ReplacePeerList(others, "")
-		log.Debugf("phonebook[%d] %#v", nodeIdx, others)
+	for _, gossipNode := range gossipNodes {
 		gossipNode.RequestConnectOutgoing(false, nil) // no disconnect.
 	}
 

--- a/agreement/gossip/networkFull_test.go
+++ b/agreement/gossip/networkFull_test.go
@@ -60,10 +60,7 @@ func spinNetwork(t *testing.T, nodesCount int) ([]*networkImpl, []*messageCounte
 	start := time.Now()
 	nodesAddresses := []string{}
 	gossipNodes := []network.GossipNode{}
-	phonebooks := make([]network.Phonebook, nodesCount)
 	for nodeIdx := 0; nodeIdx < nodesCount; nodeIdx++ {
-		phonebooks[nodeIdx] = network.MakePhonebook(cfg.ConnectionsRateLimitingCount,
-			time.Duration(cfg.ConnectionsRateLimitingWindowSeconds)*time.Second)
 		gossipNode, err := network.NewWebsocketGossipNode(log.With("node", nodeIdx), cfg, nodesAddresses, "go-test-agreement-network-genesis", config.Devtestnet)
 		if err != nil {
 			t.Fatalf("fail making ws node: %v", err)

--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -249,23 +249,23 @@ func main() {
 		log.Fatalf("DefaultDeadlock is somehow not set to an expected value (enable / disable): %s", config.DefaultDeadlock)
 	}
 
-	var phonebookAddressees []string
+	var phonebookAddresses []string
 	if peerOverrideArray != nil {
-		phonebookAddressees = peerOverrideArray
+		phonebookAddresses = peerOverrideArray
 	} else {
 		ex, err := os.Executable()
 		if err != nil {
 			log.Errorf("cannot locate node executable: %s", err)
-		}
-
-		phonebookDir := filepath.Dir(ex)
-		phonebookAddressees, err = config.LoadPhonebook(phonebookDir)
-		if err != nil {
-			log.Debugf("Cannot load static phonebook: %v", err)
+		} else {
+			phonebookDir := filepath.Dir(ex)
+			phonebookAddresses, err = config.LoadPhonebook(phonebookDir)
+			if err != nil {
+				log.Debugf("Cannot load static phonebook: %v", err)
+			}
 		}
 	}
 
-	err = s.Initialize(cfg, phonebookAddressees)
+	err = s.Initialize(cfg, phonebookAddresses)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		log.Error(err)

--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -264,7 +264,7 @@ func main() {
 			log.Debugf("Cannot load static phonebook: %v", err)
 		}
 	}
-	
+
 	err = s.Initialize(cfg, phonebookAddressees)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -275,7 +275,7 @@ func main() {
 	if *initAndExit {
 		return
 	}
-	
+
 	deadlockState := "enabled"
 	if deadlock.Opts.Disable {
 		deadlockState = "disabled"

--- a/cmd/netdummy/main.go
+++ b/cmd/netdummy/main.go
@@ -47,13 +47,13 @@ func main() {
 	log.SetLevel(logging.Debug)
 	log.SetOutput(os.Stderr)
 
-	addrs := network.MakePhonebook(conf.ConnectionsRateLimitingCount,
-		time.Duration(conf.ConnectionsRateLimitingWindowSeconds)*time.Second)
-	addrs.ReplacePeerList([]string{*serverAddress}, conf.DNSBootstrapID)
-
 	var nodes []network.GossipNode
 	for i := 0; i < *numClients; i++ {
-		n, _ := network.NewWebsocketGossipNode(log, conf, addrs, *genesisID, protocol.NetworkID(*networkID))
+		n, _ := network.NewWebsocketGossipNode(log,
+			conf,
+			[]string{*serverAddress},
+			*genesisID,
+			protocol.NetworkID(*networkID))
 		n.Start()
 		nodes = append(nodes, n)
 	}

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -59,7 +59,7 @@ type Server struct {
 }
 
 // Initialize creates a Node instance with applicable network services
-func (s *Server) Initialize(cfg config.Local, phonebookAddressees []string) error {
+func (s *Server) Initialize(cfg config.Local, phonebookAddresses []string) error {
 	// set up node
 	s.log = logging.Base()
 
@@ -119,7 +119,7 @@ func (s *Server) Initialize(cfg config.Local, phonebookAddressees []string) erro
 			NodeExporterPath:          cfg.NodeExporterPath,
 		})
 
-	s.node, err = node.MakeFull(s.log, s.RootPath, cfg, phonebookAddressees, s.Genesis)
+	s.node, err = node.MakeFull(s.log, s.RootPath, cfg, phonebookAddresses, s.Genesis)
 	if os.IsNotExist(err) {
 		return fmt.Errorf("node has not been installed: %s", err)
 	}

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -59,7 +59,7 @@ type Server struct {
 }
 
 // Initialize creates a Node instance with applicable network services
-func (s *Server) Initialize(cfg config.Local) error {
+func (s *Server) Initialize(cfg config.Local, phonebookAddressees []string) error {
 	// set up node
 	s.log = logging.Base()
 
@@ -119,13 +119,7 @@ func (s *Server) Initialize(cfg config.Local) error {
 			NodeExporterPath:          cfg.NodeExporterPath,
 		})
 
-	ex, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("cannot locate node executable: %s", err)
-	}
-	phonebookDir := filepath.Dir(ex)
-
-	s.node, err = node.MakeFull(s.log, s.RootPath, cfg, phonebookDir, s.Genesis)
+	s.node, err = node.MakeFull(s.log, s.RootPath, cfg, phonebookAddressees, s.Genesis)
 	if os.IsNotExist(err) {
 		return fmt.Errorf("node has not been installed: %s", err)
 	}
@@ -271,10 +265,4 @@ func (s *Server) Stop() {
 	os.Remove(s.pidFile)
 	os.Remove(s.netFile)
 	os.Remove(s.netListenFile)
-}
-
-// OverridePhonebook is used to replace the phonebook associated with
-// the server's node.
-func (s *Server) OverridePhonebook(dialOverride ...string) {
-	s.node.ReplacePeerList(dialOverride...)
 }

--- a/network/phonebook.go
+++ b/network/phonebook.go
@@ -134,8 +134,8 @@ func (e *phonebookImpl) filterRetryTime(t time.Time) []string {
 }
 
 // ReplacePeerList merges a set of addresses with that passed in.
-// new entries in they are being added
-// existing items that aren't included in they are being removed
+// new entries in addressesThey are being added
+// existing items that aren't included in addressesThey are being removed
 // matching entries don't change
 func (e *phonebookImpl) ReplacePeerList(addressesThey []string, networkName string) {
 	e.lock.Lock()

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1689,10 +1689,10 @@ func (wn *WebsocketNetwork) tryConnect(addr, gossipAddr string) {
 }
 
 // NewWebsocketNetwork constructor for websockets based gossip network
-func NewWebsocketNetwork(log logging.Logger, config config.Local, phonebookAddressees []string, genesisID string, networkID protocol.NetworkID) (wn *WebsocketNetwork, err error) {
+func NewWebsocketNetwork(log logging.Logger, config config.Local, phonebookAddresses []string, genesisID string, networkID protocol.NetworkID) (wn *WebsocketNetwork, err error) {
 	phonebook := MakePhonebook(config.ConnectionsRateLimitingCount,
 		time.Duration(config.ConnectionsRateLimitingWindowSeconds)*time.Second)
-	phonebook.ReplacePeerList(phonebookAddressees, config.DNSBootstrapID)
+	phonebook.ReplacePeerList(phonebookAddresses, config.DNSBootstrapID)
 	wn = &WebsocketNetwork{
 		log:       log,
 		config:    config,
@@ -1706,8 +1706,8 @@ func NewWebsocketNetwork(log logging.Logger, config config.Local, phonebookAddre
 }
 
 // NewWebsocketGossipNode constructs a websocket network node and returns it as a GossipNode interface implementation
-func NewWebsocketGossipNode(log logging.Logger, config config.Local, phonebookAddressees []string, genesisID string, networkID protocol.NetworkID) (gn GossipNode, err error) {
-	return NewWebsocketNetwork(log, config, phonebookAddressees, genesisID, networkID)
+func NewWebsocketGossipNode(log logging.Logger, config config.Local, phonebookAddresses []string, genesisID string, networkID protocol.NetworkID) (gn GossipNode, err error) {
+	return NewWebsocketNetwork(log, config, phonebookAddresses, genesisID, networkID)
 }
 
 // SetPrioScheme specifies the network priority scheme for a network node

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1689,16 +1689,25 @@ func (wn *WebsocketNetwork) tryConnect(addr, gossipAddr string) {
 }
 
 // NewWebsocketNetwork constructor for websockets based gossip network
-func NewWebsocketNetwork(log logging.Logger, config config.Local, phonebook Phonebook, genesisID string, networkID protocol.NetworkID) (wn *WebsocketNetwork, err error) {
-	wn = &WebsocketNetwork{log: log, config: config, phonebook: phonebook, GenesisID: genesisID, NetworkID: networkID}
+func NewWebsocketNetwork(log logging.Logger, config config.Local, phonebookAddressees []string, genesisID string, networkID protocol.NetworkID) (wn *WebsocketNetwork, err error) {
+	phonebook := MakePhonebook(config.ConnectionsRateLimitingCount,
+		time.Duration(config.ConnectionsRateLimitingWindowSeconds)*time.Second)
+	phonebook.ReplacePeerList(phonebookAddressees, config.DNSBootstrapID)
+	wn = &WebsocketNetwork{
+		log: log,
+		config: config,
+		phonebook: phonebook,
+		GenesisID: genesisID,
+		NetworkID: networkID,
+	}
 
 	wn.setup()
 	return wn, nil
 }
 
 // NewWebsocketGossipNode constructs a websocket network node and returns it as a GossipNode interface implementation
-func NewWebsocketGossipNode(log logging.Logger, config config.Local, phonebook Phonebook, genesisID string, networkID protocol.NetworkID) (gn GossipNode, err error) {
-	return NewWebsocketNetwork(log, config, phonebook, genesisID, networkID)
+func NewWebsocketGossipNode(log logging.Logger, config config.Local, phonebookAddressees []string, genesisID string, networkID protocol.NetworkID) (gn GossipNode, err error) {
+	return NewWebsocketNetwork(log, config, phonebookAddressees, genesisID, networkID)
 }
 
 // SetPrioScheme specifies the network priority scheme for a network node

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1694,8 +1694,8 @@ func NewWebsocketNetwork(log logging.Logger, config config.Local, phonebookAddre
 		time.Duration(config.ConnectionsRateLimitingWindowSeconds)*time.Second)
 	phonebook.ReplacePeerList(phonebookAddressees, config.DNSBootstrapID)
 	wn = &WebsocketNetwork{
-		log: log,
-		config: config,
+		log:       log,
+		config:    config,
 		phonebook: phonebook,
 		GenesisID: genesisID,
 		NetworkID: networkID,

--- a/node/node.go
+++ b/node/node.go
@@ -86,7 +86,6 @@ type AlgorandFullNode struct {
 
 	ledger    *data.Ledger
 	net       network.GossipNode
-	phonebook network.Phonebook
 
 	transactionPool *pools.TransactionPool
 	txHandler       *data.TxHandler
@@ -140,7 +139,7 @@ type TxnWithStatus struct {
 
 // MakeFull sets up an Algorand full node
 // (i.e., it returns a node that participates in consensus)
-func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookDir string, genesis bookkeeping.Genesis) (*AlgorandFullNode, error) {
+func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAddressees []string, genesis bookkeeping.Genesis) (*AlgorandFullNode, error) {
 
 	node := new(AlgorandFullNode)
 	node.rootDir = rootDir
@@ -148,17 +147,9 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookDir
 	node.log = log.With("name", cfg.NetAddress)
 	node.genesisID = genesis.ID()
 	node.genesisHash = crypto.HashObj(genesis)
-	node.phonebook = network.MakePhonebook(cfg.ConnectionsRateLimitingCount,
-		time.Duration(cfg.ConnectionsRateLimitingWindowSeconds)*time.Second)
-
-	addrs, err := config.LoadPhonebook(phonebookDir)
-	if err != nil {
-		log.Debugf("Cannot load static phonebook: %v", err)
-	}
-	node.phonebook.ReplacePeerList(addrs, node.config.DNSBootstrapID)
 
 	// tie network, block fetcher, and agreement services together
-	p2pNode, err := network.NewWebsocketNetwork(node.log, node.config, node.phonebook, genesis.ID(), genesis.Network)
+	p2pNode, err := network.NewWebsocketNetwork(node.log, node.config, phonebookAddressees, genesis.ID(), genesis.Network)
 	if err != nil {
 		log.Errorf("could not create websocket node: %v", err)
 		return nil, err
@@ -591,16 +582,6 @@ func (node *AlgorandFullNode) PoolStats() PoolStats {
 		NumOutstanding: uint64(node.transactionPool.PendingCount()),
 		NumExpired:     uint64(node.transactionPool.NumExpired(r)),
 	}
-}
-
-// ExtendPeerList dynamically adds a peer to a node's peer list.
-func (node *AlgorandFullNode) ExtendPeerList(peers ...string) {
-	node.phonebook.ExtendPeerList(peers, node.config.DNSBootstrapID)
-}
-
-// ReplacePeerList replaces the current peer list with a different one
-func (node *AlgorandFullNode) ReplacePeerList(peers ...string) {
-	node.phonebook.ReplacePeerList(peers, node.config.DNSBootstrapID)
 }
 
 // SuggestedFee returns the suggested fee per byte recommended to ensure a new transaction is processed in a timely fashion.

--- a/node/node.go
+++ b/node/node.go
@@ -84,8 +84,8 @@ type AlgorandFullNode struct {
 	cancelCtx context.CancelFunc
 	config    config.Local
 
-	ledger    *data.Ledger
-	net       network.GossipNode
+	ledger *data.Ledger
+	net    network.GossipNode
 
 	transactionPool *pools.TransactionPool
 	txHandler       *data.TxHandler

--- a/node/node.go
+++ b/node/node.go
@@ -139,7 +139,7 @@ type TxnWithStatus struct {
 
 // MakeFull sets up an Algorand full node
 // (i.e., it returns a node that participates in consensus)
-func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAddressees []string, genesis bookkeeping.Genesis) (*AlgorandFullNode, error) {
+func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAddresses []string, genesis bookkeeping.Genesis) (*AlgorandFullNode, error) {
 
 	node := new(AlgorandFullNode)
 	node.rootDir = rootDir
@@ -149,7 +149,7 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 	node.genesisHash = crypto.HashObj(genesis)
 
 	// tie network, block fetcher, and agreement services together
-	p2pNode, err := network.NewWebsocketNetwork(node.log, node.config, phonebookAddressees, genesis.ID(), genesis.Network)
+	p2pNode, err := network.NewWebsocketNetwork(node.log, node.config, phonebookAddresses, genesis.ID(), genesis.Network)
 	if err != nil {
 		log.Errorf("could not create websocket node: %v", err)
 		return nil, err

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -55,13 +55,7 @@ var defaultConfig = config.Local{
 	IncomingConnectionsLimit: -1,
 }
 
-func setupFullNodes(
-	t *testing.T, 
-	proto protocol.ConsensusVersion,
-	verificationPool execpool.BacklogPool,
-	customConsensus config.ConsensusProtocols,
-	willDelayStartFirstNode bool) ([]*AlgorandFullNode, []string, []string) {
-	
+func setupFullNodes(t *testing.T, proto protocol.ConsensusVersion, verificationPool execpool.BacklogPool, customConsensus config.ConsensusProtocols) ([]*AlgorandFullNode, []string, []string) {
 	util.RaiseRlimit(1000)
 	f, _ := os.Create(t.Name() + ".log")
 	logging.Base().SetJSONFormatter()
@@ -168,15 +162,6 @@ func setupFullNodes(
 	}
 
 	for i := range nodes {
-		// prepare the phonebook addresses
-		if willDelayStartFirstNode {
-			// connectPeers(nodes[1:])
-			
-			// delayStartNode(nodes[0], nodes[1:], 20*time.Second)
-		} else {
-			// connectPeers(nodes)
-		}
-		
 		rootDirectory := rootDirs[i]
 		cfg, err := config.LoadConfigFromDisk(rootDirectory)
 		require.NoError(t, err)
@@ -195,7 +180,7 @@ func TestSyncingFullNode(t *testing.T) {
 	backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)
 	defer backlogPool.Shutdown()
 
-	nodes, wallets, rootDirs := setupFullNodes(t, protocol.ConsensusCurrentVersion, backlogPool, nil, true)
+	nodes, wallets, rootDirs := setupFullNodes(t, protocol.ConsensusCurrentVersion, backlogPool, nil)
 	for i := 0; i < len(nodes); i++ {
 		defer os.Remove(wallets[i])
 		defer os.RemoveAll(rootDirs[i])
@@ -252,7 +237,7 @@ func TestInitialSync(t *testing.T) {
 	backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)
 	defer backlogPool.Shutdown()
 
-	nodes, wallets, rootdirs := setupFullNodes(t, protocol.ConsensusCurrentVersion, backlogPool, nil, true)
+	nodes, wallets, rootdirs := setupFullNodes(t, protocol.ConsensusCurrentVersion, backlogPool, nil)
 	for i := 0; i < len(nodes); i++ {
 		defer os.Remove(wallets[i])
 		defer os.RemoveAll(rootdirs[i])
@@ -319,7 +304,7 @@ func TestSimpleUpgrade(t *testing.T) {
 	testParams1.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 	configurableConsensus[consensusTest1] = testParams1
 
-	nodes, wallets, rootDirs := setupFullNodes(t, consensusTest0, backlogPool, configurableConsensus, true)
+	nodes, wallets, rootDirs := setupFullNodes(t, consensusTest0, backlogPool, configurableConsensus)
 	for i := 0; i < len(nodes); i++ {
 		defer os.Remove(wallets[i])
 		defer os.RemoveAll(rootDirs[i])


### PR DESCRIPTION
## Summary
The phonebook object is removed from the node. The phonebook is now local to the network. 
The node only passes list of addresses in string type to the network upon creation. 

## Test Plan

The node_test.go has many skipped test points relevant to this job. 
https://github.com/algorand/go-algorand/issues/892 is tracking this.
