### PR TITLE
Dynamically adjust catchpoint file serving timeouts based on file size

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -739,13 +739,35 @@ func (au *accountUpdates) Totals(rnd basics.Round) (totals AccountTotals, err er
 	return au.totalsImpl(rnd)
 }
 
-// GetCatchpointStream returns an io.Reader to the catchpoint file associated with the provided round
-func (au *accountUpdates) GetCatchpointStream(round basics.Round) (io.ReadCloser, error) {
+// ReadCloseSizer interface implements the standard io.Reader and io.Closer as well
+// as supporting the Size() function that let the caller know what the size of the stream would be (in bytes).
+type ReadCloseSizer interface {
+	io.ReadCloser
+	Size() (int64, error)
+}
+
+// readCloseSizer is an instance of the ReadCloseSizer interface
+type readCloseSizer struct {
+	io.ReadCloser
+	size int64
+}
+
+// Size returns the length of the assiciated stream.
+func (r *readCloseSizer) Size() (int64, error) {
+	if r.size < 0 {
+		return 0, fmt.Errorf("unknown stream size")
+	}
+	return r.size, nil
+}
+
+// GetCatchpointStream returns a ReadCloseSizer to the catchpoint file associated with the provided round
+func (au *accountUpdates) GetCatchpointStream(round basics.Round) (ReadCloseSizer, error) {
 	dbFileName := ""
+	fileSize := int64(0)
 	start := time.Now()
 	ledgerGetcatchpointCount.Inc(nil)
 	err := au.dbs.rdb.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
-		dbFileName, _, _, err = getCatchpoint(tx, round)
+		dbFileName, _, fileSize, err = getCatchpoint(tx, round)
 		return
 	})
 	ledgerGetcatchpointMicros.AddMicrosecondsSince(start, nil)
