### PR TITLE
testing: lookup in no-GOPATH locations for packages in gocodec testing

### DIFF
--- a/protocol/codec_tester.go
+++ b/protocol/codec_tester.go
@@ -93,6 +93,27 @@ func checkMsgpAllocBoundDirective(dataType reflect.Type) bool {
 	// does any of the go files in the package directory has the msgp:allocbound defined for that datatype ?
 	gopath := os.Getenv("GOPATH")
 	packageFilesPath := path.Join(gopath, "src", dataType.PkgPath())
+	if _, err := os.Stat(packageFilesPath); os.IsNotExist(err) {
+		// no such directory. Try to assemble the path based on the current working directory.
+		cwd, err := os.Getwd()
+		if err != nil {
+			return false
+		}
+		if cwdPaths := strings.SplitAfter(cwd, "go-algorand/"); len(cwdPaths) == 2 {
+			cwd = cwdPaths[0]
+		} else {
+			return false
+		}
+
+		relPkdPath := strings.SplitAfter(dataType.PkgPath(), "go-algorand/")
+		if len(relPkdPath) != 2 {
+			return false
+		}
+		packageFilesPath = path.Join(cwd, relPkdPath[1])
+		if _, err := os.Stat(packageFilesPath); os.IsNotExist(err) {
+			return false
+		}
+	}
 	packageFiles := []string{}
 	filepath.Walk(packageFilesPath, func(path string, info os.FileInfo, err error) error {
 		if filepath.Ext(path) == ".go" {

--- a/protocol/codec_tester.go
+++ b/protocol/codec_tester.go
@@ -92,20 +92,22 @@ var testedDatatypesForAllocBoundMu = deadlock.Mutex{}
 func checkMsgpAllocBoundDirective(dataType reflect.Type) bool {
 	// does any of the go files in the package directory has the msgp:allocbound defined for that datatype ?
 	gopath := os.Getenv("GOPATH")
+	const repositoryRoot = "go-algorand/"
 	packageFilesPath := path.Join(gopath, "src", dataType.PkgPath())
+
 	if _, err := os.Stat(packageFilesPath); os.IsNotExist(err) {
 		// no such directory. Try to assemble the path based on the current working directory.
 		cwd, err := os.Getwd()
 		if err != nil {
 			return false
 		}
-		if cwdPaths := strings.SplitAfter(cwd, "go-algorand/"); len(cwdPaths) == 2 {
+		if cwdPaths := strings.SplitAfter(cwd, repositoryRoot); len(cwdPaths) == 2 {
 			cwd = cwdPaths[0]
 		} else {
 			return false
 		}
 
-		relPkdPath := strings.SplitAfter(dataType.PkgPath(), "go-algorand/")
+		relPkdPath := strings.SplitAfter(dataType.PkgPath(), repositoryRoot)
 		if len(relPkdPath) != 2 {
 			return false
 		}


### PR DESCRIPTION
## Summary

lookup in no-GOPATH locations for packages in gocodec testing; The existing code is trying to use the GOPATH as the base for the packages directories, however, this might not be the case when tests are being executed on travis.

## Test Plan

This is a test.