### PR TITLE
Optimize accountsUpdateBalances implementation

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1076,7 +1076,7 @@ func (au *accountUpdates) accountsUpdateBalances(accountsDeltasRound []map[basic
 			}
 		}
 		if accumulatedChanges >= trieAccumulatedChangesFlush {
-			accumulatedChanges -= trieAccumulatedChangesFlush
+			accumulatedChanges = 0
 			err = au.balancesTrie.Commit()
 			if err != nil {
 				return

--- a/ledger/totals_test.go
+++ b/ledger/totals_test.go
@@ -17,7 +17,6 @@
 package ledger
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"

--- a/ledger/totals_test.go
+++ b/ledger/totals_test.go
@@ -68,8 +68,7 @@ func TestAlgoCountMarshalMsg(t *testing.T) {
 	inBuffer := make([]byte, 0, 128)
 	outBuffer, err := ac.MarshalMsg(inBuffer)
 	require.NoError(t, err)
-	//fmt.Printf("out %d in %d\n", len(outBuffer), len(inBuffer))
-	require.True(t, len(outBuffer) > len(inBuffer))
+	require.Truef(t, len(outBuffer) > len(inBuffer), "len(outBuffer) : %d\nlen(inBuffer): %d\n", len(outBuffer), len(inBuffer))
 
 	// allocate a buffer that is just the right size.
 	inBuffer = make([]byte, len(outBuffer))

--- a/ledger/totals_test.go
+++ b/ledger/totals_test.go
@@ -69,7 +69,7 @@ func TestAlgoCountMarshalMsg(t *testing.T) {
 	inBuffer := make([]byte, 0, 128)
 	outBuffer, err := ac.MarshalMsg(inBuffer)
 	require.NoError(t, err)
-	fmt.Printf("out %d in %d\n", len(outBuffer), len(inBuffer))
+	//fmt.Printf("out %d in %d\n", len(outBuffer), len(inBuffer))
 	require.True(t, len(outBuffer) > len(inBuffer))
 
 	// allocate a buffer that is just the right size.


### PR DESCRIPTION
## Summary
Existing code was calling `accountsUpdateBalances` for each round, applying the deltas to the trie and committing the changes to disk. However, on some of our testings, we have 1-2 changes per block, and we're pushing 2000-4000 blocks very quickly. This leads to a scenario where `commitRound` is asked to flush 500+ rounds to disk in a single batch. From
logical perspective, there is nothing wrong here.

Unfortunately, flushing 500 rounds * 2 changes =~ 1000 Merkle trie pages. ( i.e. the root page + one extra page update)
When flushing 1000 pages on slow machines such as travis, it can take a long time, and we want to avoid that.
( i.e. if a single flush takes 50ms on a NAS drive, it would take 50 seconds to complete.. )
In order to resolve that, I have moved the round iteration loop into the `accountsUpdateBalances`, and added periodic flush that depends on the number of pending changes. The Merkle trie implementation is sufficiently smart to omit unneeded changes, so that if some pages are being added and later on removed, it would just ignore these pages completly.

Note that for a normal running node, this is not an issue, since the incoming block update rate would not be that high.

## Solution Approach
I was contemplating whether a good fix would be to update the unit test to reflect a realistic usage of the `Ledger` interface or improve the `acctupdate` implementation. I went with the `acctupdate` path as this would marginally improve the overall performance.

## Test Plan
Use existing test