### PR TITLE
Fix 10 minute timeout in travis. (Revert parts of #2324)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
     - stage: build_commit
       os: linux
       script:
-        - scripts/travis/build_test.sh
+        - travis_retry scripts/travis/build_test.sh
 
     - stage: build_pr
       os: linux
@@ -39,12 +39,12 @@ jobs:
       os: linux
       name: Ubuntu AMD64 Build
       script:
-        - scripts/travis/build_test.sh
+        - travis_retry scripts/travis/build_test.sh
     - # same stage, parallel job
       os: linux
       name: Ubuntu AMD64 Integration Test
       script:
-        - ./scripts/travis/integration_test.sh
+        - travis_retry ./scripts/travis/integration_test.sh
     - # same stage, parallel job
       name: External ARM64 Build
       os: linux
@@ -56,7 +56,7 @@ jobs:
           packages:
             - awscli
       script:
-        - scripts/travis/external_build.sh ./scripts/travis/build_test.sh
+        - travis_retry scripts/travis/external_build.sh ./scripts/travis/build_test.sh
     - # same stage, parallel job
       name: External ARM64 Integration Test
       os: linux
@@ -74,13 +74,13 @@ jobs:
       osx_image: xcode11
       name: MacOS AMD64 Build
       script:
-        - scripts/travis/build_test.sh
+        - travis_retry scripts/travis/build_test.sh
     - # same stage, parallel job
       os: osx
       osx_image: xcode11
       name: MacOS AMD64 Integration Test
       script:
-        - ./scripts/travis/integration_test.sh
+        - travis_retry ./scripts/travis/integration_test.sh
     - # same stage, parallel job
        os: windows
        name: Windows x64 Build
@@ -89,7 +89,7 @@ jobs:
            - $HOME/AppData/Local/Temp/chocolatey
            - /C/tools/msys64
        script:
-         - $mingw64 scripts/travis/build_test.sh
+         - travis_retry $mingw64 scripts/travis/build_test.sh
 
     - stage: build_release
       os: linux
@@ -100,12 +100,12 @@ jobs:
       os: linux
       name: Ubuntu AMD64 Build
       script:
-        - ./scripts/travis/build_test.sh
+        - travis_retry ./scripts/travis/build_test.sh
     - # same stage, parallel job
       os: linux
       name: Ubuntu AMD64 Integration Test
       script:
-        - ./scripts/travis/integration_test.sh
+        - travis_retry ./scripts/travis/integration_test.sh
     - # same stage, parallel job
       name: External ARM64 Build
       os: linux
@@ -117,7 +117,7 @@ jobs:
           packages:
             - awscli
       script:
-        - scripts/travis/external_build.sh ./scripts/travis/build_test.sh
+        - travis_retry scripts/travis/external_build.sh ./scripts/travis/build_test.sh
     - # same stage, parallel job
       name: External ARM64 Integration Test
       os: linux
@@ -135,13 +135,13 @@ jobs:
       osx_image: xcode11
       name: MacOS AMD64 Build
       script:
-        - scripts/travis/build_test.sh
+        - travis_retry scripts/travis/build_test.sh
     - # same stage, parallel job
       os: osx
       osx_image: xcode11
       name: MacOS AMD64 Integration Test
       script:
-        - ./scripts/travis/integration_test.sh
+        - travis_retry ./scripts/travis/integration_test.sh
     - # same stage, parallel job
        os: windows
        name: Windows x64 Build
@@ -150,7 +150,7 @@ jobs:
            - $HOME/AppData/Local/Temp/chocolatey
            - /C/tools/msys64
        script:
-         - $mingw64 scripts/travis/build_test.sh
+         - travis_retry $mingw64 scripts/travis/build_test.sh
 
     - stage: deploy
       name: Ubuntu Deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
     - stage: build_commit
       os: linux
       script:
-        - travis_retry scripts/travis/build_test.sh
+        - scripts/travis/build_test.sh
 
     - stage: build_pr
       os: linux
@@ -39,12 +39,12 @@ jobs:
       os: linux
       name: Ubuntu AMD64 Build
       script:
-        - travis_retry scripts/travis/build_test.sh
+        - scripts/travis/build_test.sh
     - # same stage, parallel job
       os: linux
       name: Ubuntu AMD64 Integration Test
       script:
-        - travis_retry ./scripts/travis/integration_test.sh
+        - ./scripts/travis/integration_test.sh
     - # same stage, parallel job
       name: External ARM64 Build
       os: linux
@@ -56,7 +56,7 @@ jobs:
           packages:
             - awscli
       script:
-        - travis_retry scripts/travis/external_build.sh ./scripts/travis/build_test.sh
+        - scripts/travis/external_build.sh ./scripts/travis/build_test.sh
     - # same stage, parallel job
       name: External ARM64 Integration Test
       os: linux
@@ -74,13 +74,13 @@ jobs:
       osx_image: xcode11
       name: MacOS AMD64 Build
       script:
-        - travis_retry scripts/travis/build_test.sh
+        - scripts/travis/build_test.sh
     - # same stage, parallel job
       os: osx
       osx_image: xcode11
       name: MacOS AMD64 Integration Test
       script:
-        - travis_retry ./scripts/travis/integration_test.sh
+        - ./scripts/travis/integration_test.sh
     - # same stage, parallel job
        os: windows
        name: Windows x64 Build
@@ -89,7 +89,7 @@ jobs:
            - $HOME/AppData/Local/Temp/chocolatey
            - /C/tools/msys64
        script:
-         - travis_retry $mingw64 scripts/travis/build_test.sh
+         - $mingw64 scripts/travis/build_test.sh
 
     - stage: build_release
       os: linux
@@ -100,12 +100,12 @@ jobs:
       os: linux
       name: Ubuntu AMD64 Build
       script:
-        - travis_retry ./scripts/travis/build_test.sh
+        - ./scripts/travis/build_test.sh
     - # same stage, parallel job
       os: linux
       name: Ubuntu AMD64 Integration Test
       script:
-        - travis_retry ./scripts/travis/integration_test.sh
+        - ./scripts/travis/integration_test.sh
     - # same stage, parallel job
       name: External ARM64 Build
       os: linux
@@ -117,7 +117,7 @@ jobs:
           packages:
             - awscli
       script:
-        - travis_retry scripts/travis/external_build.sh ./scripts/travis/build_test.sh
+        - scripts/travis/external_build.sh ./scripts/travis/build_test.sh
     - # same stage, parallel job
       name: External ARM64 Integration Test
       os: linux
@@ -135,13 +135,13 @@ jobs:
       osx_image: xcode11
       name: MacOS AMD64 Build
       script:
-        - travis_retry scripts/travis/build_test.sh
+        - scripts/travis/build_test.sh
     - # same stage, parallel job
       os: osx
       osx_image: xcode11
       name: MacOS AMD64 Integration Test
       script:
-        - travis_retry ./scripts/travis/integration_test.sh
+        - ./scripts/travis/integration_test.sh
     - # same stage, parallel job
        os: windows
        name: Windows x64 Build
@@ -150,7 +150,7 @@ jobs:
            - $HOME/AppData/Local/Temp/chocolatey
            - /C/tools/msys64
        script:
-         - travis_retry $mingw64 scripts/travis/build_test.sh
+         - $mingw64 scripts/travis/build_test.sh
 
     - stage: deploy
       name: Ubuntu Deploy

--- a/scripts/travis/build_test.sh
+++ b/scripts/travis/build_test.sh
@@ -16,9 +16,11 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 if [ "${USER}" = "travis" ]; then
     # we're running on a travis machine
     "${SCRIPTPATH}/build.sh" --make_debug
-    "${SCRIPTPATH}/travis_wait.sh" 90 "${SCRIPTPATH}/test.sh"
+    # Need to call travis_retry first, if travis_wait calls travis_retry
+    # it doesn't show the output.
+    "${SCRIPTPATH}/travis_retry.sh" "${SCRIPTPATH}/travis_wait.sh" 90 "${SCRIPTPATH}/test.sh"
 else
     # we're running on an ephermal build machine
     "${SCRIPTPATH}/build.sh" --make_debug
-    "${SCRIPTPATH}/test.sh"
+    "${SCRIPTPATH}/travis_retry.sh" "${SCRIPTPATH}/test.sh"
 fi

--- a/scripts/travis/build_test.sh
+++ b/scripts/travis/build_test.sh
@@ -13,5 +13,12 @@ ALGORAND_DEADLOCK=enable
 export ALGORAND_DEADLOCK
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-"${SCRIPTPATH}/build.sh" --make_debug
-"${SCRIPTPATH}/test.sh"
+if [ "${USER}" = "travis" ]; then
+    # we're running on a travis machine
+    "${SCRIPTPATH}/build.sh" --make_debug
+    "${SCRIPTPATH}/travis_wait.sh" 90 "${SCRIPTPATH}/test.sh"
+else
+    # we're running on an ephermal build machine
+    "${SCRIPTPATH}/build.sh" --make_debug
+    "${SCRIPTPATH}/test.sh"
+fi

--- a/scripts/travis/run_tests.sh
+++ b/scripts/travis/run_tests.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-
 if [ "${BUILD_TYPE}" = "integration" ]; then
     # Run short tests when doing pull requests; leave the long testing for nightly runs.
     if [[ "${TRAVIS_BRANCH}" =~ ^rel/nightly ]]; then
@@ -12,9 +10,9 @@ if [ "${BUILD_TYPE}" = "integration" ]; then
         SHORTTEST=-short
     fi
     export SHORTTEST 
-    "${SCRIPTPATH}/travis_retry.sh" make integration
+    make integration
 elif [ "${TRAVIS_EVENT_TYPE}" = "cron" ] || [[ "${TRAVIS_BRANCH}" =~ ^rel/ ]]; then
-    "${SCRIPTPATH}/travis_retry.sh" make fulltest -j2
+    make fulltest -j2
 else
-    "${SCRIPTPATH}/travis_retry.sh" make shorttest -j2
+    make shorttest -j2
 fi


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
We started seeing the 10-minute timeout error on travis after the recent changes to where travis_retry gets called.

This means travis_wait is still needed. travis_wait and travis_retry don't play well together on the ephemeral build machine, so we basically need to rollback the entire change in #2324 

Note: while making this change I noticed that we don't use travis_retry for all of the build_test.sh / integration_test.sh entries. Not sure why but I left them as they were before #2324 

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan
CI
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
