### PR TITLE
Remove GOPATH dependencies in integration tests

### DIFF
--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -86,7 +86,7 @@ python3 -m venv ${TEMPDIR}/ve
 . ${TEMPDIR}/ve/bin/activate
 ${TEMPDIR}/ve/bin/pip3 install --upgrade pip
 ${TEMPDIR}/ve/bin/pip3 install --upgrade py-algorand-sdk cryptography
-${TEMPDIR}/ve/bin/python3 e2e_client_runner.py e2e_subs/*.sh
+${TEMPDIR}/ve/bin/python3 e2e_client_runner.py "$SRCROOT"/test/scripts/e2e_subs/*.sh
 deactivate
 
 # Export our root temp folder as 'TESTDIR' for tests to use as their root test folder

--- a/test/scripts/e2e_client_runner.py
+++ b/test/scripts/e2e_client_runner.py
@@ -3,10 +3,11 @@
 # Create a local private network and run functional tests on it in parallel.
 #
 # Each test is run as `ftest.sh wallet_name` for a wallet with a
-# million Algos.  A test should carefully specify that wallet (or
-# wallets created for the test) for all actions. Tests are expected to
-# not be CPU intensive, merely setting up a handful of transactions
-# and executing them against the network, exercising aspects of the
+# million Algos, with the current directory set to the top of the
+# repo.  A test should carefully specify that wallet (or wallets
+# created for the test) for all actions. Tests are expected to not be
+# CPU intensive, merely setting up a handful of transactions and
+# executing them against the network, exercising aspects of the
 # network and the goal tools.
 #
 # Usage:
@@ -33,6 +34,9 @@ import threading
 import algosdk
 
 logger = logging.getLogger(__name__)
+
+scriptdir = os.path.dirname(os.path.realpath(__file__))
+repodir =  os.path.join(scriptdir, "..", "..")
 
 # less than 16kB of log we show the whole thing, otherwise the last 16kB
 LOG_WHOLE_CUTOFF = 1024 * 16
@@ -104,7 +108,7 @@ def _script_thread_inner(runset, scriptname):
         runset.done(scriptname, False, time.time() - start)
         return
     logger.info('starting %s', scriptname)
-    p = subprocess.Popen([scriptname, walletname], env=env, stdout=cmdlog, stderr=subprocess.STDOUT)
+    p = subprocess.Popen([scriptname, walletname], env=env, cwd=repodir, stdout=cmdlog, stderr=subprocess.STDOUT)
     cmdlog.close()
     runset.running(scriptname, p)
     timeout = read_script_for_timeout(scriptname)
@@ -387,13 +391,8 @@ def main():
     netdir = os.path.join(tempdir, 'net')
     env['NETDIR'] = netdir
 
-    gopath = os.getenv('GOPATH')
-    if not gopath:
-        logger.error('$GOPATH not set')
-        sys.exit(1)
-
     retcode = 0
-    xrun(['goal', 'network', 'create', '-r', netdir, '-n', 'tbd', '-t', os.path.join(gopath, 'src/github.com/algorand/go-algorand/test/testdata/nettemplates/TwoNodes50EachFuture.json')], timeout=90)
+    xrun(['goal', 'network', 'create', '-r', netdir, '-n', 'tbd', '-t', os.path.join(repodir, 'test/testdata/nettemplates/TwoNodes50EachFuture.json')], timeout=90)
     xrun(['goal', 'network', 'start', '-r', netdir], timeout=90)
     atexit.register(goal_network_stop, netdir, env)
 

--- a/test/scripts/e2e_subs/dynamic-fee-teal-test.sh
+++ b/test/scripts/e2e_subs/dynamic-fee-teal-test.sh
@@ -22,7 +22,7 @@ LEASE=uImiLf+mqOqs0BFsqIUHBh436N/z964X50e3P9Ii4ac=
 ${gcmd} clerk send -a 100000000 -f ${ACCOUNT} -t ${ACCOUNTB}
 
 # Generate the template
-algotmpl -d ${GOPATH}/src/github.com/algorand/go-algorand/tools/teal/templates/ dynamic-fee --amt=1000000 --cls=${ACCOUNTC} --to=${ACCOUNTD} --fv=1 --lv=1001 --lease=${LEASE} > ${TEMPDIR}/dynamic.teal
+algotmpl -d tools/teal/templates/ dynamic-fee --amt=1000000 --cls=${ACCOUNTC} --to=${ACCOUNTD} --fv=1 --lv=1001 --lease=${LEASE} > ${TEMPDIR}/dynamic.teal
 
 #
 # Fee will come from ACCOUNT in the first transaction

--- a/test/scripts/e2e_subs/e2e-teal.sh
+++ b/test/scripts/e2e_subs/e2e-teal.sh
@@ -21,7 +21,7 @@ ROUND=$(goal node status | grep 'Last committed block:'|awk '{ print $4 }')
 TIMEOUT_ROUND=$((${ROUND} + 14))
 
 # timeout after 14 rounds
-python ${GOPATH}/src/github.com/algorand/go-algorand/data/transactions/logic/tlhc.py --from ${ACCOUNT} --to ${ACCOUNTB} --timeout-round ${TIMEOUT_ROUND} > ${TEMPDIR}/tlhc.teal 2> ${TEMPDIR}/tlhc.teal.secret
+python data/transactions/logic/tlhc.py --from ${ACCOUNT} --to ${ACCOUNTB} --timeout-round ${TIMEOUT_ROUND} > ${TEMPDIR}/tlhc.teal 2> ${TEMPDIR}/tlhc.teal.secret
 
 cat ${TEMPDIR}/tlhc.teal
 

--- a/test/scripts/e2e_subs/htlc-teal-test.sh
+++ b/test/scripts/e2e_subs/htlc-teal-test.sh
@@ -17,7 +17,7 @@ ZERO_ADDRESS=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ
 LEASE=YmxhaCBibGFoIGxlYXNlIHdoYXRldmVyIGJsYWghISE=
 
 # Generate the template
-algotmpl -d ${GOPATH}/src/github.com/algorand/go-algorand/tools/teal/templates/ htlc --fee=2000 --hashfn="sha256" --hashimg="9S+9MrKzuG/4jvbEkGKChfSCrxXdyylUH5S89Saj9sc=" --own=${ACCOUNT} --rcv=${ACCOUNTB} --timeout=100000 > ${TEMPDIR}/atomic.teal
+algotmpl -d tools/teal/templates/ htlc --fee=2000 --hashfn="sha256" --hashimg="9S+9MrKzuG/4jvbEkGKChfSCrxXdyylUH5S89Saj9sc=" --own=${ACCOUNT} --rcv=${ACCOUNTB} --timeout=100000 > ${TEMPDIR}/atomic.teal
 
 # Compile the template
 CONTRACT=$(${gcmd} clerk compile ${TEMPDIR}/atomic.teal | awk '{ print $2 }')

--- a/test/scripts/e2e_subs/keyreg-teal-test.sh
+++ b/test/scripts/e2e_subs/keyreg-teal-test.sh
@@ -24,7 +24,7 @@ FEE=100000
 echo "generating new delegate and participation keys for newly-funded account ${ACCOUNTA}"
 ${gcmd} clerk send --from ${ACCOUNT} --to ${ACCOUNTA} -a 1000000
 DELKEY=$(algokey generate -f ${TEMPDIR}/delegate.keyregkey | grep "Public key" | awk '{ print $3 }')
-algotmpl -d ${GOPATH}/src/github.com/algorand/go-algorand/tools/teal/templates/ delegate-key-registration --fee ${FEE} --dur ${DUR} --period ${PERIOD} --expire ${EXPIRE} --auth ${DELKEY} --lease ${LEASE} > ${TEMPDIR}/delegate.teal
+algotmpl -d tools/teal/templates/ delegate-key-registration --fee ${FEE} --dur ${DUR} --period ${PERIOD} --expire ${EXPIRE} --auth ${DELKEY} --lease ${LEASE} > ${TEMPDIR}/delegate.teal
 ${gcmd} clerk compile -a ${ACCOUNTA} -s -o ${TEMPDIR}/kr.lsig ${TEMPDIR}/delegate.teal
 
 RES=$(${gcmd} account addpartkey -a ${ACCOUNTA} --roundFirstValid 0 --roundLastValid 100)
@@ -115,7 +115,7 @@ FEE=100000
 
 ${gcmd} clerk send --from ${ACCOUNT} --to ${ACCOUNTB} -a 1000000
 DELKEY=$(algokey generate -f ${TEMPDIR}/delegate.keyregkey | grep "Public key" | awk '{ print $3 }')
-algotmpl -d ${GOPATH}/src/github.com/algorand/go-algorand/tools/teal/templates/ delegate-key-registration --fee ${FEE} --dur ${DUR} --period ${PERIOD} --expire ${EXPIRE} --auth ${DELKEY} --lease ${LEASE} > ${TEMPDIR}/delegate.teal
+algotmpl -d tools/teal/templates/ delegate-key-registration --fee ${FEE} --dur ${DUR} --period ${PERIOD} --expire ${EXPIRE} --auth ${DELKEY} --lease ${LEASE} > ${TEMPDIR}/delegate.teal
 ${gcmd} clerk compile -a ${ACCOUNTB} -s -o ${TEMPDIR}/kr.lsig ${TEMPDIR}/delegate.teal
 
 RES=$(${gcmd} account addpartkey -a ${ACCOUNTB} --roundFirstValid 0 --roundLastValid 100)

--- a/test/scripts/e2e_subs/limit-swap-test.sh
+++ b/test/scripts/e2e_subs/limit-swap-test.sh
@@ -26,7 +26,7 @@ echo "closeout part a, Algo trader"
 ROUND=$(goal node status | grep 'Last committed block:'|awk '{ print $4 }')
 TIMEOUT_ROUND=$((${ROUND} + 2))
 
-sed s/TMPL_ASSET/${ASSET_ID}/g < ${GOPATH}/src/github.com/algorand/go-algorand/tools/teal/templates/limit-order-a.teal.tmpl | sed s/TMPL_SWAPN/31337/g | sed s/TMPL_SWAPD/137/g | sed s/TMPL_TIMEOUT/${TIMEOUT_ROUND}/g | sed s/TMPL_OWN/${ACCOUNT}/g | sed s/TMPL_FEE/100000/g | sed s/TMPL_MINTRD/10000/g > ${TEMPDIR}/limit-order-a.teal
+sed s/TMPL_ASSET/${ASSET_ID}/g < tools/teal/templates/limit-order-a.teal.tmpl | sed s/TMPL_SWAPN/31337/g | sed s/TMPL_SWAPD/137/g | sed s/TMPL_TIMEOUT/${TIMEOUT_ROUND}/g | sed s/TMPL_OWN/${ACCOUNT}/g | sed s/TMPL_FEE/100000/g | sed s/TMPL_MINTRD/10000/g > ${TEMPDIR}/limit-order-a.teal
 
 ACCOUNT_ALGO_TRADER=$(${gcmd} clerk compile ${TEMPDIR}/limit-order-a.teal -o ${TEMPDIR}/limit-order-a.tealc|awk '{ print $2 }')
 
@@ -45,7 +45,7 @@ ROUND=$(goal node status | grep 'Last committed block:'|awk '{ print $4 }')
 SETUP_ROUND=$((${ROUND} + 10))
 TIMEOUT_ROUND=$((${SETUP_ROUND} + 1))
 
-sed s/TMPL_ASSET/${ASSET_ID}/g < ${GOPATH}/src/github.com/algorand/go-algorand/tools/teal/templates/limit-order-b.teal.tmpl | sed s/TMPL_SWAPN/137/g | sed s/TMPL_SWAPD/31337/g | sed s/TMPL_TIMEOUT/${TIMEOUT_ROUND}/g | sed s/TMPL_OWN/${ACCOUNT}/g | sed s/TMPL_FEE/100000/g | sed s/TMPL_MINTRD/10000/g > ${TEMPDIR}/limit-order-b.teal
+sed s/TMPL_ASSET/${ASSET_ID}/g < tools/teal/templates/limit-order-b.teal.tmpl | sed s/TMPL_SWAPN/137/g | sed s/TMPL_SWAPD/31337/g | sed s/TMPL_TIMEOUT/${TIMEOUT_ROUND}/g | sed s/TMPL_OWN/${ACCOUNT}/g | sed s/TMPL_FEE/100000/g | sed s/TMPL_MINTRD/10000/g > ${TEMPDIR}/limit-order-b.teal
 
 
 ACCOUNT_ASSET_TRADER=$(${gcmd} clerk compile ${TEMPDIR}/limit-order-b.teal -o ${TEMPDIR}/limit-order-b.tealc|awk '{ print $2 }')
@@ -94,7 +94,7 @@ ROUND=$(goal node status | grep 'Last committed block:'|awk '{ print $4 }')
 SETUP_ROUND=$((${ROUND} + 199))
 TIMEOUT_ROUND=$((${SETUP_ROUND} + 1))
 
-sed s/TMPL_ASSET/${ASSET_ID}/g < ${GOPATH}/src/github.com/algorand/go-algorand/tools/teal/templates/limit-order-b.teal.tmpl | sed s/TMPL_SWAPN/137/g | sed s/TMPL_SWAPD/31337/g | sed s/TMPL_TIMEOUT/${TIMEOUT_ROUND}/g | sed s/TMPL_OWN/${ACCOUNT}/g | sed s/TMPL_FEE/100000/g | sed s/TMPL_MINTRD/10000/g > ${TEMPDIR}/limit-order-b.teal
+sed s/TMPL_ASSET/${ASSET_ID}/g < tools/teal/templates/limit-order-b.teal.tmpl | sed s/TMPL_SWAPN/137/g | sed s/TMPL_SWAPD/31337/g | sed s/TMPL_TIMEOUT/${TIMEOUT_ROUND}/g | sed s/TMPL_OWN/${ACCOUNT}/g | sed s/TMPL_FEE/100000/g | sed s/TMPL_MINTRD/10000/g > ${TEMPDIR}/limit-order-b.teal
 
 ACCOUNT_ASSET_TRADER=$(${gcmd} clerk compile ${TEMPDIR}/limit-order-b.teal -o ${TEMPDIR}/limit-order-b.tealc|awk '{ print $2 }')
 
@@ -115,7 +115,7 @@ ${gcmd} asset send --assetid ${ASSET_ID} -f ${ACCOUNT} -t ${ACCOUNT_ASSET_TRADER
 
 echo "make Algo trader"
 
-sed s/TMPL_ASSET/${ASSET_ID}/g < ${GOPATH}/src/github.com/algorand/go-algorand/tools/teal/templates/limit-order-a.teal.tmpl | sed s/TMPL_SWAPN/31337/g | sed s/TMPL_SWAPD/137/g | sed s/TMPL_TIMEOUT/${TIMEOUT_ROUND}/g | sed s/TMPL_OWN/${ACCOUNT}/g | sed s/TMPL_FEE/100000/g | sed s/TMPL_MINTRD/10000/g > ${TEMPDIR}/limit-order-a.teal
+sed s/TMPL_ASSET/${ASSET_ID}/g < tools/teal/templates/limit-order-a.teal.tmpl | sed s/TMPL_SWAPN/31337/g | sed s/TMPL_SWAPD/137/g | sed s/TMPL_TIMEOUT/${TIMEOUT_ROUND}/g | sed s/TMPL_OWN/${ACCOUNT}/g | sed s/TMPL_FEE/100000/g | sed s/TMPL_MINTRD/10000/g > ${TEMPDIR}/limit-order-a.teal
 
 ACCOUNT_ALGO_TRADER=$(${gcmd} clerk compile ${TEMPDIR}/limit-order-a.teal -o ${TEMPDIR}/limit-order-a.tealc|awk '{ print $2 }')
 

--- a/test/scripts/e2e_subs/periodic-teal-test.sh
+++ b/test/scripts/e2e_subs/periodic-teal-test.sh
@@ -16,7 +16,7 @@ ACCOUNTB=$(${gcmd} account new|awk '{ print $6 }')
 ZERO_ADDRESS=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ
 LEASE=YmxhaCBibGFoIGxlYXNlIHdoYXRldmVyIGJsYWghISE=
 
-sed s/TMPL_RCV/${ACCOUNTB}/g < ${GOPATH}/src/github.com/algorand/go-algorand/tools/teal/templates/periodic-payment-escrow.teal.tmpl | sed s/TMPL_PERIOD/5/g | sed s/TMPL_DUR/2/g | sed s/TMPL_AMT/100000/g | sed s/TMPL_LEASE/${LEASE}/g | sed s/TMPL_TIMEOUT/16/g | sed s/TMPL_FEE/10000/g > ${TEMPDIR}/periodic.teal
+sed s/TMPL_RCV/${ACCOUNTB}/g < tools/teal/templates/periodic-payment-escrow.teal.tmpl | sed s/TMPL_PERIOD/5/g | sed s/TMPL_DUR/2/g | sed s/TMPL_AMT/100000/g | sed s/TMPL_LEASE/${LEASE}/g | sed s/TMPL_TIMEOUT/16/g | sed s/TMPL_FEE/10000/g > ${TEMPDIR}/periodic.teal
 
 ACCOUNT_PERIODIC=$(${gcmd} clerk compile ${TEMPDIR}/periodic.teal -o ${TEMPDIR}/periodic.tealc|awk '{ print $2 }')
 

--- a/test/scripts/e2e_subs/teal-split-test.sh
+++ b/test/scripts/e2e_subs/teal-split-test.sh
@@ -16,7 +16,7 @@ ACCOUNT=$(${gcmd} account list|awk '{ print $3 }')
 ACCOUNTB=$(${gcmd} account new|awk '{ print $6 }')
 ACCOUNTC=$(${gcmd} account new|awk '{ print $6 }')
 
-sed s/TMPL_RCV1/${ACCOUNTB}/g < ${GOPATH}/src/github.com/algorand/go-algorand/tools/teal/templates/split.teal.tmpl | sed s/TMPL_RCV2/${ACCOUNTC}/g | sed s/TMPL_RAT1/60/g | sed s/TMPL_RAT2/40/g | sed s/TMPL_MINPAY/100000/g | sed s/TMPL_TIMEOUT/4/g | sed s/TMPL_OWN/${ACCOUNTB}/g | sed s/TMPL_FEE/10000/g > ${TEMPDIR}/split.teal
+sed s/TMPL_RCV1/${ACCOUNTB}/g < tools/teal/templates/split.teal.tmpl | sed s/TMPL_RCV2/${ACCOUNTC}/g | sed s/TMPL_RAT1/60/g | sed s/TMPL_RAT2/40/g | sed s/TMPL_MINPAY/100000/g | sed s/TMPL_TIMEOUT/4/g | sed s/TMPL_OWN/${ACCOUNTB}/g | sed s/TMPL_FEE/10000/g > ${TEMPDIR}/split.teal
 
 ACCOUNT_SPLIT=$(${gcmd} clerk compile ${TEMPDIR}/split.teal -o ${TEMPDIR}/split.tealc|awk '{ print $2 }')
 


### PR DESCRIPTION
This allows running integration tests without a repo under GOPATH.

## Summary

Tests had been using GOPATH, but mostly just to find the top of the repo to
refer to tests.  This breaks if doing module oriented stuff outside of
GOPATH. These changes make it so that e2e.sh uses the full name of the
e2e test files, and e2e_client_runner executes the e2e scripts with
cwd set to top of repo.  That allowed removing the few places those
scripts used GOPATH, in favor of relative filenames.


## Test Plan

It *is* the tests.  Was able to run integration tests in my local development environment,
which was impossible without these changes, as I don't work under GOPATH.  That is the way
forward with Go, so we should get ready.  I will be checking if CI broke in any way by watching
it!
