### PR TITLE
ledger: refactor maxPaysetHint -> avarageEncodedTxnSizeHint

### DIFF
--- a/ledger/internal/eval.go
+++ b/ledger/internal/eval.go
@@ -48,11 +48,11 @@ type LedgerForCowBase interface {
 // ErrRoundZero is self-explanatory
 var ErrRoundZero = errors.New("cannot start evaluator for round 0")
 
-// avarageEncodedTxnSizeHint is an estimation for the encoded transaction size
+// averageEncodedTxnSizeHint is an estimation for the encoded transaction size
 // which is used for preallocating memory upfront in the payset. Preallocating
 // helps to avoid re-allocating storage during the evaluation/validation which
 // is considerably slower.
-const avarageEncodedTxnSizeHint = 150
+const averageEncodedTxnSizeHint = 150
 
 // asyncAccountLoadingThreadCount controls how many go routines would be used
 // to load the account data before the Eval() start processing individual
@@ -482,7 +482,7 @@ func StartEvaluator(l LedgerForEvaluator, hdr bookkeeping.BlockHeader, evalOpts 
 	// Preallocate space for the payset so that we don't have to
 	// dynamically grow a slice (if evaluating a whole block).
 	if evalOpts.PaysetHint > 0 {
-		maxPaysetHint := evalOpts.MaxTxnBytesPerBlock / avarageEncodedTxnSizeHint
+		maxPaysetHint := evalOpts.MaxTxnBytesPerBlock / averageEncodedTxnSizeHint
 		if evalOpts.PaysetHint > maxPaysetHint {
 			evalOpts.PaysetHint = maxPaysetHint
 		}


### PR DESCRIPTION
## Summary

This refactoring would eliminate the need to change the maxPaysetHint while we modify the block size.

## Test Plan

Use existing tests.