### PR TITLE
Add application account into a dryrun req created by goal

### DIFF
--- a/cmd/goal/application.go
+++ b/cmd/goal/application.go
@@ -31,7 +31,6 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/data/transactions/logic"
-	"github.com/algorand/go-algorand/libgoal"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -434,19 +433,13 @@ var createAppCmd = &cobra.Command{
 			}
 		} else {
 			if dumpForDryrun {
-				// Write dryrun data to file
-				proto, _ := getProto(protoVersion)
-				data, err := libgoal.MakeDryrunStateBytes(client, tx, []transactions.SignedTxn{}, string(proto), dumpForDryrunFormat.String())
-				if err != nil {
-					reportErrorf(err.Error())
-				}
-				writeFile(outFilename, data, 0600)
+				err = writeDryrunReqToFile(client, tx, outFilename)
 			} else {
 				// Write transaction to file
 				err = writeTxnToFile(client, sign, dataDir, walletName, tx, outFilename)
-				if err != nil {
-					reportErrorf(err.Error())
-				}
+			}
+			if err != nil {
+				reportErrorf(err.Error())
 			}
 		}
 	},
@@ -513,18 +506,12 @@ var updateAppCmd = &cobra.Command{
 			}
 		} else {
 			if dumpForDryrun {
-				// Write dryrun data to file
-				proto, _ := getProto(protoVersion)
-				data, err := libgoal.MakeDryrunStateBytes(client, tx, []transactions.SignedTxn{}, string(proto), dumpForDryrunFormat.String())
-				if err != nil {
-					reportErrorf(err.Error())
-				}
-				writeFile(outFilename, data, 0600)
+				err = writeDryrunReqToFile(client, tx, outFilename)
 			} else {
 				err = writeTxnToFile(client, sign, dataDir, walletName, tx, outFilename)
-				if err != nil {
-					reportErrorf(err.Error())
-				}
+			}
+			if err != nil {
+				reportErrorf(err.Error())
 			}
 		}
 	},
@@ -590,18 +577,12 @@ var optInAppCmd = &cobra.Command{
 			}
 		} else {
 			if dumpForDryrun {
-				// Write dryrun data to file
-				proto, _ := getProto(protoVersion)
-				data, err := libgoal.MakeDryrunStateBytes(client, tx, []transactions.SignedTxn{}, string(proto), dumpForDryrunFormat.String())
-				if err != nil {
-					reportErrorf(err.Error())
-				}
-				writeFile(outFilename, data, 0600)
+				err = writeDryrunReqToFile(client, tx, outFilename)
 			} else {
 				err = writeTxnToFile(client, sign, dataDir, walletName, tx, outFilename)
-				if err != nil {
-					reportErrorf(err.Error())
-				}
+			}
+			if err != nil {
+				reportErrorf(err.Error())
 			}
 		}
 	},
@@ -667,18 +648,12 @@ var closeOutAppCmd = &cobra.Command{
 			}
 		} else {
 			if dumpForDryrun {
-				// Write dryrun data to file
-				proto, _ := getProto(protoVersion)
-				data, err := libgoal.MakeDryrunStateBytes(client, tx, []transactions.SignedTxn{}, string(proto), dumpForDryrunFormat.String())
-				if err != nil {
-					reportErrorf(err.Error())
-				}
-				writeFile(outFilename, data, 0600)
+				err = writeDryrunReqToFile(client, tx, outFilename)
 			} else {
 				err = writeTxnToFile(client, sign, dataDir, walletName, tx, outFilename)
-				if err != nil {
-					reportErrorf(err.Error())
-				}
+			}
+			if err != nil {
+				reportErrorf(err.Error())
 			}
 		}
 	},
@@ -744,18 +719,12 @@ var clearAppCmd = &cobra.Command{
 			}
 		} else {
 			if dumpForDryrun {
-				// Write dryrun data to file
-				proto, _ := getProto(protoVersion)
-				data, err := libgoal.MakeDryrunStateBytes(client, tx, []transactions.SignedTxn{}, string(proto), dumpForDryrunFormat.String())
-				if err != nil {
-					reportErrorf(err.Error())
-				}
-				writeFile(outFilename, data, 0600)
+				err = writeDryrunReqToFile(client, tx, outFilename)
 			} else {
 				err = writeTxnToFile(client, sign, dataDir, walletName, tx, outFilename)
-				if err != nil {
-					reportErrorf(err.Error())
-				}
+			}
+			if err != nil {
+				reportErrorf(err.Error())
 			}
 		}
 	},
