### PR TITLE
Fix incorrect asset error message when trying to overspent an asset

### DIFF
--- a/data/transactions/asset.go
+++ b/data/transactions/asset.go
@@ -213,11 +213,11 @@ func takeOut(balances Balances, addr basics.Address, asset basics.AssetIndex, am
 		return fmt.Errorf("asset %v frozen in %v", asset, addr)
 	}
 
-	var overflowed bool
-	sndHolding.Amount, overflowed = basics.OSub(sndHolding.Amount, amount)
+	newAmount, overflowed := basics.OSub(sndHolding.Amount, amount)
 	if overflowed {
 		return fmt.Errorf("underflow on subtracting %d from sender amount %d", amount, sndHolding.Amount)
 	}
+	sndHolding.Amount = newAmount
 
 	snd.Assets[asset] = sndHolding
 	return balances.Put(snd)

--- a/test/e2e-go/features/transactions/asset_test.go
+++ b/test/e2e-go/features/transactions/asset_test.go
@@ -792,13 +792,13 @@ func TestAssetSend(t *testing.T) {
 	tx, err = client.MakeUnsignedAssetSendTx(nonFrozenIdx, 11, extra, "", "")
 	_, err = helperFillSignBroadcast(client, wh, extra, tx, err)
 	a.Error(err)
-	a.True(strings.Contains(err.Error(), "underflow on subtracting 11 from sender amount"))
+	a.True(strings.Contains(err.Error(), "underflow on subtracting 11 from sender amount 10"))
 
 	// Should not be able to clawback more than is available
 	tx, err = client.MakeUnsignedAssetSendTx(nonFrozenIdx, 11, account0, "", extra)
 	_, err = helperFillSignBroadcast(client, wh, clawback, tx, err)
 	a.Error(err)
-	a.True(strings.Contains(err.Error(), "underflow on subtracting 11 from sender amount"))
+	a.True(strings.Contains(err.Error(), "underflow on subtracting 11 from sender amount 10"))
 
 	tx, err = client.MakeUnsignedAssetSendTx(nonFrozenIdx, 10, extra, "", "")
 	_, err = helperFillSignBroadcast(client, wh, extra, tx, err)


### PR DESCRIPTION
## Summary

Fix incorrect asset error message when trying to overspent an asset.
The reported value in the error message was the subtracted ( invalid ) result, instead of the pre-subtraction value.

## Test Plan

Existing e2e test was extended to cover this change.