### PR TITLE
1k+ assets benchmarks and groups merging

### DIFF
--- a/ledger/creatablecow.go
+++ b/ledger/creatablecow.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 )
 
 // Allocate creates kv storage for a given {addr, aidx, global}. It is called on app creation (global) or opting in (local)
@@ -49,7 +50,7 @@ func (cb *roundCowState) Allocate(addr basics.Address, cidx basics.CreatableInde
 	}
 
 	if ctype == basics.AssetCreatable {
-		cb.mods.Accts.SetHoldingDelta(addr, basics.AssetIndex(cidx), true)
+		cb.mods.Accts.SetHoldingDelta(addr, basics.AssetIndex(cidx), ledgercore.ActionCreate)
 		return nil
 	}
 
@@ -84,7 +85,7 @@ func (cb *roundCowState) Deallocate(addr basics.Address, cidx basics.CreatableIn
 	}
 
 	if ctype == basics.AssetCreatable {
-		cb.mods.Accts.SetHoldingDelta(addr, basics.AssetIndex(cidx), false)
+		cb.mods.Accts.SetHoldingDelta(addr, basics.AssetIndex(cidx), ledgercore.ActionDelete)
 		return nil
 	}
 

--- a/ledger/ledgercore/msgp_gen.go
+++ b/ledger/ledgercore/msgp_gen.go
@@ -1296,7 +1296,7 @@ func (z *ExtendedAssetHolding) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0002Len := uint32(2)
-	var zb0002Mask uint8 /* 4 bits */
+	var zb0002Mask uint8 /* 3 bits */
 	if (*z).Count == 0 {
 		zb0002Len--
 		zb0002Mask |= 0x2

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -103,7 +103,7 @@ type AccountDeltas struct {
 	holdings map[basics.Address]map[basics.AssetIndex]HoldingAction
 }
 
-// PersistedBalanceRecord is similar to BalanceREcord but contains PersistedAccountData
+// PersistedBalanceRecord is similar to BalanceRecord but contains PersistedAccountData
 //msgp:ignore PersistedBalanceRecord
 type PersistedBalanceRecord struct {
 	Addr basics.Address
@@ -191,16 +191,13 @@ func (ad *AccountDeltas) upsert(pbr PersistedBalanceRecord) {
 // SetHoldingDelta saves creation/deletion info about asset holding
 // Creation is not really important since the holding is already in ad.accts,
 // but saving deleteion info is only the way to know if the asset gone
-func (ad *AccountDeltas) SetHoldingDelta(addr basics.Address, aidx basics.AssetIndex, created bool) {
+func (ad *AccountDeltas) SetHoldingDelta(addr basics.Address, aidx basics.AssetIndex, action HoldingAction) {
 	hmap, ok := ad.holdings[addr]
 	if !ok {
-		hmap = make(map[basics.AssetIndex]HoldingAction)
-	}
-
-	if created {
-		hmap[aidx] = ActionCreate
+		// in most cases there will be only one asset modification per account
+		hmap = map[basics.AssetIndex]HoldingAction{aidx: action}
 	} else {
-		hmap[aidx] = ActionDelete
+		hmap[aidx] = action
 	}
 
 	if ad.holdings == nil {


### PR DESCRIPTION
## Summary

### Benchmarks

**Load All** benchmark

1. All accounts have large holdings

Num holdings | master  | challenger | challenger (in mem db)
--------------|---------|------------|-----------------------
1               | 3564 (12050398 ns/op) | 3547 (11755549 ns/op) | 3606 (12008160 ns/op)
512          | 393 (11650118 ns/op) | 380 (10823573 ns/op)    | 403 (11898689 ns/op)
2,000      | - | 100 (15267542 ns/op) | 100 (15748125 ns/op)
3,000      | - | 100 (25761635 ns/op) | 100 (26671236 ns/op)
5,000      | - | 100 (40956548 ns/op) | 100 (38489401 ns/op)
10,000    | - | 100 (86983336 ns/op) | 100(81456949 ns/op) 
100,000  | - | 80 (736586721 ns/op) | 100 (834930061 ns/op)

2. 10% of accounts have large holdings

Num holdings | challenger |
--------------|------------|
2,000      | 530 (9857459 ns/op)
3,000      | 325 (8926785 ns/op)
5,000      | 247 (10595941 ns/op)
10,000    | 142 (11782498 ns/op)
100,000  | 100 (103990600 ns/op)

**Load Single Holding** benchmark

1. 10% of accounts have large holdings, read entire AD record + a single random asset

Num holdings | master  |challenger   |
--------------|---------|------------|
1              | 89392(14966 ns/op) | 71932 (16120 ns/op)
512          | 89116 (14858 ns/op) | 79610 (15005 ns/op)
2,000      | - | 75006 (16218 ns/op)
5,000      | -  | 81076 (17681 ns/op)
10,000    | - | 61008 (16637 ns/op)
100,000  | - | 39366 (181110 ns/op)

### Other optimizations
I also checked perf impact of struct of arrays vs array of structs on performance and memory
```golang
type AssetsHoldingGroupData struct {
	_struct struct{} `codec:",omitempty,omitemptyarray"`
	AssetOffsets []basics.AssetIndex `codec:"ao,allocbound=MaxHoldingGroupSize"`
	Amounts []uint64 `codec:"a,allocbound=MaxHoldingGroupSize"`
	Frozens []bool `codec:"f,allocbound=MaxHoldingGroupSize"`
}

//  vs
 type AssetsHoldingGroupData struct {
	 _struct struct{} `codec:",omitempty,omitemptyarray"`
	Data []AssetsHoldingGroupDataElement `codec:"d,allocbound=MaxHoldingGroupSize"`
}
type AssetsHoldingGroupDataElement struct {
	_struct struct{} `codec:",omitempty,omitemptyarray"`
	AssetOffset basics.AssetIndex `codec:"o"`
	Amount      uint64            `codec:"a"`
	Frozen      bool              `codec:"f"`
}
```

The latter is +30% longer in serialized form, but consumes ~3x less memory that former. Benchmark data is better for the former although:

```
BenchmarkReadingAllBalancesDiskLarge/holdings=5000/pct=100-8                 100          29100580 ns/op              1378 num_db_reads

vs

BenchmarkReadingAllBalancesDiskLarge/holdings=5000/pct=100-8                 100          44189482 ns/op              1388 num_db_reads

```


## Test Plan

Added a new benchmark that allocates holdings according to normal distribution with 95% of holdings within [num_holdings/4, num_holdings] range