### PR TITLE
txnsync: optimize message encoding & decoding queue

### DIFF
--- a/logging/telemetryspec/metric.go
+++ b/logging/telemetryspec/metric.go
@@ -108,8 +108,6 @@ type TransactionSyncProfilingMetrics struct {
 	GetTxnGroupsOps uint64
 	// number of times the transaction sync was assembling messages
 	AssembleMessageOps uint64
-	// number of times the transaction sync was sending messages
-	SendMessageOps uint64
 	// number of times the transaction sync was creating bloom filters
 	MakeBloomFilterOps uint64
 	// number of times the transaction sync was selecting pending transactions out of existing pool
@@ -135,8 +133,6 @@ type TransactionSyncProfilingMetrics struct {
 	GetTxnGroupsPercent float64
 	// percent of time the transaction sync was assembling messages
 	AssembleMessagePercent float64
-	// percent of time the transaction sync was sending messages
-	SendMessagePercent float64
 	// percent of time the transaction sync was creating bloom filter
 	MakeBloomFilterPercent float64
 	// percent of time the transaction sync was selecting transaction to be sent

--- a/node/node.go
+++ b/node/node.go
@@ -831,8 +831,8 @@ func (node *AlgorandFullNode) OnNewBlock(block bookkeeping.Block, delta ledgerco
 		return
 	}
 
-	// the transaction pool already update it's transactions, dumping out old and invalid transactions. At this point,
-	// we need to let the txsync know about the size of the transaction pool.
+	// the transaction pool already updated its transactions (dumping out old and invalid transactions). At this point,
+	// we need to let the txnsync know about the size of the transaction pool.
 	node.txnSyncConnector.onNewTransactionPoolEntry(node.transactionPool.PendingCount())
 
 	node.syncStatusMu.Lock()

--- a/node/node.go
+++ b/node/node.go
@@ -253,7 +253,7 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 	node.catchupService = catchup.MakeService(node.log, node.config, p2pNode, node.ledger, node.catchupBlockAuth, agreementLedger.UnmatchedPendingCertificates, node.lowPriorityCryptoVerificationPool)
 	node.txPoolSyncerService = rpcs.MakeTxSyncer(node.transactionPool, node.net, node.txHandler.SolicitedTxHandler(), time.Duration(cfg.TxSyncIntervalSeconds)*time.Second, time.Duration(cfg.TxSyncTimeoutSeconds)*time.Second, cfg.TxSyncServeResponseSize)
 	node.txnSyncConnector = makeTranscationSyncNodeConnector(node)
-	node.txnSyncService = txnsync.MakeTranscationSyncService(node.log, &node.txnSyncConnector, cfg.NetAddress != "", node.genesisID, node.genesisHash, node.config)
+	node.txnSyncService = txnsync.MakeTranscationSyncService(node.log, &node.txnSyncConnector, cfg.NetAddress != "", node.genesisID, node.genesisHash, node.config, node.lowPriorityCryptoVerificationPool)
 
 	err = node.loadParticipationKeys()
 	if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -252,8 +252,8 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 	node.catchupBlockAuth = blockAuthenticatorImpl{Ledger: node.ledger, AsyncVoteVerifier: agreement.MakeAsyncVoteVerifier(node.lowPriorityCryptoVerificationPool)}
 	node.catchupService = catchup.MakeService(node.log, node.config, p2pNode, node.ledger, node.catchupBlockAuth, agreementLedger.UnmatchedPendingCertificates, node.lowPriorityCryptoVerificationPool)
 	node.txPoolSyncerService = rpcs.MakeTxSyncer(node.transactionPool, node.net, node.txHandler.SolicitedTxHandler(), time.Duration(cfg.TxSyncIntervalSeconds)*time.Second, time.Duration(cfg.TxSyncTimeoutSeconds)*time.Second, cfg.TxSyncServeResponseSize)
-	node.txnSyncService = txnsync.MakeTranscationSyncService(node.log, &node.txnSyncConnector, cfg.NetAddress != "", node.genesisID, node.genesisHash, node.config)
 	node.txnSyncConnector = makeTranscationSyncNodeConnector(node)
+	node.txnSyncService = txnsync.MakeTranscationSyncService(node.log, &node.txnSyncConnector, cfg.NetAddress != "", node.genesisID, node.genesisHash, node.config)
 
 	err = node.loadParticipationKeys()
 	if err != nil {

--- a/node/txnSyncConn.go
+++ b/node/txnSyncConn.go
@@ -160,7 +160,8 @@ func (tsnc *transcationSyncNodeConnector) onNewTransactionPoolEntry(transcationP
 }
 
 // OnNewBlock receives a notification that we've moved to a new round from the ledger.
-// This notification would be sent before the transaction pool gets a similar notification
+// This notification would be received before the transaction pool get a similar notification, due
+// the ordering of the block notifier registration.
 func (tsnc *transcationSyncNodeConnector) OnNewBlock(block bookkeeping.Block, delta ledgercore.StateDelta) {
 	blkRound := block.Round()
 	fetchTransactions := tsnc.node.accountManager.HasLiveKeys(blkRound, blkRound)

--- a/node/txnSyncConn.go
+++ b/node/txnSyncConn.go
@@ -22,8 +22,9 @@ import (
 	"time"
 
 	"github.com/algorand/go-algorand/data"
-	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/txnsync"
@@ -158,17 +159,21 @@ func (tsnc *transcationSyncNodeConnector) onNewTransactionPoolEntry(transcationP
 	}
 }
 
-func (tsnc *transcationSyncNodeConnector) onNewRound(round basics.Round, hasParticipationKeys bool) {
+// OnNewBlock receives a notification that we've moved to a new round from the ledger.
+// This notification would be sent before the transaction pool gets a similar notification
+func (tsnc *transcationSyncNodeConnector) OnNewBlock(block bookkeeping.Block, delta ledgercore.StateDelta) {
+	blkRound := block.Round()
+	fetchTransactions := tsnc.node.accountManager.HasLiveKeys(blkRound, blkRound)
 	// if this is a relay, then we always want to fetch transactions, regardless if we have participation keys.
-	fetchTransactions := hasParticipationKeys
 	if tsnc.node.config.NetAddress != "" {
 		fetchTransactions = true
 	}
 
 	select {
-	case tsnc.eventsCh <- txnsync.MakeNewRoundEvent(round, fetchTransactions):
+	case tsnc.eventsCh <- txnsync.MakeNewRoundEvent(blkRound, fetchTransactions):
 	default:
 	}
+
 }
 
 func (tsnc *transcationSyncNodeConnector) start() {

--- a/txnsync/bloomFilter.go
+++ b/txnsync/bloomFilter.go
@@ -116,7 +116,9 @@ func makeBloomFilter(encodingParams requestParams, txnGroups []transactions.Sign
 	default:
 		// we want subset.
 		result.containedTxnsRange.firstCounter = math.MaxUint64
-		filtedTransactionsIDs := make([]transactions.Txid, 0, len(txnGroups))
+		filtedTransactionsIDs := getTxIDSliceBuffer(len(txnGroups))
+		defer releaseTxIDSliceBuffer(filtedTransactionsIDs)
+
 		for _, group := range txnGroups {
 			txID := group.FirstTransactionID
 			if txidToUint64(txID)%uint64(encodingParams.Modulator) != uint64(encodingParams.Offset) {

--- a/txnsync/bloomFilter_test.go
+++ b/txnsync/bloomFilter_test.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package txnsync
+
+import (
+	"testing"
+
+	"github.com/algorand/go-algorand/data/transactions"
+)
+
+func BenchmarkTxidToUint64(b *testing.B) {
+	txID := transactions.Txid{1, 2, 3, 4, 5}
+	for i := 0; i < b.N; i++ {
+		txidToUint64(txID)
+	}
+}

--- a/txnsync/emulatorCore_test.go
+++ b/txnsync/emulatorCore_test.go
@@ -17,6 +17,7 @@
 package txnsync
 
 import (
+	"context"
 	"sort"
 	"testing"
 	"time"
@@ -29,6 +30,7 @@ import (
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/util/execpool"
 )
 
 const roundDuration = 4 * time.Second
@@ -169,6 +171,7 @@ func (e *emulator) initNodes() {
 			"",
 			crypto.Digest{},
 			config.GetDefaultLocal(),
+			e,
 		)
 		e.syncers = append(e.syncers, syncer)
 	}
@@ -223,4 +226,30 @@ func (e *emulator) collectResult() (result emulatorResult) {
 		result.nodes[i] = txns
 	}
 	return result
+}
+
+// Dummy implementation of execpool.BacklogPool
+func (e *emulator) EnqueueBacklog(enqueueCtx context.Context, t execpool.ExecFunc, arg interface{}, out chan interface{}) error {
+	t(arg)
+	return nil
+}
+
+// Dummy implementation of execpool.BacklogPool
+func (e *emulator) Enqueue(enqueueCtx context.Context, t execpool.ExecFunc, arg interface{}, i execpool.Priority, out chan interface{}) error {
+	return nil
+}
+
+// Dummy implementation of execpool.BacklogPool
+func (e *emulator) GetOwner() interface{} {
+	return nil
+}
+
+// Dummy implementation of execpool.BacklogPool
+func (e *emulator) Shutdown() {
+
+}
+
+// Dummy implementation of execpool.BacklogPool
+func (e *emulator) GetParallelism() int {
+	return 0
 }

--- a/txnsync/emulatorCore_test.go
+++ b/txnsync/emulatorCore_test.go
@@ -176,6 +176,7 @@ func (e *emulator) initNodes() {
 		e.syncers = append(e.syncers, syncer)
 	}
 	randCounter := 0
+	encodingBuf := protocol.GetEncodingBuf()
 	for _, initAlloc := range e.scenario.initialAlloc {
 		node := e.nodes[initAlloc.node]
 		for i := 0; i < initAlloc.transactionsCount; i++ {
@@ -199,6 +200,8 @@ func (e *emulator) initNodes() {
 				randCounter++
 			}
 			group.FirstTransactionID = group.Transactions[0].ID()
+			encodingBuf = encodingBuf[:0]
+			group.EncodedLength = len(group.Transactions[0].MarshalMsg(encodingBuf))
 			node.txpoolIds[group.FirstTransactionID] = true
 			node.txpoolEntries = append(node.txpoolEntries, group)
 		}
@@ -207,6 +210,7 @@ func (e *emulator) initNodes() {
 		node.txpoolGroupCounter += uint64(initAlloc.transactionsCount)
 		node.onNewTransactionPoolEntry()
 	}
+	protocol.PutEncodingBuf(encodingBuf)
 }
 
 func (e *emulator) collectResult() (result emulatorResult) {

--- a/txnsync/emulatorCore_test.go
+++ b/txnsync/emulatorCore_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -167,6 +168,7 @@ func (e *emulator) initNodes() {
 			e.scenario.netConfig.nodes[i].isRelay,
 			"",
 			crypto.Digest{},
+			config.GetDefaultLocal(),
 		)
 		e.syncers = append(e.syncers, syncer)
 	}

--- a/txnsync/emulatorNode_test.go
+++ b/txnsync/emulatorNode_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/util/timers"
 )
 
@@ -258,7 +259,10 @@ func (n *emulatedNode) enqueueMessage(from int, msg queuedMessage) {
 			baseTime = n.peers[from].messageQ[len(n.peers[from].messageQ)-1].readyAt
 		}
 	}
-	n.peers[from].messageQ = append(n.peers[from].messageQ, queuedMessage{bytes: msg.bytes, readyAt: baseTime + msg.readyAt})
+	// the message bytes need to be copied, so that the originating bytes could be safely deleted.
+	msgBytes := make([]byte, len(msg.bytes))
+	copy(msgBytes[:], msg.bytes[:])
+	n.peers[from].messageQ = append(n.peers[from].messageQ, queuedMessage{bytes: msgBytes, readyAt: baseTime + msg.readyAt})
 	n.peers[from].mu.Unlock()
 }
 
@@ -280,6 +284,7 @@ func (n *emulatedNode) IncomingTransactionGroups(peer *Peer, messageSeq uint64, 
 	// add to transaction pool.
 	duplicateMessage := 0
 	duplicateMessageSize := 0
+	encodingBuf := protocol.GetEncodingBuf()
 	for _, group := range txGroups {
 		if group.Transactions[0].Txn.LastValid < n.emulator.currentRound {
 			continue
@@ -294,8 +299,13 @@ func (n *emulatedNode) IncomingTransactionGroups(peer *Peer, messageSeq uint64, 
 		group.GroupCounter = n.txpoolGroupCounter
 		n.txpoolGroupCounter++
 		group.FirstTransactionID = txID
+		for _, txn := range group.Transactions {
+			encodingBuf = encodingBuf[:0]
+			group.EncodedLength += len(txn.MarshalMsg(encodingBuf))
+		}
 		n.txpoolEntries = append(n.txpoolEntries, group)
 	}
+	protocol.PutEncodingBuf(encodingBuf)
 	if duplicateMessage > 0 {
 		fmt.Printf("%s : %d duplicate messages recieved\n", n.name, duplicateMessage)
 	}

--- a/txnsync/emulator_test.go
+++ b/txnsync/emulator_test.go
@@ -628,7 +628,7 @@ func TestEmulatedTwoNodesFourRelays(t *testing.T) {
 			},
 		},
 		step:         1 * time.Millisecond / 10,
-		testDuration: 2000 * time.Millisecond,
+		testDuration: 2100 * time.Millisecond,
 	}
 	// update the expected results to have the correct number of entries.
 	for j := range testScenario.initialAlloc {

--- a/txnsync/incoming.go
+++ b/txnsync/incoming.go
@@ -203,7 +203,9 @@ func (s *syncState) evaluateIncomingMessage(message incomingMessage) {
 			if err == nil {
 				peer.addIncomingBloomFilter(txMsg.Round, bloomFilter, s.round)
 			} else {
-				panic(err)
+				s.log.Infof("Invalid bloom filter received from peer : %v", err)
+				// for now we can ignore that - but a better handling would be to disconnect
+				// from such a peer.
 			}
 		}
 		peer.updateRequestParams(txMsg.UpdatedRequestParams.Modulator, txMsg.UpdatedRequestParams.Offset)

--- a/txnsync/mainloop.go
+++ b/txnsync/mainloop.go
@@ -382,6 +382,7 @@ func (s *syncState) updatePeersRequestParams(peers []*Peer) {
 		for _, peer := range peers {
 			peer.setLocalRequestParams(0, 0)
 		}
+		return
 	}
 	if s.isRelay {
 		for _, peer := range peers {

--- a/txnsync/mainloop.go
+++ b/txnsync/mainloop.go
@@ -86,6 +86,9 @@ type syncState struct {
 	// pool is full, a node would not ask any of the other peers for additional transactions.
 	transactionPoolFull bool
 
+	// messageSendWaitGroup coordinates the messages that are being sent to the network. Before aborting the mainloop, we want to make
+	// sure there are no outbound messages that are waiting to be sent to the network ( i.e. that all the tasks that we enqueued to the
+	// execution pool were completed ). This does not include the time where the message spent while waiting on the network queue itself.
 	messageSendWaitGroup sync.WaitGroup
 }
 

--- a/txnsync/msgbuffers.go
+++ b/txnsync/msgbuffers.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package txnsync
+
+import (
+	"sync"
+
+	"github.com/algorand/go-algorand/data/transactions"
+)
+
+const messageBufferDefaultInitialSize = 10240
+
+//const txidSliceBufferDefaultInitialSize = 128
+
+// msgBuffersPool holds temporary byte slice buffers used for encoding messages.
+var msgBuffersPool = sync.Pool{
+	New: func() interface{} {
+		return make([]byte, 0, messageBufferDefaultInitialSize)
+	},
+}
+
+// GetEncodingBuf returns a byte slice that can be used for encoding a
+// temporary message.  The byte slice has zero length but potentially
+// non-zero capacity.  The caller gets full ownership of the byte slice,
+// but is encouraged to return it using releaseMessageBuffer().
+func getMessageBuffer() []byte {
+	return msgBuffersPool.Get().([]byte)[:0]
+}
+
+// releaseMessageBuffer places a byte slice into the pool of temporary buffers
+// for encoding.  The caller gives up ownership of the byte slice when
+// passing it to releaseMessageBuffer().
+func releaseMessageBuffer(s []byte) {
+	msgBuffersPool.Put(s)
+}
+
+// txidSlicePool holds temporary byte slice buffers used for encoding messages.
+var txidSlicePool = sync.Pool{}
+
+// getTxIDSliceBuffer returns a slice that can be used for storing a
+// list of transaction IDs. The slice has zero length but potentially
+// non-zero capacity.  The caller gets full ownership of the slice,
+// but is encouraged to return it using releaseTxIDSliceBuffer().
+func getTxIDSliceBuffer(minSize int) []transactions.Txid {
+	alloc := txidSlicePool.Get()
+	if alloc == nil {
+		return make([]transactions.Txid, 0, minSize)
+	}
+	buf := alloc.([]transactions.Txid)[:0]
+	if cap(buf) >= minSize {
+		return buf
+	}
+	txidSlicePool.Put(alloc)
+	return make([]transactions.Txid, 0, minSize)
+}
+
+// releaseTxIDSliceBuffer places a slice into the pool of buffers
+// for storage.  The caller gives up ownership of the byte slice when
+// passing it to releaseMessageBuffer().
+func releaseTxIDSliceBuffer(s []transactions.Txid) {
+	if cap(s) > 0 {
+		txidSlicePool.Put(s)
+	}
+}

--- a/txnsync/msgbuffers.go
+++ b/txnsync/msgbuffers.go
@@ -24,8 +24,6 @@ import (
 
 const messageBufferDefaultInitialSize = 10240
 
-//const txidSliceBufferDefaultInitialSize = 128
-
 // msgBuffersPool holds temporary byte slice buffers used for encoding messages.
 var msgBuffersPool = sync.Pool{
 	New: func() interface{} {

--- a/txnsync/peer.go
+++ b/txnsync/peer.go
@@ -94,7 +94,7 @@ type Peer struct {
 	// lastRound is the latest round reported by the peer.
 	lastRound basics.Round
 
-	// incomingMessages contains the incoming messages from this peer. This heap help us to reorder the imcoming messages so that
+	// incomingMessages contains the incoming messages from this peer. This heap help us to reorder the incoming messages so that
 	// we could process them in the tcp-transport order.
 	incomingMessages messageOrderingHeap
 

--- a/txnsync/peer.go
+++ b/txnsync/peer.go
@@ -558,14 +558,16 @@ func (p *Peer) getMessageConstructionOps(isRelay bool, fetchTransactions bool) (
 		if p.isOutgoing {
 			switch p.state {
 			case peerStateLateBloom:
-				ops |= messageConstBloomFilter
+				if p.localTransactionsModulator != 0 {
+					ops |= messageConstBloomFilter
+				}
 			case peerStateHoldsoff:
 				ops |= messageConstTransactions
 			}
 		} else {
 			if p.requestedTransactionsModulator != 0 {
 				ops |= messageConstTransactions
-				if p.nextStateTimestamp == 0 {
+				if p.nextStateTimestamp == 0 && p.localTransactionsModulator != 0 {
 					ops |= messageConstBloomFilter
 				}
 			}
@@ -577,7 +579,10 @@ func (p *Peer) getMessageConstructionOps(isRelay bool, fetchTransactions bool) (
 	} else {
 		ops |= messageConstTransactions // send transactions to the other peer
 		if fetchTransactions {
-			if p.localTransactionsModulator == 1 {
+			switch p.localTransactionsModulator {
+			case 0:
+				// don't send bloom filter.
+			case 1:
 				// special optimization if we have just one relay that we're connected to:
 				// generate the bloom filter only once per 2*beta message.
 				// this would reduce the number of unneeded bloom filters generation dramatically.
@@ -586,7 +591,7 @@ func (p *Peer) getMessageConstructionOps(isRelay bool, fetchTransactions bool) (
 				if p.nextStateTimestamp == 0 {
 					ops |= messageConstBloomFilter
 				}
-			} else {
+			default:
 				ops |= messageConstBloomFilter
 			}
 			ops |= messageConstUpdateRequestParams

--- a/txnsync/profiler.go
+++ b/txnsync/profiler.go
@@ -39,7 +39,6 @@ const (
 	// detached elements
 	profElementGetTxnsGroups
 	profElementAssembleMessage
-	profElementSendMessage
 	profElementMakeBloomFilter
 	profElementTxnsSelection
 
@@ -168,7 +167,6 @@ func (p *profiler) logProfile() {
 		NextOffsetOps:                uint64(len(p.elements[profElementNextOffset].times)),
 		GetTxnGroupsOps:              uint64(len(p.elements[profElementGetTxnsGroups].times)),
 		AssembleMessageOps:           uint64(len(p.elements[profElementAssembleMessage].times)),
-		SendMessageOps:               uint64(len(p.elements[profElementSendMessage].times)),
 		MakeBloomFilterOps:           uint64(len(p.elements[profElementMakeBloomFilter].times)),
 		SelectPendingTransactionsOps: uint64(len(p.elements[profElementTxnsSelection].times)),
 
@@ -182,7 +180,6 @@ func (p *profiler) logProfile() {
 		NextOffsetPercent:                float64(p.elements[profElementNextOffset].total) * 100.0 / float64(p.profileSum),
 		GetTxnGroupsPercent:              float64(p.elements[profElementGetTxnsGroups].total) * 100.0 / float64(p.profileSum),
 		AssembleMessagePercent:           float64(p.elements[profElementAssembleMessage].total) * 100.0 / float64(p.profileSum),
-		SendMessagePercent:               float64(p.elements[profElementSendMessage].total) * 100.0 / float64(p.profileSum),
 		MakeBloomFilterPercent:           float64(p.elements[profElementMakeBloomFilter].total) * 100.0 / float64(p.profileSum),
 		SelectPendingTransactionsPercent: float64(p.elements[profElementTxnsSelection].total) * 100.0 / float64(p.profileSum),
 	}

--- a/txnsync/service.go
+++ b/txnsync/service.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/logging"
 )
@@ -34,7 +35,7 @@ type Service struct {
 }
 
 // MakeTranscationSyncService creates a new Service object
-func MakeTranscationSyncService(log logging.Logger, conn NodeConnector, isRelay bool, genesisID string, genesisHash crypto.Digest) *Service {
+func MakeTranscationSyncService(log logging.Logger, conn NodeConnector, isRelay bool, genesisID string, genesisHash crypto.Digest, cfg config.Local) *Service {
 	s := &Service{
 		state: syncState{
 			node:        conn,
@@ -42,6 +43,7 @@ func MakeTranscationSyncService(log logging.Logger, conn NodeConnector, isRelay 
 			isRelay:     isRelay,
 			genesisID:   genesisID,
 			genesisHash: genesisHash,
+			config:      cfg,
 		},
 	}
 	s.state.service = s

--- a/txnsync/service.go
+++ b/txnsync/service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/util/execpool"
 )
 
 // Service is the transaction sync main service object.
@@ -35,7 +36,7 @@ type Service struct {
 }
 
 // MakeTranscationSyncService creates a new Service object
-func MakeTranscationSyncService(log logging.Logger, conn NodeConnector, isRelay bool, genesisID string, genesisHash crypto.Digest, cfg config.Local) *Service {
+func MakeTranscationSyncService(log logging.Logger, conn NodeConnector, isRelay bool, genesisID string, genesisHash crypto.Digest, cfg config.Local, threadpool execpool.BacklogPool) *Service {
 	s := &Service{
 		state: syncState{
 			node:        conn,
@@ -44,6 +45,7 @@ func MakeTranscationSyncService(log logging.Logger, conn NodeConnector, isRelay 
 			genesisID:   genesisID,
 			genesisHash: genesisHash,
 			config:      cfg,
+			threadpool:  threadpool,
 		},
 	}
 	s.state.service = s


### PR DESCRIPTION
## Summary

This PR optimize the message encoding and decoding by - 
1. For decoding, it moves the decoding to be executed within the incoming message call from the network stack. This would  give the mainloop thread more CPU time, and allow us to perform the incoming message decoding in parallel.
2. For encoding, we use the execution pool to asynchronously encode the message and send it to the network.
3. Use message buffers ( sync.Pool ) in order to avoid allocating memory for message data. This is particularly valuable for relays, which keeps allocating/releasing memory.

## Test Plan

 - [x] Deployed S1 network to confirm it's working as expected.
 - [x] Checked profiler output to confirm the statistics above.
