### PR TITLE
Fix path to spec file for rpm builds

### DIFF
--- a/scripts/release/mule/package/rpm/package.sh
+++ b/scripts/release/mule/package/rpm/package.sh
@@ -43,7 +43,7 @@ find tmp/node_pkgs -name "*${CHANNEL}*linux*${VERSION}*.tar.gz" | cut -d '/' -f3
         INSTALLER_DIR=algorand
     fi
     trap 'rm -rf $TEMPDIR' 0
-    < "./installer/rpm/$INSTALLER_DIR/$ALGORAND_PACKAGE_NAME.spec" \
+    < "./installer/rpm/$INSTALLER_DIR/$INSTALLER_DIR.spec" \
         sed -e "s,@PKG_NAME@,$ALGORAND_PACKAGE_NAME," \
             -e "s,@VER@,$VERSION," \
             -e "s,@ARCH@,$ARCH_UNAME," \


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

A recent update broke the path to the spec file for rpm building.

## Test Plan

Verify with a rel/beta build.
