### PR TITLE
Update GOPROXY, replace https://gocenter.io with https://pkg.go.dev

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /root
 RUN wget --quiet https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz && tar -xvf go${GOLANG_VERSION}.linux-amd64.tar.gz && mv go /usr/local
 ENV GOROOT=/usr/local/go \
     GOPATH=$HOME/go \
-    GOPROXY=https://gocenter.io,https://goproxy.io,direct
+    GOPROXY=https://pkg.go.dev,direct
 RUN mkdir -p $GOPATH/src/github.com/algorand
 WORKDIR $GOPATH/src/github.com/algorand
 COPY ./go-algorand ./go-algorand/

--- a/docker/build/Dockerfile-deploy
+++ b/docker/build/Dockerfile-deploy
@@ -6,7 +6,7 @@ WORKDIR /root
 RUN wget --quiet https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz && tar -xvf go${GOLANG_VERSION}.linux-amd64.tar.gz && mv go /usr/local
 ENV GOROOT=/usr/local/go \
     GOPATH=$HOME/go \
-    GOPROXY=https://gocenter.io,https://goproxy.io,direct
+    GOPROXY=https://pkg.go.dev,https://goproxy.io,direct
 RUN mkdir -p $GOPATH/src/github.com/algorand
 WORKDIR $GOPATH/src/github.com/algorand
 COPY . ./go-algorand/

--- a/docker/build/cicd.alpine.Dockerfile
+++ b/docker/build/cicd.alpine.Dockerfile
@@ -25,7 +25,7 @@ RUN apk add dpkg && \
 COPY . $GOPATH/src/github.com/algorand/go-algorand
 WORKDIR $GOPATH/src/github.com/algorand/go-algorand
 ENV GCC_CONFIG="--with-arch=armv6" \
-    GOPROXY=https://gocenter.io,https://goproxy.io,direct
+    GOPROXY=https://pkg.go.dev,https://goproxy.io,direct
 RUN make ci-deps && make clean
 RUN rm -rf $GOPATH/src/github.com/algorand/go-algorand && \
     mkdir -p $GOPATH/src/github.com/algorand/go-algorand

--- a/docker/build/cicd.centos.Dockerfile
+++ b/docker/build/cicd.centos.Dockerfile
@@ -18,7 +18,7 @@ ENV GOROOT=/usr/local/go \
 RUN mkdir -p $GOPATH/src/github.com/algorand
 COPY . $GOPATH/src/github.com/algorand/go-algorand
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH \
-    GOPROXY=https://gocenter.io
+    GOPROXY=https://pkg.go.dev
 WORKDIR $GOPATH/src/github.com/algorand/go-algorand
 RUN make ci-deps && make clean
 RUN rm -rf $GOPATH/src/github.com/algorand/go-algorand && \

--- a/docker/build/cicd.ubuntu.Dockerfile
+++ b/docker/build/cicd.ubuntu.Dockerfile
@@ -15,7 +15,7 @@ ENV GOROOT=/usr/local/go \
 RUN mkdir -p $GOPATH/src/github.com/algorand
 COPY . $GOPATH/src/github.com/algorand/go-algorand
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH \
-    GOPROXY=https://gocenter.io
+    GOPROXY=https://pkg.go.dev
 WORKDIR $GOPATH/src/github.com/algorand/go-algorand
 RUN make ci-deps && make clean
 RUN rm -rf $GOPATH/src/github.com/algorand/go-algorand && \


### PR DESCRIPTION
## Summary

For GOPROXY, replace the use of https://gocenter.io with https://pkg.go.dev, since gocenter.io is at end of life.  

## Test Plan

Testing with make clean install test integration and running Travis build and test. 
