### PR TITLE
testing: disable deadlock for netgoal

### DIFF
--- a/cmd/netgoal/commands.go
+++ b/cmd/netgoal/commands.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/algorand/go-deadlock"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -32,6 +34,8 @@ func init() {
 
 	log.Out = os.Stdout
 	log.SetLevel(logrus.DebugLevel)
+	// disable the deadlock detection for this tool.
+	deadlock.Opts.Disable = true
 }
 
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
## Summary

When creating large networks with bootstrapped databases ( 60m accounts ), the netgoal was failing due to a false-positive deadlock detection. Given that the netgoal is a testing utility, it would be better to turn off these false-positives testing off netgoal.

## Test Plan

Tested manually.