### PR TITLE
testing: fix unit test data race

### DIFF
--- a/compactcert/worker_test.go
+++ b/compactcert/worker_test.go
@@ -393,7 +393,9 @@ func TestLatestSigsFromThisNode(t *testing.T) {
 	}
 
 	// Add a block that claims the compact cert is formed.
+	s.mu.Lock()
 	s.addBlock(3 * basics.Round(proto.CompactCertRounds))
+	s.mu.Unlock()
 
 	// Wait for the builder to discard the signatures.
 	time.Sleep(time.Second)


### PR DESCRIPTION
## Summary

The unit test `TestLatestSigsFromThisNode` was data racing. The fix is trivial.

## Test Plan

This is a test.