### PR TITLE
Fix bug in TestGetBlockHTTP and TestGetBlockWS

### DIFF
--- a/catchup/fetcher_test.go
+++ b/catchup/fetcher_test.go
@@ -567,7 +567,7 @@ func (p *testHTTPPeer) GetHTTPPeer() network.HTTPPeer {
 
 func buildTestHTTPPeerSource(rootURLs ...string) *httpTestPeerSource {
 	peers := []network.Peer{}
-	for url := range rootURLs {
+	for _, url := range rootURLs {
 		peer := testHTTPPeer(url)
 		peers = append(peers, &peer)
 	}


### PR DESCRIPTION
## Summary

Fix uncovered bug in buildTestHTTPPeerSource implementation.
The following seems to create an issue for go 1.15.X, whereas it passes on go 1.14.X:
```
func buildTestHTTPPeerSource(rootURLs ...string) *httpTestPeerSource {
	for url := range rootURLs {
		...
	}
}
buildTestHTTPPeerSource()
```

In this case, the affect is no-op : since the function parameter list is always empty, the looping never executed. The call to testHTTPPeer(url) is bogus, but never noted since it's not being used.

## Test Plan

This is a unit test. Unit test was executed and working correctly.
