### PR TITLE
testing: fix telemetry unit tests

### DIFF
--- a/logging/telemetryhook.go
+++ b/logging/telemetryhook.go
@@ -33,13 +33,17 @@ func createAsyncHook(wrappedHook logrus.Hook, channelDepth uint, maxQueueDepth i
 }
 
 func createAsyncHookLevels(wrappedHook logrus.Hook, channelDepth uint, maxQueueDepth int, levels []logrus.Level) *asyncTelemetryHook {
+	// one time check to see if the wrappedHook is ready (true for mocked telemetry)
+	tfh, ok := wrappedHook.(*telemetryFilteredHook)
+	ready := ok && tfh.wrappedHook != nil
+
 	hook := &asyncTelemetryHook{
 		wrappedHook:   wrappedHook,
 		entries:       make(chan *logrus.Entry, channelDepth),
 		quit:          make(chan struct{}),
 		maxQueueDepth: maxQueueDepth,
 		levels:        levels,
-		ready:         false,
+		ready:         ready,
 		urlUpdate:     make(chan bool),
 	}
 

--- a/logging/telemetryhook.go
+++ b/logging/telemetryhook.go
@@ -33,17 +33,13 @@ func createAsyncHook(wrappedHook logrus.Hook, channelDepth uint, maxQueueDepth i
 }
 
 func createAsyncHookLevels(wrappedHook logrus.Hook, channelDepth uint, maxQueueDepth int, levels []logrus.Level) *asyncTelemetryHook {
-	// one time check to see if the wrappedHook is ready (true for mocked telemetry)
-	tfh, ok := wrappedHook.(*telemetryFilteredHook)
-	ready := ok && tfh.wrappedHook != nil
-
 	hook := &asyncTelemetryHook{
 		wrappedHook:   wrappedHook,
 		entries:       make(chan *logrus.Entry, channelDepth),
 		quit:          make(chan struct{}),
 		maxQueueDepth: maxQueueDepth,
 		levels:        levels,
-		ready:         ready,
+		ready:         false,
 		urlUpdate:     make(chan bool),
 	}
 

--- a/logging/telemetryhook.go
+++ b/logging/telemetryhook.go
@@ -33,7 +33,7 @@ func createAsyncHook(wrappedHook logrus.Hook, channelDepth uint, maxQueueDepth i
 }
 
 func createAsyncHookLevels(wrappedHook logrus.Hook, channelDepth uint, maxQueueDepth int, levels []logrus.Level) *asyncTelemetryHook {
-	// one time check to see if the wrappedHook is ready (true for mocked telemetry)
+	// needed by 'makeTelemetryTestFixtureWithConfig' to mark ready in unit tests.
 	tfh, ok := wrappedHook.(*telemetryFilteredHook)
 	ready := ok && tfh.wrappedHook != nil
 

--- a/logging/telemetryhook_test.go
+++ b/logging/telemetryhook_test.go
@@ -179,13 +179,13 @@ func TestAsyncTelemetryHook_CloseDrop(t *testing.T) {
 		<-filling // Block while filling
 	}
 	hook := createAsyncHook(&testHook, 4, entryCount)
+	hook.ready = true
 	for i := 0; i < entryCount; i++ {
 		entry := logrus.Entry{
 			Level: logrus.ErrorLevel,
 		}
 		hook.Fire(&entry)
 	}
-	hook.ready = true
 
 	close(filling)
 	hook.Close()
@@ -206,13 +206,13 @@ func TestAsyncTelemetryHook_QueueDepth(t *testing.T) {
 	}
 
 	hook := createAsyncHook(&testHook, entryCount, maxDepth)
+	hook.ready = true
 	for i := 0; i < entryCount; i++ {
 		entry := logrus.Entry{
 			Level: logrus.ErrorLevel,
 		}
 		hook.Fire(&entry)
 	}
-	hook.ready = true
 
 	close(filling)
 	hook.Close()

--- a/logging/telemetryhook_test.go
+++ b/logging/telemetryhook_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -170,17 +169,14 @@ func TestSaveLoadConfig(t *testing.T) {
 	os.RemoveAll(configDir)
 }
 
-func TestAsyncTelemetryHook_Close(t *testing.T) {
-	t.Skip("We no longer ensure 100% delivery. To not block, we drop messages when they come in faster than the network sends them.")
-	a := require.New(t)
-	t.Parallel()
-
+func TestAsyncTelemetryHook_CloseDrop(t *testing.T) {
 	const entryCount = 100
+
+	filling := make(chan struct{})
 
 	testHook := makeMockTelemetryHook(logrus.DebugLevel)
 	testHook.cb = func(entry *logrus.Entry) {
-		// Inject a delay to ensure we buffer entries
-		time.Sleep(1 * time.Millisecond)
+		<-filling // Block while filling
 	}
 	hook := createAsyncHook(&testHook, 4, entryCount)
 	for i := 0; i < entryCount; i++ {
@@ -189,17 +185,16 @@ func TestAsyncTelemetryHook_Close(t *testing.T) {
 		}
 		hook.Fire(&entry)
 	}
+	hook.ready = true
 
+	close(filling)
 	hook.Close()
 
-	a.Equal(entryCount, len(testHook.entries()))
+	// To not block, we drop messages when they come in faster than the network sends them.
+	require.Less(t, len(testHook.entries()), entryCount)
 }
 
 func TestAsyncTelemetryHook_QueueDepth(t *testing.T) {
-	t.Skip("flakey test can fail on slow test systems")
-	a := require.New(t)
-	t.Parallel()
-
 	const entryCount = 100
 	const maxDepth = 10
 
@@ -217,9 +212,10 @@ func TestAsyncTelemetryHook_QueueDepth(t *testing.T) {
 		}
 		hook.Fire(&entry)
 	}
+	hook.ready = true
 
 	close(filling)
 	hook.Close()
 
-	a.Equal(maxDepth, len(testHook.entries()))
+	require.Equal(t, maxDepth, len(testHook.entries()))
 }


### PR DESCRIPTION
## Summary

Fix and re-enable async telemetry unit test TestAsyncTelemetryHook_CloseDrop.

## Test Plan

Manual, use travis-CI to validate.