### PR TITLE
Fix accounting bug in page loading

### DIFF
--- a/crypto/merkletrie/cache.go
+++ b/crypto/merkletrie/cache.go
@@ -177,12 +177,15 @@ func (mtc *merkleTrieCache) loadPage(page uint64) (err error) {
 		return
 	}
 	if mtc.pageToNIDsPtr[page] == nil {
-		mtc.pageToNIDsPtr[page] = make(map[storedNodeIdentifier]*node, mtc.nodesPerPage)
+		mtc.pageToNIDsPtr[page] = decodedNodes
+		mtc.cachedNodeCount += len(mtc.pageToNIDsPtr[page])
+	} else {
+		mtc.cachedNodeCount -= len(mtc.pageToNIDsPtr[page])
+		for nodeID, pnode := range decodedNodes {
+			mtc.pageToNIDsPtr[page][nodeID] = pnode
+		}
+		mtc.cachedNodeCount += len(mtc.pageToNIDsPtr[page])
 	}
-	for nodeID, pnode := range decodedNodes {
-		mtc.pageToNIDsPtr[page][nodeID] = pnode
-	}
-	mtc.cachedNodeCount += len(mtc.pageToNIDsPtr[page])
 
 	// if we've just loaded a deferred page, no need to reload it during the commit.
 	if mtc.deferedPageLoad != page {
@@ -438,10 +441,18 @@ func (mtc *merkleTrieCache) encodePage(nodeIDs map[storedNodeIdentifier]*node) [
 	return serializedBuffer[:walk]
 }
 
-// evict releases the least used pages from cache until the number of elements in cache are less than cachedNodeCountTarget
+// evict releases the least used pages from cache until the number of elements in cache are less than cachedNodeCountTarget.
+// the root element page is being moved to the front so that it would get flushed last.
 func (mtc *merkleTrieCache) evict() (removedNodes int) {
 	removedNodes = mtc.cachedNodeCount
-
+	// check the root element ( if there is such ), and give it a higher priority, since we want
+	// to release the page with the root element last.
+	if mtc.mt.root != storedNodeIdentifierNull {
+		rootPage := uint64(mtc.mt.root) / uint64(mtc.nodesPerPage)
+		if element, has := mtc.pagesPrioritizationMap[rootPage]; has && element != nil {
+			mtc.pagesPrioritizationList.MoveToFront(element)
+		}
+	}
 	for mtc.cachedNodeCount > mtc.cachedNodeCountTarget {
 		// get the least used page off the pagesPrioritizationList
 		element := mtc.pagesPrioritizationList.Back()

--- a/crypto/merkletrie/cache_test.go
+++ b/crypto/merkletrie/cache_test.go
@@ -370,3 +370,76 @@ func TestCacheDeleteNodeMidTransaction(t *testing.T) {
 		require.NotZerof(t, len(pageContent), "Memory page %d has zero nodes", page)
 	}
 }
+
+// TestCachePageLoading ensures that during page loading, the number of cachedNodeCount is not
+// increased if the page was already loaded previously into memory.
+func TestCachePageReloading(t *testing.T) {
+	var memoryCommitter InMemoryCommitter
+	mt1, _ := MakeTrie(&memoryCommitter, defaultTestEvictSize)
+	// create 10 hashes.
+	leafsCount := 10
+	hashes := make([]crypto.Digest, leafsCount)
+	for i := 0; i < len(hashes); i++ {
+		hashes[i] = crypto.Hash([]byte{byte(i % 256), byte((i / 256) % 256), byte(i / 65536)})
+	}
+
+	for i := 0; i < len(hashes); i++ {
+		mt1.Add(hashes[i][:])
+	}
+	_, err := mt1.Evict(true)
+	require.NoError(t, err)
+
+	earlyCachedNodeCount := mt1.cache.cachedNodeCount
+	// reloading existing cached page multiple time should not cause increase cached node count.
+	page := uint64(mt1.nextNodeID) / uint64(memoryCommitter.GetNodesCountPerPage())
+	err = mt1.cache.loadPage(page)
+	require.NoError(t, err)
+	lateCachedNodeCount := mt1.cache.cachedNodeCount
+	require.Equal(t, earlyCachedNodeCount, lateCachedNodeCount)
+
+	// manually remove one item off this page
+	for k := range mt1.cache.pageToNIDsPtr[page] {
+		delete(mt1.cache.pageToNIDsPtr[page], k)
+		break
+	}
+	mt1.cache.cachedNodeCount--
+
+	// reload to see if that would "fix" the missing entry.
+	err = mt1.cache.loadPage(page)
+	require.NoError(t, err)
+	lateCachedNodeCount = mt1.cache.cachedNodeCount
+	require.Equal(t, earlyCachedNodeCount, lateCachedNodeCount)
+}
+
+// TestCachePagedOutTip verifies that the evict function would prioritize
+// evicting other pages before evicting the top page.
+func TestCachePagedOutTip(t *testing.T) {
+	var memoryCommitter InMemoryCommitter
+	mt1, _ := MakeTrie(&memoryCommitter, 600)
+	// create 2048 hashes.
+	leafsCount := 2048
+	hashes := make([]crypto.Digest, leafsCount)
+	for i := 0; i < len(hashes); i++ {
+		hashes[i] = crypto.Hash([]byte{byte(i % 256), byte((i / 256) % 256), byte(i / 65536)})
+	}
+
+	for i := 0; i < len(hashes)/2; i++ {
+		mt1.Add(hashes[i][:])
+	}
+	err := mt1.Commit()
+	require.NoError(t, err)
+
+	for i := 0; i < len(hashes)/2; i++ {
+		mt1.Add(hashes[i+len(hashes)/2][:])
+	}
+
+	// check the tip page before evicting
+	page := uint64(mt1.nextNodeID) / uint64(memoryCommitter.GetNodesCountPerPage())
+	require.NotNil(t, mt1.cache.pageToNIDsPtr[page])
+
+	_, err = mt1.Evict(true)
+	require.NoError(t, err)
+
+	// ensures that the tip page was not flushed out.
+	require.NotNil(t, mt1.cache.pageToNIDsPtr[page])
+}


### PR DESCRIPTION
## Summary

This PR contains two changes:
1. accounting bug fix in `merkleTrieCache::loadPage`, which could lead to incorrect `cachedNodeCount` values being used. In turn, it would cause the cache to evict pages ( or not to evict pages ) regardless of the eviction target. This could lead to excessive memory consumption.
2. modify the behavior of `merkleTrieCache::evict` so that it would re-prioritize the eviction of the root node page last. Currently, the hash calculation reloads multiple pages, which could lead to a situation where a call to `Evict(true)` would cause us to evict the root element. While this won't cause any issue on it's own, reloading the root element on the next Add/Delete operation is not desired. This change would place the root element page as the last place to consider evicting.
( note that a change to the hash recalculation page management is on it's way, and this one is a temporary patch )

## Bonus

As a side node, part of the fix in (1) was the elimination of following in the trivial case:
```
for nodeID, pnode := range decodedNodes {
	mtc.pageToNIDsPtr[page][nodeID] = pnode
}
```

This seems to consume notable amount of memory. Given that it's not usually needed, removing it on the trivial use case improves memory utilization.

## Test Plan

Unit tests were added to verify that change, and change was tested and against betanet and testnet.