### PR TITLE
txnsync: remove known txid from bloom filter

### DIFF
--- a/txnsync/bloomFilter.go
+++ b/txnsync/bloomFilter.go
@@ -137,13 +137,13 @@ func filterFactoryXor32(numEntries int, s *syncState) (filter bloom.GenericFilte
 
 var filterFactory func(int, *syncState) (filter bloom.GenericFilter, filterType bloomFilterType) = filterFactoryXor32
 
-func (s *syncState) makeBloomFilter(encodingParams requestParams, txnGroups []pooldata.SignedTxGroup, hintPrevBloomFilter *bloomFilter) (result bloomFilter) {
+func (s *syncState) makeBloomFilter(encodingParams requestParams, txnGroups []pooldata.SignedTxGroup, excludeTransactions *transactionCache, hintPrevBloomFilter *bloomFilter) (result bloomFilter) {
 	result.encoded.EncodingParams = encodingParams
-	switch {
-	case encodingParams.Modulator == 0:
+	if encodingParams.Modulator == 0 {
 		// we want none.
 		return
-	case encodingParams.Modulator == 1:
+	}
+	if encodingParams.Modulator == 1 && excludeTransactions == nil {
 		// we want all.
 		if len(txnGroups) > 0 {
 			result.containedTxnsRange.firstCounter = txnGroups[0].GroupCounter
@@ -173,51 +173,55 @@ func (s *syncState) makeBloomFilter(encodingParams requestParams, txnGroups []po
 			result.encode(filter, filterType) //nolint:errcheck
 			// the error in the above case can be silently ignored.
 		}
-	default:
-		// we want subset.
-		result.containedTxnsRange.firstCounter = math.MaxUint64
-		filteredTransactionsIDs := getTxIDSliceBuffer(len(txnGroups))
-		defer releaseTxIDSliceBuffer(filteredTransactionsIDs)
+		return result
+	}
 
-		for _, group := range txnGroups {
-			txID := group.GroupTransactionID
-			if txidToUint64(txID)%uint64(encodingParams.Modulator) != uint64(encodingParams.Offset) {
-				continue
-			}
-			filteredTransactionsIDs = append(filteredTransactionsIDs, txID)
-			if result.containedTxnsRange.firstCounter == math.MaxUint64 {
-				result.containedTxnsRange.firstCounter = group.GroupCounter
-			}
-			result.containedTxnsRange.lastCounter = group.GroupCounter
+	// we want subset.
+	result.containedTxnsRange.firstCounter = math.MaxUint64
+	filteredTransactionsIDs := getTxIDSliceBuffer(len(txnGroups))
+	defer releaseTxIDSliceBuffer(filteredTransactionsIDs)
+
+	for _, group := range txnGroups {
+		txID := group.GroupTransactionID
+		if txidToUint64(txID)%uint64(encodingParams.Modulator) != uint64(encodingParams.Offset) {
+			continue
 		}
-
-		result.containedTxnsRange.transactionsCount = uint64(len(filteredTransactionsIDs))
-
-		if hintPrevBloomFilter != nil {
-			if result.sameParams(*hintPrevBloomFilter) {
-				return *hintPrevBloomFilter
-			}
+		if excludeTransactions != nil && excludeTransactions.contained(txID) {
+			continue
 		}
-
-		if len(filteredTransactionsIDs) == 0 {
-			return
+		filteredTransactionsIDs = append(filteredTransactionsIDs, txID)
+		if result.containedTxnsRange.firstCounter == math.MaxUint64 {
+			result.containedTxnsRange.firstCounter = group.GroupCounter
 		}
+		result.containedTxnsRange.lastCounter = group.GroupCounter
+	}
 
-		filter, filterType := filterFactory(len(filteredTransactionsIDs), s)
+	result.containedTxnsRange.transactionsCount = uint64(len(filteredTransactionsIDs))
 
+	if hintPrevBloomFilter != nil {
+		if result.sameParams(*hintPrevBloomFilter) {
+			return *hintPrevBloomFilter
+		}
+	}
+
+	if len(filteredTransactionsIDs) == 0 {
+		return
+	}
+
+	filter, filterType := filterFactory(len(filteredTransactionsIDs), s)
+
+	for _, txid := range filteredTransactionsIDs {
+		filter.Set(txid[:])
+	}
+	err := result.encode(filter, filterType)
+	if err != nil {
+		// fall back to standard bloom filter
+		filter, filterType = filterFactoryBloom(len(filteredTransactionsIDs), s)
 		for _, txid := range filteredTransactionsIDs {
 			filter.Set(txid[:])
 		}
-		err := result.encode(filter, filterType)
-		if err != nil {
-			// fall back to standard bloom filter
-			filter, filterType = filterFactoryBloom(len(filteredTransactionsIDs), s)
-			for _, txid := range filteredTransactionsIDs {
-				filter.Set(txid[:])
-			}
-			result.encode(filter, filterType) //nolint:errcheck
-			// the error in the above case can be silently ignored.
-		}
+		result.encode(filter, filterType) //nolint:errcheck
+		// the error in the above case can be silently ignored.
 	}
 
 	return result

--- a/txnsync/bloomFilter_test.go
+++ b/txnsync/bloomFilter_test.go
@@ -149,7 +149,7 @@ func TestBloomFallback(t *testing.T) {
 
 	for encodingParams.Modulator = 1; encodingParams.Modulator < 3; encodingParams.Modulator++ {
 		txnGroups := getTxnGroups(testingGenesisHash, testingGenesisID)
-		bf := s.makeBloomFilter(encodingParams, txnGroups, nil)
+		bf := s.makeBloomFilter(encodingParams, txnGroups, nil, nil)
 
 		switch bloomFilterType(bf.encoded.BloomFilterType) {
 		case multiHashBloomFilter:
@@ -169,7 +169,7 @@ func TestBloomFallback(t *testing.T) {
 		stg := txnGroups[1]
 		txnGroups = append(txnGroups, stg)
 
-		bf = s.makeBloomFilter(encodingParams, txnGroups, nil)
+		bf = s.makeBloomFilter(encodingParams, txnGroups, nil, nil)
 		switch bloomFilterType(bf.encoded.BloomFilterType) {
 		case multiHashBloomFilter:
 			// ok
@@ -194,7 +194,7 @@ func TestHint(t *testing.T) {
 
 	for encodingParams.Modulator = 1; encodingParams.Modulator < 3; encodingParams.Modulator++ {
 		txnGroups := getTxnGroups(testingGenesisHash, testingGenesisID)
-		bf := s.makeBloomFilter(encodingParams, txnGroups, nil)
+		bf := s.makeBloomFilter(encodingParams, txnGroups, nil, nil)
 
 		switch bloomFilterType(bf.encoded.BloomFilterType) {
 		case xorBloomFilter32:
@@ -208,7 +208,7 @@ func TestHint(t *testing.T) {
 		bf.encoded.BloomFilterType = byte(xorBloomFilter8)
 
 		// Pass bf as a hint.
-		bf2 := s.makeBloomFilter(encodingParams, txnGroups, &bf)
+		bf2 := s.makeBloomFilter(encodingParams, txnGroups, nil, &bf)
 
 		// If the filter of bf2 is not defaultFilterType (i.e. is XorFilter8), then the hint was used.
 		// The hint must be used, and the filter should not be the default filter.
@@ -224,7 +224,7 @@ func TestHint(t *testing.T) {
 		for i := range txnGroups {
 			txnGroups[i].GroupCounter += uint64(len(txnGroups))
 		}
-		bf2 = s.makeBloomFilter(encodingParams, txnGroups, &bf)
+		bf2 = s.makeBloomFilter(encodingParams, txnGroups, nil, &bf)
 
 		// If the filter of bf2 is XorFilter (i.e. defaultFilterType), then the hint was not used
 		switch bloomFilterType(bf2.encoded.BloomFilterType) {

--- a/txnsync/outgoing.go
+++ b/txnsync/outgoing.go
@@ -43,7 +43,6 @@ type sentMessageMetadata struct {
 	sentTimestamp           time.Duration
 	sequenceNumber          uint64
 	partialMessage          bool
-	filter                  bloomFilter
 	transactionGroups       []pooldata.SignedTxGroup
 	projectedSequenceNumber uint64
 }
@@ -132,13 +131,14 @@ func (s *syncState) sendMessageLoop(currentTime time.Duration, deadline timers.D
 	var pendingTransactions pendingTransactionGroupsSnapshot
 	profGetTxnsGroups := s.profiler.getElement(profElementGetTxnsGroups)
 	profAssembleMessage := s.profiler.getElement(profElementAssembleMessage)
+	var assembledBloomFilter bloomFilter
 	profGetTxnsGroups.start()
 	pendingTransactions.pendingTransactionsGroups, pendingTransactions.latestLocallyOriginatedGroupCounter = s.node.GetPendingTransactionGroups()
 	profGetTxnsGroups.end()
 	for _, peer := range peers {
 		msgEncoder := &messageAsyncEncoder{state: s, roundClock: s.clock, peerDataExchangeRate: peer.dataExchangeRate}
 		profAssembleMessage.start()
-		msgEncoder.messageData = s.assemblePeerMessage(peer, &pendingTransactions)
+		msgEncoder.messageData, assembledBloomFilter = s.assemblePeerMessage(peer, &pendingTransactions)
 		profAssembleMessage.end()
 		isPartialMessage := msgEncoder.messageData.partialMessage
 		// The message that we've just encoded is expected to be sent out with the next sequence number.
@@ -147,6 +147,12 @@ func (s *syncState) sendMessageLoop(currentTime time.Duration, deadline timers.D
 		// so we can have accurate elapsed time measurements for the data exchange rate calculations.
 		msgEncoder.messageData.projectedSequenceNumber = peer.lastSentMessageSequenceNumber + 1
 		msgEncoder.enqueue()
+
+		// update the bloom filter right here, since we want to make sure the peer contains the
+		// correct sent bloom filter, regardless of the message sending timing. If and when we
+		// generate the next message, we need to ensure that we're aware of this bloom filter, since
+		// it would affect whether we re-generate another bloom filter or not.
+		peer.updateSentBoomFilter(assembledBloomFilter)
 
 		scheduleOffset, ops := peer.getNextScheduleOffset(s.isRelay, s.lastBeta, isPartialMessage, currentTime)
 		if (ops & peerOpsSetInterruptible) == peerOpsSetInterruptible {
@@ -172,7 +178,7 @@ func (s *syncState) sendMessageLoop(currentTime time.Duration, deadline timers.D
 	}
 }
 
-func (s *syncState) assemblePeerMessage(peer *Peer, pendingTransactions *pendingTransactionGroupsSnapshot) (metaMessage sentMessageMetadata) {
+func (s *syncState) assemblePeerMessage(peer *Peer, pendingTransactions *pendingTransactionGroupsSnapshot) (metaMessage sentMessageMetadata, assembledBloomFilter bloomFilter) {
 	metaMessage = sentMessageMetadata{
 		peer: peer,
 		message: &transactionBlockMessage{
@@ -205,6 +211,7 @@ func (s *syncState) assemblePeerMessage(peer *Peer, pendingTransactions *pending
 		} else {
 			// for peers, we want to make sure we don't regenerate the same bloom filter as before.
 			lastBloomFilter = &peer.lastSentBloomFilter
+
 			// for non-relays, we want to be more picky and send bloom filter that excludes the transactions that were send from that relay
 			// ( since the relay already knows that it sent us these transactions ). we cannot do the same for relay->relay since it would
 			// conflict with the bloom filters being calculated only once.
@@ -213,15 +220,17 @@ func (s *syncState) assemblePeerMessage(peer *Peer, pendingTransactions *pending
 		profMakeBloomFilter := s.profiler.getElement(profElementMakeBloomFilter)
 		profMakeBloomFilter.start()
 		// generate a bloom filter that matches the requests params.
-		metaMessage.filter = s.makeBloomFilter(metaMessage.message.UpdatedRequestParams, pendingTransactions.pendingTransactionsGroups, excludeTransactions, lastBloomFilter)
+		assembledBloomFilter = s.makeBloomFilter(metaMessage.message.UpdatedRequestParams, pendingTransactions.pendingTransactionsGroups, excludeTransactions, lastBloomFilter)
 		// we check here to see if the bloom filter we need happen to be the same as the one that was previously sent to the peer.
 		// ( note that we check here againt the peer, whereas the hint to makeBloomFilter could be the cached one for the relay )
-		if !metaMessage.filter.sameParams(peer.lastSentBloomFilter) && metaMessage.filter.encodedLength > 0 {
-			metaMessage.message.TxnBloomFilter = metaMessage.filter.encoded
-			bloomFilterSize = metaMessage.filter.encodedLength
+		if !assembledBloomFilter.sameParams(peer.lastSentBloomFilter) && assembledBloomFilter.encodedLength > 0 {
+			metaMessage.message.TxnBloomFilter = assembledBloomFilter.encoded
+			bloomFilterSize = assembledBloomFilter.encodedLength
 		}
 		profMakeBloomFilter.end()
-		s.lastBloomFilter = metaMessage.filter
+		if s.isRelay {
+			s.lastBloomFilter = assembledBloomFilter
+		}
 	}
 
 	if msgOps&messageConstTransactions == messageConstTransactions {
@@ -274,7 +283,7 @@ func (s *syncState) evaluateOutgoingMessage(msgData sentMessageMetadata) {
 		// incoming message handler to identify that we shouldn't use this timestamp for calculating the data exchange rate.
 		timestamp = 0
 	}
-	msgData.peer.updateMessageSent(msgData.message, msgData.sentTransactionsIDs, timestamp, msgData.sequenceNumber, msgData.encodedMessageSize, msgData.filter)
+	msgData.peer.updateMessageSent(msgData.message, msgData.sentTransactionsIDs, timestamp, msgData.sequenceNumber, msgData.encodedMessageSize)
 	s.log.outgoingMessage(msgStats{msgData.sequenceNumber, msgData.message.Round, len(msgData.sentTransactionsIDs), msgData.message.UpdatedRequestParams, len(msgData.message.TxnBloomFilter.BloomFilter), msgData.message.MsgSync.NextMsgMinDelay, msgData.peer.networkAddress()})
 }
 

--- a/txnsync/outgoing_test.go
+++ b/txnsync/outgoing_test.go
@@ -286,7 +286,7 @@ func TestAssemblePeerMessage_messageConstBloomFilter(t *testing.T) {
 	peer.isOutgoing = true
 	peer.state = peerStateLateBloom
 
-	metaMessage := s.assemblePeerMessage(&peer, &pendingTransactions)
+	metaMessage, _ := s.assemblePeerMessage(&peer, &pendingTransactions)
 
 	a.Equal(metaMessage.message.UpdatedRequestParams.Modulator, byte(222))
 	a.Equal(metaMessage.message.UpdatedRequestParams.Offset, byte(111))
@@ -329,7 +329,7 @@ func TestAssemblePeerMessage_messageConstBloomFilterNonRelay(t *testing.T) {
 	peer.isOutgoing = true
 	peer.state = peerStateLateBloom
 
-	metaMessage := s.assemblePeerMessage(&peer, &pendingTransactions)
+	metaMessage, _ := s.assemblePeerMessage(&peer, &pendingTransactions)
 
 	a.Equal(metaMessage.message.UpdatedRequestParams.Modulator, byte(222))
 	a.Equal(metaMessage.message.UpdatedRequestParams.Offset, byte(111))
@@ -337,7 +337,7 @@ func TestAssemblePeerMessage_messageConstBloomFilterNonRelay(t *testing.T) {
 	a.Equal(metaMessage.message.Version, int32(txnBlockMessageVersion))
 	a.Equal(metaMessage.message.Round, s.round)
 	a.True(metaMessage.message.MsgSync.ResponseElapsedTime != 0)
-	a.Equal(s.lastBloomFilter, expectedFilter)
+	a.NotEqual(s.lastBloomFilter, expectedFilter)
 }
 
 // TestAssemblePeerMessage_messageConstNextMinDelay_messageConstUpdateRequestParams Tests assemblePeerMessage with messageConstNextMinDelay | messageConstUpdateRequestParams msgOps
@@ -361,7 +361,7 @@ func TestAssemblePeerMessage_messageConstNextMinDelay_messageConstUpdateRequestP
 	s.isRelay = true
 	s.lastBeta = 123 * time.Nanosecond
 
-	metaMessage := s.assemblePeerMessage(&peer, &pendingTransactions)
+	metaMessage, _ := s.assemblePeerMessage(&peer, &pendingTransactions)
 
 	a.Equal(metaMessage.message.UpdatedRequestParams.Modulator, byte(222))
 	a.Equal(metaMessage.message.UpdatedRequestParams.Offset, byte(111))
@@ -405,7 +405,7 @@ func TestAssemblePeerMessage_messageConstTransactions(t *testing.T) {
 	peer.isOutgoing = true
 	peer.state = peerStateHoldsoff
 
-	metaMessage := s.assemblePeerMessage(&peer, &pendingTransactions)
+	metaMessage, _ := s.assemblePeerMessage(&peer, &pendingTransactions)
 
 	a.Equal(len(metaMessage.transactionGroups), 1)
 	a.True(reflect.DeepEqual(metaMessage.transactionGroups[0], pendingTransactions.pendingTransactionsGroups[0]))

--- a/txnsync/outgoing_test.go
+++ b/txnsync/outgoing_test.go
@@ -280,7 +280,7 @@ func TestAssemblePeerMessage_messageConstBloomFilter(t *testing.T) {
 	peer.lastReceivedMessageTimestamp = 100
 	peer.lastReceivedMessageLocalRound = s.round
 
-	expectedFilter := s.makeBloomFilter(requestParams{Offset: 111, Modulator: 222}, pendingTransactions.pendingTransactionsGroups, &s.lastBloomFilter)
+	expectedFilter := s.makeBloomFilter(requestParams{Offset: 111, Modulator: 222}, pendingTransactions.pendingTransactionsGroups, nil, &s.lastBloomFilter)
 
 	s.isRelay = true
 	peer.isOutgoing = true
@@ -322,7 +322,7 @@ func TestAssemblePeerMessage_messageConstBloomFilterNonRelay(t *testing.T) {
 	peer.lastReceivedMessageTimestamp = 100
 	peer.lastReceivedMessageLocalRound = s.round
 
-	expectedFilter := s.makeBloomFilter(requestParams{Offset: 111, Modulator: 222}, pendingTransactions.pendingTransactionsGroups, &s.lastBloomFilter)
+	expectedFilter := s.makeBloomFilter(requestParams{Offset: 111, Modulator: 222}, pendingTransactions.pendingTransactionsGroups, nil, &s.lastBloomFilter)
 
 	s.isRelay = false
 	s.fetchTransactions = true

--- a/txnsync/peer.go
+++ b/txnsync/peer.go
@@ -456,12 +456,16 @@ func (p *Peer) getLocalRequestParams() (offset, modulator byte) {
 }
 
 // update the peer once the message was sent successfully.
-func (p *Peer) updateMessageSent(txMsg *transactionBlockMessage, selectedTxnIDs []transactions.Txid, timestamp time.Duration, sequenceNumber uint64, messageSize int, filter bloomFilter) {
+func (p *Peer) updateMessageSent(txMsg *transactionBlockMessage, selectedTxnIDs []transactions.Txid, timestamp time.Duration, sequenceNumber uint64, messageSize int) {
 	p.recentSentTransactions.addSlice(selectedTxnIDs, sequenceNumber, timestamp)
 	p.lastSentMessageSequenceNumber = sequenceNumber
 	p.lastSentMessageRound = txMsg.Round
 	p.lastSentMessageTimestamp = timestamp
 	p.lastSentMessageSize = messageSize
+}
+
+// update the peer's lastSentBloomFilter.
+func (p *Peer) updateSentBoomFilter(filter bloomFilter) {
 	if filter.encodedLength > 0 {
 		p.lastSentBloomFilter = filter
 	}

--- a/txnsync/peer_test.go
+++ b/txnsync/peer_test.go
@@ -858,13 +858,16 @@ func TestUpdateMessageSent(t *testing.T) {
 
 	a.False(p.recentSentTransactions.contained(txnIds[0]))
 
-	p.updateMessageSent(txMsg, txnIds, timestamp, sequenceNumber, messageSize, bFilter)
+	p.updateMessageSent(txMsg, txnIds, timestamp, sequenceNumber, messageSize)
 
 	a.True(p.recentSentTransactions.contained(txnIds[0]))
 	a.Equal(p.lastSentMessageSequenceNumber, sequenceNumber)
 	a.Equal(p.lastSentMessageRound, txMsg.Round)
 	a.Equal(p.lastSentMessageTimestamp, timestamp)
 	a.Equal(p.lastSentMessageSize, messageSize)
+
+	p.updateSentBoomFilter(bFilter)
+
 	a.Equal(p.lastSentBloomFilter, bFilter)
 
 }


### PR DESCRIPTION
## Summary

On non-relays, exclude txid that were sent from the relay from the bloom filter sent to the relay.
This is expected to reduce the size of the bloom filters by 25%.

## Test Plan

Unit tests updated.