### PR TITLE
Update catchpointdump utility to have progress bars

### DIFF
--- a/catchup/ledgerFetcher.go
+++ b/catchup/ledgerFetcher.go
@@ -33,6 +33,7 @@ import (
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/rpcs"
+	"github.com/algorand/go-algorand/util"
 )
 
 var errNoLedgerForRound = errors.New("No ledger available for given round")
@@ -142,7 +143,7 @@ func (lf *ledgerFetcher) getPeerLedger(ctx context.Context, peer network.HTTPPee
 		maxCatchpointFileChunkDownloadDuration += maxCatchpointFileChunkSize * time.Second / defaultMinCatchpointFileDownloadBytesPerSecond
 	}
 
-	watchdogReader := makeWatchdogStreamReader(response.Body, catchpointFileStreamReadSize, 2*maxCatchpointFileChunkSize, maxCatchpointFileChunkDownloadDuration)
+	watchdogReader := util.MakeWatchdogStreamReader(response.Body, catchpointFileStreamReadSize, 2*maxCatchpointFileChunkSize, maxCatchpointFileChunkDownloadDuration)
 	defer watchdogReader.Close()
 	tarReader := tar.NewReader(watchdogReader)
 	var downloadProgress ledger.CatchpointCatchupAccessorProgress

--- a/cmd/catchpointdump/database.go
+++ b/cmd/catchpointdump/database.go
@@ -53,5 +53,8 @@ var databaseCmd = &cobra.Command{
 		if err != nil {
 			reportErrorf("Unable to print account database : %v", err)
 		}
+		if outFileName != "" {
+			outFile.Close()
+		}
 	},
 }

--- a/cmd/catchpointdump/database.go
+++ b/cmd/catchpointdump/database.go
@@ -48,13 +48,11 @@ var databaseCmd = &cobra.Command{
 			if err != nil {
 				reportErrorf("Unable to create file '%s' : %v", outFileName, err)
 			}
+			defer outFile.Close()
 		}
 		err = printAccountsDatabase(ledgerTrackerFilename, ledger.CatchpointFileHeader{}, outFile)
 		if err != nil {
 			reportErrorf("Unable to print account database : %v", err)
-		}
-		if outFileName != "" {
-			outFile.Close()
 		}
 	},
 }

--- a/cmd/catchpointdump/file.go
+++ b/cmd/catchpointdump/file.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -93,41 +94,24 @@ var fileCmd = &cobra.Command{
 			if err != nil {
 				reportErrorf("Unable to create file '%s' : %v", outFileName, err)
 			}
+			defer outFile.Close()
 		}
 
 		err = printAccountsDatabase("./ledger.tracker.sqlite", fileHeader, outFile)
 		if err != nil {
 			reportErrorf("Unable to print account database : %v", err)
 		}
