### PR TITLE
lruaccounts-no-copy

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1709,7 +1709,7 @@ func (au *accountUpdates) newBlockImpl(blk bookkeeping.Block, delta ledgercore.S
 				au.log.Panicf("accountUpdates: newBlockImpl failed to lookup account %v when processing round %d : %v", addr, rnd, err)
 			} else {
 				previousAccountData = acctData.accountData
-				au.baseAccounts.write(acctData)
+				au.baseAccounts.write(&acctData)
 			}
 		}
 
@@ -2291,8 +2291,8 @@ func (au *accountUpdates) commitRound(offset uint64, dbRound basics.Round, lookb
 		}
 	}
 
-	for _, persistedAcct := range updatedPersistedAccounts {
-		au.baseAccounts.write(persistedAcct)
+	for i := range updatedPersistedAccounts {
+		au.baseAccounts.write(&updatedPersistedAccounts[i])
 	}
 
 	for cidx, modCrt := range compactCreatableDeltas {

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1400,7 +1400,7 @@ func TestCompactDeltas(t *testing.T) {
 	creatableDeltas[1][100] = ledgercore.ModifiedCreatable{Creator: addrs[2], Created: false}
 	creatableDeltas[1][101] = ledgercore.ModifiedCreatable{Creator: addrs[4], Created: true}
 
-	baseAccounts.write(persistedAccountData{addr: addrs[0], accountData: basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 1}}})
+	baseAccounts.write(&persistedAccountData{addr: addrs[0], accountData: basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 1}}})
 	outAccountDeltas = makeCompactAccountDeltas(accountDeltas, baseAccounts)
 	outCreatableDeltas = compactCreatableDeltas(creatableDeltas)
 

--- a/ledger/lruaccts_test.go
+++ b/ledger/lruaccts_test.go
@@ -41,7 +41,7 @@ func TestBasicLRUAccounts(t *testing.T) {
 			rowid:       int64(i),
 			accountData: basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: uint64(i)}},
 		}
-		baseAcct.write(acct)
+		baseAcct.write(&acct)
 	}
 
 	// verify that all these accounts are truly there.
@@ -224,7 +224,7 @@ func benchLruWrite(b *testing.B, fillerAccounts []persistedAccountData, accounts
 
 func fillLRUAccounts(baseAcct lruAccounts, fillerAccounts []persistedAccountData) lruAccounts {
 	for _, account := range fillerAccounts {
-		baseAcct.write(account)
+		baseAcct.write(&account)
 	}
 	return baseAcct
 }


### PR DESCRIPTION
… on write

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
improved speed of lruaccounts write functionality by avoiding copying persistedAccountData in writes
<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
