### PR TITLE
1k+ assets (part 2)

### DIFF
--- a/cmd/tealdbg/localLedger.go
+++ b/cmd/tealdbg/localLedger.go
@@ -23,12 +23,10 @@ import (
 	"math/rand"
 	"net/http"
 
-	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	v2 "github.com/algorand/go-algorand/daemon/algod/api/server/v2"
 	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
 	"github.com/algorand/go-algorand/data/basics"
-	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger"
 	"github.com/algorand/go-algorand/ledger/apply"
@@ -268,14 +266,6 @@ func getRandomAddress() (basics.Address, error) {
 
 	address := crypto.Hash(b)
 	return basics.Address(address), nil
-}
-
-func (l *localLedger) BlockHdr(basics.Round) (bookkeeping.BlockHeader, error) {
-	return bookkeeping.BlockHeader{}, nil
-}
-
-func (l *localLedger) CheckDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, ledger.TxLease) error {
-	return nil
 }
 
 func (l *localLedger) LookupWithoutRewards(rnd basics.Round, addr basics.Address) (basics.AccountData, basics.Round, error) {

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -252,14 +252,6 @@ func (dl *dryrunLedger) init() error {
 	return nil
 }
 
-func (dl *dryrunLedger) BlockHdr(basics.Round) (bookkeeping.BlockHeader, error) {
-	return bookkeeping.BlockHeader{}, nil
-}
-
-func (dl *dryrunLedger) CheckDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, ledger.TxLease) error {
-	return nil
-}
-
 func (dl *dryrunLedger) LookupWithoutRewards(rnd basics.Round, addr basics.Address) (basics.AccountData, basics.Round, error) {
 	// check accounts from debug records uploaded
 	any := false

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -855,7 +855,7 @@ func (aul *accountUpdatesLedgerEvaluator) Totals(rnd basics.Round) (ledgercore.A
 }
 
 // CheckDup test to see if the given transaction id/lease already exists. It's not needed by the accountUpdatesLedgerEvaluator and implemented as a stub.
-func (aul *accountUpdatesLedgerEvaluator) CheckDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, TxLease) error {
+func (aul *accountUpdatesLedgerEvaluator) checkDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, TxLease) error {
 	// this is a non-issue since this call will never be made on non-validating evaluation
 	return fmt.Errorf("accountUpdatesLedgerEvaluator: tried to check for dup during accountUpdates initialization ")
 }
@@ -866,7 +866,7 @@ func (aul *accountUpdatesLedgerEvaluator) LookupWithoutRewards(rnd basics.Round,
 }
 
 // GetCreatorForRound returns the asset/app creator for a given asset/app index at a given round
-func (aul *accountUpdatesLedgerEvaluator) GetCreatorForRound(rnd basics.Round, cidx basics.CreatableIndex, ctype basics.CreatableType) (creator basics.Address, ok bool, err error) {
+func (aul *accountUpdatesLedgerEvaluator) getCreatorForRound(rnd basics.Round, cidx basics.CreatableIndex, ctype basics.CreatableType) (creator basics.Address, ok bool, err error) {
 	return aul.au.getCreatorForRound(rnd, cidx, ctype, false /* don't sync */)
 }
 

--- a/ledger/appcow.go
+++ b/ledger/appcow.go
@@ -19,13 +19,9 @@ package ledger
 import (
 	"fmt"
 
-	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/basics"
-	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/data/transactions/logic"
-	"github.com/algorand/go-algorand/ledger/apply"
-	"github.com/algorand/go-algorand/protocol"
 )
 
 type storageAction uint64
@@ -386,23 +382,6 @@ func (cb *roundCowState) DelKey(addr basics.Address, aidx basics.AppIndex, globa
 	}
 
 	return nil // note: deletion cannot cause us to violate maxCount
-}
-
-// MakeDebugBalances creates a ledger suitable for dryrun and debugger
-func MakeDebugBalances(l ledgerForCowBase, round basics.Round, proto protocol.ConsensusVersion, prevTimestamp int64) apply.Balances {
-	base := &roundCowBase{
-		l:     l,
-		rnd:   round - 1,
-		proto: config.Consensus[proto],
-	}
-
-	hdr := bookkeeping.BlockHeader{
-		Round:        round,
-		UpgradeState: bookkeeping.UpgradeState{CurrentProtocol: proto},
-	}
-	hint := 2
-	cb := makeRoundCowState(base, hdr, prevTimestamp, hint)
-	return cb
 }
 
 // StatefulEval runs application.

--- a/ledger/appdbg.go
+++ b/ledger/appdbg.go
@@ -39,7 +39,7 @@ func (w *ledgerForCowBaseWrapper) BlockHdr(basics.Round) (bookkeeping.BlockHeade
 	return bookkeeping.BlockHeader{}, nil
 }
 
