### PR TITLE
Netgoal general templates

### DIFF
--- a/cmd/netgoal/network.go
+++ b/cmd/netgoal/network.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -32,6 +33,7 @@ var networkRootDir string
 var networkRecipeFile string
 var networkName string
 var networkGenesisVersionModifier string
+var miscStringStringTokens []string
 
 var networkUseGenesisFiles bool
 var networkIgnoreExistingDir bool
@@ -49,6 +51,7 @@ func init() {
 
 	networkBuildCmd.Flags().BoolVarP(&networkUseGenesisFiles, "use-existing-files", "e", false, "Use existing genesis files.")
 	networkBuildCmd.Flags().BoolVarP(&networkIgnoreExistingDir, "force", "f", false, "Force generation into existing directory.")
+	networkBuildCmd.Flags().StringSliceVarP(&miscStringStringTokens, "val", "v", nil, "name=value, may be reapeated")
 
 	rootCmd.PersistentFlags().StringVarP(&networkGenesisVersionModifier, "modifier", "m", "", "Override Genesis Version Modifier (eg 'v1')")
 }
@@ -103,6 +106,10 @@ func runBuildNetwork() (err error) {
 	buildConfig, err := remote.LoadBuildConfig(configFile)
 	if err != nil {
 		return fmt.Errorf("error loading Build Config file: %v", err)
+	}
+	for _, kev := range miscStringStringTokens {
+		ab := strings.SplitN(kev, "=", 2)
+		buildConfig.MiscStringString = append(buildConfig.MiscStringString, "{{" + ab[0] + "}}", ab[1])
 	}
 
 	networkTemplateFile := resolveFile(r.NetworkFile, templateBaseDir)

--- a/netdeploy/remote/buildConfig.go
+++ b/netdeploy/remote/buildConfig.go
@@ -40,6 +40,7 @@ type BuildConfig struct {
 	CrontabSchedule   string
 	EnableAlgoh       bool
 	DashboardEndpoint string
+	MiscStringString  []string
 }
 
 // LoadBuildConfig loads a BuildConfig structure from a json file

--- a/netdeploy/remote/deployedNetwork.go
+++ b/netdeploy/remote/deployedNetwork.go
@@ -45,6 +45,16 @@ var ErrDeployedNetworkInsufficientHosts = fmt.Errorf("target network requires mo
 // ErrDeployedNetworkNameCantIncludeWildcard is returned by Validate if network name contains '*'
 var ErrDeployedNetworkNameCantIncludeWildcard = fmt.Errorf("network name cannont include wild-cards")
 
+// ErrDeployedNetworkTemplate A template file contained {{Field}} sections that were not handled by a corresponding Field value in configuration.
+type ErrDeployedNetworkTemplate struct {
+	UnhandledTemplate string
+}
+
+// Error satisfies error interface
+func (ednt ErrDeployedNetworkTemplate) Error() string {
+	return fmt.Sprintf("config file contains unrecognized token: %s", ednt.UnhandledTemplate)
+}
+
 // DeployedNetworkConfig represents the complete configuration specification for a deployed network
 type DeployedNetworkConfig struct {
 	Hosts []HostConfig
@@ -114,7 +124,7 @@ func replaceTokens(original string, buildConfig BuildConfig) (expanded string, e
 		if closeIndex < 0 {
 			closeIndex = len(expanded) - 2
 		}
-		return "", fmt.Errorf("config file contains unrecognized token: %s", expanded[openIndex:closeIndex+2])
+		return "", ErrDeployedNetworkTemplate{expanded[openIndex : closeIndex+2]}
 	}
 
 	return

--- a/netdeploy/remote/deployedNetwork.go
+++ b/netdeploy/remote/deployedNetwork.go
@@ -42,10 +42,6 @@ var ErrDeployedNetworkRootDirExists = fmt.Errorf("unable to generate deployed ne
 // ErrDeployedNetworkInsufficientHosts is returned by Validate if our target network requires more hosts than the topology provides
 var ErrDeployedNetworkInsufficientHosts = fmt.Errorf("target network requires more hosts than the topology provides")
 
-// ErrDeployedNetworkTokenError is returned by InitDeployedNetworkConfig
-// if the config file contains {{ or }} after token replacement
-var ErrDeployedNetworkTokenError = fmt.Errorf("config file contains unrecognized token")
-
 // ErrDeployedNetworkNameCantIncludeWildcard is returned by Validate if network name contains '*'
 var ErrDeployedNetworkNameCantIncludeWildcard = fmt.Errorf("network name cannont include wild-cards")
 
@@ -104,12 +100,13 @@ func replaceTokens(original string, buildConfig BuildConfig) (expanded string, e
 	tokenPairs = append(tokenPairs, "{{CrontabSchedule}}", buildConfig.CrontabSchedule)
 	tokenPairs = append(tokenPairs, "{{EnableAlgoh}}", strconv.FormatBool(buildConfig.EnableAlgoh))
 	tokenPairs = append(tokenPairs, "{{DashboardEndpoint}}", buildConfig.DashboardEndpoint)
+	tokenPairs = append(tokenPairs, buildConfig.MiscStringString...)
 
 	expanded = strings.NewReplacer(tokenPairs...).Replace(original)
 
 	// To validate that there wasn't a typo in an intended token, look for obvious clues like "{{" or "}}"
 	if strings.Index(expanded, "{{") >= 0 || strings.Index(expanded, "}}") >= 0 {
-		return "", ErrDeployedNetworkTokenError
+		return "", fmt.Errorf("config file contains unrecognized token: %s", expanded)
 	}
 
 	return

--- a/netdeploy/remote/deployedNetwork.go
+++ b/netdeploy/remote/deployedNetwork.go
@@ -105,8 +105,16 @@ func replaceTokens(original string, buildConfig BuildConfig) (expanded string, e
 	expanded = strings.NewReplacer(tokenPairs...).Replace(original)
 
 	// To validate that there wasn't a typo in an intended token, look for obvious clues like "{{" or "}}"
-	if strings.Index(expanded, "{{") >= 0 || strings.Index(expanded, "}}") >= 0 {
-		return "", fmt.Errorf("config file contains unrecognized token: %s", expanded)
+	openIndex := strings.Index(expanded, "{{")
+	closeIndex := strings.Index(expanded, "}}")
+	if openIndex >= 0 || closeIndex >= 0 {
+		if openIndex < 0 {
+			openIndex = 0
+		}
+		if closeIndex < 0 {
+			closeIndex = len(expanded) - 2
+		}
+		return "", fmt.Errorf("config file contains unrecognized token: %s", expanded[openIndex:closeIndex+2])
 	}
 
 	return


### PR DESCRIPTION
Allow `netgoal build` to more generally fill in template values.
`netgoal build ... -v SomeConfigField=foo` will replace `{{SomeConfigField}}` in template files with `foo`
I have used this to construct a test cluster that configures an experimental config.json field I hacked into a development `algod`