### PR TITLE
Cache the most recent Seed/Circulation calls to reduce pressure on ledger

### DIFF
--- a/data/ledger.go
+++ b/data/ledger.go
@@ -45,22 +45,34 @@ type Ledger struct {
 
 	log logging.Logger
 
+	// a two-item moving window cache for the total number of online circulating coins
 	lastRoundCirculation atomic.Value
-	lastRoundSeed        atomic.Value
+	// a two-item moving window cache for the round seed
+	lastRoundSeed atomic.Value
 }
 
+// roundCirculation is the cache for the circulating coins
 type roundCirculation struct {
-	prevRound       basics.Round
+	// prevRound is the round number for the previously fetched online circulating coins
+	prevRound basics.Round
+	// prevOnlineMoney is the amount of coins in circulation for the round prevRound
 	prevOnlineMoney basics.MicroAlgos
-	curRound        basics.Round
-	curOnlineMoney  basics.MicroAlgos
+	// curRound is the round number for the last fetched online circulating coins
+	curRound basics.Round
+	// curOnlineMoney is the amount of coins in circulation for the round curRound
+	curOnlineMoney basics.MicroAlgos
 }
 
+// roundSeed is the cache for the seed
 type roundSeed struct {
+	// prevRound is the round number for the previously fetched round seed
 	prevRound basics.Round
-	prevSeed  committee.Seed
-	curRound  basics.Round
-	curSeed   committee.Seed
+	// prevSeed is the seed value for the round prevRound
+	prevSeed committee.Seed
+	// curRound is the round number for the last fetched seed
+	curRound basics.Round
+	// curSeed is the seed for the round curRound
+	curSeed committee.Seed
 }
 
 func makeGenesisBlock(proto protocol.ConsensusVersion, genesisBal GenesisBalances, genesisID string, genesisHash crypto.Digest) (bookkeeping.Block, error) {

--- a/data/ledger_test.go
+++ b/data/ledger_test.go
@@ -1,0 +1,314 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package data
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/agreement"
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+
+	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/ledger"
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/protocol"
+)
+
+var testPoolAddr = basics.Address{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+var testSinkAddr = basics.Address{0x2c, 0x2a, 0x6c, 0xe9, 0xa9, 0xa7, 0xc2, 0x8c, 0x22, 0x95, 0xfd, 0x32, 0x4f, 0x77, 0xa5, 0x4, 0x8b, 0x42, 0xc2, 0xb7, 0xa8, 0x54, 0x84, 0xb6, 0x80, 0xb1, 0xe1, 0x3d, 0x59, 0x9b, 0xeb, 0x36}
+
+func testGenerateInitState(tb testing.TB, proto protocol.ConsensusVersion) (genesisInitState ledger.InitState, initKeys map[basics.Address]*crypto.SignatureSecrets) {
+
+	var poolSecret, sinkSecret *crypto.SignatureSecrets
+	var seed crypto.Seed
+
+	incentivePoolName := []byte("incentive pool")
+	copy(seed[:], incentivePoolName)
+	poolSecret = crypto.GenerateSignatureSecrets(seed)
+
+	feeSinkName := []byte("fee sink")
+	copy(seed[:], feeSinkName)
+	sinkSecret = crypto.GenerateSignatureSecrets(seed)
+
+	params := config.Consensus[proto]
+	poolAddr := testPoolAddr
+	sinkAddr := testSinkAddr
+
+	var zeroSeed crypto.Seed
+	var genaddrs [10]basics.Address
+	var gensecrets [10]*crypto.SignatureSecrets
+	for i := range genaddrs {
+		seed := zeroSeed
+		seed[0] = byte(i)
+		x := crypto.GenerateSignatureSecrets(seed)
+		genaddrs[i] = basics.Address(x.SignatureVerifier)
+		gensecrets[i] = x
+	}
+
+	initKeys = make(map[basics.Address]*crypto.SignatureSecrets)
+	initAccounts := make(map[basics.Address]basics.AccountData)
+	for i := range genaddrs {
+		initKeys[genaddrs[i]] = gensecrets[i]
+		// Give each account quite a bit more balance than MinFee or MinBalance
+		accountStatus := basics.Online
+		if i%2 == 0 {
+			accountStatus = basics.NotParticipating
+		}
+		initAccounts[genaddrs[i]] = basics.MakeAccountData(accountStatus, basics.MicroAlgos{Raw: uint64((i + 100) * 100000)})
+	}
+	initKeys[poolAddr] = poolSecret
+	initAccounts[poolAddr] = basics.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 1234567})
+	initKeys[sinkAddr] = sinkSecret
+	initAccounts[sinkAddr] = basics.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 7654321})
+
+	incentivePoolBalanceAtGenesis := initAccounts[poolAddr].MicroAlgos
+	initialRewardsPerRound := incentivePoolBalanceAtGenesis.Raw / uint64(params.RewardsRateRefreshInterval)
+	var emptyPayset transactions.Payset
+
+	initBlock := bookkeeping.Block{
+		BlockHeader: bookkeeping.BlockHeader{
+			GenesisID: tb.Name(),
+			Round:     0,
+			RewardsState: bookkeeping.RewardsState{
+				RewardsRate: initialRewardsPerRound,
+				RewardsPool: poolAddr,
+				FeeSink:     sinkAddr,
+			},
+			UpgradeState: bookkeeping.UpgradeState{
+				CurrentProtocol: proto,
+			},
+			TxnRoot: emptyPayset.Commit(params.PaysetCommitFlat),
+		},
+	}
+	if params.SupportGenesisHash {
+		initBlock.BlockHeader.GenesisHash = crypto.Hash([]byte(tb.Name()))
+	}
+
+	genesisInitState.Block = initBlock
+	genesisInitState.Accounts = initAccounts
+	genesisInitState.GenesisHash = crypto.Hash([]byte(tb.Name()))
+
+	return
+}
+
+func TestLedgerCirculation(t *testing.T) {
+	genesisInitState, keys := testGenerateInitState(t, protocol.ConsensusCurrentVersion)
+
+	const inMem = true
+	cfg := config.GetDefaultLocal()
+	cfg.Archival = true
+	log := logging.TestingLog(t)
+	log.SetLevel(logging.Warn)
+	realLedger, err := ledger.OpenLedger(log, t.Name(), inMem, genesisInitState, cfg)
+	require.NoError(t, err, "could not open ledger")
+	defer realLedger.Close()
+
+	l := Ledger{Ledger: realLedger}
+	require.NotNil(t, &l)
+
+	var sourceAccount basics.Address
+	var destAccount basics.Address
+	for addr, acctData := range genesisInitState.Accounts {
+		if addr == testPoolAddr || addr == testSinkAddr {
+			continue
+		}
+		if acctData.Status == basics.Online {
+			sourceAccount = addr
+			break
+		}
+	}
+	for addr, acctData := range genesisInitState.Accounts {
+		if addr == testPoolAddr || addr == testSinkAddr {
+			continue
+		}
+		if acctData.Status == basics.NotParticipating {
+			destAccount = addr
+			break
+		}
+	}
+	require.False(t, sourceAccount.IsZero())
+	require.False(t, destAccount.IsZero())
+
+	data, err := realLedger.Lookup(basics.Round(0), destAccount)
+	require.NoError(t, err)
+	baseDestValue := data.MicroAlgos.Raw
+
+	blk := genesisInitState.Block
+	totals, _ := realLedger.Totals(basics.Round(0))
+	baseCirculation := totals.Online.Money.Raw
+
+	srcAccountKey := keys[sourceAccount]
+	require.NotNil(t, srcAccountKey)
+
+	for rnd := basics.Round(1); rnd < basics.Round(600); rnd++ {
+		blk.BlockHeader.Round++
+		blk.BlockHeader.TimeStamp += int64(crypto.RandUint64() % 100 * 1000)
+		var tx transactions.Transaction
+		tx.Sender = sourceAccount
+		tx.Fee = basics.MicroAlgos{Raw: 10000}
+		tx.FirstValid = rnd - 1
+		tx.LastValid = tx.FirstValid + 999
+		tx.Receiver = destAccount
+		tx.Amount = basics.MicroAlgos{Raw: 1}
+		tx.Type = protocol.PaymentTx
+		signedTx := tx.Sign(srcAccountKey)
+		blk.Payset = transactions.Payset{transactions.SignedTxnInBlock{
+			SignedTxnWithAD: transactions.SignedTxnWithAD{
+				SignedTxn: signedTx,
+			},
+		}}
+		require.NoError(t, l.AddBlock(blk, agreement.Certificate{}))
+		l.WaitForCommit(rnd)
+
+		// test most recent round
+		if rnd < basics.Round(500) {
+			data, err = realLedger.Lookup(rnd, destAccount)
+			require.NoError(t, err)
+			require.Equal(t, baseDestValue+uint64(rnd), data.MicroAlgos.Raw)
+			data, err = l.Lookup(rnd, destAccount)
+			require.NoError(t, err)
+			require.Equal(t, baseDestValue+uint64(rnd), data.MicroAlgos.Raw)
+
+			totals, err = realLedger.Totals(rnd)
+			require.NoError(t, err)
+			roundCirculation := totals.Online.Money.Raw
+			require.Equal(t, baseCirculation-uint64(rnd)*(10001), roundCirculation)
+
+			totals, err = l.Totals(rnd)
+			require.NoError(t, err)
+			roundCirculation = totals.Online.Money.Raw
+			require.Equal(t, baseCirculation-uint64(rnd)*(10001), roundCirculation)
+		} else if rnd < basics.Round(510) {
+			// test one round ago
+			data, err = realLedger.Lookup(rnd-1, destAccount)
+			require.NoError(t, err)
+			require.Equal(t, baseDestValue+uint64(rnd)-1, data.MicroAlgos.Raw)
+			data, err = l.Lookup(rnd-1, destAccount)
+			require.NoError(t, err)
+			require.Equal(t, baseDestValue+uint64(rnd)-1, data.MicroAlgos.Raw)
+
+			totals, err = realLedger.Totals(rnd - 1)
+			require.NoError(t, err)
+			roundCirculation := totals.Online.Money.Raw
+			require.Equal(t, baseCirculation-uint64(rnd-1)*(10001), roundCirculation)
+
+			totals, err = l.Totals(rnd - 1)
+			require.NoError(t, err)
+			roundCirculation = totals.Online.Money.Raw
+			require.Equal(t, baseCirculation-uint64(rnd-1)*(10001), roundCirculation)
+		} else if rnd < basics.Round(520) {
+			// test one round in the future ( expected error )
+			data, err = realLedger.Lookup(rnd+1, destAccount)
+			require.Error(t, err)
+			require.Equal(t, uint64(0), data.MicroAlgos.Raw)
+			data, err = l.Lookup(rnd+1, destAccount)
+			require.Error(t, err)
+			require.Equal(t, uint64(0), data.MicroAlgos.Raw)
+
+			_, err = realLedger.Totals(rnd + 1)
+			require.Error(t, err)
+
+			_, err = l.Totals(rnd + 1)
+			require.Error(t, err)
+		} else if rnd < basics.Round(520) {
+			// test expired round ( expected error )
+			_, err = realLedger.Totals(rnd - 500)
+			require.Error(t, err)
+
+			_, err = l.Totals(rnd - 500)
+			require.Error(t, err)
+		}
+	}
+	return
+}
+
+func TestLedgerSeed(t *testing.T) {
+	genesisInitState, _ := testGenerateInitState(t, protocol.ConsensusCurrentVersion)
+
+	const inMem = true
+	cfg := config.GetDefaultLocal()
+	cfg.Archival = true
+	log := logging.TestingLog(t)
+	log.SetLevel(logging.Warn)
+	realLedger, err := ledger.OpenLedger(log, t.Name(), inMem, genesisInitState, cfg)
+	require.NoError(t, err, "could not open ledger")
+	defer realLedger.Close()
+
+	l := Ledger{Ledger: realLedger}
+	require.NotNil(t, &l)
+
+	blk := genesisInitState.Block
+	for rnd := basics.Round(1); rnd < basics.Round(32); rnd++ {
+		blk.BlockHeader.Round++
+		blk.BlockHeader.Seed[0] = byte(uint64(rnd))
+		blk.BlockHeader.Seed[1] = byte(uint64(rnd) / 256)
+		blk.BlockHeader.Seed[2] = byte(uint64(rnd) / 65536)
+		blk.BlockHeader.TimeStamp += int64(crypto.RandUint64() % 100 * 1000)
+		require.NoError(t, l.AddBlock(blk, agreement.Certificate{}))
+		l.WaitForCommit(rnd)
+		if rnd < basics.Round(16) {
+			// test the current round
+			expectedHdr, err := realLedger.BlockHdr(rnd)
+			require.NoError(t, err)
+
+			// ensure the item is not in the cache
+			seed, cached := l.lastRoundSeed.Load().(roundSeed)
+			if cached {
+				require.NotEqual(t, seed.curSeed, expectedHdr.Seed)
+			}
+
+			actualSeed, err := l.Seed(rnd)
+			require.NoError(t, err)
+
+			require.Equal(t, expectedHdr.Seed, actualSeed)
+
+			seed, cached = l.lastRoundSeed.Load().(roundSeed)
+			require.True(t, cached)
+			require.Equal(t, seed.curSeed, expectedHdr.Seed)
+		} else if rnd < basics.Round(32) {
+			// test against the previous round
+			expectedHdr, err := realLedger.BlockHdr(rnd - 1)
+			require.NoError(t, err)
+
+			// ensure the cache is aligned with the previous round
+			seed, cached := l.lastRoundSeed.Load().(roundSeed)
+			require.True(t, cached)
+			require.Equal(t, seed.curRound, rnd-1)
+			require.Equal(t, seed.curSeed, expectedHdr.Seed)
+
+			actualSeed, err := l.Seed(rnd)
+			require.NoError(t, err)
+
+			expectedHdr, err = realLedger.BlockHdr(rnd)
+			require.NoError(t, err)
+
+			require.Equal(t, expectedHdr.Seed, actualSeed)
+
+			// ensure the cache is aligned with the updated round
+			seed, cached = l.lastRoundSeed.Load().(roundSeed)
+			require.True(t, cached)
+			require.Equal(t, seed.curRound, rnd)
+			require.Equal(t, seed.curSeed, expectedHdr.Seed)
+		}
+	}
+	return
+}

