### PR TITLE
Adjust the network outgoing buffer sizes

### DIFF
--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -598,6 +598,17 @@ func (wn *WebsocketNetwork) GetPeers(options ...PeerOption) []Peer {
 	return outPeers
 }
 
+// find the max value across the given uint64 numbers.
+func max(numbers ...uint64) (maxNum uint64) {
+	maxNum = 0 // this is the lowest uint64 value.
+	for _, num := range numbers {
+		if num > maxNum {
+			maxNum = num
+		}
+	}
+	return
+}
+
 func (wn *WebsocketNetwork) setup() {
 	var preferredResolver dnssec.ResolverIf
 	if wn.config.DNSSecurityRelayAddrEnforced() {
@@ -626,14 +637,18 @@ func (wn *WebsocketNetwork) setup() {
 	wn.server.MaxHeaderBytes = httpServerMaxHeaderBytes
 	wn.ctx, wn.ctxCancel = context.WithCancel(context.Background())
 	wn.relayMessages = wn.config.NetAddress != "" || wn.config.ForceRelayMessages
-	// roughly estimate the number of messages that could be sent over the lifespan of a single round.
-	wn.outgoingMessagesBufferSize = int(config.Consensus[protocol.ConsensusCurrentVersion].NumProposers*2 +
-		config.Consensus[protocol.ConsensusCurrentVersion].SoftCommitteeSize +
-		config.Consensus[protocol.ConsensusCurrentVersion].CertCommitteeSize +
-		config.Consensus[protocol.ConsensusCurrentVersion].NextCommitteeSize +
-		config.Consensus[protocol.ConsensusCurrentVersion].LateCommitteeSize +
-		config.Consensus[protocol.ConsensusCurrentVersion].RedoCommitteeSize +
-		config.Consensus[protocol.ConsensusCurrentVersion].DownCommitteeSize)
+	// roughly estimate the number of messages that could be seen at any given moment.
+	// For the late/redo/down committee, which happen in parallel, we need to allocate
+	// extra space there.
+	wn.outgoingMessagesBufferSize = int(
+		max(config.Consensus[protocol.ConsensusCurrentVersion].NumProposers,
+			config.Consensus[protocol.ConsensusCurrentVersion].SoftCommitteeSize,
+			config.Consensus[protocol.ConsensusCurrentVersion].CertCommitteeSize,
+			config.Consensus[protocol.ConsensusCurrentVersion].NextCommitteeSize) +
+			max(config.Consensus[protocol.ConsensusCurrentVersion].LateCommitteeSize,
+				config.Consensus[protocol.ConsensusCurrentVersion].RedoCommitteeSize,
+				config.Consensus[protocol.ConsensusCurrentVersion].DownCommitteeSize),
+	)
 
 	wn.broadcastQueueHighPrio = make(chan broadcastRequest, wn.outgoingMessagesBufferSize)
 	wn.broadcastQueueBulk = make(chan broadcastRequest, 100)


### PR DESCRIPTION
## Summary

Initial implementation of this code was using the worst-case single round message count as the number of pending outgoing messages. This was found to be more then just wasteful, but also problematic when it being used on relays.
From practical perspective, the agreement protocol for a node is only at a single step on any given moment. Therefore, creating a buffer that is big enough for that step should be enough. An exception for that are the late committees, which can run in parallel to the above step.

Accounting for both of the above reduces the practical outgoing buffer size from 38,000 to 11,000 - which in turns reduces the pending queues size from 3M -> 880K.

## Test Plan

Use existing unit test to verify functionality.