### PR TITLE
Improve peerScheduler.peerDuration performance

### DIFF
--- a/txnsync/bloomFilter_test.go
+++ b/txnsync/bloomFilter_test.go
@@ -255,9 +255,9 @@ func TestEncodingDecoding(t *testing.T) {
 	var testableBf *testableBloomFilter
 	var remarshaled []byte
 	// For each filter type
-	for _, filterFactory = range filters {
+	for _, ff := range filters {
 
-		filter, filterType := filterFactory(len(randomEntries), &s)
+		filter, filterType := ff(len(randomEntries), &s)
 		for i := range randomEntries {
 			filter.Set(randomEntries[i][:])
 		}
@@ -296,14 +296,14 @@ func TestBloomFilterTest(t *testing.T) {
 	filters := []func(int, *syncState) (filter bloom.GenericFilter, filterType bloomFilterType){
 		filterFactoryXor8, filterFactoryXor32, filterFactoryBloom}
 
-	for _, filterFactory = range filters {
+	for _, ff := range filters {
 
 		var s syncState
 		s.node = &justRandomFakeNode{}
 		var err error
 		txnGroups := getTxnGroups(testingGenesisHash, testingGenesisID)
 
-		filter, filterType := filterFactory(len(txnGroups), &s)
+		filter, filterType := ff(len(txnGroups), &s)
 		for _, txnGroup := range txnGroups {
 			filter.Set(txnGroup.GroupTransactionID[:])
 		}

--- a/txnsync/incoming_test.go
+++ b/txnsync/incoming_test.go
@@ -272,12 +272,14 @@ func TestEvaluateIncomingMessagePart3(t *testing.T) {
 	mNodeConnector.peerInfo.TxnSyncPeer = peer
 
 	s := syncState{
-		node:    mNodeConnector,
-		log:     wrapLogger(&incLogger, &cfg),
-		clock:   mNodeConnector.Clock(),
-		round:   1,
-		config:  cfg,
-		isRelay: true}
+		node:      mNodeConnector,
+		log:       wrapLogger(&incLogger, &cfg),
+		clock:     mNodeConnector.Clock(),
+		round:     1,
+		config:    cfg,
+		isRelay:   true,
+		scheduler: makePeerScheduler(),
+	}
 
 	// the peer will be added to s.scheduler
 	s.evaluateIncomingMessage(incomingMessage{

--- a/txnsync/mainloop.go
+++ b/txnsync/mainloop.go
@@ -311,7 +311,7 @@ func (s *syncState) onNewRoundEvent(ent Event) {
 }
 
 func (s *syncState) evaluatePeerStateChanges(currentTimeout time.Duration) {
-	peers := s.scheduler.nextPeers()
+	peers := s.scheduler.getNextPeers()
 	if len(peers) == 0 {
 		return
 	}

--- a/txnsync/outgoing_test.go
+++ b/txnsync/outgoing_test.go
@@ -521,7 +521,10 @@ func TestSendMessageLoop(t *testing.T) {
 
 	enqueueCalled := 0
 
-	s := syncState{clock: timers.MakeMonotonicClock(time.Now())}
+	s := syncState{
+		clock:     timers.MakeMonotonicClock(time.Now()),
+		scheduler: makePeerScheduler(),
+	}
 	s.log = mockAsyncLogger{}
 	// Get a large amount of signed txns with a low data exchange rate
 	// to get partial messages to trigger peerOpsClearInterruptible

--- a/txnsync/peerscheduler.go
+++ b/txnsync/peerscheduler.go
@@ -17,7 +17,6 @@
 package txnsync
 
 import (
-	"fmt"
 	"container/heap"
 	"sort"
 	"time"
@@ -51,15 +50,11 @@ func (p *peerScheduler) Push(x interface{}) {
 	p.peers = append(p.peers, entry)
 	p.nextPeers[entry.peer] = append(p.nextPeers[entry.peer], len(p.peers)-1)
 
-
 	if len(p.nextPeers[entry.peer]) > 1 {
 		peerIndices := p.nextPeers[entry.peer]
 		sort.Slice(peerIndices, func(i, j int) bool {
 			return p.peers[peerIndices[i]].next < p.peers[peerIndices[j]].next
 		})
-		if p.peers[peerIndices[0]].next > p.peers[peerIndices[1]].next {
-			fmt.Println("push boom")
-		}
 	}
 
 }
@@ -74,12 +69,9 @@ func (p *peerScheduler) Pop() interface{} {
 
 	if peerIndices[0] != end {
 		// this case is possible when the peer has two elements in p.peers.
-		// and both have the same next value. 
+		// and both have the same next value.
 		for idx, x := range peerIndices {
 			if x == end {
-				if p.peers[peerIndices[0]].next != p.peers[peerIndices[idx]].next {
-					fmt.Println("nboom")
-				}
 				peerIndices[0], peerIndices[idx] = peerIndices[idx], peerIndices[0]
 				break
 			}
@@ -87,7 +79,6 @@ func (p *peerScheduler) Pop() interface{} {
 	}
 	// the peer index must be the first entry.
 	peerIndices = peerIndices[1:]
-
 
 	// store if non-empty.
 	if len(peerIndices) > 0 {
@@ -122,8 +113,8 @@ func (p *peerScheduler) replaceIndices(indices []int, i, j int) {
 	for idx, x := range indices {
 		if x == i {
 			indices[idx] = j
-		} else if x ==j {
-			indices[idx] = i 
+		} else if x == j {
+			indices[idx] = i
 		}
 	}
 	sort.Slice(indices, func(i, j int) bool {
@@ -210,9 +201,6 @@ func (p *peerScheduler) peerDuration(peer *Peer) time.Duration {
 	peerIndices := p.nextPeers[peer]
 	if len(peerIndices) == 0 {
 		return time.Duration(0)
-	}
-	if len(peerIndices) > 1 && p.peers[peerIndices[0]].next > p.peers[peerIndices[1]].next {
-		fmt.Println("boom")
 	}
 	bucket := heap.Remove(p, peerIndices[0]).(peerBucket)
 	return bucket.next

--- a/txnsync/peerscheduler.go
+++ b/txnsync/peerscheduler.go
@@ -97,17 +97,6 @@ func (p *peerScheduler) Len() int {
 	return len(p.peers)
 }
 
-// find returns the smallest index i at which x == a[i],
-// or len(a) if there is no such index.
-func find(a []int, x int) int {
-	for i, n := range a {
-		if x == n {
-			return i
-		}
-	}
-	return len(a)
-}
-
 func (p *peerScheduler) replaceIndices(indices []int, i, j int) {
 
 	for idx, x := range indices {

--- a/txnsync/peerscheduler.go
+++ b/txnsync/peerscheduler.go
@@ -116,8 +116,8 @@ func (p *peerScheduler) Swap(i, j int) {
 	p.peers[i], p.peers[j] = p.peers[j], p.peers[i]
 	if p.peers[i].peer == p.peers[j].peer {
 		indices := p.nextPeers[p.peers[i].peer]
-		sort.Slice(indices, func(i, j int) bool {
-			return p.peers[indices[i]].next < p.peers[indices[j]].next
+		sort.Slice(indices, func(x, y int) bool {
+			return p.peers[indices[x]].next < p.peers[indices[y]].next
 		})
 		return
 	}

--- a/txnsync/peerscheduler.go
+++ b/txnsync/peerscheduler.go
@@ -114,10 +114,14 @@ func (p *peerScheduler) replaceIndices(indices []int, i, j int) {
 // Swap implements heap.Interface
 func (p *peerScheduler) Swap(i, j int) {
 	p.peers[i], p.peers[j] = p.peers[j], p.peers[i]
-	p.replaceIndices(p.nextPeers[p.peers[i].peer], i, j)
-	if p.peers[i] == p.peers[j] {
+	if p.peers[i].peer == p.peers[j].peer {
+		indices := p.nextPeers[p.peers[i].peer]
+		sort.Slice(indices, func(i, j int) bool {
+			return p.peers[indices[i]].next < p.peers[indices[j]].next
+		})
 		return
 	}
+	p.replaceIndices(p.nextPeers[p.peers[i].peer], i, j)
 	p.replaceIndices(p.nextPeers[p.peers[j].peer], i, j)
 }
 

--- a/txnsync/peerscheduler_test.go
+++ b/txnsync/peerscheduler_test.go
@@ -29,7 +29,7 @@ import (
 func TestBasics(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	ps := peerScheduler{}
+	ps := makePeerScheduler()
 
 	require.Equal(t, 0, ps.Len())
 
@@ -71,7 +71,7 @@ func TestBasics(t *testing.T) {
 func TestSchedulerBasics(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	ps := peerScheduler{}
+	ps := makePeerScheduler()
 
 	peers := []Peer{
 		Peer{
@@ -110,9 +110,8 @@ func TestSchedulerBasics(t *testing.T) {
 func TestScheduleNewRound(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	ps := peerScheduler{
-		node: &mockNodeConnector{},
-	}
+	ps := makePeerScheduler()
+	ps.node = &mockNodeConnector{}
 
 	peers := []Peer{
 		Peer{
@@ -155,9 +154,8 @@ func TestScheduleNewRound(t *testing.T) {
 func TestNextPeers(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	ps := peerScheduler{
-		node: &mockNodeConnector{},
-	}
+	ps := makePeerScheduler()
+	ps.node = &mockNodeConnector{}
 
 	peers := []Peer{
 		Peer{
@@ -178,13 +176,13 @@ func TestNextPeers(t *testing.T) {
 
 	require.Equal(t, 4, ps.Len())
 
-	outPeers := ps.nextPeers()
+	outPeers := ps.getNextPeers()
 
 	require.Equal(t, 3, ps.Len())
 	require.Equal(t, 1, len(outPeers))
 	require.Equal(t, uint64(1), outPeers[0].lastSentMessageSequenceNumber)
 
-	outPeers = ps.nextPeers()
+	outPeers = ps.getNextPeers()
 
 	require.Equal(t, 0, ps.Len())
 	require.Equal(t, 2, len(outPeers))

--- a/txnsync/peerscheduler_test.go
+++ b/txnsync/peerscheduler_test.go
@@ -17,6 +17,7 @@
 package txnsync
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -189,4 +190,94 @@ func TestNextPeers(t *testing.T) {
 	require.Equal(t, uint64(3), outPeers[0].lastSentMessageSequenceNumber)
 	require.Equal(t, uint64(2), outPeers[1].lastSentMessageSequenceNumber)
 
+}
+
+func TestNextPeersLargeSet(t *testing.T) {
+
+	partitiontest.PartitionTest(t)
+
+	ps := makePeerScheduler()
+	ps.node = &mockNodeConnector{}
+
+	numPeers := 100
+	dupTimesPerPeer := 3
+	numTimeSamples := 10
+
+	peers := make([]*Peer, 0, numPeers)
+	for x := 1; x <= numPeers; x++ {
+		peer := Peer{lastSentMessageSequenceNumber: uint64(x)}
+		peers = append(peers, &peer)
+	}
+	require.Equal(t, int64(0), int64(ps.nextDuration()))
+
+	// Add peers with random next values
+	ps.scheduleNewRound(peers)
+	checkMonotonicNexts(&ps, t)
+	checkIndexMatch(&ps, t)
+
+	// Add nexts with defined values to guarantee duplicate values
+	for dups := 0; dups < dupTimesPerPeer; dups++ {
+		for x := 1; x <= numTimeSamples; x++ {
+			for p := 0; p < len(peers); p++ {
+				val := int64(math.Abs(math.Sin(float64(x))) * 100.00)
+				ps.schedulePeer(peers[p], time.Millisecond*time.Duration(val))
+			}
+		}
+	}
+	outPeers := ps.getNextPeers()
+	require.Equal(t, numPeers, len(outPeers))
+	checkMonotonicNexts(&ps, t)
+	checkIndexMatch(&ps, t)
+
+	// Repeatedly schedule and remove peers, and varify the invariants are honored
+	for dups := 0; dups < dupTimesPerPeer; dups++ {
+		for x := 1; x <= numTimeSamples*numPeers; {
+			for p := 0; p < len(peers); p++ {
+				val := int64(math.Abs(math.Sin(float64(x))) * 10.00)
+				ps.schedulePeer(peers[p], time.Millisecond*time.Duration(val))
+				x++
+			}
+			checkMonotonicNexts(&ps, t)
+			checkIndexMatch(&ps, t)
+			outPeers := ps.getNextPeers()
+			require.GreaterOrEqual(t, len(outPeers), 0)
+		}
+	}
+
+	// Drain the peers and make sure goes down to 0 without errors
+	for _, peerB := range ps.peers {
+		prev := int64(0)
+		for {
+			dur := int64(ps.peerDuration(peerB.peer))
+			if dur == 0 {
+				break
+			}
+			require.GreaterOrEqual(t, dur, prev)
+			prev = dur
+		}
+		checkMonotonicNexts(&ps, t)
+		checkIndexMatch(&ps, t)
+	}
+}
+
+func checkMonotonicNexts(ps *peerScheduler, t *testing.T) {
+	for _, s := range ps.nextPeers {
+		prevIdx := -1
+		for _, idx := range s {
+			if prevIdx == -1 {
+				prevIdx = idx
+			}
+			require.LessOrEqual(t, int64(ps.peers[prevIdx].next), int64(ps.peers[idx].next))
+			prevIdx = idx
+		}
+	}
+}
+
+func checkIndexMatch(ps *peerScheduler, t *testing.T) {
+	for peer, s := range ps.nextPeers {
+		for _, peerIdx := range s {
+			require.Equal(t, peer, ps.peers[peerIdx].peer)
+
+		}
+	}
 }

--- a/txnsync/service.go
+++ b/txnsync/service.go
@@ -46,6 +46,7 @@ func MakeTransactionSyncService(log logging.Logger, conn NodeConnector, isRelay 
 			genesisHash: genesisHash,
 			config:      cfg,
 			threadpool:  threadpool,
+			scheduler:   makePeerScheduler(),
 		},
 	}
 	s.state.service = s


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->


In `onTransactionPoolChangedEvent`, there is an action taken on every peer which is both in `s.interruptablePeers` and in `s.scheduler.peers`.
This is accomplished in the loop:
```
	for _, peer := range peers {
		peerNext := s.scheduler.peerDuration(peer)
```
where for each peer, the list of `s.scheduler.peers` is traversed when `peerDuration` is called. 

This is `len(peers) * len(s.scheduler.peers)` complexity. 
The task here is to make this operation linear instead of potentially a quadratic operation. 



## Test Plan
A test is added.
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
