### PR TITLE
ledger: fix regression in transaction pool

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -760,6 +760,10 @@ func (pool *TransactionPool) recomputeBlockEvaluator(committedTxIds map[transact
 	}
 	pool.pendingBlockEvaluator, err = pool.ledger.StartEvaluator(next.BlockHeader, hint, pool.calculateMaxTxnBytesPerBlock(next.BlockHeader.CurrentProtocol))
 	if err != nil {
+		// The pendingBlockEvaluator is an interface, and in case of an evaluator error
+		// we want to remove the interface itself rather then keeping an interface
+		// to a nil.
+		pool.pendingBlockEvaluator = nil
 		var nonSeqBlockEval ledgercore.ErrNonSequentialBlockEval
 		if errors.As(err, &nonSeqBlockEval) {
 			if nonSeqBlockEval.EvaluatorRound <= nonSeqBlockEval.LatestRound {


### PR DESCRIPTION
## Summary

This PR addresses a regression introduced in https://github.com/algorand/go-algorand/pull/2983. 
The culprit is that an interface might contain a nil pointer, which makes it insufficient to test the interface pointer itself.

Fail cases: https://app.circleci.com/pipelines/github/algorand/go-algorand/2451/workflows/8807ced7-89ae-4b6b-96b0-1bc5bdf9d84c/jobs/27259/tests#failed-test-0

## Test Plan

Use existing unit testing. In particular TestCatchupOverGossip.