### PR TITLE
fix the systemctl conditional so it restarts with systemd

### DIFF
--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -375,7 +375,7 @@ function run_systemd_action() {
                 echo "systemd system service: $action"
                 return 0
             fi
-        elif grep sudo <(groups "$process_owner" &> /dev/null); then
+        elif grep sudo <(groups "$process_owner") &> /dev/null; then
             if sudo -n systemctl "$action" "algorand@$(systemd-escape "$data_dir")"; then
                 echo "sudo -n systemd system service: $action"
                 return 0


### PR DESCRIPTION
## Summary

Fix systemctl condition so that it will restart with systemd

## Test Plan

```
# Make changes to cmd/updater/update.sh and add the following:
# cp /home/ubuntu/go-algorand/cmd/updater/update.sh "${UPDATESRCDIR}/bin/${FILENAME}"
# add it above the following line so that the update script doesn't get overwritten while testing.:
# exec "${UPDATESRCDIR}/bin/${FILENAME}" ${INSTALLOPT} -r -c ${CHANNEL} ${DATADIRSPEC} ${NOSTART} ${BINDIRSPEC} ${HOSTEDSPEC} ${GENESIS_NETWORK_DIR_SPEC} ${UNKNOWNARGS[@]}

cd ~/go-algorand && ./scripts/configure_dev.sh
make install
cd /home/ubuntu/go/bin
sudo ./systemd-setup.sh ubuntu ubuntu
sudo systemctl daemon-reload
export ALGORAND_DATA=~/.algorand
sudo systemctl start algorand@$(systemd-escape $ALGORAND_DATA)
sudo systemctl status algorand@$(systemd-escape $ALGORAND_DATA)

curl http://$(cat ~/.algorand/algod.net)/versions # 2.5.4
./algod -v # 2.5.4

./update.sh -u -c stable-tmp -p . -d ~/.algorand
./algod -v # becomes latest 2.5.6 
curl http://$(cat ~/.algorand/algod.net)/versions # remains 2.5.4 without the execstart change but updates to 2.5.6 with the new change
sudo systemctl status algorand@$(systemd-escape $ALGORAND_DATA)
```
