### PR TITLE
adding extra docs for pushbytes and pushint

### DIFF
--- a/data/transactions/logic/TEAL_opcodes.md
+++ b/data/transactions/logic/TEAL_opcodes.md
@@ -840,6 +840,8 @@ params: txn.ForeignAssets offset. Return: did_exist flag (1 if exist and 0 other
 - push the following program bytes to the stack
 - LogicSigVersion >= 3
 
+pushbytes args are not added to the bytecblock during assembly processes
+
 ## pushint uint
 
 - Opcode: 0x81 {varuint int}
@@ -847,3 +849,5 @@ params: txn.ForeignAssets offset. Return: did_exist flag (1 if exist and 0 other
 - Pushes: uint64
 - push immediate UINT to the stack as an integer
 - LogicSigVersion >= 3
+
+pushint args are not added to the intcblock during assembly processes

--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -164,6 +164,8 @@ var opDocExtras = map[string]string{
 	"gtxns":             "for notes on transaction fields available, see `txn`. If top of stack is _i_, `gtxns field` is equivalent to `gtxn _i_ field`. gtxns exists so that _i_ can be calculated, often based on the index of the current transaction.",
 	"btoi":              "`btoi` panics if the input is longer than 8 bytes.",
 	"concat":            "`concat` panics if the result would be greater than 4096 bytes.",
+	"pushbytes":         "pushbytes args are not added to the bytecblock during assembly processes",
+	"pushint":           "pushint args are not added to the intcblock during assembly processes",
 	"getbit":            "see explanation of bit ordering in setbit",
 	"setbit":            "bit indexing begins with low-order bits in integers. Setting bit 4 to 1 on the integer 0 yields 16 (`int 0x0010`, or 2^4). Indexing begins in the first bytes of a byte-string (as seen in getbyte and substring). Setting bits 0 through 11 to 1 in a 4 byte-array of 0s yields `byte 0xfff00000`",
 	"app_opted_in":      "params: account index, application id (top of the stack on opcode entry). Return: 1 if opted in and 0 otherwise.",


### PR DESCRIPTION
Mention that the args to ops pushbytes and pushint do not get added to the bytecblock or intcblock.

This replaces another PR with docs generated using Makefile since it was created with the edit feature. 

## Summary

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
