### PR TITLE
Fix merge issue with TestApplicationsUpgradeOver e2e test

### DIFF
--- a/test/e2e-go/upgrades/application_support_test.go
+++ b/test/e2e-go/upgrades/application_support_test.go
@@ -150,7 +150,7 @@ int 1
 
 	// create the app
 	tx, err := client.MakeUnsignedAppCreateTx(
-		transactions.OptInOC, approval, clearstate, schema, schema, nil, nil, nil,
+		transactions.OptInOC, approval, clearstate, schema, schema, nil, nil, nil, nil,
 	)
 	require.NoError(t, err)
 	tx, err = client.FillUnsignedTxTemplate(creator, 0, 0, fee, tx)
@@ -224,7 +224,7 @@ int 1
 	require.Equal(t, uint64(1), value.Uint)
 
 	// call the app
-	tx, err = client.MakeUnsignedAppOptInTx(uint64(appIdx), nil, nil, nil)
+	tx, err = client.MakeUnsignedAppOptInTx(uint64(appIdx), nil, nil, nil, nil)
 	require.NoError(t, err)
 	tx, err = client.FillUnsignedTxTemplate(user, 0, 0, fee, tx)
 	require.NoError(t, err)
@@ -390,7 +390,7 @@ int 1
 
 	// create the app
 	tx, err := client.MakeUnsignedAppCreateTx(
-		transactions.OptInOC, approval, clearstate, schema, schema, nil, nil, nil,
+		transactions.OptInOC, approval, clearstate, schema, schema, nil, nil, nil, nil,
 	)
 	require.NoError(t, err)
 	tx, err = client.FillUnsignedTxTemplate(creator, round, round+primaryNodeUnupgradedProtocol.DefaultUpgradeWaitRounds, fee, tx)
@@ -487,7 +487,7 @@ int 1
 	require.Equal(t, uint64(1), value.Uint)
 
 	// call the app
-	tx, err = client.MakeUnsignedAppOptInTx(uint64(appIdx), nil, nil, nil)
+	tx, err = client.MakeUnsignedAppOptInTx(uint64(appIdx), nil, nil, nil, nil)
 	require.NoError(t, err)
 	tx, err = client.FillUnsignedTxTemplate(user, 0, 0, fee, tx)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Fix merge issues with TestApplicationsUpgradeOver. Due to merge orders, the underlying `libgoal.MakeUnsignedAppCreateTx`  was changed without the test being updated.