### PR TITLE
Disable the deadlock detection on TestArchivalCreatables

### DIFF
--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -172,9 +172,10 @@ func TestArchivalRestart(t *testing.T) {
 	// Start in archival mode, add 2K blocks, restart, ensure all blocks are there
 
 	// disable deadlock checking code
+	deadlockDisable := deadlock.Opts.Disable
 	deadlock.Opts.Disable = true
 	defer func() {
-		deadlock.Opts.Disable = false
+		deadlock.Opts.Disable = deadlockDisable
 	}()
 
 	dbTempDir, err := ioutil.TempDir("", "testdir"+t.Name())
@@ -317,6 +318,13 @@ func TestArchivalCreatables(t *testing.T) {
 	// Start in archival mode, add 2K blocks with asset + app txns
 	// restart, ensure all assets are there in index unless they were
 	// deleted
+
+	// disable deadlock checking code
+	deadlockDisable := deadlock.Opts.Disable
+	deadlock.Opts.Disable = true
+	defer func() {
+		deadlock.Opts.Disable = deadlockDisable
+	}()
 
 	dbTempDir, err := ioutil.TempDir("", "testdir"+t.Name())
 	require.NoError(t, err)
@@ -664,9 +672,10 @@ func makeSignedTxnInBlock(tx transactions.Transaction) transactions.SignedTxnInB
 
 func TestArchivalFromNonArchival(t *testing.T) {
 	// Start in non-archival mode, add 2K blocks, restart in archival mode ensure only genesis block is there
+	deadlockDisable := deadlock.Opts.Disable
 	deadlock.Opts.Disable = true
 	defer func() {
-		deadlock.Opts.Disable = false
+		deadlock.Opts.Disable = deadlockDisable
 	}()
 	dbTempDir, err := ioutil.TempDir(os.TempDir(), "testdir")
 	require.NoError(t, err)

--- a/ledger/ledger_perf_test.go
+++ b/ledger/ledger_perf_test.go
@@ -135,9 +135,12 @@ func (vc *alwaysVerifiedCache) Verified(txn transactions.SignedTxn, params verif
 }
 
 func benchmarkFullBlocks(params testParams, b *testing.B) {
-	// Disable deadlock checking library (we do this here and not in init
-	// because we want deadlock detection for unit tests)
+	// disable deadlock checking code
+	deadlockDisable := deadlock.Opts.Disable
 	deadlock.Opts.Disable = true
+	defer func() {
+		deadlock.Opts.Disable = deadlockDisable
+	}()
 
 	dbTempDir, err := ioutil.TempDir("", "testdir"+b.Name())
 	require.NoError(b, err)


### PR DESCRIPTION
## Summary

In https://github.com/algorand/go-algorand/pull/1310 I missed to update the TestArchivalCreatables unit test itself.
Instead, I updated two other unit tests ( that needed this update as well ).

This is a follow up PR, addressing what was missed in #1310  as well as applying @algobolson recommendation.
