### PR TITLE
bug: disable networking on devmode

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -161,7 +161,6 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 
 	node := new(AlgorandFullNode)
 	node.rootDir = rootDir
-	node.config = cfg
 	node.log = log.With("name", cfg.NetAddress)
 	node.genesisID = genesis.ID()
 	node.genesisHash = crypto.HashObj(genesis)
@@ -170,6 +169,7 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 	if node.devMode {
 		cfg.DisableNetworking = true
 	}
+	node.config = cfg
 
 	// tie network, block fetcher, and agreement services together
 	p2pNode, err := network.NewWebsocketNetwork(node.log, node.config, phonebookAddresses, genesis.ID(), genesis.Network)


### PR DESCRIPTION
## Summary

The current code would not pass the `DisableNetworking` flag to the network package. This could be worked around by adding the `DisableNetworking` to the `config.json` file, or with this fix.

## Test Plan

Tested manually.
