### PR TITLE
comments. add lock to test to prevent rare race

### DIFF
--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -601,6 +601,7 @@ type SignedTxGroup struct {
 	// GroupCounter is a monotonic increasing counter, that provides an identify for each transaction group.
 	// The transaction sync is using it as a way to scan the transactions group list more efficiently, as it
 	// can continue scanning the list from the place where it last stopped.
+	// GroupCounter is local, assigned when the group is first seen by the local transaction pool.
 	GroupCounter uint64
 	// FirstTransactionID is the transaction ID of the first transaction in this transaction group.
 	// TODO - make this more secure by making this the hash of the first signed transaction.

--- a/txnsync/bloomFilter.go
+++ b/txnsync/bloomFilter.go
@@ -72,7 +72,7 @@ func (bf *bloomFilter) encode() (out encodedBloomFilter) {
 	}
 	return
 }
-func (bf *bloomFilter) compare(other bloomFilter) bool {
+func (bf *bloomFilter) sameParams(other bloomFilter) bool {
 	return (bf.encodingParams == other.encodingParams) && (bf.containedTxnsRange == other.containedTxnsRange)
 }
 

--- a/txnsync/emulatorTimer_test.go
+++ b/txnsync/emulatorTimer_test.go
@@ -57,6 +57,8 @@ func (g *guidedClock) TimeoutAt(delta time.Duration) <-chan time.Time {
 		close(c)
 		return c
 	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	if g.timers == nil {
 		g.timers = make(map[time.Duration]chan time.Time)
 	}
@@ -92,6 +94,7 @@ func (g *guidedClock) Advance(adv time.Duration) {
 		ch       chan time.Time
 	}
 	expiredClocks := []entryStruct{}
+	g.mu.Lock()
 	// find all the expired clocks.
 	for delta, ch := range g.timers {
 		if delta < g.adv {
@@ -106,6 +109,7 @@ func (g *guidedClock) Advance(adv time.Duration) {
 	for _, entry := range expiredClocks {
 		delete(g.timers, entry.duration)
 	}
+	g.mu.Unlock()
 	// fire expired clocks
 	for _, entry := range expiredClocks {
 		entry.ch <- g.zero.Add(g.adv)

--- a/txnsync/outgoing.go
+++ b/txnsync/outgoing.go
@@ -17,10 +17,10 @@
 package txnsync
 
 import (
-	"github.com/algorand/go-algorand/util/timers"
 	"time"
 
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/util/timers"
 )
 
 const messageTimeWindow = 20 * time.Millisecond
@@ -123,7 +123,7 @@ func (s *syncState) assemblePeerMessage(peer *Peer, pendingTransactions []transa
 	if (msgOps&messageConstBloomFilter == messageConstBloomFilter) && len(pendingTransactions) > 0 {
 		// generate a bloom filter that matches the requests params.
 		metaMessage.filter = makeBloomFilter(metaMessage.message.UpdatedRequestParams, pendingTransactions, uint32(s.node.Random(0xffffffff)))
-		if !metaMessage.filter.compare(peer.lastSentBloomFilter) {
+		if !metaMessage.filter.sameParams(peer.lastSentBloomFilter) {
 			metaMessage.message.TxnBloomFilter = metaMessage.filter.encode()
 			bloomFilterSize = metaMessage.message.TxnBloomFilter.Msgsize()
 		}


### PR DESCRIPTION
## Summary

Comments to help understand the code better. Rename 'compare' to 'sameParams' to be more descriptive.
Add a lock to a test to prevent rare race crash.

## Test Plan

Ran tests many times, race crash hasn't happened since adding lock.