### PR TITLE
testing: fix regression in BenchmarkReadingAllBalancesRAM and BenchmarkReadingAllBalancesDisk

### DIFF
--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -695,10 +695,10 @@ func generateRandomTestingAccountBalances(numAccounts int) (updates map[basics.A
 	for i := 0; i < numAccounts; i++ {
 		addr := randomAddress()
 		updates[addr] = basics.AccountData{
-			MicroAlgos:         basics.MicroAlgos{Raw: 0x000ffffffffffffff},
+			MicroAlgos:         basics.MicroAlgos{Raw: 0x000ffffffffffffff / uint64(numAccounts)},
 			Status:             basics.NotParticipating,
 			RewardsBase:        uint64(i),
-			RewardedMicroAlgos: basics.MicroAlgos{Raw: 0x000ffffffffffffff},
+			RewardedMicroAlgos: basics.MicroAlgos{Raw: 0x000ffffffffffffff / uint64(numAccounts)},
 			VoteID:             secrets.OneTimeSignatureVerifier,
 			SelectionID:        pubVrfKey,
 			VoteFirstValid:     basics.Round(0x000ffffffffffffff),


### PR DESCRIPTION
## Summary

The benchmark BenchmarkReadingAllBalancesRAM and BenchmarkReadingAllBalancesDisk started failing after BenchmarkWritingRandomBalancesDisk was introduced (8ea0fb1555a4e8dea46405f2bccb4ca33a3bddd6).

The culprit was setting up the accounts data structure with too much algos, causing the total amount of algos to overflow the uint64.

## Test Plan

Tested manually.