### PR TITLE
Skip V22 consensus upgrade

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -556,8 +556,6 @@ func initConsensusProtocols() {
 	v22.MinUpgradeWaitRounds = 10000
 	v22.MaxUpgradeWaitRounds = 150000
 	Consensus[protocol.ConsensusV22] = v22
-	// v21 can be upgraded to v22.
-	v21.ApprovedUpgrades[protocol.ConsensusV22] = 0
 
 	// v23 is an upgrade which fixes the behavior of leases so that
 	// it conforms with the intended spec.
@@ -567,6 +565,8 @@ func initConsensusProtocols() {
 	Consensus[protocol.ConsensusV23] = v23
 	// v22 can be upgraded to v23.
 	v22.ApprovedUpgrades[protocol.ConsensusV23] = 10000
+	// v21 can be upgraded to v23.
+	v21.ApprovedUpgrades[protocol.ConsensusV23] = 0
 
 	// ConsensusFuture is used to test features that are implemented
 	// but not yet released in a production protocol version.


### PR DESCRIPTION
To prevent a dual upgrade round, we need to jump directly from V21 to
V23. This was tested in a custom algonet and is merged to rel/stable for the 2.0.6 release.
