### PR TITLE
Support large integers in tealdbg

### DIFF
--- a/cmd/tealdbg/cdtState.go
+++ b/cmd/tealdbg/cdtState.go
@@ -330,7 +330,7 @@ func makeStringResult(value string) cdt.RuntimeRemoteObject {
 // tealTypeMap maps TealType to JS type
 var tealTypeMap = map[basics.TealType]string{
 	basics.TealBytesType: "string",
-	basics.TealUintType:  "number",
+	basics.TealUintType:  "bigint",
 }
 
 type fieldDesc struct {
@@ -403,8 +403,8 @@ func tealValueToFieldDesc(name string, tv basics.TealValue) fieldDesc {
 			}
 		}
 	} else {
-		valType = "number"
-		value = strconv.Itoa(int(tv.Uint))
+		valType = "bigint"
+		value = strconv.FormatUint(tv.Uint, 10)
 	}
 	return fieldDesc{name, value, valType}
 }

--- a/cmd/tealdbg/home.html
+++ b/cmd/tealdbg/home.html
@@ -199,7 +199,7 @@
 
                     type.innerText = values[i].tt == TealUintType ? "u": "b";
                     if (values[i].tt === TealUintType) {
-                        value.innerText = values[i].ui || 0;
+                        value.innerText = values[i].ui || "0";
                     } else {
                         value.innerText = values[i].tb || "";
                     }
@@ -313,7 +313,10 @@
             });
 
             socket.addEventListener('message', function (event) {
-                var msg = JSON.parse(event.data);
+                const preparedData = event.data.replace(/"ui": ([0-9]+)/g, function (match, value) {
+                    return '"ui": "' + value + '"'; // replace teal uint64s with strings to maintain precision
+                });
+                var msg = JSON.parse(preparedData);
 
                 if (msg["event"] !== "connected") {
                     document.getElementById("loading").style.display = "none";

--- a/cmd/tealdbg/homepage.go
+++ b/cmd/tealdbg/homepage.go
@@ -219,7 +219,7 @@ var homepage string = `
 
                     type.innerText = values[i].tt == TealUintType ? "u": "b";
                     if (values[i].tt === TealUintType) {
-                        value.innerText = values[i].ui || 0;
+                        value.innerText = values[i].ui || "0";
                     } else {
                         value.innerText = values[i].tb || "";
                     }
@@ -333,7 +333,10 @@ var homepage string = `
             });
 
             socket.addEventListener('message', function (event) {
-                var msg = JSON.parse(event.data);
+                const preparedData = event.data.replace(/"ui": ([0-9]+)/g, function (match, value) {
+                    return '"ui": "' + value + '"'; // replace teal uint64s with strings to maintain precision
+                });
+                var msg = JSON.parse(preparedData);
 
                 if (msg["event"] !== "connected") {
                     document.getElementById("loading").style.display = "none";


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

When using tealdbg to debug a program that manipulates integers larger than `2^53 - 1` (JavaScript's max safe integer), these values are unable to be displayed accurately. This affects both the Chrome DevTools and the web frontends.

Given this example program, below are images of the current behavior on both frontends:
```
#pragma version 2
int 0xFFFFFFFFFFFFFFFF
dup
store 0
int 0xFFFFFFFFFFFFFFFE
dup
store 1
-
```

<details>
<summary>Chrome current behavior (values turned negative)</summary>
<img src="https://user-images.githubusercontent.com/5856867/104653722-0b002800-5689-11eb-9c12-4f11c65021c6.png">
</details>

<details>
<summary>Web current behavior (values lose precision)</summary>
<img src="https://user-images.githubusercontent.com/5856867/104653779-20755200-5689-11eb-9784-4fe6287f5a29.png">
</details>

### Chrome Fix
For the Chrome frontend, I fixed this by changing the debugging object type of TEAL integers from "number" to "bigint". (Note: I didn't change every numeric type to "bigint" because some values, like array lengths, will never be large enough to surpass the maximum safe integer).

### Web Fix
The web frontend was more difficult to fix because the fundamental issue here is JavaScript's inability to parse JSON integers greater than `2^53 - 1`. A robust solution to this would be to use a library like [json-bigint](https://github.com/sidorares/json-bigint) to parse integers as BigInts (the JavaScript SDK is currently adopting this).

However, since the structure of the JSON messages the frontend receives is known in advanced, I actually fixed this by modifying the JSON message string to convert TEAL integers to strings before they are parsed. Since the integers aren't manipulated by the client, only displayed, this doesn't reduce any functionality.

After the fixes I described above, here is the behavior:

<details>
<summary>Chrome fixed behavior</summary>
<img src="https://user-images.githubusercontent.com/5856867/104653910-4f8bc380-5689-11eb-8282-243f5a9fa776.png">
</details>

<details>
<summary>Web fixed behavior</summary>
<img src="https://user-images.githubusercontent.com/5856867/104653922-53b7e100-5689-11eb-8355-3dad61e7fec6.png">
</details>

## Test Plan

I've not added any tests because this is purely a frontend issue and it doesn't seem like we have the infrastructure to test that currently.
