### PR TITLE
using the appIdx instead of txn app id

### DIFF
--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -1035,7 +1035,7 @@ func MakeDryrunStateGenerated(client Client, txnOrStxn interface{}, other []tran
 				} else {
 					// otherwise need to fetch app state
 					var app generatedV2.Application
-					if app, err = client.ApplicationInformation(uint64(tx.ApplicationID)); err != nil {
+					if app, err = client.ApplicationInformation(uint64(appIdx)); err != nil {
 						return
 					}
 					appParams = app.Params


### PR DESCRIPTION

## Summary

Passing a foreign app id to the `goal app create` cmd with dryrun tries to use ApplicationId (0) instead of the foreign app id.

## Test Plan

