### PR TITLE
bugfix: prevent misleading agreement error message

### DIFF
--- a/data/basics/units.go
+++ b/data/basics/units.go
@@ -121,7 +121,7 @@ func OneTimeIDForRound(round Round, keyDilution uint64) crypto.OneTimeSignatureI
 	}
 }
 
-// SubSaturate subtracts two rounds with saturation arithmetic that does not
+// SubSaturate subtracts x rounds with saturation arithmetic that does not
 // wrap around past zero, and instead returns 0 on underflow.
 func (round Round) SubSaturate(x Round) Round {
 	if round < x {

--- a/data/bookkeeping/block.go
+++ b/data/bookkeeping/block.go
@@ -179,11 +179,15 @@ type (
 	// (instead of materializing it separately, like balances).
 	//msgp:ignore UpgradeState
 	UpgradeState struct {
-		CurrentProtocol        protocol.ConsensusVersion `codec:"proto"`
-		NextProtocol           protocol.ConsensusVersion `codec:"nextproto"`
-		NextProtocolApprovals  uint64                    `codec:"nextyes"`
-		NextProtocolVoteBefore basics.Round              `codec:"nextbefore"`
-		NextProtocolSwitchOn   basics.Round              `codec:"nextswitch"`
+		CurrentProtocol       protocol.ConsensusVersion `codec:"proto"`
+		NextProtocol          protocol.ConsensusVersion `codec:"nextproto"`
+		NextProtocolApprovals uint64                    `codec:"nextyes"`
+		// NextProtocolVoteBefore specify the last voting round for the next protocol proposal. If there is no voting for
+		// an upgrade taking place, this would be zero.
+		NextProtocolVoteBefore basics.Round `codec:"nextbefore"`
+		// NextProtocolSwitchOn specify the round number at which the next protocol would be adopted. If there is no upgrade taking place,
+		// nor a wait for the next protocol, this would be zero.
+		NextProtocolSwitchOn basics.Round `codec:"nextswitch"`
 	}
 
 	// CompactCertState tracks the state of compact certificates.

--- a/data/ledger.go
+++ b/data/ledger.go
@@ -308,15 +308,48 @@ func (l *Ledger) ConsensusParams(r basics.Round) (config.ConsensusParams, error)
 }
 
 // ConsensusVersion gives the consensus version agreed on in a given round,
-// returning an error if we don't have that round or we have an
-// I/O error.
+// returning an error if the consensus version could not be figured using
+// either the block header for the given round, or the latest block header.
 // Implements agreement.Ledger.ConsensusVersion
 func (l *Ledger) ConsensusVersion(r basics.Round) (protocol.ConsensusVersion, error) {
 	blockhdr, err := l.BlockHdr(r)
-	if err != nil {
+	if err == nil {
+		return blockhdr.UpgradeState.CurrentProtocol, nil
+	}
+	// try to see if we can figure out what the version would be.
+	latestRound := l.Latest()
+	// if the request round was for an older round, then just say the we don't know.
+	if r < latestRound {
 		return "", err
 	}
-	return blockhdr.UpgradeState.CurrentProtocol, nil
+	// the request was for a future round. See if we have any known plans for the next round.
+	latestBlockhdr, err := l.BlockHdr(latestRound)
+	// if we have the lastest block header, look inside and try to figure out if we can deduce the
+	// protocol version for the given round.
+	if err == nil {
+		// check to see if we have a protocol upgrade.
+		if latestBlockhdr.NextProtocolSwitchOn == 0 {
+			// no protocol upgrade taking place, which implies the next round has the same version as the current one.
+			if r == (latestBlockhdr.Round + 1) {
+				return latestBlockhdr.CurrentProtocol, nil
+			}
+			// otherwise, we can't really tell.
+			return "", ledgercore.ErrNoEntry{Round: r, Latest: latestRound, Committed: latestRound}
+		}
+		// in this case, we do have a protocol upgrade taking place.
+		if r < latestBlockhdr.NextProtocolSwitchOn {
+			// if we're in the voting duration or uprade waiting period, then the protocol version is the current version.
+			return latestBlockhdr.CurrentProtocol, nil
+		}
+		// if the requested round aligns with the protocol version switch version and we've passed the voting period, then we know that on the switching round
+		// we will be using the next protocol.
+		if r == latestBlockhdr.NextProtocolSwitchOn && latestBlockhdr.Round >= latestBlockhdr.NextProtocolVoteBefore {
+			return latestBlockhdr.NextProtocol, nil
+		}
+		err = ledgercore.ErrNoEntry{Round: r, Latest: latestRound, Committed: latestRound}
+	}
+	// otherwise, we can't really tell what the protocol version would be at round r.
+	return "", err
 }
 
 // EnsureValidatedBlock ensures that the block, and associated certificate c, are

--- a/data/ledger_test.go
+++ b/data/ledger_test.go
@@ -359,15 +359,17 @@ func TestConsensusVersion(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, previousProtocol, ver)
 	}
-	// the next round can also be known to have the previous version.
-	ver, err := l.ConsensusVersion(basics.Round(consensusParams.MaxTxnLife + 5))
-	require.NoError(t, err)
-	require.Equal(t, previousProtocol, ver)
+	// the next UpgradeVoteRounds can also be known to have the previous version.
+	for rnd := basics.Round(consensusParams.MaxTxnLife + 5); rnd < basics.Round(consensusParams.MaxTxnLife+5+consensusParams.UpgradeVoteRounds); rnd++ {
+		ver, err := l.ConsensusVersion(rnd)
+		require.NoError(t, err)
+		require.Equal(t, previousProtocol, ver)
+	}
 
 	// but two rounds ahead is not known.
-	ver, err = l.ConsensusVersion(basics.Round(consensusParams.MaxTxnLife + 6))
+	ver, err := l.ConsensusVersion(basics.Round(consensusParams.MaxTxnLife + 6 + consensusParams.UpgradeVoteRounds))
 	require.Equal(t, protocol.ConsensusVersion(""), ver)
-	require.Equal(t, ledgercore.ErrNoEntry{Round: basics.Round(consensusParams.MaxTxnLife + 6), Latest: basics.Round(consensusParams.MaxTxnLife + 4), Committed: basics.Round(consensusParams.MaxTxnLife + 4)}, err)
+	require.Equal(t, ledgercore.ErrNoEntry{Round: basics.Round(consensusParams.MaxTxnLife + 6 + consensusParams.UpgradeVoteRounds), Latest: basics.Round(consensusParams.MaxTxnLife + 4), Committed: basics.Round(consensusParams.MaxTxnLife + 4)}, err)
 
 	// check round #1 which was already dropped.
 	ver, err = l.ConsensusVersion(basics.Round(1))

--- a/data/ledger_test.go
+++ b/data/ledger_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
-
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 )
@@ -312,4 +312,104 @@ func TestLedgerSeed(t *testing.T) {
 		}
 	}
 	return
