### PR TITLE
Update mule docs for new pipeline

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -47,6 +47,14 @@ jobs:
       - docker.Make.deb
       - docker.Make.rpm
 
+  package-deb:
+    tasks:
+      - docker.Make.deb
+
+  package-rpm:
+    tasks:
+      - docker.Make.rpm
+
   package-docker:
     tasks:
       - docker.Make.docker-image

--- a/package.yaml
+++ b/package.yaml
@@ -15,7 +15,7 @@ agents:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
     workDir: $HOME/projects/go-algorand
 
-  - name: docker-ubuntu
+  - name: docker
     dockerFilePath: docker/build/docker.ubuntu.Dockerfile
     image: algorand/go-algorand-docker-linux-ubuntu
     version: scripts/configure_dev-deps.sh
@@ -37,8 +37,8 @@ tasks:
     target: mule-package-deb
 
   - task: docker.Make
-    name: docker-image
-    agent: docker-ubuntu
+    name: docker
+    agent: docker
     target: mule-package-docker
 
 jobs:
@@ -46,6 +46,7 @@ jobs:
     tasks:
       - docker.Make.deb
       - docker.Make.rpm
+      - docker.Make.docker
 
   package-deb:
     tasks:
@@ -57,5 +58,5 @@ jobs:
 
   package-docker:
     tasks:
-      - docker.Make.docker-image
+      - docker.Make.docker
 

