### PR TITLE
Make catchpoint generation asynchronous

### DIFF
--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1345,7 +1345,7 @@ func BenchmarkLargeCatchpointWriting(b *testing.B) {
 	require.NoError(b, err)
 
 	b.ResetTimer()
-	au.generateCatchpoint(basics.Round(0), "0#ABCD", crypto.Digest{}, time.Second)
+	au.generateCatchpoint(basics.Round(0), "0#ABCD", crypto.Digest{}, time.Second, nil)
 	b.StopTimer()
 	b.ReportMetric(float64(accountsNumber), "accounts")
 }


### PR DESCRIPTION
## Summary

According to https://www.sqlite.org/isolation.html if
   - DB is opened in WAL mode
   - There are two different connections

then read transaction in connection A sees unchanged DB state
even if connection B writes data in parallel

## Test Plan

Existing test suite