### PR TITLE
Return 404 if v1/transaction/{txid} doesn't find the txn.

### DIFF
--- a/daemon/algod/api/server/v1/handlers/handlers.go
+++ b/daemon/algod/api/server/v1/handlers/handlers.go
@@ -17,6 +17,7 @@
 package handlers
 
 import (
+	"database/sql"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -1846,6 +1847,10 @@ func GetTransactionByID(ctx lib.ReqContext, context echo.Context) {
 	}
 
 	rnd, err := indexer.GetRoundByTXID(queryTxID)
+	if err == sql.ErrNoRows {
+		lib.ErrorResponse(w, http.StatusNotFound, err, errTransactionNotFound, ctx.Log)
+		return
+	}
 	if err != nil {
 		lib.ErrorResponse(w, http.StatusInternalServerError, err, errFailedGettingInformationFromIndexer, ctx.Log)
 		return


### PR DESCRIPTION
## Summary

Return 404 instead of 500 if the transaction isn't found.