### PR TITLE
Fix datarace in TestPing unit test

### DIFF
--- a/network/ping.go
+++ b/network/ping.go
@@ -28,7 +28,7 @@ func pingHandler(message IncomingMessage) OutgoingMessage {
 	if len(message.Data) > 8 {
 		return OutgoingMessage{}
 	}
-	message.Net.(*WebsocketNetwork).log.Debugf("ping from %#v", message.Sender)
+	message.Net.(*WebsocketNetwork).log.Debugf("ping from peer %#v", message.Sender.(*wsPeer).wsPeerCore)
 	peer := message.Sender.(*wsPeer)
 	tbytes := []byte(protocol.PingReplyTag)
 	mbytes := make([]byte, len(tbytes)+len(message.Data))


### PR DESCRIPTION
## Summary

Following the recent MOI change, the TestPing started to fail due to the race detector being triggered.
Investigation shown that the naive : 
```
Debugf("ping from %#v", message.Sender)
```

was the culprit. During the expression evaluation, the Debugf was accessing the `intermittentOutgoingMessageEnqueueTime` field in `wsPeer`, which was concurrently accessed by the `writeLoopSend` function. To resolve the issue, I've limited the printing to the `wsPeerCore` which doesn't have any synchronization primitives.

## Test Plan

This is a test