### PR TITLE
Encode `SignedTxnInBlock` to measure length, not `SignedTxn`

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -31,6 +31,7 @@ import (
 	"github.com/algorand/go-algorand/ledger"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/logging/telemetryspec"
+	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/util/condvar"
 )
 
@@ -652,7 +653,7 @@ func (pool *TransactionPool) AssembleBlock(round basics.Round, deadline time.Tim
 
 			for i, txib := range payset {
 				fee := txib.Txn.Fee.Raw
-				encodedLen := txib.GetEncodedLength()
+				encodedLen := len(protocol.Encode(&txib))
 
 				stats.IncludedCount++
 				totalFees += fee


### PR DESCRIPTION
`GetEncodedLength` is defined on `SignedTxn`, not `SignedTxnInBlock` (which embeds `SignedTxnWithAD` which embeds `SignedTxn`). So attempting to call it on a `SignedTxnInBlock` will produce an unexpected result since the encoding will omit e.g. `ApplyData`.

This PR matches is closer to how length is [actually computed in the block evaluator](https://github.com/algorand/go-algorand/blob/82e804e4c374876e3c8a2f45d2ce49cdbf82dc26/ledger/eval.go#L485).