### PR TITLE
TEAL: assembler error on branching behind last instruction

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1072,6 +1072,16 @@ func (ops *OpStream) assemble(fin io.Reader) error {
 		err := fmt.Errorf("unknown opcode %v", opstring)
 		return lineErr(ops.sourceLine, err)
 	}
+
+	// backward compatibility: do not allow jumps behind last instruction in TEAL v1
+	if ops.Version <= 1 {
+		for label, dest := range ops.labels {
+			if dest == ops.Out.Len() {
+				return fmt.Errorf(":%d label %v is too far away", ops.sourceLine, label)
+			}
+		}
+	}
+
 	// TODO: warn if expected resulting stack is not len==1 ?
 	return ops.resolveLabels()
 }
@@ -1296,6 +1306,13 @@ func (dis *disassembleState) putLabel(label string, target int) {
 		dis.pendingLabels = make(map[int]string)
 	}
 	dis.pendingLabels[target] = label
+}
+
+func (dis *disassembleState) outputLabelIfNeeded() (err error) {
+	if label, hasLabel := dis.pendingLabels[dis.pc]; hasLabel {
+		_, err = fmt.Fprintf(dis.out, "%s:\n", label)
+	}
+	return
 }
 
 type disassembleFunc func(dis *disassembleState, spec *OpSpec)
@@ -1684,7 +1701,7 @@ type disInfo struct {
 	hasStatefulOps bool
 }
 
