### PR TITLE
txnsync: add support for transaction pool saturation

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -831,8 +831,8 @@ func (node *AlgorandFullNode) OnNewBlock(block bookkeeping.Block, delta ledgerco
 		return
 	}
 
-	// the transaction pool already update it's transactions, dumping out old and invalid transactions. At this point,
-	// we need to let the txsync know about the size of the transaction pool.
+	// the transaction pool already updated its transactions (dumping out old and invalid transactions). At this point,
+	// we need to let the txnsync know about the size of the transaction pool.
 	node.txnSyncConnector.onNewTransactionPoolEntry(node.transactionPool.PendingCount())
 
 	node.syncStatusMu.Lock()

--- a/node/node.go
+++ b/node/node.go
@@ -252,8 +252,8 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 	node.catchupBlockAuth = blockAuthenticatorImpl{Ledger: node.ledger, AsyncVoteVerifier: agreement.MakeAsyncVoteVerifier(node.lowPriorityCryptoVerificationPool)}
 	node.catchupService = catchup.MakeService(node.log, node.config, p2pNode, node.ledger, node.catchupBlockAuth, agreementLedger.UnmatchedPendingCertificates, node.lowPriorityCryptoVerificationPool)
 	node.txPoolSyncerService = rpcs.MakeTxSyncer(node.transactionPool, node.net, node.txHandler.SolicitedTxHandler(), time.Duration(cfg.TxSyncIntervalSeconds)*time.Second, time.Duration(cfg.TxSyncTimeoutSeconds)*time.Second, cfg.TxSyncServeResponseSize)
-	node.txnSyncService = txnsync.MakeTranscationSyncService(node.log, &node.txnSyncConnector, cfg.NetAddress != "", node.genesisID, node.genesisHash, node.config)
 	node.txnSyncConnector = makeTranscationSyncNodeConnector(node)
