### PR TITLE
Harden mule signing task

### DIFF
--- a/scripts/release/mule/sign/sign.sh
+++ b/scripts/release/mule/sign/sign.sh
@@ -17,6 +17,14 @@ PKG_DIR="./tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE"
 SIGNING_KEY_ADDR=dev@algorand.com
 STATUSFILE="build_status_${CHANNEL}_${VERSION}"
 
+# It seems that copying/mounting the gpg dir from another machine can result in insecure
+# access privileges, so set the correct permissions to avoid the following warning:
+#
+#   gpg: WARNING: unsafe permissions on homedir '/root/.gnupg'
+#
+find /root/.gnupg -type d -exec chmod 700 {} \;
+find /root/.gnupg -type f -exec chmod 600 {} \;
+
 cd "$PKG_DIR"
 
 if [ -n "$S3_SOURCE" ]
@@ -47,7 +55,7 @@ do
     gpg -u rpm@algorand.com --detach-sign "$file"
 done
 
-HASHFILE=hashes_${CHANNEL}_${OS_TYPE}_${ARCH_TYPE}_${VERSION}
+HASHFILE="hashes_${CHANNEL}_${OS_TYPE}_${ARCH_TYPE}_${VERSION}"
 
 md5sum *.tar.gz *.deb *.rpm >> "$HASHFILE"
 shasum -a 256 *.tar.gz *.deb *.rpm >> "$HASHFILE"
@@ -56,8 +64,12 @@ shasum -a 512 *.tar.gz *.deb *.rpm >> "$HASHFILE"
 gpg -u "$SIGNING_KEY_ADDR" --detach-sign "$HASHFILE"
 gpg -u "$SIGNING_KEY_ADDR" --clearsign "$HASHFILE"
 
-gpg -u "$SIGNING_KEY_ADDR" --clearsign "$STATUSFILE"
-gzip -c "$STATUSFILE.asc" > "$STATUSFILE.asc.gz"
+# The status file *should* be present, but let's check to be safe.
+if [ -f "$STATUSFILE" ]
+then
+    gpg -u "$SIGNING_KEY_ADDR" --clearsign "$STATUSFILE"
+    gzip -c "$STATUSFILE.asc" > "$STATUSFILE.asc.gz"
+fi
 
 echo
 date "+build_release end SIGN stage %Y%m%d_%H%M%S"

--- a/scripts/release/mule/sign/sign.sh
+++ b/scripts/release/mule/sign/sign.sh
@@ -64,12 +64,8 @@ shasum -a 512 *.tar.gz *.deb *.rpm >> "$HASHFILE"
 gpg -u "$SIGNING_KEY_ADDR" --detach-sign "$HASHFILE"
 gpg -u "$SIGNING_KEY_ADDR" --clearsign "$HASHFILE"
 
-# The status file *should* be present, but let's check to be safe.
-if [ -f "$STATUSFILE" ]
-then
-    gpg -u "$SIGNING_KEY_ADDR" --clearsign "$STATUSFILE"
-    gzip -c "$STATUSFILE.asc" > "$STATUSFILE.asc.gz"
-fi
+gpg -u "$SIGNING_KEY_ADDR" --clearsign "$STATUSFILE"
+gzip -c "$STATUSFILE.asc" > "$STATUSFILE.asc.gz"
 
 echo
 date "+build_release end SIGN stage %Y%m%d_%H%M%S"


### PR DESCRIPTION
## Summary

Improved the signing shell script in the following ways:
1. Fixed gpg warning by setting correct permissions in the docker container.
1. Instead of assuming the build status file is present, check for it first.

## Test Plan

`mule -f package-signing package-signing`