### PR TITLE
txnsync: Add fields to txnsync msgs for proposal sending

### DIFF
--- a/txnsync/exchange.go
+++ b/txnsync/exchange.go
@@ -17,6 +17,7 @@
 package txnsync
 
 import (
+	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 )
 
@@ -34,6 +35,7 @@ type transactionBlockMessage struct {
 	UpdatedRequestParams requestParams           `codec:"p"`
 	TransactionGroups    packedTransactionGroups `codec:"g"`
 	MsgSync              timingParams            `codec:"t"`
+	ProposalData         relayedProposal         `codec:"pd"`
 }
 
 type encodedBloomFilter struct {
@@ -72,4 +74,19 @@ type timingParams struct {
 	ResponseElapsedTime uint64   `codec:"r"`
 	AcceptedMsgSeq      []uint64 `codec:"a,allocbound=maxAcceptedMsgSeq"`
 	NextMsgMinDelay     uint64   `codec:"m"`
+}
+
+const (
+	noProposal byte = iota
+	transactionsForProposal
+	proposalByte
+	proposalFilter
+)
+
+type relayedProposal struct {
+	_struct struct{} `codec:",omitempty,omitemptyarray"`
+
+	ProposalBytes   []byte        `codec:"pb,allocbound=maxEncodedTransactionGroupBytes"`
+	ProposalFilter  crypto.Digest `codec:"pf"`
+	ProposalMsgType byte          `codec:"mt"`
 }

--- a/txnsync/exchange.go
+++ b/txnsync/exchange.go
@@ -25,6 +25,7 @@ const txnBlockMessageVersion = 1
 const maxBloomFilterSize = 100000
 const maxAcceptedMsgSeq = 64
 const maxEncodedTransactionGroupBytes = 10000000
+const maxProposalSize = 350000
 
 type transactionBlockMessage struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
@@ -35,7 +36,7 @@ type transactionBlockMessage struct {
 	UpdatedRequestParams requestParams           `codec:"p"`
 	TransactionGroups    packedTransactionGroups `codec:"g"`
 	MsgSync              timingParams            `codec:"t"`
-	ProposalData         relayedProposal         `codec:"pd"`
+	RelayedProposal      relayedProposal         `codec:"rp"`
 }
 
 type encodedBloomFilter struct {
@@ -79,14 +80,12 @@ type timingParams struct {
 const (
 	noProposal byte = iota
 	transactionsForProposal
-	proposalByte
-	proposalFilter
 )
 
 type relayedProposal struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	ProposalBytes   []byte        `codec:"pb,allocbound=maxEncodedTransactionGroupBytes"`
-	ProposalFilter  crypto.Digest `codec:"pf"`
-	ProposalMsgType byte          `codec:"mt"`
+	RawBytes        []byte        `codec:"b,allocbound=maxProposalSize"`
+	ExcludeProposal crypto.Digest `codec:"e"`
+	Content         byte          `codec:"c"`
 }

--- a/txnsync/incoming.go
+++ b/txnsync/incoming.go
@@ -232,7 +232,7 @@ func (s *syncState) evaluateIncomingMessage(message incomingMessage) {
 		peer.nextReceivedMessageSeq++
 
 		// skip txnsync messages with proposalData for now
-		if incomingMsg.message.ProposalData.ProposalMsgType != noProposal {
+		if !incomingMsg.message.RelayedProposal.MsgIsZero() {
 			continue
 		}
 

--- a/txnsync/incoming.go
+++ b/txnsync/incoming.go
@@ -231,6 +231,11 @@ func (s *syncState) evaluateIncomingMessage(message incomingMessage) {
 		// increase the message sequence number, since we're processing this message.
 		peer.nextReceivedMessageSeq++
 
+		// skip txnsync messages with proposalData for now
+		if incomingMsg.message.ProposalData.ProposalMsgType != noProposal {
+			continue
+		}
+
 		// update the round number if needed.
 		if incomingMsg.message.Round > peer.lastRound {
 			peer.lastRound = incomingMsg.message.Round

--- a/txnsync/msgp_gen.go
+++ b/txnsync/msgp_gen.go
@@ -199,6 +199,14 @@ import (
 //    |-----> Msgsize
 //    |-----> MsgIsZero
 //
+// relayedProposal
+//        |-----> (*) MarshalMsg
+//        |-----> (*) CanMarshalMsg
+//        |-----> (*) UnmarshalMsg
+//        |-----> (*) CanUnmarshalMsg
+//        |-----> (*) Msgsize
+//        |-----> (*) MsgIsZero
+//
 // requestParams
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
@@ -26337,6 +26345,178 @@ func (z program) MsgIsZero() bool {
 }
 
 // MarshalMsg implements msgp.Marshaler
+func (z *relayedProposal) MarshalMsg(b []byte) (o []byte) {
+	o = msgp.Require(b, z.Msgsize())
+	// omitempty: check for empty values
+	zb0001Len := uint32(3)
+	var zb0001Mask uint8 /* 4 bits */
+	if (*z).ProposalMsgType == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if len((*z).ProposalBytes) == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if (*z).ProposalFilter.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x2) == 0 { // if not empty
+			// string "mt"
+			o = append(o, 0xa2, 0x6d, 0x74)
+			o = msgp.AppendByte(o, (*z).ProposalMsgType)
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not empty
+			// string "pb"
+			o = append(o, 0xa2, 0x70, 0x62)
+			o = msgp.AppendBytes(o, (*z).ProposalBytes)
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not empty
+			// string "pf"
+			o = append(o, 0xa2, 0x70, 0x66)
+			o = (*z).ProposalFilter.MarshalMsg(o)
+		}
+	}
+	return
+}
+
+func (_ *relayedProposal) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(*relayedProposal)
+	return ok
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *relayedProposal) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 int
+	var zb0002 bool
+	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if _, ok := err.(msgp.TypeError); ok {
+		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0001 > 0 {
+			zb0001--
+			var zb0003 int
+			zb0003, err = msgp.ReadBytesBytesHeader(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "ProposalBytes")
+				return
+			}
+			if zb0003 > maxEncodedTransactionGroupBytes {
+				err = msgp.ErrOverflow(uint64(zb0003), uint64(maxEncodedTransactionGroupBytes))
+				return
+			}
+			(*z).ProposalBytes, bts, err = msgp.ReadBytesBytes(bts, (*z).ProposalBytes)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "ProposalBytes")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).ProposalFilter.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "ProposalFilter")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			(*z).ProposalMsgType, bts, err = msgp.ReadByteBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "ProposalMsgType")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			err = msgp.ErrTooManyArrayFields(zb0001)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array")
+				return
+			}
+		}
+	} else {
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0002 {
+			(*z) = relayedProposal{}
+		}
+		for zb0001 > 0 {
+			zb0001--
+			field, bts, err = msgp.ReadMapKeyZC(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+			switch string(field) {
+			case "pb":
+				var zb0004 int
+				zb0004, err = msgp.ReadBytesBytesHeader(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ProposalBytes")
+					return
+				}
+				if zb0004 > maxEncodedTransactionGroupBytes {
+					err = msgp.ErrOverflow(uint64(zb0004), uint64(maxEncodedTransactionGroupBytes))
+					return
+				}
+				(*z).ProposalBytes, bts, err = msgp.ReadBytesBytes(bts, (*z).ProposalBytes)
+				if err != nil {
+					err = msgp.WrapError(err, "ProposalBytes")
+					return
+				}
+			case "pf":
+				bts, err = (*z).ProposalFilter.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ProposalFilter")
+					return
+				}
+			case "mt":
+				(*z).ProposalMsgType, bts, err = msgp.ReadByteBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ProposalMsgType")
+					return
+				}
+			default:
+				err = msgp.ErrNoField(string(field))
+				if err != nil {
+					err = msgp.WrapError(err)
+					return
+				}
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (_ *relayedProposal) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*relayedProposal)
+	return ok
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *relayedProposal) Msgsize() (s int) {
+	s = 1 + 3 + msgp.BytesPrefixSize + len((*z).ProposalBytes) + 3 + (*z).ProposalFilter.Msgsize() + 3 + msgp.ByteSize
+	return
+}
+
+// MsgIsZero returns whether this is a zero value
+func (z *relayedProposal) MsgIsZero() bool {
+	return (len((*z).ProposalBytes) == 0) && ((*z).ProposalFilter.MsgIsZero()) && ((*z).ProposalMsgType == 0)
+}
+
+// MarshalMsg implements msgp.Marshaler
 func (z *requestParams) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
