### PR TITLE
Run all tests on hotfix branches too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,111 +15,147 @@ workflows:
             - amd64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore:
+                - "hotfix/*"
+                - "rel/nightly"
       - amd64_test_nightly:
           requires:
             - amd64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only:
+                - "hotfix/*"
+                - "rel/nightly"
       - amd64_integration:
           requires:
             - amd64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore:
+                - "hotfix/*"
+                - "rel/nightly"
       - amd64_integration_nightly:
           requires:
             - amd64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only:
+                - "hotfix/*"
+                - "rel/nightly"
       - amd64_e2e_subs:
           requires:
             - amd64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore:
+                - "hotfix/*"
+                - "rel/nightly"
       - amd64_e2e_subs_nightly:
           requires:
             - amd64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only:
+                - "hotfix/*"
+                - "rel/nightly"
       - arm64_build
       - arm64_test:
           requires:
             - arm64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore:
+                - "hotfix/*"
+                - "rel/nightly"
       - arm64_test_nightly:
           requires:
             - arm64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only:
+                - "hotfix/*"
+                - "rel/nightly"
       - arm64_integration:
           requires:
             - arm64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore:
+                - "hotfix/*"
+                - "rel/nightly"
       - arm64_integration_nightly:
           requires:
             - arm64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only:
+                - "hotfix/*"
+                - "rel/nightly"
       - arm64_e2e_subs:
           requires:
             - arm64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore:
+                - "hotfix/*"
+                - "rel/nightly"
       - arm64_e2e_subs_nightly:
           requires:
             - arm64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only:
+                - "hotfix/*"
+                - "rel/nightly"
       - mac_amd64_build
       - mac_amd64_test:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore:
+                - "hotfix/*"
+                - "rel/nightly"
       - mac_amd64_test_nightly:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only:
+                - "hotfix/*"
+                - "rel/nightly"
       - mac_amd64_integration:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore:
+                - "hotfix/*"
+                - "rel/nightly"
       - mac_amd64_integration_nightly:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only:
+                - "hotfix/*"
+                - "rel/nightly"
       - mac_amd64_e2e_subs:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              ignore: "rel/nightly"
+              ignore:
+                - "hotfix/*"
+                - "rel/nightly"
       - mac_amd64_e2e_subs_nightly:
           requires:
             - mac_amd64_build
           filters:
             branches:
-              only: "rel/nightly"
+              only:
+                - "hotfix/*"
+                - "rel/nightly"
       #- windows_x64_build
 
 commands:


### PR DESCRIPTION
## Summary

We want to run all tests on hotfix branches in addition to rel/nightly, since hotfix changes will not go through the standard rel/nightly merge.

## Test Plan

I plan to test this by creating a hotfix branch and seeing that it runs all tests