### PR TITLE
Simplify dryrunning and debugging group txn

### DIFF
--- a/cmd/tealdbg/main.go
+++ b/cmd/tealdbg/main.go
@@ -184,8 +184,8 @@ func debugLocal(args []string) {
 	// program can be set either directly
 	// or with SignedTxn.Lsig.Logic,
 	// or with BalanceRecord.AppParams.ApprovalProgram
-	if len(args) == 0 && (len(txnFile) == 0 || len(balanceFile) == 0) && len(ddrFile) == 0 {
-		log.Fatalln("No program to debug: must specify program(s), or transaction(s) and a balance record(s), or dryrun-req object")
+	if len(args) == 0 && len(txnFile) == 0 && len(ddrFile) == 0 {
+		log.Fatalln("No program to debug: must specify program(s), or transaction(s), or dryrun-req object")
 	}
 
 	if len(args) == 0 && groupIndex != 0 {

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -411,12 +411,11 @@ func doDryrunRequest(dr *DryrunRequest, proto *config.ConsensusParams, response 
 			GroupIndex: ti,
 			//Logger: nil, // TODO: capture logs, send them back
 		}
-		var result *generated.DryrunTxnResult
+		var result generated.DryrunTxnResult
 		if len(stxn.Lsig.Logic) > 0 {
 			var debug dryrunDebugReceiver
 			ep.Debugger = &debug
 			pass, err := logic.Eval(stxn.Lsig.Logic, ep)
-			result = new(generated.DryrunTxnResult)
 			var messages []string
 			result.Disassembly = debug.lines
 			result.LogicSigTrace = &debug.history
@@ -460,9 +459,6 @@ func doDryrunRequest(dr *DryrunRequest, proto *config.ConsensusParams, response 
 				}
 			}
 			var messages []string
-			if result == nil {
-				result = new(generated.DryrunTxnResult)
-			}
 			if !ok {
 				messages = make([]string, 1)
 				messages[0] = fmt.Sprintf("uploaded state did not include app id %d referenced in txn[%d]", appIdx, ti)
@@ -507,7 +503,7 @@ func doDryrunRequest(dr *DryrunRequest, proto *config.ConsensusParams, response 
 			}
 			result.AppCallMessages = &messages
 		}
-		response.Txns[ti] = *result
+		response.Txns[ti] = result
 	}
 }
 

--- a/test/e2e-go/cli/goal/expect/goalDryrunRestTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalDryrunRestTest.exp
@@ -101,6 +101,27 @@ if { [catch {
         timeout { ::AlgorandGoal::Abort "goal app create timeout" }
     }
 
+    # atomic transfer
+    set DRREQ_FILE_4 "$TEST_ROOT_DIR/atomic-tran-drreq.msgp"
+    set AT_TX1_FILE "$TEST_ROOT_DIR/atomic-tran-tx1.mspg"
+    set AT_TX2_FILE "$TEST_ROOT_DIR/atomic-tran-tx2.mspg"
+    set AT_COMBINED_FILE "$TEST_ROOT_DIR/atomic-tran-comb.mspg"
+    set AT_GROUPPED_FILE "$TEST_ROOT_DIR/atomic-tran-group.mspg"
+    spawn goal clerk send --from $PRIMARY_ACCOUNT_ADDRESS --to $PRIMARY_ACCOUNT_ADDRESS -a 1 --fee 1000 -d $TEST_PRIMARY_NODE_DIR -o $AT_TX1_FILE
+    expect {
+        timeout { ::AlgorandGoal::Abort "goal clerk send timeout" }
+    }
+    spawn goal app create --creator $PRIMARY_ACCOUNT_ADDRESS --approval-prog $TEAL_PROG_FILE --clear-prog $TEAL_PROG_FILE --global-byteslices 0 --global-ints 0 --local-byteslices 0 --local-ints 0 -d $TEST_PRIMARY_NODE_DIR -o $AT_TX2_FILE
+    expect {
+        timeout { ::AlgorandGoal::Abort "goal app create timeout" }
+    }
+    exec cat $AT_TX1_FILE $AT_TX2_FILE > $AT_COMBINED_FILE
+    exec goal clerk group -i $AT_COMBINED_FILE -o $AT_GROUPPED_FILE
+    spawn goal clerk dryrun -t $AT_GROUPPED_FILE -d $TEST_PRIMARY_NODE_DIR -o $DRREQ_FILE_4 --dryrun-dump --dryrun-dump-format=msgp
+    expect {
+        timeout { ::AlgorandGoal::Abort "goal clerk dryrun timeout" }
+    }
+
     # invalid app
     set INVALID_FILE_1 "$TEST_ROOT_DIR/invalid-app.json"
     set INVALID_FILE_1_ID [open $INVALID_FILE_1 "w"]
@@ -111,6 +132,8 @@ if { [catch {
     TestGoalDryrun $DRREQ_FILE_1 $TEST_PRIMARY_NODE_DIR
     TestGoalDryrun $DRREQ_FILE_2 $TEST_PRIMARY_NODE_DIR
     TestGoalDryrun $DRREQ_FILE_3 $TEST_PRIMARY_NODE_DIR
+    TestGoalDryrun $DRREQ_FILE_4 $TEST_PRIMARY_NODE_DIR
+
     TestGoalDryrunExitCode $DRREQ_FILE_3 $TEST_PRIMARY_NODE_DIR 0 "PASS"
     TestGoalDryrunExitCode "" $TEST_PRIMARY_NODE_DIR 1 "Cannot read file : open : no such file or directory"
     TestGoalDryrunExitCode $INVALID_FILE_1 $TEST_PRIMARY_NODE_DIR 1 "dryrun-remote: HTTP 400 Bad Request:"


### PR DESCRIPTION
## Summary

* Extend clerk dryrun so it can dump dryrun state object suitable for REST, tealdbg and python tests
  goal clerk dryrun -t grouptxn.msgp -o dr.mspg --dryrun-dump --dryrun-dump-format=msgp
* Fix parameter validation in tealdbg
* Fix NPE in REST dryrun when a first txn in a group non-TEAL

## Test Plan

Extended expect test for group txn