### PR TITLE
Only add the latest version to the rpm repo

### DIFF
--- a/scripts/release/mule/deploy/rpm/deploy.sh
+++ b/scripts/release/mule/deploy/rpm/deploy.sh
@@ -3,9 +3,11 @@
 
 set -ex
 
+VERSION=$(./scripts/compute_build_number.sh -f)
+
 mule -f package-deploy.yaml package-deploy-setup-gnupg
 
-cd /root
+pushd /root
 tar jxf gnupg*.tar.bz2
 
 export PATH=/root/gnupg2/bin:"${PATH}"
@@ -22,10 +24,6 @@ else
     echo "no-autostart" >> .gnupg/gpg.conf
 fi
 
-#gpg --import /root/keys/dev.pub
-#gpg --import /root/keys/rpm.pub
-#rpmkeys --import /root/keys/rpm.pub
-
 echo "wat" | gpg -u rpm@algorand.com --clearsign
 
 cat << EOF > .rpmmacros
@@ -41,7 +39,7 @@ rpm.addSign(sys.argv[1], '')
 EOF
 
 mkdir rpmrepo
-for rpm in $(ls packages/rpm/stable/*.rpm)
+for rpm in $(ls packages/rpm/stable/*"$VERSION"*.rpm)
 do
     python2 rpmsign.py "$rpm"
     cp -p "$rpm" rpmrepo
@@ -50,6 +48,8 @@ done
 createrepo --database rpmrepo
 rm -f rpmrepo/repodata/repomd.xml.asc
 gpg -u rpm@algorand.com --detach-sign --armor rpmrepo/repodata/repomd.xml
+
+popd
 
 mule -f package-deploy.yaml package-deploy-rpm-repo
 


### PR DESCRIPTION
## Summary

This won't overwrite the current repo on s3.  It will append to it.  Doing it this way ensures that the latest release is downloaded and installed via `yum`.

## Test Plan

After running this script, go to a centos container and download the latest package to make sure it's the same one.