### PR TITLE
Fix path to gpg-fake.sh script

### DIFF
--- a/scripts/release/test/stage/test/task.sh
+++ b/scripts/release/test/stage/test/task.sh
@@ -9,7 +9,7 @@ date "+build_release begin TEST stage %Y%m%d_%H%M%S"
 echo
 
 echo Setup GPG
-"${HOME}"/go/src/github.com/algorand/go-algorand/scripts/release/test/gpg-fake.sh
+"${HOME}"/go/src/github.com/algorand/go-algorand/scripts/release/test/util/gpg-fake.sh
 
 "${HOME}"/go/src/github.com/algorand/go-algorand/scripts/release/test/deb/run_ubuntu.sh
 date "+build_release done testing ubuntu %Y%m%d_%H%M%S"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

The gpg-fake script was recently moved, but the path was incorrectly updated.

## Test Plan

Ensure test pipeline works correctly.
