### PR TITLE
Fix route path to use echo parameter notation.

### DIFF
--- a/daemon/algod/api/server/router_test.go
+++ b/daemon/algod/api/server/router_test.go
@@ -53,20 +53,20 @@ func TestRoute(t *testing.T) {
 	func() {
 		ctx := e.NewContext(nil, nil)
 		e.Router().Find(http.MethodGet, "/v0/this/is/no/endpoint", ctx)
-		assert.Equal(t, ctx.Handler()(ctx), echo.ErrNotFound)
-		assert.Equal(t, calls, 0)
+		assert.Equal(t, echo.ErrNotFound, ctx.Handler()(ctx))
+		assert.Equal(t, 0, calls)
 	}()
 
 	// pending transaction extracted parameter
 	func() {
 		ctx := e.NewContext(nil, nil)
 		e.Router().Find(http.MethodGet, "/v1/account/address-param/transactions/pending", ctx)
-		assert.Equal(t, ctx.Path(), "/v1/account/:addr/transactions/pending")
-		assert.Equal(t, ctx.Param("addr"), "address-param")
+		assert.Equal(t, "/v1/account/:addr/transactions/pending", ctx.Path())
+		assert.Equal(t, "address-param", ctx.Param("addr"))
 
 		// Ensure that a handler in the route array was called by checking that the 'calls' variable is incremented.
 		callsBefore := calls
-		ctx.Handler()(ctx)
+		assert.Equal(t, nil, ctx.Handler()(ctx))
 		assert.Equal(t, callsBefore + 1, calls)
 	}()
 }

