### PR TITLE
Env variables while make execution list is created

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 UNAME := $(shell uname)
-ifneq (, $(findstring MINGW,$(UNAME)))
+ifneq (,$(findstring MINGW,$(UNAME)))
 #Gopath is not saved across sessions, probably existing Windows env vars, override them
-export GOPATH := ${HOME}/go
+export GOPATH := $(HOME)/go
 GOPATH1 := $(GOPATH)
 export PATH := $(PATH):$(GOPATH)/bin
 else
@@ -51,7 +51,7 @@ export GOBUILDMODE := -buildmode=exe
 endif
 
 GOTAGS      := --tags "$(GOTAGSLIST)"
-GOTRIMPATH	:= $(shell go help build | grep -q .-trimpath && echo -trimpath)
+GOTRIMPATH	:= $(shell GOPATH=$(GOPATH) && go help build | grep -q .-trimpath && echo -trimpath)
 
 GOLDFLAGS_BASE  := -X github.com/algorand/go-algorand/config.BuildNumber=$(BUILDNUMBER) \
 		 -X github.com/algorand/go-algorand/config.CommitHash=$(COMMITHASH) \
@@ -62,8 +62,8 @@ GOLDFLAGS_BASE  := -X github.com/algorand/go-algorand/config.BuildNumber=$(BUILD
 GOLDFLAGS := $(GOLDFLAGS_BASE) \
 		 -X github.com/algorand/go-algorand/config.Channel=$(CHANNEL)
 
-UNIT_TEST_SOURCES := $(sort $(shell GO111MODULE=off go list ./... | grep -v /go-algorand/test/ ))
-ALGOD_API_PACKAGES := $(sort $(shell GO111MODULE=off cd daemon/algod/api; go list ./... ))
+UNIT_TEST_SOURCES := $(sort $(shell GOPATH=$(GOPATH) && GO111MODULE=off && go list ./... | grep -v /go-algorand/test/ ))
+ALGOD_API_PACKAGES := $(sort $(shell GOPATH=$(GOPATH) && GO111MODULE=off && cd daemon/algod/api; go list ./... ))
 
 MSGP_GENERATE	:= ./protocol ./crypto ./crypto/compactcert ./data/basics ./data/transactions ./data/committee ./data/bookkeeping ./data/hashable ./auction ./agreement ./rpcs ./node ./ledger
 


### PR DESCRIPTION
Exported environment variables are not propagated to child processes while the script is being evaluated and variables resolved. This is the normal behavior of `make`.

This causes, for e.g., `go list` execution while resolving variables like `UNIT_TEST_SOURCES` to receive the original `GOPATH` variable instead of the modified at the beginning of the script.

On the other hand, MinGW/Windows also requires to add delimiters or concat multiple command with the `&&` operator for actions executed with `$shell`

The fix ensures correct variables are passed down and also, on Windows, it prevents dependencies to be installed outside the `MSYS2` box if Go is installed outside `MSYS2` environment too.

The example makefile below shows the issue. You can observe the first `RESULT` does not include the value of `SAMPLEVAR`.

    export SAMPLEVAR := 1234
    RESULT := $(shell sh -c "printenv")
    
    $(info *********** PRINTING VALUE OF RESULT ***************)
    $(info $(RESULT))
    $(info *********** END ************************************)
    
    RESULT2 := $(shell SAMPLEVAR="$(SAMPLEVAR)" sh -c "printenv")
    
    $(info *********** PRINTING VALUE OF RESULT 2 *************)
    $(info $(RESULT2))
    $(info *********** END ************************************)
    
    default:
            sh -c "printenv"
