### PR TITLE
Fix fast catchup processed/total account values swapped.

### DIFF
--- a/cmd/goal/node.go
+++ b/cmd/goal/node.go
@@ -422,8 +422,8 @@ func makeStatusString(stat generatedV2.NodeStatusResponse) string {
 			*stat.Catchpoint)
 
 		if stat.CatchpointTotalAccounts != nil && (*stat.CatchpointTotalAccounts > 0) && stat.CatchpointProcessedAccounts != nil {
-			statusString = statusString + "\n" + fmt.Sprintf(infoNodeCatchpointCatchupAccounts, *stat.CatchpointProcessedAccounts,
-				*stat.CatchpointTotalAccounts)
+			statusString = statusString + "\n" + fmt.Sprintf(infoNodeCatchpointCatchupAccounts, *stat.CatchpointTotalAccounts,
+				*stat.CatchpointProcessedAccounts)
 		}
 		if stat.CatchpointAcquiredBlocks != nil && stat.CatchpointTotalBlocks != nil && (*stat.CatchpointAcquiredBlocks+*stat.CatchpointTotalBlocks > 0) {
 			statusString = statusString + "\n" + fmt.Sprintf(infoNodeCatchpointCatchupBlocks, *stat.CatchpointTotalBlocks,


### PR DESCRIPTION
## Summary

While writing a script to consume fast catchup data I noticed that these values were swapped.

For your review reference...

```
$ rg infoNodeCatchpointCatchupAccounts -A 1
cmd/goal/node.go
425:			statusString = statusString + "\n" + fmt.Sprintf(infoNodeCatchpointCatchupAccounts, *stat.CatchpointTotalAccounts,
426-				*stat.CatchpointProcessedAccounts)

cmd/goal/messages.go
65:	infoNodeCatchpointCatchupAccounts = "Catchpoint total accounts: %d\nCatchpoint accounts processed: %d"
66-	infoNodeCatchpointCatchupBlocks   = "Catchpoint total blocks: %d\nCatchpoint downloaded blocks: %d"
```