### PR TITLE
diagcfg : Read from global logging config if data dir not provided

### DIFF
--- a/cmd/diagcfg/telemetry.go
+++ b/cmd/diagcfg/telemetry.go
@@ -55,7 +55,7 @@ func maybeUpdateDataDirFromEnv() {
 
 func readTelemetryConfigOrExit() logging.TelemetryConfig {
 	maybeUpdateDataDirFromEnv()
-	cfg, err := logging.ReadTelemetryConfigOrDefault(&dataDir, "")
+	cfg, err := logging.ReadTelemetryConfigOrDefault(dataDir, "")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, telemetryConfigReadError, err)
 		os.Exit(1)
@@ -112,7 +112,7 @@ var telemetryStatusCmd = &cobra.Command{
 	Long:  `Print the node's telemetry status`,
 	Run: func(cmd *cobra.Command, args []string) {
 		maybeUpdateDataDirFromEnv()
-		cfg, err := logging.ReadTelemetryConfigOrDefault(&dataDir, "")
+		cfg, err := logging.ReadTelemetryConfigOrDefault(dataDir, "")
 
 		// If error loading config, can't disable / no need to disable
 		if err != nil {

--- a/logging/telemetry.go
+++ b/logging/telemetry.go
@@ -97,7 +97,7 @@ func ReadTelemetryConfigOrDefault(dataDir *string, genesisID string) (cfg Teleme
 		configPath := filepath.Join(*dataDir, TelemetryConfigFilename)
 		cfg, err = LoadTelemetryConfig(configPath)
 	}
-	if err != nil && os.IsNotExist(err) || !dataDirProvided {
+	if (err != nil && os.IsNotExist(err)) || !dataDirProvided {
 		var configPath string
 		configPath, err = config.GetConfigFilePath(TelemetryConfigFilename)
 		if err != nil {

--- a/logging/telemetry.go
+++ b/logging/telemetry.go
@@ -92,11 +92,12 @@ func makeTelemetryState(cfg TelemetryConfig, hookFactory hookFactory) (*telemetr
 // ReadTelemetryConfigOrDefault reads telemetry config from file or defaults if no config file found.
 func ReadTelemetryConfigOrDefault(dataDir *string, genesisID string) (cfg TelemetryConfig, err error) {
 	err = nil
-	if dataDir != nil && *dataDir != "" {
+	dataDirProvided := dataDir != nil && *dataDir != ""
+	if dataDirProvided {
 		configPath := filepath.Join(*dataDir, TelemetryConfigFilename)
 		cfg, err = LoadTelemetryConfig(configPath)
 	}
-	if err != nil && os.IsNotExist(err) {
+	if err != nil && os.IsNotExist(err) || !dataDirProvided {
 		var configPath string
 		configPath, err = config.GetConfigFilePath(TelemetryConfigFilename)
 		if err != nil {

--- a/logging/telemetry.go
+++ b/logging/telemetry.go
@@ -90,11 +90,11 @@ func makeTelemetryState(cfg TelemetryConfig, hookFactory hookFactory) (*telemetr
 }
 
 // ReadTelemetryConfigOrDefault reads telemetry config from file or defaults if no config file found.
-func ReadTelemetryConfigOrDefault(dataDir *string, genesisID string) (cfg TelemetryConfig, err error) {
+func ReadTelemetryConfigOrDefault(dataDir string, genesisID string) (cfg TelemetryConfig, err error) {
 	err = nil
-	dataDirProvided := dataDir != nil && *dataDir != ""
+	dataDirProvided := dataDir != ""
 	if dataDirProvided {
-		configPath := filepath.Join(*dataDir, TelemetryConfigFilename)
+		configPath := filepath.Join(dataDir, TelemetryConfigFilename)
 		cfg, err = LoadTelemetryConfig(configPath)
 	}
 	if (err != nil && os.IsNotExist(err)) || !dataDirProvided {

--- a/logging/telemetry_test.go
+++ b/logging/telemetry_test.go
@@ -325,12 +325,13 @@ func TestReadTelemetryConfigOrDefaultNoDataDir(t *testing.T) {
 	config.SetGlobalConfigFileRoot(tempDir)
 
 	cfg, err := ReadTelemetryConfigOrDefault("", "")
+	defaultCfgSettings := createTelemetryConfig()
 	config.SetGlobalConfigFileRoot(originalGlobalConfigFileRoot)
 
 	a.Nil(err)
 	a.NotNil(cfg)
-	a.NotNil(cfg.UserName)
-	a.NotNil(cfg.Password)
-	a.NotNil(cfg.GUID)
-	a.NotEqual(t, TelemetryConfig{}, cfg)
+	a.NotEqual(TelemetryConfig{}, cfg)
+	a.Equal(defaultCfgSettings.UserName, cfg.UserName)
+	a.Equal(defaultCfgSettings.Password, cfg.Password)
+	a.Equal(len(defaultCfgSettings.GUID), len(cfg.GUID))
 }

--- a/logging/telemetry_test.go
+++ b/logging/telemetry_test.go
@@ -18,6 +18,8 @@ package logging
 
 import (
 	"fmt"
+	"github.com/algorand/go-algorand/config"
+	"os"
 	"testing"
 	"time"
 
@@ -314,4 +316,20 @@ func TestLogHistoryLevels(t *testing.T) {
 	a.NotNil(data[4]["log"]) // Error
 	a.Nil(data[5]["log"])    // Panic - this is stack trace
 	a.NotNil(data[6]["log"]) // Panic
+}
+
+func TestReadTelemetryConfigOrDefaultNoDataDir(t *testing.T) {
+	a := require.New(t)
+	tempDir := os.TempDir()
+	originalGlobalConfigFileRoot, _ := config.GetGlobalConfigFileRoot()
+	config.SetGlobalConfigFileRoot(tempDir)
+
+	cfg, err := ReadTelemetryConfigOrDefault("", "")
+	config.SetGlobalConfigFileRoot(originalGlobalConfigFileRoot)
+
+	a.Nil(err)
+	a.NotNil(cfg)
+	a.NotNil(cfg.UserName)
+	a.NotNil(cfg.Password)
+	a.NotNil(cfg.GUID)
 }

--- a/logging/telemetry_test.go
+++ b/logging/telemetry_test.go
@@ -332,4 +332,5 @@ func TestReadTelemetryConfigOrDefaultNoDataDir(t *testing.T) {
 	a.NotNil(cfg.UserName)
 	a.NotNil(cfg.Password)
 	a.NotNil(cfg.GUID)
+	a.NotEqual(t, TelemetryConfig{}, cfg)
 }

--- a/logging/telemetry_test.go
+++ b/logging/telemetry_test.go
@@ -18,15 +18,16 @@ package logging
 
 import (
 	"fmt"
-	"github.com/algorand/go-algorand/config"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/algorand/go-deadlock"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
+	"github.com/algorand/go-deadlock"
+
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/logging/telemetryspec"
 )
 


### PR DESCRIPTION
## Summary

When a datadir is not provided, this will have diagcfg read from the default logging config in the global config path. It will then generate a default config if that file does not exist

## Test Plan

I ran this locally and was able to produce correctly configured default logging configs
