### PR TITLE
handle is left open in importRootKeys

### DIFF
--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -170,6 +170,7 @@ func (f *LibGoalFixture) importRootKeys(lg *libgoal.Client, dataDir string) {
 				f.failOnError(err, "couldn't import secret: %v")
 			}
 			accountsWithRootKeys[root.Address().String()] = true
+			handle.Close()
 		} else if config.IsPartKeyFilename(filename) {
 			// Fetch a handle to this database
 			handle, err = db.MakeErasableAccessor(filepath.Join(keyDir, filename))


### PR DESCRIPTION
## Summary

The database handle is not closed in this code path.
In normal situations, this passes unnoticed, since it will be closed once the test terminates. However, when running the test multiple times, the OS will complain about too many open files. 

## Test Plan
This is a test infrastructure fix. 
