### PR TITLE
global GroupID

### DIFF
--- a/data/transactions/logic/README.md
+++ b/data/transactions/logic/README.md
@@ -327,6 +327,7 @@ Global fields are fields that are common to all the transactions in the group. I
 | 8 | CurrentApplicationID | uint64 | ID of current application executing. Fails if no such application is executing. LogicSigVersion >= 2. |
 | 9 | CreatorAddress | []byte | Address of the creator of the current application. Fails if no such application is executing. LogicSigVersion >= 3. |
 | 10 | CurrentApplicationAddress | []byte | Address that the current application controls. Fails if no such application is executing. LogicSigVersion >= 5. |
+| 11 | GroupID | []byte | ID of the transaction group. 32 zero bytes if the transaction is not part of a group. LogicSigVersion >= 5. |
 
 
 **Asset Fields**

--- a/data/transactions/logic/TEAL_opcodes.md
+++ b/data/transactions/logic/TEAL_opcodes.md
@@ -465,6 +465,7 @@ FirstValidTime causes the program to fail. The field is reserved for future use.
 | 8 | CurrentApplicationID | uint64 | ID of current application executing. Fails if no such application is executing. LogicSigVersion >= 2. |
 | 9 | CreatorAddress | []byte | Address of the creator of the current application. Fails if no such application is executing. LogicSigVersion >= 3. |
 | 10 | CurrentApplicationAddress | []byte | Address that the current application controls. Fails if no such application is executing. LogicSigVersion >= 5. |
+| 11 | GroupID | []byte | ID of the transaction group. 32 zero bytes if the transaction is not part of a group. LogicSigVersion >= 5. |
 
 
 ## gtxn t f

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -1256,6 +1256,7 @@ global Round
 global LatestTimestamp
 global CurrentApplicationID
 global CreatorAddress
+global GroupID
 txn Sender
 txn Fee
 bnz label1

--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -404,6 +404,7 @@ var globalFieldDocs = map[string]string{
 	"CurrentApplicationID":      "ID of current application executing. Fails if no such application is executing",
 	"CreatorAddress":            "Address of the creator of the current application. Fails if no such application is executing",
 	"CurrentApplicationAddress": "Address that the current application controls. Fails if no such application is executing",
+	"GroupID":                   "ID of the transaction group. 32 zero bytes if the transaction is not part of a group.",
 }
 
 // GlobalFieldDocs are notes on fields available in `global` with extra versioning info if any

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -2346,6 +2346,10 @@ func (cx *EvalContext) getCreatorAddress() ([]byte, error) {
 	return creator[:], nil
 }
 
+func (cx *EvalContext) getGroupID() []byte {
+	return cx.Txn.Txn.Group[:]
+}
+
 var zeroAddress basics.Address
 
 func (cx *EvalContext) globalFieldToValue(fs globalFieldSpec) (sv stackValue, err error) {
@@ -2374,6 +2378,8 @@ func (cx *EvalContext) globalFieldToValue(fs globalFieldSpec) (sv stackValue, er
 		sv.Bytes = addr[:]
 	case CreatorAddress:
 		sv.Bytes, err = cx.getCreatorAddress()
+	case GroupID:
+		sv.Bytes = cx.getGroupID()
 	default:
 		err = fmt.Errorf("invalid global field %d", fs.field)
 	}

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -1034,6 +1034,10 @@ len
 int 32
 ==
 &&
+global GroupID
+byte 0x0706000000000000000000000000000000000000000000000000000000000000
+==
+&&
 `
 
 func TestGlobal(t *testing.T) {
@@ -1062,7 +1066,7 @@ func TestGlobal(t *testing.T) {
 			EvalStateful, CheckStateful,
 		},
 		5: {
-			CurrentApplicationAddress, globalV5TestProgram,
+			GroupID, globalV5TestProgram,
 			EvalStateful, CheckStateful,
 		},
 	}
@@ -1091,6 +1095,7 @@ func TestGlobal(t *testing.T) {
 			require.NoError(t, err)
 			var txn transactions.SignedTxn
 			txn.Lsig.Logic = ops.Program
+			txn.Txn.Group = crypto.Digest{0x07, 0x06}
 			txgroup := make([]transactions.SignedTxn, 1)
 			txgroup[0] = txn
 			sb := strings.Builder{}

--- a/data/transactions/logic/fields.go
+++ b/data/transactions/logic/fields.go
@@ -335,6 +335,8 @@ const (
 
 	// CurrentApplicationAddress [32]byte
 	CurrentApplicationAddress
+	// GroupID [32]byte
+	GroupID
 
 	invalidGlobalField
 )
@@ -364,6 +366,7 @@ var globalFieldSpecs = []globalFieldSpec{
 	{CurrentApplicationID, StackUint64, runModeApplication, 2},
 	{CreatorAddress, StackBytes, runModeApplication, 3},
 	{CurrentApplicationAddress, StackBytes, runModeApplication, 5},
+	{GroupID, StackBytes, modeAny, 5},
 }
 
 // GlobalFieldSpecByField maps GlobalField to spec

--- a/data/transactions/logic/fields_string.go
+++ b/data/transactions/logic/fields_string.go
@@ -94,12 +94,13 @@ func _() {
 	_ = x[CurrentApplicationID-8]
 	_ = x[CreatorAddress-9]
 	_ = x[CurrentApplicationAddress-10]
-	_ = x[invalidGlobalField-11]
+	_ = x[GroupID-11]
+	_ = x[invalidGlobalField-12]
 }
 
-const _GlobalField_name = "MinTxnFeeMinBalanceMaxTxnLifeZeroAddressGroupSizeLogicSigVersionRoundLatestTimestampCurrentApplicationIDCreatorAddressCurrentApplicationAddressinvalidGlobalField"
+const _GlobalField_name = "MinTxnFeeMinBalanceMaxTxnLifeZeroAddressGroupSizeLogicSigVersionRoundLatestTimestampCurrentApplicationIDCreatorAddressCurrentApplicationAddressGroupIDinvalidGlobalField"
 
-var _GlobalField_index = [...]uint8{0, 9, 19, 29, 40, 49, 64, 69, 84, 104, 118, 143, 161}
+var _GlobalField_index = [...]uint8{0, 9, 19, 29, 40, 49, 64, 69, 84, 104, 118, 143, 150, 168}
 
 func (i GlobalField) String() string {
 	if i >= GlobalField(len(_GlobalField_index)-1) {


### PR DESCRIPTION
Add GroupID as an accessible global field in AVM.

Co-authored-by: Zach Langley <zachary.langley@algorand.com>
