### PR TITLE
Remove references to centos8 rpm packaging

### DIFF
--- a/package-deploy.yaml
+++ b/package-deploy.yaml
@@ -64,25 +64,6 @@ agents:
     workDir: $HOME/projects/go-algorand
 
 
-  - name: rpm.centos8
-    dockerFilePath: docker/build/cicd.centos8.Dockerfile
-    image: algorand/go-algorand-ci-linux-centos8
-    version: scripts/configure_dev-deps.sh
-    buildArgs:
-      - GOLANG_VERSION=`./scripts/get_golang_version.sh`
-    env:
-      - AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
-      - NETWORK=$NETWORK
-      - PACKAGES_DIR=$PACKAGES_DIR
-      - NO_DEPLOY=$NO_DEPLOY
-      - S3_SOURCE=$S3_SOURCE
-      - VERSION=$VERSION
-    volumes:
-      - $XDG_RUNTIME_DIR/gnupg/S.gpg-agent:/root/.gnupg/S.gpg-agent
-      - $HOME/.gnupg/pubring.kbx:/root/.gnupg/pubring.kbx
-    workDir: $HOME/projects/go-algorand
-
 tasks:
   - task: docker.Make
     name: docker
@@ -104,11 +85,6 @@ tasks:
     agent: rpm
     target: mule-deploy-rpm
 
-  - task: docker.Make
-    name: rpm.centos8
-    agent: rpm.centos8
-    target: mule-deploy-rpm-centos8
-
 jobs:
   package-deploy:
     tasks:
@@ -124,7 +100,6 @@ jobs:
   package-deploy-rpm:
     tasks:
       - docker.Make.rpm
-      - docker.Make.rpm.centos8
 
   docker-hub:
     tasks:

--- a/package-test.yaml
+++ b/package-test.yaml
@@ -31,22 +31,6 @@ agents:
       - VERSION=$VERSION
     workDir: $HOME/projects/go-algorand
 
-  - name: rpm-centos8
-    dockerFilePath: docker/build/cicd.centos8.Dockerfile
-    image: algorand/mule-linux-centos8
-    version: scripts/configure_dev-deps.sh
-    buildArgs:
-      - GOLANG_VERSION=`./scripts/get_golang_version.sh`
-    env:
-      - AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
-      - BRANCH=$BRANCH
-      - NETWORK=$NETWORK
-      - S3_SOURCE=$S3_SOURCE
-      - SHA=$SHA
-      - VERSION=$VERSION
-    workDir: $HOME/projects/go-algorand
-
 tasks:
   - task: docker.Make
     name: package-test-deb
@@ -58,17 +42,11 @@ tasks:
     agent: rpm
     target: mule-test-rpm
 
-  - task: docker.Make
-    name: package-test-rpm-centos8
-    agent: rpm-centos8
-    target: mule-test-rpm-centos8
-
 jobs:
   package-test:
     tasks:
       - docker.Make.package-test-deb
       - docker.Make.package-test-rpm
-      - docker.Make.package-test-rpm-centos8
 
   package-test-deb:
     tasks:
@@ -77,5 +55,3 @@ jobs:
   package-test-rpm:
     tasks:
       - docker.Make.package-test-rpm
-      - docker.Make.package-test-rpm-centos8
-

--- a/package.yaml
+++ b/package.yaml
@@ -21,17 +21,6 @@ agents:
       - VERSION=$VERSION
     workDir: $HOME/projects/go-algorand
 
-  - name: rpm.centos8
-    dockerFilePath: docker/build/cicd.centos8.Dockerfile
-    image: algorand/go-algorand-ci-linux-centos8
-    version: scripts/configure_dev-deps.sh
-    buildArgs:
-      - GOLANG_VERSION=`./scripts/get_golang_version.sh`
-    env:
-      - NETWORK=$NETWORK
-      - VERSION=$VERSION
-    workDir: $HOME/projects/go-algorand
-
   - name: docker
     dockerFilePath: docker/build/docker.ubuntu.Dockerfile
     image: algorand/go-algorand-docker-linux-ubuntu
