### PR TITLE
Fix and enable TestNewAccountCanGoOnlineAndParticipate

### DIFF
--- a/test/e2e-go/features/multisig/multisig_test.go
+++ b/test/e2e-go/features/multisig/multisig_test.go
@@ -68,7 +68,7 @@ func TestBasicMultisig(t *testing.T) {
 	// fund account with enough Algos to allow for 3 transactions and still keep a minBalance in the account
 	amountToFund := 4*minAcctBalance + 3*minTxnFee
 	curStatus, err := client.Status()
-	fixture.SendMoneyAndWait(curStatus.LastRound, amountToFund, minTxnFee, fundingAddr, multisigAddr)
+	fixture.SendMoneyAndWait(curStatus.LastRound, amountToFund, minTxnFee, fundingAddr, multisigAddr, "")
 	// try to transact with 1 of 3
 	amountToSend := minAcctBalance
 	unsignedTransaction, err := client.ConstructPayment(multisigAddr, addrs[0], minTxnFee, amountToSend, nil, "", [32]byte{}, 0, 0)
@@ -193,7 +193,7 @@ func TestDuplicateKeys(t *testing.T) {
 	amountToFund := 3 * minAcctBalance
 	txnFee := minTxnFee
 	curStatus, _ := client.Status()
-	fixture.SendMoneyAndWait(curStatus.LastRound, amountToFund, txnFee, fundingAddr, multisigAddr)
+	fixture.SendMoneyAndWait(curStatus.LastRound, amountToFund, txnFee, fundingAddr, multisigAddr, "")
 	// try to transact with "1" signature (though, this is a signature from "every" member of the multisig)
 	amountToSend := minAcctBalance
 	unsignedTransaction, err := client.ConstructPayment(multisigAddr, addrs[0], txnFee, amountToSend, nil, "", [32]byte{}, 0, 0)

--- a/test/e2e-go/features/participation/onlineOfflineParticipation_test.go
+++ b/test/e2e-go/features/participation/onlineOfflineParticipation_test.go
@@ -18,13 +18,18 @@ package participation
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/test/e2e-go/globals"
 	"github.com/algorand/go-algorand/test/framework/fixtures"
+
 )
 
 func TestParticipationKeyOnlyAccountParticipatesCorrectly(t *testing.T) {
@@ -96,18 +101,28 @@ func waitForAccountToProposeBlock(a *require.Assertions, fixture *fixtures.RestC
 }
 
 func TestNewAccountCanGoOnlineAndParticipate(t *testing.T) {
-	/*if runtime.GOOS == "darwin" {
-		t.Skip()
-	}
 	if testing.Short() {
 		t.Skip()
-	}*/
-	t.Skip() // temporary disable the test since it's failing.
+	}
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))
 
+	// Make the seed lookback shorter, otherwise will waite for 320 rounds
+	consensus := make(config.ConsensusProtocols)
+	shortPartKeysProtocol := config.Consensus[protocol.ConsensusCurrentVersion]
+	shortPartKeysProtocol.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	shortPartKeysProtocol.SeedLookback = 2
+	shortPartKeysProtocol.SeedRefreshInterval = 8
+	if runtime.GOARCH == "amd64" {
+		// amd64 platforms are generally quite capable, so accelerate the round times to make the test run faster.
+		shortPartKeysProtocol.AgreementFilterTimeoutPeriod0 = 1 * time.Second
+		shortPartKeysProtocol.AgreementFilterTimeout = 1 * time.Second
+	}
+	consensus[protocol.ConsensusVersion("shortpartkeysprotocol")] = shortPartKeysProtocol
+	
 	var fixture fixtures.RestClientFixture
+	fixture.SetConsensus(consensus)
 	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodesOneOnline.json"))
 	defer fixture.Shutdown()
 	client := fixture.LibGoalClient