@@ -26785,8 +26965,8 @@ func (z *timingParams) MsgIsZero() bool {
 func (z *transactionBlockMessage) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0001Len := uint32(6)
-	var zb0001Mask uint8 /* 7 bits */
+	zb0001Len := uint32(7)
+	var zb0001Mask uint8 /* 8 bits */
 	if (*z).TxnBloomFilter.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x2
@@ -26799,17 +26979,21 @@ func (z *transactionBlockMessage) MarshalMsg(b []byte) (o []byte) {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
-	if (*z).Round.MsgIsZero() {
+	if (*z).ProposalData.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x10
 	}
-	if (*z).MsgSync.MsgIsZero() {
+	if (*z).Round.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x20
 	}
-	if (*z).Version == 0 {
+	if (*z).MsgSync.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x40
+	}
+	if (*z).Version == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -26852,16 +27036,21 @@ func (z *transactionBlockMessage) MarshalMsg(b []byte) (o []byte) {
 			}
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
+			// string "pd"
+			o = append(o, 0xa2, 0x70, 0x64)
+			o = (*z).ProposalData.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "r"
 			o = append(o, 0xa1, 0x72)
 			o = (*z).Round.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x20) == 0 { // if not empty
+		if (zb0001Mask & 0x40) == 0 { // if not empty
 			// string "t"
 			o = append(o, 0xa1, 0x74)
 			o = (*z).MsgSync.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x40) == 0 { // if not empty
+		if (zb0001Mask & 0x80) == 0 { // if not empty
 			// string "v"
 			o = append(o, 0xa1, 0x76)
 			o = msgp.AppendInt32(o, (*z).Version)
@@ -27001,6 +27190,14 @@ func (z *transactionBlockMessage) UnmarshalMsg(bts []byte) (o []byte, err error)
 			}
 		}
 		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).ProposalData.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "ProposalData")
