### PR TITLE
add ascii filtering for remote requests logged data

### DIFF
--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -104,6 +104,10 @@ const maxMessageQueueDuration = 25 * time.Second
 // verify that their current outgoing message is not being blocked for too long.
 const slowWritingPeerMonitorInterval = 5 * time.Second
 
+// unprintableCharacterGlyph is used to replace any non-ascii character when logging incoming network string directly
+// to the log file. Note that the log file itself would also json-encode these before placing them in the log file.
+const unprintableCharacterGlyph = "▯"
+
 var networkIncomingConnections = metrics.MakeGauge(metrics.NetworkIncomingConnections)
 var networkOutgoingConnections = metrics.MakeGauge(metrics.NetworkOutgoingConnections)
 
@@ -1754,7 +1758,8 @@ func (wn *WebsocketNetwork) GetRoundTripper() http.RoundTripper {
 	return &wn.transport
 }
 
-// filterASCII filter out the non-ascii printable characters out of the given input string.
+// filterASCII filter out the non-ascii printable characters out of the given input string and
+// and replace these with unprintableCharacterGlyph.
 // It's used as a security qualifier before logging a network-provided data.
 // The function allows only characters in the range of [32..126], which excludes all the
 // control character, new lines, deletion, etc. All the alpha numeric and punctuation characters
