### PR TITLE
Add test for when the user does not provide a correct application json

### DIFF
--- a/test/e2e-go/cli/goal/expect/goalDryrunRestTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalDryrunRestTest.exp
@@ -21,7 +21,7 @@ proc TestGoalDryrun { DRREQ_FILE TEST_PRIMARY_NODE_DIR } {
     }
 }
 
-proc TestGoalDryrunFailure { DRREQ_FILE TEST_PRIMARY_NODE_DIR EXPECTED_STATUS_CODE EXPECTED_MESSAGE} {
+proc TestGoalDryrunExitCode { DRREQ_FILE TEST_PRIMARY_NODE_DIR EXPECTED_STATUS_CODE EXPECTED_MESSAGE} {
     set MESSAGE_MATCHED 0
     spawn goal clerk dryrun-remote -d $TEST_PRIMARY_NODE_DIR -D $DRREQ_FILE -v
     expect {
@@ -114,8 +114,9 @@ if { [catch {
     TestGoalDryrun $DRREQ_FILE_1 $TEST_PRIMARY_NODE_DIR
     TestGoalDryrun $DRREQ_FILE_2 $TEST_PRIMARY_NODE_DIR
     TestGoalDryrun $DRREQ_FILE_3 $TEST_PRIMARY_NODE_DIR
-    TestGoalDryrunFailure "" $TEST_PRIMARY_NODE_DIR 1 "Cannot read file : open : no such file or directory"
-    TestGoalDryrunFailure $INVALID_FILE_1 $TEST_PRIMARY_NODE_DIR 1 "dryrun-remote: HTTP 400 Bad Request:"
+    TestGoalDryrunExitCode $DRREQ_FILE_3 $TEST_PRIMARY_NODE_DIR 0 "PASS"
+    TestGoalDryrunExitCode "" $TEST_PRIMARY_NODE_DIR 1 "Cannot read file : open : no such file or directory"
+    TestGoalDryrunExitCode $INVALID_FILE_1 $TEST_PRIMARY_NODE_DIR 1 "dryrun-remote: HTTP 400 Bad Request:"
 
     # Shutdown the network
     ::AlgorandGoal::StopNetwork $NETWORK_NAME $TEST_ALGO_DIR $TEST_ROOT_DIR

--- a/test/e2e-go/cli/goal/expect/goalDryrunRestTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalDryrunRestTest.exp
@@ -21,6 +21,25 @@ proc TestGoalDryrun { DRREQ_FILE TEST_PRIMARY_NODE_DIR } {
     }
 }
 
+proc TestGoalDryrunFailure { DRREQ_FILE TEST_PRIMARY_NODE_DIR EXPECTED_STATUS_CODE EXPECTED_MESSAGE} {
+    set MESSAGE_MATCHED 0
+    spawn goal clerk dryrun-remote -d $TEST_PRIMARY_NODE_DIR -D $DRREQ_FILE -v
+    expect {
+        timeout { ::AlgorandGoal::Abort "goal clerk dryrun-remote timeout" }
+        $EXPECTED_MESSAGE {puts "message matched"; set MESSAGE_MATCHED 1; close}
+        eof
+    }
+    catch wait result
+    set STATUS_CODE [lindex $result 3]
+    if { $STATUS_CODE != $EXPECTED_STATUS_CODE } {
+        puts "Exit code: $STATUS_CODE, expected: $EXPECTED_STATUS_CODE"
+        ::AlgorandGoal::Abort "Progran exited with incorrect code"
+    }
+    if { $MESSAGE_MATCHED == 0 } {
+        ::AlgorandGoal::Abort "Progam message did not match expected"
+    }
+}
+
 if { [catch {
 
     source  goalExpectCommon.exp
@@ -88,6 +107,7 @@ if { [catch {
     TestGoalDryrun $DRREQ_FILE_1 $TEST_PRIMARY_NODE_DIR
     TestGoalDryrun $DRREQ_FILE_2 $TEST_PRIMARY_NODE_DIR
     TestGoalDryrun $DRREQ_FILE_3 $TEST_PRIMARY_NODE_DIR
+    TestGoalDryrunFailure "" $TEST_PRIMARY_NODE_DIR 1 "Cannot read file : open : no such file or directory"
 
     # Shutdown the network
     ::AlgorandGoal::StopNetwork $NETWORK_NAME $TEST_ALGO_DIR $TEST_ROOT_DIR

--- a/test/e2e-go/cli/goal/expect/goalDryrunRestTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalDryrunRestTest.exp
@@ -104,10 +104,18 @@ if { [catch {
         timeout { ::AlgorandGoal::Abort "goal app create timeout" }
     }
 
+    # invalid app
+    set INVALID_FILE_1 "$TEST_ROOT_DIR/invalid-app.json"
+    set INVALID_FILE_1_ID [open $INVALID_FILE_1 "w"]
+    set INVALID_FILE_1_DATA "{ \"round\": -1 }"
+    puts -nonewline $INVALID_FILE_1_ID $INVALID_FILE_1_DATA
+    close $INVALID_FILE_1_ID
+
     TestGoalDryrun $DRREQ_FILE_1 $TEST_PRIMARY_NODE_DIR
     TestGoalDryrun $DRREQ_FILE_2 $TEST_PRIMARY_NODE_DIR
     TestGoalDryrun $DRREQ_FILE_3 $TEST_PRIMARY_NODE_DIR
     TestGoalDryrunFailure "" $TEST_PRIMARY_NODE_DIR 1 "Cannot read file : open : no such file or directory"
+    TestGoalDryrunFailure $INVALID_FILE_1 $TEST_PRIMARY_NODE_DIR 1 "dryrun-remote: HTTP 400 Bad Request:"
 
     # Shutdown the network
     ::AlgorandGoal::StopNetwork $NETWORK_NAME $TEST_ALGO_DIR $TEST_ROOT_DIR


### PR DESCRIPTION
## Summary

This adds a test for goal clerk dryrun failures. Right now it just tests the failure case of not providing an application file, but it includes a method that can test any error message scenario we can expect

## Test Plan

I ran the test and ensured that the test is checking the expected values
