### PR TITLE
extend account lookup to include validity range

### DIFF
--- a/daemon/algod/api/server/v1/handlers/handlers.go
+++ b/daemon/algod/api/server/v1/handlers/handlers.go
@@ -738,7 +738,7 @@ func AccountInformation(ctx lib.ReqContext, context echo.Context) {
 		lib.ErrorResponse(w, http.StatusInternalServerError, err, errFailedLookingUpLedger, ctx.Log)
 		return
 	}
-	recordWithoutPendingRewards, err := ledger.LookupWithoutRewards(lastRound, basics.Address(addr))
+	recordWithoutPendingRewards, _, err := ledger.LookupWithoutRewards(lastRound, basics.Address(addr))
 	if err != nil {
 		lib.ErrorResponse(w, http.StatusInternalServerError, err, errFailedLookingUpLedger, ctx.Log)
 		return

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -110,7 +110,7 @@ func (v2 *Handlers) AccountInformation(ctx echo.Context, address string, params 
 		return ctx.Blob(http.StatusOK, contentType, data)
 	}
 
-	recordWithoutPendingRewards, err := myLedger.LookupWithoutRewards(lastRound, addr)
+	recordWithoutPendingRewards, _, err := myLedger.LookupWithoutRewards(lastRound, addr)
 	if err != nil {
 		return internalError(ctx, err, errFailedLookingUpLedger, v2.Log)
 	}

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -366,11 +366,16 @@ func (au *accountUpdates) IsWritingCatchpointFile() bool {
 	}
 }
 
