### PR TITLE
use the error-free msgp encoding

### DIFF
--- a/agreement/msgp_gen.go
+++ b/agreement/msgp_gen.go
@@ -174,7 +174,7 @@ import (
 //
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Certificate) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Certificate) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0003Len := uint32(6)
@@ -215,11 +215,7 @@ func (z *Certificate) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).EquivocationVotes)))
 			}
 			for zb0002 := range (*z).EquivocationVotes {
-				o, err = (*z).EquivocationVotes[zb0002].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "EquivocationVotes", zb0002)
-					return
-				}
+				o = (*z).EquivocationVotes[zb0002].MarshalMsg(o)
 			}
 		}
 		if (zb0003Mask & 0x4) == 0 { // if not empty
@@ -230,20 +226,12 @@ func (z *Certificate) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x8) == 0 { // if not empty
 			// string "prop"
 			o = append(o, 0xa4, 0x70, 0x72, 0x6f, 0x70)
-			o, err = (*z).Proposal.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Proposal")
-				return
-			}
+			o = (*z).Proposal.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x10) == 0 { // if not empty
 			// string "rnd"
 			o = append(o, 0xa3, 0x72, 0x6e, 0x64)
-			o, err = (*z).Round.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Round")
-				return
-			}
+			o = (*z).Round.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x20) == 0 { // if not empty
 			// string "step"
@@ -259,11 +247,7 @@ func (z *Certificate) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).Votes)))
 			}
 			for zb0001 := range (*z).Votes {
-				o, err = (*z).Votes[zb0001].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Votes", zb0001)
-					return
-				}
+				o = (*z).Votes[zb0001].MarshalMsg(o)
 			}
 		}
 	}
@@ -532,7 +516,7 @@ func (z *Certificate) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *bundle) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *bundle) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0003Len := uint32(3)
@@ -561,21 +545,13 @@ func (z *bundle) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).EquivocationVotes)))
 			}
 			for zb0002 := range (*z).EquivocationVotes {
-				o, err = (*z).EquivocationVotes[zb0002].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "EquivocationVotes", zb0002)
-					return
-				}
+				o = (*z).EquivocationVotes[zb0002].MarshalMsg(o)
 			}
 		}
 		if (zb0003Mask & 0x4) == 0 { // if not empty
 			// string "u"
 			o = append(o, 0xa1, 0x75)
-			o, err = (*z).U.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "U")
-				return
-			}
+			o = (*z).U.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x8) == 0 { // if not empty
 			// string "vote"
@@ -586,11 +562,7 @@ func (z *bundle) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).Votes)))
 			}
 			for zb0001 := range (*z).Votes {
-				o, err = (*z).Votes[zb0001].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Votes", zb0001)
-					return
-				}
+				o = (*z).Votes[zb0001].MarshalMsg(o)
 			}
 		}
 	}
@@ -801,7 +773,7 @@ func (z *bundle) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *equivocationVote) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *equivocationVote) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0003Len := uint32(7)
@@ -840,11 +812,7 @@ func (z *equivocationVote) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x2) == 0 { // if not empty
 			// string "cred"
 			o = append(o, 0xa4, 0x63, 0x72, 0x65, 0x64)
-			o, err = (*z).Cred.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Cred")
-				return
-			}
+			o = (*z).Cred.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x4) == 0 { // if not empty
 			// string "per"
@@ -856,42 +824,26 @@ func (z *equivocationVote) MarshalMsg(b []byte) (o []byte, err error) {
 			o = append(o, 0xa5, 0x70, 0x72, 0x6f, 0x70, 0x73)
 			o = msgp.AppendArrayHeader(o, 2)
 			for zb0001 := range (*z).Proposals {
-				o, err = (*z).Proposals[zb0001].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Proposals", zb0001)
-					return
-				}
+				o = (*z).Proposals[zb0001].MarshalMsg(o)
 			}
 		}
 		if (zb0003Mask & 0x10) == 0 { // if not empty
 			// string "rnd"
 			o = append(o, 0xa3, 0x72, 0x6e, 0x64)
-			o, err = (*z).Round.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Round")
-				return
-			}
+			o = (*z).Round.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x20) == 0 { // if not empty
 			// string "sigs"
 			o = append(o, 0xa4, 0x73, 0x69, 0x67, 0x73)
 			o = msgp.AppendArrayHeader(o, 2)
 			for zb0002 := range (*z).Sigs {
-				o, err = (*z).Sigs[zb0002].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Sigs", zb0002)
-					return
-				}
+				o = (*z).Sigs[zb0002].MarshalMsg(o)
 			}
 		}
 		if (zb0003Mask & 0x40) == 0 { // if not empty
 			// string "snd"
 			o = append(o, 0xa3, 0x73, 0x6e, 0x64)
-			o, err = (*z).Sender.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sender")
-				return
-			}
+			o = (*z).Sender.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x80) == 0 { // if not empty
 			// string "step"
@@ -1142,7 +1094,7 @@ func (z *equivocationVote) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *equivocationVoteAuthenticator) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *equivocationVoteAuthenticator) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0003Len := uint32(4)
@@ -1151,38 +1103,22 @@ func (z *equivocationVoteAuthenticator) MarshalMsg(b []byte) (o []byte, err erro
 	if zb0003Len != 0 {
 		// string "cred"
 		o = append(o, 0xa4, 0x63, 0x72, 0x65, 0x64)
-		o, err = (*z).Cred.MarshalMsg(o)
-		if err != nil {
-			err = msgp.WrapError(err, "Cred")
-			return
-		}
+		o = (*z).Cred.MarshalMsg(o)
 		// string "props"
 		o = append(o, 0xa5, 0x70, 0x72, 0x6f, 0x70, 0x73)
 		o = msgp.AppendArrayHeader(o, 2)
 		for zb0002 := range (*z).Proposals {
-			o, err = (*z).Proposals[zb0002].MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Proposals", zb0002)
-				return
-			}
+			o = (*z).Proposals[zb0002].MarshalMsg(o)
 		}
 		// string "sig"
 		o = append(o, 0xa3, 0x73, 0x69, 0x67)
 		o = msgp.AppendArrayHeader(o, 2)
 		for zb0001 := range (*z).Sigs {
-			o, err = (*z).Sigs[zb0001].MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sigs", zb0001)
-				return
-			}
+			o = (*z).Sigs[zb0001].MarshalMsg(o)
 		}
 		// string "snd"
 		o = append(o, 0xa3, 0x73, 0x6e, 0x64)
-		o, err = (*z).Sender.MarshalMsg(o)
-		if err != nil {
-			err = msgp.WrapError(err, "Sender")
-			return
-		}
+		o = (*z).Sender.MarshalMsg(o)
 	}
 	return
 }
@@ -1369,7 +1305,7 @@ func (z *equivocationVoteAuthenticator) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z period) MarshalMsg(b []byte) (o []byte, err error) {
+func (z period) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendUint64(o, uint64(z))
 	return
@@ -1415,7 +1351,7 @@ func (z period) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *proposal) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *proposal) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0003Len := uint32(27)
@@ -1547,16 +1483,8 @@ func (z *proposal) MarshalMsg(b []byte) (o []byte, err error) {
 			for _, zb0001 := range zb0001_keys {
 				zb0002 := (*z).unauthenticatedProposal.Block.BlockHeader.CompactCert[zb0001]
 				_ = zb0002
-				o, err = zb0001.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "CompactCert", zb0001)
-					return
-				}
-				o, err = zb0002.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "CompactCert", zb0001)
-					return
-				}
+				o = zb0001.MarshalMsg(o)
+				o = zb0002.MarshalMsg(o)
 			}
 		}
 		if (zb0003Mask & 0x20) == 0 { // if not empty
@@ -1567,11 +1495,7 @@ func (z *proposal) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x40) == 0 { // if not empty
 			// string "fees"
 			o = append(o, 0xa4, 0x66, 0x65, 0x65, 0x73)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.FeeSink.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "FeeSink")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.FeeSink.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x80) == 0 { // if not empty
 			// string "frac"
@@ -1586,38 +1510,22 @@ func (z *proposal) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x200) == 0 { // if not empty
 			// string "gh"
 			o = append(o, 0xa2, 0x67, 0x68)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.GenesisHash.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "GenesisHash")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.GenesisHash.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x400) == 0 { // if not empty
 			// string "nextbefore"
 			o = append(o, 0xaa, 0x6e, 0x65, 0x78, 0x74, 0x62, 0x65, 0x66, 0x6f, 0x72, 0x65)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocolVoteBefore.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "NextProtocolVoteBefore")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocolVoteBefore.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x800) == 0 { // if not empty
 			// string "nextproto"
 			o = append(o, 0xa9, 0x6e, 0x65, 0x78, 0x74, 0x70, 0x72, 0x6f, 0x74, 0x6f)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocol.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "NextProtocol")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocol.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x1000) == 0 { // if not empty
 			// string "nextswitch"
 			o = append(o, 0xaa, 0x6e, 0x65, 0x78, 0x74, 0x73, 0x77, 0x69, 0x74, 0x63, 0x68)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocolSwitchOn.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "NextProtocolSwitchOn")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocolSwitchOn.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x2000) == 0 { // if not empty
 			// string "nextyes"
@@ -1632,29 +1540,17 @@ func (z *proposal) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x8000) == 0 { // if not empty
 			// string "oprop"
 			o = append(o, 0xa5, 0x6f, 0x70, 0x72, 0x6f, 0x70)
-			o, err = (*z).unauthenticatedProposal.OriginalProposer.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "OriginalProposer")
-				return
-			}
+			o = (*z).unauthenticatedProposal.OriginalProposer.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x10000) == 0 { // if not empty
 			// string "prev"
 			o = append(o, 0xa4, 0x70, 0x72, 0x65, 0x76)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.Branch.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Branch")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.Branch.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x20000) == 0 { // if not empty
 			// string "proto"
 			o = append(o, 0xa5, 0x70, 0x72, 0x6f, 0x74, 0x6f)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.CurrentProtocol.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CurrentProtocol")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.CurrentProtocol.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x40000) == 0 { // if not empty
 			// string "rate"
@@ -1664,47 +1560,27 @@ func (z *proposal) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x80000) == 0 { // if not empty
 			// string "rnd"
 			o = append(o, 0xa3, 0x72, 0x6e, 0x64)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.Round.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Round")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.Round.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x100000) == 0 { // if not empty
 			// string "rwcalr"
 			o = append(o, 0xa6, 0x72, 0x77, 0x63, 0x61, 0x6c, 0x72)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRecalculationRound.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RewardsRecalculationRound")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRecalculationRound.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x200000) == 0 { // if not empty
 			// string "rwd"
 			o = append(o, 0xa3, 0x72, 0x77, 0x64)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsPool.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RewardsPool")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsPool.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x400000) == 0 { // if not empty
 			// string "sdpf"
 			o = append(o, 0xa4, 0x73, 0x64, 0x70, 0x66)
-			o, err = (*z).unauthenticatedProposal.SeedProof.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "SeedProof")
-				return
-			}
+			o = (*z).unauthenticatedProposal.SeedProof.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x800000) == 0 { // if not empty
 			// string "seed"
 			o = append(o, 0xa4, 0x73, 0x65, 0x65, 0x64)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.Seed.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Seed")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.Seed.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x1000000) == 0 { // if not empty
 			// string "tc"
@@ -1719,38 +1595,22 @@ func (z *proposal) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x4000000) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.TxnRoot.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "TxnRoot")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.TxnRoot.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x8000000) == 0 { // if not empty
 			// string "txns"
 			o = append(o, 0xa4, 0x74, 0x78, 0x6e, 0x73)
-			o, err = (*z).unauthenticatedProposal.Block.Payset.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Payset")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.Payset.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x10000000) == 0 { // if not empty
 			// string "upgradedelay"
 			o = append(o, 0xac, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x64, 0x65, 0x6c, 0x61, 0x79)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeDelay.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "UpgradeDelay")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeDelay.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x20000000) == 0 { // if not empty
 			// string "upgradeprop"
 			o = append(o, 0xab, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x70, 0x72, 0x6f, 0x70)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradePropose.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "UpgradePropose")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradePropose.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x40000000) == 0 { // if not empty
 			// string "upgradeyes"
@@ -2282,7 +2142,7 @@ func (z *proposal) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *proposalValue) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *proposalValue) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(4)
@@ -2309,20 +2169,12 @@ func (z *proposalValue) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "dig"
 			o = append(o, 0xa3, 0x64, 0x69, 0x67)
-			o, err = (*z).BlockDigest.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "BlockDigest")
-				return
-			}
+			o = (*z).BlockDigest.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "encdig"
 			o = append(o, 0xa6, 0x65, 0x6e, 0x63, 0x64, 0x69, 0x67)
-			o, err = (*z).EncodingDigest.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "EncodingDigest")
-				return
-			}
+			o = (*z).EncodingDigest.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "oper"
@@ -2332,11 +2184,7 @@ func (z *proposalValue) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "oprop"
 			o = append(o, 0xa5, 0x6f, 0x70, 0x72, 0x6f, 0x70)
-			o, err = (*z).OriginalProposer.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "OriginalProposer")
-				return
-			}
+			o = (*z).OriginalProposer.MarshalMsg(o)
 		}
 	}
 	return
@@ -2477,23 +2325,15 @@ func (z *proposalValue) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *proposerSeed) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *proposerSeed) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 2
 	// string "addr"
 	o = append(o, 0x82, 0xa4, 0x61, 0x64, 0x64, 0x72)
-	o, err = (*z).Addr.MarshalMsg(o)
-	if err != nil {
-		err = msgp.WrapError(err, "Addr")
-		return
-	}
+	o = (*z).Addr.MarshalMsg(o)
 	// string "vrf"
 	o = append(o, 0xa3, 0x76, 0x72, 0x66)
-	o, err = (*z).VRF.MarshalMsg(o)
-	if err != nil {
-		err = msgp.WrapError(err, "VRF")
-		return
-	}
+	o = (*z).VRF.MarshalMsg(o)
 	return
 }
 
@@ -2596,7 +2436,7 @@ func (z *proposerSeed) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *rawVote) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *rawVote) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(5)
@@ -2632,29 +2472,17 @@ func (z *rawVote) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "prop"
 			o = append(o, 0xa4, 0x70, 0x72, 0x6f, 0x70)
-			o, err = (*z).Proposal.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Proposal")
-				return
-			}
+			o = (*z).Proposal.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "rnd"
 			o = append(o, 0xa3, 0x72, 0x6e, 0x64)
-			o, err = (*z).Round.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Round")
-				return
-			}
+			o = (*z).Round.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "snd"
 			o = append(o, 0xa3, 0x73, 0x6e, 0x64)
-			o, err = (*z).Sender.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sender")
-				return
-			}
+			o = (*z).Sender.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "step"
@@ -2822,23 +2650,15 @@ func (z *rawVote) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *seedInput) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *seedInput) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 2
 	// string "alpha"
 	o = append(o, 0x82, 0xa5, 0x61, 0x6c, 0x70, 0x68, 0x61)
-	o, err = (*z).Alpha.MarshalMsg(o)
-	if err != nil {
-		err = msgp.WrapError(err, "Alpha")
-		return
-	}
+	o = (*z).Alpha.MarshalMsg(o)
 	// string "hist"
 	o = append(o, 0xa4, 0x68, 0x69, 0x73, 0x74)
-	o, err = (*z).History.MarshalMsg(o)
-	if err != nil {
-		err = msgp.WrapError(err, "History")
-		return
-	}
+	o = (*z).History.MarshalMsg(o)
 	return
 }
 
@@ -2941,7 +2761,7 @@ func (z *seedInput) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *selector) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *selector) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 4
 	// string "per"
@@ -2949,18 +2769,10 @@ func (z *selector) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.AppendUint64(o, uint64((*z).Period))
 	// string "rnd"
 	o = append(o, 0xa3, 0x72, 0x6e, 0x64)
-	o, err = (*z).Round.MarshalMsg(o)
-	if err != nil {
-		err = msgp.WrapError(err, "Round")
-		return
-	}
+	o = (*z).Round.MarshalMsg(o)
 	// string "seed"
 	o = append(o, 0xa4, 0x73, 0x65, 0x65, 0x64)
-	o, err = (*z).Seed.MarshalMsg(o)
-	if err != nil {
-		err = msgp.WrapError(err, "Seed")
-		return
-	}
+	o = (*z).Seed.MarshalMsg(o)
 	// string "step"
 	o = append(o, 0xa4, 0x73, 0x74, 0x65, 0x70)
 	o = msgp.AppendUint64(o, uint64((*z).Step))
@@ -3110,7 +2922,7 @@ func (z *selector) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z serializableErrorUnderlying) MarshalMsg(b []byte) (o []byte, err error) {
+func (z serializableErrorUnderlying) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendString(o, string(z))
 	return
@@ -3156,7 +2968,7 @@ func (z serializableErrorUnderlying) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z step) MarshalMsg(b []byte) (o []byte, err error) {
+func (z step) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendUint64(o, uint64(z))
 	return
@@ -3202,7 +3014,7 @@ func (z step) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *transmittedPayload) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *transmittedPayload) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0003Len := uint32(28)
@@ -3338,16 +3150,8 @@ func (z *transmittedPayload) MarshalMsg(b []byte) (o []byte, err error) {
 			for _, zb0001 := range zb0001_keys {
 				zb0002 := (*z).unauthenticatedProposal.Block.BlockHeader.CompactCert[zb0001]
 				_ = zb0002
-				o, err = zb0001.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "CompactCert", zb0001)
-					return
-				}
-				o, err = zb0002.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "CompactCert", zb0001)
-					return
-				}
+				o = zb0001.MarshalMsg(o)
+				o = zb0002.MarshalMsg(o)
 			}
 		}
 		if (zb0003Mask & 0x40) == 0 { // if not empty
@@ -3358,11 +3162,7 @@ func (z *transmittedPayload) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x80) == 0 { // if not empty
 			// string "fees"
 			o = append(o, 0xa4, 0x66, 0x65, 0x65, 0x73)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.FeeSink.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "FeeSink")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.FeeSink.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x100) == 0 { // if not empty
 			// string "frac"
@@ -3377,38 +3177,22 @@ func (z *transmittedPayload) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x400) == 0 { // if not empty
 			// string "gh"
 			o = append(o, 0xa2, 0x67, 0x68)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.GenesisHash.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "GenesisHash")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.GenesisHash.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x800) == 0 { // if not empty
 			// string "nextbefore"
 			o = append(o, 0xaa, 0x6e, 0x65, 0x78, 0x74, 0x62, 0x65, 0x66, 0x6f, 0x72, 0x65)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocolVoteBefore.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "NextProtocolVoteBefore")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocolVoteBefore.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x1000) == 0 { // if not empty
 			// string "nextproto"
 			o = append(o, 0xa9, 0x6e, 0x65, 0x78, 0x74, 0x70, 0x72, 0x6f, 0x74, 0x6f)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocol.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "NextProtocol")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocol.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x2000) == 0 { // if not empty
 			// string "nextswitch"
 			o = append(o, 0xaa, 0x6e, 0x65, 0x78, 0x74, 0x73, 0x77, 0x69, 0x74, 0x63, 0x68)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocolSwitchOn.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "NextProtocolSwitchOn")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocolSwitchOn.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x4000) == 0 { // if not empty
 			// string "nextyes"
@@ -3423,38 +3207,22 @@ func (z *transmittedPayload) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x10000) == 0 { // if not empty
 			// string "oprop"
 			o = append(o, 0xa5, 0x6f, 0x70, 0x72, 0x6f, 0x70)
-			o, err = (*z).unauthenticatedProposal.OriginalProposer.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "OriginalProposer")
-				return
-			}
+			o = (*z).unauthenticatedProposal.OriginalProposer.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x20000) == 0 { // if not empty
 			// string "prev"
 			o = append(o, 0xa4, 0x70, 0x72, 0x65, 0x76)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.Branch.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Branch")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.Branch.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x40000) == 0 { // if not empty
 			// string "proto"
 			o = append(o, 0xa5, 0x70, 0x72, 0x6f, 0x74, 0x6f)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.CurrentProtocol.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CurrentProtocol")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.CurrentProtocol.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x80000) == 0 { // if not empty
 			// string "pv"
 			o = append(o, 0xa2, 0x70, 0x76)
-			o, err = (*z).PriorVote.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "PriorVote")
-				return
-			}
+			o = (*z).PriorVote.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x100000) == 0 { // if not empty
 			// string "rate"
@@ -3464,47 +3232,27 @@ func (z *transmittedPayload) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x200000) == 0 { // if not empty
 			// string "rnd"
 			o = append(o, 0xa3, 0x72, 0x6e, 0x64)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.Round.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Round")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.Round.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x400000) == 0 { // if not empty
 			// string "rwcalr"
 			o = append(o, 0xa6, 0x72, 0x77, 0x63, 0x61, 0x6c, 0x72)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRecalculationRound.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RewardsRecalculationRound")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRecalculationRound.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x800000) == 0 { // if not empty
 			// string "rwd"
 			o = append(o, 0xa3, 0x72, 0x77, 0x64)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsPool.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RewardsPool")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsPool.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x1000000) == 0 { // if not empty
 			// string "sdpf"
 			o = append(o, 0xa4, 0x73, 0x64, 0x70, 0x66)
-			o, err = (*z).unauthenticatedProposal.SeedProof.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "SeedProof")
-				return
-			}
+			o = (*z).unauthenticatedProposal.SeedProof.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x2000000) == 0 { // if not empty
 			// string "seed"
 			o = append(o, 0xa4, 0x73, 0x65, 0x65, 0x64)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.Seed.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Seed")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.Seed.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x4000000) == 0 { // if not empty
 			// string "tc"
@@ -3519,38 +3267,22 @@ func (z *transmittedPayload) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x10000000) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.TxnRoot.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "TxnRoot")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.TxnRoot.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x20000000) == 0 { // if not empty
 			// string "txns"
 			o = append(o, 0xa4, 0x74, 0x78, 0x6e, 0x73)
-			o, err = (*z).unauthenticatedProposal.Block.Payset.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Payset")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.Payset.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x40000000) == 0 { // if not empty
 			// string "upgradedelay"
 			o = append(o, 0xac, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x64, 0x65, 0x6c, 0x61, 0x79)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeDelay.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "UpgradeDelay")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeDelay.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x80000000) == 0 { // if not empty
 			// string "upgradeprop"
 			o = append(o, 0xab, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x70, 0x72, 0x6f, 0x70)
-			o, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradePropose.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "UpgradePropose")
-				return
-			}
+			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradePropose.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x100000000) == 0 { // if not empty
 			// string "upgradeyes"
@@ -4096,7 +3828,7 @@ func (z *transmittedPayload) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *unauthenticatedBundle) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *unauthenticatedBundle) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0003Len := uint32(6)
@@ -4137,11 +3869,7 @@ func (z *unauthenticatedBundle) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).EquivocationVotes)))
 			}
 			for zb0002 := range (*z).EquivocationVotes {
-				o, err = (*z).EquivocationVotes[zb0002].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "EquivocationVotes", zb0002)
-					return
-				}
+				o = (*z).EquivocationVotes[zb0002].MarshalMsg(o)
 			}
 		}
 		if (zb0003Mask & 0x4) == 0 { // if not empty
@@ -4152,20 +3880,12 @@ func (z *unauthenticatedBundle) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x8) == 0 { // if not empty
 			// string "prop"
 			o = append(o, 0xa4, 0x70, 0x72, 0x6f, 0x70)
-			o, err = (*z).Proposal.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Proposal")
-				return
-			}
+			o = (*z).Proposal.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x10) == 0 { // if not empty
 			// string "rnd"
 			o = append(o, 0xa3, 0x72, 0x6e, 0x64)
-			o, err = (*z).Round.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Round")
-				return
-			}
+			o = (*z).Round.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x20) == 0 { // if not empty
 			// string "step"
@@ -4181,11 +3901,7 @@ func (z *unauthenticatedBundle) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).Votes)))
 			}
 			for zb0001 := range (*z).Votes {
-				o, err = (*z).Votes[zb0001].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Votes", zb0001)
-					return
-				}
+				o = (*z).Votes[zb0001].MarshalMsg(o)
 			}
 		}
 	}
