### PR TITLE
Update code to take advantage of byteslice allocbounding

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -321,6 +321,14 @@ var MaxLogicSigMaxSize int
 // of the consensus protocols. used for decoding purposes.
 var MaxTxnNoteBytes int
 
+// MaxTxGroupSize is the largest supported number of transactions per transaction group supported by any
+// of the consensus protocols. used for decoding purposes.
+var MaxTxGroupSize int
+
+// MaxAppProgramLen is the largest supported app program size supported by any
+// of the consensus protocols. used for decoding purposes.
+var MaxAppProgramLen int
+
 func checkSetMax(value int, curMax *int) {
 	if value > *curMax {
 		*curMax = value
@@ -343,8 +351,11 @@ func checkSetAllocBounds(p ConsensusParams) {
 	// executed TEAL instructions should be fine (order of ~1000)
 	checkSetMax(p.MaxAppProgramLen, &MaxStateDeltaKeys)
 	checkSetMax(p.MaxAppProgramLen, &MaxEvalDeltaAccounts)
+
+	checkSetMax(p.MaxAppProgramLen, &MaxAppProgramLen)
 	checkSetMax(int(p.LogicSigMaxSize), &MaxLogicSigMaxSize)
 	checkSetMax(p.MaxTxnNoteBytes, &MaxTxnNoteBytes)
+	checkSetMax(p.MaxTxGroupSize, &MaxTxGroupSize)
 }
 
 // SaveConfigurableConsensus saves the configurable protocols file to the provided data directory.
@@ -409,6 +420,10 @@ func LoadConfigurableConsensusProtocols(dataDirectory string) error {
 	}
 	if newConsensus != nil {
 		Consensus = newConsensus
+		// Set allocation limits
+		for _, p := range Consensus {
+			checkSetAllocBounds(p)
+		}
 	}
 	return nil
 }

--- a/data/basics/msgp_gen.go
+++ b/data/basics/msgp_gen.go
@@ -1882,6 +1882,16 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
+			var zb0005 int
+			zb0005, err = msgp.ReadBytesBytesHeader(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "ApprovalProgram")
+				return
+			}
+			if zb0005 > config.MaxAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0005), uint64(config.MaxAppProgramLen))
+				return
+			}
 			(*z).ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApprovalProgram)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ApprovalProgram")
@@ -1890,6 +1900,16 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
+			var zb0006 int
+			zb0006, err = msgp.ReadBytesBytesHeader(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "ClearStateProgram")
+				return
+			}
+			if zb0006 > config.MaxAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxAppProgramLen))
+				return
+			}
 			(*z).ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ClearStateProgram)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ClearStateProgram")
@@ -1898,33 +1918,33 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0007 int
+			var zb0008 bool
+			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema")
 					return
 				}
-				if zb0005 > 0 {
-					zb0005--
+				if zb0007 > 0 {
+					zb0007--
 					(*z).LocalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema", "struct-from-array", "NumUint")
 						return
 					}
 				}
-				if zb0005 > 0 {
-					zb0005--
+				if zb0007 > 0 {
+					zb0007--
 					(*z).LocalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema", "struct-from-array", "NumByteSlice")
 						return
 					}
 				}
-				if zb0005 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0005)
+				if zb0007 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0007)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema", "struct-from-array")
 						return
@@ -1935,11 +1955,11 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema")
 					return
 				}
-				if zb0006 {
+				if zb0008 {
 					(*z).LocalStateSchema = StateSchema{}
 				}
-				for zb0005 > 0 {
-					zb0005--
+				for zb0007 > 0 {
+					zb0007--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema")
@@ -1970,33 +1990,33 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0007 int
-			var zb0008 bool
-			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0009 int
+			var zb0010 bool
+			zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema")
 					return
 				}
-				if zb0007 > 0 {
-					zb0007--
+				if zb0009 > 0 {
+					zb0009--
 					(*z).GlobalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema", "struct-from-array", "NumUint")
 						return
 					}
 				}
-				if zb0007 > 0 {
-					zb0007--
+				if zb0009 > 0 {
+					zb0009--
 					(*z).GlobalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema", "struct-from-array", "NumByteSlice")
 						return
 					}
 				}
-				if zb0007 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0007)
+				if zb0009 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0009)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema", "struct-from-array")
 						return
