### PR TITLE
TEAL: allow empty string literals

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -435,7 +435,7 @@ func parseBinaryArgs(args []string) (val []byte, consumed int, err error) {
 			return
 		}
 		consumed = 2
-	} else if len(arg) > 2 && arg[0] == '"' && arg[len(arg)-1] == '"' {
+	} else if len(arg) > 1 && arg[0] == '"' && arg[len(arg)-1] == '"' {
 		val, err = parseStringLiteral(arg)
 		consumed = 1
 	} else {

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -734,6 +734,11 @@ func TestFieldsFromLine(t *testing.T) {
 	require.Equal(t, 2, len(fields))
 	require.Equal(t, `\"test1`, fields[0])
 	require.Equal(t, `test2"`, fields[1])
+
+	line = `"" // test`
+	fields = fieldsFromLine(line)
+	require.Equal(t, 1, len(fields))
+	require.Equal(t, `""`, fields[0])
 }
 
 func TestAssembleRejectNegJump(t *testing.T) {
@@ -1333,6 +1338,12 @@ func TestStringLiteralParsing(t *testing.T) {
 
 	s = `"\x74\x65\x73\x74\x31\x32\x33"`
 	e = []byte(`test123`)
+	result, err = parseStringLiteral(s)
+	require.NoError(t, err)
+	require.Equal(t, e, result)
+
+	s = `""`
+	e = []byte("")
 	result, err = parseStringLiteral(s)
 	require.NoError(t, err)
 	require.Equal(t, e, result)

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -3646,6 +3646,26 @@ byte b64(Zm9vIGJhciAvLyBub3QgYSBjb21tZW50)
 	pass, err = Eval(program, ep)
 	require.NoError(t, err)
 	require.True(t, pass)
+
+	text = `byte ""
+byte 0x
+==
+`
+	program, err = AssembleStringWithVersion(text, AssemblerMaxVersion)
+	require.NoError(t, err)
+	pass, err = Eval(program, ep)
+	require.NoError(t, err)
+	require.True(t, pass)
+
+	text = `byte "" // empty string literal
+byte 0x // empty byte constant
+==
+`
+	program, err = AssembleStringWithVersion(text, AssemblerMaxVersion)
+	require.NoError(t, err)
+	pass, err = Eval(program, ep)
+	require.NoError(t, err)
+	require.True(t, pass)
 }
 
 func TestArgType(t *testing.T) {


### PR DESCRIPTION
## Summary

"byte 0x" produces empty byte slice and substring also can return empty slice
so it is better to be consistent and allow empty literals as well

## Test Plan

Added test