### PR TITLE
Cache docker images in Travis and re-load them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -165,6 +165,7 @@ jobs:
 cache:
   directories:
     - crypto/lib
+    - docker_cache
 
 before_install:
 - |-
@@ -189,6 +190,7 @@ before_install:
      export MAKE=mingw32-make  # so that Autotools can find it
      ;;
    esac
+   docker load -i docker_cache/images.tar || true
 
 before_cache:
 - |-
@@ -198,6 +200,7 @@ before_cache:
      $msys2 pacman --sync --clean --noconfirm
      ;;
    esac
+   docker save -o docker_cache/images.tar $(docker images -a -q)
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -165,7 +165,7 @@ jobs:
 cache:
   directories:
     - crypto/lib
-    - docker_cache
+    - $HOME/docker_cache
 
 before_install:
 - |-
@@ -190,7 +190,7 @@ before_install:
      export MAKE=mingw32-make  # so that Autotools can find it
      ;;
    esac
-   docker load -i docker_cache/images.tar || true
+   docker load -i $HOME/docker_cache/images.tar || true
 
 before_cache:
 - |-
@@ -200,7 +200,7 @@ before_cache:
      $msys2 pacman --sync --clean --noconfirm
      ;;
    esac
-   docker save -o docker_cache/images.tar $(docker images -a -q)
+   docker save -o $HOME/docker_cache/images.tar $(docker images -a -q)
 
 addons:
   apt:


### PR DESCRIPTION
## Summary

To get around Docker Hub pull limits, we can try to explicitly cache docker images between builds. This seems like a safer approach than #2009.

## Test Plan

Verify docker images are saved by running this, then re-running and seeing if it's cached.