@@ -2007,11 +2027,11 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema")
 					return
 				}
-				if zb0008 {
+				if zb0010 {
 					(*z).GlobalStateSchema = StateSchema{}
 				}
-				for zb0007 > 0 {
-					zb0007--
+				for zb0009 > 0 {
+					zb0009--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema")
@@ -2042,27 +2062,27 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0009 int
-			var zb0010 bool
-			zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0011 int
+			var zb0012 bool
+			zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "GlobalState")
 				return
 			}
-			if zb0009 > encodedMaxKeyValueEntries {
-				err = msgp.ErrOverflow(uint64(zb0009), uint64(encodedMaxKeyValueEntries))
+			if zb0011 > encodedMaxKeyValueEntries {
+				err = msgp.ErrOverflow(uint64(zb0011), uint64(encodedMaxKeyValueEntries))
 				err = msgp.WrapError(err, "struct-from-array", "GlobalState")
 				return
 			}
-			if zb0010 {
+			if zb0012 {
 				(*z).GlobalState = nil
 			} else if (*z).GlobalState == nil {
-				(*z).GlobalState = make(TealKeyValue, zb0009)
+				(*z).GlobalState = make(TealKeyValue, zb0011)
 			}
-			for zb0009 > 0 {
+			for zb0011 > 0 {
 				var zb0001 string
 				var zb0002 TealValue
-				zb0009--
+				zb0011--
 				zb0001, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "GlobalState")
@@ -2100,45 +2120,65 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "approv":
+				var zb0013 int
+				zb0013, err = msgp.ReadBytesBytesHeader(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ApprovalProgram")
+					return
+				}
+				if zb0013 > config.MaxAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0013), uint64(config.MaxAppProgramLen))
+					return
+				}
 				(*z).ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApprovalProgram)
 				if err != nil {
 					err = msgp.WrapError(err, "ApprovalProgram")
 					return
 				}
 			case "clearp":
+				var zb0014 int
+				zb0014, err = msgp.ReadBytesBytesHeader(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ClearStateProgram")
+					return
+				}
+				if zb0014 > config.MaxAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0014), uint64(config.MaxAppProgramLen))
+					return
+				}
 				(*z).ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ClearStateProgram)
 				if err != nil {
 					err = msgp.WrapError(err, "ClearStateProgram")
 					return
 				}
 			case "lsch":
-				var zb0011 int
-				var zb0012 bool
-				zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
+				var zb0015 int
+				var zb0016 bool
+				zb0015, zb0016, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0015, zb0016, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "LocalStateSchema")
 						return
 					}
-					if zb0011 > 0 {
-						zb0011--
+					if zb0015 > 0 {
+						zb0015--
 						(*z).LocalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "LocalStateSchema", "struct-from-array", "NumUint")
 							return
 						}
 					}
-					if zb0011 > 0 {
-						zb0011--
+					if zb0015 > 0 {
+						zb0015--
 						(*z).LocalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "LocalStateSchema", "struct-from-array", "NumByteSlice")
 							return
 						}
 					}
-					if zb0011 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0011)
+					if zb0015 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0015)
 						if err != nil {
 							err = msgp.WrapError(err, "LocalStateSchema", "struct-from-array")
 							return
@@ -2149,11 +2189,11 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "LocalStateSchema")
 						return
 					}
