### PR TITLE
ledger: move StartEvaluator parameters into an object

### DIFF
--- a/ledger/internal/appcow.go
+++ b/ledger/internal/appcow.go
@@ -459,7 +459,7 @@ func (cb *roundCowState) DelKey(addr basics.Address, aidx basics.AppIndex, globa
 
 // MakeDebugBalances creates a ledger suitable for dryrun and debugger
 func MakeDebugBalances(l LedgerForCowBase, round basics.Round, proto protocol.ConsensusVersion, prevTimestamp int64) apply.Balances {
-	base := makeRoundCowBase(l, round-1, 0, basics.Round(0), config.Consensus[proto])
+	base := makeRoundCowBase(l, round-1, 0, basics.Round(0), config.Consensus[proto], nil, nil)
 
 	hdr := bookkeeping.BlockHeader{
 		Round:        round,

--- a/ledger/internal/eval_test.go
+++ b/ledger/internal/eval_test.go
@@ -1030,12 +1030,13 @@ func (ledger *evalTestLedger) Validate(ctx context.Context, blk bookkeeping.Bloc
 // payset being evaluated is known in advance, a paysetHint >= 0 can be
 // passed, avoiding unnecessary payset slice growth.
 func (ledger *evalTestLedger) StartEvaluator(hdr bookkeeping.BlockHeader, paysetHint, maxTxnBytesPerBlock int) (*BlockEvaluator, error) {
-	proto, ok := config.Consensus[hdr.CurrentProtocol]
-	if !ok {
-		return nil, protocol.Error(hdr.CurrentProtocol)
-	}
-
-	return StartEvaluator(ledger, hdr, proto, paysetHint, true, true, maxTxnBytesPerBlock)
+	return StartEvaluator(ledger, hdr,
+		EvaluatorOptions{
+			PaysetHint:          paysetHint,
+			Validate:            true,
+			Generate:            true,
+			MaxTxnBytesPerBlock: maxTxnBytesPerBlock,
+		})
 }
 
 // GetCreatorForRound takes a CreatableIndex and a CreatableType and tries to

--- a/ledger/internal/evalindexer.go
+++ b/ledger/internal/evalindexer.go
@@ -19,7 +19,6 @@ package internal
 import (
 	"fmt"
 
-	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
@@ -54,40 +53,4 @@ func (eval *BlockEvaluator) ProcessBlockForIndexer(block *bookkeeping.Block) (le
 	// it doesn't track any totals and therefore cannot calculate the new totals.
 
 	return eval.state.deltas(), eval.block.Payset, nil
-}
-
-// PreloadAccountDataCache initialize the account data cache so that we won't need to make a
-// ledger query for that account.
-func (eval *BlockEvaluator) PreloadAccountDataCache(accountDataMap map[basics.Address]*basics.AccountData) {
-	base := eval.state.lookupParent.(*roundCowBase)
-	for address, accountData := range accountDataMap {
-		if accountData == nil {
-			base.accounts[address] = basics.AccountData{}
-		} else {
-			base.accounts[address] = *accountData
-		}
-	}
-}
-
-// EvalForIndexerResources contains resources preloaded from the Indexer database.
-// Indexer is able to do the preloading more efficiently than the evaluator loading
-// resources one by one.
-type EvalForIndexerResources struct {
-	// The map value is nil iff the account does not exist. The account data is owned here.
-	Accounts map[basics.Address]*basics.AccountData
-	Creators map[Creatable]ledgercore.FoundAddress
-}
-
-// SaveResourcesInCowBase saves the given resources into the rowCowBase accounts & creators cache.
-func (eval *BlockEvaluator) SaveResourcesInCowBase(resources EvalForIndexerResources) {
-	base := eval.state.lookupParent.(*roundCowBase)
-	for address, accountData := range resources.Accounts {
-		if accountData == nil {
-			base.accounts[address] = basics.AccountData{}
-		} else {
-			base.accounts[address] = *accountData
-		}
-	}
-
-	base.creators = resources.Creators
 }

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -672,12 +672,13 @@ func (l *Ledger) VerifiedTransactionCache() verify.VerifiedTransactionCache {
 // If a value of zero or less is passed to maxTxnBytesPerBlock, the consensus MaxTxnBytesPerBlock would
 // be used instead.
 func (l *Ledger) StartEvaluator(hdr bookkeeping.BlockHeader, paysetHint, maxTxnBytesPerBlock int) (*internal.BlockEvaluator, error) {
-	proto, ok := config.Consensus[hdr.CurrentProtocol]
-	if !ok {
-		return nil, protocol.Error(hdr.CurrentProtocol)
-	}
-
-	return internal.StartEvaluator(l, hdr, proto, paysetHint, true, true, maxTxnBytesPerBlock)
+	return internal.StartEvaluator(l, hdr,
+		internal.EvaluatorOptions{
+			PaysetHint:          paysetHint,
+			Generate:            true,
+			Validate:            true,
+			MaxTxnBytesPerBlock: maxTxnBytesPerBlock,
+		})
 }
 
 // Validate uses the ledger to validate block blk as a candidate next block.


### PR DESCRIPTION
## Summary

move StartEvaluator parameters into an object. Given that most of the time the parameters are using a "default" state, it reduce the number of passed parameters, improving the caller readability.

## Test Plan

Unit tests updated.
