### PR TITLE
Tealdbg: use round number and latestTimestamp from dryrun-req if available

### DIFF
--- a/cmd/tealdbg/local.go
+++ b/cmd/tealdbg/local.go
@@ -291,6 +291,14 @@ func (r *LocalRunner) Setup(dp *DebugParams) (err error) {
 		balances[record.Addr] = record.AccountData
 	}
 
+	if dp.Round == 0 && ddr.Round != 0 {
+		dp.Round = ddr.Round
+	}
+
+	if dp.LatestTimestamp == 0 && ddr.LatestTimestamp != 0 {
+		dp.LatestTimestamp = int64(ddr.LatestTimestamp)
+	}
+
 	// if program(s) specified then run from it
 	if len(dp.ProgramBlobs) > 0 {
 		if len(r.txnGroup) == 1 && dp.GroupIndex != 0 {

--- a/cmd/tealdbg/localLedger.go
+++ b/cmd/tealdbg/localLedger.go
@@ -33,12 +33,12 @@ type balancesAdapter struct {
 	txnGroup   []transactions.SignedTxn
 	groupIndex int
 	proto      config.ConsensusParams
-	round      int
+	round      uint64
 }
 
 func makeAppLedger(
 	balances map[basics.Address]basics.AccountData, txnGroup []transactions.SignedTxn,
-	groupIndex int, proto config.ConsensusParams, round int, latestTimestamp int64,
+	groupIndex int, proto config.ConsensusParams, round uint64, latestTimestamp int64,
 	appIdx basics.AppIndex, painless bool,
 ) (logic.LedgerForLogic, appState, error) {
 

--- a/cmd/tealdbg/main.go
+++ b/cmd/tealdbg/main.go
@@ -129,7 +129,7 @@ var txnFile string
 var groupIndex int
 var balanceFile string
 var ddrFile string
-var roundNumber int
+var roundNumber uint64
 var timestamp int64
 var runMode runModeValue = runModeValue{makeCobraStringValue("auto", []string{"signature", "application"})}
 var port int
@@ -138,7 +138,7 @@ var noBrowserCheck bool
 var noSourceMap bool
 var verbose bool
 var painless bool
-var appID int
+var appID uint64
 
 func init() {
 	rootCmd.PersistentFlags().VarP(&frontend, "frontend", "f", "Frontend to use: "+frontend.AllowedString())
@@ -155,8 +155,8 @@ func init() {
 	debugCmd.Flags().IntVarP(&groupIndex, "group-index", "g", 0, "Transaction index in a txn group")
 	debugCmd.Flags().StringVarP(&balanceFile, "balance", "b", "", "Balance records to evaluate stateful TEAL on in form of json or msgpack file")
 	debugCmd.Flags().StringVarP(&ddrFile, "dryrun-req", "d", "", "Program(s) and state(s) in dryrun REST request format")
-	debugCmd.Flags().IntVarP(&appID, "app-id", "a", 1380011588, "Application ID for stateful TEAL if not set in transaction(s)")
-	debugCmd.Flags().IntVarP(&roundNumber, "round", "r", 1095518031, "Ledger round number to evaluate stateful TEAL on")
+	debugCmd.Flags().Uint64VarP(&appID, "app-id", "a", 1380011588, "Application ID for stateful TEAL if not set in transaction(s)")
+	debugCmd.Flags().Uint64VarP(&roundNumber, "round", "r", 0, "Ledger round number to evaluate stateful TEAL on")
 	debugCmd.Flags().Int64VarP(&timestamp, "latest-timestamp", "l", 0, "Latest confirmed timestamp to evaluate stateful TEAL on")
 	debugCmd.Flags().VarP(&runMode, "mode", "m", "TEAL evaluation mode: "+runMode.AllowedString())
 	debugCmd.Flags().BoolVar(&painless, "painless", false, "Automatically create balance record for all accounts and applications")
@@ -248,7 +248,7 @@ func debugLocal(args []string) {
 		GroupIndex:       groupIndex,
 		BalanceBlob:      balanceBlob,
 		DdrBlob:          ddrBlob,
-		Round:            roundNumber,
+		Round:            uint64(roundNumber),
 		LatestTimestamp:  timestamp,
 		RunMode:          runMode.String(),
 		DisableSourceMap: noSourceMap,

--- a/cmd/tealdbg/server.go
+++ b/cmd/tealdbg/server.go
@@ -64,11 +64,11 @@ type DebugParams struct {
 	GroupIndex       int
 	BalanceBlob      []byte
 	DdrBlob          []byte
-	Round            int
+	Round            uint64
 	LatestTimestamp  int64
 	RunMode          string
 	DisableSourceMap bool
-	AppID            int
+	AppID            uint64
 	Painless         bool
 }
 


### PR DESCRIPTION
## Summary

While documenting TEAL testing in Python, I found `tealdbg` does not use `Round` and `LatestTimestamp`
from dryrun request object that creates difficulties with tests debugging.

## Test Plan

Rely on existing auto tests.
Manual test Using python SDK:

```python
        # ... some init code ...
        accounts = [creator_data, sender_data]
        req = Helper.build_dryrun_request(source, sender=sender, app=dict(
            app_idx=1,
            creator=creator,
            args=[b"vote", "test"],
            round=3,
            accounts=accounts,
        ))
        Helper.save_dryrun_request("dr.mgsp", req)
```

Then run the debugger with the command below and open the `devtools://` url in Google Chrome:

```bash
tealdbg debug --dryrun-req dr.mgsp --proto future
```