### PR TITLE
Allow env vars to be set for mule package task

### DIFF
--- a/scripts/release/mule/package/linux/amd64/deb/package.sh
+++ b/scripts/release/mule/package/linux/amd64/deb/package.sh
@@ -16,24 +16,21 @@ if [ -z "$OS_TYPE" ] || [ -z "$ARCH" ] || [ -z "$WORKDIR" ]; then
     exit 1
 fi
 
-REPO_DIR="$WORKDIR"
-BRANCH=$("$REPO_DIR/scripts/compute_branch.sh")
-CHANNEL=$("$REPO_DIR/scripts/compute_branch_channel.sh" "$BRANCH")
-BASE="$REPO_DIR/tmp/node_pkgs/$OS_TYPE/$ARCH"
+BRANCH=${BRANCH:-$("$WORKDIR/scripts/compute_branch.sh" "$BRANCH")}
+CHANNEL=${CHANNEL:-$("$WORKDIR/scripts/compute_branch_channel.sh" "$BRANCH")}
+BASE="$WORKDIR/tmp/node_pkgs/$OS_TYPE/$ARCH"
 mkdir -p "$BASE/$CHANNEL/$OS_TYPE-$ARCH/bin"
 ALGO_BIN="$BASE/$CHANNEL/$OS_TYPE-$ARCH/bin"
-mkdir -p "$BASE/pkg"
-OUTDIR="$BASE/pkg"
-PKG_NAME=$("$REPO_DIR/scripts/compute_package_name.sh" "${CHANNEL:-stable}")
+OUTDIR="$BASE"
+PKG_NAME=$("$WORKDIR/scripts/compute_package_name.sh" "${CHANNEL:-stable}")
+VER=${VERSION:-$("$WORKDIR/scripts/compute_build_number.sh" -f)}
 
 echo "Building debian package for '${OS} - ${ARCH}'"
 
-VER=$("$REPO_DIR/scripts/compute_build_number.sh" -f)
-
 if [ "${DEFAULTNETWORK}" = "" ]; then
-    DEFAULTNETWORK=$("$REPO_DIR/scripts/compute_branch_network.sh")
+    DEFAULTNETWORK=$("$WORKDIR/scripts/compute_branch_network.sh")
 fi
-DEFAULT_RELEASE_NETWORK=$("$REPO_DIR/scripts/compute_branch_release_network.sh" "${DEFAULTNETWORK}")
+DEFAULT_RELEASE_NETWORK=$("$WORKDIR/scripts/compute_branch_release_network.sh" "${DEFAULTNETWORK}")
 
 PKG_ROOT=$(mktemp -d)
 trap "rm -rf $PKG_ROOT" 0
@@ -65,14 +62,14 @@ if [ ! -z "${RELEASE_GENESIS_PROCESS}" ]; then
     genesis_dirs=("devnet" "testnet" "mainnet" "betanet")
     for dir in "${genesis_dirs[@]}"; do
         mkdir -p "${PKG_ROOT}/var/lib/algorand/genesis/${dir}"
-        cp "${REPO_DIR}/installer/genesis/${dir}/genesis.json" "${PKG_ROOT}/var/lib/algorand/genesis/${dir}/genesis.json"
+        cp "${WORKDIR}/installer/genesis/${dir}/genesis.json" "${PKG_ROOT}/var/lib/algorand/genesis/${dir}/genesis.json"
     done
     # Copy the appropriate network genesis.json for our default (in root ./genesis folder)
     cp "${PKG_ROOT}/var/lib/algorand/genesis/${DEFAULT_RELEASE_NETWORK}/genesis.json" "${PKG_ROOT}/var/lib/algorand"
 elif [[ "${CHANNEL}" == "dev" || "${CHANNEL}" == "stable" || "${CHANNEL}" == "nightly" || "${CHANNEL}" == "beta" ]]; then
-    cp "${REPO_DIR}/installer/genesis/${DEFAULTNETWORK}/genesis.json" "${PKG_ROOT}/var/lib/algorand/genesis.json"
+    cp "${WORKDIR}/installer/genesis/${DEFAULTNETWORK}/genesis.json" "${PKG_ROOT}/var/lib/algorand/genesis.json"
 else
