### PR TITLE
Bugfix - build_packages should be build-packages

### DIFF
--- a/scripts/release/forward_gpg_agent.sh
+++ b/scripts/release/forward_gpg_agent.sh
@@ -9,7 +9,7 @@ then
     exit 1
 fi
 
-BRANCH=build_packages
+BRANCH=build-packages
 EC2_INSTANCE_KEY=ReleaseBuildInstanceKey.pem
 
 # Get the ec2 instance name and the ephemeral private key from the Jenkins server.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

There was an error in the forward GPG agent script, that caused the SSH key copying to fail.

## Test Plan

N/A, not an easy way to test this. Script was executed manually to ensure the SSH key copying worked (which it did).
