### PR TITLE
tealdbg: hide unexposed fields

### DIFF
--- a/cmd/tealdbg/cdtState.go
+++ b/cmd/tealdbg/cdtState.go
@@ -364,7 +364,11 @@ func prepareTxn(txn *transactions.Transaction, groupIndex int) []fieldDesc {
 			field == int(logic.Accounts) ||
 			field == int(logic.ApplicationArgs) ||
 			field == int(logic.Assets) ||
-			field == int(logic.Applications) {
+			field == int(logic.Applications) ||
+			field == int(logic.CreatedApplicationID) ||
+			field == int(logic.CreatedAssetID) ||
+			field == int(logic.Logs) ||
+			field == int(logic.NumLogs) {
 			continue
 		}
 		var value string


### PR DESCRIPTION
## Summary

In tealdbg, the txn obj has a number of fields that are only available after the transaction has been evaluated in ApplyData. At the moment we show "Unable to obtain effects from top-level transactions" from https://github.com/algorand/go-algorand/blob/master/data/transactions/logic/eval.go#L1939 . This should be hidden for now.

![image](https://user-images.githubusercontent.com/520236/138276784-e1492925-425a-4a7c-b9b3-462480002db0.png)

