### PR TITLE
Fix dryrun crash on rewards calculation

### DIFF
--- a/cmd/tealdbg/localLedger.go
+++ b/cmd/tealdbg/localLedger.go
@@ -285,7 +285,10 @@ func (l *localLedger) CheckDup(config.ConsensusParams, basics.Round, basics.Roun
 }
 
 func (l *localLedger) LookupWithoutRewards(rnd basics.Round, addr basics.Address) (basics.AccountData, basics.Round, error) {
-	return l.balances[addr], rnd, nil
+	ad := l.balances[addr]
+	// Clear RewardsBase since tealdbg has no idea about rewards level so the underlying calculation with reward will fail.
+	ad.RewardsBase = 0
+	return ad, rnd, nil
 }
 
 func (l *localLedger) GetCreatorForRound(rnd basics.Round, cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.Address, bool, error) {

--- a/daemon/algod/api/server/v2/account.go
+++ b/daemon/algod/api/server/v2/account.go
@@ -105,7 +105,7 @@ func AccountDataToAccount(
 	amount := record.MicroAlgos
 	pendingRewards, overflowed := basics.OSubA(amount, amountWithoutPendingRewards)
 	if overflowed {
-		return generated.Account{}, errors.New("overflow on pending reward calcuation")
+		return generated.Account{}, errors.New("overflow on pending reward calculation")
 	}
 
 	return generated.Account{

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -273,6 +273,9 @@ func (dl *dryrunLedger) LookupWithoutRewards(rnd basics.Round, addr basics.Addre
 			return basics.AccountData{}, 0, err
 		}
 		out.MicroAlgos.Raw = acct.AmountWithoutPendingRewards
+		// Clear RewardsBase since dryrun has no idea about rewards level so the underlying calculation with reward will fail.
+		// The amount needed is known as acct.Amount but this method must return AmountWithoutPendingRewards
+		out.RewardsBase = 0
 	}
 	appi, ok := dl.accountApps[addr]
 	if ok {


### PR DESCRIPTION
## Summary

dryrun/tealdbg ledgers do not have block info so cannot provide correct value of `rewardLevel` used in balance calculation for `balance` opcode. Fixed by clearing `RewardBase` field in account data returned by dryrun/tealdbg ledgers.

The crash was [reported](https://forum.algorand.org/t/teal-rejection-error-panic-in-evaluation-overflowed-account-balance-when-applying-rewards/4294) at the community forum.

## Test Plan

Test added