### PR TITLE
Disable deadlock detection on TestArchivalRestart and TestArchivalCreatables unit tests 

### DIFF
--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -410,8 +410,10 @@ func TestArchivalCreatables(t *testing.T) {
 		// Add the block
 		err = l.AddBlock(blk, agreement.Certificate{})
 		require.NoError(t, err)
+
+		l.Wait(blk.BlockHeader.Round - basics.Round(blk.BlockHeader.Round&31))
 	}
-	l.WaitForCommit(blk.Round())
+	l.Wait(blk.Round())
 
 	// check that we can fetch creator for all created assets/apps and
 	// can't for deleted assets/apps
@@ -591,8 +593,9 @@ func TestArchivalCreatables(t *testing.T) {
 		blk.Payset = nil
 		err = l.AddBlock(blk, agreement.Certificate{})
 		require.NoError(t, err)
+		l.Wait(blk.BlockHeader.Round - basics.Round(blk.BlockHeader.Round&31))
 	}
-	l.WaitForCommit(blk.Round())
+	l.Wait(blk.Round())
 
 	// close and reopen the same DB
 	l.Close()

--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -190,7 +190,6 @@ func TestArchivalRestart(t *testing.T) {
 		blk.BlockHeader.Round++
 		blk.BlockHeader.TimeStamp += int64(crypto.RandUint64() % 100 * 1000)
 		l.AddBlock(blk, agreement.Certificate{})
-		<-l.Wait(blk.BlockHeader.Round - basics.Round(blk.BlockHeader.Round&31))
 	}
 	l.WaitForCommit(blk.Round())
 
@@ -416,10 +415,8 @@ func TestArchivalCreatables(t *testing.T) {
 		// Add the block
 		err = l.AddBlock(blk, agreement.Certificate{})
 		require.NoError(t, err)
-
-		<-l.Wait(blk.BlockHeader.Round - basics.Round(blk.BlockHeader.Round&31))
 	}
-	<-l.Wait(blk.Round())
+	l.WaitForCommit(blk.Round())
 
 	// check that we can fetch creator for all created assets/apps and
 	// can't for deleted assets/apps
@@ -599,9 +596,8 @@ func TestArchivalCreatables(t *testing.T) {
 		blk.Payset = nil
 		err = l.AddBlock(blk, agreement.Certificate{})
 		require.NoError(t, err)
-		<-l.Wait(blk.BlockHeader.Round - basics.Round(blk.BlockHeader.Round&31))
 	}
-	<-l.Wait(blk.Round())
+	l.WaitForCommit(blk.Round())
 
 	// close and reopen the same DB
 	l.Close()

