### PR TITLE
bugfix: netgoal errors when bootstrap files was missing

### DIFF
--- a/cmd/netgoal/network.go
+++ b/cmd/netgoal/network.go
@@ -142,7 +142,10 @@ func runBuildNetwork() (err error) {
 		net.GenesisData.VersionModifier = networkGenesisVersionModifier
 	}
 
-	bootstrappedFile := resolveFile(r.BootstrappedFile, templateBaseDir)
+	var bootstrappedFile string
+	if r.BootstrappedFile != "" {
+		bootstrappedFile = resolveFile(r.BootstrappedFile, templateBaseDir)
+	}
 	if util.FileExists(bootstrappedFile) && bootstrapLoadingFile {
 		fileTemplate, err := remote.LoadBootstrappedData(bootstrappedFile)
 		if err != nil {
@@ -200,9 +203,6 @@ func runBuildNetwork() (err error) {
 func resolveFile(filename string, baseDir string) string {
 	if filepath.IsAbs(filename) {
 		return filename
-	}
-	if filename == "" {
-		return ""
 	}
 	// Assume path is relative to the directory of the template file
 	return filepath.Join(baseDir, filename)

--- a/cmd/netgoal/network.go
+++ b/cmd/netgoal/network.go
@@ -201,7 +201,9 @@ func resolveFile(filename string, baseDir string) string {
 	if filepath.IsAbs(filename) {
 		return filename
 	}
-
+	if filename == "" {
+		return ""
+	}
 	// Assume path is relative to the directory of the template file
 	return filepath.Join(baseDir, filename)
 }


### PR DESCRIPTION
## Summary

netgoal was failing to build network when the bootstrap files was missing.

## Test Plan

test manually.
