### PR TITLE
catchpoint: truncate output file

### DIFF
--- a/cmd/catchpointdump/database.go
+++ b/cmd/catchpointdump/database.go
@@ -52,7 +52,7 @@ var databaseCmd = &cobra.Command{
 		outFile := os.Stdout
 		var err error
 		if outFileName != "" {
-			outFile, err = os.OpenFile(outFileName, os.O_RDWR|os.O_CREATE, 0755)
+			outFile, err = os.OpenFile(outFileName, os.O_RDWR|os.O_TRUNC|os.O_CREATE, 0755)
 			if err != nil {
 				reportErrorf("Unable to create file '%s' : %v", outFileName, err)
 			}

--- a/cmd/catchpointdump/file.go
+++ b/cmd/catchpointdump/file.go
@@ -91,7 +91,7 @@ var fileCmd = &cobra.Command{
 
 		outFile := os.Stdout
 		if outFileName != "" {
-			outFile, err = os.OpenFile(outFileName, os.O_RDWR|os.O_CREATE, 0755)
+			outFile, err = os.OpenFile(outFileName, os.O_RDWR|os.O_TRUNC|os.O_CREATE, 0755)
 			if err != nil {
 				reportErrorf("Unable to create file '%s' : %v", outFileName, err)
 			}

--- a/cmd/catchpointdump/net.go
+++ b/cmd/catchpointdump/net.go
@@ -300,7 +300,7 @@ func makeFileDump(addr string, catchpointFileBytes []byte) error {
 	}
 
 	dirName := "./" + strings.Split(networkName, ".")[0] + "/" + strings.Split(addr, ".")[0]
-	outFile, err := os.OpenFile(dirName+"/"+strconv.FormatUint(uint64(round), 10)+".dump", os.O_RDWR|os.O_CREATE, 0755)
+	outFile, err := os.OpenFile(dirName+"/"+strconv.FormatUint(uint64(round), 10)+".dump", os.O_RDWR|os.O_TRUNC|os.O_CREATE, 0755)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Dump utility have not truncated output dump file so it might have some unexpected data.

## Test Plan

Manually tested