### PR TITLE
reduce verbosity of logged messages

### DIFF
--- a/catchup/service.go
+++ b/catchup/service.go
@@ -183,7 +183,18 @@ func (s *Service) fetchAndWrite(r basics.Round, prevFetchCompleteChan chan bool,
 
 		// Stop retrying after a while.
 		if i > catchupRetryLimit {
-			s.log.Errorf("fetchAndWrite: block retrieval exceeded retry limit")
+			if _, initialSync := s.IsSynchronizing(); initialSync {
+				// on the initial sync, it's completly expected that we won't be able to get all the "next" blocks. therefore info should suffice.
+				s.log.Infof("fetchAndWrite(%d): block retrieval exceeded retry limit", r)
+			} else {
+				// on any subsequent sync, we migth be looking for multiple rounds into the future, so it's completly reasonable that we would fail retrieving the future
+				// block. Generate a warning here only if we're failing to retrieve X+1 or below. all other retrievals should not generate a warning.
+				if r > s.ledger.NextRound() {
+					s.log.Infof("fetchAndWrite(%d): block retrieval exceeded retry limit", r)
+				} else {
+					s.log.Warnf("fetchAndWrite(%d): block retrieval exceeded retry limit", r)
+				}
+			}
 			return false
 		}
 

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -183,16 +183,20 @@ func (s *Service) fetchAndWrite(r basics.Round, prevFetchCompleteChan chan bool,
 
 		// Stop retrying after a while.
 		if i > catchupRetryLimit {
+			loggedMessage := fmt.Sprintf("fetchAndWrite(%d): block retrieval exceeded retry limit", r)
 			if _, initialSync := s.IsSynchronizing(); initialSync {
-				// on the initial sync, it's completly expected that we won't be able to get all the "next" blocks. therefore info should suffice.
-				s.log.Infof("fetchAndWrite(%d): block retrieval exceeded retry limit", r)
+				// on the initial sync, it's completly expected that we won't be able to get all the "next" blocks.
+				// Therefore info should suffice.
+				s.log.Info(loggedMessage)
 			} else {
-				// on any subsequent sync, we migth be looking for multiple rounds into the future, so it's completly reasonable that we would fail retrieving the future
-				// block. Generate a warning here only if we're failing to retrieve X+1 or below. all other retrievals should not generate a warning.
+				// On any subsequent sync, we migth be looking for multiple rounds into the future, so it's completly
+				// reasonable that we would fail retrieving the future block.
+				// Generate a warning here only if we're failing to retrieve X+1 or below.
+				// All other block retrievals should not generate a warning.
 				if r > s.ledger.NextRound() {
-					s.log.Infof("fetchAndWrite(%d): block retrieval exceeded retry limit", r)
+					s.log.Info(loggedMessage)
 				} else {
-					s.log.Warnf("fetchAndWrite(%d): block retrieval exceeded retry limit", r)
+					s.log.Warn(loggedMessage)
 				}
 			}
 			return false

--- a/node/node.go
+++ b/node/node.go
@@ -734,6 +734,13 @@ func (node *AlgorandFullNode) loadParticipationKeys() error {
 		// Fetch a handle to this database
 		handle, err := node.getExistingPartHandle(filename)
 		if err != nil {
+			if err.Error() == "database is locked" {
+				// this is a special case:
+				// we might get "database is locked" when we attempt to access a database that is conurrently updates it's participation keys.
+				// that database is clearly already on the account manager, and doesn't need to be processed through this logic, and therefore
+				// we can safely ignore that fail case.
+				continue
+			}
 			return fmt.Errorf("AlgorandFullNode.loadParticipationKeys: cannot load db %v: %v", filename, err)
 		}
 

--- a/node/node.go
+++ b/node/node.go
@@ -734,7 +734,7 @@ func (node *AlgorandFullNode) loadParticipationKeys() error {
 		// Fetch a handle to this database
 		handle, err := node.getExistingPartHandle(filename)
 		if err != nil {
-			if err.Error() == "database is locked" {
+			if db.IsErrBusy(err) {
 				// this is a special case:
 				// we might get "database is locked" when we attempt to access a database that is conurrently updates it's participation keys.
 				// that database is clearly already on the account manager, and doesn't need to be processed through this logic, and therefore

--- a/util/db/dbutil.go
+++ b/util/db/dbutil.go
@@ -438,6 +438,12 @@ func dbretry(obj error) bool {
 	return ok && (err.Code == sqlite3.ErrLocked || err.Code == sqlite3.ErrBusy)
 }
 
+// IsErrBusy examine the input inerr varaible of type error and determine if it's a sqlite3 error for the ErrBusy error code.
+func IsErrBusy(inerr error) bool {
+	err, ok := inerr.(sqlite3.Error)
+	return ok && (err.Code == sqlite3.ErrBusy)
+}
+
 type idemFn func(ctx context.Context, tx *sql.Tx) error
 
 const infoTxRetries = 5


### PR DESCRIPTION
## Summary

This PR reduces the severity of two benign logged errors/warnings:
1. On the catchup service, the following warning was extremely common:
```
fetchAndWrite: block retrieval exceeded retry limit
```
This PR moves this to be a info messages rather than a warning message ( in most cases ), and extend it to include the round number.
2. On the AlgorandFullNode struct, we used to log a message like this:
```
AlgorandFullNode.loadParticipationKeys: cannot load db XXX.part: database is locked
```
This was caused by concurrent database access to the same part key database. This is a benign error : if we already updating the file, then we don't need to re-evaluate it's content.

## Test Plan

Logged level changes were tested manually.