### PR TITLE
Fix two more dataraces during catchup mode switch

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -910,14 +910,14 @@ func (node *AlgorandFullNode) SetCatchpointCatchupMode(catchpointCatchupMode boo
 		node.log.Infof("Indexer is not available - %v", err)
 	}
 
-	node.cancelCtx()
+	// Set up a context we can use to cancel goroutines on Stop()
+	node.ctx, node.cancelCtx = context.WithCancel(context.Background())
 
 	node.startMonitoringRoutines()
+
 	// at this point, the catchpoint catchup is done ( either successfully or not.. )
 	node.catchpointCatchupService = nil
 
-	// Set up a context we can use to cancel goroutines on Stop()
-	node.ctx, node.cancelCtx = context.WithCancel(context.Background())
 	return node.ctx
 
 }


### PR DESCRIPTION
## Summary

The initializeFromDisk function is called a second ( or third..) time when we attempt to complete the fast catchup process and switch to the new accounts data. When that happen, we need to shut down the entire backend and reload it.

This PR addresses two such data races - 
The first in the account initialization, where the previously allocated communication channel with the commit goroutine need to be updated.
The second is on the node itself, where we need to preallocate the node context object prior to creating the node monitoring goroutines 

## Test Plan

These two issues were found using the fast catchup e2e test. I have used this test in order to verify the fix as well.
