### PR TITLE
Update systemd-setup.sh to install system.json

### DIFF
--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -75,7 +75,7 @@ const (
 	errorNodeRunning                  = "Node must be stopped before writing APIToken"
 	errorNodeFailGenToken             = "Cannot generate API token: %s"
 	errorNodeCreation                 = "Error during node creation: %v"
-	errorNodeManagedBySystemd         = "This node is managed by systemd, you must run the following command to make your desired state change to your node:\n\nsystemctl %s algorand.service"
+	errorNodeManagedBySystemd         = "This node is managed by systemd, you must run the following command to make your desired state change to your node:\n\nsystemctl %s algorand@$(systemd-escape $ALGORAND_DATA)"
 	errorKill                         = "Cannot kill node: %s"
 	errorCloningNode                  = "Error cloning the node: %s"
 	infoNodeCloned                    = "Node cloned successfully to: %s"

--- a/cmd/goal/node.go
+++ b/cmd/goal/node.go
@@ -165,7 +165,7 @@ var startCmd = &cobra.Command{
 		}
 		onDataDirs(func(dataDir string) {
 			if libgoal.AlgorandDaemonSystemdManaged(dataDir) {
-				reportErrorf(errorNodeManagedBySystemd, "start")
+				reportErrorf(errorNodeManagedBySystemd)
 			}
 
 			nc := nodecontrol.MakeNodeController(binDir, dataDir)
@@ -237,7 +237,7 @@ var stopCmd = &cobra.Command{
 		}
 		onDataDirs(func(dataDir string) {
 			if libgoal.AlgorandDaemonSystemdManaged(dataDir) {
-				reportErrorf(errorNodeManagedBySystemd, "stop")
+				reportErrorf(errorNodeManagedBySystemd)
 			}
 
 			nc := nodecontrol.MakeNodeController(binDir, dataDir)
@@ -268,7 +268,7 @@ var restartCmd = &cobra.Command{
 		}
 		onDataDirs(func(dataDir string) {
 			if libgoal.AlgorandDaemonSystemdManaged(dataDir) {
-				reportErrorf(errorNodeManagedBySystemd, "restart")
+				reportErrorf(errorNodeManagedBySystemd)
 			}
 
 			nc := nodecontrol.MakeNodeController(binDir, dataDir)

--- a/installer/algorand@.service.template
+++ b/installer/algorand@.service.template
@@ -30,6 +30,7 @@ After=network.target
 AssertPathExists=%I
 
 [Service]
+ExecStartPre=bash -c "[[ ! -f /home/pi/node/data/system.json ]] && echo '{\"shared_server\":true,\"systemd_managed\":true}' > /home/pi/node/data/system.json || :"
 ExecStart=@@BINDIR@@/algod -d %I
 User=@@USER@@
 Group=@@GROUP@@


### PR DESCRIPTION
## Summary

Right now a system.json file is not created when setting up systemd through the setup-systemd.sh script. Therefore, users aren't letting their nodes know that the algod process will be managed with systemd. This change has the setup-systemd.sh script download the systemd system.json file and lets the user know they need to copy that into any systemd managed data directory.

## Test Plan

I ran the script on a raspberry pi and saw that it worked.
