### PR TITLE
Updated GetTelemetryHostName() to return GUID

### DIFF
--- a/logging/log.go
+++ b/logging/log.go
@@ -391,10 +391,7 @@ func (l logger) GetTelemetrySession() string {
 }
 
 func (l logger) GetTelemetryHostName() string {
-	if !l.GetTelemetryEnabled() {
-		return ""
-	}
-	return l.loggerState.telemetry.telemetryConfig.getHostName()
+	return l.loggerState.telemetry.telemetryConfig.GUID
 }
 
 func (l logger) GetInstanceName() string {

--- a/logging/telemetry.go
+++ b/logging/telemetry.go
@@ -93,24 +93,44 @@ func makeTelemetryState(cfg TelemetryConfig, hookFactory hookFactory) (*telemetr
 func ReadTelemetryConfigOrDefault(dataDir string, genesisID string) (cfg TelemetryConfig, err error) {
 	err = nil
 	dataDirProvided := dataDir != ""
+	var configPath string
+
+	// If we have a data directory, then load the config
 	if dataDirProvided {
-		configPath := filepath.Join(dataDir, TelemetryConfigFilename)
+		configPath = filepath.Join(dataDir, TelemetryConfigFilename)
+		// Load the config, if the GUID is there then we are all set
+		// However if it isn't there then we must create it, save the file and load it.
 		cfg, err = LoadTelemetryConfig(configPath)
 	}
+
+	// We couldn't load the telemetry config for some reason
+	// If the reason is because the directory doesn't exist or we didn't provide a data directory then...
 	if (err != nil && os.IsNotExist(err)) || !dataDirProvided {
-		var configPath string
+
 		configPath, err = config.GetConfigFilePath(TelemetryConfigFilename)
 		if err != nil {
+			// In this case we don't know what to do since we couldn't
+			// create the directory.  Just create an ephemeral config.
 			cfg = createTelemetryConfig()
 			return
 		}
+
+		// Load the telemetry from the default config path
 		cfg, err = LoadTelemetryConfig(configPath)
 	}
+
+	// If there was some error loading the configuration from the config path...
 	if err != nil {
+		// Create an ephemeral config
 		cfg = createTelemetryConfig()
+
+		// If the error was that the the config wasn't there then it wasn't really an error
+		// We actually want to save the information here
 		if os.IsNotExist(err) {
+			cfg.Save(configPath)
 			err = nil
 		} else {
+			// The error was actually due to a malformed config file...just return
 			return
 		}
 	}
@@ -149,6 +169,8 @@ func EnsureTelemetryConfigCreated(dataDir *string, genesisID string) (TelemetryC
 		configPath, err = config.GetConfigFilePath(TelemetryConfigFilename)
 		if err != nil {
 			cfg := createTelemetryConfig()
+			// Since GetConfigFilePath failed, there is no chance that we
+			// can save the next config files
 			return cfg, true, err
 		}
 		cfg, err = LoadTelemetryConfig(configPath)

--- a/logging/telemetryConfig.go
+++ b/logging/telemetryConfig.go
@@ -81,6 +81,7 @@ func (cfg TelemetryConfig) Save(configPath string) error {
 	if err != nil {
 		return err
 	}
+
 	defer f.Close()
 
 	var marshaledConfig MarshalingTelemetryConfig
@@ -127,6 +128,7 @@ func SanitizeTelemetryString(input string, maxParts int) string {
 	return input
 }
 
+// Returns err if os.Open fails or if config is mal-formed
 func loadTelemetryConfig(path string) (TelemetryConfig, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/logging/telemetry_test.go
+++ b/logging/telemetry_test.go
@@ -335,4 +335,25 @@ func TestReadTelemetryConfigOrDefaultNoDataDir(t *testing.T) {
 	a.Equal(defaultCfgSettings.UserName, cfg.UserName)
 	a.Equal(defaultCfgSettings.Password, cfg.Password)
 	a.Equal(len(defaultCfgSettings.GUID), len(cfg.GUID))
+
+}
+
+func TestReadTelemetryConfigOrDefaultHasSameGUID(t *testing.T) {
+	a := require.New(t)
+	originalGlobalConfigFileRoot, _ := config.GetGlobalConfigFileRoot()
+	config.SetGlobalConfigFileRoot(originalGlobalConfigFileRoot)
+
+	cfg, err := ReadTelemetryConfigOrDefault("", "")
+
+	a.Nil(err)
+	a.NotNil(cfg)
+
+	// Test that if we read twice, then the GUIDs are the same
+	cfg2, err2 := ReadTelemetryConfigOrDefault("", "")
+
+	a.Nil(err2)
+	a.NotNil(cfg2)
+
+	a.Equal(cfg.GUID, cfg2.GUID)
+
 }


### PR DESCRIPTION
Updated the GetTelemetryHostName() function under log.go to return
the GUID even if telemetry is disabled.

Updated the ReadTelemetryConfigOrDefault() function under telemetry.go
with comments as well as saving the configuration.  Included a unit
test to address this.

Added some comments in telemetryConfig.go

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
