### PR TITLE
CircleCI: parameterizing no_output_timeout and -short

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,13 +285,19 @@ commands:
         default: "/home/circleci"
       result_subdir:
         type: string
+      no_output_timeout:
+        type: string
+        default: 30m
+      go_test_flags:
+        type: string
+        default: "-short"
     steps:
       - attach_workspace:
           at: << parameters.circleci_home >>
       - run: mkdir -p /tmp/results/<< parameters.result_subdir >>
       - run:
           name: Run integration tests
-          no_output_timeout: 30m
+          no_output_timeout: << parameters.no_output_timeout >>
           command: |
             set -x
             export PATH=$(echo "$PATH" | sed -e 's|:<< parameters.circleci_home >>/\.go_workspace/bin||g' | sed -e 's|:/usr/local/go/bin||g')
@@ -305,46 +311,7 @@ commands:
             scripts/configure_dev.sh
             scripts/buildtools/install_buildtools.sh -o "gotest.tools/gotestsum"
             export ALGOTEST=1
-            export SHORTTEST=-short
-            export TEST_RESULTS=/tmp/results/<< parameters.result_subdir >>
-            export PARTITION_TOTAL=$CIRCLE_NODE_TOTAL
-            export PARTITION_ID=$CIRCLE_NODE_INDEX
-            test/scripts/run_integration_tests.sh
-      - store_artifacts:
-          path: /tmp/results
-          destination: test-results
-      - store_test_results:
-          path: /tmp/results
-
-  generic_nightlyintegration:
-    description: Run nightly integration tests from build workspace, for re-use by diferent architectures
-    parameters:
-      circleci_home:
-        type: string
-        default: "/home/circleci"
-      result_subdir:
-        type: string
-    steps:
-      - attach_workspace:
-          at: << parameters.circleci_home >>
-      - run: mkdir -p /tmp/results/<< parameters.result_subdir >>
-      - run:
-          name: Run integration tests
-          no_output_timeout: 45m
-          command: |
-            set -x
-            export PATH=$(echo "$PATH" | sed -e 's|:<< parameters.circleci_home >>/\.go_workspace/bin||g' | sed -e 's|:/usr/local/go/bin||g')
-            export KMD_NOUSB=True
-            export GOPATH="<< parameters.circleci_home >>/go"
-            export PATH="${PATH}:${GOPATH}/bin"
-            export ALGORAND_DEADLOCK=enable
-            export BUILD_TYPE=integration
-            GOLANG_VERSION=$(./scripts/get_golang_version.sh)
-            eval "$(~/gimme "${GOLANG_VERSION}")"
-            scripts/configure_dev.sh
-            scripts/buildtools/install_buildtools.sh -o "gotest.tools/gotestsum"
-            export ALGOTEST=1
-            export SHORTTEST=-short
+            export SHORTTEST=<< parameters.go_test_flags >>
             export TEST_RESULTS=/tmp/results/<< parameters.result_subdir >>
             export PARTITION_TOTAL=$CIRCLE_NODE_TOTAL
             export PARTITION_ID=$CIRCLE_NODE_INDEX
@@ -404,7 +371,7 @@ jobs:
   amd64_integration:
     machine:
       image: ubuntu-2004:202104-01
-    resource_class: medium
+    resource_class: large
     parallelism: 4
     environment:
       SKIP_E2E_SUBS: "true"
@@ -416,14 +383,16 @@ jobs:
   amd64_integration_nightly:
     machine:
       image: ubuntu-2004:202104-01
-    resource_class: medium
+    resource_class: large
     parallelism: 4
     environment:
       SKIP_E2E_SUBS: "true"
     steps:
       - prepare_go
-      - generic_nightlyintegration:
+      - generic_integration:
           result_subdir: amd64-integrationnightly
+          no_output_timeout: 45m
+          go_test_flags: ""
 
   amd64_e2e_subs:
     machine:
