### PR TITLE
Brice/fix blockers

### DIFF
--- a/scripts/build_package.sh
+++ b/scripts/build_package.sh
@@ -88,29 +88,15 @@ done
 
 mkdir ${PKG_ROOT}/genesis
 
-if [ ! -z "${RELEASE_GENESIS_PROCESS}" ]; then
-    genesis_dirs=("devnet" "testnet" "mainnet" "betanet")
-    for dir in "${genesis_dirs[@]}"; do
-        mkdir -p ${PKG_ROOT}/genesis/${dir}
-        cp ${REPO_DIR}/installer/genesis/${dir}/genesis.json ${PKG_ROOT}/genesis/${dir}/
-        #${GOPATHBIN}/buildtools genesis ensure -n ${dir} --source ${REPO_DIR}/gen/${dir}/genesis.json --target ${PKG_ROOT}/genesis/${dir}/genesis.json --releasedir ${REPO_DIR}/installer/genesis
-        if [ $? -ne 0 ]; then exit 1; fi
-    done
-    # Copy the appropriate network genesis.json for our default (in root ./genesis folder)
-    cp ${PKG_ROOT}/genesis/${DEFAULT_RELEASE_NETWORK}/genesis.json ${PKG_ROOT}/genesis
+genesis_dirs=("devnet" "testnet" "mainnet" "betanet")
+for dir in "${genesis_dirs[@]}"; do
+    mkdir -p ${PKG_ROOT}/genesis/${dir}
+    cp ${REPO_DIR}/installer/genesis/${dir}/genesis.json ${PKG_ROOT}/genesis/${dir}/
     if [ $? -ne 0 ]; then exit 1; fi
-elif [[ "${CHANNEL}" == "dev" || "${CHANNEL}" == "stable" || "${CHANNEL}" == "nightly" || "${CHANNEL}" == "beta" ]]; then
-    cp ${REPO_DIR}/installer/genesis/${DEFAULTNETWORK}/genesis.json ${PKG_ROOT}/genesis/
-    #${GOPATHBIN}/buildtools genesis ensure -n ${DEFAULTNETWORK} --source ${REPO_DIR}/gen/${DEFAULTNETWORK}/genesis.json --target ${PKG_ROOT}/genesis/genesis.json --releasedir ${REPO_DIR}/installer/genesis
-    if [ $? -ne 0 ]; then exit 1; fi
-else
-    cp installer/genesis/${DEFAULTNETWORK}/genesis.json ${PKG_ROOT}/genesis
-    if [ $? -ne 0 ]; then exit 1; fi
-    #if [ -z "${TIMESTAMP}" ]; then
-    #  TIMESTAMP=$(date +%s)
-    #fi
-    #${GOPATHBIN}/buildtools genesis timestamp -f ${PKG_ROOT}/genesis/genesis.json -t ${TIMESTAMP}
-fi
+done
+# Copy the appropriate network genesis.json for our default (in root ./genesis folder)
+cp ${PKG_ROOT}/genesis/${DEFAULT_RELEASE_NETWORK}/genesis.json ${PKG_ROOT}/genesis
+if [ $? -ne 0 ]; then exit 1; fi
 
 TOOLS_ROOT=${PKG_ROOT}/tools
 

--- a/scripts/release/common/cpu_name.sh
+++ b/scripts/release/common/cpu_name.sh
@@ -1,0 +1,16 @@
+# Take common name (amd64, arm64, arm) and map to the unames (x86_64, aarch64)
+
+COMMON_NAME="${1}"
+
+if [ "amd64" == "${COMMON_NAME}" ]; then
+    echo "x86_64"
+elif [ "arm64" == "${COMMON_NAME}" ]; then
+    echo "aarch64"
+elif [ "arm32" == "${COMMON_NAME}" ]; then
+    echo "armv7l"
+elif [ "arm" == "${COMMON_NAME}" ]; then
+    echo "armv7l"
+else
+    echo "Unsupported cpu arch ${COMMON_NAME}"
+    exit 1
+fi

--- a/scripts/release/mule/Makefile.mule
+++ b/scripts/release/mule/Makefile.mule
@@ -51,7 +51,7 @@ mule-docker:
 mule-package-%: PKG_TYPE=$*
 mule-package-%:
 	echo Building algorand package...
-	scripts/release/mule/package/$(PKG_TYPE)/package.sh
+	scripts/release/mule/package/$(PKG_TYPE)/package.sh algorand
 	echo Building algorand-devtools package...
 	scripts/release/mule/package/$(PKG_TYPE)/package.sh algorand-devtools
 

