### PR TITLE
Re-keying: backend

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -209,6 +209,9 @@ type ConsensusParams struct {
 	// whether to use the old buggy Credential.lowestOutput function
 	// TODO(upgrade): Please remove as soon as the upgrade goes through
 	UseBuggyProposalLowestOutput bool
+
+	// SupportRekeying indicates support for account rekeying (the RekeyTo and AuthAddr fields)
+	SupportRekeying bool
 }
 
 // ConsensusProtocols defines a set of supported protocol versions and their

--- a/data/basics/msgp_gen.go
+++ b/data/basics/msgp_gen.go
@@ -13,8 +13,8 @@ import (
 func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0005Len := uint32(11)
-	var zb0005Mask uint16 /* 12 bits */
+	zb0005Len := uint32(12)
+	var zb0005Mask uint16 /* 13 bits */
 	if (*z).MicroAlgos.MsgIsZero() {
 		zb0005Len--
 		zb0005Mask |= 0x2
@@ -43,21 +43,25 @@ func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0005Len--
 		zb0005Mask |= 0x80
 	}
-	if (*z).VoteID.MsgIsZero() {
+	if (*z).SpendingKey.MsgIsZero() {
 		zb0005Len--
 		zb0005Mask |= 0x100
 	}
-	if (*z).VoteFirstValid == 0 {
+	if (*z).VoteID.MsgIsZero() {
 		zb0005Len--
 		zb0005Mask |= 0x200
 	}
-	if (*z).VoteKeyDilution == 0 {
+	if (*z).VoteFirstValid == 0 {
 		zb0005Len--
 		zb0005Mask |= 0x400
 	}
-	if (*z).VoteLastValid == 0 {
+	if (*z).VoteKeyDilution == 0 {
 		zb0005Len--
 		zb0005Mask |= 0x800
+	}
+	if (*z).VoteLastValid == 0 {
+		zb0005Len--
+		zb0005Mask |= 0x1000
 	}
 	// variable map header, size zb0005Len
 	o = append(o, 0x80|uint8(zb0005Len))
@@ -176,6 +180,15 @@ func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
 			}
 		}
 		if (zb0005Mask & 0x100) == 0 { // if not empty
+			// string "spend"
+			o = append(o, 0xa5, 0x73, 0x70, 0x65, 0x6e, 0x64)
+			o, err = (*z).SpendingKey.MarshalMsg(o)
+			if err != nil {
+				err = msgp.WrapError(err, "SpendingKey")
+				return
+			}
+		}
+		if (zb0005Mask & 0x200) == 0 { // if not empty
 			// string "vote"
 			o = append(o, 0xa4, 0x76, 0x6f, 0x74, 0x65)
 			o, err = (*z).VoteID.MarshalMsg(o)
@@ -184,17 +197,17 @@ func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
 				return
 			}
 		}
-		if (zb0005Mask & 0x200) == 0 { // if not empty
+		if (zb0005Mask & 0x400) == 0 { // if not empty
 			// string "voteFst"
 			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x46, 0x73, 0x74)
 			o = msgp.AppendUint64(o, uint64((*z).VoteFirstValid))
 		}
-		if (zb0005Mask & 0x400) == 0 { // if not empty
+		if (zb0005Mask & 0x800) == 0 { // if not empty
 			// string "voteKD"
 			o = append(o, 0xa6, 0x76, 0x6f, 0x74, 0x65, 0x4b, 0x44)
 			o = msgp.AppendUint64(o, (*z).VoteKeyDilution)
 		}
-		if (zb0005Mask & 0x800) == 0 { // if not empty
+		if (zb0005Mask & 0x1000) == 0 { // if not empty
 			// string "voteLst"
 			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x4c, 0x73, 0x74)
 			o = msgp.AppendUint64(o, uint64((*z).VoteLastValid))
@@ -432,6 +445,14 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 		}
 		if zb0005 > 0 {
+			zb0005--
+			bts, err = (*z).SpendingKey.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "SpendingKey")
+				return
+			}
+		}
+		if zb0005 > 0 {
 			err = msgp.ErrTooManyArrayFields(zb0005)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array")
@@ -642,6 +663,12 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).Assets[zb0003] = zb0004
 				}
+			case "spend":
+				bts, err = (*z).SpendingKey.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "SpendingKey")
+					return
+				}
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -678,12 +705,13 @@ func (z *AccountData) Msgsize() (s int) {
 			s += 0 + zb0003.Msgsize() + 1 + 2 + msgp.Uint64Size + 2 + msgp.BoolSize
 		}
 	}
+	s += 6 + (*z).SpendingKey.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *AccountData) MsgIsZero() bool {
-	return ((*z).Status == 0) && ((*z).MicroAlgos.MsgIsZero()) && ((*z).RewardsBase == 0) && ((*z).RewardedMicroAlgos.MsgIsZero()) && ((*z).VoteID.MsgIsZero()) && ((*z).SelectionID.MsgIsZero()) && ((*z).VoteFirstValid == 0) && ((*z).VoteLastValid == 0) && ((*z).VoteKeyDilution == 0) && (len((*z).AssetParams) == 0) && (len((*z).Assets) == 0)
+	return ((*z).Status == 0) && ((*z).MicroAlgos.MsgIsZero()) && ((*z).RewardsBase == 0) && ((*z).RewardedMicroAlgos.MsgIsZero()) && ((*z).VoteID.MsgIsZero()) && ((*z).SelectionID.MsgIsZero()) && ((*z).VoteFirstValid == 0) && ((*z).VoteLastValid == 0) && ((*z).VoteKeyDilution == 0) && (len((*z).AssetParams) == 0) && (len((*z).Assets) == 0) && ((*z).SpendingKey.MsgIsZero())
 }
 
 // MarshalMsg implements msgp.Marshaler
@@ -1245,8 +1273,8 @@ func (z *AssetParams) MsgIsZero() bool {
 func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0005Len := uint32(12)
-	var zb0005Mask uint16 /* 14 bits */
+	zb0005Len := uint32(13)
+	var zb0005Mask uint16 /* 15 bits */
 	if (*z).Addr.MsgIsZero() {
 		zb0005Len--
 		zb0005Mask |= 0x4
@@ -1279,21 +1307,25 @@ func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0005Len--
 		zb0005Mask |= 0x200
 	}
-	if (*z).AccountData.VoteID.MsgIsZero() {
+	if (*z).AccountData.SpendingKey.MsgIsZero() {
 		zb0005Len--
 		zb0005Mask |= 0x400
 	}
-	if (*z).AccountData.VoteFirstValid == 0 {
+	if (*z).AccountData.VoteID.MsgIsZero() {
 		zb0005Len--
 		zb0005Mask |= 0x800
 	}
-	if (*z).AccountData.VoteKeyDilution == 0 {
+	if (*z).AccountData.VoteFirstValid == 0 {
 		zb0005Len--
 		zb0005Mask |= 0x1000
 	}
-	if (*z).AccountData.VoteLastValid == 0 {
+	if (*z).AccountData.VoteKeyDilution == 0 {
 		zb0005Len--
 		zb0005Mask |= 0x2000
+	}
+	if (*z).AccountData.VoteLastValid == 0 {
+		zb0005Len--
+		zb0005Mask |= 0x4000
 	}
 	// variable map header, size zb0005Len
 	o = append(o, 0x80|uint8(zb0005Len))
@@ -1421,6 +1453,15 @@ func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 			}
 		}
 		if (zb0005Mask & 0x400) == 0 { // if not empty
+			// string "spend"
+			o = append(o, 0xa5, 0x73, 0x70, 0x65, 0x6e, 0x64)
+			o, err = (*z).AccountData.SpendingKey.MarshalMsg(o)
+			if err != nil {
+				err = msgp.WrapError(err, "SpendingKey")
+				return
+			}
+		}
+		if (zb0005Mask & 0x800) == 0 { // if not empty
 			// string "vote"
 			o = append(o, 0xa4, 0x76, 0x6f, 0x74, 0x65)
 			o, err = (*z).AccountData.VoteID.MarshalMsg(o)
@@ -1429,17 +1470,17 @@ func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 				return
 			}
 		}
-		if (zb0005Mask & 0x800) == 0 { // if not empty
+		if (zb0005Mask & 0x1000) == 0 { // if not empty
 			// string "voteFst"
 			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x46, 0x73, 0x74)
 			o = msgp.AppendUint64(o, uint64((*z).AccountData.VoteFirstValid))
 		}
-		if (zb0005Mask & 0x1000) == 0 { // if not empty
+		if (zb0005Mask & 0x2000) == 0 { // if not empty
 			// string "voteKD"
 			o = append(o, 0xa6, 0x76, 0x6f, 0x74, 0x65, 0x4b, 0x44)
 			o = msgp.AppendUint64(o, (*z).AccountData.VoteKeyDilution)
 		}
-		if (zb0005Mask & 0x2000) == 0 { // if not empty
+		if (zb0005Mask & 0x4000) == 0 { // if not empty
 			// string "voteLst"
 			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x4c, 0x73, 0x74)
 			o = msgp.AppendUint64(o, uint64((*z).AccountData.VoteLastValid))
@@ -1685,6 +1726,14 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 		}
 		if zb0005 > 0 {
+			zb0005--
+			bts, err = (*z).AccountData.SpendingKey.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "SpendingKey")
+				return
+			}
+		}
+		if zb0005 > 0 {
 			err = msgp.ErrTooManyArrayFields(zb0005)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array")
@@ -1901,6 +1950,12 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).AccountData.Assets[zb0003] = zb0004
 				}
