### PR TITLE
txpool: Fix incorrect datatype checking in recomputeBlockEvaluator

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -695,7 +695,7 @@ func (pool *TransactionPool) recomputeBlockEvaluator(committedTxIds map[transact
 			}
 
 			switch err.(type) {
-			case ledgercore.TransactionInLedgerError:
+			case *ledgercore.TransactionInLedgerError:
 				asmStats.CommittedCount++
 				stats.RemovedInvalidCount++
 			case transactions.TxnDeadError:


### PR DESCRIPTION
## Summary

When the recomputeBlockEvaluator runs, it tests all the pending transactions against the ledger to detect duplicate transactions ( which happen all the time; these aren't an issue ).
The block evaluator reports the error by returning `*ledgercore.TransactionInLedgerError` and not `ledgercore.TransactionInLedgerError` as the code was testing against.

## Note
Yet another one character bug fix.


## Test Plan

The bug would only affect the reported block assembly stats, and therefore the issue was validated against the telemetry.
