### PR TITLE
Fixing CircleCI deploy for Betanet and Stablenet (#3077)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,8 @@ workflows:
             - << matrix.platform >>_test_nightly_verification
             - << matrix.platform >>_integration_nightly_verification
             - << matrix.platform >>_e2e_expect_nightly_verification
+            - << matrix.platform >>_e2e_subs_nightly
+            - codegen_verification
           filters:
             branches:
               only:
@@ -431,15 +433,18 @@ commands:
     steps:
         - run:
             name: Upload binaries << parameters.platform >>
-            environment:
-              TRAVIS_BRANCH: ${CIRCLE_BRANCH}
             command: |
+              export TRAVIS_BRANCH=${CIRCLE_BRANCH}
               scripts/travis/deploy_packages.sh
         - when:
             condition:
               equal: [ "amd64", << parameters.platform >> ]
             steps:
-              - run: scripts/travis/test_release.sh
+              - run:
+                  name: test_release.sh
+                  command: |
+                    export TRAVIS_BRANCH=${CIRCLE_BRANCH}
+                    scripts/travis/test_release.sh
 
 jobs:
   codegen_verification:


### PR DESCRIPTION
Fixing deploy pipeline in circleci
- including 2 required tests
- making sure environment variable for branch is correct
This should name the binaries correctly and put them in correct bucket