### PR TITLE
Fix StateDelta conversion in Dryrun

### DIFF
--- a/daemon/algod/api/server/v2/dryrun_test.go
+++ b/daemon/algod/api/server/v2/dryrun_test.go
@@ -928,3 +928,47 @@ func TestDryrunRequestJSON(t *testing.T) {
 		logResponse(t, &response)
 	}
 }
+
+func TestStateDeltaToStateDelta(t *testing.T) {
+	t.Parallel()
+	sd := basics.StateDelta{
+		"intkey": {
+			Action: basics.SetUintAction,
+			Uint:   11,
+		},
+		"byteskey": {
+			Action: basics.SetBytesAction,
+			Bytes:  "test",
+		},
+		"delkey": {
+			Action: basics.DeleteAction,
+		},
+	}
+	gsd := StateDeltaToStateDelta(sd)
+	require.Equal(t, 3, len(*gsd))
+
+	var keys []string
+	// test with a loop because sd is a map and iteration order is random
+	for _, item := range *gsd {
+		if item.Key == "intkey" {
+			require.Equal(t, uint64(1), item.Value.Action)
+			require.NotNil(t, item.Value.Uint)
+			require.Equal(t, uint64(11), *item.Value.Uint)
+			require.Nil(t, item.Value.Bytes)
+		} else if item.Key == "byteskey" {
+			require.Equal(t, uint64(2), item.Value.Action)
+			require.Nil(t, item.Value.Uint)
+			require.NotNil(t, item.Value.Bytes)
+			require.Equal(t, base64.StdEncoding.EncodeToString([]byte("test")), *item.Value.Bytes)
+		} else if item.Key == "delkey" {
+			require.Equal(t, uint64(3), item.Value.Action)
+			require.Nil(t, item.Value.Uint)
+			require.Nil(t, item.Value.Bytes)
+		}
+		keys = append(keys, item.Key)
+	}
+	require.Equal(t, 3, len(keys))
+	require.Contains(t, keys, "intkey")
+	require.Contains(t, keys, "byteskey")
+	require.Contains(t, keys, "delkey")
+}


### PR DESCRIPTION
## Summary

StateDelta conversion in Dryrun incorrectly used pointers to in-loop variable.

## Test Plan

Added a unit test