### PR TITLE
Rename balrecord.SpendingKey to AuthAddr

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -92,7 +92,7 @@ func init() {
 	sendCmd.Flags().StringVarP(&txFilename, "out", "o", "", "Dump an unsigned tx to the given file. In order to dump a signed transaction, pass -s")
 	sendCmd.Flags().BoolVarP(&sign, "sign", "s", false, "Use with -o to indicate that the dumped transaction should be signed")
 	sendCmd.Flags().StringVarP(&closeToAddress, "close-to", "c", "", "Close account and send remainder to this address")
-	sendCmd.Flags().StringVar(&rekeyToAddress, "rekey-to", "", "Rekey account to the given spending key/address. (Future transactions from this account will need to be signed with the new key.)")
+	sendCmd.Flags().StringVar(&rekeyToAddress, "rekey-to", "", "Rekey account to the given effective address. (Future transactions from this account will need to be signed with the new key.)")
 	sendCmd.Flags().BoolVarP(&noWaitAfterSend, "no-wait", "N", false, "Don't wait for transaction to commit")
 	sendCmd.Flags().StringVarP(&programSource, "from-program", "F", "", "Program source to use as account logic")
 	sendCmd.Flags().StringVarP(&progByteFile, "from-program-bytes", "P", "", "Program binary to use as account logic")

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -92,7 +92,7 @@ func init() {
 	sendCmd.Flags().StringVarP(&txFilename, "out", "o", "", "Dump an unsigned tx to the given file. In order to dump a signed transaction, pass -s")
 	sendCmd.Flags().BoolVarP(&sign, "sign", "s", false, "Use with -o to indicate that the dumped transaction should be signed")
 	sendCmd.Flags().StringVarP(&closeToAddress, "close-to", "c", "", "Close account and send remainder to this address")
-	sendCmd.Flags().StringVar(&rekeyToAddress, "rekey-to", "", "Rekey account to the given effective address. (Future transactions from this account will need to be signed with the new key.)")
+	sendCmd.Flags().StringVar(&rekeyToAddress, "rekey-to", "", "Rekey account to the given authorization address. (Future transactions from this account will need to be signed with the new key.)")
 	sendCmd.Flags().BoolVarP(&noWaitAfterSend, "no-wait", "N", false, "Don't wait for transaction to commit")
 	sendCmd.Flags().StringVarP(&programSource, "from-program", "F", "", "Program source to use as account logic")
 	sendCmd.Flags().StringVarP(&progByteFile, "from-program-bytes", "P", "", "Program binary to use as account logic")

--- a/data/basics/msgp_gen.go
+++ b/data/basics/msgp_gen.go
@@ -43,7 +43,7 @@ func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0005Len--
 		zb0005Mask |= 0x80
 	}
-	if (*z).SpendingKey.MsgIsZero() {
+	if (*z).EffectiveAddr.MsgIsZero() {
 		zb0005Len--
 		zb0005Mask |= 0x100
 	}
@@ -182,9 +182,9 @@ func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0005Mask & 0x100) == 0 { // if not empty
 			// string "spend"
 			o = append(o, 0xa5, 0x73, 0x70, 0x65, 0x6e, 0x64)
-			o, err = (*z).SpendingKey.MarshalMsg(o)
+			o, err = (*z).EffectiveAddr.MarshalMsg(o)
 			if err != nil {
-				err = msgp.WrapError(err, "SpendingKey")
+				err = msgp.WrapError(err, "EffectiveAddr")
 				return
 			}
 		}
@@ -446,9 +446,9 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0005 > 0 {
 			zb0005--
-			bts, err = (*z).SpendingKey.UnmarshalMsg(bts)
+			bts, err = (*z).EffectiveAddr.UnmarshalMsg(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "SpendingKey")
+				err = msgp.WrapError(err, "struct-from-array", "EffectiveAddr")
 				return
 			}
 		}
@@ -664,9 +664,9 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					(*z).Assets[zb0003] = zb0004
 				}
 			case "spend":
