### PR TITLE
Fix deprication warning on sortition compilation

### DIFF
--- a/data/committee/sortition/sortition.go
+++ b/data/committee/sortition/sortition.go
@@ -17,6 +17,7 @@
 package sortition
 
 // #cgo CFLAGS: -O3
+// #cgo CXXFLAGS: -std=c++11
 // #include <stdint.h>
 // #include <stdlib.h>
 // #include "sortition.h"


### PR DESCRIPTION
## Summary

Boost complains about non c++11 compiler, so make it happy.

## Test Plan

Use existing test suite