### PR TITLE
testing: modify TestAccountInformationV2 to wait for transaction

### DIFF
--- a/test/e2e-go/features/transactions/accountv2_test.go
+++ b/test/e2e-go/features/transactions/accountv2_test.go
@@ -89,7 +89,7 @@ func TestAccountInformationV2(t *testing.T) {
 	proto.AgreementFilterTimeout = 400 * time.Millisecond
 	fixture.SetConsensus(config.ConsensusProtocols{protocol.ConsensusFuture: proto})
 
-	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50EachFuture.json"))
+	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50EachV26.json"))
 	defer fixture.Shutdown()
 
 	client := fixture.LibGoalClient
@@ -105,13 +105,15 @@ func TestAccountInformationV2(t *testing.T) {
 
 	fee := uint64(1000)
 
+	var txn transactions.Transaction
+
 	// Fund the manager, so it can issue transactions later on
-	_, err = client.SendPaymentFromUnencryptedWallet(creator, user, fee, 10000000000, nil)
+	txn, err = client.SendPaymentFromUnencryptedWallet(creator, user, fee, 10000000000, nil)
 	a.NoError(err)
 
 	round, err := client.CurrentRound()
 	a.NoError(err)
-	client.WaitForRound(round + 4)
+	fixture.WaitForConfirmedTxn(round+4, creator, txn.ID().String())
 
 	// There should be no apps to start with
 	ad, err := client.AccountData(creator)
@@ -285,16 +287,23 @@ int 1
 	a.NoError(err)
 	signedTxn, err = client.SignTransactionWithWallet(wh, nil, tx)
 	a.NoError(err)
-	_, err = client.BroadcastTransaction(signedTxn)
+	txid, err = client.BroadcastTransaction(signedTxn)
 	a.NoError(err)
-	round, err = client.CurrentRound()
-	a.NoError(err)
-	_, err = client.WaitForRound(round + 2)
-	a.NoError(err)
-	// Ensure the txn committed
-	resp, err = client.GetPendingTransactions(2)
-	a.NoError(err)
-	a.Equal(uint64(0), resp.TotalTxns)
+	for {
+		round, err = client.CurrentRound()
+		a.NoError(err)
+		_, err = client.WaitForRound(round + 1)
+		a.NoError(err)
+		// Ensure the txn committed
+		resp, err = client.GetPendingTransactions(2)
+		a.NoError(err)
+		if resp.TotalTxns == 1 {
+			a.Equal(resp.TruncatedTxns.Transactions[0].TxID, txid)
+			continue
+		}
+		a.Equal(uint64(0), resp.TotalTxns)
+		break
+	}
 
 	ad, err = client.AccountData(creator)
 	a.NoError(err)


### PR DESCRIPTION
## Summary

This change wait for a given broadcasted transaction to be included instead of expecting it to be included after a predetermined number of rounds. This would increase the testing platform flexibility in case we're testing on slow machines.

## Test Plan

This is a test.
