### PR TITLE
Increase machine size to large and use consistent parallelism for circleci nightly testing.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -412,7 +412,7 @@ jobs:
     parameters:
       platform:
         type: string
-    executor: << parameters.platform >>_medium
+    executor: << parameters.platform >>_large
     working_directory: /opt/cibuild/project
     parallelism: 4
     steps:
@@ -427,7 +427,7 @@ jobs:
     parameters:
       platform:
         type: string
-    executor: << parameters.platform >>_medium
+    executor: << parameters.platform >>_large
     working_directory: /opt/cibuild/project
     parallelism: 4
     steps:
@@ -445,9 +445,9 @@ jobs:
     parameters:
       platform:
         type: string
-    executor: << parameters.platform >>_medium
+    executor: << parameters.platform >>_large
     working_directory: /opt/cibuild/project
-    parallelism: 2
+    parallelism: 4
     environment:
       E2E_TEST_FILTER: "GO"
     steps:
@@ -461,9 +461,9 @@ jobs:
     parameters:
       platform:
         type: string
-    executor: << parameters.platform >>_medium
+    executor: << parameters.platform >>_large
     working_directory: /opt/cibuild/project
-    parallelism: 2
+    parallelism: 4
     environment:
       E2E_TEST_FILTER: "GO"
     steps:
@@ -479,9 +479,9 @@ jobs:
     parameters:
       platform:
         type: string
-    executor: << parameters.platform >>_medium
+    executor: << parameters.platform >>_large
     working_directory: /opt/cibuild/project
-    parallelism: 2
+    parallelism: 4
     environment:
       E2E_TEST_FILTER: "EXPECT"
     steps:
@@ -495,9 +495,9 @@ jobs:
     parameters:
       platform:
         type: string
-    executor: << parameters.platform >>_medium
+    executor: << parameters.platform >>_large
     working_directory: /opt/cibuild/project
-    parallelism: 2
+    parallelism: 4
     environment:
       E2E_TEST_FILTER: "EXPECT"
     steps:
@@ -515,6 +515,7 @@ jobs:
         type: string
     executor: << parameters.platform >>_large
     working_directory: /opt/cibuild/project
+    parallelism: 4
     environment:
       E2E_TEST_FILTER: "SCRIPTS"
     steps:
@@ -530,6 +531,7 @@ jobs:
         type: string
     executor: << parameters.platform >>_large
     working_directory: /opt/cibuild/project
+    parallelism: 4
     environment:
       E2E_TEST_FILTER: "SCRIPTS"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ workflows:
               only:
                 - /rel\/.*/
                 - /hotfix\/.*/
-                - /egieseke/update-circle-machine-size\/.*/
+                - /pull\/[0-9]+/
           context: slack-secrets
 
       - integration:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ workflows:
                 - /rel\/.*/
                 - /hotfix\/.*/
                 - /pull\/[0-9]+/
-          context: slack-secrets
+#          context: slack-secrets
 
       - integration:
           name: << matrix.platform >>_integration
@@ -90,7 +90,7 @@ workflows:
             - << matrix.platform >>_build
           filters:
             <<: *filters-nightly
-          context: slack-secrets
+#          context: slack-secrets
 
       - e2e_expect:
           name: << matrix.platform >>_e2e_expect
@@ -109,7 +109,7 @@ workflows:
             - << matrix.platform >>_build
           filters:
             <<: *filters-nightly
-          context: slack-secrets
+#          context: slack-secrets
 
       - e2e_subs:
           name: << matrix.platform >>_e2e_subs
@@ -128,7 +128,7 @@ workflows:
             - << matrix.platform >>_build
           filters:
             <<: *filters-nightly
-          context: slack-secrets
+#          context: slack-secrets
 
       - tests_verification_job:
           name: << matrix.platform >>_<< matrix.job_type >>_verification
@@ -438,9 +438,9 @@ jobs:
           result_subdir: << parameters.platform >>_test_nightly
           no_output_timeout: 45m
       - upload_coverage
