### PR TITLE
Adding test for parseStringLiteral cases \r and \\

### DIFF
--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -1331,7 +1331,7 @@ func TestStringLiteralParsing(t *testing.T) {
 	require.Equal(t, e, result)
 
 	s = `"test\ra"`
-	e = []byte("test\ra")
+	e = []byte("test\x0da")
 	result, err = parseStringLiteral(s)
 	require.NoError(t, err)
 	require.Equal(t, e, result)

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -1330,6 +1330,18 @@ func TestStringLiteralParsing(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, e, result)
 
+	s = `"test\ra"`
+	e = []byte("test\ra")
+	result, err = parseStringLiteral(s)
+	require.NoError(t, err)
+	require.Equal(t, e, result)
+
+	s = `"test\\"`
+	e = []byte(`test\`)
+	result, err = parseStringLiteral(s)
+	require.NoError(t, err)
+	require.Equal(t, e, result)
+
 	s = `"test 123"`
 	e = []byte(`test 123`)
 	result, err = parseStringLiteral(s)


### PR DESCRIPTION
Adding test for parseStringLiteral cases \r and \\
Note: \r does not bring the cursor to the beginning of the line.

This test completes the coverage of data/transactions/logic