-		if outFileName != "" {
-			outFile.Close()
-		}
-
 	},
 }
 
 func printLoadCatchpointProgressLine(progress int, barLength int, dld int64) {
-	const (
-		CUU    = string("\033[A") // Cursor Up
-		DL     = string("\033[M") // Delete Line
-		SQUARE = string("▪")
-		DOT    = string("·")
-	)
 	if barLength == 0 {
-		fmt.Printf(CUU + DL + "[ Done ] Loaded\n")
+		fmt.Printf(escapeCursorUp + escapeDeleteLine + "[ Done ] Loaded\n")
 		return
 	}
 
-	outString := "["
-	for i := 0; i < barLength; i++ {
-		if i < progress {
-			outString += SQUARE
-		} else {
-			outString += DOT
-		}
-	}
-	outString += "] Loading..."
-	fmt.Printf(CUU+DL+outString+" %s\n", formatSize(dld))
+	outString := "[" + strings.Repeat(escapeSquare, progress) + strings.Repeat(escapeDot, barLength-progress) + "] Loading..."
+	fmt.Printf(escapeCursorUp+escapeDeleteLine+outString+" %s\n", formatSize(dld))
 }
 
 func loadCatchpointIntoDatabase(ctx context.Context, catchupAccessor ledger.CatchpointCatchupAccessor, fileBytes []byte) (fileHeader ledger.CatchpointFileHeader, err error) {
@@ -181,30 +165,16 @@ func loadCatchpointIntoDatabase(ctx context.Context, catchupAccessor ledger.Catc
 }
 
 func printDumpingCatchpointProgressLine(progress int, barLength int, dld int64) {
-	const (
-		CUU    = string("\033[A") // Cursor Up
-		DL     = string("\033[M") // Delete Line
-		SQUARE = string("▪")
-		DOT    = string("·")
-	)
 	if barLength == 0 {
-		fmt.Printf(CUU + DL + "[ Done ] Dumped\n")
+		fmt.Printf(escapeCursorUp + escapeDeleteLine + "[ Done ] Dumped\n")
 		return
 	}
 
-	outString := "["
-	for i := 0; i < barLength; i++ {
-		if i < progress {
-			outString += SQUARE
-		} else {
-			outString += DOT
-		}
-	}
-	outString += "] Dumping..."
+	outString := "[" + strings.Repeat(escapeSquare, progress) + strings.Repeat(escapeDot, barLength-progress) + "] Dumping..."
 	if dld > 0 {
 		outString = fmt.Sprintf(outString+" %d", dld)
 	}
-	fmt.Printf(CUU + DL + outString + "\n")
+	fmt.Printf(escapeCursorUp + escapeDeleteLine + outString + "\n")
 }
 
 func printAccountsDatabase(databaseName string, fileHeader ledger.CatchpointFileHeader, outFile *os.File) error {

--- a/cmd/catchpointdump/file.go
+++ b/cmd/catchpointdump/file.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"archive/tar"
+	"bufio"
 	"bytes"
 	"context"
 	"database/sql"
@@ -26,6 +27,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -97,11 +99,44 @@ var fileCmd = &cobra.Command{
 		if err != nil {
 			reportErrorf("Unable to print account database : %v", err)
 		}
+		if outFileName != "" {
+			outFile.Close()
+		}
 
 	},
 }
 
+func printLoadCatchpointProgressLine(progress int, barLength int, dld int64) {
+	const (
+		CUU    = string("\033[A") // Cursor Up
+		DL     = string("\033[M") // Delete Line
+		SQUARE = string("▪")
+		DOT    = string("·")
+	)
+	if barLength == 0 {
+		fmt.Printf(CUU + DL + "[ Done ] Loaded\n")
+		return
+	}
+
+	outString := "["
+	for i := 0; i < barLength; i++ {
+		if i < progress {
+			outString += SQUARE
+		} else {
+			outString += DOT
+		}
+	}
+	outString += "] Loading..."
+	fmt.Printf(CUU+DL+outString+" %s\n", formatSize(dld))
+}
+
 func loadCatchpointIntoDatabase(ctx context.Context, catchupAccessor ledger.CatchpointCatchupAccessor, fileBytes []byte) (fileHeader ledger.CatchpointFileHeader, err error) {
+	fmt.Printf("\n")
+	printLoadCatchpointProgressLine(0, 50, 0)
+	lastProgressUpdate := time.Now()
+	progress := uint64(0)
+	defer printLoadCatchpointProgressLine(0, 0, 0)
+
 	reader := bytes.NewReader(fileBytes)
 	tarReader := tar.NewReader(reader)
 	var downloadProgress ledger.CatchpointCatchupAccessorProgress
@@ -119,6 +154,7 @@ func loadCatchpointIntoDatabase(ctx context.Context, catchupAccessor ledger.Catc
 		for readComplete < header.Size {
 			bytesRead, err := tarReader.Read(balancesBlockBytes[readComplete:])
 			readComplete += int64(bytesRead)
+			progress += uint64(bytesRead)
 			if err != nil {
 				if err == io.EOF {
 					if readComplete == header.Size {
@@ -137,16 +173,54 @@ func loadCatchpointIntoDatabase(ctx context.Context, catchupAccessor ledger.Catc
 			// we already know it's valid, since we validated that above.
 			protocol.Decode(balancesBlockBytes, &fileHeader)
 		}
+		if time.Now().Sub(lastProgressUpdate) > 50*time.Millisecond && len(fileBytes) > 0 {
+			lastProgressUpdate = time.Now()
+			printLoadCatchpointProgressLine(int(float64(progress)*50.0/float64(len(fileBytes))), 50, int64(progress))
+		}
 	}
 }
 
+func printDumpingCatchpointProgressLine(progress int, barLength int, dld int64) {
+	const (
+		CUU    = string("\033[A") // Cursor Up
+		DL     = string("\033[M") // Delete Line
+		SQUARE = string("▪")
+		DOT    = string("·")
+	)
+	if barLength == 0 {
+		fmt.Printf(CUU + DL + "[ Done ] Dumped\n")
+		return
+	}
+
+	outString := "["
+	for i := 0; i < barLength; i++ {
+		if i < progress {
+			outString += SQUARE
+		} else {
+			outString += DOT
+		}
+	}
+	outString += "] Dumping..."
+	if dld > 0 {
+		outString = fmt.Sprintf(outString+" %d", dld)
+	}
+	fmt.Printf(CUU + DL + outString + "\n")
+}
+
 func printAccountsDatabase(databaseName string, fileHeader ledger.CatchpointFileHeader, outFile *os.File) error {
+	lastProgressUpdate := time.Now()
+	progress := uint64(0)
+	defer printDumpingCatchpointProgressLine(0, 0, 0)
+
+	fileWriter := bufio.NewWriterSize(outFile, 1024*1024)
+	defer fileWriter.Flush()
+
 	dbAccessor, err := db.MakeAccessor(databaseName, true, false)
 	if err != nil || dbAccessor.Handle == nil {
 		return err
 	}
 	if fileHeader.Version != 0 {
-		fmt.Fprintf(outFile, "Version: %d\nBalances Round: %d\nBlock Round: %d\nBlock Header Digest: %s\nCatchpoint: %s\nTotal Accounts: %d\nTotal Chunks: %d\n",
+		fmt.Fprintf(fileWriter, "Version: %d\nBalances Round: %d\nBlock Round: %d\nBlock Header Digest: %s\nCatchpoint: %s\nTotal Accounts: %d\nTotal Chunks: %d\n",
 			fileHeader.Version,
 			fileHeader.BalancesRound,
 			fileHeader.BlocksRound,
@@ -156,13 +230,16 @@ func printAccountsDatabase(databaseName string, fileHeader ledger.CatchpointFile
 			fileHeader.TotalChunks)
 
 		totals := fileHeader.Totals
-		fmt.Fprintf(outFile, "AccountTotals - Online Money: %d\nAccountTotals - Online RewardUnits : %d\nAccountTotals - Offline Money: %d\nAccountTotals - Offline RewardUnits : %d\nAccountTotals - Not Participating Money: %d\nAccountTotals - Not Participating Money RewardUnits: %d\nAccountTotals - Rewards Level: %d\n",
+		fmt.Fprintf(fileWriter, "AccountTotals - Online Money: %d\nAccountTotals - Online RewardUnits : %d\nAccountTotals - Offline Money: %d\nAccountTotals - Offline RewardUnits : %d\nAccountTotals - Not Participating Money: %d\nAccountTotals - Not Participating Money RewardUnits: %d\nAccountTotals - Rewards Level: %d\n",
 			totals.Online.Money.Raw, totals.Online.RewardUnits,
 			totals.Offline.Money.Raw, totals.Offline.RewardUnits,
 			totals.NotParticipating.Money.Raw, totals.NotParticipating.RewardUnits,
 			totals.RewardsLevel)
 	}
 	return dbAccessor.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
+		fmt.Printf("\n")
+		printDumpingCatchpointProgressLine(0, 50, 0)
+
 		if fileHeader.Version == 0 {
 			var totals ledger.AccountTotals
 			id := ""
@@ -174,7 +251,7 @@ func printAccountsDatabase(databaseName string, fileHeader ledger.CatchpointFile
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(outFile, "AccountTotals - Online Money: %d\nAccountTotals - Online RewardUnits : %d\nAccountTotals - Offline Money: %d\nAccountTotals - Offline RewardUnits : %d\nAccountTotals - Not Participating Money: %d\nAccountTotals - Not Participating Money RewardUnits: %d\nAccountTotals - Rewards Level: %d\n",
+			fmt.Fprintf(fileWriter, "AccountTotals - Online Money: %d\nAccountTotals - Online RewardUnits : %d\nAccountTotals - Offline Money: %d\nAccountTotals - Offline RewardUnits : %d\nAccountTotals - Not Participating Money: %d\nAccountTotals - Not Participating Money RewardUnits: %d\nAccountTotals - Rewards Level: %d\n",
 				totals.Online.Money.Raw, totals.Online.RewardUnits,
 				totals.Offline.Money.Raw, totals.Offline.RewardUnits,
 				totals.NotParticipating.Money.Raw, totals.NotParticipating.RewardUnits,
@@ -185,6 +262,13 @@ func printAccountsDatabase(databaseName string, fileHeader ledger.CatchpointFile
 		if fileHeader.Version != 0 {
 			balancesTable = "catchpointbalances"
 		}
+
+		var rowsCount int64
+		err = tx.QueryRow(fmt.Sprintf("SELECT count(*) from %s", balancesTable)).Scan(&rowsCount)
+		if err != nil {
+			return
+		}
+
 		rows, err := tx.Query(fmt.Sprintf("SELECT address, data FROM %s order by address", balancesTable))
 		if err != nil {
 			return
@@ -216,10 +300,18 @@ func printAccountsDatabase(databaseName string, fileHeader ledger.CatchpointFile
 				return err
 			}
 
-			fmt.Fprintf(outFile, "%v : %s\n", addr, string(jsonData))
+			fmt.Fprintf(fileWriter, "%v : %s\n", addr, string(jsonData))
+
+			if time.Now().Sub(lastProgressUpdate) > 50*time.Millisecond && rowsCount > 0 {
+				lastProgressUpdate = time.Now()
+				printDumpingCatchpointProgressLine(int(float64(progress)*50.0/float64(rowsCount)), 50, int64(progress))
+			}
+			progress++
 		}
 
 		err = rows.Err()
+		// increase the deadline warning to disable the warning message.
+		db.ResetTransactionWarnDeadline(ctx, tx, time.Now().Add(5*time.Second))
 		return nil
 	})
 }

--- a/cmd/catchpointdump/net.go
+++ b/cmd/catchpointdump/net.go
@@ -40,6 +40,13 @@ var networkName string
 var round int
 var relayAddress string
 
+const (
+	escapeCursorUp   = string("\033[A") // Cursor Up
+	escapeDeleteLine = string("\033[M") // Delete Line
+	escapeSquare     = string("▪")
+	escapeDot        = string("·")
+)
+
 func init() {
 	netCmd.Flags().StringVarP(&networkName, "net", "n", "", "Specify the network name ( i.e. mainnet.algorand.network )")
 	netCmd.Flags().IntVarP(&round, "round", "r", 0, "Specify the round number ( i.e. 7700000 )")
@@ -104,14 +111,8 @@ func formatSize(dld int64) string {
 }
 
 func printDownloadProgressLine(progress int, barLength int, url string, dld int64) {
-	const (
-		CUU    = string("\033[A") // Cursor Up
-		DL     = string("\033[M") // Delete Line
-		SQUARE = string("▪")
-		DOT    = string("·")
-	)
 	if barLength == 0 {
-		fmt.Printf(CUU+DL+"[ Done ] Downloaded %s\n", url)
+		fmt.Printf(escapeCursorUp+escapeDeleteLine+"[ Done ] Downloaded %s\n", url)
 		return
 	}
 	if progress >= barLength {
@@ -124,22 +125,22 @@ func printDownloadProgressLine(progress int, barLength int, url string, dld int6
 	if start < end {
 		for i := 0; i < barLength; i++ {
 			if i < start || i > end {
-				outString += SQUARE
+				outString += escapeSquare
 			} else {
-				outString += DOT
+				outString += escapeDot
 			}
 		}
 	} else {
 		for i := 0; i < barLength; i++ {
 			if i > start || i < end {
-				outString += DOT
+				outString += escapeDot
 			} else {
-				outString += SQUARE
+				outString += escapeSquare
 			}
 		}
 	}
 	outString += "] Downloading " + url + " ..."
-	fmt.Printf(CUU+DL+outString+" %s\n", formatSize(dld))
+	fmt.Printf(escapeCursorUp+escapeDeleteLine+outString+" %s\n", formatSize(dld))
 }
 
 func downloadCatchpoint(addr string) ([]byte, error) {
@@ -210,27 +211,14 @@ func downloadCatchpoint(addr string) ([]byte, error) {
 }
 
 func printSaveProgressLine(progress int, barLength int, filename string, dld int64) {
-	const (
-		CUU    = string("\033[A") // Cursor Up
-		DL     = string("\033[M") // Delete Line
-		SQUARE = string("▪")
-		DOT    = string("·")
-	)
 	if barLength == 0 {
-		fmt.Printf(CUU+DL+"[ Done ] Saved %s\n", filename)
+		fmt.Printf(escapeCursorUp+escapeDeleteLine+"[ Done ] Saved %s\n", filename)
 		return
 	}
 
-	outString := "["
-	for i := 0; i < barLength; i++ {
-		if i < progress {
-			outString += SQUARE
-		} else {
-			outString += DOT
-		}
-	}
-	outString += "] Saving " + filename + " ..."
-	fmt.Printf(CUU+DL+outString+" %s\n", formatSize(dld))
+	outString := "[" + strings.Repeat(escapeSquare, progress) + strings.Repeat(escapeDot, barLength-progress) + "] Saving " + filename + " ..."
+
+	fmt.Printf(escapeCursorUp+escapeDeleteLine+outString+" %s\n", formatSize(dld))
 }
 
 func saveCatchpointTarFile(addr string, catchpointFileBytes []byte) (err error) {

--- a/util/watchdogStreamReader.go
+++ b/util/watchdogStreamReader.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
 
-package catchup
+package util
 
 import (
 	"fmt"
@@ -56,8 +56,15 @@ type watchdogStreamReader struct {
 	readerCond    *sync.Cond     // conditional check variable for the reader goroutine
 }
 
-// makeWatchdogStreamReader creates a watchdogStreamReader and initializes it.
-func makeWatchdogStreamReader(underlayingReader io.Reader, readSize uint64, readaheadSize uint64, readaheadDuration time.Duration) *watchdogStreamReader {
+// WatchdogStreamReader is the public interface for the watchdogStreamReader implementation.
+type WatchdogStreamReader interface {
+	Reset() error
+	Read(p []byte) (n int, err error)
+	Close()
+}
+
+// MakeWatchdogStreamReader creates a watchdogStreamReader and initializes it.
+func MakeWatchdogStreamReader(underlayingReader io.Reader, readSize uint64, readaheadSize uint64, readaheadDuration time.Duration) WatchdogStreamReader {
 	reader := &watchdogStreamReader{
 		underlayingReader: underlayingReader,
 		readerClose:       make(chan struct{}, 1),


### PR DESCRIPTION
## Summary

*  Update catchpointdump utility to have progress bars, which makes it more user friendly.

```
[ Done ] Downloaded http://r-sn.algorand-mainnet.network:4160/v1/mainnet-v1.0/ledger/5yc1s
[ Done ] Saved ./mainnet/r-sn/10000000.tar
[ Done ] Loaded
[ Done ] Dumped
[········▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪················] Downloading http://r-zn.algorand-mainnet.network:4160/v1/mainnet-v1.0/ledger/5yc1s ... 409 MB
```

*  Delete temporary ledger database files before and after use to ensure no leftovers from previous iterations.
*  Fix long database atomic operation warning message.

## Test Plan

Tested manually.

## Notes

Moved the `WatchdogStreamReader` from `catchup` package to the `util` package.