+			case "spend":
+				bts, err = (*z).AccountData.SpendingKey.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "SpendingKey")
+					return
+				}
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1937,12 +1992,13 @@ func (z *BalanceRecord) Msgsize() (s int) {
 			s += 0 + zb0003.Msgsize() + 1 + 2 + msgp.Uint64Size + 2 + msgp.BoolSize
 		}
 	}
+	s += 6 + (*z).AccountData.SpendingKey.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *BalanceRecord) MsgIsZero() bool {
-	return ((*z).Addr.MsgIsZero()) && ((*z).AccountData.Status == 0) && ((*z).AccountData.MicroAlgos.MsgIsZero()) && ((*z).AccountData.RewardsBase == 0) && ((*z).AccountData.RewardedMicroAlgos.MsgIsZero()) && ((*z).AccountData.VoteID.MsgIsZero()) && ((*z).AccountData.SelectionID.MsgIsZero()) && ((*z).AccountData.VoteFirstValid == 0) && ((*z).AccountData.VoteLastValid == 0) && ((*z).AccountData.VoteKeyDilution == 0) && (len((*z).AccountData.AssetParams) == 0) && (len((*z).AccountData.Assets) == 0)
+	return ((*z).Addr.MsgIsZero()) && ((*z).AccountData.Status == 0) && ((*z).AccountData.MicroAlgos.MsgIsZero()) && ((*z).AccountData.RewardsBase == 0) && ((*z).AccountData.RewardedMicroAlgos.MsgIsZero()) && ((*z).AccountData.VoteID.MsgIsZero()) && ((*z).AccountData.SelectionID.MsgIsZero()) && ((*z).AccountData.VoteFirstValid == 0) && ((*z).AccountData.VoteLastValid == 0) && ((*z).AccountData.VoteKeyDilution == 0) && (len((*z).AccountData.AssetParams) == 0) && (len((*z).AccountData.Assets) == 0) && ((*z).AccountData.SpendingKey.MsgIsZero())
 }
 
 // MarshalMsg implements msgp.Marshaler

--- a/data/basics/userBalance.go
+++ b/data/basics/userBalance.go
@@ -136,6 +136,12 @@ type AccountData struct {
 	// structs; allocate a copy and modify that instead.  AccountData
 	// is expected to have copy-by-value semantics.
 	Assets map[AssetIndex]AssetHolding `codec:"asset,allocbound=-"`
+
+	// SpendingKey is the address against which signatures/multisigs/logicsigs should be checked.
+	// If empty, the address of the account whose AccountData this is is used.
+	// A transaction may change an account's SpendingKey to "re-key" the account.
+	// This allows key rotation, changing the members in a multisig, etc.
+	SpendingKey Address `codec:"spend"`
 }
 
 // AccountDetail encapsulates meaningful details about a given account, for external consumption

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -379,7 +379,7 @@ func (pool *TransactionPool) Verified(txn transactions.SignedTxn, params verify.
 		return false
 	}
 	pendingSigTxn := cacheval.txn
-	return pendingSigTxn.Sig == txn.Sig && pendingSigTxn.Msig.Equal(txn.Msig) && pendingSigTxn.Lsig.Equal(&txn.Lsig)
+	return pendingSigTxn.Sig == txn.Sig && pendingSigTxn.Msig.Equal(txn.Msig) && pendingSigTxn.Lsig.Equal(&txn.Lsig) && (pendingSigTxn.AuthAddr == txn.AuthAddr)
 }
 
 // OnNewBlock excises transactions from the pool that are included in the specified Block or if they've expired

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -209,10 +209,15 @@ func Eval(program []byte, params EvalParams) (pass bool, err error) {
 		cx.err = fmt.Errorf("program version %d greater than protocol supported version %d", version, params.Proto.LogicSigVersion)
 		return false, cx.err
 	}
+	if (params.Txn.Txn.RekeyTo != basics.Address{}) { // Currently no TEAL version knows about the RekeyTo field, but this may change in a future TEAL version
+		cx.err = fmt.Errorf("program version %d doesn't allow transactions with nonzero RekeyTo field", version)
+		return false, cx.err
+	}
 	// TODO: if EvalMaxVersion > version, ensure that inaccessible
 	// fields as of the program's version are zero or other
 	// default value so that no one is hiding unexpected
 	// operations from an old program.
+
 	cx.version = version
 	cx.pc = vlen
 	cx.EvalParams = params

--- a/data/transactions/msgp_gen.go
+++ b/data/transactions/msgp_gen.go
@@ -713,8 +713,8 @@ func (z *AssetTransferTxnFields) MsgIsZero() bool {
 func (z *Header) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0002Len := uint32(9)
-	var zb0002Mask uint16 /* 10 bits */
+	zb0002Len := uint32(10)
+	var zb0002Mask uint16 /* 11 bits */
 	if (*z).Fee.MsgIsZero() {
 		zb0002Len--
 		zb0002Mask |= 0x2
@@ -747,9 +747,13 @@ func (z *Header) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0002Len--
 		zb0002Mask |= 0x100
 	}
-	if (*z).Sender.MsgIsZero() {
+	if (*z).RekeyTo.MsgIsZero() {
 		zb0002Len--
 		zb0002Mask |= 0x200
+	}
+	if (*z).Sender.MsgIsZero() {
+		zb0002Len--
+		zb0002Mask |= 0x400
 	}
 	// variable map header, size zb0002Len
 	o = append(o, 0x80|uint8(zb0002Len))
@@ -815,6 +819,15 @@ func (z *Header) MarshalMsg(b []byte) (o []byte, err error) {
 			o = msgp.AppendBytes(o, (*z).Note)
 		}
 		if (zb0002Mask & 0x200) == 0 { // if not empty
+			// string "rekey"
+			o = append(o, 0xa5, 0x72, 0x65, 0x6b, 0x65, 0x79)
+			o, err = (*z).RekeyTo.MarshalMsg(o)
+			if err != nil {
+				err = msgp.WrapError(err, "RekeyTo")
+				return
+			}
+		}
+		if (zb0002Mask & 0x400) == 0 { // if not empty
 			// string "snd"
 			o = append(o, 0xa3, 0x73, 0x6e, 0x64)
 			o, err = (*z).Sender.MarshalMsg(o)
@@ -918,6 +931,14 @@ func (z *Header) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 		}
 		if zb0002 > 0 {
+			zb0002--
+			bts, err = (*z).RekeyTo.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "RekeyTo")
+				return
+			}
+		}
+		if zb0002 > 0 {
 			err = msgp.ErrTooManyArrayFields(zb0002)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array")
@@ -994,6 +1015,12 @@ func (z *Header) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "Lease")
 					return
 				}
