### PR TITLE
netgoal: fixup small amounts of float64 roundoff

### DIFF
--- a/cmd/genesis/newgenesis.go
+++ b/cmd/genesis/newgenesis.go
@@ -19,7 +19,9 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log"
+	"os"
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/gen"
@@ -54,7 +56,11 @@ func main() {
 		genesisData.NetworkName = *netName
 	}
 
-	err = gen.GenerateGenesisFiles(genesisData, config.Consensus, *outDir, !*quiet)
+	var verboseOut io.Writer = nil
+	if !*quiet {
+		verboseOut = os.Stdout
+	}
+	err = gen.GenerateGenesisFiles(genesisData, config.Consensus, *outDir, verboseOut)
 	if err != nil {
 		reportErrorf("Cannot write genesis files: %s", err)
 	}

--- a/gen/generate.go
+++ b/gen/generate.go
@@ -68,7 +68,7 @@ func u64absDiff(a, b uint64) uint64 {
 }
 
 // testable inner function that doesn't touch filesystem
-func setupGenerateGenesisFiles(genesisData GenesisData, consensus config.ConsensusProtocols, verboseOut io.Writer) (proto protocol.ConsensusVersion, consensusParams config.ConsensusParams, allocation []genesisAllocation, err error) {
+func setupGenerateGenesisFiles(genesisData *GenesisData, consensus config.ConsensusProtocols, verboseOut io.Writer) (proto protocol.ConsensusVersion, consensusParams config.ConsensusParams, allocation []genesisAllocation, err error) {
 	err = nil
 	// Backwards compatibility with older genesis files: if the consensus
 	// protocol version is not specified, default to V0.
@@ -139,7 +139,7 @@ func setupGenerateGenesisFiles(genesisData GenesisData, consensus config.Consens
 
 // GenerateGenesisFiles generates the genesis.json file and wallet files for a give genesis configuration.
 func GenerateGenesisFiles(genesisData GenesisData, consensus config.ConsensusProtocols, outDir string, verboseOut io.Writer) error {
-	proto, consensusParams, allocation, err := setupGenerateGenesisFiles(genesisData, consensus, verboseOut)
+	proto, consensusParams, allocation, err := setupGenerateGenesisFiles(&genesisData, consensus, verboseOut)
 	if err != nil {
 		return err
 	}

--- a/gen/generate_test.go
+++ b/gen/generate_test.go
@@ -105,11 +105,7 @@ func TestLoadSingleRootKeyConcurrent(t *testing.T) {
 }
 
 func TestGenesisRoundoff(t *testing.T) {
-	defer func() {
-		verboseOutWriter = os.Stdout
-	}()
-	fakeStdout := strings.Builder{}
-	verboseOutWriter = &fakeStdout
+	verbosity := strings.Builder{}
 	genesisData := DefaultGenesis
 	genesisData.NetworkName = "wat"
 	genesisData.ConsensusProtocol = protocol.ConsensusCurrentVersion // TODO: also check ConsensusFuture ?
@@ -118,7 +114,7 @@ func TestGenesisRoundoff(t *testing.T) {
 		genesisData.Wallets[i].Name = fmt.Sprintf("w%d", i)
 		genesisData.Wallets[i].Stake = 100.0 / float64(len(genesisData.Wallets))
 	}
-	_, _, _, err := setupGenerateGenesisFiles(genesisData, config.Consensus, true)
+	_, _, _, err := setupGenerateGenesisFiles(genesisData, config.Consensus, &verbosity)
 	require.NoError(t, err)
-	require.True(t, strings.Contains(fakeStdout.String(), "roundoff"))
+	require.True(t, strings.Contains(verbosity.String(), "roundoff"))
 }

--- a/gen/generate_test.go
+++ b/gen/generate_test.go
@@ -114,7 +114,7 @@ func TestGenesisRoundoff(t *testing.T) {
 		genesisData.Wallets[i].Name = fmt.Sprintf("w%d", i)
 		genesisData.Wallets[i].Stake = 100.0 / float64(len(genesisData.Wallets))
 	}
-	_, _, _, err := setupGenerateGenesisFiles(genesisData, config.Consensus, &verbosity)
+	_, _, _, err := setupGenerateGenesisFiles(&genesisData, config.Consensus, &verbosity)
 	require.NoError(t, err)
 	require.True(t, strings.Contains(verbosity.String(), "roundoff"))
 }

--- a/netdeploy/networkTemplate.go
+++ b/netdeploy/networkTemplate.go
@@ -50,7 +50,7 @@ func (t NetworkTemplate) generateGenesisAndWallets(targetFolder, networkName, bi
 	genesisData := t.Genesis
 	genesisData.NetworkName = networkName
 	mergedConsensus := config.Consensus.Merge(t.Consensus)
-	return gen.GenerateGenesisFiles(genesisData, mergedConsensus, targetFolder, true)
+	return gen.GenerateGenesisFiles(genesisData, mergedConsensus, targetFolder, os.Stdout)
 }
 
 // Create data folders for all NodeConfigs, configuring relays appropriately and

--- a/netdeploy/remote/deployedNetwork.go
+++ b/netdeploy/remote/deployedNetwork.go
@@ -268,7 +268,7 @@ func (cfg DeployedNetwork) BuildNetworkFromTemplate(buildCfg BuildConfig, rootDi
 	if cfg.useExistingGenesis {
 		fmt.Println(" *** using existing genesis files ***")
 	} else {
-		if err = gen.GenerateGenesisFiles(cfg.GenesisData, config.Consensus, genesisFolder, true); err != nil {
+		if err = gen.GenerateGenesisFiles(cfg.GenesisData, config.Consensus, genesisFolder, os.Stdout); err != nil {
 			return
 		}
 	}


### PR DESCRIPTION
## Summary

Genesis blocks (now usually for test networks) initial stake must add up to exactly the total money, but the network description is in float64 and there can be small roundoff to fixup.

## Test Plan

Added unit test that has 5 out of 10,000,000,000,000,000 micro-Algos roundoff in naive wallet generation.