### PR TITLE
Improve emulator logging & send request on offset change.

### DIFF
--- a/txnsync/emulatorLogger_test.go
+++ b/txnsync/emulatorLogger_test.go
@@ -79,7 +79,10 @@ func (e emulatorNodeLogger) printMsg(s string, args ...interface{}) {
 	var offset, modulator int
 	var bloom int
 	var nextTS int
-	fmt.Sscanf(fmt.Sprintf("%v %v %v %v %v %v %v", args...), "%d %d %d %d %d %d %d", &seq, &round, &transactions, &offset, &modulator, &bloom, &nextTS)
+	var destIndex int
+	fmt.Sscanf(fmt.Sprintf("%v %v %v %v %v %v %v %v", args...), "%d %d %d %d %d %d %d %d", &seq, &round, &transactions, &offset, &modulator, &bloom, &nextTS, &destIndex)
+
+	destName := e.node.emulator.nodes[destIndex].name
 
 	if e.longestName == 0 {
 		for _, node := range e.node.emulator.nodes {
@@ -94,7 +97,7 @@ func (e emulatorNodeLogger) printMsg(s string, args ...interface{}) {
 	if s == outgoingTxSyncMsgFormat {
 		out += fmt.Sprintf("%"+fmt.Sprintf("%d", e.longestName)+"s", e.node.name)
 	} else {
-		out += strings.Repeat(" ", e.longestName)
+		out += fmt.Sprintf("%"+fmt.Sprintf("%d", e.longestName)+"s", destName)
 	}
 	bfColor := hiblack
 	if bloom > 0 {
@@ -123,7 +126,7 @@ func (e emulatorNodeLogger) printMsg(s string, args ...interface{}) {
 	}
 
 	if s == outgoingTxSyncMsgFormat {
-		out += strings.Repeat(" ", e.longestName)
+		out += fmt.Sprintf("%"+fmt.Sprintf("%d", e.longestName)+"s", destName)
 	} else {
 		out += fmt.Sprintf("%"+fmt.Sprintf("%d", e.longestName)+"s", e.node.name)
 	}

--- a/txnsync/emulatorNode_test.go
+++ b/txnsync/emulatorNode_test.go
@@ -362,3 +362,7 @@ func (n *emulatedNode) onNewRound(round basics.Round, hasParticipationKeys bool)
 func (n *emulatedNode) onNewTransactionPoolEntry() {
 	n.externalEvents <- MakeTranscationPoolChangeEvent(len(n.txpoolEntries))
 }
+
+func (p *networkPeer) GetAddress() string {
+	return fmt.Sprintf("%d", p.target)
+}

--- a/txnsync/incoming.go
+++ b/txnsync/incoming.go
@@ -21,7 +21,7 @@ import (
 	"time"
 )
 
-var incomingTxSyncMsgFormat = "Incoming Txsync #%d round %d transacations %d request [%d/%d] bloom %d nextTS %d"
+var incomingTxSyncMsgFormat = "Incoming Txsync #%d round %d transacations %d request [%d/%d] bloom %d nextTS %d to '%s'"
 
 var errUnsupportedTransactionSyncMessageVersion = errors.New("unsupported transaction sync message version")
 
@@ -153,7 +153,7 @@ func (s *syncState) evaluateIncomingMessage(message incomingMessage) {
 		// add the received transaction groups to the peer's recentSentTransactions so that we won't be sending these back to the peer.
 		peer.updateIncomingTransactionGroups(txnGroups)
 
-		s.log.Infof(incomingTxSyncMsgFormat, seq, txMsg.Round, len(txnGroups), txMsg.UpdatedRequestParams.Offset, txMsg.UpdatedRequestParams.Modulator, len(txMsg.TxnBloomFilter.BloomFilter), txMsg.MsgSync.NextMsgMinDelay)
+		s.log.Infof(incomingTxSyncMsgFormat, seq, txMsg.Round, len(txnGroups), txMsg.UpdatedRequestParams.Offset, txMsg.UpdatedRequestParams.Modulator, len(txMsg.TxnBloomFilter.BloomFilter), txMsg.MsgSync.NextMsgMinDelay, peer.networkAddress())
 		messageProcessed = true
 	}
 	// if we're a relay, this is an outgoing peer and we've processed a valid message,

--- a/txnsync/interfaces.go
+++ b/txnsync/interfaces.go
@@ -57,6 +57,12 @@ type PeerInfo struct {
 	IsOutgoing  bool
 }
 
+// networkPeerAddress is a subset of the network package HTTPPeer and UnicastPeer interface that
+// provides feedback for the destination address. It's used for logging out packet's destination addresses.
+type networkPeerAddress interface {
+	GetAddress() string
+}
+
 // NodeConnector is used by the transaction sync for communicating with components external to the txnsync package.
 type NodeConnector interface {
 	Events() <-chan Event

--- a/txnsync/outgoing.go
+++ b/txnsync/outgoing.go
@@ -25,7 +25,7 @@ import (
 
 const messageTimeWindow = 20 * time.Millisecond
 
-var outgoingTxSyncMsgFormat = "Outgoing Txsync #%d round %d transacations %d request [%d/%d] bloom %d nextTS %d"
+var outgoingTxSyncMsgFormat = "Outgoing Txsync #%d round %d transacations %d request [%d/%d] bloom %d nextTS %d to '%s'"
 
 type sentMessageMetadata struct {
 	encodedMessageSize  int
@@ -116,7 +116,7 @@ func (s *syncState) assemblePeerMessage(peer *Peer, pendingTransactions []transa
 		metaMessage.message.UpdatedRequestParams.Modulator = modulator
 		if modulator > 0 {
 			// for relays, the modulator is always one, which means the following would always be zero.
-			metaMessage.message.UpdatedRequestParams.Offset = byte((s.requestsOffset + uint64(offset)) % uint64(modulator))
+			metaMessage.message.UpdatedRequestParams.Offset = byte(uint64(offset) % uint64(modulator))
 		}
 	}
 
@@ -161,8 +161,9 @@ func (s *syncState) assemblePeerMessage(peer *Peer, pendingTransactions []transa
 
 func (s *syncState) evaluateOutgoingMessage(msg *messageSentCallback) {
 	msgData := msg.messageData
+
 	msgData.peer.updateMessageSent(msgData.message, msgData.sentTranscationsIDs, msgData.sentTimestamp, msgData.sequenceNumber, msgData.encodedMessageSize, msgData.filter)
-	s.log.Infof(outgoingTxSyncMsgFormat, msgData.sequenceNumber, msgData.message.Round, len(msgData.sentTranscationsIDs), msgData.message.UpdatedRequestParams.Offset, msgData.message.UpdatedRequestParams.Modulator, len(msgData.message.TxnBloomFilter.BloomFilter), msgData.message.MsgSync.NextMsgMinDelay)
+	s.log.Infof(outgoingTxSyncMsgFormat, msgData.sequenceNumber, msgData.message.Round, len(msgData.sentTranscationsIDs), msgData.message.UpdatedRequestParams.Offset, msgData.message.UpdatedRequestParams.Modulator, len(msgData.message.TxnBloomFilter.BloomFilter), msgData.message.MsgSync.NextMsgMinDelay, msg.messageData.peer.networkAddress())
 	//s.log.Infof("outgoing message %v \n", msgData.message.MsgSync.NextMsgMinDelay)
 }
 

--- a/txnsync/peer.go
+++ b/txnsync/peer.go
@@ -564,3 +564,10 @@ func (p *Peer) getNextScheduleOffset(isRelay bool, beta time.Duration, partialMe
 	}
 	return time.Duration(0), 0
 }
+
+func (p *Peer) networkAddress() string {
+	if peerAddress, supportInterface := p.networkPeer.(networkPeerAddress); supportInterface {
+		return peerAddress.GetAddress()
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

This PR handles two separate issues:
1. On the non-relay, it sends a message every time the offset for the node changes. ( i.e. ~4 times a second).
    This helps to reduce the amount of redundant transactions are sent to the non-relay.
2. Added a destination to the logged message so that we can see on the emulation the name of the destination node.

## Test Plan

Unit tests were updated.