### PR TITLE
Add txn.Accounts and txn.ApplicationArgs support to tealdbg

### DIFF
--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1249,9 +1249,9 @@ func (cx *evalContext) assetParamsEnumToValue(params *basics.AssetParams, field 
 }
 
 // TxnFieldToTealValue is a thin wrapper for txnFieldToStack for external use
-func TxnFieldToTealValue(txn *transactions.Transaction, groupIndex int, field TxnField) (basics.TealValue, error) {
+func TxnFieldToTealValue(txn *transactions.Transaction, groupIndex int, field TxnField, arrayFieldIdx uint64) (basics.TealValue, error) {
 	cx := evalContext{EvalParams: EvalParams{GroupIndex: groupIndex}}
-	sv, err := cx.txnFieldToStack(txn, field, 0, groupIndex)
+	sv, err := cx.txnFieldToStack(txn, field, arrayFieldIdx, groupIndex)
 	return sv.toTealValue(), err
 }
 


### PR DESCRIPTION
## Summary

Tealdbg now can show content of txn.Accounts and txn.ApplicationArgs
Addresses now as shown as standard base32 strings rather than hex-encoded blobs

## Test Plan

How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale.
