### PR TITLE
Fix and enable TestSlowOutboundPeer

### DIFF
--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -846,7 +846,7 @@ func TestSlowOutboundPeer(t *testing.T) {
 			MessageHandler: HandlerFunc(waitMessageArriveHandlerB),
 		}})
 
-	readyTimeout := time.NewTimer(2 * time.Second)	
+	readyTimeout := time.NewTimer(2 * time.Second)
 	waitReady(t, node, readyTimeout.C)
 	require.Equal(t, 2, len(node.peers))
 
@@ -854,7 +854,7 @@ func TestSlowOutboundPeer(t *testing.T) {
 		time.Sleep(2 * maxMessageQueueDuration)
 		return nil
 	}
-	
+
 	rand.Read(msg)
 	x := 0
 MAINLOOP:
@@ -870,23 +870,23 @@ MAINLOOP:
 			break MAINLOOP
 		default:
 		}
-		
-		node.Broadcast(context.Background(), protocol.AgreementVoteTag, msg, true, nil)		
+
+		node.Broadcast(context.Background(), protocol.AgreementVoteTag, msg, true, nil)
 		if x == 0 {
-			node.peers[0].Unicast(context.Background(), msg, protocol.AgreementVoteTag, callback)			
+			node.peers[0].Unicast(context.Background(), msg, protocol.AgreementVoteTag, callback)
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
 
 	require.Less(t, x, 1000)
-	
+
 	maxNumHandled := 0
 	minNumHandled := 0
 	for i := 0; i < 10; i++ {
 		muHandleA.Lock()
 		a := numHandledA
 		muHandleA.Unlock()
-		
+
 		muHandleB.Lock()
 		b := numHandledB
 		muHandleB.Unlock()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
TestSlowOutboundPeer was disabled after https://github.com/algorand/go-algorand/commit/ea855418b0b928435c0f883e3847456b938ab293

Changing the test to confirm to the new behavior and enabling it. 

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
