### PR TITLE
Disable 'make fulltest' in travis builds.

### DIFF
--- a/scripts/travis/run_tests.sh
+++ b/scripts/travis/run_tests.sh
@@ -13,8 +13,9 @@ if [ "${BUILD_TYPE}" = "integration" ]; then
     fi
     export SHORTTEST 
     "${SCRIPTPATH}/travis_retry.sh" make integration
-elif [ "${TRAVIS_EVENT_TYPE}" = "cron" ] || [[ "${TRAVIS_BRANCH}" =~ ^rel/ ]]; then
-    "${SCRIPTPATH}/travis_retry.sh" make fulltest -j2
+# TODO: re-enable fulltest
+#elif [ "${TRAVIS_EVENT_TYPE}" = "cron" ] || [[ "${TRAVIS_BRANCH}" =~ ^rel/ ]]; then
+#    "${SCRIPTPATH}/travis_retry.sh" make fulltest -j2
 else
     "${SCRIPTPATH}/travis_retry.sh" make shorttest -j2
 fi


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
The nightly release hasn't been going out because of testing issues. To unblock things, use the same test profile as PRs until we can finish fixing tests.
<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan
CI
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
