### PR TITLE
If the branch is rel/nightly set channel to nightly

### DIFF
--- a/scripts/release/mule/common/get_channel.sh
+++ b/scripts/release/mule/common/get_channel.sh
@@ -8,6 +8,10 @@ then
 elif [ "$NETWORK" = mainnet ] || [ "$NETWORK" = testnet ]
 then
     echo stable
+elif [ "$TRAVIS_BRANCH" = 'rel/nightly' ]
+then
+    # The rel/nightly branch is only the nightly channel
+    echo nightly
 else
     echo dev
 fi


### PR DESCRIPTION
## Summary

The way that the new pipeline scripts computed channel did not account for the rel/nightly branch, which should set the channel to nightly. This was preventing rpm and deb binaries from being built. This change identifies if the TRAVIS_BRANCH env is set to rel/nightly, and if so, will set the channel to nightly.

## Test Plan

Verified with: `TRAVIS_BRANCH=rel/nightly ./scripts/release/mule/common/get_channel.sh devnet` which returned nightly. Specifying 'betanet', 'testnet', and 'mainnet' remain the same. 

Should verify with a nightly build using the new pipeline.