-					if zb0012 {
+					if zb0016 {
 						(*z).LocalStateSchema = StateSchema{}
 					}
-					for zb0011 > 0 {
-						zb0011--
+					for zb0015 > 0 {
+						zb0015--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "LocalStateSchema")
@@ -2182,33 +2222,33 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 				}
 			case "gsch":
-				var zb0013 int
-				var zb0014 bool
-				zb0013, zb0014, bts, err = msgp.ReadMapHeaderBytes(bts)
+				var zb0017 int
+				var zb0018 bool
+				zb0017, zb0018, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0017, zb0018, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "GlobalStateSchema")
 						return
 					}
-					if zb0013 > 0 {
-						zb0013--
+					if zb0017 > 0 {
+						zb0017--
 						(*z).GlobalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "GlobalStateSchema", "struct-from-array", "NumUint")
 							return
 						}
 					}
-					if zb0013 > 0 {
-						zb0013--
+					if zb0017 > 0 {
+						zb0017--
 						(*z).GlobalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "GlobalStateSchema", "struct-from-array", "NumByteSlice")
 							return
 						}
 					}
-					if zb0013 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0013)
+					if zb0017 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0017)
 						if err != nil {
 							err = msgp.WrapError(err, "GlobalStateSchema", "struct-from-array")
 							return
@@ -2219,11 +2259,11 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "GlobalStateSchema")
 						return
 					}
-					if zb0014 {
+					if zb0018 {
 						(*z).GlobalStateSchema = StateSchema{}
 					}
-					for zb0013 > 0 {
-						zb0013--
+					for zb0017 > 0 {
+						zb0017--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "GlobalStateSchema")
@@ -2252,27 +2292,27 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 				}
 			case "gs":
-				var zb0015 int
-				var zb0016 bool
-				zb0015, zb0016, bts, err = msgp.ReadMapHeaderBytes(bts)
+				var zb0019 int
+				var zb0020 bool
+				zb0019, zb0020, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GlobalState")
 					return
 				}
