### PR TITLE
Fix go vet error for string(int) conversion in TestWebsocketNetworkCancel

### DIFF
--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -388,7 +388,7 @@ func TestWebsocketNetworkCancel(t *testing.T) {
 	data := make([][]byte, 100)
 	for i := range data {
 		tags[i] = protocol.TxnTag
-		data[i] = []byte(string(i))
+		data[i] = []byte(string(rune(i)))
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary

Go 1.15 introduced a new check in the vet tool for `string(int)` conversion that is enabled by default when running `go test`, causing the TestWebsocketNetworkCancel test to fail. This replaces int-to-string conversion with the first recommended solution from the [Go 1.15 release notes](https://golang.org/doc/go1.15#vet):

> Experience with Go has shown that many conversions of this form erroneously assume that `string(x)` evaluates to the string representation of the integer x. It actually evaluates to a string containing the UTF-8 encoding of the value of x. ...
>
> Code that is using `string(x)` correctly can be rewritten to `string(rune(x))`. Or, in some cases, calling `utf8.EncodeRune(buf, x)` with a suitable byte slice `buf` may be the right solution. Other code should most likely use `strconv.Itoa` or `fmt.Sprint`.

## Test Plan

This fixes a unit test.