### PR TITLE
Make bytes and pushbytes check their immediate better (and similarly)

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -472,12 +472,15 @@ func asmPushInt(ops *OpStream, spec *OpSpec, args []string) error {
 	return nil
 }
 func asmPushBytes(ops *OpStream, spec *OpSpec, args []string) error {
-	if len(args) != 1 {
-		return ops.errorf("%s needs one argument", spec.Name)
+	if len(args) == 0 {
+		return ops.errorf("%s operation needs byte literal argument", spec.Name)
 	}
-	val, _, err := parseBinaryArgs(args)
+	val, consumed, err := parseBinaryArgs(args)
 	if err != nil {
 		return ops.error(err)
+	}
+	if len(args) != consumed {
+		return ops.errorf("%s operation with extraneous argument", spec.Name)
 	}
 	ops.pending.WriteByte(spec.Opcode)
 	var scratch [binary.MaxVarintLen64]byte
@@ -636,11 +639,14 @@ func parseStringLiteral(input string) (result []byte, err error) {
 // byte "this is a string\n"
 func assembleByte(ops *OpStream, spec *OpSpec, args []string) error {
 	if len(args) == 0 {
-		return ops.error("byte operation needs byte literal argument")
+		return ops.errorf("%s operation needs byte literal argument", spec.Name)
 	}
-	val, _, err := parseBinaryArgs(args)
+	val, consumed, err := parseBinaryArgs(args)
 	if err != nil {
 		return ops.error(err)
+	}
+	if len(args) != consumed {
+		return ops.errorf("%s operation with extraneous argument", spec.Name)
 	}
 	ops.ByteLiteral(val)
 	return nil

--- a/data/transactions/teal.go
+++ b/data/transactions/teal.go
@@ -37,9 +37,6 @@ type EvalDelta struct {
 
 	Logs []string `codec:"lg,allocbound=config.MaxLogCalls"`
 
-	// Intentionally, temporarily wrong - need to decide how to
-	// allocbound properly when structure is recursive.  Even a bound
-	// of 2 would allow arbitrarily large object if deep.
 	InnerTxns []SignedTxnWithAD `codec:"itx,allocbound=config.MaxInnerTransactions"`
 }
 


### PR DESCRIPTION
`byte "hi" "there"` did not report an error, but should.
`pushbytes` was not consistent with `bytes` in reporting errors, but should be.
