### PR TITLE
testing: fix gotestsum install

### DIFF
--- a/scripts/buildtools/install_buildtools.sh
+++ b/scripts/buildtools/install_buildtools.sh
@@ -36,6 +36,12 @@ while getopts ":o:h" opt; do
 done
 shift $((OPTIND -1))
 
+if [ "$#" -ne 0 ]; then
+  echo "Unexpected positional arguments passed to script: $@"
+  exit 1
+fi
+
+
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 pushd .
 cd ${SCRIPTPATH}
@@ -76,7 +82,7 @@ function install_go_module {
 
 if [[ "${BUILDTOOLS_INSTALL}" != "ALL" ]]; then
   install_go_module "${BUILDTOOLS_INSTALL}"
-  return
+  exit 0
 fi
 
 install_go_module golang.org/x/lint golang.org/x/lint/golint

--- a/scripts/travis/test.sh
+++ b/scripts/travis/test.sh
@@ -15,7 +15,7 @@ chmod +x ~/gimme
 eval "$(~/gimme "${GOLANG_VERSION}")"
 
 # If this command fails the Makefile will select 'go test' instead.
-"${SCRIPTPATH}/../buildtools/install_buildtools.sh" "gotest.tools/gotestsum" || true
+"${SCRIPTPATH}/../buildtools/install_buildtools.sh" -o "gotest.tools/gotestsum" || true
 
 if [ "${OS}-${ARCH}" = "linux-arm" ] || [ "${OS}-${ARCH}" = "windows-amd64" ]; then
      # for arm, no tests need to be invoked.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

I forgot the "-o" option for specifying one package to install. Added the missing flag and made the install_buildtools.sh command stricter about extra positional arguments.

## Test Plan

Check the CI output and ensure the extra packages are not installed.