### PR TITLE
Add some TEAL3 opcodes

### DIFF
--- a/data/transactions/logic/README.md
+++ b/data/transactions/logic/README.md
@@ -220,6 +220,8 @@ Some of these have immediate data in the byte or bytes after the opcode.
 | 45 | FreezeAsset | uint64 | Asset ID being frozen or un-frozen. LogicSigVersion >= 2. |
 | 46 | FreezeAssetAccount | []byte | 32 byte address of the account whose asset slot is being frozen or un-frozen. LogicSigVersion >= 2. |
 | 47 | FreezeAssetFrozen | uint64 | The new frozen value, 0 or 1. LogicSigVersion >= 2. |
+| 48 | Args | []byte | Arguments passed to the logic signature in a logic signature transaction. LogicSigVersion >= 2. |
+| 49 | NumArgs | uint64 | Number of Args. LogicSigVersion >= 2. |
 
 
 Additional details in the [opcodes document](TEAL_opcodes.md#txn) on the `txn` op.

--- a/data/transactions/logic/TEAL_opcodes.md
+++ b/data/transactions/logic/TEAL_opcodes.md
@@ -406,6 +406,8 @@ Overflow is an error condition which halts execution and fails the transaction. 
 | 45 | FreezeAsset | uint64 | Asset ID being frozen or un-frozen. LogicSigVersion >= 2. |
 | 46 | FreezeAssetAccount | []byte | 32 byte address of the account whose asset slot is being frozen or un-frozen. LogicSigVersion >= 2. |
 | 47 | FreezeAssetFrozen | uint64 | The new frozen value, 0 or 1. LogicSigVersion >= 2. |
+| 48 | Args | []byte | Arguments passed to the logic signature in a logic signature transaction. LogicSigVersion >= 2. |
+| 49 | NumArgs | uint64 | Number of Args. LogicSigVersion >= 2. |
 
 
 TypeEnum mapping:

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -890,6 +890,7 @@ txn ConfigAssetClawback
 txn FreezeAsset
 txn FreezeAssetAccount
 txn FreezeAssetFrozen
+txn NumArgs
 gtxn 12 Fee
 `
 	for _, globalField := range GlobalFieldNames {

--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -325,6 +325,8 @@ var txnFieldDocList = []stringString{
 	{"FreezeAsset", "Asset ID being frozen or un-frozen"},
 	{"FreezeAssetAccount", "32 byte address of the account whose asset slot is being frozen or un-frozen"},
 	{"FreezeAssetFrozen", "The new frozen value, 0 or 1"},
+	{"Args", "Arguments passed to the logic signature in a logic signature transaction"},
+	{"NumArgs", "Number of Args"},
 }
 
 // TxnFieldDocs are notes on fields available by `txn` and `gtxn`

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -980,13 +980,13 @@ func opIte(cx *evalContext) {
 	last := len(cx.stack) - 1 // false
 	prev := last - 1          // true
 	pprev := prev - 1         // cond
-	cond := cx.stack[pprev].Uint == 0
-	if cond {
+	isZero := cx.stack[pprev].Uint == 0
+	if isZero {
 		cx.stack[pprev] = cx.stack[last]
 	} else {
 		cx.stack[pprev] = cx.stack[prev]
 	}
-	cx.stack = cx.stack[:pprev]
+	cx.stack = cx.stack[:prev]
 }
 
 func opLen(cx *evalContext) {

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"math"
 	"math/big"
+	"os"
 	"runtime"
 	"sort"
 	"strings"
@@ -414,6 +415,11 @@ func eval(program []byte, cx *evalContext) (pass bool, err error) {
 	cx.pc = vlen
 	cx.stack = make([]stackValue, 0, 10)
 	cx.program = program
+
+	debugURL := os.Getenv("TEAL_DEBUGGER_URL")
+	if debugURL != "" {
+		cx.Debugger = &WebDebuggerHook{URL: debugURL}
+	}
 
 	if cx.Debugger != nil {
 		cx.debugState = makeDebugState(cx)

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1063,12 +1063,15 @@ func opBitRsh(cx *evalContext) {
 func opByteGet(cx *evalContext) {
 	last := len(cx.stack) - 1
 	cx.stack[last].Uint = uint64(cx.stack[last].Bytes[cx.program[cx.pc+1]])
+	cx.stack[last].Bytes = nil
+	cx.nextpc = cx.pc + 2
 }
 
 func opByteGet2(cx *evalContext) {
 	last := len(cx.stack) - 1
 	prev := last - 1
 	cx.stack[prev].Uint = uint64(cx.stack[prev].Bytes[byte(cx.stack[last].Uint)])
+	cx.stack[prev].Bytes = nil
 	cx.stack = cx.stack[:last]
 }
 
@@ -1077,6 +1080,7 @@ func opByteSet(cx *evalContext) {
 	prev := last - 1
 	cx.stack[prev].Bytes[cx.program[cx.pc+1]] = byte(cx.stack[last].Uint)
 	cx.stack = cx.stack[:last]
+	cx.nextpc = cx.pc + 2
 }
 
 func opByteSet2(cx *evalContext) {

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1229,12 +1229,13 @@ func opBz(cx *evalContext) {
 func opAssert(cx *evalContext) {
 	last := len(cx.stack) - 1
 	isZero := cx.stack[last].Uint == 0
-	cx.stack = cx.stack[:last]
 	if isZero {
 		cx.stack[0] = cx.stack[last]
 		cx.stack = cx.stack[:1]
 		cx.nextpc = len(cx.program)
-	}
+	} else {
+		cx.stack = cx.stack[:last]
+	} 
 }
 
 func opB(cx *evalContext) {

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1060,6 +1060,33 @@ func opBitRsh(cx *evalContext) {
 	cx.stack = cx.stack[:last]
 }
 
+func opByteGet(cx *evalContext) {
+	last := len(cx.stack) - 1
+	cx.stack[last].Uint = uint64(cx.stack[last].Bytes[cx.program[cx.pc+1]])
+}
+
+func opByteGet2(cx *evalContext) {
+	last := len(cx.stack) - 1
+	prev := last - 1
+	cx.stack[prev].Uint = uint64(cx.stack[prev].Bytes[byte(cx.stack[last].Uint)])
+	cx.stack = cx.stack[:last]
+}
+
+func opByteSet(cx *evalContext) {
+	last := len(cx.stack) - 1
+	prev := last - 1
+	cx.stack[prev].Bytes[cx.program[cx.pc+1]] = byte(cx.stack[last].Uint)
+	cx.stack = cx.stack[:last]
+}
+
+func opByteSet2(cx *evalContext) {
+	last := len(cx.stack) - 1
+	prev := last - 1
+	pprev := prev - 1
+	cx.stack[pprev].Bytes[cx.stack[prev].Uint] = byte(cx.stack[last].Uint)
+	cx.stack = cx.stack[:prev]
+}
+
 func opIntConstBlock(cx *evalContext) {
 	cx.intc, cx.nextpc, cx.err = parseIntcblock(cx.program, cx.pc)
 }

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1078,7 +1078,9 @@ func opByteGet2(cx *evalContext) {
 func opByteSet(cx *evalContext) {
 	last := len(cx.stack) - 1
 	prev := last - 1
-	cx.stack[prev].Bytes[cx.program[cx.pc+1]] = byte(cx.stack[last].Uint)
+	newstr := append([]byte(nil), cx.stack[prev].Bytes...)
+	newstr[cx.program[cx.pc+1]] = byte(cx.stack[last].Uint)
+	cx.stack[prev].Bytes = newstr
 	cx.stack = cx.stack[:last]
 	cx.nextpc = cx.pc + 2
 }
@@ -1087,7 +1089,9 @@ func opByteSet2(cx *evalContext) {
 	last := len(cx.stack) - 1
 	prev := last - 1
 	pprev := prev - 1
-	cx.stack[pprev].Bytes[cx.stack[prev].Uint] = byte(cx.stack[last].Uint)
+	newstr := append([]byte(nil), cx.stack[pprev].Bytes...)
+	newstr[cx.stack[prev].Uint] = byte(cx.stack[last].Uint)
+	cx.stack[pprev].Bytes = newstr
 	cx.stack = cx.stack[:prev]
 }
 

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -132,14 +132,15 @@ func TestMinTealVersionParamEvalCheck(t *testing.T) {
 
 func TestTxnFieldToTealValue(t *testing.T) {
 
-	txn := transactions.Transaction{}
+	stxn := transactions.SignedTxn{}
+	txn := stxn.Txn
 	groupIndex := 0
 	field := FirstValid
 	values := [6]uint64{0, 1, 2, 0xffffffff, 0xffffffffffffffff}
 
 	for _, value := range values {
 		txn.FirstValid = basics.Round(value)
-		tealValue, err := TxnFieldToTealValue(&txn, groupIndex, field, 0)
+		tealValue, err := TxnFieldToTealValue(&stxn, groupIndex, field, 0)
 		require.NoError(t, err)
 		require.Equal(t, basics.TealUintType, tealValue.Type)
 		require.Equal(t, value, tealValue.Uint)
@@ -149,7 +150,7 @@ func TestTxnFieldToTealValue(t *testing.T) {
 	field = FirstValid
 	value := uint64(1)
 	txn.FirstValid = basics.Round(value)
-	tealValue, err := TxnFieldToTealValue(&txn, groupIndex, field, 10)
+	tealValue, err := TxnFieldToTealValue(&stxn, groupIndex, field, 10)
 	require.NoError(t, err)
 	require.Equal(t, basics.TealUintType, tealValue.Type)
 	require.Equal(t, value, tealValue.Uint)
@@ -159,17 +160,17 @@ func TestTxnFieldToTealValue(t *testing.T) {
 	sender := basics.Address{}
 	addr, _ := basics.UnmarshalChecksumAddress("DFPKC2SJP3OTFVJFMCD356YB7BOT4SJZTGWLIPPFEWL3ZABUFLTOY6ILYE")
 	txn.Accounts = []basics.Address{addr}
-	tealValue, err = TxnFieldToTealValue(&txn, groupIndex, field, 0)
+	tealValue, err = TxnFieldToTealValue(&stxn, groupIndex, field, 0)
 	require.NoError(t, err)
 	require.Equal(t, basics.TealBytesType, tealValue.Type)
 	require.Equal(t, string(sender[:]), tealValue.Bytes)
 
-	tealValue, err = TxnFieldToTealValue(&txn, groupIndex, field, 1)
+	tealValue, err = TxnFieldToTealValue(&stxn, groupIndex, field, 1)
 	require.NoError(t, err)
 	require.Equal(t, basics.TealBytesType, tealValue.Type)
 	require.Equal(t, string(addr[:]), tealValue.Bytes)
 
-	tealValue, err = TxnFieldToTealValue(&txn, groupIndex, field, 100)
+	tealValue, err = TxnFieldToTealValue(&stxn, groupIndex, field, 100)
 	require.Error(t, err)
 	require.Equal(t, basics.TealUintType, tealValue.Type)
 	require.Equal(t, uint64(0), tealValue.Uint)

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -133,7 +133,7 @@ func TestMinTealVersionParamEvalCheck(t *testing.T) {
 func TestTxnFieldToTealValue(t *testing.T) {
 
 	stxn := transactions.SignedTxn{}
-	txn := stxn.Txn
+	txn := &stxn.Txn
 	groupIndex := 0
 	field := FirstValid
 	values := [6]uint64{0, 1, 2, 0xffffffff, 0xffffffffffffffff}
@@ -1652,6 +1652,10 @@ txna ApplicationArgs 7
 &&
 txn FreezeAssetFrozen
 int 1
+==
+&&
+txn NumArgs
+int 11
 ==
 &&
 `

--- a/data/transactions/logic/fields.go
+++ b/data/transactions/logic/fields.go
@@ -123,6 +123,10 @@ const (
 	FreezeAssetAccount
 	// FreezeAssetFrozen bool
 	FreezeAssetFrozen
+	// Args []basics.TealValue
+	Args
+	// NumArgs len(Args)
+	NumArgs
 
 	invalidTxnField // fence for some setup that loops from Sender..invalidTxnField
 )
@@ -201,21 +205,25 @@ var txnFieldSpecs = []txnFieldSpec{
 	{FreezeAsset, StackUint64, 2},
 	{FreezeAssetAccount, StackBytes, 2},
 	{FreezeAssetFrozen, StackUint64, 2},
+	{Args, StackBytes, 2},
+	{NumArgs, StackUint64, 2},
 }
 
 // TxnaFieldNames are arguments to the 'txna' opcode
 // It is a subset of txn transaction fields so initialized here in-place
-var TxnaFieldNames = []string{ApplicationArgs.String(), Accounts.String()}
+var TxnaFieldNames = []string{ApplicationArgs.String(), Accounts.String(), Args.String()}
 
 // TxnaFieldTypes is StackBytes or StackUint64 parallel to TxnFieldNames
 var TxnaFieldTypes = []StackType{
 	txnaFieldSpecByField[ApplicationArgs].ftype,
 	txnaFieldSpecByField[Accounts].ftype,
+	txnaFieldSpecByField[Args].ftype,
 }
 
 var txnaFieldSpecByField = map[TxnField]txnFieldSpec{
 	ApplicationArgs: {ApplicationArgs, StackBytes, 2},
 	Accounts:        {Accounts, StackBytes, 2},
+	Args:            {Args, StackBytes, 2},
 }
 
 // TxnTypeNames is the values of Txn.Type in enum order

--- a/data/transactions/logic/fields_string.go
+++ b/data/transactions/logic/fields_string.go
@@ -56,12 +56,14 @@ func _() {
 	_ = x[FreezeAsset-45]
 	_ = x[FreezeAssetAccount-46]
 	_ = x[FreezeAssetFrozen-47]
-	_ = x[invalidTxnField-48]
+	_ = x[Args-48]
+	_ = x[NumArgs-49]
+	_ = x[invalidTxnField-50]
 }
 
-const _TxnField_name = "SenderFeeFirstValidFirstValidTimeLastValidNoteLeaseReceiverAmountCloseRemainderToVotePKSelectionPKVoteFirstVoteLastVoteKeyDilutionTypeTypeEnumXferAssetAssetAmountAssetSenderAssetReceiverAssetCloseToGroupIndexTxIDApplicationIDOnCompletionApplicationArgsNumAppArgsAccountsNumAccountsApprovalProgramClearStateProgramRekeyToConfigAssetConfigAssetTotalConfigAssetDecimalsConfigAssetDefaultFrozenConfigAssetUnitNameConfigAssetNameConfigAssetURLConfigAssetMetadataHashConfigAssetManagerConfigAssetReserveConfigAssetFreezeConfigAssetClawbackFreezeAssetFreezeAssetAccountFreezeAssetFrozeninvalidTxnField"
+const _TxnField_name = "SenderFeeFirstValidFirstValidTimeLastValidNoteLeaseReceiverAmountCloseRemainderToVotePKSelectionPKVoteFirstVoteLastVoteKeyDilutionTypeTypeEnumXferAssetAssetAmountAssetSenderAssetReceiverAssetCloseToGroupIndexTxIDApplicationIDOnCompletionApplicationArgsNumAppArgsAccountsNumAccountsApprovalProgramClearStateProgramRekeyToConfigAssetConfigAssetTotalConfigAssetDecimalsConfigAssetDefaultFrozenConfigAssetUnitNameConfigAssetNameConfigAssetURLConfigAssetMetadataHashConfigAssetManagerConfigAssetReserveConfigAssetFreezeConfigAssetClawbackFreezeAssetFreezeAssetAccountFreezeAssetFrozenArgsNumArgsinvalidTxnField"
 
-var _TxnField_index = [...]uint16{0, 6, 9, 19, 33, 42, 46, 51, 59, 65, 81, 87, 98, 107, 115, 130, 134, 142, 151, 162, 173, 186, 198, 208, 212, 225, 237, 252, 262, 270, 281, 296, 313, 320, 331, 347, 366, 390, 409, 424, 438, 461, 479, 497, 514, 533, 544, 562, 579, 594}
+var _TxnField_index = [...]uint16{0, 6, 9, 19, 33, 42, 46, 51, 59, 65, 81, 87, 98, 107, 115, 130, 134, 142, 151, 162, 173, 186, 198, 208, 212, 225, 237, 252, 262, 270, 281, 296, 313, 320, 331, 347, 366, 390, 409, 424, 438, 461, 479, 497, 514, 533, 544, 562, 579, 583, 590, 605}
 
 func (i TxnField) String() string {
 	if i < 0 || i >= TxnField(len(_TxnField_index)-1) {

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -64,6 +64,7 @@ var oneInt = StackTypes{StackUint64}
 var twoInts = StackTypes{StackUint64, StackUint64}
 var oneAny = StackTypes{StackAny}
 var twoAny = StackTypes{StackAny, StackAny}
+var intAnyAny = StackTypes{StackUint64, StackAny, StackAny}
 
 // OpSpecs is the table of operations that can be assembled and evaluated.
 //
@@ -164,6 +165,12 @@ var OpSpecs = []OpSpec{
 
 	{0x70, "asset_holding_get", opAssetHoldingGet, assembleAssetHolding, disAssetHolding, twoInts, oneInt.plus(oneAny), 2, runModeApplication, opSize{1, 2, nil}},
 	{0x71, "asset_params_get", opAssetParamsGet, assembleAssetParams, disAssetParams, oneInt, oneInt.plus(oneAny), 2, runModeApplication, opSize{1, 2, nil}},
+
+	{0x80, "<<", opBitLsh, asmDefault, disDefault, twoInts, oneInt, 2, modeAny, opSizeDefault},
+	{0x81, ">>", opBitRsh, asmDefault, disDefault, twoInts, oneInt, 2, modeAny, opSizeDefault},
+	{0x82, "assert", opAssert, asmDefault, disDefault, oneInt, nil, 2, modeAny, opSizeDefault},
+	{0x83, "swap", opSwap, asmDefault, disDefault, twoAny, twoAny, 2, modeAny, opSizeDefault},
+	{0x84, "ite", opIte, asmDefault, disDefault, intAnyAny, oneAny, 2, modeAny, opSizeDefault},
 }
 
 type sortByOpcode []OpSpec

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -60,11 +60,15 @@ var oneBytes = StackTypes{StackBytes}
 var twoBytes = StackTypes{StackBytes, StackBytes}
 var threeBytes = StackTypes{StackBytes, StackBytes, StackBytes}
 var byteIntInt = StackTypes{StackBytes, StackUint64, StackUint64}
+var byteInt = StackTypes{StackBytes, StackUint64}
 var oneInt = StackTypes{StackUint64}
 var twoInts = StackTypes{StackUint64, StackUint64}
+var threeInts = StackTypes{StackUint64, StackUint64, StackUint64}
 var oneAny = StackTypes{StackAny}
 var twoAny = StackTypes{StackAny, StackAny}
 var intAnyAny = StackTypes{StackUint64, StackAny, StackAny}
+var anyInt = StackTypes{StackAny, StackUint64}
+var anyIntInt = StackTypes{StackAny, StackUint64, StackUint64}
 
 // OpSpecs is the table of operations that can be assembled and evaluated.
 //
@@ -171,6 +175,10 @@ var OpSpecs = []OpSpec{
 	{0x82, "assert", opAssert, asmDefault, disDefault, oneInt, nil, 2, modeAny, opSizeDefault},
 	{0x83, "swap", opSwap, asmDefault, disDefault, twoAny, twoAny, 2, modeAny, opSizeDefault},
 	{0x84, "ite", opIte, asmDefault, disDefault, intAnyAny, oneAny, 2, modeAny, opSizeDefault},
+	{0x85, "byteget", opByteGet, assembleByteGet, disByteGet, oneBytes, oneInt, 2, modeAny, opSize{1, 2, nil}},
+	{0x86, "byteget2", opByteGet2, asmDefault, disDefault, byteInt, oneInt, 2, modeAny, opSizeDefault},
+	{0x87, "byteset", opByteSet, assembleByteSet, disByteSet, byteInt, oneBytes, 2, modeAny, opSize{1, 2, nil}},
+	{0x88, "byteset2", opByteSet2, asmDefault, disDefault, byteIntInt, oneBytes, 2, modeAny, opSizeDefault},
 }
 
 type sortByOpcode []OpSpec


### PR DESCRIPTION
I don't expect you to take this as-is, without addressing #1633, and adding a version 3, but I am working on a program and these instructions are very useful for me.

For example, I have an example program that verifies the rules of a simple game in a TEAL contract. My original compiler as of Monday used ~6000 bytes for the program, then I fixed a dumb thing and got it to 3262 bytes, but then I did a lot of aggressive optimizations over the last few days and got it down to 946 bytes, but I expect the argument size to be 77 bytes, so `946 + 77 = 1023`, so I needed to do something else. These new instructions, especially `assert` and `ite` drop this program down to 864 bytes, which is good for me.

(You can get `assert` via `bz fail; .....; fail: int 0; return <EOF>`, but `bz` is three bytes, so that's a lot when most of a TEAL program is checking or failing.)

(You can get `cond; true; false; ite` via `cond; bz l_false; true; bz l_join; false; l_join:` which is 6 bytes vs 1, so it's a pretty decent win. `ite` is only useful if `true` and `false` are simple, so it is like a conditional move or the `?:` operator.)

(Swap is a big win in size, because `store 0; store 1; load 0; load 1` is 8 bytes plus pinning two slots.)