### PR TITLE
Tealdbg don't assume program version

### DIFF
--- a/cmd/tealdbg/local.go
+++ b/cmd/tealdbg/local.go
@@ -336,6 +336,9 @@ func (r *LocalRunner) Setup(dp *DebugParams) (err error) {
 			if IsTextFile(data) {
 				source := string(data)
 				ops, err := logic.AssembleString(source)
+				if ops.Version > r.proto.LogicSigVersion {
+					return fmt.Errorf("Program version (%d) is beyond the maximum supported protocol version (%d)", ops.Version, r.proto.LogicSigVersion)
+				}
 				if err != nil {
 					errorLines := ""
 					for _, lineError := range ops.Errors {

--- a/cmd/tealdbg/local.go
+++ b/cmd/tealdbg/local.go
@@ -335,7 +335,7 @@ func (r *LocalRunner) Setup(dp *DebugParams) (err error) {
 			r.runs[i].program = data
 			if IsTextFile(data) {
 				source := string(data)
-				ops, err := logic.AssembleStringWithVersion(source, r.proto.LogicSigVersion)
+				ops, err := logic.AssembleString(source)
 				if err != nil {
 					errorLines := ""
 					for _, lineError := range ops.Errors {

--- a/cmd/tealdbg/local_test.go
+++ b/cmd/tealdbg/local_test.go
@@ -337,7 +337,8 @@ func TestDebugEnvironment(t *testing.T) {
 
 	// create sample programs that checks all the environment:
 	// transaction fields, global properties,
-	source := `global Round
+	source := `#pragma version 2
+global Round
 int 222
 ==
 global LatestTimestamp
@@ -476,7 +477,8 @@ int 100
 	a.True(pass)
 
 	// check relaxed - opted in for both
-	source = `int 1
+	source = `#pragma version 2
+int 1
 int 100
 app_opted_in
 int 1
@@ -499,7 +501,7 @@ int 1
 	ds.Painless = false
 
 	// check ForeignApp
-	source = `
+	source = `#pragma version 2
 int 300
 byte 0x676b657962797465 // gkeybyte
 app_global_get_ex

--- a/cmd/tealdbg/main.go
+++ b/cmd/tealdbg/main.go
@@ -155,7 +155,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&noSourceMap, "no-source-map", false, "Do not generate source maps")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
 
-	debugCmd.Flags().StringVarP(&proto, "proto", "p", "", "Consensus protocol version for TEAL")
+	debugCmd.Flags().StringVarP(&proto, "proto", "p", "", "Consensus protocol version for TEAL evaluation")
 	debugCmd.Flags().StringVarP(&txnFile, "txn", "t", "", "Transaction(s) to evaluate TEAL on in form of json or msgpack file")
 	debugCmd.Flags().IntVarP(&groupIndex, "group-index", "g", 0, "Transaction index in a txn group")
 	debugCmd.Flags().StringVarP(&balanceFile, "balance", "b", "", "Balance records to evaluate stateful TEAL on in form of json or msgpack file")

--- a/test/e2e-go/cli/tealdbg/expect/tealdbgSpinoffTest.exp
+++ b/test/e2e-go/cli/tealdbg/expect/tealdbgSpinoffTest.exp
@@ -56,6 +56,6 @@ if { [catch {
     }
 
 } EXCEPTION ] } {
-    puts "ERROR in teadbgTest: $EXCEPTION"
+    puts "ERROR in tealdbgTest: $EXCEPTION"
     exit 1
 }

--- a/test/e2e-go/cli/tealdbg/expect/tealdbgTest.exp
+++ b/test/e2e-go/cli/tealdbg/expect/tealdbgTest.exp
@@ -65,17 +65,20 @@ if { [catch {
     # this is ConsensusV26
     set PROTOCOL_VERSION_3 "https://github.com/algorandfoundation/specs/tree/ac2255d586c4474d4ebcf3809acccb59b7ef34ff"
 
-    # run the test using version 2:
+    # run the test using version 2 on protocol version 2:
     exec printf "#pragma version 2\nint 1\ndup\n+\n" > $TEAL_PROG_FILE
     TestTealdbg $TEAL_PROG_FILE $PROTOCOL_VERSION_2 ""
 
-    # run the test using version 3:
+    # run the test using version 2 on protocol version 3:
+    TestTealdbg $TEAL_PROG_FILE $PROTOCOL_VERSION_3 "--remote-debugging-port 9392 --listen 127.0.0.1"
+
+    # run the test using version 3 on protocol version 3:
     exec printf "#pragma version 3\nint 1\ndup\n+\n" > $TEAL_PROG_FILE
     TestTealdbg $TEAL_PROG_FILE $PROTOCOL_VERSION_3 "--remote-debugging-port 9392 --listen 127.0.0.1"
 
     exec rm $TEAL_PROG_FILE
 
 } EXCEPTION ] } {
-    puts "ERROR in teadbgTest: $EXCEPTION"
+    puts "ERROR in tealdbgTest: $EXCEPTION"
     exit 1
 }

--- a/test/e2e-go/cli/tealdbg/expect/tealdbgTest.exp
+++ b/test/e2e-go/cli/tealdbg/expect/tealdbgTest.exp
@@ -76,6 +76,19 @@ if { [catch {
     exec printf "#pragma version 3\nint 1\ndup\n+\n" > $TEAL_PROG_FILE
     TestTealdbg $TEAL_PROG_FILE $PROTOCOL_VERSION_3 "--remote-debugging-port 9392 --listen 127.0.0.1"
 
+    # run the test using version 3 on protocol version 2 (this should fail)
+    set FAILED 0
+    spawn tealdbg debug -v $TEAL_PROG_FILE -p $PROTOCOL_VERSION_2 --remote-debugging-port 9392 --listen 127.0.0.1
+    expect {
+        timeout { puts "tealdbg debug timed out"; exit 1 }
+        -re {Debug error: Program version \([0-9]+\) is beyond the maximum supported protocol version \([0-9]+\)} { set FAILED 1; close }
+    }
+    if { $FAILED == 0 } {
+        puts "ERROR: the command should have failed"
+        exit 1
+    }
+    puts "The command failed as expected"
+
     exec rm $TEAL_PROG_FILE
 
 } EXCEPTION ] } {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Currently the TEAL debugger always compiles programs with the latest TEAL version. This means that programs using prior versions are unable to be properly debugged. This PR fixes this issue.

## Test Plan

I've added a regression test case to `tealdbgTest.exp` that uses a version lower than the maximum version the protocol supports.
