### PR TITLE
Support of older kernels for locking files

### DIFF
--- a/libgoal/lockedFile.go
+++ b/libgoal/lockedFile.go
@@ -28,11 +28,15 @@ type locker interface {
 	unlock(fd *os.File) error
 }
 
-func newLockedFile(path string) *lockedFile {
+func newLockedFile(path string) (*lockedFile, error) {
+	locker, err := makeLocker()
+	if err != nil {
+		return nil, err
+	}
 	return &lockedFile{
 		path:   path,
-		locker: makeLocker(),
-	}
+		locker: locker,
+	}, nil
 }
 
 // lockedFile implementation

--- a/libgoal/lockedFileLinux.go
+++ b/libgoal/lockedFileLinux.go
@@ -21,8 +21,6 @@ package libgoal
 import (
 	"io"
 	"os"
-	"syscall"
-
 	"golang.org/x/sys/unix"
 )
 
@@ -41,31 +39,31 @@ func makeLocker() *linuxLocker {
 // the FcntlFlock has the most consistent behaviour across platforms,
 // and supports both local and network file systems.
 func (f *linuxLocker) tryRLock(fd *os.File) error {
-	flock := &syscall.Flock_t{
-		Type:   syscall.F_RDLCK,
+	flock := &unix.Flock_t{
+		Type:   unix.F_RDLCK,
 		Whence: int16(io.SeekStart),
 		Start:  0,
 		Len:    0,
 	}
-	return syscall.FcntlFlock(fd.Fd(), unix.F_OFD_SETLKW, flock)
+	return unix.FcntlFlock(fd.Fd(), unix.F_OFD_SETLKW, flock)
 }
 
 func (f *linuxLocker) tryLock(fd *os.File) error {
-	flock := &syscall.Flock_t{
-		Type:   syscall.F_WRLCK,
+	flock := &unix.Flock_t{
+		Type:   unix.F_WRLCK,
 		Whence: int16(io.SeekStart),
 		Start:  0,
 		Len:    0,
 	}
-	return syscall.FcntlFlock(fd.Fd(), unix.F_OFD_SETLKW, flock)
+	return unix.FcntlFlock(fd.Fd(), unix.F_OFD_SETLKW, flock)
 }
 
 func (f *linuxLocker) unlock(fd *os.File) error {
-	flock := &syscall.Flock_t{
-		Type:   syscall.F_UNLCK,
+	flock := &unix.Flock_t{
+		Type:   unix.F_UNLCK,
 		Whence: int16(io.SeekStart),
 		Start:  0,
 		Len:    0,
 	}
-	return syscall.FcntlFlock(fd.Fd(), unix.F_OFD_SETLKW, flock)
+	return unix.FcntlFlock(fd.Fd(), unix.F_OFD_SETLKW, flock)
 }

--- a/libgoal/lockedFileLinux.go
+++ b/libgoal/lockedFileLinux.go
@@ -19,9 +19,10 @@
 package libgoal
 
 import (
-	"golang.org/x/sys/unix"
 	"io"
 	"os"
+
+	"golang.org/x/sys/unix"
 )
 
 type linuxLocker struct {

--- a/libgoal/lockedFileUnix.go
+++ b/libgoal/lockedFileUnix.go
@@ -22,9 +22,10 @@
 package libgoal
 
 import (
-	"golang.org/x/sys/unix"
 	"io"
 	"os"
+
+	"golang.org/x/sys/unix"
 )
 
 type unixLocker struct {

--- a/libgoal/lockedFileUnix.go
+++ b/libgoal/lockedFileUnix.go
@@ -36,9 +36,9 @@ type unixLocker struct {
 // As OFD is not available on non-Linux OS, we fall back to the non-OFD lock
 // Falling back to the non-OFD lock would allow obtaining two locks by the same process. If this becomes
 // and issue, we might want to use flock, which wouldn't work across NFS.
-func makeLocker() *unixLocker {
+func makeLocker() (*unixLocker, error) {
 	locker := &unixLocker{}
-	return locker
+	return locker, nil
 }
 
 // the FcntlFlock has the most unixLocker behaviour across platforms,

--- a/libgoal/walletHandles.go
+++ b/libgoal/walletHandles.go
@@ -31,12 +31,18 @@ type walletHandles struct {
 }
 
 func readLocked(path string) ([]byte, error) {
-	lf := newLockedFile(path)
+	lf, err := newLockedFile(path)
+	if err != nil {
+		return nil, err
+	}
 	return lf.read()
 }
 
 func writeLocked(path string, data []byte, perm os.FileMode) error {
-	lf := newLockedFile(path)
+	lf, err := newLockedFile(path)
+	if err != nil {
+		return err
+	}
 	return lf.write(data, perm)
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

1. Fix locking file system to support older kernels and WSL. Fixes #852 
2. Remove use of deprecated `syscall` package: https://golang.org/pkg/syscall/
3. Remove use of hardcoded system constants that may depend on the architecture.

## Test Plan

Tested using `make test` on Ubuntu 18.04 and macOS. (But not on Ubuntu 18.04 in WSL.)
Tested that `goal account new` and `goal account list` work on Ubuntu 18.04 in WSL.
