### PR TITLE
Improve TestCompactCerts error testing

### DIFF
--- a/test/e2e-go/features/compactcert/compactcert_test.go
+++ b/test/e2e-go/features/compactcert/compactcert_test.go
@@ -80,7 +80,9 @@ func TestCompactCerts(t *testing.T) {
 		_, err = node0Client.SendPaymentFromUnencryptedWallet(node0Account, node1Account, minTxnFee, rnd, nil)
 		r.NoError(err)
 
-		fixture.WaitForRound(rnd, 30*time.Second)
+		err = fixture.WaitForRound(rnd, 30*time.Second)
+		r.NoError(err)
+
 		blk, err := libgoal.Block(rnd)
 		r.NoErrorf(err, "failed to retrieve block from algod on round %d", rnd)
 


### PR DESCRIPTION
## Summary

Analyzing a random failure in an unrelated branch, I ran into the following:
```
    compactcert_test.go:85: 
8350        	Error Trace:	compactcert_test.go:85
8351        	Error:      	Received unexpected error:
8352        	            	HTTP 500 Internal Server Error: failed to retrieve information from the ledger
8353        	Test:       	TestCompactCerts
8354        	Messages:   	failed to retrieve block from algod on round 15
```

While I still don't know why this happen, the testing code was ignoring the return code from
```
fixture.WaitForRound(rnd, 30*time.Second)
```

which would lead to the above error, instead of reporting the real underlying issue.


## Test Plan

This is a test.