### PR TITLE
Add make and g++ to configure_dev.sh

### DIFF
--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -75,7 +75,7 @@ if [ "${OS}" = "linux" ]; then
     fi
 
     sudo apt-get update
-    sudo apt-get install -y libboost-all-dev expect jq autoconf shellcheck sqlite3 python3-venv
+    sudo apt-get install -y libboost-all-dev expect jq autoconf shellcheck sqlite3 python3-venv make g++
 elif [ "${OS}" = "darwin" ]; then
     brew update
     brew tap homebrew/cask


### PR DESCRIPTION
## Summary

When building on vanila Ubuntu 20.04 make and g++ are missing

## Test Plan

This is a build script, tested on a Ubuntu 20.04