@@ -821,18 +790,12 @@ var callAppCmd = &cobra.Command{
 			}
 		} else {
 			if dumpForDryrun {
-				// Write dryrun data to file
-				proto, _ := getProto(protoVersion)
-				data, err := libgoal.MakeDryrunStateBytes(client, tx, []transactions.SignedTxn{}, string(proto), dumpForDryrunFormat.String())
-				if err != nil {
-					reportErrorf(err.Error())
-				}
-				writeFile(outFilename, data, 0600)
+				err = writeDryrunReqToFile(client, tx, outFilename)
 			} else {
 				err = writeTxnToFile(client, sign, dataDir, walletName, tx, outFilename)
-				if err != nil {
-					reportErrorf(err.Error())
-				}
+			}
+			if err != nil {
+				reportErrorf(err.Error())
 			}
 		}
 	},
@@ -898,18 +861,13 @@ var deleteAppCmd = &cobra.Command{
 			}
 		} else {
 			if dumpForDryrun {
-				// Write dryrun data to file
-				proto, _ := getProto(protoVersion)
-				data, err := libgoal.MakeDryrunStateBytes(client, tx, []transactions.SignedTxn{}, string(proto), dumpForDryrunFormat.String())
-				if err != nil {
-					reportErrorf(err.Error())
-				}
-				writeFile(outFilename, data, 0600)
+				err = writeDryrunReqToFile(client, tx, outFilename)
 			} else {
 				err = writeTxnToFile(client, sign, dataDir, walletName, tx, outFilename)
-				if err != nil {
-					reportErrorf(err.Error())
-				}
+
+			}
+			if err != nil {
+				reportErrorf(err.Error())
 			}
 		}
 	},

--- a/cmd/goal/common.go
+++ b/cmd/goal/common.go
@@ -41,14 +41,15 @@ var lastValid uint64
 var numValidRounds uint64 // also used in account and asset
 
 var (
-	fee             uint64
-	outFilename     string
-	sign            bool
-	noteBase64      string
-	noteText        string
-	lease           string
-	noWaitAfterSend bool
-	dumpForDryrun   bool
+	fee                uint64
+	outFilename        string
+	sign               bool
+	noteBase64         string
+	noteText           string
+	lease              string
+	noWaitAfterSend    bool
+	dumpForDryrun      bool
+	dumpForDryrunAccts []string
 )
 
 var dumpForDryrunFormat cobraStringValue = *makeCobraStringValue("json", []string{"msgp"})
@@ -66,6 +67,7 @@ func addTxnFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&noWaitAfterSend, "no-wait", "N", false, "Don't wait for transaction to commit")
 	cmd.Flags().BoolVar(&dumpForDryrun, "dryrun-dump", false, "Dump in dryrun format acceptable by dryrun REST api")
 	cmd.Flags().Var(&dumpForDryrunFormat, "dryrun-dump-format", "Dryrun dump format: "+dumpForDryrunFormat.AllowedString())
