### PR TITLE
tests for the compactcert package

### DIFF
--- a/compactcert/abstractions.go
+++ b/compactcert/abstractions.go
@@ -1,0 +1,58 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package compactcert
+
+import (
+	"context"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/account"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/ledger"
+	"github.com/algorand/go-algorand/network"
+	"github.com/algorand/go-algorand/protocol"
+)
+
+// TransactionSender is an interface that captures the node's ability
+// to broadcast a new transaction.
+type TransactionSender interface {
+	BroadcastSignedTxGroup([]transactions.SignedTxn) error
+}
+
+// Ledger captures the aspects of the ledger that are used by this package.
+type Ledger interface {
+	Latest() basics.Round
+	Wait(basics.Round) chan struct{}
+	GenesisHash() crypto.Digest
+	BlockHdr(basics.Round) (bookkeeping.BlockHeader, error)
+	CompactCertVoters(basics.Round) (*ledger.VotersForRound, error)
+}
+
+// Network captures the aspects of the gossip network protocol that are
+// used by this package.
+type Network interface {
+	Broadcast(context.Context, protocol.Tag, []byte, bool, network.Peer) error
+	RegisterHandlers([]network.TaggedMessageHandler)
+}
+
+// Accounts captures the aspects of the AccountManager that are used by
+// this package.
+type Accounts interface {
+	Keys() []account.Participation
+}

--- a/compactcert/builder.go
+++ b/compactcert/builder.go
@@ -185,7 +185,7 @@ func (ccw *Worker) handleSig(sfa sigFromAddr, sender network.Peer) (network.Forw
 	return network.Broadcast, nil
 }
 