+}
+
+func TestConsensusVersion(t *testing.T) {
+	// find a consensus protocol that leads to ConsensusCurrentVersion
+	var previousProtocol protocol.ConsensusVersion
+	for ver, params := range config.Consensus {
+		if _, has := params.ApprovedUpgrades[protocol.ConsensusCurrentVersion]; has {
+			previousProtocol = ver
+			break
+		}
+	}
+	require.NotEqual(t, protocol.ConsensusVersion(""), previousProtocol)
+	consensusParams := config.Consensus[previousProtocol]
+
+	genesisInitState, _ := testGenerateInitState(t, previousProtocol)
+
+	const inMem = true
+	cfg := config.GetDefaultLocal()
+	cfg.Archival = false
+	log := logging.TestingLog(t)
+	log.SetLevel(logging.Warn)
+	realLedger, err := ledger.OpenLedger(log, t.Name(), inMem, genesisInitState, cfg)
+	require.NoError(t, err, "could not open ledger")
+	defer realLedger.Close()
+
+	l := Ledger{Ledger: realLedger}
+	require.NotNil(t, &l)
+
+	blk := genesisInitState.Block
+
+	// add 5 blocks.
+	for rnd := basics.Round(1); rnd < basics.Round(consensusParams.MaxTxnLife+5); rnd++ {
+		blk.BlockHeader.Round++
+		blk.BlockHeader.Seed[0] = byte(uint64(rnd))
+		blk.BlockHeader.Seed[1] = byte(uint64(rnd) / 256)
+		blk.BlockHeader.Seed[2] = byte(uint64(rnd) / 65536)
+		blk.BlockHeader.TimeStamp += int64(crypto.RandUint64() % 100 * 1000)
+		blk.BlockHeader.CurrentProtocol = previousProtocol
+		require.NoError(t, l.AddBlock(blk, agreement.Certificate{}))
+		l.WaitForCommit(rnd)
+	}
+	// ensure that all the first 5 has the expected version.
+	for rnd := basics.Round(consensusParams.MaxTxnLife); rnd < basics.Round(consensusParams.MaxTxnLife+5); rnd++ {
+		ver, err := l.ConsensusVersion(rnd)
+		require.NoError(t, err)
+		require.Equal(t, previousProtocol, ver)
+	}
+	// the next round can also be known to have the previous version.
+	ver, err := l.ConsensusVersion(basics.Round(consensusParams.MaxTxnLife + 5))
+	require.NoError(t, err)
+	require.Equal(t, previousProtocol, ver)
+
+	// but two rounds ahead is not known.
+	ver, err = l.ConsensusVersion(basics.Round(consensusParams.MaxTxnLife + 6))
+	require.Equal(t, protocol.ConsensusVersion(""), ver)
+	require.Equal(t, ledgercore.ErrNoEntry{Round: basics.Round(consensusParams.MaxTxnLife + 6), Latest: basics.Round(consensusParams.MaxTxnLife + 4), Committed: basics.Round(consensusParams.MaxTxnLife + 4)}, err)
+
+	// check round #1 which was already dropped.
+	ver, err = l.ConsensusVersion(basics.Round(1))
+	require.Equal(t, protocol.ConsensusVersion(""), ver)
+	require.Equal(t, ledgercore.ErrNoEntry{Round: basics.Round(1), Latest: basics.Round(consensusParams.MaxTxnLife + 4), Committed: basics.Round(consensusParams.MaxTxnLife + 4)}, err)
+
+	// add another round, with upgrade
+	rnd := basics.Round(consensusParams.MaxTxnLife + 5)
+	blk.BlockHeader.Round++
+	blk.BlockHeader.Seed[0] = byte(uint64(rnd))
+	blk.BlockHeader.Seed[1] = byte(uint64(rnd) / 256)
+	blk.BlockHeader.Seed[2] = byte(uint64(rnd) / 65536)
+	blk.BlockHeader.TimeStamp += int64(crypto.RandUint64() % 100 * 1000)
+	blk.BlockHeader.CurrentProtocol = previousProtocol
+	blk.BlockHeader.NextProtocol = protocol.ConsensusCurrentVersion
+	blk.BlockHeader.NextProtocolVoteBefore = basics.Round(rnd) + basics.Round(consensusParams.UpgradeVoteRounds)
+	blk.BlockHeader.NextProtocolSwitchOn = basics.Round(rnd) + basics.Round(consensusParams.UpgradeVoteRounds) + basics.Round(consensusParams.ApprovedUpgrades[protocol.ConsensusCurrentVersion])
+	require.NoError(t, l.AddBlock(blk, agreement.Certificate{}))
+	l.WaitForCommit(rnd)
+
+	for ; rnd < blk.BlockHeader.NextProtocolSwitchOn; rnd++ {
+		ver, err := l.ConsensusVersion(rnd)
+		require.NoError(t, err)
+		require.Equal(t, previousProtocol, ver)
+	}
+
+	for rnd = blk.BlockHeader.Round; rnd <= blk.BlockHeader.NextProtocolVoteBefore; rnd++ {
+		blk.BlockHeader.Round++
+		blk.BlockHeader.Seed[0] = byte(uint64(rnd))
+		blk.BlockHeader.Seed[1] = byte(uint64(rnd) / 256)
+		blk.BlockHeader.Seed[2] = byte(uint64(rnd) / 65536)
+		blk.BlockHeader.NextProtocolApprovals++
+		blk.BlockHeader.TimeStamp += int64(crypto.RandUint64() % 100 * 1000)
+		require.NoError(t, l.AddBlock(blk, agreement.Certificate{}))
+		l.WaitForCommit(rnd)
+	}
+
+	ver, err = l.ConsensusVersion(blk.BlockHeader.NextProtocolSwitchOn)
+	require.NoError(t, err)
+	require.Equal(t, protocol.ConsensusCurrentVersion, ver)
+
+	ver, err = l.ConsensusVersion(blk.BlockHeader.NextProtocolSwitchOn + 1)
+	require.Equal(t, protocol.ConsensusVersion(""), ver)
+	require.Equal(t, ledgercore.ErrNoEntry{Round: basics.Round(blk.BlockHeader.NextProtocolSwitchOn + 1), Latest: basics.Round(blk.BlockHeader.Round), Committed: basics.Round(blk.BlockHeader.Round)}, err)
 }


### PR DESCRIPTION
## Summary

The agreement was printing out the following error message:
```
 (1) unable to retrieve consensus version for round 8764517, defaulting to binary consensus version
```

The culprit was a recent change to the [agreement initialization code](https://github.com/algorand/go-algorand/pull/1896) that would try to use the consensus version of the next round in order to find out some of the agreement runtime parameters.

This PR improves the data.Ledger.ConsensusVersion logic, allowing it to "predict" future protocol versions, based on known and previously agreed upon block headers.

## Test Plan

Unit test added.