-// Lookup returns the account data for a given address at a given round. The withRewards indicates whether the
-// rewards should be added to the AccountData before returning. Note that the function doesn't update the account with the rewards,
-// even while it could return the AccoutData which represent the "rewarded" account data.
-func (au *accountUpdates) Lookup(rnd basics.Round, addr basics.Address, withRewards bool) (data basics.AccountData, err error) {
-	return au.lookupImpl(rnd, addr, withRewards, true /* take lock*/)
+// LookupWithRewards returns the account data for a given address at a given round.
+// Note that the function doesn't update the account with the rewards,
+// even while it does return the AccoutData which represent the "rewarded" account data.
+func (au *accountUpdates) LookupWithRewards(rnd basics.Round, addr basics.Address) (data basics.AccountData, err error) {
+	return au.lookupWithRewardsImpl(rnd, addr)
+}
+
+// LookupWithoutRewards returns the account data for a given address at a given round.
+func (au *accountUpdates) LookupWithoutRewards(rnd basics.Round, addr basics.Address) (data basics.AccountData, validThrough basics.Round, err error) {
+	return au.lookupWithoutRewardsImpl(rnd, addr, true /* take lock*/)
 }
 
 // ListAssets lists the assets by their asset index, limiting to the first maxResults
@@ -839,8 +844,8 @@ func (aul *accountUpdatesLedgerEvaluator) isDup(config.ConsensusParams, basics.R
 }
 
 // LookupWithoutRewards returns the account balance for a given address at a given round, without the reward
-func (aul *accountUpdatesLedgerEvaluator) LookupWithoutRewards(rnd basics.Round, addr basics.Address) (basics.AccountData, error) {
-	return aul.au.lookupImpl(rnd, addr, false /*no rewards*/, false /*don't sync*/)
+func (aul *accountUpdatesLedgerEvaluator) LookupWithoutRewards(rnd basics.Round, addr basics.Address) (basics.AccountData, basics.Round, error) {
+	return aul.au.lookupWithoutRewardsImpl(rnd, addr, false /*don't sync*/)
 }
 
 // GetCreatorForRound returns the asset/app creator for a given asset/app index at a given round
@@ -1439,15 +1444,12 @@ func (au *accountUpdates) newBlockImpl(blk bookkeeping.Block, delta StateDelta) 
 	au.voters.newBlock(blk.BlockHeader)
 }
 
-// lookupImpl returns the account data for a given address at a given round. The withRewards indicates whether the
-// rewards should be added to the AccountData before returning. Note that the function doesn't update the account with the rewards,
-// even while it could return the AccoutData which represent the "rewarded" account data.
-func (au *accountUpdates) lookupImpl(rnd basics.Round, addr basics.Address, withRewards, syncronized bool) (data basics.AccountData, err error) {
-	needUnlock := false
-	if syncronized {
-		au.accountsMu.RLock()
-		needUnlock = true
-	}
+// lookupWithRewardsImpl returns the account data for a given address at a given round.
+// The rewards are added to the AccountData before returning. Note that the function doesn't update the account with the rewards,
+// even while it does return the AccoutData which represent the "rewarded" account data.
+func (au *accountUpdates) lookupWithRewardsImpl(rnd basics.Round, addr basics.Address) (data basics.AccountData, err error) {
+	au.accountsMu.RLock()
+	needUnlock := true
 	defer func() {
 		if needUnlock {
 			au.accountsMu.RUnlock()
@@ -1456,6 +1458,7 @@ func (au *accountUpdates) lookupImpl(rnd basics.Round, addr basics.Address, with
 	var offset uint64
 	var rewardsProto config.ConsensusParams
 	var rewardsLevel uint64
+	withRewards := true
 	for {
 		currentDbRound := au.dbRound
 		currentDeltaLen := len(au.deltas)
@@ -1497,6 +1500,73 @@ func (au *accountUpdates) lookupImpl(rnd basics.Round, addr basics.Address, with
 			}
 		}
 
+		au.accountsMu.RUnlock()
+		needUnlock = false
+
+		var dbRound basics.Round
+		// No updates of this account in the in-memory deltas; use on-disk DB.
+		// The check in roundOffset() made sure the round is exactly the one
+		// present in the on-disk DB.  As an optimization, we avoid creating
+		// a separate transaction here, and directly use a prepared SQL query
+		// against the database.
+		data, dbRound, err = au.accountsq.lookup(addr)
+		if dbRound == currentDbRound {
+			return data, err
+		}
+
+		if dbRound < currentDbRound {
+			au.log.Errorf("accountUpdates.lookupWithRewardsImpl: database round %d is behind in-memory round %d", dbRound, currentDbRound)
+			return basics.AccountData{}, &StaleDatabaseRoundError{databaseRound: dbRound, memoryRound: currentDbRound}
+		}
+		au.accountsMu.RLock()
+		needUnlock = true
+		for currentDbRound >= au.dbRound && currentDeltaLen == len(au.deltas) {
+			au.accountsReadCond.Wait()
+		}
+	}
+}
+
+// lookupWithoutRewardsImpl returns the account data for a given address at a given round.
+func (au *accountUpdates) lookupWithoutRewardsImpl(rnd basics.Round, addr basics.Address, syncronized bool) (data basics.AccountData, validThrough basics.Round, err error) {
+	needUnlock := false
+	if syncronized {
+		au.accountsMu.RLock()
+		needUnlock = true
+	}
+	defer func() {
+		if needUnlock {
+			au.accountsMu.RUnlock()
+		}
+	}()
+	var offset uint64
+	for {
+		currentDbRound := au.dbRound
+		currentDeltaLen := len(au.deltas)
+		offset, err = au.roundOffset(rnd)
+		if err != nil {
+			return
+		}
+
+		// Check if this is the most recent round, in which case, we can
+		// use a cache of the most recent account state.
+		if offset == uint64(len(au.deltas)) {
+			macct, ok := au.accounts[addr]
+			if ok {
+				return macct.data, rnd, nil
+			}
+		} else {
+			// Check if the account has been updated recently.  Traverse the deltas
+			// backwards to ensure that later updates take priority if present.
+			for offset > 0 {
+				offset--
+				d, ok := au.deltas[offset][addr]
+				if ok {
+					// todo - at this point, we need to scan forward to determine the validity range.
+					return d.new, rnd, nil
+				}
+			}
+		}
+
 		if syncronized {
 			au.accountsMu.RUnlock()
 			needUnlock = false
@@ -1509,12 +1579,13 @@ func (au *accountUpdates) lookupImpl(rnd basics.Round, addr basics.Address, with
 		// against the database.
 		data, dbRound, err = au.accountsq.lookup(addr)
 		if dbRound == currentDbRound {
-			return data, err
+			// todo - at this point, we need to scan forward to determine the validity range.
+			return data, rnd, err
 		}
 		if syncronized {
 			if dbRound < currentDbRound {
-				au.log.Errorf("accountUpdates.lookupImpl: database round %d is behind in-memory round %d", dbRound, currentDbRound)
-				return basics.AccountData{}, &StaleDatabaseRoundError{databaseRound: dbRound, memoryRound: currentDbRound}
+				au.log.Errorf("accountUpdates.lookupWithoutRewardsImpl: database round %d is behind in-memory round %d", dbRound, currentDbRound)
+				return basics.AccountData{}, basics.Round(0), &StaleDatabaseRoundError{databaseRound: dbRound, memoryRound: currentDbRound}
 			}
 			au.accountsMu.RLock()
 			needUnlock = true
@@ -1523,8 +1594,8 @@ func (au *accountUpdates) lookupImpl(rnd basics.Round, addr basics.Address, with
 			}
 		} else {
 			// in non-sync mode, we don't wait since we already assume that we're syncronized.
-			au.log.Errorf("accountUpdates.lookupImpl: database round %d mismatching in-memory round %d", dbRound, currentDbRound)
-			return basics.AccountData{}, &MismatchingDatabaseRoundError{databaseRound: dbRound, memoryRound: currentDbRound}
+			au.log.Errorf("accountUpdates.lookupWithoutRewardsImpl: database round %d mismatching in-memory round %d", dbRound, currentDbRound)
+			return basics.AccountData{}, basics.Round(0), &MismatchingDatabaseRoundError{databaseRound: dbRound, memoryRound: currentDbRound}
 		}
 	}
 }

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1570,7 +1570,7 @@ func (au *accountUpdates) lookupWithoutRewardsImpl(rnd basics.Round, addr basics
 			// we've going to fall back to search in the database, but before doing so, we should
 			// update the rnd so that it would point to the end of the known delta range.
 			// ( that would give us the best validity range )
-			rnd = currentDbRound + basics.Round(currentDeltaLen-1)
+			rnd = currentDbRound + basics.Round(currentDeltaLen)
 		}
 
 		if syncronized {

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1481,14 +1481,14 @@ func (au *accountUpdates) lookupWithRewardsImpl(rnd basics.Round, addr basics.Ad
 			withRewards = false
 		}
 
-		// Check if this is the most recent round, in which case, we can
-		// use a cache of the most recent account state.
-		if offset == uint64(len(au.deltas)) {
-			macct, ok := au.accounts[addr]
-			if ok {
+		// check if we've had this address modified in the past rounds. ( i.e. if it's in the deltas )
+		macct, indeltas := au.accounts[addr]
+		if indeltas {
+			// Check if this is the most recent round, in which case, we can
+			// use a cache of the most recent account state.
+			if offset == uint64(len(au.deltas)) {
 				return macct.data, nil
 			}
-		} else {
 			// Check if the account has been updated recently.  Traverse the deltas
 			// backwards to ensure that later updates take priority if present.
 			for offset > 0 {

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1489,8 +1489,10 @@ func (au *accountUpdates) lookupWithRewardsImpl(rnd basics.Round, addr basics.Ad
 			if offset == uint64(len(au.deltas)) {
 				return macct.data, nil
 			}
-			// Check if the account has been updated recently.  Traverse the deltas
-			// backwards to ensure that later updates take priority if present.
+			// the account appears in the deltas, but we don't know if it appears in the
+			// delta range of [0..offset], so we'll need to check :
+			// Traverse the deltas backwards to ensure that later updates take
+			// priority if present.
 			for offset > 0 {
 				offset--
 				d, ok := au.deltas[offset][addr]
@@ -1547,8 +1549,11 @@ func (au *accountUpdates) lookupWithoutRewardsImpl(rnd basics.Round, addr basics
 			return
 		}
 
+		// check if we've had this address modified in the past rounds. ( i.e. if it's in the deltas )
 		macct, indeltas := au.accounts[addr]
 		if indeltas {
+			// Check if this is the most recent round, in which case, we can
+			// use a cache of the most recent account state.
 			if offset == uint64(len(au.deltas)) {
 				return macct.data, rnd, nil
 			}

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -156,14 +156,14 @@ func checkAcctUpdates(t *testing.T, au *accountUpdates, base basics.Round, lates
 	_, err := au.Totals(latest + 1)
 	require.Error(t, err)
 
-	_, err = au.Lookup(latest+1, randomAddress(), false)
+	_, _, err = au.LookupWithoutRewards(latest+1, randomAddress())
 	require.Error(t, err)
 
 	if base > 0 {
 		_, err := au.Totals(base - 1)
 		require.Error(t, err)
 
-		_, err = au.Lookup(base-1, randomAddress(), false)
+		_, _, err = au.LookupWithoutRewards(base-1, randomAddress())
 		require.Error(t, err)
 	}
 
@@ -189,7 +189,7 @@ func checkAcctUpdates(t *testing.T, au *accountUpdates, base basics.Round, lates
 			var totalOnline, totalOffline, totalNotPart uint64
 
 			for addr, data := range accts[rnd] {
-				d, err := au.Lookup(rnd, addr, false)
+				d, _, err := au.LookupWithoutRewards(rnd, addr)
 				require.NoError(t, err)
 				require.Equal(t, d, data)
 
@@ -220,7 +220,7 @@ func checkAcctUpdates(t *testing.T, au *accountUpdates, base basics.Round, lates
 			require.Equal(t, totals.Participating().Raw, totalOnline+totalOffline)
 			require.Equal(t, totals.All().Raw, totalOnline+totalOffline+totalNotPart)
 
-			d, err := au.Lookup(rnd, randomAddress(), false)
+			d, _, err := au.LookupWithoutRewards(rnd, randomAddress())
 			require.NoError(t, err)
 			require.Equal(t, d, basics.AccountData{})
 		}
@@ -711,14 +711,14 @@ func TestAcctUpdatesUpdatesCorrectness(t *testing.T) {
 			updates := make(map[basics.Address]accountDelta)
 			moneyAccountsExpectedAmounts = append(moneyAccountsExpectedAmounts, make([]uint64, len(moneyAccounts)))
 			toAccount := moneyAccounts[0]
-			toAccountDataOld, err := au.Lookup(i-1, toAccount, false)
+			toAccountDataOld, _, err := au.LookupWithoutRewards(i-1, toAccount)
 			require.NoError(t, err)
 			toAccountDataNew := toAccountDataOld
 
 			for j := 1; j < len(moneyAccounts); j++ {
 				fromAccount := moneyAccounts[j]
 
-				fromAccountDataOld, err := au.Lookup(i-1, fromAccount, false)
+				fromAccountDataOld, _, err := au.LookupWithoutRewards(i-1, fromAccount)
 				require.NoError(t, err)
 				require.Equalf(t, moneyAccountsExpectedAmounts[i-1][j], fromAccountDataOld.MicroAlgos.Raw, "Account index : %d\nRound number : %d", j, i)
 
@@ -747,7 +747,7 @@ func TestAcctUpdatesUpdatesCorrectness(t *testing.T) {
 					if checkRound < uint64(testback) {
 						continue
 					}
-					acct, err := au.Lookup(basics.Round(checkRound-uint64(testback)), moneyAccounts[j], false)
+					acct, _, err := au.LookupWithoutRewards(basics.Round(checkRound-uint64(testback)), moneyAccounts[j])
 					// we might get an error like "round 2 before dbRound 5", which is the success case, so we'll ignore it.
 					if err != nil {
 						// verify it's the expected error and not anything else.
@@ -791,7 +791,7 @@ func TestAcctUpdatesUpdatesCorrectness(t *testing.T) {
 		au.waitAccountsWriting()
 
 		for idx, addr := range moneyAccounts {
-			balance, err := au.Lookup(lastRound, addr, false)
+			balance, _, err := au.LookupWithoutRewards(lastRound, addr)
 			require.NoErrorf(t, err, "unable to retrieve balance for account idx %d %v", idx, addr)
 			if idx != 0 {
 				require.Equalf(t, 100*1000000-roundCount*(roundCount-1)/2, int(balance.MicroAlgos.Raw), "account idx %d %v has the wrong balance", idx, addr)

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -156,15 +157,18 @@ func checkAcctUpdates(t *testing.T, au *accountUpdates, base basics.Round, lates
 	_, err := au.Totals(latest + 1)
 	require.Error(t, err)
 
-	_, _, err = au.LookupWithoutRewards(latest+1, randomAddress())
+	var validThrough basics.Round
+	_, validThrough, err = au.LookupWithoutRewards(latest+1, randomAddress())
 	require.Error(t, err)
+	require.Equal(t, basics.Round(0), validThrough)
 
 	if base > 0 {
 		_, err := au.Totals(base - 1)
 		require.Error(t, err)
 
-		_, _, err = au.LookupWithoutRewards(base-1, randomAddress())
+		_, validThrough, err = au.LookupWithoutRewards(base-1, randomAddress())
 		require.Error(t, err)
+		require.Equal(t, basics.Round(0), validThrough)
 	}
 
 	roundsRanges := []struct {
@@ -189,9 +193,10 @@ func checkAcctUpdates(t *testing.T, au *accountUpdates, base basics.Round, lates
 			var totalOnline, totalOffline, totalNotPart uint64
 
 			for addr, data := range accts[rnd] {
-				d, _, err := au.LookupWithoutRewards(rnd, addr)
+				d, validThrough, err := au.LookupWithoutRewards(rnd, addr)
 				require.NoError(t, err)
 				require.Equal(t, d, data)
+				require.GreaterOrEqualf(t, uint64(validThrough), uint64(rnd), fmt.Sprintf("validThrough :%v\nrnd :%v\n", validThrough, rnd))
 
 				rewardsDelta := rewards[rnd] - d.RewardsBase
 				switch d.Status {
@@ -220,8 +225,9 @@ func checkAcctUpdates(t *testing.T, au *accountUpdates, base basics.Round, lates
 			require.Equal(t, totals.Participating().Raw, totalOnline+totalOffline)
 			require.Equal(t, totals.All().Raw, totalOnline+totalOffline+totalNotPart)
 
-			d, _, err := au.LookupWithoutRewards(rnd, randomAddress())
+			d, validThrough, err := au.LookupWithoutRewards(rnd, randomAddress())
 			require.NoError(t, err)
+			require.GreaterOrEqualf(t, uint64(validThrough), uint64(rnd), fmt.Sprintf("validThrough :%v\nrnd :%v\n", validThrough, rnd))
 			require.Equal(t, d, basics.AccountData{})
 		}
 	}
@@ -711,15 +717,17 @@ func TestAcctUpdatesUpdatesCorrectness(t *testing.T) {
 			updates := make(map[basics.Address]accountDelta)
 			moneyAccountsExpectedAmounts = append(moneyAccountsExpectedAmounts, make([]uint64, len(moneyAccounts)))
 			toAccount := moneyAccounts[0]
-			toAccountDataOld, _, err := au.LookupWithoutRewards(i-1, toAccount)
+			toAccountDataOld, validThrough, err := au.LookupWithoutRewards(i-1, toAccount)
 			require.NoError(t, err)
+			require.Equal(t, i-1, validThrough)
 			toAccountDataNew := toAccountDataOld
 
 			for j := 1; j < len(moneyAccounts); j++ {
 				fromAccount := moneyAccounts[j]
 
-				fromAccountDataOld, _, err := au.LookupWithoutRewards(i-1, fromAccount)
+				fromAccountDataOld, validThrough, err := au.LookupWithoutRewards(i-1, fromAccount)
 				require.NoError(t, err)
+				require.Equal(t, i-1, validThrough)
 				require.Equalf(t, moneyAccountsExpectedAmounts[i-1][j], fromAccountDataOld.MicroAlgos.Raw, "Account index : %d\nRound number : %d", j, i)
 
 				fromAccountDataNew := fromAccountDataOld
@@ -747,20 +755,20 @@ func TestAcctUpdatesUpdatesCorrectness(t *testing.T) {
 					if checkRound < uint64(testback) {
 						continue
 					}
-					acct, _, err := au.LookupWithoutRewards(basics.Round(checkRound-uint64(testback)), moneyAccounts[j])
+					acct, validThrough, err := au.LookupWithoutRewards(basics.Round(checkRound-uint64(testback)), moneyAccounts[j])
 					// we might get an error like "round 2 before dbRound 5", which is the success case, so we'll ignore it.
-					if err != nil {
+					roundOffsetError := &RoundOffsetError{}
+					if errors.As(err, &roundOffsetError) {
+						require.Equal(t, basics.Round(0), validThrough)
 						// verify it's the expected error and not anything else.
-						var r1, r2 int
-						n, err2 := fmt.Sscanf(err.Error(), "round %d before dbRound %d", &r1, &r2)
-						require.NoErrorf(t, err2, "unable to parse : %v", err)
-						require.Equal(t, 2, n)
-						require.Less(t, r1, r2)
+						require.Less(t, int64(roundOffsetError.round), int64(roundOffsetError.dbRound))
 						if testback > 1 {
 							testback--
 						}
 						continue
 					}
+					require.NoError(t, err)
+					require.GreaterOrEqual(t, int64(validThrough), int64(basics.Round(checkRound-uint64(testback))))
 					// if we received no error, we want to make sure the reported amount is correct.
 					require.Equalf(t, moneyAccountsExpectedAmounts[checkRound-uint64(testback)][j], acct.MicroAlgos.Raw, "Account index : %d\nRound number : %d", j, checkRound)
 					testback++
@@ -791,8 +799,9 @@ func TestAcctUpdatesUpdatesCorrectness(t *testing.T) {
 		au.waitAccountsWriting()
 
 		for idx, addr := range moneyAccounts {
-			balance, _, err := au.LookupWithoutRewards(lastRound, addr)
+			balance, validThrough, err := au.LookupWithoutRewards(lastRound, addr)
 			require.NoErrorf(t, err, "unable to retrieve balance for account idx %d %v", idx, addr)
+			require.Equal(t, lastRound, validThrough)
 			if idx != 0 {
 				require.Equalf(t, 100*1000000-roundCount*(roundCount-1)/2, int(balance.MicroAlgos.Raw), "account idx %d %v has the wrong balance", idx, addr)
 			} else {

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -324,8 +324,10 @@ func TestFullCatchpointWriter(t *testing.T) {
 
 	// verify that the account data aligns with what we originally stored :
 	for addr, acct := range accts {
-		acctData, _, err := l.LookupWithoutRewards(0, addr)
+		acctData, validThrough, err := l.LookupWithoutRewards(0, addr)
 		require.NoError(t, err)
 		require.Equal(t, acct, acctData)
+		require.Equal(t, basics.Round(0), validThrough)
+
 	}
 }

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -324,7 +324,7 @@ func TestFullCatchpointWriter(t *testing.T) {
 
 	// verify that the account data aligns with what we originally stored :
 	for addr, acct := range accts {
-		acctData, err := l.LookupWithoutRewards(0, addr)
+		acctData, _, err := l.LookupWithoutRewards(0, addr)
 		require.NoError(t, err)
 		require.Equal(t, acct, acctData)
 	}

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -71,8 +71,9 @@ func (x *roundCowBase) getCreator(cidx basics.CreatableIndex, ctype basics.Creat
 	return x.l.GetCreatorForRound(x.rnd, cidx, ctype)
 }
 
-func (x *roundCowBase) lookup(addr basics.Address) (basics.AccountData, error) {
-	return x.l.LookupWithoutRewards(x.rnd, addr)
+func (x *roundCowBase) lookup(addr basics.Address) (acctData basics.AccountData, err error) {
+	acctData, _, err = x.l.LookupWithoutRewards(x.rnd, addr)
+	return acctData, err
 }
 
 func (x *roundCowBase) isDup(firstValid, lastValid basics.Round, txid transactions.Txid, txl txlease) (bool, error) {
@@ -221,7 +222,7 @@ type ledgerForEvaluator interface {
 	BlockHdr(basics.Round) (bookkeeping.BlockHeader, error)
 	Totals(basics.Round) (AccountTotals, error)
 	isDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, txlease) (bool, error)
-	LookupWithoutRewards(basics.Round, basics.Address) (basics.AccountData, error)
+	LookupWithoutRewards(basics.Round, basics.Address) (basics.AccountData, basics.Round, error)
 	GetCreatorForRound(basics.Round, basics.CreatableIndex, basics.CreatableType) (basics.Address, bool, error)
 	CompactCertVoters(basics.Round) (*VotersForRound, error)
 }
@@ -292,7 +293,7 @@ func startEvaluator(l ledgerForEvaluator, hdr bookkeeping.BlockHeader, paysetHin
 
 	poolAddr := eval.prevHeader.RewardsPool
 	// get the reward pool account data without any rewards
-	incentivePoolData, err := l.LookupWithoutRewards(eval.prevHeader.Round, poolAddr)
+	incentivePoolData, _, err := l.LookupWithoutRewards(eval.prevHeader.Round, poolAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -441,7 +441,7 @@ func (l *Ledger) Lookup(rnd basics.Round, addr basics.Address) (basics.AccountDa
 	defer l.trackerMu.RUnlock()
 
 	// Intentionally apply (pending) rewards up to rnd.
-	data, err := l.accts.Lookup(rnd, addr, true)
+	data, err := l.accts.LookupWithRewards(rnd, addr)
 	if err != nil {
 		return basics.AccountData{}, err
 	}
@@ -451,16 +451,16 @@ func (l *Ledger) Lookup(rnd basics.Round, addr basics.Address) (basics.AccountDa
 
 // LookupWithoutRewards is like Lookup but does not apply pending rewards up
 // to the requested round rnd.
-func (l *Ledger) LookupWithoutRewards(rnd basics.Round, addr basics.Address) (basics.AccountData, error) {
+func (l *Ledger) LookupWithoutRewards(rnd basics.Round, addr basics.Address) (basics.AccountData, basics.Round, error) {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()
 
-	data, err := l.accts.Lookup(rnd, addr, false)
+	data, validThrough, err := l.accts.LookupWithoutRewards(rnd, addr)
 	if err != nil {
-		return basics.AccountData{}, err
+		return basics.AccountData{}, basics.Round(0), err
 	}
 
-	return data, nil
+	return data, validThrough, nil
 }
 
 // Totals returns the totals of all accounts at the end of round rnd.


### PR DESCRIPTION
## Summary

Extend the existing implementation of account updates to provide already-available information for round range validity for account data queries. The long term goal here is to take advantage of that in the agreement implementation so that the number of queries that would reach the ledger would get reduced.

The change in a nutshell:
The function `accountUpdates. Lookup` got broken into
`LookupWithRewards(rnd basics.Round, addr basics.Address) (data basics.AccountData, err error)`
and
`LookupWithoutRewards(rnd basics.Round, addr basics.Address) (basics.AccountData, basics.Round, error)`

The latter includes a validity round as the second return value.

## Test Plan

Unit tests were extended to cover the changes.