-func (ccw *Worker) builder() {
+func (ccw *Worker) builder(latest basics.Round) {
 	// We clock the building of compact certificates based on new
 	// blocks.  This is because the acceptable compact certificate
 	// size grows over time, so that we aim to construct an extremely
@@ -194,7 +194,7 @@ func (ccw *Worker) builder() {
 	// if a compact cert has been committed, so that we can stop trying
 	// to build it.
 	for {
-		nextrnd := ccw.ledger.Latest() + 1
+		nextrnd := latest + 1
 		select {
 		case <-ccw.ctx.Done():
 			ccw.wg.Done()
@@ -204,6 +204,8 @@ func (ccw *Worker) builder() {
 			// Continue on
 		}
 
+		// See if any new compact certificates were formed, according to
+		// the new block, which would mean we can clean up some builders.
 		hdr, err := ccw.ledger.BlockHdr(nextrnd)
 		if err != nil {
 			ccw.log.Warnf("ccw.builder: BlockHdr(%d): %v", nextrnd, err)
@@ -212,12 +214,19 @@ func (ccw *Worker) builder() {
 			ccw.deleteOldSigs(hdr.CompactCertNextRound)
 		}
 
-		// Broadcast signatures based on the previous block that
-		// was agreed upon.  This ensures that, if we send a signature
+		// Broadcast signatures based on the previous block(s) that
+		// were agreed upon.  This ensures that, if we send a signature
 		// for block R, nodes will have already verified block R, because
 		// block R+1 has been formed.
 		proto := config.Consensus[hdr.CurrentProtocol]
-		ccw.broadcastSigs(nextrnd-1, proto)
+		newLatest := ccw.ledger.Latest()
+		for r := latest; r < newLatest; r++ {
+			// Wait for the signer to catch up; mostly relevant in tests.
+			ccw.waitForSignedBlock(r)
+
+			ccw.broadcastSigs(r, proto)
+		}
+		latest = newLatest
 
 		ccw.tryBuilding()
 	}
@@ -238,6 +247,10 @@ func (ccw *Worker) builder() {
 // The broadcast schedule is randomized by the address of the block signer,
 // for load-balancing over time.
 func (ccw *Worker) broadcastSigs(brnd basics.Round, proto config.ConsensusParams) {
+	if proto.CompactCertRounds == 0 {
+		return
+	}
+
 	ccw.mu.Lock()
 	defer ccw.mu.Unlock()
 
@@ -256,6 +269,13 @@ func (ccw *Worker) broadcastSigs(brnd basics.Round, proto config.ConsensusParams
 	}
 
 	for rnd, sigs := range roundSigs {
+		if rnd > brnd {
+			// Signature is for later block than brnd.  This could happen
+			// during catchup or testing.  The caller's loop will eventually
+			// invoke this function with a suitably high brnd.
+			continue
+		}
+
 		for _, sig := range sigs {
 			// Randomize which sigs get broadcast over time.
 			addr64 := binary.LittleEndian.Uint64(sig.signer[:])
@@ -329,6 +349,37 @@ func (ccw *Worker) tryBuilding() {
 		err = ccw.txnSender.BroadcastSignedTxGroup([]transactions.SignedTxn{stxn})
 		if err != nil {
 			ccw.log.Warnf("ccw.tryBuilding: broadcasting compact cert txn for %d: %v", rnd, err)
+		}
+	}
+}
+
+func (ccw *Worker) signedBlock(r basics.Round) {
+	ccw.mu.Lock()
+	ccw.signed = r
+	ccw.mu.Unlock()
+
+	select {
+	case ccw.signedCh <- struct{}{}:
+	default:
+	}
+}
+
+func (ccw *Worker) lastSignedBlock() basics.Round {
+	ccw.mu.Lock()
+	defer ccw.mu.Unlock()
+	return ccw.signed
+}
+
+func (ccw *Worker) waitForSignedBlock(r basics.Round) {
+	for {
+		if r <= ccw.lastSignedBlock() {
+			return
+		}
+
+		select {
+		case <-ccw.ctx.Done():
+			return
+		case <-ccw.signedCh:
 		}
 	}
 }

--- a/compactcert/builder.go
+++ b/compactcert/builder.go
@@ -194,6 +194,8 @@ func (ccw *Worker) builder(latest basics.Round) {
 	// if a compact cert has been committed, so that we can stop trying
 	// to build it.
 	for {
+		ccw.tryBuilding()
+
 		nextrnd := latest + 1
 		select {
 		case <-ccw.ctx.Done():
@@ -227,8 +229,6 @@ func (ccw *Worker) builder(latest basics.Round) {
 			ccw.broadcastSigs(r, proto)
 		}
 		latest = newLatest
-
-		ccw.tryBuilding()
 	}
 }
 

--- a/compactcert/db_test.go
+++ b/compactcert/db_test.go
@@ -1,0 +1,112 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package compactcert
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/util/db"
+)
+
+func dbOpenTest(t testing.TB, inMemory bool) (db.Pair, string) {
+	fn := fmt.Sprintf("%s.%d", strings.ReplaceAll(t.Name(), "/", "."), crypto.RandUint64())
+	dbs, err := db.OpenPair(fn, inMemory)
+	require.NoErrorf(t, err, "Filename: %s\nInMemory: %v", fn, inMemory)
+
+        dblogger := logging.TestingLog(t)
+        dbs.Rdb.SetLogger(dblogger)
+        dbs.Wdb.SetLogger(dblogger)
+
+	return dbs, fn
+}
+
+func TestPendingSigDB(t *testing.T) {
+	dbs, _ := dbOpenTest(t, true)
+	defer dbs.Close()
+
+	err := dbs.Wdb.Atomic(func (ctx context.Context, tx *sql.Tx) error {
+		return initDB(tx)
+	})
+	require.NoError(t, err)
+
+	for r := basics.Round(0); r < basics.Round(100); r++ {
+		err = dbs.Wdb.Atomic(func (ctx context.Context, tx *sql.Tx) error {
+			var psig pendingSig
+			crypto.RandBytes(psig.signer[:])
+			return addPendingSig(tx, r, psig)
+		})
+		require.NoError(t, err)
+
+		err = dbs.Wdb.Atomic(func (ctx context.Context, tx *sql.Tx) error {
+			var psig pendingSig
+			crypto.RandBytes(psig.signer[:])
+			// watermark signers from this node: 4th byte is zero
+			psig.signer[4] = 0
+			psig.fromThisNode = true
+			return addPendingSig(tx, r, psig)
+		})
+		require.NoError(t, err)
+	}
+
+	for deletedBefore := basics.Round(0); deletedBefore < basics.Round(200); deletedBefore++ {
+		err = dbs.Wdb.Atomic(func (ctx context.Context, tx *sql.Tx) error {
+			return deletePendingSigsBeforeRound(tx, deletedBefore)
+		})
+		require.NoError(t, err)
+
+		var psigs map[basics.Round][]pendingSig
+		var psigsThis map[basics.Round][]pendingSig
+		err = dbs.Rdb.Atomic(func (ctx context.Context, tx *sql.Tx) error {
+			var err error
+			psigs, err = getPendingSigs(tx)
+			if err != nil {
+				return err
+			}
+
+			psigsThis, err = getPendingSigsFromThisNode(tx)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+		require.NoError(t, err)
+
+		expectedLen := 100-int(deletedBefore)
+		if expectedLen < 0 {
+			expectedLen = 0
+		}
+
+		require.Equal(t, len(psigs), expectedLen)
+		require.Equal(t, len(psigsThis), expectedLen)
+
+		for r := deletedBefore; r < basics.Round(100); r++ {
+			require.Equal(t, len(psigs[r]), 2)
+			require.Equal(t, len(psigsThis[r]), 1)
+			require.Equal(t, psigsThis[r][0].signer[4], byte(0))
+		}
+	}
+}

--- a/compactcert/db_test.go
+++ b/compactcert/db_test.go
@@ -36,9 +36,9 @@ func dbOpenTest(t testing.TB, inMemory bool) (db.Pair, string) {
 	dbs, err := db.OpenPair(fn, inMemory)
 	require.NoErrorf(t, err, "Filename: %s\nInMemory: %v", fn, inMemory)
 
-        dblogger := logging.TestingLog(t)
-        dbs.Rdb.SetLogger(dblogger)
-        dbs.Wdb.SetLogger(dblogger)
+	dblogger := logging.TestingLog(t)
+	dbs.Rdb.SetLogger(dblogger)
+	dbs.Wdb.SetLogger(dblogger)
 
 	return dbs, fn
 }
@@ -47,20 +47,20 @@ func TestPendingSigDB(t *testing.T) {
 	dbs, _ := dbOpenTest(t, true)
 	defer dbs.Close()
 
-	err := dbs.Wdb.Atomic(func (ctx context.Context, tx *sql.Tx) error {
+	err := dbs.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 		return initDB(tx)
 	})
 	require.NoError(t, err)
 
 	for r := basics.Round(0); r < basics.Round(100); r++ {
-		err = dbs.Wdb.Atomic(func (ctx context.Context, tx *sql.Tx) error {
+		err = dbs.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 			var psig pendingSig
 			crypto.RandBytes(psig.signer[:])
 			return addPendingSig(tx, r, psig)
 		})
 		require.NoError(t, err)
 
-		err = dbs.Wdb.Atomic(func (ctx context.Context, tx *sql.Tx) error {
+		err = dbs.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 			var psig pendingSig
 			crypto.RandBytes(psig.signer[:])
 			// watermark signers from this node: 4th byte is zero
@@ -72,14 +72,14 @@ func TestPendingSigDB(t *testing.T) {
 	}
 
 	for deletedBefore := basics.Round(0); deletedBefore < basics.Round(200); deletedBefore++ {
-		err = dbs.Wdb.Atomic(func (ctx context.Context, tx *sql.Tx) error {
+		err = dbs.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 			return deletePendingSigsBeforeRound(tx, deletedBefore)
 		})
 		require.NoError(t, err)
 
 		var psigs map[basics.Round][]pendingSig
 		var psigsThis map[basics.Round][]pendingSig
-		err = dbs.Rdb.Atomic(func (ctx context.Context, tx *sql.Tx) error {
+		err = dbs.Rdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 			var err error
 			psigs, err = getPendingSigs(tx)
 			if err != nil {
@@ -95,7 +95,7 @@ func TestPendingSigDB(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		expectedLen := 100-int(deletedBefore)
+		expectedLen := 100 - int(deletedBefore)
 		if expectedLen < 0 {
 			expectedLen = 0
 		}

--- a/compactcert/db_test.go
+++ b/compactcert/db_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/algorand/go-algorand/util/db"
 )
 
-func dbOpenTest(t testing.TB, inMemory bool) (db.Pair, string) {
-	fn := fmt.Sprintf("%s.%d", strings.ReplaceAll(t.Name(), "/", "."), crypto.RandUint64())
+func dbOpenTestRand(t testing.TB, inMemory bool, rnd uint64) (db.Pair, string) {
+	fn := fmt.Sprintf("%s.%d", strings.ReplaceAll(t.Name(), "/", "."), rnd)
 	dbs, err := db.OpenPair(fn, inMemory)
 	require.NoErrorf(t, err, "Filename: %s\nInMemory: %v", fn, inMemory)
 
@@ -41,6 +41,10 @@ func dbOpenTest(t testing.TB, inMemory bool) (db.Pair, string) {
 	dbs.Wdb.SetLogger(dblogger)
 
 	return dbs, fn
+}
+
+func dbOpenTest(t testing.TB, inMemory bool) (db.Pair, string) {
+	return dbOpenTestRand(t, inMemory, crypto.RandUint64())
 }
 
 func TestPendingSigDB(t *testing.T) {

--- a/compactcert/signer.go
+++ b/compactcert/signer.go
@@ -38,19 +38,20 @@ type sigFromAddr struct {
 	Sig    crypto.OneTimeSignature `codec:"sig"`
 }
 
-func (ccw *Worker) signer() {
+func (ccw *Worker) signer(latest basics.Round) {
 	var nextrnd basics.Round
 
+restart:
 	for {
-		latest := ccw.ledger.Latest()
 		latestHdr, err := ccw.ledger.BlockHdr(latest)
 		if err != nil {
 			ccw.log.Warnf("ccw.signer(): BlockHdr(latest %d): %v", latest, err)
 			time.Sleep(1 * time.Second)
+			latest = ccw.ledger.Latest()
 			continue
 		}
 
-		nextrnd := latestHdr.CompactCertNextRound
+		nextrnd = latestHdr.CompactCertNextRound
 		if nextrnd == 0 {
 			// Compact certs not enabled yet.  Keep monitoring new blocks.
 			nextrnd = latest + 1
@@ -65,10 +66,12 @@ func (ccw *Worker) signer() {
 			if err != nil {
 				ccw.log.Warnf("ccw.signer(): BlockHdr(next %d): %v", nextrnd, err)
 				time.Sleep(1 * time.Second)
-				continue
+				latest = ccw.ledger.Latest()
+				goto restart
 			}
 
 			ccw.signBlock(hdr)
+			ccw.signedBlock(nextrnd)
 			nextrnd++
 
 		case <-ccw.ctx.Done():
@@ -119,7 +122,7 @@ func (ccw *Worker) signBlock(hdr bookkeeping.BlockHeader) {
 
 	var sigs []sigFromAddr
 	var sigkeys []crypto.OneTimeSignatureVerifier
-	for _, key := range ccw.accts.Keys() {
+	for _, key := range keys {
 		if key.FirstValid <= sigKeyRound && sigKeyRound <= key.LastValid {
 			keyDilution := key.KeyDilution
 			if keyDilution == 0 {

--- a/compactcert/worker.go
+++ b/compactcert/worker.go
@@ -22,10 +22,8 @@ import (
 	"sync"
 
 	"github.com/algorand/go-algorand/crypto/compactcert"
-	"github.com/algorand/go-algorand/data"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
-	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/network"
@@ -42,12 +40,6 @@ type builder struct {
 	votersHdr bookkeeping.BlockHeader
 }
 
-// TransactionSender is an interface that captures the node's ability
-// to broadcast a new transaction.
-type TransactionSender interface {
-	BroadcastSignedTxGroup([]transactions.SignedTxn) error
-}
-
 // Worker builds compact certificates, by broadcasting
 // signatures using this node's participation keys, by collecting
 // signatures sent by others, and by sending out the resulting
@@ -59,9 +51,9 @@ type Worker struct {
 
 	db        db.Accessor
 	log       logging.Logger
-	accts     *data.AccountManager
-	ledger    *ledger.Ledger
-	net       network.GossipNode
+	accts     Accounts
+	ledger    Ledger
+	net       Network
 	txnSender TransactionSender
 
 	// builders is indexed by the round of the block being signed.
@@ -73,7 +65,7 @@ type Worker struct {
 }
 
 // NewWorker constructs a new Worker, as used by the node.
-func NewWorker(db db.Accessor, log logging.Logger, accts *data.AccountManager, ledger *ledger.Ledger, net network.GossipNode, txnSender TransactionSender) *Worker {
+func NewWorker(db db.Accessor, log logging.Logger, accts Accounts, ledger Ledger, net Network, txnSender TransactionSender) *Worker {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &Worker{

--- a/compactcert/worker_test.go
+++ b/compactcert/worker_test.go
@@ -1,0 +1,339 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package compactcert
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/crypto/compactcert"
+	"github.com/algorand/go-algorand/crypto/merklearray"
+	"github.com/algorand/go-algorand/data/account"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/ledger"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/network"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/util/db"
+)
+
+type testWorkerStubs struct {
+	t       testing.TB
+	mu      sync.Mutex
+	latest  basics.Round
+	waiters map[basics.Round]chan struct{}
+	blocks  map[basics.Round]bookkeeping.BlockHeader
+	keys    []account.Participation
+	sigmsg  chan []byte
+	txmsg   chan transactions.SignedTxn
+	totalWeight int
+}
+
+func newWorkerStubs(t testing.TB, keys []account.Participation, totalWeight int) *testWorkerStubs {
+	s := &testWorkerStubs{
+		waiters: make(map[basics.Round]chan struct{}),
+		blocks:  make(map[basics.Round]bookkeeping.BlockHeader),
+		sigmsg:  make(chan []byte, 1024),
+		txmsg:   make(chan transactions.SignedTxn, 1024),
+		keys:    keys,
+		totalWeight: totalWeight,
+	}
+	s.latest--
+	s.addBlock()
+	return s
+}
+
+func (s *testWorkerStubs) addBlock() {
+	s.latest++
+
+	hdr := bookkeeping.BlockHeader{}
+	hdr.Round = s.latest
+	hdr.CurrentProtocol = protocol.ConsensusFuture
+	hdr.CompactCertVotersTotal.Raw = uint64(s.totalWeight)
+
+	if hdr.Round > 0 {
+		// Just so it's not zero, since the signer logic checks for all-zeroes
+		hdr.CompactCertVoters[1] = 0x12
+	}
+
+	if s.latest == 0 {
+		hdr.CompactCertNextRound = 2 * basics.Round(config.Consensus[hdr.CurrentProtocol].CompactCertRounds)
+	} else {
+		hdr.CompactCertNextRound = s.blocks[s.latest-1].CompactCertNextRound
+	}
+
+	s.blocks[s.latest] = hdr
+	if s.waiters[s.latest] != nil {
+		close(s.waiters[s.latest])
+	}
+}
+
+func (s *testWorkerStubs) Keys() []account.Participation {
+	return s.keys
+}
+
+func (s *testWorkerStubs) BlockHdr(r basics.Round) (bookkeeping.BlockHeader, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	hdr, ok := s.blocks[r]
+	if !ok {
+		return hdr, ledgercore.ErrNoEntry{
+			Round:     r,
+			Latest:    s.latest,
+			Committed: s.latest,
+		}
+	}
+
+	return hdr, nil
+}
+
+func (s *testWorkerStubs) CompactCertVoters(r basics.Round) (*ledger.VotersForRound, error) {
+	voters := &ledger.VotersForRound{
+		Proto:       config.Consensus[protocol.ConsensusFuture],
+		AddrToPos:   make(map[basics.Address]uint64),
+		TotalWeight: basics.MicroAlgos{Raw: uint64(s.totalWeight)},
+	}
+
+	for i, k := range s.keys {
+		voters.AddrToPos[k.Parent] = uint64(i)
+		voters.Participants = append(voters.Participants, compactcert.Participant{
+			PK:          k.Voting.OneTimeSignatureVerifier,
+			Weight:      1,
+			KeyDilution: config.Consensus[protocol.ConsensusFuture].DefaultKeyDilution,
+		})
+	}
+
+	tree, err := merklearray.Build(voters.Participants)
+	if err != nil {
+		return nil, err
+	}
+
+	voters.Tree = tree
+	return voters, nil
+}
+
+func (s *testWorkerStubs) GenesisHash() crypto.Digest {
+	return crypto.Digest{0x01, 0x02, 0x03, 0x04}
+}
+
+func (s *testWorkerStubs) Latest() basics.Round {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.latest
+}
+
+func (s *testWorkerStubs) Wait(r basics.Round) chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.waiters[r] == nil {
+		s.waiters[r] = make(chan struct{})
+		if r <= s.latest {
+			close(s.waiters[r])
+		}
+	}
+	return s.waiters[r]
+}
+
+func (s *testWorkerStubs) Broadcast(ctx context.Context, tag protocol.Tag, data []byte, wait bool, except network.Peer) error {
+	require.Equal(s.t, tag, protocol.CompactCertSigTag)
+	s.sigmsg <- data
+	return nil
+}
+
+func (s *testWorkerStubs) BroadcastSignedTxGroup(tx []transactions.SignedTxn) error {
+	require.Equal(s.t, len(tx), 1)
+	s.txmsg <- tx[0]
+	return nil
+}
+
+func (s *testWorkerStubs) RegisterHandlers([]network.TaggedMessageHandler) {
+}
+
+func (s *testWorkerStubs) advanceLatest(delta uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for r := uint64(0); r < delta; r++ {
+		s.addBlock()
+	}
+}
+
+func newTestWorker(t testing.TB, s *testWorkerStubs) *Worker {
+	dbs, _ := dbOpenTest(t, true)
+	return NewWorker(dbs.Wdb, logging.TestingLog(t), s, s, s, s)
+}
+
+func newPartKey(t testing.TB, parent basics.Address) account.Participation {
+	fn := fmt.Sprintf("%s.%d", strings.ReplaceAll(t.Name(), "/", "."), crypto.RandUint64())
+	partDB, err := db.MakeAccessor(fn, false, true)
+	require.NoError(t, err)
+
+	part, err := account.FillDBWithParticipationKeys(partDB, parent, 0, 1024*1024, config.Consensus[protocol.ConsensusFuture].DefaultKeyDilution)
+	require.NoError(t, err)
+	return part
+}
+
+func TestWorkerAllSigs(t *testing.T) {
+	var keys []account.Participation
+	for i := 0; i < 10; i++ {
+		var parent basics.Address
+		crypto.RandBytes(parent[:])
+		keys = append(keys, newPartKey(t, parent))
+	}
+
+	s := newWorkerStubs(t, keys, len(keys))
+	w := newTestWorker(t, s)
+	w.Start()
+	defer w.Shutdown()
+
+	proto := config.Consensus[protocol.ConsensusFuture]
+	s.advanceLatest(proto.CompactCertRounds + proto.CompactCertRounds/2)
+
+	// Go through several iterations, making sure that we get
+	// the signatures and certs broadcast at each round.
+	for iter := 0; iter < 5; iter++ {
+		s.advanceLatest(proto.CompactCertRounds)
+
+		for i := 0; i < len(keys); i++ {
+			// Expect all signatures to be broadcast.
+			_ = <-s.sigmsg
+		}
+
+		// Expect a compact cert to be formed.
+		for {
+			tx := <-s.txmsg
+			require.Equal(t, tx.Txn.Type, protocol.CompactCertTx)
+			if tx.Txn.CertRound < basics.Round(iter+2) * basics.Round(proto.CompactCertRounds) {
+				continue
+			}
+
+			require.Equal(t, tx.Txn.CertRound, basics.Round(iter+2) * basics.Round(proto.CompactCertRounds))
+
+			signedHdr, err := s.BlockHdr(tx.Txn.CertRound)
+			require.NoError(t, err)
+
+			ccparams := compactcert.Params{
+				Msg:          signedHdr,
+				ProvenWeight: uint64(s.totalWeight) * proto.CompactCertWeightThreshold / 100,
+				SigRound:     basics.Round(signedHdr.Round + 1),
+				SecKQ:        proto.CompactCertSecKQ,
+			}
+
+			voters, err := s.CompactCertVoters(tx.Txn.CertRound - basics.Round(proto.CompactCertRounds) - basics.Round(proto.CompactCertVotersLookback))
+			require.NoError(t, err)
+
+			verif := compactcert.MkVerifier(ccparams, voters.Tree.Root())
+			err = verif.Verify(&tx.Txn.Cert)
+			require.NoError(t, err)
+			break
+		}
+	}
+}
+
+func TestWorkerPartialSigs(t *testing.T) {
+	var keys []account.Participation
+	for i := 0; i < 7; i++ {
+		var parent basics.Address
+		crypto.RandBytes(parent[:])
+		keys = append(keys, newPartKey(t, parent))
+	}
+
+	s := newWorkerStubs(t, keys, 10)
+	w := newTestWorker(t, s)
+	w.Start()
+	defer w.Shutdown()
+
+	proto := config.Consensus[protocol.ConsensusFuture]
+	s.advanceLatest(proto.CompactCertRounds + proto.CompactCertRounds/2)
+	s.advanceLatest(proto.CompactCertRounds)
+
+	for i := 0; i < len(keys); i++ {
+		// Expect all signatures to be broadcast.
+		_ = <-s.sigmsg
+	}
+
+	// No compact cert should be formed yet: not enough sigs for a cert this early.
+	select {
+	case <-s.txmsg:
+		t.Fatal("compact cert formed too early")
+	case <-time.After(time.Second):
+	}
+
+	// Expect a compact cert to be formed in the next CompactCertRounds/2.
+	s.advanceLatest(proto.CompactCertRounds/2)
+	tx := <-s.txmsg
+	require.Equal(t, tx.Txn.Type, protocol.CompactCertTx)
+	require.Equal(t, tx.Txn.CertRound, 2 * basics.Round(proto.CompactCertRounds))
+
+	signedHdr, err := s.BlockHdr(tx.Txn.CertRound)
+	require.NoError(t, err)
+
+	ccparams := compactcert.Params{
+		Msg:          signedHdr,
+		ProvenWeight: uint64(s.totalWeight) * proto.CompactCertWeightThreshold / 100,
+		SigRound:     basics.Round(signedHdr.Round + 1),
+		SecKQ:        proto.CompactCertSecKQ,
+	}
+
+	voters, err := s.CompactCertVoters(tx.Txn.CertRound - basics.Round(proto.CompactCertRounds) - basics.Round(proto.CompactCertVotersLookback))
+	require.NoError(t, err)
+
+	verif := compactcert.MkVerifier(ccparams, voters.Tree.Root())
+	err = verif.Verify(&tx.Txn.Cert)
+	require.NoError(t, err)
+}
+
+func TestWorkerInsufficientSigs(t *testing.T) {
+	var keys []account.Participation
+	for i := 0; i < 2; i++ {
+		var parent basics.Address
+		crypto.RandBytes(parent[:])
+		keys = append(keys, newPartKey(t, parent))
+	}
+
+	s := newWorkerStubs(t, keys, 10)
+	w := newTestWorker(t, s)
+	w.Start()
+	defer w.Shutdown()
+
+	proto := config.Consensus[protocol.ConsensusFuture]
+	s.advanceLatest(3 * proto.CompactCertRounds)
+
+	for i := 0; i < len(keys); i++ {
+		// Expect all signatures to be broadcast.
+		_ = <-s.sigmsg
+	}
+
+	// No compact cert should be formed: not enough sigs.
+	select {
+	case <-s.txmsg:
+		t.Fatal("compact cert formed without enough sigs")
+	case <-time.After(time.Second):
+	}
+}

--- a/compactcert/worker_test.go
+++ b/compactcert/worker_test.go
@@ -238,9 +238,12 @@ func TestWorkerAllSigs(t *testing.T) {
 			signedHdr, err := s.BlockHdr(tx.Txn.CertRound)
 			require.NoError(t, err)
 
+			provenWeight, overflowed := basics.Muldiv(uint64(s.totalWeight), uint64(proto.CompactCertWeightThreshold), 1<<32)
+			require.False(t, overflowed)
+
 			ccparams := compactcert.Params{
 				Msg:          signedHdr,
-				ProvenWeight: uint64(s.totalWeight) * proto.CompactCertWeightThreshold / 100,
+				ProvenWeight: provenWeight,
 				SigRound:     basics.Round(signedHdr.Round + 1),
 				SecKQ:        proto.CompactCertSecKQ,
 			}
@@ -294,9 +297,12 @@ func TestWorkerPartialSigs(t *testing.T) {
 	signedHdr, err := s.BlockHdr(tx.Txn.CertRound)
 	require.NoError(t, err)
 
+	provenWeight, overflowed := basics.Muldiv(uint64(s.totalWeight), uint64(proto.CompactCertWeightThreshold), 1<<32)
+	require.False(t, overflowed)
+
 	ccparams := compactcert.Params{
 		Msg:          signedHdr,
-		ProvenWeight: uint64(s.totalWeight) * proto.CompactCertWeightThreshold / 100,
+		ProvenWeight: provenWeight,
 		SigRound:     basics.Round(signedHdr.Round + 1),
 		SecKQ:        proto.CompactCertSecKQ,
 	}

--- a/compactcert/worker_test.go
+++ b/compactcert/worker_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 

--- a/test/e2e-go/features/compactcert/compactcert_test.go
+++ b/test/e2e-go/features/compactcert/compactcert_test.go
@@ -114,7 +114,7 @@ func TestCompactCerts(t *testing.T) {
 				Msg:          nextCertBlockDecoded.Block.BlockHeader,
 				ProvenWeight: lastCertBlock.CompactCertVotersTotal * consensusParams.CompactCertWeightThreshold / 100,
 				SigRound:     basics.Round(nextCertBlock.Round + 1),
-				SecKQ:        128,
+				SecKQ:        consensusParams.CompactCertSecKQ,
 			}
 			verif := compactcert.MkVerifier(ccparams, votersRoot)
 			err = verif.Verify(&compactCert)


### PR DESCRIPTION
This PR adds unit tests to the compactcert package, as suggested by Pavel.

As part of introducing these unit tests, this PR refactors the worker threads to be more predictable when the test harness is quickly advancing rounds in the simulated ledger.