### PR TITLE
tealdbg: listen for upcoming spinoff connections

### DIFF
--- a/cmd/tealdbg/debugger.go
+++ b/cmd/tealdbg/debugger.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/algorand/go-deadlock"
 
@@ -161,9 +162,18 @@ func makeSession(disassembly string, line int) (s *session) {
 }
 
 func (s *session) resume() {
-	select {
-	case s.acknowledged <- true:
-	default:
+	// There is a chance for race in automated environments like tests and scripted executions:
+	// acknowledged channel is not listening but attempted to write here.
+	// See a comment in Registered function.
+	// This loop adds delays to mitigate possible race:
+	// if the channel is not ready then yield and give another go-routine a chance.
+	for i := 0; i < 50; i++ {
+		select {
+		case s.acknowledged <- true:
+			return
+		default:
+			time.Sleep(1 * time.Millisecond)
+		}
 	}
 }
 
@@ -451,14 +461,15 @@ func (d *Debugger) Update(state *logic.DebugState) error {
 		return err
 	}
 	s.line.Store(state.Line)
+	cfg := s.debugConfig
 
-	go func() {
+	// copy state to prevent a data race in this the go-routine and upcoming updates to the state
+	go func(localState logic.DebugState) {
 		// Check if we are triggered and acknowledge asynchronously
-		cfg := s.debugConfig
 		if cfg.BreakAtLine != noBreak {
-			if cfg.BreakAtLine == stepBreak || breakpointLine(state.Line) == cfg.BreakAtLine {
+			if cfg.BreakAtLine == stepBreak || breakpointLine(localState.Line) == cfg.BreakAtLine {
 				// Breakpoint hit! Inform the user
-				s.notifications <- Notification{"updated", *state}
+				s.notifications <- Notification{"updated", localState}
 			} else {
 				// Continue if we haven't hit the next breakpoint
 				s.acknowledged <- true
@@ -467,7 +478,7 @@ func (d *Debugger) Update(state *logic.DebugState) error {
 			// User won't send acknowledgment, so we will
 			s.acknowledged <- true
 		}
-	}()
+	}(*state)
 
 	// Let TEAL continue when acknowledged
 	<-s.acknowledged

--- a/cmd/tealdbg/debugger.go
+++ b/cmd/tealdbg/debugger.go
@@ -36,9 +36,17 @@ type Notification struct {
 
 // DebugAdapter represents debugger frontend (i.e. CDT, webpage, VSCode, etc)
 type DebugAdapter interface {
+	// SessionStarted is called by the debugging core on the beginning of execution.
+	// Control interface must be used to manage execution (step, break, resume, etc).
+	// Notification channel must be used for receiving events from the debugger.
 	SessionStarted(sid string, debugger Control, ch chan Notification)
+	// SessionStarted is called by the debugging core on the competion of execution.
 	SessionEnded(sid string)
+	// WaitForCompletion must returns only when all session were completed and block otherwise.
 	WaitForCompletion()
+	// URL returns the most frontend URL for the most recent session
+	// or an empty string if there are no sessions yet.
+	URL() string
 }
 
 // Control interface for execution control

--- a/cmd/tealdbg/debugger_test.go
+++ b/cmd/tealdbg/debugger_test.go
@@ -66,6 +66,10 @@ func (d *testDbgAdapter) SessionEnded(sid string) {
 	d.ended = true
 }
 
+func (d *testDbgAdapter) URL() string {
+	return ""
+}
+
 func (d *testDbgAdapter) eventLoop() {
 	for {
 		select {

--- a/cmd/tealdbg/debugger_test.go
+++ b/cmd/tealdbg/debugger_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -86,8 +85,6 @@ func (d *testDbgAdapter) eventLoop() {
 				require.NotEmpty(d.t, n.DebugState.ExecID)
 				d.debugger.SetBreakpoint(n.DebugState.Line + 1)
 			}
-			// simulate user delay to workaround race cond
-			time.Sleep(10 * time.Millisecond)
 			d.debugger.Resume()
 		}
 	}
@@ -146,19 +143,17 @@ func TestSession(t *testing.T) {
 	err = s.SetBreakpoint(2)
 	require.NoError(t, err)
 
-	sig := make(chan struct{})
 	ackCount := 0
+	done := make(chan struct{})
 	ackFunc := func() {
-		sig <- struct{}{}
 		<-s.acknowledged
 		ackCount++
-		<-sig
+		done <- struct{}{}
 	}
 	go ackFunc()
 
-	<-sig
 	s.Resume()
-	sig <- struct{}{}
+	<-done
 
 	require.Equal(t, breakpointLine(2), s.debugConfig.BreakAtLine)
 	require.Equal(t, breakpoint{true, true}, s.breakpoints[2])
@@ -175,9 +170,8 @@ func TestSession(t *testing.T) {
 
 	go ackFunc()
 
-	<-sig
 	s.Step()
-	sig <- struct{}{}
+	<-done
 
 	require.Equal(t, stepBreak, s.debugConfig.BreakAtLine)
 	require.Equal(t, 2, ackCount)

--- a/cmd/tealdbg/main.go
+++ b/cmd/tealdbg/main.go
@@ -46,9 +46,9 @@ with Web or Chrome DevTools frontends`,
 }
 
 var debugCmd = &cobra.Command{
-	Use:   "debug program.tok [program.teal ...]",
-	Short: "Debug a local TEAL program(s)",
-	Long:  `Debug a local TEAL program(s) in controlled environment`,
+	Use:   "debug [program.tok [program.teal ...]]",
+	Short: "Debug TEAL program(s) off-chain",
+	Long:  `Debug TEAL program(s) in controlled environment using a local TEAL evaluator`,
 	Run: func(cmd *cobra.Command, args []string) {
 		debugLocal(args)
 		// //If no arguments passed, we should fallback to help
@@ -58,8 +58,8 @@ var debugCmd = &cobra.Command{
 
 var remoteCmd = &cobra.Command{
 	Use:   "remote",
-	Short: "Debug remote TEAL program",
-	Long:  `Start the server and wait upcoming debug connections from remote TEAL evaluator`,
+	Short: "Debug TEAL program on-chain",
+	Long:  `Start the server and wait for upcoming debug connections from remote TEAL evaluator`,
 	Run: func(cmd *cobra.Command, args []string) {
 		debugRemote()
 	},
@@ -141,6 +141,7 @@ var noSourceMap bool
 var verbose bool
 var painless bool
 var appID uint64
+var listenForDrReq bool
 
 func init() {
 	rootCmd.PersistentFlags().VarP(&frontend, "frontend", "f", "Frontend to use: "+frontend.AllowedString())
@@ -158,12 +159,13 @@ func init() {
 	debugCmd.Flags().StringVarP(&balanceFile, "balance", "b", "", "Balance records to evaluate stateful TEAL on in form of json or msgpack file")
 	debugCmd.Flags().StringVarP(&ddrFile, "dryrun-req", "d", "", "Program(s) and state(s) in dryrun REST request format")
 	debugCmd.Flags().Uint64VarP(&appID, "app-id", "a", 1380011588, "Application ID for stateful TEAL if not set in transaction(s)")
-	debugCmd.Flags().StringVarP(&indexerURL, "indexer-url", "i", "", "URL for indexer to fetch Balance records from to evaluate stateful TEAL")
-	debugCmd.Flags().StringVarP(&indexerToken, "indexer-token", "", "", "API token for indexer to fetch Balance records from to evaluate stateful TEAL")
 	debugCmd.Flags().Uint64VarP(&roundNumber, "round", "r", 0, "Ledger round number to evaluate stateful TEAL on")
 	debugCmd.Flags().Int64VarP(&timestamp, "latest-timestamp", "l", 0, "Latest confirmed timestamp to evaluate stateful TEAL on")
 	debugCmd.Flags().VarP(&runMode, "mode", "m", "TEAL evaluation mode: "+runMode.AllowedString())
 	debugCmd.Flags().BoolVar(&painless, "painless", false, "Automatically create balance record for all accounts and applications")
+	debugCmd.Flags().StringVarP(&indexerURL, "indexer-url", "i", "", "URL for indexer to fetch Balance records from to evaluate stateful TEAL")
+	debugCmd.Flags().StringVarP(&indexerToken, "indexer-token", "", "", "API token for indexer to fetch Balance records from to evaluate stateful TEAL")
+	debugCmd.Flags().BoolVarP(&listenForDrReq, "listen-dr-req", "q", false, "Listen for upcoming debugging dryrun request objects instead of taking program(s) from command line")
 
 	rootCmd.AddCommand(debugCmd)
 	rootCmd.AddCommand(remoteCmd)
@@ -183,27 +185,37 @@ func debugLocal(args []string) {
 		log.Fatalln("Invalid round")
 	}
 
-	// program can be set either directly
-	// or with SignedTxn.Lsig.Logic,
-	// or with BalanceRecord.AppParams.ApprovalProgram
-	if len(args) == 0 && len(txnFile) == 0 && len(ddrFile) == 0 {
-		log.Fatalln("No program to debug: must specify program(s), or transaction(s), or dryrun-req object")
+	// local debugging works in two modes:
+	// - listening for upcoming Dryrun Requests
+	// - or taking program, transaction or Dryrun Request from command line
+	// they can not be combined
+	if listenForDrReq && (len(args) != 0 || len(txnFile) != 0 && len(ddrFile) != 0) {
+		log.Fatalln("Can not combine listening for Dryrun Requests and program(s), or transaction(s), or dryrun-req object")
 	}
 
-	if len(args) == 0 && groupIndex != 0 {
-		log.Fatalln("Error: group-index may be only set only along with program(s)")
-	}
+	if !listenForDrReq {
+		// program can be set either directly
+		// or with SignedTxn.Lsig.Logic,
+		// or with BalanceRecord.AppParams.ApprovalProgram
+		if len(args) == 0 && len(txnFile) == 0 && len(ddrFile) == 0 {
+			log.Fatalln("No program to debug: must specify program(s), or transaction(s), or dryrun-req object")
+		}
 
-	if len(args) == 0 && runMode.IsSet() {
-		log.Fatalln("Error: mode may be only set only along with program(s)")
-	}
+		if len(args) == 0 && groupIndex != 0 {
+			log.Fatalln("Error: group-index may be only set only along with program(s)")
+		}
 
-	if len(txnFile) != 0 && len(ddrFile) != 0 {
-		log.Fatalln("Error: cannot specify both transaction(s) and dryrun-req")
-	}
+		if len(args) == 0 && runMode.IsSet() {
+			log.Fatalln("Error: mode may be only set only along with program(s)")
+		}
 
-	if len(balanceFile) != 0 && len(ddrFile) != 0 {
-		log.Fatalln("Error: cannot specify both balance records(s) and dryrun-req")
+		if len(txnFile) != 0 && len(ddrFile) != 0 {
+			log.Fatalln("Error: cannot specify both transaction(s) and dryrun-req")
+		}
+
+		if len(balanceFile) != 0 && len(ddrFile) != 0 {
+			log.Fatalln("Error: cannot specify both balance records(s) and dryrun-req")
+		}
 	}
 
 	var programNames []string
@@ -262,6 +274,7 @@ func debugLocal(args []string) {
 		DisableSourceMap: noSourceMap,
 		AppID:            appID,
 		Painless:         painless,
+		ListenForDrReq:   listenForDrReq,
 	}
 
 	ds := makeDebugServer(port, &frontend, &dp)

--- a/cmd/tealdbg/server.go
+++ b/cmd/tealdbg/server.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -50,12 +51,18 @@ var upgrader = websocket.Upgrader{
 
 // DebugServer is Debugger + HTTP/WS handlers for frontends
 type DebugServer struct {
-	debugger *Debugger
-	frontend DebugAdapter
-	router   *mux.Router
-	server   *http.Server
-	remote   *RemoteHookAdapter
-	params   *DebugParams
+	debugger  *Debugger
+	frontend  DebugAdapter
+	router    *mux.Router
+	server    *http.Server
+	remote    *RemoteHookAdapter
+	params    *DebugParams
+	spinoffCh chan spinoffMsg
+}
+
+type spinoffMsg struct {
+	err  error
+	data []byte
 }
 
 // DebugParams is a container for debug parameters
@@ -75,6 +82,7 @@ type DebugParams struct {
 	DisableSourceMap bool
 	AppID            uint64
 	Painless         bool
+	ListenForDrReq   bool
 }
 
 // FrontendFactory interface for attaching debug frontends
@@ -99,11 +107,12 @@ func makeDebugServer(port int, ff FrontendFactory, dp *DebugParams) DebugServer 
 	}
 
 	return DebugServer{
-		debugger: debugger,
-		frontend: da,
-		router:   router,
-		server:   server,
-		params:   dp,
+		debugger:  debugger,
+		frontend:  da,
+		router:    router,
+		server:    server,
+		params:    dp,
+		spinoffCh: make(chan spinoffMsg),
 	}
 }
 
@@ -120,10 +129,17 @@ func (ds *DebugServer) startRemote() error {
 	return nil
 }
 
+// DebugServer in local evaluator mode either accepts Dryrun Request obj if ListenForDrReq is set
+// or works with existing args set via command line.
+// So that for ListenForDrReq case a new endpoint is created and incoming data is await first.
+// Then execution is set up and program(s) run with stage-by-stage sync with ListenForDrReq's handler.
 func (ds *DebugServer) startDebug() (err error) {
 	local := MakeLocalRunner(ds.debugger)
-	if err = local.Setup(ds.params); err != nil {
-		return
+
+	if ds.params.ListenForDrReq {
+		path := "/spinoff"
+		ds.router.HandleFunc(path, ds.dryrunReqHander).Methods("POST")
+		log.Printf("listening for upcoming dryrun requests at http://%s%s", ds.server.Addr, path)
 	}
 
 	go func() {
@@ -134,11 +150,83 @@ func (ds *DebugServer) startDebug() (err error) {
 	}()
 	defer ds.server.Shutdown(context.Background())
 
-	err = local.RunAll()
-	if err != nil {
+	urlFetcherCh := make(chan struct{})
+	if ds.params.ListenForDrReq {
+		msg := <-ds.spinoffCh
+		ds.params.DdrBlob = msg.data
+		go func() {
+			for {
+				url := ds.frontend.URL()
+				if len(url) > 0 {
+					ds.spinoffCh <- spinoffMsg{nil, []byte(url)}
+					break
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+			urlFetcherCh <- struct{}{}
+		}()
+	}
+
+	if err = local.Setup(ds.params); err != nil {
+		if ds.params.ListenForDrReq {
+			ds.spinoffCh <- spinoffMsg{err, []byte(err.Error())}
+			<-ds.spinoffCh // wait handler to complete
+		}
+		return
+	}
+
+	if err = local.RunAll(); err != nil {
+		if ds.params.ListenForDrReq {
+			ds.spinoffCh <- spinoffMsg{err, []byte(err.Error())}
+			<-ds.spinoffCh // wait handler to complete
+		}
 		return
 	}
 
 	ds.frontend.WaitForCompletion()
+
+	if ds.params.ListenForDrReq {
+		// It is possible URL fetcher routine does not return anything and stuck in the loop.
+		// By this point all executions are done and a message urlFetcherCh must be available.
+		// If not then URL fetcher stuck and special handling is needed: send an error message
+		// to the network handler in order to unblock it.
+		select {
+		case <-urlFetcherCh:
+		default:
+			err = fmt.Errorf("no URL from frontend")
+			ds.spinoffCh <- spinoffMsg{err, []byte(err.Error())}
+		}
+		<-ds.spinoffCh // wait handler to complete
+	}
+	return
+}
+
+func (ds *DebugServer) dryrunReqHander(w http.ResponseWriter, r *http.Request) {
+	blob := make([]byte, 0, 4096)
+	buf := make([]byte, 1024)
+	n, err := r.Body.Read(buf)
+	for n > 0 {
+		blob = append(blob, buf...)
+		n, err = r.Body.Read(buf)
+	}
+	if err != nil && err != io.EOF {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	// send data
+	ds.spinoffCh <- spinoffMsg{nil, blob}
+	// wait for confirmation message
+	msg := <-ds.spinoffCh
+
+	w.Header().Set("Content-Type", "text/plain")
+	if msg.err == nil {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusBadRequest)
+	}
+	w.Write(msg.data)
+
+	// let the main thread to exit
+	close(ds.spinoffCh)
 	return
 }

--- a/cmd/tealdbg/server_test.go
+++ b/cmd/tealdbg/server_test.go
@@ -46,6 +46,10 @@ func (t testServerDebugFrontend) SessionEnded(sid string) {
 func (t testServerDebugFrontend) WaitForCompletion() {
 }
 
+func (t testServerDebugFrontend) URL() string {
+	return ""
+}
+
 func (t testServerDebugFrontend) eventLoop() {
 	for {
 		select {

--- a/cmd/tealdbg/webdbg.go
+++ b/cmd/tealdbg/webdbg.go
@@ -21,6 +21,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"html/template"
 	"log"
 	"net/http"
@@ -88,7 +89,7 @@ func (a *WebPageFrontend) SessionStarted(sid string, debugger Control, ch chan N
 
 	a.sessions[sid] = wpaSession{debugger, ch}
 
-	log.Printf("Open %s in a web browser", a.apiAddress)
+	log.Printf("Open http://%s in a web browser", a.apiAddress)
 }
 
 // SessionEnded removes the session
@@ -102,6 +103,17 @@ func (a *WebPageFrontend) SessionEnded(sid string) {
 // WaitForCompletion waits session to complete
 func (a *WebPageFrontend) WaitForCompletion() {
 	<-a.done
+}
+
+// URL returns an URL to access the latest debugging session
+func (a *WebPageFrontend) URL() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.sessions) == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf("http://%s/", a.apiAddress)
 }
 
 func (a *WebPageFrontend) homeHandler(w http.ResponseWriter, r *http.Request) {

--- a/test/e2e-go/cli/tealdbg/expect/tealdbgSpinoffTest.exp
+++ b/test/e2e-go/cli/tealdbg/expect/tealdbgSpinoffTest.exp
@@ -1,0 +1,61 @@
+#!/usr/bin/expect -f
+set err 0
+log_user 1
+
+if { [catch {
+
+    set TEST_ALGO_DIR [lindex $argv 0]
+    set timeout 30
+
+    set TEST_DIR $TEST_ALGO_DIR
+    exec mkdir -p $TEST_DIR
+
+    # this is simple escrow logic sig txn in form of dryrun request
+    # it is hardcoded to do not start a network so that speedup the test a bit
+    set DR_ENCODED_FILE "$TEST_DIR/drreq.base64"
+    set DR_FILE "$TEST_DIR/drreq.msgp"
+    exec echo "h6hhY2NvdW50c8CkYXBwc8CwbGF0ZXN0LXRpbWVzdGFtcACwcHJvdG9jb2wtdmVyc2lvbqClcm91bmQAp3NvdXJjZXPApHR4bnORgqRsc2lngaFsxAUCIAEAIqN0eG6Ko2FtdM0D6KNmZWXNA+iiZnbOAIouvaNnZW6sdGVzdG5ldC12MS4womdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJsds4AijKlpG5vdGXECNUWZX6OlD7Yo3JjdsQgpyYUTlC0jaNxDE4C5LyEF3fcPjIrI6STeWXGbGv02ISjc25kxCCnJhROULSNo3EMTgLkvIQXd9w+MisjpJN5ZcZsa/TYhKR0eXBlo3BheQ==" > $DR_ENCODED_FILE
+    exec cat $DR_ENCODED_FILE | base64 --decode > $DR_FILE
+
+    set URL_SPINOFF ""
+    set URL_WS ""
+    set PASSED 0
+    spawn tealdbg debug -q
+    expect_background {
+        timeout { puts "tealdbg debug timed out"; exit 1 }
+        -re {listening for upcoming dryrun requests at (http://[.a-z0-9:/]+)} { set URL_SPINOFF $expect_out(1,string); }
+    }
+
+    # wait until URL is set or timeout
+    set it 0
+    while { $it < 10 && $URL_SPINOFF == "" } {
+        set it [expr {$it + 1}]
+        sleep 1
+    }
+    if { $URL_SPINOFF == "" } {
+        puts "ERROR: SPINOFF URL is not set after timeout"
+        exit 1
+    }
+
+    spawn curl -X POST $URL_SPINOFF -H'Content-Type: octet/stream' --data-binary @$DR_FILE
+    expect {
+        timeout { puts "curl timed out"; exit 1 }
+        -re {(ws://[.a-z0-9:/]+)} { set URL_WS $expect_out(1,string); }
+    }
+
+    spawn cdtmock $URL_WS
+    expect {
+        timeout { puts "cdt-mock debug timed out"; exit 1 }
+        -re {Debugger.paused} { set PASSED 1; }
+        eof { catch wait result; if { [lindex $result 3] == 0 } { puts "Expected non-zero exit code"; exit [lindex $result 3] } }
+    }
+
+    if { $PASSED == 0 } {
+        puts "ERROR: have not found 'Debugger.paused' in cdtmock output"
+        exit 1
+    }
+
+} EXCEPTION ] } {
+    puts "ERROR in teadbgTest: $EXCEPTION"
+    exit 1
+}


### PR DESCRIPTION
## Summary

Use:
$ tealdbg debug -q
$ curl -X http://localhost:9293/spinoff --data-binary @dr.msgp

The /spinoff handler returns text/plain and
- HTTP 200 and ws://abc/sessionid in case of success
- HTTP 400 and error text in case of error
An URL in response body (ws://abc/) can be used for interactive debugging
with Chrome DevTools or for scripted debugging with CDT proto 1.1

A race condition is also fixed: dbg state access in the evaluator and in debugging core go-routine.
A possible deadlock on start is fixed: attempt to resume execution before initialization completed.

## Test Plan

Added e2e test