### PR TITLE
goal node restart message when node already started

### DIFF
--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -58,6 +58,7 @@ const (
 	// Node
 	infoNodeStart                     = "Algorand node successfully started!"
 	infoNodeAlreadyStarted            = "Algorand node was already started!"
+	infoNodeDidNotRestart             = "Algorand node did not restart. The node is still running!"
 	infoTryingToStopNode              = "Trying to stop the node..."
 	infoNodeShuttingDown              = "Algorand node is shutting down..."
 	infoNodeSuccessfullyStopped       = "The node was successfully stopped."

--- a/cmd/goal/node.go
+++ b/cmd/goal/node.go
@@ -182,14 +182,14 @@ var startCmd = &cobra.Command{
 			}
 
 			algodAlreadyRunning, err := nc.StartAlgod(nodeArgs)
-			if algodAlreadyRunning {
-				reportInfoln(infoNodeAlreadyStarted)
-			}
-
 			if err != nil {
 				reportErrorf(errorNodeFailedToStart, err)
 			} else {
-				reportInfoln(infoNodeStart)
+				if algodAlreadyRunning {
+					reportInfoln(infoNodeAlreadyStarted)
+				} else {
+					reportInfoln(infoNodeStart)
+				}
 			}
 		})
 	},
@@ -308,7 +308,8 @@ var restartCmd = &cobra.Command{
 				reportErrorf(errorNodeFailedToStart, err)
 			} else {
 				if algodAlreadyRunning {
-					reportInfoln(infoNodeAlreadyStarted)
+					// This can never happen. In case it does, report about it.
+					reportInfoln(infoNodeDidNotRestart)
 				} else {
 					reportInfoln(infoNodeStart)
 				}

--- a/cmd/goal/node.go
+++ b/cmd/goal/node.go
@@ -304,14 +304,14 @@ var restartCmd = &cobra.Command{
 			}
 
 			algodAlreadyRunning, err := nc.StartAlgod(nodeArgs)
-			if algodAlreadyRunning {
-				reportInfoln(infoNodeAlreadyStarted)
-			}
-
 			if err != nil {
 				reportErrorf(errorNodeFailedToStart, err)
 			} else {
-				reportInfoln(infoNodeStart)
+				if algodAlreadyRunning {
+					reportInfoln(infoNodeAlreadyStarted)
+				} else {
+					reportInfoln(infoNodeStart)
+				}
 			}
 		})
 	},

--- a/test/e2e-go/cli/goal/expect/goalNodeTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalNodeTest.exp
@@ -30,6 +30,23 @@ if { [catch {
     # Start node
     ::AlgorandGoal::StartNode $TEST_PRIMARY_NODE_DIR
 
+    # Try starting the node again, should just report the node is already running
+    set ALREADY_STARTED_MESSAGE_RECEIVED 0
+    spawn goal node start -d $TEST_PRIMARY_NODE_DIR
+    expect {
+        timeout { close; ::AlgorandGoal::Abort "goal node start unexpectedly failed" }
+        "^Algorand node was already started!" {
+	    set ALREADY_STARTED_MESSAGE_RECEIVED 1
+	    exp_continue
+	}
+	-re "\\S+" { close; ::AlgorandGoal::Abort "Unexpected message for goal node start on a running node" }
+        eof {
+	    if {$ALREADY_STARTED_MESSAGE_RECEIVED == 0} {
+		{ close; ::AlgorandGoal::Abort "eof recieved before the expected message "}
+	    }
+	}
+    }
+
     # Restart node
     ::AlgorandGoal::RestartNode $TEST_PRIMARY_NODE_DIR
 


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
When starting a node which is already started, two messages are show: already started and successfully started:

$ goal node start
Algorand node was already started!
Algorand node successfully started!

Only the already started message should be shown.

Also, when node restart command is given, there is a check in the code if the node was already running. 
This check comes after the node was stopped, so should never return as the node is still running. But in case it does, a message is added to notify the user. 

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan
Added a test to make sure no other output is printed. 

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
