### PR TITLE
catchup: speedup initial node DNS bootstrap time

### DIFF
--- a/catchup/service.go
+++ b/catchup/service.go
@@ -481,6 +481,9 @@ func (s *Service) periodicSync() {
 	defer close(s.done)
 	// if the catchup is disabled in the config file, just skip it.
 	if s.parallelBlocks != 0 && !s.cfg.DisableNetworking {
+		// The following request might be redundent, but it ensures we wait long enough for the DNS records to be loaded,
+		// which are required for the sync operation.
+		s.net.RequestConnectOutgoing(false, s.ctx.Done())
 		s.sync()
 	}
 	stuckInARow := 0


### PR DESCRIPTION
## Summary

Ensures that the catchup service have the network library load the DNS records before attempting the first sync - 

Current code was attempting to sync without any DNS records available, failing, and trying again later on. Since the DNS records were being refreshed every 60 seconds, the third or fourth attempt would be successful. This PR attempt to give the catchup service a good chance of succeeding on the first attempt.

## Test Plan

Tested manually.