### PR TITLE
Simplify mule signing task

### DIFF
--- a/docker/build/cicd.ubuntu.Dockerfile
+++ b/docker/build/cicd.ubuntu.Dockerfile
@@ -3,7 +3,8 @@ ARG ARCH="amd64"
 FROM ${ARCH}/ubuntu:18.04
 ARG GOLANG_VERSION
 ARG ARCH="amd64"
-RUN apt-get update && apt-get install -y build-essential git libboost-all-dev wget sqlite3 autoconf jq bsdmainutils shellcheck
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y build-essential git libboost-all-dev wget sqlite3 autoconf jq bsdmainutils shellcheck awscli
 WORKDIR /root
 RUN wget https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH%v*}.tar.gz \
     && tar -xvf go${GOLANG_VERSION}.linux-${ARCH%v*}.tar.gz && \

--- a/package-sign.yaml
+++ b/package-sign.yaml
@@ -1,13 +1,17 @@
 agents:
   - name: deb
-    dockerFilePath: docker/build/mule.go.debian.Dockerfile
-    image: algorand/go-algorand-ci-mule-debian
+    dockerFilePath: docker/build/cicd.ubuntu.Dockerfile
+    image: algorand/cicd-ubuntu
     version: scripts/configure_dev-deps.sh
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
     env:
       - AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+      - BRANCH=$BRANCH
+      - CHANNEL=$CHANNEL
+      - USE_CACHE=$USE_CACHE
+      - VERSION=$VERSION
     volumes:
       - $XDG_RUNTIME_DIR/gnupg/S.gpg-agent:/root/.gnupg/S.gpg-agent
       - $HOME/.gnupg/pubring.kbx:/root/.gnupg/pubring.kbx
@@ -15,61 +19,12 @@ agents:
 
 tasks:
   - task: docker.Make
-    name: package-sign-deb
+    name: package-sign
     agent: deb
-    target: mule-sign-deb
-
-  - task: docker.Make
-    name: package-sign-rpm
-    agent: deb
-    target: mule-sign-rpm
-
-  - task: docker.Make
-    name: package-sign-tarball
-    agent: deb
-    target: mule-sign-tar.gz
-
-  - task: docker.Make
-    name: package-sign-source
-    agent: deb
-    target: mule-sign-source
-
-  - task: s3.DownloadFile
-    name: deb
-    bucketName: algorand-staging
-    objectName: releases/$CHANNEL/$VERSION/algorand_${CHANNEL}_${OS_TYPE}-${ARCH_TYPE}_${VERSION}.deb
-    outputDir: /projects/go-algorand/tmp/node_pkgs/${OS_TYPE}/${ARCH_TYPE}
-
-  - task: s3.DownloadFile
-    name: rpm
-    bucketName: algorand-staging
-    objectName: releases/$CHANNEL/$VERSION/algorand-${VERSION}-1.${ARCH_BIT}.rpm
-    outputDir: /projects/go-algorand/tmp/node_pkgs/${OS_TYPE}/${ARCH_TYPE}
-
-  - task: s3.DownloadFiles
-    name: tarball
-    bucketName: algorand-staging
-    prefix: releases/$CHANNEL/$VERSION
-    suffix: tar.gz
-    outputDir: /projects/go-algorand/tmp/node_pkgs/${OS_TYPE}/${ARCH_TYPE}
+    target: mule-sign
 
 jobs:
   package-sign:
     tasks:
-      - docker.Make.package-sign-deb
-      - docker.Make.package-sign-rpm
-      - docker.Make.package-sign-tarball
-      - docker.Make.package-sign-source
-
-  package-sign-setup-deb:
-    tasks:
-      - s3.DownloadFile.deb
-
-  package-sign-setup-rpm:
-    tasks:
-      - s3.DownloadFile.rpm
-
-  package-sign-setup-tarball:
-    tasks:
-      - s3.DownloadFiles.tarball
+      - docker.Make.package-sign
 

--- a/scripts/release/mule/Makefile.mule
+++ b/scripts/release/mule/Makefile.mule
@@ -53,9 +53,8 @@ mule-package-%:
 	echo Building algorand-devtools package...
 	scripts/release/mule/package/$(PKG_TYPE)/package.sh algorand-devtools
 
-mule-sign-%: PKG_TYPE=$*
-mule-sign-%:
-	scripts/release/mule/sign/sign.sh $(PKG_TYPE)
+mule-sign:
+	scripts/release/mule/sign/sign.sh
 
 mule-test-%: PKG_TYPE=$*
 mule-test-%:

