### PR TITLE
Specify truncated division is used in TEAL

### DIFF
--- a/data/transactions/logic/README.md
+++ b/data/transactions/logic/README.md
@@ -80,7 +80,7 @@ An application transaction must indicate the action to be taken following the ex
 
 Most operations work with only one type of argument, uint64 or bytes, and panic if the wrong type value is on the stack.
 
-Many instructions accept values to designate Accounts, Assets, or Applications. Beginning with TEAL v4, these values may always be given as an _offset_ in the corresponding Txn fields (Txn.Accounts, Txn.ForeignAssets, Txn.ForeignApps) _or_ as the value itself (a bytes address for Accounts, or a uint64 ID). The values, however, must still be present in the Txn fields. Before TEAL v4, most opcodes required the use of an offset, except for reading account local values of assets or applications, which accepted the IDs directly and did not require the ID to be present in they corresponding _Foreign_ array. (Note that beginning with TEAL v4, those ID are required to be present in their corresponding _Foreign_ array.) See individual opcodes for details. In the case of account offsets or application offsets, 0 is specially defined to Txn.Sender or the ID of the current application, respectively.
+Many instructions accept values to designate Accounts, Assets, or Applications. Beginning with TEAL v4, these values may always be given as an _offset_ in the corresponding Txn fields (Txn.Accounts, Txn.ForeignAssets, Txn.ForeignApps) _or_ as the value itself (a bytes address for Accounts, or a uint64 ID). The values, however, must still be present in the Txn fields. Before TEAL v4, most opcodes required the use of an offset, except for reading account local values of assets or applications, which accepted the IDs directly and did not require the ID to be present in they corresponding _Foreign_ array. (Note that beginning with TEAL v4, those IDs are required to be present in their corresponding _Foreign_ array.) See individual opcodes for details. In the case of account offsets or application offsets, 0 is specially defined to Txn.Sender or the ID of the current application, respectively.
 
 Many programs need only a few dozen instructions. The instruction set has some optimization built in. `intc`, `bytec`, and `arg` take an immediate value byte, making a 2-byte op to load a value onto the stack, but they also have single byte versions for loading the most common constant values. Any program will benefit from having a few common values loaded with a smaller one byte opcode. Cryptographic hashes and `ed25519verify` are single byte opcodes with powerful libraries behind them. These operations still take more time than other ops (and this is reflected in the cost of each op and the cost limit of a program) but are efficient in compiled code space.
 
@@ -96,7 +96,7 @@ For one-argument ops, `X` is the last element on the stack, which is typically r
 
 For two-argument ops, `A` is the penultimate element on the stack and `B` is the top of the stack. These typically result in popping A and B from the stack and pushing the result.
 
-For three-argument ops, `A` is the element two below the top, `B` is the penultimate stack element and `C` is the top of the stack. These operatiosn typically pop A, B, and C from the stack and push the result.
+For three-argument ops, `A` is the element two below the top, `B` is the penultimate stack element and `C` is the top of the stack. These operations typically pop A, B, and C from the stack and push the result.
 
 | Op | Description |
 | --- | --- |
@@ -106,7 +106,7 @@ For three-argument ops, `A` is the element two below the top, `B` is the penulti
 | `ed25519verify` | for (data A, signature B, pubkey C) verify the signature of ("ProgData" \|\| program_hash \|\| data) against the pubkey => {0 or 1} |
 | `+` | A plus B. Panic on overflow. |
 | `-` | A minus B. Panic if B > A. |
-| `/` | A divided by B. Panic if B == 0. |
+| `/` | A divided by B (truncated division). Panic if B == 0. |
 | `*` | A times B. Panic on overflow. |
 | `<` | A less than B => {0 or 1} |
 | `>` | A greater than B => {0 or 1} |
@@ -158,7 +158,7 @@ bytes on outputs.
 | --- | --- |
 | `b+` | A plus B, where A and B are byte-arrays interpreted as big-endian unsigned integers |
 | `b-` | A minus B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic on underflow. |
-| `b/` | A divided by B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic if B is zero. |
+| `b/` | A divided by B (truncated division), where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic if B is zero. |
 | `b*` | A times B, where A and B are byte-arrays interpreted as big-endian unsigned integers. |
 | `b<` | A is less than B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1} |
 | `b>` | A is greater than B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1} |

--- a/data/transactions/logic/TEAL_opcodes.md
+++ b/data/transactions/logic/TEAL_opcodes.md
@@ -72,7 +72,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 - Opcode: 0x0a
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
-- A divided by B. Panic if B == 0.
+- A divided by B (truncated division). Panic if B == 0.
 
 `divmodw` is available to divide the two-element values produced by `mulw` and `addw`.
 
@@ -1007,7 +1007,7 @@ bitlen interprets arrays as big-endian integers, unlike setbit/getbit
 - Opcode: 0xa2
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
-- A divided by B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic if B is zero.
+- A divided by B (truncated division), where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic if B is zero.
 - **Cost**: 20
 - LogicSigVersion >= 4
 

--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -31,7 +31,7 @@ var opDocByName = map[string]string{
 	"ed25519verify":     "for (data A, signature B, pubkey C) verify the signature of (\"ProgData\" || program_hash || data) against the pubkey => {0 or 1}",
 	"+":                 "A plus B. Panic on overflow.",
 	"-":                 "A minus B. Panic if B > A.",
-	"/":                 "A divided by B. Panic if B == 0.",
+	"/":                 "A divided by B (truncated division). Panic if B == 0.",
 	"*":                 "A times B. Panic on overflow.",
 	"<":                 "A less than B => {0 or 1}",
 	">":                 "A greater than B => {0 or 1}",
@@ -128,7 +128,7 @@ var opDocByName = map[string]string{
 
 	"b+":  "A plus B, where A and B are byte-arrays interpreted as big-endian unsigned integers",
 	"b-":  "A minus B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic on underflow.",
-	"b/":  "A divided by B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic if B is zero.",
+	"b/":  "A divided by B (truncated division), where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic if B is zero.",
 	"b*":  "A times B, where A and B are byte-arrays interpreted as big-endian unsigned integers.",
 	"b<":  "A is less than B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1}",
 	"b>":  "A is greater than B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1}",


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Specify that the truncated division is used (https://en.wikipedia.org/wiki/Modulo_operation#Variants_of_the_definition)


<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Just a minor change in documentation.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
