### PR TITLE
Limit txn group size when broadcasting raw transactions

### DIFF
--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -273,6 +273,12 @@ func (v2 *Handlers) WaitForBlock(ctx echo.Context, round uint64) error {
 // RawTransaction broadcasts a raw transaction to the network.
 // (POST /v2/transactions)
 func (v2 *Handlers) RawTransaction(ctx echo.Context) error {
+	stat, err := v2.Node.Status()
+	if err != nil {
+		return internalError(ctx, err, errFailedRetrievingNodeStatus, v2.Log)
+	}
+	proto := config.Consensus[stat.LastVersion]
+
 	var txgroup []transactions.SignedTxn
 	dec := protocol.NewDecoder(ctx.Request().Body)
 	for {
@@ -285,6 +291,11 @@ func (v2 *Handlers) RawTransaction(ctx echo.Context) error {
 			return badRequest(ctx, err, err.Error(), v2.Log)
 		}
 		txgroup = append(txgroup, st)
+
+		if len(txgroup) > proto.MaxTxGroupSize {
+			err := fmt.Errorf("max group size is %d", proto.MaxTxGroupSize)
+			return badRequest(ctx, err, err.Error(), v2.Log)
+		}
 	}
 
 	if len(txgroup) == 0 {
@@ -292,7 +303,7 @@ func (v2 *Handlers) RawTransaction(ctx echo.Context) error {
 		return badRequest(ctx, err, err.Error(), v2.Log)
 	}
 
-	err := v2.Node.BroadcastSignedTxGroup(txgroup)
+	err = v2.Node.BroadcastSignedTxGroup(txgroup)
 	if err != nil {
 		return badRequest(ctx, err, err.Error(), v2.Log)
 	}

--- a/test/e2e-go/features/transactions/group_test.go
+++ b/test/e2e-go/features/transactions/group_test.go
@@ -274,7 +274,8 @@ func TestGroupTransactionsSubmission(t *testing.T) {
 		err = client.BroadcastTransactionGroup(expanded)
 		a.Error(err)
 		if len(expanded) >= exceedGroupSize {
-			a.Contains(err.Error(), fmt.Sprintf("group size %d exceeds maximum %d", len(expanded), maxTxGroupSize))
+			a.Contains(err.Error(), "group size")
+			a.Contains(err.Error(), fmt.Sprintf("%d", maxTxGroupSize))
 		} else {
 			a.Contains(err.Error(), "inconsistent group values")
 		}


### PR DESCRIPTION
## Summary

We should never need to decode more than `MaxTxGroupSize` transactions on transaction submission, because that group can never be valid.

## Test Plan

Covered by an existing test that I modified in this PR. The failure just happens higher up the stack now.

## Issue

https://github.com/algorand/go-algorand/issues/1090