### PR TITLE
Fix tealdbg CDT url

### DIFF
--- a/cmd/tealdbg/README.md
+++ b/cmd/tealdbg/README.md
@@ -28,7 +28,7 @@
     $ tealdbg debug samples/calls_count.teal --balance samples/calls_count_balance.json --txn samples/calls_count_txn.json --proto=future
     $ tealdbg debug samples/calls_count.teal --proto=future --painless
     ```
-    It prints out the URL to follow: `chrome-devtools://devtools/bundled/js_app.html?...`
+    It prints out the URL to follow: `devtools://devtools/bundled/js_app.html?...`
 2. Open the URL in Google Chrome.
   If you see the `This site can’t be reached` page, open Chrome DevTools [as explained](https://developers.google.com/web/tools/chrome-devtools/open) and refresh the page.
 

--- a/cmd/tealdbg/cdtdbg.go
+++ b/cmd/tealdbg/cdtdbg.go
@@ -127,8 +127,8 @@ func (a *CDTAdapter) enableWebsocketEndpoint(
 		Title:                     "Algorand TEAL program",
 		TabType:                   "node",
 		URL:                       "https://algorand.com/",
-		DevtoolsFrontendURL:       "chrome-devtools://devtools/bundled/js_app.html?experiments=true&v8only=false&ws=" + address,
-		DevtoolsFrontendURLCompat: "chrome-devtools://devtools/bundled/inspector.html?experiments=true&v8only=false&ws=" + address,
+		DevtoolsFrontendURL:       "devtools://devtools/bundled/js_app.html?experiments=true&v8only=false&ws=" + address,
+		DevtoolsFrontendURLCompat: "devtools://devtools/bundled/inspector.html?experiments=true&v8only=false&ws=" + address,
 		WebSocketDebuggerURL:      "ws://" + address,
 		FaviconURL:                "https://www.algorand.com/icons/icon-144x144.png",
 	}


### PR DESCRIPTION
## Summary

Newer versions of Google Chrome dropped chrome-devtools:// schema and use devtools:// instead

## Test Plan

Tested manually