### PR TITLE
Perform parameter validation on -p arguments on goal & algod

### DIFF
--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -36,8 +36,9 @@ import (
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/logging/telemetryspec"
+	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/protocol"
-	"github.com/algorand/go-algorand/tools/network"
+	toolsnet "github.com/algorand/go-algorand/tools/network"
 	"github.com/algorand/go-algorand/util/metrics"
 	"github.com/algorand/go-algorand/util/tokens"
 )
@@ -248,6 +249,20 @@ func main() {
 		if cfg.GossipFanout > len(peerOverrideArray) {
 			cfg.GossipFanout = len(peerOverrideArray)
 		}
+
+		// make sure that the format of each entry is valid:
+		stagingArray := []string{}
+		for _, peer := range peerOverrideArray {
+			url, err := network.ParseHostOrURL(peer)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Provided command line parameter '%s' is not a valid host:port pair\n", peer)
+				os.Exit(1)
+				return
+			}
+			stagingArray = append(stagingArray, url.Host)
+		}
+		peerOverrideArray = stagingArray
+
 	}
 
 	// Apply the default deadlock setting before starting the server.
@@ -303,7 +318,7 @@ func main() {
 
 		// If the telemetry URI is not set, periodically check SRV records for new telemetry URI
 		if remoteTelemetryEnabled && log.GetTelemetryURI() == "" {
-			network.StartTelemetryURIUpdateService(time.Minute, cfg, s.Genesis.Network, log, done)
+			toolsnet.StartTelemetryURIUpdateService(time.Minute, cfg, s.Genesis.Network, log, done)
 		}
 
 		currentVersion := config.GetCurrentVersion()

--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -251,18 +251,15 @@ func main() {
 		}
 
 		// make sure that the format of each entry is valid:
-		stagingArray := []string{}
-		for _, peer := range peerOverrideArray {
+		for idx, peer := range peerOverrideArray {
 			url, err := network.ParseHostOrURL(peer)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Provided command line parameter '%s' is not a valid host:port pair\n", peer)
 				os.Exit(1)
 				return
 			}
-			stagingArray = append(stagingArray, url.Host)
+			peerOverrideArray[idx] = url.Host
 		}
-		peerOverrideArray = stagingArray
-
 	}
 
 	// Apply the default deadlock setting before starting the server.

--- a/cmd/goal/node.go
+++ b/cmd/goal/node.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/libgoal"
+	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/nodecontrol"
 	"github.com/algorand/go-algorand/util"
 	"github.com/algorand/go-algorand/util/tokens"
@@ -105,6 +106,9 @@ var startCmd = &cobra.Command{
 	Short: "Init the specified Algorand node.",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
+		if !verifyPeerDialArg() {
+			return
+		}
 		binDir, err := util.ExeDir()
 		if err != nil {
 			panic(err)
@@ -205,6 +209,9 @@ var restartCmd = &cobra.Command{
 	Short: "Stop, and then start, the specified Algorand node.",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
+		if !verifyPeerDialArg() {
+			return
+		}
 		binDir, err := util.ExeDir()
 		if err != nil {
 			panic(err)
@@ -531,4 +538,23 @@ var createCmd = &cobra.Command{
 			reportErrorf(errorNodeCreation, err)
 		}
 	},
+}
+
+// verifyPeerDialArg verifies that the peers provided in peerDial are valid peers.
+func verifyPeerDialArg() bool {
+	if peerDial == "" {
+		return true
+	}
+
+	// make sure that the format of each entry is valid:
+	for _, peer := range strings.Split(peerDial, ";") {
+		_, err := network.ParseHostOrURL(peer)
+		if err != nil {
+			reportErrorf("Provided peer '%s' is not a valid peer address : %v", peer, err)
+			return false
+		}
+
+	}
+	return true
+
 }

--- a/test/e2e-go/cli/goal/expect/goalCmdFlagsTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalCmdFlagsTest.exp
@@ -21,6 +21,18 @@ proc TestGoalCommandLineFlags { CMD EXPECTED_RE } {
 
 if { [catch {
 
+    TestGoalCommandLineFlags "goal node start -p :xxx:445" ".*is not a valid peer address.*"
+    TestGoalCommandLineFlags "goal node start -p {http://1.2.3.4:5050;:xxx:445}" ".*is not a valid peer address.*"
+    TestGoalCommandLineFlags "goal node start -p http://1.2.3.4:5050" "^Data directory not specified.*"
+    TestGoalCommandLineFlags "goal node start -p {http://1.2.3.4:5050;5.6.7.8}" "^Data directory not specified.*"
+
+} EXCEPTION ] } {
+    puts "ERROR in Goal Start Validity test: $EXCEPTION"
+    exit 1
+}
+
+if { [catch {
+
     TestGoalCommandLineFlags "goal asset create --decimals 0 --validrounds 0 --creator ABC --total 100" ".*can not be zero.*"
     TestGoalCommandLineFlags "goal asset create --decimals 0 --validrounds 1 --lastvalid 1 --creator ABC --total 100" "Only one of .* can be specified"
 


### PR DESCRIPTION
## Summary

Neither algod nor goal were validating the -p parameter ( i.e. the -p parameter is used to specify a peer list to connect to ).

The -p parameter is used extensively in our testing environment, but rarely on production code. Since the automated testing was always passing the "correct" and "valid" values, it never was an issue. However, while implementing the fast catchup, I attempted to use it incorrectly and ran into various issues as a result. Having the code verify the correctness upstream would have prevented these issues.

## Test Plan

This change is covered by an expect test.

## Issue

While not strictly required for the fast catchup, it was created during the fast catchup development, so I'll leave that as the originating issue. issue #1024 