### PR TITLE
Fix finding dev@algorand.com's Keygrip for signing

### DIFF
--- a/scripts/release/forward_gpg_agent.sh
+++ b/scripts/release/forward_gpg_agent.sh
@@ -29,7 +29,7 @@ INSTANCE=$(ssh -i "$JENKINS_KEY" "$JENKINS" sudo cat /opt/jenkins/workspace/$BRA
 gpgp=$(find /usr/lib/gnupg{2,,1} -type f -name gpg-preset-passphrase 2> /dev/null)
 
 # Here we need to grab the signing subkey, hence `tail -1`.
-KEYGRIP=$(gpg -K --with-keygrip --textmode dev@algorand.com | grep Keygrip | tail -1 | awk '{ print $3 }')
+KEYGRIP=$(gpg -K --with-keygrip --textmode dev@algorand.com | egrep -A 1 '^ssb[^#]' | grep Keygrip | awk '{ print $3 }')
 echo "enter dev@ password"
 $gpgp --verbose --preset "$KEYGRIP"
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

The code to find the correct Keygrip for the signing key was not correct for dev@algorand.com. This fixes it by selecting the right key.

## Test Plan

Keygrip command tested on Ubuntu 18.04 Vagrant image.
