### PR TITLE
Rename AppStateChage to AppStateChange.

### DIFF
--- a/cmd/tealdbg/cdtSession.go
+++ b/cmd/tealdbg/cdtSession.go
@@ -242,7 +242,7 @@ func (s *cdtSession) websocketHandler(w http.ResponseWriter, r *http.Request) {
 			case <-cdtUpdatedCh:
 				dbgStateMu.Lock()
 
-				appState := s.debugger.GetStates(&dbgState.AppStateChage)
+				appState := s.debugger.GetStates(&dbgState.AppStateChange)
 				state.Update(cdtStateUpdate{
 					dbgState.Stack, dbgState.Scratch,
 					dbgState.PC, dbgState.Line, dbgState.Error,

--- a/cmd/tealdbg/debugger.go
+++ b/cmd/tealdbg/debugger.go
@@ -53,7 +53,7 @@ type Control interface {
 
 	GetSourceMap() ([]byte, error)
 	GetSource() (string, []byte)
-	GetStates(changes *logic.AppStateChage) appState
+	GetStates(changes *logic.AppStateChange) appState
 }
 
 // Debugger is TEAL event-driven debugger
@@ -285,7 +285,7 @@ func (s *session) GetSource() (string, []byte) {
 	return s.programName, []byte(s.source)
 }
 
-func (s *session) GetStates(changes *logic.AppStateChage) appState {
+func (s *session) GetStates(changes *logic.AppStateChange) appState {
 	if changes == nil {
 		return s.states
 	}

--- a/data/transactions/logic/debugger.go
+++ b/data/transactions/logic/debugger.go
@@ -76,11 +76,11 @@ type DebugState struct {
 	Error   string             `codec:"error"`
 
 	// global/local state changes are updated every step. Stateful TEAL only.
-	AppStateChage
+	AppStateChange
 }
 
-// AppStateChage encapsulates global and local app state changes
-type AppStateChage struct {
+// AppStateChange encapsulates global and local app state changes
+type AppStateChange struct {
 	GlobalStateChanges basics.StateDelta                    `codec:"gsch"`
 	LocalStateChanges  map[basics.Address]basics.StateDelta `codec:"lsch"`
 }


### PR DESCRIPTION
This change fixes a presumed typo.