### PR TITLE
Fix tealdbg Accounts array

### DIFF
--- a/cmd/tealdbg/cdtState.go
+++ b/cmd/tealdbg/cdtState.go
@@ -721,7 +721,7 @@ func makeTxnImpl(txn *transactions.Transaction, groupIndex int, preview bool) (d
 		var length int
 		switch logic.TxnField(fieldIdx) {
 		case logic.Accounts:
-			length = len(txn.Accounts)
+			length = len(txn.Accounts) + 1
 		case logic.ApplicationArgs:
 			length = len(txn.ApplicationArgs)
 		}
@@ -765,7 +765,7 @@ func makeTxnArrayField(s *cdtState, groupIndex int, fieldIdx int) (desc []cdt.Ru
 		var length int
 		switch logic.TxnField(fieldIdx) {
 		case logic.Accounts:
-			length = len(txn.Accounts)
+			length = len(txn.Accounts) + 1
 		case logic.ApplicationArgs:
 			length = len(txn.ApplicationArgs)
 		}


### PR DESCRIPTION
## Summary

Currently the `Accounts` array is not displayed properly in tealdbg. The debugger does not account for the special case that index 0 of the `Accounts` array is always the sender. This means that if the ForeignAccounts txn field contains `n` accounts, the `Accounts` array in tealdbg contains the sender's account followed by `n-1` of the ForeignAccounts. The last account never gets displayed.

This PR fixes this problem by making tealdbg aware that the `Accounts` array has 1 more member (the sender's account) than `len(txn.Accounts)`. As a consequence of this, the sender's account will always appear at index 0 of the `Accounts` array in the debugger, even when the transaction's ForeignAccounts array is empty. This aligns with the behavior of the TEAL op `txna Accounts 0` always returning the sender's address, even in stateless TEAL.

## Test Plan

Tested visually on the following txn group:

```
txns.msgp[0]
{
  ...
}
txns.msgp[1]
{
  "sig": "eGj0ng3AH2AtKDCKJ8kGKxaLIcx2lNuY5/icVVGk5eklrqPK8wby4lgytE7gRg5VbZoZlh+gI0BIUfm/kzP8Bg==",
  "txn": {
    "apaa": [
      "c3dhcA==",
      "Zmk="
    ],
    "apat": [
      "ECMT7R5ZU2U4RWFV3D3GOE3ORSJ4WTZNUTPAUJH5KT7YYLGGMOVVUA2KAA"
    ],
    "apid": 18167,
    "fee": 1000,
    "fv": 115378,
    "gen": "sandnet-v1",
    "gh": "fNM6YsUZ/negqJ9mnBt348s38pbuoe/Xyw9iT6VUbzg=",
    "grp": "H6B8jJ3AACvyz7uEnjxeccFJL6sR5GyYQNi8nF4WZYo=",
    "lv": 116378,
    "snd": "XZ7SYOHYQAEES7XIEJ554GET66IEDEA7ABMGGH3ELQZNTSTK36BMCAAY7A",
    "type": "appl"
  }
}
txns.msgp[2]
{
  ...
}
txns.msgp[3]
{
  ...
}
```

<details>
<summary>Behavior before this PR:</summary>
<p>Note that the Accounts array should contain "ECMT7R5ZU2U4RWFV3D3GOE3ORSJ4WTZNUTPAUJH5KT7YYLGGMOVVUA2KAA", but it only contains the sender's address.</p>
<img src="https://user-images.githubusercontent.com/5856867/106161550-26713580-6155-11eb-94b2-fe5e71f128e9.png">
</details>

<details>
<summary>Behavior with this PR:</summary>
<p>Now the Accounts array correctly shows the sender's address at index 0 and the first ForeignAccount argument at index 1.</p>
<img src="https://user-images.githubusercontent.com/5856867/106161556-28d38f80-6155-11eb-8cba-bcdbb304965a.png">
</details>