### PR TITLE
Increase pending proposals queue

### DIFF
--- a/agreement/gossip/network.go
+++ b/agreement/gossip/network.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	voteBufferSize     = 10000
-	proposalBufferSize = 5
+	proposalBufferSize = 2
 	bundleBufferSize   = 7
 )
 

--- a/agreement/gossip/network.go
+++ b/agreement/gossip/network.go
@@ -32,12 +32,22 @@ import (
 
 var (
 	voteBufferSize     = 10000
-	proposalBufferSize = 14
+	proposalBufferSize = 5
 	bundleBufferSize   = 7
 )
 
 var messagesHandled = metrics.MakeCounter(metrics.AgreementMessagesHandled)
 var messagesDropped = metrics.MakeCounter(metrics.AgreementMessagesDropped)
+
+var agreementVoteMessage = map[string]string{
+	"message_type": "vote",
+}
+var agreementProposalMessage = map[string]string{
+	"message_type": "proposal",
+}
+var agreementBundleMessage = map[string]string{
+	"message_type": "bundle",
+}
 
 type messageMetadata struct {
 	raw network.IncomingMessage
@@ -92,22 +102,22 @@ func messageMetadataFromHandle(h agreement.MessageHandle) *messageMetadata {
 }
 
 func (i *networkImpl) processVoteMessage(raw network.IncomingMessage) network.OutgoingMessage {
-	return i.processMessage(raw, i.voteCh)
+	return i.processMessage(raw, i.voteCh, agreementVoteMessage)
 }
 
 func (i *networkImpl) processProposalMessage(raw network.IncomingMessage) network.OutgoingMessage {
 	if i.trace != nil {
 		i.trace.HashTrace(messagetracer.Proposal, raw.Data)
 	}
-	return i.processMessage(raw, i.proposalCh)
+	return i.processMessage(raw, i.proposalCh, agreementProposalMessage)
 }
 
 func (i *networkImpl) processBundleMessage(raw network.IncomingMessage) network.OutgoingMessage {
-	return i.processMessage(raw, i.bundleCh)
+	return i.processMessage(raw, i.bundleCh, agreementBundleMessage)
 }
 
 // i.e. process<Type>Message
-func (i *networkImpl) processMessage(raw network.IncomingMessage, submit chan<- agreement.Message) network.OutgoingMessage {
+func (i *networkImpl) processMessage(raw network.IncomingMessage, submit chan<- agreement.Message, msgType map[string]string) network.OutgoingMessage {
 	metadata := &messageMetadata{raw: raw}
 
 	select {
@@ -115,9 +125,9 @@ func (i *networkImpl) processMessage(raw network.IncomingMessage, submit chan<- 
 		// It would be slightly better to measure at de-queue
 		// time, but that happens in many places in code and
 		// this is much easier.
-		messagesHandled.Inc(nil)
+		messagesHandled.Inc(msgType)
 	default:
-		messagesDropped.Inc(nil)
+		messagesDropped.Inc(msgType)
 	}
 
 	// Immediately ignore everything here, sometimes Relay/Broadcast/Disconnect later based on API handles saved from IncomingMessage

--- a/agreement/gossip/network.go
+++ b/agreement/gossip/network.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	voteBufferSize     = 10000
-	proposalBufferSize = 2
+	proposalBufferSize = 25
 	bundleBufferSize   = 7
 )
 


### PR DESCRIPTION
## Summary

The number of proposals generated derives from the consensus params. At this time, we have (up to) 20 proposals.
In a rare network event, when all the relays connected to a given proposer are lagging behind, the winning proposal could be dropped out, causing a 21 second round.

This was verified by lowering the proposalBufferSize dramatically, confirming that the only dropped agreement messages were proposals, and that a 21 second rounds were introduced.

## Test Plan

Tested by lowering the proposalBufferSize to 2, and running a deployed network. Once every few *hours*, we would have a 21-second round.