-				bts, err = (*z).SpendingKey.UnmarshalMsg(bts)
+				bts, err = (*z).EffectiveAddr.UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "SpendingKey")
+					err = msgp.WrapError(err, "EffectiveAddr")
 					return
 				}
 			default:
@@ -705,13 +705,13 @@ func (z *AccountData) Msgsize() (s int) {
 			s += 0 + zb0003.Msgsize() + 1 + 2 + msgp.Uint64Size + 2 + msgp.BoolSize
 		}
 	}
-	s += 6 + (*z).SpendingKey.Msgsize()
+	s += 6 + (*z).EffectiveAddr.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *AccountData) MsgIsZero() bool {
-	return ((*z).Status == 0) && ((*z).MicroAlgos.MsgIsZero()) && ((*z).RewardsBase == 0) && ((*z).RewardedMicroAlgos.MsgIsZero()) && ((*z).VoteID.MsgIsZero()) && ((*z).SelectionID.MsgIsZero()) && ((*z).VoteFirstValid == 0) && ((*z).VoteLastValid == 0) && ((*z).VoteKeyDilution == 0) && (len((*z).AssetParams) == 0) && (len((*z).Assets) == 0) && ((*z).SpendingKey.MsgIsZero())
+	return ((*z).Status == 0) && ((*z).MicroAlgos.MsgIsZero()) && ((*z).RewardsBase == 0) && ((*z).RewardedMicroAlgos.MsgIsZero()) && ((*z).VoteID.MsgIsZero()) && ((*z).SelectionID.MsgIsZero()) && ((*z).VoteFirstValid == 0) && ((*z).VoteLastValid == 0) && ((*z).VoteKeyDilution == 0) && (len((*z).AssetParams) == 0) && (len((*z).Assets) == 0) && ((*z).EffectiveAddr.MsgIsZero())
 }
 
 // MarshalMsg implements msgp.Marshaler
@@ -1307,7 +1307,7 @@ func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0005Len--
 		zb0005Mask |= 0x200
 	}
-	if (*z).AccountData.SpendingKey.MsgIsZero() {
+	if (*z).AccountData.EffectiveAddr.MsgIsZero() {
 		zb0005Len--
 		zb0005Mask |= 0x400
 	}
@@ -1455,9 +1455,9 @@ func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0005Mask & 0x400) == 0 { // if not empty
 			// string "spend"
 			o = append(o, 0xa5, 0x73, 0x70, 0x65, 0x6e, 0x64)
-			o, err = (*z).AccountData.SpendingKey.MarshalMsg(o)
+			o, err = (*z).AccountData.EffectiveAddr.MarshalMsg(o)
 			if err != nil {
-				err = msgp.WrapError(err, "SpendingKey")
+				err = msgp.WrapError(err, "EffectiveAddr")
 				return
 			}
 		}
@@ -1727,9 +1727,9 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0005 > 0 {
 			zb0005--
-			bts, err = (*z).AccountData.SpendingKey.UnmarshalMsg(bts)
+			bts, err = (*z).AccountData.EffectiveAddr.UnmarshalMsg(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "SpendingKey")
+				err = msgp.WrapError(err, "struct-from-array", "EffectiveAddr")
 				return
 			}
 		}
@@ -1951,9 +1951,9 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					(*z).AccountData.Assets[zb0003] = zb0004
 				}
 			case "spend":
-				bts, err = (*z).AccountData.SpendingKey.UnmarshalMsg(bts)
+				bts, err = (*z).AccountData.EffectiveAddr.UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "SpendingKey")
+					err = msgp.WrapError(err, "EffectiveAddr")
 					return
 				}
 			default:
@@ -1992,13 +1992,13 @@ func (z *BalanceRecord) Msgsize() (s int) {
 			s += 0 + zb0003.Msgsize() + 1 + 2 + msgp.Uint64Size + 2 + msgp.BoolSize
 		}
 	}
