### PR TITLE
Change default genesis partkey round validity to 3,000,000

### DIFF
--- a/cmd/goal/network.go
+++ b/cmd/goal/network.go
@@ -101,7 +101,7 @@ var networkCreateCmd = &cobra.Command{
 			consensus, _ = config.PreloadConfigurableConsensusProtocols(dataDir)
 		}
 
-		network, err := netdeploy.CreateNetworkFromTemplate(networkName, networkRootDir, networkTemplateFile, binDir, !noImportKeys, nil, consensus)
+		network, err := netdeploy.CreateNetworkFromTemplate(networkName, networkRootDir, networkTemplateFile, binDir, !noImportKeys, nil, consensus, false)
 		if err != nil {
 			if noClean {
 				reportInfof(" ** failed ** - Preserving network rootdir '%s'", networkRootDir)

--- a/gen/walletData.go
+++ b/gen/walletData.go
@@ -28,7 +28,7 @@ import (
 // instance (because we have no ctors...)
 var DefaultGenesis = GenesisData{
 	FirstPartKeyRound: 0,
-	LastPartKeyRound:  3000,
+	LastPartKeyRound:  3000000,
 }
 
 // WalletData represents a wallet's name, percent stake, and initial online status for a genesis.json file

--- a/netdeploy/network.go
+++ b/netdeploy/network.go
@@ -59,7 +59,7 @@ type Network struct {
 
 // CreateNetworkFromTemplate uses the specified template to deploy a new private network
 // under the specified root directory.
-func CreateNetworkFromTemplate(name, rootDir, templateFile, binDir string, importKeys bool, nodeExitCallback nodecontrol.AlgodExitErrorCallback, consensus config.ConsensusProtocols) (Network, error) {
+func CreateNetworkFromTemplate(name, rootDir, templateFile, binDir string, importKeys bool, nodeExitCallback nodecontrol.AlgodExitErrorCallback, consensus config.ConsensusProtocols, isTest bool) (Network, error) {
 	n := Network{
 		rootDir:          rootDir,
 		nodeExitCallback: nodeExitCallback,
@@ -81,6 +81,12 @@ func CreateNetworkFromTemplate(name, rootDir, templateFile, binDir string, impor
 		return n, err
 	}
 	template.Consensus = consensus
+
+	if isTest {
+		// Generate participation keys for a shorter period
+		template.Genesis.LastPartKeyRound = 3000
+	}
+
 	err = template.generateGenesisAndWallets(rootDir, name, binDir)
 	if err != nil {
 		return n, err
@@ -91,7 +97,6 @@ func CreateNetworkFromTemplate(name, rootDir, templateFile, binDir string, impor
 		return n, err
 	}
 	n.gen = template.Genesis
-
 	err = n.Save(rootDir)
 	n.SetConsensus(binDir, consensus)
 	return n, err

--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -93,7 +93,7 @@ func (f *LibGoalFixture) setup(test TestingTB, testName string, templateFile str
 	os.RemoveAll(f.rootDir)
 	templateFile = filepath.Join(f.testDataDir, templateFile)
 	importKeys := false // Don't automatically import root keys when creating folders, we'll import on-demand
-	network, err := netdeploy.CreateNetworkFromTemplate("test", f.rootDir, templateFile, f.binDir, importKeys, f.nodeExitWithError, f.consensus)
+	network, err := netdeploy.CreateNetworkFromTemplate("test", f.rootDir, templateFile, f.binDir, importKeys, f.nodeExitWithError, f.consensus, true)
 	f.failOnError(err, "CreateNetworkFromTemplate failed: %v")
 	f.network = network
 


### PR DESCRIPTION
and add a condition for test cases to generate keys for a shorted period

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
