### PR TITLE
REST API: make extra-program-pages and apps-total-extra-pages optional

### DIFF
--- a/daemon/algod/api/server/v2/account.go
+++ b/daemon/algod/api/server/v2/account.go
@@ -125,7 +125,7 @@ func AccountDataToAccount(
 		AuthAddr:                    addrOrNil(record.AuthAddr),
 		AppsLocalState:              &appsLocalState,
 		AppsTotalSchema:             &totalAppSchema,
-		AppsTotalExtraPages:         &totalExtraPages,
+		AppsTotalExtraPages:         numOrNil(totalExtraPages),
 	}, nil
 }
 
@@ -401,13 +401,13 @@ func ApplicationParamsToAppParams(gap *generated.ApplicationParams) (basics.AppP
 func AppParamsToApplication(creator string, appIdx basics.AppIndex, appParams *basics.AppParams) generated.Application {
 	globalState := convertTKVToGenerated(&appParams.GlobalState)
 	extraProgramPages := uint64(appParams.ExtraProgramPages)
-	return generated.Application{
+	app := generated.Application{
 		Id: uint64(appIdx),
 		Params: generated.ApplicationParams{
 			Creator:           creator,
 			ApprovalProgram:   appParams.ApprovalProgram,
 			ClearStateProgram: appParams.ClearStateProgram,
-			ExtraProgramPages: &extraProgramPages,
+			ExtraProgramPages: numOrNil(extraProgramPages),
 			GlobalState:       globalState,
 			LocalStateSchema: &generated.ApplicationStateSchema{
 				NumByteSlice: appParams.LocalStateSchema.NumByteSlice,
@@ -419,6 +419,7 @@ func AppParamsToApplication(creator string, appIdx basics.AppIndex, appParams *b
 			},
 		},
 	}
+	return app
 }
 
 // AssetParamsToAsset converts basics.AssetParams to generated.Asset

--- a/daemon/algod/api/server/v2/account_test.go
+++ b/daemon/algod/api/server/v2/account_test.go
@@ -114,8 +114,12 @@ func TestAccount(t *testing.T) {
 	verifyCreatedApp := func(index int, appIdx basics.AppIndex, params basics.AppParams) {
 		require.Equal(t, uint64(appIdx), (*conv.CreatedApps)[index].Id)
 		require.Equal(t, params.ApprovalProgram, (*conv.CreatedApps)[index].Params.ApprovalProgram)
-		require.NotNil(t, (*conv.CreatedApps)[index].Params.ExtraProgramPages)
-		require.Equal(t, uint64(params.ExtraProgramPages), *(*conv.CreatedApps)[index].Params.ExtraProgramPages)
+		if params.ExtraProgramPages != 0 {
+			require.NotNil(t, (*conv.CreatedApps)[index].Params.ExtraProgramPages)
+			require.Equal(t, uint64(params.ExtraProgramPages), *(*conv.CreatedApps)[index].Params.ExtraProgramPages)
+		} else {
+			require.Nil(t, (*conv.CreatedApps)[index].Params.ExtraProgramPages)
+		}
 		require.NotNil(t, (*conv.CreatedApps)[index].Params.GlobalStateSchema)
 		require.Equal(t, params.GlobalStateSchema.NumUint, (*conv.CreatedApps)[index].Params.GlobalStateSchema.NumUint)
 		require.Equal(t, params.GlobalStateSchema.NumByteSlice, (*conv.CreatedApps)[index].Params.GlobalStateSchema.NumByteSlice)

--- a/daemon/algod/api/server/v2/test/helpers.go
+++ b/daemon/algod/api/server/v2/test/helpers.go
@@ -61,7 +61,6 @@ var poolAddrAssetsGolden = make([]generatedV2.AssetHolding, 0)
 var poolAddrCreatedAssetsGolden = make([]generatedV2.Asset, 0)
 var appLocalStates = make([]generatedV2.ApplicationLocalState, 0)
 var appsTotalSchema = generatedV2.ApplicationStateSchema{}
-var appsTotalExtraPages = uint64(0)
 var appCreatedApps = make([]generatedV2.Application, 0)
 var poolAddrResponseGolden = generatedV2.AccountResponse{
 	Address:                     poolAddr.String(),
@@ -73,7 +72,6 @@ var poolAddrResponseGolden = generatedV2.AccountResponse{
 	Status:                      "Not Participating",
 	AppsLocalState:              &appLocalStates,
 	AppsTotalSchema:             &appsTotalSchema,
-	AppsTotalExtraPages:         &appsTotalExtraPages,
 	CreatedApps:                 &appCreatedApps,
 }
 var txnPoolGolden = make([]transactions.SignedTxn, 2)


### PR DESCRIPTION
## Summary

Make extra-program-pages and apps-total-extra-pages optional in order to do not exposing them before the protocol switch.

## Test Plan

Existing tests updated