-// DisassembleInstrumented is like Disassemble, but additionally returns where
+// disassembleInstrumented is like Disassemble, but additionally returns where
 // each program counter value maps in the disassembly
 func disassembleInstrumented(program []byte) (text string, ds disInfo, err error) {
 	out := strings.Builder{}
@@ -1703,13 +1720,9 @@ func disassembleInstrumented(program []byte) (text string, ds disInfo, err error
 	fmt.Fprintf(dis.out, "// version %d\n", version)
 	dis.pc = vlen
 	for dis.pc < len(program) {
-		label, hasLabel := dis.pendingLabels[dis.pc]
-		if hasLabel {
-			_, dis.err = fmt.Fprintf(dis.out, "%s:\n", label)
-			if dis.err != nil {
-				err = dis.err
-				return
-			}
+		err = dis.outputLabelIfNeeded()
+		if err != nil {
+			return
 		}
 		op := opsByOpcode[version][program[dis.pc]]
 		if op.Modes == runModeApplication {
@@ -1736,6 +1749,11 @@ func disassembleInstrumented(program []byte) (text string, ds disInfo, err error
 		}
 		dis.pc = dis.nextpc
 	}
+	err = dis.outputLabelIfNeeded()
+	if err != nil {
+		return
+	}
+
 	text = out.String()
 	return
 }

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -789,6 +789,7 @@ bnz nowhere`
 }
 
 func TestAssembleJumpToTheEnd(t *testing.T) {
+	t.Parallel()
 	text := `intcblock 1
 intc 0
 intc 0
@@ -931,6 +932,8 @@ func TestAssembleDisassembleCycle(t *testing.T) {
 }
 
 func TestAssembleDisassembleErrors(t *testing.T) {
+	t.Parallel()
+
 	source := `txn Sender`
 	program, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
@@ -1040,6 +1043,7 @@ func TestAssembleDisassembleErrors(t *testing.T) {
 }
 
 func TestAssembleVersions(t *testing.T) {
+	t.Parallel()
 	text := `int 1
 txna Accounts 0
 `
@@ -1067,6 +1071,7 @@ int 1
 }
 
 func TestAssembleAsset(t *testing.T) {
+	t.Parallel()
 	source := "int 0\nint 0\nasset_holding_get ABC 1"
 	_, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.Error(t, err)
@@ -1089,6 +1094,7 @@ func TestAssembleAsset(t *testing.T) {
 }
 
 func TestDisassembleSingleOp(t *testing.T) {
+	t.Parallel()
 	// test ensures no double arg_0 entries in disassembly listing
 	sample := "// version 2\narg_0\n"
 	program, err := AssembleStringWithVersion(sample, AssemblerMaxVersion)
@@ -1100,6 +1106,7 @@ func TestDisassembleSingleOp(t *testing.T) {
 }
 
 func TestDisassembleTxna(t *testing.T) {
+	t.Parallel()
 	// check txn and txna are properly disassembled
 	txnSample := "// version 2\ntxn Sender\n"
 	program, err := AssembleStringWithVersion(txnSample, AssemblerMaxVersion)
@@ -1125,6 +1132,7 @@ func TestDisassembleTxna(t *testing.T) {
 }
 
 func TestDisassembleGtxna(t *testing.T) {
+	t.Parallel()
 	// check gtxn and gtxna are properly disassembled
 	gtxnSample := "// version 2\ngtxn 0 Sender\n"
 	program, err := AssembleStringWithVersion(gtxnSample, AssemblerMaxVersion)
@@ -1149,7 +1157,29 @@ func TestDisassembleGtxna(t *testing.T) {
 	require.Equal(t, gtxnaSample, disassembled)
 }
 
+func TestDisassembleLastLabel(t *testing.T) {
+	t.Parallel()
+
+	// starting from TEAL v2 branching to the last line are legal
+	for v := uint64(2); v <= AssemblerMaxVersion; v++ {
+		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
+			source := fmt.Sprintf(`// version %d
+intcblock 1
+intc_0
+bnz label1
+label1:
+`, v)
+			program, err := AssembleStringWithVersion(source, v)
+			require.NoError(t, err)
+			dis, err := Disassemble(program)
+			require.NoError(t, err)
+			require.Equal(t, source, dis)
+		})
+	}
+}
+
 func TestAssembleOffsets(t *testing.T) {
+	t.Parallel()
 	source := "err"
 	program, offsets, err := AssembleStringWithVersionEx(source, AssemblerMaxVersion)
 	require.NoError(t, err)
@@ -1247,6 +1277,7 @@ err
 }
 
 func TestHasStatefulOps(t *testing.T) {
+	t.Parallel()
 	source := "int 1"
 	program, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
@@ -1267,6 +1298,7 @@ err
 }
 
 func TestStringLiteralParsing(t *testing.T) {
+	t.Parallel()
 	s := `"test"`
 	e := []byte(`test`)
 	result, err := parseStringLiteral(s)
@@ -1343,6 +1375,7 @@ func TestStringLiteralParsing(t *testing.T) {
 }
 
 func TestPragmaStream(t *testing.T) {
+	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		text := fmt.Sprintf("#pragma version %d", v)
 		sr := strings.NewReader(text)
@@ -1452,6 +1485,7 @@ func TestPragmaStream(t *testing.T) {
 }
 
 func TestAssemblePragmaVersion(t *testing.T) {
+	t.Parallel()
 	text := `#pragma version 1
 int 1
 `
@@ -1513,7 +1547,6 @@ len
 
 func TestAssembleConstants(t *testing.T) {
 	t.Parallel()
-
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			_, err := AssembleStringWithVersion("intc 1", v)

--- a/data/transactions/logic/backwardCompat_test.go
+++ b/data/transactions/logic/backwardCompat_test.go
@@ -250,6 +250,7 @@ dup
 var programTEALv1 = "01200500010220ffffffffffffffffff012608014120559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd0142201f675bff07515f5df96737194ea945c36c41e7b4fcef307b7cd4d0e602a6911101432034b99f8dde1ba273c0a28cf5b2e4dbe497f8cb2453de0c8ba6d578c9431a62cb0100200000000000000000000000000000000000000000000000000000000000000000280129122a022b1210270403270512102d2e2f041022082209230a230b240c220d230e230f231022112312231314301525121617182319231a221b21041c1d12222312242512102104231210482829122a2b121027042706121048310031071331013102121022310413103105310613103108311613103109310a1210310b310f1310310c310d1210310e31101310311131121310311331141210311531171210483300003300071333000133000212102233000413103300053300061310330008330016131033000933000a121033000b33000f131033000c33000d121033000e3300101310330011330012131033001333001412103300153300171210483200320112320232041310320327071210350034001040000100234912"
 
 func TestBackwardCompatTEALv1(t *testing.T) {
+	t.Parallel()
 	var s crypto.Seed
 	crypto.RandBytes(s[:])
 	c := crypto.GenerateSignatureSecrets(s)
@@ -330,6 +331,7 @@ func TestBackwardCompatTEALv1(t *testing.T) {
 // ensure v2 fields error on pre TEAL v2 logicsig version
 // ensure v2 fields error in v1 program
 func TestBackwardCompatGlobalFields(t *testing.T) {
+	t.Parallel()
 	var fields []string
 	for _, fs := range globalFieldSpecs {
 		if fs.version > 1 {
@@ -395,6 +397,7 @@ func TestBackwardCompatGlobalFields(t *testing.T) {
 
 // ensure v2 fields error in v1 program
 func TestBackwardCompatTxnFields(t *testing.T) {
+	t.Parallel()
 	var fields []txnFieldSpec
 	for _, fs := range txnFieldSpecs {
 		if fs.version > 1 {
@@ -478,5 +481,43 @@ func TestBackwardCompatTxnFields(t *testing.T) {
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "invalid txn field")
 		}
+	}
+}
+
+func TestBackwardCompatAssemble(t *testing.T) {
+	// TEAL v1 does not allow branching to the last line
+	// TEAL v2 makes such programs legal
+	t.Parallel()
+	source := `int 0
+int 1
+bnz done
+done:`
+
+	t.Run("v=default", func(t *testing.T) {
+		_, err := AssembleString(source)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), ":4 label done is too far away")
+	})
+
+	t.Run("v=0", func(t *testing.T) {
+		_, err := AssembleStringWithVersion(source, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), ":4 label done is too far away")
+	})
+
+	t.Run("v=1", func(t *testing.T) {
+		_, err := AssembleStringWithVersion(source, 1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), ":4 label done is too far away")
+	})
+
+	for v := uint64(2); v <= AssemblerMaxVersion; v++ {
+		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
+			program, err := AssembleStringWithVersion(source, v)
+			require.NoError(t, err)
+			ep := defaultEvalParams(nil, nil)
+			_, err = Eval(program, ep)
+			require.NoError(t, err)
+		})
 	}
 }

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -2662,9 +2662,12 @@ func TestShortProgram(t *testing.T) {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			program, err := AssembleStringWithVersion(`int 1
 bnz done
-done:`, v)
+done:
+int 1
+`, v)
 			require.NoError(t, err)
-			program = program[:len(program)-1]
+			// cut two last bytes - intc_1 and last byte of bnz
+			program = program[:len(program)-2]
 			cost, err := Check(program, defaultEvalParams(nil, nil))
 			require.Error(t, err)
 			require.True(t, cost < 1000)


### PR DESCRIPTION
## Summary

* TEAL v1 does not allow such program, so make assembler compatible
* TEAL v2 permits the mentioned behavior

## Test Plan

Added new test to validate v1 and v2 behavior

## Notes

1. Fixed disassembly listing for such programs - no unknown labels anymore
2. Switched some asm tests to `t.Parallel()`