### PR TITLE
Fix overriding consensus parameters in evaluator.

### DIFF
--- a/ledger/appcow.go
+++ b/ledger/appcow.go
@@ -476,7 +476,7 @@ func MakeDebugBalances(l ledgerForCowBase, round basics.Round, proto protocol.Co
 		UpgradeState: bookkeeping.UpgradeState{CurrentProtocol: proto},
 	}
 	hint := 2
-	cb := makeRoundCowState(base, hdr, prevTimestamp, hint)
+	cb := makeRoundCowState(base, hdr, config.Consensus[proto], prevTimestamp, hint)
 	return cb
 }
 

--- a/ledger/appcow_test.go
+++ b/ledger/appcow_test.go
@@ -195,7 +195,9 @@ func TestCowStorage(t *testing.T) {
 	ml := emptyLedger{}
 	var bh bookkeeping.BlockHeader
 	bh.CurrentProtocol = protocol.ConsensusCurrentVersion
-	cow := makeRoundCowState(&ml, bh, 0, 0)
+	proto, ok := config.Consensus[bh.CurrentProtocol]
+	require.True(t, ok)
+	cow := makeRoundCowState(&ml, bh, proto, 0, 0)
 	allSptrs, allAddrs := randomAddrApps(10)
 
 	st := makeStateTracker()

--- a/ledger/cow.go
+++ b/ledger/cow.go
@@ -78,11 +78,11 @@ type roundCowState struct {
 	trackedCreatables map[int]basics.CreatableIndex
 }
 
-func makeRoundCowState(b roundCowParent, hdr bookkeeping.BlockHeader, prevTimestamp int64, hint int) *roundCowState {
+func makeRoundCowState(b roundCowParent, hdr bookkeeping.BlockHeader, proto config.ConsensusParams, prevTimestamp int64, hint int) *roundCowState {
 	cb := roundCowState{
 		lookupParent:      b,
 		commitParent:      nil,
-		proto:             config.Consensus[hdr.CurrentProtocol],
+		proto:             proto,
 		mods:              ledgercore.MakeStateDelta(&hdr, prevTimestamp, hint, 0),
 		sdeltas:           make(map[basics.Address]map[storagePtr]*storageDelta),
 		trackedCreatables: make(map[int]basics.CreatableIndex),

--- a/ledger/cow_test.go
+++ b/ledger/cow_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
+	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
@@ -113,7 +114,9 @@ func TestCowBalance(t *testing.T) {
 	accts0 := randomAccounts(20, true)
 	ml := mockLedger{balanceMap: accts0}
 
-	c0 := makeRoundCowState(&ml, bookkeeping.BlockHeader{}, config.ConsensusParams{}, 0, 0)
+	c0 := makeRoundCowState(
+		&ml, bookkeeping.BlockHeader{}, config.Consensus[protocol.ConsensusCurrentVersion],
+		0, 0)
 	checkCow(t, c0, accts0)
 
 	c1 := c0.child(0)

--- a/ledger/cow_test.go
+++ b/ledger/cow_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -112,7 +113,7 @@ func TestCowBalance(t *testing.T) {
 	accts0 := randomAccounts(20, true)
 	ml := mockLedger{balanceMap: accts0}
 
-	c0 := makeRoundCowState(&ml, bookkeeping.BlockHeader{}, 0, 0)
+	c0 := makeRoundCowState(&ml, bookkeeping.BlockHeader{}, config.ConsensusParams{}, 0, 0)
 	checkCow(t, c0, accts0)
 
 	c1 := c0.child(0)

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -465,7 +465,7 @@ func startEvaluator(l ledgerForEvaluator, hdr bookkeeping.BlockHeader, proto con
 		eval.block.BlockHeader.RewardsState = eval.prevHeader.NextRewardsState(hdr.Round, proto, incentivePoolData.MicroAlgos, prevTotals.RewardUnits())
 	}
 	// set the eval state with the current header
-	eval.state = makeRoundCowState(base, eval.block.BlockHeader, eval.prevHeader.TimeStamp, paysetHint)
+	eval.state = makeRoundCowState(base, eval.block.BlockHeader, proto, eval.prevHeader.TimeStamp, paysetHint)
 
 	if validate {
 		err := eval.block.BlockHeader.PreCheck(eval.prevHeader)
@@ -1116,7 +1116,14 @@ func (eval *BlockEvaluator) GenerateBlock() (*ValidatedBlock, error) {
 		delta: eval.state.deltas(),
 	}
 	eval.blockGenerated = true
-	eval.state = makeRoundCowState(eval.state, eval.block.BlockHeader, eval.prevHeader.TimeStamp, len(eval.block.Payset))
+	proto, ok := config.Consensus[eval.block.BlockHeader.CurrentProtocol]
+	if !ok {
+		return nil, fmt.Errorf(
+			"unknown consensus version: %s", eval.block.BlockHeader.CurrentProtocol)
+	}
+	eval.state = makeRoundCowState(
+		eval.state, eval.block.BlockHeader, proto, eval.prevHeader.TimeStamp,
+		len(eval.block.Payset))
 	return &vb, nil
 }
 

--- a/ledger/eval_test.go
+++ b/ledger/eval_test.go
@@ -347,7 +347,7 @@ func TestPrepareEvalParams(t *testing.T) {
 	}
 
 	params := []config.ConsensusParams{
-		config.ConsensusParams{Application: true, MaxAppProgramCost: 700},
+		{Application: true, MaxAppProgramCost: 700},
 		config.Consensus[protocol.ConsensusV29],
 		config.Consensus[protocol.ConsensusFuture],
 	}
@@ -856,7 +856,7 @@ func TestCowCompactCert(t *testing.T) {
 	blocks := make(map[basics.Round]bookkeeping.BlockHeader)
 	blockErr := make(map[basics.Round]error)
 	ml := mockLedger{balanceMap: accts0, blocks: blocks, blockErr: blockErr}
-	c0 := makeRoundCowState(&ml, bookkeeping.BlockHeader{}, 0, 0)
+	c0 := makeRoundCowState(&ml, bookkeeping.BlockHeader{}, config.ConsensusParams{}, 0, 0)
 
 	certType = protocol.CompactCertType(1234) // bad cert type
 	err := c0.compactCert(certRnd, certType, cert, atRound, validate)
@@ -1401,4 +1401,101 @@ func TestModifiedAppLocalStates(t *testing.T) {
 		require.True(t, ok)
 		assert.False(t, created)
 	}
+}
+
+// Test that overriding the consensus parameters effects the generated apply data.
+func TestCustomProtocolParams(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	genesisBalances, addrs, _ := newTestGenesis()
+
+	var genHash crypto.Digest
+	crypto.RandBytes(genHash[:])
+	block, err := bookkeeping.MakeGenesisBlock(protocol.ConsensusV24,
+		genesisBalances, "test", genHash)
+
+	dbName := fmt.Sprintf("%s", t.Name())
+	cfg := config.GetDefaultLocal()
+	cfg.Archival = true
+	l, err := OpenLedger(logging.Base(), dbName, true, InitState{
+		Block:       block,
+		Accounts:    genesisBalances.Balances,
+		GenesisHash: genHash,
+	}, cfg)
+	require.NoError(t, err)
+	defer l.Close()
+
+	const assetid basics.AssetIndex = 1
+	proto := config.Consensus[protocol.ConsensusV24]
+
+	block = bookkeeping.MakeBlock(block.BlockHeader)
+
+	createTxn := txntest.Txn{
+		Type:        "acfg",
+		Sender:      addrs[0],
+		GenesisHash: block.GenesisHash(),
+		AssetParams: basics.AssetParams{
+			Total:    200,
+			Decimals: 0,
+			Manager:  addrs[0],
+			Reserve:  addrs[0],
+			Freeze:   addrs[0],
+			Clawback: addrs[0],
+		},
+	}
+	createTxn.FillDefaults(proto)
+	createStib, err := block.BlockHeader.EncodeSignedTxn(
+		createTxn.SignedTxn(), transactions.ApplyData{})
+	require.NoError(t, err)
+
+	optInTxn := txntest.Txn{
+		Type:          "axfer",
+		Sender:        addrs[1],
+		GenesisHash:   block.GenesisHash(),
+		XferAsset:     assetid,
+		AssetAmount:   0,
+		AssetReceiver: addrs[1],
+	}
+	optInTxn.FillDefaults(proto)
+	optInStib, err := block.BlockHeader.EncodeSignedTxn(
+		optInTxn.SignedTxn(), transactions.ApplyData{})
+	require.NoError(t, err)
+
+	fundTxn := txntest.Txn{
+		Type:          "axfer",
+		Sender:        addrs[0],
+		GenesisHash:   block.GenesisHash(),
+		XferAsset:     assetid,
+		AssetAmount:   100,
+		AssetReceiver: addrs[1],
+	}
+	fundTxn.FillDefaults(proto)
+	fundStib, err := block.BlockHeader.EncodeSignedTxn(
+		fundTxn.SignedTxn(), transactions.ApplyData{})
+	require.NoError(t, err)
+
+	optOutTxn := txntest.Txn{
+		Type:          "axfer",
+		Sender:        addrs[1],
+		GenesisHash:   block.GenesisHash(),
+		XferAsset:     assetid,
+		AssetAmount:   30,
+		AssetReceiver: addrs[0],
+		AssetCloseTo:  addrs[0],
+	}
+	optOutTxn.FillDefaults(proto)
+	optOutStib, err := block.BlockHeader.EncodeSignedTxn(
+		optOutTxn.SignedTxn(), transactions.ApplyData{})
+	require.NoError(t, err)
+
+	block.Payset = []transactions.SignedTxnInBlock{
+		createStib, optInStib, fundStib, optOutStib,
+	}
+
+	proto.EnableAssetCloseAmount = true
+	_, modifiedTxns, err := Eval(l, &block, proto)
+	require.NoError(t, err)
+
+	require.Equal(t, 4, len(modifiedTxns))
+	assert.Equal(t, uint64(70), modifiedTxns[3].AssetClosingAmount)
 }

--- a/ledger/eval_test.go
+++ b/ledger/eval_test.go
@@ -856,7 +856,9 @@ func TestCowCompactCert(t *testing.T) {
 	blocks := make(map[basics.Round]bookkeeping.BlockHeader)
 	blockErr := make(map[basics.Round]error)
 	ml := mockLedger{balanceMap: accts0, blocks: blocks, blockErr: blockErr}
-	c0 := makeRoundCowState(&ml, bookkeeping.BlockHeader{}, config.ConsensusParams{}, 0, 0)
+	c0 := makeRoundCowState(
+		&ml, bookkeeping.BlockHeader{}, config.Consensus[protocol.ConsensusCurrentVersion],
+		0, 0)
 
 	certType = protocol.CompactCertType(1234) // bad cert type
 	err := c0.compactCert(certRnd, certType, cert, atRound, validate)


### PR DESCRIPTION
## Summary

We failed to override the consensus parameters in COW. This PR fixes it. Background: overriding of consensus parameters is used by Indexer to retrieve the asset close amount of a transaction even when the protocol doesn't support it.

## Test Plan

Add a unit test.