### PR TITLE
Fix requestNonce alignment on arm32

### DIFF
--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -143,6 +143,9 @@ type wsPeer struct {
 	// peer, or zero if no message is being written.
 	intermittentOutgoingMessageEnqueueTime int64
 
+	// Nonce used to uniquely identify requests
+	requestNonce uint64
+
 	wsPeerCore
 
 	// conn will be *websocket.Conn (except in testing)
@@ -190,9 +193,6 @@ type wsPeer struct {
 
 	// peer version ( this is one of the version supported by the current node and listed in SupportedProtocolVersions )
 	version string
-
-	// Nonce used to uniquely identify requests
-	requestNonce uint64
 
 	// responseChannels used by the client to wait on the response of the request
 	responseChannels map[uint64]chan *Response

--- a/network/wsPeer_test.go
+++ b/network/wsPeer_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/stretchr/testify/require"
 )
@@ -76,4 +77,13 @@ func TestDefaultMessageTagsLength(t *testing.T) {
 	for tag := range defaultSendMessageTags {
 		require.Equal(t, 2, len(tag))
 	}
+}
+
+// TestRequestNonceOffset ensures that the requestNonce is on a 64-bit
+// offset, which is needed so that we can use atomic on arm platform.
+func TestAtomicVariablesAligment(t *testing.T) {
+	p := wsPeer{}
+	require.True(t, (unsafe.Offsetof(p.requestNonce)%8) == 0)
+	require.True(t, (unsafe.Offsetof(p.lastPacketTime)%8) == 0)
+	require.True(t, (unsafe.Offsetof(p.intermittentOutgoingMessageEnqueueTime)%8) == 0)
 }

--- a/network/wsPeer_test.go
+++ b/network/wsPeer_test.go
@@ -79,8 +79,9 @@ func TestDefaultMessageTagsLength(t *testing.T) {
 	}
 }
 
-// TestRequestNonceOffset ensures that the requestNonce is on a 64-bit
-// offset, which is needed so that we can use atomic on arm platform.
+// TestAtomicVariablesAligment ensures that the 64-bit atomic variables
+// offsets are 64-bit aligned. This is required due to go atomic library
+// limitation.
 func TestAtomicVariablesAligment(t *testing.T) {
 	p := wsPeer{}
 	require.True(t, (unsafe.Offsetof(p.requestNonce)%8) == 0)


### PR DESCRIPTION
## Summary

On ARM32, all 64 bit atomic operations need to be using a 64-bit aligned address.
This PR moves the requestNonce to a 64 bit aligned address.


## Test Plan

Unit test added.
