### PR TITLE
Fine tune catchup peer selection logic

### DIFF
--- a/catchup/peerSelector.go
+++ b/catchup/peerSelector.go
@@ -141,8 +141,15 @@ func (hs *historicStats) computerPenalty() float64 {
 func (hs *historicStats) updateRequestPenalty(counter uint64) float64 {
 	newGap := counter - hs.counter
 	hs.counter = counter
+
+	if len(hs.requestGaps) == hs.windowSize {
+		hs.gapSum -= 1.0 / float64(hs.requestGaps[0])
+		hs.requestGaps = hs.requestGaps[1:]
+	}
+	
 	hs.requestGaps = append(hs.requestGaps, newGap)
 	hs.gapSum += 1.0 / float64(newGap)
+	
 	return hs.computerPenalty()
 }
 
@@ -187,11 +194,6 @@ func (hs *historicStats) push(value int, counter uint64, class peerClass) (avera
 	if len(hs.rankSamples) == hs.windowSize {
 		hs.rankSum -= uint64(hs.rankSamples[0])
 		hs.rankSamples = hs.rankSamples[1:]
-	}
-
-	if len(hs.requestGaps) == hs.windowSize {
-		hs.gapSum -= 1.0 / float64(hs.requestGaps[0])
-		hs.requestGaps = hs.requestGaps[1:]
 	}
 
 	initialRank := value

--- a/catchup/peerSelector.go
+++ b/catchup/peerSelector.go
@@ -18,7 +18,6 @@ package catchup
 
 import (
 	"errors"
-	"fmt"
 	"math"
 	"sort"
 	"time"
@@ -100,13 +99,11 @@ type peerPool struct {
 // client to provide feedback regarding the peer's performance, and to have the subsequent
 // query(s) take advantage of that intel.
 type peerSelector struct {
-	mu                 deadlock.Mutex
-	net                peersRetriever
-	peerClasses        []peerClass
-	pools              []peerPool
-	counter            uint64
-	lastSelected       network.Peer
-	resetAndRerankPeer network.Peer
+	mu          deadlock.Mutex
+	net         peersRetriever
+	peerClasses []peerClass
+	pools       []peerPool
+	counter     uint64
 }
 
 // historicStats stores the past windowSize ranks for the peer
@@ -134,57 +131,6 @@ func makeHistoricStatus(windowSize int) *historicStats {
 	return &hs
 }
 
-/*
-// Add a penalty to the ranking when the peer is repeatedly used.
-// This is a compunding penalty, to facilitate the rotation of peers.
-func computeRequestPenalty(peerCounter, totalCounter uint64) float64 {
-
-
-
-	/*
-	// add 1 mocrosecond to avoid infinity when divided by a very small duration
-	earlyUseFactor := float64(int64(1*time.Microsecond) + duration.Milliseconds())
-
-	// The window size dictates how long the compunding of the penalty can be
-
-	// When the window size is small, the penalty will eventually
-	// hit an upper bound which is not be effective. Hence, the
-	// increase should be steeper to force the selector to pick a
-	// different peer.
-	windowSizeFactor := 1 / math.Log(peerHistoryWindowSize)
-
-	// The sooner the next use of the peer, the smaller earlyUseFactor,
-	// and the bigger the penalty
-	//
-	// Let the maximum tolarlnce be 10 minutes 4
-	penalty := 1.0 / earlyUseFactor * windowSizeFactor
-	//	fmt.Printf("d = %d p = %f\n", duration, penalty)
-	return penalty
-}
-*/
-
-/*
-func (hs *historicStats) trim(rank int, counter uint64, class peerClass) int {
-	if len(hs.requestGaps) == 0 {
-		return rank
-	}
-	if (counter - hs.counter) > uint64(len(hs.requestGaps)) {
-		hs.penalty = 0
-		hs.requestGaps = hs.requestGaps[:0]
-		hs.counter = counter
-		return int((1.0 + hs.penalty) * (float64(hs.rankSum) / float64(len(hs.rankSamples))))
-	}
-	g := 0
-	for i := hs.counter; i < counter; i++ {
-		hs.penalty -= computeRequestPenalty(hs.requestGaps[g])
-		g++
-	}
-	hs.requestGaps = hs.requestGaps[g:]
-	hs.counter = counter
-	return int((1.0 + hs.penalty) * (float64(hs.rankSum) / float64(len(hs.rankSamples))))
-}
-*/
-
 func (hs *historicStats) computerPenalty() float64 {
 	return 1 + (math.Exp(hs.gapSum/10) / 1000)
 }
@@ -197,9 +143,12 @@ func (hs *historicStats) updateRequestPenalty(counter uint64) float64 {
 	return hs.computerPenalty()
 }
 
-func (hs *historicStats) resetRequestPenalty(steps int, initialRank int) int {
+func (hs *historicStats) resetRequestPenalty(steps int, initialRank int, class peerClass) int {
 	if len(hs.requestGaps) == 0 || len(hs.rankSamples) == 0 {
-		fmt.Println("_")
+		return initialRank
+	}
+	// resetRequestPenalty cannot move the peer to a better class
+	if upperBound(class) < initialRank {
 		return initialRank
 	}
 	if steps == 0 {
@@ -211,14 +160,14 @@ func (hs *historicStats) resetRequestPenalty(steps int, initialRank int) int {
 	hs.requestGaps = hs.requestGaps[1:]
 	hs.gapSum -= 1 / float64(removed)
 
-	fmt.Printf("resetPenalty steps: %d %d -> %d\n", steps, initialRank, int(hs.computerPenalty() * (float64(hs.rankSum) / float64(len(hs.rankSamples)))))
 	return int(hs.computerPenalty() * (float64(hs.rankSum) / float64(len(hs.rankSamples))))
 }
 
 // push pushes a new rank to the historicStats, and returns the new rank
 // based on the average of ranks in the windowSize window
-func (hs *historicStats) push(value int, counter uint64) (averagedRank int) {
+func (hs *historicStats) push(value int, counter uint64, class peerClass) (averagedRank int) {
 
+	// This is a moving window. Remore the least recent value once the window is full
 	if len(hs.rankSamples) == hs.windowSize {
 		hs.rankSum -= uint64(hs.rankSamples[0])
 		hs.rankSamples = hs.rankSamples[1:]
@@ -228,17 +177,35 @@ func (hs *historicStats) push(value int, counter uint64) (averagedRank int) {
 			hs.requestGaps = hs.requestGaps[1:]
 		}
 	}
+	dontBound := false
+	if value == peerRankDownloadFailed {
+		// Set the rank to 1 + the class upper bound, to evict
+		// the peer from the class if it is repeatedly
+		// failing. This is to make sure to switch to the next
+		// class when all peers in this class are failing.
+		value = upperBound(class) + 10
+		dontBound = true
+	}
+
 	hs.rankSamples = append(hs.rankSamples, value)
 	hs.rankSum += uint64(value)
 
-	//	sinceLastRequest := now.Sub(hs.lastRequest)
-	//	hs.lastRequest = now
-
+	// A penalty is added relative to how freequently the peer is used
 	penalty := hs.updateRequestPenalty(counter)
-	//	fmt.Println(penalty)
-
-	fmt.Printf("penalty: %f histo(%d): %f\n", penalty, len(hs.rankSamples), float64(hs.rankSum)/float64(len(hs.rankSamples)))
-	return int(penalty * (float64(hs.rankSum) / float64(len(hs.rankSamples))))
+	// The average performance of the peer
+	average := float64(hs.rankSum) / float64(len(hs.rankSamples))
+	// The rank based on the performance and the freequency
+	avgWithPenalty := int(penalty * average)
+	if dontBound {
+		if int(average) > upperBound(class) {
+			return peerRankDownloadFailed
+		}
+		return avgWithPenalty
+	}
+	// Keep the peer in the same class. The rank will be within bounds, but
+	// the penalty may push it over. Prevent it here.
+	bounded := boundRankByClass(avgWithPenalty, class)
+	return bounded
 }
 
 // makePeerSelector creates a peerSelector, given a peersRetriever and peerClass array.
@@ -257,15 +224,6 @@ func (ps *peerSelector) GetNextPeer() (peer network.Peer, err error) {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 	ps.refreshAvailablePeers()
-
-	for _, pool := range ps.pools {
-		fmt.Printf("rank: %d\n", pool.rank)
-		for _, p := range pool.peers {
-			fmt.Printf("%s ", peerAddress(p.peer))
-		}
-		fmt.Printf("\n\n")
-	}
-	fmt.Printf("-----------------------\n\n")
 	for _, pool := range ps.pools {
 		if len(pool.peers) > 0 {
 			// the previous call to refreshAvailablePeers ensure that this would always be the case;
@@ -274,13 +232,6 @@ func (ps *peerSelector) GetNextPeer() (peer network.Peer, err error) {
 			// pick one of the peers from this pool at random
 			peerIdx := crypto.RandUint64() % uint64(len(pool.peers))
 			peer = pool.peers[peerIdx].peer
-
-			if pool.peers[peerIdx].peer != ps.lastSelected {
-				ps.resetAndRerankPeer = ps.lastSelected
-				ps.lastSelected = pool.peers[peerIdx].peer
-			} else {
-				ps.resetAndRerankPeer = ""
-			}
 			return
 		}
 	}
@@ -301,16 +252,12 @@ func (ps *peerSelector) RankPeer(peer network.Peer, rank int) bool {
 	if poolIdx < 0 || peerIdx < 0 {
 		return false
 	}
-
 	sortNeeded := false
 
 	// we need to remove the peer from the pool so we can place it in a different location.
 	pool := ps.pools[poolIdx]
 	ps.counter++
-	xrank := rank
-	rank = pool.peers[peerIdx].history.push(rank, ps.counter)
-	rank = boundRankByClass(rank, pool.peers[peerIdx].class)
-	fmt.Printf("RankPeer %s %d -> %d\n", peerAddress(peer), xrank, rank)
+	rank = pool.peers[peerIdx].history.push(rank, ps.counter, pool.peers[peerIdx].class)
 	if pool.rank != rank {
 		class := pool.peers[peerIdx].class
 		peerHistory := pool.peers[peerIdx].history
@@ -325,21 +272,6 @@ func (ps *peerSelector) RankPeer(peer network.Peer, rank int) bool {
 		sortNeeded = ps.addToPool(peer, rank, class, peerHistory)
 	}
 
-	var trimmedUpdates []struct {
-		poolIdx int
-		peerIdx int
-		newRank int
-	}
-
-	for _, pool := range ps.pools {
-		fmt.Printf("rank: %d\n", pool.rank)
-		for _, p := range pool.peers {
-			fmt.Printf("%s ", peerAddress(p.peer))
-		}
-		fmt.Printf("\n\n")
-	}
-	fmt.Printf("-BBBBBBBBbb----------------------\n\n")
-
 	// Update the ranks of the peers by reducing the penalty for not beeing selected
 	for pl := len(ps.pools) - 1; pl >= 0; pl-- {
 		pool := ps.pools[pl]
@@ -348,7 +280,7 @@ func (ps *peerSelector) RankPeer(peer network.Peer, rank int) bool {
 			if pool.peers[pr].peer == peer {
 				continue
 			}
-			newRank := localPeer.history.resetRequestPenalty(1, pool.rank)
+			newRank := localPeer.history.resetRequestPenalty(1, pool.rank, pool.peers[pr].class)
 			if newRank != pool.rank {
 				upeer := pool.peers[pr].peer
 				class := pool.peers[pr].class
@@ -361,77 +293,12 @@ func (ps *peerSelector) RankPeer(peer network.Peer, rank int) bool {
 					ps.pools = append(ps.pools[:pl], ps.pools[pl+1:]...)
 				}
 				sortNeeded = ps.addToPool(upeer, newRank, class, peerHistory) || sortNeeded
-
-				/*
-					trimmedUpdates = append(trimmedUpdates, struct {
-						poolIdx int
-						peerIdx int
-						newRank int
-					}{pl, pr, newRank})*/
 			}
 		}
 	}
-	// Reposition the peers whose rank has changed
-	for t := len(trimmedUpdates) - 1; t >= 0; t-- {
-		fmt.Print(".")
-		tup := trimmedUpdates[t]
-		pool := ps.pools[tup.poolIdx]
-		peer := pool.peers[tup.peerIdx].peer
-		class := pool.peers[tup.peerIdx].class
-		peerHistory := pool.peers[tup.peerIdx].history
-		if len(pool.peers) > 1 {
-			pool.peers = append(pool.peers[:tup.peerIdx], pool.peers[tup.peerIdx+1:]...)
-			ps.pools[tup.poolIdx] = pool
-		} else {
-			// the last peer was removed from the pool; delete this pool.
-			ps.pools = append(ps.pools[:tup.poolIdx], ps.pools[tup.poolIdx+1:]...)
-		}
-		sortNeeded = sortNeeded || ps.addToPool(peer, tup.newRank, class, peerHistory)
-	}
-	fmt.Println(".")
-	/*
-		if ps.resetAndRerankPeer != "" {
-			poolIdx, peerIdx := ps.findPeer(ps.resetAndRerankPeer)
-			ps.resetAndRerankPeer = ""
-			if poolIdx < 0 || peerIdx < 0 {
-				return true
-			}
-
-			// we need to remove the peer from the pool so we can place it in a different location.
-			pool := ps.pools[poolIdx]
-			newRank := pool.peers[peerIdx].history.resetRequestPenalty(0)
-			if pool.rank != newRank {
-				class := pool.peers[peerIdx].class
-				peerHistory := pool.peers[peerIdx].history
-				if len(pool.peers) > 1 {
-					pool.peers = append(pool.peers[:peerIdx], pool.peers[peerIdx+1:]...)
-					ps.pools[poolIdx] = pool
-				} else {
-					// the last peer was removed from the pool; delete this pool.
-					ps.pools = append(ps.pools[:poolIdx], ps.pools[poolIdx+1:]...)
-				}
-
-				sortNeeded := ps.addToPool(peer, newRank, class, peerHistory)
-				if sortNeeded {
-					ps.sort()
-				}
-			}
-		}
-	*/
-
 	if sortNeeded {
 		ps.sort()
 	}
-
-	for _, pool := range ps.pools {
-		fmt.Printf("rank: %d\n", pool.rank)
-		for _, p := range pool.peers {
-			fmt.Printf("%s ", peerAddress(p.peer))
-		}
-		fmt.Printf("\n\n")
-	}
-	fmt.Printf("CCC-----------------------\n\n")
-
 	return true
 }
 
@@ -453,7 +320,6 @@ func (ps *peerSelector) PeerDownloadDurationToRank(peer network.Peer, blockDownl
 		return downloadDurationToRank(blockDownloadDuration, lowBlockDownloadThreshold, highBlockDownloadThreshold, peerRank2LowBlockTime, peerRank2HighBlockTime)
 	default: // i.e. peerRankInitialFourthPriority
 		return downloadDurationToRank(blockDownloadDuration, lowBlockDownloadThreshold, highBlockDownloadThreshold, peerRank3LowBlockTime, peerRank3HighBlockTime)
-
 	}
 }
 
@@ -496,44 +362,14 @@ func peerAddress(peer network.Peer) string {
 // corresponding initial rank, and deletes peers that have been dropped by the network package.
 func (ps *peerSelector) refreshAvailablePeers() {
 	existingPeers := make(map[string]network.Peer)
-	var trimmedUpdates []struct {
-		poolIdx int
-		peerIdx int
-		newRank int
-	}
 	for _, pool := range ps.pools {
 		for _, localPeer := range pool.peers {
 			if peerAddress := peerAddress(localPeer.peer); peerAddress != "" {
 				existingPeers[peerAddress] = localPeer.peer
-				/*				newRank := localPeer.history.trim(pool.rank, ps.counter, localPeer.class)
-								if newRank != pool.rank {
-									trimmedUpdates = append(trimmedUpdates, struct {
-										poolIdx int
-										peerIdx int
-										newRank int
-									}{pl, pr, newRank})
-								}*/
 			}
 		}
 	}
 	sortNeeded := false
-	for t := len(trimmedUpdates) - 1; t >= 0; t-- {
-		tup := trimmedUpdates[t]
-		// TODO refactor this
-		pool := ps.pools[tup.poolIdx]
-		peer := pool.peers[tup.peerIdx].peer
-		class := pool.peers[tup.peerIdx].class
-		peerHistory := pool.peers[tup.peerIdx].history
-		if len(pool.peers) > 1 {
-			pool.peers = append(pool.peers[:tup.peerIdx], pool.peers[tup.peerIdx+1:]...)
-			ps.pools[tup.poolIdx] = pool
-		} else {
-			// the last peer was removed from the pool; delete this pool.
-			ps.pools = append(ps.pools[:tup.poolIdx], ps.pools[tup.poolIdx+1:]...)
-		}
-		sortNeeded = ps.addToPool(peer, tup.newRank, class, peerHistory) || sortNeeded
-	}
-
 	for _, initClass := range ps.peerClasses {
 		peers := ps.net.GetPeers(initClass.peerClass)
 		for _, peer := range peers {
@@ -604,38 +440,38 @@ func downloadDurationToRank(downloadDuration, minDownloadDuration, maxDownloadDu
 	return
 }
 
-func boundRankByClass(rank int, class peerClass) int {
+func lowerBound(class peerClass) int {
 	switch class.initialRank {
 	case peerRankInitialFirstPriority:
-		if rank < peerRank0LowBlockTime {
-			return peerRank0LowBlockTime
-		}
-		if rank > peerRank0HighBlockTime {
-			return peerRank0HighBlockTime
-		}
+		return peerRank0LowBlockTime
 	case peerRankInitialSecondPriority:
-		if rank < peerRank1LowBlockTime {
-			return peerRank1LowBlockTime
-		}
-		if rank > peerRank1HighBlockTime {
-			return peerRank1HighBlockTime
-		}
-
+		return peerRank1LowBlockTime
 	case peerRankInitialThirdPriority:
-		if rank < peerRank2LowBlockTime {
-			return peerRank2LowBlockTime
-		}
-		if rank > peerRank2HighBlockTime {
-			return peerRank2HighBlockTime
-		}
-
+		return peerRank2LowBlockTime
 	default: // i.e. peerRankInitialFourthPriority
-		if rank < peerRank3LowBlockTime {
-			return peerRank3LowBlockTime
-		}
-		if rank > peerRank3HighBlockTime {
-			return peerRank3HighBlockTime
-		}
+		return peerRank3LowBlockTime
+	}
+}
+
+func upperBound(class peerClass) int {
+	switch class.initialRank {
+	case peerRankInitialFirstPriority:
+		return peerRank0HighBlockTime
+	case peerRankInitialSecondPriority:
+		return peerRank1HighBlockTime
+	case peerRankInitialThirdPriority:
+		return peerRank2HighBlockTime
+	default: // i.e. peerRankInitialFourthPriority
+		return peerRank3HighBlockTime
+	}
+}
+
+func boundRankByClass(rank int, class peerClass) int {
+	if rank < lowerBound(class) {
+		return lowerBound(class)
+	}
+	if rank > upperBound(class) {
+		return upperBound(class)
 	}
 	return rank
 }

--- a/catchup/peerSelector_test.go
+++ b/catchup/peerSelector_test.go
@@ -131,13 +131,15 @@ func TestPeerSelector(t *testing.T) {
 
 	// add another peer
 	peers = []network.Peer{&mockHTTPPeer{address: "54321"}, &mockHTTPPeer{address: "abcde"}}
-	require.True(t, peerSelector.RankPeer(peer, 5))
+	r1, r2 := peerSelector.RankPeer(peer, 5)
+	require.True(t, r1 != r2)
 
 	peer, err = peerSelector.GetNextPeer()
 	require.NoError(t, err)
 	require.Equal(t, "abcde", peerAddress(peer))
 
-	require.True(t, peerSelector.RankPeer(peer, 10))
+	r1, r2 = peerSelector.RankPeer(peer, 10)
+	require.True(t, r1 != r2)
 
 	peer, err = peerSelector.GetNextPeer()
 	require.NoError(t, err)
@@ -154,8 +156,10 @@ func TestPeerSelector(t *testing.T) {
 	require.Equal(t, errPeerSelectorNoPeerPoolsAvailable, err)
 	require.Nil(t, peer)
 
-	require.False(t, peerSelector.RankPeer(nil, 10))
-	require.False(t, peerSelector.RankPeer(&mockHTTPPeer{address: "abc123"}, 10))
+	r1, r2 = peerSelector.RankPeer(nil, 10)
+	require.False(t, r1 != r2 )
+	r2, r2 = peerSelector.RankPeer(&mockHTTPPeer{address: "abc123"}, 10)
+	require.False(t, r1 != r2)
 
 	return
 }

--- a/catchup/peerSelector_test.go
+++ b/catchup/peerSelector_test.go
@@ -261,7 +261,7 @@ func TestHistoricData(t *testing.T) {
 		randVal := float64(crypto.RandUint64()%uint64(100)) / 100
 		randVal = randVal + 1
 		if randVal < 1.98 {
-			var duration time.Duration			
+			var duration time.Duration
 			switch peer.(*mockHTTPPeer).address {
 			case "a1":
 				duration = time.Duration(1500 * float64(time.Millisecond) * randVal)
@@ -349,19 +349,80 @@ func TestPeersDownloadFailed(t *testing.T) {
 	require.GreaterOrEqual(t, counters[3], 20)
 	require.GreaterOrEqual(t, counters[4], 20)
 
-	b1orb2 := peerAddress(peerSelector.pools[0].peers[0].peer) == "b1" || 	peerAddress(peerSelector.pools[0].peers[0].peer) == "b2"	
+	b1orb2 := peerAddress(peerSelector.pools[0].peers[0].peer) == "b1" || peerAddress(peerSelector.pools[0].peers[0].peer) == "b2"
 	require.True(t, b1orb2)
 	if len(peerSelector.pools) == 2 {
-		b1orb2 := peerAddress(peerSelector.pools[0].peers[1].peer) == "b1" || 	peerAddress(peerSelector.pools[0].peers[1].peer) == "b2"	
+		b1orb2 := peerAddress(peerSelector.pools[0].peers[1].peer) == "b1" || peerAddress(peerSelector.pools[0].peers[1].peer) == "b2"
 		require.True(t, b1orb2)
 		require.Equal(t, peerSelector.pools[1].rank, 900)
 		require.Equal(t, len(peerSelector.pools[1].peers), 3)
 	} else {
-		b1orb2 := peerAddress(peerSelector.pools[1].peers[0].peer) == "b1" || 	peerAddress(peerSelector.pools[1].peers[0].peer) == "b2"	
+		b1orb2 := peerAddress(peerSelector.pools[1].peers[0].peer) == "b1" || peerAddress(peerSelector.pools[1].peers[0].peer) == "b2"
 		require.True(t, b1orb2)
 		require.Equal(t, peerSelector.pools[2].rank, 900)
 		require.Equal(t, len(peerSelector.pools[2].peers), 3)
 	}
 
+}
 
+// TestPenalty tests that the penalty is calculated correctly and one peer
+// is not dominating all the selection.
+func TestPenalty(t *testing.T) {
+
+	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}, &mockHTTPPeer{address: "a3"}}
+	peers2 := []network.Peer{&mockHTTPPeer{address: "b1"}, &mockHTTPPeer{address: "b2"}}
+
+	peerSelector := makePeerSelector(
+		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
+			for _, opt := range options {
+				if opt == network.PeersPhonebookArchivers {
+					peers = append(peers, peers1...)
+				} else {
+					peers = append(peers, peers2...)
+				}
+			}
+			return
+		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
+			{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays}},
+	)
+
+	var counters [5]int
+	for i := 0; i < 1000; i++ {
+		peer, getPeerErr := peerSelector.GetNextPeer()
+		switch peer.(*mockHTTPPeer).address {
+		case "a1":
+			counters[0]++
+		case "a2":
+			counters[1]++
+		case "a3":
+			counters[2]++
+		case "b1":
+			counters[3]++
+		case "b2":
+			counters[4]++
+		}
+
+		require.NoError(t, getPeerErr)
+		var duration time.Duration
+		switch peer.(*mockHTTPPeer).address {
+		case "a1":
+			duration = time.Duration(1500 * float64(time.Millisecond))
+		case "a2":
+			duration = time.Duration(500 * float64(time.Millisecond))
+		case "a3":
+			duration = time.Duration(100 * float64(time.Millisecond))
+		}
+		peerRank := peerSelector.PeerDownloadDurationToRank(peer, duration)
+		peerSelector.RankPeer(peer, peerRank)
+	}
+
+	fmt.Printf("a1: %d\n", counters[0])
+	fmt.Printf("a2: %d\n", counters[1])
+	fmt.Printf("a3: %d\n", counters[2])
+	fmt.Printf("b1: %d\n", counters[3])
+	fmt.Printf("b2: %d\n", counters[4])
+	require.GreaterOrEqual(t, counters[1], 50)
+	require.GreaterOrEqual(t, counters[2], 2*counters[1])
+	require.Equal(t, counters[3], 0)
+	require.Equal(t, counters[4], 0)
 }

--- a/catchup/peerSelector_test.go
+++ b/catchup/peerSelector_test.go
@@ -264,7 +264,7 @@ func TestHistoricData(t *testing.T) {
 		randVal := float64(crypto.RandUint64() % uint64(100))/100
 		//		randVal = 1
 		randVal = randVal + 1
-		if randVal > 1.8 {
+		if randVal > 1.98 {
 			duration = time.Duration(4*time.Second)
 
 

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -197,7 +197,7 @@ func (s *Service) fetchAndWrite(r basics.Round, prevFetchCompleteChan chan bool,
 		block, cert, blockDownloadDuration, err := s.innerFetch(r, peer)
 
 		if err != nil {
-			s.log.Infof("fetchAndWrite(%v): Could not fetch: %v (attempt %d)", r, err, i)
+			s.log.Debugf("fetchAndWrite(%v): Could not fetch: %v (attempt %d)", r, err, i)
 			peerSelector.RankPeer(peer, peerRankDownloadFailed)
 			// we've just failed to retrieve a block; wait until the previous block is fetched before trying again
 			// to avoid the usecase where the first block doesn't exists and we're making many requests down the chain
@@ -257,7 +257,7 @@ func (s *Service) fetchAndWrite(r basics.Round, prevFetchCompleteChan chan bool,
 
 		peerRank := peerSelector.PeerDownloadDurationToRank(peer, blockDownloadDuration)
 		r1, r2 := peerSelector.RankPeer(peer, peerRank)
-		s.log.Infof("fetchAndWrite(%d): ranked peer with %d from %d to %d", r, peerRank, r1, r2)
+		s.log.Debugf("fetchAndWrite(%d): ranked peer with %d from %d to %d", r, peerRank, r1, r2)
 
 		// Write to ledger, noting that ledger writes must be in order
 		select {

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -197,8 +197,11 @@ func (s *Service) fetchAndWrite(r basics.Round, prevFetchCompleteChan chan bool,
 		block, cert, blockDownloadDuration, err := s.innerFetch(r, peer)
 
 		if err != nil {
-			s.log.Debugf("fetchAndWrite(%v): Could not fetch: %v (attempt %d)", r, err, i)
-			peerSelector.RankPeer(peer, peerRankDownloadFailed)
+			s.log.Infof("fetchAndWrite(%v): Could not fetch: %v (attempt %d)", r, err, i)
+			duration := time.Duration(s.cfg.CatchupHTTPBlockFetchTimeoutSec*2)*time.Second
+			peerRank := peerSelector.PeerDownloadDurationToRank(peer, duration)
+			peerSelector.RankPeer(peer, peerRank)
+			//			peerSelector.RankPeer(peer, peerRankDownloadFailed)
 			// we've just failed to retrieve a block; wait until the previous block is fetched before trying again
 			// to avoid the usecase where the first block doesn't exists and we're making many requests down the chain
 			// for no reason.

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -197,7 +197,7 @@ func (s *Service) fetchAndWrite(r basics.Round, prevFetchCompleteChan chan bool,
 		block, cert, blockDownloadDuration, err := s.innerFetch(r, peer)
 
 		if err != nil {
-			s.log.Debugf("fetchAndWrite(%v): Could not fetch: %v (attempt %d)", r, err, i)
+			s.log.Infof("fetchAndWrite(%v): Could not fetch: %v (attempt %d)", r, err, i)
 			peerSelector.RankPeer(peer, peerRankDownloadFailed)
 			// we've just failed to retrieve a block; wait until the previous block is fetched before trying again
 			// to avoid the usecase where the first block doesn't exists and we're making many requests down the chain
@@ -257,7 +257,7 @@ func (s *Service) fetchAndWrite(r basics.Round, prevFetchCompleteChan chan bool,
 
 		peerRank := peerSelector.PeerDownloadDurationToRank(peer, blockDownloadDuration)
 		r1, r2 := peerSelector.RankPeer(peer, peerRank)
-		s.log.Debugf("fetchAndWrite(%d): ranked peer with %d from %d to %d", r, peerRank, r1, r2)
+		s.log.Infof("fetchAndWrite(%d): ranked peer with %d from %d to %d", r, peerRank, r1, r2)
 
 		// Write to ledger, noting that ledger writes must be in order
 		select {

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -256,7 +256,8 @@ func (s *Service) fetchAndWrite(r basics.Round, prevFetchCompleteChan chan bool,
 		}
 
 		peerRank := peerSelector.PeerDownloadDurationToRank(peer, blockDownloadDuration)
-		peerSelector.RankPeer(peer, peerRank)
+		r1, r2 := peerSelector.RankPeer(peer, peerRank)
+		s.log.Debugf("fetchAndWrite(%d): ranked peer with %d from %d to %d", r, peerRank, r1, r2)
 
 		// Write to ledger, noting that ledger writes must be in order
 		select {

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -197,11 +197,8 @@ func (s *Service) fetchAndWrite(r basics.Round, prevFetchCompleteChan chan bool,
 		block, cert, blockDownloadDuration, err := s.innerFetch(r, peer)
 
 		if err != nil {
-			s.log.Infof("fetchAndWrite(%v): Could not fetch: %v (attempt %d)", r, err, i)
-			duration := time.Duration(s.cfg.CatchupHTTPBlockFetchTimeoutSec*2)*time.Second
-			peerRank := peerSelector.PeerDownloadDurationToRank(peer, duration)
-			peerSelector.RankPeer(peer, peerRank)
-			//			peerSelector.RankPeer(peer, peerRankDownloadFailed)
+			s.log.Debugf("fetchAndWrite(%v): Could not fetch: %v (attempt %d)", r, err, i)
+			peerSelector.RankPeer(peer, peerRankDownloadFailed)
 			// we've just failed to retrieve a block; wait until the previous block is fetched before trying again
 			// to avoid the usecase where the first block doesn't exists and we're making many requests down the chain
 			// for no reason.

--- a/catchup/universalFetcher.go
+++ b/catchup/universalFetcher.go
@@ -86,7 +86,7 @@ func (uf *universalBlockFetcher) fetchBlock(ctx context.Context, round basics.Ro
 	if err != nil {
 		return nil, nil, time.Duration(0), err
 	}
-	uf.log.Debugf("fetchBlock: downloaded block %d from %s", uint64(round), address)
+	uf.log.Infof("fetchBlock: downloaded block %d in %d from %s", uint64(round), downloadDuration, address)
 	return block, cert, downloadDuration, err
 }
 

--- a/catchup/universalFetcher.go
+++ b/catchup/universalFetcher.go
@@ -86,7 +86,7 @@ func (uf *universalBlockFetcher) fetchBlock(ctx context.Context, round basics.Ro
 	if err != nil {
 		return nil, nil, time.Duration(0), err
 	}
-	uf.log.Infof("fetchBlock: downloaded block %d in %d from %s", uint64(round), downloadDuration, address)
+	uf.log.Debugf("fetchBlock: downloaded block %d in %d from %s", uint64(round), downloadDuration, address)
 	return block, cert, downloadDuration, err
 }
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -576,7 +576,7 @@ func (l *Ledger) AddValidatedBlock(vb ValidatedBlock, cert agreement.Certificate
 	}
 	l.headerCache.Put(vb.blk.Round(), vb.blk.BlockHeader)
 	l.trackers.newBlock(vb.blk, vb.delta)
-	l.log.Infof("added blk %d", vb.blk.Round())
+	l.log.Debugf("added blk %d", vb.blk.Round())
 	return nil
 }
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -576,6 +576,7 @@ func (l *Ledger) AddValidatedBlock(vb ValidatedBlock, cert agreement.Certificate
 	}
 	l.headerCache.Put(vb.blk.Round(), vb.blk.BlockHeader)
 	l.trackers.newBlock(vb.blk, vb.delta)
+	l.log.Infof("added blk %d", vb.blk.Round())
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

The peer selector has the following goals:
1. Block malicious hosts that return invalid blocks
2. Pick hosts that perform better than others
3. Adapt to changes to the performance of hosts
4. Avoid hosts that download fails

The current implementation of the peer selector meets all these goals, but it is not flexible to random failures.
- It will rank the peers by the first download time. When a good performing peer returns a bad value in the first download, it will have a low rank and may never be selected. 
- When the download fails from a good performing peer, that peer may never be considered again (until it runs out of all other peers)
- The top performing peer is selected all the time, until it's performance degrades. It will never consider other peers as long as the top peer's rank is better than others obtained in the beginning.

These situations make a big difference when using archival buckets. When switching from a peer in the same region to a peer in a different region, the performance difference is huge. If a local peer fails occasionally, the peer selector needs to be smart enough to evaluate it based on it's overall performance, and not just the most recent performance. 

This change enhances the peer selector so that it implements the above 4 points, and is resilient to occasional performance changes:
- It established the initial ranks with multiple download value points
- It penalizes a peer for frequently being selected, to also consider other peers
- A single download failure will be forgiven if the peer is otherwise performing well

These flexibility is implemented with:
- Historical ranks. A moving window of the last 100 ranks is stored, and the new ranks is calculates by taking the average of these values.
- Frequency penalty. When a peer is frequently selected, it will be penalized for that. When a peer is not selected, then the penalty will be reduced. This is done by storing a window of its selection frequency, and the penalty is higher (exponential) if the peer is continuously selected. The penalty will quickly get high enough to favor the next best ranking peer. This way, the selection will be diversified.  



<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan
Tests added to confirm the new features are properly implemented. 
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
