### PR TITLE
goal: refactor waitForCommit

### DIFF
--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -810,7 +810,8 @@ func changeAccountOnlineStatus(acct string, part *algodAcct.Participation, goOnl
 		return nil
 	}
 
-	return waitForCommit(client, txid, lastTxRound)
+	_, err = waitForCommit(client, txid, lastTxRound)
+	return err
 }
 
 var addParticipationKeyCmd = &cobra.Command{
@@ -1323,7 +1324,7 @@ var markNonparticipatingCmd = &cobra.Command{
 			return
 		}
 
-		err = waitForCommit(client, txid, lastTxRound)
+		_, err = waitForCommit(client, txid, lastTxRound)
 		if err != nil {
 			reportErrorf("error waiting for transaction to be committed: %v", err)
 		}

--- a/cmd/goal/application.go
+++ b/cmd/goal/application.go
@@ -416,14 +416,9 @@ var createAppCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid, lv)
+				txn, err := waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
-				}
-				// Check if we know about the transaction yet
-				txn, err := client.PendingTransactionInformation(txid)
-				if err != nil {
-					reportErrorf("%v", err)
 				}
 				if txn.TransactionResults != nil && txn.TransactionResults.CreatedAppIndex != 0 {
 					reportInfof("Created app with app index %d", txn.TransactionResults.CreatedAppIndex)
@@ -499,14 +494,9 @@ var updateAppCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid, lv)
+				_, err = waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
-				}
-				// Check if we know about the transaction yet
-				_, err := client.PendingTransactionInformation(txid)
-				if err != nil {
-					reportErrorf("%v", err)
 				}
 			}
 		} else {
@@ -577,14 +567,9 @@ var optInAppCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid, lv)
+				_, err = waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
-				}
-				// Check if we know about the transaction yet
-				_, err := client.PendingTransactionInformation(txid)
-				if err != nil {
-					reportErrorf("%v", err)
 				}
 			}
 		} else {
@@ -655,14 +640,9 @@ var closeOutAppCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid, lv)
+				_, err = waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
-				}
-				// Check if we know about the transaction yet
-				_, err := client.PendingTransactionInformation(txid)
-				if err != nil {
-					reportErrorf("%v", err)
 				}
 			}
 		} else {
@@ -733,14 +713,9 @@ var clearAppCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid, lv)
+				_, err = waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
-				}
-				// Check if we know about the transaction yet
-				_, err := client.PendingTransactionInformation(txid)
-				if err != nil {
-					reportErrorf("%v", err)
 				}
 			}
 		} else {
@@ -811,14 +786,9 @@ var callAppCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid, lv)
+				_, err = waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
-				}
-				// Check if we know about the transaction yet
-				_, err := client.PendingTransactionInformation(txid)
-				if err != nil {
-					reportErrorf("%v", err)
 				}
 			}
 		} else {
@@ -889,14 +859,9 @@ var deleteAppCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid, lv)
+				_, err = waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
-				}
-				// Check if we know about the transaction yet
-				_, err := client.PendingTransactionInformation(txid)
-				if err != nil {
-					reportErrorf("%v", err)
 				}
 			}
 		} else {

--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -231,12 +231,7 @@ var createAssetCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid, lv)
-				if err != nil {
-					reportErrorf(err.Error())
-				}
-				// Check if we know about the transaction yet
-				txn, err := client.PendingTransactionInformation(txid)
+				txn, err := waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
 				}
@@ -311,7 +306,7 @@ var destroyAssetCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid, lastValid)
+				_, err = waitForCommit(client, txid, lastValid)
 				if err != nil {
 					reportErrorf(err.Error())
 				}
@@ -400,7 +395,7 @@ var configAssetCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid, lastValid)
+				_, err = waitForCommit(client, txid, lastValid)
 				if err != nil {
 					reportErrorf(err.Error())
 				}
@@ -481,7 +476,7 @@ var sendAssetCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid, lastValid)
+				_, err = waitForCommit(client, txid, lastValid)
 				if err != nil {
 					reportErrorf(err.Error())
 				}
