### PR TITLE
base64 encode binary keys/values in json `TealKeyValue`, `EvalDeltaKeyValue` model

### DIFF
--- a/cmd/tealdbg/dryrunRequest.go
+++ b/cmd/tealdbg/dryrunRequest.go
@@ -80,7 +80,11 @@ func balanceRecordsFromDdr(ddr *v2.DryrunRequest) (records []basics.BalanceRecor
 			return
 		}
 		// deserialize app params and update account data
-		params := v2.ApplicationParamsToAppParams(&a.Params)
+		var params basics.AppParams
+		params, err = v2.ApplicationParamsToAppParams(&a.Params)
+		if err != nil {
+			return
+		}
 		appIdx := basics.AppIndex(a.Id)
 		ad := accounts[addr]
 		if ad.AppParams == nil {

--- a/daemon/algod/api/server/v2/account.go
+++ b/daemon/algod/api/server/v2/account.go
@@ -132,9 +132,9 @@ func convertTKVToGenerated(tkv *basics.TealKeyValue) *generated.TealKeyValueStor
 	return &converted
 }
 
-func convertGeneratedTKV(akvs *generated.TealKeyValueStore) basics.TealKeyValue {
+func convertGeneratedTKV(akvs *generated.TealKeyValueStore) (basics.TealKeyValue, error) {
 	if akvs == nil || len(*akvs) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	tkv := make(basics.TealKeyValue)
@@ -142,13 +142,13 @@ func convertGeneratedTKV(akvs *generated.TealKeyValueStore) basics.TealKeyValue 
 		// Decode base-64 encoded map key
 		decodedKey, err := base64.StdEncoding.DecodeString(kv.Key)
 		if err != nil {
-			decodedKey = nil
+			return nil, err
 		}
 
 		// Decode base-64 encoded map value (OK even if empty string)
 		decodedBytes, err := base64.StdEncoding.DecodeString(kv.Value.Bytes)
 		if err != nil {
-			decodedBytes = nil
+			return nil, err
 		}
 
 		tkv[string(decodedKey)] = basics.TealValue{
@@ -157,7 +157,7 @@ func convertGeneratedTKV(akvs *generated.TealKeyValueStore) basics.TealKeyValue 
 			Bytes: string(decodedBytes),
 		}
 	}
-	return tkv
+	return tkv, nil
 }
 
 // AccountToAccountData converts v2.generated.Account to basics.AccountData
