### PR TITLE
Bugfix - don't use output for error detection

### DIFF
--- a/scripts/configure_dev-deps.sh
+++ b/scripts/configure_dev-deps.sh
@@ -20,8 +20,8 @@ function install_go_module {
     else
      	OUTPUT=$(cd && GO111MODULE=on go get "$1@${VERSION}" 2>&1)
     fi
-    if [ "${OUTPUT}" != "" ]; then
-        echo "error: executing \"go get -u $1\" failed : ${OUTPUT}"
+    if [ $? != 0 ]; then
+        echo "error: executing \"go get $1\" failed : ${OUTPUT}"
         exit 1
     fi
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Fix bug in configure_dev-deps.sh - was using output for error checking instead of last exit code.

## Test Plan

Make sure tests pass.
