### PR TITLE
Add e2e test for LegderForLogic

### DIFF
--- a/test/scripts/e2e_subs/e2e-app-cross-round.sh
+++ b/test/scripts/e2e_subs/e2e-app-cross-round.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+date '+app-cross-round-test start %Y%m%d_%H%M%S'
+
+set -e
+set -x
+set -o pipefail
+export SHELLOPTS
+
+WALLET=$1
+
+# Directory of this bash program
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+gcmd="goal -w ${WALLET}"
+
+ACCOUNT=$(${gcmd} account list|awk '{ print $3 }')
+
+printf '#pragma version 2\nint 1' > "${TEMPDIR}/int1.teal"
+APPID=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog ${DIR}/tealprogs/cross-round.teal --global-byteslices 1 --global-ints 1 --local-byteslices 1 --local-ints 1 --clear-prog "${TEMPDIR}/int1.teal" | grep Created | awk '{ print $6 }')
+
+# Should succeed to opt in with first arg hello
+${gcmd} app optin --app-id $APPID --from $ACCOUNT --app-arg "str:first"
+
+# Write should now succeed
+${gcmd} app call --app-id $APPID --from $ACCOUNT --app-arg "str:second"
+
+# Write should now succeed
+${gcmd} app call --app-id $APPID --from $ACCOUNT --app-arg "str:third"
+
+# Delete application should still succeed
+${gcmd} app delete --app-id $APPID --from $ACCOUNT --app-arg "str:any"
+
+# Clear should still succeed with arbitrary args
+${gcmd} app clear --app-id $APPID --from $ACCOUNT --app-arg "str:any"

--- a/test/scripts/e2e_subs/tealprogs/cross-round.teal
+++ b/test/scripts/e2e_subs/tealprogs/cross-round.teal
@@ -1,0 +1,170 @@
+#pragma version 2
+
+// This program writes some data on optin and then
+// validates stored values on subsequent invocations.
+// Invocation parameter is controlled by app arg ("first", "second", "third").
+// The program also establishes behavior for reading and deleting non-existing keys.
+
+// allow app creation and deletion
+txn ApplicationID
+int 0
+==
+bnz success
+
+txn OnCompletion
+int DeleteApplication
+==
+bnz success
+
+txn OnCompletion
+int OptIn
+==
+txna ApplicationArgs 0
+byte "first"
+==
+&&
+bnz first
+txna ApplicationArgs 0
+byte "second"
+==
+bnz second
+txna ApplicationArgs 0
+byte "third"
+==
+bnz third
+b fail
+
+// check non-existing keys deletion and reading
+// write some initial values
+// check same-txn opt-in
+first:
+int 0 // account idx
+int 0 // app idx
+app_opted_in
+bz fail // must be opted in
+// check global non-existing
+int 0
+byte "foo"
+app_global_get_ex
+bnz fail // value may not exist
+// keep one zero value (non-initialized value) on the stack from app_global_get_ex
+byte "foo"
+app_global_get
+// check local non-existing
+// re-use 0 in the top of the stack as account idx = 0 => sender
+// re-use 0 from the stack as app idx
+// this both are done by purpose to coin possible side effects of non-initialized stack values
+byte "bar"
+app_local_get_ex
+bnz fail // value may not exist
+// re-use 0 in the top of the stack as account idx = 0 => sender
+byte "bar"
+app_local_get
+// keep one zero value (non-initialized value) on the stack from app_local_get
+byte "foobar"
+app_global_del
+// re-use 0 in the top of the stack as account idx = 0 => sender
+byte "barfoo"
+app_local_del
+
+// now set some keys
+byte "gki"
+int 100
+app_global_put
+byte "gkb"
+byte "test"
+app_global_put
+int 0
+byte "lki"
+int 200
+app_local_put
+int 0
+byte "lkb"
+byte "anothertest"
+app_local_put
+b success
+
+// check keys written during previous invocation
+// delete one key and update another
+second:
+int 0 // app idx
+byte "gki"
+app_global_get_ex
+bz fail
+int 100
+!=
+bnz fail
+byte "gkb"
+app_global_get
+byte "test"
+!=
+bnz fail
+// check opted-in
+int 0 // account idx
+int 0 // app idx
+app_opted_in
+bz fail // must be opted in
+int 0 // account idx
+int 0 // app idx
+byte "lki"
+app_local_get_ex
+bz fail
+int 200
+!=
+bnz fail
+int 0
+byte "lkb"
+app_local_get
+byte "anothertest"
+!=
+bnz fail
+// delete and update keys
+byte "gki"
+app_global_del
+int 0
+byte "lkb"
+app_local_del
+byte "gkb"
+byte "data"
+app_global_put
+int 0
+byte "lki"
+int 201
+app_local_put
+b success
+
+// check keys updated
+// check deleted keys do not exist
+third:
+int 0 // app idx
+byte "gki"
+app_global_get_ex
+bnz fail
+// re-use 0 in the top of the stack as app idx
+byte "gkb"
+app_global_get_ex
+bz fail
+byte "data"
+!=
+bnz fail
+int 0 // acc idx
+int 0 // app idx
+byte "lki"
+app_local_get_ex
+bz fail
+int 201
+!=
+bnz fail
+int 0
+byte "lkb"
+app_local_get
+int 0 // no such value
+==
+bnz success
+
+// program tail
+fail:
+int 0
+return
+success:
+int 1


### PR DESCRIPTION
## Summary

For upcoming ledger update we need to coin current TEAL behavior for key value store:
  - deletion of non-existing keys is no-op
  - reading non-existing keys does not fail and returns zero/empty value
  - values are preserved between rounds
  - opted_in works during OptIn and after

## Test Plan

This is a test