### PR TITLE
Change goal account and clerk commands to consistently accept account aliases for address

### DIFF
--- a/cmd/goal/accountsList.go
+++ b/cmd/goal/accountsList.go
@@ -29,6 +29,26 @@ import (
 	"github.com/algorand/go-algorand/libgoal"
 )
 
+// getAccount is a simple helper which returns the default account (if passed an empty string), an account address
+// as-is, or an account address for an account alias.
+// If an AccountsList instance is available it can be passed instead of a data directory to avoid reloading.
+// If not available, the data directory can be set and accountList set to nil.
+// Note: It is a hard error if no account is specified, and no default account is defined.
+// No validation of the account address itself is performed.
+func getAccount(dataDir string, accountList *AccountsList, accountAddress string) string {
+	if accountList == nil {
+		accountList = makeAccountsList(dataDir)
+	}
+	if accountAddress == "" {
+		accountAddress = accountList.getDefaultAccount()
+		if accountAddress == "" {
+			reportErrorln(errorNoDefaultAccount)
+		}
+	}
+
+	return accountList.getAddressByName(accountAddress)
+}
+
 // AccountsList holds a mapping between the account's address, its friendly name and whether it's a default one.
 type AccountsList struct {
 	Accounts        map[string]string

--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -43,6 +43,7 @@ const (
 	errExistingPartKey             = "Account already has a participation key valid at least until roundLastValid (%d) - current is %d"
 	errorSeedConversion            = "Got private key for account %s, but was unable to convert to seed: %s"
 	errorMnemonicConversion        = "Got seed for account %s, but was unable to convert to mnemonic: %s"
+	errorNoDefaultAccount          = "Account not specified and no default account set. set one with 'goal account -f'"
 
 	// KMD
 	infoKMDStopped        = "Stopped kmd"


### PR DESCRIPTION
### Summary
A number of the goal account commands are inconsistent in their allowance of users specifying account aliases. Many only accept a full account address.
This change adds a simple helper to provide for commands (not all were changed) to use the default account if an account isn't specified, an account address, or an account alias.

### Test Plan
Unfortunately, there are currently no test abstractions in the codebase for the CLI and much of the logic is directly within the CLI run commands.

The individual pieces of logic are typically quite simple though so visual validation combined with test executions against testnet seem sufficient.