### PR TITLE
Allow updater to request any package with 'gettools' subcommand.

### DIFF
--- a/cmd/updater/toolsCmd.go
+++ b/cmd/updater/toolsCmd.go
@@ -26,10 +26,12 @@ import (
 
 var toolsDestFile string
 var toolsBucket string
+var toolsPackage string
 
 func init() {
 	getToolsCmd.Flags().StringVarP(&toolsDestFile, "outputFile", "o", "", "Path for downloaded file (required)")
 	getToolsCmd.Flags().StringVarP(&toolsBucket, "bucket", "b", "", "S3 bucket to check for tools.")
+	getToolsCmd.Flags().StringVarP(&toolsPackage, "package", "p", "tools", "Download a specific package.")
 	getToolsCmd.MarkFlagRequired("outputFile")
 }
 
@@ -46,7 +48,7 @@ var getToolsCmd = &cobra.Command{
 			exitErrorf("Error creating s3 session %s\n", err.Error())
 		}
 
-		version, name, err := s3Session.GetPackageVersion(channel, "tools", specificVersion)
+		version, name, err := s3Session.GetPackageVersion(channel, toolsPackage, specificVersion)
 		if err != nil {
 			exitErrorf("Error getting latest tools version from s3 %s\n", err.Error())
 		}


### PR DESCRIPTION
## Summary

Updater was almost a general purpose algorand package fetcher. Add the missing "--package" option so that we can use it to fetch other packages (I don't think the third package has been deployed yet, but it is why I want this new option):
```
~$ updater gettools -c nightly -o tools.tar.gz
~$ updater gettools -c nightly -p tools -o tools.tar.gz
~$ updater gettools -c nightly -p node -o node.tar.gz
~$ updater gettools -c nightly -p algorand-updater -o updater.tar.gz
```

## Test Plan

Ran the above commands and made sure the correct packages are downloaded (when available).