### PR TITLE
allow to parse ipv6 localhost "[::]:4601"

### DIFF
--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1931,7 +1931,7 @@ func ParseHostOrURL(addr string) (*url.URL, error) {
 		}
 		return parsed, nil
 	}
-	if strings.HasPrefix(addr, "http:") || strings.HasPrefix(addr, "https:") || strings.HasPrefix(addr, "ws:") || strings.HasPrefix(addr, "wss:") || strings.HasPrefix(addr, "//") {
+	if strings.HasPrefix(addr, "http:") || strings.HasPrefix(addr, "https:") || strings.HasPrefix(addr, "ws:") || strings.HasPrefix(addr, "wss:") || strings.HasPrefix(addr, "://") || strings.HasPrefix(addr, "//") {
 		return parsed, err
 	}
 	// This turns "[::]:4601" into "http://[::]:4601" which url.Parse can do

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1911,6 +1911,8 @@ var errBcastInvalidArray = errors.New("invalid broadcast array")
 
 var errBcastQFull = errors.New("broadcast queue full")
 
+var errUrlNoHost = errors.New("could not parse a host from url")
+
 // HostColonPortPattern matches "^[^:]+:\\d+$" e.g. "foo.com.:1234"
 var HostColonPortPattern = regexp.MustCompile("^[^:]+:\\d+$")
 
@@ -1924,7 +1926,13 @@ func ParseHostOrURL(addr string) (*url.URL, error) {
 	}
 	parsed, err := url.Parse(addr)
 	if err == nil {
+		if parsed.Host == "" {
+			return nil, errUrlNoHost
+		}
 		return parsed, nil
+	}
+	if strings.HasPrefix(addr, "http:") || strings.HasPrefix(addr, "https:") || strings.HasPrefix(addr, "ws:") || strings.HasPrefix(addr, "wss:") {
+		return parsed, err
 	}
 	// This turns "[::]:4601" into "http://[::]:4601" which url.Parse can do
 	parsed, e2 := url.Parse("http://" + addr)

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1911,10 +1911,10 @@ var errBcastInvalidArray = errors.New("invalid broadcast array")
 
 var errBcastQFull = errors.New("broadcast queue full")
 
-var errUrlNoHost = errors.New("could not parse a host from url")
+var errURLNoHost = errors.New("could not parse a host from url")
 
-// HostColonPortPattern matches "^[^:]+:\\d+$" e.g. "foo.com.:1234"
-var HostColonPortPattern = regexp.MustCompile("^[^:]+:\\d+$")
+// HostColonPortPattern matches "^[a-zA-Z0-9.]+:\\d+$" e.g. "foo.com.:1234"
+var HostColonPortPattern = regexp.MustCompile("^[a-zA-Z0-9.]+:\\d+$")
 
 // ParseHostOrURL handles "host:port" or a full URL.
 // Standard library net/url.Parse chokes on "host:port".
@@ -1927,11 +1927,11 @@ func ParseHostOrURL(addr string) (*url.URL, error) {
 	parsed, err := url.Parse(addr)
 	if err == nil {
 		if parsed.Host == "" {
-			return nil, errUrlNoHost
+			return nil, errURLNoHost
 		}
 		return parsed, nil
 	}
-	if strings.HasPrefix(addr, "http:") || strings.HasPrefix(addr, "https:") || strings.HasPrefix(addr, "ws:") || strings.HasPrefix(addr, "wss:") {
+	if strings.HasPrefix(addr, "http:") || strings.HasPrefix(addr, "https:") || strings.HasPrefix(addr, "ws:") || strings.HasPrefix(addr, "wss:") || strings.HasPrefix(addr, "//") {
 		return parsed, err
 	}
 	// This turns "[::]:4601" into "http://[::]:4601" which url.Parse can do

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -1974,41 +1974,47 @@ func BenchmarkVariableTransactionMessageBlockSizes(t *testing.B) {
 type urlCase struct {
 	text string
 	out  url.URL
-	err  error
-}
-
-var urlTestCases = []urlCase{
-	{"localhost:123", url.URL{Scheme: "http", Host: "localhost:123"}, nil},
-	{"http://localhost:123", url.URL{Scheme: "http", Host: "localhost:123"}, nil},
-	{"ws://localhost:123", url.URL{Scheme: "ws", Host: "localhost:123"}, nil},
-	{"https://localhost:123", url.URL{Scheme: "https", Host: "localhost:123"}, nil},
-	{"http://127.0.0.1:123", url.URL{Scheme: "http", Host: "127.0.0.1:123"}, nil},
-	{"http://[::]:123", url.URL{Scheme: "http", Host: "[::]:123"}, nil},
-	{"1.2.3.4:123", url.URL{Scheme: "http", Host: "1.2.3.4:123"}, nil},
-	{"[::]:123", url.URL{Scheme: "http", Host: "[::]:123"}, nil},
 }
 
 func TestParseHostOrURL(t *testing.T) {
+	urlTestCases := []urlCase{
+		{"localhost:123", url.URL{Scheme: "http", Host: "localhost:123"}},
+		{"http://localhost:123", url.URL{Scheme: "http", Host: "localhost:123"}},
+		{"ws://localhost:9999", url.URL{Scheme: "ws", Host: "localhost:9999"}},
+		{"wss://localhost:443", url.URL{Scheme: "wss", Host: "localhost:443"}},
+		{"https://localhost:123", url.URL{Scheme: "https", Host: "localhost:123"}},
+		{"https://somewhere.tld", url.URL{Scheme: "https", Host: "somewhere.tld"}},
+		{"http://127.0.0.1:123", url.URL{Scheme: "http", Host: "127.0.0.1:123"}},
+		{"http://[::]:123", url.URL{Scheme: "http", Host: "[::]:123"}},
+		{"1.2.3.4:123", url.URL{Scheme: "http", Host: "1.2.3.4:123"}},
+		{"[::]:123", url.URL{Scheme: "http", Host: "[::]:123"}},
+	}
+	badUrls := []string{
+		"justahost",
+		"localhost:WAT",
+		"http://localhost:WAT",
+		"https://localhost:WAT",
+		"ws://localhost:WAT",
+		"wss://localhost:WAT",
+	}
 	for _, tc := range urlTestCases {
 		t.Run(tc.text, func(t *testing.T) {
 			v, err := ParseHostOrURL(tc.text)
-			if (err != nil) && (tc.err == nil) {
+			if err != nil {
 				t.Errorf("unexpected error, %s", err)
 				return
-			}
-			if (err == nil) && (tc.err != nil) {
-				t.Errorf("wanted err but got none")
-				return
-			}
-			if (err != nil) && (tc.err != nil) {
-				if err.Error() != tc.err.Error() {
-					t.Errorf("err mismatch, wanted %#v got %#v", tc.err, err)
-					return
-				}
 			}
 			if tc.out != *v {
 				t.Errorf("url wanted %#v, got %#v", tc.out, v)
 				return
+			}
+		})
+	}
+	for _, addr := range badUrls {
+		t.Run(addr, func(t *testing.T) {
+			_, err := ParseHostOrURL(addr)
+			if err == nil {
+				t.Errorf("url should fail: %#v", addr)
 			}
 		})
 	}

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -1999,6 +1999,8 @@ func TestParseHostOrURL(t *testing.T) {
 		"ws://localhost:WAT",
 		"wss://localhost:WAT",
 		"//localhost:WAT",
+		"://badaddress", // See rpcs/blockService_test.go TestRedirectFallbackEndpoints
+		"://localhost:1234",
 	}
 	for _, tc := range urlTestCases {
 		t.Run(tc.text, func(t *testing.T) {

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -1985,6 +1985,8 @@ func TestParseHostOrURL(t *testing.T) {
 		{"https://localhost:123", url.URL{Scheme: "https", Host: "localhost:123"}},
 		{"https://somewhere.tld", url.URL{Scheme: "https", Host: "somewhere.tld"}},
 		{"http://127.0.0.1:123", url.URL{Scheme: "http", Host: "127.0.0.1:123"}},
+		{"//somewhere.tld", url.URL{Scheme: "", Host: "somewhere.tld"}},
+		{"//somewhere.tld:4601", url.URL{Scheme: "", Host: "somewhere.tld:4601"}},
 		{"http://[::]:123", url.URL{Scheme: "http", Host: "[::]:123"}},
 		{"1.2.3.4:123", url.URL{Scheme: "http", Host: "1.2.3.4:123"}},
 		{"[::]:123", url.URL{Scheme: "http", Host: "[::]:123"}},
@@ -1996,14 +1998,12 @@ func TestParseHostOrURL(t *testing.T) {
 		"https://localhost:WAT",
 		"ws://localhost:WAT",
 		"wss://localhost:WAT",
+		"//localhost:WAT",
 	}
 	for _, tc := range urlTestCases {
 		t.Run(tc.text, func(t *testing.T) {
 			v, err := ParseHostOrURL(tc.text)
-			if err != nil {
-				t.Errorf("unexpected error, %s", err)
-				return
-			}
+			require.NoError(t, err)
 			if tc.out != *v {
 				t.Errorf("url wanted %#v, got %#v", tc.out, v)
 				return
@@ -2013,9 +2013,7 @@ func TestParseHostOrURL(t *testing.T) {
 	for _, addr := range badUrls {
 		t.Run(addr, func(t *testing.T) {
 			_, err := ParseHostOrURL(addr)
-			if err == nil {
-				t.Errorf("url should fail: %#v", addr)
-			}
+			require.Error(t, err, "url should fail", addr)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Allow parsing of ipv6 localhost -colon- port address.
"[::]:4601" was failing to parse. This and other forms pass ParseHostOrURL() now. 

## Test Plan

Added unit test for previously uncovered `ParseHostOrURL()`