### PR TITLE
Use byte type for group indexes

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -796,7 +796,7 @@ var signCmd = &cobra.Command{
 				var signedTxn transactions.SignedTxn
 				if lsig.Logic != nil {
 					txn.Lsig = lsig
-					err = verify.LogicSigSanityCheck(&txn, i, groupCtx)
+					err = verify.LogicSigSanityCheck(&txn, byte(i), groupCtx)
 					if err != nil {
 						reportErrorf("%s: txn[%d] error %s", txFilename, txnIndex[txnGroups[group][i]], err)
 					}
@@ -1087,7 +1087,7 @@ var dryrunCmd = &cobra.Command{
 			if uint64(txn.Lsig.Len()) > params.LogicSigMaxSize {
 				reportErrorf("program size too large: %d > %d", len(txn.Lsig.Logic), params.LogicSigMaxSize)
 			}
-			ep := logic.EvalParams{Txn: &txn, Proto: &params, GroupIndex: i, TxnGroup: txgroup}
+			ep := logic.EvalParams{Txn: &txn, Proto: &params, GroupIndex: byte(i), TxnGroup: txgroup}
 			err := logic.Check(txn.Lsig.Logic, ep)
 			if err != nil {
 				reportErrorf("program failed Check: %s", err)
@@ -1095,7 +1095,7 @@ var dryrunCmd = &cobra.Command{
 			sb := strings.Builder{}
 			ep = logic.EvalParams{
 				Txn:        &txn,
-				GroupIndex: i,
+				GroupIndex: byte(i),
 				Proto:      &params,
 				Trace:      &sb,
 				TxnGroup:   txgroup,

--- a/cmd/tealdbg/local.go
+++ b/cmd/tealdbg/local.go
@@ -209,7 +209,7 @@ type evaluation struct {
 	source          string
 	offsetToLine    map[int]int
 	name            string
-	groupIndex      int
+	groupIndex      byte
 	pastSideEffects []logic.EvalSideEffects
 	mode            modeType
 	aidx            basics.AppIndex
@@ -357,7 +357,7 @@ func (r *LocalRunner) Setup(dp *DebugParams) (err error) {
 			err = fmt.Errorf("invalid group index %d for a single transaction", dp.GroupIndex)
 			return
 		}
-		if len(r.txnGroup) > 0 && dp.GroupIndex >= len(r.txnGroup) {
+		if len(r.txnGroup) > 0 && int(dp.GroupIndex) >= len(r.txnGroup) {
 			err = fmt.Errorf("invalid group index %d for a txn in a transaction group of %d", dp.GroupIndex, len(r.txnGroup))
 			return
 		}
@@ -431,7 +431,7 @@ func (r *LocalRunner) Setup(dp *DebugParams) (err error) {
 		if len(stxn.Lsig.Logic) > 0 {
 			run := evaluation{
 				program:    stxn.Lsig.Logic,
-				groupIndex: gi,
+				groupIndex: byte(gi),
 				mode:       modeLogicsig,
 			}
 			r.runs = append(r.runs, run)
@@ -443,7 +443,7 @@ func (r *LocalRunner) Setup(dp *DebugParams) (err error) {
 				if len(stxn.Txn.ApprovalProgram) > 0 {
 					appIdx = basics.AppIndex(dp.AppID)
 					b, states, err = makeBalancesAdapter(
-						balances, r.txnGroup, gi,
+						balances, r.txnGroup, byte(gi),
 						r.protoName, dp.Round, dp.LatestTimestamp,
 						appIdx, dp.Painless, dp.IndexerURL, dp.IndexerToken,
 					)
@@ -452,7 +452,7 @@ func (r *LocalRunner) Setup(dp *DebugParams) (err error) {
 					}
 					run := evaluation{
 						program:         stxn.Txn.ApprovalProgram,
-						groupIndex:      gi,
+						groupIndex:      byte(gi),
 						pastSideEffects: dp.PastSideEffects,
 						mode:            modeStateful,
 						aidx:            appIdx,
@@ -479,7 +479,7 @@ func (r *LocalRunner) Setup(dp *DebugParams) (err error) {
 								return
 							}
 							b, states, err = makeBalancesAdapter(
-								balances, r.txnGroup, gi,
+								balances, r.txnGroup, byte(gi),
 								r.protoName, dp.Round, dp.LatestTimestamp,
 								appIdx, dp.Painless, dp.IndexerURL, dp.IndexerToken,
 							)
@@ -488,7 +488,7 @@ func (r *LocalRunner) Setup(dp *DebugParams) (err error) {
 							}
 							run := evaluation{
 								program:         program,
-								groupIndex:      gi,
+								groupIndex:      byte(gi),
 								pastSideEffects: dp.PastSideEffects,
 								mode:            modeStateful,
 								aidx:            appIdx,

--- a/cmd/tealdbg/localLedger.go
+++ b/cmd/tealdbg/localLedger.go
@@ -60,7 +60,7 @@ type ApplicationIndexerResponse struct {
 type localLedger struct {
 	balances        map[basics.Address]basics.AccountData
 	txnGroup        []transactions.SignedTxn
-	groupIndex      int
+	groupIndex      byte
 	round           uint64
 	aidx            basics.AppIndex
 	latestTimestamp int64
@@ -68,11 +68,11 @@ type localLedger struct {
 
 func makeBalancesAdapter(
 	balances map[basics.Address]basics.AccountData, txnGroup []transactions.SignedTxn,
-	groupIndex int, proto string, round uint64, latestTimestamp int64,
+	groupIndex byte, proto string, round uint64, latestTimestamp int64,
 	appIdx basics.AppIndex, painless bool, indexerURL string, indexerToken string,
 ) (apply.Balances, AppState, error) {
 
-	if groupIndex >= len(txnGroup) {
+	if int(groupIndex) >= len(txnGroup) {
 		return nil, AppState{}, fmt.Errorf("invalid groupIndex %d exceed txn group length %d", groupIndex, len(txnGroup))
 	}
 	txn := txnGroup[groupIndex]

--- a/cmd/tealdbg/main.go
+++ b/cmd/tealdbg/main.go
@@ -265,7 +265,7 @@ func debugLocal(args []string) {
 		ProgramBlobs:     programBlobs,
 		Proto:            proto,
 		TxnBlob:          txnBlob,
-		GroupIndex:       groupIndex,
+		GroupIndex:       byte(groupIndex),
 		BalanceBlob:      balanceBlob,
 		DdrBlob:          ddrBlob,
 		IndexerURL:       indexerURL,

--- a/cmd/tealdbg/server.go
+++ b/cmd/tealdbg/server.go
@@ -72,7 +72,7 @@ type DebugParams struct {
 	ProgramBlobs     [][]byte
 	Proto            string
 	TxnBlob          []byte
-	GroupIndex       int
+	GroupIndex       byte
 	PastSideEffects  []logic.EvalSideEffects
 	BalanceBlob      []byte
 	DdrBlob          []byte

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -420,7 +420,7 @@ func doDryrunRequest(dr *DryrunRequest, response *generated.DryrunResponse) {
 			Txn:                     &stxn,
 			Proto:                   &proto,
 			TxnGroup:                dr.Txns,
-			GroupIndex:              ti,
+			GroupIndex:              byte(ti),
 			PastSideEffects:         pse,
 			PooledApplicationBudget: &pooledAppBudget,
 		}

--- a/data/transactions/logic/debugger.go
+++ b/data/transactions/logic/debugger.go
@@ -64,7 +64,7 @@ type DebugState struct {
 	Disassembly string                   `codec:"disasm"`
 	PCOffset    []PCOffset               `codec:"pctooffset"`
 	TxnGroup    []transactions.SignedTxn `codec:"txngroup"`
-	GroupIndex  int                      `codec:"gindex"`
+	GroupIndex  byte                     `codec:"gindex"`
 	Proto       *config.ConsensusParams  `codec:"proto"`
 	Globals     []basics.TealValue       `codec:"globals"`
 

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -163,7 +163,7 @@ func TestTxnFieldToTealValue(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	txn := transactions.Transaction{}
-	groupIndex := 0
+	groupIndex := byte(0)
 	field := FirstValid
 	values := [6]uint64{0, 1, 2, 0xffffffff, 0xffffffffffffffff}
 
@@ -2395,7 +2395,7 @@ int 1`,
 					Proto:           &proto,
 					Txn:             &txgroup[j],
 					TxnGroup:        txgroup,
-					GroupIndex:      j,
+					GroupIndex:      byte(j),
 					PastSideEffects: pastSideEffects,
 				}
 			}
@@ -2469,7 +2469,7 @@ int 1`,
 					Proto:           &proto,
 					Txn:             &txgroup[j],
 					TxnGroup:        txgroup,
-					GroupIndex:      j,
+					GroupIndex:      byte(j),
 					PastSideEffects: pastSideEffects,
 				}
 			}
@@ -2542,7 +2542,7 @@ byte "txn 2"
 			Proto:           &proto,
 			Txn:             &txgroup[j],
 			TxnGroup:        txgroup,
-			GroupIndex:      j,
+			GroupIndex:      byte(j),
 			PastSideEffects: pastSideEffects,
 		}
 	}

--- a/data/transactions/logictest/ledger.go
+++ b/data/transactions/logictest/ledger.go
@@ -70,7 +70,7 @@ type Ledger struct {
 	balances          map[basics.Address]balanceRecord
 	applications      map[basics.AppIndex]appParams
 	assets            map[basics.AssetIndex]asaParams
-	trackedCreatables map[int]basics.CreatableIndex
+	trackedCreatables map[byte]basics.CreatableIndex
 	appID             basics.AppIndex
 	mods              map[basics.AppIndex]map[string]basics.ValueDelta
 	rnd               basics.Round
@@ -85,7 +85,7 @@ func MakeLedger(balances map[basics.Address]uint64) *Ledger {
 	}
 	l.applications = make(map[basics.AppIndex]appParams)
 	l.assets = make(map[basics.AssetIndex]asaParams)
-	l.trackedCreatables = make(map[int]basics.CreatableIndex)
+	l.trackedCreatables = make(map[byte]basics.CreatableIndex)
 	l.mods = make(map[basics.AppIndex]map[string]basics.ValueDelta)
 	return l
 }
@@ -441,13 +441,13 @@ func (l *Ledger) OptedIn(addr basics.Address, appIdx basics.AppIndex) (bool, err
 
 // SetTrackedCreatable remembers that the given cl "happened" in txn
 // groupIdx of the group, for use by GetCreatableID.
-func (l *Ledger) SetTrackedCreatable(groupIdx int, cl basics.CreatableLocator) {
+func (l *Ledger) SetTrackedCreatable(groupIdx byte, cl basics.CreatableLocator) {
 	l.trackedCreatables[groupIdx] = cl.Index
 }
 
 // GetCreatableID returns the creatable constructed in a given transaction
 // slot. For the test ledger, that's been set up by SetTrackedCreatable
-func (l *Ledger) GetCreatableID(groupIdx int) basics.CreatableIndex {
+func (l *Ledger) GetCreatableID(groupIdx byte) basics.CreatableIndex {
 	return l.trackedCreatables[groupIdx]
 }
 

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -99,7 +99,7 @@ func (g *GroupContext) Equal(other *GroupContext) bool {
 
 // Txn verifies a SignedTxn as being signed and having no obviously inconsistent data.
 // Block-assembly time checks of LogicSig and accounting rules may still block the txn.
-func Txn(s *transactions.SignedTxn, txnIdx int, groupCtx *GroupContext) error {
+func Txn(s *transactions.SignedTxn, txnIdx byte, groupCtx *GroupContext) error {
 	batchVerifier := crypto.MakeBatchVerifierDefaultSize()
 
 	if err := TxnBatchVerify(s, txnIdx, groupCtx, batchVerifier); err != nil {
@@ -119,7 +119,7 @@ func Txn(s *transactions.SignedTxn, txnIdx int, groupCtx *GroupContext) error {
 // TxnBatchVerify verifies a SignedTxn having no obviously inconsistent data.
 // Block-assembly time checks of LogicSig and accounting rules may still block the txn.
 // it is the caller responsibility to call batchVerifier.verify()
-func TxnBatchVerify(s *transactions.SignedTxn, txnIdx int, groupCtx *GroupContext, verifier *crypto.BatchVerifier) error {
+func TxnBatchVerify(s *transactions.SignedTxn, txnIdx byte, groupCtx *GroupContext, verifier *crypto.BatchVerifier) error {
 	if !groupCtx.consensusParams.SupportRekeying && (s.AuthAddr != basics.Address{}) {
 		return errors.New("nonempty AuthAddr but rekeying not supported")
 	}
@@ -161,7 +161,7 @@ func TxnGroupBatchVerify(stxs []transactions.SignedTxn, contextHdr bookkeeping.B
 	minFeeCount := uint64(0)
 	feesPaid := uint64(0)
 	for i, stxn := range stxs {
-		err = TxnBatchVerify(&stxn, i, groupCtx, verifier)
+		err = TxnBatchVerify(&stxn, byte(i), groupCtx, verifier)
 		if err != nil {
 			err = fmt.Errorf("transaction %+v invalid : %w", stxn, err)
 			return
@@ -191,7 +191,7 @@ func TxnGroupBatchVerify(stxs []transactions.SignedTxn, contextHdr bookkeeping.B
 	return
 }
 
-func stxnVerifyCore(s *transactions.SignedTxn, txnIdx int, groupCtx *GroupContext, batchVerifier *crypto.BatchVerifier) error {
+func stxnVerifyCore(s *transactions.SignedTxn, txnIdx byte, groupCtx *GroupContext, batchVerifier *crypto.BatchVerifier) error {
 	numSigs := 0
 	hasSig := false
 	hasMsig := false
@@ -245,7 +245,7 @@ func stxnVerifyCore(s *transactions.SignedTxn, txnIdx int, groupCtx *GroupContex
 
 // LogicSigSanityCheck checks that the signature is valid and that the program is basically well formed.
 // It does not evaluate the logic.
-func LogicSigSanityCheck(txn *transactions.SignedTxn, groupIndex int, groupCtx *GroupContext) error {
+func LogicSigSanityCheck(txn *transactions.SignedTxn, groupIndex byte, groupCtx *GroupContext) error {
 	batchVerifier := crypto.MakeBatchVerifierDefaultSize()
 
 	if err := LogicSigSanityCheckBatchVerify(txn, groupIndex, groupCtx, batchVerifier); err != nil {
@@ -266,7 +266,7 @@ func LogicSigSanityCheck(txn *transactions.SignedTxn, groupIndex int, groupCtx *
 // LogicSigSanityCheckBatchVerify checks that the signature is valid and that the program is basically well formed.
 // It does not evaluate the logic.
 // it is the caller responsibility to call batchVerifier.verify()
-func LogicSigSanityCheckBatchVerify(txn *transactions.SignedTxn, groupIndex int, groupCtx *GroupContext, batchVerifier *crypto.BatchVerifier) error {
+func LogicSigSanityCheckBatchVerify(txn *transactions.SignedTxn, groupIndex byte, groupCtx *GroupContext, batchVerifier *crypto.BatchVerifier) error {
 	lsig := txn.Lsig
 
 	if groupCtx.consensusParams.LogicSigVersion == 0 {
@@ -334,7 +334,7 @@ func LogicSigSanityCheckBatchVerify(txn *transactions.SignedTxn, groupIndex int,
 
 // logicSigBatchVerify checks that the signature is valid, executing the program.
 // it is the caller responsibility to call batchVerifier.verify()
-func logicSigBatchVerify(txn *transactions.SignedTxn, groupIndex int, groupCtx *GroupContext, batchverifier *crypto.BatchVerifier) error {
+func logicSigBatchVerify(txn *transactions.SignedTxn, groupIndex byte, groupCtx *GroupContext, batchverifier *crypto.BatchVerifier) error {
 	err := LogicSigSanityCheck(txn, groupIndex, groupCtx)
 	if err != nil {
 		return err

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -425,7 +425,7 @@ func BenchmarkTxn(b *testing.B) {
 		groupCtx, err := PrepareGroupContext(txnGroup, blk.BlockHeader)
 		require.NoError(b, err)
 		for i, txn := range txnGroup {
-			err := Txn(&txn, i, groupCtx)
+			err := Txn(&txn, byte(i), groupCtx)
 			require.NoError(b, err)
 		}
 	}

--- a/ledger/applications.go
+++ b/ledger/applications.go
@@ -34,7 +34,7 @@ type logicLedger struct {
 
 type cowForLogicLedger interface {
 	Get(addr basics.Address, withPendingRewards bool) (basics.AccountData, error)
-	GetCreatableID(groupIdx int) basics.CreatableIndex
+	GetCreatableID(groupIdx byte) basics.CreatableIndex
 	GetCreator(cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.Address, bool, error)
 	GetKey(addr basics.Address, aidx basics.AppIndex, global bool, key string, accountIdx uint64) (basics.TealValue, bool, error)
 	BuildEvalDelta(aidx basics.AppIndex, txn *transactions.Transaction) (transactions.EvalDelta, error)
@@ -98,7 +98,7 @@ func (al *logicLedger) Authorizer(addr basics.Address) (basics.Address, error) {
 	return addr, nil
 }
 
-func (al *logicLedger) GetCreatableID(groupIdx int) basics.CreatableIndex {
+func (al *logicLedger) GetCreatableID(groupIdx byte) basics.CreatableIndex {
 	return al.cow.GetCreatableID(groupIdx)
 }
 

--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -60,7 +60,7 @@ type mockCowForLogicLedger struct {
 	cr     map[creatableLocator]basics.Address
 	brs    map[basics.Address]basics.AccountData
 	stores map[storeLocator]basics.TealKeyValue
-	tcs    map[int]basics.CreatableIndex
+	tcs    map[byte]basics.CreatableIndex
 }
 
 func (c *mockCowForLogicLedger) Get(addr basics.Address, withPendingRewards bool) (basics.AccountData, error) {
@@ -71,7 +71,7 @@ func (c *mockCowForLogicLedger) Get(addr basics.Address, withPendingRewards bool
 	return br, nil
 }
 
-func (c *mockCowForLogicLedger) GetCreatableID(groupIdx int) basics.CreatableIndex {
+func (c *mockCowForLogicLedger) GetCreatableID(groupIdx byte) basics.CreatableIndex {
 	return c.tcs[groupIdx]
 }
 

--- a/ledger/cow.go
+++ b/ledger/cow.go
@@ -70,9 +70,9 @@ type roundCowState struct {
 	compatibilityGetKeyCache map[basics.Address]map[storagePtr]uint64
 
 	// index of a txn within a group; used in conjunction with trackedCreatables
-	groupIdx int
+	groupIdx byte
 	// track creatables created during each transaction in the round
-	trackedCreatables map[int]basics.CreatableIndex
+	trackedCreatables map[byte]basics.CreatableIndex
 }
 
 func makeRoundCowState(b roundCowParent, hdr bookkeeping.BlockHeader, proto config.ConsensusParams, prevTimestamp int64, hint int) *roundCowState {
@@ -82,7 +82,7 @@ func makeRoundCowState(b roundCowParent, hdr bookkeeping.BlockHeader, proto conf
 		proto:             proto,
 		mods:              ledgercore.MakeStateDelta(&hdr, prevTimestamp, hint, 0),
 		sdeltas:           make(map[basics.Address]map[storagePtr]*storageDelta),
-		trackedCreatables: make(map[int]basics.CreatableIndex),
+		trackedCreatables: make(map[byte]basics.CreatableIndex),
 	}
 
 	// compatibilityMode retains producing application' eval deltas under the following rule:
@@ -139,7 +139,7 @@ func (cb *roundCowState) prevTimestamp() int64 {
 	return cb.mods.PrevTimestamp
 }
 
-func (cb *roundCowState) getCreatableIndex(groupIdx int) basics.CreatableIndex {
+func (cb *roundCowState) getCreatableIndex(groupIdx byte) basics.CreatableIndex {
 	return cb.trackedCreatables[groupIdx]
 }
 
@@ -219,7 +219,7 @@ func (cb *roundCowState) child(hint int) *roundCowState {
 	}
 
 	// clone tracked creatables
-	ch.trackedCreatables = make(map[int]basics.CreatableIndex)
+	ch.trackedCreatables = make(map[byte]basics.CreatableIndex)
 	for i, tc := range cb.trackedCreatables {
 		ch.trackedCreatables[i] = tc
 	}
@@ -232,7 +232,7 @@ func (cb *roundCowState) child(hint int) *roundCowState {
 }
 
 // setGroupIdx sets this transaction's index within its group
-func (cb *roundCowState) setGroupIdx(txnIdx int) {
+func (cb *roundCowState) setGroupIdx(txnIdx byte) {
 	cb.groupIdx = txnIdx
 }
 

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -241,7 +241,7 @@ func (cs *roundCowState) Get(addr basics.Address, withPendingRewards bool) (basi
 	return acct, nil
 }
 
-func (cs *roundCowState) GetCreatableID(groupIdx int) basics.CreatableIndex {
+func (cs *roundCowState) GetCreatableID(groupIdx byte) basics.CreatableIndex {
 	return cs.getCreatableIndex(groupIdx)
 }
 
@@ -705,7 +705,7 @@ func (eval *BlockEvaluator) prepareEvalParams(txgroup []transactions.SignedTxnWi
 			Txn:                     &groupNoAD[i],
 			Proto:                   &eval.proto,
 			TxnGroup:                groupNoAD,
-			GroupIndex:              i,
+			GroupIndex:              byte(i),
 			PastSideEffects:         pastSideEffects,
 			MinTealVersion:          &minTealVersion,
 			PooledApplicationBudget: &pooledApplicationBudget,
@@ -741,7 +741,7 @@ func (eval *BlockEvaluator) transactionGroup(txgroup []transactions.SignedTxnWit
 	for gi, txad := range txgroup {
 		var txib transactions.SignedTxnInBlock
 
-		cow.setGroupIdx(gi)
+		cow.setGroupIdx(byte(gi))
 		err := eval.transaction(txad.SignedTxn, evalParams[gi], txad.ApplyData, cow, &txib)
 		if err != nil {
 			return err


### PR DESCRIPTION
We had some places where we cast uint64 teal values to ints, which we
used as group indexes.  This could lead to negative references and
panics (which we caught, but still...).

This PR fixes them and goes further - it uses a byte type in many
places where a txgroup index is expected.  There's an argument against
that - as we do end up casting some slice indexes to bytes, which
could lose precision if we allow groups to have more that 256
transactions.  On the other hand, that bug seems less likely than the
kind of bug we had.

Discourse welcome.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
