### PR TITLE
Prevent storing empty accounts in DB after opting out from an app

### DIFF
--- a/ledger/appcow.go
+++ b/ledger/appcow.go
@@ -562,9 +562,12 @@ func applyStorageDelta(data basics.AccountData, aapp storagePtr, store *storageD
 	// duplicate code in branches is proven to be a bit faster than
 	// having basics.AppParams and basics.AppLocalState under a common interface with additional loops and type assertions
 	if aapp.global {
-		owned := make(map[basics.AppIndex]basics.AppParams, len(data.AppParams))
-		for k, v := range data.AppParams {
-			owned[k] = v
+		var owned map[basics.AppIndex]basics.AppParams
+		if len(data.AppParams) > 0 {
+			owned = make(map[basics.AppIndex]basics.AppParams, len(data.AppParams))
+			for k, v := range data.AppParams {
+				owned[k] = v
+			}
 		}
 
 		switch store.action {
@@ -600,9 +603,12 @@ func applyStorageDelta(data basics.AccountData, aapp storagePtr, store *storageD
 		data.AppParams = owned
 
 	} else {
-		owned := make(map[basics.AppIndex]basics.AppLocalState, len(data.AppLocalStates))
-		for k, v := range data.AppLocalStates {
-			owned[k] = v
+		var owned map[basics.AppIndex]basics.AppLocalState
+		if len(data.AppLocalStates) > 0 {
+			owned = make(map[basics.AppIndex]basics.AppLocalState, len(data.AppLocalStates))
+			for k, v := range data.AppLocalStates {
+				owned[k] = v
+			}
 		}
 
 		switch store.action {
@@ -610,7 +616,8 @@ func applyStorageDelta(data basics.AccountData, aapp storagePtr, store *storageD
 			delete(owned, aapp.aidx)
 		case allocAction, remainAllocAction:
 			// note: these should always exist because they were
-			// at least preceded by a call to Put?
+			// at least preceded by a call to Put (opting in),
+			// or the account has opted in before and local states are pre-allocated
 			states, ok := owned[aapp.aidx]
 			if !ok {
 				return basics.AccountData{}, fmt.Errorf("could not find existing states for %v", aapp.aidx)

--- a/ledger/appcow_test.go
+++ b/ledger/appcow_test.go
@@ -843,6 +843,18 @@ func TestApplyStorageDelta(t *testing.T) {
 	data = applyAll(kv, &sdd)
 	testDuplicateKeys(data.AppParams[1].GlobalState, data.AppParams[2].GlobalState)
 	testDuplicateKeys(data.AppLocalStates[1].KeyValue, data.AppLocalStates[2].KeyValue)
+
+	sd := storageDelta{action: deallocAction, kvCow: map[string]valueDelta{}}
+	data, err := applyStorageDelta(basics.AccountData{}, storagePtr{1, true}, &sd)
+	a.NoError(err)
+	a.Nil(data.AppParams)
+	a.Nil(data.AppLocalStates)
+	a.True(data.IsZero())
+	data, err = applyStorageDelta(basics.AccountData{}, storagePtr{1, false}, &sd)
+	a.NoError(err)
+	a.Nil(data.AppParams)
+	a.Nil(data.AppLocalStates)
+	a.True(data.IsZero())
 }
 
 func TestCowAllocated(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix for empty accounts stored in DB after app clear state or app removal

## Test Plan

New tests added

