### PR TITLE
txnsync: bloom filter refactoring

### DIFF
--- a/txnsync/bloomFilter_test.go
+++ b/txnsync/bloomFilter_test.go
@@ -314,9 +314,20 @@ func TestBloomFilterTest(t *testing.T) {
 
 		testableBf, err := decodeBloomFilter(enc)
 		require.NoError(t, err)
-		for _, tx := range txnGroups {
-			ans := testableBf.test(tx.GroupTransactionID)
-			require.True(t, ans)
+
+		for testableBf.encodingParams.Modulator = 0; testableBf.encodingParams.Modulator < 7; testableBf.encodingParams.Modulator++ {
+			for testableBf.encodingParams.Offset = 0; testableBf.encodingParams.Offset < testableBf.encodingParams.Modulator; testableBf.encodingParams.Offset++ {
+				for _, tx := range txnGroups {
+					ans := testableBf.test(tx.GroupTransactionID)
+					expected := true
+					if testableBf.encodingParams.Modulator > 1 {
+						if txidToUint64(tx.GroupTransactionID)%uint64(testableBf.encodingParams.Modulator) != uint64(testableBf.encodingParams.Offset) {
+							expected = false
+						}
+					}
+					require.Equal(t, expected, ans)
+				}
+			}
 		}
 	}
 

--- a/txnsync/bloomFilter_test.go
+++ b/txnsync/bloomFilter_test.go
@@ -233,6 +233,7 @@ func TestHint(t *testing.T) {
 	}
 }
 
+/*
 // TestEncodingDecoding checks the encoding/decoding of the filters
 func TestEncodingDecoding(t *testing.T) {
 	partitiontest.PartitionTest(t)
@@ -266,14 +267,14 @@ func TestEncodingDecoding(t *testing.T) {
 			require.Equal(t, encoded, encodedAgain)
 		}
 	}
-}
+}*/
 
 func TestDecodingErrors(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	bf, err := decodeBloomFilter(encodedBloomFilter{})
 	require.Equal(t, errInvalidBloomFilterEncoding, err)
-	require.Equal(t, bloomFilter{}, bf)
+	require.Equal(t, (*testableBloomFilter)(nil), bf)
 
 	var ebf encodedBloomFilter
 	ebf.BloomFilterType = byte(multiHashBloomFilter)
@@ -282,6 +283,7 @@ func TestDecodingErrors(t *testing.T) {
 	require.Error(t, err)
 }
 
+/*
 func TestBloomFilterTest(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
@@ -316,7 +318,7 @@ func TestBloomFilterTest(t *testing.T) {
 	}
 	var bf bloomFilter
 	require.False(t, bf.test(transactions.Txid{1}))
-}
+}*/
 
 type justRandomFakeNode struct {
 }

--- a/txnsync/exchange.go
+++ b/txnsync/exchange.go
@@ -44,7 +44,6 @@ type encodedBloomFilter struct {
 
 	BloomFilterType byte          `codec:"t"`
 	EncodingParams  requestParams `codec:"p"`
-	Shuffler        byte          `codec:"s"`
 	BloomFilter     []byte        `codec:"f,allocbound=maxBloomFilterSize"`
 }
 

--- a/txnsync/incoming.go
+++ b/txnsync/incoming.go
@@ -38,7 +38,7 @@ type incomingMessage struct {
 	sequenceNumber    uint64
 	peer              *Peer
 	encodedSize       int
-	bloomFilter       bloomFilter
+	bloomFilter       *testableBloomFilter
 	transactionGroups []pooldata.SignedTxGroup
 }
 
@@ -242,7 +242,7 @@ incomingMessageLoop:
 		}
 
 		// if the peer sent us a bloom filter, store this.
