### PR TITLE
Refactor account updates consistency checking 

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -119,6 +119,9 @@ type accountDelta struct {
 	new basics.AccountData
 }
 
+// accountDeltaCount is an extention to accountDelta that is being used by the commitRound function for counting the
+// number of changes we've made per account. The ndeltas is used execlusively for consistency checking - making sure that
+// all the pending changes were written and that there are no outstanding writes missing.
 type accountDeltaCount struct {
 	accountDelta
 	ndeltas int

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -119,6 +119,11 @@ type accountDelta struct {
 	new basics.AccountData
 }
 
+type accountDeltaCount struct {
+	accountDelta
+	ndeltas int
+}
+
 // catchpointState is used to store catchpoint related variables into the catchpointstate table.
 type catchpointState string
 
@@ -872,7 +877,7 @@ func accountsPutTotals(tx *sql.Tx, totals AccountTotals, catchpointStaging bool)
 }
 
 // accountsNewRound updates the accountbase and assetcreators by applying the provided deltas to the accounts / creatables.
-func accountsNewRound(tx *sql.Tx, updates map[basics.Address]accountDelta, creatables map[basics.CreatableIndex]modifiedCreatable, proto config.ConsensusParams) (err error) {
+func accountsNewRound(tx *sql.Tx, updates map[basics.Address]accountDeltaCount, creatables map[basics.CreatableIndex]modifiedCreatable, proto config.ConsensusParams) (err error) {
 
 	var insertCreatableIdxStmt, deleteCreatableIdxStmt, deleteStmt, replaceStmt *sql.Stmt
 

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -529,7 +529,9 @@ func TestAccountDBRound(t *testing.T) {
 		accts = newaccts
 		ctbsWithDeletes := randomCreatableSampling(i, ctbsList, randomCtbs,
 			expectedDbImage, numElementsPerSegement)
-		err = accountsNewRound(tx, updates, ctbsWithDeletes, proto)
+
+		updatesCnt, _ := compactDeltas([]map[basics.Address]accountDelta{updates}, nil)
+		err = accountsNewRound(tx, updatesCnt, ctbsWithDeletes, proto)
 		require.NoError(t, err)
 		err = totalsNewRounds(tx, []map[basics.Address]accountDelta{updates}, []AccountTotals{{}}, []config.ConsensusParams{proto})
 		require.NoError(t, err)

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -686,7 +686,7 @@ func benchmarkInitBalances(b testing.TB, numAccounts int, dbs dbPair, proto conf
 			VoteLastValid:      basics.Round(0x000ffffffffffffff),
 			VoteKeyDilution:    0x000ffffffffffffff,
 			AssetParams: map[basics.AssetIndex]basics.AssetParams{
-				0x000ffffffffffffff: basics.AssetParams{
+				0x000ffffffffffffff: {
 					Total:         0x000ffffffffffffff,
 					Decimals:      0x2ffffff,
 					DefaultFrozen: true,
@@ -701,7 +701,7 @@ func benchmarkInitBalances(b testing.TB, numAccounts int, dbs dbPair, proto conf
 				},
 			},
 			Assets: map[basics.AssetIndex]basics.AssetHolding{
-				0x000ffffffffffffff: basics.AssetHolding{
+				0x000ffffffffffffff: {
 					Amount: 0x000ffffffffffffff,
 					Frozen: true,
 				},
@@ -829,7 +829,7 @@ func TestAccountsReencoding(t *testing.T) {
 				VoteLastValid:      basics.Round(0x000ffffffffffffff),
 				VoteKeyDilution:    0x000ffffffffffffff,
 				AssetParams: map[basics.AssetIndex]basics.AssetParams{
-					0x000ffffffffffffff: basics.AssetParams{
+					0x000ffffffffffffff: {
 						Total:         0x000ffffffffffffff,
 						Decimals:      0x2ffffff,
 						DefaultFrozen: true,
@@ -844,7 +844,7 @@ func TestAccountsReencoding(t *testing.T) {
 					},
 				},
 				Assets: map[basics.AssetIndex]basics.AssetHolding{
-					0x000ffffffffffffff: basics.AssetHolding{
+					0x000ffffffffffffff: {
 						Amount: 0x000ffffffffffffff,
 						Frozen: true,
 					},

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1958,7 +1958,8 @@ func (au *accountUpdates) commitRound(offset uint64, dbRound basics.Round, lookb
 }
 
 // compactDeltas takes an arary of account map deltas ( one array entry per round ), and corresponding creatables array, and compact the arrays into a single
-// map that contains all the account deltas changes. While doing that, the function eliminate any intermediate account changes.
+// map that contains all the account deltas changes. While doing that, the function eliminate any intermediate account changes. For both the account deltas as well as for the creatables,
+// it counts the number of changes per round by specifying it in the ndeltas field of the accountDeltaCount/modifiedCreatable. The ndeltas field of the input creatableDeltas is ignored.
 func compactDeltas(accountDeltas []map[basics.Address]accountDelta, creatableDeltas []map[basics.CreatableIndex]modifiedCreatable) (outAccountDeltas map[basics.Address]accountDeltaCount, outCreatableDeltas map[basics.CreatableIndex]modifiedCreatable) {
 	if len(accountDeltas) > 0 {
 		// the sizes of the maps here aren't super accurate, but would hopefully be a rough estimate for a resonable starting point.

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1287,7 +1287,7 @@ func BenchmarkCompactDeltas(b *testing.B) {
 		}
 		b.ResetTimer()
 
-		compactDeltas(accountDeltas, []map[basics.CreatableIndex]modifiedCreatable{map[basics.CreatableIndex]modifiedCreatable{}})
+		compactDeltas(accountDeltas, []map[basics.CreatableIndex]modifiedCreatable{{}})
 
 	})
 }
@@ -1310,6 +1310,10 @@ func TestCompactDeltas(t *testing.T) {
 	require.Equal(t, len(accountDeltas[0]), len(outAccountDeltas))
 	require.Equal(t, len(creatableDeltas[0]), len(outCreatableDeltas))
 
+	require.Equal(t, basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 1}}, outAccountDeltas[addrs[0]].old)
+	require.Equal(t, basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 2}}, outAccountDeltas[addrs[0]].new)
+	require.Equal(t, modifiedCreatable{creator: addrs[2], created: true, ndeltas: 1}, outCreatableDeltas[100])
+
 	// add another round
 	accountDeltas = append(accountDeltas, make(map[basics.Address]accountDelta))
 	creatableDeltas = append(creatableDeltas, make(map[basics.CreatableIndex]modifiedCreatable))
@@ -1326,12 +1330,16 @@ func TestCompactDeltas(t *testing.T) {
 
 	require.Equal(t, uint64(1), outAccountDeltas[addrs[0]].old.MicroAlgos.Raw)
 	require.Equal(t, uint64(3), outAccountDeltas[addrs[0]].new.MicroAlgos.Raw)
+	require.Equal(t, int(2), outAccountDeltas[addrs[0]].ndeltas)
 	require.Equal(t, uint64(0), outAccountDeltas[addrs[3]].old.MicroAlgos.Raw)
 	require.Equal(t, uint64(8), outAccountDeltas[addrs[3]].new.MicroAlgos.Raw)
+	require.Equal(t, int(1), outAccountDeltas[addrs[3]].ndeltas)
 
 	require.Equal(t, addrs[2], outCreatableDeltas[100].creator)
 	require.Equal(t, addrs[4], outCreatableDeltas[101].creator)
 	require.Equal(t, false, outCreatableDeltas[100].created)
 	require.Equal(t, true, outCreatableDeltas[101].created)
+	require.Equal(t, 2, outCreatableDeltas[100].ndeltas)
+	require.Equal(t, 1, outCreatableDeltas[101].ndeltas)
 
 }

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1017,7 +1017,7 @@ func TestListCreatables(t *testing.T) {
 	// ******* All results are obtained from the database. Empty cache *******
 	// ******* No deletes	                                           *******
 	// sync with the database
-	var updates map[basics.Address]accountDelta
+	var updates map[basics.Address]accountDeltaCount
 	err = accountsNewRound(tx, updates, ctbsWithDeletes, proto)
 	require.NoError(t, err)
 	// nothing left in cache
@@ -1162,12 +1162,12 @@ func BenchmarkLargeMerkleTrieRebuild(b *testing.B) {
 	// at this point, the database was created. We want to fill the accounts data
 	accountsNumber := 6000000 * b.N
 	for i := 0; i < accountsNumber-5-2; { // subtract the account we've already created above, plus the sink/reward
-		updates := make(map[basics.Address]accountDelta, 0)
+		updates := make(map[basics.Address]accountDeltaCount, 0)
 		for k := 0; i < accountsNumber-5-2 && k < 1024; k++ {
 			addr := randomAddress()
 			acctData := basics.AccountData{}
 			acctData.MicroAlgos.Raw = 1
-			updates[addr] = accountDelta{new: acctData}
+			updates[addr] = accountDeltaCount{accountDelta: accountDelta{new: acctData}}
 			i++
 		}
 
@@ -1234,12 +1234,12 @@ func BenchmarkLargeCatchpointWriting(b *testing.B) {
 	accountsNumber := 6000000 * b.N
 	err = ml.dbs.wdb.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
 		for i := 0; i < accountsNumber-5-2; { // subtract the account we've already created above, plus the sink/reward
-			updates := make(map[basics.Address]accountDelta, 0)
+			updates := make(map[basics.Address]accountDeltaCount, 0)
 			for k := 0; i < accountsNumber-5-2 && k < 1024; k++ {
 				addr := randomAddress()
 				acctData := basics.AccountData{}
 				acctData.MicroAlgos.Raw = 1
-				updates[addr] = accountDelta{new: acctData}
+				updates[addr] = accountDeltaCount{accountDelta: accountDelta{new: acctData}}
 				i++
 			}
 
@@ -1307,8 +1307,8 @@ func TestCompactDeltas(t *testing.T) {
 	creatableDeltas[0][100] = modifiedCreatable{creator: addrs[2], created: true}
 	outAccountDeltas, outCreatableDeltas := compactDeltas(accountDeltas, creatableDeltas)
 
-	require.Equal(t, accountDeltas[0], outAccountDeltas)
-	require.Equal(t, creatableDeltas[0], outCreatableDeltas)
+	require.Equal(t, len(accountDeltas[0]), len(outAccountDeltas))
+	require.Equal(t, len(creatableDeltas[0]), len(outCreatableDeltas))
 
 	// add another round
 	accountDeltas = append(accountDeltas, make(map[basics.Address]accountDelta))


### PR DESCRIPTION
## Summary

This PR is a followup to the previous compact deltas PR. It moves the accounts & creatables flush counters into the compact deltas data structures, allowing to perform the counting in a single pass.

## Test Plan

Unit tests were updated