### PR TITLE
fix TestTxnGroupEncodingReflection

### DIFF
--- a/txnsync/txngroups_test.go
+++ b/txnsync/txngroups_test.go
@@ -426,9 +426,15 @@ func TestTxnGroupEncodingReflection(t *testing.T) {
 			case protocol.KeyRegistrationTx:
 				v0, err := protocol.RandomizeObject(&txn.Txn.KeyregTxnFields)
 				require.NoError(t, err)
-				KeyregTxnFields, ok := v0.(*transactions.KeyregTxnFields)
+				keyregTxnFields, ok := v0.(*transactions.KeyregTxnFields)
 				require.True(t, ok)
-				txn.Txn.KeyregTxnFields = *KeyregTxnFields
+				if keyregTxnFields.BlockProofPK.Root != [64]uint8{} {
+					// To copy BlockProofPK.Root, the condition in deconstructKeyregTxnFields requires:
+					// !txn.Txn.VotePK.MsgIsZero() || !txn.Txn.SelectionPK.MsgIsZero()
+					// || txn.Txn.VoteKeyDilution != 0
+					keyregTxnFields.VoteKeyDilution = 5
+				}
+				txn.Txn.KeyregTxnFields = *keyregTxnFields
 			case protocol.AssetConfigTx:
 				v0, err := protocol.RandomizeObject(&txn.Txn.AssetConfigTxnFields)
 				require.NoError(t, err)


### PR DESCRIPTION
TestTxnGroupEncodingReflection generates random txns and tests the msg encoding/decoding

However, BlockProofPK.Root is copied under certain conditons. When the randomly generate txn fails the condtion, BlockProofPK.Root is not copied over.

This fix makes sure the random txn satisfies the conditon when BlockProofPK.Root is not empty.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
