### PR TITLE
Refactor parseIntcblock

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1322,7 +1322,7 @@ func disDefault(dis *disassembleState, spec *OpSpec) {
 	_, dis.err = fmt.Fprintf(dis.out, "%s\n", spec.Name)
 }
 
-var errShortIntcblock  = errors.New("intcblock ran past end of program")
+var errShortIntcblock = errors.New("intcblock ran past end of program")
 var errTooManyIntc = errors.New("intcblock with too many items")
 
 func parseIntcblock(program []byte, pc int) (intc []uint64, nextpc int, err error) {

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1322,6 +1322,7 @@ func disDefault(dis *disassembleState, spec *OpSpec) {
 	_, dis.err = fmt.Fprintf(dis.out, "%s\n", spec.Name)
 }
 
+var errShortIntcblock  = errors.New("intcblock ran past end of program")
 var errTooManyIntc = errors.New("intcblock with too many items")
 
 func parseIntcblock(program []byte, pc int) (intc []uint64, nextpc int, err error) {
@@ -1339,7 +1340,7 @@ func parseIntcblock(program []byte, pc int) (intc []uint64, nextpc int, err erro
 	intc = make([]uint64, numInts)
 	for i := uint64(0); i < numInts; i++ {
 		if pos >= len(program) {
-			err = fmt.Errorf("bytecblock ran past end of program")
+			err = errShortIntcblock
 			return
 		}
 		intc[i], bytesUsed = binary.Uvarint(program[pos:])
@@ -1368,7 +1369,7 @@ func checkIntConstBlock(cx *evalContext) int {
 	//intc = make([]uint64, numInts)
 	for i := uint64(0); i < numInts; i++ {
 		if pos >= len(cx.program) {
-			cx.err = fmt.Errorf("bytecblock ran past end of program")
+			cx.err = errShortIntcblock
 			return 0
 		}
 		_, bytesUsed = binary.Uvarint(cx.program[pos:])

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -1594,4 +1594,9 @@ func TestErrShortBytecblock(t *testing.T) {
 	require.NoError(t, err)
 	_, _, err = parseIntcblock(program, 0)
 	require.Equal(t, err, errShortIntcblock)
+
+	var cx evalContext
+	cx.program = program
+	checkIntConstBlock(&cx)
+	require.Equal(t, cx.err, errShortIntcblock)
 }

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -1587,3 +1587,11 @@ func TestAssembleConstants(t *testing.T) {
 		})
 	}
 }
+
+func TestErrShortBytecblock(t *testing.T) {
+	text := `intcblock 0x1234567812345678 0x1234567812345671 0x1234567812345672 0x1234567812345673 4 5 6 7 8`
+	program, err := AssembleStringWithVersion(text, 1)
+	require.NoError(t, err)
+	_, _, err = parseIntcblock(program, 0)
+	require.Equal(t, err, errShortIntcblock)
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Modify the error messages for parseIntcblock to distinguish fro, parseBytecblock

## Test Plan

None