+				return
+			}
+		}
+		if zb0001 > 0 {
 			err = msgp.ErrTooManyArrayFields(zb0001)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array")
@@ -27123,6 +27320,12 @@ func (z *transactionBlockMessage) UnmarshalMsg(bts []byte) (o []byte, err error)
 					err = msgp.WrapError(err, "MsgSync")
 					return
 				}
+			case "pd":
+				bts, err = (*z).ProposalData.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ProposalData")
+					return
+				}
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -27143,13 +27346,13 @@ func (_ *transactionBlockMessage) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *transactionBlockMessage) Msgsize() (s int) {
-	s = 1 + 2 + msgp.Int32Size + 2 + (*z).Round.Msgsize() + 2 + (*z).TxnBloomFilter.Msgsize() + 2 + 1 + 2 + msgp.ByteSize + 2 + msgp.ByteSize + 2 + (*z).TransactionGroups.Msgsize() + 2 + (*z).MsgSync.Msgsize()
+	s = 1 + 2 + msgp.Int32Size + 2 + (*z).Round.Msgsize() + 2 + (*z).TxnBloomFilter.Msgsize() + 2 + 1 + 2 + msgp.ByteSize + 2 + msgp.ByteSize + 2 + (*z).TransactionGroups.Msgsize() + 2 + (*z).MsgSync.Msgsize() + 3 + (*z).ProposalData.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *transactionBlockMessage) MsgIsZero() bool {
-	return ((*z).Version == 0) && ((*z).Round.MsgIsZero()) && ((*z).TxnBloomFilter.MsgIsZero()) && (((*z).UpdatedRequestParams.Offset == 0) && ((*z).UpdatedRequestParams.Modulator == 0)) && ((*z).TransactionGroups.MsgIsZero()) && ((*z).MsgSync.MsgIsZero())
+	return ((*z).Version == 0) && ((*z).Round.MsgIsZero()) && ((*z).TxnBloomFilter.MsgIsZero()) && (((*z).UpdatedRequestParams.Offset == 0) && ((*z).UpdatedRequestParams.Modulator == 0)) && ((*z).TransactionGroups.MsgIsZero()) && ((*z).MsgSync.MsgIsZero()) && ((*z).ProposalData.MsgIsZero())
 }
 
 // MarshalMsg implements msgp.Marshaler

