### PR TITLE
Improve trie failuires warning message formatting

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -19,6 +19,7 @@ package ledger
 import (
 	"context"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -854,7 +855,7 @@ func (au *accountUpdates) accountsInitialize(ctx context.Context, tx *sql.Tx) (b
 					return rnd, fmt.Errorf("accountsInitialize was unable to add changes to trie: %v", err)
 				}
 				if !added {
-					au.log.Warnf("accountsInitialize attempted to add duplicate hash '%v' to merkle trie.", hash)
+					au.log.Warnf("accountsInitialize attempted to add duplicate hash '%s' to merkle trie for account %v", hex.EncodeToString(hash), balance.Address)
 				}
 			}
 
@@ -1032,11 +1033,10 @@ func (au *accountUpdates) accountsUpdateBalances(accountsDeltasRound []map[basic
 					return err
 				}
 				if !deleted {
-					au.log.Warnf("failed to delete hash '%v' from merkle trie", deleteHash)
+					au.log.Warnf("failed to delete hash '%s' from merkle trie for account %v", hex.EncodeToString(deleteHash), addr)
 				} else {
 					accumulatedChanges++
 				}
-
 			}
 			if !delta.new.IsZero() {
 				addHash := accountHashBuilder(addr, delta.new, protocol.Encode(&delta.new))
@@ -1045,7 +1045,7 @@ func (au *accountUpdates) accountsUpdateBalances(accountsDeltasRound []map[basic
 					return err
 				}
 				if !added {
-					au.log.Warnf("attempted to add duplicate hash '%v' to merkle trie", addHash)
+					au.log.Warnf("attempted to add duplicate hash '%s' to merkle trie for account %v", hex.EncodeToString(addHash), addr)
 				} else {
 					accumulatedChanges++
 				}

--- a/ledger/catchupaccessor.go
+++ b/ledger/catchupaccessor.go
@@ -19,6 +19,7 @@ package ledger
 import (
 	"context"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -331,7 +332,7 @@ func (c *CatchpointCatchupAccessorImpl) processStagingBalances(ctx context.Conte
 			hash := accountHashBuilder(balance.Address, accountData, balance.AccountData)
 			added, err := trie.Add(hash)
 			if !added {
-				return fmt.Errorf("CatchpointCatchupAccessorImpl::processStagingBalances: The provided catchpoint file contained the same account more than once. Account address %#v, account data %#v", balance.Address, accountData)
+				return fmt.Errorf("CatchpointCatchupAccessorImpl::processStagingBalances: The provided catchpoint file contained the same account more than once. Account address %#v, account data %#v, hash '%s'", balance.Address, accountData, hex.EncodeToString(hash))
 			}
 			if err != nil {
 				return err


### PR DESCRIPTION
## Summary

This PR changes the formatting of the errors reported when we run into (unexpected) merkle trie add/delete issue - 
Instead of printing the following:
```
failed to delete hash '[0 2 10 225 180 83 237 205 167 133 27 115 84 225 197 100 156 173 4 243 70 109 250 128 36 70 89 174 211 3 136 249 71 157 224 106]' from merkle trie
```

It would print
```
failed to delete hash '00020a60dc5baf1440cc6148b1a837f0091acae8514f2cb92e638db88450819c7405e6c7' from merkle trie for account address WDXD7FP3P3RLOTN3IMHDO5QX3CKBYCKLRHBNQ64GL4BJE5BN3VKCQR2RGA
```

The change is not only less noisy, but also provide us with some pointers for what we need to look for when diagnosing the issue.