### PR TITLE
Bugfix/cicdnightly

### DIFF
--- a/scripts/deploy_private_version.sh
+++ b/scripts/deploy_private_version.sh
@@ -97,7 +97,7 @@ fi
 
 # modify genesis.json to use a custom network name to prevent SRV record resolving
 TEMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t "tmp")
-cp gen/${DEFAULTNETWORK}/genesis.json ${TEMPDIR}
+cp installer/genesis/${DEFAULTNETWORK}/genesis.json ${TEMPDIR}
 trap "cp ${TEMPDIR}/genesis.json gen/${DEFAULTNETWORK};rm -rf ${TEMPDIR}" 0
 if [[ "${GENESISFILE}" = "" ]]; then
     sed "s/${DEFAULTNETWORK}/${NETWORK}/" ${TEMPDIR}/genesis.json > gen/${DEFAULTNETWORK}/genesis.json

--- a/scripts/deploy_private_version.sh
+++ b/scripts/deploy_private_version.sh
@@ -97,12 +97,11 @@ fi
 
 # modify genesis.json to use a custom network name to prevent SRV record resolving
 TEMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t "tmp")
-echo "test cp installer/genesis/${DEFAULTNETWORK}/genesis.json ${TEMPDIR}"
-ls -al
-pwd
 cp installer/genesis/${DEFAULTNETWORK}/genesis.json ${TEMPDIR}
-echo "cp ${TEMPDIR}/genesis.json gen/pregen/${DEFAULTNETWORK};rm -rf ${TEMPDIR}"
-trap "cp ${TEMPDIR}/genesis.json gen/pregen/${DEFAULTNETWORK};rm -rf ${TEMPDIR}" 0
+# make directory to hold genesis.json file
+mkdir -p "gen/${DEFAULTNETWORK}"
+echo "cp ${TEMPDIR}/genesis.json gen/${DEFAULTNETWORK};rm -rf ${TEMPDIR}"
+trap "cp ${TEMPDIR}/genesis.json gen/${DEFAULTNETWORK};rm -rf ${TEMPDIR}" 0
 echo "if genesis file then sed in GENESISFILE=${GENESISFILE}"
 if [[ "${GENESISFILE}" = "" ]]; then
     echo "${GENESISFILE} was empty"
@@ -110,6 +109,7 @@ if [[ "${GENESISFILE}" = "" ]]; then
     sed "s/${DEFAULTNETWORK}/${NETWORK}/" ${TEMPDIR}/genesis.json > gen/${DEFAULTNETWORK}/genesis.json
 else
     echo "${GENESISFILE} not empty"
+
     cp ${GENESISFILE} gen/${DEFAULTNETWORK}/genesis.json
 fi
 

--- a/scripts/deploy_private_version.sh
+++ b/scripts/deploy_private_version.sh
@@ -97,14 +97,19 @@ fi
 
 # modify genesis.json to use a custom network name to prevent SRV record resolving
 TEMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t "tmp")
-echo "test p installer/genesis/${DEFAULTNETWORK}/genesis.json ${TEMPDIR}"
+echo "test cp installer/genesis/${DEFAULTNETWORK}/genesis.json ${TEMPDIR}"
 ls -al
 pwd
 cp installer/genesis/${DEFAULTNETWORK}/genesis.json ${TEMPDIR}
+echo "cp ${TEMPDIR}/genesis.json gen/pregen/${DEFAULTNETWORK};rm -rf ${TEMPDIR}"
 trap "cp ${TEMPDIR}/genesis.json gen/pregen/${DEFAULTNETWORK};rm -rf ${TEMPDIR}" 0
+echo "if genesis file then sed in GENESISFILE=${GENESISFILE}"
 if [[ "${GENESISFILE}" = "" ]]; then
+    echo "${GENESISFILE} was empty"
+    echo "sed s/${DEFAULTNETWORK}/${NETWORK}/ ${TEMPDIR}/genesis.json > gen/${DEFAULTNETWORK}/genesis.json"
     sed "s/${DEFAULTNETWORK}/${NETWORK}/" ${TEMPDIR}/genesis.json > gen/${DEFAULTNETWORK}/genesis.json
 else
