### PR TITLE
Add blocks header to the header cache

### DIFF
--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -477,6 +477,7 @@ func (l *Ledger) AddValidatedBlock(vb ValidatedBlock, cert agreement.Certificate
 	if err != nil {
 		return err
 	}
+	l.headerCache.Put(vb.blk.Round(), vb.blk.BlockHeader)
 	l.trackers.newBlock(vb.blk, vb.delta)
 	return nil
 }

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -862,3 +862,35 @@ func testLedgerRegressionFaultyLeaseFirstValidCheck2f3880f7(t *testing.T, versio
 		a.NoError(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctPayLease, ad), "should allow leasing payment transaction with newer FirstValid")
 	}
 }
+
+func TestLedgerBlockHdrCaching(t *testing.T) {
+	dbName := fmt.Sprintf("%s.%d", t.Name(), crypto.RandUint64())
+	genesisInitState := getInitState()
+	const inMem = true
+	cfg := config.GetDefaultLocal()
+	cfg.Archival = true
+	log := logging.TestingLog(t)
+	l, err := OpenLedger(log, dbName, inMem, genesisInitState, cfg)
+	require.NoError(t, err)
+	defer l.Close()
+
+	blk := genesisInitState.Block
+
+	for i := 0; i < 2000; i++ {
+		blk.BlockHeader.Round++
+		blk.BlockHeader.TimeStamp += int64(crypto.RandUint64() % 100 * 1000)
+		err := l.AddBlock(blk, agreement.Certificate{})
+		require.NoError(t, err)
+		l.WaitForCommit(blk.Round())
+		be, lastCommitted, latest, err := l.blockQ.checkEntry(blk.BlockHeader.Round)
+		require.NoError(t, err)
+		require.NotNilf(t, be, "round : %d", blk.BlockHeader.Round)
+		require.Equal(t, blk, be.block)
+		require.LessOrEqual(t, uint64(lastCommitted), uint64(blk.BlockHeader.Round))
+		require.Equal(t, latest, blk.BlockHeader.Round)
+
+		hdr, err := l.blockQ.getBlockHdr(blk.BlockHeader.Round)
+		require.NoError(t, err)
+		require.Equal(t, blk.BlockHeader, hdr)
+	}
+}

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -881,15 +881,8 @@ func TestLedgerBlockHdrCaching(t *testing.T) {
 		blk.BlockHeader.TimeStamp += int64(crypto.RandUint64() % 100 * 1000)
 		err := l.AddBlock(blk, agreement.Certificate{})
 		require.NoError(t, err)
-		l.WaitForCommit(blk.Round())
-		be, lastCommitted, latest, err := l.blockQ.checkEntry(blk.BlockHeader.Round)
-		require.NoError(t, err)
-		require.NotNilf(t, be, "round : %d", blk.BlockHeader.Round)
-		require.Equal(t, blk, be.block)
-		require.LessOrEqual(t, uint64(lastCommitted), uint64(blk.BlockHeader.Round))
-		require.Equal(t, latest, blk.BlockHeader.Round)
 
-		hdr, err := l.blockQ.getBlockHdr(blk.BlockHeader.Round)
+		hdr, err := l.BlockHdr(blk.BlockHeader.Round)
 		require.NoError(t, err)
 		require.Equal(t, blk.BlockHeader, hdr)
 	}


### PR DESCRIPTION
## Summary

The typical flow is that we add a new block, and then try to evaluate the subsequent block.
When doing so, the previous block was already flushed to disk by the `block.syncer`, and so we're reloading the block from the `blockqueue` just so we can store it's header in the `ledger.headerCache`.

From functional perspective, there is nothing wrong here, but it's not very efficient. This PR adds the block header to the blocks header cache on Ledger.AddValidatedBlock, which ensure that subsequent calls to BlockHdr would not hit the disk.

## Test Plan

Added a unit test to verify that it's working correctly.