### PR TITLE
Bug fix - revert change to grep recommended by shellcheck

### DIFF
--- a/scripts/release/forward_gpg_agent.sh
+++ b/scripts/release/forward_gpg_agent.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=2196
+
 # JENKINS=username@ip
 # JENKINS_KEY=location/to/jenkins/private_key.pem
 

--- a/scripts/release/forward_gpg_agent.sh
+++ b/scripts/release/forward_gpg_agent.sh
@@ -29,7 +29,7 @@ INSTANCE=$(ssh -i "$JENKINS_KEY" "$JENKINS" sudo cat /opt/jenkins/workspace/"$BR
 gpgp=$(find /usr/lib/gnupg{2,,1} -type f -name gpg-preset-passphrase 2> /dev/null)
 
 # Here we need to grab the signing subkey, hence `tail -1`.
-KEYGRIP=$(gpg -K --with-keygrip --textmode dev@algorand.com | grep -AE 1 '^ssb[^#]' | grep Keygrip | awk '{ print $3 }')
+KEYGRIP=$(gpg -K --with-keygrip --textmode dev@algorand.com | egrep -A 1 '^ssb[^#]' | grep Keygrip | awk '{ print $3 }')
 echo "enter dev@ password"
 $gpgp --verbose --preset "$KEYGRIP"
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

This script was modified to implement a suggestion from shellcheck. However, changing `egrep -A` to `grep -AE` doesn't work in Ubuntu 18.04.

## Test Plan

Verified that forward_gpg_agent.sh worked with this modification.