### PR TITLE
Exclude "beta" dir from sync to s3

### DIFF
--- a/scripts/release/build/stage/upload/run.sh
+++ b/scripts/release/build/stage/upload/run.sh
@@ -15,5 +15,5 @@ rm -rf pkg && mkdir -p pkg/"$FULLVERSION"
 ssh -i ReleaseBuildInstanceKey.pem -A ubuntu@"$INSTANCE" bash go/src/github.com/algorand/go-algorand/scripts/release/build/stage/upload/task.sh
 scp -i ReleaseBuildInstanceKey.pem -o StrictHostKeyChecking=no -r ubuntu@"$INSTANCE":~/node_pkg/* pkg/"$FULLVERSION"/
 
-aws s3 sync --exclude dev* --exclude master* --exclude nightly* --exclude stable* pkg/"$FULLVERSION" "s3://algorand-staging/releases/$CHANNEL/$FULLVERSION/"
+aws s3 sync --exclude dev* --exclude master* --exclude nightly* --exclude stable* --exclude beta* pkg/"$FULLVERSION" "s3://algorand-staging/releases/$CHANNEL/$FULLVERSION/"
 


### PR DESCRIPTION
## Summary

The generate releases page python script breaks if any directories are uploaded to the staging area from which we then copy to `algorand-dev-deb-repo`.  The generate script then is ran after the sync to the aforementioned bucket.

## Test Plan

In the `releases-page` repo, run `./generate_releases_page.py`.