-				if zb0015 > encodedMaxKeyValueEntries {
-					err = msgp.ErrOverflow(uint64(zb0015), uint64(encodedMaxKeyValueEntries))
+				if zb0019 > encodedMaxKeyValueEntries {
+					err = msgp.ErrOverflow(uint64(zb0019), uint64(encodedMaxKeyValueEntries))
 					err = msgp.WrapError(err, "GlobalState")
 					return
 				}
-				if zb0016 {
+				if zb0020 {
 					(*z).GlobalState = nil
 				} else if (*z).GlobalState == nil {
-					(*z).GlobalState = make(TealKeyValue, zb0015)
+					(*z).GlobalState = make(TealKeyValue, zb0019)
 				}
-				for zb0015 > 0 {
+				for zb0019 > 0 {
 					var zb0001 string
 					var zb0002 TealValue
-					zb0015--
+					zb0019--
 					zb0001, bts, err = msgp.ReadStringBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "GlobalState")

--- a/data/basics/userBalance.go
+++ b/data/basics/userBalance.go
@@ -200,8 +200,8 @@ type AppLocalState struct {
 type AppParams struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	ApprovalProgram   []byte      `codec:"approv"`
-	ClearStateProgram []byte      `codec:"clearp"`
+	ApprovalProgram   []byte      `codec:"approv,allocbound=config.MaxAppProgramLen"`
+	ClearStateProgram []byte      `codec:"clearp,allocbound=config.MaxAppProgramLen"`
 	LocalStateSchema  StateSchema `codec:"lsch"`
 	GlobalStateSchema StateSchema `codec:"gsch"`
 

--- a/data/bookkeeping/genesis.go
+++ b/data/bookkeeping/genesis.go
@@ -23,6 +23,14 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 )
 
+const (
+	// MaxInitialGenesisAllocationSize is the maximum number of accounts that are supported when
+	// bootstrapping a new network. The number of account *can* grow further after the bootstrapping.
+	// This value is used exclusively for the messagepack decoder, and has no affect on the network
+	// capabilities/capacity in any way.
+	MaxInitialGenesisAllocationSize = 100000000
+)
+
 // A Genesis object defines an Algorand "universe" -- a set of nodes that can
 // talk to each other, agree on the ledger contents, etc.  This is defined
 // by the initial account states (GenesisAllocation), the initial
@@ -47,7 +55,7 @@ type Genesis struct {
 	Proto protocol.ConsensusVersion `codec:"proto"`
 
 	// Allocation determines the initial accounts and their state.
-	Allocation []GenesisAllocation `codec:"alloc,allocbound=-"`
+	Allocation []GenesisAllocation `codec:"alloc,allocbound=MaxInitialGenesisAllocationSize"`
 
 	// RewardsPool is the address of the rewards pool.
 	RewardsPool string `codec:"rwd"`

--- a/data/bookkeeping/msgp_gen.go
+++ b/data/bookkeeping/msgp_gen.go
@@ -1565,6 +1565,11 @@ func (z *Genesis) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "struct-from-array", "Allocation")
 				return
 			}
+			if zb0004 > MaxInitialGenesisAllocationSize {
+				err = msgp.ErrOverflow(uint64(zb0004), uint64(MaxInitialGenesisAllocationSize))
+				err = msgp.WrapError(err, "struct-from-array", "Allocation")
+				return
+			}
 			if zb0005 {
 				(*z).Allocation = nil
 			} else if (*z).Allocation != nil && cap((*z).Allocation) >= zb0004 {
@@ -1658,6 +1663,11 @@ func (z *Genesis) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				var zb0007 bool
 				zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
+					err = msgp.WrapError(err, "Allocation")
+					return
+				}
+				if zb0006 > MaxInitialGenesisAllocationSize {
+					err = msgp.ErrOverflow(uint64(zb0006), uint64(MaxInitialGenesisAllocationSize))
 					err = msgp.WrapError(err, "Allocation")
 					return
 				}

--- a/data/transactions/application.go
+++ b/data/transactions/application.go
@@ -88,8 +88,8 @@ type ApplicationCallTxnFields struct {
 
 	LocalStateSchema  basics.StateSchema `codec:"apls"`
 	GlobalStateSchema basics.StateSchema `codec:"apgs"`
-	ApprovalProgram   []byte             `codec:"apap"`
-	ClearStateProgram []byte             `codec:"apsu"`
+	ApprovalProgram   []byte             `codec:"apap,allocbound=config.MaxAppProgramLen"`
+	ClearStateProgram []byte             `codec:"apsu,allocbound=config.MaxAppProgramLen"`
 
 	// If you add any fields here, remember you MUST modify the Empty
 	// method below!

--- a/data/transactions/msgp_gen.go
+++ b/data/transactions/msgp_gen.go
@@ -433,6 +433,16 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 		}
 		if zb0004 > 0 {
 			zb0004--
+			var zb0013 int
+			zb0013, err = msgp.ReadBytesBytesHeader(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "ApprovalProgram")
+				return
+			}
+			if zb0013 > config.MaxAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0013), uint64(config.MaxAppProgramLen))
+				return
+			}
 			(*z).ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApprovalProgram)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ApprovalProgram")
@@ -441,6 +451,16 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 		}
 		if zb0004 > 0 {
 			zb0004--
+			var zb0014 int
+			zb0014, err = msgp.ReadBytesBytesHeader(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "ClearStateProgram")
+				return
+			}
+			if zb0014 > config.MaxAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0014), uint64(config.MaxAppProgramLen))
+				return
+			}
 			(*z).ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ClearStateProgram)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ClearStateProgram")
@@ -478,33 +498,33 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 				}
 			case "apan":
 				{
-					var zb0013 uint64
-					zb0013, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0015 uint64
+					zb0015, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "OnCompletion")
 						return
 					}
-					(*z).OnCompletion = OnCompletion(zb0013)
+					(*z).OnCompletion = OnCompletion(zb0015)
 				}
 			case "apaa":
