### PR TITLE
non-utf8 app value keys for test

### DIFF
--- a/test/scripts/e2e_subs/tealprogs/globcheck.teal
+++ b/test/scripts/e2e_subs/tealprogs/globcheck.teal
@@ -26,10 +26,9 @@ txna ApplicationArgs 0
 byte base64 Y2hlY2s=
 ==
 
-// and arg 1 must be the value at "foo"
-// Key "foo"
+// and arg 1 must be the value inserted by globwrite.teal
 int 0
-byte base64 Zm9v
+byte 0xfefeffef0000112233
 app_global_get_ex
 
 // Value must exist
@@ -48,8 +47,8 @@ bnz done
 write:
 // Write to GlobalState
 
-// Key "foo"
-byte base64 Zm9v
+// non-utf8 key
+byte 0xfefeffef0000112233
 
 // Value "bar"
 byte base64 YmFy

--- a/test/scripts/e2e_subs/tealprogs/globwrite.teal
+++ b/test/scripts/e2e_subs/tealprogs/globwrite.teal
@@ -1,6 +1,7 @@
 #pragma version 2
-// Key is "foo"
-byte base64 Zm9v
+// Key is deliberately not valid utf-8
+// Keep in sync with globcheck.teal
+byte 0xfefeffef0000112233
 
 // Value is ApplicationArgs 0
 txna ApplicationArgs 0

--- a/test/scripts/e2e_subs/tealprogs/xappreads.teal
+++ b/test/scripts/e2e_subs/tealprogs/xappreads.teal
@@ -1,8 +1,8 @@
 #pragma version 2
 // Fetch app idx we want to read global state from
 int 1  // ForeignApps index
-// Fetch key "foo"
-byte base64 Zm9v
+// non-utf8 key
+byte 0xfefeffef0000112233
 
 // Get value
 app_global_get_ex


### PR DESCRIPTION
## Summary

Replace some app value keys "foo" with a non-utf8 string to test binary cleanness.

## Test Plan

This is a test. It should pass.