### PR TITLE
Improve txnsync emulator performance and memory profile

### DIFF
--- a/txnsync/emulatorNode_test.go
+++ b/txnsync/emulatorNode_test.go
@@ -22,8 +22,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/algorand/go-deadlock"
-
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -47,7 +45,7 @@ type networkPeer struct {
 	inSeq                uint64
 	target               int
 	messageQ             []queuedMessage // incoming message queue
-	mu                   deadlock.Mutex
+	lockCh               chan struct{}
 	deferredSentMessages []queuedSentMessageCallback // outgoing messages callback queue
 }
 
@@ -62,7 +60,7 @@ type emulatedNode struct {
 	txpoolIds          map[transactions.Txid]bool
 	name               string
 	blocked            chan struct{}
-	mu                 deadlock.Mutex
+	lockCh             chan struct{}
 	txpoolGroupCounter uint64
 	blockingEnabled    bool
 	nodeBlocked        chan struct{} // channel is closed when node is blocked.
@@ -80,6 +78,7 @@ func makeEmulatedNode(emulator *emulator, nodeIdx int) *emulatedNode {
 		blockingEnabled: true,
 		nodeBlocked:     make(chan struct{}, 1),
 		nodeRunning:     make(chan struct{}, 1),
+		lockCh:          make(chan struct{}, 1),
 	}
 	close(en.nodeRunning)
 
@@ -90,6 +89,7 @@ func makeEmulatedNode(emulator *emulator, nodeIdx int) *emulatedNode {
 			downloadSpeed: conn.downloadSpeed,
 			isOutgoing:    true,
 			target:        conn.target,
+			lockCh:        make(chan struct{}, 1),
 		}
 	}
 	// add incoming connections
@@ -108,6 +108,7 @@ func makeEmulatedNode(emulator *emulator, nodeIdx int) *emulatedNode {
 				downloadSpeed: conn.uploadSpeed,
 				isOutgoing:    false,
 				target:        nodeID,
+				lockCh:        make(chan struct{}, 1),
 			}
 		}
 	}
