### PR TITLE
Convert the catchpointWriting from a channel to an atomic variable

### DIFF
--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1046,11 +1046,11 @@ func TestIsWritingCatchpointFile(t *testing.T) {
 
 	au := &accountUpdates{}
 
-	au.catchpointWriting = make(chan struct{}, 1)
+	au.catchpointWriting = -1
 	ans := au.IsWritingCatchpointFile()
 	require.True(t, ans)
 
-	close(au.catchpointWriting)
+	au.catchpointWriting = 0
 	ans = au.IsWritingCatchpointFile()
 	require.False(t, ans)
 }


### PR DESCRIPTION
## Summary

Convert the catchpointWriting from a channel to an atomic variable. In the past, we used to have a value in having this as a channel, however, this is no longer the case. I have converted this to an atomic variable to improve code simplicity and readability.

## Test Plan

Unit tests were updated.