### PR TITLE
txnsync: Add linked list based short term lru cache

### DIFF
--- a/txnsync/transactionCache.go
+++ b/txnsync/transactionCache.go
@@ -173,11 +173,6 @@ func (lru *transactionCache) acknowledge(seqs []uint64) {
 	}
 }
 
-/*
-first           shortTermCacheEntry
-free            shortTermCacheEntry
-transactionsMap map[transactions.Txid]bool
-*/
 func (ce *shortTermCacheEntry) detach() bool {
 	if ce.next == ce.prev {
 		return false

--- a/txnsync/transactionCache_test.go
+++ b/txnsync/transactionCache_test.go
@@ -35,49 +35,52 @@ func TestTransactionCache(t *testing.T) {
 
 	var txid transactions.Txid
 	a := makeTransactionCache(5, 10, 20)
-	// add 5
-	for i := 0; i < 5; i++ {
-		txid[0] = byte(i)
+	for repeat := 0; repeat < 2; repeat++ {
+		// add 5
+		for i := 0; i < 5; i++ {
+			txid[0] = byte(i)
+			a.add(txid)
+		}
+
+		// all 5 still there
+		for i := 0; i < 5; i++ {
+			txid[0] = byte(i)
+			require.True(t, a.contained(txid), "txid: %v", txid[:])
+		}
+
+		// repeatedly adding existing data doesn't lose anything
+		txid[0] = 1
 		a.add(txid)
-	}
+		a.add(txid)
+		a.add(txid)
+		for i := 0; i < 5; i++ {
+			txid[0] = byte(i)
+			require.True(t, a.contained(txid), "txid: %v", txid[:])
+		}
 
-	// all 5 still there
-	for i := 0; i < 5; i++ {
-		txid[0] = byte(i)
-		require.True(t, a.contained(txid))
-	}
+		// adding a sixth forgets the first
+		txid[0] = 5
+		a.add(txid)
+		for i := 1; i < 6; i++ {
+			txid[0] = byte(i)
+			require.True(t, a.contained(txid), "txid: %v", txid[:])
+		}
+		txid[0] = 0
+		require.False(t, a.contained(txid))
 
-	// repeatedly adding existing data doesn't lose anything
-	txid[0] = 1
-	a.add(txid)
-	a.add(txid)
-	a.add(txid)
-	for i := 0; i < 5; i++ {
-		txid[0] = byte(i)
-		require.True(t, a.contained(txid))
-	}
-
-	// adding a sixth forgets the first
-	txid[0] = 5
-	a.add(txid)
-	for i := 1; i < 6; i++ {
-		txid[0] = byte(i)
-		require.True(t, a.contained(txid))
-	}
-	txid[0] = 0
-	require.False(t, a.contained(txid))
-
-	// adding a seventh forgets the third
-	txid[0] = 6
-	a.add(txid)
-	for i := 3; i < 7; i++ {
-		txid[0] = byte(i)
+		// adding a seventh forgets the third
+		txid[0] = 6
+		a.add(txid)
+		for i := 3; i < 7; i++ {
+			txid[0] = byte(i)
+			require.True(t, a.contained(txid), "txid: %v", txid[:])
+		}
+		txid[0] = 1
 		require.True(t, a.contained(txid), "txid: %v", txid[:])
+		txid[0] = 2
+		require.False(t, a.contained(txid))
+		a.reset()
 	}
-	txid[0] = 1
-	require.True(t, a.contained(txid), "txid: %v", txid[:])
-	txid[0] = 2
-	require.False(t, a.contained(txid))
 }
 
 // TestTransactionCacheAddSlice tests addSlice functionality of the transaction cache

--- a/txnsync/transactionCache_test.go
+++ b/txnsync/transactionCache_test.go
@@ -67,14 +67,16 @@ func TestTransactionCache(t *testing.T) {
 	txid[0] = 0
 	require.False(t, a.contained(txid))
 
-	// adding a seventh forgets the second
+	// adding a seventh forgets the third
 	txid[0] = 6
 	a.add(txid)
-	for i := 2; i < 7; i++ {
+	for i := 3; i < 7; i++ {
 		txid[0] = byte(i)
-		require.True(t, a.contained(txid))
+		require.True(t, a.contained(txid), "txid: %v", txid[:])
 	}
 	txid[0] = 1
+	require.True(t, a.contained(txid), "txid: %v", txid[:])
+	txid[0] = 2
 	require.False(t, a.contained(txid))
 }
 
@@ -138,7 +140,8 @@ func TestAddSliceCapacity(t *testing.T) {
 func TestShortTermCacheReset(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	tc := makeTransactionCache(5, 10, 5)
-	require.Equal(t, 0, tc.shortTermCache.oldest)
+	require.Nil(t, tc.shortTermCache.first)
+	require.Nil(t, tc.shortTermCache.free)
 	require.Equal(t, 0, len(tc.shortTermCache.transactionsMap))
 
 	var txid transactions.Txid
@@ -147,12 +150,14 @@ func TestShortTermCacheReset(t *testing.T) {
 		tc.add(txid)
 	}
 
-	require.Equal(t, 1, tc.shortTermCache.oldest)
+	require.Nil(t, tc.shortTermCache.free)
+	require.NotNil(t, tc.shortTermCache.first)
 	require.Equal(t, 5, len(tc.shortTermCache.transactionsMap))
 
 	tc.reset()
 
-	require.Equal(t, 0, tc.shortTermCache.oldest)
+	require.Nil(t, tc.shortTermCache.first)
+	require.NotNil(t, tc.shortTermCache.free)
 	require.Equal(t, 0, len(tc.shortTermCache.transactionsMap))
 }
 


### PR DESCRIPTION
## Summary

Existing short term cache in the transaction sync was not supporting promoting updated cache entries.
In this PR, I have replaced the circulating buffer with a dual linked list to allow promoting cached entries.

## Test Plan

Extend existing unit test
