### PR TITLE
Correctly account for bloom filter binary marshaling size

### DIFF
--- a/rpcs/txService.go
+++ b/rpcs/txService.go
@@ -60,8 +60,8 @@ func base64PaddedSize(n int64) int64 {
 
 func makeTxService(pool PendingTxAggregate, genesisID string, txPoolSize int, responseSizeLimit int) *TxService {
 	// figure out how many bytes do we expect the bloom filter to be in the worst case scenario.
-	bloomRequestSizeBits, _ := bloom.Optimal(txPoolSize, bloomFilterFalsePositiveRate)
-	filterBytes := int64((bloomRequestSizeBits + 7) / 8) // convert bits -> bytes.
+	filterBytes := bloom.BinaryMarshalLength(txPoolSize, bloomFilterFalsePositiveRate)
+	// since the bloom filter is going to be base64 encoded, account for that as well.
 	filterPackedBytes := base64PaddedSize(filterBytes)
 	// The http transport add some additional content to the form ( form keys, separators, etc.)
 	// we need to account for these if we're trying to match the size in the worst case scenario.

--- a/util/bloom/bloom.go
+++ b/util/bloom/bloom.go
@@ -96,6 +96,14 @@ func (f *Filter) MarshalBinary() ([]byte, error) {
 	return data, nil
 }
 
+// BinaryMarshalLength returns the length of a binary marshaled filter ( in bytes ) using the
+// optimal configuration for the given number of elements with the desired false positive rate.
+func BinaryMarshalLength(numElements int, falsePositiveRate float64) int64 {
+	sizeBits, _ := Optimal(numElements, falsePositiveRate)
+	filterBytes := int64((sizeBits + 7) / 8) // convert bits -> bytes.
+	return filterBytes + 8                   // adding 8 to match 4 prefix array, plus 4 bytes for the numHashes uint32
+}
+
 // UnmarshalBinary restores the state of the filter from raw data
 func UnmarshalBinary(data []byte) (*Filter, error) {
 	f := &Filter{}


### PR DESCRIPTION
## Summary

The http read size limiter for the tx sync was not configured correctly, causing failures when bloom filter requests reached or were near capacity.

### Quick summary

The allowed body buffer read size should have been 8 bytes longer.

## Test Plan

Use the performance system, where the issue was found as a test bed.
