### PR TITLE
Calculate normalized balance using genesis proto

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -421,7 +421,7 @@ func (au *accountUpdates) onlineTop(rnd basics.Round, voteRnd basics.Round, n ui
 		return nil, err
 	}
 
-	proto := au.protos[offset]
+	proto := au.ledger.GenesisProto()
 
 	// Determine how many accounts have been modified in-memory,
 	// so that we obtain enough top accounts from disk (accountdb).


### PR DESCRIPTION
## Summary

Calculate the accounts normalized balance when calling accountUpdates.onlineTop using the Genesis Proto rather then the current round's consensus params, so that it would align with the current values in the table.
