### PR TITLE
Use pre-existing homebrew state on CircleCI VMs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,81 +8,81 @@ workflows:
   version: 2
   build_pr:
     jobs:
-      # - codegen_verification
-      # - amd64_build
-      # - amd64_test:
-      #     requires:
-      #       - amd64_build
-      #     filters:
-      #       branches:
-      #         ignore: "rel/nightly"
-      # - amd64_test_nightly:
-      #     requires:
-      #       - amd64_build
-      #     filters:
-      #       branches:
-      #         only: "rel/nightly"
-      # - amd64_integration:
-      #     requires:
-      #       - amd64_build
-      #     filters:
-      #       branches:
-      #         ignore: "rel/nightly"
-      # - amd64_integration_nightly:
-      #     requires:
-      #       - amd64_build
-      #     filters:
-      #       branches:
-      #         only: "rel/nightly"
-      # - amd64_e2e_subs:
-      #     requires:
-      #       - amd64_build
-      #     filters:
-      #       branches:
-      #         ignore: "rel/nightly"
-      # - amd64_e2e_subs_nightly:
-      #     requires:
-      #       - amd64_build
-      #     filters:
-      #       branches:
-      #         only: "rel/nightly"
-      # - arm64_build
-      # - arm64_test:
-      #     requires:
-      #       - arm64_build
-      #     filters:
-      #       branches:
-      #         ignore: "rel/nightly"
-      # - arm64_test_nightly:
-      #     requires:
-      #       - arm64_build
-      #     filters:
-      #       branches:
-      #         only: "rel/nightly"
-      # - arm64_integration:
-      #     requires:
-      #       - arm64_build
-      #     filters:
-      #       branches:
-      #         ignore: "rel/nightly"
-      # - arm64_integration_nightly:
-      #     requires:
-      #       - arm64_build
-      #     filters:
-      #       branches:
-      #         only: "rel/nightly"
-      # - arm64_e2e_subs:
-      #     requires:
-      #       - arm64_build
-      #     filters:
-      #       branches:
-      #         ignore: "rel/nightly"
-      # - arm64_e2e_subs_nightly:
-      #     requires:
-      #       - arm64_build
-      #     filters:
-      #       branches:
-      #         only: "rel/nightly"
+      - codegen_verification
+      - amd64_build
+      - amd64_test:
+          requires:
+            - amd64_build
+          filters:
+            branches:
+              ignore: "rel/nightly"
+      - amd64_test_nightly:
+          requires:
+            - amd64_build
+          filters:
+            branches:
+              only: "rel/nightly"
+      - amd64_integration:
+          requires:
+            - amd64_build
+          filters:
+            branches:
+              ignore: "rel/nightly"
+      - amd64_integration_nightly:
+          requires:
+            - amd64_build
+          filters:
+            branches:
+              only: "rel/nightly"
+      - amd64_e2e_subs:
+          requires:
+            - amd64_build
+          filters:
+            branches:
+              ignore: "rel/nightly"
+      - amd64_e2e_subs_nightly:
+          requires:
+            - amd64_build
+          filters:
+            branches:
+              only: "rel/nightly"
+      - arm64_build
+      - arm64_test:
+          requires:
+            - arm64_build
+          filters:
+            branches:
+              ignore: "rel/nightly"
+      - arm64_test_nightly:
+          requires:
+            - arm64_build
+          filters:
+            branches:
+              only: "rel/nightly"
+      - arm64_integration:
+          requires:
+            - arm64_build
+          filters:
+            branches:
+              ignore: "rel/nightly"
+      - arm64_integration_nightly:
+          requires:
+            - arm64_build
+          filters:
+            branches:
+              only: "rel/nightly"
+      - arm64_e2e_subs:
+          requires:
+            - arm64_build
+          filters:
+            branches:
+              ignore: "rel/nightly"
+      - arm64_e2e_subs_nightly:
+          requires:
+            - arm64_build
+          filters:
+            branches:
+              only: "rel/nightly"
       - mac_amd64_build
       - mac_amd64_test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,81 +8,81 @@ workflows:
   version: 2
   build_pr:
     jobs:
