### PR TITLE
Fixing CircleCI deploy for Betanet and Stablenet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,7 @@ workflows:
             - << matrix.platform >>_integration_nightly_verification
             - << matrix.platform >>_e2e_expect_nightly_verification
             - << matrix.platform >>_e2e_subs_nightly
+            - codegen_verification
           filters:
             branches:
               only:


### PR DESCRIPTION
Noticed our environment passing variable is not working as intended, implemented a different way of passing it.

**please squash merge when merging**