### PR TITLE
Fix testing bug : avoid datarace on a node crash during e2e test

### DIFF
--- a/test/e2e-go/cli/algod/cleanup_test.go
+++ b/test/e2e-go/cli/algod/cleanup_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestNodeControllerCleanup(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodesPartialPartkeyOnlyWallets.json"))

--- a/test/e2e-go/cli/algod/stdstreams_test.go
+++ b/test/e2e-go/cli/algod/stdstreams_test.go
@@ -44,7 +44,7 @@ func TestAlgodLogsToFile(t *testing.T) {
 }
 
 func testNodeCreatesLogFiles(t *testing.T, nc nodecontrol.NodeController, redirect bool) {
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	stdOutFile := filepath.Join(nc.GetDataDir(), nodecontrol.StdOutFilename)
 	exists := util.FileExists(stdOutFile)

--- a/test/e2e-go/cli/goal/account_test.go
+++ b/test/e2e-go/cli/goal/account_test.go
@@ -29,7 +29,7 @@ const statusOnline = "[online]"
 
 func TestAccountNew(t *testing.T) {
 	defer fixture.SetTestContext(t)()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	newAcctName := "new_account"
 
@@ -54,7 +54,7 @@ func TestAccountNew(t *testing.T) {
 
 func TestAccountNewDuplicateFails(t *testing.T) {
 	defer fixture.SetTestContext(t)()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	newAcctName := "duplicate_account"
 
@@ -69,7 +69,7 @@ func TestAccountNewDuplicateFails(t *testing.T) {
 
 func TestAccountRename(t *testing.T) {
 	defer fixture.SetTestContext(t)()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	initialAcctName := "initial"
 	newAcctName := "renamed"
@@ -99,7 +99,7 @@ func TestAccountRename(t *testing.T) {
 // Importing an account multiple times should not be considered an error by goal
 func TestAccountMultipleImportRootKey(t *testing.T) {
 	defer fixture.SetTestContext(t)()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	walletName := ""
 	createUnencryptedWallet := false

--- a/test/e2e-go/cli/goal/clerk_test.go
+++ b/test/e2e-go/cli/goal/clerk_test.go
@@ -22,11 +22,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/test/framework/fixtures"
 )
 
 func TestClerkSendNoteEncoding(t *testing.T) {
 	defer fixture.SetTestContext(t)()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	// wait for consensus on first round prior to sending transactions, time out after 2 minutes
 	err := fixture.WaitForRound(2, time.Duration(2*time.Minute))

--- a/test/e2e-go/cli/goal/node_cleanup_test.go
+++ b/test/e2e-go/cli/goal/node_cleanup_test.go
@@ -22,11 +22,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/nodecontrol"
+	"github.com/algorand/go-algorand/test/framework/fixtures"
 )
 
 func TestGoalNodeCleanup(t *testing.T) {
 	defer fixture.SetTestContext(t)()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	primaryDir := fixture.PrimaryDataDir()
 	nc := nodecontrol.MakeNodeController(fixture.GetBinDir(), primaryDir)

--- a/test/e2e-go/cli/perf/libgoal_test.go
+++ b/test/e2e-go/cli/perf/libgoal_test.go
@@ -34,19 +34,20 @@ func BenchmarkLibGoalPerf(b *testing.B) {
 	binDir := fixture.GetBinDir()
 
 	c, err := libgoal.MakeClientWithBinDir(binDir, fixture.PrimaryDataDir(), fixture.PrimaryDataDir(), libgoal.FullClient)
-	require.NoError(b, err)
+	a := require.New(fixtures.SynchronizedTest(b))
+	a.NoError(err)
 
 	b.Run("algod", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			_, err := c.AlgodVersions()
-			require.NoError(b, err)
+			a.NoError(err)
 		}
 	})
 
 	b.Run("kmd", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			_, err := c.GetUnencryptedWalletHandle()
-			require.NoError(b, err)
+			a.NoError(err)
 		}
 	})
 }

--- a/test/e2e-go/cli/perf/payment_test.go
+++ b/test/e2e-go/cli/perf/payment_test.go
@@ -35,21 +35,23 @@ func BenchmarkSendPayment(b *testing.B) {
 	defer fixture.Shutdown()
 	binDir := fixture.GetBinDir()
 
+	a := require.New(fixtures.SynchronizedTest(b))
+
 	c, err := libgoal.MakeClientWithBinDir(binDir, fixture.PrimaryDataDir(), fixture.PrimaryDataDir(), libgoal.FullClient)
-	require.NoError(b, err)
+	a.NoError(err)
 
 	wallet, err := c.GetUnencryptedWalletHandle()
-	require.NoError(b, err)
+	a.NoError(err)
 
 	addrs, err := c.ListAddresses(wallet)
-	require.NoError(b, err)
+	a.NoError(err)
 	require.True(b, len(addrs) > 0)
 	addr := addrs[0]
 
 	b.Run("getwallet", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			_, err = c.GetUnencryptedWalletHandle()
-			require.NoError(b, err)
+			a.NoError(err)
 		}
 	})
 
@@ -59,14 +61,14 @@ func BenchmarkSendPayment(b *testing.B) {
 			var nonce [8]byte
 			crypto.RandBytes(nonce[:])
 			tx, err = c.ConstructPayment(addr, addr, 1, 1, nonce[:], "", [32]byte{}, 0, 0)
-			require.NoError(b, err)
+			a.NoError(err)
 		}
 	})
 
 	b.Run("signtxn", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			_, err = c.SignTransactionWithWallet(wallet, nil, tx)
-			require.NoError(b, err)
+			a.NoError(err)
 		}
 	})
 
