### PR TITLE
listCreatablesStmt is selecting 3 columns instead of 2

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -305,7 +305,7 @@ func accountsDbInit(r db.Queryable, w db.Queryable) (*accountsDbQueries, error) 
 	var err error
 	qs := &accountsDbQueries{}
 
-	qs.listCreatablesStmt, err = r.Prepare("SELECT asset, creator, ctype FROM assetcreators WHERE asset <= ? AND ctype = ? ORDER BY asset desc LIMIT ?")
+	qs.listCreatablesStmt, err = r.Prepare("SELECT asset, creator FROM assetcreators WHERE asset <= ? AND ctype = ? ORDER BY asset desc LIMIT ?")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

listCreatablesStmt is selecting 3 columns:
"SELECT asset, creator FROM assetcreators WHERE asset <= ? AND ctype = ? ORDER BY asset desc LIMIT ?"
but the scan is expecting just 2.
rows.Scan will fail for listCreatablesStmt with the error:
sql: expected 3 destination arguments in Scan, not 2

ctype is not relevant, since it is already specified in the WHERE claws. 

## Test Plan
Will add a test for this in the next PR