### PR TITLE
Adding logic for source line to pc mapping and template variable details

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -1005,6 +1005,10 @@ func disassembleFile(fname, outname string) {
 	}
 }
 
+// AssemblyDetails contains details from the source to assembly process
+// Right now it is just the map of line number to program counter or byte position in
+// the assembled program but may contain other details like ABI spec or Template Variable
+// relative positions in the future
 type AssemblyDetails struct {
 	LineMap []int `json:"line_map"`
 }

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -486,7 +486,7 @@ func asmPushInt(ops *OpStream, spec *OpSpec, args []string) error {
 		err error
 	)
 
-	if len(args[0]) > 5 && args[0][:5] == "TMPL_" {
+	if len(args[0]) > 5 && args[0][:5] == TmplPrefix {
 		val = 0
 		ops.TemplateLabels[args[0]] = TemplateVariable{
 			SourceLine: uint64(ops.sourceLine),
@@ -516,9 +516,7 @@ func asmPushBytes(ops *OpStream, spec *OpSpec, args []string) error {
 		val []byte
 		err error
 	)
-	print("hi")
-	if len(args[0]) > 5 && args[0][:5] == "TMPL_" {
-		print("hi" + args[0])
+	if len(args[0]) > 5 && args[0][:5] == TmplPrefix {
 		val = []byte{}
 		ops.TemplateLabels[args[0]] = TemplateVariable{
 			SourceLine: uint64(ops.sourceLine),
@@ -526,7 +524,6 @@ func asmPushBytes(ops *OpStream, spec *OpSpec, args []string) error {
 			Position:   uint64(ops.pending.Len()),
 		}
 	} else {
-		print("ok?" + args[0])
 		val, _, err = parseBinaryArgs(args)
 		if err != nil {
 			return ops.error(err)
@@ -748,9 +745,9 @@ func assembleByteCBlock(ops *OpStream, spec *OpSpec, args []string) error {
 		var (
 			val      []byte
 			err      error
-			consumed int 
+			consumed int
 		)
-		if len(rest[0]) > 5 && rest[0][:5] == "TMPL_" {
+		if len(rest[0]) > 5 && rest[0][:5] == TmplPrefix {
 			ops.TemplateLabels[rest[0]] = TemplateVariable{
 				SourceLine: uint64(ops.sourceLine),
 				IsBytes:    true,

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -248,6 +248,22 @@ type OpStream struct {
 	HasStatefulOps bool
 }
 
+func (ops *OpStream) GetLineToOffset() []int {
+	maxLines := 0
+	for _, line := range ops.OffsetToLine {
+		if line > maxLines {
+			maxLines = line
+		}
+	}
+
+	lto := make([]int, maxLines+1)
+	for pc, line := range ops.OffsetToLine {
+		lto[line] = pc
+	}
+
+	return lto
+}
+
 // GetVersion returns the LogicSigVersion we're building to
 func (ops *OpStream) GetVersion() uint64 {
 	if ops.Version == 0 {

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -248,6 +248,7 @@ type OpStream struct {
 	HasStatefulOps bool
 }
 
+// GetLineToOffset returns a slice mapping TEAL source line to PC
 func (ops *OpStream) GetLineToOffset() []int {
 	maxLines := 0
 	for _, line := range ops.OffsetToLine {

--- a/data/transactions/logic/template_variables.go
+++ b/data/transactions/logic/template_variables.go
@@ -1,0 +1,13 @@
+package logic
+
+// TmplPrefix is the special prefix for placeholder values to
+// be tracked for template contracts
+const TmplPrefix = "TMPL_"
+
+// TemplateVariable holds the details for a special placeholder variable
+// in a template contract
+type TemplateVariable struct {
+	SourceLine uint64 `json:"source_line"`
+	Position   uint64 `json:"position"`
+	IsBytes    bool   `json:"bytes"`
+}


### PR DESCRIPTION
## Summary

I'd like to be able to easily map source line of TEAL back to pc in compiled program, detailed here: https://github.com/algorand/go-algorand/issues/2870

Really just wanted to test out the idea, many changes likely necessary. If actually implemented, we'd probably want to flag off the assembly details and choose a better name for the output.

`goal clerk compile` now outputs a json object with details about the assembled program including a map of source line number to pc and template variable details.

In the `line_map`  array, the index is the line number and the value is the pc.  Any 0 past the first one is considered empty space in the teal source program and should not be used. This output could be used by an editor to display pc in line number gutter or just manually referenced when debugging. 

In the `template_labels` object, the keys are the template variable names and the values are a set of details about their location and type. This allows template contracts to be compiled directly with no "dummy variables".  It also makes the insertion or removal of variables in the compiled bytecode easier. 

Care will need to be taken when working with the bytecode to ensure the appropriate length in bytes is written after the opcode byte or the program counter in the evaluator will get confused.  Also if populated, the bytes template variables will throw off the `position` field by whatever length of bytes its populated with.  Accounting for these issues is functionality that'd be nice for the SDKs to provide. 

