### PR TITLE
bugfix: correct accounting of transactions in checkPendingQueueSize

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -248,7 +248,7 @@ func (pool *TransactionPool) pendingCountNoLock() int {
 // surpassed the size limit, we should be good to go.
 func (pool *TransactionPool) checkPendingQueueSize(txCount int) error {
 	pendingSize := pool.pendingTxIDsCount()
-	if pendingSize+txCount >= pool.txPoolMaxSize {
+	if pendingSize+txCount > pool.txPoolMaxSize {
 		return fmt.Errorf("TransactionPool.checkPendingQueueSize: transaction pool have reached capacity")
 	}
 	return nil

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -244,11 +244,11 @@ func (pool *TransactionPool) pendingCountNoLock() int {
 }
 
 // checkPendingQueueSize test to see if there is more room in the pending
-// group transaction list. As long as we haven't surpassed the size limit, we
-// should be good to go.
-func (pool *TransactionPool) checkPendingQueueSize() error {
+// group transaction list for additional txCount entries. As long as we haven't
+// surpassed the size limit, we should be good to go.
+func (pool *TransactionPool) checkPendingQueueSize(txCount int) error {
 	pendingSize := pool.pendingTxIDsCount()
-	if pendingSize >= pool.txPoolMaxSize {
+	if pendingSize+txCount >= pool.txPoolMaxSize {
 		return fmt.Errorf("TransactionPool.checkPendingQueueSize: transaction pool have reached capacity")
 	}
 	return nil
@@ -329,7 +329,7 @@ func (pool *TransactionPool) checkSufficientFee(txgroup []transactions.SignedTxn
 // Test performs basic duplicate detection and well-formedness checks
 // on a transaction group without storing the group.
 func (pool *TransactionPool) Test(txgroup []transactions.SignedTxn) error {
-	if err := pool.checkPendingQueueSize(); err != nil {
+	if err := pool.checkPendingQueueSize(len(txgroup)); err != nil {
 		return err
 	}
 
@@ -418,7 +418,7 @@ func (pool *TransactionPool) RememberOne(t transactions.SignedTxn, verifyParams 
 // Remember stores the provided transaction group.
 // Precondition: Only Remember() properly-signed and well-formed transactions (i.e., ensure t.WellFormed())
 func (pool *TransactionPool) Remember(txgroup []transactions.SignedTxn, verifyParams []verify.Params) error {
-	if err := pool.checkPendingQueueSize(); err != nil {
+	if err := pool.checkPendingQueueSize(len(txgroup)); err != nil {
 		return err
 	}
 

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -243,9 +243,10 @@ func (pool *TransactionPool) pendingCountNoLock() int {
 	return count
 }
 
-// checkPendingQueueSize test to see if there is more room in the pending
-// group transaction list for additional txCount entries. As long as we haven't
-// surpassed the size limit, we should be good to go.
+// checkPendingQueueSize tests to see if we can grow the pending group transaction list
+// by adding txCount more transactions. The limits comes from the total number of transactions
+// and not from the total number of transaction groups.
+// As long as we haven't surpassed the size limit, we should be good to go.
 func (pool *TransactionPool) checkPendingQueueSize(txCount int) error {
 	pendingSize := pool.pendingTxIDsCount()
 	if pendingSize+txCount > pool.txPoolMaxSize {

--- a/data/pools/transactionPool_test.go
+++ b/data/pools/transactionPool_test.go
@@ -1178,7 +1178,7 @@ func TestTxPoolSizeLimits(t *testing.T) {
 
 	receiver := addresses[1]
 
-	uniqueTxId := 0
+	uniqueTxID := 0
 	// almost fill the transaction pool, leaving room for one additional transaction group of the biggest size.
 	for i := 0; i <= cfg.TxPoolSize-config.Consensus[protocol.ConsensusCurrentVersion].MaxTxGroupSize; i++ {
 		tx := transactions.Transaction{
@@ -1188,7 +1188,7 @@ func TestTxPoolSizeLimits(t *testing.T) {
 				Fee:         basics.MicroAlgos{Raw: proto.MinTxnFee + 1},
 				FirstValid:  0,
 				LastValid:   10,
-				Note:        []byte{byte(uniqueTxId), byte(uniqueTxId >> 8), byte(uniqueTxId >> 16)},
+				Note:        []byte{byte(uniqueTxID), byte(uniqueTxID >> 8), byte(uniqueTxID >> 16)},
 				GenesisHash: ledger.GenesisHash(),
 			},
 			PaymentTxnFields: transactions.PaymentTxnFields{
@@ -1200,7 +1200,7 @@ func TestTxPoolSizeLimits(t *testing.T) {
 
 		// consume the transaction of allowed limit
 		require.NoError(t, transactionPool.RememberOne(signedTx, verify.Params{}))
-		uniqueTxId++
+		uniqueTxID++
 	}
 
 	for groupSize := config.Consensus[protocol.ConsensusCurrentVersion].MaxTxGroupSize; groupSize > 0; groupSize-- {
@@ -1215,7 +1215,7 @@ func TestTxPoolSizeLimits(t *testing.T) {
 					Fee:         basics.MicroAlgos{Raw: proto.MinTxnFee + 1},
 					FirstValid:  0,
 					LastValid:   10,
-					Note:        []byte{byte(uniqueTxId), byte(uniqueTxId >> 8), byte(uniqueTxId >> 16)},
+					Note:        []byte{byte(uniqueTxID), byte(uniqueTxID >> 8), byte(uniqueTxID >> 16)},
 					GenesisHash: ledger.GenesisHash(),
 				},
 				PaymentTxnFields: transactions.PaymentTxnFields{
@@ -1226,7 +1226,7 @@ func TestTxPoolSizeLimits(t *testing.T) {
 			signedTx := tx.Sign(secrets[0])
 			txgroup = append(txgroup, signedTx)
 			verifyParams = append(verifyParams, verify.Params{})
-			uniqueTxId++
+			uniqueTxID++
 		}
 
 		// ensure that we would fail adding this.


### PR DESCRIPTION
## Summary

The checkPendingQueueSize function is called per new transaction group that is being added to the transaction pool. Unfortunately, it tests whether a single entry can be added to the transaction pool, whereas it should have checked wether all the transaction included in the incoming transaction group would be able to fit into the transaction pool.


## Test Plan

Unit test added.
