### PR TITLE
Improve error message in update.sh when updater is corrupt.

### DIFF
--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -246,7 +246,7 @@ function check_for_update() {
     fi
 
     if [ -z ${LATEST} ]; then
-        echo "Failed to lookup latest release. This could happen if the 'updater' binary is corrupted."
+        echo "Failed to lookup latest release"
         return 1
     fi
 

--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -245,7 +245,12 @@ function check_for_update() {
         return 1
     fi
 
-    echo Latest Version = ${LATEST}
+    if [ -z ${LATEST} ]; then
+        echo "Failed to lookup latest release. This could happen if the 'updater' binary is corrupted."
+        return 1
+    fi
+
+    echo "Latest Version = ${LATEST}"
 
     if [ ${CURRENTVER} -ge ${LATEST} ]; then
         if [ "${UPDATETYPE}" = "install" ]; then

--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -196,8 +196,8 @@ function get_updater_url() {
 
 # check to see if the binary updater exists. if not, it will automatically the correct updater binary for the current platform
 function check_for_updater() {
-    # check if the updater binary exist.
-    if [ -f "${SCRIPTPATH}/updater" ]; then
+    # check if the updater binary exist and is not empty.
+    if [[ -s "${SCRIPTPATH}/updater" && -f "${SCRIPTPATH}/updater" ]]; then
         return 0
     fi
     get_updater_url


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
A user reported a strange and not very helpful error message. This was due to incomplete error handling in the bash script relating to a truncated `updater` binary.

The current workaround for this is to delete the `updater` binary and trigger `update.sh` to re-download it, but this is not obvious and I wouldn't expect any user to reach that conclusion.

This fix adds error handling in case `updater` fails and should fix this particular failure.

Here is the error message:
```
Current Version = 8590458880
Latest Version =
./update.sh: line 250: [: 8590458880: unary operator expected
New version found
Update Downloaded to /tmp/tmp.QlV71NLGFr/.tar.gz
Expanding update...
tar (child): /tmp/tmp.QlV71NLGFr/.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
*** UPDATE FAILED: Error expanding update ***
```
## Test Plan

Ran some tests against a directory, empty file, and regular file in my shell:
```
will@arendelle:~/go/src/github.com/algorand/go-algorand/cmd/updater$ [[ -f dir && -s dir ]]
will@arendelle:~/go/src/github.com/algorand/go-algorand/cmd/updater$ echo $?
1
will@arendelle:~/go/src/github.com/algorand/go-algorand/cmd/updater$ [[ -f empty && -s empty ]]
will@arendelle:~/go/src/github.com/algorand/go-algorand/cmd/updater$ echo $?
1
will@arendelle:~/go/src/github.com/algorand/go-algorand/cmd/updater$ [[ -f util.go && -s util.go ]]
will@arendelle:~/go/src/github.com/algorand/go-algorand/cmd/updater$ echo $?
0
```