### PR TITLE
Write the catchpoint file in parallel of reading from the database

### DIFF
--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1161,9 +1161,9 @@ func BenchmarkLargeMerkleTrieRebuild(b *testing.B) {
 
 	// at this point, the database was created. We want to fill the accounts data
 	accountsNumber := 6000000 * b.N
-	for i := 0; i < accountsNumber; {
+	for i := 0; i < accountsNumber-5-2; { // subtract the account we've already created above, plus the sink/reward
 		updates := make(map[basics.Address]accountDelta, 0)
-		for k := 0; i < accountsNumber && k < 1024; k++ {
+		for k := 0; i < accountsNumber-5-2 && k < 1024; k++ {
 			addr := randomAddress()
 			acctData := basics.AccountData{}
 			acctData.MicroAlgos.Raw = 1
@@ -1189,4 +1189,72 @@ func BenchmarkLargeMerkleTrieRebuild(b *testing.B) {
 	require.NoError(b, err)
 	b.StopTimer()
 	b.ReportMetric(float64(accountsNumber), "entries/trie")
+}
+
+func BenchmarkLargeCatchpointWriting(b *testing.B) {
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+
+	ml := makeMockLedgerForTracker(b, true)
+	defer ml.close()
+	ml.blocks = randomInitChain(protocol.ConsensusCurrentVersion, 10)
+
+	accts := []map[basics.Address]basics.AccountData{randomAccounts(5, true)}
+
+	pooldata := basics.AccountData{}
+	pooldata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
+	pooldata.Status = basics.NotParticipating
+	accts[0][testPoolAddr] = pooldata
+
+	sinkdata := basics.AccountData{}
+	sinkdata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
+	sinkdata.Status = basics.NotParticipating
+	accts[0][testSinkAddr] = sinkdata
+
+	au := &accountUpdates{}
+	cfg := config.GetDefaultLocal()
+	cfg.Archival = true
+	au.initialize(cfg, ".", proto, accts[0])
+	defer au.close()
+
+	temporaryDirectroy, err := ioutil.TempDir(os.TempDir(), "catchpoints")
+	require.NoError(b, err)
+	defer func() {
+		os.RemoveAll(temporaryDirectroy)
+	}()
+	catchpointsDirectory := filepath.Join(temporaryDirectroy, "catchpoints")
+	err = os.Mkdir(catchpointsDirectory, 0777)
+	require.NoError(b, err)
+
+	au.dbDirectory = temporaryDirectroy
+
+	err = au.loadFromDisk(ml)
+	require.NoError(b, err)
+
+	// at this point, the database was created. We want to fill the accounts data
+	accountsNumber := 6000000 * b.N
+	err = ml.dbs.wdb.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
+		for i := 0; i < accountsNumber-5-2; { // subtract the account we've already created above, plus the sink/reward
+			updates := make(map[basics.Address]accountDelta, 0)
+			for k := 0; i < accountsNumber-5-2 && k < 1024; k++ {
+				addr := randomAddress()
+				acctData := basics.AccountData{}
+				acctData.MicroAlgos.Raw = 1
+				updates[addr] = accountDelta{new: acctData}
+				i++
+			}
+
+			err = accountsNewRound(tx, updates, nil, proto)
+			if err != nil {
+				return
+			}
+		}
+
+		return updateAccountsRound(tx, 0, 1)
+	})
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	au.generateCatchpoint(basics.Round(0), "0#ABCD", crypto.Digest{}, time.Second)
+	b.StopTimer()
+	b.ReportMetric(float64(accountsNumber), "accounts")
 }

--- a/ledger/catchpointwriter.go
+++ b/ledger/catchpointwriter.go
@@ -170,6 +170,24 @@ func (cw *catchpointWriter) WriteStep(stepCtx context.Context) (more bool, err e
 		cw.headerWritten = true
 	}
 
+	writerRequest := make(chan catchpointFileBalancesChunk, 1)
+	writerResponse := make(chan error, 2)
+	go cw.asyncWriter(writerRequest, writerResponse, cw.balancesChunkNum)
+	defer func() {
+		close(writerRequest)
+		// wait for the writerResponse to close.
+		for {
+			select {
+			case writerError, open := <-writerResponse:
+				if open {
+					err = writerError
+				} else {
+					return
+				}
+			}
+		}
+	}()
+
 	for {
 		// have we timed-out / canceled by that point ?
 		if more, err = hasContextDeadlineExceeded(stepCtx); more == true || err != nil {
@@ -188,39 +206,80 @@ func (cw *catchpointWriter) WriteStep(stepCtx context.Context) (more bool, err e
 			return
 		}
 
+		// check if we had any error on the writer from previous iterations.
+		select {
+		case err := <-writerResponse:
+			// we ran into an error. wait for the channel to close before returning with the error.
+			select {
+			case <-writerResponse:
+			}
+			return false, err
+		default:
+		}
+
 		// write to disk.
 		if len(cw.balancesChunk.Balances) > 0 {
 			cw.balancesChunkNum++
-			encodedChunk := protocol.Encode(&cw.balancesChunk)
-			err = cw.tar.WriteHeader(&tar.Header{
-				Name: fmt.Sprintf("balances.%d.%d.msgpack", cw.balancesChunkNum, cw.fileHeader.TotalChunks),
-				Mode: 0600,
-				Size: int64(len(encodedChunk)),
-			})
-
-			if err != nil {
-				return
-			}
-			_, err = cw.tar.Write(encodedChunk)
-			if err != nil {
-				return
-			}
-
+			writerRequest <- cw.balancesChunk
 			if len(cw.balancesChunk.Balances) < BalancesPerCatchpointFileChunk || cw.balancesChunkNum == cw.fileHeader.TotalChunks {
-				cw.tar.Close()
-				cw.gzip.Close()
-				cw.file.Close()
-				cw.balancesChunk.Balances = nil
-				cw.file = nil
-				var fileInfo os.FileInfo
-				fileInfo, err = os.Stat(cw.filePath)
-				if err != nil {
-					return false, err
+				cw.accountsIterator.Close()
+				// if we're done, wait for the writer to complete it's writing.
+				select {
+				case err, opened := <-writerResponse:
+					if opened {
+						// we ran into an error. wait for the channel to close before returning with the error.
+						select {
+						case <-writerResponse:
+						}
+						return false, err
+					}
+					// channel is closed. we're done writing and no issues detected.
+					return false, nil
 				}
-				cw.writtenBytes = fileInfo.Size()
-				return false, nil
 			}
 			cw.balancesChunk.Balances = nil
+		}
+	}
+}
+
+func (cw *catchpointWriter) asyncWriter(balances chan catchpointFileBalancesChunk, response chan error, initialBalancesChunkNum uint64) {
+	defer close(response)
+	balancesChunkNum := initialBalancesChunkNum
+	for bc := range balances {
+		balancesChunkNum++
+		if len(bc.Balances) == 0 {
+			break
+		}
+
+		encodedChunk := protocol.Encode(&bc)
+		err := cw.tar.WriteHeader(&tar.Header{
+			Name: fmt.Sprintf("balances.%d.%d.msgpack", balancesChunkNum, cw.fileHeader.TotalChunks),
+			Mode: 0600,
+			Size: int64(len(encodedChunk)),
+		})
+		if err != nil {
+			response <- err
+			break
+		}
+		_, err = cw.tar.Write(encodedChunk)
+		if err != nil {
+			response <- err
+			break
+		}
+
+		if len(bc.Balances) < BalancesPerCatchpointFileChunk || balancesChunkNum == cw.fileHeader.TotalChunks {
+			cw.tar.Close()
+			cw.gzip.Close()
+			cw.file.Close()
+			cw.file = nil
+			var fileInfo os.FileInfo
+			fileInfo, err = os.Stat(cw.filePath)
+			if err != nil {
+				response <- err
+				break
+			}
+			cw.writtenBytes = fileInfo.Size()
+			break
 		}
 	}
 }

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -217,7 +217,7 @@ func TestBasicCatchpointWriter(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, uint64(len(accts)), uint64(len(balances.Balances)))
 		} else {
-			require.Failf(t, "unexpected tar chunk name %s", header.Name)
+			require.Failf(t, "unexpected tar chunk name", "tar chunk name %s", header.Name)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

This PR improves the speed of the catchpoint file writer; it parallelize the gzip file writing with the account database reading.

## Test Plan

Existing tests already cover the functional portion.

## Performance Gains

| Number of accounts   |     Before the change      |  With the change | Performance gains |
|:----------:|:-------------:|:------:|:------:|
| 6,000,000 |  22 seconds | 13 seconds | +90% |
