### PR TITLE
goal: improve waitForCommit logic

### DIFF
--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -810,7 +810,7 @@ func changeAccountOnlineStatus(acct string, part *algodAcct.Participation, goOnl
 		return nil
 	}
 
-	return waitForCommit(client, txid)
+	return waitForCommit(client, txid, lastTxRound)
 }
 
 var addParticipationKeyCmd = &cobra.Command{
@@ -1325,7 +1325,7 @@ var markNonparticipatingCmd = &cobra.Command{
 			return
 		}
 
-		err = waitForCommit(client, txid)
+		err = waitForCommit(client, txid, lastTxRound)
 		if err != nil {
 			reportErrorf("error waiting for transaction to be committed: %v", err)
 		}

--- a/cmd/goal/application.go
+++ b/cmd/goal/application.go
@@ -416,7 +416,7 @@ var createAppCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid)
+				err = waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
 				}
@@ -499,7 +499,7 @@ var updateAppCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid)
+				err = waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
 				}
@@ -577,7 +577,7 @@ var optInAppCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid)
+				err = waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
 				}
@@ -655,7 +655,7 @@ var closeOutAppCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid)
+				err = waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
 				}
@@ -733,7 +733,7 @@ var clearAppCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid)
+				err = waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
 				}
@@ -811,7 +811,7 @@ var callAppCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid)
+				err = waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
 				}
@@ -889,7 +889,7 @@ var deleteAppCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid)
+				err = waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
 				}

--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -231,7 +231,7 @@ var createAssetCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid)
+				err = waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
 				}
@@ -311,7 +311,7 @@ var destroyAssetCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid)
+				err = waitForCommit(client, txid, lastValid)
 				if err != nil {
 					reportErrorf(err.Error())
 				}
@@ -400,7 +400,7 @@ var configAssetCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid)
+				err = waitForCommit(client, txid, lastValid)
 				if err != nil {
 					reportErrorf(err.Error())
 				}
@@ -481,7 +481,7 @@ var sendAssetCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid)
+				err = waitForCommit(client, txid, lastValid)
 				if err != nil {
 					reportErrorf(err.Error())
 				}
@@ -546,7 +546,7 @@ var freezeAssetCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid)
+				err = waitForCommit(client, txid, lastValid)
 				if err != nil {
 					reportErrorf(err.Error())
 				}

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -158,13 +158,6 @@ func waitForCommit(client libgoal.Client, txid string, transactionLastValidRound
 		return fmt.Errorf(errorRequestFail, err)
 	}
 
-	// check if we've already committed to the block number equals to the transaction's last valid round.
-	// if this is the case, the transaction would not be included in the blockchain, and we can exit right
-	// here.
-	if stat.LastRound >= transactionLastValidRound {
-		return fmt.Errorf(errorTransactionExpired, txid)
-	}
-
 	for {
 		// Check if we know about the transaction yet
 		txn, err := client.PendingTransactionInformation(txid)

--- a/cmd/goal/interact.go
+++ b/cmd/goal/interact.go
@@ -622,7 +622,7 @@ var appExecuteCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid)
+				err = waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
 				}