-				var zb0014 int
-				var zb0015 bool
-				zb0014, zb0015, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				var zb0016 int
+				var zb0017 bool
+				zb0016, zb0017, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ApplicationArgs")
 					return
 				}
-				if zb0014 > encodedMaxApplicationArgs {
-					err = msgp.ErrOverflow(uint64(zb0014), uint64(encodedMaxApplicationArgs))
+				if zb0016 > encodedMaxApplicationArgs {
+					err = msgp.ErrOverflow(uint64(zb0016), uint64(encodedMaxApplicationArgs))
 					err = msgp.WrapError(err, "ApplicationArgs")
 					return
 				}
-				if zb0015 {
+				if zb0017 {
 					(*z).ApplicationArgs = nil
-				} else if (*z).ApplicationArgs != nil && cap((*z).ApplicationArgs) >= zb0014 {
-					(*z).ApplicationArgs = ((*z).ApplicationArgs)[:zb0014]
+				} else if (*z).ApplicationArgs != nil && cap((*z).ApplicationArgs) >= zb0016 {
+					(*z).ApplicationArgs = ((*z).ApplicationArgs)[:zb0016]
 				} else {
-					(*z).ApplicationArgs = make([][]byte, zb0014)
+					(*z).ApplicationArgs = make([][]byte, zb0016)
 				}
 				for zb0001 := range (*z).ApplicationArgs {
 					(*z).ApplicationArgs[zb0001], bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationArgs[zb0001])
@@ -514,24 +534,24 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 					}
 				}
 			case "apat":
-				var zb0016 int
-				var zb0017 bool
-				zb0016, zb0017, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				var zb0018 int
+				var zb0019 bool
+				zb0018, zb0019, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Accounts")
 					return
 				}
-				if zb0016 > encodedMaxAccounts {
-					err = msgp.ErrOverflow(uint64(zb0016), uint64(encodedMaxAccounts))
+				if zb0018 > encodedMaxAccounts {
+					err = msgp.ErrOverflow(uint64(zb0018), uint64(encodedMaxAccounts))
 					err = msgp.WrapError(err, "Accounts")
 					return
 				}
-				if zb0017 {
+				if zb0019 {
 					(*z).Accounts = nil
-				} else if (*z).Accounts != nil && cap((*z).Accounts) >= zb0016 {
-					(*z).Accounts = ((*z).Accounts)[:zb0016]
+				} else if (*z).Accounts != nil && cap((*z).Accounts) >= zb0018 {
+					(*z).Accounts = ((*z).Accounts)[:zb0018]
 				} else {
-					(*z).Accounts = make([]basics.Address, zb0016)
+					(*z).Accounts = make([]basics.Address, zb0018)
 				}
 				for zb0002 := range (*z).Accounts {
 					bts, err = (*z).Accounts[zb0002].UnmarshalMsg(bts)
@@ -541,24 +561,24 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 					}
 				}
 			case "apfa":
-				var zb0018 int
-				var zb0019 bool
-				zb0018, zb0019, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				var zb0020 int
+				var zb0021 bool
+				zb0020, zb0021, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ForeignApps")
 					return
 				}
