### PR TITLE
Get system DNS on Windows

### DIFF
--- a/tools/network/dnssec/config.go
+++ b/tools/network/dnssec/config.go
@@ -17,12 +17,7 @@
 package dnssec
 
 import (
-	"fmt"
-	"io"
-	"os"
 	"time"
-
-	"github.com/miekg/dns"
 )
 
 // DefaultMaxHops sets max hops for DNS request
@@ -43,51 +38,15 @@ const maxTimeout = 5 * time.Second
 // Other - no DNSSEC - last check 2020-12-01
 // Alibaba 223.6.6.6:53
 
-// ResolverAddress is ip addr + port as string
-type ResolverAddress string
-
 // DefaultDnssecAwareNSServers is a list of known public DNSSEC-aware servers
 var DefaultDnssecAwareNSServers = []ResolverAddress{"1.1.1.1:53", "208.67.222.222:53", "8.8.8.8:53", "77.88.8.8:53", "8.26.56.26:53", "180.76.76.76:53"}
 
 const defaultConfigFile = "/etc/resolv.conf"
 
+// ResolverAddress is ip addr + port as string
+type ResolverAddress string
+
 // MakeResolverAddress creates a new ResolverAddress instance from address and port
 func MakeResolverAddress(addr, port string) ResolverAddress {
 	return ResolverAddress(addr + ":" + port)
-}
-
-// SystemConfig return list of servers and timeout from
-// This is Linux only.
-//
-// For Windows need to implement DNS servers retrieval from GetNetworkParams
-//  see https://docs.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getnetworkparams
-func SystemConfig() (servers []ResolverAddress, timeout time.Duration, err error) {
-	f, err := os.Open(defaultConfigFile)
-	defer f.Close()
-	if err != nil {
-		return
-	}
-	return systemConfig(f)
-}
-
-func systemConfig(configFile io.Reader) (servers []ResolverAddress, timeout time.Duration, err error) {
-	if configFile == nil {
-		err = fmt.Errorf("empty config reader")
-		return
-	}
-	cc, err := dns.ClientConfigFromReader(configFile)
-	if err != nil {
-		return
-	}
-	for _, addr := range cc.Servers {
-		servers = append(servers, MakeResolverAddress(addr, cc.Port))
-	}
-	timeout = DefaultTimeout
-	if cc.Timeout != 0 && len(servers) > 0 {
-		timeout = time.Duration(cc.Timeout) * time.Second
-	}
-	if timeout > maxTimeout {
-		timeout = maxTimeout
-	}
-	return
 }

--- a/tools/network/dnssec/config_unix.go
+++ b/tools/network/dnssec/config_unix.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+// +build !windows
+
+package dnssec
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// SystemConfig return list of servers and timeout from
+// This is Linux only.
+//
+// For Windows need to implement DNS servers retrieval from GetNetworkParams
+//  see https://docs.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getnetworkparams
+func SystemConfig() (servers []ResolverAddress, timeout time.Duration, err error) {
+	f, err := os.Open(defaultConfigFile)
+	defer f.Close()
+	if err != nil {
+		return
+	}
+	return systemConfig(f)
+}
+
+func systemConfig(configFile io.Reader) (servers []ResolverAddress, timeout time.Duration, err error) {
+	if configFile == nil {
+		err = fmt.Errorf("empty config reader")
+		return
+	}
+	cc, err := dns.ClientConfigFromReader(configFile)
+	if err != nil {
+		return
+	}
+	for _, addr := range cc.Servers {
+		servers = append(servers, MakeResolverAddress(addr, cc.Port))
+	}
+	timeout = DefaultTimeout
+	if cc.Timeout != 0 && len(servers) > 0 {
+		timeout = time.Duration(cc.Timeout) * time.Second
+	}
+	if timeout > maxTimeout {
+		timeout = maxTimeout
+	}
+	return
+}

