### PR TITLE
bugfix: clear roundDigest when fast catchup is switching off

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -984,6 +984,7 @@ func (au *accountUpdates) initializeFromDisk(l ledgerForTracker) (lastBalancesRo
 	au.accounts = make(map[basics.Address]modifiedAccount)
 	au.creatables = make(map[basics.CreatableIndex]modifiedCreatable)
 	au.deltasAccum = []int{0}
+	au.roundDigest = nil
 
 	au.catchpointWriting = 0
 	// keep these channel closed if we're not generating catchpoint

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -59,8 +59,8 @@ func makeMockLedgerForTracker(t testing.TB, inMemory bool) *mockLedgerForTracker
 	return &mockLedgerForTracker{dbs: dbs, log: dblogger, filename: fileName, inMemory: inMemory}
 }
 
-// Fork creates another database which has the same content as the current one. Works only for non-memory databases.
-func (ml *mockLedgerForTracker) Fork(t testing.TB) *mockLedgerForTracker {
+// fork creates another database which has the same content as the current one. Works only for non-memory databases.
+func (ml *mockLedgerForTracker) fork(t testing.TB) *mockLedgerForTracker {
 	if ml.inMemory {
 		return nil
 	}
@@ -118,13 +118,13 @@ func (ml *mockLedgerForTracker) addMockBlock(be blockEntry, delta StateDelta) er
 }
 
 func (ml *mockLedgerForTracker) trackerEvalVerified(blk bookkeeping.Block, accUpdatesLedger ledgerForEvaluator) (StateDelta, error) {
+	// support returning the deltas if the client explicitly provided them by calling addMockBlock
 	if len(ml.deltas) > int(blk.Round()) {
 		return ml.deltas[uint64(blk.Round())], nil
-	} else {
-		return StateDelta{
-			hdr: &bookkeeping.BlockHeader{},
-		}, nil
 	}
+	return StateDelta{
+		hdr: &bookkeeping.BlockHeader{},
+	}, nil
 }
 
 func (ml *mockLedgerForTracker) Block(rnd basics.Round) (bookkeeping.Block, error) {
@@ -1476,7 +1476,7 @@ func TestReproducibleCatchpointLabels(t *testing.T) {
 		if uint64(i)%cfg.CatchpointInterval == 0 {
 			au.waitAccountsWriting()
 			catchpointLabels[i] = au.GetLastCatchpointLabel()
-			ledgerHistory[i] = ml.Fork(t)
+			ledgerHistory[i] = ml.fork(t)
 			defer ledgerHistory[i].close()
 		}
 	}

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1487,7 +1487,9 @@ func TestReproducibleCatchpointLabels(t *testing.T) {
 	}
 
 	// test in revese what happens when we try to repeat the exact same blocks.
-	for startingRound := basics.Round((testCatchpointLabelsCount - 1) * cfg.CatchpointInterval); startingRound > basics.Round(cfg.CatchpointInterval); startingRound -= basics.Round(cfg.CatchpointInterval) {
+	// start off with the catchpoint before the last one
+	startingRound := basics.Round((testCatchpointLabelsCount - 1) * cfg.CatchpointInterval)
+	for ; startingRound > basics.Round(cfg.CatchpointInterval); startingRound -= basics.Round(cfg.CatchpointInterval) {
 		au.close()
 		err := au.loadFromDisk(ledgerHistory[startingRound])
 		require.NoError(t, err)

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -137,9 +137,8 @@ func TestBasicCatchpointWriter(t *testing.T) {
 		os.RemoveAll(temporaryDirectroy)
 	}()
 
-	ml := makeMockLedgerForTracker(t, true)
+	ml := makeMockLedgerForTracker(t, true, 10, testProtocolVersion)
 	defer ml.close()
-	ml.blocks = randomInitChain(testProtocolVersion, 10)
 	accts := randomAccounts(300, false)
 
 	au := &accountUpdates{}
@@ -236,9 +235,8 @@ func TestFullCatchpointWriter(t *testing.T) {
 		os.RemoveAll(temporaryDirectroy)
 	}()
 
-	ml := makeMockLedgerForTracker(t, true)
+	ml := makeMockLedgerForTracker(t, true, 10, testProtocolVersion)
 	defer ml.close()
-	ml.blocks = randomInitChain(testProtocolVersion, 10)
 	accts := randomAccounts(BalancesPerCatchpointFileChunk*3, false)
 
 	au := &accountUpdates{}

--- a/ledger/txtail_test.go
+++ b/ledger/txtail_test.go
@@ -31,8 +31,7 @@ import (
 )
 
 func TestTxTailCheckdup(t *testing.T) {
-	ledger := makeMockLedgerForTracker(t, true)
-	ledger.blocks = randomInitChain(protocol.ConsensusCurrentVersion, 1)
+	ledger := makeMockLedgerForTracker(t, true, 1, protocol.ConsensusCurrentVersion)
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	tail := txTail{}
 	require.NoError(t, tail.loadFromDisk(ledger))


### PR DESCRIPTION
## Summary

The `roundDigest` variable in the `accountUpdates` structure was expected to be cleared out during `initializeFromDisk`, but it wasn't. As a result, a node that has caught up using the fast catchup would produce incorrect catchpoint labels.

## Test Plan

Add a unit test to verify the correctness of the fix. The unit test is far more comprehensive than required, and would detect other potential failure cases that would end up having a different catchpoint label.