### PR TITLE
Add travis_retry to build and test commands in case of random failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
           packages:
             - awscli
       script:
-        - scripts/travis/external_build.sh ./scripts/travis/build_test.sh
+        - travis_retry scripts/travis/external_build.sh ./scripts/travis/build_test.sh
     - # same stage, parallel job
       name: External ARM64 Integration Test
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,18 +29,18 @@ jobs:
     - stage: build_commit
       os: linux
       script:
-        - scripts/travis/build_test.sh
+        - travis_retry scripts/travis/build_test.sh
 
     - stage: build_pr
       os: linux
       name: Ubuntu AMD64 Build
       script:
-        - scripts/travis/build_test.sh
+        - travis_retry scripts/travis/build_test.sh
     - # same stage, parallel job
       os: linux
       name: Ubuntu AMD64 Integration Test
       script:
-        - ./scripts/travis/integration_test.sh
+        - travis_retry ./scripts/travis/integration_test.sh
     - # same stage, parallel job
       name: External ARM64 Build
       os: linux
@@ -70,13 +70,13 @@ jobs:
       osx_image: xcode11
       name: MacOS AMD64 Build
       script:
-        - scripts/travis/build_test.sh
+        - travis_retry scripts/travis/build_test.sh
     - # same stage, parallel job
       os: osx
       osx_image: xcode11
       name: MacOS AMD64 Integration Test
       script:
-        - ./scripts/travis/integration_test.sh
+        - travis_retry ./scripts/travis/integration_test.sh
     - # same stage, parallel job
        os: windows
        name: Windows x64 Build
@@ -85,24 +85,24 @@ jobs:
            - $HOME/AppData/Local/Temp/chocolatey
            - /C/tools/msys64
        script:
-         - $mingw64 scripts/travis/build_test.sh
+         - travis_retry $mingw64 scripts/travis/build_test.sh
 
     - stage: build_release
       os: linux
       name: Ubuntu AMD64 Build
       script:
-        - ./scripts/travis/build_test.sh
+        - travis_retry ./scripts/travis/build_test.sh
     - # same stage, parallel job
       os: linux
       name: Ubuntu AMD64 Integration Test
       script:
-        - ./scripts/travis/integration_test.sh
+        - travis_retry ./scripts/travis/integration_test.sh
     - # same stage, parallel job
       os: osx
       osx_image: xcode11
       name: MacOS AMD64 Build
       script:
-        - scripts/travis/build_test.sh
+        - travis_retry scripts/travis/build_test.sh
     - # same stage, parallel job
       name: External ARM64 Integration Test
       os: linux
@@ -123,7 +123,7 @@ jobs:
            - $HOME/AppData/Local/Temp/chocolatey
            - /C/tools/msys64
        script:
-         - $mingw64 scripts/travis/build_test.sh
+         - travis_retry $mingw64 scripts/travis/build_test.sh
 
     - stage: deploy
       name: Ubuntu Deploy


### PR DESCRIPTION
## Summary

The build always seems to fail with intermittent errors. See if adding `travis_retry` helps.