### PR TITLE
Avoid requesting unsupported blocks by the ensure digest catchup path

### DIFF
--- a/catchup/service.go
+++ b/catchup/service.go
@@ -600,6 +600,15 @@ func (s *Service) syncCert(cert *PendingUnmatchedCertificate) {
 
 // TODO this doesn't actually use the digest from cert!
 func (s *Service) fetchRound(cert agreement.Certificate, verifier *agreement.AsyncVoteVerifier) {
+	// is there any point attempting to retrieve the block ?
+	if s.nextRoundIsNotSupported(cert.Round) {
+		// we migth get here if the agreement was seeing the certs votes for the next
+		// block, without seeing the actual block. Since it hasn't seen the block, it couldn't
+		// tell that it's an unsupported protocol, and would try to request it from the catchup.
+		s.handleUnsupportedRound(cert.Round)
+		return
+	}
+
 	blockHash := bookkeeping.BlockHash(cert.Proposal.BlockDigest) // semantic digest (i.e., hash of the block header), not byte-for-byte digest
 	peerSelector := s.createPeerSelector(false)
 	for s.ledger.LastRound() < cert.Round {

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -602,7 +602,7 @@ func (s *Service) syncCert(cert *PendingUnmatchedCertificate) {
 func (s *Service) fetchRound(cert agreement.Certificate, verifier *agreement.AsyncVoteVerifier) {
 	// is there any point attempting to retrieve the block ?
 	if s.nextRoundIsNotSupported(cert.Round) {
-		// we migth get here if the agreement was seeing the certs votes for the next
+		// we might get here if the agreement service was seeing the certs votes for the next
 		// block, without seeing the actual block. Since it hasn't seen the block, it couldn't
 		// tell that it's an unsupported protocol, and would try to request it from the catchup.
 		s.handleUnsupportedRound(cert.Round)


### PR DESCRIPTION
## Summary

In current logic, the agreement is sending a notification to the catchup whenever it sees a cert vote
threshold without a corresponding block. When this happens on a round that is no longer supported
by the current binary, it would lead to continues requests for the said block. This PR addresses the issue
by testing if the coming block is expected to be supported or not. In case we know that it won't be supported,
we avoid downloading it entirely.

## Test Plan

Use existing testing.