### PR TITLE
Hot fix for fixing bad genesis file on 2.1.5 install

### DIFF
--- a/installer/debian/algorand/postinst
+++ b/installer/debian/algorand/postinst
@@ -39,7 +39,7 @@ fi
 if [ "$1" = "configure" ]; then
     if [ -f /var/lib/algorand/genesis.json-2.1.5-patch ]; then
         # 2.1.5 bug fix - restore user-modified genesis.json
-        mv /var/lib/algorand/genesis.json-2.1.5-patch /var/lib/algorand/genesis.json
+        mv -f /var/lib/algorand/genesis.json-2.1.5-patch /var/lib/algorand/genesis.json
     fi
 fi
 

--- a/installer/debian/algorand/postinst
+++ b/installer/debian/algorand/postinst
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 adduser --system --group --home /var/lib/algorand --no-create-home algorand >/dev/null
 # prior versions didn't create this group and adduser above won't create it if the algorand user exists
@@ -39,7 +39,7 @@ fi
 if [ "$1" = "configure" ]; then
     if [ -f /var/lib/algorand/genesis.json-2.1.5-patch ]; then
         # 2.1.5 bug fix - restore user-modified genesis.json
-        mv /var/lib/algorand/genesis.json{-2.1.5-patch,}
+        mv /var/lib/algorand/genesis.json-2.1.5-patch /var/lib/algorand/genesis.json
     fi
 fi
 

--- a/installer/debian/algorand/postinst
+++ b/installer/debian/algorand/postinst
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 adduser --system --group --home /var/lib/algorand --no-create-home algorand >/dev/null
 # prior versions didn't create this group and adduser above won't create it if the algorand user exists
@@ -35,3 +35,11 @@ if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-decon
 		deb-systemd-invoke $_dh_action algorand.service >/dev/null || true
 	fi
 fi
+
+if [ "$1" = "configure" ]; then
+    if [ -f /var/lib/algorand/genesis.json-2.1.5-patch ]; then
+        # 2.1.5 bug fix - restore user-modified genesis.json
+        mv /var/lib/algorand/genesis.json{-2.1.5-patch,}
+    fi
+fi
+

--- a/installer/debian/algorand/preinst
+++ b/installer/debian/algorand/preinst
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
+set -eo pipefail
+export BASHOPTS
 
 PKG_NAME=@PKG_NAME@
 

--- a/installer/debian/algorand/preinst
+++ b/installer/debian/algorand/preinst
@@ -39,7 +39,7 @@ then
                 ( "$ALGO_TIMESTAMP" = 1600456830 && ! -d /var/lib/algorand/mainnet-v1.0 ) ]]
             then
                 # 2.1.5 bug fix - back up user-modified genesis.json to restore after conffiles
-                cp -p /var/lib/algorand/genesis.json{,-2.1.5-patch}
+                cp -p /var/lib/algorand/genesis.json /var/lib/algorand/genesis.json-2.1.5-patch
             fi
         fi
 

--- a/installer/debian/algorand/preinst
+++ b/installer/debian/algorand/preinst
@@ -4,27 +4,45 @@ set -e
 
 PKG_NAME=@PKG_NAME@
 
-if [ "$1" != install ]
+if [ "$1" = install ]
 then
-    exit 0
+    if dpkg-query --list 'algorand*' &> /dev/null
+    then
+        if PKG_INFO=$(dpkg-query --show --showformat='${Package} ${Status}\n' 'algorand*' | grep "install ok installed")
+        then
+            # Filter out `algorand-indexer` and `algorand-devtools` packages, they are allowed to be
+            # installed alongside other `algorand` packages.
+            INSTALLED_PKG=$(grep -v -e algorand-indexer -e algorand-devtools <<< "$PKG_INFO" | awk '{print $1}')
+
+            if [ -n "$INSTALLED_PKG" ]
+            then
+                echo -e "\nAlgorand does not currently support multi-distribution installations!\n\
+        To install this package, it is necessary to first remove the \`$INSTALLED_PKG\` package:\n\n\
+        sudo apt-get remove $INSTALLED_PKG\n\
+        sudo apt-get install $PKG_NAME\n"
+                exit 1
+            fi
+        fi
+    fi
 fi
 
-if dpkg-query --list 'algorand*' &> /dev/null
+if [ "$1" = upgrade ]
 then
-    if PKG_INFO=$(dpkg-query --show --showformat='${Package} ${Status}\n' 'algorand*' | grep "install ok installed")
+    if [ -f /var/lib/algorand/genesis.json ]
     then
-        # Filter out `algorand-indexer` and `algorand-devtools` packages, they are allowed to be
-        # installed alongside other `algorand` packages.
-        INSTALLED_PKG=$(grep -v -e algorand-indexer -e algorand-devtools <<< "$PKG_INFO" | awk '{print $1}')
+        ALGO_MD5=$(md5sum /var/lib/algorand/genesis.json | awk '{print $1}')
+        ALGO_TIMESTAMP=$(stat -c %Y /var/lib/algorand/genesis.json)
 
-        if [ -n "$INSTALLED_PKG" ]
+        if [ "$ALGO_MD5" = "9afc34b96a2c4a9f936870cd26ae7873" ]
         then
-            echo -e "\nAlgorand does not currently support multi-distribution installations!\n\
-    To install this package, it is necessary to first remove the \`$INSTALLED_PKG\` package:\n\n\
-    sudo apt-get remove $INSTALLED_PKG\n\
-    sudo apt-get install $PKG_NAME\n"
-            exit 1
+            if [[ "$ALGO_TIMESTAMP" != 1600456830 ||
+                ( "$ALGO_TIMESTAMP" = 1600456830 && ! -d /var/lib/algorand/mainnet-v1.0 ) ]]
+            then
+                # 2.1.5 bug fix - back up user-modified genesis.json to restore after conffiles
+                cp -p /var/lib/algorand/genesis.json{,-2.1.5-patch}
+            fi
         fi
+
     fi
 fi
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

This tests the following scenarios:

1. MainNet debian user who upgraded to 2.1.5, and was moved to TestNet accidentally
2. TestNet debian user who upgraded to 2.1.5
3. MainNet debian user who installed 2.1.5 between Monday 2:30pm and Wednesday 12:00pm, and changed their genesis.json to MainNet
4. TestNet debian user who installed 2.1.5 between Monday 2:30pm and Wednesday 12:00pm


## Test Plan

Build package locally and run through each of the tests outlined above.
