### PR TITLE
Add pushing docker tag to betanet

### DIFF
--- a/scripts/release/mule/deploy/docker/docker.sh
+++ b/scripts/release/mule/deploy/docker/docker.sh
@@ -38,7 +38,8 @@ then
    ./build_releases.sh --tagname "$VERSION"
 elif [ "$NETWORK" = betanet ]
 then
-   ./build_releases.sh --network betanet
+  ./build_releases.sh --network betanet
+  ./build_releases.sh --network betanet --tagname "$VERSION"
 fi
 
 popd


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

The betanet docker image was not getting tagged. Added tagging for betanet.

## Test Plan

Try to deploy 2.5.2-beta to docker hub again using mule.