+			case "rekey":
+				bts, err = (*z).RekeyTo.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "RekeyTo")
+					return
+				}
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1014,13 +1041,13 @@ func (_ *Header) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *Header) Msgsize() (s int) {
-	s = 1 + 4 + (*z).Sender.Msgsize() + 4 + (*z).Fee.Msgsize() + 3 + (*z).FirstValid.Msgsize() + 3 + (*z).LastValid.Msgsize() + 5 + msgp.BytesPrefixSize + len((*z).Note) + 4 + msgp.StringPrefixSize + len((*z).GenesisID) + 3 + (*z).GenesisHash.Msgsize() + 4 + (*z).Group.Msgsize() + 3 + msgp.ArrayHeaderSize + (32 * (msgp.ByteSize))
+	s = 1 + 4 + (*z).Sender.Msgsize() + 4 + (*z).Fee.Msgsize() + 3 + (*z).FirstValid.Msgsize() + 3 + (*z).LastValid.Msgsize() + 5 + msgp.BytesPrefixSize + len((*z).Note) + 4 + msgp.StringPrefixSize + len((*z).GenesisID) + 3 + (*z).GenesisHash.Msgsize() + 4 + (*z).Group.Msgsize() + 3 + msgp.ArrayHeaderSize + (32 * (msgp.ByteSize)) + 6 + (*z).RekeyTo.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *Header) MsgIsZero() bool {
-	return ((*z).Sender.MsgIsZero()) && ((*z).Fee.MsgIsZero()) && ((*z).FirstValid.MsgIsZero()) && ((*z).LastValid.MsgIsZero()) && (len((*z).Note) == 0) && ((*z).GenesisID == "") && ((*z).GenesisHash.MsgIsZero()) && ((*z).Group.MsgIsZero()) && ((*z).Lease == ([32]byte{}))
+	return ((*z).Sender.MsgIsZero()) && ((*z).Fee.MsgIsZero()) && ((*z).FirstValid.MsgIsZero()) && ((*z).LastValid.MsgIsZero()) && (len((*z).Note) == 0) && ((*z).GenesisID == "") && ((*z).GenesisHash.MsgIsZero()) && ((*z).Group.MsgIsZero()) && ((*z).Lease == ([32]byte{})) && ((*z).RekeyTo.MsgIsZero())
 }
 
 // MarshalMsg implements msgp.Marshaler
@@ -1786,8 +1813,8 @@ func (z Payset) MsgIsZero() bool {
 func (z *SignedTxn) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0001Len := uint32(4)
-	var zb0001Mask uint8 /* 5 bits */
+	zb0001Len := uint32(5)
+	var zb0001Mask uint8 /* 6 bits */
 	if (*z).Lsig.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x2
@@ -1796,13 +1823,17 @@ func (z *SignedTxn) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if (*z).Sig.MsgIsZero() {
+	if (*z).AuthAddr.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
-	if (*z).Txn.MsgIsZero() {
+	if (*z).Sig.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x10
+	}
+	if (*z).Txn.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x20
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -1826,6 +1857,15 @@ func (z *SignedTxn) MarshalMsg(b []byte) (o []byte, err error) {
 			}
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
+			// string "sgnr"
+			o = append(o, 0xa4, 0x73, 0x67, 0x6e, 0x72)
+			o, err = (*z).AuthAddr.MarshalMsg(o)
+			if err != nil {
+				err = msgp.WrapError(err, "AuthAddr")
+				return
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "sig"
 			o = append(o, 0xa3, 0x73, 0x69, 0x67)
 			o, err = (*z).Sig.MarshalMsg(o)
@@ -1834,7 +1874,7 @@ func (z *SignedTxn) MarshalMsg(b []byte) (o []byte, err error) {
 				return
 			}
 		}
-		if (zb0001Mask & 0x10) == 0 { // if not empty
+		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
 			o, err = (*z).Txn.MarshalMsg(o)
@@ -1898,6 +1938,14 @@ func (z *SignedTxn) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 		}
 		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).AuthAddr.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "AuthAddr")
+				return
+			}
+		}
+		if zb0001 > 0 {
 			err = msgp.ErrTooManyArrayFields(zb0001)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array")
@@ -1944,6 +1992,12 @@ func (z *SignedTxn) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "Txn")
 					return
 				}
+			case "sgnr":
+				bts, err = (*z).AuthAddr.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "AuthAddr")
+					return
+				}
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1964,21 +2018,21 @@ func (_ *SignedTxn) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *SignedTxn) Msgsize() (s int) {
-	s = 1 + 4 + (*z).Sig.Msgsize() + 5 + (*z).Msig.Msgsize() + 5 + (*z).Lsig.Msgsize() + 4 + (*z).Txn.Msgsize()
+	s = 1 + 4 + (*z).Sig.Msgsize() + 5 + (*z).Msig.Msgsize() + 5 + (*z).Lsig.Msgsize() + 4 + (*z).Txn.Msgsize() + 5 + (*z).AuthAddr.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *SignedTxn) MsgIsZero() bool {
-	return ((*z).Sig.MsgIsZero()) && ((*z).Msig.MsgIsZero()) && ((*z).Lsig.MsgIsZero()) && ((*z).Txn.MsgIsZero())
+	return ((*z).Sig.MsgIsZero()) && ((*z).Msig.MsgIsZero()) && ((*z).Lsig.MsgIsZero()) && ((*z).Txn.MsgIsZero()) && ((*z).AuthAddr.MsgIsZero())
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z *SignedTxnInBlock) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0001Len := uint32(10)
-	var zb0001Mask uint16 /* 14 bits */
+	zb0001Len := uint32(11)
+	var zb0001Mask uint16 /* 15 bits */
 	if (*z).SignedTxnWithAD.ApplyData.ClosingAmount.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x10
@@ -2011,13 +2065,17 @@ func (z *SignedTxnInBlock) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0001Len--
 		zb0001Mask |= 0x800
 	}
-	if (*z).SignedTxnWithAD.SignedTxn.Sig.MsgIsZero() {
+	if (*z).SignedTxnWithAD.SignedTxn.AuthAddr.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x1000
 	}
-	if (*z).SignedTxnWithAD.SignedTxn.Txn.MsgIsZero() {
+	if (*z).SignedTxnWithAD.SignedTxn.Sig.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x2000
+	}
+	if (*z).SignedTxnWithAD.SignedTxn.Txn.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x4000
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -2087,6 +2145,15 @@ func (z *SignedTxnInBlock) MarshalMsg(b []byte) (o []byte, err error) {
 			}
 		}
 		if (zb0001Mask & 0x1000) == 0 { // if not empty
+			// string "sgnr"
+			o = append(o, 0xa4, 0x73, 0x67, 0x6e, 0x72)
+			o, err = (*z).SignedTxnWithAD.SignedTxn.AuthAddr.MarshalMsg(o)
+			if err != nil {
+				err = msgp.WrapError(err, "AuthAddr")
+				return
+			}
+		}
+		if (zb0001Mask & 0x2000) == 0 { // if not empty
 			// string "sig"
 			o = append(o, 0xa3, 0x73, 0x69, 0x67)
 			o, err = (*z).SignedTxnWithAD.SignedTxn.Sig.MarshalMsg(o)
@@ -2095,7 +2162,7 @@ func (z *SignedTxnInBlock) MarshalMsg(b []byte) (o []byte, err error) {
 				return
 			}
 		}
