### PR TITLE
Avoid regenerating msgp decoders/encoders dynamically on ARM

### DIFF
--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -58,17 +58,19 @@ scripts/travis/before_build.sh
 # Force re-evaluation of genesis files to see if source files changed w/o running make
 touch gen/generate.go
 
-# Force re-generation of msgpack encoders/decoders with msgp.  If this re-generated code
-# does not match the checked-in code, some structs may have been added or updated without
-# refreshing the generated codecs.  The enlistment check below will error out, if so.
-make msgp
-
 if [ "${OS}-${ARCH}" = "linux-arm" ]; then
     # for arm, build just the basic distro
     MAKE_DEBUG_OPTION=""
 fi
 
 if [ "${MAKE_DEBUG_OPTION}" != "" ]; then
+    # Force re-generation of msgpack encoders/decoders with msgp.  If this re-generated code
+    # does not match the checked-in code, some structs may have been added or updated without
+    # refreshing the generated codecs.  The enlistment check below will error out, if so.
+    # we want to have that only on system where we have some debugging abilities. Platforms that do not support
+    # debugging ( i.e. arm ) are also usually under powered and making this extra step
+    # would be very costly there.
+    make msgp
     make build build-race
 else
     make build


### PR DESCRIPTION
## Summary

Compiling on ARM takes a long time. As a partial workaround, we want to eliminate recreating the message-pack encoders/decoders, as these already generated by other platforms.

## Test Plan

Execute the build on ARM and see that we're able to compile