### PR TITLE
Improve agreement cadaver & crash database error handling

### DIFF
--- a/agreement/cadaver.go
+++ b/agreement/cadaver.go
@@ -68,9 +68,14 @@ func (c *cadaver) filename() string {
 }
 
 func (c *cadaver) init() (err error) {
-	f, err := os.OpenFile(c.filename(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	f, err := os.OpenFile(c.filename(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return fmt.Errorf("cadaver: failed to create file %v: %v", c.filename(), err)
+	}
+
+	err = f.Chmod(0666)
+	if err != nil {
+		return err
 	}
 
 	c.out, err = makeCadaverHandle(f)
@@ -116,8 +121,11 @@ func (c *cadaver) trySetup() bool {
 	}
 
 	if c.out.bytesWritten >= c.fileSizeTarget {
-		c.out.Close()
-		err := os.Rename(c.filename(), c.filename()+".archive")
+		err := c.out.Close()
+		if err != nil {
+			logging.Base().Warn("unable to close cadaver file : %v", err)
+		}
+		err = os.Rename(c.filename(), c.filename()+".archive")
 		if err != nil {
 			if os.IsNotExist(err) {
 				// we can't rename the cadaver file since it doesn't exists.

--- a/agreement/persistence.go
+++ b/agreement/persistence.go
@@ -19,6 +19,7 @@ package agreement
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -87,21 +88,23 @@ func persist(log serviceLogger, crash db.Accessor, Round basics.Round, Period pe
 
 // reset deletes the existing recovery state from database.
 //
-// It returns whether the delete operation was successfull or not.
-func reset(log logging.Logger, crash db.Accessor) (err error) {
+// In case it's unable to clear the Service table, an error would get logged.
+func reset(log logging.Logger, crash db.Accessor) {
 	logging.Base().Infof("reset (agreement): resetting crash state")
 
-	err = crash.Atomic(func(ctx context.Context, tx *sql.Tx) (res error) {
+	err := crash.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
 		// we could not retrieve our state, so wipe it
-		_, err := tx.Exec("delete from Service")
-		if err != nil {
-			res = fmt.Errorf("reset (agreement): failed to clear Service table")
-			return
-		}
-		return nil
+		_, err = tx.Exec("delete from Service")
+		return
 	})
-	return err
+
+	if err != nil {
+		logging.Base().Warnf("reset (agreement): failed to clear Service table - %v", err)
+	}
 }
+
+// errNoCrashStateAvailable returned by restore when the crash recovery state is not available in the crash recovery database table.
+var errNoCrashStateAvailable = errors.New("restore (agreement): no crash state available")
 
 // restore reads state from a crash database. It does not attempt to parse the encoded data.
 //
@@ -114,9 +117,17 @@ func restore(log logging.Logger, crash db.Accessor) (raw []byte, err error) {
 		}
 	}()
 
-	crash.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+	err = crash.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 		return agreeInstallDatabase(tx)
-	}) // ignore error
+	})
+
+	if err == nil {
+		// the above call was completed sucecssfully, which means that we've just created the table ( which wasn't there ! ).
+		// in that case, the table is guaranteed to be empty, and therefore we can return right here.
+		logging.Base().Infof("restore (agreement): crash state table initialized")
+		err = errNoCrashStateAvailable
+		return
+	}
 
 	err = crash.Atomic(func(ctx context.Context, tx *sql.Tx) (res error) {
 		var reset bool
@@ -143,10 +154,10 @@ func restore(log logging.Logger, crash db.Accessor) (raw []byte, err error) {
 			return err
 		}
 		if nrows != 1 {
-			logging.Base().Infof("restore (agreement): crash state not found (n = %v)", nrows)
+			logging.Base().Infof("restore (agreement): crash state not found (n = %d)", nrows)
 			reset = true
 			noCrashState = true // this is a normal case (we have leftover crash state from an old round)
-			return fmt.Errorf("restore (agreement): crash state not found (n = %v)", nrows)
+			return errNoCrashStateAvailable
 		}
 
 		row = tx.QueryRow("select data from Service")


### PR DESCRIPTION
## Summary

This PR contains few changes to improve error handling and file permissions -
1. cadaver file now being created with 0600 instead of 0666 and being modified to 0666 after creation. This allow us to make this modification symmetrically if the file is opened for appending, which ensures that when we attempt to rename the file to ".archive" the file always has the 0666 permission.
2. add handling for failure to close the cadaver file.
3. modify the reset() function so that it would log the error, in case it encountered any.
4. modify the restore() function to review the returned error code from agreeInstallDatabase and take advantage of the result.

