### PR TITLE
testing: fix failure in TestAccountInformationV2

### DIFF
--- a/test/e2e-go/features/transactions/accountv2_test.go
+++ b/test/e2e-go/features/transactions/accountv2_test.go
@@ -105,11 +105,11 @@ func TestAccountInformationV2(t *testing.T) {
 
 	fee := uint64(1000)
 
-	round, err := client.CurrentRound()
-	a.NoError(err)
-
 	// Fund the manager, so it can issue transactions later on
 	_, err = client.SendPaymentFromUnencryptedWallet(creator, user, fee, 10000000000, nil)
+	a.NoError(err)
+
+	round, err := client.CurrentRound()
 	a.NoError(err)
 	client.WaitForRound(round + 4)
 
@@ -165,9 +165,9 @@ int 1
 	a.NoError(err)
 	signedTxn, err := client.SignTransactionWithWallet(wh, nil, tx)
 	a.NoError(err)
-	round, err = client.CurrentRound()
-	a.NoError(err)
 	txid, err := client.BroadcastTransaction(signedTxn)
+	a.NoError(err)
+	round, err = client.CurrentRound()
 	a.NoError(err)
 	// ensure transaction is accepted into a block within 5 rounds.
 	confirmed := fixture.WaitForAllTxnsToConfirm(round+5, map[string]string{txid: signedTxn.Txn.Sender.String()})
@@ -214,9 +214,9 @@ int 1
 	a.NoError(err)
 	signedTxn, err = client.SignTransactionWithWallet(wh, nil, tx)
 	a.NoError(err)
-	round, err = client.CurrentRound()
-	a.NoError(err)
 	txid, err = client.BroadcastTransaction(signedTxn)
+	a.NoError(err)
+	round, err = client.CurrentRound()
 	a.NoError(err)
 	_, err = client.WaitForRound(round + 3)
 	a.NoError(err)
@@ -285,9 +285,9 @@ int 1
 	a.NoError(err)
 	signedTxn, err = client.SignTransactionWithWallet(wh, nil, tx)
 	a.NoError(err)
-	round, err = client.CurrentRound()
-	a.NoError(err)
 	_, err = client.BroadcastTransaction(signedTxn)
+	a.NoError(err)
+	round, err = client.CurrentRound()
 	a.NoError(err)
 	_, err = client.WaitForRound(round + 2)
 	a.NoError(err)


### PR DESCRIPTION

## Summary

The test had a conceptual buggy pattern. It was using 
```golang
round, err = client.CurrentRound()
...
_, err = client.BroadcastTransaction(signedTxn)
...
resp, err = client.GetPendingTransactions(2)
```
which is doomed to fail if the test process goes to sleep for a minute between the `client.CurrentRound()` call and the `client.BroadcastTransaction` call. The trivial solution is to reorder the calls so that 
```golang
_, err = client.BroadcastTransaction(signedTxn)
...
round, err = client.CurrentRound()
...
resp, err = client.GetPendingTransactions(2)
```


## Test Plan

This is a test.
