### PR TITLE
Update telemetry credentials

### DIFF
--- a/logging/telemetryConfig.go
+++ b/logging/telemetryConfig.go
@@ -33,8 +33,8 @@ import (
 // TelemetryConfigFilename default file name for telemetry config "logging.config"
 var TelemetryConfigFilename = "logging.config"
 
-var defaultTelemetryUsername = "telemetry-v9"
-var defaultTelemetryPassword = "oq%$FA1TOJ!yYeMEcJ7D688eEOE#MGCu"
+var defaultTelemetryUsername = "telemetry-v10"
+var defaultTelemetryPassword = "ndn9lNvmoRD46i5gMljBZg"
 
 const hostnameLength = 255
 

--- a/test/testdata/configs/logging/logging.config.example
+++ b/test/testdata/configs/logging/logging.config.example
@@ -5,6 +5,6 @@
   "MinLogLevel":        4,
   "ReportHistoryLevel": 4,
   "LogHistoryDepth":    100,
-  "UserName":           "telemetry-v9",
-  "Password":           "oq%$FA1TOJ!yYeMEcJ7D688eEOE#MGCu"
+  "UserName":           "telemetry-v10",
+  "Password":           "ndn9lNvmoRD46i5gMljBZg"
 }


### PR DESCRIPTION
## Summary

Update telemetry configs so that we can stop receiving logs from very old algod instances that should not be running anymore. The plan is to deactivate the old credentials at some point after this change goes to mainnet

## Test Plan

I built a local branch with the new credentials and tested that telemetry.go isn't showing errors and logs are being reported to telemetry (stable-testnet-v1.0).
