### PR TITLE
Remove the network v1 fetcher via websocket connections.

### DIFF
--- a/catchup/fetcher_test.go
+++ b/catchup/fetcher_test.go
@@ -867,7 +867,7 @@ func TestGetBlockWS(t *testing.T) {
 
 	cfg := config.GetDefaultLocal()
 
-	versions := []string{"1", "2.1"}
+	versions := []string{"2.1"}
 	for _, version := range versions { // range network.SupportedProtocolVersions {
 
 		net := &httpTestPeerSource{}

--- a/cmd/catchupsrv/main.go
+++ b/cmd/catchupsrv/main.go
@@ -85,7 +85,7 @@ func main() {
 		requestHeader := make(http.Header)
 		requestHeader.Set(network.GenesisHeader, genesisID)
 		requestHeader.Set(network.NodeRandomHeader, base64.StdEncoding.EncodeToString(rnd[:]))
-		requestHeader.Set(network.ProtocolVersionHeader, "1")
+		requestHeader.Set(network.ProtocolVersionHeader, "2.1")
 
 		conn, err := upgrader.Upgrade(w, r, requestHeader)
 		if err != nil {

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1783,10 +1783,14 @@ const ProtocolVersionHeader = "X-Algorand-Version"
 const ProtocolAcceptVersionHeader = "X-Algorand-Accept-Version"
 
 // SupportedProtocolVersions contains the list of supported protocol versions by this node ( in order of preference ).
-var SupportedProtocolVersions = []string{"2.1", "1"}
+var SupportedProtocolVersions = []string{"2.1"}
 
 // ProtocolVersion is the current version attached to the ProtocolVersionHeader header
-const ProtocolVersion = "1"
+/* Version history:
+ *  1   Catchup service over websocket connections with unicast messages between peers
+ *  2.1 Introducted topic key/data pairs and enabled services over the gossip connections
+*/
+const ProtocolVersion = "2.1"
 
 // TelemetryIDHeader HTTP header for telemetry-id for logging
 const TelemetryIDHeader = "X-Algorand-TelId"

--- a/rpcs/wsFetcherService.go
+++ b/rpcs/wsFetcherService.go
@@ -115,28 +115,7 @@ func (fs *WsFetcherService) RequestBlock(ctx context.Context, target network.Uni
 		delete(fs.pendingRequests, waitKey)
 		fs.mu.Unlock()
 	}()
-	if target.Version() == "1" {
-		req := WsGetBlockRequest{Round: uint64(round)}
-		err := target.Unicast(ctx, protocol.EncodeReflect(req), tag)
-		if err != nil {
-			return WsGetBlockOut{}, fmt.Errorf("WsFetcherService.RequestBlock(%d): unicast failed, %v", round, err)
-		}
-		select {
-		case resp := <-waitCh:
-			return resp, nil
-		case <-ctx.Done():
-			switch ctx.Err() {
-			case context.DeadlineExceeded:
-				return WsGetBlockOut{}, fmt.Errorf("WsFetcherService.RequestBlock(%d): request to %s was timed out", round, target.GetAddress())
-			case context.Canceled:
-				return WsGetBlockOut{}, fmt.Errorf("WsFetcherService.RequestBlock(%d): request to %s was cancelled by context", round, target.GetAddress())
-			default:
-				return WsGetBlockOut{}, ctx.Err()
-			}
-		}
-	}
 
-	// Else, if version == 2.1
 	roundBin := make([]byte, binary.MaxVarintLen64)
 	binary.PutUvarint(roundBin, uint64(round))
 	topics := network.Topics{

--- a/test/e2e-go/features/catchup/basicCatchup_test.go
+++ b/test/e2e-go/features/catchup/basicCatchup_test.go
@@ -78,12 +78,6 @@ func TestCatchupOverGossip(t *testing.T) {
 	t.Parallel()
 	// ledger node upgraded version, fetcher node upgraded version
 	runCatchupOverGossip(t, false, false)
-	// ledger node older version, fetcher node upgraded version
-	runCatchupOverGossip(t, true, false)
-	// ledger node upgraded older version, fetcher node older version
-	runCatchupOverGossip(t, false, true)
-	// ledger node older version, fetcher node older version
-	runCatchupOverGossip(t, true, true)
 }
 
 func runCatchupOverGossip(t *testing.T,

--- a/test/e2e-go/features/catchup/basicCatchup_test.go
+++ b/test/e2e-go/features/catchup/basicCatchup_test.go
@@ -78,15 +78,17 @@ func TestBasicCatchup(t *testing.T) {
 func TestCatchupOverGossip(t *testing.T) {
 	t.Parallel()
 
-	versions := network.SupportedProtocolVersions
-	require.LessOrEqual(t, len(versions), 3)
+	supportedVersions := network.SupportedProtocolVersions
+	require.LessOrEqual(t, len(supportedVersions), 3)
 
 	// ledger node upgraded version, fetcher node upgraded version
-	for i := 0; i < len(versions); i++ {
-		runCatchupOverGossip(t, "", "")
-		runCatchupOverGossip(t, versions[i], "")
-		runCatchupOverGossip(t, "", versions[i])
-		runCatchupOverGossip(t, versions[i], versions[i])
+	// Run with the default values. Instead of "", pass the default value
+	// to exercise loading it from the config file. 
+	runCatchupOverGossip(t, supportedVersions[0], supportedVersions[0])
+	for i := 1; i < len(supportedVersions); i++ {
+		runCatchupOverGossip(t, supportedVersions[i], "")
+		runCatchupOverGossip(t, "", supportedVersions[i])
+		runCatchupOverGossip(t, supportedVersions[i], supportedVersions[i])
 	}
 }
 
@@ -115,6 +117,7 @@ func runCatchupOverGossip(t *testing.T,
 		a.NoError(err)
 		cfg, err := config.LoadConfigFromDisk(dir)
 		a.NoError(err)
+		require.Empty(t, cfg.NetworkProtocolVersion)
 		cfg.NetworkProtocolVersion = ledgerNodeDowngradeTo
 		cfg.SaveToDisk(dir)
 	}
@@ -124,6 +127,7 @@ func runCatchupOverGossip(t *testing.T,
 		dir := fixture.PrimaryDataDir()
 		cfg, err := config.LoadConfigFromDisk(dir)
 		a.NoError(err)
+		require.Empty(t, cfg.NetworkProtocolVersion)
 		cfg.NetworkProtocolVersion = fetcherNodeDowngradeTo
 		cfg.SaveToDisk(dir)
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Remove the network v1 fetcher service via websocket connections.

## Test Plan

This is only removing unused code. The existing tests should be sufficient. 