### PR TITLE
Avoid printing control characters for displaying assets

### DIFF
--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -570,10 +570,12 @@ func printAccountInfo(client libgoal.Client, address string, account v1.Account)
 		if len(name) == 0 {
 			name = "<unnamed>"
 		}
+		_, name = unicodePrintable(name)
 		units := assetParams.UnitName
 		if len(units) == 0 {
 			units = "units"
 		}
+		_, units = unicodePrintable(units)
 		total := assetDecimalsFmt(assetParams.Total, assetParams.Decimals)
 		url := ""
 		if len(assetParams.URL) != 0 {
@@ -602,11 +604,13 @@ func printAccountInfo(client libgoal.Client, address string, account v1.Account)
 		if len(assetName) == 0 {
 			assetName = "<unnamed>"
 		}
+		_, assetName = unicodePrintable(assetName)
 
 		unitName := assetParams.UnitName
 		if len(unitName) == 0 {
 			unitName = "units"
 		}
+		_, unitName = unicodePrintable(unitName)
 
 		frozen := ""
 		if assetHolding.Frozen {

--- a/cmd/goal/accountsList.go
+++ b/cmd/goal/accountsList.go
@@ -228,7 +228,8 @@ func (accountList *AccountsList) outputAccount(addr string, acctInfo v1.Account,
 	if len(acctInfo.AssetParams) > 0 {
 		var out []string
 		for curid, params := range acctInfo.AssetParams {
-			out = append(out, fmt.Sprintf("%d (%d %s)", curid, params.Total, params.UnitName))
+			_, unitName := unicodePrintable(params.UnitName)
+			out = append(out, fmt.Sprintf("%d (%d %s)", curid, params.Total, unitName))
 		}
 		fmt.Printf("\t[created asset IDs: %s]", strings.Join(out, ", "))
 	}

--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -603,7 +603,7 @@ var infoAssetCmd = &cobra.Command{
 
 		fmt.Printf("Asset ID:         %d\n", assetID)
 		fmt.Printf("Creator:          %s\n", params.Creator)
-		fmt.Printf("Asset name:       %s\n", params.AssetName)
+		reportInfof("Asset name:       %s\n", params.AssetName)
 		fmt.Printf("Unit name:        %s\n", params.UnitName)
 		fmt.Printf("Maximum issue:    %s %s\n", assetDecimalsFmt(params.Total, params.Decimals), params.UnitName)
 		fmt.Printf("Reserve amount:   %s %s\n", assetDecimalsFmt(res.Amount, params.Decimals), params.UnitName)

--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -604,7 +604,7 @@ var infoAssetCmd = &cobra.Command{
 		fmt.Printf("Asset ID:         %d\n", assetID)
 		fmt.Printf("Creator:          %s\n", params.Creator)
 		reportInfof("Asset name:       %s\n", params.AssetName)
-		fmt.Printf("Unit name:        %s\n", params.UnitName)
+		reportInfof("Unit name:        %s\n", params.UnitName)
 		fmt.Printf("Maximum issue:    %s %s\n", assetDecimalsFmt(params.Total, params.Decimals), params.UnitName)
 		fmt.Printf("Reserve amount:   %s %s\n", assetDecimalsFmt(res.Amount, params.Decimals), params.UnitName)
 		fmt.Printf("Issued:           %s %s\n", assetDecimalsFmt(params.Total-res.Amount, params.Decimals), params.UnitName)

--- a/test/e2e-go/cli/goal/expect/goalAssetTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalAssetTest.exp
@@ -41,6 +41,13 @@ if { [catch {
         "Asset name:       'testassetname'" { puts "Successfully displayed asset"; close;}
         eof { close; ::AlgorandGoal::Abort "Asset Info Unexpected Result" }
     }
+
+    spawn goal account info --address $PRIMARY_ACCOUNT_ADDRESS --datadir $TEST_PRIMARY_NODE_DIR
+    expect {
+        timeout { close; ::AlgorandGoal::Abort "Account Info Failed" }
+        "'testassetname', supply" { puts "Successfully displayed account asset"; close;}
+        eof { close; ::AlgorandGoal::Abort "Account Info Unexpected Result" }
+    }
 } EXCEPTION] } {
     puts "ERROR in goalFormattingTest: $EXCEPTION"
     exit 1

--- a/test/e2e-go/cli/goal/expect/goalAssetTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalAssetTest.exp
@@ -1,0 +1,47 @@
+#!/usr/bin/expect -f
+set err 0
+log_user 1
+
+if { [catch {
+
+    source  goalExpectCommon.exp
+    set TEST_ALGO_DIR [lindex $argv 0]
+    set TEST_DATA_DIR [lindex $argv 1]
+
+    puts "TEST_ALGO_DIR: $TEST_ALGO_DIR"
+    puts "TEST_DATA_DIR: $TEST_DATA_DIR"
+
+    set TIME_STAMP [clock seconds]
+
+    set TEST_ROOT_DIR $TEST_ALGO_DIR/root
+    set TEST_PRIMARY_NODE_DIR $TEST_ROOT_DIR/Primary/
+    set NETWORK_NAME test_net_expect_$TIME_STAMP
+    set NETWORK_TEMPLATE "$TEST_DATA_DIR/nettemplates/TwoNodes50EachFuture.json"
+
+    exec cp $TEST_DATA_DIR/../../gen/devnet/genesis.json $TEST_ALGO_DIR
+
+    # Create network
+    ::AlgorandGoal::CreateNetwork $NETWORK_NAME $NETWORK_TEMPLATE $TEST_ALGO_DIR $TEST_ROOT_DIR
+
+    ::AlgorandGoal::StartNetwork $NETWORK_NAME $NETWORK_TEMPLATE $TEST_ALGO_DIR $TEST_ROOT_DIR
+
+    set PRIMARY_NODE_ADDRESS [ ::AlgorandGoal::GetAlgodNetworkAddress $TEST_PRIMARY_NODE_DIR ]
+    puts "Primary Node Address: $PRIMARY_NODE_ADDRESS"
+
+    set PRIMARY_WALLET_NAME unencrypted-default-wallet
+
+    # Determine primary account
+    set PRIMARY_ACCOUNT_ADDRESS [::AlgorandGoal::GetHighestFundedAccountForWallet $PRIMARY_WALLET_NAME  $TEST_PRIMARY_NODE_DIR]
+
+    exec goal asset create --creator $PRIMARY_ACCOUNT_ADDRESS --total 90000 --name 'testassetname\b\b\b' --unitname 'u' --datadir $TEST_PRIMARY_NODE_DIR
+
+    spawn goal asset info --creator $PRIMARY_ACCOUNT_ADDRESS --unitname 'u' --datadir $TEST_PRIMARY_NODE_DIR
+    expect {
+        timeout { close; ::AlgorandGoal::Abort "Asset Info Failed" }
+        "Asset name:       'testassetname'" { puts "Successfully displayed asset"; close;}
+        eof { close; ::AlgorandGoal::Abort "Asset Info Unexpected Result" }
+    }
+} EXCEPTION] } {
+    puts "ERROR in goalFormattingTest: $EXCEPTION"
+    exit 1
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Asset names can have control characters, which will be displayed to the terminal when run commands such as `goal asset info`. This allows malicious asset names to delete terminal input and / or print arbitrary input.

## Test Plan

Expect test
