### PR TITLE
Fix for TestKeysWithoutStateProofKeyCannotRegister and TestAccountStorageWithBlockProofID

### DIFF
--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -322,8 +322,12 @@ func TestAccountStorageWithBlockProofID(t *testing.T) {
 
 	totals, err := accountsTotals(tx, false)
 	require.NoError(t, err)
-
-	totals = ledgertesting.CalculateNewRoundAccountTotals(t, updates, 0, proto, accts, totals)
+	cAccounts := make(map[basics.Address]basics.AccountData, updatesCnt.len())
+	for i := 0; i < updatesCnt.len(); i++ {
+		addr, acctData := updatesCnt.getByIdx(i)
+		cAccounts[addr] = acctData.old.accountData
+	}
+	totals = ledgertesting.CalculateNewRoundAccountTotals(t, updates, 0, proto, cAccounts, totals)
 	err = accountsPutTotals(tx, totals, false)
 	require.NoError(t, err)
 	_, err = accountsNewRound(tx, updatesCnt, nil, proto, basics.Round(0))

--- a/test/testdata/nettemplates/TwoNodesWithoutStateProofPartkeys.json
+++ b/test/testdata/nettemplates/TwoNodesWithoutStateProofPartkeys.json
@@ -2,7 +2,7 @@
   "Genesis": {
     "NetworkName": "tbd",
 
-    "ConsensusProtocol": "test-fast-upgrade-https://github.com/algorandfoundation/specs/tree/abc54f79f9ad679d2d22f0fb9909fb005c16f8a1",
+    "ConsensusProtocol": "test-fast-upgrade-https://github.com/algorandfoundation/specs/tree/bc36005dbd776e6d1eaf0c560619bb183215645c",
     "Wallets": [
       {
         "Name": "Wallet1",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
The test TestKeysWithoutStateProofKeyCannotRegister lets the nodes make progress until changes the consensus version.
The test passes when the consensus version changes to Future. However, the test starts from V29, and quickly gets to Future, passing through V30. Sometimes, the node progress is halted at V30, in which case the test fails. 

Also, in this change, reusing the client handle instead of regenerating one every time. 
  
TestAccountStorageWithBlockProofID broke after the merge with changes to the Master. 
This fixes it. 

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
