### PR TITLE
selector pseudo-op in support of ABI

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -644,10 +644,10 @@ func assembleByte(ops *OpStream, spec *OpSpec, args []string) error {
 	return nil
 }
 
-// selector "add(uint64,uint64)uint64"
-func assembleSelector(ops *OpStream, spec *OpSpec, args []string) error {
+// method "add(uint64,uint64)uint64"
+func assembleMethod(ops *OpStream, spec *OpSpec, args []string) error {
 	if len(args) == 0 {
-		return ops.error("selector requires a literal argument")
+		return ops.error("method requires a literal argument")
 	}
 	arg := args[0]
 	if len(arg) > 1 && arg[0] == '"' && arg[len(arg)-1] == '"' {
@@ -1056,7 +1056,7 @@ var keywords = map[string]OpSpec{
 	// parse basics.Address, actually just another []byte constant
 	"addr": {0, "addr", nil, assembleAddr, nil, nil, oneBytes, 1, modeAny, opDetails{1, 2, nil, nil}},
 	// take a signature, hash it, and take first 4 bytes, actually just another []byte constant
-	"selector": {0, "selector", nil, assembleSelector, nil, nil, oneBytes, 1, modeAny, opDetails{1, 2, nil, nil}}}
+	"method": {0, "method", nil, assembleMethod, nil, nil, oneBytes, 1, modeAny, opDetails{1, 2, nil, nil}}}
 
 type lineError struct {
 	Line int

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1056,7 +1056,7 @@ var keywords = map[string]OpSpec{
 	// parse basics.Address, actually just another []byte constant
 	"addr": {0, "addr", nil, assembleAddr, nil, nil, oneBytes, 1, modeAny, opDetails{1, 2, nil, nil}},
 	// take a signature, hash it, and take first 4 bytes, actually just another []byte constant
-	"selector": {0, "selector", nil, assembleSelector, nil, nil, oneBytes, 4, modeAny, opDetails{1, 2, nil, nil}}}
+	"selector": {0, "selector", nil, assembleSelector, nil, nil, oneBytes, 1, modeAny, opDetails{1, 2, nil, nil}}}
 
 type lineError struct {
 	Line int

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -4096,7 +4096,10 @@ func TestBytes(t *testing.T) {
 
 func TestSelector(t *testing.T) {
 	t.Parallel()
-	testAccepts(t, "selector \"add(uint64,uint64)uint128\"; byte 0x8aa3b61f; ==", 4)
+	// Although 'selector' is new around the time of v5, it is a
+	// pseudo-op, so it's ok to use it earlier, as it compiles to
+	// existing opcodes.
+	testAccepts(t, "selector \"add(uint64,uint64)uint128\"; byte 0x8aa3b61f; ==", 1)
 }
 
 func TestSwap(t *testing.T) {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -4094,6 +4094,11 @@ func TestBytes(t *testing.T) {
 	testAccepts(t, `byte "jo"; byte "hn"; concat; dup; int 2; int 105; setbyte; pop; byte "john"; ==`, 3)
 }
 
+func TestSelector(t *testing.T) {
+	t.Parallel()
+	testAccepts(t, "selector \"add(uint64,uint64)uint128\"; byte 0x8aa3b61f; ==", 4)
+}
+
 func TestSwap(t *testing.T) {
 	t.Parallel()
 	testAccepts(t, "int 1; byte 0x1234; swap; int 1; ==; assert; byte 0x1234; ==", 3)

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -4094,12 +4094,12 @@ func TestBytes(t *testing.T) {
 	testAccepts(t, `byte "jo"; byte "hn"; concat; dup; int 2; int 105; setbyte; pop; byte "john"; ==`, 3)
 }
 
-func TestSelector(t *testing.T) {
+func TestMethod(t *testing.T) {
 	t.Parallel()
-	// Although 'selector' is new around the time of v5, it is a
+	// Although 'method' is new around the time of v5, it is a
 	// pseudo-op, so it's ok to use it earlier, as it compiles to
 	// existing opcodes.
-	testAccepts(t, "selector \"add(uint64,uint64)uint128\"; byte 0x8aa3b61f; ==", 1)
+	testAccepts(t, "method \"add(uint64,uint64)uint128\"; byte 0x8aa3b61f; ==", 1)
 }
 
 func TestSwap(t *testing.T) {


### PR DESCRIPTION
Adds a Teal pseudo-op `selector` that assembles as if it were the `byte` pseudo-op, but stores 4 bytes of hash.

This allows Teal, like:
```
txn ApplicationArgs 0
selector "add(uint64,uint64)uint128"
==
bnz add
```

and avoid the need to embed the actual hash in a .teal file (which would also require calculating it)

Unlike `byte`, the argument *must* be a quoted string - no base64 or hex allowed, as the argument should be a method signature.
