### PR TITLE
Add a unit test for catchpointWriter

### DIFF
--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -112,7 +112,7 @@ func randomFullAccountData(rewardsLevel uint64) basics.AccountData {
 				},
 				KeyValue: make(map[string]basics.TealValue),
 			}
-			appName := fmt.Sprintf("app%x", crypto.RandUint64())
+			appName := fmt.Sprintf("lapp%x", crypto.RandUint64())
 			for i := uint64(0); i < ap.Schema.NumUint; i++ {
 				ap.KeyValue[appName] = basics.TealValue{
 					Type: basics.TealUintType,
@@ -132,21 +132,31 @@ func randomFullAccountData(rewardsLevel uint64) basics.AccountData {
 		}
 	}
 
+	if 1 == (crypto.RandUint64() % 3) {
+		data.TotalAppSchema = basics.StateSchema{
+			NumUint:      crypto.RandUint64() % 50,
+			NumByteSlice: crypto.RandUint64() % 50,
+		}
+	}
+	if 1 == (crypto.RandUint64() % 3) {
+		data.AppParams = make(map[basics.AppIndex]basics.AppParams)
+		appParamsCount := crypto.RandUint64()%20 + 1
+		for i := uint64(0); i < appParamsCount; i++ {
+			ap := basics.AppParams{
+				ApprovalProgram:   make([]byte, int(crypto.RandUint64())%config.MaxAppProgramLen),
+				ClearStateProgram: make([]byte, int(crypto.RandUint64())%config.MaxAppProgramLen),
+			}
+			crypto.RandBytes(ap.ApprovalProgram[:])
+			crypto.RandBytes(ap.ClearStateProgram[:])
+			data.AppParams[basics.AppIndex(crypto.RandUint64()%50000)] = ap
+		}
+
+	}
 	//fmt.Printf("%v\n", data.SelectionID)
 	/*
-		// AppLocalStates stores the local states associated with any applications
-		// that this account has opted in to.
-		AppLocalStates map[AppIndex]AppLocalState `codec:"appl,allocbound=encodedMaxAppLocalStates"`
-
 		// AppParams stores the global parameters and state associated with any
 		// applications that this account has created.
 		AppParams map[AppIndex]AppParams `codec:"appp,allocbound=encodedMaxAppParams"`
-
-		// TotalAppSchema stores the sum of all of the LocalStateSchemas
-		// and GlobalStateSchemas in this account (global for applications
-		// we created local for applications we opted in to), so that we don't
-		// have to iterate over all of them to compute MinBalance.
-		TotalAppSchema StateSchema `codec:"tsch"`
 	*/
 	return data
 }

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -101,6 +101,37 @@ func randomFullAccountData(rewardsLevel uint64) basics.AccountData {
 		crypto.RandBytes(data.AuthAddr[:])
 	}
 
