### PR TITLE
Remove extra newline from version output.

### DIFF
--- a/config/version.go
+++ b/config/version.go
@@ -113,7 +113,7 @@ func GetCurrentVersion() Version {
 // FormatVersionAndLicense prints current version and license information
 func FormatVersionAndLicense() string {
 	version := GetCurrentVersion()
-	return fmt.Sprintf("%d\n%s.%s [%s] (commit #%s)\n%s\n", version.AsUInt64(), version.String(),
+	return fmt.Sprintf("%d\n%s.%s [%s] (commit #%s)\n%s", version.AsUInt64(), version.String(),
 		version.Channel, version.Branch, version.GetCommitHash(), GetLicenseInfo())
 }
 


### PR DESCRIPTION
##  Summary

There's an extra newline at the end of `goal -v` which looks weird in one of my scripts. In general I think these sort of helper functions to leave the formatting to the caller, which it is in this case where it adds a 2nd newline.