### PR TITLE
onetechnical/relbeta2.1.5-2

### DIFF
--- a/installer/rpm/algorand-devtools/algorand-devtools.spec
+++ b/installer/rpm/algorand-devtools/algorand-devtools.spec
@@ -4,7 +4,7 @@ Release:       1
 Summary:       Algorand tools software
 URL:           https://www.algorand.com
 License:       AGPL-3+
-Requires:      algorand >= @VER@
+Requires:      @REQUIRED_ALGORAND_PKG@ >= @VER@
 
 %define SRCDIR go-algorand-rpmbuild
 %define _buildshell /bin/bash

--- a/scripts/release/build/deb/build_deb.sh
+++ b/scripts/release/build/deb/build_deb.sh
@@ -27,15 +27,15 @@ trap "rm -rf $PKG_ROOT" 0
 mkdir -p "$PKG_ROOT/usr/bin"
 
 # NOTE: keep in sync with `./installer/rpm/algorand.spec`.
-if [ "$PKG_NAME" = "algorand-devtools" ]; then
+if [[ "$PKG_NAME" =~ devtools ]]; then
     BIN_FILES=("carpenter" "catchupsrv" "msgpacktool" "tealcut" "tealdbg")
     UNATTENDED_UPGRADES_FILE="53algorand-devtools-upgrades"
-    OUTPUT_DEB="$OUTDIR/algorand_devtools_${CHANNEL}_${OS_TYPE}-${ARCH}_${VER}.deb"
+    OUTPUT_DEB="$OUTDIR/algorand-devtools_${CHANNEL}_${OS_TYPE}-${ARCH}_${VER}.deb"
     REQUIRED_ALGORAND_PKG=$("./scripts/compute_package_name.sh" "$CHANNEL")
 else
     BIN_FILES=("algocfg" "algod" "algoh" "algokey" "ddconfig.sh" "diagcfg" "goal" "kmd" "node_exporter")
-    UNATTENDED_UPGRADES_FILE="51algorand-upgrades"
     OUTPUT_DEB="$OUTDIR/algorand_${CHANNEL}_${OS_TYPE}-${ARCH}_${VER}.deb"
+    UNATTENDED_UPGRADES_FILE="51algorand-upgrades"
 fi
 
 for binary in "${BIN_FILES[@]}"; do
@@ -43,7 +43,7 @@ for binary in "${BIN_FILES[@]}"; do
     chmod 755 "$PKG_ROOT/usr/bin/$binary"
 done
 
-if [ "$PKG_NAME" != "algorand-devtools" ]; then
+if [[ ! "$PKG_NAME" =~ devtools ]]; then
     mkdir -p "${PKG_ROOT}/usr/lib/algorand"
     lib_files=("updater" "find-nodes.sh")
     for lib in "${lib_files[@]}"; do
@@ -92,8 +92,15 @@ Dpkg::Options {
 EOF
 
 mkdir -p "$PKG_ROOT/DEBIAN"
+
+if [[ "$PKG_NAME" =~ devtools ]]; then
+    INSTALLER_DIR="algorand-devtools"
+else
+    INSTALLER_DIR=algorand
+fi
+
 # Can contain `control`, `preinst`, `postinst`, `prerm`, `postrm`, `conffiles`.
-CTL_FILES_DIR="./installer/debian/$PKG_NAME"
+CTL_FILES_DIR="./installer/debian/$INSTALLER_DIR"
 for ctl_file in $(ls "$CTL_FILES_DIR"); do
     # Copy first, to preserve permissions, then overwrite to fill in template.
     cp -a "$CTL_FILES_DIR/$ctl_file" "$PKG_ROOT/DEBIAN/$ctl_file"

--- a/scripts/release/build/deb/package.sh
+++ b/scripts/release/build/deb/package.sh
@@ -27,7 +27,13 @@ for pkg_name in "${PKG_NAMES[@]}"; do
         exit 1
     fi
 
-    cp -p "${DEBTMP}"/*.deb "${PKG_ROOT}/${pkg_name}_${CHANNEL}_${OS}-${ARCH}_${FULLVERSION}.deb"
+    if [[ "$pkg_name" =~ devtools ]]; then
+        BASE_NAME="algorand-devtools"
+    else
+        BASE_NAME=algorand
+    fi
+
+    cp -p "${DEBTMP}"/*.deb "${PKG_ROOT}/${BASE_NAME}_${CHANNEL}_${OS}-${ARCH}_${FULLVERSION}.deb"
 done
 
 popd

--- a/scripts/release/build/rpm/package.sh
+++ b/scripts/release/build/rpm/package.sh
@@ -30,9 +30,15 @@ for pkg_name in "${PKG_NAMES[@]}"; do
 
     mkdir "$TEMPDIR/$pkg_name"
 
+    if [[ "$pkg_name" =~ devtools ]]; then
+        INSTALLER_DIR="algorand-devtools"
+    else
+        INSTALLER_DIR=algorand
+    fi
+
     echo "Building rpm package $pkg_name ($CHANNEL)"
 
-    < "$REPO_DIR/installer/rpm/$pkg_name/$pkg_name.spec" \
+    < "$REPO_DIR/installer/rpm/$INSTALLER_DIR/$INSTALLER_DIR.spec" \
         sed -e "s,@PKG_NAME@,$pkg_name," \
             -e "s,@VER@,$FULLVERSION," \
             -e "s,@REQUIRED_ALGORAND_PKG@,$ALGORAND_PACKAGE_NAME," \

--- a/scripts/release/mule/package/rpm/package.sh
+++ b/scripts/release/mule/package/rpm/package.sh
@@ -32,8 +32,13 @@ RPMTMP=$(mktemp -d 2>/dev/null || mktemp -d -t "rpmtmp")
 trap 'rm -rf $RPMTMP' 0
 
 TEMPDIR=$(mktemp -d)
+if [[ "$ALGORAND_PACKAGE_NAME" =~ devtools ]]; then
+    INSTALLER_DIR="algorand-devtools"
+else
+    INSTALLER_DIR=algorand
+fi
 trap 'rm -rf $TEMPDIR' 0
-< "./installer/rpm/$ALGORAND_PACKAGE_NAME/$ALGORAND_PACKAGE_NAME.spec" \
+< "./installer/rpm/$INSTALLER_DIR/$INSTALLER_DIR.spec" \
     sed -e "s,@ALGORAND_PACKAGE_NAME@,$REQUIRED_ALGORAND_PACKAGE," \
         -e "s,@VER@,$FULLVERSION," \
         -e "s,@ARCH@,$ARCH," \


### PR DESCRIPTION
Regardless of the channel, the installer scripts are either located at algorand or algorand-devtools and do not include the channel name (hence, the package name shouldn't be used to construct the path).

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

## Changes

1. Other
    * Fix pathing issue to installer directory

## Test Plan

Standard release testing. Verify contents of binaries after build.

