### PR TITLE
testing: make the TestMultiThreaded run at a constant time

### DIFF
--- a/txnsync/msgorderingheap_test.go
+++ b/txnsync/msgorderingheap_test.go
@@ -128,7 +128,7 @@ func TestMultiThreaded(t *testing.T) {
 
 	a := require.New(t)
 
-	loopCount := 1000
+	loopTime := 5 * time.Second
 	numThreads := 100
 	itemsPerThread := 10
 
@@ -218,7 +218,8 @@ func TestMultiThreaded(t *testing.T) {
 
 	}
 
-	for i := 0; i < loopCount; i++ {
+	startTime := time.Now()
+	for time.Now().Sub(startTime) < loopTime {
 
 		var enqueuedList []int
 		var enqueuedMtx deadlock.Mutex


### PR DESCRIPTION
## Summary

The TestMultiThreaded was running too slow on Travis machines, causing it to fail due to deadlock detection false-positive.

The change in this PR modify the execution time of the test, ensuring that it won't run for more than 5 second ( which should be enough for data racing detection testing )

## Test Plan

This is a test.