### PR TITLE
agreement: fix simulator random data race

### DIFF
--- a/agreement/demux.go
+++ b/agreement/demux.go
@@ -74,15 +74,14 @@ func makeDemux(net Network, ledger LedgerReader, validator BlockValidator, voteV
 	d.crypto = makeCryptoVerifier(ledger, validator, voteVerifier, log)
 	d.log = log
 	d.ledger = ledger
+	d.queue = make([]<-chan externalEvent, 0)
+	d.processingMonitor = processingMonitor
 
 	tokenizerCtx, cancelTokenizers := context.WithCancel(context.Background())
 	d.rawVotes = d.tokenizeMessages(tokenizerCtx, net, protocol.AgreementVoteTag, decodeVote)
 	d.rawProposals = d.tokenizeMessages(tokenizerCtx, net, protocol.ProposalPayloadTag, decodeProposal)
 	d.rawBundles = d.tokenizeMessages(tokenizerCtx, net, protocol.VoteBundleTag, decodeBundle)
 	d.cancelTokenizers = cancelTokenizers
-
-	d.queue = make([]<-chan externalEvent, 0)
-	d.processingMonitor = processingMonitor
 
 	return d
 }


### PR DESCRIPTION
## Summary

The agreement simulator unit test fails randomly ( and rarely ), with a data race related to the `processingMonitor`. The data race is caused due to incoming message arriving before the demux initialization is complete.

specifically, the tokenizeMessages is calling UpdateEventsQueue which tests the value of processingMonitor while the makeDemux attempts to set it.
Setting the `processingMonitor` before calling tokenizeMessages completely resolves this issue.
