### PR TITLE
Precise calculation of paysetHint for block eval

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -109,7 +109,7 @@ func MakeTransactionPool(ledger *ledger.Ledger, cfg config.Local, log logging.Lo
 	}
 	pool.cond.L = &pool.mu
 	pool.assemblyCond.L = &pool.assemblyMu
-	pool.recomputeBlockEvaluator(make(map[transactions.Txid]basics.Round))
+	pool.recomputeBlockEvaluator(make(map[transactions.Txid]basics.Round), 0)
 	return &pool
 }
 
@@ -162,7 +162,7 @@ func (pool *TransactionPool) Reset() {
 	pool.numPendingWholeBlocks = 0
 	pool.pendingBlockEvaluator = nil
 	pool.statusCache.reset()
-	pool.recomputeBlockEvaluator(make(map[transactions.Txid]basics.Round))
+	pool.recomputeBlockEvaluator(make(map[transactions.Txid]basics.Round), 0)
 }
 
 // NumExpired returns the number of transactions that expired at the
@@ -468,10 +468,10 @@ func (pool *TransactionPool) OnNewBlock(block bookkeeping.Block, delta ledgercor
 	var knownCommitted uint
 	var unknownCommitted uint
 
-	commitedTxids := delta.Txids
+	committedTxids := delta.Txids
 	if pool.logProcessBlockStats {
 		pool.pendingMu.RLock()
-		for txid := range commitedTxids {
+		for txid := range committedTxids {
 			if _, ok := pool.pendingTxids[txid]; ok {
 				knownCommitted++
 			} else {
@@ -512,7 +512,7 @@ func (pool *TransactionPool) OnNewBlock(block bookkeeping.Block, delta ledgercor
 		// Recompute the pool by starting from the new latest block.
 		// This has the side-effect of discarding transactions that
 		// have been committed (or that are otherwise no longer valid).
-		stats = pool.recomputeBlockEvaluator(commitedTxids)
+		stats = pool.recomputeBlockEvaluator(committedTxids, knownCommitted)
 	}
 
 	stats.KnownCommittedCount = knownCommitted
@@ -625,7 +625,7 @@ func (pool *TransactionPool) addToPendingBlockEvaluator(txgroup []transactions.S
 // recomputeBlockEvaluator constructs a new BlockEvaluator and feeds all
 // in-pool transactions to it (removing any transactions that are rejected
 // by the BlockEvaluator). Expects that the pool.mu mutex would be already taken.
-func (pool *TransactionPool) recomputeBlockEvaluator(committedTxIds map[transactions.Txid]basics.Round) (stats telemetryspec.ProcessBlockMetrics) {
+func (pool *TransactionPool) recomputeBlockEvaluator(committedTxIds map[transactions.Txid]basics.Round, knownCommitted uint) (stats telemetryspec.ProcessBlockMetrics) {
 	pool.pendingBlockEvaluator = nil
 
 	latest := pool.ledger.Latest()
@@ -665,7 +665,11 @@ func (pool *TransactionPool) recomputeBlockEvaluator(committedTxIds map[transact
 
 	next := bookkeeping.MakeBlock(prev)
 	pool.numPendingWholeBlocks = 0
-	pool.pendingBlockEvaluator, err = pool.ledger.StartEvaluator(next.BlockHeader, pendingCount)
+	hint := pendingCount - int(knownCommitted)
+	if hint < 0 || int(knownCommitted) < 0 {
+		hint = 0
+	}
+	pool.pendingBlockEvaluator, err = pool.ledger.StartEvaluator(next.BlockHeader, hint)
 	if err != nil {
 		pool.log.Warnf("TransactionPool.recomputeBlockEvaluator: cannot start evaluator: %v", err)
 		return

--- a/ledger/appcow.go
+++ b/ledger/appcow.go
@@ -410,7 +410,7 @@ func MakeDebugBalances(l ledgerForCowBase, round basics.Round, proto protocol.Co
 // Execution happens in a child cow and all modifications are merged into parent if the program passes
 func (cb *roundCowState) StatefulEval(params logic.EvalParams, aidx basics.AppIndex, program []byte) (pass bool, evalDelta basics.EvalDelta, err error) {
 	// Make a child cow to eval our program in
-	calf := cb.child()
+	calf := cb.child(1)
 	params.Ledger, err = newLogicLedger(calf, aidx)
 	if err != nil {
 		return false, basics.EvalDelta{}, err

--- a/ledger/appcow_test.go
+++ b/ledger/appcow_test.go
@@ -305,7 +305,7 @@ func TestCowStorage(t *testing.T) {
 		// Make a child
 		if childDepth < maxChildDepth && rand.Float32() < 0.1 {
 			lastParent = cow
-			cow = cow.child()
+			cow = cow.child(1)
 			childDepth++
 		}
 

--- a/ledger/cow.go
+++ b/ledger/cow.go
@@ -195,12 +195,12 @@ func (cb *roundCowState) setCompactCertNext(rnd basics.Round) {
 	cb.mods.CompactCertNext = rnd
 }
 
-func (cb *roundCowState) child() *roundCowState {
+func (cb *roundCowState) child(hint int) *roundCowState {
 	return &roundCowState{
 		lookupParent: cb,
 		commitParent: cb,
 		proto:        cb.proto,
-		mods:         ledgercore.MakeStateDelta(cb.mods.Hdr, cb.mods.PrevTimestamp, 1, cb.mods.CompactCertNext),
+		mods:         ledgercore.MakeStateDelta(cb.mods.Hdr, cb.mods.PrevTimestamp, hint, cb.mods.CompactCertNext),
 		sdeltas:      make(map[basics.Address]map[storagePtr]*storageDelta),
 	}
 }

--- a/ledger/cow_test.go
+++ b/ledger/cow_test.go
@@ -105,7 +105,7 @@ func TestCowBalance(t *testing.T) {
 	c0 := makeRoundCowState(&ml, bookkeeping.BlockHeader{}, 0, 0)
 	checkCow(t, c0, accts0)
 
-	c1 := c0.child()
+	c1 := c0.child(0)
 	checkCow(t, c0, accts0)
 	checkCow(t, c1, accts0)
 
@@ -114,7 +114,7 @@ func TestCowBalance(t *testing.T) {
 	checkCow(t, c0, accts0)
 	checkCow(t, c1, accts1)
 
-	c2 := c1.child()
+	c2 := c1.child(0)
 	checkCow(t, c0, accts0)
 	checkCow(t, c1, accts1)
 	checkCow(t, c2, accts1)

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -579,7 +579,7 @@ func (eval *BlockEvaluator) TestTransactionGroup(txgroup []transactions.SignedTx
 		return fmt.Errorf("group size %d exceeds maximum %d", len(txgroup), eval.proto.MaxTxGroupSize)
 	}
 
-	cow := eval.state.child()
+	cow := eval.state.child(len(txgroup))
 
 	var group transactions.TxGroup
 	for gi, txn := range txgroup {
@@ -713,7 +713,7 @@ func (eval *BlockEvaluator) transactionGroup(txgroup []transactions.SignedTxnWit
 	var group transactions.TxGroup
 	var groupTxBytes int
 
-	cow := eval.state.child()
+	cow := eval.state.child(len(txgroup))
 
 	// Prepare eval params for any ApplicationCall transactions in the group
 	evalParams := eval.prepareEvalParams(txgroup)

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -171,14 +171,16 @@ func (ad *AccountDeltas) upsert(br basics.BalanceRecord) {
 // For each data structure, reallocate if it would save us at least 50MB aggregate
 func (sd *StateDelta) OptimizeAllocatedMemory(proto config.ConsensusParams) {
 	// accts takes up 232 bytes per entry, and is saved for 320 rounds
-	if uint64(2*sd.initialTransactionsCount-len(sd.Accts.accts))*accountArrayEntrySize*proto.MaxBalLookback > stateDeltaTargetOptimizationThreshold {
+	if uint64(cap(sd.Accts.accts)-len(sd.Accts.accts))*accountArrayEntrySize*proto.MaxBalLookback > stateDeltaTargetOptimizationThreshold {
 		accts := make([]basics.BalanceRecord, len(sd.Accts.acctsCache))
 		copy(accts, sd.Accts.accts)
 		sd.Accts.accts = accts
 	}
 
 	// acctsCache takes up 64 bytes per entry, and is saved for 320 rounds
-	if uint64(2*sd.initialTransactionsCount-len(sd.Accts.acctsCache))*accountMapCacheEntrySize*proto.MaxBalLookback > stateDeltaTargetOptimizationThreshold {
+	// realloc if original allocation capacity greater than length of data, and space difference is significant
+	if 2*sd.initialTransactionsCount > len(sd.Accts.acctsCache) &&
+		uint64(2*sd.initialTransactionsCount-len(sd.Accts.acctsCache))*accountMapCacheEntrySize*proto.MaxBalLookback > stateDeltaTargetOptimizationThreshold {
 		acctsCache := make(map[basics.Address]int, len(sd.Accts.acctsCache))
 		for k, v := range sd.Accts.acctsCache {
 			acctsCache[k] = v
@@ -187,7 +189,8 @@ func (sd *StateDelta) OptimizeAllocatedMemory(proto config.ConsensusParams) {
 	}
 
 	// TxLeases takes up 112 bytes per entry, and is saved for 1000 rounds
-	if uint64(sd.initialTransactionsCount-len(sd.Txleases))*txleasesEntrySize*proto.MaxTxnLife > stateDeltaTargetOptimizationThreshold {
+	if sd.initialTransactionsCount > len(sd.Txleases) &&
+		uint64(sd.initialTransactionsCount-len(sd.Txleases))*txleasesEntrySize*proto.MaxTxnLife > stateDeltaTargetOptimizationThreshold {
 		txLeases := make(map[Txlease]basics.Round, len(sd.Txleases))
 		for k, v := range sd.Txleases {
 			txLeases[k] = v
@@ -196,7 +199,7 @@ func (sd *StateDelta) OptimizeAllocatedMemory(proto config.ConsensusParams) {
 	}
 
 	// Creatables takes up 100 bytes per entry, and is saved for 320 rounds
-	if uint64(sd.initialTransactionsCount-len(sd.Creatables))*creatablesEntrySize*proto.MaxBalLookback > stateDeltaTargetOptimizationThreshold {
+	if uint64(len(sd.Creatables))*creatablesEntrySize*proto.MaxBalLookback > stateDeltaTargetOptimizationThreshold {
 		creatableDeltas := make(map[basics.CreatableIndex]ModifiedCreatable, len(sd.Creatables))
 		for k, v := range sd.Creatables {
 			creatableDeltas[k] = v

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -90,16 +90,19 @@ type AccountDeltas struct {
 	acctsCache map[basics.Address]int
 }
 
-// MakeStateDelta creates a new instance of StateDelta
+// MakeStateDelta creates a new instance of StateDelta.
+// hint is amount of transactions for evaluation, 2 * hint is for sender and receiver balance records.
+// This does not play well for AssetConfig and ApplicationCall transactions on scale
 func MakeStateDelta(hdr *bookkeeping.BlockHeader, prevTimestamp int64, hint int, compactCertNext basics.Round) StateDelta {
 	return StateDelta{
 		Accts: AccountDeltas{
 			accts:      make([]basics.BalanceRecord, 0, hint*2),
 			acctsCache: make(map[basics.Address]int, hint*2),
 		},
-		Txids:                    make(map[transactions.Txid]basics.Round, hint),
-		Txleases:                 make(map[Txlease]basics.Round, hint),
-		Creatables:               make(map[basics.CreatableIndex]ModifiedCreatable, hint),
+		Txids:    make(map[transactions.Txid]basics.Round, hint),
+		Txleases: make(map[Txlease]basics.Round, hint),
+		// asset or application creation are considered as rare events so do not pre-allocate space for them
+		Creatables:               make(map[basics.CreatableIndex]ModifiedCreatable),
 		Hdr:                      hdr,
 		PrevTimestamp:            prevTimestamp,
 		initialTransactionsCount: hint,


### PR DESCRIPTION
## Summary

* Exclude committed count from pending count and calculate paysetHint precisely.
* Provide correct hint for child cow.
* Do not preallocate Creatable map since app/asset creation are relatively rare operations.

## Test Plan

Use existing test suite