### PR TITLE
more precise CompactCertWeightThreshold

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -326,16 +326,18 @@ type ConsensusParams struct {
 	// accounts and balances) in the critical path.
 	CompactCertVotersLookback uint64
 
-	// CompactCertWeightThreshold is the percentage of top voters weight
+	// CompactCertWeightThreshold specifies the fraction of top voters weight
 	// that must sign the message (block header) for security.  The compact
 	// certificate ensures this threshold holds; however, forming a valid
 	// compact certificate requires a somewhat higher number of signatures,
 	// and the more signatures are collected, the smaller the compact cert
 	// can be.
 	//
-	// This threshold can be thought of as the maximum percentage of
+	// This threshold can be thought of as the maximum fraction of
 	// malicious weight that compact certificates defend against.
-	CompactCertWeightThreshold uint64
+	//
+	// The threshold is computed as CompactCertWeightThreshold/(1<<32).
+	CompactCertWeightThreshold uint32
 
 	// CompactCertSecKQ is the security parameter (k+q) for the compact
 	// certificate scheme.
@@ -822,7 +824,7 @@ func initConsensusProtocols() {
 	vFuture.CompactCertRounds = 128
 	vFuture.CompactCertTopVoters = 1024 * 1024
 	vFuture.CompactCertVotersLookback = 16
-	vFuture.CompactCertWeightThreshold = 30
+	vFuture.CompactCertWeightThreshold = (1 << 32) * 30 / 100
 	vFuture.CompactCertSecKQ = 128
 
 	Consensus[protocol.ConsensusFuture] = vFuture

--- a/ledger/compactcert.go
+++ b/ledger/compactcert.go
@@ -64,17 +64,34 @@ func AcceptableCompactCertWeight(votersHdr bookkeeping.BlockHeader, firstValid b
 	}
 
 	// In the next proto.CompactCertRounds/2 blocks, linearly scale
-	// the acceptable weight from 100% to 0%.  If we are outside of
-	// that window, accept any weight.
-	if offset >= basics.Round(proto.CompactCertRounds/2) {
+	// the acceptable weight from 100% to CompactCertWeightThreshold.
+	// If we are outside of that window, accept any weight at or above
+	// CompactCertWeightThreshold.
+	provenWeight, overflowed := basics.Muldiv(total.ToUint64(), uint64(proto.CompactCertWeightThreshold), 1<<32)
+	if overflowed || provenWeight > total.ToUint64() {
+		// Shouldn't happen, but a safe fallback is to accept a larger cert.
+		logging.Base().Warnf("AcceptableCompactCertWeight(%d, %d, %d, %d) overflow provenWeight",
+			total, proto.CompactCertRounds, certRound, firstValid)
 		return 0
 	}
 
-	w, overflowed := basics.Muldiv(total.ToUint64(), proto.CompactCertRounds/2-uint64(offset), proto.CompactCertRounds/2)
+	if offset >= basics.Round(proto.CompactCertRounds/2) {
+		return provenWeight
+	}
+
+	scaledWeight, overflowed := basics.Muldiv(total.ToUint64()-provenWeight, proto.CompactCertRounds/2-uint64(offset), proto.CompactCertRounds/2)
 	if overflowed {
 		// Shouldn't happen, but a safe fallback is to accept a larger cert.
-		logging.Base().Warnf("AcceptableCompactCertWeight(%d, %d, %d, %d) overflow",
+		logging.Base().Warnf("AcceptableCompactCertWeight(%d, %d, %d, %d) overflow scaledWeight",
 			total, proto.CompactCertRounds, certRound, firstValid)
+		return 0
+	}
+
+	w, overflowed := basics.OAdd(provenWeight, scaledWeight)
+	if overflowed {
+		// Shouldn't happen, but a safe fallback is to accept a larger cert.
+		logging.Base().Warnf("AcceptableCompactCertWeight(%d, %d, %d, %d) overflow provenWeight (%d) + scaledWeight (%d)",
+			total, proto.CompactCertRounds, certRound, firstValid, provenWeight, scaledWeight)
 		return 0
 	}
 
@@ -104,9 +121,9 @@ func CompactCertParams(votersHdr bookkeeping.BlockHeader, hdr bookkeeping.BlockH
 	}
 
 	totalWeight := votersHdr.CompactCertVotersTotal.ToUint64()
-	provenWeight, overflowed := basics.Muldiv(totalWeight, proto.CompactCertWeightThreshold, 100)
+	provenWeight, overflowed := basics.Muldiv(totalWeight, uint64(proto.CompactCertWeightThreshold), 1<<32)
 	if overflowed {
-		err = fmt.Errorf("overflow computing provenWeight[%d]: %d * %d / 100",
+		err = fmt.Errorf("overflow computing provenWeight[%d]: %d * %d / (1<<32)",
 			hdr.Round, totalWeight, proto.CompactCertWeightThreshold)
 		return
 	}


### PR DESCRIPTION
Two related changes to how CompactCertWeightThreshold works:

1. For precision, treat it as a fraction of (1/2^32)ths, instead of a
   fraction of (1/100)ths.  This also makes the integer math easier to
   implement for other verifiers.

2. The decaying threshold of acceptable cert weights now goes from full
   (all signatures required) to CompactCertWeightThreshold, instead of
   going down to 0.  The 0 was meaningless anyway, because if a compact
   cert has less than CompactCertWeightThreshold of signatures, it would
   be rejected elsewhere.