### PR TITLE
Support multiple OS and ARCH for signing

### DIFF
--- a/package-upload.yaml
+++ b/package-upload.yaml
@@ -1,11 +1,23 @@
 tasks:
   - task: s3.BucketCopy
-    name: upload
+    name: amd64
     src: $HOME/projects/go-algorand/tmp/node_pkgs/linux/amd64
-    dest: s3://$STAGING/$CHANNEL/$VERSION
+    dest: s3://$STAGING/$CHANNEL/$VERSION/
+
+  - task: s3.BucketCopy
+    name: arm
+    src: $HOME/projects/go-algorand/tmp/node_pkgs/linux/arm
+    dest: s3://$STAGING/$CHANNEL/$VERSION/
+
+  - task: s3.BucketCopy
+    name: arm64
+    src: $HOME/projects/go-algorand/tmp/node_pkgs/linux/arm64
+    dest: s3://$STAGING/$CHANNEL/$VERSION/
 
 jobs:
   package-upload:
     tasks:
-      - s3.BucketCopy.upload
+      - s3.BucketCopy.amd64
+      - s3.BucketCopy.arm
+      - s3.BucketCopy.arm64
 

--- a/scripts/release/mule/sign/sign.sh
+++ b/scripts/release/mule/sign/sign.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# shellcheck disable=2035,2129
+# shellcheck disable=2035,2129,2162
+
+# TODO: This needs to be reworked a bit to support Darwin.
 
 set -exo pipefail
 
@@ -7,12 +9,11 @@ echo
 date "+build_release begin SIGN stage %Y%m%d_%H%M%S"
 echo
 
-ARCH_TYPE=$(./scripts/archtype.sh)
 OS_TYPE=$(./scripts/ostype.sh)
 VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
 BRANCH=${BRANCH:-$(./scripts/compute_branch.sh)}
 CHANNEL=${CHANNEL:-$(./scripts/compute_branch_channel.sh "$BRANCH")}
-PKG_DIR="./tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE"
+PKG_DIR="./tmp/node_pkgs"
 SIGNING_KEY_ADDR=dev@algorand.com
 STATUSFILE="build_status_${CHANNEL}_${VERSION}"
 
@@ -29,35 +30,52 @@ cd "$PKG_DIR"
 
 if [ -n "$S3_SOURCE" ]
 then
-    aws s3 sync "s3://$S3_SOURCE/$CHANNEL/$VERSION/$OS_TYPE/$ARCH_TYPE/" .
+    aws s3 cp --recursive --exclude "*" --include "*$CHANNEL*$VERSION*" "s3://$S3_SOURCE/$CHANNEL/$VERSION" .
 fi
 
 # TODO: "$PKG_TYPE" == "source"
 
-# Clean package directory of any previous operations.
-rm -rf hashes* *.sig *.asc *.asc.gz
+# https://unix.stackexchange.com/a/46259
+# Grab the directories directly underneath (max-depth 1) ./tmp/node_pkgs/ into a space-delimited string.
+# This will help us target `linux`, `darwin` and (possibly) `windows` build assets.
+# Note the surrounding parens turns the string created by `find` into an array.
+OS_TYPES=($(find . -mindepth 1 -maxdepth 1 -type d -printf '%f\n'))
+for os in "${OS_TYPES[@]}"; do
+    if [ "$os" = linux ]
+    then
+        ARCHS=(amd64 arm arm64)
+        for arch in "${ARCHS[@]}"; do
+            (
+                cd "$OS_TYPE/$arch"
 
-for file in *.tar.gz *.deb
-do
-    gpg -u "$SIGNING_KEY_ADDR" --detach-sign "$file"
+                # Clean package directory of any previous operations.
+                rm -rf hashes* *.sig *.asc *.asc.gz
+
+                for file in *.tar.gz *.deb
+                do
+                    gpg -u "$SIGNING_KEY_ADDR" --detach-sign "$file"
+                done
+
+                for file in *.rpm
+                do
+                    gpg -u rpm@algorand.com --detach-sign "$file"
+                done
+
+                HASHFILE="hashes_${CHANNEL}_${OS_TYPE}_${ARCH_TYPE}_${VERSION}"
+
+                md5sum *.tar.gz *.deb *.rpm >> "$HASHFILE"
+                shasum -a 256 *.tar.gz *.deb *.rpm >> "$HASHFILE"
+                shasum -a 512 *.tar.gz *.deb *.rpm >> "$HASHFILE"
+
+                gpg -u "$SIGNING_KEY_ADDR" --detach-sign "$HASHFILE"
+                gpg -u "$SIGNING_KEY_ADDR" --clearsign "$HASHFILE"
+
+                gpg -u "$SIGNING_KEY_ADDR" --clearsign "$STATUSFILE"
+                gzip -c "$STATUSFILE.asc" > "$STATUSFILE.asc.gz"
+            )
+        done
+    fi
 done
