### PR TITLE
IncomingConnectionsLimit -> 800

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -97,7 +97,8 @@ type Local struct {
 
 	// IncomingConnectionsLimit specifies the max number of long-lived incoming
 	// connections.  0 means no connections allowed.  -1 is unbounded.
-	IncomingConnectionsLimit int `version[0]:"-1" version[1]:"10000"`
+	// Estimating 5MB per incoming connection, 5MB*800 = 4GB
+	IncomingConnectionsLimit int `version[0]:"-1" version[1]:"10000" version[17]:"800"`
 
 	// BroadcastConnectionsLimit specifies the number of connections that
 	// will receive broadcast (gossip) messages from this node.  If the

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -50,7 +50,7 @@
     "ForceFetchTransactions": false,
     "ForceRelayMessages": false,
     "GossipFanout": 4,
-    "IncomingConnectionsLimit": 10000,
+    "IncomingConnectionsLimit": 800,
     "IncomingMessageFilterBucketCount": 5,
     "IncomingMessageFilterBucketSize": 512,
     "IsIndexerActive": false,

--- a/test/testdata/configs/config-v17.json
+++ b/test/testdata/configs/config-v17.json
@@ -50,7 +50,7 @@
     "ForceFetchTransactions": false,
     "ForceRelayMessages": false,
     "GossipFanout": 4,
-    "IncomingConnectionsLimit": 10000,
+    "IncomingConnectionsLimit": 800,
     "IncomingMessageFilterBucketCount": 5,
     "IncomingMessageFilterBucketSize": 512,
     "IsIndexerActive": false,


### PR DESCRIPTION
## Summary

Change incoming connection limit default to 800, which might use ~4GB of RAM given our measured estimate of 5MB per peer.
Prior peer RAM overhead may have been as much as 2MB per peer (but never before actually measured), so the old limit of 10,000 might have been too optimistic.

## Test Plan

Manual testing found this guideline of 5MB per peer.