--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -124,7 +124,7 @@ const (
 	rekeySenderTargetSameError = "The sender and the resulted multisig address are the same"
 	noOutputFileError          = "--msig-params must be specified with an output file name (-o)"
 	infoAutoFeeSet             = "Automatically set fee to %d MicroAlgos"
-	errorTransactionExpired    = "Transaction %s expired before it could included in a block"
+	errorTransactionExpired    = "Transaction %s expired before it could be included in a block"
 
 	loggingNotConfigured = "Remote logging is not currently configured and won't be enabled"
 	loggingNotEnabled    = "Remote logging is current disabled"

--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -124,6 +124,7 @@ const (
 	rekeySenderTargetSameError = "The sender and the resulted multisig address are the same"
 	noOutputFileError          = "--msig-params must be specified with an output file name (-o)"
 	infoAutoFeeSet             = "Automatically set fee to %d MicroAlgos"
+	errorTransactionExpired    = "Transaction %s expired before it could included in a block"
 
 	loggingNotConfigured = "Remote logging is not currently configured and won't be enabled"
 	loggingNotEnabled    = "Remote logging is current disabled"

--- a/test/e2e-go/cli/goal/expect/goalAccountTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalAccountTest.exp
@@ -50,6 +50,10 @@ if { [catch {
                 # this is a legit possible case, so just keep iterating if we hit this one.
                 close;
             }
+            -re {Couldn't broadcast tx with algod: HTTP 400 Bad Request: TransactionPool.Remember: txn dead: round ([0-9]+) outside of ([0-9]+)--([0-9]+)} {
+                # this is a legit possible case, so just keep iterating if we hit this one.
+                close;
+            }
             eof { ::AlgorandGoal::CheckEOF "Failed to send a dummy transaction" }
         }
         set TEST_TRANSACTION_EXPIRATION [expr {$TEST_TRANSACTION_EXPIRATION - 1}]

--- a/test/e2e-go/cli/goal/expect/goalAccountTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalAccountTest.exp
@@ -32,6 +32,29 @@ if { [catch {
     # Determine primary account
     set PRIMARY_ACCOUNT_ADDRESS [::AlgorandGoal::GetHighestFundedAccountForWallet $PRIMARY_WALLET_NAME  $TEST_PRIMARY_NODE_DIR]
 
+    # try to generate an expired transaction for 5 times before giving up.
+    set TEST_TRANSACTION_EXPIRATION 5
+    while {$TEST_TRANSACTION_EXPIRATION > 0} {
+        # Get the lastest block
+        set LAST_COMMITTED_BLOCK [::AlgorandGoal::GetNodeLastCommittedBlock $TEST_PRIMARY_NODE_DIR]
+
+        # test that sending a transaction where the last round is equal to the current round end up resulting in "Transaction %s expired before it could be included in a block" error.
+        spawn goal clerk send -a 10 --fee 1000 --firstvalid [expr {$LAST_COMMITTED_BLOCK + 1}] --lastvalid [expr {$LAST_COMMITTED_BLOCK + 1}] -f $PRIMARY_ACCOUNT_ADDRESS -t $PRIMARY_ACCOUNT_ADDRESS -d $TEST_PRIMARY_NODE_DIR
+        expect {
+            timeout { close; ::AlgorandGoal::Abort "goal clerk send timeout" }
+            -re {Transaction ([A-Z0-9]+) expired before it could be included in a block} {
+                break;
+                close;
+            }
+            -re {Transaction ([A-Z0-9]+) kicked out of local node pool} {
+                # this is a legit possible case, so just keep iterating if we hit this one.
+                close;
+            }
+            eof { ::AlgorandGoal::CheckEOF "Failed to send a dummy transaction" }
+        }
+        set TEST_TRANSACTION_EXPIRATION [expr {$TEST_TRANSACTION_EXPIRATION - 1}]
+    }
+
     set MN "advice pudding treat near rule blouse same whisper inner electric quit surface sunny dismiss leader blood seat clown cost exist hospital century reform able sponsor"
     spawn goal account import -m $MN --datadir $TEST_PRIMARY_NODE_DIR
     expect {

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -830,6 +830,28 @@ proc ::AlgorandGoal::GetNodeLastCatchpoint { NODE_DATA_DIR } {
     return $CATCHPOINT
 }
 
+
+# Get node's last reached round
+proc ::AlgorandGoal::GetNodeLastCommittedBlock { NODE_DATA_DIR } {
+    set COMMITTEDROUND ""
+    if { [catch {
+        # Check node status
+        puts "spawn node status"
+        spawn goal node status -d $NODE_DATA_DIR
+        expect {
+            timeout { ::AlgorandGoal::Abort "goal node status timed out" }
+            -re {Last committed block: ([0-9]+)} {regexp -- {[0-9]+} $expect_out(0,string) COMMITTEDROUND; exp_continue }
+            eof { catch wait result; if { [lindex $result 3] != 0 } { ::AlgorandGoal::Abort "failed to perform goal node status : error code [lindex $result 3]"} }
+        }
+        if { $COMMITTEDROUND == "" } {
+            ::AlgorandGoal::Abort "Last committed block entry was missing from goal node status"
+        }
+    } EXCEPTION ] } {
+       ::AlgorandGoal::Abort "ERROR in GetNodeLastCommittedBlock: $EXCEPTION"
+    }
+    return $COMMITTEDROUND
+}
+
 # Start catching up to a specific catchpoint
 proc ::AlgorandGoal::StartCatchup { NODE_DATA_DIR CATCHPOINT } {
     if { [catch {


### PR DESCRIPTION
## Summary

The existing implementation of `waitForCommit` had two deficiencies:
- It was waiting for two rounds at the time, instead of waiting for a single round before re-testing the pending transactions.
- It wasn't limiting it's execution time to the transaction's last valid ( on the client side ).
   - Note that there is a server side handling for that, which returns an error "kicked out of local node pool".
   - This would ensure we have a proper working client in case the server-side restarts.

## Test Plan

Existing unit tests provide good coverage. I've added an e2e test to verify the transaction timeout.
