### PR TITLE
Enable upgrade delay tuning.

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -542,12 +542,19 @@ func initConsensusProtocols() {
 	// v20 can be upgraded to v21.
 	v20.ApprovedUpgrades[protocol.ConsensusV21] = 0
 
+	// v21_1 (betanet-only) is an upgrade which allows tuning the number of rounds to wait to execute upgrades.
+	v21_1 := v21
+	v21_1.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	v21_1.MinUpgradeWaitRounds = 10000
+	v21_1.MaxUpgradeWaitRounds = 150000
+	Consensus[protocol.ConsensusV21_1] = v21_1
+	// v21 can be upgraded to v21_1.
+	v21.ApprovedUpgrades[protocol.ConsensusV21_1] = 0
+
 	// ConsensusFuture is used to test features that are implemented
 	// but not yet released in a production protocol version.
-	vFuture := v21
+	vFuture := v21_1
 	vFuture.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
-	vFuture.MinUpgradeWaitRounds = 10000
-	vFuture.MaxUpgradeWaitRounds = 150000
 	Consensus[protocol.ConsensusFuture] = vFuture
 }
 

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -542,18 +542,18 @@ func initConsensusProtocols() {
 	// v20 can be upgraded to v21.
 	v20.ApprovedUpgrades[protocol.ConsensusV21] = 0
 
-	// v21_1 (betanet-only) is an upgrade which allows tuning the number of rounds to wait to execute upgrades.
-	v21_1 := v21
-	v21_1.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
-	v21_1.MinUpgradeWaitRounds = 10000
-	v21_1.MaxUpgradeWaitRounds = 150000
-	Consensus[protocol.ConsensusV21_1] = v21_1
-	// v21 can be upgraded to v21_1.
-	v21.ApprovedUpgrades[protocol.ConsensusV21_1] = 0
+	// v22 is an upgrade which allows tuning the number of rounds to wait to execute upgrades.
+	v22 := v21
+	v22.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	v22.MinUpgradeWaitRounds = 10000
+	v22.MaxUpgradeWaitRounds = 150000
+	Consensus[protocol.ConsensusV22] = v22
+	// v21 can be upgraded to v22.
+	v21.ApprovedUpgrades[protocol.ConsensusV22] = 0
 
 	// ConsensusFuture is used to test features that are implemented
 	// but not yet released in a production protocol version.
-	vFuture := v21_1
+	vFuture := v22
 	vFuture.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 	Consensus[protocol.ConsensusFuture] = vFuture
 }

--- a/data/bookkeeping/block.go
+++ b/data/bookkeeping/block.go
@@ -394,7 +394,7 @@ func ProcessUpgradeParams(prev BlockHeader) (uv UpgradeVote, us UpgradeState, er
 		}
 	}
 
-	// If there is a proposal being voted on, see if we approve it and its delay
+	// If there is a proposal being voted on, see if we approve it
 	round := prev.Round + 1
 	if round < prev.NextProtocolVoteBefore {
 		_, ok := prevParams.ApprovedUpgrades[prev.NextProtocol]

--- a/data/bookkeeping/block_test.go
+++ b/data/bookkeeping/block_test.go
@@ -42,6 +42,8 @@ func init() {
 	params1.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{
 		proto2: 0,
 	}
+	params1.MinUpgradeWaitRounds = 0
+	params1.MaxUpgradeWaitRounds = 0
 	config.Consensus[proto1] = params1
 
 	params2 := config.Consensus[protocol.ConsensusCurrentVersion]

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -118,6 +118,11 @@ const ConsensusV21 = ConsensusVersion(
 	"https://github.com/algorandfoundation/specs/tree/8096e2df2da75c3339986317f9abe69d4fa86b4b",
 )
 
+// ConsensusV21_1 (betanet-only) allows tuning the upgrade delay.
+const ConsensusV21_1 = ConsensusVersion(
+	"https://github.com/algorandfoundation/specs/tree/96076cefdb621f5024f9f1ebd7d0ce8c895b1dbc",
+)
+
 // ConsensusFuture is a protocol that should not appear in any production
 // network, but is used to test features before they are released.
 const ConsensusFuture = ConsensusVersion(

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -118,9 +118,9 @@ const ConsensusV21 = ConsensusVersion(
 	"https://github.com/algorandfoundation/specs/tree/8096e2df2da75c3339986317f9abe69d4fa86b4b",
 )
 
-// ConsensusV21_1 (betanet-only) allows tuning the upgrade delay.
-const ConsensusV21_1 = ConsensusVersion(
-	"https://github.com/algorandfoundation/specs/tree/96076cefdb621f5024f9f1ebd7d0ce8c895b1dbc",
+// ConsensusV22 allows tuning the upgrade delay.
+const ConsensusV22 = ConsensusVersion(
+	"https://github.com/algorandfoundation/specs/tree/57016b942f6d97e6d4c0688b373bb0a2fc85a1a2",
 )
 
 // ConsensusFuture is a protocol that should not appear in any production

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -135,7 +135,7 @@ const ConsensusFuture = ConsensusVersion(
 
 // ConsensusCurrentVersion is the latest version and should be used
 // when a specific version is not provided.
-const ConsensusCurrentVersion = ConsensusV21
+const ConsensusCurrentVersion = ConsensusV22
 
 // Error is used to indicate that an unsupported protocol has been detected.
 type Error ConsensusVersion


### PR DESCRIPTION
Enable executing protocol upgrade as implemented at 
https://github.com/algorand/go-algorand/commit/7a415e4855558e66b55785b8342f4e59cb60a2ec and approved at 
https://github.com/algorandfoundation/specs/commit/57016b942f6d97e6d4c0688b373bb0a2fc85a1a2