### PR TITLE
testing: make e2e_client_runner more robust

### DIFF
--- a/test/scripts/e2e_client_runner.py
+++ b/test/scripts/e2e_client_runner.py
@@ -174,7 +174,7 @@ class RunSet:
         if self.algod and self.kmd:
             return
         # should run from inside self.lock
-        xrun(['goal', 'kmd', 'start', '-t', '200'], env=self.env, timeout=5)
+        xrun(['goal', 'kmd', 'start', '-t', '3600'], env=self.env, timeout=5)
         algodata = self.env['ALGORAND_DATA']
         self.kmd = openkmd(algodata)
         self.algod = openalgod(algodata)
@@ -279,6 +279,7 @@ def goal_network_stop(netdir, normal_cleanup=False):
     logger.info('stop network in %s', netdir)
     try:
         xrun(['goal', 'network', 'stop', '-r', netdir], timeout=10)
+        xrun(['goal', 'kmd', 'stop'], env=self.env, timeout=5)
     except Exception as e:
         logger.error('error stopping network', exc_info=True)
         if normal_cleanup:

--- a/test/scripts/e2e_client_runner.py
+++ b/test/scripts/e2e_client_runner.py
@@ -285,10 +285,16 @@ def goal_network_stop(netdir, env, normal_cleanup=False):
     logger.info('stop network in %s', netdir)
     try:
         xrun(['goal', 'network', 'stop', '-r', netdir], timeout=10)
-        algodata = env['ALGORAND_DATA']
-        xrun(['goal', 'kmd', 'stop', '-d', algodata], timeout=5)
     except Exception as e:
         logger.error('error stopping network', exc_info=True)
+        if normal_cleanup:
+            raise e
+    try:
+        algodata = env['ALGORAND_DATA']
+        logger.info('stop kmd in %s', algodata)
+        xrun(['goal', 'kmd', 'stop', '-d', algodata], timeout=5)
+    except Exception as e:
+        logger.error('error stopping kmd', exc_info=True)
         if normal_cleanup:
             raise e
     already_stopped = True
@@ -389,7 +395,7 @@ def main():
     retcode = 0
     xrun(['goal', 'network', 'create', '-r', netdir, '-n', 'tbd', '-t', os.path.join(gopath, 'src/github.com/algorand/go-algorand/test/testdata/nettemplates/TwoNodes50EachFuture.json')], timeout=90)
     xrun(['goal', 'network', 'start', '-r', netdir], timeout=90)
-    atexit.register(goal_network_stop, env, netdir)
+    atexit.register(goal_network_stop, netdir, env)
 
     env['ALGORAND_DATA'] = os.path.join(netdir, 'Node')
     env['ALGORAND_DATA2'] = os.path.join(netdir, 'Primary')

--- a/test/scripts/e2e_client_runner.py
+++ b/test/scripts/e2e_client_runner.py
@@ -92,7 +92,7 @@ def _script_thread_inner(runset, scriptname):
         round = status['lastRound']
 
     if ptxinfo is not None:
-        sys.stderr.write('failed to initialize temporary test wallet account for test ({}) for {} rounds.\n'.format(scriptname), max_init_wait_rounds)
+        sys.stderr.write('failed to initialize temporary test wallet account for test ({}) for {} rounds.\n'.format(scriptname, max_init_wait_rounds))
         runset.done(scriptname, False, time.time() - start)
 
     env = dict(runset.env)


### PR DESCRIPTION
## Summary

This PR improves the existing e2e client runner in two different ways:
1. It extends the time the kmd would remain in memory from 200 seconds to 3600 seconds.
    Given that some of our tests have a timeout of 300 seconds, it only make sense to align it with *at least* the duration of the longest test. Since we don't don't when each of the tests start running, we need to ensure it would be sufficiently large.
2. The existing wallet initialization bootstrapping code was polling for up to 5 seconds for the funds to be moved to the wallet. The changes here would ensure that:
    - The funds were moved successfully.
    - The operation is completed within a known number of rounds.
    - Instead of polling, it would wait for a new round. That sounds reduce the cpu load when running many e2e tests concurrently.
     

## Test Plan

See the above summary for details.
