### PR TITLE
Fix rel nightly test by extending catchpoint round timeout

### DIFF
--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -220,7 +220,7 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 	targetRound = uint64(37)
 	log.Infof("Second node catching up to round 36")
 	for {
-		err = fixture.ClientWaitForRound(secondNodeRestClient, currentRound, 10000*time.Millisecond)
+		err = fixture.ClientWaitForRound(secondNodeRestClient, currentRound, 60*time.Second)
 		a.NoError(err)
 		if targetRound <= currentRound {
 			break

--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -200,7 +200,7 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 	targetRound = uint64(1)
 	log.Infof("Second node catching up to round 1")
 	for {
-		err = fixture.ClientWaitForRound(secondNodeRestClient, currentRound, 10000*time.Millisecond)
+		err = fixture.ClientWaitForRound(secondNodeRestClient, currentRound, 60*time.Second)
 		a.NoError(err)
 		if targetRound <= currentRound {
 			break


### PR DESCRIPTION

## Summary

Fix catchpoint unit test by extending timeout from 10 to 60 seconds.

## Test Plan

Tested locally.  
