### PR TITLE
testing: adjust TenNodesDistributedMultiWallet.json to use smaller key dilution

### DIFF
--- a/test/testdata/nettemplates/TenNodesDistributedMultiWallet.json
+++ b/test/testdata/nettemplates/TenNodesDistributedMultiWallet.json
@@ -1,6 +1,8 @@
 {
     "Genesis": {
         "NetworkName": "tbd",
+        "PartKeyDilution": 50,
+        "LastPartKeyRound": 2000,
         "Wallets": [
             {
                 "Name": "20pct",


### PR DESCRIPTION
## Summary

The e2e test `TestPartitionHalfOffline` was failing due to the deadlock detection failing while the old keys are being deleted.
This change would reduce the key dilution, and should shorten the duration it takes to generate a new batch.

## Test Plan

This is a test.