--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -31,6 +31,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/algorand/go-deadlock"
+
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
@@ -164,6 +166,9 @@ func TestArchival(t *testing.T) {
 
 func TestArchivalRestart(t *testing.T) {
 	// Start in archival mode, add 2K blocks, restart, ensure all blocks are there
+
+	// disable deadlock checking code
+	deadlock.Opts.Disable = true
 
 	dbTempDir, err := ioutil.TempDir("", "testdir"+t.Name())
 	require.NoError(t, err)
@@ -656,7 +661,7 @@ func makeSignedTxnInBlock(tx transactions.Transaction) transactions.SignedTxnInB
 
 func TestArchivalFromNonArchival(t *testing.T) {
 	// Start in non-archival mode, add 2K blocks, restart in archival mode ensure only genesis block is there
-
+	deadlock.Opts.Disable = true
 	dbTempDir, err := ioutil.TempDir(os.TempDir(), "testdir")
 	require.NoError(t, err)
 	dbName := fmt.Sprintf("%s.%d", t.Name(), crypto.RandUint64())

--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -679,7 +679,6 @@ func TestArchivalFromNonArchival(t *testing.T) {
 		blk.BlockHeader.Round++
 		blk.BlockHeader.TimeStamp += int64(crypto.RandUint64() % 100 * 1000)
 		l.AddBlock(blk, agreement.Certificate{})
-		<-l.Wait(blk.BlockHeader.Round - basics.Round(blk.BlockHeader.Round&31))
 	}
 	l.WaitForCommit(blk.Round())
 

--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -185,6 +185,7 @@ func TestArchivalRestart(t *testing.T) {
 		blk.BlockHeader.Round++
 		blk.BlockHeader.TimeStamp += int64(crypto.RandUint64() % 100 * 1000)
 		l.AddBlock(blk, agreement.Certificate{})
+		<-l.Wait(blk.BlockHeader.Round - basics.Round(blk.BlockHeader.Round&31))
 	}
 	l.WaitForCommit(blk.Round())
 
@@ -411,9 +412,9 @@ func TestArchivalCreatables(t *testing.T) {
 		err = l.AddBlock(blk, agreement.Certificate{})
 		require.NoError(t, err)
 
-		l.Wait(blk.BlockHeader.Round - basics.Round(blk.BlockHeader.Round&31))
+		<-l.Wait(blk.BlockHeader.Round - basics.Round(blk.BlockHeader.Round&31))
 	}
-	l.Wait(blk.Round())
+	<-l.Wait(blk.Round())
 
 	// check that we can fetch creator for all created assets/apps and
 	// can't for deleted assets/apps
@@ -593,9 +594,9 @@ func TestArchivalCreatables(t *testing.T) {
 		blk.Payset = nil
 		err = l.AddBlock(blk, agreement.Certificate{})
 		require.NoError(t, err)
-		l.Wait(blk.BlockHeader.Round - basics.Round(blk.BlockHeader.Round&31))
+		<-l.Wait(blk.BlockHeader.Round - basics.Round(blk.BlockHeader.Round&31))
 	}
-	l.Wait(blk.Round())
+	<-l.Wait(blk.Round())
 
 	// close and reopen the same DB
 	l.Close()
@@ -677,6 +678,7 @@ func TestArchivalFromNonArchival(t *testing.T) {
 		blk.BlockHeader.Round++
 		blk.BlockHeader.TimeStamp += int64(crypto.RandUint64() % 100 * 1000)
 		l.AddBlock(blk, agreement.Certificate{})
+		<-l.Wait(blk.BlockHeader.Round - basics.Round(blk.BlockHeader.Round&31))
 	}
 	l.WaitForCommit(blk.Round())
 

--- a/ledger/notifier.go
+++ b/ledger/notifier.go
@@ -81,7 +81,10 @@ func (bn *blockNotifier) close() {
 		bn.cond.Broadcast()
 	}
 	bn.mu.Unlock()
-	<-bn.closed
+	// we use select here so that we can read from nil channels - it's being used in our unit testing.
+	select {
+	case <-bn.closed:
+	}
 }
 
 func (bn *blockNotifier) loadFromDisk(l ledgerForTracker) error {


### PR DESCRIPTION
## Summary

The deadlock detection code was giving us lots of false positives when running the TestArchivalRestart and TestArchivalCreatables unit tests. Both these test have the following attributes:
1. Both are writing large number of blocks into the ledger almost at-once.
2. Both are using on disk storage.

As a result the account update tracker is attempting to make large operations, which, in turn, perform very slowly when running on travis since it uses network disk storage.

To work around that, I have disabled the deadlock detection during the runtime of these tests. To accomplish the latter without running into race condition with the `deadlock.Opts.Disable` global variable, I added a closing WaitGroup on the notifier.

Also, the `TestArchivalRestart` was not implemented correctly: writing 2000 blocks doesn't guarantee that once you reach round 2000, all the rounds before 1000 would get deleted. The account update is smart enough to update only as long as there are changes. Therefore, in order to ensure deletion, we also need to have some transactions inside these blocks. With having these transactions, the account updates would be forced to update the balances, and then committedUpTo would return an updated dbRound which would be the marker for blocks to get deleted.

## Fixes
This change would fix the following random failures:
```
POTENTIAL DEADLOCK:
Previous place where the lock was grabbed
goroutine 1215390 lock 0xc042084768
ledger.go:300 ledger.(*Ledger).notifyCommit { l.trackerMu.Lock() } <<<<<
blockqueue.go:136 ledger.(*blockQueue).syncer { minToSave := bq.l.notifyCommit(committed) }
Have been trying to lock it again for more than 30s
goroutine 1215359 lock 0xc042084768
ledger.go:387 ledger.(*Ledger).Totals { l.trackerMu.RLock() } <<<<<
eval.go:244 ledger.startEvaluator { prevTotals, err := l.Totals(eval.prevHeader.Round) }
eval.go:820 ledger.(*Ledger).eval { eval, err := startEvaluator(l, blk.BlockHeader, len(blk.Payset), validate, false) }
ledger.go:454 ledger.(*Ledger).AddBlock { updates, err := l.eval(context.Background(), blk, false, nil, nil) }
archival_test.go:411 ledger.TestArchivalCreatables { err = l.AddBlock(blk, agreement.Certificate{}) }
Here is what goroutine 1215390 doing now
goroutine 1215390 [chan send, 3 minutes]:
github.com/algorand/go-algorand/ledger.(*accountUpdates).committedUpTo.func1(0xc0420842d0, 0xc036427be8)
	/home/travis/gopath/src/github.com/algorand/go-algorand/ledger/acctupdates.go:440 +0xd3
github.com/algorand/go-algorand/ledger.(*accountUpdates).committedUpTo(0xc0420842d0, 0x56a, 0x3fc)
	/home/travis/gopath/src/github.com/algorand/go-algorand/ledger/acctupdates.go:532 +0x619
github.com/algorand/go-algorand/ledger.(*trackerRegistry).committedUpTo(0xc042084750, 0x56a, 0xc042084768)
	/home/travis/gopath/src/github.com/algorand/go-algorand/ledger/tracker.go:129 +0xae
github.com/algorand/go-algorand/ledger.(*Ledger).notifyCommit(0xc042084000, 0x56a, 0x0)
	/home/travis/gopath/src/github.com/algorand/go-algorand/ledger/ledger.go:302 +0x99
github.com/algorand/go-algorand/ledger.(*blockQueue).syncer(0xc041ea3a40)
	/home/travis/gopath/src/github.com/algorand/go-algorand/ledger/blockqueue.go:136 +0x53f
created by github.com/algorand/go-algorand/ledger.bqInit
	/home/travis/gopath/src/github.com/algorand/go-algorand/ledger/blockqueue.go:66 +0x304
FAIL	github.com/algorand/go-algorand/ledger	521.002s
```

and 
```
POTENTIAL DEADLOCK:
Previous place where the lock was grabbed
goroutine 1368610 lock 0xc043976768
ledger.go:300 ledger.(*Ledger).notifyCommit { l.trackerMu.Lock() } <<<<<
blockqueue.go:136 ledger.(*blockQueue).syncer { minToSave := bq.l.notifyCommit(committed) }
Have been trying to lock it again for more than 30s
goroutine 1368596 lock 0xc043976768
ledger.go:374 ledger.(*Ledger).LookupWithoutRewards { l.trackerMu.RLock() } <<<<<
eval.go:70 ledger.(*roundCowBase).lookup { return x.l.LookupWithoutRewards(x.rnd, addr) }
cow.go:103 ledger.(*roundCowState).lookup { return cb.lookupParent.lookup(addr) }
eval.go:102 ledger.(*roundCowState).PutWithCreatable { olddata, err := cs.lookup(record.Addr) }
eval.go:98 ledger.(*roundCowState).Put { return cs.PutWithCreatable(record, nil, nil) }
eval.go:98 ledger.(*roundCowState).Put { return cs.PutWithCreatable(record, nil, nil) }
eval.go:820 ledger.(*Ledger).eval { eval, err := startEvaluator(l, blk.BlockHeader, len(blk.Payset), validate, false) }
ledger.go:454 ledger.(*Ledger).AddBlock { updates, err := l.eval(context.Background(), blk, false, nil, nil) }
archival_test.go:676 ledger.TestArchivalFromNonArchival { l.AddBlock(blk, agreement.Certificate{}) }
Here is what goroutine 1368610 doing now
goroutine 1368610 [chan send]:
github.com/algorand/go-algorand/ledger.(*accountUpdates).committedUpTo.func1(0xc0439762d0, 0xc05a401be8)
	/home/travis/gopath/src/github.com/algorand/go-algorand/ledger/acctupdates.go:440 +0xd3
github.com/algorand/go-algorand/ledger.(*accountUpdates).committedUpTo(0xc0439762d0, 0x5ef, 0x433)
	/home/travis/gopath/src/github.com/algorand/go-algorand/ledger/acctupdates.go:532 +0x619
github.com/algorand/go-algorand/ledger.(*trackerRegistry).committedUpTo(0xc043976750, 0x5ef, 0xc043976768)
	/home/travis/gopath/src/github.com/algorand/go-algorand/ledger/tracker.go:129 +0xae
github.com/algorand/go-algorand/ledger.(*Ledger).notifyCommit(0xc043976000, 0x5ef, 0x0)
	/home/travis/gopath/src/github.com/algorand/go-algorand/ledger/ledger.go:302 +0x99
github.com/algorand/go-algorand/ledger.(*blockQueue).syncer(0xc05731c8c0)
	/home/travis/gopath/src/github.com/algorand/go-algorand/ledger/blockqueue.go:136 +0x53f
created by github.com/algorand/go-algorand/ledger.bqInit
	/home/travis/gopath/src/github.com/algorand/go-algorand/ledger/blockqueue.go:66 +0x304
FAIL	github.com/algorand/go-algorand/ledger	540.721s
```