### PR TITLE
Add missing txna allowed args to doc and langspec

### DIFF
--- a/data/transactions/logic/fields.go
+++ b/data/transactions/logic/fields.go
@@ -236,7 +236,7 @@ var txnFieldSpecs = []txnFieldSpec{
 
 // TxnaFieldNames are arguments to the 'txna' opcode
 // It is a subset of txn transaction fields so initialized here in-place
-var TxnaFieldNames = []string{ApplicationArgs.String(), Accounts.String()}
+var TxnaFieldNames = []string{ApplicationArgs.String(), Accounts.String(), Assets.String(), Applications.String()}
 
 // TxnaFieldTypes is StackBytes or StackUint64 parallel to TxnFieldNames
 var TxnaFieldTypes = []StackType{

--- a/data/transactions/logic/fields_test.go
+++ b/data/transactions/logic/fields_test.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package logic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestArrayFields(t *testing.T) {
+	require.Equal(t, len(TxnaFieldNames), len(TxnaFieldTypes))
+	require.Equal(t, len(txnaFieldSpecByField), len(TxnaFieldTypes))
+}


### PR DESCRIPTION
## Summary

We [exposed](https://github.com/algorandfoundation/specs/pull/37/files#diff-9b783466d1b1961a07008f11e6537b45242a2fdb9679612cf0576191641c19f1R237) `Assets` and `Applications` in TEAL v3 but did not update doc/langspec. This commit fixes it.

## Test Plan

Added a test checking `TxnaFieldNames` (used only in doc) against `txnaFieldSpecByField` (used in code)