### PR TITLE
Reformat some of the short commands descriptions

### DIFF
--- a/cmd/algocfg/main.go
+++ b/cmd/algocfg/main.go
@@ -31,7 +31,7 @@ func init() {
 
 var rootCmd = &cobra.Command{
 	Use:   "algocfg",
-	Short: "tool for inspecting and updating algod's config.json file",
+	Short: "Tool for inspecting and updating algod's config.json file",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.HelpFunc()(cmd, args)

--- a/cmd/diagcfg/telemetry.go
+++ b/cmd/diagcfg/telemetry.go
@@ -169,7 +169,7 @@ var telemetryNameCmd = &cobra.Command{
 
 var telemetryEndpointCmd = &cobra.Command{
 	Use:   "endpoint -e <url>",
-	Short: "sets the \"URI\" property",
+	Short: "Sets the \"URI\" property",
 	Long:  `Sets the "URI" property in the telemetry configuration`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := readTelemetryConfigOrExit()

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -563,7 +563,7 @@ var rawsendCmd = &cobra.Command{
 
 var inspectCmd = &cobra.Command{
 	Use:   "inspect [input file 1] [input file 2]...",
-	Short: "print a transaction file",
+	Short: "Print a transaction file",
 	Long:  `Loads a transaction file, attempts to decode the transaction, and displays the decoded information.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		for _, txFilename := range args {
@@ -851,7 +851,7 @@ func disassembleFile(fname, outname string) {
 
 var compileCmd = &cobra.Command{
 	Use:   "compile [input file 1] [input file 2]...",
-	Short: "compile a contract program",
+	Short: "Compile a contract program",
 	Long:  "Reads a TEAL contract program and compiles it to binary output and contract address.",
 	Run: func(cmd *cobra.Command, args []string) {
 		for _, fname := range args {
@@ -909,7 +909,7 @@ var compileCmd = &cobra.Command{
 
 var dryrunCmd = &cobra.Command{
 	Use:   "dryrun",
-	Short: "test a program offline",
+	Short: "Test a program offline",
 	Long:  "Test a TEAL program offline under various conditions and verbosity.",
 	Run: func(cmd *cobra.Command, args []string) {
 		data, err := readFile(txFilename)
@@ -972,7 +972,7 @@ var dryrunCmd = &cobra.Command{
 
 var dryrunRemoteCmd = &cobra.Command{
 	Use:   "dryrun-remote",
-	Short: "test a program with algod's dryrun REST endpoint",
+	Short: "Test a program with algod's dryrun REST endpoint",
 	Long:  "Test a TEAL program with algod's dryrun REST endpoint under various conditions and verbosity.",
 	Run: func(cmd *cobra.Command, args []string) {
 		data, err := readFile(txFilename)

--- a/cmd/goal/commands.go
+++ b/cmd/goal/commands.go
@@ -103,7 +103,7 @@ func init() {
 
 var rootCmd = &cobra.Command{
 	Use:   "goal",
-	Short: "CLI for interacting with Algorand.",
+	Short: "CLI for interacting with Algorand",
 	Long:  `GOAL is the CLI for interacting Algorand software instance. The binary 'goal' is installed alongside the algod binary and is considered an integral part of the complete installation. The binaries should be used in tandem - you should not try to use a version of goal with a different version of algod.`,
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -160,7 +160,7 @@ func main() {
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "The current version of the Algorand daemon (algod).",
+	Short: "The current version of the Algorand daemon (algod)",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, args []string) {
 		onDataDirs(func(dataDir string) {
@@ -184,7 +184,7 @@ var versionCmd = &cobra.Command{
 
 var licenseCmd = &cobra.Command{
 	Use:   "license",
-	Short: "Display license information.",
+	Short: "Display license information",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(config.GetLicenseInfo())

--- a/cmd/goal/completion.go
+++ b/cmd/goal/completion.go
@@ -29,7 +29,7 @@ func init() {
 
 var completionCmd = &cobra.Command{
 	Use:   "completion",
-	Short: "Shell completion helper.",
+	Short: "Shell completion helper",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, args []string) {
 		// If no arguments passed, we should fallback to help
@@ -39,7 +39,7 @@ var completionCmd = &cobra.Command{
 
 var bashCompletionCmd = &cobra.Command{
 	Use:   "bash",
-	Short: "Generate bash completion commands.",
+	Short: "Generate bash completion commands",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
 		rootCmd.GenBashCompletion(os.Stdout)
@@ -48,7 +48,7 @@ var bashCompletionCmd = &cobra.Command{
 
 var zshCompletionCmd = &cobra.Command{
 	Use:   "zsh",
-	Short: "Generate zsh completion commands.",
+	Short: "Generate zsh completion commands",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
 		rootCmd.GenZshCompletion(os.Stdout)

--- a/cmd/goal/kmd.go
+++ b/cmd/goal/kmd.go
@@ -61,7 +61,7 @@ func startKMDForDataDir(binDir, algodDataDir, kmdDataDir string) {
 
 var startKMDCmd = &cobra.Command{
 	Use:   "start",
-	Short: "Start the kmd process, or restart it with an updated timeout.",
+	Short: "Start the kmd process, or restart it with an updated timeout",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, args []string) {
 		binDir, err := util.ExeDir()
@@ -78,7 +78,7 @@ var startKMDCmd = &cobra.Command{
 
 var stopKMDCmd = &cobra.Command{
 	Use:   "stop",
-	Short: "Stop the kmd process if it is running.",
+	Short: "Stop the kmd process if it is running",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, args []string) {
 		binDir, err := util.ExeDir()

--- a/cmd/goal/ledger.go
+++ b/cmd/goal/ledger.go
@@ -45,7 +45,7 @@ func init() {
 
 var ledgerCmd = &cobra.Command{
 	Use:   "ledger",
-	Short: "Access ledger-related details.",
+	Short: "Access ledger-related details",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, args []string) {
 		// If no arguments passed, we should fallback to help

--- a/cmd/goal/logging.go
+++ b/cmd/goal/logging.go
@@ -90,7 +90,7 @@ var enableCmd = &cobra.Command{
 
 var disableCmd = &cobra.Command{
 	Use:   "disable",
-	Short: "Disable Algorand remote logging.",
+	Short: "Disable Algorand remote logging",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
 		fmt.Fprintf(os.Stderr, "Warning: `goal logging disable` deprecated, use `diagcfg telemetry disable`\n")

--- a/cmd/goal/network.go
+++ b/cmd/goal/network.go
@@ -156,7 +156,7 @@ var networkStartCmd = &cobra.Command{
 
 var networkRestartCmd = &cobra.Command{
 	Use:   "restart",
-	Short: "Restart a deployed private network.",
+	Short: "Restart a deployed private network",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
 		network, binDir := getNetworkAndBinDir()
@@ -171,7 +171,7 @@ var networkRestartCmd = &cobra.Command{
 
 var networkStopCmd = &cobra.Command{
 	Use:   "stop",
-	Short: "Stop a deployed private network.",
+	Short: "Stop a deployed private network",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
 		network, binDir := getNetworkAndBinDir()
@@ -182,7 +182,7 @@ var networkStopCmd = &cobra.Command{
 
 var networkStatusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Prints status for all nodes in a deployed private network.",
+	Short: "Prints status for all nodes in a deployed private network",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
 		network, binDir := getNetworkAndBinDir()

--- a/cmd/goal/node.go
+++ b/cmd/goal/node.go
@@ -153,7 +153,7 @@ func catchpointCmdArgument(cmd *cobra.Command, args []string) error {
 
 var startCmd = &cobra.Command{
 	Use:   "start",
-	Short: "Initialize the specified Algorand node.",
+	Short: "Initialize the specified Algorand node",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
 		if !verifyPeerDialArg() {
@@ -228,7 +228,7 @@ func getRunHostedConfigFlag(dataDir string) bool {
 
 var stopCmd = &cobra.Command{
 	Use:   "stop",
-	Short: "stop the specified Algorand node.",
+	Short: "Stop the specified Algorand node",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
 		binDir, err := util.ExeDir()
@@ -256,7 +256,7 @@ var stopCmd = &cobra.Command{
 
 var restartCmd = &cobra.Command{
 	Use:   "restart",
-	Short: "Stop, and then start, the specified Algorand node.",
+	Short: "Stop, and then start, the specified Algorand node",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
 		if !verifyPeerDialArg() {
@@ -319,7 +319,7 @@ var restartCmd = &cobra.Command{
 
 var generateTokenCmd = &cobra.Command{
 	Use:   "generatetoken",
-	Short: "Generate and install a new API token.",
+	Short: "Generate and install a new API token",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
 		onDataDirs(func(dataDir string) {
@@ -553,7 +553,7 @@ func isValidIP(userInput string) bool {
 
 var createCmd = &cobra.Command{
 	Use:   "create",
-	Short: "Create a node at the desired data directory for the desired network.",
+	Short: "Create a node at the desired data directory for the desired network",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
 

--- a/cmd/goal/wallet.go
+++ b/cmd/goal/wallet.go
@@ -48,7 +48,7 @@ func init() {
 
 var walletCmd = &cobra.Command{
 	Use:   "wallet",
-	Short: "Manage wallets: encrypted collections of Algorand account keys.",
+	Short: "Manage wallets: encrypted collections of Algorand account keys",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Update the default wallet
@@ -79,7 +79,7 @@ var walletCmd = &cobra.Command{
 
 var newWalletCmd = &cobra.Command{
 	Use:   "new [wallet name]",
-	Short: "Create a new wallet.",
+	Short: "Create a new wallet",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
@@ -185,7 +185,7 @@ var newWalletCmd = &cobra.Command{
 
 var listWalletsCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List wallets managed by kmd.",
+	Short: "List wallets managed by kmd",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
 		onDataDirs(func(dataDir string) {

--- a/cmd/netgoal/generate.go
+++ b/cmd/netgoal/generate.go
@@ -79,8 +79,8 @@ var generateTemplateLines = []string{
 
 var generateCmd = &cobra.Command{
 	Use:   "generate",
-	Short: "generate network template",
-	Long: `generate network template or genesis.json
+	Short: "Generate network template",
+	Long: `Generate network template or genesis.json
 -r is required for all netgoal commands but unused by generate
 
 template modes for -t:`,

--- a/cmd/netgoal/network.go
+++ b/cmd/netgoal/network.go
@@ -55,8 +55,8 @@ func init() {
 
 var networkBuildCmd = &cobra.Command{
 	Use:   "build",
-	Short: "build network deployment artifacts",
-	Long:  `build network deployment artifacts for modifying before deploying`,
+	Short: "Build network deployment artifacts",
+	Long:  `Build network deployment artifacts for modifying before deploying`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Similar to `goal network create`, we need to generate a genesis.json and wallets and store somewhere.
 		// We have a lot more parameters to define, so we'll support a subset of parameters on cmdline but

--- a/cmd/nodecfg/apply.go
+++ b/cmd/nodecfg/apply.go
@@ -54,8 +54,8 @@ func init() {
 
 var applyCmd = &cobra.Command{
 	Use:   "apply",
-	Short: "apply a node configuration to a new host",
-	Long:  `apply a node configuration to a new host providing feedback on progress`,
+	Short: "Apply a node configuration to a new host",
+	Long:  `Apply a node configuration to a new host providing feedback on progress`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := validateArgs(); err != nil {
 			reportErrorf("Error validating arguments: %v", err)


### PR DESCRIPTION
## Summary

Updates the short commands descriptions so that they would be :
1. Capitalized ( with the exception of tool names, which are case sensitive )
2. Have no "." at the end of the sentence ( just to align it with the rest of the commands. )