### PR TITLE
txsync: transaction sync profiler

### DIFF
--- a/logging/telemetryspec/metric.go
+++ b/logging/telemetryspec/metric.go
@@ -83,6 +83,44 @@ func (m AssembleBlockMetrics) Identifier() Metric {
 	return assembleBlockMetricsIdentifier
 }
 
+const transactionSyncProfilingMetricsIdentifier Metric = "SyncProfile"
+
+// TransactionSyncProfilingMetrics is the profiling metrics of the recent transaction sync activity
+type TransactionSyncProfilingMetrics struct {
+	TotalOps                     uint64
+	IdleOps                      uint64
+	TransactionPoolChangedOps    uint64
+	NewRoundOps                  uint64
+	PeerStateOps                 uint64
+	IncomingMsgOps               uint64
+	OutgoingMsgOps               uint64
+	NextOffsetOps                uint64
+	GetTxnGroupsOps              uint64
+	AssembleMessageOps           uint64
+	SendMessageOps               uint64
+	MakeBloomFilterOps           uint64
+	SelectPendingTransactionsOps uint64
+
+	TotalDuration                    uint64
+	IdlePercent                      float64
+	TransactionPoolChangedPercent    float64
+	NewRoundPercent                  float64
+	PeerStatePercent                 float64
+	IncomingMsgPercent               float64
+	OutgoingMsgPercent               float64
+	NextOffsetPercent                float64
+	GetTxnGroupsPercent              float64
+	AssembleMessagePercent           float64
+	SendMessagePercent               float64
+	MakeBloomFilterPercent           float64
+	SelectPendingTransactionsPercent float64
+}
+
+// Identifier implements the required MetricDetails interface, retrieving the Identifier for this set of metrics.
+func (m TransactionSyncProfilingMetrics) Identifier() Metric {
+	return transactionSyncProfilingMetricsIdentifier
+}
+
 //-------------------------------------------------------
 // ProcessBlock
 

