### PR TITLE
Improve node error code checking

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -182,11 +182,9 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 
 	// create initial ledger, if it doesn't exist
 	err = os.Mkdir(genesisDir, 0700)
-	if err != nil {
-		if !os.IsExist(err) {
-			log.Errorf("Unable to create genesis directroy: %v", err)
-			return nil, err
-		}
+	if err != nil && !os.IsExist(err) {
+		log.Errorf("Unable to create genesis directroy: %v", err)
+		return nil, err
 	}
 	var genalloc data.GenesisBalances
 	genalloc, err = bootstrapData(genesis, log)

--- a/node/node.go
+++ b/node/node.go
@@ -181,7 +181,13 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 	ledgerPathnamePrefix := filepath.Join(genesisDir, config.LedgerFilenamePrefix)
 
 	// create initial ledger, if it doesn't exist
-	os.Mkdir(genesisDir, 0700)
+	err = os.Mkdir(genesisDir, 0700)
+	if err != nil {
+		if !os.IsExist(err) {
+			log.Errorf("Unable to create genesis directroy: %v", err)
+			return nil, err
+		}
+	}
 	var genalloc data.GenesisBalances
 	genalloc, err = bootstrapData(genesis, log)
 	if err != nil {
@@ -687,7 +693,10 @@ func (node *AlgorandFullNode) checkForParticipationKeys() {
 	for {
 		select {
 		case <-ticker.C:
-			node.loadParticipationKeys()
+			err := node.loadParticipationKeys()
+			if err != nil {
+				node.log.Error("Could not refresh participation keys: %v", err)
+			}
 		case <-node.ctx.Done():
 			ticker.Stop()
 			return
@@ -723,11 +732,13 @@ func (node *AlgorandFullNode) loadParticipationKeys() error {
 			handle.Close()
 			if err == account.ErrUnsupportedSchema {
 				node.log.Infof("Loaded participation keys from storage: %s %s", part.Address(), info.Name())
-				msg := fmt.Sprintf("loadParticipationKeys: not loading unsupported participation key: %v; renaming to *.old", info.Name())
-				fmt.Println(msg)
-				node.log.Warn(msg)
+				node.log.Warn("loadParticipationKeys: not loading unsupported participation key: %s; renaming to *.old", info.Name())
 				fullname := filepath.Join(genesisDir, info.Name())
-				os.Rename(fullname, filepath.Join(fullname, ".old"))
+				renamedFileName := filepath.Join(fullname, ".old")
+				err = os.Rename(fullname, renamedFileName)
+				if err != nil {
+					node.log.Warn("loadParticipationKeys: failed to rename unsupported participation key file '%s' to '%s': %v", fullname, renamedFileName, err)
+				}
 			} else {
 				return fmt.Errorf("AlgorandFullNode.loadParticipationKeys: cannot load account at %v: %v", info.Name(), err)
 			}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -459,3 +459,40 @@ func TestStatusReport_TimeSinceLastRound(t *testing.T) {
 		})
 	}
 }
+
+type mismatchingDirectroyPermissionsLog struct {
+	logging.Logger
+	t *testing.T
+}
+
+func (m mismatchingDirectroyPermissionsLog) Errorf(fmts string, args ...interface{}) {
+	fmtStr := fmt.Sprintf(fmts, args...)
+	require.Contains(m.t, fmtStr, "Unable to create genesis directroy")
+}
+
+// TestMismatchingGenesisDirectoryPermissions tests to see that the os.MkDir check we have in MakeFull works as expected. It tests both the return error as well as the logged error.
+func TestMismatchingGenesisDirectoryPermissions(t *testing.T) {
+	testDirectroy, err := ioutil.TempDir(os.TempDir(), t.Name())
+	require.NoError(t, err)
+
+	genesis := bookkeeping.Genesis{
+		SchemaID:    "go-test-node-genesis",
+		Proto:       protocol.ConsensusCurrentVersion,
+		Network:     config.Devtestnet,
+		FeeSink:     sinkAddr.String(),
+		RewardsPool: poolAddr.String(),
+	}
+
+	log := mismatchingDirectroyPermissionsLog{logging.TestingLog(t), t}
+
+	require.NoError(t, os.Chmod(testDirectroy, 0200))
+
+	node, err := MakeFull(log, testDirectroy, config.GetDefaultLocal(), []string{}, genesis)
+
+	require.Nil(t, node)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "permission denied")
+
+	require.NoError(t, os.Chmod(testDirectroy, 1700))
+	require.NoError(t, os.RemoveAll(testDirectroy))
+}


### PR DESCRIPTION
## Summary

This PR handles the following missing error code checking:
1. Add a test to verify the error in the creation of the genesis directory.
2. Add logging in case `node.loadParticipationKeys` returns an error
3. Add logging in case `os.Rename` has failed.
4. Remove `fmt.Println(msg)`, as the node reporting output is the log file, and not the console.
