### PR TITLE
Fixed off-by-one error in the assembler's typeDig()

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1290,8 +1290,8 @@ func typeDig(ops *OpStream, args []string) (StackTypes, StackTypes) {
 	idx := len(ops.typeStack) - depth
 	if idx >= 0 {
 		returns[len(returns)-1] = ops.typeStack[idx]
-		for i := idx + 1; i < len(ops.typeStack); i++ {
-			returns[i-idx-1] = ops.typeStack[i]
+		for i := idx; i < len(ops.typeStack); i++ {
+			returns[i-idx] = ops.typeStack[i]
 		}
 	}
 	return anys, returns

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2207,7 +2207,8 @@ func TestDigAsm(t *testing.T) {
 
 	// Confirm that digging something out does not ruin our knowledge about the types in the middle
 	testProg(t, "int 1; byte 0x1234; byte 0x1234; dig 2; dig 3; +; pop; +", AssemblerMaxVersion,
-		expect{6, "+ arg 1..."})
+		expect{8, "+ arg 1..."})
+	testProg(t, "int 3; pushbytes \"123456\"; int 1; dig 2; substring3", AssemblerMaxVersion)
 
 }
 


### PR DESCRIPTION
## Summary
This type checking bug was discovered while using the TEAL debugger. A correction to typedDig() + improved unit tests were added.

## Test Plan
Added new unit test and corrected existing one.
