### PR TITLE
Remove codegen from travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,6 @@ jobs:
 
     - stage: build_pr
       os: linux
-      name: Ubuntu AMD64 CodeGen Verification
-      script:
-        - scripts/travis/codegen_verification.sh
-    - # same stage, parallel job
-      os: linux
       name: Ubuntu AMD64 Build
       script:
         - scripts/travis/build_test.sh
@@ -92,11 +87,6 @@ jobs:
          - $mingw64 scripts/travis/build_test.sh
 
     - stage: build_release
-      os: linux
-      name: Ubuntu AMD64 CodeGen Verification
-      script:
-        - scripts/travis/codegen_verification.sh
-    - # same stage, parallel job
       os: linux
       name: Ubuntu AMD64 Build
       script:
@@ -216,9 +206,6 @@ before_cache:
      ;;
    esac
    docker save -o $HOME/docker_cache/images.tar $(docker images -a -q)
-
-#after_success:
-#  - scripts/travis/upload_coverage.sh || true
 
 addons:
   apt:


### PR DESCRIPTION
## Summary

Codegen verification step is now being run by CircleCI, so it's no longer necessary to run it on Travis, especially since we recently got a `toomanyrequests: You have reached your pull rate limit.` docker error. We want to reduce unnecessary docker requests.

## Test Plan
Will check the PR tests to make sure codegen is no longer run on Travis tests.