+	cmd.Flags().StringSliceVar(&dumpForDryrunAccts, "dryrun-accounts", nil, "additional accounts to include into dryrun request obj")
 }
 
 type cobraStringValue struct {

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -970,18 +970,18 @@ func (c *Client) Catchup(catchpointLabel string) error {
 const defaultAppIdx = 1380011588
 
 // MakeDryrunStateBytes function creates DryrunRequest data structure in serialized form according to the format
-func MakeDryrunStateBytes(client Client, txnOrStxn interface{}, other []transactions.SignedTxn, proto string, format string) (result []byte, err error) {
+func MakeDryrunStateBytes(client Client, txnOrStxn interface{}, otherTxns []transactions.SignedTxn, otherAccts []basics.Address, proto string, format string) (result []byte, err error) {
 	switch format {
 	case "json":
 		var gdr generatedV2.DryrunRequest
-		gdr, err = MakeDryrunStateGenerated(client, txnOrStxn, other, proto)
+		gdr, err = MakeDryrunStateGenerated(client, txnOrStxn, otherTxns, otherAccts, proto)
 		if err == nil {
 			result = protocol.EncodeJSON(&gdr)
 		}
 		return
 	case "msgp":
 		var dr v2.DryrunRequest
-		dr, err = MakeDryrunState(client, txnOrStxn, other, proto)
+		dr, err = MakeDryrunState(client, txnOrStxn, otherTxns, otherAccts, proto)
 		if err == nil {
 			result = protocol.EncodeReflect(&dr)
 		}
@@ -992,8 +992,8 @@ func MakeDryrunStateBytes(client Client, txnOrStxn interface{}, other []transact
 }
 
 // MakeDryrunState function creates v2.DryrunRequest data structure
-func MakeDryrunState(client Client, txnOrStxn interface{}, other []transactions.SignedTxn, proto string) (dr v2.DryrunRequest, err error) {
-	gdr, err := MakeDryrunStateGenerated(client, txnOrStxn, other, proto)
+func MakeDryrunState(client Client, txnOrStxn interface{}, otherTxns []transactions.SignedTxn, otherAccts []basics.Address, proto string) (dr v2.DryrunRequest, err error) {
+	gdr, err := MakeDryrunStateGenerated(client, txnOrStxn, otherTxns, otherAccts, proto)
 	if err != nil {
 		return
 	}
@@ -1001,7 +1001,7 @@ func MakeDryrunState(client Client, txnOrStxn interface{}, other []transactions.
 }
 
 // MakeDryrunStateGenerated function creates generatedV2.DryrunRequest data structure
-func MakeDryrunStateGenerated(client Client, txnOrStxn interface{}, other []transactions.SignedTxn, proto string) (dr generatedV2.DryrunRequest, err error) {
+func MakeDryrunStateGenerated(client Client, txnOrStxn interface{}, otherTxns []transactions.SignedTxn, otherAccts []basics.Address, proto string) (dr generatedV2.DryrunRequest, err error) {
 	var txns []transactions.SignedTxn
 	if txnOrStxn == nil {
 		// empty input do nothing
@@ -1014,7 +1014,7 @@ func MakeDryrunStateGenerated(client Client, txnOrStxn interface{}, other []tran
 		return
 	}
 
-	txns = append(txns, other...)
+	txns = append(txns, otherTxns...)
 	for i := range txns {
 		enc := protocol.EncodeJSON(&txns[i])
 		dr.Txns = append(dr.Txns, enc)
@@ -1023,6 +1023,9 @@ func MakeDryrunStateGenerated(client Client, txnOrStxn interface{}, other []tran
 	for _, txn := range txns {
 		tx := txn.Txn
 		if tx.Type == protocol.ApplicationCallTx {
+			accounts := append(tx.Accounts, tx.Sender)
+			accounts = append(accounts, otherAccts...)
+
 			apps := []basics.AppIndex{tx.ApplicationID}
 			apps = append(apps, tx.ForeignApps...)
 			for _, appIdx := range apps {
@@ -1049,6 +1052,7 @@ func MakeDryrunStateGenerated(client Client, txnOrStxn interface{}, other []tran
 						return
 					}
 					appParams = app.Params
+					accounts = append(accounts, appIdx.Address())
 				}
 				dr.Apps = append(dr.Apps, generatedV2.Application{
 					Id:     uint64(appIdx),
@@ -1056,11 +1060,10 @@ func MakeDryrunStateGenerated(client Client, txnOrStxn interface{}, other []tran
 				})
 			}
 
-			accounts := append(tx.Accounts, tx.Sender)
 			for _, acc := range accounts {
 				var info generatedV2.Account
 				if info, err = client.AccountInformationV2(acc.String()); err != nil {
-					return
+					// ignore error and continue
 				}
 				dr.Accounts = append(dr.Accounts, info)
 			}

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -1063,7 +1063,8 @@ func MakeDryrunStateGenerated(client Client, txnOrStxn interface{}, otherTxns []
 			for _, acc := range accounts {
 				var info generatedV2.Account
 				if info, err = client.AccountInformationV2(acc.String()); err != nil {
-					// ignore error and continue
+					// ignore error - accounts might have app addresses that were not funded
+					continue
 				}
 				dr.Accounts = append(dr.Accounts, info)
 			}


### PR DESCRIPTION
## Summary

* AVM 1.0 introduces application accounts
* `goal clerk` needs to consider this account when creates dryrun request object
* Added a new option `--dryrun-accounts` for adding accounts that were rekeyed to an app account (or any other accounts).

## Test Plan

Tested manually. I'll add example from Jason W into sub-e2e tests in subseq PRs (need inner txns for indexer as well)