### PR TITLE
Increase ASA URL size 

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -913,6 +913,9 @@ func initConsensusProtocols() {
 	// Enable TEAL 4
 	vFuture.LogicSigVersion = 4
 
+	// Increase asset URL length to allow for IPFS URLs
+	vFuture.MaxAssetURLBytes = 96
+
 	Consensus[protocol.ConsensusFuture] = vFuture
 }
 

--- a/test/scripts/e2e_subs/asset-misc.sh
+++ b/test/scripts/e2e_subs/asset-misc.sh
@@ -18,7 +18,10 @@ ACCOUNTD=$(${gcmd} account new|awk '{ print $6 }')
 
 ASSET_NAME='Birlot : décollage vs. ࠶🦪'
 
-${gcmd} asset create --creator ${ACCOUNT} --name "${ASSET_NAME}" --unitname amisc --total 1000000000000
+# to ensure IPFS URLs longer than 32 characters are supported
+ASSET_URL="/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/"
+
+${gcmd} asset create --creator ${ACCOUNT} --name "${ASSET_NAME}" --unitname amisc --total 1000000000000 --asseturl "${ASSET_URL}"
 
 ASSET_ID=$(${gcmd} asset info --creator $ACCOUNT --unitname amisc|grep 'Asset ID'|awk '{ print $3 }')
 

--- a/test/scripts/e2e_subs/asset-misc.sh
+++ b/test/scripts/e2e_subs/asset-misc.sh
@@ -21,7 +21,7 @@ ASSET_NAME='Birlot : décollage vs. ࠶🦪'
 # to ensure IPFS URLs longer than 32 characters are supported
 ASSET_URL="/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/"
 
-${gcmd} asset create --creator ${ACCOUNT} --name "${ASSET_NAME}" --unitname amisc --total 1000000000000 --asseturl "${ASSET_URL}"
+${gcmd} asset create --creator "${ACCOUNT}" --name "${ASSET_NAME}" --unitname amisc --total 1000000000000 --asseturl "${ASSET_URL}"
 
 ASSET_ID=$(${gcmd} asset info --creator $ACCOUNT --unitname amisc|grep 'Asset ID'|awk '{ print $3 }')
 

--- a/test/scripts/e2e_subs/asset-misc.sh
+++ b/test/scripts/e2e_subs/asset-misc.sh
@@ -19,7 +19,7 @@ ACCOUNTD=$(${gcmd} account new|awk '{ print $6 }')
 ASSET_NAME='Birlot : décollage vs. ࠶🦪'
 
 # to ensure IPFS URLs longer than 32 characters are supported
-ASSET_URL="/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/"
+ASSET_URL="/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/Verifiable_random_function.html"
 
 ${gcmd} asset create --creator "${ACCOUNT}" --name "${ASSET_NAME}" --unitname amisc --total 1000000000000 --asseturl "${ASSET_URL}"
 

--- a/test/scripts/e2e_subs/v26/short-asset-url-only.sh
+++ b/test/scripts/e2e_subs/v26/short-asset-url-only.sh
@@ -21,7 +21,7 @@ ${gcmd} asset create \
     --name "${ASSET_NAME}" \
     --unitname amisc \
     --total 1000000000000 \
-    --asseturl "12345678901234567890123" \
+    --asseturl "123456789012345678901234567890123" 2>&1 \
     | grep "is too long (max 32 bytes)"
 set -o pipefail
 

--- a/test/scripts/e2e_subs/v26/short-asset-url-only.sh
+++ b/test/scripts/e2e_subs/v26/short-asset-url-only.sh
@@ -17,7 +17,7 @@ ASSET_NAME='Birlot : décollage vs. ࠶🦪'
 set +o pipefail
 # longer than 32-byte ASA URLs should fail
 ${gcmd} asset create \
-    --creator ${ACCOUNT} \
+    --creator "${ACCOUNT}" \
     --name "${ASSET_NAME}" \
     --unitname amisc \
     --total 1000000000000 \

--- a/test/scripts/e2e_subs/v26/short-asset-url-only.sh
+++ b/test/scripts/e2e_subs/v26/short-asset-url-only.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+date '+short-asset-url-only start %Y%m%d_%H%M%S'
+
+set -e
+set -x
+set -o pipefail
+export SHELLOPTS
+
+WALLET=$1
+
+gcmd="goal -w ${WALLET}"
+
+ACCOUNT=$(${gcmd} account list|awk '{ print $3 }')
+ASSET_NAME='Birlot : décollage vs. ࠶🦪'
+
+set +o pipefail
+# longer than 32-byte ASA URLs should fail
+${gcmd} asset create \
+    --creator ${ACCOUNT} \
+    --name "${ASSET_NAME}" \
+    --unitname amisc \
+    --total 1000000000000 \
+    --asseturl "12345678901234567890123" \
+    | grep "is too long (max 32 bytes)"
+set -o pipefail
+
+date '+short-asset-url-only finish %Y%m%d_%H%M%S'

--- a/test/scripts/e2e_subs/v26/short-asset-url-only.sh
+++ b/test/scripts/e2e_subs/v26/short-asset-url-only.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-date '+short-asset-url-only start %Y%m%d_%H%M%S'
+filename=$(basename "$0")
+scriptname="${filename%.*}"
+date "+${scriptname} start %Y%m%d_%H%M%S"
 
 set -e
 set -x
@@ -25,4 +27,4 @@ ${gcmd} asset create \
     | grep "is too long (max 32 bytes)"
 set -o pipefail
 
-date '+short-asset-url-only finish %Y%m%d_%H%M%S'
+date "+${scriptname} finish %Y%m%d_%H%M%S"

--- a/test/scripts/e2e_subs/v26/teal-v3-only.sh
+++ b/test/scripts/e2e_subs/v26/teal-v3-only.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-date '+teal-v3-only start %Y%m%d_%H%M%S'
+filename=$(basename "$0")
+scriptname="${filename%.*}"
+date "+${scriptname} start %Y%m%d_%H%M%S"
 
 set -e
 set -x
@@ -96,4 +98,4 @@ set -o pipefail
 
 
 
-date '+teal-v3-only OK %Y%m%d_%H%M%S'
+date "+${scriptname} finish %Y%m%d_%H%M%S"


### PR DESCRIPTION
## Summary

Increase the ASA URL size from a limiting 32 bytes to 96 bytes to support NFTs with longer IPFS URLs. 

Closes algorand/go-algorand-internal#1179.

## Test Plan

Integration tests for before and after the change.