--- a/txnsync/msgp_gen.go
+++ b/txnsync/msgp_gen.go
@@ -26350,15 +26350,15 @@ func (z *relayedProposal) MarshalMsg(b []byte) (o []byte) {
 	// omitempty: check for empty values
 	zb0001Len := uint32(3)
 	var zb0001Mask uint8 /* 4 bits */
-	if (*z).ProposalMsgType == 0 {
+	if len((*z).RawBytes) == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x2
 	}
-	if len((*z).ProposalBytes) == 0 {
+	if (*z).Content == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if (*z).ProposalFilter.MsgIsZero() {
+	if (*z).ExcludeProposal.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
@@ -26366,19 +26366,19 @@ func (z *relayedProposal) MarshalMsg(b []byte) (o []byte) {
 	o = append(o, 0x80|uint8(zb0001Len))
 	if zb0001Len != 0 {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
-			// string "mt"
-			o = append(o, 0xa2, 0x6d, 0x74)
-			o = msgp.AppendByte(o, (*z).ProposalMsgType)
+			// string "b"
+			o = append(o, 0xa1, 0x62)
+			o = msgp.AppendBytes(o, (*z).RawBytes)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
-			// string "pb"
-			o = append(o, 0xa2, 0x70, 0x62)
-			o = msgp.AppendBytes(o, (*z).ProposalBytes)
+			// string "c"
+			o = append(o, 0xa1, 0x63)
+			o = msgp.AppendByte(o, (*z).Content)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
-			// string "pf"
-			o = append(o, 0xa2, 0x70, 0x66)
-			o = (*z).ProposalFilter.MarshalMsg(o)
+			// string "e"
+			o = append(o, 0xa1, 0x65)
+			o = (*z).ExcludeProposal.MarshalMsg(o)
 		}
 	}
 	return
@@ -26407,32 +26407,32 @@ func (z *relayedProposal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			var zb0003 int
 			zb0003, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "ProposalBytes")
+				err = msgp.WrapError(err, "struct-from-array", "RawBytes")
 				return
 			}
-			if zb0003 > maxEncodedTransactionGroupBytes {
-				err = msgp.ErrOverflow(uint64(zb0003), uint64(maxEncodedTransactionGroupBytes))
+			if zb0003 > maxProposalSize {
+				err = msgp.ErrOverflow(uint64(zb0003), uint64(maxProposalSize))
 				return
 			}
-			(*z).ProposalBytes, bts, err = msgp.ReadBytesBytes(bts, (*z).ProposalBytes)
+			(*z).RawBytes, bts, err = msgp.ReadBytesBytes(bts, (*z).RawBytes)
 			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "ProposalBytes")
+				err = msgp.WrapError(err, "struct-from-array", "RawBytes")
 				return
 			}
 		}
 		if zb0001 > 0 {
 			zb0001--
-			bts, err = (*z).ProposalFilter.UnmarshalMsg(bts)
+			bts, err = (*z).ExcludeProposal.UnmarshalMsg(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "ProposalFilter")
+				err = msgp.WrapError(err, "struct-from-array", "ExcludeProposal")
 				return
 			}
 		}
 		if zb0001 > 0 {
 			zb0001--
-			(*z).ProposalMsgType, bts, err = msgp.ReadByteBytes(bts)
+			(*z).Content, bts, err = msgp.ReadByteBytes(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "ProposalMsgType")
+				err = msgp.WrapError(err, "struct-from-array", "Content")
 				return
 			}
 		}
