### PR TITLE
txnsync: fix building on windows

### DIFF
--- a/util/compress/deflate.go
+++ b/util/compress/deflate.go
@@ -102,7 +102,7 @@ func Compress(in, out []byte, compressLevel int) (int, []byte, error) {
 	inAddr := startMemAddr(in)
 	outAddr := startMemAddr(out)
 
-	written := int(C.libdeflate_gzip_compress(c, unsafe.Pointer(inAddr), C.ulong(len(in)), unsafe.Pointer(outAddr), C.ulong(cap(out))))
+	written := int(C.libdeflate_gzip_compress(c, unsafe.Pointer(inAddr), C.size_t(len(in)), unsafe.Pointer(outAddr), C.size_t(cap(out))))
 
 	if written == 0 {
 		return written, out, ErrShortBuffer


### PR DESCRIPTION
## Summary

This code change is pretty trivial, ensuring to use C.size_t instead of C.ulong, which is cross-platform compatible.

## Test Plan

Unit tests for these already exists.