### PR TITLE
txnsync: optimize selectPendingTransactions loop

### DIFF
--- a/txnsync/bloomFilter.go
+++ b/txnsync/bloomFilter.go
@@ -61,6 +61,7 @@ func decodeBloomFilter(enc encodedBloomFilter) (outFilter bloomFilter, err error
 	if err != nil {
 		return bloomFilter{}, err
 	}
+	outFilter.encodingParams = enc.EncodingParams
 	return outFilter, nil
 }
 

--- a/txnsync/incoming.go
+++ b/txnsync/incoming.go
@@ -129,6 +129,7 @@ func (s *syncState) asyncIncomingMessageHandler(networkPeer interface{}, peer *P
 			return errInvalidBloomFilter
 		}
 		incomingMessage.bloomFilter = bloomFilter
+		incomingMessage.bloomFilter.encodingParams = incomingMessage.message.TxnBloomFilter.EncodingParams
 	}
 
 	// if the peer sent us any transactions, decode these.

--- a/txnsync/incoming.go
+++ b/txnsync/incoming.go
@@ -129,7 +129,6 @@ func (s *syncState) asyncIncomingMessageHandler(networkPeer interface{}, peer *P
 			return errInvalidBloomFilter
 		}
 		incomingMessage.bloomFilter = bloomFilter
-		incomingMessage.bloomFilter.encodingParams = incomingMessage.message.TxnBloomFilter.EncodingParams
 	}
 
 	// if the peer sent us any transactions, decode these.

--- a/txnsync/msgp_gen.go
+++ b/txnsync/msgp_gen.go
@@ -264,8 +264,8 @@ func (z addresses) MarshalMsg(b []byte) (o []byte) {
 	} else {
 		o = msgp.AppendArrayHeader(o, uint32(len(z)))
 	}
-	for za0004 := range z {
-		o = z[za0004].MarshalMsg(o)
+	for za0005 := range z {
+		o = z[za0005].MarshalMsg(o)
 	}
 	return
 }
@@ -318,8 +318,8 @@ func (_ *addresses) CanUnmarshalMsg(z interface{}) bool {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z addresses) Msgsize() (s int) {
 	s = msgp.ArrayHeaderSize
-	for za0004 := range z {
-		s += z[za0004].Msgsize()
+	for za0005 := range z {
+		s += z[za0005].Msgsize()
 	}
 	return
 }
@@ -26473,16 +26473,16 @@ func (z revealMap) MarshalMsg(b []byte) (o []byte) {
 	} else {
 		o = msgp.AppendMapHeader(o, uint32(len(z)))
 	}
-	za0001_keys := make([]uint64, 0, len(z))
-	for za0001 := range z {
-		za0001_keys = append(za0001_keys, za0001)
+	za0002_keys := make([]uint64, 0, len(z))
+	for za0002 := range z {
+		za0002_keys = append(za0002_keys, za0002)
 	}
-	sort.Sort(SortUint64(za0001_keys))
-	for _, za0001 := range za0001_keys {
-		za0002 := z[za0001]
-		_ = za0002
-		o = msgp.AppendUint64(o, za0001)
-		o = za0002.MarshalMsg(o)
+	sort.Sort(SortUint64(za0002_keys))
+	for _, za0002 := range za0002_keys {
+		za0003 := z[za0002]
+		_ = za0003
+		o = msgp.AppendUint64(o, za0002)
+		o = za0003.MarshalMsg(o)
 	}
 	return
 }
@@ -26543,10 +26543,10 @@ func (_ *revealMap) CanUnmarshalMsg(z interface{}) bool {
 func (z revealMap) Msgsize() (s int) {
 	s = msgp.MapHeaderSize
 	if z != nil {
-		for za0001, za0002 := range z {
-			_ = za0001
+		for za0002, za0003 := range z {
 			_ = za0002
-			s += 0 + msgp.Uint64Size + za0002.Msgsize()
+			_ = za0003
+			s += 0 + msgp.Uint64Size + za0003.Msgsize()
 		}
 	}
 	return

--- a/txnsync/peer.go
+++ b/txnsync/peer.go
@@ -239,8 +239,8 @@ func (t *transactionGroupCounterTracker) roll(offset, modulator byte) {
 // a requestParamsGroupCounterState in the array that matches the provided request params. The method
 // uses a linear search, which works best against small arrays.
 func (t *transactionGroupCounterTracker) index(offset, modulator byte) int {
-	for i := range *t {
-		if (*t)[i].offset == offset && (*t)[i].modulator == modulator {
+	for i, counter := range *t {
+		if counter.offset == offset && counter.modulator == modulator {
 			return i
 		}
 	}


### PR DESCRIPTION
## Summary

The txsync profiler shown that the selectPendingTransactions takes longer-then-desired computation time. To improve that, this PR adds the following:
1. add tracking of the lastTransactionGroupCounter per each set of request params and bloom filter. Together, these would prevent redundant scanning of the pending transactions, and would allow controlled number of iterations when scanning for previously-missed-transactions.
2. extract the loop over the bloom filters outside of the pending transactions loop, so that we need to iterate on these only once, and extract only the bloom filter indices that are relevant.
3. fix a bug in the `decodeBloomFilter` which failed to update the encoding params.

## Test Plan

- [x] Tested using the emulator
- [x] Tested using S1 deployed network
- [x] Bandwidth testing