### PR TITLE
Increase travis builtin vm.max_map_count

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,8 @@ jobs:
     - stage: build_release
       os: linux
       name: Ubuntu AMD64 Build
+      before_script:
+        - sudo sysctl -w vm.max_map_count=262144
       script:
         - ./scripts/travis/build_test.sh
     - # same stage, parallel job

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,9 @@ jobs:
     - stage: build_pr
       os: linux
       name: Ubuntu AMD64 Build
+      before_script:
+        - sudo sysctl -w vm.max_map_count=262144
       script:
-        - ps aux
         - scripts/travis/build_test.sh
     - # same stage, parallel job
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ jobs:
       os: linux
       name: Ubuntu AMD64 Build
       script:
+        - ps aux
         - scripts/travis/build_test.sh
     - # same stage, parallel job
       os: linux


### PR DESCRIPTION
## Summary

Travis builds are occasionally failing with the following error:
```
==21650==ERROR: ThreadSanitizer failed to allocate 0x80000 (524288) bytes of clock allocator (error code: 12)
2471FATAL: ThreadSanitizer CHECK failed: ./gotsan.cc:6976 "((0 && "unable to mmap")) != (0)" (0x0, 0x0)
2472FAIL	github.com/algorand/go-algorand/ledger	477.548s
2473Makefile:199: recipe for target 'short_test_target_github.com/algorand/go-algorand/ledger' failed
```
Error 12 above is "out of memory" error. 

If the underlying culprit is a limit of the map count, this should boost it up.
Note that the real consumer of the high-volume of mmaps is the go race detector ( or the underlaying ThreadSanitizer ).