### PR TITLE
Show all errors, not just the first, when compiling TEAL.

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -845,7 +845,7 @@ var splitCmd = &cobra.Command{
 func mustReadFile(fname string) []byte {
 	contents, err := readFile(fname)
 	if err != nil {
-		reportErrorf("%s: %s\n", fname, err)
+		reportErrorf("%s: %s", fname, err)
 	}
 	return contents
 }
@@ -853,19 +853,20 @@ func mustReadFile(fname string) []byte {
 func assembleFile(fname string) (program []byte) {
 	text, err := readFile(fname)
 	if err != nil {
-		reportErrorf("%s: %s\n", fname, err)
+		reportErrorf("%s: %s", fname, err)
 	}
-	program, err = logic.AssembleString(string(text))
+	ops, err := logic.AssembleString(string(text))
 	if err != nil {
-		reportErrorf("%s: %s\n", fname, err)
+		ops.ReportProblems(fname)
+		reportErrorf("%s: %s", fname, err)
 	}
-	return program
+	return ops.Program
 }
 
 func disassembleFile(fname, outname string) {
 	program, err := readFile(fname)
 	if err != nil {
-		reportErrorf("%s: %s\n", fname, err)
+		reportErrorf("%s: %s", fname, err)
 	}
 	// try parsing it as a msgpack LogicSig
 	var lsig transactions.LogicSig
@@ -883,7 +884,7 @@ func disassembleFile(fname, outname string) {
 	}
 	text, err := logic.Disassemble(program)
 	if err != nil {
-		reportErrorf("%s: %s\n", fname, err)
+		reportErrorf("%s: %s", fname, err)
 	}
 	if extra != "" {
 		text = text + extra + "\n"
@@ -893,7 +894,7 @@ func disassembleFile(fname, outname string) {
 	} else {
 		err = writeFile(outname, []byte(text), 0666)
 		if err != nil {
-			reportErrorf("%s: %s\n", outname, err)
+			reportErrorf("%s: %s", outname, err)
 		}
 	}
 }
@@ -944,7 +945,7 @@ var compileCmd = &cobra.Command{
 			if !noProgramOutput {
 				err := writeFile(outname, outblob, 0666)
 				if err != nil {
-					reportErrorf("%s: %s\n", outname, err)
+					reportErrorf("%s: %s", outname, err)
 				}
 			}
 			if !signProgram && outname != stdoutFilenameValue {
@@ -1045,7 +1046,7 @@ var dryrunRemoteCmd = &cobra.Command{
 		client := ensureFullClient(dataDir)
 		resp, err := client.Dryrun(data)
 		if err != nil {
-			reportErrorf("dryrun-remote: %s\n", err.Error())
+			reportErrorf("dryrun-remote: %s", err.Error())
 		}
 		if rawOutput {
 			fmt.Fprintf(os.Stdout, string(protocol.EncodeJSON(&resp)))

--- a/cmd/goal/inspect.go
+++ b/cmd/goal/inspect.go
@@ -94,9 +94,9 @@ func (prog inspectProgram) MarshalText() ([]byte, error) {
 }
 
 func (prog *inspectProgram) UnmarshalText(text []byte) error {
-	program, err := logic.AssembleString(string(text))
+	ops, err := logic.AssembleString(string(text))
 	if err == nil {
-		*prog = program
+		*prog = ops.Program
 	}
 	return err
 }

--- a/cmd/goal/multisig.go
+++ b/cmd/goal/multisig.go
@@ -170,6 +170,7 @@ var signProgramCmd = &cobra.Command{
 				outname = fmt.Sprintf("%s.lsig", programSource)
 			}
 			lsig.Logic = ops.Program
+			program = ops.Program
 		} else if logicSigFile != "" {
 			if progByteFile != "" {
 				reportErrorf(multisigProgramCollision)

--- a/cmd/goal/multisig.go
+++ b/cmd/goal/multisig.go
@@ -161,14 +161,15 @@ var signProgramCmd = &cobra.Command{
 			if err != nil {
 				reportErrorf(fileReadError, programSource, err)
 			}
-			program, err = logic.AssembleString(string(text))
+			ops, err := logic.AssembleString(string(text))
 			if err != nil {
+				ops.ReportProblems(programSource)
 				reportErrorf("%s: %s", programSource, err)
 			}
 			if outname == "" {
 				outname = fmt.Sprintf("%s.lsig", programSource)
 			}
-			lsig.Logic = program
+			lsig.Logic = ops.Program
 		} else if logicSigFile != "" {
 			if progByteFile != "" {
 				reportErrorf(multisigProgramCollision)

--- a/cmd/netgoal/network.go
+++ b/cmd/netgoal/network.go
@@ -109,7 +109,7 @@ func runBuildNetwork() (err error) {
 	}
 	for _, kev := range miscStringStringTokens {
 		ab := strings.SplitN(kev, "=", 2)
-		buildConfig.MiscStringString = append(buildConfig.MiscStringString, "{{" + ab[0] + "}}", ab[1])
+		buildConfig.MiscStringString = append(buildConfig.MiscStringString, "{{"+ab[0]+"}}", ab[1])
 	}
 
 	networkTemplateFile := resolveFile(r.NetworkFile, templateBaseDir)

--- a/cmd/pingpong/runCmd.go
+++ b/cmd/pingpong/runCmd.go
@@ -238,10 +238,12 @@ var runCmd = &cobra.Command{
 			default:
 				reportErrorf("Invalid argument for --teal: %v\n", teal)
 			}
-			cfg.Program, err = logic.AssembleString(programStr)
+			ops, err := logic.AssembleString(programStr)
 			if err != nil {
+				ops.ReportProblems(teal)
 				reportErrorf("Internal error, cannot assemble %v \n", programStr)
 			}
+			cfg.Program = ops.Program
 		}
 
 		if logicProg != "" {

--- a/cmd/tealdbg/debugger_test.go
+++ b/cmd/tealdbg/debugger_test.go
@@ -108,10 +108,10 @@ func TestDebuggerSimple(t *testing.T) {
 int 1
 +
 `
-	program, err := logic.AssembleStringV1(source)
+	ops, err := logic.AssembleStringWithVersion(source, 1)
 	require.NoError(t, err)
 
-	_, err = logic.Eval(program, ep)
+	_, err = logic.Eval(ops.Program, ep)
 	require.NoError(t, err)
 
 	da.WaitForCompletion()
@@ -123,22 +123,22 @@ int 1
 
 func TestSession(t *testing.T) {
 	source := fmt.Sprintf("#pragma version %d\nint 1\ndup\n+\n", logic.LogicVersion)
-	program, offsets, err := logic.AssembleStringWithVersionEx(source, logic.LogicVersion)
+	ops, err := logic.AssembleStringWithVersion(source, logic.LogicVersion)
 	require.NoError(t, err)
-	disassembly, err := logic.Disassemble(program)
+	disassembly, err := logic.Disassemble(ops.Program)
 	require.NoError(t, err)
 
 	// create a sample disassembly line to pc mapping
 	// this simple source is similar to disassembly except intcblock at the begining
-	pcOffset := make(map[int]int, len(offsets))
-	for pc, line := range offsets {
+	pcOffset := make(map[int]int, len(ops.OffsetToLine))
+	for pc, line := range ops.OffsetToLine {
 		pcOffset[line+1] = pc
 	}
 
 	s := makeSession(disassembly, 0)
 	s.source = source
 	s.programName = "test"
-	s.offsetToLine = offsets
+	s.offsetToLine = ops.OffsetToLine
 	s.pcOffset = pcOffset
 	err = s.SetBreakpoint(2)
 	require.NoError(t, err)

--- a/cmd/tealdbg/local.go
+++ b/cmd/tealdbg/local.go
@@ -316,13 +316,13 @@ func (r *LocalRunner) Setup(dp *DebugParams) (err error) {
 			r.runs[i].program = data
 			if IsTextFile(data) {
 				source := string(data)
-				program, offsets, err := logic.AssembleStringWithVersionEx(source, r.proto.LogicSigVersion)
+				ops, err := logic.AssembleStringWithVersion(source, r.proto.LogicSigVersion)
 				if err != nil {
 					return err
 				}
-				r.runs[i].program = program
+				r.runs[i].program = ops.Program
 				if !dp.DisableSourceMap {
-					r.runs[i].offsetToLine = offsets
+					r.runs[i].offsetToLine = ops.OffsetToLine
 					r.runs[i].source = source
 				}
 			}

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -82,21 +82,21 @@ func DryrunRequestFromGenerated(gdr *generated.DryrunRequest) (dr DryrunRequest,
 // puts into appropriate DryrunRequest.Apps entry
 func (dr *DryrunRequest) ExpandSources() error {
 	for i, s := range dr.Sources {
-		program, err := logic.AssembleString(s.Source)
+		ops, err := logic.AssembleString(s.Source)
 		if err != nil {
 			return fmt.Errorf("Dryrun Source[%d]: %v", i, err)
 		}
 		switch s.FieldName {
 		case "lsig":
-			dr.Txns[s.TxnIndex].Lsig.Logic = program
+			dr.Txns[s.TxnIndex].Lsig.Logic = ops.Program
 		case "approv", "clearp":
 			for ai, app := range dr.Apps {
 				if app.Id == s.AppIndex {
 					switch s.FieldName {
 					case "approv":
-						dr.Apps[ai].Params.ApprovalProgram = program
+						dr.Apps[ai].Params.ApprovalProgram = ops.Program
 					case "clearp":
-						dr.Apps[ai].Params.ClearStateProgram = program
+						dr.Apps[ai].Params.ClearStateProgram = ops.Program
 					}
 				}
 			}

--- a/daemon/algod/api/server/v2/dryrun_test.go
+++ b/daemon/algod/api/server/v2/dryrun_test.go
@@ -334,15 +334,16 @@ done:
 var localStateCheckProg []byte
 
 func init() {
-	var err error
-	globalTestProgram, err = logic.AssembleString(globalTestSource)
+	ops, err := logic.AssembleString(globalTestSource)
 	if err != nil {
 		panic(err)
 	}
-	localStateCheckProg, err = logic.AssembleString(localStateCheckSource)
+	globalTestProgram = ops.Program
+	ops, err = logic.AssembleString(localStateCheckSource)
 	if err != nil {
 		panic(err)
 	}
+	localStateCheckProg = ops.Program
 }
 
 func checkLogicSigPass(t *testing.T, response *generated.DryrunResponse) {

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -692,16 +692,15 @@ func (v2 *Handlers) TealCompile(ctx echo.Context) error {
 	ctx.Request().Body = http.MaxBytesReader(nil, ctx.Request().Body, maxTealSourceBytes)
 	buf.ReadFrom(ctx.Request().Body)
 	source := buf.String()
-	program, err := logic.AssembleString(source)
+	ops, err := logic.AssembleString(source)
 	if err != nil {
 		return badRequest(ctx, err, err.Error(), v2.Log)
 	}
-
-	pd := logic.HashProgram(program)
+	pd := logic.HashProgram(ops.Program)
 	addr := basics.Address(pd)
 	response := generated.CompileResponse{
 		Hash:   addr.String(),
-		Result: base64.StdEncoding.EncodeToString(program),
+		Result: base64.StdEncoding.EncodeToString(ops.Program),
 	}
 	return ctx.JSON(http.StatusOK, response)
 }

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -442,17 +442,17 @@ func TestTealDryrun(t *testing.T) {
 		gdr.Txns = append(gdr.Txns, enc)
 	}
 
-	sucProgram, err := logic.AssembleStringV2("int 1")
+	sucOps, err := logic.AssembleStringWithVersion("int 1", 2)
 	require.NoError(t, err)
 
-	failProgram, err := logic.AssembleStringV2("int 0")
+	failOps, err := logic.AssembleStringWithVersion("int 0", 2)
 	require.NoError(t, err)
 
 	gdr.Apps = []generated.Application{
 		{
 			Id: 1,
 			Params: generated.ApplicationParams{
-				ApprovalProgram: sucProgram,
+				ApprovalProgram: sucOps.Program,
 			},
 		},
 	}
@@ -490,7 +490,7 @@ func TestTealDryrun(t *testing.T) {
 	ddr := tealDryrunTest(t, &gdr, "json", 200, "PASS", true)
 	require.Equal(t, string(protocol.ConsensusFuture), ddr.ProtocolVersion)
 
-	gdr.Apps[0].Params.ApprovalProgram = failProgram
+	gdr.Apps[0].Params.ApprovalProgram = failOps.Program
 	tealDryrunTest(t, &gdr, "json", 200, "REJECT", true)
 	tealDryrunTest(t, &gdr, "msgp", 200, "REJECT", true)
 	tealDryrunTest(t, &gdr, "json", 404, "", false)

--- a/data/pools/transactionPool_test.go
+++ b/data/pools/transactionPool_test.go
@@ -847,9 +847,9 @@ func TestLogicSigOK(t *testing.T) {
 	}
 
 	src := `int 1`
-	program, err := logic.AssembleString(src)
+	ops, err := logic.AssembleString(src)
 	require.NoError(t, err)
-	programAddress := logic.HashProgram(program)
+	programAddress := logic.HashProgram(ops.Program)
 	addresses[0] = basics.Address(programAddress)
 
 	limitedAccounts := make(map[basics.Address]uint64)
@@ -879,7 +879,7 @@ func TestLogicSigOK(t *testing.T) {
 	signedTx := transactions.SignedTxn{
 		Txn: tx,
 		Lsig: transactions.LogicSig{
-			Logic: program,
+			Logic: ops.Program,
 		},
 	}
 	require.NoError(t, transactionPool.RememberOne(signedTx, verify.Params{}))

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1227,6 +1227,7 @@ func (ops *OpStream) warnf(format string, a ...interface{}) error {
 	return ops.warn(fmt.Errorf(format, a...))
 }
 
+// ReportProblems issues accumulated warnings and errors to stderr.
 func (ops *OpStream) ReportProblems(fname string) {
 	for _, e := range ops.Errors {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", fname, e)
@@ -1244,10 +1245,8 @@ func AssembleString(text string) (*OpStream, error) {
 // AssembleStringWithVersion takes an entire program in a string and
 // assembles it to bytecode using the assembler version specified.  If
 // version is assemblerNoVersion it uses #pragma version or fallsback
-// to AssemblerDefaultVersion.
-
-// OpStream is returned to allow access to warnings, (multiple)
-// errors, or the PC to source line mapping.
+// to AssemblerDefaultVersion.  OpStream is returned to allow access
+// to warnings, (multiple) errors, or the PC to source line mapping.
 func AssembleStringWithVersion(text string, version uint64) (*OpStream, error) {
 	sr := strings.NewReader(text)
 	ps := PragmaStream{}

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -372,8 +372,7 @@ func TestOpUint(t *testing.T) {
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			ops := OpStream{Version: v}
-			err := ops.Uint(0xcafebabe)
-			require.NoError(t, err)
+			ops.Uint(0xcafebabe)
 			prog := ops.prependCBlocks()
 			require.NotNil(t, prog)
 			s := hex.EncodeToString(prog)
@@ -389,8 +388,7 @@ func TestOpUint64(t *testing.T) {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			t.Parallel()
 			ops := OpStream{Version: v}
-			err := ops.Uint(0xcafebabecafebabe)
-			require.NoError(t, err)
+			ops.Uint(0xcafebabecafebabe)
 			prog := ops.prependCBlocks()
 			require.NotNil(t, prog)
 			s := hex.EncodeToString(prog)
@@ -404,8 +402,7 @@ func TestOpBytes(t *testing.T) {
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			ops := OpStream{Version: v}
-			err := ops.ByteLiteral([]byte("abcdef"))
-			require.NoError(t, err)
+			ops.ByteLiteral([]byte("abcdef"))
 			prog := ops.prependCBlocks()
 			require.NotNil(t, prog)
 			s := hex.EncodeToString(prog)

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -235,15 +235,15 @@ func TestAssemble(t *testing.T) {
 			t.Errorf("test should contain op %v", spec.Name)
 		}
 	}
-	program, err := AssembleStringWithVersion(bigTestAssembleNonsenseProgram, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(bigTestAssembleNonsenseProgram, AssemblerMaxVersion)
 	require.NoError(t, err)
 	// check that compilation is stable over time and we assemble to the same bytes this month that we did last month.
 	expectedBytes, _ := hex.DecodeString("022008b7a60cf8acd19181cf959a12f8acd19181cf951af8acd19181cf15f8acd191810f01020026050212340c68656c6c6f20776f726c6421208dae2087fbba51304eb02b91f656948397a7946390e8cb70fc9ea4d95f92251d024242047465737400320032013202320328292929292a0431003101310231043105310731083109310a310b310c310d310e310f3111311231133114311533000033000133000233000433000533000733000833000933000a33000b33000c33000d33000e33000f3300113300123300133300143300152d2e0102222324252104082209240a220b230c240d250e230f23102311231223132314181b1c2b171615400003290349483403350222231d4a484848482a50512a63222352410003420000432105602105612105270463484821052b62482b642b65484821052b2106662b21056721072b682b692107210570004848210771004848361c0037001a0031183119311b311d311e311f3120210721051e312131223123312431253126312731283129312a312b312c312d312e312f")
-	if bytes.Compare(expectedBytes, program) != 0 {
+	if bytes.Compare(expectedBytes, ops.Program) != 0 {
 		// this print is for convenience if the program has been changed. the hex string can be copy pasted back in as a new expected result.
-		t.Log(hex.EncodeToString(program))
+		t.Log(hex.EncodeToString(ops.Program))
 	}
-	require.Equal(t, expectedBytes, program)
+	require.Equal(t, expectedBytes, ops.Program)
 }
 
 func TestAssembleAlias(t *testing.T) {
@@ -253,7 +253,7 @@ pop
 gtxn 0 ApplicationArgs 0 // alias to gtxn
 pop
 `
-	prog1, err := AssembleStringWithVersion(source1, AssemblerMaxVersion)
+	ops1, err := AssembleStringWithVersion(source1, AssemblerMaxVersion)
 	require.NoError(t, err)
 
 	source2 := `txna Accounts 0
@@ -261,10 +261,53 @@ pop
 gtxna 0 ApplicationArgs 0
 pop
 `
-	prog2, err := AssembleStringWithVersion(source2, AssemblerMaxVersion)
+	ops2, err := AssembleStringWithVersion(source2, AssemblerMaxVersion)
 	require.NoError(t, err)
 
-	require.Equal(t, prog1, prog2)
+	require.Equal(t, ops1.Program, ops2.Program)
+}
+
+type expect struct {
+	l int
+	s string
+}
+
+func testMatch(t *testing.T, actual, expected string) {
+	if strings.HasPrefix(expected, "...") && strings.HasSuffix(expected, "...") {
+		require.Contains(t, actual, expected[3:len(expected)-3])
+	} else if strings.HasPrefix(expected, "...") {
+		require.Contains(t, actual+"^", expected[3:]+"^")
+	} else if strings.HasSuffix(expected, "...") {
+		require.Contains(t, "^"+actual, "^"+expected[:len(expected)-3])
+	} else {
+		require.Equal(t, actual, expected)
+	}
+}
+
+func testProg(t *testing.T, source string, ver uint64, expected ...expect) {
+	ops, err := AssembleStringWithVersion(source, ver)
+	if len(expected) == 0 {
+		require.NoError(t, err)
+		require.NotNil(t, ops)
+		require.Empty(t, ops.Errors)
+		require.NotNil(t, ops.Program)
+	} else {
+		require.Error(t, err)
+		errors := ops.Errors
+		require.Len(t, errors, len(expected))
+		for _, exp := range expected {
+			var found *lineError
+			for _, err := range errors {
+				if err.Line == exp.l {
+					found = err
+				}
+			}
+			require.NotNil(t, found)
+			msg := found.Unwrap().Error()
+			testMatch(t, msg, exp.s)
+		}
+		require.Nil(t, ops.Program)
+	}
 }
 
 func testLine(t *testing.T, line string, ver uint64, expected string) {
@@ -272,17 +315,11 @@ func testLine(t *testing.T, line string, ver uint64, expected string) {
 	// test for the correct line number in the error is more
 	// meaningful.
 	source := "int 1\n" + line + "\nint 1\n"
-	_, err := AssembleStringWithVersion(source, ver)
 	if expected == "" {
-		require.NoError(t, err)
-	} else {
-		require.Error(t, err)
-		if strings.HasSuffix(expected, "...") {
-			require.Contains(t, "^"+err.Error(), "^2: "+expected[:len(expected)-3])
-		} else {
-			require.Equal(t, "2: "+expected, err.Error())
-		}
+		testProg(t, source, ver)
+		return
 	}
+	testProg(t, source, ver, expect{2, expected})
 }
 func TestAssembleTxna(t *testing.T) {
 	testLine(t, "txna Accounts 256", AssemblerMaxVersion, "txna array index beyond 255: 256")
@@ -323,9 +360,7 @@ int 1
 +
 // comment
 `
-	_, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "3: + arg 0 wanted type uint64 got []byte")
+	testProg(t, source, AssemblerMaxVersion, expect{3, "+ arg 0 wanted type uint64 got []byte"})
 }
 
 // mutateProgVersion replaces version (first two symbols) in hex-encoded program
@@ -339,9 +374,9 @@ func TestOpUint(t *testing.T) {
 			ops := OpStream{Version: v}
 			err := ops.Uint(0xcafebabe)
 			require.NoError(t, err)
-			program, err := ops.Bytes()
-			require.NoError(t, err)
-			s := hex.EncodeToString(program)
+			prog := ops.prependCBlocks()
+			require.NotNil(t, prog)
+			s := hex.EncodeToString(prog)
 			expected := mutateProgVersion(v, "012001bef5fad70c22")
 			require.Equal(t, expected, s)
 		})
@@ -356,9 +391,9 @@ func TestOpUint64(t *testing.T) {
 			ops := OpStream{Version: v}
 			err := ops.Uint(0xcafebabecafebabe)
 			require.NoError(t, err)
-			program, err := ops.Bytes()
-			require.NoError(t, err)
-			s := hex.EncodeToString(program)
+			prog := ops.prependCBlocks()
+			require.NotNil(t, prog)
+			s := hex.EncodeToString(prog)
 			require.Equal(t, mutateProgVersion(v, "012001bef5fad7ecd7aeffca0122"), s)
 		})
 	}
@@ -371,9 +406,9 @@ func TestOpBytes(t *testing.T) {
 			ops := OpStream{Version: v}
 			err := ops.ByteLiteral([]byte("abcdef"))
 			require.NoError(t, err)
-			program, err := ops.Bytes()
-			require.NoError(t, err)
-			s := hex.EncodeToString(program)
+			prog := ops.prependCBlocks()
+			require.NotNil(t, prog)
+			s := hex.EncodeToString(prog)
 			require.Equal(t, mutateProgVersion(v, "0126010661626364656628"), s)
 		})
 	}
@@ -384,9 +419,9 @@ func TestAssembleInt(t *testing.T) {
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			text := "int 0xcafebabe"
-			program, err := AssembleStringWithVersion(text, v)
+			ops, err := AssembleStringWithVersion(text, v)
 			require.NoError(t, err)
-			s := hex.EncodeToString(program)
+			s := hex.EncodeToString(ops.Program)
 			require.Equal(t, mutateProgVersion(v, "012001bef5fad70c22"), s)
 		})
 	}
@@ -424,9 +459,9 @@ func TestAssembleBytes(t *testing.T) {
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			for _, vi := range variations {
-				program, err := AssembleStringWithVersion(vi, v)
+				ops, err := AssembleStringWithVersion(vi, v)
 				require.NoError(t, err)
-				s := hex.EncodeToString(program)
+				s := hex.EncodeToString(ops.Program)
 				require.Equal(t, mutateProgVersion(v, "0126010661626364656628"), s)
 			}
 
@@ -437,13 +472,8 @@ func TestAssembleBytes(t *testing.T) {
 func TestAssembleBytesString(t *testing.T) {
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			text := `byte "foo bar"`
-			_, err := AssembleStringWithVersion(text, v)
-			require.NoError(t, err)
-
-			text = `byte "foo bar // not a comment"`
-			_, err = AssembleStringWithVersion(text, v)
-			require.NoError(t, err)
+			testLine(t, `byte "foo bar"`, v, "")
+			testLine(t, `byte "foo bar // not a comment"`, v, "")
 		})
 	}
 }
@@ -656,16 +686,13 @@ func TestFieldsFromLine(t *testing.T) {
 
 func TestAssembleRejectNegJump(t *testing.T) {
 	t.Parallel()
-	text := `wat:
+	source := `wat:
 int 1
 bnz wat
 int 2`
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(text, v)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "3: label wat is before reference")
-			require.Nil(t, program)
+			testProg(t, source, v, expect{3, "label wat is before reference but only forward jumps are allowed"})
 		})
 	}
 }
@@ -686,9 +713,9 @@ byte b64 avGWRM+yy3BCavBDXO/FYTNZ6o2Jai5edsMCBdDEz//=
 ||`
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(text, v)
+			ops, err := AssembleStringWithVersion(text, v)
 			require.NoError(t, err)
-			s := hex.EncodeToString(program)
+			s := hex.EncodeToString(ops.Program)
 			require.Equal(t, mutateProgVersion(v, "01200101260320fff19644cfb2cb70426af0435cefc5613359ea8d896a2e5e76c30205d0c4cfed206af19644cfb2cb70426af0435cefc5613359ea8d896a2e5e76c30205d0c4cfff20fff19644cfb2cb70426af0435cefc5613359ea8d896a2e5e76c30205d0c4cfef2829122210122a291211"), s)
 		})
 	}
@@ -696,32 +723,45 @@ byte b64 avGWRM+yy3BCavBDXO/FYTNZ6o2Jai5edsMCBdDEz//=
 
 func TestAssembleRejectUnkLabel(t *testing.T) {
 	t.Parallel()
-	text := `int 1
+	source := `int 1
 bnz nowhere
 int 2`
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(text, v)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "2: reference to undefined label nowhere")
-			require.Nil(t, program)
+			testProg(t, source, v, expect{2, "reference to undefined label nowhere"})
 		})
 	}
 }
 
 func TestAssembleJumpToTheEnd(t *testing.T) {
 	t.Parallel()
-	text := `intcblock 1
+	source := `intcblock 1
 intc 0
 intc 0
 bnz done
 done:`
-	program, err := AssembleStringWithVersion(text, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	require.Equal(t, 9, len(program))
+	require.Equal(t, 9, len(ops.Program))
 	expectedProgBytes := []byte("\x01\x20\x01\x01\x22\x22\x40\x00\x00")
 	expectedProgBytes[0] = byte(AssemblerMaxVersion)
-	require.Equal(t, expectedProgBytes, program)
+	require.Equal(t, expectedProgBytes, ops.Program)
+}
+
+func TestMultipleErrors(t *testing.T) {
+	t.Parallel()
+	source := `int 1
+bnz nowhere
+// comment
+txn XYZ
+int 2`
+	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
+		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
+			testProg(t, source, v,
+				expect{2, "reference to undefined label nowhere"},
+				expect{4, "txn unknown arg: XYZ"})
+		})
+	}
 }
 
 func TestAssembleDisassemble(t *testing.T) {
@@ -819,9 +859,9 @@ gtxn 12 Fee
 			t.Errorf("TestAssembleDisassemble missing field txn %v", txnField)
 		}
 	}
-	program, err := AssembleStringWithVersion(text, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(text, AssemblerMaxVersion)
 	require.NoError(t, err)
-	t2, err := Disassemble(program)
+	t2, err := Disassemble(ops.Program)
 	require.Equal(t, text, t2)
 	require.NoError(t, err)
 }
@@ -838,16 +878,16 @@ func TestAssembleDisassembleCycle(t *testing.T) {
 
 	for v, source := range tests {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(source, v)
+			ops, err := AssembleStringWithVersion(source, v)
 			require.NoError(t, err)
-			t2, err := Disassemble(program)
+			t2, err := Disassemble(ops.Program)
 			require.NoError(t, err)
-			p2, err := AssembleStringV2(t2)
+			ops2, err := AssembleStringWithVersion(t2, 2)
 			if err != nil {
 				t.Log(t2)
 			}
 			require.NoError(t, err)
-			require.Equal(t, program[1:], p2[1:])
+			require.Equal(t, ops.Program[1:], ops2.Program[1:])
 		})
 	}
 }
@@ -856,172 +896,147 @@ func TestAssembleDisassembleErrors(t *testing.T) {
 	t.Parallel()
 
 	source := `txn Sender`
-	program, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	program[2] = 0x50 // txn field
-	_, err = Disassemble(program)
+	ops.Program[2] = 0x50 // txn field
+	_, err = Disassemble(ops.Program)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid txn arg index")
 
 	source = `txna Accounts 0`
-	program, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	program[2] = 0x50 // txn field
-	_, err = Disassemble(program)
+	ops.Program[2] = 0x50 // txn field
+	_, err = Disassemble(ops.Program)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid txn arg index")
 
 	source = `gtxn 0 Sender`
-	program, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	program[3] = 0x50 // txn field
-	_, err = Disassemble(program)
+	ops.Program[3] = 0x50 // txn field
+	_, err = Disassemble(ops.Program)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid txn arg index")
 
 	source = `gtxna 0 Accounts 0`
-	program, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	program[3] = 0x50 // txn field
-	_, err = Disassemble(program)
+	ops.Program[3] = 0x50 // txn field
+	_, err = Disassemble(ops.Program)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid txn arg index")
 
 	source = `global MinTxnFee`
-	program, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	program[2] = 0x50 // txn field
-	_, err = Disassemble(program)
+	ops.Program[2] = 0x50 // txn field
+	_, err = Disassemble(ops.Program)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid global arg index")
 
-	program[0] = 0x11 // version
-	out, err := Disassemble(program)
+	ops.Program[0] = 0x11 // version
+	out, err := Disassemble(ops.Program)
 	require.NoError(t, err)
 	require.Contains(t, out, "unsupported version")
 
-	program[0] = 0x01 // version
-	program[1] = 0xFF // first opcode
-	_, err = Disassemble(program)
+	ops.Program[0] = 0x01 // version
+	ops.Program[1] = 0xFF // first opcode
+	_, err = Disassemble(ops.Program)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid opcode")
 
 	source = "int 0\nint 0\nasset_holding_get AssetFrozen"
-	program, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	program[7] = 0x50 // holding field
-	_, err = Disassemble(program)
+	ops.Program[7] = 0x50 // holding field
+	_, err = Disassemble(ops.Program)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid asset holding arg index")
 
 	source = "int 0\nasset_params_get AssetTotal"
-	program, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	program[6] = 0x50 // params field
-	_, err = Disassemble(program)
+	ops.Program[6] = 0x50 // params field
+	_, err = Disassemble(ops.Program)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid asset params arg index")
 
 	source = "int 0\nasset_params_get AssetTotal"
-	program, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	_, err = Disassemble(program)
+	_, err = Disassemble(ops.Program)
 	require.NoError(t, err)
-	program = program[0 : len(program)-1]
-	_, err = Disassemble(program)
+	ops.Program = ops.Program[0 : len(ops.Program)-1]
+	_, err = Disassemble(ops.Program)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected asset_params_get opcode end: missing 1 bytes")
 
 	source = "gtxna 0 Accounts 0"
-	program, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	_, err = Disassemble(program)
+	_, err = Disassemble(ops.Program)
 	require.NoError(t, err)
-	program = program[0 : len(program)-2]
-	_, err = Disassemble(program)
+	ops.Program = ops.Program[0 : len(ops.Program)-2]
+	_, err = Disassemble(ops.Program)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected gtxna opcode end: missing 2 bytes")
 
 	source = "txna Accounts 0"
-	program, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	_, err = Disassemble(program)
+	_, err = Disassemble(ops.Program)
 	require.NoError(t, err)
-	program = program[0 : len(program)-1]
-	_, err = Disassemble(program)
+	ops.Program = ops.Program[0 : len(ops.Program)-1]
+	_, err = Disassemble(ops.Program)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected txna opcode end: missing 1 bytes")
 
 	source = "byte 0x4141\nsubstring 0 1"
-	program, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	_, err = Disassemble(program)
+	_, err = Disassemble(ops.Program)
 	require.NoError(t, err)
-	program = program[0 : len(program)-1]
-	_, err = Disassemble(program)
+	ops.Program = ops.Program[0 : len(ops.Program)-1]
+	_, err = Disassemble(ops.Program)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected substring opcode end: missing 1 bytes")
 }
 
 func TestAssembleVersions(t *testing.T) {
 	t.Parallel()
-	text := `int 1
-txna Accounts 0
-`
-	_, err := AssembleStringWithVersion(text, AssemblerMaxVersion)
-	require.NoError(t, err)
-
-	_, err = AssembleStringV2(text)
-	require.NoError(t, err)
-
-	_, err = AssembleStringV1(text)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "2: unknown opcode: txna")
+	testLine(t, "txna Accounts 0", AssemblerMaxVersion, "")
+	testLine(t, "txna Accounts 0", 2, "")
+	testLine(t, "txna Accounts 0", 1, "unknown opcode: txna")
 }
 
 func TestAssembleBalance(t *testing.T) {
 	t.Parallel()
 
-	text := `byte 0x00
+	source := `byte 0x00
 balance
 int 1
 ==`
-	_, err := AssembleStringWithVersion(text, AssemblerMaxVersion)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "balance arg 0 wanted type uint64 got []byte")
+	testProg(t, source, AssemblerMaxVersion, expect{2, "balance arg 0 wanted type uint64 got []byte"})
 }
 
 func TestAssembleAsset(t *testing.T) {
 	t.Parallel()
-	source := "int 0\nint 0\nasset_holding_get ABC 1"
-	_, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "asset_holding_get expects one argument")
 
-	source = "int 0\nint 0\nasset_holding_get ABC"
-	_, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "asset_holding_get unknown arg: ABC")
-
-	source = "int 0\nasset_params_get ABC 1"
-	_, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "asset_params_get expects one argument")
-
-	source = "int 0\nasset_params_get ABC"
-	_, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "asset_params_get unknown arg: ABC")
+	testLine(t, "asset_holding_get ABC 1", AssemblerMaxVersion, "asset_holding_get expects one argument")
+	testLine(t, "asset_holding_get ABC", AssemblerMaxVersion, "asset_holding_get unknown arg: ABC")
+	testLine(t, "asset_params_get ABC 1", AssemblerMaxVersion, "asset_params_get expects one argument")
+	testLine(t, "asset_params_get ABC", AssemblerMaxVersion, "asset_params_get unknown arg: ABC")
 }
 
 func TestDisassembleSingleOp(t *testing.T) {
 	t.Parallel()
 	// test ensures no double arg_0 entries in disassembly listing
 	sample := "// version 2\narg_0\n"
-	program, err := AssembleStringWithVersion(sample, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(sample, AssemblerMaxVersion)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(program))
-	disassembled, err := Disassemble(program)
+	require.Equal(t, 2, len(ops.Program))
+	disassembled, err := Disassemble(ops.Program)
 	require.NoError(t, err)
 	require.Equal(t, sample, disassembled)
 }