+	node.txnSyncService = txnsync.MakeTranscationSyncService(node.log, &node.txnSyncConnector, cfg.NetAddress != "", node.genesisID, node.genesisHash, node.config)
 
 	err = node.loadParticipationKeys()
 	if err != nil {

--- a/node/txnSyncConn.go
+++ b/node/txnSyncConn.go
@@ -160,7 +160,8 @@ func (tsnc *transcationSyncNodeConnector) onNewTransactionPoolEntry(transcationP
 }
 
 // OnNewBlock receives a notification that we've moved to a new round from the ledger.
-// This notification would be sent before the transaction pool gets a similar notification
+// This notification would be received before the transaction pool get a similar notification, due
+// the ordering of the block notifier registration.
 func (tsnc *transcationSyncNodeConnector) OnNewBlock(block bookkeeping.Block, delta ledgercore.StateDelta) {
 	blkRound := block.Round()
 	fetchTransactions := tsnc.node.accountManager.HasLiveKeys(blkRound, blkRound)

--- a/node/txnSyncConn.go
+++ b/node/txnSyncConn.go
@@ -22,8 +22,9 @@ import (
 	"time"
 
 	"github.com/algorand/go-algorand/data"
-	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/txnsync"
@@ -158,17 +159,21 @@ func (tsnc *transcationSyncNodeConnector) onNewTransactionPoolEntry(transcationP
 	}
 }
 
-func (tsnc *transcationSyncNodeConnector) onNewRound(round basics.Round, hasParticipationKeys bool) {
+// OnNewBlock receives a notification that we've moved to a new round from the ledger.
+// This notification would be sent before the transaction pool gets a similar notification
+func (tsnc *transcationSyncNodeConnector) OnNewBlock(block bookkeeping.Block, delta ledgercore.StateDelta) {
+	blkRound := block.Round()
+	fetchTransactions := tsnc.node.accountManager.HasLiveKeys(blkRound, blkRound)
 	// if this is a relay, then we always want to fetch transactions, regardless if we have participation keys.
-	fetchTransactions := hasParticipationKeys
 	if tsnc.node.config.NetAddress != "" {
 		fetchTransactions = true
 	}
 
 	select {
-	case tsnc.eventsCh <- txnsync.MakeNewRoundEvent(round, fetchTransactions):
+	case tsnc.eventsCh <- txnsync.MakeNewRoundEvent(blkRound, fetchTransactions):
 	default:
 	}
+
 }
 
 func (tsnc *transcationSyncNodeConnector) start() {

--- a/txnsync/emulatorCore_test.go
+++ b/txnsync/emulatorCore_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -167,6 +168,7 @@ func (e *emulator) initNodes() {
 			e.scenario.netConfig.nodes[i].isRelay,
 			"",
 			crypto.Digest{},
+			config.GetDefaultLocal(),
 		)
 		e.syncers = append(e.syncers, syncer)
 	}

--- a/txnsync/incoming.go
+++ b/txnsync/incoming.go
@@ -203,7 +203,9 @@ func (s *syncState) evaluateIncomingMessage(message incomingMessage) {
 			if err == nil {
 				peer.addIncomingBloomFilter(txMsg.Round, bloomFilter, s.round)
 			} else {
-				panic(err)
+				s.log.Infof("Invalid bloom filter received from peer : %v", err)
+				// for now we can ignore that - but a better handling would be to disconnect
+				// from such a peer.
 			}
 		}
 		peer.updateRequestParams(txMsg.UpdatedRequestParams.Modulator, txMsg.UpdatedRequestParams.Offset)

--- a/txnsync/mainloop.go
+++ b/txnsync/mainloop.go
@@ -382,6 +382,7 @@ func (s *syncState) updatePeersRequestParams(peers []*Peer) {
 		for _, peer := range peers {
 			peer.setLocalRequestParams(0, 0)
 		}
+		return
 	}
 	if s.isRelay {
 		for _, peer := range peers {

--- a/txnsync/peer.go
+++ b/txnsync/peer.go
@@ -558,14 +558,16 @@ func (p *Peer) getMessageConstructionOps(isRelay bool, fetchTransactions bool) (
 		if p.isOutgoing {
 			switch p.state {
 			case peerStateLateBloom:
-				ops |= messageConstBloomFilter
+				if p.localTransactionsModulator != 0 {
+					ops |= messageConstBloomFilter
+				}
 			case peerStateHoldsoff:
 				ops |= messageConstTransactions
 			}
 		} else {
 			if p.requestedTransactionsModulator != 0 {
 				ops |= messageConstTransactions
-				if p.nextStateTimestamp == 0 {
+				if p.nextStateTimestamp == 0 && p.localTransactionsModulator != 0 {
 					ops |= messageConstBloomFilter
 				}
 			}
@@ -577,7 +579,10 @@ func (p *Peer) getMessageConstructionOps(isRelay bool, fetchTransactions bool) (
 	} else {
 		ops |= messageConstTransactions // send transactions to the other peer
 		if fetchTransactions {
-			if p.localTransactionsModulator == 1 {
+			switch p.localTransactionsModulator {
+			case 0:
+				// don't send bloom filter.
+			case 1:
 				// special optimization if we have just one relay that we're connected to:
 				// generate the bloom filter only once per 2*beta message.
 				// this would reduce the number of unneeded bloom filters generation dramatically.
@@ -586,7 +591,7 @@ func (p *Peer) getMessageConstructionOps(isRelay bool, fetchTransactions bool) (
 				if p.nextStateTimestamp == 0 {
 					ops |= messageConstBloomFilter
 				}
-			} else {
+			default:
 				ops |= messageConstBloomFilter
 			}
 			ops |= messageConstUpdateRequestParams

--- a/txnsync/service.go
+++ b/txnsync/service.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/logging"
 )
@@ -34,7 +35,7 @@ type Service struct {
 }
 
 // MakeTranscationSyncService creates a new Service object
-func MakeTranscationSyncService(log logging.Logger, conn NodeConnector, isRelay bool, genesisID string, genesisHash crypto.Digest) *Service {
+func MakeTranscationSyncService(log logging.Logger, conn NodeConnector, isRelay bool, genesisID string, genesisHash crypto.Digest, cfg config.Local) *Service {
 	s := &Service{
 		state: syncState{
 			node:        conn,
@@ -42,6 +43,7 @@ func MakeTranscationSyncService(log logging.Logger, conn NodeConnector, isRelay 
 			isRelay:     isRelay,
 			genesisID:   genesisID,
 			genesisHash: genesisHash,
+			config:      cfg,
 		},
 	}
 	s.state.service = s


### PR DESCRIPTION
## Summary

This PR follow the original design, establishing low and high watermarks for the transaction pool levels. The transaction sync would stop requesting transactions once the transactions count is above the high watermark, and would resume accepting messages once the transactions count drops below the low watermark.

## Test Plan

1. Manual S1 testing and reviewing of log files.
2. Use bandwidth tests to observe differences.