### PR TITLE
TestRequestBlockBytesErrors: Various fixes

### DIFF
--- a/catchup/universalFetcher.go
+++ b/catchup/universalFetcher.go
@@ -64,6 +64,9 @@ func (uf *universalBlockFetcher) fetchBlock(ctx context.Context, round basics.Ro
 			config: &uf.config,
 		}
 		fetchedBuf, err = fetcherClient.getBlockBytes(ctx, round)
+		if err != nil {
+			return nil, nil, time.Duration(0), err
+		}
 		address = fetcherClient.address()
 	} else if httpPeer, validHTTPPeer := peer.(network.HTTPPeer); validHTTPPeer {
 		fetcherClient := &HTTPFetcher{
@@ -74,14 +77,14 @@ func (uf *universalBlockFetcher) fetchBlock(ctx context.Context, round basics.Ro
 			log:     uf.log,
 			config:  &uf.config}
 		fetchedBuf, err = fetcherClient.getBlockBytes(ctx, round)
+		if err != nil {
+			return nil, nil, time.Duration(0), err
+		}
 		address = fetcherClient.address()
 	} else {
 		return nil, nil, time.Duration(0), fmt.Errorf("fetchBlock: UniversalFetcher only supports HTTPPeer and UnicastPeer")
 	}
 	downloadDuration = time.Now().Sub(blockDownloadStartTime)
-	if err != nil {
-		return nil, nil, time.Duration(0), err
-	}
 	block, cert, err := processBlockBytes(fetchedBuf, round, address)
 	if err != nil {
 		return nil, nil, time.Duration(0), err

--- a/catchup/universalFetcher_test.go
+++ b/catchup/universalFetcher_test.go
@@ -182,6 +182,7 @@ func TestRequestBlockBytesErrors(t *testing.T) {
 		t.Fatal(err)
 		return
 	}
+	defer ledger.Ledger.Close()
 
 	blockServiceConfig := config.GetDefaultLocal()
 	blockServiceConfig.EnableBlockService = true
@@ -191,6 +192,7 @@ func TestRequestBlockBytesErrors(t *testing.T) {
 	up := makeTestUnicastPeer(net, t)
 	ls := rpcs.MakeBlockService(logging.Base(), blockServiceConfig, ledger, net, "test genesisID")
 	ls.Start()
+	defer ls.Stop()
 
 	fetcher := makeUniversalBlockFetcher(logging.TestingLog(t), net, cfg)
 
@@ -198,7 +200,7 @@ func TestRequestBlockBytesErrors(t *testing.T) {
 	cancel()
 	_, _, _, err = fetcher.fetchBlock(ctx, next, up)
 	var wrfe errWsFetcherRequestFailed
-	require.True(t, errors.As(err, &wrfe))
+	require.True(t, errors.As(err, &wrfe), "unexpected err: %w", wrfe)
 	require.Equal(t, "context canceled", err.(errWsFetcherRequestFailed).cause)
 
 	ctx = context.Background()

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -21,7 +21,6 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/algorand/go-deadlock"
@@ -85,9 +84,6 @@ type Ledger struct {
 
 	// verifiedTxnCache holds all the verified transactions state
 	verifiedTxnCache verify.VerifiedTransactionCache
-
-	// wg to wait for the termination of goroutines using ledger/blockQ
-	wg sync.WaitGroup
 }
 
 // InitState structure defines blockchain init params
@@ -344,8 +340,6 @@ func initBlocksDB(tx *sql.Tx, l *Ledger, initBlocks []bookkeeping.Block, isArchi
 // Close reclaims resources used by the ledger (namely, the database connection
 // and goroutines used by trackers).
 func (l *Ledger) Close() {
-	l.wg.Wait()
-
 	// we shut the the blockqueue first, since it's sync goroutine dispatches calls
 	// back to the trackers.
 	if l.blockQ != nil {
@@ -650,16 +644,6 @@ func (l *Ledger) IsWritingCatchpointFile() bool {
 // VerifiedTransactionCache returns the verify.VerifiedTransactionCache
 func (l *Ledger) VerifiedTransactionCache() verify.VerifiedTransactionCache {
 	return l.verifiedTxnCache
-}
-
-// WaitGroupAdd adds a dependent routine on ledger/blockQ
-func (l *Ledger) WaitGroupAdd() {
-	l.wg.Add(1)
-}
-
-// WaitGroupDone removes a dependent routine on ledger/blockQ
-func (l *Ledger) WaitGroupDone() {
-	l.wg.Done()
 }
 
 // TxLease is an exported version of txlease

--- a/rpcs/blockService.go
+++ b/rpcs/blockService.go
@@ -125,6 +125,7 @@ func (bs *BlockService) Start() {
 		bs.net.RegisterHandlers(handlers)
 	}
 	bs.stop = make(chan struct{})
+	bs.ledger.WaitGroupAdd()
 	go bs.listenForCatchupReq(bs.catchupReqs, bs.stop)
 }
 
@@ -239,6 +240,7 @@ func (bs *BlockService) processIncomingMessage(msg network.IncomingMessage) (n n
 func (bs *BlockService) listenForCatchupReq(reqs <-chan network.IncomingMessage, stop chan struct{}) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	defer bs.ledger.WaitGroupDone()
 	for {
 		select {
 		case reqMsg := <-reqs:

--- a/rpcs/blockService.go
+++ b/rpcs/blockService.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/gorilla/mux"
 
@@ -72,6 +73,7 @@ type BlockService struct {
 	fallbackEndpoints       fallbackEndpoints
 	enableArchiverFallback  bool
 	log                     logging.Logger
+	closeWaitGroup          sync.WaitGroup
 }
 
 // EncodedBlockCert defines how GetBlockBytes encodes a block and its certificate
@@ -125,13 +127,14 @@ func (bs *BlockService) Start() {
 		bs.net.RegisterHandlers(handlers)
 	}
 	bs.stop = make(chan struct{})
-	bs.ledger.WaitGroupAdd()
+	bs.closeWaitGroup.Add(1)
 	go bs.listenForCatchupReq(bs.catchupReqs, bs.stop)
 }
 
 // Stop servicing catchup requests over ws
 func (bs *BlockService) Stop() {
 	close(bs.stop)
+	bs.closeWaitGroup.Wait()
 }
 
 // ServerHTTP returns blocks
@@ -238,9 +241,9 @@ func (bs *BlockService) processIncomingMessage(msg network.IncomingMessage) (n n
 
 // listenForCatchupReq handles catchup getblock request
 func (bs *BlockService) listenForCatchupReq(reqs <-chan network.IncomingMessage, stop chan struct{}) {
+	defer bs.closeWaitGroup.Done()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	defer bs.ledger.WaitGroupDone()
 	for {
 		select {
 		case reqMsg := <-reqs:


### PR DESCRIPTION
## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

The test TestRequestBlockBytesErrors has failed, and the reason is unidentifiable.
Various fixes are here, including more verbose error reporting to identify the issue when it occurs again.

- Add waitgrop to ledger to wait before closing the ledger and blockQ when goroutines are using them.
- In universalFetcher, return the error immediately in case of an error.
- Proper closing of objects in TestRequestBlockBytesErrors, and more verbose error reporting.


The waitGroup is needed for the following situation:

in blockService.go listenForCatchupReq

When, immediately after calling `bq.handleCatchupReq`, `BlockService.Stop()` is called, `blockQueue` will be `nil` by the time `blockQueue.getEncodedBlockCert` is called. 
```

0  0x0000000004e16846 in github.com/algorand/go-algorand/ledger.(*blockQueue).checkEntry
   at /Users/shantkarakashian/go/src/github.com/algorand/go-algorand/ledger/blockqueue.go:215
1  0x0000000004e174a9 in github.com/algorand/go-algorand/ledger.(*blockQueue).getEncodedBlockCert
   at /Users/shantkarakashian/go/src/github.com/algorand/go-algorand/ledger/blockqueue.go:295
2  0x0000000004e3a2a7 in github.com/algorand/go-algorand/ledger.(*Ledger).EncodedBlockCert
   at /Users/shantkarakashian/go/src/github.com/algorand/go-algorand/ledger/ledger.go:516
3  0x0000000004f46eed in github.com/algorand/go-algorand/rpcs.topicBlockBytes
   at /Users/shantkarakashian/go/src/github.com/algorand/go-algorand/rpcs/blockService.go:355
4  0x0000000004f45e1b in github.com/algorand/go-algorand/rpcs.(*BlockService).handleCatchupReq
   at /Users/shantkarakashian/go/src/github.com/algorand/go-algorand/rpcs/blockService.go:299
5  0x0000000004f45318 in github.com/algorand/go-algorand/rpcs.(*BlockService).listenForCatchupReq
   at /Users/shantkarakashian/go/src/github.com/algorand/go-algorand/rpcs/blockService.go:245

```

## Test Plan
Test is enhanced. 
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