-		if (zb0001Mask & 0x2000) == 0 { // if not empty
+		if (zb0001Mask & 0x4000) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
 			o, err = (*z).SignedTxnWithAD.SignedTxn.Txn.MarshalMsg(o)
@@ -2155,6 +2222,14 @@ func (z *SignedTxnInBlock) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			bts, err = (*z).SignedTxnWithAD.SignedTxn.Txn.UnmarshalMsg(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Txn")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).SignedTxnWithAD.SignedTxn.AuthAddr.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "AuthAddr")
 				return
 			}
 		}
@@ -2253,6 +2328,12 @@ func (z *SignedTxnInBlock) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "Txn")
 					return
 				}
+			case "sgnr":
+				bts, err = (*z).SignedTxnWithAD.SignedTxn.AuthAddr.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "AuthAddr")
+					return
+				}
 			case "ca":
 				bts, err = (*z).SignedTxnWithAD.ApplyData.ClosingAmount.UnmarshalMsg(bts)
 				if err != nil {
@@ -2309,21 +2390,21 @@ func (_ *SignedTxnInBlock) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *SignedTxnInBlock) Msgsize() (s int) {
-	s = 1 + 4 + (*z).SignedTxnWithAD.SignedTxn.Sig.Msgsize() + 5 + (*z).SignedTxnWithAD.SignedTxn.Msig.Msgsize() + 5 + (*z).SignedTxnWithAD.SignedTxn.Lsig.Msgsize() + 4 + (*z).SignedTxnWithAD.SignedTxn.Txn.Msgsize() + 3 + (*z).SignedTxnWithAD.ApplyData.ClosingAmount.Msgsize() + 3 + (*z).SignedTxnWithAD.ApplyData.SenderRewards.Msgsize() + 3 + (*z).SignedTxnWithAD.ApplyData.ReceiverRewards.Msgsize() + 3 + (*z).SignedTxnWithAD.ApplyData.CloseRewards.Msgsize() + 4 + msgp.BoolSize + 4 + msgp.BoolSize
+	s = 1 + 4 + (*z).SignedTxnWithAD.SignedTxn.Sig.Msgsize() + 5 + (*z).SignedTxnWithAD.SignedTxn.Msig.Msgsize() + 5 + (*z).SignedTxnWithAD.SignedTxn.Lsig.Msgsize() + 4 + (*z).SignedTxnWithAD.SignedTxn.Txn.Msgsize() + 5 + (*z).SignedTxnWithAD.SignedTxn.AuthAddr.Msgsize() + 3 + (*z).SignedTxnWithAD.ApplyData.ClosingAmount.Msgsize() + 3 + (*z).SignedTxnWithAD.ApplyData.SenderRewards.Msgsize() + 3 + (*z).SignedTxnWithAD.ApplyData.ReceiverRewards.Msgsize() + 3 + (*z).SignedTxnWithAD.ApplyData.CloseRewards.Msgsize() + 4 + msgp.BoolSize + 4 + msgp.BoolSize
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *SignedTxnInBlock) MsgIsZero() bool {
-	return ((*z).SignedTxnWithAD.SignedTxn.Sig.MsgIsZero()) && ((*z).SignedTxnWithAD.SignedTxn.Msig.MsgIsZero()) && ((*z).SignedTxnWithAD.SignedTxn.Lsig.MsgIsZero()) && ((*z).SignedTxnWithAD.SignedTxn.Txn.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.ClosingAmount.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.SenderRewards.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.ReceiverRewards.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.CloseRewards.MsgIsZero()) && ((*z).HasGenesisID == false) && ((*z).HasGenesisHash == false)
+	return ((*z).SignedTxnWithAD.SignedTxn.Sig.MsgIsZero()) && ((*z).SignedTxnWithAD.SignedTxn.Msig.MsgIsZero()) && ((*z).SignedTxnWithAD.SignedTxn.Lsig.MsgIsZero()) && ((*z).SignedTxnWithAD.SignedTxn.Txn.MsgIsZero()) && ((*z).SignedTxnWithAD.SignedTxn.AuthAddr.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.ClosingAmount.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.SenderRewards.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.ReceiverRewards.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.CloseRewards.MsgIsZero()) && ((*z).HasGenesisID == false) && ((*z).HasGenesisHash == false)
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z *SignedTxnWithAD) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0001Len := uint32(8)
-	var zb0001Mask uint16 /* 11 bits */
+	zb0001Len := uint32(9)
+	var zb0001Mask uint16 /* 12 bits */
 	if (*z).ApplyData.ClosingAmount.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x8
@@ -2348,13 +2429,17 @@ func (z *SignedTxnWithAD) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0001Len--
 		zb0001Mask |= 0x100
 	}
-	if (*z).SignedTxn.Sig.MsgIsZero() {
+	if (*z).SignedTxn.AuthAddr.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x200
 	}
-	if (*z).SignedTxn.Txn.MsgIsZero() {
+	if (*z).SignedTxn.Sig.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x400
+	}
+	if (*z).SignedTxn.Txn.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x800
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -2414,6 +2499,15 @@ func (z *SignedTxnWithAD) MarshalMsg(b []byte) (o []byte, err error) {
 			}
 		}
 		if (zb0001Mask & 0x200) == 0 { // if not empty
+			// string "sgnr"
+			o = append(o, 0xa4, 0x73, 0x67, 0x6e, 0x72)
+			o, err = (*z).SignedTxn.AuthAddr.MarshalMsg(o)
+			if err != nil {
+				err = msgp.WrapError(err, "AuthAddr")
+				return
+			}
+		}
+		if (zb0001Mask & 0x400) == 0 { // if not empty
 			// string "sig"
 			o = append(o, 0xa3, 0x73, 0x69, 0x67)
 			o, err = (*z).SignedTxn.Sig.MarshalMsg(o)
@@ -2422,7 +2516,7 @@ func (z *SignedTxnWithAD) MarshalMsg(b []byte) (o []byte, err error) {
 				return
 			}
 		}
-		if (zb0001Mask & 0x400) == 0 { // if not empty
+		if (zb0001Mask & 0x800) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
 			o, err = (*z).SignedTxn.Txn.MarshalMsg(o)
@@ -2482,6 +2576,14 @@ func (z *SignedTxnWithAD) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			bts, err = (*z).SignedTxn.Txn.UnmarshalMsg(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Txn")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).SignedTxn.AuthAddr.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "AuthAddr")
 				return
 			}
 		}
@@ -2564,6 +2666,12 @@ func (z *SignedTxnWithAD) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "Txn")
 					return
 				}