@@ -546,7 +541,7 @@ var freezeAssetCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid, lastValid)
+				_, err = waitForCommit(client, txid, lastValid)
 				if err != nil {
 					reportErrorf(err.Error())
 				}

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -163,7 +163,7 @@ func waitForCommit(client libgoal.Client, txid string, transactionLastValidRound
 		// Check if we know about the transaction yet
 		txn, err = client.PendingTransactionInformation(txid)
 		if err != nil {
-			return txn, fmt.Errorf(errorRequestFail, err)
+			return v1.Transaction{}, fmt.Errorf(errorRequestFail, err)
 		}
 
 		if txn.ConfirmedRound > 0 {

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -29,6 +29,7 @@ import (
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	generatedV2 "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
+	v1 "github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -151,18 +152,18 @@ var clerkCmd = &cobra.Command{
 	},
 }
 
-func waitForCommit(client libgoal.Client, txid string, transactionLastValidRound uint64) error {
+func waitForCommit(client libgoal.Client, txid string, transactionLastValidRound uint64) (txn v1.Transaction, err error) {
 	// Get current round information
 	stat, err := client.Status()
 	if err != nil {
-		return fmt.Errorf(errorRequestFail, err)
+		return v1.Transaction{}, fmt.Errorf(errorRequestFail, err)
 	}
 
 	for {
 		// Check if we know about the transaction yet
-		txn, err := client.PendingTransactionInformation(txid)
+		txn, err = client.PendingTransactionInformation(txid)
 		if err != nil {
-			return fmt.Errorf(errorRequestFail, err)
+			return txn, fmt.Errorf(errorRequestFail, err)
 		}
 
 		if txn.ConfirmedRound > 0 {
@@ -171,25 +172,25 @@ func waitForCommit(client libgoal.Client, txid string, transactionLastValidRound
 		}
 
 		if txn.PoolError != "" {
-			return fmt.Errorf(txPoolError, txid, txn.PoolError)
+			return v1.Transaction{}, fmt.Errorf(txPoolError, txid, txn.PoolError)
 		}
 
 		// check if we've already committed to the block number equals to the transaction's last valid round.
 		// if this is the case, the transaction would not be included in the blockchain, and we can exit right
 		// here.
-		if stat.LastRound >= transactionLastValidRound {
-			return fmt.Errorf(errorTransactionExpired, txid)
+		if transactionLastValidRound > 0 && stat.LastRound >= transactionLastValidRound {
+			return v1.Transaction{}, fmt.Errorf(errorTransactionExpired, txid)
 		}
 
 		reportInfof(infoTxPending, txid, stat.LastRound)
 		// WaitForRound waits until round "stat.LastRound+1" is committed
 		stat, err = client.WaitForRound(stat.LastRound)
 		if err != nil {
-			return fmt.Errorf(errorRequestFail, err)
+			return v1.Transaction{}, fmt.Errorf(errorRequestFail, err)
 		}
 	}
 
-	return nil
+	return
 }
 
 func createSignedTransaction(client libgoal.Client, signTx bool, dataDir string, walletName string, tx transactions.Transaction) (stxn transactions.SignedTxn, err error) {
@@ -468,7 +469,7 @@ var sendCmd = &cobra.Command{
 			reportInfof(infoTxIssued, amount, fromAddressResolved, toAddressResolved, txid, fee)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid, lastValid)
+				_, err = waitForCommit(client, txid, lastValid)
 				if err != nil {
 					reportErrorf(err.Error())
 				}

--- a/cmd/goal/interact.go
+++ b/cmd/goal/interact.go
@@ -622,14 +622,9 @@ var appExecuteCmd = &cobra.Command{
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
-				err = waitForCommit(client, txid, lv)
+				txn, err := waitForCommit(client, txid, lv)
 				if err != nil {
 					reportErrorf(err.Error())
-				}
-				// Check if we know about the transaction yet
-				txn, err := client.PendingTransactionInformation(txid)
-				if err != nil {
-					reportErrorf("%v", err)
 				}
 				if txn.TransactionResults != nil && txn.TransactionResults.CreatedAppIndex != 0 {
 					reportInfof("Created app with app index %d", txn.TransactionResults.CreatedAppIndex)


### PR DESCRIPTION
## Summary

refactor waitForCommit to return the output of PendingTransactionInformation. This PR should eliminate a redundant call to PendingTransactionInformation.

## Test Plan

Use existing unit tests and e2e tests.