### PR TITLE
Set content type header for health endpoint

### DIFF
--- a/daemon/algod/api/server/common/handlers.go
+++ b/daemon/algod/api/server/common/handlers.go
@@ -83,6 +83,7 @@ func HealthCheck(ctx lib.ReqContext, context echo.Context) {
 	//         description: OK.
 	//       default: { description: Unknown Error }
 	w := context.Response().Writer
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(nil)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

According to algod.oas2.json, the `/health` endpoint should return `application/json`, however that endpoint does not set the `Content-Type` header.

This became an issue when running tests for the Javascript SDK in the browser. Our HTTP request library behaves differently in the browser when the `Content-Type` is not JSON, which led to a bug there.

I don't imagine this change will break any consumers of the API, since the endpoint always returns `null`, which is valid JSON.

## Test Plan

I'm not aware of any tests specifically for the REST endpoints. If there are, let me know and I'll add a check there.