@@ -57,11 +46,6 @@ tasks:
     target: mule-package-rpm
 
   - task: docker.Make
-    name: rpm.centos8
-    agent: rpm.centos8
-    target: mule-package-rpm.centos8
-
-  - task: docker.Make
     name: deb
     agent: deb
     target: mule-package-deb
@@ -77,7 +61,6 @@ jobs:
       - docker.Make.build
       - docker.Make.deb
       - docker.Make.rpm
-      - docker.Make.rpm.centos8
       - docker.Make.docker
 
   package-deb:
@@ -88,7 +71,6 @@ jobs:
     tasks:
       - docker.Make.build
       - docker.Make.rpm
-      - docker.Make.rpm.centos8
 
   package-docker:
     tasks:

--- a/scripts/release/build/rpm/docker.sh
+++ b/scripts/release/build/rpm/docker.sh
@@ -9,7 +9,6 @@ echo
 set -ex
 
 sg docker "docker run --rm --env-file ${HOME}/build_env_docker --mount type=bind,src=${HOME},dst=/root/subhome algocentosbuild /root/subhome/go/src/github.com/algorand/go-algorand/scripts/release/build/rpm/package.sh"
-sg docker "docker run --rm --env-file ${HOME}/build_env_docker --mount type=bind,src=${HOME},dst=/root/subhome algocentos8build /root/subhome/go/src/github.com/algorand/go-algorand/scripts/release/build/rpm/package.sh"
 
 echo
 date "+build_release end PACKAGE RPM stage %Y%m%d_%H%M%S"

--- a/scripts/release/build/stage/build/task.sh
+++ b/scripts/release/build/stage/build/task.sh
@@ -30,13 +30,9 @@ else
     echo ${BUILD_NUMBER} > "${REPO_ROOT}"/buildnumber.dat
 fi
 
-# Run RPM build in Centos7 Docker container
+# Run RPM build in Centos 7 & 8 Docker container
 sg docker "docker build -t algocentosbuild - < $HOME/go/src/github.com/algorand/go-algorand/scripts/release/common/docker/centos.Dockerfile"
 sg docker "docker run --rm --env-file ${HOME}/build_env_docker --mount type=bind,src=${HOME},dst=/root/subhome algocentosbuild /root/subhome/go/src/github.com/algorand/go-algorand/scripts/release/build/rpm/build.sh"
-
-# Run RPM build in Centos8 Docker container
-sg docker "docker build -t algocentos8build - < $HOME/go/src/github.com/algorand/go-algorand/scripts/release/common/docker/centos8.Dockerfile"
-sg docker "docker run --rm --env-file ${HOME}/build_env_docker --mount type=bind,src=${HOME},dst=/root/subhome algocentos8build /root/subhome/go/src/github.com/algorand/go-algorand/scripts/release/build/rpm/build.sh"
 
 echo
 date "+build_release end BUILD stage %Y%m%d_%H%M%S"

--- a/scripts/release/build/stage/package/task.sh
+++ b/scripts/release/build/stage/package/task.sh
@@ -13,7 +13,6 @@ echo
 "${HOME}"/go/src/github.com/algorand/go-algorand/scripts/release/build/deb/package.sh
 
 sg docker "docker run --rm --env-file $HOME/build_env_docker --mount type=bind,src=$HOME,dst=/root/subhome algocentosbuild /root/subhome/go/src/github.com/algorand/go-algorand/scripts/release/build/rpm/package.sh"
-sg docker "docker run --rm --env-file $HOME/build_env_docker --mount type=bind,src=$HOME,dst=/root/subhome algocentos8build /root/subhome/go/src/github.com/algorand/go-algorand/scripts/release/build/rpm/package.sh"
 
 echo
 date "+build_release end PACKAGE stage %Y%m%d_%H%M%S"

--- a/scripts/release/prod/rpm/run_centos.sh
+++ b/scripts/release/prod/rpm/run_centos.sh
@@ -5,12 +5,8 @@ set -ex
 
 . "${HOME}"/build_env
 
