### PR TITLE
Avoid redundent info message for replacing block 0

### DIFF
--- a/ledger/blockdb.go
+++ b/ledger/blockdb.go
@@ -166,6 +166,11 @@ func blockReplaceIfExists(tx *sql.Tx, log logging.Logger, blk bookkeeping.Block,
 	newBlk := protocol.Encode(&blk)
 	newCert := protocol.Encode(&cert)
 
+	// if the header hasn't been modified, just return.
+	if bytes.Compare(oldHdr[:], newHdr[:]) == 0 {
+		return false, nil
+	}
+
 	// Log if protocol version or certificate changed for the block we're replacing
 	if newProto != oldProto {
 		log.Warnf("blockReplaceIfExists(%v): old proto %v != new proto %v", blk.Round(), oldProto, newProto)

--- a/ledger/blockdb.go
+++ b/ledger/blockdb.go
@@ -167,7 +167,7 @@ func blockReplaceIfExists(tx *sql.Tx, log logging.Logger, blk bookkeeping.Block,
 	newCert := protocol.Encode(&cert)
 
 	// if the header hasn't been modified, just return.
-	if bytes.Compare(oldHdr[:], newHdr[:]) == 0 {
+	if bytes.Equal(oldHdr[:], newHdr[:]) {
 		return false, nil
 	}
 


### PR DESCRIPTION
## Summary

The current code does fix the issue of having incorrect TxnRoot on block 0, however, it also write to the log file the message `initBlocksDB replaced block 0` on every startup.

To address that, I have compared the old and new headers. If they are identical, the update is not needed. Note that the bug was in the TxnRoot field, but the test cover the entire block header.

## Test Plan

Tested manually to ensure correctness.
