### PR TITLE
Separate the error message for duplicate txn id and lease

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -837,10 +837,10 @@ func (aul *accountUpdatesLedgerEvaluator) Totals(rnd basics.Round) (AccountTotal
 	return aul.au.totalsImpl(rnd)
 }
 
-// isDup return whether a transaction is a duplicate one. It's not needed by the accountUpdatesLedgerEvaluator and implemented as a stub.
-func (aul *accountUpdatesLedgerEvaluator) isDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, txlease) (bool, error) {
+// checkDup test to see if the given transaction id/lease already exists. It's not needed by the accountUpdatesLedgerEvaluator and implemented as a stub.
+func (aul *accountUpdatesLedgerEvaluator) checkDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, txlease) error {
 	// this is a non-issue since this call will never be made on non-validating evaluation
-	return false, fmt.Errorf("accountUpdatesLedgerEvaluator: tried to check for dup during accountUpdates initialization ")
+	return fmt.Errorf("accountUpdatesLedgerEvaluator: tried to check for dup during accountUpdates initialization ")
 }
 
 // LookupWithoutRewards returns the account balance for a given address at a given round, without the reward

--- a/ledger/cow_test.go
+++ b/ledger/cow_test.go
@@ -34,8 +34,8 @@ func (ml *mockLedger) lookup(addr basics.Address) (basics.AccountData, error) {
 	return ml.balanceMap[addr], nil
 }
 
