### PR TITLE
Add vacuumming to the database upgrade process

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -100,7 +100,7 @@ var accountsResetExprs = []string{
 // accountDBVersion is the database version that this binary would know how to support and how to upgrade to.
 // details about the content of each of the versions can be found in the upgrade functions upgradeDatabaseSchemaXXXX
 // and their descriptions.
-var accountDBVersion = int32(2)
+var accountDBVersion = int32(3)
 
 type accountDelta struct {
 	old basics.AccountData


### PR DESCRIPTION
## Summary

This change adds another step to the database upgrade process by triggering the vacuuming on completion of the upgrade process.

## Test Plan

Tested and confirmed to be working manually by reviewing the log files.
