### PR TITLE
Roll back temporary debug printing

### DIFF
--- a/cmd/goal/commands.go
+++ b/cmd/goal/commands.go
@@ -447,8 +447,6 @@ func getWalletHandleMaybePassword(dataDir string, walletName string, getPassword
 		return token, nil, nil
 	}
 
-	reportInfof("Failed to get cached wallet handle: %v", err)
-
 	// Assume any errors were "wrong password" errors, until we have actual
 	// API error codes
 	pw = ensurePasswordForWallet(walletName)


### PR DESCRIPTION
## Summary

When investigating the random failures on the teal e2e tests, we ran into various unexplained failures. Once we implemented the file locking, these issue went away. however, we forget to remove the debug line telling us about the issue.
