### PR TITLE
Handle stopping and aborting in catchpoint catchup service

### DIFF
--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -568,7 +568,8 @@ func (cs *CatchpointCatchupService) abort(originatingErr error) error {
 	}
 	cs.updateNodeCatchupMode(false)
 	// we want to abort the catchpoint catchup process, and the node already reverted to normal operation.
-	// at this point, all we need to do is to abort the run function.
+	// as part of the returning to normal operation, we've re-created our context. This context need to be
+	// canceled so that when we go back to run(), we would exit from there right away.
 	cs.cancelCtxFunc()
 	return outError
 }

--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -146,6 +146,9 @@ func (cs *CatchpointCatchupService) Start(ctx context.Context) {
 
 // Abort aborts the catchpoint catchup process
 func (cs *CatchpointCatchupService) Abort() {
+	// In order to abort the catchpoint catchup process, we need to first set the flag of abortCtxFunc, and follow that by canceling the main context.
+	// The order of these calls is crucial : The various stages are blocked on the main context. When that one expires, it uses the abort context to determine
+	// if the cancelation meaning that we want to shut down the process, or aborting the catchpoint catchup completly.
 	cs.abortCtxFunc()
 	cs.cancelCtxFunc()
 }


### PR DESCRIPTION
## Summary

When the node is in fast catchup mode, either stopping the node or aborting the catchup does not work in fashionable manner.
The stop/abort operation is expected to happen right away, whereas we had some long delays before it would complete.

## Test Plan

Both node stopping during fast catchup as well as aborting the fast catchup were tested manually.
I was able to confirm the issue with both of them, as well as confirm that the issue was resolved after the change.