### PR TITLE
txnsync: Avoid regenerating bloom filters when not needed

### DIFF
--- a/txnsync/mainloop.go
+++ b/txnsync/mainloop.go
@@ -49,6 +49,11 @@ type syncState struct {
 	outgoingMessagesCallbackCh chan *messageSentCallback
 	nextOffsetRollingCh        <-chan time.Time
 	requestsOffset             uint64
+
+	// The lastBloomFilter allows us to share the same bloom filter across multiples messages,
+	// and compute it only once. Since this bloom filter could contain many hashes ( especially on relays )
+	// it's important to avoid recomputing it needlessly.
+	lastBloomFilter bloomFilter
 }
 
 func (s *syncState) mainloop(serviceCtx context.Context, wg *sync.WaitGroup) {


### PR DESCRIPTION
## Summary

This PR improves the generation of bloom filters :
- on relays, it ensures that we reuse the same bloom filter ( when applicable ) for multiple peers.
- on non-relays, it attempts to reuse the previous bloom filter *before* building the new one.

Separately, it optimizes the case of a non-relay connected to a single relay, where it would send the bloom filter
only once rather than with every 2*beta messages.

Last, it corrects a miscalculation in the `getNextScheduleOffset` method, causing us to send more data than the available bandwidth allows.

## Test Plan

Tested using the emulator and performance validated by algonet network.
