### PR TITLE
Optimize Merkle trie memory consumption

### DIFF
--- a/crypto/merkletrie/bitset.go
+++ b/crypto/merkletrie/bitset.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package merkletrie
+
+import ()
+
+// bitset is used as a 256 bits bitmask storage. The simplistic implementation is designed
+// explicitly to reduce memory utilization to the minimum required.
+type bitset struct {
+	d [4]uint64
+}
+
+func (b *bitset) SetBit(bit byte, bitVal bool) {
+	if bitVal {
+		b.d[bit/64] |= 1 << (bit & 63)
+	} else {
+		// the &^ is the go and-not operator
+		b.d[bit/64] &^= 1 << (bit & 63)
+	}
+
+}
+
+func (b *bitset) Bit(bit byte) bool {
+	return (b.d[bit/64] & (1 << (bit & 63))) != 0
+}
+
+func (b *bitset) IsZero() bool {
+	return b.d[0] == 0 && b.d[1] == 0 && b.d[2] == 0 && b.d[3] == 0
+}

--- a/crypto/merkletrie/bitset.go
+++ b/crypto/merkletrie/bitset.go
@@ -16,28 +16,29 @@
 
 package merkletrie
 
-import ()
-
 // bitset is used as a 256 bits bitmask storage. The simplistic implementation is designed
 // explicitly to reduce memory utilization to the minimum required.
 type bitset struct {
 	d [4]uint64
 }
 
