### PR TITLE
testing: fixing a typo in e2e.sh for integration tests

### DIFF
--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -100,7 +100,7 @@ export GOPATH=$(go env GOPATH)
 # Change current directory to test/scripts so we can just use ./test.sh to exec.
 cd "${SCRIPT_PATH}"
 
-if [ -z $E2E_TEST_FILTER || $E2E_TEST_FILTER="SCRIPTS" ]; then
+if [ -z $E2E_TEST_FILTER || $E2E_TEST_FILTER=="SCRIPTS" ]; then
 
     ./timeout 200 ./e2e_basic_start_stop.sh
     duration "e2e_basic_start_stop.sh"
@@ -127,7 +127,7 @@ if [ -z $E2E_TEST_FILTER || $E2E_TEST_FILTER="SCRIPTS" ]; then
     deactivate
 fi # if E2E_TEST_FILTER = "" or = "SCRIPTS"
 
-if [ -z $E2E_TEST_FILTER || $E2E_TEST_FILTER="GO" ]; then
+if [ -z $E2E_TEST_FILTER || $E2E_TEST_FILTER=="GO" ]; then
     # Export our root temp folder as 'TESTDIR' for tests to use as their root test folder
     # This allows us to clean up everything with our rm -rf trap.
     export TESTDIR=${TEMPDIR}

--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -100,7 +100,7 @@ export GOPATH=$(go env GOPATH)
 # Change current directory to test/scripts so we can just use ./test.sh to exec.
 cd "${SCRIPT_PATH}"
 
-if [ -z $E2E_TEST_FILTER || $E2E_TEST_FILTER=="SCRIPTS" ]; then
+if [ -z "$E2E_TEST_FILTER" ] || [ "$E2E_TEST_FILTER" == "SCRIPTS" ]; then
 
     ./timeout 200 ./e2e_basic_start_stop.sh
     duration "e2e_basic_start_stop.sh"
@@ -125,9 +125,9 @@ if [ -z $E2E_TEST_FILTER || $E2E_TEST_FILTER=="SCRIPTS" ]; then
     duration "serial client runners"
 
     deactivate
-fi # if E2E_TEST_FILTER = "" or = "SCRIPTS"
+fi # if E2E_TEST_FILTER == "" or == "SCRIPTS"
 
-if [ -z $E2E_TEST_FILTER || $E2E_TEST_FILTER=="GO" ]; then
+if [ -z "$E2E_TEST_FILTER" ] || [ "$E2E_TEST_FILTER" == "GO" ]; then
     # Export our root temp folder as 'TESTDIR' for tests to use as their root test folder
     # This allows us to clean up everything with our rm -rf trap.
     export TESTDIR=${TEMPDIR}
@@ -146,4 +146,4 @@ if [ -z $E2E_TEST_FILTER || $E2E_TEST_FILTER=="GO" ]; then
     echo "----------------------------------------------------------------------"
     echo "  DONE: E2E"
     echo "----------------------------------------------------------------------"
-fi # if E2E_TEST_FILTER = "" or = "GO"
+fi # if E2E_TEST_FILTER == "" or == "GO"


### PR DESCRIPTION
## Summary
Fixing typo of one equal sign instead of two for integration tests

## Test Plan

CircleCI Tests