### PR TITLE
Fixing a bug in eval and TestOnSwitchToUnSupportedProtocol

### DIFF
--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -422,7 +422,6 @@ func TestServiceFetchBlocksMalformed(t *testing.T) {
 }
 
 func TestOnSwitchToUnSupportedProtocol(t *testing.T) {
-	t.Skip("This test is flacky and need to be fixed.")
 
 	// Test the interruption in the initial loop
 	// This cannot happen in practice, but is used to test the code.
@@ -535,7 +534,8 @@ func helperTestOnSwitchToUnSupportedProtocol(
 	config := defaultConfig
 	config.CatchupParallelBlocks = 2
 
-	remote, _, blk, err := buildTestLedger(t, bookkeeping.Block{}) //mRemote.blocks[0])
+	block1 := mRemote.blocks[1]
+	remote, _, blk, err := buildTestLedger(t, block1)
 	if err != nil {
 		t.Fatal(err)
 		return local, remote

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -421,97 +421,96 @@ func TestServiceFetchBlocksMalformed(t *testing.T) {
 	//require.True(t, s.fetcherFactory.(*MockedFetcherFactory).fetcher.client.closed)
 }
 
-func TestOnSwitchToUnSupportedProtocol(t *testing.T) {
+// Test the interruption in the initial loop
+// This cannot happen in practice, but is used to test the code.
+func TestOnSwitchToUnSupportedProtocol1(t *testing.T) {
 
-	// Test the interruption in the initial loop
-	// This cannot happen in practice, but is used to test the code.
-	{
-		lastRoundRemote := 5
-		lastRoundLocal := 0
-		roundWithSwitchOn := 0
-		local, remote := helperTestOnSwitchToUnSupportedProtocol(t, lastRoundRemote, lastRoundLocal, roundWithSwitchOn, 0)
+	lastRoundRemote := 5
+	lastRoundLocal := 0
+	roundWithSwitchOn := 0
+	local, remote := helperTestOnSwitchToUnSupportedProtocol(t, lastRoundRemote, lastRoundLocal, roundWithSwitchOn, 0)
 
-		// Last supported round is 0, but is guaranteed
-		// to stop after 2 rounds.
+	// Last supported round is 0, but is guaranteed
+	// to stop after 2 rounds.
 
-		// SeedLookback is 2, which allows two parallel fetches.
-		// i.e. rounds 1 and 2 may be simultaneously fetched.
-		require.Less(t, int(local.LastRound()), 3)
-		require.Equal(t, lastRoundRemote, int(remote.LastRound()))
-		remote.Ledger.Close()
+	// SeedLookback is 2, which allows two parallel fetches.
+	// i.e. rounds 1 and 2 may be simultaneously fetched.
+	require.Less(t, int(local.LastRound()), 3)
+	require.Equal(t, lastRoundRemote, int(remote.LastRound()))
+	remote.Ledger.Close()
+}
+
+// Test the interruption in "the rest" loop
+func TestOnSwitchToUnSupportedProtocol2(t *testing.T) {
+
+	lastRoundRemote := 10
+	lastRoundLocal := 7
+	roundWithSwitchOn := 5
+	local, remote := helperTestOnSwitchToUnSupportedProtocol(t, lastRoundRemote, lastRoundLocal, roundWithSwitchOn, 0)
+	for r := 1; r <= lastRoundLocal; r++ {
+		blk, err := local.Block(basics.Round(r))
+		require.NoError(t, err)
+		require.Equal(t, r, int(blk.Round()))
 	}
+	require.Equal(t, lastRoundLocal, int(local.LastRound()))
+	require.Equal(t, lastRoundRemote, int(remote.LastRound()))
+	remote.Ledger.Close()
+}
 
-	// Test the interruption in "the rest" loop
-	{
-		lastRoundRemote := 10
-		lastRoundLocal := 7
-		roundWithSwitchOn := 5
-		local, remote := helperTestOnSwitchToUnSupportedProtocol(t, lastRoundRemote, lastRoundLocal, roundWithSwitchOn, 0)
-		for r := 1; r <= lastRoundLocal; r++ {
-			blk, err := local.Block(basics.Round(r))
-			require.NoError(t, err)
-			require.Equal(t, r, int(blk.Round()))
-		}
-		require.Equal(t, lastRoundLocal, int(local.LastRound()))
-		require.Equal(t, lastRoundRemote, int(remote.LastRound()))
-		remote.Ledger.Close()
+// Test the interruption with short notice (less than
+// SeedLookback or the number of parallel fetches which in the
+// test is the same: 2)
+// This can not happen in practice, because there will be
+// enough rounds for the protocol upgrade notice.
+func TestOnSwitchToUnSupportedProtocol3(t *testing.T) {
+
+	lastRoundRemote := 14
+	lastRoundLocal := 7
+	roundWithSwitchOn := 7
+	local, remote := helperTestOnSwitchToUnSupportedProtocol(t, lastRoundRemote, lastRoundLocal, roundWithSwitchOn, 0)
+	for r := 1; r <= lastRoundLocal; r = r + 1 {
+		blk, err := local.Block(basics.Round(r))
+		require.NoError(t, err)
+		require.Equal(t, r, int(blk.Round()))
 	}
+	// Since round with switch on (7) can be fetched
+	// Simultaneously with round 8, round 8 might also be
+	// fetched.
+	require.Less(t, int(local.LastRound()), lastRoundLocal+2)
+	require.Equal(t, lastRoundRemote, int(remote.LastRound()))
+	remote.Ledger.Close()
+}
 
-	// Test the interruption with short notice (less than
-	// SeedLookback or the number of parallel fetches which in the
-	// test is the same: 2)
+// Test the interruption with short notice (less than
+// SeedLookback or the number of parallel fetches which in the
+// test is the same: 2)
+// This case is a variation of the previous case. This may
+// happen when the catchup service restart at the round when
+// an upgrade happens.
+func TestOnSwitchToUnSupportedProtocol4(t *testing.T) {
 
-	// This can not happen in practice, because there will be
-	// enough rounds for the protocol upgrade notice.
-	{
-		lastRoundRemote := 14
-		lastRoundLocal := 7
-		roundWithSwitchOn := 7
-		local, remote := helperTestOnSwitchToUnSupportedProtocol(t, lastRoundRemote, lastRoundLocal, roundWithSwitchOn, 0)
-		for r := 1; r <= lastRoundLocal; r = r + 1 {
-			blk, err := local.Block(basics.Round(r))
-			require.NoError(t, err)
-			require.Equal(t, r, int(blk.Round()))
-		}
-		// Since round with switch on (7) can be fetched
-		// Simultaneously with round 8, round 8 might also be
-		// fetched.
-		require.Less(t, int(local.LastRound()), lastRoundLocal+2)
-		require.Equal(t, lastRoundRemote, int(remote.LastRound()))
-		remote.Ledger.Close()
+	lastRoundRemote := 14
+	lastRoundLocal := 7
+	roundWithSwitchOn := 7
+	roundsAlreadyInLocal := 8 // round 0 -> 7
+
+	local, remote := helperTestOnSwitchToUnSupportedProtocol(
+		t,
+		lastRoundRemote,
+		lastRoundLocal,
+		roundWithSwitchOn,
+		roundsAlreadyInLocal)
+
+	for r := 1; r <= lastRoundLocal; r = r + 1 {
+		blk, err := local.Block(basics.Round(r))
+		require.NoError(t, err)
+		require.Equal(t, r, int(blk.Round()))
 	}
-
-	// Test the interruption with short notice (less than
-	// SeedLookback or the number of parallel fetches which in the
-	// test is the same: 2)
-
-	// This case is a variation of the previous case. This may
-	// happen when the catchup service restart at the round when
-	// an upgrade happens.
-	{
-		lastRoundRemote := 14
-		lastRoundLocal := 7
-		roundWithSwitchOn := 7
-		roundsAlreadyInLocal := 8 // round 0 -> 7
-
-		local, remote := helperTestOnSwitchToUnSupportedProtocol(
-			t,
-			lastRoundRemote,
-			lastRoundLocal,
-			roundWithSwitchOn,
-			roundsAlreadyInLocal)
-
-		for r := 1; r <= lastRoundLocal; r = r + 1 {
-			blk, err := local.Block(basics.Round(r))
-			require.NoError(t, err)
-			require.Equal(t, r, int(blk.Round()))
-		}
-		// Since round with switch on (7) is already in the
-		// ledger, round 8 will not be fetched.
-		require.Equal(t, int(local.LastRound()), lastRoundLocal)
-		require.Equal(t, lastRoundRemote, int(remote.LastRound()))
-		remote.Ledger.Close()
-	}
+	// Since round with switch on (7) is already in the
+	// ledger, round 8 will not be fetched.
+	require.Equal(t, int(local.LastRound()), lastRoundLocal)
+	require.Equal(t, lastRoundRemote, int(remote.LastRound()))
+	remote.Ledger.Close()
 }
 
 func helperTestOnSwitchToUnSupportedProtocol(
@@ -541,8 +540,9 @@ func helperTestOnSwitchToUnSupportedProtocol(
 		return local, remote
 	}
 	for i := 1; i < lastRoundRemote; i++ {
-		blk.NextProtocolSwitchOn = mRemote.blocks[i].NextProtocolSwitchOn
-		blk.NextProtocol = mRemote.blocks[i].NextProtocol
+		blk.NextProtocolSwitchOn = mRemote.blocks[i+1].NextProtocolSwitchOn
+		blk.NextProtocol = mRemote.blocks[i+1].NextProtocol
+		// Adds blk.BlockHeader.Round + 1
 		addBlocks(t, remote, blk, 1)
 		blk.BlockHeader.Round++
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

TestOnSwitchToUnSupportedProtocol had multiple segments. This test is separated into multiple tests.

This PR fixes two issues:
1. Fix for a bug in eval: in the event of an error and early termination of the eval, the loading of accounts in a separate go routine was not terminated. loadAccounts will be terminated when eval returns. 
2. TestOnSwitchToUnSupportedProtocol1 had a bug in setting the blocks for protocol switch. The first block was not getting the NextProtocolSwitchOn set to 1. Despite the bug, the test was passing most of the time, and failing some of the time. 
3. TestOnSwitchToUnSupportedProtocol3 had a bug in setting the blocks for protocol switch. AddBlocks starts adding from the next round of the passed block. NextProtocolSwitchOn was getting set one round late.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan
Fix 1 has existing tests covering it.
Fixes 2 and 3 are test fixes.
I ran the tests more than 100 times and all passed. 100 runs was enough to expose the problem.  
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
