### PR TITLE
copy GetPeerData()/SetPeerData() from txnsync branch

### DIFF
--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -201,6 +201,10 @@ type GossipNode interface {
 
 	// SubstituteGenesisID substitutes the "{genesisID}" with their network-specific genesisID.
 	SubstituteGenesisID(rawURL string) string
+
+	GetPeerData(peer Peer, key string) interface{}
+
+	SetPeerData(peer Peer, key string, value interface{})
 }
 
 // IncomingMessage represents a message arriving from some peer in our p2p network
@@ -2036,6 +2040,26 @@ func (wn *WebsocketNetwork) tryConnect(addr, gossipAddr string) {
 				}
 			}
 		}
+	}
+}
+
+// GetPeerData returns the peer data associated with a particular key.
+func (wn *WebsocketNetwork) GetPeerData(peer Peer, key string) interface{} {
+	switch p := peer.(type) {
+	case *wsPeer:
+		return p.getPeerData(key)
+	default:
+		return nil
+	}
+}
+
+// SetPeerData sets the peer data associated with a particular key.
+func (wn *WebsocketNetwork) SetPeerData(peer Peer, key string, value interface{}) {
+	switch p := peer.(type) {
+	case *wsPeer:
+		p.setPeerData(key, value)
+	default:
+		return
 	}
 }
 

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -202,8 +202,11 @@ type GossipNode interface {
 	// SubstituteGenesisID substitutes the "{genesisID}" with their network-specific genesisID.
 	SubstituteGenesisID(rawURL string) string
 
+	// GetPeerData returns a value stored by SetPeerData
 	GetPeerData(peer Peer, key string) interface{}
 
+	// SetPeerData attaches a piece of data to a peer.
+	// Other services inside go-algorand may attach data to a peer that gets garbage collected when the peer is closed.
 	SetPeerData(peer Peer, key string, value interface{})
 }
 

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -289,6 +289,42 @@ func TestWebsocketNetworkUnicast(t *testing.T) {
 	}
 }
 
+// Like a basic test, but really we just want to have SetPeerData()/GetPeerData()
+func TestWebsocketPeerData(t *testing.T) {
+	netA := makeTestWebsocketNode(t)
+	netA.config.GossipFanout = 1
+	netA.Start()
+	defer func() { t.Log("stopping A"); netA.Stop(); t.Log("A done") }()
+	netB := makeTestWebsocketNode(t)
+	netB.config.GossipFanout = 1
+	addrA, postListen := netA.Address()
+	require.True(t, postListen)
+	t.Log(addrA)
+	netB.phonebook.ReplacePeerList([]string{addrA}, "default", PhoneBookEntryRelayRole)
+	netB.Start()
+	defer func() { t.Log("stopping B"); netB.Stop(); t.Log("B done") }()
+	counter := newMessageCounter(t, 2)
+	netB.RegisterHandlers([]TaggedMessageHandler{{Tag: protocol.TxnTag, MessageHandler: counter}})
+
+	readyTimeout := time.NewTimer(2 * time.Second)
+	waitReady(t, netA, readyTimeout.C)
+	t.Log("a ready")
+	waitReady(t, netB, readyTimeout.C)
+	t.Log("b ready")
+
+	require.Equal(t, 1, len(netA.peers))
+	require.Equal(t, 1, len(netA.GetPeers(PeersConnectedIn)))
+	peerB := netA.peers[0]
+
+	require.Equal(t, nil, netA.GetPeerData(peerB, "not there"))
+	netA.SetPeerData(peerB, "foo", "bar")
+	require.Equal(t, "bar", netA.GetPeerData(peerB, "foo"))
+	netA.SetPeerData(peerB, "foo", "qux")
+	require.Equal(t, "qux", netA.GetPeerData(peerB, "foo"))
+	netA.SetPeerData(peerB, "foo", nil)
+	require.Equal(t, nil, netA.GetPeerData(peerB, "foo"))
+}
+
 // Set up two nodes, test that a.Broadcast is received by B, when B has no address.
 func TestWebsocketNetworkNoAddress(t *testing.T) {
 	netA := makeTestWebsocketNode(t)

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -211,8 +211,10 @@ type wsPeer struct {
 	throttledOutgoingConnection bool
 
 	// clientDataStore is a generic key/value store used to store client-side data entries associated with a particular peer.
+	// Locked by clientDataStoreMu.
 	clientDataStore map[string]interface{}
 
+	// clientDataStoreMu synchronizes access to clientDataStore
 	clientDataStoreMu deadlock.Mutex
 }
 


### PR DESCRIPTION
## Summary

Add GetPeerData()/SetPeerData() to network interface for data to be associated with a peer by other parts of the system so that data gets garbage collected when peer goes away.

## Test Plan

Trivial feature. No testing yet.