### PR TITLE
Fix a bug where goal inspect fails to process a rekeyed transaction

### DIFF
--- a/cmd/goal/inspect.go
+++ b/cmd/goal/inspect.go
@@ -33,10 +33,11 @@ import (
 type inspectSignedTxn struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	Sig  crypto.Signature         `codec:"sig"`
-	Msig inspectMultisigSig       `codec:"msig"`
-	Lsig inspectLogicSig          `codec:"lsig"`
-	Txn  transactions.Transaction `codec:"txn"`
+	Sig      crypto.Signature         `codec:"sig"`
+	Msig     inspectMultisigSig       `codec:"msig"`
+	Lsig     inspectLogicSig          `codec:"lsig"`
+	Txn      transactions.Transaction `codec:"txn"`
+	AuthAddr basics.Address           `codec:"sgnr"`
 }
 
 // inspectMultisigSig is isomorphic to MultisigSig but uses different
@@ -115,19 +116,21 @@ func inspectTxn(stxn transactions.SignedTxn) (sti inspectSignedTxn, err error) {
 
 func stxnToInspect(stxn transactions.SignedTxn) inspectSignedTxn {
 	return inspectSignedTxn{
-		Txn:  stxn.Txn,
-		Sig:  stxn.Sig,
-		Msig: msigToInspect(stxn.Msig),
-		Lsig: lsigToInspect(stxn.Lsig),
+		Txn:      stxn.Txn,
+		Sig:      stxn.Sig,
+		Msig:     msigToInspect(stxn.Msig),
+		Lsig:     lsigToInspect(stxn.Lsig),
+		AuthAddr: stxn.AuthAddr,
 	}
 }
 
 func stxnFromInspect(sti inspectSignedTxn) transactions.SignedTxn {
 	return transactions.SignedTxn{
-		Txn:  sti.Txn,
-		Sig:  sti.Sig,
-		Msig: msigFromInspect(sti.Msig),
-		Lsig: lsigFromInspect(sti.Lsig),
+		Txn:      sti.Txn,
+		Sig:      sti.Sig,
+		Msig:     msigFromInspect(sti.Msig),
+		Lsig:     lsigFromInspect(sti.Lsig),
+		AuthAddr: sti.AuthAddr,
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

`goal clerk inspect` failed to work on rekeyed transactions. This PR fixes it. 

Fixes #1300 