### PR TITLE
Update AMI for arm buildhost (#506)

### DIFF
--- a/scripts/buildhost/linux-arm.sh
+++ b/scripts/buildhost/linux-arm.sh
@@ -19,7 +19,7 @@ cd ${TMPPATH}
 
 AWS_REGION="us-west-2"
 # this is the private AMI that contains the RasPI VM running on port 5022
-AWS_LINUX_AMI="ami-092a4cbb66cbd47f7"
+AWS_LINUX_AMI="ami-06819013739d79715"
 AWS_INSTANCE_TYPE="i3.xlarge"
 INSTANCE_NUMBER=$RANDOM
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

The AMI for the ARM host builder was updated in rel/beta, but not in master. This fixes that.

## Test Plan

N/A
