### PR TITLE
logfilter: exit with non-zero when test fails

### DIFF
--- a/debug/logfilter/main.go
+++ b/debug/logfilter/main.go
@@ -35,6 +35,7 @@ func logFilter(inFile io.Reader, outFile io.Writer) int {
 
 	tests := make(map[string]test)
 	currentTestName := ""
+	incomingFails := false
 	// packageOutputBuffer is used to buffer messages that are package-oriented. i.e. TestMain() generated messages,
 	// which are called before any test starts to run.
 	packageOutputBuffer := ""
@@ -83,6 +84,7 @@ func logFilter(inFile io.Reader, outFile io.Writer) int {
 			continue
 		}
 		if idx := strings.Index(line, "--- FAIL:"); idx >= 0 {
+			incomingFails = true
 			var testName string
 			fmt.Sscanf(line[idx:], "--- FAIL: %s", &testName)
 			test, have := tests[testName]
@@ -114,6 +116,7 @@ func logFilter(inFile io.Reader, outFile io.Writer) int {
 			continue
 		}
 		if strings.HasPrefix(line, "FAIL	") {
+			incomingFails = true
 			if len(packageOutputBuffer) > 0 {
 				fmt.Fprintf(outFile, line+"...\r\n%s\r\n", packageOutputBuffer)
 			}
@@ -130,7 +133,9 @@ func logFilter(inFile io.Reader, outFile io.Writer) int {
 			fmt.Fprint(outFile, tests[currentTestName].outputBuffer)
 		}
 		fmt.Fprintf(outFile, "logfilter: the following error received on the input stream : %v\r\n", scannerErr)
-		return 0
+	}
+	if incomingFails {
+		return 1
 	}
 	return 0
 }

--- a/debug/logfilter/main_test.go
+++ b/debug/logfilter/main_test.go
@@ -48,12 +48,16 @@ func TestLogFilterExamples(t *testing.T) {
 		expectedOutFile := strings.Replace(exampleFileName, ".in", ".out.expected", 1)
 		expectedOutBytes, err := ioutil.ReadFile(expectedOutFile)
 		require.NoError(t, err)
+		expectedErrorCode := 0
+		if strings.Contains(string(expectedOutBytes), "FAIL") {
+			expectedErrorCode = 1
+		}
 
 		inFile, err := os.Open(exampleFileName)
 		require.NoError(t, err)
 		writingBuffer := bytes.NewBuffer(nil)
 		errCode := logFilter(inFile, writingBuffer)
-		require.Zero(t, errCode)
+		require.Equal(t, expectedErrorCode, errCode)
 		require.Equal(t, string(expectedOutBytes), writingBuffer.String())
 	}
 }


### PR DESCRIPTION
## Summary

Exit from the logfilter process with non-zero output when "FAIL" was detected on input stream.
This allows us to pipe the input of the test without using `-o pipefail`.

## Test Plan

Unit test updated.