### PR TITLE
Add created/opted in apps to `goal account list`

### DIFF
--- a/cmd/goal/accountsList.go
+++ b/cmd/goal/accountsList.go
@@ -231,6 +231,21 @@ func (accountList *AccountsList) outputAccount(addr string, acctInfo v1.Account,
 		}
 		fmt.Printf("]")
 	}
+	if len(acctInfo.AppParams) > 0 {
+		fmt.Printf("\t[created apps:")
+		for aid := range acctInfo.AppParams {
+			fmt.Printf(" %d", aid)
+		}
+		fmt.Printf("]")
+	}
+	if len(acctInfo.AppLocalStates) > 0 {
+		fmt.Printf("\t[opted in apps:")
+		for aid := range acctInfo.AppLocalStates {
+			fmt.Printf(" %d", aid)
+		}
+		fmt.Printf("]")
+	}
+
 	if accountList.isDefault(addr) {
 		fmt.Printf("\t*Default")
 	}

--- a/cmd/goal/accountsList.go
+++ b/cmd/goal/accountsList.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 
 	"github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
 	"github.com/algorand/go-algorand/data/basics"
@@ -225,25 +226,28 @@ func (accountList *AccountsList) outputAccount(addr string, acctInfo v1.Account,
 		fmt.Printf("\t[%d/%d multisig]", multisigInfo.Threshold, len(multisigInfo.PKs))
 	}
 	if len(acctInfo.AssetParams) > 0 {
-		fmt.Printf("\t[created assets:")
+		fmt.Printf("\t[created asset IDs: ")
+		var out []string
 		for curid, params := range acctInfo.AssetParams {
-			fmt.Printf(" %d (%d %s)", curid, params.Total, params.UnitName)
+			out = append(out, fmt.Sprintf("%d (%d %s)", curid, params.Total, params.UnitName))
 		}
-		fmt.Printf("]")
+		fmt.Printf("%s]", strings.Join(out, ", "))
 	}
 	if len(acctInfo.AppParams) > 0 {
-		fmt.Printf("\t[created app IDs:")
+		fmt.Printf("\t[created app IDs: ")
+		var out []string
 		for aid := range acctInfo.AppParams {
-			fmt.Printf(" %d", aid)
+			out = append(out, fmt.Sprintf("%d", aid))
 		}
-		fmt.Printf("]")
+		fmt.Printf("%s]", strings.Join(out, ", "))
 	}
 	if len(acctInfo.AppLocalStates) > 0 {
-		fmt.Printf("\t[opted in app IDs:")
+		fmt.Printf("\t[opted in app IDs: ")
+		var out []string
 		for aid := range acctInfo.AppLocalStates {
-			fmt.Printf(" %d", aid)
+			out = append(out, fmt.Sprintf("%d", aid))
 		}
-		fmt.Printf("]")
+		fmt.Printf("%s]", strings.Join(out, ", "))
 	}
 
 	if accountList.isDefault(addr) {

--- a/cmd/goal/accountsList.go
+++ b/cmd/goal/accountsList.go
@@ -226,28 +226,25 @@ func (accountList *AccountsList) outputAccount(addr string, acctInfo v1.Account,
 		fmt.Printf("\t[%d/%d multisig]", multisigInfo.Threshold, len(multisigInfo.PKs))
 	}
 	if len(acctInfo.AssetParams) > 0 {
-		fmt.Printf("\t[created asset IDs: ")
 		var out []string
 		for curid, params := range acctInfo.AssetParams {
 			out = append(out, fmt.Sprintf("%d (%d %s)", curid, params.Total, params.UnitName))
 		}
-		fmt.Printf("%s]", strings.Join(out, ", "))
+		fmt.Printf("\t[created asset IDs: %s]", strings.Join(out, ", "))
 	}
 	if len(acctInfo.AppParams) > 0 {
-		fmt.Printf("\t[created app IDs: ")
 		var out []string
 		for aid := range acctInfo.AppParams {
 			out = append(out, fmt.Sprintf("%d", aid))
 		}
-		fmt.Printf("%s]", strings.Join(out, ", "))
+		fmt.Printf("\t[created app IDs: %s]", strings.Join(out, ", "))
 	}
 	if len(acctInfo.AppLocalStates) > 0 {
-		fmt.Printf("\t[opted in app IDs: ")
 		var out []string
 		for aid := range acctInfo.AppLocalStates {
 			out = append(out, fmt.Sprintf("%d", aid))
 		}
-		fmt.Printf("%s]", strings.Join(out, ", "))
+		fmt.Printf("\t[opted in app IDs: %s]", strings.Join(out, ", "))
 	}
 
 	if accountList.isDefault(addr) {

--- a/cmd/goal/accountsList.go
+++ b/cmd/goal/accountsList.go
@@ -232,14 +232,14 @@ func (accountList *AccountsList) outputAccount(addr string, acctInfo v1.Account,
 		fmt.Printf("]")
 	}
 	if len(acctInfo.AppParams) > 0 {
-		fmt.Printf("\t[created apps:")
+		fmt.Printf("\t[created app IDs:")
 		for aid := range acctInfo.AppParams {
 			fmt.Printf(" %d", aid)
 		}
 		fmt.Printf("]")
 	}
 	if len(acctInfo.AppLocalStates) > 0 {
-		fmt.Printf("\t[opted in apps:")
+		fmt.Printf("\t[opted in app IDs:")
 		for aid := range acctInfo.AppLocalStates {
 			fmt.Printf(" %d", aid)
 		}


### PR DESCRIPTION
## Summary

It's not very pretty, but it matches what we do currently for assets. Here is example output:

```
[online]	VMQAA7D43Y6SZ7SJNMA6EPFEQ3DGD575OEKV4FP5EVZWSCRHKVLXZXQFZE	VMQAA7D43Y6SZ7SJNMA6EPFEQ3DGD575OEKV4FP5EVZWSCRHKVLXZXQFZE	4999999999995000 microAlgos	[created asset IDs: 4 (1234 foo), 5 (1234 bar)]	[created app IDs: 1, 2]	[opted in app IDs: 1]
```

## Testing

I manually tested this change using a private network.