### PR TITLE
Enable upgrade delay tuning. (#902)

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -542,12 +542,19 @@ func initConsensusProtocols() {
 	// v20 can be upgraded to v21.
 	v20.ApprovedUpgrades[protocol.ConsensusV21] = 0
 
+	// v22 is an upgrade which allows tuning the number of rounds to wait to execute upgrades.
+	v22 := v21
+	v22.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	v22.MinUpgradeWaitRounds = 10000
+	v22.MaxUpgradeWaitRounds = 150000
+	Consensus[protocol.ConsensusV22] = v22
+	// v21 can be upgraded to v22.
+	v21.ApprovedUpgrades[protocol.ConsensusV22] = 0
+
 	// ConsensusFuture is used to test features that are implemented
 	// but not yet released in a production protocol version.
-	vFuture := v21
+	vFuture := v22
 	vFuture.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
-	vFuture.MinUpgradeWaitRounds = 10000
-	vFuture.MaxUpgradeWaitRounds = 150000
 	Consensus[protocol.ConsensusFuture] = vFuture
 }
 

--- a/data/bookkeeping/block.go
+++ b/data/bookkeeping/block.go
@@ -394,7 +394,7 @@ func ProcessUpgradeParams(prev BlockHeader) (uv UpgradeVote, us UpgradeState, er
 		}
 	}
 
-	// If there is a proposal being voted on, see if we approve it and its delay
+	// If there is a proposal being voted on, see if we approve it
 	round := prev.Round + 1
 	if round < prev.NextProtocolVoteBefore {
 		_, ok := prevParams.ApprovedUpgrades[prev.NextProtocol]

--- a/data/bookkeeping/block_test.go
+++ b/data/bookkeeping/block_test.go
@@ -42,6 +42,8 @@ func init() {
 	params1.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{
 		proto2: 0,
 	}
+	params1.MinUpgradeWaitRounds = 0
+	params1.MaxUpgradeWaitRounds = 0
 	config.Consensus[proto1] = params1
 
 	params2 := config.Consensus[protocol.ConsensusCurrentVersion]

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -118,6 +118,11 @@ const ConsensusV21 = ConsensusVersion(
 	"https://github.com/algorandfoundation/specs/tree/8096e2df2da75c3339986317f9abe69d4fa86b4b",
 )
 
+// ConsensusV22 allows tuning the upgrade delay.
+const ConsensusV22 = ConsensusVersion(
+	"https://github.com/algorandfoundation/specs/tree/57016b942f6d97e6d4c0688b373bb0a2fc85a1a2",
+)
+
 // ConsensusFuture is a protocol that should not appear in any production
 // network, but is used to test features before they are released.
 const ConsensusFuture = ConsensusVersion(
@@ -130,7 +135,7 @@ const ConsensusFuture = ConsensusVersion(
 
 // ConsensusCurrentVersion is the latest version and should be used
 // when a specific version is not provided.
-const ConsensusCurrentVersion = ConsensusV21
+const ConsensusCurrentVersion = ConsensusV22
 
 // Error is used to indicate that an unsupported protocol has been detected.
 type Error ConsensusVersion


### PR DESCRIPTION
* [betanet] Enable upgrade delay tuning.

* Use official spec commit hash.

* Bump ConsensusCurrentVersion.

* Fix old failing test.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Explain the goal of this change and what problem it is solving.

## Test Plan

How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale.

