### PR TITLE
rollback .travis.yml by removing the max_map_count change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,6 @@ jobs:
     - stage: build_pr
       os: linux
       name: Ubuntu AMD64 Build
-      before_script:
-        - sudo sysctl -w vm.max_map_count=262144
       script:
         - scripts/travis/build_test.sh
     - # same stage, parallel job
@@ -85,8 +83,6 @@ jobs:
     - stage: build_release
       os: linux
       name: Ubuntu AMD64 Build
-      before_script:
-        - sudo sysctl -w vm.max_map_count=262144
       script:
         - ./scripts/travis/build_test.sh
     - # same stage, parallel job


### PR DESCRIPTION
## Summary

Adding vm.max_map_count to travis did not helped to fix the observed issue #1175 was intended to solve. This PR rolls back the change.