### PR TITLE
Better missing argument error message for "goal asset destroy"

### DIFF
--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -71,14 +71,15 @@ func init() {
 	destroyAssetCmd.Flags().Uint64Var(&assetID, "assetid", 0, "Asset ID to destroy")
 	destroyAssetCmd.Flags().StringVar(&assetUnitName, "asset", "", "Unit name of asset to destroy")
 
-	configAssetCmd.Flags().StringVar(&assetManager, "manager", "", "Manager account to issue the config transaction (defaults to creator)")
-	configAssetCmd.Flags().StringVar(&assetCreator, "creator", "", "Account address for asset to configure")
+	configAssetCmd.Flags().StringVar(&assetManager, "manager", "", "Manager account to issue the config transaction")
+	configAssetCmd.Flags().StringVar(&assetCreator, "creator", "", "Account address for asset to configure (defaults to manager)")
 	configAssetCmd.Flags().Uint64Var(&assetID, "assetid", 0, "Asset ID to configure")
 	configAssetCmd.Flags().StringVar(&assetUnitName, "asset", "", "Unit name of asset to configure")
 	configAssetCmd.Flags().StringVar(&assetNewManager, "new-manager", "", "New manager address")
 	configAssetCmd.Flags().StringVar(&assetNewReserve, "new-reserve", "", "New reserve address")
 	configAssetCmd.Flags().StringVar(&assetNewFreezer, "new-freezer", "", "New freeze address")
 	configAssetCmd.Flags().StringVar(&assetNewClawback, "new-clawback", "", "New clawback address")
+	createAssetCmd.MarkFlagRequired("manager")
 
 	sendAssetCmd.Flags().StringVar(&assetClawback, "clawback", "", "Address to issue a clawback transaction from (defaults to no clawback)")
 	sendAssetCmd.Flags().StringVar(&assetCreator, "creator", "", "Account address for asset creator")
@@ -336,12 +337,8 @@ var configAssetCmd = &cobra.Command{
 		client := ensureFullClient(dataDir)
 		accountList := makeAccountsList(dataDir)
 
-		if assetManager == "" && assetCreator == "" {
-			reportErrorf("Missing required parameter [--manager] or [--creator]")
-		}
-
-		if assetManager == "" {
-			assetManager = assetCreator
+		if assetCreator == "" {
+			assetCreator = assetManager
 		}
 
 		creator := accountList.getAddressByName(assetCreator)

--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -79,7 +79,7 @@ func init() {
 	configAssetCmd.Flags().StringVar(&assetNewReserve, "new-reserve", "", "New reserve address")
 	configAssetCmd.Flags().StringVar(&assetNewFreezer, "new-freezer", "", "New freeze address")
 	configAssetCmd.Flags().StringVar(&assetNewClawback, "new-clawback", "", "New clawback address")
-	createAssetCmd.MarkFlagRequired("manager")
+	configAssetCmd.MarkFlagRequired("manager")
 
 	sendAssetCmd.Flags().StringVar(&assetClawback, "clawback", "", "Address to issue a clawback transaction from (defaults to no clawback)")
 	sendAssetCmd.Flags().StringVar(&assetCreator, "creator", "", "Account address for asset creator")

--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -79,7 +79,6 @@ func init() {
 	configAssetCmd.Flags().StringVar(&assetNewReserve, "new-reserve", "", "New reserve address")
 	configAssetCmd.Flags().StringVar(&assetNewFreezer, "new-freezer", "", "New freeze address")
 	configAssetCmd.Flags().StringVar(&assetNewClawback, "new-clawback", "", "New clawback address")
-	configAssetCmd.MarkFlagRequired("manager")
 
 	sendAssetCmd.Flags().StringVar(&assetClawback, "clawback", "", "Address to issue a clawback transaction from (defaults to no clawback)")
 	sendAssetCmd.Flags().StringVar(&assetCreator, "creator", "", "Account address for asset creator")
@@ -145,7 +144,7 @@ func lookupAssetID(cmd *cobra.Command, creator string, client libgoal.Client) {
 	}
 
 	if !assetOrUnit {
-		reportErrorf("Either [--assetid] or [--unitname and --creator] must be specified")
+		reportErrorf("Missing required parameter [--assetid] or [--unitname and --creator] must be specified")
 	}
 
 	if !cmd.Flags().Changed("creator") {
@@ -265,6 +264,10 @@ var destroyAssetCmd = &cobra.Command{
 		client := ensureFullClient(dataDir)
 		accountList := makeAccountsList(dataDir)
 
+		if assetManager == "" && assetCreator == "" {
+			reportErrorf("Missing required parameter [--manager] or [--creator]")
+		}
+
 		if assetManager == "" {
 			assetManager = assetCreator
 		}
@@ -332,6 +335,10 @@ var configAssetCmd = &cobra.Command{
 		dataDir := ensureSingleDataDir()
 		client := ensureFullClient(dataDir)
 		accountList := makeAccountsList(dataDir)
+
+		if assetManager == "" && assetCreator == "" {
+			reportErrorf("Missing required parameter [--manager] or [--creator]")
+		}
 
 		if assetManager == "" {
 			assetManager = assetCreator


### PR DESCRIPTION
before:
```
$ goal asset destroy --assetid 0
Cannot construct transaction: decoded bad addr:
```

after:
```
$ goal asset destroy --assetid 0
Missing required parameter [--manager] or [--creator]
```