@@ -75,7 +77,7 @@ func BenchmarkSendPayment(b *testing.B) {
 			var nonce [8]byte
 			crypto.RandBytes(nonce[:])
 			_, err := c.SendPaymentFromWallet(wallet, nil, addr, addr, 1, 1, nonce[:], "", 0, 0)
-			require.NoError(b, err)
+			a.NoError(err)
 		}
 	})
 }

--- a/test/e2e-go/features/auction/auctionCancel_test.go
+++ b/test/e2e-go/features/auction/auctionCancel_test.go
@@ -31,7 +31,7 @@ func TestStartAndCancelAuctionNoBids(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 	var fixture fixtures.AuctionFixture
 	netTemplate := filepath.Join("nettemplates", "ThreeNodesEvenDist.json")
 	auctionParamFile := filepath.Join("auctions", "AuctionParams_1.json")
@@ -62,7 +62,7 @@ func TestStartAndCancelAuctionOneUserTenBids(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 	var fixture fixtures.AuctionFixture
 	netTemplate := filepath.Join("nettemplates", "TwoNodes50Each.json")
 	auctionParamFile := filepath.Join("auctions", "AuctionParams_1.json")
@@ -122,7 +122,7 @@ func TestStartAndCancelAuctionOneUserTenBids(t *testing.T) {
 
 func TestStartAndCancelAuctionEarlyOneUserTenBids(t *testing.T) {
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 	var fixture fixtures.AuctionFixture
 	netTemplate := filepath.Join("nettemplates", "TwoNodes50Each.json")
 	auctionParamFile := filepath.Join("auctions", "AuctionParams_1.json")

--- a/test/e2e-go/features/auction/auctionErrors_test.go
+++ b/test/e2e-go/features/auction/auctionErrors_test.go
@@ -35,7 +35,7 @@ func TestInvalidDeposit(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.AuctionFixture
 	netTemplate := filepath.Join("nettemplates", "TwoNodes50Each.json")
@@ -123,7 +123,7 @@ func TestNoDepositAssociatedWithBid(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.AuctionFixture
 	netTemplate := filepath.Join("nettemplates", "TwoNodes50Each.json")
@@ -192,7 +192,7 @@ func TestNoDepositAssociatedWithBid(t *testing.T) {
 func TestDeadbeatBid(t *testing.T) {
 	// an error is expected when an account attempts to overbid
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.AuctionFixture
 	netTemplate := filepath.Join("nettemplates", "TwoNodes50Each.json")
@@ -290,7 +290,7 @@ func TestStartAndPartitionAuctionTenUsersTenBidsEach(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 	var fixture fixtures.AuctionFixture
 	netTemplate := filepath.Join("nettemplates", "TwoNodes50Each.json")
 	auctionParamFile := filepath.Join("auctions", "AuctionParams_1.json")

--- a/test/e2e-go/features/auction/basicAuction_test.go
+++ b/test/e2e-go/features/auction/basicAuction_test.go
@@ -43,7 +43,7 @@ func TestStartAndEndAuctionNoBids(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 	var fixture fixtures.AuctionFixture
 	netTemplate := filepath.Join("nettemplates", "ThreeNodesEvenDist.json")
 	auctionParamFile := filepath.Join("auctions", "AuctionParams_1.json")
@@ -84,7 +84,7 @@ func TestStartAndEndAuctionOneUserOneBid(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 	var fixture fixtures.AuctionFixture
 	netTemplate := filepath.Join("nettemplates", "TwoNodes50Each.json")
 	auctionParamFile := filepath.Join("auctions", "AuctionParams_1.json")
@@ -153,7 +153,7 @@ func TestStartAndEndAuctionOneUserTenBids(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 	var fixture fixtures.AuctionFixture
 	netTemplate := filepath.Join("nettemplates", "TwoNodes50Each.json")
 	auctionParamFile := filepath.Join("auctions", "AuctionParams_1.json")
@@ -222,7 +222,7 @@ func TestStartAndEndAuctionOneUserTenBids(t *testing.T) {
 
 func TestStartAndEndAuctionTenUsersOneBidEach(t *testing.T) {
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 	var fixture fixtures.AuctionFixture
 	netTemplate := filepath.Join("nettemplates", "TwoNodes50Each.json")
 	auctionParamFile := filepath.Join("auctions", "AuctionParams_1.json")
@@ -317,7 +317,7 @@ func TestStartAndEndAuctionTenUsersTenBidsEach(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 	var fixture fixtures.AuctionFixture
 	netTemplate := filepath.Join("nettemplates", "TwoNodes50Each.json")
 	auctionParamFile := filepath.Join("auctions", "AuctionParams_1.json")
@@ -414,7 +414,7 @@ func TestDecayingPrice(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 	var fixture fixtures.AuctionFixture
 	netTemplate := filepath.Join("nettemplates", "TwoNodes50Each.json")
 	// "price goes from 10 to 1, decreasing by 1 each block for 10 blocks."

--- a/test/e2e-go/features/catchup/basicCatchup_test.go
+++ b/test/e2e-go/features/catchup/basicCatchup_test.go
@@ -35,7 +35,7 @@ func TestBasicCatchup(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	// Overview of this test:
 	// Start a two-node network (primary has 0%, secondary has 100%)
@@ -99,7 +99,7 @@ func runCatchupOverGossip(t *testing.T,
 	if testing.Short() {
 		t.Skip()
 	}
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 	// Overview of this test:
 	// Start a two-node network (Primary with 0% stake, Secondary with 100% stake)
 	// Kill the primary for a few blocks. (Note that primary only has incoming connections)
@@ -198,7 +198,7 @@ func TestStoppedCatchupOnUnsupported(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	consensus := make(config.ConsensusProtocols)
 	// The following two protocols: testUnupgradedProtocol and testUnupgradedToProtocol

--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -82,7 +82,7 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 	log := logging.TestingLog(t)
 
 	// Overview of this test:

--- a/test/e2e-go/features/compactcert/compactcert_test.go
+++ b/test/e2e-go/features/compactcert/compactcert_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestCompactCerts(t *testing.T) {
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 
 	configurableConsensus := make(config.ConsensusProtocols)
 	consensusVersion := protocol.ConsensusVersion("test-fast-compactcert")

--- a/test/e2e-go/features/multisig/multisig_test.go
+++ b/test/e2e-go/features/multisig/multisig_test.go
@@ -37,7 +37,7 @@ func TestBasicMultisig(t *testing.T) {
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50Each.json"))
 	defer fixture.Shutdown()
 
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 
 	// create three addrs
 	client := fixture.LibGoalClient
@@ -112,7 +112,7 @@ func TestZeroThreshold(t *testing.T) {
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50Each.json"))
 	defer fixture.Shutdown()
 
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 	client := fixture.LibGoalClient
 	walletHandle, err := client.GetUnencryptedWalletHandle()
 	r.NoError(err, "Getting default wallet handle should not return error")
@@ -139,7 +139,7 @@ func TestZeroSigners(t *testing.T) {
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50Each.json"))
 	defer fixture.Shutdown()
 
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 	client := fixture.LibGoalClient
 	walletHandle, err := client.GetUnencryptedWalletHandle()
 	r.NoError(err, "Getting default wallet handle should not return error")
@@ -162,7 +162,7 @@ func TestDuplicateKeys(t *testing.T) {
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50Each.json"))
 	defer fixture.Shutdown()
 
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 
 	// create one addr
 	client := fixture.LibGoalClient

--- a/test/e2e-go/features/participation/onlineOfflineParticipation_test.go
+++ b/test/e2e-go/features/participation/onlineOfflineParticipation_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestParticipationKeyOnlyAccountParticipatesCorrectly(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodesPartialPartkeyOnlyWallets.json"))
@@ -105,7 +105,7 @@ func TestNewAccountCanGoOnlineAndParticipate(t *testing.T) {
 	t.Skip() // temporary disable the test since it's failing.
 
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodesOneOnline.json"))

--- a/test/e2e-go/features/participation/participationRewards_test.go
+++ b/test/e2e-go/features/participation/participationRewards_test.go
@@ -75,7 +75,7 @@ func spendToNonParticipating(t *testing.T, fixture *fixtures.RestClientFixture, 
 
 func TestOnlineOfflineRewards(t *testing.T) {
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "FourNodes.json"))
@@ -137,7 +137,7 @@ func TestPartkeyOnlyRewards(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "FourNodes.json"))
@@ -180,7 +180,7 @@ func TestPartkeyOnlyRewards(t *testing.T) {
 
 func TestRewardUnitThreshold(t *testing.T) {
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "FourNodes.json"))
@@ -299,7 +299,7 @@ var defaultPoolAddr = basics.Address{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0
 
 func TestRewardRateRecalculation(t *testing.T) {
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 
 	// consensusTestRapidRewardRecalculation is a version of ConsensusCurrentVersion
 	// that decreases the RewardsRateRefreshInterval greatly.

--- a/test/e2e-go/features/partitionRecovery/partitionRecovery_test.go
+++ b/test/e2e-go/features/partitionRecovery/partitionRecovery_test.go
@@ -34,7 +34,7 @@ func TestBasicPartitionRecovery(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	// Overview of this test:
 	// Start a two-node network (with 50% each)
@@ -114,7 +114,7 @@ func TestPartitionRecoveryStaggerRestart(t *testing.T) {
 }
 
 func runTestWithStaggeredStopStart(t *testing.T, fixture *fixtures.RestClientFixture) {
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	// Get Node1 so we can wait until it has reached the target round
 	nc1, err := fixture.GetNodeController("Node1")
@@ -159,7 +159,7 @@ func TestBasicPartitionRecoveryPartOffline(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	// Overview of this test:
 	// Start a three-node network capable of making progress.
@@ -210,7 +210,7 @@ func TestPartitionHalfOffline(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	// Overview of this test:
 	// Start a TenNodeDistributed network

--- a/test/e2e-go/features/teal/compile_test.go
+++ b/test/e2e-go/features/teal/compile_test.go
@@ -31,7 +31,7 @@ func TestTealCompile(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.SetupNoStart(t, filepath.Join("nettemplates", "OneNodeFuture.json"))

--- a/test/e2e-go/features/transactions/accountv2_test.go
+++ b/test/e2e-go/features/transactions/accountv2_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func checkEvalDelta(t *testing.T, client *libgoal.Client, startRnd, endRnd uint64, gval uint64, lval uint64) {
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	foundGlobal := false
 	foundLocal := false
@@ -76,7 +76,7 @@ func checkEvalDelta(t *testing.T, client *libgoal.Client, startRnd, endRnd uint6
 
 func TestAccountInformationV2(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	proto, ok := config.Consensus[protocol.ConsensusFuture]

--- a/test/e2e-go/features/transactions/asset_test.go
+++ b/test/e2e-go/features/transactions/asset_test.go
@@ -54,7 +54,7 @@ func helperFillSignBroadcast(client libgoal.Client, wh []byte, sender string, tx
 
 func TestAssetValidRounds(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50EachFuture.json"))
@@ -188,7 +188,7 @@ func TestAssetConfig(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50EachFuture.json"))
@@ -420,7 +420,7 @@ func TestAssetConfig(t *testing.T) {
 
 func TestAssetInformation(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50EachFuture.json"))
@@ -512,7 +512,7 @@ func TestAssetInformation(t *testing.T) {
 
 func TestAssetGroupCreateSendDestroy(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50Each.json"))
@@ -653,7 +653,7 @@ func TestAssetGroupCreateSendDestroy(t *testing.T) {
 
 func TestAssetSend(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50EachFuture.json"))
@@ -1049,7 +1049,7 @@ func setupTestAndNetwork(t *testing.T, networkTemplate string, consensus config.
 	Assertions *require.Assertions, Fixture *fixtures.RestClientFixture, Client *libgoal.Client, Account0 string) {
 
 	t.Parallel()
-	asser := require.New(t)
+	asser := require.New(fixtures.SynchronizedTest(t))
 	if 0 == len(networkTemplate) {
 		// If the  networkTemplate is not specified, used the default one
 		networkTemplate = "TwoNodes50Each.json"

--- a/test/e2e-go/features/transactions/close_account_test.go
+++ b/test/e2e-go/features/transactions/close_account_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestAccountsCanClose(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50EachV15.json"))

--- a/test/e2e-go/features/transactions/group_test.go
+++ b/test/e2e-go/features/transactions/group_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestGroupTransactions(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50EachFuture.json"))
@@ -101,7 +101,7 @@ func TestGroupTransactions(t *testing.T) {
 
 func TestGroupTransactionsDifferentSizes(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50EachFuture.json"))
@@ -207,7 +207,7 @@ func TestGroupTransactionsDifferentSizes(t *testing.T) {
 
 func TestGroupTransactionsSubmission(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50Each.json"))

--- a/test/e2e-go/features/transactions/lease_test.go
+++ b/test/e2e-go/features/transactions/lease_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestLeaseTransactionsSameSender(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50Each.json"))
@@ -87,7 +87,7 @@ func TestLeaseTransactionsSameSender(t *testing.T) {
 
 func TestLeaseRegressionFaultyFirstValidCheckOld_2f3880f7(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50EachV22.json"))
@@ -159,7 +159,7 @@ func TestLeaseRegressionFaultyFirstValidCheckOld_2f3880f7(t *testing.T) {
 
 func TestLeaseRegressionFaultyFirstValidCheckNew_2f3880f7(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50Each.json"))
@@ -218,7 +218,7 @@ func TestLeaseRegressionFaultyFirstValidCheckNew_2f3880f7(t *testing.T) {
 
 func TestLeaseTransactionsSameSenderDifferentLease(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50Each.json"))
@@ -279,7 +279,7 @@ func TestLeaseTransactionsSameSenderDifferentLease(t *testing.T) {
 
 func TestLeaseTransactionsDifferentSender(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50Each.json"))
@@ -353,7 +353,7 @@ func TestLeaseTransactionsDifferentSender(t *testing.T) {
 
 func TestOverlappingLeases(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50Each.json"))

--- a/test/e2e-go/features/transactions/onlineStatusChange_test.go
+++ b/test/e2e-go/features/transactions/onlineStatusChange_test.go
@@ -40,7 +40,7 @@ func TestAccountsCanChangeOnlineStateInTheFuture(t *testing.T) {
 func testAccountsCanChangeOnlineState(t *testing.T, templatePath string) {
 
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, templatePath)

--- a/test/e2e-go/features/transactions/proof_test.go
+++ b/test/e2e-go/features/transactions/proof_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestTxnMerkleProof(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "OneNodeFuture.json"))

--- a/test/e2e-go/features/transactions/sendReceive_test.go
+++ b/test/e2e-go/features/transactions/sendReceive_test.go
@@ -49,7 +49,7 @@ func TestAccountsCanSendMoney(t *testing.T) {
 
 func testAccountsCanSendMoney(t *testing.T, templatePath string, numberOfSends int) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, templatePath)

--- a/test/e2e-go/features/transactions/transactionPool_test.go
+++ b/test/e2e-go/features/transactions/transactionPool_test.go
@@ -29,7 +29,7 @@ import (
 func TestTransactionPoolOrderingAndClearing(t *testing.T) {
 	t.Skip("test is flaky as of 2019-06-18")
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50EachOneOnline.json"))
@@ -115,7 +115,7 @@ func TestTransactionPoolExponentialFees(t *testing.T) {
 	t.Skip("new FIFO pool does not have exponential fee txn replacement")
 
 	t.Parallel()
-	r := require.New(t)
+	r := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50Each.json"))

--- a/test/e2e-go/kmd/e2e_kmd_wallet_keyops_test.go
+++ b/test/e2e-go/kmd/e2e_kmd_wallet_keyops_test.go
@@ -376,7 +376,7 @@ func BenchmarkSignTransaction(b *testing.B) {
 	}
 	resp0 := kmdapi.APIV1POSTKeyImportResponse{}
 	err := f.Client.DoV1Request(req0, &resp0)
-	require.NoError(b, err)
+	a.NoError(err)
 
 	// Make a transaction
 	tx := transactions.Transaction{
@@ -404,7 +404,7 @@ func BenchmarkSignTransaction(b *testing.B) {
 			}
 			resp1 := kmdapi.APIV1POSTTransactionSignResponse{}
 			err = f.Client.DoV1Request(req1, &resp1)
-			require.NoError(b, err)
+			a.NoError(err)
 		}
 	})
 }

--- a/test/e2e-go/perf/basic_test.go
+++ b/test/e2e-go/perf/basic_test.go
@@ -69,7 +69,7 @@ func signer(b *testing.B, wg *sync.WaitGroup, c libgoal.Client, wh []byte, txnCh
 		if err != nil {
 			fmt.Printf("Error signing: %v\n", err)
 		}
-		require.NoError(b, err)
+		a.NoError(err)
 
 		sigTxnChan <- &stxn
 	}
@@ -106,15 +106,15 @@ func doBenchTemplate(b *testing.B, template string, moneynode string) {
 	c := fixture.GetLibGoalClientForNamedNode(moneynode)
 
 	wallet, err := c.GetUnencryptedWalletHandle()
-	require.NoError(b, err)
+	a.NoError(err)
 
 	addrs, err := c.ListAddresses(wallet)
-	require.NoError(b, err)
+	a.NoError(err)
 	require.True(b, len(addrs) > 0)
 	addr := addrs[0]
 
 	suggest, err := c.SuggestedParams()
-	require.NoError(b, err)
+	a.NoError(err)
 
 	var genesisHash crypto.Digest
 	copy(genesisHash[:], suggest.GenesisHash)
@@ -133,7 +133,7 @@ func doBenchTemplate(b *testing.B, template string, moneynode string) {
 
 			fmt.Printf("Pre-signing %d transactions..\n", numTransactions)
 			wh, err := c.GetUnencryptedWalletHandle()
-			require.NoError(b, err)
+			a.NoError(err)
 
 			var sigWg sync.WaitGroup
 			txnChan := make(chan *transactions.Transaction, 100)
@@ -145,13 +145,13 @@ func doBenchTemplate(b *testing.B, template string, moneynode string) {
 
 			go func() {
 				sender, err := basics.UnmarshalChecksumAddress(addr)
-				require.NoError(b, err)
+				a.NoError(err)
 
 				round, err := c.CurrentRound()
-				require.NoError(b, err)
+				a.NoError(err)
 
 				params, err := c.SuggestedParams()
-				require.NoError(b, err)
+				a.NoError(err)
 				proto := config.Consensus[protocol.ConsensusVersion(params.ConsensusVersion)]
 
 				for txi := 0; txi < numTransactions; txi++ {
@@ -192,11 +192,11 @@ func doBenchTemplate(b *testing.B, template string, moneynode string) {
 			}
 
 			status, err = c.Status()
-			require.NoError(b, err)
+			a.NoError(err)
 
 			fmt.Printf("Waiting for round %d to start benchmark..\n", status.LastRound+1)
 			status, err = c.WaitForRound(status.LastRound + 1)
-			require.NoError(b, err)
+			a.NoError(err)
 
 			b.StartTimer()
 
@@ -232,7 +232,7 @@ func doBenchTemplate(b *testing.B, template string, moneynode string) {
 
 			_, err = fixture.WaitForConfirmedTxn(status.LastRound+100, addr, tx.ID().String())
 			fmt.Printf("Waiting for confirmation transaction to commit..\n")
-			require.NoError(b, err)
+			a.NoError(err)
 		}
 	})
 

--- a/test/e2e-go/stress/transactions/createManyAndGoOnline_test.go
+++ b/test/e2e-go/stress/transactions/createManyAndGoOnline_test.go
@@ -49,7 +49,7 @@ func cascadeCreateAndFundAccounts(amountToSend, transactionFee uint64, fundingAc
 // sends them all money, and sends them online
 func TestManyAccountsCanGoOnline(t *testing.T) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50Each.json"))

--- a/test/e2e-go/upgrades/rekey_support_test.go
+++ b/test/e2e-go/upgrades/rekey_support_test.go
@@ -29,7 +29,7 @@ import (
 
 // TestRekeyUpgrade tests that we rekey does not work before the upgrade and works well after
 func TestRekeyUpgrade(t *testing.T) {
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	smallLambdaMs := 500
 	consensus := makeApplicationUpgradeConsensus(t)

--- a/test/e2e-go/upgrades/send_receive_upgrade_test.go
+++ b/test/e2e-go/upgrades/send_receive_upgrade_test.go
@@ -98,7 +98,7 @@ func generateFastUpgradeConsensus() (fastUpgradeProtocols config.ConsensusProtoc
 
 func testAccountsCanSendMoneyAcrossUpgrade(t *testing.T, templatePath string) {
 	t.Parallel()
-	a := require.New(t)
+	a := require.New(fixtures.SynchronizedTest(t))
 
 	consensus := generateFastUpgradeConsensus()
 

--- a/test/framework/fixtures/auctionFixture.go
+++ b/test/framework/fixtures/auctionFixture.go
@@ -30,7 +30,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -164,9 +163,9 @@ func (f *AuctionFixture) GetAuctionConsoleRestClient() auctionClient.ConsoleRest
 }
 
 // Setup is called to initialize the test fixture for the test(s), uses default ports for auction bank and console
-func (f *AuctionFixture) Setup(t *testing.T, templateFile string) (err error) {
+func (f *AuctionFixture) Setup(t TestingTB, templateFile string) (err error) {
 
-	f.t = t
+	f.t = SynchronizedTest(t)
 
 	f.bidderSecretKeyCache = make(map[string]crypto.PrivateKey)
 

--- a/test/framework/fixtures/fixture.go
+++ b/test/framework/fixtures/fixture.go
@@ -16,18 +16,31 @@
 
 package fixtures
 
-import "testing"
+import (
+	"testing"
 
-// TestingT captures the common methods of *testing.T and *testing.B
-// that we use.
-type TestingT interface {
-	Fatalf(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
+	"github.com/algorand/go-deadlock"
+)
+
+// TestingTB is identical to testing.TB, beside the private method.
+type TestingTB interface {
+	Cleanup(func())
 	Error(args ...interface{})
-	Logf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+	Fail()
 	FailNow()
 	Failed() bool
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Helper()
+	Log(args ...interface{})
+	Logf(format string, args ...interface{})
 	Name() string
+	Skip(args ...interface{})
+	SkipNow()
+	Skipf(format string, args ...interface{})
+	Skipped() bool
+	//TempDir() string
 }
 
 // Fixture provides the base interface for all E2E test fixtures
@@ -50,3 +63,116 @@ type Fixture interface {
 	// (e.g. shared across all tests in a package)
 	ShutdownImpl(preserveData bool)
 }
+
+var synchTestMu deadlock.Mutex
+var synchTests = make(map[TestingTB]TestingTB)
+
+// SynchronizedTest generates a testing.TB compatible test for a given testing.TB interface.
+// calling SynchronizedTest with the same tb would return the exact same instance of synchTest
+func SynchronizedTest(tb TestingTB) TestingTB {
+	if st, ok := tb.(*synchTest); ok {
+		return st
+	}
+	synchTestMu.Lock()
+	defer synchTestMu.Unlock()
+	if t, have := synchTests[tb]; have {
+		return t
+	}
+	t := &synchTest{
+		t: tb,
+	}
+	synchTests[tb] = t
+	return t
+}
+
+type synchTest struct {
+	deadlock.Mutex
+	t TestingTB
+}
+
+func (st *synchTest) Cleanup(f func()) {
+	st.Lock()
+	defer st.Unlock()
+	st.t.Cleanup(f)
+}
+func (st *synchTest) Error(args ...interface{}) {
+	st.Lock()
+	defer st.Unlock()
+	st.t.Error(args...)
+}
+func (st *synchTest) Errorf(format string, args ...interface{}) {
+	st.Lock()
+	defer st.Unlock()
+	st.t.Errorf(format, args...)
+}
+func (st *synchTest) Fail() {
+	st.Lock()
+	defer st.Unlock()
+	st.t.Fail()
+}
+func (st *synchTest) FailNow() {
+	st.Lock()
+	defer st.Unlock()
+	st.t.FailNow()
+}
+func (st *synchTest) Failed() bool {
+	st.Lock()
+	defer st.Unlock()
+	return st.t.Failed()
+}
+func (st *synchTest) Fatal(args ...interface{}) {
+	st.Lock()
+	defer st.Unlock()
+	st.t.Fatal(args...)
+}
+func (st *synchTest) Fatalf(format string, args ...interface{}) {
+	st.Lock()
+	defer st.Unlock()
+	st.t.Fatalf(format, args...)
+}
+func (st *synchTest) Helper() {
+	st.Lock()
+	defer st.Unlock()
+	st.t.Helper()
+}
+func (st *synchTest) Log(args ...interface{}) {
+	st.Lock()
+	defer st.Unlock()
+	st.t.Log(args...)
+}
+func (st *synchTest) Logf(format string, args ...interface{}) {
+	st.Lock()
+	defer st.Unlock()
+	st.t.Logf(format, args...)
+}
+func (st *synchTest) Name() string {
+	st.Lock()
+	defer st.Unlock()
+	return st.t.Name()
+}
+func (st *synchTest) Skip(args ...interface{}) {
+	st.Lock()
+	defer st.Unlock()
+	st.t.Skip(args...)
+}
+func (st *synchTest) SkipNow() {
+	st.Lock()
+	defer st.Unlock()
+	st.t.SkipNow()
+}
+func (st *synchTest) Skipf(format string, args ...interface{}) {
+	st.Lock()
+	defer st.Unlock()
+	st.t.Skipf(format, args...)
+}
+func (st *synchTest) Skipped() bool {
+	st.Lock()
+	defer st.Unlock()
+	return st.t.Skipped()
+}
+
+/*func (st *synchTest) TempDir() string {
+	st.Lock()
+	defer st.Unlock()
+	return st.t.TempDir()
+}*/

--- a/test/framework/fixtures/kmdFixture.go
+++ b/test/framework/fixtures/kmdFixture.go
@@ -50,7 +50,7 @@ var defaultAPIToken = []byte(strings.Repeat("a", 64))
 // KMDFixture is a test fixture for tests requiring interactions with kmd
 type KMDFixture struct {
 	baseFixture
-	t              TestingT
+	t              TestingTB
 	initialized    bool
 	dataDir        string
 	kmdDir         string
@@ -94,21 +94,21 @@ func (f *KMDFixture) ShutdownImpl(preserveData bool) {
 }
 
 // SetupWithWallet starts kmd and creates a wallet, returning a wallet handle
-func (f *KMDFixture) SetupWithWallet(t TestingT) (handleToken string) {
+func (f *KMDFixture) SetupWithWallet(t TestingTB) (handleToken string) {
 	f.Setup(t)
 	handleToken, _ = f.MakeWalletAndHandleToken()
 	return
 }
 
 // Setup starts kmd with the default config
-func (f *KMDFixture) Setup(t TestingT) {
+func (f *KMDFixture) Setup(t TestingTB) {
 	f.SetupWithConfig(t, "")
 }
 
 // Initialize initializes the dataDir and TestingT for this test but doesn't start kmd
-func (f *KMDFixture) Initialize(t TestingT) {
+func (f *KMDFixture) Initialize(t TestingTB) {
 	f.initialize(f)
-	f.t = t
+	f.t = SynchronizedTest(t)
 	f.dataDir = filepath.Join(f.testDir, t.Name())
 	// Remove any existing tests in this dataDir + recreate
 	err := os.RemoveAll(f.dataDir)
@@ -126,7 +126,7 @@ func (f *KMDFixture) Initialize(t TestingT) {
 // config, if the passed config is blank. Though internally an error might
 // occur during setup, we never return one, because we'll still fail the test
 // for any errors here, and it keeps the test code much cleaner
-func (f *KMDFixture) SetupWithConfig(t TestingT, config string) {
+func (f *KMDFixture) SetupWithConfig(t TestingTB, config string) {
 	// Setup is called once per test, so it's OK for test to store one particular TestingT
 	f.Initialize(t)
 

--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -50,7 +50,7 @@ type LibGoalFixture struct {
 	rootDir        string
 	Name           string
 	network        netdeploy.Network
-	t              TestingT
+	t              TestingTB
 	tMu            deadlock.RWMutex
 	clientPartKeys map[string][]account.Participation
 	consensus      config.ConsensusProtocols
@@ -63,13 +63,13 @@ func (f *RestClientFixture) SetConsensus(consensus config.ConsensusProtocols) {
 }
 
 // Setup is called to initialize the test fixture for the test(s)
-func (f *LibGoalFixture) Setup(t TestingT, templateFile string) {
+func (f *LibGoalFixture) Setup(t TestingTB, templateFile string) {
 	f.setup(t, t.Name(), templateFile, true)
 }
 
 // SetupNoStart is called to initialize the test fixture for the test(s)
 // but does not start the network before returning.  Call NC.Start() to start later.
-func (f *LibGoalFixture) SetupNoStart(t TestingT, templateFile string) {
+func (f *LibGoalFixture) SetupNoStart(t TestingTB, templateFile string) {
 	f.setup(t, t.Name(), templateFile, false)
 }
 
@@ -83,10 +83,10 @@ func (f *LibGoalFixture) Genesis() gen.GenesisData {
 	return f.network.Genesis()
 }
 
-func (f *LibGoalFixture) setup(test TestingT, testName string, templateFile string, startNetwork bool) {
+func (f *LibGoalFixture) setup(test TestingTB, testName string, templateFile string, startNetwork bool) {
 	// Call initialize for our base implementation
 	f.initialize(f)
-	f.t = test
+	f.t = SynchronizedTest(test)
 	f.rootDir = filepath.Join(f.testDir, testName)
 
 	// In case we're running tests against the same rootDir, purge it to avoid errors from already-exists
@@ -273,10 +273,10 @@ func (f *LibGoalFixture) Start() {
 // SetTestContext should be called within each test using a shared fixture.
 // It ensures the current test context is set and then reset after the test ends
 // It should be called in the form of "defer fixture.SetTestContext(t)()"
-func (f *LibGoalFixture) SetTestContext(t TestingT) func() {
+func (f *LibGoalFixture) SetTestContext(t TestingTB) func() {
 	f.tMu.Lock()
 	defer f.tMu.Unlock()
-	f.t = t
+	f.t = SynchronizedTest(t)
 	return func() {
 		f.tMu.Lock()
 		defer f.tMu.Unlock()

--- a/test/framework/fixtures/restClientFixture.go
+++ b/test/framework/fixtures/restClientFixture.go
@@ -39,14 +39,14 @@ type RestClientFixture struct {
 }
 
 // Setup is called to initialize the test fixture for the test(s)
-func (f *RestClientFixture) Setup(t TestingT, templateFile string) {
+func (f *RestClientFixture) Setup(t TestingTB, templateFile string) {
 	f.LibGoalFixture.Setup(t, templateFile)
 	f.AlgodClient = f.GetAlgodClientForController(f.NC)
 }
 
 // SetupNoStart is called to initialize the test fixture for the test(s)
 // but does not start the network before returning.  Call NC.Start() to start later.
-func (f *RestClientFixture) SetupNoStart(t TestingT, templateFile string) {
+func (f *RestClientFixture) SetupNoStart(t TestingTB, templateFile string) {
 	f.LibGoalFixture.SetupNoStart(t, templateFile)
 }
 


### PR DESCRIPTION
## Summary

Synchronize testing.T access to avoid generating a datarace in case of a node crash feedback.
When the node controller notice that the node has exit, it reports it back to the test fixture.
However, the test fixture cannot report that to the underlying test since doing so would create a data race : the testing.TB is not meant to support concurrency.

To address that, I've created an abstraction above the testing.TB called TestingTB, which would retain the same functionality, but would use a mutex to synchronize the access.

## Test Plan

Tested manually to confirm correctness.