### PR TITLE
Fixes for pending transaction endpoint

### DIFF
--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"time"
 
@@ -583,11 +584,16 @@ func (v2 *Handlers) getPendingTransactions(ctx echo.Context, max *uint64, format
 		RewardsPool: basics.Address{},
 	}
 
+	txnLimit := uint64(math.MaxUint64)
+	if max != nil && *max != 0 {
+		txnLimit = *max
+	}
+
 	// Convert transactions to msgp / json strings
 	topTxns := make([]transactions.SignedTxn, 0)
 	for _, txn := range txnPool {
 		// break out if we've reached the max number of transactions
-		if max != nil && *max != 0 && uint64(len(topTxns)) >= *max {
+		if uint64(len(topTxns)) >= txnLimit {
 			break
 		}
 

--- a/daemon/algod/api/server/v2/test/helpers.go
+++ b/daemon/algod/api/server/v2/test/helpers.go
@@ -74,6 +74,7 @@ var poolAddrResponseGolden = generatedV2.AccountResponse{
 	AppsTotalSchema:             &appsTotalSchema,
 	CreatedApps:                 &appCreatedApps,
 }
+var txnPoolGolden = make([]transactions.SignedTxn, 2)
 
 // ordinarily mockNode would live in `components/mocks`
 // but doing this would create an import cycle, as mockNode needs
@@ -120,7 +121,7 @@ func (m mockNode) GetPendingTransaction(txID transactions.Txid) (res node.TxnWit
 }
 
 func (m mockNode) GetPendingTxnsFromPool() ([]transactions.SignedTxn, error) {
-	return nil, m.err
+	return txnPoolGolden, m.err
 }
 
 func (m mockNode) SuggestedFee() basics.MicroAlgos {


### PR DESCRIPTION
## Summary

I discovered that #1004 accidentally changed the `total-transactions` field in the `getPendingTransactions` handler function. That value is supposed to be the total number of pending transactions, but currently it is only the number of transactions returned by the current API call. I've fixed this and improved the names of local variables to make this easier to see.

While testing this, I also discovered a bug with the `max` parameter. When set to 0, `getPendingTransactions` should return all pending transactions. The current behavior is correct when there is no `max` query param in the API request, but when explicitly setting `max` to 0 (i.e.`/v2/transactions/pending?max=0`) the endpoint always returns 0 transactions.

Since the documentation states `If max=0, returns all pending txns`, I believe this is undesirable so I've also fixed this.

## Test Plan

Unit test for `getPendingTransactions`  have been improved.