### PR TITLE
make the msgp less verbosed on the success case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,18 @@ generate: deps
 msgp: $(patsubst %,%/msgp_gen.go,$(MSGP_GENERATE))
 
 %/msgp_gen.go: deps ALWAYS
-	$(GOPATH1)/bin/msgp -file ./$(@D) -o $@ -warnmask github.com/algorand/go-algorand
+		@set +e; \
+		printf "msgp: $(@D)..."; \
+		$(GOPATH1)/bin/msgp -file ./$(@D) -o $@ -warnmask github.com/algorand/go-algorand > ./$@.out 2>&1; \
+		if [ "$$?" != "0" ]; then \
+			printf "failed:\n$(GOPATH1)/bin/msgp -file ./$(@D) -o $@ -warnmask github.com/algorand/go-algorand\n"; \
+			cat ./$@.out; \
+			rm ./$@.out; \
+			exit 1; \
+		else \
+			echo " done."; \
+		fi; \
+		rm -f ./$@.out
 ALWAYS:
 
 # build our fork of libsodium, placing artifacts into crypto/lib/ and crypto/include/


### PR DESCRIPTION
## Summary

The message pack generator is very noisy. It tends to emit lot of messages that aren't being used.
This PR cache the output of the message pack so that it would only present these in case of an error.

## Test Plan

Tested on travis.