### PR TITLE
Remove deprecated sudo key from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ go:
   - "1.12"
 go_import_path: github.com/algorand/go-algorand
 language: go
-sudo: required
 
 # Don't build tags
 if: tag IS blank


### PR DESCRIPTION
## Summary

The `sudo` key on the .travis file is no longer supported, and completely ignored.
This PR delete this deprecated line.