@@ -444,8 +413,10 @@ jobs:
       E2E_SUBS_ONLY: "true"
     steps:
       - prepare_go
-      - generic_nightlyintegration:
+      - generic_integration:
           result_subdir: amd64-e2e_subs_nightly
+          no_output_timeout: 45m
+          go_test_flags: ""
 
   arm64_build:
     machine:
@@ -485,7 +456,7 @@ jobs:
   arm64_integration:
     machine:
       image: ubuntu-2004:202101-01
-    resource_class: arm.medium
+    resource_class: arm.large
     parallelism: 4
     environment:
       SKIP_E2E_SUBS: "true"
@@ -494,19 +465,23 @@ jobs:
       - prepare_go
       - generic_integration:
           result_subdir: arm64-integration
+          no_output_timeout: 45m
+          go_test_flags: ""
 
   arm64_integration_nightly:
     machine:
       image: ubuntu-2004:202101-01
-    resource_class: arm.medium
+    resource_class: arm.large
     parallelism: 4
     environment:
       SKIP_E2E_SUBS: "true"
     steps:
       - checkout
       - prepare_go
-      - generic_nightlyintegration:
+      - generic_integration:
           result_subdir: arm64-integration-nightly
+          no_output_timeout: 45m
+          go_test_flags: ""
 
   arm64_e2e_subs:
     machine:
@@ -529,8 +504,10 @@ jobs:
     steps:
       - checkout
       - prepare_go
-      - generic_nightlyintegration:
+      - generic_integration:
           result_subdir: arm64-e2e_subs-nightly
+          no_output_timeout: 45m
+          go_test_flags: ""
 
   mac_amd64_build:
     macos:
@@ -580,7 +557,7 @@ jobs:
   mac_amd64_integration:
     macos:
       xcode: 12.0.1
-    resource_class: medium
+    resource_class: large
     parallelism: 4
     environment:
       SKIP_E2E_SUBS: "true"
@@ -591,11 +568,13 @@ jobs:
       - generic_integration:
           result_subdir: mac-amd64-integration
           circleci_home: /Users/distiller
+          no_output_timeout: 45m
+          go_test_flags: ""
 
   mac_amd64_integration_nightly:
     macos:
       xcode: 12.0.1
-    resource_class: medium
+    resource_class: large
     parallelism: 4
     environment:
       SKIP_E2E_SUBS: "true"
@@ -603,9 +582,11 @@ jobs:
     steps:
       #- run: git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
       - prepare_go
-      - generic_nightlyintegration:
+      - generic_integration:
           result_subdir: mac-amd64-integration-nightly
           circleci_home: /Users/distiller
+          no_output_timeout: 45m
+          go_test_flags: ""
 
   mac_amd64_e2e_subs:
     macos:
@@ -617,7 +598,7 @@ jobs:
     steps:
       #- run: git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
       - prepare_go
-      - generic_nightlyintegration:
+      - generic_integration:
           result_subdir: mac-amd64-e2e_subs
           circleci_home: /Users/distiller
 
@@ -631,9 +612,11 @@ jobs:
     steps:
       #- run: git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
       - prepare_go
-      - generic_nightlyintegration:
+      - generic_integration:
           result_subdir: mac-amd64-e2e_subs-nightly
           circleci_home: /Users/distiller
+          no_output_timeout: 45m
+          go_test_flags: ""
 
   windows_x64_build:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,111 +15,111 @@ workflows:
             - amd64_build
           filters:
             branches:
-              ignore: /pull\/[0-9]+/
+              ignore: "rel/nightly"
       - amd64_test_nightly:
           requires:
             - amd64_build
           filters:
             branches:
-              only: /pull\/[0-9]+/
+              only: "rel/nightly"
       - amd64_integration:
           requires:
             - amd64_build
           filters:
             branches:
