### PR TITLE
Remove jq from check golang version script to fix deploy jobs in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ stages:
   - name: build_release
     if: branch =~ /^rel\// AND type != pull_request
   - name: deploy
-    if: type = pull_request
+    if: branch =~ /^rel\// AND type != pull_request
   - name: post_deploy
     if: branch =~ /^rel\// AND type != pull_request
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,16 @@ language: go
 if: tag IS blank
 
 stages:
-  - name: build_commit
-    if: NOT (branch =~ /^rel\//) AND type != pull_request
-  - name: build_pr
-    if: type = pull_request
-  - name: build_release
-    if: branch =~ /^rel\// AND type != pull_request
+  # - name: build_commit
+  #   if: NOT (branch =~ /^rel\//) AND type != pull_request
+  # - name: build_pr
+  #   if: type = pull_request
+  # - name: build_release
+  #   if: branch =~ /^rel\// AND type != pull_request
   - name: deploy
-    if: branch =~ /^rel\// AND type != pull_request
-  - name: post_deploy
-    if: branch =~ /^rel\// AND type != pull_request
+    if: type = pull_request
+  # - name: post_deploy
+  #   if: branch =~ /^rel\// AND type != pull_request
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,16 @@ language: go
 if: tag IS blank
 
 stages:
-  # - name: build_commit
-  #   if: NOT (branch =~ /^rel\//) AND type != pull_request
-  # - name: build_pr
-  #   if: type = pull_request
-  # - name: build_release
-  #   if: branch =~ /^rel\// AND type != pull_request
+  - name: build_commit
+    if: NOT (branch =~ /^rel\//) AND type != pull_request
+  - name: build_pr
+    if: type = pull_request
+  - name: build_release
+    if: branch =~ /^rel\// AND type != pull_request
   - name: deploy
     if: type = pull_request
-  # - name: post_deploy
-  #   if: branch =~ /^rel\// AND type != pull_request
+  - name: post_deploy
+    if: branch =~ /^rel\// AND type != pull_request
 
 jobs:
   allow_failures:

--- a/scripts/check_golang_version.sh
+++ b/scripts/check_golang_version.sh
@@ -38,7 +38,7 @@ elif [ "$1" == "build" ]; then
     fi
 else
     # Check to make sure that it matches what is specified in `go.mod`.
-    GOMOD_VERSION=$(go mod edit -json | jq -r ".Go")
+    GOMOD_VERSION=$(go mod edit -print | awk '/^go[ \t]+[0-9]+\.[0-9]+(\.[0-9]+)?[ \t]*$/{print $2}')
 
     if [[ ! "${BUILD_VERSION}" =~ ^"${GOMOD_VERSION}" ]]; then
         echo "[$0] ERROR: go version mismatch, go mod version ${GOMOD_VERSION} does not match required version ${BUILD_VERSION}"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

A change to use go tooling to get go version from go.mod used jq to parse the results. This breaks on platforms that don't have jq. This change just removes the dependency (and replaces it with the more accessible awk).

## Test Plan

Set travis to run the deploy jobs with the change, and verify they succeed.
