### PR TITLE
locally allow sync.Mutex

### DIFF
--- a/cmd/algofix/deadlock_test.go
+++ b/cmd/algofix/deadlock_test.go
@@ -70,8 +70,8 @@ func main() {
 }
 `
 
-func tripleQuoteToBacktick(x string) string {
-	return strings.ReplaceAll(x, "\"\"\"", "`")
+func tripleTickToBacktick(x string) string {
+	return strings.ReplaceAll(x, "'''", "`")
 }
 
 const deadlock_test_src = `package main
@@ -82,7 +82,7 @@ import (
 
 type thing struct {
 	l sync.Mutex
-	r sync.Mutex """algofix:allow sync.Mutex"""
+	r sync.Mutex '''algofix:"allow sync.Mutex"'''
 	x sync.Mutex
 }
 
@@ -110,7 +110,7 @@ import (
 
 type thing struct {
 	l deadlock.Mutex
-	r deadlock.Mutex """algofix:allow sync.Mutex"""
+	r sync.Mutex '''algofix:"allow sync.Mutex"'''
 	x deadlock.Mutex
 }
 
@@ -144,8 +144,8 @@ func testGoFmt(fset *token.FileSet, node interface{}) (out string, err error) {
 }
 
 func testDeadlock(t *testing.T, src, dest string) {
-	src = tripleQuoteToBacktick(src)
-	dest = tripleQuoteToBacktick(dest)
+	src = tripleTickToBacktick(src)
+	dest = tripleTickToBacktick(dest)
 	fset := token.NewFileSet()
 	filename := "testmain.go"
 	file, err := parser.ParseFile(fset, filename, src, parserMode)

--- a/cmd/algofix/deadlock_test.go
+++ b/cmd/algofix/deadlock_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const deadlock_simple_src = `package main
+const deadlockSimpleSrc = `package main
 
 import (
 	"sync"
@@ -48,7 +48,7 @@ func main() {
 	defer x.Unlock()
 }
 `
