### PR TITLE
txnsync: reduce the amount of logging

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -423,6 +423,11 @@ type Local struct {
 	// into it's transaction pool, even if those would not be required as the node doesn't
 	// participate in the consensus or used to relay transactions.
 	ForceFetchTransactions bool `version[17]:"false"`
+
+	// EnableVerbosedTransactionSyncLogging enables the transaction sync to write extensive
+	// message exchange information to the log file. This option is disabled by default,
+	// so that the log files would not grow too rapidly.
+	EnableVerbosedTransactionSyncLogging bool `version[17]:"false"`
 }
 
 // Filenames of config files within the configdir (e.g. ~/.algorand)

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -65,6 +65,7 @@ var defaultLocal = Local{
 	EnableProfiler:                          false,
 	EnableRequestLogger:                     false,
 	EnableTopAccountsReporting:              false,
+	EnableVerbosedTransactionSyncLogging:    false,
 	EndpointAddress:                         "127.0.0.1:0",
 	FallbackDNSResolverAddress:              "",
 	ForceFetchTransactions:                  false,

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -44,6 +44,7 @@
     "EnableProfiler": false,
     "EnableRequestLogger": false,
     "EnableTopAccountsReporting": false,
+    "EnableVerbosedTransactionSyncLogging": false,
     "EndpointAddress": "127.0.0.1:0",
     "FallbackDNSResolverAddress": "",
     "ForceFetchTransactions": false,

--- a/test/testdata/configs/config-v17.json
+++ b/test/testdata/configs/config-v17.json
@@ -44,6 +44,7 @@
     "EnableProfiler": false,
     "EnableRequestLogger": false,
     "EnableTopAccountsReporting": false,
+    "EnableVerbosedTransactionSyncLogging": false,
     "EndpointAddress": "127.0.0.1:0",
     "FallbackDNSResolverAddress": "",
     "ForceFetchTransactions": false,

--- a/txnsync/incoming.go
+++ b/txnsync/incoming.go
@@ -250,7 +250,9 @@ func (s *syncState) evaluateIncomingMessage(message incomingMessage) {
 		// if the peer's round is more than a single round behind the local node, then we don't want to
 		// try and load the transactions. The other peer should first catch up before getting transactions.
 		if (peer.lastRound + 1) < s.round {
-			s.log.Infof("Incoming Txsync #%d late round %d", seq, peer.lastRound)
+			if s.config.EnableVerbosedTransactionSyncLogging {
+				s.log.Infof("Incoming Txsync #%d late round %d", seq, peer.lastRound)
+			}
 			continue
 		}
 

--- a/txnsync/logger.go
+++ b/txnsync/logger.go
@@ -17,6 +17,7 @@
 package txnsync
 
 import (
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/logging"
 )
@@ -47,18 +48,24 @@ type Logger interface {
 
 type basicMsgLogger struct {
 	algodlogger
+	config *config.Local
 }
 
-func wrapLogger(l logging.Logger) Logger {
+func wrapLogger(l logging.Logger, config *config.Local) Logger {
 	if ll, ok := l.(Logger); ok {
 		return ll
 	}
-	out := new(basicMsgLogger)
-	out.algodlogger = l
+	out := &basicMsgLogger{
+		algodlogger: l,
+		config:      config,
+	}
 	return out
 }
 
 func (l *basicMsgLogger) logMessage(mstat msgStats, mode, tofrom string) {
+	if !l.config.EnableVerbosedTransactionSyncLogging {
+		return
+	}
 	l.Infof(
 		"%s Txsync #%d round %d transacations %d request [%d/%d] bloom %d nextTS %d %s '%s'",
 		mode,

--- a/txnsync/outgoing.go
+++ b/txnsync/outgoing.go
@@ -131,11 +131,7 @@ func (s *syncState) sendMessageLoop(currentTime time.Duration, deadline timers.D
 	for _, peer := range peers {
 		msgEncoder := &messageAsyncEncoder{state: s, roundClock: s.clock, peerDataExchangeRate: peer.dataExchangeRate}
 		profAssembleMessage.start()
-		var err error
-		msgEncoder.messageData, err = s.assemblePeerMessage(peer, &pendingTransactions)
-		if err != nil {
-			s.log.Errorf("failed to send peer msg: %v", err)
-		}
+		msgEncoder.messageData = s.assemblePeerMessage(peer, &pendingTransactions)
 		profAssembleMessage.end()
 		isPartialMessage := msgEncoder.messageData.partialMessage
 		msgEncoder.enqueue()
@@ -164,7 +160,7 @@ func (s *syncState) sendMessageLoop(currentTime time.Duration, deadline timers.D
 	}
 }
 
-func (s *syncState) assemblePeerMessage(peer *Peer, pendingTransactions *pendingTransactionGroupsSnapshot) (metaMessage sentMessageMetadata, err error) {
+func (s *syncState) assemblePeerMessage(peer *Peer, pendingTransactions *pendingTransactionGroupsSnapshot) (metaMessage sentMessageMetadata) {
 	metaMessage = sentMessageMetadata{
 		peer: peer,
 		message: &transactionBlockMessage{

--- a/txnsync/service.go
+++ b/txnsync/service.go
@@ -40,7 +40,7 @@ func MakeTransactionSyncService(log logging.Logger, conn NodeConnector, isRelay 
 	s := &Service{
 		state: syncState{
 			node:        conn,
-			log:         wrapLogger(log),
+			log:         wrapLogger(log, &cfg),
 			isRelay:     isRelay,
 			genesisID:   genesisID,
 			genesisHash: genesisHash,

--- a/txnsync/service_test.go
+++ b/txnsync/service_test.go
@@ -128,7 +128,7 @@ func TestMakeTransactionSyncService(t *testing.T) {
 	a.NotNil(service1)
 
 	a.Equal(service1.state.node, mNodeConnector)
-	a.Equal(service1.state.log, wrapLogger(mLogger))
+	a.Equal(service1.state.log, wrapLogger(mLogger, &cfg))
 	a.Equal(service1.state.isRelay, true)
 	a.Equal(service1.state.genesisID, "GENID")
 	a.Equal(service1.state.genesisHash, hashDigest)
@@ -142,7 +142,7 @@ func TestMakeTransactionSyncService(t *testing.T) {
 	a.NotNil(service1)
 
 	a.Equal(service2.state.node, mNodeConnector)
-	a.Equal(service2.state.log, wrapLogger(mLogger))
+	a.Equal(service2.state.log, wrapLogger(mLogger, &cfg))
 	a.Equal(service2.state.isRelay, false)
 	a.Equal(service2.state.genesisID, "GENID2")
 	a.Equal(service2.state.genesisHash, hashDigest)

--- a/txnsync/txngroups.go
+++ b/txnsync/txngroups.go
@@ -108,7 +108,7 @@ func (s *syncState) compressTransactionGroupsBytes(data []byte) ([]byte, byte) {
 	_, out, err := compress.Compress(data, b, 1)
 	if err != nil {
 		if errors.Is(err, compress.ErrShortBuffer) {
-			s.log.Infof("compression had negative effect, made message bigger: original msg length: %d", len(data))
+			s.log.Debugf("compression had negative effect, made message bigger: original msg length: %d", len(data))
 		} else {
 			s.log.Warnf("failed to compress %d bytes txnsync msg: %v", len(data), err)
 		}


### PR DESCRIPTION
## Summary

Add a new config option `EnableVerbosedTransactionSyncLogging` ( defaults to false ), to allow us to control whether we want to log incoming/outgoing messages. These messages are being sent at a high frequency ( especially on relays ), and would bloat the `node.log` file very quickly.

## Test Plan

Unit tests updated.