-func (w *ledgerForCowBaseWrapper) CheckDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, TxLease) error {
+func (w *ledgerForCowBaseWrapper) checkDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, TxLease) error {
 	return nil
 }
 
@@ -47,7 +47,7 @@ func (w *ledgerForCowBaseWrapper) LookupWithoutRewards(rnd basics.Round, addr ba
 	return w.l.LookupWithoutRewards(rnd, addr)
 }
 
-func (w *ledgerForCowBaseWrapper) GetCreatorForRound(rnd basics.Round, cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.Address, bool, error) {
+func (w *ledgerForCowBaseWrapper) getCreatorForRound(rnd basics.Round, cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.Address, bool, error) {
 	return w.l.GetCreatorForRound(rnd, cidx, ctype)
 }
 

--- a/ledger/appdbg.go
+++ b/ledger/appdbg.go
@@ -1,0 +1,71 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package ledger
+
+import (
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/ledger/apply"
+	"github.com/algorand/go-algorand/protocol"
+)
+
+// ApplicationDbgLedger is a subset of ledgerForCowBase for external use (dryrun, tealdbg)
+type ApplicationDbgLedger interface {
+	LookupWithoutRewards(basics.Round, basics.Address) (basics.AccountData, basics.Round, error)
+	GetCreatorForRound(basics.Round, basics.CreatableIndex, basics.CreatableType) (basics.Address, bool, error)
+}
+
+type ledgerForCowBaseWrapper struct {
+	l ApplicationDbgLedger
+}
+
+func (w *ledgerForCowBaseWrapper) BlockHdr(basics.Round) (bookkeeping.BlockHeader, error) {
+	return bookkeeping.BlockHeader{}, nil
+}
+
+func (w *ledgerForCowBaseWrapper) CheckDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, TxLease) error {
+	return nil
+}
+
+func (w *ledgerForCowBaseWrapper) LookupWithoutRewards(rnd basics.Round, addr basics.Address) (basics.AccountData, basics.Round, error) {
+	return w.l.LookupWithoutRewards(rnd, addr)
+}
+
+func (w *ledgerForCowBaseWrapper) GetCreatorForRound(rnd basics.Round, cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.Address, bool, error) {
+	return w.l.GetCreatorForRound(rnd, cidx, ctype)
+}
+
+// MakeDebugBalances creates a ledger suitable for dryrun and debugger
+func MakeDebugBalances(l ApplicationDbgLedger, round basics.Round, proto protocol.ConsensusVersion, prevTimestamp int64) apply.Balances {
+	w := ledgerForCowBaseWrapper{l}
+
+	base := &roundCowBase{
+		l:     &w,
+		rnd:   round - 1,
+		proto: config.Consensus[proto],
+	}
+
+	hdr := bookkeeping.BlockHeader{
+		Round:        round,
+		UpgradeState: bookkeeping.UpgradeState{CurrentProtocol: proto},
+	}
+	hint := 2
+	cb := makeRoundCowState(base, hdr, prevTimestamp, hint)
+	return cb
+}