+    echo "${GENESISFILE} not empty"
     cp ${GENESISFILE} gen/${DEFAULTNETWORK}/genesis.json
 fi
 

--- a/scripts/deploy_private_version.sh
+++ b/scripts/deploy_private_version.sh
@@ -99,7 +99,7 @@ fi
 TEMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t "tmp")
 cp installer/genesis/${DEFAULTNETWORK}/genesis.json ${TEMPDIR}
 
-# make directory to hold genesis.json file
+# make directory to hold genesis.json file if it doesn't exist.
 mkdir -p "gen/${DEFAULTNETWORK}"
 trap "cp ${TEMPDIR}/genesis.json gen/${DEFAULTNETWORK};rm -rf ${TEMPDIR}" 0
 if [[ "${GENESISFILE}" = "" ]]; then

--- a/scripts/deploy_private_version.sh
+++ b/scripts/deploy_private_version.sh
@@ -97,6 +97,9 @@ fi
 
 # modify genesis.json to use a custom network name to prevent SRV record resolving
 TEMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t "tmp")
+echo "test p installer/genesis/${DEFAULTNETWORK}/genesis.json ${TEMPDIR}"
+ls -al
+pwd
 cp installer/genesis/${DEFAULTNETWORK}/genesis.json ${TEMPDIR}
 trap "cp ${TEMPDIR}/genesis.json gen/pregen/${DEFAULTNETWORK};rm -rf ${TEMPDIR}" 0
 if [[ "${GENESISFILE}" = "" ]]; then

--- a/scripts/deploy_private_version.sh
+++ b/scripts/deploy_private_version.sh
@@ -98,7 +98,7 @@ fi
 # modify genesis.json to use a custom network name to prevent SRV record resolving
 TEMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t "tmp")
 cp installer/genesis/${DEFAULTNETWORK}/genesis.json ${TEMPDIR}
-trap "cp ${TEMPDIR}/genesis.json gen/${DEFAULTNETWORK};rm -rf ${TEMPDIR}" 0
+trap "cp ${TEMPDIR}/genesis.json gen/pregen/${DEFAULTNETWORK};rm -rf ${TEMPDIR}" 0
 if [[ "${GENESISFILE}" = "" ]]; then
     sed "s/${DEFAULTNETWORK}/${NETWORK}/" ${TEMPDIR}/genesis.json > gen/${DEFAULTNETWORK}/genesis.json
 else

--- a/scripts/deploy_private_version.sh
+++ b/scripts/deploy_private_version.sh
@@ -98,18 +98,13 @@ fi
 # modify genesis.json to use a custom network name to prevent SRV record resolving
 TEMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t "tmp")
 cp installer/genesis/${DEFAULTNETWORK}/genesis.json ${TEMPDIR}
+
 # make directory to hold genesis.json file
 mkdir -p "gen/${DEFAULTNETWORK}"
-echo "cp ${TEMPDIR}/genesis.json gen/${DEFAULTNETWORK};rm -rf ${TEMPDIR}"
 trap "cp ${TEMPDIR}/genesis.json gen/${DEFAULTNETWORK};rm -rf ${TEMPDIR}" 0
-echo "if genesis file then sed in GENESISFILE=${GENESISFILE}"
 if [[ "${GENESISFILE}" = "" ]]; then
-    echo "${GENESISFILE} was empty"
-    echo "sed s/${DEFAULTNETWORK}/${NETWORK}/ ${TEMPDIR}/genesis.json > gen/${DEFAULTNETWORK}/genesis.json"
     sed "s/${DEFAULTNETWORK}/${NETWORK}/" ${TEMPDIR}/genesis.json > gen/${DEFAULTNETWORK}/genesis.json
 else
-    echo "${GENESISFILE} not empty"
-
     cp ${GENESISFILE} gen/${DEFAULTNETWORK}/genesis.json
 fi
 


### PR DESCRIPTION
## Summary

Fix issue `cp: cannot create regular file 'gen/devnet/genesis.json': No such file or directory` by creating a directory if it doesn't exist to store the genesis file. Changed the reference genesis.json file to `installer/genesis/` path.

## Test Plan

Ran the CICD pipeline against the forked repo and branch and it passed the steps that errored previously.
