### PR TITLE
Hint payset size in block evaluator

### DIFF
--- a/data/ledger_test.go
+++ b/data/ledger_test.go
@@ -160,7 +160,7 @@ func BenchmarkAssemblePayset(b *testing.B) {
 		}
 		b.StartTimer()
 		newEmptyBlk := bookkeeping.MakeBlock(prev)
-		eval, err := l.StartEvaluator(newEmptyBlk.BlockHeader)
+		eval, err := l.StartEvaluator(newEmptyBlk.BlockHeader, 0)
 		if err != nil {
 			b.Errorf("could not make proposals at round %d: could not start evaluator: %v", next, err)
 			return

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -514,7 +514,7 @@ func (pool *TransactionPool) recomputeBlockEvaluator(committedTxIds map[transact
 		return
 	}
 
-	// Grab the trnasactions to be replayed through the new block evaluator
+	// Grab the transactions to be played through the new block evaluator
 	pool.pendingMu.RLock()
 	txgroups := pool.pendingTxGroups
 	verifyParams := pool.pendingVerifyParams
@@ -529,7 +529,7 @@ func (pool *TransactionPool) recomputeBlockEvaluator(committedTxIds map[transact
 		return
 	}
 
-	// Feed the transactions in order.
+	// Feed the transactions in order
 	for i, txgroup := range txgroups {
 		if len(txgroup) == 0 {
 			continue

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -164,12 +164,12 @@ func (pool *TransactionPool) rememberCommit(flush bool) {
 func (pool *TransactionPool) PendingCount() int {
 	pool.pendingMu.RLock()
 	defer pool.pendingMu.RUnlock()
-	return pool.pendingCountLocked()
+	return pool.pendingCountNoLock()
 }
 
-// pendingCountLocked is a helper for PendingCount that returns the number of
+// pendingCountNoLock is a helper for PendingCount that returns the number of
 // transactions pending in the pool
-func (pool *TransactionPool) pendingCountLocked() int {
+func (pool *TransactionPool) pendingCountNoLock() int {
 	var count int
 	for _, txgroup := range pool.pendingTxGroups {
 		count += len(txgroup)
@@ -518,7 +518,7 @@ func (pool *TransactionPool) recomputeBlockEvaluator(committedTxIds map[transact
 	pool.pendingMu.RLock()
 	txgroups := pool.pendingTxGroups
 	verifyParams := pool.pendingVerifyParams
-	pendingCount := pool.pendingCountLocked()
+	pendingCount := pool.pendingCountNoLock()
 	pool.pendingMu.RUnlock()
 
 	next := bookkeeping.MakeBlock(prev)

--- a/data/pools/transactionPool_test.go
+++ b/data/pools/transactionPool_test.go
@@ -102,7 +102,7 @@ func newBlockEvaluator(t TestingT, l *ledger.Ledger) *ledger.BlockEvaluator {
 	require.NoError(t, err)
 
 	next := bookkeeping.MakeBlock(prev)
-	eval, err := l.StartEvaluator(next.BlockHeader)
+	eval, err := l.StartEvaluator(next.BlockHeader, 0)
 	require.NoError(t, err)
 
 	return eval

--- a/data/transactions/aggregates.go
+++ b/data/transactions/aggregates.go
@@ -37,6 +37,10 @@ type (
 // depends on the order in which the Txids appear, and that Txids do NOT cover
 // transaction signatures.
 func (payset Payset) Commit(flat bool) crypto.Digest {
+	if len(payset) == 0 {
+		payset = nil
+	}
+
 	if flat {
 		return crypto.HashObj(payset)
 	}

--- a/data/transactions/aggregates.go
+++ b/data/transactions/aggregates.go
@@ -37,6 +37,11 @@ type (
 // depends on the order in which the Txids appear, and that Txids do NOT cover
 // transaction signatures.
 func (payset Payset) Commit(flat bool) crypto.Digest {
+	// We used to build up Paysets from a nil slice with `append` during
+	// block evaluation, meaning zero-length paysets would remain nil.
+	// After we started allocating them up front, we started calling Commit
+	// on zero-length but non-nil Paysets. However, we want payset
+	// encodings to remain the same with or without this optimization.
 	if len(payset) == 0 {
 		payset = nil
 	}

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -161,9 +161,8 @@ type BlockEvaluator struct {
 	proto       config.ConsensusParams
 	genesisHash crypto.Digest
 
-	block           bookkeeping.Block
-	blockTxBytes    int
-	blockPaysetHint int
+	block        bookkeeping.Block
+	blockTxBytes int
 
 	l ledgerForEvaluator
 }

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -339,11 +339,6 @@ func (eval *BlockEvaluator) workaroundOverspentRewards(rewardPoolBalance basics.
 	return
 }
 
-// PaysetLength returns the number of transactions in the block's payset so far.
-func (eval *BlockEvaluator) PaysetLength() int {
-	return len(eval.block.Payset)
-}
-
 // Round returns the round number of the block being evaluated by the BlockEvaluator.
 func (eval *BlockEvaluator) Round() basics.Round {
 	return eval.block.Round()

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -36,6 +36,11 @@ import (
 // ErrNoSpace indicates insufficient space for transaction in block
 var ErrNoSpace = errors.New("block does not have space for transaction")
 
+// maxPaysetHint makes sure that we don't allocate too much memory up front
+// in the block evaluator, since there cannot reasonably be more than this
+// many transactions in a block.
+const maxPaysetHint = 20000
+
 // VerifiedTxnCache captures the interface for a cache of previously
 // verified transactions.  This is expected to match the transaction
 // pool object.
@@ -214,6 +219,9 @@ func startEvaluator(l ledgerForEvaluator, hdr bookkeeping.BlockHeader, paysetHin
 	// Preallocate space for the payset so that we don't have to
 	// dynamically grow a slice (if evaluating a whole block).
 	if paysetHint >= 0 {
+		if paysetHint > maxPaysetHint {
+			paysetHint = maxPaysetHint
+		}
 		eval.block.Payset = make([]transactions.SignedTxnInBlock, 0, paysetHint)
 	}
 

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -218,7 +218,7 @@ func startEvaluator(l ledgerForEvaluator, hdr bookkeeping.BlockHeader, paysetHin
 
 	// Preallocate space for the payset so that we don't have to
 	// dynamically grow a slice (if evaluating a whole block).
-	if paysetHint >= 0 {
+	if paysetHint > 0 {
 		if paysetHint > maxPaysetHint {
 			paysetHint = maxPaysetHint
 		}

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -161,8 +161,9 @@ type BlockEvaluator struct {
 	proto       config.ConsensusParams
 	genesisHash crypto.Digest
 
-	block        bookkeeping.Block
-	blockTxBytes int
+	block           bookkeeping.Block
+	blockTxBytes    int
+	blockPaysetHint int
 
 	l ledgerForEvaluator
 }
@@ -179,12 +180,14 @@ type ledgerForEvaluator interface {
 }
 
 // StartEvaluator creates a BlockEvaluator, given a ledger and a block header
-// of the block that the caller is planning to evaluate.
-func (l *Ledger) StartEvaluator(hdr bookkeeping.BlockHeader) (*BlockEvaluator, error) {
-	return startEvaluator(l, hdr, true, true)
+// of the block that the caller is planning to evaluate. If the length of the
+// payset being evaluated is known in advance, a paysetHint >= 0 can be
+// passed, avoiding unnecessary payset slice growth.
+func (l *Ledger) StartEvaluator(hdr bookkeeping.BlockHeader, paysetHint int) (*BlockEvaluator, error) {
+	return startEvaluator(l, hdr, paysetHint, true, true)
 }
 
-func startEvaluator(l ledgerForEvaluator, hdr bookkeeping.BlockHeader, validate bool, generate bool) (*BlockEvaluator, error) {
+func startEvaluator(l ledgerForEvaluator, hdr bookkeeping.BlockHeader, paysetHint int, validate bool, generate bool) (*BlockEvaluator, error) {
 	proto, ok := config.Consensus[hdr.CurrentProtocol]
 	if !ok {
 		return nil, protocol.Error(hdr.CurrentProtocol)
@@ -207,6 +210,12 @@ func startEvaluator(l ledgerForEvaluator, hdr bookkeeping.BlockHeader, validate 
 		proto:       proto,
 		genesisHash: l.GenesisHash(),
 		l:           l,
+	}
+
+	// Preallocate space for the payset so that we don't have to
+	// dynamically grow a slice (if evaluating a whole block).
+	if paysetHint >= 0 {
+		eval.block.Payset = make([]transactions.SignedTxnInBlock, 0, paysetHint)
 	}
 
 	if hdr.Round > 0 {
@@ -323,6 +332,11 @@ func (eval *BlockEvaluator) workaroundOverspentRewards(rewardPoolBalance basics.
 	return
 }
 
+// PaysetLength returns the number of transactions in the block's payset so far.
+func (eval *BlockEvaluator) PaysetLength() int {
+	return len(eval.block.Payset)
+}
+
 // Round returns the round number of the block being evaluated by the BlockEvaluator.
 func (eval *BlockEvaluator) Round() basics.Round {
 	return eval.block.Round()
@@ -426,22 +440,20 @@ func (eval *BlockEvaluator) Transaction(txn transactions.SignedTxn, ad transacti
 			SignedTxn: txn,
 			ApplyData: ad,
 		},
-	}, true)
+	})
 }
 
 // TransactionGroup tentatively adds a new transaction group as part of this block evaluation.
 // If the transaction group cannot be added to the block without violating some constraints,
 // an error is returned and the block evaluator state is unchanged.
 func (eval *BlockEvaluator) TransactionGroup(txads []transactions.SignedTxnWithAD) error {
-	return eval.transactionGroup(txads, true)
+	return eval.transactionGroup(txads)
 }
 
 // transactionGroup tentatively executes a group of transactions as part of this block evaluation.
 // If the transaction group cannot be added to the block without violating some constraints,
-// an error is returned and the block evaluator state is unchanged.  If remember is true,
-// the transaction group is added to the block evaluator state; otherwise, the block evaluator
-// is not modified and does not remember this transaction group.
-func (eval *BlockEvaluator) transactionGroup(txgroup []transactions.SignedTxnWithAD, remember bool) error {
+// an error is returned and the block evaluator state is unchanged.
+func (eval *BlockEvaluator) transactionGroup(txgroup []transactions.SignedTxnWithAD) error {
 	// Nothing to do if there are no transactions.
 	if len(txgroup) == 0 {
 		return nil
@@ -498,11 +510,9 @@ func (eval *BlockEvaluator) transactionGroup(txgroup []transactions.SignedTxnWit
 		}
 	}
 
-	if remember {
-		eval.block.Payset = append(eval.block.Payset, txibs...)
-		eval.blockTxBytes += groupTxBytes
-		cow.commitToParent()
-	}
+	eval.block.Payset = append(eval.block.Payset, txibs...)
+	eval.blockTxBytes += groupTxBytes
+	cow.commitToParent()
 
 	return nil
 }
@@ -722,7 +732,7 @@ func validateTransaction(txn transactions.SignedTxn, block bookkeeping.Block, pr
 // AddBlock: eval(context.Background(), blk, false, nil, nil)
 // tracker:  eval(context.Background(), blk, false, nil, nil)
 func (l *Ledger) eval(ctx context.Context, blk bookkeeping.Block, validate bool, txcache VerifiedTxnCache, executionPool execpool.BacklogPool) (StateDelta, error) {
-	eval, err := startEvaluator(l, blk.BlockHeader, validate, false)
+	eval, err := startEvaluator(l, blk.BlockHeader, len(blk.Payset), validate, false)
 	if err != nil {
 		return StateDelta{}, err
 	}

--- a/ledger/eval_test.go
+++ b/ledger/eval_test.go
@@ -52,7 +52,7 @@ func TestBlockEvaluator(t *testing.T) {
 	defer l.Close()
 
 	newBlock := bookkeeping.MakeBlock(genesisInitState.Block.BlockHeader)
-	eval, err := l.StartEvaluator(newBlock.BlockHeader)
+	eval, err := l.StartEvaluator(newBlock.BlockHeader, 0)
 	require.NoError(t, err)
 
 	genHash := genesisInitState.Block.BlockHeader.GenesisHash

--- a/node/impls.go
+++ b/node/impls.go
@@ -94,7 +94,9 @@ func (i *blockFactoryImpl) AssembleBlock(round basics.Round, deadline time.Time)
 
 	newEmptyBlk := bookkeeping.MakeBlock(prev)
 
-	eval, err := i.l.StartEvaluator(newEmptyBlk.BlockHeader)
+	// Start the block evaluator, hinting its payset length based on the
+	// transaction pool's block evaluator
+	eval, err := i.l.StartEvaluator(newEmptyBlk.BlockHeader, i.tp.PaysetLength())
 	if err != nil {
 		return nil, fmt.Errorf("could not make proposals at round %d: could not start evaluator: %v", round, err)
 	}

--- a/node/impls.go
+++ b/node/impls.go
@@ -96,7 +96,7 @@ func (i *blockFactoryImpl) AssembleBlock(round basics.Round, deadline time.Time)
 
 	// Start the block evaluator, hinting its payset length based on the
 	// transaction pool's block evaluator
-	eval, err := i.l.StartEvaluator(newEmptyBlk.BlockHeader, i.tp.PaysetLength())
+	eval, err := i.l.StartEvaluator(newEmptyBlk.BlockHeader, i.tp.PendingCount())
 	if err != nil {
 		return nil, fmt.Errorf("could not make proposals at round %d: could not start evaluator: %v", round, err)
 	}


### PR DESCRIPTION
In go, as `append` is called over and over on a slice, its capacity grows like this:

```
0xc000014180 cap 1
0xc0000200f0 cap 2
0xc00001a0c0 cap 4
0xc00009c000 cap 8
0xc00009e000 cap 16
0xc0000a0000 cap 32
0xc00001c600 cap 64
0xc0000a2000 cap 128
0xc0000a8000 cap 256
0xc0000ae000 cap 512
0xc0000b4000 cap 1024
0xc0000ba000 cap 1365
0xc0000c2000 cap 1706
0xc0000cc000 cap 2389
0xc0000da000 cap 3072
0xc0000ec000 cap 4096
0xc000104000 cap 5120
0xc000122000 cap 6485
0xc000148000 cap 8192
0xc000178000 cap 10240
```

Currently, in the `BlockEvaluator`, the block's `Payset` is growing only by successive calls to `append`. However, everywhere we are currently using a `BlockEvaluator`, we have a reasonable hint for how big the evaluated `Payset` will be.

On my `maxj/applications` branch with this PR applied, I'm seeing about a 16% performance improvement in `BenchmarkPay`, which evaluates full blocks of payment transactions. However, it would be good to see `pingpong` data on this branch before merging.

Additionally, though I don't see a reason why this would hurt performance for empty/small blocks, it would be good to confirm that this is the case.