### PR TITLE
Algod clientv2

### DIFF
--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -537,7 +537,7 @@ func (client RestClient) Block(round uint64) (response v1.Block, err error) {
 }
 
 // Block gets the block info for the given round using the V2 API
-func (client RestClient) BlockV2(round uint64) (response v1.Block, err error) {
+func (client RestClient) BlockV2(round uint64) (response generatedV2.BlockResponse, err error) {
 	err = client.get(&response, fmt.Sprintf("/v2/blocks/%d", round), nil)
 	return
 }


### PR DESCRIPTION

## Summary

Draft of Algod rest client changes needed for  #2985 

Adding additional methods with explicit version seems safer than switching on affinity and converting old to new.  It still feels weird given some methods do the switching and these wont. 

A more comprehensive refactor might expose the un-versioned method names with some dispatching to the correct version and do switching and conversion with errors reported for unsupported endpoints

## Test Plan

tbd