-              ignore: /pull\/[0-9]+/
+              ignore: "rel/nightly"
       - amd64_integration_nightly:
           requires:
             - amd64_build
           filters:
             branches:
-              only: /pull\/[0-9]+/
+              only: "rel/nightly"
       - amd64_e2e_subs:
           requires:
             - amd64_build
           filters:
             branches:
-              ignore: /pull\/[0-9]+/
+              ignore: "rel/nightly"
       - amd64_e2e_subs_nightly:
           requires:
             - amd64_build
           filters:
             branches:
-              only: /pull\/[0-9]+/
+              only: "rel/nightly"
       - arm64_build
       - arm64_test:
           requires:
             - arm64_build
           filters:
             branches:
-              ignore: /pull\/[0-9]+/
+              ignore: "rel/nightly"
       - arm64_test_nightly:
           requires:
             - arm64_build
           filters:
             branches:
-              only: /pull\/[0-9]+/
+              only: "rel/nightly"
       - arm64_integration:
           requires:
             - arm64_build
           filters:
             branches:
-              ignore: /pull\/[0-9]+/
+              ignore: "rel/nightly"
       - arm64_integration_nightly:
           requires:
             - arm64_build
           filters:
             branches:
-              only: /pull\/[0-9]+/
+              only: "rel/nightly"
       - arm64_e2e_subs:
           requires:
             - arm64_build
           filters:
             branches:
-              ignore: /pull\/[0-9]+/
+              ignore: "rel/nightly"
       - arm64_e2e_subs_nightly:
           requires:
             - arm64_build
           filters:
             branches:
-              only: /pull\/[0-9]+/
+              only: "rel/nightly"
       - mac_amd64_build
       - mac_amd64_test:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              ignore: /pull\/[0-9]+/
+              ignore: "rel/nightly"
       - mac_amd64_test_nightly:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              only: /pull\/[0-9]+/
+              only: "rel/nightly"
       - mac_amd64_integration:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              ignore: /pull\/[0-9]+/
+              ignore: "rel/nightly"
       - mac_amd64_integration_nightly:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              only: /pull\/[0-9]+/
+              only: "rel/nightly"
       - mac_amd64_e2e_subs:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              ignore: /pull\/[0-9]+/
+              ignore: "rel/nightly"
       - mac_amd64_e2e_subs_nightly:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              only: /pull\/[0-9]+/
+              only: "rel/nightly"
       #- windows_x64_build
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,8 +465,6 @@ jobs:
       - prepare_go
       - generic_integration:
           result_subdir: arm64-integration
-          no_output_timeout: 45m
-          go_test_flags: ""
 
   arm64_integration_nightly:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,111 +15,111 @@ workflows:
             - amd64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore: /pull\/[0-9]+/
       - amd64_test_nightly:
           requires:
             - amd64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only: /pull\/[0-9]+/
       - amd64_integration:
           requires:
             - amd64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore: /pull\/[0-9]+/
       - amd64_integration_nightly:
           requires:
             - amd64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only: /pull\/[0-9]+/
       - amd64_e2e_subs:
           requires:
             - amd64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore: /pull\/[0-9]+/
       - amd64_e2e_subs_nightly:
           requires:
             - amd64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only: /pull\/[0-9]+/
       - arm64_build
       - arm64_test:
           requires:
             - arm64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore: /pull\/[0-9]+/
       - arm64_test_nightly:
           requires:
             - arm64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only: /pull\/[0-9]+/
       - arm64_integration:
           requires:
             - arm64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore: /pull\/[0-9]+/
       - arm64_integration_nightly:
           requires:
             - arm64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only: /pull\/[0-9]+/
       - arm64_e2e_subs:
           requires:
             - arm64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore: /pull\/[0-9]+/
       - arm64_e2e_subs_nightly:
           requires:
             - arm64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only: /pull\/[0-9]+/
       - mac_amd64_build
       - mac_amd64_test:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore: /pull\/[0-9]+/
       - mac_amd64_test_nightly:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only: /pull\/[0-9]+/
       - mac_amd64_integration:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore: /pull\/[0-9]+/
       - mac_amd64_integration_nightly:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only: /pull\/[0-9]+/
       - mac_amd64_e2e_subs:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore: /pull\/[0-9]+/
       - mac_amd64_e2e_subs_nightly:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only: /pull\/[0-9]+/
       #- windows_x64_build
 
 commands:
