### PR TITLE
fix issue with checking RUN_EXPECT when listing packages

### DIFF
--- a/test/scripts/e2e_go_tests.sh
+++ b/test/scripts/e2e_go_tests.sh
@@ -109,7 +109,7 @@ if [[ "${ARCHTYPE}" = arm* ]]; then
 fi
 
 PACKAGES="./..."
-if [ "$RUN_EXPECT" != "" ]; then
+if [ "$RUN_EXPECT" = "TRUE" ]; then
   PACKAGES=$(go list ./...|grep expect)
 fi
 


### PR DESCRIPTION
## Summary

@algoidan noticed we were not running some non-expect e2e-go tests and we spotted this issue in the test script when checking the value of RUN_EXPECT.

## Test Plan

Check to ensure non-expect e2e-go tests are run as expected.