### PR TITLE
update go.mod/sum to use msgp 46

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/algorand/go-codec/codec v0.0.0-20190507210007-269d70b6135d
 	github.com/algorand/go-deadlock v0.2.1
 	github.com/algorand/graphtrace v0.0.0-20201117160756-e524ed1a6f64
-	github.com/algorand/msgp v1.1.45
+	github.com/algorand/msgp v1.1.46
 	github.com/algorand/oapi-codegen v1.3.5-algorand5
 	github.com/algorand/websocket v1.4.1
 	github.com/aws/aws-sdk-go v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/algorand/graphtrace v0.0.0-20201023193244-96dde3c58a7a h1:0vQcZhPB7rC
 github.com/algorand/graphtrace v0.0.0-20201023193244-96dde3c58a7a/go.mod h1:qFtQmC+kmsfnLfS9j3xgKtzsWyozemL5ek1R4dWZa5c=
 github.com/algorand/graphtrace v0.0.0-20201117160756-e524ed1a6f64 h1:yvKeJdS/mvLRiyIxu8j5BQDXIzs1XbC9/22KycJnt3A=
 github.com/algorand/graphtrace v0.0.0-20201117160756-e524ed1a6f64/go.mod h1:qFtQmC+kmsfnLfS9j3xgKtzsWyozemL5ek1R4dWZa5c=
-github.com/algorand/msgp v1.1.45 h1:uLEPvg0BfTrb2JjBcXexON8il4vv0EsD7HYFaA7e5jg=
-github.com/algorand/msgp v1.1.45/go.mod h1:LtOntbYiCHj/Sl/Sqxtf8CZOrDt2a8Dv3tLaS6mcnUE=
+github.com/algorand/msgp v1.1.46 h1:R2C3pr4WDLrqAisFVJVSvGtQO9pk9eikOL/4u07K38g=
+github.com/algorand/msgp v1.1.46/go.mod h1:LtOntbYiCHj/Sl/Sqxtf8CZOrDt2a8Dv3tLaS6mcnUE=
 github.com/algorand/oapi-codegen v1.3.5-algorand5 h1:y576Ca2/guQddQrQA7dtL5KcOx5xQgPeIupiuFMGyCI=
 github.com/algorand/oapi-codegen v1.3.5-algorand5/go.mod h1:/k0Ywn0lnt92uBMyE+yiRf/Wo3/chxHHsAfenD09EbY=
 github.com/algorand/websocket v1.4.1 h1:FPoNHI8i2VZWZzhCscY8JTzsAE7Vv73753cMbzb3udk=


### PR DESCRIPTION
## Summary

update go.mod/sum to use msgp 46, which is a prerequisite to subsequent PR.

This new version of msgp supports including embedded structures from different packages.

## Test Plan

Tests included in msgp library

## Notes

The changes made in the msgp are not expected to make any changes before the subsequent PR is added.