### PR TITLE
ledger: compatibility mode for account index calculation in eval delta

### DIFF
--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -134,9 +134,9 @@ type LedgerForLogic interface {
 	CreatorAddress() basics.Address
 	OptedIn(addr basics.Address, appIdx basics.AppIndex) (bool, error)
 
-	GetLocal(addr basics.Address, appIdx basics.AppIndex, key string) (value basics.TealValue, exists bool, err error)
-	SetLocal(addr basics.Address, key string, value basics.TealValue) error
-	DelLocal(addr basics.Address, key string) error
+	GetLocal(addr basics.Address, appIdx basics.AppIndex, key string, accountIdx uint64) (value basics.TealValue, exists bool, err error)
+	SetLocal(addr basics.Address, key string, value basics.TealValue, accountIdx uint64) error
+	DelLocal(addr basics.Address, key string, accountIdx uint64) error
 
 	GetGlobal(appIdx basics.AppIndex, key string) (value basics.TealValue, exists bool, err error)
 	SetGlobal(key string, value basics.TealValue) error
@@ -2076,7 +2076,7 @@ func (cx *evalContext) appReadLocalKey(appIdx uint64, accountIdx uint64, key str
 	if err != nil {
 		return basics.TealValue{}, false, err
 	}
-	return cx.Ledger.GetLocal(addr, basics.AppIndex(appIdx), key)
+	return cx.Ledger.GetLocal(addr, basics.AppIndex(appIdx), key, accountIdx)
 }
 
 // appWriteLocalKey writes value to local key/value cow
@@ -2086,7 +2086,7 @@ func (cx *evalContext) appWriteLocalKey(accountIdx uint64, key string, tv basics
 	if err != nil {
 		return err
 	}
-	return cx.Ledger.SetLocal(addr, key, tv)
+	return cx.Ledger.SetLocal(addr, key, tv, accountIdx)
 }
 
 // appDeleteLocalKey deletes a value from the key/value cow
@@ -2096,7 +2096,7 @@ func (cx *evalContext) appDeleteLocalKey(accountIdx uint64, key string) error {
 	if err != nil {
 		return err
 	}
-	return cx.Ledger.DelLocal(addr, key)
+	return cx.Ledger.DelLocal(addr, key, accountIdx)
 }
 
 func (cx *evalContext) appReadGlobalKey(foreignAppsIndex uint64, key string) (basics.TealValue, bool, error) {

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -258,7 +258,7 @@ func (l *testLedger) DelGlobal(key string) error {
 	return nil
 }
 
-func (l *testLedger) GetLocal(addr basics.Address, appIdx basics.AppIndex, key string) (basics.TealValue, bool, error) {
+func (l *testLedger) GetLocal(addr basics.Address, appIdx basics.AppIndex, key string, accountIdx uint64) (basics.TealValue, bool, error) {
 	if appIdx == 0 {
 		appIdx = l.appID
 	}
@@ -285,7 +285,7 @@ func (l *testLedger) GetLocal(addr basics.Address, appIdx basics.AppIndex, key s
 	return val, ok, nil
 }
 
-func (l *testLedger) SetLocal(addr basics.Address, key string, value basics.TealValue) error {
+func (l *testLedger) SetLocal(addr basics.Address, key string, value basics.TealValue, accountIdx uint64) error {
 	appIdx := l.appID
 
 	br, ok := l.balances[addr]
@@ -313,7 +313,7 @@ func (l *testLedger) SetLocal(addr basics.Address, key string, value basics.Teal
 	return nil
 }
 
-func (l *testLedger) DelLocal(addr basics.Address, key string) error {
+func (l *testLedger) DelLocal(addr basics.Address, key string, accountIdx uint64) error {
 	appIdx := l.appID
 
 	br, ok := l.balances[addr]

--- a/ledger/appcow.go
+++ b/ledger/appcow.go
@@ -505,6 +505,8 @@ func (cb *roundCowState) BuildEvalDelta(aidx basics.AppIndex, txn *transactions.
 				}
 
 				d := sdelta.kvCow.serialize()
+				// noEmptyDeltas restricts prodicing empty local deltas in general
+				// but allows it for a period of time when a buggy version was live
 				noEmptyDeltas := cb.proto.NoEmptyLocalDeltas || (cb.mods.Hdr.CurrentProtocol == protocol.ConsensusV24) && (cb.mods.Hdr.NextProtocol != protocol.ConsensusV26)
 				if !noEmptyDeltas || len(d) != 0 {
 					evalDelta.LocalDeltas[addrOffset] = d

--- a/ledger/appcow.go
+++ b/ledger/appcow.go
@@ -92,10 +92,15 @@ type storageDelta struct {
 	kvCow  stateDelta
 
 	counts, maxCounts *basics.StateSchema
+
+	// account index for an address that was first referenced as in app_local_get/app_local_put/app_local_del
+	// this is for backward compatibility with original implementation of applications
+	// it is set only once on storageDelta creation and used only for local delta generation
+	accountIdx uint64
 }
 
 // ensureStorageDelta finds existing or allocate a new storageDelta for given {addr, aidx, global}
-func (cb *roundCowState) ensureStorageDelta(addr basics.Address, aidx basics.AppIndex, global bool, defaultAction storageAction) (*storageDelta, error) {
+func (cb *roundCowState) ensureStorageDelta(addr basics.Address, aidx basics.AppIndex, global bool, defaultAction storageAction, accountIdx uint64) (*storageDelta, error) {
 	// If we already have a storageDelta, return it
 	aapp := storagePtr{aidx, global}
 	lsd, ok := cb.sdeltas[addr][aapp]
@@ -120,6 +125,17 @@ func (cb *roundCowState) ensureStorageDelta(addr basics.Address, aidx basics.App
 		kvCow:     make(stateDelta),
 		counts:    &counts,
 		maxCounts: &maxCounts,
+	}
+
+	if cb.compatibilityMode && !global {
+		lsd.accountIdx = accountIdx
+
+		// if there was previous getKey call for this app and address, use that index instead
+		if s, ok := cb.compatibilityGetKeyCache[addr]; ok {
+			if idx, ok := s[aapp]; ok {
+				lsd.accountIdx = idx
+			}
+		}
 	}
 
 	_, ok = cb.sdeltas[addr]
@@ -217,7 +233,7 @@ func (cb *roundCowState) Allocate(addr basics.Address, aidx basics.AppIndex, glo
 		return err
 	}
 
-	lsd, err := cb.ensureStorageDelta(addr, aidx, global, allocAction)
+	lsd, err := cb.ensureStorageDelta(addr, aidx, global, allocAction, 0)
 	if err != nil {
 		return err
 	}
@@ -240,7 +256,7 @@ func (cb *roundCowState) Deallocate(addr basics.Address, aidx basics.AppIndex, g
 		return err
 	}
 
-	lsd, err := cb.ensureStorageDelta(addr, aidx, global, deallocAction)
+	lsd, err := cb.ensureStorageDelta(addr, aidx, global, deallocAction, 0)
 	if err != nil {
 		return err
 	}
@@ -253,13 +269,13 @@ func (cb *roundCowState) Deallocate(addr basics.Address, aidx basics.AppIndex, g
 }
 
 // GetKey looks for a key in {addr, aidx, global} storage
-func (cb *roundCowState) GetKey(addr basics.Address, aidx basics.AppIndex, global bool, key string) (basics.TealValue, bool, error) {
-	return cb.getKey(addr, aidx, global, key)
+func (cb *roundCowState) GetKey(addr basics.Address, aidx basics.AppIndex, global bool, key string, accountIdx uint64) (basics.TealValue, bool, error) {
+	return cb.getKey(addr, aidx, global, key, accountIdx)
 }
 
 // getKey looks for a key in {addr, aidx, global} storage
 // This is hierarchical lookup: if the key not in this cow cache, then request parent and all way down to ledger
-func (cb *roundCowState) getKey(addr basics.Address, aidx basics.AppIndex, global bool, key string) (basics.TealValue, bool, error) {
+func (cb *roundCowState) getKey(addr basics.Address, aidx basics.AppIndex, global bool, key string, accountIdx uint64) (basics.TealValue, bool, error) {
 	// Check that account has allocated storage
 	allocated, err := cb.allocated(addr, aidx, global)
 	if err != nil {
@@ -287,13 +303,28 @@ func (cb *roundCowState) getKey(addr basics.Address, aidx basics.AppIndex, globa
 		}
 	}
 
+	if cb.compatibilityMode && !global {
+		// if fetching a key first time for this app,
+		// cache account index, and use it later on lsd allocation
+		s, ok := cb.compatibilityGetKeyCache[addr]
+		if !ok {
+			s = map[storagePtr]uint64{{aidx, global}: accountIdx}
+			cb.compatibilityGetKeyCache[addr] = s
+		} else {
+			if _, ok := s[storagePtr{aidx, global}]; !ok {
+				s[storagePtr{aidx, global}] = accountIdx
+				cb.compatibilityGetKeyCache[addr] = s
+			}
+		}
+	}
+
 	// At this point, we know we're allocated, and we don't have a delta,
 	// so we should check our parent.
-	return cb.lookupParent.getKey(addr, aidx, global, key)
+	return cb.lookupParent.getKey(addr, aidx, global, key, accountIdx)
 }
 
 // SetKey creates a new key-value in {addr, aidx, global} storage
-func (cb *roundCowState) SetKey(addr basics.Address, aidx basics.AppIndex, global bool, key string, value basics.TealValue) error {
+func (cb *roundCowState) SetKey(addr basics.Address, aidx basics.AppIndex, global bool, key string, value basics.TealValue, accountIdx uint64) error {
 	// Enforce maximum key length
 	if len(key) > cb.proto.MaxAppKeyLen {
 		return fmt.Errorf("key too long: length was %d, maximum is %d", len(key), cb.proto.MaxAppKeyLen)
@@ -316,13 +347,13 @@ func (cb *roundCowState) SetKey(addr basics.Address, aidx basics.AppIndex, globa
 	}
 
 	// Fetch the old value + presence so we know how to update
-	oldValue, oldOk, err := cb.GetKey(addr, aidx, global, key)
+	oldValue, oldOk, err := cb.GetKey(addr, aidx, global, key, accountIdx)
 	if err != nil {
 		return err
 	}
 
 	// Write the value delta associated with this key/value
-	lsd, err := cb.ensureStorageDelta(addr, aidx, global, remainAllocAction)
+	lsd, err := cb.ensureStorageDelta(addr, aidx, global, remainAllocAction, accountIdx)
 	if err != nil {
 		return err
 	}
@@ -347,7 +378,7 @@ func (cb *roundCowState) SetKey(addr basics.Address, aidx basics.AppIndex, globa
 }
 
 // DelKey removes a key from {addr, aidx, global} storage
-func (cb *roundCowState) DelKey(addr basics.Address, aidx basics.AppIndex, global bool, key string) error {
+func (cb *roundCowState) DelKey(addr basics.Address, aidx basics.AppIndex, global bool, key string, accountIdx uint64) error {
 	// Check that account has allocated storage
 	allocated, err := cb.allocated(addr, aidx, global)
 	if err != nil {
@@ -359,13 +390,13 @@ func (cb *roundCowState) DelKey(addr basics.Address, aidx basics.AppIndex, globa
 	}
 
 	// Fetch the old value + presence so we know how to update counts
-	oldValue, oldOk, err := cb.GetKey(addr, aidx, global, key)
+	oldValue, oldOk, err := cb.GetKey(addr, aidx, global, key, accountIdx)
 	if err != nil {
 		return err
 	}
 
 	// Write the value delta associated with deleting this key
-	lsd, err := cb.ensureStorageDelta(addr, aidx, global, remainAllocAction)
+	lsd, err := cb.ensureStorageDelta(addr, aidx, global, remainAllocAction, accountIdx)
 	if err != nil {
 		return nil
 	}
@@ -457,19 +488,25 @@ func (cb *roundCowState) BuildEvalDelta(aidx basics.AppIndex, txn *transactions.
 				if evalDelta.LocalDeltas == nil {
 					evalDelta.LocalDeltas = make(map[uint64]basics.StateDelta)
 				}
+
 				// It is impossible for there to be more than one local delta for
 				// a particular (address, app ID) in sdeltas, because the appAddr
 				// type consists only of (address, appID, global=false). So if
 				// IndexByAddress is deterministic (and it is), there is no need
 				// to check for duplicates here.
 				var addrOffset uint64
-				addrOffset, err = txn.IndexByAddress(addr, txn.Sender)
-				if err != nil {
-					return basics.EvalDelta{}, err
+				if cb.compatibilityMode {
+					addrOffset = sdelta.accountIdx
+				} else {
+					addrOffset, err = txn.IndexByAddress(addr, txn.Sender)
+					if err != nil {
+						return basics.EvalDelta{}, err
+					}
 				}
 
 				d := sdelta.kvCow.serialize()
-				if !cb.proto.NoEmptyLocalDeltas || len(d) != 0 {
+				noEmptyDeltas := cb.proto.NoEmptyLocalDeltas || (cb.mods.Hdr.CurrentProtocol == protocol.ConsensusV24) && (cb.mods.Hdr.NextProtocol != protocol.ConsensusV26)
+				if !noEmptyDeltas || len(d) != 0 {
 					evalDelta.LocalDeltas[addrOffset] = d
 				}
 			}

--- a/ledger/applications.go
+++ b/ledger/applications.go
@@ -33,11 +33,11 @@ type logicLedger struct {
 type cowForLogicLedger interface {
 	Get(addr basics.Address, withPendingRewards bool) (basics.AccountData, error)
 	GetCreator(cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.Address, bool, error)
-	GetKey(addr basics.Address, aidx basics.AppIndex, global bool, key string) (basics.TealValue, bool, error)
+	GetKey(addr basics.Address, aidx basics.AppIndex, global bool, key string, accountIdx uint64) (basics.TealValue, bool, error)
 	BuildEvalDelta(aidx basics.AppIndex, txn *transactions.Transaction) (basics.EvalDelta, error)
 
-	SetKey(addr basics.Address, aidx basics.AppIndex, global bool, key string, value basics.TealValue) error
-	DelKey(addr basics.Address, aidx basics.AppIndex, global bool, key string) error
+	SetKey(addr basics.Address, aidx basics.AppIndex, global bool, key string, value basics.TealValue, accountIdx uint64) error
+	DelKey(addr basics.Address, aidx basics.AppIndex, global bool, key string, accountIdx uint64) error
 
 	round() basics.Round
 	prevTimestamp() int64
@@ -152,19 +152,19 @@ func (al *logicLedger) OptedIn(addr basics.Address, appIdx basics.AppIndex) (boo
 	return al.cow.allocated(addr, appIdx, false)
 }
 
-func (al *logicLedger) GetLocal(addr basics.Address, appIdx basics.AppIndex, key string) (basics.TealValue, bool, error) {
+func (al *logicLedger) GetLocal(addr basics.Address, appIdx basics.AppIndex, key string, accountIdx uint64) (basics.TealValue, bool, error) {
 	if appIdx == basics.AppIndex(0) {
 		appIdx = al.aidx
 	}
-	return al.cow.GetKey(addr, appIdx, false, key)
+	return al.cow.GetKey(addr, appIdx, false, key, accountIdx)
 }
 
-func (al *logicLedger) SetLocal(addr basics.Address, key string, value basics.TealValue) error {
-	return al.cow.SetKey(addr, al.aidx, false, key, value)
+func (al *logicLedger) SetLocal(addr basics.Address, key string, value basics.TealValue, accountIdx uint64) error {
+	return al.cow.SetKey(addr, al.aidx, false, key, value, accountIdx)
 }
 
-func (al *logicLedger) DelLocal(addr basics.Address, key string) error {
-	return al.cow.DelKey(addr, al.aidx, false, key)
+func (al *logicLedger) DelLocal(addr basics.Address, key string, accountIdx uint64) error {
+	return al.cow.DelKey(addr, al.aidx, false, key, accountIdx)
 }
 
 func (al *logicLedger) fetchAppCreator(appIdx basics.AppIndex) (basics.Address, error) {
@@ -188,15 +188,15 @@ func (al *logicLedger) GetGlobal(appIdx basics.AppIndex, key string) (basics.Tea
 	if err != nil {
 		return basics.TealValue{}, false, err
 	}
-	return al.cow.GetKey(addr, appIdx, true, key)
+	return al.cow.GetKey(addr, appIdx, true, key, 0)
 }
 
 func (al *logicLedger) SetGlobal(key string, value basics.TealValue) error {
-	return al.cow.SetKey(al.creator, al.aidx, true, key, value)
+	return al.cow.SetKey(al.creator, al.aidx, true, key, value, 0)
 }
 
 func (al *logicLedger) DelGlobal(key string) error {
-	return al.cow.DelKey(al.creator, al.aidx, true, key)
+	return al.cow.DelKey(al.creator, al.aidx, true, key, 0)
 }
 
 func (al *logicLedger) GetDelta(txn *transactions.Transaction) (evalDelta basics.EvalDelta, err error) {

--- a/ledger/cow.go
+++ b/ledger/cow.go
@@ -24,6 +24,7 @@ import (
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
+	"github.com/algorand/go-algorand/protocol"
 )
 
 //   ___________________
@@ -47,7 +48,7 @@ type roundCowParent interface {
 	// and is provided to optimize state schema lookups
 	getStorageLimits(addr basics.Address, aidx basics.AppIndex, global bool) (basics.StateSchema, error)
 	allocated(addr basics.Address, aidx basics.AppIndex, global bool) (bool, error)
-	getKey(addr basics.Address, aidx basics.AppIndex, global bool, key string) (basics.TealValue, bool, error)
+	getKey(addr basics.Address, aidx basics.AppIndex, global bool, key string, accountIdx uint64) (basics.TealValue, bool, error)
 }
 
 type roundCowState struct {
@@ -61,16 +62,30 @@ type roundCowState struct {
 	// 2. Stateful TEAL evaluation (see SetKey/DelKey)
 	// must be incorporated into mods.accts before passing deltas forward
 	sdeltas map[basics.Address]map[storagePtr]*storageDelta
+
+	// either or not maintain compatibility with original app refactoring behavior
+	// this is needed for generating old eval delta in new code
+	compatibilityMode bool
+	// cache mainaining accountIdx used in getKey for local keys access
+	compatibilityGetKeyCache map[basics.Address]map[storagePtr]uint64
 }
 
 func makeRoundCowState(b roundCowParent, hdr bookkeeping.BlockHeader, prevTimestamp int64, hint int) *roundCowState {
-	return &roundCowState{
+	cb := roundCowState{
 		lookupParent: b,
 		commitParent: nil,
 		proto:        config.Consensus[hdr.CurrentProtocol],
 		mods:         ledgercore.MakeStateDelta(&hdr, prevTimestamp, hint, 0),
 		sdeltas:      make(map[basics.Address]map[storagePtr]*storageDelta),
 	}
+
+	compatibilityMode := (hdr.CurrentProtocol == protocol.ConsensusV24) &&
+		(hdr.NextProtocol != protocol.ConsensusV26 || (hdr.UpgradePropose == "" && hdr.UpgradeApprove == false))
+	if compatibilityMode {
+		cb.compatibilityMode = true
+		cb.compatibilityGetKeyCache = make(map[basics.Address]map[storagePtr]uint64)
+	}
+	return &cb
 }
 
 func (cb *roundCowState) deltas() ledgercore.StateDelta {
@@ -196,13 +211,19 @@ func (cb *roundCowState) setCompactCertNext(rnd basics.Round) {
 }
 
 func (cb *roundCowState) child(hint int) *roundCowState {
-	return &roundCowState{
+	ch := roundCowState{
 		lookupParent: cb,
 		commitParent: cb,
 		proto:        cb.proto,
 		mods:         ledgercore.MakeStateDelta(cb.mods.Hdr, cb.mods.PrevTimestamp, hint, cb.mods.CompactCertNext),
 		sdeltas:      make(map[basics.Address]map[storagePtr]*storageDelta),
 	}
+
+	if cb.compatibilityMode {
+		ch.compatibilityMode = cb.compatibilityMode
+		ch.compatibilityGetKeyCache = make(map[basics.Address]map[storagePtr]uint64)
+	}
+	return &ch
 }
 
 func (cb *roundCowState) commitToParent() {

--- a/ledger/cow.go
+++ b/ledger/cow.go
@@ -79,8 +79,11 @@ func makeRoundCowState(b roundCowParent, hdr bookkeeping.BlockHeader, prevTimest
 		sdeltas:      make(map[basics.Address]map[storagePtr]*storageDelta),
 	}
 
+	// compatibilityMode retains producing application' eval deltas under the following rule:
+	// local delta has account index as it specified in TEAL either in set/del key or prior get key calls.
+	// The predicate is that complex in order to cover all the block seen on testnet and mainnet.
 	compatibilityMode := (hdr.CurrentProtocol == protocol.ConsensusV24) &&
-		(hdr.NextProtocol != protocol.ConsensusV26 || (hdr.UpgradePropose == "" && hdr.UpgradeApprove == false))
+		(hdr.NextProtocol != protocol.ConsensusV26 || (hdr.UpgradePropose == "" && hdr.UpgradeApprove == false && hdr.Round < hdr.UpgradeState.NextProtocolVoteBefore))
 	if compatibilityMode {
 		cb.compatibilityMode = true
 		cb.compatibilityGetKeyCache = make(map[basics.Address]map[storagePtr]uint64)

--- a/ledger/cow_test.go
+++ b/ledger/cow_test.go
@@ -63,7 +63,7 @@ func (ml *mockLedger) allocated(addr basics.Address, aidx basics.AppIndex, globa
 	return true, nil
 }
 
-func (ml *mockLedger) getKey(addr basics.Address, aidx basics.AppIndex, global bool, key string) (basics.TealValue, bool, error) {
+func (ml *mockLedger) getKey(addr basics.Address, aidx basics.AppIndex, global bool, key string, accountIdx uint64) (basics.TealValue, bool, error) {
 	return basics.TealValue{}, false, nil
 }
 

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -132,7 +132,7 @@ func (x *roundCowBase) allocated(addr basics.Address, aidx basics.AppIndex, glob
 
 // getKey gets the value for a particular key in some storage
 // associated with an application globally or locally
-func (x *roundCowBase) getKey(addr basics.Address, aidx basics.AppIndex, global bool, key string) (basics.TealValue, bool, error) {
+func (x *roundCowBase) getKey(addr basics.Address, aidx basics.AppIndex, global bool, key string, accountIdx uint64) (basics.TealValue, bool, error) {
 	ad, _, err := x.l.LookupWithoutRewards(x.rnd, addr)
 	if err != nil {
 		return basics.TealValue{}, false, err


### PR DESCRIPTION
## Summary

* roundCowState now has compatibility mode
* accountIdx param is propagated from logic to GetKey/SetKey/DelKey
* Logic:
 - store account index for used in GetKey for this app
 - in SetKey/DelKey use store either the index from GetKey if exist or a current account index
 - if in compatibility mode, BuildEvalDelta uses indices mentioned above
 - otherwise it calculates account index using txn.Accounts

## Test Plan

New tests added