### PR TITLE
Make /tmp into a tmpfs on travis linux/amd64

### DIFF
--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -18,6 +18,8 @@ if [[ "${OS}" == "linux" ]]; then
         sudo apt-get update -y
         sudo apt-get -y install sqlite3
     elif [[ "${ARCH}" == "amd64" ]]; then
+        echo "/etc/fstab : "
+        sudo cat /etc/fstab
         sudo mv /tmp /old_tmp
         sudo mkdir -p /tmp
         sudo chmod 777 /tmp

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -26,8 +26,9 @@ if [[ "${OS}" == "linux" ]]; then
         # none /var/ramfs tmpfs defaults,size=768m,noatime 0 2
 
         sudo umount -l /var/ramfs
+        sudo umount -l /dev/shm
         sudo sed '3d' /etc/fstab > fstab
-        sudo echo "none /var/ramfs tmpfs defaults,noatime,nosuid,nodev,size=256m,noatime,mode=0755 0 0" >> fstab
+        #sudo echo "none /var/ramfs tmpfs defaults,noatime,nosuid,nodev,size=256m,noatime,mode=0755 0 0" >> fstab
         sudo echo "tmpfs /tmp tmpfs rw,noatime,size=768m,noatime,mode=1777 0 0" >> fstab
         sudo cp fstab /etc/fstab
         sudo rm fstab

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -24,9 +24,11 @@ if [[ "${OS}" == "linux" ]]; then
         sudo cat /etc/fstab
         # removes the last line which is
         # none /var/ramfs tmpfs defaults,size=768m,noatime 0 2
+
+        sudo umount -l /var/ramfs
         sudo sed '3d' /etc/fstab > fstab
         sudo echo "none /var/ramfs tmpfs defaults,noatime,nosuid,nodev,size=256m,noatime,mode=0755 0 0" >> fstab
-        sudo echo "tmpfs /tmp tmpfs defaults,noatime,nosuid,nodev,size=768m,noatime,mode=0755 0 0" >> fstab
+        sudo echo "tmpfs /tmp tmpfs rw,noatime,size=768m,noatime,mode=1777 0 0" >> fstab
         sudo cp fstab /etc/fstab
         sudo rm fstab
         sudo mount -a

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -22,6 +22,7 @@ if [[ "${OS}" == "linux" ]]; then
         sudo mkdir -p /tmp
         sudo chmod 777 /tmp
         sudo mount -t tmpfs -o rw,size=768M tmpfs /tmp
+        cp -r /old_tmp/ /tmp
     fi
 elif [[ "${OS}" == "darwin" ]]; then
     # we don't want to upgrade boost if we already have it, as it will try to update

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -33,6 +33,9 @@ if [[ "${OS}" == "linux" ]]; then
         sudo chmod 777 /tmp
         sudo mount -t tmpfs -o rw,size=768M tmpfs /tmp
         sudo cp -r /old_tmp/ /tmp
+        echo "/etc/fstab (updated): "
+        sudo cat /etc/fstab
+        sudo df -H
     fi
 elif [[ "${OS}" == "darwin" ]]; then
     # we don't want to upgrade boost if we already have it, as it will try to update

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -19,6 +19,8 @@ if [[ "${OS}" == "linux" ]]; then
         sudo apt-get -y install sqlite3
     elif [[ "${ARCH}" == "amd64" ]]; then
         sudo mv /tmp /old_tmp
+        sudo mkdir -p /tmp
+        sudo chmod 777 /tmp
         sudo mount -t tmpfs -o rw,size=512M tmpfs /tmp
     fi
 elif [[ "${OS}" == "darwin" ]]; then

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -18,9 +18,8 @@ if [[ "${OS}" == "linux" ]]; then
         sudo apt-get update -y
         sudo apt-get -y install sqlite3
     elif [[ "${ARCH}" == "amd64" ]]; then
-        sudo mkdir -p /mnt/ramdisk
-        sudo mount -t tmpfs -o rw,size=512M tmpfs /mnt/ramdisk
-        ln -s /mnt/ramdisk /tmp
+        sudo mv /tmp /old_tmp
+        sudo mount -t tmpfs -o rw,size=512M tmpfs /tmp
     fi
 elif [[ "${OS}" == "darwin" ]]; then
     # we don't want to upgrade boost if we already have it, as it will try to update

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -21,7 +21,7 @@ if [[ "${OS}" == "linux" ]]; then
         sudo mv /tmp /old_tmp
         sudo mkdir -p /tmp
         sudo chmod 777 /tmp
