### PR TITLE
faster computation of transaction ID and length

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -763,7 +763,7 @@ func (pool *TransactionPool) AssembleBlock(round basics.Round, deadline time.Tim
 
 				for i, txib := range payset {
 					fee := txib.Txn.Fee.Raw
-					encodedLen := len(protocol.Encode(&txib))
+					encodedLen := txib.GetEncodedLength()
 
 					stats.IncludedCount++
 					totalFees += fee

--- a/data/transactions/signedtxn.go
+++ b/data/transactions/signedtxn.go
@@ -70,7 +70,16 @@ func (s SignedTxnInBlock) ID() {
 
 // GetEncodedLength returns the length in bytes of the encoded transaction
 func (s SignedTxn) GetEncodedLength() int {
-	return len(protocol.Encode(&s))
+	enc := s.MarshalMsg(protocol.GetEncodingBuf())
+	defer protocol.PutEncodingBuf(enc)
+	return len(enc)
+}
+
+// GetEncodedLength returns the length in bytes of the encoded transaction
+func (s SignedTxnInBlock) GetEncodedLength() int {
+	enc := s.MarshalMsg(protocol.GetEncodingBuf())
+	defer protocol.PutEncodingBuf(enc)
+	return len(enc)
 }
 
 // Authorizer returns the address against which the signature/msig/lsig should be checked,

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -156,7 +156,9 @@ func (tx Transaction) ToBeHashed() (protocol.HashID, []byte) {
 
 // ID returns the Txid (i.e., hash) of the transaction.
 func (tx Transaction) ID() Txid {
-	return Txid(crypto.HashObj(tx))
+	enc := tx.MarshalMsg(append(protocol.GetEncodingBuf(), []byte(protocol.Transaction)...))
+	defer protocol.PutEncodingBuf(enc)
+	return Txid(crypto.Hash(enc))
 }
 
 // Sign signs a transaction using a given Account's secrets.

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -733,7 +733,7 @@ func (eval *BlockEvaluator) transactionGroup(txgroup []transactions.SignedTxnWit
 		txibs = append(txibs, txib)
 
 		if eval.validate {
-			groupTxBytes += len(protocol.Encode(&txib))
+			groupTxBytes += txib.GetEncodedLength()
 			if eval.blockTxBytes+groupTxBytes > eval.proto.MaxTxnBytesPerBlock {
 				return ErrNoSpace
 			}

--- a/protocol/codec.go
+++ b/protocol/codec.go
@@ -241,3 +241,25 @@ func NewJSONDecoder(r io.Reader) Decoder {
 func NewDecoderBytes(b []byte) Decoder {
 	return codec.NewDecoderBytes(b, CodecHandle)
 }
+
+// encodingPool holds temporary byte slice buffers used for encoding messages.
+var encodingPool = sync.Pool{
+	New: func() interface{} {
+		return []byte{}
+	},
+}
+
+// GetEncodingBuf returns a byte slice that can be used for encoding a
+// temporary message.  The byte slice has zero length but potentially
+// non-zero capacity.  The caller gets full ownership of the byte slice,
+// but is encouraged to return it using PutEncodingBuf().
+func GetEncodingBuf() []byte {
+	return encodingPool.Get().([]byte)[:0]
+}
+
+// PutEncodingBuf places a byte slice into the pool of temporary buffers
+// for encoding.  The caller gives up ownership of the byte slice when
+// passing it to PutEncodingBuf().
+func PutEncodingBuf(s []byte) {
+	encodingPool.Put(s)
+}


### PR DESCRIPTION
This change optimizes ID() and GetEncodedLength() for Transaction, SignedTxn, and SignedTxnInBlock.  There are two sources of overhead that this change avoids: interface conversions (to msgp.Marshaler) and memory allocations (for temporary slices to hold the encoding).

To avoid interface conversions, the code invokes the msgp-generated MarshalMsg() method directly.

To avoid memory allocation overhead, the code uses a sync.Pool to track existing dirty slices that can be used for encoding.  This seems to be more efficient than letting the Go GC manage slices, probably because the encoder is OK with dirty (non-zero) slices.

This significantly improves performance according to BenchmarkEncoding (in data/transactions).  Before this change:

    BenchmarkEncoding/EncodeLen-32          276892        4363 ns/op
    BenchmarkEncoding/ID-32                 169942        7131 ns/op

After this change:

    BenchmarkEncoding/EncodeLen-32         1963832         593 ns/op
    BenchmarkEncoding/ID-32                1109022        1042 ns/op

The broader use of this change is in significantly speeding up the Merkle tree computation for PR #1879.