### PR TITLE
Require one of keyFilename or signareAcct in `goal clerk tealsign`

### DIFF
--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -117,7 +117,7 @@ const (
 
 	multisigProgramCollision = "should have at most one of --program/-p | --program-bytes/-P | --lsig/-L"
 
-	tealsignMutKeyArgs    = "--keyfile and --account are mutually exclusive"
+	tealsignMutKeyArgs    = "Need exactly one of --keyfile or --account"
 	tealsignMutLsigArgs   = "Need exactly one of --contract-addr or --lsig-txn"
 	tealsignKeyfileFail   = "Failed to read keyfile: %v"
 	tealsignNoWithAcct    = "--account is not yet supported"

--- a/cmd/goal/tealsign.go
+++ b/cmd/goal/tealsign.go
@@ -76,6 +76,10 @@ The base64 encoding of the signature will always be printed to stdout. Optionall
 			reportErrorf(tealsignMutKeyArgs)
 		}
 
+		if keyFilename == "" && signerAcct == "" {
+			reportErrorf(tealsignMutKeyArgs)
+		}
+
 		var kdata []byte
 		var err error
 		if keyFilename != "" {


### PR DESCRIPTION
Currently if you specify neither, you'll sign with an empty key.