### PR TITLE
Attempt to pull from a custom cache of images

### DIFF
--- a/scripts/release/test/util/test_package.sh
+++ b/scripts/release/test/util/test_package.sh
@@ -35,7 +35,7 @@ build_images () {
     # We'll use this simple tokenized Dockerfile.
     # https://serverfault.com/a/72511
     TOKENIZED=$(echo -e "\
-FROM {{OS}}\n\n\
+FROM public.ecr.aws/i3h3n7g0/{{OS}}\n\n\
 WORKDIR /root\n\
 COPY . .\n\
 CMD [\"/bin/bash\"]")

--- a/test/packages/test_release.sh
+++ b/test/packages/test_release.sh
@@ -48,7 +48,7 @@ build_images () {
     # We'll use this simple tokenized Dockerfile.
     # https://serverfault.com/a/72511
     IFS='' read -r -d '' TOKENIZED <<EOF
-FROM {{OS}}
+FROM public.ecr.aws/i3h3n7g0/{{OS}}
 
 ENV AWS_ACCESS_KEY_ID=""
 ENV AWS_SECRET_ACCESS_KEY=""

--- a/test/platform/test_linux_amd64_compatibility.sh
+++ b/test/platform/test_linux_amd64_compatibility.sh
@@ -29,7 +29,7 @@ build_images () {
     # We'll use this simple tokenized Dockerfile.
     # https://serverfault.com/a/72511
     IFS='' read -r -d '' TOKENIZED <<EOF
-FROM {{OS}}
+FROM public.ecr.aws/i3h3n7g0/{{OS}}
 
 WORKDIR /root
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Summary

Docker Hub now limits the number of pulls against its repository for unauthenticated users. While we can login to Travis in job using secret variables, these are not available in forked repositories. As a result, PRs coming from forks that hit the docker pull limit will start failing. This is most notable in integration tests.

To work around this, we cache the images requested to our custom public repository that does not require authentication. This is not a good solution, but will help work around pulls in Travis for forked repositories for now. Bandwidth usage should be monitored, both from activity as well as for potential for abuse.

## Test Plan

See if integration tests can pull images.
