### PR TITLE
testing: fix random failure in TestAppEmptyAccountsLocal

### DIFF
--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -926,7 +926,7 @@ return`
 		Header:                   txHeader,
 		ApplicationCallTxnFields: appCallFields,
 	}
-	err = l.appendUnvalidatedTx(t, genesisInitState.Accounts, initKeys, appCall, transactions.ApplyData{
+	err = l.appendUnvalidatedTx(t, nil, initKeys, appCall, transactions.ApplyData{
 		EvalDelta: basics.EvalDelta{
 			LocalDeltas: map[uint64]basics.StateDelta{0: {"lk": basics.ValueDelta{
 				Action: basics.SetBytesAction,
@@ -974,6 +974,8 @@ return`
 	a.NoError(err)
 	err = l.appendUnvalidated(blk)
 	a.NoError(err)
+
+	l.WaitForCommit(3)
 
 	// save data into DB and write into local state
 	l.accts.accountsWriting.Add(1)

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -177,8 +177,17 @@ func makeNewEmptyBlock(t *testing.T, l *Ledger, GenesisID string, initAccounts m
 	proto := config.Consensus[lastBlock.CurrentProtocol]
 	poolAddr := testPoolAddr
 	var totalRewardUnits uint64
-	for _, acctdata := range initAccounts {
-		totalRewardUnits += acctdata.MicroAlgos.RewardUnits(proto)
+	if l.Latest() == 0 {
+		require.NotNil(t, initAccounts)
+		for _, acctdata := range initAccounts {
+			if acctdata.Status != basics.NotParticipating {
+				totalRewardUnits += acctdata.MicroAlgos.RewardUnits(proto)
+			}
+		}
+	} else {
+		totals, err := l.Totals(l.Latest())
+		require.NoError(t, err)
+		totalRewardUnits = totals.RewardUnits()
 	}
 	poolBal, err := l.Lookup(l.Latest(), poolAddr)
 	a.NoError(err, "could not get incentive pool balance")


### PR DESCRIPTION
## Summary

The test had two unrelated bugs:
1. We need to call `WaitForCommit` before `reloadLedger` to ensure the block is being written to disk before the blockQ getting reinitialized ( and loose its content ).
2. The calculation of the total rewards unit in `makeNewEmptyBlock` was wrong. I corrected it. For tests that run only one or two rounds, this might be good enough, but for long-running tests, it would start fail pretty quickly.

## Test Plan

Run using travis to confirm fix.
I was able to repro this locally by running 500 times consecutively. After the fix, I was no longer able to reproduce the failure.
