### PR TITLE
txnsync: improve outgoing message error handling

### DIFF
--- a/node/txnSyncConn.go
+++ b/node/txnSyncConn.go
@@ -135,8 +135,11 @@ func (tsnc *transcationSyncNodeConnector) SendPeerMessage(netPeer interface{}, m
 	if err := unicastPeer.Unicast(context.Background(), msg, protocol.Txn2Tag, func(enqueued bool, sequenceNumber uint64) {
 		callback(enqueued, sequenceNumber)
 	}); err != nil {
-		callback(false, 0)
-		return
+		callbackError := callback(false, 0)
+		if callbackError != nil {
+			// disconnect from peer - the transaction sync wasn't able to process message sending confirmation
+			tsnc.node.net.Disconnect(unicastPeer)
+		}
 	}
 }
 

--- a/node/txnSyncConn.go
+++ b/node/txnSyncConn.go
@@ -132,14 +132,15 @@ func (tsnc *transcationSyncNodeConnector) SendPeerMessage(netPeer interface{}, m
 	if unicastPeer == nil {
 		return
 	}
+	var callbackErr error
 	if err := unicastPeer.Unicast(context.Background(), msg, protocol.Txn2Tag, func(enqueued bool, sequenceNumber uint64) {
-		callback(enqueued, sequenceNumber)
+		callbackErr = callback(enqueued, sequenceNumber)
 	}); err != nil {
-		callbackError := callback(false, 0)
-		if callbackError != nil {
-			// disconnect from peer - the transaction sync wasn't able to process message sending confirmation
-			tsnc.node.net.Disconnect(unicastPeer)
-		}
+		callbackErr = callback(false, 0)
+	}
+	if callbackErr != nil {
+		// disconnect from peer - the transaction sync wasn't able to process message sending confirmation
+		tsnc.node.net.Disconnect(unicastPeer)
 	}
 }
 

--- a/txnsync/emulatorNode_test.go
+++ b/txnsync/emulatorNode_test.go
@@ -315,10 +315,13 @@ func (n *emulatedNode) step() {
 			dm := peer.deferredSentMessages[0]
 			peer.deferredSentMessages = peer.deferredSentMessages[1:]
 			peer.mu.Unlock()
-			dm.callback(true, dm.seq)
+			err := dm.callback(true, dm.seq)
 			n.unblock()
 			n.waitBlocked()
 			peer.mu.Lock()
+			if err != nil {
+				panic(err)
+			}
 		}
 
 		for i := len(peer.messageQ); i > 0; i-- {

--- a/txnsync/interfaces.go
+++ b/txnsync/interfaces.go
@@ -48,7 +48,7 @@ type Event struct {
 type IncomingMessageHandler func(networkPeer interface{}, peer *Peer, message []byte, sequenceNumber uint64) error
 
 // SendMessageCallback define a message sent feedback for performing message tracking
-type SendMessageCallback func(enqueued bool, sequenceNumber uint64)
+type SendMessageCallback func(enqueued bool, sequenceNumber uint64) error
 
 // PeerInfo describes a single peer returned by GetPeers or GetPeer
 type PeerInfo struct {


### PR DESCRIPTION
## Summary

Add error handling for outgoing messages:
1. If we fail to send a message to a peer, disconnect the peer ( it's probably already disconnected. But we can't tell that for sure ).
2. If the txnsync internally unable to enqueue the response for the successfully sent message, disconnect from peer. ( we could probably do better here, but that's an issue for future PR ).
3. In the emulator, detect txnsync error and panic on it.

## Test Plan

1. Emulator
2. Performance testing
3. Reviewing log files under load.