### PR TITLE
1k+ assets: without rowid PoC

### DIFF
--- a/data/basics/userBalance.go
+++ b/data/basics/userBalance.go
@@ -309,6 +309,12 @@ const (
 
 	// AppCreatable is the CreatableType corresponds to apps
 	AppCreatable CreatableType = 1
+
+	// AssetCreatableData corresponds to asset holdings
+	AssetCreatableData CreatableType = 2
+
+	// AppCreatableData means apps local state
+	AppCreatableData CreatableType = 3
 )
 
 // CreatableLocator stores both the creator, whose balance record contains

--- a/data/basics/userBalance_test.go
+++ b/data/basics/userBalance_test.go
@@ -206,16 +206,16 @@ func TestEncodedAccountAllocationBounds(t *testing.T) {
 			require.Failf(t, "proto.MaxAssetsPerAccount > EncodedMaxAssetsPerAccount", "protocol version = %s", protoVer)
 		}
 		if proto.MaxAppsCreated > EncodedMaxAppParams {
-			require.Failf(t, "proto.MaxAppsCreated > encodedMaxAppParams", "protocol version = %s", protoVer)
+			require.Failf(t, "proto.MaxAppsCreated > EncodedMaxAppParams", "protocol version = %s", protoVer)
 		}
 		if proto.MaxAppsOptedIn > EncodedMaxAppLocalStates {
-			require.Failf(t, "proto.MaxAppsOptedIn > encodedMaxAppLocalStates", "protocol version = %s", protoVer)
+			require.Failf(t, "proto.MaxAppsOptedIn > EncodedMaxAppLocalStates", "protocol version = %s", protoVer)
 		}
 		if proto.MaxLocalSchemaEntries > EncodedMaxKeyValueEntries {
-			require.Failf(t, "proto.MaxLocalSchemaEntries > encodedMaxKeyValueEntries", "protocol version = %s", protoVer)
+			require.Failf(t, "proto.MaxLocalSchemaEntries > EncodedMaxKeyValueEntries", "protocol version = %s", protoVer)
 		}
 		if proto.MaxGlobalSchemaEntries > EncodedMaxKeyValueEntries {
-			require.Failf(t, "proto.MaxGlobalSchemaEntries > encodedMaxKeyValueEntries", "protocol version = %s", protoVer)
+			require.Failf(t, "proto.MaxGlobalSchemaEntries > EncodedMaxKeyValueEntries", "protocol version = %s", protoVer)
 		}
 	}
 }

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -1675,6 +1675,10 @@ func accountsNewUpdate(qabu, qabq, qaeu, qaei, qaed *sql.Stmt, addr basics.Addre
 		}
 	}
 
