### PR TITLE
make deadlockLogger thread-safe

### DIFF
--- a/daemon/algod/deadlockLogger.go
+++ b/daemon/algod/deadlockLogger.go
@@ -50,7 +50,7 @@ func (logger *deadlockLogger) Write(p []byte) (n int, err error) {
 }
 
 // captureCallstack captures the callstack and return a byte array of the output.
-func (logger *deadlockLogger) captureCallstack() []byte {
+func captureCallstack() []byte {
 	// Capture all goroutine stacks
 	var buf []byte
 	bufferSize := 256 * 1024
@@ -70,7 +70,7 @@ func (logger *deadlockLogger) onPotentialDeadlock() {
 	// in practive, once we report the deadlock, we panic and abort anyway, so it won't be an issue.
 	logger.reportDeadlock.Do(func() {
 		// Capture all goroutine stacks
-		buf := logger.captureCallstack()
+		buf := captureCallstack()
 
 		logger.bufferSync <- struct{}{}
 		loggedString := logger.String()

--- a/daemon/algod/deadlockLogger.go
+++ b/daemon/algod/deadlockLogger.go
@@ -21,48 +21,81 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"sync"
 
 	"github.com/algorand/go-deadlock"
 
 	"github.com/algorand/go-algorand/logging"
 )
 
-type dumpLogger struct {
+type deadlockLogger struct {
 	logging.Logger
 	*bytes.Buffer
+	bufferSync     chan struct{}
+	panic          func()
+	reportDeadlock sync.Once
 }
 
-func (logger *dumpLogger) dump() {
-	logger.Error(logger.String())
+// Panic is defined here just so we can emulate the usage of the deadlockLogger
+func (logger *deadlockLogger) Panic() {
+	logger.Logger.Panic("potential deadlock detected")
 }
 
-var logger = dumpLogger{Logger: logging.Base(), Buffer: bytes.NewBuffer(make([]byte, 0))}
+// Write implements the io.Writer interface, ensuring that the write is syncronized.
+func (logger *deadlockLogger) Write(p []byte) (n int, err error) {
+	logger.bufferSync <- struct{}{}
+	n, err = logger.Buffer.Write(p)
+	<-logger.bufferSync
+	return
+}
 
-var deadlockPanic func()
-
-func setupDeadlockLogger() {
-	deadlockPanic = func() {
-		logger.Panic("potential deadlock detected")
-	}
-
-	deadlock.Opts.LogBuf = logger
-	deadlock.Opts.OnPotentialDeadlock = func() {
-		// Capture all goroutine stacks
-		var buf []byte
-		bufferSize := 256 * 1024
-		for {
-			buf = make([]byte, bufferSize)
-			if runtime.Stack(buf, true) < bufferSize {
-				break
-			}
-			bufferSize *= 2
+// captureCallstack captures the callstack and return a byte array of the output.
+func (logger *deadlockLogger) captureCallstack() []byte {
+	// Capture all goroutine stacks
+	var buf []byte
+	bufferSize := 256 * 1024
+	for {
+		buf = make([]byte, bufferSize)
+		if runtime.Stack(buf, true) < bufferSize {
+			break
 		}
-
-		// Run this code in a separate goroutine because it might grab locks.
-		go func() {
-			logger.dump()
-			fmt.Fprintln(os.Stderr, string(buf))
-			deadlockPanic()
-		}()
+		bufferSize *= 2
 	}
+	return buf
+}
+
+// onPotentialDeadlock is the handler to be used by the deadlock library.
+func (logger *deadlockLogger) onPotentialDeadlock() {
+	// The deadlock reporting is done only once; this would prevent recursive deadlock issues.
+	// in practive, once we report the deadlock, we panic and abort anyway, so it won't be an issue.
+	logger.reportDeadlock.Do(func() {
+		// Capture all goroutine stacks
+		buf := logger.captureCallstack()
+
+		logger.bufferSync <- struct{}{}
+		loggedString := logger.String()
+		<-logger.bufferSync
+
+		fmt.Fprintln(os.Stderr, string(buf))
+
+		// logging the logged string to the logger has to happen in a separate go-routine, since the
+		// logger itself ( for instance, the CyclicLogWriter ) is using a mutex of it's own.
+		go func() {
+			logger.Error(loggedString)
+			logger.panic()
+		}()
+	})
+}
+
+func setupDeadlockLogger() *deadlockLogger {
+	logger := &deadlockLogger{
+		Logger:     logging.Base(),
+		Buffer:     bytes.NewBuffer(make([]byte, 0)),
+		bufferSync: make(chan struct{}, 1),
+	}
+
+	logger.panic = logger.Panic
+	deadlock.Opts.LogBuf = logger
+	deadlock.Opts.OnPotentialDeadlock = logger.onPotentialDeadlock
+	return logger
 }


### PR DESCRIPTION
## Summary

The deadlock logger we've used was not thread-safe. That was fine until the point where a deadlock would be detected, at which there was a chance of creating a subsequent failure while reporting the first one.

This PR re-implement the logger in a safe-way : it inherently prevent concurrent calls to `onPotentialDeadlock` as well as ensures that all the writes using the `Writer` interface are synchronized.

## Test Plan

Existing unit test was updated. New unit test was added.