### PR TITLE
Add GroupID global to TEAL

### DIFF
--- a/data/transactions/logic/README.md
+++ b/data/transactions/logic/README.md
@@ -303,6 +303,7 @@ Global fields are fields that are common to all the transactions in the group. I
 | 7 | LatestTimestamp | uint64 | Last confirmed block UNIX timestamp. Fails if negative. LogicSigVersion >= 2. |
 | 8 | CurrentApplicationID | uint64 | ID of current application executing. Fails if no such application is executing. LogicSigVersion >= 2. |
 | 9 | CreatorAddress | []byte | Address of the creator of the current application. Fails if no such application is executing. LogicSigVersion >= 3. |
+| 10 | GroupID | []byte | ID of the transaction group. Empty if the transaction is not part of a group. LogicSigVersion >= 5. |
 
 
 **Asset Fields**

--- a/data/transactions/logic/TEAL_opcodes.md
+++ b/data/transactions/logic/TEAL_opcodes.md
@@ -464,6 +464,7 @@ FirstValidTime causes the program to fail. The field is reserved for future use.
 | 7 | LatestTimestamp | uint64 | Last confirmed block UNIX timestamp. Fails if negative. LogicSigVersion >= 2. |
 | 8 | CurrentApplicationID | uint64 | ID of current application executing. Fails if no such application is executing. LogicSigVersion >= 2. |
 | 9 | CreatorAddress | []byte | Address of the creator of the current application. Fails if no such application is executing. LogicSigVersion >= 3. |
+| 10 | GroupID | []byte | ID of the transaction group. Empty if the transaction is not part of a group. LogicSigVersion >= 5. |
 
 
 ## gtxn t f

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -1202,6 +1202,7 @@ global Round
 global LatestTimestamp
 global CurrentApplicationID
 global CreatorAddress
+global GroupID
 txn Sender
 txn Fee
 bnz label1

--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -390,6 +390,7 @@ var globalFieldDocs = map[string]string{
 	"LatestTimestamp":      "Last confirmed block UNIX timestamp. Fails if negative",
 	"CurrentApplicationID": "ID of current application executing. Fails if no such application is executing",
 	"CreatorAddress":       "Address of the creator of the current application. Fails if no such application is executing",
+	"GroupID":              "ID of the transaction group. Empty if the transaction is not part of a group.",
 }
 
 // GlobalFieldDocs are notes on fields available in `global` with extra versioning info if any

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -2232,6 +2232,10 @@ func (cx *evalContext) getCreatorAddress() ([]byte, error) {
 	return addr[:], nil
 }
 
+func (cx *evalContext) getGroupID() []byte {
+	return cx.Txn.Txn.Group[:]
+}
+
 var zeroAddress basics.Address
 
 func (cx *evalContext) globalFieldToStack(field GlobalField) (sv stackValue, err error) {
@@ -2256,6 +2260,8 @@ func (cx *evalContext) globalFieldToStack(field GlobalField) (sv stackValue, err
 		sv.Uint, err = cx.getApplicationID()
 	case CreatorAddress:
 		sv.Bytes, err = cx.getCreatorAddress()
+	case GroupID:
+		sv.Bytes = cx.getGroupID()
 	default:
 		err = fmt.Errorf("invalid global[%d]", field)
 	}

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -911,7 +911,11 @@ const globalV4TestProgram = globalV3TestProgram + `
 `
 
 const globalV5TestProgram = globalV4TestProgram + `
-// No new globals in v5
+global GroupID
+int 32
+bzero
+==
+&&
 `
 
 func TestGlobal(t *testing.T) {
@@ -941,6 +945,7 @@ func TestGlobal(t *testing.T) {
 			CreatorAddress, globalV5TestProgram,
 			EvalStateful, CheckStateful,
 		},
+		6: {GroupID, globalV5TestProgram, Eval, Check},
 	}
 	ledger := makeTestLedger(nil)
 	ledger.appID = 42

--- a/data/transactions/logic/fields.go
+++ b/data/transactions/logic/fields.go
@@ -327,6 +327,11 @@ const (
 	// CreatorAddress [32]byte
 	CreatorAddress
 
+	// v5
+
+	// GroupID [32]byte
+	GroupID
+
 	invalidGlobalField
 )
 
@@ -354,6 +359,7 @@ var globalFieldSpecs = []globalFieldSpec{
 	{LatestTimestamp, StackUint64, runModeApplication, 2},
 	{CurrentApplicationID, StackUint64, runModeApplication, 2},
 	{CreatorAddress, StackBytes, runModeApplication, 3},
+	{GroupID, StackBytes, modeAny, 5},
 }
 
 // GlobalFieldSpecByField maps GlobalField to spec

--- a/data/transactions/logic/fields_string.go
+++ b/data/transactions/logic/fields_string.go
@@ -92,12 +92,13 @@ func _() {
 	_ = x[LatestTimestamp-7]
 	_ = x[CurrentApplicationID-8]
 	_ = x[CreatorAddress-9]
-	_ = x[invalidGlobalField-10]
+	_ = x[GroupID-10]
+	_ = x[invalidGlobalField-11]
 }
 
-const _GlobalField_name = "MinTxnFeeMinBalanceMaxTxnLifeZeroAddressGroupSizeLogicSigVersionRoundLatestTimestampCurrentApplicationIDCreatorAddressinvalidGlobalField"
+const _GlobalField_name = "MinTxnFeeMinBalanceMaxTxnLifeZeroAddressGroupSizeLogicSigVersionRoundLatestTimestampCurrentApplicationIDCreatorAddressGroupIDinvalidGlobalField"
 
-var _GlobalField_index = [...]uint8{0, 9, 19, 29, 40, 49, 64, 69, 84, 104, 118, 136}
+var _GlobalField_index = [...]uint8{0, 9, 19, 29, 40, 49, 64, 69, 84, 104, 118, 125, 143}
 
 func (i GlobalField) String() string {
 	if i >= GlobalField(len(_GlobalField_index)-1) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Adds the global field `GroupID` to retrieve the group of the transaction. This follows the pattern established for `GroupSize`. 

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Added/ran unit tests.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
