### PR TITLE
Update goal error message for unauthorized access

### DIFF
--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -69,7 +69,7 @@ const (
 	nodeLastCatchpoint                = "Last Catchpoint: %s"
 	errorNodeCreationIPFailure        = "Parsing passed IP %v failed: need a valid IPv4 or IPv6 address with a specified port number"
 	errorNodeNotDetected              = "Algorand node does not appear to be running: %s"
-	errorNodeStatus                   = "Cannot contact Algorand node: %s."
+	errorNodeStatus                   = "Cannot contact Algorand node: %s"
 	errorNodeFailedToStart            = "Algorand node failed to start: %s"
 	errorNodeRunning                  = "Node must be stopped before writing APIToken"
 	errorNodeFailGenToken             = "Cannot generate API token: %s"

--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -117,7 +117,7 @@ func filterASCII(unfilteredString string) (filteredString string) {
 // extractError checks if the response signifies an error (for now, StatusCode != 200 or StatusCode != 201).
 // If so, it returns the error.
 // Otherwise, it returns nil.
-func (client RestClient) extractError(resp *http.Response) error {
+func extractError(resp *http.Response) error {
 	if resp.StatusCode == 200 || resp.StatusCode == 201 {
 		return nil
 	}
@@ -126,8 +126,8 @@ func (client RestClient) extractError(resp *http.Response) error {
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		errorString := filterASCII(string(errorBuf))
-
-		return unauthorizedRequestError{errorString, client.apiToken, resp.Request.URL.String()}
+		apiToken := resp.Request.Header.Get(authHeader)
+		return unauthorizedRequestError{errorString, apiToken, resp.Request.URL.String()}
 	}
 
 	return fmt.Errorf("HTTP %v: %s", resp.Status, errorBuf)
@@ -192,7 +192,7 @@ func (client RestClient) submitForm(response interface{}, path string, request i
 	resp.Body = http.MaxBytesReader(nil, resp.Body, maxRawResponseBytes)
 	defer resp.Body.Close()
 
-	err = client.extractError(resp)
+	err = extractError(resp)
 	if err != nil {
 		return err
 	}
@@ -535,7 +535,7 @@ func (client RestClient) doGetWithQuery(ctx context.Context, path string, queryA
 	}
 	defer resp.Body.Close()
 
-	err = client.extractError(resp)
+	err = extractError(resp)
 	if err != nil {
 		return
 	}

--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -123,14 +123,14 @@ func extractError(resp *http.Response) error {
 	}
 
 	errorBuf, _ := ioutil.ReadAll(resp.Body) // ignore returned error
+	errorString := filterASCII(string(errorBuf))
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		errorString := filterASCII(string(errorBuf))
 		apiToken := resp.Request.Header.Get(authHeader)
 		return unauthorizedRequestError{errorString, apiToken, resp.Request.URL.String()}
 	}
 
-	return fmt.Errorf("HTTP %v: %s", resp.Status, errorBuf)
+	return fmt.Errorf("HTTP %s: %s", resp.Status, errorString)
 }
 
 // stripTransaction gets a transaction of the form "tx-XXXXXXXX" and truncates the "tx-" part, if it starts with "tx-"

--- a/test/e2e-go/cli/algoh/expect/algohTimeoutTest.exp
+++ b/test/e2e-go/cli/algoh/expect/algohTimeoutTest.exp
@@ -69,7 +69,7 @@ if { [catch {
     set timeout 201
     spawn $env(GOPATH)/bin/goal node wait -d $TEST_NODE_DIR -w 200
     expect {
-        "^Cannot contact Algorand node: open $TEST_NODE_DIR/algod.net: no such file or directory." {puts "ERROR: node shutdown"; close; exit 1}
+        "^Cannot contact Algorand node: open $TEST_NODE_DIR/algod.net: no such file or directory" {puts "ERROR: node shutdown"; close; exit 1}
         "^Timed out waiting for node to make progress" {puts "node correctly continued running despite relay shutdown"; close}
         timeout {puts "should not reached this case", close; exit 1}
     }

--- a/test/e2e-go/cli/goal/expect/goalNodeConnectionTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalNodeConnectionTest.exp
@@ -1,0 +1,58 @@
+#!/usr/bin/expect -f
+#exp_internal 1
+set err 0
+log_user 1
+
+if { [catch {
+
+    source  goalExpectCommon.exp
+    set TEST_ALGO_DIR [lindex $argv 0]
+    set TEST_DATA_DIR [lindex $argv 1]
+
+    puts "TEST_ALGO_DIR: $TEST_ALGO_DIR"
+    puts "TEST_DATA_DIR: $TEST_DATA_DIR"
+
+    set TIME_STAMP [clock seconds]
+
+    set TEST_ROOT_DIR $TEST_ALGO_DIR/root
+    set TEST_PRIMARY_NODE_DIR $TEST_ROOT_DIR/Primary/
+    set NETWORK_NAME test_net_expect_$TIME_STAMP
+    set NETWORK_TEMPLATE "$TEST_DATA_DIR/nettemplates/TwoNodes50Each.json"
+
+    # Create network
+    ::AlgorandGoal::CreateNetwork $NETWORK_NAME $NETWORK_TEMPLATE $TEST_ALGO_DIR $TEST_ROOT_DIR
+
+    # Start node
+    ::AlgorandGoal::StartNode $TEST_PRIMARY_NODE_DIR
+
+    exec cp $TEST_PRIMARY_NODE_DIR/algod.admin.token $TEST_PRIMARY_NODE_DIR/algod.admin.token.backup
+    exec echo "XXX" >> $TEST_PRIMARY_NODE_DIR/algod.admin.token
+
+    set UNABLE_TO_CONNECT_MESSAGE 0
+    spawn goal node status -d $TEST_PRIMARY_NODE_DIR
+    expect {
+        timeout { close; ::AlgorandGoal::Abort "failed to test node status" }
+        "Cannot contact Algorand node: Unauthorized request to * when using token *Invalid API Token*" {
+            set UNABLE_TO_CONNECT_MESSAGE 1
+            exp_continue
+        }
+        eof {
+            if {$UNABLE_TO_CONNECT_MESSAGE == 0} {
+                puts "eof received before the expected output " 
+                exit 1
+            }
+        }
+    }
+
+    exec cp $TEST_PRIMARY_NODE_DIR/algod.admin.token.backup $TEST_PRIMARY_NODE_DIR/algod.admin.token
+
+    # Stop node
+    ::AlgorandGoal::StopNode $TEST_PRIMARY_NODE_DIR
+
+    puts "Goal Node Connection Test Successful"
+
+    exit 0
+} EXCEPTION] } {
+    puts "ERROR in goalNodeConnectionTest: $EXCEPTION"
+    exit 1
+}


### PR DESCRIPTION
## Summary

Update error message to be more informative when the libgoal is failing to connect to a node with 401 error.
New error would look like this
```
Cannot contact Algorand node: Unauthorized request to `http://127.0.0.1:5160/v2/status` when using token `d1187151e420f660573403f2068c0948659e4eb9f4c9ecc17d38e72665179d1b` : {"message":"Invalid API Token"}
```

instead of

```
Cannot contact Algorand node: HTTP 401 : {"message":"Invalid API Token"}
.
```


## Test Plan

Update existing test and add a new one.