--- a/scripts/release/mule/README.md
+++ b/scripts/release/mule/README.md
@@ -1,0 +1,98 @@
+# Package Build Pipeline
+
+## Build Stages
+
+- [package](#package)
+- [upload](#upload)
+- [test](#test)
+- [sign](#sign)
+- [deploy](#deploy)
+
+## Environment Variables
+
+Each stage will have several environment variables automatically that are available to the stage. Depending on the stage, the environment variables may be exported to subprocesses.
+
+These env vars generally don't change between stages. Here is a list of variables that are computed if not passed on the CLI (more on that later):
+
+- `ARCH_TYPE`, i.e., `amd64`
+- `BRANCH`
+- `CHANNEL`
+- `OS_TYPE`
+- `VERSION`
+
+## package
+
+- see `./go-algorand/package.yaml`
+
+#### `mule` jobs
+
+    - package
+        + packages both `deb` and `rpm`
+
+    - package-deb
+        + packages only `deb`
+
+    - package-rpm:
+        + packages only `rpm`
+
+    - package-docker
+        + packages docker image
+
+## upload
+
+- see `./go-algorand/package-test.yaml`
+
+#### `mule` jobs
+
+    - package-upload
+
+## test
+
+- see `./go-algorand/package-test.yaml`
+
+- `ARCH_BIT`, i.e., the value from `uname -m`
+- `NETWORK`
+- `SHA`, i.e., the value from `git rev-parse HEAD` if not passed on CLI
+- `USE_CACHE`
+
+#### `mule` jobs
+
+    - package-test
+        + tests both `deb` and `rpm`
+
+    - package-test-deb
+        + tests only `deb`
+
+    - package-test-rpm
+        + tests only `rpm`
+
+## sign
+
+- see `./$go-algorand/package-sign.yaml`
+
+- `ARCH_BIT`, i.e., the value from `uname -m`
+- `USE_CACHE`
+
+### `mule` jobs
+
+    - package-sign
+        + signs both `deb` and `rpm`
+
+## deploy
+
+- see `./go-algorand/package-deploy.yaml`
+
+- `NETWORK`
+- `NO_DEPLOY`
+
+#### `mule` jobs
+
+    - package-deploy
+        + deploys both `deb` and `rpm`
+
+    - package-deploy-deb
+        + deploys only `deb`
+
+    - package-deploy-rpm
+        + deploys only `rpm`
+

--- a/scripts/release/mule/README.md
+++ b/scripts/release/mule/README.md
@@ -131,7 +131,7 @@ It is common that a custom build is performed on a feature branch other than `re
 
 The most common way to do this is to modify the environment that the subprocess inherits by specifying the values on the command *before* the command.  This won't need to be done for the package stage, but often needs to be done with subsequent stages.
 
-In order to be able to correctly run some of the stages, such as testing and signing, several values needed by the subsequent stages must to be explicitly passed to those stages.
+In order to be able to correctly run some of the stages, such as testing and signing, several values needed by the subsequent stages must be explicitly passed to those stages.
 
 > Verifying which env vars can be overridden is as simple as opening the `mule` yaml file for the respective stage and examining the list of env vars in the `agents`' `env` list.
 >

--- a/scripts/release/mule/README.md
+++ b/scripts/release/mule/README.md
@@ -47,6 +47,11 @@ These env vars generally don't change between stages. Here is a list of variable
 
 - see `./go-algorand/package-test.yaml`
 
+- customizable environment variables:
+
+    + `CHANNEL`
+    + `VERSION`
+
 #### `mule` jobs
 
     - package-upload
@@ -158,6 +163,10 @@ Let's look at some examples.
 ### Packaging
 
     mule -f package.yaml package
+
+### Uploading
+
+    VERSION=latest mule -f package-upload.yaml package-upload
 
 ### Testing
 

--- a/scripts/release/mule/README.md
+++ b/scripts/release/mule/README.md
@@ -1,16 +1,13 @@
 # Package Build Pipeline
 
-## Build Stages
+- [Environment Variables](#environment-variables)
+- [Build Stages](#build-stages)
+- [Custom Builds](#custom-builds)
+- [Examples](#examples)
 
-- [package](#package)
-- [upload](#upload)
-- [test](#test)
-- [sign](#sign)
-- [deploy](#deploy)
+# Environment Variables
 
-## Environment Variables
-
-Each stage will have several environment variables automatically that are available to the stage. Depending on the stage, the environment variables may be exported to subprocesses.
+Each stage listed in the next section will have several environment variables automatically that are available to the stage. Depending on the stage, the environment variables may be exported to subprocesses.
 
 These env vars generally don't change between stages. Here is a list of variables that are computed if not passed on the CLI (more on that later):
 
@@ -19,6 +16,14 @@ These env vars generally don't change between stages. Here is a list of variable
 - `CHANNEL`
 - `OS_TYPE`
 - `VERSION`
+
+# Build Stages
+
+- [package](#package)
+- [upload](#upload)
+- [test](#test)
+- [sign](#sign)
+- [deploy](#deploy)
 
 ## package
 
@@ -84,6 +89,7 @@ These env vars generally don't change between stages. Here is a list of variable
 
 - `NETWORK`
 - `NO_DEPLOY`
+- `PACKAGES_DIR`
 
 #### `mule` jobs
 
@@ -95,4 +101,85 @@ These env vars generally don't change between stages. Here is a list of variable
 
     - package-deploy-rpm
         + deploys only `rpm`
+
+# Custom Builds
+
+It is sometimes necessary to create packages after doing a local build.
+
+For instance, it is common that a custom build is performed on a feature branch other than `rel/stable` or `rel/beta`.  Also, the version will need to be specified.  In these instances, it is important to be able to pass values to the build process to customize a build.
+
+For example, the packaging build process would be starting as usual:
+
+```
+mule -f package.yaml package
+```
+
+This can produce packages like the following:
+
+```
+algorand_dev_linux-amd64_2.1.86615.deb
+algorand-devtools_dev_linux-amd64_2.1.86615.deb
+```
+
+In order to be able to correctly run some of the stages, such as testing and signing, several values needed by the subsequent stages must to be explicitly passed to those stages.
+
+Now, let's look at some examples.
+
+# Examples
+
+### Testing
+
+1. As part of the test suite, the `verify_package_string.sh` test needs the `BRANCH` as well as the `SHA`:
+
+```
+BRANCH=update_signing CHANNEL=dev SHA=aecd5318 VERSION=2.1.86615 mule -f package-test.yaml package-test
+```
+
+2. Test local packages on the filesystem because `USE_CACHE` is set to `true`. Note that the tests still expect the packages to be in the usual place, i.e., `./go-algorand/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/`.
+
+As this is the default behavior, `USE_CACHE` can be omitted.
+
+```
+BRANCH=update_signing CHANNEL=dev USE_CACHE=true VERSION=2.1.86615 mule -f package-test.yaml package-test
+```
+
+3. Download packages from `s3:algorand-staging:` and test.  `USE_CACHE` is set to `false`. This will download the packages to the usual place, i.e., `./go-algorand/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/`.
+
+Note that this is used to test a pending official release.
+
+```
+CHANNEL=beta USE_CACHE=false VERSION=2.1.6 mule -f package-test.yaml package-test
+```
+
+### Testing
+
+#1. Sign local packages on the filesystem because `USE_CACHE` is set to `true`. Note that the packages should be in the usual place, i.e., `./go-algorand/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/`.
+#
+#As this is the default behavior, `USE_CACHE` can be omitted.
+#
+#```
+#BRANCH=update_signing CHANNEL=dev USE_CACHE=true VERSION=2.1.86615 mule -f package-test.yaml package-test
+#```
+
+### Deploying
+
+1. Packages will be automatically downloaded from `s3:algorand-staging`. Each package will then be pushed to `s3:algorand-releases:`.
+
+```
+VERSION=2.1.6 mule -f package-deploy.yaml package-deploy
+```
+
+2. Packages are not downloaded from `s3:algorand-staging` but rather are copied from the location on the local filesystem specified by `PACKAGES_DIR` in the `mule` yaml file. Each package will then be pushed to `s3:algorand-releases:`.
+
+```
+PACKAGES_DIR=/packages_location/foo VERSION=2.1.86615 mule -f package-deploy.yaml package-deploy
+```
+
+3. `NO_DEPLOY` is set to `true`. Instead of automatically pushing to `s3:algorand-releases:`, this will copy the `rpmrepo` directory that was created in the container to the `WORKDIR` in the host environment (the `WORKDIR` is set in the `mule` yaml file).
+
+This is handy when testing a deployment and not yet ready to deploy.
+
+```
+NO_DEPLOY=true VERSION=2.1.6 mule -f package-deploy.yaml package-deploy
+```
 

--- a/scripts/release/mule/README.md
+++ b/scripts/release/mule/README.md
@@ -32,7 +32,7 @@ These env vars generally don't change between stages. Here is a list of variable
 #### `mule` jobs
 
     - package
-        + packages both `deb` and `rpm`
+        + packages `deb`, `rpm` and `docker`
 
     - package-deb
         + packages only `deb`

--- a/scripts/release/mule/README.md
+++ b/scripts/release/mule/README.md
@@ -108,6 +108,8 @@ It is sometimes necessary to create packages after doing a local build.
 
 For instance, it is common that a custom build is performed on a feature branch other than `rel/stable` or `rel/beta`.  Also, the version will need to be specified.  In these instances, it is important to be able to pass values to the build process to customize a build.
 
+The most common way to do this is to modify the environment that the subprocess inherits by specifying the values on the command *before* the command.  This won't need to be done for the package stage, but often needs to be done with subsequent stages.
+
 For example, the packaging build process would be starting as usual:
 
 ```
@@ -151,15 +153,21 @@ Note that this is used to test a pending official release.
 CHANNEL=beta USE_CACHE=false VERSION=2.1.6 mule -f package-test.yaml package-test
 ```
 
-### Testing
+### Signing
 
-#1. Sign local packages on the filesystem because `USE_CACHE` is set to `true`. Note that the packages should be in the usual place, i.e., `./go-algorand/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/`.
-#
-#As this is the default behavior, `USE_CACHE` can be omitted.
-#
-#```
-#BRANCH=update_signing CHANNEL=dev USE_CACHE=true VERSION=2.1.86615 mule -f package-test.yaml package-test
-#```
+1. Sign local packages on the filesystem because `USE_CACHE` is set to `true`. Note that the packages should be in the usual place, i.e., `./go-algorand/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/`.
+
+As this is the default behavior, `USE_CACHE` can be omitted.
+
+```
+CHANNEL=dev USE_CACHE=true VERSION=2.1.86615 mule -f package-sign.yaml package-sign
+```
+
+2. Download packages from `s3:algorand-staging:` and sign.  `USE_CACHE` is set to `false`. This will download the packages to the usual place, i.e., `./go-algorand/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/`.
+
+```
+CHANNEL=beta USE_CACHE=false VERSION=2.1.6 mule -f package-sign.yaml package-sign
+```
 
 ### Deploying
 

--- a/scripts/release/mule/README.md
+++ b/scripts/release/mule/README.md
@@ -73,7 +73,7 @@ These env vars generally don't change between stages. Here is a list of variable
 
 ## sign
 
-- see `./$go-algorand/package-sign.yaml`
+- see `./go-algorand/package-sign.yaml`
 
 - `ARCH_BIT`, i.e., the value from `uname -m`
 - `USE_CACHE`
@@ -129,65 +129,55 @@ Now, let's look at some examples.
 
 # Examples
 
+### Packaging
+
+    mule -f package.yaml package
+
 ### Testing
 
 1. As part of the test suite, the `verify_package_string.sh` test needs the `BRANCH` as well as the `SHA`:
 
-```
-BRANCH=update_signing CHANNEL=dev SHA=aecd5318 VERSION=2.1.86615 mule -f package-test.yaml package-test
-```
+        BRANCH=update_signing CHANNEL=dev SHA=aecd5318 VERSION=2.1.86615 mule -f package-test.yaml package-test
 
-2. Test local packages on the filesystem because `USE_CACHE` is set to `true`. Note that the tests still expect the packages to be in the usual place, i.e., `./go-algorand/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/`.
+1. Test local packages on the filesystem because `USE_CACHE` is set to `true`. Note that the tests still expect the packages to be in the usual place, i.e., `./go-algorand/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/`.
 
-As this is the default behavior, `USE_CACHE` can be omitted.
+    As this is the default behavior, `USE_CACHE` can be omitted.
 
-```
-BRANCH=update_signing CHANNEL=dev USE_CACHE=true VERSION=2.1.86615 mule -f package-test.yaml package-test
-```
+        BRANCH=update_signing CHANNEL=dev USE_CACHE=true VERSION=2.1.86615 mule -f package-test.yaml package-test
 
-3. Download packages from `s3:algorand-staging:` and test.  `USE_CACHE` is set to `false`. This will download the packages to the usual place, i.e., `./go-algorand/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/`.
+1. Download packages from `s3:algorand-staging:` and test.  `USE_CACHE` is set to `false`. This will download the packages to the usual place, i.e., `./go-algorand/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/`.
 
-Note that this is used to test a pending official release.
+    Note that this is used to test a pending official release.
 
-```
-CHANNEL=beta USE_CACHE=false VERSION=2.1.6 mule -f package-test.yaml package-test
-```
+        CHANNEL=beta USE_CACHE=false VERSION=2.1.6 mule -f package-test.yaml package-test
 
 ### Signing
 
 1. Sign local packages on the filesystem because `USE_CACHE` is set to `true`. Note that the packages should be in the usual place, i.e., `./go-algorand/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/`.
 
-As this is the default behavior, `USE_CACHE` can be omitted.
+    As this is the default behavior, `USE_CACHE` can be omitted.
 
-```
-CHANNEL=dev USE_CACHE=true VERSION=2.1.86615 mule -f package-sign.yaml package-sign
-```
+        CHANNEL=dev USE_CACHE=true VERSION=2.1.86615 mule -f package-sign.yaml package-sign
 
-2. Download packages from `s3:algorand-staging:` and sign.  `USE_CACHE` is set to `false`. This will download the packages to the usual place, i.e., `./go-algorand/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/`.
+1. Download packages from `s3:algorand-staging:` and sign.  `USE_CACHE` is set to `false`. This will download the packages to the usual place, i.e., `./go-algorand/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/`.
 
-```
-CHANNEL=beta USE_CACHE=false VERSION=2.1.6 mule -f package-sign.yaml package-sign
-```
+        CHANNEL=beta USE_CACHE=false VERSION=2.1.6 mule -f package-sign.yaml package-sign
 
 ### Deploying
 
 1. Packages will be automatically downloaded from `s3:algorand-staging`. Each package will then be pushed to `s3:algorand-releases:`.
 
-```
-VERSION=2.1.6 mule -f package-deploy.yaml package-deploy
-```
+    ```
+    VERSION=2.1.6 mule -f package-deploy.yaml package-deploy
+    ```
 
-2. Packages are not downloaded from `s3:algorand-staging` but rather are copied from the location on the local filesystem specified by `PACKAGES_DIR` in the `mule` yaml file. Each package will then be pushed to `s3:algorand-releases:`.
+1. Packages are not downloaded from `s3:algorand-staging` but rather are copied from the location on the local filesystem specified by `PACKAGES_DIR` in the `mule` yaml file. Each package will then be pushed to `s3:algorand-releases:`.
 
-```
-PACKAGES_DIR=/packages_location/foo VERSION=2.1.86615 mule -f package-deploy.yaml package-deploy
-```
+        PACKAGES_DIR=/packages_location/foo VERSION=2.1.86615 mule -f package-deploy.yaml package-deploy
 
-3. `NO_DEPLOY` is set to `true`. Instead of automatically pushing to `s3:algorand-releases:`, this will copy the `rpmrepo` directory that was created in the container to the `WORKDIR` in the host environment (the `WORKDIR` is set in the `mule` yaml file).
+1. `NO_DEPLOY` is set to `true`. Instead of automatically pushing to `s3:algorand-releases:`, this will copy the `rpmrepo` directory that was created in the container to the `WORKDIR` in the host environment (the `WORKDIR` is set in the `mule` yaml file).
 
-This is handy when testing a deployment and not yet ready to deploy.
+    This is handy when testing a deployment and not yet ready to deploy.
 
-```
-NO_DEPLOY=true VERSION=2.1.6 mule -f package-deploy.yaml package-deploy
-```
+        NO_DEPLOY=true VERSION=2.1.6 mule -f package-deploy.yaml package-deploy
 

--- a/scripts/release/mule/package/deb/package.sh
+++ b/scripts/release/mule/package/deb/package.sh
@@ -7,18 +7,18 @@ echo
 date "+build_release begin PACKAGE DEB stage %Y%m%d_%H%M%S"
 echo
 
-ARCH=$(./scripts/archtype.sh)
+ARCH_TYPE=$(./scripts/archtype.sh)
 OS_TYPE=$(./scripts/ostype.sh)
 BRANCH=${BRANCH:-$(./scripts/compute_branch.sh "$BRANCH")}
 CHANNEL=${CHANNEL:-$(./scripts/compute_branch_channel.sh "$BRANCH")}
-OUTDIR="./tmp/node_pkgs/$OS_TYPE/$ARCH"
+OUTDIR="./tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE"
 mkdir -p "$OUTDIR/bin"
-ALGO_BIN="./tmp/node_pkgs/$OS_TYPE/$ARCH/$CHANNEL/$OS_TYPE-$ARCH/bin"
-VER=${VERSION:-$(./scripts/compute_build_number.sh -f)}
+ALGO_BIN="./tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/$CHANNEL/$OS_TYPE-$ARCH_TYPE/bin"
+VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
 # A make target in Makefile.mule may pass the name as an argument.
 ALGORAND_PACKAGE_NAME=${1:-$(./scripts/compute_package_name.sh "$CHANNEL")}
 
-echo "Building debian package for '${OS} - ${ARCH}'"
+echo "Building debian package for '${OS} - ${ARCH_TYPE}'"
 
 DEFAULTNETWORK=$("./scripts/compute_branch_network.sh")
 DEFAULT_RELEASE_NETWORK=$("./scripts/compute_branch_release_network.sh" "${DEFAULTNETWORK}")
@@ -33,12 +33,12 @@ mkdir -p "${PKG_ROOT}/usr/bin"
 if [[ "$ALGORAND_PACKAGE_NAME" =~ devtools ]]; then
     BIN_FILES=("carpenter" "catchupsrv" "msgpacktool" "tealcut" "tealdbg")
     UNATTENDED_UPGRADES_FILE="53algorand-devtools-upgrades"
-    OUTPUT_DEB="$OUTDIR/algorand-devtools_${CHANNEL}_${OS_TYPE}-${ARCH}_${VER}.deb"
+    OUTPUT_DEB="$OUTDIR/algorand-devtools_${CHANNEL}_${OS_TYPE}-${ARCH_TYPE}_${VERSION}.deb"
     REQUIRED_ALGORAND_PKG=$("./scripts/compute_package_name.sh" "$CHANNEL")
 else
     BIN_FILES=("algocfg" "algod" "algoh" "algokey" "ddconfig.sh" "diagcfg" "goal" "kmd" "node_exporter")
     UNATTENDED_UPGRADES_FILE="51algorand-upgrades"
-    OUTPUT_DEB="$OUTDIR/algorand_${CHANNEL}_${OS_TYPE}-${ARCH}_${VER}.deb"
+    OUTPUT_DEB="$OUTDIR/algorand_${CHANNEL}_${OS_TYPE}-${ARCH_TYPE}_${VERSION}.deb"
 fi
 
 for binary in "${BIN_FILES[@]}"; do
@@ -106,8 +106,8 @@ for ctl_file in $(ls "${CTL_FILES_DIR}"); do
     # Copy first, to preserve permissions, then overwrite to fill in template.
     cp -a "${CTL_FILES_DIR}/${ctl_file}" "${PKG_ROOT}/DEBIAN/${ctl_file}"
     < "${CTL_FILES_DIR}/${ctl_file}" \
-      sed -e "s,@ARCH@,${ARCH}," \
-          -e "s,@VER@,${VER}," \
+      sed -e "s,@ARCH@,${ARCH_TYPE}," \
+          -e "s,@VER@,${VERSION}," \
           -e "s,@PKG_NAME@,$ALGORAND_PACKAGE_NAME," \
           -e "s,@REQUIRED_ALGORAND_PKG@,$REQUIRED_ALGORAND_PKG," \
       > "${PKG_ROOT}/DEBIAN/${ctl_file}"

--- a/scripts/release/mule/package/docker/package.sh
+++ b/scripts/release/mule/package/docker/package.sh
@@ -6,13 +6,13 @@ echo
 date "+build_release begin PACKAGE DOCKER stage %Y%m%d_%H%M%S"
 echo
 
-ARCH=$(./scripts/archtype.sh)
+ARCH_TYPE=$(./scripts/archtype.sh)
 OS_TYPE=$(./scripts/ostype.sh)
 BRANCH=${BRANCH:-$(./scripts/compute_branch.sh "$BRANCH")}
 CHANNEL=${CHANNEL:-$(./scripts/compute_branch_channel.sh "$BRANCH")}
-PKG_ROOT_DIR="./tmp/node_pkgs/$OS_TYPE/$ARCH"
-FULLVERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
-ALGOD_INSTALL_TAR_FILE="$PKG_ROOT_DIR/node_${CHANNEL}_${OS_TYPE}-${ARCH}_${FULLVERSION}.tar.gz"
+PKG_ROOT_DIR="./tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE"
+VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
+ALGOD_INSTALL_TAR_FILE="$PKG_ROOT_DIR/node_${CHANNEL}_${OS_TYPE}-${ARCH_TYPE}_${VERSION}.tar.gz"
 
 if [ -f "$ALGOD_INSTALL_TAR_FILE" ]; then
     echo "using install file $ALGOD_INSTALL_TAR_FILE"
@@ -22,7 +22,7 @@ else
 fi
 
 INPUT_ALGOD_TAR_FILE="temp_install.tar.gz"
-CHANNEL_VERSION="${CHANNEL}_${FULLVERSION}"
+CHANNEL_VERSION="${CHANNEL}_${VERSION}"
 NEW_PKG_DIR="algod_pkg_$CHANNEL_VERSION"
 DOCKER_EXPORT_FILE="algod_docker_export_$CHANNEL_VERSION.tar.gz"
 DOCKER_PKG_FILE="algod_docker_package_$CHANNEL_VERSION.tar.gz"

--- a/scripts/release/mule/package/rpm/package.sh
+++ b/scripts/release/mule/package/rpm/package.sh
@@ -11,7 +11,6 @@ VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
 BRANCH=${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
 CHANNEL=${CHANNEL:-$(./scripts/compute_branch_channel.sh "$BRANCH")}
 ALGO_BIN="$REPO_DIR/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/$CHANNEL/$OS_TYPE-$ARCH_TYPE/bin"
-# TODO: Should there be a default network?
 DEFAULTNETWORK=devnet
 DEFAULT_RELEASE_NETWORK=$(./scripts/compute_branch_release_network.sh "$DEFAULTNETWORK")
 

--- a/scripts/release/mule/package/rpm/package.sh
+++ b/scripts/release/mule/package/rpm/package.sh
@@ -5,12 +5,12 @@ set -ex
 echo "Building RPM package"
 
 REPO_DIR=$(pwd)
-ARCH=$(./scripts/archtype.sh)
+ARCH_TYPE=$(./scripts/archtype.sh)
 OS_TYPE=$(./scripts/ostype.sh)
-FULLVERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
+VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
 BRANCH=${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
 CHANNEL=${CHANNEL:-$(./scripts/compute_branch_channel.sh "$BRANCH")}
-ALGO_BIN="$REPO_DIR/tmp/node_pkgs/$OS_TYPE/$ARCH/$CHANNEL/$OS_TYPE-$ARCH/bin"
+ALGO_BIN="$REPO_DIR/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/$CHANNEL/$OS_TYPE-$ARCH_TYPE/bin"
 # TODO: Should there be a default network?
 DEFAULTNETWORK=devnet
 DEFAULT_RELEASE_NETWORK=$(./scripts/compute_branch_release_network.sh "$DEFAULTNETWORK")
@@ -40,12 +40,12 @@ fi
 trap 'rm -rf $TEMPDIR' 0
 < "./installer/rpm/$INSTALLER_DIR/$INSTALLER_DIR.spec" \
     sed -e "s,@PKG_NAME@,$ALGORAND_PACKAGE_NAME," \
-        -e "s,@VER@,$FULLVERSION," \
-        -e "s,@ARCH@,$ARCH," \
+        -e "s,@VER@,$VERSION," \
+        -e "s,@ARCH@,$ARCH_TYPE," \
         -e "s,@REQUIRED_ALGORAND_PKG@,$REQUIRED_ALGORAND_PACKAGE," \
     > "$TEMPDIR/$ALGORAND_PACKAGE_NAME.spec"
 
 rpmbuild --buildroot "$HOME/foo" --define "_rpmdir $RPMTMP" --define "RELEASE_GENESIS_PROCESS x$RELEASE_GENESIS_PROCESS" --define "LICENSE_FILE ./COPYING" -bb "$TEMPDIR/$ALGORAND_PACKAGE_NAME.spec"
 
-cp -p "$RPMTMP"/*/*.rpm "./tmp/node_pkgs/$OS_TYPE/$ARCH"
+cp -p "$RPMTMP"/*/*.rpm "./tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE"
 

--- a/scripts/release/mule/test/tests/post/verify_genesis_file.sh
+++ b/scripts/release/mule/test/tests/post/verify_genesis_file.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 echo "[$0] Testing network string in genesis.json"
 

--- a/scripts/release/mule/test/tests/post/verify_package_binaries.sh
+++ b/scripts/release/mule/test/tests/post/verify_package_binaries.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=2116
 
-set -e
+set -ex
 
 echo "[$0] Verifying installed binaries..."
 

--- a/scripts/release/mule/test/tests/post/verify_package_string.sh
+++ b/scripts/release/mule/test/tests/post/verify_package_string.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 echo "[$0] Testing: algod -v"
 

--- a/scripts/release/mule/test/tests/pre/verify_control_files.sh
+++ b/scripts/release/mule/test/tests/pre/verify_control_files.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=2035,2076
 
-set -e
+set -ex
 
 echo "[$0] Testing control files"
 


### PR DESCRIPTION
## Summary

Update `mule` docs for the new pipeline.

The changes in the other scripts are to reflect what appears in the docs, i.e.:

- `ARCH` becomes `ARCH_TYPE`
- `VER` or `FULLVERSION` becomes `VERSION`

Also, futzed with jobs in `package.yaml`.

## Test Plan

n/a
