### PR TITLE
Improve client-side catchpoint catchup performance

### DIFF
--- a/ledger/catchupaccessor.go
+++ b/ledger/catchupaccessor.go
@@ -296,7 +296,7 @@ func (c *CatchpointCatchupAccessorImpl) processStagingBalances(ctx context.Conte
 		var mc *merkleCommitter
 		mc, err = makeMerkleCommitter(tx, true)
 		if err != nil {
-			return err
+			return
 		}
 
 		if progress.cachedTrie == nil {


### PR DESCRIPTION
## Summary

Existing code was naive: it would have created a new Merkle Trie object on each catchpoint file chunk.
This approach is correct, but inefficient - the internal trie cache need to reload all the relevant pages on each iteration.

Instead of doing so, I switched to persisted Merkle Trie object, and added the changes to it. It has the benefits of a persistent cache, and perform significantly faster.

## Test Plan

Tested manually against betanet and mainnet, and seems to be considerably faster.