### PR TITLE
Remove call to build_deb.sh from build_packages.sh

### DIFF
--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -107,19 +107,5 @@ for var in "${VARIATION_ARRAY[@]}"; do
         cd ${PLATFORM_ROOT}/tools
         tar -zcf ${PKG_ROOT}/tools_${CHANNEL}_${PKG_NAME}_${FULLVERSION}.tar.gz * >/dev/null 2>&1
         popd
-
-        # If Linux package, build debian (deb) package as well
-        if [ ! -z "${BUILD_DEB}" -a $(scripts/ostype.sh) = "linux" ]; then
-            DEBTMP=$(mktemp -d 2>/dev/null || mktemp -d -t "debtmp")
-            trap "rm -rf ${DEBTMP}" 0
-            scripts/build_deb.sh ${ARCH} ${DEBTMP} ${CHANNEL}
-            if [ $? -ne 0 ]; then
-                echo "Error building debian package for ${PLATFORM}.  Aborting..."
-                exit 1
-            fi
-            pushd ${DEBTMP}
-            cp -p *.deb ${PKG_ROOT}/algorand_${CHANNEL}_${PKG_NAME}_${FULLVERSION}.deb
-            popd
-        fi
     done
 done

--- a/scripts/release/build/deb/package.sh
+++ b/scripts/release/build/deb/package.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=1090
+# shellcheck disable=1090,2064
 
 echo
 date "+build_release begin PACKAGE DEB stage %Y%m%d_%H%M%S"
@@ -9,12 +9,23 @@ echo
 
 set -ex
 
-export BUILD_DEB=1
 export NO_BUILD=1
 export GOPATH="${HOME}"/go
 export PATH="${GOPATH}":/usr/local/go/bin:"${PATH}"
+
 pushd "${REPO_ROOT}"
 ./scripts/build_packages.sh "${PLATFORM}"
+
+DEBTMP=$(mktemp -d 2>/dev/null || mktemp -d -t "debtmp")
+trap "rm -rf ${DEBTMP}" 0
+
+if ! ./scripts/build_deb.sh "${ARCH}" "${DEBTMP}" "${CHANNEL}"
+then
+    echo "Error building debian package for ${PLATFORM}.  Aborting..."
+    exit 1
+fi
+
+cp -p "${DEBTMP}"/*.deb "${PKG_ROOT}/algorand_${CHANNEL}_${PKG_NAME}_${FULLVERSION}.deb"
 popd
 
 # build docker release package


### PR DESCRIPTION
This code is only needed in one place, so let's move it there.  Also, extracting it from `build_packages.sh` helps greatly when creating breaking the build pipeline up into individual operations that then become `mule` tasks.