@@ -4454,7 +4170,7 @@ func (z *unauthenticatedBundle) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *unauthenticatedEquivocationVote) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *unauthenticatedEquivocationVote) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0003Len := uint32(7)
@@ -4493,11 +4209,7 @@ func (z *unauthenticatedEquivocationVote) MarshalMsg(b []byte) (o []byte, err er
 		if (zb0003Mask & 0x2) == 0 { // if not empty
 			// string "cred"
 			o = append(o, 0xa4, 0x63, 0x72, 0x65, 0x64)
-			o, err = (*z).Cred.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Cred")
-				return
-			}
+			o = (*z).Cred.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x4) == 0 { // if not empty
 			// string "per"
@@ -4509,42 +4221,26 @@ func (z *unauthenticatedEquivocationVote) MarshalMsg(b []byte) (o []byte, err er
 			o = append(o, 0xa5, 0x70, 0x72, 0x6f, 0x70, 0x73)
 			o = msgp.AppendArrayHeader(o, 2)
 			for zb0001 := range (*z).Proposals {
-				o, err = (*z).Proposals[zb0001].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Proposals", zb0001)
-					return
-				}
+				o = (*z).Proposals[zb0001].MarshalMsg(o)
 			}
 		}
 		if (zb0003Mask & 0x10) == 0 { // if not empty
 			// string "rnd"
 			o = append(o, 0xa3, 0x72, 0x6e, 0x64)
-			o, err = (*z).Round.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Round")
-				return
-			}
+			o = (*z).Round.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x20) == 0 { // if not empty
 			// string "sigs"
 			o = append(o, 0xa4, 0x73, 0x69, 0x67, 0x73)
 			o = msgp.AppendArrayHeader(o, 2)
 			for zb0002 := range (*z).Sigs {
-				o, err = (*z).Sigs[zb0002].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Sigs", zb0002)
-					return
-				}
+				o = (*z).Sigs[zb0002].MarshalMsg(o)
 			}
 		}
 		if (zb0003Mask & 0x40) == 0 { // if not empty
 			// string "snd"
 			o = append(o, 0xa3, 0x73, 0x6e, 0x64)
-			o, err = (*z).Sender.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sender")
-				return
-			}
+			o = (*z).Sender.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x80) == 0 { // if not empty
 			// string "step"
@@ -4795,7 +4491,7 @@ func (z *unauthenticatedEquivocationVote) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *unauthenticatedProposal) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *unauthenticatedProposal) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0003Len := uint32(27)
@@ -4927,16 +4623,8 @@ func (z *unauthenticatedProposal) MarshalMsg(b []byte) (o []byte, err error) {
 			for _, zb0001 := range zb0001_keys {
 				zb0002 := (*z).Block.BlockHeader.CompactCert[zb0001]
 				_ = zb0002
-				o, err = zb0001.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "CompactCert", zb0001)
-					return
-				}
-				o, err = zb0002.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "CompactCert", zb0001)
-					return
-				}
+				o = zb0001.MarshalMsg(o)
+				o = zb0002.MarshalMsg(o)
 			}
 		}
 		if (zb0003Mask & 0x20) == 0 { // if not empty
@@ -4947,11 +4635,7 @@ func (z *unauthenticatedProposal) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x40) == 0 { // if not empty
 			// string "fees"
 			o = append(o, 0xa4, 0x66, 0x65, 0x65, 0x73)
-			o, err = (*z).Block.BlockHeader.RewardsState.FeeSink.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "FeeSink")
-				return
-			}
+			o = (*z).Block.BlockHeader.RewardsState.FeeSink.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x80) == 0 { // if not empty
 			// string "frac"
@@ -4966,38 +4650,22 @@ func (z *unauthenticatedProposal) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x200) == 0 { // if not empty
 			// string "gh"
 			o = append(o, 0xa2, 0x67, 0x68)
-			o, err = (*z).Block.BlockHeader.GenesisHash.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "GenesisHash")
-				return
-			}
+			o = (*z).Block.BlockHeader.GenesisHash.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x400) == 0 { // if not empty
 			// string "nextbefore"
 			o = append(o, 0xaa, 0x6e, 0x65, 0x78, 0x74, 0x62, 0x65, 0x66, 0x6f, 0x72, 0x65)
-			o, err = (*z).Block.BlockHeader.UpgradeState.NextProtocolVoteBefore.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "NextProtocolVoteBefore")
-				return
-			}
+			o = (*z).Block.BlockHeader.UpgradeState.NextProtocolVoteBefore.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x800) == 0 { // if not empty
 			// string "nextproto"
 			o = append(o, 0xa9, 0x6e, 0x65, 0x78, 0x74, 0x70, 0x72, 0x6f, 0x74, 0x6f)
-			o, err = (*z).Block.BlockHeader.UpgradeState.NextProtocol.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "NextProtocol")
-				return
-			}
+			o = (*z).Block.BlockHeader.UpgradeState.NextProtocol.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x1000) == 0 { // if not empty
 			// string "nextswitch"
 			o = append(o, 0xaa, 0x6e, 0x65, 0x78, 0x74, 0x73, 0x77, 0x69, 0x74, 0x63, 0x68)
-			o, err = (*z).Block.BlockHeader.UpgradeState.NextProtocolSwitchOn.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "NextProtocolSwitchOn")
-				return
-			}
+			o = (*z).Block.BlockHeader.UpgradeState.NextProtocolSwitchOn.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x2000) == 0 { // if not empty
 			// string "nextyes"
@@ -5012,29 +4680,17 @@ func (z *unauthenticatedProposal) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x8000) == 0 { // if not empty
 			// string "oprop"
 			o = append(o, 0xa5, 0x6f, 0x70, 0x72, 0x6f, 0x70)
-			o, err = (*z).OriginalProposer.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "OriginalProposer")
-				return
-			}
+			o = (*z).OriginalProposer.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x10000) == 0 { // if not empty
 			// string "prev"
 			o = append(o, 0xa4, 0x70, 0x72, 0x65, 0x76)
-			o, err = (*z).Block.BlockHeader.Branch.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Branch")
-				return
-			}
+			o = (*z).Block.BlockHeader.Branch.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x20000) == 0 { // if not empty
 			// string "proto"
 			o = append(o, 0xa5, 0x70, 0x72, 0x6f, 0x74, 0x6f)
-			o, err = (*z).Block.BlockHeader.UpgradeState.CurrentProtocol.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CurrentProtocol")
-				return
-			}
+			o = (*z).Block.BlockHeader.UpgradeState.CurrentProtocol.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x40000) == 0 { // if not empty
 			// string "rate"
@@ -5044,47 +4700,27 @@ func (z *unauthenticatedProposal) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x80000) == 0 { // if not empty
 			// string "rnd"
 			o = append(o, 0xa3, 0x72, 0x6e, 0x64)
-			o, err = (*z).Block.BlockHeader.Round.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Round")
-				return
-			}
+			o = (*z).Block.BlockHeader.Round.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x100000) == 0 { // if not empty
 			// string "rwcalr"
 			o = append(o, 0xa6, 0x72, 0x77, 0x63, 0x61, 0x6c, 0x72)
-			o, err = (*z).Block.BlockHeader.RewardsState.RewardsRecalculationRound.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RewardsRecalculationRound")
-				return
-			}
+			o = (*z).Block.BlockHeader.RewardsState.RewardsRecalculationRound.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x200000) == 0 { // if not empty
 			// string "rwd"
 			o = append(o, 0xa3, 0x72, 0x77, 0x64)
-			o, err = (*z).Block.BlockHeader.RewardsState.RewardsPool.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RewardsPool")
-				return
-			}
+			o = (*z).Block.BlockHeader.RewardsState.RewardsPool.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x400000) == 0 { // if not empty
 			// string "sdpf"
 			o = append(o, 0xa4, 0x73, 0x64, 0x70, 0x66)
-			o, err = (*z).SeedProof.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "SeedProof")
-				return
-			}
+			o = (*z).SeedProof.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x800000) == 0 { // if not empty
 			// string "seed"
 			o = append(o, 0xa4, 0x73, 0x65, 0x65, 0x64)
-			o, err = (*z).Block.BlockHeader.Seed.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Seed")
-				return
-			}
+			o = (*z).Block.BlockHeader.Seed.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x1000000) == 0 { // if not empty
 			// string "tc"
@@ -5099,38 +4735,22 @@ func (z *unauthenticatedProposal) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x4000000) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
-			o, err = (*z).Block.BlockHeader.TxnRoot.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "TxnRoot")
-				return
-			}
+			o = (*z).Block.BlockHeader.TxnRoot.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x8000000) == 0 { // if not empty
 			// string "txns"
 			o = append(o, 0xa4, 0x74, 0x78, 0x6e, 0x73)
-			o, err = (*z).Block.Payset.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Payset")
-				return
-			}
+			o = (*z).Block.Payset.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x10000000) == 0 { // if not empty
 			// string "upgradedelay"
 			o = append(o, 0xac, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x64, 0x65, 0x6c, 0x61, 0x79)
-			o, err = (*z).Block.BlockHeader.UpgradeVote.UpgradeDelay.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "UpgradeDelay")
-				return
-			}
+			o = (*z).Block.BlockHeader.UpgradeVote.UpgradeDelay.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x20000000) == 0 { // if not empty
 			// string "upgradeprop"
 			o = append(o, 0xab, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x70, 0x72, 0x6f, 0x70)
-			o, err = (*z).Block.BlockHeader.UpgradeVote.UpgradePropose.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "UpgradePropose")
-				return
-			}
+			o = (*z).Block.BlockHeader.UpgradeVote.UpgradePropose.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x40000000) == 0 { // if not empty
 			// string "upgradeyes"
@@ -5662,7 +5282,7 @@ func (z *unauthenticatedProposal) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *unauthenticatedVote) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *unauthenticatedVote) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(3)
@@ -5685,29 +5305,17 @@ func (z *unauthenticatedVote) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "cred"
 			o = append(o, 0xa4, 0x63, 0x72, 0x65, 0x64)
-			o, err = (*z).Cred.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Cred")
-				return
-			}
+			o = (*z).Cred.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "r"
 			o = append(o, 0xa1, 0x72)
-			o, err = (*z).R.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "R")
-				return
-			}
+			o = (*z).R.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "sig"
 			o = append(o, 0xa3, 0x73, 0x69, 0x67)
-			o, err = (*z).Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sig")
-				return
-			}
+			o = (*z).Sig.MarshalMsg(o)
 		}
 	}
 	return
@@ -5826,7 +5434,7 @@ func (z *unauthenticatedVote) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *vote) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *vote) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(3)
@@ -5849,29 +5457,17 @@ func (z *vote) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "cred"
 			o = append(o, 0xa4, 0x63, 0x72, 0x65, 0x64)
-			o, err = (*z).Cred.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Cred")
-				return
-			}
+			o = (*z).Cred.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "r"
 			o = append(o, 0xa1, 0x72)
-			o, err = (*z).R.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "R")
-				return
-			}
+			o = (*z).R.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "sig"
 			o = append(o, 0xa3, 0x73, 0x69, 0x67)
-			o, err = (*z).Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sig")
-				return
-			}
+			o = (*z).Sig.MarshalMsg(o)
 		}
 	}
 	return
@@ -5990,7 +5586,7 @@ func (z *vote) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *voteAuthenticator) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *voteAuthenticator) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(3)
@@ -6004,27 +5600,15 @@ func (z *voteAuthenticator) MarshalMsg(b []byte) (o []byte, err error) {
 	if zb0001Len != 0 {
 		// string "cred"
 		o = append(o, 0xa4, 0x63, 0x72, 0x65, 0x64)
-		o, err = (*z).Cred.MarshalMsg(o)
-		if err != nil {
-			err = msgp.WrapError(err, "Cred")
-			return
-		}
+		o = (*z).Cred.MarshalMsg(o)
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "sig"
 			o = append(o, 0xa3, 0x73, 0x69, 0x67)
-			o, err = (*z).Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sig")
-				return
-			}
+			o = (*z).Sig.MarshalMsg(o)
 		}
 		// string "snd"
 		o = append(o, 0xa3, 0x73, 0x6e, 0x64)
-		o, err = (*z).Sender.MarshalMsg(o)
-		if err != nil {
-			err = msgp.WrapError(err, "Sender")
-			return
-		}
+		o = (*z).Sender.MarshalMsg(o)
 	}
 	return
 }

