### PR TITLE
add a non-utf8 Note

### DIFF
--- a/test/scripts/e2e_subs/rekey.sh
+++ b/test/scripts/e2e_subs/rekey.sh
@@ -24,7 +24,7 @@ ESCROWV2=$(${gcmd} clerk compile "${TEMPDIR}/simple.teal" -o "${TEMPDIR}/simple.
 
 # Fund v1 escrow, v2 escrow, and ACCOUNTD
 ACCOUNTD=$(${gcmd} account new|awk '{ print $6 }')
-${gcmd} clerk send -a 10000000 -f "${ACCOUNT}" -t "${ESCROWV1}"
+${gcmd} clerk send -a 10000000 -f "${ACCOUNT}" -t "${ESCROWV1}" --noteb64 /v8AAAAAAP/////+/g==
 ${gcmd} clerk send -a 10000000 -f "${ACCOUNT}" -t "${ESCROWV2}"
 ${gcmd} clerk send -a 10000000 -f "${ACCOUNT}" -t "${ACCOUNTD}"
 
@@ -121,4 +121,3 @@ if [ "$BALANCEB" -ne 400000 ]; then
     date "+e2e_subs/rekey.sh FAIL wanted balance=400000 but got ${BALANCEB} %Y%m%d_%H%M%S"
     false
 fi
-

--- a/test/scripts/e2e_subs/rekey.sh
+++ b/test/scripts/e2e_subs/rekey.sh
@@ -24,6 +24,7 @@ ESCROWV2=$(${gcmd} clerk compile "${TEMPDIR}/simple.teal" -o "${TEMPDIR}/simple.
 
 # Fund v1 escrow, v2 escrow, and ACCOUNTD
 ACCOUNTD=$(${gcmd} account new|awk '{ print $6 }')
+# The Note attached to this transaction is a specific non-utf8 string to help test that tools are binary safe and not assuming a readable "string".
 ${gcmd} clerk send -a 10000000 -f "${ACCOUNT}" -t "${ESCROWV1}" --noteb64 /v8AAAAAAP/////+/g==
 ${gcmd} clerk send -a 10000000 -f "${ACCOUNT}" -t "${ESCROWV2}"
 ${gcmd} clerk send -a 10000000 -f "${ACCOUNT}" -t "${ACCOUNTD}"


### PR DESCRIPTION
## Summary

To better test the binary-clean-ness of the tools at every stage, add a non-utf8 Note field

## Test Plan

This is a test. It should pass. Downstream tests (Indxer) will also benefit.