### PR TITLE
txnsync: correctness e2e test

### DIFF
--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -328,6 +328,10 @@ func (client RestClient) LedgerSupply() (response v1.Supply, err error) {
 	return
 }
 
+type pendingTransactionsByAddrParams struct {
+	Max uint64 `url:"max"`
+}
+
 type transactionsByAddrParams struct {
 	FirstRound uint64 `url:"firstRound"`
 	LastRound  uint64 `url:"lastRound"`
@@ -356,6 +360,12 @@ type rawFormat struct {
 // last] rounds range.
 func (client RestClient) TransactionsByAddr(addr string, first, last, max uint64) (response v1.TransactionList, err error) {
 	err = client.get(&response, fmt.Sprintf("/v1/account/%s/transactions", addr), transactionsByAddrParams{first, last, max})
+	return
+}
+
+// PendingTransactionsByAddr returns all the pending transactions for a PK [addr].
+func (client RestClient) PendingTransactionsByAddr(addr string, max uint64) (response v1.PendingTransactions, err error) {
+	err = client.get(&response, fmt.Sprintf("/v1/account/%s/transactions/pending", addr), pendingTransactionsByAddrParams{max})
 	return
 }
 

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -871,6 +871,16 @@ func (c *Client) GetPendingTransactions(maxTxns uint64) (resp v1.PendingTransact
 	return
 }
 
+// GetPendingTransactionsByAddress gets a snapshot of current pending transactions on the node for the given address.
+// If maxTxns = 0, fetches as many transactions as possible.
+func (c *Client) GetPendingTransactionsByAddress(addr string, maxTxns uint64) (resp v1.PendingTransactions, err error) {
+	algod, err := c.ensureAlgodClient()
+	if err == nil {
+		resp, err = algod.PendingTransactionsByAddr(addr, maxTxns)
+	}
+	return
+}
+
 // ExportKey exports the private key of the passed account, assuming it's available
 func (c *Client) ExportKey(walletHandle []byte, password, account string) (resp kmdapi.APIV1POSTKeyExportResponse, err error) {
 	kmd, err := c.ensureKmdClient()

--- a/test/e2e-go/features/transactions/txnsync_test.go
+++ b/test/e2e-go/features/transactions/txnsync_test.go
@@ -1,0 +1,229 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package transactions
+
+import (
+	"context"
+	"math"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/libgoal"
+	"github.com/algorand/go-algorand/test/framework/fixtures"
+)
+
+// TestTxnSync sends payments between two nodes, and verifies that
+// each transaction is received by the other node and the relay
+func TestTxnSync(t *testing.T) {
+	t.Parallel()
+
+	numberOfSends := 2500
+	targetRate := 30 // txn/sec
+	if testing.Short() {
+		numberOfSends = 3
+	}
+	templatePath := filepath.Join("nettemplates", "TwoNodes50EachWithRelay.json")
+
+	var fixture fixtures.RestClientFixture
+	fixture.Setup(t, templatePath)
+
+	node1 := fixture.GetLibGoalClientForNamedNode("Node1")
+	node2 := fixture.GetLibGoalClientForNamedNode("Node2")
+	relay := fixture.GetLibGoalClientForNamedNode("Relay")
+
+	n1chan := make(chan string)
+	n2chan := make(chan string)
+	rchan := make(chan string)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	ttn1 := transactionTracker{
+		t:                   t,
+		ctx:                 ctx,
+		client:              &node1,
+		othersToVerify:      []chan string{n2chan, rchan},
+		selfToVerify:        n1chan,
+		pendingVerification: make(map[string]bool),
+	}
+
+	ttn2 := transactionTracker{
+		t:                   t,
+		ctx:                 ctx,
+		client:              &node2,
+		othersToVerify:      []chan string{n1chan, rchan},
+		selfToVerify:        n2chan,
+		pendingVerification: make(map[string]bool),
+	}
+
+	ttr := transactionTracker{
+		t:                   t,
+		ctx:                 ctx,
+		client:              &relay,
+		othersToVerify:      []chan string{n1chan, n2chan},
+		selfToVerify:        rchan,
+		pendingVerification: make(map[string]bool),
+	}
+
+	defer fixture.Shutdown()
+
+	account1List, err := fixture.GetNodeWalletsSortedByBalance(node1.DataDir())
+	require.NoError(t, err)
+	account1 := account1List[0].Address
+
+	account2List, err := fixture.GetNodeWalletsSortedByBalance(node2.DataDir())
+	require.NoError(t, err)
+	account2 := account2List[0].Address
+
+	minTxnFee, minAcctBalance, err := fixture.CurrentMinFeeAndBalance()
+	require.NoError(t, err)
+
+	transactionFee := minTxnFee + 5
+	amount1 := minAcctBalance / uint64(numberOfSends)
+	amount2 := minAcctBalance / uint64(numberOfSends)
+
+	go ttn1.verifyTransactions()
+	go ttn2.verifyTransactions()
+	go ttr.verifyTransactions()
+
+	st := time.Now()
+
+	for i := 0; i < numberOfSends; i++ {
+		tx1, err := node1.SendPaymentFromUnencryptedWallet(account1, account2, transactionFee, amount1, GenerateRandomBytes(8))
+		require.NoError(t, err, "Failed to send transaction on iteration %d", i)
+		ttn1.addTransactionToVerify(tx1.ID().String())
+		tx2, err := node2.SendPaymentFromUnencryptedWallet(account2, account1, transactionFee, amount2, GenerateRandomBytes(8))
+		require.NoError(t, err, "Failed to send transaction on iteration %d", i)
+		// Post "http://127.0.0.1:57255/v1/transactions": dial tcp 127.0.0.1:57255: connect: can't assign requested address
+		ttn2.addTransactionToVerify(tx2.ID().String())
+
+		throttleTransactionRate(st, targetRate, i)
+	}
+
+	// wait until all channels are empty for max 1 second
+	for x := 0; x < 100; x++ {
+		if ttn1.channelsAreEmpty() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.True(t, ttn1.channelsAreEmpty())
+
+	for x := 0; x < 100; x++ {
+		unprocessed := len(ttn1.pendingVerification) +
+			len(ttn2.pendingVerification) +
+			len(ttr.pendingVerification)
+		if unprocessed == 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel()
+	ttn1.wg.Wait()
+	ttn2.wg.Wait()
+	ttr.wg.Wait()
+
+	require.Empty(t, ttn1.pendingVerification)
+	require.Empty(t, ttn2.pendingVerification)
+	require.Empty(t, ttr.pendingVerification)
+}
+
+type transactionTracker struct {
+	t                   *testing.T
+	ctx                 context.Context
+	mu                  sync.Mutex
+	wg                  sync.WaitGroup
+	client              *libgoal.Client
+	othersToVerify      []chan string
+	selfToVerify        chan string
+	pendingVerification map[string]bool
+}
+
+// Adds the transaction to the channels of the nodes intended to receive the transaction
+func (tt *transactionTracker) addTransactionToVerify(transactionID string) {
+	for _, c := range tt.othersToVerify {
+		c <- transactionID
+	}
+}
+
+// Pulls transactions from the channel and async checks if recived by the node  
+func (tt *transactionTracker) verifyTransactions() {
+	for {
+		select {
+		case <-tt.ctx.Done():
+			return
+		case tid := <-tt.selfToVerify:
+			tt.mu.Lock()
+			tt.pendingVerification[tid] = true
+			tt.mu.Unlock()
+			go tt.checkIfReceivedTransaction(tid)
+		default:
+		}
+	}
+}
+
+// Waits until gets a confirmation that the transaction is recieved by the node
+func (tt *transactionTracker) checkIfReceivedTransaction(transactionID string) {
+	tt.wg.Add(1)
+	defer tt.wg.Done()
+	for {
+		select {
+		case <-tt.ctx.Done():
+			return
+		default:
+			transactionInfo, err := tt.client.PendingTransactionInformation(transactionID)
+			if err != nil {
+				time.Sleep(200 * time.Millisecond)
+				continue
+			}
+			require.NotNil(tt.t, transactionInfo)
+		}
+		break
+	}
+	// if received
+	tt.mu.Lock()
+	defer tt.mu.Unlock()
+	delete(tt.pendingVerification, transactionID)
+}
+
+// Retruns true if all the associated channels are empty
+func (tt *transactionTracker) channelsAreEmpty() bool {
+	if len(tt.selfToVerify) > 0 {
+		return false
+	}
+	for _, c := range tt.othersToVerify {
+		if len(c) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// throttle transaction rate
+func throttleTransactionRate(startTime time.Time, targetRate int, totalSent int) {
+	localTimeDelta := time.Now().Sub(startTime)
+	currentTps := float64(totalSent) / localTimeDelta.Seconds()
+	if currentTps > float64(targetRate) {
+		sleepSec := float64(totalSent)/float64(targetRate) - localTimeDelta.Seconds()
+		sleepTime := time.Duration(int64(math.Round(sleepSec*1000))) * time.Millisecond
+		time.Sleep(sleepTime)
+	}
+}

--- a/test/e2e-go/features/transactions/txnsync_test.go
+++ b/test/e2e-go/features/transactions/txnsync_test.go
@@ -21,10 +21,10 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
+	"github.com/algorand/go-deadlock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/config"
@@ -264,7 +264,7 @@ func TestTxnSync(t *testing.T) {
 type transactionTracker struct {
 	t                   *testing.T
 	ctx                 context.Context
-	mu                  sync.Mutex
+	mu                  deadlock.Mutex
 	client              *libgoal.Client
 	othersToVerify      []chan string
 	selfToVerify        chan string

--- a/test/e2e-go/features/transactions/txnsync_test.go
+++ b/test/e2e-go/features/transactions/txnsync_test.go
@@ -175,7 +175,7 @@ func TestTxnSync(t *testing.T) {
 	require.True(t, ttn1.channelsAreEmpty())
 
 	unprocessed := 0
-	for x := 0; x < numberOfSends / 10 ; x++ {
+	for x := 0; x < numberOfSends/10; x++ {
 		fmt.Printf("unprocessed items: %d\n", unprocessed)
 		select {
 		case <-ctx.Done():
@@ -186,7 +186,7 @@ func TestTxnSync(t *testing.T) {
 		ttn1.mu.Lock()
 		unprocessed = len(ttn1.pendingVerification)
 		ttn1.mu.Unlock()
-		
+
 		ttn2.mu.Lock()
 		unprocessed += len(ttn2.pendingVerification)
 		ttn2.mu.Unlock()
@@ -199,12 +199,11 @@ func TestTxnSync(t *testing.T) {
 		unprocessed += len(ttr2.pendingVerification)
 		ttr2.mu.Unlock()
 
-
+		if unprocessed == 0 {
 			break
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-
 	require.Equal(t, 0, unprocessed)
 }
 
@@ -298,12 +297,12 @@ func (tt *transactionTracker) checkIfReceivedTransaction(transactionID string) {
 // Retruns true if all the associated channels are empty
 func (tt *transactionTracker) channelsAreEmpty() bool {
 	if len(tt.selfToVerify) > 0 {
-		fmt.Printf("channelsAreEmpty0 %d\n", len(tt.selfToVerify) )
+		fmt.Printf("channelsAreEmpty0 %d\n", len(tt.selfToVerify))
 		return false
 	}
 	for _, c := range tt.othersToVerify {
 		if len(c) > 0 {
-			fmt.Printf("channelsAreEmpty %d\n", len(c) )
+			fmt.Printf("channelsAreEmpty %d\n", len(c))
 			return false
 		}
 	}

--- a/test/e2e-go/features/transactions/txnsync_test.go
+++ b/test/e2e-go/features/transactions/txnsync_test.go
@@ -70,7 +70,7 @@ func TestTxnSync(t *testing.T) {
 
 	var fixture fixtures.RestClientFixture
 
-	roundTime := time.Duration(10 * 1000 * time.Millisecond)
+	roundTime := time.Duration(8 * 1000 * time.Millisecond)
 
 	proto, ok := config.Consensus[protocol.ConsensusCurrentVersion]
 	require.True(t, ok)
@@ -179,7 +179,7 @@ func TestTxnSync(t *testing.T) {
 
 	// wait for the 1st round
 	nextRound := uint64(1)
-	err = fixture.ClientWaitForRound(fixture.AlgodClient, nextRound, 4*roundTime)
+	err = fixture.ClientWaitForRound(fixture.AlgodClient, nextRound, 10*roundTime)
 	require.NoError(t, err)
 	nextRound++
 
@@ -193,6 +193,8 @@ func TestTxnSync(t *testing.T) {
 			require.True(t, false, "Context canceled due to an error at iteration %d", i)
 			return
 		case <-timeout.C:
+			// Send the transactions only during the first half of the round
+			// Wait for the next round, and stop sending transactions after the first half
 			err = fixture.ClientWaitForRound(fixture.AlgodClient, nextRound, 2*roundTime)
 			require.NoError(t, err)
 			fmt.Printf("Round %d\n", int(nextRound))

--- a/test/e2e-go/features/transactions/txnsync_test.go
+++ b/test/e2e-go/features/transactions/txnsync_test.go
@@ -63,8 +63,8 @@ func TestTxnSync(t *testing.T) {
 	// transaction is received by the node.
 	// If this is too large, the system will report too many open files.
 	// If too small, the txns will be moved to the block.
-	maxParallelChecks := 100
-	numberOfSends := 2500
+	maxParallelChecks := 10
+	numberOfSends := 500
 	targetRate := 300 // txn/sec
 	if testing.Short() {
 		numberOfSends = 100
@@ -307,9 +307,8 @@ func (tt *transactionTracker) checkIfReceivedTransaction(transactionID string) {
 			// If we got txn information
 			if transactionInfo.ConfirmedRound > 0 {
 				tt.cancelFunc()
-				require.True(tt.t, false)
+				require.Equal(tt.t, 0, int(transactionInfo.ConfirmedRound))
 			}
-			require.Equal(tt.t, 0, int(transactionInfo.ConfirmedRound))
 		}
 		break
 	}

--- a/test/e2e-go/features/transactions/txnsync_test.go
+++ b/test/e2e-go/features/transactions/txnsync_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/libgoal"
-	"github.com/algorand/go-algorand/nodecontrol"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/framework/fixtures"
 )

--- a/test/e2e-go/features/transactions/txnsync_test.go
+++ b/test/e2e-go/features/transactions/txnsync_test.go
@@ -33,31 +33,20 @@ import (
 	"github.com/algorand/go-algorand/test/framework/fixtures"
 )
 
-// TestTxnSync sends payments by two nodes, and verifies that
-// each transaction is received by the other node and the relay
-//
-// The test sets up a network with 2 nodes and 2 relays.
+// This test sets up a network with 2 nodes and 2 relays.
 // The two nodes send payment transactions.
-//
+
 // For each transaction, the test checks if the relays and the nodes
 // (including the node that originated the transaction) have the
 // transaction in the pool (i.e. the transactionInfo.ConfirmedRound ==
 // 0).
-//
-// The tests needs a delicate balance to pass.
-//
-// The transactions need to be checked in the pool fast enough before
-// they are moved out to the block.
-//
-// In order to quickly test them while maintaining a high transaction
-// throughput, the checks need to be performed in parallel.
-//
-// The parallel checks require open files for the rest
-// connections. Too many of them and the system will complain about
-// too many open files.
-//
-// The test keeps the number of simultaneous open connections via
-// maxParallelChecks.
+
+// The tests needs to check for the transactions in the pool fast
+// enough before they get evicted from the pool to the block.
+
+// To achieve this, it sends transactions during the first half of the
+// round period, to give the test enough time to check for the
+// transactions.
 func TestTxnSync(t *testing.T) {
 	t.Parallel()
 

--- a/test/e2e-go/features/transactions/txnsync_test.go
+++ b/test/e2e-go/features/transactions/txnsync_test.go
@@ -179,7 +179,7 @@ func TestTxnSync(t *testing.T) {
 
 	// wait for the 1st round
 	nextRound := uint64(1)
-	err = fixture.ClientWaitForRound(fixture.AlgodClient, nextRound, 10*roundTime)
+	err = fixture.ClientWaitForRound(fixture.AlgodClient, nextRound, 20*roundTime)
 	require.NoError(t, err)
 	nextRound++
 

--- a/test/e2e-go/features/transactions/txnsync_test.go
+++ b/test/e2e-go/features/transactions/txnsync_test.go
@@ -183,11 +183,23 @@ func TestTxnSync(t *testing.T) {
 			return
 		default:
 		}
-		unprocessed = len(ttn1.pendingVerification) +
-			len(ttn2.pendingVerification) +
-			len(ttr1.pendingVerification) +
-			len(ttr2.pendingVerification)
-		if unprocessed == 0 {
+		ttn1.mu.Lock()
+		unprocessed = len(ttn1.pendingVerification)
+		ttn1.mu.Unlock()
+		
+		ttn2.mu.Lock()
+		unprocessed += len(ttn2.pendingVerification)
+		ttn2.mu.Unlock()
+
+		ttr1.mu.Lock()
+		unprocessed += len(ttr1.pendingVerification)
+		ttr1.mu.Unlock()
+
+		ttr2.mu.Lock()
+		unprocessed += len(ttr2.pendingVerification)
+		ttr2.mu.Unlock()
+
+
 			break
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -211,6 +223,8 @@ type transactionTracker struct {
 
 func (tt *transactionTracker) terminate() {
 	tt.wg.Wait()
+	tt.mu.Lock()
+	defer tt.mu.Unlock()
 	require.Equal(tt.t, 0, len(tt.pendingVerification))
 }
 

--- a/test/testdata/nettemplates/TwoNodes50EachWithTwoRelays.json
+++ b/test/testdata/nettemplates/TwoNodes50EachWithTwoRelays.json
@@ -1,0 +1,41 @@
+{
+    "Genesis": {
+        "NetworkName": "tbd",
+        "Wallets": [
+            {
+                "Name": "Wallet1",
+                "Stake": 50,
+                "Online": true
+            },
+            {
+                "Name": "Wallet2",
+                "Stake": 50,
+                "Online": true
+            }
+        ]
+    },
+    "Nodes": [
+        {
+            "Name": "Relay1",
+            "IsRelay": true
+        },
+        {
+            "Name": "Relay2",
+            "IsRelay": true
+        },
+        {
+            "Name": "Node1",
+            "Wallets": [
+                { "Name": "Wallet1",
+                  "ParticipationOnly": false }
+            ]
+        },
+        {
+            "Name": "Node2",
+            "Wallets": [
+                { "Name": "Wallet2",
+                    "ParticipationOnly": false }
+            ]
+        }
+    ]
+}

--- a/txnsync/incoming_test.go
+++ b/txnsync/incoming_test.go
@@ -241,7 +241,7 @@ func TestEvaluateIncomingMessagePart2(t *testing.T) {
 				Transactions: []transactions.SignedTxn{
 					transactions.SignedTxn{}}}},
 	})
-	require.Equal(t, "Incoming Txsync #5 round 5 transacations 1 request [0/0] bloom 0 nextTS 0 from ''", incLogger.lastLogged)
+	require.Equal(t, "Incoming Txsync #5 round 5 transactions 1 request [0/0] bloom 0 nextTS 0 from ''", incLogger.lastLogged)
 
 }
 

--- a/txnsync/logger.go
+++ b/txnsync/logger.go
@@ -67,7 +67,7 @@ func (l *basicMsgLogger) logMessage(mstat msgStats, mode, tofrom string) {
 		return
 	}
 	l.Infof(
-		"%s Txsync #%d round %d transacations %d request [%d/%d] bloom %d nextTS %d %s '%s'",
+		"%s Txsync #%d round %d transactions %d request [%d/%d] bloom %d nextTS %d %s '%s'",
 		mode,
 		mstat.sequenceNumber,
 		mstat.round,

--- a/txnsync/txngroups.go
+++ b/txnsync/txngroups.go
@@ -127,10 +127,10 @@ func (s *syncState) compressTransactionGroupsBytes(uncompressedData []byte) ([]b
 	return compressedData, compressionFormatDeflate
 }
 
-func decodeTransactionGroups(ptg packedTransactionGroups, genesisID string, genesisHash crypto.Digest) (txnGroups []transactions.SignedTxGroup, totalTxnsInGroups int, err error) {
+func decodeTransactionGroups(ptg packedTransactionGroups, genesisID string, genesisHash crypto.Digest) (txnGroups []transactions.SignedTxGroup, err error) {
 	data := ptg.Bytes
 	if len(data) == 0 {
-		return nil, 0, nil
+		return nil, nil
 	}
 
 	switch ptg.CompressionFormat {
@@ -142,23 +142,23 @@ func decodeTransactionGroups(ptg packedTransactionGroups, genesisID string, gene
 		}
 		defer releaseMessageBuffer(data)
 	default:
-		return nil, 0, fmt.Errorf("invalid compressionFormat, %d", ptg.CompressionFormat)
+		return nil, fmt.Errorf("invalid compressionFormat, %d", ptg.CompressionFormat)
 	}
 	var stub txGroupsEncodingStub
 	_, err = stub.UnmarshalMsg(data)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
 	if stub.TransactionGroupCount > maxEncodedTransactionGroup {
-		return nil, 0, errors.New("invalid TransactionGroupCount")
+		return nil, errors.New("invalid TransactionGroupCount")
 	}
 
 	stx := make([]transactions.SignedTxn, stub.TotalTransactionsCount)
 
 	err = stub.reconstructSignedTransactions(stx, genesisID, genesisHash)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
 	txnGroups = make([]transactions.SignedTxGroup, stub.TransactionGroupCount)
@@ -167,7 +167,7 @@ func decodeTransactionGroups(ptg packedTransactionGroups, genesisID string, gene
 		if txnGroupIndex < len(stub.TransactionGroupSizes)*2 {
 			nibble, err := getNibble(stub.TransactionGroupSizes, txnGroupIndex)
 			if err != nil {
-				return nil, 0, err
+				return nil, err
 			}
 			size = int(nibble) + 1
 		}
@@ -177,10 +177,10 @@ func decodeTransactionGroups(ptg packedTransactionGroups, genesisID string, gene
 
 	err = addGroupHashes(txnGroups, int(stub.TotalTransactionsCount), stub.BitmaskGroup)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
-	return txnGroups, int(stub.TotalTransactionsCount), nil
+	return txnGroups, nil
 }
 
 func decompressTransactionGroupsBytes(data []byte, lenDecompressedBytes uint64) (decoded []byte, err error) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->
### Correctness test: 
This test sets up a network with 2 nodes and 2 relays. 
The two nodes send payment transactions.
For each transaction, the test checks if the relays and the nodes (including the node that originated the transaction) have the transaction in the pool (i.e. the transactionInfo.ConfirmedRound == 0).

The tests needs to check for the transactions in the pool fast enough before they get evicted from the pool to the block.
To achieve this, it sends transactions during the first half of the round period, to give the test enough time to check for the transactions. 

### Fix for a possible data race

TxHandler processDecodedArray and syncState evaluateIncomingMessage
may execute at the same time.

When this happens, evaluateIncomingMessage reads transactionGroups to
count the number if transactions there. At the same time,
processDecodedArray will be replacing verifiedTxGroup arrays with a
copy.

This leads to data race.

This change caches the number of transactions in the groups to avoid
reading transactionGroups to count that number.


## Test Plan
This is a test.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
