### PR TITLE
Fix node panicing during shutdown

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -410,6 +410,10 @@ func (node *AlgorandFullNode) Stop() {
 	defer func() {
 		node.mu.Unlock()
 		node.waitMonitoringRoutines()
+		// we want to shut down the compactCert last, since the oldKeyDeletionThread might depend on it when making the
+		// call to LatestSigsFromThisNode.
+		node.compactCert.Shutdown()
+		node.compactCert = nil
 	}()
 
 	node.net.ClearHandlers()
@@ -429,7 +433,6 @@ func (node *AlgorandFullNode) Stop() {
 	node.lowPriorityCryptoVerificationPool.Shutdown()
 	node.cryptoPool.Shutdown()
 	node.cancelCtx()
-	node.compactCert.Shutdown()
 	if node.indexer != nil {
 		node.indexer.Shutdown()
 	}


### PR DESCRIPTION
## Summary

During catchup testing, the following panic was captured:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xc55173]

goroutine 10141 [running]:
database/sql.(*DB).conn(0x0, 0x1b25020, 0xc000036080, 0xc000891401, 0x45f8cb, 0x1be912743e8, 0x757daf0)
	database/sql/sql.go:1134 +0x43
database/sql.(*DB).Conn(0x0, 0x1b25020, 0xc000036080, 0x3b9aca00, 0xc012f61d4757daf0, 0x149ffc08bc)
	database/sql/sql.go:1739 +0x84
github.com/algorand/go-algorand/util/db.(*Accessor).atomic(0xc00015e3d0, 0xc003fb00c0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	github.com/algorand/go-algorand/util/db/dbutil.go:269 +0x139
github.com/algorand/go-algorand/util/db.(*Accessor).Atomic(...)
	github.com/algorand/go-algorand/util/db/dbutil.go:207
github.com/algorand/go-algorand/compactcert.(*Worker).LatestSigsFromThisNode(0xc00015e3c0, 0xa65315, 0xa65315, 0x7ef92bb793be67de)
	github.com/algorand/go-algorand/compactcert/signer.go:161 +0x96
github.com/algorand/go-algorand/node.(*AlgorandFullNode).oldKeyDeletionThread(0xc00025d200)
	github.com/algorand/go-algorand/node/node.go:836 +0x340
created by github.com/algorand/go-algorand/node.(*AlgorandFullNode).startMonitoringRoutines
	github.com/algorand/go-algorand/node/node.go:387 +0xa9
```

Reviewing the codebase, it looks like the `oldKeyDeletionThread` was attempting to access the `compactcert` during the node's `Stop` timeframe. Moving the `compactcert` shutdown to be after the monitoring routines seems to have resolved the issue.

## Test Plan

Tested several times using the catchup testing script, and it seems to work correctly.