### PR TITLE
Change constant values of DeltaAction

### DIFF
--- a/daemon/algod/api/server/v2/dryrun_test.go
+++ b/daemon/algod/api/server/v2/dryrun_test.go
@@ -924,13 +924,13 @@ func TestDryrunRequestJSON(t *testing.T) {
 func TestStateDeltaToStateDelta(t *testing.T) {
 	t.Parallel()
 	sd := basics.StateDelta{
-		"intkey": {
-			Action: basics.SetUintAction,
-			Uint:   11,
-		},
 		"byteskey": {
 			Action: basics.SetBytesAction,
 			Bytes:  "test",
+		},
+		"intkey": {
+			Action: basics.SetUintAction,
+			Uint:   11,
 		},
 		"delkey": {
 			Action: basics.DeleteAction,
@@ -942,16 +942,16 @@ func TestStateDeltaToStateDelta(t *testing.T) {
 	var keys []string
 	// test with a loop because sd is a map and iteration order is random
 	for _, item := range *gsd {
-		if item.Key == "intkey" {
+		if item.Key == "byteskey" {
 			require.Equal(t, uint64(1), item.Value.Action)
-			require.NotNil(t, item.Value.Uint)
-			require.Equal(t, uint64(11), *item.Value.Uint)
-			require.Nil(t, item.Value.Bytes)
-		} else if item.Key == "byteskey" {
-			require.Equal(t, uint64(2), item.Value.Action)
 			require.Nil(t, item.Value.Uint)
 			require.NotNil(t, item.Value.Bytes)
 			require.Equal(t, base64.StdEncoding.EncodeToString([]byte("test")), *item.Value.Bytes)
+		} else if item.Key == "intkey" {
+			require.Equal(t, uint64(2), item.Value.Action)
+			require.NotNil(t, item.Value.Uint)
+			require.Equal(t, uint64(11), *item.Value.Uint)
+			require.Nil(t, item.Value.Bytes)
 		} else if item.Key == "delkey" {
 			require.Equal(t, uint64(3), item.Value.Action)
 			require.Nil(t, item.Value.Uint)

--- a/data/basics/teal.go
+++ b/data/basics/teal.go
@@ -28,11 +28,11 @@ import (
 type DeltaAction uint64
 
 const (
-	// SetUintAction indicates that a Uint should be stored at a key
-	SetUintAction DeltaAction = 1
-
 	// SetBytesAction indicates that a TEAL byte slice should be stored at a key
-	SetBytesAction DeltaAction = 2
+	SetBytesAction DeltaAction = 1
+
+	// SetUintAction indicates that a Uint should be stored at a key
+	SetUintAction DeltaAction = 2
 
 	// DeleteAction indicates that the value for a particular key should be deleted
 	DeleteAction DeltaAction = 3


### PR DESCRIPTION
## Summary

* Motivation: having TealBytesType = 1 and SetBytesAction = 2
  looks confusing for non-golang consumers of REST API
  Namely in SDKs these types are used as raw int values.
* This change sets SetBytesAction = 1 and SetUintAction = 2
  to keep things consistent

## Test Plan

Rely on existing test suite. Tested with

```
go test ./data/transactions/... ./data/basics/...
go test ./cmd/... ./libgoal/... daemon/algod/api/...

export NODEBINDIR=~/go/bin
export TESTDATADIR=`pwd`/test/testdata
go test ./test/e2e-go/features/transactions/... -run TestAssetInformation
go test ./test/e2e-go/features/transactions/... -run TestAccountInformationV2

export TESTFILTER=Dryrun
go test ./test/e2e-go/cli/goal/... -run TestGoalWithExpect -count=1
unset TESTFILTER
unset TESTDATADIR
unset NODEBINDIR
```