### PR TITLE
bugfix: incorrect block download retry accounting during fast catchup

### DIFF
--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -453,7 +453,7 @@ func (cs *CatchpointCatchupService) processStageBlocksDownload() (err error) {
 	blocksFetched := uint64(1) // we already got the first block in the previous step.
 	var blk *bookkeeping.Block
 	var client FetcherClient
-	for attemptsCount := uint64(1); blocksFetched <= lookback; attemptsCount++ {
+	for attemptsCount := uint64(1); blocksFetched <= lookback; {
 		if err := cs.ctx.Err(); err != nil {
 			return cs.stopOrAbort()
 		}
@@ -481,6 +481,7 @@ func (cs *CatchpointCatchupService) processStageBlocksDownload() (err error) {
 				if attemptsCount <= uint64(cs.config.CatchupBlockDownloadRetryAttempts) {
 					// try again.
 					cs.log.Infof("Failed to download block %d on attempt %d out of %d. %v", topBlock.Round()-basics.Round(blocksFetched), attemptsCount, cs.config.CatchupBlockDownloadRetryAttempts, err)
+					attemptsCount++
 					continue
 				}
 				return cs.abort(fmt.Errorf("processStageBlocksDownload failed after multiple blocks download attempts"))
@@ -498,6 +499,7 @@ func (cs *CatchpointCatchupService) processStageBlocksDownload() (err error) {
 			cs.updateBlockRetrievalStatistics(-1, 0)
 			if attemptsCount <= uint64(cs.config.CatchupBlockDownloadRetryAttempts) {
 				// try again.
+				attemptsCount++
 				continue
 			}
 			return cs.abort(fmt.Errorf("processStageBlocksDownload downloaded block(%d) did not match it's successor(%d) block hash %v != %v", blk.Round(), prevBlock.Round(), blk.Hash(), prevBlock.BlockHeader.Branch))
@@ -509,6 +511,7 @@ func (cs *CatchpointCatchupService) processStageBlocksDownload() (err error) {
 			cs.updateBlockRetrievalStatistics(-1, 0)
 			if attemptsCount <= uint64(cs.config.CatchupBlockDownloadRetryAttempts) {
 				// try again.
+				attemptsCount++
 				continue
 			}
 			return cs.abort(fmt.Errorf("processStageBlocksDownload: unsupported protocol version detected: '%v'", blk.BlockHeader.CurrentProtocol))
@@ -521,6 +524,7 @@ func (cs *CatchpointCatchupService) processStageBlocksDownload() (err error) {
 			cs.updateBlockRetrievalStatistics(-1, 0)
 			if attemptsCount <= uint64(cs.config.CatchupBlockDownloadRetryAttempts) {
 				// try again.
+				attemptsCount++
 				continue
 			}
 			return cs.abort(fmt.Errorf("processStageBlocksDownload: downloaded block content does not match downloaded block header"))
@@ -535,6 +539,7 @@ func (cs *CatchpointCatchupService) processStageBlocksDownload() (err error) {
 			cs.updateBlockRetrievalStatistics(-1, -1)
 			if attemptsCount <= uint64(cs.config.CatchupBlockDownloadRetryAttempts) {
 				// try again.
+				attemptsCount++
 				continue
 			}
 			return cs.abort(fmt.Errorf("processStageBlocksDownload failed to store downloaded staging block for round %d", blk.Round()))


### PR DESCRIPTION
## Summary

Incorrect block download retry accounting during fast catchup. The existing code was counting successful block retrieval as an retry attempt, which would "exhaust" the `CatchupBlockDownloadRetryAttempts` before the catchup is complete, causing the fast catchup to fail in case the `CatchupBlockDownloadRetryAttempts` was set too low.

The workaround of this is to set the `CatchupBlockDownloadRetryAttempts` to a value that is higher by 1000 than then number of desired attempts count.

## Test Plan

Tested by running fast catchup and observing the failed attempts logs.
