### PR TITLE
Add retry for creating a DB connection

### DIFF
--- a/util/db/dbutil.go
+++ b/util/db/dbutil.go
@@ -147,12 +147,12 @@ func LoggedRetry(fn func() error, log logging.Logger) (err error) {
 	for i := 0; ; i++ {
 		if i > 0 {
 			if i < infoTxRetries {
-				log.Infof("db.LoggedRetry: %d connection retries (last err: %v)", i, err)
+				log.Infof("db.LoggedRetry: %d retries (last err: %v)", i, err)
 			} else if i >= 1000 {
-				log.Errorf("db.LoggedRetry: %d connection retries (last err: %v)", i, err)
+				log.Errorf("db.LoggedRetry: %d retries (last err: %v)", i, err)
 				return
 			} else if i%warnTxRetriesInterval == 0 {
-				log.Warnf("db.LoggedRetry: %d connection retries (last err: %v)", i, err)
+				log.Warnf("db.LoggedRetry: %d retries (last err: %v)", i, err)
 			}
 		}
 
@@ -241,12 +241,12 @@ func (db *Accessor) Atomic(fn idemFn, extras ...interface{}) (err error) {
 	for i := 0; ; i++ {
 		if i > 0 {
 			if i < infoTxRetries {
-				db.getDecoratedLogger(fn, extras).Infof("db.atomic: %d connection retries (last err: %v)", i, err)
+				db.getDecoratedLogger(fn, extras).Infof("db.atomic: %d retries (last err: %v)", i, err)
 			} else if i >= 1000 {
-				db.getDecoratedLogger(fn, extras).Errorf("db.atomic: %d connection retries (last err: %v)", i, err)
+				db.getDecoratedLogger(fn, extras).Errorf("db.atomic: %d retries (last err: %v)", i, err)
 				break
 			} else if i%warnTxRetriesInterval == 0 {
-				db.getDecoratedLogger(fn, extras).Warnf("db.atomic: %d connection retries (last err: %v)", i, err)
+				db.getDecoratedLogger(fn, extras).Warnf("db.atomic: %d retries (last err: %v)", i, err)
 			}
 		}
 

--- a/util/db/dbutil.go
+++ b/util/db/dbutil.go
@@ -151,8 +151,7 @@ func LoggedRetry(fn func() error, log logging.Logger) (err error) {
 			} else if i >= 1000 {
 				log.Errorf("db.LoggedRetry: %d connection retries (last err: %v)", i, err)
 				return
-			}
-			if i%warnTxRetriesInterval == 0 {
+			} else if i%warnTxRetriesInterval == 0 {
 				log.Warnf("db.LoggedRetry: %d connection retries (last err: %v)", i, err)
 			}
 		}
@@ -223,8 +222,7 @@ func (db *Accessor) Atomic(fn idemFn, extras ...interface{}) (err error) {
 			} else if i >= 1000 {
 				db.getDecoratedLogger(fn, extras).Errorf("db.atomic: %d connection retries (last err: %v)", i, err)
 				break
-			}
-			if i%warnTxRetriesInterval == 0 {
+			} else if i%warnTxRetriesInterval == 0 {
 				db.getDecoratedLogger(fn, extras).Warnf("db.atomic: %d connection retries (last err: %v)", i, err)
 			}
 		}
@@ -247,8 +245,7 @@ func (db *Accessor) Atomic(fn idemFn, extras ...interface{}) (err error) {
 			} else if i >= 1000 {
 				db.getDecoratedLogger(fn, extras).Errorf("db.atomic: %d connection retries (last err: %v)", i, err)
 				break
-			}
-			if i%warnTxRetriesInterval == 0 {
+			} else if i%warnTxRetriesInterval == 0 {
 				db.getDecoratedLogger(fn, extras).Warnf("db.atomic: %d connection retries (last err: %v)", i, err)
 			}
 		}

--- a/util/db/dbutil.go
+++ b/util/db/dbutil.go
@@ -155,9 +155,9 @@ func LoggedRetry(fn func() error, log logging.Logger) (err error) {
 				log.Warnf("db.LoggedRetry: %d retries (last err: %v)", i, err)
 			}
 		}
-
 		err = fn()
 	}
+	return
 }
 
 // Retry executes a function repeatedly as long as it returns an error


### PR DESCRIPTION
## Summary

Ledger service was generating the following error:
```
{"file":"ledgerService.go","function":"github.com/algorand/go-algorand/rpcs.(*LedgerService).ServeHTTP","level":"warning","line":174,"msg":"ServeHTTP : failed to retrieve block 3735696 database is locked","time":"2020-03-15T16:21:05.316959Z"}
```

The root cause was the sqlite driver returning a `database is locked` when a new connection attempt was made. Existing code was already testing extensively for temporary locked database conditions on transaction creation/execution, but not on connection creation.

resolves issue https://github.com/algorand/go-algorand/issues/915