--- a/agreement/msgp_gen_test.go
+++ b/agreement/msgp_gen_test.go
@@ -13,10 +13,7 @@ import (
 
 func TestMarshalUnmarshalCertificate(t *testing.T) {
 	v := Certificate{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -50,18 +47,18 @@ func BenchmarkMarshalMsgCertificate(b *testing.B) {
 func BenchmarkAppendMsgCertificate(b *testing.B) {
 	v := Certificate{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalCertificate(b *testing.B) {
 	v := Certificate{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -75,10 +72,7 @@ func BenchmarkUnmarshalCertificate(b *testing.B) {
 
 func TestMarshalUnmarshalbundle(t *testing.T) {
 	v := bundle{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -112,18 +106,18 @@ func BenchmarkMarshalMsgbundle(b *testing.B) {
 func BenchmarkAppendMsgbundle(b *testing.B) {
 	v := bundle{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalbundle(b *testing.B) {
 	v := bundle{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -137,10 +131,7 @@ func BenchmarkUnmarshalbundle(b *testing.B) {
 
 func TestMarshalUnmarshalequivocationVote(t *testing.T) {
 	v := equivocationVote{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -174,18 +165,18 @@ func BenchmarkMarshalMsgequivocationVote(b *testing.B) {
 func BenchmarkAppendMsgequivocationVote(b *testing.B) {
 	v := equivocationVote{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalequivocationVote(b *testing.B) {
 	v := equivocationVote{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -199,10 +190,7 @@ func BenchmarkUnmarshalequivocationVote(b *testing.B) {
 
 func TestMarshalUnmarshalequivocationVoteAuthenticator(t *testing.T) {
 	v := equivocationVoteAuthenticator{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -236,18 +224,18 @@ func BenchmarkMarshalMsgequivocationVoteAuthenticator(b *testing.B) {
 func BenchmarkAppendMsgequivocationVoteAuthenticator(b *testing.B) {
 	v := equivocationVoteAuthenticator{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalequivocationVoteAuthenticator(b *testing.B) {
 	v := equivocationVoteAuthenticator{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -261,10 +249,7 @@ func BenchmarkUnmarshalequivocationVoteAuthenticator(b *testing.B) {
 
 func TestMarshalUnmarshalproposal(t *testing.T) {
 	v := proposal{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -298,18 +283,18 @@ func BenchmarkMarshalMsgproposal(b *testing.B) {
 func BenchmarkAppendMsgproposal(b *testing.B) {
 	v := proposal{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalproposal(b *testing.B) {
 	v := proposal{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -323,10 +308,7 @@ func BenchmarkUnmarshalproposal(b *testing.B) {
 
 func TestMarshalUnmarshalproposalValue(t *testing.T) {
 	v := proposalValue{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -360,18 +342,18 @@ func BenchmarkMarshalMsgproposalValue(b *testing.B) {
 func BenchmarkAppendMsgproposalValue(b *testing.B) {
 	v := proposalValue{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalproposalValue(b *testing.B) {
 	v := proposalValue{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -385,10 +367,7 @@ func BenchmarkUnmarshalproposalValue(b *testing.B) {
 
 func TestMarshalUnmarshalproposerSeed(t *testing.T) {
 	v := proposerSeed{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -422,18 +401,18 @@ func BenchmarkMarshalMsgproposerSeed(b *testing.B) {
 func BenchmarkAppendMsgproposerSeed(b *testing.B) {
 	v := proposerSeed{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalproposerSeed(b *testing.B) {
 	v := proposerSeed{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -447,10 +426,7 @@ func BenchmarkUnmarshalproposerSeed(b *testing.B) {
 
 func TestMarshalUnmarshalrawVote(t *testing.T) {
 	v := rawVote{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -484,18 +460,18 @@ func BenchmarkMarshalMsgrawVote(b *testing.B) {
 func BenchmarkAppendMsgrawVote(b *testing.B) {
 	v := rawVote{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalrawVote(b *testing.B) {
 	v := rawVote{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -509,10 +485,7 @@ func BenchmarkUnmarshalrawVote(b *testing.B) {
 
 func TestMarshalUnmarshalseedInput(t *testing.T) {
 	v := seedInput{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -546,18 +519,18 @@ func BenchmarkMarshalMsgseedInput(b *testing.B) {
 func BenchmarkAppendMsgseedInput(b *testing.B) {
 	v := seedInput{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalseedInput(b *testing.B) {
 	v := seedInput{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -571,10 +544,7 @@ func BenchmarkUnmarshalseedInput(b *testing.B) {
 
 func TestMarshalUnmarshalselector(t *testing.T) {
 	v := selector{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -608,18 +578,18 @@ func BenchmarkMarshalMsgselector(b *testing.B) {
 func BenchmarkAppendMsgselector(b *testing.B) {
 	v := selector{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalselector(b *testing.B) {
 	v := selector{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -633,10 +603,7 @@ func BenchmarkUnmarshalselector(b *testing.B) {
 
 func TestMarshalUnmarshaltransmittedPayload(t *testing.T) {
 	v := transmittedPayload{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -670,18 +637,18 @@ func BenchmarkMarshalMsgtransmittedPayload(b *testing.B) {
 func BenchmarkAppendMsgtransmittedPayload(b *testing.B) {
 	v := transmittedPayload{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshaltransmittedPayload(b *testing.B) {
 	v := transmittedPayload{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -695,10 +662,7 @@ func BenchmarkUnmarshaltransmittedPayload(b *testing.B) {
 
 func TestMarshalUnmarshalunauthenticatedBundle(t *testing.T) {
 	v := unauthenticatedBundle{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -732,18 +696,18 @@ func BenchmarkMarshalMsgunauthenticatedBundle(b *testing.B) {
 func BenchmarkAppendMsgunauthenticatedBundle(b *testing.B) {
 	v := unauthenticatedBundle{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalunauthenticatedBundle(b *testing.B) {
 	v := unauthenticatedBundle{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -757,10 +721,7 @@ func BenchmarkUnmarshalunauthenticatedBundle(b *testing.B) {
 
 func TestMarshalUnmarshalunauthenticatedEquivocationVote(t *testing.T) {
 	v := unauthenticatedEquivocationVote{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -794,18 +755,18 @@ func BenchmarkMarshalMsgunauthenticatedEquivocationVote(b *testing.B) {
 func BenchmarkAppendMsgunauthenticatedEquivocationVote(b *testing.B) {
 	v := unauthenticatedEquivocationVote{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalunauthenticatedEquivocationVote(b *testing.B) {
 	v := unauthenticatedEquivocationVote{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -819,10 +780,7 @@ func BenchmarkUnmarshalunauthenticatedEquivocationVote(b *testing.B) {
 
 func TestMarshalUnmarshalunauthenticatedProposal(t *testing.T) {
 	v := unauthenticatedProposal{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -856,18 +814,18 @@ func BenchmarkMarshalMsgunauthenticatedProposal(b *testing.B) {
 func BenchmarkAppendMsgunauthenticatedProposal(b *testing.B) {
 	v := unauthenticatedProposal{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalunauthenticatedProposal(b *testing.B) {
 	v := unauthenticatedProposal{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -881,10 +839,7 @@ func BenchmarkUnmarshalunauthenticatedProposal(b *testing.B) {
 
 func TestMarshalUnmarshalunauthenticatedVote(t *testing.T) {
 	v := unauthenticatedVote{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -918,18 +873,18 @@ func BenchmarkMarshalMsgunauthenticatedVote(b *testing.B) {
 func BenchmarkAppendMsgunauthenticatedVote(b *testing.B) {
 	v := unauthenticatedVote{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalunauthenticatedVote(b *testing.B) {
 	v := unauthenticatedVote{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -943,10 +898,7 @@ func BenchmarkUnmarshalunauthenticatedVote(b *testing.B) {
 
 func TestMarshalUnmarshalvote(t *testing.T) {
 	v := vote{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -980,18 +932,18 @@ func BenchmarkMarshalMsgvote(b *testing.B) {
 func BenchmarkAppendMsgvote(b *testing.B) {
 	v := vote{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalvote(b *testing.B) {
 	v := vote{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -1005,10 +957,7 @@ func BenchmarkUnmarshalvote(b *testing.B) {
 
 func TestMarshalUnmarshalvoteAuthenticator(t *testing.T) {
 	v := voteAuthenticator{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -1042,18 +991,18 @@ func BenchmarkMarshalMsgvoteAuthenticator(b *testing.B) {
 func BenchmarkAppendMsgvoteAuthenticator(b *testing.B) {
 	v := voteAuthenticator{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalvoteAuthenticator(b *testing.B) {
 	v := voteAuthenticator{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()

--- a/auction/msgp_gen.go
+++ b/auction/msgp_gen.go
@@ -113,7 +113,7 @@ import (
 //
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Bid) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Bid) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(6)
@@ -153,20 +153,12 @@ func (z *Bid) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "auc"
 			o = append(o, 0xa3, 0x61, 0x75, 0x63)
-			o, err = (*z).AuctionKey.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AuctionKey")
-				return
-			}
+			o = (*z).AuctionKey.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "bidder"
 			o = append(o, 0xa6, 0x62, 0x69, 0x64, 0x64, 0x65, 0x72)
-			o, err = (*z).BidderKey.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "BidderKey")
-				return
-			}
+			o = (*z).BidderKey.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "cur"
@@ -342,7 +334,7 @@ func (z *Bid) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *BidOutcomes) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *BidOutcomes) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0002Len := uint32(5)
@@ -378,11 +370,7 @@ func (z *BidOutcomes) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0002Mask & 0x4) == 0 { // if not empty
 			// string "auc"
 			o = append(o, 0xa3, 0x61, 0x75, 0x63)
-			o, err = (*z).AuctionKey.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AuctionKey")
-				return
-			}
+			o = (*z).AuctionKey.MarshalMsg(o)
 		}
 		if (zb0002Mask & 0x8) == 0 { // if not empty
 			// string "cleared"
@@ -398,11 +386,7 @@ func (z *BidOutcomes) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).Outcomes)))
 			}
 			for zb0001 := range (*z).Outcomes {
-				o, err = (*z).Outcomes[zb0001].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Outcomes", zb0001)
-					return
-				}
+				o = (*z).Outcomes[zb0001].MarshalMsg(o)
 			}
 		}
 		if (zb0002Mask & 0x20) == 0 { // if not empty
@@ -590,7 +574,7 @@ func (z *BidOutcomes) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *BidderOutcome) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *BidderOutcome) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(4)
@@ -627,20 +611,12 @@ func (z *BidderOutcome) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "key"
 			o = append(o, 0xa3, 0x6b, 0x65, 0x79)
-			o, err = (*z).BidderKey.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "BidderKey")
-				return
-			}
+			o = (*z).BidderKey.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "out"
 			o = append(o, 0xa3, 0x6f, 0x75, 0x74)
-			o, err = (*z).WinningsAddress.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "WinningsAddress")
-				return
-			}
+			o = (*z).WinningsAddress.MarshalMsg(o)
 		}
 	}
 	return
@@ -773,7 +749,7 @@ func (z *BidderOutcome) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Deposit) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Deposit) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(6)
@@ -813,11 +789,7 @@ func (z *Deposit) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "auc"
 			o = append(o, 0xa3, 0x61, 0x75, 0x63)
-			o, err = (*z).AuctionKey.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AuctionKey")
-				return
-			}
+			o = (*z).AuctionKey.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "cur"
@@ -832,20 +804,12 @@ func (z *Deposit) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "key"
 			o = append(o, 0xa3, 0x6b, 0x65, 0x79)
-			o, err = (*z).BidderKey.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "BidderKey")
-				return
-			}
+			o = (*z).BidderKey.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not empty
 			// string "out"
 			o = append(o, 0xa3, 0x6f, 0x75, 0x74)
-			o, err = (*z).WinningsAddress.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "WinningsAddress")
-				return
-			}
+			o = (*z).WinningsAddress.MarshalMsg(o)
 		}
 	}
 	return
@@ -1006,7 +970,7 @@ func (z *Deposit) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *MasterInput) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *MasterInput) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(4)
@@ -1049,20 +1013,12 @@ func (z *MasterInput) MarshalMsg(b []byte) (o []byte, err error) {
 			if (zb0002Mask & 0x2) == 0 { // if not empty
 				// string "bid"
 				o = append(o, 0xa3, 0x62, 0x69, 0x64)
-				o, err = (*z).SignedBid.Bid.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "SignedBid", "Bid")
-					return
-				}
+				o = (*z).SignedBid.Bid.MarshalMsg(o)
 			}
 			if (zb0002Mask & 0x4) == 0 { // if not empty
 				// string "sig"
 				o = append(o, 0xa3, 0x73, 0x69, 0x67)
-				o, err = (*z).SignedBid.Sig.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "SignedBid", "Sig")
-					return
-				}
+				o = (*z).SignedBid.Sig.MarshalMsg(o)
 			}
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
@@ -1084,20 +1040,12 @@ func (z *MasterInput) MarshalMsg(b []byte) (o []byte, err error) {
 			if (zb0003Mask & 0x2) == 0 { // if not empty
 				// string "dep"
 				o = append(o, 0xa3, 0x64, 0x65, 0x70)
-				o, err = (*z).SignedDeposit.Deposit.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "SignedDeposit", "Deposit")
-					return
-				}
+				o = (*z).SignedDeposit.Deposit.MarshalMsg(o)
 			}
 			if (zb0003Mask & 0x4) == 0 { // if not empty
 				// string "sig"
 				o = append(o, 0xa3, 0x73, 0x69, 0x67)
-				o, err = (*z).SignedDeposit.Sig.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "SignedDeposit", "Sig")
-					return
-				}
+				o = (*z).SignedDeposit.Sig.MarshalMsg(o)
 			}
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
@@ -1505,7 +1453,7 @@ func (z *MasterInput) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *NoteField) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *NoteField) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(5)
@@ -1552,20 +1500,12 @@ func (z *NoteField) MarshalMsg(b []byte) (o []byte, err error) {
 			if (zb0002Mask & 0x2) == 0 { // if not empty
 				// string "bid"
 				o = append(o, 0xa3, 0x62, 0x69, 0x64)
-				o, err = (*z).SignedBid.Bid.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "SignedBid", "Bid")
-					return
-				}
+				o = (*z).SignedBid.Bid.MarshalMsg(o)
 			}
 			if (zb0002Mask & 0x4) == 0 { // if not empty
 				// string "sig"
 				o = append(o, 0xa3, 0x73, 0x69, 0x67)
-				o, err = (*z).SignedBid.Sig.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "SignedBid", "Sig")
-					return
-				}
+				o = (*z).SignedBid.Sig.MarshalMsg(o)
 			}
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
@@ -1587,20 +1527,12 @@ func (z *NoteField) MarshalMsg(b []byte) (o []byte, err error) {
 			if (zb0003Mask & 0x2) == 0 { // if not empty
 				// string "dep"
 				o = append(o, 0xa3, 0x64, 0x65, 0x70)
-				o, err = (*z).SignedDeposit.Deposit.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "SignedDeposit", "Deposit")
-					return
-				}
+				o = (*z).SignedDeposit.Deposit.MarshalMsg(o)
 			}
 			if (zb0003Mask & 0x4) == 0 { // if not empty
 				// string "sig"
 				o = append(o, 0xa3, 0x73, 0x69, 0x67)
-				o, err = (*z).SignedDeposit.Sig.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "SignedDeposit", "Sig")
-					return
-				}
+				o = (*z).SignedDeposit.Sig.MarshalMsg(o)
 			}
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
@@ -1622,20 +1554,12 @@ func (z *NoteField) MarshalMsg(b []byte) (o []byte, err error) {
 			if (zb0004Mask & 0x2) == 0 { // if not empty
 				// string "param"
 				o = append(o, 0xa5, 0x70, 0x61, 0x72, 0x61, 0x6d)
-				o, err = (*z).SignedParams.Params.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "SignedParams", "Params")
-					return
-				}
+				o = (*z).SignedParams.Params.MarshalMsg(o)
 			}
 			if (zb0004Mask & 0x4) == 0 { // if not empty
 				// string "sig"
 				o = append(o, 0xa3, 0x73, 0x69, 0x67)
-				o, err = (*z).SignedParams.Sig.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "SignedParams", "Sig")
-					return
-				}
+				o = (*z).SignedParams.Sig.MarshalMsg(o)
 			}
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
@@ -1657,20 +1581,12 @@ func (z *NoteField) MarshalMsg(b []byte) (o []byte, err error) {
 			if (zb0005Mask & 0x2) == 0 { // if not empty
 				// string "settle"
 				o = append(o, 0xa6, 0x73, 0x65, 0x74, 0x74, 0x6c, 0x65)
-				o, err = (*z).SignedSettlement.Settlement.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "SignedSettlement", "Settlement")
-					return
-				}
+				o = (*z).SignedSettlement.Settlement.MarshalMsg(o)
 			}
 			if (zb0005Mask & 0x4) == 0 { // if not empty
 				// string "sig"
 				o = append(o, 0xa3, 0x73, 0x69, 0x67)
-				o, err = (*z).SignedSettlement.Sig.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "SignedSettlement", "Sig")
-					return
-				}
+				o = (*z).SignedSettlement.Sig.MarshalMsg(o)
 			}
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not empty
@@ -2343,7 +2259,7 @@ func (z *NoteField) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z NoteFieldType) MarshalMsg(b []byte) (o []byte, err error) {
+func (z NoteFieldType) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendString(o, string(z))
 	return
@@ -2389,7 +2305,7 @@ func (z NoteFieldType) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Params) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Params) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(12)
@@ -2453,20 +2369,12 @@ func (z *Params) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "auc"
 			o = append(o, 0xa3, 0x61, 0x75, 0x63)
-			o, err = (*z).AuctionKey.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AuctionKey")
-				return
-			}
+			o = (*z).AuctionKey.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "bank"
 			o = append(o, 0xa4, 0x62, 0x61, 0x6e, 0x6b)
-			o, err = (*z).BankKey.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "BankKey")
-				return
-			}
+			o = (*z).BankKey.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "chunkrnds"
@@ -2481,11 +2389,7 @@ func (z *Params) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x40) == 0 { // if not empty
 			// string "dispense"
 			o = append(o, 0xa8, 0x64, 0x69, 0x73, 0x70, 0x65, 0x6e, 0x73, 0x65)
-			o, err = (*z).DispensingKey.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "DispensingKey")
-				return
-			}
+			o = (*z).DispensingKey.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x80) == 0 { // if not empty
 			// string "firstrnd"
@@ -2760,7 +2664,7 @@ func (z *Params) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Settlement) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Settlement) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(5)
@@ -2796,11 +2700,7 @@ func (z *Settlement) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "auc"
 			o = append(o, 0xa3, 0x61, 0x75, 0x63)
-			o, err = (*z).AuctionKey.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AuctionKey")
-				return
-			}
+			o = (*z).AuctionKey.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "canceled"
@@ -2815,11 +2715,7 @@ func (z *Settlement) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "outhash"
 			o = append(o, 0xa7, 0x6f, 0x75, 0x74, 0x68, 0x61, 0x73, 0x68)
-			o, err = (*z).OutcomesHash.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "OutcomesHash")
-				return
-			}
+			o = (*z).OutcomesHash.MarshalMsg(o)
 		}
 	}
 	return
@@ -2966,7 +2862,7 @@ func (z *Settlement) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *SignedBid) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *SignedBid) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(2)
@@ -2985,20 +2881,12 @@ func (z *SignedBid) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "bid"
 			o = append(o, 0xa3, 0x62, 0x69, 0x64)
-			o, err = (*z).Bid.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Bid")
-				return
-			}
+			o = (*z).Bid.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "sig"
 			o = append(o, 0xa3, 0x73, 0x69, 0x67)
-			o, err = (*z).Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sig")
-				return
-			}
+			o = (*z).Sig.MarshalMsg(o)
 		}
 	}
 	return
@@ -3103,7 +2991,7 @@ func (z *SignedBid) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *SignedDeposit) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *SignedDeposit) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(2)
@@ -3122,20 +3010,12 @@ func (z *SignedDeposit) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "dep"
 			o = append(o, 0xa3, 0x64, 0x65, 0x70)
-			o, err = (*z).Deposit.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Deposit")
-				return
-			}
+			o = (*z).Deposit.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "sig"
 			o = append(o, 0xa3, 0x73, 0x69, 0x67)
-			o, err = (*z).Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sig")
-				return
-			}
+			o = (*z).Sig.MarshalMsg(o)
 		}
 	}
 	return
@@ -3240,7 +3120,7 @@ func (z *SignedDeposit) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *SignedParams) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *SignedParams) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(2)
@@ -3259,20 +3139,12 @@ func (z *SignedParams) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "param"
 			o = append(o, 0xa5, 0x70, 0x61, 0x72, 0x61, 0x6d)
-			o, err = (*z).Params.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Params")
-				return
-			}
+			o = (*z).Params.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "sig"
 			o = append(o, 0xa3, 0x73, 0x69, 0x67)
-			o, err = (*z).Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sig")
-				return
-			}
+			o = (*z).Sig.MarshalMsg(o)
 		}
 	}
 	return
@@ -3377,7 +3249,7 @@ func (z *SignedParams) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *SignedSettlement) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *SignedSettlement) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(2)
@@ -3396,20 +3268,12 @@ func (z *SignedSettlement) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "settle"
 			o = append(o, 0xa6, 0x73, 0x65, 0x74, 0x74, 0x6c, 0x65)
-			o, err = (*z).Settlement.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Settlement")
-				return
-			}
+			o = (*z).Settlement.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "sig"
 			o = append(o, 0xa3, 0x73, 0x69, 0x67)
-			o, err = (*z).Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sig")
-				return
-			}
+			o = (*z).Sig.MarshalMsg(o)
 		}
 	}
 	return

--- a/auction/msgp_gen_test.go
+++ b/auction/msgp_gen_test.go
@@ -13,10 +13,7 @@ import (
 
 func TestMarshalUnmarshalBid(t *testing.T) {
 	v := Bid{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -50,18 +47,18 @@ func BenchmarkMarshalMsgBid(b *testing.B) {
 func BenchmarkAppendMsgBid(b *testing.B) {
 	v := Bid{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalBid(b *testing.B) {
 	v := Bid{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -75,10 +72,7 @@ func BenchmarkUnmarshalBid(b *testing.B) {
 
 func TestMarshalUnmarshalBidOutcomes(t *testing.T) {
 	v := BidOutcomes{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -112,18 +106,18 @@ func BenchmarkMarshalMsgBidOutcomes(b *testing.B) {
 func BenchmarkAppendMsgBidOutcomes(b *testing.B) {
 	v := BidOutcomes{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalBidOutcomes(b *testing.B) {
 	v := BidOutcomes{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -137,10 +131,7 @@ func BenchmarkUnmarshalBidOutcomes(b *testing.B) {
 
 func TestMarshalUnmarshalBidderOutcome(t *testing.T) {
 	v := BidderOutcome{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -174,18 +165,18 @@ func BenchmarkMarshalMsgBidderOutcome(b *testing.B) {
 func BenchmarkAppendMsgBidderOutcome(b *testing.B) {
 	v := BidderOutcome{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalBidderOutcome(b *testing.B) {
 	v := BidderOutcome{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -199,10 +190,7 @@ func BenchmarkUnmarshalBidderOutcome(b *testing.B) {
 
 func TestMarshalUnmarshalDeposit(t *testing.T) {
 	v := Deposit{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -236,18 +224,18 @@ func BenchmarkMarshalMsgDeposit(b *testing.B) {
 func BenchmarkAppendMsgDeposit(b *testing.B) {
 	v := Deposit{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalDeposit(b *testing.B) {
 	v := Deposit{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -261,10 +249,7 @@ func BenchmarkUnmarshalDeposit(b *testing.B) {
 
 func TestMarshalUnmarshalMasterInput(t *testing.T) {
 	v := MasterInput{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -298,18 +283,18 @@ func BenchmarkMarshalMsgMasterInput(b *testing.B) {
 func BenchmarkAppendMsgMasterInput(b *testing.B) {
 	v := MasterInput{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalMasterInput(b *testing.B) {
 	v := MasterInput{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -323,10 +308,7 @@ func BenchmarkUnmarshalMasterInput(b *testing.B) {
 
 func TestMarshalUnmarshalNoteField(t *testing.T) {
 	v := NoteField{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -360,18 +342,18 @@ func BenchmarkMarshalMsgNoteField(b *testing.B) {
 func BenchmarkAppendMsgNoteField(b *testing.B) {
 	v := NoteField{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalNoteField(b *testing.B) {
 	v := NoteField{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -385,10 +367,7 @@ func BenchmarkUnmarshalNoteField(b *testing.B) {
 
 func TestMarshalUnmarshalParams(t *testing.T) {
 	v := Params{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -422,18 +401,18 @@ func BenchmarkMarshalMsgParams(b *testing.B) {
 func BenchmarkAppendMsgParams(b *testing.B) {
 	v := Params{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalParams(b *testing.B) {
 	v := Params{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -447,10 +426,7 @@ func BenchmarkUnmarshalParams(b *testing.B) {
 
 func TestMarshalUnmarshalSettlement(t *testing.T) {
 	v := Settlement{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -484,18 +460,18 @@ func BenchmarkMarshalMsgSettlement(b *testing.B) {
 func BenchmarkAppendMsgSettlement(b *testing.B) {
 	v := Settlement{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalSettlement(b *testing.B) {
 	v := Settlement{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -509,10 +485,7 @@ func BenchmarkUnmarshalSettlement(b *testing.B) {
 
 func TestMarshalUnmarshalSignedBid(t *testing.T) {
 	v := SignedBid{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -546,18 +519,18 @@ func BenchmarkMarshalMsgSignedBid(b *testing.B) {
 func BenchmarkAppendMsgSignedBid(b *testing.B) {
 	v := SignedBid{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalSignedBid(b *testing.B) {
 	v := SignedBid{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -571,10 +544,7 @@ func BenchmarkUnmarshalSignedBid(b *testing.B) {
 
 func TestMarshalUnmarshalSignedDeposit(t *testing.T) {
 	v := SignedDeposit{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -608,18 +578,18 @@ func BenchmarkMarshalMsgSignedDeposit(b *testing.B) {
 func BenchmarkAppendMsgSignedDeposit(b *testing.B) {
 	v := SignedDeposit{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalSignedDeposit(b *testing.B) {
 	v := SignedDeposit{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -633,10 +603,7 @@ func BenchmarkUnmarshalSignedDeposit(b *testing.B) {
 
 func TestMarshalUnmarshalSignedParams(t *testing.T) {
 	v := SignedParams{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -670,18 +637,18 @@ func BenchmarkMarshalMsgSignedParams(b *testing.B) {
 func BenchmarkAppendMsgSignedParams(b *testing.B) {
 	v := SignedParams{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalSignedParams(b *testing.B) {
 	v := SignedParams{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -695,10 +662,7 @@ func BenchmarkUnmarshalSignedParams(b *testing.B) {
 
 func TestMarshalUnmarshalSignedSettlement(t *testing.T) {
 	v := SignedSettlement{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -732,18 +696,18 @@ func BenchmarkMarshalMsgSignedSettlement(b *testing.B) {
 func BenchmarkAppendMsgSignedSettlement(b *testing.B) {
 	v := SignedSettlement{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalSignedSettlement(b *testing.B) {
 	v := SignedSettlement{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()

--- a/compactcert/msgp_gen.go
+++ b/compactcert/msgp_gen.go
@@ -17,7 +17,7 @@ import (
 //
 
 // MarshalMsg implements msgp.Marshaler
-func (z *sigFromAddr) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *sigFromAddr) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(3)
@@ -40,29 +40,17 @@ func (z *sigFromAddr) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "rnd"
 			o = append(o, 0xa3, 0x72, 0x6e, 0x64)
-			o, err = (*z).Round.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Round")
-				return
-			}
+			o = (*z).Round.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "sig"
 			o = append(o, 0xa3, 0x73, 0x69, 0x67)
-			o, err = (*z).Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sig")
-				return
-			}
+			o = (*z).Sig.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "signer"
 			o = append(o, 0xa6, 0x73, 0x69, 0x67, 0x6e, 0x65, 0x72)
-			o, err = (*z).Signer.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Signer")
-				return
-			}
+			o = (*z).Signer.MarshalMsg(o)
 		}
 	}
 	return

--- a/compactcert/msgp_gen_test.go
+++ b/compactcert/msgp_gen_test.go
@@ -13,10 +13,7 @@ import (
 
 func TestMarshalUnmarshalsigFromAddr(t *testing.T) {
 	v := sigFromAddr{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -50,18 +47,18 @@ func BenchmarkMarshalMsgsigFromAddr(b *testing.B) {
 func BenchmarkAppendMsgsigFromAddr(b *testing.B) {
 	v := sigFromAddr{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalsigFromAddr(b *testing.B) {
 	v := sigFromAddr{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()

--- a/crypto/compactcert/msgp_gen.go
+++ b/crypto/compactcert/msgp_gen.go
@@ -60,7 +60,7 @@ import (
 //
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Cert) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Cert) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0005Len := uint32(5)
@@ -97,11 +97,7 @@ func (z *Cert) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).PartProofs)))
 			}
 			for zb0002 := range (*z).PartProofs {
-				o, err = (*z).PartProofs[zb0002].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "PartProofs", zb0002)
-					return
-				}
+				o = (*z).PartProofs[zb0002].MarshalMsg(o)
 			}
 		}
 		if (zb0005Mask & 0x2) == 0 { // if not empty
@@ -113,21 +109,13 @@ func (z *Cert) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).SigProofs)))
 			}
 			for zb0001 := range (*z).SigProofs {
-				o, err = (*z).SigProofs[zb0001].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "SigProofs", zb0001)
-					return
-				}
+				o = (*z).SigProofs[zb0001].MarshalMsg(o)
 			}
 		}
 		if (zb0005Mask & 0x8) == 0 { // if not empty
 			// string "c"
 			o = append(o, 0xa1, 0x63)
-			o, err = (*z).SigCommit.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "SigCommit")
-				return
-			}
+			o = (*z).SigCommit.MarshalMsg(o)
 		}
 		if (zb0005Mask & 0x10) == 0 { // if not empty
 			// string "r"
@@ -146,11 +134,7 @@ func (z *Cert) MarshalMsg(b []byte) (o []byte, err error) {
 				zb0004 := (*z).Reveals[zb0003]
 				_ = zb0004
 				o = msgp.AppendUint64(o, zb0003)
-				o, err = zb0004.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Reveals", zb0003)
-					return
-				}
+				o = zb0004.MarshalMsg(o)
 			}
 		}
 		if (zb0005Mask & 0x20) == 0 { // if not empty
@@ -458,7 +442,7 @@ func (z *Cert) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *CompactOneTimeSignature) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *CompactOneTimeSignature) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(6)
@@ -493,56 +477,32 @@ func (z *CompactOneTimeSignature) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "p"
 			o = append(o, 0xa1, 0x70)
-			o, err = (*z).OneTimeSignature.PK.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "PK")
-				return
-			}
+			o = (*z).OneTimeSignature.PK.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "p1s"
 			o = append(o, 0xa3, 0x70, 0x31, 0x73)
-			o, err = (*z).OneTimeSignature.PK1Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "PK1Sig")
-				return
-			}
+			o = (*z).OneTimeSignature.PK1Sig.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "p2"
 			o = append(o, 0xa2, 0x70, 0x32)
-			o, err = (*z).OneTimeSignature.PK2.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "PK2")
-				return
-			}
+			o = (*z).OneTimeSignature.PK2.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "p2s"
 			o = append(o, 0xa3, 0x70, 0x32, 0x73)
-			o, err = (*z).OneTimeSignature.PK2Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "PK2Sig")
-				return
-			}
+			o = (*z).OneTimeSignature.PK2Sig.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not empty
 			// string "ps"
 			o = append(o, 0xa2, 0x70, 0x73)
-			o, err = (*z).OneTimeSignature.PKSigOld.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "PKSigOld")
-				return
-			}
+			o = (*z).OneTimeSignature.PKSigOld.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x80) == 0 { // if not empty
 			// string "s"
 			o = append(o, 0xa1, 0x73)
-			o, err = (*z).OneTimeSignature.Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sig")
-				return
-			}
+			o = (*z).OneTimeSignature.Sig.MarshalMsg(o)
 		}
 	}
 	return
@@ -703,7 +663,7 @@ func (z *CompactOneTimeSignature) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Participant) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Participant) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(3)
@@ -731,11 +691,7 @@ func (z *Participant) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "p"
 			o = append(o, 0xa1, 0x70)
-			o, err = (*z).PK.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "PK")
-				return
-			}
+			o = (*z).PK.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "w"
@@ -859,7 +815,7 @@ func (z *Participant) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Reveal) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Reveal) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(2)
@@ -878,11 +834,7 @@ func (z *Reveal) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "p"
 			o = append(o, 0xa1, 0x70)
-			o, err = (*z).Part.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Part")
-				return
-			}
+			o = (*z).Part.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "s"
@@ -908,11 +860,7 @@ func (z *Reveal) MarshalMsg(b []byte) (o []byte, err error) {
 			if (zb0002Mask & 0x4) == 0 { // if not empty
 				// string "s"
 				o = append(o, 0xa1, 0x73)
-				o, err = (*z).SigSlot.Sig.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "SigSlot", "Sig")
-					return
-				}
+				o = (*z).SigSlot.Sig.MarshalMsg(o)
 			}
 		}
 	}
@@ -1146,7 +1094,7 @@ func (z *Reveal) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *coinChoice) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *coinChoice) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(6)
@@ -1186,20 +1134,12 @@ func (z *coinChoice) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "msghash"
 			o = append(o, 0xa7, 0x6d, 0x73, 0x67, 0x68, 0x61, 0x73, 0x68)
-			o, err = (*z).MsgHash.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "MsgHash")
-				return
-			}
+			o = (*z).MsgHash.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "partcom"
 			o = append(o, 0xa7, 0x70, 0x61, 0x72, 0x74, 0x63, 0x6f, 0x6d)
-			o, err = (*z).Partcom.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Partcom")
-				return
-			}
+			o = (*z).Partcom.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "provenweight"
@@ -1209,11 +1149,7 @@ func (z *coinChoice) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "sigcom"
 			o = append(o, 0xa6, 0x73, 0x69, 0x67, 0x63, 0x6f, 0x6d)
-			o, err = (*z).Sigcom.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sigcom")
-				return
-			}
+			o = (*z).Sigcom.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not empty
 			// string "sigweight"
@@ -1379,7 +1315,7 @@ func (z *coinChoice) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *sigslotCommit) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *sigslotCommit) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(2)
@@ -1403,11 +1339,7 @@ func (z *sigslotCommit) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "s"
 			o = append(o, 0xa1, 0x73)
-			o, err = (*z).Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sig")
-				return
-			}
+			o = (*z).Sig.MarshalMsg(o)
 		}
 	}
 	return

--- a/crypto/compactcert/msgp_gen_test.go
+++ b/crypto/compactcert/msgp_gen_test.go
@@ -13,10 +13,7 @@ import (
 
 func TestMarshalUnmarshalCert(t *testing.T) {
 	v := Cert{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -50,18 +47,18 @@ func BenchmarkMarshalMsgCert(b *testing.B) {
 func BenchmarkAppendMsgCert(b *testing.B) {
 	v := Cert{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalCert(b *testing.B) {
 	v := Cert{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -75,10 +72,7 @@ func BenchmarkUnmarshalCert(b *testing.B) {
 
 func TestMarshalUnmarshalCompactOneTimeSignature(t *testing.T) {
 	v := CompactOneTimeSignature{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -112,18 +106,18 @@ func BenchmarkMarshalMsgCompactOneTimeSignature(b *testing.B) {
 func BenchmarkAppendMsgCompactOneTimeSignature(b *testing.B) {
 	v := CompactOneTimeSignature{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalCompactOneTimeSignature(b *testing.B) {
 	v := CompactOneTimeSignature{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -137,10 +131,7 @@ func BenchmarkUnmarshalCompactOneTimeSignature(b *testing.B) {
 
 func TestMarshalUnmarshalParticipant(t *testing.T) {
 	v := Participant{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -174,18 +165,18 @@ func BenchmarkMarshalMsgParticipant(b *testing.B) {
 func BenchmarkAppendMsgParticipant(b *testing.B) {
 	v := Participant{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalParticipant(b *testing.B) {
 	v := Participant{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -199,10 +190,7 @@ func BenchmarkUnmarshalParticipant(b *testing.B) {
 
 func TestMarshalUnmarshalReveal(t *testing.T) {
 	v := Reveal{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -236,18 +224,18 @@ func BenchmarkMarshalMsgReveal(b *testing.B) {
 func BenchmarkAppendMsgReveal(b *testing.B) {
 	v := Reveal{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalReveal(b *testing.B) {
 	v := Reveal{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -261,10 +249,7 @@ func BenchmarkUnmarshalReveal(b *testing.B) {
 
 func TestMarshalUnmarshalcoinChoice(t *testing.T) {
 	v := coinChoice{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -298,18 +283,18 @@ func BenchmarkMarshalMsgcoinChoice(b *testing.B) {
 func BenchmarkAppendMsgcoinChoice(b *testing.B) {
 	v := coinChoice{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalcoinChoice(b *testing.B) {
 	v := coinChoice{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -323,10 +308,7 @@ func BenchmarkUnmarshalcoinChoice(b *testing.B) {
 
 func TestMarshalUnmarshalsigslotCommit(t *testing.T) {
 	v := sigslotCommit{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -360,18 +342,18 @@ func BenchmarkMarshalMsgsigslotCommit(b *testing.B) {
 func BenchmarkAppendMsgsigslotCommit(b *testing.B) {
 	v := sigslotCommit{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalsigslotCommit(b *testing.B) {
 	v := sigslotCommit{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()

--- a/crypto/msgp_gen.go
+++ b/crypto/msgp_gen.go
@@ -212,7 +212,7 @@ import (
 //
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Digest) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Digest) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendBytes(o, (*z)[:])
 	return
@@ -251,7 +251,7 @@ func (z *Digest) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *MasterDerivationKey) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *MasterDerivationKey) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendBytes(o, (*z)[:])
 	return
@@ -290,7 +290,7 @@ func (z *MasterDerivationKey) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *MultisigSig) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *MultisigSig) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0002Len := uint32(3)
@@ -319,11 +319,7 @@ func (z *MultisigSig) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).Subsigs)))
 			}
 			for zb0001 := range (*z).Subsigs {
-				o, err = (*z).Subsigs[zb0001].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Subsigs", zb0001)
-					return
-				}
+				o = (*z).Subsigs[zb0001].MarshalMsg(o)
 			}
 		}
 		if (zb0002Mask & 0x4) == 0 { // if not empty
@@ -498,7 +494,7 @@ func (z *MultisigSig) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *MultisigSubsig) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *MultisigSubsig) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0003Len := uint32(2)
@@ -627,7 +623,7 @@ func (z *MultisigSubsig) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *OneTimeSignature) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *OneTimeSignature) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 6
 	// string "p"
@@ -806,7 +802,7 @@ func (z *OneTimeSignature) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *OneTimeSignatureSecrets) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *OneTimeSignatureSecrets) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0006Len := uint32(7)
@@ -861,11 +857,7 @@ func (z *OneTimeSignatureSecrets) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).OneTimeSignatureSecretsPersistent.Batches)))
 			}
 			for zb0002 := range (*z).OneTimeSignatureSecretsPersistent.Batches {
-				o, err = (*z).OneTimeSignatureSecretsPersistent.Batches[zb0002].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Batches", zb0002)
-					return
-				}
+				o = (*z).OneTimeSignatureSecretsPersistent.Batches[zb0002].MarshalMsg(o)
 			}
 		}
 		if (zb0006Mask & 0x20) == 0 { // if not empty
@@ -882,11 +874,7 @@ func (z *OneTimeSignatureSecrets) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).OneTimeSignatureSecretsPersistent.Offsets)))
 			}
 			for zb0003 := range (*z).OneTimeSignatureSecretsPersistent.Offsets {
-				o, err = (*z).OneTimeSignatureSecretsPersistent.Offsets[zb0003].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Offsets", zb0003)
-					return
-				}
+				o = (*z).OneTimeSignatureSecretsPersistent.Offsets[zb0003].MarshalMsg(o)
 			}
 		}
 		if (zb0006Mask & 0x100) == 0 { // if not empty
@@ -1144,7 +1132,7 @@ func (z *OneTimeSignatureSecrets) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *OneTimeSignatureSecretsPersistent) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *OneTimeSignatureSecretsPersistent) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0006Len := uint32(7)
@@ -1199,11 +1187,7 @@ func (z *OneTimeSignatureSecretsPersistent) MarshalMsg(b []byte) (o []byte, err 
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).Batches)))
 			}
 			for zb0002 := range (*z).Batches {
-				o, err = (*z).Batches[zb0002].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Batches", zb0002)
-					return
-				}
+				o = (*z).Batches[zb0002].MarshalMsg(o)
 			}
 		}
 		if (zb0006Mask & 0x10) == 0 { // if not empty
@@ -1220,11 +1204,7 @@ func (z *OneTimeSignatureSecretsPersistent) MarshalMsg(b []byte) (o []byte, err 
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).Offsets)))
 			}
 			for zb0003 := range (*z).Offsets {
-				o, err = (*z).Offsets[zb0003].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Offsets", zb0003)
-					return
-				}
+				o = (*z).Offsets[zb0003].MarshalMsg(o)
 			}
 		}
 		if (zb0006Mask & 0x40) == 0 { // if not empty
@@ -1482,7 +1462,7 @@ func (z *OneTimeSignatureSecretsPersistent) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *OneTimeSignatureSubkeyBatchID) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *OneTimeSignatureSubkeyBatchID) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 2
 	// string "batch"
@@ -1593,7 +1573,7 @@ func (z *OneTimeSignatureSubkeyBatchID) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *OneTimeSignatureSubkeyOffsetID) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *OneTimeSignatureSubkeyOffsetID) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 3
 	// string "batch"
@@ -1721,7 +1701,7 @@ func (z *OneTimeSignatureSubkeyOffsetID) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *OneTimeSignatureVerifier) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *OneTimeSignatureVerifier) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendBytes(o, (*z)[:])
 	return
@@ -1760,7 +1740,7 @@ func (z *OneTimeSignatureVerifier) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *PrivateKey) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *PrivateKey) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendBytes(o, (*z)[:])
 	return
@@ -1799,7 +1779,7 @@ func (z *PrivateKey) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *PublicKey) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *PublicKey) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendBytes(o, (*z)[:])
 	return
@@ -1838,7 +1818,7 @@ func (z *PublicKey) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Seed) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Seed) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendBytes(o, (*z)[:])
 	return
@@ -1877,7 +1857,7 @@ func (z *Seed) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Signature) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Signature) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendBytes(o, (*z)[:])
 	return
@@ -1916,7 +1896,7 @@ func (z *Signature) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *SignatureSecrets) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *SignatureSecrets) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 2
 	// string "SK"
@@ -1924,11 +1904,7 @@ func (z *SignatureSecrets) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.AppendBytes(o, ((*z).SK)[:])
 	// string "SignatureVerifier"
 	o = append(o, 0xb1, 0x53, 0x69, 0x67, 0x6e, 0x61, 0x74, 0x75, 0x72, 0x65, 0x56, 0x65, 0x72, 0x69, 0x66, 0x69, 0x65, 0x72)
-	o, err = (*z).SignatureVerifier.MarshalMsg(o)
-	if err != nil {
-		err = msgp.WrapError(err, "SignatureVerifier")
-		return
-	}
+	o = (*z).SignatureVerifier.MarshalMsg(o)
 	return
 }
 
@@ -2031,7 +2007,7 @@ func (z *SignatureSecrets) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *VRFSecrets) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *VRFSecrets) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 2
 	// string "PK"
@@ -2142,7 +2118,7 @@ func (z *VRFSecrets) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *VrfOutput) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *VrfOutput) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendBytes(o, (*z)[:])
 	return
@@ -2181,7 +2157,7 @@ func (z *VrfOutput) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *VrfPrivkey) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *VrfPrivkey) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendBytes(o, (*z)[:])
 	return
@@ -2220,7 +2196,7 @@ func (z *VrfPrivkey) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *VrfProof) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *VrfProof) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendBytes(o, (*z)[:])
 	return
@@ -2259,7 +2235,7 @@ func (z *VrfProof) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *VrfPubkey) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *VrfPubkey) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendBytes(o, (*z)[:])
 	return
@@ -2298,7 +2274,7 @@ func (z *VrfPubkey) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *ed25519PrivateKey) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *ed25519PrivateKey) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendBytes(o, (*z)[:])
 	return
@@ -2337,7 +2313,7 @@ func (z *ed25519PrivateKey) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *ed25519PublicKey) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *ed25519PublicKey) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendBytes(o, (*z)[:])
 	return
@@ -2376,7 +2352,7 @@ func (z *ed25519PublicKey) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *ed25519Seed) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *ed25519Seed) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendBytes(o, (*z)[:])
 	return
@@ -2415,7 +2391,7 @@ func (z *ed25519Seed) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *ed25519Signature) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *ed25519Signature) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendBytes(o, (*z)[:])
 	return
@@ -2454,7 +2430,7 @@ func (z *ed25519Signature) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *ephemeralSubkey) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *ephemeralSubkey) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 4
 	// string "PK"

--- a/crypto/msgp_gen_test.go
+++ b/crypto/msgp_gen_test.go
@@ -13,10 +13,7 @@ import (
 
 func TestMarshalUnmarshalDigest(t *testing.T) {
 	v := Digest{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -50,18 +47,18 @@ func BenchmarkMarshalMsgDigest(b *testing.B) {
 func BenchmarkAppendMsgDigest(b *testing.B) {
 	v := Digest{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalDigest(b *testing.B) {
 	v := Digest{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -75,10 +72,7 @@ func BenchmarkUnmarshalDigest(b *testing.B) {
 
 func TestMarshalUnmarshalMasterDerivationKey(t *testing.T) {
 	v := MasterDerivationKey{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -112,18 +106,18 @@ func BenchmarkMarshalMsgMasterDerivationKey(b *testing.B) {
 func BenchmarkAppendMsgMasterDerivationKey(b *testing.B) {
 	v := MasterDerivationKey{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalMasterDerivationKey(b *testing.B) {
 	v := MasterDerivationKey{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -137,10 +131,7 @@ func BenchmarkUnmarshalMasterDerivationKey(b *testing.B) {
 
 func TestMarshalUnmarshalMultisigSig(t *testing.T) {
 	v := MultisigSig{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -174,18 +165,18 @@ func BenchmarkMarshalMsgMultisigSig(b *testing.B) {
 func BenchmarkAppendMsgMultisigSig(b *testing.B) {
 	v := MultisigSig{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalMultisigSig(b *testing.B) {
 	v := MultisigSig{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -199,10 +190,7 @@ func BenchmarkUnmarshalMultisigSig(b *testing.B) {
 
 func TestMarshalUnmarshalMultisigSubsig(t *testing.T) {
 	v := MultisigSubsig{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -236,18 +224,18 @@ func BenchmarkMarshalMsgMultisigSubsig(b *testing.B) {
 func BenchmarkAppendMsgMultisigSubsig(b *testing.B) {
 	v := MultisigSubsig{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalMultisigSubsig(b *testing.B) {
 	v := MultisigSubsig{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -261,10 +249,7 @@ func BenchmarkUnmarshalMultisigSubsig(b *testing.B) {
 
 func TestMarshalUnmarshalOneTimeSignature(t *testing.T) {
 	v := OneTimeSignature{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -298,18 +283,18 @@ func BenchmarkMarshalMsgOneTimeSignature(b *testing.B) {
 func BenchmarkAppendMsgOneTimeSignature(b *testing.B) {
 	v := OneTimeSignature{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalOneTimeSignature(b *testing.B) {
 	v := OneTimeSignature{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -323,10 +308,7 @@ func BenchmarkUnmarshalOneTimeSignature(b *testing.B) {
 
 func TestMarshalUnmarshalOneTimeSignatureSecrets(t *testing.T) {
 	v := OneTimeSignatureSecrets{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -360,18 +342,18 @@ func BenchmarkMarshalMsgOneTimeSignatureSecrets(b *testing.B) {
 func BenchmarkAppendMsgOneTimeSignatureSecrets(b *testing.B) {
 	v := OneTimeSignatureSecrets{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalOneTimeSignatureSecrets(b *testing.B) {
 	v := OneTimeSignatureSecrets{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -385,10 +367,7 @@ func BenchmarkUnmarshalOneTimeSignatureSecrets(b *testing.B) {
 
 func TestMarshalUnmarshalOneTimeSignatureSecretsPersistent(t *testing.T) {
 	v := OneTimeSignatureSecretsPersistent{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -422,18 +401,18 @@ func BenchmarkMarshalMsgOneTimeSignatureSecretsPersistent(b *testing.B) {
 func BenchmarkAppendMsgOneTimeSignatureSecretsPersistent(b *testing.B) {
 	v := OneTimeSignatureSecretsPersistent{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalOneTimeSignatureSecretsPersistent(b *testing.B) {
 	v := OneTimeSignatureSecretsPersistent{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -447,10 +426,7 @@ func BenchmarkUnmarshalOneTimeSignatureSecretsPersistent(b *testing.B) {
 
 func TestMarshalUnmarshalOneTimeSignatureSubkeyBatchID(t *testing.T) {
 	v := OneTimeSignatureSubkeyBatchID{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -484,18 +460,18 @@ func BenchmarkMarshalMsgOneTimeSignatureSubkeyBatchID(b *testing.B) {
 func BenchmarkAppendMsgOneTimeSignatureSubkeyBatchID(b *testing.B) {
 	v := OneTimeSignatureSubkeyBatchID{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalOneTimeSignatureSubkeyBatchID(b *testing.B) {
 	v := OneTimeSignatureSubkeyBatchID{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -509,10 +485,7 @@ func BenchmarkUnmarshalOneTimeSignatureSubkeyBatchID(b *testing.B) {
 
 func TestMarshalUnmarshalOneTimeSignatureSubkeyOffsetID(t *testing.T) {
 	v := OneTimeSignatureSubkeyOffsetID{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -546,18 +519,18 @@ func BenchmarkMarshalMsgOneTimeSignatureSubkeyOffsetID(b *testing.B) {
 func BenchmarkAppendMsgOneTimeSignatureSubkeyOffsetID(b *testing.B) {
 	v := OneTimeSignatureSubkeyOffsetID{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalOneTimeSignatureSubkeyOffsetID(b *testing.B) {
 	v := OneTimeSignatureSubkeyOffsetID{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -571,10 +544,7 @@ func BenchmarkUnmarshalOneTimeSignatureSubkeyOffsetID(b *testing.B) {
 
 func TestMarshalUnmarshalOneTimeSignatureVerifier(t *testing.T) {
 	v := OneTimeSignatureVerifier{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -608,18 +578,18 @@ func BenchmarkMarshalMsgOneTimeSignatureVerifier(b *testing.B) {
 func BenchmarkAppendMsgOneTimeSignatureVerifier(b *testing.B) {
 	v := OneTimeSignatureVerifier{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalOneTimeSignatureVerifier(b *testing.B) {
 	v := OneTimeSignatureVerifier{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -633,10 +603,7 @@ func BenchmarkUnmarshalOneTimeSignatureVerifier(b *testing.B) {
 
 func TestMarshalUnmarshalPrivateKey(t *testing.T) {
 	v := PrivateKey{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -670,18 +637,18 @@ func BenchmarkMarshalMsgPrivateKey(b *testing.B) {
 func BenchmarkAppendMsgPrivateKey(b *testing.B) {
 	v := PrivateKey{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalPrivateKey(b *testing.B) {
 	v := PrivateKey{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -695,10 +662,7 @@ func BenchmarkUnmarshalPrivateKey(b *testing.B) {
 
 func TestMarshalUnmarshalPublicKey(t *testing.T) {
 	v := PublicKey{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -732,18 +696,18 @@ func BenchmarkMarshalMsgPublicKey(b *testing.B) {
 func BenchmarkAppendMsgPublicKey(b *testing.B) {
 	v := PublicKey{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalPublicKey(b *testing.B) {
 	v := PublicKey{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -757,10 +721,7 @@ func BenchmarkUnmarshalPublicKey(b *testing.B) {
 
 func TestMarshalUnmarshalSeed(t *testing.T) {
 	v := Seed{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -794,18 +755,18 @@ func BenchmarkMarshalMsgSeed(b *testing.B) {
 func BenchmarkAppendMsgSeed(b *testing.B) {
 	v := Seed{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalSeed(b *testing.B) {
 	v := Seed{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -819,10 +780,7 @@ func BenchmarkUnmarshalSeed(b *testing.B) {
 
 func TestMarshalUnmarshalSignature(t *testing.T) {
 	v := Signature{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -856,18 +814,18 @@ func BenchmarkMarshalMsgSignature(b *testing.B) {
 func BenchmarkAppendMsgSignature(b *testing.B) {
 	v := Signature{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalSignature(b *testing.B) {
 	v := Signature{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -881,10 +839,7 @@ func BenchmarkUnmarshalSignature(b *testing.B) {
 
 func TestMarshalUnmarshalSignatureSecrets(t *testing.T) {
 	v := SignatureSecrets{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -918,18 +873,18 @@ func BenchmarkMarshalMsgSignatureSecrets(b *testing.B) {
 func BenchmarkAppendMsgSignatureSecrets(b *testing.B) {
 	v := SignatureSecrets{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalSignatureSecrets(b *testing.B) {
 	v := SignatureSecrets{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -943,10 +898,7 @@ func BenchmarkUnmarshalSignatureSecrets(b *testing.B) {
 
 func TestMarshalUnmarshalVRFSecrets(t *testing.T) {
 	v := VRFSecrets{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -980,18 +932,18 @@ func BenchmarkMarshalMsgVRFSecrets(b *testing.B) {
 func BenchmarkAppendMsgVRFSecrets(b *testing.B) {
 	v := VRFSecrets{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalVRFSecrets(b *testing.B) {
 	v := VRFSecrets{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -1005,10 +957,7 @@ func BenchmarkUnmarshalVRFSecrets(b *testing.B) {
 
 func TestMarshalUnmarshalVrfOutput(t *testing.T) {
 	v := VrfOutput{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -1042,18 +991,18 @@ func BenchmarkMarshalMsgVrfOutput(b *testing.B) {
 func BenchmarkAppendMsgVrfOutput(b *testing.B) {
 	v := VrfOutput{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalVrfOutput(b *testing.B) {
 	v := VrfOutput{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -1067,10 +1016,7 @@ func BenchmarkUnmarshalVrfOutput(b *testing.B) {
 
 func TestMarshalUnmarshalVrfPrivkey(t *testing.T) {
 	v := VrfPrivkey{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -1104,18 +1050,18 @@ func BenchmarkMarshalMsgVrfPrivkey(b *testing.B) {
 func BenchmarkAppendMsgVrfPrivkey(b *testing.B) {
 	v := VrfPrivkey{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalVrfPrivkey(b *testing.B) {
 	v := VrfPrivkey{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -1129,10 +1075,7 @@ func BenchmarkUnmarshalVrfPrivkey(b *testing.B) {
 
 func TestMarshalUnmarshalVrfProof(t *testing.T) {
 	v := VrfProof{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -1166,18 +1109,18 @@ func BenchmarkMarshalMsgVrfProof(b *testing.B) {
 func BenchmarkAppendMsgVrfProof(b *testing.B) {
 	v := VrfProof{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalVrfProof(b *testing.B) {
 	v := VrfProof{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -1191,10 +1134,7 @@ func BenchmarkUnmarshalVrfProof(b *testing.B) {
 
 func TestMarshalUnmarshalVrfPubkey(t *testing.T) {
 	v := VrfPubkey{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -1228,18 +1168,18 @@ func BenchmarkMarshalMsgVrfPubkey(b *testing.B) {
 func BenchmarkAppendMsgVrfPubkey(b *testing.B) {
 	v := VrfPubkey{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalVrfPubkey(b *testing.B) {
 	v := VrfPubkey{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -1253,10 +1193,7 @@ func BenchmarkUnmarshalVrfPubkey(b *testing.B) {
 
 func TestMarshalUnmarshaled25519PrivateKey(t *testing.T) {
 	v := ed25519PrivateKey{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -1290,18 +1227,18 @@ func BenchmarkMarshalMsged25519PrivateKey(b *testing.B) {
 func BenchmarkAppendMsged25519PrivateKey(b *testing.B) {
 	v := ed25519PrivateKey{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshaled25519PrivateKey(b *testing.B) {
 	v := ed25519PrivateKey{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -1315,10 +1252,7 @@ func BenchmarkUnmarshaled25519PrivateKey(b *testing.B) {
 
 func TestMarshalUnmarshaled25519PublicKey(t *testing.T) {
 	v := ed25519PublicKey{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -1352,18 +1286,18 @@ func BenchmarkMarshalMsged25519PublicKey(b *testing.B) {
 func BenchmarkAppendMsged25519PublicKey(b *testing.B) {
 	v := ed25519PublicKey{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshaled25519PublicKey(b *testing.B) {
 	v := ed25519PublicKey{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -1377,10 +1311,7 @@ func BenchmarkUnmarshaled25519PublicKey(b *testing.B) {
 
 func TestMarshalUnmarshaled25519Seed(t *testing.T) {
 	v := ed25519Seed{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -1414,18 +1345,18 @@ func BenchmarkMarshalMsged25519Seed(b *testing.B) {
 func BenchmarkAppendMsged25519Seed(b *testing.B) {
 	v := ed25519Seed{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshaled25519Seed(b *testing.B) {
 	v := ed25519Seed{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -1439,10 +1370,7 @@ func BenchmarkUnmarshaled25519Seed(b *testing.B) {
 
 func TestMarshalUnmarshaled25519Signature(t *testing.T) {
 	v := ed25519Signature{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -1476,18 +1404,18 @@ func BenchmarkMarshalMsged25519Signature(b *testing.B) {
 func BenchmarkAppendMsged25519Signature(b *testing.B) {
 	v := ed25519Signature{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshaled25519Signature(b *testing.B) {
 	v := ed25519Signature{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -1501,10 +1429,7 @@ func BenchmarkUnmarshaled25519Signature(b *testing.B) {
 
 func TestMarshalUnmarshalephemeralSubkey(t *testing.T) {
 	v := ephemeralSubkey{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -1538,18 +1463,18 @@ func BenchmarkMarshalMsgephemeralSubkey(b *testing.B) {
 func BenchmarkAppendMsgephemeralSubkey(b *testing.B) {
 	v := ephemeralSubkey{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalephemeralSubkey(b *testing.B) {
 	v := ephemeralSubkey{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()

--- a/data/basics/msgp_gen.go
+++ b/data/basics/msgp_gen.go
@@ -197,7 +197,7 @@ import (
 //
 
 // MarshalMsg implements msgp.Marshaler
-func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *AccountData) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0009Len := uint32(15)
@@ -268,11 +268,7 @@ func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0009Mask & 0x2) == 0 { // if not empty
 			// string "algo"
 			o = append(o, 0xa4, 0x61, 0x6c, 0x67, 0x6f)
-			o, err = (*z).MicroAlgos.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "MicroAlgos")
-				return
-			}
+			o = (*z).MicroAlgos.MarshalMsg(o)
 		}
 		if (zb0009Mask & 0x4) == 0 { // if not empty
 			// string "apar"
@@ -290,16 +286,8 @@ func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
 			for _, zb0001 := range zb0001_keys {
 				zb0002 := (*z).AssetParams[zb0001]
 				_ = zb0002
-				o, err = zb0001.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "AssetParams", zb0001)
-					return
-				}
-				o, err = zb0002.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "AssetParams", zb0001)
-					return
-				}
+				o = zb0001.MarshalMsg(o)
+				o = zb0002.MarshalMsg(o)
 			}
 		}
 		if (zb0009Mask & 0x8) == 0 { // if not empty
@@ -318,16 +306,8 @@ func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
 			for _, zb0005 := range zb0005_keys {
 				zb0006 := (*z).AppLocalStates[zb0005]
 				_ = zb0006
-				o, err = zb0005.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "AppLocalStates", zb0005)
-					return
-				}
-				o, err = zb0006.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "AppLocalStates", zb0005)
-					return
-				}
+				o = zb0005.MarshalMsg(o)
+				o = zb0006.MarshalMsg(o)
 			}
 		}
 		if (zb0009Mask & 0x10) == 0 { // if not empty
@@ -346,16 +326,8 @@ func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
 			for _, zb0007 := range zb0007_keys {
 				zb0008 := (*z).AppParams[zb0007]
 				_ = zb0008
-				o, err = zb0007.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "AppParams", zb0007)
-					return
-				}
-				o, err = zb0008.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "AppParams", zb0007)
-					return
-				}
+				o = zb0007.MarshalMsg(o)
+				o = zb0008.MarshalMsg(o)
 			}
 		}
 		if (zb0009Mask & 0x20) == 0 { // if not empty
@@ -374,11 +346,7 @@ func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
 			for _, zb0003 := range zb0003_keys {
 				zb0004 := (*z).Assets[zb0003]
 				_ = zb0004
-				o, err = zb0003.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Assets", zb0003)
-					return
-				}
+				o = zb0003.MarshalMsg(o)
 				// omitempty: check for empty values
 				zb0010Len := uint32(2)
 				var zb0010Mask uint8 /* 3 bits */
@@ -414,11 +382,7 @@ func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0009Mask & 0x80) == 0 { // if not empty
 			// string "ern"
 			o = append(o, 0xa3, 0x65, 0x72, 0x6e)
-			o, err = (*z).RewardedMicroAlgos.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RewardedMicroAlgos")
-				return
-			}
+			o = (*z).RewardedMicroAlgos.MarshalMsg(o)
 		}
 		if (zb0009Mask & 0x100) == 0 { // if not empty
 			// string "onl"
@@ -428,20 +392,12 @@ func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0009Mask & 0x200) == 0 { // if not empty
 			// string "sel"
 			o = append(o, 0xa3, 0x73, 0x65, 0x6c)
-			o, err = (*z).SelectionID.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "SelectionID")
-				return
-			}
+			o = (*z).SelectionID.MarshalMsg(o)
 		}
 		if (zb0009Mask & 0x400) == 0 { // if not empty
 			// string "spend"
 			o = append(o, 0xa5, 0x73, 0x70, 0x65, 0x6e, 0x64)
-			o, err = (*z).AuthAddr.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AuthAddr")
-				return
-			}
+			o = (*z).AuthAddr.MarshalMsg(o)
 		}
 		if (zb0009Mask & 0x800) == 0 { // if not empty
 			// string "tsch"
@@ -473,11 +429,7 @@ func (z *AccountData) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0009Mask & 0x1000) == 0 { // if not empty
 			// string "vote"
 			o = append(o, 0xa4, 0x76, 0x6f, 0x74, 0x65)
-			o, err = (*z).VoteID.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "VoteID")
-				return
-			}
+			o = (*z).VoteID.MarshalMsg(o)
 		}
 		if (zb0009Mask & 0x2000) == 0 { // if not empty
 			// string "voteFst"
@@ -1315,7 +1267,7 @@ func (z *AccountData) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Address) MarshalMsg(b []byte) ([]byte, error) {
+func (z *Address) MarshalMsg(b []byte) []byte {
 	return ((*(crypto.Digest))(z)).MarshalMsg(b)
 }
 func (_ *Address) CanMarshalMsg(z interface{}) bool {
@@ -1343,7 +1295,7 @@ func (z *Address) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z AppIndex) MarshalMsg(b []byte) (o []byte, err error) {
+func (z AppIndex) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendUint64(o, uint64(z))
 	return
@@ -1389,7 +1341,7 @@ func (z AppIndex) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *AppLocalState) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *AppLocalState) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0003Len := uint32(2)
@@ -1449,11 +1401,7 @@ func (z *AppLocalState) MarshalMsg(b []byte) (o []byte, err error) {
 				zb0002 := (*z).KeyValue[zb0001]
 				_ = zb0002
 				o = msgp.AppendString(o, zb0001)
-				o, err = zb0002.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "KeyValue", zb0001)
-					return
-				}
+				o = zb0002.MarshalMsg(o)
 			}
 		}
 	}
@@ -1750,7 +1698,7 @@ func (z *AppLocalState) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *AppParams) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *AppParams) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0003Len := uint32(5)
@@ -1805,11 +1753,7 @@ func (z *AppParams) MarshalMsg(b []byte) (o []byte, err error) {
 				zb0002 := (*z).GlobalState[zb0001]
 				_ = zb0002
 				o = msgp.AppendString(o, zb0001)
-				o, err = zb0002.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "GlobalState", zb0001)
-					return
-				}
+				o = zb0002.MarshalMsg(o)
 			}
 		}
 		if (zb0003Mask & 0x20) == 0 { // if not empty
@@ -2371,7 +2315,7 @@ func (z *AppParams) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *AssetHolding) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *AssetHolding) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(2)
@@ -2500,7 +2444,7 @@ func (z *AssetHolding) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z AssetIndex) MarshalMsg(b []byte) (o []byte, err error) {
+func (z AssetIndex) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendUint64(o, uint64(z))
 	return
@@ -2546,7 +2490,7 @@ func (z AssetIndex) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *AssetParams) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *AssetParams) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0002Len := uint32(11)
@@ -2616,11 +2560,7 @@ func (z *AssetParams) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0002Mask & 0x10) == 0 { // if not empty
 			// string "c"
 			o = append(o, 0xa1, 0x63)
-			o, err = (*z).Clawback.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Clawback")
-				return
-			}
+			o = (*z).Clawback.MarshalMsg(o)
 		}
 		if (zb0002Mask & 0x20) == 0 { // if not empty
 			// string "dc"
@@ -2635,29 +2575,17 @@ func (z *AssetParams) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0002Mask & 0x80) == 0 { // if not empty
 			// string "f"
 			o = append(o, 0xa1, 0x66)
-			o, err = (*z).Freeze.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Freeze")
-				return
-			}
+			o = (*z).Freeze.MarshalMsg(o)
 		}
 		if (zb0002Mask & 0x100) == 0 { // if not empty
 			// string "m"
 			o = append(o, 0xa1, 0x6d)
-			o, err = (*z).Manager.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Manager")
-				return
-			}
+			o = (*z).Manager.MarshalMsg(o)
 		}
 		if (zb0002Mask & 0x200) == 0 { // if not empty
 			// string "r"
 			o = append(o, 0xa1, 0x72)
-			o, err = (*z).Reserve.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Reserve")
-				return
-			}
+			o = (*z).Reserve.MarshalMsg(o)
 		}
 		if (zb0002Mask & 0x400) == 0 { // if not empty
 			// string "t"
@@ -2898,7 +2826,7 @@ func (z *AssetParams) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0009Len := uint32(16)
@@ -2973,20 +2901,12 @@ func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0009Mask & 0x4) == 0 { // if not empty
 			// string "addr"
 			o = append(o, 0xa4, 0x61, 0x64, 0x64, 0x72)
-			o, err = (*z).Addr.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Addr")
-				return
-			}
+			o = (*z).Addr.MarshalMsg(o)
 		}
 		if (zb0009Mask & 0x8) == 0 { // if not empty
 			// string "algo"
 			o = append(o, 0xa4, 0x61, 0x6c, 0x67, 0x6f)
-			o, err = (*z).AccountData.MicroAlgos.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "MicroAlgos")
-				return
-			}
+			o = (*z).AccountData.MicroAlgos.MarshalMsg(o)
 		}
 		if (zb0009Mask & 0x10) == 0 { // if not empty
 			// string "apar"
@@ -3004,16 +2924,8 @@ func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 			for _, zb0001 := range zb0001_keys {
 				zb0002 := (*z).AccountData.AssetParams[zb0001]
 				_ = zb0002
-				o, err = zb0001.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "AssetParams", zb0001)
-					return
-				}
-				o, err = zb0002.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "AssetParams", zb0001)
-					return
-				}
+				o = zb0001.MarshalMsg(o)
+				o = zb0002.MarshalMsg(o)
 			}
 		}
 		if (zb0009Mask & 0x20) == 0 { // if not empty
@@ -3032,16 +2944,8 @@ func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 			for _, zb0005 := range zb0005_keys {
 				zb0006 := (*z).AccountData.AppLocalStates[zb0005]
 				_ = zb0006
-				o, err = zb0005.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "AppLocalStates", zb0005)
-					return
-				}
-				o, err = zb0006.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "AppLocalStates", zb0005)
-					return
-				}
+				o = zb0005.MarshalMsg(o)
+				o = zb0006.MarshalMsg(o)
 			}
 		}
 		if (zb0009Mask & 0x40) == 0 { // if not empty
@@ -3060,16 +2964,8 @@ func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 			for _, zb0007 := range zb0007_keys {
 				zb0008 := (*z).AccountData.AppParams[zb0007]
 				_ = zb0008
-				o, err = zb0007.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "AppParams", zb0007)
-					return
-				}
-				o, err = zb0008.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "AppParams", zb0007)
-					return
-				}
+				o = zb0007.MarshalMsg(o)
+				o = zb0008.MarshalMsg(o)
 			}
 		}
 		if (zb0009Mask & 0x80) == 0 { // if not empty
@@ -3088,11 +2984,7 @@ func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 			for _, zb0003 := range zb0003_keys {
 				zb0004 := (*z).AccountData.Assets[zb0003]
 				_ = zb0004
-				o, err = zb0003.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Assets", zb0003)
-					return
-				}
+				o = zb0003.MarshalMsg(o)
 				// omitempty: check for empty values
 				zb0010Len := uint32(2)
 				var zb0010Mask uint8 /* 3 bits */
@@ -3128,11 +3020,7 @@ func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0009Mask & 0x200) == 0 { // if not empty
 			// string "ern"
 			o = append(o, 0xa3, 0x65, 0x72, 0x6e)
-			o, err = (*z).AccountData.RewardedMicroAlgos.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RewardedMicroAlgos")
-				return
-			}
+			o = (*z).AccountData.RewardedMicroAlgos.MarshalMsg(o)
 		}
 		if (zb0009Mask & 0x400) == 0 { // if not empty
 			// string "onl"
@@ -3142,20 +3030,12 @@ func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0009Mask & 0x800) == 0 { // if not empty
 			// string "sel"
 			o = append(o, 0xa3, 0x73, 0x65, 0x6c)
-			o, err = (*z).AccountData.SelectionID.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "SelectionID")
-				return
-			}
+			o = (*z).AccountData.SelectionID.MarshalMsg(o)
 		}
 		if (zb0009Mask & 0x1000) == 0 { // if not empty
 			// string "spend"
 			o = append(o, 0xa5, 0x73, 0x70, 0x65, 0x6e, 0x64)
-			o, err = (*z).AccountData.AuthAddr.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AuthAddr")
-				return
-			}
+			o = (*z).AccountData.AuthAddr.MarshalMsg(o)
 		}
 		if (zb0009Mask & 0x2000) == 0 { // if not empty
 			// string "tsch"
@@ -3187,11 +3067,7 @@ func (z *BalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0009Mask & 0x4000) == 0 { // if not empty
 			// string "vote"
 			o = append(o, 0xa4, 0x76, 0x6f, 0x74, 0x65)
-			o, err = (*z).AccountData.VoteID.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "VoteID")
-				return
-			}
+			o = (*z).AccountData.VoteID.MarshalMsg(o)
 		}
 		if (zb0009Mask & 0x8000) == 0 { // if not empty
 			// string "voteFst"
@@ -4043,7 +3919,7 @@ func (z *BalanceRecord) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z CreatableIndex) MarshalMsg(b []byte) (o []byte, err error) {
+func (z CreatableIndex) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendUint64(o, uint64(z))
 	return
@@ -4089,7 +3965,7 @@ func (z CreatableIndex) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z CreatableType) MarshalMsg(b []byte) (o []byte, err error) {
+func (z CreatableType) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendUint64(o, uint64(z))
 	return
@@ -4135,7 +4011,7 @@ func (z CreatableType) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z DeltaAction) MarshalMsg(b []byte) (o []byte, err error) {
+func (z DeltaAction) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendUint64(o, uint64(z))
 	return
@@ -4181,7 +4057,7 @@ func (z DeltaAction) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *EvalDelta) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *EvalDelta) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0007Len := uint32(2)
@@ -4214,11 +4090,7 @@ func (z *EvalDelta) MarshalMsg(b []byte) (o []byte, err error) {
 				zb0002 := (*z).GlobalDelta[zb0001]
 				_ = zb0002
 				o = msgp.AppendString(o, zb0001)
-				o, err = zb0002.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "GlobalDelta", zb0001)
-					return
-				}
+				o = zb0002.MarshalMsg(o)
 			}
 		}
 		if (zb0007Mask & 0x4) == 0 { // if not empty
@@ -4252,11 +4124,7 @@ func (z *EvalDelta) MarshalMsg(b []byte) (o []byte, err error) {
 					zb0006 := zb0004[zb0005]
 					_ = zb0006
 					o = msgp.AppendString(o, zb0005)
-					o, err = zb0006.MarshalMsg(o)
-					if err != nil {
-						err = msgp.WrapError(err, "LocalDeltas", zb0003, zb0005)
-						return
-					}
+					o = zb0006.MarshalMsg(o)
 				}
 			}
 		}
@@ -4553,7 +4421,7 @@ func (z *EvalDelta) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z Round) MarshalMsg(b []byte) (o []byte, err error) {
+func (z Round) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendUint64(o, uint64(z))
 	return
@@ -4599,7 +4467,7 @@ func (z Round) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z RoundInterval) MarshalMsg(b []byte) (o []byte, err error) {
+func (z RoundInterval) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendUint64(o, uint64(z))
 	return
@@ -4645,7 +4513,7 @@ func (z RoundInterval) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z StateDelta) MarshalMsg(b []byte) (o []byte, err error) {
+func (z StateDelta) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	if z == nil {
 		o = msgp.AppendNil(o)
@@ -4661,11 +4529,7 @@ func (z StateDelta) MarshalMsg(b []byte) (o []byte, err error) {
 		za0002 := z[za0001]
 		_ = za0002
 		o = msgp.AppendString(o, za0001)
-		o, err = za0002.MarshalMsg(o)
-		if err != nil {
-			err = msgp.WrapError(err, za0001)
-			return
-		}
+		o = za0002.MarshalMsg(o)
 	}
 	return
 }
@@ -4741,7 +4605,7 @@ func (z StateDelta) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *StateSchema) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *StateSchema) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(2)
@@ -4870,7 +4734,7 @@ func (z *StateSchema) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *StateSchemas) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *StateSchemas) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(2)
@@ -5299,7 +5163,7 @@ func (z *StateSchemas) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z Status) MarshalMsg(b []byte) (o []byte, err error) {
+func (z Status) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendByte(o, byte(z))
 	return
@@ -5345,7 +5209,7 @@ func (z Status) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z TealKeyValue) MarshalMsg(b []byte) (o []byte, err error) {
+func (z TealKeyValue) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	if z == nil {
 		o = msgp.AppendNil(o)
@@ -5361,11 +5225,7 @@ func (z TealKeyValue) MarshalMsg(b []byte) (o []byte, err error) {
 		za0002 := z[za0001]
 		_ = za0002
 		o = msgp.AppendString(o, za0001)
-		o, err = za0002.MarshalMsg(o)
-		if err != nil {
-			err = msgp.WrapError(err, za0001)
-			return
-		}
+		o = za0002.MarshalMsg(o)
 	}
 	return
 }
@@ -5441,7 +5301,7 @@ func (z TealKeyValue) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z TealType) MarshalMsg(b []byte) (o []byte, err error) {
+func (z TealType) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendUint64(o, uint64(z))
 	return
@@ -5487,7 +5347,7 @@ func (z TealType) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *TealValue) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *TealValue) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(3)
@@ -5647,7 +5507,7 @@ func (z *TealValue) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *ValueDelta) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *ValueDelta) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(3)

--- a/data/basics/msgp_gen_test.go
+++ b/data/basics/msgp_gen_test.go
@@ -13,10 +13,7 @@ import (
 
 func TestMarshalUnmarshalAccountData(t *testing.T) {
 	v := AccountData{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -50,18 +47,18 @@ func BenchmarkMarshalMsgAccountData(b *testing.B) {
 func BenchmarkAppendMsgAccountData(b *testing.B) {
 	v := AccountData{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalAccountData(b *testing.B) {
 	v := AccountData{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -75,10 +72,7 @@ func BenchmarkUnmarshalAccountData(b *testing.B) {
 
 func TestMarshalUnmarshalAppLocalState(t *testing.T) {
 	v := AppLocalState{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -112,18 +106,18 @@ func BenchmarkMarshalMsgAppLocalState(b *testing.B) {
 func BenchmarkAppendMsgAppLocalState(b *testing.B) {
 	v := AppLocalState{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalAppLocalState(b *testing.B) {
 	v := AppLocalState{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -137,10 +131,7 @@ func BenchmarkUnmarshalAppLocalState(b *testing.B) {
 
 func TestMarshalUnmarshalAppParams(t *testing.T) {
 	v := AppParams{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -174,18 +165,18 @@ func BenchmarkMarshalMsgAppParams(b *testing.B) {
 func BenchmarkAppendMsgAppParams(b *testing.B) {
 	v := AppParams{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalAppParams(b *testing.B) {
 	v := AppParams{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -199,10 +190,7 @@ func BenchmarkUnmarshalAppParams(b *testing.B) {
 
 func TestMarshalUnmarshalAssetHolding(t *testing.T) {
 	v := AssetHolding{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -236,18 +224,18 @@ func BenchmarkMarshalMsgAssetHolding(b *testing.B) {
 func BenchmarkAppendMsgAssetHolding(b *testing.B) {
 	v := AssetHolding{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalAssetHolding(b *testing.B) {
 	v := AssetHolding{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -261,10 +249,7 @@ func BenchmarkUnmarshalAssetHolding(b *testing.B) {
 
 func TestMarshalUnmarshalAssetParams(t *testing.T) {
 	v := AssetParams{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -298,18 +283,18 @@ func BenchmarkMarshalMsgAssetParams(b *testing.B) {
 func BenchmarkAppendMsgAssetParams(b *testing.B) {
 	v := AssetParams{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalAssetParams(b *testing.B) {
 	v := AssetParams{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -323,10 +308,7 @@ func BenchmarkUnmarshalAssetParams(b *testing.B) {
 
 func TestMarshalUnmarshalBalanceRecord(t *testing.T) {
 	v := BalanceRecord{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -360,18 +342,18 @@ func BenchmarkMarshalMsgBalanceRecord(b *testing.B) {
 func BenchmarkAppendMsgBalanceRecord(b *testing.B) {
 	v := BalanceRecord{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalBalanceRecord(b *testing.B) {
 	v := BalanceRecord{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -385,10 +367,7 @@ func BenchmarkUnmarshalBalanceRecord(b *testing.B) {
 
 func TestMarshalUnmarshalEvalDelta(t *testing.T) {
 	v := EvalDelta{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -422,18 +401,18 @@ func BenchmarkMarshalMsgEvalDelta(b *testing.B) {
 func BenchmarkAppendMsgEvalDelta(b *testing.B) {
 	v := EvalDelta{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalEvalDelta(b *testing.B) {
 	v := EvalDelta{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -447,10 +426,7 @@ func BenchmarkUnmarshalEvalDelta(b *testing.B) {
 
 func TestMarshalUnmarshalStateDelta(t *testing.T) {
 	v := StateDelta{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -484,18 +460,18 @@ func BenchmarkMarshalMsgStateDelta(b *testing.B) {
 func BenchmarkAppendMsgStateDelta(b *testing.B) {
 	v := StateDelta{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalStateDelta(b *testing.B) {
 	v := StateDelta{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -509,10 +485,7 @@ func BenchmarkUnmarshalStateDelta(b *testing.B) {
 
 func TestMarshalUnmarshalStateSchema(t *testing.T) {
 	v := StateSchema{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -546,18 +519,18 @@ func BenchmarkMarshalMsgStateSchema(b *testing.B) {
 func BenchmarkAppendMsgStateSchema(b *testing.B) {
 	v := StateSchema{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalStateSchema(b *testing.B) {
 	v := StateSchema{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -571,10 +544,7 @@ func BenchmarkUnmarshalStateSchema(b *testing.B) {
 
 func TestMarshalUnmarshalStateSchemas(t *testing.T) {
 	v := StateSchemas{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -608,18 +578,18 @@ func BenchmarkMarshalMsgStateSchemas(b *testing.B) {
 func BenchmarkAppendMsgStateSchemas(b *testing.B) {
 	v := StateSchemas{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalStateSchemas(b *testing.B) {
 	v := StateSchemas{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -633,10 +603,7 @@ func BenchmarkUnmarshalStateSchemas(b *testing.B) {
 
 func TestMarshalUnmarshalTealKeyValue(t *testing.T) {
 	v := TealKeyValue{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -670,18 +637,18 @@ func BenchmarkMarshalMsgTealKeyValue(b *testing.B) {
 func BenchmarkAppendMsgTealKeyValue(b *testing.B) {
 	v := TealKeyValue{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalTealKeyValue(b *testing.B) {
 	v := TealKeyValue{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -695,10 +662,7 @@ func BenchmarkUnmarshalTealKeyValue(b *testing.B) {
 
 func TestMarshalUnmarshalTealValue(t *testing.T) {
 	v := TealValue{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -732,18 +696,18 @@ func BenchmarkMarshalMsgTealValue(b *testing.B) {
 func BenchmarkAppendMsgTealValue(b *testing.B) {
 	v := TealValue{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalTealValue(b *testing.B) {
 	v := TealValue{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -757,10 +721,7 @@ func BenchmarkUnmarshalTealValue(b *testing.B) {
 
 func TestMarshalUnmarshalValueDelta(t *testing.T) {
 	v := ValueDelta{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -794,18 +755,18 @@ func BenchmarkMarshalMsgValueDelta(b *testing.B) {
 func BenchmarkAppendMsgValueDelta(b *testing.B) {
 	v := ValueDelta{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalValueDelta(b *testing.B) {
 	v := ValueDelta{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()

--- a/data/basics/units.go
+++ b/data/basics/units.go
@@ -80,7 +80,7 @@ func (MicroAlgos) CanMarshalMsg(z interface{}) bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (a MicroAlgos) MarshalMsg(b []byte) (o []byte, err error) {
+func (a MicroAlgos) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, msgp.Uint64Size)
 	o = msgp.AppendUint64(o, a.Raw)
 	return

--- a/data/basics/userBalance_test.go
+++ b/data/basics/userBalance_test.go
@@ -194,8 +194,7 @@ func TestEncodedAccountDataSize(t *testing.T) {
 		ad.AppLocalStates[AppIndex(0x1234123412341234-appHolderApps)] = ls
 	}
 
-	encoded, err := ad.MarshalMsg(nil)
-	require.NoError(t, err)
+	encoded := ad.MarshalMsg(nil)
 	require.GreaterOrEqual(t, MaxEncodedAccountDataSize, len(encoded))
 }
 

--- a/data/bookkeeping/msgp_gen.go
+++ b/data/bookkeeping/msgp_gen.go
@@ -77,7 +77,7 @@ import (
 //
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Block) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Block) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0003Len := uint32(24)
@@ -197,16 +197,8 @@ func (z *Block) MarshalMsg(b []byte) (o []byte, err error) {
 			for _, zb0001 := range zb0001_keys {
 				zb0002 := (*z).BlockHeader.CompactCert[zb0001]
 				_ = zb0002
-				o, err = zb0001.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "CompactCert", zb0001)
-					return
-				}
-				o, err = zb0002.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "CompactCert", zb0001)
-					return
-				}
+				o = zb0001.MarshalMsg(o)
+				o = zb0002.MarshalMsg(o)
 			}
 		}
 		if (zb0003Mask & 0x10) == 0 { // if not empty
@@ -217,11 +209,7 @@ func (z *Block) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x20) == 0 { // if not empty
 			// string "fees"
 			o = append(o, 0xa4, 0x66, 0x65, 0x65, 0x73)
-			o, err = (*z).BlockHeader.RewardsState.FeeSink.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "FeeSink")
-				return
-			}
+			o = (*z).BlockHeader.RewardsState.FeeSink.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x40) == 0 { // if not empty
 			// string "frac"
@@ -236,38 +224,22 @@ func (z *Block) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x100) == 0 { // if not empty
 			// string "gh"
 			o = append(o, 0xa2, 0x67, 0x68)
-			o, err = (*z).BlockHeader.GenesisHash.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "GenesisHash")
-				return
-			}
+			o = (*z).BlockHeader.GenesisHash.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x200) == 0 { // if not empty
 			// string "nextbefore"
 			o = append(o, 0xaa, 0x6e, 0x65, 0x78, 0x74, 0x62, 0x65, 0x66, 0x6f, 0x72, 0x65)
-			o, err = (*z).BlockHeader.UpgradeState.NextProtocolVoteBefore.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "NextProtocolVoteBefore")
-				return
-			}
+			o = (*z).BlockHeader.UpgradeState.NextProtocolVoteBefore.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x400) == 0 { // if not empty
 			// string "nextproto"
 			o = append(o, 0xa9, 0x6e, 0x65, 0x78, 0x74, 0x70, 0x72, 0x6f, 0x74, 0x6f)
-			o, err = (*z).BlockHeader.UpgradeState.NextProtocol.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "NextProtocol")
-				return
-			}
+			o = (*z).BlockHeader.UpgradeState.NextProtocol.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x800) == 0 { // if not empty
 			// string "nextswitch"
 			o = append(o, 0xaa, 0x6e, 0x65, 0x78, 0x74, 0x73, 0x77, 0x69, 0x74, 0x63, 0x68)
-			o, err = (*z).BlockHeader.UpgradeState.NextProtocolSwitchOn.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "NextProtocolSwitchOn")
-				return
-			}
+			o = (*z).BlockHeader.UpgradeState.NextProtocolSwitchOn.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x1000) == 0 { // if not empty
 			// string "nextyes"
@@ -277,20 +249,12 @@ func (z *Block) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x2000) == 0 { // if not empty
 			// string "prev"
 			o = append(o, 0xa4, 0x70, 0x72, 0x65, 0x76)
-			o, err = (*z).BlockHeader.Branch.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Branch")
-				return
-			}
+			o = (*z).BlockHeader.Branch.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x4000) == 0 { // if not empty
 			// string "proto"
 			o = append(o, 0xa5, 0x70, 0x72, 0x6f, 0x74, 0x6f)
-			o, err = (*z).BlockHeader.UpgradeState.CurrentProtocol.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CurrentProtocol")
-				return
-			}
+			o = (*z).BlockHeader.UpgradeState.CurrentProtocol.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x8000) == 0 { // if not empty
 			// string "rate"
@@ -300,38 +264,22 @@ func (z *Block) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x10000) == 0 { // if not empty
 			// string "rnd"
 			o = append(o, 0xa3, 0x72, 0x6e, 0x64)
-			o, err = (*z).BlockHeader.Round.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Round")
-				return
-			}
+			o = (*z).BlockHeader.Round.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x20000) == 0 { // if not empty
 			// string "rwcalr"
 			o = append(o, 0xa6, 0x72, 0x77, 0x63, 0x61, 0x6c, 0x72)
-			o, err = (*z).BlockHeader.RewardsState.RewardsRecalculationRound.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RewardsRecalculationRound")
-				return
-			}
+			o = (*z).BlockHeader.RewardsState.RewardsRecalculationRound.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x40000) == 0 { // if not empty
 			// string "rwd"
 			o = append(o, 0xa3, 0x72, 0x77, 0x64)
-			o, err = (*z).BlockHeader.RewardsState.RewardsPool.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RewardsPool")
-				return
-			}
+			o = (*z).BlockHeader.RewardsState.RewardsPool.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x80000) == 0 { // if not empty
 			// string "seed"
 			o = append(o, 0xa4, 0x73, 0x65, 0x65, 0x64)
-			o, err = (*z).BlockHeader.Seed.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Seed")
-				return
-			}
+			o = (*z).BlockHeader.Seed.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x100000) == 0 { // if not empty
 			// string "tc"
@@ -346,38 +294,22 @@ func (z *Block) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x400000) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
-			o, err = (*z).BlockHeader.TxnRoot.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "TxnRoot")
-				return
-			}
+			o = (*z).BlockHeader.TxnRoot.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x800000) == 0 { // if not empty
 			// string "txns"
 			o = append(o, 0xa4, 0x74, 0x78, 0x6e, 0x73)
-			o, err = (*z).Payset.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Payset")
-				return
-			}
+			o = (*z).Payset.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x1000000) == 0 { // if not empty
 			// string "upgradedelay"
 			o = append(o, 0xac, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x64, 0x65, 0x6c, 0x61, 0x79)
-			o, err = (*z).BlockHeader.UpgradeVote.UpgradeDelay.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "UpgradeDelay")
-				return
-			}
+			o = (*z).BlockHeader.UpgradeVote.UpgradeDelay.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x2000000) == 0 { // if not empty
 			// string "upgradeprop"
 			o = append(o, 0xab, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x70, 0x72, 0x6f, 0x70)
-			o, err = (*z).BlockHeader.UpgradeVote.UpgradePropose.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "UpgradePropose")
-				return
-			}
+			o = (*z).BlockHeader.UpgradeVote.UpgradePropose.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x4000000) == 0 { // if not empty
 			// string "upgradeyes"
@@ -859,7 +791,7 @@ func (z *Block) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *BlockHash) MarshalMsg(b []byte) ([]byte, error) {
+func (z *BlockHash) MarshalMsg(b []byte) []byte {
 	return ((*(crypto.Digest))(z)).MarshalMsg(b)
 }
 func (_ *BlockHash) CanMarshalMsg(z interface{}) bool {
@@ -887,7 +819,7 @@ func (z *BlockHash) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *BlockHeader) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *BlockHeader) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0003Len := uint32(23)
@@ -1003,16 +935,8 @@ func (z *BlockHeader) MarshalMsg(b []byte) (o []byte, err error) {
 			for _, zb0001 := range zb0001_keys {
 				zb0002 := (*z).CompactCert[zb0001]
 				_ = zb0002
-				o, err = zb0001.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "CompactCert", zb0001)
-					return
-				}
-				o, err = zb0002.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "CompactCert", zb0001)
-					return
-				}
+				o = zb0001.MarshalMsg(o)
+				o = zb0002.MarshalMsg(o)
 			}
 		}
 		if (zb0003Mask & 0x10) == 0 { // if not empty
@@ -1023,11 +947,7 @@ func (z *BlockHeader) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x20) == 0 { // if not empty
 			// string "fees"
 			o = append(o, 0xa4, 0x66, 0x65, 0x65, 0x73)
-			o, err = (*z).RewardsState.FeeSink.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "FeeSink")
-				return
-			}
+			o = (*z).RewardsState.FeeSink.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x40) == 0 { // if not empty
 			// string "frac"
@@ -1042,38 +962,22 @@ func (z *BlockHeader) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x100) == 0 { // if not empty
 			// string "gh"
 			o = append(o, 0xa2, 0x67, 0x68)
-			o, err = (*z).GenesisHash.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "GenesisHash")
-				return
-			}
+			o = (*z).GenesisHash.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x200) == 0 { // if not empty
 			// string "nextbefore"
 			o = append(o, 0xaa, 0x6e, 0x65, 0x78, 0x74, 0x62, 0x65, 0x66, 0x6f, 0x72, 0x65)
-			o, err = (*z).UpgradeState.NextProtocolVoteBefore.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "NextProtocolVoteBefore")
-				return
-			}
+			o = (*z).UpgradeState.NextProtocolVoteBefore.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x400) == 0 { // if not empty
 			// string "nextproto"
 			o = append(o, 0xa9, 0x6e, 0x65, 0x78, 0x74, 0x70, 0x72, 0x6f, 0x74, 0x6f)
-			o, err = (*z).UpgradeState.NextProtocol.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "NextProtocol")
-				return
-			}
+			o = (*z).UpgradeState.NextProtocol.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x800) == 0 { // if not empty
 			// string "nextswitch"
 			o = append(o, 0xaa, 0x6e, 0x65, 0x78, 0x74, 0x73, 0x77, 0x69, 0x74, 0x63, 0x68)
-			o, err = (*z).UpgradeState.NextProtocolSwitchOn.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "NextProtocolSwitchOn")
-				return
-			}
+			o = (*z).UpgradeState.NextProtocolSwitchOn.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x1000) == 0 { // if not empty
 			// string "nextyes"
@@ -1083,20 +987,12 @@ func (z *BlockHeader) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x2000) == 0 { // if not empty
 			// string "prev"
 			o = append(o, 0xa4, 0x70, 0x72, 0x65, 0x76)
-			o, err = (*z).Branch.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Branch")
-				return
-			}
+			o = (*z).Branch.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x4000) == 0 { // if not empty
 			// string "proto"
 			o = append(o, 0xa5, 0x70, 0x72, 0x6f, 0x74, 0x6f)
-			o, err = (*z).UpgradeState.CurrentProtocol.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CurrentProtocol")
-				return
-			}
+			o = (*z).UpgradeState.CurrentProtocol.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x8000) == 0 { // if not empty
 			// string "rate"
@@ -1106,38 +1002,22 @@ func (z *BlockHeader) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x10000) == 0 { // if not empty
 			// string "rnd"
 			o = append(o, 0xa3, 0x72, 0x6e, 0x64)
-			o, err = (*z).Round.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Round")
-				return
-			}
+			o = (*z).Round.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x20000) == 0 { // if not empty
 			// string "rwcalr"
 			o = append(o, 0xa6, 0x72, 0x77, 0x63, 0x61, 0x6c, 0x72)
-			o, err = (*z).RewardsState.RewardsRecalculationRound.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RewardsRecalculationRound")
-				return
-			}
+			o = (*z).RewardsState.RewardsRecalculationRound.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x40000) == 0 { // if not empty
 			// string "rwd"
 			o = append(o, 0xa3, 0x72, 0x77, 0x64)
-			o, err = (*z).RewardsState.RewardsPool.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RewardsPool")
-				return
-			}
+			o = (*z).RewardsState.RewardsPool.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x80000) == 0 { // if not empty
 			// string "seed"
 			o = append(o, 0xa4, 0x73, 0x65, 0x65, 0x64)
-			o, err = (*z).Seed.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Seed")
-				return
-			}
+			o = (*z).Seed.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x100000) == 0 { // if not empty
 			// string "tc"
@@ -1152,29 +1032,17 @@ func (z *BlockHeader) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0003Mask & 0x400000) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
-			o, err = (*z).TxnRoot.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "TxnRoot")
-				return
-			}
+			o = (*z).TxnRoot.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x800000) == 0 { // if not empty
 			// string "upgradedelay"
 			o = append(o, 0xac, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x64, 0x65, 0x6c, 0x61, 0x79)
-			o, err = (*z).UpgradeVote.UpgradeDelay.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "UpgradeDelay")
-				return
-			}
+			o = (*z).UpgradeVote.UpgradeDelay.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x1000000) == 0 { // if not empty
 			// string "upgradeprop"
 			o = append(o, 0xab, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x70, 0x72, 0x6f, 0x70)
-			o, err = (*z).UpgradeVote.UpgradePropose.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "UpgradePropose")
-				return
-			}
+			o = (*z).UpgradeVote.UpgradePropose.MarshalMsg(o)
 		}
 		if (zb0003Mask & 0x2000000) == 0 { // if not empty
 			// string "upgradeyes"
@@ -1641,7 +1509,7 @@ func (z *BlockHeader) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *CompactCertState) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *CompactCertState) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(3)
@@ -1664,29 +1532,17 @@ func (z *CompactCertState) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "n"
 			o = append(o, 0xa1, 0x6e)
-			o, err = (*z).CompactCertNextRound.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CompactCertNextRound")
-				return
-			}
+			o = (*z).CompactCertNextRound.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "t"
 			o = append(o, 0xa1, 0x74)
-			o, err = (*z).CompactCertVotersTotal.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CompactCertVotersTotal")
-				return
-			}
+			o = (*z).CompactCertVotersTotal.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "v"
 			o = append(o, 0xa1, 0x76)
-			o, err = (*z).CompactCertVoters.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CompactCertVoters")
-				return
-			}
+			o = (*z).CompactCertVoters.MarshalMsg(o)
 		}
 	}
 	return
@@ -1805,7 +1661,7 @@ func (z *CompactCertState) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Genesis) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Genesis) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0002Len := uint32(8)
@@ -1854,11 +1710,7 @@ func (z *Genesis) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).Allocation)))
 			}
 			for zb0001 := range (*z).Allocation {
-				o, err = (*z).Allocation[zb0001].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Allocation", zb0001)
-					return
-				}
+				o = (*z).Allocation[zb0001].MarshalMsg(o)
 			}
 		}
 		if (zb0002Mask & 0x4) == 0 { // if not empty
@@ -1879,20 +1731,12 @@ func (z *Genesis) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0002Mask & 0x20) == 0 { // if not empty
 			// string "network"
 			o = append(o, 0xa7, 0x6e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b)
-			o, err = (*z).Network.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Network")
-				return
-			}
+			o = (*z).Network.MarshalMsg(o)
 		}
 		if (zb0002Mask & 0x40) == 0 { // if not empty
 			// string "proto"
 			o = append(o, 0xa5, 0x70, 0x72, 0x6f, 0x74, 0x6f)
-			o, err = (*z).Proto.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Proto")
-				return
-			}
+			o = (*z).Proto.MarshalMsg(o)
 		}
 		if (zb0002Mask & 0x80) == 0 { // if not empty
 			// string "rwd"
@@ -2137,7 +1981,7 @@ func (z *Genesis) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *GenesisAllocation) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *GenesisAllocation) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 3
 	// string "addr"
@@ -2148,11 +1992,7 @@ func (z *GenesisAllocation) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.AppendString(o, (*z).Comment)
 	// string "state"
 	o = append(o, 0xa5, 0x73, 0x74, 0x61, 0x74, 0x65)
-	o, err = (*z).State.MarshalMsg(o)
-	if err != nil {
-		err = msgp.WrapError(err, "State")
-		return
-	}
+	o = (*z).State.MarshalMsg(o)
 	return
 }
 
@@ -2269,7 +2109,7 @@ func (z *GenesisAllocation) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *RewardsState) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *RewardsState) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(6)
@@ -2309,11 +2149,7 @@ func (z *RewardsState) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "fees"
 			o = append(o, 0xa4, 0x66, 0x65, 0x65, 0x73)
-			o, err = (*z).FeeSink.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "FeeSink")
-				return
-			}
+			o = (*z).FeeSink.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "frac"
@@ -2328,20 +2164,12 @@ func (z *RewardsState) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "rwcalr"
 			o = append(o, 0xa6, 0x72, 0x77, 0x63, 0x61, 0x6c, 0x72)
-			o, err = (*z).RewardsRecalculationRound.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RewardsRecalculationRound")
-				return
-			}
+			o = (*z).RewardsRecalculationRound.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not empty
 			// string "rwd"
 			o = append(o, 0xa3, 0x72, 0x77, 0x64)
-			o, err = (*z).RewardsPool.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RewardsPool")
-				return
-			}
+			o = (*z).RewardsPool.MarshalMsg(o)
 		}
 	}
 	return
@@ -2502,7 +2330,7 @@ func (z *RewardsState) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *UpgradeVote) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *UpgradeVote) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(3)
@@ -2525,20 +2353,12 @@ func (z *UpgradeVote) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "upgradedelay"
 			o = append(o, 0xac, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x64, 0x65, 0x6c, 0x61, 0x79)
-			o, err = (*z).UpgradeDelay.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "UpgradeDelay")
-				return
-			}
+			o = (*z).UpgradeDelay.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "upgradeprop"
 			o = append(o, 0xab, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x70, 0x72, 0x6f, 0x70)
-			o, err = (*z).UpgradePropose.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "UpgradePropose")
-				return
-			}
+			o = (*z).UpgradePropose.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "upgradeyes"

--- a/data/bookkeeping/msgp_gen_test.go
+++ b/data/bookkeeping/msgp_gen_test.go
@@ -13,10 +13,7 @@ import (
 
 func TestMarshalUnmarshalBlock(t *testing.T) {
 	v := Block{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -50,18 +47,18 @@ func BenchmarkMarshalMsgBlock(b *testing.B) {
 func BenchmarkAppendMsgBlock(b *testing.B) {
 	v := Block{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalBlock(b *testing.B) {
 	v := Block{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -75,10 +72,7 @@ func BenchmarkUnmarshalBlock(b *testing.B) {
 
 func TestMarshalUnmarshalBlockHeader(t *testing.T) {
 	v := BlockHeader{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -112,18 +106,18 @@ func BenchmarkMarshalMsgBlockHeader(b *testing.B) {
 func BenchmarkAppendMsgBlockHeader(b *testing.B) {
 	v := BlockHeader{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalBlockHeader(b *testing.B) {
 	v := BlockHeader{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -137,10 +131,7 @@ func BenchmarkUnmarshalBlockHeader(b *testing.B) {
 
 func TestMarshalUnmarshalCompactCertState(t *testing.T) {
 	v := CompactCertState{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -174,18 +165,18 @@ func BenchmarkMarshalMsgCompactCertState(b *testing.B) {
 func BenchmarkAppendMsgCompactCertState(b *testing.B) {
 	v := CompactCertState{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalCompactCertState(b *testing.B) {
 	v := CompactCertState{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -199,10 +190,7 @@ func BenchmarkUnmarshalCompactCertState(b *testing.B) {
 
 func TestMarshalUnmarshalGenesis(t *testing.T) {
 	v := Genesis{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -236,18 +224,18 @@ func BenchmarkMarshalMsgGenesis(b *testing.B) {
 func BenchmarkAppendMsgGenesis(b *testing.B) {
 	v := Genesis{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalGenesis(b *testing.B) {
 	v := Genesis{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -261,10 +249,7 @@ func BenchmarkUnmarshalGenesis(b *testing.B) {
 
 func TestMarshalUnmarshalGenesisAllocation(t *testing.T) {
 	v := GenesisAllocation{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -298,18 +283,18 @@ func BenchmarkMarshalMsgGenesisAllocation(b *testing.B) {
 func BenchmarkAppendMsgGenesisAllocation(b *testing.B) {
 	v := GenesisAllocation{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalGenesisAllocation(b *testing.B) {
 	v := GenesisAllocation{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -323,10 +308,7 @@ func BenchmarkUnmarshalGenesisAllocation(b *testing.B) {
 
 func TestMarshalUnmarshalRewardsState(t *testing.T) {
 	v := RewardsState{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -360,18 +342,18 @@ func BenchmarkMarshalMsgRewardsState(b *testing.B) {
 func BenchmarkAppendMsgRewardsState(b *testing.B) {
 	v := RewardsState{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalRewardsState(b *testing.B) {
 	v := RewardsState{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -385,10 +367,7 @@ func BenchmarkUnmarshalRewardsState(b *testing.B) {
 
 func TestMarshalUnmarshalUpgradeVote(t *testing.T) {
 	v := UpgradeVote{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -422,18 +401,18 @@ func BenchmarkMarshalMsgUpgradeVote(b *testing.B) {
 func BenchmarkAppendMsgUpgradeVote(b *testing.B) {
 	v := UpgradeVote{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalUpgradeVote(b *testing.B) {
 	v := UpgradeVote{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()

--- a/data/committee/msgp_gen.go
+++ b/data/committee/msgp_gen.go
@@ -41,7 +41,7 @@ import (
 //
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Credential) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Credential) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(5)
@@ -77,29 +77,17 @@ func (z *Credential) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "h"
 			o = append(o, 0xa1, 0x68)
-			o, err = (*z).VrfOut.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "VrfOut")
-				return
-			}
+			o = (*z).VrfOut.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "hc"
 			o = append(o, 0xa2, 0x68, 0x63)
-			o, err = (*z).Hashable.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Hashable")
-				return
-			}
+			o = (*z).Hashable.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "pf"
 			o = append(o, 0xa2, 0x70, 0x66)
-			o, err = (*z).UnauthenticatedCredential.Proof.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Proof")
-				return
-			}
+			o = (*z).UnauthenticatedCredential.Proof.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not empty
 			// string "wt"
@@ -251,7 +239,7 @@ func (z *Credential) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Seed) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Seed) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendBytes(o, (*z)[:])
 	return
@@ -290,7 +278,7 @@ func (z *Seed) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *UnauthenticatedCredential) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *UnauthenticatedCredential) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(1)
@@ -305,11 +293,7 @@ func (z *UnauthenticatedCredential) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "pf"
 			o = append(o, 0xa2, 0x70, 0x66)
-			o, err = (*z).Proof.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Proof")
-				return
-			}
+			o = (*z).Proof.MarshalMsg(o)
 		}
 	}
 	return
@@ -400,7 +384,7 @@ func (z *UnauthenticatedCredential) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *hashableCredential) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *hashableCredential) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(3)
@@ -428,20 +412,12 @@ func (z *hashableCredential) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "m"
 			o = append(o, 0xa1, 0x6d)
-			o, err = (*z).Member.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Member")
-				return
-			}
+			o = (*z).Member.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "v"
 			o = append(o, 0xa1, 0x76)
-			o, err = (*z).RawOut.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RawOut")
-				return
-			}
+			o = (*z).RawOut.MarshalMsg(o)
 		}
 	}
 	return

--- a/data/committee/msgp_gen_test.go
+++ b/data/committee/msgp_gen_test.go
@@ -13,10 +13,7 @@ import (
 
 func TestMarshalUnmarshalCredential(t *testing.T) {
 	v := Credential{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -50,18 +47,18 @@ func BenchmarkMarshalMsgCredential(b *testing.B) {
 func BenchmarkAppendMsgCredential(b *testing.B) {
 	v := Credential{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalCredential(b *testing.B) {
 	v := Credential{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -75,10 +72,7 @@ func BenchmarkUnmarshalCredential(b *testing.B) {
 
 func TestMarshalUnmarshalSeed(t *testing.T) {
 	v := Seed{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -112,18 +106,18 @@ func BenchmarkMarshalMsgSeed(b *testing.B) {
 func BenchmarkAppendMsgSeed(b *testing.B) {
 	v := Seed{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalSeed(b *testing.B) {
 	v := Seed{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -137,10 +131,7 @@ func BenchmarkUnmarshalSeed(b *testing.B) {
 
 func TestMarshalUnmarshalUnauthenticatedCredential(t *testing.T) {
 	v := UnauthenticatedCredential{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -174,18 +165,18 @@ func BenchmarkMarshalMsgUnauthenticatedCredential(b *testing.B) {
 func BenchmarkAppendMsgUnauthenticatedCredential(b *testing.B) {
 	v := UnauthenticatedCredential{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalUnauthenticatedCredential(b *testing.B) {
 	v := UnauthenticatedCredential{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -199,10 +190,7 @@ func BenchmarkUnmarshalUnauthenticatedCredential(b *testing.B) {
 
 func TestMarshalUnmarshalhashableCredential(t *testing.T) {
 	v := hashableCredential{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -236,18 +224,18 @@ func BenchmarkMarshalMsghashableCredential(b *testing.B) {
 func BenchmarkAppendMsghashableCredential(b *testing.B) {
 	v := hashableCredential{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalhashableCredential(b *testing.B) {
 	v := hashableCredential{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()

--- a/data/hashable/msgp_gen.go
+++ b/data/hashable/msgp_gen.go
@@ -17,7 +17,7 @@ import (
 //
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Message) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Message) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(1)

--- a/data/hashable/msgp_gen_test.go
+++ b/data/hashable/msgp_gen_test.go
@@ -13,10 +13,7 @@ import (
 
 func TestMarshalUnmarshalMessage(t *testing.T) {
 	v := Message{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -50,18 +47,18 @@ func BenchmarkMarshalMsgMessage(b *testing.B) {
 func BenchmarkAppendMsgMessage(b *testing.B) {
 	v := Message{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalMessage(b *testing.B) {
 	v := Message{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()

--- a/data/transactions/msgp_gen.go
+++ b/data/transactions/msgp_gen.go
@@ -164,7 +164,7 @@ import (
 //
 
 // MarshalMsg implements msgp.Marshaler
-func (z *ApplicationCallTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *ApplicationCallTxnFields) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0005Len := uint32(10)
@@ -243,11 +243,7 @@ func (z *ApplicationCallTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).ForeignAssets)))
 			}
 			for zb0004 := range (*z).ForeignAssets {
-				o, err = (*z).ForeignAssets[zb0004].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "ForeignAssets", zb0004)
-					return
-				}
+				o = (*z).ForeignAssets[zb0004].MarshalMsg(o)
 			}
 		}
 		if (zb0005Mask & 0x20) == 0 { // if not empty
@@ -259,11 +255,7 @@ func (z *ApplicationCallTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).Accounts)))
 			}
 			for zb0002 := range (*z).Accounts {
-				o, err = (*z).Accounts[zb0002].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Accounts", zb0002)
-					return
-				}
+				o = (*z).Accounts[zb0002].MarshalMsg(o)
 			}
 		}
 		if (zb0005Mask & 0x40) == 0 { // if not empty
@@ -275,39 +267,23 @@ func (z *ApplicationCallTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).ForeignApps)))
 			}
 			for zb0003 := range (*z).ForeignApps {
-				o, err = (*z).ForeignApps[zb0003].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "ForeignApps", zb0003)
-					return
-				}
+				o = (*z).ForeignApps[zb0003].MarshalMsg(o)
 			}
 		}
 		if (zb0005Mask & 0x80) == 0 { // if not empty
 			// string "apgs"
 			o = append(o, 0xa4, 0x61, 0x70, 0x67, 0x73)
-			o, err = (*z).GlobalStateSchema.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "GlobalStateSchema")
-				return
-			}
+			o = (*z).GlobalStateSchema.MarshalMsg(o)
 		}
 		if (zb0005Mask & 0x100) == 0 { // if not empty
 			// string "apid"
 			o = append(o, 0xa4, 0x61, 0x70, 0x69, 0x64)
-			o, err = (*z).ApplicationID.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "ApplicationID")
-				return
-			}
+			o = (*z).ApplicationID.MarshalMsg(o)
 		}
 		if (zb0005Mask & 0x200) == 0 { // if not empty
 			// string "apls"
 			o = append(o, 0xa4, 0x61, 0x70, 0x6c, 0x73)
-			o, err = (*z).LocalStateSchema.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "LocalStateSchema")
-				return
-			}
+			o = (*z).LocalStateSchema.MarshalMsg(o)
 		}
 		if (zb0005Mask & 0x400) == 0 { // if not empty
 			// string "apsu"
@@ -761,7 +737,7 @@ func (z *ApplicationCallTxnFields) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *ApplyData) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *ApplyData) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(5)
@@ -792,47 +768,27 @@ func (z *ApplyData) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "ca"
 			o = append(o, 0xa2, 0x63, 0x61)
-			o, err = (*z).ClosingAmount.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "ClosingAmount")
-				return
-			}
+			o = (*z).ClosingAmount.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "dt"
 			o = append(o, 0xa2, 0x64, 0x74)
-			o, err = (*z).EvalDelta.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "EvalDelta")
-				return
-			}
+			o = (*z).EvalDelta.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "rc"
 			o = append(o, 0xa2, 0x72, 0x63)
-			o, err = (*z).CloseRewards.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CloseRewards")
-				return
-			}
+			o = (*z).CloseRewards.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "rr"
 			o = append(o, 0xa2, 0x72, 0x72)
-			o, err = (*z).ReceiverRewards.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "ReceiverRewards")
-				return
-			}
+			o = (*z).ReceiverRewards.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "rs"
 			o = append(o, 0xa2, 0x72, 0x73)
-			o, err = (*z).SenderRewards.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "SenderRewards")
-				return
-			}
+			o = (*z).SenderRewards.MarshalMsg(o)
 		}
 	}
 	return
@@ -979,7 +935,7 @@ func (z *ApplyData) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *AssetConfigTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *AssetConfigTxnFields) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(2)
@@ -998,20 +954,12 @@ func (z *AssetConfigTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "apar"
 			o = append(o, 0xa4, 0x61, 0x70, 0x61, 0x72)
-			o, err = (*z).AssetParams.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AssetParams")
-				return
-			}
+			o = (*z).AssetParams.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "caid"
 			o = append(o, 0xa4, 0x63, 0x61, 0x69, 0x64)
-			o, err = (*z).ConfigAsset.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "ConfigAsset")
-				return
-			}
+			o = (*z).ConfigAsset.MarshalMsg(o)
 		}
 	}
 	return
@@ -1116,7 +1064,7 @@ func (z *AssetConfigTxnFields) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *AssetFreezeTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *AssetFreezeTxnFields) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(3)
@@ -1144,20 +1092,12 @@ func (z *AssetFreezeTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "fadd"
 			o = append(o, 0xa4, 0x66, 0x61, 0x64, 0x64)
-			o, err = (*z).FreezeAccount.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "FreezeAccount")
-				return
-			}
+			o = (*z).FreezeAccount.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "faid"
 			o = append(o, 0xa4, 0x66, 0x61, 0x69, 0x64)
-			o, err = (*z).FreezeAsset.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "FreezeAsset")
-				return
-			}
+			o = (*z).FreezeAsset.MarshalMsg(o)
 		}
 	}
 	return
@@ -1276,7 +1216,7 @@ func (z *AssetFreezeTxnFields) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *AssetTransferTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *AssetTransferTxnFields) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(5)
@@ -1312,38 +1252,22 @@ func (z *AssetTransferTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "aclose"
 			o = append(o, 0xa6, 0x61, 0x63, 0x6c, 0x6f, 0x73, 0x65)
-			o, err = (*z).AssetCloseTo.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AssetCloseTo")
-				return
-			}
+			o = (*z).AssetCloseTo.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "arcv"
 			o = append(o, 0xa4, 0x61, 0x72, 0x63, 0x76)
-			o, err = (*z).AssetReceiver.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AssetReceiver")
-				return
-			}
+			o = (*z).AssetReceiver.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "asnd"
 			o = append(o, 0xa4, 0x61, 0x73, 0x6e, 0x64)
-			o, err = (*z).AssetSender.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AssetSender")
-				return
-			}
+			o = (*z).AssetSender.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "xaid"
 			o = append(o, 0xa4, 0x78, 0x61, 0x69, 0x64)
-			o, err = (*z).XferAsset.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "XferAsset")
-				return
-			}
+			o = (*z).XferAsset.MarshalMsg(o)
 		}
 	}
 	return
@@ -1490,7 +1414,7 @@ func (z *AssetTransferTxnFields) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *CompactCertTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *CompactCertTxnFields) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(3)
@@ -1513,29 +1437,17 @@ func (z *CompactCertTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "cert"
 			o = append(o, 0xa4, 0x63, 0x65, 0x72, 0x74)
-			o, err = (*z).Cert.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Cert")
-				return
-			}
+			o = (*z).Cert.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "certrnd"
 			o = append(o, 0xa7, 0x63, 0x65, 0x72, 0x74, 0x72, 0x6e, 0x64)
-			o, err = (*z).CertRound.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CertRound")
-				return
-			}
+			o = (*z).CertRound.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "certtype"
 			o = append(o, 0xa8, 0x63, 0x65, 0x72, 0x74, 0x74, 0x79, 0x70, 0x65)
-			o, err = (*z).CertType.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CertType")
-				return
-			}
+			o = (*z).CertType.MarshalMsg(o)
 		}
 	}
 	return
@@ -1654,7 +1566,7 @@ func (z *CompactCertTxnFields) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Header) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Header) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0002Len := uint32(10)
@@ -1705,20 +1617,12 @@ func (z *Header) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0002Mask & 0x2) == 0 { // if not empty
 			// string "fee"
 			o = append(o, 0xa3, 0x66, 0x65, 0x65)
-			o, err = (*z).Fee.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Fee")
-				return
-			}
+			o = (*z).Fee.MarshalMsg(o)
 		}
 		if (zb0002Mask & 0x4) == 0 { // if not empty
 			// string "fv"
 			o = append(o, 0xa2, 0x66, 0x76)
-			o, err = (*z).FirstValid.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "FirstValid")
-				return
-			}
+			o = (*z).FirstValid.MarshalMsg(o)
 		}
 		if (zb0002Mask & 0x8) == 0 { // if not empty
 			// string "gen"
@@ -1728,29 +1632,17 @@ func (z *Header) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0002Mask & 0x10) == 0 { // if not empty
 			// string "gh"
 			o = append(o, 0xa2, 0x67, 0x68)
-			o, err = (*z).GenesisHash.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "GenesisHash")
-				return
-			}
+			o = (*z).GenesisHash.MarshalMsg(o)
 		}
 		if (zb0002Mask & 0x20) == 0 { // if not empty
 			// string "grp"
 			o = append(o, 0xa3, 0x67, 0x72, 0x70)
-			o, err = (*z).Group.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Group")
-				return
-			}
+			o = (*z).Group.MarshalMsg(o)
 		}
 		if (zb0002Mask & 0x40) == 0 { // if not empty
 			// string "lv"
 			o = append(o, 0xa2, 0x6c, 0x76)
-			o, err = (*z).LastValid.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "LastValid")
-				return
-			}
+			o = (*z).LastValid.MarshalMsg(o)
 		}
 		if (zb0002Mask & 0x80) == 0 { // if not empty
 			// string "lx"
@@ -1765,20 +1657,12 @@ func (z *Header) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0002Mask & 0x200) == 0 { // if not empty
 			// string "rekey"
 			o = append(o, 0xa5, 0x72, 0x65, 0x6b, 0x65, 0x79)
-			o, err = (*z).RekeyTo.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RekeyTo")
-				return
-			}
+			o = (*z).RekeyTo.MarshalMsg(o)
 		}
 		if (zb0002Mask & 0x400) == 0 { // if not empty
 			// string "snd"
 			o = append(o, 0xa3, 0x73, 0x6e, 0x64)
-			o, err = (*z).Sender.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sender")
-				return
-			}
+			o = (*z).Sender.MarshalMsg(o)
 		}
 	}
 	return
@@ -2015,7 +1899,7 @@ func (z *Header) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *KeyregTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *KeyregTxnFields) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(6)
@@ -2055,20 +1939,12 @@ func (z *KeyregTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "selkey"
 			o = append(o, 0xa6, 0x73, 0x65, 0x6c, 0x6b, 0x65, 0x79)
-			o, err = (*z).SelectionPK.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "SelectionPK")
-				return
-			}
+			o = (*z).SelectionPK.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "votefst"
 			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x66, 0x73, 0x74)
-			o, err = (*z).VoteFirst.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "VoteFirst")
-				return
-			}
+			o = (*z).VoteFirst.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "votekd"
@@ -2078,20 +1954,12 @@ func (z *KeyregTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "votekey"
 			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x6b, 0x65, 0x79)
-			o, err = (*z).VotePK.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "VotePK")
-				return
-			}
+			o = (*z).VotePK.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not empty
 			// string "votelst"
 			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x6c, 0x73, 0x74)
-			o, err = (*z).VoteLast.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "VoteLast")
-				return
-			}
+			o = (*z).VoteLast.MarshalMsg(o)
 		}
 	}
 	return
@@ -2252,7 +2120,7 @@ func (z *KeyregTxnFields) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *LogicSig) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *LogicSig) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0002Len := uint32(4)
@@ -2296,20 +2164,12 @@ func (z *LogicSig) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0002Mask & 0x8) == 0 { // if not empty
 			// string "msig"
 			o = append(o, 0xa4, 0x6d, 0x73, 0x69, 0x67)
-			o, err = (*z).Msig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Msig")
-				return
-			}
+			o = (*z).Msig.MarshalMsg(o)
 		}
 		if (zb0002Mask & 0x10) == 0 { // if not empty
 			// string "sig"
 			o = append(o, 0xa3, 0x73, 0x69, 0x67)
-			o, err = (*z).Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sig")
-				return
-			}
+			o = (*z).Sig.MarshalMsg(o)
 		}
 	}
 	return
@@ -2527,7 +2387,7 @@ func (z *LogicSig) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z MinFeeError) MarshalMsg(b []byte) (o []byte, err error) {
+func (z MinFeeError) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendString(o, string(z))
 	return
@@ -2573,7 +2433,7 @@ func (z MinFeeError) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z OnCompletion) MarshalMsg(b []byte) (o []byte, err error) {
+func (z OnCompletion) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendUint64(o, uint64(z))
 	return
@@ -2619,7 +2479,7 @@ func (z OnCompletion) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *PaymentTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *PaymentTxnFields) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(3)
@@ -2642,29 +2502,17 @@ func (z *PaymentTxnFields) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "amt"
 			o = append(o, 0xa3, 0x61, 0x6d, 0x74)
-			o, err = (*z).Amount.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Amount")
-				return
-			}
+			o = (*z).Amount.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "close"
 			o = append(o, 0xa5, 0x63, 0x6c, 0x6f, 0x73, 0x65)
-			o, err = (*z).CloseRemainderTo.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CloseRemainderTo")
-				return
-			}
+			o = (*z).CloseRemainderTo.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "rcv"
 			o = append(o, 0xa3, 0x72, 0x63, 0x76)
-			o, err = (*z).Receiver.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Receiver")
-				return
-			}
+			o = (*z).Receiver.MarshalMsg(o)
 		}
 	}
 	return
@@ -2783,7 +2631,7 @@ func (z *PaymentTxnFields) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z Payset) MarshalMsg(b []byte) (o []byte, err error) {
+func (z Payset) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	if z == nil {
 		o = msgp.AppendNil(o)
@@ -2791,11 +2639,7 @@ func (z Payset) MarshalMsg(b []byte) (o []byte, err error) {
 		o = msgp.AppendArrayHeader(o, uint32(len(z)))
 	}
 	for za0001 := range z {
-		o, err = z[za0001].MarshalMsg(o)
-		if err != nil {
-			err = msgp.WrapError(err, za0001)
-			return
-		}
+		o = z[za0001].MarshalMsg(o)
 	}
 	return
 }
@@ -2860,7 +2704,7 @@ func (z Payset) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *SignedTxn) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *SignedTxn) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(5)
@@ -2891,47 +2735,27 @@ func (z *SignedTxn) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "lsig"
 			o = append(o, 0xa4, 0x6c, 0x73, 0x69, 0x67)
-			o, err = (*z).Lsig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Lsig")
-				return
-			}
+			o = (*z).Lsig.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "msig"
 			o = append(o, 0xa4, 0x6d, 0x73, 0x69, 0x67)
-			o, err = (*z).Msig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Msig")
-				return
-			}
+			o = (*z).Msig.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "sgnr"
 			o = append(o, 0xa4, 0x73, 0x67, 0x6e, 0x72)
-			o, err = (*z).AuthAddr.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AuthAddr")
-				return
-			}
+			o = (*z).AuthAddr.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "sig"
 			o = append(o, 0xa3, 0x73, 0x69, 0x67)
-			o, err = (*z).Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sig")
-				return
-			}
+			o = (*z).Sig.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
-			o, err = (*z).Txn.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Txn")
-				return
-			}
+			o = (*z).Txn.MarshalMsg(o)
 		}
 	}
 	return
@@ -3078,7 +2902,7 @@ func (z *SignedTxn) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *SignedTxnInBlock) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *SignedTxnInBlock) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(12)
@@ -3137,20 +2961,12 @@ func (z *SignedTxnInBlock) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "ca"
 			o = append(o, 0xa2, 0x63, 0x61)
-			o, err = (*z).SignedTxnWithAD.ApplyData.ClosingAmount.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "ClosingAmount")
-				return
-			}
+			o = (*z).SignedTxnWithAD.ApplyData.ClosingAmount.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "dt"
 			o = append(o, 0xa2, 0x64, 0x74)
-			o, err = (*z).SignedTxnWithAD.ApplyData.EvalDelta.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "EvalDelta")
-				return
-			}
+			o = (*z).SignedTxnWithAD.ApplyData.EvalDelta.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not empty
 			// string "hgh"
@@ -3165,74 +2981,42 @@ func (z *SignedTxnInBlock) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x100) == 0 { // if not empty
 			// string "lsig"
 			o = append(o, 0xa4, 0x6c, 0x73, 0x69, 0x67)
-			o, err = (*z).SignedTxnWithAD.SignedTxn.Lsig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Lsig")
-				return
-			}
+			o = (*z).SignedTxnWithAD.SignedTxn.Lsig.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x200) == 0 { // if not empty
 			// string "msig"
 			o = append(o, 0xa4, 0x6d, 0x73, 0x69, 0x67)
-			o, err = (*z).SignedTxnWithAD.SignedTxn.Msig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Msig")
-				return
-			}
+			o = (*z).SignedTxnWithAD.SignedTxn.Msig.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x400) == 0 { // if not empty
 			// string "rc"
 			o = append(o, 0xa2, 0x72, 0x63)
-			o, err = (*z).SignedTxnWithAD.ApplyData.CloseRewards.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CloseRewards")
-				return
-			}
+			o = (*z).SignedTxnWithAD.ApplyData.CloseRewards.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x800) == 0 { // if not empty
 			// string "rr"
 			o = append(o, 0xa2, 0x72, 0x72)
-			o, err = (*z).SignedTxnWithAD.ApplyData.ReceiverRewards.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "ReceiverRewards")
-				return
-			}
+			o = (*z).SignedTxnWithAD.ApplyData.ReceiverRewards.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x1000) == 0 { // if not empty
 			// string "rs"
 			o = append(o, 0xa2, 0x72, 0x73)
-			o, err = (*z).SignedTxnWithAD.ApplyData.SenderRewards.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "SenderRewards")
-				return
-			}
+			o = (*z).SignedTxnWithAD.ApplyData.SenderRewards.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x2000) == 0 { // if not empty
 			// string "sgnr"
 			o = append(o, 0xa4, 0x73, 0x67, 0x6e, 0x72)
-			o, err = (*z).SignedTxnWithAD.SignedTxn.AuthAddr.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AuthAddr")
-				return
-			}
+			o = (*z).SignedTxnWithAD.SignedTxn.AuthAddr.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4000) == 0 { // if not empty
 			// string "sig"
 			o = append(o, 0xa3, 0x73, 0x69, 0x67)
-			o, err = (*z).SignedTxnWithAD.SignedTxn.Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sig")
-				return
-			}
+			o = (*z).SignedTxnWithAD.SignedTxn.Sig.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8000) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
-			o, err = (*z).SignedTxnWithAD.SignedTxn.Txn.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Txn")
-				return
-			}
+			o = (*z).SignedTxnWithAD.SignedTxn.Txn.MarshalMsg(o)
 		}
 	}
 	return
@@ -3477,7 +3261,7 @@ func (z *SignedTxnInBlock) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *SignedTxnWithAD) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *SignedTxnWithAD) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(10)
@@ -3528,92 +3312,52 @@ func (z *SignedTxnWithAD) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "ca"
 			o = append(o, 0xa2, 0x63, 0x61)
-			o, err = (*z).ApplyData.ClosingAmount.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "ClosingAmount")
-				return
-			}
+			o = (*z).ApplyData.ClosingAmount.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "dt"
 			o = append(o, 0xa2, 0x64, 0x74)
-			o, err = (*z).ApplyData.EvalDelta.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "EvalDelta")
-				return
-			}
+			o = (*z).ApplyData.EvalDelta.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "lsig"
 			o = append(o, 0xa4, 0x6c, 0x73, 0x69, 0x67)
-			o, err = (*z).SignedTxn.Lsig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Lsig")
-				return
-			}
+			o = (*z).SignedTxn.Lsig.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not empty
 			// string "msig"
 			o = append(o, 0xa4, 0x6d, 0x73, 0x69, 0x67)
-			o, err = (*z).SignedTxn.Msig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Msig")
-				return
-			}
+			o = (*z).SignedTxn.Msig.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x80) == 0 { // if not empty
 			// string "rc"
 			o = append(o, 0xa2, 0x72, 0x63)
-			o, err = (*z).ApplyData.CloseRewards.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CloseRewards")
-				return
-			}
+			o = (*z).ApplyData.CloseRewards.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x100) == 0 { // if not empty
 			// string "rr"
 			o = append(o, 0xa2, 0x72, 0x72)
-			o, err = (*z).ApplyData.ReceiverRewards.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "ReceiverRewards")
-				return
-			}
+			o = (*z).ApplyData.ReceiverRewards.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x200) == 0 { // if not empty
 			// string "rs"
 			o = append(o, 0xa2, 0x72, 0x73)
-			o, err = (*z).ApplyData.SenderRewards.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "SenderRewards")
-				return
-			}
+			o = (*z).ApplyData.SenderRewards.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x400) == 0 { // if not empty
 			// string "sgnr"
 			o = append(o, 0xa4, 0x73, 0x67, 0x6e, 0x72)
-			o, err = (*z).SignedTxn.AuthAddr.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AuthAddr")
-				return
-			}
+			o = (*z).SignedTxn.AuthAddr.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x800) == 0 { // if not empty
 			// string "sig"
 			o = append(o, 0xa3, 0x73, 0x69, 0x67)
-			o, err = (*z).SignedTxn.Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sig")
-				return
-			}
+			o = (*z).SignedTxn.Sig.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x1000) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
-			o, err = (*z).SignedTxn.Txn.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Txn")
-				return
-			}
+			o = (*z).SignedTxn.Txn.MarshalMsg(o)
 		}
 	}
 	return
@@ -3830,7 +3574,7 @@ func (z *SignedTxnWithAD) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *Transaction) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0006Len := uint32(43)
@@ -4018,11 +3762,7 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0006Mask & 0x400) == 0 { // if not empty
 			// string "aclose"
 			o = append(o, 0xa6, 0x61, 0x63, 0x6c, 0x6f, 0x73, 0x65)
-			o, err = (*z).AssetTransferTxnFields.AssetCloseTo.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AssetCloseTo")
-				return
-			}
+			o = (*z).AssetTransferTxnFields.AssetCloseTo.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x800) == 0 { // if not empty
 			// string "afrz"
@@ -4032,11 +3772,7 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0006Mask & 0x1000) == 0 { // if not empty
 			// string "amt"
 			o = append(o, 0xa3, 0x61, 0x6d, 0x74)
-			o, err = (*z).PaymentTxnFields.Amount.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Amount")
-				return
-			}
+			o = (*z).PaymentTxnFields.Amount.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x2000) == 0 { // if not empty
 			// string "apaa"
@@ -4063,11 +3799,7 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0006Mask & 0x10000) == 0 { // if not empty
 			// string "apar"
 			o = append(o, 0xa4, 0x61, 0x70, 0x61, 0x72)
-			o, err = (*z).AssetConfigTxnFields.AssetParams.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AssetParams")
-				return
-			}
+			o = (*z).AssetConfigTxnFields.AssetParams.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x20000) == 0 { // if not empty
 			// string "apas"
@@ -4078,11 +3810,7 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).ApplicationCallTxnFields.ForeignAssets)))
 			}
 			for zb0005 := range (*z).ApplicationCallTxnFields.ForeignAssets {
-				o, err = (*z).ApplicationCallTxnFields.ForeignAssets[zb0005].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "ForeignAssets", zb0005)
-					return
-				}
+				o = (*z).ApplicationCallTxnFields.ForeignAssets[zb0005].MarshalMsg(o)
 			}
 		}
 		if (zb0006Mask & 0x40000) == 0 { // if not empty
@@ -4094,11 +3822,7 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).ApplicationCallTxnFields.Accounts)))
 			}
 			for zb0003 := range (*z).ApplicationCallTxnFields.Accounts {
-				o, err = (*z).ApplicationCallTxnFields.Accounts[zb0003].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Accounts", zb0003)
-					return
-				}
+				o = (*z).ApplicationCallTxnFields.Accounts[zb0003].MarshalMsg(o)
 			}
 		}
 		if (zb0006Mask & 0x80000) == 0 { // if not empty
@@ -4110,39 +3834,23 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).ApplicationCallTxnFields.ForeignApps)))
 			}
 			for zb0004 := range (*z).ApplicationCallTxnFields.ForeignApps {
-				o, err = (*z).ApplicationCallTxnFields.ForeignApps[zb0004].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "ForeignApps", zb0004)
-					return
-				}
+				o = (*z).ApplicationCallTxnFields.ForeignApps[zb0004].MarshalMsg(o)
 			}
 		}
 		if (zb0006Mask & 0x100000) == 0 { // if not empty
 			// string "apgs"
 			o = append(o, 0xa4, 0x61, 0x70, 0x67, 0x73)
-			o, err = (*z).ApplicationCallTxnFields.GlobalStateSchema.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "GlobalStateSchema")
-				return
-			}
+			o = (*z).ApplicationCallTxnFields.GlobalStateSchema.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x200000) == 0 { // if not empty
 			// string "apid"
 			o = append(o, 0xa4, 0x61, 0x70, 0x69, 0x64)
-			o, err = (*z).ApplicationCallTxnFields.ApplicationID.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "ApplicationID")
-				return
-			}
+			o = (*z).ApplicationCallTxnFields.ApplicationID.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x400000) == 0 { // if not empty
 			// string "apls"
 			o = append(o, 0xa4, 0x61, 0x70, 0x6c, 0x73)
-			o, err = (*z).ApplicationCallTxnFields.LocalStateSchema.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "LocalStateSchema")
-				return
-			}
+			o = (*z).ApplicationCallTxnFields.LocalStateSchema.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x800000) == 0 { // if not empty
 			// string "apsu"
@@ -4152,101 +3860,57 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0006Mask & 0x1000000) == 0 { // if not empty
 			// string "arcv"
 			o = append(o, 0xa4, 0x61, 0x72, 0x63, 0x76)
-			o, err = (*z).AssetTransferTxnFields.AssetReceiver.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AssetReceiver")
-				return
-			}
+			o = (*z).AssetTransferTxnFields.AssetReceiver.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x2000000) == 0 { // if not empty
 			// string "asnd"
 			o = append(o, 0xa4, 0x61, 0x73, 0x6e, 0x64)
-			o, err = (*z).AssetTransferTxnFields.AssetSender.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AssetSender")
-				return
-			}
+			o = (*z).AssetTransferTxnFields.AssetSender.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x4000000) == 0 { // if not empty
 			// string "caid"
 			o = append(o, 0xa4, 0x63, 0x61, 0x69, 0x64)
-			o, err = (*z).AssetConfigTxnFields.ConfigAsset.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "ConfigAsset")
-				return
-			}
+			o = (*z).AssetConfigTxnFields.ConfigAsset.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x8000000) == 0 { // if not empty
 			// string "cert"
 			o = append(o, 0xa4, 0x63, 0x65, 0x72, 0x74)
-			o, err = (*z).CompactCertTxnFields.Cert.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Cert")
-				return
-			}
+			o = (*z).CompactCertTxnFields.Cert.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x10000000) == 0 { // if not empty
 			// string "certrnd"
 			o = append(o, 0xa7, 0x63, 0x65, 0x72, 0x74, 0x72, 0x6e, 0x64)
-			o, err = (*z).CompactCertTxnFields.CertRound.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CertRound")
-				return
-			}
+			o = (*z).CompactCertTxnFields.CertRound.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x20000000) == 0 { // if not empty
 			// string "certtype"
 			o = append(o, 0xa8, 0x63, 0x65, 0x72, 0x74, 0x74, 0x79, 0x70, 0x65)
-			o, err = (*z).CompactCertTxnFields.CertType.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CertType")
-				return
-			}
+			o = (*z).CompactCertTxnFields.CertType.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x40000000) == 0 { // if not empty
 			// string "close"
 			o = append(o, 0xa5, 0x63, 0x6c, 0x6f, 0x73, 0x65)
-			o, err = (*z).PaymentTxnFields.CloseRemainderTo.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "CloseRemainderTo")
-				return
-			}
+			o = (*z).PaymentTxnFields.CloseRemainderTo.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x80000000) == 0 { // if not empty
 			// string "fadd"
 			o = append(o, 0xa4, 0x66, 0x61, 0x64, 0x64)
-			o, err = (*z).AssetFreezeTxnFields.FreezeAccount.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "FreezeAccount")
-				return
-			}
+			o = (*z).AssetFreezeTxnFields.FreezeAccount.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x100000000) == 0 { // if not empty
 			// string "faid"
 			o = append(o, 0xa4, 0x66, 0x61, 0x69, 0x64)
-			o, err = (*z).AssetFreezeTxnFields.FreezeAsset.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "FreezeAsset")
-				return
-			}
+			o = (*z).AssetFreezeTxnFields.FreezeAsset.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x200000000) == 0 { // if not empty
 			// string "fee"
 			o = append(o, 0xa3, 0x66, 0x65, 0x65)
-			o, err = (*z).Header.Fee.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Fee")
-				return
-			}
+			o = (*z).Header.Fee.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x400000000) == 0 { // if not empty
 			// string "fv"
 			o = append(o, 0xa2, 0x66, 0x76)
-			o, err = (*z).Header.FirstValid.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "FirstValid")
-				return
-			}
+			o = (*z).Header.FirstValid.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x800000000) == 0 { // if not empty
 			// string "gen"
@@ -4256,29 +3920,17 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0006Mask & 0x1000000000) == 0 { // if not empty
 			// string "gh"
 			o = append(o, 0xa2, 0x67, 0x68)
-			o, err = (*z).Header.GenesisHash.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "GenesisHash")
-				return
-			}
+			o = (*z).Header.GenesisHash.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x2000000000) == 0 { // if not empty
 			// string "grp"
 			o = append(o, 0xa3, 0x67, 0x72, 0x70)
-			o, err = (*z).Header.Group.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Group")
-				return
-			}
+			o = (*z).Header.Group.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x4000000000) == 0 { // if not empty
 			// string "lv"
 			o = append(o, 0xa2, 0x6c, 0x76)
-			o, err = (*z).Header.LastValid.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "LastValid")
-				return
-			}
+			o = (*z).Header.LastValid.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x8000000000) == 0 { // if not empty
 			// string "lx"
@@ -4298,56 +3950,32 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0006Mask & 0x40000000000) == 0 { // if not empty
 			// string "rcv"
 			o = append(o, 0xa3, 0x72, 0x63, 0x76)
-			o, err = (*z).PaymentTxnFields.Receiver.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Receiver")
-				return
-			}
+			o = (*z).PaymentTxnFields.Receiver.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x80000000000) == 0 { // if not empty
 			// string "rekey"
 			o = append(o, 0xa5, 0x72, 0x65, 0x6b, 0x65, 0x79)
-			o, err = (*z).Header.RekeyTo.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "RekeyTo")
-				return
-			}
+			o = (*z).Header.RekeyTo.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x100000000000) == 0 { // if not empty
 			// string "selkey"
 			o = append(o, 0xa6, 0x73, 0x65, 0x6c, 0x6b, 0x65, 0x79)
-			o, err = (*z).KeyregTxnFields.SelectionPK.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "SelectionPK")
-				return
-			}
+			o = (*z).KeyregTxnFields.SelectionPK.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x200000000000) == 0 { // if not empty
 			// string "snd"
 			o = append(o, 0xa3, 0x73, 0x6e, 0x64)
-			o, err = (*z).Header.Sender.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sender")
-				return
-			}
+			o = (*z).Header.Sender.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x400000000000) == 0 { // if not empty
 			// string "type"
 			o = append(o, 0xa4, 0x74, 0x79, 0x70, 0x65)
-			o, err = (*z).Type.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Type")
-				return
-			}
+			o = (*z).Type.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x800000000000) == 0 { // if not empty
 			// string "votefst"
 			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x66, 0x73, 0x74)
-			o, err = (*z).KeyregTxnFields.VoteFirst.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "VoteFirst")
-				return
-			}
+			o = (*z).KeyregTxnFields.VoteFirst.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x1000000000000) == 0 { // if not empty
 			// string "votekd"
@@ -4357,29 +3985,17 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0006Mask & 0x2000000000000) == 0 { // if not empty
 			// string "votekey"
 			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x6b, 0x65, 0x79)
-			o, err = (*z).KeyregTxnFields.VotePK.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "VotePK")
-				return
-			}
+			o = (*z).KeyregTxnFields.VotePK.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x4000000000000) == 0 { // if not empty
 			// string "votelst"
 			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x6c, 0x73, 0x74)
-			o, err = (*z).KeyregTxnFields.VoteLast.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "VoteLast")
-				return
-			}
+			o = (*z).KeyregTxnFields.VoteLast.MarshalMsg(o)
 		}
 		if (zb0006Mask & 0x8000000000000) == 0 { // if not empty
 			// string "xaid"
 			o = append(o, 0xa4, 0x78, 0x61, 0x69, 0x64)
-			o, err = (*z).AssetTransferTxnFields.XferAsset.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "XferAsset")
-				return
-			}
+			o = (*z).AssetTransferTxnFields.XferAsset.MarshalMsg(o)
 		}
 	}
 	return
@@ -5310,7 +4926,7 @@ func (z *Transaction) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *TxGroup) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *TxGroup) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0002Len := uint32(1)
@@ -5331,11 +4947,7 @@ func (z *TxGroup) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendArrayHeader(o, uint32(len((*z).TxGroupHashes)))
 			}
 			for zb0001 := range (*z).TxGroupHashes {
-				o, err = (*z).TxGroupHashes[zb0001].MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "TxGroupHashes", zb0001)
-					return
-				}
+				o = (*z).TxGroupHashes[zb0001].MarshalMsg(o)
 			}
 		}
 	}
@@ -5472,7 +5084,7 @@ func (z *TxGroup) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *Txid) MarshalMsg(b []byte) ([]byte, error) {
+func (z *Txid) MarshalMsg(b []byte) []byte {
 	return ((*(crypto.Digest))(z)).MarshalMsg(b)
 }
 func (_ *Txid) CanMarshalMsg(z interface{}) bool {

--- a/data/transactions/msgp_gen_test.go
+++ b/data/transactions/msgp_gen_test.go
@@ -13,10 +13,7 @@ import (
 
 func TestMarshalUnmarshalApplicationCallTxnFields(t *testing.T) {
 	v := ApplicationCallTxnFields{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -50,18 +47,18 @@ func BenchmarkMarshalMsgApplicationCallTxnFields(b *testing.B) {
 func BenchmarkAppendMsgApplicationCallTxnFields(b *testing.B) {
 	v := ApplicationCallTxnFields{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalApplicationCallTxnFields(b *testing.B) {
 	v := ApplicationCallTxnFields{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -75,10 +72,7 @@ func BenchmarkUnmarshalApplicationCallTxnFields(b *testing.B) {
 
 func TestMarshalUnmarshalApplyData(t *testing.T) {
 	v := ApplyData{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -112,18 +106,18 @@ func BenchmarkMarshalMsgApplyData(b *testing.B) {
 func BenchmarkAppendMsgApplyData(b *testing.B) {
 	v := ApplyData{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalApplyData(b *testing.B) {
 	v := ApplyData{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -137,10 +131,7 @@ func BenchmarkUnmarshalApplyData(b *testing.B) {
 
 func TestMarshalUnmarshalAssetConfigTxnFields(t *testing.T) {
 	v := AssetConfigTxnFields{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -174,18 +165,18 @@ func BenchmarkMarshalMsgAssetConfigTxnFields(b *testing.B) {
 func BenchmarkAppendMsgAssetConfigTxnFields(b *testing.B) {
 	v := AssetConfigTxnFields{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalAssetConfigTxnFields(b *testing.B) {
 	v := AssetConfigTxnFields{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -199,10 +190,7 @@ func BenchmarkUnmarshalAssetConfigTxnFields(b *testing.B) {
 
 func TestMarshalUnmarshalAssetFreezeTxnFields(t *testing.T) {
 	v := AssetFreezeTxnFields{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -236,18 +224,18 @@ func BenchmarkMarshalMsgAssetFreezeTxnFields(b *testing.B) {
 func BenchmarkAppendMsgAssetFreezeTxnFields(b *testing.B) {
 	v := AssetFreezeTxnFields{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalAssetFreezeTxnFields(b *testing.B) {
 	v := AssetFreezeTxnFields{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -261,10 +249,7 @@ func BenchmarkUnmarshalAssetFreezeTxnFields(b *testing.B) {
 
 func TestMarshalUnmarshalAssetTransferTxnFields(t *testing.T) {
 	v := AssetTransferTxnFields{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -298,18 +283,18 @@ func BenchmarkMarshalMsgAssetTransferTxnFields(b *testing.B) {
 func BenchmarkAppendMsgAssetTransferTxnFields(b *testing.B) {
 	v := AssetTransferTxnFields{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalAssetTransferTxnFields(b *testing.B) {
 	v := AssetTransferTxnFields{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -323,10 +308,7 @@ func BenchmarkUnmarshalAssetTransferTxnFields(b *testing.B) {
 
 func TestMarshalUnmarshalCompactCertTxnFields(t *testing.T) {
 	v := CompactCertTxnFields{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -360,18 +342,18 @@ func BenchmarkMarshalMsgCompactCertTxnFields(b *testing.B) {
 func BenchmarkAppendMsgCompactCertTxnFields(b *testing.B) {
 	v := CompactCertTxnFields{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalCompactCertTxnFields(b *testing.B) {
 	v := CompactCertTxnFields{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -385,10 +367,7 @@ func BenchmarkUnmarshalCompactCertTxnFields(b *testing.B) {
 
 func TestMarshalUnmarshalHeader(t *testing.T) {
 	v := Header{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -422,18 +401,18 @@ func BenchmarkMarshalMsgHeader(b *testing.B) {
 func BenchmarkAppendMsgHeader(b *testing.B) {
 	v := Header{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalHeader(b *testing.B) {
 	v := Header{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -447,10 +426,7 @@ func BenchmarkUnmarshalHeader(b *testing.B) {
 
 func TestMarshalUnmarshalKeyregTxnFields(t *testing.T) {
 	v := KeyregTxnFields{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -484,18 +460,18 @@ func BenchmarkMarshalMsgKeyregTxnFields(b *testing.B) {
 func BenchmarkAppendMsgKeyregTxnFields(b *testing.B) {
 	v := KeyregTxnFields{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalKeyregTxnFields(b *testing.B) {
 	v := KeyregTxnFields{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -509,10 +485,7 @@ func BenchmarkUnmarshalKeyregTxnFields(b *testing.B) {
 
 func TestMarshalUnmarshalLogicSig(t *testing.T) {
 	v := LogicSig{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -546,18 +519,18 @@ func BenchmarkMarshalMsgLogicSig(b *testing.B) {
 func BenchmarkAppendMsgLogicSig(b *testing.B) {
 	v := LogicSig{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalLogicSig(b *testing.B) {
 	v := LogicSig{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -571,10 +544,7 @@ func BenchmarkUnmarshalLogicSig(b *testing.B) {
 
 func TestMarshalUnmarshalPaymentTxnFields(t *testing.T) {
 	v := PaymentTxnFields{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -608,18 +578,18 @@ func BenchmarkMarshalMsgPaymentTxnFields(b *testing.B) {
 func BenchmarkAppendMsgPaymentTxnFields(b *testing.B) {
 	v := PaymentTxnFields{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalPaymentTxnFields(b *testing.B) {
 	v := PaymentTxnFields{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -633,10 +603,7 @@ func BenchmarkUnmarshalPaymentTxnFields(b *testing.B) {
 
 func TestMarshalUnmarshalPayset(t *testing.T) {
 	v := Payset{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -670,18 +637,18 @@ func BenchmarkMarshalMsgPayset(b *testing.B) {
 func BenchmarkAppendMsgPayset(b *testing.B) {
 	v := Payset{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalPayset(b *testing.B) {
 	v := Payset{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -695,10 +662,7 @@ func BenchmarkUnmarshalPayset(b *testing.B) {
 
 func TestMarshalUnmarshalSignedTxn(t *testing.T) {
 	v := SignedTxn{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -732,18 +696,18 @@ func BenchmarkMarshalMsgSignedTxn(b *testing.B) {
 func BenchmarkAppendMsgSignedTxn(b *testing.B) {
 	v := SignedTxn{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalSignedTxn(b *testing.B) {
 	v := SignedTxn{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -757,10 +721,7 @@ func BenchmarkUnmarshalSignedTxn(b *testing.B) {
 
 func TestMarshalUnmarshalSignedTxnInBlock(t *testing.T) {
 	v := SignedTxnInBlock{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -794,18 +755,18 @@ func BenchmarkMarshalMsgSignedTxnInBlock(b *testing.B) {
 func BenchmarkAppendMsgSignedTxnInBlock(b *testing.B) {
 	v := SignedTxnInBlock{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalSignedTxnInBlock(b *testing.B) {
 	v := SignedTxnInBlock{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -819,10 +780,7 @@ func BenchmarkUnmarshalSignedTxnInBlock(b *testing.B) {
 
 func TestMarshalUnmarshalSignedTxnWithAD(t *testing.T) {
 	v := SignedTxnWithAD{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -856,18 +814,18 @@ func BenchmarkMarshalMsgSignedTxnWithAD(b *testing.B) {
 func BenchmarkAppendMsgSignedTxnWithAD(b *testing.B) {
 	v := SignedTxnWithAD{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalSignedTxnWithAD(b *testing.B) {
 	v := SignedTxnWithAD{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -881,10 +839,7 @@ func BenchmarkUnmarshalSignedTxnWithAD(b *testing.B) {
 
 func TestMarshalUnmarshalTransaction(t *testing.T) {
 	v := Transaction{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -918,18 +873,18 @@ func BenchmarkMarshalMsgTransaction(b *testing.B) {
 func BenchmarkAppendMsgTransaction(b *testing.B) {
 	v := Transaction{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalTransaction(b *testing.B) {
 	v := Transaction{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -943,10 +898,7 @@ func BenchmarkUnmarshalTransaction(b *testing.B) {
 
 func TestMarshalUnmarshalTxGroup(t *testing.T) {
 	v := TxGroup{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -980,18 +932,18 @@ func BenchmarkMarshalMsgTxGroup(b *testing.B) {
 func BenchmarkAppendMsgTxGroup(b *testing.B) {
 	v := TxGroup{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalTxGroup(b *testing.B) {
 	v := TxGroup{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/algorand/go-codec/codec v0.0.0-20190507210007-269d70b6135d
 	github.com/algorand/go-deadlock v0.2.1
 	github.com/algorand/graphtrace v0.0.0-20201117160756-e524ed1a6f64
-	github.com/algorand/msgp v1.1.46
+	github.com/algorand/msgp v1.1.47
 	github.com/algorand/oapi-codegen v1.3.5-algorand5
 	github.com/algorand/websocket v1.4.1
 	github.com/aws/aws-sdk-go v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/algorand/graphtrace v0.0.0-20201023193244-96dde3c58a7a h1:0vQcZhPB7rC
 github.com/algorand/graphtrace v0.0.0-20201023193244-96dde3c58a7a/go.mod h1:qFtQmC+kmsfnLfS9j3xgKtzsWyozemL5ek1R4dWZa5c=
 github.com/algorand/graphtrace v0.0.0-20201117160756-e524ed1a6f64 h1:yvKeJdS/mvLRiyIxu8j5BQDXIzs1XbC9/22KycJnt3A=
 github.com/algorand/graphtrace v0.0.0-20201117160756-e524ed1a6f64/go.mod h1:qFtQmC+kmsfnLfS9j3xgKtzsWyozemL5ek1R4dWZa5c=
-github.com/algorand/msgp v1.1.46 h1:R2C3pr4WDLrqAisFVJVSvGtQO9pk9eikOL/4u07K38g=
-github.com/algorand/msgp v1.1.46/go.mod h1:LtOntbYiCHj/Sl/Sqxtf8CZOrDt2a8Dv3tLaS6mcnUE=
+github.com/algorand/msgp v1.1.47 h1:xeU6G/Mb1iudJe4L5X38YrOY+VHhvHQDZXxyXYHTzOw=
+github.com/algorand/msgp v1.1.47/go.mod h1:LtOntbYiCHj/Sl/Sqxtf8CZOrDt2a8Dv3tLaS6mcnUE=
 github.com/algorand/oapi-codegen v1.3.5-algorand5 h1:y576Ca2/guQddQrQA7dtL5KcOx5xQgPeIupiuFMGyCI=
 github.com/algorand/oapi-codegen v1.3.5-algorand5/go.mod h1:/k0Ywn0lnt92uBMyE+yiRf/Wo3/chxHHsAfenD09EbY=
 github.com/algorand/websocket v1.4.1 h1:FPoNHI8i2VZWZzhCscY8JTzsAE7Vv73753cMbzb3udk=

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -133,19 +133,17 @@ func makeTestEncodedBalanceRecord(t *testing.T) encodedBalanceRecord {
 		ad.AppLocalStates[basics.AppIndex(aidx)] = basics.AppLocalState{KeyValue: lkv}
 	}
 
-	encodedAd, err := ad.MarshalMsg(nil)
-	require.NoError(t, err)
+	encodedAd := ad.MarshalMsg(nil)
 	er.AccountData = encodedAd
 	return er
 }
 
 func TestEncodedBalanceRecordEncoding(t *testing.T) {
 	er := makeTestEncodedBalanceRecord(t)
-	encodedBr, err := er.MarshalMsg(nil)
-	require.NoError(t, err)
+	encodedBr := er.MarshalMsg(nil)
 
 	var er2 encodedBalanceRecord
-	_, err = er2.UnmarshalMsg(encodedBr)
+	_, err := er2.UnmarshalMsg(encodedBr)
 	require.NoError(t, err)
 
 	require.Equal(t, er, er2)
@@ -156,11 +154,10 @@ func TestCatchpointFileBalancesChunkEncoding(t *testing.T) {
 	for i := 0; i < 512; i++ {
 		fbc.Balances = append(fbc.Balances, makeTestEncodedBalanceRecord(t))
 	}
-	encodedFbc, err := fbc.MarshalMsg(nil)
-	require.NoError(t, err)
+	encodedFbc := fbc.MarshalMsg(nil)
 
 	var fbc2 catchpointFileBalancesChunk
-	_, err = fbc2.UnmarshalMsg(encodedFbc)
+	_, err := fbc2.UnmarshalMsg(encodedFbc)
 	require.NoError(t, err)
 
 	require.Equal(t, fbc, fbc2)

--- a/ledger/ledgercore/msgp_gen.go
+++ b/ledger/ledgercore/msgp_gen.go
@@ -25,7 +25,7 @@ import (
 //
 
 // MarshalMsg implements msgp.Marshaler
-func (z *AccountTotals) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *AccountTotals) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(4)
@@ -68,11 +68,7 @@ func (z *AccountTotals) MarshalMsg(b []byte) (o []byte, err error) {
 			if (zb0002Mask & 0x2) == 0 { // if not empty
 				// string "mon"
 				o = append(o, 0xa3, 0x6d, 0x6f, 0x6e)
-				o, err = (*z).NotParticipating.Money.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "NotParticipating", "Money")
-					return
-				}
+				o = (*z).NotParticipating.Money.MarshalMsg(o)
 			}
 			if (zb0002Mask & 0x4) == 0 { // if not empty
 				// string "rwd"
@@ -99,11 +95,7 @@ func (z *AccountTotals) MarshalMsg(b []byte) (o []byte, err error) {
 			if (zb0003Mask & 0x2) == 0 { // if not empty
 				// string "mon"
 				o = append(o, 0xa3, 0x6d, 0x6f, 0x6e)
-				o, err = (*z).Offline.Money.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Offline", "Money")
-					return
-				}
+				o = (*z).Offline.Money.MarshalMsg(o)
 			}
 			if (zb0003Mask & 0x4) == 0 { // if not empty
 				// string "rwd"
@@ -130,11 +122,7 @@ func (z *AccountTotals) MarshalMsg(b []byte) (o []byte, err error) {
 			if (zb0004Mask & 0x2) == 0 { // if not empty
 				// string "mon"
 				o = append(o, 0xa3, 0x6d, 0x6f, 0x6e)
-				o, err = (*z).Online.Money.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "Online", "Money")
-					return
-				}
+				o = (*z).Online.Money.MarshalMsg(o)
 			}
 			if (zb0004Mask & 0x4) == 0 { // if not empty
 				// string "rwd"
@@ -662,7 +650,7 @@ func (z *AccountTotals) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *AlgoCount) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *AlgoCount) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(2)
@@ -681,11 +669,7 @@ func (z *AlgoCount) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "mon"
 			o = append(o, 0xa3, 0x6d, 0x6f, 0x6e)
-			o, err = (*z).Money.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Money")
-				return
-			}
+			o = (*z).Money.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "rwd"

--- a/ledger/ledgercore/msgp_gen_test.go
+++ b/ledger/ledgercore/msgp_gen_test.go
@@ -13,10 +13,7 @@ import (
 
 func TestMarshalUnmarshalAccountTotals(t *testing.T) {
 	v := AccountTotals{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -50,18 +47,18 @@ func BenchmarkMarshalMsgAccountTotals(b *testing.B) {
 func BenchmarkAppendMsgAccountTotals(b *testing.B) {
 	v := AccountTotals{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalAccountTotals(b *testing.B) {
 	v := AccountTotals{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -75,10 +72,7 @@ func BenchmarkUnmarshalAccountTotals(b *testing.B) {
 
 func TestMarshalUnmarshalAlgoCount(t *testing.T) {
 	v := AlgoCount{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -112,18 +106,18 @@ func BenchmarkMarshalMsgAlgoCount(b *testing.B) {
 func BenchmarkAppendMsgAlgoCount(b *testing.B) {
 	v := AlgoCount{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalAlgoCount(b *testing.B) {
 	v := AlgoCount{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()

--- a/ledger/ledgercore/totals_test.go
+++ b/ledger/ledgercore/totals_test.go
@@ -49,14 +49,12 @@ func TestAccountTotalsMarshalMsg(t *testing.T) {
 		RewardsLevel: 0x1234123412340007,
 	}
 	inBuffer := make([]byte, 0, 128)
-	outBuffer, err := at.MarshalMsg(inBuffer)
-	require.NoError(t, err)
+	outBuffer := at.MarshalMsg(inBuffer)
 	require.True(t, len(outBuffer) < cap(inBuffer))
 
 	// allocate a buffer that is just the right size.
 	inBuffer = make([]byte, len(outBuffer))
-	outBuffer, err = at.MarshalMsg(inBuffer)
-	require.NoError(t, err)
+	outBuffer = at.MarshalMsg(inBuffer)
 	require.True(t, len(outBuffer) > 0)
 }
 
@@ -66,14 +64,12 @@ func TestAlgoCountMarshalMsg(t *testing.T) {
 		RewardUnits: 0x1234123412341234,
 	}
 	inBuffer := make([]byte, 0, 128)
-	outBuffer, err := ac.MarshalMsg(inBuffer)
-	require.NoError(t, err)
+	outBuffer := ac.MarshalMsg(inBuffer)
 	require.Truef(t, len(outBuffer) > len(inBuffer), "len(outBuffer) : %d\nlen(inBuffer): %d\n", len(outBuffer), len(inBuffer))
 
 	// allocate a buffer that is just the right size.
 	inBuffer = make([]byte, len(outBuffer))
-	outBuffer, err = ac.MarshalMsg(inBuffer)
-	require.NoError(t, err)
+	outBuffer = ac.MarshalMsg(inBuffer)
 	require.True(t, len(outBuffer) > 0)
 }
 
@@ -204,8 +200,7 @@ func TestAccountTotalsMarshalMsgUnique(t *testing.T) {
 	uniqueAt := make(map[crypto.Digest]bool, 0)
 	for _, at := range uniqueAccountTotals {
 		inBuffer := make([]byte, 0, 128)
-		outBuffer, err := at.MarshalMsg(inBuffer)
-		require.NoError(t, err)
+		outBuffer := at.MarshalMsg(inBuffer)
 		outBufDigest := crypto.Hash(outBuffer)
 		require.False(t, uniqueAt[outBufDigest])
 		uniqueAt[outBufDigest] = true
@@ -215,10 +210,9 @@ func TestAccountTotalsMarshalMsgUnique(t *testing.T) {
 func TestAccountTotalsMarshalUnMarshal(t *testing.T) {
 	for _, at := range uniqueAccountTotals {
 		inBuffer := make([]byte, 0, 128)
-		outBuffer, err := at.MarshalMsg(inBuffer)
-		require.NoError(t, err)
+		outBuffer := at.MarshalMsg(inBuffer)
 		var at2 AccountTotals
-		_, err = at2.UnmarshalMsg(outBuffer)
+		_, err := at2.UnmarshalMsg(outBuffer)
 		require.NoError(t, err)
 		require.Equal(t, at, at2)
 	}

--- a/ledger/msgp_gen.go
+++ b/ledger/msgp_gen.go
@@ -57,7 +57,7 @@ import (
 //
 
 // MarshalMsg implements msgp.Marshaler
-func (z CatchpointCatchupState) MarshalMsg(b []byte) (o []byte, err error) {
+func (z CatchpointCatchupState) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendInt32(o, int32(z))
 	return
@@ -103,7 +103,7 @@ func (z CatchpointCatchupState) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *CatchpointFileHeader) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *CatchpointFileHeader) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(8)
@@ -146,11 +146,7 @@ func (z *CatchpointFileHeader) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "accountTotals"
 			o = append(o, 0xad, 0x61, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x54, 0x6f, 0x74, 0x61, 0x6c, 0x73)
-			o, err = (*z).Totals.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Totals")
-				return
-			}
+			o = (*z).Totals.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "accountsCount"
@@ -160,29 +156,17 @@ func (z *CatchpointFileHeader) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "balancesRound"
 			o = append(o, 0xad, 0x62, 0x61, 0x6c, 0x61, 0x6e, 0x63, 0x65, 0x73, 0x52, 0x6f, 0x75, 0x6e, 0x64)
-			o, err = (*z).BalancesRound.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "BalancesRound")
-				return
-			}
+			o = (*z).BalancesRound.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "blockHeaderDigest"
 			o = append(o, 0xb1, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x48, 0x65, 0x61, 0x64, 0x65, 0x72, 0x44, 0x69, 0x67, 0x65, 0x73, 0x74)
-			o, err = (*z).BlockHeaderDigest.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "BlockHeaderDigest")
-				return
-			}
+			o = (*z).BlockHeaderDigest.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "blocksRound"
 			o = append(o, 0xab, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x73, 0x52, 0x6f, 0x75, 0x6e, 0x64)
-			o, err = (*z).BlocksRound.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "BlocksRound")
-				return
-			}
+			o = (*z).BlocksRound.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not empty
 			// string "catchpoint"
@@ -386,7 +370,7 @@ func (z *CatchpointFileHeader) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *catchpointFileBalancesChunk) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *catchpointFileBalancesChunk) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0002Len := uint32(1)
@@ -423,20 +407,12 @@ func (z *catchpointFileBalancesChunk) MarshalMsg(b []byte) (o []byte, err error)
 				if (zb0003Mask & 0x2) == 0 { // if not empty
 					// string "ad"
 					o = append(o, 0xa2, 0x61, 0x64)
-					o, err = (*z).Balances[zb0001].AccountData.MarshalMsg(o)
-					if err != nil {
-						err = msgp.WrapError(err, "Balances", zb0001, "AccountData")
-						return
-					}
+					o = (*z).Balances[zb0001].AccountData.MarshalMsg(o)
 				}
 				if (zb0003Mask & 0x4) == 0 { // if not empty
 					// string "pk"
 					o = append(o, 0xa2, 0x70, 0x6b)
-					o, err = (*z).Balances[zb0001].Address.MarshalMsg(o)
-					if err != nil {
-						err = msgp.WrapError(err, "Balances", zb0001, "Address")
-						return
-					}
+					o = (*z).Balances[zb0001].Address.MarshalMsg(o)
 				}
 			}
 		}
@@ -702,7 +678,7 @@ func (z *catchpointFileBalancesChunk) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z catchpointState) MarshalMsg(b []byte) (o []byte, err error) {
+func (z catchpointState) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendString(o, string(z))
 	return
@@ -748,7 +724,7 @@ func (z catchpointState) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *encodedBalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *encodedBalanceRecord) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(2)
@@ -767,20 +743,12 @@ func (z *encodedBalanceRecord) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "ad"
 			o = append(o, 0xa2, 0x61, 0x64)
-			o, err = (*z).AccountData.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "AccountData")
-				return
-			}
+			o = (*z).AccountData.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "pk"
 			o = append(o, 0xa2, 0x70, 0x6b)
-			o, err = (*z).Address.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Address")
-				return
-			}
+			o = (*z).Address.MarshalMsg(o)
 		}
 	}
 	return
@@ -885,7 +853,7 @@ func (z *encodedBalanceRecord) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z storageAction) MarshalMsg(b []byte) (o []byte, err error) {
+func (z storageAction) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendUint64(o, uint64(z))
 	return

--- a/ledger/msgp_gen_test.go
+++ b/ledger/msgp_gen_test.go
@@ -13,10 +13,7 @@ import (
 
 func TestMarshalUnmarshalCatchpointFileHeader(t *testing.T) {
 	v := CatchpointFileHeader{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -50,18 +47,18 @@ func BenchmarkMarshalMsgCatchpointFileHeader(b *testing.B) {
 func BenchmarkAppendMsgCatchpointFileHeader(b *testing.B) {
 	v := CatchpointFileHeader{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalCatchpointFileHeader(b *testing.B) {
 	v := CatchpointFileHeader{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -75,10 +72,7 @@ func BenchmarkUnmarshalCatchpointFileHeader(b *testing.B) {
 
 func TestMarshalUnmarshalcatchpointFileBalancesChunk(t *testing.T) {
 	v := catchpointFileBalancesChunk{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -112,18 +106,18 @@ func BenchmarkMarshalMsgcatchpointFileBalancesChunk(b *testing.B) {
 func BenchmarkAppendMsgcatchpointFileBalancesChunk(b *testing.B) {
 	v := catchpointFileBalancesChunk{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalcatchpointFileBalancesChunk(b *testing.B) {
 	v := catchpointFileBalancesChunk{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -137,10 +131,7 @@ func BenchmarkUnmarshalcatchpointFileBalancesChunk(b *testing.B) {
 
 func TestMarshalUnmarshalencodedBalanceRecord(t *testing.T) {
 	v := encodedBalanceRecord{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -174,18 +165,18 @@ func BenchmarkMarshalMsgencodedBalanceRecord(b *testing.B) {
 func BenchmarkAppendMsgencodedBalanceRecord(b *testing.B) {
 	v := encodedBalanceRecord{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalencodedBalanceRecord(b *testing.B) {
 	v := encodedBalanceRecord{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()

--- a/node/msgp_gen.go
+++ b/node/msgp_gen.go
@@ -25,7 +25,7 @@ import (
 //
 
 // MarshalMsg implements msgp.Marshaler
-func (z *netPrioResponse) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *netPrioResponse) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(1)
@@ -131,7 +131,7 @@ func (z *netPrioResponse) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *netPrioResponseSigned) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *netPrioResponseSigned) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(4)
@@ -176,29 +176,17 @@ func (z *netPrioResponseSigned) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "Round"
 			o = append(o, 0xa5, 0x52, 0x6f, 0x75, 0x6e, 0x64)
-			o, err = (*z).Round.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Round")
-				return
-			}
+			o = (*z).Round.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "Sender"
 			o = append(o, 0xa6, 0x53, 0x65, 0x6e, 0x64, 0x65, 0x72)
-			o, err = (*z).Sender.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sender")
-				return
-			}
+			o = (*z).Sender.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "Sig"
 			o = append(o, 0xa3, 0x53, 0x69, 0x67)
-			o, err = (*z).Sig.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Sig")
-				return
-			}
+			o = (*z).Sig.MarshalMsg(o)
 		}
 	}
 	return

--- a/node/msgp_gen_test.go
+++ b/node/msgp_gen_test.go
@@ -13,10 +13,7 @@ import (
 
 func TestMarshalUnmarshalnetPrioResponse(t *testing.T) {
 	v := netPrioResponse{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -50,18 +47,18 @@ func BenchmarkMarshalMsgnetPrioResponse(b *testing.B) {
 func BenchmarkAppendMsgnetPrioResponse(b *testing.B) {
 	v := netPrioResponse{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalnetPrioResponse(b *testing.B) {
 	v := netPrioResponse{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()
@@ -75,10 +72,7 @@ func BenchmarkUnmarshalnetPrioResponse(b *testing.B) {
 
 func TestMarshalUnmarshalnetPrioResponseSigned(t *testing.T) {
 	v := netPrioResponseSigned{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -112,18 +106,18 @@ func BenchmarkMarshalMsgnetPrioResponseSigned(b *testing.B) {
 func BenchmarkAppendMsgnetPrioResponseSigned(b *testing.B) {
 	v := netPrioResponseSigned{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalnetPrioResponseSigned(b *testing.B) {
 	v := netPrioResponseSigned{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()

--- a/protocol/codec.go
+++ b/protocol/codec.go
@@ -114,12 +114,7 @@ func EncodeReflect(obj interface{}) []byte {
 // EncodeMsgp returns a msgpack-encoded byte buffer, requiring
 // that we pre-generated the code for doing so using msgp.
 func EncodeMsgp(obj msgp.Marshaler) []byte {
-	res, err := obj.MarshalMsg(nil)
-	if err != nil {
-		panic(err)
-	}
-
-	return res
+	return obj.MarshalMsg(nil)
 }
 
 // Encode returns a msgpack-encoded byte buffer for a given object.

--- a/protocol/msgp_gen.go
+++ b/protocol/msgp_gen.go
@@ -65,7 +65,7 @@ import (
 //
 
 // MarshalMsg implements msgp.Marshaler
-func (z CompactCertType) MarshalMsg(b []byte) (o []byte, err error) {
+func (z CompactCertType) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendUint64(o, uint64(z))
 	return
@@ -111,7 +111,7 @@ func (z CompactCertType) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z ConsensusVersion) MarshalMsg(b []byte) (o []byte, err error) {
+func (z ConsensusVersion) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendString(o, string(z))
 	return
@@ -157,7 +157,7 @@ func (z ConsensusVersion) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z Error) MarshalMsg(b []byte) (o []byte, err error) {
+func (z Error) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendString(o, string(z))
 	return
@@ -203,7 +203,7 @@ func (z Error) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z HashID) MarshalMsg(b []byte) (o []byte, err error) {
+func (z HashID) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendString(o, string(z))
 	return
@@ -249,7 +249,7 @@ func (z HashID) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z NetworkID) MarshalMsg(b []byte) (o []byte, err error) {
+func (z NetworkID) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendString(o, string(z))
 	return
@@ -295,7 +295,7 @@ func (z NetworkID) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z Tag) MarshalMsg(b []byte) (o []byte, err error) {
+func (z Tag) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendString(o, string(z))
 	return
@@ -341,7 +341,7 @@ func (z Tag) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z TxType) MarshalMsg(b []byte) (o []byte, err error) {
+func (z TxType) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendString(o, string(z))
 	return

--- a/rpcs/msgp_gen.go
+++ b/rpcs/msgp_gen.go
@@ -17,23 +17,15 @@ import (
 //
 
 // MarshalMsg implements msgp.Marshaler
-func (z *EncodedBlockCert) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *EncodedBlockCert) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 2
 	// string "block"
 	o = append(o, 0x82, 0xa5, 0x62, 0x6c, 0x6f, 0x63, 0x6b)
-	o, err = (*z).Block.MarshalMsg(o)
-	if err != nil {
-		err = msgp.WrapError(err, "Block")
-		return
-	}
+	o = (*z).Block.MarshalMsg(o)
 	// string "cert"
 	o = append(o, 0xa4, 0x63, 0x65, 0x72, 0x74)
-	o, err = (*z).Certificate.MarshalMsg(o)
-	if err != nil {
-		err = msgp.WrapError(err, "Certificate")
-		return
-	}
+	o = (*z).Certificate.MarshalMsg(o)
 	return
 }
 

--- a/rpcs/msgp_gen_test.go
+++ b/rpcs/msgp_gen_test.go
@@ -13,10 +13,7 @@ import (
 
 func TestMarshalUnmarshalEncodedBlockCert(t *testing.T) {
 	v := EncodedBlockCert{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
 	if err != nil {
 		t.Fatal(err)
@@ -50,18 +47,18 @@ func BenchmarkMarshalMsgEncodedBlockCert(b *testing.B) {
 func BenchmarkAppendMsgEncodedBlockCert(b *testing.B) {
 	v := EncodedBlockCert{}
 	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
+	bts = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
+		bts = v.MarshalMsg(bts[0:0])
 	}
 }
 
 func BenchmarkUnmarshalEncodedBlockCert(b *testing.B) {
 	v := EncodedBlockCert{}
-	bts, _ := v.MarshalMsg(nil)
+	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
 	b.ResetTimer()


### PR DESCRIPTION
This PR uses msgp version 1.1.47, which eliminates the possibility of MarshalMsg returning an error.