### PR TITLE
Handle #pragma errors more like all others

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -942,10 +942,6 @@ type lineError struct {
 	Err  error
 }
 
-func fmtLineError(line int, format string, args ...interface{}) error {
-	return &lineError{Line: line, Err: fmt.Errorf(format, args...)}
-}
-
 func (le *lineError) Error() string {
 	return fmt.Sprintf("%d: %s", le.Line, le.Err.Error())
 }
@@ -1086,14 +1082,18 @@ func (ops *OpStream) assemble(fin io.Reader) error {
 			continue
 		}
 		if strings.HasPrefix(line, "#pragma") {
-			// all pragmas must be be already processed in advance
 			ops.trace("%d: #pragma line\n", ops.sourceLine)
+			ops.pragma(line)
 			continue
 		}
 		fields := fieldsFromLine(line)
 		if len(fields) == 0 {
 			ops.trace("%d: no fields\n", ops.sourceLine)
 			continue
+		}
+		// we're going to process opcodes, so fix the Version
+		if ops.Version == assemblerNoVersion {
+			ops.Version = AssemblerDefaultVersion
 		}
 		opstring := fields[0]
 		spec, ok := opsByName[ops.Version][opstring]
@@ -1141,6 +1141,49 @@ func (ops *OpStream) assemble(fin io.Reader) error {
 	}
 	ops.Program = program
 	return nil
+}
+
+func (ops *OpStream) pragma(line string) error {
+	fields := strings.Split(line, " ")
+	if fields[0] != "#pragma" {
+		return ops.errorf("invalid syntax: %s", fields[0])
+	}
+	if len(fields) < 2 {
+		return ops.error("empty pragma")
+	}
+	key := fields[1]
+	switch key {
+	case "version":
+		if len(fields) < 3 {
+			return ops.error("no version value")
+		}
+		value := fields[2]
+		var ver uint64
+		if ops.pending.Len() > 0 {
+			return ops.error("#pragma version is only allowed before instructions")
+		}
+		ver, err := strconv.ParseUint(value, 0, 64)
+		if err != nil {
+			return ops.error(err)
+		}
+		if ver < 1 || ver > AssemblerMaxVersion {
+			return ops.errorf("unsupported version: %d", ver)
+		}
+
+		// We initialize Version with assemblerNoVersion as a marker for
+		// non-specified version because version 0 is valid
+		// version for TEAL v1.
+		if ops.Version == assemblerNoVersion {
+			ops.Version = ver
+		} else if ops.Version != ver {
+			return ops.errorf("version mismatch: assembling v%d with v%d assembler", ops.Version, ver)
+		} else {
+			// ops.Version is already correct
+		}
+		return nil
+	default:
+		return ops.errorf("unsupported pragma directive: %s", key)
+	}
 }
 
 func (ops *OpStream) resolveLabels() {
@@ -1300,80 +1343,9 @@ func AssembleString(text string) (*OpStream, error) {
 // to warnings, (multiple) errors, or the PC to source line mapping.
 func AssembleStringWithVersion(text string, version uint64) (*OpStream, error) {
 	sr := strings.NewReader(text)
-	ps := PragmaStream{}
-	err := ps.Process(sr)
-	if err != nil {
-		return nil, err
-	}
-	// If version not set yet then set either default or #pragma version.
-	// We have to use assemblerNoVersion as a marker for non-specified version
-	// because version 0 is valid version for TEAL v1
-	if version == assemblerNoVersion {
-		if ps.Version != 0 {
-			version = ps.Version
-		} else {
-			version = AssemblerDefaultVersion
-		}
-	} else if ps.Version != 0 && version != ps.Version {
-		err = fmt.Errorf("version mismatch: assembling v%d with v%d assembler", ps.Version, version)
-		return nil, err
-	} else {
-		// otherwise the passed version matches the pragma and we are ok
-	}
-
-	sr = strings.NewReader(text)
 	ops := OpStream{Version: version}
-	err = ops.assemble(sr)
+	err := ops.assemble(sr)
 	return &ops, err
-}
-
-// PragmaStream represents all parsed pragmas from the program
-type PragmaStream struct {
-	Version uint64
-}
-
-// Process all pragmas in the input stream
-func (ps *PragmaStream) Process(fin io.Reader) (err error) {
-	scanner := bufio.NewScanner(fin)
-	sourceLine := 0
-	for scanner.Scan() {
-		sourceLine++
-		line := scanner.Text()
-		if len(line) == 0 || !strings.HasPrefix(line, "#pragma") {
-			continue
-		}
-
-		fields := strings.Split(line, " ")
-		if fields[0] != "#pragma" {
-			return fmtLineError(sourceLine, "invalid syntax: %s", fields[0])
-		}
-		if len(fields) < 2 {
-			return fmtLineError(sourceLine, "empty pragma")
-		}
-		key := fields[1]
-		switch key {
-		case "version":
-			if len(fields) < 3 {
-				return fmtLineError(sourceLine, "no version value")
-			}
-			value := fields[2]
-			var ver uint64
-			if sourceLine != 1 {
-				return fmtLineError(sourceLine, "#pragma version is only allowed on 1st line")
-			}
-			ver, err = strconv.ParseUint(value, 0, 64)
-			if err != nil {
-				return &lineError{Line: sourceLine, Err: err}
-			}
-			if ver < 1 || ver > AssemblerMaxVersion {
-				return fmtLineError(sourceLine, "unsupported version: %d", ver)
-			}
-			ps.Version = ver
-		default:
-			return fmtLineError(sourceLine, "unsupported pragma directive: %s", key)
-		}
-	}
-	return
 }
 
 type disassembleState struct {


### PR DESCRIPTION
This moves #pragma handling into the main loop of assembly, allowing
simpler error reporting.  Multiple errors that include pragma errors
and "normal" errors can both be reported.  Since this fixes #1874, I
want to get it into mainline, rather than waiting for the teal3
branch.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged.

## Test Plan

How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale.