+			case "sgnr":
+				bts, err = (*z).SignedTxn.AuthAddr.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "AuthAddr")
+					return
+				}
 			case "ca":
 				bts, err = (*z).ApplyData.ClosingAmount.UnmarshalMsg(bts)
 				if err != nil {
@@ -2608,21 +2716,21 @@ func (_ *SignedTxnWithAD) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *SignedTxnWithAD) Msgsize() (s int) {
-	s = 1 + 4 + (*z).SignedTxn.Sig.Msgsize() + 5 + (*z).SignedTxn.Msig.Msgsize() + 5 + (*z).SignedTxn.Lsig.Msgsize() + 4 + (*z).SignedTxn.Txn.Msgsize() + 3 + (*z).ApplyData.ClosingAmount.Msgsize() + 3 + (*z).ApplyData.SenderRewards.Msgsize() + 3 + (*z).ApplyData.ReceiverRewards.Msgsize() + 3 + (*z).ApplyData.CloseRewards.Msgsize()
+	s = 1 + 4 + (*z).SignedTxn.Sig.Msgsize() + 5 + (*z).SignedTxn.Msig.Msgsize() + 5 + (*z).SignedTxn.Lsig.Msgsize() + 4 + (*z).SignedTxn.Txn.Msgsize() + 5 + (*z).SignedTxn.AuthAddr.Msgsize() + 3 + (*z).ApplyData.ClosingAmount.Msgsize() + 3 + (*z).ApplyData.SenderRewards.Msgsize() + 3 + (*z).ApplyData.ReceiverRewards.Msgsize() + 3 + (*z).ApplyData.CloseRewards.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *SignedTxnWithAD) MsgIsZero() bool {
-	return ((*z).SignedTxn.Sig.MsgIsZero()) && ((*z).SignedTxn.Msig.MsgIsZero()) && ((*z).SignedTxn.Lsig.MsgIsZero()) && ((*z).SignedTxn.Txn.MsgIsZero()) && ((*z).ApplyData.ClosingAmount.MsgIsZero()) && ((*z).ApplyData.SenderRewards.MsgIsZero()) && ((*z).ApplyData.ReceiverRewards.MsgIsZero()) && ((*z).ApplyData.CloseRewards.MsgIsZero())
+	return ((*z).SignedTxn.Sig.MsgIsZero()) && ((*z).SignedTxn.Msig.MsgIsZero()) && ((*z).SignedTxn.Lsig.MsgIsZero()) && ((*z).SignedTxn.Txn.MsgIsZero()) && ((*z).SignedTxn.AuthAddr.MsgIsZero()) && ((*z).ApplyData.ClosingAmount.MsgIsZero()) && ((*z).ApplyData.SenderRewards.MsgIsZero()) && ((*z).ApplyData.ReceiverRewards.MsgIsZero()) && ((*z).ApplyData.CloseRewards.MsgIsZero())
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0002Len := uint32(29)
-	var zb0002Mask uint64 /* 36 bits */
+	zb0002Len := uint32(30)
+	var zb0002Mask uint64 /* 37 bits */
 	if (*z).AssetTransferTxnFields.AssetAmount == 0 {
 		zb0002Len--
 		zb0002Mask |= 0x80
@@ -2707,37 +2815,41 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0002Len--
 		zb0002Mask |= 0x8000000
 	}
-	if (*z).KeyregTxnFields.SelectionPK.MsgIsZero() {
+	if (*z).Header.RekeyTo.MsgIsZero() {
 		zb0002Len--
 		zb0002Mask |= 0x10000000
 	}
-	if (*z).Header.Sender.MsgIsZero() {
+	if (*z).KeyregTxnFields.SelectionPK.MsgIsZero() {
 		zb0002Len--
 		zb0002Mask |= 0x20000000
 	}
-	if (*z).Type.MsgIsZero() {
+	if (*z).Header.Sender.MsgIsZero() {
 		zb0002Len--
 		zb0002Mask |= 0x40000000
 	}
-	if (*z).KeyregTxnFields.VoteFirst.MsgIsZero() {
+	if (*z).Type.MsgIsZero() {
 		zb0002Len--
 		zb0002Mask |= 0x80000000
 	}
-	if (*z).KeyregTxnFields.VoteKeyDilution == 0 {
+	if (*z).KeyregTxnFields.VoteFirst.MsgIsZero() {
 		zb0002Len--
 		zb0002Mask |= 0x100000000
 	}
-	if (*z).KeyregTxnFields.VotePK.MsgIsZero() {
+	if (*z).KeyregTxnFields.VoteKeyDilution == 0 {
 		zb0002Len--
 		zb0002Mask |= 0x200000000
 	}
-	if (*z).KeyregTxnFields.VoteLast.MsgIsZero() {
+	if (*z).KeyregTxnFields.VotePK.MsgIsZero() {
 		zb0002Len--
 		zb0002Mask |= 0x400000000
 	}
-	if (*z).AssetTransferTxnFields.XferAsset.MsgIsZero() {
+	if (*z).KeyregTxnFields.VoteLast.MsgIsZero() {
 		zb0002Len--
 		zb0002Mask |= 0x800000000
+	}
+	if (*z).AssetTransferTxnFields.XferAsset.MsgIsZero() {
+		zb0002Len--
+		zb0002Mask |= 0x1000000000
 	}
 	// variable map header, size zb0002Len
 	o = msgp.AppendMapHeader(o, zb0002Len)
@@ -2908,6 +3020,15 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 			}
 		}
 		if (zb0002Mask & 0x10000000) == 0 { // if not empty
+			// string "rekey"
+			o = append(o, 0xa5, 0x72, 0x65, 0x6b, 0x65, 0x79)
+			o, err = (*z).Header.RekeyTo.MarshalMsg(o)
+			if err != nil {
+				err = msgp.WrapError(err, "RekeyTo")
+				return
+			}
+		}
+		if (zb0002Mask & 0x20000000) == 0 { // if not empty
 			// string "selkey"
 			o = append(o, 0xa6, 0x73, 0x65, 0x6c, 0x6b, 0x65, 0x79)
 			o, err = (*z).KeyregTxnFields.SelectionPK.MarshalMsg(o)
@@ -2916,7 +3037,7 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 				return
 			}
 		}
-		if (zb0002Mask & 0x20000000) == 0 { // if not empty
+		if (zb0002Mask & 0x40000000) == 0 { // if not empty
 			// string "snd"
 			o = append(o, 0xa3, 0x73, 0x6e, 0x64)
 			o, err = (*z).Header.Sender.MarshalMsg(o)
@@ -2925,7 +3046,7 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 				return
 			}
 		}
-		if (zb0002Mask & 0x40000000) == 0 { // if not empty
+		if (zb0002Mask & 0x80000000) == 0 { // if not empty
 			// string "type"
 			o = append(o, 0xa4, 0x74, 0x79, 0x70, 0x65)
 			o, err = (*z).Type.MarshalMsg(o)
@@ -2934,7 +3055,7 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 				return
 			}
 		}
-		if (zb0002Mask & 0x80000000) == 0 { // if not empty
+		if (zb0002Mask & 0x100000000) == 0 { // if not empty
 			// string "votefst"
 			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x66, 0x73, 0x74)
 			o, err = (*z).KeyregTxnFields.VoteFirst.MarshalMsg(o)
@@ -2943,12 +3064,12 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 				return
 			}
 		}
-		if (zb0002Mask & 0x100000000) == 0 { // if not empty
+		if (zb0002Mask & 0x200000000) == 0 { // if not empty
 			// string "votekd"
 			o = append(o, 0xa6, 0x76, 0x6f, 0x74, 0x65, 0x6b, 0x64)
 			o = msgp.AppendUint64(o, (*z).KeyregTxnFields.VoteKeyDilution)
 		}
-		if (zb0002Mask & 0x200000000) == 0 { // if not empty
+		if (zb0002Mask & 0x400000000) == 0 { // if not empty
 			// string "votekey"
 			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x6b, 0x65, 0x79)
 			o, err = (*z).KeyregTxnFields.VotePK.MarshalMsg(o)
@@ -2957,7 +3078,7 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 				return
 			}
 		}
-		if (zb0002Mask & 0x400000000) == 0 { // if not empty
+		if (zb0002Mask & 0x800000000) == 0 { // if not empty
 			// string "votelst"
 			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x6c, 0x73, 0x74)
 			o, err = (*z).KeyregTxnFields.VoteLast.MarshalMsg(o)
@@ -2966,7 +3087,7 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 				return
 			}
 		}
-		if (zb0002Mask & 0x800000000) == 0 { // if not empty
+		if (zb0002Mask & 0x1000000000) == 0 { // if not empty
 			// string "xaid"
 			o = append(o, 0xa4, 0x78, 0x61, 0x69, 0x64)
 			o, err = (*z).AssetTransferTxnFields.XferAsset.MarshalMsg(o)
@@ -3074,6 +3195,14 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			bts, err = msgp.ReadExactBytes(bts, ((*z).Header.Lease)[:])
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Lease")
+				return
+			}
+		}
+		if zb0002 > 0 {
+			zb0002--
+			bts, err = (*z).Header.RekeyTo.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "RekeyTo")
 				return
 			}
 		}
@@ -3312,6 +3441,12 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "Lease")
 					return
 				}
