### PR TITLE
Reverse the network protocols ordering to de-prioritize the txnsync utilization

### DIFF
--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1807,7 +1807,7 @@ const ProtocolVersionHeader = "X-Algorand-Version"
 const ProtocolAcceptVersionHeader = "X-Algorand-Accept-Version"
 
 // SupportedProtocolVersions contains the list of supported protocol versions by this node ( in order of preference ).
-var SupportedProtocolVersions = []string{"3.0", "2.1"}
+var SupportedProtocolVersions = []string{"2.1", "3.0"}
 
 // ProtocolVersion is the current version attached to the ProtocolVersionHeader header
 /* Version history:


### PR DESCRIPTION
## Summary

In order to reduce risk on the migration to the new transaction sync, the network protocols order was flipped.
Nodes would default to use the old transaction propagation, and would use the new transaction propagation only when configured via the config.json "NetworkProtocol" flag.

## Test Plan

Need to be tested on betanet.