@@ -159,35 +174,45 @@ func TestNewAccountCanGoOnlineAndParticipate(t *testing.T) {
 	newAccountStatus, err := client.AccountInformation(newAccount)
 	a.NoError(err, "client should be able to get information about new account")
 	a.Equal(basics.Online.String(), newAccountStatus.Status, "new account should be online")
+
+	nodeStatus, _ = client.Status()
+	fundedRoundBefore := nodeStatus.LastRound
+	
 	// account receives almost all of rich account's stake (minus enough to
 	// keep it over MinBalance), so it will be selected for participation
 	amountToSend := richBalance - 3*transactionFee - amountToSendInitial - minAcctBalance
 	fixture.SendMoneyAndWait(onlineRound, amountToSend, transactionFee, richAccount, newAccount)
 
 	nodeStatus, _ = client.Status()
-	fundedRound := nodeStatus.LastRound
+	fundedRoundAfter := nodeStatus.LastRound	
 
-	params, err := client.ConsensusParams(nodeStatus.LastRound)
+	params, err := client.ConsensusParams(fundedRoundAfter)
 	a.NoError(err)
-	lookbackRound := balanceRound(basics.Round(nodeStatus.LastRound), params)
-	delta := int64(nodeStatus.LastRound) - int64(lookbackRound)
-	a.True(delta > 0)
+	fundedAccountRoundBefore := balanceRoundOf(basics.Round(fundedRoundBefore), params)
+	fundedAccountRoundAfter := balanceRoundOf(basics.Round(fundedRoundAfter), params)
 
 	// Need to wait for funding to take effect on selection, then we can see if we're participating
 	// Stop before the account should become eligible for selection so we can ensure it wasn't
-	err = fixture.WaitForRoundWithTimeout(fundedRound + uint64(delta) - 1)
+	err = fixture.ClientWaitForRound(fixture.AlgodClient, uint64(fundedAccountRoundBefore),
+		time.Duration(uint64(globals.MaxTimePerRound) * uint64(fundedAccountRoundBefore)))
+	err = fixture.WaitForRoundWithTimeout(uint64(fundedAccountRoundBefore))
 	a.NoError(err)
 
-	blockWasProposed := fixture.VerifyBlockProposed(newAccount, int(delta)-1)
-	a.False(blockWasProposed, "account should not be selected until BalLookback (round %d) passes", int(delta)-1)
+	blockWasProposed := fixture.VerifyBlockProposedRange(newAccount, int(fundedAccountRoundBefore),
+		int(fundedAccountRoundBefore)-1)
+	a.False(blockWasProposed, "account should not be selected until BalLookback (round %d) passes", int(fundedAccountRoundBefore))
 
-	// check that account starts participating after a while
-	proposalWindow := 20 // arbitrary
-	blockWasProposedByNewAccountRecently := waitForAccountToProposeBlock(a, &fixture, newAccount, proposalWindow)
+	// Now wait until the round where the funded account will be used. Give additonal rounds for stability. 
+	err = fixture.ClientWaitForRound(fixture.AlgodClient, uint64(fundedAccountRoundAfter) + 4,
+		time.Duration(uint64(globals.MaxTimePerRound) * uint64(fundedAccountRoundAfter + 4)))
+	a.NoError(err)
+	
+	blockWasProposedByNewAccountRecently := fixture.VerifyBlockProposedRange(newAccount, int(fundedAccountRoundAfter) + 4,
+		int(fundedAccountRoundAfter) + 3)
 	a.True(blockWasProposedByNewAccountRecently, "newly online account should be proposing blocks")
 }
 
