### PR TITLE
Ensure syncStartNS is managed correctly across catchpoint file writing

### DIFF
--- a/catchup/pref_test.go
+++ b/catchup/pref_test.go
@@ -60,7 +60,7 @@ func BenchmarkServiceFetchBlocks(b *testing.B) {
 		syncer.fetcherFactory = makeMockFactory(&MockedFetcher{ledger: remote, timeout: false, tries: make(map[basics.Round]int), latency: 100 * time.Millisecond, predictable: true})
 
 		b.StartTimer()
-		syncer.sync(nil)
+		syncer.sync()
 		b.StopTimer()
 		local.Close()
 		require.Equal(b, remote.LastRound(), local.LastRound())

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -73,6 +73,10 @@ type Service struct {
 	auth            BlockAuthenticator
 	parallelBlocks  uint64
 	deadlineTimeout time.Duration
+	// catchpointWriting defines whether we've ran into a state where the ledger is currently busy writing the
+	// catchpoint file. If so, we want to pospone all the catchup process until the catchpoint file writing is complete,
+	// and resume from there without stopping the catchup timer.
+	catchpointWriting bool
 
 	// The channel gets closed when the initial sync is complete. This allows for other services to avoid
 	// the overhead of starting prematurely (before this node is caught-up and can validate messages for example).
@@ -390,6 +394,7 @@ func (s *Service) pipelinedFetch(seedLookback uint64) {
 			// could resume with the catchup.
 			if s.ledger.IsWritingCatchpointFile() {
 				s.log.Info("Catchup is stopping due to catchpoint file being written")
+				s.catchpointWriting = true
 				return
 			}
 			completedRounds[round] = true
@@ -423,7 +428,7 @@ func (s *Service) periodicSync() {
 	case <-s.ctx.Done():
 		return
 	}
-	s.sync(nil)
+	s.sync()
 	stuckInARow := 0
 	sleepDuration := s.deadlineTimeout
 	for {
@@ -448,11 +453,12 @@ func (s *Service) periodicSync() {
 				// keep the existing sleep duration and try again later.
 				continue
 			}
+			s.catchpointWriting = false
 			s.log.Info("It's been too long since our ledger advanced; resyncing")
-			s.sync(nil)
+			s.sync()
 		case cert := <-s.unmatchedPendingCertificates:
 			// the agreement service has a valid certificate for a block, but not the block itself.
-			s.sync(&cert)
+			s.syncCert(&cert)
 		}
 
 		if currBlock == s.ledger.LastRound() {
@@ -469,18 +475,24 @@ func (s *Service) periodicSync() {
 }
 
 // Syncs the client with the network. sync asks the network for last known block and tries to sync the system
-// up the to the highest number it gets. When a certificate is provided, the sync function attempts to keep trying
-// to fetch the matching block or abort when the catchup service exits.
-func (s *Service) sync(cert *PendingUnmatchedCertificate) {
+// up the to the highest number it gets.
+func (s *Service) sync() {
 	// Only run sync once at a time
 	// Store start time of sync - in NS so we can compute time.Duration (which is based on NS)
 	start := time.Now()
+
 	timeInNS := start.UnixNano()
 	if !atomic.CompareAndSwapInt64(&s.syncStartNS, 0, timeInNS) {
-		s.log.Infof("previous sync from %d still running (now=%d)", atomic.LoadInt64(&s.syncStartNS), timeInNS)
-		return
+		s.log.Infof("resuming previous sync from %d (now=%d)", atomic.LoadInt64(&s.syncStartNS), timeInNS)
 	}
-	defer atomic.StoreInt64(&s.syncStartNS, 0)
+
+	defer func() {
+		// if the catchupWriting flag is set, it means that we aborted the sync due to the ledger writing the catchup file.
+		// in that case, don't change the timer so that the "timer" would keep running.
+		if !s.catchpointWriting {
+			atomic.StoreInt64(&s.syncStartNS, 0)
+		}
+	}()
 
 	pr := s.ledger.LastRound()
 
@@ -488,19 +500,14 @@ func (s *Service) sync(cert *PendingUnmatchedCertificate) {
 		StartRound: uint64(pr),
 	})
 
-	if cert == nil {
-		seedLookback := uint64(2)
-		proto, err := s.ledger.ConsensusParams(pr)
-		if err != nil {
-			s.log.Errorf("catchup: could not get consensus parameters for round %v: %v", pr, err)
-		} else {
-			seedLookback = proto.SeedLookback
-		}
-		s.pipelinedFetch(seedLookback)
+	seedLookback := uint64(2)
+	proto, err := s.ledger.ConsensusParams(pr)
+	if err != nil {
+		s.log.Errorf("catchup: could not get consensus parameters for round %v: %v", pr, err)
 	} else {
-		// we want to fetch a single round. no need to be concerned about lookback.
-		s.fetchRound(cert.Cert, cert.VoteVerifier)
+		seedLookback = proto.SeedLookback
 	}
+	s.pipelinedFetch(seedLookback)
 
 	initSync := false
 
@@ -518,6 +525,13 @@ func (s *Service) sync(cert *PendingUnmatchedCertificate) {
 		InitSync:   initSync,
 	})
 	s.log.Infof("Catchup Service: finished catching up, now at round %v (previously %v). Total time catching up %v.", s.ledger.LastRound(), pr, elapsedTime)
+}
+
+// syncCert retrieving a single round identified by the provided certificate and adds it to the ledger.
+// The sync function attempts to keep trying to fetch the matching block or abort when the catchup service exits.
+func (s *Service) syncCert(cert *PendingUnmatchedCertificate) {
+	// we want to fetch a single round. no need to be concerned about lookback.
+	s.fetchRound(cert.Cert, cert.VoteVerifier)
 }
 
 // TODO this doesn't actually use the digest from cert!

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -188,7 +188,7 @@ func TestServiceFetchBlocksSameRange(t *testing.T) {
 	syncer.fetcherFactory = makeMockFactory(&MockedFetcher{ledger: remote, timeout: false, tries: make(map[basics.Round]int)})
 
 	syncer.testStart()
-	syncer.sync(nil)
+	syncer.sync()
 
 	require.Equal(t, remote.LastRound(), local.LastRound())
 }
@@ -248,7 +248,7 @@ func TestServiceFetchBlocksOneBlock(t *testing.T) {
 	s.testStart()
 
 	// Fetch blocks
-	s.sync(nil)
+	s.sync()
 
 	// Asserts that the last block is the one we expect
 	require.Equal(t, lastRoundAtStart+basics.Round(numBlocks), local.LastRound())
@@ -301,7 +301,7 @@ func TestAbruptWrites(t *testing.T) {
 	// Start the service ( dummy )
 	s.testStart()
 
-	s.sync(nil)
+	s.sync()
 	require.Equal(t, remote.LastRound(), local.LastRound())
 }
 
@@ -322,7 +322,7 @@ func TestServiceFetchBlocksMultiBlocks(t *testing.T) {
 	syncer.testStart()
 
 	// Fetch blocks
-	syncer.sync(nil)
+	syncer.sync()
 
 	// Asserts that the last block is the one we expect
 	require.Equal(t, lastRoundAtStart+numberOfBlocks, local.LastRound())
@@ -353,7 +353,7 @@ func TestServiceFetchBlocksMalformed(t *testing.T) {
 	// Start the service ( dummy )
 	s.testStart()
 
-	s.sync(nil)
+	s.sync()
 	require.Equal(t, lastRoundAtStart, local.LastRound())
 	require.True(t, s.fetcherFactory.(*MockedFetcherFactory).fetcher.client.closed)
 }
@@ -664,7 +664,7 @@ func TestCatchupUnmatchedCertificate(t *testing.T) {
 		}
 		block, _ := remote.Block(basics.Round(roundNumber))
 		pc.Cert.Proposal.BlockDigest = block.Digest()
-		s.sync(pc)
+		s.syncCert(pc)
 		require.True(t, s.latestRoundFetcherFactory.(*MockedFetcherFactory).fetcher.client.closed)
 	}
 }


### PR DESCRIPTION
## Summary

The `catchup.Service.sync` function was incorrectly setting/resetting the `syncStartNS` in the case of the catchup was paused due to a catchpoint file being written.

The PR changes the function logic as follows :
- When the function starts, it sets the `syncStartNS` only if it's zero. That allows as to "resume" previously suspended catchup.
- When the function ends, it tests to see if the catchup termination was due to catchpoint file being written. If so, it doesn't reset the `syncStartNS`.

Also, the PR separate the handling of an agreement-derived `sync()` from a non-agreement derived `sync()`. That simplify the logic of the `sync()` function, and defer the agreement-logic to be implemented in `syncCert()`.

Resolves #1529