-func (b *bitset) SetBit(bit byte, bitVal bool) {
-	if bitVal {
-		b.d[bit/64] |= 1 << (bit & 63)
-	} else {
-		// the &^ is the go and-not operator
-		b.d[bit/64] &^= 1 << (bit & 63)
-	}
-
+// SetBit sets the given bit in the bitset.
+func (b *bitset) SetBit(bit byte) {
+	b.d[bit/64] |= 1 << (bit & 63)
 }
 
+// ClearBit clears the given bit in the bitset.
+func (b *bitset) ClearBit(bit byte) {
+	// the &^ is the go and-not operator
+	b.d[bit/64] &^= 1 << (bit & 63)
+}
+
+// Bit tests the given bit in the bitset.
 func (b *bitset) Bit(bit byte) bool {
 	return (b.d[bit/64] & (1 << (bit & 63))) != 0
 }
 
+// IsZero tests to see if all the bits in the bitset are set to zero.
 func (b *bitset) IsZero() bool {
 	return b.d[0] == 0 && b.d[1] == 0 && b.d[2] == 0 && b.d[3] == 0
 }

--- a/crypto/merkletrie/bitset_test.go
+++ b/crypto/merkletrie/bitset_test.go
@@ -17,6 +17,7 @@
 package merkletrie
 
 import (
+	"math/bits"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,4 +59,13 @@ func TestBitSet(t *testing.T) {
 
 	// check that the bitset is zero.
 	require.True(t, a.IsZero())
+}
+
+// TestBitSetOneBit test that only one bit is being set when we call SetBit
+func TestBitSetOneBit(t *testing.T) {
+	for i := 0; i < 256; i++ {
+		var a bitset
+		a.SetBit(byte(i))
+		require.Equal(t, 1, bits.OnesCount64(a.d[0])+bits.OnesCount64(a.d[1])+bits.OnesCount64(a.d[2])+bits.OnesCount64(a.d[3]))
+	}
 }

--- a/crypto/merkletrie/bitset_test.go
+++ b/crypto/merkletrie/bitset_test.go
@@ -1,0 +1,61 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package merkletrie
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBitSet(t *testing.T) {
+	var a, b bitset
+
+	// set the bits in a different order, and see if we're ending with the same set.
+	for i := 0; i <= 255; i += 2 {
+		a.SetBit(byte(i))
+		b.SetBit(byte(256 - i))
+	}
+	require.Equal(t, a, b)
+
+	for i := 0; i <= 255; i += 2 {
+		require.NotZero(t, a.Bit(byte(i)))
+	}
+
+	for i := 1; i <= 255; i += 2 {
+		require.Zero(t, a.Bit(byte(i)))
+	}
+
+	// clear the bits at different order, and testing that the bits were cleared correctly.
+	for i := 0; i <= 255; i += 32 {
+		a.ClearBit(byte(i))
+		b.ClearBit(byte(256 - i))
+	}
+	require.Equal(t, a, b)
+
+	for i := 0; i <= 255; i += 32 {
+		require.Zero(t, a.Bit(byte(i)))
+	}
+
+	// clear all bits ( some would get cleared more than once )
+	for i := 0; i <= 255; i += 2 {
+		a.ClearBit(byte(i))
+	}
+
+	// check that the bitset is zero.
+	require.True(t, a.IsZero())
+}

--- a/crypto/merkletrie/cache_test.go
+++ b/crypto/merkletrie/cache_test.go
@@ -286,7 +286,7 @@ func (mt *Trie) TestDeleteRollback(d []byte) (bool, error) {
 		return false, err
 	}
 	mt.cache.beginTransaction()
-	if pnode.leaf {
+	if pnode.leaf() {
 		// remove the root.
 		mt.cache.deleteNode(mt.root)
 		mt.root = storedNodeIdentifierNull

--- a/crypto/merkletrie/committer_test.go
+++ b/crypto/merkletrie/committer_test.go
@@ -83,17 +83,14 @@ func TestInMemoryCommitter(t *testing.T) {
 }
 
 func (n *node) getChildren() (list []storedNodeIdentifier) {
-	if n.leaf {
+	if n.leaf() {
 		return []storedNodeIdentifier{}
 	}
-	i := n.firstChild
-	for {
-		list = append(list, n.children[i])
-		if i == n.childrenNext[i] {
-			return
-		}
-		i = n.childrenNext[i]
+	for _, child := range n.children {
+		list = append(list, child.id)
+
 	}
+	return
 }
 
 func TestNoRedundentPages(t *testing.T) {

--- a/crypto/merkletrie/node.go
+++ b/crypto/merkletrie/node.go
@@ -19,21 +19,27 @@ package merkletrie
 import (
 	"bytes"
 	"encoding/binary"
+	"sort"
 
 	"github.com/algorand/go-algorand/crypto"
 )
 
+type childEntry struct {
+	id    storedNodeIdentifier
+	index byte
+}
 type node struct {
 	hash         []byte
-	children     []storedNodeIdentifier
-	childrenNext []byte
-	firstChild   byte
-	leaf         bool
+	children     []childEntry
+	childrenMask bitset
 }
 
+func (n *node) leaf() bool {
+	return n.childrenMask.IsZero()
+}
 func (n *node) stats(cache *merkleTrieCache, stats *Stats, depth int) (err error) {
 	stats.nodesCount++
-	if n.leaf {
+	if n.leaf() {
 		stats.leafCount++
 		if depth > stats.depth {
 			stats.depth = depth
@@ -41,10 +47,9 @@ func (n *node) stats(cache *merkleTrieCache, stats *Stats, depth int) (err error
 		stats.size += 4 + len(n.hash) + 1
 		return nil
 	}
-	i := n.firstChild
-	stats.size += 4 + len(n.hash) + cap(n.children)*8 + cap(n.childrenNext) + 1
-	for {
-		childNode, err := cache.getNode(n.children[i])
+	stats.size += 32 + len(n.hash) + len(n.children)*9
+	for _, child := range n.children {
+		childNode, err := cache.getNode(child.id)
 		if err != nil {
 			return err
 		}
@@ -52,23 +57,24 @@ func (n *node) stats(cache *merkleTrieCache, stats *Stats, depth int) (err error
 		if err != nil {
 			return err
 		}
-		if i == n.childrenNext[i] {
-			break
-		}
-		i = n.childrenNext[i]
 	}
 	return nil
 }
 
+func (n *node) indexOf(b byte) byte {
+	// find the child using binary search:
+	return byte(sort.Search(len(n.children), func(i int) bool { return n.children[i].index >= b }))
+}
+
 // find searches the trie for the element, recursively.
 func (n *node) find(cache *merkleTrieCache, d []byte) (bool, error) {
-	if n.leaf {
+	if n.leaf() {
 		return 0 == bytes.Compare(d, n.hash), nil
 	}
-	childNodeID := n.children[d[0]]
-	if childNodeID == storedNodeIdentifierNull {
+	if n.childrenMask.Bit(d[0]) == false {
 		return false, nil
 	}
+	childNodeID := n.children[n.indexOf(d[0])].id
 	childNode, err := cache.getNode(childNodeID)
 	if err != nil {
 		return false, err
@@ -81,7 +87,7 @@ func (n *node) find(cache *merkleTrieCache, d []byte) (bool, error) {
 func (n *node) add(cache *merkleTrieCache, d []byte, path []byte) (nodeID storedNodeIdentifier, err error) {
 	// allocate a new node to replace the current one.
 	var pnode *node
-	if n.leaf {
+	if n.leaf() {
 		// find the diff index:
 		idiff := 0
 		for ; n.hash[idiff] == d[idiff]; idiff++ {
@@ -90,38 +96,48 @@ func (n *node) add(cache *merkleTrieCache, d []byte, path []byte) (nodeID stored
 		curChildNode, curChildNodeID := cache.allocateNewNode()
 		newChildNode, newChildNodeID := cache.allocateNewNode()
 
-		curChildNode.leaf = true
 		curChildNode.hash = n.hash[idiff+1:]
-		newChildNode.leaf = true
 		newChildNode.hash = d[idiff+1:]
 
 		pnode, nodeID = cache.allocateNewNode()
-		pnode.leaf = false
-		pnode.children = make([]storedNodeIdentifier, 256)
-		pnode.childrenNext = make([]byte, 256)
+		pnode.childrenMask.SetBit(n.hash[idiff], true)
+		pnode.childrenMask.SetBit(d[idiff], true)
 
-		pnode.children[n.hash[idiff]] = curChildNodeID
-		pnode.children[d[idiff]] = newChildNodeID
 		if n.hash[idiff] < d[idiff] {
-			pnode.firstChild = n.hash[idiff]
-			pnode.childrenNext[pnode.firstChild] = d[idiff]
-			pnode.childrenNext[d[idiff]] = d[idiff]
+			pnode.children = []childEntry{
+				childEntry{
+					id:    curChildNodeID,
+					index: n.hash[idiff],
+				},
+				childEntry{
+					id:    newChildNodeID,
+					index: d[idiff],
+				},
+			}
 		} else {
-			pnode.firstChild = d[idiff]
-			pnode.childrenNext[pnode.firstChild] = n.hash[idiff]
-			pnode.childrenNext[n.hash[idiff]] = n.hash[idiff]
+			pnode.children = []childEntry{
+				childEntry{
+					id:    newChildNodeID,
+					index: d[idiff],
+				},
+				childEntry{
+					id:    curChildNodeID,
+					index: n.hash[idiff],
+				},
+			}
 		}
 		pnode.hash = append(path, d[:idiff]...)
 
 		for i := idiff - 1; i >= 0; i-- {
 			// create a parent node for pnode.
 			pnode2, nodeID2 := cache.allocateNewNode()
-			pnode2.leaf = false
-			pnode2.children = make([]storedNodeIdentifier, 256)
-			pnode2.childrenNext = make([]byte, 256)
-			pnode2.children[d[i]] = nodeID
-			pnode2.firstChild = d[i]
-			pnode2.childrenNext[d[i]] = d[i]
+			pnode2.childrenMask.SetBit(d[i], true)
+			pnode2.children = []childEntry{
+				childEntry{
+					id:    nodeID,
+					index: d[i],
+				},
+			}
 			pnode2.hash = append(path, d[:i]...)
 
 			pnode = pnode2
@@ -130,41 +146,48 @@ func (n *node) add(cache *merkleTrieCache, d []byte, path []byte) (nodeID stored
 		return nodeID, nil
 	}
 
-	if n.children[d[0]] == storedNodeIdentifierNull {
+	if n.childrenMask.Bit(d[0]) == false {
 		// no such child.
 		var childNode *node
 		var childNodeID storedNodeIdentifier
 		childNode, childNodeID = cache.allocateNewNode()
-		childNode.leaf = true
 		childNode.hash = d[1:]
 
-		pnode, nodeID = n.duplicate(cache)
-		pnode.children[d[0]] = childNodeID
+		pnode, nodeID = cache.allocateNewNode()
+		pnode.childrenMask = n.childrenMask
+		pnode.childrenMask.SetBit(d[0], true)
 
-		if pnode.firstChild > d[0] {
-			pnode.childrenNext[d[0]] = pnode.firstChild
-			pnode.firstChild = d[0]
+		pnode.children = make([]childEntry, len(n.children)+1, len(n.children)+1)
+		if d[0] > n.children[len(n.children)-1].index {
+			// the new entry comes after all the existing ones.
+			for i, child := range n.children {
+				pnode.children[i] = child
+			}
+			pnode.children[len(pnode.children)-1] = childEntry{
+				id:    childNodeID,
+				index: d[0],
+			}
 		} else {
-			// iterate on all the entries.
-			i := pnode.firstChild
-			for {
-				if pnode.childrenNext[i] < d[0] {
-					if pnode.childrenNext[i] == i {
-						pnode.childrenNext[i] = d[0]
-						pnode.childrenNext[d[0]] = d[0]
-						break
+			for i, child := range n.children {
+				if d[0] < child.index {
+					pnode.children[i] = childEntry{
+						index: d[0],
+						id:    childNodeID,
 					}
-				} else {
-					pnode.childrenNext[d[0]] = pnode.childrenNext[i]
-					pnode.childrenNext[i] = d[0]
+					// copy the rest of the items.
+					for ; i < len(n.children); i++ {
+						pnode.children[i+1] = n.children[i]
+					}
 					break
 				}
-				i = pnode.childrenNext[i]
+				pnode.children[i] = child
 			}
 		}
 	} else {
 		// there is already a child there.
-		childNode, err := cache.getNode(n.children[d[0]])
+		curNodeIndex := n.indexOf(d[0])
+		curNodeID := n.children[curNodeIndex].id
+		childNode, err := cache.getNode(curNodeID)
 		if err != nil {
 			return storedNodeIdentifierNull, err
 		}
@@ -173,8 +196,8 @@ func (n *node) add(cache *merkleTrieCache, d []byte, path []byte) (nodeID stored
 			return storedNodeIdentifierNull, err
 		}
 		pnode, nodeID = n.duplicate(cache)
-		cache.deleteNode(n.children[d[0]])
-		pnode.children[d[0]] = updatedChild
+		cache.deleteNode(curNodeID)
+		pnode.children[curNodeIndex].id = updatedChild
 	}
 	pnode.hash = path
 	return nodeID, nil
@@ -186,31 +209,26 @@ func (n *node) add(cache *merkleTrieCache, d []byte, path []byte) (nodeID stored
 // 1. all node id allocations are done in incremental monolitic order, from the bottom up.
 // 2. hash calculations are being doing in node id incremental ordering
 func (n *node) calculateHash(cache *merkleTrieCache) error {
-	if n.leaf {
+	if n.leaf() {
 		return nil
 	}
 	path := n.hash
 	hashAccumulator := make([]byte, 0, 64*256)                 // we can have up to 256 elements, so preallocate sufficient storage; append would expand the storage if it won't be enough.
 	hashAccumulator = append(hashAccumulator, byte(len(path))) // we add this string length before the actual string so it could get "decoded"; in practice, it makes a good domain separator.
 	hashAccumulator = append(hashAccumulator, path...)
-	i := n.firstChild
-	for {
-		childNode, err := cache.getNode(n.children[i])
+	for _, child := range n.children {
+		childNode, err := cache.getNode(child.id)
 		if err != nil {
 			return err
 		}
-		if childNode.leaf {
+		if childNode.leaf() {
 			hashAccumulator = append(hashAccumulator, byte(0))
 		} else {
 			hashAccumulator = append(hashAccumulator, byte(1))
 		}
 		hashAccumulator = append(hashAccumulator, byte(len(childNode.hash))) // we add this string length before the actual string so it could get "decoded"; in practice, it makes a good domain separator.
-		hashAccumulator = append(hashAccumulator, i)                         // adding the first byte of the child
+		hashAccumulator = append(hashAccumulator, child.index)               // adding the first byte of the child
 		hashAccumulator = append(hashAccumulator, childNode.hash...)         // adding the reminder of the child
-		if n.childrenNext[i] == i {
-			break
-		}
-		i = n.childrenNext[i]
 	}
 	hash := crypto.Hash(hashAccumulator)
 	n.hash = hash[:]
@@ -223,44 +241,17 @@ func (n *node) calculateHash(cache *merkleTrieCache) error {
 func (n *node) remove(cache *merkleTrieCache, key []byte, path []byte) (nodeID storedNodeIdentifier, err error) {
 	// allocate a new node to replace the current one.
 	var pnode, childNode *node
-	childNodeID := n.children[key[0]]
+	childIndex := n.indexOf(key[0])
+	childNodeID := n.children[childIndex].id
 	childNode, err = cache.getNode(childNodeID)
 	if err != nil {
 		return
 	}
-	if childNode.leaf {
+	if childNode.leaf() {
 		pnode, nodeID = n.duplicate(cache)
 		// we are guaranteed to have other children, because our tree forbids nodes that have exactly one leaf child and no other children.
-		// we have one or more children, see if it's the first child:
-		if pnode.firstChild == key[0] {
-			// we're removing the first child.
-			next := pnode.childrenNext[pnode.firstChild]
-			pnode.children[pnode.firstChild] = storedNodeIdentifierNull
-			pnode.childrenNext[pnode.firstChild] = 0
-			pnode.firstChild = next
-		} else {
-			// wer're removing a child off the list ( known to be there, and not to be the first )
-			i := pnode.firstChild
-			for {
-				if pnode.childrenNext[i] == key[0] {
-					// is this the last item ?
-					if pnode.childrenNext[key[0]] == key[0] {
-						// yes, it's the last item.
-						pnode.childrenNext[i] = i
-						// clear out pointers.
-						pnode.childrenNext[key[0]] = 0
-						pnode.children[key[0]] = storedNodeIdentifierNull
-						break
-					}
-					pnode.childrenNext[i] = pnode.childrenNext[key[0]]
-					// clear out pointers
-					pnode.childrenNext[key[0]] = 0
-					pnode.children[key[0]] = storedNodeIdentifierNull
-					break
-				}
-				i = pnode.childrenNext[i]
-			}
-		}
+		pnode.children = append(pnode.children[:childIndex], pnode.children[childIndex+1:]...)
+		pnode.childrenMask.SetBit(key[0], false)
 	} else {
 		var updatedChildNodeID storedNodeIdentifier
 		updatedChildNodeID, err = childNode.remove(cache, key[1:], append(path, key[0]))
@@ -268,27 +259,25 @@ func (n *node) remove(cache *merkleTrieCache, key []byte, path []byte) (nodeID s
 			return storedNodeIdentifierNull, err
 		}
 		pnode, nodeID = n.duplicate(cache)
-		pnode.children[key[0]] = updatedChildNodeID
+		pnode.children[childIndex].id = updatedChildNodeID
 	}
 	cache.deleteNode(childNodeID)
 
 	// at this point, we might end up with a single leaf child. collapse that.
-	if pnode.childrenNext[pnode.firstChild] == pnode.firstChild {
-		childNode, err = cache.getNode(pnode.children[pnode.firstChild])
+	if len(pnode.children) == 1 {
+		childNode, err = cache.getNode(pnode.children[0].id)
 		if err != nil {
 			return
 		}
-		if childNode.leaf {
+		if childNode.leaf() {
 			// convert current node into a leaf.
-			pnode.leaf = true
-			pnode.hash = append([]byte{pnode.firstChild}, childNode.hash...)
-			cache.deleteNode(pnode.children[pnode.firstChild])
+			pnode.hash = append([]byte{pnode.children[0].index}, childNode.hash...)
+			cache.deleteNode(pnode.children[0].id)
+			pnode.childrenMask.SetBit(pnode.children[0].index, false)
 			pnode.children = nil
-			pnode.childrenNext = nil
-			pnode.firstChild = 0
 		}
 	}
-	if !pnode.leaf {
+	if !pnode.leaf() {
 		pnode.hash = path
 	}
 	return nodeID, nil
@@ -297,15 +286,13 @@ func (n *node) remove(cache *merkleTrieCache, key []byte, path []byte) (nodeID s
 // duplicate creates a copy of the current node
 func (n *node) duplicate(cache *merkleTrieCache) (pnode *node, nodeID storedNodeIdentifier) {
 	pnode, nodeID = cache.allocateNewNode()
-	pnode.firstChild = n.firstChild
 	pnode.hash = n.hash // the hash is safe for just copy without duplicate, since it's always being reallocated upon change.
-	pnode.leaf = n.leaf
-	if !pnode.leaf {
-		pnode.children = make([]storedNodeIdentifier, 256)
-		pnode.childrenNext = make([]byte, 256)
-		// copy the elements starting the first known entry.
-		copy(pnode.children[n.firstChild:], n.children[n.firstChild:])
-		copy(pnode.childrenNext[n.firstChild:], n.childrenNext[n.firstChild:])
+	pnode.childrenMask = n.childrenMask
+	if !pnode.leaf() {
+		pnode.children = make([]childEntry, len(n.children), len(n.children))
+		for i, v := range n.children {
+			pnode.children[i] = v
+		}
 	}
 	return
 }
@@ -315,7 +302,7 @@ func (n *node) serialize(buf []byte) int {
 	w := binary.PutUvarint(buf[:], uint64(len(n.hash)))
 	copy(buf[w:], n.hash)
 	w += len(n.hash)
-	if n.leaf {
+	if n.leaf() {
 		buf[w] = 0 // leaf
 		return w + 1
 	}
@@ -323,18 +310,13 @@ func (n *node) serialize(buf []byte) int {
 	buf[w] = 1 // non-leaf
 	w++
 	// store all the children, and terminate with a null.
-	i := n.firstChild
-	for {
-		buf[w] = i
+	for _, child := range n.children {
+		buf[w] = child.index
 		w++
-		x := binary.PutUvarint(buf[w:], uint64(n.children[i]))
+		x := binary.PutUvarint(buf[w:], uint64(child.id))
 		w += x
-		if i == n.childrenNext[i] {
-			break
-		}
-		i = n.childrenNext[i]
 	}
-	buf[w] = i
+	buf[w] = n.children[len(n.children)-1].index
 	w++
 	return w
 }
@@ -349,36 +331,34 @@ func deserializeNode(buf []byte) (n *node, s int) {
 	n.hash = make([]byte, hashLength)
 	copy(n.hash, buf[hashLength2:hashLength2+int(hashLength)])
 	s = hashLength2 + int(hashLength)
-	n.leaf = (buf[s] == 0)
+	isLeaf := (buf[s] == 0)
 	s++
-	if n.leaf {
+	if isLeaf {
 		return
 	}
-	n.children = make([]storedNodeIdentifier, 256)
-	n.childrenNext = make([]byte, 256)
+	var childEntries [256]childEntry
 	first := true
 	prevChildIndex := byte(0)
-
+	i := 0
 	for {
 		childIndex := buf[s]
 		s++
 		if childIndex <= prevChildIndex && !first {
 			break
 		}
-		if first {
-			first = false
-			n.firstChild = childIndex
-		} else {
-			n.childrenNext[prevChildIndex] = childIndex
-		}
+		first = false
 		nodeID, nodeIDLength := binary.Uvarint(buf[s:])
 		if nodeIDLength <= 0 {
 			return nil, nodeIDLength
 		}
 		s += nodeIDLength
-		n.children[childIndex] = storedNodeIdentifier(nodeID)
+
+		childEntries[i] = childEntry{index: childIndex, id: storedNodeIdentifier(nodeID)}
+		n.childrenMask.SetBit(childIndex, true)
 		prevChildIndex = childIndex
+		i++
 	}
-	n.childrenNext[prevChildIndex] = prevChildIndex
+	n.children = make([]childEntry, i, i)
+	copy(n.children[:], childEntries[:i])
 	return
 }

--- a/crypto/merkletrie/node_test.go
+++ b/crypto/merkletrie/node_test.go
@@ -46,6 +46,10 @@ func TestNodeSerialization(t *testing.T) {
 			require.Equal(t, consumedWrite, consumedRead)
 			require.Equal(t, pnode.leaf(), outNode.leaf())
 			require.Equal(t, len(pnode.children), len(outNode.children))
+			reencodedBuffer := make([]byte, 10000)
+			renecodedConsumedWrite := outNode.serialize(reencodedBuffer[:])
+			require.Equal(t, consumedWrite, renecodedConsumedWrite)
+			require.Equal(t, buf, reencodedBuffer)
 		}
 	}
 }

--- a/crypto/merkletrie/node_test.go
+++ b/crypto/merkletrie/node_test.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package merkletrie
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/crypto"
+)
+
+// TestNodeSerialization tests the serialization and deserialization of nodes.
+func TestNodeSerialization(t *testing.T) {
+	var memoryCommitter InMemoryCommitter
+	mt1, _ := MakeTrie(&memoryCommitter, 1000)
+	// create 1024 hashes.
+	leafsCount := 1024
+	hashes := make([]crypto.Digest, leafsCount)
+	for i := 0; i < len(hashes); i++ {
+		hashes[i] = crypto.Hash([]byte{byte(i % 256), byte((i / 256) % 256), byte(i / 65536)})
+	}
+
+	for i := 0; i < len(hashes); i++ {
+		mt1.Add(hashes[i][:])
+	}
+	for _, page := range mt1.cache.pageToNIDsPtr {
+		for _, pnode := range page {
+			buf := make([]byte, 10000)
+			consumedWrite := pnode.serialize(buf[:])
+			outNode, consumedRead := deserializeNode(buf[:])
+			require.Equal(t, consumedWrite, consumedRead)
+			require.Equal(t, pnode.leaf(), outNode.leaf())
+			require.Equal(t, len(pnode.children), len(outNode.children))
+		}
+	}
+}

--- a/crypto/merkletrie/trie.go
+++ b/crypto/merkletrie/trie.go
@@ -117,7 +117,7 @@ func (mt *Trie) RootHash() (crypto.Digest, error) {
 		return crypto.Digest{}, err
 	}
 
-	if pnode.leaf {
+	if pnode.leaf() {
 		return crypto.Hash(append([]byte{0}, pnode.hash...)), nil
 	}
 	return crypto.Hash(append([]byte{1}, pnode.hash...)), nil
@@ -132,7 +132,6 @@ func (mt *Trie) Add(d []byte) (bool, error) {
 		mt.cache.beginTransaction()
 		pnode, mt.root = mt.cache.allocateNewNode()
 		mt.cache.commitTransaction()
-		pnode.leaf = true
 		pnode.hash = d
 		mt.elementLength = len(d)
 		return true, nil
@@ -179,7 +178,7 @@ func (mt *Trie) Delete(d []byte) (bool, error) {
 		return false, err
 	}
 	mt.cache.beginTransaction()
-	if pnode.leaf {
+	if pnode.leaf() {
 		// remove the root.
 		mt.cache.deleteNode(mt.root)
 		mt.root = storedNodeIdentifierNull

--- a/crypto/merkletrie/trie_test.go
+++ b/crypto/merkletrie/trie_test.go
@@ -50,7 +50,7 @@ func TestAddingAndRemoving(t *testing.T) {
 	require.Equal(t, len(hashes), int(stats.leafCount))
 	require.Equal(t, 4, int(stats.depth))
 	require.Equal(t, 10915, int(stats.nodesCount))
-	require.Equal(t, 1059347, int(stats.size))
+	require.Equal(t, 1135745, int(stats.size))
 	require.True(t, int(stats.nodesCount) > len(hashes))
 	require.True(t, int(stats.nodesCount) < 2*len(hashes))
 

--- a/crypto/merkletrie/trie_test.go
+++ b/crypto/merkletrie/trie_test.go
@@ -50,7 +50,7 @@ func TestAddingAndRemoving(t *testing.T) {
 	require.Equal(t, len(hashes), int(stats.leafCount))
 	require.Equal(t, 4, int(stats.depth))
 	require.Equal(t, 10915, int(stats.nodesCount))
-	require.Equal(t, 2490656, int(stats.size))
+	//require.Equal(t, 2490656, int(stats.size))
 	require.True(t, int(stats.nodesCount) > len(hashes))
 	require.True(t, int(stats.nodesCount) < 2*len(hashes))
 

--- a/crypto/merkletrie/trie_test.go
+++ b/crypto/merkletrie/trie_test.go
@@ -50,7 +50,7 @@ func TestAddingAndRemoving(t *testing.T) {
 	require.Equal(t, len(hashes), int(stats.leafCount))
 	require.Equal(t, 4, int(stats.depth))
 	require.Equal(t, 10915, int(stats.nodesCount))
-	//require.Equal(t, 2490656, int(stats.size))
+	require.Equal(t, 1059347, int(stats.size))
 	require.True(t, int(stats.nodesCount) > len(hashes))
 	require.True(t, int(stats.nodesCount) < 2*len(hashes))
 


### PR DESCRIPTION
## Summary

This PR improves the memory consumption used by a single node in the Merkle trie implementation.
The memory pressure is roughly half compared to not having this, while the performance is roughly the same.

### Core change:
Convert this 
```
type node struct {
 	hash         []byte
 	children     []storedNodeIdentifier
 	childrenNext []byte
 	firstChild   byte
 	leaf         bool
 }
```
Into this:
```
type childEntry struct {
	id    storedNodeIdentifier
	index byte
}
type bitset struct {
	d [4]uint64
}
type node struct {
 	hash         []byte
 	children     []childEntry
 	childrenMask bitset
 }
```

## Test Plan

Tested against mainnet, betanet and testnet. Plus added unit tests.