--- a/tools/network/dnssec/config_windows.go
+++ b/tools/network/dnssec/config_windows.go
@@ -1,0 +1,126 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+// +build windows
+
+package dnssec
+
+import (
+	"fmt"
+	"runtime/debug"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	dll               = windows.NewLazyDLL("iphlpapi.dll")
+	networkParamsProc = dll.NewProc("GetNetworkParams")
+)
+
+// values from https://referencesource.microsoft.com/#System/net/System/Net/NetworkInformation/UnSafeNetInfoNativemethods.cs,c5dd09342271faba,references
+const (
+	max_hostname_len    = 128
+	max_domain_name_len = 128
+	max_scope_id_len    = 256
+)
+
+const ip_size = 16
+
+// typedef struct _IP_ADDR_STRING {
+// 	struct _IP_ADDR_STRING *Next;
+// 	IP_ADDRESS_STRING      IpAddress;  // The String member is a char array of size 16. This array holds an IPv4 address in dotted decimal notation.
+// 	IP_MASK_STRING         IpMask;     // The String member is a char array of size 16. This array holds the IPv4 subnet mask in dotted decimal notation.
+// 	DWORD                  Context;
+//   } IP_ADDR_STRING, *PIP_ADDR_STRING;
+//
+// https://docs.microsoft.com/en-us/windows/win32/api/iptypes/ns-iptypes-ip_addr_string
+type ipAddrString struct {
+	Next      uintptr
+	IpAddress [ip_size]uint8
+	IpMask    [ip_size]uint8
+	Context   uint32
+}
+
+// typedef struct {
+// 	char            HostName[MAX_HOSTNAME_LEN + 4];
+// 	char            DomainName[MAX_DOMAIN_NAME_LEN + 4];
+// 	PIP_ADDR_STRING CurrentDnsServer;
+// 	IP_ADDR_STRING  DnsServerList;
+// 	UINT            NodeType;
+// 	char            ScopeId[MAX_SCOPE_ID_LEN + 4];
+// 	UINT            EnableRouting;
+// 	UINT            EnableProxy;
+// 	UINT            EnableDns;
+//   } FIXED_INFO_W2KSP1, *PFIXED_INFO_W2KSP1;
+//
+// https://docs.microsoft.com/en-us/windows/win32/api/iptypes/ns-iptypes-fixed_info_w2ksp1
+type fixedInfo struct {
+	HostName         [max_hostname_len + 4]uint8
+	DomainName       [max_domain_name_len + 4]uint8
+	CurrentDnsServer uintptr
+	DnsServerList    ipAddrString
+	NodeType         uint32
+	ScopeId          [max_scope_id_len + 4]uint8
+	EnableRouting    uint32
+	EnableProxy      uint32
+	EnableDns        uint32
+}
+
+const ipAddrStringSizeof = 48
+
+type fixedInfoWithOverlay struct {
+	fixedInfo
+	overlay [ipAddrStringSizeof * 32]uint8 // space for max 32 IP_ADDR_STRING entries in the overlay
+}
+
+func SystemConfig() (servers []ResolverAddress, timeout time.Duration, err error) {
+	// disable GC to prevent fi collection earlier than lookups in fi completed
+	pct := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(pct)
+
+	var fi fixedInfoWithOverlay
+	var ulSize uint32 = uint32(unsafe.Sizeof(fi))
+	ret, _, _ := networkParamsProc.Call(
+		uintptr(unsafe.Pointer(&fi)),
+		uintptr(unsafe.Pointer(&ulSize)),
+	)
+	if ret != 0 {
+		if windows.Errno(ret) == windows.ERROR_BUFFER_OVERFLOW {
+			err = fmt.Errorf("GetNetworkParams requested %d bytes of memory, max supported is %d. Error code is %x", ulSize, unsafe.Sizeof(fi), ret)
+			return
+		}
+		err = fmt.Errorf("GetNetworkParams failed with code is %x", ret)
+		return
+	}
+
+	var p *ipAddrString = &fi.DnsServerList
+	for {
+		ip := make([]byte, ip_size)
+		for i := 0; i < len(p.IpAddress) && p.IpAddress[i] != 0; i++ {
+			ip[i] = p.IpAddress[i]
+		}
+		servers = append(servers, MakeResolverAddress(string(ip), "53"))
+
+		if p.Next == 0 {
+			break
+		}
+		p = (*ipAddrString)(unsafe.Pointer(p.Next))
+	}
+	timeout = DefaultTimeout
+	return
+}

--- a/tools/network/resolveController_test.go
+++ b/tools/network/resolveController_test.go
@@ -19,7 +19,6 @@ package network
 import (
 	"context"
 	"net"
-	"runtime"
 	"testing"
 	"time"
 
@@ -90,12 +89,8 @@ func TestRealNamesWithResolver(t *testing.T) {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	addrs, err = r.LookupIPAddr(timeoutCtx, example)
 	cancel()
-	if runtime.GOOS == "windows" {
-		a.Error(err) // dnssec implementation does not support system resolver on Windows
-	} else {
-		a.NoError(err)
-		a.Equal(len(addrs), 1) // ipv4 only
-	}
+	a.NoError(err)
+	a.Equal(len(addrs), 1) // ipv4 only
 
 	for _, secure := range []bool{false, true} {
 		c := NewResolveController(secure, "1.1.1.1", log)


### PR DESCRIPTION
## Summary

Use GetNetworkParams to get list system DNS servers on Windows.
The main issue with the implementation it relies on the fact `GetNetworkParams` allocates list of `IP_ADDR_STRING` for `DnsServerList` field directly after the input struct. In the same time it is a part of interface - `FIXED_INFO` has a fixed size across versions (no version or size field) but the API accepts size of allocated memory region for `FIXED_INFO` and overlay.

## Test Plan

Use existing tests