### PR TITLE
txnsync: avoid deadlock when disconnecting from network peer

### DIFF
--- a/node/txnSyncConn.go
+++ b/node/txnSyncConn.go
@@ -19,6 +19,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/algorand/go-algorand/data"
@@ -31,7 +32,9 @@ import (
 	"github.com/algorand/go-algorand/util/timers"
 )
 
-// transcationSyncNodeConnector implements the txnsync.NodeConnector interface, allowing the
+var errDisconnectFromNetworkPeer = errors.New("disconnect from network peer")
+
+// transcationSyncNodeConnector implementes the txnsync.NodeConnector interface, allowing the
 // transaction sync communicate with the node and it's child objects.
 type transcationSyncNodeConnector struct {
 	node           *AlgorandFullNode
@@ -141,11 +144,12 @@ func (tsnc *transcationSyncNodeConnector) SendPeerMessage(netPeer interface{}, m
 		return
 	}
 
-	if err := unicastPeer.Unicast(context.Background(), msg, protocol.Txn2Tag, func(enqueued bool, sequenceNumber uint64) {
+	if err := unicastPeer.Unicast(context.Background(), msg, protocol.Txn2Tag, func(enqueued bool, sequenceNumber uint64) error {
 		if callbackErr := callback(enqueued, sequenceNumber); callbackErr != nil {
-			// disconnect from peer - the transaction sync wasn't able to process message sending confirmation
-			tsnc.node.net.Disconnect(unicastPeer)
+			// disconnect from peer - return a non-nil error
+			return errDisconnectFromNetworkPeer
 		}
+		return nil
 	}); err != nil {
 		if callbackErr := callback(false, 0); callbackErr != nil {
 			// disconnect from peer - the transaction sync wasn't able to process message sending confirmation


### PR DESCRIPTION
## Summary

This PR address a deadlock between the `SendPeerMessage` and network package in the following scenario:
1. The `SendPeerMessage` is calling the peer `Unicast` method, passing a custom callback method.
2. The `Unicast` method returns nil, and the `SendPeerMessage` returns.
3. The network peer is failing to enqueue the message, making the call to the custom method specified in `SendPeerMessage`.
4. The custom method makes a call to the txsync, and concludes that the network connection need to be disconnected.
5. The custom method calls network's `Disconnect`, passing the peer.

At that point, the network package would block the `Disconnect` until the peer is disconnected. However, since the sending loop call is blocked due to the call to the callback method, the peer's `CloseAndWait` would never exit.

The solution implemented here is to return an error code from the callback method. When an error code is returned, the network package would treat that as a communication error and disconnect the peer.

## Test Plan

Tested manually.
