### PR TITLE
Update catchup test to support adjustable upgrade window

### DIFF
--- a/test/e2e-go/features/catchup/basicCatchup_test.go
+++ b/test/e2e-go/features/catchup/basicCatchup_test.go
@@ -213,6 +213,7 @@ func TestStoppedCatchupOnUnsupported(t *testing.T) {
 	testUnupgradedProtocol.UpgradeVoteRounds = 3
 	testUnupgradedProtocol.UpgradeThreshold = 2
 	testUnupgradedProtocol.DefaultUpgradeWaitRounds = 3
+	testUnupgradedProtocol.MinUpgradeWaitRounds = 0
 
 	testUnupgradedProtocol.ApprovedUpgrades[consensusTestUnupgradedToProtocol] = 0
 	consensus[consensusTestUnupgradedProtocol] = testUnupgradedProtocol


### PR DESCRIPTION
## Summary

The catchup upgrade test was not setting up the MinUpgradeWaitRounds while using an upgrade window of 0. This caused the test to use an MinUpgradeWaitRounds=10000, which failed the applyUpgradeVote test. 

Fix https://github.com/algorand/go-algorand/issues/942