### PR TITLE
add to Peer interface DataGet and DataPut

### DIFF
--- a/network/ping.go
+++ b/network/ping.go
@@ -28,7 +28,7 @@ func pingHandler(message IncomingMessage) OutgoingMessage {
 	if len(message.Data) > 8 {
 		return OutgoingMessage{}
 	}
-	message.Net.(*WebsocketNetwork).log.Debugf("ping from peer %#v", message.Sender.(*wsPeer).wsPeerCore)
+	message.Net.(*WebsocketNetwork).log.Debugf("ping from peer %#v", &(message.Sender.(*wsPeer).wsPeerCore))
 	peer := message.Sender.(*wsPeer)
 	tbytes := []byte(protocol.PingReplyTag)
 	mbytes := make([]byte, len(tbytes)+len(message.Data))

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -131,7 +131,10 @@ var incomingPeers = metrics.MakeGauge(metrics.MetricName{Name: "algod_network_in
 var outgoingPeers = metrics.MakeGauge(metrics.MetricName{Name: "algod_network_outgoing_peers", Description: "Number of active outgoing peers."})
 
 // Peer opaque interface for referring to a neighbor in the network
-type Peer interface{}
+type Peer interface {
+	DataGet(key interface{}) (value interface{}, exists bool)
+	DataPut(key, value interface{})
+}
 
 // PeerOption allows users to specify a subset of peers to query
 type PeerOption int

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -105,6 +105,9 @@ type wsPeerCore struct {
 	rootURL       string
 	originAddress string // incoming connection remote host
 	client        http.Client
+
+	appData     map[interface{}]interface{}
+	appDataLock deadlock.Mutex
 }
 
 type disconnectReason string
@@ -250,6 +253,18 @@ func (wp *wsPeerCore) GetAddress() string {
 // http.Client will maintain a cache of connections with some keepalive.
 func (wp *wsPeerCore) GetHTTPClient() *http.Client {
 	return &wp.client
+}
+
+func (wp *wsPeerCore) DataGet(key interface{}) (value interface{}, exists bool) {
+	wp.appDataLock.Lock()
+	defer wp.appDataLock.Unlock()
+	value, exists = wp.appData[key]
+	return
+}
+func (wp *wsPeerCore) DataPut(key, value interface{}) {
+	wp.appDataLock.Lock()
+	defer wp.appDataLock.Unlock()
+	wp.appData[key] = value
 }
 
 // Version returns the matching version from network.SupportedProtocolVersions


### PR DESCRIPTION
for misc service/app data associated with a peer

## Summary

For use by future expansion on protocols, add misc data to a Peer, which goes away when the peer closes.

## Test Plan

Code is pretty trivial, but I should add at least one unit test...