### PR TITLE
Add support for Raw msgp interfaces on unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/algorand/go-codec/codec v0.0.0-20190507210007-269d70b6135d
 	github.com/algorand/go-deadlock v0.0.0-20181221160745-78d8cb5e2759
-	github.com/algorand/msgp v1.1.39
+	github.com/algorand/msgp v1.1.40
 	github.com/algorand/oapi-codegen v1.3.5-algorand4
 	github.com/algorand/websocket v1.4.1
 	github.com/aws/aws-sdk-go v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/algorand/go-codec/codec v0.0.0-20190507210007-269d70b6135d h1:W9MgGUo
 github.com/algorand/go-codec/codec v0.0.0-20190507210007-269d70b6135d/go.mod h1:qm6LyXvDa1+uZJxaVg8X+OEjBqt/zDinDa2EohtTDxU=
 github.com/algorand/go-deadlock v0.0.0-20181221160745-78d8cb5e2759 h1:IiCuOE1YCReVyEr1IQHKTBTvFLKdeBCfQuxrqhniq+I=
 github.com/algorand/go-deadlock v0.0.0-20181221160745-78d8cb5e2759/go.mod h1:Kve3O9VpxZIHsPzpfxNdyFltFU9jBTeVYMYxSC99tdg=
-github.com/algorand/msgp v1.1.39 h1:sVDmS0CH7hDtJHWwNqwy3wgu5DQ9EM3VBIXS3KaNlNI=
-github.com/algorand/msgp v1.1.39/go.mod h1:LtOntbYiCHj/Sl/Sqxtf8CZOrDt2a8Dv3tLaS6mcnUE=
+github.com/algorand/msgp v1.1.40 h1:GljBzSmwUhlRSA/y/U3hlMcR2WCisW6E1s6B4lwExow=
+github.com/algorand/msgp v1.1.40/go.mod h1:LtOntbYiCHj/Sl/Sqxtf8CZOrDt2a8Dv3tLaS6mcnUE=
 github.com/algorand/oapi-codegen v1.3.5-algorand4 h1:skjv/lhlWAGnQPHQ9qdzTE5Bk9W555EKrh1bSul0JJs=
 github.com/algorand/oapi-codegen v1.3.5-algorand4/go.mod h1:/k0Ywn0lnt92uBMyE+yiRf/Wo3/chxHHsAfenD09EbY=
 github.com/algorand/websocket v1.4.1 h1:FPoNHI8i2VZWZzhCscY8JTzsAE7Vv73753cMbzb3udk=

