### PR TITLE
Only compute TxID once during validated eval

### DIFF
--- a/ledger/cow.go
+++ b/ledger/cow.go
@@ -140,8 +140,12 @@ func (cb *roundCowState) put(addr basics.Address, old basics.AccountData, new ba
 	}
 }
 
-func (cb *roundCowState) addTx(txn transactions.Transaction) {
-	cb.mods.Txids[txn.ID()] = txn.LastValid
+func (cb *roundCowState) addTx(txn transactions.Transaction, cachedTxid transactions.Txid) {
+	if cachedTxid == (transactions.Txid{}) {
+		cachedTxid = txn.ID()
+	}
+
+	cb.mods.Txids[cachedTxid] = txn.LastValid
 	cb.mods.txleases[txlease{sender: txn.Sender, lease: txn.Lease}] = txn.LastValid
 }
 

--- a/ledger/cow.go
+++ b/ledger/cow.go
@@ -140,12 +140,8 @@ func (cb *roundCowState) put(addr basics.Address, old basics.AccountData, new ba
 	}
 }
 
-func (cb *roundCowState) addTx(txn transactions.Transaction, cachedTxid transactions.Txid) {
-	if cachedTxid == (transactions.Txid{}) {
-		cachedTxid = txn.ID()
-	}
-
-	cb.mods.Txids[cachedTxid] = txn.LastValid
+func (cb *roundCowState) addTx(txn transactions.Transaction, txid transactions.Txid) {
+	cb.mods.Txids[txid] = txn.LastValid
 	cb.mods.txleases[txlease{sender: txn.Sender, lease: txn.Lease}] = txn.LastValid
 }
 

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -512,6 +512,7 @@ func (eval *BlockEvaluator) transactionGroup(txgroup []transactions.SignedTxnWit
 // an error is returned and the block evaluator state is unchanged.
 func (eval *BlockEvaluator) transaction(txn transactions.SignedTxn, ad transactions.ApplyData, cow *roundCowState, txib *transactions.SignedTxnInBlock) error {
 	var err error
+	var cachedTxid transactions.Txid
 
 	if eval.validate {
 		err = txn.Txn.Alive(eval.block)
@@ -520,8 +521,8 @@ func (eval *BlockEvaluator) transaction(txn transactions.SignedTxn, ad transacti
 		}
 
 		// Transaction already in the ledger?
-		txid := txn.ID()
-		dup, err := cow.isDup(txn.Txn.First(), txn.Txn.Last(), txid, txlease{sender: txn.Txn.Sender, lease: txn.Txn.Lease})
+		cachedTxid = txn.ID()
+		dup, err := cow.isDup(txn.Txn.First(), txn.Txn.Last(), cachedTxid, txlease{sender: txn.Txn.Sender, lease: txn.Txn.Lease})
 		if err != nil {
 			return err
 		}
@@ -594,7 +595,7 @@ func (eval *BlockEvaluator) transaction(txn transactions.SignedTxn, ad transacti
 	}
 
 	// Remember this txn
-	cow.addTx(txn.Txn)
+	cow.addTx(txn.Txn, cachedTxid)
 
 	return nil
 }


### PR DESCRIPTION
CPU pprof graphs here: [txid-graphs.tar.gz](https://github.com/algorand/go-algorand/files/4410682/txid-graphs.tar.gz)

The benchmark I used may be [found on the maxj/applications branch here](https://github.com/justicz/go-algorand/blob/maxj/applications/ledger/ledger_perf_test.go).

```
maxj@algog ~/P/a/g/ledger> go test -run=XXX -bench='BenchmarkPay.*5000' -benchtime=25x -cpuprofile perf-no-opt.prof
goos: linux
goarch: amd64
pkg: github.com/algorand/go-algorand/ledger
BenchmarkPaymentEvalPerf5000-8                25         240774911 ns/op
...
maxj@algog ~/P/a/g/ledger> git checkout maxj/txid_calc_eval_once
Switched to branch 'maxj/txid_calc_eval_once'
maxj@algog ~/P/a/g/ledger> go test -run=XXX -bench='BenchmarkPay.*5000' -benchtime=25x -cpuprofile perf-wi-opt.prof
goos: linux
goarch: amd64
pkg: github.com/algorand/go-algorand/ledger
BenchmarkPaymentEvalPerf5000-8                25         231878331 ns/op
...
```

Currently, about 13.0% of time spent in `(*BlockEvaluator).transaction` is spent in `(*roundCowState).addTx`, which keeps track of the transaction for duplicate detection.

When we're verifying a block, we have already computed the `TxID` when we were checking if it was a duplicate. If we pass that value down to `(*roundCowState).addTx`, then we only spend 6.54% of our time in `(*BlockEvaluator).transaction` there.