### PR TITLE
Remove unused var in compute_branch_channel.sh

### DIFF
--- a/scripts/compute_branch_channel.sh
+++ b/scripts/compute_branch_channel.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-# If enlistment isn't clean, it's 'dev'
-CWD=$(cd "$(dirname "$0")" && pwd -P)
+# If workspace isn't clean, it's 'dev'.
 
 if [ "$1" = "master" ]; then
     echo "master"


### PR DESCRIPTION
## Summary

While working on the indexer pipeline, `shellcheck` found an unused variable in `scripts/compute_branch_channel.sh`, which this commit removes.

## Test Plan

Nothing to test.