-				if zb0018 > encodedMaxForeignApps {
-					err = msgp.ErrOverflow(uint64(zb0018), uint64(encodedMaxForeignApps))
+				if zb0020 > encodedMaxForeignApps {
+					err = msgp.ErrOverflow(uint64(zb0020), uint64(encodedMaxForeignApps))
 					err = msgp.WrapError(err, "ForeignApps")
 					return
 				}
-				if zb0019 {
+				if zb0021 {
 					(*z).ForeignApps = nil
-				} else if (*z).ForeignApps != nil && cap((*z).ForeignApps) >= zb0018 {
-					(*z).ForeignApps = ((*z).ForeignApps)[:zb0018]
+				} else if (*z).ForeignApps != nil && cap((*z).ForeignApps) >= zb0020 {
+					(*z).ForeignApps = ((*z).ForeignApps)[:zb0020]
 				} else {
-					(*z).ForeignApps = make([]basics.AppIndex, zb0018)
+					(*z).ForeignApps = make([]basics.AppIndex, zb0020)
 				}
 				for zb0003 := range (*z).ForeignApps {
 					bts, err = (*z).ForeignApps[zb0003].UnmarshalMsg(bts)
@@ -580,12 +600,32 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 					return
 				}
 			case "apap":
+				var zb0022 int
+				zb0022, err = msgp.ReadBytesBytesHeader(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ApprovalProgram")
+					return
+				}
+				if zb0022 > config.MaxAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0022), uint64(config.MaxAppProgramLen))
+					return
+				}
 				(*z).ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApprovalProgram)
 				if err != nil {
 					err = msgp.WrapError(err, "ApprovalProgram")
 					return
 				}
 			case "apsu":
+				var zb0023 int
+				zb0023, err = msgp.ReadBytesBytesHeader(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ClearStateProgram")
+					return
+				}
+				if zb0023 > config.MaxAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0023), uint64(config.MaxAppProgramLen))
+					return
+				}
 				(*z).ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ClearStateProgram)
 				if err != nil {
 					err = msgp.WrapError(err, "ClearStateProgram")
@@ -4427,6 +4467,16 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0005 > 0 {
 			zb0005--
+			var zb0015 int
+			zb0015, err = msgp.ReadBytesBytesHeader(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "ApprovalProgram")
+				return
+			}
+			if zb0015 > config.MaxAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0015), uint64(config.MaxAppProgramLen))
+				return
+			}
 			(*z).ApplicationCallTxnFields.ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.ApprovalProgram)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ApprovalProgram")
@@ -4435,6 +4485,16 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0005 > 0 {
 			zb0005--
+			var zb0016 int
+			zb0016, err = msgp.ReadBytesBytesHeader(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "ClearStateProgram")
+				return
+			}
+			if zb0016 > config.MaxAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0016), uint64(config.MaxAppProgramLen))
+				return
+			}
 			(*z).ApplicationCallTxnFields.ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.ClearStateProgram)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ClearStateProgram")
@@ -4495,14 +4555,14 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			case "note":
-				var zb0015 int
-				zb0015, err = msgp.ReadBytesBytesHeader(bts)
+				var zb0017 int
+				zb0017, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Note")
 					return
 				}
-				if zb0015 > config.MaxTxnNoteBytes {
-					err = msgp.ErrOverflow(uint64(zb0015), uint64(config.MaxTxnNoteBytes))
+				if zb0017 > config.MaxTxnNoteBytes {
+					err = msgp.ErrOverflow(uint64(zb0017), uint64(config.MaxTxnNoteBytes))
 					return
 				}
 				(*z).Header.Note, bts, err = msgp.ReadBytesBytes(bts, (*z).Header.Note)
@@ -4662,33 +4722,33 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 			case "apan":
 				{
-					var zb0016 uint64
-					zb0016, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0018 uint64
+					zb0018, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "OnCompletion")
 						return
 					}
-					(*z).ApplicationCallTxnFields.OnCompletion = OnCompletion(zb0016)
+					(*z).ApplicationCallTxnFields.OnCompletion = OnCompletion(zb0018)
 				}
 			case "apaa":
-				var zb0017 int
-				var zb0018 bool
-				zb0017, zb0018, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				var zb0019 int
+				var zb0020 bool
+				zb0019, zb0020, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ApplicationArgs")
 					return
 				}
