### PR TITLE
1k+ assets (part 5)

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -49,8 +49,7 @@ type accountsDbQueries struct {
 	selectCatchpointStateString *sql.Stmt
 	insertCatchpointStateString *sql.Stmt
 
-	// these are lazily initialized
-	loadAssetHoldingGroupStmt *sql.Stmt
+	loadAccountGroupDataStmt *sql.Stmt
 }
 
 var accountsSchema = []string{
@@ -158,9 +157,10 @@ type compactAccountDeltas struct {
 }
 
 type accountDelta struct {
-	old     dbAccountData
-	new     basics.AccountData
-	ndeltas int
+	old      dbAccountData
+	new      ledgercore.PersistedAccountData
+	holdings map[basics.AssetIndex]ledgercore.HoldingAction
+	ndeltas  int
 }
 
 // catchpointState is used to store catchpoint related variables into the catchpointstate table.
@@ -226,22 +226,26 @@ func makeCompactAccountDeltas(accountDeltas []ledgercore.AccountDeltas, baseAcco
 	for _, roundDelta := range accountDeltas {
 		for i := 0; i < roundDelta.Len(); i++ {
 			addr, acctDelta := roundDelta.GetByIdx(i)
+			hmap := roundDelta.GetHoldingDeltas(addr)
 			if prev, idx := outAccountDeltas.get(addr); idx != -1 {
 				outAccountDeltas.update(idx, accountDelta{ // update instead of upsert economizes one map lookup
-					old:     prev.old,
-					new:     acctDelta,
-					ndeltas: prev.ndeltas + 1,
+					old:      prev.old,
+					new:      acctDelta,
+					holdings: hmap,
+					ndeltas:  prev.ndeltas + 1,
 				})
 			} else {
 				// it's a new entry.
 				newEntry := accountDelta{
-					new:     acctDelta,
-					ndeltas: 1,
+					new:      acctDelta,
+					holdings: hmap,
+					ndeltas:  1,
 				}
 				if baseAccountData, has := baseAccounts.read(addr); has {
 					newEntry.old = baseAccountData
 					outAccountDeltas.insert(addr, newEntry) // insert instead of upsert economizes one map lookup
 				} else {
+					// missing old entries will be populated in accountsLoadOld
 					outAccountDeltas.insertMissing(addr, newEntry)
 				}
 			}
@@ -285,27 +289,53 @@ func (a *compactAccountDeltas) accountsLoadOld(tx *sql.Tx) (err error) {
 					return err
 				}
 
-				// fetch holdings that are in new
-				// these are either new or modified, and needed to be written back later.
-				// to simplify upcoming reconciliation load them now
-				_, delta := a.getByIdx(idx)
-				if len(delta.new.Assets) > 0 && len(dbad.pad.Assets) == 0 {
-					dbad.pad.Assets = make(map[basics.AssetIndex]basics.AssetHolding, len(delta.new.Assets))
-				}
-				for aidx := range delta.new.Assets {
-					if _, ok := dbad.pad.AccountData.Assets[aidx]; !ok {
+				// accountsLoadOld is called from commitRound as db.Atomic => safe to load data without additional sync
+				if dbad.pad.ExtendedAssetHolding.Count > 0 {
+					// fetch holdings that are in new
+					// these are either new or modified, and needed to be written back later.
+					// to simplify upcoming reconciliation load them now
+					_, delta := a.getByIdx(idx)
+					if len(delta.new.Assets) > 0 && len(dbad.pad.AccountData.Assets) == 0 {
+						dbad.pad.AccountData.Assets = make(map[basics.AssetIndex]basics.AssetHolding, len(delta.new.Assets))
+					}
+
+					// load created and deleted asset holding groups
+					for aidx, action := range delta.holdings {
+						gi := -1
+						if action == ledgercore.ActionCreate {
+							// use FindGroup to find a possible matching group for insertion
+							gi = dbad.pad.ExtendedAssetHolding.FindGroup(aidx, 0)
+						} else if action == ledgercore.ActionDelete {
+							gi, _ = dbad.pad.ExtendedAssetHolding.FindAsset(aidx, 0)
+						}
+						if gi != -1 {
+							g := &dbad.pad.ExtendedAssetHolding.Groups[gi]
+							if !g.Loaded() {
+								groupData, err := loadHoldingGroupData(loadStmt, g.AssetGroupKey)
+								if err != nil {
+									return err
+								}
+								g.Load(groupData)
+							}
+						}
+					}
+
+					// load updated assets
+					for aidx := range delta.new.Assets {
 						gi, ai := dbad.pad.ExtendedAssetHolding.FindAsset(aidx, 0)
 						if gi != -1 {
 							g := &dbad.pad.ExtendedAssetHolding.Groups[gi]
-							groupData, err := loadAssetHoldingGroupData(loadStmt, g.AssetGroupKey)
-							if err != nil {
-								return err
+							if !g.Loaded() {
+								groupData, err := loadHoldingGroupData(loadStmt, g.AssetGroupKey)
+								if err != nil {
+									return err
+								}
+								g.Load(groupData)
 							}
-							g.Load(groupData)
 							_, ai = dbad.pad.ExtendedAssetHolding.FindAsset(aidx, gi)
 							if ai != -1 {
 								// found!
-								dbad.pad.AccountData.Assets[aidx] = groupData.GetHolding(ai)
+								dbad.pad.AccountData.Assets[aidx] = g.GetHolding(ai)
 							} else {
 								// no such asset => newly created
 							}
@@ -771,6 +801,9 @@ func accountsRound(tx *sql.Tx) (rnd basics.Round, hashrnd basics.Round, err erro
 	return
 }
 
+const lookupAcctBaseQuery string = "SELECT accountbase.rowid, rnd, data FROM acctrounds LEFT JOIN accountbase ON address=? WHERE id='acctbase'"
+const loadAcctExtQuery string = "SELECT data FROM accountext WHERE id=?"
+
 func accountsDbInit(r db.Queryable, w db.Queryable) (*accountsDbQueries, error) {
 	var err error
 	qs := &accountsDbQueries{}
@@ -780,7 +813,7 @@ func accountsDbInit(r db.Queryable, w db.Queryable) (*accountsDbQueries, error) 
 		return nil, err
 	}
 
-	qs.lookupStmt, err = r.Prepare("SELECT accountbase.rowid, rnd, data FROM acctrounds LEFT JOIN accountbase ON address=? WHERE id='acctbase'")
+	qs.lookupStmt, err = r.Prepare(lookupAcctBaseQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -830,7 +863,7 @@ func accountsDbInit(r db.Queryable, w db.Queryable) (*accountsDbQueries, error) 
 		return nil, err
 	}
 
-	qs.loadAssetHoldingGroupStmt, err = r.Prepare("SELECT data from accountext WHERE id=?")
+	qs.loadAccountGroupDataStmt, err = r.Prepare(loadAcctExtQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -900,28 +933,83 @@ func (qs *accountsDbQueries) lookupCreator(cidx basics.CreatableIndex, ctype bas
 // be retrieved.
 func (qs *accountsDbQueries) lookup(addr basics.Address) (data dbAccountData, err error) {
 	err = db.Retry(func() error {
-		var buf []byte
-		var rowid sql.NullInt64
-		err := qs.lookupStmt.QueryRow(addr[:]).Scan(&rowid, &data.round, &buf)
-		if err == nil {
-			data.addr = addr
-			if len(buf) > 0 && rowid.Valid {
-				data.rowid = rowid.Int64
-				return protocol.Decode(buf, &data.pad)
-			}
-			// we don't have that account, just return the database round.
-			return nil
-		}
-
-		// this should never happen; it indicates that we don't have a current round in the acctrounds table.
-		if err == sql.ErrNoRows {
-			// Return the zero value of data
-			return fmt.Errorf("unable to query account data for address %v : %w", addr, err)
-		}
-
+		data, err = lookupImpl(qs.lookupStmt, addr)
 		return err
 	})
 
+	return
+}
+
+func lookupImpl(lookupStmt *sql.Stmt, addr basics.Address) (data dbAccountData, err error) {
+	var buf []byte
+	var rowid sql.NullInt64
+	err = lookupStmt.QueryRow(addr[:]).Scan(&rowid, &data.round, &buf)
+	if err == nil {
+		data.addr = addr
+		if len(buf) > 0 && rowid.Valid {
+			data.rowid = rowid.Int64
+			err = protocol.Decode(buf, &data.pad)
+			return data, err
+		}
+		// we don't have that account, just return the database round.
+		return data, nil
+	}
+
+	// this should never happen; it indicates that we don't have a current round in the acctrounds table.
+	if err == sql.ErrNoRows {
+		// Return the zero value of data
+		return data, fmt.Errorf("unable to query account data for address %v : %w", addr, err)
+	}
+
+	return
+}
+
+func lookupExt(rdb db.Accessor, addr basics.Address, extension func(*sql.Stmt, *ledgercore.PersistedAccountData) error) (data dbAccountData, err error) {
+	rdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		lookupStmt, err := tx.Prepare(lookupAcctBaseQuery)
+		if err != nil {
+			return err
+		}
+		loadStmt, err := tx.Prepare(loadAcctExtQuery)
+		if err != nil {
+			return err
+		}
+
+		data, err = lookupImpl(lookupStmt, addr)
+		if err != nil {
+			return err
+		}
+
+		if extension != nil && data.pad.ExtendedAssetHolding.Count > 0 {
+			err = extension(loadStmt, &data.pad)
+		}
+		return err
+	})
+
+	return
+}
+
+// lookupFull atomically loads base account data and all extension groups
+func lookupFull(rdb db.Accessor, addr basics.Address) (data dbAccountData, err error) {
+	rdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		lookupStmt, err := tx.Prepare(lookupAcctBaseQuery)
+		if err != nil {
+			return err
+		}
+		loadStmt, err := tx.Prepare(loadAcctExtQuery)
+		if err != nil {
+			return err
+		}
+
+		data, err = lookupImpl(lookupStmt, addr)
+		if err != nil {
+			return err
+		}
+		if data.pad.ExtendedAssetHolding.Count > 0 {
+			data.pad.Assets, data.pad.ExtendedAssetHolding, err = loadHoldings(loadStmt, data.pad.ExtendedAssetHolding)
+		}
+		return err
+	})
 	return
 }
 
@@ -1033,7 +1121,7 @@ func (qs *accountsDbQueries) close() {
 		&qs.listCreatablesStmt,
 		&qs.lookupStmt,
 		&qs.lookupCreatorStmt,
-		&qs.loadAssetHoldingGroupStmt,
+		&qs.loadAccountGroupDataStmt,
 		&qs.deleteStoredCatchpoint,
 		&qs.insertStoredCatchpoint,
 		&qs.selectOldestCatchpointFiles,
@@ -1049,6 +1137,14 @@ func (qs *accountsDbQueries) close() {
 			*preparedQuery = nil
 		}
 	}
+}
+
+func (qs *accountsDbQueries) loadHoldings(eah ledgercore.ExtendedAssetHolding) (holdings map[basics.AssetIndex]basics.AssetHolding, result ledgercore.ExtendedAssetHolding, err error) {
+	err = db.Retry(func() error {
+		holdings, result, err = loadHoldings(qs.loadAccountGroupDataStmt, eah)
+		return err
+	})
+	return
 }
 
 // accountsOnlineTop returns the top n online accounts starting at position offset
@@ -1076,8 +1172,8 @@ func accountsOnlineTop(tx *sql.Tx, offset, n uint64, proto config.ConsensusParam
 			return nil, err
 		}
 
-		var data basics.AccountData
-		err = protocol.Decode(buf, &data)
+		var pad ledgercore.PersistedAccountData
+		err = protocol.Decode(buf, &pad)
 		if err != nil {
 			return nil, err
 		}
@@ -1089,7 +1185,7 @@ func accountsOnlineTop(tx *sql.Tx, offset, n uint64, proto config.ConsensusParam
 		}
 
 		copy(addr[:], addrbuf)
-		res[addr] = accountDataToOnline(addr, &data, proto)
+		res[addr] = accountDataToOnline(addr, &pad.AccountData, proto)
 	}
 
 	return res, rows.Err()
@@ -1123,6 +1219,7 @@ func accountsPutTotals(tx *sql.Tx, totals ledgercore.AccountTotals, catchpointSt
 	return err
 }
 
+// loadHoldings initiates all holdings leading mentioned in ExtendedAssetHolding groups.
 func loadHoldings(stmt *sql.Stmt, eah ledgercore.ExtendedAssetHolding) (map[basics.AssetIndex]basics.AssetHolding, ledgercore.ExtendedAssetHolding, error) {
 	if len(eah.Groups) == 0 {
 		return nil, ledgercore.ExtendedAssetHolding{}, nil
@@ -1142,41 +1239,42 @@ func loadHoldings(stmt *sql.Stmt, eah ledgercore.ExtendedAssetHolding) (map[basi
 }
 
 func loadHoldingGroup(stmt *sql.Stmt, g ledgercore.AssetsHoldingGroup, holdings map[basics.AssetIndex]basics.AssetHolding) (map[basics.AssetIndex]basics.AssetHolding, ledgercore.AssetsHoldingGroup, error) {
-	if holdings == nil {
-		holdings = make(map[basics.AssetIndex]basics.AssetHolding, g.Count)
-	}
-	groupData, err := loadAssetHoldingGroupData(stmt, g.AssetGroupKey)
+	groupData, err := loadHoldingGroupData(stmt, g.AssetGroupKey)
 	if err != nil {
 		return nil, ledgercore.AssetsHoldingGroup{}, err
 	}
 	aidx := g.MinAssetIndex
 	for i := 0; i < len(groupData.AssetOffsets); i++ {
 		aidx += groupData.AssetOffsets[i]
-		holdings[aidx] = groupData.GetHolding(i)
+		if holdings != nil {
+			holdings[aidx] = groupData.GetHolding(i)
+		}
 	}
 	g.Load(groupData)
 	return holdings, g, nil
 }
 
-func loadAssetHoldingGroupData(stmt *sql.Stmt, key int64) (group ledgercore.AssetsHoldingGroupData, err error) {
+// loadHoldingGroupData loads a single holdings group data
+func loadHoldingGroupData(stmt *sql.Stmt, key int64) (group ledgercore.AssetsHoldingGroupData, err error) {
 	var buf []byte
 	err = stmt.QueryRow(key).Scan(&buf)
+	if err == sql.ErrNoRows {
+		return ledgercore.AssetsHoldingGroupData{}, fmt.Errorf("loadHoldingGroupData failed to retrive data for key %d", key)
+	}
+
+	// Some other database error
 	if err != nil {
-		return ledgercore.AssetsHoldingGroupData{}, err
+		return
 	}
 
 	err = protocol.Decode(buf, &group)
 	return
 }
 
-func accountsNewCreate(qabi *sql.Stmt, qaei *sql.Stmt, addr basics.Address, ad basics.AccountData, genesisProto config.ConsensusParams, updatedAccounts []dbAccountData, updateIdx int) ([]dbAccountData, error) {
+func accountsNewCreate(qabi *sql.Stmt, qaei *sql.Stmt, addr basics.Address, pad ledgercore.PersistedAccountData, genesisProto config.ConsensusParams, updatedAccounts []dbAccountData, updateIdx int) ([]dbAccountData, error) {
 	assetsThreshold := config.Consensus[protocol.ConsensusV18].MaxAssetsPerAccount
-	var pad ledgercore.PersistedAccountData
-	if len(ad.Assets) <= assetsThreshold {
-		pad.AccountData = ad
-	} else {
-		pad.ExtendedAssetHolding.ConvertToGroups(ad.Assets)
-		pad.AccountData = ad
+	if len(pad.Assets) > assetsThreshold {
+		pad.ExtendedAssetHolding.ConvertToGroups(pad.Assets)
 		pad.AccountData.Assets = nil
 	}
 
@@ -1194,7 +1292,7 @@ func accountsNewCreate(qabi *sql.Stmt, qaei *sql.Stmt, addr basics.Address, ad b
 	}
 
 	if err == nil {
-		normBalance := ad.NormalizedOnlineBalance(genesisProto)
+		normBalance := pad.AccountData.NormalizedOnlineBalance(genesisProto)
 		result, err = qabi.Exec(addr[:], normBalance, protocol.Encode(&pad))
 		if err == nil {
 			updatedAccounts[updateIdx].rowid, err = result.LastInsertId()
@@ -1234,12 +1332,17 @@ func accountsNewDelete(qabd *sql.Stmt, qaed *sql.Stmt, addr basics.Address, dbad
 func accountsNewUpdate(qabu, qabq, qaeu, qaei, qaed *sql.Stmt, addr basics.Address, delta accountDelta, genesisProto config.ConsensusParams, updatedAccounts []dbAccountData, updateIdx int) ([]dbAccountData, error) {
 	assetsThreshold := config.Consensus[protocol.ConsensusV18].MaxAssetsPerAccount
 
-	// need to reconcile asset holdings
+	// sanity check: counts must match since all the modications are in delta.new.Assets and mods map
+	if delta.old.pad.ExtendedAssetHolding.Count != delta.new.ExtendedAssetHolding.Count {
+		return updatedAccounts, fmt.Errorf("extended holdings count mismatch (old) %d != %d (new)", delta.old.pad.ExtendedAssetHolding.Count, delta.new.ExtendedAssetHolding.Count)
+	}
+
+	// Reconciliation asset holdings logic:
 	// old.Assets must always have the assets modified in new (see accountsLoadOld)
 	// PersistedAccountData stores the data either in Assets field or as ExtendedHoldings
 	// this means:
 	// 1. if both old and new below the threshold then all set
-	// 2. if old is below and new is above then clear Assets field and regroup
+	// 2. if old is below and new is above then create group data and clear Assets field
 	// 3. if old is above the threshold
 	//  - find created and deleted entries
 	//  - if the result is below the threshold then move everything in Assets field
@@ -1247,10 +1350,10 @@ func accountsNewUpdate(qabu, qabq, qaeu, qaei, qaed *sql.Stmt, addr basics.Addre
 	var pad ledgercore.PersistedAccountData
 	var err error
 	if delta.old.pad.NumAssetHoldings() <= assetsThreshold && len(delta.new.Assets) <= assetsThreshold {
-		pad.AccountData = delta.new
+		pad.AccountData = delta.new.AccountData
 	} else if delta.old.pad.NumAssetHoldings() <= assetsThreshold && len(delta.new.Assets) > assetsThreshold {
 		pad.ExtendedAssetHolding.ConvertToGroups(delta.new.Assets)
-		pad.AccountData = delta.new
+		pad.AccountData = delta.new.AccountData
 		pad.AccountData.Assets = nil
 
 		// update group data DB table
@@ -1266,28 +1369,20 @@ func accountsNewUpdate(qabu, qabq, qaeu, qaei, qaed *sql.Stmt, addr basics.Addre
 			}
 		}
 	} else { // default case: delta.old.pad.NumAssetHoldings() > assetsThreshold
-		deleted := make([]basics.AssetIndex, 0, len(delta.old.pad.Assets)) // items in old but not in new
-		updated := make([]basics.AssetIndex, 0, len(delta.new.Assets))     // items in both new and old
-		created := make([]basics.AssetIndex, 0, len(delta.new.Assets))     // items in new but not in old
+		deleted := make([]basics.AssetIndex, 0, len(delta.holdings))
+		created := make([]basics.AssetIndex, 0, len(delta.holdings))
 
-		pad.AccountData = delta.new
+		pad = delta.new
 		oldPad := delta.old.pad
 
-		for aidx := range oldPad.AccountData.Assets {
-			if _, ok := delta.new.Assets[aidx]; ok {
-				updated = append(updated, aidx)
-			} else {
+		for aidx, action := range delta.holdings {
+			if action == ledgercore.ActionDelete {
 				deleted = append(deleted, aidx)
-			}
-		}
-		for aidx := range delta.new.Assets {
-			if _, ok := oldPad.AccountData.Assets[aidx]; ok {
-				// updated = append(updated, aidx)
-				// handled above as updated
 			} else {
 				created = append(created, aidx)
 			}
 		}
+
 		newCount := oldPad.NumAssetHoldings() + len(created) - len(deleted)
 		if newCount < assetsThreshold {
 			// Move all assets from groups to Assets field
@@ -1298,11 +1393,9 @@ func accountsNewUpdate(qabu, qabq, qaeu, qaei, qaed *sql.Stmt, addr basics.Addre
 			for _, aidx := range deleted {
 				delete(assets, aidx)
 			}
-			for _, aidx := range created {
-				assets[aidx] = delta.new.Assets[aidx]
-			}
-			for _, aidx := range updated {
-				assets[aidx] = delta.new.Assets[aidx]
+			// copy created + deleted from delta.new
+			for aidx, holding := range delta.new.Assets {
+				assets[aidx] = holding
 			}
 			pad.AccountData.Assets = assets
 
@@ -1315,6 +1408,13 @@ func accountsNewUpdate(qabu, qabq, qaeu, qaei, qaed *sql.Stmt, addr basics.Addre
 			// Reconcile groups data:
 			// identify groups, load, update, then delete and insert, dump to the disk
 
+			updated := make([]basics.AssetIndex, 0, len(delta.new.Assets))
+			for aidx := range delta.new.Assets {
+				if _, ok := delta.holdings[aidx]; !ok {
+					updated = append(updated, aidx)
+				}
+			}
+
 			pad.ExtendedAssetHolding = oldPad.ExtendedAssetHolding
 			if len(updated) > 0 {
 				sort.SliceStable(updated, func(i, j int) bool { return updated[i] < updated[j] })
@@ -1322,7 +1422,7 @@ func accountsNewUpdate(qabu, qabq, qaeu, qaei, qaed *sql.Stmt, addr basics.Addre
 				for _, aidx := range updated {
 					gi, ai = pad.ExtendedAssetHolding.FindAsset(aidx, gi)
 					if gi == -1 || ai == -1 {
-						return updatedAccounts, fmt.Errorf("failed to find asset group for %d", aidx)
+						return updatedAccounts, fmt.Errorf("failed to find asset group for %d: (%d, %d)", aidx, gi, ai)
 					}
 					// group data is loaded in accountsLoadOld
 					pad.ExtendedAssetHolding.Groups[gi].Update(ai, delta.new.Assets[aidx])
@@ -1330,13 +1430,15 @@ func accountsNewUpdate(qabu, qabq, qaeu, qaei, qaed *sql.Stmt, addr basics.Addre
 			}
 
 			if len(deleted) > 0 {
-				// TODO: handle pad.NumAssetHoldings() == len(deleted)
+				// TODO: possible optimizations:
+				// 1. pad.NumAssetHoldings() == len(deleted)
+				// 2. deletion of entire group
 				sort.SliceStable(deleted, func(i, j int) bool { return deleted[i] < deleted[j] })
 				gi, ai := 0, 0
 				for _, aidx := range deleted {
 					gi, ai = pad.ExtendedAssetHolding.FindAsset(aidx, gi)
 					if gi == -1 || ai == -1 {
-						return updatedAccounts, fmt.Errorf("failed to find asset group for %d", aidx)
+						return updatedAccounts, fmt.Errorf("failed to find asset group for %d: (%d, %d)", aidx, gi, ai)
 					}
 					// group data is loaded in accountsLoadOld
 					key := pad.ExtendedAssetHolding.Groups[gi].AssetGroupKey
@@ -1577,8 +1679,8 @@ func totalsNewRounds(tx *sql.Tx, updates []ledgercore.AccountDeltas, compactUpda
 		totals.ApplyRewards(accountTotals[i].RewardsLevel, &ot)
 
 		for j := 0; j < updates[i].Len(); j++ {
-			addr, data := updates[i].GetByIdx(j)
-
+			addr, pad := updates[i].GetByIdx(j)
+			data := pad.AccountData
 			if oldAccountData, has := accounts[addr]; has {
 				totals.DelAccount(proto, oldAccountData, &ot)
 			} else {

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -190,19 +190,24 @@ func (au *accountUpdates) allBalances(rnd basics.Round) (bals map[basics.Address
 		return
 	}
 
+	pars := make(map[basics.Address]ledgercore.PersistedAccountData)
 	err = au.dbs.Rdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 		var err0 error
-		bals, err0 = accountsAll(tx)
+		pars, err0 = accountsAll(tx)
 		return err0
 	})
 	if err != nil {
 		return
 	}
+	bals = make(map[basics.Address]basics.AccountData, len(pars))
+	for addr, pad := range pars {
+		bals[addr] = pad.AccountData
+	}
 
 	for offset := uint64(0); offset < offsetLimit; offset++ {
 		for i := 0; i < au.deltas[offset].Len(); i++ {
 			addr, delta := au.deltas[offset].GetByIdx(i)
-			bals[addr] = delta
+			bals[addr] = delta.AccountData
 		}
 	}
 	return
@@ -361,7 +366,7 @@ func TestAcctUpdates(t *testing.T) {
 
 		newPool := totals[testPoolAddr]
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
-		updates.Upsert(testPoolAddr, newPool)
+		updates.Upsert(testPoolAddr, ledgercore.PersistedAccountData{AccountData: newPool})
 		totals[testPoolAddr] = newPool
 
 		blk := bookkeeping.Block{
@@ -444,7 +449,7 @@ func TestAcctUpdatesFastUpdates(t *testing.T) {
 
 		newPool := totals[testPoolAddr]
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
-		updates.Upsert(testPoolAddr, newPool)
+		updates.Upsert(testPoolAddr, ledgercore.PersistedAccountData{AccountData: newPool})
 		totals[testPoolAddr] = newPool
 
 		blk := bookkeeping.Block{
@@ -533,7 +538,7 @@ func BenchmarkBalancesChanges(b *testing.B) {
 
 		newPool := totals[testPoolAddr]
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
-		updates.Upsert(testPoolAddr, newPool)
+		updates.Upsert(testPoolAddr, ledgercore.PersistedAccountData{AccountData: newPool})
 		totals[testPoolAddr] = newPool
 
 		blk := bookkeeping.Block{
@@ -660,7 +665,7 @@ func TestLargeAccountCountCatchpointGeneration(t *testing.T) {
 
 		newPool := totals[testPoolAddr]
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
-		updates.Upsert(testPoolAddr, newPool)
+		updates.Upsert(testPoolAddr, ledgercore.PersistedAccountData{AccountData: newPool})
 		totals[testPoolAddr] = newPool
 
 		blk := bookkeeping.Block{
@@ -836,7 +841,7 @@ func TestAcctUpdatesUpdatesCorrectness(t *testing.T) {
 
 			delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, len(updates), 0)
 			for addr, ad := range updates {
-				delta.Accts.Upsert(addr, ad)
+				delta.Accts.Upsert(addr, ledgercore.PersistedAccountData{AccountData: ad})
 			}
 			au.newBlock(blk, delta)
 			au.committedUpTo(i)
@@ -1172,14 +1177,20 @@ func TestGetCatchpointStream(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func accountsAll(tx *sql.Tx) (bals map[basics.Address]basics.AccountData, err error) {
+func accountsAll(tx *sql.Tx) (bals map[basics.Address]ledgercore.PersistedAccountData, err error) {
 	rows, err := tx.Query("SELECT address, data FROM accountbase")
 	if err != nil {
 		return
 	}
 	defer rows.Close()
 
-	bals = make(map[basics.Address]basics.AccountData)
+	stmt, err := tx.Prepare("SELECT data FROM accountext WHERE id=?")
+	if err != nil {
+		return
+	}
+	defer stmt.Close()
+
+	bals = make(map[basics.Address]ledgercore.PersistedAccountData)
 	for rows.Next() {
 		var addrbuf []byte
 		var buf []byte
@@ -1188,8 +1199,8 @@ func accountsAll(tx *sql.Tx) (bals map[basics.Address]basics.AccountData, err er
 			return
 		}
 
-		var data basics.AccountData
-		err = protocol.Decode(buf, &data)
+		var pad ledgercore.PersistedAccountData
+		err = protocol.Decode(buf, &pad)
 		if err != nil {
 			return
 		}
@@ -1199,9 +1210,12 @@ func accountsAll(tx *sql.Tx) (bals map[basics.Address]basics.AccountData, err er
 			err = fmt.Errorf("Account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
 			return
 		}
+		if pad.ExtendedAssetHolding.Count > 0 {
+			pad.AccountData.Assets, pad.ExtendedAssetHolding, err = loadHoldings(stmt, pad.ExtendedAssetHolding)
+		}
 
 		copy(addr[:], addrbuf)
-		bals[addr] = data
+		bals[addr] = pad
 	}
 
 	err = rows.Err()
@@ -1243,7 +1257,7 @@ func BenchmarkLargeMerkleTrieRebuild(b *testing.B) {
 			addr := randomAddress()
 			acctData := basics.AccountData{}
 			acctData.MicroAlgos.Raw = 1
-			updates.upsert(addr, accountDelta{new: acctData})
+			updates.upsert(addr, accountDelta{new: ledgercore.PersistedAccountData{AccountData: acctData}})
 			i++
 		}
 
@@ -1315,7 +1329,7 @@ func BenchmarkLargeCatchpointWriting(b *testing.B) {
 				addr := randomAddress()
 				acctData := basics.AccountData{}
 				acctData.MicroAlgos.Raw = 1
-				updates.upsert(addr, accountDelta{new: acctData})
+				updates.upsert(addr, accountDelta{new: ledgercore.PersistedAccountData{AccountData: acctData}})
 				i++
 			}
 
@@ -1353,7 +1367,7 @@ func BenchmarkCompactDeltas(b *testing.B) {
 				start = window/2 + (rnd-1)*window
 			}
 			for k := start; k < start+window; k++ {
-				accountDeltas[rnd].Upsert(addrs[k], basics.AccountData{})
+				accountDeltas[rnd].Upsert(addrs[k], ledgercore.PersistedAccountData{})
 				m[addrs[k]] = basics.AccountData{}
 			}
 		}
@@ -1374,7 +1388,7 @@ func TestCompactDeltas(t *testing.T) {
 	accountDeltas := make([]ledgercore.AccountDeltas, 1, 1)
 	creatableDeltas := make([]map[basics.CreatableIndex]ledgercore.ModifiedCreatable, 1, 1)
 	creatableDeltas[0] = make(map[basics.CreatableIndex]ledgercore.ModifiedCreatable)
-	accountDeltas[0].Upsert(addrs[0], basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 2}})
+	accountDeltas[0].Upsert(addrs[0], ledgercore.PersistedAccountData{AccountData: basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 2}}})
 	creatableDeltas[0][100] = ledgercore.ModifiedCreatable{Creator: addrs[2], Created: true}
 	var baseAccounts lruAccounts
 	baseAccounts.init(nil, 100, 80)
@@ -1387,14 +1401,14 @@ func TestCompactDeltas(t *testing.T) {
 
 	delta, _ := outAccountDeltas.get(addrs[0])
 	require.Equal(t, dbAccountData{}, delta.old)
-	require.Equal(t, basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 2}}, delta.new)
+	require.Equal(t, ledgercore.PersistedAccountData{AccountData: basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 2}}}, delta.new)
 	require.Equal(t, ledgercore.ModifiedCreatable{Creator: addrs[2], Created: true, Ndeltas: 1}, outCreatableDeltas[100])
 
 	// add another round
 	accountDeltas = append(accountDeltas, ledgercore.AccountDeltas{})
 	creatableDeltas = append(creatableDeltas, make(map[basics.CreatableIndex]ledgercore.ModifiedCreatable))
-	accountDeltas[1].Upsert(addrs[0], basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 3}})
-	accountDeltas[1].Upsert(addrs[3], basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 8}})
+	accountDeltas[1].Upsert(addrs[0], ledgercore.PersistedAccountData{AccountData: basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 3}}})
+	accountDeltas[1].Upsert(addrs[3], ledgercore.PersistedAccountData{AccountData: basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 8}}})
 
 	creatableDeltas[1][100] = ledgercore.ModifiedCreatable{Creator: addrs[2], Created: false}
 	creatableDeltas[1][101] = ledgercore.ModifiedCreatable{Creator: addrs[4], Created: true}
@@ -1487,7 +1501,7 @@ func TestReproducibleCatchpointLabels(t *testing.T) {
 
 		newPool := totals[testPoolAddr]
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
-		updates.Upsert(testPoolAddr, newPool)
+		updates.Upsert(testPoolAddr, ledgercore.PersistedAccountData{AccountData: newPool})
 		totals[testPoolAddr] = newPool
 
 		blk := bookkeeping.Block{
@@ -1595,7 +1609,7 @@ func TestCachesInitialization(t *testing.T) {
 
 		newPool := totals[testPoolAddr]
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
-		updates.Upsert(testPoolAddr, newPool)
+		updates.Upsert(testPoolAddr, ledgercore.PersistedAccountData{AccountData: newPool})
 		totals[testPoolAddr] = newPool
 
 		blk := bookkeeping.Block{
@@ -1689,7 +1703,7 @@ func TestSplittingConsensusVersionCommits(t *testing.T) {
 
 		newPool := totals[testPoolAddr]
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
-		updates.Upsert(testPoolAddr, newPool)
+		updates.Upsert(testPoolAddr, ledgercore.PersistedAccountData{AccountData: newPool})
 		totals[testPoolAddr] = newPool
 
 		blk := bookkeeping.Block{
@@ -1723,7 +1737,7 @@ func TestSplittingConsensusVersionCommits(t *testing.T) {
 
 		newPool := totals[testPoolAddr]
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
-		updates.Upsert(testPoolAddr, newPool)
+		updates.Upsert(testPoolAddr, ledgercore.PersistedAccountData{AccountData: newPool})
 		totals[testPoolAddr] = newPool
 
 		blk := bookkeeping.Block{
@@ -1801,7 +1815,7 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 
 		newPool := totals[testPoolAddr]
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
-		updates.Upsert(testPoolAddr, newPool)
+		updates.Upsert(testPoolAddr, ledgercore.PersistedAccountData{AccountData: newPool})
 		totals[testPoolAddr] = newPool
 
 		blk := bookkeeping.Block{
@@ -1834,7 +1848,7 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 
 		newPool := totals[testPoolAddr]
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
-		updates.Upsert(testPoolAddr, newPool)
+		updates.Upsert(testPoolAddr, ledgercore.PersistedAccountData{AccountData: newPool})
 		totals[testPoolAddr] = newPool
 
 		blk := bookkeeping.Block{
@@ -1869,7 +1883,7 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 
 		newPool := totals[testPoolAddr]
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
-		updates.Upsert(testPoolAddr, newPool)
+		updates.Upsert(testPoolAddr, ledgercore.PersistedAccountData{AccountData: newPool})
 		totals[testPoolAddr] = newPool
 
 		blk := bookkeeping.Block{

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1184,7 +1184,7 @@ func accountsAll(tx *sql.Tx) (bals map[basics.Address]ledgercore.PersistedAccoun
 	}
 	defer rows.Close()
 
-	stmt, err := tx.Prepare("SELECT data FROM accountext WHERE id=?")
+	stmt, err := tx.Prepare(loadAcctExtQuery)
 	if err != nil {
 		return
 	}
@@ -1211,7 +1211,7 @@ func accountsAll(tx *sql.Tx) (bals map[basics.Address]ledgercore.PersistedAccoun
 			return
 		}
 		if pad.ExtendedAssetHolding.Count > 0 {
-			pad.AccountData.Assets, pad.ExtendedAssetHolding, err = loadHoldings(stmt, pad.ExtendedAssetHolding)
+			pad.AccountData.Assets, pad.ExtendedAssetHolding, err = loadHoldings(stmt, pad.ExtendedAssetHolding, 0)
 		}
 
 		copy(addr[:], addrbuf)

--- a/ledger/appcow.go
+++ b/ledger/appcow.go
@@ -218,53 +218,6 @@ func errAlreadyStorage(addr basics.Address, aidx basics.AppIndex, global bool) e
 	return fmt.Errorf("%v has already opted in to app %d", addr, aidx)
 }
 
-// Allocate creates kv storage for a given {addr, aidx, global}. It is called on app creation (global) or opting in (local)
-func (cb *roundCowState) Allocate(addr basics.Address, aidx basics.AppIndex, global bool, space basics.StateSchema) error {
-	// Check that account is not already opted in
-	allocated, err := cb.allocated(addr, aidx, global)
-	if err != nil {
-		return err
-	}
-	if allocated {
-		err = fmt.Errorf("cannot allocate storage, %v", errAlreadyStorage(addr, aidx, global))
-		return err
-	}
-
-	lsd, err := cb.ensureStorageDelta(addr, aidx, global, allocAction, 0)
-	if err != nil {
-		return err
-	}
-
-	lsd.action = allocAction
-	lsd.maxCounts = &space
-
-	return nil
-}
-
-// Deallocate clears storage for {addr, aidx, global}. It happens on app deletion (global) or closing out (local)
-func (cb *roundCowState) Deallocate(addr basics.Address, aidx basics.AppIndex, global bool) error {
-	// Check that account has allocated storage
-	allocated, err := cb.allocated(addr, aidx, global)
-	if err != nil {
-		return err
-	}
-	if !allocated {
-		err = fmt.Errorf("cannot deallocate storage, %v", errNoStorage(addr, aidx, global))
-		return err
-	}
-
-	lsd, err := cb.ensureStorageDelta(addr, aidx, global, deallocAction, 0)
-	if err != nil {
-		return err
-	}
-
-	lsd.action = deallocAction
-	lsd.counts = &basics.StateSchema{}
-	lsd.maxCounts = &basics.StateSchema{}
-	lsd.kvCow = make(stateDelta)
-	return nil
-}
-
 // GetKey looks for a key in {addr, aidx, global} storage
 func (cb *roundCowState) GetKey(addr basics.Address, aidx basics.AppIndex, global bool, key string, accountIdx uint64) (basics.TealValue, bool, error) {
 	return cb.getKey(addr, aidx, global, key, accountIdx)

--- a/ledger/appdbg.go
+++ b/ledger/appdbg.go
@@ -53,6 +53,11 @@ func (w *ledgerForCowBaseWrapper) lookupWithoutRewards(rnd basics.Round, addr ba
 	return ledgercore.PersistedAccountData{AccountData: ad}, rnd, err
 }
 
+func (w *ledgerForCowBaseWrapper) lookupHoldingWithoutRewards(rnd basics.Round, addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.PersistedAccountData, error) {
+	ad, _, err := w.l.LookupWithoutRewards(rnd, addr)
+	return ledgercore.PersistedAccountData{AccountData: ad}, err
+}
+
 func (w *ledgerForCowBaseWrapper) getCreatorForRound(rnd basics.Round, cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.Address, bool, error) {
 	return w.l.GetCreatorForRound(rnd, cidx, ctype)
 }
@@ -63,9 +68,9 @@ func MakeDebugBalances(l ApplicationDbgLedger, round basics.Round, proto protoco
 
 	base := &roundCowBase{
 		l:        &w,
-		rnd:      round - 1,
+		rnd:      round.SubSaturate(1),
 		proto:    config.Consensus[proto],
-		accounts: make(map[basics.Address]basics.AccountData),
+		accounts: make(map[basics.Address]ledgercore.PersistedAccountData),
 	}
 
 	hdr := bookkeeping.BlockHeader{

--- a/ledger/apply/application.go
+++ b/ledger/apply/application.go
@@ -128,7 +128,7 @@ func createApplication(ac *transactions.ApplicationCallTxnFields, balances Balan
 	}
 
 	// Allocate global storage
-	err = balances.Allocate(creator, appIdx, true, ac.GlobalStateSchema)
+	err = balances.Allocate(creator, basics.CreatableIndex(appIdx), basics.AppCreatable, true, ac.GlobalStateSchema)
 	if err != nil {
 		return 0, err
 	}
@@ -166,7 +166,7 @@ func deleteApplication(balances Balances, creator basics.Address, appIdx basics.
 	}
 
 	// Deallocate global storage
-	err = balances.Deallocate(creator, appIdx, true)
+	err = balances.Deallocate(creator, basics.CreatableIndex(appIdx), basics.AppCreatable, true)
 	if err != nil {
 		return err
 	}
@@ -228,7 +228,7 @@ func optInApplication(balances Balances, sender basics.Address, appIdx basics.Ap
 	}
 
 	// Allocate local storage
-	err = balances.Allocate(sender, appIdx, false, params.LocalStateSchema)
+	err = balances.Allocate(sender, basics.CreatableIndex(appIdx), basics.AppCreatable, false, params.LocalStateSchema)
 	if err != nil {
 		return err
 	}
@@ -266,7 +266,7 @@ func closeOutApplication(balances Balances, sender basics.Address, appIdx basics
 	}
 
 	// Deallocate local storage
-	err = balances.Deallocate(sender, appIdx, false)
+	err = balances.Deallocate(sender, basics.CreatableIndex(appIdx), basics.AppCreatable, false)
 	if err != nil {
 		return err
 	}

--- a/ledger/apply/application_test.go
+++ b/ledger/apply/application_test.go
@@ -129,6 +129,14 @@ func (b *testBalances) Get(addr basics.Address, withPendingRewards bool) (basics
 	return ad, nil
 }
 
+func (b *testBalances) GetEx(addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.AccountData, error) {
+	ad, ok := b.balances[addr]
+	if !ok {
+		return basics.AccountData{}, fmt.Errorf("mock balance not found")
+	}
+	return ad, nil
+}
+
 func (b *testBalances) Put(addr basics.Address, ad basics.AccountData) error {
 	b.put++
 	if b.putBalances == nil {
@@ -173,13 +181,13 @@ func (b *testBalances) Move(src, dst basics.Address, amount basics.MicroAlgos, s
 func (b *testBalances) ConsensusParams() config.ConsensusParams {
 	return b.proto
 }
-func (b *testBalances) Allocate(addr basics.Address, aidx basics.AppIndex, global bool, space basics.StateSchema) error {
-	b.allocatedAppIdx = aidx
+func (b *testBalances) Allocate(addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType, global bool, space basics.StateSchema) error {
+	b.allocatedAppIdx = basics.AppIndex(cidx)
 	return nil
 }
 
-func (b *testBalances) Deallocate(addr basics.Address, aidx basics.AppIndex, global bool) error {
-	b.deAllocatedAppIdx = aidx
+func (b *testBalances) Deallocate(addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType, global bool) error {
+	b.deAllocatedAppIdx = basics.AppIndex(cidx)
 	return nil
 }
 
@@ -188,6 +196,14 @@ func (b *testBalances) StatefulEval(params logic.EvalParams, aidx basics.AppInde
 }
 
 func (b *testBalancesPass) Get(addr basics.Address, withPendingRewards bool) (basics.AccountData, error) {
+	ad, ok := b.balances[addr]
+	if !ok {
+		return basics.AccountData{}, fmt.Errorf("mock balance not found")
+	}
+	return ad, nil
+}
+
+func (b *testBalancesPass) GetEx(addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.AccountData, error) {
 	ad, ok := b.balances[addr]
 	if !ok {
 		return basics.AccountData{}, fmt.Errorf("mock balance not found")
@@ -214,12 +230,12 @@ func (b *testBalancesPass) PutWithCreatable(addr basics.Address, ad basics.Accou
 func (b *testBalancesPass) ConsensusParams() config.ConsensusParams {
 	return b.proto
 }
-func (b *testBalancesPass) Allocate(addr basics.Address, aidx basics.AppIndex, global bool, space basics.StateSchema) error {
-	b.allocatedAppIdx = aidx
+func (b *testBalancesPass) Allocate(addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType, global bool, space basics.StateSchema) error {
+	b.allocatedAppIdx = basics.AppIndex(cidx)
 	return nil
 }
 
-func (b *testBalancesPass) Deallocate(addr basics.Address, aidx basics.AppIndex, global bool) error {
+func (b *testBalancesPass) Deallocate(addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType, global bool) error {
 	return nil
 }
 

--- a/ledger/apply/apply.go
+++ b/ledger/apply/apply.go
@@ -31,6 +31,9 @@ type Balances interface {
 	// A non-nil error means the lookup is impossible (e.g., if the database doesn't have necessary state anymore)
 	Get(addr basics.Address, withPendingRewards bool) (basics.AccountData, error)
 
+	// GetEx is like Get(addr, false), but also loads specific creatable
+	GetEx(addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.AccountData, error)
+
 	Put(basics.Address, basics.AccountData) error
 
 	// PutWithCreatable is like Put, but should be used when creating or deleting an asset or application.
@@ -39,15 +42,17 @@ type Balances interface {
 	// GetCreator gets the address of the account that created a given creatable
 	GetCreator(cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.Address, bool, error)
 
-	// Allocate or Deallocate either global or address-local app storage.
+	// Allocate or Deallocate either global or address-local app storage, or asset holding
 	//
 	// PutWithCreatable(...) and then {Allocate/Deallocate}(..., ..., global=true)
 	// creates/destroys an application.
 	//
 	// Put(...) and then {Allocate/Deallocate}(..., ..., global=false)
 	// opts into/closes out of an application.
-	Allocate(addr basics.Address, aidx basics.AppIndex, global bool, space basics.StateSchema) error
-	Deallocate(addr basics.Address, aidx basics.AppIndex, global bool) error
+	//
+	// global and space parmaters are not used for assets
+	Allocate(addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType, global bool, space basics.StateSchema) error
+	Deallocate(addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType, global bool) error
 
 	// StatefulEval executes a TEAL program in stateful mode on the balances.
 	// It returns whether the program passed and its error.  It alo returns

--- a/ledger/apply/keyreg_test.go
+++ b/ledger/apply/keyreg_test.go
@@ -40,6 +40,10 @@ func (balances keyregTestBalances) Get(addr basics.Address, withPendingRewards b
 	return balances.addrs[addr], nil
 }
 
+func (balances keyregTestBalances) GetEx(basics.Address, basics.CreatableIndex, basics.CreatableType) (basics.AccountData, error) {
+	return basics.AccountData{}, nil
+}
+
 func (balances keyregTestBalances) GetCreator(cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.Address, bool, error) {
 	return basics.Address{}, true, nil
 }
@@ -64,11 +68,11 @@ func (balances keyregTestBalances) Round() basics.Round {
 	return basics.Round(4294967296)
 }
 
-func (balances keyregTestBalances) Allocate(basics.Address, basics.AppIndex, bool, basics.StateSchema) error {
+func (balances keyregTestBalances) Allocate(basics.Address, basics.CreatableIndex, basics.CreatableType, bool, basics.StateSchema) error {
 	return nil
 }
 
-func (balances keyregTestBalances) Deallocate(basics.Address, basics.AppIndex, bool) error {
+func (balances keyregTestBalances) Deallocate(basics.Address, basics.CreatableIndex, basics.CreatableType, bool) error {
 	return nil
 }
 

--- a/ledger/apply/mockBalances_test.go
+++ b/ledger/apply/mockBalances_test.go
@@ -49,11 +49,11 @@ func (balances mockBalances) Round() basics.Round {
 	return basics.Round(8675309)
 }
 
-func (balances mockBalances) Allocate(basics.Address, basics.AppIndex, bool, basics.StateSchema) error {
+func (balances mockBalances) Allocate(basics.Address, basics.CreatableIndex, basics.CreatableType, bool, basics.StateSchema) error {
 	return nil
 }
 
-func (balances mockBalances) Deallocate(basics.Address, basics.AppIndex, bool) error {
+func (balances mockBalances) Deallocate(basics.Address, basics.CreatableIndex, basics.CreatableType, bool) error {
 	return nil
 }
 
@@ -66,6 +66,10 @@ func (balances mockBalances) PutWithCreatable(basics.Address, basics.AccountData
 }
 
 func (balances mockBalances) Get(addr basics.Address, withPendingRewards bool) (basics.AccountData, error) {
+	return balances.b[addr], nil
+}
+
+func (balances mockBalances) GetEx(addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.AccountData, error) {
 	return balances.b[addr], nil
 }
 

--- a/ledger/creatablecow.go
+++ b/ledger/creatablecow.go
@@ -1,0 +1,92 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package ledger
+
+import (
+	"fmt"
+
+	"github.com/algorand/go-algorand/data/basics"
+)
+
+// Allocate creates kv storage for a given {addr, aidx, global}. It is called on app creation (global) or opting in (local)
+// Allocate also registers an asset holding as created
+func (cb *roundCowState) Allocate(addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType, global bool, space basics.StateSchema) error {
+	if ctype == basics.AppCreatable {
+		// Check that account is not already opted in
+		aidx := basics.AppIndex(cidx)
+		allocated, err := cb.allocated(addr, aidx, global)
+		if err != nil {
+			return err
+		}
+		if allocated {
+			err = fmt.Errorf("cannot allocate storage, %v", errAlreadyStorage(addr, aidx, global))
+			return err
+		}
+
+		lsd, err := cb.ensureStorageDelta(addr, aidx, global, allocAction, 0)
+		if err != nil {
+			return err
+		}
+
+		lsd.action = allocAction
+		lsd.maxCounts = &space
+
+		return nil
+	}
+
+	if ctype == basics.AssetCreatable {
+		cb.mods.Accts.SetHoldingDelta(addr, basics.AssetIndex(cidx), true)
+		return nil
+	}
+
+	return fmt.Errorf("not supported creatable type %v", ctype)
+}
+
+// Deallocate clears storage for {addr, aidx, global}. It happens on app deletion (global) or closing out (local)
+// Deallocate also registers an asset holding as deleted
+func (cb *roundCowState) Deallocate(addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType, global bool) error {
+	if ctype == basics.AppCreatable {
+		// Check that account has allocated storage
+		aidx := basics.AppIndex(cidx)
+		allocated, err := cb.allocated(addr, aidx, global)
+		if err != nil {
+			return err
+		}
+		if !allocated {
+			err = fmt.Errorf("cannot deallocate storage, %v", errNoStorage(addr, aidx, global))
+			return err
+		}
+
+		lsd, err := cb.ensureStorageDelta(addr, aidx, global, deallocAction, 0)
+		if err != nil {
+			return err
+		}
+
+		lsd.action = deallocAction
+		lsd.counts = &basics.StateSchema{}
+		lsd.maxCounts = &basics.StateSchema{}
+		lsd.kvCow = make(stateDelta)
+		return nil
+	}
+
+	if ctype == basics.AssetCreatable {
+		cb.mods.Accts.SetHoldingDelta(addr, basics.AssetIndex(cidx), false)
+		return nil
+	}
+
+	return fmt.Errorf("not supported creatable type %v", ctype)
+}

--- a/ledger/ledgercore/statedelta_test.go
+++ b/ledger/ledgercore/statedelta_test.go
@@ -37,19 +37,19 @@ func TestAccountDeltas(t *testing.T) {
 	ad := AccountDeltas{}
 	data, ok := ad.Get(basics.Address{})
 	a.False(ok)
-	a.Equal(basics.AccountData{}, data)
+	a.Equal(PersistedAccountData{}, data)
 
 	addr := randomAddress()
 	data, ok = ad.Get(addr)
 	a.False(ok)
-	a.Equal(basics.AccountData{}, data)
+	a.Equal(PersistedAccountData{}, data)
 
 	a.Equal(0, ad.Len())
 	a.Panics(func() { ad.GetByIdx(0) })
 
 	a.Equal([]basics.Address{}, ad.ModifiedAccounts())
 
-	sample1 := basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 123}}
+	sample1 := PersistedAccountData{AccountData: basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 123}}}
 	ad.Upsert(addr, sample1)
 	data, ok = ad.Get(addr)
 	a.True(ok)
@@ -60,7 +60,7 @@ func TestAccountDeltas(t *testing.T) {
 	a.Equal(addr, address)
 	a.Equal(sample1, data)
 
-	sample2 := basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 456}}
+	sample2 := PersistedAccountData{AccountData: basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 456}}}
 	ad.Upsert(addr, sample2)
 	data, ok = ad.Get(addr)
 	a.True(ok)


### PR DESCRIPTION
## Summary

1. Extend `apply.Balances` interface with `GetEx` methods. 
2. Use `Allocate`/`Deallocate` for asset holdings adding/removing.
3. Implement ledger.LookupFull that loads all the assets.
