### PR TITLE
Report algod panic in algoh

### DIFF
--- a/cmd/algoh/main.go
+++ b/cmd/algoh/main.go
@@ -145,7 +145,6 @@ func main() {
 		}
 		err = cmd.Wait()
 		if err != nil {
-			captureErrorLogs(algohConfig, errorOutput, output, absolutePath, true)
 			reportErrorf("error waiting for algod: %v", err)
 		}
 		close(done)
@@ -363,7 +362,7 @@ func captureErrorLogs(algohConfig algoh.HostConfig, errorOutput stdCollector, ou
 
 func reportErrorf(format string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, format, args...)
-	logging.Base().Fatalf(format, args...)
+	logging.Base().Warnf(format, args...)
 }
 
 func sendLogs() {

--- a/cmd/algoh/main.go
+++ b/cmd/algoh/main.go
@@ -145,6 +145,7 @@ func main() {
 		}
 		err = cmd.Wait()
 		if err != nil {
+			captureErrorLogs(algohConfig, errorOutput, output, absolutePath, true)
 			reportErrorf("error waiting for algod: %v", err)
 		}
 		close(done)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

When algoh spawns an algod instance and the algod panics, algoh simply exits without logging the panic. This change logs the algod panic before the algoh exits.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

Started an algoh with algod, hardcoded a panic when it hits round 10, sees that `algod-err.log` contains the panic message
