### PR TITLE
TEAL: fix return type check in assembler

### DIFF
--- a/cmd/opdoc/opdoc.go
+++ b/cmd/opdoc/opdoc.go
@@ -120,12 +120,17 @@ func opToMarkdown(out io.Writer, op *logic.OpSpec) (err error) {
 		}
 		out.Write([]byte("\n"))
 	}
+
 	if op.Returns == nil {
 		fmt.Fprintf(out, "- Pushes: _None_\n")
 	} else {
-		fmt.Fprintf(out, "- Pushes: %s", op.Returns[0].String())
-		for _, rt := range op.Returns[1:] {
-			fmt.Fprintf(out, ", %s", rt.String())
+		if len(op.Returns) == 1 {
+			fmt.Fprintf(out, "- Pushes: %s", op.Returns[0].String())
+		} else {
+			fmt.Fprintf(out, "- Pushes: *... stack*, %s", op.Returns[0].String())
+			for _, rt := range op.Returns[1:] {
+				fmt.Fprintf(out, ", %s", rt.String())
+			}
 		}
 		fmt.Fprintf(out, "\n")
 	}

--- a/data/transactions/logic/README.md
+++ b/data/transactions/logic/README.md
@@ -352,6 +352,12 @@ For version 1, subsequent bytes after the varuint are program opcode bytes. Futu
 
 It is important to prevent newly-introduced transaction fields from breaking assumptions made by older versions of TEAL. If one of the transactions in a group will execute a TEAL program whose version predates a given field, that field must not be set anywhere in the transaction group, or the group will be rejected. For example, executing a TEAL version 1 program on a transaction with RekeyTo set to a nonzero address will cause the program to fail, regardless of the other contents of the program itself.
 
+This requirement is enforced as follows:
+
+* For every transaction, compute the earliest TEAL version that supports all the fields and and values in this transaction. For example, a transaction with a nonzero RekeyTo field will have version (at least) 2.
+
+* Compute the largest version number across all the transactions in a group (of size 1 or more), call it `maxVerNo`. If any transaction in this group has a TEAL program with a version smaller than `maxVerNo`, then that TEAL program will fail.
+
 ## Varuint
 
 A '[proto-buf style variable length unsigned int](https://developers.google.com/protocol-buffers/docs/encoding#varint)' is encoded with 7 data bits per byte and the high bit is 1 if there is a following byte and 0 for the last byte. The lowest order 7 bits are in the first byte, followed by successively higher groups of 7 bits.

--- a/data/transactions/logic/README_in.md
+++ b/data/transactions/logic/README_in.md
@@ -173,6 +173,12 @@ For version 1, subsequent bytes after the varuint are program opcode bytes. Futu
 
 It is important to prevent newly-introduced transaction fields from breaking assumptions made by older versions of TEAL. If one of the transactions in a group will execute a TEAL program whose version predates a given field, that field must not be set anywhere in the transaction group, or the group will be rejected. For example, executing a TEAL version 1 program on a transaction with RekeyTo set to a nonzero address will cause the program to fail, regardless of the other contents of the program itself.
 
+This requirement is enforced as follows:
+
+* For every transaction, compute the earliest TEAL version that supports all the fields and and values in this transaction. For example, a transaction with a nonzero RekeyTo field will have version (at least) 2.
+
+* Compute the largest version number across all the transactions in a group (of size 1 or more), call it `maxVerNo`. If any transaction in this group has a TEAL program with a version smaller than `maxVerNo`, then that TEAL program will fail.
+
 ## Varuint
 
 A '[proto-buf style variable length unsigned int](https://developers.google.com/protocol-buffers/docs/encoding#varint)' is encoded with 7 data bits per byte and the high bit is 1 if there is a following byte and 0 for the last byte. The lowest order 7 bits are in the first byte, followed by successively higher groups of 7 bits.

--- a/data/transactions/logic/TEAL_opcodes.md
+++ b/data/transactions/logic/TEAL_opcodes.md
@@ -208,14 +208,14 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 - Opcode: 0x1d
 - Pops: *... stack*, {uint64 A}, {uint64 B}
-- Pushes: uint64, uint64
+- Pushes: *... stack*, uint64, uint64
 - A times B out to 128-bit long result as low (top) and high uint64 values on the stack
 
 ## addw
 
 - Opcode: 0x1e
 - Pops: *... stack*, {uint64 A}, {uint64 B}
-- Pushes: uint64, uint64
+- Pushes: *... stack*, uint64, uint64
 - A plus B out to 128-bit long result as sum (top) and carry-bit uint64 values on the stack
 - LogicSigVersion >= 2
 
@@ -534,14 +534,14 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 - Opcode: 0x49
 - Pops: *... stack*, any
-- Pushes: any, any
+- Pushes: *... stack*, any, any
 - duplicate last value on stack
 
 ## dup2
 
 - Opcode: 0x4a
 - Pops: *... stack*, {any A}, {any B}
-- Pushes: any, any, any, any
+- Pushes: *... stack*, any, any, any, any
 - duplicate two last values on stack: A, B -> A, B, A, B
 - LogicSigVersion >= 2
 
@@ -606,7 +606,7 @@ params: account index, state key. Return: value. The value is zero if the key do
 
 - Opcode: 0x63
 - Pops: *... stack*, {uint64 A}, {uint64 B}, {[]byte C}
-- Pushes: uint64, any
+- Pushes: *... stack*, any, uint64
 - read from account specified by Txn.Accounts[A] from local state of the application B key C => {0 or 1 (top), value}
 - LogicSigVersion >= 2
 - Mode: Application
@@ -628,7 +628,7 @@ params: state key. Return: value. The value is zero if the key does not exist.
 
 - Opcode: 0x65
 - Pops: *... stack*, {uint64 A}, {[]byte B}
-- Pushes: uint64, any
+- Pushes: *... stack*, any, uint64
 - read from application Txn.ForeignApps[A] global state key B => {0 or 1 (top), value}. A is specified as an account index in the ForeignApps field of the ApplicationCall transaction, zero index means this app
 - LogicSigVersion >= 2
 - Mode: Application
@@ -685,7 +685,7 @@ Deleting a key which is already absent has no effect on the application global s
 
 - Opcode: 0x70 {uint8 asset holding field index}
 - Pops: *... stack*, {uint64 A}, {uint64 B}
-- Pushes: uint64, any
+- Pushes: *... stack*, any, uint64
 - read from account specified by Txn.Accounts[A] and asset B holding field X (imm arg) => {0 or 1 (top), value}
 - LogicSigVersion >= 2
 - Mode: Application
@@ -704,7 +704,7 @@ params: account index, asset id. Return: did_exist flag (1 if exist and 0 otherw
 
 - Opcode: 0x71 {uint8 asset params field index}
 - Pops: *... stack*, uint64
-- Pushes: uint64, any
+- Pushes: *... stack*, any, uint64
 - read from asset Txn.ForeignAssets[A] params field X (imm arg) => {0 or 1 (top), value}
 - LogicSigVersion >= 2
 - Mode: Application

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -53,6 +53,7 @@ type OpStream struct {
 	Out     bytes.Buffer
 	Version uint64
 	Trace   io.Writer
+	Stderr  io.Writer
 	vubytes [9]byte
 
 	intc        []uint64
@@ -1003,7 +1004,7 @@ func (ops *OpStream) checkArgs(spec OpSpec) error {
 		if !typecheck(argType, stype) {
 			msg := fmt.Sprintf("%s arg %d wanted type %s got %s", spec.Name, i, argType.String(), stype.String())
 			if len(ops.labelReferences) > 0 {
-				fmt.Fprintf(os.Stderr, "warning: %d: %s; but branches have happened and assembler does not precisely track types in this case\n", ops.sourceLine, msg)
+				fmt.Fprintf(ops.Stderr, "warning: %d: %s; but branches have happened and assembler does not precisely track types in this case\n", ops.sourceLine, msg)
 			} else {
 				return lineErr(ops.sourceLine, errors.New(msg))
 			}
@@ -1226,7 +1227,7 @@ func AssembleStringWithVersionEx(text string, version uint64) ([]byte, map[int]i
 	}
 
 	sr = strings.NewReader(text)
-	ops := OpStream{Version: version}
+	ops := OpStream{Version: version, Stderr: os.Stderr}
 	err = ops.assemble(sr)
 	if err != nil {
 		return nil, nil, err

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -1600,3 +1600,38 @@ func TestErrShortBytecblock(t *testing.T) {
 	checkIntConstBlock(&cx)
 	require.Equal(t, cx.err, errShortIntcblock)
 }
+
+func TestBranchAssemblyTypeCheck(t *testing.T) {
+	text := `
+	int 0             // current app id  [0]
+	int 1             // key  [1, 0]
+	itob              // ["\x01", 0]
+	app_global_get_ex // [0|1, x]
+	pop               // [x]
+	btoi              // [n]
+`
+
+	sr := strings.NewReader(text)
+	var buf bytes.Buffer
+	ops := OpStream{Version: AssemblerMaxVersion, Stderr: &buf}
+	err := ops.assemble(sr)
+	require.NoError(t, err)
+	require.Empty(t, buf, buf.String())
+
+	text = `
+	int 0             // current app id  [0]
+	int 1             // key  [1, 0]
+	itob              // ["\x01", 0]
+	app_global_get_ex // [0|1, x]
+	bnz flip          // [x]
+flip:                 // [x]
+	btoi              // [n]
+`
+
+	sr = strings.NewReader(text)
+	buf.Reset()
+	ops = OpStream{Version: AssemblerMaxVersion, Stderr: &buf}
+	err = ops.assemble(sr)
+	require.NoError(t, err)
+	require.Empty(t, buf, buf.String())
+}

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -154,16 +154,16 @@ var OpSpecs = []OpSpec{
 	{0x60, "balance", opBalance, asmDefault, disDefault, oneInt, oneInt, 2, runModeApplication, opSizeDefault},
 	{0x61, "app_opted_in", opAppCheckOptedIn, asmDefault, disDefault, twoInts, oneInt, 2, runModeApplication, opSizeDefault},
 	{0x62, "app_local_get", opAppGetLocalState, asmDefault, disDefault, oneInt.plus(oneBytes), oneAny, 2, runModeApplication, opSizeDefault},
-	{0x63, "app_local_get_ex", opAppGetLocalStateEx, asmDefault, disDefault, twoInts.plus(oneBytes), oneInt.plus(oneAny), 2, runModeApplication, opSizeDefault},
+	{0x63, "app_local_get_ex", opAppGetLocalStateEx, asmDefault, disDefault, twoInts.plus(oneBytes), oneAny.plus(oneInt), 2, runModeApplication, opSizeDefault},
 	{0x64, "app_global_get", opAppGetGlobalState, asmDefault, disDefault, oneBytes, oneAny, 2, runModeApplication, opSizeDefault},
-	{0x65, "app_global_get_ex", opAppGetGlobalStateEx, asmDefault, disDefault, oneInt.plus(oneBytes), oneInt.plus(oneAny), 2, runModeApplication, opSizeDefault},
+	{0x65, "app_global_get_ex", opAppGetGlobalStateEx, asmDefault, disDefault, oneInt.plus(oneBytes), oneAny.plus(oneInt), 2, runModeApplication, opSizeDefault},
 	{0x66, "app_local_put", opAppPutLocalState, asmDefault, disDefault, oneInt.plus(oneBytes).plus(oneAny), nil, 2, runModeApplication, opSizeDefault},
 	{0x67, "app_global_put", opAppPutGlobalState, asmDefault, disDefault, oneBytes.plus(oneAny), nil, 2, runModeApplication, opSizeDefault},
 	{0x68, "app_local_del", opAppDeleteLocalState, asmDefault, disDefault, oneInt.plus(oneBytes), nil, 2, runModeApplication, opSizeDefault},
 	{0x69, "app_global_del", opAppDeleteGlobalState, asmDefault, disDefault, oneBytes, nil, 2, runModeApplication, opSizeDefault},
 
-	{0x70, "asset_holding_get", opAssetHoldingGet, assembleAssetHolding, disAssetHolding, twoInts, oneInt.plus(oneAny), 2, runModeApplication, opSize{1, 2, nil}},
-	{0x71, "asset_params_get", opAssetParamsGet, assembleAssetParams, disAssetParams, oneInt, oneInt.plus(oneAny), 2, runModeApplication, opSize{1, 2, nil}},
+	{0x70, "asset_holding_get", opAssetHoldingGet, assembleAssetHolding, disAssetHolding, twoInts, oneAny.plus(oneInt), 2, runModeApplication, opSize{1, 2, nil}},
+	{0x71, "asset_params_get", opAssetParamsGet, assembleAssetParams, disAssetParams, oneInt, oneAny.plus(oneInt), 2, runModeApplication, opSize{1, 2, nil}},
 }
 
 type sortByOpcode []OpSpec


### PR DESCRIPTION
## Release notes

This PR addresses inconsistency in the spec where operands pushing order is different from return values order.
There is no changes in TEAL evaluation so that no protocol upgrade is required.

Corresponding conning to the spec is https://github.com/algorandfoundation/specs/commit/21adc34b722ff365076b7e83a797190e7f99d6a2

Please note, the consensus protocol version is pointing to the not up-to-date spec https://github.com/algorandfoundation/specs/releases/tag/August2020-TEALv2 that includes only Rekey but not applications.

## Summary

* app and asset getters return a pair
* order in opcode specification was "top-left"
* type check expects "bottom-left" order

## Test Plan

New test added