@@ -1763,6 +1768,8 @@ func filterASCII(unfilteredString string) (filteredString string) {
 	for i, r := range unfilteredString {
 		if int(r) >= 0x20 && int(r) <= 0x7e {
 			filteredString += string(unfilteredString[i])
+		} else {
+			filteredString += unprintableCharacterGlyph
 		}
 	}
 	return

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -803,7 +803,7 @@ func (wn *WebsocketNetwork) setHeaders(header http.Header) {
 func (wn *WebsocketNetwork) checkServerResponseVariables(otherHeader http.Header, addr string) (bool, string) {
 	matchingVersion, otherVersion := wn.checkProtocolVersionMatch(otherHeader)
 	if matchingVersion == "" {
-		wn.log.Infof("new peer %s version mismatch, mine=%v theirs=%s, headers %#v", addr, SupportedProtocolVersions, otherVersion, otherHeader)
+		wn.log.Info(filterASCII(fmt.Sprintf("new peer %s version mismatch, mine=%v theirs=%s, headers %#v", addr, SupportedProtocolVersions, otherVersion, otherHeader)))
 		return false, ""
 	}
 	otherRandom := otherHeader.Get(NodeRandomHeader)
@@ -811,7 +811,7 @@ func (wn *WebsocketNetwork) checkServerResponseVariables(otherHeader http.Header
 		// This is pretty harmless and some configurations of phonebooks or DNS records make this likely. Quietly filter it out.
 		if otherRandom == "" {
 			// missing header.
-			wn.log.Warnf("new peer %s did not include random ID header in request. mine=%s headers %#v", addr, wn.RandomID, otherHeader)
+			wn.log.Warn(filterASCII(fmt.Sprintf("new peer %s did not include random ID header in request. mine=%s headers %#v", addr, wn.RandomID, otherHeader)))
 		} else {
 			wn.log.Debugf("new peer %s has same node random id, am I talking to myself? %s", addr, wn.RandomID)
 		}
@@ -820,7 +820,7 @@ func (wn *WebsocketNetwork) checkServerResponseVariables(otherHeader http.Header
 	otherGenesisID := otherHeader.Get(GenesisHeader)
 	if wn.GenesisID != otherGenesisID {
 		if otherGenesisID != "" {
-			wn.log.Warnf("new peer %#v genesis mismatch, mine=%#v theirs=%#v, headers %#v", addr, wn.GenesisID, otherGenesisID, otherHeader)
+			wn.log.Warn(filterASCII(fmt.Sprintf("new peer %#v genesis mismatch, mine=%#v theirs=%#v, headers %#v", addr, wn.GenesisID, otherGenesisID, otherHeader)))
 		} else {
 			wn.log.Warnf("new peer %#v did not include genesis header in response. mine=%#v headers %#v", addr, wn.GenesisID, otherHeader)
 		}

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1754,8 +1754,11 @@ func (wn *WebsocketNetwork) GetRoundTripper() http.RoundTripper {
 	return &wn.transport
 }
 
-// filterAscii filter out the non-ascii characters out of the given input string. It's used as a
-// security qualifier before logging a network-provided data.
+// filterASCII filter out the non-ascii printable characters out of the given input string.
+// It's used as a security qualifier before logging a network-provided data.
+// The function allows only characters in the range of [32..126], which excludes all the
+// control character, new lines, deletion, etc. All the alpha numeric and punctuation characters
+// are included in this range.
 func filterASCII(unfilteredString string) (filteredString string) {
 	for i, r := range unfilteredString {
 		if int(r) >= 0x20 && int(r) <= 0x7e {

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -1635,3 +1635,21 @@ func TestWebsocketDisconnection(t *testing.T) {
 		require.FailNow(t, "The DisconnectPeerEvent was missing")
 	}
 }
+
+// TestASCIIFiltering tests the behaviour of filterASCII by feeding it with few known inputs and verifying the expected outputs.
+func TestASCIIFiltering(t *testing.T) {
+	testUnicodePrintableStrings := []struct {
+		testString     string
+		expectedString string
+	}{
+		{"abc", "abc"},
+		{"", ""},
+		{"אבג", ""},
+		{"\u001b[31mABC\u001b[0m", "[31mABC[0m"},
+		{"ab\nc", "abc"},
+	}
+	for _, testElement := range testUnicodePrintableStrings {
+		outString := filterASCII(testElement.testString)
+		require.Equalf(t, testElement.expectedString, outString, "test string:%s", testElement.testString)
+	}
+}

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -1378,6 +1378,12 @@ func TestCheckProtocolVersionMatch(t *testing.T) {
 	matchingVersion, otherVersion = wn.checkProtocolVersionMatch(header3)
 	require.Equal(t, "", matchingVersion)
 	require.Equal(t, "3", otherVersion)
+
+	header4 := make(http.Header)
+	header4.Add(ProtocolVersionHeader, "5\n")
+	matchingVersion, otherVersion = wn.checkProtocolVersionMatch(header4)
+	require.Equal(t, "", matchingVersion)
+	require.Equal(t, "5", otherVersion)
 }
 
 func handleTopicRequest(msg IncomingMessage) (out OutgoingMessage) {
@@ -1652,4 +1658,76 @@ func TestASCIIFiltering(t *testing.T) {
 		outString := filterASCII(testElement.testString)
 		require.Equalf(t, testElement.expectedString, outString, "test string:%s", testElement.testString)
 	}
+}
+
+type callbackLogger struct {
+	logging.Logger
+	InfoCallback  func(...interface{})
+	InfofCallback func(string, ...interface{})
+	WarnCallback  func(...interface{})
+	WarnfCallback func(string, ...interface{})
+}
+
+func (cl callbackLogger) Info(args ...interface{}) {
+	cl.InfoCallback(args...)
+}
+func (cl callbackLogger) Infof(s string, args ...interface{}) {
+	cl.InfofCallback(s, args...)
+}
+
+func (cl callbackLogger) Warn(args ...interface{}) {
+	cl.WarnCallback(args...)
+}
+func (cl callbackLogger) Warnf(s string, args ...interface{}) {
+	cl.WarnfCallback(s, args...)
+}
+
+// TestMaliciousCheckServerResponseVariables test the checkServerResponseVariables to ensure it doesn't print the a malicious input without being filtered to the log file.
+func TestMaliciousCheckServerResponseVariables(t *testing.T) {
+	wn := makeTestWebsocketNode(t)
+	wn.GenesisID = "genesis-id1"
+	wn.RandomID = "random-id1"
+	wn.log = callbackLogger{
+		Logger: wn.log,
+		InfoCallback: func(args ...interface{}) {
+			s := fmt.Sprint(args...)
+			require.NotContains(t, s, "א")
+		},
+		InfofCallback: func(s string, args ...interface{}) {
+			s = fmt.Sprintf(s, args...)
+			require.NotContains(t, s, "א")
+		},
+		WarnCallback: func(args ...interface{}) {
+			s := fmt.Sprint(args...)
+			require.NotContains(t, s, "א")
+		},
+		WarnfCallback: func(s string, args ...interface{}) {
+			s = fmt.Sprintf(s, args...)
+			require.NotContains(t, s, "א")
+		},
+	}
+
+	header1 := http.Header{}
+	header1.Set(ProtocolVersionHeader, ProtocolVersion+"א")
+	header1.Set(NodeRandomHeader, wn.RandomID+"tag")
+	header1.Set(GenesisHeader, wn.GenesisID)
+	responseVariableOk, matchingVersion := wn.checkServerResponseVariables(header1, "addressX")
+	require.Equal(t, false, responseVariableOk)
+	require.Equal(t, "", matchingVersion)
+
+	header2 := http.Header{}
+	header2.Set(ProtocolVersionHeader, ProtocolVersion)
+	header2.Set("א", "א")
+	header2.Set(GenesisHeader, wn.GenesisID)
+	responseVariableOk, matchingVersion = wn.checkServerResponseVariables(header2, "addressX")
+	require.Equal(t, false, responseVariableOk)
+	require.Equal(t, "", matchingVersion)
+
+	header3 := http.Header{}
+	header3.Set(ProtocolVersionHeader, ProtocolVersion)
+	header3.Set(NodeRandomHeader, wn.RandomID+"tag")
+	header3.Set(GenesisHeader, wn.GenesisID+"א")
+	responseVariableOk, matchingVersion = wn.checkServerResponseVariables(header3, "addressX")
+	require.Equal(t, false, responseVariableOk)
+	require.Equal(t, "", matchingVersion)
 }

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -1383,7 +1383,7 @@ func TestCheckProtocolVersionMatch(t *testing.T) {
 	header4.Add(ProtocolVersionHeader, "5\n")
 	matchingVersion, otherVersion = wn.checkProtocolVersionMatch(header4)
 	require.Equal(t, "", matchingVersion)
-	require.Equal(t, "5", otherVersion)
+	require.Equal(t, "5"+unprintableCharacterGlyph, otherVersion)
 }
 
 func handleTopicRequest(msg IncomingMessage) (out OutgoingMessage) {
@@ -1650,9 +1650,9 @@ func TestASCIIFiltering(t *testing.T) {
 	}{
 		{"abc", "abc"},
 		{"", ""},
-		{"אבג", ""},
-		{"\u001b[31mABC\u001b[0m", "[31mABC[0m"},
-		{"ab\nc", "abc"},
+		{"אבג", unprintableCharacterGlyph + unprintableCharacterGlyph + unprintableCharacterGlyph},
+		{"\u001b[31mABC\u001b[0m", unprintableCharacterGlyph + "[31mABC" + unprintableCharacterGlyph + "[0m"},
+		{"ab\nc", "ab" + unprintableCharacterGlyph + "c"},
 	}
 	for _, testElement := range testUnicodePrintableStrings {
 		outString := filterASCII(testElement.testString)

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -434,7 +434,7 @@ func (wp *wsPeer) readLoop() {
 			}
 			requestHash, found := topics.GetValue(requestHashKey)
 			if !found {
-				wp.net.log.Warnf("wsPeer readLoop: message from %s is missing the %s", wp.conn.RemoteAddr().String(), filterASCII(requestHashKey))
+				wp.net.log.Warnf("wsPeer readLoop: message from %s is missing the %s", wp.conn.RemoteAddr().String(), requestHashKey)
 				continue
 			}
 			hashKey, _ := binary.Uvarint(requestHash)

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -434,7 +434,7 @@ func (wp *wsPeer) readLoop() {
 			}
 			requestHash, found := topics.GetValue(requestHashKey)
 			if !found {
-				wp.net.log.Warnf("wsPeer readLoop: message from %s is missing the %s", wp.conn.RemoteAddr().String(), requestHashKey)
+				wp.net.log.Warnf("wsPeer readLoop: message from %s is missing the %s", wp.conn.RemoteAddr().String(), filterASCII(requestHashKey))
 				continue
 			}
 			hashKey, _ := binary.Uvarint(requestHash)
@@ -543,7 +543,7 @@ func (wp *wsPeer) handleFilterMessage(msg IncomingMessage) {
 
 func (wp *wsPeer) writeLoopSend(msg sendMessage) (exit bool) {
 	if len(msg.data) > maxMessageLength {
-		wp.net.log.Errorf("trying to send a message longer than we would recieve: %d > %d tag=%#v", len(msg.data), maxMessageLength, string(msg.data[0:2]))
+		wp.net.log.Errorf("trying to send a message longer than we would recieve: %d > %d tag=%s", len(msg.data), maxMessageLength, string(msg.data[0:2]))
 		// just drop it, don't break the connection
 		return false
 	}


### PR DESCRIPTION
## Summary

Avoid logging raw data received from network in case of an error. Instead, filter the incoming data and ensure it's ASCII before logging it.

Note that unlike what mentioned in the issue, we were not really writing raw data to the log file directly. In all cases, the data was properly encoded as json strings. This PR ensure that we don't attempt to encode a non-ASCII characters into json strings.

## Test Plan

Unit tests added.

Resolves #1568