### PR TITLE
Improvements/bugfixes for tealdbg

### DIFF
--- a/cmd/tealdbg/cdtState.go
+++ b/cmd/tealdbg/cdtState.go
@@ -429,6 +429,7 @@ func prepareArray(array []basics.TealValue) []fieldDesc {
 }
 
 func makePreview(fields []fieldDesc) (prop []cdt.RuntimePropertyPreview) {
+	prop = make([]cdt.RuntimePropertyPreview, 0, len(fields))
 	for _, field := range fields {
 		v := cdt.RuntimePropertyPreview{
 			Name:  field.Name,
@@ -441,6 +442,7 @@ func makePreview(fields []fieldDesc) (prop []cdt.RuntimePropertyPreview) {
 }
 
 func makeIntPreview(n int) (prop []cdt.RuntimePropertyPreview) {
+	prop = make([]cdt.RuntimePropertyPreview, 0, n)
 	for i := 0; i < n; i++ {
 		v := cdt.RuntimePropertyPreview{
 			Name:  strconv.Itoa(i),
@@ -480,7 +482,8 @@ func makeArrayPreview(array []basics.TealValue) cdt.RuntimeObjectPreview {
 	fields := prepareArray(array)
 
 	length := len(fields)
-	if length > maxArrayPreviewLength {
+	overflow := length > maxArrayPreviewLength
+	if overflow {
 		length = maxArrayPreviewLength
 	}
 	prop := makePreview(fields[:length])
@@ -489,7 +492,7 @@ func makeArrayPreview(array []basics.TealValue) cdt.RuntimeObjectPreview {
 		Type:        "object",
 		Subtype:     "array",
 		Description: fmt.Sprintf("Array(%d)", len(array)),
-		Overflow:    true,
+		Overflow:    overflow,
 		Properties:  prop}
 	return p
 }
@@ -655,9 +658,7 @@ func makeLocalScope(s *cdtState, preview bool) (desc []cdt.RuntimePropertyDescri
 			gtxn.Value.Preview = &gtxnPreview
 		}
 		stackPreview := makeArrayPreview(s.stack)
-		if len(stackPreview.Properties) > 0 {
-			stack.Value.Preview = &stackPreview
-		}
+		stack.Value.Preview = &stackPreview
 		scratchPreview := makeArrayPreview(s.scratch)
 		if len(scratchPreview.Properties) > 0 {
 			scratch.Value.Preview = &scratchPreview
@@ -694,6 +695,7 @@ func makeLocalScope(s *cdtState, preview bool) (desc []cdt.RuntimePropertyDescri
 
 func makeGlobals(s *cdtState, preview bool) (desc []cdt.RuntimePropertyDescriptor) {
 	fields := prepareGlobals(s.globals)
+	desc = make([]cdt.RuntimePropertyDescriptor, 0, len(fields))
 	for _, field := range fields {
 		desc = append(desc, makePrimitive(field))
 	}
@@ -701,6 +703,7 @@ func makeGlobals(s *cdtState, preview bool) (desc []cdt.RuntimePropertyDescripto
 }
 
 func makeTxn(s *cdtState, preview bool) (desc []cdt.RuntimePropertyDescriptor) {
+	desc = make([]cdt.RuntimePropertyDescriptor, 0)
 	if len(s.txnGroup) > 0 && s.groupIndex < len(s.txnGroup) && s.groupIndex >= 0 {
 		return makeTxnImpl(&s.txnGroup[s.groupIndex].Txn, s.groupIndex, preview)
 	}
@@ -730,7 +733,7 @@ func makeTxnImpl(txn *transactions.Transaction, groupIndex int, preview bool) (d
 				Type:        "object",
 				Subtype:     "array",
 				Description: fmt.Sprintf("Array(%d)", length),
-				Overflow:    true,
+				Overflow:    false,
 				Properties:  prop,
 			}
 			field.Value.Preview = &p
@@ -778,20 +781,20 @@ func makeTxnArrayField(s *cdtState, groupIndex int, fieldIdx int) (desc []cdt.Ru
 }
 
 func makeTxnGroup(s *cdtState, preview bool) (desc []cdt.RuntimePropertyDescriptor) {
-	if len(s.txnGroup) > 0 {
-		for i := 0; i < len(s.txnGroup); i++ {
-			item := makeObject(strconv.Itoa(i), encodeGroupTxnID(i))
-			if preview {
-				txnPreview := makeTxnPreview(s.txnGroup, i)
-				item.Value.Preview = &txnPreview
-			}
-			desc = append(desc, item)
+	desc = make([]cdt.RuntimePropertyDescriptor, 0, len(s.txnGroup))
+	for i := 0; i < len(s.txnGroup); i++ {
+		item := makeObject(strconv.Itoa(i), encodeGroupTxnID(i))
+		if preview {
+			txnPreview := makeTxnPreview(s.txnGroup, i)
+			item.Value.Preview = &txnPreview
 		}
+		desc = append(desc, item)
 	}
 	return
 }
 
 func makeAppGlobalState(s *cdtState, preview bool) (desc []cdt.RuntimePropertyDescriptor) {
+	desc = make([]cdt.RuntimePropertyDescriptor, 0, len(s.AppState.global))
 	for key := range s.AppState.global {
 		s := strconv.Itoa(int(key))
 		item := makeObject(s, encodeAppGlobalAppID(s))
@@ -801,6 +804,7 @@ func makeAppGlobalState(s *cdtState, preview bool) (desc []cdt.RuntimePropertyDe
 }
 
 func makeAppLocalsState(s *cdtState, preview bool) (desc []cdt.RuntimePropertyDescriptor) {
+	desc = make([]cdt.RuntimePropertyDescriptor, 0, len(s.AppState.locals))
 	for addr := range s.AppState.locals {
 		a := addr.String()
 		item := makeObject(a, encodeAppLocalsAddr(a))
@@ -810,6 +814,7 @@ func makeAppLocalsState(s *cdtState, preview bool) (desc []cdt.RuntimePropertyDe
 }
 
 func makeAppLocalState(s *cdtState, addr string) (desc []cdt.RuntimePropertyDescriptor) {
+	desc = make([]cdt.RuntimePropertyDescriptor, 0)
 	a, err := basics.UnmarshalChecksumAddress(addr)
 	if err != nil {
 		return
@@ -850,6 +855,7 @@ func makeAppLocalsKV(s *cdtState, addr string, appID uint64) (desc []cdt.Runtime
 }
 
 func tkvToRpd(tkv basics.TealKeyValue) (desc []cdt.RuntimePropertyDescriptor) {
+	desc = make([]cdt.RuntimePropertyDescriptor, 0, len(tkv))
 	for key, value := range tkv {
 		field := tealValueToFieldDesc(key, basics.TealValue{Type: value.Type, Uint: value.Uint, Bytes: value.Bytes})
 		desc = append(desc, makePrimitive(field))
@@ -900,6 +906,7 @@ func makeScratch(s *cdtState, preview bool) (desc []cdt.RuntimePropertyDescripto
 }
 
 func makeTealError(s *cdtState, preview bool) (desc []cdt.RuntimePropertyDescriptor) {
+	desc = make([]cdt.RuntimePropertyDescriptor, 0)
 	if lastError := s.err.Load(); len(lastError) != 0 {
 		field := fieldDesc{Name: "message", Value: lastError, Type: "string"}
 		desc = append(desc, makePrimitive(field))

--- a/cmd/tealdbg/cdtState.go
+++ b/cmd/tealdbg/cdtState.go
@@ -442,7 +442,7 @@ func makePreview(fields []fieldDesc) (prop []cdt.RuntimePropertyPreview) {
 }
 
 func makeIntPreview(n int) (prop []cdt.RuntimePropertyPreview) {
-	prop = make([]cdt.RuntimePropertyPreview, 0, n)
+	prop = make([]cdt.RuntimePropertyPreview, 0)
 	for i := 0; i < n; i++ {
 		v := cdt.RuntimePropertyPreview{
 			Name:  strconv.Itoa(i),
@@ -695,18 +695,18 @@ func makeLocalScope(s *cdtState, preview bool) (desc []cdt.RuntimePropertyDescri
 
 func makeGlobals(s *cdtState, preview bool) (desc []cdt.RuntimePropertyDescriptor) {
 	fields := prepareGlobals(s.globals)
-	desc = make([]cdt.RuntimePropertyDescriptor, 0, len(fields))
-	for _, field := range fields {
-		desc = append(desc, makePrimitive(field))
+	desc = make([]cdt.RuntimePropertyDescriptor, len(fields))
+	for i, field := range fields {
+		desc[i] = makePrimitive(field)
 	}
 	return
 }
 
 func makeTxn(s *cdtState, preview bool) (desc []cdt.RuntimePropertyDescriptor) {
-	desc = make([]cdt.RuntimePropertyDescriptor, 0)
 	if len(s.txnGroup) > 0 && s.groupIndex < len(s.txnGroup) && s.groupIndex >= 0 {
 		return makeTxnImpl(&s.txnGroup[s.groupIndex].Txn, s.groupIndex, preview)
 	}
+	desc = make([]cdt.RuntimePropertyDescriptor, 0)
 	return
 }
 

--- a/cmd/tealdbg/home.html
+++ b/cmd/tealdbg/home.html
@@ -211,7 +211,7 @@
 
                 // Update stack and scratch
                 var stacktable = exec.querySelector(".stack");
-                updateMemory(stacktable, state["stack"])
+                updateMemory(stacktable, state["stack"] || [])
 
                 var scratchtable = exec.querySelector(".scratch");
                 updateMemory(scratchtable, state["scratch"])

--- a/cmd/tealdbg/homepage.go
+++ b/cmd/tealdbg/homepage.go
@@ -231,7 +231,7 @@ var homepage string = `
 
                 // Update stack and scratch
                 var stacktable = exec.querySelector(".stack");
-                updateMemory(stacktable, state["stack"])
+                updateMemory(stacktable, state["stack"] || [])
 
                 var scratchtable = exec.querySelector(".scratch");
                 updateMemory(scratchtable, state["scratch"])

--- a/cmd/tealdbg/webdbg.go
+++ b/cmd/tealdbg/webdbg.go
@@ -19,7 +19,6 @@ package main
 //go:generate ./bundle_home_html.sh
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -223,7 +222,8 @@ func (a *WebPageFrontend) subscribeHandler(w http.ResponseWriter, r *http.Reques
 	event := Notification{
 		Event: "connected",
 	}
-	err = ws.WriteJSON(&event)
+	enc := protocol.EncodeJSONStrict(&event)
+	err = ws.WriteMessage(websocket.TextMessage, enc)
 	if err != nil {
 		return
 	}
@@ -242,13 +242,8 @@ func (a *WebPageFrontend) subscribeHandler(w http.ResponseWriter, r *http.Reques
 	for {
 		select {
 		case notification := <-notifications:
-			var data bytes.Buffer
-			enc := protocol.NewJSONEncoder(&data)
-			err := enc.Encode(notification)
-			if err != nil {
-				return
-			}
-			err = ws.WriteMessage(websocket.TextMessage, data.Bytes())
+			enc := protocol.EncodeJSONStrict(&notification)
+			err = ws.WriteMessage(websocket.TextMessage, enc)
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Some transactions are not able to be fully expanded and viewed in tealdbg when using the Chrome DevTools frontend. This specifically affects transactions with empty `Accounts` or `ApplicationArgs` fields.

This bug happened because empty fields were being represented as nil slices in tealdbg, which translates to a `null` JSON value instead of an empty array, causing the Chrome frontend to fail to display any part of the expanded object. I've fixed this and made the following additional fixes in this PR:
* Made the object overflow field for Chrome more useful.
* Fixed an issue where the web frontend fails because the stack is empty.
* Fixed an issue where the web frontend fails to decode JSON with application local state because of integer map keys.

<details>
<summary>Current Chrome behavior (note the expanded arrow at gtxn[0] but nothing is shown)</summary>
<img src="https://user-images.githubusercontent.com/5856867/104783773-c5109600-5754-11eb-8f1b-88d733d45984.png">
</details>

<details>
<summary>Fixed Chrome behavior</summary>
<img src="https://user-images.githubusercontent.com/5856867/104783780-c8a41d00-5754-11eb-9ddf-6d5a2a72999d.png">
</details>

## Test Plan

No tests added because these are frontend changes.
