### PR TITLE
Fix deb package name

### DIFF
--- a/scripts/release/mule/package/deb/package.sh
+++ b/scripts/release/mule/package/deb/package.sh
@@ -117,7 +117,7 @@ sed 's/^$/./g' < COPYING | sed 's/^/ /g' >> "${PKG_ROOT}/DEBIAN/copyright"
 mkdir -p "${PKG_ROOT}/usr/share/doc/algorand"
 cp -p "${PKG_ROOT}/DEBIAN/copyright" "${PKG_ROOT}/usr/share/doc/algorand/copyright"
 
-OUTPUT="$OUTDIR/algorand_${VER}_${ARCH}.deb"
+OUTPUT="$OUTDIR/algorand_${CHANNEL}_${OS_TYPE}-${ARCH}_${VER}.deb"
 dpkg-deb --build "${PKG_ROOT}" "${OUTPUT}"
 
 echo


### PR DESCRIPTION
## Summary

The deb package name wasn't corrrect.  This adds the `CHANNEL` and the `OS_TYPE` and arranges the bits in the proper order.

## Test Plan

n/a
