### PR TITLE
E2E test: txnsync message rate increases with txn rate

### DIFF
--- a/test/e2e-go/features/transactions/messageRate_test.go
+++ b/test/e2e-go/features/transactions/messageRate_test.go
@@ -38,8 +38,6 @@ import (
 	"github.com/algorand/go-algorand/util/db"
 )
 
-// TODO: remove print statements
-
 // this test checks that the txsync outgoing message rate
 // varies according to the transaction rate
 func TestMessageRateChangesWithTxnRate(t *testing.T) {
@@ -141,7 +139,8 @@ func testMessageRateChangesWithTxnRate(t *testing.T, templatePath string, txnRat
 		endTimeDelta := time.Since(startTime)
 		avgTps := float64(txnSentCount) / endTimeDelta.Seconds()
 		avgTpsErrorMessage := fmt.Sprintf("Avg txn rate %f < expected txn rate %f", avgTps, float64(txnRate))
-		a.Greaterf(avgTps, 0.9*float64(txnRate), avgTpsErrorMessage)
+		// fail the test if avg tps deviates more than 10% of the expected txn rate
+		a.Greater(avgTps, 0.9*float64(txnRate), avgTpsErrorMessage)
 
 		// wait for some time for the logs to get flushed
 		time.Sleep(2 * time.Second)
@@ -207,21 +206,6 @@ func parseLog(ctx context.Context, logPath string, filterAddress string, errChan
 		line := scanner.Text()
 		// look for txnsync messages sent to `filterAddress`
 		if strings.Contains(line, "Outgoing Txsync") && strings.Contains(line, filterAddress) {
-			// var logEvent map[string]interface{}
-			// json.Unmarshal([]byte(line), &logEvent)
-			// eventTime := fmt.Sprintf("%v", logEvent["time"])
-			// message := fmt.Sprintf("%v", logEvent["msg"])
-			// skip lines containing empty bloom filter
-			// if strings.Contains(message, "bloom 0") || strings.Contains(message, "transacations 0") {
-			// 	continue
-			// }
-			// record the timestamps of txnsync messages
-			// lastTimestamp, err = time.Parse(time.RFC3339, eventTime)
-			// lastMessage = message
-			// if err != nil {
-			// 	errChan <- err
-			// 	return
-			// }
 			messageCount++
 		}
 	}

--- a/test/e2e-go/features/transactions/messageRate_test.go
+++ b/test/e2e-go/features/transactions/messageRate_test.go
@@ -59,7 +59,7 @@ func throttleTransactionRate(startTime time.Time, txnRate uint, sentSoFar uint) 
 }
 
 func testMessageRateChangesWithTxnRate(t *testing.T, templatePath string, txnRates []uint) {
-	t.Parallel()
+	// t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture

--- a/test/e2e-go/features/transactions/messageRate_test.go
+++ b/test/e2e-go/features/transactions/messageRate_test.go
@@ -44,7 +44,7 @@ import (
 // this test checks that the txsync outgoing message rate
 // varies according to the transaction rate
 func TestMessageRateChangesWithTxnRate(t *testing.T) {
-	txnRates := []uint{50, 150, 450, 1100, 2000}
+	txnRates := []uint{50, 1200}
 	if testing.Short() {
 		txnRates = []uint{20, 40}
 	}
@@ -72,11 +72,11 @@ func testMessageRateChangesWithTxnRate(t *testing.T, templatePath string, txnRat
 	cfg, err := config.LoadConfigFromDisk(nodeDataDir)
 	a.NoError(err)
 	cfg.EnableVerbosedTransactionSyncLogging = true
-	cfg.TxPoolSize = 50000
+	// cfg.TxPoolSize = 50000
 	cfg.SaveToDisk(nodeDataDir)
 	fixture.Start()
 
-	defer fixture.Shutdown()
+	defer fixture.ShutdownImpl(true)
 
 	client := fixture.GetLibGoalClientForNamedNode("Node")
 	accountsList, err := fixture.GetNodeWalletsSortedByBalance(client.DataDir())

--- a/test/e2e-go/features/transactions/messageRate_test.go
+++ b/test/e2e-go/features/transactions/messageRate_test.go
@@ -41,6 +41,9 @@ import (
 // this test checks that the txsync outgoing message rate
 // varies according to the transaction rate
 func TestMessageRateChangesWithTxnRate(t *testing.T) {
+	if _, present := os.LookupEnv("GORACE"); present {
+		t.Skip("Skipping MessageRateChangesWithTxnRate test when race mode is enabled")
+	}
 	a := require.New(fixtures.SynchronizedTest(t))
 	txnRates := []uint{50, 300, 800, 1200}
 	if testing.Short() {

--- a/test/e2e-go/features/transactions/messageRate_test.go
+++ b/test/e2e-go/features/transactions/messageRate_test.go
@@ -140,8 +140,8 @@ func testMessageRateChangesWithTxnRate(t *testing.T, templatePath string, txnRat
 		// calculate avg tps
 		endTimeDelta := time.Since(startTime)
 		avgTps := float64(txnSentCount) / endTimeDelta.Seconds()
-		avgTpsSatisfied := avgTps > (0.9 * float64(txnRate))
-		a.Truef(avgTpsSatisfied, "Cannot achieve txn rate of %d", txnRate)
+		avgTpsErrorMessage := fmt.Sprintf("Avg txn rate %f < expected txn rate %f", avgTps, float64(txnRate))
+		a.Greaterf(avgTps, 0.9*float64(txnRate), avgTpsErrorMessage)
 
 		// wait for some time for the logs to get flushed
 		time.Sleep(2 * time.Second)

--- a/test/e2e-go/features/transactions/messageRate_test.go
+++ b/test/e2e-go/features/transactions/messageRate_test.go
@@ -83,11 +83,6 @@ func testMessageRateChangesWithTxnRate(t *testing.T, templatePath string, txnRat
 	account := accountsList[0].Address
 	clientAlgod := fixture.GetAlgodClientForController(fixture.GetNodeControllerForDataDir(nodeDataDir))
 
-	_, minAcctBalance, err := fixture.CurrentMinFeeAndBalance()
-	a.NoError(err)
-
-	amount := minAcctBalance * 3 / 2
-
 	// get the node account's secret key
 	secretKey, err := fetchSecretKey(client, nodeDataDir)
 	a.NoError(err)
@@ -131,7 +126,7 @@ func testMessageRateChangesWithTxnRate(t *testing.T, templatePath string, txnRat
 				break
 			}
 
-			tx, err := client.ConstructPayment(account, account, transactionFee, amount, GenerateRandomBytes(8), "", [32]byte{}, 0, 0)
+			tx, err := client.ConstructPayment(account, account, transactionFee, 0, GenerateRandomBytes(8), "", [32]byte{}, 0, 0)
 			a.NoError(err)
 			signedTxn := tx.Sign(signatureSecrets)
 

--- a/test/e2e-go/features/transactions/messageRate_test.go
+++ b/test/e2e-go/features/transactions/messageRate_test.go
@@ -1,0 +1,170 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package transactions
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/test/framework/fixtures"
+)
+
+// this test checks that the txsync outgoing message rate
+// varies according to the transaction rate
+func TestMessageRateChangesWithTxnRate(t *testing.T) {
+	txnRates := []uint{20, 40, 80, 160}
+	if testing.Short() {
+		txnRates = []uint{20, 40}
+	}
+	testMessageRateChangesWithTxnRate(t, filepath.Join("nettemplates", "TwoNodes50Each.json"), txnRates)
+}
+
+func throttleTransactionRate(startTime time.Time, txnRate uint, sentSoFar uint) {
+	timeDelta := time.Since(startTime)
+	currentTps := float64(sentSoFar) / timeDelta.Seconds()
+	if currentTps > float64(txnRate) {
+		sleepDuration := float64(sentSoFar)/float64(txnRate) - timeDelta.Seconds()
+		sleepTime := time.Duration(int64(math.Round(sleepDuration*1000))) * time.Millisecond
+		time.Sleep(sleepTime)
+	}
+}
+
+func testMessageRateChangesWithTxnRate(t *testing.T, templatePath string, txnRates []uint) {
+	t.Parallel()
+	a := require.New(fixtures.SynchronizedTest(t))
+
+	var fixture fixtures.RestClientFixture
+	fixture.Setup(t, templatePath)
+
+	defer fixture.Shutdown()
+
+	pingClient := fixture.LibGoalClient
+	pingAccountList, err := fixture.GetWalletsSortedByBalance()
+	a.NoError(err, "fixture should be able to get wallets sorted by balance")
+	pingAccount := pingAccountList[0].Address
+
+	pongClient := fixture.GetLibGoalClientForNamedNode("Node")
+	pongAccounts, err := fixture.GetNodeWalletsSortedByBalance(pongClient.DataDir())
+	a.NoError(err)
+	var pongAccount string
+	for _, acct := range pongAccounts {
+		if acct.Address == pingAccount {
+			continue
+		}
+		// we found an account.
+		pongAccount = acct.Address
+		break
+	}
+
+	a.NotEqual(pingAccount, pongAccount, "accounts under study should be different")
+
+	minTxnFee, minAcctBalance, err := fixture.CurrentMinFeeAndBalance()
+	a.NoError(err)
+
+	transactionFee := minTxnFee + 5
+	amountPingSendsPong := minAcctBalance * 3 / 2
+
+	// build the path for the primary node's log file
+	var logPath strings.Builder
+	logPath.WriteString(pingClient.DataDir())
+	logPath.WriteString("/node.log")
+
+	// seek to `bytesRead` bytes when reading the log file
+	bytesRead := 0
+
+	// store message rate for each of the txn rates
+	prevMsgRate := 0.0
+
+	for _, txnRate := range txnRates {
+		startTime := time.Now()
+		txnSentCount := uint(0)
+
+		for {
+			// send txns at txnRate for 10s
+			timeSinceStart := time.Since(startTime)
+			if timeSinceStart > 10*time.Second {
+				break
+			}
+
+			_, err := pingClient.SendPaymentFromUnencryptedWallet(pingAccount, pongAccount, transactionFee, amountPingSendsPong, GenerateRandomBytes(8))
+			a.NoError(err, "fixture should be able to send money (ping -> pong)")
+			txnSentCount++
+
+			throttleTransactionRate(startTime, txnRate, txnSentCount)
+		}
+
+		// parse the log to find out message rate and bytes of the log file read including seek
+		msgRate, newBytesRead, err := parseLog(logPath.String(), bytesRead)
+		a.NoError(err)
+		aErrorMessage := fmt.Sprintf("TxSync message rate not monotonic for txn rate: %d", txnRate)
+		a.GreaterOrEqual(msgRate, prevMsgRate, aErrorMessage)
+		bytesRead = newBytesRead
+		prevMsgRate = msgRate
+	}
+
+}
+
+func parseLog(logPath string, startByte int) (float64, int, error) {
+	file, err := os.Open(logPath)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer file.Close()
+
+	// start reading log file from startByte
+	_, err = file.Seek(int64(startByte), 0)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	messageCount := 0
+	bytesRead := 0
+	var firstTimestamp, lastTimestamp time.Time
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		bytesRead += len(line)
+		if strings.Contains(line, "BroadcastSignedTxGroup") {
+			var logEvent map[string]interface{}
+			json.Unmarshal([]byte(line), &logEvent)
+			eventTime := fmt.Sprintf("%v", logEvent["time"])
+			lastTimestamp, err = time.Parse(time.RFC3339, eventTime)
+			if firstTimestamp.IsZero() {
+				firstTimestamp = lastTimestamp
+			}
+			if err != nil {
+				return 0, startByte + bytesRead, err
+			}
+			messageCount++
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, startByte + bytesRead, err
+	}
+	msgRate := float64(messageCount) / (float64(lastTimestamp.Sub(firstTimestamp) / time.Second))
+	return msgRate, startByte + bytesRead, nil
+}

--- a/test/testdata/nettemplates/OneNodeTwoRelays.json
+++ b/test/testdata/nettemplates/OneNodeTwoRelays.json
@@ -1,0 +1,30 @@
+{
+    "Genesis": {
+        "NetworkName": "tbd",
+        "Wallets": [
+            {
+                "Name": "Wallet1",
+                "Stake": 100,
+                "Online": true
+            }
+        ]
+    },
+    "Nodes": [
+        {
+            "Name": "Relay1",
+            "IsRelay": true
+
+        },
+        {
+            "Name": "Relay2",
+            "IsRelay": true
+        },
+        {
+            "Name": "Node",
+            "Wallets": [
+                { "Name": "Wallet1",
+                  "ParticipationOnly": false }
+            ]
+        }
+    ]
+}

--- a/txnsync/mainloop.go
+++ b/txnsync/mainloop.go
@@ -229,6 +229,7 @@ func (s *syncState) onTransactionPoolChangedEvent(ent Event) {
 	}
 
 	newBeta := beta(ent.transactionPoolSize)
+	s.log.Info("Beta Prev: ", s.lastBeta, " New: ", newBeta)
 
 	// check if beta should be updated
 	if !shouldUpdateBeta(s.lastBeta, newBeta, betaGranularChangeThreshold) {
@@ -237,7 +238,7 @@ func (s *syncState) onTransactionPoolChangedEvent(ent Event) {
 	}
 	// yes, change beta as the number of transactions in the pool have changed dramatically since the last time.
 	s.lastBeta = newBeta
-
+	s.log.Info("Beta new: ", s.lastBeta)
 	peers := make([]*Peer, 0, len(s.interruptablePeers))
 	for _, peer := range s.interruptablePeers {
 		if peer == nil {

--- a/txnsync/mainloop.go
+++ b/txnsync/mainloop.go
@@ -229,7 +229,6 @@ func (s *syncState) onTransactionPoolChangedEvent(ent Event) {
 	}
 
 	newBeta := beta(ent.transactionPoolSize)
-	s.log.Info("Beta Prev: ", s.lastBeta, " New: ", newBeta)
 
 	// check if beta should be updated
 	if !shouldUpdateBeta(s.lastBeta, newBeta, betaGranularChangeThreshold) {
@@ -238,7 +237,7 @@ func (s *syncState) onTransactionPoolChangedEvent(ent Event) {
 	}
 	// yes, change beta as the number of transactions in the pool have changed dramatically since the last time.
 	s.lastBeta = newBeta
-	s.log.Info("Beta new: ", s.lastBeta)
+
 	peers := make([]*Peer, 0, len(s.interruptablePeers))
 	for _, peer := range s.interruptablePeers {
 		if peer == nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

 An end-to-end test to confirm that the txnsync message rate increases with the txn rate.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

This is a test.