--- a/logging/telemetryspec/metric.go
+++ b/logging/telemetryspec/metric.go
@@ -108,15 +108,15 @@ type TransactionSyncProfilingMetrics struct {
 	GetTxnGroupsOps uint64
 	// number of times the transaction sync was assembling messages
 	AssembleMessageOps uint64
-	// number of time the transaction sync was sending messages
+	// number of times the transaction sync was sending messages
 	SendMessageOps uint64
-	// number of time the transaction sync was creating bloom filters
+	// number of times the transaction sync was creating bloom filters
 	MakeBloomFilterOps uint64
-	// number of time the transaction sync was selecting pending transactions out of existing pool
+	// number of times the transaction sync was selecting pending transactions out of existing pool
 	SelectPendingTransactionsOps uint64
 
 	// total duration of this profiling session
-	TotalDuration uint64
+	TotalDuration time.Duration
 	// percent of time the transaction sync was idle
 	IdlePercent float64
 	// percent of time the transaction sync was processing transaction pool changes

--- a/logging/telemetryspec/metric.go
+++ b/logging/telemetryspec/metric.go
@@ -83,36 +83,63 @@ func (m AssembleBlockMetrics) Identifier() Metric {
 	return assembleBlockMetricsIdentifier
 }
 
+// the identifier for the transaction sync profiling metrics.
 const transactionSyncProfilingMetricsIdentifier Metric = "SyncProfile"
 
 // TransactionSyncProfilingMetrics is the profiling metrics of the recent transaction sync activity
 type TransactionSyncProfilingMetrics struct {
-	TotalOps                     uint64
-	IdleOps                      uint64
-	TransactionPoolChangedOps    uint64
-	NewRoundOps                  uint64
-	PeerStateOps                 uint64
-	IncomingMsgOps               uint64
-	OutgoingMsgOps               uint64
-	NextOffsetOps                uint64
-	GetTxnGroupsOps              uint64
-	AssembleMessageOps           uint64
-	SendMessageOps               uint64
-	MakeBloomFilterOps           uint64
+	// total number of operations
+	TotalOps uint64
+	// number of idle operations
+	IdleOps uint64
+	// number of transaction pool changes operations
+	TransactionPoolChangedOps uint64
+	// number of new rounds operations
+	NewRoundOps uint64
+	// number of peer state changes operations
+	PeerStateOps uint64
+	// number of incoming messages operations
+	IncomingMsgOps uint64
+	// number of outgoing message operations
+	OutgoingMsgOps uint64
+	// number of next offsets message operations
+	NextOffsetOps uint64
+	// number of times transaction sync was retrieving the transaction groups from the transaction pool
+	GetTxnGroupsOps uint64
+	// number of times the transaction sync was assembling messages
+	AssembleMessageOps uint64
+	// number of time the transaction sync was sending messages
+	SendMessageOps uint64
+	// number of time the transaction sync was creating bloom filters
+	MakeBloomFilterOps uint64
+	// number of time the transaction sync was selecting pending transactions out of existing pool
 	SelectPendingTransactionsOps uint64
 
-	TotalDuration                    uint64
-	IdlePercent                      float64
-	TransactionPoolChangedPercent    float64
-	NewRoundPercent                  float64
-	PeerStatePercent                 float64
-	IncomingMsgPercent               float64
-	OutgoingMsgPercent               float64
-	NextOffsetPercent                float64
-	GetTxnGroupsPercent              float64
-	AssembleMessagePercent           float64
-	SendMessagePercent               float64
-	MakeBloomFilterPercent           float64
+	// total duration of this profiling session
+	TotalDuration uint64
+	// percent of time the transaction sync was idle
+	IdlePercent float64
+	// percent of time the transaction sync was processing transaction pool changes
+	TransactionPoolChangedPercent float64
+	// percent of time the transaction sync was processing new rounds
+	NewRoundPercent float64
+	// percent of time the transaction sync was processing peer state changes
+	PeerStatePercent float64
+	// percent of time the transaction sync was processing incoming messages
+	IncomingMsgPercent float64
+	// percent of time the transaction sync was processing outgoing messages
+	OutgoingMsgPercent float64
+	// percent of time the transaction sync was processing next offset messages
+	NextOffsetPercent float64
+	// percent of time the transaction sync was collecting next set of transaction groups from the transaction pool
+	GetTxnGroupsPercent float64
+	// percent of time the transaction sync was assembling messages
+	AssembleMessagePercent float64
+	// percent of time the transaction sync was sending messages
+	SendMessagePercent float64
+	// percent of time the transaction sync was creating bloom filter
+	MakeBloomFilterPercent float64
+	// percent of time the transaction sync was selecting transaction to be sent
 	SelectPendingTransactionsPercent float64
 }
 

--- a/txnsync/mainloop.go
+++ b/txnsync/mainloop.go
@@ -54,6 +54,8 @@ type syncState struct {
 	// and compute it only once. Since this bloom filter could contain many hashes ( especially on relays )
 	// it's important to avoid recomputing it needlessly.
 	lastBloomFilter bloomFilter
+
+	profiler *profiler
 }
 
 func (s *syncState) mainloop(serviceCtx context.Context, wg *sync.WaitGroup) {
@@ -71,6 +73,16 @@ func (s *syncState) mainloop(serviceCtx context.Context, wg *sync.WaitGroup) {
 	roundSettings := s.node.GetCurrentRoundSettings()
 	s.onNewRoundEvent(MakeNewRoundEvent(roundSettings.Round, roundSettings.FetchTransactions))
 
+	// create a profiler, and it's profiling elements.
+	s.profiler = makeProfiler(200*time.Millisecond, s.clock, s.log, 2000*time.Millisecond) // todo : make the time configurable.
+	profIdle := s.profiler.getElement(profElementIdle)
+	profTxChange := s.profiler.getElement(profElementTxChange)
+	profNewRounnd := s.profiler.getElement(profElementNewRounnd)
+	profPeerState := s.profiler.getElement(profElementPeerState)
+	profIncomingMsg := s.profiler.getElement(profElementIncomingMsg)
+	profOutgoingMsg := s.profiler.getElement(profElementOutgoingMsg)
+	profNextOffset := s.profiler.getElement(profElementNextOffset)
+
 	externalEvents := s.node.Events()
 	var nextPeerStateCh <-chan time.Time
 	for {
@@ -85,47 +97,79 @@ func (s *syncState) mainloop(serviceCtx context.Context, wg *sync.WaitGroup) {
 		case ent := <-externalEvents:
 			switch ent.eventType {
 			case transactionPoolChangedEvent:
+				profTxChange.start()
 				s.onTransactionPoolChangedEvent(ent)
+				profTxChange.end()
 			case newRoundEvent:
+				profNewRounnd.start()
 				s.onNewRoundEvent(ent)
+				profNewRounnd.end()
 			}
 			continue
 		case <-nextPeerStateCh:
+			profPeerState.start()
 			s.evaluatePeerStateChanges(nextPeerStateTime)
+			profPeerState.end()
 			continue
 		case incomingMsg := <-s.incomingMessagesCh:
+			profIncomingMsg.start()
 			s.evaluateIncomingMessage(incomingMsg)
+			profIncomingMsg.end()
 			continue
 		case msgSent := <-s.outgoingMessagesCallbackCh:
+			profOutgoingMsg.start()
 			s.evaluateOutgoingMessage(msgSent)
+			profOutgoingMsg.end()
 			continue
 		case <-s.nextOffsetRollingCh:
+			profNextOffset.start()
 			s.rollOffsets()
+			profNextOffset.end()
 			continue
 		case <-serviceCtx.Done():
 			return
 		default:
 		}
 
+		profIdle.start()
 		select {
 		case ent := <-externalEvents:
+			profIdle.end()
 			switch ent.eventType {
 			case transactionPoolChangedEvent:
+				profTxChange.start()
 				s.onTransactionPoolChangedEvent(ent)
+				profTxChange.end()
 			case newRoundEvent:
+				profNewRounnd.start()
 				s.onNewRoundEvent(ent)
+				profNewRounnd.end()
 			}
 		case <-nextPeerStateCh:
+			profIdle.end()
+			profPeerState.start()
 			s.evaluatePeerStateChanges(nextPeerStateTime)
+			profPeerState.end()
 		case incomingMsg := <-s.incomingMessagesCh:
+			profIdle.end()
+			profIncomingMsg.start()
 			s.evaluateIncomingMessage(incomingMsg)
+			profIncomingMsg.end()
 		case msgSent := <-s.outgoingMessagesCallbackCh:
+			profIdle.end()
+			profOutgoingMsg.start()
 			s.evaluateOutgoingMessage(msgSent)
+			profOutgoingMsg.end()
 		case <-s.nextOffsetRollingCh:
+			profIdle.end()
+			profNextOffset.start()
 			s.rollOffsets()
+			profNextOffset.end()
 		case <-serviceCtx.Done():
+			profIdle.end()
 			return
 		case <-s.node.NotifyMonitor():
+			profIdle.end()
 		}
 	}
 }

--- a/txnsync/mainloop.go
+++ b/txnsync/mainloop.go
@@ -55,6 +55,8 @@ type syncState struct {
 	// it's important to avoid recomputing it needlessly.
 	lastBloomFilter bloomFilter
 
+	// The profiler helps us monitor the transaction sync components execution time. When enabled, it would report these
+	// to the telemetry.
 	profiler *profiler
 }
 

--- a/txnsync/mainloop.go
+++ b/txnsync/mainloop.go
@@ -75,11 +75,11 @@ func (s *syncState) mainloop(serviceCtx context.Context, wg *sync.WaitGroup) {
 	roundSettings := s.node.GetCurrentRoundSettings()
 	s.onNewRoundEvent(MakeNewRoundEvent(roundSettings.Round, roundSettings.FetchTransactions))
 
-	// create a profiler, and it's profiling elements.
+	// create a profiler, and its profiling elements.
 	s.profiler = makeProfiler(200*time.Millisecond, s.clock, s.log, 2000*time.Millisecond) // todo : make the time configurable.
 	profIdle := s.profiler.getElement(profElementIdle)
 	profTxChange := s.profiler.getElement(profElementTxChange)
-	profNewRounnd := s.profiler.getElement(profElementNewRounnd)
+	profNewRounnd := s.profiler.getElement(profElementNewRound)
 	profPeerState := s.profiler.getElement(profElementPeerState)
 	profIncomingMsg := s.profiler.getElement(profElementIncomingMsg)
 	profOutgoingMsg := s.profiler.getElement(profElementOutgoingMsg)

--- a/txnsync/profiler.go
+++ b/txnsync/profiler.go
@@ -1,0 +1,203 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package txnsync
+
+import (
+	"time"
+
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/logging/telemetryspec"
+	"github.com/algorand/go-algorand/util/timers"
+)
+
+type profElements int
+
+const (
+	profElementIdle = iota
+	profElementTxChange
+	profElementNewRounnd
+	profElementPeerState
+	profElementIncomingMsg
+	profElementOutgoingMsg
+	profElementNextOffset
+
+	profElementGetTxnsGroups
+	profElementAssembleMessage
+	profElementSendMessage
+	profElementMakeBloomFilter
+	profElementTxnsSelection
+
+	profElementLast
+)
+
+var profElementNames = []string{
+	"idle",
+	"transactionPoolChangedEvent",
+	"newRound",
+	"peerState",
+	"incomingMsg",
+	"outgoingMsg",
+	"nextOffset",
+	"getTxnGroups",
+	"assembleMessage",
+	"sendMessage",
+	"makeBloomFilter",
+	"selectPendingTransactions",
+}
+
+// The profiler struct provides profiling information regarding the main loop performance
+// characteristics. Using it provides statistics information about the recent duty cycle utilization,
+// that could be used when trying to throlle the accuracy and performance of the transaction sync.
+type profiler struct {
+	clock    timers.WallClock
+	elements []*element
+	log      logging.Logger
+
+	profile        []int
+	profileSum     time.Duration
+	profileSpan    time.Duration
+	spanReached    bool
+	lastProfileLog time.Duration
+	logInterval    time.Duration // what is the frequency at which we send an event to the telemetry. Zero to disable.
+}
+
+// element represent a single tracked element that would be profiled.
+type element struct {
+	name      string
+	id        int
+	lastStart time.Duration
+	profiler  *profiler
+	times     []time.Duration
+	total     time.Duration
+	detached  bool
+}
+
+func makeProfiler(span time.Duration, clock timers.WallClock, log logging.Logger, logInterval time.Duration) *profiler {
+	prof := &profiler{
+		profileSpan: span,
+		clock:       clock,
+		log:         log,
+		logInterval: logInterval,
+	}
+	prof.createElements()
+	return prof
+}
+
+func (p *profiler) createElements() {
+	for element := 0; element < profElementLast; element++ {
+		p.createElement(profElementNames[element], element > profElementNextOffset)
+	}
+}
+
+func (p *profiler) createElement(name string, detached bool) *element {
+	i := len(p.elements)
+	e := &element{
+		name:     name,
+		id:       i,
+		profiler: p,
+		detached: detached,
+	}
+	p.elements = append(p.elements, e)
+	return e
+}
+
+func (p *profiler) getElement(el profElements) *element {
+	return p.elements[el]
+}
+
+func (p *profiler) prune() {
+	for p.profileSum > p.profileSpan {
+		// remove the first elements from the profile.
+		i := p.profile[0]
+		e := p.elements[i]
+		dt := e.times[0]
+
+		e.total -= dt
+		if !e.detached {
+			p.profileSum -= dt
+		}
+
+		p.profile = p.profile[1:]
+		e.times = e.times[1:]
+		p.spanReached = true
+	}
+	p.logProfile()
+}
+
+func (p *profiler) logProfile() {
+	if !p.spanReached || p.logInterval == 0 {
+		return
+	}
+	curTime := p.clock.Since()
+	if curTime-p.lastProfileLog <= p.logInterval {
+		return
+	}
+	p.lastProfileLog = curTime
+
+	metrics := telemetryspec.TransactionSyncProfilingMetrics{
+		TotalOps:                     uint64(len(p.profile)),
+		IdleOps:                      uint64(len(p.elements[profElementIdle].times)),
+		TransactionPoolChangedOps:    uint64(len(p.elements[profElementTxChange].times)),
+		NewRoundOps:                  uint64(len(p.elements[profElementNewRounnd].times)),
+		PeerStateOps:                 uint64(len(p.elements[profElementPeerState].times)),
+		IncomingMsgOps:               uint64(len(p.elements[profElementIncomingMsg].times)),
+		OutgoingMsgOps:               uint64(len(p.elements[profElementOutgoingMsg].times)),
+		NextOffsetOps:                uint64(len(p.elements[profElementNextOffset].times)),
+		GetTxnGroupsOps:              uint64(len(p.elements[profElementGetTxnsGroups].times)),
+		AssembleMessageOps:           uint64(len(p.elements[profElementAssembleMessage].times)),
+		SendMessageOps:               uint64(len(p.elements[profElementSendMessage].times)),
+		MakeBloomFilterOps:           uint64(len(p.elements[profElementMakeBloomFilter].times)),
+		SelectPendingTransactionsOps: uint64(len(p.elements[profElementTxnsSelection].times)),
+
+		TotalDuration:                    uint64(p.profileSum),
+		IdlePercent:                      float64(p.elements[profElementIdle].total) * 100.0 / float64(p.profileSum),
+		TransactionPoolChangedPercent:    float64(p.elements[profElementTxChange].total) * 100.0 / float64(p.profileSum),
+		NewRoundPercent:                  float64(p.elements[profElementNewRounnd].total) * 100.0 / float64(p.profileSum),
+		PeerStatePercent:                 float64(p.elements[profElementPeerState].total) * 100.0 / float64(p.profileSum),
+		IncomingMsgPercent:               float64(p.elements[profElementIncomingMsg].total) * 100.0 / float64(p.profileSum),
+		OutgoingMsgPercent:               float64(p.elements[profElementOutgoingMsg].total) * 100.0 / float64(p.profileSum),
+		NextOffsetPercent:                float64(p.elements[profElementNextOffset].total) * 100.0 / float64(p.profileSum),
+		GetTxnGroupsPercent:              float64(p.elements[profElementGetTxnsGroups].total) * 100.0 / float64(p.profileSum),
+		AssembleMessagePercent:           float64(p.elements[profElementAssembleMessage].total) * 100.0 / float64(p.profileSum),
+		SendMessagePercent:               float64(p.elements[profElementSendMessage].total) * 100.0 / float64(p.profileSum),
+		MakeBloomFilterPercent:           float64(p.elements[profElementMakeBloomFilter].total) * 100.0 / float64(p.profileSum),
+		SelectPendingTransactionsPercent: float64(p.elements[profElementTxnsSelection].total) * 100.0 / float64(p.profileSum),
+	}
+
+	p.log.Metrics(telemetryspec.Transaction, metrics, struct{}{})
+}
+
+func (e *element) start() {
+	if e.profiler.logInterval > 0 {
+		e.lastStart = e.profiler.clock.Since()
+	}
+}
+
+func (e *element) end() {
+	if e.profiler.logInterval == 0 {
+		return
+	}
+	diff := e.profiler.clock.Since() - e.lastStart
+	e.total += diff
+	e.times = append(e.times, diff)
+	e.profiler.profile = append(e.profiler.profile, e.id)
+
+	if !e.detached {
+		e.profiler.profileSum += diff
+		e.profiler.prune()
+	}
+}

--- a/txnsync/profiler.go
+++ b/txnsync/profiler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/algorand/go-algorand/util/timers"
 )
 
+//msgp:ignore profElements
 type profElements int
 
 const (

--- a/txnsync/profiler.go
+++ b/txnsync/profiler.go
@@ -147,7 +147,7 @@ func (p *profiler) maybeLogProfile() {
 	if p.profileSum < p.profileSpan/2 {
 		return
 	}
-	// have we send metrics recently ?
+	// have we sent metrics recently ?
 	curTime := p.clock.Since()
 	if curTime-p.lastProfileLog <= p.logInterval {
 		return
@@ -172,7 +172,7 @@ func (p *profiler) logProfile() {
 		MakeBloomFilterOps:           uint64(len(p.elements[profElementMakeBloomFilter].times)),
 		SelectPendingTransactionsOps: uint64(len(p.elements[profElementTxnsSelection].times)),
 
-		TotalDuration:                    time.Duration(p.profileSum),
+		TotalDuration:                    p.profileSum,
 		IdlePercent:                      float64(p.elements[profElementIdle].total) * 100.0 / float64(p.profileSum),
 		TransactionPoolChangedPercent:    float64(p.elements[profElementTxChange].total) * 100.0 / float64(p.profileSum),
 		NewRoundPercent:                  float64(p.elements[profElementNewRound].total) * 100.0 / float64(p.profileSum),


### PR DESCRIPTION
## Summary

This PR adds a lightweight profiler to the transaction sync. The profiler measures the execution time of the various internal components in the transaction sync and provide feedback for their relative CPU consumption.


## Test Plan

Test output on Kibana