### PR TITLE
Fix ClearState program applying when it errs

### DIFF
--- a/ledger/appcow.go
+++ b/ledger/appcow.go
@@ -25,6 +25,7 @@ import (
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/ledger/apply"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -419,7 +420,7 @@ func (cb *roundCowState) StatefulEval(params logic.EvalParams, aidx basics.AppIn
 	// Eval the program
 	pass, err = logic.EvalStateful(program, params)
 	if err != nil {
-		return false, basics.EvalDelta{}, err
+		return false, basics.EvalDelta{}, ledgercore.LogicEvalError{Err: err}
 	}
 
 	// If program passed, build our eval delta, and commit to state changes

--- a/ledger/ledgercore/error.go
+++ b/ledger/ledgercore/error.go
@@ -76,3 +76,13 @@ type ErrNoEntry struct {
 func (err ErrNoEntry) Error() string {
 	return fmt.Sprintf("ledger does not have entry %d (latest %d, committed %d)", err.Round, err.Latest, err.Committed)
 }
+
+// LogicEvalError indicates TEAL evaluation failure
+type LogicEvalError struct {
+	Err error
+}
+
+// Error satisfies builtin interface `error`
+func (err LogicEvalError) Error() string {
+	return fmt.Sprintf("logic eval error: %v", err.Err)
+}

--- a/test/scripts/e2e_subs/e2e-app-simple.sh
+++ b/test/scripts/e2e_subs/e2e-app-simple.sh
@@ -101,3 +101,23 @@ if [[ $RES != *"${EXPERROR}"* ]]; then
     date '+app-create-test FAIL clearing state twice should fail %Y%m%d_%H%M%S'
     false
 fi
+
+# Create an application with clear program always errs
+# Ensure clear still works
+APPID=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog <(printf '#pragma version 2\nint 1') --clear-prog <(printf '#pragma version 2\nerr') --global-byteslices 0 --global-ints 0 --local-byteslices 0 --local-ints 0 | grep Created | awk '{ print $6 }')
+
+# Should succeed to opt in
+${gcmd} app optin --app-id $APPID --from $ACCOUNT
+
+# Succeed in clearing state for the app
+${gcmd} app clear --app-id $APPID --from $ACCOUNT
+
+# Create an application with clear program always fails
+# Ensure clear still works
+APPID=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog <(printf '#pragma version 2\nint 1') --clear-prog <(printf '#pragma version 2\nint 0') --global-byteslices 0 --global-ints 0 --local-byteslices 0 --local-ints 0 | grep Created | awk '{ print $6 }')
+
+# Should succeed to opt in
+${gcmd} app optin --app-id $APPID --from $ACCOUNT
+
+# Succeed in clearing state for the app
+${gcmd} app clear --app-id $APPID --from $ACCOUNT


### PR DESCRIPTION
## Summary

* Apps logic needs to ignore result and error from logic evaluator but but fail on other errors
* The bug happened in app refactor PR
* Added unit and e2e test

## Test Plan

Added e2e test that ensures success with clear state programs that always fail or err.
Added unit test that check clear state error does not lead to `apply.ApplicationCall` error