### PR TITLE
Data race in tests: TestApplicationsUpgradeOverREST race

### DIFF
--- a/nodecontrol/algodControl.go
+++ b/nodecontrol/algodControl.go
@@ -229,6 +229,7 @@ func (nc *NodeController) StartAlgod(args AlgodStartArgs) (alreadyRunning bool, 
 		case <-startAlgodCompletedChan:
 			// we've already exited this function, so we want to report to the error to the callback.
 			if args.ExitErrorCallback != nil {
+				err = fmt.Errorf("some error")
 				args.ExitErrorCallback(nc, err)
 			}
 		default:

--- a/nodecontrol/algodControl.go
+++ b/nodecontrol/algodControl.go
@@ -229,7 +229,6 @@ func (nc *NodeController) StartAlgod(args AlgodStartArgs) (alreadyRunning bool, 
 		case <-startAlgodCompletedChan:
 			// we've already exited this function, so we want to report to the error to the callback.
 			if args.ExitErrorCallback != nil {
-				err = fmt.Errorf("some error")
 				args.ExitErrorCallback(nc, err)
 			}
 		default:

--- a/test/e2e-go/cli/algod/cleanup_test.go
+++ b/test/e2e-go/cli/algod/cleanup_test.go
@@ -29,6 +29,7 @@ import (
 
 func TestNodeControllerCleanup(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))

--- a/test/e2e-go/cli/algod/expect/algod_expect_test.go
+++ b/test/e2e-go/cli/algod/expect/algod_expect_test.go
@@ -25,6 +25,8 @@ import (
 // TestAlgodWithExpect Process all expect script files with suffix Test.exp within the test/e2e-go/cli/algod/expect directory
 func TestAlgodWithExpect(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
+
 	et := fixtures.MakeExpectTest(t)
 	et.Run()
 }

--- a/test/e2e-go/cli/algod/stdstreams_test.go
+++ b/test/e2e-go/cli/algod/stdstreams_test.go
@@ -30,6 +30,7 @@ import (
 
 func TestAlgodLogsToFile(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 

--- a/test/e2e-go/cli/algoh/expect/algoh_expect_test.go
+++ b/test/e2e-go/cli/algoh/expect/algoh_expect_test.go
@@ -25,6 +25,7 @@ import (
 func TestAlgohWithExpect(t *testing.T) {
 	// partitiontest.PartitionTest(t)
 	// Causes double partition, so commented out on purpose
+	defer fixtures.ShutdownSynchronizedTest(t)
 	et := fixtures.MakeExpectTest(t)
 	et.Run()
 }

--- a/test/e2e-go/cli/goal/account_test.go
+++ b/test/e2e-go/cli/goal/account_test.go
@@ -28,7 +28,9 @@ const statusOffline = "[offline]"
 const statusOnline = "[online]"
 
 func TestAccountNew(t *testing.T) {
+	defer fixtures.ShutdownSynchronizedTest(t)
 	defer fixture.SetTestContext(t)()
+
 	a := require.New(fixtures.SynchronizedTest(t))
 
 	newAcctName := "new_account"
@@ -53,6 +55,7 @@ func TestAccountNew(t *testing.T) {
 }
 
 func TestAccountNewDuplicateFails(t *testing.T) {
+	defer fixtures.ShutdownSynchronizedTest(t)
 	defer fixture.SetTestContext(t)()
 	a := require.New(fixtures.SynchronizedTest(t))
 
@@ -68,6 +71,7 @@ func TestAccountNewDuplicateFails(t *testing.T) {
 }
 
 func TestAccountRename(t *testing.T) {
+	defer fixtures.ShutdownSynchronizedTest(t)
 	defer fixture.SetTestContext(t)()
 	a := require.New(fixtures.SynchronizedTest(t))
 
@@ -98,6 +102,7 @@ func TestAccountRename(t *testing.T) {
 
 // Importing an account multiple times should not be considered an error by goal
 func TestAccountMultipleImportRootKey(t *testing.T) {
+	defer fixtures.ShutdownSynchronizedTest(t)
 	defer fixture.SetTestContext(t)()
 	a := require.New(fixtures.SynchronizedTest(t))
 

--- a/test/e2e-go/cli/goal/account_test.go
+++ b/test/e2e-go/cli/goal/account_test.go
@@ -30,7 +30,6 @@ const statusOnline = "[online]"
 func TestAccountNew(t *testing.T) {
 	defer fixtures.ShutdownSynchronizedTest(t)
 	defer fixture.SetTestContext(t)()
-
 	a := require.New(fixtures.SynchronizedTest(t))
 
 	newAcctName := "new_account"

--- a/test/e2e-go/cli/goal/clerk_test.go
+++ b/test/e2e-go/cli/goal/clerk_test.go
@@ -27,7 +27,9 @@ import (
 )
 
 func TestClerkSendNoteEncoding(t *testing.T) {
+	defer fixtures.ShutdownSynchronizedTest(t)
 	defer fixture.SetTestContext(t)()
+
 	a := require.New(fixtures.SynchronizedTest(t))
 
 	// wait for consensus on first round prior to sending transactions, time out after 2 minutes

--- a/test/e2e-go/cli/goal/clerk_test.go
+++ b/test/e2e-go/cli/goal/clerk_test.go
@@ -29,7 +29,6 @@ import (
 func TestClerkSendNoteEncoding(t *testing.T) {
 	defer fixtures.ShutdownSynchronizedTest(t)
 	defer fixture.SetTestContext(t)()
-
 	a := require.New(fixtures.SynchronizedTest(t))
 
 	// wait for consensus on first round prior to sending transactions, time out after 2 minutes

--- a/test/e2e-go/cli/goal/expect/goal_expect_test.go
+++ b/test/e2e-go/cli/goal/expect/goal_expect_test.go
@@ -26,6 +26,7 @@ import (
 func TestGoalWithExpect(t *testing.T) {
 	// partitiontest.PartitionTest(t)
 	// Causes double partition, so commented out on purpose
+	defer fixtures.ShutdownSynchronizedTest(t)
 	et := fixtures.MakeExpectTest(t)
 	et.Run()
 }

--- a/test/e2e-go/cli/goal/node_cleanup_test.go
+++ b/test/e2e-go/cli/goal/node_cleanup_test.go
@@ -26,7 +26,9 @@ import (
 )
 
 func TestGoalNodeCleanup(t *testing.T) {
+	defer fixtures.ShutdownSynchronizedTest(t)
 	defer fixture.SetTestContext(t)()
+
 	a := require.New(fixtures.SynchronizedTest(t))
 
 	primaryDir := fixture.PrimaryDataDir()

--- a/test/e2e-go/cli/tealdbg/expect/tealdbg_expect_test.go
+++ b/test/e2e-go/cli/tealdbg/expect/tealdbg_expect_test.go
@@ -25,6 +25,7 @@ import (
 func TestTealdbgWithExpect(t *testing.T) {
 	// partitiontest.PartitionTest(t)
 	// Causes double partition, so commented out on purpose
+	defer fixtures.ShutdownSynchronizedTest(t)
 	et := fixtures.MakeExpectTest(t)
 	et.Run()
 }

--- a/test/e2e-go/features/catchup/basicCatchup_test.go
+++ b/test/e2e-go/features/catchup/basicCatchup_test.go
@@ -33,6 +33,7 @@ import (
 
 func TestBasicCatchup(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	if testing.Short() {
 		t.Skip()
@@ -80,6 +81,7 @@ func TestBasicCatchup(t *testing.T) {
 // The current versions are the original v1 and the upgraded to v2.1
 func TestCatchupOverGossip(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 
@@ -201,6 +203,7 @@ const consensusTestUnupgradedToProtocol = protocol.ConsensusVersion("test-unupgr
 
 func TestStoppedCatchupOnUnsupported(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	if testing.Short() {
 		t.Skip()

--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -81,6 +81,7 @@ func (ec *nodeExitErrorCollector) Print() {
 
 func TestBasicCatchpointCatchup(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	if testing.Short() {
 		t.Skip()

--- a/test/e2e-go/features/compactcert/compactcert_test.go
+++ b/test/e2e-go/features/compactcert/compactcert_test.go
@@ -37,6 +37,7 @@ import (
 
 func TestCompactCerts(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Skip("Disabling since they need work and shouldn't block releases")
 	t.Parallel()

--- a/test/e2e-go/features/multisig/multisig_test.go
+++ b/test/e2e-go/features/multisig/multisig_test.go
@@ -33,6 +33,7 @@ import (
 // try to transact with 3 sigs: expect success
 func TestBasicMultisig(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 
@@ -110,6 +111,7 @@ func TestBasicMultisig(t *testing.T) {
 // create a 0-of-3 multisig address: expect failure
 func TestZeroThreshold(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 
@@ -139,6 +141,7 @@ func TestZeroThreshold(t *testing.T) {
 // create a 3-of-0 multisig address: expect failure
 func TestZeroSigners(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 
@@ -164,6 +167,7 @@ func TestZeroSigners(t *testing.T) {
 // then try to transact
 func TestDuplicateKeys(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 

--- a/test/e2e-go/features/participation/onlineOfflineParticipation_test.go
+++ b/test/e2e-go/features/participation/onlineOfflineParticipation_test.go
@@ -34,6 +34,7 @@ import (
 
 func TestParticipationKeyOnlyAccountParticipatesCorrectly(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -108,6 +109,8 @@ func waitForAccountToProposeBlock(a *require.Assertions, fixture *fixtures.RestC
 // - When the account balance receives enough stake, it should be proposing after lookback rounds
 func TestNewAccountCanGoOnlineAndParticipate(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
+
 	if testing.Short() {
 		t.Skip()
 	}

--- a/test/e2e-go/features/participation/overlappingParticipationKeys_test.go
+++ b/test/e2e-go/features/participation/overlappingParticipationKeys_test.go
@@ -41,6 +41,7 @@ import (
 
 func TestOverlappingParticipationKeys(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))

--- a/test/e2e-go/features/participation/participationRewards_test.go
+++ b/test/e2e-go/features/participation/participationRewards_test.go
@@ -78,6 +78,7 @@ func spendToNonParticipating(t *testing.T, fixture *fixtures.RestClientFixture, 
 
 func TestOnlineOfflineRewards(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	r := require.New(fixtures.SynchronizedTest(t))
@@ -136,6 +137,7 @@ func TestOnlineOfflineRewards(t *testing.T) {
 
 func TestPartkeyOnlyRewards(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	if runtime.GOOS == "darwin" {
 		t.Skip()
@@ -187,6 +189,7 @@ func TestPartkeyOnlyRewards(t *testing.T) {
 
 func TestRewardUnitThreshold(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	r := require.New(fixtures.SynchronizedTest(t))
@@ -308,6 +311,7 @@ var defaultPoolAddr = basics.Address{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0
 
 func TestRewardRateRecalculation(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	r := require.New(fixtures.SynchronizedTest(t))

--- a/test/e2e-go/features/partitionRecovery/partitionRecovery_test.go
+++ b/test/e2e-go/features/partitionRecovery/partitionRecovery_test.go
@@ -32,6 +32,7 @@ const inducePartitionTime = 6 * time.Second    // Try to minimize change of proc
 
 func TestBasicPartitionRecovery(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	if testing.Short() {
 		t.Skip()
@@ -78,6 +79,7 @@ func TestBasicPartitionRecovery(t *testing.T) {
 
 func TestPartitionRecoverySwapStartup(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	if testing.Short() {
 		t.Skip()
@@ -100,6 +102,7 @@ func TestPartitionRecoverySwapStartup(t *testing.T) {
 
 func TestPartitionRecoveryStaggerRestart(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	if testing.Short() {
 		t.Skip()
@@ -167,6 +170,7 @@ func runTestWithStaggeredStopStart(t *testing.T, fixture *fixtures.RestClientFix
 
 func TestBasicPartitionRecoveryPartOffline(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	if testing.Short() {
 		t.Skip()
@@ -224,6 +228,7 @@ func TestBasicPartitionRecoveryPartOffline(t *testing.T) {
 
 func TestPartitionHalfOffline(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	if testing.Short() {
 		t.Skip()

--- a/test/e2e-go/features/teal/compile_test.go
+++ b/test/e2e-go/features/teal/compile_test.go
@@ -30,6 +30,7 @@ import (
 
 func TestTealCompile(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	if testing.Short() {
 		t.Skip()

--- a/test/e2e-go/features/transactions/accountv2_test.go
+++ b/test/e2e-go/features/transactions/accountv2_test.go
@@ -77,6 +77,7 @@ func checkEvalDelta(t *testing.T, client *libgoal.Client, startRnd, endRnd uint6
 
 func TestAccountInformationV2(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))

--- a/test/e2e-go/features/transactions/app_pages_test.go
+++ b/test/e2e-go/features/transactions/app_pages_test.go
@@ -33,6 +33,7 @@ import (
 
 func TestExtraProgramPages(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))

--- a/test/e2e-go/features/transactions/application_test.go
+++ b/test/e2e-go/features/transactions/application_test.go
@@ -46,6 +46,7 @@ func checkEqual(expected []string, actual []string) bool {
 
 func TestApplication(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))

--- a/test/e2e-go/features/transactions/asset_test.go
+++ b/test/e2e-go/features/transactions/asset_test.go
@@ -55,6 +55,7 @@ func helperFillSignBroadcast(client libgoal.Client, wh []byte, sender string, tx
 
 func TestAssetValidRounds(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -188,6 +189,7 @@ func TestAssetValidRounds(t *testing.T) {
 
 func TestAssetConfig(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	if testing.Short() {
 		t.Skip()
@@ -425,6 +427,7 @@ func TestAssetConfig(t *testing.T) {
 
 func TestAssetInformation(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -519,6 +522,7 @@ func TestAssetInformation(t *testing.T) {
 
 func TestAssetGroupCreateSendDestroy(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -662,6 +666,7 @@ func TestAssetGroupCreateSendDestroy(t *testing.T) {
 
 func TestAssetSend(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -911,6 +916,7 @@ func TestAssetSend(t *testing.T) {
 
 func TestAssetCreateWaitRestartDelete(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a, fixture, client, account0 := setupTestAndNetwork(t, "", nil)
 	defer fixture.Shutdown()
@@ -974,6 +980,7 @@ func TestAssetCreateWaitRestartDelete(t *testing.T) {
 
 func TestAssetCreateWaitBalLookbackDelete(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	if testing.Short() {
 		t.Skip()

--- a/test/e2e-go/features/transactions/close_account_test.go
+++ b/test/e2e-go/features/transactions/close_account_test.go
@@ -28,6 +28,7 @@ import (
 
 func TestAccountsCanClose(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))

--- a/test/e2e-go/features/transactions/group_test.go
+++ b/test/e2e-go/features/transactions/group_test.go
@@ -32,6 +32,7 @@ import (
 
 func TestGroupTransactions(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -104,6 +105,7 @@ func TestGroupTransactions(t *testing.T) {
 
 func TestGroupTransactionsDifferentSizes(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -212,6 +214,7 @@ func TestGroupTransactionsDifferentSizes(t *testing.T) {
 
 func TestGroupTransactionsSubmission(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))

--- a/test/e2e-go/features/transactions/lease_test.go
+++ b/test/e2e-go/features/transactions/lease_test.go
@@ -29,6 +29,7 @@ import (
 
 func TestLeaseTransactionsSameSender(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -90,6 +91,7 @@ func TestLeaseTransactionsSameSender(t *testing.T) {
 
 func TestLeaseRegressionFaultyFirstValidCheckOld_2f3880f7(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -164,6 +166,7 @@ func TestLeaseRegressionFaultyFirstValidCheckOld_2f3880f7(t *testing.T) {
 
 func TestLeaseRegressionFaultyFirstValidCheckNew_2f3880f7(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -225,6 +228,7 @@ func TestLeaseRegressionFaultyFirstValidCheckNew_2f3880f7(t *testing.T) {
 
 func TestLeaseTransactionsSameSenderDifferentLease(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -288,6 +292,7 @@ func TestLeaseTransactionsSameSenderDifferentLease(t *testing.T) {
 
 func TestLeaseTransactionsDifferentSender(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -364,6 +369,7 @@ func TestLeaseTransactionsDifferentSender(t *testing.T) {
 
 func TestOverlappingLeases(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))

--- a/test/e2e-go/features/transactions/onlineStatusChange_test.go
+++ b/test/e2e-go/features/transactions/onlineStatusChange_test.go
@@ -32,12 +32,14 @@ const transactionFee = uint64(0)
 
 func TestAccountsCanChangeOnlineState(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	testAccountsCanChangeOnlineState(t, filepath.Join("nettemplates", "TwoNodesPartlyOffline.json"))
 }
 
 func TestAccountsCanChangeOnlineStateInTheFuture(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	testAccountsCanChangeOnlineState(t, filepath.Join("nettemplates", "TwoNodesPartlyOfflineVFuture.json"))
 }

--- a/test/e2e-go/features/transactions/proof_test.go
+++ b/test/e2e-go/features/transactions/proof_test.go
@@ -31,6 +31,7 @@ import (
 
 func TestTxnMerkleProof(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))

--- a/test/e2e-go/features/transactions/sendReceive_test.go
+++ b/test/e2e-go/features/transactions/sendReceive_test.go
@@ -43,6 +43,7 @@ func GenerateRandomBytes(n int) []byte {
 // as they send each other money many times
 func TestAccountsCanSendMoney(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	numberOfSends := 25
 	if testing.Short() {
@@ -54,6 +55,8 @@ func TestAccountsCanSendMoney(t *testing.T) {
 // this test checks that two accounts' balances stay up to date
 // as they send each other money many times
 func TestDevModeAccountsCanSendMoney(t *testing.T) {
+	defer fixtures.ShutdownSynchronizedTest(t)
+
 	numberOfSends := 25
 	if testing.Short() {
 		numberOfSends = 3

--- a/test/e2e-go/kmd/e2e_kmd_server_client_test.go
+++ b/test/e2e-go/kmd/e2e_kmd_server_client_test.go
@@ -30,6 +30,7 @@ import (
 
 func TestServerStartsStopsSuccessfully(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -46,6 +47,7 @@ func TestServerStartsStopsSuccessfully(t *testing.T) {
 
 func TestBadAuthFails(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -67,6 +69,7 @@ func TestBadAuthFails(t *testing.T) {
 
 func TestGoodAuthSucceeds(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()

--- a/test/e2e-go/kmd/e2e_kmd_sqlite_test.go
+++ b/test/e2e-go/kmd/e2e_kmd_sqlite_test.go
@@ -28,6 +28,7 @@ import (
 
 func TestNonAbsSQLiteWalletConfigFails(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -46,6 +47,7 @@ func TestNonAbsSQLiteWalletConfigFails(t *testing.T) {
 
 func TestAbsSQLiteWalletConfigSucceeds(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()

--- a/test/e2e-go/kmd/e2e_kmd_wallet_keyops_test.go
+++ b/test/e2e-go/kmd/e2e_kmd_wallet_keyops_test.go
@@ -34,6 +34,7 @@ import (
 
 func TestGenerateAndListKeys(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -88,6 +89,7 @@ func TestGenerateAndListKeys(t *testing.T) {
 
 func TestImportKey(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -140,6 +142,7 @@ func TestImportKey(t *testing.T) {
 
 func TestExportKey(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -204,6 +207,7 @@ func TestExportKey(t *testing.T) {
 
 func TestDeleteKey(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -270,6 +274,7 @@ func TestDeleteKey(t *testing.T) {
 
 func TestSignTransaction(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -330,6 +335,7 @@ func TestSignTransaction(t *testing.T) {
 
 func TestSignProgram(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -431,6 +437,7 @@ func BenchmarkSignTransaction(b *testing.B) {
 
 func TestMasterKeyImportExport(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -600,6 +607,7 @@ func TestMasterKeyImportExport(t *testing.T) {
 
 func TestMasterKeyGeneratePastImportedKeys(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()

--- a/test/e2e-go/kmd/e2e_kmd_wallet_multisig_test.go
+++ b/test/e2e-go/kmd/e2e_kmd_wallet_multisig_test.go
@@ -41,6 +41,7 @@ func addrToPK(t *testing.T, addr string) crypto.PublicKey {
 
 func TestMultisigImportList(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -90,6 +91,7 @@ func TestMultisigImportList(t *testing.T) {
 
 func TestMultisigExportDelete(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -162,6 +164,7 @@ func TestMultisigExportDelete(t *testing.T) {
 
 func TestMultisigSign(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -237,6 +240,7 @@ func TestMultisigSign(t *testing.T) {
 
 func TestMultisigSignWithSigner(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -319,6 +323,7 @@ func TestMultisigSignWithSigner(t *testing.T) {
 
 func TestMultisigSignWithWrongSigner(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -378,6 +383,7 @@ func TestMultisigSignWithWrongSigner(t *testing.T) {
 
 func TestMultisigSignProgram(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()

--- a/test/e2e-go/kmd/e2e_kmd_wallet_test.go
+++ b/test/e2e-go/kmd/e2e_kmd_wallet_test.go
@@ -29,6 +29,7 @@ import (
 
 func TestWalletCreation(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -81,6 +82,7 @@ func TestWalletCreation(t *testing.T) {
 
 func TestBlankWalletCreation(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -116,6 +118,7 @@ func TestBlankWalletCreation(t *testing.T) {
 
 func TestWalletRename(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -196,6 +199,7 @@ func TestWalletRename(t *testing.T) {
 
 func TestWalletSessionRelease(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -238,6 +242,7 @@ func TestWalletSessionRelease(t *testing.T) {
 
 func TestWalletSessionRenew(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()
@@ -286,6 +291,7 @@ func TestWalletSessionRenew(t *testing.T) {
 
 func TestWalletSessionExpiry(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	t.Parallel()

--- a/test/e2e-go/restAPI/restClient_test.go
+++ b/test/e2e-go/restAPI/restClient_test.go
@@ -190,6 +190,7 @@ func waitForTransaction(t *testing.T, testClient libgoal.Client, fromAddress, tx
 
 func TestClientCanGetStatus(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -206,6 +207,7 @@ func TestClientCanGetStatus(t *testing.T) {
 
 func TestClientCanGetStatusAfterBlock(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -221,6 +223,7 @@ func TestClientCanGetStatusAfterBlock(t *testing.T) {
 
 func TestTransactionsByAddr(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	var localFixture fixtures.RestClientFixture
@@ -269,6 +272,7 @@ func TestTransactionsByAddr(t *testing.T) {
 
 func TestClientCanGetVersion(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -280,6 +284,7 @@ func TestClientCanGetVersion(t *testing.T) {
 
 func TestClientCanGetSuggestedFee(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -291,6 +296,7 @@ func TestClientCanGetSuggestedFee(t *testing.T) {
 
 func TestClientCanGetMinTxnFee(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -302,6 +308,7 @@ func TestClientCanGetMinTxnFee(t *testing.T) {
 
 func TestClientCanGetBlockInfo(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -314,6 +321,7 @@ func TestClientCanGetBlockInfo(t *testing.T) {
 
 func TestClientRejectsBadFromAddressWhenSending(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -330,6 +338,7 @@ func TestClientRejectsBadFromAddressWhenSending(t *testing.T) {
 
 func TestClientRejectsBadToAddressWhenSending(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -346,6 +355,7 @@ func TestClientRejectsBadToAddressWhenSending(t *testing.T) {
 
 func TestClientRejectsMutatedFromAddressWhenSending(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -369,6 +379,7 @@ func TestClientRejectsMutatedFromAddressWhenSending(t *testing.T) {
 
 func TestClientRejectsMutatedToAddressWhenSending(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -392,6 +403,7 @@ func TestClientRejectsMutatedToAddressWhenSending(t *testing.T) {
 
 func TestClientRejectsSendingMoneyFromAccountForWhichItHasNoKey(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -408,6 +420,7 @@ func TestClientRejectsSendingMoneyFromAccountForWhichItHasNoKey(t *testing.T) {
 
 func TestClientOversizedNote(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -433,6 +446,7 @@ func TestClientOversizedNote(t *testing.T) {
 
 func TestClientCanSendAndGetNote(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -458,6 +472,7 @@ func TestClientCanSendAndGetNote(t *testing.T) {
 
 func TestClientCanGetTransactionStatus(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -482,6 +497,7 @@ func TestClientCanGetTransactionStatus(t *testing.T) {
 
 func TestAccountBalance(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -511,6 +527,7 @@ func TestAccountBalance(t *testing.T) {
 
 func TestAccountParticipationInfo(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -574,6 +591,7 @@ func TestAccountParticipationInfo(t *testing.T) {
 
 func TestSupply(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -587,6 +605,7 @@ func TestSupply(t *testing.T) {
 
 func TestClientCanGetGoRoutines(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -601,6 +620,7 @@ func TestClientCanGetGoRoutines(t *testing.T) {
 
 func TestSendingTooMuchFails(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -642,6 +662,7 @@ func TestSendingTooMuchFails(t *testing.T) {
 
 func TestSendingFromEmptyAccountFails(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -681,6 +702,7 @@ func TestSendingFromEmptyAccountFails(t *testing.T) {
 
 func TestSendingTooLittleToEmptyAccountFails(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -713,6 +735,7 @@ func TestSendingTooLittleToEmptyAccountFails(t *testing.T) {
 
 func TestSendingLowFeeFails(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	defer fixture.SetTestContext(t)()
@@ -748,6 +771,7 @@ func TestSendingLowFeeFails(t *testing.T) {
 
 func TestSendingNotClosingAccountFails(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	// use a local fixture because we might really mess with the balances
@@ -794,6 +818,7 @@ func TestSendingNotClosingAccountFails(t *testing.T) {
 
 func TestClientCanGetPendingTransactions(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	var localFixture fixtures.RestClientFixture
@@ -827,6 +852,7 @@ func TestClientCanGetPendingTransactions(t *testing.T) {
 
 func TestClientTruncatesPendingTransactions(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	var localFixture fixtures.RestClientFixture
@@ -867,6 +893,7 @@ func TestClientTruncatesPendingTransactions(t *testing.T) {
 
 func TestClientPrioritizesPendingTransactions(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Skip("new FIFO pool does not have prioritization")
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -909,6 +936,7 @@ func TestClientPrioritizesPendingTransactions(t *testing.T) {
 
 func TestClientCanGetPendingTransactionInfo(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	var localFixture fixtures.RestClientFixture

--- a/test/e2e-go/stress/transactions/createManyAndGoOnline_test.go
+++ b/test/e2e-go/stress/transactions/createManyAndGoOnline_test.go
@@ -50,6 +50,7 @@ func cascadeCreateAndFundAccounts(amountToSend, transactionFee uint64, fundingAc
 // sends them all money, and sends them online
 func TestManyAccountsCanGoOnline(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))

--- a/test/e2e-go/upgrades/application_support_test.go
+++ b/test/e2e-go/upgrades/application_support_test.go
@@ -73,6 +73,8 @@ func makeApplicationUpgradeConsensus(t *testing.T) (appConsensus config.Consensu
 func TestApplicationsUpgradeOverREST(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
+	defer fixtures.TerminateTestFailures(t)
+	
 	smallLambdaMs := 500
 	consensus := makeApplicationUpgradeConsensus(t)
 

--- a/test/e2e-go/upgrades/application_support_test.go
+++ b/test/e2e-go/upgrades/application_support_test.go
@@ -74,8 +74,6 @@ func TestApplicationsUpgradeOverREST(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	defer fixtures.ShutdownSynchronizedTest(t)
 
-	defer fixtures.TerminateTestFailures(t)
-
 	smallLambdaMs := 500
 	consensus := makeApplicationUpgradeConsensus(t)
 

--- a/test/e2e-go/upgrades/application_support_test.go
+++ b/test/e2e-go/upgrades/application_support_test.go
@@ -72,9 +72,10 @@ func makeApplicationUpgradeConsensus(t *testing.T) (appConsensus config.Consensu
 // any application transaction and after the upgrade is complete, it would support that.
 func TestApplicationsUpgradeOverREST(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	defer fixtures.TerminateTestFailures(t)
-	
+
 	smallLambdaMs := 500
 	consensus := makeApplicationUpgradeConsensus(t)
 
@@ -304,6 +305,7 @@ int 1
 // any application transaction and after the upgrade is complete, it would support that.
 func TestApplicationsUpgradeOverGossip(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	smallLambdaMs := 500

--- a/test/e2e-go/upgrades/rekey_support_test.go
+++ b/test/e2e-go/upgrades/rekey_support_test.go
@@ -33,6 +33,7 @@ import (
 // TestRekeyUpgrade tests that the rekey does not work before the upgrade and works well after
 func TestRekeyUpgrade(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
 

--- a/test/e2e-go/upgrades/send_receive_upgrade_test.go
+++ b/test/e2e-go/upgrades/send_receive_upgrade_test.go
@@ -45,30 +45,35 @@ func GenerateRandomBytes(n int) []byte {
 // across a protocol upgrade.
 func TestAccountsCanSendMoneyAcrossUpgradeV15toV16(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	testAccountsCanSendMoneyAcrossUpgrade(t, filepath.Join("nettemplates", "TwoNodes50EachV15Upgrade.json"))
 }
 
 func TestAccountsCanSendMoneyAcrossUpgradeV21toV22(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	testAccountsCanSendMoneyAcrossUpgrade(t, filepath.Join("nettemplates", "TwoNodes50EachV21Upgrade.json"))
 }
 
 func TestAccountsCanSendMoneyAcrossUpgradeV22toV23(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	testAccountsCanSendMoneyAcrossUpgrade(t, filepath.Join("nettemplates", "TwoNodes50EachV22Upgrade.json"))
 }
 
 func TestAccountsCanSendMoneyAcrossUpgradeV23toV24(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	testAccountsCanSendMoneyAcrossUpgrade(t, filepath.Join("nettemplates", "TwoNodes50EachV23Upgrade.json"))
 }
 
 func TestAccountsCanSendMoneyAcrossUpgradeV24toV25(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
 
 	testAccountsCanSendMoneyAcrossUpgrade(t, filepath.Join("nettemplates", "TwoNodes50EachV24Upgrade.json"))
 }

--- a/test/framework/fixtures/fixture.go
+++ b/test/framework/fixtures/fixture.go
@@ -109,7 +109,7 @@ func (st *synchTest) Fail() {
 	st.Lock()
 	defer st.Unlock()
 	if !st.failed {
-		st.failed = true		
+		st.failed = true
 		st.t.Fail()
 	}
 }
@@ -117,7 +117,7 @@ func (st *synchTest) FailNow() {
 	st.Lock()
 	defer st.Unlock()
 	if !st.failed {
-		st.failed = true		
+		st.failed = true
 		st.t.FailNow()
 	}
 }

--- a/test/framework/fixtures/fixture.go
+++ b/test/framework/fixtures/fixture.go
@@ -86,7 +86,8 @@ func SynchronizedTest(tb TestingTB) TestingTB {
 
 type synchTest struct {
 	deadlock.Mutex
-	t TestingTB
+	t      TestingTB
+	failed bool
 }
 
 func (st *synchTest) Cleanup(f func()) {
@@ -107,12 +108,18 @@ func (st *synchTest) Errorf(format string, args ...interface{}) {
 func (st *synchTest) Fail() {
 	st.Lock()
 	defer st.Unlock()
-	st.t.Fail()
+	if !st.failed {
+		st.failed = true		
+		st.t.Fail()
+	}
 }
 func (st *synchTest) FailNow() {
 	st.Lock()
 	defer st.Unlock()
-	st.t.FailNow()
+	if !st.failed {
+		st.failed = true		
+		st.t.FailNow()
+	}
 }
 func (st *synchTest) Failed() bool {
 	st.Lock()

--- a/test/framework/fixtures/fixture.go
+++ b/test/framework/fixtures/fixture.go
@@ -90,10 +90,10 @@ type synchTest struct {
 	dontReportFailures bool
 }
 
-// TerminateTestFailures should be called within each test using a shared fixture.
+// ShutdownSynchronizedTest should be called within each test using synchTest.
 // It ensures the base test will no longer get t.finished modified and cause a data race.
-// It should be called in the form of "defer fixtures.TerminateTestFailures(t)"
-func TerminateTestFailures(t TestingTB) {
+// It should be called in the form of "defer fixtures.ShutdownSynchronizedTest(t)"
+func ShutdownSynchronizedTest(t TestingTB) {
 	st := SynchronizedTest(t).(*synchTest)
 	st.Lock()
 	defer st.Unlock()
@@ -108,12 +108,18 @@ func (st *synchTest) Cleanup(f func()) {
 func (st *synchTest) Error(args ...interface{}) {
 	st.Lock()
 	defer st.Unlock()
-	st.t.Error(args...)
+	if !st.dontReportFailures {
+		st.dontReportFailures = true
+		st.t.Error(args...)
+	}
 }
 func (st *synchTest) Errorf(format string, args ...interface{}) {
 	st.Lock()
 	defer st.Unlock()
-	st.t.Errorf(format, args...)
+	if !st.dontReportFailures {
+		st.dontReportFailures = true
+		st.t.Errorf(format, args...)
+	}
 }
 func (st *synchTest) Fail() {
 	st.Lock()
@@ -139,12 +145,18 @@ func (st *synchTest) Failed() bool {
 func (st *synchTest) Fatal(args ...interface{}) {
 	st.Lock()
 	defer st.Unlock()
-	st.t.Fatal(args...)
+	if !st.dontReportFailures {
+		st.dontReportFailures = true
+		st.t.Fatal(args...)
+	}
 }
 func (st *synchTest) Fatalf(format string, args ...interface{}) {
 	st.Lock()
 	defer st.Unlock()
-	st.t.Fatalf(format, args...)
+	if !st.dontReportFailures {
+		st.dontReportFailures = true
+		st.t.Fatalf(format, args...)
+	}
 }
 func (st *synchTest) Helper() {
 	st.Lock()
@@ -169,17 +181,26 @@ func (st *synchTest) Name() string {
 func (st *synchTest) Skip(args ...interface{}) {
 	st.Lock()
 	defer st.Unlock()
-	st.t.Skip(args...)
+	if !st.dontReportFailures {
+		st.dontReportFailures = true
+		st.t.Skip(args...)
+	}
 }
 func (st *synchTest) SkipNow() {
 	st.Lock()
 	defer st.Unlock()
-	st.t.SkipNow()
+	if !st.dontReportFailures {
+		st.dontReportFailures = true
+		st.t.SkipNow()
+	}
 }
 func (st *synchTest) Skipf(format string, args ...interface{}) {
 	st.Lock()
 	defer st.Unlock()
-	st.t.Skipf(format, args...)
+	if !st.dontReportFailures {
+		st.dontReportFailures = true
+		st.t.Skipf(format, args...)
+	}
 }
 func (st *synchTest) Skipped() bool {
 	st.Lock()

--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -116,6 +116,7 @@ func (f *LibGoalFixture) nodeExitWithError(nc *nodecontrol.NodeController, err e
 	}
 	exitError, ok := err.(*exec.ExitError)
 	if !ok {
+		time.Sleep(10*time.Second)
 		require.NoError(f.t, err, "Node at %s has terminated with an error", nc.GetDataDir())
 		return
 	}

--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -116,7 +116,6 @@ func (f *LibGoalFixture) nodeExitWithError(nc *nodecontrol.NodeController, err e
 	}
 	exitError, ok := err.(*exec.ExitError)
 	if !ok {
-		time.Sleep(10*time.Second)
 		require.NoError(f.t, err, "Node at %s has terminated with an error", nc.GetDataDir())
 		return
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->


When multiple threads use the synchTest object, and one fails, all call FailNow.

After the first call, the main test routine reads t.finished to terminate the test.

While the main test routine is reading t.finished, another thread calls FailNow, which in turn writes to t.finished, causing the data race.

While FailNow called from synchTest are guarded by a mutex, the main testing object has the TestingTB object, which does not use the same mutex.

The solution is to call FailNow from synchTest object only the first time.

fixes #2507

### More details:
The problem with the string of data race conditions we are observing in different tests when the test fails is the following:

When the test fails, FailNow in go/src/testing/testing.go sets `c.finished`, which is the "Previous write" part of the data race
```
func (c *common) FailNow() {
...
	c.finished = true
...
```
this call comes from different threads, possibly multiple ones, forked from (not exclusively) 
go-algorand/nodecontrol/algodControl.go
```
func (nc *NodeController) StartAlgod(args AlgodStartArgs) (alreadyRunning bool, err error) {
...
	go func() {
...
			if args.ExitErrorCallback != nil {
				args.ExitErrorCallback(nc, err)
```
where, `ExitErrorCallback` is:
```
func (f *LibGoalFixture) nodeExitWithError(nc *nodecontrol.NodeController, err error) {
...
		require.NoError(f.t, err, "Node at %s has terminated with an error", nc.GetDataDir())
...
}
```
and NoError, in case of an error, calls `FailNow`.

`f.t` happens to be `synchTest`, which has a mutex guarding the `FailNow` call, and hence, prevents simultaneous access `t.finished`.

However, there is one more read access to `t.finished`, which comes from the following location, which does not use synchTest object, hence, does not have the mutex used for the write:

go/src/testing/testing.go
```
func tRunner(t *T, fn func(t *T)) {
...
	defer func() {
...
		if !t.finished && err == nil {
```

In other words, when there are multiple threads, and all are fine, no thread will write to `t.finished`. When something goes wrong and `FailNow` is initiated, the other threads will be notified of the failure, and, in their turn, also report `require.NoError`, which calls `FailNow`, and writes `t.finished = true`.



## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
