### PR TITLE
Catchup service through gossip connections using the topics

### DIFF
--- a/catchup/fetcher_test.go
+++ b/catchup/fetcher_test.go
@@ -770,12 +770,59 @@ func TestGetFutureBlock(t *testing.T) {
 
 // implement network.UnicastPeer
 type testUnicastPeer struct {
-	gn network.GossipNode
-	t  *testing.T
+	gn               network.GossipNode
+	version          string
+	responseChannels map[uint64]chan *network.Response
+	t                *testing.T
 }
 
 func (p *testUnicastPeer) GetAddress() string {
 	return "test"
+}
+
+func (p *testUnicastPeer) Request(ctx context.Context, tag protocol.Tag, topics network.Topics) (resp *network.Response, e error) {
+
+	responseChannel := make(chan *network.Response, 1)      
+	p.responseChannels[0] = responseChannel
+	
+	ps := p.gn.(*httpTestPeerSource)
+	var dispather network.MessageHandler
+	for _, v := range ps.dispatchHandlers {
+		if v.Tag == tag {
+			dispather = v.MessageHandler
+			break
+		}
+	}
+	require.NotNil(p.t, dispather)
+	dispather.Handle(network.IncomingMessage{Tag: tag, Data: topics.MarshallTopics(), Sender: p, Net: p.gn})
+
+	// wait for the channel.
+	select {
+	case resp = <-responseChannel:
+		return resp, nil
+	case <-ctx.Done():
+		return resp, ctx.Err()
+	}
+	return resp, nil
+}
+
+func (p *testUnicastPeer) Respond(ctx context.Context, reqMsg network.IncomingMessage, responseTopics network.Topics) (e error) {
+	
+	hashKey := uint64(0)
+	channel, found := p.responseChannels[hashKey]
+	if !found {
+	}
+	
+	select {
+	case channel <- &network.Response{Topics: responseTopics}:
+	default:
+	}
+	
+	return nil
+}
+
+func (p *testUnicastPeer) Version() string {
+	return p.version
 }
 
 func (p *testUnicastPeer) Unicast(ctx context.Context, msg []byte, tag protocol.Tag) error {
@@ -792,10 +839,12 @@ func (p *testUnicastPeer) Unicast(ctx context.Context, msg []byte, tag protocol.
 	return nil
 }
 
-func makeTestUnicastPeer(gn network.GossipNode, t *testing.T) network.UnicastPeer {
+func makeTestUnicastPeer(gn network.GossipNode, version string, t *testing.T) network.UnicastPeer {
 	wsp := testUnicastPeer{}
 	wsp.gn = gn
 	wsp.t = t
+	wsp.version = version
+	wsp.responseChannels = make(map[uint64]chan *network.Response)
 	return &wsp
 }
 
@@ -816,40 +865,44 @@ func TestGetBlockWS(t *testing.T) {
 		return
 	}
 
-	net := buildTestHTTPPeerSource()
-	ledgerServiceConfig := config.GetDefaultLocal()
-	ledgerServiceConfig.CatchupParallelBlocks = 5
-	ls := rpcs.RegisterLedgerService(ledgerServiceConfig, ledger, net, "test genesisID")
+	versions := []string{"1", "2.1"}
+	for _, version := range versions { // range network.SupportedProtocolVersions {
 
-	ls.Start()
+		net := buildTestHTTPPeerSource()
+		ledgerServiceConfig := config.GetDefaultLocal()
+		ledgerServiceConfig.CatchupParallelBlocks = 5
+		ls := rpcs.RegisterLedgerService(ledgerServiceConfig, ledger, net, "test genesisID")
 
-	up := makeTestUnicastPeer(net, t)
-	net.peers = append(net.peers, up)
+		ls.Start()
 
-	fs := rpcs.RegisterWsFetcherService(logging.TestingLog(t), net)
+		up := makeTestUnicastPeer(net, version, t)
+		net.peers = append(net.peers, up)
 
-	_, ok := net.GetPeers(network.PeersConnectedIn)[0].(network.UnicastPeer)
-	require.True(t, ok)
-	factory := MakeNetworkFetcherFactory(net, numberOfPeers, fs)
-	factory.log = logging.TestingLog(t)
-	fetcher := factory.NewOverGossip(protocol.UniCatchupReqTag)
-	// we have one peer, the Ws block server
-	require.Equal(t, fetcher.NumPeers(), 1)
+		fs := rpcs.RegisterWsFetcherService(logging.TestingLog(t), net)
 
-	var block *bookkeeping.Block
-	var cert *agreement.Certificate
-	var client FetcherClient
+		_, ok := net.GetPeers(network.PeersConnectedIn)[0].(network.UnicastPeer)
+		require.True(t, ok)
+		factory := MakeNetworkFetcherFactory(net, numberOfPeers, fs)
+		factory.log = logging.TestingLog(t)
+		fetcher := factory.NewOverGossip(protocol.UniCatchupReqTag)
+		// we have one peer, the Ws block server
+		require.Equal(t, fetcher.NumPeers(), 1)
 
-	start := time.Now()
-	block, cert, client, err = fetcher.FetchBlock(context.Background(), next)
-	require.NotNil(t, client)
-	require.NoError(t, err)
-	end := time.Now()
-	require.True(t, end.Sub(start) < 10*time.Second)
-	require.Equal(t, &b, block)
-	if err == nil {
-		require.NotEqual(t, nil, block)
-		require.NotEqual(t, nil, cert)
+		var block *bookkeeping.Block
+		var cert *agreement.Certificate
+		var client FetcherClient
+
+		//		start := time.Now()
+		block, cert, client, err = fetcher.FetchBlock(context.Background(), next)
+		require.NotNil(t, client)
+		require.NoError(t, err)
+		//		end := time.Now()
+		//		require.True(t, end.Sub(start) < 10*time.Second)
+		require.Equal(t, &b, block)
+		if err == nil {
+			require.NotEqual(t, nil, block)
+			require.NotEqual(t, nil, cert)
+		}
+		fetcher.Close()
 	}
-	fetcher.Close()
 }

--- a/catchup/fetcher_test.go
+++ b/catchup/fetcher_test.go
@@ -782,9 +782,9 @@ func (p *testUnicastPeer) GetAddress() string {
 
 func (p *testUnicastPeer) Request(ctx context.Context, tag protocol.Tag, topics network.Topics) (resp *network.Response, e error) {
 
-	responseChannel := make(chan *network.Response, 1)      
+	responseChannel := make(chan *network.Response, 1)
 	p.responseChannels[0] = responseChannel
-	
+
 	ps := p.gn.(*httpTestPeerSource)
 	var dispather network.MessageHandler
 	for _, v := range ps.dispatchHandlers {
@@ -803,21 +803,20 @@ func (p *testUnicastPeer) Request(ctx context.Context, tag protocol.Tag, topics 
 	case <-ctx.Done():
 		return resp, ctx.Err()
 	}
-	return resp, nil
 }
 
 func (p *testUnicastPeer) Respond(ctx context.Context, reqMsg network.IncomingMessage, responseTopics network.Topics) (e error) {
-	
+
 	hashKey := uint64(0)
 	channel, found := p.responseChannels[hashKey]
 	if !found {
 	}
-	
+
 	select {
 	case channel <- &network.Response{Topics: responseTopics}:
 	default:
 	}
-	
+
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -269,6 +269,9 @@ type Local struct {
 	// DisableOutgoingConnectionThrottling disables the connection throttling of the network library, which
 	// allow the network library to continuesly disconnect relays based on their relative ( and absolute ) performance.
 	DisableOutgoingConnectionThrottling bool
+
+	// NetworkProtocolVersion overrides network protocol version ( if present )
+	NetworkProtocolVersion string
 }
 
 // Filenames of config files within the configdir (e.g. ~/.algorand)

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -71,6 +71,7 @@ var defaultLocalV6 = Local{
 	LogSizeLimit:                          1073741824,
 	MaxConnectionsPerIP:                   30,
 	NetAddress:                            "",
+	NetworkProtocolVersion:                "",
 	NodeExporterListenAddress:             ":9100",
 	NodeExporterPath:                      "./node_exporter",
 	OutgoingMessageFilterBucketCount:      3,

--- a/network/topics.go
+++ b/network/topics.go
@@ -23,15 +23,10 @@ import (
 	"github.com/algorand/go-algorand/crypto"
 )
 
-// Constant strings used as keys or values for topics
+// Constant strings used as keys for topics
 const (
-	RoundKey           = "ky"
-	RequestDataTypeKey = "typ"
-	RequestHashKey     = "RequestHash"
-	BlockDataKey       = "BDK"
-	CertDataKey        = "CDK"
-	ErrorKey           = "ERR"
-	BlockAndCertValue  = "BlockAndCertificate"
+	requestHashKey     = "RequestHash"
+	ErrorKey           = "ERR" // used for passing an error message
 )
 
 // Topic is a key-value pair
@@ -40,7 +35,7 @@ type Topic struct {
 	data []byte
 }
 
-// MakeTopic Create a Topic
+// MakeTopic Creates a Topic
 func MakeTopic(key string, data []byte) Topic {
 	return Topic{key: key, data: data}
 }

--- a/network/topics.go
+++ b/network/topics.go
@@ -23,15 +23,15 @@ import (
 	"github.com/algorand/go-algorand/crypto"
 )
 
-
+// Constant strings used as keys or values for topics
 const (
-	RoundKey  = "ky"
-	RequestDataTypeKey  = "typ"
-	RequestHashKey = "RequestHash"
-	BlockDataKey = "BDK"
-	CertDataKey = "CDK"
-	ErrorKey = "ERR"
-	BlockAndCertValue = "BlockAndCertificate"
+	RoundKey           = "ky"
+	RequestDataTypeKey = "typ"
+	RequestHashKey     = "RequestHash"
+	BlockDataKey       = "BDK"
+	CertDataKey        = "CDK"
+	ErrorKey           = "ERR"
+	BlockAndCertValue  = "BlockAndCertificate"
 )
 
 // Topic is a key-value pair
@@ -40,8 +40,9 @@ type Topic struct {
 	data []byte
 }
 
+// MakeTopic Create a Topic
 func MakeTopic(key string, data []byte) Topic {
-	return Topic {key: key, data:data}
+	return Topic{key: key, data: data}
 }
 
 // Topics is an array of type Topic

--- a/network/topics.go
+++ b/network/topics.go
@@ -25,8 +25,8 @@ import (
 
 // Constant strings used as keys for topics
 const (
-	requestHashKey     = "RequestHash"
-	ErrorKey           = "ERR" // used for passing an error message
+	requestHashKey = "RequestHash"
+	ErrorKey       = "ERR" // used for passing an error message
 )
 
 // Topic is a key-value pair

--- a/network/topics.go
+++ b/network/topics.go
@@ -23,10 +23,25 @@ import (
 	"github.com/algorand/go-algorand/crypto"
 )
 
+
+const (
+	RoundKey  = "ky"
+	RequestDataTypeKey  = "typ"
+	RequestHashKey = "RequestHash"
+	BlockDataKey = "BDK"
+	CertDataKey = "CDK"
+	ErrorKey = "ERR"
+	BlockAndCertValue = "BlockAndCertificate"
+)
+
 // Topic is a key-value pair
 type Topic struct {
 	key  string
 	data []byte
+}
+
+func MakeTopic(key string, data []byte) Topic {
+	return Topic {key: key, data:data}
 }
 
 // Topics is an array of type Topic

--- a/network/topics.go
+++ b/network/topics.go
@@ -26,7 +26,7 @@ import (
 // Constant strings used as keys for topics
 const (
 	requestHashKey = "RequestHash"
-	ErrorKey       = "ERR" // used for passing an error message
+	ErrorKey       = "Error" // used for passing an error message
 )
 
 // Topic is a key-value pair

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -615,6 +615,10 @@ func (wn *WebsocketNetwork) setup() {
 	wn.connPerfMonitor = makeConnectionPerformanceMonitor([]Tag{protocol.AgreementVoteTag, protocol.TxnTag})
 	wn.lastNetworkAdvance = time.Now().UTC()
 	wn.handlers.log = wn.log
+
+	if wn.config.NetworkProtocolVersion != "" {
+		SupportedProtocolVersions = []string{wn.config.NetworkProtocolVersion}
+	}
 }
 
 func (wn *WebsocketNetwork) rlimitIncomingConnections() error {

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1056,7 +1056,7 @@ func (wn *WebsocketNetwork) messageHandlerThread() {
 			case Broadcast:
 				wn.Broadcast(wn.ctx, msg.Tag, msg.Data, false, msg.Sender)
 			case Respond:
-				msg.Sender.(*wsPeer).Respond(wn.ctx, msg, outmsg)
+				msg.Sender.(*wsPeer).Respond(wn.ctx, msg, outmsg.Topics)
 			default:
 			}
 		case <-inactivityCheckTicker.C:
@@ -1618,7 +1618,7 @@ const ProtocolVersionHeader = "X-Algorand-Version"
 const ProtocolAcceptVersionHeader = "X-Algorand-Accept-Version"
 
 // SupportedProtocolVersions contains the list of supported protocol versions by this node ( in order of preference ).
-var SupportedProtocolVersions = []string{ /*"2",*/ "1"}
+var SupportedProtocolVersions = []string{"2.1", "1"}
 
 // ProtocolVersion is the current version attached to the ProtocolVersionHeader header
 const ProtocolVersion = "1"

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -255,7 +255,7 @@ func (wp *wsPeerCore) PrepareURL(rawURL string) string {
 	return strings.Replace(rawURL, "{genesisID}", wp.net.GenesisID, -1)
 }
 
-func (wp *wsPeer) Verion() string {
+func (wp *wsPeer) Version() string {
 	return wp.version
 }
 

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -223,6 +223,7 @@ type UnicastPeer interface {
 	GetAddress() string
 	// Unicast sends the given bytes to this specific peer. Does not wait for message to be sent.
 	Unicast(ctx context.Context, data []byte, tag protocol.Tag) error
+	// Version returns the matching version from network.SupportedProtocolVersions
 	Version() string
 	Request(ctx context.Context, tag Tag, topics Topics) (resp *Response, e error)
 	Respond(ctx context.Context, reqMsg IncomingMessage, topics Topics) (e error)
@@ -255,7 +256,7 @@ func (wp *wsPeerCore) PrepareURL(rawURL string) string {
 	return strings.Replace(rawURL, "{genesisID}", wp.net.GenesisID, -1)
 }
 
-// Version returns the network.SupportedProtocolVersions version of the peer
+// Version returns the matching version from network.SupportedProtocolVersions
 func (wp *wsPeer) Version() string {
 	return wp.version
 }

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -255,6 +255,7 @@ func (wp *wsPeerCore) PrepareURL(rawURL string) string {
 	return strings.Replace(rawURL, "{genesisID}", wp.net.GenesisID, -1)
 }
 
+// Version returns the network.SupportedProtocolVersions version of the peer
 func (wp *wsPeer) Version() string {
 	return wp.version
 }
@@ -291,7 +292,7 @@ func (wp *wsPeer) Respond(ctx context.Context, reqMsg IncomingMessage, responseT
 	// Add the request hash
 	requestHashData := make([]byte, binary.MaxVarintLen64)
 	binary.PutUvarint(requestHashData, requestHash)
-	responseTopics = append(responseTopics, Topic{key: RequestHashKey, data: requestHashData})
+	responseTopics = append(responseTopics, Topic{key: requestHashKey, data: requestHashData})
 
 	// Serialize the topics
 	serializedMsg := responseTopics.MarshallTopics()
@@ -424,9 +425,9 @@ func (wp *wsPeer) readLoop() {
 				wp.net.log.Warnf("wsPeer readLoop: could not read the message from: %s %s", wp.conn.RemoteAddr().String(), err)
 				continue
 			}
-			requestHash, found := topics.GetValue(RequestHashKey)
+			requestHash, found := topics.GetValue(requestHashKey)
 			if !found {
-				wp.net.log.Warnf("wsPeer readLoop: message from %s is missing the %v", wp.conn.RemoteAddr().String(), RequestHashKey)
+				wp.net.log.Warnf("wsPeer readLoop: message from %s is missing the %s", wp.conn.RemoteAddr().String(), requestHashKey)
 				continue
 			}
 			hashKey, _ := binary.Uvarint(requestHash)

--- a/rpcs/ledgerService.go
+++ b/rpcs/ledgerService.go
@@ -280,7 +280,7 @@ func (ls *LedgerService) handleCatchupReq(ctx context.Context, reqMsg network.In
 				[]byte("LedgerService handleCatchupReq: request data-type is missing"))}
 		return
 	}
-	
+
 	round, read := binary.Uvarint(roundBytes)
 	if read <= 0 {
 		topics = network.Topics{
@@ -319,7 +319,7 @@ func topicBlockBytes(ledger *data.Ledger, round basics.Round, requestType string
 	default:
 		errMsg := "LedgerService topicBlockBytes: request type is unknown"
 		return network.Topics{
-			network.MakeTopic(network.ErrorKey, []byte(errMsg))}		
+			network.MakeTopic(network.ErrorKey, []byte(errMsg))}
 	}
 }
 

--- a/rpcs/ledgerService.go
+++ b/rpcs/ledgerService.go
@@ -261,31 +261,34 @@ func (ls *LedgerService) handleCatchupReq(ctx context.Context, reqMsg network.In
 
 	topics, err := network.UnmarshallTopics(reqMsg.Data)
 	if err != nil {
-		errMsg := "LedgerService handleCatchupReq UnmarshallTopics error: " + err.Error()
+		logging.Base().Infof("LedgerService handleCatchupReq: %s", err.Error()) 
 		respTopics = network.Topics{
-			network.MakeTopic(network.ErrorKey, []byte(errMsg))}
+			network.MakeTopic(network.ErrorKey, []byte(err.Error()))}
 		return
 	}
 	roundBytes, found := topics.GetValue(roundKey)
 	if !found {
+		logging.Base().Infof("LedgerService handleCatchupReq: can't find round number")
 		respTopics = network.Topics{
 			network.MakeTopic(network.ErrorKey,
-				[]byte("LedgerService handleCatchupReq: round-number topic is missing"))}
+				[]byte("can't find round number"))}
 		return
 	}
 	requestType, found := topics.GetValue(requestDataTypeKey)
 	if !found {
+		logging.Base().Infof("LedgerService handleCatchupReq: can't find data-type")
 		respTopics = network.Topics{
 			network.MakeTopic(network.ErrorKey,
-				[]byte("LedgerService handleCatchupReq: request data-type is missing"))}
+				[]byte("can't find data-type"))}
 		return
 	}
 
 	round, read := binary.Uvarint(roundBytes)
 	if read <= 0 {
+		logging.Base().Infof("LedgerService handleCatchupReq: unable to parse round number")
 		respTopics = network.Topics{
 			network.MakeTopic(network.ErrorKey,
-				[]byte("LedgerService handleCatchupReq: error reading the round number"))}
+				[]byte("unable to parse round number"))}
 		return
 	}
 	respTopics = topicBlockBytes(ls.ledger, basics.Round(round), string(requestType))

--- a/rpcs/ledgerService.go
+++ b/rpcs/ledgerService.go
@@ -262,20 +262,20 @@ func (ls *LedgerService) handleCatchupReq(ctx context.Context, reqMsg network.In
 	topics, err := network.UnmarshallTopics(reqMsg.Data)
 	if err != nil {
 		errMsg := "LedgerService handleCatchupReq UnmarshallTopics error: " + err.Error()
-		topics = network.Topics{
+		respTopics = network.Topics{
 			network.MakeTopic(network.ErrorKey, []byte(errMsg))}
 		return
 	}
 	roundBytes, found := topics.GetValue(roundKey)
 	if !found {
-		topics = network.Topics{
+		respTopics = network.Topics{
 			network.MakeTopic(network.ErrorKey,
 				[]byte("LedgerService handleCatchupReq: round-number topic is missing"))}
 		return
 	}
 	requestType, found := topics.GetValue(requestDataTypeKey)
 	if !found {
-		topics = network.Topics{
+		respTopics = network.Topics{
 			network.MakeTopic(network.ErrorKey,
 				[]byte("LedgerService handleCatchupReq: request data-type is missing"))}
 		return
@@ -283,7 +283,7 @@ func (ls *LedgerService) handleCatchupReq(ctx context.Context, reqMsg network.In
 
 	round, read := binary.Uvarint(roundBytes)
 	if read <= 0 {
-		topics = network.Topics{
+		respTopics = network.Topics{
 			network.MakeTopic(network.ErrorKey,
 				[]byte("LedgerService handleCatchupReq: error reading the round number"))}
 		return

--- a/rpcs/ledgerService.go
+++ b/rpcs/ledgerService.go
@@ -316,7 +316,7 @@ func topicBlockBytes(dataLedger *data.Ledger, round basics.Round, requestType st
 		switch err.(type) {
 		case ledger.ErrNoEntry:
 		default:
-			logging.Base().Infof("LedgerService topicBlockBytes: %s", err)			
+			logging.Base().Infof("LedgerService topicBlockBytes: %s", err)
 		}
 		return network.Topics{
 			network.MakeTopic(network.ErrorKey, []byte(blockNotAvailabeErrMsg))}
@@ -330,7 +330,7 @@ func topicBlockBytes(dataLedger *data.Ledger, round basics.Round, requestType st
 				certDataKey, cert),
 		}
 	default:
-    		return network.Topics{
+		return network.Topics{
 			network.MakeTopic(network.ErrorKey, []byte(datatypeUnsupportedErrMsg))}
 	}
 }

--- a/rpcs/ledgerService_test.go
+++ b/rpcs/ledgerService_test.go
@@ -58,7 +58,7 @@ func TestHandleCatchupReqNegative(t *testing.T) {
 		ledger: nil,
 	}
 
-	// case where topics is nil	
+	// case where topics is nil
 	ls.handleCatchupReq(context.Background(), reqMsg)
 	respTopics := reqMsg.Sender.(*mockUnicastPeer).responseTopics
 	val, found := respTopics.GetValue(network.ErrorKey)
@@ -66,29 +66,29 @@ func TestHandleCatchupReqNegative(t *testing.T) {
 	require.Equal(t, "UnmarshallTopics: could not read the number of topics", string(val))
 
 	// case where round number is missing
-	reqTopics := network.Topics {}
+	reqTopics := network.Topics{}
 	reqMsg.Data = reqTopics.MarshallTopics()
 	ls.handleCatchupReq(context.Background(), reqMsg)
 	respTopics = reqMsg.Sender.(*mockUnicastPeer).responseTopics
 
 	val, found = respTopics.GetValue(network.ErrorKey)
 	require.Equal(t, true, found)
-	require.Equal(t, "can't find round number", string(val))
+	require.Equal(t, noRoundNumberErrMsg, string(val))
 
 	// case where data type is missing
 	roundNumberData := make([]byte, 0)
-	reqTopics = network.Topics {network.MakeTopic(roundKey, roundNumberData)}
+	reqTopics = network.Topics{network.MakeTopic(roundKey, roundNumberData)}
 	reqMsg.Data = reqTopics.MarshallTopics()
 	ls.handleCatchupReq(context.Background(), reqMsg)
 	respTopics = reqMsg.Sender.(*mockUnicastPeer).responseTopics
 
 	val, found = respTopics.GetValue(network.ErrorKey)
 	require.Equal(t, true, found)
-	require.Equal(t, "can't find data-type", string(val))
+	require.Equal(t, noDataTypeErrMsg, string(val))
 
 	// case where round number is corrupted
 	roundNumberData = make([]byte, 0)
-	reqTopics = network.Topics {network.MakeTopic(roundKey, roundNumberData),
+	reqTopics = network.Topics{network.MakeTopic(roundKey, roundNumberData),
 		network.MakeTopic(requestDataTypeKey, []byte(blockAndCertValue)),
 	}
 	reqMsg.Data = reqTopics.MarshallTopics()
@@ -97,5 +97,5 @@ func TestHandleCatchupReqNegative(t *testing.T) {
 
 	val, found = respTopics.GetValue(network.ErrorKey)
 	require.Equal(t, true, found)
-	require.Equal(t, "unable to parse round number", string(val))
+	require.Equal(t, roundNumberParseErrMsg, string(val))
 }

--- a/rpcs/ledgerService_test.go
+++ b/rpcs/ledgerService_test.go
@@ -1,0 +1,101 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package rpcs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/network"
+	"github.com/algorand/go-algorand/protocol"
+)
+
+type mockUnicastPeer struct {
+	responseTopics network.Topics
+}
+
+func (mup *mockUnicastPeer) GetAddress() string {
+	return ""
+}
+func (mup *mockUnicastPeer) Unicast(ctx context.Context, data []byte, tag protocol.Tag) error {
+	return nil
+}
+func (mup *mockUnicastPeer) Version() string {
+	return "2.1"
+}
+func (mup *mockUnicastPeer) Request(ctx context.Context, tag network.Tag, topics network.Topics) (resp *network.Response, e error) {
+	return nil, nil
+}
+func (mup *mockUnicastPeer) Respond(ctx context.Context, reqMsg network.IncomingMessage, topics network.Topics) (e error) {
+	mup.responseTopics = topics
+	return nil
+}
+
+// TestHandleCatchupReqNegative covers the error reporting in handleCatchupReq
+func TestHandleCatchupReqNegative(t *testing.T) {
+
+	reqMsg := network.IncomingMessage{
+		Sender: &mockUnicastPeer{},
+		Data:   nil, // topics
+	}
+	ls := LedgerService{
+		ledger: nil,
+	}
+
+	// case where topics is nil	
+	ls.handleCatchupReq(context.Background(), reqMsg)
+	respTopics := reqMsg.Sender.(*mockUnicastPeer).responseTopics
+	val, found := respTopics.GetValue(network.ErrorKey)
+	require.Equal(t, true, found)
+	require.Equal(t, "UnmarshallTopics: could not read the number of topics", string(val))
+
+	// case where round number is missing
+	reqTopics := network.Topics {}
+	reqMsg.Data = reqTopics.MarshallTopics()
+	ls.handleCatchupReq(context.Background(), reqMsg)
+	respTopics = reqMsg.Sender.(*mockUnicastPeer).responseTopics
+
+	val, found = respTopics.GetValue(network.ErrorKey)
+	require.Equal(t, true, found)
+	require.Equal(t, "can't find round number", string(val))
+
+	// case where data type is missing
+	roundNumberData := make([]byte, 0)
+	reqTopics = network.Topics {network.MakeTopic(roundKey, roundNumberData)}
+	reqMsg.Data = reqTopics.MarshallTopics()
+	ls.handleCatchupReq(context.Background(), reqMsg)
+	respTopics = reqMsg.Sender.(*mockUnicastPeer).responseTopics
+
+	val, found = respTopics.GetValue(network.ErrorKey)
+	require.Equal(t, true, found)
+	require.Equal(t, "can't find data-type", string(val))
+
+	// case where round number is corrupted
+	roundNumberData = make([]byte, 0)
+	reqTopics = network.Topics {network.MakeTopic(roundKey, roundNumberData),
+		network.MakeTopic(requestDataTypeKey, []byte(blockAndCertValue)),
+	}
+	reqMsg.Data = reqTopics.MarshallTopics()
+	ls.handleCatchupReq(context.Background(), reqMsg)
+	respTopics = reqMsg.Sender.(*mockUnicastPeer).responseTopics
+
+	val, found = respTopics.GetValue(network.ErrorKey)
+	require.Equal(t, true, found)
+	require.Equal(t, "unable to parse round number", string(val))
+}

--- a/rpcs/wsFetcherService.go
+++ b/rpcs/wsFetcherService.go
@@ -37,7 +37,6 @@ type WsFetcherService struct {
 	pendingRequests map[string]chan WsGetBlockOut
 }
 
-
 // Constant strings used as keys for topics
 const (
 	roundKey           = "roundKey"

--- a/rpcs/wsFetcherService.go
+++ b/rpcs/wsFetcherService.go
@@ -37,6 +37,16 @@ type WsFetcherService struct {
 	pendingRequests map[string]chan WsGetBlockOut
 }
 
+
+// Constant strings used as keys for topics
+const (
+	roundKey           = "roundKey"
+	requestDataTypeKey = "requestDataType"
+	blockDataKey       = "blockData"
+	certDataKey        = "certData"
+	blockAndCertValue  = "blockAndCert"
+)
+
 func makePendingRequestKey(target network.UnicastPeer, round basics.Round, tag protocol.Tag) string {
 	return fmt.Sprintf("<%s>:%d:%s", target.GetAddress(), round, tag)
 
@@ -105,66 +115,66 @@ func (fs *WsFetcherService) RequestBlock(ctx context.Context, target network.Uni
 		delete(fs.pendingRequests, waitKey)
 		fs.mu.Unlock()
 	}()
-	if target.Version() == "2.1" {
-		roundBin := make([]byte, binary.MaxVarintLen64)
-		binary.PutUvarint(roundBin, uint64(round))
-		topics := network.Topics{
-			network.MakeTopic(network.RequestDataTypeKey,
-				[]byte(network.BlockAndCertValue)),
-			network.MakeTopic(
-				network.RoundKey,
-				roundBin),
-		}
-		resp, err := target.Request(ctx, tag, topics)
+	if target.Version() == "1" {
+		req := WsGetBlockRequest{Round: uint64(round)}
+		err := target.Unicast(ctx, protocol.EncodeReflect(req), tag)
 		if err != nil {
-			return WsGetBlockOut{}, fmt.Errorf("WsFetcherService.RequestBlock(%d): Request failed, %v", round, err)
+			return WsGetBlockOut{}, fmt.Errorf("WsFetcherService.RequestBlock(%d): unicast failed, %v", round, err)
 		}
-
-		if errMsg, found := resp.Topics.GetValue(network.ErrorKey); found {
-			return WsGetBlockOut{}, fmt.Errorf(string(errMsg))
+		select {
+		case resp := <-waitCh:
+			return resp, nil
+		case <-ctx.Done():
+			switch ctx.Err() {
+			case context.DeadlineExceeded:
+				return WsGetBlockOut{}, fmt.Errorf("WsFetcherService.RequestBlock(%d): request to %s was timed out", round, target.GetAddress())
+			case context.Canceled:
+				return WsGetBlockOut{}, fmt.Errorf("WsFetcherService.RequestBlock(%d): request to %s was cancelled by context", round, target.GetAddress())
+			default:
+				return WsGetBlockOut{}, ctx.Err()
+			}
 		}
-
-		blk, found := resp.Topics.GetValue(network.BlockDataKey)
-		if !found {
-			return WsGetBlockOut{}, fmt.Errorf("WsFetcherService(%s): request failed: block data not found", target.GetAddress())
-		}
-		cert, found := resp.Topics.GetValue(network.CertDataKey)
-		if !found {
-			return WsGetBlockOut{}, fmt.Errorf("WsFetcherService(%s): request failed: cert data not found", target.GetAddress())
-		}
-
-		// For backward compatibility, the block and cert are repackaged here.
-		// This can be dropeed once the v1 is dropped.
-		blockCertBytes := protocol.EncodeReflect(PreEncodedBlockCert{
-			Block:       blk,
-			Certificate: cert})
-
-		wsBlockOut := WsGetBlockOut{
-			Round:      uint64(round),
-			BlockBytes: blockCertBytes,
-		}
-		return wsBlockOut, nil
 	}
 
-	// Else, if version == 1
-	req := WsGetBlockRequest{Round: uint64(round)}
-	err := target.Unicast(ctx, protocol.EncodeReflect(req), tag)
+	// Else, if version == 2.1
+	roundBin := make([]byte, binary.MaxVarintLen64)
+	binary.PutUvarint(roundBin, uint64(round))
+	topics := network.Topics{
+		network.MakeTopic(requestDataTypeKey,
+			[]byte(blockAndCertValue)),
+		network.MakeTopic(
+			roundKey,
+			roundBin),
+	}
+	resp, err := target.Request(ctx, tag, topics)
 	if err != nil {
-		return WsGetBlockOut{}, fmt.Errorf("WsFetcherService.RequestBlock(%d): unicast failed, %v", round, err)
+		return WsGetBlockOut{}, fmt.Errorf("WsFetcherService(%s).RequestBlock(%d): Request failed, %v", target.GetAddress(), round, err)
 	}
-	select {
-	case resp := <-waitCh:
-		return resp, nil
-	case <-ctx.Done():
-		switch ctx.Err() {
-		case context.DeadlineExceeded:
-			return WsGetBlockOut{}, fmt.Errorf("WsFetcherService.RequestBlock(%d): request to %s was timed out", round, target.GetAddress())
-		case context.Canceled:
-			return WsGetBlockOut{}, fmt.Errorf("WsFetcherService.RequestBlock(%d): request to %s was cancelled by context", round, target.GetAddress())
-		default:
-			return WsGetBlockOut{}, ctx.Err()
-		}
+
+	if errMsg, found := resp.Topics.GetValue(network.ErrorKey); found {
+		return WsGetBlockOut{}, fmt.Errorf("WsFetcherService(%s).RequestBlock(%d): Request failed, %s", target.GetAddress(), round, string(errMsg))
 	}
+
+	blk, found := resp.Topics.GetValue(blockDataKey)
+	if !found {
+		return WsGetBlockOut{}, fmt.Errorf("WsFetcherService(%s): request failed: block data not found", target.GetAddress())
+	}
+	cert, found := resp.Topics.GetValue(certDataKey)
+	if !found {
+		return WsGetBlockOut{}, fmt.Errorf("WsFetcherService(%s): request failed: cert data not found", target.GetAddress())
+	}
+
+	// For backward compatibility, the block and cert are repackaged here.
+	// This can be dropeed once the v1 is dropped.
+	blockCertBytes := protocol.EncodeReflect(PreEncodedBlockCert{
+		Block:       blk,
+		Certificate: cert})
+
+	wsBlockOut := WsGetBlockOut{
+		Round:      uint64(round),
+		BlockBytes: blockCertBytes,
+	}
+	return wsBlockOut, nil
 }
 
 // RegisterWsFetcherService creates and returns a WsFetcherService that services gossip fetcher responses

--- a/rpcs/wsFetcherService.go
+++ b/rpcs/wsFetcherService.go
@@ -39,11 +39,11 @@ type WsFetcherService struct {
 
 // Constant strings used as keys for topics
 const (
-	roundKey           = "roundKey"
-	requestDataTypeKey = "requestDataType"
-	blockDataKey       = "blockData"
-	certDataKey        = "certData"
-	blockAndCertValue  = "blockAndCert"
+	roundKey           = "roundKey"        // Block round-number topic-key in the request
+	requestDataTypeKey = "requestDataType" // Data-type topic-key in the request (e.g. block, cert, block+cert)
+	blockDataKey       = "blockData"       // Block-data topic-key in the response
+	certDataKey        = "certData"        // Cert-data topic-key in the response
+	blockAndCertValue  = "blockAndCert"    // block+cert request data (as the value of requestDataTypeKey)
 )
 
 func makePendingRequestKey(target network.UnicastPeer, round basics.Round, tag protocol.Tag) string {

--- a/rpcs/wsFetcherService.go
+++ b/rpcs/wsFetcherService.go
@@ -144,24 +144,25 @@ func (fs *WsFetcherService) RequestBlock(ctx context.Context, target network.Uni
 			BlockBytes: blockCertBytes,
 		}
 		return wsBlockOut, nil
-	} else {
-		req := WsGetBlockRequest{Round: uint64(round)}
-		err := target.Unicast(ctx, protocol.EncodeReflect(req), tag)
-		if err != nil {
-			return WsGetBlockOut{}, fmt.Errorf("WsFetcherService.RequestBlock(%d): unicast failed, %v", round, err)
-		}
-		select {
-		case resp := <-waitCh:
-			return resp, nil
-		case <-ctx.Done():
-			switch ctx.Err() {
-			case context.DeadlineExceeded:
-				return WsGetBlockOut{}, fmt.Errorf("WsFetcherService.RequestBlock(%d): request to %s was timed out", round, target.GetAddress())
-			case context.Canceled:
-				return WsGetBlockOut{}, fmt.Errorf("WsFetcherService.RequestBlock(%d): request to %s was cancelled by context", round, target.GetAddress())
-			default:
-				return WsGetBlockOut{}, ctx.Err()
-			}
+	}
+
+	// Else, if version == 1
+	req := WsGetBlockRequest{Round: uint64(round)}
+	err := target.Unicast(ctx, protocol.EncodeReflect(req), tag)
+	if err != nil {
+		return WsGetBlockOut{}, fmt.Errorf("WsFetcherService.RequestBlock(%d): unicast failed, %v", round, err)
+	}
+	select {
+	case resp := <-waitCh:
+		return resp, nil
+	case <-ctx.Done():
+		switch ctx.Err() {
+		case context.DeadlineExceeded:
+			return WsGetBlockOut{}, fmt.Errorf("WsFetcherService.RequestBlock(%d): request to %s was timed out", round, target.GetAddress())
+		case context.Canceled:
+			return WsGetBlockOut{}, fmt.Errorf("WsFetcherService.RequestBlock(%d): request to %s was cancelled by context", round, target.GetAddress())
+		default:
+			return WsGetBlockOut{}, ctx.Err()
 		}
 	}
 }

--- a/test/framework/fixtures/restClientFixture.go
+++ b/test/framework/fixtures/restClientFixture.go
@@ -48,7 +48,6 @@ func (f *RestClientFixture) Setup(t TestingT, templateFile string) {
 // but does not start the network before returning.  Call NC.Start() to start later.
 func (f *RestClientFixture) SetupNoStart(t TestingT, templateFile string) {
 	f.LibGoalFixture.SetupNoStart(t, templateFile)
-	f.AlgodClient = f.GetAlgodClientForController(f.NC)
 }
 
 // SetupShared is called to initialize the test fixture that will be used for multiple tests


### PR DESCRIPTION
* Introduce versioning: old: 1, new: 2.1
* Add keys to topics as const in topics.go
* Introduce MakeTopic to create topics without exporting the Topic fields
* Change wsPeer.Respond to accept Topics instead of OutgoingMessage
* Add methods: Version, Request, Respond to UnicastPeer interface (should rename UnicastPeer?)
* Make LedgerService handleCatchupReq support v2.1 (request/respond using topics)
* Make WsFetcherService RequestBlock support v2.1 (request/respond using topics)

Modifying TestGetBlockWS to test version 2.1

## Test Plan

Will add e2e test to test all cases of the two version combinations. 