### PR TITLE
Add optional pk argument to KMD's SignTransaction

### DIFF
--- a/daemon/kmd/api/v1/handlers.go
+++ b/daemon/kmd/api/v1/handlers.go
@@ -843,7 +843,7 @@ func postTransactionSignHandler(ctx reqContext, w http.ResponseWriter, r *http.R
 	}
 
 	// Sign the transaction
-	stx, err := wallet.SignTransaction(tx, []byte(req.WalletPassword))
+	stx, err := wallet.SignTransaction(tx, req.PublicKey, []byte(req.WalletPassword))
 	if err != nil {
 		errorResponse(w, http.StatusBadRequest, err)
 		return

--- a/daemon/kmd/client/wrappers.go
+++ b/daemon/kmd/client/wrappers.go
@@ -197,11 +197,12 @@ func (kcl KMDClient) ExportMasterDerivationKey(walletHandle []byte, walletPasswo
 }
 
 // SignTransaction wraps kmdapi.APIV1POSTTransactionSignRequest
-func (kcl KMDClient) SignTransaction(walletHandle, pw []byte, tx transactions.Transaction) (resp kmdapi.APIV1POSTTransactionSignResponse, err error) {
+func (kcl KMDClient) SignTransaction(walletHandle, pw []byte, pk crypto.PublicKey, tx transactions.Transaction) (resp kmdapi.APIV1POSTTransactionSignResponse, err error) {
 	txBytes := protocol.Encode(&tx)
 	req := kmdapi.APIV1POSTTransactionSignRequest{
 		WalletHandleToken: string(walletHandle),
 		WalletPassword:    string(pw),
+		PublicKey:         pk,
 		Transaction:       txBytes,
 	}
 	err = kcl.DoV1Request(req, &resp)

--- a/daemon/kmd/lib/kmdapi/requests.go
+++ b/daemon/kmd/lib/kmdapi/requests.go
@@ -163,6 +163,7 @@ type APIV1POSTTransactionSignRequest struct {
 	WalletHandleToken string `json:"wallet_handle_token"`
 	// swagger:strfmt byte
 	Transaction    []byte `json:"transaction"`
+	PublicKey      crypto.PublicKey `json:"public_key"`
 	WalletPassword string `json:"wallet_password"`
 }
 

--- a/daemon/kmd/lib/kmdapi/requests.go
+++ b/daemon/kmd/lib/kmdapi/requests.go
@@ -162,9 +162,9 @@ type APIV1POSTTransactionSignRequest struct {
 	APIV1RequestEnvelope
 	WalletHandleToken string `json:"wallet_handle_token"`
 	// swagger:strfmt byte
-	Transaction    []byte `json:"transaction"`
+	Transaction    []byte           `json:"transaction"`
 	PublicKey      crypto.PublicKey `json:"public_key"`
-	WalletPassword string `json:"wallet_password"`
+	WalletPassword string           `json:"wallet_password"`
 }
 
 // APIV1POSTProgramSignRequest is the request for `POST /v1/program/sign`

--- a/daemon/kmd/wallet/driver/ledger.go
+++ b/daemon/kmd/wallet/driver/ledger.go
@@ -317,11 +317,12 @@ func (lw *LedgerWallet) SignTransaction(tx transactions.Transaction, pk crypto.P
 	if len(pks) > 1 {
 		return nil, errors.New("LedgerWallet device only supports one key but ListKeys returned more than one")
 	}
-	if (pk != crypto.PublicKey{}) {
+	if len(pks) < 1 {
+		return nil, errKeyNotFound
+	}
+	if (pk != crypto.PublicKey{}) && pk != crypto.PublicKey(pks[0]) {
 		// A specific key was requested; return an error if it's not the one on the device.
-		if len(pks) < 1 || pks[0] != crypto.Digest(pk) {
-			return nil, errKeyNotFound
-		}
+		return nil, errKeyNotFound
 	}
 	pk = crypto.PublicKey(pks[0])
 

--- a/daemon/kmd/wallet/driver/sqlite.go
+++ b/daemon/kmd/wallet/driver/sqlite.go
@@ -1087,9 +1087,9 @@ func (sw *SQLiteWallet) ListMultisigAddrs() (addrs []crypto.Digest, err error) {
 	return
 }
 
-// SignTransaction signs the passed transaction, inferring the required private
-// key from the transaction itself
-func (sw *SQLiteWallet) SignTransaction(tx transactions.Transaction, pw []byte) (stx []byte, err error) {
+// SignTransaction signs the passed transaction with the private key whose public key is provided, or
+// if the provided public key is zero, inferring the required private key from the transaction itself
+func (sw *SQLiteWallet) SignTransaction(tx transactions.Transaction, pk crypto.PublicKey, pw []byte) (stx []byte, err error) {
 	// Check the password
 	err = sw.CheckPassword(pw)
 	if err != nil {
@@ -1097,7 +1097,12 @@ func (sw *SQLiteWallet) SignTransaction(tx transactions.Transaction, pw []byte) 
 	}
 
 	// Fetch the required key
-	sk, err := sw.fetchSecretKey(crypto.Digest(tx.Src()))
+	var sk crypto.PrivateKey
+	if (pk == crypto.PublicKey{}) {
+		sk, err = sw.fetchSecretKey(crypto.Digest(tx.Src()))
+	} else {
+		sk, err = sw.fetchSecretKey(crypto.Digest(pk))
+	}
 	if err != nil {
 		return
 	}

--- a/daemon/kmd/wallet/wallet.go
+++ b/daemon/kmd/wallet/wallet.go
@@ -51,7 +51,7 @@ type Wallet interface {
 	ListMultisigAddrs() (addrs []crypto.Digest, err error)
 	DeleteMultisigAddr(addr crypto.Digest, pw []byte) error
 
-	SignTransaction(tx transactions.Transaction, pw []byte) ([]byte, error)
+	SignTransaction(tx transactions.Transaction, pk crypto.PublicKey, pw []byte) ([]byte, error)
 
 	MultisigSignTransaction(tx transactions.Transaction, pk crypto.PublicKey, partial crypto.MultisigSig, pw []byte) (crypto.MultisigSig, error)
 

--- a/data/transactions/signedtxn.go
+++ b/data/transactions/signedtxn.go
@@ -20,8 +20,8 @@ import (
 	"errors"
 
 	"github.com/algorand/go-algorand/crypto"
-	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/protocol"
 )
 
 // SignedTxn wraps a transaction and a signature.
@@ -31,11 +31,11 @@ import (
 type SignedTxn struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	Sig  crypto.Signature   `codec:"sig"`
-	Msig crypto.MultisigSig `codec:"msig"`
-	Lsig LogicSig           `codec:"lsig"`
-	Txn  Transaction        `codec:"txn"`
-	AuthAddr basics.Address `codec:"sgnr"`
+	Sig      crypto.Signature   `codec:"sig"`
+	Msig     crypto.MultisigSig `codec:"msig"`
+	Lsig     LogicSig           `codec:"lsig"`
+	Txn      Transaction        `codec:"txn"`
+	AuthAddr basics.Address     `codec:"sgnr"`
 }
 
 // SignedTxnInBlock is how a signed transaction is encoded in a block.

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -167,6 +167,10 @@ func (tx Transaction) Sign(secrets *crypto.SignatureSecrets) SignedTxn {
 		Txn: tx,
 		Sig: sig,
 	}
+	// Set the AuthAddr if the signing key doesn't match the transaction sender
+	if basics.Address(secrets.SignatureVerifier) != tx.Sender {
+		s.AuthAddr = basics.Address(secrets.SignatureVerifier)
+	}
 	return s
 }
 

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -412,11 +412,14 @@ func (tx Transaction) GetReceiverAddress() basics.Address {
 
 // EstimateEncodedSize returns the estimated encoded size of the transaction including the signature.
 // This function is to be used for calculating the fee
+// Note that it may be an underestimate if the transaction is signed in an unusual way
+// (e.g., with an authaddr or via multisig or logicsig)
 func (tx Transaction) EstimateEncodedSize() int {
-	var seed crypto.Seed
-	crypto.RandBytes(seed[:])
-	keys := crypto.GenerateSignatureSecrets(seed)
-	stx := tx.Sign(keys)
+	// Make a signedtxn with a nonzero signature and encode it
+	stx := SignedTxn{
+		Txn: tx,
+		Sig: crypto.Signature{1},
+	}
 	return stx.GetEncodedLength()
 }
 

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -18,9 +18,9 @@ package ledger
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
-	"runtime"
 
 	"github.com/stretchr/testify/require"
 

--- a/ledger/eval_test.go
+++ b/ledger/eval_test.go
@@ -30,8 +30,8 @@ import (
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/logging"
-	"github.com/algorand/go-algorand/util/execpool"
 	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/util/execpool"
 )
 
 var testPoolAddr = basics.Address{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
@@ -123,7 +123,7 @@ func TestRekeying(t *testing.T) {
 	pretend := actual
 	pretend.SupportRekeying = true
 	config.Consensus[protocol.ConsensusCurrentVersion] = pretend
-	defer func(){
+	defer func() {
 		config.Consensus[protocol.ConsensusCurrentVersion] = actual
 	}()
 
@@ -146,13 +146,13 @@ func TestRekeying(t *testing.T) {
 		txn := transactions.Transaction{
 			Type: protocol.PaymentTx,
 			Header: transactions.Header{
-				Sender: sender,
-				Fee:    minFee,
-				FirstValid: nextRound,
-				LastValid: nextRound,
+				Sender:      sender,
+				Fee:         minFee,
+				FirstValid:  nextRound,
+				LastValid:   nextRound,
 				GenesisHash: genHash,
-				RekeyTo: rekeyto,
-				Note: []byte{uniq},
+				RekeyTo:     rekeyto,
+				Note:        []byte{uniq},
 			},
 			PaymentTxnFields: transactions.PaymentTxnFields{
 				Receiver: sender,
@@ -192,7 +192,7 @@ func TestRekeying(t *testing.T) {
 	// [A -> 0][0,A] (normal transaction)
 	// [A -> B][0,A] (rekey)
 	txn0 := makeTxn(addrs[0], basics.Address{}, basics.Address{}, keys[0], 0) // Normal transaction
-	txn1 := makeTxn(addrs[0], addrs[1], basics.Address{}, keys[0], 1) // Rekey transaction
+	txn1 := makeTxn(addrs[0], addrs[1], basics.Address{}, keys[0], 1)         // Rekey transaction
 
 	// Test 1: Do only good things
 	// (preamble)
@@ -201,8 +201,8 @@ func TestRekeying(t *testing.T) {
 	// [A -> 0][0,A] (normal transaction again)
 	test1txns := []transactions.SignedTxn{
 		txn0, txn1, // (preamble)
-		makeTxn(addrs[0], basics.Address{}, addrs[1], keys[1], 2), // [A -> 0][B,B]
-		makeTxn(addrs[0], addrs[0], addrs[1], keys[1], 3), // [A -> A][B,B]
+		makeTxn(addrs[0], basics.Address{}, addrs[1], keys[1], 2),         // [A -> 0][B,B]
+		makeTxn(addrs[0], addrs[0], addrs[1], keys[1], 3),                 // [A -> A][B,B]
 		makeTxn(addrs[0], basics.Address{}, basics.Address{}, keys[0], 4), // [A -> 0][0,A]
 	}
 	err = tryBlock(test1txns)

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -460,7 +460,8 @@ func (c *Client) signAndBroadcastTransactionWithWallet(walletHandle, pw []byte, 
 	if err != nil {
 		return transactions.Transaction{}, err
 	}
-	resp0, err := kmd.SignTransaction(walletHandle, pw, tx)
+	// TODO(rekeying) probably libgoal should allow passing in different public key to sign with
+	resp0, err := kmd.SignTransaction(walletHandle, pw, crypto.PublicKey{}, tx)
 	if err != nil {
 		return transactions.Transaction{}, err
 	}

--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -36,7 +36,8 @@ func (c *Client) SignTransactionWithWallet(walletHandle, pw []byte, utx transact
 	}
 
 	// Sign the transaction
-	resp, err := kmd.SignTransaction(walletHandle, pw, utx)
+	// TODO(rekeying): Probably libgoal should allow passing in authaddr
+	resp, err := kmd.SignTransaction(walletHandle, pw, crypto.PublicKey{}, utx)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Give KMD's SignTransaction an (optional) public key argument.
If provided, KMD signs the transaction using the corresponding private key and sets the AuthAddr if necessary.
goal / libgoal will use this KMD functionality in order to sign transactions from rekeyed accounts (which will come in a separate PR)