### PR TITLE
setting group index to be the one assocaited with the run

### DIFF
--- a/cmd/tealdbg/local.go
+++ b/cmd/tealdbg/local.go
@@ -540,7 +540,7 @@ func (r *LocalRunner) RunAll() error {
 		ep := logic.EvalParams{
 			Proto:                   &r.proto,
 			Debugger:                r.debugger,
-			Txn:                     &r.txnGroup[groupIndex],
+			Txn:                     &r.txnGroup[run.groupIndex],
 			TxnGroup:                r.txnGroup,
 			GroupIndex:              run.groupIndex,
 			PastSideEffects:         run.pastSideEffects,


### PR DESCRIPTION
## Summary

The `groupIndex` variable is a global set by a flag and defaults to 0. In the `main.go` file its checked and then set in DebugParams. 

I believe this is a bug that affects any grouped transactions where the groupIndex meant to be evaluated is > 0 and we should really be using the groupIndex passed in the `evaluation` struct.


## Test Plan

Existing tests
