### PR TITLE
txsync: add synced incoming message handler

### DIFF
--- a/txnsync/incoming.go
+++ b/txnsync/incoming.go
@@ -85,7 +85,7 @@ func (imq *incomingMessageQueue) enqueue(m incomingMessage) bool {
 	}
 }
 
-// clear removed the peer that is associated with the message ( if any ) from
+// clear removes the peer that is associated with the message ( if any ) from
 // the enqueuedPeers map, allowing future messages from this peer to be placed on the
 // incoming message queue.
 func (imq *incomingMessageQueue) clear(m incomingMessage) {

--- a/txnsync/incoming.go
+++ b/txnsync/incoming.go
@@ -47,8 +47,8 @@ type incomingMessageQueue struct {
 const maxPeersCount = 1024
 
 // makeIncomingMessageQueue creates an incomingMessageQueue object and initializes all the internal variables.
-func makeIncomingMessageQueue() *incomingMessageQueue {
-	return &incomingMessageQueue{
+func makeIncomingMessageQueue() incomingMessageQueue {
+	return incomingMessageQueue{
 		incomingMessages: make(chan incomingMessage, maxPeersCount),
 		enqueuedPeers:    make(map[*Peer]struct{}, maxPeersCount),
 	}

--- a/txnsync/mainloop.go
+++ b/txnsync/mainloop.go
@@ -45,7 +45,7 @@ type syncState struct {
 	scheduler                  peerScheduler
 	interruptablePeers         []*Peer
 	interruptablePeersMap      map[*Peer]int // map a peer into the index of interruptablePeers
-	incomingMessagesQ          *incomingMessageQueue
+	incomingMessagesQ          incomingMessageQueue
 	outgoingMessagesCallbackCh chan *messageSentCallback
 	nextOffsetRollingCh        <-chan time.Time
 	requestsOffset             uint64


### PR DESCRIPTION
## Summary

### Symptoms
When running the branch on a scenario-1 network that has pingpong, the following message appear in the log file:
```
unable to enqueue incoming message from a peer with txsync allocated data; incoming messages queue is full. disconnecting from peer.
```

As a result of the above disconnection, the network experiences poor performance as the nodes keeps re-establishing connections.

### Solution
The node's incomingMessageCh was 1024 entries long. That channel included every single incoming message, including (potentially) multiple messages from a single peer.

The solution here was to better scale the solution so that the "main" incoming message channel would contain only a single message for each peer. The peer itself already contains a heap of all it's incoming messages ( which is required in order to process the messages in-order ).

To encapsulate that, I implemented the `incomingMessageQueue` which wraps the said channel ( renamed `incomingMessageCh` -> `incomingMessages` ), along with a state map `enqueuedPeers` and a state map synchronization object `enqueuedPeersMu`.

Combining the above, allow us to enqueue an entry to the channel only if there is no pending entry on that channel for the same peer. Before we get to start pull entries of the *peer* queue, we reset the peer entry from the map, allowing future messages to be enqueued.

### Notes issues

With the above addressed, the following issue is reported to the log file:
```
solicitedAyncTxHandler exhusted groups backlog
```

This issue will be fixed in a subsequent PR.

## Test Plan

1. Tested using the emulator
2. Short term scenario-1 network /w payment pingpong
3. Long term scenario-1 network /w payment pingpong
4. Performance testing
