### PR TITLE
Fix random catchpoint catchup expect test case

### DIFF
--- a/test/e2e-go/cli/goal/expect/catchpointCatchupTest.exp
+++ b/test/e2e-go/cli/goal/expect/catchpointCatchupTest.exp
@@ -61,6 +61,12 @@ if { [catch {
     exec rm $TEST_ROOT_DIR/Primary/config.json
     exec mv $TEST_ROOT_DIR/Primary/config.json.new $TEST_ROOT_DIR/Primary/config.json
 
+    # Update the Second Node configuration
+    exec -- cat "$TEST_ROOT_DIR/Node/config.json" | jq {. |= . + {"CatchupParallelBlocks":2}} > $TEST_ROOT_DIR/Node/config.json.new
+    exec rm $TEST_ROOT_DIR/Node/config.json
+    exec mv $TEST_ROOT_DIR/Node/config.json.new $TEST_ROOT_DIR/Node/config.json
+
+
     set ::GLOBAL_TEST_ALGO_DIR $TEST_ALGO_DIR
     set ::GLOBAL_TEST_ROOT_DIR $TEST_ROOT_DIR
     set ::GLOBAL_NETWORK_NAME $NETWORK_NAME


### PR DESCRIPTION
## Summary

The test was creating a proxy which delays requests execution as a way to slow down the catchpoint catchup process.
This is important so that we can monitor from the goal command that the catchup is working as intended.
However, delaying the command execution caused an issue where the node was trying to issue multiple requests for blocks 1-16, in parallel, which reached the proxy at an arbitrary order. As a result, the request for block #1 was delayed by more than 4 second, causing it it timeout.

The solution was to reconfigure the number of parallel blocks being retrieved to 2. This would ensure that we only getting two blocks at a time. Since the delay is configured to 1.5 seconds, this would also be the delay, which is well under 4 second.
