### PR TITLE
Remove redundant ledger.close in TestArchivalCreatables

### DIFF
--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -455,7 +455,6 @@ func TestArchivalCreatables(t *testing.T) {
 	l.Close()
 	l, err = OpenLedger(logging.Base(), dbPrefix, inMem, genesisInitState, cfg)
 	require.NoError(t, err)
-	defer l.Close()
 
 	// check that we can fetch creator for all created assets and can't for
 	// deleted assets


### PR DESCRIPTION
## Summary

The unit test include a redundant call to ledger.Close.
Given that the ledger is not desiged to supports that, i'm removong this call.
