### PR TITLE
Compact accounts deltas before persisting to disk

### DIFF
--- a/agreement/certificate.go
+++ b/agreement/certificate.go
@@ -17,7 +17,7 @@
 package agreement
 
 import (
-	"context"
+	//"context"
 	"fmt"
 
 	"github.com/algorand/go-algorand/data/bookkeeping"
@@ -44,7 +44,7 @@ func (c Certificate) Authenticate(e bookkeeping.Block, l LedgerReader, avv *Asyn
 	if err != nil {
 		return
 	}
-	_, err = unauthenticatedBundle(c).verify(context.Background(), l, avv)
+	//_, err = unauthenticatedBundle(c).verify(context.Background(), l, avv)
 	return
 }
 

--- a/agreement/certificate.go
+++ b/agreement/certificate.go
@@ -17,7 +17,7 @@
 package agreement
 
 import (
-	//"context"
+	"context"
 	"fmt"
 
 	"github.com/algorand/go-algorand/data/bookkeeping"
@@ -44,7 +44,7 @@ func (c Certificate) Authenticate(e bookkeeping.Block, l LedgerReader, avv *Asyn
 	if err != nil {
 		return
 	}
-	//_, err = unauthenticatedBundle(c).verify(context.Background(), l, avv)
+	_, err = unauthenticatedBundle(c).verify(context.Background(), l, avv)
 	return
 }
 


### PR DESCRIPTION
## Summary

When we run catchup, we often attempt to persist multiple rounds in a single sqlite transaction. When doing so, we were iterating throughout the rounds we were attempting to update and flushing all the deltas for each individual round.

While this work correctly, it's also not the most efficient, since we are updating the same account multiple times. To address that issue, this PR compact the deltas into a single map, which corresponds to the entire change set across the updated rounds range.

## Test Plan

Unit test and benchmark added. Ran a test against mainnet and it seems to be working correctly with roughly 30% performance increase.