### PR TITLE
Brice/write install script for mule

### DIFF
--- a/scripts/install_mule.sh
+++ b/scripts/install_mule.sh
@@ -26,8 +26,6 @@ while getopts ":v:uh" opt; do
   esac
 done
 
-
-
 if CURRENT_MULE_VERSION=$(mule -v 2> /dev/null); then
     if [[ ${CURRENT_MULE_VERSION} == ${MULE_VERSION} ]]; then
         echo "Mule version $(mule -v) is already installed"

--- a/scripts/install_mule.sh
+++ b/scripts/install_mule.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+if mule -v &> /dev/null; then
+    echo "Mule version $(mule -v) is already installed"
+    exit 0
+fi
+
+if VERSION=$(pip3 --version) &> /dev/null; then
+    PIP="pip3"
+elif VERSION=$(pip --version) &> /dev/null; then
+    PIP="pip"
+else
+    echo "You must have pip installed to set up Mule"
+    exit 1
+fi
+
+if [[ ! "${VERSION}" =~ .*'python 3'.* ]]; then
+    echo "Your pip installation must be using python 3"
+    exit 1
+fi
+
+TIME=$(date +%s)
+INSTALL_DIR="/tmp/mule-install-${TIME}"
+mkdir -p ${INSTALL_DIR}
+git clone git@github.com:algorand/go-algorand-ci.git ${INSTALL_DIR}/go-algorand-ci
+pip3 install ${INSTALL_DIR}/go-algorand-ci/cli/dist/mule-0.0.0-py3-none-any.whl
+rm -rf ${INSTALL_DIR}

--- a/scripts/install_mule.sh
+++ b/scripts/install_mule.sh
@@ -24,9 +24,12 @@ done
 
 
 
-if mule -v &> /dev/null; then
-    echo "Mule version $(mule -v) is already installed"
-    exit 0
+if CURRENT_MULE_VERSION=$(mule -v 2> /dev/null); then
+    if [[ ${CURRENT_MULE_VERSION} == ${MULE_VERSION} ]]; then
+        echo "Mule version $(mule -v) is already installed"
+        exit 0
+    fi
+    echo "Mule version ${CURRENT_MULE_VERSION} currently installed, installing ${MULE_VERSION}..."
 fi
 
 if VERSION=$(pip3 --version 2> /dev/null); then

--- a/scripts/install_mule.sh
+++ b/scripts/install_mule.sh
@@ -4,20 +4,24 @@ set -e
 
 MULE_VERSION='0.0.0'
 
-while getopts ":v:u" opt; do
+HELP="Usage: cmd [-v] [-u]
+
+Options:
+    -v        Version of mule cli (default is '${MULE_VERSION}')
+    -u        Authenticate to github (algorand/go-algorand-ci repository) with user credentials (Default is over ssh)
+"
+
+while getopts ":v:uh" opt; do
   case ${opt} in
     v ) MULE_VERSION=$OPTARG
       ;;
     u ) USER_AUTH="True"
       ;;
-    \? ) echo """
-Usage: cmd [-v] [-u]
-
-Options:
-    -v        Version of mule cli
-    -u        Authenticate to github (algorand/go-algorand-ci repository) with user credentials (Default is over ssh)
-"""
-        exit 1
+    h ) echo "${HELP}"
+        exit 0
+      ;;
+    \? ) echo "${HELP}"
+        exit 2
       ;;
   esac
 done

--- a/scripts/install_mule.sh
+++ b/scripts/install_mule.sh
@@ -4,7 +4,7 @@ set -e
 
 MULE_VERSION='0.0.0'
 
-HELP="Usage: cmd [-v] [-u]
+HELP="Usage: $0 [-v] [-u]
 
 Script for installing the mule cli.
 

--- a/scripts/install_mule.sh
+++ b/scripts/install_mule.sh
@@ -6,9 +6,16 @@ MULE_VERSION='0.0.0'
 
 HELP="Usage: cmd [-v] [-u]
 
+Script for installing the mule cli.
+
+Requires:
+    * pip
+    * python 3
+    * git (And access to algorand/go-algorand-ci repository on github)
+
 Options:
     -v        Version of mule cli (default is '${MULE_VERSION}')
-    -u        Authenticate to github (algorand/go-algorand-ci repository) with user credentials (Default is over ssh)
+    -u        Authenticate to github (algorand/go-algorand-ci repository) with user credentials (default is over ssh)
 "
 
 while getopts ":v:uh" opt; do
