### PR TITLE
Vote validation error refactor

### DIFF
--- a/agreement/abstractions.go
+++ b/agreement/abstractions.go
@@ -307,3 +307,18 @@ type Message struct {
 type EventsProcessingMonitor interface {
 	UpdateEventsQueue(queueName string, queueLength int)
 }
+
+// LedgerDroppedRoundError is a wrapper error for when the ledger cannot return a Lookup query because
+// the entry is old and was dropped from the ledger. The purpose of this wrapper is to help the
+// agreement differentiate between a malicious vote and a vote that it cannot verify
+type LedgerDroppedRoundError struct {
+	Err error
+}
+
+func (e *LedgerDroppedRoundError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *LedgerDroppedRoundError) Unwrap() error {
+	return e.Err
+}

--- a/agreement/asyncVoteVerifier.go
+++ b/agreement/asyncVoteVerifier.go
@@ -118,11 +118,8 @@ func (avv *AsyncVoteVerifier) executeVoteVerification(task interface{}) interfac
 		v, err := req.uv.verify(req.l)
 		req.message.Vote = v
 
-		cancelled := false
 		var e *RoundOffsetError
-		if ok := errors.As(err, &e); ok {
-			cancelled = true
-		}
+		cancelled := errors.As(err, &e)
 
 		return &asyncVerifyVoteResponse{v: v, index: req.index, message: req.message, err: err, cancelled: cancelled, req: &req}
 	}
@@ -139,11 +136,8 @@ func (avv *AsyncVoteVerifier) executeEqVoteVerification(task interface{}) interf
 		// request was not cancelled, so we verify it here and return the result on the channel
 		ev, err := req.uev.verify(req.l)
 
-		cancelled := false
 		var e *RoundOffsetError
-		if ok := errors.As(err, &e); ok {
-			cancelled = true
-		}
+		cancelled := errors.As(err, &e)
 
 		return &asyncVerifyVoteResponse{ev: ev, index: req.index, message: req.message, err: err, cancelled: cancelled, req: &req}
 	}

--- a/agreement/asyncVoteVerifier.go
+++ b/agreement/asyncVoteVerifier.go
@@ -66,7 +66,7 @@ type RoundOffsetError struct {
 	DbRound basics.Round
 }
 
