### PR TITLE
Remove go version from travis.yaml file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 dist: bionic
-go:
-  - "1.12"
 go_import_path: github.com/algorand/go-algorand
 language: go
 


### PR DESCRIPTION

## Summary

Remove specification of go version from Travis.yaml file.  Go version is now specified using `get_go_version.sh` script.  

## Test Plan

Using PR to test running Travis builds.
