### PR TITLE
Ensure script picks up TRAVIS_BRANCH env var if set

### DIFF
--- a/scripts/release/mule/package/rpm/package.sh
+++ b/scripts/release/mule/package/rpm/package.sh
@@ -6,7 +6,7 @@ echo "Building RPM package"
 
 REPO_DIR=$(pwd)
 FULLVERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
-BRANCH=${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
+BRANCH=${BRANCH:-$(./scripts/compute_branch.sh "$BRANCH")}
 CHANNEL=${CHANNEL:-$(./scripts/compute_branch_channel.sh "$BRANCH")}
 # TODO: Should there be a default network?
 DEFAULTNETWORK=devnet


### PR DESCRIPTION
## Summary

This sets the rpm package script to use the same method to get branch name as the deb package script.  This allows the BRANCH var to get the TRAVIS_BRANCH value, if set.

## Test Plan

`mule -f package.yaml package`
