### PR TITLE
Removing close from eof pattern match

### DIFF
--- a/test/e2e-go/cli/goal/expect/goalAppAccountAddressTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalAppAccountAddressTest.exp
@@ -107,7 +107,7 @@ proc goalAppAccountAddress { TEST_ALGO_DIR TEST_DATA_DIR} {
     expect {
 	timeout { puts timeout; ::AlgorandGoal::Abort  "\n Failed to see expected output" }
 	"*committed in round*" {puts "app call successful"; close}
-	eof {close; ::AlgorandGoal::Abort "app call failed" }
+	eof {::AlgorandGoal::Abort "app call failed" }
     }
 
     puts "Checking the results"
@@ -124,18 +124,17 @@ proc goalAppAccountAddress { TEST_ALGO_DIR TEST_DATA_DIR} {
     expect {
 	timeout { puts timeout; ::AlgorandGoal::Abort  "\n Failed to see expected output" }
 	"*$EXPECTED_OUTPUT*" {puts "Local state read correctly"; close}
-	eof {close; ::AlgorandGoal::Abort "app read failed" }
+	eof {::AlgorandGoal::Abort "app read failed" }
     }
 
     # check the local state of account 2
     spawn goal app read --app-id $APP_ID --local --guess-format \
 	--from $ACCOUNT_2_ADDRESS -w $WALLET_1_NAME -d $TEST_PRIMARY_NODE_DIR
-
     expect {
 	timeout { puts timeout; ::AlgorandGoal::Abort  "\n Failed to see expected output" }
 	"Please enter the password for wallet '$WALLET_1_NAME':" {send "$WALLET_1_PASSWORD\r" ; exp_continue}
 	"*$EXPECTED_OUTPUT*" {puts "Local state read correctly"; close}
-	eof {close; ::AlgorandGoal::Abort "app read failed" }
+	eof {::AlgorandGoal::Abort "app read failed" }
     }
     
     # call the app with a missing app-account. It should fail
@@ -148,7 +147,7 @@ proc goalAppAccountAddress { TEST_ALGO_DIR TEST_DATA_DIR} {
 	timeout { puts timeout; ::AlgorandGoal::Abort  "\n Failed to see expected output" }
 	"*Couldn't broadcast tx with algod: HTTP 400 Bad Request: TransactionPool.Remember: transaction*invalid Accounts index 4*" \
 	    {puts "Error received successfully "; close}
-	eof {close; ::AlgorandGoal::Abort "failed to get the expected error" }
+	eof {::AlgorandGoal::Abort "failed to get the expected error" }
     }
 
     # Shutdown the network


### PR DESCRIPTION
From expect man page:
Both expect and interact will detect when the current process exits
and implicitly do a close.

When eof pattern is detected, there will already be an implicit close.
Closing again will throw an error like: spawn_id: spawn id exp13 not open
