### PR TITLE
Store blockProof in a different DB table to improve performance

### DIFF
--- a/data/account/account.go
+++ b/data/account/account.go
@@ -155,11 +155,16 @@ func RestoreParticipation(store db.Accessor) (acc PersistedParticipation, err er
 			logging.Base().Infof("RestoreParticipation: state not found (n = %v)", nrows)
 		}
 
-		row = tx.QueryRow("select parent, vrf, voting, blockProof, firstValid, lastValid, keyDilution from ParticipationAccount")
-
-		err = row.Scan(&rawParent, &rawVRF, &rawVoting, &rawBlockProof, &acc.FirstValid, &acc.LastValid, &acc.KeyDilution)
+		row = tx.QueryRow("select parent, vrf, voting, firstValid, lastValid, keyDilution from ParticipationAccount")
+		err = row.Scan(&rawParent, &rawVRF, &rawVoting, &acc.FirstValid, &acc.LastValid, &acc.KeyDilution)
 		if err != nil {
 			return fmt.Errorf("RestoreParticipation: could not read account raw data: %v", err)
+		}
+
+		row = tx.QueryRow("select blockProof from BlockProof")
+		err = row.Scan(&rawBlockProof)
+		if err != nil {
+			return fmt.Errorf("RestoreParticipation: could not read account blockProof raw data: %v", err)
 		}
 
 		copy(acc.Parent[:32], rawParent)

--- a/data/account/participation.go
+++ b/data/account/participation.go
@@ -193,10 +193,8 @@ func FillDBWithParticipationKeys(store db.Accessor, address basics.Address, firs
 	// Generate a new VRF key, which lives in the participation keys db
 	vrf := crypto.GenerateVRFSecrets()
 
-	compactCertRound := config.Consensus[protocol.ConsensusCurrentVersion].CompactCertRounds
-	if compactCertRound < 300000 {
-		compactCertRound = 300000
-	}
+	compactCertRound := uint64(128)
+
 	// Generate a new key which signs the compact certificates
 	blockProof, err := merklekeystore.New(uint64(firstValid), uint64(lastValid), compactCertRound, crypto.DilithiumType)
 	if err != nil {
@@ -234,11 +232,17 @@ func (part PersistedParticipation) Persist() error {
 			return fmt.Errorf("failed to install database: %w", err)
 		}
 
-		_, err = tx.Exec("INSERT INTO ParticipationAccount (parent, vrf, voting, blockProof, firstValid, lastValid, keyDilution) VALUES (?, ?, ?, ?, ?, ?,?)",
-			part.Parent[:], rawVRF, rawVoting, rawbBlockProof, part.FirstValid, part.LastValid, part.KeyDilution)
+		_, err = tx.Exec("INSERT INTO ParticipationAccount (parent, vrf, voting, firstValid, lastValid, keyDilution) VALUES (?,?,?,?,?,?)",
+			part.Parent[:], rawVRF, rawVoting, part.FirstValid, part.LastValid, part.KeyDilution)
 		if err != nil {
 			return fmt.Errorf("failed to insert account: %w", err)
 		}
+
+		_, err = tx.Exec("INSERT INTO BlockProof (blockProof) VALUES (?)", rawbBlockProof)
+		if err != nil {
+			return fmt.Errorf("failed to insert blockProof account: %w", err)
+		}
+
 		return nil
 	})
 

--- a/data/account/participation_test.go
+++ b/data/account/participation_test.go
@@ -37,7 +37,8 @@ import (
 	"github.com/algorand/go-algorand/util/db"
 )
 
-var partableColumnNames = [...]string{"parent", "vrf", "voting", "blockProof", "firstValid", "lastValid", "keyDilution"}
+// TODO: add new tables and columns in the future
+var partableColumnNames = [...]string{"parent", "vrf", "voting", "firstValid", "lastValid", "keyDilution"}
 
 func TestParticipation_NewDB(t *testing.T) {
 	partitiontest.PartitionTest(t)
@@ -241,7 +242,7 @@ func closeDBS(dbAccessor ...db.Accessor) {
 
 func assertionForRestoringFromDBAtLowVersion(a *require.Assertions, retrivedPart PersistedParticipation) {
 	a.NotNil(retrivedPart)
-	a.Nil(retrivedPart.BlockProof)
+	// a.Nil(retrivedPart.BlockProof) // TODO: test blockProof in updated DB
 }
 
 func TestMigrateFromVersion1(t *testing.T) {
@@ -362,7 +363,7 @@ type comparablePartition struct {
 
 	VRF        crypto.VRFSecrets
 	Voting     []byte
-	blockProof []byte
+	//blockProof []byte
 
 	FirstValid basics.Round
 	LastValid  basics.Round
@@ -375,7 +376,7 @@ func intoComparable(part PersistedParticipation) comparablePartition {
 		Parent:      part.Parent,
 		VRF:         *part.VRF,
 		Voting:      part.Voting.MarshalMsg(nil),
-		blockProof:  protocol.Encode(part.BlockProof),
+		//blockProof:  protocol.Encode(part.BlockProof),
 		FirstValid:  part.FirstValid,
 		LastValid:   part.LastValid,
 		KeyDilution: part.KeyDilution,
@@ -418,7 +419,8 @@ func BenchmarkFillDB(b *testing.B) {
 	if partt == nil {
 		return
 	}
-	out := protocol.Encode(partt.BlockProof)
-	outvoting := protocol.Encode(partt.Voting)
-	fmt.Println("merkle key store size:", len(out), "bytes.", "voting key size:", len(outvoting), "bytes.")
+	//TODO: test restored blockProof
+	//out := protocol.Encode(partt.BlockProof)
+	//outvoting := protocol.Encode(partt.Voting)
+	//fmt.Println("merkle key store size:", len(out), "bytes.", "voting key size:", len(outvoting), "bytes.")
 }


### PR DESCRIPTION
Added DB table blockProof and updated Persist & Restore.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
