### PR TITLE
bugfix: ensure loading of a merkle trie deferred page during commit

### DIFF
--- a/crypto/merkletrie/cache.go
+++ b/crypto/merkletrie/cache.go
@@ -109,10 +109,8 @@ func (mtc *merkleTrieCache) initialize(mt *Trie, committer Committer, memoryConf
 	mtc.targetPageFillFactor = memoryConfig.PageFillFactor
 	mtc.maxChildrenPagesThreshold = memoryConfig.MaxChildrenPagesThreshold
 	if mt.nextNodeID != storedNodeIdentifierBase {
-		// if the next node is going to be the first node on this page, we don't
-		// need to reload that page ( since it doesn't exist! ). However, if the next node
-		// would reside on a page that already have few entries in it, make sure to mark it
-		// for late loading.
+		// If the next node would reside on a page that already has a few entries in it, make sure to mark it for late loading.
+		// Otherwise, the next node is going to be the first node on this page, we don't need to reload that page ( since it doesn't exist! ).
 		if (int64(mtc.mt.nextNodeID) % mtc.nodesPerPage) > 0 {
 			mtc.deferedPageLoad = uint64(mtc.mt.nextNodeID) / uint64(mtc.nodesPerPage)
 		}

--- a/crypto/merkletrie/cache.go
+++ b/crypto/merkletrie/cache.go
@@ -262,7 +262,7 @@ func (mtc *merkleTrieCache) loadPage(page uint64) (err error) {
 	}
 
 	// if we've just loaded a deferred page, no need to reload it during the commit.
-	if mtc.deferedPageLoad != page {
+	if mtc.deferedPageLoad == page {
 		mtc.deferedPageLoad = storedNodeIdentifierNull
 	}
 	return

--- a/crypto/merkletrie/cache.go
+++ b/crypto/merkletrie/cache.go
@@ -116,7 +116,6 @@ func (mtc *merkleTrieCache) initialize(mt *Trie, committer Committer, memoryConf
 		if (int64(mtc.mt.nextNodeID) % mtc.nodesPerPage) > 0 {
 			mtc.deferedPageLoad = uint64(mtc.mt.nextNodeID) / uint64(mtc.nodesPerPage)
 		}
-
 	}
 	mtc.modified = false
 	return

--- a/crypto/merkletrie/cache.go
+++ b/crypto/merkletrie/cache.go
@@ -109,10 +109,14 @@ func (mtc *merkleTrieCache) initialize(mt *Trie, committer Committer, memoryConf
 	mtc.targetPageFillFactor = memoryConfig.PageFillFactor
 	mtc.maxChildrenPagesThreshold = memoryConfig.MaxChildrenPagesThreshold
 	if mt.nextNodeID != storedNodeIdentifierBase {
-		// if the next node is going to be on a new page, no need to reload the last page.
-		if (int64(mtc.mt.nextNodeID) / mtc.nodesPerPage) == (int64(mtc.mt.nextNodeID-1) / mtc.nodesPerPage) {
+		// if the next node is going to be the first node on this page, we don't
+		// need to reload that page ( since it doesn't exist! ). However, if the next node
+		// would reside on a page that already have few entries in it, make sure to mark it
+		// for late loading.
+		if (int64(mtc.mt.nextNodeID) % mtc.nodesPerPage) > 0 {
 			mtc.deferedPageLoad = uint64(mtc.mt.nextNodeID) / uint64(mtc.nodesPerPage)
 		}
+
 	}
 	mtc.modified = false
 	return

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -1341,7 +1341,7 @@ func makeMerkleCommitter(tx *sql.Tx, staging bool) (mc *merkleCommitter, err err
 	return mc, nil
 }
 
-// StorePage stores a single page in an in-memory persistence.
+// StorePage is the merkletrie.Committer interface implementation, stores a single page in a sqllite database table.
 func (mc *merkleCommitter) StorePage(page uint64, content []byte) error {
 	if len(content) == 0 {
 		_, err := mc.deleteStmt.Exec(page)
@@ -1351,7 +1351,7 @@ func (mc *merkleCommitter) StorePage(page uint64, content []byte) error {
 	return err
 }
 
-// LoadPage load a single page from an in-memory persistence.
+// LoadPage is the merkletrie.Committer interface implementation, load a single page from a sqllite database table.
 func (mc *merkleCommitter) LoadPage(page uint64) (content []byte, err error) {
 	err = mc.selectStmt.QueryRow(page).Scan(&content)
 	if err == sql.ErrNoRows {


### PR DESCRIPTION
## Summary

When using the MerkleTrie, the trie avoid making loads from disk for pages that aren't needed. In particular, it won't load the latest page ( known as the deferred page ) until it needs to commit it.

The implementation had a bug in the `loadPage` method, where it would reset the loading page flag incorrectly.

## Test Plan

1. Unit test added.
2. Tested against mainnet and testnet.