+			case "rekey":
+				bts, err = (*z).Header.RekeyTo.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "RekeyTo")
+					return
+				}
 			case "votekey":
 				bts, err = (*z).KeyregTxnFields.VotePK.UnmarshalMsg(bts)
 				if err != nil {
@@ -3446,13 +3581,13 @@ func (_ *Transaction) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *Transaction) Msgsize() (s int) {
-	s = 3 + 5 + (*z).Type.Msgsize() + 4 + (*z).Header.Sender.Msgsize() + 4 + (*z).Header.Fee.Msgsize() + 3 + (*z).Header.FirstValid.Msgsize() + 3 + (*z).Header.LastValid.Msgsize() + 5 + msgp.BytesPrefixSize + len((*z).Header.Note) + 4 + msgp.StringPrefixSize + len((*z).Header.GenesisID) + 3 + (*z).Header.GenesisHash.Msgsize() + 4 + (*z).Header.Group.Msgsize() + 3 + msgp.ArrayHeaderSize + (32 * (msgp.ByteSize)) + 8 + (*z).KeyregTxnFields.VotePK.Msgsize() + 7 + (*z).KeyregTxnFields.SelectionPK.Msgsize() + 8 + (*z).KeyregTxnFields.VoteFirst.Msgsize() + 8 + (*z).KeyregTxnFields.VoteLast.Msgsize() + 7 + msgp.Uint64Size + 8 + msgp.BoolSize + 4 + (*z).PaymentTxnFields.Receiver.Msgsize() + 4 + (*z).PaymentTxnFields.Amount.Msgsize() + 6 + (*z).PaymentTxnFields.CloseRemainderTo.Msgsize() + 5 + (*z).AssetConfigTxnFields.ConfigAsset.Msgsize() + 5 + (*z).AssetConfigTxnFields.AssetParams.Msgsize() + 5 + (*z).AssetTransferTxnFields.XferAsset.Msgsize() + 5 + msgp.Uint64Size + 5 + (*z).AssetTransferTxnFields.AssetSender.Msgsize() + 5 + (*z).AssetTransferTxnFields.AssetReceiver.Msgsize() + 7 + (*z).AssetTransferTxnFields.AssetCloseTo.Msgsize() + 5 + (*z).AssetFreezeTxnFields.FreezeAccount.Msgsize() + 5 + (*z).AssetFreezeTxnFields.FreezeAsset.Msgsize() + 5 + msgp.BoolSize
+	s = 3 + 5 + (*z).Type.Msgsize() + 4 + (*z).Header.Sender.Msgsize() + 4 + (*z).Header.Fee.Msgsize() + 3 + (*z).Header.FirstValid.Msgsize() + 3 + (*z).Header.LastValid.Msgsize() + 5 + msgp.BytesPrefixSize + len((*z).Header.Note) + 4 + msgp.StringPrefixSize + len((*z).Header.GenesisID) + 3 + (*z).Header.GenesisHash.Msgsize() + 4 + (*z).Header.Group.Msgsize() + 3 + msgp.ArrayHeaderSize + (32 * (msgp.ByteSize)) + 6 + (*z).Header.RekeyTo.Msgsize() + 8 + (*z).KeyregTxnFields.VotePK.Msgsize() + 7 + (*z).KeyregTxnFields.SelectionPK.Msgsize() + 8 + (*z).KeyregTxnFields.VoteFirst.Msgsize() + 8 + (*z).KeyregTxnFields.VoteLast.Msgsize() + 7 + msgp.Uint64Size + 8 + msgp.BoolSize + 4 + (*z).PaymentTxnFields.Receiver.Msgsize() + 4 + (*z).PaymentTxnFields.Amount.Msgsize() + 6 + (*z).PaymentTxnFields.CloseRemainderTo.Msgsize() + 5 + (*z).AssetConfigTxnFields.ConfigAsset.Msgsize() + 5 + (*z).AssetConfigTxnFields.AssetParams.Msgsize() + 5 + (*z).AssetTransferTxnFields.XferAsset.Msgsize() + 5 + msgp.Uint64Size + 5 + (*z).AssetTransferTxnFields.AssetSender.Msgsize() + 5 + (*z).AssetTransferTxnFields.AssetReceiver.Msgsize() + 7 + (*z).AssetTransferTxnFields.AssetCloseTo.Msgsize() + 5 + (*z).AssetFreezeTxnFields.FreezeAccount.Msgsize() + 5 + (*z).AssetFreezeTxnFields.FreezeAsset.Msgsize() + 5 + msgp.BoolSize
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *Transaction) MsgIsZero() bool {
-	return ((*z).Type.MsgIsZero()) && ((*z).Header.Sender.MsgIsZero()) && ((*z).Header.Fee.MsgIsZero()) && ((*z).Header.FirstValid.MsgIsZero()) && ((*z).Header.LastValid.MsgIsZero()) && (len((*z).Header.Note) == 0) && ((*z).Header.GenesisID == "") && ((*z).Header.GenesisHash.MsgIsZero()) && ((*z).Header.Group.MsgIsZero()) && ((*z).Header.Lease == ([32]byte{})) && ((*z).KeyregTxnFields.VotePK.MsgIsZero()) && ((*z).KeyregTxnFields.SelectionPK.MsgIsZero()) && ((*z).KeyregTxnFields.VoteFirst.MsgIsZero()) && ((*z).KeyregTxnFields.VoteLast.MsgIsZero()) && ((*z).KeyregTxnFields.VoteKeyDilution == 0) && ((*z).KeyregTxnFields.Nonparticipation == false) && ((*z).PaymentTxnFields.Receiver.MsgIsZero()) && ((*z).PaymentTxnFields.Amount.MsgIsZero()) && ((*z).PaymentTxnFields.CloseRemainderTo.MsgIsZero()) && ((*z).AssetConfigTxnFields.ConfigAsset.MsgIsZero()) && ((*z).AssetConfigTxnFields.AssetParams.MsgIsZero()) && ((*z).AssetTransferTxnFields.XferAsset.MsgIsZero()) && ((*z).AssetTransferTxnFields.AssetAmount == 0) && ((*z).AssetTransferTxnFields.AssetSender.MsgIsZero()) && ((*z).AssetTransferTxnFields.AssetReceiver.MsgIsZero()) && ((*z).AssetTransferTxnFields.AssetCloseTo.MsgIsZero()) && ((*z).AssetFreezeTxnFields.FreezeAccount.MsgIsZero()) && ((*z).AssetFreezeTxnFields.FreezeAsset.MsgIsZero()) && ((*z).AssetFreezeTxnFields.AssetFrozen == false)
+	return ((*z).Type.MsgIsZero()) && ((*z).Header.Sender.MsgIsZero()) && ((*z).Header.Fee.MsgIsZero()) && ((*z).Header.FirstValid.MsgIsZero()) && ((*z).Header.LastValid.MsgIsZero()) && (len((*z).Header.Note) == 0) && ((*z).Header.GenesisID == "") && ((*z).Header.GenesisHash.MsgIsZero()) && ((*z).Header.Group.MsgIsZero()) && ((*z).Header.Lease == ([32]byte{})) && ((*z).Header.RekeyTo.MsgIsZero()) && ((*z).KeyregTxnFields.VotePK.MsgIsZero()) && ((*z).KeyregTxnFields.SelectionPK.MsgIsZero()) && ((*z).KeyregTxnFields.VoteFirst.MsgIsZero()) && ((*z).KeyregTxnFields.VoteLast.MsgIsZero()) && ((*z).KeyregTxnFields.VoteKeyDilution == 0) && ((*z).KeyregTxnFields.Nonparticipation == false) && ((*z).PaymentTxnFields.Receiver.MsgIsZero()) && ((*z).PaymentTxnFields.Amount.MsgIsZero()) && ((*z).PaymentTxnFields.CloseRemainderTo.MsgIsZero()) && ((*z).AssetConfigTxnFields.ConfigAsset.MsgIsZero()) && ((*z).AssetConfigTxnFields.AssetParams.MsgIsZero()) && ((*z).AssetTransferTxnFields.XferAsset.MsgIsZero()) && ((*z).AssetTransferTxnFields.AssetAmount == 0) && ((*z).AssetTransferTxnFields.AssetSender.MsgIsZero()) && ((*z).AssetTransferTxnFields.AssetReceiver.MsgIsZero()) && ((*z).AssetTransferTxnFields.AssetCloseTo.MsgIsZero()) && ((*z).AssetFreezeTxnFields.FreezeAccount.MsgIsZero()) && ((*z).AssetFreezeTxnFields.FreezeAsset.MsgIsZero()) && ((*z).AssetFreezeTxnFields.AssetFrozen == false)
 }
 
 // MarshalMsg implements msgp.Marshaler