@@ -26459,32 +26459,32 @@ func (z *relayedProposal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 			switch string(field) {
-			case "pb":
+			case "b":
 				var zb0004 int
 				zb0004, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "ProposalBytes")
+					err = msgp.WrapError(err, "RawBytes")
 					return
 				}
-				if zb0004 > maxEncodedTransactionGroupBytes {
-					err = msgp.ErrOverflow(uint64(zb0004), uint64(maxEncodedTransactionGroupBytes))
+				if zb0004 > maxProposalSize {
+					err = msgp.ErrOverflow(uint64(zb0004), uint64(maxProposalSize))
 					return
 				}
-				(*z).ProposalBytes, bts, err = msgp.ReadBytesBytes(bts, (*z).ProposalBytes)
+				(*z).RawBytes, bts, err = msgp.ReadBytesBytes(bts, (*z).RawBytes)
 				if err != nil {
-					err = msgp.WrapError(err, "ProposalBytes")
+					err = msgp.WrapError(err, "RawBytes")
 					return
 				}
-			case "pf":
-				bts, err = (*z).ProposalFilter.UnmarshalMsg(bts)
+			case "e":
+				bts, err = (*z).ExcludeProposal.UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "ProposalFilter")
+					err = msgp.WrapError(err, "ExcludeProposal")
 					return
 				}
-			case "mt":
-				(*z).ProposalMsgType, bts, err = msgp.ReadByteBytes(bts)
+			case "c":
+				(*z).Content, bts, err = msgp.ReadByteBytes(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "ProposalMsgType")
+					err = msgp.WrapError(err, "Content")
 					return
 				}
 			default:
@@ -26507,13 +26507,13 @@ func (_ *relayedProposal) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *relayedProposal) Msgsize() (s int) {
-	s = 1 + 3 + msgp.BytesPrefixSize + len((*z).ProposalBytes) + 3 + (*z).ProposalFilter.Msgsize() + 3 + msgp.ByteSize
+	s = 1 + 2 + msgp.BytesPrefixSize + len((*z).RawBytes) + 2 + (*z).ExcludeProposal.Msgsize() + 2 + msgp.ByteSize
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *relayedProposal) MsgIsZero() bool {
-	return (len((*z).ProposalBytes) == 0) && ((*z).ProposalFilter.MsgIsZero()) && ((*z).ProposalMsgType == 0)
+	return (len((*z).RawBytes) == 0) && ((*z).ExcludeProposal.MsgIsZero()) && ((*z).Content == 0)
 }
 
 // MarshalMsg implements msgp.Marshaler
@@ -26979,11 +26979,11 @@ func (z *transactionBlockMessage) MarshalMsg(b []byte) (o []byte) {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
-	if (*z).ProposalData.MsgIsZero() {
+	if (*z).Round.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x10
 	}
-	if (*z).Round.MsgIsZero() {
+	if (*z).RelayedProposal.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x20
 	}
@@ -27036,14 +27036,14 @@ func (z *transactionBlockMessage) MarshalMsg(b []byte) (o []byte) {
 			}
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
-			// string "pd"
-			o = append(o, 0xa2, 0x70, 0x64)
-			o = (*z).ProposalData.MarshalMsg(o)
-		}
-		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "r"
 			o = append(o, 0xa1, 0x72)
 			o = (*z).Round.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not empty
+			// string "rp"
+			o = append(o, 0xa2, 0x72, 0x70)
+			o = (*z).RelayedProposal.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not empty
 			// string "t"
