### PR TITLE
Bugfix: Better algoh parameter tunneling

### DIFF
--- a/cmd/algoh/main.go
+++ b/cmd/algoh/main.go
@@ -50,9 +50,7 @@ var telemetryOverride = flag.String("t", "", `Override telemetry setting if supp
 var peerOverride = flag.String("p", "", "Override phonebook with peer ip:port (or semicolon separated list: ip:port;ip:port;ip:port...)")
 var listenIP = flag.String("l", "", "Override config.EndpointAddress (REST listening address) with ip:port")
 var seed = flag.String("seed", "", "input to math/rand.Seed()")
-var branchCheck = flag.Bool("b", false, "Display the git branch behind the build")
-var channelCheck = flag.Bool("c", false, "Display and release channel behind the build")
-var initAndExit = flag.Bool("x", false, "Initialize the ledger and exit")
+var genesisFile = flag.String("g", "", "Genesis configuration file")
 
 const algodFileName = "algod"
 const goalFileName = "goal"

--- a/cmd/algoh/main.go
+++ b/cmd/algoh/main.go
@@ -44,6 +44,16 @@ var dataDirectory = flag.String("d", "", "Root Algorand daemon data path")
 var versionCheck = flag.Bool("v", false, "Display and write current build version and exit")
 var telemetryOverride = flag.String("t", "", `Override telemetry setting if supported (Use "true", "false", "0" or "1")`)
 
+// the following flags aren't being used by the algoh, but are needed so that the flag package won't complain that
+// these flags were provided but were not defined. We grab all the input flags and pass these downstream to the algod executable
+// as an input arguments.
+var peerOverride = flag.String("p", "", "Override phonebook with peer ip:port (or semicolon separated list: ip:port;ip:port;ip:port...)")
+var listenIP = flag.String("l", "", "Override config.EndpointAddress (REST listening address) with ip:port")
+var seed = flag.String("seed", "", "input to math/rand.Seed()")
+var branchCheck = flag.Bool("b", false, "Display the git branch behind the build")
+var channelCheck = flag.Bool("c", false, "Display and release channel behind the build")
+var initAndExit = flag.Bool("x", false, "Initialize the ledger and exit")
+
 const algodFileName = "algod"
 const goalFileName = "goal"
 


### PR DESCRIPTION
## Summary

Algoh is a host process, intended to monitor the child algod process. On algoh invocation, it starts the algod with the same input argument it was called upon.

Prior to this change, the following command line options, which were supported by algod would have been blocked by algoh:
1. -p
1. -l
1. -seed
1. -g

( note that this is not a complete list. There are other non-runnable, informational command line options which are still not supported. These provides little value )