### PR TITLE
decrease mutex critical section time in kmd CreateWallet

### DIFF
--- a/daemon/kmd/wallet/driver/sqlite.go
+++ b/daemon/kmd/wallet/driver/sqlite.go
@@ -87,6 +87,8 @@ type SQLiteWalletDriver struct {
 	globalCfg config.KMDConfig
 	sqliteCfg config.SQLiteWalletDriverConfig
 	mux       *deadlock.Mutex
+
+	claimedWallets [][][]byte
 }
 
 // SQLiteWallet represents a particular SQLiteWallet under the
@@ -360,13 +362,57 @@ func checkDBError(err error) error {
 	return nil
 }
 
-// CreateWallet ensures that a wallet of the given name/id combo doesn't exist,
-// and initializes a database with the appropriate name.
-func (swd *SQLiteWalletDriver) CreateWallet(name []byte, id []byte, pw []byte, mdk crypto.MasterDerivationKey) error {
+func (swd *SQLiteWalletDriver) claimWalletNameId(name []byte, id []byte) (dbPath string, err error) {
 	// Grab our lock to avoid races with duplicate wallet names/ids
 	swd.mux.Lock()
 	defer swd.mux.Unlock()
 
+	for _, name_id := range swd.claimedWallets {
+		if bytes.Equal(name_id[0], name) {
+			return "", errSameName
+		}
+		if bytes.Equal(name_id[1], id) {
+			return "", errSameID
+		}
+	}
+
+	// name, id -> "/data/dir/name-id.db"
+	dbPath = swd.nameIDToPath(name, id)
+
+	// Ensure the wallet with this filename doesn't already exist, and that we
+	// have permissions to access the wallet directory
+	_, err = os.Stat(dbPath)
+	if !os.IsNotExist(err) {
+		return
+	}
+
+	// Ensure a wallet with this name doesn't already exist. swd.mux is
+	// locked above to avoid races here
+	sameNameDBPaths, err := swd.findDBPathsByName(name)
+	if err != nil {
+		return
+	}
+	if len(sameNameDBPaths) != 0 {
+		return "", errSameName
+	}
+
+	// Ensure a wallet with this id doesn't already exist. As above, we use
+	// swd.mux to avoid races
+	sameIDDBPaths, err := swd.findDBPathsByID(id)
+	if err != nil {
+		return
+	}
+	if len(sameIDDBPaths) != 0 {
+		return "", errSameID
+	}
+
+	swd.claimedWallets = append(swd.claimedWallets, [][]byte{name, id})
+	return
+}
+
+// CreateWallet ensures that a wallet of the given name/id combo doesn't exist,
+// and initializes a database with the appropriate name.
+func (swd *SQLiteWalletDriver) CreateWallet(name []byte, id []byte, pw []byte, mdk crypto.MasterDerivationKey) error {
 	if len(name) > sqliteMaxWalletNameLen {
 		return errNameTooLong
 	}
@@ -375,35 +421,11 @@ func (swd *SQLiteWalletDriver) CreateWallet(name []byte, id []byte, pw []byte, m
 		return errIDTooLong
 	}
 
-	// name, id -> "/data/dir/name-id.db"
-	dbPath := swd.nameIDToPath(name, id)
-
-	// Ensure the wallet with this filename doesn't already exist, and that we
-	// have permissions to access the wallet directory
-	_, err := os.Stat(dbPath)
-	if !os.IsNotExist(err) {
-		return err
-	}
-
-	// Ensure a wallet with this name doesn't already exist. swd.mux is
-	// locked above to avoid races here
-	sameNameDBPaths, err := swd.findDBPathsByName(name)
+	dbPath, err := swd.claimWalletNameId(name, id)
 	if err != nil {
 		return err
 	}
-	if len(sameNameDBPaths) != 0 {
-		return errSameName
-	}
-
-	// Ensure a wallet with this id doesn't already exist. As above, we use
-	// swd.mux to avoid races
-	sameIDDBPaths, err := swd.findDBPathsByID(id)
-	if err != nil {
-		return err
-	}
-	if len(sameIDDBPaths) != 0 {
-		return errSameID
-	}
+	// TODO? drop the entry in swd.claimedWallets on exit?
 
 	// Create the database
 	db, err := sqlx.Connect("sqlite3", dbConnectionURL(dbPath))

--- a/daemon/kmd/wallet/driver/sqlite.go
+++ b/daemon/kmd/wallet/driver/sqlite.go
@@ -362,16 +362,16 @@ func checkDBError(err error) error {
 	return nil
 }
 
-func (swd *SQLiteWalletDriver) claimWalletNameId(name []byte, id []byte) (dbPath string, err error) {
+func (swd *SQLiteWalletDriver) claimWalletNameID(name []byte, id []byte) (dbPath string, err error) {
 	// Grab our lock to avoid races with duplicate wallet names/ids
 	swd.mux.Lock()
 	defer swd.mux.Unlock()
 
-	for _, name_id := range swd.claimedWallets {
-		if bytes.Equal(name_id[0], name) {
+	for _, nameID := range swd.claimedWallets {
+		if bytes.Equal(nameID[0], name) {
 			return "", errSameName
 		}
-		if bytes.Equal(name_id[1], id) {
+		if bytes.Equal(nameID[1], id) {
 			return "", errSameID
 		}
 	}
@@ -421,7 +421,7 @@ func (swd *SQLiteWalletDriver) CreateWallet(name []byte, id []byte, pw []byte, m
 		return errIDTooLong
 	}
 
-	dbPath, err := swd.claimWalletNameId(name, id)
+	dbPath, err := swd.claimWalletNameID(name, id)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

On some slower environments `kmd` could spend over 30s in CreateWallet while holding a mutex causing the deadlock detector to panic. This decreases the time in the critical section and puts the slow crypto operations outside.
Fixes #1402 

## Test Plan

Tested on the slow system where the problem was found. Passes test/scrits/e2e.sh which originally found the problem.