--- a/data/transactions/signedtxn.go
+++ b/data/transactions/signedtxn.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/data/basics"
 )
 
 // SignedTxn wraps a transaction and a signature.
@@ -34,6 +35,7 @@ type SignedTxn struct {
 	Msig crypto.MultisigSig `codec:"msig"`
 	Lsig LogicSig           `codec:"lsig"`
 	Txn  Transaction        `codec:"txn"`
+	AuthAddr basics.Address `codec:"sgnr"`
 }
 
 // SignedTxnInBlock is how a signed transaction is encoded in a block.
@@ -71,8 +73,20 @@ func (s SignedTxn) GetEncodedLength() int {
 	return len(protocol.Encode(&s))
 }
 
+// Authorizer returns the address against which the signature/msig/lsig should be checked,
+// or so the SignedTxn claims.
+// This is just s.AuthAddr or, if s.AuthAddr is zero, s.Txn.Sender.
+// It's provided as a convenience method.
+func (s SignedTxn) Authorizer() basics.Address {
+	if (s.AuthAddr == basics.Address{}) {
+		return s.Txn.Sender
+	}
+	return s.AuthAddr
+}
+
 // AssembleSignedTxn assembles a multisig-signed transaction from a transaction an optional sig, and an optional multisig.
 // No signature checking is done -- for example, this might only be a partial multisig
