### PR TITLE
Fix few typos in comments

### DIFF
--- a/agreement/demux.go
+++ b/agreement/demux.go
@@ -241,7 +241,7 @@ func (d *demux) next(s *Service, deadline time.Duration, fastDeadline time.Durat
 	fastPartitionRecoveryEnabled := false
 	if proto, err := d.ledger.ConsensusVersion(ParamsRound(currentRound)); err != nil {
 		logging.Base().Warnf("demux: could not get consensus parameters for round %d: %v", ParamsRound(currentRound), err)
-		// this might happen during catchup, since the Ledger.Wait fires as soon as a new block is recieved by the ledger, which could be
+		// this might happen during catchup, since the Ledger.Wait fires as soon as a new block is received by the ledger, which could be
 		// far before it's being committed. In these cases, it should be safe to default to the current consensus version. On subsequent
 		// iterations, it will get "corrected" since the ledger would finish flushing the blocks to disk.
 		fastPartitionRecoveryEnabled = config.Consensus[protocol.ConsensusCurrentVersion].FastPartitionRecovery

--- a/network/connPerfMon.go
+++ b/network/connPerfMon.go
@@ -233,7 +233,7 @@ func (pm *connectionPerformanceMonitor) notifyPresync(msg *IncomingMessage) {
 		return
 	}
 	pm.lastIncomingMsgTime = msg.Received
-	// otherwise, once we recieved a message from each of the peers, move to the sync stage.
+	// otherwise, once we received a message from each of the peers, move to the sync stage.
 	pm.advanceStage(pmStageSync, msg.Received)
 }
 

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -771,7 +771,7 @@ func TestDupFilter(t *testing.T) {
 	waitReady(t, netC, readyTimeout.C)
 	t.Log("c ready")
 
-	// TODO: this test has two halves that exercise inbound de-dup and outbound non-send due to recieved hash. But it doesn't properly _test_ them as it doesn't measure _why_ it receives each message exactly once. The second half below could actualy be because of the same inbound de-dup as this first half. You can see the actions of either in metrics.
+	// TODO: this test has two halves that exercise inbound de-dup and outbound non-send due to received hash. But it doesn't properly _test_ them as it doesn't measure _why_ it receives each message exactly once. The second half below could actualy be because of the same inbound de-dup as this first half. You can see the actions of either in metrics.
 	// algod_network_duplicate_message_received_total{} 2
 	// algod_outgoing_network_message_filtered_out_total{} 2
 	// Maybe we should just .Set(0) those counters and use them in this test?

--- a/test/commandandcontrol/cc_agent/component/agent.go
+++ b/test/commandandcontrol/cc_agent/component/agent.go
@@ -138,7 +138,7 @@ func (status CommandStatus) String() string {
 
 // ProcessRequest processes the command received via the CC Service
 func (agent *Agent) ProcessRequest(managementServiceRequest lib.CCServiceRequest) (err error) {
-	log.Infof("recieved command for %s\n", managementServiceRequest.Component)
+	log.Infof("received command for %s\n", managementServiceRequest.Component)
 	err = agent.ServiceConnection.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("received request %+v ", managementServiceRequest)))
 	if err != nil {
 		log.Errorf("problem sending ack to client , %v", err)

--- a/test/commandandcontrol/cc_service/main.go
+++ b/test/commandandcontrol/cc_service/main.go
@@ -103,11 +103,11 @@ func monitorAgent(ws *websocket.Conn) {
 		}
 		switch messageType {
 		case websocket.TextMessage:
-			log.Infof("recieved text from agent: %s", message)
+			log.Infof("received text from agent: %s", message)
 			clientBroadcast <- message
 			break
 		default:
-			log.Infof("recieved other from agent: %s", message)
+			log.Infof("received other from agent: %s", message)
 			break
 		}
 	}

--- a/util/metrics/counter_test.go
+++ b/util/metrics/counter_test.go
@@ -53,7 +53,7 @@ func TestMetricCounter(t *testing.T) {
 		// wait half-a cycle
 		time.Sleep(test.sampleRate / 2)
 	}
-	// wait two reporting cycles to ensure we recieved all the messages.
+	// wait two reporting cycles to ensure we received all the messages.
 	time.Sleep(test.sampleRate * 2)
 
 	metricService.Shutdown()
@@ -98,7 +98,7 @@ func TestMetricCounterFastInts(t *testing.T) {
 		time.Sleep(test.sampleRate / 2)
 	}
 	counter.AddUint64(2, nil)
-	// wait two reporting cycles to ensure we recieved all the messages.
+	// wait two reporting cycles to ensure we received all the messages.
 	time.Sleep(test.sampleRate * 2)
 
 	metricService.Shutdown()
@@ -145,7 +145,7 @@ func TestMetricCounterMixed(t *testing.T) {
 		time.Sleep(test.sampleRate / 2)
 	}
 	counter.AddUint64(2, nil)
-	// wait two reporting cycles to ensure we recieved all the messages.
+	// wait two reporting cycles to ensure we received all the messages.
 	time.Sleep(test.sampleRate * 2)
 
 	metricService.Shutdown()

--- a/util/metrics/gauge_test.go
+++ b/util/metrics/gauge_test.go
@@ -54,7 +54,7 @@ func TestMetricGauge(t *testing.T) {
 		time.Sleep(test.sampleRate / 2)
 	}
 
-	// wait two reporting cycles to ensure we recieved all the messages.
+	// wait two reporting cycles to ensure we received all the messages.
 	time.Sleep(test.sampleRate * 2)
 
 	metricService.Shutdown()

--- a/util/metrics/segment_test.go
+++ b/util/metrics/segment_test.go
@@ -57,7 +57,7 @@ func TestMetricSegment(t *testing.T) {
 	}
 	segmentTest()
 	segmentTest()
-	// wait two reporting cycles to ensure we recieved all the messages.
+	// wait two reporting cycles to ensure we received all the messages.
 	time.Sleep(test.sampleRate * 2)
 
 	metricService.Shutdown()


### PR DESCRIPTION
## Summary

The word `received` was misspelled multiple times in our codebase as `recieved`. This PR replaces all the typos with it's correct spelling.

## Test Plan

No tests are need for fixing in-code comments.
