### PR TITLE
Rekeying: basic frontend

### DIFF
--- a/cmd/algokey/sign.go
+++ b/cmd/algokey/sign.go
@@ -34,7 +34,6 @@ var signKeyfile string
 var signTxfile string
 var signOutfile string
 var signMnemonic string
-var rekeyed bool
 
 func init() {
 	signCmd.Flags().StringVarP(&signKeyfile, "keyfile", "k", "", "Private key filename")
@@ -43,7 +42,6 @@ func init() {
 	signCmd.MarkFlagRequired("txfile")
 	signCmd.Flags().StringVarP(&signOutfile, "outfile", "o", "", "Transaction output filename")
 	signCmd.MarkFlagRequired("outfile")
-	signCmd.Flags().BoolVarP(&rekeyed, "rekeyed", "r", false, "Required if the sending account has been rekeyed and the signing key doesn't match the account address")
 }
 
 var signCmd = &cobra.Command{
@@ -74,7 +72,7 @@ var signCmd = &cobra.Command{
 			}
 
 			stxn.Sig = key.Sign(stxn.Txn)
-			if rekeyed {
+			if stxn.Txn.Sender != basics.Address(key.SignatureVerifier) {
 				stxn.AuthAddr = basics.Address(key.SignatureVerifier)
 			}
 			outBytes = append(outBytes, protocol.Encode(&stxn)...)

--- a/cmd/algokey/sign.go
+++ b/cmd/algokey/sign.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/protocol"
 )
@@ -33,6 +34,7 @@ var signKeyfile string
 var signTxfile string
 var signOutfile string
 var signMnemonic string
+var rekeyed bool
 
 func init() {
 	signCmd.Flags().StringVarP(&signKeyfile, "keyfile", "k", "", "Private key filename")
@@ -41,6 +43,7 @@ func init() {
 	signCmd.MarkFlagRequired("txfile")
 	signCmd.Flags().StringVarP(&signOutfile, "outfile", "o", "", "Transaction output filename")
 	signCmd.MarkFlagRequired("outfile")
+	signCmd.Flags().BoolVarP(&rekeyed, "rekeyed", "r", false, "Required if the sending account has been rekeyed and the signing key doesn't match the account address")
 }
 
 var signCmd = &cobra.Command{
@@ -71,6 +74,9 @@ var signCmd = &cobra.Command{
 			}
 
 			stxn.Sig = key.Sign(stxn.Txn)
+			if rekeyed {
+				stxn.AuthAddr = basics.Address(key.SignatureVerifier)
+			}
 			outBytes = append(outBytes, protocol.Encode(&stxn)...)
 		}
 

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -63,6 +63,7 @@ var (
 	timeStamp       int64
 	protoVersion    string
 	rekeyToAddress  string
+	signerAddress   string
 )
 
 func init() {
@@ -110,6 +111,7 @@ func init() {
 
 	signCmd.Flags().StringVarP(&txFilename, "infile", "i", "", "Partially-signed transaction file to add signature to")
 	signCmd.Flags().StringVarP(&outFilename, "outfile", "o", "", "Filename for writing the signed transaction")
+	signCmd.Flags().StringVarP(&signerAddress, "signer", "S", "", "Address of key to sign with, if different from transaction \"from\" address due to rekeying")
 	signCmd.Flags().StringVarP(&programSource, "program", "p", "", "Program source to use as account logic")
 	signCmd.Flags().StringVarP(&logicSigFile, "logic-sig", "L", "", "LogicSig to apply to transaction")
 	signCmd.Flags().StringSliceVar(&argB64Strings, "argb64", nil, "base64 encoded args to pass to transaction logic")
@@ -680,7 +682,7 @@ var signCmd = &cobra.Command{
 				signedTxn = uncheckedTxn
 			} else {
 				// sign the usual way
-				signedTxn, err = client.SignTransactionWithWallet(wh, pw, uncheckedTxn.Txn)
+				signedTxn, err = client.SignTransactionWithWalletAndSigner(wh, pw, signerAddress, uncheckedTxn.Txn)
 				if err != nil {
 					reportErrorf(errorSigningTX, err)
 				}

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -62,6 +62,7 @@ var (
 	logicSigFile    string
 	timeStamp       int64
 	protoVersion    string
+	rekeyToAddress  string
 )
 
 func init() {
@@ -91,6 +92,7 @@ func init() {
 	sendCmd.Flags().StringVarP(&txFilename, "out", "o", "", "Dump an unsigned tx to the given file. In order to dump a signed transaction, pass -s")
 	sendCmd.Flags().BoolVarP(&sign, "sign", "s", false, "Use with -o to indicate that the dumped transaction should be signed")
 	sendCmd.Flags().StringVarP(&closeToAddress, "close-to", "c", "", "Close account and send remainder to this address")
+	sendCmd.Flags().StringVar(&rekeyToAddress, "rekey-to", "", "Rekey account to the given spending key/address. (Future transactions from this account will need to be signed with the new key.)")
 	sendCmd.Flags().BoolVarP(&noWaitAfterSend, "no-wait", "N", false, "Don't wait for transaction to commit")
 	sendCmd.Flags().StringVarP(&programSource, "from-program", "F", "", "Program source to use as account logic")
 	sendCmd.Flags().StringVarP(&progByteFile, "from-program-bytes", "P", "", "Program binary to use as account logic")
@@ -326,6 +328,17 @@ var sendCmd = &cobra.Command{
 			closeToAddressResolved = accountList.getAddressByName(closeToAddress)
 		}
 
+		// If rekeying, parse that address
+		// (we don't use accountList.getAddressByName because this address likely doesn't correspond to an account)
+		var rekeyTo basics.Address
+		if rekeyToAddress != "" {
+			var err error
+			rekeyTo, err = basics.UnmarshalChecksumAddress(rekeyToAddress)
+			if err != nil {
+				reportErrorf(err.Error())
+			}
+		}
+
 		client := ensureFullClient(dataDir)
 		firstValid, lastValid, err = client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
@@ -338,6 +351,10 @@ var sendCmd = &cobra.Command{
 		if err != nil {
 			reportErrorf(errorConstructingTX, err)
 		}
+		if (rekeyTo != basics.Address{}) {
+			payment.RekeyTo = rekeyTo
+		}
+
 		var stx transactions.SignedTxn
 		if lsig.Logic != nil {
 			params, err := client.SuggestedParams()

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -353,7 +353,7 @@ var sendCmd = &cobra.Command{
 		if err != nil {
 			reportErrorf(errorConstructingTX, err)
 		}
-		if (rekeyTo != basics.Address{}) {
+		if !rekeyTo.IsZero() {
 			payment.RekeyTo = rekeyTo
 		}
 

--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -36,8 +36,34 @@ func (c *Client) SignTransactionWithWallet(walletHandle, pw []byte, utx transact
 	}
 
 	// Sign the transaction
-	// TODO(rekeying): Probably libgoal should allow passing in authaddr
 	resp, err := kmd.SignTransaction(walletHandle, pw, crypto.PublicKey{}, utx)
+	if err != nil {
+		return
+	}
+
+	// Decode the SignedTxn
+	err = protocol.Decode(resp.SignedTransaction, &stx)
+	return
+}
+
+// SignTransactionWithWalletAndSigner signs the passed transaction under a specific signer (which may differ from the sender's address). This is necessary after an account has been rekeyed.
+// If signerAddr is the empty string, just infer spending key from the sender address.
+func (c *Client) SignTransactionWithWalletAndSigner(walletHandle, pw []byte, signerAddr string, utx transactions.Transaction) (stx transactions.SignedTxn, err error) {
+	if signerAddr == "" {
+		return c.SignTransactionWithWallet(walletHandle, pw, utx)
+	}
+
+	kmd, err := c.ensureKmdClient()
+	if err != nil {
+		return
+	}
+
+	authaddr, err := basics.UnmarshalChecksumAddress(signerAddr)
+	if err != nil {
+		return
+	}
+	// Sign the transaction
+	resp, err := kmd.SignTransaction(walletHandle, pw, crypto.PublicKey(authaddr), utx)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Add very basic rekeying support to goal, algokey, and libgoal.

`algokey` now sets the authaddr if necessary, inferring the address from the private key used for signing and checking whether it matches the transaction sender.

`libgoal` gets a new method `kmdClient.SignTransactionWithWalletAndSigner` that's like `SignTransactionWithWallet` but takes in an extra argument, the signer address. (If the signer address is the empty string, the behavior is the same as `SignTransactionWithWallet`.)

`goal clerk spend` gets a flag to set the rekey-to address. (It should be easy to add this flag to other goal commands that create transactions.) `goal clerk sign` gets a flag to specify the signer address; it uses the new libgoal method.