### PR TITLE
testing: remove redundant checking from TestParticipationAccountsExpirationFuture

### DIFF
--- a/test/e2e-go/features/participation/participationExpiration_test.go
+++ b/test/e2e-go/features/participation/participationExpiration_test.go
@@ -51,7 +51,16 @@ func testExpirationAccounts(t *testing.T, fixture *fixtures.RestClientFixture, f
 	transactionFee := minTxnFee
 	amountToSendInitial := 5 * minAcctBalance
 
+	initialAmt, err := sClient.GetBalance(sAccount)
+	a.NoError(err)
+
 	fixture.SendMoneyAndWait(initialRound, amountToSendInitial, transactionFee, richAccount, sAccount, "")
+
+	newAmt, err := sClient.GetBalance(sAccount)
+	a.NoError(err)
+
+	a.GreaterOrEqual(newAmt, initialAmt)
+
 	sNodeStatus, err := sClient.Status()
 	a.NoError(err)
 	seededRound := sNodeStatus.LastRound


### PR DESCRIPTION
## Summary

Reduce unneeded tests from TestParticipationAccountsExpirationFuture.

Resolves #3042

## Test Plan

This is a test