### PR TITLE
add `goal protocols`

### DIFF
--- a/cmd/goal/commands.go
+++ b/cmd/goal/commands.go
@@ -224,7 +224,7 @@ var reportCmd = &cobra.Command{
 var protoCmd = &cobra.Command{
 	Use:   "protocols",
 	Short: "",
-	Long:  "Dump known consensus protocols as json to stdout.",
+	Long:  "Dump standard consensus protocols as json to stdout.",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, args []string) {
 		os.Stdout.Write(protocol.EncodeJSON(config.Consensus))

--- a/cmd/goal/commands.go
+++ b/cmd/goal/commands.go
@@ -60,6 +60,7 @@ func init() {
 	rootCmd.Flags().BoolVarP(&versionCheck, "version", "v", false, "Display and write current build version and exit")
 	rootCmd.AddCommand(licenseCmd)
 	rootCmd.AddCommand(reportCmd)
+	rootCmd.AddCommand(protoCmd)
 
 	// account.go
 	rootCmd.AddCommand(accountCmd)
@@ -217,6 +218,16 @@ var reportCmd = &cobra.Command{
 		}
 		fmt.Println()
 		onDataDirs(getStatus)
+	},
+}
+
+var protoCmd = &cobra.Command{
+	Use:   "protocols",
+	Short: "",
+	Long:  "Dump known consensus protocols as json to stdout.",
+	Args:  validateNoPosArgsFn,
+	Run: func(cmd *cobra.Command, args []string) {
+		os.Stdout.Write(protocol.EncodeJSON(config.Consensus))
 	},
 }
 


### PR DESCRIPTION
add a goal command to dump all known protocols as json. Useful for other tools to import (Indexer).