### PR TITLE
Add ledger.GetBlockAddresses()

### DIFF
--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -1306,7 +1306,7 @@ func getTxnAddresses(txn *transactions.Transaction, out *[]basics.Address) {
 	*out = append(
 		*out, txn.Sender, txn.Receiver, txn.CloseRemainderTo, txn.AssetSender,
 		txn.AssetReceiver, txn.AssetCloseTo, txn.FreezeAccount)
-	*out = append(txn.ApplicationCallTxnFields.Accounts)
+	*out = append(*out, txn.ApplicationCallTxnFields.Accounts...)
 }
 
 // loadAccounts loads the account data for the provided transaction group list. It also loads the feeSink account and add it to the first returned transaction group.

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -1306,9 +1306,7 @@ func getTxnAddresses(txn *transactions.Transaction, out *[]basics.Address) {
 	*out = append(
 		*out, txn.Sender, txn.Receiver, txn.CloseRemainderTo, txn.AssetSender,
 		txn.AssetReceiver, txn.AssetCloseTo, txn.FreezeAccount)
-	for _, addr := range txn.ApplicationCallTxnFields.Accounts {
-		*out = append(*out, addr)
-	}
+	*out = append(txn.ApplicationCallTxnFields.Accounts)
 }
 
 // loadAccounts loads the account data for the provided transaction group list. It also loads the feeSink account and add it to the first returned transaction group.

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -1374,14 +1374,20 @@ func loadAccounts(ctx context.Context, l ledgerForEvaluator, rnd basics.Round, g
 
 		// iterate over the transaction groups and add all their account addresses to the list
 		groupsReady := make([]*groupTask, len(groups))
-		refAddresses := make([]basics.Address, 0, maxAddressesInTxn(&consensusParams))
 		for i, group := range groups {
 			task := &groupTask{}
 			groupsReady[i] = task
 			for _, stxn := range group {
-				getTxnAddresses(&stxn.Txn, &refAddresses)
-				for _, address := range refAddresses {
-					initAccount(address, task)
+				// If you add new addresses here, also add them in getTxnAddresses().
+				initAccount(stxn.Txn.Sender, task)
+				initAccount(stxn.Txn.Receiver, task)
+				initAccount(stxn.Txn.CloseRemainderTo, task)
+				initAccount(stxn.Txn.AssetSender, task)
+				initAccount(stxn.Txn.AssetReceiver, task)
+				initAccount(stxn.Txn.AssetCloseTo, task)
+				initAccount(stxn.Txn.FreezeAccount, task)
+				for _, xa := range stxn.Txn.Accounts {
+					initAccount(xa, task)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Indexer needs to know all accounts referenced in a block to be able to read all of them in one batch. This PR creates a function that returns all such account addresses.