@@ -120,33 +121,33 @@ func (n *emulatedNode) Events() <-chan Event {
 
 func (n *emulatedNode) NotifyMonitor() chan struct{} {
 	var c chan struct{}
-	n.mu.Lock()
+	n.lock()
 	if n.blockingEnabled {
 		c = make(chan struct{})
 		n.blocked = c
 		close(n.nodeBlocked)
 		n.nodeRunning = make(chan struct{}, 1)
-		n.mu.Unlock()
+		n.unlock()
 		<-c
-		n.mu.Lock()
+		n.lock()
 		close(n.nodeRunning)
 		n.nodeBlocked = make(chan struct{}, 1)
-		n.mu.Unlock()
+		n.unlock()
 		// return a closed channel.
 		return c
 	}
-	n.mu.Unlock()
+	n.unlock()
 	// return an open channel
 	return make(chan struct{})
 }
 func (n *emulatedNode) disableBlocking() {
-	n.mu.Lock()
+	n.lock()
 	n.blockingEnabled = false
-	n.mu.Unlock()
+	n.unlock()
 	n.unblock()
 }
 func (n *emulatedNode) unblock() {
-	n.mu.Lock()
+	n.lock()
 	// wait until the state chages to StateMachineRunning
 	select {
 	case <-n.nodeBlocked:
@@ -156,25 +157,25 @@ func (n *emulatedNode) unblock() {
 			n.blocked = nil
 		}
 		runningCh := n.nodeRunning
-		n.mu.Unlock()
+		n.unlock()
 		<-runningCh
 		return
 	default:
 	}
-	n.mu.Unlock()
+	n.unlock()
 }
 
 func (n *emulatedNode) waitBlocked() {
-	n.mu.Lock()
+	n.lock()
 	select {
 	case <-n.nodeRunning:
 		blockedCh := n.nodeBlocked
-		n.mu.Unlock()
+		n.unlock()
 		<-blockedCh
 		return
 	default:
 	}
-	n.mu.Unlock()
+	n.unlock()
 }
 
 func (n *emulatedNode) GetCurrentRoundSettings() RoundSettings {
@@ -247,7 +248,7 @@ func (n *emulatedNode) UpdatePeers(txPeers []*Peer, netPeers []interface{}) {
 }
 
 func (n *emulatedNode) enqueueMessage(from int, msg queuedMessage) {
-	n.peers[from].mu.Lock()
+	n.peers[from].lock()
 	baseTime := n.emulator.clock.Since()
 	if len(n.peers[from].messageQ) > 0 {
 		if n.peers[from].messageQ[len(n.peers[from].messageQ)-1].readyAt > baseTime {
@@ -255,7 +256,7 @@ func (n *emulatedNode) enqueueMessage(from int, msg queuedMessage) {
 		}
 	}
 	n.peers[from].messageQ = append(n.peers[from].messageQ, queuedMessage{bytes: msg.bytes, readyAt: baseTime + msg.readyAt})
-	n.peers[from].mu.Unlock()
+	n.peers[from].unlock()
 }
 
 func (n *emulatedNode) SendPeerMessage(netPeer interface{}, msg []byte, callback SendMessageCallback) {
@@ -306,16 +307,16 @@ func (n *emulatedNode) step() {
 	// check if we have any pending network messages and forward them.
 
 	for _, peer := range n.orderedPeers() {
-		peer.mu.Lock()
+		peer.lock()
 
 		for i := len(peer.deferredSentMessages); i > 0; i-- {
 			dm := peer.deferredSentMessages[0]
 			peer.deferredSentMessages = peer.deferredSentMessages[1:]
-			peer.mu.Unlock()
+			peer.unlock()
 			dm.callback(true, dm.seq)
 			n.unblock()
 			n.waitBlocked()
-			peer.mu.Lock()
+			peer.lock()
 		}
 
 		for i := len(peer.messageQ); i > 0; i-- {
@@ -329,15 +330,15 @@ func (n *emulatedNode) step() {
 			peer.inSeq++
 			peer.messageQ = peer.messageQ[1:]
 
-			peer.mu.Unlock()
+			peer.unlock()
 
 			msgHandler(peer, peer.peer, msgBytes, msgInSeq)
 			n.unblock()
 			n.waitBlocked()
-			peer.mu.Lock()
+			peer.lock()
 
 		}
-		peer.mu.Unlock()
+		peer.unlock()
 	}
 
 }
@@ -363,6 +364,22 @@ func (n *emulatedNode) onNewTransactionPoolEntry() {
 	n.externalEvents <- MakeTranscationPoolChangeEvent(len(n.txpoolEntries))
 }
 
+func (n *emulatedNode) lock() {
+	n.lockCh <- struct{}{}
+}
+
+func (n *emulatedNode) unlock() {
+	<-n.lockCh
+}
+
 func (p *networkPeer) GetAddress() string {
 	return fmt.Sprintf("%d", p.target)
+}
+
+func (p *networkPeer) lock() {
+	p.lockCh <- struct{}{}
+}
+
+func (p *networkPeer) unlock() {
+	<-p.lockCh
 }

--- a/txnsync/emulatorTimer_test.go
+++ b/txnsync/emulatorTimer_test.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/algorand/go-deadlock"
+	//"github.com/algorand/go-deadlock"
 
 	"github.com/algorand/go-algorand/util/timers"
 )
@@ -31,22 +31,24 @@ type guidedClock struct {
 	adv      time.Duration
 	timers   map[time.Duration]chan time.Time
 	children []*guidedClock
-	mu       deadlock.Mutex
+	lockCh   chan struct{}
 }
 
 func makeGuidedClock() *guidedClock {
 	return &guidedClock{
-		zero: time.Now(),
+		zero:   time.Now(),
+		lockCh: make(chan struct{}, 1),
 	}
 }
 func (g *guidedClock) Zero() timers.Clock {
 	// the real monotonic clock doesn't return the same clock object, which is fine.. but for our testing
 	// we want to keep the same clock object so that we can tweak with it.
 	child := &guidedClock{
-		zero: g.zero.Add(g.adv),
+		zero:   g.zero.Add(g.adv),
+		lockCh: make(chan struct{}, 1),
 	}
-	g.mu.Lock()
-	defer g.mu.Unlock()
+	g.lock()
+	defer g.unlock()
 	g.children = append(g.children, child)
 	return child
 }
@@ -57,8 +59,8 @@ func (g *guidedClock) TimeoutAt(delta time.Duration) <-chan time.Time {
 		close(c)
 		return c
 	}
-	g.mu.Lock()
-	defer g.mu.Unlock()
+	g.lock()
+	defer g.unlock()
 	if g.timers == nil {
 		g.timers = make(map[time.Duration]chan time.Time)
 	}
@@ -94,7 +96,7 @@ func (g *guidedClock) Advance(adv time.Duration) {
 		ch       chan time.Time
 	}
 	expiredClocks := []entryStruct{}
-	g.mu.Lock()
+	g.lock()
 	// find all the expired clocks.
 	for delta, ch := range g.timers {
 		if delta < g.adv {
@@ -109,14 +111,22 @@ func (g *guidedClock) Advance(adv time.Duration) {
 	for _, entry := range expiredClocks {
 		delete(g.timers, entry.duration)
 	}
-	g.mu.Unlock()
+	g.unlock()
 	// fire expired clocks
 	for _, entry := range expiredClocks {
 		entry.ch <- g.zero.Add(g.adv)
 	}
-	g.mu.Lock()
-	defer g.mu.Unlock()
+	g.lock()
+	defer g.unlock()
 	for _, child := range g.children {
 		child.Advance(adv)
 	}
+}
+
+func (g *guidedClock) lock() {
+	g.lockCh <- struct{}{}
+}
+
+func (g *guidedClock) unlock() {
+	<-g.lockCh
 }

--- a/txnsync/emulatorTimer_test.go
+++ b/txnsync/emulatorTimer_test.go
@@ -20,8 +20,6 @@ import (
 	"sort"
 	"time"
 
-	//"github.com/algorand/go-deadlock"
-
 	"github.com/algorand/go-algorand/util/timers"
 )
 

--- a/txnsync/outgoing.go
+++ b/txnsync/outgoing.go
@@ -41,6 +41,7 @@ type sentMessageMetadata struct {
 type messageSentCallback struct {
 	state       *syncState
 	messageData sentMessageMetadata
+	roundClock  timers.WallClock
 }
 
 // asyncMessageSent called via the network package to inform the txsync that a message was enqueued, and the associated sequence number.
@@ -49,7 +50,7 @@ func (msc *messageSentCallback) asyncMessageSent(enqueued bool, sequenceNumber u
 		return
 	}
 	// record the timestamp here, before placing the entry on the queue
-	msc.messageData.sentTimestamp = msc.state.clock.Since()
+	msc.messageData.sentTimestamp = msc.roundClock.Since()
 	msc.messageData.sequenceNumber = sequenceNumber
 
 	select {
@@ -67,7 +68,7 @@ func (s *syncState) sendMessageLoop(currentTime time.Duration, deadline timers.D
 	pendingTransactionGroups := s.node.GetPendingTransactionGroups()
 
 	for _, peer := range peers {
-		msgCallback := &messageSentCallback{state: s}
+		msgCallback := &messageSentCallback{state: s, roundClock: s.clock}
 		msgCallback.messageData = s.assemblePeerMessage(peer, pendingTransactionGroups, currentTime)
 		encodedMessage := msgCallback.messageData.message.MarshalMsg([]byte{})
 		msgCallback.messageData.encodedMessageSize = len(encodedMessage)


### PR DESCRIPTION
## Summary

Avoid using the `deadlock.Mutex` in the emulator, and use a channel instead.
The `deadlock.Mutex` was consuming considerable amount of memory, due to it's internally allocated timer.

edit: following on rare data races found on travis, I avoided using the main state's clock in the async methods. The clock is being updated once every round, so we can't really control that unless we add a synchronization primitive or find a better way.

## Test Plan

This is a test.