### PR TITLE
Net tag stats

### DIFF
--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -48,10 +48,15 @@ const averageMessageLength = 2 * 1024    // Most of the messages are smaller tha
 const msgsInReadBufferPerPeer = 10
 
 var networkSentBytesTotal = metrics.MakeCounter(metrics.NetworkSentBytesTotal)
+var networkSentBytesByTag = metrics.NewTagCounter("algod_network_sent_bytes_{TAG}", "Number of bytes that were sent over the network per message tag")
 var networkReceivedBytesTotal = metrics.MakeCounter(metrics.NetworkReceivedBytesTotal)
+var networkReceivedBytesByTag = metrics.NewTagCounter("algod_network_received_bytes_{TAG", "Number of bytes that were received from the network per message tag")
 
 var networkMessageReceivedTotal = metrics.MakeCounter(metrics.NetworkMessageReceivedTotal)
+var networkMessageReceivedByTag = metrics.NewTagCounter("algod_network_message_received_{TAG}", "Number of complete messages that were received from the network per message tag")
 var networkMessageSentTotal = metrics.MakeCounter(metrics.NetworkMessageSentTotal)
+var networkMessageSentByTag = metrics.NewTagCounter("algod_network_message_sent_{TAG}", "Number of complete messages that were sent to the network per message tag")
+
 var networkConnectionsDroppedTotal = metrics.MakeCounter(metrics.NetworkConnectionsDroppedTotal)
 var networkMessageQueueMicrosTotal = metrics.MakeCounter(metrics.MetricName{Name: "algod_network_message_sent_queue_micros_total", Description: "Total microseconds message spent waiting in queue to be sent"})
 
@@ -401,6 +406,8 @@ func (wp *wsPeer) readLoop() {
 		atomic.StoreInt64(&wp.lastPacketTime, msg.Received)
 		networkReceivedBytesTotal.AddUint64(uint64(len(msg.Data)+2), nil)
 		networkMessageReceivedTotal.AddUint64(1, nil)
+		networkReceivedBytesByTag.Add(string(tag[:]), uint64(len(msg.Data)+2))
+		networkMessageReceivedByTag.Add(string(tag[:]), 1)
 		msg.Sender = wp
 
 		// for outgoing connections, we want to notify the connection monitor that we've received
@@ -569,7 +576,9 @@ func (wp *wsPeer) writeLoopSend(msg sendMessage) disconnectReason {
 	}
 	atomic.StoreInt64(&wp.lastPacketTime, time.Now().UnixNano())
 	networkSentBytesTotal.AddUint64(uint64(len(msg.data)), nil)
+	networkSentBytesByTag.Add(string(tag), uint64(len(msg.data)))
 	networkMessageSentTotal.AddUint64(1, nil)
+	networkMessageSentByTag.Add(string(tag), 1)
 	networkMessageQueueMicrosTotal.AddUint64(uint64(time.Now().Sub(msg.peerEnqueued).Nanoseconds()/1000), nil)
 	return disconnectReasonNone
 }

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -50,7 +50,7 @@ const msgsInReadBufferPerPeer = 10
 var networkSentBytesTotal = metrics.MakeCounter(metrics.NetworkSentBytesTotal)
 var networkSentBytesByTag = metrics.NewTagCounter("algod_network_sent_bytes_{TAG}", "Number of bytes that were sent over the network per message tag")
 var networkReceivedBytesTotal = metrics.MakeCounter(metrics.NetworkReceivedBytesTotal)
-var networkReceivedBytesByTag = metrics.NewTagCounter("algod_network_received_bytes_{TAG", "Number of bytes that were received from the network per message tag")
+var networkReceivedBytesByTag = metrics.NewTagCounter("algod_network_received_bytes_{TAG}", "Number of bytes that were received from the network per message tag")
 
 var networkMessageReceivedTotal = metrics.MakeCounter(metrics.NetworkMessageReceivedTotal)
 var networkMessageReceivedByTag = metrics.NewTagCounter("algod_network_message_received_{TAG}", "Number of complete messages that were received from the network per message tag")

