### PR TITLE
Allow getting versions for any package.

### DIFF
--- a/cmd/updater/versionCmd.go
+++ b/cmd/updater/versionCmd.go
@@ -33,17 +33,20 @@ var (
 	semanticOutput  bool
 )
 
+// DefaultPackageName is the package we'll use by default.
+const DefaultPackageName = "node"
+
 func init() {
 	versionCmd.AddCommand(checkCmd)
 	versionCmd.AddCommand(getCmd)
 
 	checkCmd.Flags().BoolVarP(&semanticOutput, "semantic", "s", false, "Human readable semantic version output.")
-	checkCmd.Flags().StringVarP(&packageName, "package", "p", "node", "Get version of specific package.")
+	checkCmd.Flags().StringVarP(&packageName, "package", "p", DefaultPackageName, "Get version of specific package.")
 	checkCmd.Flags().StringVarP(&versionBucket, "bucket", "b", "", "S3 bucket containing updates.")
 
 	getCmd.Flags().StringVarP(&destFile, "outputFile", "o", "", "Path for downloaded file (required).")
 	getCmd.Flags().Uint64VarP(&specificVersion, "version", "v", 0, "Specific version to download.")
-	getCmd.Flags().StringVarP(&packageName, "package", "p", "node", "Get version of specific package.")
+	getCmd.Flags().StringVarP(&packageName, "package", "p", DefaultPackageName, "Get version of specific package.")
 	getCmd.Flags().StringVarP(&versionBucket, "bucket", "b", "", "S3 bucket containing updates.")
 	getCmd.MarkFlagRequired("outputFile")
 }

--- a/util/s3/s3Helper.go
+++ b/util/s3/s3Helper.go
@@ -199,11 +199,6 @@ func makeS3Session(credentials *credentials.Credentials, bucket string) (helper 
 	return
 }
 
-// GetLatestUpdateVersion returns the latest version details for the 'node' package
-func (helper *Helper) GetLatestUpdateVersion(channel string) (maxVersion uint64, maxVersionName string, err error) {
-	return helper.GetUpdateVersion(channel, 0)
-}
-
 // GetLatestPackageVersion returns the latest version details for a given package name (eg node, install, tools)
 func (helper *Helper) GetLatestPackageVersion(channel string, packageName string) (maxVersion uint64, maxVersionName string, err error) {
 	return helper.GetPackageVersion(channel, packageName, 0)
@@ -212,12 +207,6 @@ func (helper *Helper) GetLatestPackageVersion(channel string, packageName string
 // GetLatestPackageFilesVersion returns the latest version details for a given standard filename prefix
 func (helper *Helper) GetLatestPackageFilesVersion(channel string, packagePrefix string) (maxVersion uint64, maxVersionName string, err error) {
 	return helper.GetPackageFilesVersion(channel, packagePrefix, 0)
-}
-
-// GetUpdateVersion ensures the specified version is present and returns the name of the file, if found
-// Or if specificVersion == 0, returns the name of the file with the max version
-func (helper *Helper) GetUpdateVersion(channel string, specificVersion uint64) (maxVersion uint64, maxVersionName string, err error) {
-	return helper.GetPackageVersion(channel, "node", specificVersion)
 }
 
 // DownloadFile downloads the specified file to the provided Writer


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Add an option to support version checking for arbitrary packages. This would allow us to deploy indexer releases at `algorand-releases/<channel>/indexer-*`

## Test Plan

Ran the command and see the correct regex:
```
~$ updater ver check -c nightly -p indexer
Checking for files matching: 'channel/nightly/indexer_nightly_linux-amd64_' in bucket algorand-releases
no updates found for channel 'nightly'
```