### PR TITLE
Avoid using  encodedAccountsRange and replace with a single query

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -751,47 +751,6 @@ func updateAccountsRound(tx *sql.Tx, rnd basics.Round, hashRound basics.Round) (
 	return
 }
 
-// encodedAccountsRange returns an array containing the account data, in the same way it appear in the database
-// starting at entry startAccountIndex, and up to accountCount accounts long.
-func encodedAccountsRange(ctx context.Context, tx *sql.Tx, startAccountIndex, accountCount int) (bals []encodedBalanceRecord, err error) {
-	rows, err := tx.QueryContext(ctx, "SELECT address, data FROM accountbase ORDER BY rowid LIMIT ? OFFSET ?", accountCount, startAccountIndex)
-	if err != nil {
-		return
-	}
-	defer rows.Close()
-
-	bals = make([]encodedBalanceRecord, 0, accountCount)
-	var addr basics.Address
-	for rows.Next() {
-		var addrbuf []byte
-		var buf []byte
-		err = rows.Scan(&addrbuf, &buf)
-		if err != nil {
-			return
-		}
-
-		if len(addrbuf) != len(addr) {
-			err = fmt.Errorf("Account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
-			return
-		}
-
-		copy(addr[:], addrbuf)
-
-		bals = append(bals, encodedBalanceRecord{Address: addr, AccountData: buf})
-	}
-
-	err = rows.Err()
-	if err == nil {
-		// the encodedAccountsRange typically called in a loop iterating over all the accounts. This could clearly take more than the
-		// "standard" 1 second, so we want to extend the timeout on each iteration. If the last iteration takes more than a second, then
-		// it should be noted. The one second here is quite liberal to ensure symmetrical behaviour on low-power devices.
-		// The return value from ResetTransactionWarnDeadline can be safely ignored here since it would only default to writing the warnning
-		// message, which would let us know that it failed anyway.
-		db.ResetTransactionWarnDeadline(ctx, tx, time.Now().Add(time.Second))
-	}
-	return
-}
-
 // totalAccounts returns the total number of accounts
 func totalAccounts(ctx context.Context, tx *sql.Tx) (total uint64, err error) {
 	err = tx.QueryRowContext(ctx, "SELECT count(*) FROM accountbase").Scan(&total)

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -845,14 +845,14 @@ func (au *accountUpdates) accountsInitialize(ctx context.Context, tx *sql.Tx) (b
 
 	if rootHash.IsZero() {
 		au.log.Infof("accountsInitialize rebuilding merkle trie for round %d", rnd)
-		var accountsIterator encodedAccountsIterator
+		var accountsIterator encodedAccountsBatchIter
 		defer accountsIterator.Close()
 		startTrieBuildTime := time.Now()
 		accountsCount := 0
 		lastRebuildTime := startTrieBuildTime
 		pendingAccounts := 0
 		for {
-			bal, err := accountsIterator.Iterate(ctx, tx, trieRebuildAccountChunkSize)
+			bal, err := accountsIterator.Next(ctx, tx, trieRebuildAccountChunkSize)
 			if err != nil {
 				return rnd, err
 			}

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -50,7 +50,9 @@ const (
 	pendingDeltasFlushThreshold = 128
 	// trieRebuildAccountChunkSize defines the number of accounts that would get read at a single chunk
 	// before added to the trie during trie construction
-	trieRebuildAccountChunkSize = 512
+	trieRebuildAccountChunkSize = 16384
+	// trieRebuildCommitFrequency defines the number of accounts that would get added before we call evict to commit the changes and adjust the memory cache.
+	trieRebuildCommitFrequency = 65536
 	// trieAccumulatedChangesFlush defines the number of pending changes that would be applied to the merkle trie before
 	// we attempt to commit them to disk while writing a batch of rounds balances to disk.
 	trieAccumulatedChangesFlush = 256
@@ -840,16 +842,25 @@ func (au *accountUpdates) accountsInitialize(ctx context.Context, tx *sql.Tx) (b
 	if err != nil {
 		return rnd, fmt.Errorf("accountsInitialize was unable to retrieve trie root hash: %v", err)
 	}
+
 	if rootHash.IsZero() {
-		accountIdx := 0
+		au.log.Infof("accountsInitialize rebuilding merkle trie for round %d", rnd)
+		var accountsIterator encodedAccountsIterator
+		defer accountsIterator.Close()
+		startTrieBuildTime := time.Now()
+		accountsCount := 0
+		lastRebuildTime := startTrieBuildTime
+		pendingAccounts := 0
 		for {
-			bal, err := encodedAccountsRange(ctx, tx, accountIdx, trieRebuildAccountChunkSize)
+			bal, err := accountsIterator.Iterate(ctx, tx, trieRebuildAccountChunkSize)
 			if err != nil {
 				return rnd, err
 			}
 			if len(bal) == 0 {
 				break
 			}
+			accountsCount += len(bal)
+			pendingAccounts += len(bal)
 			for _, balance := range bal {
 				var accountData basics.AccountData
 				err = protocol.Decode(balance.AccountData, &accountData)
@@ -866,16 +877,32 @@ func (au *accountUpdates) accountsInitialize(ctx context.Context, tx *sql.Tx) (b
 				}
 			}
 
-			// this trie Evict will commit using the current transaction.
-			// if anything goes wrong, it will still get rolled back.
-			_, err = trie.Evict(true)
-			if err != nil {
-				return 0, fmt.Errorf("accountsInitialize was unable to commit changes to trie: %v", err)
+			if pendingAccounts >= trieRebuildCommitFrequency {
+				// this trie Evict will commit using the current transaction.
+				// if anything goes wrong, it will still get rolled back.
+				_, err = trie.Evict(true)
+				if err != nil {
+					return 0, fmt.Errorf("accountsInitialize was unable to commit changes to trie: %v", err)
+				}
+				pendingAccounts = 0
 			}
+
 			if len(bal) < trieRebuildAccountChunkSize {
 				break
 			}
-			accountIdx += trieRebuildAccountChunkSize
+
+			if time.Now().Sub(lastRebuildTime) > 5*time.Second {
+				// let the user know that the trie is still being rebuilt.
+				au.log.Infof("accountsInitialize still building the trie, and processed so far %d accounts", accountsCount)
+				lastRebuildTime = time.Now()
+			}
+		}
+
+		// this trie Evict will commit using the current transaction.
+		// if anything goes wrong, it will still get rolled back.
+		_, err = trie.Evict(true)
+		if err != nil {
+			return 0, fmt.Errorf("accountsInitialize was unable to commit changes to trie: %v", err)
 		}
 
 		// we've just updated the markle trie, update the hashRound to reflect that.
@@ -883,6 +910,8 @@ func (au *accountUpdates) accountsInitialize(ctx context.Context, tx *sql.Tx) (b
 		if err != nil {
 			return 0, fmt.Errorf("accountsInitialize was unable to update the account round to %d: %v", rnd, err)
 		}
+
+		au.log.Infof("accountsInitialize rebuilt the merkle trie with %d entries in %v", accountsCount, time.Now().Sub(startTrieBuildTime))
 	}
 	au.balancesTrie = trie
 	return rnd, nil
@@ -1499,8 +1528,6 @@ func (au *accountUpdates) generateCatchpoint(committedRound basics.Round, label 
 	relCatchpointFileName := filepath.Join("catchpoints", catchpointRoundToPath(committedRound))
 	absCatchpointFileName := filepath.Join(au.dbDirectory, relCatchpointFileName)
 
-	catchpointWriter := makeCatchpointWriter(absCatchpointFileName, au.dbs.rdb, committedRound, committedRoundDigest, label)
-
 	more := true
 	const shortChunkExecutionDuration = 50 * time.Millisecond
 	const longChunkExecutionDuration = 1 * time.Second
@@ -1511,37 +1538,54 @@ func (au *accountUpdates) generateCatchpoint(committedRound basics.Round, label 
 	default:
 		chunkExecutionDuration = shortChunkExecutionDuration
 	}
-	for more {
-		stepCtx, stepCancelFunction := context.WithTimeout(au.ctx, chunkExecutionDuration)
-		writeStepStartTime := time.Now()
-		more, err = catchpointWriter.WriteStep(stepCtx)
-		// accumulate the actual time we've spent writing in this step.
-		catchpointGenerationStats.CPUTime += uint64(time.Now().Sub(writeStepStartTime).Nanoseconds())
-		stepCancelFunction()
-		if more && err == nil {
-			// we just wrote some data, but there is more to be written.
-			// go to sleep for while.
-			select {
-			case <-time.After(100 * time.Millisecond):
-			case <-au.ctx.Done():
-				retryCatchpointCreation = true
+
+	var catchpointWriter *catchpointWriter
+	err = au.dbs.rdb.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
+		catchpointWriter = makeCatchpointWriter(au.ctx, absCatchpointFileName, tx, committedRound, committedRoundDigest, label)
+		for more {
+			stepCtx, stepCancelFunction := context.WithTimeout(au.ctx, chunkExecutionDuration)
+			writeStepStartTime := time.Now()
+			more, err = catchpointWriter.WriteStep(stepCtx)
+			// accumulate the actual time we've spent writing in this step.
+			catchpointGenerationStats.CPUTime += uint64(time.Now().Sub(writeStepStartTime).Nanoseconds())
+			stepCancelFunction()
+			if more && err == nil {
+				// we just wrote some data, but there is more to be written.
+				// go to sleep for while.
+				// before going to sleep, extend the transaction timeout so that we won't get warnings:
+				db.ResetTransactionWarnDeadline(ctx, tx, time.Now().Add(1*time.Second))
+				select {
+				case <-time.After(100 * time.Millisecond):
+				case <-au.ctx.Done():
+					retryCatchpointCreation = true
+					err2 := catchpointWriter.Abort()
+					if err2 != nil {
+						return fmt.Errorf("error removing catchpoint file : %v", err2)
+					}
+					return nil
+				case <-au.catchpointSlowWriting:
+					chunkExecutionDuration = longChunkExecutionDuration
+				}
+			}
+			if err != nil {
+				err = fmt.Errorf("unable to create catchpoint : %v", err)
 				err2 := catchpointWriter.Abort()
 				if err2 != nil {
 					au.log.Warnf("accountUpdates: generateCatchpoint: error removing catchpoint file : %v", err2)
 				}
 				return
-			case <-au.catchpointSlowWriting:
-				chunkExecutionDuration = longChunkExecutionDuration
 			}
 		}
-		if err != nil {
-			au.log.Warnf("accountUpdates: generateCatchpoint: unable to create catchpoint : %v", err)
-			err2 := catchpointWriter.Abort()
-			if err2 != nil {
-				au.log.Warnf("accountUpdates: generateCatchpoint: error removing catchpoint file : %v", err2)
-			}
-			return
-		}
+		return
+	})
+
+	if err != nil {
+		au.log.Warnf("accountUpdates: generateCatchpoint: %v", err)
+		return
+	}
+	if catchpointWriter == nil {
+		au.log.Warnf("accountUpdates: generateCatchpoint: nil catchpointWriter")
+		return
 	}
 
 	err = au.saveCatchpointFile(committedRound, relCatchpointFileName, catchpointWriter.GetSize(), catchpointWriter.GetCatchpoint())

--- a/ledger/catchpointwriter.go
+++ b/ledger/catchpointwriter.go
@@ -32,7 +32,6 @@ import (
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/protocol"
-	"github.com/algorand/go-algorand/util/db"
 )
 
 const (
@@ -49,9 +48,10 @@ const (
 // the writing is complete. It might take multiple steps until the operation is over, and the caller
 // has the option of throtteling the CPU utilization in between the calls.
 type catchpointWriter struct {
+	ctx               context.Context
 	hasher            hash.Hash
 	innerWriter       io.WriteCloser
-	dbr               db.Accessor
+	tx                *sql.Tx
 	filePath          string
 	file              *os.File
 	gzip              *gzip.Writer
@@ -65,6 +65,7 @@ type catchpointWriter struct {
 	blocksRound       basics.Round
 	blockHeaderDigest crypto.Digest
 	label             string
+	accountsIterator  encodedAccountsIterator
 }
 
 type encodedBalanceRecord struct {
@@ -94,17 +95,20 @@ type catchpointFileBalancesChunk struct {
 	Balances []encodedBalanceRecord `codec:"bl,allocbound=BalancesPerCatchpointFileChunk"`
 }
 
-func makeCatchpointWriter(filePath string, dbr db.Accessor, blocksRound basics.Round, blockHeaderDigest crypto.Digest, label string) *catchpointWriter {
+func makeCatchpointWriter(ctx context.Context, filePath string, tx *sql.Tx, blocksRound basics.Round, blockHeaderDigest crypto.Digest, label string) *catchpointWriter {
 	return &catchpointWriter{
+		ctx:               ctx,
 		filePath:          filePath,
-		dbr:               dbr,
+		tx:                tx,
 		blocksRound:       blocksRound,
 		blockHeaderDigest: blockHeaderDigest,
 		label:             label,
+		accountsIterator:  encodedAccountsIterator{orederByAddress: true},
 	}
 }
 
 func (cw *catchpointWriter) Abort() error {
+	cw.accountsIterator.Close()
 	if cw.tar != nil {
 		cw.tar.Close()
 	}
@@ -118,7 +122,7 @@ func (cw *catchpointWriter) Abort() error {
 	return err
 }
 
-func (cw *catchpointWriter) WriteStep(ctx context.Context) (more bool, err error) {
+func (cw *catchpointWriter) WriteStep(stepCtx context.Context) (more bool, err error) {
 	if cw.file == nil {
 		err = os.MkdirAll(filepath.Dir(cw.filePath), 0700)
 		if err != nil {
@@ -133,19 +137,19 @@ func (cw *catchpointWriter) WriteStep(ctx context.Context) (more bool, err error
 	}
 
 	// have we timed-out / canceled by that point ?
-	if more, err = hasContextDeadlineExceeded(ctx); more == true || err != nil {
+	if more, err = hasContextDeadlineExceeded(stepCtx); more == true || err != nil {
 		return
 	}
 
 	if cw.fileHeader == nil {
-		err = cw.dbr.Atomic(cw.readHeaderFromDatabase)
+		err = cw.readHeaderFromDatabase(cw.ctx, cw.tx)
 		if err != nil {
 			return
 		}
 	}
 
 	// have we timed-out / canceled by that point ?
-	if more, err = hasContextDeadlineExceeded(ctx); more == true || err != nil {
+	if more, err = hasContextDeadlineExceeded(stepCtx); more == true || err != nil {
 		return
 	}
 
@@ -168,19 +172,19 @@ func (cw *catchpointWriter) WriteStep(ctx context.Context) (more bool, err error
 
 	for {
 		// have we timed-out / canceled by that point ?
-		if more, err = hasContextDeadlineExceeded(ctx); more == true || err != nil {
+		if more, err = hasContextDeadlineExceeded(stepCtx); more == true || err != nil {
 			return
 		}
 
 		if len(cw.balancesChunk.Balances) == 0 {
-			err = cw.dbr.Atomic(cw.readDatabaseStep)
+			err = cw.readDatabaseStep(cw.ctx, cw.tx)
 			if err != nil {
 				return
 			}
 		}
 
 		// have we timed-out / canceled by that point ?
-		if more, err = hasContextDeadlineExceeded(ctx); more == true || err != nil {
+		if more, err = hasContextDeadlineExceeded(stepCtx); more == true || err != nil {
 			return
 		}
 
@@ -222,7 +226,7 @@ func (cw *catchpointWriter) WriteStep(ctx context.Context) (more bool, err error
 }
 
 func (cw *catchpointWriter) readDatabaseStep(ctx context.Context, tx *sql.Tx) (err error) {
-	cw.balancesChunk.Balances, err = encodedAccountsRange(ctx, tx, cw.balancesOffset, BalancesPerCatchpointFileChunk)
+	cw.balancesChunk.Balances, err = cw.accountsIterator.Iterate(ctx, tx, BalancesPerCatchpointFileChunk)
 	if err == nil {
 		cw.balancesOffset += BalancesPerCatchpointFileChunk
 	}

--- a/ledger/catchpointwriter.go
+++ b/ledger/catchpointwriter.go
@@ -65,7 +65,7 @@ type catchpointWriter struct {
 	blocksRound       basics.Round
 	blockHeaderDigest crypto.Digest
 	label             string
-	accountsIterator  encodedAccountsIterator
+	accountsIterator  encodedAccountsBatchIter
 }
 
 type encodedBalanceRecord struct {
@@ -103,7 +103,7 @@ func makeCatchpointWriter(ctx context.Context, filePath string, tx *sql.Tx, bloc
 		blocksRound:       blocksRound,
 		blockHeaderDigest: blockHeaderDigest,
 		label:             label,
-		accountsIterator:  encodedAccountsIterator{orederByAddress: true},
+		accountsIterator:  encodedAccountsBatchIter{orderByAddress: true},
 	}
 }
 
@@ -226,7 +226,7 @@ func (cw *catchpointWriter) WriteStep(stepCtx context.Context) (more bool, err e
 }
 
 func (cw *catchpointWriter) readDatabaseStep(ctx context.Context, tx *sql.Tx) (err error) {
-	cw.balancesChunk.Balances, err = cw.accountsIterator.Iterate(ctx, tx, BalancesPerCatchpointFileChunk)
+	cw.balancesChunk.Balances, err = cw.accountsIterator.Next(ctx, tx, BalancesPerCatchpointFileChunk)
 	if err == nil {
 		cw.balancesOffset += BalancesPerCatchpointFileChunk
 	}


### PR DESCRIPTION
## Summary

The encodedAccountsRange function was becoming too slow to be used on production systems.
It's performance degraded with size of data. ( i.e. first iteration is 1ms, after 5000 iterations you could get to 60ms ).
Instead, I replaced it with a single, long living, query which iterates over all the accounts.
In order to avoid a separate go-routine, I had to make some additional handling to the call stack.

Note that this function was used both in the rebuilding o the Merkle trie as well as during the generation of the catchpoint file. Both shown substantial performance gains.

## Test Plan

Existing unit tests were updated.