--- a/scripts/release/mule/package/deb/package.sh
+++ b/scripts/release/mule/package/deb/package.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=2038,2045,2064
+# shellcheck disable=2038,2045,2064,2129
 
 set -ex
 
@@ -7,21 +7,22 @@ echo
 date "+build_release begin PACKAGE DEB stage %Y%m%d_%H%M%S"
 echo
 
-ARCH=$(./scripts/archtype.sh)
+ARCH_TYPE=$(./scripts/archtype.sh)
 OS_TYPE=$(./scripts/ostype.sh)
 BRANCH=${BRANCH:-$(./scripts/compute_branch.sh "$BRANCH")}
 CHANNEL=${CHANNEL:-$(./scripts/compute_branch_channel.sh "$BRANCH")}
-OUTDIR="./tmp/node_pkgs/$OS_TYPE/$ARCH"
+OUTDIR="./tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE"
 mkdir -p "$OUTDIR/bin"
-ALGO_BIN="./tmp/node_pkgs/$OS_TYPE/$ARCH/$CHANNEL/$OS_TYPE-$ARCH/bin"
-VER=${VERSION:-$(./scripts/compute_build_number.sh -f)}
+ALGO_BIN="./tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/$CHANNEL/$OS_TYPE-$ARCH_TYPE/bin"
+VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
 # A make target in Makefile.mule may pass the name as an argument.
 ALGORAND_PACKAGE_NAME=${1:-$(./scripts/compute_package_name.sh "$CHANNEL")}
+PKG_DIR="./tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE"
 
-echo "Building debian package for '${OS} - ${ARCH}'"
+echo "Building debian package for '$OS - $ARCH_TYPE'"
 
 DEFAULTNETWORK=$("./scripts/compute_branch_network.sh")
-DEFAULT_RELEASE_NETWORK=$("./scripts/compute_branch_release_network.sh" "${DEFAULTNETWORK}")
+DEFAULT_RELEASE_NETWORK=$("./scripts/compute_branch_release_network.sh" "$DEFAULTNETWORK")
 export DEFAULT_RELEASE_NETWORK
 
 PKG_ROOT=$(mktemp -d)
@@ -33,59 +34,59 @@ mkdir -p "${PKG_ROOT}/usr/bin"
 if [[ "$ALGORAND_PACKAGE_NAME" =~ devtools ]]; then
     BIN_FILES=("carpenter" "catchupsrv" "msgpacktool" "tealcut" "tealdbg")
     UNATTENDED_UPGRADES_FILE="53algorand-devtools-upgrades"
-    OUTPUT_DEB="$OUTDIR/algorand-devtools_${CHANNEL}_${OS_TYPE}-${ARCH}_${VER}.deb"
+    OUTPUT_DEB="$OUTDIR/algorand-devtools_${CHANNEL}_${OS_TYPE}-${ARCH_TYPE}_${VERSION}.deb"
     REQUIRED_ALGORAND_PKG=$("./scripts/compute_package_name.sh" "$CHANNEL")
 else
     BIN_FILES=("algocfg" "algod" "algoh" "algokey" "ddconfig.sh" "diagcfg" "goal" "kmd" "node_exporter")
     UNATTENDED_UPGRADES_FILE="51algorand-upgrades"
-    OUTPUT_DEB="$OUTDIR/algorand_${CHANNEL}_${OS_TYPE}-${ARCH}_${VER}.deb"
+    OUTPUT_DEB="$OUTDIR/algorand_${CHANNEL}_${OS_TYPE}-${ARCH_TYPE}_${VERSION}.deb"
 fi
 
 for binary in "${BIN_FILES[@]}"; do
-    cp "${ALGO_BIN}/${binary}" "${PKG_ROOT}"/usr/bin
-    chmod 755 "${PKG_ROOT}/usr/bin/${binary}"
+    cp "${ALGO_BIN}/$binary" "$PKG_ROOT/usr/bin"
+    chmod 755 "$PKG_ROOT/usr/bin/$binary"
 done
 
 if [[ ! "$ALGORAND_PACKAGE_NAME" =~ devtools ]]; then
-    mkdir -p "${PKG_ROOT}/usr/lib/algorand"
+    mkdir -p "$PKG_ROOT/usr/lib/algorand"
     lib_files=("updater" "find-nodes.sh")
     for lib in "${lib_files[@]}"; do
-        cp "${ALGO_BIN}/${lib}" "${PKG_ROOT}/usr/lib/algorand"
-        chmod g-w "${PKG_ROOT}/usr/lib/algorand/${lib}"
+        cp "$ALGO_BIN/$lib" "$PKG_ROOT/usr/lib/algorand"
+        chmod g-w "$PKG_ROOT/usr/lib/algorand/$lib"
     done
 
     data_files=("config.json.example" "system.json")
