### PR TITLE
CI: use libboost-math-dev instead of libboost-all-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ jobs:
         apt:
           packages:
             - awscli
+            - make
       script:
         - scripts/travis/external_build.sh ./scripts/travis/build_test.sh
     - # same stage, parallel job
@@ -67,6 +68,7 @@ jobs:
         apt:
           packages:
             - awscli
+            - make
       script:
         - scripts/travis/external_build.sh ./scripts/travis/integration_test.sh
     - # same stage, parallel job
@@ -116,6 +118,7 @@ jobs:
         apt:
           packages:
             - awscli
+            - make
       script:
         - scripts/travis/external_build.sh ./scripts/travis/build_test.sh
     - # same stage, parallel job
@@ -128,6 +131,7 @@ jobs:
         apt:
           packages:
             - awscli
+            - make
       script:
         - scripts/travis/external_build.sh ./scripts/travis/integration_test.sh
     - # same stage, parallel job
@@ -229,7 +233,6 @@ addons:
       - python3-venv
       - libssl-dev
       - libffi-dev
-      - make
   artifacts:
     s3_region: "us-east-1"
     paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -229,6 +229,7 @@ addons:
       - python3-venv
       - libssl-dev
       - libffi-dev
+      - make
   artifacts:
     s3_region: "us-east-1"
     paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -223,7 +223,7 @@ before_cache:
 addons:
   apt:
     packages:
-      - libboost-all-dev
+      - libboost-math-dev
       - fakeroot
       - rpm
       - python3-venv

--- a/scripts/install_linux_deps.sh
+++ b/scripts/install_linux_deps.sh
@@ -5,7 +5,7 @@ set -e
 DISTRIB=$ID
 
 ARCH_DEPS="boost boost-libs expect jq autoconf shellcheck sqlite python-virtualenv"
-UBUNTU_DEPS="libboost-all-dev expect jq autoconf shellcheck sqlite3 python3-venv"
+UBUNTU_DEPS="libboost-math-dev expect jq autoconf shellcheck sqlite3 python3-venv"
 FEDORA_DEPS="boost-devel expect jq autoconf ShellCheck sqlite python-virtualenv"
 
 if [ "${DISTRIB}" = "arch" ]; then

--- a/scripts/install_linux_deps.sh
+++ b/scripts/install_linux_deps.sh
@@ -5,7 +5,7 @@ set -e
 DISTRIB=$ID
 
 ARCH_DEPS="boost boost-libs expect jq autoconf shellcheck sqlite python-virtualenv"
-UBUNTU_DEPS="libboost-math-dev expect jq autoconf shellcheck sqlite3 python3-venv"
+UBUNTU_DEPS="libboost-math-dev expect jq autoconf shellcheck sqlite3 python3-venv make"
 FEDORA_DEPS="boost-devel expect jq autoconf ShellCheck sqlite python-virtualenv"
 
 if [ "${DISTRIB}" = "arch" ]; then


### PR DESCRIPTION
## Summary

Small change: libboost-math-dev requires just 4 packages to install, while libboost-all-dev requires > 100. Only Debian/Ubuntu distributions provide fine-grained boost packages like this, but should shave a little time off the CI builds. (Our only boost include is boost/math/distributions/binomial.hpp.)

## Test Plan

CI tests should pass as before.