### PR TITLE
export RekeyTo txn field in the algod REST API

### DIFF
--- a/daemon/algod/api/server/v1/handlers/handlers.go
+++ b/daemon/algod/api/server/v1/handlers/handlers.go
@@ -114,6 +114,10 @@ func txEncode(tx transactions.Transaction, ad transactions.ApplyData) (v1.Transa
 		res.Lease = tx.Lease[:]
 	}
 
+	if !tx.RekeyTo.IsZero() {
+		res.RekeyTo = tx.RekeyTo.String()
+	}
+
 	return res, nil
 }
 

--- a/daemon/algod/api/spec/v1/model.go
+++ b/daemon/algod/api/spec/v1/model.go
@@ -546,6 +546,11 @@ type Transaction struct {
 	// required: false
 	// swagger:strfmt byte
 	Group []byte `json:"group,omitempty"`
+
+	// RekeyTo
+	//
+	// required: false
+	RekeyTo string `json:"rekeyto,omitempty"`
 }
 
 // PaymentTransactionType contains the additional fields for a payment Transaction


### PR DESCRIPTION
Looks like the RekeyTo field didn't get propagated into the REST API when it was added to transactions.