### PR TITLE
Remove check_golang_version check when deploying in travis

### DIFF
--- a/scripts/travis/deploy_packages.sh
+++ b/scripts/travis/deploy_packages.sh
@@ -12,10 +12,6 @@ set -e
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-if ! "${SCRIPTPATH}/../check_golang_version.sh"
-then
-    exit 1
-fi
 # Get the go build version.
 GOLANG_VERSION=$("${SCRIPTPATH}/../get_golang_version.sh")
 

--- a/scripts/travis/deploy_packages.sh
+++ b/scripts/travis/deploy_packages.sh
@@ -19,6 +19,11 @@ curl -sL -o ~/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gim
 chmod +x ~/gimme
 eval "$(~/gimme "${GOLANG_VERSION}")"
 
+if ! "${SCRIPTPATH}/../check_golang_version.sh"
+then
+    exit 1
+fi
+
 scripts/travis/build.sh
 
 export RELEASE_GENESIS_PROCESS=true


### PR DESCRIPTION
## Summary

The call to `check_golang_version.sh` is causing the travis run to fail when deploying:
https://travis-ci.com/github/algorand/go-algorand/jobs/470973034#L142

I believe that removing this check is safe.  We're installing the version of go that may be needed immediately after this check using `gimme`, so any subsequent operations will be sure to succeed because it will be installing the build version (1.14.7).

Also, the `check_golang_version` script is intended as a safeguard for dev and building and I don't believe is needed in this deploy script.

## Test Plan

Hope and pray.
