### PR TITLE
Fix exit code race in dryrun expect test

### DIFF
--- a/test/e2e-go/cli/goal/expect/goalDryrunRestTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalDryrunRestTest.exp
@@ -25,11 +25,9 @@ proc TestGoalDryrunExitCode { DRREQ_FILE TEST_PRIMARY_NODE_DIR EXPECTED_STATUS_C
     spawn goal clerk dryrun-remote -d $TEST_PRIMARY_NODE_DIR -D $DRREQ_FILE -v
     expect {
         timeout { ::AlgorandGoal::Abort "goal clerk dryrun-remote timeout" }
-        $EXPECTED_MESSAGE {puts "message matched"; set MESSAGE_MATCHED 1; close}
-        eof
+        $EXPECTED_MESSAGE {puts "message matched"; set MESSAGE_MATCHED 1; exp_continue}
+        eof { catch wait result; set STATUS_CODE [lindex $result 3]; }
     }
-    catch wait result
-    set STATUS_CODE [lindex $result 3]
     if { $STATUS_CODE != $EXPECTED_STATUS_CODE } {
         puts "Exit code: $STATUS_CODE, expected: $EXPECTED_STATUS_CODE"
         ::AlgorandGoal::Abort "Progran exited with incorrect code"


### PR DESCRIPTION
## Summary

goalDryrunRestTest fails time to time with "Exit code: 0, expected: 1".
This PR moves an exit code check to expect/eof block as all other tests do to avoid possible race in expect.

## Test Plan

This is fix for the test.