### PR TITLE
Ignore lib-sodium copies and binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,7 +166,7 @@ addons:
   artifacts:
     s3_region: "us-east-1"
     paths:
-      - $(git ls-files -o | grep -v crypto/libsodium-fork | grep -v crypto/lib/ | grep -v ^gen/ | grep -v swagger.json.validated | tr "\n" ":")
+      - $(git ls-files -o | grep -v crypto/libs | grep -v crypto/copies | grep -v crypto/libsodium-fork | grep -v crypto/lib/ | grep -v ^gen/ | grep -v swagger.json.validated | tr "\n" ":")
 
 notifications:
   slack:


### PR DESCRIPTION
## Summary

We were ignoring them before, but now that the folders have changed our artifact upload process is failing. This will ignore the new folders as well.

## Test Plan

I ran the git command to verify that these files are no longer included

