### PR TITLE
Reduce cadaver failures error levels

### DIFF
--- a/agreement/cadaver.go
+++ b/agreement/cadaver.go
@@ -119,14 +119,21 @@ func (c *cadaver) trySetup() bool {
 		c.out.Close()
 		err := os.Rename(c.filename(), c.filename()+".archive")
 		if err != nil {
-			logging.Base().Error(err)
-			c.failed = err
-			return false
+			if os.IsNotExist(err) {
+				// we can't rename the cadaver file since it doesn't exists.
+				// this typically happens when it being externally deleted, and could happen
+				// far before we close the handle above.
+				logging.Base().Info(err)
+			} else {
+				logging.Base().Warn(err)
+				c.failed = err
+				return false
+			}
 		}
 
 		err = c.init()
 		if err != nil {
-			logging.Base().Error(err)
+			logging.Base().Warn(err)
 			c.failed = err
 			return false
 		}


### PR DESCRIPTION
## Summary

The agreement service manages the creation/deletion/updates of the cadaver files.
Currently, whenever we fail to rename a cadaver file, we generate and log an error.
This shouldn't always be the case. If the cadaver file was deleted externally, we should just log it as informational message. Also, in case of a different issue, we should log it as a warning, since it doesn't affect the functional state of the node.