### PR TITLE
Disable deadlock detection on master

### DIFF
--- a/scripts/compute_branch_deadlock_default.sh
+++ b/scripts/compute_branch_deadlock_default.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
-if [[ "$1" =~ ^rel/ ]]; then
-    echo "disable"
-else
-    echo "enable"
+# if the user ( i.e. algorand developer ) has explicitly enabled the deadlock detection in his environment, we want to enable it.
+if [ "$ALGORAND_DEADLOCK" != "" ]; then
+    echo "$ALGORAND_DEADLOCK"
+    exit 0
 fi
+
+# we used to disable the deadlock on all release builds, which cause issues with individuals who compiled it on their own.
+# as a result, we decided to disable it always, unless we're running on travis. If we'll ever want to make it dependent
+# on the build branch, the build branch is available in $1. ( i.e. if [[ "$1" =~ ^rel/ ]]; then ... )
+echo "disable"

--- a/scripts/travis/build_test.sh
+++ b/scripts/travis/build_test.sh
@@ -9,6 +9,8 @@
 # Examples: scripts/travis/build_test.sh
 set -e
 
+ALGORAND_DEADLOCK=enable
+export ALGORAND_DEADLOCK
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 if [ "${USER}" = "travis" ]; then

--- a/scripts/travis/integration_test.sh
+++ b/scripts/travis/integration_test.sh
@@ -9,6 +9,9 @@
 # Examples: scripts/travis/integration_test.sh
 set -e
 
+ALGORAND_DEADLOCK=enable
+export ALGORAND_DEADLOCK
+
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 export BUILD_TYPE="integration"

--- a/scripts/travis/test_release.sh
+++ b/scripts/travis/test_release.sh
@@ -8,6 +8,8 @@
 
 set -e
 
+ALGORAND_DEADLOCK=enable
+export ALGORAND_DEADLOCK
 BRANCH=$(./scripts/compute_branch.sh)
 CHANNEL=$(./scripts/compute_branch_channel.sh "$BRANCH")
 


### PR DESCRIPTION
## Summary

Disable the deadlock by default on master; enable only when running travis tests or setting via ALGORAND_DEADLOCK