### PR TITLE
ensure the participation key database is being correctly closed after being installed.

### DIFF
--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -859,10 +859,11 @@ No --delete-input flag specified, exiting without installing key.`)
 		dataDir := ensureSingleDataDir()
 
 		client := ensureAlgodClient(dataDir)
-		_, _, err := client.InstallParticipationKeys(partKeyFile)
+		partKey, _, err := client.InstallParticipationKeys(partKeyFile)
 		if err != nil {
 			reportErrorf(errorRequestFail, err)
 		}
+		partKey.Close()
 		fmt.Println("Participation key installed successfully")
 	},
 }

--- a/libgoal/participation.go
+++ b/libgoal/participation.go
@@ -231,7 +231,6 @@ func (c *Client) InstallParticipationKeys(inputfile string) (part account.Partic
 	err = <-errCh
 	if err != nil {
 		newpartkey.Close()
-		newpartkey = account.Participation{}
 		return
 	}
 	os.Remove(inputfile)


### PR DESCRIPTION
## Summary

Ensure the participation key database is being correctly closed after being installed.

## Test Plan

Use existing testing for coverage.