### PR TITLE
merklearray implementation

### DIFF
--- a/crypto/merklearray/array.go
+++ b/crypto/merklearray/array.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package merklearray
 
 import (

--- a/crypto/merklearray/array.go
+++ b/crypto/merklearray/array.go
@@ -1,0 +1,12 @@
+package merklearray
+
+import (
+	"github.com/algorand/go-algorand/crypto"
+)
+
+// An Array represents a dense array of leaf elements that are
+// combined into a Merkle tree.  Each element must be hashable.
+type Array interface {
+	Length() uint64
+	Get(pos uint64) (crypto.Hashable, error)
+}

--- a/crypto/merklearray/layer.go
+++ b/crypto/merklearray/layer.go
@@ -27,7 +27,7 @@ func (p *pair) ToBeHashed() (protocol.HashID, []byte) {
 // and returns the next-higher level in the tree,
 // represented as a layer.
 func (l layer) up() layer {
-	res := make(layer, (len(l)+1)/2)
+	res := make(layer, (uint64(len(l))+1)/2)
 	for i := 0; i < len(l); i += 2 {
 		var p pair
 		p.l = l[i]

--- a/crypto/merklearray/layer.go
+++ b/crypto/merklearray/layer.go
@@ -1,0 +1,40 @@
+package merklearray
+
+import (
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/protocol"
+)
+
+// A layer of the Merkle tree consists of a dense array of hashes at that
+// level of the tree.  Hashes beyond the end of the array (e.g., if the
+// number of leaves is not an exact power of 2) are implicitly zero.
+type layer []crypto.Digest
+
+// A pair represents an internal node in the Merkle tree.
+type pair struct {
+	l crypto.Digest
+	r crypto.Digest
+}
+
+func (p *pair) ToBeHashed() (protocol.HashID, []byte) {
+	var buf [2 * crypto.DigestSize]byte
+	copy(buf[:crypto.DigestSize], p.l[:])
+	copy(buf[crypto.DigestSize:], p.r[:])
+	return protocol.MerkleArrayNode, buf[:]
+}
+
+// up takes a layer representing some level in the tree,
+// and returns the next-higher level in the tree,
+// represented as a layer.
+func (l layer) up() layer {
+	res := make(layer, (len(l)+1)/2)
+	for i := 0; i < len(l); i += 2 {
+		var p pair
+		p.l = l[i]
+		if i+1 < len(l) {
+			p.r = l[i+1]
+		}
+		res[i/2] = crypto.HashObj(&p)
+	}
+	return res
+}

--- a/crypto/merklearray/layer.go
+++ b/crypto/merklearray/layer.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package merklearray
 
 import (

--- a/crypto/merklearray/merkle.go
+++ b/crypto/merklearray/merkle.go
@@ -122,6 +122,10 @@ func Verify(root crypto.Digest, elems map[uint64]crypto.Hashable, proof []crypto
 		if err != nil {
 			return err
 		}
+
+		if l > 64 {
+			return fmt.Errorf("Verify exceeded 64 levels, more than 2^64 leaves not supported")
+		}
 	}
 
 	computedroot, ok := pl[0]

--- a/crypto/merklearray/merkle.go
+++ b/crypto/merklearray/merkle.go
@@ -7,6 +7,8 @@ import (
 	"github.com/algorand/go-algorand/crypto"
 )
 
+// Tree is a Merkle tree, represented by layers of nodes (hashes) in the tree
+// at each height.
 type Tree struct {
 	// Level 0 is the leaves.
 	levels []layer
@@ -16,6 +18,7 @@ func (tree *Tree) topLayer() layer {
 	return tree.levels[len(tree.levels)-1]
 }
 
+// Build constructs a Merkle tree given an array.
 func Build(array Array) (*Tree, error) {
 	tree := &Tree{}
 
@@ -41,6 +44,7 @@ func Build(array Array) (*Tree, error) {
 	return tree, nil
 }
 
+// Root returns the root hash of the tree.
 func (tree *Tree) Root() crypto.Digest {
 	// Special case: commitment to zero-length array
 	if len(tree.levels) == 0 {
@@ -53,6 +57,8 @@ func (tree *Tree) Root() crypto.Digest {
 
 const validateProof = false
 
+// Prove constructs a proof for some set of positions in the array that was
+// used to construct the tree.
 func (tree *Tree) Prove(idxs []uint64) ([]crypto.Digest, error) {
 	if len(idxs) == 0 {
 		return nil, nil
@@ -109,6 +115,9 @@ func (tree *Tree) Prove(idxs []uint64) ([]crypto.Digest, error) {
 	return s.hints, nil
 }
 
+// Verify ensures that the positions in elems correspond to the hashes of their respective
+// crypto.Hashable objects in a tree with the given root hash.  The proof is expected to
+// be the proof returned by Prove().
 func Verify(root crypto.Digest, elems map[uint64]crypto.Hashable, proof []crypto.Digest) error {
 	if len(elems) == 0 {
 		if len(proof) != 0 {

--- a/crypto/merklearray/merkle.go
+++ b/crypto/merklearray/merkle.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package merklearray
 
 import (

--- a/crypto/merklearray/merkle.go
+++ b/crypto/merklearray/merkle.go
@@ -1,0 +1,133 @@
+package merklearray
+
+import (
+	"fmt"
+
+	"github.com/algorand/go-algorand/crypto"
+)
+
+type Tree struct {
+	// Level 0 is the leaves.
+	levels []layer
+}
+
+func (tree *Tree) topLayer() layer {
+	return tree.levels[len(tree.levels)-1]
+}
+
+func Build(array Array) (*Tree, error) {
+	tree := &Tree{}
+
+	var leaves layer
+	arraylen := array.Length()
+	for i := uint64(0); i < arraylen; i++ {
+		data, err := array.Get(i)
+		if err != nil {
+			return nil, err
+		}
+
+		leaves = append(leaves, crypto.HashObj(data))
+	}
+
+	if arraylen > 0 {
+		tree.levels = []layer{leaves}
+
+		for len(tree.topLayer()) > 1 {
+			tree.levels = append(tree.levels, tree.topLayer().up())
+		}
+	}
+
+	return tree, nil
+}
+
+func (tree *Tree) Root() crypto.Digest {
+	// Special case: commitment to zero-length array
+	if len(tree.levels) == 0 {
+		var zero crypto.Digest
+		return zero
+	}
+
+	return tree.topLayer()[0]
+}
+
+const validateProof = false
+
+func (tree *Tree) Prove(idxs []uint64) ([]crypto.Digest, error) {
+	if len(idxs) == 0 {
+		return nil, nil
+	}
+
+	// Special case: commitment to zero-length array
+	if len(tree.levels) == 0 {
+		return nil, fmt.Errorf("proving in zero-length commitment")
+	}
+
+	pl := make(partialLayer)
+	for _, pos := range idxs {
+		if pos >= uint64(len(tree.levels[0])) {
+			return nil, fmt.Errorf("pos %d larger than leaf count %d", pos, len(tree.levels[0]))
+		}
+
+		pl[pos] = tree.levels[0][pos]
+	}
+
+	s := &siblings{
+		tree: tree,
+	}
+
+	for l := uint64(0); l < uint64(len(tree.levels)-1); l++ {
+		var err error
+		pl, err = pl.up(s, l, validateProof)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Confirm that we got the same root hash
+	if len(pl) != 1 {
+		return nil, fmt.Errorf("internal error: partial layer produced %d hashes", len(pl))
+	}
+
+	if validateProof {
+		computedroot, ok := pl[0]
+		if !ok || computedroot != tree.topLayer()[0] {
+			return nil, fmt.Errorf("internal error: root mismatch during proof")
+		}
+	}
+
+	return s.hints, nil
+}
+
+func Verify(root crypto.Digest, elems map[uint64]crypto.Hashable, proof []crypto.Digest) error {
+	if len(elems) == 0 {
+		if len(proof) != 0 {
+			return fmt.Errorf("non-empty proof for empty set of elements")
+		}
+
+		return nil
+	}
+
+	pl := make(partialLayer)
+	for pos, elem := range elems {
+		pl[pos] = crypto.HashObj(elem)
+	}
+
+	s := &siblings{
+		hints: proof,
+	}
+
+	for l := uint64(0); len(s.hints) > 0 || len(pl) > 1; l++ {
+		var err error
+		pl, err = pl.up(s, l, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	computedroot, ok := pl[0]
+	if !ok || computedroot != root {
+		return fmt.Errorf("root mismatch")
+	}
+
+	return nil
+}

--- a/crypto/merklearray/merkle_test.go
+++ b/crypto/merklearray/merkle_test.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package merklearray
 
 import (

--- a/crypto/merklearray/merkle_test.go
+++ b/crypto/merklearray/merkle_test.go
@@ -1,0 +1,211 @@
+package merklearray
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/protocol"
+)
+
+type TestMessage string
+
+func (m TestMessage) ToBeHashed() (protocol.HashID, []byte) {
+	return protocol.Message, []byte(m)
+}
+
+type TestData crypto.Digest
+
+func (d TestData) ToBeHashed() (protocol.HashID, []byte) {
+	return protocol.Message, d[:]
+}
+
+type TestArray []TestData
+
+func (a TestArray) Length() uint64 {
+	return uint64(len(a))
+}
+
+func (a TestArray) Get(pos uint64) (crypto.Hashable, error) {
+	if pos >= uint64(len(a)) {
+		return nil, fmt.Errorf("pos %d larger than length %d", pos, len(a))
+	}
+
+	return a[pos], nil
+}
+
+type TestRepeatingArray struct {
+	item  crypto.Hashable
+	count uint64
+}
+
+func (a TestRepeatingArray) Length() uint64 {
+	return a.count
+}
+
+func (a TestRepeatingArray) Get(pos uint64) (crypto.Hashable, error) {
+	if pos >= a.count {
+		return nil, fmt.Errorf("pos %d larger than length %d", pos, a.count)
+	}
+
+	return a.item, nil
+}
+
+func TestMerkle(t *testing.T) {
+	var junk TestData
+	crypto.RandBytes(junk[:])
+
+	for sz := uint64(0); sz < 1024; sz++ {
+		a := make(TestArray, sz)
+		for i := uint64(0); i < sz; i++ {
+			crypto.RandBytes(a[i][:])
+		}
+
+		tree, err := Build(a)
+		if err != nil {
+			t.Error(err)
+		}
+
+		root := tree.Root()
+
+		var allpos []uint64
+		allmap := make(map[uint64]crypto.Hashable)
+
+		for i := uint64(0); i < sz; i++ {
+			proof, err := tree.Prove([]uint64{i})
+			if err != nil {
+				t.Error(err)
+			}
+
+			err = Verify(root, map[uint64]crypto.Hashable{i: a[i]}, proof)
+			if err != nil {
+				t.Error(err)
+			}
+
+			err = Verify(root, map[uint64]crypto.Hashable{i: junk}, proof)
+			if err == nil {
+				t.Errorf("no error when verifying junk")
+			}
+
+			allpos = append(allpos, i)
+			allmap[i] = a[i]
+		}
+
+		proof, err := tree.Prove(allpos)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = Verify(root, allmap, proof)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = Verify(root, map[uint64]crypto.Hashable{0: junk}, proof)
+		if err == nil {
+			t.Errorf("no error when verifying junk batch")
+		}
+
+		err = Verify(root, map[uint64]crypto.Hashable{0: junk}, nil)
+		if err == nil {
+			t.Errorf("no error when verifying junk batch")
+		}
+
+		_, err = tree.Prove([]uint64{sz})
+		if err == nil {
+			t.Errorf("no error when proving past the end")
+		}
+
+		err = Verify(root, map[uint64]crypto.Hashable{sz: junk}, nil)
+		if err == nil {
+			t.Errorf("no error when verifying past the end")
+		}
+
+		if sz > 0 {
+			var somepos []uint64
+			somemap := make(map[uint64]crypto.Hashable)
+			for i := 0; i < 10; i++ {
+				pos := crypto.RandUint64() % sz
+				somepos = append(somepos, pos)
+				somemap[pos] = a[pos]
+			}
+
+			proof, err = tree.Prove(somepos)
+			if err != nil {
+				t.Error(err)
+			}
+
+			err = Verify(root, somemap, proof)
+			if err != nil {
+				t.Error(err)
+			}
+		}
+	}
+}
+
+func BenchmarkMerkleCommit(b *testing.B) {
+	msg := TestMessage("Hello world")
+
+	var a TestRepeatingArray
+	a.item = msg
+	a.count = uint64(b.N)
+
+	tree, err := Build(a)
+	if err != nil {
+		b.Error(err)
+	}
+	tree.Root()
+}
+
+func BenchmarkMerkleProve1M(b *testing.B) {
+	msg := TestMessage("Hello world")
+
+	var a TestRepeatingArray
+	a.item = msg
+	a.count = 1024 * 1024
+
+	tree, err := Build(a)
+	if err != nil {
+		b.Error(err)
+	}
+
+	b.ResetTimer()
+
+	for i := uint64(0); i < uint64(b.N); i++ {
+		_, err := tree.Prove([]uint64{i % a.count})
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkMerkleVerify1M(b *testing.B) {
+	msg := TestMessage("Hello world")
+
+	var a TestRepeatingArray
+	a.item = msg
+	a.count = 1024 * 1024
+
+	tree, err := Build(a)
+	if err != nil {
+		b.Error(err)
+	}
+	root := tree.Root()
+
+	proofs := make([][]crypto.Digest, a.count)
+	for i := uint64(0); i < a.count; i++ {
+		proofs[i], err = tree.Prove([]uint64{i})
+		if err != nil {
+			b.Error(err)
+		}
+	}
+
+	b.ResetTimer()
+
+	for i := uint64(0); i < uint64(b.N); i++ {
+		err := Verify(root, map[uint64]crypto.Hashable{i % a.count: msg}, proofs[i])
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}

--- a/crypto/merklearray/partial.go
+++ b/crypto/merklearray/partial.go
@@ -1,0 +1,107 @@
+package merklearray
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/algorand/go-algorand/crypto"
+)
+
+// siblings represents the siblings needed to compute the root hash
+// given a set of leaf nodes.  This data structure can operate in two
+// modes: either build up the set of sibling hints, if tree is not nil,
+// or use the set of sibling hints, if tree is nil.
+type siblings struct {
+	tree  *Tree
+	hints []crypto.Digest
+}
+
+// get returns the sibling from tree level l (0 being the leaves)
+// position i.
+func (s *siblings) get(l uint64, i uint64) (res crypto.Digest, err error) {
+	if s.tree == nil {
+		if len(s.hints) > 0 {
+			res = s.hints[0]
+			s.hints = s.hints[1:]
+			return
+		}
+
+		err = fmt.Errorf("no more sibling hints")
+		return
+	}
+
+	if l >= uint64(len(s.tree.levels)) {
+		err = fmt.Errorf("level %d beyond tree height %d", l, len(s.tree.levels))
+		return
+	}
+
+	if i < uint64(len(s.tree.levels[l])) {
+		res = s.tree.levels[l][i]
+	}
+
+	s.hints = append(s.hints, res)
+	return
+}
+
+// partialLayer represents a subset of a layer (i.e., nodes at some
+// level in the Merkle tree).
+type partialLayer map[uint64]crypto.Digest
+
+// up takes a partial layer at level l, and returns the next-higher (partial)
+// level in the tree.  Since the layer is partial, up() requires siblings.
+//
+// The implementation is deterministic to ensure that up() asks for siblings
+// in the same order both when generating a proof, as well as when checking
+// the proof.
+//
+// If doHash is false, fill in zero hashes, which suffices for constructing
+// a proof.
+func (pl partialLayer) up(s *siblings, l uint64, doHash bool) (partialLayer, error) {
+	positions := make([]uint64, 0, len(pl))
+	for pos := range pl {
+		positions = append(positions, pos)
+	}
+	sort.Slice(positions, func(i, j int) bool { return positions[i] < positions[j] })
+
+	res := make(partialLayer)
+	for i := 0; i < len(positions); i++ {
+		pos := positions[i]
+		posHash := pl[pos]
+
+		siblingPos := pos ^ 1
+		siblingHash, ok := pl[siblingPos]
+		if ok {
+			// If our sibling is also in the partial layer, use its
+			// hash (and skip over its position).
+			i++
+		} else {
+			// Ask for the sibling hash from the tree / proof.
+			var err error
+			siblingHash, err = s.get(l, siblingPos)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		nextLayerPos := pos / 2
+		var nextLayerHash crypto.Digest
+
+		if doHash {
+			var p pair
+			if pos&1 == 0 {
+				// We are left
+				p.l = posHash
+				p.r = siblingHash
+			} else {
+				// We are right
+				p.l = siblingHash
+				p.r = posHash
+			}
+			nextLayerHash = crypto.HashObj(&p)
+		}
+
+		res[nextLayerPos] = nextLayerHash
+	}
+
+	return res, nil
+}

--- a/crypto/merklearray/partial.go
+++ b/crypto/merklearray/partial.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package merklearray
 
 import (

--- a/protocol/hash.go
+++ b/protocol/hash.go
@@ -33,6 +33,7 @@ const (
 	BalanceRecord     HashID = "BR"
 	Credential        HashID = "CR"
 	Genesis           HashID = "GE"
+	MerkleArrayNode   HashID = "MA"
 	Message           HashID = "MX"
 	NetPrioResponse   HashID = "NPR"
 	OneTimeSigKey1    HashID = "OT1"


### PR DESCRIPTION
This adds simple support for Merkle trees over dense arrays.

This will be useful in committing to our payset (so that we can have compact proofs of transactions), and for committing to online accounts (as will be needed for compact certificates).

Nothing in this PR is using this code yet, but I figured I'd ask for feedback on this, since it's reasonably small and might be useful for other things as well.