### PR TITLE
changing circleci workflow name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 
 workflows:
   version: 2
-  build_pr:
+  "CircleCI Tests":
     jobs:
       - codegen_verification
       - amd64_build


### PR DESCRIPTION
## Summary

Fixing naming due to new way of displaying CircleCI workflow

## Test Plan

Check tests at the bottom of Conversation tab and on the Checks tab