-
-for file in *.rpm
-do
-    gpg -u rpm@algorand.com --detach-sign "$file"
-done
-
-HASHFILE="hashes_${CHANNEL}_${OS_TYPE}_${ARCH_TYPE}_${VERSION}"
-
-md5sum *.tar.gz *.deb *.rpm >> "$HASHFILE"
-shasum -a 256 *.tar.gz *.deb *.rpm >> "$HASHFILE"
-shasum -a 512 *.tar.gz *.deb *.rpm >> "$HASHFILE"
-
-gpg -u "$SIGNING_KEY_ADDR" --detach-sign "$HASHFILE"
-gpg -u "$SIGNING_KEY_ADDR" --clearsign "$HASHFILE"
-
-gpg -u "$SIGNING_KEY_ADDR" --clearsign "$STATUSFILE"
-gzip -c "$STATUSFILE.asc" > "$STATUSFILE.asc.gz"
 
 echo
 date "+build_release end SIGN stage %Y%m%d_%H%M%S"

--- a/scripts/release/mule/sign/sign.sh
+++ b/scripts/release/mule/sign/sign.sh
@@ -9,7 +9,6 @@ echo
 date "+build_release begin SIGN stage %Y%m%d_%H%M%S"
 echo
 
-OS_TYPE=$(./scripts/ostype.sh)
 VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
 BRANCH=${BRANCH:-$(./scripts/compute_branch.sh)}
 CHANNEL=${CHANNEL:-$(./scripts/compute_branch_channel.sh "$BRANCH")}
@@ -46,7 +45,7 @@ for os in "${OS_TYPES[@]}"; do
         ARCHS=(amd64 arm arm64)
         for arch in "${ARCHS[@]}"; do
             (
-                cd "$OS_TYPE/$arch"
+                cd "$os/$arch"
 
                 # Clean package directory of any previous operations.
                 rm -rf hashes* *.sig *.asc *.asc.gz
@@ -61,7 +60,7 @@ for os in "${OS_TYPES[@]}"; do
                     gpg -u rpm@algorand.com --detach-sign "$file"
                 done
 
-                HASHFILE="hashes_${CHANNEL}_${OS_TYPE}_${ARCH_TYPE}_${VERSION}"
+                HASHFILE="hashes_${CHANNEL}_${os}_${arch}_${VERSION}"
 
                 md5sum *.tar.gz *.deb *.rpm >> "$HASHFILE"
                 shasum -a 256 *.tar.gz *.deb *.rpm >> "$HASHFILE"


### PR DESCRIPTION
## Summary

This supports multiple OS and ARCH by downloading assets recursively from s3.  It then will determine multiple OS by inspecting the direct child directories of `tmp/node_pkgs` to determine how to proceed.

Assets are separated by ARCH as usual, i.e. tmp/node_pkgs/OS/ARCH, but when uploaded to staging they all go in the same object (flat directory structure).

## Test Plan

`mule -f package-sign.yaml package-sign`
`mule -f package-upload.yaml package-upload`
