### PR TITLE
Add state proof table to key registry

### DIFF
--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -668,6 +668,13 @@ func scanRecords(rows *sql.Rows) ([]ParticipationRecord, error) {
 		var rawAccount []byte
 		var rawVRF []byte
 		var rawVoting []byte
+
+		var lastVote sql.NullInt64
+		var lastBlockProposal sql.NullInt64
+		var lastCompactCertificate sql.NullInt64
+		var effectiveFirst sql.NullInt64
+		var effectiveLast sql.NullInt64
+
 		err := rows.Scan(
 			&rawParticipation,
 			&rawAccount,
@@ -675,11 +682,11 @@ func scanRecords(rows *sql.Rows) ([]ParticipationRecord, error) {
 			&record.LastValid,
 			&record.KeyDilution,
 			&rawVRF,
-			&record.LastVote,
-			&record.LastBlockProposal,
-			&record.LastCompactCertificate,
-			&record.EffectiveFirst,
-			&record.EffectiveLast,
+			&lastVote,
+			&lastBlockProposal,
+			&lastCompactCertificate,
+			&effectiveFirst,
+			&effectiveLast,
 			&rawVoting,
 		)
 		if err != nil {
@@ -703,6 +710,27 @@ func scanRecords(rows *sql.Rows) ([]ParticipationRecord, error) {
 			if err != nil {
 				return nil, fmt.Errorf("unable to decode Voting: %w", err)
 			}
+		}
+
+		// Check optional values.
+		if lastVote.Valid {
+			record.LastVote = basics.Round(lastVote.Int64)
+		}
+
+		if lastBlockProposal.Valid {
+			record.LastBlockProposal = basics.Round(lastBlockProposal.Int64)
+		}
+
+		if lastCompactCertificate.Valid {
+			record.LastCompactCertificate = basics.Round(lastCompactCertificate.Int64)
+		}
+
+		if effectiveFirst.Valid {
+			record.EffectiveFirst = basics.Round(effectiveFirst.Int64)
+		}
+
+		if effectiveLast.Valid {
+			record.EffectiveLast = basics.Round(effectiveLast.Int64)
 		}
 
 		results = append(results, record)

--- a/data/account/participationRegistry_test.go
+++ b/data/account/participationRegistry_test.go
@@ -105,9 +105,8 @@ func TestParticipation_InsertGet(t *testing.T) {
 	}
 
 	// Check that Flush works, re-initialize cache and verify GetAll.
-	err := registry.Flush()
-	a.NoError(err)
-	registry.initializeCache()
+	a.NoError(registry.Flush())
+	a.NoError(registry.initializeCache())
 	results = registry.GetAll()
 	a.Len(results, 2)
 	for _, record := range results {
@@ -147,9 +146,8 @@ func TestParticipation_Delete(t *testing.T) {
 	assertParticipation(t, p2, results[0])
 
 	// Check that result was persisted.
-	err = registry.Flush()
-	a.NoError(err)
-	registry.initializeCache()
+	a.NoError(registry.Flush())
+	a.NoError(registry.initializeCache())
 	results = registry.GetAll()
 	a.Len(results, 1)
 	assertParticipation(t, p2, results[0])
@@ -174,10 +172,8 @@ func TestParticipation_DeleteExpired(t *testing.T) {
 	a.Len(registry.GetAll(), 5, "The first 5 should be deleted.")
 
 	// Check persisting. Verify by re-initializing the cache.
-	err = registry.Flush()
-	a.NoError(err)
-	err = registry.initializeCache()
-	a.NoError(err)
+	a.NoError(registry.Flush())
+	a.NoError(registry.initializeCache())
 	a.Len(registry.GetAll(), 5, "The first 5 should be deleted.")
 }
 
@@ -272,15 +268,11 @@ func TestParticipation_Record(t *testing.T) {
 		a.NoError(err)
 	}
 
-	all := registry.GetAll()
-	a.NotNil(all)
+	a.NotNil(registry.GetAll())
 
-	err := registry.Record(p.Parent, 1000, Vote)
-	a.NoError(err)
-	err = registry.Record(p.Parent, 2000, BlockProposal)
-	a.NoError(err)
-	err = registry.Record(p.Parent, 3000, CompactCertificate)
-	a.NoError(err)
+	a.NoError(registry.Record(p.Parent, 1000, Vote))
+	a.NoError(registry.Record(p.Parent, 2000, BlockProposal))
+	a.NoError(registry.Record(p.Parent, 3000, CompactCertificate))
 
 	// Verify that one and only one key was updated.
 	test := func(registry ParticipationRegistry) {
@@ -300,11 +292,11 @@ func TestParticipation_Record(t *testing.T) {
 	}
 
 	test(registry)
-	registry.Flush()
+	a.NoError(registry.Flush())
 	a.Len(registry.dirty, 0)
 
 	// Re-initialize
-	registry.initializeCache()
+	a.NoError(registry.initializeCache())
 	test(registry)
 }
 
@@ -368,9 +360,9 @@ func TestParticipation_RecordMultipleUpdates(t *testing.T) {
 	recordCopy.EffectiveLast = p2.LastValid
 	registry.cache[p2.ID()] = recordCopy
 	registry.dirty[p2.ID()] = struct{}{}
-	registry.Flush()
+	a.NoError(registry.Flush())
 	a.Len(registry.dirty, 0)
-	registry.initializeCache()
+	a.NoError(registry.initializeCache())
 
 	// Verify bad state - both records are valid until round 3 million
 	a.NotEqual(p.ID(), p2.ID())
@@ -538,7 +530,7 @@ func TestParticipation_NoKeyToUpdate(t *testing.T) {
 // TestParticipion_Blobs adds some secrets to the registry and makes sure the same ones are returned.
 func TestParticipion_Blobs(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	a := assert.New(t)
+	a := require.New(t)
 	registry := getRegistry(t)
 	defer registry.Close()
 
@@ -574,7 +566,7 @@ func TestParticipion_Blobs(t *testing.T) {
 	check(id)
 
 	// check the re-initialized object
-	registry.initializeCache()
+	a.NoError(registry.initializeCache())
 	check(id)
 }
 
@@ -619,7 +611,7 @@ func TestParticipion_EmptyBlobs(t *testing.T) {
 	check(id)
 
 	// check the re-initialized object
-	registry.initializeCache()
+	a.NoError(registry.initializeCache())
 	check(id)
 }
 


### PR DESCRIPTION
## Summary

Allocate a spot in the key registry for state proofs. This is not used yet but should allow us to add them when we are ready.

## Test Plan

Existing tests should detect any regression.