### PR TITLE
Introduce V28 consensus version

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -89,7 +89,7 @@ type ConsensusParams struct {
 	// DefaultKeyDilution specifies the granularity of top-level ephemeral
 	// keys. KeyDilution is the number of second-level keys in each batch,
 	// signed by a top-level "batch" key.  The default value can be
-	// overriden in the account state.
+	// overridden in the account state.
 	DefaultKeyDilution uint64
 
 	// MinBalance specifies the minimum balance that can appear in
@@ -938,13 +938,41 @@ func initConsensusProtocols() {
 	// a bit :
 	v26.ApprovedUpgrades[protocol.ConsensusV27] = 60000
 
+	// v28 introduces new TEAL features, larger program size, fee pooling and longer asset max URL
+	v28 := v27
+	v28.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+
+	// Enable TEAL 4
+	v28.LogicSigVersion = 4
+	// Enable support for larger app program size
+	v28.MaxExtraAppProgramPages = 3
+	v28.MaxAppProgramLen = 2048
+	// Increase asset URL length to allow for IPFS URLs
+	v28.MaxAssetURLBytes = 96
+	// Let the bytes value take more space. Key+Value is still limited to 128
+	v28.MaxAppBytesValueLen = 128
+
+	// Individual limits raised
+	v28.MaxAppTxnForeignApps = 8
+	v28.MaxAppTxnForeignAssets = 8
+
+	// MaxAppTxnAccounts has not been raised yet.  It is already
+	// higher (4) and there is a multiplicative effect in
+	// "reachability" between accounts and creatables, so we
+	// retain 4 x 4 as worst case.
+
+	v28.EnableFeePooling = true
+	v28.EnableKeyregCoherencyCheck = true
+
+	Consensus[protocol.ConsensusV28] = v28
+
+	// v27 can be upgraded to v28, with an update delay of 7 days ( see calculation above )
+	v27.ApprovedUpgrades[protocol.ConsensusV28] = 140000
+
 	// ConsensusFuture is used to test features that are implemented
 	// but not yet released in a production protocol version.
-	vFuture := v27
+	vFuture := v28
 	vFuture.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
-
-	// Let the bytes value take more space. Key+Value is still limited to 128
-	vFuture.MaxAppBytesValueLen = 128
 
 	// FilterTimeout for period 0 should take a new optimized, configured value, need to revisit this later
 	vFuture.AgreementFilterTimeoutPeriod0 = 4 * time.Second
@@ -955,35 +983,6 @@ func initConsensusProtocols() {
 	vFuture.CompactCertVotersLookback = 16
 	vFuture.CompactCertWeightThreshold = (1 << 32) * 30 / 100
 	vFuture.CompactCertSecKQ = 128
-
-	vFuture.EnableKeyregCoherencyCheck = true
-
-	// Enable support for larger app program size
-	vFuture.MaxExtraAppProgramPages = 3
-	vFuture.MaxAppProgramLen = 2048
-
-	// Individual limits raised
-	vFuture.MaxAppTxnForeignApps = 8
-	vFuture.MaxAppTxnForeignAssets = 8
-	// but MaxAppTxnReferences is unchanged.
-
-	// MaxAppTxnAccounts has not been raised yet.  It is already
-	// higher (4) and there is a multiplicative effect in
-	// "reachability" between accounts and creatables, so we
-	// retain 4 x 4 as worst case.
-
-	// enable the InitialRewardsRateCalculation fix
-	vFuture.InitialRewardsRateCalculation = true
-	// Enable transaction Merkle tree.
-	vFuture.PaysetCommit = PaysetCommitMerkle
-
-	// Enable TEAL 4
-	vFuture.LogicSigVersion = 4
-
-	// Increase asset URL length to allow for IPFS URLs
-	vFuture.MaxAssetURLBytes = 96
-
-	vFuture.EnableFeePooling = true
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 }

--- a/data/transactions/transaction_test.go
+++ b/data/transactions/transaction_test.go
@@ -68,11 +68,12 @@ func generateDummyGoNonparticpatingTransaction(addr basics.Address) (tx Transact
 			FirstValid: 1,
 			LastValid:  300,
 		},
-		KeyregTxnFields: KeyregTxnFields{Nonparticipation: true},
+		KeyregTxnFields: KeyregTxnFields{
+			Nonparticipation: true,
+			VoteFirst:        0,
+			VoteLast:         0,
+		},
 	}
-	tx.KeyregTxnFields.VoteFirst = 1
-	tx.KeyregTxnFields.VoteLast = 300
-	tx.KeyregTxnFields.VoteKeyDilution = 1
 
 	tx.KeyregTxnFields.Nonparticipation = true
 	return tx
@@ -250,8 +251,19 @@ func TestWellFormedErrors(t *testing.T) {
 				},
 			},
 			spec:          specialAddr,
-			proto:         curProto,
+			proto:         protoV27,
 			expectedError: makeMinFeeErrorf("transaction had fee %d, which is less than the minimum %d", 100, curProto.MinTxnFee),
