### PR TITLE
Add EnableDeveloperAPI configuration flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -317,6 +317,10 @@ type Local struct {
 
 	// CatchupLedgerDownloadRetryAttempts controls the number of attempt the block fetching would be attempted before giving up catching up to the provided catchpoint.
 	CatchupBlockDownloadRetryAttempts int `version[9]:"1000"`
+
+	// EnableDeveloperAPI enables teal/compile, teal/dryrun API endpoints.
+	// This functionlity is disabled by default.
+	EnableDeveloperAPI bool `version[9]:"false"`
 }
 
 // Filenames of config files within the configdir (e.g. ~/.algorand)

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -44,6 +44,7 @@ var defaultLocal = Local{
 	EnableAgreementTimeMetrics:            false,
 	EnableAssembleStats:                   false,
 	EnableBlockService:                    false,
+	EnableDeveloperAPI:                    false,
 	EnableGossipBlockService:              true,
 	EnableIncomingMessageFilter:           false,
 	EnableLedgerService:                   false,

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -64,6 +64,7 @@ type NodeInterface interface {
 	SuggestedFee() basics.MicroAlgos
 	StartCatchup(catchpoint string) error
 	AbortCatchup(catchpoint string) error
+	Config() config.Local
 }
 
 // RegisterParticipationKeys registers participation keys.
@@ -589,6 +590,10 @@ func (v2 *Handlers) AbortCatchup(ctx echo.Context, catchpoint string) error {
 // TealCompile compiles TEAL code to binary, return both binary and hash
 // (POST /v2/teal/compile)
 func (v2 *Handlers) TealCompile(ctx echo.Context) error {
+	// return early if teal compile is not allowed in node config
+	if !v2.Node.Config().EnableDeveloperAPI {
+		return ctx.String(http.StatusNotFound, "/teal/compile was not enabled in the configuration file by setting the EnableDeveloperAPI to true")
+	}
 	buf := new(bytes.Buffer)
 	ctx.Request().Body = http.MaxBytesReader(nil, ctx.Request().Body, maxTealSourceBytes)
 	buf.ReadFrom(ctx.Request().Body)

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -301,6 +301,7 @@ func tealCompileTest(t *testing.T, bytesToUse []byte, expectedCode int) {
 	defer releasefunc()
 	dummyShutdownChan := make(chan struct{})
 	mockNode := makeMockNode(mockLedger, t.Name())
+	mockNode.config.EnableDeveloperAPI = true
 	handler := v2.Handlers{
 		Node:     &mockNode,
 		Log:      logging.Base(),

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -293,7 +293,7 @@ func TestAbortCatchup(t *testing.T) {
 	abortCatchupTest(t, badCatchPoint, 400)
 }
 
-func tealCompileTest(t *testing.T, bytesToUse []byte, expectedCode int) {
+func tealCompileTest(t *testing.T, bytesToUse []byte, expectedCode int, enableDeveloperAPI bool) {
 	numAccounts := 1
 	numTransactions := 1
 	offlineAccounts := true
@@ -301,7 +301,7 @@ func tealCompileTest(t *testing.T, bytesToUse []byte, expectedCode int) {
 	defer releasefunc()
 	dummyShutdownChan := make(chan struct{})
 	mockNode := makeMockNode(mockLedger, t.Name())
-	mockNode.config.EnableDeveloperAPI = true
+	mockNode.config.EnableDeveloperAPI = enableDeveloperAPI
 	handler := v2.Handlers{
 		Node:     &mockNode,
 		Log:      logging.Base(),
@@ -317,11 +317,12 @@ func tealCompileTest(t *testing.T, bytesToUse []byte, expectedCode int) {
 }
 
 func TestTealCompile(t *testing.T) {
-	tealCompileTest(t, nil, 200) // nil program should work
+	tealCompileTest(t, nil, 200, true) // nil program should work
 	goodProgram := `int 1`
 	goodProgramBytes := []byte(goodProgram)
-	tealCompileTest(t, goodProgramBytes, 200)
+	tealCompileTest(t, goodProgramBytes, 200, true)
+	tealCompileTest(t, goodProgramBytes, 404, false)
 	badProgram := "bad program"
 	badProgramBytes := []byte(badProgram)
-	tealCompileTest(t, badProgramBytes, 400)
+	tealCompileTest(t, badProgramBytes, 400, true)
 }

--- a/daemon/algod/api/server/v2/test/helpers.go
+++ b/daemon/algod/api/server/v2/test/helpers.go
@@ -74,10 +74,11 @@ var poolAddrResponseGolden = generatedV2.AccountResponse{
 type mockNode struct {
 	ledger    *data.Ledger
 	genesisID string
+	config    config.Local
 }
 
 func makeMockNode(ledger *data.Ledger, genesisID string) mockNode {
-	return mockNode{ledger: ledger, genesisID: genesisID}
+	return mockNode{ledger: ledger, genesisID: genesisID, config: config.GetDefaultLocal()}
 }
 
 func (m mockNode) Ledger() *data.Ledger {
@@ -116,7 +117,7 @@ func (m mockNode) SuggestedFee() basics.MicroAlgos {
 
 // unused by handlers:
 func (m mockNode) Config() config.Local {
-	return config.GetDefaultLocal()
+	return m.config
 }
 func (m mockNode) Start() {}
 

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -23,6 +23,7 @@
     "EnableAgreementTimeMetrics": false,
     "EnableAssembleStats": false,
     "EnableBlockService": false,
+    "EnableDeveloperAPI": false,
     "EnableGossipBlockService": true,
     "EnableIncomingMessageFilter": false,
     "EnableLedgerService": false,


### PR DESCRIPTION
## Summary

Add a local config to disable teal/compile in algod by default. This PR solves #1109.

The goal is to tie the TealCompile and DryRun in the algod REST endpoint with this new flag.
The DryRun functionality would be added with or after the application main PR, and this PR prepares the ground for that.

## Test Plan

Unit test was updated to use the new construct.
This is a spinoff of the original PR https://github.com/algorand/go-algorand/pull/1163 by Shumo.
