### PR TITLE
Adjust timeouts in assets-app.sh/sectok-app.sh tests

### DIFF
--- a/test/scripts/e2e_subs/assets-app.sh
+++ b/test/scripts/e2e_subs/assets-app.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# TIMEOUT=300
+# TIMEOUT=320
 
 date '+assets-app start %Y%m%d_%H%M%S'
 

--- a/test/scripts/e2e_subs/sectok-app.sh
+++ b/test/scripts/e2e_subs/sectok-app.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# TIMEOUT=300
+# TIMEOUT=380
 
 date '+sectok-app start %Y%m%d_%H%M%S'
 


### PR DESCRIPTION
## Summary

* goal waits for txn submitted at round x till x+2
  if submitting at the beginning of the round it is full 3 * 4.5 seconds per txn
* assets-app.sh has 23 txns that is 23 * 3 * 4.5 = 311 seconds
* sectok-app.sh has 27 txns that is 27 * 3 * 4.5 = 365 seconds

## Test Plan

This is fix for tests