-	s += 6 + (*z).AccountData.SpendingKey.Msgsize()
+	s += 6 + (*z).AccountData.EffectiveAddr.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *BalanceRecord) MsgIsZero() bool {
-	return ((*z).Addr.MsgIsZero()) && ((*z).AccountData.Status == 0) && ((*z).AccountData.MicroAlgos.MsgIsZero()) && ((*z).AccountData.RewardsBase == 0) && ((*z).AccountData.RewardedMicroAlgos.MsgIsZero()) && ((*z).AccountData.VoteID.MsgIsZero()) && ((*z).AccountData.SelectionID.MsgIsZero()) && ((*z).AccountData.VoteFirstValid == 0) && ((*z).AccountData.VoteLastValid == 0) && ((*z).AccountData.VoteKeyDilution == 0) && (len((*z).AccountData.AssetParams) == 0) && (len((*z).AccountData.Assets) == 0) && ((*z).AccountData.SpendingKey.MsgIsZero())
+	return ((*z).Addr.MsgIsZero()) && ((*z).AccountData.Status == 0) && ((*z).AccountData.MicroAlgos.MsgIsZero()) && ((*z).AccountData.RewardsBase == 0) && ((*z).AccountData.RewardedMicroAlgos.MsgIsZero()) && ((*z).AccountData.VoteID.MsgIsZero()) && ((*z).AccountData.SelectionID.MsgIsZero()) && ((*z).AccountData.VoteFirstValid == 0) && ((*z).AccountData.VoteLastValid == 0) && ((*z).AccountData.VoteKeyDilution == 0) && (len((*z).AccountData.AssetParams) == 0) && (len((*z).AccountData.Assets) == 0) && ((*z).AccountData.EffectiveAddr.MsgIsZero())
 }
 
 // MarshalMsg implements msgp.Marshaler

--- a/data/basics/msgp_gen.go
+++ b/data/basics/msgp_gen.go
@@ -43,7 +43,7 @@ func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0005Len--
 		zb0005Mask |= 0x80
 	}
-	if (*z).EffectiveAddr.MsgIsZero() {
+	if (*z).AuthAddr.MsgIsZero() {
 		zb0005Len--
 		zb0005Mask |= 0x100
 	}
@@ -182,9 +182,9 @@ func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0005Mask & 0x100) == 0 { // if not empty
 			// string "spend"
 			o = append(o, 0xa5, 0x73, 0x70, 0x65, 0x6e, 0x64)
-			o, err = (*z).EffectiveAddr.MarshalMsg(o)
+			o, err = (*z).AuthAddr.MarshalMsg(o)
 			if err != nil {
-				err = msgp.WrapError(err, "EffectiveAddr")
+				err = msgp.WrapError(err, "AuthAddr")
 				return
 			}
 		}
@@ -446,9 +446,9 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0005 > 0 {
 			zb0005--
-			bts, err = (*z).EffectiveAddr.UnmarshalMsg(bts)
+			bts, err = (*z).AuthAddr.UnmarshalMsg(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "EffectiveAddr")
+				err = msgp.WrapError(err, "struct-from-array", "AuthAddr")
 				return
 			}
 		}
@@ -664,9 +664,9 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					(*z).Assets[zb0003] = zb0004
 				}
 			case "spend":
-				bts, err = (*z).EffectiveAddr.UnmarshalMsg(bts)
+				bts, err = (*z).AuthAddr.UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "EffectiveAddr")
+					err = msgp.WrapError(err, "AuthAddr")
 					return
 				}
 			default:
@@ -705,13 +705,13 @@ func (z *AccountData) Msgsize() (s int) {
 			s += 0 + zb0003.Msgsize() + 1 + 2 + msgp.Uint64Size + 2 + msgp.BoolSize
 		}
 	}
