### PR TITLE
Implement protocol.EncodeJSONStrict

### DIFF
--- a/protocol/codec.go
+++ b/protocol/codec.go
@@ -34,6 +34,10 @@ var CodecHandle *codec.MsgpackHandle
 // with our settings (canonical, paranoid about decoding errors)
 var JSONHandle *codec.JsonHandle
 
+// JSONStrictHandle is the same as JSONHandle but with MapKeyAsString=true
+// for correct maps[int]interface{} encoding
+var JSONStrictHandle *codec.JsonHandle
+
 // Decoder is our interface for a thing that can decode objects.
 type Decoder interface {
 	Decode(objptr interface{}) error
@@ -56,6 +60,15 @@ func init() {
 	JSONHandle.RecursiveEmptyCheck = true
 	JSONHandle.Indent = 2
 	JSONHandle.HTMLCharsAsIs = true
+
+	JSONStrictHandle = new(codec.JsonHandle)
+	JSONStrictHandle.ErrorIfNoField = JSONHandle.ErrorIfNoField
+	JSONStrictHandle.ErrorIfNoArrayExpand = JSONHandle.ErrorIfNoArrayExpand
+	JSONStrictHandle.Canonical = JSONHandle.Canonical
+	JSONStrictHandle.RecursiveEmptyCheck = JSONHandle.RecursiveEmptyCheck
+	JSONStrictHandle.Indent = JSONHandle.Indent
+	JSONStrictHandle.HTMLCharsAsIs = JSONHandle.HTMLCharsAsIs
+	JSONStrictHandle.MapKeyAsString = true
 }
 
 type codecBytes struct {
@@ -136,6 +149,15 @@ func EncodeStream(w io.Writer, obj interface{}) {
 func EncodeJSON(obj interface{}) []byte {
 	var b []byte
 	enc := codec.NewEncoderBytes(&b, JSONHandle)
+	enc.MustEncode(obj)
+	return b
+}
+
+// EncodeJSONStrict returns a JSON-encoded byte buffer for a given object
+// It is the same EncodeJSON but encodes map's int keys as strings
+func EncodeJSONStrict(obj interface{}) []byte {
+	var b []byte
+	enc := codec.NewEncoderBytes(&b, JSONStrictHandle)
 	enc.MustEncode(obj)
 	return b
 }


### PR DESCRIPTION
### Summary
EncodeJSONStrict is like EncodeJSON but converts integer keys to strings so that the output is valid json.

### Test Plan
Unit test ensures no integer keys and correct decoding.

Closes #1076