### PR TITLE
Make algorelay handle domain names type conversions

### DIFF
--- a/tools/network/cloudflare/cloudflare.go
+++ b/tools/network/cloudflare/cloudflare.go
@@ -132,7 +132,7 @@ func (d *DNS) ListDNSRecord(ctx context.Context, recordType string, name string,
 
 		parsedReponse, err := parseListDNSRecordResponse(response)
 		if err != nil {
-			return []DNSRecordResponseEntry{}, err
+			return []DNSRecordResponseEntry{}, fmt.Errorf("failed to list DNS records. Request url = '%v', response error : %v", request.URL, err)
 		}
 		if len(parsedReponse.Errors) > 0 {
 			return []DNSRecordResponseEntry{}, fmt.Errorf("Failed to list DNS entries. %+v", parsedReponse.Errors)
@@ -163,12 +163,12 @@ func (d *DNS) CreateDNSRecord(ctx context.Context, recordType string, name strin
 	client := &http.Client{}
 	response, err := client.Do(request.WithContext(ctx))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create DNS record. Request url = '%v', response : %v", request.URL, err)
 	}
 
 	parsedResponse, err := parseCreateDNSRecordResponse(response)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create DNS record. Request url = '%v', response error : %v", request.URL, err)
 	}
 	if parsedResponse.Success == false {
 		request, _ := createDNSRecordRequest(d.zoneID, d.authEmail, d.authKey, recordType, name, content, ttl, priority, proxied)
@@ -188,12 +188,12 @@ func (d *DNS) CreateSRVRecord(ctx context.Context, name string, target string, t
 	client := &http.Client{}
 	response, err := client.Do(request.WithContext(ctx))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create SRV record. Request url = '%v', response : %v", request.URL, err)
 	}
 
 	parsedResponse, err := parseCreateDNSRecordResponse(response)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create SRV record. Request url = '%v', response error : %v", request.URL, err)
 	}
 	if parsedResponse.Success == false {
 		request, _ := createSRVRecordRequest(d.zoneID, d.authEmail, d.authKey, name, service, protocol, weight, port, ttl, priority, target)
@@ -218,7 +218,7 @@ func (d *DNS) DeleteDNSRecord(ctx context.Context, recordID string) error {
 
 	parsedResponse, err := parseDeleteDNSRecordResponse(response)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to delete DNS record. Request url = '%v', response error : %v", request.URL, err)
 	}
 	if parsedResponse.Success == false {
 		request, _ := deleteDNSRecordRequest(d.zoneID, d.authEmail, d.authKey, recordID)
@@ -243,7 +243,7 @@ func (d *DNS) UpdateDNSRecord(ctx context.Context, recordID string, recordType s
 
 	parsedResponse, err := parseUpdateDNSRecordResponse(response)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to update DNS record. Request url = '%v', response error : %v", request.URL, err)
 	}
 
 	if parsedResponse.Success == false {
@@ -270,7 +270,7 @@ func (d *DNS) UpdateSRVRecord(ctx context.Context, recordID string, name string,
 
 	parsedResponse, err := parseUpdateDNSRecordResponse(response)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to update SRV record. Request url = '%v', response error : %v", request.URL, err)
 	}
 	if parsedResponse.Success == false {
 		request, _ := updateSRVRecordRequest(d.zoneID, d.authEmail, d.authKey, recordID, name, service, protocol, weight, port, ttl, priority, target)
@@ -301,7 +301,7 @@ func (c *Cred) GetZones(ctx context.Context) (zones []Zone, err error) {
 
 	parsedResponse, err := parseGetZonesResponse(response)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get zones. Request url = '%v', response error : %v", request.URL, err)
 	}
 	if parsedResponse.Success == false {
 		request, _ := getZonesRequest(c.authEmail, c.authKey)

--- a/tools/network/cloudflare/cloudflare.go
+++ b/tools/network/cloudflare/cloudflare.go
@@ -69,7 +69,7 @@ func NewDNS(zoneID string, authEmail string, authKey string) *DNS {
 
 // SetDNSRecord sets the DNS record to the given content.
 func (d *DNS) SetDNSRecord(ctx context.Context, recordType string, name string, content string, ttl uint, priority uint, proxied bool) error {
-	entries, err := d.ListDNSRecord(ctx, recordType, name, content, "", "", "")
+	entries, err := d.ListDNSRecord(ctx, "", name, "", "", "", "")
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func (d *DNS) DeleteDNSRecord(ctx context.Context, recordID string) error {
 
 // UpdateDNSRecord update the DNS record with the given content.
 func (d *DNS) UpdateDNSRecord(ctx context.Context, recordID string, recordType string, name string, content string, ttl uint, priority uint, proxied bool) error {
-	request, err := updateDNSRecordRequest(d.zoneID, d.authEmail, d.authKey, recordType, recordID, name, content, ttl, priority, proxied)
+	request, err := updateDNSRecordRequest(d.zoneID, d.authEmail, d.authKey, recordID, recordType, name, content, ttl, priority, proxied)
 	if err != nil {
 		return err
 	}
@@ -247,7 +247,7 @@ func (d *DNS) UpdateDNSRecord(ctx context.Context, recordID string, recordType s
 	}
 
 	if parsedResponse.Success == false {
-		request, _ := updateDNSRecordRequest(d.zoneID, d.authEmail, d.authKey, recordType, recordID, name, content, ttl, priority, proxied)
+		request, _ := updateDNSRecordRequest(d.zoneID, d.authEmail, d.authKey, recordID, recordType, name, content, ttl, priority, proxied)
 		requestBody, _ := request.GetBody()
 		bodyBytes, _ := ioutil.ReadAll(requestBody)
 		return fmt.Errorf("failed to update DNS record. Request url = '%v', body = %s, parsedResponse = %#v, response headers = %#v", request.URL, string(bodyBytes), parsedResponse, response.Header)

--- a/tools/network/cloudflare/createRecord.go
+++ b/tools/network/cloudflare/createRecord.go
@@ -149,7 +149,7 @@ func parseCreateDNSRecordResponse(response *http.Response) (*CreateDNSRecordResp
 		return nil, err
 	}
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Response status code %d", response.StatusCode)
+		return nil, fmt.Errorf("Response status code %d; body = %s", response.StatusCode, string(body))
 	}
 	var parsedReponse CreateDNSRecordResponse
 	if err := json.Unmarshal(body, &parsedReponse); err != nil {

--- a/tools/network/cloudflare/createRecord.go
+++ b/tools/network/cloudflare/createRecord.go
@@ -148,9 +148,12 @@ func parseCreateDNSRecordResponse(response *http.Response) (*CreateDNSRecordResp
 	if err != nil {
 		return nil, err
 	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Response status code %d", response.StatusCode)
+	}
 	var parsedReponse CreateDNSRecordResponse
 	if err := json.Unmarshal(body, &parsedReponse); err != nil {
-		return nil, fmt.Errorf("failed to Unmarshal response body '%s' : %v", string(body), err)
+		return nil, fmt.Errorf("failed to unmarshal response body '%s' : %v", string(body), err)
 	}
 	return &parsedReponse, nil
 }

--- a/tools/network/cloudflare/createRecord.go
+++ b/tools/network/cloudflare/createRecord.go
@@ -150,7 +150,7 @@ func parseCreateDNSRecordResponse(response *http.Response) (*CreateDNSRecordResp
 	}
 	var parsedReponse CreateDNSRecordResponse
 	if err := json.Unmarshal(body, &parsedReponse); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to Unmarshal response body '%s' : %v", string(body), err)
 	}
 	return &parsedReponse, nil
 }

--- a/tools/network/cloudflare/deleteRecord.go
+++ b/tools/network/cloudflare/deleteRecord.go
@@ -61,7 +61,7 @@ func parseDeleteDNSRecordResponse(response *http.Response) (*DeleteDNSRecordResp
 	}
 	var parsedResponse DeleteDNSRecordResponse
 	if err := json.Unmarshal(body, &parsedResponse); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal response body '%s' : %v", string(body), err)
 	}
 	return &parsedResponse, nil
 }

--- a/tools/network/cloudflare/listRecords.go
+++ b/tools/network/cloudflare/listRecords.go
@@ -127,7 +127,7 @@ func parseListDNSRecordResponse(response *http.Response) (*ListDNSRecordResponse
 	}
 	var parsedResponse ListDNSRecordResponse
 	if err := json.Unmarshal(body, &parsedResponse); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal response body '%s' : %v", string(body), err)
 	}
 	return &parsedResponse, nil
 }

--- a/tools/network/cloudflare/listRecords.go
+++ b/tools/network/cloudflare/listRecords.go
@@ -27,9 +27,6 @@ import (
 // listDNSRecordRequest creates a new http request for listing of DNS records.
 func listDNSRecordRequest(zoneID string, authEmail string, authKey string, recordType string, name string, content string, page uint, perPage uint, order string, direction string, match string) (*http.Request, error) {
 	// verify and validate input parameters.
-	if recordType == "" {
-		recordType = "A"
-	}
 	if page == 0 {
 		page = 1
 	}
@@ -48,7 +45,9 @@ func listDNSRecordRequest(zoneID string, authEmail string, authKey string, recor
 
 	// build all the arguments
 	uriValues := make(url.Values)
-	uriValues.Add("type", recordType)
+	if len(recordType) > 0 {
+		uriValues.Add("type", recordType)
+	}
 	if len(name) > 0 {
 		uriValues.Add("name", name)
 	}

--- a/tools/network/cloudflare/zones.go
+++ b/tools/network/cloudflare/zones.go
@@ -18,6 +18,7 @@ package cloudflare
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -76,7 +77,7 @@ func parseGetZonesResponse(response *http.Response) (*GetZonesResult, error) {
 	}
 	var parsedReponse GetZonesResult
 	if err := json.Unmarshal(body, &parsedReponse); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal response body '%s' : %v", string(body), err)
 	}
 	return &parsedReponse, nil
 }

--- a/tools/network/cloudflare/zones.go
+++ b/tools/network/cloudflare/zones.go
@@ -75,6 +75,9 @@ func parseGetZonesResponse(response *http.Response) (*GetZonesResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Response status code %d", response.StatusCode)
+	}
 	var parsedReponse GetZonesResult
 	if err := json.Unmarshal(body, &parsedReponse); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response body '%s' : %v", string(body), err)


### PR DESCRIPTION
## Summary

Algorelay needs to have the ability to convert a previously created A DNS record into a CNAME DNS record and vice versa.
This PR adds that ability as well as improve the error logging in case of an issue.