### PR TITLE
create a msgStat object so that we don't have to sscanf(sprintf())

### DIFF
--- a/txnsync/emulatorLogger_test.go
+++ b/txnsync/emulatorLogger_test.go
@@ -18,6 +18,7 @@ package txnsync
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/algorand/go-algorand/logging"
@@ -63,24 +64,20 @@ func makeNodeLogger(l logging.Logger, node *emulatedNode) logging.Logger {
 }
 
 func (e emulatorNodeLogger) Infof(s string, args ...interface{}) {
-	if s == incomingTxSyncMsgFormat || s == outgoingTxSyncMsgFormat {
-		// special output.
-		e.printMsg(s, args...)
-	} else {
-		e.Logger.Infof(e.node.name+" :"+s, args...)
-	}
+	e.Logger.Infof(e.node.name+" :"+s, args...)
 }
 
-func (e emulatorNodeLogger) printMsg(s string, args ...interface{}) {
-	// "Incoming Txsync #%d round %d transacations %d request [%d/%d]"
-	var seq int
-	var round int
-	var transactions int
-	var offset, modulator int
-	var bloom int
-	var nextTS int
-	var destIndex int
-	fmt.Sscanf(fmt.Sprintf("%v %v %v %v %v %v %v %v", args...), "%d %d %d %d %d %d %d %d", &seq, &round, &transactions, &offset, &modulator, &bloom, &nextTS, &destIndex)
+// implement local interface msgStatsReceiver
+func (e emulatorNodeLogger) printMsgStats(mode msgMode, mstat *msgStats) {
+	seq := int(mstat.sequenceNumber)
+	round := mstat.round
+	transactions := mstat.transactions
+	offset := mstat.offsetModulator.Offset
+	modulator := mstat.offsetModulator.Modulator
+	bloom := mstat.bloomSize
+	nextTS := mstat.nextMsgMinDelay
+	// emulator peer addresses are just an int
+	destIndex, _ := strconv.Atoi(mstat.peerAddress)
 
 	destName := e.node.emulator.nodes[destIndex].name
 
@@ -94,7 +91,7 @@ func (e emulatorNodeLogger) printMsg(s string, args ...interface{}) {
 
 	elapsed := e.node.emulator.clock.Since().Milliseconds()
 	out := fmt.Sprintf("%3d.%03d ", elapsed/1000, elapsed%1000)
-	if s == outgoingTxSyncMsgFormat {
+	if mode == modeOutgoing {
 		out += fmt.Sprintf("%"+fmt.Sprintf("%d", e.longestName)+"s", e.node.name)
 	} else {
 		out += fmt.Sprintf("%"+fmt.Sprintf("%d", e.longestName)+"s", destName)
@@ -108,24 +105,24 @@ func (e emulatorNodeLogger) printMsg(s string, args ...interface{}) {
 		nextTSColor = higreen
 	}
 	mid := fmt.Sprintf("Round %s Txns %s Req [%3d/%3d] %s %s",
-		wrapRollingColor(round, fmt.Sprintf("%2d", round)),
+		wrapRollingColor(int(round), fmt.Sprintf("%2d", round)),
 		wrapRollingColor(transactions, fmt.Sprintf("%3d", transactions)),
 		offset,
 		modulator,
 		wrapColor(bfColor, "BF"),
 		wrapColor(nextTSColor, "TS"),
 	)
-	if s == incomingTxSyncMsgFormat {
-		out += wrapColor(hiblack, " [ ")
-		out += strings.Repeat(" ", 20) + wrapRollingLowColor(seq, " <-- ") + mid
-		out += wrapRollingLowColor(seq, " ] ")
-	} else {
+	if mode == modeOutgoing {
 		out += wrapRollingLowColor(seq, " [ ")
 		out += mid + wrapRollingLowColor(seq, " --> ") + strings.Repeat(" ", 20)
 		out += wrapColor(hiblack, " ] ")
+	} else {
+		out += wrapColor(hiblack, " [ ")
+		out += strings.Repeat(" ", 20) + wrapRollingLowColor(seq, " <-- ") + mid
+		out += wrapRollingLowColor(seq, " ] ")
 	}
 
-	if s == outgoingTxSyncMsgFormat {
+	if mode == modeOutgoing {
 		out += fmt.Sprintf("%"+fmt.Sprintf("%d", e.longestName)+"s", destName)
 	} else {
 		out += fmt.Sprintf("%"+fmt.Sprintf("%d", e.longestName)+"s", e.node.name)

--- a/txnsync/incoming.go
+++ b/txnsync/incoming.go
@@ -21,8 +21,6 @@ import (
 	"time"
 )
 
-var incomingTxSyncMsgFormat = "Incoming Txsync #%d round %d transacations %d request [%d/%d] bloom %d nextTS %d to '%s'"
-
 var errUnsupportedTransactionSyncMessageVersion = errors.New("unsupported transaction sync message version")
 
 type incomingMessage struct {
@@ -153,7 +151,7 @@ func (s *syncState) evaluateIncomingMessage(message incomingMessage) {
 		// add the received transaction groups to the peer's recentSentTransactions so that we won't be sending these back to the peer.
 		peer.updateIncomingTransactionGroups(txnGroups)
 
-		s.log.Infof(incomingTxSyncMsgFormat, seq, txMsg.Round, len(txnGroups), txMsg.UpdatedRequestParams.Offset, txMsg.UpdatedRequestParams.Modulator, len(txMsg.TxnBloomFilter.BloomFilter), txMsg.MsgSync.NextMsgMinDelay, peer.networkAddress())
+		s.logMsgStats(modeIncoming, msgStats{seq, txMsg.Round, len(txnGroups), txMsg.UpdatedRequestParams, len(txMsg.TxnBloomFilter.BloomFilter), txMsg.MsgSync.NextMsgMinDelay, peer.networkAddress()})
 		messageProcessed = true
 	}
 	// if we're a relay, this is an outgoing peer and we've processed a valid message,

--- a/txnsync/mainloop.go
+++ b/txnsync/mainloop.go
@@ -302,3 +302,55 @@ func (s *syncState) updatePeersRequestParams(peers []*Peer) {
 		}
 	}
 }
+
+func (s *syncState) logMsgStats(mode msgMode, mstat msgStats) {
+	var modeString string
+	var tofrom string
+	switch mode {
+	case modeIncoming:
+		modeString = "Incoming"
+		tofrom = "from"
+	case modeOutgoing:
+		modeString = "Outgoing"
+		tofrom = "to"
+	}
+
+	s.log.Infof(
+		"%s Txsync #%d round %d transacations %d request [%d/%d] bloom %d nextTS %d %s '%s'",
+		modeString,
+		mstat.sequenceNumber,
+		mstat.round,
+		mstat.transactions,
+		mstat.offsetModulator.Offset,
+		mstat.offsetModulator.Modulator,
+		mstat.bloomSize,
+		mstat.nextMsgMinDelay,
+		tofrom,
+		mstat.peerAddress,
+	)
+	if mr, ok := s.log.(msgStatsReceiver); ok {
+		mr.printMsgStats(mode, &mstat)
+	}
+}
+
+type msgMode int
+
+const (
+	modeZero     msgMode = 0
+	modeIncoming msgMode = iota
+	modeOutgoing msgMode = iota
+)
+
+type msgStats struct {
+	sequenceNumber  uint64
+	round           basics.Round
+	transactions    int
+	offsetModulator requestParams
+	bloomSize       int
+	nextMsgMinDelay uint64
+	peerAddress     string
+}
+
+type msgStatsReceiver interface {
+	printMsgStats(mode msgMode, mstat *msgStats)
+}

--- a/txnsync/outgoing.go
+++ b/txnsync/outgoing.go
@@ -25,8 +25,6 @@ import (
 
 const messageTimeWindow = 20 * time.Millisecond
 
-var outgoingTxSyncMsgFormat = "Outgoing Txsync #%d round %d transacations %d request [%d/%d] bloom %d nextTS %d to '%s'"
-
 type sentMessageMetadata struct {
 	encodedMessageSize  int
 	sentTranscationsIDs []transactions.Txid
@@ -163,8 +161,7 @@ func (s *syncState) evaluateOutgoingMessage(msg *messageSentCallback) {
 	msgData := msg.messageData
 
 	msgData.peer.updateMessageSent(msgData.message, msgData.sentTranscationsIDs, msgData.sentTimestamp, msgData.sequenceNumber, msgData.encodedMessageSize, msgData.filter)
-	s.log.Infof(outgoingTxSyncMsgFormat, msgData.sequenceNumber, msgData.message.Round, len(msgData.sentTranscationsIDs), msgData.message.UpdatedRequestParams.Offset, msgData.message.UpdatedRequestParams.Modulator, len(msgData.message.TxnBloomFilter.BloomFilter), msgData.message.MsgSync.NextMsgMinDelay, msg.messageData.peer.networkAddress())
-	//s.log.Infof("outgoing message %v \n", msgData.message.MsgSync.NextMsgMinDelay)
+	s.logMsgStats(modeOutgoing, msgStats{msgData.sequenceNumber, msgData.message.Round, len(msgData.sentTranscationsIDs), msgData.message.UpdatedRequestParams, len(msgData.message.TxnBloomFilter.BloomFilter), msgData.message.MsgSync.NextMsgMinDelay, msg.messageData.peer.networkAddress()})
 }
 
 // locallyGeneratedTransactions return a subset of the given transactionGroups array by filtering out transactions that are not locally generated.


### PR DESCRIPTION
## Summary

Create a msgStat{} object for logging to unify rx and tx logging and to make debug logging better without the need for sscanf(sprintf())

## Test Plan

Minor logging tweaks. Existing tests still pass.