--- a/data/ledger_test.go
+++ b/data/ledger_test.go
@@ -273,7 +273,7 @@ func TestLedgerSeed(t *testing.T) {
 			// ensure the item is not in the cache
 			seed, cached := l.lastRoundSeed.Load().(roundSeed)
 			if cached {
-				require.NotEqual(t, seed.curSeed, expectedHdr.Seed)
+				require.NotEqual(t, seed.elements[1].seed, expectedHdr.Seed)
 			}
 
 			actualSeed, err := l.Seed(rnd)
@@ -283,7 +283,7 @@ func TestLedgerSeed(t *testing.T) {
 
 			seed, cached = l.lastRoundSeed.Load().(roundSeed)
 			require.True(t, cached)
-			require.Equal(t, seed.curSeed, expectedHdr.Seed)
+			require.Equal(t, seed.elements[1].seed, expectedHdr.Seed)
 		} else if rnd < basics.Round(32) {
 			// test against the previous round
 			expectedHdr, err := realLedger.BlockHdr(rnd - 1)
@@ -292,8 +292,8 @@ func TestLedgerSeed(t *testing.T) {
 			// ensure the cache is aligned with the previous round
 			seed, cached := l.lastRoundSeed.Load().(roundSeed)
 			require.True(t, cached)
-			require.Equal(t, seed.curRound, rnd-1)
-			require.Equal(t, seed.curSeed, expectedHdr.Seed)
+			require.Equal(t, seed.elements[1].round, rnd-1)
+			require.Equal(t, seed.elements[1].seed, expectedHdr.Seed)
 
 			actualSeed, err := l.Seed(rnd)
 			require.NoError(t, err)
@@ -306,8 +306,8 @@ func TestLedgerSeed(t *testing.T) {
 			// ensure the cache is aligned with the updated round
 			seed, cached = l.lastRoundSeed.Load().(roundSeed)
 			require.True(t, cached)
-			require.Equal(t, seed.curRound, rnd)
-			require.Equal(t, seed.curSeed, expectedHdr.Seed)
+			require.Equal(t, seed.elements[1].round, rnd)
+			require.Equal(t, seed.elements[1].seed, expectedHdr.Seed)
 		}
 	}
 	return


### PR DESCRIPTION
## Summary

This PR adds a cache for the data.Ledger for the `Circulation` and `Seed` calls.
The goal of this PR is to reduce the contingency pressure on the downstream accounts update lock.

The high-level plan is to eventually eliminate this code, and make sure that the agreement service is sufficiently smart to perform a similar logic.

## Test Plan

Unit test added.