### PR TITLE
Remove Travis token, which is not needed for open source repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/algorand/go-algorand.svg?token=25XP72ADqbCQJ3TJVC9S&branch=master)](https://travis-ci.com/algorand/go-algorand)
+[![Build Status](https://travis-ci.com/algorand/go-algorand.svg?branch=master)](https://travis-ci.com/algorand/go-algorand)
 
 go-algorand
 ====================

--- a/scripts/buildhost/README.md
+++ b/scripts/buildhost/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.com/algorand/go-algorand.svg?branch=master)](https://travis-ci.com/algorand/go-algorand)
-
 buildhost
 ====================
 
@@ -32,6 +30,7 @@ sudo cp 50-cloud-init.yaml 50-cloud-init.yaml.bak
 ```
 
  Merge the following into 50-cloud-init.yaml, while retaining the original mac address:
+ ```
 # This file is generated from information provided by
 # the datasource.  Changes to it will not persist across an instance.
 # To disable cloud-init's network configuration capabilities, write a file
@@ -50,6 +49,7 @@ network:
       interfaces: [ens3]
       macaddress: "02:2c:f9:9d:ec:04"
       dhcp4: true
+```
 
 run the following script:
 ```bash

--- a/scripts/buildhost/README.md
+++ b/scripts/buildhost/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/algorand/go-algorand.svg?token=25XP72ADqbCQJ3TJVC9S&branch=master)](https://travis-ci.com/algorand/go-algorand)
+[![Build Status](https://travis-ci.com/algorand/go-algorand.svg?branch=master)](https://travis-ci.com/algorand/go-algorand)
 
 buildhost
 ====================


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

A Travis token was included for a build status image, but this token is not needed for open source repositories.

## Test Plan

Just ensure build image continues to work for README.md and is removed from buildhost/README.md.
