### PR TITLE
Infrastructure to check AVM stack manipulation opcodes better

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1067,9 +1067,9 @@ func asmDefault(ops *OpStream, spec *OpSpec, args []string) error {
 func typeSwap(ops *OpStream, args []string) (StackTypes, StackTypes) {
 	topTwo := oneAny.plus(oneAny)
 	top := len(ops.typeStack) - 1
-	if top > 0 {
+	if top >= 0 {
 		topTwo[1] = ops.typeStack[top]
-		if top > 1 {
+		if top >= 1 {
 			topTwo[0] = ops.typeStack[top-1]
 		}
 	}

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1091,6 +1091,9 @@ func typeDig(ops *OpStream, args []string) (StackTypes, StackTypes) {
 	idx := len(ops.typeStack) - depth
 	if idx >= 0 {
 		returns[len(returns)-1] = ops.typeStack[idx]
+		for i := idx + 1; i < len(ops.typeStack); i++ {
+			returns[i-idx-1] = ops.typeStack[i]
+		}
 	}
 	return anys, returns
 }

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1078,6 +1078,9 @@ func typeSwap(ops *OpStream, args []string) (StackTypes, StackTypes) {
 }
 
 func typeDig(ops *OpStream, args []string) (StackTypes, StackTypes) {
+	if len(args) == 0 {
+		return oneAny, oneAny
+	}
 	n, err := strconv.ParseUint(args[0], 0, 64)
 	if err != nil {
 		return oneAny, oneAny

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -281,6 +281,8 @@ func (ops *OpStream) ReferToLabel(pc int, label string) {
 	ops.labelReferences = append(ops.labelReferences, labelReference{ops.sourceLine, pc, label})
 }
 
+type opTypeFunc func(ops *OpStream, immediates []string) (StackTypes, StackTypes)
+
 // returns allows opcodes like `txn` to be specific about their return
 // value types, based on the field requested, rather than use Any as
 // specified by opSpec.
@@ -1062,15 +1064,47 @@ func asmDefault(ops *OpStream, spec *OpSpec, args []string) error {
 	return nil
 }
 
+func typeSwap(ops *OpStream, args []string) (StackTypes, StackTypes) {
+	topTwo := oneAny.plus(oneAny)
+	top := len(ops.typeStack) - 1
+	if top > 0 {
+		topTwo[1] = ops.typeStack[top]
+		if top > 1 {
+			topTwo[0] = ops.typeStack[top-1]
+		}
+	}
+	reversed := StackTypes{topTwo[1], topTwo[0]}
+	return topTwo, reversed
+}
+
+func typeDig(ops *OpStream, args []string) (StackTypes, StackTypes) {
+	n, err := strconv.ParseUint(args[0], 0, 64)
+	if err != nil {
+		return oneAny, oneAny
+	}
+	depth := int(n) + 1
+	anys := make(StackTypes, depth)
+	for i := range anys {
+		anys[i] = StackAny
+	}
+	returns := anys.plus(oneAny)
+	idx := len(ops.typeStack) - depth
+	if idx >= 0 {
+		returns[len(returns)-1] = ops.typeStack[idx]
+	}
+	return anys, returns
+}
+
 // keywords handle parsing and assembling special asm language constructs like 'addr'
 // We use OpSpec here, but somewhat degenerate, since they don't have opcodes or eval functions
 var keywords = map[string]OpSpec{
-	"int":  {0, "int", nil, assembleInt, nil, nil, oneInt, 1, modeAny, opDetails{1, 2, nil, nil}},
-	"byte": {0, "byte", nil, assembleByte, nil, nil, oneBytes, 1, modeAny, opDetails{1, 2, nil, nil}},
+	"int":  {0, "int", nil, assembleInt, nil, nil, oneInt, 1, modeAny, opDetails{1, 2, nil, nil, nil}},
+	"byte": {0, "byte", nil, assembleByte, nil, nil, oneBytes, 1, modeAny, opDetails{1, 2, nil, nil, nil}},
 	// parse basics.Address, actually just another []byte constant
-	"addr": {0, "addr", nil, assembleAddr, nil, nil, oneBytes, 1, modeAny, opDetails{1, 2, nil, nil}},
+	"addr": {0, "addr", nil, assembleAddr, nil, nil, oneBytes, 1, modeAny, opDetails{1, 2, nil, nil, nil}},
 	// take a signature, hash it, and take first 4 bytes, actually just another []byte constant
-	"method": {0, "method", nil, assembleMethod, nil, nil, oneBytes, 1, modeAny, opDetails{1, 2, nil, nil}}}
+	"method": {0, "method", nil, assembleMethod, nil, nil, oneBytes, 1, modeAny, opDetails{1, 2, nil, nil, nil}},
+}
 
 type lineError struct {
 	Line int
@@ -1179,35 +1213,45 @@ func (ops *OpStream) trace(format string, args ...interface{}) {
 }
 
 // checks (and pops) arg types from arg type stack
-func (ops *OpStream) checkArgs(spec OpSpec) {
-	firstPop := true
-	for i := len(spec.Args) - 1; i >= 0; i-- {
-		argType := spec.Args[i]
-		stype := ops.tpop()
-		if firstPop {
-			firstPop = false
-			ops.trace("pops(%s", argType.String())
+func (ops *OpStream) checkStack(args StackTypes, returns StackTypes, instruction []string) {
+	argcount := len(args)
+	if argcount > len(ops.typeStack) {
+		err := fmt.Errorf("%s expects %d stack arguments but stack height is %d", strings.Join(instruction, " "), argcount, len(ops.typeStack))
+		if len(ops.labelReferences) > 0 {
+			ops.warnf("%w; but branches have happened and assembler does not precisely track the stack in this case", err)
 		} else {
-			ops.trace(", %s", argType.String())
+			ops.error(err)
 		}
-		if !typecheck(argType, stype) {
-			err := fmt.Errorf("%s arg %d wanted type %s got %s", spec.Name, i, argType.String(), stype.String())
-			if len(ops.labelReferences) > 0 {
-				ops.warnf("%w; but branches have happened and assembler does not precisely track types in this case", err)
+	} else {
+		firstPop := true
+		for i := argcount - 1; i >= 0; i-- {
+			argType := args[i]
+			stype := ops.tpop()
+			if firstPop {
+				firstPop = false
+				ops.trace("pops(%s", argType.String())
 			} else {
-				ops.error(err)
+				ops.trace(", %s", argType.String())
+			}
+			if !typecheck(argType, stype) {
+				err := fmt.Errorf("%s arg %d wanted type %s got %s", strings.Join(instruction, " "), i, argType.String(), stype.String())
+				if len(ops.labelReferences) > 0 {
+					ops.warnf("%w; but branches have happened and assembler does not precisely track types in this case", err)
+				} else {
+					ops.error(err)
+				}
 			}
 		}
-	}
-	if !firstPop {
-		ops.trace(")")
+		if !firstPop {
+			ops.trace(")")
+		}
 	}
 
-	if len(spec.Returns) > 0 {
-		ops.tpusha(spec.Returns)
-		ops.trace(" pushes(%s", spec.Returns[0].String())
-		if len(spec.Returns) > 1 {
-			for _, rt := range spec.Returns[1:] {
+	if len(returns) > 0 {
+		ops.tpusha(returns)
+		ops.trace(" pushes(%s", returns[0].String())
+		if len(returns) > 1 {
+			for _, rt := range returns[1:] {
 				ops.trace(", %s", rt.String())
 			}
 		}
@@ -1272,7 +1316,11 @@ func (ops *OpStream) assemble(fin io.Reader) error {
 			if spec.Modes == runModeApplication {
 				ops.HasStatefulOps = true
 			}
-			ops.checkArgs(spec)
+			args, returns := spec.Args, spec.Returns
+			if spec.Details.typeFunc != nil {
+				args, returns = spec.Details.typeFunc(ops, fields[1:])
+			}
+			ops.checkStack(args, returns, fields)
 			spec.asm(ops, &spec, fields[1:])
 			ops.trace("\n")
 			continue

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2052,4 +2052,9 @@ func TestDigTypeCheck(t *testing.T) {
 		expect{4, "dig 3 expects 4..."})
 	testProg(t, "int 1; byte 0x1234; int 2; dig 12; +", AssemblerMaxVersion,
 		expect{4, "dig 12 expects 13..."})
+
+	// Confirm that digging something out does not ruin our knowledge about the types in the middle
+	testProg(t, "int 1; byte 0x1234; byte 0x1234; dig 2; dig 3; +; pop; +", AssemblerMaxVersion,
+		expect{6, "+ arg 1..."})
+
 }

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2041,6 +2041,7 @@ func TestSwapTypeCheck(t *testing.T) {
 	testProg(t, "int 1; byte 0x1234; +", AssemblerMaxVersion, expect{3, "+ arg 1..."})
 	/* despite swap, we track types */
 	testProg(t, "int 1; byte 0x1234; swap; +", AssemblerMaxVersion, expect{4, "+ arg 0..."})
+	testProg(t, "byte 0x1234; int 1; swap; +", AssemblerMaxVersion, expect{4, "+ arg 1..."})
 }
 
 func TestDigTypeCheck(t *testing.T) {

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2044,8 +2044,11 @@ func TestSwapTypeCheck(t *testing.T) {
 	testProg(t, "byte 0x1234; int 1; swap; +", AssemblerMaxVersion, expect{4, "+ arg 1..."})
 }
 
-func TestDigTypeCheck(t *testing.T) {
+func TestDigAsm(t *testing.T) {
 	t.Parallel()
+	testProg(t, "int 1; dig; +", AssemblerMaxVersion, expect{2, "dig expects 1 immediate..."})
+	testProg(t, "int 1; dig junk; +", AssemblerMaxVersion, expect{2, "...invalid syntax..."})
+
 	testProg(t, "int 1; byte 0x1234; int 2; dig 2; +", AssemblerMaxVersion)
 	testProg(t, "byte 0x32; byte 0x1234; int 2; dig 2; +", AssemblerMaxVersion,
 		expect{5, "+ arg 1..."})

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -346,7 +346,6 @@ func (pe PanicError) Error() string {
 	return fmt.Sprintf("panic in TEAL Eval: %v\n%s", pe.PanicValue, pe.StackTrace)
 }
 
-var errLoopDetected = errors.New("loop detected")
 var errLogicSigNotSupported = errors.New("LogicSig not supported")
 var errTooManyArgs = errors.New("LogicSig has too many arguments")
 
@@ -1034,7 +1033,7 @@ func opEq(cx *evalContext) {
 	}
 	var cond bool
 	if ta == StackBytes {
-		cond = bytes.Compare(cx.stack[prev].Bytes, cx.stack[last].Bytes) == 0
+		cond = bytes.Equal(cx.stack[prev].Bytes, cx.stack[last].Bytes)
 	} else {
 		cond = cx.stack[prev].Uint == cx.stack[last].Uint
 	}

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -1260,7 +1260,7 @@ func TestAssets(t *testing.T) {
 
 	// it wasn't legal to use a direct ref for account
 	testProg(t, `byte "aoeuiaoeuiaoeuiaoeuiaoeuiaoeui00"; int 54; asset_holding_get AssetBalance`,
-		directRefEnabledVersion-1, expect{3, "asset_holding_get arg 0 wanted type uint64..."})
+		directRefEnabledVersion-1, expect{3, "asset_holding_get AssetBalance arg 0 wanted type uint64..."})
 	// but it is now (empty asset yields 0,0 on stack)
 	testApp(t, `byte "aoeuiaoeuiaoeuiaoeuiaoeuiaoeui00"; int 55; asset_holding_get AssetBalance; ==`, now)
 	// This is receiver, who is in Assets array
@@ -1303,7 +1303,7 @@ func TestAssets(t *testing.T) {
 	testApp(t, strings.Replace(assetsTestProgram, "int 55", "int 0", -1), now)
 
 	// but old code cannot
-	testProg(t, strings.Replace(assetsTestProgram, "int 0//account", "byte \"aoeuiaoeuiaoeuiaoeuiaoeuiaoeui00\"", -1), directRefEnabledVersion-1, expect{3, "asset_holding_get arg 0 wanted type uint64..."})
+	testProg(t, strings.Replace(assetsTestProgram, "int 0//account", "byte \"aoeuiaoeuiaoeuiaoeuiaoeuiaoeui00\"", -1), directRefEnabledVersion-1, expect{3, "asset_holding_get AssetBalance arg 0 wanted type uint64..."})
 	testApp(t, strings.Replace(assetsTestProgram, "int 0//params", "int 55", -1), pre, "invalid Asset ref")
 	testApp(t, strings.Replace(assetsTestProgram, "int 55", "int 0", -1), pre, "err opcode")
 

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -3336,6 +3336,7 @@ func benchmarkOperation(b *testing.B, prefix string, operation string, suffix st
 	source := prefix + ";" + strings.Repeat(operation+";", 2000) + ";" + suffix
 	source = strings.ReplaceAll(source, ";", "\n")
 	ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
+	require.NoError(b, err)
 	err = Check(ops.Program, defaultEvalParams(nil, nil))
 	require.NoError(b, err)
 	evalLoop(b, runs, ops.Program)
@@ -4042,6 +4043,7 @@ func obfuscate(program string) string {
 type evalTester func(pass bool, err error) bool
 
 func testEvaluation(t *testing.T, program string, introduced uint64, tester evalTester) error {
+	t.Helper()
 	var outer error
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
@@ -4199,7 +4201,7 @@ func TestSelect(t *testing.T) {
 func TestDig(t *testing.T) {
 	t.Parallel()
 	testAccepts(t, "int 3; int 2; int 1; dig 1; int 2; ==; return", 3)
-	testPanics(t, "int 3; int 2; int 1; dig 11; int 2; ==; return", 3)
+	testPanics(t, obfuscate("int 3; int 2; int 1; dig 11; int 2; ==; return"), 3)
 }
 
 func TestPush(t *testing.T) {

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -49,27 +49,32 @@ type opDetails struct {
 	Size       int
 	checkFunc  opCheckFunc
 	Immediates []immediate
+	typeFunc   opTypeFunc
 }
 
-var opDefault = opDetails{1, 1, nil, nil}
-var opBranch = opDetails{1, 3, checkBranch, []immediate{{"target", immLabel}}}
+var opDefault = opDetails{1, 1, nil, nil, nil}
+var opBranch = opDetails{1, 3, checkBranch, []immediate{{"target", immLabel}}, nil}
 
 func costly(cost int) opDetails {
-	return opDetails{cost, 1, nil, nil}
+	return opDetails{cost, 1, nil, nil, nil}
 }
 
-func immediates(name string, rest ...string) opDetails {
-	num := 1 + len(rest)
-	immediates := make([]immediate, num)
-	immediates[0] = immediate{name, immByte}
-	for i, n := range rest {
-		immediates[i+1] = immediate{n, immByte}
+func immediates(names ...string) opDetails {
+	var immediates []immediate
+	for _, name := range names {
+		immediates = append(immediates, immediate{name, immByte})
 	}
-	return opDetails{1, 1 + num, nil, immediates}
+	return opDetails{1, 1 + len(immediates), nil, immediates, nil}
+}
+
+func stacky(typer opTypeFunc, imms ...string) opDetails {
+	d := immediates(imms...)
+	d.typeFunc = typer
+	return d
 }
 
 func varies(checker opCheckFunc, name string, kind immKind) opDetails {
-	return opDetails{1, 0, checker, []immediate{{name, kind}}}
+	return opDetails{1, 0, checker, []immediate{{name, kind}}, nil}
 }
 
 // immType describes the immediate arguments to an opcode
@@ -211,8 +216,8 @@ var OpSpecs = []OpSpec{
 	{0x4a, "dup2", opDup2, asmDefault, disDefault, twoAny, twoAny.plus(twoAny), 2, modeAny, opDefault},
 	// There must be at least one thing on the stack for dig, but
 	// it would be nice if we did better checking than that.
-	{0x4b, "dig", opDig, asmDefault, disDefault, oneAny, twoAny, 3, modeAny, immediates("n")},
-	{0x4c, "swap", opSwap, asmDefault, disDefault, twoAny, twoAny, 3, modeAny, opDefault},
+	{0x4b, "dig", opDig, asmDefault, disDefault, oneAny, twoAny, 3, modeAny, stacky(typeDig, "n")},
+	{0x4c, "swap", opSwap, asmDefault, disDefault, twoAny, twoAny, 3, modeAny, stacky(typeSwap)},
 	{0x4d, "select", opSelect, asmDefault, disDefault, twoAny.plus(oneInt), oneAny, 3, modeAny, opDefault},
 
 	{0x50, "concat", opConcat, asmDefault, disDefault, twoBytes, oneBytes, 2, modeAny, opDefault},

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -60,9 +60,9 @@ func costly(cost int) opDetails {
 }
 
 func immediates(names ...string) opDetails {
-	var immediates []immediate
-	for _, name := range names {
-		immediates = append(immediates, immediate{name, immByte})
+	immediates := make([]immediate, len(names))
+	for i, name := range names {
+		immediates[i] = immediate{name, immByte}
 	}
 	return opDetails{1, 1 + len(immediates), nil, immediates, nil}
 }


### PR DESCRIPTION
This PR changes the way we check our understanding of the stack during
assembly.  We try to give errors as we assemble, based on the types
that we believe are on the stack when we assemble an opcode that has
stack expectations.  Previously, we *only* check the very top of the
stack, since almost all opcodes only looked at or modified the top. In
addition, we were very conservative with opcodes that manipulated the
stack.  For example, once we assembled a `swap` we only knew that the
top of the stack was [any, any]. If the top was [int, bytes], we lost
track.  Now we know the stack after that is [bytes, int].

Several opcodes still need this enhancement. "dig" and "swap" are
done, and serve as examples.  The following should be done next:
`dup`, `dup2`, `cover`, `uncover`.

Slightly trickier, we can also improve `select`.  If both of the
"then" and "else" types are the same, we can know that `select` leaves
that type behind.

`setbit` can be improved to return the type of the thing it is modifying.

To enhance an opcode, write a typeOpcode function that determines,
based on the opcodes immediates and on the current state of the stack,
what checkStack should check confirm the prior stack state (for example,
dig n needs a stack of depth n+1), and to setup the stack
afterward (for example, we know the stack after `swap` in more detail
that simply any,any.  Register this typeOpcode function using
"stacky()" in the opcodes table.

These functions must be quite careful.  The typestack might not be long enough due to user error.  To report that nicely, we need to avoid panicing here, so checkStack can do its work. For example, `dig 4` needs to yield a StackValues of 5 StackAnys, even if the current typestack is only 3 deep.
