### PR TITLE
Parallelize proposal transactions signature verification

### DIFF
--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -393,8 +393,7 @@ func PaysetGroups(ctx context.Context, payset [][]transactions.SignedTxn, blk bo
 								return errors.New("empty address")
 							}
 
-							err = stxnVerifyCore(&signTxn, &ctxs[k])
-							if err != nil {
+							if err := stxnVerifyCore(&signTxn, &ctxs[k]); err != nil {
 								return err
 							}
 						}

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -386,10 +386,6 @@ func PaysetGroups(ctx context.Context, payset [][]transactions.SignedTxn, blk bo
 						}
 						ctxs := PrepareContexts(signTxnsGrp, blk.BlockHeader)
 						for k, signTxn := range signTxnsGrp {
-							err := signTxn.Txn.Alive(blk)
-							if err != nil {
-								return err
-							}
 							if err := signTxn.Txn.WellFormed(spec, proto); err != nil {
 								return err
 							}

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -328,6 +328,9 @@ func PaysetGroups(ctx context.Context, payset [][]transactions.SignedTxn, blk bo
 	if !ok {
 		return protocol.Error(blk.BlockHeader.CurrentProtocol)
 	}
+	if len(payset) == 0 {
+		return nil
+	}
 	spec := transactions.SpecialAddresses{
 		FeeSink:     blk.BlockHeader.FeeSink,
 		RewardsPool: blk.BlockHeader.RewardsPool,
@@ -355,6 +358,7 @@ func PaysetGroups(ctx context.Context, payset [][]transactions.SignedTxn, blk bo
 				}
 				txnCounter += len(payset[i])
 			}
+
 		}
 
 		select {

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -350,15 +350,10 @@ func PaysetGroups(ctx context.Context, payset [][]transactions.SignedTxn, blk bo
 	if len(payset) == 0 {
 		return nil
 	}
-	/*spec := transactions.SpecialAddresses{
-		FeeSink:     blk.BlockHeader.FeeSink,
-		RewardsPool: blk.BlockHeader.RewardsPool,
-	}*/
 
 	// prepare up to 16 concurrent worksets.
 	worksets := make(chan struct{}, concurrentWorksets)
 	worksDoneCh := make(chan interface{}, concurrentWorksets)
-	//zeroAddress := basics.Address{}
 	processing := 0
 	tasksCtx, cancelTasksCtx := context.WithCancel(ctx)
 	defer cancelTasksCtx()

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -17,6 +17,7 @@
 package verify
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 
@@ -25,8 +26,10 @@ import (
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/util/execpool"
 )
 
 var feeSink = basics.Address{0x7, 0xda, 0xcb, 0x4b, 0x6d, 0x9e, 0xd1, 0x41, 0xb1, 0x75, 0x76, 0xbd, 0x45, 0x9a, 0xe6, 0x42, 0x1d, 0x48, 0x6d, 0xa3, 0xd4, 0xef, 0x22, 0x47, 0xc4, 0x9, 0xa3, 0x96, 0xb8, 0x2e, 0xa2, 0x21}
@@ -44,7 +47,7 @@ func keypair() *crypto.SignatureSecrets {
 	return s
 }
 
-func generateTestObjects(numTxs, numAccs int) ([]transactions.Transaction, []transactions.SignedTxn, []*crypto.SignatureSecrets, []basics.Address) {
+func generateTestObjects(numTxs, numAccs int, blockRound basics.Round) ([]transactions.Transaction, []transactions.SignedTxn, []*crypto.SignatureSecrets, []basics.Address) {
 	txs := make([]transactions.Transaction, numTxs)
 	signed := make([]transactions.SignedTxn, numTxs)
 	secrets := make([]*crypto.SignatureSecrets, numAccs)
@@ -56,22 +59,28 @@ func generateTestObjects(numTxs, numAccs int) ([]transactions.Transaction, []tra
 		secrets[i] = secret
 		addresses[i] = addr
 	}
-
+	var iss, exp int
 	for i := 0; i < numTxs; i++ {
 		s := rand.Intn(numAccs)
 		r := rand.Intn(numAccs)
 		a := rand.Intn(1000)
 		f := config.Consensus[protocol.ConsensusCurrentVersion].MinTxnFee + uint64(rand.Intn(10))
-		iss := 50 + rand.Intn(30)
-		exp := iss + 10
+		if blockRound == 0 {
+			iss = 50 + rand.Intn(30)
+			exp = iss + 10
+		} else {
+			iss = int(blockRound) / 2
+			exp = int(blockRound) + rand.Intn(30)
+		}
 
 		txs[i] = transactions.Transaction{
 			Type: protocol.PaymentTx,
 			Header: transactions.Header{
-				Sender:     addresses[s],
-				Fee:        basics.MicroAlgos{Raw: f},
-				FirstValid: basics.Round(iss),
-				LastValid:  basics.Round(exp),
+				Sender:      addresses[s],
+				Fee:         basics.MicroAlgos{Raw: f},
+				FirstValid:  basics.Round(iss),
+				LastValid:   basics.Round(exp),
+				GenesisHash: crypto.Hash([]byte{1, 2, 3, 4, 5}),
 			},
 			PaymentTxnFields: transactions.PaymentTxnFields{
 				Receiver: addresses[r],
@@ -87,7 +96,7 @@ func generateTestObjects(numTxs, numAccs int) ([]transactions.Transaction, []tra
 func TestSignedPayment(t *testing.T) {
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
-	payments, stxns, secrets, addrs := generateTestObjects(1, 1)
+	payments, stxns, secrets, addrs := generateTestObjects(1, 1, 0)
 	payment, stxn, secret, addr := payments[0], stxns[0], secrets[0], addrs[0]
 
 	require.NoError(t, payment.WellFormed(spec, proto), "generateTestObjects generated an invalid payment")
@@ -104,7 +113,7 @@ func TestSignedPayment(t *testing.T) {
 }
 
 func TestTxnValidationEncodeDecode(t *testing.T) {
-	_, signed, _, _ := generateTestObjects(100, 50)
+	_, signed, _, _ := generateTestObjects(100, 50, 0)
 
 	for _, txn := range signed {
 		if Txn(&txn, Context{Params: Params{CurrSpecAddrs: spec, CurrProto: protocol.ConsensusCurrentVersion}}) != nil {
@@ -122,7 +131,7 @@ func TestTxnValidationEncodeDecode(t *testing.T) {
 }
 
 func TestTxnValidationEmptySig(t *testing.T) {
-	_, signed, _, _ := generateTestObjects(100, 50)
+	_, signed, _, _ := generateTestObjects(100, 50, 0)
 
 	for _, txn := range signed {
 		if Txn(&txn, Context{Params: Params{CurrSpecAddrs: spec, CurrProto: protocol.ConsensusCurrentVersion}}) != nil {
@@ -207,4 +216,80 @@ func TestDecodeNil(t *testing.T) {
 		// This used to panic when run on a zero value of SignedTxn.
 		Txn(&st, Context{Params: Params{CurrSpecAddrs: spec, CurrProto: protocol.ConsensusCurrentVersion}})
 	}
+}
+
+func TestPaysetGroups(t *testing.T) {
+	_, signedTxn, _, _ := generateTestObjects(10000, 20, 50)
+	blk := bookkeeping.Block{
+		BlockHeader: bookkeeping.BlockHeader{
+			Round:       50,
+			GenesisHash: crypto.Hash([]byte{1, 2, 3, 4, 5}),
+			UpgradeState: bookkeeping.UpgradeState{
+				CurrentProtocol: protocol.ConsensusCurrentVersion,
+			},
+			RewardsState: bookkeeping.RewardsState{
+				FeeSink:     feeSink,
+				RewardsPool: poolAddr,
+			},
+		},
+	}
+	execPool := execpool.MakePool(t)
+	verificationPool := execpool.MakeBacklog(execPool, 64, execpool.LowPriority, t)
+	defer verificationPool.Shutdown()
+
+	// divide the transactions into transaction groups.
+	txnGroups := make([][]transactions.SignedTxn, 0, len(signedTxn))
+	for i := 0; i < len(signedTxn)-16; i++ {
+		txnPerGroup := rand.Intn(16)
+		txnGroups = append(txnGroups, signedTxn[i:i+txnPerGroup+1])
+		i += txnPerGroup
+	}
+
+	err := PaysetGroups(context.Background(), txnGroups, blk, verificationPool)
+	require.NoError(t, err)
+
+	// break the signature and see if it fails.
+	txnGroups[0][0].Sig[0] = txnGroups[0][0].Sig[0] + 1
+	err = PaysetGroups(context.Background(), txnGroups, blk, verificationPool)
+	require.Error(t, err)
+
+	// ensure the rest are fine
+	err = PaysetGroups(context.Background(), txnGroups[1:], blk, verificationPool)
+	require.NoError(t, err)
+}
+
+func BenchmarkPaysetGroups(b *testing.B) {
+	if b.N < 2000 {
+		b.N = 2000
+	}
+	_, signedTxn, _, _ := generateTestObjects(b.N, 20, 50)
+	blk := bookkeeping.Block{
+		BlockHeader: bookkeeping.BlockHeader{
+			Round:       50,
+			GenesisHash: crypto.Hash([]byte{1, 2, 3, 4, 5}),
+			UpgradeState: bookkeeping.UpgradeState{
+				CurrentProtocol: protocol.ConsensusCurrentVersion,
+			},
+			RewardsState: bookkeeping.RewardsState{
+				FeeSink:     feeSink,
+				RewardsPool: poolAddr,
+			},
+		},
+	}
+	execPool := execpool.MakePool(b)
+	verificationPool := execpool.MakeBacklog(execPool, 64, execpool.LowPriority, b)
+	defer verificationPool.Shutdown()
+
+	// divide the transactions into transaction groups.
+	txnGroups := make([][]transactions.SignedTxn, 0, len(signedTxn))
+	for i := 0; i < len(signedTxn)-16; i++ {
+		txnPerGroup := rand.Intn(16)
+		txnGroups = append(txnGroups, signedTxn[i:i+txnPerGroup+1])
+		i += txnPerGroup
+	}
+
+	b.ResetTimer()
+	err := PaysetGroups(context.Background(), txnGroups, blk, verificationPool)
+	require.NoError(b, err)
+	b.StopTimer()
 }

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -941,7 +941,7 @@ func (validator *evalTxValidator) run() {
 		CurrProto: validator.block.BlockHeader.CurrentProtocol,
 	}
 	var unverifiedTxnGroups [][]transactions.SignedTxn
-	unverifiedTxnGroups = make([][]transactions.SignedTxn, len(validator.txgroups))
+	unverifiedTxnGroups = make([][]transactions.SignedTxn, 0, len(validator.txgroups))
 	for _, group := range validator.txgroups {
 		signedTxnGroup := make([]transactions.SignedTxn, len(group))
 		for j, txn := range group {
@@ -1027,6 +1027,8 @@ func eval(ctx context.Context, l ledgerForEvaluator, blk bookkeeping.Block, vali
 	if validate {
 		// wait for the validation to complete.
 		select {
+		case <-ctx.Done():
+			return StateDelta{}, ctx.Err()
 		case err, open := <-txvalidator.done:
 			if !open {
 				break

--- a/ledger/ledger_perf_test.go
+++ b/ledger/ledger_perf_test.go
@@ -134,6 +134,11 @@ func (vc *alwaysVerifiedCache) Verified(txn transactions.SignedTxn, params verif
 	return true
 }
 
+// UnverifiedTxnGroups returns a list of unverified transaction groups given a payset
+func (vc *alwaysVerifiedCache) UnverifiedTxnGroups(txnGroups [][]transactions.SignedTxnWithAD, params verify.Params) (signedTxnGroups [][]transactions.SignedTxn) {
+	return [][]transactions.SignedTxn{}
+}
+
 func benchmarkFullBlocks(params testParams, b *testing.B) {
 	// disable deadlock checking code
 	deadlockDisable := deadlock.Opts.Disable

--- a/ledger/ledger_perf_test.go
+++ b/ledger/ledger_perf_test.go
@@ -134,8 +134,8 @@ func (vc *alwaysVerifiedCache) Verified(txn transactions.SignedTxn, params verif
 	return true
 }
 
-// SignedTxn returns a list of unverified transaction groups given a payset
-func (vc *alwaysVerifiedCache) SignedTxn(txnGroups [][]transactions.SignedTxn, params verify.Params) (signedTxnGroups [][]transactions.SignedTxn) {
+// UnverifiedTxnGroups returns a list of unverified transaction groups given a payset
+func (vc *alwaysVerifiedCache) UnverifiedTxnGroups(txnGroups [][]transactions.SignedTxn, params verify.Params) (signedTxnGroups [][]transactions.SignedTxn) {
 	return [][]transactions.SignedTxn{}
 }
 

--- a/ledger/ledger_perf_test.go
+++ b/ledger/ledger_perf_test.go
@@ -134,8 +134,8 @@ func (vc *alwaysVerifiedCache) Verified(txn transactions.SignedTxn, params verif
 	return true
 }
 
-// UnverifiedTxnGroups returns a list of unverified transaction groups given a payset
-func (vc *alwaysVerifiedCache) UnverifiedTxnGroups(txnGroups [][]transactions.SignedTxnWithAD, params verify.Params) (signedTxnGroups [][]transactions.SignedTxn) {
+// SignedTxn returns a list of unverified transaction groups given a payset
+func (vc *alwaysVerifiedCache) SignedTxn(txnGroups [][]transactions.SignedTxn, params verify.Params) (signedTxnGroups [][]transactions.SignedTxn) {
 	return [][]transactions.SignedTxn{}
 }
 

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -124,6 +124,20 @@ type DummyVerifiedTxnCache struct{}
 func (x DummyVerifiedTxnCache) Verified(txn transactions.SignedTxn, params verify.Params) bool {
 	return false
 }
+
+// UnverifiedTxnGroups returns a list of unverified transaction groups given a payset
+func (x DummyVerifiedTxnCache) UnverifiedTxnGroups(txnGroups [][]transactions.SignedTxnWithAD, params verify.Params) (signedTxnGroups [][]transactions.SignedTxn) {
+	signedTxnGroups = make([][]transactions.SignedTxn, len(txnGroups))
+	for _, group := range txnGroups {
+		signedTxnGroup := make([]transactions.SignedTxn, len(group))
+		for j, txn := range group {
+			signedTxnGroup[j] = txn.SignedTxn
+		}
+		signedTxnGroups = append(signedTxnGroups, signedTxnGroup)
+	}
+	return
+}
+
 func (x DummyVerifiedTxnCache) EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (found bool, err error) {
 	return false, nil
 }

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -126,16 +126,8 @@ func (x DummyVerifiedTxnCache) Verified(txn transactions.SignedTxn, params verif
 }
 
 // UnverifiedTxnGroups returns a list of unverified transaction groups given a payset
-func (x DummyVerifiedTxnCache) UnverifiedTxnGroups(txnGroups [][]transactions.SignedTxnWithAD, params verify.Params) (signedTxnGroups [][]transactions.SignedTxn) {
-	signedTxnGroups = make([][]transactions.SignedTxn, len(txnGroups))
-	for _, group := range txnGroups {
-		signedTxnGroup := make([]transactions.SignedTxn, len(group))
-		for j, txn := range group {
-			signedTxnGroup[j] = txn.SignedTxn
-		}
-		signedTxnGroups = append(signedTxnGroups, signedTxnGroup)
-	}
-	return
+func (x DummyVerifiedTxnCache) UnverifiedTxnGroups(txnGroups [][]transactions.SignedTxn, params verify.Params) (signedTxnGroups [][]transactions.SignedTxn) {
+	return txnGroups
 }
 
 func (x DummyVerifiedTxnCache) EvalOk(cvers protocol.ConsensusVersion, txid transactions.Txid) (found bool, err error) {


### PR DESCRIPTION
## Summary

Our existing code was verifying the transactions in parallel with the insertion to the evaluator, but that won't fully utilize the host computational abilities. To push it to the end, we need to break the transaction verification into subsets and parallelize the verification.

This is the first PR, which would handle the verification parallelization. The subsequent PR would ensure that we don't revalidate the same transaction coming from two different proposals, regardless if the transaction appear in the transaction pool or not.

## Test Plan

Added unit test to verify changed code correctness.

## Performance

Testing the performance gains between running `verify.TxnPool` vs using the new `verify.PaysetGroups`:
| Transaction Count | Before ( serialized ) | After ( parallelized ) |
|:--:|:--:|:--:|
|1 (amortized) |65,200 ns| 14,600 ns|
|5,000|326 ms|73 ms|
|10,000|656 ms|146 ms|
|50,000|3.260 s|730 ms|

Tests were conducted on a MacBook Pro 2.7 GHz Quad-Core Intel Core i7