--- a/ledger/appdbg.go
+++ b/ledger/appdbg.go
@@ -22,6 +22,7 @@ import (
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger/apply"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -45,6 +46,11 @@ func (w *ledgerForCowBaseWrapper) checkDup(config.ConsensusParams, basics.Round,
 
 func (w *ledgerForCowBaseWrapper) LookupWithoutRewards(rnd basics.Round, addr basics.Address) (basics.AccountData, basics.Round, error) {
 	return w.l.LookupWithoutRewards(rnd, addr)
+}
+
+func (w *ledgerForCowBaseWrapper) lookupWithoutRewards(rnd basics.Round, addr basics.Address) (ledgercore.PersistedAccountData, basics.Round, error) {
+	ad, rnd, err := w.l.LookupWithoutRewards(rnd, addr)
+	return ledgercore.PersistedAccountData{AccountData: ad}, rnd, err
 }
 
 func (w *ledgerForCowBaseWrapper) getCreatorForRound(rnd basics.Round, cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.Address, bool, error) {

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -335,6 +335,7 @@ type ledgerForCowBase interface {
 	BlockHdr(basics.Round) (bookkeeping.BlockHeader, error)
 	LookupWithoutRewards(basics.Round, basics.Address) (basics.AccountData, basics.Round, error)
 
+	lookupWithoutRewards(basics.Round, basics.Address) (ledgercore.PersistedAccountData, basics.Round, error)
 	checkDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, TxLease) error
 	getCreatorForRound(basics.Round, basics.CreatableIndex, basics.CreatableType) (basics.Address, bool, error)
 }

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -65,7 +65,7 @@ type roundCowBase struct {
 }
 
 func (x *roundCowBase) getCreator(cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.Address, bool, error) {
-	return x.l.GetCreatorForRound(x.rnd, cidx, ctype)
+	return x.l.getCreatorForRound(x.rnd, cidx, ctype)
 }
 
 func (x *roundCowBase) lookup(addr basics.Address) (acctData basics.AccountData, err error) {
@@ -74,7 +74,7 @@ func (x *roundCowBase) lookup(addr basics.Address) (acctData basics.AccountData,
 }
 
 func (x *roundCowBase) checkDup(firstValid, lastValid basics.Round, txid transactions.Txid, txl ledgercore.Txlease) error {
-	return x.l.CheckDup(x.proto, x.rnd+1, firstValid, lastValid, txid, TxLease{txl})
+	return x.l.checkDup(x.proto, x.rnd+1, firstValid, lastValid, txid, TxLease{txl})
 }
 
 func (x *roundCowBase) txnCounter() uint64 {
@@ -333,9 +333,10 @@ type ledgerForEvaluator interface {
 // ledgerForCowBase represents subset of Ledger functionality needed for cow business
 type ledgerForCowBase interface {
 	BlockHdr(basics.Round) (bookkeeping.BlockHeader, error)
-	CheckDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, TxLease) error
 	LookupWithoutRewards(basics.Round, basics.Address) (basics.AccountData, basics.Round, error)
-	GetCreatorForRound(basics.Round, basics.CreatableIndex, basics.CreatableType) (basics.Address, bool, error)
+
+	checkDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, TxLease) error
+	getCreatorForRound(basics.Round, basics.CreatableIndex, basics.CreatableType) (basics.Address, bool, error)
 }
 
 // StartEvaluator creates a BlockEvaluator, given a ledger and a block header

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -404,7 +404,7 @@ func (l *Ledger) GetLastCatchpointLabel() string {
 // GetCreatorForRound takes a CreatableIndex and a CreatableType and tries to
 // look up a creator address, setting ok to false if the query succeeded but no
 // creator was found.
-func (l *Ledger) GetCreatorForRound(rnd basics.Round, cidx basics.CreatableIndex, ctype basics.CreatableType) (creator basics.Address, ok bool, err error) {
+func (l *Ledger) getCreatorForRound(rnd basics.Round, cidx basics.CreatableIndex, ctype basics.CreatableType) (creator basics.Address, ok bool, err error) {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()
 	return l.accts.GetCreatorForRound(rnd, cidx, ctype)
@@ -483,7 +483,7 @@ func (l *Ledger) Totals(rnd basics.Round) (ledgercore.AccountTotals, error) {
 }
 
 // CheckDup return whether a transaction is a duplicate one.
-func (l *Ledger) CheckDup(currentProto config.ConsensusParams, current basics.Round, firstValid basics.Round, lastValid basics.Round, txid transactions.Txid, txl TxLease) error {
+func (l *Ledger) checkDup(currentProto config.ConsensusParams, current basics.Round, firstValid basics.Round, lastValid basics.Round, txid transactions.Txid, txl TxLease) error {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()
 	return l.txTail.checkDup(currentProto, current, firstValid, lastValid, txid, txl.Txlease)

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -464,15 +464,20 @@ func (l *Ledger) Lookup(rnd basics.Round, addr basics.Address) (basics.AccountDa
 // LookupWithoutRewards is like Lookup but does not apply pending rewards up
 // to the requested round rnd.
 func (l *Ledger) LookupWithoutRewards(rnd basics.Round, addr basics.Address) (basics.AccountData, basics.Round, error) {
+	pad, rnd, err := l.lookupWithoutRewards(rnd, addr)
+	return pad.AccountData, rnd, err
+}
+
+func (l *Ledger) lookupWithoutRewards(rnd basics.Round, addr basics.Address) (ledgercore.PersistedAccountData, basics.Round, error) {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()
 
-	data, validThrough, err := l.accts.LookupWithoutRewards(rnd, addr)
+	pad, validThrough, err := l.accts.LookupWithoutRewards(rnd, addr)
 	if err != nil {
-		return basics.AccountData{}, basics.Round(0), err
+		return ledgercore.PersistedAccountData{}, basics.Round(0), err
 	}
 
-	return data, validThrough, nil
+	return pad, validThrough, nil
 }
 
 // Totals returns the totals of all accounts at the end of round rnd.


### PR DESCRIPTION
## Summary

Introduce `ApplicationDbgLedger` interface to use in tealdbg and dryrun. This is to properly isolate internal `legderForCowBase` and allow its extension.