--- a/daemon/algod/api/server/router_test.go
+++ b/daemon/algod/api/server/router_test.go
@@ -33,19 +33,17 @@ func TestRoute(t *testing.T) {
 	// Registering v1 routes
 	registerHandlers(e, apiV1Tag, routes.V1Routes, lib.ReqContext{}, nil)
 
-	// Baseline, "method not found".
+	// Baseline, unknown endpoint
 	func() {
-		path := "/v0/this/is/no/endpoint"
 		ctx := e.NewContext(nil, nil)
-		e.Router().Find(http.MethodGet, path, ctx)
-		assert.Equal(t, ctx.Path(), path)
+		e.Router().Find(http.MethodGet, "/v0/this/is/no/endpoint", ctx)
+		assert.Equal(t, ctx.Handler()(ctx), echo.ErrNotFound)
 	}()
 
 	// pending transaction extracted parameter
 	func() {
-		path := "/v1/account/address-param/transactions/pending"
 		ctx := e.NewContext(nil, nil)
-		e.Router().Find(http.MethodGet, path, ctx)
+		e.Router().Find(http.MethodGet, "/v1/account/address-param/transactions/pending", ctx)
 		assert.Equal(t, ctx.Path(), "/v1/account/:addr/transactions/pending")
 		assert.Equal(t, ctx.Param("addr"), "address-param")
 	}()

--- a/daemon/algod/api/server/router_test.go
+++ b/daemon/algod/api/server/router_test.go
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
-
 package server
 
 import (
@@ -22,19 +21,23 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/algorand/go-algorand/daemon/algod/api/server/lib"
 	"github.com/algorand/go-algorand/daemon/algod/api/server/v1/routes"
 )
 
-func TestRoute(t *testing.T) {
-	e := echo.New()
-	calls := 0
+type TestSuite struct {
+	suite.Suite
+	calls int
+	e     *echo.Echo
+}
 
+func (s *TestSuite) SetupSuite() {
+	s.e = echo.New()
 	handler := func(context lib.ReqContext, context2 echo.Context) {
-		calls++
+		s.calls++
 	}
-
 	// Make a deep copy of the routes array with dummy handlers that log a call.
 	v1RoutesCopy := make([]lib.Route, len(routes.V1Routes))
 	for _, route := range routes.V1Routes {
@@ -45,28 +48,135 @@ func TestRoute(t *testing.T) {
 			HandlerFunc: handler,
 		})
 	}
-
 	// Registering v1 routes
-	registerHandlers(e, apiV1Tag, v1RoutesCopy, lib.ReqContext{})
+	registerHandlers(s.e, apiV1Tag, v1RoutesCopy, lib.ReqContext{})
+}
+func (s *TestSuite) SetupTest() {
+	s.calls = 0
+}
+func (s *TestSuite) TestBaselineRoute() {
+	ctx := s.e.NewContext(nil, nil)
+	s.e.Router().Find(http.MethodGet, "/v0/this/is/no/endpoint", ctx)
+	assert.Equal(s.T(), echo.ErrNotFound, ctx.Handler()(ctx))
+	assert.Equal(s.T(), 0, s.calls)
+}
+func (s *TestSuite) TestAccountPendingTransaction() {
+	ctx := s.e.NewContext(nil, nil)
+	s.e.Router().Find(http.MethodGet, "/v1/account/address-param/transactions/pending", ctx)
+	assert.Equal(s.T(), "/v1/account/:addr/transactions/pending", ctx.Path())
+	assert.Equal(s.T(), "address-param", ctx.Param("addr"))
 
-	// Baseline, unknown endpoint
-	func() {
-		ctx := e.NewContext(nil, nil)
-		e.Router().Find(http.MethodGet, "/v0/this/is/no/endpoint", ctx)
-		assert.Equal(t, echo.ErrNotFound, ctx.Handler()(ctx))
-		assert.Equal(t, 0, calls)
-	}()
+	// Ensure that a handler in the route array was called by checking that the 'calls' variable is incremented.
+	callsBefore := s.calls
+	assert.Equal(s.T(), nil, ctx.Handler()(ctx))
+	assert.Equal(s.T(), callsBefore+1, s.calls)
+}
+func (s *TestSuite) TestWaitAfterBlock() {
+	ctx := s.e.NewContext(nil, nil)
+	s.e.Router().Find(http.MethodGet, "/v1/status/wait-for-block-after/123456", ctx)
+	assert.Equal(s.T(), "/v1/status/wait-for-block-after/:round", ctx.Path())
+	assert.Equal(s.T(), "123456", ctx.Param("round"))
 
-	// pending transaction extracted parameter
-	func() {
-		ctx := e.NewContext(nil, nil)
-		e.Router().Find(http.MethodGet, "/v1/account/address-param/transactions/pending", ctx)
-		assert.Equal(t, "/v1/account/:addr/transactions/pending", ctx.Path())
-		assert.Equal(t, "address-param", ctx.Param("addr"))
+	// Ensure that a handler in the route array was called by checking that the 'calls' variable is incremented.
+	callsBefore := s.calls
+	assert.Equal(s.T(), nil, ctx.Handler()(ctx))
+	assert.Equal(s.T(), callsBefore+1, s.calls)
+}
+func (s *TestSuite) TestAccountInformation() {
+	ctx := s.e.NewContext(nil, nil)
+	s.e.Router().Find(http.MethodGet, "/v1/account/ZBBRQD73JH5KZ7XRED6GALJYJUXOMBBP3X2Z2XFA4LATV3MUJKKMKG7SHA", ctx)
+	assert.Equal(s.T(), "/v1/account/:addr", ctx.Path())
+	assert.Equal(s.T(), "ZBBRQD73JH5KZ7XRED6GALJYJUXOMBBP3X2Z2XFA4LATV3MUJKKMKG7SHA", ctx.Param("addr"))
 
-		// Ensure that a handler in the route array was called by checking that the 'calls' variable is incremented.
-		callsBefore := calls
-		assert.Equal(t, nil, ctx.Handler()(ctx))
-		assert.Equal(t, callsBefore + 1, calls)
-	}()
+	// Ensure that a handler in the route array was called by checking that the 'calls' variable is incremented.
+	callsBefore := s.calls
+	assert.Equal(s.T(), nil, ctx.Handler()(ctx))
+	assert.Equal(s.T(), callsBefore+1, s.calls)
+}
+func (s *TestSuite) TestTransactionInformation() {
+	ctx := s.e.NewContext(nil, nil)
+	addr := "ZBBRQD73JH5KZ7XRED6GALJYJUXOMBBP3X2Z2XFA4LATV3MUJKKMKG7SHA"
+	txid := "ASPB5E72OT2UWSOCQGD5OPT3W4KV4LZZDL7L5MBCC3EBAIJCDHAA"
+	s.e.Router().Find(http.MethodGet, "/v1/account/"+addr+"/transaction/"+txid, ctx)
+	assert.Equal(s.T(), "/v1/account/:addr/transaction/:txid", ctx.Path())
+	assert.Equal(s.T(), addr, ctx.Param("addr"))
+	assert.Equal(s.T(), txid, ctx.Param("txid"))
+
+	// Ensure that a handler in the route array was called by checking that the 'calls' variable is incremented.
+	callsBefore := s.calls
+	assert.Equal(s.T(), nil, ctx.Handler()(ctx))
+	assert.Equal(s.T(), callsBefore+1, s.calls)
+}
+func (s *TestSuite) TestAccountTransaction() {
+	ctx := s.e.NewContext(nil, nil)
+	addr := "ZBBRQD73JH5KZ7XRED6GALJYJUXOMBBP3X2Z2XFA4LATV3MUJKKMKG7SHA"
+	s.e.Router().Find(http.MethodGet, "/v1/account/"+addr+"/transactions", ctx)
+	assert.Equal(s.T(), "/v1/account/:addr/transactions", ctx.Path())
+	assert.Equal(s.T(), addr, ctx.Param("addr"))
+
+	// Ensure that a handler in the route array was called by checking that the 'calls' variable is incremented.
+	callsBefore := s.calls
+	assert.Equal(s.T(), nil, ctx.Handler()(ctx))
+	assert.Equal(s.T(), callsBefore+1, s.calls)
+}
+func (s *TestSuite) TestBlock() {
+	ctx := s.e.NewContext(nil, nil)
+	s.e.Router().Find(http.MethodGet, "/v1/block/123456", ctx)
+	assert.Equal(s.T(), "/v1/block/:round", ctx.Path())
+	assert.Equal(s.T(), "123456", ctx.Param("round"))
+
+	// Ensure that a handler in the route array was called by checking that the 'calls' variable is incremented.
+	callsBefore := s.calls
+	assert.Equal(s.T(), nil, ctx.Handler()(ctx))
+	assert.Equal(s.T(), callsBefore+1, s.calls)
+}
+func (s *TestSuite) TestPendingTransactionID() {
+	ctx := s.e.NewContext(nil, nil)
+	txid := "ASPB5E72OT2UWSOCQGD5OPT3W4KV4LZZDL7L5MBCC3EBAIJCDHAA"
+	s.e.Router().Find(http.MethodGet, "/v1/transactions/pending/"+txid, ctx)
+	assert.Equal(s.T(), "/v1/transactions/pending/:txid", ctx.Path())
+	assert.Equal(s.T(), txid, ctx.Param("txid"))
+
+	// Ensure that a handler in the route array was called by checking that the 'calls' variable is incremented.
+	callsBefore := s.calls
+	assert.Equal(s.T(), nil, ctx.Handler()(ctx))
+	assert.Equal(s.T(), callsBefore+1, s.calls)
+}
+func (s *TestSuite) TestPendingTransactionInformationByAddress() {
+	ctx := s.e.NewContext(nil, nil)
+	addr := "ZBBRQD73JH5KZ7XRED6GALJYJUXOMBBP3X2Z2XFA4LATV3MUJKKMKG7SHA"
+	s.e.Router().Find(http.MethodGet, "/v1/account/"+addr+"/transactions/pending", ctx)
+	assert.Equal(s.T(), "/v1/account/:addr/transactions/pending", ctx.Path())
+	assert.Equal(s.T(), addr, ctx.Param("addr"))
+
+	// Ensure that a handler in the route array was called by checking that the 'calls' variable is incremented.
+	callsBefore := s.calls
+	assert.Equal(s.T(), nil, ctx.Handler()(ctx))
+	assert.Equal(s.T(), callsBefore+1, s.calls)
+}
+func (s *TestSuite) TestGetAsset() {
+	ctx := s.e.NewContext(nil, nil)
+	s.e.Router().Find(http.MethodGet, "/v1/asset/123456", ctx)
+	assert.Equal(s.T(), "/v1/asset/:index", ctx.Path())
+	assert.Equal(s.T(), "123456", ctx.Param("index"))
+
+	// Ensure that a handler in the route array was called by checking that the 'calls' variable is incremented.
+	callsBefore := s.calls
+	assert.Equal(s.T(), nil, ctx.Handler()(ctx))
+	assert.Equal(s.T(), callsBefore+1, s.calls)
+}
+func (s *TestSuite) TestGetTransactionByID() {
+	ctx := s.e.NewContext(nil, nil)
+	txid := "ASPB5E72OT2UWSOCQGD5OPT3W4KV4LZZDL7L5MBCC3EBAIJCDHAA"
+	s.e.Router().Find(http.MethodGet, "/v1/transaction/"+txid, ctx)
+	assert.Equal(s.T(), "/v1/transaction/:txid", ctx.Path())
+	assert.Equal(s.T(), txid, ctx.Param("txid"))
+
+	// Ensure that a handler in the route array was called by checking that the 'calls' variable is incremented.
+	callsBefore := s.calls
+	assert.Equal(s.T(), nil, ctx.Handler()(ctx))
+	assert.Equal(s.T(), callsBefore+1, s.calls)
+}
+func TestTestSuite(t *testing.T) {
+	suite.Run(t, new(TestSuite))
 }

--- a/daemon/algod/api/server/router_test.go
+++ b/daemon/algod/api/server/router_test.go
@@ -64,10 +64,9 @@ func TestRoute(t *testing.T) {
 		assert.Equal(t, ctx.Path(), "/v1/account/:addr/transactions/pending")
 		assert.Equal(t, ctx.Param("addr"), "address-param")
 
-		// A "real" handler should be found
+		// Ensure that a handler in the route array was called by checking that the 'calls' variable is incremented.
 		callsBefore := calls
 		ctx.Handler()(ctx)
-
 		assert.Equal(t, callsBefore + 1, calls)
 	}()
 }