@@ -216,7 +216,7 @@ commands:
           keys:
             - 'libsodium-fork-{{ .Environment.CIRCLE_STAGE }}-{{ checksum "tmp/libsodium.md5" }}'
 
-  generic_shorttest:
+  generic_buildtest:
     description: Run short tests from build workspace, for re-use by diferent architectures
     parameters:
       circleci_home:
@@ -224,6 +224,12 @@ commands:
         default: "/home/circleci"
       result_subdir:
         type: string
+      no_output_timeout:
+        type: string
+        default: 30m
+      go_test_flags:
+        type: string
+        default: "-short"
     steps:
       - attach_workspace:
           at: << parameters.circleci_home >>
@@ -232,8 +238,8 @@ commands:
           keys:
             - 'go-cache-{{ .Environment.CIRCLE_STAGE }}-'
       - run:
-          name: Run short tests
-          no_output_timeout: 30m
+          name: Run build tests
+          no_output_timeout: << parameters.no_output_timeout >>
           command: |
             set -e
             set -x
@@ -251,7 +257,7 @@ commands:
             export PARTITION_TOTAL=$CIRCLE_NODE_TOTAL
             export PARTITION_ID=$CIRCLE_NODE_INDEX
             export PARALLEL_FLAG="-p 1"
-            gotestsum --format pkgname --junitfile /tmp/results/<< parameters.result_subdir >>/results.xml --jsonfile /tmp/results/<< parameters.result_subdir >>/testresults.json -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" -short -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 1 $PACKAGE_NAMES
+            gotestsum --format pkgname --junitfile /tmp/results/<< parameters.result_subdir >>/results.xml --jsonfile /tmp/results/<< parameters.result_subdir >>/testresults.json -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" << parameters.go_test_flags >> -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 1 $PACKAGE_NAMES
       - store_artifacts:
           path: /tmp/results
           destination: test-results
@@ -261,53 +267,6 @@ commands:
           key: 'go-cache-{{ .Environment.CIRCLE_STAGE }}-{{ .Environment.CIRCLE_BUILD_NUM }}'
           paths:
             - tmp/go-cache
-
-  generic_nightlytest:
-    description: Run nightly tests from build workspace, for re-use by diferent architectures
-    parameters:
-      circleci_home:
-        type: string
-        default: "/home/circleci"
-      result_subdir:
-        type: string
-    steps:
-      - attach_workspace:
-          at: << parameters.circleci_home >>
-      - run: mkdir -p /tmp/results/<< parameters.result_subdir >>
-      - restore_cache:
-          keys:
-            - 'go-cache-{{ .Environment.CIRCLE_STAGE }}-'
-      - run:
-          name: Run nightly tests
-          no_output_timeout: 45m
-          command: |
-            set -e
-            set -x
-            export PATH=$(echo "$PATH" | sed -e 's|:<< parameters.circleci_home >>/\.go_workspace/bin||g' | sed -e 's|:/usr/local/go/bin||g')
-            export KMD_NOUSB=True
-            export GOPATH="<< parameters.circleci_home >>/go"
-            export PATH="${PATH}:${GOPATH}/bin"
-            export ALGORAND_DEADLOCK=enable
-            GOLANG_VERSION=$(./scripts/get_golang_version.sh)
-            eval "$(~/gimme "${GOLANG_VERSION}")"
-            scripts/configure_dev.sh
-            scripts/buildtools/install_buildtools.sh -o "gotest.tools/gotestsum"
-            PACKAGES="$(go list ./... | grep -v /go-algorand/test/)"
-            export PACKAGE_NAMES=$(echo $PACKAGES | tr -d '\n')
-            export PARTITION_TOTAL=$CIRCLE_NODE_TOTAL
-            export PARTITION_ID=$CIRCLE_NODE_INDEX
-            export PARALLEL_FLAG="-p 1"
-            gotestsum --format pkgname --junitfile /tmp/results/<< parameters.result_subdir >>/results.xml --jsonfile /tmp/results/<< parameters.result_subdir >>/testresults.json -- --tags "sqlite_unlock_notify sqlite_omit_load_extension"  -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 1 $PACKAGE_NAMES
-      - store_artifacts:
-          path: /tmp/results
-          destination: test-results
-      - store_test_results:
-          path: /tmp/results
-      - save_cache:
-          key: 'go-cache-{{ .Environment.CIRCLE_STAGE }}-{{ .Environment.CIRCLE_BUILD_NUM }}'
-          paths:
-            - tmp/go-cache
-
 
   upload_coverage:
     description: Collect coverage reports and upload them