@@ -1030,25 +1045,25 @@ func TestDisassembleTxna(t *testing.T) {
 	t.Parallel()
 	// check txn and txna are properly disassembled
 	txnSample := "// version 2\ntxn Sender\n"
-	program, err := AssembleStringWithVersion(txnSample, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(txnSample, AssemblerMaxVersion)
 	require.NoError(t, err)
-	disassembled, err := Disassemble(program)
+	disassembled, err := Disassemble(ops.Program)
 	require.NoError(t, err)
 	require.Equal(t, txnSample, disassembled)
 
 	txnaSample := "// version 2\ntxna Accounts 0\n"
-	program, err = AssembleStringWithVersion(txnaSample, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(txnaSample, AssemblerMaxVersion)
 	require.NoError(t, err)
-	disassembled, err = Disassemble(program)
+	disassembled, err = Disassemble(ops.Program)
 	require.NoError(t, err)
 	require.Equal(t, txnaSample, disassembled)
 
 	txnSample2 := "// version 2\ntxn Accounts 0\n"
-	program, err = AssembleStringWithVersion(txnSample2, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(txnSample2, AssemblerMaxVersion)
 	require.NoError(t, err)
-	disassembled, err = Disassemble(program)
+	disassembled, err = Disassemble(ops.Program)
 	require.NoError(t, err)
-	// comapre with txnaSample, not txnSample2
+	// compare with txnaSample, not txnSample2
 	require.Equal(t, txnaSample, disassembled)
 }
 
@@ -1056,23 +1071,23 @@ func TestDisassembleGtxna(t *testing.T) {
 	t.Parallel()
 	// check gtxn and gtxna are properly disassembled
 	gtxnSample := "// version 2\ngtxn 0 Sender\n"
-	program, err := AssembleStringWithVersion(gtxnSample, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(gtxnSample, AssemblerMaxVersion)
 	require.NoError(t, err)
-	disassembled, err := Disassemble(program)
+	disassembled, err := Disassemble(ops.Program)
 	require.NoError(t, err)
 	require.Equal(t, gtxnSample, disassembled)
 
 	gtxnaSample := "// version 2\ngtxna 0 Accounts 0\n"
-	program, err = AssembleStringWithVersion(gtxnaSample, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(gtxnaSample, AssemblerMaxVersion)
 	require.NoError(t, err)
-	disassembled, err = Disassemble(program)
+	disassembled, err = Disassemble(ops.Program)
 	require.NoError(t, err)
 	require.Equal(t, gtxnaSample, disassembled)
 
 	gtxnSample2 := "// version 2\ngtxn 0 Accounts 0\n"
-	program, err = AssembleStringWithVersion(gtxnSample2, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(gtxnSample2, AssemblerMaxVersion)
 	require.NoError(t, err)
-	disassembled, err = Disassemble(program)
+	disassembled, err = Disassemble(ops.Program)
 	require.NoError(t, err)
 	// comapre with gtxnaSample, not gtxnSample2
 	require.Equal(t, gtxnaSample, disassembled)
@@ -1090,9 +1105,9 @@ intc_0
 bnz label1
 label1:
 `, v)
-			program, err := AssembleStringWithVersion(source, v)
+			ops, err := AssembleStringWithVersion(source, v)
 			require.NoError(t, err)
-			dis, err := Disassemble(program)
+			dis, err := Disassemble(ops.Program)
 			require.NoError(t, err)
 			require.Equal(t, source, dis)
 		})
@@ -1102,16 +1117,16 @@ label1:
 func TestAssembleOffsets(t *testing.T) {
 	t.Parallel()
 	source := "err"
-	program, offsets, err := AssembleStringWithVersionEx(source, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(program))
-	require.Equal(t, 1, len(offsets))
+	require.Equal(t, 2, len(ops.Program))
+	require.Equal(t, 1, len(ops.OffsetToLine))
 	// vlen
-	line, ok := offsets[0]
+	line, ok := ops.OffsetToLine[0]
 	require.False(t, ok)
 	require.Equal(t, 0, line)
 	// err
-	line, ok = offsets[1]
+	line, ok = ops.OffsetToLine[1]
 	require.True(t, ok)
 	require.Equal(t, 0, line)
 
@@ -1119,20 +1134,20 @@ func TestAssembleOffsets(t *testing.T) {
 // comment
 err
 `
-	program, offsets, err = AssembleStringWithVersionEx(source, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	require.Equal(t, 3, len(program))
-	require.Equal(t, 2, len(offsets))
+	require.Equal(t, 3, len(ops.Program))
+	require.Equal(t, 2, len(ops.OffsetToLine))
 	// vlen
-	line, ok = offsets[0]
+	line, ok = ops.OffsetToLine[0]
 	require.False(t, ok)
 	require.Equal(t, 0, line)
 	// err 1
-	line, ok = offsets[1]
+	line, ok = ops.OffsetToLine[1]
 	require.True(t, ok)
 	require.Equal(t, 0, line)
 	// err 2
-	line, ok = offsets[2]
+	line, ok = ops.OffsetToLine[2]
 	require.True(t, ok)
 	require.Equal(t, 2, line)
 
@@ -1142,36 +1157,36 @@ err
 label1:
 err
 `
-	program, offsets, err = AssembleStringWithVersionEx(source, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	require.Equal(t, 7, len(program))
-	require.Equal(t, 4, len(offsets))
+	require.Equal(t, 7, len(ops.Program))
+	require.Equal(t, 4, len(ops.OffsetToLine))
 	// vlen
-	line, ok = offsets[0]
+	line, ok = ops.OffsetToLine[0]
 	require.False(t, ok)
 	require.Equal(t, 0, line)
 	// err 1
-	line, ok = offsets[1]
+	line, ok = ops.OffsetToLine[1]
 	require.True(t, ok)
 	require.Equal(t, 0, line)
 	// bnz
-	line, ok = offsets[2]
+	line, ok = ops.OffsetToLine[2]
 	require.True(t, ok)
 	require.Equal(t, 1, line)
 	// bnz byte 1
-	line, ok = offsets[3]
+	line, ok = ops.OffsetToLine[3]
 	require.False(t, ok)
 	require.Equal(t, 0, line)
 	// bnz byte 2
-	line, ok = offsets[4]
+	line, ok = ops.OffsetToLine[4]
 	require.False(t, ok)
 	require.Equal(t, 0, line)
 	// err 2
-	line, ok = offsets[5]
+	line, ok = ops.OffsetToLine[5]
 	require.True(t, ok)
 	require.Equal(t, 2, line)
 	// err 3
-	line, ok = offsets[6]
+	line, ok = ops.OffsetToLine[6]
 	require.True(t, ok)
 	require.Equal(t, 4, line)
 
@@ -1179,20 +1194,20 @@ err
 // comment
 !
 `
-	program, offsets, err = AssembleStringWithVersionEx(source, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	require.Equal(t, 6, len(program))
-	require.Equal(t, 2, len(offsets))
+	require.Equal(t, 6, len(ops.Program))
+	require.Equal(t, 2, len(ops.OffsetToLine))
 	// vlen
-	line, ok = offsets[0]
+	line, ok = ops.OffsetToLine[0]
 	require.False(t, ok)
 	require.Equal(t, 0, line)
 	// int 0
-	line, ok = offsets[4]
+	line, ok = ops.OffsetToLine[4]
 	require.True(t, ok)
 	require.Equal(t, 0, line)
 	// !
-	line, ok = offsets[5]
+	line, ok = ops.OffsetToLine[5]
 	require.True(t, ok)
 	require.Equal(t, 2, line)
 }
@@ -1200,9 +1215,9 @@ err
 func TestHasStatefulOps(t *testing.T) {
 	t.Parallel()
 	source := "int 1"
-	program, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	has, err := HasStatefulOps(program)
+	has, err := HasStatefulOps(ops.Program)
 	require.NoError(t, err)
 	require.False(t, has)
 
@@ -1211,9 +1226,9 @@ int 1
 app_opted_in
 err
 `
-	program, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	has, err = HasStatefulOps(program)
+	has, err = HasStatefulOps(ops.Program)
 	require.NoError(t, err)
 	require.True(t, has)
 }
@@ -1428,11 +1443,11 @@ func TestAssemblePragmaVersion(t *testing.T) {
 	text := `#pragma version 1
 int 1
 `
-	program, err := AssembleStringWithVersion(text, 1)
+	ops, err := AssembleStringWithVersion(text, 1)
 	require.NoError(t, err)
-	program1, err := AssembleStringV1("int 1")
+	ops1, err := AssembleStringWithVersion("int 1", 1)
 	require.NoError(t, err)
-	require.Equal(t, program1, program)
+	require.Equal(t, ops1.Program, ops.Program)
 
 	_, err = AssembleStringWithVersion(text, 0)
 	require.Error(t, err)
@@ -1442,18 +1457,18 @@ int 1
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "version mismatch")
 
-	program, err = AssembleStringWithVersion(text, assemblerNoVersion)
+	ops, err = AssembleStringWithVersion(text, assemblerNoVersion)
 	require.NoError(t, err)
-	require.Equal(t, program1, program)
+	require.Equal(t, ops1.Program, ops.Program)
 
 	text = `#pragma version 2
 int 1
 `
-	program, err = AssembleStringWithVersion(text, 2)
+	ops, err = AssembleStringWithVersion(text, 2)
 	require.NoError(t, err)
-	program2, err := AssembleStringV2("int 1")
+	ops2, err := AssembleStringWithVersion("int 1", 2)
 	require.NoError(t, err)
-	require.Equal(t, program2, program)
+	require.Equal(t, ops2.Program, ops.Program)
 
 	_, err = AssembleStringWithVersion(text, 0)
 	require.Error(t, err)
@@ -1463,22 +1478,22 @@ int 1
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "version mismatch")
 
-	program, err = AssembleStringWithVersion(text, assemblerNoVersion)
+	ops, err = AssembleStringWithVersion(text, assemblerNoVersion)
 	require.NoError(t, err)
-	require.Equal(t, program2, program)
+	require.Equal(t, ops2.Program, ops.Program)
 
 	// check if no version it defaults to TEAL v1
 	text = `byte "test"
 len
 `
-	program, err = AssembleStringWithVersion(text, assemblerNoVersion)
+	ops, err = AssembleStringWithVersion(text, assemblerNoVersion)
 	require.NoError(t, err)
-	program1, err = AssembleStringV1(text)
-	require.Equal(t, program1, program)
+	ops1, err = AssembleStringWithVersion(text, 1)
+	require.Equal(t, ops1.Program, ops.Program)
 	require.NoError(t, err)
-	program2, err = AssembleString(text)
+	ops2, err = AssembleString(text)
 	require.NoError(t, err)
-	require.Equal(t, program2, program)
+	require.Equal(t, ops2.Program, ops.Program)
 
 	_, err = AssembleString("#pragma unk")
 	require.Error(t, err)
@@ -1490,32 +1505,24 @@ func TestAssembleConstants(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			_, err := AssembleStringWithVersion("intc 1", v)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "1: intc 1 is not defined")
+			testLine(t, "intc 1", v, "intc 1 is not defined")
+			testProg(t, "intcblock 1 2\nintc 1", v)
 
-			_, err = AssembleStringWithVersion("intcblock 1 2\nintc 1", v)
-			require.NoError(t, err)
-
-			_, err = AssembleStringWithVersion("bytec 1", v)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "1: bytec 1 is not defined")
-
-			_, err = AssembleStringWithVersion("bytecblock 0x01 0x02\nbytec 1", v)
-			require.NoError(t, err)
+			testLine(t, "bytec 1", v, "bytec 1 is not defined")
+			testProg(t, "bytecblock 0x01 0x02\nbytec 1", v)
 		})
 	}
 }
 
 func TestErrShortBytecblock(t *testing.T) {
 	text := `intcblock 0x1234567812345678 0x1234567812345671 0x1234567812345672 0x1234567812345673 4 5 6 7 8`
-	program, err := AssembleStringWithVersion(text, 1)
+	ops, err := AssembleStringWithVersion(text, 1)
 	require.NoError(t, err)
-	_, _, err = parseIntcblock(program, 0)
+	_, _, err = parseIntcblock(ops.Program, 0)
 	require.Equal(t, err, errShortIntcblock)
 
 	var cx evalContext
-	cx.program = program
+	cx.program = ops.Program
 	checkIntConstBlock(&cx)
 	require.Equal(t, cx.err, errShortIntcblock)
 }
@@ -1531,11 +1538,10 @@ func TestBranchAssemblyTypeCheck(t *testing.T) {
 `
 
 	sr := strings.NewReader(text)
-	var buf bytes.Buffer
-	ops := OpStream{Version: AssemblerMaxVersion, Stderr: &buf}
+	ops := OpStream{Version: AssemblerMaxVersion}
 	err := ops.assemble(sr)
 	require.NoError(t, err)
-	require.Empty(t, buf, buf.String())
+	require.Empty(t, ops.Warnings)
 
 	text = `
 	int 0             // current app id  [0]
@@ -1548,9 +1554,8 @@ flip:                 // [x]
 `
 
 	sr = strings.NewReader(text)
-	buf.Reset()
-	ops = OpStream{Version: AssemblerMaxVersion, Stderr: &buf}
+	ops = OpStream{Version: AssemblerMaxVersion}
 	err = ops.assemble(sr)
 	require.NoError(t, err)
-	require.Empty(t, buf, buf.String())
+	require.Empty(t, ops.Warnings)
 }

--- a/data/transactions/logic/backwardCompat_test.go
+++ b/data/transactions/logic/backwardCompat_test.go
@@ -263,13 +263,13 @@ func TestBackwardCompatTEALv1(t *testing.T) {
 	require.NoError(t, err)
 
 	// ensure old program is the same as a new one when assembling without version
-	program1, err := AssembleString(sourceTEALv1)
+	ops, err := AssembleString(sourceTEALv1)
 	require.NoError(t, err)
-	require.Equal(t, program, program1)
+	require.Equal(t, program, ops.Program)
 	// ensure the old program is the same as a new one except TEAL version byte
-	program2, err := AssembleStringWithVersion(sourceTEALv1, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(sourceTEALv1, AssemblerMaxVersion)
 	require.NoError(t, err)
-	require.Equal(t, program[1:], program2[1:])
+	require.Equal(t, program[1:], ops.Program[1:])
 
 	sig := c.Sign(Msg{
 		ProgramHash: crypto.HashObj(Program(program)),
@@ -301,14 +301,14 @@ func TestBackwardCompatTEALv1(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, pass)
 
-	cost2, err := Check(program2, ep)
+	cost2, err := Check(ops.Program, ep)
 	require.NoError(t, err)
 
 	// Costs for v2 should be higher because of hash opcode cost changes
 	require.Equal(t, 2308, cost2)
-	pass, err = Eval(program2, ep)
+	pass, err = Eval(ops.Program, ep)
 	if err != nil || !pass {
-		t.Log(hex.EncodeToString(program2))
+		t.Log(hex.EncodeToString(ops.Program))
 		t.Log(sb.String())
 	}
 	require.NoError(t, err)
@@ -346,22 +346,11 @@ func TestBackwardCompatGlobalFields(t *testing.T) {
 	for _, field := range fields {
 		text := fmt.Sprintf("global %s", field)
 		// check V1 assembler fails
-		program, err := AssembleStringWithVersion(text, 0)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "available in version 2")
-		require.Nil(t, program)
+		testLine(t, text, assemblerNoVersion, "...available in version 2. Missed #pragma version?")
+		testLine(t, text, 0, "...available in version 2. Missed #pragma version?")
+		testLine(t, text, 1, "...available in version 2. Missed #pragma version?")
 
-		program, err = AssembleStringWithVersion(text, 1)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "available in version 2")
-		require.Nil(t, program)
-
-		program, err = AssembleString(text)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "available in version 2")
-		require.Nil(t, program)
-
-		program, err = AssembleStringWithVersion(text, AssemblerMaxVersion)
+		ops, err := AssembleStringWithVersion(text, AssemblerMaxVersion)
 		require.NoError(t, err)
 
 		proto := config.Consensus[protocol.ConsensusV23]
@@ -371,28 +360,28 @@ func TestBackwardCompatGlobalFields(t *testing.T) {
 		ep.Ledger = ledger
 
 		// check failure with version check
-		_, err = Eval(program, ep)
+		_, err = Eval(ops.Program, ep)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "greater than protocol supported version")
-		_, err = Eval(program, ep)
+		_, err = Eval(ops.Program, ep)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "greater than protocol supported version")
 
 		// check opcodes failures
-		program[0] = 1 // set version to 1
-		_, err = Eval(program, ep)
+		ops.Program[0] = 1 // set version to 1
+		_, err = Eval(ops.Program, ep)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid global[")
-		_, err = Eval(program, ep)
+		_, err = Eval(ops.Program, ep)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid global[")
 
 		// check opcodes failures
-		program[0] = 0 // set version to 0
-		_, err = Eval(program, ep)
+		ops.Program[0] = 0 // set version to 0
+		_, err = Eval(ops.Program, ep)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid global[")
-		_, err = Eval(program, ep)
+		_, err = Eval(ops.Program, ep)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid global[")
 	}
@@ -425,29 +414,18 @@ func TestBackwardCompatTxnFields(t *testing.T) {
 		field := fs.field.String()
 		for _, command := range tests {
 			text := fmt.Sprintf(command, field)
-			asmError := "available in version 2"
+			asmError := "...available in version 2..."
 			if _, ok := txnaFieldSpecByField[fs.field]; ok {
 				parts := strings.Split(text, " ")
 				op := parts[0]
 				asmError = fmt.Sprintf("found %sa field %s in %s op", op, field, op)
 			}
 			// check V1 assembler fails
-			program, err := AssembleStringWithVersion(text, 0)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), asmError)
-			require.Nil(t, program)
+			testLine(t, text, assemblerNoVersion, asmError)
+			testLine(t, text, 0, asmError)
+			testLine(t, text, 1, asmError)
 
-			program, err = AssembleStringWithVersion(text, 1)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), asmError)
-			require.Nil(t, program)
-
-			program, err = AssembleString(text)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), asmError)
-			require.Nil(t, program)
-
-			program, err = AssembleStringWithVersion(text, AssemblerMaxVersion)
+			ops, err := AssembleStringWithVersion(text, AssemblerMaxVersion)
 			if _, ok := txnaFieldSpecByField[fs.field]; ok {
 				// "txn Accounts" is invalid, so skip evaluation
 				require.Error(t, err, asmError)
@@ -464,28 +442,28 @@ func TestBackwardCompatTxnFields(t *testing.T) {
 			ep.TxnGroup = txgroup
 
 			// check failure with version check
-			_, err = Eval(program, ep)
+			_, err = Eval(ops.Program, ep)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "greater than protocol supported version")
-			_, err = Eval(program, ep)
+			_, err = Eval(ops.Program, ep)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "greater than protocol supported version")
 
 			// check opcodes failures
-			program[0] = 1 // set version to 1
-			_, err = Eval(program, ep)
+			ops.Program[0] = 1 // set version to 1
+			_, err = Eval(ops.Program, ep)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "invalid txn field")
-			_, err = Eval(program, ep)
+			_, err = Eval(ops.Program, ep)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "invalid txn field")
 
 			// check opcodes failures
-			program[0] = 0 // set version to 0
-			_, err = Eval(program, ep)
+			ops.Program[0] = 0 // set version to 0
+			_, err = Eval(ops.Program, ep)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "invalid txn field")
-			_, err = Eval(program, ep)
+			_, err = Eval(ops.Program, ep)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "invalid txn field")
 		}
@@ -502,29 +480,23 @@ bnz done
 done:`
 
 	t.Run("v=default", func(t *testing.T) {
-		_, err := AssembleString(source)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "4: label done is too far away")
+		testProg(t, source, assemblerNoVersion, expect{4, "label done is too far away"})
 	})
 
-	t.Run("v=0", func(t *testing.T) {
-		_, err := AssembleStringWithVersion(source, 0)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "4: label done is too far away")
+	t.Run("v=default", func(t *testing.T) {
+		testProg(t, source, 0, expect{4, "label done is too far away"})
 	})
 
-	t.Run("v=1", func(t *testing.T) {
-		_, err := AssembleStringWithVersion(source, 1)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "4: label done is too far away")
+	t.Run("v=default", func(t *testing.T) {
+		testProg(t, source, 1, expect{4, "label done is too far away"})
 	})
 
 	for v := uint64(2); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(source, v)
+			ops, err := AssembleStringWithVersion(source, v)
 			require.NoError(t, err)
 			ep := defaultEvalParams(nil, nil)
-			_, err = Eval(program, ep)
+			_, err = Eval(ops.Program, ep)
 			require.NoError(t, err)
 		})
 	}

--- a/data/transactions/logic/debugger_test.go
+++ b/data/transactions/logic/debugger_test.go
@@ -79,12 +79,12 @@ func TestWebDebuggerManual(t *testing.T) {
 		txn.Txn.Note,
 	}
 
-	program, err := AssembleString(testProgram)
+	ops, err := AssembleString(testProgram)
 	require.NoError(t, err)
 	ep := defaultEvalParams(nil, &txn)
 	ep.TxnGroup = txgroup
 	ep.Debugger = &WebDebuggerHook{URL: debugURL}
-	_, err = Eval(program, ep)
+	_, err = Eval(ops.Program, ep)
 	require.NoError(t, err)
 }
 
@@ -115,11 +115,11 @@ func (d *testDbgHook) Complete(state *DebugState) error {
 
 func TestDebuggerHook(t *testing.T) {
 	testDbg := testDbgHook{}
-	program, err := AssembleString(testProgram)
+	ops, err := AssembleString(testProgram)
 	require.NoError(t, err)
 	ep := defaultEvalParams(nil, nil)
 	ep.Debugger = &testDbg
-	_, err = Eval(program, ep)
+	_, err = Eval(ops.Program, ep)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, testDbg.register)

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1303,7 +1303,7 @@ func (cx *evalContext) txnFieldToStack(txn *transactions.Transaction, field TxnF
 	case Type:
 		sv.Bytes = []byte(txn.Type)
 	case TypeEnum:
-		sv.Uint = uint64(txnTypeIndexes[string(txn.Type)])
+		sv.Uint = txnTypeIndexes[string(txn.Type)]
 	case XferAsset:
 		sv.Uint = uint64(txn.XferAsset)
 	case AssetAmount:

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -88,14 +88,14 @@ func TestTooManyArgs(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1`, v)
+			ops, err := AssembleStringWithVersion(`int 1`, v)
 			require.NoError(t, err)
 			var txn transactions.SignedTxn
-			txn.Lsig.Logic = program
+			txn.Lsig.Logic = ops.Program
 			args := [transactions.EvalMaxArgs + 1][]byte{}
 			txn.Lsig.Args = args[:]
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, &txn))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, &txn))
 			require.Error(t, err)
 			require.False(t, pass)
 		})
