### PR TITLE
network: refactor broadcastThread

### DIFF
--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -54,7 +54,6 @@ import (
 )
 
 const incomingThreads = 20
-const broadcastThreads = 4
 const messageFilterSize = 5000 // messages greater than that size may be blocked by incoming/outgoing filter
 
 // httpServerReadHeaderTimeout is the amount of time allowed to read
@@ -308,8 +307,9 @@ type WebsocketNetwork struct {
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 
-	peersLock deadlock.RWMutex
-	peers     []*wsPeer
+	peersLock          deadlock.RWMutex
+	peers              []*wsPeer
+	peersChangeCounter int32 // peersChangeCounter is an atomic variable that increases on each change to the peers. It helps avoiding taking the peersLock when checking if the peers list was modified.
 
 	broadcastQueueHighPrio chan broadcastRequest
 	broadcastQueueBulk     chan broadcastRequest
@@ -736,10 +736,8 @@ func (wn *WebsocketNetwork) Start() {
 		wn.wg.Add(1)
 		go wn.messageHandlerThread()
 	}
-	for i := 0; i < broadcastThreads; i++ {
-		wn.wg.Add(1)
-		go wn.broadcastThread()
-	}
+	wn.wg.Add(1)
+	go wn.broadcastThread()
 	if wn.prioScheme != nil {
 		wn.wg.Add(1)
 		go wn.prioWeightRefresh()
@@ -1168,28 +1166,51 @@ func (wn *WebsocketNetwork) broadcastThread() {
 	var peers []*wsPeer
 	slowWritingPeerCheckTicker := time.NewTicker(wn.slowWritingPeerMonitorInterval)
 	defer slowWritingPeerCheckTicker.Stop()
+	lastPeersChangeCounter := atomic.LoadInt32(&wn.peersChangeCounter)
 	for {
-		// broadcast from high prio channel as long as we can
-		// we want to try and keep this as a single case select with a default, since go compiles a single-case
-		// select with a default into a more efficient non-blocking receive, instead of compiling it to the general-purpose selectgo
-		select {
-		case request := <-wn.broadcastQueueHighPrio:
-			wn.innerBroadcast(request, true, &peers)
-			continue
-		default:
+		// wait until the we have at least a single peer connected.
+		peers = wn.peerSnapshot(peers)
+		for len(peers) == 0 {
+			select {
+			case <-time.After(5 * time.Millisecond):
+				if curPeersChangeCounter := atomic.LoadInt32(&wn.peersChangeCounter); curPeersChangeCounter != lastPeersChangeCounter {
+					peers = wn.peerSnapshot(peers)
+					lastPeersChangeCounter = curPeersChangeCounter
+				}
+				continue
+			case <-wn.ctx.Done():
+				return
+			}
 		}
 
-		// if nothing high prio, broadcast anything
-		select {
-		case request := <-wn.broadcastQueueHighPrio:
-			wn.innerBroadcast(request, true, &peers)
-		case <-slowWritingPeerCheckTicker.C:
-			wn.checkSlowWritingPeers()
-			continue
-		case request := <-wn.broadcastQueueBulk:
-			wn.innerBroadcast(request, false, &peers)
-		case <-wn.ctx.Done():
-			return
+		for {
+			// broadcast from high prio channel as long as we can
+			// we want to try and keep this as a single case select with a default, since go compiles a single-case
+			// select with a default into a more efficient non-blocking receive, instead of compiling it to the general-purpose selectgo
+			select {
+			case request := <-wn.broadcastQueueHighPrio:
+				wn.innerBroadcast(request, true, peers)
+				continue
+			default:
+			}
+
+			// if nothing high prio, broadcast anything
+			select {
+			case request := <-wn.broadcastQueueHighPrio:
+				wn.innerBroadcast(request, true, peers)
+			case <-slowWritingPeerCheckTicker.C:
+				wn.checkSlowWritingPeers()
+				continue
+			case request := <-wn.broadcastQueueBulk:
+				wn.innerBroadcast(request, false, peers)
+			case <-wn.ctx.Done():
+				return
+			}
+
+			if curPeersChangeCounter := atomic.LoadInt32(&wn.peersChangeCounter); curPeersChangeCounter != lastPeersChangeCounter {
+				lastPeersChangeCounter = curPeersChangeCounter
+				break
+			}
 		}
 	}
 }
@@ -1207,7 +1228,7 @@ func (wn *WebsocketNetwork) peerSnapshot(dest []*wsPeer) []*wsPeer {
 }
 
 // prio is set if the broadcast is a high-priority broadcast.
-func (wn *WebsocketNetwork) innerBroadcast(request broadcastRequest, prio bool, ppeers *[]*wsPeer) {
+func (wn *WebsocketNetwork) innerBroadcast(request broadcastRequest, prio bool, peers []*wsPeer) {
 	if request.done != nil {
 		defer close(request.done)
 	}
@@ -1230,22 +1251,17 @@ func (wn *WebsocketNetwork) innerBroadcast(request broadcastRequest, prio bool, 
 		digest = crypto.Hash(mbytes)
 	}
 
-	*ppeers = wn.peerSnapshot(*ppeers)
-	peers := *ppeers
-
 	// first send to all the easy outbound peers who don't block, get them started.
 	sentMessageCount := 0
-	for pi, peer := range peers {
+	for _, peer := range peers {
 		if wn.config.BroadcastConnectionsLimit >= 0 && sentMessageCount >= wn.config.BroadcastConnectionsLimit {
 			break
 		}
 		if peer == request.except {
-			peers[pi] = nil
 			continue
 		}
 		ok := peer.writeNonBlock(mbytes, prio, digest, request.enqueueTime)
 		if ok {
-			peers[pi] = nil
 			sentMessageCount++
 			continue
 		}
@@ -2027,6 +2043,7 @@ func (wn *WebsocketNetwork) removePeer(peer *wsPeer, reason disconnectReason) {
 		if peer.throttledOutgoingConnection {
 			atomic.AddInt32(&wn.throttledOutgoingConnections, int32(1))
 		}
+		atomic.AddInt32(&wn.peersChangeCounter, 1)
 	}
 	wn.countPeersSetGauges()
 }
@@ -2042,6 +2059,7 @@ func (wn *WebsocketNetwork) addPeer(peer *wsPeer) {
 	}
 	heap.Push(peersHeap{wn}, peer)
 	wn.prioTracker.setPriority(peer, peer.prioAddress, peer.prioWeight)
+	atomic.AddInt32(&wn.peersChangeCounter, 1)
 	wn.countPeersSetGauges()
 	if len(wn.peers) >= wn.config.GossipFanout {
 		// we have a quorum of connected peers, if we weren't ready before, we are now

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1172,8 +1172,12 @@ func (wn *WebsocketNetwork) broadcastThread() {
 		if curPeersChangeCounter := atomic.LoadInt32(&wn.peersChangeCounter); curPeersChangeCounter != lastPeersChangeCounter {
 			peers, lastPeersChangeCounter = wn.peerSnapshot(peers[:0])
 			// clear out the unused portion of the peers array to allow the GC to cleanup unused peers.
-			for i := len(peers); i < cap(peers) && peers[i] != nil; i++ {
-				peers[i] = nil
+			remainderPeers := peers[len(peers):cap(peers)]
+			for i := range remainderPeers {
+				if remainderPeers[i] == nil {
+					break
+				}
+				remainderPeers[i] = nil
 			}
 		}
 	}

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1170,7 +1170,11 @@ func (wn *WebsocketNetwork) broadcastThread() {
 	// updatePeers update the peers list if their peer change counter has changed.
 	updatePeers := func() {
 		if curPeersChangeCounter := atomic.LoadInt32(&wn.peersChangeCounter); curPeersChangeCounter != lastPeersChangeCounter {
-			peers, lastPeersChangeCounter = wn.peerSnapshot(peers)
+			peers, lastPeersChangeCounter = wn.peerSnapshot(peers[:0])
+			// clear out the unused portion of the peers array to allow the GC to cleanup unused peers.
+			for i := len(peers); i < cap(peers) && peers[i] != nil; i++ {
+				peers[i] = nil
+			}
 		}
 	}
 

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1166,7 +1166,6 @@ func (wn *WebsocketNetwork) broadcastThread() {
 
 	slowWritingPeerCheckTicker := time.NewTicker(wn.slowWritingPeerMonitorInterval)
 	defer slowWritingPeerCheckTicker.Stop()
-	lastPeersChangeCounter := atomic.LoadInt32(&wn.peersChangeCounter)
 	peers, lastPeersChangeCounter := wn.peerSnapshot([]*wsPeer{})
 	// updatePeers update the peers list if their peer change counter has changed.
 	updatePeers := func() {

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -1231,7 +1231,7 @@ func TestSlowPeerDisconnection(t *testing.T) {
 	waitReady(t, netB, readyTimeout.C)
 
 	var peers []*wsPeer
-	peers = netA.peerSnapshot(peers)
+	peers, _ = netA.peerSnapshot(peers)
 	require.Equalf(t, len(peers), 1, "Expected number of peers should be 1")
 	peer := peers[0]
 	// modify the peer on netA and
@@ -1240,7 +1240,7 @@ func TestSlowPeerDisconnection(t *testing.T) {
 	// wait up to 10 seconds for the monitor to figure out it needs to disconnect.
 	expire := beforeLoopTime.Add(2 * slowWritingPeerMonitorInterval)
 	for {
-		peers = netA.peerSnapshot(peers)
+		peers, _ = netA.peerSnapshot(peers)
 		if len(peers) == 0 || peers[0] != peer {
 			// make sure it took more than 1 second, and less than 5 seconds.
 			waitTime := time.Now().Sub(beforeLoopTime)

--- a/node/node.go
+++ b/node/node.go
@@ -487,7 +487,7 @@ func (node *AlgorandFullNode) BroadcastSignedTxGroup(txgroup []transactions.Sign
 		enc = append(enc, protocol.Encode(&tx)...)
 		txids = append(txids, tx.ID())
 	}
-	err = node.net.Broadcast(context.TODO(), protocol.TxnTag, enc, true, nil)
+	err = node.net.Broadcast(context.TODO(), protocol.TxnTag, enc, false, nil)
 	if err != nil {
 		node.log.Infof("failure broadcasting transaction to network: %v - transaction group was %+v", err, txgroup)
 		return err


### PR DESCRIPTION
## Summary

The broadcastThread implementation was sub-optimal, and this PR addresses the issues we had there -
1. The broadcastThread is now using a single broadcasting go-routine rather than 4.
2. The broadcastThread/innerBroadcast used to drop queued messages just because there are no current peers. Instead, it will hold off until there is an available peer before queuing up the messages to the peers.
3. The peers array is being updated only if there is enough "wait time" between consecutive messages. In case of a high message burst, the peers would not get updated to avoid taking the peers lock.
4. The node's broadcast call was replaced with non-blocking to align with previous behavior.
5. The single thread implementation would ensure that queued messages would also be sent to the underlying peers at the order in which they were enqueued. This, in turn would ensure message id monotonicity.

## Test Plan

Unit tests updated, performance tests shown no regression.