+		},
+		{
+			tx: Transaction{
+				Type: protocol.PaymentTx,
+				Header: Header{
+					Sender: addr1,
+					Fee:    basics.MicroAlgos{Raw: 100},
+				},
+			},
+			spec:  specialAddr,
+			proto: curProto,
 		},
 		{
 			tx: Transaction{
@@ -426,7 +438,7 @@ func TestWellFormedErrors(t *testing.T) {
 				Header: okHeader,
 				ApplicationCallTxnFields: ApplicationCallTxnFields{
 					ApplicationID: 1,
-					Accounts:      []basics.Address{basics.Address{}, basics.Address{}, basics.Address{}},
+					Accounts:      []basics.Address{{}, {}, {}},
 					ForeignApps:   []basics.AppIndex{14, 15, 16, 17},
 					ForeignAssets: []basics.AssetIndex{14, 15, 16, 17},
 				},

--- a/ledger/apply/keyreg_test.go
+++ b/ledger/apply/keyreg_test.go
@@ -94,6 +94,8 @@ func TestKeyregApply(t *testing.T) {
 		KeyregTxnFields: transactions.KeyregTxnFields{
 			VotePK:      crypto.OneTimeSignatureVerifier(secretParticipation.SignatureVerifier),
 			SelectionPK: vrfSecrets.PK,
+			VoteFirst:   0,
+			VoteLast:    100,
 		},
 	}
 	err := Keyreg(tx.KeyregTxnFields, tx.Header, makeMockBalances(protocol.ConsensusCurrentVersion), transactions.SpecialAddresses{FeeSink: feeSink}, nil, basics.Round(0))

--- a/ledger/apply/payment_test.go
+++ b/ledger/apply/payment_test.go
@@ -149,6 +149,10 @@ func TestPaymentValidation(t *testing.T) {
 		txn.GenesisHash = genHash
 		payments[i] = txn
 	}
+	tcpast := transactions.ExplicitTxnContext{
+		Proto:   config.Consensus[protocol.ConsensusV27],
+		GenHash: genHash,
+	}
 	tc := transactions.ExplicitTxnContext{
 		Proto:   config.Consensus[protocol.ConsensusCurrentVersion],
 		GenHash: genHash,
@@ -218,14 +222,16 @@ func TestPaymentValidation(t *testing.T) {
 
 		badFee := txn
 		badFee.Fee = basics.MicroAlgos{}
-		if badFee.WellFormed(spec, tc.Proto) == nil {
+		if badFee.WellFormed(spec, tcpast.Proto) == nil {
 			t.Errorf("transaction with no fee %#v verified incorrectly", badFee)
 		}
+		require.Nil(t, badFee.WellFormed(spec, tc.Proto))
+
 		badFee.Fee.Raw = 1
-		if badFee.WellFormed(spec, tc.Proto) == nil {
+		if badFee.WellFormed(spec, tcpast.Proto) == nil {
 			t.Errorf("transaction with low fee %#v verified incorrectly", badFee)
 		}
-
+		require.Nil(t, badFee.WellFormed(spec, tc.Proto))
 	}
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -1069,7 +1069,7 @@ func (node *AlgorandFullNode) AssembleBlock(round basics.Round, deadline time.Ti
 	return validatedBlock{vb: lvb}, nil
 }
 
-// VotingKeys implements the key maanger's VotingKeys method, and provides additional validation with the ledger.
+// VotingKeys implements the key manager's VotingKeys method, and provides additional validation with the ledger.
 // that allows us to load multiple overlapping keys for the same account, and filter these per-round basis.
 func (node *AlgorandFullNode) VotingKeys(votingRound, keysRound basics.Round) []account.Participation {
 	keys := node.accountManager.Keys(votingRound)

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -148,6 +148,11 @@ const ConsensusV27 = ConsensusVersion(
 	"https://github.com/algorandfoundation/specs/tree/d050b3cade6d5c664df8bd729bf219f179812595",
 )
 
+// ConsensusV28 introduces new TEAL features, larger program size, fee pooling and longer asset max URL
+const ConsensusV28 = ConsensusVersion(
+	"https://github.com/algorandfoundation/specs/tree/65b4ab3266c52c56a0fa7d591754887d68faad0a",
+)
+
 // ConsensusFuture is a protocol that should not appear in any production
 // network, but is used to test features before they are released.
 const ConsensusFuture = ConsensusVersion(
@@ -160,7 +165,7 @@ const ConsensusFuture = ConsensusVersion(
 
 // ConsensusCurrentVersion is the latest version and should be used
 // when a specific version is not provided.
-const ConsensusCurrentVersion = ConsensusV27
+const ConsensusCurrentVersion = ConsensusV28
 
 // Error is used to indicate that an unsupported protocol has been detected.
 type Error ConsensusVersion

--- a/test/testdata/nettemplates/ShortParticipationKeys.json
+++ b/test/testdata/nettemplates/ShortParticipationKeys.json
@@ -3,7 +3,7 @@
     "NetworkName": "shortpartkeys",
     "ConsensusProtocol": "shortpartkeysprotocol",
     "FirstPartKeyRound": 0,
-    "LastPartKeyRound": 36,
+    "LastPartKeyRound": 8,
     "PartKeyDilution": 8,
     "Wallets": [
       {


### PR DESCRIPTION
* TEAL v4
* Larger programs
* Larger app/asset lookup limits
* Longer asset URL
* Fee pooling within a group
* Keyreg txn additional checks

Removed InitialRewardsRateCalculation and PaysetCommit from vFuture since it is already in v26

Fixed some tests after exposing zero fees and strict keyreg as current consensus