### PR TITLE
Add f.Close() return code testing in SystemConfig()

### DIFF
--- a/tools/network/dnssec/config_unix.go
+++ b/tools/network/dnssec/config_unix.go
@@ -31,7 +31,8 @@ const defaultConfigFile = "/etc/resolv.conf"
 
 // SystemConfig return list of DNS servers and timeout from /etc/resolv.conf
 func SystemConfig() (servers []ResolverAddress, timeout time.Duration, err error) {
-	f, err := os.Open(defaultConfigFile)
+	var f *os.File
+	f, err = os.Open(defaultConfigFile)
 	if err != nil {
 		return
 	}

--- a/tools/network/dnssec/config_unix.go
+++ b/tools/network/dnssec/config_unix.go
@@ -32,10 +32,15 @@ const defaultConfigFile = "/etc/resolv.conf"
 // SystemConfig return list of DNS servers and timeout from /etc/resolv.conf
 func SystemConfig() (servers []ResolverAddress, timeout time.Duration, err error) {
 	f, err := os.Open(defaultConfigFile)
-	defer f.Close()
 	if err != nil {
 		return
 	}
+	defer func() {
+		localErr := f.Close()
+		if err == nil {
+			err = localErr
+		}
+	}()
 	return systemConfig(f)
 }
 


### PR DESCRIPTION
## Summary

Add f.Close() return code testing in SystemConfig()
There was a small bug there calling f.Close() on a erroneous return from os.Open ( which would have returned nil as the f )