### PR TITLE
report substring missing immediates properly

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -747,7 +747,10 @@ func assembleBranch(ops *OpStream, spec *OpSpec, args []string) error {
 }
 
 func assembleSubstring(ops *OpStream, spec *OpSpec, args []string) error {
-	asmDefault(ops, spec, args)
+	err := asmDefault(ops, spec, args)
+	if err != nil {
+		return err
+	}
 	// Having run asmDefault, only need to check extra constraints.
 	start, _ := strconv.ParseUint(args[0], 0, 64)
 	end, _ := strconv.ParseUint(args[1], 0, 64)
@@ -1010,7 +1013,7 @@ type assembleFunc func(*OpStream, *OpSpec, []string) error
 // Basic assembly. Any extra bytes of opcode are encoded as byte immediates.
 func asmDefault(ops *OpStream, spec *OpSpec, args []string) error {
 	if len(args) != spec.Details.Size-1 {
-		ops.errorf("%s expects %d immediate arguments", spec.Name, spec.Details.Size-1)
+		return ops.errorf("%s expects %d immediate arguments", spec.Name, spec.Details.Size-1)
 	}
 	ops.pending.WriteByte(spec.Opcode)
 	for i := 0; i < spec.Details.Size-1; i++ {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -1983,6 +1983,16 @@ func TestSubstringFlop(t *testing.T) {
 	t.Parallel()
 	// fails in compiler
 	testProg(t, `byte 0xf000000000000000
+substring
+len`, 2, expect{2, "substring expects 2 immediate arguments"})
+
+	// fails in compiler
+	testProg(t, `byte 0xf000000000000000
+substring 1
+len`, 2, expect{2, "substring expects 2 immediate arguments"})
+
+	// fails in compiler
+	testProg(t, `byte 0xf000000000000000
 substring 4 2
 len`, 2, expect{2, "substring end is before start"})
 


### PR DESCRIPTION
Fixes crash that should be a clean error report for using `substring` wrong.

Unit tests added to confirm and prevent regression.