### PR TITLE
Dynamically install deb package in legacy pipeline

### DIFF
--- a/scripts/release/test/deb/test_algorand.sh
+++ b/scripts/release/test/deb/test_algorand.sh
@@ -5,6 +5,11 @@ set -ex
 export GOPATH=${HOME}/go
 export PATH=${GOPATH}/bin:/usr/local/go/bin:${PATH}
 
+PKG_NAME=algorand
+if [ "${CHANNEL}" = beta ]; then
+    PKG_NAME=algorand-beta
+fi
+
 apt-get update
 apt-get install -y gnupg2 curl software-properties-common python3
 
@@ -22,7 +27,7 @@ apt-key add /root/keys/dev.pub
 apt-key add /root/keys/rpm.pub
 add-apt-repository "deb http://${DC_IP}:8111/ stable main"
 apt-get update
-apt-get install -y algorand
+apt-get install -y "${PKG_NAME}"
 algod -v
 # check that the installed version is now the current version
 algod -v | grep -q "${FULLVERSION}.${CHANNEL}"

--- a/scripts/release/test/deb/test_apt-get.sh
+++ b/scripts/release/test/deb/test_apt-get.sh
@@ -1,18 +1,23 @@
 #!/usr/bin/env bash
 
-#set -xv
+set -ex
 
 echo "test_apt-get starting within docker container"
 
 export GOPATH=${HOME}/go
 export PATH=${GOPATH}/bin:/usr/local/go/bin:${PATH}
 
+PKG_NAME=algorand
+if [ "${CHANNEL}" = beta ]; then
+    PKG_NAME=algorand-beta
+fi
+
 apt-get update
 apt-get install -y gnupg2 curl software-properties-common python3
 apt-key add /root/keys/dev.pub
 add-apt-repository -y "deb [trusted=yes] http://${DC_IP}:8111/ stable main"
 apt-get update
-apt-get install -y algorand
+apt-get install -y "${PKG_NAME}"
 apt-get install -y expect
 
 algod -v

--- a/scripts/release/test/rpm/run_centos.sh
+++ b/scripts/release/test/rpm/run_centos.sh
@@ -9,6 +9,11 @@ echo
 date "+build_release begin TEST stage %Y%m%d_%H%M%S"
 echo
 
+if [ "$CHANNEL" = beta ]; then
+    echo "There is currently no support for RPM beta packages. Exiting RPM test stage..."
+    exit 0
+fi
+
 # Run RPM build in Centos7 Docker container
 sg docker "docker build -t algocentosbuild - < ${HOME}/go/src/github.com/algorand/go-algorand/scripts/release/common/docker/centos.Dockerfile"
 


### PR DESCRIPTION
## Summary

The legacy pipeline isn't distinguishing between stable and beta release packages. It needs to test algorand for the former and algorand-beta for the latter.

## Test Plan

https://ci.algorand.network/job/test-packages/