### PR TITLE
speed up merklearray

### DIFF
--- a/crypto/compactcert/builder.go
+++ b/crypto/compactcert/builder.go
@@ -129,12 +129,12 @@ func (sc sigsToCommit) Length() uint64 {
 	return uint64(len(sc))
 }
 
-func (sc sigsToCommit) Get(pos uint64) (crypto.Hashable, error) {
+func (sc sigsToCommit) GetHash(pos uint64) (crypto.Digest, error) {
 	if pos >= uint64(len(sc)) {
-		return nil, fmt.Errorf("pos %d past end %d", pos, len(sc))
+		return crypto.Digest{}, fmt.Errorf("pos %d past end %d", pos, len(sc))
 	}
 
-	return &sc[pos].sigslotCommit, nil
+	return crypto.HashObj(&sc[pos].sigslotCommit), nil
 }
 
 // coinIndex returns the position pos in the sigs array such that the sum

--- a/crypto/compactcert/builder_test.go
+++ b/crypto/compactcert/builder_test.go
@@ -42,12 +42,12 @@ func (pc PartCommit) Length() uint64 {
 	return uint64(len(pc.participants))
 }
 
-func (pc PartCommit) Get(pos uint64) (crypto.Hashable, error) {
+func (pc PartCommit) GetHash(pos uint64) (crypto.Digest, error) {
 	if pos >= uint64(len(pc.participants)) {
-		return nil, fmt.Errorf("pos %d >= len %d", pos, len(pc.participants))
+		return crypto.Digest{}, fmt.Errorf("pos %d >= len %d", pos, len(pc.participants))
 	}
 
-	return pc.participants[pos], nil
+	return crypto.HashObj(pc.participants[pos]), nil
 }
 
 func TestBuildVerify(t *testing.T) {

--- a/crypto/merklearray/array.go
+++ b/crypto/merklearray/array.go
@@ -21,8 +21,9 @@ import (
 )
 
 // An Array represents a dense array of leaf elements that are
-// combined into a Merkle tree.  Each element must be hashable.
+// combined into a Merkle tree.  The GetHash method returns the
+// hash of a particular element in the array.
 type Array interface {
 	Length() uint64
-	Get(pos uint64) (crypto.Hashable, error)
+	GetHash(pos uint64) (crypto.Digest, error)
 }

--- a/crypto/merklearray/layer.go
+++ b/crypto/merklearray/layer.go
@@ -39,6 +39,16 @@ func (p *pair) ToBeHashed() (protocol.HashID, []byte) {
 	return protocol.MerkleArrayNode, buf[:]
 }
 
+// Hash implements an optimized version of crypto.HashObj(p).
+func (p *pair) Hash() crypto.Digest {
+	var buf [len(protocol.MerkleArrayNode) + 2 * crypto.DigestSize]byte
+	s := buf[:0]
+	s = append(s, protocol.MerkleArrayNode...)
+	s = append(s, p.l[:]...)
+	s = append(s, p.r[:]...)
+	return crypto.Hash(s)
+}
+
 // up takes a layer representing some level in the tree,
 // and returns the next-higher level in the tree,
 // represented as a layer.
@@ -50,7 +60,7 @@ func (l layer) up() layer {
 		if i+1 < len(l) {
 			p.r = l[i+1]
 		}
-		res[i/2] = crypto.HashObj(&p)
+		res[i/2] = p.Hash()
 	}
 	return res
 }

--- a/crypto/merklearray/layer.go
+++ b/crypto/merklearray/layer.go
@@ -41,7 +41,7 @@ func (p *pair) ToBeHashed() (protocol.HashID, []byte) {
 
 // Hash implements an optimized version of crypto.HashObj(p).
 func (p *pair) Hash() crypto.Digest {
-	var buf [len(protocol.MerkleArrayNode) + 2 * crypto.DigestSize]byte
+	var buf [len(protocol.MerkleArrayNode) + 2*crypto.DigestSize]byte
 	s := buf[:0]
 	s = append(s, protocol.MerkleArrayNode...)
 	s = append(s, p.l[:]...)
@@ -49,18 +49,43 @@ func (p *pair) Hash() crypto.Digest {
 	return crypto.Hash(s)
 }
 
+func upWorker(ws *workerState, in layer, out layer) {
+	ws.started()
+	batchSize := uint64(2)
+
+	for {
+		off := ws.next(batchSize)
+		if off >= ws.maxidx {
+			break
+		}
+
+		for i := off; i < off+batchSize && i < ws.maxidx; i += 2 {
+			var p pair
+			p.l = in[i]
+			if i+1 < ws.maxidx {
+				p.r = in[i+1]
+			}
+			out[i/2] = p.Hash()
+		}
+
+		batchSize += 2
+	}
+
+	ws.done()
+}
+
 // up takes a layer representing some level in the tree,
 // and returns the next-higher level in the tree,
 // represented as a layer.
 func (l layer) up() layer {
-	res := make(layer, (uint64(len(l))+1)/2)
-	for i := 0; i < len(l); i += 2 {
-		var p pair
-		p.l = l[i]
-		if i+1 < len(l) {
-			p.r = l[i+1]
-		}
-		res[i/2] = p.Hash()
+	n := len(l)
+	res := make(layer, (uint64(n)+1)/2)
+
+	ws := newWorkerState(uint64(n))
+	for ws.nextWorker() {
+		go upWorker(ws, l, res)
 	}
+	ws.wait()
+
 	return res
 }

--- a/crypto/merklearray/layer_test.go
+++ b/crypto/merklearray/layer_test.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package merklearray
+
+import (
+	"testing"
+
+	"github.com/algorand/go-algorand/crypto"
+)
+
+func TestLayerHash(t *testing.T) {
+	var p pair
+	crypto.RandBytes(p.l[:])
+	crypto.RandBytes(p.r[:])
+	if crypto.HashObj(&p) != p.Hash() {
+		t.Error("hash mismatch")
+	}
+}

--- a/crypto/merklearray/merkle.go
+++ b/crypto/merklearray/merkle.go
@@ -41,12 +41,12 @@ func Build(array Array) (*Tree, error) {
 	var leaves layer
 	arraylen := array.Length()
 	for i := uint64(0); i < arraylen; i++ {
-		data, err := array.Get(i)
+		hash, err := array.GetHash(i)
 		if err != nil {
 			return nil, err
 		}
 
-		leaves = append(leaves, crypto.HashObj(data))
+		leaves = append(leaves, hash)
 	}
 
 	if arraylen > 0 {

--- a/crypto/merklearray/merkle_test.go
+++ b/crypto/merklearray/merkle_test.go
@@ -48,12 +48,12 @@ func (a TestArray) Length() uint64 {
 	return uint64(len(a))
 }
 
-func (a TestArray) Get(pos uint64) (crypto.Hashable, error) {
+func (a TestArray) GetHash(pos uint64) (crypto.Digest, error) {
 	if pos >= uint64(len(a)) {
-		return nil, fmt.Errorf("pos %d larger than length %d", pos, len(a))
+		return crypto.Digest{}, fmt.Errorf("pos %d larger than length %d", pos, len(a))
 	}
 
-	return a[pos], nil
+	return crypto.HashObj(a[pos]), nil
 }
 
 type TestRepeatingArray struct {
@@ -65,12 +65,12 @@ func (a TestRepeatingArray) Length() uint64 {
 	return a.count
 }
 
-func (a TestRepeatingArray) Get(pos uint64) (crypto.Hashable, error) {
+func (a TestRepeatingArray) GetHash(pos uint64) (crypto.Digest, error) {
 	if pos >= a.count {
-		return nil, fmt.Errorf("pos %d larger than length %d", pos, a.count)
+		return crypto.Digest{}, fmt.Errorf("pos %d larger than length %d", pos, a.count)
 	}
 
-	return a.item, nil
+	return crypto.HashObj(a.item), nil
 }
 
 func TestMerkle(t *testing.T) {

--- a/crypto/merklearray/partial.go
+++ b/crypto/merklearray/partial.go
@@ -114,7 +114,7 @@ func (pl partialLayer) up(s *siblings, l uint64, doHash bool) (partialLayer, err
 				p.l = siblingHash
 				p.r = posHash
 			}
-			nextLayerHash = crypto.HashObj(&p)
+			nextLayerHash = p.Hash()
 		}
 
 		res = append(res, layerItem{

--- a/crypto/merklearray/worker.go
+++ b/crypto/merklearray/worker.go
@@ -1,0 +1,104 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package merklearray
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+)
+
+// workerState describes a group of goroutines processing a sequential list
+// of maxidx elements starting from 0.
+type workerState struct {
+	// nworkers is the number of workers that can be started.
+	// This field gets decremented once workers are launched,
+	// and represents the number of remaining workers that can
+	// be launched.
+	nworkers int
+
+	// starting is a channel that paces the creation of workers.
+	// In particular, a new worker can be started only when the
+	// previous worker starts running code.  The first thing that
+	// a worker does is to send a message on this channel, to allow
+	// for more workers to start.  This ensures reasonable performance
+	// even when the number of elements to process is small (and where
+	// otherwise the cost of launching workers might dominate).
+	starting chan struct{}
+
+	// wg tracks outstanding workers, to determine when all workers
+	// have finished their processing.
+	wg sync.WaitGroup
+
+	// maxidx is the total number of elements to process, and nextidx
+	// is the next element that a worker should process.
+	maxidx  uint64
+	nextidx uint64
+}
+
+func newWorkerState(max uint64) *workerState {
+	var ws workerState
+	ws.nworkers = runtime.NumCPU()
+	ws.maxidx = max
+
+	ws.starting = make(chan struct{}, 1)
+	ws.starting <- struct{}{}
+
+	return &ws
+}
+
+// next returns the next position to process, and bumps the counter
+// by delta.  This implicitly means that the worker that calls next
+// is promising to process delta elements at the returned position.
+func (ws *workerState) next(delta uint64) uint64 {
+	return atomic.AddUint64(&ws.nextidx, delta) - delta
+}
+
+// When a worker is about to exit, it should call done.
+func (ws *workerState) done() {
+	ws.wg.Done()
+}
+
+// wait waits for all of the workers to finish.
+func (ws *workerState) wait() {
+	ws.wg.Wait()
+}
+
+// nextWorker() is used by the top-level caller to decide when it
+// should launch the next worker.
+func (ws *workerState) nextWorker() bool {
+	if ws.nworkers <= 0 {
+		return false
+	}
+
+	_ = <-ws.starting
+
+	curidx := atomic.LoadUint64(&ws.nextidx)
+	if curidx >= ws.maxidx {
+		return false
+	}
+
+	ws.nworkers--
+	ws.wg.Add(1)
+	return true
+}
+
+// When a worker thread starts running, it can call started() to
+// allow the next worker thread to be spawned.
+func (ws *workerState) started() {
+	ws.starting <- struct{}{}
+}

--- a/ledger/voters.go
+++ b/ledger/voters.go
@@ -341,10 +341,10 @@ func (a participantsArray) Length() uint64 {
 	return uint64(len(a))
 }
 
-func (a participantsArray) Get(pos uint64) (crypto.Hashable, error) {
+func (a participantsArray) GetHash(pos uint64) (crypto.Digest, error) {
 	if pos >= uint64(len(a)) {
-		return nil, fmt.Errorf("participantsArray.Get(%d) out of bounds %d", pos, len(a))
+		return crypto.Digest{}, fmt.Errorf("participantsArray.Get(%d) out of bounds %d", pos, len(a))
 	}
 
-	return a[pos], nil
+	return crypto.HashObj(a[pos]), nil
 }


### PR DESCRIPTION
This PR speeds up merklearray, both with some small absolute performance wins (avoiding crypto.HashObj overheads), as well as parallelism in hashing the leaves and the internal nodes.

For tiny trees (10 elements where each element is something like 10-100 bytes), the parallelism adds a slight overhead (about 30-40 microseconds on my test machine, on top of a total runtime of 25-80 microseconds).  But for anything larger (either more elements or more complex-to-hash elements), this ends up being an improvement.

This might have some benefit for the current use of merklearray (namely, compact certificates), but should be even more useful for the upcoming use of merklearray for hashing all transactions in a block.