### PR TITLE
Fix catchup concurrently from a single host

### DIFF
--- a/catchup/service.go
+++ b/catchup/service.go
@@ -204,11 +204,11 @@ func (s *Service) fetchAndWrite(fetcher Fetcher, r basics.Round, prevFetchComple
 			if !hasLookback {
 				select {
 				case <-s.ctx.Done():
-					s.log.Debugf("fetchAndWrite(%v): Aborted while waiting for lookback block to ledger after failing once", r)
+					s.log.Infof("fetchAndWrite(%d): Aborted while waiting for lookback block to ledger after failing once : %v", r, err)
 					return false
 				case hasLookback = <-lookbackComplete:
 					if !hasLookback {
-						s.log.Debugf("fetchAndWrite(%v): lookback block doesn't exist, won't try to retrieve block again", r)
+						s.log.Infof("fetchAndWrite(%d): lookback block doesn't exist, won't try to retrieve block again : %v", r, err)
 						return false
 					}
 				}
@@ -262,11 +262,26 @@ func (s *Service) fetchAndWrite(fetcher Fetcher, r basics.Round, prevFetchComple
 			return false
 		case prevFetchSuccess := <-prevFetchCompleteChan:
 			if prevFetchSuccess {
-				err := s.ledger.AddBlock(*block, *cert)
+				// make sure the ledger wrote enough of the account data to disk, since we don't want the ledger to hold a large amount of data in memory.
+				proto, err := s.ledger.ConsensusParams(r.SubSaturate(1))
+				if err != nil {
+					s.log.Errorf("fetchAndWrite(%d): Unable to determine consensus params for round %d: %v", r, r-1, err)
+					return false
+				}
+				ledgerBacklogRound := r.SubSaturate(basics.Round(proto.MaxBalLookback))
+				select {
+				case <-s.ledger.Wait(ledgerBacklogRound):
+					// i.e. round r-320 is no longer in the blockqueue, so it's account data is either being currently written, or it was already written.
+				case <-s.ctx.Done():
+					s.log.Debugf("fetchAndWrite(%d): Aborted while waiting for ledger to complete writing up to round %d", r, ledgerBacklogRound)
+					return false
+				}
+
+				err = s.ledger.AddBlock(*block, *cert)
 				if err != nil {
 					switch err.(type) {
 					case ledger.BlockInLedgerError:
-						s.log.Debugf("fetchAndWrite(%v): block already in ledger", r)
+						s.log.Infof("fetchAndWrite(%d): block already in ledger", r)
 						return true
 					case protocol.Error:
 						if !s.protocolErrorLogged {
@@ -407,6 +422,7 @@ func (s *Service) pipelinedFetch(seedLookback uint64) {
 					return
 				}
 				delete(completedRounds, nextRound)
+
 				currentRoundComplete := make(chan bool, 2)
 				// len(taskCh) + (# pending writes to completed) increases by 1
 				taskCh <- s.pipelineCallback(fetcher, nextRound, currentRoundComplete, recentReqs[len(recentReqs)-1], recentReqs[0])

--- a/network/rateLimitingTransport.go
+++ b/network/rateLimitingTransport.go
@@ -35,7 +35,7 @@ var ErrConnectionQueueingTimeout = errors.New("rateLimitingTransport: queueing t
 
 // makeRateLimitingTransport creates a rate limiting http transport that would limit the requests rate
 // according to the entries in the phonebook.
-func makeRateLimitingTransport(phonebook Phonebook, queueingTimeout time.Duration, dialer *Dialer) rateLimitingTransport {
+func makeRateLimitingTransport(phonebook Phonebook, queueingTimeout time.Duration, dialer *Dialer, maxIdleConnsPerHost int) rateLimitingTransport {
 	defaultTransport := http.DefaultTransport.(*http.Transport)
 	return rateLimitingTransport{
 		phonebook: phonebook,
@@ -46,6 +46,7 @@ func makeRateLimitingTransport(phonebook Phonebook, queueingTimeout time.Duratio
 			IdleConnTimeout:       defaultTransport.IdleConnTimeout,
 			TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
 			ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
+			MaxIdleConnsPerHost:   maxIdleConnsPerHost,
 		},
 		queueingTimeout: queueingTimeout,
 	}

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -584,8 +584,9 @@ func (wn *WebsocketNetwork) setup() {
 	if wn.config.DNSSecurityRelayAddrEnforced() {
 		preferredResolver = dnssec.MakeDefaultDnssecResolver(wn.config.FallbackDNSResolverAddress, wn.log)
 	}
+	maxIdleConnsPerHost := int(wn.config.ConnectionsRateLimitingCount)
 	wn.dialer = makeRateLimitingDialer(wn.phonebook, preferredResolver)
-	wn.transport = makeRateLimitingTransport(wn.phonebook, 10*time.Second, &wn.dialer)
+	wn.transport = makeRateLimitingTransport(wn.phonebook, 10*time.Second, &wn.dialer, maxIdleConnsPerHost)
 
 	wn.upgrader.ReadBufferSize = 4096
 	wn.upgrader.WriteBufferSize = 4096


### PR DESCRIPTION
## Summary

When trying to perform a catchup from a single host, the following error comes up:
```
 dial tcp 127.0.0.1:8088: can't assign requested address
```

The cause of this is that GO runtime runs of out connection. When doing so, it creates new one. And the new connection that was created has a system-wide timeout. The solution for that is to increase the number of MaxIdleConnsPerHost to the expected number of concurrent requests. 

Secondly, once having that solved, the catchup started working fast. In fact, it was working so fast that the accounts update could not keep up, causing the memory utilization to grow up and the "dbatomic" to report slow flushing performance.
To resolve that, we need to hold off newly fetched block until the queue isn't too large. Once we have that, it would be safe to add these to the ledger.


## Test Plan

Tested manually, as automated testing is highly complicated for these use cases and won't add too much value.
