### PR TITLE
fix docker builds: skip the `make deps`

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -17,5 +17,5 @@ ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH \
     FULLVERSION=${FULLVERSION} \
     PKG_ROOT=${PKG_ROOT}
 WORKDIR $GOPATH/src/github.com/algorand/go-algorand
-RUN scripts/configure_dev-deps.sh && make deps && make clean && scripts/local_install.sh -n
+RUN scripts/configure_dev-deps.sh && make clean && scripts/local_install.sh -n
 ENTRYPOINT ["/bin/bash"]

--- a/docker/build/Dockerfile-deploy
+++ b/docker/build/Dockerfile-deploy
@@ -21,5 +21,5 @@ ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH \
     S3_RELEASE_BUCKET=${S3_RELEASE_BUCKET} \
     NETWORK=${NETWORK}
 WORKDIR $GOPATH/src/github.com/algorand/go-algorand
-RUN scripts/configure_dev-deps.sh && make deps && make clean && find tmp && TMPDIR/deploy_linux_version_exec.sh
+RUN scripts/configure_dev-deps.sh && make clean && find tmp && TMPDIR/deploy_linux_version_exec.sh
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
## Summary

Fix the two docker files - avoid make deps step, which is no longer needed.
The compilation of go-algorand no longer requires the installation ( and therefore the validation ) of the dependencies.

## Test Plan

Tested manually.