### PR TITLE
testing: ensure deploy_linux_version generates a linux/amd64 binaries for algonet usage

### DIFF
--- a/docker/build/Dockerfile-deploy
+++ b/docker/build/Dockerfile-deploy
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM --platform=linux/amd64 ubuntu:18.04
 ARG GOLANG_VERSION
 
 RUN apt-get update && apt-get install -y git libboost-all-dev wget sqlite3 autoconf jq bsdmainutils shellcheck


### PR DESCRIPTION
## Summary

The deploy_linux_version.sh script currently creates a linux version of the current project tree with the same architecture as the hosting environment.

When we attempt to builds on M1 Macs, it default to arm64 base images and as a result - makes a linux/arm64 compatible binaries. These resulting binaries, however, would not work correctly on an algonet deployed network, since the hosts there are amd64.

To rectify that situation, we'll be changing the docker file to ensure linux/amd64 binaries are generated. This would ensure that the existing functionality works as intended. In the future, when we would add arm64 support for algonet, we could accompany that by creating corresponding images on docker as well.

## Test Plan

Tested manually that amd64 compatible binaries were built.