-	s += 6 + (*z).EffectiveAddr.Msgsize()
+	s += 6 + (*z).AuthAddr.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *AccountData) MsgIsZero() bool {
-	return ((*z).Status == 0) && ((*z).MicroAlgos.MsgIsZero()) && ((*z).RewardsBase == 0) && ((*z).RewardedMicroAlgos.MsgIsZero()) && ((*z).VoteID.MsgIsZero()) && ((*z).SelectionID.MsgIsZero()) && ((*z).VoteFirstValid == 0) && ((*z).VoteLastValid == 0) && ((*z).VoteKeyDilution == 0) && (len((*z).AssetParams) == 0) && (len((*z).Assets) == 0) && ((*z).EffectiveAddr.MsgIsZero())
+	return ((*z).Status == 0) && ((*z).MicroAlgos.MsgIsZero()) && ((*z).RewardsBase == 0) && ((*z).RewardedMicroAlgos.MsgIsZero()) && ((*z).VoteID.MsgIsZero()) && ((*z).SelectionID.MsgIsZero()) && ((*z).VoteFirstValid == 0) && ((*z).VoteLastValid == 0) && ((*z).VoteKeyDilution == 0) && (len((*z).AssetParams) == 0) && (len((*z).Assets) == 0) && ((*z).AuthAddr.MsgIsZero())
 }
 
 // MarshalMsg implements msgp.Marshaler
@@ -1307,7 +1307,7 @@ func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0005Len--
 		zb0005Mask |= 0x200
 	}
-	if (*z).AccountData.EffectiveAddr.MsgIsZero() {
+	if (*z).AccountData.AuthAddr.MsgIsZero() {
 		zb0005Len--
 		zb0005Mask |= 0x400
 	}
@@ -1455,9 +1455,9 @@ func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0005Mask & 0x400) == 0 { // if not empty
 			// string "spend"
 			o = append(o, 0xa5, 0x73, 0x70, 0x65, 0x6e, 0x64)
-			o, err = (*z).AccountData.EffectiveAddr.MarshalMsg(o)
+			o, err = (*z).AccountData.AuthAddr.MarshalMsg(o)
 			if err != nil {
-				err = msgp.WrapError(err, "EffectiveAddr")
+				err = msgp.WrapError(err, "AuthAddr")
 				return
 			}
 		}
@@ -1727,9 +1727,9 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0005 > 0 {
 			zb0005--
-			bts, err = (*z).AccountData.EffectiveAddr.UnmarshalMsg(bts)
+			bts, err = (*z).AccountData.AuthAddr.UnmarshalMsg(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "EffectiveAddr")
+				err = msgp.WrapError(err, "struct-from-array", "AuthAddr")
 				return
 			}
 		}
@@ -1951,9 +1951,9 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					(*z).AccountData.Assets[zb0003] = zb0004
 				}
 			case "spend":
-				bts, err = (*z).AccountData.EffectiveAddr.UnmarshalMsg(bts)
+				bts, err = (*z).AccountData.AuthAddr.UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "EffectiveAddr")
+					err = msgp.WrapError(err, "AuthAddr")
 					return
 				}
 			default:
@@ -1992,13 +1992,13 @@ func (z *BalanceRecord) Msgsize() (s int) {
 			s += 0 + zb0003.Msgsize() + 1 + 2 + msgp.Uint64Size + 2 + msgp.BoolSize
 		}
 	}
-	s += 6 + (*z).AccountData.EffectiveAddr.Msgsize()
+	s += 6 + (*z).AccountData.AuthAddr.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *BalanceRecord) MsgIsZero() bool {
-	return ((*z).Addr.MsgIsZero()) && ((*z).AccountData.Status == 0) && ((*z).AccountData.MicroAlgos.MsgIsZero()) && ((*z).AccountData.RewardsBase == 0) && ((*z).AccountData.RewardedMicroAlgos.MsgIsZero()) && ((*z).AccountData.VoteID.MsgIsZero()) && ((*z).AccountData.SelectionID.MsgIsZero()) && ((*z).AccountData.VoteFirstValid == 0) && ((*z).AccountData.VoteLastValid == 0) && ((*z).AccountData.VoteKeyDilution == 0) && (len((*z).AccountData.AssetParams) == 0) && (len((*z).AccountData.Assets) == 0) && ((*z).AccountData.EffectiveAddr.MsgIsZero())
+	return ((*z).Addr.MsgIsZero()) && ((*z).AccountData.Status == 0) && ((*z).AccountData.MicroAlgos.MsgIsZero()) && ((*z).AccountData.RewardsBase == 0) && ((*z).AccountData.RewardedMicroAlgos.MsgIsZero()) && ((*z).AccountData.VoteID.MsgIsZero()) && ((*z).AccountData.SelectionID.MsgIsZero()) && ((*z).AccountData.VoteFirstValid == 0) && ((*z).AccountData.VoteLastValid == 0) && ((*z).AccountData.VoteKeyDilution == 0) && (len((*z).AccountData.AssetParams) == 0) && (len((*z).AccountData.Assets) == 0) && ((*z).AccountData.AuthAddr.MsgIsZero())
 }
 
 // MarshalMsg implements msgp.Marshaler

