### PR TITLE
Remove unused GetRoundTxIds from ledgerForEvaluator interface

### DIFF
--- a/agreement/voteTracker.go
+++ b/agreement/voteTracker.go
@@ -220,7 +220,7 @@ func (tracker *voteTracker) handle(r routerHandle, p player, e0 event) event {
 
 			// at this point, we need to check if this is the very last vote or not.
 			// if we have no regular votes, we won't be generating a bundle so we can abort right here.
-			// note that it migth be a legit thing; if we received two votes from X followed by 100 regular votes,
+			// note that it might be a legit thing; if we received two votes from X followed by 100 regular votes,
 			// we would end up here for the second vote.
 			if len(tracker.Voters) == 0 {
 				return res

--- a/crypto/merkletrie/node.go
+++ b/crypto/merkletrie/node.go
@@ -272,7 +272,7 @@ func (n *node) remove(cache *merkleTrieCache, key []byte, path []byte) (nodeID s
 	}
 	cache.deleteNode(childNodeID)
 
-	// at this point, we migth end up with a single leaf child. collapse that.
+	// at this point, we might end up with a single leaf child. collapse that.
 	if pnode.childrenNext[pnode.firstChild] == pnode.firstChild {
 		childNode, err = cache.getNode(pnode.children[pnode.firstChild])
 		if err != nil {

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -847,7 +847,7 @@ func (au *accountUpdates) accountsInitialize(ctx context.Context, tx *sql.Tx) (b
 		return 0, fmt.Errorf("accountsInitialize was unable to MakeTrie: %v", err)
 	}
 
-	// we migth have a database that was previously initialized, and now we're adding the balances trie. In that case, we need to add all the existing balances to this trie.
+	// we might have a database that was previously initialized, and now we're adding the balances trie. In that case, we need to add all the existing balances to this trie.
 	// we can figure this out by examinine the hash of the root:
 	rootHash, err := trie.RootHash()
 	if err != nil {

--- a/ledger/catchpointwriter.go
+++ b/ledger/catchpointwriter.go
@@ -46,7 +46,7 @@ const (
 
 // catchpointWriter is the struct managing the persistance of accounts data into the catchpoint file.
 // it's designed to work in a step fashion : a caller will call the WriteStep method in a loop until
-// the writing is complete. It migth take multiple steps until the operation is over, and the caller
+// the writing is complete. It might take multiple steps until the operation is over, and the caller
 // has the option of throtteling the CPU utilization in between the calls.
 type catchpointWriter struct {
 	hasher            hash.Hash

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -185,7 +185,6 @@ type ledgerForEvaluator interface {
 	Lookup(basics.Round, basics.Address) (basics.AccountData, error)
 	Totals(basics.Round) (AccountTotals, error)
 	isDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, txlease) (bool, error)
-	GetRoundTxIds(rnd basics.Round) (txMap map[transactions.Txid]bool)
 	LookupWithoutRewards(basics.Round, basics.Address) (basics.AccountData, error)
 	GetCreatorForRound(basics.Round, basics.CreatableIndex, basics.CreatableType) (basics.Address, bool, error)
 }

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -396,6 +396,7 @@ func (l *Ledger) isDup(currentProto config.ConsensusParams, current basics.Round
 }
 
 // GetRoundTxIds returns a map of the transactions ids that we have for the given round
+// this function is currently not being used, but remains here as it migth be useful in the future.
 func (l *Ledger) GetRoundTxIds(rnd basics.Round) (txMap map[transactions.Txid]bool) {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()

--- a/scripts/travis/external_build_printlog.sh
+++ b/scripts/travis/external_build_printlog.sh
@@ -59,7 +59,7 @@ while [ $SECONDS -lt $end ]; do
     if [ "${TRAVIS}" = "true" ]; then
         # under travis, if we have passed the 1h:45m mark, the build is going to likely fail due to timeout.
         # instead of failing, we want to exit the build with success, indicating where the log could be retrieved later on.
-        # ( note that there migth be an issue with that build, but we don't want to cap it via travis timeouts. )
+        # ( note that there might be an issue with that build, but we don't want to cap it via travis timeouts. )
         if [ $((SECONDS-LOG_WAITING_START)) -gt $((60*105)) ]; then
             echo "Build is taking too long. Travis is going to timeout this build, so we'll tell travis that we're done for now."
             echo "Once this build is complete, you could get a complete log by typing:"

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -882,7 +882,7 @@ proc ::AlgorandGoal::AddParticipationKey { ADDRESS FIRST_ROUND LAST_ROUND TEST_P
 
 # Register online participation with a given account
 proc ::AlgorandGoal::TakeAccountOnline { ADDRESS FIRST_ROUND LAST_ROUND TEST_PRIMARY_NODE_DIR } {
-    # we need to set the timeout to more than one round, since it migth take few rounds for the transaction to be accepted, transmitted, proposed, etc.
+    # we need to set the timeout to more than one round, since it might take few rounds for the transaction to be accepted, transmitted, proposed, etc.
     set timeout 20
 
     if { [ catch {

--- a/util/metrics/serviceCommon.go
+++ b/util/metrics/serviceCommon.go
@@ -24,7 +24,7 @@ import (
 )
 
 // ServiceConfig would contain all the information we need in order to create a listening server endpoint.
-// We migth want to support rolling port numbers so that we could easily support multiple endpoints per machine.
+// We might want to support rolling port numbers so that we could easily support multiple endpoints per machine.
 // ( note that multiple endpoints per machine doesn't solve the question "how would the prometheus server figure that out")
 type ServiceConfig struct {
 	NodeExporterListenAddress string


### PR DESCRIPTION
## Summary

The function `GetRoundTxIds` is no longer used by the evaluator, and not needed to be part of the `ledgerForEvaluator` interface. The backing implementation on `Ledger` was left as is for future usage. 

Note that as of this PR, there are no other places in our codebase which calls to `GetRoundTxIds`.

Also - I fixed a common typo of mine: `migth` -> `might`