### PR TITLE
Make config.MaxLogCalls dependant on some consensus param

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -423,8 +423,8 @@ var MaxEvalDeltaAccounts int
 var MaxStateDeltaKeys int
 
 // MaxLogCalls is the highest allowable log messages that may appear in
-// any version, used for decoding purposes. Never decrease this value.
-const MaxLogCalls = 32
+// any version, used only for decoding purposes. Never decrease this value.
+var MaxLogCalls int
 
 // MaxLogicSigMaxSize is the largest logical signature appear in any of the supported
 // protocols, used for decoding purposes.
@@ -486,6 +486,9 @@ func checkSetAllocBounds(p ConsensusParams) {
 	checkSetMax(p.MaxExtraAppProgramPages, &MaxExtraAppProgramLen)
 	// MaxAvailableAppProgramLen is the max of supported app program size
 	MaxAvailableAppProgramLen = MaxAppProgramLen * (1 + MaxExtraAppProgramLen)
+	// There is no consensus parameter for MaxLogCalls and MaxAppProgramLen as an approximation
+	// Its value is much larger than any possible reasonable MaxLogCalls value in future
+	checkSetMax(p.MaxAppProgramLen, &MaxLogCalls)
 }
 
 // SaveConfigurableConsensus saves the configurable protocols file to the provided data directory.

--- a/data/transactions/logic/backwardCompat_test.go
+++ b/data/transactions/logic/backwardCompat_test.go
@@ -404,3 +404,12 @@ done:`
 		})
 	}
 }
+
+func TestExplicitConstants(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	require.Equal(t, 4096, MaxStringSize, "constant changed, move it to consensus params")
+	require.Equal(t, 64, MaxByteMathSize, "constant changed, move it to consensus params")
+	require.Equal(t, 1024, MaxLogSize, "constant changed, move it to consensus params")
+	require.Equal(t, 32, MaxLogCalls, "constant changed, move it to consensus params")
+}

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -44,8 +44,8 @@ import (
 // EvalMaxVersion is the max version we can interpret and run
 const EvalMaxVersion = LogicVersion
 
-// EvalMaxScratchSize is the maximum number of scratch slots.
-const EvalMaxScratchSize = 255
+// The constants below control TEAL opcodes evaluation and MAY NOT be changed
+// without moving them into consensus parameters.
 
 // MaxStringSize is the limit of byte strings created by `concat`
 const MaxStringSize = 4096
@@ -57,7 +57,7 @@ const MaxByteMathSize = 64
 const MaxLogSize = 1024
 
 // MaxLogCalls is the limit of total log calls during a program execution
-const MaxLogCalls = config.MaxLogCalls
+const MaxLogCalls = 32
 
 // stackValue is the type for the operand stack.
 // Each stackValue is either a valid []byte value or a uint64 value.

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -4764,7 +4764,7 @@ func TestLog(t *testing.T) {
 			loglen: 2,
 		},
 		{
-			source: fmt.Sprintf(`%s int 1`, strings.Repeat(`byte "a logging message"; log;`, config.MaxLogCalls)),
+			source: fmt.Sprintf(`%s int 1`, strings.Repeat(`byte "a logging message"; log;`, MaxLogCalls)),
 			loglen: MaxLogCalls,
 		},
 		{
@@ -4816,7 +4816,7 @@ func TestLog(t *testing.T) {
 			runMode:     runModeApplication,
 		},
 		{
-			source:      fmt.Sprintf(`%s; int 1`, strings.Repeat(`byte "a"; log;`, config.MaxLogCalls+1)),
+			source:      fmt.Sprintf(`%s; int 1`, strings.Repeat(`byte "a"; log;`, MaxLogCalls+1)),
 			errContains: "too many log calls",
 			runMode:     runModeApplication,
 		},


### PR DESCRIPTION
## Summary

* Commented some constants in teal evaluator and added a test
  enforcing their values and directing on how to change them if/when needed.

## Test Plan

Existing tests