### PR TITLE
Allow algorand-indexer to be installed alongside other packages

### DIFF
--- a/installer/debian/preinst
+++ b/installer/debian/preinst
@@ -1,23 +1,27 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -e
 
 PKG_NAME=@PKG_NAME@
-VERSION="$2"
+INDEXER=algorand-indexer
 
-if test "$1" = install &&
-    dpkg-query --list 'algorand*' > /dev/null
+if [ "$1" != install ] || [ "$PKG_NAME" == $INDEXER ]
 then
-    if PKG_INFO=$(dpkg-query --show --showformat='${Package} ${Status}\n' 'algorand*' | grep "install ok installed")
-    then
-        INSTALLED_PKG=$(echo "$PKG_INFO" | awk '{print $1}')
+    exit 0
+fi
 
-        if [ "$INSTALLED_PKG" != "$PKG_NAME" ]
-        then
-            echo -e "\nAlgorand does not currently support multi-distribution installations!\n\
+if dpkg-query --list 'algorand*' &> /dev/null
+then
+    PKG_INFO=$(dpkg-query --show --showformat='${Package} ${Status}\n' 'algorand*' | grep "install ok installed")
+    INSTALLED_PKG=$(grep -v $INDEXER <<< "$PKG_INFO" | awk '{print $1}')
+
+    if [ -n "$INSTALLED_PKG" ]
+    then
+        echo -e "\nAlgorand does not currently support multi-distribution installations!\n\
 To install this package, it is necessary to first remove the \`$INSTALLED_PKG\` package:\n\n\
-apt remove $INSTALLED_PKG\n\
-apt install $PKG_NAME=$VERSION\n"
-            exit 1
-        fi
+sudo apt-get remove $INSTALLED_PKG\n\
+sudo apt-get install $PKG_NAME\n"
+        exit 1
     fi
 fi
 

--- a/installer/debian/preinst
+++ b/installer/debian/preinst
@@ -3,9 +3,8 @@
 set -e
 
 PKG_NAME=@PKG_NAME@
-INDEXER=algorand-indexer
 
-if [ "$1" != install ] || [ "$PKG_NAME" == $INDEXER ]
+if [ "$1" != install ]
 then
     exit 0
 fi
@@ -13,7 +12,7 @@ fi
 if dpkg-query --list 'algorand*' &> /dev/null
 then
     PKG_INFO=$(dpkg-query --show --showformat='${Package} ${Status}\n' 'algorand*' | grep "install ok installed")
-    INSTALLED_PKG=$(grep -v $INDEXER <<< "$PKG_INFO" | awk '{print $1}')
+    INSTALLED_PKG=$(grep -v algorand-indexer <<< "$PKG_INFO" | awk '{print $1}')
 
     if [ -n "$INSTALLED_PKG" ]
     then


### PR DESCRIPTION
## Summary

The `preinst` maintenance script was not allowing for the indexer to be install alongside an `algorand` or `algorand-beta` package.

## Test Plan

Build the deb package doing `mule -f package.yaml package` in the root of the project directory.  This will put the package under the `./tmp/` directory, and then run the following to install `sudo dpkg -i tmp/...*.deb`.
