### PR TITLE
Specify swagger version v0.25.0 to fix build.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/algorand/go-algorand
 go 1.14
 
 require (
-        github.com/go-swagger/go-swagger/cmd/swagger v0.25.0
+	github.com/go-swagger/go-swagger/cmd/swagger v0.25.0
 	github.com/algorand/go-codec/codec v0.0.0-20190507210007-269d70b6135d
 	github.com/algorand/go-deadlock v0.2.1
 	github.com/algorand/msgp v1.1.45

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/algorand/go-algorand
 go 1.14
 
 require (
+        github.com/go-swagger/go-swagger/cmd/swagger v0.25.0
 	github.com/algorand/go-codec/codec v0.0.0-20190507210007-269d70b6135d
 	github.com/algorand/go-deadlock v0.2.1
 	github.com/algorand/msgp v1.1.45

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/algorand/go-algorand
 go 1.14
 
 require (
-	github.com/go-swagger/go-swagger/cmd/swagger v0.25.0
 	github.com/algorand/go-codec/codec v0.0.0-20190507210007-269d70b6135d
 	github.com/algorand/go-deadlock v0.2.1
 	github.com/algorand/msgp v1.1.45

--- a/scripts/configure_dev-deps.sh
+++ b/scripts/configure_dev-deps.sh
@@ -6,12 +6,12 @@ function get_go_version {
     if [[ -z "$2" ]]
     then
         (
-        cd $(dirname "$0")
-        VERSION=$(cat ../go.mod | grep "$1" 2>/dev/null | awk -F " " '{print $2}')
-        echo $VERSION
+        cd "$(dirname "$0")"
+        VERSION=$( grep "$1" 2>/dev/null < ../go.mod | awk -F " " '{print $2}')
+        echo "$VERSION"
         )
     else
-        (echo $2)
+        (echo "$2")
     fi
     return
 }

--- a/scripts/configure_dev-deps.sh
+++ b/scripts/configure_dev-deps.sh
@@ -3,18 +3,23 @@
 set -ex
 
 function get_go_version {
-    (
-	cd $(dirname "$0")
-	VERSION=$(cat ../go.mod | grep "$1" 2>/dev/null | awk -F " " '{print $2}')
-	echo $VERSION
-    )
+    if [[ -z "$2" ]]
+    then
+        (
+        cd $(dirname "$0")
+        VERSION=$(cat ../go.mod | grep "$1" 2>/dev/null | awk -F " " '{print $2}')
+        echo $VERSION
+        )
+    else
+        (echo $2)
+    fi
     return
 }
 
 function install_go_module {
     local OUTPUT
     # Check for version to go.mod version
-    VERSION=$(get_go_version "$1")
+    VERSION=$(get_go_version "$1" "$2")
     if [ -z "$VERSION" ]; then
      	OUTPUT=$(GO111MODULE=off go get -u "$1" 2>&1)
     else
@@ -28,5 +33,5 @@ function install_go_module {
 
 install_go_module golang.org/x/lint/golint
 install_go_module golang.org/x/tools/cmd/stringer
-install_go_module github.com/go-swagger/go-swagger/cmd/swagger
+install_go_module github.com/go-swagger/go-swagger/cmd/swagger v0.25.0
 install_go_module github.com/algorand/msgp


### PR DESCRIPTION

## Summary

Fix a build problem by specifying version 0.25.0 of the go swagger module.  The latest released version is stricter and breaking the build.  

## Test Plan

Tested with scripts/configure_dev-deps.sh to ensure that the correct version is installed. 
