### PR TITLE
use periodicSyncLogger for cleaner test runs

### DIFF
--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -438,6 +438,7 @@ func TestServiceFetchBlocksMalformed(t *testing.T) {
 
 	// Make Service
 	s := MakeService(logging.Base(), defaultConfig, net, local, &mockedAuthenticator{errorRound: int(lastRoundAtStart + 1)}, nil, nil)
+	s.log = &periodicSyncLogger{Logger: logging.Base()}
 
 	// Start the service ( dummy )
 	s.testStart()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
Use periodicSyncLogger in a test to avoid unnecessary log outputs. 

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan
This is a change to a test. 

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
