### PR TITLE
Fix DNSBootstrapArray returning empty strings

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -445,6 +445,12 @@ func loadConfig(reader io.Reader, config *Local) error {
 func (cfg Local) DNSBootstrapArray(networkID protocol.NetworkID) (bootstrapArray []string) {
 	dnsBootstrapString := cfg.DNSBootstrap(networkID)
 	bootstrapArray = strings.Split(dnsBootstrapString, ";")
+	// omit zero length entries from the result set.
+	for i := len(bootstrapArray) - 1; i >= 0; i-- {
+		if len(bootstrapArray[i]) == 0 {
+			bootstrapArray = append(bootstrapArray[:i], bootstrapArray[i+1:]...)
+		}
+	}
 	return
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -369,6 +369,11 @@ func TestLocal_DNSBootstrapArray(t *testing.T) {
 			args:               args{networkID: "devnet"},
 			wantBootstrapArray: []string{"devnet.cloudflare.com", "devnet.cloudfront.com"},
 		},
+		{name: "test3",
+			fields:             fields{DNSBootstrapID: ""},
+			args:               args{networkID: "devnet"},
+			wantBootstrapArray: []string{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -376,7 +381,7 @@ func TestLocal_DNSBootstrapArray(t *testing.T) {
 				DNSBootstrapID: tt.fields.DNSBootstrapID,
 			}
 			if gotBootstrapArray := cfg.DNSBootstrapArray(tt.args.networkID); !reflect.DeepEqual(gotBootstrapArray, tt.wantBootstrapArray) {
-				t.Errorf("Local.DNSBootstrapArray() = %v, want %v", gotBootstrapArray, tt.wantBootstrapArray)
+				t.Errorf("Local.DNSBootstrapArray() = %#v, want %#v", gotBootstrapArray, tt.wantBootstrapArray)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

The `DNSBootstrapArray` function is expected to return a list of the DNS bootstrap entries. Internally, it converts the config file DNSBootstrapID using a list of DNS bootstrap entries. However, in the case of having the `DNSBootstrapID` set to an empty string, the function would also return an array containing an empty string.

The above behavior, in turn, trigger a downstream failure when searching for the telemetry SRV records.

## Test Plan

Update a unit test to cover this use case.
