### PR TITLE
Allow AVM code to access a max number of foreign refs.

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -262,7 +262,7 @@ type ConsensusParams struct {
 
 	// maximum number of "foreign references" (accounts, asa, app)
 	// that can be attached to a single app call.
-	MaxAppTxnReferences int
+	MaxAppTotalTxnReferences int
 
 	// maximum cost of application approval program or clear state program
 	MaxAppProgramCost int
@@ -863,9 +863,10 @@ func initConsensusProtocols() {
 	// Can look up 2 assets to see asset parameters
 	v24.MaxAppTxnForeignAssets = 2
 
-	// Appears superfluous here in v24, but allows increasing the
-	// individual limits while maintaining max components in later vers.
-	v24.MaxAppTxnReferences = 8
+	// Intended to have no effect in v24 (it's set to accounts +
+	// asas + apps). In later vers, it allows increasing the
+	// individual limits while maintaining same max references.
+	v24.MaxAppTotalTxnReferences = 8
 
 	// 64 byte keys @ ~333 microAlgos/byte + delta
 	v24.SchemaMinBalancePerEntry = 25000

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -260,6 +260,10 @@ type ConsensusParams struct {
 	// be read in the transaction
 	MaxAppTxnForeignAssets int
 
+	// maximum number of "foreign references" (accounts, asa, app)
+	// that can be attached to a single app call.
+	MaxAppTxnReferences int
+
 	// maximum cost of application approval program or clear state program
 	MaxAppProgramCost int
 
@@ -859,6 +863,10 @@ func initConsensusProtocols() {
 	// Can look up 2 assets to see asset parameters
 	v24.MaxAppTxnForeignAssets = 2
 
+	// Appears superfluous here in v24, but allows increasing the
+	// individual limits while maintaining max components in later vers.
+	v24.MaxAppTxnReferences = 8
+
 	// 64 byte keys @ ~333 microAlgos/byte + delta
 	v24.SchemaMinBalancePerEntry = 25000
 
@@ -952,6 +960,16 @@ func initConsensusProtocols() {
 	// Enable support for larger app program size
 	vFuture.MaxExtraAppProgramPages = 3
 	vFuture.MaxAppProgramLen = 2048
+
+	// Individual limits raised
+	vFuture.MaxAppTxnForeignApps = 8
+	vFuture.MaxAppTxnForeignAssets = 8
+	// but MaxAppTxnReferences is unchanged.
+
+	// MaxAppTxnAccounts has not been raised yet.  It is already
+	// higher (4) and there is a multiplicative effect in
+	// "reachability" between accounts and creatables, so we
+	// retain 4 x 4 as worst case.
 
 	// enable the InitialRewardsRateCalculation fix
 	vFuture.InitialRewardsRateCalculation = true

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -385,6 +385,11 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 			return fmt.Errorf("tx.ForeignAssets too long, max number of foreign assets is %d", proto.MaxAppTxnForeignAssets)
 		}
 
+		// Limit the sum of all types of references that bring in account records
+		if len(tx.Accounts)+len(tx.ForeignApps)+len(tx.ForeignAssets) > proto.MaxAppTxnReferences {
+			return fmt.Errorf("tx has too many references, max is %d", proto.MaxAppTxnReferences)
+		}
+
 		if tx.ExtraProgramPages > uint32(proto.MaxExtraAppProgramPages) {
 			return fmt.Errorf("tx.ExtraProgramPages too large, max number of extra pages is %d", proto.MaxExtraAppProgramPages)
 		}

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -386,8 +386,8 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 		}
 
 		// Limit the sum of all types of references that bring in account records
-		if len(tx.Accounts)+len(tx.ForeignApps)+len(tx.ForeignAssets) > proto.MaxAppTxnReferences {
-			return fmt.Errorf("tx has too many references, max is %d", proto.MaxAppTxnReferences)
+		if len(tx.Accounts)+len(tx.ForeignApps)+len(tx.ForeignAssets) > proto.MaxAppTotalTxnReferences {
+			return fmt.Errorf("tx has too many references, max is %d", proto.MaxAppTotalTxnReferences)
 		}
 
 		if tx.ExtraProgramPages > uint32(proto.MaxExtraAppProgramPages) {

--- a/data/transactions/transaction_test.go
+++ b/data/transactions/transaction_test.go
@@ -370,6 +370,71 @@ func TestWellFormedErrors(t *testing.T) {
 			proto:         futureProto,
 			expectedError: fmt.Errorf("tx.ExtraProgramPages too large, max number of extra pages is %d", futureProto.MaxExtraAppProgramPages),
 		},
+		{
+			tx: Transaction{
+				Type:   protocol.ApplicationCallTx,
+				Header: okHeader,
+				ApplicationCallTxnFields: ApplicationCallTxnFields{
+					ApplicationID: 1,
+					ForeignApps:   []basics.AppIndex{10, 11},
+				},
+			},
+			spec:  specialAddr,
+			proto: protoV27,
+		},
+		{
+			tx: Transaction{
+				Type:   protocol.ApplicationCallTx,
+				Header: okHeader,
+				ApplicationCallTxnFields: ApplicationCallTxnFields{
+					ApplicationID: 1,
+					ForeignApps:   []basics.AppIndex{10, 11, 12},
+				},
+			},
+			spec:          specialAddr,
+			proto:         protoV27,
+			expectedError: fmt.Errorf("tx.ForeignApps too long, max number of foreign apps is 2"),
+		},
+		{
+			tx: Transaction{
+				Type:   protocol.ApplicationCallTx,
+				Header: okHeader,
+				ApplicationCallTxnFields: ApplicationCallTxnFields{
+					ApplicationID: 1,
+					ForeignApps:   []basics.AppIndex{10, 11, 12, 13, 14, 15, 16, 17},
+				},
+			},
+			spec:  specialAddr,
+			proto: futureProto,
+		},
+		{
+			tx: Transaction{
+				Type:   protocol.ApplicationCallTx,
+				Header: okHeader,
+				ApplicationCallTxnFields: ApplicationCallTxnFields{
+					ApplicationID: 1,
+					ForeignAssets: []basics.AssetIndex{14, 15, 16, 17, 18, 19, 20, 21, 22},
+				},
+			},
+			spec:          specialAddr,
+			proto:         futureProto,
+			expectedError: fmt.Errorf("tx.ForeignAssets too long, max number of foreign assets is 8"),
+		},
+		{
+			tx: Transaction{
+				Type:   protocol.ApplicationCallTx,
+				Header: okHeader,
+				ApplicationCallTxnFields: ApplicationCallTxnFields{
+					ApplicationID: 1,
+					Accounts:      []basics.Address{basics.Address{}, basics.Address{}, basics.Address{}},
+					ForeignApps:   []basics.AppIndex{14, 15, 16, 17},
+					ForeignAssets: []basics.AssetIndex{14, 15, 16, 17},
+				},
+			},
+			spec:          specialAddr,
+			proto:         futureProto,
+			expectedError: fmt.Errorf("tx has too many references, max is 8"),
+		},
 	}
 	for _, usecase := range usecases {
 		err := usecase.tx.WellFormed(usecase.spec, usecase.proto)


### PR DESCRIPTION
Along the lines of similar "combine" PRs, this allows AVM code to access a *total* number of "foreign" references, as opposed to limiting each one individually.

