### PR TITLE
Fix silent failure in test phase

### DIFF
--- a/scripts/release/test/Jenkinsfile
+++ b/scripts/release/test/Jenkinsfile
@@ -4,7 +4,7 @@ def TYPE = "t2.2xlarge"
 
 pipeline {
     parameters {
-        string defaultValue: 'master', description: 'Branch name or tag name.', name: 'branch', trim: true
+        string defaultValue: 'rel/stable', description: 'Branch name or tag name.', name: 'branch', trim: true
     }
 
     environment {

--- a/scripts/release/test/Jenkinsfile
+++ b/scripts/release/test/Jenkinsfile
@@ -4,7 +4,7 @@ def TYPE = "t2.2xlarge"
 
 pipeline {
     parameters {
-        string defaultValue: 'rel/stable', description: 'Branch name or tag name.', name: 'branch', trim: true
+        string defaultValue: 'master', description: 'Branch name or tag name.', name: 'branch', trim: true
     }
 
     environment {

--- a/scripts/release/test/util/test_package.sh
+++ b/scripts/release/test/util/test_package.sh
@@ -34,14 +34,11 @@ fi
 build_images () {
     # We'll use this simple tokenized Dockerfile.
     # https://serverfault.com/a/72511
-    IFS='' read -r -d '' TOKENIZED <<EOF
-FROM {{OS}}
-
-WORKDIR /root
-# It's easier just to copy all contents into the container.
-COPY . .
-CMD ["/bin/bash"]
-EOF
+    TOKENIZED=$(echo -e "\
+FROM {{OS}}\n\n\
+WORKDIR /root\n\
+COPY . .\n\
+CMD [\"/bin/bash\"]")
 
     for item in ${OS_LIST[*]}
     do


### PR DESCRIPTION
Setting `set -e` caused the build to abort and clean itself up (delete the ec2 instance), as the script returned `exit 1`.  However, removing the `set` statement had the effect of the script running and finishing properly with a return value of `exit 0`.  I found it very odd, and played with it for a while, but then decided that it was more important to just fix it and move on.