### PR TITLE
Disable compact certs and auction tests

### DIFF
--- a/test/e2e-go/features/auction/auctionCancel_test.go
+++ b/test/e2e-go/features/auction/auctionCancel_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestStartAndCancelAuctionNoBids(t *testing.T) {
+	t.Skip("Disabling since they need work and shouldn't block releases")
 	if testing.Short() {
 		t.Skip()
 	}
@@ -58,6 +59,7 @@ func TestStartAndCancelAuctionNoBids(t *testing.T) {
 }
 
 func TestStartAndCancelAuctionOneUserTenBids(t *testing.T) {
+	t.Skip("Disabling since they need work and shouldn't block releases")
 	if runtime.GOOS == "darwin" {
 		t.Skip()
 	}
@@ -121,6 +123,7 @@ func TestStartAndCancelAuctionOneUserTenBids(t *testing.T) {
 }
 
 func TestStartAndCancelAuctionEarlyOneUserTenBids(t *testing.T) {
+	t.Skip("Disabling since they need work and shouldn't block releases")
 	t.Parallel()
 	r := require.New(fixtures.SynchronizedTest(t))
 	var fixture fixtures.AuctionFixture

--- a/test/e2e-go/features/auction/auctionErrors_test.go
+++ b/test/e2e-go/features/auction/auctionErrors_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestInvalidDeposit(t *testing.T) {
+	t.Skip("Disabling since they need work and shouldn't block releases")
 	if testing.Short() {
 		t.Skip()
 	}
@@ -119,6 +120,7 @@ func TestInvalidDeposit(t *testing.T) {
 }
 
 func TestNoDepositAssociatedWithBid(t *testing.T) {
+	t.Skip("Disabling since they need work and shouldn't block releases")
 	if testing.Short() {
 		t.Skip()
 	}
@@ -190,6 +192,7 @@ func TestNoDepositAssociatedWithBid(t *testing.T) {
 }
 
 func TestDeadbeatBid(t *testing.T) {
+	t.Skip("Disabling since they need work and shouldn't block releases")
 	// an error is expected when an account attempts to overbid
 	t.Parallel()
 	r := require.New(fixtures.SynchronizedTest(t))
@@ -283,6 +286,7 @@ func unpartitionNetwork(fixture *fixtures.AuctionFixture, r *require.Assertions)
 }
 
 func TestStartAndPartitionAuctionTenUsersTenBidsEach(t *testing.T) {
+	t.Skip("Disabling since they need work and shouldn't block releases")
 	if runtime.GOOS == "darwin" {
 		t.Skip()
 	}

--- a/test/e2e-go/features/auction/basicAuction_test.go
+++ b/test/e2e-go/features/auction/basicAuction_test.go
@@ -36,6 +36,7 @@ func detectAuctionCannotProceed(r *require.Assertions, params auction.Params, la
 }
 
 func TestStartAndEndAuctionNoBids(t *testing.T) {
+	t.Skip("Disabling since they need work and shouldn't block releases")
 	if runtime.GOOS == "darwin" {
 		t.Skip()
 	}
@@ -77,6 +78,7 @@ func TestStartAndEndAuctionNoBids(t *testing.T) {
 }
 
 func TestStartAndEndAuctionOneUserOneBid(t *testing.T) {
+	t.Skip("Disabling since they need work and shouldn't block releases")
 	if runtime.GOOS == "darwin" {
 		t.Skip()
 	}
@@ -146,6 +148,7 @@ func TestStartAndEndAuctionOneUserOneBid(t *testing.T) {
 }
 
 func TestStartAndEndAuctionOneUserTenBids(t *testing.T) {
+	t.Skip("Disabling since they need work and shouldn't block releases")
 	if runtime.GOOS == "darwin" {
 		t.Skip()
 	}
@@ -221,6 +224,7 @@ func TestStartAndEndAuctionOneUserTenBids(t *testing.T) {
 }
 
 func TestStartAndEndAuctionTenUsersOneBidEach(t *testing.T) {
+	t.Skip("Disabling since they need work and shouldn't block releases")
 	t.Parallel()
 	r := require.New(fixtures.SynchronizedTest(t))
 	var fixture fixtures.AuctionFixture
@@ -313,6 +317,7 @@ func TestStartAndEndAuctionTenUsersOneBidEach(t *testing.T) {
 }
 
 func TestStartAndEndAuctionTenUsersTenBidsEach(t *testing.T) {
+	t.Skip("Disabling since they need work and shouldn't block releases")
 	if runtime.GOOS == "darwin" {
 		t.Skip()
 	}
@@ -410,6 +415,7 @@ func TestStartAndEndAuctionTenUsersTenBidsEach(t *testing.T) {
 }
 
 func TestDecayingPrice(t *testing.T) {
+	t.Skip("Disabling since they need work and shouldn't block releases")
 	if runtime.GOOS == "darwin" {
 		t.Skip()
 	}

--- a/test/e2e-go/features/compactcert/compactcert_test.go
+++ b/test/e2e-go/features/compactcert/compactcert_test.go
@@ -35,6 +35,7 @@ import (
 )
 
 func TestCompactCerts(t *testing.T) {
+	t.Skip("Disabling since they need work and shouldn't block releases")
 	t.Parallel()
 	r := require.New(fixtures.SynchronizedTest(t))
 


### PR DESCRIPTION
## Summary

They need work and shouldn't block our releases since they features aren't currently in use/enabled

## Test Plan

I ran these tests locally and saw that they all got skipped