--- a/scripts/release/mule/package/rpm/package.sh
+++ b/scripts/release/mule/package/rpm/package.sh
@@ -15,9 +15,10 @@ DEFAULT_RELEASE_NETWORK=$(./scripts/compute_branch_release_network.sh "$DEFAULTN
 find tmp/node_pkgs -name "*${CHANNEL}*linux*${FULLVERSION}*.tar.gz" | cut -d '/' -f3-4 | sort --unique | while read OS_ARCH; do
     OS_TYPE=$(echo "${OS_ARCH}" | cut -d '/' -f1)
     ARCH_TYPE=$(echo "${OS_ARCH}" | cut -d '/' -f2)
+    ARCH_UNAME=$(./scripts/release/common/cpu_name.sh ${ARCH_TYPE})
     ALGO_BIN="$REPO_DIR/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/$CHANNEL/$OS_TYPE-$ARCH_TYPE/bin"
     # A make target in Makefile.mule may pass the name as an argument.
-    ALGORAND_PACKAGE_NAME=${1:-$(./scripts/compute_package_name.sh "$CHANNEL")}
+    ALGORAND_PACKAGE_NAME=${1:-$(./scripts/compute_package_name.sh "$CHANNEL" "$ALGORAND_PACKAGE_NAME")}
 
     if [[ "$ALGORAND_PACKAGE_NAME" =~ devtools ]]; then
         REQUIRED_ALGORAND_PACKAGE=$(./scripts/compute_package_name.sh "$CHANNEL")
@@ -42,11 +43,11 @@ find tmp/node_pkgs -name "*${CHANNEL}*linux*${FULLVERSION}*.tar.gz" | cut -d '/'
     < "./installer/rpm/$INSTALLER_DIR/$INSTALLER_DIR.spec" \
         sed -e "s,@PKG_NAME@,$ALGORAND_PACKAGE_NAME," \
             -e "s,@VER@,$FULLVERSION," \
-            -e "s,@ARCH@,$ARCH_TYPE," \
+            -e "s,@ARCH@,$ARCH_UNAME," \
             -e "s,@REQUIRED_ALGORAND_PKG@,$REQUIRED_ALGORAND_PACKAGE," \
         > "$TEMPDIR/$ALGORAND_PACKAGE_NAME.spec"
 
-    rpmbuild --buildroot "$HOME/foo" --define "_rpmdir $RPMTMP" --define "RELEASE_GENESIS_PROCESS x$RELEASE_GENESIS_PROCESS" --define "LICENSE_FILE ./COPYING" -bb "$TEMPDIR/$ALGORAND_PACKAGE_NAME.spec" --target $ARCH_TYPE
+    rpmbuild --buildroot "$HOME/foo" --define "_rpmdir $RPMTMP" --define "RELEASE_GENESIS_PROCESS x$RELEASE_GENESIS_PROCESS" --define "LICENSE_FILE ./COPYING" -bb "$TEMPDIR/$ALGORAND_PACKAGE_NAME.spec" --target $ARCH_UNAME
 
     cp -p "$RPMTMP"/*/*.rpm "./tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE"
     echo "${RPMTMP}"

--- a/scripts/release/mule/package/rpm/package.sh
+++ b/scripts/release/mule/package/rpm/package.sh
@@ -11,6 +11,7 @@ BRANCH=${BRANCH:-$(./scripts/compute_branch.sh)}
 CHANNEL=${CHANNEL:-$(./scripts/compute_branch_channel.sh "$BRANCH")}
 DEFAULTNETWORK=${DEFAULTNETWORK:-$(./scripts/compute_branch_network.sh "$BRANCH")}
 DEFAULT_RELEASE_NETWORK=$(./scripts/compute_branch_release_network.sh "$DEFAULTNETWORK")
+PACKAGE_NAME="$1"
 
 find tmp/node_pkgs -name "*${CHANNEL}*linux*${FULLVERSION}*.tar.gz" | cut -d '/' -f3-4 | sort --unique | while read OS_ARCH; do
     OS_TYPE=$(echo "${OS_ARCH}" | cut -d '/' -f1)
@@ -18,7 +19,7 @@ find tmp/node_pkgs -name "*${CHANNEL}*linux*${FULLVERSION}*.tar.gz" | cut -d '/'
     ARCH_UNAME=$(./scripts/release/common/cpu_name.sh ${ARCH_TYPE})
     ALGO_BIN="$REPO_DIR/tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/$CHANNEL/$OS_TYPE-$ARCH_TYPE/bin"
     # A make target in Makefile.mule may pass the name as an argument.
-    ALGORAND_PACKAGE_NAME=${1:-$(./scripts/compute_package_name.sh "$CHANNEL" "$ALGORAND_PACKAGE_NAME")}
+    ALGORAND_PACKAGE_NAME=$(./scripts/compute_package_name.sh "$CHANNEL" "$PACKAGE_NAME")
 
     if [[ "$ALGORAND_PACKAGE_NAME" =~ devtools ]]; then
         REQUIRED_ALGORAND_PACKAGE=$(./scripts/compute_package_name.sh "$CHANNEL")


### PR DESCRIPTION
We found these blocking issues while performing a betanet release:

RPM/arch issue when installing yum
Missing genesisfiles for tarballs
missing algorand-devtools-beta package
We updated the yum packages to use the uname style names for cpu architectures, updated our build_packages script to always bundle all long lived network genesis files, and fixed an issue in the rpm packaging scripts so that the devtools package will contain the channel of the build

These were all tested locally by performing the same build our pipeline does