### PR TITLE
Extend catchpoint wait for round timeout from 10 to 60 seconds.

### DIFF
--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -220,7 +220,7 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 	targetRound = uint64(37)
 	log.Infof("Second node catching up to round 36")
 	for {
-		err = fixture.ClientWaitForRound(secondNodeRestClient, currentRound, 10000*time.Millisecond)
+		err = fixture.ClientWaitForRound(secondNodeRestClient, currentRound, 60*time.Second)
 		a.NoError(err)
 		if targetRound <= currentRound {
 			break


### PR DESCRIPTION

## Summary

Extend catchpoint test next round timeout from 10 to 60 seconds to avoid test failure.

## Test Plan

Tested locally. 
