### PR TITLE
Update pushbytes/pushint extra docs

### DIFF
--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -164,6 +164,8 @@ var opDocExtras = map[string]string{
 	"gtxns":             "for notes on transaction fields available, see `txn`. If top of stack is _i_, `gtxns field` is equivalent to `gtxn _i_ field`. gtxns exists so that _i_ can be calculated, often based on the index of the current transaction.",
 	"btoi":              "`btoi` panics if the input is longer than 8 bytes.",
 	"concat":            "`concat` panics if the result would be greater than 4096 bytes.",
+	"pushbytes":         "pushbytes args are not added to the bytecblock during assembly processes",
+	"pushint":           "pushint args are not added to the intcblock during assembly processes",
 	"getbit":            "see explanation of bit ordering in setbit",
 	"setbit":            "bit indexing begins with low-order bits in integers. Setting bit 4 to 1 on the integer 0 yields 16 (`int 0x0010`, or 2^4). Indexing begins in the first bytes of a byte-string (as seen in getbyte and substring). Setting bits 0 through 11 to 1 in a 4 byte-array of 0s yields `byte 0xfff00000`",
 	"app_opted_in":      "params: account index, application id (top of the stack on opcode entry). Return: 1 if opted in and 0 otherwise.",


### PR DESCRIPTION
Mention that the args to ops `pushbytes` and `pushint` do not get added to the bytecblock or intcblock.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
