### PR TITLE
Remove ci-deps and update GOPROXY in Dockerfiles

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /root
 RUN wget --quiet https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz && tar -xvf go${GOLANG_VERSION}.linux-amd64.tar.gz && mv go /usr/local
 ENV GOROOT=/usr/local/go \
     GOPATH=$HOME/go \
-    GOPROXY=https://pkg.go.dev,https://goproxy.io,direct
+    GOPROXY=https://proxy.golang.org,https://pkg.go.dev,https://goproxy.io,direct
 RUN mkdir -p $GOPATH/src/github.com/algorand
 WORKDIR $GOPATH/src/github.com/algorand
 COPY ./go-algorand ./go-algorand/

--- a/docker/build/Dockerfile-deploy
+++ b/docker/build/Dockerfile-deploy
@@ -6,7 +6,7 @@ WORKDIR /root
 RUN wget --quiet https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz && tar -xvf go${GOLANG_VERSION}.linux-amd64.tar.gz && mv go /usr/local
 ENV GOROOT=/usr/local/go \
     GOPATH=$HOME/go \
-    GOPROXY=https://pkg.go.dev,https://goproxy.io,direct
+    GOPROXY=https://proxy.golang.org,https://pkg.go.dev,https://goproxy.io,direct
 RUN mkdir -p $GOPATH/src/github.com/algorand
 WORKDIR $GOPATH/src/github.com/algorand
 COPY . ./go-algorand/

--- a/docker/build/cicd.alpine.Dockerfile
+++ b/docker/build/cicd.alpine.Dockerfile
@@ -26,7 +26,7 @@ COPY . $GOPATH/src/github.com/algorand/go-algorand
 WORKDIR $GOPATH/src/github.com/algorand/go-algorand
 ENV GCC_CONFIG="--with-arch=armv6" \
     GOPROXY=https://proxy.golang.org,https://pkg.go.dev,https://goproxy.io,direct
-RUN make ci-deps && make clean
+RUN make clean
 RUN rm -rf $GOPATH/src/github.com/algorand/go-algorand && \
     mkdir -p $GOPATH/src/github.com/algorand/go-algorand
 CMD ["/bin/bash"]

--- a/docker/build/cicd.alpine.Dockerfile
+++ b/docker/build/cicd.alpine.Dockerfile
@@ -25,7 +25,7 @@ RUN apk add dpkg && \
 COPY . $GOPATH/src/github.com/algorand/go-algorand
 WORKDIR $GOPATH/src/github.com/algorand/go-algorand
 ENV GCC_CONFIG="--with-arch=armv6" \
-    GOPROXY=https://pkg.go.dev,https://goproxy.io,direct
+    GOPROXY=https://proxy.golang.org,https://pkg.go.dev,https://goproxy.io,direct
 RUN make ci-deps && make clean
 RUN rm -rf $GOPATH/src/github.com/algorand/go-algorand && \
     mkdir -p $GOPATH/src/github.com/algorand/go-algorand

--- a/docker/build/cicd.centos.Dockerfile
+++ b/docker/build/cicd.centos.Dockerfile
@@ -18,7 +18,7 @@ ENV GOROOT=/usr/local/go \
 RUN mkdir -p $GOPATH/src/github.com/algorand
 COPY . $GOPATH/src/github.com/algorand/go-algorand
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH \
-    https://proxy.golang.org,https://pkg.go.dev,https://goproxy.io,direct
+    GOPROXY=https://proxy.golang.org,https://pkg.go.dev,https://goproxy.io,direct
 WORKDIR $GOPATH/src/github.com/algorand/go-algorand
 RUN make clean
 RUN rm -rf $GOPATH/src/github.com/algorand/go-algorand && \

