### PR TITLE
Fix `TxnRoot` for block 0

### DIFF
--- a/data/ledger.go
+++ b/data/ledger.go
@@ -72,7 +72,7 @@ func makeGenesisBlock(proto protocol.ConsensusVersion, genesisBal GenesisBalance
 			Round:        0,
 			Branch:       bookkeeping.BlockHash{},
 			Seed:         committee.Seed(genesisHash),
-			TxnRoot:      transactions.Payset{}.Commit(params.PaysetCommitFlat),
+			TxnRoot:      transactions.Payset{}.CommitGenesis(params.PaysetCommitFlat),
 			TimeStamp:    genesisBal.timestamp,
 			GenesisID:    genesisID,
 			RewardsState: genesisRewardsState,

--- a/data/transactions/aggregates.go
+++ b/data/transactions/aggregates.go
@@ -37,12 +37,27 @@ type (
 // depends on the order in which the Txids appear, and that Txids do NOT cover
 // transaction signatures.
 func (payset Payset) Commit(flat bool) crypto.Digest {
+	return payset.commit(flat, false)
+}
+
+// CommitGenesis is like Commit, but with special handling for zero-length
+// but non-nil paysets.
+func (payset Payset) CommitGenesis(flat bool) crypto.Digest {
+	return payset.commit(flat, true)
+}
+
+// commit handles the logic for both Commit and CommitGenesis
+func (payset Payset) commit(flat bool, genesis bool) crypto.Digest {
 	// We used to build up Paysets from a nil slice with `append` during
 	// block evaluation, meaning zero-length paysets would remain nil.
 	// After we started allocating them up front, we started calling Commit
 	// on zero-length but non-nil Paysets. However, we want payset
 	// encodings to remain the same with or without this optimization.
-	if len(payset) == 0 {
+	//
+	// Additionally, the genesis block commits to a zero-length but non-nil
+	// payset (the only block to do so), so we have to let the nil value
+	// pass through.
+	if !genesis && len(payset) == 0 {
 		payset = nil
 	}
 

--- a/data/transactions/aggregates_test.go
+++ b/data/transactions/aggregates_test.go
@@ -61,6 +61,7 @@ func TestPaysetDoesNotCommitToSignatures(t *testing.T) {
 func TestEmptyPaysetCommitment(t *testing.T) {
 	const nilFlatPaysetHash = "WRS2VL2OQ5LPWBYLNBCZV3MEQ4DACSRDES6IUKHGOWYQERJRWC5A"
 	const emptyFlatPaysetHash = "E54GFMNS2LISPG5VUGOQ3B2RR7TRKAHRE24LUM3HOW6TJGQ6PNZQ"
+	const merklePaysetHash = "4OYMIQUY7QOBJGX36TEJS35ZEQT24QPEMSNZGTFESWMRW6CSXBKQ"
 
 	// Non-genesis blocks should encode empty paysets identically to nil paysets
 	var nilPayset Payset
@@ -70,4 +71,11 @@ func TestEmptyPaysetCommitment(t *testing.T) {
 	// Genesis block should encode the empty payset differently
 	require.Equal(t, emptyFlatPaysetHash, Payset{}.CommitGenesis(true).String())
 	require.Equal(t, nilFlatPaysetHash, nilPayset.CommitGenesis(true).String())
+
+	// Non-flat paysets (which we have dropped support for) should encode
+	// the same regardless of nilness or if this is a genesis block
+	require.Equal(t, merklePaysetHash, Payset{}.CommitGenesis(false).String())
+	require.Equal(t, merklePaysetHash, nilPayset.CommitGenesis(false).String())
+	require.Equal(t, merklePaysetHash, Payset{}.Commit(false).String())
+	require.Equal(t, merklePaysetHash, nilPayset.Commit(false).String())
 }

--- a/data/transactions/aggregates_test.go
+++ b/data/transactions/aggregates_test.go
@@ -57,3 +57,17 @@ func TestPaysetDoesNotCommitToSignatures(t *testing.T) {
 	commit2 := payset.Commit(false)
 	require.Equal(t, commit1, commit2)
 }
+
+func TestEmptyPaysetCommitment(t *testing.T) {
+	const nilFlatPaysetHash = "WRS2VL2OQ5LPWBYLNBCZV3MEQ4DACSRDES6IUKHGOWYQERJRWC5A"
+	const emptyFlatPaysetHash = "E54GFMNS2LISPG5VUGOQ3B2RR7TRKAHRE24LUM3HOW6TJGQ6PNZQ"
+
+	// Non-genesis blocks should encode empty paysets identically to nil paysets
+	var nilPayset Payset
+	require.Equal(t, nilFlatPaysetHash, Payset{}.Commit(true).String())
+	require.Equal(t, nilFlatPaysetHash, nilPayset.Commit(true).String())
+
+	// Genesis block should encode empty payset differently
+	require.Equal(t, emptyFlatPaysetHash, Payset{}.CommitGenesis(true).String())
+	require.Equal(t, nilFlatPaysetHash, nilPayset.CommitGenesis(true).String())
+}

--- a/data/transactions/aggregates_test.go
+++ b/data/transactions/aggregates_test.go
@@ -67,7 +67,7 @@ func TestEmptyPaysetCommitment(t *testing.T) {
 	require.Equal(t, nilFlatPaysetHash, Payset{}.Commit(true).String())
 	require.Equal(t, nilFlatPaysetHash, nilPayset.Commit(true).String())
 
-	// Genesis block should encode empty payset differently
+	// Genesis block should encode the empty payset differently
 	require.Equal(t, emptyFlatPaysetHash, Payset{}.CommitGenesis(true).String())
 	require.Equal(t, nilFlatPaysetHash, nilPayset.CommitGenesis(true).String())
 }

--- a/ledger/blockdb.go
+++ b/ledger/blockdb.go
@@ -144,6 +144,17 @@ func blockGetCert(tx *sql.Tx, rnd basics.Round) (blk bookkeeping.Block, cert agr
 	return
 }
 
+func blockReplaceIfExists(tx *sql.Tx, blk bookkeeping.Block, cert agreement.Certificate) error {
+	_, err := tx.Exec("UPDATE blocks SET proto=?, hdrdata=?, blkdata=?, certdata=? WHERE rnd=?",
+		blk.CurrentProtocol,
+		protocol.Encode(&blk.BlockHeader),
+		protocol.Encode(&blk),
+		protocol.Encode(&cert),
+		blk.Round(),
+	)
+	return err
+}
+
 func blockPut(tx *sql.Tx, blk bookkeeping.Block, cert agreement.Certificate) error {
 	var max sql.NullInt64
 	err := tx.QueryRow("SELECT MAX(rnd) FROM blocks").Scan(&max)

--- a/ledger/blockdb.go
+++ b/ledger/blockdb.go
@@ -17,6 +17,7 @@
 package ledger
 
 import (
+	"bytes"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -26,6 +27,7 @@ import (
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -144,15 +146,58 @@ func blockGetCert(tx *sql.Tx, rnd basics.Round) (blk bookkeeping.Block, cert agr
 	return
 }
 
-func blockReplaceIfExists(tx *sql.Tx, blk bookkeeping.Block, cert agreement.Certificate) error {
-	_, err := tx.Exec("UPDATE blocks SET proto=?, hdrdata=?, blkdata=?, certdata=? WHERE rnd=?",
-		blk.CurrentProtocol,
-		protocol.Encode(&blk.BlockHeader),
-		protocol.Encode(&blk),
-		protocol.Encode(&cert),
+func blockReplaceIfExists(tx *sql.Tx, log logging.Logger, blk bookkeeping.Block, cert agreement.Certificate) (updated bool, err error) {
+	// Fetch encoded block + cert for the requested round so we can compare
+	var oldProto protocol.ConsensusVersion
+	var oldHdr, oldBlk, oldCert []byte
+	const query = "SELECT proto, hdrdata, blkdata, certdata FROM blocks WHERE rnd=?"
+	err = tx.QueryRow(query, blk.Round()).Scan(&oldProto, &oldHdr, &oldBlk, &oldCert)
+	if err != nil {
+		// Didn't have a block to replace, no problem
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+
+	// Encode new block + cert in order to check against old values and replace
+	newProto := blk.CurrentProtocol
+	newHdr := protocol.Encode(&blk.BlockHeader)
+	newBlk := protocol.Encode(&blk)
+	newCert := protocol.Encode(&cert)
+
+	// Log if protocol version or certificate changed for the block we're replacing
+	if newProto != oldProto {
+		log.Warnf("blockReplaceIfExists(%v): old proto %v != new proto %v", blk.Round(), oldProto, newProto)
+	}
+	if !bytes.Equal(oldCert, newCert) {
+		log.Warnf("blockReplaceIfExists(%v): old cert %v != new cert %v", blk.Round(), oldCert, newCert)
+	}
+
+	// Replace the block
+	res, err := tx.Exec("UPDATE blocks SET proto=?, hdrdata=?, blkdata=?, certdata=? WHERE rnd=?",
+		newProto,
+		newHdr,
+		newBlk,
+		newCert,
 		blk.Round(),
 	)
-	return err
+	if err != nil {
+		return false, err
+	}
+
+	// Ensure we actually updated a row
+	cnt, err := res.RowsAffected()
+	if err != nil {
+		return true, err
+	}
+	if cnt > 0 {
+		return true, nil
+	}
+
+	// Shouldn't get here since we found the block
+	log.Warnf("blockReplaceIfExists(%v): found block but didn't update any rows?", blk.Round())
+	return false, nil
 }
 
 func blockPut(tx *sql.Tx, blk bookkeeping.Block, cert agreement.Certificate) error {

--- a/ledger/blockdb_test.go
+++ b/ledger/blockdb_test.go
@@ -25,9 +25,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/agreement"
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 )
@@ -173,4 +175,50 @@ func TestBlockDBAppend(t *testing.T) {
 		blocks = append(blocks, blkent)
 		checkBlockDB(t, tx, blocks)
 	}
+}
+
+func TestFixGenesisPaysetHash(t *testing.T) {
+	dbs, _ := dbOpenTest(t, true)
+	setDbLogging(t, dbs)
+	defer dbs.close()
+
+	tx, err := dbs.wdb.Handle.Begin()
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	// Fetch some consensus params
+	params := config.Consensus[protocol.ConsensusCurrentVersion]
+
+	// Make a genesis block with a good payset hash
+	goodGenesis := randomBlock(basics.Round(0))
+	goodGenesis.block.BlockHeader.TxnRoot = transactions.Payset{}.CommitGenesis(params.PaysetCommitFlat)
+	require.NoError(t, err)
+
+	// Copy the genesis block and replace its payset hash with the buggy value
+	badGenesis := goodGenesis
+	badGenesis.block.BlockHeader.TxnRoot = transactions.Payset{}.Commit(params.PaysetCommitFlat)
+
+	// Assert that the buggy value is different from the good value
+	require.NotEqual(t, goodGenesis.block.BlockHeader.TxnRoot, badGenesis.block.BlockHeader.TxnRoot)
+
+	// Insert the buggy block
+	err = blockInit(tx, []bookkeeping.Block{badGenesis.block})
+	require.NoError(t, err)
+	checkBlockDB(t, tx, []blockEntry{badGenesis})
+
+	// Check that it has the bad TxnRoot
+	blk, err := blockGet(tx, basics.Round(0))
+	require.NoError(t, err)
+	require.Equal(t, blk.BlockHeader.TxnRoot, badGenesis.block.BlockHeader.TxnRoot)
+
+	// Pretend to initBlocksDB for an archival node with the good genesis
+	l := &Ledger{log: logging.Base()}
+	err = initBlocksDB(tx, l, []bookkeeping.Block{goodGenesis.block}, true)
+	require.NoError(t, err)
+	checkBlockDB(t, tx, []blockEntry{goodGenesis})
+
+	// Check that it has the good TxnRoot
+	blk, err = blockGet(tx, basics.Round(0))
+	require.NoError(t, err)
+	require.Equal(t, blk.BlockHeader.TxnRoot, goodGenesis.block.BlockHeader.TxnRoot)
 }

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -275,8 +275,11 @@ func initBlocksDB(tx *sql.Tx, l *Ledger, initBlocks []bookkeeping.Block, isArchi
 		//
 		// Don't bother for non-archival nodes since they will toss
 		// block 0 almost immediately
+		//
+		// TODO remove this once a version containing this code has
+		// been deployed to archival nodes
 		if len(initBlocks) > 0 && initBlocks[0].Round() == basics.Round(0) {
-			blockReplaceIfExists(tx, initBlocks[0], agreement.Certificate{})
+			err = blockReplaceIfExists(tx, initBlocks[0], agreement.Certificate{})
 			if err != nil {
 				err = fmt.Errorf("initBlocksDB.blockReplaceIfExists %v", err)
 				return err

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -279,10 +279,13 @@ func initBlocksDB(tx *sql.Tx, l *Ledger, initBlocks []bookkeeping.Block, isArchi
 		// TODO remove this once a version containing this code has
 		// been deployed to archival nodes
 		if len(initBlocks) > 0 && initBlocks[0].Round() == basics.Round(0) {
-			err = blockReplaceIfExists(tx, initBlocks[0], agreement.Certificate{})
+			updated, err := blockReplaceIfExists(tx, l.log, initBlocks[0], agreement.Certificate{})
 			if err != nil {
 				err = fmt.Errorf("initBlocksDB.blockReplaceIfExists %v", err)
 				return err
+			}
+			if updated {
+				l.log.Infof("initBlocksDB replaced block 0")
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Back in https://github.com/algorand/go-algorand/pull/944, we started encoding nil paysets and empty paysets with the same commitment. In normal operation, blocks with no transactions create a `nil` payset. The genesis block, however, commits to a payset that is empty but not nil. I noted this in the PR at the time and didn't think it was a big deal because it didn't affect catchup, but in hindsight that was silly since it introduces version-based subjectivity into what block 0 is.

This PR computes the genesis `TxnRoot` as we originally did for the genesis block. For archival nodes, it replaces block 0 with the recomputed block 0 at startup. We should remove this code after the next protocol upgrade, when we're sure that all up-to-date archival nodes have run it once.