### PR TITLE
Remove allBalances from acctupdates and move it to testing

### DIFF
--- a/data/common_test.go
+++ b/data/common_test.go
@@ -17,6 +17,7 @@
 package data
 
 import (
+	"errorf"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -125,10 +126,10 @@ func testingenv(t testing.TB, numAccounts, numTxs int, offlineAccounts bool) (*L
 
 	tx := make([]transactions.SignedTxn, TXs)
 	latest := ledger.Latest()
-	bal, err := ledger.AllBalances(latest)
-	if err != nil {
-		panic(err)
+	if latest != 0 {
+		panic(fmt.Errorf("newly created ledger doesn't start on round 0"))
 	}
+	bal := bootstrap.balances
 
 	for i := 0; i < TXs; i++ {
 		send := gen.Int() % P

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -290,33 +290,6 @@ func (au *accountUpdates) lookup(rnd basics.Round, addr basics.Address, withRewa
 	return au.accountsq.lookup(addr)
 }
 
-func (au *accountUpdates) allBalances(rnd basics.Round) (bals map[basics.Address]basics.AccountData, err error) {
-	au.accountsMu.RLock()
-
-	offsetLimit, err := au.roundOffset(rnd)
-	au.accountsMu.RUnlock()
-	if err != nil {
-		return
-	}
-
-	err = au.dbs.rdb.Atomic(func(tx *sql.Tx) error {
-		var err0 error
-		bals, err0 = accountsAll(tx)
-		return err0
-	})
-	if err != nil {
-		return
-	}
-	au.accountsMu.RLock()
-	defer au.accountsMu.RUnlock()
-	for offset := uint64(0); offset < offsetLimit; offset++ {
-		for addr, delta := range au.deltas[offset] {
-			bals[addr] = delta.new
-		}
-	}
-	return
-}
-
 func (au *accountUpdates) listAssets(maxAssetIdx basics.AssetIndex, maxResults uint64) ([]basics.AssetLocator, error) {
 	au.accountsMu.RLock()
 	defer au.accountsMu.RUnlock()

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -500,13 +500,6 @@ func (l *Ledger) Timestamp(r basics.Round) (int64, error) {
 	return l.time.timestamp(r)
 }
 
-// AllBalances returns a map of every account balance as of round rnd.
-func (l *Ledger) AllBalances(rnd basics.Round) (map[basics.Address]basics.AccountData, error) {
-	l.trackerMu.RLock()
-	defer l.trackerMu.RUnlock()
-	return l.accts.allBalances(rnd)
-}
-
 // GenesisHash returns the genesis hash for this ledger.
 func (l *Ledger) GenesisHash() crypto.Digest {
 	return l.genesisHash

--- a/node/assemble_test.go
+++ b/node/assemble_test.go
@@ -86,11 +86,6 @@ func BenchmarkAssembleBlock(b *testing.B) {
 	require.NoError(b, err)
 
 	l := ledger
-	// allb, err := l.AllBalances(l.Latest())
-	// require.NoError(b, err)
-	// for addr, ad := range allb {
-	// 	b.Logf("%s\t%d", addr, ad.MicroAlgos)
-	// }
 	next := l.LastRound()
 	if err != nil {
 		b.Errorf("could not make proposals at round %d: could not read block from ledger: %v", next, err)


### PR DESCRIPTION
##  Summary

The function acctupdates.allBalances had a functional bug where the locking semantics could cause it to work incorrectly in some cases. Fortunately, this function is not used anywhere outside our unit testings.

In this PR, I've moved this function to be executed only within our unit testing, removing it's usage from ledger.AllBalances and updating relevant unit tests.


## Test Plan

Unit tests covering the affected functionality were updated.