### PR TITLE
Fix for empty local state key value map assignment

### DIFF
--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -18,14 +18,19 @@ package ledger
 
 import (
 	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/data/transactions/logic"
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/protocol"
 )
 
 func getRandomAddress(a *require.Assertions) basics.Address {
@@ -330,5 +335,235 @@ func TestLogicLedgerDelKey(t *testing.T) {
 	addr1 := getRandomAddress(a)
 	c.stores = map[storeLocator]basics.TealKeyValue{{addr1, aidx, false}: {"lkey": tv}}
 	err = l.DelLocal(addr1, "lkey")
+	a.NoError(err)
+}
+
+// test ensures that
+// 1) app's GlobalState and local state's KeyValue are stored in the same way
+// before and after application code refactoring
+// 2) writing into empty (opted-in) local state's KeyValue works after reloading
+// Hardcoded values are from commit 9a0b439 (pre app refactor commit)
+func TestAppAccountDataStorage(t *testing.T) {
+	a := require.New(t)
+	source := `#pragma version 2
+// do not write local key on opt in or on app create
+txn ApplicationID
+int 0
+==
+bnz success
+txn OnCompletion
+int NoOp
+==
+bnz writetostate
+txn OnCompletion
+int OptIn
+==
+bnz checkargs
+int 0
+return
+checkargs:
+// if no args the success
+// otherwise write data
+txn NumAppArgs
+int 0
+==
+bnz success
+// write local or global key depending on arg1
+writetostate:
+txna ApplicationArgs 0
+byte "local"
+==
+bnz writelocal
+txna ApplicationArgs 0
+byte "global"
+==
+bnz writeglobal
+int 0
+return
+writelocal:
+int 0
+byte "lk"
+byte "local"
+app_local_put
+b success
+writeglobal:
+byte "gk"
+byte "global"
+app_global_put
+success:
+int 1
+return`
+
+	ops, err := logic.AssembleString(source)
+	a.NoError(err)
+	a.Greater(len(ops.Program), 1)
+	program := ops.Program
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	genesisInitState, initKeys := testGenerateInitState(t, protocol.ConsensusCurrentVersion)
+
+	creator, err := basics.UnmarshalChecksumAddress("3LN5DBFC2UTPD265LQDP3LMTLGZCQ5M3JV7XTVTGRH5CKSVNQVDFPN6FG4")
+	a.NoError(err)
+	userOptin, err := basics.UnmarshalChecksumAddress("6S6UMUQ4462XRGNON5GKBHW55RUJGJ5INIRDFVFD6KSPHGWGRKPC6RK2O4")
+	a.NoError(err)
+	userLocal, err := basics.UnmarshalChecksumAddress("UL5C6SRVLOROSB5FGAE6TY34VXPXVR7GNIELUB3DD5KTA4VT6JGOZ6WFAY")
+	a.NoError(err)
+	userLocal2, err := basics.UnmarshalChecksumAddress("XNOGOJECWDOMVENCDJHNMOYVV7PIVIJXRWTSZUA3GSKYTVXH3VVGOXP7CU")
+	a.NoError(err)
+
+	a.Contains(genesisInitState.Accounts, creator)
+	a.Contains(genesisInitState.Accounts, userOptin)
+	a.Contains(genesisInitState.Accounts, userLocal)
+	a.Contains(genesisInitState.Accounts, userLocal2)
+
+	expectedCreator, err := hex.DecodeString("84a4616c676fce009d2290a461707070810184a6617070726f76c45602200200012604056c6f63616c06676c6f62616c026c6b02676b3118221240003331192212400010311923124000022243311b221240001c361a00281240000a361a0029124000092243222a28664200032b29672343a6636c65617270c40102a46773636881a36e627304a46c73636881a36e627301a36f6e6c01a47473636881a36e627304")
+	a.NoError(err)
+	expectedUserOptIn, err := hex.DecodeString("84a4616c676fce00a02fd0a46170706c810181a46873636881a36e627301a36f6e6c01a47473636881a36e627301")
+	a.NoError(err)
+	expectedUserLocal, err := hex.DecodeString("84a4616c676fce00a33540a46170706c810182a46873636881a36e627301a3746b7681a26c6b82a27462a56c6f63616ca2747401a36f6e6c01a47473636881a36e627301")
+	a.NoError(err)
+
+	cfg := config.GetDefaultLocal()
+	l, err := OpenLedger(logging.Base(), "TestAppAccountData", true, genesisInitState, cfg)
+	a.NoError(err)
+	defer l.Close()
+
+	txHeader := transactions.Header{
+		Sender:      creator,
+		Fee:         basics.MicroAlgos{Raw: proto.MinTxnFee * 2},
+		FirstValid:  l.Latest() + 1,
+		LastValid:   l.Latest() + 10,
+		GenesisID:   t.Name(),
+		GenesisHash: genesisInitState.GenesisHash,
+	}
+
+	// create application
+	approvalProgram := program
+	clearStateProgram := []byte("\x02") // empty
+	appCreateFields := transactions.ApplicationCallTxnFields{
+		ApprovalProgram:   approvalProgram,
+		ClearStateProgram: clearStateProgram,
+		GlobalStateSchema: basics.StateSchema{NumByteSlice: 4},
+		LocalStateSchema:  basics.StateSchema{NumByteSlice: 1},
+	}
+	appCreate := transactions.Transaction{
+		Type:                     protocol.ApplicationCallTx,
+		Header:                   txHeader,
+		ApplicationCallTxnFields: appCreateFields,
+	}
+	err = l.appendUnvalidatedTx(t, genesisInitState.Accounts, initKeys, appCreate, transactions.ApplyData{})
+	a.NoError(err)
+
+	appIdx := basics.AppIndex(1) // first tnx => idx = 1
+
+	// opt-in, do no write
+	txHeader.Sender = userOptin
+	appCallFields := transactions.ApplicationCallTxnFields{
+		OnCompletion:  transactions.OptInOC,
+		ApplicationID: appIdx,
+	}
+	appCall := transactions.Transaction{
+		Type:                     protocol.ApplicationCallTx,
+		Header:                   txHeader,
+		ApplicationCallTxnFields: appCallFields,
+	}
+	err = l.appendUnvalidatedTx(t, genesisInitState.Accounts, initKeys, appCall, transactions.ApplyData{})
+	a.NoError(err)
+
+	// opt-in + write
+	txHeader.Sender = userLocal
+	appCall = transactions.Transaction{
+		Type:                     protocol.ApplicationCallTx,
+		Header:                   txHeader,
+		ApplicationCallTxnFields: appCallFields,
+	}
+	err = l.appendUnvalidatedTx(t, genesisInitState.Accounts, initKeys, appCall, transactions.ApplyData{})
+	a.NoError(err)
+
+	// save data into DB and write into local state
+	l.accts.accountsWriting.Add(1)
+	l.accts.commitRound(3, 0, 0)
+	l.reloadLedger()
+
+	appCallFields = transactions.ApplicationCallTxnFields{
+		OnCompletion:    0,
+		ApplicationID:   appIdx,
+		ApplicationArgs: [][]byte{[]byte("local")},
+	}
+	appCall = transactions.Transaction{
+		Type:                     protocol.ApplicationCallTx,
+		Header:                   txHeader,
+		ApplicationCallTxnFields: appCallFields,
+	}
+	err = l.appendUnvalidatedTx(t, genesisInitState.Accounts, initKeys, appCall,
+		transactions.ApplyData{EvalDelta: basics.EvalDelta{
+			LocalDeltas: map[uint64]basics.StateDelta{0: {"lk": basics.ValueDelta{Action: basics.SetBytesAction, Bytes: "local"}}}},
+		})
+	a.NoError(err)
+
+	// save data into DB
+	l.accts.accountsWriting.Add(1)
+	l.accts.commitRound(1, 3, 0)
+	l.reloadLedger()
+
+	// dump accounts
+	var rowid int64
+	var dbRound basics.Round
+	var buf []byte
+	err = l.accts.accountsq.lookupStmt.QueryRow(creator[:]).Scan(&rowid, &dbRound, &buf)
+	a.NoError(err)
+	a.Equal(expectedCreator, buf)
+
+	err = l.accts.accountsq.lookupStmt.QueryRow(userOptin[:]).Scan(&rowid, &dbRound, &buf)
+	a.NoError(err)
+	a.Equal(expectedUserOptIn, buf)
+	pad, err := l.accts.accountsq.lookup(userOptin)
+	a.Nil(pad.accountData.AppLocalStates[appIdx].KeyValue)
+	ad, err := l.Lookup(dbRound, userOptin)
+	a.Nil(ad.AppLocalStates[appIdx].KeyValue)
+
+	err = l.accts.accountsq.lookupStmt.QueryRow(userLocal[:]).Scan(&rowid, &dbRound, &buf)
+	a.NoError(err)
+	a.Equal(expectedUserLocal, buf)
+
+	ad, err = l.Lookup(dbRound, userLocal)
+	a.NoError(err)
+	a.Equal("local", ad.AppLocalStates[appIdx].KeyValue["lk"].Bytes)
+
+	// ensure writing into empty global state works as well
+	l.reloadLedger()
+	txHeader.Sender = creator
+	appCallFields = transactions.ApplicationCallTxnFields{
+		OnCompletion:    0,
+		ApplicationID:   appIdx,
+		ApplicationArgs: [][]byte{[]byte("global")},
+	}
+	appCall = transactions.Transaction{
+		Type:                     protocol.ApplicationCallTx,
+		Header:                   txHeader,
+		ApplicationCallTxnFields: appCallFields,
+	}
+	err = l.appendUnvalidatedTx(t, genesisInitState.Accounts, initKeys, appCall,
+		transactions.ApplyData{EvalDelta: basics.EvalDelta{
+			GlobalDelta: basics.StateDelta{"gk": basics.ValueDelta{Action: basics.SetBytesAction, Bytes: "global"}}},
+		})
+	a.NoError(err)
+
+	// opt-in + write by during opt-in
+	txHeader.Sender = userLocal2
+	appCallFields = transactions.ApplicationCallTxnFields{
+		OnCompletion:    transactions.OptInOC,
+		ApplicationID:   appIdx,
+		ApplicationArgs: [][]byte{[]byte("local")},
+	}
+	appCall = transactions.Transaction{
+		Type:                     protocol.ApplicationCallTx,
+		Header:                   txHeader,
+		ApplicationCallTxnFields: appCallFields,
+	}
+	err = l.appendUnvalidatedTx(t, genesisInitState.Accounts, initKeys, appCall,
+		transactions.ApplyData{EvalDelta: basics.EvalDelta{
+			LocalDeltas: map[uint64]basics.StateDelta{0: {"lk": basics.ValueDelta{Action: basics.SetBytesAction, Bytes: "local"}}}},
+		})
 	a.NoError(err)
 }


### PR DESCRIPTION
## Summary

* Opting in does not allocate key value map
* State delta merging code assumed the map in old AD was allocated
* Added that missed allocation, and a test verifying combinations
* Inspected and removed TODOs from applyStorageDelta

## Test Plan

Added a test for
1. checking serialization against before app-refactor
2. combinations of `allocAction` and `remainAllocAction` for opting in and writing local state