### PR TITLE
Fix insufficient fee error message formatting

### DIFF
--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -422,7 +422,7 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 		if tx.Type == protocol.CompactCertTx {
 			// Zero fee allowed for compact cert txn.
 		} else {
-			return makeMinFeeErrorf("transaction had fee %v, which is less than the minimum %v", tx.Fee, proto.MinTxnFee)
+			return makeMinFeeErrorf("transaction had fee %d, which is less than the minimum %d", tx.Fee.Raw, proto.MinTxnFee)
 		}
 	}
 	if tx.LastValid < tx.FirstValid {

--- a/data/transactions/transaction_test.go
+++ b/data/transactions/transaction_test.go
@@ -17,6 +17,7 @@
 package transactions
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/algorand/go-algorand/config"
@@ -117,4 +118,49 @@ func TestGoNonparticipatingWellFormed(t *testing.T) {
 	curProto.SupportBecomeNonParticipatingTransactions = false
 	err = tx.WellFormed(SpecialAddresses{FeeSink: feeSink}, curProto)
 	require.Error(t, err)
+}
+
+func TestWellFormedErrors(t *testing.T) {
+	feeSink := basics.Address{0x7, 0xda, 0xcb, 0x4b, 0x6d, 0x9e, 0xd1, 0x41, 0xb1, 0x75, 0x76, 0xbd, 0x45, 0x9a, 0xe6, 0x42, 0x1d, 0x48, 0x6d, 0xa3, 0xd4, 0xef, 0x22, 0x47, 0xc4, 0x9, 0xa3, 0x96, 0xb8, 0x2e, 0xa2, 0x21}
+	specialAddr := SpecialAddresses{FeeSink: feeSink}
+	curProto := config.Consensus[protocol.ConsensusCurrentVersion]
+	addr1, err := basics.UnmarshalChecksumAddress("NDQCJNNY5WWWFLP4GFZ7MEF2QJSMZYK6OWIV2AQ7OMAVLEFCGGRHFPKJJA")
+	require.NoError(t, err)
+	usecases := []struct {
+		tx            Transaction
+		spec          SpecialAddresses
+		proto         config.ConsensusParams
+		expectedError error
+	}{
+		{
+			tx: Transaction{
+				Type: protocol.PaymentTx,
+				Header: Header{
+					Sender: addr1,
+					Fee:    basics.MicroAlgos{Raw: 100},
+				},
+			},
+			spec:          specialAddr,
+			proto:         curProto,
+			expectedError: makeMinFeeErrorf("transaction had fee %d, which is less than the minimum %d", 100, curProto.MinTxnFee),
+		},
+		{
+			tx: Transaction{
+				Type: protocol.PaymentTx,
+				Header: Header{
+					Sender:     addr1,
+					Fee:        basics.MicroAlgos{Raw: 1000},
+					LastValid:  100,
+					FirstValid: 105,
+				},
+			},
+			spec:          specialAddr,
+			proto:         curProto,
+			expectedError: fmt.Errorf("transaction invalid range (%d--%d)", 105, 100),
+		},
+	}
+	for _, usecase := range usecases {
+		err := usecase.tx.WellFormed(usecase.spec, usecase.proto)
+		require.Equal(t, usecase.expectedError, err)
+	}
 }


### PR DESCRIPTION
## Summary

This PR modifies the error message generated when the amount of fee is below the `MinTxnFee` from
```
transaction had fee {100}, which is less than the minimum 1000
```
to
```
transaction had fee 100, which is less than the minimum 1000
```
