### PR TITLE
Initialize past side effects with correct length during dryrun requests

### DIFF
--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -400,7 +400,7 @@ func doDryrunRequest(dr *DryrunRequest, response *generated.DryrunResponse) {
 
 	response.Txns = make([]generated.DryrunTxnResult, len(dr.Txns))
 	for ti, stxn := range dr.Txns {
-		pse := logic.MakePastSideEffects(1)
+		pse := logic.MakePastSideEffects(len(dr.Txns))
 		ep := logic.EvalParams{
 			Txn:             &stxn,
 			Proto:           &proto,


### PR DESCRIPTION
## Summary

This PR fixes a typo in the dryrun code that caused certain dryrun requests containing multiple transactions to fail.

## Test Plan

- A dryrun test containing multiple transactions to show that the bug is now fixed.
