### PR TITLE
Check setbyte length properly.

### DIFF
--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -2452,7 +2452,7 @@ func opGetByte(cx *evalContext) {
 	target := cx.stack[prev]
 
 	if idx >= uint64(len(target.Bytes)) {
-		cx.err = errors.New("getbyte index beyond byteslice")
+		cx.err = errors.New("getbyte index beyond array length")
 		return
 	}
 	cx.stack[prev].Uint = uint64(target.Bytes[idx])
@@ -2468,8 +2468,8 @@ func opSetByte(cx *evalContext) {
 		cx.err = errors.New("setbyte value > 255")
 		return
 	}
-	if cx.stack[prev].Uint > uint64(len(cx.stack[pprev].Bytes)) {
-		cx.err = errors.New("setbyte index > byte length")
+	if cx.stack[prev].Uint >= uint64(len(cx.stack[pprev].Bytes)) {
+		cx.err = errors.New("setbyte index beyond array length")
 		return
 	}
 	// Copy to avoid modifying shared slice

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -4004,6 +4004,9 @@ func TestBytes(t *testing.T) {
 
 	testAccepts(t, `byte "john"; int 2; int 105; setbyte; byte "join"; ==`, 3)
 
+	testPanics(t, `global ZeroAddress; dup; concat; int 64; int 7; setbyte; int 1; return`, 3)
+	testAccepts(t, `global ZeroAddress; dup; concat; int 63; int 7; setbyte; int 1; return`, 3)
+
 	// These test that setbyte is not modifying a shared value.
 	// Since neither bytec nor dup copies, the first test is
 	// insufficient, the setbyte changes the original constant (if


### PR DESCRIPTION
We were checking the against the length with > instead of >=.  That's
wrong, so we could cause a panic instead of clean error when trying to
set the byte 1 past the array length.  Fortunately, both have the same
effect: the txn fails. But we should do this properly.  Thanks to
@amityadav0 for the report in #2221.

New unit test to detect regression:
```
	testPanics(t, `global ZeroAddress; dup; concat; int 64; int 7; setbyte; int 1; return`, 3)
	testAccepts(t, `global ZeroAddress; dup; concat; int 63; int 7; setbyte; int 1; return`, 3)
```
