### PR TITLE
Re-enable gofmt check during travis build

### DIFF
--- a/catchup/fetcher_test.go
+++ b/catchup/fetcher_test.go
@@ -232,7 +232,7 @@ type testUnicastPeer struct {
 	version          string
 	responseChannels map[uint64]chan *network.Response
 	t                *testing.T
-	responseOverride *network.Response 
+	responseOverride *network.Response
 }
 
 func (p *testUnicastPeer) GetAddress() string {
@@ -258,7 +258,7 @@ func (p *testUnicastPeer) Request(ctx context.Context, tag protocol.Tag, topics 
 	if p.responseOverride != nil {
 		return p.responseOverride, nil
 	}
-	
+
 	// wait for the channel.
 	select {
 	case resp = <-responseChannel:

--- a/catchup/peerSelector.go
+++ b/catchup/peerSelector.go
@@ -155,16 +155,16 @@ func (hs *historicStats) updateRequestPenalty(counter uint64) float64 {
 		hs.gapSum -= 1.0 / float64(hs.requestGaps[0])
 		hs.requestGaps = hs.requestGaps[1:]
 	}
-	
+
 	hs.requestGaps = append(hs.requestGaps, newGap)
 	hs.gapSum += 1.0 / float64(newGap)
-	
+
 	return hs.computerPenalty()
 }
 
 // resetRequestPenalty removes steps least recent gaps and recomputes the new penalty.
 // Returns the new rank calculated with the new penalty.
-// If steps is 0, it is a full reset i.e. drops all gap values. 
+// If steps is 0, it is a full reset i.e. drops all gap values.
 func (hs *historicStats) resetRequestPenalty(steps int, initialRank int, class peerClass) (rank int) {
 	if len(hs.requestGaps) == 0 {
 		return initialRank

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -805,7 +805,6 @@ func TestCreatePeerSelector(t *testing.T) {
 	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[1].peerClass)
 	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].peerClass)
 
-	
 	// cfg.EnableCatchupFromArchiveServers = true;  cfg.NetAddress != ""; pipelineFetch = false
 	cfg.EnableCatchupFromArchiveServers = true
 	cfg.NetAddress = "someAddress"
@@ -880,7 +879,7 @@ func TestCreatePeerSelector(t *testing.T) {
 	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
 	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[1].peerClass)
 	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].peerClass)
-	
+
 	// cfg.EnableCatchupFromArchiveServers = false; cfg.NetAddress == ""; pipelineFetch = false
 	cfg.EnableCatchupFromArchiveServers = false
 	cfg.NetAddress = ""
@@ -903,7 +902,7 @@ func TestServiceStartStop(t *testing.T) {
 	s.Start()
 	s.Stop()
 	_, ok := (<-s.done)
-	require.False(t, ok)	
+	require.False(t, ok)
 }
 
 func TestSynchronizingTime(t *testing.T) {

--- a/catchup/universalFetcher.go
+++ b/catchup/universalFetcher.go
@@ -310,14 +310,14 @@ func (wbfpe errWrongBlockFromPeer) Error() string {
 type errCannotDecodeBlock struct {
 	round basics.Round
 	peer  string
-	err error
+	err   error
 }
 
 func makeErrCannotDecodeBlock(round basics.Round, peer string, err error) errCannotDecodeBlock {
 	return errCannotDecodeBlock{
 		round: round,
 		peer:  peer,
-		err: err}
+		err:   err}
 }
 
 func (cdbe errCannotDecodeBlock) Error() string {
@@ -342,7 +342,7 @@ func makeErrWsFetcherRequestFailed(round basics.Round, peer, cause string) errWs
 		cause: cause}
 }
 
