### PR TITLE
Update configure dev script to work with ubuntu 20.04

### DIFF
--- a/scripts/buildnumber.py
+++ b/scripts/buildnumber.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Computes a build number that is:
 # D[DD]HH

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -49,7 +49,7 @@ if [ "${OS}" = "linux" ]; then
     fi
 
     sudo apt-get update
-    sudo apt-get install -y libboost-all-dev expect jq autoconf shellcheck sqlite3 python3.7-venv
+    sudo apt-get install -y libboost-all-dev expect jq autoconf shellcheck sqlite3 python3-venv
 elif [ "${OS}" = "darwin" ]; then
     brew update
     brew tap homebrew/cask

--- a/test/scripts/timeout
+++ b/test/scripts/timeout
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Usage:
 #  timeout <integer seconds> subcommand args...


### PR DESCRIPTION
## Summary

`python3.7-venv` turned into `python3.8-venv` in ubuntu 20.04, use the default version instead.

## Test Plan

Setup a new machine with the script and see `make install` and `make integration` work.
This script is also used by travis, but travis has a wrapper script that is already using `python3-venv`.