### PR TITLE
Revert "Change rpm package file to match rename (#1666)"

### DIFF
--- a/scripts/release/mule/README.md
+++ b/scripts/release/mule/README.md
@@ -72,6 +72,7 @@ In addition, make sure that the following AWS credentials are set in environment
 
     + `BRANCH`
     + `CHANNEL`
+    + `ARCH_BIT`, i.e., the value from `uname -m`
     + `NETWORK`
     + `S3_SOURCE`, i.e., the S3 bucket from which to download
     + `SHA`, i.e., the value from `git rev-parse HEAD` if not passed on CLI
@@ -96,6 +97,7 @@ In addition, make sure that the following AWS credentials are set in environment
 
     + `BRANCH`
     + `CHANNEL`
+    + `ARCH_BIT`, i.e., the value from `uname -m`
     + `S3_SOURCE`, i.e., the S3 bucket from which to download
     + `VERSION`
 

--- a/scripts/release/mule/sign/sign.sh
+++ b/scripts/release/mule/sign/sign.sh
@@ -7,6 +7,7 @@ echo
 date "+build_release begin SIGN stage %Y%m%d_%H%M%S"
 echo
 
+ARCH_BIT=$(uname -m)
 ARCH_TYPE=$(./scripts/archtype.sh)
 OS_TYPE=$(./scripts/ostype.sh)
 VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
@@ -24,12 +25,19 @@ STATUSFILE="build_status_${CHANNEL}_${VERSION}"
 find /root/.gnupg -type d -exec chmod 700 {} \;
 find /root/.gnupg -type f -exec chmod 600 {} \;
 
-mkdir -p "$PKG_DIR"
 cd "$PKG_DIR"
 
 if [ -n "$S3_SOURCE" ]
 then
-    aws s3 sync "s3://$S3_SOURCE/$CHANNEL/$VERSION/$OS_TYPE/$ARCH_TYPE/" .
+    PREFIX="$S3_SOURCE/$CHANNEL/$VERSION"
+
+    # deb
+    aws s3 cp "s3://$PREFIX/algorand_${CHANNEL}_${OS_TYPE}-${ARCH_TYPE}_${VERSION}.deb" .
+    aws s3 cp "s3://$PREFIX/algorand-devtools_${CHANNEL}_${OS_TYPE}-${ARCH_TYPE}_${VERSION}.deb" .
+
+    # rpm
+    aws s3 cp "s3://$PREFIX/algorand-${VERSION}-1.${ARCH_BIT}.rpm" .
+    aws s3 cp "s3://$PREFIX/algorand-devtools-${VERSION}-1.${ARCH_BIT}.rpm" .
 fi
 
 # TODO: "$PKG_TYPE" == "source"

--- a/scripts/release/mule/test/test.sh
+++ b/scripts/release/mule/test/test.sh
@@ -4,6 +4,8 @@
 set -ex
 
 export PKG_TYPE="$1"
+ARCH_BIT=$(uname -m)
+export ARCH_BIT
 ARCH_TYPE=$(./scripts/archtype.sh)
 export ARCH_TYPE
 OS_TYPE=$(./scripts/ostype.sh)
@@ -28,8 +30,8 @@ then
     aws s3 cp "s3://$PREFIX/algorand-devtools_${CHANNEL}_${OS_TYPE}-${ARCH_TYPE}_${VERSION}.deb" .
 
     # rpm
-    aws s3 cp "s3://$PREFIX/algorand-$CHANNEL-$VERSION-1.$ARCH_TYPE.rpm" .
-    aws s3 cp "s3://$PREFIX/algorand-devtools-$CHANNEL-$VERSION-1.$ARCH_TYPE.rpm" .
+    aws s3 cp "s3://$PREFIX/algorand-$VERSION-1.$ARCH_BIT.rpm" .
+    aws s3 cp "s3://$PREFIX/algorand-devtools-$VERSION-1.$ARCH_BIT.rpm" .
 fi
 
 popd
@@ -50,8 +52,8 @@ else
     # Normally, this is installed for us b/c it's a dependency.
     # See `./installer/rpm/algorand/algorand.spec`.
     yum install yum-cron -y
-    rpm -i algorand-"$VERSION"-1."$ARCH_TYPE".rpm
-    rpm -i algorand-devtools-"$VERSION"-1."$ARCH_TYPE".rpm
+    rpm -i algorand-"$VERSION"-1."$ARCH_BIT".rpm
+    rpm -i algorand-devtools-"$VERSION"-1."$ARCH_BIT".rpm
 fi
 
 popd

--- a/scripts/release/mule/test/tests/pre/verify_control_files.sh
+++ b/scripts/release/mule/test/tests/pre/verify_control_files.sh
@@ -32,7 +32,7 @@ else
     # attempt to generate the .spec file, but it doesn't give us the info we need.
     #
     # Instead, we'll just install using `dpkg` and grep the error stream.
-    if ! rpm -i "./tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/algorand-devtools-$VERSION"*"$ARCH_TYPE".rpm 2> "$RPMTMP/rpm.install"
+    if ! rpm -i "./tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE/algorand-devtools-$VERSION"*"$ARCH_BIT".rpm 2> "$RPMTMP/rpm.install"
     then
         #
         # We're looking for lines that looks like the following:


### PR DESCRIPTION
This reverts commit 450fd8c7984528070fc412aa322af304b54c2a65.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

While we need to change the arch type for other reasons, we do not need to rename the RPM. A separate commit is reverting the name change, so this is reverting the related changes.

## Test Plan

Standard release testing.