-# Run RPM build in Centos7 Docker container
+# Run RPM build in Centos 7 & 8 Docker container
 sg docker "docker build -t algocentosbuild - < ${HOME}/go/src/github.com/algorand/go-algorand/scripts/release/common/docker/centos.Dockerfile"
 
 sg docker "docker run --rm --env-file ${HOME}/build_env_docker --mount type=bind,src=/run/user/1000/gnupg/S.gpg-agent,dst=/root/S.gpg-agent --mount type=bind,src=${HOME}/prodrepo,dst=/root/prodrepo --mount type=bind,src=${HOME}/keys,dst=/root/keys --mount type=bind,src=${HOME},dst=/root/subhome algocentosbuild /root/subhome/go/src/github.com/algorand/go-algorand/scripts/release/prod/rpm/snapshot.sh"
 
-# Run RPM build in Centos8 Docker container
-sg docker "docker build -t algocentos8build - < ${HOME}/go/src/github.com/algorand/go-algorand/scripts/release/common/docker/centos8.Dockerfile"
-
-sg docker "docker run --rm --env-file ${HOME}/build_env_docker --mount type=bind,src=/run/user/1000/gnupg/S.gpg-agent,dst=/root/S.gpg-agent --mount type=bind,src=${HOME}/prodrepo,dst=/root/prodrepo --mount type=bind,src=${HOME}/keys,dst=/root/keys --mount type=bind,src=${HOME},dst=/root/subhome algocentos8build /root/subhome/go/src/github.com/algorand/go-algorand/scripts/release/prod/rpm/snapshot.sh"

--- a/scripts/release/test/rpm/run_centos.sh
+++ b/scripts/release/test/rpm/run_centos.sh
@@ -14,10 +14,8 @@ if [ "$CHANNEL" = beta ]; then
     exit 0
 fi
 
-# Run RPM build in Centos7 Docker container
+# Run RPM build in Centos 7 & 8 Docker container
 sg docker "docker build -t algocentosbuild - < ${HOME}/go/src/github.com/algorand/go-algorand/scripts/release/common/docker/centos.Dockerfile"
-# Run RPM build in Centos8 Docker container
-sg docker "docker build -t algocentos8build - < ${HOME}/go/src/github.com/algorand/go-algorand/scripts/release/common/docker/centos8.Dockerfile"
 
 cat <<EOF>"${HOME}"/dummyrepo/algodummy.repo
 [algodummy]
@@ -32,7 +30,6 @@ cd "${HOME}"/dummyrepo && python3 "${HOME}"/go/src/github.com/algorand/go-algora
 trap "${HOME}"/go/src/github.com/algorand/go-algorand/scripts/kill_httpd.sh 0
 
 sg docker "docker run --rm --env-file ${HOME}/build_env_docker --mount type=bind,src=/run/user/1000/gnupg/S.gpg-agent,dst=/root/S.gpg-agent --mount type=bind,src=${HOME}/dummyrepo,dst=/root/dummyrepo --mount type=bind,src=${HOME}/keys,dst=/root/keys --mount type=bind,src=${HOME},dst=/root/subhome algocentosbuild /root/subhome/go/src/github.com/algorand/go-algorand/scripts/release/test/rpm/test_algorand.sh"
-sg docker "docker run --rm --env-file ${HOME}/build_env_docker --mount type=bind,src=/run/user/1000/gnupg/S.gpg-agent,dst=/root/S.gpg-agent --mount type=bind,src=${HOME}/dummyrepo,dst=/root/dummyrepo --mount type=bind,src=${HOME}/keys,dst=/root/keys --mount type=bind,src=${HOME},dst=/root/subhome algocentos8build /root/subhome/go/src/github.com/algorand/go-algorand/scripts/release/test/rpm/test_algorand.sh"
 
 echo
 date "+build_release end TEST stage %Y%m%d_%H%M%S"


### PR DESCRIPTION


## Summary

Remove old references to centos8 rpm packaging.  There is now a single package for both centos 7 & 8.

## Test Plan

make clean, make install, make test.  Validate PR testing completes successfully.
