### PR TITLE
improve e2e script runner

### DIFF
--- a/test/scripts/e2e_client_runner.py
+++ b/test/scripts/e2e_client_runner.py
@@ -299,6 +299,17 @@ def goal_network_delete(netdir, normal_cleanup=False):
             raise e
     already_deleted = True
 
+def reportcomms(p, stdout, stderr):
+    cmdr = repr(p.args)
+    if not stdout and p.stdout:
+        stdout = p.stdout.read()
+    if not stderr and p.stderr:
+        stderr = p.stderr.read()
+    if stdout:
+        sys.stderr.write('output from {}:\n{}\n\n'.format(cmdr, stdout))
+    if stderr:
+        sys.stderr.write('stderr from {}:\n{}\n\n'.format(cmdr, stderr))
+
 def xrun(cmd, *args, **kwargs):
     timeout = kwargs.pop('timeout', None)
     kwargs['stdout'] = subprocess.PIPE
@@ -310,32 +321,21 @@ def xrun(cmd, *args, **kwargs):
         raise
     try:
         if timeout:
-            p.communicate(timeout=timeout)
+            stdout,stderr = p.communicate(timeout=timeout)
         else:
-            p.communicate()
+            stdout,stderr = p.communicate()
     except subprocess.TimeoutExpired as te:
-        cmdr = repr(cmd)
-        logger.error('subprocess timed out {}'.format(cmdr), exc_info=True)
-        if p.stdout:
-            sys.stderr.write('output from {}:\n{}\n\n'.format(cmdr, p.stdout.read()))
-        if p.stderr:
-            sys.stderr.write('stderr from {}:\n{}\n\n'.format(cmdr, p.stderr.read()))
+        logger.error('subprocess timed out {!r}'.format(cmd), exc_info=True)
+        reportcomms(p, stdout, stderr)
         raise
     except Exception as e:
-        cmdr = repr(cmd)
-        logger.error('subprocess exception {}'.format(cmdr), exc_info=True)
-        if p.stdout:
-            sys.stderr.write('output from {}:\n{}\n\n'.format(cmdr, p.stdout.read()))
-        if p.stderr:
-            sys.stderr.write('stderr from {}:\n{}\n\n'.format(cmdr, p.stderr.read()))
+        logger.error('subprocess exception {!r}'.format(cmd), exc_info=True)
+        reportcomms(p, stdout, stderr)
         raise
     if p.returncode != 0:
         cmdr = repr(cmd)
         logger.error('cmd failed {}'.format(cmdr))
-        if p.stdout:
-            sys.stderr.write('output from {}:\n{}\n\n'.format(cmdr, p.stdout.read()))
-        if p.stderr:
-            sys.stderr.write('stderr from {}:\n{}\n\n'.format(cmdr, p.stderr.read()))
+        reportcomms(p, stdout, stderr)
         raise Exception('error: cmd failed: {}'.format(cmdr))
 
 _logging_format = '%(asctime)s :%(lineno)d %(message)s'


### PR DESCRIPTION
## Summary

e2e_client_runner.py would sometimes fail to capture stdio from failing subtasks. Fix:
If p.communicate() finishes, use returned stdio.
If p.communicate() throws exception, try p.stdout p.stderr

## Test Plan

This **is** a test.
`(make && cd test/scripts && python3 e2e_client_runner.py e2e_subs/*.sh)`