### PR TITLE
catchup: ignore benign evaluator failures

### DIFF
--- a/catchup/service.go
+++ b/catchup/service.go
@@ -349,6 +349,9 @@ func (s *Service) fetchAndWrite(r basics.Round, prevFetchCompleteChan chan bool,
 
 				if err != nil {
 					switch err.(type) {
+					case ledgercore.ErrNonSequentialBlockEval:
+						s.log.Infof("fetchAndWrite(%d): no need to re-evaluate historical block", r)
+						return true
 					case ledgercore.BlockInLedgerError:
 						s.log.Infof("fetchAndWrite(%d): block already in ledger", r)
 						return true


### PR DESCRIPTION
## Summary

The catchup was occasionally reporting
```
(1): fetchAndWrite(13932148): ledger write failed: block evaluation for round 13932148 requires sequential evaluation while the latest round is 13932148
```

This issue indicates that the catchup was attempting to validate a block which is not the latest+1, but rather newer.
In this case, we can safely ignore this error, and skip applying this block, since the block was already added to the ledger.

## Test Plan

Tested manually.