-				if zb0017 > encodedMaxApplicationArgs {
-					err = msgp.ErrOverflow(uint64(zb0017), uint64(encodedMaxApplicationArgs))
+				if zb0019 > encodedMaxApplicationArgs {
+					err = msgp.ErrOverflow(uint64(zb0019), uint64(encodedMaxApplicationArgs))
 					err = msgp.WrapError(err, "ApplicationArgs")
 					return
 				}
-				if zb0018 {
+				if zb0020 {
 					(*z).ApplicationCallTxnFields.ApplicationArgs = nil
-				} else if (*z).ApplicationCallTxnFields.ApplicationArgs != nil && cap((*z).ApplicationCallTxnFields.ApplicationArgs) >= zb0017 {
-					(*z).ApplicationCallTxnFields.ApplicationArgs = ((*z).ApplicationCallTxnFields.ApplicationArgs)[:zb0017]
+				} else if (*z).ApplicationCallTxnFields.ApplicationArgs != nil && cap((*z).ApplicationCallTxnFields.ApplicationArgs) >= zb0019 {
+					(*z).ApplicationCallTxnFields.ApplicationArgs = ((*z).ApplicationCallTxnFields.ApplicationArgs)[:zb0019]
 				} else {
-					(*z).ApplicationCallTxnFields.ApplicationArgs = make([][]byte, zb0017)
+					(*z).ApplicationCallTxnFields.ApplicationArgs = make([][]byte, zb0019)
 				}
 				for zb0002 := range (*z).ApplicationCallTxnFields.ApplicationArgs {
 					(*z).ApplicationCallTxnFields.ApplicationArgs[zb0002], bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.ApplicationArgs[zb0002])
@@ -4698,24 +4758,24 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 				}
 			case "apat":
-				var zb0019 int
-				var zb0020 bool
-				zb0019, zb0020, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				var zb0021 int
+				var zb0022 bool
+				zb0021, zb0022, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Accounts")
 					return
 				}
-				if zb0019 > encodedMaxAccounts {
-					err = msgp.ErrOverflow(uint64(zb0019), uint64(encodedMaxAccounts))
+				if zb0021 > encodedMaxAccounts {
+					err = msgp.ErrOverflow(uint64(zb0021), uint64(encodedMaxAccounts))
 					err = msgp.WrapError(err, "Accounts")
 					return
 				}
-				if zb0020 {
+				if zb0022 {
 					(*z).ApplicationCallTxnFields.Accounts = nil
-				} else if (*z).ApplicationCallTxnFields.Accounts != nil && cap((*z).ApplicationCallTxnFields.Accounts) >= zb0019 {
-					(*z).ApplicationCallTxnFields.Accounts = ((*z).ApplicationCallTxnFields.Accounts)[:zb0019]
+				} else if (*z).ApplicationCallTxnFields.Accounts != nil && cap((*z).ApplicationCallTxnFields.Accounts) >= zb0021 {
+					(*z).ApplicationCallTxnFields.Accounts = ((*z).ApplicationCallTxnFields.Accounts)[:zb0021]
 				} else {
-					(*z).ApplicationCallTxnFields.Accounts = make([]basics.Address, zb0019)
+					(*z).ApplicationCallTxnFields.Accounts = make([]basics.Address, zb0021)
 				}
 				for zb0003 := range (*z).ApplicationCallTxnFields.Accounts {
 					bts, err = (*z).ApplicationCallTxnFields.Accounts[zb0003].UnmarshalMsg(bts)
@@ -4725,24 +4785,24 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 				}
 			case "apfa":
-				var zb0021 int
-				var zb0022 bool
-				zb0021, zb0022, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				var zb0023 int
+				var zb0024 bool
+				zb0023, zb0024, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ForeignApps")
 					return
 				}
-				if zb0021 > encodedMaxForeignApps {
-					err = msgp.ErrOverflow(uint64(zb0021), uint64(encodedMaxForeignApps))
+				if zb0023 > encodedMaxForeignApps {
+					err = msgp.ErrOverflow(uint64(zb0023), uint64(encodedMaxForeignApps))
 					err = msgp.WrapError(err, "ForeignApps")
 					return
 				}
-				if zb0022 {
+				if zb0024 {
 					(*z).ApplicationCallTxnFields.ForeignApps = nil
-				} else if (*z).ApplicationCallTxnFields.ForeignApps != nil && cap((*z).ApplicationCallTxnFields.ForeignApps) >= zb0021 {
-					(*z).ApplicationCallTxnFields.ForeignApps = ((*z).ApplicationCallTxnFields.ForeignApps)[:zb0021]
+				} else if (*z).ApplicationCallTxnFields.ForeignApps != nil && cap((*z).ApplicationCallTxnFields.ForeignApps) >= zb0023 {
+					(*z).ApplicationCallTxnFields.ForeignApps = ((*z).ApplicationCallTxnFields.ForeignApps)[:zb0023]
 				} else {
-					(*z).ApplicationCallTxnFields.ForeignApps = make([]basics.AppIndex, zb0021)
+					(*z).ApplicationCallTxnFields.ForeignApps = make([]basics.AppIndex, zb0023)
 				}
 				for zb0004 := range (*z).ApplicationCallTxnFields.ForeignApps {
 					bts, err = (*z).ApplicationCallTxnFields.ForeignApps[zb0004].UnmarshalMsg(bts)
@@ -4764,12 +4824,32 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			case "apap":
+				var zb0025 int
+				zb0025, err = msgp.ReadBytesBytesHeader(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ApprovalProgram")
+					return
+				}
+				if zb0025 > config.MaxAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0025), uint64(config.MaxAppProgramLen))
+					return
+				}
 				(*z).ApplicationCallTxnFields.ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.ApprovalProgram)
 				if err != nil {
 					err = msgp.WrapError(err, "ApprovalProgram")
 					return
 				}
 			case "apsu":
