### PR TITLE
Fix heuristicFormatStr logic

### DIFF
--- a/cmd/goal/application.go
+++ b/cmd/goal/application.go
@@ -1048,17 +1048,7 @@ func jsonPrintable(str string) bool {
 }
 
 func heuristicFormatStr(str string) string {
-	// if it's a base32 address string which has a valid checksum, then make the assumption it's an address
-	if len(str) == 58 {
-		// try to decode the string and perform a checksum validation on it.
-		_, err := basics.UnmarshalChecksumAddress(str)
-		// if err is nil, then the checksum is valid
-		if err == nil {
-			return str
-		}
-	}
-
-	// otherwise, see if we can print it as a json output
+	// See if we can print it as a json output
 	if jsonPrintable(str) {
 		return str
 	}

--- a/cmd/goal/application.go
+++ b/cmd/goal/application.go
@@ -1048,11 +1048,13 @@ func jsonPrintable(str string) bool {
 }
 
 func heuristicFormatStr(str string) string {
-	// if it's a 32 byte string which has a valid checksum, then make the assumption it's an address
-	if len(str) == 32 {
-		addr, err := basics.UnmarshalChecksumAddress(str)
+	// if it's a base32 address string which has a valid checksum, then make the assumption it's an address
+	if len(str) == 58 {
+		// try to decode the string and perform a checksum validation on it.
+		_, err := basics.UnmarshalChecksumAddress(str)
+		// if err is nil, then the checksum is valid
 		if err == nil {
-			return addr.String()
+			return str
 		}
 	}
 

--- a/cmd/goal/application.go
+++ b/cmd/goal/application.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/spf13/cobra"
 
@@ -919,7 +920,7 @@ var deleteAppCmd = &cobra.Command{
 	},
 }
 
-func printable(str string) bool {
+func unicodePrintable(str string) bool {
 	for _, r := range str {
 		if !unicode.IsPrint(r) {
 			return false
@@ -928,17 +929,146 @@ func printable(str string) bool {
 	return true
 }
 
+func jsonPrintable(str string) bool {
+	// htmlSafeSet holds the value true if the ASCII character with the given
+	// array position can be safely represented inside a JSON string, embedded
+	// inside of HTML <script> tags, without any additional escaping.
+	//
+	// All values are true except for the ASCII control characters (0-31), the
+	// double quote ("), the backslash character ("\"), HTML opening and closing
+	// tags ("<" and ">"), and the ampersand ("&").
+	var htmlSafeSet = [utf8.RuneSelf]bool{
+		' ':      true,
+		'!':      true,
+		'"':      false,
+		'#':      true,
+		'$':      true,
+		'%':      true,
+		'&':      false,
+		'\'':     true,
+		'(':      true,
+		')':      true,
+		'*':      true,
+		'+':      true,
+		',':      true,
+		'-':      true,
+		'.':      true,
+		'/':      true,
+		'0':      true,
+		'1':      true,
+		'2':      true,
+		'3':      true,
+		'4':      true,
+		'5':      true,
+		'6':      true,
+		'7':      true,
+		'8':      true,
+		'9':      true,
+		':':      true,
+		';':      true,
+		'<':      false,
+		'=':      true,
+		'>':      false,
+		'?':      true,
+		'@':      true,
+		'A':      true,
+		'B':      true,
+		'C':      true,
+		'D':      true,
+		'E':      true,
+		'F':      true,
+		'G':      true,
+		'H':      true,
+		'I':      true,
+		'J':      true,
+		'K':      true,
+		'L':      true,
+		'M':      true,
+		'N':      true,
+		'O':      true,
+		'P':      true,
+		'Q':      true,
+		'R':      true,
+		'S':      true,
+		'T':      true,
+		'U':      true,
+		'V':      true,
+		'W':      true,
+		'X':      true,
+		'Y':      true,
+		'Z':      true,
+		'[':      true,
+		'\\':     false,
+		']':      true,
+		'^':      true,
+		'_':      true,
+		'`':      true,
+		'a':      true,
+		'b':      true,
+		'c':      true,
+		'd':      true,
+		'e':      true,
+		'f':      true,
+		'g':      true,
+		'h':      true,
+		'i':      true,
+		'j':      true,
+		'k':      true,
+		'l':      true,
+		'm':      true,
+		'n':      true,
+		'o':      true,
+		'p':      true,
+		'q':      true,
+		'r':      true,
+		's':      true,
+		't':      true,
+		'u':      true,
+		'v':      true,
+		'w':      true,
+		'x':      true,
+		'y':      true,
+		'z':      true,
+		'{':      true,
+		'|':      true,
+		'}':      true,
+		'~':      true,
+		'\u007f': true,
+	}
+
+	for _, r := range str {
+		if r >= utf8.RuneSelf {
+			return false
+		}
+		if htmlSafeSet[r] == false {
+			return false
+		}
+	}
+	return true
+}
+
 func heuristicFormatStr(str string) string {
-	if printable(str) {
+	// if it's a 32 byte string which has a valid checksum, then make the assumption it's an address
+	if len(str) == 32 {
+		addr, err := basics.UnmarshalChecksumAddress(str)
+		if err == nil {
+			return addr.String()
+		}
+	}
+
+	// otherwise, see if we can print it as a json output
+	if jsonPrintable(str) {
 		return str
 	}
 
+	// otherwise, see if it's a 32 byte string that could be printed as an address
 	if len(str) == 32 {
 		var addr basics.Address
 		copy(addr[:], []byte(str))
 		return addr.String()
 	}
 
+	// otherwise, use the default json formatter to output the byte array.
 	return str
 }
 

--- a/cmd/goal/interact.go
+++ b/cmd/goal/interact.go
@@ -128,7 +128,7 @@ func appSpecStringInvalid(s string) error {
 }
 
 func appSpecHelpStringInvalid(s string) error {
-	if !printable(s) {
+	if !unicodePrintable(s) {
 		return fmt.Errorf("%s is not Unicode printable", strconv.Quote(s))
 	}
 	return nil

--- a/data/basics/address.go
+++ b/data/basics/address.go
@@ -49,6 +49,8 @@ func (addr Address) GetUserAddress() string {
 }
 
 // UnmarshalChecksumAddress tries to unmarshal the checksummed address string.
+// Algorand strings addresses ( base32 encoded ) have a postamble which serves as the checksum of the address.
+// When converted to an Address object representation, that checksum is dropped (after validation).
 func UnmarshalChecksumAddress(address string) (Address, error) {
 	decoded, err := base32Encoder.DecodeString(address)
 

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -65,30 +65,30 @@ proc ::AlgorandGoal::Abort { ERROR } {
 proc ::AlgorandGoal::CheckProcessReturnedCode {ABORT} {
     upvar spawn_id spawn_id
     lassign [wait -i $spawn_id] PID SPAWNID OS_CODE ERR_CODE KILLED KILL_SIGNAL EXP
-
+    puts "CheckProcessReturnedCode vars PID = $PID SPAWNID = $SPAWNID OS_CODE = $OS_CODE ERR_CODE = $ERR_CODE KILLED = $KILLED KILL_SIGNAL = $KILL_SIGNAL EXP = $EXP"
     if {$KILLED == "CHILDKILLED"} {
-	if {$KILL_SIGNAL == "SIGHUP" && $EXP == "hangup"} {
-	    # this is caused by expect close. Will ignore.
-	    return 0
-	}
-	if {$ABORT} {
-	    ::AlgorandGoal::Abort "process killed: $KILL_SIGNAL $EXP"
-	}
-	return [list 1 $OS_CODE $ERR_CODE $KILLED $KILL_SIGNAL $EXP]
+        if {$KILL_SIGNAL == "SIGHUP" && $EXP == "hangup"} {
+            # this is caused by expect close. Will ignore.
+            return 0
+        }
+        if {$ABORT} {
+            ::AlgorandGoal::Abort "process killed: $KILL_SIGNAL $EXP"
+        }
+        return [list 1 $OS_CODE $ERR_CODE $KILLED $KILL_SIGNAL $EXP]
     }
 
     if {$OS_CODE == -1} {
-	if {$ABORT} {
-	    ::AlgorandGoal::Abort "OS error code: $ERR_CODE"
-	}
-	return [list 1 $OS_CODE $ERR_CODE $KILLED $KILL_SIGNAL $EXP]
+        if {$ABORT} {
+            ::AlgorandGoal::Abort "OS error code: $ERR_CODE"
+        }
+        return [list 1 $OS_CODE $ERR_CODE $KILLED $KILL_SIGNAL $EXP]
     } else {
-	if {$ERR_CODE != 0} {
-	    if {$ABORT} {
-		::AlgorandGoal::Abort "porcess returned non-zero value: $ERR_CODE"
-	    }
-	    return [list 1 $OS_CODE $ERR_CODE $KILLED $KILL_SIGNAL $EXP]
-	}
+        if {$ERR_CODE != 0} {
+            if {$ABORT} {
+                ::AlgorandGoal::Abort "porcess returned non-zero value: $ERR_CODE"
+            }
+            return [list 1 $OS_CODE $ERR_CODE $KILLED $KILL_SIGNAL $EXP]
+        }
     }
     return 0
 }

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -65,30 +65,30 @@ proc ::AlgorandGoal::Abort { ERROR } {
 proc ::AlgorandGoal::CheckProcessReturnedCode {ABORT} {
     upvar spawn_id spawn_id
     lassign [wait -i $spawn_id] PID SPAWNID OS_CODE ERR_CODE KILLED KILL_SIGNAL EXP
-    puts "CheckProcessReturnedCode vars PID = $PID SPAWNID = $SPAWNID OS_CODE = $OS_CODE ERR_CODE = $ERR_CODE KILLED = $KILLED KILL_SIGNAL = $KILL_SIGNAL EXP = $EXP"
+
     if {$KILLED == "CHILDKILLED"} {
-        if {$KILL_SIGNAL == "SIGHUP" && $EXP == "hangup"} {
-            # this is caused by expect close. Will ignore.
-            return 0
-        }
-        if {$ABORT} {
-            ::AlgorandGoal::Abort "process killed: $KILL_SIGNAL $EXP"
-        }
-        return [list 1 $OS_CODE $ERR_CODE $KILLED $KILL_SIGNAL $EXP]
+	if {$KILL_SIGNAL == "SIGHUP" && $EXP == "hangup"} {
+	    # this is caused by expect close. Will ignore.
+	    return 0
+	}
+	if {$ABORT} {
+	    ::AlgorandGoal::Abort "process killed: $KILL_SIGNAL $EXP"
+	}
+	return [list 1 $OS_CODE $ERR_CODE $KILLED $KILL_SIGNAL $EXP]
     }
 
     if {$OS_CODE == -1} {
-        if {$ABORT} {
-            ::AlgorandGoal::Abort "OS error code: $ERR_CODE"
-        }
-        return [list 1 $OS_CODE $ERR_CODE $KILLED $KILL_SIGNAL $EXP]
+	if {$ABORT} {
+	    ::AlgorandGoal::Abort "OS error code: $ERR_CODE"
+	}
+	return [list 1 $OS_CODE $ERR_CODE $KILLED $KILL_SIGNAL $EXP]
     } else {
-        if {$ERR_CODE != 0} {
-            if {$ABORT} {
-                ::AlgorandGoal::Abort "porcess returned non-zero value: $ERR_CODE"
-            }
-            return [list 1 $OS_CODE $ERR_CODE $KILLED $KILL_SIGNAL $EXP]
-        }
+	if {$ERR_CODE != 0} {
+	    if {$ABORT} {
+		::AlgorandGoal::Abort "porcess returned non-zero value: $ERR_CODE"
+	    }
+	    return [list 1 $OS_CODE $ERR_CODE $KILLED $KILL_SIGNAL $EXP]
+	}
     }
     return 0
 }


### PR DESCRIPTION
## Summary

The goalAppAccountAddressTest was randomally failing. The culprit was the heuristicFormatStr which was testing to see if the string is unicode printable before printing it out. To address this issue, I made two modifications by adding steps 1 and 2 below :
1. A byte array that corresponds to a checksumed address, would be printed as address.
2. A json formatteble string, would be printed as is.
3. A byte array that corresponds to a non-checksumed address, would be printed as address
4. The string would be printed as is.

Note that the checking if the byte array was printable was misleading : it was checking if it's a valid unicode string, instead of checking if it's a json string. I think that we might want to add another option for forcing a specific bytes output formatter, but that's already a separate issue.

## Test Plan

Existing (failing) test provides coverage for this use case.