### PR TITLE
DO NOT MERGE - CircleCI Testing Increase Machine Size for Nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ version: 2.1
 orbs:
   win: circleci/windows@2.3.0
   go: circleci/go@1.7.0
-  slack: circleci/slack@4.4.2
 
 workflows:
   version: 2
@@ -27,7 +26,6 @@ workflows:
               only:
                 - /rel\/.*/
                 - /pull\/[0-9]+/
-          context: slack-secrets
       - amd64_integration:
           requires:
             - amd64_build
@@ -44,7 +42,6 @@ workflows:
               only:
                 - /rel\/.*/
                 - /pull\/[0-9]+/
-          context: slack-secrets
       - amd64_e2e_subs:
           requires:
             - amd64_build
@@ -61,7 +58,6 @@ workflows:
               only:
                 - /rel\/.*/
                 - /pull\/[0-9]+/
-          context: slack-secrets
       - arm64_build
       - arm64_test:
           requires:
@@ -79,7 +75,6 @@ workflows:
               only:
                 - /rel\/.*/
                 - /pull\/[0-9]+/
-          context: slack-secrets
       - arm64_integration:
           requires:
             - arm64_build
@@ -96,7 +91,6 @@ workflows:
               only:
                 - /rel\/.*/
                 - /pull\/[0-9]+/
-          context: slack-secrets
       - arm64_e2e_subs:
           requires:
             - arm64_build
@@ -113,7 +107,6 @@ workflows:
               only:
                 - /rel\/.*/
                 - /pull\/[0-9]+/
-          context: slack-secrets
       - mac_amd64_build
       - mac_amd64_test:
           requires:
@@ -131,7 +124,6 @@ workflows:
               only:
                 - /rel\/.*/
                 - /pull\/[0-9]+/
-          context: slack-secrets
       - mac_amd64_integration:
           requires:
             - mac_amd64_build
@@ -148,7 +140,6 @@ workflows:
               only:
                 - /rel\/.*/
                 - /pull\/[0-9]+/
-          context: slack-secrets
       - mac_amd64_e2e_subs:
           requires:
             - mac_amd64_build
@@ -165,7 +156,6 @@ workflows:
               only:
                 - /rel\/.*/
                 - /pull\/[0-9]+/
-          context: slack-secrets
       #- windows_x64_build
 
 commands:
@@ -413,9 +403,6 @@ jobs:
           result_subdir: amd64-nightly
           no_output_timeout: 45m
       - upload_coverage
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
 
   amd64_integration:
     machine:
@@ -442,9 +429,6 @@ jobs:
       - generic_integration:
           result_subdir: amd64-integrationnightly
           no_output_timeout: 45m
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
 
   amd64_e2e_subs:
     machine:
@@ -469,9 +453,6 @@ jobs:
       - generic_integration:
           result_subdir: amd64-e2e_subs_nightly
           no_output_timeout: 45m
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
 
   arm64_build:
     machine:
@@ -507,9 +488,6 @@ jobs:
           result_subdir: arm64-nightly
           no_output_timeout: 45m
       - upload_coverage
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
 
   arm64_integration:
     machine:
@@ -538,9 +516,6 @@ jobs:
       - generic_integration:
           result_subdir: arm64-integration-nightly
           no_output_timeout: 45m
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
 
   arm64_e2e_subs:
     machine:
@@ -567,9 +542,6 @@ jobs:
       - generic_integration:
           result_subdir: arm64-e2e_subs-nightly
           no_output_timeout: 45m
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
 
   mac_amd64_build:
     macos:
@@ -615,9 +587,6 @@ jobs:
           circleci_home: /Users/distiller
           no_output_timeout: 45m
       - upload_coverage
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
 
   mac_amd64_integration:
     macos:
@@ -650,9 +619,6 @@ jobs:
           result_subdir: mac-amd64-integration-nightly
           circleci_home: /Users/distiller
           no_output_timeout: 45m
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
 
   mac_amd64_e2e_subs:
     macos:
@@ -683,9 +649,6 @@ jobs:
           result_subdir: mac-amd64-e2e_subs-nightly
           circleci_home: /Users/distiller
           no_output_timeout: 45m
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
 
   windows_x64_build:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -607,7 +607,7 @@ jobs:
   mac_amd64_integration_nightly:
     macos:
       xcode: 12.0.1
