### PR TITLE
txnsync: recalibrate the MsgDigestSkip threshold

### DIFF
--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -54,7 +54,11 @@ import (
 )
 
 const incomingThreads = 20
-const messageFilterSize = 5000 // messages greater than that size may be blocked by incoming/outgoing filter
+
+// messageFilterSize is the threshold beyond we send a request to the other peer to avoid sending us a message with that particular hash.
+// typically, this is beneficial for proposal messages, which tends to be large and uniform across the network. Non-uniform messages, such
+// as the transaction sync messages should not included in this filter.
+const messageFilterSize = 200000
 
 // httpServerReadHeaderTimeout is the amount of time allowed to read
 // request headers. The connection's read deadline is reset

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -424,7 +424,7 @@ func TestWebsocketNetworkCancel(t *testing.T) {
 		mbytes := make([]byte, len(tbytes)+len(msg))
 		copy(mbytes, tbytes)
 		copy(mbytes[len(tbytes):], msg)
-		msgs = append(msgs, sendMessage{data: mbytes, enqueued: time.Now(), peerEnqueued: enqueueTime, hash: crypto.Hash(mbytes), ctx: context.Background()})
+		msgs = append(msgs, sendMessage{data: mbytes, enqueued: time.Now(), peerEnqueued: enqueueTime, ctx: context.Background()})
 	}
 
 	msgs[50].ctx = ctx

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -98,7 +98,6 @@ type sendMessage struct {
 	peerEnqueued time.Time                            // the time at which the peer was attempting to enqueue the message
 	msgTags      map[protocol.Tag]bool                // when msgTags is speficied ( i.e. non-nil ), the send goroutine is to replace the message tag filter with this one. No data would be accompanied to this message.
 	callback     UnicastWebsocketMessageStateCallback // when non-nil, the callback function would be called after entry would be placed on the outgoing websocket queue
-	hash         crypto.Digest
 	ctx          context.Context
 }
 
@@ -745,7 +744,7 @@ func (wp *wsPeer) writeNonBlockMsgs(ctx context.Context, data [][]byte, highPrio
 	msgs := make([]sendMessage, 0, len(includeIndices))
 	enqueueTime := time.Now()
 	for _, index := range includeIndices {
-		msgs = append(msgs, sendMessage{data: data[index], enqueued: msgEnqueueTime, peerEnqueued: enqueueTime, hash: digest[index], ctx: ctx, callback: callback})
+		msgs = append(msgs, sendMessage{data: data[index], enqueued: msgEnqueueTime, peerEnqueued: enqueueTime, ctx: ctx, callback: callback})
 	}
 
 	if highPrio {


### PR DESCRIPTION
## Summary

Increase the threshold of the filtered message digest size, so that we still keep most of the proposal messages, but eliminate the transaction sync messages.

## Test Plan

Tested by deploying a S1 network and analyzing its MS message counts and overall bandwidth consumption.