### PR TITLE
Prevent warning message for block assembly when catching up

### DIFF
--- a/agreement/abstractions.go
+++ b/agreement/abstractions.go
@@ -18,6 +18,7 @@ package agreement
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/algorand/go-algorand/config"
@@ -64,6 +65,10 @@ type ValidatedBlock interface {
 	// Block returns the underlying block that has been validated.
 	Block() bookkeeping.Block
 }
+
+// ErrAssembleBlockRoundStale is returned by AssembleBlock when the requested round number is not the
+// one that matches the ledger last committed round + 1.
+var ErrAssembleBlockRoundStale = errors.New("requested round for AssembleBlock is stale")
 
 // An BlockFactory produces an Block which is suitable for proposal for a given
 // Round.

--- a/agreement/pseudonode.go
+++ b/agreement/pseudonode.go
@@ -266,17 +266,7 @@ func (n asyncPseudonode) makeProposals(round basics.Round, period period, accoun
 	deadline := time.Now().Add(AssemblyTime)
 	ve, err := n.factory.AssembleBlock(round, deadline)
 	if err != nil {
-		if err == ErrAssembleBlockRoundStale {
-			// check to see if we're truely stale.
-			ledgerNextRound := n.ledger.NextRound()
-			if ledgerNextRound == round {
-				// we've asked for the right round.. and the ledger doesn't think it's stale.
-				n.log.Errorf("pseudonode.makeProposals: could not generate a proposal for round %d, ledger and proposal generation are synced: %v", round, err)
-			} else if ledgerNextRound < round {
-				// from some reason, the ledger is behind the round that we're asking. That shouldn't happen, but error if it does.
-				n.log.Errorf("pseudonode.makeProposals: could not generate a proposal for round %d, ledger next round is %d: %v", round, ledgerNextRound, err)
-			}
-		} else {
+		if err != ErrAssembleBlockRoundStale {
 			n.log.Errorf("pseudonode.makeProposals: could not generate a proposal for round %d: %v", round, err)
 		}
 		return nil, nil

--- a/node/node.go
+++ b/node/node.go
@@ -982,6 +982,17 @@ func (node *AlgorandFullNode) AssembleBlock(round basics.Round, deadline time.Ti
 		if err == pools.ErrTxPoolStaleBlockAssembly {
 			// convert specific error to one that would have special handling in the agreement code.
 			err = agreement.ErrAssembleBlockRoundStale
+
+			ledgerNextRound := node.ledger.NextRound()
+			if ledgerNextRound == round {
+				// we've asked for the right round.. and the ledger doesn't think it's stale.
+				node.log.Errorf("AlgorandFullNode.AssembleBlock: could not generate a proposal for round %d, ledger and proposal generation are synced: %v", round, err)
+			} else if ledgerNextRound < round {
+				// from some reason, the ledger is behind the round that we're asking. That shouldn't happen, but error if it does.
+				node.log.Errorf("AlgorandFullNode.AssembleBlock: could not generate a proposal for round %d, ledger next round is %d: %v", round, ledgerNextRound, err)
+			}
+			// the case where ledgerNextRound > round was not implemented here on purpose. This is the "normal case" where the
+			// ledger was advancing faster then the agreement by the catchup.
 		}
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -979,6 +979,10 @@ func (vb validatedBlock) Block() bookkeeping.Block {
 func (node *AlgorandFullNode) AssembleBlock(round basics.Round, deadline time.Time) (agreement.ValidatedBlock, error) {
 	lvb, err := node.transactionPool.AssembleBlock(round, deadline)
 	if err != nil {
+		if err == pools.ErrTxPoolStaleBlockAssembly {
+			// convert specific error to one that would have special handling in the agreement code.
+			err = agreement.ErrAssembleBlockRoundStale
+		}
 		return nil, err
 	}
 	return validatedBlock{vb: lvb}, nil


### PR DESCRIPTION
## Summary

During catchup, both the agreement and the transaction pool are being informed of new blocks. The transaction pool might be processing the blocks faster than the agreement messaging works, and as a result, the agreement might request the transaction pool to assemble a block for an older round.

Currently, the transaction pool would respond with an error, which would propagate to the agreement protocol, having the latter print a warning message. This is a benign message, as it does not indicate of a concrete issue but rather a normal system operation.

To resolve that, this PR add a special error returned by the AssembleBlock to indicate that the requested block round is too old. The agreement, in turn, would check this error code and would verify that "claim" against the ledger's round. If this is legit, the proposal generation for that round would be skipped. Otherwise, an error message would be printed out, indicating of the issue.
