### PR TITLE
Install with dnf if present, otherwise fallback to yum

### DIFF
--- a/scripts/release/mule/test/test.sh
+++ b/scripts/release/mule/test/test.sh
@@ -93,7 +93,11 @@ else
     # We need to install this since it's not being installed by a package manager.
     # Normally, this is installed for us b/c it's a dependency.
     # See `./installer/rpm/algorand/algorand.spec`.
-    dnf install dnf-automatic -y
+    if command -v dnf &>/dev/null; then
+      dnf install dnf-automatic -y
+    else
+      yum install dnf-automatic -y
+    fi
     #
     # Note that the RPM package DOES NOT have the CHANNEL in its filename (unlike DEB),
     # instead it contains the package name.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

In rpm package testing, dnf is not always installed. Check to see if it's available; otherwise fall back to yum.

## Test Plan

Tried it on current rel/beta branch and it worked.
