### PR TITLE
Bump arm integration jobs to large on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -535,7 +535,7 @@ jobs:
   arm64_integration_nightly:
     machine:
       image: ubuntu-2004:202101-01
-    resource_class: arm.medium
+    resource_class: arm.large
     parallelism: 4
     environment:
       SKIP_E2E_SUBS: "true"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -522,7 +522,7 @@ jobs:
   arm64_integration:
     machine:
       image: ubuntu-2004:202101-01
-    resource_class: arm.medium
+    resource_class: arm.large
     parallelism: 4
     environment:
       SKIP_E2E_SUBS: "true"


### PR DESCRIPTION
## Summary

We have seem some test failures that have happened only for arm64 integration tests on PRs that don't touch the code. This PR raises the resource class to give those jobs more compute to see if that resolves the problem.

## Test Plan

The plan is to run jobs with this resource class and see if there's improvement in consistency.
