### PR TITLE
Blank reseve address shows creator's address.

### DIFF
--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -620,7 +620,13 @@ var infoAssetCmd = &cobra.Command{
 			reportErrorf(errorRequestFail, err)
 		}
 
-		reserve, err := client.AccountInformation(params.Creator)
+		reserveEmpty := false
+		if params.ReserveAddr == "" {
+			reserveEmpty = true
+			params.ReserveAddr = params.Creator
+		}
+
+		reserve, err := client.AccountInformation(params.ReserveAddr)
 		if err != nil {
 			reportErrorf(errorRequestFail, err)
 		}
@@ -637,7 +643,11 @@ var infoAssetCmd = &cobra.Command{
 		fmt.Printf("Decimals:         %d\n", params.Decimals)
 		fmt.Printf("Default frozen:   %v\n", params.DefaultFrozen)
 		fmt.Printf("Manager address:  %s\n", params.ManagerAddr)
-		fmt.Printf("Reserve address:  %s\n", params.ReserveAddr)
+		if reserveEmpty {
+			fmt.Printf("Reserve address:  %s (Empty. Defaulting to creator)\n", params.ReserveAddr)
+		} else {
+			fmt.Printf("Reserve address:  %s\n", params.ReserveAddr)
+		}
 		fmt.Printf("Freeze address:   %s\n", params.FreezeAddr)
 		fmt.Printf("Clawback address: %s\n", params.ClawbackAddr)
 	},

--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -620,11 +620,7 @@ var infoAssetCmd = &cobra.Command{
 			reportErrorf(errorRequestFail, err)
 		}
 
-		if params.ReserveAddr == "" {
-			params.ReserveAddr = params.Creator
-		}
-
-		reserve, err := client.AccountInformation(params.ReserveAddr)
+		reserve, err := client.AccountInformation(params.Creator)
 		if err != nil {
 			reportErrorf(errorRequestFail, err)
 		}


### PR DESCRIPTION
* The reserve address, when blank, is shown in the asset info as if it
  is set to the creator's address.

* When reserve address change transaction is accepted, nothing changes
  (because the blank remains blank, and shows the creator's address).

* When the reserve address is empty, but showing the creator's
  address, then it does not count towards a non-empty address. So,
  when all the addresses but the manager are empty, but shows as if
  reserve and manager are non-empty, clearing the manager address
  destroys the asset.

This change removes the lines which set the reserve address to the
creator's address when the reserve address is blank.
