### PR TITLE
Fix docker repo update

### DIFF
--- a/docker/releases/build_releases.sh
+++ b/docker/releases/build_releases.sh
@@ -53,50 +53,58 @@ while [ "$1" != "" ]; do
     shift
 done
 
-if [[ ! "$NETWORK" =~ ^mainnet$|^testnet$|^betanet$ ]]
-then
+# Set IMAGE_NAME to docker image name
+case $NETWORK in
+  mainnet)
+    IMAGE_NAME=stable
+    ;;
+  testnet)
+    IMAGE_NAME=testnet
+    ;;
+  betanet)
+    IMAGE_NAME=betanet
+    CHANNEL=beta
+    ;;
+  *)
     echo "$RED_FG[$0]$END_FG_COLOR Network values must be either \`mainnet\`, \`testnet\` or \`betanet\`."
     exit 1
-elif [ "$NETWORK" != "mainnet" ]
-then
-    if [ "$NETWORK" == "betanet" ]
-    then
-        CHANNEL=beta
-    fi
+    ;;
+esac
 
-    IMAGE_NAME="$NETWORK"
-    NETWORK="-g $NETWORK"
-fi
+IFS='' read -r -d '' DOCKERFILE <<EOF
+FROM ubuntu
 
-build_image () {
-    IFS='' read -r -d '' DOCKERFILE <<EOF
-    FROM ubuntu
-
-    RUN apt-get update && apt-get install -y ca-certificates curl --no-install-recommends && \
-        curl --silent -L https://github.com/algorand/go-algorand-doc/blob/master/downloads/installers/linux_amd64/install_master_linux-amd64.tar.gz?raw=true | tar xzf - && \
-        ./update.sh -c $CHANNEL -n -p ~/node -d ~/node/data -i $NETWORK
-    WORKDIR /root/node
+RUN apt-get update && apt-get install -y ca-certificates curl --no-install-recommends && \
+    curl --silent -L https://github.com/algorand/go-algorand-doc/blob/master/downloads/installers/linux_amd64/install_master_linux-amd64.tar.gz?raw=true | tar xzf - && \
+    ./update.sh -c $CHANNEL -n -p ~/node -d ~/node/data -i -g $NETWORK
+WORKDIR /root/node
 EOF
 
-    if ! echo "$DOCKERFILE" | docker build -t "algorand/$IMAGE_NAME:$TAGNAME" -
-    then
-        echo -e "\n$RED_FG[$0]$END_FG_COLOR The algorand/$IMAGE_NAME:$TAGNAME image could not be built."
-        exit 1
-    fi
-}
-
-build_image
+if ! echo "$DOCKERFILE" | docker build --no-cache -t "algorand/$IMAGE_NAME:$TAGNAME" -
+then
+    echo -e "\n$RED_FG[$0]$END_FG_COLOR The algorand/$IMAGE_NAME:$TAGNAME image could not be built."
+    exit 1
+fi
 
 if $DEPLOY
 then
     if ! docker push "algorand/$IMAGE_NAME:$TAGNAME"
     then
-        echo -e "\n$RED_FG[$0]$END_FG_COLOR \`docker push\` failed."
+        echo -e "\n$RED_FG[$0]$END_FG_COLOR \`docker push\` of $IMAGE_NAME:$TAGNAME failed."
         exit 1
+    fi
+
+    if [ "$TAGNAME" != 'latest' ]
+    then
+      # We built a new tag, so also tag this as latest.
+      docker tag algorand/$IMAGE_NAME:$TAGNAME algorand/$IMAGE_NAME:latest
+      if ! docker push algorand/$IMAGE_NAME:latest
+      then
+        echo -e "\n$RED_FG[$0]$END_FG_COLOR \`docker push\` of $IMAGE_NAME:latest failed."
+      fi
     fi
 
     echo -e "\n$GREEN_FG[$0]$END_FG_COLOR Successfully published to docker hub."
 fi
 
 echo "$GREEN_FG[$0]$END_FG_COLOR Build completed with no failures."
-

--- a/scripts/release/mule/deploy/docker/docker.sh
+++ b/scripts/release/mule/deploy/docker/docker.sh
@@ -6,7 +6,7 @@
 # For betanet:
 #   ./docker.sh betanet
 #
-set -ex
+set -e
 
 if [ -z "$NETWORK" ] || [ -z "$VERSION" ]; then
     echo "[$0] NETWORK=$NETWORK or VERSION=$VERSION is missing."
@@ -23,24 +23,14 @@ pushd docker/releases
 
 if [ "$NETWORK" = mainnet ]
 then
-    # Build and push mainnet.
-   ./build_releases.sh
+  # Build and push mainnet.
+  ./build_releases.sh --tagname "$VERSION"
 
-    # Build and push testnet.
-   ./build_releases.sh --network testnet
-
-    if [ -z "$VERSION" ]
-    then
-        echo "[$0] No version specified."
-        exit 1
-    fi
-
-   ./build_releases.sh --tagname "$VERSION"
+  # Build and push testnet.
+  ./build_releases.sh --tagname "$VERSION" --network testnet
 elif [ "$NETWORK" = betanet ]
 then
-  ./build_releases.sh --network betanet
-  ./build_releases.sh --network betanet --tagname "$VERSION"
+  ./build_releases.sh --tagname "$VERSION" --network betanet
 fi
 
 popd
-

--- a/scripts/release/mule/deploy/docker/docker.sh
+++ b/scripts/release/mule/deploy/docker/docker.sh
@@ -27,7 +27,7 @@ then
   ./build_releases.sh --tagname "$VERSION"
 
   # Build and push testnet.
-  ./build_releases.sh --tagname "$VERSION" --network testnet
+  ./build_releases.sh --tagname "$VERSION" --network testnet --cached
 elif [ "$NETWORK" = betanet ]
 then
   ./build_releases.sh --tagname "$VERSION" --network betanet


### PR DESCRIPTION
## Summary

The scripts to update the docker repository do not do a full rebuild, and the submitted Dockerfile does not change. This means that if you run the docker image/repo update, it'll re-use the old image. To fix this, we call docker build with --no-cache. Other refactoring helps simplify the code.

We add a new `--cached` flag to the `docker/releases/build_releases.sh` script to explicitly cache. Otherwise the testnet update would issue a full rebuild. We additionally automatically handle the 'latest' tagging in build_releases.sh as well.

## Test Plan

Ran the update for betanet and mainnet/testnet, which seemed to update the container appropriately.

