### PR TITLE
Unattended deb upgrades fail because `origin` value is mixed case

### DIFF
--- a/installer/51algorand-upgrades
+++ b/installer/51algorand-upgrades
@@ -2,7 +2,7 @@
 ## unattended upgrades for the Algorand node software.
 
 Unattended-Upgrade::Allowed-Origins {
-  "Algorand:@CHANNEL@";
+  "algorand:@CHANNEL@";
 };
 
 Dpkg::Options {

--- a/installer/rpm/algorand.repo
+++ b/installer/rpm/algorand.repo
@@ -1,5 +1,5 @@
 [algorand]
-name=Algorand
+name=algorand
 baseurl=https://releases.algorand.com/rpm/stable/
 enabled=1
 gpgcheck=1

--- a/scripts/release/mule/deploy/deb/deploy.sh
+++ b/scripts/release/mule/deploy/deb/deploy.sh
@@ -71,7 +71,7 @@ SNAPSHOT="${CHANNEL}-${VERSION}"
 aptly repo create -distribution="$CHANNEL" -component=main algorand
 aptly repo add algorand "$DEBS_DIR"/*.deb
 aptly snapshot create "$SNAPSHOT" from repo algorand
-aptly publish snapshot -gpg-key="$SIGNING_KEY_ADDR" -origin=Algorand -label=Algorand "$SNAPSHOT" "s3:algorand-releases:"
+aptly publish snapshot -gpg-key="$SIGNING_KEY_ADDR" -origin=algorand -label=algorand "$SNAPSHOT" "s3:algorand-releases:"
 
 echo
 date "+build_release end SNAPSHOT stage %Y%m%d_%H%M%S"

--- a/scripts/release/mule/package/deb/package.sh
+++ b/scripts/release/mule/package/deb/package.sh
@@ -84,7 +84,7 @@ done
 # TODO: make `Files:` segments for vendor/... and crypto/libsodium-fork, but reasonably this should be understood to cover all _our_ files and copied in packages continue to be licenced under their own terms
 cat <<EOF> "${PKG_ROOT}/DEBIAN/copyright"
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: Algorand
+Upstream-Name: algorand
 Upstream-Contact: Algorand developers <dev@algorand.com>
 Source: https://github.com/algorand/go-algorand
 

--- a/scripts/release/prod/stage/snapshot.sh
+++ b/scripts/release/prod/stage/snapshot.sh
@@ -24,7 +24,7 @@ aptly repo add algorand "$DEBS_DIR"
 aptly snapshot create "${CHANNEL}-${VERSION}" from repo algorand
 
 # Note: only run the first command below if there is nothing published.
-#aptly -config="$HOME"/.aptly.conf publish snapshot -gpg-key=dev@algorand.com -origin=Algorand -label=Algorand "${CHANNEL}-${VERSION}" "s3:ben-test-2.0.3:"
+#aptly -config="$HOME"/.aptly.conf publish snapshot -gpg-key=dev@algorand.com -origin=algorand -label=algorand "${CHANNEL}-${VERSION}" "s3:ben-test-2.0.3:"
 
 # Since snapshots have already been published, it's only necessary to switch the old one for the new one.
 aptly -config="$HOME"/.aptly.conf -gpg-key=dev@algorand.com publish switch "$CHANNEL" "s3:algorand-releases:" "$SNAPSHOT"

--- a/scripts/release/test/deb/run_ubuntu.sh
+++ b/scripts/release/test/deb/run_ubuntu.sh
@@ -34,7 +34,7 @@ EOF
 SNAPSHOT=algodummy-$(date +%Y%m%d_%H%M%S)
 "$HOME"/go/bin/aptly -config="${HOME}"/dummyaptly.conf snapshot create "${SNAPSHOT}" from repo algodummy
 # Creates ~/dummyaptly/public
-"$HOME"/go/bin/aptly -config="${HOME}"/dummyaptly.conf publish snapshot -origin=Algorand -label=Algorand "${SNAPSHOT}"
+"$HOME"/go/bin/aptly -config="${HOME}"/dummyaptly.conf publish snapshot -origin=algorand -label=algorand "${SNAPSHOT}"
 
 (cd "${HOME}"/dummyaptly/public && python3 "${HOME}"/go/src/github.com/algorand/go-algorand/scripts/httpd.py --pid "${HOME}"/phttpd.pid) &
 trap "${HOME}"/go/src/github.com/algorand/go-algorand/scripts/kill_httpd.sh 0

--- a/scripts/release/test/rpm/run_centos.sh
+++ b/scripts/release/test/rpm/run_centos.sh
@@ -14,7 +14,7 @@ sg docker "docker build -t algocentosbuild - < ${HOME}/go/src/github.com/algoran
 
 cat <<EOF>"${HOME}"/dummyrepo/algodummy.repo
 [algodummy]
-name=Algorand
+name=algorand
 baseurl=http://${DC_IP}:8111/
 enabled=1
 gpgcheck=1


### PR DESCRIPTION
##  Summary

Currently, there is a mixed-case discrepancy among the shell scripts that create the deb package.  This will lower-case all areas where `algorand` is given for the package name or instance which references it.

## Test Plan

n/a
