### PR TITLE
Revert "Match msgp version in configure dev deps and go.mod"

### DIFF
--- a/scripts/configure_dev-deps.sh
+++ b/scripts/configure_dev-deps.sh
@@ -2,24 +2,9 @@
 
 set -ex
 
-function get_go_version {
-    (
-	cd $(dirname "$0")
-	VERSION=$(cat ../go.mod | grep "$1" 2>/dev/null | awk -F " " '{print $2}')
-	echo $VERSION
-    )
-    return
-}
-
 function install_go_module {
     local OUTPUT
-    # Check for version to go.mod version
-    VERSION=$(get_go_version "$1")
-    if [ -z "$VERSION" ]; then
-     	OUTPUT=$(GO111MODULE=off go get -u "$1" 2>&1)
-    else
-     	OUTPUT=$(cd && GO111MODULE=on go get "$1@${VERSION}" 2>&1)
-    fi
+    OUTPUT=$(GO111MODULE=off go get -u "$1" 2>&1)
     if [ "${OUTPUT}" != "" ]; then
         echo "error: executing \"go get -u $1\" failed : ${OUTPUT}"
         exit 1


### PR DESCRIPTION
Reverts algorand/go-algorand#1150

There is concern this may be breaking Travis tests, so reverting for previous behavior.
