### PR TITLE
Add c5d.4xlarge and c5d.18xlarge us-east-2 to hosttemplates.json

### DIFF
--- a/test/testdata/deployednettemplates/hosttemplates/hosttemplates.json
+++ b/test/testdata/deployednettemplates/hosttemplates/hosttemplates.json
@@ -201,10 +201,22 @@
       "BaseConfiguration": "m5d.4xlarge"
     },
     {
+      "Name": "AWS-US-EAST-1-c5d.4xl",
+      "Provider": "AWS",
+      "Region": "us-east-1",
+      "BaseConfiguration": "c5d.4xlarge"
+    },
+    {
       "Name": "AWS-US-EAST-1-c5d.9xl",
       "Provider": "AWS",
       "Region": "us-east-1",
       "BaseConfiguration": "c5d.9xlarge"
+    },
+    {
+      "Name": "AWS-US-EAST-1-c5d.18xl",
+      "Provider": "AWS",
+      "Region": "us-east-1",
+      "BaseConfiguration": "c5d.18xlarge"
     },
     {
       "Name": "AWS-US-EAST-2-c5.xlarge",
@@ -237,10 +249,22 @@
       "BaseConfiguration": "m5d.4xlarge"
     },
     {
+      "Name": "AWS-US-EAST-2-c5d.4xl",
+      "Provider": "AWS",
+      "Region": "us-east-2",
+      "BaseConfiguration": "c5d.4xlarge"
+    },
+    {
       "Name": "AWS-US-EAST-2-c5d.9xl",
       "Provider": "AWS",
       "Region": "us-east-2",
       "BaseConfiguration": "c5d.9xlarge"
+    },
+    {
+      "Name": "AWS-US-EAST-2-c5d.18xl",
+      "Provider": "AWS",
+      "Region": "us-east-2",
+      "BaseConfiguration": "c5d.18xlarge"
     },
     {
       "Name": "AWS-AP-SOUTH-1-c5.xlarge",


### PR DESCRIPTION
## Summary

Add c5d.4xlarge and c5d.18xlarge us-east-2 to hosttemplates.json so that our team can use them moving forward for performance tests. 

For performance testing, we've needed to add these to each codebase we're working with to use these machines. This is part of our effort to automate performance testing internally.

## Test Plan
This same hosttemplates.json has been used in our performance testing.
