### PR TITLE
Deprecate algolambdamsec environment variable

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/algorand/go-algorand/protocol"
@@ -832,15 +831,6 @@ func init() {
 	Consensus = make(ConsensusProtocols)
 
 	initConsensusProtocols()
-
-	// Allow tuning SmallLambda for faster consensus in single-machine e2e
-	// tests.  Useful for development.  This might make sense to fold into
-	// a protocol-version-specific setting, once we move SmallLambda into
-	// ConsensusParams.
-	algoSmallLambda, err := strconv.ParseInt(os.Getenv("ALGOSMALLLAMBDAMSEC"), 10, 64)
-	if err == nil {
-		Protocol.SmallLambda = time.Duration(algoSmallLambda) * time.Millisecond
-	}
 
 	// Set allocation limits
 	for _, p := range Consensus {

--- a/test/e2e-go/cli/goal/expect/catchpointCatchupTest.exp
+++ b/test/e2e-go/cli/goal/expect/catchpointCatchupTest.exp
@@ -71,8 +71,6 @@ if { [catch {
     set ::GLOBAL_TEST_ROOT_DIR $TEST_ROOT_DIR
     set ::GLOBAL_NETWORK_NAME $NETWORK_NAME
 
-    set ::env(ALGOSMALLLAMBDAMSEC) 500
-
     # Start the Primary Node
     ::AlgorandGoal::StartNode $TEST_ROOT_DIR/Primary
 

--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -19,7 +19,6 @@ package catchup
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -86,11 +85,6 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 	a := require.New(t)
 	log := logging.TestingLog(t)
 
-	if runtime.GOARCH == "amd64" {
-		// amd64 platforms are generally quite capable, so exceletate the round times to make the test run faster.
-		os.Setenv("ALGOSMALLLAMBDAMSEC", "500")
-	}
-
 	// Overview of this test:
 	// Start a two-node network (primary has 100%, secondary has 0%)
 	// Nodes are having a consensus allowing balances history of 32 rounds and transaction history of 33 rounds.
@@ -109,6 +103,12 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 	catchpointCatchupProtocol.SeedRefreshInterval = 8
 	catchpointCatchupProtocol.MaxBalLookback = 2 * catchpointCatchupProtocol.SeedLookback * catchpointCatchupProtocol.SeedRefreshInterval // 32
 	catchpointCatchupProtocol.MaxTxnLife = 33
+
+	if runtime.GOARCH == "amd64" {
+		// amd64 platforms are generally quite capable, so accelerate the round times to make the test run faster.
+		catchpointCatchupProtocol.AgreementFilterTimeoutPeriod0 = 1 * time.Second
+		catchpointCatchupProtocol.AgreementFilterTimeout = 1 * time.Second
+	}
 
 	consensus[consensusCatchpointCatchupTestProtocol] = catchpointCatchupProtocol
 

--- a/test/e2e-go/features/transactions/accountv2_test.go
+++ b/test/e2e-go/features/transactions/accountv2_test.go
@@ -17,7 +17,6 @@
 package transactions
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -39,13 +38,9 @@ func TestAccountInformationV2(t *testing.T) {
 	var fixture fixtures.RestClientFixture
 	proto, ok := config.Consensus[protocol.ConsensusFuture]
 	a.True(ok)
-	os.Setenv("ALGOSMALLLAMBDAMSEC", "200")
 	proto.AgreementFilterTimeoutPeriod0 = 400 * time.Millisecond
 	proto.AgreementFilterTimeout = 400 * time.Millisecond
 	fixture.SetConsensus(config.ConsensusProtocols{protocol.ConsensusFuture: proto})
-	defer func() {
-		os.Unsetenv("ALGOSMALLLAMBDAMSEC")
-	}()
 
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50EachFuture.json"))
 	defer fixture.Shutdown()

--- a/test/e2e-go/upgrades/application_support_test.go
+++ b/test/e2e-go/upgrades/application_support_test.go
@@ -17,8 +17,6 @@
 package upgrades
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -67,18 +65,7 @@ func makeApplicationUpgradeConsensus(t *testing.T) (appConsensus config.Consensu
 // to a version that supports applications. It verify that prior to supporting applications, the node would not accept
 // any application transaction and after the upgrade is complete, it would support that.
 func TestApplicationsUpgradeOverREST(t *testing.T) {
-	// set the small lambda to 500 for the duration of this test.
-	roundTimeMs := 500
-	lambda := os.Getenv("ALGOSMALLLAMBDAMSEC")
-	os.Setenv("ALGOSMALLLAMBDAMSEC", fmt.Sprintf("%d", roundTimeMs))
-	defer func() {
-		if lambda == "" {
-			os.Unsetenv("ALGOSMALLLAMBDAMSEC")
-		} else {
-			os.Setenv("ALGOSMALLLAMBDAMSEC", lambda)
-		}
-	}()
-
+	smallLambdaMs := 500
 	consensus := makeApplicationUpgradeConsensus(t)
 
 	var fixture fixtures.RestClientFixture
@@ -177,7 +164,7 @@ int 1
 		require.NoError(t, err)
 
 		require.Less(t, int64(time.Now().Sub(startLoopTime)), int64(3*time.Minute))
-		time.Sleep(time.Duration(roundTimeMs) * time.Millisecond)
+		time.Sleep(time.Duration(smallLambdaMs) * time.Millisecond)
 		round = curStatus.LastRound
 	}
 
@@ -291,18 +278,7 @@ int 1
 // to a version that supports applications. It verify that prior to supporting applications, the node would not accept
 // any application transaction and after the upgrade is complete, it would support that.
 func TestApplicationsUpgradeOverGossip(t *testing.T) {
-	// set the small lambda to 500 for the duration of this test.
-	roundTimeMs := 500
-	lambda := os.Getenv("ALGOSMALLLAMBDAMSEC")
-	os.Setenv("ALGOSMALLLAMBDAMSEC", fmt.Sprintf("%d", roundTimeMs))
-	defer func() {
-		if lambda == "" {
-			os.Unsetenv("ALGOSMALLLAMBDAMSEC")
-		} else {
-			os.Setenv("ALGOSMALLLAMBDAMSEC", lambda)
-		}
-	}()
-
+	smallLambdaMs := 500
 	consensus := makeApplicationUpgradeConsensus(t)
 
 	var fixture fixtures.RestClientFixture
@@ -436,7 +412,7 @@ int 1
 		require.NoError(t, err)
 
 		require.Less(t, int64(time.Now().Sub(startLoopTime)), int64(3*time.Minute))
-		time.Sleep(time.Duration(roundTimeMs) * time.Millisecond)
+		time.Sleep(time.Duration(smallLambdaMs) * time.Millisecond)
 		round = curStatus.LastRound
 	}
 

--- a/test/e2e-go/upgrades/rekey_support_test.go
+++ b/test/e2e-go/upgrades/rekey_support_test.go
@@ -17,8 +17,6 @@
 package upgrades
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -33,18 +31,7 @@ import (
 func TestRekeyUpgrade(t *testing.T) {
 	a := require.New(t)
 
-	// set the small lambda to 500 for the duration of this test.
-	roundTimeMs := 500
-	lambda := os.Getenv("ALGOSMALLLAMBDAMSEC")
-	os.Setenv("ALGOSMALLLAMBDAMSEC", fmt.Sprintf("%d", roundTimeMs))
-	defer func() {
-		if lambda == "" {
-			os.Unsetenv("ALGOSMALLLAMBDAMSEC")
-		} else {
-			os.Setenv("ALGOSMALLLAMBDAMSEC", lambda)
-		}
-	}()
-
+	smallLambdaMs := 500
 	consensus := makeApplicationUpgradeConsensus(t)
 
 	var fixture fixtures.RestClientFixture
@@ -108,7 +95,7 @@ func TestRekeyUpgrade(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Less(t, int64(time.Now().Sub(startLoopTime)), int64(3*time.Minute))
-		time.Sleep(time.Duration(roundTimeMs) * time.Millisecond)
+		time.Sleep(time.Duration(smallLambdaMs) * time.Millisecond)
 		round = curStatus.LastRound
 	}
 

--- a/test/e2e-go/upgrades/send_receive_upgrade_test.go
+++ b/test/e2e-go/upgrades/send_receive_upgrade_test.go
@@ -18,7 +18,6 @@ package upgrades
 
 import (
 	"math/rand"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -118,7 +117,7 @@ func generateFastUpgradeConsensus() (fastUpgradeProtocols config.ConsensusProtoc
 
 		fastUpgradeProtocols[consensusTestFastUpgrade(proto)] = fastParams
 
-		// support the ALGOSMALLLAMBDAMSEC = 500 env variable
+		// set the small lambda to 500 for the duration of dependent tests.
 		fastParams.AgreementFilterTimeout = time.Second
 		fastParams.AgreementFilterTimeoutPeriod0 = time.Second
 	}
@@ -128,7 +127,6 @@ func generateFastUpgradeConsensus() (fastUpgradeProtocols config.ConsensusProtoc
 func testAccountsCanSendMoneyAcrossUpgrade(t *testing.T, templatePath string) {
 	t.Parallel()
 	a := require.New(t)
-	os.Setenv("ALGOSMALLLAMBDAMSEC", "500")
 
 	consensus := generateFastUpgradeConsensus()
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Since we are now using AgreementFilterTimeout as a consensParam, we can remove the algolambdamsec environment variable from the codebase and eliminate that tech debt.

## Test Plan

Run unit tests again to make sure functionality still the same
