### PR TITLE
Fix sporadic TestCatchupOverGossip e2e test failure(s)

### DIFF
--- a/test/e2e-go/features/catchup/basicCatchup_test.go
+++ b/test/e2e-go/features/catchup/basicCatchup_test.go
@@ -124,35 +124,29 @@ func runCatchupOverGossip(t *testing.T,
 		cfg.SaveToDisk(dir)
 	}
 
-	fixture.Start()
 	defer fixture.Shutdown()
 	ncPrim, err := fixture.GetNodeController("Primary")
 	a.NoError(err)
-
-	// Kill the primary
-	ncPrim.FullStop()
 
 	// Get 2nd node, which makes all the progress
 	nc, err := fixture.GetNodeController("Node")
 	a.NoError(err)
 
-	// Let the network make some progress
+	// Start the secondary
+	_, err = fixture.StartNode(nc.GetDataDir())
+	a.NoError(err)
 
+	// Let the secondary make progress up to round 3, while the primary was never startred ( hence, it's on round = 0)
 	waitForRound := uint64(3)
 	err = fixture.ClientWaitForRoundWithTimeout(fixture.GetAlgodClientForController(nc), waitForRound)
 	a.NoError(err)
 
-	// Now, revive the primary
-	lg, err := fixture.StartNode(ncPrim.GetDataDir())
-	a.NoError(err)
-
-	status, err := lg.Status()
-	a.NoError(err)
-	a.True(status.LastRound < waitForRound)
-
-	// Now, kill the secondary and restart it to reinitiate inbound connection
+	// stop the secondary, which is on round 3 or more.
 	nc.FullStop()
-	_, err = fixture.StartNode(nc.GetDataDir())
+
+	// Now, start both primary and secondary, and let the primary catchup up.
+	fixture.Start()
+	lg, err := fixture.StartNode(ncPrim.GetDataDir())
 	a.NoError(err)
 
 	// Now, catch up


### PR DESCRIPTION
## Summary

The TestCatchupOverGossip was randomly failing during testing on slow machines. The culprit was that we were making few performance related assumptions, which were not correct. In this case, we started a network, and shut it right away. The assumption was that the network would not be able to make any progress since it was shut down right away. This is not guaranteed to be the case. The better way to make sure no progress is made on a node is to prevent it from running at all.