@@ -34,16 +41,16 @@ if CURRENT_MULE_VERSION=$(mule -v 2> /dev/null); then
     echo "Mule version ${CURRENT_MULE_VERSION} currently installed, installing ${MULE_VERSION}..."
 fi
 
-if VERSION=$(pip3 --version 2> /dev/null); then
+if PIP_VERSION=$(pip3 --version 2> /dev/null); then
     PIP="pip3"
-elif VERSION=$(pip --version 2> /dev/null); then
+elif PIP_VERSION=$(pip --version 2> /dev/null); then
     PIP="pip"
 else
     echo "You must have pip installed to set up Mule"
     exit 1
 fi
 
-if [[ ! "${VERSION}" =~ .*'python 3'.* ]]; then
+if [[ ! "${PIP_VERSION}" =~ .*'python 3'.* ]]; then
     echo "Your pip installation must be using python 3"
     exit 1
 fi
@@ -56,5 +63,5 @@ if [[ ${USER_AUTH} == "True" ]]; then
 else
     git clone git@github.com:algorand/go-algorand-ci.git ${INSTALL_DIR}/go-algorand-ci
 fi
-pip3 install ${INSTALL_DIR}/go-algorand-ci/cli/dist/mule-${MULE_VERSION}-py3-none-any.whl --upgrade
+${PIP} install ${INSTALL_DIR}/go-algorand-ci/cli/dist/mule-${MULE_VERSION}-py3-none-any.whl --upgrade
 rm -rf ${INSTALL_DIR}

--- a/scripts/install_mule.sh
+++ b/scripts/install_mule.sh
@@ -7,9 +7,9 @@ if mule -v &> /dev/null; then
     exit 0
 fi
 
-if VERSION=$(pip3 --version) &> /dev/null; then
+if VERSION=$(pip3 --version 2> /dev/null); then
     PIP="pip3"
-elif VERSION=$(pip --version) &> /dev/null; then
+elif VERSION=$(pip --version 2> /dev/null); then
     PIP="pip"
 else
     echo "You must have pip installed to set up Mule"

--- a/scripts/install_mule.sh
+++ b/scripts/install_mule.sh
@@ -2,6 +2,28 @@
 
 set -e
 
+MULE_VERSION='0.0.0'
+
+while getopts ":v:u" opt; do
+  case ${opt} in
+    v ) MULE_VERSION=$OPTARG
+      ;;
+    u ) USER_AUTH="True"
+      ;;
+    \? ) echo """
+Usage: cmd [-v] [-u]
+
+Options:
+    -v        Version of mule cli
+    -u        Authenticate to github (algorand/go-algorand-ci repository) with user credentials (Default is over ssh)
+"""
+        exit 1
+      ;;
+  esac
+done
+
+
+
 if mule -v &> /dev/null; then
     echo "Mule version $(mule -v) is already installed"
     exit 0
@@ -24,6 +46,10 @@ fi
 TIME=$(date +%s)
 INSTALL_DIR="/tmp/mule-install-${TIME}"
 mkdir -p ${INSTALL_DIR}
-git clone git@github.com:algorand/go-algorand-ci.git ${INSTALL_DIR}/go-algorand-ci
-pip3 install ${INSTALL_DIR}/go-algorand-ci/cli/dist/mule-0.0.0-py3-none-any.whl
+if [[ ${USER_AUTH} == "True" ]]; then
+    git clone https://github.com/algorand/go-algorand-ci.git ${INSTALL_DIR}/go-algorand-ci
+else
+    git clone git@github.com:algorand/go-algorand-ci.git ${INSTALL_DIR}/go-algorand-ci
+fi
+pip3 install ${INSTALL_DIR}/go-algorand-ci/cli/dist/mule-${MULE_VERSION}-py3-none-any.whl --upgrade
 rm -rf ${INSTALL_DIR}


### PR DESCRIPTION
## Summary

This script ensures that mule is installed on the machine it is run on. This will be necessary for our travis job and likely useful for any devs wanting to use the mule cli.

## Test Plan

I tested the following scenarios:
* No pip installation
* Pip installed with wrong version of python
* git clone from ssh url of go-algorand-ci repo
* git clone from https url of go-algorand-ci repo
* install of default mule version (0.0.0)
* version change to 0.0.0 when version 0.0.1 is currently installed on the system
* desired version already installed on system (both for default and set to 0.0.1)

