### PR TITLE
Adjust the application of dontReportFailures in syncTest

### DIFF
--- a/test/framework/fixtures/fixture.go
+++ b/test/framework/fixtures/fixture.go
@@ -109,7 +109,6 @@ func (st *synchTest) Error(args ...interface{}) {
 	st.Lock()
 	defer st.Unlock()
 	if !st.dontReportFailures {
-		st.dontReportFailures = true
 		st.t.Error(args...)
 	}
 }
@@ -117,7 +116,6 @@ func (st *synchTest) Errorf(format string, args ...interface{}) {
 	st.Lock()
 	defer st.Unlock()
 	if !st.dontReportFailures {
-		st.dontReportFailures = true
 		st.t.Errorf(format, args...)
 	}
 }
@@ -125,7 +123,6 @@ func (st *synchTest) Fail() {
 	st.Lock()
 	defer st.Unlock()
 	if !st.dontReportFailures {
-		st.dontReportFailures = true
 		st.t.Fail()
 	}
 }


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
In testing.T, Error, Errorf, and Fail do not terminate the test.
Error and Errorf call Fail.
There will be another call to FailNow to terminate the test. (FailNow also calls Fail.)

When dontReportFailures is set in Error, Errorf, and Fail, the test will not be terminated.
Moreover, the subsequent call to FailNow will be ignored because of the set dontReportFailures flag.

In this change, dontReportFailures will not be set for Error, Errorf, and Fail so that the subsequent FailNow will terminate the test.

This issue is a fallout from https://github.com/algorand/go-algorand/pull/2844

Fixes #3020

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan
This is a fix to the testing infrastructure. 

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
