### PR TITLE
add an API for using MsgOfInterest messages

### DIFF
--- a/network/msgOfInterest.go
+++ b/network/msgOfInterest.go
@@ -28,6 +28,7 @@ var errInvalidMessageOfInterest = errors.New("unmarshalMessageOfInterest: messag
 var errInvalidMessageOfInterestLength = errors.New("unmarshalMessageOfInterest: message length is too long")
 
 const maxMessageOfInterestTags = 1024
+const topicsEncodingSeparator = ","
 
 func unmarshallMessageOfInterest(data []byte) (map[protocol.Tag]bool, error) {
 	// decode the message, and ensure it's a valid message.
@@ -44,7 +45,7 @@ func unmarshallMessageOfInterest(data []byte) (map[protocol.Tag]bool, error) {
 	}
 	// convert the tags into a tags map.
 	msgTagsMap := make(map[protocol.Tag]bool, len(tags))
-	for _, tag := range strings.Split(string(tags), ",") {
+	for _, tag := range strings.Split(string(tags), topicsEncodingSeparator) {
 		msgTagsMap[protocol.Tag(tag)] = true
 	}
 	return msgTagsMap, nil
@@ -55,10 +56,10 @@ func MarshallMessageOfInterest(messageTags []protocol.Tag) []byte {
 	// create a long string with all these messages.
 	tags := ""
 	for _, tag := range messageTags {
-		tags += "," + string(tag)
+		tags += topicsEncodingSeparator + string(tag)
 	}
 	if len(tags) > 0 {
-		tags = tags[1:]
+		tags = tags[len(topicsEncodingSeparator):]
 	}
 	topics := Topics{Topic{key: "tags", data: []byte(tags)}}
 	return topics.MarshallTopics()
@@ -70,11 +71,11 @@ func MarshallMessageOfInterestMap(tagmap map[protocol.Tag]bool) []byte {
 	tags := ""
 	for tag, flag := range tagmap {
 		if flag {
-			tags += "," + string(tag)
+			tags += topicsEncodingSeparator + string(tag)
 		}
 	}
 	if len(tags) > 0 {
-		tags = tags[1:]
+		tags = tags[len(topicsEncodingSeparator):]
 	}
 	topics := Topics{Topic{key: "tags", data: []byte(tags)}}
 	return topics.MarshallTopics()

--- a/network/msgOfInterest.go
+++ b/network/msgOfInterest.go
@@ -63,3 +63,19 @@ func MarshallMessageOfInterest(messageTags []protocol.Tag) []byte {
 	topics := Topics{Topic{key: "tags", data: []byte(tags)}}
 	return topics.MarshallTopics()
 }
+
+// MarshallMessageOfInterestMap generates a message of interest message body
+// for the message tags that map to "true" in the map argument.
+func MarshallMessageOfInterestMap(tagmap map[protocol.Tag]bool) []byte {
+	tags := ""
+	for tag, flag := range tagmap {
+		if flag {
+			tags += "," + string(tag)
+		}
+	}
+	if len(tags) > 0 {
+		tags = tags[1:]
+	}
+	topics := Topics{Topic{key: "tags", data: []byte(tags)}}
+	return topics.MarshallTopics()
+}

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -814,6 +814,12 @@ func (wn *WebsocketNetwork) Stop() {
 	if wn.listener != nil {
 		wn.log.Debugf("closed %s", listenAddr)
 	}
+
+	wn.messagesOfInterestMu.Lock()
+	defer wn.messagesOfInterestMu.Unlock()
+	wn.messagesOfInterestEncoded = false
+	wn.messagesOfInterestEnc = nil
+	wn.messagesOfInterest = nil
 }
 
 // RegisterHandlers registers the set of given message handlers.

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -2076,6 +2076,11 @@ func SetUserAgentHeader(header http.Header) {
 	header.Set(UserAgentHeader, ua)
 }
 
+// RegisterMessageInterest notifies the network library that this node
+// wants to receive messages with the specified tag.  This will cause
+// this node to send corresponding MsgOfInterest notifications to any
+// newly connecting peers.  This should be called before the network
+// is started.
 func (wn *WebsocketNetwork) RegisterMessageInterest(t protocol.Tag) error {
 	wn.messagesOfInterestMu.Lock()
 	defer wn.messagesOfInterestMu.Unlock()

--- a/protocol/tags.go
+++ b/protocol/tags.go
@@ -21,16 +21,18 @@ package protocol
 type Tag string
 
 // Tags, in lexicographic sort order of tag values to avoid duplicates.
+// These tags must not contain a comma character because lists of tags
+// are encoded using a comma separator (see network/msgOfInterest.go).
 const (
 	UnknownMsgTag      Tag = "??"
 	AgreementVoteTag   Tag = "AV"
+	MsgOfInterestTag   Tag = "MI"
 	MsgDigestSkipTag   Tag = "MS"
 	NetPrioResponseTag Tag = "NP"
 	PingTag            Tag = "pi"
 	PingReplyTag       Tag = "pj"
 	ProposalPayloadTag Tag = "PP"
 	TopicMsgRespTag    Tag = "TS"
-	MsgOfInterestTag   Tag = "MI"
 	TxnTag             Tag = "TX"
 	UniCatchupReqTag   Tag = "UC"
 	UniEnsBlockReqTag  Tag = "UE"


### PR DESCRIPTION
This adds an API that callers can use to cause the wsNetwork node to send MsgOfInterest messages to its peers so that peers can send additional message types not included in `defaultSendMessageTags`.

This is intended to be used by the compact cert code, so that relays use MsgOfInterest messages to request compact cert sigs, whereas regular non-relay nodes don't see compact cert sig messages.