-func (ml *mockLedger) isDup(firstValid, lastValid basics.Round, txn transactions.Txid, txl txlease) (bool, error) {
-	return false, nil
+func (ml *mockLedger) checkDup(firstValid, lastValid basics.Round, txn transactions.Txid, txl txlease) error {
+	return nil
 }
 
 func (ml *mockLedger) getAssetCreator(assetIdx basics.AssetIndex) (basics.Address, bool, error) {

--- a/ledger/error.go
+++ b/ledger/error.go
@@ -33,6 +33,17 @@ func (tile TransactionInLedgerError) Error() string {
 	return fmt.Sprintf("transaction already in ledger: %v", tile.Txid)
 }
 
+// LeaseInLedgerError is returned when a transaction cannot be added because it has a lease that already being used in the relavant rounds
+type LeaseInLedgerError struct {
+	txid  transactions.Txid
+	lease txlease
+}
+
+// Error implements the error interface for the LeaseInLedgerError stuct
+func (lile LeaseInLedgerError) Error() string {
+	return fmt.Sprintf("transaction %v using a currently used lease %v", lile.txid, lile.lease)
+}
+
 // BlockInLedgerError is returned when a block cannot be added because it has already been done
 type BlockInLedgerError struct {
 	LastRound basics.Round

--- a/ledger/error.go
+++ b/ledger/error.go
@@ -40,7 +40,7 @@ type LeaseInLedgerError struct {
 }
 
 // Error implements the error interface for the LeaseInLedgerError stuct
-func (lile LeaseInLedgerError) Error() string {
+func (lile *LeaseInLedgerError) Error() string {
 	// format the lease as address.
 	addr := basics.Address(lile.lease.lease)
 	return fmt.Sprintf("transaction %v using an overlapping lease %s", lile.txid, addr.String())

--- a/ledger/error.go
+++ b/ledger/error.go
@@ -41,7 +41,9 @@ type LeaseInLedgerError struct {
 
 // Error implements the error interface for the LeaseInLedgerError stuct
 func (lile LeaseInLedgerError) Error() string {
-	return fmt.Sprintf("transaction %v using a currently used lease %v", lile.txid, lile.lease)
+	// format the lease as address.
+	addr := basics.Address(lile.lease.lease)
+	return fmt.Sprintf("transaction %v using an overlapping lease %s", lile.txid, addr.String())
 }
 
 // BlockInLedgerError is returned when a block cannot be added because it has already been done

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -470,10 +470,10 @@ func (l *Ledger) Totals(rnd basics.Round) (AccountTotals, error) {
 	return l.accts.Totals(rnd)
 }
 
-func (l *Ledger) isDup(currentProto config.ConsensusParams, current basics.Round, firstValid basics.Round, lastValid basics.Round, txid transactions.Txid, txl txlease) (bool, error) {
+func (l *Ledger) checkDup(currentProto config.ConsensusParams, current basics.Round, firstValid basics.Round, lastValid basics.Round, txid transactions.Txid, txl txlease) error {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()
-	return l.txTail.isDup(currentProto, current, firstValid, lastValid, txid, txl)
+	return l.txTail.checkDup(currentProto, current, firstValid, lastValid, txid, txl)
 }
 
 // GetRoundTxIds returns a map of the transactions ids that we have for the given round

--- a/ledger/txtail_test.go
+++ b/ledger/txtail_test.go
@@ -1,0 +1,92 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package ledger
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/protocol"
+)
+
+func TestTxTailCheckdup(t *testing.T) {
+	ledger := makeMockLedgerForTracker(t, true)
+	ledger.blocks = randomInitChain(protocol.ConsensusCurrentVersion, 1)
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	tail := txTail{}
+	require.NoError(t, tail.loadFromDisk(ledger))
+
+	lastRound := basics.Round(proto.MaxTxnLife)
+	lookback := basics.Round(100)
+	txvalidity := basics.Round(10)
+	leasevalidity := basics.Round(32)
+
+	// push 1000 rounds into the txtail
+	for rnd := basics.Round(1); rnd < lastRound; rnd++ {
+		blk := bookkeeping.Block{
+			BlockHeader: bookkeeping.BlockHeader{
+				Round: rnd,
+				UpgradeState: bookkeeping.UpgradeState{
+					CurrentProtocol: protocol.ConsensusCurrentVersion,
+				},
+			},
+		}
+
+		txids := make(map[transactions.Txid]basics.Round)
+		txids[transactions.Txid(crypto.Hash([]byte{byte(rnd % 256), byte(rnd / 256), byte(1)}))] = rnd + txvalidity
+		txleases := make(map[txlease]basics.Round)
+		txleases[txlease{sender: basics.Address(crypto.Hash([]byte{byte(rnd % 256), byte(rnd / 256), byte(2)})), lease: crypto.Hash([]byte{byte(rnd % 256), byte(rnd / 256), byte(3)})}] = rnd + leasevalidity
+
+		tail.newBlock(blk, StateDelta{accts: make(map[basics.Address]accountDelta), hdr: &blk.BlockHeader, Txids: txids, txleases: txleases})
+		tail.committedUpTo(rnd.SubSaturate(lookback))
+	}
+
+	// test txid duplication testing.
+	for rnd := basics.Round(1); rnd < lastRound; rnd++ {
+		txid := transactions.Txid(crypto.Hash([]byte{byte(rnd % 256), byte(rnd / 256), byte(1)}))
+		err := tail.checkDup(proto, basics.Round(0), basics.Round(0), rnd+txvalidity, txid, txlease{})
+		require.Errorf(t, err, "round %d", rnd)
+		if rnd < lastRound-lookback-txvalidity-1 {
+			var missingRoundErr *txtailMissingRound
+			require.Truef(t, errors.As(err, &missingRoundErr), "error a txtailMissingRound(%d) : %v ", rnd, err)
+		} else {
+			var txInLedgerErr *TransactionInLedgerError
+			require.Truef(t, errors.As(err, &txInLedgerErr), "error a TransactionInLedgerError(%d) : %v ", rnd, err)
+		}
+	}
+
+	// test lease detection
+	for rnd := basics.Round(1); rnd < lastRound; rnd++ {
+		lease := txlease{sender: basics.Address(crypto.Hash([]byte{byte(rnd % 256), byte(rnd / 256), byte(2)})), lease: crypto.Hash([]byte{byte(rnd % 256), byte(rnd / 256), byte(3)})}
+		err := tail.checkDup(proto, rnd, basics.Round(0), rnd, transactions.Txid{}, lease)
+		require.Errorf(t, err, "round %d", rnd)
+		if rnd < lastRound-lookback-1 {
+			var missingRoundErr *txtailMissingRound
+			require.Truef(t, errors.As(err, &missingRoundErr), "error a txtailMissingRound(%d) : %v ", rnd, err)
+		} else {
+			var leaseInLedgerErr *LeaseInLedgerError
+			require.Truef(t, errors.As(err, &leaseInLedgerErr), "error a LeaseInLedgerError(%d) : %v ", rnd, err)
+		}
+	}
+}

--- a/test/scripts/e2e_subs/keyreg-teal-test.sh
+++ b/test/scripts/e2e_subs/keyreg-teal-test.sh
@@ -100,7 +100,7 @@ ${gcmd} account changeonlinestatus -a ${ACCOUNTA} -x ${LEASE} --online --firstva
 dsign ${TEMPDIR}/delegate.keyregkey ${TEMPDIR}/kr.lsig < ${TEMPDIR}/keyreg.tx > ${TEMPDIR}/keyreg.stx
 
 RES=$(${gcmd} clerk rawsend -f ${TEMPDIR}/keyreg.stx || true)
-EXPERROR='already in ledger'
+EXPERROR='using an overlapping lease'
 if [[ $RES != *"${EXPERROR}"* ]]; then
     date '+keyreg-teal-test FAIL replayed txn should be rejected %Y%m%d_%H%M%S'
     false


### PR DESCRIPTION
## Summary

Convert isDup to checkDup and move error object generation into checkDup so that we can differentiate between txid duplicate and txlease collision.

## Test Plan

Update existing unit tests and add new one.

resolves #1637