-// helper copied from agreement/selector.go
-func balanceRound(r basics.Round, cparams config.ConsensusParams) basics.Round {
-	return r.SubSaturate(basics.Round(2 * cparams.SeedRefreshInterval * cparams.SeedLookback))
+// Returns the earliest round which will have the balanceRound equal to r
+func balanceRoundOf(r basics.Round, cparams config.ConsensusParams) basics.Round {
+	return basics.Round(2 * cparams.SeedRefreshInterval * cparams.SeedLookback) + r
 }

--- a/test/e2e-go/features/participation/onlineOfflineParticipation_test.go
+++ b/test/e2e-go/features/participation/onlineOfflineParticipation_test.go
@@ -192,7 +192,6 @@ func TestNewAccountCanGoOnlineAndParticipate(t *testing.T) {
 	// Stop before the account should become eligible for selection so we can ensure it wasn't
 	err = fixture.ClientWaitForRound(fixture.AlgodClient, uint64(accountProposesStarting-1),
 		time.Duration(uint64(globals.MaxTimePerRound)*uint64(accountProposesStarting-1)))
-	err = fixture.WaitForRoundWithTimeout(uint64(accountProposesStarting - 1))
 	a.NoError(err)
 
 	// Check if the account did not propose any blocks up to this round

--- a/test/e2e-go/features/participation/onlineOfflineParticipation_test.go
+++ b/test/e2e-go/features/participation/onlineOfflineParticipation_test.go
@@ -25,11 +25,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/config"
-	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/e2e-go/globals"
 	"github.com/algorand/go-algorand/test/framework/fixtures"
-
 )
 
 func TestParticipationKeyOnlyAccountParticipatesCorrectly(t *testing.T) {
@@ -124,7 +123,7 @@ func TestNewAccountCanGoOnlineAndParticipate(t *testing.T) {
 		shortPartKeysProtocol.AgreementFilterTimeout = 1 * time.Second
 	}
 	consensus[protocol.ConsensusVersion("shortpartkeysprotocol")] = shortPartKeysProtocol
-	
+
 	var fixture fixtures.RestClientFixture
 	fixture.SetConsensus(consensus)
 	fixture.Setup(t, filepath.Join("nettemplates", "OneNode.json"))
@@ -192,8 +191,8 @@ func TestNewAccountCanGoOnlineAndParticipate(t *testing.T) {
 	// Need to wait for funding to take effect on selection, then we can see if we're participating
 	// Stop before the account should become eligible for selection so we can ensure it wasn't
 	err = fixture.ClientWaitForRound(fixture.AlgodClient, uint64(accountProposesStarting-1),
-		time.Duration(uint64(globals.MaxTimePerRound) * uint64(accountProposesStarting-1)))
-	err = fixture.WaitForRoundWithTimeout(uint64(accountProposesStarting-1))
+		time.Duration(uint64(globals.MaxTimePerRound)*uint64(accountProposesStarting-1)))
+	err = fixture.WaitForRoundWithTimeout(uint64(accountProposesStarting - 1))
 	a.NoError(err)
 
 	// Check if the account did not propose any blocks up to this round
@@ -201,15 +200,15 @@ func TestNewAccountCanGoOnlineAndParticipate(t *testing.T) {
 		int(accountProposesStarting)-1)
 	a.False(blockWasProposed, "account should not be selected until BalLookback (round %d) passes", int(accountProposesStarting-1))
 
-	// Now wait until the round where the funded account will be used. 
+	// Now wait until the round where the funded account will be used.
 	err = fixture.ClientWaitForRound(fixture.AlgodClient, uint64(accountProposesStarting), 10*globals.MaxTimePerRound)
 	a.NoError(err)
-	
+
 	blockWasProposedByNewAccountRecently := fixture.VerifyBlockProposedRange(newAccount, int(accountProposesStarting), 1)
 	a.True(blockWasProposedByNewAccountRecently, "newly online account should be proposing blocks")
 }
 
 // Returns the earliest round which will have the balanceRound equal to r
 func balanceRoundOf(r basics.Round, cparams config.ConsensusParams) basics.Round {
-	return basics.Round(2 * cparams.SeedRefreshInterval * cparams.SeedLookback) + r
+	return basics.Round(2*cparams.SeedRefreshInterval*cparams.SeedLookback) + r
 }

--- a/test/e2e-go/features/participation/participationRewards_test.go
+++ b/test/e2e-go/features/participation/participationRewards_test.go
@@ -335,7 +335,7 @@ func TestRewardRateRecalculation(t *testing.T) {
 	minFee, minBal, err := fixture.MinFeeAndBalance(curStatus.LastRound)
 	r.NoError(err)
 	deadline := curStatus.LastRound + uint64(5)
-	fixture.SendMoneyAndWait(deadline, amountToSend, minFee, richAccount.Address, rewardsAccount)
+	fixture.SendMoneyAndWait(deadline, amountToSend, minFee, richAccount.Address, rewardsAccount, "")
 
 	blk, err := client.Block(curStatus.LastRound)
 	r.NoError(err)
@@ -361,7 +361,7 @@ func TestRewardRateRecalculation(t *testing.T) {
 	curStatus, err = client.Status()
 	r.NoError(err)
 	deadline = curStatus.LastRound + uint64(5)
-	fixture.SendMoneyAndWait(deadline, amountToSend, minFee, richAccount.Address, rewardsAccount)
+	fixture.SendMoneyAndWait(deadline, amountToSend, minFee, richAccount.Address, rewardsAccount, "")
 
 	rewardRecalcRound = rewardRecalcRound + consensusParams.RewardsRateRefreshInterval
 

--- a/test/framework/fixtures/restClientFixture.go
+++ b/test/framework/fixtures/restClientFixture.go
@@ -267,22 +267,22 @@ func (f *RestClientFixture) WaitForAllTxnsToConfirm(roundTimeout uint64, txidsAn
 
 // SendMoneyAndWait uses the rest client to send money and WaitForTxnConfirmation to wait for the send to confirm
 // it adds some extra error checking as well
-func (f *RestClientFixture) SendMoneyAndWait(curRound, amountToSend, transactionFee uint64, fromAccount, toAccount string) (fundingTxid string) {
+func (f *RestClientFixture) SendMoneyAndWait(curRound, amountToSend, transactionFee uint64, fromAccount, toAccount string, closeToAccount string) (txn v1.Transaction) {
 	client := f.LibGoalClient
 	wh, err := client.GetUnencryptedWalletHandle()
 	require.NoError(f.t, err, "client should be able to get unencrypted wallet handle")
-	fundingTxid = f.SendMoneyAndWaitFromWallet(wh, nil, curRound, amountToSend, transactionFee, fromAccount, toAccount)
+	txn = f.SendMoneyAndWaitFromWallet(wh, nil, curRound, amountToSend, transactionFee, fromAccount, toAccount, closeToAccount)
 	return
 }
 
 // SendMoneyAndWaitFromWallet is as above, but for a specific wallet
-func (f *RestClientFixture) SendMoneyAndWaitFromWallet(walletHandle, walletPassword []byte, curRound, amountToSend, transactionFee uint64, fromAccount, toAccount string) (fundingTxid string) {
+func (f *RestClientFixture) SendMoneyAndWaitFromWallet(walletHandle, walletPassword []byte, curRound, amountToSend, transactionFee uint64, fromAccount, toAccount string, closeToAccount string) (txn v1.Transaction) {
 	client := f.LibGoalClient
-	fundingTx, err := client.SendPaymentFromWallet(walletHandle, walletPassword, fromAccount, toAccount, transactionFee, amountToSend, nil, "", 0, 0)
+	fundingTx, err := client.SendPaymentFromWallet(walletHandle, walletPassword, fromAccount, toAccount, transactionFee, amountToSend, nil, closeToAccount, 0, 0)
 	require.NoError(f.t, err, "client should be able to send money from rich to poor account")
 	require.NotEmpty(f.t, fundingTx.ID().String(), "transaction ID should not be empty")
 	waitingDeadline := curRound + uint64(5)
-	_, err = f.WaitForConfirmedTxn(waitingDeadline, fromAccount, fundingTx.ID().String())
+	txn, err = f.WaitForConfirmedTxn(waitingDeadline, fromAccount, fundingTx.ID().String())
 	require.NoError(f.t, err)
 	return
 }

--- a/test/framework/fixtures/restClientFixture.go
+++ b/test/framework/fixtures/restClientFixture.go
@@ -293,7 +293,7 @@ func (f *RestClientFixture) VerifyBlockProposedRange(account string, fromRound, 
 	c := f.LibGoalClient
 	for i := 0; i < countDownNumRounds; i++ {
 		block, err := c.Block(uint64(fromRound - i))
-		require.NoError(f.t, err, "client failed to get block %d", fromRound - i)
+		require.NoError(f.t, err, "client failed to get block %d", fromRound-i)
 		if block.Proposer == account {
 			blockWasProposed = true
 			break

--- a/test/framework/fixtures/restClientFixture.go
+++ b/test/framework/fixtures/restClientFixture.go
@@ -287,7 +287,7 @@ func (f *RestClientFixture) SendMoneyAndWaitFromWallet(walletHandle, walletPassw
 	return
 }
 
-// VerifyBlockProposed checks the rounds starting at fromRounds and moving backwards checking countDownNumRounds rounds if any
+// VerifyBlockProposedRange checks the rounds starting at fromRounds and moving backwards checking countDownNumRounds rounds if any
 // blocks were proposed by address
 func (f *RestClientFixture) VerifyBlockProposedRange(account string, fromRound, countDownNumRounds int) (blockWasProposed bool) {
 	c := f.LibGoalClient

--- a/test/testdata/nettemplates/OneNode.json
+++ b/test/testdata/nettemplates/OneNode.json
@@ -28,12 +28,7 @@
         { "Name": "Rich",
           "ParticipationOnly": false },
         { "Name": "Partkey",
-          "ParticipationOnly": true }
-      ]
-    },
-    {
-      "Name": "Node",
-      "Wallets": [
+          "ParticipationOnly": true },
         { "Name": "Offline",
           "ParticipationOnly": true }
       ]

--- a/test/testdata/nettemplates/TwoNodesOneOnline.json
+++ b/test/testdata/nettemplates/TwoNodesOneOnline.json
@@ -1,6 +1,7 @@
 {
   "Genesis": {
     "NetworkName": "tbd",
+    "ConsensusProtocol": "shortpartkeysprotocol",
     "Wallets": [
       {
         "Name": "Rich",


### PR DESCRIPTION


<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->
TestNewAccountCanGoOnlineAndParticipate was failing because the test was not waiting enough to get to the round where the newly funded account's funds will be considered for proposing purposes.

- Fixed the calculation of the round when the refunded account can propose. 
- Fixed the way the rounds were considered for deciding when the account is funded, which was prone to race conditions.
- The test was using WaitForRoundWithTimeout which may be very slow if the current round is already ahead. Instead, replaced it with ClientWaitForRound, which does not care if an individual round is delayed.
- Changed the configuration parameters so that the refunded account proposes sooner than the default config values. This is to avoid waiting to round 320. 

## Test Plan
This is a test fix. 
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
