### PR TITLE
Extend expect timeout when checking account balance

### DIFF
--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -453,7 +453,7 @@ proc ::AlgorandGoal::WaitForAccountBalance { WALLET_NAME ACCOUNT_ADDRESS EXPECTE
                 puts "Account balance OK: $ACCOUNT_BALANCE"; break
             } else {
                puts "Account balance: '$ACCOUNT_BALANCE' does not match expected balance: '$EXPECTED_BALANCE'"
-               if { $i >= 10 } then { ::AlgorandGoal::Abort "Account balance $ACCOUNT_BALANCE does not match expected amount: $EXPECTED_BALANCE"; break;}
+               if { $i >= 20 } then { ::AlgorandGoal::Abort "Account balance $ACCOUNT_BALANCE does not match expected amount: $EXPECTED_BALANCE"; break;}
             }
         }
     } EXCEPTION ] } {

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -452,8 +452,8 @@ proc ::AlgorandGoal::WaitForAccountBalance { WALLET_NAME ACCOUNT_ADDRESS EXPECTE
             if { $ACCOUNT_BALANCE == $EXPECTED_BALANCE } {
                 puts "Account balance OK: $ACCOUNT_BALANCE"; break
             } else {
-               puts "Account balance: '$ACCOUNT_BALANCE' does not match expected balance: '$EXPECTED_BALANCE'"
-               if { $i >= 20 } then { ::AlgorandGoal::Abort "Account balance $ACCOUNT_BALANCE does not match expected amount: $EXPECTED_BALANCE"; break;}
+               puts "Account balance: '$ACCOUNT_BALANCE' does not match expected balance: '$EXPECTED_BALANCE', still waiting..."
+               if { $i >= 20 } then { ::AlgorandGoal::Abort "Account balance '$ACCOUNT_BALANCE' does not match expected amount: '$EXPECTED_BALANCE', waited too long, FAIL"; break;}
             }
         }
     } EXCEPTION ] } {


### PR DESCRIPTION

## Summary

Extend timeout for the Expect common function `WaitForAccountBalance` to wait for the account balance to reflect the expected amount.  Changed from 20 to 40 seconds.  

## Test Plan

Ran Integration tests.  
