### PR TITLE
Add mention of install_buildtools.sh to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Initial environment setup:
 git clone https://github.com/algorand/go-algorand
 cd go-algorand
 ./scripts/configure_dev.sh
+./scripts/buildtools/install_buildtools.sh
 ```
 
 At this point you are ready to build go-algorand. We use `make` and have a


### PR DESCRIPTION
## Summary

Recently the build tooling was updated in #2108 which split out the installation of Go tools golint, stringer, swagger, msgp into a separate script `install_buildtools.sh`. This updates the README to reflect that in the environment setup instructions.