@@ -425,7 +384,7 @@ jobs:
     parallelism: 4
     steps:
       - prepare_go
-      - generic_shorttest:
+      - generic_buildtest:
           result_subdir: amd64-short
       - upload_coverage
 
@@ -436,8 +395,10 @@ jobs:
     parallelism: 4
     steps:
       - prepare_go
-      - generic_nightlytest:
+      - generic_buildtest:
           result_subdir: amd64-nightly
+          no_output_timeout: 45m
+          go_test_flags: ""
       - upload_coverage
 
   amd64_integration:
@@ -503,7 +464,7 @@ jobs:
     steps:
       - checkout
       - prepare_go
-      - generic_shorttest:
+      - generic_buildtest:
           result_subdir: arm64-short
       - upload_coverage
 
@@ -515,8 +476,10 @@ jobs:
     steps:
       - checkout
       - prepare_go
-      - generic_nightlytest:
+      - generic_buildtest:
           result_subdir: arm64-nightly
+          no_output_timeout: 45m
+          go_test_flags: ""
       - upload_coverage
 
   arm64_integration:
@@ -592,7 +555,7 @@ jobs:
     steps:
       #- run: git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
       - prepare_go
-      - generic_shorttest:
+      - generic_buildtest:
           result_subdir: mac-amd64-short
           circleci_home: /Users/distiller
       - upload_coverage
@@ -607,9 +570,11 @@ jobs:
     steps:
       #- run: git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
       - prepare_go
-      - generic_nightlytest:
+      - generic_buildtest:
           result_subdir: mac-amd64-short
           circleci_home: /Users/distiller
+          no_output_timeout: 45m
+          go_test_flags: ""
       - upload_coverage
 
   mac_amd64_integration:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,7 +371,7 @@ jobs:
   amd64_integration:
     machine:
       image: ubuntu-2004:202104-01
-    resource_class: large
+    resource_class: medium
     parallelism: 4
     environment:
       SKIP_E2E_SUBS: "true"
@@ -383,7 +383,7 @@ jobs:
   amd64_integration_nightly:
     machine:
       image: ubuntu-2004:202104-01
-    resource_class: large
+    resource_class: medium
     parallelism: 4
     environment:
       SKIP_E2E_SUBS: "true"
@@ -456,7 +456,7 @@ jobs:
   arm64_integration:
     machine:
       image: ubuntu-2004:202101-01
-    resource_class: arm.large
+    resource_class: arm.medium
     parallelism: 4
     environment:
       SKIP_E2E_SUBS: "true"
@@ -471,7 +471,7 @@ jobs:
   arm64_integration_nightly:
     machine:
       image: ubuntu-2004:202101-01
