### PR TITLE
Match msgp version in configure dev deps and go.mod

### DIFF
--- a/scripts/configure_dev-deps.sh
+++ b/scripts/configure_dev-deps.sh
@@ -4,7 +4,13 @@ set -ex
 
 function install_go_module {
     local OUTPUT
-    OUTPUT=$(GO111MODULE=off go get -u "$1" 2>&1)
+    # Match msgp version to go.mod version
+    if [ "$1" = "github.com/algorand/msgp" ]; then
+	VERSION=$(cd $(dirname "$0") && cat ../go.mod | grep msgp | awk -F " " '{print $NF}')
+	OUTPUT=$(GO111MODULE=on go get -u "$1@${VERSION}" 2>&1)
+    else
+	OUTPUT=$(GO111MODULE=off go get -u "$1" 2>&1)
+    fi
     if [ "${OUTPUT}" != "" ]; then
         echo "error: executing \"go get -u $1\" failed : ${OUTPUT}"
         exit 1


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

The configure_dev-deps.sh script installs latest msgp, which conflicts with the later request to install a specific msgp version in go.mod. This is a quick fix to grep the version from go.mod and use it in the case of msgp.

This appears to be the only module referenced in configure_dev-deps.sh and go.mod.

## Test Plan

Attempt a build based on a branch that does not include a latest version of msgp, but includes this commit.