-        cp /old_tmp /tmp
+        cp -r /old_tmp /tmp
         sudo mount -t tmpfs -o rw,size=512M tmpfs /tmp
     fi
 elif [[ "${OS}" == "darwin" ]]; then

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -18,13 +18,21 @@ if [[ "${OS}" == "linux" ]]; then
         sudo apt-get update -y
         sudo apt-get -y install sqlite3
     elif [[ "${ARCH}" == "amd64" ]]; then
+        set +x
         echo "/etc/fstab : "
         sudo cat /etc/fstab
+        # removes the last line which is
+        # none /var/ramfs tmpfs defaults,size=768m,noatime 0 2
+        sudo sed '3d' /etc/fstab > fstab
+        sudo echo "none /var/ramfs tmpfs rw,size=256m,noatime,mode=1777 0 2" >> fstab
+        sudo cp fstab /etc/fstab
+        sudo rm fstab
+        sudo mount -a
         sudo mv /tmp /old_tmp
         sudo mkdir -p /tmp
         sudo chmod 777 /tmp
         sudo mount -t tmpfs -o rw,size=768M tmpfs /tmp
-        cp -r /old_tmp/ /tmp
+        sudo cp -r /old_tmp/ /tmp
     fi
 elif [[ "${OS}" == "darwin" ]]; then
     # we don't want to upgrade boost if we already have it, as it will try to update

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -21,7 +21,7 @@ if [[ "${OS}" == "linux" ]]; then
         sudo mv /tmp /old_tmp
         sudo mkdir -p /tmp
         sudo chmod 777 /tmp
-        cp -r /old_tmp /tmp
+        cp -r /old_tmp/ /tmp
         sudo mount -t tmpfs -o rw,size=512M tmpfs /tmp
     fi
 elif [[ "${OS}" == "darwin" ]]; then

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -21,7 +21,7 @@ if [[ "${OS}" == "linux" ]]; then
         sudo mv /tmp /old_tmp
         sudo mkdir -p /tmp
         sudo chmod 777 /tmp
-        sudo mount -t tmpfs -o rw,size=512M tmpfs /tmp
+        sudo mount -t tmpfs -o rw,size=1024M tmpfs /tmp
         cp -r /old_tmp/ /tmp
     fi
 elif [[ "${OS}" == "darwin" ]]; then

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -21,8 +21,8 @@ if [[ "${OS}" == "linux" ]]; then
         sudo mv /tmp /old_tmp
         sudo mkdir -p /tmp
         sudo chmod 777 /tmp
-        cp -r /old_tmp/ /tmp
         sudo mount -t tmpfs -o rw,size=512M tmpfs /tmp
+        cp -r /old_tmp/ /tmp
     fi
 elif [[ "${OS}" == "darwin" ]]; then
     # we don't want to upgrade boost if we already have it, as it will try to update

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -21,6 +21,7 @@ if [[ "${OS}" == "linux" ]]; then
         sudo mv /tmp /old_tmp
         sudo mkdir -p /tmp
         sudo chmod 777 /tmp
+        cp /old_tmp /tmp
         sudo mount -t tmpfs -o rw,size=512M tmpfs /tmp
     fi
 elif [[ "${OS}" == "darwin" ]]; then

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -19,20 +19,24 @@ if [[ "${OS}" == "linux" ]]; then
         sudo apt-get -y install sqlite3
     elif [[ "${ARCH}" == "amd64" ]]; then
         set -x
+        sudo df -H
         echo "/etc/fstab : "
         sudo cat /etc/fstab
         # removes the last line which is
         # none /var/ramfs tmpfs defaults,size=768m,noatime 0 2
         sudo sed '3d' /etc/fstab > fstab
-        sudo echo "none /var/ramfs tmpfs rw,size=256m,noatime,mode=1777 0 2" >> fstab
+        sudo echo "none /var/ramfs tmpfs defaults,noatime,nosuid,nodev,size=256m,noatime,mode=0755 0 0" >> fstab
+        sudo echo "tmpfs /tmp tmpfs defaults,noatime,nosuid,nodev,size=768m,noatime,mode=0755 0 0" >> fstab
         sudo cp fstab /etc/fstab
         sudo rm fstab
         sudo mount -a
