### PR TITLE
Bugfix: Swap EnableAssembleStats with EnableProcessBlockStats.

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -79,7 +79,7 @@ func MakeTransactionPool(ledger *ledger.Ledger, cfg config.Local) *TransactionPo
 		expiredTxCount:  make(map[basics.Round]int),
 		ledger:          ledger,
 		statusCache:     makeStatusCache(cfg.TxPoolSize),
-		logStats:        cfg.EnableAssembleStats,
+		logStats:        cfg.EnableProcessBlockStats,
 		expFeeFactor:    cfg.TxPoolExponentialIncreaseFactor,
 		txPoolMaxSize:   cfg.TxPoolSize,
 	}

--- a/data/pools/transactionPool_test.go
+++ b/data/pools/transactionPool_test.go
@@ -148,7 +148,7 @@ func TestMinBalanceOK(t *testing.T) {
 	ledger := makeMockLedger(t, initAcc(limitedAccounts))
 	cfg := config.GetDefaultLocal()
 	cfg.TxPoolSize = testPoolSize
-	cfg.EnableAssembleStats = false
+	cfg.EnableProcessBlockStats = false
 	transactionPool := MakeTransactionPool(ledger, cfg)
 
 	// sender goes below min
@@ -189,7 +189,7 @@ func TestSenderGoesBelowMinBalance(t *testing.T) {
 	ledger := makeMockLedger(t, initAcc(limitedAccounts))
 	cfg := config.GetDefaultLocal()
 	cfg.TxPoolSize = testPoolSize
-	cfg.EnableAssembleStats = false
+	cfg.EnableProcessBlockStats = false
 	transactionPool := MakeTransactionPool(ledger, cfg)
 
 	// sender goes below min
@@ -231,7 +231,7 @@ func TestSenderGoesBelowMinBalanceDueToAssets(t *testing.T) {
 	ledger := makeMockLedgerFuture(t, initAcc(limitedAccounts))
 	cfg := config.GetDefaultLocal()
 	cfg.TxPoolSize = testPoolSize
-	cfg.EnableAssembleStats = false
+	cfg.EnableProcessBlockStats = false
 	transactionPool := MakeTransactionPool(ledger, cfg)
 
 	assetTx := transactions.Transaction{
@@ -300,7 +300,7 @@ func TestCloseAccount(t *testing.T) {
 	ledger := makeMockLedger(t, initAcc(limitedAccounts))
 	cfg := config.GetDefaultLocal()
 	cfg.TxPoolSize = testPoolSize
-	cfg.EnableAssembleStats = false
+	cfg.EnableProcessBlockStats = false
 	transactionPool := MakeTransactionPool(ledger, cfg)
 
 	// sender goes below min
@@ -361,7 +361,7 @@ func TestCloseAccountWhileTxIsPending(t *testing.T) {
 	ledger := makeMockLedger(t, initAcc(limitedAccounts))
 	cfg := config.GetDefaultLocal()
 	cfg.TxPoolSize = testPoolSize
-	cfg.EnableAssembleStats = false
+	cfg.EnableProcessBlockStats = false
 	transactionPool := MakeTransactionPool(ledger, cfg)
 
 	// sender goes below min
@@ -423,7 +423,7 @@ func TestClosingAccountBelowMinBalance(t *testing.T) {
 	ledger := makeMockLedger(t, initAcc(limitedAccounts))
 	cfg := config.GetDefaultLocal()
 	cfg.TxPoolSize = testPoolSize
-	cfg.EnableAssembleStats = false
+	cfg.EnableProcessBlockStats = false
 	transactionPool := MakeTransactionPool(ledger, cfg)
 
 	// sender goes below min
@@ -465,7 +465,7 @@ func TestRecipientGoesBelowMinBalance(t *testing.T) {
 	ledger := makeMockLedger(t, initAcc(limitedAccounts))
 	cfg := config.GetDefaultLocal()
 	cfg.TxPoolSize = testPoolSize
-	cfg.EnableAssembleStats = false
+	cfg.EnableProcessBlockStats = false
 	transactionPool := MakeTransactionPool(ledger, cfg)
 
 	// sender goes below min
@@ -504,7 +504,7 @@ func TestRememberForget(t *testing.T) {
 	mockLedger := makeMockLedger(t, initAccFixed(addresses, 1<<32))
 	cfg := config.GetDefaultLocal()
 	cfg.TxPoolSize = testPoolSize
-	cfg.EnableAssembleStats = false
+	cfg.EnableProcessBlockStats = false
 	transactionPool := MakeTransactionPool(mockLedger, cfg)
 
 	eval := newBlockEvaluator(t, mockLedger)
@@ -569,7 +569,7 @@ func TestCleanUp(t *testing.T) {
 	mockLedger := makeMockLedger(t, initAccFixed(addresses, 1<<32))
 	cfg := config.GetDefaultLocal()
 	cfg.TxPoolSize = testPoolSize
-	cfg.EnableAssembleStats = false
+	cfg.EnableProcessBlockStats = false
 	transactionPool := MakeTransactionPool(mockLedger, cfg)
 
 	issuedTransactions := 0
@@ -646,7 +646,7 @@ func TestFixOverflowOnNewBlock(t *testing.T) {
 	mockLedger := makeMockLedger(t, initAccFixed(addresses, 1<<32))
 	cfg := config.GetDefaultLocal()
 	cfg.TxPoolSize = testPoolSize
-	cfg.EnableAssembleStats = false
+	cfg.EnableProcessBlockStats = false
 	transactionPool := MakeTransactionPool(mockLedger, cfg)
 
 	overSpender := addresses[0]
@@ -741,7 +741,7 @@ func TestOverspender(t *testing.T) {
 	ledger := makeMockLedger(t, initAcc(map[basics.Address]uint64{overSpender: proto.MinTxnFee - 1}))
 	cfg := config.GetDefaultLocal()
 	cfg.TxPoolSize = testPoolSize
-	cfg.EnableAssembleStats = false
+	cfg.EnableProcessBlockStats = false
 	transactionPool := MakeTransactionPool(ledger, cfg)
 
 	receiver := addresses[1]
@@ -801,7 +801,7 @@ func TestRemove(t *testing.T) {
 	ledger := makeMockLedger(t, initAccFixed(addresses, 1<<32))
 	cfg := config.GetDefaultLocal()
 	cfg.TxPoolSize = testPoolSize
-	cfg.EnableAssembleStats = false
+	cfg.EnableProcessBlockStats = false
 	transactionPool := MakeTransactionPool(ledger, cfg)
 
 	sender := addresses[0]
@@ -856,7 +856,7 @@ func TestLogicSigOK(t *testing.T) {
 	ledger := makeMockLedger(t, initAcc(limitedAccounts))
 	cfg := config.GetDefaultLocal()
 	cfg.TxPoolSize = testPoolSize
-	cfg.EnableAssembleStats = false
+	cfg.EnableProcessBlockStats = false
 	transactionPool := MakeTransactionPool(ledger, cfg)
 
 	// sender goes below min
@@ -900,7 +900,7 @@ func BenchmarkTransactionPoolRememberOne(b *testing.B) {
 	ledger := makeMockLedger(b, initAccFixed(addresses, 1<<32))
 	cfg := config.GetDefaultLocal()
 	cfg.TxPoolSize = b.N
-	cfg.EnableAssembleStats = false
+	cfg.EnableProcessBlockStats = false
 	transactionPool := MakeTransactionPool(ledger, cfg)
 	signedTransactions := make([]transactions.SignedTxn, 0, b.N)
 	for i, sender := range addresses {
@@ -961,7 +961,7 @@ func BenchmarkTransactionPoolPending(b *testing.B) {
 		ledger := makeMockLedger(b, initAccFixed(addresses, 1<<32))
 		cfg := config.GetDefaultLocal()
 		cfg.TxPoolSize = benchPoolSize
-		cfg.EnableAssembleStats = false
+		cfg.EnableProcessBlockStats = false
 		transactionPool := MakeTransactionPool(ledger, cfg)
 		var block bookkeeping.Block
 		block.Payset = make(transactions.Payset, 0)
@@ -1026,7 +1026,7 @@ func BenchmarkTransactionPoolSteadyState(b *testing.B) {
 	l := makeMockLedger(b, initAccFixed(addresses, 1<<32))
 	cfg := config.GetDefaultLocal()
 	cfg.TxPoolSize = poolSize
-	cfg.EnableAssembleStats = false
+	cfg.EnableProcessBlockStats = false
 	transactionPool := MakeTransactionPool(l, cfg)
 
 	var signedTransactions []transactions.SignedTxn

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -73,7 +73,7 @@ func BenchmarkTxHandlerProcessDecoded(b *testing.B) {
 
 	cfg := config.GetDefaultLocal()
 	cfg.TxPoolSize = 20000
-	cfg.EnableAssembleStats = false
+	cfg.EnableProcessBlockStats = false
 	tp := pools.MakeTransactionPool(l.Ledger, cfg)
 	signedTransactions := make([]transactions.SignedTxn, 0, b.N)
 	for i := 0; i < b.N/numUsers; i++ {

--- a/node/node.go
+++ b/node/node.go
@@ -220,7 +220,7 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 		return nil, err
 	}
 
-	blockFactory := makeBlockFactory(node.ledger, node.transactionPool, node.config.EnableProcessBlockStats, node.highPriorityCryptoVerificationPool)
+	blockFactory := makeBlockFactory(node.ledger, node.transactionPool, node.config.EnableAssembleStats, node.highPriorityCryptoVerificationPool)
 	blockValidator := blockValidatorImpl{l: node.ledger, tp: node.transactionPool, verificationPool: node.highPriorityCryptoVerificationPool}
 	agreementLedger := makeAgreementLedger(node.ledger, node.net)
 


### PR DESCRIPTION
The documented intended behavior for EnableAssembleStats is to
generate AssembleBlockMetrics, while for EnableProcessBlockStats it is
to generate ProcessBlockMetrics.  The current implementation reverses
these behaviors.
