### PR TITLE
Minimal bug fixes for latest package deployment

### DIFF
--- a/package-deploy.yaml
+++ b/package-deploy.yaml
@@ -1,7 +1,7 @@
 agents:
   - name: docker
     dockerFilePath: docker/build/docker.ubuntu.Dockerfile
-    image: algorand/go-algorand-ci-linux-ubuntu
+    image: algorand/docker
     version: scripts/configure_dev-deps.sh
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`

--- a/scripts/release/mule/deploy/rpm/deploy.sh
+++ b/scripts/release/mule/deploy/rpm/deploy.sh
@@ -78,7 +78,6 @@ then
     cp -r /root/rpmrepo .
 else
     aws s3 sync rpmrepo "s3://algorand-releases/rpm/$CHANNEL/"
-    aws s3 cp *"$VERSION"*.rpm "s3://algorand-internal/packages/rpm/$CHANNEL/"
 fi
 
 echo


### PR DESCRIPTION
## Summary

This removes uploading to a now-obsolete S3 location.  Also, `mule` needs to use a different image for doing the docker publishing, one that has docker pre-installed.

## Test Plan

Run the respective `mule` commands.
