### PR TITLE
Improve dryrun and tealdbg compatibility

### DIFF
--- a/cmd/tealdbg/dryrunRequest.go
+++ b/cmd/tealdbg/dryrunRequest.go
@@ -79,21 +79,22 @@ func balanceRecordsFromDdr(ddr *v2.DryrunRequest) (records []basics.BalanceRecor
 		if err != nil {
 			return
 		}
-		appIdx := basics.AppIndex(a.Id)
-		var ad basics.AccountData
-		var ok bool
-		if ad, ok = accounts[addr]; ok {
-			// skip if this app params are already set
-			if _, ok = ad.AppParams[appIdx]; ok {
-				continue
-			}
-		}
 		// deserialize app params and update account data
 		params := v2.ApplicationParamsToAppParams(&a.Params)
+		appIdx := basics.AppIndex(a.Id)
+		ad := accounts[addr]
 		if ad.AppParams == nil {
 			ad.AppParams = make(map[basics.AppIndex]basics.AppParams, 1)
+			ad.AppParams[appIdx] = params
+		} else {
+			ap, ok := ad.AppParams[appIdx]
+			if ok {
+				v2.MergeAppParams(&ap, &params)
+				ad.AppParams[appIdx] = ap
+			} else {
+				ad.AppParams[appIdx] = params
+			}
 		}
-		ad.AppParams[appIdx] = params
 		accounts[addr] = ad
 	}
 

--- a/cmd/tealdbg/local.go
+++ b/cmd/tealdbg/local.go
@@ -230,7 +230,19 @@ func determineEvalMode(program []byte, modeIn string) (eval evalFn, mode string,
 	return
 }
 
-// Setup validates input params
+// Setup validates input params and resolves inputs into canonical balance record structures.
+// Programs for execution are discovered in the following way:
+// - Sources from command line file names.
+// - Programs mentioned in transaction group txnGroup.
+// - if DryrunRequest present and no sources or transaction group set in command line then:
+//   1. DryrunRequest.Sources are expanded to DryrunRequest.Apps or DryrunRequest.Txns.
+//   2. DryrunRequest.Apps are expanded into DryrunRequest.Txns.
+//   3. txnGroup is set to DryrunRequest.Txns
+// Application search by id:
+//  - Balance records from CLI or DryrunRequest.Accounts
+//  - If no balance records set in CLI then DryrunRequest.Accounts and DryrunRequest.Apps are used.
+//    In this case Accounts data is used as a base for balance records creation,
+//    and Apps supply updates to AppParams field.
 func (r *LocalRunner) Setup(dp *DebugParams) (err error) {
 	ddr, err := ddrFromParams(dp)
 	if err != nil {
@@ -251,6 +263,14 @@ func (r *LocalRunner) Setup(dp *DebugParams) (err error) {
 	r.txnGroup = ddr.Txns
 	if len(dp.TxnBlob) != 0 || len(r.txnGroup) == 0 {
 		r.txnGroup, err = txnGroupFromParams(dp)
+		if err != nil {
+			return
+		}
+	}
+
+	// if no sources provided, check dryrun request object
+	if len(dp.ProgramBlobs) == 0 && len(ddr.Sources) > 0 {
+		err = ddr.ExpandSources()
 		if err != nil {
 			return
 		}

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -78,7 +78,9 @@ func DryrunRequestFromGenerated(gdr *generated.DryrunRequest) (dr DryrunRequest,
 	return
 }
 
-func (dr *DryrunRequest) expandSources() error {
+// ExpandSources takes DryrunRequest.Source, compiles and
+// puts into appropriate DryrunRequest.Apps entry
+func (dr *DryrunRequest) ExpandSources() error {
 	for i, s := range dr.Sources {
 		program, err := logic.AssembleString(s.Source)
 		if err != nil {
@@ -287,8 +289,19 @@ func (dl *dryrunLedger) Get(addr basics.Address, withPendingRewards bool) (basic
 	if ok {
 		any = true
 		app := dl.dr.Apps[appi]
-		out.AppParams = make(map[basics.AppIndex]basics.AppParams)
-		out.AppParams[basics.AppIndex(app.Id)] = ApplicationParamsToAppParams(&app.Params)
+		params := ApplicationParamsToAppParams(&app.Params)
+		if out.AppParams == nil {
+			out.AppParams = make(map[basics.AppIndex]basics.AppParams)
+			out.AppParams[basics.AppIndex(app.Id)] = params
+		} else {
+			ap, ok := out.AppParams[basics.AppIndex(app.Id)]
+			if ok {
+				MergeAppParams(&ap, &params)
+				out.AppParams[basics.AppIndex(app.Id)] = ap
+			} else {
+				out.AppParams[basics.AppIndex(app.Id)] = params
+			}
+		}
 	}
 	if !any {
 		return basics.BalanceRecord{}, fmt.Errorf("no account for addr %s", addr.String())
@@ -369,8 +382,13 @@ func makeAppLedger(dl *dryrunLedger, txn *transactions.Transaction, appIdx basic
 }
 
 // unit-testable core of dryrun handler
+// programs for execution are discovered in the following way:
+// - LogicSig: stxn.Lsig.Logic
+// - Application: Apps[i].ClearStateProgram or Apps[i].ApprovalProgram for matched appIdx
+// if DryrunRequest.Sources is set it overrides appropriate entires in stxn.Lsig.Logic or Apps[i]
+// important: Accounts are not used for program lookup for application execution
 func doDryrunRequest(dr *DryrunRequest, proto *config.ConsensusParams, response *generated.DryrunResponse) {
-	err := dr.expandSources()
+	err := dr.ExpandSources()
 	if err != nil {
 		response.Error = err.Error()
 		return
@@ -511,4 +529,23 @@ func StateDeltaToStateDelta(sd basics.StateDelta) *generated.StateDelta {
 	}
 
 	return &gsd
+}
+
+// MergeAppParams merges values, existing in "base" take priority over new in "update"
+func MergeAppParams(base *basics.AppParams, update *basics.AppParams) {
+	if len(base.ApprovalProgram) == 0 && len(update.ApprovalProgram) > 0 {
+		base.ApprovalProgram = update.ApprovalProgram
+	}
+	if len(base.ClearStateProgram) == 0 && len(update.ClearStateProgram) > 0 {
+		base.ClearStateProgram = update.ClearStateProgram
+	}
+	if len(base.GlobalState) == 0 && len(update.GlobalState) > 0 {
+		base.GlobalState = update.GlobalState
+	}
+	if base.LocalStateSchema == (basics.StateSchema{}) && update.LocalStateSchema != (basics.StateSchema{}) {
+		base.LocalStateSchema = update.LocalStateSchema
+	}
+	if base.GlobalStateSchema == (basics.StateSchema{}) && update.GlobalStateSchema != (basics.StateSchema{}) {
+		base.GlobalStateSchema = update.GlobalStateSchema
+	}
 }


### PR DESCRIPTION
## Summary

* tealdbg now uses DryrunRequest.Sources if supplied
* Fix competing AppParams resolution
  if both present in accounts and DryrunRequest.Apps: account data
  take priority and only empty values are overwritten
* Document program search in both dryrun and tealdbg

## Test Plan

Existing autotest.
Manual test with Python SDK: craft a TEAL test, save DryrunRequest, use it to run both dryrun and tealdbg.