+	if 1 == (crypto.RandUint64() % 3) {
+		data.AppLocalStates = make(map[basics.AppIndex]basics.AppLocalState)
+		appStatesCount := crypto.RandUint64()%20 + 1
+		for i := uint64(0); i < appStatesCount; i++ {
+			ap := basics.AppLocalState{
+				Schema: basics.StateSchema{
+					NumUint:      crypto.RandUint64() % 5,
+					NumByteSlice: crypto.RandUint64() % 5,
+				},
+				KeyValue: make(map[string]basics.TealValue),
+			}
+			appName := fmt.Sprintf("app%x", crypto.RandUint64())
+			for i := uint64(0); i < ap.Schema.NumUint; i++ {
+				ap.KeyValue[appName] = basics.TealValue{
+					Type: basics.TealUintType,
+					Uint: crypto.RandUint64(),
+				}
+			}
+			for i := uint64(0); i < ap.Schema.NumByteSlice; i++ {
+				tv := basics.TealValue{
+					Type: basics.TealBytesType,
+				}
+				bytes := make([]byte, crypto.RandUint64()%512)
+				crypto.RandBytes(bytes[:])
+				tv.Bytes = string(bytes)
+				ap.KeyValue[appName] = tv
+			}
+			data.AppLocalStates[basics.AppIndex(crypto.RandUint64()%50000)] = ap
+		}
+	}
+
 	//fmt.Printf("%v\n", data.SelectionID)
 	/*
 		// AppLocalStates stores the local states associated with any applications

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -542,7 +542,7 @@ func TestLargeAccountCountCatchpointGeneration(t *testing.T) {
 	ml := makeMockLedgerForTracker(t, true)
 	defer ml.close()
 	ml.blocks = randomInitChain(testProtocolVersion, 10)
-	accts := []map[basics.Address]basics.AccountData{randomAccounts(100000, false)}
+	accts := []map[basics.Address]basics.AccountData{randomAccounts(100000, true)}
 	rewardsLevels := []uint64{0}
 
 	pooldata := basics.AccountData{}

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -237,7 +237,7 @@ func TestAcctUpdates(t *testing.T) {
 	defer ml.close()
 	ml.blocks = randomInitChain(protocol.ConsensusCurrentVersion, 10)
 
-	accts := []map[basics.Address]basics.AccountData{randomAccounts(20)}
+	accts := []map[basics.Address]basics.AccountData{randomAccounts(20, true)}
 	rewardsLevels := []uint64{0}
 
 	pooldata := basics.AccountData{}
@@ -318,7 +318,7 @@ func TestAcctUpdatesFastUpdates(t *testing.T) {
 	defer ml.close()
 	ml.blocks = randomInitChain(protocol.ConsensusCurrentVersion, 10)
 
-	accts := []map[basics.Address]basics.AccountData{randomAccounts(20)}
+	accts := []map[basics.Address]basics.AccountData{randomAccounts(20, true)}
 	rewardsLevels := []uint64{0}
 
 	pooldata := basics.AccountData{}
@@ -411,7 +411,7 @@ func BenchmarkBalancesChanges(b *testing.B) {
 	initialRounds := uint64(1)
 	ml.blocks = randomInitChain(protocolVersion, int(initialRounds))
 	accountsCount := 5000
-	accts := []map[basics.Address]basics.AccountData{randomAccounts(accountsCount)}
+	accts := []map[basics.Address]basics.AccountData{randomAccounts(accountsCount, true)}
 	rewardsLevels := []uint64{0}
 
 	pooldata := basics.AccountData{}
@@ -542,7 +542,7 @@ func TestLargeAccountCountCatchpointGeneration(t *testing.T) {
 	ml := makeMockLedgerForTracker(t, true)
 	defer ml.close()
 	ml.blocks = randomInitChain(testProtocolVersion, 10)
-	accts := []map[basics.Address]basics.AccountData{randomAccounts(100000)}
+	accts := []map[basics.Address]basics.AccountData{randomAccounts(100000, false)}
 	rewardsLevels := []uint64{0}
 
 	pooldata := basics.AccountData{}
@@ -635,7 +635,7 @@ func TestAcctUpdatesUpdatesCorrectness(t *testing.T) {
 		defer ml.close()
 		ml.blocks = randomInitChain(testProtocolVersion, 10)
 
-		accts := []map[basics.Address]basics.AccountData{randomAccounts(9)}
+		accts := []map[basics.Address]basics.AccountData{randomAccounts(9, true)}
 
 		pooldata := basics.AccountData{}
 		pooldata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
@@ -798,7 +798,7 @@ func TestAcctUpdatesDeleteStoredCatchpoints(t *testing.T) {
 	defer ml.close()
 	ml.blocks = randomInitChain(protocol.ConsensusCurrentVersion, 10)
 
-	accts := []map[basics.Address]basics.AccountData{randomAccounts(20)}
+	accts := []map[basics.Address]basics.AccountData{randomAccounts(20, true)}
 	au := &accountUpdates{}
 	conf := config.GetDefaultLocal()
 	conf.CatchpointInterval = 1

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -140,13 +140,13 @@ func TestBasicCatchpointWriter(t *testing.T) {
 	ml := makeMockLedgerForTracker(t, true)
 	defer ml.close()
 	ml.blocks = randomInitChain(testProtocolVersion, 10)
-	accts := []map[basics.Address]basics.AccountData{randomAccounts(300, false)}
+	accts := randomAccounts(300, false)
 
 	au := &accountUpdates{}
 	conf := config.GetDefaultLocal()
 	conf.CatchpointInterval = 1
 	conf.Archival = true
-	au.initialize(conf, ".", protoParams, accts[0])
+	au.initialize(conf, ".", protoParams, accts)
 	defer au.close()
 	err := au.loadFromDisk(ml)
 	require.NoError(t, err)
@@ -204,12 +204,12 @@ func TestBasicCatchpointWriter(t *testing.T) {
 			require.Equal(t, catchpointLabel, fileHeader.Catchpoint)
 			require.Equal(t, blocksRound, fileHeader.BlocksRound)
 			require.Equal(t, blockHeaderDigest, fileHeader.BlockHeaderDigest)
-			require.Equal(t, uint64(len(accts[0])), fileHeader.TotalAccounts)
+			require.Equal(t, uint64(len(accts)), fileHeader.TotalAccounts)
 		} else if header.Name == "balances.1.1.msgpack" {
 			var balances catchpointFileBalancesChunk
 			err = protocol.Decode(balancesBlockBytes, &balances)
 			require.NoError(t, err)
-			require.Equal(t, uint64(len(accts[0])), uint64(len(balances.Balances)))
+			require.Equal(t, uint64(len(accts)), uint64(len(balances.Balances)))
 		} else {
 			require.Failf(t, "unexpected tar chunk name %s", header.Name)
 		}
@@ -233,13 +233,13 @@ func TestFullCatchpointWriter(t *testing.T) {
 	ml := makeMockLedgerForTracker(t, true)
 	defer ml.close()
 	ml.blocks = randomInitChain(testProtocolVersion, 10)
-	accts := []map[basics.Address]basics.AccountData{randomAccounts(BalancesPerCatchpointFileChunk*3, false)}
+	accts := randomAccounts(BalancesPerCatchpointFileChunk*3, false)
 
 	au := &accountUpdates{}
 	conf := config.GetDefaultLocal()
 	conf.CatchpointInterval = 1
 	conf.Archival = true
-	au.initialize(conf, ".", protoParams, accts[0])
+	au.initialize(conf, ".", protoParams, accts)
 	defer au.close()
 	err := au.loadFromDisk(ml)
 	require.NoError(t, err)
@@ -310,7 +310,7 @@ func TestFullCatchpointWriter(t *testing.T) {
 	require.NoError(t, err)
 
 	// verify that the account data aligns with what we originally stored :
-	for addr, acct := range accts[0] {
+	for addr, acct := range accts {
 		acctData, err := l.LookupWithoutRewards(0, addr)
 		require.NoError(t, err)
 		require.Equal(t, acct, acctData)

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -130,15 +130,16 @@ func TestBasicCatchpointWriter(t *testing.T) {
 	protoParams.SeedLookback = 2
 	protoParams.SeedRefreshInterval = 8
 	config.Consensus[testProtocolVersion] = protoParams
+	temporaryDirectroy, _ := ioutil.TempDir(os.TempDir(), "catchpoints")
 	defer func() {
 		delete(config.Consensus, testProtocolVersion)
-		os.RemoveAll("./catchpoints")
+		os.RemoveAll(temporaryDirectroy)
 	}()
 
 	ml := makeMockLedgerForTracker(t, true)
 	defer ml.close()
 	ml.blocks = randomInitChain(testProtocolVersion, 10)
-	accts := []map[basics.Address]basics.AccountData{randomAccounts(300)}
+	accts := []map[basics.Address]basics.AccountData{randomAccounts(300, false)}
 
 	au := &accountUpdates{}
 	conf := config.GetDefaultLocal()
@@ -149,7 +150,99 @@ func TestBasicCatchpointWriter(t *testing.T) {
 	err := au.loadFromDisk(ml)
 	require.NoError(t, err)
 	au.close()
-	fileName := filepath.Join("./catchpoints", "15.catchpoint")
+	fileName := filepath.Join(temporaryDirectroy, "15.catchpoint")
+	blocksRound := basics.Round(12345)
+	blockHeaderDigest := crypto.Hash([]byte{1, 2, 3})
+	catchpointLabel := fmt.Sprintf("%d#%v", blocksRound, blockHeaderDigest) // this is not a correct way to create a label, but it's good enough for this unit test
+	writer := makeCatchpointWriter(fileName, ml.trackerDB().rdb, blocksRound, blockHeaderDigest, catchpointLabel)
+	for {
+		more, err := writer.WriteStep(context.Background())
+		require.NoError(t, err)
+		if !more {
+			break
+		}
+	}
+
+	// load the file from disk.
+	fileContent, err := ioutil.ReadFile(fileName)
+	require.NoError(t, err)
+	gzipReader, err := gzip.NewReader(bytes.NewBuffer(fileContent))
+	require.NoError(t, err)
+	tarReader := tar.NewReader(gzipReader)
+	defer gzipReader.Close()
+	for {
+		header, err := tarReader.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			break
+		}
+		balancesBlockBytes := make([]byte, header.Size)
+		readComplete := int64(0)
+
+		for readComplete < header.Size {
+			bytesRead, err := tarReader.Read(balancesBlockBytes[readComplete:])
+			readComplete += int64(bytesRead)
+			if err != nil {
+				if err == io.EOF {
+					if readComplete == header.Size {
+						break
+					}
+					require.NoError(t, err)
+				}
+				break
+			}
+		}
+		if header.Name == "content.msgpack" {
+			var fileHeader CatchpointFileHeader
+			err = protocol.Decode(balancesBlockBytes, &fileHeader)
+			require.NoError(t, err)
+			require.Equal(t, catchpointLabel, fileHeader.Catchpoint)
+			require.Equal(t, blocksRound, fileHeader.BlocksRound)
+			require.Equal(t, blockHeaderDigest, fileHeader.BlockHeaderDigest)
+			require.Equal(t, uint64(len(accts[0])), fileHeader.TotalAccounts)
+		} else if header.Name == "balances.1.1.msgpack" {
+			var balances catchpointFileBalancesChunk
+			err = protocol.Decode(balancesBlockBytes, &balances)
+			require.NoError(t, err)
+			require.Equal(t, uint64(len(accts[0])), uint64(len(balances.Balances)))
+		} else {
+			require.Failf(t, "unexpected tar chunk name %s", header.Name)
+		}
+	}
+}
+
+func TestCatchpointWriterWithApplicationsData(t *testing.T) {
+	// create new protocol version, which has lower back balance.
+	testProtocolVersion := protocol.ConsensusVersion("test-protocol-TestCatchpointWriterWithApplicationsData")
+	protoParams := config.Consensus[protocol.ConsensusCurrentVersion]
+	protoParams.MaxBalLookback = 32
+	protoParams.SeedLookback = 2
+	protoParams.SeedRefreshInterval = 8
+	config.Consensus[testProtocolVersion] = protoParams
+	temporaryDirectroy, _ := ioutil.TempDir(os.TempDir(), "catchpoints")
+	defer func() {
+		delete(config.Consensus, testProtocolVersion)
+		os.RemoveAll(temporaryDirectroy)
+	}()
+
+	ml := makeMockLedgerForTracker(t, true)
+	defer ml.close()
+	ml.blocks = randomInitChain(testProtocolVersion, 10)
+	accts := []map[basics.Address]basics.AccountData{randomAccounts(300, false)}
+
+	au := &accountUpdates{}
+	conf := config.GetDefaultLocal()
+	conf.CatchpointInterval = 1
+	conf.Archival = true
+	au.initialize(conf, ".", protoParams, accts[0])
+	defer au.close()
+	err := au.loadFromDisk(ml)
+	require.NoError(t, err)
+	au.close()
+	fileName := filepath.Join(temporaryDirectroy, "15.catchpoint")
 	blocksRound := basics.Round(12345)
 	blockHeaderDigest := crypto.Hash([]byte{1, 2, 3})
 	catchpointLabel := fmt.Sprintf("%d#%v", blocksRound, blockHeaderDigest) // this is not a correct way to create a label, but it's good enough for this unit test

--- a/ledger/cow_test.go
+++ b/ledger/cow_test.go
@@ -73,7 +73,7 @@ func applyUpdates(cow *roundCowState, updates map[basics.Address]accountDelta) {
 }
 
 func TestCowBalance(t *testing.T) {
-	accts0 := randomAccounts(20)
+	accts0 := randomAccounts(20, true)
 	ml := mockLedger{balanceMap: accts0}
 
 	c0 := makeRoundCowState(&ml, bookkeeping.BlockHeader{})


### PR DESCRIPTION
## Summary

Add a unit test for `catchpointWriter` named `TestFullCatchpointWriter`.
The test generates a random set of accounts, and initialize a database with them.
It generates a catchpoint file, and restore the file into another in-memory database using the catchup accessor.
Then, each of the original accounts are being compared to the one ended up on the in-memory database.