### PR TITLE
Bug fix - use DEFAULT_RELEASE_NETWORK genesis file in debian package

### DIFF
--- a/scripts/release/build/deb/build_deb.sh
+++ b/scripts/release/build/deb/build_deb.sh
@@ -62,7 +62,7 @@ if [[ ! "$PKG_NAME" =~ devtools ]]; then
         mkdir -p "$PKG_ROOT/var/lib/algorand/genesis/$dir"
         cp "./installer/genesis/$dir/genesis.json" "$PKG_ROOT/var/lib/algorand/genesis/$dir/genesis.json"
     done
-    cp "./installer/genesis/$DEFAULTNETWORK/genesis.json" "$PKG_ROOT/var/lib/algorand/genesis.json"
+    cp "./installer/genesis/$DEFAULT_RELEASE_NETWORK/genesis.json" "$PKG_ROOT/var/lib/algorand/genesis.json"
 
     # files should not be group writable but directories should be
     chmod -R g-w "$PKG_ROOT/var/lib/algorand"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

The current debian package will incorrectly package the testnet genesis file. This fix addresses that issue.

## Test Plan

Compile a release package and verify the genesis version.