-      - slack/notify: &slack-fail-event
-          event: fail
-          template: basic_fail_1
+#      - slack/notify: &slack-fail-event
+#          event: fail
+#          template: basic_fail_1
 
   integration:
     parameters:
@@ -473,8 +473,8 @@ jobs:
       - generic_integration:
           result_subdir: << parameters.platform >>_integration_nightly
           no_output_timeout: 45m
-      - slack/notify:
-          <<: *slack-fail-event
+#      - slack/notify:
+#          <<: *slack-fail-event
 
   e2e_expect:
     parameters:
@@ -507,8 +507,8 @@ jobs:
       - generic_integration:
           result_subdir: << parameters.platform>>_e2e_expect_nightly
           no_output_timeout: 45m
-      - slack/notify:
-          <<: *slack-fail-event
+#      - slack/notify:
+#          <<: *slack-fail-event
 
   e2e_subs:
     parameters:
@@ -541,8 +541,8 @@ jobs:
       - generic_integration:
           result_subdir: << parameters.platform >>_e2e_subs_nightly
           no_output_timeout: 45m
-      - slack/notify:
-          <<: *slack-fail-event
+#      - slack/notify:
+#          <<: *slack-fail-event
 
   windows_x64_build:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,7 @@ workflows:
               only:
                 - /rel\/.*/
                 - /hotfix\/.*/
-                - /pull\/[0-9]+/
-#          context: slack-secrets
+          context: slack-secrets
 
       - integration:
           name: << matrix.platform >>_integration
@@ -90,7 +89,7 @@ workflows:
             - << matrix.platform >>_build
           filters:
             <<: *filters-nightly
-#          context: slack-secrets
+          context: slack-secrets
 
       - e2e_expect:
           name: << matrix.platform >>_e2e_expect
@@ -109,7 +108,7 @@ workflows:
             - << matrix.platform >>_build
           filters:
             <<: *filters-nightly
-#          context: slack-secrets
+          context: slack-secrets
 
       - e2e_subs:
           name: << matrix.platform >>_e2e_subs
@@ -128,7 +127,7 @@ workflows:
             - << matrix.platform >>_build
           filters:
             <<: *filters-nightly
-#          context: slack-secrets
+          context: slack-secrets
 
       - tests_verification_job:
           name: << matrix.platform >>_<< matrix.job_type >>_verification
@@ -438,9 +437,9 @@ jobs:
           result_subdir: << parameters.platform >>_test_nightly
           no_output_timeout: 45m
       - upload_coverage
-#      - slack/notify: &slack-fail-event
-#          event: fail
-#          template: basic_fail_1
+      - slack/notify: &slack-fail-event
+          event: fail
+          template: basic_fail_1
 
   integration:
     parameters:
@@ -473,8 +472,8 @@ jobs:
       - generic_integration:
           result_subdir: << parameters.platform >>_integration_nightly
           no_output_timeout: 45m
-#      - slack/notify:
-#          <<: *slack-fail-event
+      - slack/notify:
+          <<: *slack-fail-event
 
   e2e_expect:
     parameters:
@@ -507,8 +506,8 @@ jobs:
       - generic_integration:
           result_subdir: << parameters.platform>>_e2e_expect_nightly
           no_output_timeout: 45m
-#      - slack/notify:
-#          <<: *slack-fail-event
+      - slack/notify:
+          <<: *slack-fail-event
 
   e2e_subs:
     parameters:
@@ -541,8 +540,8 @@ jobs:
       - generic_integration:
           result_subdir: << parameters.platform >>_e2e_subs_nightly
           no_output_timeout: 45m
-#      - slack/notify:
-#          <<: *slack-fail-event
+      - slack/notify:
+          <<: *slack-fail-event
 
   windows_x64_build:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ workflows:
               only:
                 - /rel\/.*/
                 - /hotfix\/.*/
+                - /egieseke/update-circle-machine-size\/.*/
           context: slack-secrets
 
       - integration:


### PR DESCRIPTION

## Summary

For CircleCI testing, increase machine size from medium to large and set parallelism to 4.

## Test Plan

Testing by running nightly builds on the branch.
