### PR TITLE
Slow down catchup while catchpoint file is being written

### DIFF
--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -577,6 +577,10 @@ func (m *mockedLedger) LookupDigest(basics.Round) (crypto.Digest, error) {
 	return crypto.Digest{}, errors.New("not needed for mockedLedger")
 }
 
+func (m *mockedLedger) IsWritingCatchpointFile() bool {
+	return false
+}
+
 func testingenv(t testing.TB, numBlocks int) (ledger, emptyLedger Ledger) {
 	mLedger := new(mockedLedger)
 	mEmptyLedger := new(mockedLedger)

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -584,6 +584,14 @@ func (l *Ledger) trackerEvalVerified(blk bookkeeping.Block, accUpdatesLedger led
 	return eval(context.Background(), accUpdatesLedger, blk, false, nil, nil)
 }
 
+// IsWritingCatchpointFile returns true when a catchpoint file is being generated. The function is used by the catchup service so
+// that the memory pressure could be decreased until the catchpoint file writing is complete.
+func (l *Ledger) IsWritingCatchpointFile() bool {
+	l.trackerMu.RLock()
+	defer l.trackerMu.RUnlock()
+	return l.accts.IsWritingCatchpointFile()
+}
+
 // A txlease is a transaction (sender, lease) pair which uniquely specifies a
 // transaction lease.
 type txlease struct {

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -584,8 +584,8 @@ func (l *Ledger) trackerEvalVerified(blk bookkeeping.Block, accUpdatesLedger led
 	return eval(context.Background(), accUpdatesLedger, blk, false, nil, nil)
 }
 
-// IsWritingCatchpointFile returns true when a catchpoint file is being generated. The function is used by the catchup service so
-// that the memory pressure could be decreased until the catchpoint file writing is complete.
+// IsWritingCatchpointFile returns true when a catchpoint file is being generated. The function is used by the catchup service
+// to avoid memory pressure until the catchpoint file writing is complete.
 func (l *Ledger) IsWritingCatchpointFile() bool {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()


### PR DESCRIPTION
## Summary

Testing the algod against mainnet shown that memory utilization during catchup could be substantial.
This PR slows down the catchup when catchpoint file is being written. This would lower the memory pressure
on the accounts updater, as no additional blocks would get added.

Note that it will make a difference only on archival nodes. Non-archival nodes would behave as they do today.