### PR TITLE
Reconstruct balances database from blocks

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -94,7 +94,7 @@ const initializeCachesRoundFlushInterval = 1000
 const initializingAccountCachesMessageTimeout = 3 * time.Second
 
 // accountsUpdatePerRoundHighWatermark is the warning watermark for updating accounts data that takes
-// longer then expected. We set it up here for one second per round, so that if we're bulk updating
+// longer than expected. We set it up here for one second per round, so that if we're bulk updating
 // four rounds, we would allow up to 4 seconds. This becomes important when supporting balances recovery
 // where we end up batching up to 1000 rounds in a single update.
 const accountsUpdatePerRoundHighWatermark = 1 * time.Second
@@ -993,8 +993,9 @@ func (au *accountUpdates) initializeCaches(lastBalancesRound, lastestBlockRound,
 		// flush to disk if any of the following applies:
 		// 1. if we have loaded up more than initializeCachesRoundFlushInterval rounds since the last time we flushed the data to disk
 		// 2. if we completed the loading and we loaded up more than 320 rounds.
-		if blk.Round()-lastFlushedRound > initializeCachesRoundFlushInterval ||
-			(lastestBlockRound == blk.Round() && lastBalancesRound+basics.Round(blk.ConsensusProtocol().MaxBalLookback) < lastestBlockRound) {
+		flushIntervalExceed := blk.Round()-lastFlushedRound > initializeCachesRoundFlushInterval
+		loadCompleted := (lastestBlockRound == blk.Round() && lastBalancesRound+basics.Round(blk.ConsensusProtocol().MaxBalLookback) < lastestBlockRound)
+		if flushIntervalExceed || loadCompleted {
 			// adjust the last flush time, so that we would not hold off the flushing due to "working too fast"
 			au.lastFlushTime = time.Now().Add(-balancesFlushInterval)
 

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -932,10 +932,16 @@ func (au *accountUpdates) initializeCaches(lastBalancesRound, lastestBlockRound,
 		close(skipAccountCacheMessage)
 		select {
 		case <-writeAccountCacheMessageCompleted:
-			au.log.Infof("initializeCaches completed initializing account data caches")
+			if err == nil {
+				au.log.Infof("initializeCaches completed initializing account data caches")
+			}
 		default:
 		}
 	}()
+
+	// this goroutine logs a message once if the parent function have not completed in initializingAccountCachesMessageTimeout seconds.
+	// the message is important, since we're blocking on the ledger block database here, and we want to make sure that we log a message
+	// within the above timeout.
 	go func() {
 		select {
 		case <-time.After(initializingAccountCachesMessageTimeout):

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1575,7 +1575,6 @@ func TestCachesInitialization(t *testing.T) {
 	au.initialize(config.GetDefaultLocal(), ".", proto, accts[0])
 	err := au.loadFromDisk(ml)
 	require.NoError(t, err)
-	defer au.close()
 
 	// cover initialRounds genesis blocks
 	rewardLevel := uint64(0)
@@ -1584,7 +1583,7 @@ func TestCachesInitialization(t *testing.T) {
 		rewardsLevels = append(rewardsLevels, rewardLevel)
 	}
 
-	recoveredLedgerRound := basics.Round(initializeCachesRoundFlushInterval * 3)
+	recoveredLedgerRound := basics.Round(initialRounds + initializeCachesRoundFlushInterval + proto.MaxBalLookback + 1)
 
 	for i := basics.Round(initialRounds); i <= recoveredLedgerRound; i++ {
 		rewardLevelDelta := crypto.RandUint64() % 5
@@ -1632,6 +1631,7 @@ func TestCachesInitialization(t *testing.T) {
 	au.initialize(config.GetDefaultLocal(), ".", proto, accts[0])
 	err = au.loadFromDisk(ml2)
 	require.NoError(t, err)
+	defer au.close()
 
 	// make sure the deltas array end up containing only the most recent 320 rounds.
 	require.Equal(t, int(proto.MaxBalLookback), len(au.deltas))


### PR DESCRIPTION
## Summary

During the accounts update initialization, we call the initializeCaches method to preload the most recent 320 rounds.
These 320 rounds are the difference between where the accounts database round and the latest blocks database round.

If (from any reason), the difference is more than 320 rounds, then all the rounds in that range are being loaded into memory. This, in turn, creates an issue when we have to recover from a large gap, as it would run out of memory.

To address this issue, this PR reconstruct the accounts database in "chunks" of 1000 rounds. This method prevent the node from going into a situation where it needs to handle large quantity of rounds sitting in memory.

## Test Plan

Unit test added. Verified manually that recovered account database end up generating the same catchpoints as on published mainnet.