-func (e RoundOffsetError) Error() string {
+func (e *RoundOffsetError) Error() string {
 	return fmt.Sprintf("round %d before dbRound %d", e.Round, e.DbRound)
 }
 
@@ -114,12 +114,12 @@ func (avv *AsyncVoteVerifier) executeVoteVerification(task interface{}) interfac
 		return &asyncVerifyVoteResponse{err: req.ctx.Err(), cancelled: true, req: &req}
 	default:
 		// request was not cancelled, so we verify it here and return the result on the channel
-		v, err := req.uv.verify(req.l)
+ 		v, err := req.uv.verify(req.l)
 		req.message.Vote = v
 		cancelled := false
 
 		var e *RoundOffsetError
-		if errors.As(err, &e) {
+		if ok := errors.As(err, &e); ok {
 			cancelled = true
 		}
 

--- a/agreement/asyncVoteVerifier.go
+++ b/agreement/asyncVoteVerifier.go
@@ -59,15 +59,6 @@ type AsyncVoteVerifier struct {
 	ctxCancel       context.CancelFunc
 }
 
-// LedgerDroppedRoundError is an error for when agreement far behind ledger
-type LedgerDroppedRoundError struct {
-	Err error
-}
-
-func (e *LedgerDroppedRoundError) Error() string {
-	return e.Err.Error()
-}
-
 // MakeAsyncVoteVerifier creates an AsyncVoteVerifier with workers as the number of CPUs
 func MakeAsyncVoteVerifier(verificationPool execpool.BacklogPool) *AsyncVoteVerifier {
 	verifier := &AsyncVoteVerifier{

--- a/agreement/common_test.go
+++ b/agreement/common_test.go
@@ -313,7 +313,7 @@ func (l *testLedger) LookupDigest(r basics.Round) (crypto.Digest, error) {
 		panic(err)
 	}
 
-	if l.maxNumBlocks != 0 && l.nextRound > round(l.maxNumBlocks) && r < l.nextRound-round(l.maxNumBlocks) {
+	if l.maxNumBlocks != 0 && r+round(l.maxNumBlocks) < l.nextRound {
 		return crypto.Digest{}, &LedgerDroppedRoundError{}
 	}
 
@@ -329,7 +329,7 @@ func (l *testLedger) Lookup(r basics.Round, a basics.Address) (basics.AccountDat
 		panic(err)
 	}
 
-	if l.maxNumBlocks != 0 && l.nextRound > round(l.maxNumBlocks) && r < l.nextRound-round(l.maxNumBlocks) {
+	if l.maxNumBlocks != 0 && r+round(l.maxNumBlocks) < l.nextRound {
 		return basics.AccountData{}, &LedgerDroppedRoundError{}
 	}
 

--- a/agreement/common_test.go
+++ b/agreement/common_test.go
@@ -314,7 +314,7 @@ func (l *testLedger) LookupDigest(r basics.Round) (crypto.Digest, error) {
 	}
 
 	if l.maxNumBlocks != 0 && l.nextRound > round(l.maxNumBlocks) && r < l.nextRound-round(l.maxNumBlocks) {
-		return crypto.Digest{}, &RoundOffsetError{r, l.nextRound - round(l.maxNumBlocks)}
+		return crypto.Digest{}, &LedgerDroppedRoundError{}
 	}
 
 	return l.entries[r].Digest(), nil
@@ -330,7 +330,7 @@ func (l *testLedger) Lookup(r basics.Round, a basics.Address) (basics.AccountDat
 	}
 
 	if l.maxNumBlocks != 0 && l.nextRound > round(l.maxNumBlocks) && r < l.nextRound-round(l.maxNumBlocks) {
-		return basics.AccountData{}, &RoundOffsetError{r, l.nextRound - round(l.maxNumBlocks)}
+		return basics.AccountData{}, &LedgerDroppedRoundError{}
 	}
 
 	return l.state[a], nil

--- a/agreement/common_test.go
+++ b/agreement/common_test.go
@@ -290,7 +290,7 @@ func (l *testLedger) LookupDigest(r basics.Round) (crypto.Digest, error) {
 		panic(err)
 	}
 
-	if l.nextRound > 320 && r < l.nextRound - 320 { // TODO: (nguo) fix this to use the right params
+	if l.nextRound > 320 && r < l.nextRound-320 { // TODO: (nguo) fix this to use the right params
 		return crypto.Digest{}, &RoundOffsetError{r, l.nextRound - 320}
 	}
 
@@ -306,7 +306,7 @@ func (l *testLedger) Lookup(r basics.Round, a basics.Address) (basics.AccountDat
 		panic(err)
 	}
 
-	if l.nextRound > 320 && r < l.nextRound - 320 { // TODO: (nguo) fix this to use the right params
+	if l.nextRound > 320 && r < l.nextRound-320 { // TODO: (nguo) fix this to use the right params
 		return basics.AccountData{}, &RoundOffsetError{r, l.nextRound - 320}
 	}
 

--- a/agreement/common_test.go
+++ b/agreement/common_test.go
@@ -290,6 +290,10 @@ func (l *testLedger) LookupDigest(r basics.Round) (crypto.Digest, error) {
 		panic(err)
 	}
 
+	if l.nextRound > 320 && r < l.nextRound - 320 { // TODO: (nguo) fix this to use the right params
+		return crypto.Digest{}, &RoundOffsetError{r, l.nextRound - 320}
+	}
+
 	return l.entries[r].Digest(), nil
 }
 
@@ -301,6 +305,11 @@ func (l *testLedger) Lookup(r basics.Round, a basics.Address) (basics.AccountDat
 		err := fmt.Errorf("Lookup called on future round: %v >= %v! (this is probably a bug)", r, l.nextRound)
 		panic(err)
 	}
+
+	if l.nextRound > 320 && r < l.nextRound - 320 { // TODO: (nguo) fix this to use the right params
+		return basics.AccountData{}, &RoundOffsetError{r, l.nextRound - 320}
+	}
+
 	return l.state[a], nil
 }
 

--- a/agreement/common_test.go
+++ b/agreement/common_test.go
@@ -314,7 +314,7 @@ func (l *testLedger) LookupDigest(r basics.Round) (crypto.Digest, error) {
 	}
 
 	if l.maxNumBlocks != 0 && l.nextRound > round(l.maxNumBlocks) && r < l.nextRound-round(l.maxNumBlocks) {
-		return crypto.Digest{}, &RoundOffsetError{r, l.nextRound - 320}
+		return crypto.Digest{}, &RoundOffsetError{r, l.nextRound - round(l.maxNumBlocks)}
 	}
 
 	return l.entries[r].Digest(), nil
@@ -330,7 +330,7 @@ func (l *testLedger) Lookup(r basics.Round, a basics.Address) (basics.AccountDat
 	}
 
 	if l.maxNumBlocks != 0 && l.nextRound > round(l.maxNumBlocks) && r < l.nextRound-round(l.maxNumBlocks) {
-		return basics.AccountData{}, &RoundOffsetError{r, l.nextRound - 320}
+		return basics.AccountData{}, &RoundOffsetError{r, l.nextRound - round(l.maxNumBlocks)}
 	}
 
 	return l.state[a], nil

--- a/agreement/selector.go
+++ b/agreement/selector.go
@@ -66,7 +66,7 @@ func membership(l LedgerReader, addr basics.Address, r basics.Round, p period, s
 
 	record, err := l.Lookup(balanceRound, addr)
 	if err != nil {
-		err = fmt.Errorf("Service.initializeVote (r=%d): Failed to obtain balance record for address %v in round %d: %v", r, addr, balanceRound, err)
+		err = fmt.Errorf("Service.initializeVote (r=%d): Failed to obtain balance record for address %v in round %d: %w", r, addr, balanceRound, err)
 		return
 	}
 

--- a/agreement/vote.go
+++ b/agreement/vote.go
@@ -90,7 +90,7 @@ type UnauthenticatedVoteVerifyError struct {
 }
 
 func (e *UnauthenticatedVoteVerifyError) Error() string {
-	return fmt.Sprintf("unauthenticatedVote.verify: could not get membership parameters: %v", e.Err.Error())
+	return fmt.Sprintf("unauthenticatedVote.verify: could not get membership parameters: %s", e.Err.Error())
 }
 
 // verify verifies that a vote that was received from the network is valid.
@@ -98,9 +98,7 @@ func (uv unauthenticatedVote) verify(l LedgerReader) (vote, error) {
 	rv := uv.R
 	m, err := membership(l, rv.Sender, rv.Round, rv.Period, rv.Step)
 	if err != nil {
-		return vote{}, &UnauthenticatedVoteVerifyError{
-			Err: err,
-		}
+		return vote{}, fmt.Errorf("unauthenticatedVote.verify: could not get membership parameters: %w", err)
 	}
 
 	switch rv.Step {
@@ -214,12 +212,12 @@ func (pair unauthenticatedEquivocationVote) verify(l LedgerReader) (equivocation
 
 	v0, err := uv0.verify(l)
 	if err != nil {
-		return equivocationVote{}, fmt.Errorf("unauthenticatedEquivocationVote.verify: failed to verify pair 0: %v", err)
+		return equivocationVote{}, fmt.Errorf("unauthenticatedEquivocationVote.verify: failed to verify pair 0: %w", err)
 	}
 
 	_, err = uv1.verify(l)
 	if err != nil {
-		return equivocationVote{}, fmt.Errorf("unauthenticatedEquivocationVote.verify: failed to verify pair 1: %v", err)
+		return equivocationVote{}, fmt.Errorf("unauthenticatedEquivocationVote.verify: failed to verify pair 1: %w", err)
 	}
 
 	return equivocationVote{

--- a/agreement/vote.go
+++ b/agreement/vote.go
@@ -85,14 +85,6 @@ type (
 	}
 )
 
-type UnauthenticatedVoteVerifyError struct {
-	Err error
-}
-
-func (e *UnauthenticatedVoteVerifyError) Error() string {
-	return fmt.Sprintf("unauthenticatedVote.verify: could not get membership parameters: %s", e.Err.Error())
-}
-
 // verify verifies that a vote that was received from the network is valid.
 func (uv unauthenticatedVote) verify(l LedgerReader) (vote, error) {
 	rv := uv.R

--- a/agreement/vote.go
+++ b/agreement/vote.go
@@ -85,12 +85,22 @@ type (
 	}
 )
 
+type UnauthenticatedVoteVerifyError struct {
+	Err error
+}
+
+func (e *UnauthenticatedVoteVerifyError) Error() string {
+	return fmt.Sprintf("unauthenticatedVote.verify: could not get membership parameters: %v", e.Err.Error())
+}
+
 // verify verifies that a vote that was received from the network is valid.
 func (uv unauthenticatedVote) verify(l LedgerReader) (vote, error) {
 	rv := uv.R
 	m, err := membership(l, rv.Sender, rv.Round, rv.Period, rv.Step)
 	if err != nil {
-		return vote{}, fmt.Errorf("unauthenticatedVote.verify: could not get membership parameters: %v", err)
+		return vote{}, &UnauthenticatedVoteVerifyError{
+			Err: err,
+		}
 	}
 
 	switch rv.Step {

--- a/agreement/voteAggregator_test.go
+++ b/agreement/voteAggregator_test.go
@@ -869,7 +869,7 @@ func TestVoteAggregatorOldVote(t *testing.T) {
 
 	for i, uv := range uvs {
 		avv.verifyVote(context.Background(), ledger, uv, i, message{}, results)
-		result := <- results
+		result := <-results
 		require.True(t, result.cancelled)
 	}
 }

--- a/agreement/voteAggregator_test.go
+++ b/agreement/voteAggregator_test.go
@@ -841,7 +841,9 @@ func TestVoteAggregatorFiltersVoteNextRound(t *testing.T) {
 }
 
 func TestVoteAggregatorOldVote(t *testing.T) {
-	ledger := makeTestLedgerMaxBlocks(readOnlyGenesis100, 320)
+	cparams := config.Consensus[protocol.ConsensusCurrentVersion]
+	maxNumBlocks := 2 * cparams.SeedRefreshInterval * cparams.SeedLookback
+	ledger := makeTestLedgerMaxBlocks(readOnlyGenesis100, maxNumBlocks)
 	addresses, vrfSecrets, otSecrets := readOnlyAddrs100, readOnlyVRF100, readOnlyOT100
 	round := ledger.NextRound()
 	period := period(0)

--- a/agreement/voteAggregator_test.go
+++ b/agreement/voteAggregator_test.go
@@ -841,7 +841,8 @@ func TestVoteAggregatorFiltersVoteNextRound(t *testing.T) {
 }
 
 func TestVoteAggregatorOldVote(t *testing.T) {
-	ledger, addresses, vrfSecrets, otSecrets := readOnlyFixture100()
+	ledger := makeTestLedgerMaxBlocks(readOnlyGenesis100, 320)
+	addresses, vrfSecrets, otSecrets := readOnlyAddrs100, readOnlyVRF100, readOnlyOT100
 	round := ledger.NextRound()
 	period := period(0)
 

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -215,12 +215,12 @@ type deferedCommit struct {
 
 // RoundOffsetError is an error for when requested round is behind earliest stored db entry
 type RoundOffsetError struct {
-	Round   basics.Round
-	DbRound basics.Round
+	round   basics.Round
+	dbRound basics.Round
 }
 
 func (e *RoundOffsetError) Error() string {
-	return fmt.Sprintf("round %d before dbRound %d", e.Round, e.DbRound)
+	return fmt.Sprintf("round %d before dbRound %d", e.round, e.dbRound)
 }
 
 // initialize initializes the accountUpdates structure
@@ -1441,8 +1441,8 @@ func (au *accountUpdates) accountsCreateCatchpointLabel(committedRound basics.Ro
 func (au *accountUpdates) roundOffset(rnd basics.Round) (offset uint64, err error) {
 	if rnd < au.dbRound {
 		err = &RoundOffsetError{
-			Round:   rnd,
-			DbRound: au.dbRound,
+			round:   rnd,
+			dbRound: au.dbRound,
 		}
 		return
 	}

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1432,8 +1432,8 @@ func (au *accountUpdates) accountsCreateCatchpointLabel(committedRound basics.Ro
 func (au *accountUpdates) roundOffset(rnd basics.Round) (offset uint64, err error) {
 	if rnd < au.dbRound {
 		err = &agreement.RoundOffsetError{
-			Round: rnd,
-			DbRound:  au.dbRound,
+			Round:   rnd,
+			DbRound: au.dbRound,
 		}
 		return
 	}

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/algorand/go-deadlock"
 
+	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/merkletrie"
@@ -1430,7 +1431,10 @@ func (au *accountUpdates) accountsCreateCatchpointLabel(committedRound basics.Ro
 // roundOffset calculates the offset of the given round compared to the current dbRound. Requires that the lock would be taken.
 func (au *accountUpdates) roundOffset(rnd basics.Round) (offset uint64, err error) {
 	if rnd < au.dbRound {
-		err = fmt.Errorf("round %d before dbRound %d", rnd, au.dbRound)
+		err = &agreement.RoundOffsetError{
+			Round: rnd,
+			DbRound:  au.dbRound,
+		}
 		return
 	}
 

--- a/node/impls.go
+++ b/node/impls.go
@@ -19,7 +19,6 @@ package node
 import (
 	"context"
 	"errors"
-	"github.com/algorand/go-algorand/ledger"
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/catchup"
@@ -27,6 +26,7 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/pools"
+	"github.com/algorand/go-algorand/ledger"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/util/execpool"

--- a/node/impls.go
+++ b/node/impls.go
@@ -115,6 +115,7 @@ func (l agreementLedger) EnsureDigest(cert agreement.Certificate, verifier *agre
 	l.UnmatchedPendingCertificates <- catchup.PendingUnmatchedCertificate{Cert: cert, VoteVerifier: verifier}
 }
 
+// Wrapping error with a LedgerDroppedRoundError when an old round is requested but the ledger has already dropped the entry
 func (l agreementLedger) Lookup(rnd basics.Round, addr basics.Address) (basics.AccountData, error) {
 	record, err := l.Ledger.Lookup(rnd, addr)
 	var e *ledger.RoundOffsetError


### PR DESCRIPTION
## Summary

When an extremely old vote is received, the verifier will not be able to fetch the membership and will mark it as ProposalMalformed and cause a WARN log. This change downgrades that to a DEBUG and marks it as ProposalFiltered by using the cancelled tag.

Resolves https://github.com/algorand/go-algorand/issues/914

## Test Plan

Wrote additional unit test that simulates the described scenario to test this change
