### PR TITLE
Fix missing algod_telemetry_drops_total event

### DIFF
--- a/logging/telemetryhook.go
+++ b/logging/telemetryhook.go
@@ -108,6 +108,7 @@ func (hook *asyncTelemetryHook) appendEntry(entry *logrus.Entry) bool {
 	if len(hook.pending) >= hook.maxQueueDepth {
 		hook.pending = hook.pending[1:]
 		hook.wg.Done()
+		telemetryDrops.Inc(nil)
 	}
 	hook.pending = append(hook.pending, entry)
 


### PR DESCRIPTION
## Summary

When creating an async hook with channelDepth > maxQueueDepth, we might get to a situation where the immediate processing queue isn't large enough to contains all the pulled events. When that happens, the existing code drop the event.

To account for loss of event, we have the algod_telemetry_drops_total metrics, which measures how many events we have dropped. Unfortunately, the above code does not update the algod_telemetry_drops_total, causing the wrong number of events to be reported.

Resolves issue #1086 