@@ -180,19 +180,19 @@ func TestWrongProtoVersion(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1`, v)
+			ops, err := AssembleStringWithVersion(`int 1`, v)
 			require.NoError(t, err)
 			var txn transactions.SignedTxn
-			txn.Lsig.Logic = program
+			txn.Lsig.Logic = ops.Program
 			sb := strings.Builder{}
 			proto := defaultEvalProto()
 			proto.LogicSigVersion = 0
 			ep := defaultEvalParams(&sb, &txn)
 			ep.Proto = &proto
-			_, err = Check(program, ep)
+			_, err = Check(ops.Program, ep)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "LogicSig not supported")
-			pass, err := Eval(program, ep)
+			pass, err := Eval(ops.Program, ep)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "LogicSig not supported")
 			require.False(t, pass)
@@ -204,18 +204,18 @@ func TestTrivialMath(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 2
+			ops, err := AssembleStringWithVersion(`int 2
 int 3
 +
 int 5
 ==`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			var txn transactions.SignedTxn
-			txn.Lsig.Logic = program
-			pass, err := Eval(program, defaultEvalParams(nil, &txn))
+			txn.Lsig.Logic = ops.Program
+			pass, err := Eval(ops.Program, defaultEvalParams(nil, &txn))
 			require.True(t, pass)
 			require.NoError(t, err)
 		})
@@ -226,20 +226,20 @@ func TestSha256EqArg(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`arg 0
+			ops, err := AssembleStringWithVersion(`arg 0
 sha256
 byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
 ==`, 1)
 			require.NoError(t, err)
 			var txn transactions.SignedTxn
-			txn.Lsig.Logic = program
+			txn.Lsig.Logic = ops.Program
 			txn.Lsig.Args = [][]byte{[]byte("=0\x97S\x85H\xe9\x91B\xfd\xdb;1\xf5Z\xaec?\xae\xf2I\x93\x08\x12\x94\xaa~\x06\x08\x849b")}
 			sb := strings.Builder{}
 			ep := defaultEvalParams(&sb, &txn)
-			cost, err := Check(program, ep)
+			cost, err := Check(ops.Program, ep)
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
-			pass, err := Eval(program, ep)
+			pass, err := Eval(ops.Program, ep)
 			require.True(t, pass)
 			require.NoError(t, err)
 		})
