### PR TITLE
Fix omitempty for AssetCloseAmount

### DIFF
--- a/daemon/algod/api/spec/v1/model.go
+++ b/daemon/algod/api/spec/v1/model.go
@@ -679,7 +679,7 @@ type AssetTransferTransactionType struct {
 	// CloseToAmount is amount of the remaining funds that were transferred to the close to address (if closing).
 	//
 	// required: false
-	CloseToAmount uint64 `json:"closetoamount"`
+	CloseToAmount uint64 `json:"closetoamount,omitempty"`
 }
 
 // AssetFreezeTransactionType contains the additional fields for an asset freeze transaction

--- a/ledger/apply/mockBalances_test.go
+++ b/ledger/apply/mockBalances_test.go
@@ -28,6 +28,7 @@ type mockBalances struct {
 	b map[basics.Address]basics.AccountData
 }
 
+// makeMockBalances takes a ConsensusVersion and returns a mocked balances with an Address to AccountData map
 func makeMockBalances(cv protocol.ConsensusVersion) *mockBalances {
 	return &mockBalances{
 		ConsensusVersion: cv,
@@ -35,6 +36,8 @@ func makeMockBalances(cv protocol.ConsensusVersion) *mockBalances {
 	}
 }
 
+// makeMockBalancesWithAccounts takes a ConsensusVersion and a map of Address to AccountData and returns a mocked
+// balances.
 func makeMockBalancesWithAccounts(cv protocol.ConsensusVersion, b map[basics.Address]basics.AccountData) *mockBalances {
 	return &mockBalances{
 		ConsensusVersion: cv,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

As a fix to #1886, now API v1 omits the `closetoamount` in case of the 0 value.
