### PR TITLE
Eliminate nil map entries on Merkle trie cache

### DIFF
--- a/crypto/merkletrie/cache.go
+++ b/crypto/merkletrie/cache.go
@@ -349,8 +349,8 @@ func (mtc *merkleTrieCache) commit() error {
 		if element != nil {
 			mtc.pagesPrioritizationList.Remove(element)
 			delete(mtc.pagesPrioritizationMap, uint64(page))
-			mtc.cachedNodeCount -= len(mtc.pageToNIDsPtr[uint64(page)])
 		}
+		mtc.cachedNodeCount -= len(mtc.pageToNIDsPtr[uint64(page)])
 		delete(mtc.pageToNIDsPtr, uint64(page))
 	}
 

--- a/crypto/merkletrie/cache.go
+++ b/crypto/merkletrie/cache.go
@@ -203,7 +203,6 @@ func (mtc *merkleTrieCache) deleteNode(nid storedNodeIdentifier) {
 		}
 		mtc.cachedNodeCount--
 	} else {
-
 		mtc.txDeletedNodeIDs[nid] = true
 	}
 	mtc.modified = true

--- a/crypto/merkletrie/cache.go
+++ b/crypto/merkletrie/cache.go
@@ -67,8 +67,8 @@ type merkleTrieCache struct {
 
 	// pendingCreatedNID contains a list of the node ids that has been created since the last commit and need to be stored.
 	pendingCreatedNID map[storedNodeIdentifier]bool
-	// pendingDeletionNID contains a list of the node ids that has been deleted since the last commit and need to be removed.
-	pendingDeletionNID map[storedNodeIdentifier]bool
+	// pendingDeletionPage contains a map of pages to delete, each pointing to a map of all the nodes ids that need to be removed.
+	pendingDeletionPages map[uint64]map[storedNodeIdentifier]*node
 
 	// a list of the pages priorities. The item in the front has higher priority and would not get evicted as quickly as the item on the back
 	pagesPrioritizationList *list.List
@@ -86,7 +86,7 @@ func (mtc *merkleTrieCache) initialize(mt *Trie, committer Committer, cachedNode
 	mtc.committer = committer
 	mtc.cachedNodeCount = 0
 	mtc.pendingCreatedNID = make(map[storedNodeIdentifier]bool)
-	mtc.pendingDeletionNID = make(map[storedNodeIdentifier]bool)
+	mtc.pendingDeletionPages = make(map[uint64]map[storedNodeIdentifier]*node)
 	mtc.pagesPrioritizationList = list.New()
 	mtc.pagesPrioritizationMap = make(map[uint64]*list.Element)
 	mtc.cachedNodeCountTarget = cachedNodeCountTarget
@@ -226,17 +226,23 @@ func (mtc *merkleTrieCache) commitTransaction() {
 
 	// delete the ones that we don't want from the list.
 	for nodeID := range mtc.txDeletedNodeIDs {
+		page := uint64(nodeID) / uint64(mtc.nodesPerPage)
 		if mtc.pendingCreatedNID[nodeID] {
 			// it was never flushed.
 			delete(mtc.pendingCreatedNID, nodeID)
+			delete(mtc.pageToNIDsPtr[page], nodeID)
+			// if the page is empty, and it's not on the pendingDeletionPages, it means that we have no further references to it,
+			// so we can delete it right away.
+			if len(mtc.pageToNIDsPtr[page]) == 0 && mtc.pendingDeletionPages[page] == nil {
+				delete(mtc.pageToNIDsPtr, page)
+			}
 		} else {
-			mtc.pendingDeletionNID[nodeID] = true
-		}
-
-		page := uint64(nodeID) / uint64(mtc.nodesPerPage)
-		delete(mtc.pageToNIDsPtr[page], nodeID)
-		if len(mtc.pageToNIDsPtr[page]) == 0 {
-			delete(mtc.pageToNIDsPtr, page)
+			if mtc.pendingDeletionPages[page] == nil {
+				mtc.pendingDeletionPages[page] = make(map[storedNodeIdentifier]*node)
+			}
+			mtc.pendingDeletionPages[page][nodeID] = nil
+			delete(mtc.pageToNIDsPtr[page], nodeID)
+			// no need to clear out the mtc.pageToNIDsPtr page, since it will be taken care by the commit() function.
 		}
 	}
 	mtc.cachedNodeCount -= len(mtc.txDeletedNodeIDs)
@@ -261,16 +267,16 @@ func (mtc *merkleTrieCache) rollbackTransaction() {
 	mtc.txNextNodeID = storedNodeIdentifierNull
 }
 
-// Int64Slice attaches the methods of Interface to []uint64, sorting in increasing order.
-type Int64Slice []int64
+// Uint64Slice attaches the methods of Interface to []uint64, sorting in increasing order.
+type Uint64Slice []uint64
 
-func (p Int64Slice) Len() int           { return len(p) }
-func (p Int64Slice) Less(i, j int) bool { return p[i] < p[j] }
-func (p Int64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p Uint64Slice) Len() int           { return len(p) }
+func (p Uint64Slice) Less(i, j int) bool { return p[i] < p[j] }
+func (p Uint64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
-// SortInt64 sorts a slice of uint64s in increasing order.
-func SortInt64(a []int64) {
-	sort.Sort(Int64Slice(a))
+// SortUint64 sorts a slice of uint64s in increasing order.
+func SortUint64(a []uint64) {
+	sort.Sort(Uint64Slice(a))
 }
 
 // commit - used as part of the Trie Commit functionality
@@ -284,26 +290,26 @@ func (mtc *merkleTrieCache) commit() error {
 		mtc.deferedPageLoad = storedNodeIdentifierNull
 	}
 
-	createdPages := make(map[int64]map[storedNodeIdentifier]*node)
+	createdPages := make(map[uint64]map[storedNodeIdentifier]*node)
 
 	// create a list of all the pages that need to be created/updated
 	for nodeID := range mtc.pendingCreatedNID {
-		nodePage := int64(nodeID) / mtc.nodesPerPage
+		nodePage := uint64(nodeID) / uint64(mtc.nodesPerPage)
 		if nil == createdPages[nodePage] {
 			createdPages[nodePage] = mtc.pageToNIDsPtr[uint64(nodePage)]
 		}
 	}
 
 	// create a sorted list of created pages
-	sortedCreatedPages := make([]int64, 0, len(createdPages))
+	sortedCreatedPages := make([]uint64, 0, len(createdPages))
 	for page := range createdPages {
 		sortedCreatedPages = append(sortedCreatedPages, page)
 	}
-	SortInt64(sortedCreatedPages)
+	SortUint64(sortedCreatedPages)
 	// updated the hashes of these pages. this works correctly
 	// since all trie modification are done with ids that are bottom-up
 	for _, page := range sortedCreatedPages {
-		err := mtc.calculatePageHashes(page)
+		err := mtc.calculatePageHashes(int64(page))
 		if err != nil {
 			return err
 		}
@@ -319,19 +325,12 @@ func (mtc *merkleTrieCache) commit() error {
 	}
 
 	// pages that contains elemets that were removed.
-	toRemovePages := make(map[int64]map[storedNodeIdentifier]*node)
-	toUpdatePages := make(map[int64]map[storedNodeIdentifier]*node)
-	for nodeID := range mtc.pendingDeletionNID {
-		nodePage := int64(nodeID) / mtc.nodesPerPage
-		if toRemovePages[nodePage] == nil {
-			toRemovePages[nodePage] = make(map[storedNodeIdentifier]*node, mtc.nodesPerPage)
-		}
-		toRemovePages[nodePage][nodeID] = nil
-	}
+	toRemovePages := mtc.pendingDeletionPages
+	toUpdatePages := make(map[uint64]map[storedNodeIdentifier]*node)
 
 	// iterate over the existing list and ensure we don't delete any page that has active elements
 	for pageRemovalCandidate := range toRemovePages {
-		if mtc.pageToNIDsPtr[uint64(pageRemovalCandidate)] == nil {
+		if len(mtc.pageToNIDsPtr[uint64(pageRemovalCandidate)]) == 0 {
 			// we have no nodes associated with this page, so
 			// it means that we can remove this page safely.
 			continue
@@ -354,8 +353,8 @@ func (mtc *merkleTrieCache) commit() error {
 			mtc.pagesPrioritizationList.Remove(element)
 			delete(mtc.pagesPrioritizationMap, uint64(page))
 			mtc.cachedNodeCount -= len(mtc.pageToNIDsPtr[uint64(page)])
-			delete(mtc.pageToNIDsPtr, uint64(page))
 		}
+		delete(mtc.pageToNIDsPtr, uint64(page))
 	}
 
 	// updated pages
@@ -371,7 +370,7 @@ func (mtc *merkleTrieCache) commit() error {
 	}
 
 	mtc.pendingCreatedNID = make(map[storedNodeIdentifier]bool)
-	mtc.pendingDeletionNID = make(map[storedNodeIdentifier]bool)
+	mtc.pendingDeletionPages = make(map[uint64]map[storedNodeIdentifier]*node)
 	mtc.modified = false
 	return nil
 }

--- a/crypto/merkletrie/cache.go
+++ b/crypto/merkletrie/cache.go
@@ -199,10 +199,11 @@ func (mtc *merkleTrieCache) deleteNode(nid storedNodeIdentifier) {
 		page := uint64(nid) / uint64(mtc.nodesPerPage)
 		delete(mtc.pageToNIDsPtr[page], nid)
 		if len(mtc.pageToNIDsPtr[page]) == 0 {
-			mtc.pageToNIDsPtr[page] = nil
+			delete(mtc.pageToNIDsPtr, page)
 		}
 		mtc.cachedNodeCount--
 	} else {
+
 		mtc.txDeletedNodeIDs[nid] = true
 	}
 	mtc.modified = true
@@ -236,7 +237,7 @@ func (mtc *merkleTrieCache) commitTransaction() {
 		page := uint64(nodeID) / uint64(mtc.nodesPerPage)
 		delete(mtc.pageToNIDsPtr[page], nodeID)
 		if len(mtc.pageToNIDsPtr[page]) == 0 {
-			mtc.pageToNIDsPtr[page] = nil
+			delete(mtc.pageToNIDsPtr, page)
 		}
 	}
 	mtc.cachedNodeCount -= len(mtc.txDeletedNodeIDs)
@@ -252,7 +253,7 @@ func (mtc *merkleTrieCache) rollbackTransaction() {
 		page := uint64(nodeID) / uint64(mtc.nodesPerPage)
 		delete(mtc.pageToNIDsPtr[page], nodeID)
 		if len(mtc.pageToNIDsPtr[page]) == 0 {
-			mtc.pageToNIDsPtr[page] = nil
+			delete(mtc.pageToNIDsPtr, page)
 		}
 	}
 	mtc.cachedNodeCount -= len(mtc.txCreatedNodeIDs)

--- a/crypto/merkletrie/cache_test.go
+++ b/crypto/merkletrie/cache_test.go
@@ -35,16 +35,9 @@ func verifyCacheNodeCount(t *testing.T, trie *Trie) {
 	// make sure that the pagesPrioritizationMap aligns with pagesPrioritizationList
 	require.Equal(t, len(trie.cache.pagesPrioritizationMap), trie.cache.pagesPrioritizationList.Len())
 
-	// if we're not within a transaction, the following should also hold true:
-	if !trie.cache.modified {
-		require.Equal(t, len(trie.cache.pageToNIDsPtr), trie.cache.pagesPrioritizationList.Len())
-	}
-
 	for e := trie.cache.pagesPrioritizationList.Back(); e != nil; e = e.Next() {
 		page := e.Value.(uint64)
 		_, has := trie.cache.pagesPrioritizationMap[page]
-		require.True(t, has)
-		_, has = trie.cache.pageToNIDsPtr[page]
 		require.True(t, has)
 	}
 }

--- a/crypto/merkletrie/cache_test.go
+++ b/crypto/merkletrie/cache_test.go
@@ -222,3 +222,158 @@ func TestCacheEvictionFuzzer2(t *testing.T) {
 		})
 	}
 }
+
+// TestCacheMidTransactionPageDeletion ensures that if we need to
+// delete a in-memory page during merkleTrieCache.commitTransaction(),
+// it's being deleted correctly.
+func TestCacheMidTransactionPageDeletion(t *testing.T) {
+	var memoryCommitter smallPageMemoryCommitter
+	memoryCommitter.pageSize = 2
+	mt1, _ := MakeTrie(&memoryCommitter, defaultTestEvictSize)
+
+	// create 10000 hashes.
+	leafsCount := 10000
+	hashes := make([]crypto.Digest, leafsCount)
+	for i := 0; i < len(hashes); i++ {
+		hashes[i] = crypto.Hash([]byte{byte(i % 256), byte((i / 256) % 256), byte(i / 65536)})
+	}
+
+	for i := 0; i < len(hashes); i++ {
+		added, err := mt1.Add(hashes[i][:])
+		require.NoError(t, err)
+		require.True(t, added)
+	}
+	for i := 0; i < len(hashes)/4; i++ {
+		deleted, err := mt1.Delete(hashes[i][:])
+		require.NoError(t, err)
+		require.True(t, deleted)
+	}
+	mt1.Commit()
+
+	// compare committed pages to the in-memory pages.
+
+	for page, pageContent := range memoryCommitter.memStore {
+		if page == storedNodeIdentifierNull {
+			continue
+		}
+
+		decodedPage, err := decodePage(pageContent)
+		require.NoError(t, err)
+
+		// stored page should have more than a single node.
+		require.Greater(t, len(decodedPage), 0)
+	}
+
+	for page, pageContent := range mt1.cache.pageToNIDsPtr {
+
+		// memory page should have more than a single node.
+		require.NotZerof(t, len(pageContent), "Memory page %d has zero nodes", page)
+
+		// memory page should also be available on disk:
+		require.NotNil(t, memoryCommitter.memStore[page])
+	}
+}
+
+// TestDeleteRollback is a modified version of the real Trie.Delete,
+// which always "fails" and rollback the transaction.
+// this function is used in TestCacheTransactionRollbackPageDeletion
+func (mt *Trie) TestDeleteRollback(d []byte) (bool, error) {
+	if mt.root == storedNodeIdentifierNull {
+		return false, nil
+	}
+	if len(d) != mt.elementLength {
+		return false, ErrMismatchingElementLength
+	}
+	pnode, err := mt.cache.getNode(mt.root)
+	if err != nil {
+		return false, err
+	}
+	found, err := pnode.find(mt.cache, d[:])
+	if !found || err != nil {
+		return false, err
+	}
+	mt.cache.beginTransaction()
+	if pnode.leaf {
+		// remove the root.
+		mt.cache.deleteNode(mt.root)
+		mt.root = storedNodeIdentifierNull
+		mt.cache.commitTransaction()
+		mt.elementLength = 0
+		return true, nil
+	}
+	_, err = pnode.remove(mt.cache, d[:], make([]byte, 0, len(d)))
+	// unlike the "real" function, we want always to fail here to test the rollbackTransaction() functionality.
+	mt.cache.rollbackTransaction()
+	return false, fmt.Errorf("this is a test for failing a Delete request")
+}
+
+// TestCacheTransactionRollbackPageDeletion ensures that if we need to
+// delete a in-memory page during merkleTrieCache.rollbackTransaction(),
+// it's being deleted correctly.
+func TestCacheTransactionRollbackPageDeletion(t *testing.T) {
+	var memoryCommitter smallPageMemoryCommitter
+	memoryCommitter.pageSize = 2
+	mt1, _ := MakeTrie(&memoryCommitter, 5)
+
+	// create 1000 hashes.
+	leafsCount := 1000
+	hashes := make([]crypto.Digest, leafsCount)
+	for i := 0; i < len(hashes); i++ {
+		hashes[i] = crypto.Hash([]byte{byte(i % 256), byte((i / 256) % 256), byte(i / 65536)})
+	}
+
+	for i := 0; i < len(hashes); i++ {
+		added, err := mt1.Add(hashes[i][:])
+		require.NoError(t, err)
+		require.True(t, added)
+	}
+
+	mt1.Evict(true)
+
+	var deleted bool
+	var err error
+	for i := 0; i < len(hashes); i++ {
+		deleted, err = mt1.TestDeleteRollback(hashes[i][:])
+		if err != nil {
+			break
+		}
+		require.True(t, deleted)
+	}
+
+	for page, pageContent := range mt1.cache.pageToNIDsPtr {
+		// memory page should have more than a single node.
+		require.NotZerof(t, len(pageContent), "Memory page %d has zero nodes", page)
+	}
+}
+
+// TestCacheDeleteNodeMidTransaction ensures that if we need to
+// delete a in-memory page during merkleTrieCache.deleteNode(),
+// it's being deleted correctly.
+func TestCacheDeleteNodeMidTransaction(t *testing.T) {
+	var memoryCommitter smallPageMemoryCommitter
+	memoryCommitter.pageSize = 1
+	mt1, _ := MakeTrie(&memoryCommitter, 5)
+
+	// create 1000 hashes.
+	leafsCount := 10000
+	hashes := make([]crypto.Digest, leafsCount)
+	for i := 0; i < len(hashes); i++ {
+		hashes[i] = crypto.Hash([]byte{byte(i % 256), byte((i / 256) % 256), byte(i / 65536)})
+	}
+
+	for i := 0; i < len(hashes); i++ {
+		added, err := mt1.Add(hashes[i][:])
+		require.NoError(t, err)
+		require.True(t, added)
+	}
+	for i := 0; i < len(hashes); i++ {
+		deleted, err := mt1.Delete(hashes[i][:])
+		require.NoError(t, err)
+		require.True(t, deleted)
+	}
+
+	for page, pageContent := range mt1.cache.pageToNIDsPtr {
+		// memory page should have more than a single node.
+		require.NotZerof(t, len(pageContent), "Memory page %d has zero nodes", page)
+	}
+}

--- a/crypto/merkletrie/committer_test.go
+++ b/crypto/merkletrie/committer_test.go
@@ -17,6 +17,7 @@
 package merkletrie
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -171,4 +172,65 @@ func TestMultipleCommits(t *testing.T) {
 		storageSize2 += len(bytes)
 	}
 	require.Equal(t, storageSize1, storageSize2)
+}
+
+func TestCommittedPagesDeletion(t *testing.T) {
+
+	testSize := 100000
+	hashes := make([]crypto.Digest, testSize)
+	for i := 0; i < len(hashes); i++ {
+		hashes[i] = crypto.Hash([]byte{byte(i % 256), byte((i / 256) % 256), byte(i / 65536)})
+	}
+
+	var memoryCommitter1 InMemoryCommitter
+	mt1, _ := MakeTrie(&memoryCommitter1, defaultTestEvictSize)
+	for i := 0; i < len(hashes); i++ {
+		mt1.Add(hashes[i][:])
+		if i%300 == 0 {
+			mt1.Commit()
+		}
+	}
+
+	leftNodes := 9
+	for i := leftNodes; i < len(hashes); i++ {
+		mt1.Delete(hashes[i][:])
+		if i%300 == 0 {
+			mt1.Commit()
+		}
+	}
+	mt1.Commit()
+	maxExpectedNodes := 2 * leftNodes
+
+	stats, err := mt1.GetStats()
+	require.NoError(t, err)
+
+	require.Equal(t, leftNodes, int(stats.leafCount))
+	require.LessOrEqual(t, int(stats.nodesCount), maxExpectedNodes)
+
+	fmt.Printf("%#v\n", stats)
+
+	fmt.Printf("disk dump:\n")
+	for page, pageContent := range memoryCommitter1.memStore {
+		if page == storedNodeIdentifierNull {
+			continue
+		}
+		fmt.Printf("page %d:\n", page)
+		decodedPage, err := decodePage(pageContent)
+		require.NoError(t, err)
+		for nodeid, pNode := range decodedPage {
+			fmt.Printf("\tnode id %d leaf(%v) \n", nodeid, pNode.leaf)
+		}
+	}
+
+	fmt.Printf("\nmemory dump:\n")
+	for page, pageContent := range mt1.cache.pageToNIDsPtr {
+		fmt.Printf("page %d:\n", page)
+		for nodeid, pNode := range pageContent {
+			fmt.Printf("\tnode id %d leaf(%v) \n", nodeid, pNode.leaf)
+		}
+	}
+
+	fmt.Printf("cache node count = %d\n", mt1.cache.cachedNodeCount)
+	//require.Equal(t, mt1.cache.cachedNodeCount
+	require.LessOrEqual(t, len(memoryCommitter1.memStore), int(stats.nodesCount))
 }


### PR DESCRIPTION
## Summary

The Merkle trie was using the `pageToNIDsPtr` map to associate in-memory cached pages of nodes with the actual nodes.
During trie rearrangements, nodes are being deleted, which could lead to deletion of entries from this map. The map was
correctly deleting the internal list object, but left it as "nil" instead of completely eliminating it from the map. Over time, this 
could result is a memory leak.

The solution is quite straight-forward. Instead of just placing `nil` value on the map when the associated page gets empty, delete the page completely.

## Test Plan

Unit tests added to cover the relevant changes.