### PR TITLE
ledger: update EvalForIndexer to avoid totals computation

### DIFF
--- a/ledger/evalIndexer.go
+++ b/ledger/evalIndexer.go
@@ -213,11 +213,10 @@ func EvalForIndexer(il indexerLedgerForEval, block *bookkeeping.Block, proto con
 			fmt.Errorf("EvalForIndexer() err: %w", err)
 	}
 
-	err = eval.finalValidation()
-	if err != nil {
-		return ledgercore.StateDelta{}, []transactions.SignedTxnInBlock{},
-			fmt.Errorf("EvalForIndexer() err: %w", err)
-	}
+	// here, in the EvalForIndexer, we don't want to call finalValidation(). This would
+	// skip the calculation of the account totals in the state delta, which is a serious
+	// issue if it were to be used by algod, but it's perfectly fine for the indexer since
+	// it doesn't track any totals and therefore cannot calculate the new totals.
 
 	return eval.state.deltas(), eval.block.Payset, nil
 }


### PR DESCRIPTION
## Summary
In the EvalForIndexer, we don't want to call finalValidation(). This would
skip the calculation of the account totals in the state delta, which is a serious
issue if it were to be used by algod, but it's perfectly fine for the indexer since
it doesn't track any totals and therefore cannot calculate the new totals.

## Test Plan

Test against the indexer.