--- a/daemon/algod/api/server/router_test.go
+++ b/daemon/algod/api/server/router_test.go
@@ -44,7 +44,7 @@ func TestRoute(t *testing.T) {
 	// pending transaction extracted parameter
 	func() {
 		path := "/v1/account/address-param/transactions/pending"
-		ctx := e.NewContext(nil, nil)//.(*context)
+		ctx := e.NewContext(nil, nil)
 		e.Router().Find(http.MethodGet, path, ctx)
 		assert.Equal(t, ctx.Path(), "/v1/account/:addr/transactions/pending")
 		assert.Equal(t, ctx.Param("addr"), "address-param")

--- a/daemon/algod/api/server/router_test.go
+++ b/daemon/algod/api/server/router_test.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/algorand/go-algorand/daemon/algod/api/server/lib"
+	"github.com/algorand/go-algorand/daemon/algod/api/server/v1/routes"
+)
+
+func TestRoute(t *testing.T) {
+	e := echo.New()
+
+	// Registering v1 routes
+	registerHandlers(e, apiV1Tag, routes.V1Routes, lib.ReqContext{}, nil)
+
+	// Baseline, "method not found".
+	func() {
+		path := "/v0/this/is/no/endpoint"
+		ctx := e.NewContext(nil, nil)
+		e.Router().Find(http.MethodGet, path, ctx)
+		assert.Equal(t, ctx.Path(), path)
+	}()
+
+	// pending transaction extracted parameter
+	func() {
+		path := "/v1/account/address-param/transactions/pending"
+		ctx := e.NewContext(nil, nil)//.(*context)
+		e.Router().Find(http.MethodGet, path, ctx)
+		assert.Equal(t, ctx.Path(), "/v1/account/:addr/transactions/pending")
+		assert.Equal(t, ctx.Param("addr"), "address-param")
+	}()
+}

--- a/daemon/algod/api/server/v1/routes/routes.go
+++ b/daemon/algod/api/server/v1/routes/routes.go
@@ -113,7 +113,7 @@ var V1Routes = lib.Routes{
 	lib.Route{
 		Name:        "pending-transaction-information-by-address",
 		Method:      "GET",
-		Path:        "/account/{addr}/transactions/pending",
+		Path:        "/account/:addr/transactions/pending",
 		HandlerFunc: handlers.GetPendingTransactionsByAddress,
 	},
 


### PR DESCRIPTION
##  Summary

When I converted the route path from Gorilla Mux notation to Echo I missed one of the parameters.

## Test Plan

Before:
```
$ curl "$(cat ~/.algorand/algod.net)/v1/account/invalid/transactions/pending" -H "Authorization: bearer $(cat ~/.algorand/algod.token)"
{"message":"Not Found"}

$ curl "$(cat ~/.algorand/algod.net)/v1/account/FCHLCNFIQ3L5QELMQDADI6BU2ANK2A2ICKXXG7ACJBNEAB64J7UJUPJHJE/transactions/pending" -H "Authorization: bearer $(cat ~/.algorand/algod.token)"
{"message":"Not Found"}
```

After:
```
$ curl "$(cat ~/.algorand/algod.net)/v1/account/invalid/transactions/pending" -H "Authorization: bearer $(cat ~/.algorand/algod.token)"
failed to parse the address

$ curl "$(cat ~/.algorand/algod.net)/v1/account/FCHLCNFIQ3L5QELMQDADI6BU2ANK2A2ICKXXG7ACJBNEAB64J7UJUPJHJE/transactions/pending" -H "Authorization: bearer $(cat ~/.algorand/algod.token)"
{"truncatedTxns":{},"totalTxns":0}
```