--- a/util/metrics/tagcounter.go
+++ b/util/metrics/tagcounter.go
@@ -120,8 +120,12 @@ func (tc *TagCounter) WriteMetric(buf *strings.Builder, parentLabels string) {
 // AddMetric is part of the Metric interface
 // Copy the values in this TagCounter out into the string-string map.
 func (tc *TagCounter) AddMetric(values map[string]string) {
+	tagp := tc.tagptr.Load()
+	if tagp == nil {
+		return
+	}
 	isTemplate := strings.Contains(tc.Name, "{TAG}")
-	tags := tc.tagptr.Load().(map[string]*uint64)
+	tags := tagp.(map[string]*uint64)
 	for tag, tagcount := range tags {
 		if tagcount == nil {
 			continue

--- a/util/metrics/tagcounter.go
+++ b/util/metrics/tagcounter.go
@@ -1,0 +1,137 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package metrics
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+func NewTagCounter(rootName, desc string) *TagCounter {
+	tc := &TagCounter{Name: rootName, Description: desc}
+	DefaultRegistry().Register(tc)
+	return tc
+}
+
+type TagCounter struct {
+	Name        string
+	Description string
+
+	// a read only race-free reference to tags
+	tagptr atomic.Value
+
+	tags map[string]*uint64
+
+	storage    [][]uint64
+	storagePos int
+
+	tagLock sync.Mutex
+}
+
+func (tc *TagCounter) Add(tag string, val uint64) {
+	for {
+		var tags map[string]*uint64
+		tagptr := tc.tagptr.Load()
+		if tagptr != nil {
+			tags = tagptr.(map[string]*uint64)
+		}
+
+		count, ok := tags[tag]
+		if ok {
+			atomic.AddUint64(count, val)
+			return
+		}
+		tc.tagLock.Lock()
+		if _, ok = tc.tags[tag]; !ok {
+			// Still need to add a new tag.
+			// Make a new map so there's never any race.
+			newtags := make(map[string]*uint64, len(tc.tags)+1)
+			for k, v := range tc.tags {
+				newtags[k] = v
+			}
+			var st []uint64
+			if len(tc.storage) > 0 {
+				st = tc.storage[len(tc.storage)-1]
+				//fmt.Printf("new tag %v, old block\n", tag)
+			}
+			if tc.storagePos > (len(st) - 1) {
+				//fmt.Printf("new tag %v, new block\n", tag)
+				st = make([]uint64, 16)
+				tc.storagePos = 0
+				tc.storage = append(tc.storage, st)
+			}
+			newtags[tag] = &(st[tc.storagePos])
+			//fmt.Printf("tag %v = %p\n", tag, newtags[tag])
+			tc.storagePos++
+			tc.tags = newtags
+			tc.tagptr.Store(newtags)
+		}
+		tc.tagLock.Unlock()
+	}
+}
+
+// WriteMetric is part of the Metric interface
+func (tc *TagCounter) WriteMetric(buf *strings.Builder, parentLabels string) {
+	// TODO: what to do with "parentLabels"? obsolete part of interface?
+	buf.WriteString("# ")
+	buf.WriteString(tc.Name)
+	buf.WriteString(" ")
+	buf.WriteString(tc.Description)
+	buf.WriteString("\n")
+	isTemplate := strings.Contains(tc.Name, "{TAG}")
+	tags := tc.tagptr.Load().(map[string]*uint64)
+	for tag, tagcount := range tags {
+		if tagcount == nil {
+			continue
+		}
+		if isTemplate {
+			name := strings.ReplaceAll(tc.Name, "{TAG}", tag)
+			buf.WriteString(name)
+			buf.WriteRune(' ')
+			buf.WriteString(strconv.FormatUint(*tagcount, 10))
+			buf.WriteRune('\n')
+		} else {
+			buf.WriteString(tc.Name)
+			buf.WriteRune('_')
+			buf.WriteString(tag)
+			buf.WriteRune(' ')
+			buf.WriteString(strconv.FormatUint(*tagcount, 10))
+			buf.WriteRune('\n')
+		}
+	}
+}
+
+// AddMetric is part of the Metric interface
+// Copy the values in this TagCounter out into the string-string map.
+func (tc *TagCounter) AddMetric(values map[string]string) {
+	isTemplate := strings.Contains(tc.Name, "{TAG}")
+	tags := tc.tagptr.Load().(map[string]*uint64)
+	for tag, tagcount := range tags {
+		if tagcount == nil {
+			continue
+		}
+		var name string
+		if isTemplate {
+			name = strings.ReplaceAll(tc.Name, "{TAG}", tag)
+		} else {
+			name = tc.Name + "_" + tag
+		}
+		values[name] = strconv.FormatUint(*tagcount, 10)
+	}
+}

--- a/util/metrics/tagcounter_test.go
+++ b/util/metrics/tagcounter_test.go
@@ -1,0 +1,117 @@
+package metrics
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestTagCounter(t *testing.T) {
+	tags := make([]string, 17)
+	for i := range tags {
+		tags[i] = fmt.Sprintf("A%c", 'A'+i)
+	}
+	//t.Logf("tags %v", tags)
+	countsIn := make([]uint64, len(tags))
+	for i := range countsIn {
+		countsIn[i] = uint64(10 * (i + 1))
+	}
+
+	tc := NewTagCounter("tc", "wat")
+	var wg sync.WaitGroup
+	wg.Add(len(tags))
+
+	runf := func(tag string, count uint64) {
+		for i := 0; i < int(count); i++ {
+			tc.Add(tag, 1)
+		}
+		wg.Done()
+	}
+
+	for i, tag := range tags {
+		go runf(tag, countsIn[i])
+	}
+	wg.Wait()
+
+	endtags := tc.tagptr.Load().(map[string]*uint64)
+	for i, tag := range tags {
+		countin := countsIn[i]
+		endcountp := endtags[tag]
+		if endcountp == nil {
+			t.Errorf("tag[%d] %s nil counter", i, tag)
+			continue
+		}
+		endcount := *endcountp
+		if endcount != countin {
+			t.Errorf("tag[%d] %v wanted %d got %d", i, tag, countin, endcount)
+		}
+	}
+}
+
+func BenchmarkTagCounter(b *testing.B) {
+	b.Logf("b.N = %d", b.N)
+	t := b
+	tags := make([]string, 17)
+	for i := range tags {
+		tags[i] = fmt.Sprintf("A%c", 'A'+i)
+	}
+	//t.Logf("tags %v", tags)
+	triangle := make([]int, len(tags))
+	tsum := 0
+	for i := range triangle {
+		triangle[i] = i + 1
+		tsum += i + 1
+	}
+	wholeN := b.N / tsum
+	remainder := b.N - (tsum * wholeN)
+	rchunk := (remainder / len(tags)) + 1
+	countsIn := make([]uint64, len(tags))
+	csum := uint64(0)
+	for i := range countsIn {
+		rcc := rchunk
+		if remainder < rcc {
+			rcc = remainder
+			remainder = 0
+		} else {
+			remainder -= rchunk
+		}
+		countsIn[i] = uint64((triangle[i] * wholeN) + rcc)
+		csum += countsIn[i]
+	}
+	if csum != uint64(b.N) {
+		b.Errorf("b.N = %d, but total = %d", b.N, csum)
+	}
+
+	tc := NewTagCounter("tc", "wat")
+	//var wg sync.WaitGroup
+	//wg.Add(len(tags))
+
+	runf := func(tag string, count uint64) {
+		for i := 0; i < int(count); i++ {
+			tc.Add(tag, 1)
+		}
+		//wg.Done()
+	}
+
+	for i, tag := range tags {
+		// don't run in threads so that we can benchmark time
+		runf(tag, countsIn[i])
+	}
+	//wg.Wait()
+
+	endtags := tc.tagptr.Load().(map[string]*uint64)
+	for i, tag := range tags {
+		countin := countsIn[i]
+		endcount := uint64(0)
+		endcountp := endtags[tag]
+		if endcountp != nil {
+			endcount = *endcountp
+			//t.Errorf("tag[%d] %s nil counter", i, tag)
+			//continue
+		}
+		//endcount := *endcountp
+		if endcount != countin {
+			t.Errorf("tag[%d] %v wanted %d got %d", i, tag, countin, endcount)
+		}
+	}
+}

--- a/util/metrics/tagcounter_test.go
+++ b/util/metrics/tagcounter_test.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package metrics
 
 import (


### PR DESCRIPTION
## Summary

Expand /metrics to show per-message-tag stats on number of messages and amount of bytes moved.
e.g.

```
algod_network_message_received_AV 4431
algod_network_message_received_MI 1
algod_network_message_received_MS 137
algod_network_message_received_PP 1082
algod_network_message_received_TX 303
algod_network_message_received_UE 17
algod_network_message_received_total{} 5971
algod_network_message_sent_AV 2243
algod_network_message_sent_CS 9
algod_network_message_sent_NP 1
algod_network_message_sent_PP 583
algod_network_message_sent_TS 17
algod_network_message_sent_TX 187647
algod_network_message_sent_queue_micros_total{} 6774576
algod_network_message_sent_total{} 190500
algod_network_received_bytes_AV 2784680
algod_network_received_bytes_MI 47
algod_network_received_bytes_MS 4658
algod_network_received_bytes_PP 45924230
algod_network_received_bytes_TX 350136
algod_network_received_bytes_UE 1173
algod_network_received_bytes_total{} 49064924
algod_network_rx_buffer_micros_total{} 299806
algod_network_rx_handle_micros_total{} 74041
algod_network_sent_bytes_AV 1409489
algod_network_sent_bytes_CS 3672
algod_network_sent_bytes_NP 472
algod_network_sent_bytes_PP 27467155
algod_network_sent_bytes_TS 1105
algod_network_sent_bytes_TX 49590248
algod_network_sent_bytes_total{} 78472140
```

## Test Plan

New metrics TagCounter comes with unit test and benchmark to show it's pretty fast (~15ns per call)