+				var zb0026 int
+				zb0026, err = msgp.ReadBytesBytesHeader(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ClearStateProgram")
+					return
+				}
+				if zb0026 > config.MaxAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0026), uint64(config.MaxAppProgramLen))
+					return
+				}
 				(*z).ApplicationCallTxnFields.ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.ClearStateProgram)
 				if err != nil {
 					err = msgp.WrapError(err, "ClearStateProgram")
@@ -4876,6 +4956,11 @@ func (z *TxGroup) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "struct-from-array", "TxGroupHashes")
 				return
 			}
+			if zb0004 > config.MaxTxGroupSize {
+				err = msgp.ErrOverflow(uint64(zb0004), uint64(config.MaxTxGroupSize))
+				err = msgp.WrapError(err, "struct-from-array", "TxGroupHashes")
+				return
+			}
 			if zb0005 {
 				(*z).TxGroupHashes = nil
 			} else if (*z).TxGroupHashes != nil && cap((*z).TxGroupHashes) >= zb0004 {
@@ -4919,6 +5004,11 @@ func (z *TxGroup) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				var zb0007 bool
 				zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
+					err = msgp.WrapError(err, "TxGroupHashes")
+					return
+				}
+				if zb0006 > config.MaxTxGroupSize {
+					err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxTxGroupSize))
 					err = msgp.WrapError(err, "TxGroupHashes")
 					return
 				}

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -180,7 +180,7 @@ type TxGroup struct {
 	// together, sequentially, in a block in order for the group to be
 	// valid.  Each hash in the list is a hash of a transaction with
 	// the `Group` field omitted.
-	TxGroupHashes []crypto.Digest `codec:"txlist,allocbound=-"`
+	TxGroupHashes []crypto.Digest `codec:"txlist,allocbound=config.MaxTxGroupSize"`
 }
 
 // ToBeHashed implements the crypto.Hashable interface.


### PR DESCRIPTION
## Summary

Add a allocbound for the byte slices definition in our code that gets message-packed.
The unit testing is verifying that we didn't miss any additional instance.

## Test Plan

Auto-generated tests were updated, and detection of missing allocbound tag testing was updated.