-        sudo mv /tmp /old_tmp
-        sudo mkdir -p /tmp
-        sudo chmod 777 /tmp
-        sudo mount -t tmpfs -o rw,size=768M tmpfs /tmp
-        sudo cp -r /old_tmp/ /tmp
+        
+        #sudo mv /tmp /old_tmp
+        #sudo mkdir -p /tmp
+        #sudo chmod 777 /tmp
+        #sudo mount -t tmpfs -o rw,size=768M tmpfs /tmp
+        #sudo cp -r /old_tmp/ /tmp
+        
         echo "/etc/fstab (updated): "
         sudo cat /etc/fstab
         sudo df -H

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -18,11 +18,20 @@ if [[ "${OS}" == "linux" ]]; then
         sudo apt-get update -y
         sudo apt-get -y install sqlite3
     elif [[ "${ARCH}" == "amd64" ]]; then
+        #sudo mv /tmp /old_tmp
+        #sudo mkdir -p /tmp
+        #sudo chmod 777 /tmp
+        #sudo mount -t tmpfs -o rw,size=768M tmpfs /tmp
+        #cp -r /old_tmp/ /tmp
+        ls -h /tmp
+        sudo df -h
         sudo mv /tmp /old_tmp
         sudo mkdir -p /tmp
-        sudo chmod 777 /tmp
-        sudo mount -t tmpfs -o rw,size=768M tmpfs /tmp
+        sudo mkdir -p /run/tmp
+        sudo chmod 777 /run/tmp
+        ln -s /tmp /run/tmp
         cp -r /old_tmp/ /tmp
+        ls -h /tmp
     fi
 elif [[ "${OS}" == "darwin" ]]; then
     # we don't want to upgrade boost if we already have it, as it will try to update

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -18,7 +18,7 @@ if [[ "${OS}" == "linux" ]]; then
         sudo apt-get update -y
         sudo apt-get -y install sqlite3
     elif [[ "${ARCH}" == "amd64" ]]; then
-        set +x
+        set -x
         echo "/etc/fstab : "
         sudo cat /etc/fstab
         # removes the last line which is

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -17,6 +17,10 @@ if [[ "${OS}" == "linux" ]]; then
         set -e
         sudo apt-get update -y
         sudo apt-get -y install sqlite3
+    elif [[ "${ARCH}" == "amd64" ]]; then
+        sudo mkdir -p /mnt/ramdisk
+        sudo mount -t tmpfs -o rw,size=512M tmpfs /mnt/ramdisk
+        ln -s /mnt/ramdisk /tmp
     fi
 elif [[ "${OS}" == "darwin" ]]; then
     # we don't want to upgrade boost if we already have it, as it will try to update

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -18,20 +18,10 @@ if [[ "${OS}" == "linux" ]]; then
         sudo apt-get update -y
         sudo apt-get -y install sqlite3
     elif [[ "${ARCH}" == "amd64" ]]; then
-        #sudo mv /tmp /old_tmp
-        #sudo mkdir -p /tmp
-        #sudo chmod 777 /tmp
-        #sudo mount -t tmpfs -o rw,size=768M tmpfs /tmp
-        #cp -r /old_tmp/ /tmp
-        ls -h /tmp
-        sudo df -h
         sudo mv /tmp /old_tmp
         sudo mkdir -p /tmp
-        sudo mkdir -p /run/tmp
-        sudo chmod 777 /run/tmp
-        ln -s /tmp /run/tmp
-        cp -r /old_tmp/ /tmp
-        ls -h /tmp
+        sudo chmod 777 /tmp
+        sudo mount -t tmpfs -o rw,size=768M tmpfs /tmp
     fi
 elif [[ "${OS}" == "darwin" ]]; then
     # we don't want to upgrade boost if we already have it, as it will try to update

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -21,7 +21,7 @@ if [[ "${OS}" == "linux" ]]; then
         sudo mv /tmp /old_tmp
         sudo mkdir -p /tmp
         sudo chmod 777 /tmp
-        sudo mount -t tmpfs -o rw,size=1024M tmpfs /tmp
+        sudo mount -t tmpfs -o rw,size=768M tmpfs /tmp
         cp -r /old_tmp/ /tmp
     fi
 elif [[ "${OS}" == "darwin" ]]; then


### PR DESCRIPTION
## Solution

Configure the travis linux/amd64 hosts to use a 768MB of in-memory tmp directory.
This change is intended to create a more deterministic running environment, where the network mapped disk would not negatively affect the unit tests. 


