### PR TITLE
Fix e2e test missing runtime package.

### DIFF
--- a/test/e2e-go/upgrades/send_receive_upgrade_test.go
+++ b/test/e2e-go/upgrades/send_receive_upgrade_test.go
@@ -80,16 +80,10 @@ func TestAccountsCanSendMoneyAcrossUpgradeV15toV16(t *testing.T) {
 }
 
 func TestAccountsCanSendMoneyAcrossUpgradeV21toV22(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip()
-	}
 	testAccountsCanSendMoneyAcrossUpgrade(t, filepath.Join("nettemplates", "TwoNodes50EachV21Upgrade.json"))
 }
 
 func TestAccountsCanSendMoneyAcrossUpgradeV22toV23(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip()
-	}
 	testAccountsCanSendMoneyAcrossUpgrade(t, filepath.Join("nettemplates", "TwoNodes50EachV22Upgrade.json"))
 }
 


### PR DESCRIPTION
## Summary

e2e test was failing due to missing package dependency.
Issue triggered due to auto-merge during the GitHub merge process.