-    cp "${REPO_DIR}/installer/genesis/${DEFAULTNETWORK}/genesis.json" "${PKG_ROOT}/var/lib/algorand"
+    cp "${WORKDIR}/installer/genesis/${DEFAULTNETWORK}/genesis.json" "${PKG_ROOT}/var/lib/algorand"
 fi
 
 systemd_files=("algorand.service" "algorand@.service")

--- a/scripts/release/mule/package/linux/amd64/rpm/package.sh
+++ b/scripts/release/mule/package/linux/amd64/rpm/package.sh
@@ -13,19 +13,19 @@ if [ -z "$OS_TYPE" ] || [ -z "$ARCH" ] || [ -z "$WORKDIR" ]; then
     exit 1
 fi
 
-REPO_DIR="$WORKDIR"
-FULLVERSION=$("$REPO_DIR/scripts/compute_build_number.sh" -f)
-BRANCH=$("$REPO_DIR/scripts/compute_branch.sh")
-CHANNEL=$("$REPO_DIR/scripts/compute_branch_channel.sh" "$BRANCH")
-ALGO_BIN="$REPO_DIR/tmp/node_pkgs/$OS_TYPE/$ARCH/$CHANNEL/$OS_TYPE-$ARCH/bin"
+FULLVERSION=${VERSION:-$("$WORKDIR/scripts/compute_build_number.sh" -f)}
+BRANCH=${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
+CHANNEL=${CHANNEL:-$("$WORKDIR/scripts/compute_branch_channel.sh" "$BRANCH")}
+ALGO_BIN="$WORKDIR/tmp/node_pkgs/$OS_TYPE/$ARCH/$CHANNEL/$OS_TYPE-$ARCH/bin"
 # TODO: Should there be a default network?
 DEFAULTNETWORK=devnet
-DEFAULT_RELEASE_NETWORK=$("$REPO_DIR/scripts/compute_branch_release_network.sh" "${DEFAULTNETWORK}")
-PKG_NAME=$("$REPO_DIR/scripts/compute_package_name.sh" "${CHANNEL:-stable}")
+DEFAULT_RELEASE_NETWORK=$("$WORKDIR/scripts/compute_branch_release_network.sh" "${DEFAULTNETWORK}")
+PKG_NAME=$("$WORKDIR/scripts/compute_package_name.sh" "${CHANNEL:-stable}")
 
 # The following need to be exported for use in ./go-algorand/installer/rpm/algorand.spec.
 export DEFAULT_NETWORK
 export DEFAULT_RELEASE_NETWORK
+REPO_DIR="$WORKDIR"
 export REPO_DIR
 export ALGO_BIN
 
@@ -34,13 +34,12 @@ trap 'rm -rf $RPMTMP' 0
 
 TEMPDIR=$(mktemp -d)
 trap 'rm -rf $TEMPDIR' 0
-< "$REPO_DIR/installer/rpm/algorand.spec" \
+< "$WORKDIR/installer/rpm/algorand.spec" \
     sed -e "s,@PKG_NAME@,${PKG_NAME}," \
         -e "s,@VER@,$FULLVERSION," \
     > "$TEMPDIR/algorand.spec"
 
 rpmbuild --buildroot "$HOME/foo" --define "_rpmdir $RPMTMP" --define "RELEASE_GENESIS_PROCESS x$RELEASE_GENESIS_PROCESS" --define "LICENSE_FILE ./COPYING" -bb "$TEMPDIR/algorand.spec"
 
-mkdir -p "$REPO_DIR/tmp/node_pkgs/$OS_TYPE/$ARCH/pkg"
-cp -p "$RPMTMP"/*/*.rpm "$REPO_DIR/tmp/node_pkgs/$OS_TYPE/$ARCH/pkg"
+cp -p "$RPMTMP"/*/*.rpm "$WORKDIR/tmp/node_pkgs/$OS_TYPE/$ARCH"
 


### PR DESCRIPTION
### Summary
This allows the BRANCH, CHANNEL and VERSION env vars to be specified in the mule yaml file.  It is the same functionality that was added later to other mule tasks.

### Test Plan
Add any or all of the above to the env block in any mule yaml file.