### PR TITLE
Skip V22 consensus upgrade

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -553,8 +553,6 @@ func initConsensusProtocols() {
 	v22.MinUpgradeWaitRounds = 10000
 	v22.MaxUpgradeWaitRounds = 150000
 	Consensus[protocol.ConsensusV22] = v22
-	// v21 can be upgraded to v22.
-	v21.ApprovedUpgrades[protocol.ConsensusV22] = 0
 
 	// v23 is an upgrade which fixes the behavior of leases so that
 	// it conforms with the intended spec.
@@ -564,6 +562,8 @@ func initConsensusProtocols() {
 	Consensus[protocol.ConsensusV23] = v23
 	// v22 can be upgraded to v23.
 	v22.ApprovedUpgrades[protocol.ConsensusV23] = 10000
+	// v21 can be upgraded to v23.
+	v21.ApprovedUpgrades[protocol.ConsensusV23] = 0
 
 	// ConsensusFuture is used to test features that are implemented
 	// but not yet released in a production protocol version.


### PR DESCRIPTION
To prevent a dual upgrade round, we need to jump directly from V21 to
V23.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Explain the goal of this change and what problem it is solving.

## Test Plan

How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale.

