### PR TITLE
Allow mule packaging to be done without having to first explicitly call `ci-build`

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -27,10 +27,6 @@ agents:
 
 tasks:
   - task: docker.Make
-    name: build
-    target: ci-build
-
-  - task: docker.Make
     name: rpm
     agent: rpm
     target: mule-package-rpm

--- a/scripts/release/mule/Makefile.mule
+++ b/scripts/release/mule/Makefile.mule
@@ -47,7 +47,7 @@ mule-deploy-%:
 	scripts/release/mule/deploy/$(PKG_TYPE)/deploy.sh
 
 mule-package-%: PKG_TYPE=$*
-mule-package-%:
+mule-package-%: ci-build
 	scripts/release/mule/package/$(PKG_TYPE)/package.sh
 
 mule-sign-%: PKG_TYPE=$*


### PR DESCRIPTION
## Summary

I would like an end-user (or me) to be able to define a `mule` job that simply calls the `package` make target that will then first do a build if it determines that one has not been done yet.

The intent is to support the building of packages locally, i.e. via the cli, without having to open the make file to see what needs to be done to get the packages to build correctly.

## Test Plan

`mule -f package.yaml package`