-    mkdir -p "${PKG_ROOT}/var/lib/algorand"
+    mkdir -p "$PKG_ROOT/var/lib/algorand"
     for data in "${data_files[@]}"; do
-        cp "installer/${data}" "${PKG_ROOT}/var/lib/algorand"
+        cp "installer/$data" "$PKG_ROOT/var/lib/algorand"
     done
 
     genesis_dirs=("devnet" "testnet" "mainnet" "betanet")
     for dir in "${genesis_dirs[@]}"; do
-        mkdir -p "${PKG_ROOT}/var/lib/algorand/genesis/${dir}"
-        cp "./installer/genesis/${dir}/genesis.json" "${PKG_ROOT}/var/lib/algorand/genesis/${dir}/genesis.json"
+        mkdir -p "$PKG_ROOT/var/lib/algorand/genesis/$dir"
+        cp "./installer/genesis/$dir/genesis.json" "$PKG_ROOT/var/lib/algorand/genesis/$dir/genesis.json"
     done
-    cp "./installer/genesis/${DEFAULT_RELEASE_NETWORK}/genesis.json" "${PKG_ROOT}/var/lib/algorand/genesis.json"
+    cp "./installer/genesis/$DEFAULT_RELEASE_NETWORK/genesis.json" "$PKG_ROOT/var/lib/algorand/genesis.json"
 
     # files should not be group writable but directories should be
-    chmod -R g-w "${PKG_ROOT}/var/lib/algorand"
-    find "${PKG_ROOT}/var/lib/algorand" -type d | xargs chmod g+w
+    chmod -R g-w "$PKG_ROOT/var/lib/algorand"
+    find "$PKG_ROOT/var/lib/algorand" -type d | xargs chmod g+w
 
     SYSTEMD_FILES=("algorand.service" "algorand@.service")
-    mkdir -p "${PKG_ROOT}/lib/systemd/system"
+    mkdir -p "$PKG_ROOT/lib/systemd/system"
     for svc in "${SYSTEMD_FILES[@]}"; do
-        cp "installer/${svc}" "${PKG_ROOT}/lib/systemd/system"
-        chmod 644 "${PKG_ROOT}/lib/systemd/system/${svc}"
+        cp "installer/$svc" "$PKG_ROOT/lib/systemd/system"
+        chmod 644 "$PKG_ROOT/lib/systemd/system/$svc"
     done
 fi
 
