### PR TITLE
node controller: delete pid file on process killing

### DIFF
--- a/nodecontrol/algodControl.go
+++ b/nodecontrol/algodControl.go
@@ -160,9 +160,15 @@ func (nc *NodeController) StopAlgod() (err error) {
 	algodPID, err := nc.GetAlgodPID()
 	if err == nil {
 		// Kill algod by PID
-		err = killPID(int(algodPID))
-		if err != nil {
-			return
+		killed, killErr := killPID(int(algodPID))
+		if killErr != nil {
+			return killErr
+		}
+		// if we ended up killing the process, make sure to delete the pid file to avoid
+		// potential downstream issues.
+		if killed {
+			// delete the pid file.
+			os.Remove(nc.algodPidFile)
 		}
 	} else {
 		return &NodeNotRunningError{algodDataDir: nc.algodDataDir}

--- a/nodecontrol/kmdControl.go
+++ b/nodecontrol/kmdControl.go
@@ -121,9 +121,15 @@ func (kc *KMDController) StopKMD() (alreadyStopped bool, err error) {
 	kmdPID, err := kc.GetKMDPID()
 	if err == nil {
 		// Kill kmd by PID
-		err = killPID(int(kmdPID))
-		if err != nil {
-			return
+		killed, killErr := killPID(int(kmdPID))
+		if killErr != nil {
+			return false, killErr
+		}
+		// if we ended up killing the process, make sure to delete the pid file to avoid
+		// potential downstream issues.
+		if killed {
+			// delete the pid file.
+			os.Remove(kc.kmdPIDPath)
 		}
 	} else {
 		err = nil


### PR DESCRIPTION
## Summary

Existing code wait 30 seconds between sending SIGTERM and SIGKILL. When sending the SIGKILL, the process is deleted, but the pid file remains on disk.

Leaving the pid file on disk could cause subsequent failures - and we could easily avoid them by clearing this file if we SIGKILL'ed the process.

## Test Plan

Tested manually.