### PR TITLE
Add teal converter

### DIFF
--- a/tools/teal/converter/converter.go
+++ b/tools/teal/converter/converter.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2019-2020 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package converter


### PR DESCRIPTION
## Summary
This PR is a follow up to my previous PR https://github.com/algorand/go-algorand/pull/1763. As I mentioned in that PR the current approach for storing state of smart contracts has several problems. On the other hand, changing the memory architecture of TEAL is not easy and it will take some time. While this development is in progress addition of new smart contracts can not be stopped. These new contracts will use current inefficient approach for storing their state and the data they save can not be changed and optimized later.

Therefore, I recommend changing TEAL to a newer version **as soon as possible**. The new version should use an efficient array-style memory model. Fortunately, **applying this change does not require any change in the code-base. All scripts written in new TEAL can be safely converted to the current version of TEAL.** Because The current version of TEAL uses a more general memory model the conversion can be done safely and algorithmically. 

For example, in the new version of TEAL we may want to change `app_global_get` opcode to something like this:
```
app_global_get
    Opcode: 0x64 {uint8 position in global static memory space to load from}
    Pops: None
    Pushes: any
    LogicSigVersion >= 3
    Mode: Application
```
This instruction can safely be converted to two TEALv2 instructions:
```
app_global_get 12 -----> byte "12"
                         app_global_get
```

After introduction of the new TEAL the installation of TEALv2 contracts should be disallowed. Later, when the support for new memory model is added to the code-base the stored state of contracts that are written in the new TEAL can be safely converted and optimized to new array-style memory model.