### PR TITLE
Support arm cross compile

### DIFF
--- a/scripts/archtype.sh
+++ b/scripts/archtype.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ ! -z "${GOHOSTARCH+x}" ]; then
+    echo "${GOHOSTARCH}"
+    exit 0
+fi
+
 ARCH=$(uname -m)
 
 if [[ "${ARCH}" = "x86_64" ]]; then

--- a/scripts/ostype.sh
+++ b/scripts/ostype.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ ! -z "${GOHOSTOS+x}" ]; then
+    echo "${GOHOSTOS}"
+    exit 0
+fi
+
 UNAME=$(uname)
 
 if [ "${UNAME}" = "Darwin" ]; then

--- a/test/muleCI/Jenkinsfile
+++ b/test/muleCI/Jenkinsfile
@@ -1,3 +1,3 @@
 @Library('go-algorand-ci') _
 
-muleCI('test/muleCI/mule.yaml', '0.0.12')
+muleCI('test/muleCI/mule.yaml', '0.0.23')

--- a/test/muleCI/mule.yaml
+++ b/test/muleCI/mule.yaml
@@ -197,11 +197,11 @@ jobs:
   build-linux-arm64:
     tasks:
       - docker.Make.build.arm64
-      #- stash.Stash.linux-arm64
+      - stash.Stash.linux-arm64
   build-linux-arm32:
     tasks:
       - docker.Make.build.arm
-      #- stash.Stash.linux-arm
+      - stash.Stash.linux-arm
   package-linux-amd64:
     tasks:
       - stash.Unstash.linux-amd64

--- a/test/muleCI/mule.yaml
+++ b/test/muleCI/mule.yaml
@@ -35,6 +35,7 @@ agents:
       - NETWORK=$NETWORK
       - VERSION=$VERSION
       - BUILD_NUMBER=$BUILD_NUMBER
+      - GOHOSTARCH=arm64
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
       - ARCH=arm64v8
@@ -48,6 +49,7 @@ agents:
       - NETWORK=$NETWORK
       - VERSION=$VERSION
       - BUILD_NUMBER=$BUILD_NUMBER
+      - GOHOSTARCH=arm
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
       - ARCH=arm32v6
@@ -195,11 +197,11 @@ jobs:
   build-linux-arm64:
     tasks:
       - docker.Make.build.arm64
-      - stash.Stash.linux-arm64
+      #- stash.Stash.linux-arm64
   build-linux-arm32:
     tasks:
       - docker.Make.build.arm
-      - stash.Stash.linux-arm
+      #- stash.Stash.linux-arm
   package-linux-amd64:
     tasks:
       - stash.Unstash.linux-amd64

--- a/test/muleCI/mule.yaml
+++ b/test/muleCI/mule.yaml
@@ -9,6 +9,7 @@ agents:
       - NETWORK=$NETWORK
       - VERSION=$VERSION
       - BUILD_NUMBER=$BUILD_NUMBER
+      - GOHOSTARCH=amd64
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
       - ARCH=amd64
@@ -22,6 +23,7 @@ agents:
       - NETWORK=$NETWORK
       - VERSION=$VERSION
       - BUILD_NUMBER=$BUILD_NUMBER
+      - GOHOSTARCH=amd64
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
       - ARCH=amd64
@@ -62,6 +64,7 @@ agents:
       - NETWORK=$NETWORK
       - VERSION=$VERSION
       - BUILD_NUMBER=$BUILD_NUMBER
+      - GOHOSTARCH=amd64
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
     volumes:
@@ -75,6 +78,7 @@ agents:
       - NETWORK=$NETWORK
       - VERSION=$VERSION
       - BUILD_NUMBER=$BUILD_NUMBER
+      - GOHOSTARCH=amd64
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
     volumes:


### PR DESCRIPTION
## Summary

This PR is to take advantage of arm64's ability to run arm32 binaries. Using this, we are able to build for arm32 on arm64 hosts by running containers with arm32 OS's on them. This is much faster than our qemu set up because it doesn't rely on emulations. The binaries produced with this process work and the arm64/arm32 build times are as fast as the intel builds, reducing our build time by about an hour.

## Test Plan

I ran our build pipeline against this branch using arm64 hosts and tested the produced artifacts using emulated cpu's to make sure they still work on their native architectures.
