### PR TITLE
Addressing panic in assembler

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -445,11 +445,11 @@ func assembleIntC(ops *OpStream, spec *OpSpec, args []string) error {
 }
 func assembleByteC(ops *OpStream, spec *OpSpec, args []string) error {
 	if len(args) != 1 {
-		ops.error("bytec operation needs one argument")
+		return ops.error("bytec operation needs one argument")
 	}
 	constIndex, err := strconv.ParseUint(args[0], 0, 64)
 	if err != nil {
-		ops.error(err)
+		return ops.error(err)
 	}
 	ops.Bytec(uint(constIndex))
 	return nil
@@ -457,11 +457,11 @@ func assembleByteC(ops *OpStream, spec *OpSpec, args []string) error {
 
 func asmPushInt(ops *OpStream, spec *OpSpec, args []string) error {
 	if len(args) != 1 {
-		ops.errorf("%s needs one argument", spec.Name)
+		return ops.errorf("%s needs one argument", spec.Name)
 	}
 	val, err := strconv.ParseUint(args[0], 0, 64)
 	if err != nil {
-		ops.error(err)
+		return ops.error(err)
 	}
 	ops.pending.WriteByte(spec.Opcode)
 	var scratch [binary.MaxVarintLen64]byte
@@ -471,7 +471,7 @@ func asmPushInt(ops *OpStream, spec *OpSpec, args []string) error {
 }
 func asmPushBytes(ops *OpStream, spec *OpSpec, args []string) error {
 	if len(args) != 1 {
-		ops.errorf("%s needs one argument", spec.Name)
+		return ops.errorf("%s needs one argument", spec.Name)
 	}
 	val, _, err := parseBinaryArgs(args)
 	if err != nil {

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -1331,6 +1331,22 @@ func TestConstantDisassembly(t *testing.T) {
 
 }
 
+func TestConstantArgs(t *testing.T) {
+	t.Parallel()
+	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
+		testProg(t, "int", v, expect{1, "int needs one argument"})
+		testProg(t, "intc", v, expect{1, "intc operation needs one argument"})
+		testProg(t, "byte", v, expect{1, "byte operation needs byte literal argument"})
+		testProg(t, "bytec", v, expect{1, "bytec operation needs one argument"})
+		testProg(t, "addr", v, expect{1, "addr operation needs one argument"})
+	}
+	for v := uint64(3); v <= AssemblerMaxVersion; v++ {
+		testProg(t, "pushint", v, expect{1, "pushint needs one argument"})
+		testProg(t, "pushbytes", v, expect{1, "pushbytes needs one argument"})
+	}
+
+}
+
 func TestAssembleDisassembleErrors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
I'm probably doing something wrong in my code somewhere* but started getting no response from remote compile.  Tracked it down to one of the bytec functions that does check the slice it accesses is long enough but doesn't bail, so it panics.

Took the liberty of adding returns to the other functions in the area but I don't feel confident enough to add them elsewhere. 


*had a pushbytes with no arg

## Test Plan

I didn't 