### PR TITLE
fix regex for matching charset of valid DNS hosts, add test

### DIFF
--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1913,8 +1913,8 @@ var errBcastQFull = errors.New("broadcast queue full")
 
 var errURLNoHost = errors.New("could not parse a host from url")
 
-// HostColonPortPattern matches "^[a-zA-Z0-9.]+:\\d+$" e.g. "foo.com.:1234"
-var HostColonPortPattern = regexp.MustCompile("^[a-zA-Z0-9.]+:\\d+$")
+// HostColonPortPattern matches "^[-a-zA-Z0-9.]+:\\d+$" e.g. "foo.com.:1234"
+var HostColonPortPattern = regexp.MustCompile("^[-a-zA-Z0-9.]+:\\d+$")
 
 // ParseHostOrURL handles "host:port" or a full URL.
 // Standard library net/url.Parse chokes on "host:port".

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -1990,6 +1990,7 @@ func TestParseHostOrURL(t *testing.T) {
 		{"http://[::]:123", url.URL{Scheme: "http", Host: "[::]:123"}},
 		{"1.2.3.4:123", url.URL{Scheme: "http", Host: "1.2.3.4:123"}},
 		{"[::]:123", url.URL{Scheme: "http", Host: "[::]:123"}},
+		{"r2-devnet.devnet.algodev.network:4560", url.URL{Scheme: "http", Host: "r2-devnet.devnet.algodev.network:4560"}},
 	}
 	badUrls := []string{
 		"justahost",


### PR DESCRIPTION
## Summary

A regex was trying to match valid DNS names but missed the '-' char. Fix.

## Test Plan

Added unit test case.