### PR TITLE
Modify libgoal to use v2 status instead of v1 status

### DIFF
--- a/cmd/algoh/client.go
+++ b/cmd/algoh/client.go
@@ -19,12 +19,13 @@ package main
 import (
 	"context"
 
+	generatedV2 "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
 	"github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
 )
 
 // Client is a minimal interface for the RestClient
 type Client interface {
-	Status() (v1.NodeStatus, error)
+	Status() (generatedV2.NodeStatusResponse, error)
 	Block(round uint64) (v1.Block, error)
 	GetGoRoutines(ctx context.Context) (string, error)
 }

--- a/cmd/algoh/mockClient.go
+++ b/cmd/algoh/mockClient.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	generatedV2 "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
 	"github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
 )
 
@@ -27,10 +28,10 @@ import (
 // Helpers to initialize mockClient //
 //////////////////////////////////////
 
-func makeNodeStatuses(blocks ...uint64) (ret []v1.NodeStatus) {
-	ret = make([]v1.NodeStatus, 0, len(blocks))
+func makeNodeStatuses(blocks ...uint64) (ret []generatedV2.NodeStatusResponse) {
+	ret = make([]generatedV2.NodeStatusResponse, 0, len(blocks))
 	for _, block := range blocks {
-		ret = append(ret, v1.NodeStatus{LastRound: block})
+		ret = append(ret, generatedV2.NodeStatusResponse{LastRound: block})
 	}
 	return ret
 }
@@ -50,12 +51,12 @@ type mockClient struct {
 	BlockCalls         map[uint64]int
 	GetGoRoutinesCalls int
 	error              []error
-	status             []v1.NodeStatus
+	status             []generatedV2.NodeStatusResponse
 	routine            []string
 	block              map[uint64]v1.Block
 }
 
-func makeMockClient(error []error, status []v1.NodeStatus, block map[uint64]v1.Block, routine []string) mockClient {
+func makeMockClient(error []error, status []generatedV2.NodeStatusResponse, block map[uint64]v1.Block, routine []string) mockClient {
 	return mockClient{
 		BlockCalls: make(map[uint64]int),
 		error:      error,
@@ -77,7 +78,7 @@ func (c *mockClient) nextError() (e error) {
 	return
 }
 
-func (c *mockClient) Status() (s v1.NodeStatus, e error) {
+func (c *mockClient) Status() (s generatedV2.NodeStatusResponse, e error) {
 	c.StatusCalls++
 	s = c.status[0]
 	// Repeat last status...

--- a/cmd/goal/commands.go
+++ b/cmd/goal/commands.go
@@ -30,6 +30,9 @@ import (
 	"github.com/spf13/cobra/doc"
 	"golang.org/x/crypto/ssh/terminal"
 
+	algodclient "github.com/algorand/go-algorand/daemon/algod/api/client"
+	kmdclient "github.com/algorand/go-algorand/daemon/kmd/client"
+
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/daemon/algod/api/spec/common"
 	"github.com/algorand/go-algorand/data/bookkeeping"
@@ -364,6 +367,7 @@ func ensureGoalClient(dataDir string, clientType libgoal.ClientType) libgoal.Cli
 	if err != nil {
 		reportErrorf(errorNodeStatus, err)
 	}
+	client.SetAPIVersionAffinity(algodclient.APIVersionV2, kmdclient.APIVersionV1)
 	return client
 }
 

--- a/cmd/goal/node.go
+++ b/cmd/goal/node.go
@@ -28,8 +28,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	generatedV2 "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
+
 	"github.com/algorand/go-algorand/config"
-	"github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
 	"github.com/algorand/go-algorand/libgoal"
 	"github.com/algorand/go-algorand/nodecontrol"
 	"github.com/algorand/go-algorand/util"
@@ -319,7 +320,7 @@ func getStatus(dataDir string) {
 	fmt.Printf("Genesis hash: %s\n", base64.StdEncoding.EncodeToString(vers.GenesisHash[:]))
 }
 
-func makeStatusString(stat v1.NodeStatus) string {
+func makeStatusString(stat generatedV2.NodeStatusResponse) string {
 	lastRoundTime := fmt.Sprintf("%.1fs", time.Duration(stat.TimeSinceLastRound).Seconds())
 	catchupTime := fmt.Sprintf("%.1fs", time.Duration(stat.CatchupTime).Seconds())
 	statusString := fmt.Sprintf(

--- a/daemon/algod/api/algod.oas2.json
+++ b/daemon/algod/api/algod.oas2.json
@@ -358,7 +358,7 @@
         }
       }
     },
-    "/v2/status/wait-for-block-after/{round}/": {
+    "/v2/status/wait-for-block-after/{round}": {
       "get": {
         "description": "Waits for a block to appear after round {round} and returns the node's status at the time.",
         "produces": [

--- a/daemon/algod/api/algod.oas3.yml
+++ b/daemon/algod/api/algod.oas3.yml
@@ -1361,7 +1361,7 @@
             "summary" : "Gets the current node status."
          }
       },
-      "/v2/status/wait-for-block-after/{round}/" : {
+      "/v2/status/wait-for-block-after/{round}" : {
          "get" : {
             "description" : "Waits for a block to appear after round {round} and returns the node's status at the time.",
             "operationId" : "WaitForBlock",

--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -193,7 +193,7 @@ func (client RestClient) HealthCheck() error {
 // blocks on the node end
 // Not supported
 func (client RestClient) StatusAfterBlock(blockNum uint64) (response generatedV2.NodeStatusResponse, err error) {
-	err = client.get(&response, fmt.Sprintf("/v1/status/wait-for-block-after/%d", blockNum), nil)
+	err = client.get(&response, fmt.Sprintf("/v2/status/wait-for-block-after/%d", blockNum), nil)
 	return
 }
 

--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -42,6 +42,16 @@ const (
 	maxRawResponseBytes = 50e6
 )
 
+// APIVersion is used to define which server side API version would be used when making http requests to the server
+type APIVersion string
+
+const (
+	// APIVersionV1 suggests that the RestClient would use v1 calls whenever it's available for the given request.
+	APIVersionV1 APIVersion = "v1"
+	// APIVersionV2 suggests that the RestClient would use v2 calls whenever it's available for the given request.
+	APIVersionV2 APIVersion = "v2"
+)
+
 // rawRequestPaths is a set of paths where the body should not be urlencoded
 var rawRequestPaths = map[string]bool{
 	"/v1/transactions": true,
@@ -49,16 +59,25 @@ var rawRequestPaths = map[string]bool{
 
 // RestClient manages the REST interface for a calling user.
 type RestClient struct {
-	serverURL url.URL
-	apiToken  string
+	serverURL       url.URL
+	apiToken        string
+	versionAffinity APIVersion
 }
 
 // MakeRestClient is the factory for constructing a RestClient for a given endpoint
 func MakeRestClient(url url.URL, apiToken string) RestClient {
 	return RestClient{
-		serverURL: url,
-		apiToken:  apiToken,
+		serverURL:       url,
+		apiToken:        apiToken,
+		versionAffinity: APIVersionV1,
 	}
+}
+
+// SetAPIVersionAffinity sets the client affinity to use a specific version of the API
+func (client *RestClient) SetAPIVersionAffinity(affinity APIVersion) (previousAffinity APIVersion) {
+	previousAffinity = client.versionAffinity
+	client.versionAffinity = affinity
+	return
 }
 
 // extractError checks if the response signifies an error (for now, StatusCode != 200).
@@ -179,7 +198,16 @@ func (client RestClient) post(response interface{}, path string, request interfa
 // the StatusResponse includes data like the consensus version and current round
 // Not supported
 func (client RestClient) Status() (response generatedV2.NodeStatusResponse, err error) {
-	err = client.get(&response, "/v2/status", nil)
+	switch client.versionAffinity {
+	case APIVersionV2:
+		err = client.get(&response, "/v2/status", nil)
+	default:
+		var nodeStatus v1.NodeStatus
+		err = client.get(&nodeStatus, "/v1/status", nil)
+		if err == nil {
+			response = fillNodeStatusResponse(nodeStatus)
+		}
+	}
 	return
 }
 
@@ -189,11 +217,34 @@ func (client RestClient) HealthCheck() error {
 	return client.get(nil, "/health", nil)
 }
 
+func fillNodeStatusResponse(nodeStatus v1.NodeStatus) generatedV2.NodeStatusResponse {
+	return generatedV2.NodeStatusResponse{
+		LastRound:                 nodeStatus.LastRound,
+		LastVersion:               nodeStatus.LastVersion,
+		NextVersion:               nodeStatus.NextVersion,
+		NextVersionRound:          nodeStatus.NextVersionRound,
+		NextVersionSupported:      nodeStatus.NextVersionSupported,
+		TimeSinceLastRound:        uint64(nodeStatus.TimeSinceLastRound),
+		CatchupTime:               uint64(nodeStatus.CatchupTime),
+		StoppedAtUnsupportedRound: nodeStatus.StoppedAtUnsupportedRound,
+	}
+}
+
 // StatusAfterBlock waits for a block to occur then returns the StatusResponse after that block
 // blocks on the node end
 // Not supported
 func (client RestClient) StatusAfterBlock(blockNum uint64) (response generatedV2.NodeStatusResponse, err error) {
-	err = client.get(&response, fmt.Sprintf("/v2/status/wait-for-block-after/%d", blockNum), nil)
+	switch client.versionAffinity {
+	case APIVersionV2:
+		err = client.get(&response, fmt.Sprintf("/v2/status/wait-for-block-after/%d", blockNum), nil)
+	default:
+		var nodeStatus v1.NodeStatus
+		err = client.get(&nodeStatus, fmt.Sprintf("/v1/status/wait-for-block-after/%d", blockNum), nil)
+		if err == nil {
+			response = fillNodeStatusResponse(nodeStatus)
+		}
+	}
+
 	return
 }
 

--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/google/go-querystring/query"
 
+	generatedV2 "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
 	"github.com/algorand/go-algorand/daemon/algod/api/spec/common"
 	"github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -177,8 +178,8 @@ func (client RestClient) post(response interface{}, path string, request interfa
 // Status retrieves the StatusResponse from the running node
 // the StatusResponse includes data like the consensus version and current round
 // Not supported
-func (client RestClient) Status() (response v1.NodeStatus, err error) {
-	err = client.get(&response, "/v1/status", nil)
+func (client RestClient) Status() (response generatedV2.NodeStatusResponse, err error) {
+	err = client.get(&response, "/v2/status", nil)
 	return
 }
 
@@ -191,7 +192,7 @@ func (client RestClient) HealthCheck() error {
 // StatusAfterBlock waits for a block to occur then returns the StatusResponse after that block
 // blocks on the node end
 // Not supported
-func (client RestClient) StatusAfterBlock(blockNum uint64) (response v1.NodeStatus, err error) {
+func (client RestClient) StatusAfterBlock(blockNum uint64) (response generatedV2.NodeStatusResponse, err error) {
 	err = client.get(&response, fmt.Sprintf("/v1/status/wait-for-block-after/%d", blockNum), nil)
 	return
 }

--- a/daemon/algod/api/server/v2/generated/private/routes.go
+++ b/daemon/algod/api/server/v2/generated/private/routes.go
@@ -251,8 +251,8 @@ var swaggerSpec = []string{
 	"C7/o0lQSJt/693PhH4PdiZL3LNtx4Z8EdRqqrPKxX/gxC9c47wMU8lOnfwAhQZCHfx/lYvCS+/HR0f/z",
 	"TmN03fjG0IMULa64hdnFjbdqZlvbTO3ktOGiAgUvfPhPAXlj8zEy9wAaS7Vg4YF3sQ8/r8E4/XIVhj+9",
 	"X70Jle/Bgwr/20Zr2AhJG5CW0y4uz8U7UaR/Vzk2gmceszfuGerA7kV/NsDhGNf7mNJ/qizd/SnlQR6G",
-	"Dore30tUBQyYE7roEqJcuO2W7ezBE4nI12VTC4oODu/V2Ojyg70W7pLteHXEiMafe3+B9KQUhOdR66Qc",
-	"L5eFSnmxVcYuZ2hP+g5Md/CiIdWHwNhAspuLm/8NAAD//01XMXukUQAA",
+	"Dore30tUBQyYE7roEqLc+LYbvJCIfF02paDo4PBajY0uP9hr4XbtOHXEh8ade3+B5KQMhGdR66McL5eF",
+	"SnmxVcYuZ2hO+v5Ld/CiodSHwNdAsZuLm/8NAAD//3Y6VwOjUQAA",
 }
 
 // GetSwagger returns the Swagger specification corresponding to the generated code

--- a/daemon/algod/api/server/v2/generated/routes.go
+++ b/daemon/algod/api/server/v2/generated/routes.go
@@ -33,7 +33,7 @@ type ServerInterface interface {
 	// (GET /v2/status)
 	GetStatus(ctx echo.Context) error
 	// Gets the node status after waiting for the given round.
-	// (GET /v2/status/wait-for-block-after/{round}/)
+	// (GET /v2/status/wait-for-block-after/{round})
 	WaitForBlock(ctx echo.Context, round uint64) error
 	// Broadcasts a raw transaction to the network.
 	// (POST /v2/transactions)
@@ -399,7 +399,7 @@ func RegisterHandlers(router interface {
 	router.GET("/v2/blocks/:round", wrapper.GetBlock, m...)
 	router.GET("/v2/ledger/supply", wrapper.GetSupply, m...)
 	router.GET("/v2/status", wrapper.GetStatus, m...)
-	router.GET("/v2/status/wait-for-block-after/:round/", wrapper.WaitForBlock, m...)
+	router.GET("/v2/status/wait-for-block-after/:round", wrapper.WaitForBlock, m...)
 	router.POST("/v2/transactions", wrapper.RawTransaction, m...)
 	router.GET("/v2/transactions/params", wrapper.TransactionParams, m...)
 	router.GET("/v2/transactions/pending", wrapper.GetPendingTransactions, m...)
@@ -499,16 +499,16 @@ var swaggerSpec = []string{
 	"k7tjxh3sBubZIfgzXM7zMa3VNch8Iz3/lGfsNfxWgbEsYS8pWUkCHm5N+8im72PDF7Wk+3v7dxagl0oC",
 	"gwthqNvX8eLH9g4+PpFuzdmgbgFCSjgU1T6FU7sOOWQL0FN31nKb5+DOao5uNRjbna+9A+drP7+/fyMZ",
 	"2IBWQ/syLWCO/xt5CH22/ebTbnLcDzfLymZqJVtP6mMXg5IULpG7RUna3WS3u8lud5Pd7ia7u3eT3d1L",
-	"J0WusP1YXlzXYLcUd2Ow3N/TFRcWg72EfL6E2lZDQmg6WA36Oxf+OmrunUWrUFsAD1eMO03jJ/KX9DUV",
-	"XZ9R9acHwxVuoqBW3K7hw6WeK32tBFST1bGKIWSsklaEYjIKYm2+vrxszs4w7wzzzjDvDPPdN8yfsMrS",
-	"yb4loagWilGxUhTb1aJu7Fi0DI4392hsUZ625ow2C8elMpFI9zVftcvQTlDA2KcqW29B2UUyE5L2+S72",
-	"K1r+5fhqLwydiNnaQihIxarsVrGZVjxL0QBZFe4L6jkPl7da4bkbt+h9PvlnTUPZoa9jdLCxk/wPlfyn",
-	"gdnpx7X4alMYnLElGZhQHQklZwEy8bKbzFS2DidnNV/ZCxnVCtPmlHM0C9a7q+p2s2G7q/t2V/ftru7b",
-	"Xd23u7rvbtdvNk6R15DSDx9sAjtgiG6hH/rLboK+Mpm2aznetRzvWo6v2XJ8jQ6PHXV3DeV3uKH8f1kL",
-	"267d69Z6yydbXajpO3shsqsPht7dn9dht/XrOuxj/bjOZ/5pnYhP2jd/73M+d4NZ4vVcZLv3PI73x+uc",
-	"xfu/4n/uftZv97N+u5/12/2s3+5n/XY/63e3f9bvc5Ukv4w06sc8rLO1RPxSWfaczMrNIpT6ypiYB+I2",
-	"Ee4lImexvpHozVt0iegSPe9HNtfsHEynuUp5vlTGTkfo5XWv4Gm/RHXCF24G76eVWpzTabi3l/8TAAD/",
-	"/7RnmyFmkAAA",
+	"J0WusP1YXlzXYLcUd2Ow3N/TFRcWg72EfL6E2lYjCaHu6n/nwt9Gzb2vaBUqC+DhhnGnaPw8/o6+pqDr",
+	"E6r+8GC4wU0U1InbtXu41HOlr5V/apI6VjEEjFXSilBLRjmsrdeXl8zZ2eWdXd7Z5Z1dvvt2+RMWWTrJ",
+	"tyTU1EItKlaJYrtS1I39ipbB8eYejS3K09aU0WbduFQmEui+5qt2FdoJChj7VGXrLSi7SGZC0j7fxX5E",
+	"y78cX+2EoRMxW1sI9ahYkd0qNtOKZykaIKvCdUE95+HyVgs8d+MSvc8n/6zpJzv0ZYwONnaS/6GS/zQw",
+	"O/22Fl9tCoMztiQDEyojoeQsQCZedpOZytbh4KzmK3sho1ph2hxyjibBeldV3W4ybHdz3+7mvt3Nfbub",
+	"+3Y3993t8s3GIfIaUvrdg01gBwzRLbRDf9k90Fcm03Ydx7uO413H8TU7jq/R4LGj7q6f/A73k/8v62Db",
+	"dXvdWmv5ZKsLNX1nL0R29bnQu/vrOuy2flyHfazf1vnMv6wT8Un75u99juduMEu8nots956n8f54naN4",
+	"/1f8z92v+u1+1W/3q367X/Xb/arf7lf97vav+n2ukuSXkUb9mGd1tpaIXyrLnpNZuVmEUt8YE/NA3CbC",
+	"tUTkLNYXEr15iy4R3aHn/cjmlp2D6TRXKc+XytjpCL287g087ZeoTvjCzeD9tFKLczoM9/byfwIAAP//",
+	"We+NdWWQAAA=",
 }
 
 // GetSwagger returns the Swagger specification corresponding to the generated code

--- a/daemon/kmd/client/client.go
+++ b/daemon/kmd/client/client.go
@@ -25,6 +25,14 @@ const (
 	timeoutSecs = 120
 )
 
+// APIVersion is used to define which server side API version would be used when making http requests to the server
+type APIVersion string
+
+const (
+	// APIVersionV1 suggests that the RestClient would use v1 calls whenever it's available for the given request.
+	APIVersionV1 APIVersion = "v1"
+)
+
 // KMDClient is the client used to interact with the kmd API over its socket
 type KMDClient struct {
 	httpClient http.Client

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 
 	algodclient "github.com/algorand/go-algorand/daemon/algod/api/client"
+	generatedV2 "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
 	kmdclient "github.com/algorand/go-algorand/daemon/kmd/client"
 
 	"github.com/algorand/go-algorand/config"
@@ -625,7 +626,7 @@ func (c *Client) ConstructPayment(from, to string, fee, amount uint64, note []by
 /* Algod Wrappers */
 
 // Status returns the node status
-func (c *Client) Status() (resp v1.NodeStatus, err error) {
+func (c *Client) Status() (resp generatedV2.NodeStatusResponse, err error) {
 	algod, err := c.ensureAlgodClient()
 	if err == nil {
 		resp, err = algod.Status()
@@ -698,7 +699,7 @@ func (c *Client) HealthCheck() error {
 }
 
 // WaitForRound takes a round, waits until it appears and returns its status. This function blocks.
-func (c *Client) WaitForRound(round uint64) (resp v1.NodeStatus, err error) {
+func (c *Client) WaitForRound(round uint64) (resp generatedV2.NodeStatusResponse, err error) {
 	algod, err := c.ensureAlgodClient()
 	if err == nil {
 		resp, err = algod.StatusAfterBlock(round)

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -47,11 +47,13 @@ const DefaultKMDDataDir = nodecontrol.DefaultKMDDataDir
 
 // Client represents the entry point for all libgoal functions
 type Client struct {
-	nc           nodecontrol.NodeController
-	kmdStartArgs nodecontrol.KMDStartArgs
-	dataDir      string
-	cacheDir     string
-	consensus    config.ConsensusProtocols
+	nc                   nodecontrol.NodeController
+	kmdStartArgs         nodecontrol.KMDStartArgs
+	dataDir              string
+	cacheDir             string
+	consensus            config.ConsensusProtocols
+	algodVersionAffinity algodclient.APIVersion
+	kmdVersionAffinity   kmdclient.APIVersion
 }
 
 // ClientConfig is data to configure a Client
@@ -134,6 +136,8 @@ func (c *Client) init(config ClientConfig, clientType ClientType) error {
 	}
 	c.dataDir = dataDir
 	c.cacheDir = config.CacheDir
+	c.algodVersionAffinity = algodclient.APIVersionV1
+	c.kmdVersionAffinity = kmdclient.APIVersionV1
 
 	// Get node controller
 	nc, err := getNodeController(config.BinDir, config.AlgodDataDir)
@@ -171,6 +175,7 @@ func (c *Client) init(config ClientConfig, clientType ClientType) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -187,6 +192,7 @@ func (c *Client) ensureAlgodClient() (*algodclient.RestClient, error) {
 	if err != nil {
 		return nil, err
 	}
+	algod.SetAPIVersionAffinity(c.algodVersionAffinity)
 	return &algod, err
 }
 
@@ -810,4 +816,10 @@ func (c *Client) ConsensusParams(round uint64) (consensus config.ConsensusParams
 	}
 
 	return params, nil
+}
+
+// SetAPIVersionAffinity sets the client API version affinity of the algod client.
+func (c *Client) SetAPIVersionAffinity(algodVersionAffinity algodclient.APIVersion, kmdVersionAffinity kmdclient.APIVersion) {
+	c.algodVersionAffinity = algodVersionAffinity
+	c.kmdVersionAffinity = kmdVersionAffinity
 }

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -818,7 +818,7 @@ func (c *Client) ConsensusParams(round uint64) (consensus config.ConsensusParams
 	return params, nil
 }
 
-// SetAPIVersionAffinity sets the client API version affinity of the algod client.
+// SetAPIVersionAffinity sets the desired client API version affinity of the algod and kmd clients.
 func (c *Client) SetAPIVersionAffinity(algodVersionAffinity algodclient.APIVersion, kmdVersionAffinity kmdclient.APIVersion) {
 	c.algodVersionAffinity = algodVersionAffinity
 	c.kmdVersionAffinity = kmdVersionAffinity

--- a/netdeploy/network.go
+++ b/netdeploy/network.go
@@ -25,8 +25,9 @@ import (
 	"strings"
 	"time"
 
+	generatedV2 "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
+
 	"github.com/algorand/go-algorand/config"
-	"github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
 	"github.com/algorand/go-algorand/gen"
 	"github.com/algorand/go-algorand/libgoal"
 	"github.com/algorand/go-algorand/nodecontrol"
@@ -376,7 +377,7 @@ func (n Network) Stop(binDir string) {
 
 // NetworkNodeStatus represents the result from checking the status of a particular node instance
 type NetworkNodeStatus struct {
-	Status v1.NodeStatus
+	Status generatedV2.NodeStatusResponse
 	Error  error
 }
 
@@ -404,7 +405,7 @@ func (n Network) NodesStatus(binDir string) map[string]NetworkNodeStatus {
 	statuses := make(map[string]NetworkNodeStatus)
 
 	for _, relayDir := range n.cfg.RelayDirs {
-		var status v1.NodeStatus
+		var status generatedV2.NodeStatusResponse
 		nc := nodecontrol.MakeNodeController(binDir, n.getNodeFullPath(relayDir))
 		algodClient, err := nc.AlgodClient()
 		if err == nil {
@@ -417,7 +418,7 @@ func (n Network) NodesStatus(binDir string) map[string]NetworkNodeStatus {
 	}
 
 	for _, nodeDir := range n.nodeDirs {
-		var status v1.NodeStatus
+		var status generatedV2.NodeStatusResponse
 		nc := nodecontrol.MakeNodeController(binDir, n.getNodeFullPath(nodeDir))
 		algodClient, err := nc.AlgodClient()
 		if err == nil {

--- a/test/e2e-go/perf/basic_test.go
+++ b/test/e2e-go/perf/basic_test.go
@@ -26,9 +26,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	generatedV2 "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
+
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
-	"github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/libgoal"
@@ -122,7 +123,7 @@ func doBenchTemplate(b *testing.B, template string, moneynode string) {
 	// goroutines to talk to algod and kmd.
 	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 100
 
-	var status v1.NodeStatus
+	var status generatedV2.NodeStatusResponse
 
 	b.Run(template, func(b *testing.B) {
 		for i := 0; i < b.N; i++ {

--- a/test/e2e-go/restAPI/restClient_test.go
+++ b/test/e2e-go/restAPI/restClient_test.go
@@ -31,6 +31,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	algodclient "github.com/algorand/go-algorand/daemon/algod/api/client"
+	kmdclient "github.com/algorand/go-algorand/daemon/kmd/client"
+
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
@@ -184,12 +187,21 @@ func TestClientCanGetStatus(t *testing.T) {
 	statusResponse, err := testClient.Status()
 	require.NoError(t, err)
 	require.NotEmpty(t, statusResponse)
+	testClient.SetAPIVersionAffinity(algodclient.APIVersionV2, kmdclient.APIVersionV1)
+	statusResponse2, err := testClient.Status()
+	require.NoError(t, err)
+	require.NotEmpty(t, statusResponse2)
+	require.True(t, statusResponse2.LastRound >= statusResponse.LastRound)
 }
 
 func TestClientCanGetStatusAfterBlock(t *testing.T) {
 	defer fixture.SetTestContext(t)()
 	testClient := fixture.LibGoalClient
 	statusResponse, err := testClient.WaitForRound(1)
+	require.NoError(t, err)
+	require.NotEmpty(t, statusResponse)
+	testClient.SetAPIVersionAffinity(algodclient.APIVersionV2, kmdclient.APIVersionV1)
+	statusResponse, err = testClient.WaitForRound(statusResponse.LastRound + 1)
 	require.NoError(t, err)
 	require.NotEmpty(t, statusResponse)
 }

--- a/test/framework/fixtures/auctionFixture.go
+++ b/test/framework/fixtures/auctionFixture.go
@@ -35,11 +35,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	generatedV2 "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
+
 	"github.com/algorand/go-algorand/auction"
 	auctionClient "github.com/algorand/go-algorand/auction/client"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/daemon/algod/api/client"
-	"github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
 	"github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -964,7 +965,7 @@ func (f *AuctionFixture) CrossVerifyEndOfAuction(params auction.Params, outcome 
 }
 
 // WaitForNextRound is a utility function to wait for next round
-func (f *AuctionFixture) WaitForNextRound() (newAlgodStatus v1.NodeStatus, err error) {
+func (f *AuctionFixture) WaitForNextRound() (newAlgodStatus generatedV2.NodeStatusResponse, err error) {
 	// get the algod rest client
 	algodRestClient := f.GetAlgodRestClient()
 	algodStatus, err := algodRestClient.Status()


### PR DESCRIPTION
## Summary

Libgoal is currently using the v1 entry points exclusively.
This change modify the libgoal to start using the v2 status command, which will be expanded in subsequent PRs.