### PR TITLE
ledger: move account totals calculation to StateDelta

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1671,7 +1671,6 @@ func (au *accountUpdates) accountsUpdateBalances(accountsDeltas compactAccountDe
 // newBlockImpl is the accountUpdates implementation of the ledgerTracker interface. This is the "internal" facing function
 // which assumes that no lock need to be taken.
 func (au *accountUpdates) newBlockImpl(blk bookkeeping.Block, delta ledgercore.StateDelta) {
-	proto := config.Consensus[blk.CurrentProtocol]
 	rnd := blk.Round()
 
 	if rnd <= au.latest() {
@@ -1688,33 +1687,10 @@ func (au *accountUpdates) newBlockImpl(blk bookkeeping.Block, delta ledgercore.S
 	au.roundDigest = append(au.roundDigest, blk.Digest())
 	au.deltasAccum = append(au.deltasAccum, delta.Accts.Len()+au.deltasAccum[len(au.deltasAccum)-1])
 
-	var ot basics.OverflowTracker
-	newTotals := au.roundTotals[len(au.roundTotals)-1]
-	allBefore := newTotals.All()
-	newTotals.ApplyRewards(delta.Hdr.RewardsLevel, &ot)
-
 	au.baseAccounts.flushPendingWrites()
 
-	var previousAccountData basics.AccountData
 	for i := 0; i < delta.Accts.Len(); i++ {
 		addr, data := delta.Accts.GetByIdx(i)
-		if latestAcctData, has := au.accounts[addr]; has {
-			previousAccountData = latestAcctData.data
-		} else if baseAccountData, has := au.baseAccounts.read(addr); has {
-			previousAccountData = baseAccountData.accountData
-		} else {
-			// it's missing from the base accounts, so we'll try to load it from disk.
-			if acctData, err := au.accountsq.lookup(addr); err != nil {
-				au.log.Panicf("accountUpdates: newBlockImpl failed to lookup account %v when processing round %d : %v", addr, rnd, err)
-			} else {
-				previousAccountData = acctData.accountData
-				au.baseAccounts.write(acctData)
-			}
-		}
-
-		newTotals.DelAccount(proto, previousAccountData, &ot)
-		newTotals.AddAccount(proto, data, &ot)
-
 		macct := au.accounts[addr]
 		macct.ndeltas++
 		macct.data = data
@@ -1730,15 +1706,7 @@ func (au *accountUpdates) newBlockImpl(blk bookkeeping.Block, delta ledgercore.S
 		au.creatables[cidx] = mcreat
 	}
 
-	if ot.Overflowed {
-		au.log.Panicf("accountUpdates: newBlockImpl %d overflowed totals", rnd)
-	}
-	allAfter := newTotals.All()
-	if allBefore != allAfter {
-		au.log.Panicf("accountUpdates: newBlockImpl sum of money changed from %d to %d", allBefore.Raw, allAfter.Raw)
-	}
-
-	au.roundTotals = append(au.roundTotals, newTotals)
+	au.roundTotals = append(au.roundTotals, delta.Totals)
 
 	// calling prune would drop old entries from the base accounts.
 	newBaseAccountSize := (len(au.accounts) + 1) + baseAccountsPendingAccountsBufferSize

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1749,6 +1749,7 @@ func TestSplittingConsensusVersionCommits(t *testing.T) {
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
+		delta.Totals = acculateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
 		accts = append(accts, totals)
@@ -1783,6 +1784,7 @@ func TestSplittingConsensusVersionCommits(t *testing.T) {
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
+		delta.Totals = acculateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
 		accts = append(accts, totals)
@@ -1863,6 +1865,7 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
+		delta.Totals = acculateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
 		accts = append(accts, totals)
@@ -1896,6 +1899,7 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
+		delta.Totals = acculateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
 		accts = append(accts, totals)
@@ -1931,6 +1935,7 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
+		delta.Totals = acculateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
 		accts = append(accts, totals)

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -54,7 +54,7 @@ type mockLedgerForTracker struct {
 	consensusParams config.ConsensusParams
 }
 
-func acculateTotals(t testing.TB, consensusVersion protocol.ConsensusVersion, accts []map[basics.Address]basics.AccountData, rewardLevel uint64) (totals ledgercore.AccountTotals) {
+func accumulateTotals(t testing.TB, consensusVersion protocol.ConsensusVersion, accts []map[basics.Address]basics.AccountData, rewardLevel uint64) (totals ledgercore.AccountTotals) {
 	var ot basics.OverflowTracker
 	proto := config.Consensus[consensusVersion]
 	totals.RewardsLevel = rewardLevel
@@ -76,7 +76,7 @@ func makeMockLedgerForTracker(t testing.TB, inMemory bool, initialBlocksCount in
 
 	blocks := randomInitChain(consensusVersion, initialBlocksCount)
 	deltas := make([]ledgercore.StateDelta, initialBlocksCount)
-	totals := acculateTotals(t, consensusVersion, accts, 0)
+	totals := accumulateTotals(t, consensusVersion, accts, 0)
 	for i := range deltas {
 		deltas[i] = ledgercore.StateDelta{
 			Hdr:    &bookkeeping.BlockHeader{},
@@ -395,7 +395,7 @@ func TestAcctUpdates(t *testing.T) {
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
 		delta.Creatables = creatablesFromUpdates(base, updates, knownCreatables)
-		delta.Totals = acculateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
+		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
 		au.newBlock(blk, delta)
 		accts = append(accts, totals)
 		rewardsLevels = append(rewardsLevels, rewardLevel)
@@ -1649,7 +1649,7 @@ func TestCachesInitialization(t *testing.T) {
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
-		delta.Totals = acculateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
+		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
 		au.committedUpTo(basics.Round(i))
@@ -1749,7 +1749,7 @@ func TestSplittingConsensusVersionCommits(t *testing.T) {
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
-		delta.Totals = acculateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
+		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
 		accts = append(accts, totals)
@@ -1784,7 +1784,7 @@ func TestSplittingConsensusVersionCommits(t *testing.T) {
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
-		delta.Totals = acculateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
+		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
 		accts = append(accts, totals)
@@ -1865,7 +1865,7 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
-		delta.Totals = acculateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
+		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
 		accts = append(accts, totals)
@@ -1899,7 +1899,7 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
-		delta.Totals = acculateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
+		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
 		accts = append(accts, totals)
@@ -1935,7 +1935,7 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
-		delta.Totals = acculateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
+		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
 		accts = append(accts, totals)

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -54,7 +54,20 @@ type mockLedgerForTracker struct {
 	consensusParams config.ConsensusParams
 }
 
-func makeMockLedgerForTracker(t testing.TB, inMemory bool, initialBlocksCount int, consensusVersion protocol.ConsensusVersion) *mockLedgerForTracker {
+func acculateTotals(t testing.TB, consensusVersion protocol.ConsensusVersion, accts []map[basics.Address]basics.AccountData, rewardLevel uint64) (totals ledgercore.AccountTotals) {
+	var ot basics.OverflowTracker
+	proto := config.Consensus[consensusVersion]
+	totals.RewardsLevel = rewardLevel
+	for _, ar := range accts {
+		for _, data := range ar {
+			totals.AddAccount(proto, data, &ot)
+		}
+	}
+	require.False(t, ot.Overflowed)
+	return
+}
+
+func makeMockLedgerForTracker(t testing.TB, inMemory bool, initialBlocksCount int, consensusVersion protocol.ConsensusVersion, accts []map[basics.Address]basics.AccountData) *mockLedgerForTracker {
 	dbs, fileName := dbOpenTest(t, inMemory)
 	dblogger := logging.TestingLog(t)
 	dblogger.SetLevel(logging.Info)
@@ -63,8 +76,12 @@ func makeMockLedgerForTracker(t testing.TB, inMemory bool, initialBlocksCount in
 
 	blocks := randomInitChain(consensusVersion, initialBlocksCount)
 	deltas := make([]ledgercore.StateDelta, initialBlocksCount)
+	totals := acculateTotals(t, consensusVersion, accts, 0)
 	for i := range deltas {
-		deltas[i] = ledgercore.StateDelta{Hdr: &bookkeeping.BlockHeader{}}
+		deltas[i] = ledgercore.StateDelta{
+			Hdr:    &bookkeeping.BlockHeader{},
+			Totals: totals,
+		}
 	}
 	consensusParams := config.Consensus[consensusVersion]
 	return &mockLedgerForTracker{dbs: dbs, log: dblogger, filename: fileName, inMemory: inMemory, blocks: blocks, deltas: deltas, consensusParams: consensusParams}
@@ -317,9 +334,6 @@ func TestAcctUpdates(t *testing.T) {
 	}
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
-	ml := makeMockLedgerForTracker(t, true, 10, protocol.ConsensusCurrentVersion)
-	defer ml.Close()
-
 	accts := []map[basics.Address]basics.AccountData{randomAccounts(20, true)}
 	rewardsLevels := []uint64{0}
 
@@ -332,6 +346,9 @@ func TestAcctUpdates(t *testing.T) {
 	sinkdata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
 	sinkdata.Status = basics.NotParticipating
 	accts[0][testSinkAddr] = sinkdata
+
+	ml := makeMockLedgerForTracker(t, true, 10, protocol.ConsensusCurrentVersion, accts)
+	defer ml.Close()
 
 	au := &accountUpdates{}
 	au.initialize(config.GetDefaultLocal(), ".", proto, accts[0])
@@ -378,6 +395,7 @@ func TestAcctUpdates(t *testing.T) {
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
 		delta.Creatables = creatablesFromUpdates(base, updates, knownCreatables)
+		delta.Totals = acculateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
 		au.newBlock(blk, delta)
 		accts = append(accts, totals)
 		rewardsLevels = append(rewardsLevels, rewardLevel)
@@ -403,9 +421,6 @@ func TestAcctUpdatesFastUpdates(t *testing.T) {
 	}
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
-	ml := makeMockLedgerForTracker(t, true, 10, protocol.ConsensusCurrentVersion)
-	defer ml.Close()
-
 	accts := []map[basics.Address]basics.AccountData{randomAccounts(20, true)}
 	rewardsLevels := []uint64{0}
 
@@ -418,6 +433,9 @@ func TestAcctUpdatesFastUpdates(t *testing.T) {
 	sinkdata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
 	sinkdata.Status = basics.NotParticipating
 	accts[0][testSinkAddr] = sinkdata
+
+	ml := makeMockLedgerForTracker(t, true, 10, protocol.ConsensusCurrentVersion, accts)
+	defer ml.Close()
 
 	au := &accountUpdates{}
 	conf := config.GetDefaultLocal()
@@ -494,9 +512,6 @@ func BenchmarkBalancesChanges(b *testing.B) {
 
 	initialRounds := uint64(1)
 
-	ml := makeMockLedgerForTracker(b, true, int(initialRounds), protocolVersion)
-	defer ml.Close()
-
 	accountsCount := 5000
 	accts := []map[basics.Address]basics.AccountData{randomAccounts(accountsCount, true)}
 	rewardsLevels := []uint64{0}
@@ -510,6 +525,9 @@ func BenchmarkBalancesChanges(b *testing.B) {
 	sinkdata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
 	sinkdata.Status = basics.NotParticipating
 	accts[0][testSinkAddr] = sinkdata
+
+	ml := makeMockLedgerForTracker(b, true, int(initialRounds), protocolVersion, accts)
+	defer ml.Close()
 
 	au := &accountUpdates{}
 	au.initialize(config.GetDefaultLocal(), ".", proto, accts[0])
@@ -626,8 +644,6 @@ func TestLargeAccountCountCatchpointGeneration(t *testing.T) {
 		os.RemoveAll("./catchpoints")
 	}()
 
-	ml := makeMockLedgerForTracker(t, true, 10, testProtocolVersion)
-	defer ml.Close()
 	accts := []map[basics.Address]basics.AccountData{randomAccounts(100000, true)}
 	rewardsLevels := []uint64{0}
 
@@ -640,6 +656,9 @@ func TestLargeAccountCountCatchpointGeneration(t *testing.T) {
 	sinkdata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
 	sinkdata.Status = basics.NotParticipating
 	accts[0][testSinkAddr] = sinkdata
+
+	ml := makeMockLedgerForTracker(t, true, 10, testProtocolVersion, accts)
+	defer ml.Close()
 
 	au := &accountUpdates{}
 	conf := config.GetDefaultLocal()
@@ -717,9 +736,6 @@ func TestAcctUpdatesUpdatesCorrectness(t *testing.T) {
 	inMemory := true
 
 	testFunction := func(t *testing.T) {
-		ml := makeMockLedgerForTracker(t, inMemory, 10, testProtocolVersion)
-		defer ml.Close()
-
 		accts := []map[basics.Address]basics.AccountData{randomAccounts(9, true)}
 
 		pooldata := basics.AccountData{}
@@ -731,6 +747,9 @@ func TestAcctUpdatesUpdatesCorrectness(t *testing.T) {
 		sinkdata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
 		sinkdata.Status = basics.NotParticipating
 		accts[0][testSinkAddr] = sinkdata
+
+		ml := makeMockLedgerForTracker(t, inMemory, 10, testProtocolVersion, accts)
+		defer ml.Close()
 
 		var moneyAccounts []basics.Address
 
@@ -878,11 +897,11 @@ func TestAcctUpdatesDeleteStoredCatchpoints(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	accts := []map[basics.Address]basics.AccountData{randomAccounts(20, true)}
 
-	ml := makeMockLedgerForTracker(t, true, 10, protocol.ConsensusCurrentVersion)
+	ml := makeMockLedgerForTracker(t, true, 10, protocol.ConsensusCurrentVersion, accts)
 	defer ml.Close()
 
-	accts := []map[basics.Address]basics.AccountData{randomAccounts(20, true)}
 	au := &accountUpdates{}
 	conf := config.GetDefaultLocal()
 	conf.CatchpointInterval = 1
@@ -1116,10 +1135,11 @@ func TestGetCatchpointStream(t *testing.T) {
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
-	ml := makeMockLedgerForTracker(t, true, 10, protocol.ConsensusCurrentVersion)
+	accts := []map[basics.Address]basics.AccountData{randomAccounts(20, true)}
+
+	ml := makeMockLedgerForTracker(t, true, 10, protocol.ConsensusCurrentVersion, accts)
 	defer ml.Close()
 
-	accts := []map[basics.Address]basics.AccountData{randomAccounts(20, true)}
 	au := &accountUpdates{}
 	conf := config.GetDefaultLocal()
 	conf.CatchpointInterval = 1
@@ -1226,9 +1246,6 @@ func accountsAll(tx *sql.Tx) (bals map[basics.Address]basics.AccountData, err er
 func BenchmarkLargeMerkleTrieRebuild(b *testing.B) {
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
-	ml := makeMockLedgerForTracker(b, true, 10, protocol.ConsensusCurrentVersion)
-	defer ml.Close()
-
 	accts := []map[basics.Address]basics.AccountData{randomAccounts(5, true)}
 
 	pooldata := basics.AccountData{}
@@ -1240,6 +1257,9 @@ func BenchmarkLargeMerkleTrieRebuild(b *testing.B) {
 	sinkdata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
 	sinkdata.Status = basics.NotParticipating
 	accts[0][testSinkAddr] = sinkdata
+
+	ml := makeMockLedgerForTracker(b, true, 10, protocol.ConsensusCurrentVersion, accts)
+	defer ml.Close()
 
 	au := &accountUpdates{}
 	cfg := config.GetDefaultLocal()
@@ -1286,9 +1306,6 @@ func BenchmarkLargeMerkleTrieRebuild(b *testing.B) {
 func BenchmarkLargeCatchpointWriting(b *testing.B) {
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
-	ml := makeMockLedgerForTracker(b, true, 10, protocol.ConsensusCurrentVersion)
-	defer ml.Close()
-
 	accts := []map[basics.Address]basics.AccountData{randomAccounts(5, true)}
 
 	pooldata := basics.AccountData{}
@@ -1300,6 +1317,9 @@ func BenchmarkLargeCatchpointWriting(b *testing.B) {
 	sinkdata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
 	sinkdata.Status = basics.NotParticipating
 	accts[0][testSinkAddr] = sinkdata
+
+	ml := makeMockLedgerForTracker(b, true, 10, protocol.ConsensusCurrentVersion, accts)
+	defer ml.Close()
 
 	au := &accountUpdates{}
 	cfg := config.GetDefaultLocal()
@@ -1458,9 +1478,6 @@ func TestReproducibleCatchpointLabels(t *testing.T) {
 		delete(config.Consensus, testProtocolVersion)
 	}()
 
-	ml := makeMockLedgerForTracker(t, false, 1, testProtocolVersion)
-	defer ml.Close()
-
 	accts := []map[basics.Address]basics.AccountData{randomAccounts(20, true)}
 	rewardsLevels := []uint64{0}
 
@@ -1473,6 +1490,9 @@ func TestReproducibleCatchpointLabels(t *testing.T) {
 	sinkdata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
 	sinkdata.Status = basics.NotParticipating
 	accts[0][testSinkAddr] = sinkdata
+
+	ml := makeMockLedgerForTracker(t, false, 1, testProtocolVersion, accts)
+	defer ml.Close()
 
 	au := &accountUpdates{}
 	cfg := config.GetDefaultLocal()
@@ -1572,12 +1592,8 @@ func TestCachesInitialization(t *testing.T) {
 	proto := config.Consensus[protocolVersion]
 
 	initialRounds := uint64(1)
-
-	ml := makeMockLedgerForTracker(t, true, int(initialRounds), protocolVersion)
-	ml.log.SetLevel(logging.Warn)
-	defer ml.Close()
-
 	accountsCount := 5
+
 	accts := []map[basics.Address]basics.AccountData{randomAccounts(accountsCount, true)}
 	rewardsLevels := []uint64{0}
 
@@ -1590,6 +1606,10 @@ func TestCachesInitialization(t *testing.T) {
 	sinkdata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
 	sinkdata.Status = basics.NotParticipating
 	accts[0][testSinkAddr] = sinkdata
+
+	ml := makeMockLedgerForTracker(t, true, int(initialRounds), protocolVersion, accts)
+	ml.log.SetLevel(logging.Warn)
+	defer ml.Close()
 
 	au := &accountUpdates{}
 	au.initialize(config.GetDefaultLocal(), ".", proto, accts[0])
@@ -1629,6 +1649,7 @@ func TestCachesInitialization(t *testing.T) {
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
+		delta.Totals = acculateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
 		au.committedUpTo(basics.Round(i))
@@ -1638,8 +1659,11 @@ func TestCachesInitialization(t *testing.T) {
 	}
 	au.close()
 
+	// reset the accounts, since their balances are now changed due to the rewards.
+	accts = []map[basics.Address]basics.AccountData{randomAccounts(accountsCount, true)}
+
 	// create another mocked ledger, but this time with a fresh new tracker database.
-	ml2 := makeMockLedgerForTracker(t, true, int(initialRounds), protocolVersion)
+	ml2 := makeMockLedgerForTracker(t, true, int(initialRounds), protocolVersion, accts)
 	ml2.log.SetLevel(logging.Warn)
 	defer ml2.Close()
 
@@ -1667,10 +1691,6 @@ func TestSplittingConsensusVersionCommits(t *testing.T) {
 
 	initialRounds := uint64(1)
 
-	ml := makeMockLedgerForTracker(t, true, int(initialRounds), initProtocolVersion)
-	ml.log.SetLevel(logging.Warn)
-	defer ml.Close()
-
 	accountsCount := 5
 	accts := []map[basics.Address]basics.AccountData{randomAccounts(accountsCount, true)}
 	rewardsLevels := []uint64{0}
@@ -1684,6 +1704,10 @@ func TestSplittingConsensusVersionCommits(t *testing.T) {
 	sinkdata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
 	sinkdata.Status = basics.NotParticipating
 	accts[0][testSinkAddr] = sinkdata
+
+	ml := makeMockLedgerForTracker(t, true, int(initialRounds), initProtocolVersion, accts)
+	ml.log.SetLevel(logging.Warn)
+	defer ml.Close()
 
 	au := &accountUpdates{}
 	au.initialize(config.GetDefaultLocal(), ".", initialProtoParams, accts[0])
@@ -1781,10 +1805,6 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 
 	initialRounds := uint64(1)
 
-	ml := makeMockLedgerForTracker(t, true, int(initialRounds), initProtocolVersion)
-	ml.log.SetLevel(logging.Warn)
-	defer ml.Close()
-
 	accountsCount := 5
 	accts := []map[basics.Address]basics.AccountData{randomAccounts(accountsCount, true)}
 	rewardsLevels := []uint64{0}
@@ -1798,6 +1818,10 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 	sinkdata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
 	sinkdata.Status = basics.NotParticipating
 	accts[0][testSinkAddr] = sinkdata
+
+	ml := makeMockLedgerForTracker(t, true, int(initialRounds), initProtocolVersion, accts)
+	ml.log.SetLevel(logging.Warn)
+	defer ml.Close()
 
 	au := &accountUpdates{}
 	au.initialize(config.GetDefaultLocal(), ".", initialProtoParams, accts[0])

--- a/ledger/appcow.go
+++ b/ledger/appcow.go
@@ -470,7 +470,8 @@ func MakeDebugBalances(l ledgerForCowBase, round basics.Round, proto protocol.Co
 		UpgradeState: bookkeeping.UpgradeState{CurrentProtocol: proto},
 	}
 	hint := 2
-	cb := makeRoundCowState(base, hdr, config.Consensus[proto], prevTimestamp, hint)
+	// passing an empty AccountTotals here is fine since it's only being used by the top level cow state object.
+	cb := makeRoundCowState(base, hdr, config.Consensus[proto], prevTimestamp, ledgercore.AccountTotals{}, hint)
 	return cb
 }
 

--- a/ledger/appcow_test.go
+++ b/ledger/appcow_test.go
@@ -197,7 +197,7 @@ func TestCowStorage(t *testing.T) {
 	bh.CurrentProtocol = protocol.ConsensusCurrentVersion
 	proto, ok := config.Consensus[bh.CurrentProtocol]
 	require.True(t, ok)
-	cow := makeRoundCowState(&ml, bh, proto, 0, 0)
+	cow := makeRoundCowState(&ml, bh, proto, 0, ledgercore.AccountTotals{}, 0)
 	allSptrs, allAddrs := randomAddrApps(10)
 
 	st := makeStateTracker()

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -182,10 +182,10 @@ func TestBasicCatchpointWriter(t *testing.T) {
 		delete(config.Consensus, testProtocolVersion)
 		os.RemoveAll(temporaryDirectroy)
 	}()
-
-	ml := makeMockLedgerForTracker(t, true, 10, testProtocolVersion)
-	defer ml.Close()
 	accts := randomAccounts(300, false)
+
+	ml := makeMockLedgerForTracker(t, true, 10, testProtocolVersion, []map[basics.Address]basics.AccountData{accts})
+	defer ml.Close()
 
 	au := &accountUpdates{}
 	conf := config.GetDefaultLocal()
@@ -283,9 +283,9 @@ func TestFullCatchpointWriter(t *testing.T) {
 		os.RemoveAll(temporaryDirectroy)
 	}()
 
-	ml := makeMockLedgerForTracker(t, true, 10, testProtocolVersion)
-	defer ml.Close()
 	accts := randomAccounts(BalancesPerCatchpointFileChunk*3, false)
+	ml := makeMockLedgerForTracker(t, true, 10, testProtocolVersion, []map[basics.Address]basics.AccountData{accts})
+	defer ml.Close()
 
 	au := &accountUpdates{}
 	conf := config.GetDefaultLocal()

--- a/ledger/cow.go
+++ b/ledger/cow.go
@@ -77,9 +77,13 @@ type roundCowState struct {
 	groupIdx int
 	// track creatables created during each transaction in the round
 	trackedCreatables map[int]basics.CreatableIndex
+
+	// prevTotals contains the accounts totals for the previous round. It's being used to calculate the totals for the new round
+	// so that we could perform the validation test on these to ensure the block evaluator generate a valid changeset.
+	prevTotals ledgercore.AccountTotals
 }
 
-func makeRoundCowState(b roundCowParent, hdr bookkeeping.BlockHeader, proto config.ConsensusParams, prevTimestamp int64, hint int) *roundCowState {
+func makeRoundCowState(b roundCowParent, hdr bookkeeping.BlockHeader, proto config.ConsensusParams, prevTimestamp int64, prevTotals ledgercore.AccountTotals, hint int) *roundCowState {
 	cb := roundCowState{
 		lookupParent:      b,
 		commitParent:      nil,
@@ -87,6 +91,7 @@ func makeRoundCowState(b roundCowParent, hdr bookkeeping.BlockHeader, proto conf
 		mods:              ledgercore.MakeStateDelta(&hdr, prevTimestamp, hint, 0),
 		sdeltas:           make(map[basics.Address]map[storagePtr]*storageDelta),
 		trackedCreatables: make(map[int]basics.CreatableIndex),
+		prevTotals:        prevTotals,
 	}
 
 	// compatibilityMode retains producing application' eval deltas under the following rule:
@@ -284,4 +289,35 @@ func (cb *roundCowState) commitToParent() {
 
 func (cb *roundCowState) modifiedAccounts() []basics.Address {
 	return cb.mods.Accts.ModifiedAccounts()
+}
+
+// CalculateTotals calculates the totals given the changes in the StateDelta.
+// these changes allow the validator to validate that the totals still align with the
+// expected values. ( i.e. total amount of algos in the system should remain consistent )
+func (cb *roundCowState) CalculateTotals() error {
+	// this method applies only for the top level roundCowState
+	if cb.commitParent != nil {
+		return nil
+	}
+	totals := cb.prevTotals
+	var ot basics.OverflowTracker
+	totals.ApplyRewards(cb.mods.Hdr.RewardsLevel, &ot)
+
+	for i := 0; i < cb.mods.Accts.Len(); i++ {
+		accountAddr, updatedAccountData := cb.mods.Accts.GetByIdx(i)
+		previousAccountData, lookupError := cb.lookupParent.lookup(accountAddr)
+		if lookupError != nil {
+			return fmt.Errorf("roundCowState.CalculateTotals unable to load account data for address %v", accountAddr)
+		}
+		totals.DelAccount(cb.proto, previousAccountData, &ot)
+		totals.AddAccount(cb.proto, updatedAccountData, &ot)
+	}
+	cb.mods.Totals = totals
+	if ot.Overflowed {
+		return fmt.Errorf("roundCowState: CalculateTotals %d overflowed totals", cb.mods.Hdr.Round)
+	}
+	if totals.All() != cb.prevTotals.All() {
+		return fmt.Errorf("roundCowState: CalculateTotals sum of money changed from %d to %d", cb.prevTotals.All().Raw, totals.All().Raw)
+	}
+	return nil
 }

--- a/ledger/cow_test.go
+++ b/ledger/cow_test.go
@@ -116,7 +116,7 @@ func TestCowBalance(t *testing.T) {
 
 	c0 := makeRoundCowState(
 		&ml, bookkeeping.BlockHeader{}, config.Consensus[protocol.ConsensusCurrentVersion],
-		0, 0)
+		0, ledgercore.AccountTotals{}, 0)
 	checkCow(t, c0, accts0)
 
 	c1 := c0.child(0)

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -473,7 +473,7 @@ func startEvaluator(l ledgerForEvaluator, hdr bookkeeping.BlockHeader, proto con
 		eval.block.BlockHeader.RewardsState = eval.prevHeader.NextRewardsState(hdr.Round, proto, incentivePoolData.MicroAlgos, prevTotals.RewardUnits())
 	}
 	// set the eval state with the current header
-	eval.state = makeRoundCowState(base, eval.block.BlockHeader, proto, eval.prevHeader.TimeStamp, paysetHint)
+	eval.state = makeRoundCowState(base, eval.block.BlockHeader, proto, eval.prevHeader.TimeStamp, prevTotals, paysetHint)
 
 	if validate {
 		err := eval.block.BlockHeader.PreCheck(eval.prevHeader)
@@ -1119,6 +1119,11 @@ func (eval *BlockEvaluator) GenerateBlock() (*ValidatedBlock, error) {
 		return nil, err
 	}
 
+	err = eval.state.CalculateTotals()
+	if err != nil {
+		return nil, err
+	}
+
 	vb := ValidatedBlock{
 		blk:   eval.block,
 		delta: eval.state.deltas(),
@@ -1130,7 +1135,7 @@ func (eval *BlockEvaluator) GenerateBlock() (*ValidatedBlock, error) {
 			"unknown consensus version: %s", eval.block.BlockHeader.CurrentProtocol)
 	}
 	eval.state = makeRoundCowState(
-		eval.state, eval.block.BlockHeader, proto, eval.prevHeader.TimeStamp,
+		eval.state, eval.block.BlockHeader, proto, eval.prevHeader.TimeStamp, eval.state.mods.Totals,
 		len(eval.block.Payset))
 	return &vb, nil
 }

--- a/ledger/eval.go
+++ b/ledger/eval.go
@@ -1090,7 +1090,7 @@ func (eval *BlockEvaluator) finalValidation() error {
 		}
 	}
 
-	return nil
+	return eval.state.CalculateTotals()
 }
 
 // GenerateBlock produces a complete block from the BlockEvaluator.  This is
@@ -1115,11 +1115,6 @@ func (eval *BlockEvaluator) GenerateBlock() (*ValidatedBlock, error) {
 	}
 
 	err = eval.finalValidation()
-	if err != nil {
-		return nil, err
-	}
-
-	err = eval.state.CalculateTotals()
 	if err != nil {
 		return nil, err
 	}
@@ -1274,7 +1269,7 @@ transactionGroupLoop:
 
 	// If validating, do final block checks that depend on our new state
 	if validate {
-		// wait for the validation to complete.
+		// wait for the signature validation to complete.
 		select {
 		case <-ctx.Done():
 			return ledgercore.StateDelta{}, ctx.Err()
@@ -1286,10 +1281,11 @@ transactionGroupLoop:
 				return ledgercore.StateDelta{}, err
 			}
 		}
-		err = eval.finalValidation()
-		if err != nil {
-			return ledgercore.StateDelta{}, err
-		}
+	}
+
+	err = eval.finalValidation()
+	if err != nil {
+		return ledgercore.StateDelta{}, err
 	}
 
 	return eval.state.deltas(), nil

--- a/ledger/evalIndexer.go
+++ b/ledger/evalIndexer.go
@@ -213,5 +213,11 @@ func EvalForIndexer(il indexerLedgerForEval, block *bookkeeping.Block, proto con
 			fmt.Errorf("EvalForIndexer() err: %w", err)
 	}
 
+	err = eval.finalValidation()
+	if err != nil {
+		return ledgercore.StateDelta{}, []transactions.SignedTxnInBlock{},
+			fmt.Errorf("EvalForIndexer() err: %w", err)
+	}
+
 	return eval.state.deltas(), eval.block.Payset, nil
 }

--- a/ledger/eval_test.go
+++ b/ledger/eval_test.go
@@ -1054,7 +1054,7 @@ func TestCowCompactCert(t *testing.T) {
 	ml := mockLedger{balanceMap: accts0, blocks: blocks, blockErr: blockErr}
 	c0 := makeRoundCowState(
 		&ml, bookkeeping.BlockHeader{}, config.Consensus[protocol.ConsensusCurrentVersion],
-		0, 0)
+		0, ledgercore.AccountTotals{}, 0)
 
 	certType = protocol.CompactCertType(1234) // bad cert type
 	err := c0.compactCert(certRnd, certType, cert, atRound, validate)

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -98,7 +98,7 @@ type StateDelta struct {
 	// initial hint for allocating data structures for StateDelta
 	initialTransactionsCount int
 
-	// The account totals reflecting the changes in this StateDelta object. The
+	// The account totals reflecting the changes in this StateDelta object.
 	Totals AccountTotals
 }
 

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -97,6 +97,9 @@ type StateDelta struct {
 
 	// initial hint for allocating data structures for StateDelta
 	initialTransactionsCount int
+
+	// The account totals reflecting the changes in this StateDelta object. The
+	Totals AccountTotals
 }
 
 // AccountDeltas stores ordered accounts and allows fast lookup by address

--- a/ledger/txtail_test.go
+++ b/ledger/txtail_test.go
@@ -35,7 +35,8 @@ import (
 func TestTxTailCheckdup(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	ledger := makeMockLedgerForTracker(t, true, 1, protocol.ConsensusCurrentVersion)
+	accts := randomAccounts(10, false)
+	ledger := makeMockLedgerForTracker(t, true, 1, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{accts})
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	tail := txTail{}
 	require.NoError(t, tail.loadFromDisk(ledger))


### PR DESCRIPTION
## Summary

The account totals are being tested once every round to ensure that the total amount of money in the system doesn't change. Prior to this PR, the accounts update newBlock method was responsible for testing that : this would ensure that we're not writing a new round to disk that violates the totals predicate.

While this was working correctly, conducting this test at the time we're writing this information to the disk is too late. By that time, we've already agreed upon applying this (problematic) block to disk. Ideally, we could detect this situation ahead of time, and avoid agreeing on a block which would violate the totals predicate.

In this PR, we've moving the totals calculation as the last step of the delta state calculation. Few thoughts:
- From security perspective, it's just as secured, since the StateDeltas are always in-process and never shared across the network.
- From agreement perspective - in case we have a bug in the evaluator that would cause it to generate a state deltas that would violate the totals predicate, the evaluator is going to fail assembling the state deltas on the generator, validator and applicator ( i.e. "consumer" ). Ideally, in the future, we would be able to propose the empty block in such case, allowing the problematic transactions to time-out.
- From code-flow perspective - this seem to be a much better approach: a failure to store the block to the disk has only one potential outcome - panicking. Having the ability to detect that the state delta is invalid would give us a way out of that.

## Test Plan

1. Unit tests updated.
2. Tested against mainnet : catchup from scratch to force validation of the entire blockchain.