### PR TITLE
Dryrun return cost

### DIFF
--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -398,11 +398,12 @@ func doDryrunRequest(dr *DryrunRequest, response *generated.DryrunResponse) {
 	}
 	proto := config.Consensus[protocol.ConsensusVersion(dr.ProtocolVersion)]
 	proto.EnableAppCostPooling = true
+	proto.MaxTxGroupSize = 16
 	response.Txns = make([]generated.DryrunTxnResult, len(dr.Txns))
 	for ti, stxn := range dr.Txns {
 		pse := logic.MakePastSideEffects(len(dr.Txns))
-		maxBudget := uint64(16*700)
-		evalBudget := uint64(16*700)
+		maxBudget := uint64(proto.MaxAppProgramCost * proto.MaxTxGroupSize)
+		evalBudget := uint64(proto.MaxAppProgramCost * proto.MaxTxGroupSize)
 		ep := logic.EvalParams{
 			Txn:                     &stxn,
 			Proto:                   &proto,

--- a/daemon/algod/api/server/v2/generated/types.go
+++ b/daemon/algod/api/server/v2/generated/types.go
@@ -316,7 +316,7 @@ type ErrorResponse struct {
 	Message string  `json:"message"`
 }
 
-// EvalDelta defines model for EvalDelta.
+// EvalDelta defines model for f.
 type EvalDelta struct {
 
 	// \[at\] delta action.
@@ -498,6 +498,7 @@ type DryrunResponse struct {
 	// Protocol version is the protocol version Dryrun was operated under.
 	ProtocolVersion string            `json:"protocol-version"`
 	Txns            []DryrunTxnResult `json:"txns"`
+	Cost            uint64            `json:"cost"`
 }
 
 // NodeStatusResponse defines model for NodeStatusResponse.


### PR DESCRIPTION
This PR adds a `Cost` Parameter to DryrunResponse. It is calculated by giving the evalParams object in dryrun.go the maximum budget allowed (maxappcost * maxgroupsize) and checking the difference after stateful evaluation. LogicSig dryruns will return cost of 0. 

Added a single test with sqrt and default opcodes
