### PR TITLE
Dynamically install deb package in legacy pipeline

### DIFF
--- a/scripts/release/build/rpm/build.sh
+++ b/scripts/release/build/rpm/build.sh
@@ -13,7 +13,7 @@ export HOME=/root
 
 mkdir -p "${HOME}/go/src/github.com/algorand"
 cd "${HOME}/go/src/github.com/algorand"
-if ! git clone --single-branch --branch "${BRANCH}" https://github.com/algorand/go-algorand go-algorand
+if ! git clone --single-branch --branch rel/beta https://github.com/algorand/go-algorand go-algorand
 then
     echo There has been a problem cloning the "$BRANCH" branch.
     exit 1

--- a/scripts/release/common/setup.sh
+++ b/scripts/release/common/setup.sh
@@ -32,13 +32,14 @@ sudo rngd -r /dev/urandom
 mkdir -p "${HOME}"/{.gnupg,dummyaptly,dummyrepo,go,gpgbin,keys,node_pkg,prodrepo}
 mkdir -p "${HOME}"/go/bin
 
-BRANCH=${1:-"master"}
+#BRANCH=${1:-"master"}
+BRANCH=rel/beta
 export BRANCH
 
 # Check out
 mkdir -p "${HOME}/go/src/github.com/algorand"
 cd "${HOME}/go/src/github.com/algorand"
-if ! git clone --single-branch --branch "${BRANCH}" https://github.com/algorand/go-algorand go-algorand
+if ! git clone --single-branch --branch "$BRANCH" https://github.com/algorand/go-algorand go-algorand
 then
     echo There has been a problem cloning the "$BRANCH" branch.
     exit 1

--- a/scripts/release/test/deb/test_algorand.sh
+++ b/scripts/release/test/deb/test_algorand.sh
@@ -5,6 +5,11 @@ set -ex
 export GOPATH=${HOME}/go
 export PATH=${GOPATH}/bin:/usr/local/go/bin:${PATH}
 
+PKG_NAME=algorand
+if [ "${CHANNEL}" = beta ]; then
+    PKG_NAME=algorand-beta
+fi
+
 apt-get update
 apt-get install -y gnupg2 curl software-properties-common python3
 
@@ -22,7 +27,7 @@ apt-key add /root/keys/dev.pub
 apt-key add /root/keys/rpm.pub
 add-apt-repository "deb http://${DC_IP}:8111/ stable main"
 apt-get update
-apt-get install -y algorand
+apt-get install -y "${PKG_NAME}"
 algod -v
 # check that the installed version is now the current version
 algod -v | grep -q "${FULLVERSION}.${CHANNEL}"

--- a/scripts/release/test/deb/test_apt-get.sh
+++ b/scripts/release/test/deb/test_apt-get.sh
@@ -1,18 +1,23 @@
 #!/usr/bin/env bash
 
-#set -xv
+set -ex
 
 echo "test_apt-get starting within docker container"
 
 export GOPATH=${HOME}/go
 export PATH=${GOPATH}/bin:/usr/local/go/bin:${PATH}
 
+PKG_NAME=algorand
+if [ "${CHANNEL}" = beta ]; then
+    PKG_NAME=algorand-beta
+fi
+
 apt-get update
 apt-get install -y gnupg2 curl software-properties-common python3
 apt-key add /root/keys/dev.pub
 add-apt-repository -y "deb [trusted=yes] http://${DC_IP}:8111/ stable main"
 apt-get update
-apt-get install -y algorand
+apt-get install -y "${PKG_NAME}"
 apt-get install -y expect
 
 algod -v


### PR DESCRIPTION
## Summary

The legacy pipeline isn't distinguishing between stable and beta release packages. It needs to test algorand for the former and algorand-beta for the latter.

## Test Plan

Run the legacy pipeline in Jenkins (https://ci.algorand.network/job/build-packages/).
