### PR TITLE
Fix computed network for packaging

### DIFF
--- a/scripts/compute_branch_network.sh
+++ b/scripts/compute_branch_network.sh
@@ -12,6 +12,9 @@ fi
 if [ "${BRANCH}" = "rel/stable" ]; then
     echo "testnet"
     exit 0
+elif [ "${BRANCH}" = "rel/beta" ]; then
+    echo "betanet"
+    exit 0
 fi
 
 #get parent of current branch

--- a/scripts/release/mule/package/deb/package.sh
+++ b/scripts/release/mule/package/deb/package.sh
@@ -14,7 +14,7 @@ VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
 ALGORAND_PACKAGE_NAME=${1:-$(./scripts/compute_package_name.sh "$CHANNEL")}
 PKG_DIR="./tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE"
 
-DEFAULTNETWORK=$("./scripts/compute_branch_network.sh")
+DEFAULTNETWORK=${DEFAULTNETWORK:-$(./scripts/compute_branch_network.sh "$BRANCH")}
 DEFAULT_RELEASE_NETWORK=$("./scripts/compute_branch_release_network.sh" "$DEFAULTNETWORK")
 export DEFAULT_RELEASE_NETWORK
 

--- a/scripts/release/mule/package/rpm/package.sh
+++ b/scripts/release/mule/package/rpm/package.sh
@@ -9,8 +9,7 @@ REPO_DIR=$(pwd)
 FULLVERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
 BRANCH=${BRANCH:-$(./scripts/compute_branch.sh)}
 CHANNEL=${CHANNEL:-$(./scripts/compute_branch_channel.sh "$BRANCH")}
-# TODO: Should there be a default network?
-DEFAULTNETWORK=devnet
+DEFAULTNETWORK=${DEFAULTNETWORK:-$(./scripts/compute_branch_network.sh "$BRANCH")}
 DEFAULT_RELEASE_NETWORK=$(./scripts/compute_branch_release_network.sh "$DEFAULTNETWORK")
 
 find tmp/node_pkgs -name "*${CHANNEL}*linux*${FULLVERSION}*.tar.gz" | cut -d '/' -f3-4 | sort --unique | while read OS_ARCH; do


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

The RPM packaging script wasn't pulling the right network due to hardcoding. Modified this and the deb script to use the passed branch to calculate the correct network. Also modified the compute branch network script to return betanet if passed rel/beta.

## Test Plan

Ensure packaging pipeline selects correct networks for packages.
