### PR TITLE
Fix - avoid "ran out of time for round"

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -667,8 +667,9 @@ func (pool *TransactionPool) recomputeBlockEvaluator(committedTxIds map[transact
 	}
 
 	pool.assemblyMu.Lock()
-	if !pool.assemblyResults.ok && pool.assemblyRound == pool.pendingBlockEvaluator.Round() {
+	if !pool.assemblyResults.ok && pool.assemblyRound <= pool.pendingBlockEvaluator.Round() {
 		pool.assemblyResults.ok = true
+		pool.assemblyResults.stats = asmStats
 		lvb, err := pool.pendingBlockEvaluator.GenerateBlock()
 		if err != nil {
 			pool.assemblyResults.err = fmt.Errorf("could not generate block for %d (end): %v", pool.assemblyResults.round, err)

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -554,6 +554,8 @@ func (pool *TransactionPool) addToPendingBlockEvaluatorOnce(txgroup []transactio
 				} else {
 					stats.StopReason = telemetryspec.AssembleBlockTimeout
 				}
+				pool.assemblyResults.stats = *stats
+
 				lvb, gerr := pool.pendingBlockEvaluator.GenerateBlock()
 				if gerr != nil {
 					pool.assemblyResults.err = fmt.Errorf("could not generate block for %d: %v", pool.assemblyResults.round, gerr)

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -648,6 +648,7 @@ func (pool *TransactionPool) recomputeBlockEvaluator(committedTxIds map[transact
 
 	// Feed the transactions in order
 	for i, txgroup := range txgroups {
+		txStart := time.Now()
 		if len(txgroup) == 0 {
 			asmStats.InvalidCount++
 			continue
@@ -678,6 +679,9 @@ func (pool *TransactionPool) recomputeBlockEvaluator(committedTxIds map[transact
 				stats.RemovedInvalidCount++
 				logging.Base().Warnf("Cannot re-add pending transaction to pool: %v", err)
 			}
+		}
+		if time.Now().Sub(txStart) > 5*time.Millisecond {
+			logging.Base().Warnf("TransactionPool.recomputeBlockEvaluator: transaction group processing time was %v", time.Now().Sub(txStart))
 		}
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -970,7 +970,7 @@ func (vb validatedBlock) Block() bookkeeping.Block {
 func (node *AlgorandFullNode) AssembleBlock(round basics.Round, deadline time.Time) (agreement.ValidatedBlock, error) {
 	lvb, err := node.transactionPool.AssembleBlock(round, deadline)
 	if err != nil {
-		if err == pools.ErrTxPoolStaleBlockAssembly {
+		if err == pools.ErrStaleBlockAssemblyRequest {
 			// convert specific error to one that would have special handling in the agreement code.
 			err = agreement.ErrAssembleBlockRoundStale
 


### PR DESCRIPTION
## Summary

We've seen multiple warning on telemetry indicating the `AssembleBlock: ran out of time for round XXXX`.
When this happen, the node would not make a proposal, as the block assembler failed. In turn, it has the potential of leading to a network stall.

The solution to this issue spanned across two areas - prevention and recovery.

### Prevention
The key issue which was observed is that a single TxnGroup processing can take ( sometimes ) more then 10, 20 or 30 milliseconds. As such, it means that the iterating loop in `recomputeBlockEvaluator` and the "aborting logic" in `addToPendingBlockEvaluatorOnce` might not be the best mean to achieve accurate measuring of allocated time.

Placing a condition that wait on that short timeframe in `AssembleBlock` would randomly fails, in particular when we don't use dedicated servers with plenty of cores.

Another observation is that the requested round number by `AssembleBlock` might be older or *newer* than the transaction pool round. This is a normal behavior, since the agreement service is moving forward by the notification channel, whereas the transaction pool by the OnNewBlock ( i.e. backlogged notifier ).

As such, the transaction pool might be processing the transactions of block X, and while doing this, it receives a request to assemble the block for round X+1. To address this use case, I've added early abort:  
When the AssembleBlock is called, is sets the assemblyRound to the desired round number.
If we get to a situation where we would consider to "save" the results from the evaluator and form a block, we compare that block number with the assemblyRound first. This help us to "drop" wasting CPU time on creating blocks that we don't need.

Unfortunately, the above also has a downside - not every iteration of `recomputeBlockEvaluator` would end up with a block. And we do need to have the current round number, for checking which round number we're at. To do that, I've added `round` to `poolAsmResults` so we can monitor which round is currently being generated.

### Recovery
The recovery phase attempts to restore some of the previous behavior; in essence, we're doing the following
waiting up to 250ms for the `recomputeBlockEvaluator` to finish preparing the block of the desired round.
if we received a block before reaching the 250ms mark - that's great. we return this block.
If not, we're releasing the lock, and giving the `recomputeBlockEvaluator` a second chance. Than,
we're preparing an empty block. ( preparing empty block isn't free - it require some ledger access, just like the evaluator ).
Once the block ready, we'll be waiting additional 150ms to a total of 400ms from the moment we entered the `AssembleBlock`.
If by the end of the waiting ( or before ), we get a block from the  `recomputeBlockEvaluator`, then we return that block. Otherwise, we return the empty block which we've prepared during the "over-time".

## Test Plan

We have identified that the above scenario is reproducible under load, and confirmed that it's working correctly using the performance testing infrastructure.