### PR TITLE
Increase max app opt ins to 50

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1016,6 +1016,9 @@ func initConsensusProtocols() {
 	// Enable App calls to pool budget in grouped transactions
 	vFuture.EnableAppCostPooling = true
 
+	// Allow 50 app opt ins
+	vFuture.MaxAppsOptedIn = 50
+
 	Consensus[protocol.ConsensusFuture] = vFuture
 }
 

--- a/data/basics/userBalance.go
+++ b/data/basics/userBalance.go
@@ -42,7 +42,7 @@ const (
 
 	// MaxEncodedAccountDataSize is a rough estimate for the worst-case scenario we're going to have of the account data and address serialized.
 	// this number is verified by the TestEncodedAccountDataSize function.
-	MaxEncodedAccountDataSize = 750000
+	MaxEncodedAccountDataSize = 850000
 
 	// encodedMaxAssetsPerAccount is the decoder limit of number of assets stored per account.
 	// it's being verified by the unit test TestEncodedAccountAllocationBounds to align

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -47,6 +47,12 @@ func randomAddress() basics.Address {
 	return addr
 }
 
+func randomNote() []byte {
+	var note [16]byte
+	crypto.RandBytes(note[:])
+	return note[:]
+}
+
 func randomAccountData(rewardsLevel uint64) basics.AccountData {
 	var data basics.AccountData
 

--- a/ledger/apply/application_test.go
+++ b/ledger/apply/application_test.go
@@ -126,6 +126,12 @@ const appIdxError basics.AppIndex = 0x11223344
 const appIdxOk basics.AppIndex = 1
 
 func (b *testBalances) Get(addr basics.Address, withPendingRewards bool) (basics.AccountData, error) {
+	if b.putBalances != nil {
+		ad, ok := b.putBalances[addr]
+		if ok {
+			return ad, nil
+		}
+	}
 	ad, ok := b.balances[addr]
 	if !ok {
 		return basics.AccountData{}, fmt.Errorf("mock balance not found")
@@ -515,15 +521,6 @@ func TestAppCallApplyCreate(t *testing.T) {
 
 	b.ResetWrites()
 
-	// now looking up the creator will succeed, but we reset writes, so
-	// they won't have the app params
-	err = ApplicationCall(ac, h, &b, ad, &ep, txnCounter)
-	a.Error(err)
-	a.Contains(err.Error(), fmt.Sprintf("app %d not found in account", appIdx))
-	a.Equal(1, b.put)
-
-	b.ResetWrites()
-
 	// now we give the creator the app params again
 	cp := basics.AccountData{}
 	cp.AppParams = cloneAppParams(saved.AppParams)
@@ -690,6 +687,42 @@ func TestAppCallOptIn(t *testing.T) {
 		},
 		br,
 	)
+
+	// check max optins
+
+	var optInCountTest = []struct {
+		proto protocol.ConsensusVersion
+	}{
+		{protocol.ConsensusV29},
+		{protocol.ConsensusFuture},
+	}
+
+	prevMaxAppsOptedIn := 0
+	for _, test := range optInCountTest {
+		cparams, ok := config.Consensus[test.proto]
+		a.True(ok)
+		a.Less(prevMaxAppsOptedIn, cparams.MaxAppsOptedIn)
+		prevMaxAppsOptedIn = cparams.MaxAppsOptedIn
+
+		b.SetParams(cparams)
+		aparams := basics.AppParams{
+			StateSchemas: basics.StateSchemas{
+				LocalStateSchema: basics.StateSchema{NumUint: 1},
+			},
+		}
+		sender = getRandomAddress(a)
+		b.balances = map[basics.Address]basics.AccountData{sender: {}}
+		var appIdx basics.AppIndex = appIdx
+		for i := 0; i < cparams.MaxAppsOptedIn; i++ {
+			appIdx = appIdx + basics.AppIndex(i)
+			err = optInApplication(&b, sender, appIdx, aparams)
+			a.NoError(err)
+		}
+		appIdx++
+		err = optInApplication(&b, sender, appIdx, aparams)
+		a.Error(err)
+		a.Contains(err.Error(), "max opted-in apps per acct")
+	}
 }
 
 func TestAppCallClearState(t *testing.T) {
@@ -931,8 +964,12 @@ func TestAppCallApplyCloseOut(t *testing.T) {
 	a.Equal(basics.EvalDelta{GlobalDelta: gd}, ad.EvalDelta)
 	a.Equal(basics.StateSchema{NumUint: 0}, br.TotalAppSchema)
 
+	b.ResetWrites()
 	logs := []basics.LogItem{{ID: 0, Message: "a"}}
 	b.delta = basics.EvalDelta{Logs: []basics.LogItem{{ID: 0, Message: "a"}}}
+	b.balances[sender] = basics.AccountData{
+		AppLocalStates: map[basics.AppIndex]basics.AppLocalState{appIdx: {}},
+	}
 	err = ApplicationCall(ac, h, &b, ad, &ep, txnCounter)
 	a.NoError(err)
 	a.Equal(basics.EvalDelta{Logs: logs}, ad.EvalDelta)
@@ -1062,6 +1099,7 @@ func TestAppCallApplyUpdate(t *testing.T) {
 		a.Contains(err.Error(), fmt.Sprintf("updateApplication %s program too long", test.name))
 	}
 
+	b.ResetWrites()
 	// check extraProgramPages allows length of proto.MaxAppProgramLen + 1
 	appr = make([]byte, proto.MaxAppProgramLen+1)
 	appr[0] = 4

--- a/ledger/ledger_perf_test.go
+++ b/ledger/ledger_perf_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io/ioutil"
+	rnd "math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,6 +38,7 @@ import (
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/data/transactions/verify"
+	"github.com/algorand/go-algorand/data/txntest"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 )
@@ -1294,3 +1296,136 @@ int 32
 &&
 if_end1:
 `
+
+func BenchmarkAppOptIns(b *testing.B) {
+	a := require.New(b)
+
+	genBalances, addrs, _ := newTestGenesis()
+	l, dbName, genBlock := newTestLedgerOnDisk(b, genBalances)
+	genAccounts := l.genesisAccounts
+	genHash := l.genesisHash
+	defer testLedgerCleanup(l, dbName, false)
+
+	l.accts.ctxCancel() // force commitSyncer to exit
+
+	// wait commitSyncer to exit
+	// the test calls commitRound directly and does not need commitSyncer/committedUpTo
+	select {
+	case <-l.accts.commitSyncerClosed:
+		break
+	}
+
+	maxAppsCreated := config.Consensus[protocol.ConsensusFuture].MaxAppsCreated
+	maxLocalSchemaEntries := config.Consensus[protocol.ConsensusFuture].MaxLocalSchemaEntries
+
+	// create apps
+	txns := make([]*txntest.Txn, 0, maxAppsCreated*len(addrs))
+	for i := 0; i < len(addrs); i++ {
+		creator := addrs[i]
+		for j := 0; j < maxAppsCreated; j++ {
+			createTxn := txntest.Txn{
+				Type:              "appl",
+				Sender:            creator,
+				ApprovalProgram:   []byte{0x02, 0x20, 0x01, 0x01, 0x22},
+				ClearStateProgram: []byte{0x02, 0x20, 0x01, 0x01, 0x22},
+				LocalStateSchema:  basics.StateSchema{NumByteSlice: maxLocalSchemaEntries},
+				Note:              randomNote(),
+			}
+			txns = append(txns, &createTxn)
+		}
+	}
+	// app ids are expected to be in range 1..len(txns)-1 => 1..100
+	maxAppIndex := len(txns)
+	maxAppsOptedIn := config.Consensus[protocol.ConsensusFuture].MaxAppsOptedIn
+
+	eval := l.nextBlock(b)
+	eval.txns(b, txns...)
+	l.endBlock(b, eval)
+
+	l.accts.accountsWriting.Add(1)
+	l.accts.commitRound(0, 0, 0)
+	l.accts.accountsWriting.Wait()
+
+	// fund some accounts for apps
+	const numAcct = 10000
+	txns = make([]*txntest.Txn, 0, numAcct)
+	accounts := make(map[basics.Address]map[basics.AppIndex]struct{}, numAcct)
+	for i := 0; i < numAcct; i++ {
+		receiver := randomAddress()
+		payTxn := txntest.Txn{
+			Type:     "pay",
+			Sender:   addrs[i%len(addrs)],
+			Receiver: receiver,
+			Amount:   basics.MicroAlgos{Raw: 100 * 1000000}, // 100 algo
+			Note:     randomNote(),
+		}
+		txns = append(txns, &payTxn)
+		accounts[receiver] = make(map[basics.AppIndex]struct{}, maxAppsOptedIn)
+	}
+
+	eval = l.nextBlock(b)
+	eval.txns(b, txns...)
+	l.endBlock(b, eval)
+
+	l.accts.accountsWriting.Add(1)
+	l.accts.commitRound(1, 1, 0)
+	l.accts.accountsWriting.Wait()
+
+	l.Close()
+
+	const txnPerBlock = 50
+	for _, full := range []bool{false, true} {
+		b.Run(fmt.Sprintf("max-opt-ins=%d/full-opt-in=%v", maxAppsOptedIn, full), func(b *testing.B) {
+			cfg := config.GetDefaultLocal()
+			cfg.Archival = true
+			l, err := OpenLedger(logging.Base(), dbName, false, InitState{
+				Block:       genBlock,
+				Accounts:    genAccounts,
+				GenesisHash: genHash,
+			}, cfg)
+			a.NoError(err)
+
+			b.ResetTimer()
+
+			txns = make([]*txntest.Txn, 0, txnPerBlock)
+			totalTxn := 0
+			for i := 0; i < b.N; i++ {
+				var addr basics.Address
+				for addr = range accounts {
+					if len(accounts[addr]) < maxAppsOptedIn {
+						break
+					}
+				}
+			repeat:
+				var appIdx basics.AppIndex
+				for {
+					appIdx = basics.AppIndex(rnd.Intn(maxAppIndex) + 1)
+					if _, ok := accounts[addr][appIdx]; !ok {
+						accounts[addr][appIdx] = struct{}{}
+						break
+					}
+				}
+				optInTxn := txntest.Txn{
+					Type:          "appl",
+					Sender:        addr,
+					ApplicationID: appIdx,
+					OnCompletion:  transactions.OptInOC,
+				}
+				txns = append(txns, &optInTxn)
+				if full && len(accounts[addr]) < maxAppsOptedIn {
+					goto repeat
+				}
+
+				if i%txnPerBlock == 0 {
+					eval := l.nextBlock(b)
+					eval.txns(b, txns...)
+					l.endBlock(b, eval)
+					totalTxn += len(txns)
+					txns = txns[:0]
+				}
+			}
+			b.ReportMetric(float64(totalTxn), "txn_sent")
+			l.Close()
+		})
+	}
+}

--- a/ledger/perf_test.go
+++ b/ledger/perf_test.go
@@ -36,8 +36,11 @@ import (
 )
 
 func genesis(naccts int) (InitState, []basics.Address, []*crypto.SignatureSecrets) {
+	return genesisWithProto(naccts, protocol.ConsensusCurrentVersion)
+}
+func genesisWithProto(naccts int, proto protocol.ConsensusVersion) (InitState, []basics.Address, []*crypto.SignatureSecrets) {
 	blk := bookkeeping.Block{}
-	blk.CurrentProtocol = protocol.ConsensusCurrentVersion
+	blk.CurrentProtocol = proto
 	blk.BlockHeader.GenesisID = "test"
 	blk.FeeSink = testSinkAddr
 	blk.RewardsPool = testPoolAddr


### PR DESCRIPTION
## Summary

As a temporary relief increase max number of opt ins to 50.
Also found and fixed an error check in new ledger testing harness.

## Test Plan

* Unit tested ledger.apply and ledger.eval

## Benchmarks

Benchmark 1: create 100k accounts, 500 apps (no local data) and opt-in 10k accounts to max number of apps. Restart ledgers, measure a single block validation time of 50k pay transactions on random opted-in accounts.
| 10 opt ins | 50 opt ins | 100 opt ins |
|-----------|-----------|------------|
| 644 ms | 660 ms | 683 ms |

Benchmark 2: same as 2 but with full local data (16 keys each 64 bytes long with 64 bytes of value data)
| 10 opt ins | 50 opt ins | 100 opt ins |
|-----------|-----------|------------|
| 1.4 - 2.2 s |  9-16 s | ~20-25 s |

Benchmark 3: same as 2 but 5k txns per block
| 50 opt ins | 30 opt ins | 20 opt ins | 10 opt ins |
|-----------|-----------|------------|-----------|
| 3.2 s | 1.7 s | 1.1 s | 0.27 s|

