### PR TITLE
Combine Clear and Approval Program size limits

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -231,6 +231,9 @@ type ConsensusParams struct {
 	// program in bytes
 	MaxAppProgramLen int
 
+	// maximum total length of an application's programs (approval + clear state)
+	MaxAppTotalProgramLen int
+
 	// extra length for application program in pages. A page is MaxAppProgramLen bytes
 	MaxExtraAppProgramPages int
 
@@ -827,6 +830,7 @@ func initConsensusProtocols() {
 	v24.MaxAppArgs = 16
 	v24.MaxAppTotalArgLen = 2048
 	v24.MaxAppProgramLen = 1024
+	v24.MaxAppTotalProgramLen = 2048 // No effect until v28, when MaxAppProgramLen increased
 	v24.MaxAppKeyLen = 64
 	v24.MaxAppBytesValueLen = 64
 
@@ -932,6 +936,7 @@ func initConsensusProtocols() {
 
 	// Enable support for larger app program size
 	vFuture.MaxExtraAppProgramPages = 3
+	vFuture.MaxAppProgramLen = 2048
 
 	// enable the InitialRewardsRateCalculation fix
 	vFuture.InitialRewardsRateCalculation = true

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -227,11 +227,14 @@ type ConsensusParams struct {
 	// max sum([len(arg) for arg in txn.ApplicationArgs])
 	MaxAppTotalArgLen int
 
-	// maximum length of application approval program or clear state
-	// program in bytes
+	// maximum byte len of application approval program or clear state
+	// When MaxExtraAppProgramPages > 0, this is the size of those pages.
+	// So two "extra pages" would mean 3*MaxAppProgramLen bytes are available.
 	MaxAppProgramLen int
 
 	// maximum total length of an application's programs (approval + clear state)
+	// When MaxExtraAppProgramPages > 0, this is the size of those pages.
+	// So two "extra pages" would mean 3*MaxAppTotalProgramLen bytes are available.
 	MaxAppTotalProgramLen int
 
 	// extra length for application program in pages. A page is MaxAppProgramLen bytes

--- a/data/transactions/logic/README_in.md
+++ b/data/transactions/logic/README_in.md
@@ -36,9 +36,9 @@ Starting from version 2 TEAL evaluator can run programs in two modes:
 2. Application run (stateful)
 
 Differences between modes include:
-1. Max program length (consensus parameters LogicSigMaxSize, MaxApprovalProgramLen and MaxClearStateProgramLen)
+1. Max program length (consensus parameters LogicSigMaxSize, MaxAppProgramLen & MaxExtraAppProgramPages)
 2. Max program cost (consensus parameters LogicSigMaxCost, MaxAppProgramCost)
-3. Opcodes availability. For example, all stateful operations are only available in stateful mode. Refer to [opcodes document](TEAL_opcodes.md) for details.
+3. Opcode availability. For example, all stateful operations are only available in stateful mode. Refer to [opcodes document](TEAL_opcodes.md) for details.
 
 ## Constants
 

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -351,7 +351,7 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 				return fmt.Errorf("local and global state schemas are immutable")
 			}
 			if tx.ExtraProgramPages != 0 {
-				return fmt.Errorf("ExtraProgramPages field is immutable")
+				return fmt.Errorf("tx.ExtraProgramPages is immutable")
 			}
 		}
 
@@ -389,12 +389,17 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 			return fmt.Errorf("tx.ExtraProgramPages too large, max number of extra pages is %d", proto.MaxExtraAppProgramPages)
 		}
 
-		if uint32(len(tx.ApprovalProgram)) > ((1 + tx.ExtraProgramPages) * uint32(proto.MaxAppProgramLen)) {
-			return fmt.Errorf("approval program too long. max len %d bytes", (1+tx.ExtraProgramPages)*uint32(proto.MaxAppProgramLen))
+		lap := len(tx.ApprovalProgram)
+		lcs := len(tx.ClearStateProgram)
+		pages := int(1 + tx.ExtraProgramPages)
+		if lap > pages*proto.MaxAppProgramLen {
+			return fmt.Errorf("approval program too long. max len %d bytes", pages*proto.MaxAppProgramLen)
 		}
-
-		if uint32(len(tx.ClearStateProgram)) > ((1 + tx.ExtraProgramPages) * uint32(proto.MaxAppProgramLen)) {
-			return fmt.Errorf("clear state program too long. max len %d bytes", (1+tx.ExtraProgramPages)*uint32(proto.MaxAppProgramLen))
+		if lcs > pages*proto.MaxAppProgramLen {
+			return fmt.Errorf("clear state program too long. max len %d bytes", pages*proto.MaxAppProgramLen)
+		}
+		if lap+lcs > pages*proto.MaxAppTotalProgramLen {
+			return fmt.Errorf("app programs too long. max total len %d bytes", pages*proto.MaxAppTotalProgramLen)
 		}
 
 		if tx.LocalStateSchema.NumEntries() > proto.MaxLocalSchemaEntries {

--- a/data/transactions/transaction_test.go
+++ b/data/transactions/transaction_test.go
@@ -19,6 +19,7 @@ package transactions
 import (
 	"flag"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/algorand/go-algorand/config"
@@ -228,6 +229,12 @@ func TestWellFormedErrors(t *testing.T) {
 	protoV27 := config.Consensus[protocol.ConsensusV27]
 	addr1, err := basics.UnmarshalChecksumAddress("NDQCJNNY5WWWFLP4GFZ7MEF2QJSMZYK6OWIV2AQ7OMAVLEFCGGRHFPKJJA")
 	require.NoError(t, err)
+	okHeader := Header{
+		Sender:     addr1,
+		Fee:        basics.MicroAlgos{Raw: 1000},
+		LastValid:  105,
+		FirstValid: 100,
+	}
 	usecases := []struct {
 		tx            Transaction
 		spec          SpecialAddresses
@@ -262,15 +269,10 @@ func TestWellFormedErrors(t *testing.T) {
 		},
 		{
 			tx: Transaction{
-				Type: protocol.ApplicationCallTx,
-				Header: Header{
-					Sender:     addr1,
-					Fee:        basics.MicroAlgos{Raw: 1000},
-					LastValid:  105,
-					FirstValid: 100,
-				},
+				Type:   protocol.ApplicationCallTx,
+				Header: okHeader,
 				ApplicationCallTxnFields: ApplicationCallTxnFields{
-					ApplicationID: 0,
+					ApplicationID: 0, // creation
 					ApplicationArgs: [][]byte{
 						[]byte("write"),
 					},
@@ -279,17 +281,67 @@ func TestWellFormedErrors(t *testing.T) {
 			},
 			spec:          specialAddr,
 			proto:         protoV27,
-			expectedError: fmt.Errorf("tx.ExtraProgramPages too large, max number of extra pages is %d", curProto.MaxExtraAppProgramPages),
+			expectedError: fmt.Errorf("tx.ExtraProgramPages too large, max number of extra pages is %d", protoV27.MaxExtraAppProgramPages),
 		},
 		{
 			tx: Transaction{
-				Type: protocol.ApplicationCallTx,
-				Header: Header{
-					Sender:     addr1,
-					Fee:        basics.MicroAlgos{Raw: 1000},
-					LastValid:  105,
-					FirstValid: 100,
+				Type:   protocol.ApplicationCallTx,
+				Header: okHeader,
+				ApplicationCallTxnFields: ApplicationCallTxnFields{
+					ApplicationID:     0, // creation
+					ApprovalProgram:   []byte(strings.Repeat("X", 1025)),
+					ClearStateProgram: []byte("junk"),
 				},
+			},
+			spec:          specialAddr,
+			proto:         protoV27,
+			expectedError: fmt.Errorf("approval program too long. max len 1024 bytes"),
+		},
+		{
+			tx: Transaction{
+				Type:   protocol.ApplicationCallTx,
+				Header: okHeader,
+				ApplicationCallTxnFields: ApplicationCallTxnFields{
+					ApplicationID:     0, // creation
+					ApprovalProgram:   []byte(strings.Repeat("X", 1025)),
+					ClearStateProgram: []byte("junk"),
+				},
+			},
+			spec:  specialAddr,
+			proto: futureProto,
+		},
+		{
+			tx: Transaction{
+				Type:   protocol.ApplicationCallTx,
+				Header: okHeader,
+				ApplicationCallTxnFields: ApplicationCallTxnFields{
+					ApplicationID:     0, // creation
+					ApprovalProgram:   []byte(strings.Repeat("X", 1025)),
+					ClearStateProgram: []byte(strings.Repeat("X", 1025)),
+				},
+			},
+			spec:          specialAddr,
+			proto:         futureProto,
+			expectedError: fmt.Errorf("app programs too long. max total len 2048 bytes"),
+		},
+		{
+			tx: Transaction{
+				Type:   protocol.ApplicationCallTx,
+				Header: okHeader,
+				ApplicationCallTxnFields: ApplicationCallTxnFields{
+					ApplicationID:     0, // creation
+					ApprovalProgram:   []byte(strings.Repeat("X", 1025)),
+					ClearStateProgram: []byte(strings.Repeat("X", 1025)),
+					ExtraProgramPages: 1,
+				},
+			},
+			spec:  specialAddr,
+			proto: futureProto,
+		},
+		{
+			tx: Transaction{
+				Type:   protocol.ApplicationCallTx,
+				Header: okHeader,
 				ApplicationCallTxnFields: ApplicationCallTxnFields{
 					ApplicationID: 1,
 					ApplicationArgs: [][]byte{
@@ -300,17 +352,12 @@ func TestWellFormedErrors(t *testing.T) {
 			},
 			spec:          specialAddr,
 			proto:         futureProto,
-			expectedError: fmt.Errorf("ExtraProgramPages field is immutable"),
+			expectedError: fmt.Errorf("tx.ExtraProgramPages is immutable"),
 		},
 		{
 			tx: Transaction{
-				Type: protocol.ApplicationCallTx,
-				Header: Header{
-					Sender:     addr1,
-					Fee:        basics.MicroAlgos{Raw: 1000},
-					LastValid:  105,
-					FirstValid: 100,
-				},
+				Type:   protocol.ApplicationCallTx,
+				Header: okHeader,
 				ApplicationCallTxnFields: ApplicationCallTxnFields{
 					ApplicationID: 0,
 					ApplicationArgs: [][]byte{

--- a/test/scripts/e2e_client_runner.py
+++ b/test/scripts/e2e_client_runner.py
@@ -13,7 +13,10 @@
 # Usage:
 #  ./e2e_client_runner.py e2e_subs/*.sh
 #
-# Reads each bash script for `# TIMEOUT=N` line to configure timeout to N seconds. (default timeout is 200 seconds)
+# Reads each bash script for `# TIMEOUT=N` line to configure timeout
+# to N seconds. The default is 10 seconds less than the timeout
+# associated with the entire set of tests, which defaults to 500, but
+# can be controlled with --timeout
 
 import argparse
 import atexit
@@ -67,7 +70,7 @@ def read_script_for_timeout(fname):
                     return int(m.group(1))
         except:
             logger.debug('read timeout match err', exc_info=True)
-    return 200
+    return None
 
 
 def create_kmd_config_with_unsafe_scrypt(working_dir):
@@ -94,9 +97,8 @@ def create_kmd_config_with_unsafe_scrypt(working_dir):
         json.dump(kmd_conf_data,f)
 
 
-    
 
-def _script_thread_inner(runset, scriptname):
+def _script_thread_inner(runset, scriptname, timeout):
     start = time.time()
     algod, kmd = runset.connect()
     pubw, maxpubaddr = runset.get_pub_wallet()
@@ -138,7 +140,9 @@ def _script_thread_inner(runset, scriptname):
     p = subprocess.Popen([scriptname, walletname], env=env, cwd=repodir, stdout=cmdlog, stderr=subprocess.STDOUT)
     cmdlog.close()
     runset.running(scriptname, p)
-    timeout = read_script_for_timeout(scriptname)
+    script_timeout = read_script_for_timeout(scriptname)
+    if script_timeout:
+        timeout = script_timeout
     try:
         retcode = p.wait(timeout)
     except subprocess.TimeoutExpired as te:
@@ -175,10 +179,10 @@ def _script_thread_inner(runset, scriptname):
     runset.done(scriptname, retcode == 0, dt)
     return
 
-def script_thread(runset, scriptname):
+def script_thread(runset, scriptname, to):
     start = time.time()
     try:
-        _script_thread_inner(runset, scriptname)
+        _script_thread_inner(runset, scriptname, to)
     except Exception as e:
         logger.error('error in e2e_client_runner.py', exc_info=True)
         runset.done(scriptname, False, time.time() - start)
@@ -218,10 +222,9 @@ class RunSet:
         if self.algod and self.kmd:
             return
 
-
         # should run from inside self.lock
         algodata = self.env['ALGORAND_DATA']
-        
+
         xrun(['goal', 'kmd', 'start', '-t', '3600','-d', algodata], env=self.env, timeout=5)
         self.kmd = openkmd(algodata)
         self.algod = openalgod(algodata)
@@ -250,11 +253,11 @@ class RunSet:
                 self.maxpubaddr = maxpubaddr
             return self.pubw, self.maxpubaddr
 
-    def start(self, scriptname):
+    def start(self, scriptname, timeout):
         with self.lock:
             if not self.ok:
                 return
-        t = threading.Thread(target=script_thread, args=(self, scriptname,))
+        t = threading.Thread(target=script_thread, args=(self, scriptname, timeout))
         t.start()
         with self.lock:
             self.threads[scriptname] = t
@@ -450,7 +453,7 @@ def main():
 
     rs = RunSet(env)
     for scriptname in args.scripts:
-        rs.start(scriptname)
+        rs.start(scriptname, args.timeout-10)
     rs.wait(args.timeout)
     if rs.errors:
         retcode = 1


### PR DESCRIPTION
Apps have been able to use 1k space for each of their programs since apps were introduced in v24.  But clear state programs are quite small.  It is more useful to provide 2k of space, divided however the app prefers.  This PR does that, including giving 2k extra space for each unit of "extra pages" requested at app creation time.

Tests considering before and after consensus updates.