+// TODO: is this method used anywhere, or is it safe to remove?
 func AssembleSignedTxn(txn Transaction, sig crypto.Signature, msig crypto.MultisigSig) (SignedTxn, error) {
 	if sig != (crypto.Signature{}) && !msig.Blank() {
 		return SignedTxn{}, errors.New("signed txn can only have one of sig or msig")

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -93,6 +93,12 @@ type Header struct {
 	// the LastValid round passes.  While this transaction possesses the
 	// lease, no other transaction specifying this lease can be confirmed.
 	Lease [32]byte `codec:"lx"`
+
+	// RekeyTo, if nonzero, sets the sender's SpendingKey to the given address
+	// If the RekeyTo address is the sender's actual address, the SpendingKey is set to zero
+	// This allows "re-keying" a long-lived account -- rotating the signing key, changing
+	// membership of a multisig account, etc.
+	RekeyTo basics.Address `codec:"rekey"`
 }
 
 // Transaction describes a transaction that can appear in a block.
@@ -332,6 +338,7 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 	if !proto.SupportTxGroups && (tx.Group != crypto.Digest{}) {
 		return fmt.Errorf("transaction has group but groups not yet enabled")
 	}
+	// TODO(rekey) check that rekeyto is empty if rekeying is not supported
 	return nil
 }
 
@@ -412,6 +419,27 @@ func (tx Transaction) Apply(balances Balances, spec SpecialAddresses, ctr uint64
 	err = balances.Move(tx.Sender, spec.FeeSink, tx.Fee, &ad.SenderRewards, nil)
 	if err != nil {
 		return
+	}
+
+	// rekeying: update balrecord.SpendingKey to tx.RekeyTo if provided
+	if (tx.RekeyTo != basics.Address{}) {
+		var record basics.BalanceRecord
+		record, err = balances.Get(tx.Sender, false)
+		if err != nil {
+			return
+		}
+		// Special case: rekeying to the account's actual address just sets balrecord.SpendingKey to 0
+		// This saves 32 bytes in your balance record if you want to go back to using your original key
+		if tx.RekeyTo == tx.Sender {
+			record.SpendingKey = basics.Address{}
+		} else {
+			record.SpendingKey = tx.RekeyTo
+		}
+
+		err = balances.Put(record)
+		if err != nil {
+			return
+		}
 	}
 
 	switch tx.Type {

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -338,7 +338,9 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 	if !proto.SupportTxGroups && (tx.Group != crypto.Digest{}) {
 		return fmt.Errorf("transaction has group but groups not yet enabled")
 	}
-	// TODO(rekey) check that rekeyto is empty if rekeying is not supported
+	if !proto.SupportRekeying && (tx.RekeyTo != basics.Address{}) {
+		return fmt.Errorf("transaction has RekeyTo set but rekeying not yet enabled")
+	}
 	return nil
 }
 

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -100,6 +100,9 @@ func TxnPool(s *transactions.SignedTxn, ctx Context, verificationPool execpool.B
 	if s.Txn.Src() == zeroAddress {
 		return errors.New("empty address")
 	}
+	if !proto.SupportRekeying && (s.AuthAddr != basics.Address{}) {
+		return errors.New("nonempty AuthAddr but rekeying not supported")
+	}
 
 	outCh := make(chan error, 1)
 	cx := asyncVerifyContext{s: s, outCh: outCh, ctx: &ctx}
@@ -124,6 +127,9 @@ func Txn(s *transactions.SignedTxn, ctx Context) error {
 	zeroAddress := basics.Address{}
 	if s.Txn.Src() == zeroAddress {
 		return errors.New("empty address")
+	}
+	if !proto.SupportRekeying && (s.AuthAddr != basics.Address{}) {
+		return errors.New("nonempty AuthAddr but rekeying not supported")
 	}
 
 	return stxnVerifyCore(s, &ctx)

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 	"time"
+	"runtime"
 
 	"github.com/stretchr/testify/require"
 
@@ -161,6 +162,9 @@ func checkAcctUpdatesConsistency(t *testing.T, au *accountUpdates) {
 }
 
 func TestAcctUpdates(t *testing.T) {
+	if runtime.GOARCH == "arm" || runtime.GOARCH == "arm64" {
+		t.Skip("This test is too slow on ARM and causes travis builds to time out")
+	}
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
 	ml := makeMockLedgerForTracker(t)

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -528,6 +528,20 @@ func (eval *BlockEvaluator) transaction(txn transactions.SignedTxn, ad transacti
 		if dup {
 			return TransactionInLedgerError{txn.ID()}
 		}
+
+		// Does the address that authorized the transaction actually match whatever address the sender has rekeyed to?
+		// i.e., the sig/lsig/msig was checked against the txn.Authorizer() address, but does this match the SpendingKey in the sender's balance record?
+		acctdata, err := cow.lookup(txn.Txn.Sender)
+		if err != nil {
+			return err
+		}
+		correctAuthorizer := acctdata.SpendingKey
+		if (correctAuthorizer == basics.Address{}) {
+			correctAuthorizer = txn.Txn.Sender
+		}
+		if txn.Authorizer() != correctAuthorizer {
+			return fmt.Errorf("transaction %v: should have been authorized by %v but was actually authorized by %v", txn.ID(), correctAuthorizer, txn.Authorizer())
+		}
 	}
 
 	spec := transactions.SpecialAddresses{

--- a/ledger/eval_test.go
+++ b/ledger/eval_test.go
@@ -168,7 +168,7 @@ func TestRekeying(t *testing.T) {
 		// So the ValidatedBlock that comes out isn't necessarily actually a valid block. We'll call Validate ourselves.
 
 		newBlock := bookkeeping.MakeBlock(genesisInitState.Block.BlockHeader)
-		eval, err := l.StartEvaluator(newBlock.BlockHeader)
+		eval, err := l.StartEvaluator(newBlock.BlockHeader, 0)
 		require.NoError(t, err)
 
 		for _, stxn := range stxns {

--- a/ledger/eval_test.go
+++ b/ledger/eval_test.go
@@ -118,6 +118,15 @@ func TestBlockEvaluator(t *testing.T) {
 }
 
 func TestRekeying(t *testing.T) {
+	// Pretend rekeying is supported
+	actual := config.Consensus[protocol.ConsensusCurrentVersion]
+	pretend := actual
+	pretend.SupportRekeying = true
+	config.Consensus[protocol.ConsensusCurrentVersion] = pretend
+	defer func(){
+		config.Consensus[protocol.ConsensusCurrentVersion] = actual
+	}()
+
 	// Bring up a ledger
 	genesisInitState, addrs, keys := genesis(10)
 	dbName := fmt.Sprintf("%s.%d", t.Name(), crypto.RandUint64())

--- a/ledger/eval_test.go
+++ b/ledger/eval_test.go
@@ -17,6 +17,7 @@
 package ledger
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/util/execpool"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -113,4 +115,99 @@ func TestBlockEvaluator(t *testing.T) {
 	require.Equal(t, bal0new.MicroAlgos.Raw, bal0.MicroAlgos.Raw-minFee.Raw-100)
 	require.Equal(t, bal1new.MicroAlgos.Raw, bal1.MicroAlgos.Raw+100)
 	require.Equal(t, bal2new.MicroAlgos.Raw, bal2.MicroAlgos.Raw-minFee.Raw)
+}
+
+func TestRekeying(t *testing.T) {
+	// Bring up a ledger
+	genesisInitState, addrs, keys := genesis(10)
+	dbName := fmt.Sprintf("%s.%d", t.Name(), crypto.RandUint64())
+	const inMem = true
+	const archival = true
+	l, err := OpenLedger(logging.Base(), dbName, inMem, genesisInitState, archival)
+	require.NoError(t, err)
+	defer l.Close()
+
+	// Make a new block
+	nextRound := l.Latest() + basics.Round(1)
+	genHash := genesisInitState.Block.BlockHeader.GenesisHash
+
+	// Test plan
+	// Syntax: [A -> B][C, D] means transaction from A that rekeys to B with authaddr C and actual sig from D
+	makeTxn := func(sender, rekeyto, authaddr basics.Address, signer *crypto.SignatureSecrets, uniq uint8) transactions.SignedTxn {
+		txn := transactions.Transaction{
+			Type: protocol.PaymentTx,
+			Header: transactions.Header{
+				Sender: sender,
+				Fee:    minFee,
+				FirstValid: nextRound,
+				LastValid: nextRound,
+				GenesisHash: genHash,
+				RekeyTo: rekeyto,
+				Note: []byte{uniq},
+			},
+			PaymentTxnFields: transactions.PaymentTxnFields{
+				Receiver: sender,
+			},
+		}
+		sig := signer.Sign(txn)
+		return transactions.SignedTxn{Txn: txn, Sig: sig, AuthAddr: authaddr}
+	}
+
+	tryBlock := func(stxns []transactions.SignedTxn) error {
+		// We'll make a block using the evaluator.
+		// When generating a block, the evaluator doesn't check transaction sigs -- it assumes the transaction pool already did that.
+		// So the ValidatedBlock that comes out isn't necessarily actually a valid block. We'll call Validate ourselves.
+
+		newBlock := bookkeeping.MakeBlock(genesisInitState.Block.BlockHeader)
+		eval, err := l.StartEvaluator(newBlock.BlockHeader)
+		require.NoError(t, err)
+
+		for _, stxn := range stxns {
+			err = eval.Transaction(stxn, transactions.ApplyData{})
+			if err != nil {
+				return err
+			}
+		}
+		validatedBlock, err := eval.GenerateBlock()
+		if err != nil {
+			return err
+		}
+
+		backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)
+		defer backlogPool.Shutdown()
+		_, err = l.Validate(context.Background(), validatedBlock.Block(), nil, backlogPool)
+		return err
+	}
+
+	// Preamble transactions, which all of the blocks in this test will start with
+	// [A -> 0][0,A] (normal transaction)
+	// [A -> B][0,A] (rekey)
+	txn0 := makeTxn(addrs[0], basics.Address{}, basics.Address{}, keys[0], 0) // Normal transaction
+	txn1 := makeTxn(addrs[0], addrs[1], basics.Address{}, keys[0], 1) // Rekey transaction
+
+	// Test 1: Do only good things
+	// (preamble)
+	// [A -> 0][B,B] (normal transaction using new key)
+	// [A -> A][B,B] (rekey back to A, transaction still signed by B)
+	// [A -> 0][0,A] (normal transaction again)
+	test1txns := []transactions.SignedTxn{
+		txn0, txn1, // (preamble)
+		makeTxn(addrs[0], basics.Address{}, addrs[1], keys[1], 2), // [A -> 0][B,B]
+		makeTxn(addrs[0], addrs[0], addrs[1], keys[1], 3), // [A -> A][B,B]
+		makeTxn(addrs[0], basics.Address{}, basics.Address{}, keys[0], 4), // [A -> 0][0,A]
+	}
+	err = tryBlock(test1txns)
+	require.NoError(t, err)
+
+	// Test 2: Use old key after rekeying
+	// (preamble)
+	// [A -> A][0,A] (rekey back to A, but signed by A instead of B)
+	test2txns := []transactions.SignedTxn{
+		txn0, txn1, // (preamble)
+		makeTxn(addrs[0], addrs[0], basics.Address{}, keys[0], 2), // [A -> A][0,A]
+	}
+	err = tryBlock(test2txns)
+	require.Error(t, err)
+
+	// TODO: More tests
 }


### PR DESCRIPTION
Add backend support for rekeying: allowing transactions to change the spending key of an existing account. Such transactions will only be allowed once the protocol supports them -- this PR can be merged now without changing any behavior, and a future protocol upgrade can flip the switch to enable the feature.
This PR is the backend logic -- the ledger / block evaluator. Frontend work (goal / kmd support) will be in a subsequent PR.