### PR TITLE
Default to branch name when branch parent fails

### DIFF
--- a/scripts/compute_branch_network.sh
+++ b/scripts/compute_branch_network.sh
@@ -18,6 +18,10 @@ fi
 #credit to https://stackoverflow.com/questions/3161204/find-the-parent-branch-of-a-git-branch
 BRANCHPARENT="$(git show-branch | grep '\*' | grep -v '${BRANCH}' | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//')"
 
+if [ $? != 0 ]; then
+    BRANCHPARENT="${BRANCH}"
+fi
+
 if [ "${BRANCHPARENT}" = "rel/stable" ]; then
     echo "testnet"
 elif [ "${BRANCHPARENT}" = "rel/beta" ]; then

--- a/scripts/compute_branch_network.sh
+++ b/scripts/compute_branch_network.sh
@@ -16,11 +16,8 @@ fi
 
 #get parent of current branch
 #credit to https://stackoverflow.com/questions/3161204/find-the-parent-branch-of-a-git-branch
-BRANCHPARENT="$(git show-branch | grep '\*' | grep -v '${BRANCH}' | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//')"
-
-if [ $? != 0 ]; then
-    BRANCHPARENT="${BRANCH}"
-fi
+BRANCHPARENT="$(git show-branch | grep '\*' | grep -v '${BRANCH}' | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//' || ${BRANCH})"
+BRANCHPARENT=${BRANCHPARENT-$BRANCH}
 
 if [ "${BRANCHPARENT}" = "rel/stable" ]; then
     echo "testnet"


### PR DESCRIPTION
Since jenkins doesn't pull the full git tree with refs, this will have compute_branch_network use the current branch instead of the branch parent when that rev parse fails