@@ -757,7 +779,7 @@ func (au *accountUpdates) GetCatchpointStream(round basics.Round) (io.ReadCloser
 		catchpointPath := filepath.Join(au.dbDirectory, dbFileName)
 		file, err := os.OpenFile(catchpointPath, os.O_RDONLY, 0666)
 		if err == nil && file != nil {
-			return file, nil
+			return &readCloseSizer{ReadCloser: file, size: fileSize}, nil
 		}
 		// else, see if this is a file-not-found error
 		if os.IsNotExist(err) {
@@ -784,14 +806,14 @@ func (au *accountUpdates) GetCatchpointStream(round basics.Round) (io.ReadCloser
 		fileInfo, err := file.Stat()
 		if err != nil {
 			// we couldn't get the stat, so just return with the file.
-			return file, nil
+			return &readCloseSizer{ReadCloser: file, size: -1}, nil
 		}
 
 		err = au.saveCatchpointFile(round, fileName, fileInfo.Size(), "")
 		if err != nil {
 			au.log.Warnf("accountUpdates: getCatchpointStream: unable to save missing catchpoint entry: %v", err)
 		}
-		return file, nil
+		return &readCloseSizer{ReadCloser: file, size: fileInfo.Size()}, nil
 	}
 	return nil, ErrNoEntry{}
 }

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1108,7 +1108,7 @@ func TestGetCatchpointStream(t *testing.T) {
 	require.Equal(t, 3, n)
 	outData := []byte{1, 2, 3}
 	require.Equal(t, outData, dataRead)
-	len, err := reader.Length()
+	len, err := reader.Size()
 	require.NoError(t, err)
 	require.Equal(t, int64(3), len)
 

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1094,7 +1094,7 @@ func TestGetCatchpointStream(t *testing.T) {
 		require.NoError(t, err)
 
 		// Store the catchpoint into the database
-		err := au.accountsq.storeCatchpoint(context.Background(), basics.Round(i), fileName, "", 0)
+		err := au.accountsq.storeCatchpoint(context.Background(), basics.Round(i), fileName, "", int64(len(data)))
 		require.NoError(t, err)
 	}
 
@@ -1108,6 +1108,9 @@ func TestGetCatchpointStream(t *testing.T) {
 	require.Equal(t, 3, n)
 	outData := []byte{1, 2, 3}
 	require.Equal(t, outData, dataRead)
+	len, err := reader.Length()
+	require.NoError(t, err)
+	require.Equal(t, int64(3), len)
 
 	// File deleted, but record in the database
 	err = os.Remove(filepath.Join(temporaryDirectroy, "catchpoints", "2.catchpoint"))

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io"
 	"os"
 	"time"
 
@@ -604,12 +603,12 @@ func (l *Ledger) GetCatchpointCatchupState(ctx context.Context) (state Catchpoin
 	return MakeCatchpointCatchupAccessor(l, l.log).GetState(ctx)
 }
 
-// GetCatchpointStream returns an io.ReadCloser file stream from which the catchpoint file
+// GetCatchpointStream returns a ReadCloseSizer file stream from which the catchpoint file
 // for the provided round could be retrieved. If no such stream can be generated, a non-nil
 // error is returned. The io.ReadCloser and the error are mutually exclusive -
 // if error is returned, the file stream is guaranteed to be nil, and vice versa,
 // if the file stream is not nil, the error is guaranteed to be nil.
-func (l *Ledger) GetCatchpointStream(round basics.Round) (io.ReadCloser, error) {
+func (l *Ledger) GetCatchpointStream(round basics.Round) (ReadCloseSizer, error) {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()
 	return l.accts.GetCatchpointStream(round)

--- a/rpcs/ledgerService.go
+++ b/rpcs/ledgerService.go
@@ -47,14 +47,11 @@ const (
 	// e.g. .Handle(LedgerServiceLedgerPath, &ls)
 	LedgerServiceLedgerPath = "/v{version:[0-9.]+}/{genesisID}/ledger/{round:[0-9a-z]+}"
 
-	// maxCatchpointFileSize is a rough estimate for the worst-case scenario we're going to have of all the accounts data per a single catchpoint file chunk.
+	// maxCatchpointFileSize is the default catchpoint file size, if we can't get a concreate number from the ledger.
 	maxCatchpointFileSize = 512 * 1024 * 1024 // 512MB
 
-	// expectedWorstDownloadSpeedBytesPerSecond defines the worst-case scenario upload speed we expect to get while uploading a catchpoint file
-	expectedWorstDownloadSpeedBytesPerSecond = 200 * 1024
-
-	// maxCatchpointFileChunkDownloadDuration is the maximum amount of time we would wait to download a single chunk off a catchpoint file
-	maxCatchpointFileWritingDuration = 2*time.Minute + maxCatchpointFileSize*time.Second/expectedWorstDownloadSpeedBytesPerSecond
+	// expectedWorstUploadSpeedBytesPerSecond defines the worst-case scenario upload speed we expect to get while uploading a catchpoint file
+	expectedWorstUploadSpeedBytesPerSecond = 20 * 1024
 )
 
 // LedgerService represents the Ledger RPC API
@@ -177,11 +174,6 @@ func (ls *LedgerService) ServeHTTP(response http.ResponseWriter, request *http.R
 		response.Write([]byte(fmt.Sprintf("specified round number could not be parsed using base 36 : %v", err)))
 		return
 	}
-	if conn := ls.net.GetHTTPRequestConnection(request); conn != nil {
-		conn.SetWriteDeadline(time.Now().Add(maxCatchpointFileWritingDuration))
-	} else {
-		logging.Base().Warnf("LedgerService.ServeHTTP unable to set connection timeout")
-	}
 	cs, err := ls.ledger.GetCatchpointStream(basics.Round(round))
 	if err != nil {
 		switch err.(type) {
@@ -199,6 +191,20 @@ func (ls *LedgerService) ServeHTTP(response http.ResponseWriter, request *http.R
 		}
 	}
 	defer cs.Close()
+	if conn := ls.net.GetHTTPRequestConnection(request); conn != nil {
+		maxCatchpointFileWritingDuration := 2 * time.Minute
+
+		catchpointFileSize, err := cs.Size()
+		if err != nil || catchpointFileSize <= 0 {
+			maxCatchpointFileWritingDuration += maxCatchpointFileSize * time.Second / expectedWorstUploadSpeedBytesPerSecond
+		} else {
+			maxCatchpointFileWritingDuration += time.Duration(catchpointFileSize) * time.Second / expectedWorstUploadSpeedBytesPerSecond
+		}
+		conn.SetWriteDeadline(time.Now().Add(maxCatchpointFileWritingDuration))
+	} else {
+		logging.Base().Warnf("LedgerService.ServeHTTP unable to set connection timeout")
+	}
+
 	response.Header().Set("Content-Type", LedgerResponseContentType)
 	requestedCompressedResponse := strings.Contains(request.Header.Get("Accept-Encoding"), "gzip")
 	if requestedCompressedResponse {


### PR DESCRIPTION
## Summary

The catchpoint file serving used to have a hard-coded timeout for all catchpoint file requests. This is sub-optimal, since large catchpoint files would be served over longer period of time.

This PR dynamically adjust the timeout based on the file size, taking advantage of the sizing information we already store in the database, and passing it upstream.

## Test Plan

Unit tests updated.