-      - codegen_verification
-      - amd64_build
-      - amd64_test:
-          requires:
-            - amd64_build
-          filters:
-            branches:
-              ignore: "rel/nightly"
-      - amd64_test_nightly:
-          requires:
-            - amd64_build
-          filters:
-            branches:
-              only: "rel/nightly"
-      - amd64_integration:
-          requires:
-            - amd64_build
-          filters:
-            branches:
-              ignore: "rel/nightly"
-      - amd64_integration_nightly:
-          requires:
-            - amd64_build
-          filters:
-            branches:
-              only: "rel/nightly"
-      - amd64_e2e_subs:
-          requires:
-            - amd64_build
-          filters:
-            branches:
-              ignore: "rel/nightly"
-      - amd64_e2e_subs_nightly:
-          requires:
-            - amd64_build
-          filters:
-            branches:
-              only: "rel/nightly"
-      - arm64_build
-      - arm64_test:
-          requires:
-            - arm64_build
-          filters:
-            branches:
-              ignore: "rel/nightly"
-      - arm64_test_nightly:
-          requires:
-            - arm64_build
-          filters:
-            branches:
-              only: "rel/nightly"
-      - arm64_integration:
-          requires:
-            - arm64_build
-          filters:
-            branches:
-              ignore: "rel/nightly"
-      - arm64_integration_nightly:
-          requires:
-            - arm64_build
-          filters:
-            branches:
-              only: "rel/nightly"
-      - arm64_e2e_subs:
-          requires:
-            - arm64_build
-          filters:
-            branches:
-              ignore: "rel/nightly"
-      - arm64_e2e_subs_nightly:
-          requires:
-            - arm64_build
-          filters:
-            branches:
-              only: "rel/nightly"
+      # - codegen_verification
+      # - amd64_build
+      # - amd64_test:
+      #     requires:
+      #       - amd64_build
+      #     filters:
+      #       branches:
+      #         ignore: "rel/nightly"
+      # - amd64_test_nightly:
+      #     requires:
+      #       - amd64_build
+      #     filters:
+      #       branches:
+      #         only: "rel/nightly"
+      # - amd64_integration:
+      #     requires:
+      #       - amd64_build
+      #     filters:
+      #       branches:
+      #         ignore: "rel/nightly"
+      # - amd64_integration_nightly:
+      #     requires:
+      #       - amd64_build
+      #     filters:
+      #       branches:
+      #         only: "rel/nightly"
+      # - amd64_e2e_subs:
+      #     requires:
+      #       - amd64_build
+      #     filters:
+      #       branches:
+      #         ignore: "rel/nightly"
+      # - amd64_e2e_subs_nightly:
+      #     requires:
+      #       - amd64_build
+      #     filters:
+      #       branches:
+      #         only: "rel/nightly"
+      # - arm64_build
+      # - arm64_test:
+      #     requires:
+      #       - arm64_build
+      #     filters:
+      #       branches:
+      #         ignore: "rel/nightly"
+      # - arm64_test_nightly:
+      #     requires:
+      #       - arm64_build
+      #     filters:
+      #       branches:
+      #         only: "rel/nightly"
+      # - arm64_integration:
+      #     requires:
+      #       - arm64_build
+      #     filters:
+      #       branches:
+      #         ignore: "rel/nightly"
+      # - arm64_integration_nightly:
+      #     requires:
+      #       - arm64_build
+      #     filters:
+      #       branches:
+      #         only: "rel/nightly"
+      # - arm64_e2e_subs:
+      #     requires:
+      #       - arm64_build
+      #     filters:
+      #       branches:
+      #         ignore: "rel/nightly"
+      # - arm64_e2e_subs_nightly:
+      #     requires:
+      #       - arm64_build
+      #     filters:
+      #       branches:
+      #         only: "rel/nightly"
       - mac_amd64_build
       - mac_amd64_test:
           requires:

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -76,12 +76,14 @@ elif [ "${OS}" = "darwin" ]; then
     brew tap homebrew/cask
     install_or_upgrade pkg-config
     install_or_upgrade boost
-    install_or_upgrade jq
     install_or_upgrade libtool
-    install_or_upgrade autoconf
-    install_or_upgrade automake
     install_or_upgrade shellcheck
-    install_or_upgrade python3
+    if [ "${CIRCLECI}" != "true" ]; then
+        install_or_upgrade jq
+        install_or_upgrade autoconf
+        install_or_upgrade automake
+        install_or_upgrade python3
+    fi
 elif [ "${OS}" = "windows" ]; then
     if ! $msys2 pacman -S --disable-download-timeout --noconfirm git automake autoconf m4 libtool make mingw-w64-x86_64-gcc mingw-w64-x86_64-boost mingw-w64-x86_64-python mingw-w64-x86_64-jq unzip procps; then
         echo "Error installing pacman dependencies"

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -e
-set -x
 
 ./scripts/check_golang_version.sh dev
 

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -72,8 +72,10 @@ if [ "${OS}" = "linux" ]; then
         sudo "$SCRIPTPATH/install_linux_deps.sh"
     fi
 elif [ "${OS}" = "darwin" ]; then
-    brew update
-    brew tap homebrew/cask
+    if [ "${CIRCLECI}" != "true" ]; then
+        brew update
+        brew tap homebrew/cask
+    fi
     install_or_upgrade pkg-config
     install_or_upgrade boost
     install_or_upgrade libtool

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set -x
 
 ./scripts/check_golang_version.sh dev
 

--- a/scripts/travis/configure_dev.sh
+++ b/scripts/travis/configure_dev.sh
@@ -21,9 +21,11 @@ if [[ "${OS}" == "linux" ]]; then
 elif [[ "${OS}" == "darwin" ]]; then
     # we don't want to upgrade boost if we already have it, as it will try to update
     # other components.
-    brew update
-    brew tap homebrew/cask
-    brew pin boost || true
+    if [ "${CIRCLECI}" != "true" ]; then
+        brew update
+        brew tap homebrew/cask
+        brew pin boost || true
+    fi
 elif [[ "${OS}" == "windows" ]]; then
     git config --global core.autocrlf true
     # Golang probably is not installed under MSYS2 so add the environment variable temporarily


### PR DESCRIPTION
## Summary

CircleCI VMs come pre-installed with homebrew and some of the taps and packages we need already set up, so skipping running update and tap and install for those pre-existing assets reduces each job by ~6 minutes each (x 4 jobs).

## Test Plan

Should not impact tests, just make them run quicker