### PR TITLE
Minor change to rename helper function in Extract ops

### DIFF
--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -2619,11 +2619,11 @@ func convertBytesToInt(x []byte) (out uint64) {
 	return
 }
 
-func opExtractNBits(cx *evalContext, n int) {
+func opExtractNBytes(cx *evalContext, n int) {
 	last := len(cx.stack) - 1 // start
 	prev := last - 1          // bytes
 	startIdx := cx.stack[last].Uint
-	cx.stack[prev].Bytes, cx.err = opExtractImpl(cx.stack[prev].Bytes, int(startIdx), n) // extract n bits
+	cx.stack[prev].Bytes, cx.err = opExtractImpl(cx.stack[prev].Bytes, int(startIdx), n) // extract n bytes
 
 	cx.stack[prev].Uint = convertBytesToInt(cx.stack[prev].Bytes)
 	cx.stack[prev].Bytes = nil
@@ -2631,15 +2631,15 @@ func opExtractNBits(cx *evalContext, n int) {
 }
 
 func opExtract16Bits(cx *evalContext) {
-	opExtractNBits(cx, 2) // extract 16 bits
+	opExtractNBytes(cx, 2) // extract 2 bytes
 }
 
 func opExtract32Bits(cx *evalContext) {
-	opExtractNBits(cx, 4) // extract 32 bits
+	opExtractNBytes(cx, 4) // extract 4 bytes
 }
 
 func opExtract64Bits(cx *evalContext) {
-	opExtractNBits(cx, 8) // extract 64 bits
+	opExtractNBytes(cx, 8) // extract 8 bytes
 }
 
 func accountReference(cx *evalContext, account stackValue) (basics.Address, uint64, error) {


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

Changes a helper function name from opExtractNBits to opExtractNBytes to reflect actual behavior.
