### PR TITLE
Add BenchmarkVariableTransactionMessageBlockSizes

### DIFF
--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -724,8 +724,10 @@ func (wn *WebsocketNetwork) Start() {
 		wn.wg.Add(1)
 		go wn.broadcastThread()
 	}
-	wn.wg.Add(1)
-	go wn.prioWeightRefresh()
+	if wn.prioScheme != nil {
+		wn.wg.Add(1)
+		go wn.prioWeightRefresh()
+	}
 	wn.log.Infof("serving genesisID=%s on %#v with RandomID=%s", wn.GenesisID, wn.PublicAddress(), wn.RandomID)
 }
 


### PR DESCRIPTION
## Summary

Add a benchmark to test the performance of a local client->server transaction communication.
Benchmark results:

| Transactions Per Message  | Rate |
| ------------- | ------------- |
| 1  | 15,615 txn/sec |
| 2  | 29,868 txn/sec |
| 3 | 37,998 txn/sec|
| 4 |39,873 txn/sec |
| 5 |49,403 txn/sec |
| 6 | 53,004 txn/sec|
| 7 | 50,405 txn/sec|
| 9 | 56,094 txn/sec|
| 10 | 60,297 txn/sec|
| 12 | 63,149 txn/sec|
| 14 | 65,401 txn/sec|
| 16 |66,755 txn/sec |
| 18 | 65,710 txn/sec|
| 23 | 60,318 txn/sec|
| 29 |63,359 txn/sec |

Running parameters-
1. Transaction size 250 bytes
2. Transaction processing delay 10,000ns
  This delays should impose a theoretical limit of 100,000 txn/sec.

## Test Plan

Benchmark is a test.