### PR TITLE
txnsync: avoid reallocating pending transaction ids slice

### DIFF
--- a/txnsync/peer.go
+++ b/txnsync/peer.go
@@ -517,6 +517,7 @@ func (p *Peer) updateRequestParams(modulator, offset byte) {
 func (p *Peer) updateIncomingTransactionGroups(txnGroups []transactions.SignedTxGroup) {
 	for _, txnGroup := range txnGroups {
 		if len(txnGroup.Transactions) > 0 {
+			// The GroupTransactionID field is not yet updated, so we'll be calculating it's value here and passing it.
 			p.recentSentTransactions.add(txnGroup.Transactions.ID())
 		}
 	}

--- a/txnsync/peer.go
+++ b/txnsync/peer.go
@@ -517,7 +517,7 @@ func (p *Peer) updateRequestParams(modulator, offset byte) {
 func (p *Peer) updateIncomingTransactionGroups(txnGroups []transactions.SignedTxGroup) {
 	for _, txnGroup := range txnGroups {
 		if len(txnGroup.Transactions) > 0 {
-			p.recentSentTransactions.add(txnGroup.GroupTransactionID)
+			p.recentSentTransactions.add(txnGroup.Transactions.ID())
 		}
 	}
 }

--- a/txnsync/transactionCache.go
+++ b/txnsync/transactionCache.go
@@ -102,9 +102,10 @@ func (lru *transactionCache) addSlice(txids []transactions.Txid, msgSeq uint64, 
 	}
 
 	if len(lru.ackPendingTxids) == cap(lru.ackPendingTxids) {
-		// clear out the entry at lru.ackPendingTxids[0] so that the GC could reclaim it.
-		lru.ackPendingTxids[0] = ackPendingTxids{}
-		lru.ackPendingTxids = append(lru.ackPendingTxids[1:], ackPendingTxids{txids: txids, seq: msgSeq, timestamp: timestamp})
+		// roll this array without reallocation.
+		copy(lru.ackPendingTxids, lru.ackPendingTxids[1:])
+		// update the last entry of the array.
+		lru.ackPendingTxids[len(lru.ackPendingTxids)-1] = ackPendingTxids{txids: txids, seq: msgSeq, timestamp: timestamp}
 	} else {
 		lru.ackPendingTxids = append(lru.ackPendingTxids, ackPendingTxids{txids: txids, seq: msgSeq, timestamp: timestamp})
 	}


### PR DESCRIPTION
## Summary

The current code was rolling the `ackPendingTxids` slice by using append. This works correctly from functional standpoint, but require an additional allocation + copy. Given that this allocation appeared in the memory profiler, I'm going to defer to doing a plain copy and avoid the allocation completely.

## Test Plan

- [x] Tested using s1 network.
- [x] Tested using emulator.
