### PR TITLE
Add ParticipationKeysRefreshInterval to the node config

### DIFF
--- a/agreement/fuzzer/fuzzer_test.go
+++ b/agreement/fuzzer/fuzzer_test.go
@@ -84,7 +84,7 @@ func MakeFuzzer(config FuzzerConfig) *Fuzzer {
 		crashAccessors:   make([]db.Accessor, config.NodesCount),
 		accounts:         make([]account.Participation, config.NodesCount),
 		balances:         make(map[basics.Address]basics.AccountData),
-		accountAccessors: make([]db.Accessor, config.NodesCount*2),
+		accountAccessors: make([]db.Accessor, config.NodesCount),
 		ledgers:          make([]*testLedger, config.NodesCount),
 		agreementParams:  make([]agreement.Parameters, config.NodesCount),
 		tickGranularity:  time.Millisecond * 300,
@@ -196,7 +196,7 @@ func (n *Fuzzer) initAccountsAndBalances(rootSeed []byte, onlineNodes []bool) er
 		if err != nil {
 			return err
 		}
-		n.accountAccessors[i*2+0] = rootAccess
+		n.accountAccessors[i] = rootAccess
 
 		seed = sha256.Sum256(seed[:])
 		root, err := account.ImportRoot(rootAccess, seed)

--- a/config/config.go
+++ b/config/config.go
@@ -409,6 +409,10 @@ type Local struct {
 	// Time interval in nanoseconds for generating accountUpdates telemetry event
 	AccountUpdatesStatsInterval time.Duration `version[17]:"5000000000"`
 
+	// ParticipationKeysRefreshInterval is the duration between two consecutive checks to see if new participation
+	// keys have been placed on the genesis directory.
+	ParticipationKeysRefreshInterval time.Duration `version[17]:"60000000000"`
+
 	// DisableNetworking disables all the incoming and outgoing communication a node would perform. This is useful
 	// when we have a single-node private network, where there is no other nodes that need to be communicated with.
 	// features like catchpoint catchup would be rendered completly non-operational, and many of the node inner

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -88,6 +88,7 @@ var defaultLocal = Local{
 	OptimizeAccountsDatabaseOnStartup:       false,
 	OutgoingMessageFilterBucketCount:        3,
 	OutgoingMessageFilterBucketSize:         128,
+	ParticipationKeysRefreshInterval:        60000000000,
 	PeerConnectionsUpdateInterval:           3600,
 	PeerPingPeriodSeconds:                   0,
 	PriorityPeers:                           map[string]bool{},

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -67,6 +67,7 @@
     "OptimizeAccountsDatabaseOnStartup": false,
     "OutgoingMessageFilterBucketCount": 3,
     "OutgoingMessageFilterBucketSize": 128,
+    "ParticipationKeysRefreshInterval": 60000000000,
     "PeerConnectionsUpdateInterval": 3600,
     "PeerPingPeriodSeconds": 0,
     "PriorityPeers": {},

--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -229,7 +229,7 @@ func (c *Client) MakeUnsignedGoOnlineTx(address string, part *account.Participat
 	parsedLastValid := basics.Round(lastValid)
 	parsedFee := basics.MicroAlgos{Raw: fee}
 
-	goOnlineTransaction := part.GenerateRegistrationTransaction(parsedFee, parsedFrstValid, parsedLastValid, leaseBytes, cparams)
+	goOnlineTransaction := part.GenerateRegistrationTransaction(parsedFee, parsedFrstValid, parsedLastValid, leaseBytes)
 	if cparams.SupportGenesisHash {
 		var genHash crypto.Digest
 		copy(genHash[:], params.GenesisHash)

--- a/netdeploy/network.go
+++ b/netdeploy/network.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -146,6 +147,7 @@ func (n Network) NodeDataDirs() []string {
 	for _, nodeDir := range n.nodeDirs {
 		directories = append(directories, n.getNodeFullPath(nodeDir))
 	}
+	sort.Strings(directories)
 	return directories
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -55,8 +55,6 @@ import (
 	"github.com/algorand/go-deadlock"
 )
 
-const participationKeyCheckSecs = 60
-
 // StatusReport represents the current basic status of the node
 type StatusReport struct {
 	LastRound                          basics.Round
@@ -704,7 +702,7 @@ func (node *AlgorandFullNode) GetPendingTxnsFromPool() ([]transactions.SignedTxn
 // Reload participation keys from disk periodically
 func (node *AlgorandFullNode) checkForParticipationKeys() {
 	defer node.monitoringRoutinesWaitGroup.Done()
-	ticker := time.NewTicker(participationKeyCheckSecs * time.Second)
+	ticker := time.NewTicker(node.config.ParticipationKeysRefreshInterval)
 	for {
 		select {
 		case <-ticker.C:

--- a/test/testdata/configs/config-v17.json
+++ b/test/testdata/configs/config-v17.json
@@ -67,6 +67,7 @@
     "OptimizeAccountsDatabaseOnStartup": false,
     "OutgoingMessageFilterBucketCount": 3,
     "OutgoingMessageFilterBucketSize": 128,
+    "ParticipationKeysRefreshInterval": 60000000000,
     "PeerConnectionsUpdateInterval": 3600,
     "PeerPingPeriodSeconds": 0,
     "PriorityPeers": {},


### PR DESCRIPTION
## Summary

This PR adds a ParticipationKeysRefreshInterval config option that would replace the hard-coded 60-second value used.

## Test Plan

No testing provided in this PR. Subsequent PR ( https://github.com/algorand/go-algorand/pull/2125 ) will be using these config option in it's e2e test.
