### PR TITLE
Add a benchmark to test restoring from catchpoint performance

### DIFF
--- a/ledger/catchupaccessor_test.go
+++ b/ledger/catchupaccessor_test.go
@@ -1,0 +1,111 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package ledger
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/protocol"
+)
+
+func benchmarkRestoringFromCatchpointFileHelper(b *testing.B) {
+	genesisInitState, _ := testGenerateInitState(b, protocol.ConsensusCurrentVersion)
+	const inMem = false
+	log := logging.TestingLog(b)
+	cfg := config.GetDefaultLocal()
+	cfg.Archival = false
+	log.SetLevel(logging.Warn)
+	dbBaseFileName := strings.Replace(b.Name(), "/", "_", -1)
+	l, err := OpenLedger(log, dbBaseFileName, inMem, genesisInitState, cfg)
+	require.NoError(b, err, "could not open ledger")
+	defer func() {
+		l.Close()
+		os.Remove(dbBaseFileName + ".block.sqlite")
+		os.Remove(dbBaseFileName + ".tracker.sqlite")
+	}()
+
+	catchpointAccessor := MakeCatchpointCatchupAccessor(l, log)
+	catchpointAccessor.ResetStagingBalances(context.Background(), true)
+
+	accountsCount := uint64(b.N)
+	fileHeader := CatchpointFileHeader{
+		Version:           catchpointFileVersion,
+		BalancesRound:     basics.Round(0),
+		BlocksRound:       basics.Round(0),
+		Totals:            AccountTotals{},
+		TotalAccounts:     accountsCount,
+		TotalChunks:       (accountsCount + BalancesPerCatchpointFileChunk - 1) / BalancesPerCatchpointFileChunk,
+		Catchpoint:        "",
+		BlockHeaderDigest: crypto.Digest{},
+	}
+	encodedFileHeader := protocol.Encode(&fileHeader)
+	var progress CatchpointCatchupAccessorProgress
+	err = catchpointAccessor.ProgressStagingBalances(context.Background(), "content.msgpack", encodedFileHeader, &progress)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	accounts := uint64(0)
+	var last64KStart time.Time
+	for accounts < accountsCount {
+		// generate a chunk;
+		chunkSize := accountsCount - accounts
+		if chunkSize > BalancesPerCatchpointFileChunk {
+			chunkSize = BalancesPerCatchpointFileChunk
+		}
+		if accounts >= accountsCount-64*1024 && last64KStart.IsZero() {
+			last64KStart = time.Now()
+		}
+		var balances catchpointFileBalancesChunk
+		balances.Balances = make([]encodedBalanceRecord, chunkSize)
+		for i := uint64(0); i < chunkSize; i++ {
+			var randomAccount encodedBalanceRecord
+			accountData := basics.AccountData{}
+			accountData.MicroAlgos.Raw = crypto.RandUint63()
+			randomAccount.AccountData = protocol.Encode(&accountData)
+			crypto.RandBytes(randomAccount.Address[:])
+			balances.Balances[i] = randomAccount
+		}
+		err = catchpointAccessor.ProgressStagingBalances(context.Background(), "balances.XX.msgpack", protocol.Encode(&balances), &progress)
+		require.NoError(b, err)
+		accounts += chunkSize
+	}
+	if !last64KStart.IsZero() {
+		last64KDuration := time.Now().Sub(last64KStart)
+		b.Logf("Last 64K\t%v\n", last64KDuration)
+	}
+}
+
+func BenchmarkRestoringFromCatchpointFile(b *testing.B) {
+	benchSizes := []int{1024 * 100, 1024 * 200, 1024 * 400}
+	for _, size := range benchSizes {
+		b.Run(fmt.Sprintf("Restore-%d", size), func(b *testing.B) {
+			b.N = size
+			benchmarkRestoringFromCatchpointFileHelper(b)
+		})
+	}
+}

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -61,7 +61,7 @@ func sign(secrets map[basics.Address]*crypto.SignatureSecrets, t transactions.Tr
 	}
 }
 
-func testGenerateInitState(t *testing.T, proto protocol.ConsensusVersion) (genesisInitState InitState, initKeys map[basics.Address]*crypto.SignatureSecrets) {
+func testGenerateInitState(tb testing.TB, proto protocol.ConsensusVersion) (genesisInitState InitState, initKeys map[basics.Address]*crypto.SignatureSecrets) {
 	params := config.Consensus[proto]
 	poolAddr := testPoolAddr
 	sinkAddr := testSinkAddr
@@ -95,7 +95,7 @@ func testGenerateInitState(t *testing.T, proto protocol.ConsensusVersion) (genes
 
 	initBlock := bookkeeping.Block{
 		BlockHeader: bookkeeping.BlockHeader{
-			GenesisID: t.Name(),
+			GenesisID: tb.Name(),
 			Round:     0,
 			RewardsState: bookkeeping.RewardsState{
 				RewardsRate: initialRewardsPerRound,
@@ -109,12 +109,12 @@ func testGenerateInitState(t *testing.T, proto protocol.ConsensusVersion) (genes
 		},
 	}
 	if params.SupportGenesisHash {
-		initBlock.BlockHeader.GenesisHash = crypto.Hash([]byte(t.Name()))
+		initBlock.BlockHeader.GenesisHash = crypto.Hash([]byte(tb.Name()))
 	}
 
 	genesisInitState.Block = initBlock
 	genesisInitState.Accounts = initAccounts
-	genesisInitState.GenesisHash = crypto.Hash([]byte(t.Name()))
+	genesisInitState.GenesisHash = crypto.Hash([]byte(tb.Name()))
 
 	return
 }


### PR DESCRIPTION
## Summary

Before attempting to improve the catchpoint catchup performance, we need a way to systematically test how well we perform. Running this test, produces the following output:
```
goos: darwin
Add a benchmark to test restoring from catchpoint performance.
goarch: amd64
pkg: github.com/algorand/go-algorand/ledger
BenchmarkRestoringFromCatchpointFile/Restore-102400-8         	  102400	     64479 ns/op
--- BENCH: BenchmarkRestoringFromCatchpointFile/Restore-102400-8
    catchupaccessor_test.go:99: Last 64K	4.949638275s
BenchmarkRestoringFromCatchpointFile/Restore-204800-8         	  204800	     86044 ns/op
--- BENCH: BenchmarkRestoringFromCatchpointFile/Restore-204800-8
    catchupaccessor_test.go:99: Last 64K	7.556581895s
BenchmarkRestoringFromCatchpointFile/Restore-409600-8         	  409600	    105683 ns/op
--- BENCH: BenchmarkRestoringFromCatchpointFile/Restore-409600-8
    testingLogger.go:38: time="2020-09-04T12:24:42.944604 -0400" level=warning msg="dbatomic: tx surpassed expected deadline by 11.728647ms" callee="github.com/algorand/go-algorand/ledger.(*CatchpointCatchupAccessorImpl).processStagingBalances.func1" caller="/Users/tsachi/go/src/github.com/algorand/go-algorand/ledger/catchupaccessor.go:294" file=dbutil.go function="github.com/algorand/go-algorand/util/db.(*Accessor).atomic" line=355 readonly=false
    catchupaccessor_test.go:99: Last 64K	9.041332973s
PASS
ok  	github.com/algorand/go-algorand/ledger	68.104s
```

by itself, it's not good or bad. But it's a measurable starting point for performance tuning.