### PR TITLE
Improve catchpoint catchup expect test

### DIFF
--- a/test/e2e-go/cli/goal/expect/catchpointCatchupTest.exp
+++ b/test/e2e-go/cli/goal/expect/catchpointCatchupTest.exp
@@ -19,10 +19,17 @@ proc spawnCatchpointCatchupWebProxy { TARGET_ENDPOINT RUNTIME REQUEST_DELAY } {
     upvar WP_SPAWN_ID WP_SPAWN_ID
     set WEBPROXY_LISTEN_ADDRESS ""
 
-    # the timeout is set here to take a long while since the command below would end up compiling the go source code before running it.
-    # on slow machines, this could take a long while.
-    set timeout 60
-    spawn go run ./catchpointCatchupWebProxy -targetEndpoint "$TARGET_ENDPOINT" -runtime $RUNTIME -requestDelay $REQUEST_DELAY
+    # compile the catchpointCatchupWebProxy, so we can kick it off quickly later on.
+    # this can take a while, especially if we compiled just the build-race version.
+    set timeout 240
+    spawn go install ./catchpointCatchupWebProxy
+    expect {
+        timeout {::AlgorandGoal::Abort "timed out compiling catchpointCatchupWebProxy"}
+        eof { ::AlgorandGoal::CheckEOF "failed to compile catchpointCatchupWebProxy"}
+    }
+
+    set timeout 5
+    spawn catchpointCatchupWebProxy -targetEndpoint "$TARGET_ENDPOINT" -runtime $RUNTIME -requestDelay $REQUEST_DELAY
     set WP_SPAWN_ID $spawn_id
     expect {
         -re {(^[0-9\.]+:[0-9]+)} { set WEBPROXY_LISTEN_ADDRESS $expect_out(1,string) }

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -935,33 +935,41 @@ proc ::AlgorandGoal::Report { TEST_PRIMARY_NODE_DIR } {
             -re {Last committed block: (\d+)} {puts "status check ok"}
         }
     } EXCEPTION ] } {
-    ::AlgorandGoal::Abort "ERROR in Report: $EXCEPTION"
+        ::AlgorandGoal::Abort "ERROR in Report: $EXCEPTION"
     }
 }
 
 # List Participation keys
 proc ::AlgorandGoal::ListParticipationKeys { TEST_PRIMARY_NODE_DIR } {
+    # the function account.RestoreParticipation.func1 seems to be running slow on
+    # arm64; for now, we'll give it abit more time to run:
+    set GOARCH [exec go env GOARCH]
+    if { $GOARCH == "arm64" } {
+        set timeout 20
+    }
     if { [ catch {
         spawn goal account listpartkeys -d $TEST_PRIMARY_NODE_DIR
         expect {
             timeout { ::AlgorandGoal::Abort "goal ListParticipationKeys timed out"  }
-            close
+            eof { ::AlgorandGoal::CheckEOF "failed to list participation keys" }
         }
     } EXCEPTION ] } {
-    ::AlgorandGoal::Abort "ERROR in ListParticipationKeys: $EXCEPTION"
+        ::AlgorandGoal::Abort "ERROR in ListParticipationKeys: $EXCEPTION"
     }
 }
 
 # Add a participation key
 proc ::AlgorandGoal::AddParticipationKey { ADDRESS FIRST_ROUND LAST_ROUND TEST_PRIMARY_NODE_DIR } {
+    # we need to set the timeout to more than one round, since it might take few rounds for the transaction to be accepted, transmitted, proposed, etc.
+    set timeout 20
     if { [ catch {
         spawn goal account addpartkey --address $ADDRESS --roundFirstValid $FIRST_ROUND --roundLastValid $LAST_ROUND -d $TEST_PRIMARY_NODE_DIR
         expect {
             timeout { ::AlgorandGoal::Abort "goal AddParticipationKey timed out"  }
-            close
+            eof { ::AlgorandGoal::CheckEOF "failed to AddParticipationKey" }
         }
     } EXCEPTION ] } {
-    ::AlgorandGoal::Abort "ERROR in AddParticipationKey: $EXCEPTION"
+        ::AlgorandGoal::Abort "ERROR in AddParticipationKey: $EXCEPTION"
     }
 }
 
@@ -974,7 +982,7 @@ proc ::AlgorandGoal::TakeAccountOnline { ADDRESS FIRST_ROUND LAST_ROUND TEST_PRI
        spawn goal account changeonlinestatus --address $ADDRESS --firstvalid $FIRST_ROUND --lastvalid $LAST_ROUND -d $TEST_PRIMARY_NODE_DIR
        expect {
            timeout { ::AlgorandGoal::Abort "goal TakeAccountOnline timed out"  }
-           close
+           eof { ::AlgorandGoal::CheckEOF "failed to change account online status" }
        }
    } EXCEPTION ] } {
    ::AlgorandGoal::Abort "ERROR in TakeAccountOnline: $EXCEPTION"


### PR DESCRIPTION
## Summary

The test was running a go source code directly. While there is nothing wrong with that, it doesn't allow us to separate the compilation time from execution time.

## Test Plan

This is. a test