### PR TITLE
Add support for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ the [official Go documentation website](https://golang.org/doc/).
 ### Linux / OSX ###
 
 We currently strive to support Debian based distributions with Ubuntu 18.04
-being our official release target. Our core engineering team uses Linux and OSX,
-so both environments are well supported for development.
+being our official release target.
+Building on Arch Linux works as well.
+Our core engineering team uses Linux and OSX, so both environments are well
+supported for development.
 
 OSX only: [Homebrew (brew)](https://brew.sh) must be installed before
 continuing. [Here](https://docs.brew.sh/Installation) are the installation

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -70,12 +70,10 @@ function install_windows_shellcheck() {
 
 if [ "${OS}" = "linux" ]; then
     if ! which sudo > /dev/null; then
-        apt-get update
-        apt-get -y install sudo
+        "$SCRIPTPATH/install_linux_deps.sh"
+    else
+        sudo "$SCRIPTPATH/install_linux_deps.sh"
     fi
-
-    sudo apt-get update
-    sudo apt-get install -y libboost-all-dev expect jq autoconf shellcheck sqlite3 python3-venv
 elif [ "${OS}" = "darwin" ]; then
     brew update
     brew tap homebrew/cask
@@ -103,4 +101,3 @@ if ${SKIP_GO_DEPS}; then
 fi
 
 "$SCRIPTPATH/configure_dev-deps.sh"
-

--- a/scripts/install_linux_deps.sh
+++ b/scripts/install_linux_deps.sh
@@ -11,5 +11,5 @@ if [ "${DISTRIB}" = "arch" ]; then
     pacman -S --refresh --needed --noconfirm $ARCH_DEPS
 else
     apt-get update
-    apt-get -y install sudo
+    apt-get -y install $UBUNTU_DEPS
 fi

--- a/scripts/install_linux_deps.sh
+++ b/scripts/install_linux_deps.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+. /etc/os-release
+DISTRIB=$ID
+
+ARCH_DEPS="boost boost-libs expect jq autoconf shellcheck sqlite python-virtualenv"
+UBUNTU_DEPS="libboost-all-dev expect jq autoconf shellcheck sqlite3 python3-venv"
+
+if [ "${DISTRIB}" = "arch" ]; then
+    pacman -S --refresh --needed --noconfirm $ARCH_DEPS
+else
+    apt-get update
+    apt-get -y install sudo
+fi


### PR DESCRIPTION
## Summary
`scripts/configure_dev.sh` can now install dependencies for Arch Linux. This PR builds on #1850.

## Test Plan
Tested on Arch Linux.