--- a/docker/build/cicd.centos.Dockerfile
+++ b/docker/build/cicd.centos.Dockerfile
@@ -18,7 +18,7 @@ ENV GOROOT=/usr/local/go \
 RUN mkdir -p $GOPATH/src/github.com/algorand
 COPY . $GOPATH/src/github.com/algorand/go-algorand
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH \
-    GOPROXY=https://pkg.go.dev
+    https://proxy.golang.org,https://pkg.go.dev,https://goproxy.io,direct
 WORKDIR $GOPATH/src/github.com/algorand/go-algorand
 RUN make ci-deps && make clean
 RUN rm -rf $GOPATH/src/github.com/algorand/go-algorand && \

--- a/docker/build/cicd.centos.Dockerfile
+++ b/docker/build/cicd.centos.Dockerfile
@@ -20,7 +20,7 @@ COPY . $GOPATH/src/github.com/algorand/go-algorand
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH \
     https://proxy.golang.org,https://pkg.go.dev,https://goproxy.io,direct
 WORKDIR $GOPATH/src/github.com/algorand/go-algorand
-RUN make ci-deps && make clean
+RUN make clean
 RUN rm -rf $GOPATH/src/github.com/algorand/go-algorand && \
     mkdir -p $GOPATH/src/github.com/algorand/go-algorand
 RUN echo "vm.max_map_count = 262144" >> /etc/sysctl.conf

--- a/docker/build/cicd.ubuntu.Dockerfile
+++ b/docker/build/cicd.ubuntu.Dockerfile
@@ -15,9 +15,9 @@ ENV GOROOT=/usr/local/go \
 RUN mkdir -p $GOPATH/src/github.com/algorand
 COPY . $GOPATH/src/github.com/algorand/go-algorand
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH \
-    GOPROXY=https://pkg.go.dev
+    GOPROXY=https://proxy.golang.org,https://pkg.go.dev
 WORKDIR $GOPATH/src/github.com/algorand/go-algorand
-RUN make ci-deps && make clean
+RUN make clean
 RUN rm -rf $GOPATH/src/github.com/algorand/go-algorand && \
     mkdir -p $GOPATH/src/github.com/algorand/go-algorand
 RUN echo "vm.max_map_count = 262144" >> /etc/sysctl.conf

--- a/docker/build/cicd.ubuntu.Dockerfile
+++ b/docker/build/cicd.ubuntu.Dockerfile
@@ -15,7 +15,7 @@ ENV GOROOT=/usr/local/go \
 RUN mkdir -p $GOPATH/src/github.com/algorand
 COPY . $GOPATH/src/github.com/algorand/go-algorand
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH \
-    GOPROXY=https://proxy.golang.org,https://pkg.go.dev
+    GOPROXY=https://proxy.golang.org,https://pkg.go.dev,https://goproxy.io,direct
 WORKDIR $GOPATH/src/github.com/algorand/go-algorand
 RUN make clean
 RUN rm -rf $GOPATH/src/github.com/algorand/go-algorand && \

--- a/scripts/release/mule/Makefile.mule
+++ b/scripts/release/mule/Makefile.mule
@@ -8,7 +8,7 @@ ci-clean:
 	rm -rf tmp
 
 ci-deps:
-	scripts/configure_dev-deps.sh && \
+	scripts/buildtools/install_buildtools.sh && \
 	scripts/check_deps.sh
 
 ci-setup:

--- a/scripts/release/mule/Makefile.mule
+++ b/scripts/release/mule/Makefile.mule
@@ -2,14 +2,10 @@
 
 PKG_DIR = $(SRCPATH)/tmp/node_pkgs/$(OS_TYPE)/$(ARCH)
 
-.PHONY: ci-clean ci-deps ci-setup ci-build
+.PHONY: ci-clean ci-setup ci-build
 
 ci-clean:
 	rm -rf tmp
-
-ci-deps:
-	scripts/buildtools/install_buildtools.sh && \
-	scripts/check_deps.sh
 
 ci-setup:
 	mkdir -p $(PKG_DIR)


### PR DESCRIPTION
## Summary

Recent refactoring has changed dependency installation. ci-deps did not appear to be used in a meaningful way, so it was removed from the Makefile and Dockerfiles. Additionally, downloading from go has become unstable, so updating the GOPROXY options should help.

## Test Plan

Run build pipeline against branch and verify this works.