-    resource_class: arm.large
+    resource_class: arm.medium
     parallelism: 4
     environment:
       SKIP_E2E_SUBS: "true"
@@ -557,7 +557,7 @@ jobs:
   mac_amd64_integration:
     macos:
       xcode: 12.0.1
-    resource_class: large
+    resource_class: medium
     parallelism: 4
     environment:
       SKIP_E2E_SUBS: "true"
@@ -574,7 +574,7 @@ jobs:
   mac_amd64_integration_nightly:
     macos:
       xcode: 12.0.1
-    resource_class: large
+    resource_class: medium
     parallelism: 4
     environment:
       SKIP_E2E_SUBS: "true"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,9 +227,9 @@ commands:
       no_output_timeout:
         type: string
         default: 30m
-      go_test_flags:
+      short_test_flag:
         type: string
-        default: "-short"
+        default: ""
     steps:
       - attach_workspace:
           at: << parameters.circleci_home >>
@@ -257,7 +257,7 @@ commands:
             export PARTITION_TOTAL=$CIRCLE_NODE_TOTAL
             export PARTITION_ID=$CIRCLE_NODE_INDEX
             export PARALLEL_FLAG="-p 1"
-            gotestsum --format pkgname --junitfile /tmp/results/<< parameters.result_subdir >>/results.xml --jsonfile /tmp/results/<< parameters.result_subdir >>/testresults.json -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" << parameters.go_test_flags >> -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 1 $PACKAGE_NAMES
+            gotestsum --format pkgname --junitfile /tmp/results/<< parameters.result_subdir >>/results.xml --jsonfile /tmp/results/<< parameters.result_subdir >>/testresults.json -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" << parameters.short_test_flag >> -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 1 $PACKAGE_NAMES
       - store_artifacts:
           path: /tmp/results
           destination: test-results
@@ -288,9 +288,9 @@ commands:
       no_output_timeout:
         type: string
         default: 30m
-      go_test_flags:
+      short_test_flag:
         type: string
-        default: "-short"
+        default: ""
     steps:
       - attach_workspace:
           at: << parameters.circleci_home >>
@@ -311,7 +311,7 @@ commands:
             scripts/configure_dev.sh
             scripts/buildtools/install_buildtools.sh -o "gotest.tools/gotestsum"
             export ALGOTEST=1
-            export SHORTTEST=<< parameters.go_test_flags >>
+            export SHORTTEST=<< parameters.short_test_flag >>
             export TEST_RESULTS=/tmp/results/<< parameters.result_subdir >>
             export PARTITION_TOTAL=$CIRCLE_NODE_TOTAL
             export PARTITION_ID=$CIRCLE_NODE_INDEX
@@ -353,6 +353,7 @@ jobs:
       - prepare_go
       - generic_buildtest:
           result_subdir: amd64-short
+          short_test_flag: "-short"
       - upload_coverage
 
   amd64_test_nightly:
@@ -365,7 +366,6 @@ jobs:
       - generic_buildtest:
           result_subdir: amd64-nightly
           no_output_timeout: 45m
-          go_test_flags: ""
       - upload_coverage
 
   amd64_integration:
@@ -379,6 +379,7 @@ jobs:
       - prepare_go
       - generic_integration:
           result_subdir: amd64-integration
+          short_test_flag: "-short"
 
   amd64_integration_nightly:
     machine:
@@ -392,7 +393,6 @@ jobs:
       - generic_integration:
           result_subdir: amd64-integrationnightly
           no_output_timeout: 45m
-          go_test_flags: ""
 
   amd64_e2e_subs:
     machine:
@@ -404,6 +404,7 @@ jobs:
       - prepare_go
       - generic_integration:
           result_subdir: amd64-e2e_subs
+          short_test_flag: "-short"
 
   amd64_e2e_subs_nightly:
     machine:
@@ -416,7 +417,6 @@ jobs:
       - generic_integration:
           result_subdir: amd64-e2e_subs_nightly
           no_output_timeout: 45m