-const deadlock_simple_dest = `package main
+const deadlockSimpleDest = `package main
 
 import (
 	"github.com/algorand/go-deadlock"
@@ -74,7 +74,7 @@ func tripleTickToBacktick(x string) string {
 	return strings.ReplaceAll(x, "'''", "`")
 }
 
-const deadlock_test_src = `package main
+const deadlockTestSrc = `package main
 
 import (
 	"sync"
@@ -101,7 +101,7 @@ func main() {
 }
 `
 
-const deadlock_test_fin = `package main
+const deadlockTestFin = `package main
 
 import (
 	"github.com/algorand/go-deadlock"
@@ -130,8 +130,8 @@ func main() {
 `
 
 func TestDeadlockRewrite(t *testing.T) {
-	t.Run("simple", func(t *testing.T) { testDeadlock(t, deadlock_simple_src, deadlock_simple_dest) })
-	t.Run("onoff", func(t *testing.T) { testDeadlock(t, deadlock_test_src, deadlock_test_fin) })
+	t.Run("simple", func(t *testing.T) { testDeadlock(t, deadlockSimpleSrc, deadlockSimpleDest) })
+	t.Run("onoff", func(t *testing.T) { testDeadlock(t, deadlockTestSrc, deadlockTestFin) })
 }
 
 func testGoFmt(fset *token.FileSet, node interface{}) (out string, err error) {

--- a/cmd/algofix/deadlock_test.go
+++ b/cmd/algofix/deadlock_test.go
@@ -1,0 +1,163 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const deadlock_simple_src = `package main
+
+import (
+	"sync"
+)
+
+func main() {
+	// lol wut?
+	var l sync.Mutex
+	var r sync.Mutex
+	var x sync.Mutex
+
+	l.Lock()
+	defer l.Unlock()
+	r.Lock()
+	defer r.Unlock()
+	x.Lock()
+	defer x.Unlock()
+}
+`
+const deadlock_simple_dest = `package main
+
+import (
+	"github.com/algorand/go-deadlock"
+	"sync"
+)
+
+func main() {
+	// lol wut?
+	var l deadlock.Mutex
+	var r deadlock.Mutex
+	var x deadlock.Mutex
+
+	l.Lock()
+	defer l.Unlock()
+	r.Lock()
+	defer r.Unlock()
+	x.Lock()
+	defer x.Unlock()
+}
+`
+
+const deadlock_test_src = `package main
+
+import (
+	"sync"
+)
+
+func main() {
+	var l sync.Mutex
+
+	// algofix allow sync
+	var r sync.Mutex
+
+	// algofix require deadlock
+	var x sync.Mutex
+
+	l.Lock()
+	defer l.Unlock()
+	r.Lock()
+	defer r.Unlock()
+	x.Lock()
+	defer x.Unlock()
+}
+`
+
+const deadlock_test_fin = `package main
+
+import (
+	"github.com/algorand/go-deadlock"
+	"sync"
+)
+
+func main() {
+	var l deadlock.Mutex
+
+	// algofix allow sync
+	var r sync.Mutex
+
+	// algofix require deadlock
+	var x deadlock.Mutex
+
+	l.Lock()
+	defer l.Unlock()
+	r.Lock()
+	defer r.Unlock()
+	x.Lock()
+	defer x.Unlock()
+}
+`
+
+func TestDeadlockRewrite(t *testing.T) {
+	t.Run("simple", func(t *testing.T) { testDeadlock(t, deadlock_simple_src, deadlock_simple_dest) })
+	t.Run("onoff", func(t *testing.T) { testDeadlock(t, deadlock_test_src, deadlock_test_fin) })
+}
+
+func testGoFmt(fset *token.FileSet, node interface{}) (out string, err error) {
+	var buf bytes.Buffer
+	err = format.Node(&buf, fset, node)
+	if err == nil {
+		out = string(buf.Bytes())
+	}
+	return
+}
+
+func testDeadlock(t *testing.T, src, dest string) {
+	fset := token.NewFileSet()
+	filename := "testmain.go"
+	file, err := parser.ParseFile(fset, filename, src, parserMode)
+	require.NoError(t, err)
+	fixed := deadlock(file)
+	require.True(t, fixed)
+	src2, err := testGoFmt(fset, file)
+	require.NoError(t, err)
+
+	// rinse, repeat?
+	newFile, err := parser.ParseFile(fset, filename, src2, parserMode)
+	require.NoError(t, err)
+	src3, err := testGoFmt(fset, newFile)
+	require.NoError(t, err)
+
+	if string(src3) != dest {
+		fmt.Printf("===== %s orig =====\n", t.Name())
+		fmt.Println(string(src))
+		fmt.Printf("===== %s orig =====\n", t.Name())
+		fmt.Printf("===== %s src2 =====\n", t.Name())
+		fmt.Println(string(src2))
+		fmt.Printf("===== %s src2 =====\n", t.Name())
+		fmt.Printf("===== %s actual =====\n", t.Name())
+		fmt.Println(string(src3))
+		fmt.Printf("===== %s actual =====\n", t.Name())
+	}
+	require.Equal(t, dest, string(src3))
+}

--- a/test/e2e-go/features/catchup/basicCatchup_test.go
+++ b/test/e2e-go/features/catchup/basicCatchup_test.go
@@ -83,7 +83,7 @@ func TestCatchupOverGossip(t *testing.T) {
 
 	// ledger node upgraded version, fetcher node upgraded version
 	// Run with the default values. Instead of "", pass the default value
-	// to exercise loading it from the config file. 
+	// to exercise loading it from the config file.
 	runCatchupOverGossip(t, supportedVersions[0], supportedVersions[0])
 	for i := 1; i < len(supportedVersions); i++ {
 		runCatchupOverGossip(t, supportedVersions[i], "")
@@ -111,7 +111,7 @@ func runCatchupOverGossip(t *testing.T,
 	// distribution for catchup so this is fine.
 	fixture.SetupNoStart(t, filepath.Join("nettemplates", "TwoNodes100Second.json"))
 
-	if ledgerNodeDowngradeTo != ""{
+	if ledgerNodeDowngradeTo != "" {
 		// Force the node to only support v1
 		dir, err := fixture.GetNodeDir("Node")
 		a.NoError(err)

--- a/txnsync/emulatorNode_test.go
+++ b/txnsync/emulatorNode_test.go
@@ -48,7 +48,7 @@ type networkPeer struct {
 
 	messageQ []queuedMessage // incoming message queue
 
-	mu sync.Mutex `algofix:allow sync.Mutex`
+	mu sync.Mutex `algofix:"allow sync.Mutex"`
 
 	deferredSentMessages []queuedSentMessageCallback // outgoing messages callback queue
 }
@@ -64,7 +64,7 @@ type emulatedNode struct {
 	txpoolIds          map[transactions.Txid]bool
 	name               string
 	blocked            chan struct{}
-	mu                 sync.Mutex `algofix:allow sync.Mutex`
+	mu                 sync.Mutex `algofix:"allow sync.Mutex"`
 	txpoolGroupCounter uint64
 	blockingEnabled    bool
 	nodeBlocked        chan struct{} // channel is closed when node is blocked.

--- a/txnsync/emulatorNode_test.go
+++ b/txnsync/emulatorNode_test.go
@@ -19,16 +19,17 @@ package txnsync
 import (
 	"fmt"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
-
-	"github.com/algorand/go-deadlock"
 
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/util/timers"
 )
+
+// algofix allow sync
 
 type queuedSentMessageCallback struct {
 	callback SendMessageCallback
@@ -47,7 +48,7 @@ type networkPeer struct {
 	inSeq                uint64
 	target               int
 	messageQ             []queuedMessage // incoming message queue
-	mu                   deadlock.Mutex
+	mu                   sync.Mutex
 	deferredSentMessages []queuedSentMessageCallback // outgoing messages callback queue
 }
 
@@ -62,7 +63,7 @@ type emulatedNode struct {
 	txpoolIds          map[transactions.Txid]bool
 	name               string
 	blocked            chan struct{}
-	mu                 deadlock.Mutex
+	mu                 sync.Mutex
 	txpoolGroupCounter uint64
 	blockingEnabled    bool
 	nodeBlocked        chan struct{} // channel is closed when node is blocked.

--- a/txnsync/emulatorNode_test.go
+++ b/txnsync/emulatorNode_test.go
@@ -29,8 +29,6 @@ import (
 	"github.com/algorand/go-algorand/util/timers"
 )
 
-// algofix allow sync
-
 type queuedSentMessageCallback struct {
 	callback SendMessageCallback
 	seq      uint64
@@ -40,15 +38,18 @@ type queuedMessage struct {
 	readyAt time.Duration
 }
 type networkPeer struct {
-	peer                 *Peer
-	uploadSpeed          uint64
-	downloadSpeed        uint64
-	isOutgoing           bool
-	outSeq               uint64
-	inSeq                uint64
-	target               int
-	messageQ             []queuedMessage // incoming message queue
-	mu                   sync.Mutex
+	peer          *Peer
+	uploadSpeed   uint64
+	downloadSpeed uint64
+	isOutgoing    bool
+	outSeq        uint64
+	inSeq         uint64
+	target        int
+
+	messageQ []queuedMessage // incoming message queue
+
+	mu sync.Mutex `algofix:allow sync.Mutex`
+
 	deferredSentMessages []queuedSentMessageCallback // outgoing messages callback queue
 }
 
@@ -63,7 +64,7 @@ type emulatedNode struct {
 	txpoolIds          map[transactions.Txid]bool
 	name               string
 	blocked            chan struct{}
-	mu                 sync.Mutex
+	mu                 sync.Mutex `algofix:allow sync.Mutex`
 	txpoolGroupCounter uint64
 	blockingEnabled    bool
 	nodeBlocked        chan struct{} // channel is closed when node is blocked.


### PR DESCRIPTION
## Summary

use comments to locally allow sync.Mutex instead of rewriting it to the much slower deadlock.Mutex

```go
// algofix allow sync
// algofix require deadlock
```

## Test Plan

Added unit test of deadlock replacement, normal and with new comment directives