### PR TITLE
Add detailed error logging in case of failed blocks download

### DIFF
--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -466,7 +466,7 @@ func (cs *CatchpointCatchupService) processStageBlocksDownload() (err error) {
 				}
 				if attemptsCount <= uint64(cs.config.CatchupBlockDownloadRetryAttempts) {
 					// try again.
-					cs.log.Infof("Failed to download block %d. %v", topBlock.Round()-basics.Round(blocksFetched), err)
+					cs.log.Infof("Failed to download block %d on attempt %d out of %d. %v", topBlock.Round()-basics.Round(blocksFetched), attemptsCount, cs.config.CatchupBlockDownloadRetryAttempts, err)
 					continue
 				}
 				return cs.abort(fmt.Errorf("processStageBlocksDownload failed after multiple blocks download attempts"))

--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -466,6 +466,7 @@ func (cs *CatchpointCatchupService) processStageBlocksDownload() (err error) {
 				}
 				if attemptsCount <= uint64(cs.config.CatchupBlockDownloadRetryAttempts) {
 					// try again.
+					cs.log.Infof("Failed to download block %d. %v", topBlock.Round()-basics.Round(blocksFetched), err)
 					continue
 				}
 				return cs.abort(fmt.Errorf("processStageBlocksDownload failed after multiple blocks download attempts"))

--- a/catchup/httpFetcher.go
+++ b/catchup/httpFetcher.go
@@ -100,8 +100,13 @@ func (hf *HTTPFetcher) GetBlockBytes(ctx context.Context, r basics.Round) (data 
 		return nil, errNoBlockForRound
 	default:
 		hf.log.Warn("http block fetcher response status code : ", response.StatusCode)
-		response.Body.Close()
-		return nil, fmt.Errorf("GetBlockBytes error response status code %d", response.StatusCode)
+		bodyBytes, err := rpcs.ResponseBytes(response, hf.log, fetcherMaxBlockBytes)
+		if err == nil {
+			err = fmt.Errorf("GetBlockBytes error response status code %d when requesting '%s'. Response body '%s'", response.StatusCode, blockURL, string(bodyBytes))
+		} else {
+			err = fmt.Errorf("GetBlockBytes error response status code %d when requesting '%s'. %w", response.StatusCode, blockURL, err)
+		}
+		return nil, err
 	}
 
 	// at this point, we've already receieved the response headers. ensure that the


### PR DESCRIPTION
## Summary

Prior to this PR, a failed block download during `processStageBlocksDownload` would not get logged. Instead, it would retry to download the block following the configured `cs.config.CatchupBlockDownloadRetryAttempts` limits.

This PR adds an info logging in case of such a failure. The intent of this PR is to provide the node runner with the information about the download error so that she would be able to take concrete actions around that specific failure.

## Test Plan

Tested manually.