-func (wrfe errWsFetcherRequestFailed)Error () string {
+func (wrfe errWsFetcherRequestFailed) Error() string {
 	return fmt.Sprintf("wsFetcherClient(%s).requestBlock(%d): Request failed: %s",
 		wrfe.peer, wrfe.round, wrfe.cause)
 }

--- a/catchup/universalFetcher_test.go
+++ b/catchup/universalFetcher_test.go
@@ -208,7 +208,7 @@ func TestRequestBlockBytesErrors(t *testing.T) {
 
 	_, _, _, err = fetcher.fetchBlock(ctx, next, up)
 	require.True(t, errors.As(err, &wrfe))
-	require.Equal(t, "Block data not found", err.(errWsFetcherRequestFailed).cause)	
+	require.Equal(t, "Block data not found", err.(errWsFetcherRequestFailed).cause)
 }
 
 type TestHTTPHandler struct {
@@ -272,14 +272,15 @@ func TestGetBlockBytesHTTPErrors(t *testing.T) {
 	require.Equal(t, 2, err.(errHTTPResponseContentType).contentTypeCount)
 }
 
-type ErrTest struct {}
+type ErrTest struct{}
+
 func (et ErrTest) Error() string {
 	return "test"
 }
 
 // TestErrorTypes tests the error types are implemented correctly
 func TestErrorTypes(t *testing.T) {
-	err1 := makeErrWrongCertFromPeer(1, 2, "somepeer1") 
+	err1 := makeErrWrongCertFromPeer(1, 2, "somepeer1")
 	require.Equal(t, "processBlockBytes: got wrong cert from peer somepeer1: wanted 1, got 2", err1.Error())
 
 	err2 := makeErrWrongBlockFromPeer(2, 3, "somepeer2")
@@ -288,7 +289,7 @@ func TestErrorTypes(t *testing.T) {
 	err3 := makeErrCannotDecodeBlock(3, "somepeer3", fmt.Errorf("WrappedError %w", ErrTest{}))
 	require.Equal(t, "processBlockBytes: cannot decode block 3 from peer somepeer3: WrappedError test", err3.Error())
 	var et ErrTest
-	require.True(t, errors.As(err3, &et))		
+	require.True(t, errors.As(err3, &et))
 
 	err4 := makeErrWsFetcherRequestFailed(4, "somepeer4", "somecause1")
 	require.Equal(t, "wsFetcherClient(somepeer4).requestBlock(4): Request failed: somecause1", err4.Error())

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -2844,7 +2844,7 @@ func benchmarkExpensiveProgram(b *testing.B, source string) {
 // during the "operation".  They are presumed to be fast (15/ns), so
 // the idea is that you can subtract that out from the reported speed
 func benchmarkOperation(b *testing.B, prefix string, operation string, suffix string) {
-	runs := 1 + b.N / 2000
+	runs := 1 + b.N/2000
 	inst := strings.Count(operation, ";") + strings.Count(operation, "\n")
 	source := prefix + ";" + strings.Repeat(operation+";", 2000) + ";" + suffix
 	source = strings.ReplaceAll(source, ";", "\n")
@@ -2870,7 +2870,7 @@ func BenchmarkUintMath(b *testing.B) {
 	}
 	for _, bench := range benches {
 		b.Run(bench[0], func(b *testing.B) {
-			benchmarkOperation(b, bench[1], bench[2], bench[3]);
+			benchmarkOperation(b, bench[1], bench[2], bench[3])
 		})
 	}
 }
@@ -2879,7 +2879,7 @@ func BenchmarkUintCmp(b *testing.B) {
 	ops := []string{"==", "!=", "<", "<=", ">", ">="}
 	for _, op := range ops {
 		b.Run(op, func(b *testing.B) {
-			benchmarkOperation(b, "", "int 7263; int 273834; "+op+"; pop", "int 1");
+			benchmarkOperation(b, "", "int 7263; int 273834; "+op+"; pop", "int 1")
 		})
 	}
 }
@@ -2887,7 +2887,7 @@ func BenchmarkBigLogic(b *testing.B) {
 	benches := [][]string{
 		{"b&", "byte 0x01234576", "byte 0x01ffffffffffffff; b&", "pop; int 1"},
 		{"b|", "byte 0x0ffff1234576", "byte 0x1202; b|", "pop; int 1"},
-		{"b^", "byte 0x01234576",  "byte 0x0223627389; b^", "pop; int 1"},
+		{"b^", "byte 0x01234576", "byte 0x0223627389; b^", "pop; int 1"},
 		{"b~", "byte 0x0123457673624736", "b~", "pop; int 1"},
 
 		{"b&big",
@@ -2898,7 +2898,7 @@ func BenchmarkBigLogic(b *testing.B) {
 			"byte 0x0123457601234576012345760123457601234576012345760123457601234576",
 			"byte           0xffffff01ffffffffffffff01234576012345760123457601234576; b|",
 			"pop; int 1"},
-		{"b^big", "",	// u256*u256
+		{"b^big", "", // u256*u256
 			`byte 0x123457601234576012345760123457601234576012345760123457601234576a
 			 byte 0xf123457601234576012345760123457601234576012345760123457601234576; b^; pop`,
 			"int 1"},
@@ -2908,7 +2908,7 @@ func BenchmarkBigLogic(b *testing.B) {
 	}
 	for _, bench := range benches {
 		b.Run(bench[0], func(b *testing.B) {
-			benchmarkOperation(b, bench[1], bench[2], bench[3]);
+			benchmarkOperation(b, bench[1], bench[2], bench[3])
 		})
 	}
 }
@@ -2923,30 +2923,30 @@ func BenchmarkBigMath(b *testing.B) {
 		{"b/", "", "byte 0x0123457673624736; byte 0x0223627389; b/; pop", "int 1"},
 		{"b%", "", "byte 0x0123457673624736; byte 0x0223627389; b/; pop", "int 1"},
 
-		{"b+big",	// u256 + u256
+		{"b+big", // u256 + u256
 			"byte 0x0123457601234576012345760123457601234576012345760123457601234576",
 			"byte 0x01ffffffffffffff01ffffffffffffff01234576012345760123457601234576; b+",
 			"pop; int 1"},
-		{"b-big",	// second is a bit small, so we can subtract it over and over
+		{"b-big", // second is a bit small, so we can subtract it over and over
 			"byte 0x0123457601234576012345760123457601234576012345760123457601234576",
 			"byte           0xffffff01ffffffffffffff01234576012345760123457601234576; b-",
 			"pop; int 1"},
-		{"b*big", "",	// u256*u256
+		{"b*big", "", // u256*u256
 			`byte 0xa123457601234576012345760123457601234576012345760123457601234576
 			 byte 0xf123457601234576012345760123457601234576012345760123457601234576; b*; pop`,
 			"int 1"},
-		{"b/big", "",	// u256 / u128 (half sized divisor seems pessimal)
+		{"b/big", "", // u256 / u128 (half sized divisor seems pessimal)
 			`byte 0xa123457601234576012345760123457601234576012345760123457601234576
 			 byte 0x34576012345760123457601234576312; b/; pop`,
 			"int 1"},
-		{"b%big", "",	// u256 / u128 (half sized divisor seems pessimal)
+		{"b%big", "", // u256 / u128 (half sized divisor seems pessimal)
 			`byte 0xa123457601234576012345760123457601234576012345760123457601234576
 			 byte 0x34576012345760123457601234576312; b/; pop`,
 			"int 1"},
 	}
 	for _, bench := range benches {
 		b.Run(bench[0], func(b *testing.B) {
-			benchmarkOperation(b, bench[1], bench[2], bench[3]);
+			benchmarkOperation(b, bench[1], bench[2], bench[3])
 		})
 	}
 }
@@ -2956,23 +2956,22 @@ func BenchmarkHash(b *testing.B) {
 	for _, hash := range hashes {
 		b.Run(hash+"-small", func(b *testing.B) { // hash 32 bytes
 			benchmarkOperation(b, "byte 0x1234567890", hash,
-				"pop; int 1");
+				"pop; int 1")
 		})
 	}
 	for _, hash := range hashes {
 		b.Run(hash+"-med", func(b *testing.B) { // hash 128 bytes
 			benchmarkOperation(b, "byte 0x1234567890",
-				hash+"; dup; concat; dup; concat", "pop; int 1");
+				hash+"; dup; concat; dup; concat", "pop; int 1")
 		})
 	}
 	for _, hash := range hashes {
 		b.Run(hash+"-big", func(b *testing.B) { // hash 512 bytes
 			benchmarkOperation(b, "byte 0x1234567890",
-				hash+"; dup; concat; dup; concat; dup; concat; dup; concat", "pop; int 1");
+				hash+"; dup; concat; dup; concat; dup; concat; dup; concat", "pop; int 1")
 		})
 	}
 }
-
 
 func BenchmarkAddx64(b *testing.B) {
 	progs := [][]string{
@@ -3054,7 +3053,6 @@ ed25519verify`, pkStr), v)
 		})
 	}
 }
-
 
 func BenchmarkEd25519Verifyx1(b *testing.B) {
 	//benchmark setup

--- a/network/requestTracker.go
+++ b/network/requestTracker.go
@@ -379,11 +379,11 @@ func (rt *RequestTracker) Close() error {
 	return rt.listener.Close()
 }
 
-func (rt *RequestTracker) getWaitUntilNoConnectionsChannel(checkInterval time.Duration) <-chan struct{}{
+func (rt *RequestTracker) getWaitUntilNoConnectionsChannel(checkInterval time.Duration) <-chan struct{} {
 	done := make(chan struct{})
 
 	go func() {
-		checkEmpty := func (rt *RequestTracker) bool {
+		checkEmpty := func(rt *RequestTracker) bool {
 			rt.httpConnectionsMu.Lock()
 			defer rt.httpConnectionsMu.Unlock()
 			return len(rt.httpConnections) == 0

--- a/scripts/travis/codegen_verification.sh
+++ b/scripts/travis/codegen_verification.sh
@@ -28,10 +28,7 @@ eval "$(~/gimme "${GOLANG_VERSION}")"
 make gen
 
 function runGoFmt() {
-    gofiles="$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$' | grep -v ^vendor/)" || true
-    [ -z "$gofiles" ] && return 0
-
-    unformatted=$(gofmt -l $gofiles)
+    unformatted=$(gofmt -l .)
     [ -z "$unformatted" ] && return 0
 
     # Some files are not gofmt'd. Print message and fail.

--- a/util/process_windows.go
+++ b/util/process_windows.go
@@ -151,7 +151,7 @@ func getChildProcesses(pid int) []int {
 }
 
 func killProcess(pid int) error {
-	h, err := syscall.OpenProcess(syscall.SYNCHRONIZE | syscall.PROCESS_TERMINATE, false, uint32(pid))
+	h, err := syscall.OpenProcess(syscall.SYNCHRONIZE|syscall.PROCESS_TERMINATE, false, uint32(pid))
 	if err == nil {
 		err = syscall.TerminateProcess(h, STATUS_CANCELLED)
 		if err == nil {


### PR DESCRIPTION
## Summary

While talking to @tsachiherman we noticed stray fmt'd files in my repo after running `make sanity`, and he suggested submitting a fix PR. I discovered this shell line generated a list of `gofiles` that is always empty, probably because the way we set up builds for branches (and vendoring) has changed since it was written.

## Test Plan

This re-enables gofmt checking in TravisCI builds.