@@ -233,12 +233,16 @@ func AccountToAccountData(a *generated.Account) (basics.AccountData, error) {
 	if a.AppsLocalState != nil && len(*a.AppsLocalState) > 0 {
 		appLocalStates = make(map[basics.AppIndex]basics.AppLocalState, len(*a.AppsLocalState))
 		for _, ls := range *a.AppsLocalState {
+			kv, err := convertGeneratedTKV(ls.KeyValue)
+			if err != nil {
+				return basics.AccountData{}, err
+			}
 			appLocalStates[basics.AppIndex(ls.Id)] = basics.AppLocalState{
 				Schema: basics.StateSchema{
 					NumUint:      ls.Schema.NumUint,
 					NumByteSlice: ls.Schema.NumByteSlice,
 				},
-				KeyValue: convertGeneratedTKV(ls.KeyValue),
+				KeyValue: kv,
 			}
 		}
 	}
@@ -247,7 +251,11 @@ func AccountToAccountData(a *generated.Account) (basics.AccountData, error) {
 	if a.CreatedApps != nil && len(*a.CreatedApps) > 0 {
 		appParams = make(map[basics.AppIndex]basics.AppParams, len(*a.CreatedApps))
 		for _, params := range *a.CreatedApps {
-			appParams[basics.AppIndex(params.Id)] = ApplicationParamsToAppParams(&params.Params)
+			ap, err := ApplicationParamsToAppParams(&params.Params)
+			if err != nil {
+				return basics.AccountData{}, err
+			}
+			appParams[basics.AppIndex(params.Id)] = ap
 		}
 	}
 
@@ -302,7 +310,7 @@ func AccountToAccountData(a *generated.Account) (basics.AccountData, error) {
 }
 
 // ApplicationParamsToAppParams converts generated.ApplicationParams to basics.AppParams
-func ApplicationParamsToAppParams(gap *generated.ApplicationParams) basics.AppParams {
+func ApplicationParamsToAppParams(gap *generated.ApplicationParams) (basics.AppParams, error) {
 	ap := basics.AppParams{
 		ApprovalProgram:   gap.ApprovalProgram,
 		ClearStateProgram: gap.ClearStateProgram,
@@ -319,9 +327,13 @@ func ApplicationParamsToAppParams(gap *generated.ApplicationParams) basics.AppPa
 			NumByteSlice: gap.GlobalStateSchema.NumByteSlice,
 		}
 	}
-	ap.GlobalState = convertGeneratedTKV(gap.GlobalState)
+	kv, err := convertGeneratedTKV(gap.GlobalState)
+	if err != nil {
+		return basics.AppParams{}, err
+	}
+	ap.GlobalState = kv
 
-	return ap
+	return ap, nil
 }
 
 // AppParamsToApplication converts basics.AppParams to generated.Application

--- a/daemon/algod/api/server/v2/account_test.go
+++ b/daemon/algod/api/server/v2/account_test.go
@@ -78,17 +78,17 @@ func TestAccount(t *testing.T) {
 	require.Equal(t, uint64(0), ls.Schema.NumByteSlice)
 	require.Equal(t, 2, len(*ls.KeyValue))
 	value1 := generated.TealKeyValue{
-		Key: "uint",
+		Key: b64("uint"),
 		Value: generated.TealValue{
 			Type: uint64(basics.TealUintType),
 			Uint: 2,
 		},
 	}
 	value2 := generated.TealKeyValue{
-		Key: "bytes",
+		Key: b64("bytes"),
 		Value: generated.TealValue{
 			Type:  uint64(basics.TealBytesType),
-			Bytes: "value",
+			Bytes: b64("value"),
 		},
 	}
 	require.Contains(t, *ls.KeyValue, value1)

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -289,7 +289,10 @@ func (dl *dryrunLedger) Get(addr basics.Address, withPendingRewards bool) (basic
 	if ok {
 		any = true
 		app := dl.dr.Apps[appi]
-		params := ApplicationParamsToAppParams(&app.Params)
+		params, err := ApplicationParamsToAppParams(&app.Params)
+		if err != nil {
+			return basics.BalanceRecord{}, err
+		}
 		if out.AppParams == nil {
 			out.AppParams = make(map[basics.AppIndex]basics.AppParams)
 			out.AppParams[basics.AppIndex(app.Id)] = params
@@ -447,7 +450,11 @@ func doDryrunRequest(dr *DryrunRequest, proto *config.ConsensusParams, response 
 			ok := false
 			for _, appt := range dr.Apps {
 				if appt.Id == uint64(appIdx) {
-					app = ApplicationParamsToAppParams(&appt.Params)
+					app, err = ApplicationParamsToAppParams(&appt.Params)
+					if err != nil {
+						response.Error = err.Error()
+						return
+					}
 					ok = true
 					break
 				}

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -522,7 +522,7 @@ func StateDeltaToStateDelta(sd basics.StateDelta) *generated.StateDelta {
 		}
 		// basics.DeleteAction does not require Uint/Bytes
 		kv := generated.EvalDeltaKeyValue{
-			Key:   k,
+			Key:   base64.StdEncoding.EncodeToString([]byte(k)),
 			Value: value,
 		}
 		gsd = append(gsd, kv)

--- a/daemon/algod/api/server/v2/dryrun_test.go
+++ b/daemon/algod/api/server/v2/dryrun_test.go
@@ -60,6 +60,10 @@ func dbStack(stack []generated.TealValue) string {
 	return strings.Join(parts, " ")
 }
 
+func b64(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
 func logTrace(t *testing.T, lines []string, trace []generated.DryrunState) {
 	var disasm string
 	for _, ds := range trace {
@@ -396,8 +400,8 @@ func TestDryrunGlobal1(t *testing.T) {
 	}
 	gkv := generated.TealKeyValueStore{
 		generated.TealKeyValue{
-			Key:   "foo",
-			Value: generated.TealValue{Type: uint64(basics.TealBytesType), Bytes: "bar"},
+			Key:   b64("foo"),
+			Value: generated.TealValue{Type: uint64(basics.TealBytesType), Bytes: b64("bar")},
 		},
 	}
 	dr.Apps = []generated.Application{
@@ -445,8 +449,8 @@ func TestDryrunGlobal2(t *testing.T) {
 	}
 	gkv := generated.TealKeyValueStore{
 		generated.TealKeyValue{
-			Key:   "foo",
-			Value: generated.TealValue{Type: uint64(basics.TealBytesType), Bytes: "bar"},
+			Key:   b64("foo"),
+			Value: generated.TealValue{Type: uint64(basics.TealBytesType), Bytes: b64("bar")},
 		},
 	}
 	dr.Apps = []generated.Application{
@@ -525,10 +529,10 @@ func TestDryrunLocal1(t *testing.T) {
 		if lds.Address == "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ" {
 			addrFound = true
 			for _, ld := range lds.Delta {
-				if ld.Key == "foo" {
+				if ld.Key == b64("foo") {
 					valueFound = true
 					assert.Equal(t, ld.Value.Action, uint64(basics.SetBytesAction))
-					assert.Equal(t, *ld.Value.Bytes, "YmFy") // bar
+					assert.Equal(t, *ld.Value.Bytes, b64("bar"))
 
 				}
 			}
@@ -603,10 +607,10 @@ func TestDryrunLocal1A(t *testing.T) {
 		if lds.Address == "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ" {
 			addrFound = true
 			for _, ld := range lds.Delta {
-				if ld.Key == "foo" {
+				if ld.Key == b64("foo") {
 					valueFound = true
 					assert.Equal(t, ld.Value.Action, uint64(basics.SetBytesAction))
-					assert.Equal(t, *ld.Value.Bytes, "YmFy") // bar
+					assert.Equal(t, *ld.Value.Bytes, b64("bar"))
 
 				}
 			}
@@ -659,8 +663,11 @@ func TestDryrunLocalCheck(t *testing.T) {
 	}
 	localv := make(generated.TealKeyValueStore, 1)
 	localv[0] = generated.TealKeyValue{
-		Key:   "foo",
-		Value: generated.TealValue{Type: uint64(basics.TealBytesType), Bytes: "bar"},
+		Key: b64("foo"),
+		Value: generated.TealValue{
+			Type:  uint64(basics.TealBytesType),
+			Bytes: b64("bar"),
+		},
 	}
 
 	dr.Accounts = []generated.Account{
@@ -711,8 +718,8 @@ func TestDryrunEncodeDecode(t *testing.T) {
 	}
 	localv := make(generated.TealKeyValueStore, 1)
 	localv[0] = generated.TealKeyValue{
-		Key:   "foo",
-		Value: generated.TealValue{Type: uint64(basics.TealBytesType), Bytes: "bar"},
+		Key:   b64("foo"),
+		Value: generated.TealValue{Type: uint64(basics.TealBytesType), Bytes: b64("bar")},
 	}
 
 	gdr.Accounts = []generated.Account{
@@ -942,17 +949,17 @@ func TestStateDeltaToStateDelta(t *testing.T) {
 	var keys []string
 	// test with a loop because sd is a map and iteration order is random
 	for _, item := range *gsd {
-		if item.Key == "byteskey" {
+		if item.Key == b64("byteskey") {
 			require.Equal(t, uint64(1), item.Value.Action)
 			require.Nil(t, item.Value.Uint)
 			require.NotNil(t, item.Value.Bytes)
-			require.Equal(t, base64.StdEncoding.EncodeToString([]byte("test")), *item.Value.Bytes)
-		} else if item.Key == "intkey" {
+			require.Equal(t, b64("test"), *item.Value.Bytes)
+		} else if item.Key == b64("intkey") {
 			require.Equal(t, uint64(2), item.Value.Action)
 			require.NotNil(t, item.Value.Uint)
 			require.Equal(t, uint64(11), *item.Value.Uint)
 			require.Nil(t, item.Value.Bytes)
-		} else if item.Key == "delkey" {
+		} else if item.Key == b64("delkey") {
 			require.Equal(t, uint64(3), item.Value.Action)
 			require.Nil(t, item.Value.Uint)
 			require.Nil(t, item.Value.Bytes)
@@ -960,7 +967,7 @@ func TestStateDeltaToStateDelta(t *testing.T) {
 		keys = append(keys, item.Key)
 	}
 	require.Equal(t, 3, len(keys))
-	require.Contains(t, keys, "intkey")
-	require.Contains(t, keys, "byteskey")
-	require.Contains(t, keys, "delkey")
+	require.Contains(t, keys, b64("intkey"))
+	require.Contains(t, keys, b64("byteskey"))
+	require.Contains(t, keys, b64("delkey"))
 }


### PR DESCRIPTION
## Summary
- Byte keys and values should be base64 encoded when represented as json
- `EvalDeltaKeyValue` values were being base64 encoded, but their keys weren't