### PR TITLE
Bugfix: Reorder permission check for setting contract administrator.

### DIFF
--- a/test/scripts/e2e_subs/sectok-app.sh
+++ b/test/scripts/e2e_subs/sectok-app.sh
@@ -157,6 +157,12 @@ if [[ $RES != *"$ERR_APP_REJ_STR1"* ]]; then
     false
 fi
 
+RES=$(${xcmd} --from $BOB set-contract-admin --target $BOB --status 1 2>&1 || true)
+if [[ $RES != *"$ERR_APP_REJ_STR1"* ]]; then
+    date '+sectok-app FAIL non-admins cannot set own contract admin status %Y%m%d_%H%M%S'
+    false
+fi
+
 # minting/burning
 ${xcmd} --from $CREATOR mint --target $ALICE --amount $XFER1
 ${xcmd} --from $CREATOR mint --target $ALICE --amount $XFER1

--- a/test/scripts/e2e_subs/sectok-app.sh
+++ b/test/scripts/e2e_subs/sectok-app.sh
@@ -152,7 +152,7 @@ ${xcmd} --from $BOB set-transfer-admin --target $ALICE --status 1
 ${xcmd} --from $CREATOR set-contract-admin --target $BOB --status 0
 
 RES=$(${xcmd} --from $BOB set-transfer-admin --target $ALICE --status 0 2>&1 || true)
-if [[ $RES != *"$ERR_APP_REJ_STR1"* ]]; then
+if [[ $RES != *"$ERR_APP_REJ_STR2"* ]]; then
     date '+sectok-app FAIL non-admins cannot set transfer admin status %Y%m%d_%H%M%S'
     false
 fi

--- a/test/scripts/e2e_subs/sectok-app.sh
+++ b/test/scripts/e2e_subs/sectok-app.sh
@@ -130,7 +130,7 @@ if [[ $RES != *"$ERR_APP_REJ_STR1"* ]]; then
 fi
 
 RES=$(${xcmd} --from $ALICE set-transfer-admin --target $ALICE --status 1 2>&1 || true)
-if [[ $RES != *"$ERR_APP_REJ_STR1"* ]]; then
+if [[ $RES != *"$ERR_APP_REJ_STR2"* ]]; then
     date '+sectok-app FAIL non-admins cannot set transfer admin status %Y%m%d_%H%M%S'
     false
 fi

--- a/test/scripts/e2e_subs/sectok-app.sh
+++ b/test/scripts/e2e_subs/sectok-app.sh
@@ -158,7 +158,7 @@ if [[ $RES != *"$ERR_APP_REJ_STR1"* ]]; then
 fi
 
 RES=$(${xcmd} --from $BOB set-contract-admin --target $BOB --status 1 2>&1 || true)
-if [[ $RES != *"$ERR_APP_REJ_STR1"* ]]; then
+if [[ $RES != *"$ERR_APP_REJ_STR2"* ]]; then
     date '+sectok-app FAIL non-admins cannot set own contract admin status %Y%m%d_%H%M%S'
     false
 fi

--- a/test/scripts/e2e_subs/tealprogs/sectok_approve.teal
+++ b/test/scripts/e2e_subs/tealprogs/sectok_approve.teal
@@ -1,5 +1,4 @@
 #pragma version 2
-
 txn ApplicationID
 int 0
 ==
@@ -150,16 +149,20 @@ int 1
 bnz cond_end11
 cond12:
 // contract/transfer admin
-int 1
-txna ApplicationArgs 0
-txna ApplicationArgs 1
-btoi
-app_local_put
 int 0
 byte base64 Y1g=
 app_local_get
 int 1
 ==
+bnz assert15
+err
+assert15:
+int 1
+txna ApplicationArgs 0
+txna ApplicationArgs 1
+btoi
+app_local_put
+int 1
 cond_end11:
 int 1
 bnz if_end9
@@ -243,13 +246,13 @@ if6:
 txn NumAppArgs
 int 1
 ==
-bnz if15
+bnz if16
 // transfer-rule
 txna ApplicationArgs 2
 btoi
 int 0
 ==
-bnz if17
+bnz if18
 byte 0x0001
 txna ApplicationArgs 0
 concat
@@ -259,15 +262,15 @@ txna ApplicationArgs 2
 btoi
 app_global_put
 int 1
-bnz if_end18
-if17:
+bnz if_end19
+if18:
 byte 0x0001
 txna ApplicationArgs 0
 concat
 txna ApplicationArgs 1
 concat
 app_global_del
-if_end18:
+if_end19:
 txna ApplicationArgs 0
 len
 int 8
@@ -288,8 +291,8 @@ int 1
 ==
 &&
 int 1
-bnz if_end16
-if15:
+bnz if_end17
+if16:
 // pause
 byte base64 cHM=
 txna ApplicationArgs 0
@@ -300,7 +303,7 @@ byte base64 Y1g=
 app_local_get
 int 1
 ==
-if_end16:
+if_end17:
 if_end7:
 int 1
 bnz cond_end0


### PR DESCRIPTION
This fixes a security vulnerability where the contract-administrator
status of an address was checked after it was set.  Any address could
cause itself to be a contract administrator, regardless of whether it
were a contract administrator already.

This bugfix checks whether an application call's sender is a contract
administrator before modifying a target user's contract-administrator
status.

Thanks to @jasonpaulos for helping to find this bug.

## Test Plan

Added test case to e2e test.
