### PR TITLE
Disable TestArchival unit test on linux-amd64

### DIFF
--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -106,6 +107,13 @@ func TestArchival(t *testing.T) {
 	//
 	// We generate mostly empty blocks, with the exception of timestamps,
 	// which affect participationTracker.committedUpTo()'s return value.
+
+	// This test was causing random crashes on travis when executed with the race detector
+	// due to memory exhustion. For the time being, I'm taking it offline from the ubuntu
+	// configuration where it used to cause failuires.
+	if runtime.GOOS == "linux" && runtime.GOARCH == "amd64" {
+		t.Skip("Skipping the TestArchival as it tend to randomally fail on travis linux-amd64")
+	}
 
 	dbName := fmt.Sprintf("%s.%d", t.Name(), crypto.RandUint64())
 	genesisInitState := getInitState()


### PR DESCRIPTION
## Solution

The unit test TestArchival is randomly failing on travis linux-amd64 configuration due to random memory allocation failures.
