### PR TITLE
testing: fix node shutdown on error

### DIFF
--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -55,7 +55,7 @@ proc ::AlgorandGoal::Abort { ERROR } {
 
     if { [info exists ::GLOBAL_TEST_ALGO_DIR] } {
         puts "GLOBAL_TEST_ALGO_DIR $::GLOBAL_TEST_ALGO_DIR"
-        ::AlgorandGoal::StopNode $::GLOBAL_TEST_ROOT_DIR
+        ::AlgorandGoal::StopNode $::GLOBAL_TEST_ALGO_DIR
     }
 
     exit 1


### PR DESCRIPTION
## Summary

the expect `::AlgorandGoal::Abort` procedure was attempting to stop the wrong node directory, leading to consistent fails:
```
        spawn go install ./catchpointCatchupWebProxy
8738        Aborting with Error: timed out compiling catchpointCatchupWebProxy
8739        GLOBAL_TEST_ROOT_DIR /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/104023-1617148239464/catchpointCatchupTest/algod/root
8740        GLOBAL_NETWORK_NAME test_net_expect_1617149479
8741        Stopping network: test_net_expect_1617149479
8742        spawn goal network stop -r /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/104023-1617148239464/catchpointCatchupTest/algod/root
8743        Network Stopped under /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/104023-1617148239464/catchpointCatchupTest/algod/root
8744        Network Stopped under /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/104023-1617148239464/catchpointCatchupTest/algod/root
8745        
8746        GLOBAL_TEST_ALGO_DIR /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/104023-1617148239464/catchpointCatchupTest/algod/root/Primary
8747        node stop with /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/104023-1617148239464/catchpointCatchupTest/algod/root
8748        spawn goal node stop -d /Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/104023-1617148239464/catchpointCatchupTest/algod/root
8749        Cannot kill node: no running node in directory '/Users/travis/gopath/src/github.com/algorand/go-algorand/tmp/out/e2e/104023-1617148239464/catchpointCatchupTest/algod/root'
8750        ERROR in StopNode: spawn_id: spawn id exp9 not open
```

## Test Plan

This is a test.