### PR TITLE
TEAL 3 changes for tealdbg

### DIFF
--- a/cmd/tealdbg/cdtState.go
+++ b/cmd/tealdbg/cdtState.go
@@ -362,7 +362,9 @@ func prepareTxn(txn *transactions.Transaction, groupIndex int) []fieldDesc {
 	for field, name := range logic.TxnFieldNames {
 		if field == int(logic.FirstValidTime) ||
 			field == int(logic.Accounts) ||
-			field == int(logic.ApplicationArgs) {
+			field == int(logic.ApplicationArgs) ||
+			field == int(logic.Assets) ||
+			field == int(logic.Applications) {
 			continue
 		}
 		var value string
@@ -716,7 +718,7 @@ func makeTxnImpl(txn *transactions.Transaction, groupIndex int, preview bool) (d
 		desc = append(desc, makePrimitive(field))
 	}
 
-	for _, fieldIdx := range []logic.TxnField{logic.ApplicationArgs, logic.Accounts} {
+	for _, fieldIdx := range []logic.TxnField{logic.ApplicationArgs, logic.Accounts, logic.Assets, logic.Applications} {
 		fieldID := encodeTxnArrayField(groupIndex, int(fieldIdx))
 		var length int
 		switch logic.TxnField(fieldIdx) {
@@ -724,6 +726,10 @@ func makeTxnImpl(txn *transactions.Transaction, groupIndex int, preview bool) (d
 			length = len(txn.Accounts) + 1
 		case logic.ApplicationArgs:
 			length = len(txn.ApplicationArgs)
+		case logic.Assets:
+			length = len(txn.ForeignAssets)
+		case logic.Applications:
+			length = len(txn.ForeignApps) + 1
 		}
 		field := makeArray(logic.TxnFieldNames[fieldIdx], length, fieldID)
 		if preview {
@@ -768,6 +774,10 @@ func makeTxnArrayField(s *cdtState, groupIndex int, fieldIdx int) (desc []cdt.Ru
 			length = len(txn.Accounts) + 1
 		case logic.ApplicationArgs:
 			length = len(txn.ApplicationArgs)
+		case logic.Assets:
+			length = len(txn.ForeignAssets)
+		case logic.Applications:
+			length = len(txn.ForeignApps) + 1
 		}
 
 		elems := txnFieldToArrayFieldDesc(&txn, groupIndex, logic.TxnField(fieldIdx), length)

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1642,7 +1642,7 @@ func disPushBytes(dis *disassembleState, spec *OpSpec) {
 		return
 	}
 	bytes := dis.program[pos:end]
-	_, dis.err = fmt.Fprintf(dis.out, "%s 0x%s", spec.Name, hex.EncodeToString(bytes))
+	_, dis.err = fmt.Fprintf(dis.out, "%s 0x%s\n", spec.Name, hex.EncodeToString(bytes))
 	dis.nextpc = int(end)
 }
 func checkPushBytes(cx *evalContext) int {

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -1174,6 +1174,24 @@ func TestDisassembleGtxna(t *testing.T) {
 	require.Equal(t, gtxnaSample, disassembled)
 }
 
+func TestDisassemblePushConst(t *testing.T) {
+	t.Parallel()
+	// check pushint and pushbytes are properly disassembled
+	intSample := fmt.Sprintf("// version %d\npushint 1\n", AssemblerMaxVersion)
+	ops, err := AssembleStringWithVersion(intSample, AssemblerMaxVersion)
+	require.NoError(t, err)
+	disassembled, err := Disassemble(ops.Program)
+	require.NoError(t, err)
+	require.Equal(t, intSample, disassembled)
+
+	bytesSample := fmt.Sprintf("// version %d\npushbytes 0x01\n", AssemblerMaxVersion)
+	ops, err = AssembleStringWithVersion(bytesSample, AssemblerMaxVersion)
+	require.NoError(t, err)
+	disassembled, err = Disassemble(ops.Program)
+	require.NoError(t, err)
+	require.Equal(t, bytesSample, disassembled)
+}
+
 func TestDisassembleLastLabel(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION

## Summary

Most of the new TEAL 3 features already work with the debugger, but a few changes were needed to make the new array fields display properly on the Chrome frontend.

Also, I noticed the disassembly for `pushbytes` was missing a trailing newline, which made the disassembled program for debugging look strange.

## Test Plan

Added a unit test for `pushbytes` and `pushint` disassembly.
