### PR TITLE
Fix 64bit alignment for feePerByte

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -48,6 +48,10 @@ import (
 // TransactionPool.AssembleBlock constructs a valid block for
 // proposal given a deadline.
 type TransactionPool struct {
+	// feePerByte is stored at the begining of this struct to ensure it has a 64 bit aligned address. This is needed as it's being used
+	// with atomic operations which require 64 bit alignment on arm.
+	feePerByte uint64
+
 	// const
 	logProcessBlockStats bool
 	logAssembleStats     bool
@@ -61,7 +65,6 @@ type TransactionPool struct {
 	pendingBlockEvaluator  *ledger.BlockEvaluator
 	numPendingWholeBlocks  basics.Round
 	feeThresholdMultiplier uint64
-	feePerByte             uint64
 	statusCache            *statusCache
 
 	assemblyMu       deadlock.Mutex


### PR DESCRIPTION
## Summary

On ARM, all 64bit atomic operation require that the underlying variable would be stored on a 64bit aligned address.
This is a known go limitation that is unlikely to go away.
https://golang.org/pkg/sync/atomic/

Solution is to move the variable to the beginning of the structure, where it's guaranteed to be 64bit aligned.

## Test Plan

Test manually to confirm

## Error Dump
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xb51262e4]
goroutine 2812 [running]:
runtime/internal/atomic.goStore64(0x872b005c, 0x0, 0x0)
	/usr/local/go/src/runtime/internal/atomic/atomic_arm.go:140 +0x1c
github.com/algorand/go-algorand/data/pools.(*TransactionPool).computeFeePerByte(0x872b0000, 0x0, 0x0)
	/go/src/github.com/algorand/go-algorand/data/pools/transactionPool.go:280 +0xcc
github.com/algorand/go-algorand/data/pools.(*TransactionPool).checkSufficientFee(0x872b0000, 0x86b33b00, 0x1, 0x2, 0xb6f63318, 0x3b9aca00)
	/go/src/github.com/algorand/go-algorand/data/pools/transactionPool.go:289 +0x24
github.com/algorand/go-algorand/data/pools.(*TransactionPool).ingest(0x872b0000, 0x86b33b00, 0x1, 0x2, 0x8b093b80, 0x1, 0x1, 0x0, 0x0, 0x0, ...)
	/go/src/github.com/algorand/go-algorand/data/pools/transactionPool.go:365 +0x250
github.com/algorand/go-algorand/data/pools.(*TransactionPool).remember(...)
	/go/src/github.com/algorand/go-algorand/data/pools/transactionPool.go:329
github.com/algorand/go-algorand/data/pools.(*TransactionPool).Remember(0x872b0000, 0x86b33b00, 0x1, 0x2, 0x8b093b80, 0x1, 0x1, 0x0, 0x0)
	/go/src/github.com/algorand/go-algorand/data/pools/transactionPool.go:401 +0xcc
github.com/algorand/go-algorand/data.(*TxHandler).postprocessCheckedTxn(0x84c9a6c0, 0x84cea630)
	/go/src/github.com/algorand/go-algorand/data/txHandler.go:191 +0x160
github.com/algorand/go-algorand/data.(*TxHandler).backlogWorker(0x84c9a6c0)
	/go/src/github.com/algorand/go-algorand/data/txHandler.go:131 +0x98
created by github.com/algorand/go-algorand/data.(*TxHandler).Start
	/go/src/github.com/algorand/go-algorand/data/txHandler.go:103 +0x120
```