### PR TITLE
testing: avoid running TestAgreementSynchronous10 on nightly build

### DIFF
--- a/agreement/service_test.go
+++ b/agreement/service_test.go
@@ -948,6 +948,7 @@ func TestAgreementSynchronous5(t *testing.T) {
 }
 
 func TestAgreementSynchronous10(t *testing.T) {
+	t.Skip("Skipping flaky agreement integration test")
 	if testing.Short() {
 		t.Skip("Skipping agreement integration test")
 	}


### PR DESCRIPTION
## Summary

The test TestAgreementSynchronous10 is failing. We should be fixing it, but until we do that, I'm going to disable it so it won't mask other issues.

## Test Plan

Disable the test.