--- a/data/basics/userBalance.go
+++ b/data/basics/userBalance.go
@@ -137,11 +137,11 @@ type AccountData struct {
 	// is expected to have copy-by-value semantics.
 	Assets map[AssetIndex]AssetHolding `codec:"asset,allocbound=-"`
 
-	// SpendingKey is the address against which signatures/multisigs/logicsigs should be checked.
+	// EffectiveAddr is the address against which signatures/multisigs/logicsigs should be checked.
 	// If empty, the address of the account whose AccountData this is is used.
-	// A transaction may change an account's SpendingKey to "re-key" the account.
+	// A transaction may change an account's EffectiveAddr to "re-key" the account.
 	// This allows key rotation, changing the members in a multisig, etc.
-	SpendingKey Address `codec:"spend"`
+	EffectiveAddr Address `codec:"spend"`
 }
 
 // AccountDetail encapsulates meaningful details about a given account, for external consumption

--- a/data/basics/userBalance.go
+++ b/data/basics/userBalance.go
@@ -137,11 +137,11 @@ type AccountData struct {
 	// is expected to have copy-by-value semantics.
 	Assets map[AssetIndex]AssetHolding `codec:"asset,allocbound=-"`
 
-	// EffectiveAddr is the address against which signatures/multisigs/logicsigs should be checked.
+	// AuthAddr is the address against which signatures/multisigs/logicsigs should be checked.
 	// If empty, the address of the account whose AccountData this is is used.
-	// A transaction may change an account's EffectiveAddr to "re-key" the account.
+	// A transaction may change an account's AuthAddr to "re-key" the account.
 	// This allows key rotation, changing the members in a multisig, etc.
-	EffectiveAddr Address `codec:"spend"`
+	AuthAddr Address `codec:"spend"`
 }
 
 // AccountDetail encapsulates meaningful details about a given account, for external consumption

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -94,8 +94,8 @@ type Header struct {
 	// lease, no other transaction specifying this lease can be confirmed.
 	Lease [32]byte `codec:"lx"`
 
-	// RekeyTo, if nonzero, sets the sender's EffectiveAddr to the given address
-	// If the RekeyTo address is the sender's actual address, the EffectiveAddr is set to zero
+	// RekeyTo, if nonzero, sets the sender's AuthAddr to the given address
+	// If the RekeyTo address is the sender's actual address, the AuthAddr is set to zero
 	// This allows "re-keying" a long-lived account -- rotating the signing key, changing
 	// membership of a multisig account, etc.
 	RekeyTo basics.Address `codec:"rekey"`
@@ -433,19 +433,19 @@ func (tx Transaction) Apply(balances Balances, spec SpecialAddresses, ctr uint64
 		return
 	}
 
-	// rekeying: update balrecord.EffectiveAddr to tx.RekeyTo if provided
+	// rekeying: update balrecord.AuthAddr to tx.RekeyTo if provided
 	if (tx.RekeyTo != basics.Address{}) {
 		var record basics.BalanceRecord
 		record, err = balances.Get(tx.Sender, false)
 		if err != nil {
 			return
 		}
-		// Special case: rekeying to the account's actual address just sets balrecord.EffectiveAddr to 0
+		// Special case: rekeying to the account's actual address just sets balrecord.AuthAddr to 0
 		// This saves 32 bytes in your balance record if you want to go back to using your original key
 		if tx.RekeyTo == tx.Sender {
-			record.EffectiveAddr = basics.Address{}
+			record.AuthAddr = basics.Address{}
 		} else {
-			record.EffectiveAddr = tx.RekeyTo
+			record.AuthAddr = tx.RekeyTo
 		}
 
 		err = balances.Put(record)

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -94,8 +94,8 @@ type Header struct {
 	// lease, no other transaction specifying this lease can be confirmed.
 	Lease [32]byte `codec:"lx"`
 
-	// RekeyTo, if nonzero, sets the sender's SpendingKey to the given address
-	// If the RekeyTo address is the sender's actual address, the SpendingKey is set to zero
+	// RekeyTo, if nonzero, sets the sender's EffectiveAddr to the given address
+	// If the RekeyTo address is the sender's actual address, the EffectiveAddr is set to zero
 	// This allows "re-keying" a long-lived account -- rotating the signing key, changing
 	// membership of a multisig account, etc.
 	RekeyTo basics.Address `codec:"rekey"`
@@ -433,19 +433,19 @@ func (tx Transaction) Apply(balances Balances, spec SpecialAddresses, ctr uint64
 		return
 	}
 
-	// rekeying: update balrecord.SpendingKey to tx.RekeyTo if provided
+	// rekeying: update balrecord.EffectiveAddr to tx.RekeyTo if provided
 	if (tx.RekeyTo != basics.Address{}) {
 		var record basics.BalanceRecord
 		record, err = balances.Get(tx.Sender, false)
 		if err != nil {
 			return
 		}
-		// Special case: rekeying to the account's actual address just sets balrecord.SpendingKey to 0
+		// Special case: rekeying to the account's actual address just sets balrecord.EffectiveAddr to 0
 		// This saves 32 bytes in your balance record if you want to go back to using your original key
 		if tx.RekeyTo == tx.Sender {
-			record.SpendingKey = basics.Address{}
+			record.EffectiveAddr = basics.Address{}
 		} else {
-			record.SpendingKey = tx.RekeyTo
+			record.EffectiveAddr = tx.RekeyTo
 		}
 
 		err = balances.Put(record)

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -544,12 +544,12 @@ func (eval *BlockEvaluator) transaction(txn transactions.SignedTxn, ad transacti
 		}
 
 		// Does the address that authorized the transaction actually match whatever address the sender has rekeyed to?
-		// i.e., the sig/lsig/msig was checked against the txn.Authorizer() address, but does this match the EffectiveAddr in the sender's balance record?
+		// i.e., the sig/lsig/msig was checked against the txn.Authorizer() address, but does this match the sender's balrecord.AuthAddr?
 		acctdata, err := cow.lookup(txn.Txn.Sender)
 		if err != nil {
 			return err
 		}
-		correctAuthorizer := acctdata.EffectiveAddr
+		correctAuthorizer := acctdata.AuthAddr
 		if (correctAuthorizer == basics.Address{}) {
 			correctAuthorizer = txn.Txn.Sender
 		}

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -544,12 +544,12 @@ func (eval *BlockEvaluator) transaction(txn transactions.SignedTxn, ad transacti
 		}
 
 		// Does the address that authorized the transaction actually match whatever address the sender has rekeyed to?
-		// i.e., the sig/lsig/msig was checked against the txn.Authorizer() address, but does this match the SpendingKey in the sender's balance record?
+		// i.e., the sig/lsig/msig was checked against the txn.Authorizer() address, but does this match the EffectiveAddr in the sender's balance record?
 		acctdata, err := cow.lookup(txn.Txn.Sender)
 		if err != nil {
 			return err
 		}
-		correctAuthorizer := acctdata.SpendingKey
+		correctAuthorizer := acctdata.EffectiveAddr
 		if (correctAuthorizer == basics.Address{}) {
 			correctAuthorizer = txn.Txn.Sender
 		}


### PR DESCRIPTION
We're already using "spending key" to refer to private keys in various
user-facing places, so calling the rekeying-related address field a spending
key would be unnecessarily confusing.