@@ -27191,9 +27191,9 @@ func (z *transactionBlockMessage) UnmarshalMsg(bts []byte) (o []byte, err error)
 		}
 		if zb0001 > 0 {
 			zb0001--
-			bts, err = (*z).ProposalData.UnmarshalMsg(bts)
+			bts, err = (*z).RelayedProposal.UnmarshalMsg(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "ProposalData")
+				err = msgp.WrapError(err, "struct-from-array", "RelayedProposal")
 				return
 			}
 		}
@@ -27320,10 +27320,10 @@ func (z *transactionBlockMessage) UnmarshalMsg(bts []byte) (o []byte, err error)
 					err = msgp.WrapError(err, "MsgSync")
 					return
 				}
-			case "pd":
-				bts, err = (*z).ProposalData.UnmarshalMsg(bts)
+			case "rp":
+				bts, err = (*z).RelayedProposal.UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "ProposalData")
+					err = msgp.WrapError(err, "RelayedProposal")
 					return
 				}
 			default:
@@ -27346,13 +27346,13 @@ func (_ *transactionBlockMessage) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *transactionBlockMessage) Msgsize() (s int) {
-	s = 1 + 2 + msgp.Int32Size + 2 + (*z).Round.Msgsize() + 2 + (*z).TxnBloomFilter.Msgsize() + 2 + 1 + 2 + msgp.ByteSize + 2 + msgp.ByteSize + 2 + (*z).TransactionGroups.Msgsize() + 2 + (*z).MsgSync.Msgsize() + 3 + (*z).ProposalData.Msgsize()
+	s = 1 + 2 + msgp.Int32Size + 2 + (*z).Round.Msgsize() + 2 + (*z).TxnBloomFilter.Msgsize() + 2 + 1 + 2 + msgp.ByteSize + 2 + msgp.ByteSize + 2 + (*z).TransactionGroups.Msgsize() + 2 + (*z).MsgSync.Msgsize() + 3 + (*z).RelayedProposal.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *transactionBlockMessage) MsgIsZero() bool {
-	return ((*z).Version == 0) && ((*z).Round.MsgIsZero()) && ((*z).TxnBloomFilter.MsgIsZero()) && (((*z).UpdatedRequestParams.Offset == 0) && ((*z).UpdatedRequestParams.Modulator == 0)) && ((*z).TransactionGroups.MsgIsZero()) && ((*z).MsgSync.MsgIsZero()) && ((*z).ProposalData.MsgIsZero())
+	return ((*z).Version == 0) && ((*z).Round.MsgIsZero()) && ((*z).TxnBloomFilter.MsgIsZero()) && (((*z).UpdatedRequestParams.Offset == 0) && ((*z).UpdatedRequestParams.Modulator == 0)) && ((*z).TransactionGroups.MsgIsZero()) && ((*z).MsgSync.MsgIsZero()) && ((*z).RelayedProposal.MsgIsZero())
 }
 
 // MarshalMsg implements msgp.Marshaler

--- a/txnsync/msgp_gen_test.go
+++ b/txnsync/msgp_gen_test.go
@@ -1250,6 +1250,65 @@ func BenchmarkUnmarshalpackedTransactionGroups(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalrelayedProposal(t *testing.T) {
+	v := relayedProposal{}
+	bts := v.MarshalMsg(nil)
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func TestRandomizedEncodingrelayedProposal(t *testing.T) {
+	protocol.RunEncodingTest(t, &relayedProposal{})
+}
+
+func BenchmarkMarshalMsgrelayedProposal(b *testing.B) {
+	v := relayedProposal{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgrelayedProposal(b *testing.B) {
+	v := relayedProposal{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalrelayedProposal(b *testing.B) {
+	v := relayedProposal{}
+	bts := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalrequestParams(t *testing.T) {
 	v := requestParams{}
 	bts := v.MarshalMsg(nil)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

These changes add fields to the txnsync msgs in order to support sending proposals using the txnsync. For now, the txnsync message handler ignores all messages of this type.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
