### PR TITLE
goal: avoid creating invalid consensus.json file

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -433,9 +433,19 @@ func checkSetAllocBounds(p ConsensusParams) {
 }
 
 // SaveConfigurableConsensus saves the configurable protocols file to the provided data directory.
+// if the params contains zero protocols, the existing consensus.json file will be removed if exists.
 func SaveConfigurableConsensus(dataDirectory string, params ConsensusProtocols) error {
 	consensusProtocolPath := filepath.Join(dataDirectory, ConfigurableConsensusProtocolsFilename)
 
+	if len(params) == 0 {
+		// we have no consensus params to write. In this case, just delete the existing file
+		// ( if any )
+		err := os.Remove(consensusProtocolPath)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
 	encodedConsensusParams, err := json.Marshal(params)
 	if err != nil {
 		return err

--- a/netdeploy/network.go
+++ b/netdeploy/network.go
@@ -446,22 +446,20 @@ func (n Network) Delete(binDir string) error {
 // SetConsensus applies a new consensus settings which would get deployed before
 // any of the nodes starts
 func (n Network) SetConsensus(binDir string, consensus config.ConsensusProtocols) error {
-	if len(consensus) > 0 {
-		for _, relayDir := range n.cfg.RelayDirs {
-			relayFulllPath := n.getNodeFullPath(relayDir)
-			nc := nodecontrol.MakeNodeController(binDir, relayFulllPath)
-			err := nc.SetConsensus(consensus)
-			if err != nil {
-				return err
-			}
+	for _, relayDir := range n.cfg.RelayDirs {
+		relayFulllPath := n.getNodeFullPath(relayDir)
+		nc := nodecontrol.MakeNodeController(binDir, relayFulllPath)
+		err := nc.SetConsensus(consensus)
+		if err != nil {
+			return err
 		}
-		for _, nodeDir := range n.nodeDirs {
-			nodeFulllPath := n.getNodeFullPath(nodeDir)
-			nc := nodecontrol.MakeNodeController(binDir, nodeFulllPath)
-			err := nc.SetConsensus(consensus)
-			if err != nil {
-				return err
-			}
+	}
+	for _, nodeDir := range n.nodeDirs {
+		nodeFulllPath := n.getNodeFullPath(nodeDir)
+		nc := nodecontrol.MakeNodeController(binDir, nodeFulllPath)
+		err := nc.SetConsensus(consensus)
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/netdeploy/network.go
+++ b/netdeploy/network.go
@@ -446,20 +446,22 @@ func (n Network) Delete(binDir string) error {
 // SetConsensus applies a new consensus settings which would get deployed before
 // any of the nodes starts
 func (n Network) SetConsensus(binDir string, consensus config.ConsensusProtocols) error {
-	for _, relayDir := range n.cfg.RelayDirs {
-		relayFulllPath := n.getNodeFullPath(relayDir)
-		nc := nodecontrol.MakeNodeController(binDir, relayFulllPath)
-		err := nc.SetConsensus(consensus)
-		if err != nil {
-			return err
+	if len(consensus) > 0 {
+		for _, relayDir := range n.cfg.RelayDirs {
+			relayFulllPath := n.getNodeFullPath(relayDir)
+			nc := nodecontrol.MakeNodeController(binDir, relayFulllPath)
+			err := nc.SetConsensus(consensus)
+			if err != nil {
+				return err
+			}
 		}
-	}
-	for _, nodeDir := range n.nodeDirs {
-		nodeFulllPath := n.getNodeFullPath(nodeDir)
-		nc := nodecontrol.MakeNodeController(binDir, nodeFulllPath)
-		err := nc.SetConsensus(consensus)
-		if err != nil {
-			return err
+		for _, nodeDir := range n.nodeDirs {
+			nodeFulllPath := n.getNodeFullPath(nodeDir)
+			nc := nodecontrol.MakeNodeController(binDir, nodeFulllPath)
+			err := nc.SetConsensus(consensus)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/netdeploy/network_test.go
+++ b/netdeploy/network_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/config"
 )
 
 func TestSaveNetworkCfg(t *testing.T) {
@@ -41,4 +43,46 @@ func TestSaveNetworkCfg(t *testing.T) {
 	a.Nil(err)
 	cfg1, err := loadNetworkCfg(cfgFile)
 	a.Equal(cfg, cfg1)
+}
+
+func TestSaveConsensus(t *testing.T) {
+	a := require.New(t)
+
+	tmpFolder, _ := ioutil.TempDir("", "tmp")
+	defer os.RemoveAll(tmpFolder)
+	relayDir := filepath.Join(tmpFolder, "testRelayDir")
+	err := os.MkdirAll(relayDir, 0744)
+	a.NoError(err)
+	nodeDir := filepath.Join(tmpFolder, "testNodeDir")
+	err = os.MkdirAll(nodeDir, 0744)
+	a.NoError(err)
+
+	net := Network{
+		cfg: NetworkCfg{
+			Name:         "testName",
+			RelayDirs:    []string{relayDir},
+			TemplateFile: "testTemplate",
+		},
+		nodeDirs: map[string]string{
+			"node1": nodeDir,
+		},
+	}
+
+	consensusRelayFilePath := filepath.Join(relayDir, config.ConfigurableConsensusProtocolsFilename)
+	consensusNodeFilePath := filepath.Join(relayDir, config.ConfigurableConsensusProtocolsFilename)
+	err = net.SetConsensus(tmpFolder, nil)
+	a.NoError(err)
+	_, err = os.Open(consensusRelayFilePath)
+	a.True(os.IsNotExist(err), "%s should not have been created", config.ConfigurableConsensusProtocolsFilename)
+	_, err = os.Open(consensusNodeFilePath)
+	a.True(os.IsNotExist(err), "%s should not have been created", config.ConfigurableConsensusProtocolsFilename)
+
+	err = net.SetConsensus(tmpFolder, config.Consensus)
+	a.NoError(err)
+	f, err := os.Open(consensusRelayFilePath)
+	a.False(os.IsNotExist(err), "%s should have been created", config.ConfigurableConsensusProtocolsFilename)
+	f.Close()
+	f, err = os.Open(consensusNodeFilePath)
+	a.False(os.IsNotExist(err), "%s should have been created", config.ConfigurableConsensusProtocolsFilename)
+	f.Close()
 }

--- a/netdeploy/network_test.go
+++ b/netdeploy/network_test.go
@@ -85,4 +85,12 @@ func TestSaveConsensus(t *testing.T) {
 	f, err = os.Open(consensusNodeFilePath)
 	a.False(os.IsNotExist(err), "%s should have been created", config.ConfigurableConsensusProtocolsFilename)
 	f.Close()
+
+	// now that the file exists, try to see if another call to SetConsensus would delete it.
+	err = net.SetConsensus(tmpFolder, nil)
+	a.NoError(err)
+	_, err = os.Open(consensusRelayFilePath)
+	a.True(os.IsNotExist(err), "%s should have been deleted", config.ConfigurableConsensusProtocolsFilename)
+	_, err = os.Open(consensusNodeFilePath)
+	a.True(os.IsNotExist(err), "%s should have been deleted", config.ConfigurableConsensusProtocolsFilename)
 }


### PR DESCRIPTION
## Summary

Using `goal network create` would create a network directories containing a `consensus.json` file. That file would contain the `null` string.

The above file should not have been created. In case no consensus protocol changes are needed for a given network, the expected behavior is of no `consensus.json` file being generated.

## Test Plan

Add a unit test.
