### PR TITLE
network: start network only after handlers registration is complete

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -340,13 +340,19 @@ func (node *AlgorandFullNode) Start() {
 	// Set up a context we can use to cancel goroutines on Stop()
 	node.ctx, node.cancelCtx = context.WithCancel(context.Background())
 
-	node.config.NetAddress, _ = node.net.Address()
-
-	if node.catchpointCatchupService != nil {
+	// The start network is being called only after the various services start up.
+	// We want to do so in order to let the services register their callbacks with the
+	// network package before any connections are being made.
+	startNetwork := func() {
 		if !node.config.DisableNetworking {
 			// start accepting connections
 			node.net.Start()
+			node.config.NetAddress, _ = node.net.Address()
 		}
+	}
+
+	if node.catchpointCatchupService != nil {
+		startNetwork()
 		node.catchpointCatchupService.Start(node.ctx)
 	} else {
 		node.catchupService.Start()
@@ -356,11 +362,7 @@ func (node *AlgorandFullNode) Start() {
 		node.ledgerService.Start()
 		node.txHandler.Start()
 		node.compactCert.Start()
-		if !node.config.DisableNetworking {
-			// start accepting connections
-			node.net.Start()
-		}
-
+		startNetwork()
 		// start indexer
 		if idx, err := node.Indexer(); err == nil {
 			err := idx.Start()

--- a/node/node.go
+++ b/node/node.go
@@ -340,13 +340,13 @@ func (node *AlgorandFullNode) Start() {
 	// Set up a context we can use to cancel goroutines on Stop()
 	node.ctx, node.cancelCtx = context.WithCancel(context.Background())
 
-	if !node.config.DisableNetworking {
-		// start accepting connections
-		node.net.Start()
-	}
 	node.config.NetAddress, _ = node.net.Address()
 
 	if node.catchpointCatchupService != nil {
+		if !node.config.DisableNetworking {
+			// start accepting connections
+			node.net.Start()
+		}
 		node.catchpointCatchupService.Start(node.ctx)
 	} else {
 		node.catchupService.Start()
@@ -356,6 +356,10 @@ func (node *AlgorandFullNode) Start() {
 		node.ledgerService.Start()
 		node.txHandler.Start()
 		node.compactCert.Start()
+		if !node.config.DisableNetworking {
+			// start accepting connections
+			node.net.Start()
+		}
 
 		// start indexer
 		if idx, err := node.Indexer(); err == nil {


### PR DESCRIPTION
## Summary

The various services used to register to the network callbacks as soon as they started. This was working mostly fine - but allowed a potential window where a connection could be established, and a message slip through. That message would not have a registered handler associated ( yet ), and therefore would be dropped.

The solution here is to flip the order : instead of starting the network first, and then starting all the rest of the component, we will start each of the components first, followed by starting the network. The current network implementation already knows how to provide buffering, and these would be more then adequate for the short period of time between the components starting and the network establishing it's connections.


## Test Plan

Existing tests already cover these scenarios.
Providing a concrete test for this is hard - since our implementation is designed to recover around these particular issues. For testing purposes, I used the upgrade tests (TestAccountsCanSendMoneyAcrossUpgradeV24toV25) and ran all of them in parallel. Prior to this change, I was able to see that only one network was making progress, whereas all the rest of them were "stuck" on round 0 for a long time. After applying this change, it looks like it helped improving the "kick-off" for all of these networks.