### PR TITLE
Disable binary backup when running make install

### DIFF
--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -590,7 +590,9 @@ fi
 # Shutdown node before backing up so data is consistent and files aren't locked / in-use.
 shutdown_node
 
-backup_current_version
+if [ ${ALGOD_UPDATER_SKIP_BACKUP:-0} -ne 1 ]; then
+    backup_current_version
+fi
 
 # We don't care about return code - doesn't matter if we failed to archive
 

--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -18,6 +18,7 @@ HOSTEDSPEC=""
 BUCKET=""
 GENESIS_NETWORK_DIR=""
 GENESIS_NETWORK_DIR_SPEC=""
+SKIP_UPDATE=0
 
 set -o pipefail
 
@@ -83,6 +84,9 @@ while [ "$1" != "" ]; do
         -b)
             shift
             BUCKET="-b $1"
+            ;;
+        -s)
+            SKIP_UPDATE=1
             ;;
         *)
             echo "Unknown option" "$1"
@@ -590,7 +594,7 @@ fi
 # Shutdown node before backing up so data is consistent and files aren't locked / in-use.
 shutdown_node
 
-if [ ${ALGOD_UPDATER_SKIP_BACKUP:-0} -ne 1 ]; then
+if [ ${SKIP_UPDATE} -eq 0 ]; then
     backup_current_version
 fi
 

--- a/scripts/dev_install.sh
+++ b/scripts/dev_install.sh
@@ -27,4 +27,4 @@ if [ "${TARGETBINDIR}" = "" ]; then
 fi
 
 # dev_install.sh should explicitly generate 'dev' builds
-scripts/local_install.sh -c dev -p ${TARGETBINDIR} ${DATADIRSPEC}
+scripts/local_install.sh -c dev -p ${TARGETBINDIR} ${DATADIRSPEC} -f -s


### PR DESCRIPTION
## Summary

`make install` calls `updater.sh`, which backs up the old binaries before installing new ones. On my machine it takes 7 seconds to backup the files, which for small/no-op builds is 50% of the build time. Added `-s` option to updater.sh to skip the backup, and enable it by default in `dev_install.sh`.

## Test Plan

Run `make install` and see that it doesn't freeze for 5-10 seconds while backing up binaries