### PR TITLE
Static linking in Windows executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 UNAME := $(shell uname)
-ifneq (, $(findstring MINGW,$(UNAME)))
+ifneq (,$(findstring MINGW,$(UNAME)))
 #Gopath is not saved across sessions, probably existing Windows env vars, override them
-export GOPATH := ${HOME}/go
+export GOPATH := $(HOME)/go
 GOPATH1 := $(GOPATH)
 export PATH := $(PATH):$(GOPATH)/bin
 else
@@ -51,7 +51,7 @@ export GOBUILDMODE := -buildmode=exe
 endif
 
 GOTAGS      := --tags "$(GOTAGSLIST)"
-GOTRIMPATH	:= $(shell go help build | grep -q .-trimpath && echo -trimpath)
+GOTRIMPATH	:= $(shell GOPATH=$(GOPATH) && go help build | grep -q .-trimpath && echo -trimpath)
 
 GOLDFLAGS_BASE  := -X github.com/algorand/go-algorand/config.BuildNumber=$(BUILDNUMBER) \
 		 -X github.com/algorand/go-algorand/config.CommitHash=$(COMMITHASH) \
@@ -62,8 +62,8 @@ GOLDFLAGS_BASE  := -X github.com/algorand/go-algorand/config.BuildNumber=$(BUILD
 GOLDFLAGS := $(GOLDFLAGS_BASE) \
 		 -X github.com/algorand/go-algorand/config.Channel=$(CHANNEL)
 
-UNIT_TEST_SOURCES := $(sort $(shell GO111MODULE=off go list ./... | grep -v /go-algorand/test/ ))
-ALGOD_API_PACKAGES := $(sort $(shell GO111MODULE=off cd daemon/algod/api; go list ./... ))
+UNIT_TEST_SOURCES := $(sort $(shell GOPATH=$(GOPATH) && GO111MODULE=off && go list ./... | grep -v /go-algorand/test/ ))
+ALGOD_API_PACKAGES := $(sort $(shell GOPATH=$(GOPATH) && GO111MODULE=off && cd daemon/algod/api; go list ./... ))
 
 MSGP_GENERATE	:= ./protocol ./crypto ./crypto/compactcert ./data/basics ./data/transactions ./data/committee ./data/bookkeeping ./data/hashable ./auction ./agreement ./rpcs ./node ./ledger
 

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,10 @@ buildsrc: crypto/libs/$(OS_TYPE)/$(ARCH)/lib/libsodium.a node_exporter NONGO_BIN
 	mkdir -p tmp/go-cache && \
 	touch tmp/go-cache/file.txt && \
 	GOCACHE=$(SRCPATH)/tmp/go-cache go install $(GOTRIMPATH) $(GOTAGS) $(GOBUILDMODE) -ldflags="$(GOLDFLAGS)" ./...
+	UNAME=$(uname); \
+	if [[ "${UNAME}" == *"MINGW"* ]]; then \
+		cp /mingw64/bin/libwinpthread-1.dll $(GOPATH1)/bin/ ; \
+	fi
 
 SOURCES_RACE := github.com/algorand/go-algorand/cmd/kmd
 

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ endif
 endif
 
 ifneq (, $(findstring MINGW,$(UNAME)))
-EXTLDFLAGS := -static-libstdc++ -static-libgcc
+EXTLDFLAGS := -static -static-libstdc++ -static-libgcc
 export GOBUILDMODE := -buildmode=exe
 endif
 
@@ -176,10 +176,6 @@ buildsrc: crypto/libs/$(OS_TYPE)/$(ARCH)/lib/libsodium.a node_exporter NONGO_BIN
 	mkdir -p tmp/go-cache && \
 	touch tmp/go-cache/file.txt && \
 	GOCACHE=$(SRCPATH)/tmp/go-cache go install $(GOTRIMPATH) $(GOTAGS) $(GOBUILDMODE) -ldflags="$(GOLDFLAGS)" ./...
-	UNAME=$(uname); \
-	if [[ "${UNAME}" == *"MINGW"* ]]; then \
-		cp /mingw64/bin/libwinpthread-1.dll $(GOPATH1)/bin/ ; \
-	fi
 
 SOURCES_RACE := github.com/algorand/go-algorand/cmd/kmd
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/algorand/go-algorand
 go 1.14
 
 require (
-        github.com/go-swagger/go-swagger/cmd/swagger v0.25.0
+	github.com/go-swagger/go-swagger/cmd/swagger v0.25.0
 	github.com/algorand/go-codec/codec v0.0.0-20190507210007-269d70b6135d
 	github.com/algorand/go-deadlock v0.2.1
 	github.com/algorand/msgp v1.1.45

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/algorand/go-algorand
 go 1.14
 
 require (
+        github.com/go-swagger/go-swagger/cmd/swagger v0.25.0
 	github.com/algorand/go-codec/codec v0.0.0-20190507210007-269d70b6135d
 	github.com/algorand/go-deadlock v0.2.1
 	github.com/algorand/msgp v1.1.45

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/algorand/go-algorand
 go 1.14
 
 require (
-	github.com/go-swagger/go-swagger/cmd/swagger v0.25.0
 	github.com/algorand/go-codec/codec v0.0.0-20190507210007-269d70b6135d
 	github.com/algorand/go-deadlock v0.2.1
 	github.com/algorand/msgp v1.1.45

--- a/scripts/configure_dev-deps.sh
+++ b/scripts/configure_dev-deps.sh
@@ -6,12 +6,12 @@ function get_go_version {
     if [[ -z "$2" ]]
     then
         (
-        cd $(dirname "$0")
-        VERSION=$(cat ../go.mod | grep "$1" 2>/dev/null | awk -F " " '{print $2}')
-        echo $VERSION
+        cd "$(dirname "$0")"
+        VERSION=$( grep "$1" 2>/dev/null < ../go.mod | awk -F " " '{print $2}')
+        echo "$VERSION"
         )
     else
-        (echo $2)
+        (echo "$2")
     fi
     return
 }

--- a/scripts/configure_dev-deps.sh
+++ b/scripts/configure_dev-deps.sh
@@ -3,18 +3,23 @@
 set -ex
 
 function get_go_version {
-    (
-	cd $(dirname "$0")
-	VERSION=$(cat ../go.mod | grep "$1" 2>/dev/null | awk -F " " '{print $2}')
-	echo $VERSION
-    )
+    if [[ -z "$2" ]]
+    then
+        (
+        cd $(dirname "$0")
+        VERSION=$(cat ../go.mod | grep "$1" 2>/dev/null | awk -F " " '{print $2}')
+        echo $VERSION
+        )
+    else
+        (echo $2)
+    fi
     return
 }
 
 function install_go_module {
     local OUTPUT
     # Check for version to go.mod version
-    VERSION=$(get_go_version "$1")
+    VERSION=$(get_go_version "$1" "$2")
     if [ -z "$VERSION" ]; then
      	OUTPUT=$(GO111MODULE=off go get -u "$1" 2>&1)
     else
@@ -28,5 +33,5 @@ function install_go_module {
 
 install_go_module golang.org/x/lint/golint
 install_go_module golang.org/x/tools/cmd/stringer
-install_go_module github.com/go-swagger/go-swagger/cmd/swagger
+install_go_module github.com/go-swagger/go-swagger/cmd/swagger v0.25.0
 install_go_module github.com/algorand/msgp


### PR DESCRIPTION
Most of Windows binaries depends on the `MINGW` shared `pthreads` library. This addition copies it to the output directory on Windows builds.
