### PR TITLE
Fix Update Script

### DIFF
--- a/cmd/updater/systemd-setup.sh
+++ b/cmd/updater/systemd-setup.sh
@@ -17,7 +17,7 @@ setup_root() {
     systemctl daemon-reload
 }
 
-if [ "$#" != 2 ]; then
+if [ "$#" != 2 ] && [ "$#" != 3 ]; then
     echo "Usage: $0 username group [bindir]"
     exit 1
 fi

--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -601,8 +601,6 @@ function apply_fixups() {
     done
 }
 
-
-
 #--------------------------------------------
 # Main Update Driver
 

--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -552,7 +552,7 @@ function startup_node() {
     fi
 
     if ! run_systemd_action restart "${CURDATADIR}"; then
-        echo "No systemd services, starting node with goal."
+        echo "No systemd services, restarting node with goal."
         ${BINDIR}/goal node restart -d "${CURDATADIR}" ${HOSTEDFLAG}
     fi
 }

--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -376,7 +376,7 @@ function run_systemd_action() {
             fi
         else
             if sudo -n systemctl "$action" "algorand@$(systemd-escape "$data_dir")"; then
-                echo "systemd system service: $action"
+                echo "sudo -n systemd system service: $action"
                 return 0
             fi
         fi
@@ -645,12 +645,10 @@ if [ ${RESUME_INSTALL} -eq 0 ] && ! $DRYRUN; then
     # Note that the SCRIPTPATH we're passing in should be our binaries directory, which is what we expect to be
     # passed as the last argument (if any)
     echo "Starting the new update script to complete the installation..."
-    echo "copy the update script"
-    cp /home/ubuntu//go-algorand/cmd/updater/update.sh "${UPDATESRCDIR}/bin/${FILENAME}"
     exec "${UPDATESRCDIR}/bin/${FILENAME}" ${INSTALLOPT} -r -c ${CHANNEL} ${DATADIRSPEC} ${NOSTART} ${BINDIRSPEC} ${HOSTEDSPEC} ${GENESIS_NETWORK_DIR_SPEC} ${UNKNOWNARGS[@]}
 
     # If we're still here, exec failed.
-    # fail_and_exit "Error executing the new update script - unable to continue"
+    fail_and_exit "Error executing the new update script - unable to continue"
 else
     # We're running the script from our expanded update, which is located in the last script's ${TEMPDIR}/a/bin
     # We need to define our TEMPDIR and UPDATESRCDIR to match those values; we do so by making them relative
@@ -701,4 +699,5 @@ if [ "${NOSTART}" != "" ]; then
 else
     startup_nodes
 fi
+
 exit 0

--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -381,7 +381,7 @@ function run_systemd_action() {
                 return 0
             fi
         fi
-        
+
     # If the service is user-level then run systemctl --user
     elif check_service user "$data_dir"; then
         if systemctl --user "$action" "algorand@$(systemd-escape "${data_dir}")"; then
@@ -663,7 +663,7 @@ else
     determine_current_version
 fi
 
-# Any fail_and_exit beyond this point, will run a restart
+# Any fail_and_exit beyond this point will run a restart
 RESTART_NODE=1
 
 if ! $DRYRUN; then

--- a/installer/algorand@.service.template
+++ b/installer/algorand@.service.template
@@ -30,7 +30,7 @@ After=network.target
 AssertPathExists=%I
 
 [Service]
-ExecStart=@@BINDIR@@/algod -d %I
+ExecStart=/bin/bash -c "exec /%I/../../algod -d %I"
 User=@@USER@@
 Group=@@GROUP@@
 Restart=always

--- a/installer/algorand@.service.template
+++ b/installer/algorand@.service.template
@@ -30,7 +30,7 @@ After=network.target
 AssertPathExists=%I
 
 [Service]
-ExecStart=/bin/bash @@BINDIR@@/algod -d %I
+ExecStart=@@BINDIR@@/algod -d %I
 User=@@USER@@
 Group=@@GROUP@@
 Restart=always

--- a/installer/algorand@.service.template
+++ b/installer/algorand@.service.template
@@ -30,7 +30,7 @@ After=network.target
 AssertPathExists=%I
 
 [Service]
-ExecStart=/bin/bash -c "exec %I/../../algod -d %I"
+ExecStart=/bin/bash @@BINDIR@@/algod -d %I
 User=@@USER@@
 Group=@@GROUP@@
 Restart=always

--- a/installer/algorand@.service.template
+++ b/installer/algorand@.service.template
@@ -30,7 +30,7 @@ After=network.target
 AssertPathExists=%I
 
 [Service]
-ExecStart=/bin/bash -c "exec /%I/../../algod -d %I"
+ExecStart=/bin/bash -c "exec %I/../../algod -d %I"
 User=@@USER@@
 Group=@@GROUP@@
 Restart=always


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

A change in 2.5.4 broke the upgrade behavior. When a node is upgraded with the new scripts, the algod -v updates, but the node doesn't update properly when you check `curl http://$(cat data/node1/algod.net)/versions`.


## Test Plan

I tested on AWS ubuntu machines with the go-algorand source code and building the binaries with the installer/algorand@.service.template change. I ran one with the change and one without the change for 2.5.4.

### Steps taken
```
sudo snap install go --classic
sudo apt-get install build-essential
sudo apt install make
git clone https://github.com/algorand/go-algorand.git
cd ~/go-algorand && git checkout tags/v2.5.4-stable -b feature/fixupdate
cd ~/go-algorand && ./scripts/configure_dev.sh
 make install
cd /home/ubuntu/go/bin
export ALGORAND_DATA=~/.algorand
./goal node start -d ~/.algorand
./update.sh -i -c stable-254 -p . -d ~/.algorand -n
sudo ./systemd-setup.sh ubuntu ubuntu
sudo systemctl daemon-reload
export ALGORAND_DATA=~/.algorand
sudo systemctl start algorand@$(systemd-escape $ALGORAND_DATA)


./update.sh -i -c stable-254 -p . -d ~/.algorand -n
curl http://$(cat ~/.algorand/algod.net)/versions # 2.5.4
./algod -v # 2.5.4

./update.sh -u -c stable-tmp -p . -d ~/.algorand
./algod -v # becomes latest 2.5.6 
curl http://$(cat ~/.algorand/algod.net)/versions # remains 2.5.4 without the execstart change but updates to 2.5.6 with the new change

```
New Steps
```
sudo snap install go --classic
sudo apt-get install build-essential
sudo apt install make
git clone https://github.com/algorand/go-algorand.git
cd ~/go-algorand && git checkout tags/v2.5.4-stable -b feature/fixupdate

# Make changes and in cmd/updater/update.sh add the following
# cp /home/ubuntu//go-algorand/cmd/updater/update.sh "${UPDATESRCDIR}/bin/${FILENAME}"
# add it above the following line so that the update script doesn't get overwritten while testing.:
# exec "${UPDATESRCDIR}/bin/${FILENAME}" ${INSTALLOPT} -r -c ${CHANNEL} ${DATADIRSPEC} ${NOSTART} ${BINDIRSPEC} ${HOSTEDSPEC} ${GENESIS_NETWORK_DIR_SPEC} ${UNKNOWNARGS[@]}

cd ~/go-algorand && ./scripts/configure_dev.sh
 make install
cd /home/ubuntu/go/bin
export ALGORAND_DATA=~/.algorand
sudo ./systemd-setup.sh ubuntu ubuntu
sudo systemctl daemon-reload
export ALGORAND_DATA=~/.algorand
sudo systemctl start algorand@$(systemd-escape $ALGORAND_DATA)

curl http://$(cat ~/.algorand/algod.net)/versions # 2.5.4
./algod -v # 2.5.4

./update.sh -u -c stable-tmp -p . -d ~/.algorand
./algod -v # becomes latest 2.5.6 
curl http://$(cat ~/.algorand/algod.net)/versions # remains 2.5.4 without the execstart change but updates to 2.5.6 with the new change
```
Future Improvement: 
Create a regular test that could test this scenario and alert for issue.