-    resource_class: medium
+    resource_class: large
     parallelism: 4
     environment:
       E2E_TEST_FILTER: "GO"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,7 +420,7 @@ jobs:
   amd64_integration_nightly:
     machine:
       image: ubuntu-2004:202104-01
-    resource_class: medium
+    resource_class: large
     parallelism: 4
     environment:
       E2E_TEST_FILTER: "GO"
@@ -607,7 +607,7 @@ jobs:
   mac_amd64_integration_nightly:
     macos:
       xcode: 12.0.1
-    resource_class: large
+    resource_class: medium
     parallelism: 4
     environment:
       E2E_TEST_FILTER: "GO"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ workflows:
             branches:
               ignore:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
       - amd64_test_nightly:
           requires:
             - amd64_build
@@ -26,7 +26,7 @@ workflows:
             branches:
               only:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
           context: slack-secrets
       - amd64_integration:
           requires:
@@ -35,7 +35,7 @@ workflows:
             branches:
               ignore:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
       - amd64_integration_nightly:
           requires:
             - amd64_build
@@ -43,7 +43,7 @@ workflows:
             branches:
               only:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
           context: slack-secrets
       - amd64_e2e_subs:
           requires:
@@ -52,7 +52,7 @@ workflows:
             branches:
               ignore:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
       - amd64_e2e_subs_nightly:
           requires:
             - amd64_build
@@ -60,7 +60,7 @@ workflows:
             branches:
               only:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
           context: slack-secrets
       - arm64_build
       - arm64_test:
@@ -70,7 +70,7 @@ workflows:
             branches:
               ignore:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
       - arm64_test_nightly:
           requires:
             - arm64_build
@@ -78,7 +78,7 @@ workflows:
             branches:
               only:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
           context: slack-secrets
       - arm64_integration:
           requires:
@@ -87,7 +87,7 @@ workflows:
             branches:
               ignore:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
       - arm64_integration_nightly:
           requires:
             - arm64_build
@@ -95,7 +95,7 @@ workflows:
             branches:
               only:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
           context: slack-secrets
       - arm64_e2e_subs:
           requires:
@@ -104,7 +104,7 @@ workflows:
             branches:
               ignore:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
       - arm64_e2e_subs_nightly:
           requires:
             - arm64_build
@@ -112,7 +112,7 @@ workflows:
             branches:
               only:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
           context: slack-secrets
       - mac_amd64_build
       - mac_amd64_test:
@@ -122,7 +122,7 @@ workflows:
             branches:
               ignore:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
       - mac_amd64_test_nightly:
           requires:
             - mac_amd64_build
@@ -130,7 +130,7 @@ workflows:
             branches:
               only:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
           context: slack-secrets
       - mac_amd64_integration:
           requires:
@@ -139,7 +139,7 @@ workflows:
             branches:
               ignore:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
       - mac_amd64_integration_nightly:
           requires:
             - mac_amd64_build
@@ -147,7 +147,7 @@ workflows:
             branches:
               only:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
           context: slack-secrets
       - mac_amd64_e2e_subs:
           requires:
@@ -156,7 +156,7 @@ workflows:
             branches:
               ignore:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
       - mac_amd64_e2e_subs_nightly:
           requires:
             - mac_amd64_build
@@ -164,7 +164,7 @@ workflows:
             branches:
               only:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - /pull\/[0-9]+/
           context: slack-secrets
       #- windows_x64_build
 
@@ -528,7 +528,7 @@ jobs:
   arm64_integration_nightly:
     machine:
       image: ubuntu-2004:202101-01
-    resource_class: arm.medium
+    resource_class: arm.large
     parallelism: 4
     environment:
       E2E_TEST_FILTER: "GO"
@@ -638,7 +638,7 @@ jobs:
   mac_amd64_integration_nightly:
     macos:
       xcode: 12.0.1
-    resource_class: medium
+    resource_class: large
     parallelism: 4
     environment:
       E2E_TEST_FILTER: "GO"


### PR DESCRIPTION
## Summary

Increase nightly integration tests from "medium" to "large". Nightly tests have been failing consistently with the test introduced in commit #2772 because of slow node startup.

## Test Plan
Check on a PR branch whether it will succeed with a larger machine.