-mkdir -p "${PKG_ROOT}/etc/apt/apt.conf.d"
-cat <<EOF> "${PKG_ROOT}/etc/apt/apt.conf.d/${UNATTENDED_UPGRADES_FILE}"
+mkdir -p "$PKG_ROOT/etc/apt/apt.conf.d"
+cat << EOF > "$PKG_ROOT/etc/apt/apt.conf.d/$UNATTENDED_UPGRADES_FILE"
 ## This file is provided by the Algorand package to configure
 ## unattended upgrades for the Algorand node software.
 
 Unattended-Upgrade::Allowed-Origins {
-  "Algorand:${CHANNEL}";
+  "Algorand:$CHANNEL";
 };
 
 Dpkg::Options {
@@ -94,27 +95,27 @@ Dpkg::Options {
 };
 EOF
 
-mkdir -p "${PKG_ROOT}/DEBIAN"
+mkdir -p "$PKG_ROOT/DEBIAN"
 if [[ "$ALGORAND_PACKAGE_NAME" =~ devtools ]]; then
     INSTALLER_DIR="algorand-devtools"
 else
     INSTALLER_DIR=algorand
 fi
 # Can contain `control`, `preinst`, `postinst`, `prerm`, `postrm`, `conffiles`.
-CTL_FILES_DIR="installer/debian/${INSTALLER_DIR}"
+CTL_FILES_DIR="installer/debian/$INSTALLER_DIR"
 for ctl_file in $(ls "${CTL_FILES_DIR}"); do
     # Copy first, to preserve permissions, then overwrite to fill in template.
-    cp -a "${CTL_FILES_DIR}/${ctl_file}" "${PKG_ROOT}/DEBIAN/${ctl_file}"
-    < "${CTL_FILES_DIR}/${ctl_file}" \
-      sed -e "s,@ARCH@,${ARCH}," \
-          -e "s,@VER@,${VER}," \
+    cp -a "$CTL_FILES_DIR/$ctl_file" "$PKG_ROOT/DEBIAN/$ctl_file"
+    < "$CTL_FILES_DIR/$ctl_file" \
+      sed -e "s,@ARCH@,$ARCH_TYPE," \
+          -e "s,@VER@,$VERSION," \
           -e "s,@PKG_NAME@,$ALGORAND_PACKAGE_NAME," \
           -e "s,@REQUIRED_ALGORAND_PKG@,$REQUIRED_ALGORAND_PKG," \
-      > "${PKG_ROOT}/DEBIAN/${ctl_file}"
+      > "$PKG_ROOT/DEBIAN/$ctl_file"
 done
 
 # TODO: make `Files:` segments for vendor/... and crypto/libsodium-fork, but reasonably this should be understood to cover all _our_ files and copied in packages continue to be licenced under their own terms
-cat <<EOF> "${PKG_ROOT}/DEBIAN/copyright"
+cat << EOF > "$PKG_ROOT/DEBIAN/copyright"
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: Algorand
 Upstream-Contact: Algorand developers <dev@algorand.com>
@@ -125,11 +126,46 @@ Copyright: Algorand developers <dev@algorand.com>
 License: AGPL-3+
 EOF
 
-sed 's/^$/./g' < COPYING | sed 's/^/ /g' >> "${PKG_ROOT}/DEBIAN/copyright"
-mkdir -p "${PKG_ROOT}/usr/share/doc/${ALGORAND_PACKAGE_NAME}"
-cp -p "${PKG_ROOT}/DEBIAN/copyright" "${PKG_ROOT}/usr/share/doc/${ALGORAND_PACKAGE_NAME}/copyright"
+sed 's/^$/./g' < COPYING | sed 's/^/ /g' >> "$PKG_ROOT/DEBIAN/copyright"
+mkdir -p "$PKG_ROOT/usr/share/doc/$ALGORAND_PACKAGE_NAME"
+cp -p "$PKG_ROOT/DEBIAN/copyright" "$PKG_ROOT/usr/share/doc/$ALGORAND_PACKAGE_NAME/copyright"
 
-dpkg-deb --build "${PKG_ROOT}" "${OUTPUT_DEB}"
+dpkg-deb --build "$PKG_ROOT" "$OUTPUT_DEB"
+
+############################################################
+
+pushd "$PKG_DIR"
+
+STATUSFILE=build_status_${CHANNEL}_${VERSION}
+
+cat << EOF >> "$STATUSFILE"
+
+go version:
+EOF
+
+/usr/local/go/bin/go version >> "$STATUSFILE"
+
+############################################################
+
+cat << EOF >> "$STATUSFILE"
+
+go env:
+EOF
+
+/usr/local/go/bin/go env >> "$STATUSFILE"
+
+############################################################
+
+cat << EOF >> "$STATUSFILE"
+
+dpkg-l:
+EOF
+
+dpkg -l >> "$STATUSFILE"
+
+popd
+
+############################################################
 
 echo
 date "+build_release end PACKAGE DEB stage %Y%m%d_%H%M%S"

--- a/scripts/release/mule/sign/sign.sh
+++ b/scripts/release/mule/sign/sign.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=2035
+# shellcheck disable=2035,2129
 
 set -exo pipefail
 
@@ -7,7 +7,6 @@ echo
 date "+build_release begin SIGN stage %Y%m%d_%H%M%S"
 echo
 
-PKG_TYPE="$1"
 ARCH_BIT=$(uname -m)
 ARCH_TYPE=$(./scripts/archtype.sh)
 OS_TYPE=$(./scripts/ostype.sh)
@@ -16,75 +15,47 @@ BRANCH=${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
 CHANNEL=${CHANNEL:-$(./scripts/compute_branch_channel.sh "$BRANCH")}
 PKG_DIR="./tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE"
 SIGNING_KEY_ADDR=dev@algorand.com
+STATUSFILE="build_status_${CHANNEL}_${VERSION}"
+
+cd "$PKG_DIR"
 
 if ! $USE_CACHE
 then
-    export ARCH_BIT
-    export ARCH_TYPE
-    export CHANNEL
-    export OS_TYPE
-    export VERSION
+    # deb
+    aws s3 cp "s3://algorand-staging/releases/$CHANNEL/$VERSION/algorand_${CHANNEL}_${OS_TYPE}-${ARCH_TYPE}_${VERSION}.deb" .
+    aws s3 cp "s3://algorand-staging/releases/$CHANNEL/$VERSION/algorand-devtools_${CHANNEL}_${OS_TYPE}-${ARCH_TYPE}_${VERSION}.deb" .
 
-    if [ "$PKG_TYPE" == "tar.gz" ]
-    then
-        mule -f package-sign.yaml package-sign-setup-tarball
-    else
-        mule -f package-sign.yaml "package-sign-setup-$PKG_TYPE"
-    fi
+    # rpm
+    aws s3 cp "s3://algorand-staging/releases/$CHANNEL/$VERSION/algorand-${VERSION}-1.${ARCH_BIT}.rpm" .
+    aws s3 cp "s3://algorand-staging/releases/$CHANNEL/$VERSION/algorand-devtools-${VERSION}-1.${ARCH_BIT}.rpm" .
 fi
 
-make_hashes () {
-    # We need to futz a bit with "source" to make the hashes correct.
-    local HASH_TYPE=${1:-$PKG_TYPE}
-    local PACKAGE_TYPE=${2:-$PKG_TYPE}
+# TODO: "$PKG_TYPE" == "source"
 
-    HASHFILE="hashes_${CHANNEL}_${OS_TYPE}_${ARCH_TYPE}_${VERSION}_${HASH_TYPE}"
-    # Remove any previously-generated hashes.
-    rm -f "$HASHFILE"*
+# Clean package directory of any previous operations.
+rm -rf hashes* *.sig *.asc *.asc.gz
 
-    {
-        md5sum *"$VERSION"*."$PACKAGE_TYPE" ;
-        shasum -a 256 *"$VERSION"*."$PACKAGE_TYPE" ;
-        shasum -a 512 *"$VERSION"*."$PACKAGE_TYPE" ;
-    } >> "$HASHFILE"
+for file in *.tar.gz *.deb
+do
+    gpg -u "$SIGNING_KEY_ADDR" --detach-sign "$file"
+done
 
-    gpg -u "$SIGNING_KEY_ADDR" --detach-sign "$HASHFILE"
-    gpg -u "$SIGNING_KEY_ADDR" --clearsign "$HASHFILE"
-}
+for file in *.rpm
+do
+    gpg -u rpm@algorand.com --detach-sign "$file"
+done
 
-make_sigs () {
-    local PACKAGE_TYPE=${1:-$PKG_TYPE}
+HASHFILE=hashes_${CHANNEL}_${OS_TYPE}_${ARCH_TYPE}_${VERSION}
 
-    # Remove any previously-generated signatures.
-    rm -f ./*"$VERSION"*."$PACKAGE_TYPE".sig
+md5sum *.tar.gz *.deb *.rpm >> "$HASHFILE"
+shasum -a 256 *.tar.gz *.deb *.rpm >> "$HASHFILE"
+shasum -a 512 *.tar.gz *.deb *.rpm >> "$HASHFILE"
 
-    for item in *"$VERSION"*."$1"
-    do
-        gpg -u "$SIGNING_KEY_ADDR" --detach-sign "$item"
-    done
-}
+gpg -u "$SIGNING_KEY_ADDR" --detach-sign "$HASHFILE"
+gpg -u "$SIGNING_KEY_ADDR" --clearsign "$HASHFILE"
 
-pushd "$PKG_DIR"
-
-GPG_HOME_DIR=$(gpgconf --list-dirs | grep homedir | awk -F: '{ print $2 }')
-chmod 400 "$GPG_HOME_DIR"
-
-if [ "$PKG_TYPE" == "source" ]
-then
-    git archive --prefix="algorand-$FULLVERSION/" "$BRANCH" | gzip >| "$PKG_DIR/algorand_${CHANNEL}_source_${VERSION}.tar.gz"
-    make_sigs tar.gz
-    make_hashes source tar.gz
-else
-    if [ "$PKG_TYPE" == "rpm" ]
-    then
-        SIGNING_KEY_ADDR=rpm@algorand.com
-    fi
-
-    make_sigs "$PKG_TYPE"
-    make_hashes
-fi
-
-popd
+gpg -u "$SIGNING_KEY_ADDR" --clearsign "$STATUSFILE"
+gzip -c "$STATUSFILE.asc" > "$STATUSFILE.asc.gz"
 
 echo
 date "+build_release end SIGN stage %Y%m%d_%H%M%S"


### PR DESCRIPTION
## Summary

Simplify package signing by only having one task that signs all build artifacts instead of delineating them by type.

Note that there is some churn in `scripts/release/mule/package/deb/package.sh` because of the removal of the (unnecessary) brackets around the env vars, but it makes the script more readable (in my opinion).

## Test Plan

`mule -f package-sign.yaml package-sign`
