### PR TITLE
Implement database versioning support

### DIFF
--- a/util/db/versioning.go
+++ b/util/db/versioning.go
@@ -44,23 +44,31 @@ func SetUserVersion(ctx context.Context, tx *sql.Tx, userVersion int32) (previou
 	if err != nil {
 		return
 	}
+	if previousUserVersion == userVersion {
+		return
+	}
 	var result sql.Result
 	var rowsAffected int64
 	result, err = tx.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", userVersion))
 	if err != nil {
-		if err == ctx.Err() {
-			// if we're aborting due to context cancelation, just clear out the previous version.
-			// this is done so that the function result is consistant.
-			previousUserVersion = 0
-		}
+		// if we're aborting due to an error, clear the previousUserVersion so that
+		// on all error cases we'll be returning zero.
+		previousUserVersion = 0
 		return
 	}
 	rowsAffected, err = result.RowsAffected()
 	if err != nil {
+		// if we're aborting due to an error, clear the previousUserVersion so that
+		// on all error cases we'll be returning zero.
+		previousUserVersion = 0
 		return
 	}
 	if rowsAffected != 0 {
 		err = fmt.Errorf("expected rows to be affected by updating user_version was 0, but %d rows got updated instead", rowsAffected)
+		// if we're aborting due to an error, clear the previousUserVersion so that
+		// on all error cases we'll be returning zero.
+		previousUserVersion = 0
+		return
 	}
 	return
 }

--- a/util/db/versioning.go
+++ b/util/db/versioning.go
@@ -47,24 +47,8 @@ func SetUserVersion(ctx context.Context, tx *sql.Tx, userVersion int32) (previou
 	if previousUserVersion == userVersion {
 		return
 	}
-	var result sql.Result
-	var rowsAffected int64
-	result, err = tx.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", userVersion))
+	_, err = tx.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", userVersion))
 	if err != nil {
-		// if we're aborting due to an error, clear the previousUserVersion so that
-		// on all error cases we'll be returning zero.
-		previousUserVersion = 0
-		return
-	}
-	rowsAffected, err = result.RowsAffected()
-	if err != nil {
-		// if we're aborting due to an error, clear the previousUserVersion so that
-		// on all error cases we'll be returning zero.
-		previousUserVersion = 0
-		return
-	}
-	if rowsAffected != 0 {
-		err = fmt.Errorf("expected rows to be affected by updating user_version was 0, but %d rows got updated instead", rowsAffected)
 		// if we're aborting due to an error, clear the previousUserVersion so that
 		// on all error cases we'll be returning zero.
 		previousUserVersion = 0

--- a/util/db/versioning.go
+++ b/util/db/versioning.go
@@ -1,0 +1,66 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// this file contains database versioning that can be applied to any sqlite database.
+
+// GetUserVersion returns the user version field stored in the sqlite database
+// if the database was never initiliazed with a version, it would return 0 as the version.
+func GetUserVersion(ctx context.Context, tx *sql.Tx) (userVersion int32, err error) {
+
+	err = tx.QueryRowContext(ctx, "PRAGMA user_version").Scan(&userVersion)
+	// it's not really supposed to happen with a user_version, since the above would always succeed, but
+	// we want to have it so that we can align with the SQL statements "correct handling practices".
+	if err == sql.ErrNoRows {
+		err = nil
+		userVersion = 0
+	}
+	return
+}
+
+// SetUserVersion sets the userVersion as the new user version, and return the old version.
+func SetUserVersion(ctx context.Context, tx *sql.Tx, userVersion int32) (previousUserVersion int32, err error) {
+	previousUserVersion, err = GetUserVersion(ctx, tx)
+	if err != nil {
+		return
+	}
+	var result sql.Result
+	var rowsAffected int64
+	result, err = tx.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", userVersion))
+	if err != nil {
+		if err == ctx.Err() {
+			// if we're aborting due to context cancelation, just clear out the previous version.
+			// this is done so that the function result is consistant.
+			previousUserVersion = 0
+		}
+		return
+	}
+	rowsAffected, err = result.RowsAffected()
+	if err != nil {
+		return
+	}
+	if rowsAffected != 0 {
+		err = fmt.Errorf("expected rows to be affected by updating user_version was 0, but %d rows got updated instead", rowsAffected)
+	}
+	return
+}

--- a/util/db/versioning_test.go
+++ b/util/db/versioning_test.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersioning(t *testing.T) {
+	acc, err := MakeAccessor("fn.db", false, true)
+	require.NoError(t, err)
+
+	conn, err := acc.Handle.Conn(context.Background())
+	require.NoError(t, err)
+
+	tx, err := conn.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable, ReadOnly: false})
+	require.NoError(t, err)
+
+	ver, err := GetUserVersion(context.Background(), tx)
+	require.NoError(t, err)
+	require.Equal(t, int32(0), ver)
+
+	previousVersion, err := SetUserVersion(context.Background(), tx, 5)
+	require.NoError(t, err)
+	require.Equal(t, int32(0), previousVersion)
+
+	previousVersion, err = SetUserVersion(context.Background(), tx, 9)
+	require.NoError(t, err)
+	require.Equal(t, int32(5), previousVersion)
+
+	// check that expired context doesn't work:
+	expiredContext, expiredContextCancelFunc := context.WithCancel(context.Background())
+	expiredContextCancelFunc()
+	ver, err = GetUserVersion(expiredContext, tx)
+	require.Equal(t, expiredContext.Err(), err)
+	require.Equal(t, int32(0), ver)
+
+	ver, err = SetUserVersion(expiredContext, tx, 15)
+	require.Equal(t, expiredContext.Err(), err)
+	require.Equal(t, int32(0), ver)
+
+	tx.Rollback()
+	conn.Close()
+	acc.Close()
+
+}


### PR DESCRIPTION
## Summary
This PR implements the core functionality for database versioning support.
In this PR, I haven't used it in any particular database. It's part of the support for reencoding the accounts.

- [x] Implement database versioning support
- [ ]  Extend Atomic callback to support context and long running operations
- [ ]  Implement reencoding of accounts
