### PR TITLE
Simplify `startEvaluator()`

### DIFF
--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -383,6 +383,16 @@ func (l *Ledger) StartEvaluator(hdr bookkeeping.BlockHeader, paysetHint int) (*B
 }
 
 func startEvaluator(l ledgerForEvaluator, hdr bookkeeping.BlockHeader, proto config.ConsensusParams, paysetHint int, validate bool, generate bool) (*BlockEvaluator, error) {
+	if hdr.Round == 0 {
+		return nil, fmt.Errorf("cannot start evaluator for round 0")
+	}
+
+	prevHeader, err := l.BlockHdr(hdr.Round - 1)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"can't evaluate block %v without previous header: %v", hdr.Round, err)
+	}
+
 	base := &roundCowBase{
 		l: l,
 		// round that lookups come from is previous block.  We validate
@@ -390,6 +400,7 @@ func startEvaluator(l ledgerForEvaluator, hdr bookkeeping.BlockHeader, proto con
 		// If we are not validating, we must have previously checked
 		// an agreement.Certificate attesting that hdr is valid.
 		rnd:      hdr.Round - 1,
+		txnCount: prevHeader.TxnCounter,
 		proto:    proto,
 		accounts: make(map[basics.Address]basics.AccountData),
 	}
@@ -397,6 +408,7 @@ func startEvaluator(l ledgerForEvaluator, hdr bookkeeping.BlockHeader, proto con
 	eval := &BlockEvaluator{
 		validate:    validate,
 		generate:    generate,
+		prevHeader:  prevHeader,
 		block:       bookkeeping.Block{BlockHeader: hdr},
 		proto:       proto,
 		genesisHash: l.GenesisHash(),
@@ -412,35 +424,23 @@ func startEvaluator(l ledgerForEvaluator, hdr bookkeeping.BlockHeader, proto con
 		eval.block.Payset = make([]transactions.SignedTxnInBlock, 0, paysetHint)
 	}
 
-	prevProto := proto
+	base.compactCertNextRnd = eval.prevHeader.CompactCert[protocol.CompactCertBasic].CompactCertNextRound
 
-	if hdr.Round > 0 {
-		var err error
-		eval.prevHeader, err = l.BlockHdr(base.rnd)
-		if err != nil {
-			return nil, fmt.Errorf("can't evaluate block %v without previous header: %v", hdr.Round, err)
-		}
+	prevProto, ok := config.Consensus[prevHeader.CurrentProtocol]
+	if !ok {
+		return nil, protocol.Error(prevHeader.CurrentProtocol)
+	}
 
-		base.txnCount = eval.prevHeader.TxnCounter
-		base.compactCertNextRnd = eval.prevHeader.CompactCert[protocol.CompactCertBasic].CompactCertNextRound
+	// Check if compact certs are being enabled as of this block.
+	if base.compactCertNextRnd == 0 && proto.CompactCertRounds != 0 {
+		// Determine the first block that will contain a Merkle
+		// commitment to the voters.  We need to account for the
+		// fact that the voters come from CompactCertVotersLookback
+		// rounds ago.
+		votersRound := (hdr.Round + basics.Round(proto.CompactCertVotersLookback)).RoundUpToMultipleOf(basics.Round(proto.CompactCertRounds))
 
-		var ok bool
-		prevProto, ok = config.Consensus[eval.prevHeader.CurrentProtocol]
-		if !ok {
-			return nil, protocol.Error(eval.prevHeader.CurrentProtocol)
-		}
-
-		// Check if compact certs are being enabled as of this block.
-		if base.compactCertNextRnd == 0 && proto.CompactCertRounds != 0 {
-			// Determine the first block that will contain a Merkle
-			// commitment to the voters.  We need to account for the
-			// fact that the voters come from CompactCertVotersLookback
-			// rounds ago.
-			votersRound := (hdr.Round + basics.Round(proto.CompactCertVotersLookback)).RoundUpToMultipleOf(basics.Round(proto.CompactCertRounds))
-
-			// The first compact cert will appear CompactCertRounds after that.
-			base.compactCertNextRnd = votersRound + basics.Round(proto.CompactCertRounds)
-		}
+		// The first compact cert will appear CompactCertRounds after that.
+		base.compactCertNextRnd = votersRound + basics.Round(proto.CompactCertRounds)
 	}
 
 	prevTotals, err := l.Totals(eval.prevHeader.Round)


### PR DESCRIPTION
## Summary

The current code creates an impression that the evaluator can be used for round 0 which is not true. This PR simplifies the code, so this is more evident.

## Test Plan

Relying on existing tests.