@@ -288,26 +288,26 @@ func TestTLHC(t *testing.T) {
 			a1, _ := basics.UnmarshalChecksumAddress("DFPKC2SJP3OTFVJFMCD356YB7BOT4SJZTGWLIPPFEWL3ZABUFLTOY6ILYE")
 			a2, _ := basics.UnmarshalChecksumAddress("YYKRMERAFXMXCDWMBNR6BUUWQXDCUR53FPUGXLUYS7VNASRTJW2ENQ7BMQ")
 			secret, _ := base64.StdEncoding.DecodeString("xPUB+DJir1wsH7g2iEY1QwYqHqYH1vUJtzZKW4RxXsY=")
-			program, err := AssembleStringWithVersion(tlhcProgramText, v)
+			ops, err := AssembleStringWithVersion(tlhcProgramText, v)
 			require.NoError(t, err)
 			var txn transactions.SignedTxn
-			txn.Lsig.Logic = program
+			txn.Lsig.Logic = ops.Program
 			// right answer
 			txn.Lsig.Args = [][]byte{secret}
 			txn.Txn.FirstValid = 999999
 			sb := strings.Builder{}
 			block := bookkeeping.Block{}
 			ep := defaultEvalParams(&sb, &txn)
-			cost, err := Check(program, ep)
+			cost, err := Check(ops.Program, ep)
 			if err != nil {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
-			pass, err := Eval(program, ep)
+			pass, err := Eval(ops.Program, ep)
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -317,9 +317,9 @@ func TestTLHC(t *testing.T) {
 			txn.Txn.CloseRemainderTo = a2
 			sb = strings.Builder{}
 			ep = defaultEvalParams(&sb, &txn)
-			pass, err = Eval(program, ep)
+			pass, err = Eval(ops.Program, ep)
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.True(t, pass)
@@ -330,9 +330,9 @@ func TestTLHC(t *testing.T) {
 			sb = strings.Builder{}
 			txn.Txn.FirstValid = 1
 			ep = defaultEvalParams(&sb, &txn)
-			pass, err = Eval(program, ep)
+			pass, err = Eval(ops.Program, ep)
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -343,9 +343,9 @@ func TestTLHC(t *testing.T) {
 			sb = strings.Builder{}
 			txn.Txn.FirstValid = 999999
 			ep = defaultEvalParams(&sb, &txn)
-			pass, err = Eval(program, ep)
+			pass, err = Eval(ops.Program, ep)
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.True(t, pass)
@@ -356,9 +356,9 @@ func TestTLHC(t *testing.T) {
 			sb = strings.Builder{}
 			block.BlockHeader.Round = 1
 			ep = defaultEvalParams(&sb, &txn)
-			pass, err = Eval(program, ep)
+			pass, err = Eval(ops.Program, ep)
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -371,16 +371,16 @@ func TestU64Math(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 0x1234567812345678
+			ops, err := AssembleStringWithVersion(`int 0x1234567812345678
 int 0x100000000
 /
 int 0x12345678
 ==`, v)
 			require.NoError(t, err)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.True(t, pass)
@@ -393,15 +393,15 @@ func TestItob(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`byte 0x1234567812345678
+			ops, err := AssembleStringWithVersion(`byte 0x1234567812345678
 int 0x1234567812345678
 itob
 ==`, v)
 			require.NoError(t, err)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -414,15 +414,15 @@ func TestBtoi(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 0x1234567812345678
+			ops, err := AssembleStringWithVersion(`int 0x1234567812345678
 byte 0x1234567812345678
 btoi
 ==`, v)
 			require.NoError(t, err)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -435,15 +435,15 @@ func TestBtoiTooLong(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 0x1234567812345678
+			ops, err := AssembleStringWithVersion(`int 0x1234567812345678
 byte 0x1234567812345678aaaa
 btoi
 ==`, v)
 			require.NoError(t, err)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -457,7 +457,7 @@ func TestBnz(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1
+			ops, err := AssembleStringWithVersion(`int 1
 dup
 bnz safe
 err
@@ -465,13 +465,13 @@ safe:
 int 1
 +`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -484,7 +484,7 @@ func TestBnz2(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1
+			ops, err := AssembleStringWithVersion(`int 1
 int 2
 int 1
 int 2
@@ -500,13 +500,13 @@ dup
 pop
 `, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -519,7 +519,7 @@ func TestBz(t *testing.T) {
 	t.Parallel()
 	for v := uint64(2); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 0
+			ops, err := AssembleStringWithVersion(`int 0
 dup
 bz safe
 err
@@ -527,13 +527,13 @@ safe:
 int 1
 +`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -546,18 +546,18 @@ func TestB(t *testing.T) {
 	t.Parallel()
 	for v := uint64(2); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`b safe
+			ops, err := AssembleStringWithVersion(`b safe
 err
 safe:
 int 1`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -570,17 +570,17 @@ func TestReturn(t *testing.T) {
 	t.Parallel()
 	for v := uint64(2); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1
+			ops, err := AssembleStringWithVersion(`int 1
 return
 err`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -593,17 +593,17 @@ func TestReturnFalse(t *testing.T) {
 	t.Parallel()
 	for v := uint64(2); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 0
+			ops, err := AssembleStringWithVersion(`int 0
 return
 int 1`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -616,19 +616,19 @@ func TestSubUnderflow(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1
+			ops, err := AssembleStringWithVersion(`int 1
 int 0x100000000
 -
 pop
 int 1`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -642,19 +642,19 @@ func TestAddOverflow(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 0xf000000000000000
+			ops, err := AssembleStringWithVersion(`int 0xf000000000000000
 int 0x1111111111111111
 +
 pop
 int 1`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -668,19 +668,19 @@ func TestMulOverflow(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 0x111111111
+			ops, err := AssembleStringWithVersion(`int 0x111111111
 int 0x222222222
 *
 pop
 int 1`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -718,7 +718,7 @@ func TestMulw(t *testing.T) {
 	// multiply two numbers, ensure high is 2 and low is 0x468acf130eca8642
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 0x111111111
+			ops, err := AssembleStringWithVersion(`int 0x111111111
 int 0x222222222
 mulw
 int 0x468acf130eca8642  // compare low (top of the stack)
@@ -734,13 +734,13 @@ done:
 int 1                   // ret 1
 `, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.True(t, pass)
@@ -773,7 +773,7 @@ func TestAddw(t *testing.T) {
 	// add two numbers, ensure sum is 0x42 and carry is 0x1
 	for v := uint64(2); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 0xFFFFFFFFFFFFFFFF
+			ops, err := AssembleStringWithVersion(`int 0xFFFFFFFFFFFFFFFF
 int 0x43
 addw
 int 0x42  // compare sum (top of the stack)
@@ -789,13 +789,13 @@ done:
 int 1                   // ret 1
 `, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.True(t, pass)
@@ -808,23 +808,23 @@ func TestDivZero(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 0x111111111
+			ops, err := AssembleStringWithVersion(`int 0x111111111
 int 0
 /
 pop
 int 1`, v)
 			require.NoError(t, err)
 			sb := strings.Builder{}
-			cost, err := Check(program, defaultEvalParams(&sb, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(&sb, nil))
 			if err != nil {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -838,19 +838,19 @@ func TestModZero(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 0x111111111
+			ops, err := AssembleStringWithVersion(`int 0x111111111
 int 0
 %
 pop
 int 1`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -864,16 +864,16 @@ func TestErr(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`err
+			ops, err := AssembleStringWithVersion(`err
 int 1`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -887,7 +887,7 @@ func TestModSubMulOk(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 35
+			ops, err := AssembleStringWithVersion(`int 35
 int 16
 %
 int 1
@@ -897,13 +897,13 @@ int 2
 int 4
 ==`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -916,18 +916,18 @@ func TestPop(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1
+			ops, err := AssembleStringWithVersion(`int 1
 int 0
 pop`, v)
 			require.NoError(t, err)
 			sb := strings.Builder{}
-			cost, err := Check(program, defaultEvalParams(&sb, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(&sb, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb = strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -940,17 +940,17 @@ func TestStackLeftover(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1
+			ops, err := AssembleStringWithVersion(`int 1
 int 1`, v)
 			require.NoError(t, err)
 			sb := strings.Builder{}
-			cost, err := Check(program, defaultEvalParams(&sb, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(&sb, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb = strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.Error(t, err)
@@ -964,16 +964,16 @@ func TestStackBytesLeftover(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`byte 0x10101010`, v)
+			ops, err := AssembleStringWithVersion(`byte 0x10101010`, v)
 			require.NoError(t, err)
 			sb := strings.Builder{}
-			cost, err := Check(program, defaultEvalParams(&sb, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(&sb, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb = strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.Error(t, err)
@@ -987,18 +987,18 @@ func TestStackEmpty(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1
+			ops, err := AssembleStringWithVersion(`int 1
 int 1
 pop
 pop`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.Error(t, err)
@@ -1012,19 +1012,19 @@ func TestArgTooFar(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`arg_1
+			ops, err := AssembleStringWithVersion(`arg_1
 btoi`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err) // TODO: Check should know the type stack was wrong
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
 			var txn transactions.SignedTxn
-			txn.Lsig.Logic = program
+			txn.Lsig.Logic = ops.Program
 			txn.Lsig.Args = nil
-			pass, err := Eval(program, defaultEvalParams(&sb, &txn))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, &txn))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.Error(t, err)
@@ -1038,18 +1038,18 @@ func TestIntcTooFar(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`intc_1`, v)
+			ops, err := AssembleStringWithVersion(`intc_1`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err) // TODO: Check should know the type stack was wrong
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
 			var txn transactions.SignedTxn
-			txn.Lsig.Logic = program
+			txn.Lsig.Logic = ops.Program
 			txn.Lsig.Args = nil
-			pass, err := Eval(program, defaultEvalParams(&sb, &txn))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, &txn))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.Error(t, err)
@@ -1063,19 +1063,19 @@ func TestBytecTooFar(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`bytec_1
+			ops, err := AssembleStringWithVersion(`bytec_1
 btoi`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err) // TODO: Check should know the type stack was wrong
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
 			var txn transactions.SignedTxn
-			txn.Lsig.Logic = program
+			txn.Lsig.Logic = ops.Program
 			txn.Lsig.Args = nil
-			pass, err := Eval(program, defaultEvalParams(&sb, &txn))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, &txn))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.Error(t, err)
@@ -1111,11 +1111,11 @@ func TestTxnBadField(t *testing.T) {
 	fields := []TxnField{ApplicationArgs, Accounts}
 	for _, field := range fields {
 		source := fmt.Sprintf("txn %s 0", field.String())
-		program, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
+		ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 		require.NoError(t, err)
-		require.Equal(t, txnaOpcode, program[1])
-		program[1] = txnOpcode
-		pass, err = Eval(program, defaultEvalParams(&sb, &txn))
+		require.Equal(t, txnaOpcode, ops.Program[1])
+		ops.Program[1] = txnOpcode
+		pass, err = Eval(ops.Program, defaultEvalParams(&sb, &txn))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), fmt.Sprintf("invalid txn field %d", field))
 		require.False(t, pass)
@@ -1176,11 +1176,11 @@ func TestGtxnBadField(t *testing.T) {
 	fields := []TxnField{ApplicationArgs, Accounts}
 	for _, field := range fields {
 		source := fmt.Sprintf("txn %s 0", field.String())
-		program, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
+		ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 		require.NoError(t, err)
-		require.Equal(t, txnaOpcode, program[1])
-		program[1] = txnOpcode
-		pass, err = Eval(program, defaultEvalParams(&sb, &txn))
+		require.Equal(t, txnaOpcode, ops.Program[1])
+		ops.Program[1] = txnOpcode
+		pass, err = Eval(ops.Program, defaultEvalParams(&sb, &txn))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), fmt.Sprintf("invalid txn field %d", field))
 		require.False(t, pass)
@@ -1211,7 +1211,7 @@ func TestArg(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`arg 0
+			ops, err := AssembleStringWithVersion(`arg 0
 arg 1
 ==
 arg 2
@@ -1224,11 +1224,11 @@ int 9
 <
 &&`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			var txn transactions.SignedTxn
-			txn.Lsig.Logic = program
+			txn.Lsig.Logic = ops.Program
 			txn.Lsig.Args = [][]byte{
 				[]byte("aoeu"),
 				[]byte("aoeu"),
@@ -1237,9 +1237,9 @@ int 9
 				[]byte("aoeu4"),
 			}
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, &txn))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, &txn))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -1320,13 +1320,13 @@ func TestGlobal(t *testing.T) {
 					t.Errorf("TestGlobal missing field %v", globalField)
 				}
 			}
-			program, err := AssembleStringWithVersion(testProgram, v)
+			ops, err := AssembleStringWithVersion(testProgram, v)
 			require.NoError(t, err)
-			cost, err := check(program, defaultEvalParams(nil, nil))
+			cost, err := check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			var txn transactions.SignedTxn
-			txn.Lsig.Logic = program
+			txn.Lsig.Logic = ops.Program
 			txgroup := make([]transactions.SignedTxn, 1)
 			txgroup[0] = txn
 			sb := strings.Builder{}
@@ -1344,9 +1344,9 @@ func TestGlobal(t *testing.T) {
 			ep.TxnGroup = txgroup
 			ep.Proto = &proto
 			ep.Ledger = ledger
-			pass, err := eval(program, ep)
+			pass, err := eval(ops.Program, ep)
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -1388,9 +1388,9 @@ txn TypeEnum
 int %s
 ==
 &&`, symbol, string(tt))
-					program, err := AssembleStringWithVersion(text, v)
+					ops, err := AssembleStringWithVersion(text, v)
 					require.NoError(t, err)
-					cost, err := Check(program, defaultEvalParams(nil, nil))
+					cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 					require.NoError(t, err)
 					require.True(t, cost < 1000)
 					var txn transactions.SignedTxn
@@ -1398,9 +1398,9 @@ int %s
 					sb := strings.Builder{}
 					ep := defaultEvalParams(&sb, &txn)
 					ep.GroupIndex = 3
-					pass, err := Eval(program, ep)
+					pass, err := Eval(ops.Program, ep)
 					if !pass {
-						t.Log(hex.EncodeToString(program))
+						t.Log(hex.EncodeToString(ops.Program))
 						t.Log(sb.String())
 					}
 					require.NoError(t, err)
@@ -1447,9 +1447,9 @@ func TestOnCompletionConstants(t *testing.T) {
 int %s
 ==
 `, symbol, oc)
-					program, err := AssembleStringWithVersion(text, v)
+					ops, err := AssembleStringWithVersion(text, v)
 					require.NoError(t, err)
-					pass, err := Eval(program, ep)
+					pass, err := Eval(ops.Program, ep)
 					require.NoError(t, err)
 					require.True(t, pass)
 				})
@@ -1746,27 +1746,27 @@ func TestTxn(t *testing.T) {
 		2: testTxnProgramText,
 	}
 
-	clearProgram, err := AssembleStringWithVersion("int 1", 1)
+	clearOps, err := AssembleStringWithVersion("int 1", 1)
 	require.NoError(t, err)
 
 	for v, source := range tests {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(source, v)
+			ops, err := AssembleStringWithVersion(source, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			txn := makeSampleTxn()
-			txn.Txn.ApprovalProgram = program
-			txn.Txn.ClearStateProgram = clearProgram
-			txn.Lsig.Logic = program
+			txn.Txn.ApprovalProgram = ops.Program
+			txn.Txn.ClearStateProgram = clearOps.Program
+			txn.Lsig.Logic = ops.Program
 			// RekeyTo not allowed in TEAL v1
 			if v < rekeyingEnabledVersion {
 				txn.Txn.RekeyTo = basics.Address{}
 			}
 			txid := txn.Txn.ID()
-			programHash := HashProgram(program)
-			clearProgramHash := HashProgram(clearProgram)
+			programHash := HashProgram(ops.Program)
+			clearProgramHash := HashProgram(clearOps.Program)
 			txn.Lsig.Args = [][]byte{
 				txn.Txn.Sender[:],
 				txn.Txn.Receiver[:],
@@ -1783,9 +1783,9 @@ func TestTxn(t *testing.T) {
 			sb := strings.Builder{}
 			ep := defaultEvalParams(&sb, &txn)
 			ep.GroupIndex = 3
-			pass, err := Eval(program, ep)
+			pass, err := Eval(ops.Program, ep)
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -1835,19 +1835,19 @@ fail:
 int 0
 return
 `
-	program, err := AssembleStringWithVersion(cachedTxnProg, 2)
+	ops, err := AssembleStringWithVersion(cachedTxnProg, 2)
 	require.NoError(t, err)
 	sb := strings.Builder{}
-	cost, err := Check(program, defaultEvalParams(&sb, nil))
+	cost, err := Check(ops.Program, defaultEvalParams(&sb, nil))
 	if err != nil {
-		t.Log(hex.EncodeToString(program))
+		t.Log(hex.EncodeToString(ops.Program))
 		t.Log(sb.String())
 	}
 	require.NoError(t, err)
 	require.True(t, cost < 1000)
 	txn := makeSampleTxn()
 	txgroup := makeSampleTxnGroup(txn)
-	txn.Lsig.Logic = program
+	txn.Lsig.Logic = ops.Program
 	txid0 := txgroup[0].ID()
 	txid1 := txgroup[1].ID()
 	txn.Lsig.Args = [][]byte{
@@ -1857,9 +1857,9 @@ return
 	sb = strings.Builder{}
 	ep := defaultEvalParams(&sb, &txn)
 	ep.TxnGroup = txgroup
-	pass, err := Eval(program, ep)
+	pass, err := Eval(ops.Program, ep)
 	if !pass || err != nil {
-		t.Log(hex.EncodeToString(program))
+		t.Log(hex.EncodeToString(ops.Program))
 		t.Log(sb.String())
 	}
 	require.NoError(t, err)
@@ -1946,12 +1946,12 @@ int 1
 
 	for v, source := range tests {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(source, v)
+			ops, err := AssembleStringWithVersion(source, v)
 			require.NoError(t, err)
 			sb := strings.Builder{}
-			cost, err := Check(program, defaultEvalParams(&sb, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(&sb, nil))
 			if err != nil {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -1961,7 +1961,7 @@ int 1
 			if v < rekeyingEnabledVersion {
 				txn.Txn.RekeyTo = basics.Address{}
 			}
-			txn.Lsig.Logic = program
+			txn.Lsig.Logic = ops.Program
 			txn.Lsig.Args = [][]byte{
 				txn.Txn.Sender[:],
 				txn.Txn.Receiver[:],
@@ -1974,9 +1974,9 @@ int 1
 			sb = strings.Builder{}
 			ep := defaultEvalParams(&sb, &txn)
 			ep.TxnGroup = txgroup
-			pass, err := Eval(program, ep)
+			pass, err := Eval(ops.Program, ep)
 			if !pass || err != nil {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -1991,7 +1991,7 @@ func TestTxna(t *testing.T) {
 txna ApplicationArgs 0
 ==
 `
-	program, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
 	var txn transactions.SignedTxn
 	txn.Txn.Accounts = make([]basics.Address, 1)
@@ -2002,38 +2002,38 @@ txna ApplicationArgs 0
 	txgroup[0] = txn
 	ep := defaultEvalParams(nil, &txn)
 	ep.TxnGroup = txgroup
-	_, err = Eval(program, ep)
+	_, err = Eval(ops.Program, ep)
 	require.NoError(t, err)
 
 	// modify txn field
-	saved := program[2]
-	program[2] = 0x01
-	_, err = Eval(program, ep)
+	saved := ops.Program[2]
+	ops.Program[2] = 0x01
+	_, err = Eval(ops.Program, ep)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "txna unsupported field")
 
 	// modify txn field to unknown one
-	program[2] = 99
-	_, err = Eval(program, ep)
+	ops.Program[2] = 99
+	_, err = Eval(ops.Program, ep)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid txn field 99")
 
 	// modify txn array index
-	program[2] = saved
-	saved = program[3]
-	program[3] = 0x02
-	_, err = Eval(program, ep)
+	ops.Program[2] = saved
+	saved = ops.Program[3]
+	ops.Program[3] = 0x02
+	_, err = Eval(ops.Program, ep)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid Accounts index")
 
 	// modify txn array index in the second opcode
-	program[3] = saved
-	saved = program[6]
-	program[6] = 0x01
-	_, err = Eval(program, ep)
+	ops.Program[3] = saved
+	saved = ops.Program[6]
+	ops.Program[6] = 0x01
+	_, err = Eval(ops.Program, ep)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid ApplicationArgs index")
-	program[6] = saved
+	ops.Program[6] = saved
 
 	// check special case: Account 0 == Sender
 	// even without any additional context
@@ -2041,12 +2041,12 @@ txna ApplicationArgs 0
 txn Sender
 ==
 `
-	program2, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops2, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
 	var txn2 transactions.SignedTxn
 	copy(txn2.Txn.Sender[:], []byte("aoeuiaoeuiaoeuiaoeuiaoeuiaoeui00"))
 	ep2 := defaultEvalParams(nil, &txn2)
-	pass, err := Eval(program2, ep2)
+	pass, err := Eval(ops2.Program, ep2)
 	require.NoError(t, err)
 	require.True(t, pass)
 
@@ -2054,40 +2054,40 @@ txn Sender
 	source = `gtxna 0 Accounts 1
 txna ApplicationArgs 0
 ==`
-	program, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
-	_, err = Eval(program, ep)
+	_, err = Eval(ops.Program, ep)
 	require.NoError(t, err)
 
 	// modify gtxn index
-	saved = program[2]
-	program[2] = 0x01
-	_, err = Eval(program, ep)
+	saved = ops.Program[2]
+	ops.Program[2] = 0x01
+	_, err = Eval(ops.Program, ep)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "gtxna lookup TxnGroup[1] but it only has 1")
 
 	// modify gtxn field
-	program[2] = saved
-	saved = program[3]
-	program[3] = 0x01
-	_, err = Eval(program, ep)
+	ops.Program[2] = saved
+	saved = ops.Program[3]
+	ops.Program[3] = 0x01
+	_, err = Eval(ops.Program, ep)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "gtxna unsupported field")
 
 	// modify gtxn field to unknown one
-	program[3] = 99
-	_, err = Eval(program, ep)
+	ops.Program[3] = 99
+	_, err = Eval(ops.Program, ep)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid txn field 99")
 
 	// modify gtxn array index
-	program[3] = saved
-	saved = program[4]
-	program[4] = 0x02
-	_, err = Eval(program, ep)
+	ops.Program[3] = saved
+	saved = ops.Program[4]
+	ops.Program[4] = 0x02
+	_, err = Eval(ops.Program, ep)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid Accounts index")
-	program[4] = saved
+	ops.Program[4] = saved
 
 	// check special case: Account 0 == Sender
 	// even without any additional context
@@ -2095,7 +2095,7 @@ txna ApplicationArgs 0
 txn Sender
 ==
 `
-	program3, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops3, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
 	var txn3 transactions.SignedTxn
 	copy(txn2.Txn.Sender[:], []byte("aoeuiaoeuiaoeuiaoeuiaoeuiaoeui00"))
@@ -2103,7 +2103,7 @@ txn Sender
 	txgroup3[0] = txn3
 	ep3 := defaultEvalParams(nil, &txn3)
 	ep3.TxnGroup = txgroup3
-	pass, err = Eval(program3, ep3)
+	pass, err = Eval(ops3.Program, ep3)
 	require.NoError(t, err)
 	require.True(t, pass)
 }
@@ -2116,7 +2116,7 @@ btoi
 int 0
 ==
 `
-	program, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
 
 	var txn transactions.SignedTxn
@@ -2126,13 +2126,13 @@ int 0
 	txgroup[0] = txn
 	ep := defaultEvalParams(nil, &txn)
 	ep.TxnGroup = txgroup
-	pass, err := Eval(program, ep)
+	pass, err := Eval(ops.Program, ep)
 	require.NoError(t, err)
 	require.True(t, pass)
 	txn.Txn.ApplicationArgs[0] = nil
 	txgroup[0] = txn
 	ep.TxnGroup = txgroup
-	pass, err = Eval(program, ep)
+	pass, err = Eval(ops.Program, ep)
 	require.NoError(t, err)
 	require.True(t, pass)
 
@@ -2140,7 +2140,7 @@ int 0
 global ZeroAddress
 ==
 `
-	program2, err := AssembleStringWithVersion(source2, AssemblerMaxVersion)
+	ops2, err := AssembleStringWithVersion(source2, AssemblerMaxVersion)
 	require.NoError(t, err)
 
 	var txn2 transactions.SignedTxn
@@ -2150,13 +2150,13 @@ global ZeroAddress
 	txgroup2[0] = txn2
 	ep2 := defaultEvalParams(nil, &txn2)
 	ep2.TxnGroup = txgroup2
-	pass, err = Eval(program2, ep2)
+	pass, err = Eval(ops2.Program, ep2)
 	require.NoError(t, err)
 	require.True(t, pass)
 	txn2.Txn.Accounts = make([]basics.Address, 1)
 	txgroup2[0] = txn
 	ep2.TxnGroup = txgroup2
-	pass, err = Eval(program2, ep2)
+	pass, err = Eval(ops2.Program, ep2)
 	require.NoError(t, err)
 	require.True(t, pass)
 }
@@ -2165,7 +2165,7 @@ func TestBitOps(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 0x17
+			ops, err := AssembleStringWithVersion(`int 0x17
 int 0x3e
 & // == 0x16
 int 0x0a
@@ -2178,13 +2178,13 @@ int 0x300
 int 0x310
 ==`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -2360,7 +2360,7 @@ func TestLoadStore(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 37
+			ops, err := AssembleStringWithVersion(`int 37
 int 37
 store 1
 byte 0xabbacafe
@@ -2376,13 +2376,13 @@ load 1
 +
 &&`, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -2400,7 +2400,7 @@ func assembleStringWithTrace(t testing.TB, text string, version uint64) ([]byte,
 		t.Log(sb.String())
 		return nil, err
 	}
-	return ops.Bytes()
+	return ops.Program, nil
 }
 
 func TestLoadStore2(t *testing.T) {
@@ -2499,15 +2499,15 @@ func TestCompares(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(testCompareProgramText, v)
+			ops, err := AssembleStringWithVersion(testCompareProgramText, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(nil, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(nil, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -2530,15 +2530,15 @@ byte 0xc195eca25a6f4c82bfba0287082ddb0d602ae9230f9cf1f1a40b68f8e2c41567
 ==`
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(progText, v)
+			ops, err := AssembleStringWithVersion(progText, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(nil, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(nil, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -2565,15 +2565,15 @@ byte 0x98D2C31612EA500279B6753E5F6E780CA63EBA8274049664DAD66A2565ED1D2A
 ==`
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(progText, v)
+			ops, err := AssembleStringWithVersion(progText, v)
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.NoError(t, err)
@@ -2595,16 +2595,16 @@ func TestStackUnderflow(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1`, v)
-			program = append(program, 0x08) // +
+			ops, err := AssembleStringWithVersion(`int 1`, v)
+			ops.Program = append(ops.Program, 0x08) // +
 			require.NoError(t, err)
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -2617,16 +2617,16 @@ func TestWrongStackTypeRuntime(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1`, v)
+			ops, err := AssembleStringWithVersion(`int 1`, v)
 			require.NoError(t, err)
-			program = append(program, 0x01, 0x15) // sha256, len
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			ops.Program = append(ops.Program, 0x01, 0x15) // sha256, len
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -2639,17 +2639,17 @@ func TestEqMismatch(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`byte 0x1234
+			ops, err := AssembleStringWithVersion(`byte 0x1234
 int 1`, v)
 			require.NoError(t, err)
-			program = append(program, 0x12) // ==
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			ops.Program = append(ops.Program, 0x12) // ==
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err) // TODO: Check should know the type stack was wrong
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -2662,17 +2662,17 @@ func TestNeqMismatch(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`byte 0x1234
+			ops, err := AssembleStringWithVersion(`byte 0x1234
 int 1`, v)
 			require.NoError(t, err)
-			program = append(program, 0x13) // !=
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			ops.Program = append(ops.Program, 0x13) // !=
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err) // TODO: Check should know the type stack was wrong
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -2685,17 +2685,17 @@ func TestWrongStackTypeRuntime2(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`byte 0x1234
+			ops, err := AssembleStringWithVersion(`byte 0x1234
 int 1`, v)
 			require.NoError(t, err)
-			program = append(program, 0x08) // +
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			ops.Program = append(ops.Program, 0x08) // +
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.NoError(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, _ := Eval(program, defaultEvalParams(&sb, nil))
+			pass, _ := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -2708,21 +2708,21 @@ func TestIllegalOp(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1`, v)
+			ops, err := AssembleStringWithVersion(`int 1`, v)
 			require.NoError(t, err)
 			for opcode, spec := range opsByOpcode[v] {
 				if spec.op == nil {
-					program = append(program, byte(opcode))
+					ops.Program = append(ops.Program, byte(opcode))
 					break
 				}
 			}
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.Error(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -2735,21 +2735,21 @@ func TestShortProgram(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1
+			ops, err := AssembleStringWithVersion(`int 1
 bnz done
 done:
 int 1
 `, v)
 			require.NoError(t, err)
 			// cut two last bytes - intc_1 and last byte of bnz
-			program = program[:len(program)-2]
-			cost, err := Check(program, defaultEvalParams(nil, nil))
+			ops.Program = ops.Program[:len(ops.Program)-2]
+			cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 			require.Error(t, err)
 			require.True(t, cost < 1000)
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -2778,11 +2778,11 @@ func TestShortBytecblock(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			fullprogram, err := AssembleStringWithVersion(`bytecblock 0x123456 0xababcdcd "test"`, v)
+			fullops, err := AssembleStringWithVersion(`bytecblock 0x123456 0xababcdcd "test"`, v)
 			require.NoError(t, err)
-			fullprogram[2] = 50 // fake 50 elements
-			for i := 2; i < len(fullprogram); i++ {
-				program := fullprogram[:i]
+			fullops.Program[2] = 50 // fake 50 elements
+			for i := 2; i < len(fullops.Program); i++ {
+				program := fullops.Program[:i]
 				t.Run(hex.EncodeToString(program), func(t *testing.T) {
 					cost, err := Check(program, defaultEvalParams(nil, nil))
 					require.Error(t, err)
@@ -2843,7 +2843,7 @@ func TestPanic(t *testing.T) {
 	log := logging.TestingLog(t)
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1`, v)
+			ops, err := AssembleStringWithVersion(`int 1`, v)
 			require.NoError(t, err)
 			var hackedOpcode int
 			var oldSpec OpSpec
@@ -2854,14 +2854,14 @@ func TestPanic(t *testing.T) {
 					opsByOpcode[v][opcode].op = opPanic
 					opsByOpcode[v][opcode].Modes = modeAny
 					opsByOpcode[v][opcode].opSize.checkFunc = checkPanic
-					program = append(program, byte(opcode))
+					ops.Program = append(ops.Program, byte(opcode))
 					break
 				}
 			}
 			sb := strings.Builder{}
 			params := defaultEvalParams(&sb, nil)
 			params.Logger = log
-			_, err = Check(program, params)
+			_, err = Check(ops.Program, params)
 			require.Error(t, err)
 			if pe, ok := err.(PanicError); ok {
 				require.Equal(t, panicString, pe.PanicValue)
@@ -2872,12 +2872,12 @@ func TestPanic(t *testing.T) {
 			}
 			sb = strings.Builder{}
 			var txn transactions.SignedTxn
-			txn.Lsig.Logic = program
+			txn.Lsig.Logic = ops.Program
 			params = defaultEvalParams(&sb, &txn)
 			params.Logger = log
-			pass, err := Eval(program, params)
+			pass, err := Eval(ops.Program, params)
 			if pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.False(t, pass)
@@ -2941,7 +2941,7 @@ func TestMisalignedBranch(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1
+			ops, err := AssembleStringWithVersion(`int 1
 bnz done
 bytecblock 0x01234576 0xababcdcd 0xf000baad
 done:
@@ -2951,12 +2951,12 @@ int 1`, v)
 			canonicalProgramString := mutateProgVersion(v, "01200101224000112603040123457604ababcdcd04f000baad22")
 			canonicalProgramBytes, err := hex.DecodeString(canonicalProgramString)
 			require.NoError(t, err)
-			require.Equal(t, program, canonicalProgramBytes)
-			program[7] = 3 // clobber the branch offset to be in the middle of the bytecblock
-			_, err = Check(program, defaultEvalParams(nil, nil))
+			require.Equal(t, ops.Program, canonicalProgramBytes)
+			ops.Program[7] = 3 // clobber the branch offset to be in the middle of the bytecblock
+			_, err = Check(ops.Program, defaultEvalParams(nil, nil))
 			require.Error(t, err)
 			require.True(t, strings.Contains(err.Error(), "aligned"))
-			pass, err := Eval(program, defaultEvalParams(nil, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(nil, nil))
 			require.Error(t, err)
 			require.False(t, pass)
 			isNotPanic(t, err)
@@ -2968,22 +2968,22 @@ func TestBranchTooFar(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1
+			ops, err := AssembleStringWithVersion(`int 1
 bnz done
 bytecblock 0x01234576 0xababcdcd 0xf000baad
 done:
 int 1`, v)
 			require.NoError(t, err)
-			//t.Log(hex.EncodeToString(program))
+			//t.Log(hex.EncodeToString(ops.Program))
 			canonicalProgramString := mutateProgVersion(v, "01200101224000112603040123457604ababcdcd04f000baad22")
 			canonicalProgramBytes, err := hex.DecodeString(canonicalProgramString)
 			require.NoError(t, err)
-			require.Equal(t, program, canonicalProgramBytes)
-			program[7] = 200 // clobber the branch offset to be beyond the end of the program
-			_, err = Check(program, defaultEvalParams(nil, nil))
+			require.Equal(t, ops.Program, canonicalProgramBytes)
+			ops.Program[7] = 200 // clobber the branch offset to be beyond the end of the program
+			_, err = Check(ops.Program, defaultEvalParams(nil, nil))
 			require.Error(t, err)
 			require.True(t, strings.Contains(err.Error(), "beyond end of program"))
-			pass, err := Eval(program, defaultEvalParams(nil, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(nil, nil))
 			require.Error(t, err)
 			require.False(t, pass)
 			isNotPanic(t, err)
@@ -2995,22 +2995,22 @@ func TestBranchTooLarge(t *testing.T) {
 	t.Parallel()
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1
+			ops, err := AssembleStringWithVersion(`int 1
 bnz done
 bytecblock 0x01234576 0xababcdcd 0xf000baad
 done:
 int 1`, v)
 			require.NoError(t, err)
-			//t.Log(hex.EncodeToString(program))
+			//t.Log(hex.EncodeToString(ops.Program))
 			canonicalProgramString := mutateProgVersion(v, "01200101224000112603040123457604ababcdcd04f000baad22")
 			canonicalProgramBytes, err := hex.DecodeString(canonicalProgramString)
 			require.NoError(t, err)
-			require.Equal(t, program, canonicalProgramBytes)
-			program[6] = 0xff // clobber the branch offset
-			_, err = Check(program, defaultEvalParams(nil, nil))
+			require.Equal(t, ops.Program, canonicalProgramBytes)
+			ops.Program[6] = 0xff // clobber the branch offset
+			_, err = Check(ops.Program, defaultEvalParams(nil, nil))
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "too large")
-			pass, err := Eval(program, defaultEvalParams(nil, nil))
+			pass, err := Eval(ops.Program, defaultEvalParams(nil, nil))
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "too large")
 			require.False(t, pass)
@@ -3030,14 +3030,14 @@ int 1
 	for _, line := range branches {
 		t.Run(fmt.Sprintf("branch=%s", line), func(t *testing.T) {
 			source := fmt.Sprintf(template, line)
-			program, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
+			ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 			require.NoError(t, err)
-			program[7] = 0xff // clobber the branch offset
-			program[8] = 0xff // clobber the branch offset
-			_, err = Check(program, ep)
+			ops.Program[7] = 0xff // clobber the branch offset
+			ops.Program[8] = 0xff // clobber the branch offset
+			_, err = Check(ops.Program, ep)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "too large")
-			pass, err := Eval(program, ep)
+			pass, err := Eval(ops.Program, ep)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "too large")
 			require.False(t, pass)
@@ -3322,17 +3322,17 @@ int 142791994204213819
 `
 
 func benchmarkBasicProgram(b *testing.B, source string) {
-	program, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(b, err)
-	cost, err := Check(program, defaultEvalParams(nil, nil))
+	cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 	require.NoError(b, err)
 	require.True(b, cost < 2000)
-	//b.Logf("%d bytes of program", len(program))
-	//b.Log(hex.EncodeToString(program))
+	//b.Logf("%d bytes of program", len(ops.Program))
+	//b.Log(hex.EncodeToString(ops.Program))
 	b.ResetTimer()
 	sb := strings.Builder{} // Trace: &sb
 	for i := 0; i < b.N; i++ {
-		pass, err := Eval(program, defaultEvalParams(nil, nil))
+		pass, err := Eval(ops.Program, defaultEvalParams(nil, nil))
 		if !pass {
 			b.Log(sb.String())
 		}
@@ -3347,17 +3347,17 @@ func benchmarkBasicProgram(b *testing.B, source string) {
 }
 
 func benchmarkExpensiveProgram(b *testing.B, source string) {
-	program, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(b, err)
-	cost, err := Check(program, defaultEvalParams(nil, nil))
+	cost, err := Check(ops.Program, defaultEvalParams(nil, nil))
 	require.NoError(b, err)
 	require.True(b, cost > 1000)
-	//b.Logf("%d bytes of program", len(program))
-	//b.Log(hex.EncodeToString(program))
+	//b.Logf("%d bytes of program", len(ops.Program))
+	//b.Log(hex.EncodeToString(ops.Program))
 	b.ResetTimer()
 	sb := strings.Builder{} // Trace: &sb
 	for i := 0; i < b.N; i++ {
-		pass, err := Eval(program, defaultEvalParams(&sb, nil))
+		pass, err := Eval(ops.Program, defaultEvalParams(&sb, nil))
 		if !pass {
 			b.Log(sb.String())
 		}
@@ -3443,22 +3443,22 @@ func TestEd25519verify(t *testing.T) {
 
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(fmt.Sprintf(`arg 0
+			ops, err := AssembleStringWithVersion(fmt.Sprintf(`arg 0
 arg 1
 addr %s
 ed25519verify`, pkStr), v)
 			require.NoError(t, err)
 			sig := c.Sign(Msg{
-				ProgramHash: crypto.HashObj(Program(program)),
+				ProgramHash: crypto.HashObj(Program(ops.Program)),
 				Data:        data[:],
 			})
 			var txn transactions.SignedTxn
-			txn.Lsig.Logic = program
+			txn.Lsig.Logic = ops.Program
 			txn.Lsig.Args = [][]byte{data[:], sig[:]}
 			sb := strings.Builder{}
-			pass, err := Eval(program, defaultEvalParams(&sb, &txn))
+			pass, err := Eval(ops.Program, defaultEvalParams(&sb, &txn))
 			if !pass {
-				t.Log(hex.EncodeToString(program))
+				t.Log(hex.EncodeToString(ops.Program))
 				t.Log(sb.String())
 			}
 			require.True(t, pass)
@@ -3466,7 +3466,7 @@ ed25519verify`, pkStr), v)
 
 			// short sig will fail
 			txn.Lsig.Args[1] = sig[1:]
-			pass, err = Eval(program, defaultEvalParams(nil, &txn))
+			pass, err = Eval(ops.Program, defaultEvalParams(nil, &txn))
 			require.False(t, pass)
 			require.Error(t, err)
 			isNotPanic(t, err)
@@ -3477,7 +3477,7 @@ ed25519verify`, pkStr), v)
 			require.NoError(t, err)
 			txn.Lsig.Args = [][]byte{data1, sig[:]}
 			sb1 := strings.Builder{}
-			pass1, err := Eval(program, defaultEvalParams(&sb1, &txn))
+			pass1, err := Eval(ops.Program, defaultEvalParams(&sb1, &txn))
 			require.False(t, pass1)
 			require.NoError(t, err)
 			isNotPanic(t, err)
@@ -3501,12 +3501,12 @@ func BenchmarkEd25519Verifyx1(b *testing.B) {
 		secret := crypto.GenerateSignatureSecrets(s)
 		pk := basics.Address(secret.SignatureVerifier)
 		pkStr := pk.String()
-		program, err := AssembleStringWithVersion(fmt.Sprintf(`arg 0
+		ops, err := AssembleStringWithVersion(fmt.Sprintf(`arg 0
 arg 1
 addr %s
 ed25519verify`, pkStr), AssemblerMaxVersion)
 		require.NoError(b, err)
-		programs = append(programs, program)
+		programs = append(programs, ops.Program)
 		sig := secret.SignBytes(buffer[:])
 		signatures = append(signatures, sig)
 	}
@@ -3541,7 +3541,7 @@ func BenchmarkCheckx5(b *testing.B) {
 		addBenchmark2Source,
 	}
 
-	programs := make([][]byte, len(sourcePrograms))
+	programs := make([]*OpStream, len(sourcePrograms))
 	var err error
 	for i, text := range sourcePrograms {
 		programs[i], err = AssembleStringWithVersion(text, AssemblerMaxVersion)
@@ -3550,7 +3550,7 @@ func BenchmarkCheckx5(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, program := range programs {
-			_, err = Check(program, defaultEvalParams(nil, nil))
+			_, err = Check(program.Program, defaultEvalParams(nil, nil))
 			if err != nil {
 				require.NoError(b, err)
 			}
@@ -3581,24 +3581,24 @@ func TestEvalVersions(t *testing.T) {
 txna ApplicationArgs 0
 pop
 `
-	program, err := AssembleStringWithVersion(text, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(text, AssemblerMaxVersion)
 	require.NoError(t, err)
 
 	ep := defaultEvalParams(nil, nil)
 	ep.Txn = &transactions.SignedTxn{}
 	ep.Txn.Txn.ApplicationArgs = [][]byte{[]byte("test")}
-	_, err = Eval(program, ep)
+	_, err = Eval(ops.Program, ep)
 	require.NoError(t, err)
 
 	ep = defaultEvalParamsV1(nil, nil)
-	_, err = Eval(program, ep)
+	_, err = Eval(ops.Program, ep)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "greater than protocol supported version 1")
 
 	// hack the version and fail on illegal opcode
-	program[0] = 0x1
+	ops.Program[0] = 0x1
 	ep = defaultEvalParamsV1(nil, nil)
-	_, err = Eval(program, ep)
+	_, err = Eval(ops.Program, ep)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "illegal opcode 0x36") // txna
 }
@@ -3611,7 +3611,7 @@ intc_0
 intc_0
 +
 `
-	program, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 	require.NoError(t, err)
 
 	ep := defaultEvalParams(nil, nil)
@@ -3628,7 +3628,7 @@ intc_0
 		cx.stack = make([]stackValue, 2000)
 	}
 	opsByOpcode[LogicVersion][spec.Opcode] = spec
-	_, err = Eval(program, ep)
+	_, err = Eval(ops.Program, ep)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "stack overflow")
 }
@@ -3665,25 +3665,25 @@ int 1
 `
 	ep := defaultEvalParams(nil, nil)
 
-	program, err := AssembleStringWithVersion(text, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(text, AssemblerMaxVersion)
 	require.NoError(t, err)
-	pass, err := Eval(program, ep)
+	pass, err := Eval(ops.Program, ep)
 	require.NoError(t, err)
 	require.True(t, pass)
 
 	text = `dup2`
-	program, err = AssembleStringWithVersion(text, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(text, AssemblerMaxVersion)
 	require.NoError(t, err)
-	pass, err = Eval(program, ep)
+	pass, err = Eval(ops.Program, ep)
 	require.Error(t, err)
 	require.False(t, pass)
 
 	text = `int 1
 dup2
 `
-	program, err = AssembleStringWithVersion(text, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(text, AssemblerMaxVersion)
 	require.NoError(t, err)
-	pass, err = Eval(program, ep)
+	pass, err = Eval(ops.Program, ep)
 	require.Error(t, err)
 	require.False(t, pass)
 }
@@ -3697,9 +3697,9 @@ byte b64(Zm9vIGJhcg==)
 `
 	ep := defaultEvalParams(nil, nil)
 
-	program, err := AssembleStringWithVersion(text, AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(text, AssemblerMaxVersion)
 	require.NoError(t, err)
-	pass, err := Eval(program, ep)
+	pass, err := Eval(ops.Program, ep)
 	require.NoError(t, err)
 	require.True(t, pass)
 
@@ -3707,9 +3707,9 @@ byte b64(Zm9vIGJhcg==)
 byte b64(Zm9vIGJhciAvLyBub3QgYSBjb21tZW50)
 ==
 `
-	program, err = AssembleStringWithVersion(text, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(text, AssemblerMaxVersion)
 	require.NoError(t, err)
-	pass, err = Eval(program, ep)
+	pass, err = Eval(ops.Program, ep)
 	require.NoError(t, err)
 	require.True(t, pass)
 
@@ -3717,9 +3717,9 @@ byte b64(Zm9vIGJhciAvLyBub3QgYSBjb21tZW50)
 byte 0x
 ==
 `
-	program, err = AssembleStringWithVersion(text, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(text, AssemblerMaxVersion)
 	require.NoError(t, err)
-	pass, err = Eval(program, ep)
+	pass, err = Eval(ops.Program, ep)
 	require.NoError(t, err)
 	require.True(t, pass)
 
@@ -3727,9 +3727,9 @@ byte 0x
 byte 0x // empty byte constant
 ==
 `
-	program, err = AssembleStringWithVersion(text, AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(text, AssemblerMaxVersion)
 	require.NoError(t, err)
-	pass, err = Eval(program, ep)
+	pass, err = Eval(ops.Program, ep)
 	require.NoError(t, err)
 	require.True(t, pass)
 }
@@ -3758,25 +3758,25 @@ func TestApplicationsDisallowOldTeal(t *testing.T) {
 	ep.TxnGroup = txngroup
 
 	for v := uint64(0); v < appsEnabledVersion; v++ {
-		program, err := AssembleStringWithVersion(source, v)
+		ops, err := AssembleStringWithVersion(source, v)
 		require.NoError(t, err)
 
-		_, err = CheckStateful(program, ep)
+		_, err = CheckStateful(ops.Program, ep)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), fmt.Sprintf("program version must be >= %d", appsEnabledVersion))
 
-		_, _, err = EvalStateful(program, ep)
+		_, _, err = EvalStateful(ops.Program, ep)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), fmt.Sprintf("program version must be >= %d", appsEnabledVersion))
 	}
 
-	program, err := AssembleStringWithVersion(source, appsEnabledVersion)
+	ops, err := AssembleStringWithVersion(source, appsEnabledVersion)
 	require.NoError(t, err)
 
-	_, err = CheckStateful(program, ep)
+	_, err = CheckStateful(ops.Program, ep)
 	require.NoError(t, err)
 
-	_, _, err = EvalStateful(program, ep)
+	_, _, err = EvalStateful(ops.Program, ep)
 	require.NoError(t, err)
 }
 
@@ -3812,9 +3812,9 @@ func TestAnyRekeyToOrApplicationRaisesMinTealVersion(t *testing.T) {
 	}
 
 	cases := []testcase{
-		testcase{txngroup0, 0},
-		testcase{txngroup1, appsEnabledVersion},
-		testcase{txngroup2, rekeyingEnabledVersion},
+		{txngroup0, 0},
+		{txngroup1, appsEnabledVersion},
+		{txngroup2, rekeyingEnabledVersion},
 	}
 
 	for ci, cse := range cases {
@@ -3830,41 +3830,41 @@ func TestAnyRekeyToOrApplicationRaisesMinTealVersion(t *testing.T) {
 			// Should fail for all versions < validFromVersion
 			expected := fmt.Sprintf("program version must be >= %d", cse.validFromVersion)
 			for v := uint64(0); v < cse.validFromVersion; v++ {
-				program, err := AssembleStringWithVersion(source, v)
+				ops, err := AssembleStringWithVersion(source, v)
 				require.NoError(t, err)
 
-				_, err = CheckStateful(program, ep)
+				_, err = CheckStateful(ops.Program, ep)
 				require.Error(t, err)
 				require.Contains(t, err.Error(), expected)
 
-				_, _, err = EvalStateful(program, ep)
+				_, _, err = EvalStateful(ops.Program, ep)
 				require.Error(t, err)
 				require.Contains(t, err.Error(), expected)
 
-				_, err = Check(program, ep)
+				_, err = Check(ops.Program, ep)
 				require.Error(t, err)
 				require.Contains(t, err.Error(), expected)
 
-				_, err = Eval(program, ep)
+				_, err = Eval(ops.Program, ep)
 				require.Error(t, err)
 				require.Contains(t, err.Error(), expected)
 			}
 
 			// Should succeed for all versions >= validFromVersionn
 			for v := cse.validFromVersion; v <= AssemblerMaxVersion; v++ {
-				program, err := AssembleStringWithVersion(source, v)
+				ops, err := AssembleStringWithVersion(source, v)
 				require.NoError(t, err)
 
-				_, err = CheckStateful(program, ep)
+				_, err = CheckStateful(ops.Program, ep)
 				require.NoError(t, err)
 
-				_, _, err = EvalStateful(program, ep)
+				_, _, err = EvalStateful(ops.Program, ep)
 				require.NoError(t, err)
 
-				_, err = Check(program, ep)
+				_, err = Check(ops.Program, ep)
 				require.NoError(t, err)
 
-				_, err = Eval(program, ep)
+				_, err = Eval(ops.Program, ep)
 				require.NoError(t, err)
 			}
 		})
@@ -3915,12 +3915,12 @@ func TestAllowedOpcodesV2(t *testing.T) {
 		if spec.Version > 1 && !excluded[spec.Name] {
 			source, ok := tests[spec.Name]
 			require.True(t, ok, fmt.Sprintf("Missed opcode in the test: %s", spec.Name))
-			program, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
+			ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 			require.NoError(t, err, source)
 			// all opcodes allowed in stateful mode so use CheckStateful/EvalStateful
-			_, err = CheckStateful(program, ep)
+			_, err = CheckStateful(ops.Program, ep)
 			require.NoError(t, err, source)
-			_, _, err = EvalStateful(program, ep)
+			_, _, err = EvalStateful(ops.Program, ep)
 			if spec.Name != "return" {
 				// "return" opcode is always succeed so ignore it
 				require.Error(t, err, source)
@@ -3928,17 +3928,17 @@ func TestAllowedOpcodesV2(t *testing.T) {
 			}
 
 			for v := byte(0); v <= 1; v++ {
-				program[0] = v
-				_, err = Check(program, ep)
+				ops.Program[0] = v
+				_, err = Check(ops.Program, ep)
 				require.Error(t, err, source)
 				require.Contains(t, err.Error(), "illegal opcode")
-				_, err = CheckStateful(program, ep)
+				_, err = CheckStateful(ops.Program, ep)
 				require.Error(t, err, source)
 				require.Contains(t, err.Error(), "illegal opcode")
-				_, err = Eval(program, ep)
+				_, err = Eval(ops.Program, ep)
 				require.Error(t, err, source)
 				require.Contains(t, err.Error(), "illegal opcode")
-				_, _, err = EvalStateful(program, ep)
+				_, _, err = EvalStateful(ops.Program, ep)
 				require.Error(t, err, source)
 				require.Contains(t, err.Error(), "illegal opcode")
 			}
@@ -3952,20 +3952,20 @@ func TestRekeyFailsOnOldVersion(t *testing.T) {
 	t.Parallel()
 	for v := uint64(0); v < rekeyingEnabledVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			program, err := AssembleStringWithVersion(`int 1`, v)
+			ops, err := AssembleStringWithVersion(`int 1`, v)
 			require.NoError(t, err)
 			var txn transactions.SignedTxn
-			txn.Lsig.Logic = program
+			txn.Lsig.Logic = ops.Program
 			txn.Txn.RekeyTo = basics.Address{1, 2, 3, 4}
 			sb := strings.Builder{}
 			proto := defaultEvalProto()
 			ep := defaultEvalParams(&sb, &txn)
 			ep.TxnGroup = []transactions.SignedTxn{txn}
 			ep.Proto = &proto
-			_, err = Check(program, ep)
+			_, err = Check(ops.Program, ep)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), fmt.Sprintf("program version must be >= %d", rekeyingEnabledVersion))
-			pass, err := Eval(program, ep)
+			pass, err := Eval(ops.Program, ep)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), fmt.Sprintf("program version must be >= %d", rekeyingEnabledVersion))
 			require.False(t, pass)

--- a/data/transactions/logic/fields.go
+++ b/data/transactions/logic/fields.go
@@ -230,7 +230,7 @@ var TxnTypeNames = []string{
 }
 
 // map TxnTypeName to its enum index, for `txn TypeEnum`
-var txnTypeIndexes map[string]int
+var txnTypeIndexes map[string]uint64
 
 // map symbolic name to uint64 for assembleInt
 var txnTypeConstToUint64 map[string]uint64
@@ -262,7 +262,7 @@ var OnCompletionNames []string
 var onCompletionConstToUint64 map[string]uint64
 
 // GlobalField is an enum for `global` opcode
-type GlobalField int
+type GlobalField uint64
 
 const (
 	// MinTxnFee ConsensusParams.MinTxnFee
@@ -353,7 +353,7 @@ var assetHoldingFieldTypeList = []assetHoldingFieldType{
 // AssetHoldingFieldTypes is StackUint64 StackBytes in parallel with AssetHoldingFieldNames
 var AssetHoldingFieldTypes []StackType
 
-var assetHoldingFields map[string]uint
+var assetHoldingFields map[string]uint64
 
 // AssetParamsField is an enum for `asset_params_get` opcode
 type AssetParamsField int
@@ -409,7 +409,7 @@ var assetParamsFieldTypeList = []assetParamsFieldType{
 // AssetParamsFieldTypes is StackUint64 StackBytes in parallel with AssetParamsFieldNames
 var AssetParamsFieldTypes []StackType
 
-var assetParamsFields map[string]uint
+var assetParamsFields map[string]uint64
 
 func init() {
 	TxnFieldNames = make([]string, int(invalidTxnField))
@@ -453,9 +453,9 @@ func init() {
 	for _, ft := range assetHoldingFieldTypeList {
 		AssetHoldingFieldTypes[int(ft.field)] = ft.ftype
 	}
-	assetHoldingFields = make(map[string]uint)
+	assetHoldingFields = make(map[string]uint64)
 	for i, fn := range AssetHoldingFieldNames {
-		assetHoldingFields[fn] = uint(i)
+		assetHoldingFields[fn] = uint64(i)
 	}
 
 	AssetParamsFieldNames = make([]string, int(invalidAssetParamsField))
@@ -466,20 +466,20 @@ func init() {
 	for _, ft := range assetParamsFieldTypeList {
 		AssetParamsFieldTypes[int(ft.field)] = ft.ftype
 	}
-	assetParamsFields = make(map[string]uint)
+	assetParamsFields = make(map[string]uint64)
 	for i, fn := range AssetParamsFieldNames {
-		assetParamsFields[fn] = uint(i)
+		assetParamsFields[fn] = uint64(i)
 	}
 
-	txnTypeIndexes = make(map[string]int, len(TxnTypeNames))
+	txnTypeIndexes = make(map[string]uint64, len(TxnTypeNames))
 	for i, tt := range TxnTypeNames {
-		txnTypeIndexes[tt] = i
+		txnTypeIndexes[tt] = uint64(i)
 	}
 
 	txnTypeConstToUint64 = make(map[string]uint64, len(TxnTypeNames))
 	for tt, v := range txnTypeIndexes {
 		symbol := TypeNameDescription(tt)
-		txnTypeConstToUint64[symbol] = uint64(v)
+		txnTypeConstToUint64[symbol] = v
 	}
 
 	OnCompletionNames = make([]string, int(invalidOnCompletionConst))

--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -301,12 +301,12 @@ func makeUnsignedApplicationCallTx(appIdx uint64, onCompletion transactions.OnCo
 
 			int 1
 		`
-		prog, err := logic.AssembleString(testprog)
+		ops, err := logic.AssembleString(testprog)
 		if err != nil {
 			return tx, err
 		}
-		tx.ApprovalProgram = prog
-		tx.ClearStateProgram = prog
+		tx.ApprovalProgram = ops.Program
+		tx.ClearStateProgram = ops.Program
 		tx.GlobalStateSchema = basics.StateSchema{
 			NumByteSlice: 1,
 		}

--- a/ledger/ledger_perf_test.go
+++ b/ledger/ledger_perf_test.go
@@ -401,7 +401,7 @@ func init() {
 	testCases[params.name] = params
 
 	// Int 1
-	progBytes, err := logic.AssembleStringV2(`int 1`)
+	ops, err := logic.AssembleStringWithVersion(`int 1`, 2)
 	if err != nil {
 		panic(err)
 	}
@@ -409,7 +409,7 @@ func init() {
 	params = testParams{
 		testType: "app",
 		name:     fmt.Sprintf("int-1"),
-		program:  progBytes,
+		program:  ops.Program,
 	}
 	testCases[params.name] = params
 
@@ -417,21 +417,23 @@ func init() {
 	params = testParams{
 		testType: "app",
 		name:     fmt.Sprintf("int-1-many-apps"),
-		program:  progBytes,
+		program:  ops.Program,
 		numApps:  10,
 	}
 	testCases[params.name] = params
 
 	// Assemble ASA programs
-	asaClearStateProgram, err = logic.AssembleStringV2(asaClearAsm)
+	ops, err = logic.AssembleStringWithVersion(asaClearAsm, 2)
 	if err != nil {
 		panic(err)
 	}
+	asaClearStateProgram = ops.Program
 
-	asaAppovalProgram, err = logic.AssembleStringV2(asaAppovalAsm)
+	ops, err = logic.AssembleStringWithVersion(asaAppovalAsm, 2)
 	if err != nil {
 		panic(err)
 	}
+	asaAppovalProgram = ops.Program
 
 	// ASAs
 	params = testParams{
@@ -475,11 +477,11 @@ func genBigNoOp(numOps int) []byte {
 	progParts = append(progParts, `int 1`)
 	progParts = append(progParts, `return`)
 	progAsm := strings.Join(progParts, "\n")
-	progBytes, err := logic.AssembleStringV2(progAsm)
+	ops, err := logic.AssembleStringWithVersion(progAsm, 2)
 	if err != nil {
 		panic(err)
 	}
-	return progBytes
+	return ops.Program
 }
 
 func genBigHashes(numHashes int, numPad int) []byte {
@@ -495,11 +497,11 @@ func genBigHashes(numHashes int, numPad int) []byte {
 	progParts = append(progParts, `int 1`)
 	progParts = append(progParts, `return`)
 	progAsm := strings.Join(progParts, "\n")
-	progBytes, err := logic.AssembleStringV2(progAsm)
+	ops, err := logic.AssembleStringWithVersion(progAsm, 2)
 	if err != nil {
 		panic(err)
 	}
-	return progBytes
+	return ops.Program
 }
 
 func genAppTestParams(numKeys int, bigDiffs bool, stateType string) testParams {
@@ -638,7 +640,7 @@ func genAppTestParams(numKeys int, bigDiffs bool, stateType string) testParams {
 	progAsm := strings.Join(progParts, "\n")
 
 	// assemble
-	progBytes, err := logic.AssembleStringV2(progAsm)
+	ops, err := logic.AssembleStringWithVersion(progAsm, 2)
 	if err != nil {
 		panic(err)
 	}
@@ -647,7 +649,7 @@ func genAppTestParams(numKeys int, bigDiffs bool, stateType string) testParams {
 		testType:   "app",
 		name:       fmt.Sprintf("bench-%s-%d-%s", stateType, numKeys, testDiffName),
 		schemaSize: uint64(numKeys),
-		program:    progBytes,
+		program:    ops.Program,
 	}
 }
 
@@ -714,7 +716,7 @@ func genAppTestParamsMaxClone(numKeys int) testParams {
 	progAsm := strings.Join(progParts, "\n")
 
 	// assemble
-	progBytes, err := logic.AssembleStringV2(progAsm)
+	ops, err := logic.AssembleStringWithVersion(progAsm, 2)
 	if err != nil {
 		panic(err)
 	}
@@ -723,7 +725,7 @@ func genAppTestParamsMaxClone(numKeys int) testParams {
 		testType:   "app",
 		name:       fmt.Sprintf("bench-%s-%d-%s", "global", numKeys, testDiffName),
 		schemaSize: uint64(numKeys),
-		program:    progBytes,
+		program:    ops.Program,
 	}
 }
 

--- a/shared/pingpong/accounts.go
+++ b/shared/pingpong/accounts.go
@@ -442,11 +442,11 @@ func genBigNoOpAndBigHashes(numOps uint32, numHashes uint32, hashSize string) []
 	progParts = append(progParts, `int 1`)
 	progParts = append(progParts, `return`)
 	progAsm := strings.Join(progParts, "\n")
-	progBytes, err := logic.AssembleString(progAsm)
+	ops, err := logic.AssembleString(progAsm)
 	if err != nil {
 		panic(err)
 	}
-	return progBytes
+	return ops.Program
 }
 
 func genAppProgram(numOps uint32, numHashes uint32, hashSize string, numGlobalKeys uint32, numLocalKeys uint32) ([]byte, string) {
@@ -577,11 +577,11 @@ func genAppProgram(numOps uint32, numHashes uint32, hashSize string, numGlobalKe
 	progAsm := strings.Join(progParts, "\n")
 
 	// assemble
-	progBytes, err := logic.AssembleString(progAsm)
+	ops, err := logic.AssembleString(progAsm)
 	if err != nil {
 		panic(err)
 	}
-	return progBytes, progAsm
+	return ops.Program, progAsm
 }
 
 func sendAsGroup(txgroup []transactions.Transaction, client libgoal.Client, h []byte) (err error) {

--- a/test/e2e-go/features/transactions/accountv2_test.go
+++ b/test/e2e-go/features/transactions/accountv2_test.go
@@ -171,8 +171,8 @@ int 1
 	a.Equal(1, len(ad.AppParams))
 	params, ok = ad.AppParams[appIdx]
 	a.True(ok)
-	a.Equal(approvalOps, params.ApprovalProgram)
-	a.Equal(clearstateOps, params.ClearStateProgram)
+	a.Equal(approvalOps.Program, params.ApprovalProgram)
+	a.Equal(clearstateOps.Program, params.ClearStateProgram)
 	a.Equal(schema, params.LocalStateSchema)
 	a.Equal(schema, params.GlobalStateSchema)
 	a.Equal(1, len(params.GlobalState))

--- a/test/e2e-go/features/transactions/accountv2_test.go
+++ b/test/e2e-go/features/transactions/accountv2_test.go
@@ -100,9 +100,9 @@ int 1  // increment
 app_local_put
 int 1
 `
-	approval, err := logic.AssembleString(counter)
+	approvalOps, err := logic.AssembleString(counter)
 	a.NoError(err)
-	clearstate, err := logic.AssembleString("#pragma version 2\nint 1")
+	clearstateOps, err := logic.AssembleString("#pragma version 2\nint 1")
 	a.NoError(err)
 	schema := basics.StateSchema{
 		NumUint: 1,
@@ -110,7 +110,7 @@ int 1
 
 	// create the app
 	tx, err := client.MakeUnsignedAppCreateTx(
-		transactions.OptInOC, approval, clearstate, schema, schema, nil, nil, nil, nil,
+		transactions.OptInOC, approvalOps.Program, clearstateOps.Program, schema, schema, nil, nil, nil, nil,
 	)
 	a.NoError(err)
 	tx, err = client.FillUnsignedTxTemplate(creator, 0, 0, fee, tx)
@@ -134,8 +134,8 @@ int 1
 		params = p
 		break
 	}
-	a.Equal(approval, params.ApprovalProgram)
-	a.Equal(clearstate, params.ClearStateProgram)
+	a.Equal(approvalOps.Program, params.ApprovalProgram)
+	a.Equal(clearstateOps.Program, params.ClearStateProgram)
 	a.Equal(schema, params.LocalStateSchema)
 	a.Equal(schema, params.GlobalStateSchema)
 	a.Equal(1, len(params.GlobalState))
@@ -171,8 +171,8 @@ int 1
 	a.Equal(1, len(ad.AppParams))
 	params, ok = ad.AppParams[appIdx]
 	a.True(ok)
-	a.Equal(approval, params.ApprovalProgram)
-	a.Equal(clearstate, params.ClearStateProgram)
+	a.Equal(approvalOps, params.ApprovalProgram)
+	a.Equal(clearstateOps, params.ClearStateProgram)
 	a.Equal(schema, params.LocalStateSchema)
 	a.Equal(schema, params.GlobalStateSchema)
 	a.Equal(1, len(params.GlobalState))

--- a/test/e2e-go/upgrades/application_support_test.go
+++ b/test/e2e-go/upgrades/application_support_test.go
@@ -128,9 +128,9 @@ int 1  // increment
 app_local_put
 int 1
 `
-	approval, err := logic.AssembleString(counter)
+	approvalOps, err := logic.AssembleString(counter)
 	require.NoError(t, err)
-	clearstate, err := logic.AssembleString("#pragma version 2\nint 1")
+	clearstateOps, err := logic.AssembleString("#pragma version 2\nint 1")
 	require.NoError(t, err)
 	schema := basics.StateSchema{
 		NumUint: 1,
@@ -138,7 +138,7 @@ int 1
 
 	// create the app
 	tx, err := client.MakeUnsignedAppCreateTx(
-		transactions.OptInOC, approval, clearstate, schema, schema, nil, nil, nil, nil,
+		transactions.OptInOC, approvalOps.Program, clearstateOps.Program, schema, schema, nil, nil, nil, nil,
 	)
 	require.NoError(t, err)
 	tx, err = client.FillUnsignedTxTemplate(creator, 0, 0, fee, tx)
@@ -193,8 +193,8 @@ int 1
 		params = p
 		break
 	}
-	require.Equal(t, approval, params.ApprovalProgram)
-	require.Equal(t, clearstate, params.ClearStateProgram)
+	require.Equal(t, approvalOps.Program, params.ApprovalProgram)
+	require.Equal(t, clearstateOps.Program, params.ClearStateProgram)
 	require.Equal(t, schema, params.LocalStateSchema)
 	require.Equal(t, schema, params.GlobalStateSchema)
 	require.Equal(t, 1, len(params.GlobalState))
@@ -231,8 +231,8 @@ int 1
 	require.Equal(t, 1, len(ad.AppParams))
 	params, ok = ad.AppParams[appIdx]
 	require.True(t, ok)
-	require.Equal(t, approval, params.ApprovalProgram)
-	require.Equal(t, clearstate, params.ClearStateProgram)
+	require.Equal(t, approvalOps.Program, params.ApprovalProgram)
+	require.Equal(t, clearstateOps.Program, params.ClearStateProgram)
 	require.Equal(t, schema, params.LocalStateSchema)
 	require.Equal(t, schema, params.GlobalStateSchema)
 	require.Equal(t, 1, len(params.GlobalState))
@@ -357,9 +357,9 @@ int 1  // increment
 app_local_put
 int 1
 `
-	approval, err := logic.AssembleString(counter)
+	approvalOps, err := logic.AssembleString(counter)
 	require.NoError(t, err)
-	clearstate, err := logic.AssembleString("#pragma version 2\nint 1")
+	clearstateOps, err := logic.AssembleString("#pragma version 2\nint 1")
 	require.NoError(t, err)
 	schema := basics.StateSchema{
 		NumUint: 1,
@@ -367,7 +367,7 @@ int 1
 
 	// create the app
 	tx, err := client.MakeUnsignedAppCreateTx(
-		transactions.OptInOC, approval, clearstate, schema, schema, nil, nil, nil, nil,
+		transactions.OptInOC, approvalOps.Program, clearstateOps.Program, schema, schema, nil, nil, nil, nil,
 	)
 	require.NoError(t, err)
 	tx, err = client.FillUnsignedTxTemplate(creator, round, round+primaryNodeUnupgradedProtocol.DefaultUpgradeWaitRounds, fee, tx)
@@ -445,8 +445,8 @@ int 1
 		params = p
 		break
 	}
-	require.Equal(t, approval, params.ApprovalProgram)
-	require.Equal(t, clearstate, params.ClearStateProgram)
+	require.Equal(t, approvalOps.Program, params.ApprovalProgram)
+	require.Equal(t, clearstateOps.Program, params.ClearStateProgram)
 	require.Equal(t, schema, params.LocalStateSchema)
 	require.Equal(t, schema, params.GlobalStateSchema)
 	require.Equal(t, 1, len(params.GlobalState))
@@ -483,8 +483,8 @@ int 1
 	require.Equal(t, 1, len(ad.AppParams))
 	params, ok = ad.AppParams[appIdx]
 	require.True(t, ok)
-	require.Equal(t, approval, params.ApprovalProgram)
-	require.Equal(t, clearstate, params.ClearStateProgram)
+	require.Equal(t, approvalOps.Program, params.ApprovalProgram)
+	require.Equal(t, clearstateOps.Program, params.ClearStateProgram)
 	require.Equal(t, schema, params.LocalStateSchema)
 	require.Equal(t, schema, params.GlobalStateSchema)
 	require.Equal(t, 1, len(params.GlobalState))


### PR DESCRIPTION
## Summary
Previously, we used the usual Go convention of returning an error to
the caller throughout assembly, as soon as they occurred.  This meant
that assembly failed, as a whole, on the first bad line.  This model
also didn't work well for warnings, because they did not have the
context to do good reporting (they did not know the filename, for
example), but had no way to pass the warning up to the caller who did
have the info (as errors did).  So this change also allows warnings to
report the file and line, for use by external tools.

The change is to accumulate errors and warnings in the OpStream
structure, rather than return immediately (or report immediately, in
the case of warnings).  After assembly the warnings and errors are
reported to stderr, and a summary error is used in Go to signal the
caller that assembly failed.

This allows external tools to use `goal clerk compile` to show all of
a script's problems at once.  I've added support to emacs in
teal-mode. We should consider a vscode plugin.


## Test Plan

Updated and ran unit tests. (And added one for testing that multiple errors are returned.)

