### PR TITLE
Limit the number of buckets in `verifiedTransactionCache` to 3

### DIFF
--- a/data/transactions/verify/verifiedTxnCache_test.go
+++ b/data/transactions/verify/verifiedTxnCache_test.go
@@ -49,7 +49,8 @@ func TestBucketCycling(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	bucketCount := 3
-	icache := MakeVerifiedTransactionCache(entriesPerBucket * bucketCount)
+	entriesPerBucket := 100
+	icache := MakeVerifiedTransactionCache(entriesPerBucket * (bucketCount - 1))
 	impl := icache.(*verifiedTransactionCache)
 	_, signedTxn, _, _ := generateTestObjects(entriesPerBucket*bucketCount*2, bucketCount, 0)
 
@@ -58,7 +59,7 @@ func TestBucketCycling(t *testing.T) {
 	require.NoError(t, err)
 
 	// fill up the cache with entries.
-	for i := 0; i < entriesPerBucket*(bucketCount+1); i++ {
+	for i := 0; i < entriesPerBucket*bucketCount; i++ {
 		impl.Add([]transactions.SignedTxn{signedTxn[i]}, groupCtx)
 		// test to see that the base is sliding when bucket get filled up.
 		require.Equal(t, i/entriesPerBucket, impl.base)
@@ -136,13 +137,13 @@ func BenchmarkGetUnverifiedTranscationGroups50(b *testing.B) {
 func TestUpdatePinned(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	size := entriesPerBucket
+	size := 100
 	icache := MakeVerifiedTransactionCache(size * 10)
 	impl := icache.(*verifiedTransactionCache)
 	_, signedTxn, secrets, addrs := generateTestObjects(size*2, 10, 0)
 	txnGroups := generateTransactionGroups(signedTxn, secrets, addrs)
 
-	// insert half of the entries.
+	// insert some entries.
 	for i := 0; i < len(txnGroups); i++ {
 		groupCtx, _ := PrepareGroupContext(txnGroups[i], blockHeader)
 		impl.Add(txnGroups[i], groupCtx)
@@ -165,7 +166,7 @@ func TestUpdatePinned(t *testing.T) {
 func TestPinningTransactions(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	size := entriesPerBucket
+	size := 100
 	icache := MakeVerifiedTransactionCache(size)
 	impl := icache.(*verifiedTransactionCache)
 	_, signedTxn, secrets, addrs := generateTestObjects(size*2, 10, 0)
@@ -182,5 +183,4 @@ func TestPinningTransactions(t *testing.T) {
 
 	// try to pin an entry that was not added.
 	require.Error(t, impl.Pin(txnGroups[len(txnGroups)-1]))
-
 }


### PR DESCRIPTION
## Summary

The number of buckets in `verifiedTransactionCache` can be arbitrarily large depending on the requested cache size, and each lookup in the cache does that many map lookups. This PR limits the number of buckets to 3. Now, the lookup takes at most 3 lookups and the size overhead is 1.5.

## Test Plan

Modified existing unit tests.
