### PR TITLE
Use total stake instead of online money

### DIFF
--- a/agreement/abstractions.go
+++ b/agreement/abstractions.go
@@ -146,6 +146,15 @@ type LedgerReader interface {
 	// protocol may lose liveness.
 	Circulation(basics.Round) (basics.MicroAlgos, error)
 
+	// TotalStake returns the total amount of accounts stake at the conclusion of a
+	// given round.
+	//
+	// This method returns an error if the given Round has not yet been
+	// confirmed. It may also return an error if the given Round is
+	// unavailable by the storage device. In that case, the agreement
+	// protocol may lose liveness.
+	TotalStake(basics.Round) (basics.MicroAlgos, error)
+
 	// LookupDigest returns the Digest of the entry that was agreed on in a
 	// given round.
 	//

--- a/agreement/common_test.go
+++ b/agreement/common_test.go
@@ -336,6 +336,10 @@ func (l *testLedger) Lookup(r basics.Round, a basics.Address) (basics.AccountDat
 	return l.state[a], nil
 }
 
+func (l *testLedger) TotalStake(r basics.Round) (basics.MicroAlgos, error) {
+	return l.Circulation(r)
+}
+
 func (l *testLedger) Circulation(r basics.Round) (basics.MicroAlgos, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/agreement/demux_test.go
+++ b/agreement/demux_test.go
@@ -487,6 +487,12 @@ func (t *demuxTester) Lookup(basics.Round, basics.Address) (basics.AccountData, 
 }
 
 // implement Ledger
+func (t *demuxTester) TotalStake(basics.Round) (basics.MicroAlgos, error) {
+	// we don't care about this function in this test.
+	return basics.MicroAlgos{}, nil
+}
+
+// implement Ledger
 func (t *demuxTester) Circulation(basics.Round) (basics.MicroAlgos, error) {
 	// we don't care about this function in this test.
 	return basics.MicroAlgos{}, nil

--- a/agreement/fuzzer/ledger_test.go
+++ b/agreement/fuzzer/ledger_test.go
@@ -237,6 +237,26 @@ func (l *testLedger) Lookup(r basics.Round, a basics.Address) (basics.AccountDat
 	return l.state[a], nil
 }
 
+func (l *testLedger) TotalStake(r basics.Round) (basics.MicroAlgos, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if r >= l.nextRound {
+		err := fmt.Errorf("TotalStake called on future round: %d >= %d! (this is probably a bug)", r, l.nextRound)
+		panic(err)
+	}
+
+	var sum basics.MicroAlgos
+	var overflowed bool
+	for _, rec := range l.state {
+		sum, overflowed = basics.OAddA(sum, rec.VotingStake())
+		if overflowed {
+			panic("total stake computation overflowed")
+		}
+	}
+	return sum, nil
+}
+
 func (l *testLedger) Circulation(r basics.Round) (basics.MicroAlgos, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/agreement/selector.go
+++ b/agreement/selector.go
@@ -55,7 +55,7 @@ func seedRound(r basics.Round, cparams config.ConsensusParams) basics.Round {
 	return r.SubSaturate(basics.Round(cparams.SeedLookback))
 }
 
-// a helper function for obtaining memberhship verification parameters.
+// a helper function for obtaining membership verification parameters.
 func membership(l LedgerReader, addr basics.Address, r basics.Round, p period, s step) (m committee.Membership, err error) {
 	cparams, err := l.ConsensusParams(ParamsRound(r))
 	if err != nil {
@@ -70,7 +70,7 @@ func membership(l LedgerReader, addr basics.Address, r basics.Round, p period, s
 		return
 	}
 
-	total, err := l.Circulation(balanceRound)
+	total, err := l.TotalStake(balanceRound)
 	if err != nil {
 		err = fmt.Errorf("Service.initializeVote (r=%d): Failed to obtain total circulation in round %d: %v", r, balanceRound, err)
 		return

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -555,6 +555,9 @@ func (m *mockedLedger) Block(r basics.Round) (bookkeeping.Block, error) {
 func (m *mockedLedger) Lookup(basics.Round, basics.Address) (basics.AccountData, error) {
 	return basics.AccountData{}, errors.New("not needed for mockedLedger")
 }
+func (m *mockedLedger) TotalStake(basics.Round) (basics.MicroAlgos, error) {
+	return basics.MicroAlgos{}, errors.New("not needed for mockedLedger")
+}
 func (m *mockedLedger) Circulation(basics.Round) (basics.MicroAlgos, error) {
 	return basics.MicroAlgos{}, errors.New("not needed for mockedLedger")
 }

--- a/data/basics/userBalance_test.go
+++ b/data/basics/userBalance_test.go
@@ -46,7 +46,8 @@ func TestRewards(t *testing.T) {
 
 		levels := []uint64{uint64(0), uint64(1), uint64(30), uint64(3000)}
 		for _, level := range levels {
-			money, rewards := ad.Money(proto, ad.RewardsBase+level)
+			money := ad.WithUpdatedRewards(proto, ad.RewardsBase+level).Money()
+			rewards := ad.WithUpdatedRewards(proto, ad.RewardsBase+level).RewardedMicroAlgos
 			require.Equal(t, money.Raw, ad.MicroAlgos.Raw+level*ad.MicroAlgos.RewardUnits(proto))
 			require.Equal(t, rewards.Raw, ad.RewardedMicroAlgos.Raw+level*ad.MicroAlgos.RewardUnits(proto))
 		}

--- a/data/datatest/impls.go
+++ b/data/datatest/impls.go
@@ -106,6 +106,11 @@ func (i ledgerImpl) Lookup(r basics.Round, addr basics.Address) (basics.AccountD
 	return i.l.Lookup(r, addr)
 }
 
+// TotalStake implements Ledger.TotalStake.
+func (i ledgerImpl) TotalStake(r basics.Round) (basics.MicroAlgos, error) {
+	return i.l.TotalStake(r)
+}
+
 // Circulation implements Ledger.Circulation.
 func (i ledgerImpl) Circulation(r basics.Round) (basics.MicroAlgos, error) {
 	return i.l.Circulation(r)

--- a/ledger/ledgercore/msgp_gen.go
+++ b/ledger/ledgercore/msgp_gen.go
@@ -28,8 +28,8 @@ import (
 func (z *AccountTotals) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0001Len := uint32(4)
-	var zb0001Mask uint8 /* 5 bits */
+	zb0001Len := uint32(5)
+	var zb0001Mask uint8 /* 6 bits */
 	if ((*z).NotParticipating.Money.MsgIsZero()) && ((*z).NotParticipating.RewardUnits == 0) {
 		zb0001Len--
 		zb0001Mask |= 0x2
@@ -45,6 +45,10 @@ func (z *AccountTotals) MarshalMsg(b []byte) (o []byte) {
 	if (*z).RewardsLevel == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x10
+	}
+	if (*z).Stake.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x20
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -134,6 +138,11 @@ func (z *AccountTotals) MarshalMsg(b []byte) (o []byte) {
 			// string "rwdlvl"
 			o = append(o, 0xa6, 0x72, 0x77, 0x64, 0x6c, 0x76, 0x6c)
 			o = msgp.AppendUint64(o, (*z).RewardsLevel)
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not empty
+			// string "stake"
+			o = append(o, 0xa5, 0x73, 0x74, 0x61, 0x6b, 0x65)
+			o = (*z).Stake.MarshalMsg(o)
 		}
 	}
 	return
@@ -371,6 +380,14 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 					}
 				}
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).Stake.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Stake")
+				return
 			}
 		}
 		if zb0001 > 0 {
@@ -614,6 +631,12 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 					}
 				}
+			case "stake":
+				bts, err = (*z).Stake.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Stake")
+					return
+				}
 			case "rwdlvl":
 				(*z).RewardsLevel, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
@@ -640,13 +663,13 @@ func (_ *AccountTotals) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *AccountTotals) Msgsize() (s int) {
-	s = 1 + 7 + 1 + 4 + (*z).Online.Money.Msgsize() + 4 + msgp.Uint64Size + 8 + 1 + 4 + (*z).Offline.Money.Msgsize() + 4 + msgp.Uint64Size + 8 + 1 + 4 + (*z).NotParticipating.Money.Msgsize() + 4 + msgp.Uint64Size + 7 + msgp.Uint64Size
+	s = 1 + 7 + 1 + 4 + (*z).Online.Money.Msgsize() + 4 + msgp.Uint64Size + 8 + 1 + 4 + (*z).Offline.Money.Msgsize() + 4 + msgp.Uint64Size + 8 + 1 + 4 + (*z).NotParticipating.Money.Msgsize() + 4 + msgp.Uint64Size + 6 + (*z).Stake.Msgsize() + 7 + msgp.Uint64Size
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *AccountTotals) MsgIsZero() bool {
-	return (((*z).Online.Money.MsgIsZero()) && ((*z).Online.RewardUnits == 0)) && (((*z).Offline.Money.MsgIsZero()) && ((*z).Offline.RewardUnits == 0)) && (((*z).NotParticipating.Money.MsgIsZero()) && ((*z).NotParticipating.RewardUnits == 0)) && ((*z).RewardsLevel == 0)
+	return (((*z).Online.Money.MsgIsZero()) && ((*z).Online.RewardUnits == 0)) && (((*z).Offline.Money.MsgIsZero()) && ((*z).Offline.RewardUnits == 0)) && (((*z).NotParticipating.Money.MsgIsZero()) && ((*z).NotParticipating.RewardUnits == 0)) && ((*z).Stake.MsgIsZero()) && ((*z).RewardsLevel == 0)
 }
 
 // MarshalMsg implements msgp.Marshaler


### PR DESCRIPTION

### Summary

Currently `AccountData` struct has a `VotingStake` method, but there is no way for calculating the sum of voting stake of all accounts. We can only calculate the total money of online accounts. As a result, it's not possible to easily implement different agreement protocols by changing the behavior of `VotingStake` method.

This PR will add `TotalStake` method to `LedgerReader` interface which returns the sum of all accounts voting stake.

### Test Plan

I think current tests should be enough.
To be honest, I'm not sure if I've made all the necessary changes to the code.