--- a/protocol/codec_tester.go
+++ b/protocol/codec_tester.go
@@ -22,8 +22,9 @@ import (
 	"math/rand"
 	"reflect"
 	"strings"
-	"sync"
 	"testing"
+
+	"github.com/algorand/go-deadlock"
 
 	"github.com/algorand/msgp/msgp"
 	"github.com/stretchr/testify/require"
@@ -68,7 +69,7 @@ func parseStructTags(structTag string) map[string]string {
 	return tagsMap
 }
 
-var printWarningOnce sync.Mutex
+var printWarningOnce deadlock.Mutex
 var warningMessages map[string]bool
 
 func printWarning(warnMsg string) {

--- a/protocol/codec_tester.go
+++ b/protocol/codec_tester.go
@@ -21,6 +21,8 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/algorand/msgp/msgp"
@@ -34,6 +36,9 @@ type msgpMarshalUnmarshal interface {
 	msgp.Unmarshaler
 }
 
+var rawMsgpType = reflect.TypeOf(msgp.Raw{})
+var errSkipRawMsgpTesting = fmt.Errorf("skipping msgp.Raw serializing, since it won't be the same across go-codec and msgp")
+
 func oneOf(n int) bool {
 	return (rand.Int() % n) == 0
 }
@@ -46,11 +51,55 @@ func RandomizeObject(template interface{}) (interface{}, error) {
 	}
 
 	v := reflect.New(tt.Elem())
-	err := randomizeValue(v.Elem())
+	err := randomizeValue(v.Elem(), tt.String(), "")
 	return v.Interface(), err
 }
 
-func randomizeValue(v reflect.Value) error {
+func parseStructTags(structTag string) map[string]string {
+	tagsMap := map[string]string{}
+
+	for _, tag := range strings.Split(reflect.StructTag(structTag).Get("codec"), ",") {
+		elements := strings.Split(tag, "=")
+		if len(elements) != 2 {
+			continue
+		}
+		tagsMap[elements[0]] = elements[1]
+	}
+	return tagsMap
+}
+
+var printWarningOnce sync.Mutex
+var warningMessages map[string]bool
+
+func printWarning(warnMsg string) {
+	printWarningOnce.Lock()
+	defer printWarningOnce.Unlock()
+	if warningMessages == nil {
+		warningMessages = make(map[string]bool)
+	}
+	if !warningMessages[warnMsg] {
+		warningMessages[warnMsg] = true
+		fmt.Printf("%s\n", warnMsg)
+	}
+}
+
+func checkBoundsLimitingTag(objType string, datapath string, structTag string) {
+	if structTag == "" {
+		return
+	}
+	tagsMap := parseStructTags(structTag)
+
+	if _, have := tagsMap["allocbound"]; !have {
+		printWarning(fmt.Sprintf("%s %s does not have an allocbound defined", objType, datapath))
+		return
+	}
+	if tagsMap["allocbound"] == "-" {
+		printWarning(fmt.Sprintf("%s %s have an unbounded allocbound defined", objType, datapath))
+		return
+	}
+}
+
+func randomizeValue(v reflect.Value, datapath string, tag string) error {
 	if oneOf(5) {
 		// Leave zero value
 		return nil
@@ -72,28 +121,33 @@ func randomizeValue(v reflect.Value) error {
 		st := v.Type()
 		for i := 0; i < v.NumField(); i++ {
 			f := st.Field(i)
+			tag := f.Tag
+
 			if f.PkgPath != "" && !f.Anonymous {
 				// unexported
 				continue
 			}
-
-			err := randomizeValue(v.Field(i))
+			if rawMsgpType == f.Type {
+				return errSkipRawMsgpTesting
+			}
+			err := randomizeValue(v.Field(i), datapath+"/"+f.Name, string(tag))
 			if err != nil {
 				return err
 			}
 		}
 	case reflect.Array:
 		for i := 0; i < v.Len(); i++ {
-			err := randomizeValue(v.Index(i))
+			err := randomizeValue(v.Index(i), fmt.Sprintf("%s/%d", datapath, i), "")
 			if err != nil {
 				return err
 			}
 		}
 	case reflect.Slice:
+		checkBoundsLimitingTag("slice", datapath, tag)
 		l := rand.Int() % 32
 		s := reflect.MakeSlice(v.Type(), l, l)
 		for i := 0; i < l; i++ {
-			err := randomizeValue(s.Index(i))
+			err := randomizeValue(s.Index(i), fmt.Sprintf("%s/%d", datapath, i), "")
 			if err != nil {
 				return err
 			}
@@ -102,18 +156,19 @@ func randomizeValue(v reflect.Value) error {
 	case reflect.Bool:
 		v.SetBool(rand.Uint32()%2 == 0)
 	case reflect.Map:
+		checkBoundsLimitingTag("map", datapath, tag)
 		mt := v.Type()
 		v.Set(reflect.MakeMap(mt))
 		l := rand.Int() % 32
 		for i := 0; i < l; i++ {
 			mk := reflect.New(mt.Key())
-			err := randomizeValue(mk.Elem())
+			err := randomizeValue(mk.Elem(), fmt.Sprintf("%s/%d", datapath, i), "")
 			if err != nil {
 				return err
 			}
 
 			mv := reflect.New(mt.Elem())
-			err = randomizeValue(mv.Elem())
+			err = randomizeValue(mv.Elem(), fmt.Sprintf("%s/%d", datapath, i), "")
 			if err != nil {
 				return err
 			}
@@ -205,6 +260,11 @@ func EncodingTest(template msgpMarshalUnmarshal) error {
 func RunEncodingTest(t *testing.T, template msgpMarshalUnmarshal) {
 	for i := 0; i < 1000; i++ {
 		err := EncodingTest(template)
+		if err == errSkipRawMsgpTesting {
+			// we want to skip the serilization test in this case.
+			t.Skip()
+			return
+		}
 		require.NoError(t, err)
 	}
 }


### PR DESCRIPTION
## Summary

Recently we added support for Raw structures in the msgp library. This PR makes the corresponding changes to the unit testing, ensuring that structures which contains Raw interfaces would not get compared to the go-codec. ( which has it's own Raw struct implementation )