### PR TITLE
txnsync: implement missing bridge between txnsync and classic transaction messages

### DIFF
--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -534,6 +534,10 @@ func (handler *solicitedAsyncTxHandler) loop(ctx context.Context) {
 			handler.txHandler.net.RequestConnectOutgoing(false, make(chan struct{}))
 			transactionMessagesDroppedFromPool.Inc(nil)
 		} else if allTransactionsIncluded {
+			for _, txnGroup := range groups.txGroups {
+				// We reencode here instead of using rawmsg.Data to avoid broadcasting non-canonical encodings
+				handler.txHandler.net.Relay(ctx, protocol.TxnTag, reencode(txnGroup.Transactions), false, groups.networkPeer)
+			}
 			select {
 			case groups.ackCh <- groups.messageSeq:
 				// all good, write was successful.


### PR DESCRIPTION
## Summary

This PR adds the missing bridge between the txnsync and the classic transaction relaying:
when a transaction message arrive and being added to the transaction pool, we need to attempt to
relay these messages right away using the classic transaction messages. That would allow relays to
be compatible with both 2.1 and 3.0 nodes.

## Test Plan

e2e test was added.