### PR TITLE
Fix messages from TestReproducibleCatchpointLabels

### DIFF
--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1547,6 +1547,8 @@ func TestReproducibleCatchpointLabels(t *testing.T) {
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
 		delta.Creatables = creatablesFromUpdates(base, updates, knownCreatables)
+		delta.Totals.RewardsLevel = rewardLevel
+
 		au.newBlock(blk, delta)
 		au.committedUpTo(i)
 		ml.addMockBlock(blockEntry{block: blk}, delta)


### PR DESCRIPTION
## Summary

#2922 moved totals calculation from `account updates` into `cow state` but the test was expecting non-zero rewards that caused the log flooding with panics.

## Test Plan

This is a test fix.