### PR TITLE
Fix a race in arm test in algoh startup and algod.* files creation

### DIFF
--- a/test/e2e-go/cli/algoh/expect/algohExpectCommon.exp
+++ b/test/e2e-go/cli/algoh/expect/algohExpectCommon.exp
@@ -11,6 +11,7 @@ namespace eval ::Algoh {
   namespace export StartNode
 
   namespace export WaitForRound
+  namespace export CheckEOF
 
   # My Variables
    set version 1.0
@@ -137,5 +138,16 @@ proc ::Algoh::WaitForFile { WAITFILE } {
         }
     } EXCEPTION ] } {
        ::Algoh::Abort "ERROR in WaitForFile: $EXCEPTION"
+    }
+}
+
+# CheckEOF checks if there was an error, and aborts if there was an error
+proc ::Algoh::CheckEOF { { ERROR_STRING "" } } {
+    upvar spawn_id spawn_id
+    catch { wait -i $spawn_id } result;
+    if { [lindex $result 3] != 0 } {
+        puts $ERROR_STRING
+        puts "returned error code is [lindex $result 3]"
+        exit 1
     }
 }

--- a/test/e2e-go/cli/algoh/expect/algohTimeoutTest.exp
+++ b/test/e2e-go/cli/algoh/expect/algohTimeoutTest.exp
@@ -55,6 +55,7 @@ if { [catch {
     expect {
         "^Logging to: *" {puts "algoh startup successful"}
         timeout {::Algoh::Abort "algoh failed to start";}
+        eof { ::Algoh::CheckEOF "algoh failed to start" }
     }
 
     # allow algoh time to put files in Node dir

--- a/test/e2e-go/cli/algoh/expect/algohTimeoutTest.exp
+++ b/test/e2e-go/cli/algoh/expect/algohTimeoutTest.exp
@@ -57,6 +57,9 @@ if { [catch {
         timeout {::Algoh::Abort "algoh failed to start";}
     }
 
+    # allow algoh time to put files in Node dir
+    ::Algoh::WaitForFile $TEST_NODE_DIR/algod.pid
+
     # wait until Node approves blocks to the network
     set timeout 60
     spawn goal node wait -d $TEST_NODE_DIR -w 61


### PR DESCRIPTION
## Summary

Spawned algoh returns too fact, and despite the fix for `goal node start` startup code the test still fails:
```
algoh startup successful
spawn goal node wait -d /home/ubuntu/go/src/github.com/algorand/go-algorand/tmp/out/e2e/92019-1606765255748/algohTimeoutTest/algod/root/Node -w 61
Cannot contact Algorand node: open /home/ubuntu/go/src/github.com/algorand/go-algorand/tmp/out/e2e/92019-1606765255748/algohTimeoutTest/algod/root/Node/algod.token: no such file or directory
```
Added a file waiter for `algoh` startup.

## Test Plan

This is test fix