### PR TITLE
Improve TestAccountsCanSendMoney e2e test

### DIFF
--- a/test/e2e-go/features/transactions/sendReceive_test.go
+++ b/test/e2e-go/features/transactions/sendReceive_test.go
@@ -105,7 +105,7 @@ func testAccountsCanSendMoney(t *testing.T, templatePath string, numberOfSends i
 	curRound := curStatus.LastRound
 
 	fixture.AlgodClient = fixture.GetAlgodClientForController(fixture.GetNodeControllerForDataDir(pongClient.DataDir()))
-	fixture.WaitForAllTxnsToConfirm(curRound+uint64(1), pingTxidsToAddresses)
+	fixture.WaitForAllTxnsToConfirm(curRound+uint64(5), pingTxidsToAddresses)
 
 	pingBalance, _ = fixture.GetBalanceAndRound(pingAccount)
 	pongBalance, _ = fixture.GetBalanceAndRound(pongAccount)
@@ -113,7 +113,7 @@ func testAccountsCanSendMoney(t *testing.T, templatePath string, numberOfSends i
 	a.True(expectedPongBalance <= pongBalance, "pong balance is different than expected.")
 
 	fixture.AlgodClient = fixture.GetAlgodClientForController(fixture.GetNodeControllerForDataDir(pingClient.DataDir()))
-	fixture.WaitForAllTxnsToConfirm(curRound+uint64(1), pongTxidsToAddresses)
+	fixture.WaitForAllTxnsToConfirm(curRound+uint64(5), pongTxidsToAddresses)
 
 	pingBalance, _ = fixture.GetBalanceAndRound(pingAccount)
 	pongBalance, _ = fixture.GetBalanceAndRound(pongAccount)


### PR DESCRIPTION
## Summary

The existing TestAccountsCanSendMoney had three issues -
1. Testing ping ponging algos over 225 rounds is logically correct, but not very useful. If there is an issue, it would likely to show up within 25 rounds.
2. The test was not testing the transactions were received on both clients.
3. The test was not testing the pingBalance/pongBalance on both clients.

## Test Plan

This is a test