### PR TITLE
Add tealcut, a tool for splitting a TEAL program around a constant.

### DIFF
--- a/tools/teal/tealcut/main.go
+++ b/tools/teal/tealcut/main.go
@@ -32,6 +32,23 @@ import (
 	"github.com/algorand/go-algorand/data/transactions/logic"
 )
 
+// Usage:
+//
+//   tealcut <filename> 0x<number separator>
+//     Prints the program before and after the number separator,
+//     as well as a hash of both these components in base 16.
+//
+//   tealcut <filename> 0x<number separator> b64
+//     Like the above, but print in base 64 instead of base 16.
+//
+//   tealcut <filename> 0x<number separator> 0x<inserted number>
+//     In addition to the program before and after the separator,
+//     also print the program where the first occurrence of the
+//     separator is replaced by the inserted number, along with
+//     the program's hash.
+//
+// Note that all command-line number arguments are in base 16.
+
 func main() {
 	splitnum, err := strconv.ParseUint(os.Args[2], 0, 64)
 	if err != nil {

--- a/tools/teal/tealcut/main.go
+++ b/tools/teal/tealcut/main.go
@@ -1,0 +1,85 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/transactions/logic"
+)
+
+func main() {
+	splitnum, err := strconv.ParseUint(os.Args[2], 0, 64)
+	if err != nil {
+		panic(err)
+	}
+	var splitbytes [8]byte
+	binary.BigEndian.PutUint64(splitbytes[:], splitnum)
+	data, err := ioutil.ReadFile(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+	substrings := strings.SplitN(string(data), string(splitbytes[:]), 2)
+	fmt.Println(splitbytes[:])
+
+	if len(substrings) == 1 {
+		fmt.Println("split-string not found")
+		return
+	}
+
+	hash0 := sha512.Sum512_256([]byte(substrings[0]))
+	hash1 := sha512.Sum512_256([]byte(substrings[1]))
+
+	encfn := func(str []byte) string {
+		return "0x" + hex.EncodeToString(str)
+	}
+	if len(os.Args) > 3 {
+		if os.Args[3] == "b64" {
+			encfn = base64.StdEncoding.EncodeToString
+		} else {
+			writenum, err := strconv.ParseUint(os.Args[3], 0, 64)
+			if err != nil {
+				panic(err)
+			}
+			var writebytes [8]byte
+			binary.BigEndian.PutUint64(writebytes[:], writenum)
+			program := append([]byte(substrings[0]), writebytes[:]...)
+			program = append(program, []byte(substrings[1])...)
+
+			obj := logic.Program(program)
+			lhash := crypto.HashObj(&obj)
+			fmt.Println("addr:", basics.Address(lhash))
+			fmt.Println("mod:", encfn(program))
+		}
+	}
+
+	fmt.Println("hash0:", encfn([]byte(hash0[:])))
+	fmt.Println("hash1:", encfn([]byte(hash1[:])))
+	fmt.Println("sub0:", encfn([]byte(substrings[0])))
+	fmt.Println("sub1:", encfn([]byte(substrings[1])))
+	fmt.Println("data:", encfn([]byte(data)))
+}


### PR DESCRIPTION
tealcut is a command-line tool that accepts a compiled TEAL program
and a constant bytestring.  It outputs bytes preceding and following
the constant, along with their hashes.

tealcut also allows the replacement of this bytestring with a
bytestring representing a particular number.

The main use case of tealcut is to instantiate programs that are
parameterized by some bytestring representing an integer.  For
instance, tealcut can be used to instantiate an escrow TEAL program,
bound to a particular application ID, which is then checked by that
application's program itself.

## Test Plan

TODO