-          go_test_flags: ""
 
   arm64_build:
     machine:
@@ -437,6 +437,7 @@ jobs:
       - prepare_go
       - generic_buildtest:
           result_subdir: arm64-short
+          short_test_flag: "-short"
       - upload_coverage
 
   arm64_test_nightly:
@@ -450,7 +451,6 @@ jobs:
       - generic_buildtest:
           result_subdir: arm64-nightly
           no_output_timeout: 45m
-          go_test_flags: ""
       - upload_coverage
 
   arm64_integration:
@@ -465,6 +465,7 @@ jobs:
       - prepare_go
       - generic_integration:
           result_subdir: arm64-integration
+          short_test_flag: "-short"
 
   arm64_integration_nightly:
     machine:
@@ -479,7 +480,6 @@ jobs:
       - generic_integration:
           result_subdir: arm64-integration-nightly
           no_output_timeout: 45m
-          go_test_flags: ""
 
   arm64_e2e_subs:
     machine:
@@ -492,6 +492,7 @@ jobs:
       - prepare_go
       - generic_integration:
           result_subdir: arm64-e2e_subs
+          short_test_flag: "-short"
 
   arm64_e2e_subs_nightly:
     machine:
@@ -505,7 +506,6 @@ jobs:
       - generic_integration:
           result_subdir: arm64-e2e_subs-nightly
           no_output_timeout: 45m
-          go_test_flags: ""
 
   mac_amd64_build:
     macos:
@@ -533,6 +533,7 @@ jobs:
       - generic_buildtest:
           result_subdir: mac-amd64-short
           circleci_home: /Users/distiller
+          short_test_flag: "-short"
       - upload_coverage
 
   mac_amd64_test_nightly:
@@ -549,7 +550,6 @@ jobs:
           result_subdir: mac-amd64-short
           circleci_home: /Users/distiller
           no_output_timeout: 45m
-          go_test_flags: ""
       - upload_coverage
 
   mac_amd64_integration:
@@ -566,8 +566,7 @@ jobs:
       - generic_integration:
           result_subdir: mac-amd64-integration
           circleci_home: /Users/distiller
-          no_output_timeout: 45m
-          go_test_flags: ""
+          short_test_flag: "-short"
 
   mac_amd64_integration_nightly:
     macos:
@@ -584,7 +583,6 @@ jobs:
           result_subdir: mac-amd64-integration-nightly
           circleci_home: /Users/distiller
           no_output_timeout: 45m
-          go_test_flags: ""
 
   mac_amd64_e2e_subs:
     macos:
@@ -599,6 +597,7 @@ jobs:
       - generic_integration:
           result_subdir: mac-amd64-e2e_subs
           circleci_home: /Users/distiller
+          short_test_flag: "-short"
 
   mac_amd64_e2e_subs_nightly:
     macos:
@@ -614,7 +613,6 @@ jobs:
           result_subdir: mac-amd64-e2e_subs-nightly
           circleci_home: /Users/distiller
           no_output_timeout: 45m
-          go_test_flags: ""
 
   windows_x64_build:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ commands:
             - 'libsodium-fork-{{ .Environment.CIRCLE_STAGE }}-{{ checksum "tmp/libsodium.md5" }}'
 
   generic_buildtest:
-    description: Run short tests from build workspace, for re-use by diferent architectures
+    description: Run build tests from build workspace, for re-use by diferent architectures
     parameters:
       circleci_home:
         type: string


### PR DESCRIPTION
## Summary
Parameterize no_output_timeout and -short in the general commands on the circle config file to reduce duplicate code.

I did also increase the size of integration tests to large as I saw that we had errors in mac_amd64_integration, arm64_integration and arm64_integration recently but would run after manually rerunning from failure.

## Test Plan
Tested it on a Pull request that would run the nightly and then tested the regular short tests once.

