### PR TITLE
remove expected ReadError events

### DIFF
--- a/network/requestLogger_test.go
+++ b/network/requestLogger_test.go
@@ -29,19 +29,21 @@ import (
 
 type eventsDetailsLogger struct {
 	logging.Logger
-	eventReceived chan struct{}
+	eventIdentifier telemetryspec.Event
+	eventReceived   chan struct{}
 }
 
 func (dl eventsDetailsLogger) EventWithDetails(category telemetryspec.Category, identifier telemetryspec.Event, details interface{}) {
-	if category == telemetryspec.Network && identifier == telemetryspec.HTTPRequestEvent {
+	if category == telemetryspec.Network && identifier == dl.eventIdentifier {
 		dl.eventReceived <- struct{}{}
+
 	}
 }
 
 // for two node network, check that B can ping A and get a reply
 func TestRequestLogger(t *testing.T) {
 	log := logging.TestingLog(t)
-	dl := eventsDetailsLogger{Logger: log, eventReceived: make(chan struct{}, 1)}
+	dl := eventsDetailsLogger{Logger: log, eventReceived: make(chan struct{}, 1), eventIdentifier: telemetryspec.HTTPRequestEvent}
 	log.SetLevel(logging.Level(defaultConfig.BaseLoggerDebugLevel))
 	netA := &WebsocketNetwork{
 		log:       dl,

--- a/network/requestLogger_test.go
+++ b/network/requestLogger_test.go
@@ -30,12 +30,12 @@ import (
 type eventsDetailsLogger struct {
 	logging.Logger
 	eventIdentifier telemetryspec.Event
-	eventReceived   chan struct{}
+	eventReceived   chan interface{}
 }
 
 func (dl eventsDetailsLogger) EventWithDetails(category telemetryspec.Category, identifier telemetryspec.Event, details interface{}) {
 	if category == telemetryspec.Network && identifier == dl.eventIdentifier {
-		dl.eventReceived <- struct{}{}
+		dl.eventReceived <- details
 
 	}
 }
@@ -43,7 +43,7 @@ func (dl eventsDetailsLogger) EventWithDetails(category telemetryspec.Category, 
 // for two node network, check that B can ping A and get a reply
 func TestRequestLogger(t *testing.T) {
 	log := logging.TestingLog(t)
-	dl := eventsDetailsLogger{Logger: log, eventReceived: make(chan struct{}, 1), eventIdentifier: telemetryspec.HTTPRequestEvent}
+	dl := eventsDetailsLogger{Logger: log, eventReceived: make(chan interface{}, 1), eventIdentifier: telemetryspec.HTTPRequestEvent}
 	log.SetLevel(logging.Level(defaultConfig.BaseLoggerDebugLevel))
 	netA := &WebsocketNetwork{
 		log:       dl,

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1950,23 +1950,15 @@ func (wn *WebsocketNetwork) peerRemoteClose(peer *wsPeer, reason disconnectReaso
 }
 
 func (wn *WebsocketNetwork) removePeer(peer *wsPeer, reason disconnectReason) {
-	var eventDetails telemetryspec.PeerEventDetails
-	var peerAddr string
-	var logEntry logging.Logger
-	var localAddr string
-	if reason == disconnectRequestReceived {
-		goto skipErrorLogging
-	}
-
 	// first logging, then take the lock and do the actual accounting.
 	// definitely don't change this to do the logging while holding the lock.
-	localAddr, _ = wn.Address()
-	logEntry = wn.log.With("event", "Disconnected").With("remote", peer.rootURL).With("local", localAddr)
+	localAddr, _ := wn.Address()
+	logEntry := wn.log.With("event", "Disconnected").With("remote", peer.rootURL).With("local", localAddr)
 	if peer.outgoing && peer.peerMessageDelay > 0 {
 		logEntry = logEntry.With("messageDelay", peer.peerMessageDelay)
 	}
 	logEntry.Infof("Peer %s disconnected: %s", peer.rootURL, reason)
-	peerAddr = peer.OriginAddress()
+	peerAddr := peer.OriginAddress()
 	// we might be able to get addr out of conn, or it might be closed
 	if peerAddr == "" && peer.conn != nil {
 		paddr := peer.conn.RemoteAddr()
@@ -1984,7 +1976,7 @@ func (wn *WebsocketNetwork) removePeer(peer *wsPeer, reason disconnectReason) {
 			peerAddr = justHost(peer.rootURL)
 		}
 	}
-	eventDetails = telemetryspec.PeerEventDetails{
+	eventDetails := telemetryspec.PeerEventDetails{
 		Address:      peerAddr,
 		HostName:     peer.TelemetryGUID,
 		Incoming:     !peer.outgoing,
@@ -2000,7 +1992,6 @@ func (wn *WebsocketNetwork) removePeer(peer *wsPeer, reason disconnectReason) {
 			Reason:           string(reason),
 		})
 
-skipErrorLogging:
 	peers.Set(float64(wn.NumPeers()), nil)
 	incomingPeers.Set(float64(wn.numIncomingPeers()), nil)
 	outgoingPeers.Set(float64(wn.numOutgoingPeers()), nil)

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1950,15 +1950,23 @@ func (wn *WebsocketNetwork) peerRemoteClose(peer *wsPeer, reason disconnectReaso
 }
 
 func (wn *WebsocketNetwork) removePeer(peer *wsPeer, reason disconnectReason) {
+	var eventDetails telemetryspec.PeerEventDetails
+	var peerAddr string
+	var logEntry logging.Logger
+	var localAddr string
+	if reason == disconnectRequestReceived {
+		goto skipErrorLogging
+	}
+
 	// first logging, then take the lock and do the actual accounting.
 	// definitely don't change this to do the logging while holding the lock.
-	localAddr, _ := wn.Address()
-	logEntry := wn.log.With("event", "Disconnected").With("remote", peer.rootURL).With("local", localAddr)
+	localAddr, _ = wn.Address()
+	logEntry = wn.log.With("event", "Disconnected").With("remote", peer.rootURL).With("local", localAddr)
 	if peer.outgoing && peer.peerMessageDelay > 0 {
 		logEntry = logEntry.With("messageDelay", peer.peerMessageDelay)
 	}
 	logEntry.Infof("Peer %s disconnected: %s", peer.rootURL, reason)
-	peerAddr := peer.OriginAddress()
+	peerAddr = peer.OriginAddress()
 	// we might be able to get addr out of conn, or it might be closed
 	if peerAddr == "" && peer.conn != nil {
 		paddr := peer.conn.RemoteAddr()
@@ -1976,7 +1984,7 @@ func (wn *WebsocketNetwork) removePeer(peer *wsPeer, reason disconnectReason) {
 			peerAddr = justHost(peer.rootURL)
 		}
 	}
-	eventDetails := telemetryspec.PeerEventDetails{
+	eventDetails = telemetryspec.PeerEventDetails{
 		Address:      peerAddr,
 		HostName:     peer.TelemetryGUID,
 		Incoming:     !peer.outgoing,
@@ -1992,6 +2000,7 @@ func (wn *WebsocketNetwork) removePeer(peer *wsPeer, reason disconnectReason) {
 			Reason:           string(reason),
 		})
 
+skipErrorLogging:
 	peers.Set(float64(wn.NumPeers()), nil)
 	incomingPeers.Set(float64(wn.numIncomingPeers()), nil)
 	outgoingPeers.Set(float64(wn.numOutgoingPeers()), nil)

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -1547,6 +1547,7 @@ func TestWebsocketNetworkMessageOfInterest(t *testing.T) {
 // Plan:
 // Network A will be sending messages to network B.
 // Network B will respond with another message for the first 4 messages. When it receive the 5th message, it would close the connection.
+// We want to get an event with disconnectRequestReceived
 func TestWebsocketDisconnection(t *testing.T) {
 	netA := makeTestWebsocketNode(t)
 	netA.config.GossipFanout = 1
@@ -1625,8 +1626,6 @@ func TestWebsocketDisconnection(t *testing.T) {
 		case telemetryspec.DisconnectPeerEventDetails:
 			require.Equal(t, disconnectPeerEventDetails.Reason, string(disconnectRequestReceived))
 		default:
-			// if we received a disconnection event because *we* disconnected this end, it's an error. We shouldn't have receive this event.
-
 			require.FailNow(t, "Unexpected event was send : %v", eventDetails)
 		}
 

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/logging/telemetryspec"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/util/metrics"
 )
@@ -1539,5 +1540,89 @@ func TestWebsocketNetworkMessageOfInterest(t *testing.T) {
 		} else {
 			require.Equal(t, 0, count)
 		}
+	}
+}
+
+// Set up two nodes, have one of them disconnect from the other, and monitor disconnection error on the side that did not issue the disconnection.
+// Plan:
+// Network A will be sending messages to network B.
+// Network B will respond with another message for the first 4 messages. When it receive the 5th message, it would close the connection.
+func TestWebsocketDisconnection(t *testing.T) {
+	netA := makeTestWebsocketNode(t)
+	netA.config.GossipFanout = 1
+	netA.config.EnablePingHandler = false
+	dl := eventsDetailsLogger{Logger: logging.TestingLog(t), eventReceived: make(chan struct{}, 1), eventIdentifier: telemetryspec.DisconnectPeerEvent}
+	netA.log = dl
+
+	netA.Start()
+	defer func() { t.Log("stopping A"); netA.Stop(); t.Log("A done") }()
+	netB := makeTestWebsocketNode(t)
+	netB.config.GossipFanout = 1
+	netB.config.EnablePingHandler = false
+	addrA, postListen := netA.Address()
+	require.True(t, postListen)
+	t.Log(addrA)
+	netB.phonebook.ReplacePeerList([]string{addrA}, "default")
+	netB.Start()
+	defer func() { t.Log("stopping B"); netB.Stop(); t.Log("B done") }()
+
+	msgHandlerA := func(msg IncomingMessage) (out OutgoingMessage) {
+		// if we received a message, send a message back.
+		if msg.Data[0]%10 == 2 {
+			netA.Broadcast(context.Background(), protocol.ProposalPayloadTag, []byte{msg.Data[0] + 8}, true, nil)
+		}
+		return
+	}
+
+	var msgCounterNetB uint32
+	msgHandlerB := func(msg IncomingMessage) (out OutgoingMessage) {
+		if atomic.AddUint32(&msgCounterNetB, 1) == 5 {
+			// disconnect
+			netB.DisconnectPeers()
+		} else {
+			// if we received a message, send a message back.
+			netB.Broadcast(context.Background(), protocol.ProposalPayloadTag, []byte{msg.Data[0] + 1}, true, nil)
+			netB.Broadcast(context.Background(), protocol.ProposalPayloadTag, []byte{msg.Data[0] + 2}, true, nil)
+		}
+		return
+	}
+
+	// register all the handlers.
+	taggedHandlersA := []TaggedMessageHandler{
+		TaggedMessageHandler{
+			Tag:            protocol.ProposalPayloadTag,
+			MessageHandler: HandlerFunc(msgHandlerA),
+		},
+	}
+	netA.ClearHandlers()
+	netA.RegisterHandlers(taggedHandlersA)
+
+	taggedHandlersB := []TaggedMessageHandler{
+		TaggedMessageHandler{
+			Tag:            protocol.ProposalPayloadTag,
+			MessageHandler: HandlerFunc(msgHandlerB),
+		},
+	}
+	netB.ClearHandlers()
+	netB.RegisterHandlers(taggedHandlersB)
+
+	readyTimeout := time.NewTimer(2 * time.Second)
+	waitReady(t, netA, readyTimeout.C)
+	waitReady(t, netB, readyTimeout.C)
+	netA.Broadcast(context.Background(), protocol.ProposalPayloadTag, []byte{0}, true, nil)
+	// wait until the peers disconnect.
+	for {
+		peers := netA.GetPeers(PeersConnectedIn)
+		if len(peers) == 0 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	select {
+	case <-dl.eventReceived:
+		// if we received a disconnection event because *we* disconnected this end, it's an error. We shouldn't have receive this event.
+		require.FailNow(t, "The DisconnectPeerEvent was send on the peer which was gracefully closed by the other end.")
+	default:
 	}
 }

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -115,6 +115,7 @@ const disconnectIdleConn disconnectReason = "IdleConnection"
 const disconnectSlowConn disconnectReason = "SlowConnection"
 const disconnectLeastPerformingPeer disconnectReason = "LeastPerformingPeer"
 const disconnectCliqueResolve disconnectReason = "CliqueResolving"
+const disconnectRequestReceived disconnectReason = "DisconnectRequest"
 
 // Response is the structure holding the response from the server
 type Response struct {
@@ -361,7 +362,11 @@ func dedupSafeTag(t protocol.Tag) bool {
 }
 
 func (wp *wsPeer) readLoop() {
-	defer wp.readLoopCleanup()
+	// the cleanupCloseError sets the default error to disconnectReadError; depending on the exit reason, the error might get changed.
+	cleanupCloseError := disconnectReadError
+	defer func() {
+		wp.readLoopCleanup(cleanupCloseError)
+	}()
 	wp.conn.SetReadLimit(maxMessageLength)
 	slurper := LimitedReaderSlurper{Limit: maxMessageLength}
 	for {
@@ -372,6 +377,7 @@ func (wp *wsPeer) readLoop() {
 				switch ce.Code {
 				case websocket.CloseNormalClosure, websocket.CloseGoingAway:
 					// deliberate close, no error
+					cleanupCloseError = disconnectRequestReceived
 					return
 				default:
 					// fall through to reportReadErr
@@ -515,8 +521,8 @@ func (wp *wsPeer) handleMessageOfInterest(msg IncomingMessage) (shutdown bool) {
 	return
 }
 
-func (wp *wsPeer) readLoopCleanup() {
-	wp.internalClose(disconnectReadError)
+func (wp *wsPeer) readLoopCleanup(reason disconnectReason) {
+	wp.internalClose(reason)
 	wp.wg.Done()
 }
 


### PR DESCRIPTION
## Summary

Avoid ReadError event & log entry in case the other side gracefully closed the websocket.
This is not an error, and should not be marked as such. Instead, we'll be using a new reason called 'DisconnectRequest'.

## Test Plan

Unit test added

## Linked Issues

This PR would provide a partial fix for #1543. Additional changes would be required.