### PR TITLE
implement a transaction load generator

### DIFF
--- a/cmd/loadgenerator/config.go
+++ b/cmd/loadgenerator/config.go
@@ -1,0 +1,55 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"encoding/json"
+	"net/url"
+	"os"
+)
+
+const configFileName = "loadgenerator.config"
+
+type config struct {
+	AccountMnemonic string
+	ClientURL       *url.URL `json:"-"`
+	APIToken        string
+	RoundModulator  uint64
+	RoundOffset     uint64
+	Fee             uint64
+}
+
+type fileConfig struct {
+	config
+	ClientURL string `json:"ClientURL"`
+}
+
+func loadConfig() (cfg config, err error) {
+	var fd *os.File
+	fd, err = os.Open(configFileName)
+	if err != nil {
+		return config{}, err
+	}
+	jsonDecoder := json.NewDecoder(fd)
+	var fileCfg fileConfig
+	err = jsonDecoder.Decode(&fileCfg)
+	if err == nil {
+		cfg = fileCfg.config
+		cfg.ClientURL, err = url.Parse(fileCfg.ClientURL)
+	}
+	return
+}

--- a/cmd/loadgenerator/config.go
+++ b/cmd/loadgenerator/config.go
@@ -25,12 +25,18 @@ import (
 const configFileName = "loadgenerator.config"
 
 type config struct {
+	// AccountMnemonic is the mnemonic of the account from which we would like to spend Algos.
 	AccountMnemonic string
-	ClientURL       *url.URL `json:"-"`
-	APIToken        string
-	RoundModulator  uint64
-	RoundOffset     uint64
-	Fee             uint64
+	// ClientURL is the url ( such as http://127.0.0.1:8080 ) that would be used to communicate with a node REST endpoint
+	ClientURL *url.URL `json:"-"`
+	// APIToken is the API token used to communicate with the node.
+	APIToken string
+	// RoundModulator is the modulator used to determine of the current round is the round at which transactions need to be sent.
+	RoundModulator uint64
+	// RoundOffset is the offset used to determine of the current round is the round at which transactions need to be sent.
+	RoundOffset uint64
+	// Fee is the amount of algos that would be specified in the transaction fee field.
+	Fee uint64
 }
 
 type fileConfig struct {

--- a/cmd/loadgenerator/loadgenerator.config.example
+++ b/cmd/loadgenerator/loadgenerator.config.example
@@ -1,0 +1,8 @@
+{
+    "AccountMnemonic":"",
+	"ClientURL":"http://127.0.0.1:8080",
+	"APIToken":"",
+    "RoundModulator": 140111,
+    "RoundOffset": 0,
+    "Fee": 1000
+}

--- a/cmd/loadgenerator/loadgenerator.config.example
+++ b/cmd/loadgenerator/loadgenerator.config.example
@@ -1,7 +1,7 @@
 {
     "AccountMnemonic":"",
-	"ClientURL":"http://127.0.0.1:8080",
-	"APIToken":"",
+    "ClientURL":"http://127.0.0.1:8080",
+    "APIToken":"",
     "RoundModulator": 140111,
     "RoundOffset": 0,
     "Fee": 1000

--- a/cmd/loadgenerator/main.go
+++ b/cmd/loadgenerator/main.go
@@ -164,7 +164,7 @@ func generateTransactions(restClient client.RestClient, cfg config, privateKey *
 	var vers common.Version
 	vers, err = restClient.Versions()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to check status : %v", err)
+		fmt.Fprintf(os.Stderr, "unable to get versions : %v", err)
 		return false
 	}
 	var genesisHash crypto.Digest

--- a/cmd/loadgenerator/main.go
+++ b/cmd/loadgenerator/main.go
@@ -203,12 +203,9 @@ func generateTransactions(restClient client.RestClient, cfg config, privateKey *
 			for x := base; x < transactionBlockSize; x += nroutines {
 				_, err = restClient.SendRawTransaction(txns[x])
 				if err != nil {
-					if strings.Contains(err.Error(), "txn dead") {
+					if strings.Contains(err.Error(), "txn dead") || strings.Contains(err.Error(), "below threshold") {
 						break
 					}
-					/*if strings.Contains(err.Error(), "below threshold") {
-						break
-					}*/
 					fmt.Fprintf(os.Stderr, "unable to send transaction : %v\n", err)
 				} else {
 					sent[base]++

--- a/cmd/loadgenerator/main.go
+++ b/cmd/loadgenerator/main.go
@@ -1,0 +1,225 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/crypto/passphrase"
+	"github.com/algorand/go-algorand/daemon/algod/api/client"
+	generatedV2 "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
+	"github.com/algorand/go-algorand/daemon/algod/api/spec/common"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/protocol"
+)
+
+const transactionBlockSize = 800
+
+func loadMnemonic(mnemonic string) crypto.Seed {
+	seedbytes, err := passphrase.MnemonicToKey(mnemonic)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot recover key seed from mnemonic: %v\n", err)
+		os.Exit(1)
+	}
+
+	var seed crypto.Seed
+	copy(seed[:], seedbytes)
+	return seed
+}
+
+func main() {
+	var cfg config
+	var err error
+	if cfg, err = loadConfig(); err != nil {
+		fmt.Fprintf(os.Stderr, "unable to load config : %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Configuration file loaded successfully.\n")
+
+	seed := loadMnemonic(cfg.AccountMnemonic)
+	privateKey := crypto.GenerateSignatureSecrets(seed)
+	publicKey := basics.Address(privateKey.SignatureVerifier)
+
+	fmt.Printf("Spending account public key : %v\n", publicKey.String())
+
+	err = spendLoop(cfg, privateKey, publicKey)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "spend loop error : %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}
+
+func isSpendRound(cfg config, round uint64) bool {
+	return cfg.RoundModulator == 0 || ((round+cfg.RoundOffset)%cfg.RoundModulator == 0)
+}
+
+func nextSpendRound(cfg config, round uint64) uint64 {
+	if cfg.RoundModulator == 0 {
+		return round
+	}
+	return ((round+cfg.RoundOffset)/cfg.RoundModulator)*cfg.RoundModulator + cfg.RoundModulator
+}
+
+func spendLoop(cfg config, privateKey *crypto.SignatureSecrets, publicKey basics.Address) (err error) {
+	restClient := client.MakeRestClient(*cfg.ClientURL, cfg.APIToken)
+
+	for {
+		waitForSpendingRound(restClient, cfg)
+		queueFull := generateTransactions(restClient, cfg, privateKey, publicKey)
+		if queueFull {
+			waitForNonSpendingRound(restClient, cfg)
+		}
+	}
+}
+
+func waitForNonSpendingRound(restClient client.RestClient, cfg config) {
+	var nodeStatus generatedV2.NodeStatusResponse
+	var err error
+	for {
+		nodeStatus, err = restClient.Status()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to check status : %v", err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		if !isSpendRound(cfg, nodeStatus.LastRound) {
+			return
+		}
+	waitForNextBlock:
+		// wait for the next round.
+		nodeStatus, err = restClient.WaitForBlock(basics.Round(nodeStatus.LastRound))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to wait for next round node status : %v", err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		if !isSpendRound(cfg, nodeStatus.LastRound) {
+			return
+		}
+		goto waitForNextBlock
+	}
+}
+
+func waitForSpendingRound(restClient client.RestClient, cfg config) {
+	var nodeStatus generatedV2.NodeStatusResponse
+	var err error
+	for {
+		nodeStatus, err = restClient.Status()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to check status : %v", err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		if isSpendRound(cfg, nodeStatus.LastRound) {
+			// time to send transactions.
+			return
+		}
+		fmt.Printf("Current round %d, waiting for spending round %d\n", nodeStatus.LastRound, nextSpendRound(cfg, nodeStatus.LastRound))
+	waitForNextBlock:
+		// wait for the next round.
+		nodeStatus, err = restClient.WaitForBlock(basics.Round(nodeStatus.LastRound))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to wait for next round node status : %v", err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		if isSpendRound(cfg, nodeStatus.LastRound) {
+			// time to send transactions.
+			return
+		}
+		goto waitForNextBlock
+	}
+}
+
+func generateTransactions(restClient client.RestClient, cfg config, privateKey *crypto.SignatureSecrets, publicKey basics.Address) (queueFull bool) {
+	var nodeStatus generatedV2.NodeStatusResponse
+	var err error
+	nodeStatus, err = restClient.Status()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to check status : %v", err)
+		return false
+	}
+	var vers common.Version
+	vers, err = restClient.Versions()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to check status : %v", err)
+		return false
+	}
+	var genesisHash crypto.Digest
+	copy(genesisHash[:], vers.GenesisHash)
+	// create transactionBlockSize transaction to send.
+	txns := make([]transactions.SignedTxn, transactionBlockSize, transactionBlockSize)
+	for i := range txns {
+		tx := transactions.Transaction{
+			Header: transactions.Header{
+				Sender:      publicKey,
+				Fee:         basics.MicroAlgos{Raw: cfg.Fee},
+				FirstValid:  basics.Round(nodeStatus.LastRound),
+				LastValid:   basics.Round(nodeStatus.LastRound + 2),
+				Note:        make([]byte, 4),
+				GenesisID:   vers.GenesisID,
+				GenesisHash: genesisHash,
+			},
+			PaymentTxnFields: transactions.PaymentTxnFields{
+				Receiver: publicKey,
+				Amount:   basics.MicroAlgos{Raw: 0},
+			},
+			Type: protocol.PaymentTx,
+		}
+		crypto.RandBytes(tx.Note[:])
+		txns[i] = tx.Sign(privateKey)
+	}
+
+	// create multiple go-routines to send all these requests.
+	const nroutines = 8
+	var sendWaitGroup sync.WaitGroup
+	sendWaitGroup.Add(nroutines)
+	sent := make([]int, nroutines, nroutines)
+	for i := 0; i < nroutines; i++ {
+		go func(base int) {
+			defer sendWaitGroup.Done()
+			for x := base; x < transactionBlockSize; x += nroutines {
+				_, err = restClient.SendRawTransaction(txns[x])
+				if err != nil {
+					if strings.Contains(err.Error(), "txn dead") {
+						break
+					}
+					/*if strings.Contains(err.Error(), "below threshold") {
+						break
+					}*/
+					fmt.Fprintf(os.Stderr, "unable to send transaction : %v\n", err)
+				} else {
+					sent[base]++
+				}
+			}
+		}(i)
+	}
+	sendWaitGroup.Wait()
+	totalSent := 0
+	for i := 0; i < nroutines; i++ {
+		totalSent += sent[i]
+	}
+	return totalSent != transactionBlockSize
+}

--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -252,6 +252,21 @@ func (client RestClient) Status() (response generatedV2.NodeStatusResponse, err 
 	return
 }
 
+// WaitForBlock returns the node status after waiting for the given round.
+func (client RestClient) WaitForBlock(round basics.Round) (response generatedV2.NodeStatusResponse, err error) {
+	switch client.versionAffinity {
+	case APIVersionV2:
+		err = client.get(&response, fmt.Sprintf("/v2/status/wait-for-block-after/%d/", round), nil)
+	default:
+		var nodeStatus v1.NodeStatus
+		err = client.get(&nodeStatus, fmt.Sprintf("/v1/status/wait-for-block-after/%d/", round), nil)
+		if err == nil {
+			response = fillNodeStatusResponse(nodeStatus)
+		}
+	}
+	return
+}
+
 // HealthCheck does a health check on the the potentially running node,
 // returning an error if the API is down
 func (client RestClient) HealthCheck() error {


### PR DESCRIPTION
## Summary

In order to implement the "max attained throughput" on the mainnet metrics dashboard we need to generate at least a single block that would contain as many transactions as we can. The utility implemented here could assist us doing so.

## Test Plan

Tested manually.
Config file should be provided based on the example config file.
A mnemonic can be generated using 
```
algokey generate | grep "Private key mnemonic:"
```