### PR TITLE
Exit algod with a non-zero in case of a startup error

### DIFF
--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -293,6 +293,7 @@ func main() {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		log.Error(err)
+		os.Exit(1)
 		return
 	}
 


### PR DESCRIPTION
## Summary

When Algod exit during the startup, it should return a non-zero value to indicate that there was an error.