### PR TITLE
build: fix travis nightly build failure

### DIFF
--- a/scripts/travis/build_test.sh
+++ b/scripts/travis/build_test.sh
@@ -15,7 +15,7 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 if [ "${USER}" = "travis" ]; then
     # we're running on a travis machine
-    "${SCRIPTPATH}/build.sh" --make_debug
+    "${SCRIPTPATH}/travis_wait.sh" 30 "${SCRIPTPATH}/build.sh" --make_debug
     # Need to call travis_retry first, if travis_wait calls travis_retry
     # it doesn't show the output.
     "${SCRIPTPATH}/travis_retry.sh" "${SCRIPTPATH}/travis_wait.sh" 90 "${SCRIPTPATH}/test.sh"


### PR DESCRIPTION

## Summary

Travis nightly build failed due to no-output for over 10m from build process.

## Test Plan

Run on travis.
