### PR TITLE
Restore TestPeriodicSync and TestBasicCatchpointCatchup tests.

### DIFF
--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -162,7 +162,6 @@ func TestServiceFetchBlocksSameRange(t *testing.T) {
 }
 
 func TestPeriodicSync(t *testing.T) {
-	t.Skip("Disabling since they need work and shouldn't block releases")
 	// Make Ledger
 	local := new(mockedLedger)
 	local.blocks = append(local.blocks, bookkeeping.Block{})

--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -79,7 +79,6 @@ func (ec *nodeExitErrorCollector) Print() {
 }
 
 func TestBasicCatchpointCatchup(t *testing.T) {
-	t.Skip("Temporarily disabling since they need work and shouldn't block releases")
 	if testing.Short() {
 		t.Skip()
 	}


### PR DESCRIPTION
## Summary

These tests were temporarily disabled while we were troubleshooting the pipeline. As we are actively fixing these, we should re-enable these tests.

## Test Plan

N/A, these are tests, and are expected to fail. I don't think they run during a standard PR test, however.