+	if err != nil {
+		return updatedAccounts, err
+	}
+
 	// same logic as above but for asset params
 	if delta.old.pad.NumAssetParams() <= assetsThreshold && len(delta.new.AssetParams) <= assetsThreshold {
 		// AccountData assigned above
@@ -1761,8 +1765,9 @@ func accountsNewUpdate(qabu, qabq, qaeu, qaei, qaed *sql.Stmt, addr basics.Addre
 	// update accountbase
 	if err == nil {
 		var rowsAffected int64
+		var result sql.Result
 		normBalance := delta.new.NormalizedOnlineBalance(genesisProto)
-		result, err := qabu.Exec(normBalance, protocol.Encode(&pad), delta.old.rowid)
+		result, err = qabu.Exec(normBalance, protocol.Encode(&pad), delta.old.rowid)
 		if err == nil {
 			// rowid doesn't change on update.
 			updatedAccounts[updateIdx].rowid = delta.old.rowid

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -1028,7 +1028,7 @@ func lookupImpl(lookupStmt *sql.Stmt, addr basics.Address) (data dbAccountData, 
 	return
 }
 
-func lookupExt(rdb db.Accessor, addr basics.Address, extension func(*sql.Stmt, *ledgercore.PersistedAccountData) error) (data dbAccountData, err error) {
+func lookupExt(rdb db.Accessor, addr basics.Address, extension func(*sql.Stmt, *ledgercore.PersistedAccountData, basics.Round) error) (data dbAccountData, err error) {
 	err = db.Retry(func() error {
 		err = rdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 			lookupStmt, err := tx.Prepare(lookupAcctBaseQuery)
@@ -1049,7 +1049,7 @@ func lookupExt(rdb db.Accessor, addr basics.Address, extension func(*sql.Stmt, *
 			}
 
 			if extension != nil && data.pad.ExtendedAssetHolding.Count > 0 {
-				err = extension(loadStmt, &data.pad)
+				err = extension(loadStmt, &data.pad, data.round)
 			}
 			return err
 		})

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -1664,7 +1664,10 @@ func accountsNewUpdate(qabu, qabq, qaeu, qaei, qaed *sql.Stmt, addr basics.Addre
 			}
 
 			if len(created) > 0 {
-				pad.ExtendedAssetHolding.Insert(created, delta.new.Assets)
+				err = pad.ExtendedAssetHolding.Insert(created, delta.new.Assets)
+				if err != nil {
+					return updatedAccounts, err
+				}
 			}
 
 			loaded, deletedKeys := pad.ExtendedAssetHolding.Merge()

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -568,35 +568,35 @@ func accountsInit(tx *sql.Tx, initAccounts map[basics.Address]basics.AccountData
 		var ot basics.OverflowTracker
 		var totals ledgercore.AccountTotals
 
-		stmt, err := tx.Prepare("INSERT INTO accountcreatabledata (addrid, creatable, ctype, data) VALUES (?, ?, ?, ?)")
-		if err != nil {
-			return true, err
-		}
+		// stmt, err := tx.Prepare("INSERT INTO accountcreatabledata (addrid, creatable, ctype, data) VALUES (?, ?, ?, ?)")
+		// if err != nil {
+		// 	return true, err
+		// }
 		for addr, data := range initAccounts {
 			data2 := data
 			data2.Assets = nil
 			data2.AssetParams = nil
-			res, err := tx.Exec("INSERT INTO accountbase (address, data) VALUES (?, ?)",
+			_, err := tx.Exec("INSERT INTO accountbase (address, data) VALUES (?, ?)",
 				addr[:], protocol.Encode(&data2))
 			if err != nil {
 				return true, err
 			}
-			rowid, err := res.LastInsertId()
-			if err != nil {
-				return true, err
-			}
-			for aidx, holding := range data.Assets {
-				_, err := stmt.Exec(rowid, aidx, basics.AssetCreatableData, protocol.Encode(&holding))
-				if err != nil {
-					return true, err
-				}
-			}
-			for aidx, params := range data.AssetParams {
-				_, err := stmt.Exec(rowid, aidx, basics.AssetCreatable, protocol.Encode(&params))
-				if err != nil {
-					return true, err
-				}
-			}
+			// rowid, err := res.LastInsertId()
+			// if err != nil {
+			// 	return true, err
+			// }
+			// for aidx, holding := range data.Assets {
+			// 	_, err := stmt.Exec(rowid, aidx, basics.AssetCreatableData, protocol.Encode(&holding))
+			// 	if err != nil {
+			// 		return true, err
+			// 	}
+			// }
+			// for aidx, params := range data.AssetParams {
+			// 	_, err := stmt.Exec(rowid, aidx, basics.AssetCreatable, protocol.Encode(&params))
+			// 	if err != nil {
+			// 		return true, err
+			// 	}
+			// }
 
 			totals.AddAccount(proto, data, &ot)
 		}

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -2025,6 +2025,11 @@ func lookupAssetHolding(loadStmt *sql.Stmt, aidx basics.AssetIndex, pad *ledgerc
 			// pad.AccountData.Assets might not be nil because looks up into deltas cache
 			pad.AccountData.Assets = make(map[basics.AssetIndex]basics.AssetHolding, 1)
 		}
+		// clone Assets map before modifying and returning to the caller
+		// the original pad.AccountData.Assets might be in use by apply.Balances / cow logic
+		if len(pad.AccountData.Assets) > 0 {
+			pad.AccountData.Assets = ledgercore.CloneAssetHoldings(pad.AccountData.Assets)
+		}
 		pad.AccountData.Assets[aidx] = pad.ExtendedAssetHolding.Groups[gi].GetHolding(ai)
 		exist = true
 	}
@@ -2038,9 +2043,14 @@ func lookupAssetParams(loadStmt *sql.Stmt, aidx basics.AssetIndex, pad *ledgerco
 	}
 	exist := false
 	if gi != -1 && ai != -1 {
-		if pad.AccountData.Assets == nil {
+		if pad.AccountData.AssetParams == nil {
 			// pad.AccountData.AssetParams might not be nil because looks up into deltas cache
 			pad.AccountData.AssetParams = make(map[basics.AssetIndex]basics.AssetParams, 1)
+		}
+		// clone AssetParams map before modifying and returning to the caller
+		// the original pad.AccountData.AssetParams might be in use by apply.Balances / cow logic
+		if len(pad.AccountData.AssetParams) > 0 {
+			pad.AccountData.AssetParams = ledgercore.CloneAssetParams(pad.AccountData.AssetParams)
 		}
 		pad.AccountData.AssetParams[aidx] = pad.ExtendedAssetParams.Groups[gi].GetParams(ai)
 		exist = true

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1213,22 +1213,6 @@ type lookupFullTestSpec struct {
 	holdings  bool
 }
 
-func cloneAssetHoldings(m map[basics.AssetIndex]basics.AssetHolding) map[basics.AssetIndex]basics.AssetHolding {
-	res := make(map[basics.AssetIndex]basics.AssetHolding, len(m))
-	for id, val := range m {
-		res[id] = val
-	}
-	return res
-}
-
-func cloneAssetParams(m map[basics.AssetIndex]basics.AssetParams) map[basics.AssetIndex]basics.AssetParams {
-	res := make(map[basics.AssetIndex]basics.AssetParams, len(m))
-	for id, val := range m {
-		res[id] = val
-	}
-	return res
-}
-
 func lookupFullTest(t *testing.T, spec []lookupFullTestSpec) {
 	a := require.New(t)
 	inMemory := false
@@ -1294,7 +1278,7 @@ func lookupFullTest(t *testing.T, spec []lookupFullTestSpec) {
 					ads[i].AssetParams = make(map[basics.AssetIndex]basics.AssetParams)
 				}
 				ads[i].AssetParams[basics.AssetIndex(cidx)] = basics.AssetParams{Total: uint64(cidx), DefaultFrozen: true, AssetName: "test"}
-				pad.AccountData.AssetParams = cloneAssetParams(ads[i].AssetParams)
+				pad.AccountData.AssetParams = ledgercore.CloneAssetParams(ads[i].AssetParams)
 				deltas.SetEntityDelta(addresses[i], cidx, ledgercore.ActionParamsCreate)
 			}
 			if spec[i].holdings {
@@ -1302,7 +1286,7 @@ func lookupFullTest(t *testing.T, spec []lookupFullTestSpec) {
 					ads[i].Assets = make(map[basics.AssetIndex]basics.AssetHolding)
 				}
 				ads[i].Assets[basics.AssetIndex(cidx)] = basics.AssetHolding{Amount: uint64(cidx), Frozen: true}
-				pad.AccountData.Assets = cloneAssetHoldings(ads[i].Assets)
+				pad.AccountData.Assets = ledgercore.CloneAssetHoldings(ads[i].Assets)
 				deltas.SetEntityDelta(addresses[i], cidx, ledgercore.ActionHoldingCreate)
 			}
 			deltas.Upsert(addresses[i], pad)
@@ -1408,11 +1392,11 @@ func TestLargeAssetHoldingsLargeBlock(t *testing.T) {
 		cidx := basics.CreatableIndex(aidx)
 
 		ad.AssetParams[basics.AssetIndex(cidx)] = basics.AssetParams{Total: uint64(cidx), DefaultFrozen: true, AssetName: "test"}
-		pad.AccountData.AssetParams = cloneAssetParams(ad.AssetParams)
+		pad.AccountData.AssetParams = ledgercore.CloneAssetParams(ad.AssetParams)
 		deltas.SetEntityDelta(addr, cidx, ledgercore.ActionParamsCreate)
 
 		ad.Assets[basics.AssetIndex(cidx)] = basics.AssetHolding{Amount: uint64(cidx), Frozen: true}
-		pad.AccountData.Assets = cloneAssetHoldings(ad.Assets)
+		pad.AccountData.Assets = ledgercore.CloneAssetHoldings(ad.Assets)
 		deltas.SetEntityDelta(addr, cidx, ledgercore.ActionHoldingCreate)
 		deltas.Upsert(addr, pad)
 	}
@@ -1443,11 +1427,11 @@ func TestLargeAssetHoldingsLargeBlock(t *testing.T) {
 		cidx := basics.CreatableIndex(aidx)
 
 		ad.AssetParams[basics.AssetIndex(cidx)] = basics.AssetParams{Total: uint64(cidx), DefaultFrozen: true, AssetName: "test"}
-		pad.AccountData.AssetParams = cloneAssetParams(ad.AssetParams)
+		pad.AccountData.AssetParams = ledgercore.CloneAssetParams(ad.AssetParams)
 		deltas.SetEntityDelta(addr, cidx, ledgercore.ActionParamsCreate)
 
 		ad.Assets[basics.AssetIndex(cidx)] = basics.AssetHolding{Amount: uint64(cidx), Frozen: true}
-		pad.AccountData.Assets = cloneAssetHoldings(ad.Assets)
+		pad.AccountData.Assets = ledgercore.CloneAssetHoldings(ad.Assets)
 		deltas.SetEntityDelta(addr, cidx, ledgercore.ActionHoldingCreate)
 		deltas.Upsert(addr, pad)
 	}

--- a/ledger/appcow_test.go
+++ b/ledger/appcow_test.go
@@ -45,7 +45,7 @@ func (ml *emptyLedger) lookup(addr basics.Address) (ledgercore.PersistedAccountD
 	return ledgercore.PersistedAccountData{}, nil
 }
 
-func (ml *emptyLedger) lookupCreatableData(basics.Address, []creatableDataLocator) (ledgercore.PersistedAccountData, error) {
+func (ml *emptyLedger) lookupCreatableData(basics.Address, []basics.CreatableLocator) (ledgercore.PersistedAccountData, error) {
 	return ledgercore.PersistedAccountData{}, nil
 }
 

--- a/ledger/appdbg.go
+++ b/ledger/appdbg.go
@@ -53,7 +53,7 @@ func (w *ledgerForCowBaseWrapper) lookupWithoutRewards(rnd basics.Round, addr ba
 	return ledgercore.PersistedAccountData{AccountData: ad}, rnd, err
 }
 
-func (w *ledgerForCowBaseWrapper) lookupCreatableDataWithoutRewards(rnd basics.Round, addr basics.Address, locators []creatableDataLocator) (ledgercore.PersistedAccountData, error) {
+func (w *ledgerForCowBaseWrapper) lookupCreatableDataWithoutRewards(rnd basics.Round, addr basics.Address, locators []basics.CreatableLocator) (ledgercore.PersistedAccountData, error) {
 	ad, _, err := w.l.LookupWithoutRewards(rnd, addr)
 	return ledgercore.PersistedAccountData{AccountData: ad}, err
 }

--- a/ledger/apply/application.go
+++ b/ledger/apply/application.go
@@ -25,28 +25,6 @@ import (
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 )
 
-// Allocate the map of basics.AppParams if it is nil, and return a copy. We do *not*
-// call clone on each basics.AppParams -- callers must do that for any values where
-// they intend to modify a contained reference type.
-func cloneAppParams(m map[basics.AppIndex]basics.AppParams) map[basics.AppIndex]basics.AppParams {
-	res := make(map[basics.AppIndex]basics.AppParams, len(m))
-	for k, v := range m {
-		res[k] = v
-	}
-	return res
-}
-
-// Allocate the map of LocalStates if it is nil, and return a copy. We do *not*
-// call clone on each AppLocalState -- callers must do that for any values
-// where they intend to modify a contained reference type.
-func cloneAppLocalStates(m map[basics.AppIndex]basics.AppLocalState) map[basics.AppIndex]basics.AppLocalState {
-	res := make(map[basics.AppIndex]basics.AppLocalState, len(m))
-	for k, v := range m {
-		res[k] = v
-	}
-	return res
-}
-
 // getAppParams fetches the creator address and basics.AppParams for the app index,
 // if they exist. It does *not* clone the basics.AppParams, so the returned params
 // must not be modified directly.
@@ -94,7 +72,7 @@ func createApplication(ac *transactions.ApplicationCallTxnFields, balances Balan
 	}
 
 	// Clone app params, so that we have a copy that is safe to modify
-	record.AppParams = cloneAppParams(record.AppParams)
+	record.AppParams = ledgercore.CloneAppParams(record.AppParams)
 
 	// Allocate the new app params (+ 1 to match Assets Idx namespace)
 	appIdx = basics.AppIndex(txnCounter + 1)
@@ -158,7 +136,7 @@ func deleteApplication(balances Balances, creator basics.Address, appIdx basics.
 	record.TotalAppSchema = totalSchema
 
 	// Delete the AppParams
-	record.AppParams = cloneAppParams(record.AppParams)
+	record.AppParams = ledgercore.CloneAppParams(record.AppParams)
 	delete(record.AppParams, appIdx)
 
 	// Delete app's extra program pages
@@ -197,7 +175,7 @@ func updateApplication(ac *transactions.ApplicationCallTxnFields, balances Balan
 	}
 
 	// Fill in the new programs
-	record.AppParams = cloneAppParams(record.AppParams)
+	record.AppParams = ledgercore.CloneAppParams(record.AppParams)
 	params := record.AppParams[appIdx]
 	params.ApprovalProgram = ac.ApprovalProgram
 	params.ClearStateProgram = ac.ClearStateProgram
@@ -225,7 +203,7 @@ func optInApplication(balances Balances, sender basics.Address, appIdx basics.Ap
 	}
 
 	// Write an AppLocalState, opting in the user
-	record.AppLocalStates = cloneAppLocalStates(record.AppLocalStates)
+	record.AppLocalStates = ledgercore.CloneAppLocalStates(record.AppLocalStates)
 	record.AppLocalStates[appIdx] = basics.AppLocalState{
 		Schema: params.LocalStateSchema,
 	}
@@ -271,7 +249,7 @@ func closeOutApplication(balances Balances, sender basics.Address, appIdx basics
 	record.TotalAppSchema = totalSchema
 
 	// Delete the local state
-	record.AppLocalStates = cloneAppLocalStates(record.AppLocalStates)
+	record.AppLocalStates = ledgercore.CloneAppLocalStates(record.AppLocalStates)
 	delete(record.AppLocalStates, appIdx)
 
 	// Write closed-out user back to cow

--- a/ledger/apply/application_test.go
+++ b/ledger/apply/application_test.go
@@ -292,11 +292,11 @@ func TestAppCallCloneEmpty(t *testing.T) {
 	a := require.New(t)
 
 	var ls map[basics.AppIndex]basics.AppLocalState
-	cls := cloneAppLocalStates(ls)
+	cls := ledgercore.CloneAppLocalStates(ls)
 	a.Equal(0, len(cls))
 
 	var ap map[basics.AppIndex]basics.AppParams
-	cap := cloneAppParams(ap)
+	cap := ledgercore.CloneAppParams(ap)
 	a.Equal(0, len(cap))
 }
 
@@ -509,8 +509,8 @@ func TestAppCallApplyCreate(t *testing.T) {
 
 	// now we give the creator the app params again
 	cp := basics.AccountData{}
-	cp.AppParams = cloneAppParams(saved.AppParams)
-	cp.AppLocalStates = cloneAppLocalStates(saved.AppLocalStates)
+	cp.AppParams = ledgercore.CloneAppParams(saved.AppParams)
+	cp.AppLocalStates = ledgercore.CloneAppLocalStates(saved.AppLocalStates)
 	b.balances[creator] = cp
 	err = ApplicationCall(ac, h, &b, ad, &ep, txnCounter)
 	a.Error(err)
@@ -530,8 +530,8 @@ func TestAppCallApplyCreate(t *testing.T) {
 
 	b.pass = true
 	cp = basics.AccountData{}
-	cp.AppParams = cloneAppParams(saved.AppParams)
-	cp.AppLocalStates = cloneAppLocalStates(saved.AppLocalStates)
+	cp.AppParams = ledgercore.CloneAppParams(saved.AppParams)
+	cp.AppLocalStates = ledgercore.CloneAppLocalStates(saved.AppLocalStates)
 	cp.TotalAppSchema = saved.TotalAppSchema
 	b.balances[creator] = cp
 

--- a/ledger/apply/application_test.go
+++ b/ledger/apply/application_test.go
@@ -132,7 +132,7 @@ func (b *testBalances) Get(addr basics.Address, withPendingRewards bool) (basics
 	return ad, nil
 }
 
-func (b *testBalances) GetEx(addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType, global bool, local bool) (basics.AccountData, error) {
+func (b *testBalances) GetEx(addr basics.Address, cidx basics.CreatableIndex, ctypes []basics.CreatableType) (basics.AccountData, error) {
 	ad, ok := b.balances[addr]
 	if !ok {
 		return basics.AccountData{}, fmt.Errorf("mock balance not found")
@@ -206,7 +206,7 @@ func (b *testBalancesPass) Get(addr basics.Address, withPendingRewards bool) (ba
 	return ad, nil
 }
 
-func (b *testBalancesPass) GetEx(addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType, global bool, local bool) (basics.AccountData, error) {
+func (b *testBalancesPass) GetEx(addr basics.Address, cidx basics.CreatableIndex, ctypes []basics.CreatableType) (basics.AccountData, error) {
 	ad, ok := b.balances[addr]
 	if !ok {
 		return basics.AccountData{}, fmt.Errorf("mock balance not found")

--- a/ledger/apply/apply.go
+++ b/ledger/apply/apply.go
@@ -33,7 +33,7 @@ type Balances interface {
 
 	// GetEx is like Get(addr, false), but also loads specific creatable
 	// params and holding flags correspond to Params/AppGlobal and Assets/AppLocalState maps depending on creatable type
-	GetEx(addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType, params bool, holding bool) (basics.AccountData, error)
+	GetEx(addr basics.Address, cidx basics.CreatableIndex, ctypes []basics.CreatableType) (basics.AccountData, error)
 
 	Put(basics.Address, basics.AccountData) error
 

--- a/ledger/apply/asset.go
+++ b/ledger/apply/asset.go
@@ -21,23 +21,8 @@ import (
 
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 )
-
-func cloneAssetHoldings(m map[basics.AssetIndex]basics.AssetHolding) map[basics.AssetIndex]basics.AssetHolding {
-	res := make(map[basics.AssetIndex]basics.AssetHolding, len(m))
-	for id, val := range m {
-		res[id] = val
-	}
-	return res
-}
-
-func cloneAssetParams(m map[basics.AssetIndex]basics.AssetParams) map[basics.AssetIndex]basics.AssetParams {
-	res := make(map[basics.AssetIndex]basics.AssetParams, len(m))
-	for id, val := range m {
-		res[id] = val
-	}
-	return res
-}
 
 func getParams(balances Balances, aidx basics.AssetIndex) (params basics.AssetParams, creator basics.Address, err error) {
 	creator, exists, err := balances.GetCreator(basics.CreatableIndex(aidx), basics.AssetCreatable)
@@ -78,8 +63,8 @@ func AssetConfig(cc transactions.AssetConfigTxnFields, header transactions.Heade
 		if err != nil {
 			return err
 		}
-		record.Assets = cloneAssetHoldings(record.Assets)
-		record.AssetParams = cloneAssetParams(record.AssetParams)
+		record.Assets = ledgercore.CloneAssetHoldings(record.Assets)
+		record.AssetParams = ledgercore.CloneAssetParams(record.AssetParams)
 
 		// Sanity check that there isn't an asset with this counter value.
 		_, present := record.AssetParams[newidx]
@@ -131,8 +116,8 @@ func AssetConfig(cc transactions.AssetConfigTxnFields, header transactions.Heade
 		return err
 	}
 
-	record.Assets = cloneAssetHoldings(record.Assets)
-	record.AssetParams = cloneAssetParams(record.AssetParams)
+	record.Assets = ledgercore.CloneAssetHoldings(record.Assets)
+	record.AssetParams = ledgercore.CloneAssetParams(record.AssetParams)
 
 	var deleted *basics.CreatableLocator
 	if cc.AssetParams == (basics.AssetParams{}) {
@@ -186,7 +171,7 @@ func takeOut(balances Balances, addr basics.Address, asset basics.AssetIndex, am
 		return err
 	}
 
-	snd.Assets = cloneAssetHoldings(snd.Assets)
+	snd.Assets = ledgercore.CloneAssetHoldings(snd.Assets)
 	sndHolding, ok := snd.Assets[asset]
 	if !ok {
 		return fmt.Errorf("asset %v missing from %v", asset, addr)
@@ -218,7 +203,7 @@ func putIn(balances Balances, addr basics.Address, asset basics.AssetIndex, amou
 		return err
 	}
 
-	rcv.Assets = cloneAssetHoldings(rcv.Assets)
+	rcv.Assets = ledgercore.CloneAssetHoldings(rcv.Assets)
 	rcvHolding, ok := rcv.Assets[asset]
 	if !ok {
 		return fmt.Errorf("asset %v missing from %v", asset, addr)
@@ -271,7 +256,7 @@ func AssetTransfer(ct transactions.AssetTransferTxnFields, header transactions.H
 			return err
 		}
 
-		snd.Assets = cloneAssetHoldings(snd.Assets)
+		snd.Assets = ledgercore.CloneAssetHoldings(snd.Assets)
 		sndHolding, ok := snd.Assets[ct.XferAsset]
 		if !ok {
 			// Initialize holding with default Frozen value.
@@ -383,7 +368,7 @@ func AssetTransfer(ct transactions.AssetTransferTxnFields, header transactions.H
 			return err
 		}
 
-		snd.Assets = cloneAssetHoldings(snd.Assets)
+		snd.Assets = ledgercore.CloneAssetHoldings(snd.Assets)
 		sndHolding = snd.Assets[ct.XferAsset]
 		if sndHolding.Amount != 0 {
 			return fmt.Errorf("asset %v not zero (%d) after closing", ct.XferAsset, sndHolding.Amount)
@@ -420,7 +405,7 @@ func AssetFreeze(cf transactions.AssetFreezeTxnFields, header transactions.Heade
 	if err != nil {
 		return err
 	}
-	record.Assets = cloneAssetHoldings(record.Assets)
+	record.Assets = ledgercore.CloneAssetHoldings(record.Assets)
 
 	holding, ok := record.Assets[cf.FreezeAsset]
 	if !ok {

--- a/ledger/apply/asset.go
+++ b/ledger/apply/asset.go
@@ -37,7 +37,7 @@ func getParams(balances Balances, aidx basics.AssetIndex) (params basics.AssetPa
 		return
 	}
 
-	creatorRecord, err := balances.GetEx(creator, basics.CreatableIndex(aidx), basics.AssetCreatable, true, false)
+	creatorRecord, err := balances.GetEx(creator, basics.CreatableIndex(aidx), []basics.CreatableType{basics.AssetCreatable})
 	if err != nil {
 		return
 	}
@@ -59,7 +59,7 @@ func AssetConfig(cc transactions.AssetConfigTxnFields, header transactions.Heade
 		// Ensure index is never zero
 		newidx := basics.AssetIndex(txnCounter + 1)
 
-		record, err := balances.GetEx(header.Sender, basics.CreatableIndex(newidx), basics.AssetCreatable, true, true)
+		record, err := balances.GetEx(header.Sender, basics.CreatableIndex(newidx), []basics.CreatableType{basics.AssetCreatable, basics.AssetCreatableData})
 		if err != nil {
 			return err
 		}
@@ -111,7 +111,7 @@ func AssetConfig(cc transactions.AssetConfigTxnFields, header transactions.Heade
 		return fmt.Errorf("this transaction should be issued by the manager. It is issued by %v, manager key %v", header.Sender, params.Manager)
 	}
 
-	record, err := balances.GetEx(creator, basics.CreatableIndex(cc.ConfigAsset), basics.AssetCreatable, true, true)
+	record, err := balances.GetEx(creator, basics.CreatableIndex(cc.ConfigAsset), []basics.CreatableType{basics.AssetCreatable, basics.AssetCreatableData})
 	if err != nil {
 		return err
 	}
@@ -164,9 +164,7 @@ func takeOut(balances Balances, addr basics.Address, asset basics.AssetIndex, am
 		return nil
 	}
 
-	const fetchParams = false
-	const fetchHolding = true
-	snd, err := balances.GetEx(addr, basics.CreatableIndex(asset), basics.AssetCreatable, fetchParams, fetchHolding)
+	snd, err := balances.GetEx(addr, basics.CreatableIndex(asset), []basics.CreatableType{basics.AssetCreatableData})
 	if err != nil {
 		return err
 	}
@@ -196,9 +194,7 @@ func putIn(balances Balances, addr basics.Address, asset basics.AssetIndex, amou
 		return nil
 	}
 
-	const fetchParams = false
-	const fetchHolding = true
-	rcv, err := balances.GetEx(addr, basics.CreatableIndex(asset), basics.AssetCreatable, fetchParams, fetchHolding)
+	rcv, err := balances.GetEx(addr, basics.CreatableIndex(asset), []basics.CreatableType{basics.AssetCreatableData})
 	if err != nil {
 		return err
 	}
@@ -249,9 +245,7 @@ func AssetTransfer(ct transactions.AssetTransferTxnFields, header transactions.H
 
 	// Allocate a slot for asset (self-transfer of zero amount).
 	if ct.AssetAmount == 0 && ct.AssetReceiver == source && !clawback {
-		const fetchParams = false
-		const fetchHolding = true
-		snd, err := balances.GetEx(source, basics.CreatableIndex(ct.XferAsset), basics.AssetCreatable, fetchParams, fetchHolding)
+		snd, err := balances.GetEx(source, basics.CreatableIndex(ct.XferAsset), []basics.CreatableType{basics.AssetCreatableData})
 		if err != nil {
 			return err
 		}
@@ -306,9 +300,7 @@ func AssetTransfer(ct transactions.AssetTransferTxnFields, header transactions.H
 		// Fetch the sender balance record. We will use this to ensure
 		// that the sender is not the creator of the asset, and to
 		// figure out how much of the asset to move.
-		var fetchParams = true
-		var fetchHolding = true
-		snd, err := balances.GetEx(source, basics.CreatableIndex(ct.XferAsset), basics.AssetCreatable, fetchParams, fetchHolding)
+		snd, err := balances.GetEx(source, basics.CreatableIndex(ct.XferAsset), []basics.CreatableType{basics.AssetCreatable, basics.AssetCreatableData})
 		if err != nil {
 			return err
 		}
@@ -329,9 +321,7 @@ func AssetTransfer(ct transactions.AssetTransferTxnFields, header transactions.H
 
 		// Fetch the destination balance record to check if we are
 		// closing out to the creator
-		fetchParams = true
-		fetchHolding = false
-		dst, err := balances.GetEx(ct.AssetCloseTo, basics.CreatableIndex(ct.XferAsset), basics.AssetCreatable, fetchParams, fetchHolding)
+		dst, err := balances.GetEx(ct.AssetCloseTo, basics.CreatableIndex(ct.XferAsset), []basics.CreatableType{basics.AssetCreatable})
 		if err != nil {
 			return err
 		}
@@ -361,9 +351,7 @@ func AssetTransfer(ct transactions.AssetTransferTxnFields, header transactions.H
 		}
 
 		// Delete the slot from the account.
-		fetchParams = false
-		fetchHolding = true
-		snd, err = balances.GetEx(source, basics.CreatableIndex(ct.XferAsset), basics.AssetCreatable, fetchParams, fetchHolding)
+		snd, err = balances.GetEx(source, basics.CreatableIndex(ct.XferAsset), []basics.CreatableType{basics.AssetCreatableData})
 		if err != nil {
 			return err
 		}
@@ -399,9 +387,7 @@ func AssetFreeze(cf transactions.AssetFreezeTxnFields, header transactions.Heade
 	}
 
 	// Get the account to be frozen/unfrozen.
-	const fetchParams = false
-	const fetchHolding = true
-	record, err := balances.GetEx(cf.FreezeAccount, basics.CreatableIndex(cf.FreezeAsset), basics.AssetCreatable, fetchParams, fetchHolding)
+	record, err := balances.GetEx(cf.FreezeAccount, basics.CreatableIndex(cf.FreezeAsset), []basics.CreatableType{basics.AssetCreatableData})
 	if err != nil {
 		return err
 	}

--- a/ledger/apply/asset_test.go
+++ b/ledger/apply/asset_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -110,7 +111,7 @@ func BenchmarkAssetCloning(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		clone := cloneAssetHoldings(assets)
+		clone := ledgercore.CloneAssetHoldings(assets)
 		benchTotal += len(clone) // make sure the compiler does not optimize out cloneAssetHoldings call
 	}
 }

--- a/ledger/apply/keyreg_test.go
+++ b/ledger/apply/keyreg_test.go
@@ -40,7 +40,7 @@ func (balances keyregTestBalances) Get(addr basics.Address, withPendingRewards b
 	return balances.addrs[addr], nil
 }
 
-func (balances keyregTestBalances) GetEx(basics.Address, basics.CreatableIndex, basics.CreatableType, bool, bool) (basics.AccountData, error) {
+func (balances keyregTestBalances) GetEx(basics.Address, basics.CreatableIndex, []basics.CreatableType) (basics.AccountData, error) {
 	return basics.AccountData{}, nil
 }
 

--- a/ledger/apply/mockBalances_test.go
+++ b/ledger/apply/mockBalances_test.go
@@ -69,7 +69,7 @@ func (balances mockBalances) Get(addr basics.Address, withPendingRewards bool) (
 	return balances.b[addr], nil
 }
 
-func (balances mockBalances) GetEx(addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType, global bool, local bool) (basics.AccountData, error) {
+func (balances mockBalances) GetEx(addr basics.Address, cidx basics.CreatableIndex, ctypes []basics.CreatableType) (basics.AccountData, error) {
 	return balances.b[addr], nil
 }
 

--- a/ledger/cow.go
+++ b/ledger/cow.go
@@ -226,12 +226,14 @@ func (cb *roundCowState) lookupCreatableData(addr basics.Address, locators []cre
 			if loc.global {
 				params, parentOk := parentPad.AccountData.AssetParams[basics.AssetIndex(loc.cidx)]
 				if _, ok := pad.AccountData.AssetParams[basics.AssetIndex(loc.cidx)]; !ok && parentOk {
+					pad.AccountData.AssetParams = ledgercore.CloneAssetParams(pad.AccountData.AssetParams)
 					pad.AccountData.AssetParams[basics.AssetIndex(loc.cidx)] = params
 				}
 			}
 			if loc.local {
 				holding, parentOk := parentPad.AccountData.Assets[basics.AssetIndex(loc.cidx)]
 				if _, ok := pad.AccountData.Assets[basics.AssetIndex(loc.cidx)]; !ok && parentOk {
+					pad.AccountData.Assets = ledgercore.CloneAssetHoldings(pad.AccountData.Assets)
 					pad.AccountData.Assets[basics.AssetIndex(loc.cidx)] = holding
 				}
 			}
@@ -239,12 +241,14 @@ func (cb *roundCowState) lookupCreatableData(addr basics.Address, locators []cre
 			if loc.global {
 				params, parentOk := parentPad.AccountData.AppParams[basics.AppIndex(loc.cidx)]
 				if _, ok := pad.AccountData.AppParams[basics.AppIndex(loc.cidx)]; !ok && parentOk {
+					pad.AccountData.AppParams = ledgercore.CloneAppParams(pad.AccountData.AppParams)
 					pad.AccountData.AppParams[basics.AppIndex(loc.cidx)] = params
 				}
 			}
 			if loc.local {
 				states, parentOk := parentPad.AccountData.AppLocalStates[basics.AppIndex(loc.cidx)]
 				if _, ok := pad.AccountData.AppLocalStates[basics.AppIndex(loc.cidx)]; !ok && parentOk {
+					pad.AccountData.AppLocalStates = ledgercore.CloneAppLocalStates(pad.AccountData.AppLocalStates)
 					pad.AccountData.AppLocalStates[basics.AppIndex(loc.cidx)] = states
 				}
 			}

--- a/ledger/cow.go
+++ b/ledger/cow.go
@@ -210,26 +210,30 @@ func (cb *roundCowState) lookupCreatableData(addr basics.Address, locators []bas
 		case basics.AssetCreatable:
 			params, parentOk := parentPad.AccountData.AssetParams[basics.AssetIndex(loc.Index)]
 			if _, ok := pad.AccountData.AssetParams[basics.AssetIndex(loc.Index)]; !ok && parentOk {
-				pad.AccountData.AssetParams = ledgercore.CloneAssetParams(pad.AccountData.AssetParams)
-				pad.AccountData.AssetParams[basics.AssetIndex(loc.Index)] = params
+				clone := ledgercore.CloneAssetParams(pad.AccountData.AssetParams)
+				clone[basics.AssetIndex(loc.Index)] = params
+				pad.AccountData.AssetParams = clone
 			}
 		case basics.AssetCreatableData:
 			holding, parentOk := parentPad.AccountData.Assets[basics.AssetIndex(loc.Index)]
 			if _, ok := pad.AccountData.Assets[basics.AssetIndex(loc.Index)]; !ok && parentOk {
-				pad.AccountData.Assets = ledgercore.CloneAssetHoldings(pad.AccountData.Assets)
-				pad.AccountData.Assets[basics.AssetIndex(loc.Index)] = holding
+				clone := ledgercore.CloneAssetHoldings(pad.AccountData.Assets)
+				clone[basics.AssetIndex(loc.Index)] = holding
+				pad.AccountData.Assets = clone
 			}
 		case basics.AppCreatable:
 			params, parentOk := parentPad.AccountData.AppParams[basics.AppIndex(loc.Index)]
 			if _, ok := pad.AccountData.AppParams[basics.AppIndex(loc.Index)]; !ok && parentOk {
-				pad.AccountData.AppParams = ledgercore.CloneAppParams(pad.AccountData.AppParams)
-				pad.AccountData.AppParams[basics.AppIndex(loc.Index)] = params
+				clone := ledgercore.CloneAppParams(pad.AccountData.AppParams)
+				clone[basics.AppIndex(loc.Index)] = params
+				pad.AccountData.AppParams = clone
 			}
 		case basics.AppCreatableData:
 			states, parentOk := parentPad.AccountData.AppLocalStates[basics.AppIndex(loc.Index)]
 			if _, ok := pad.AccountData.AppLocalStates[basics.AppIndex(loc.Index)]; !ok && parentOk {
-				pad.AccountData.AppLocalStates = ledgercore.CloneAppLocalStates(pad.AccountData.AppLocalStates)
-				pad.AccountData.AppLocalStates[basics.AppIndex(loc.Index)] = states
+				clone := ledgercore.CloneAppLocalStates(pad.AccountData.AppLocalStates)
+				clone[basics.AppIndex(loc.Index)] = states
+				pad.AccountData.AppLocalStates = clone
 			}
 		}
 	}

--- a/ledger/cow.go
+++ b/ledger/cow.go
@@ -40,7 +40,7 @@ import (
 type roundCowParent interface {
 	// lookout with rewards
 	lookup(basics.Address) (ledgercore.PersistedAccountData, error)
-	lookupCreatableData(basics.Address, []creatableDataLocator) (ledgercore.PersistedAccountData, error)
+	lookupCreatableData(basics.Address, []basics.CreatableLocator) (ledgercore.PersistedAccountData, error)
 	checkDup(basics.Round, basics.Round, transactions.Txid, ledgercore.Txlease) error
 	txnCounter() uint64
 	getCreator(cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.Address, bool, error)
@@ -171,44 +171,28 @@ func (cb *roundCowState) lookup(addr basics.Address) (pad ledgercore.PersistedAc
 }
 
 // lookupWithHolding is gets account data but also fetches asset holding or app local data for a specified creatable
-func (cb *roundCowState) lookupCreatableData(addr basics.Address, locators []creatableDataLocator) (data ledgercore.PersistedAccountData, err error) {
+func (cb *roundCowState) lookupCreatableData(addr basics.Address, locators []basics.CreatableLocator) (data ledgercore.PersistedAccountData, err error) {
 	pad, modified := cb.mods.Accts.Get(addr)
 	if modified {
-		foundInModified := make([]bool, 0, len(locators))
+		foundInModified := 0
 		for _, loc := range locators {
-			globalExist := false
-			localExist := false
-			if loc.ctype == basics.AssetCreatable {
-				if loc.global {
-					_, globalExist = pad.AccountData.AssetParams[basics.AssetIndex(loc.cidx)]
-				}
-				if loc.local {
-					_, localExist = pad.AccountData.Assets[basics.AssetIndex(loc.cidx)]
-				}
-			} else {
-				if loc.global {
-					_, globalExist = pad.AccountData.AppParams[basics.AppIndex(loc.cidx)]
-				}
-				if loc.local {
-					_, localExist = pad.AccountData.AppLocalStates[basics.AppIndex(loc.cidx)]
-				}
+			found := false
+			switch loc.Type {
+			case basics.AssetCreatable:
+				_, found = pad.AccountData.AssetParams[basics.AssetIndex(loc.Index)]
+			case basics.AssetCreatableData:
+				_, found = pad.AccountData.Assets[basics.AssetIndex(loc.Index)]
+			case basics.AppCreatable:
+				_, found = pad.AccountData.AppParams[basics.AppIndex(loc.Index)]
+			case basics.AppCreatableData:
+				_, found = pad.AccountData.AppLocalStates[basics.AppIndex(loc.Index)]
 			}
-
-			onlyGlobal := loc.global && globalExist && !loc.local
-			onlyLocal := loc.local && localExist && !loc.global
-			bothGlobalLocal := loc.global && globalExist && loc.local && localExist
-			found := onlyGlobal || onlyLocal || bothGlobalLocal
-			foundInModified = append(foundInModified, found)
-		}
-		found := 0
-		for _, val := range foundInModified {
-			if !val {
-				break
+			if found {
+				foundInModified++
 			}
-			found++
 		}
 		// all requested items were found in modified data => return
-		if found == len(locators) {
+		if foundInModified == len(locators) {
 			return pad, nil
 		}
 	}
@@ -222,35 +206,30 @@ func (cb *roundCowState) lookupCreatableData(addr basics.Address, locators []cre
 	// data from cb.mods.Accts is newer than from lookupParent -> lookupHolding/lookupParams
 	// so add assets if they do not exist in new
 	for _, loc := range locators {
-		if loc.ctype == basics.AssetCreatable {
-			if loc.global {
-				params, parentOk := parentPad.AccountData.AssetParams[basics.AssetIndex(loc.cidx)]
-				if _, ok := pad.AccountData.AssetParams[basics.AssetIndex(loc.cidx)]; !ok && parentOk {
-					pad.AccountData.AssetParams = ledgercore.CloneAssetParams(pad.AccountData.AssetParams)
-					pad.AccountData.AssetParams[basics.AssetIndex(loc.cidx)] = params
-				}
+		switch loc.Type {
+		case basics.AssetCreatable:
+			params, parentOk := parentPad.AccountData.AssetParams[basics.AssetIndex(loc.Index)]
+			if _, ok := pad.AccountData.AssetParams[basics.AssetIndex(loc.Index)]; !ok && parentOk {
+				pad.AccountData.AssetParams = ledgercore.CloneAssetParams(pad.AccountData.AssetParams)
+				pad.AccountData.AssetParams[basics.AssetIndex(loc.Index)] = params
 			}
-			if loc.local {
-				holding, parentOk := parentPad.AccountData.Assets[basics.AssetIndex(loc.cidx)]
-				if _, ok := pad.AccountData.Assets[basics.AssetIndex(loc.cidx)]; !ok && parentOk {
-					pad.AccountData.Assets = ledgercore.CloneAssetHoldings(pad.AccountData.Assets)
-					pad.AccountData.Assets[basics.AssetIndex(loc.cidx)] = holding
-				}
+		case basics.AssetCreatableData:
+			holding, parentOk := parentPad.AccountData.Assets[basics.AssetIndex(loc.Index)]
+			if _, ok := pad.AccountData.Assets[basics.AssetIndex(loc.Index)]; !ok && parentOk {
+				pad.AccountData.Assets = ledgercore.CloneAssetHoldings(pad.AccountData.Assets)
+				pad.AccountData.Assets[basics.AssetIndex(loc.Index)] = holding
 			}
-		} else {
-			if loc.global {
-				params, parentOk := parentPad.AccountData.AppParams[basics.AppIndex(loc.cidx)]
-				if _, ok := pad.AccountData.AppParams[basics.AppIndex(loc.cidx)]; !ok && parentOk {
-					pad.AccountData.AppParams = ledgercore.CloneAppParams(pad.AccountData.AppParams)
-					pad.AccountData.AppParams[basics.AppIndex(loc.cidx)] = params
-				}
+		case basics.AppCreatable:
+			params, parentOk := parentPad.AccountData.AppParams[basics.AppIndex(loc.Index)]
+			if _, ok := pad.AccountData.AppParams[basics.AppIndex(loc.Index)]; !ok && parentOk {
+				pad.AccountData.AppParams = ledgercore.CloneAppParams(pad.AccountData.AppParams)
+				pad.AccountData.AppParams[basics.AppIndex(loc.Index)] = params
 			}
-			if loc.local {
-				states, parentOk := parentPad.AccountData.AppLocalStates[basics.AppIndex(loc.cidx)]
-				if _, ok := pad.AccountData.AppLocalStates[basics.AppIndex(loc.cidx)]; !ok && parentOk {
-					pad.AccountData.AppLocalStates = ledgercore.CloneAppLocalStates(pad.AccountData.AppLocalStates)
-					pad.AccountData.AppLocalStates[basics.AppIndex(loc.cidx)] = states
-				}
+		case basics.AppCreatableData:
+			states, parentOk := parentPad.AccountData.AppLocalStates[basics.AppIndex(loc.Index)]
+			if _, ok := pad.AccountData.AppLocalStates[basics.AppIndex(loc.Index)]; !ok && parentOk {
+				pad.AccountData.AppLocalStates = ledgercore.CloneAppLocalStates(pad.AccountData.AppLocalStates)
+				pad.AccountData.AppLocalStates[basics.AppIndex(loc.Index)] = states
 			}
 		}
 	}
@@ -300,63 +279,14 @@ func (cb *roundCowState) put(addr basics.Address, new basics.AccountData, newCre
 		logging.Base().Errorf("address %s does not have entry in getPadCache", addr.String())
 
 		// Try to recover.
-		// Problem: getPadCache have to keep AccountData with the asset/app used in lookupCreatableData call,
-		// and put() has no idea what the client needed (that's why getPadCache exists).
-		// So need to preload all elements that makes sense:
-		// - for asset params they are either newCreatable or deletedCreatable
-		// - for asset holdings it is more complicated and need to load all data from new.Assets
 		pad, err := cb.lookup(addr)
 		if err != nil {
 			// well, seems like something really wrong, panic
 			panic(fmt.Sprintf("Recovering attempt after %s missing in getPadCache failed: %s", addr.String(), err.Error()))
 		}
 
-		if pad.ExtendedAssetParams.Count != 0 {
-			var target basics.CreatableIndex
-			if newCreatable != nil && newCreatable.Type == basics.AssetCreatable {
-				target = newCreatable.Index
-			}
-			if deletedCreatable != nil && deletedCreatable.Type == basics.AssetCreatable {
-				target = deletedCreatable.Index
-			}
-			if target != 0 {
-				pad2, err := cb.lookupCreatableData(addr, []creatableDataLocator{{cidx: target, ctype: basics.AssetCreatable, global: true, local: false}})
-				if err != nil {
-					// well, seems like something really wrong, panic
-					panic(fmt.Sprintf("Recovering attempt after %s missing in getPadCache and asset params %d failed: %s", addr.String(), target, err.Error()))
-				}
-				pad2.AccountData = new
-				cb.mods.Accts.Upsert(addr, pad2)
-			}
-		}
-
-		if pad.ExtendedAssetHolding.Count != 0 {
-			// There are some extension records, need to fetch all holdings that are in new
-			// to ensure underlying code has all needed data
-			locators := make([]creatableDataLocator, 0, len(new.Assets))
-			for aidx := range new.Assets {
-				locators = append(locators, creatableDataLocator{cidx: basics.CreatableIndex(aidx), ctype: basics.AssetCreatable, global: false, local: true})
-			}
-
-			pad2, err := cb.lookupCreatableData(addr, locators)
-			if err != nil {
-				// well, seems like something really wrong, panic
-				panic(fmt.Sprintf("Recovering attempt after %s missing in getPadCache and asset holdings failed: %s", addr.String(), err.Error()))
-			}
-			for i, g := range pad2.ExtendedAssetHolding.Groups {
-				if g.Loaded() {
-					pad.ExtendedAssetHolding.Groups[i] = g
-				}
-			}
-			pad.AccountData = new
-			cb.mods.Accts.Upsert(addr, pad)
-		}
-
-		if pad.ExtendedAssetParams.Count == 0 && pad.ExtendedAssetHolding.Count == 0 {
-			// if no extension records, store a value from regular lookup
-			pad.AccountData = new
-			cb.mods.Accts.Upsert(addr, pad)
-		}
+		pad.AccountData = new
+		cb.mods.Accts.Upsert(addr, pad)
 	}
 
 	if newCreatable != nil {

--- a/ledger/cow_test.go
+++ b/ledger/cow_test.go
@@ -37,7 +37,7 @@ func (ml *mockLedger) lookup(addr basics.Address) (ledgercore.PersistedAccountDa
 	return ledgercore.PersistedAccountData{AccountData: ml.balanceMap[addr]}, nil
 }
 
-func (ml *mockLedger) lookupCreatableData(addr basics.Address, locators []creatableDataLocator) (ledgercore.PersistedAccountData, error) {
+func (ml *mockLedger) lookupCreatableData(addr basics.Address, locators []basics.CreatableLocator) (ledgercore.PersistedAccountData, error) {
 	return ledgercore.PersistedAccountData{AccountData: ml.balanceMap[addr]}, nil
 }
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -476,9 +476,9 @@ func (l *Ledger) LookupFull(rnd basics.Round, addr basics.Address) (basics.Accou
 
 // LookupCreatableDataWithoutRewards returns account data containing asset or app params if any
 func (l *Ledger) LookupCreatableDataWithoutRewards(rnd basics.Round, addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.AccountData, error) {
-	params := true
-	holdings := false
-	pad, err := l.lookupCreatableDataWithoutRewards(rnd, addr, []creatableDataLocator{{cidx: cidx, ctype: ctype, global: params, local: holdings}})
+	// params := true
+	// holdings := false
+	pad, err := l.lookupCreatableDataWithoutRewards(rnd, addr, []basics.CreatableLocator{{Type: ctype, Index: cidx}})
 	return pad.AccountData, err
 }
 
@@ -495,7 +495,7 @@ func (l *Ledger) lookupWithoutRewards(rnd basics.Round, addr basics.Address) (le
 }
 
 // lookupCreatableDataWithoutRewards is like lookupWithoutRewards but also loads the specified holding/local state
-func (l *Ledger) lookupCreatableDataWithoutRewards(rnd basics.Round, addr basics.Address, locators []creatableDataLocator) (ledgercore.PersistedAccountData, error) {
+func (l *Ledger) lookupCreatableDataWithoutRewards(rnd basics.Round, addr basics.Address, locators []basics.CreatableLocator) (ledgercore.PersistedAccountData, error) {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()
 

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -1792,13 +1792,17 @@ func TestLedgerAssetHoldingsLargeBlock(t *testing.T) {
 
 	stxns = makeAssetCreateTxns(1+margin, numAssets)
 	// Clear the timer to ensure a flush (well, not always works but needed)
+	l.accts.accountsMu.RLock()
 	l.accts.lastFlushTime = time.Time{}
+	l.accts.accountsMu.RUnlock()
 	err = l.addBlockTxns(t, genesisInitState.Accounts, stxns, transactions.ApplyData{})
 	require.NoError(t, err)
 	l.WaitForCommit(l.Latest())
 
 	for i := uint64(0); i < 2*protoParams.MaxBalLookback+2; i++ {
+		l.accts.accountsMu.RLock()
 		l.accts.lastFlushTime = time.Time{}
+		l.accts.accountsMu.RUnlock()
 		addEmptyValidatedBlock(t, l, genesisInitState.Accounts)
 	}
 
@@ -1809,7 +1813,9 @@ func TestLedgerAssetHoldingsLargeBlock(t *testing.T) {
 	require.Equal(t, int(numAssets), len(pad.AssetParams))
 
 	for i := uint64(0); i < 2*protoParams.MaxBalLookback+2; i++ {
+		l.accts.accountsMu.RLock()
 		l.accts.lastFlushTime = time.Time{}
+		l.accts.accountsMu.RUnlock()
 		addEmptyValidatedBlock(t, l, genesisInitState.Accounts)
 		// syncer may not be fast enough and delay so it a chance to trigger committedUpTo
 		time.Sleep(10 * time.Millisecond)

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -1823,8 +1823,8 @@ func TestLedgerAssetHoldingsLargeBlock(t *testing.T) {
 
 	pad, err = l.accts.lookupWithRewards(l.Latest(), addr, true)
 	require.NoError(t, err)
-	require.Equal(t, uint32(numAssets), pad.ExtendedAssetHolding.Count)
-	require.Equal(t, uint32(numAssets), pad.ExtendedAssetParams.Count)
+	require.Equal(t, int(numAssets), len(pad.Assets))
+	require.Equal(t, int(numAssets), len(pad.AssetParams))
 }
 
 func BenchmarkLedgerStartup(b *testing.B) {

--- a/ledger/ledgercore/clone.go
+++ b/ledger/ledgercore/clone.go
@@ -20,7 +20,7 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 )
 
-// Allocate the map of basics.AssetHolding if it is nil, and return a copy.
+// CloneAssetHoldings allocates the map of basics.AssetHolding if it is nil, and return a copy.
 func CloneAssetHoldings(m map[basics.AssetIndex]basics.AssetHolding) map[basics.AssetIndex]basics.AssetHolding {
 	res := make(map[basics.AssetIndex]basics.AssetHolding, len(m))
 	for id, val := range m {
@@ -29,7 +29,7 @@ func CloneAssetHoldings(m map[basics.AssetIndex]basics.AssetHolding) map[basics.
 	return res
 }
 
-// Allocate the map of basics.AssetParams if it is nil, and return a copy.
+// CloneAssetParams allocates the map of basics.AssetParams if it is nil, and return a copy.
 func CloneAssetParams(m map[basics.AssetIndex]basics.AssetParams) map[basics.AssetIndex]basics.AssetParams {
 	res := make(map[basics.AssetIndex]basics.AssetParams, len(m))
 	for id, val := range m {
@@ -38,7 +38,7 @@ func CloneAssetParams(m map[basics.AssetIndex]basics.AssetParams) map[basics.Ass
 	return res
 }
 
-// Allocate the map of basics.AppParams if it is nil, and return a copy. We do *not*
+// CloneAppParams allocates the map of basics.AppParams if it is nil, and return a copy. We do *not*
 // call clone on each basics.AppParams -- callers must do that for any values where
 // they intend to modify a contained reference type.
 func CloneAppParams(m map[basics.AppIndex]basics.AppParams) map[basics.AppIndex]basics.AppParams {
@@ -49,7 +49,7 @@ func CloneAppParams(m map[basics.AppIndex]basics.AppParams) map[basics.AppIndex]
 	return res
 }
 
-// Allocate the map of LocalStates if it is nil, and return a copy. We do *not*
+// CloneAppLocalStates allocates the map of LocalStates if it is nil, and return a copy. We do *not*
 // call clone on each AppLocalState -- callers must do that for any values
 // where they intend to modify a contained reference type.
 func CloneAppLocalStates(m map[basics.AppIndex]basics.AppLocalState) map[basics.AppIndex]basics.AppLocalState {

--- a/ledger/ledgercore/clone.go
+++ b/ledger/ledgercore/clone.go
@@ -1,0 +1,61 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package ledgercore
+
+import (
+	"github.com/algorand/go-algorand/data/basics"
+)
+
+// Allocate the map of basics.AssetHolding if it is nil, and return a copy.
+func CloneAssetHoldings(m map[basics.AssetIndex]basics.AssetHolding) map[basics.AssetIndex]basics.AssetHolding {
+	res := make(map[basics.AssetIndex]basics.AssetHolding, len(m))
+	for id, val := range m {
+		res[id] = val
+	}
+	return res
+}
+
+// Allocate the map of basics.AssetParams if it is nil, and return a copy.
+func CloneAssetParams(m map[basics.AssetIndex]basics.AssetParams) map[basics.AssetIndex]basics.AssetParams {
+	res := make(map[basics.AssetIndex]basics.AssetParams, len(m))
+	for id, val := range m {
+		res[id] = val
+	}
+	return res
+}
+
+// Allocate the map of basics.AppParams if it is nil, and return a copy. We do *not*
+// call clone on each basics.AppParams -- callers must do that for any values where
+// they intend to modify a contained reference type.
+func CloneAppParams(m map[basics.AppIndex]basics.AppParams) map[basics.AppIndex]basics.AppParams {
+	res := make(map[basics.AppIndex]basics.AppParams, len(m))
+	for k, v := range m {
+		res[k] = v
+	}
+	return res
+}
+
+// Allocate the map of LocalStates if it is nil, and return a copy. We do *not*
+// call clone on each AppLocalState -- callers must do that for any values
+// where they intend to modify a contained reference type.
+func CloneAppLocalStates(m map[basics.AppIndex]basics.AppLocalState) map[basics.AppIndex]basics.AppLocalState {
+	res := make(map[basics.AppIndex]basics.AppLocalState, len(m))
+	for k, v := range m {
+		res[k] = v
+	}
+	return res
+}

--- a/ledger/ledgercore/persistedacctdata.go
+++ b/ledger/ledgercore/persistedacctdata.go
@@ -1133,13 +1133,13 @@ func (e *ExtendedAssetHolding) appendNewGroup(aidx basics.AssetIndex, data inter
 	e.Count++
 }
 
-// insertAfter adds a new group after idx (at newly allocated position idx+1)
 func (e *ExtendedAssetHolding) insertNewGroupAfter(gi int, aidx basics.AssetIndex, data interface{}) {
 	g := makeAssetHoldingGroup(aidx, data)
 	e.insertAfter(gi, g)
 	e.Count++
 }
 
+// insertAfter adds a new group after idx (at newly allocated position idx+1)
 func (e *ExtendedAssetHolding) insertAfter(gi int, group interface{}) {
 	e.Groups = append(e.Groups, AssetsHoldingGroup{})
 	copy(e.Groups[gi+1:], e.Groups[gi:])
@@ -1203,14 +1203,12 @@ func (e *ExtendedAssetParams) Insert(input []basics.AssetIndex, data map[basics.
 	insert(flatten, e)
 }
 
-// func insert(input []basics.AssetIndex, data map[basics.AssetIndex]basics.AssetHolding, agl AbstractAssetGroupList) {
 func insert(assets []flattenAsset, agl AbstractAssetGroupList) {
 	gi := 0
 	for _, asset := range assets {
 		result := findGroup(asset.aidx, gi, agl)
 		if result.found {
 			if result.split {
-				// e.splitInsert(result.gi, aidx, data[aidx])
 				pos := agl.split(result.gi, asset.aidx)
 				agl.insertInto(pos, asset.aidx, asset.data)
 			} else {

--- a/ledger/ledgercore/persistedacctdata_test.go
+++ b/ledger/ledgercore/persistedacctdata_test.go
@@ -268,8 +268,8 @@ func genExtendedAsset(spec []groupSpec, agl AbstractAssetGroupList, maker func(A
 	return count
 }
 
-// test for AssetsHoldingGroup.insert
-func TestAssetHoldingGroupInsert(t *testing.T) {
+// test for AssetsHoldingGroup/AssetsParamsGroup.insert
+func TestAssetGroupInsert(t *testing.T) {
 	a := require.New(t)
 
 	spec := []groupSpec{
@@ -396,6 +396,32 @@ func TestAssetHoldingGroupInsert(t *testing.T) {
 	a.Equal(oldAssetOffsets[len(oldAssetOffsets)-1]-delta, e2.Groups[0].groupData.AssetOffsets[e2.Groups[0].Count-2])
 	a.Equal(delta, e2.Groups[0].groupData.AssetOffsets[e2.Groups[0].Count-1])
 
+	spec = []groupSpec{
+		{1, MaxHoldingGroupSize, MaxHoldingGroupSize},
+		{MaxHoldingGroupSize, 2 * MaxHoldingGroupSize, MaxHoldingGroupSize},
+		{2 * MaxHoldingGroupSize, 3 * MaxHoldingGroupSize, MaxHoldingGroupSize},
+	}
+
+	e = genExtendedHolding(t, spec)
+	err := e.Insert([]basics.AssetIndex{2}, map[basics.AssetIndex]basics.AssetHolding{2: {}})
+	a.Error(err)
+	a.Contains(err.Error(), "existing asset")
+	a.Equal(e.Count, uint32(MaxHoldingGroupSize*3))
+	err = e.Insert([]basics.AssetIndex{1000}, map[basics.AssetIndex]basics.AssetHolding{1000: {}})
+	a.NoError(err)
+
+	spec = []groupSpec{
+		{1, MaxParamsGroupSize, MaxParamsGroupSize},
+		{MaxParamsGroupSize, 2 * MaxParamsGroupSize, MaxParamsGroupSize},
+		{2 * MaxParamsGroupSize, 3 * MaxParamsGroupSize, MaxParamsGroupSize},
+	}
+	e2 = genExtendedParams(t, spec)
+	err = e2.Insert([]basics.AssetIndex{2}, map[basics.AssetIndex]basics.AssetParams{2: {}})
+	a.Error(err)
+	a.Contains(err.Error(), "existing asset")
+	a.Equal(e2.Count, uint32(MaxParamsGroupSize*3))
+	err = e2.Insert([]basics.AssetIndex{100}, map[basics.AssetIndex]basics.AssetParams{100: {}})
+	a.NoError(err)
 }
 
 func checkGroup(t *testing.T, group interface{}) {

--- a/test/scripts/e2e_subs/e2e-app-delete-clear.sh
+++ b/test/scripts/e2e_subs/e2e-app-delete-clear.sh
@@ -30,7 +30,7 @@ if [[ $APPID_CHECK != *"${EXPERROR}"* ]]; then
 fi
 
 # Fail if creating app with on-completion clear
-RES=$(${gcmd} app create --creator ${ACCOUNT}  --on-completion "ClearState" --approval-prog "${PROGRAM_FILE}" --clear-prog "${PROGRAM_FILE}" --global-byteslices 0 --global-ints ${GLOBAL_INTS} --local-byteslices 0 --local-ints 0 2>&1 || true  ) 
+RES=$(${gcmd} app create --creator ${ACCOUNT}  --on-completion "ClearState" --approval-prog "${PROGRAM_FILE}" --clear-prog "${PROGRAM_FILE}" --global-byteslices 0 --global-ints ${GLOBAL_INTS} --local-byteslices 0 --local-ints 0 2>&1 || true  )
 EXPERROR1='cannot clear state'
 EXPERROR2='is not currently opted in'
 if [[ $RES != *"${EXPERROR1}"*"${EXPERROR2}"* ]]; then


### PR DESCRIPTION
## Summary

This a PoC for `Assets` and `AssetParams` detached storage in a separate `accountcreatabledata` table. This is much simpler than the original 1k+ assets groups-based implementation (most of PersistedAccountData and reconciliation logic are not needed anymore), although it has almost the same code in cow/apply.

TODO: benchmark / figure out if it can be improved / remove leftovers from groups-based implementation.

## Test Plan

Existing ledger tests adjusted