### PR TITLE
Match go modules in dev deps to versions in go.mod

### DIFF
--- a/scripts/configure_dev-deps.sh
+++ b/scripts/configure_dev-deps.sh
@@ -20,8 +20,8 @@ function install_go_module {
     else
      	OUTPUT=$(cd && GO111MODULE=on go get "$1@${VERSION}" 2>&1)
     fi
-    if [ "${OUTPUT}" != "" ]; then
-        echo "error: executing \"go get -u $1\" failed : ${OUTPUT}"
+    if [ $? != 0 ]; then
+        echo "error: executing \"go get $1\" failed : ${OUTPUT}"
         exit 1
     fi
 }

--- a/scripts/configure_dev-deps.sh
+++ b/scripts/configure_dev-deps.sh
@@ -2,9 +2,24 @@
 
 set -ex
 
+function get_go_version {
+    (
+	cd $(dirname "$0")
+	VERSION=$(cat ../go.mod | grep "$1" 2>/dev/null | awk -F " " '{print $2}')
+	echo $VERSION
+    )
+    return
+}
+
 function install_go_module {
     local OUTPUT
-    OUTPUT=$(GO111MODULE=off go get -u "$1" 2>&1)
+    # Check for version to go.mod version
+    VERSION=$(get_go_version "$1")
+    if [ -z "$VERSION" ]; then
+     	OUTPUT=$(GO111MODULE=off go get -u "$1" 2>&1)
+    else
+     	OUTPUT=$(cd && GO111MODULE=on go get "$1@${VERSION}" 2>&1)
+    fi
     if [ "${OUTPUT}" != "" ]; then
         echo "error: executing \"go get -u $1\" failed : ${OUTPUT}"
         exit 1


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

The script to configure dev dependencies installs various supporting golang modules. However, these versions do not take into account entries in go.mod, which means the versions can conflict.

This is a restoration of a previous pull request, with the bug fix around handling error conditions.

## Test Plan

Successful builds in Travis.