-		if (incomingMsg.bloomFilter != bloomFilter{}) {
+		if incomingMsg.bloomFilter != nil {
 			peer.addIncomingBloomFilter(incomingMsg.message.Round, incomingMsg.bloomFilter, s.round)
 		}
 

--- a/txnsync/incoming.go
+++ b/txnsync/incoming.go
@@ -133,7 +133,7 @@ func (s *syncState) asyncIncomingMessageHandler(networkPeer interface{}, peer *P
 	}
 
 	// if the peer sent us a bloom filter, decode it
-	if incomingMessage.message.TxnBloomFilter.BloomFilterType != 0 {
+	if !incomingMessage.message.TxnBloomFilter.MsgIsZero() {
 		bloomFilter, err := decodeBloomFilter(incomingMessage.message.TxnBloomFilter)
 		if err != nil {
 			s.log.Infof("Invalid bloom filter received from peer : %v", err)

--- a/txnsync/incoming_test.go
+++ b/txnsync/incoming_test.go
@@ -222,7 +222,7 @@ func TestEvaluateIncomingMessagePart2(t *testing.T) {
 	err = peer.incomingMessages.enqueue(
 		incomingMessage{
 			sequenceNumber: 3,
-			bloomFilter:    bloomFilter{filterType: xorBloomFilter32},
+			bloomFilter:    &testableBloomFilter{encodingParams: requestParams{Offset: 8}},
 			message:        transactionBlockMessage{Round: 4}})
 	require.NoError(t, err)
 
@@ -241,7 +241,7 @@ func TestEvaluateIncomingMessagePart2(t *testing.T) {
 	// receive a message not in order
 	s.evaluateIncomingMessage(incomingMessage{sequenceNumber: 11})
 	require.Equal(t, "received message out of order; seq = 11, expecting seq = 5\n", incLogger.lastLogged)
-	require.Equal(t, xorBloomFilter32, peer.recentIncomingBloomFilters[0].filter.filterType)
+	require.Equal(t, uint8(8), peer.recentIncomingBloomFilters[0].filter.encodingParams.Offset)
 
 	// currentTransactionPoolSize is -1
 	peer.incomingMessages = messageOrderingHeap{}

--- a/txnsync/msgorderingheap_test.go
+++ b/txnsync/msgorderingheap_test.go
@@ -111,6 +111,7 @@ func TestPopSequence(t *testing.T) {
 	_, heapSeqNum, err := heap.popSequence(3)
 	a.Equal(heap.Len(), messageOrderingHeapLimit)
 	a.Equal(heapSeqNum, uint64(0), errSequenceNumberMismatch)
+	a.Error(err, errSequenceNumberMismatch)
 
 	msg, heapSeqNum, err := heap.popSequence(0)
 
@@ -118,7 +119,7 @@ func TestPopSequence(t *testing.T) {
 	a.Equal(heap.Len(), messageOrderingHeapLimit-1)
 	a.Equal(msg.sequenceNumber, uint64(0))
 	a.Equal(heapSeqNum, uint64(0))
-	a.Nil(err)
+	a.NoError(err)
 
 }
 

--- a/txnsync/msgp_gen.go
+++ b/txnsync/msgp_gen.go
@@ -6194,8 +6194,8 @@ func (z *encodedAssetTransferTxnFields) MsgIsZero() bool {
 func (z *encodedBloomFilter) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0001Len := uint32(4)
-	var zb0001Mask uint8 /* 5 bits */
+	zb0001Len := uint32(3)
+	var zb0001Mask uint8 /* 4 bits */
 	if len((*z).BloomFilter) == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x2
@@ -6204,13 +6204,9 @@ func (z *encodedBloomFilter) MarshalMsg(b []byte) (o []byte) {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if (*z).Shuffler == 0 {
-		zb0001Len--
-		zb0001Mask |= 0x8
-	}
 	if (*z).BloomFilterType == 0 {
 		zb0001Len--
-		zb0001Mask |= 0x10
+		zb0001Mask |= 0x8
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -6248,11 +6244,6 @@ func (z *encodedBloomFilter) MarshalMsg(b []byte) (o []byte) {
 			}
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
-			// string "s"
-			o = append(o, 0xa1, 0x73)
-			o = msgp.AppendByte(o, (*z).Shuffler)
-		}
-		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "t"
 			o = append(o, 0xa1, 0x74)
 			o = msgp.AppendByte(o, (*z).BloomFilterType)
@@ -6357,14 +6348,6 @@ func (z *encodedBloomFilter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 					}
 				}
-			}
-		}
-		if zb0001 > 0 {
-			zb0001--
-			(*z).Shuffler, bts, err = msgp.ReadByteBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "Shuffler")
-				return
 			}
 		}
 		if zb0001 > 0 {
@@ -6484,12 +6467,6 @@ func (z *encodedBloomFilter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 					}
 				}
-			case "s":
-				(*z).Shuffler, bts, err = msgp.ReadByteBytes(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "Shuffler")
-					return
-				}
 			case "f":
 				var zb0008 int
 				zb0008, err = msgp.ReadBytesBytesHeader(bts)
@@ -6526,13 +6503,13 @@ func (_ *encodedBloomFilter) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *encodedBloomFilter) Msgsize() (s int) {
-	s = 1 + 2 + msgp.ByteSize + 2 + 1 + 2 + msgp.ByteSize + 2 + msgp.ByteSize + 2 + msgp.ByteSize + 2 + msgp.BytesPrefixSize + len((*z).BloomFilter)
+	s = 1 + 2 + msgp.ByteSize + 2 + 1 + 2 + msgp.ByteSize + 2 + msgp.ByteSize + 2 + msgp.BytesPrefixSize + len((*z).BloomFilter)
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *encodedBloomFilter) MsgIsZero() bool {
-	return ((*z).BloomFilterType == 0) && (((*z).EncodingParams.Offset == 0) && ((*z).EncodingParams.Modulator == 0)) && ((*z).Shuffler == 0) && (len((*z).BloomFilter) == 0)
+	return ((*z).BloomFilterType == 0) && (((*z).EncodingParams.Offset == 0) && ((*z).EncodingParams.Modulator == 0)) && (len((*z).BloomFilter) == 0)
 }
 
 // MarshalMsg implements msgp.Marshaler

--- a/txnsync/outgoing.go
+++ b/txnsync/outgoing.go
@@ -209,11 +209,9 @@ func (s *syncState) assemblePeerMessage(peer *Peer, pendingTransactions *pending
 		profMakeBloomFilter.start()
 		// generate a bloom filter that matches the requests params.
 		metaMessage.filter = s.makeBloomFilter(metaMessage.message.UpdatedRequestParams, pendingTransactions.pendingTransactionsGroups, lastBloomFilter)
-		if !metaMessage.filter.sameParams(peer.lastSentBloomFilter) {
-			if bf, _ := metaMessage.filter.encode(); bf != nil {
-				metaMessage.message.TxnBloomFilter = *bf
-				bloomFilterSize = metaMessage.message.TxnBloomFilter.Msgsize()
-			}
+		if !metaMessage.filter.sameParams(peer.lastSentBloomFilter) && metaMessage.filter.encodedLength > 0 {
+			metaMessage.message.TxnBloomFilter = metaMessage.filter.encoded
+			bloomFilterSize = metaMessage.filter.encodedLength
 		}
 		profMakeBloomFilter.end()
 		s.lastBloomFilter = metaMessage.filter

--- a/txnsync/peer.go
+++ b/txnsync/peer.go
@@ -86,7 +86,7 @@ const (
 // incomingBloomFilter stores an incoming bloom filter, along with the associated round number.
 // the round number allow us to prune filters from rounds n-2 and below.
 type incomingBloomFilter struct {
-	filter bloomFilter
+	filter *testableBloomFilter
 	round  basics.Round
 }
 
@@ -138,7 +138,8 @@ type Peer struct {
 	lastSentMessageTimestamp time.Duration
 	// lastSentMessageSize is the encoded message size of the last sent message
 	lastSentMessageSize int
-	// lastSentBloomFilter is the last bloom filter that was sent to this peer. This bloom filter could be stale if no bloom filter was included in the last message.
+	// lastSentBloomFilter is the last bloom filter that was sent to this peer.
+	// This bloom filter could be stale if no bloom filter was included in the last message.
 	lastSentBloomFilter bloomFilter
 
 	// lastConfirmedMessageSeqReceived is the last message sequence number that was confirmed by the peer to have been accepted.
@@ -492,7 +493,7 @@ func incomingPeersOnly(peers []*Peer) (incomingPeers []*Peer) {
 
 // incoming related functions
 
-func (p *Peer) addIncomingBloomFilter(round basics.Round, incomingFilter bloomFilter, currentRound basics.Round) {
+func (p *Peer) addIncomingBloomFilter(round basics.Round, incomingFilter *testableBloomFilter, currentRound basics.Round) {
 	bf := incomingBloomFilter{
 		round:  round,
 		filter: incomingFilter,

--- a/txnsync/peer_test.go
+++ b/txnsync/peer_test.go
@@ -653,16 +653,13 @@ func TestAddIncomingBloomFilter(t *testing.T) {
 	p := makePeer(nil, true, true, &config)
 
 	for i := 0; i < 2*maxIncomingBloomFilterHistory; i++ {
-		bf := bloomFilter{
+		bf := &testableBloomFilter{
 			encodingParams: requestParams{
 				_struct:   struct{}{},
 				Offset:    byte(i),
 				Modulator: 0,
 			},
-			filter:             nil,
-			containedTxnsRange: transactionsRange{},
-			encoded:            nil,
-			filterType:         0,
+			filter: nil,
 		}
 		p.addIncomingBloomFilter(basics.Round(i), bf, basics.Round(i))
 	}
@@ -670,16 +667,13 @@ func TestAddIncomingBloomFilter(t *testing.T) {
 	a.Equal(len(p.recentIncomingBloomFilters), 2)
 
 	for i := 0; i < 2*maxIncomingBloomFilterHistory; i++ {
-		bf := bloomFilter{
+		bf := &testableBloomFilter{
 			encodingParams: requestParams{
 				_struct:   struct{}{},
 				Offset:    byte(i),
 				Modulator: 0,
 			},
-			filter:             nil,
-			containedTxnsRange: transactionsRange{},
-			encoded:            nil,
-			filterType:         0,
+			filter: nil,
 		}
 		p.addIncomingBloomFilter(basics.Round(i), bf, 0)
 	}

--- a/txnsync/txngroups_test.go
+++ b/txnsync/txngroups_test.go
@@ -310,7 +310,7 @@ func BenchmarkTxnGroupCompression(b *testing.B) {
 		require.Equal(b, compressionFormat, compressionFormatDeflate)
 		size = len(compressedGroupBytes)
 	}
-	loopDuration := time.Now().Sub(loopStartTime)
+	loopDuration := time.Since(loopStartTime)
 	b.StopTimer()
 	b.ReportMetric(float64(len(ptg.Bytes)*b.N)/loopDuration.Seconds(), "estimatedGzipCompressionSpeed")
 	b.ReportMetric(float64(len(ptg.Bytes)-size)/float64(len(ptg.Bytes)), "estimatedGzipCompressionGains")


### PR DESCRIPTION
## Summary

Refactor the bloom filter implementation to have two "implementations" : `testableBloomFilter` and `bloomFilter`.

`testableBloomFilter` is used exclusively when being received from the network; it does not contain any encoded
fields, nor does it include `transactionsRange` which is used for generating new bloom filters.

 `bloomFilter` on the flip side is used only for outgoing bloom filters. It doesn't support `testing`, and it contains only the encoded bloom filter ( and not the underlying bloom filter needed for testing, for instance ).

This separation allows us to ensure we don't store bloom filter object beyond the required scope, improving the memory utilization.

## Test Plan

This PR does not introduce any new functionality. The existing unit tests were updated to use the updated constructs.
