### PR TITLE
Fixes to algoh timeout e2e test

### DIFF
--- a/test/e2e-go/cli/algoh/expect/algohExpectCommon.exp
+++ b/test/e2e-go/cli/algoh/expect/algohExpectCommon.exp
@@ -10,6 +10,7 @@ namespace eval ::Algoh {
   namespace export StopNode
   namespace export StartNode
 
+  namespace export WaitForRound
 
   # My Variables
    set version 1.0
@@ -26,6 +27,14 @@ proc ::Algoh::Info {} {
 
 proc ::Algoh::Abort { ERROR } {
     puts "Aborting with error: $ERROR"
+
+    if { "$::GLOBAL_TEST_ROOT_DIR" != "" } {
+        # terminate child algod processes, if there are active child processes the test will hang on a test failure
+        puts "GLOBAL_TEST_ALGO_DIR $::GLOBAL_TEST_ALGO_DIR"
+        puts "GLOBAL_TEST_ROOT_DIR $::GLOBAL_TEST_ROOT_DIR"
+        puts "GLOBAL_NETWORK_NAME $::GLOBAL_NETWORK_NAME"
+        ::Algoh::StopNetwork $::GLOBAL_NETWORK_NAME $::GLOBAL_TEST_ROOT_DIR
+    }
     exit 1
 }
 
@@ -35,6 +44,8 @@ package require Tcl 8.0
 
 # Start the network
 proc ::Algoh::CreateNetwork { NETWORK_NAME NETWORK_TEMPLATE TEST_ROOT_DIR } {
+    set ::GLOBAL_TEST_ROOT_DIR $TEST_ROOT_DIR
+    set ::GLOBAL_NETWORK_NAME $NETWORK_NAME
 
     # Running on ARM64, it seems that network creation is pretty slow.
     # 30 second won't be enough here, so I'm changing this to 90 seconds.
@@ -50,14 +61,15 @@ proc ::Algoh::CreateNetwork { NETWORK_NAME NETWORK_TEMPLATE TEST_ROOT_DIR } {
             eof { catch wait result; if { [lindex $result 3] != 0 } { puts "Unable to create network"; Algoh::Abort } }
         }
     } EXCEPTION ] } {
-       ::AlgorandGoal::Abort "ERROR in CreateNetwork: $EXCEPTION"
+       ::Algoh::Abort "ERROR in CreateNetwork: $EXCEPTION"
     }
 }
 
 proc ::Algoh::StartNode { TEST_ALGO_DIR } {
+    set ::GLOBAL_TEST_ALGO_DIR $TEST_ALGO_DIR
 
     puts "Primary node start"
-    # Start node
+
     if { [catch {
         spawn goal node start -d $TEST_ALGO_DIR
         expect {
@@ -71,6 +83,8 @@ proc ::Algoh::StartNode { TEST_ALGO_DIR } {
 }
 
 proc ::Algoh::StopNode { TEST_ALGO_DIR } {
+    set ::GLOBAL_TEST_ALGO_DIR $TEST_ALGO_DIR
+
     set timeout 15
 
     if { [catch {
@@ -102,8 +116,26 @@ proc ::Algoh::StopNetwork { NETWORK_NAME TEST_ROOT_DIR } {
 	      exit 1
 	    }
         "Network Stopped under.*" {set NETWORK_STOP_MESSAGE $expect_out(buffer); close}
-        eof { catch wait result; if { [lindex $result 3] != 0 } { puts "Unable to stop network"; Algoh::Abort } }
-
+        eof { catch wait result; if { [lindex $result 3] != 0 } { puts "Unable to stop network"; exit 1; } }
     }
     puts $NETWORK_STOP_MESSAGE
+}
+
+# Wait for node to reach a specific round
+proc ::Algoh::WaitForFile { WAITFILE } {
+    puts "waiting for file $WAITFILE "
+    set SLEEP_TIME 1
+    if { [catch {
+        set i 0
+        while 1 {
+            incr i
+
+            if {[file exists $WAITFILE]} then { break; }
+            if { $i >= 10 } then { ::Algoh::Abort "ERROR waiting for $WAITFILE failed after $i attempts"; break;}
+            puts "sleep time $SLEEP_TIME"
+            after [expr {int($SLEEP_TIME * 1000)}]
+        }
+    } EXCEPTION ] } {
+       ::Algoh::Abort "ERROR in WaitForFile: $EXCEPTION"
+    }
 }

--- a/test/e2e-go/cli/algoh/expect/algohTimeoutTest.exp
+++ b/test/e2e-go/cli/algoh/expect/algohTimeoutTest.exp
@@ -34,9 +34,6 @@ if { [catch {
 
     puts "Successfully started node"
 
-    # ensure Primary listing before proceeding
-    ::Algoh::WaitForFile $TEST_PRIMARY_NODE_DIR/algod-listen.net
-
     exec cat ./disabled_profiler_config.json > $TEST_NODE_DIR/config.json
     exec cat ./host-config.json > $TEST_NODE_DIR/host-config.json
 
@@ -59,9 +56,6 @@ if { [catch {
         "^Logging to: *" {puts "algoh startup successful"}
         timeout {::Algoh::Abort "algoh failed to start";}
     }
-
-    # allow algoh time to put files in Node dir
-    ::Algoh::WaitForFile $TEST_NODE_DIR/algod.pid
 
     # wait until Node approves blocks to the network
     set timeout 60

--- a/test/e2e-go/cli/algoh/expect/algohTimeoutTest.exp
+++ b/test/e2e-go/cli/algoh/expect/algohTimeoutTest.exp
@@ -2,8 +2,6 @@
 set err 0
 log_user 1
 
-
-
 if { [catch {
     source algohExpectCommon.exp
 
@@ -11,7 +9,7 @@ if { [catch {
     set TEST_DATA_DIR [lindex $argv 1]
 
     exec mkdir -p $TEST_ALGO_DIR
-    
+
     set TIME_STAMP [clock seconds]
 
     set archType [exec $TEST_DATA_DIR/../../scripts/archtype.sh]
@@ -36,63 +34,59 @@ if { [catch {
 
     puts "Successfully started node"
 
-    set timeout 5
+    # ensure Primary listing before proceeding
+    ::Algoh::WaitForFile $TEST_PRIMARY_NODE_DIR/algod-listen.net
 
     exec cat ./disabled_profiler_config.json > $TEST_NODE_DIR/config.json
     exec cat ./host-config.json > $TEST_NODE_DIR/host-config.json
-    
+
     set PRIMARY_ADDR ""
-    spawn cat $TEST_ROOT_DIR/Primary/algod-listen.net
+    spawn cat $TEST_PRIMARY_NODE_DIR/algod-listen.net
     expect {
-        -regexp {http://[0-9\.]+:[0-9]+} { regexp -- {[0-9.]+:[0-9]+} $expect_out(0,string) PRIMARY_ADDR; close;}
-        timeout {puts "missed our case"; close; exit 1}
+        -re {http:\/\/([0-9\.]+:[0-9]+)} { set PRIMARY_ADDR $expect_out(1,string); exp_continue;}
+        timeout {::Algoh::Abort "timed out listing $TEST_PRIMARY_NODE_DIR/algod-listen.net"}
+    }
+
+    if { $PRIMARY_ADDR == "" } {
+        ::Algoh::Abort "Primary node listening address could not be retrieved."
     }
 
     puts "regex match: $PRIMARY_ADDR"
 
-    #start hosted node in the background
-    spawn $env(GOPATH)/bin/algoh -d $TEST_NODE_DIR -p $PRIMARY_ADDR
+    # start hosted node in the background
+    spawn algoh -d $TEST_NODE_DIR -p $PRIMARY_ADDR
     expect {
         "^Logging to: *" {puts "algoh startup successful"}
-        timeout {puts "algoh failed to start"; close; exit 1}
+        timeout {::Algoh::Abort "algoh failed to start";}
     }
 
-    #allow algoh time to put files in Node dir
-    spawn sleep 5
-    set timeout 5
-    expect {
-        timeout {puts "algod should be fully running"; close}
-    }
+    # allow algoh time to put files in Node dir
+    ::Algoh::WaitForFile $TEST_NODE_DIR/algod.pid
 
-    #wait until Node approves blocks to the network
+    # wait until Node approves blocks to the network
     set timeout 60
-    spawn $env(GOPATH)/bin/goal node wait -d $TEST_NODE_DIR -w 61
+    spawn goal node wait -d $TEST_NODE_DIR -w 61
     expect {
         eof {puts "successfully communicating with relay node"}
-        "Timed out waiting for node to make progress" {puts "timed out waiting for connection to relay node"; close; exit 1}
-        timeout {puts "should not reached this case"; close; exit 1}
+        "Timed out waiting for node to make progress" {::Algoh::Abort "timed out waiting for connection to relay node";}
+        timeout {::Algoh::Abort "should not reached this case";}
     }
-
 
     ::Algoh::StopNode $TEST_PRIMARY_NODE_DIR
 
-
     set timeout 201
-    spawn $env(GOPATH)/bin/goal node wait -d $TEST_NODE_DIR -w 200
+    spawn goal node wait -d $TEST_NODE_DIR -w 200
     expect {
-        "^Cannot contact Algorand node: open $TEST_NODE_DIR/algod.net: no such file or directory" {puts "ERROR: node shutdown"; close; exit 1}
+        "^Cannot contact Algorand node: open $TEST_NODE_DIR/algod.net: no such file or directory" {::Algoh::Abort "ERROR: node shutdown";}
         "^Timed out waiting for node to make progress" {puts "node correctly continued running despite relay shutdown"; close}
-        timeout {puts "should not reached this case", close; exit 1}
+        timeout {::Algoh::Abort "should not reached this case";}
     }
-    
+
     ::Algoh::StopNetwork $NETWORK_NAME $TEST_ROOT_DIR
 
     exec rm -d -r -f $TEST_ALGO_DIR
     puts "Basic Algoh Test Successful"
-    exit 0
 } EXCEPTION ] } {
-    puts "ERROR in algoh test: $EXCEPTION"
-
-    exec rm -d -r -f $TEST_ALGO_DIR
+    ::Algoh::Abort "ERROR in algoh test: $EXCEPTION"
     exit 1
 }

--- a/test/e2e-go/cli/goal/expect/catchpointCatchupTest.exp
+++ b/test/e2e-go/cli/goal/expect/catchpointCatchupTest.exp
@@ -86,7 +86,7 @@ if { [catch {
         timeout {::AlgorandGoal::Abort "timed out listing $TEST_ROOT_DIR/Primary/algod-listen.net"}
         eof { ::AlgorandGoal::CheckEOF "Unable to list $TEST_ROOT_DIR/Primary/algod-listen.net" }
     }
-    
+
     if { $PRIMARY_LISTEN_ADDRESS == "" } {
         ::AlgorandGoal::StopNode $TEST_ROOT_DIR/Primary
         puts "Primary node listening address could not be retrieved."


### PR DESCRIPTION
## Summary

TestAlgohWithExpect constantly fails on arm64, this PR addresses it.

* Make Abort to cleanup
* Ensure cleanup is done on errors

TODO: figure out why node startup takes longer than expected.

## Test Plan

This is a test enhancement PR