### PR TITLE
Fix regression to loadTelemetryConfig introduced in 2.3.0

### DIFF
--- a/logging/telemetryConfig.go
+++ b/logging/telemetryConfig.go
@@ -133,8 +133,9 @@ func loadTelemetryConfig(path string) (TelemetryConfig, error) {
 		return createTelemetryConfig(), err
 	}
 	defer f.Close()
-	cfg := createTelemetryConfig()
+	var cfg TelemetryConfig
 	var marshaledConfig MarshalingTelemetryConfig
+	marshaledConfig.TelemetryConfig = createTelemetryConfig()
 	dec := json.NewDecoder(f)
 	err = dec.Decode(&marshaledConfig)
 	cfg = marshaledConfig.TelemetryConfig

--- a/logging/telemetryConfig_test.go
+++ b/logging/telemetryConfig_test.go
@@ -107,3 +107,15 @@ func Test_SanitizeTelemetryString(t *testing.T) {
 		require.Equal(t, test.expected, SanitizeTelemetryString(test.input, test.parts))
 	}
 }
+
+func TestLoadTelemetryConfig(t *testing.T) {
+	testLoggingConfigFileName := "../test/testdata/configs/logging/logging.config.test1"
+	tc, err := loadTelemetryConfig(testLoggingConfigFileName)
+	require.NoError(t, err)
+	require.Equal(t, true, tc.Enable)
+	// make sure the user name was loaded from the specified file
+	require.Equal(t, "test-user-name", tc.UserName)
+	// ensure we know how to default correctly if some of the fields in the configuration field aren't specified.
+	require.Equal(t, createTelemetryConfig().Password, tc.Password)
+
+}

--- a/test/testdata/configs/logging/logging.config.test1
+++ b/test/testdata/configs/logging/logging.config.test1
@@ -1,0 +1,4 @@
+{
+  "Enable":             true,
+  "UserName":           "test-user-name"
+}


### PR DESCRIPTION
## Summary

As part of a refactoring effort in https://github.com/algorand/go-algorand/pull/1709, a small bug was introduced that changed the intended behavior of `loadTelemetryConfig`. This PR restores the previous behavior and adds a unit test for that.

## Test Plan

Unit test added.