### PR TITLE
bugfix: ensure stopping a node always stops kmd

### DIFF
--- a/nodecontrol/NodeController.go
+++ b/nodecontrol/NodeController.go
@@ -101,13 +101,13 @@ func (nc NodeController) FullStop() error {
 
 // stopProcesses attempts to read PID files for algod and kmd and kill the
 // corresponding processes. If it can't read a PID file, it doesn't return an
-// error, but if it reads a PID file and the process doesn't die, it does
+// error, but if it reads a PID file and the process doesn't die, it does.
 func (nc NodeController) stopProcesses() (kmdAlreadyStopped bool, err error) {
-	err = nc.StopAlgod()
-	if err != nil {
-		return
-	}
+	errAlgod := nc.StopAlgod()
 	kmdAlreadyStopped, err = nc.StopKMD()
+	if errAlgod != nil {
+		err = errAlgod
+	}
 	return
 }
 

--- a/test/e2e-go/cli/goal/expect/goalNodeTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalNodeTest.exp
@@ -102,6 +102,6 @@ if { [catch {
 
     exit 0
 } EXCEPTION] } {
-    puts "ERROR in goalNodeStartSystemdTest: $EXCEPTION"
+    puts "ERROR in goalNodeTest: $EXCEPTION"
     exit 1
 }


### PR DESCRIPTION
## Summary

Existing implementation was not stopping the KMD in case we have failed to stop `algod`. This is wrong. A call to `NodeController.FullStop` should stop both of them, and return an error if it's unable to do so.

The concrete use case here was that algod has crashed while kmd remained in memory. Calling the above `FullStop()` failed since the `algod` was already gone, and therefore would not attempt to stop `kmd`.

## Test Plan

This issue was uncovered by the expect node test.