### PR TITLE
bugfix: Network peers list memory leak

### DIFF
--- a/network/peersheap.go
+++ b/network/peersheap.go
@@ -33,6 +33,7 @@ func (ph peersHeap) Pop() interface{} {
 	wn := ph.wn
 	end := len(wn.peers) - 1
 	p := wn.peers[end]
+	wn.peers[end] = nil // remove the entry from the peers list, so that the GC can recycle it's memory as needed.
 	wn.peers = wn.peers[:end]
 	return p
 }


### PR DESCRIPTION
## Summary

Removing the wsPeer object pointer from the peers list would allow it to be recycled.

The original code was creating a sub-slice and not removing the entry from the underlying array.
Since the peer was left on the underlying array, it would not get GC'ed.

## Test Plan

Existing tests confirms correct behavior.