### PR TITLE
Ensure correct genesis file is provided to node packages

### DIFF
--- a/scripts/compute_branch_network.sh
+++ b/scripts/compute_branch_network.sh
@@ -14,9 +14,8 @@ if [ "${BRANCH}" = "rel/stable" ]; then
     exit 0
 fi
 
-#get parent of current branch
-#credit to https://stackoverflow.com/questions/3161204/find-the-parent-branch-of-a-git-branch
-BRANCHPARENT="$(git show-branch | grep '\*' | grep -v '${BRANCH}' | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//')"
+# Get branch that owns head commit
+BRANCHPARENT="$(git branch --contains HEAD | grep -v 'HEAD' | head -n1 | grep -Eo '\w+(\/\w*)*')"
 
 if [ "${BRANCHPARENT}" = "rel/stable" ]; then
     echo "testnet"

--- a/scripts/compute_branch_network.sh
+++ b/scripts/compute_branch_network.sh
@@ -15,7 +15,7 @@ if [ "${BRANCH}" = "rel/stable" ]; then
 fi
 
 # Get branch that owns head commit
-BRANCHPARENT="$(git branch --contains HEAD | grep -v 'HEAD' | head -n1 | grep -Eo '\w+(\/\w*)*')"
+BRANCHPARENT="$(git branch --contains HEAD | grep -v 'HEAD' | head -n1 | grep -Eo '\S+(\/\S*)*' | tail -1)"
 
 if [ "${BRANCHPARENT}" = "rel/stable" ]; then
     echo "testnet"


### PR DESCRIPTION
## Summary

For some reason it was trying to parse the parent branch of the current branch and that wasn't working. I'm not sure that would ever work to provide the correct genesis file for betanet, so I updated the script to return betanet for any commit in the rel/beta branch.

## Test Plan

I built a node package for rel/beta and master to confirm they both have their respective genesis files

## Urgency/ Impact
Without this calculation fix, branches can end up with the wrong genesis file, leading to a bunch of errors. Mostly internal issue but necessary to fix. 
