### PR TITLE
Adding support for KMD wallet password supplied as environment variable

### DIFF
--- a/cmd/diagcfg/messages.go
+++ b/cmd/diagcfg/messages.go
@@ -21,11 +21,11 @@ const (
 	loggingNotEnabled    = "Remote logging is currently disabled"
 	loggingEnabled       = "Remote logging is enabled.  Node = %s, Guid = %s\n"
 
-	metricNoConfig                          = "Unable to load configuration file : %s\n"
-	metricConfigReadingFailed               = "Failed to read configuration file : %s\n"
-	metricReportingStatus                   = "Metric reporting is %s\n"
-	metricSaveConfigFailed                  = "Metric configuration file could not be saved : %s\n"
-	metricDataDirectoryEmpty                = "no data directory was specified. Please use either -d or set environment variable ALGORAND_DATA"
+	metricNoConfig            = "Unable to load configuration file : %s\n"
+	metricConfigReadingFailed = "Failed to read configuration file : %s\n"
+	metricReportingStatus     = "Metric reporting is %s\n"
+	metricSaveConfigFailed    = "Metric configuration file could not be saved : %s\n"
+	metricDataDirectoryEmpty  = "no data directory was specified. Please use either -d or set environment variable ALGORAND_DATA"
 
 	telemetryConfigReadError = "Could not read telemetry config: %s\n"
 

--- a/cmd/goal/commands.go
+++ b/cmd/goal/commands.go
@@ -478,6 +478,10 @@ func getWalletHandleMaybePassword(dataDir string, walletName string, getPassword
 }
 
 func ensurePasswordForWallet(walletName string) []byte {
+	password, ok := os.LookupEnv("ALGORAND_KMD_PASSWORD")
+	if ok {
+		return []byte(password)
+	}
 	fmt.Printf(infoPasswordPrompt, walletName)
 	return ensurePassword()
 }

--- a/cmd/goal/commands_test.go
+++ b/cmd/goal/commands_test.go
@@ -31,26 +31,26 @@ func TestEnsureDataDirReturnsWhenDataDirIsProvided(t *testing.T) {
 	require.Equal(t, expectedDir, actualDir)
 }
 
-func TestEnsurePasswordWhenEnvironmentVariableIsProvided(t *testing.T) {
+func TestEnsurePasswordForWalletWhenEnvironmentVariableIsProvided(t *testing.T) {
 	expectedPassword := []byte("password")
 	os.Setenv("ALGORAND_KMD_PASSWORD", string(expectedPassword))
-	actualPassword := ensurePassword()
+	actualPassword := ensurePasswordForWallet("testwallet")
 	require.Equal(t, expectedPassword, actualPassword)
 }
 
-func TestEnsurePasswordWhenEnvironmentVariableIsProvidedButIncorrect(t *testing.T) {
+func TestEnsurePasswordForWalletWhenEnvironmentVariableIsProvidedButIncorrect(t *testing.T) {
 	incorrectPassword := []byte("incorrectpassword")
 	os.Setenv("ALGORAND_KMD_PASSWORD", "password")
-	actualPassword := ensurePassword()
+	actualPassword := ensurePasswordForWallet("testwallet")
 	require.NotEqual(t, incorrectPassword, actualPassword)
 }
 
-func TestEnsurePasswordWhenEnvironmentVariableIsNotProvided(t *testing.T) {
+func TestEnsurePasswordForWalletWhenEnvironmentVariableIsNotProvided(t *testing.T) {
 	if err := os.Unsetenv("ALGORAND_KMD_PASSWORD"); err != nil {
 		require.Error(t, err)
 	}
 	if os.Getenv("REAL_TEST") == "" {
-		cmd := exec.Command(os.Args[0], "-test.run=TestEnsurePasswordWhenEnvironmentVariableIsNotProvided")
+		cmd := exec.Command(os.Args[0], "-test.run=TestEnsurePasswordForWalletWhenEnvironmentVariableIsNotProvided")
 		cmd.Env = append(os.Environ(), "REAL_TEST=1")
 		err := cmd.Run()
 		e, ok := err.(*exec.ExitError)
@@ -59,5 +59,5 @@ func TestEnsurePasswordWhenEnvironmentVariableIsNotProvided(t *testing.T) {
 		require.Equal(t, "exit status 1", e.Error())
 		return
 	}
-	ensurePassword()
+	ensurePasswordForWallet("testwallet")
 }

--- a/daemon/algod/api/server/v2/utils.go
+++ b/daemon/algod/api/server/v2/utils.go
@@ -105,8 +105,6 @@ func computeCreatableIndexInPayset(tx node.TxnWithStatus, txnCounter uint64, pay
 	return &idx
 }
 
-
-
 // computeAssetIndexFromTxn returns the created asset index given a confirmed
 // transaction whose confirmation block is available in the ledger. Note that
 // 0 is an invalid asset index (they start at 1).
@@ -177,7 +175,6 @@ func computeAppIndexFromTxn(tx node.TxnWithStatus, l *data.Ledger) (aidx *uint64
 	return computeCreatableIndexInPayset(tx, blk.BlockHeader.TxnCounter, payset)
 }
 
-
 // getCodecHandle converts a format string into the encoder + content type
 func getCodecHandle(formatPtr *string) (codec.Handle, string, error) {
 	format := "json"
@@ -224,9 +221,9 @@ func stateDeltaToStateDelta(d basics.StateDelta) *generated.StateDelta {
 		return nil
 	}
 	var delta generated.StateDelta
-	for k, v:= range d {
+	for k, v := range d {
 		delta = append(delta, generated.EvalDeltaKeyValue{
-			Key:   base64.StdEncoding.EncodeToString([]byte(k)),
+			Key: base64.StdEncoding.EncodeToString([]byte(k)),
 			Value: generated.EvalDelta{
 				Action: uint64(v.Action),
 				Bytes:  strOrNil(base64.StdEncoding.EncodeToString([]byte(v.Bytes))),
@@ -249,10 +246,10 @@ func convertToDeltas(txn node.TxnWithStatus) (*[]generated.AccountStateDelta, *g
 			if k == 0 {
 				addr = txn.Txn.Txn.Sender.String()
 			} else {
-				if int(k - 1) < len(accounts) {
+				if int(k-1) < len(accounts) {
 					addr = txn.Txn.Txn.Accounts[k-1].String()
 				} else {
-					addr = fmt.Sprintf("Invalid Address Index: %d", k - 1)
+					addr = fmt.Sprintf("Invalid Address Index: %d", k-1)
 				}
 			}
 			d = append(d, generated.AccountStateDelta{

--- a/data/transactions/logic/debugger_test.go
+++ b/data/transactions/logic/debugger_test.go
@@ -17,8 +17,8 @@
 package logic
 
 import (
-	"os"
 	"encoding/base64"
+	"os"
 	"testing"
 
 	"github.com/algorand/go-algorand/data/basics"
@@ -160,7 +160,7 @@ func TestLineToPC(t *testing.T) {
 
 	dState.PCOffset = []PCOffset{{PC: 1, Offset: 0}}
 	pc = dState.LineToPC(1)
-	require.Equal(t, 0, pc)	
+	require.Equal(t, 0, pc)
 }
 
 func TestValueDeltaToValueDelta(t *testing.T) {

--- a/network/ping_test.go
+++ b/network/ping_test.go
@@ -60,7 +60,7 @@ func TestPing(t *testing.T) {
 		if lastPingRoundTripTime > 0 {
 			postPing := time.Now()
 			testTime := postPing.Sub(prePing)
-			if (lastPingRoundTripTime < testTime) {
+			if lastPingRoundTripTime < testTime {
 				// success
 				return
 			}


### PR DESCRIPTION
## Summary

Repeated usage of `goal` requires a password to be entered each time the wallet needs to be unlocked which introduces a friction for the user. This pull request allows the user to provide the wallet password in the environment variable `$ALGORAND_KMD_PASSWORD`.

## Security

Exposing passwords using environment variables is generally [safe](https://security.stackexchange.com/questions/14000/environment-variable-accessibility-in-linux/14009#14009) since the environment of a process is only available to the user (euid) running the process.

## Test Plan

Unit tests were written to account for three different use cases:

1. User provides correct password in the environment variable (should succeed)
2. User provides incorrect password in the environment variable (should fail)
3. User does not provide password in the environment variable (should exit with status code 1)

~~~~sh
$ go test ./cmd/goal -run 'TestEnsurePasswordForWallet.*'
ok      github.com/algorand/go-algorand/cmd/goal
~~~~

No integration tests are required at this stage but if this pull request is merged it can simplify other unit tests so that they don't have to depend on `expect`. 