### PR TITLE
txnsync: Use dynamic maxEncodedTransactionGroups

### DIFF
--- a/txnsync/encodedgroups_test.go
+++ b/txnsync/encodedgroups_test.go
@@ -30,7 +30,7 @@ import (
 func TestBadBitmask(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	txnGroups, genesisID, genesisHash, err := txnGroupsData(96)
+	txnGroups, genesisID, genesisHash, err := txnGroupsData(50)
 	require.NoError(t, err)
 
 	var s syncState
@@ -41,7 +41,7 @@ func TestBadBitmask(t *testing.T) {
 	require.Equal(t, errIndexNotFound, err)
 }
 
-// corrupted bitmask may bcause panic during decoding. This test is to make sure it is an error and not a panic
+// corrupted bitmask may cause panic during decoding. This test is to make sure it is an error and not a panic
 func badEncodeTransactionGroups(t *testing.T, s *syncState, inTxnGroups []pooldata.SignedTxGroup, dataExchangeRate uint64) (packedTransactionGroups, error) {
 	txnCount := 0
 	for _, txGroup := range inTxnGroups {

--- a/txnsync/encodedgroupstypes.go
+++ b/txnsync/encodedgroupstypes.go
@@ -26,11 +26,11 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 )
 
-const maxEncodedTransactionGroups = 30000
-const maxEncodedTransactionGroupEntries = 30000
-const maxBitmaskSize = (maxEncodedTransactionGroupEntries+7)/8 + 1
-const maxSignatureBytes = maxEncodedTransactionGroupEntries * len(crypto.Signature{})
-const maxAddressBytes = maxEncodedTransactionGroupEntries * crypto.DigestSize
+var maxEncodedTransactionGroups = 30000
+var maxEncodedTransactionGroupEntries = 30000
+var maxBitmaskSize = (maxEncodedTransactionGroupEntries+7)/8 + 1
+var maxSignatureBytes = maxEncodedTransactionGroupEntries * len(crypto.Signature{})
+var maxAddressBytes = maxEncodedTransactionGroupEntries * crypto.DigestSize
 
 var errInvalidTxType = errors.New("invalid txtype")
 

--- a/txnsync/encodedgroupstypes.go
+++ b/txnsync/encodedgroupstypes.go
@@ -19,6 +19,7 @@ package txnsync
 import (
 	"errors"
 
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/compactcert"
 	"github.com/algorand/go-algorand/data/basics"
@@ -26,8 +27,8 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 )
 
-var maxEncodedTransactionGroups = 30000
-var maxEncodedTransactionGroupEntries = 30000
+var maxEncodedTransactionGroups = config.GetDefaultLocal().TxPoolSize
+var maxEncodedTransactionGroupEntries = config.GetDefaultLocal().TxPoolSize
 var maxBitmaskSize = (maxEncodedTransactionGroupEntries+7)/8 + 1
 var maxSignatureBytes = maxEncodedTransactionGroupEntries * len(crypto.Signature{})
 var maxAddressBytes = maxEncodedTransactionGroupEntries * crypto.DigestSize

--- a/txnsync/encodedgroupstypes.go
+++ b/txnsync/encodedgroupstypes.go
@@ -19,7 +19,6 @@ package txnsync
 import (
 	"errors"
 
-	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/compactcert"
 	"github.com/algorand/go-algorand/data/basics"
@@ -27,11 +26,12 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 )
 
-var maxEncodedTransactionGroups = config.GetDefaultLocal().TxPoolSize
-var maxEncodedTransactionGroupEntries = config.GetDefaultLocal().TxPoolSize
-var maxBitmaskSize = (maxEncodedTransactionGroupEntries+7)/8 + 1
-var maxSignatureBytes = maxEncodedTransactionGroupEntries * len(crypto.Signature{})
-var maxAddressBytes = maxEncodedTransactionGroupEntries * crypto.DigestSize
+// set in init() in service.go
+var maxEncodedTransactionGroups int
+var maxEncodedTransactionGroupEntries int
+var maxBitmaskSize int
+var maxSignatureBytes int
+var maxAddressBytes int
 
 var errInvalidTxType = errors.New("invalid txtype")
 

--- a/txnsync/exchange.go
+++ b/txnsync/exchange.go
@@ -17,7 +17,6 @@
 package txnsync
 
 import (
-	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 )
@@ -25,9 +24,10 @@ import (
 const txnBlockMessageVersion = 1
 const maxAcceptedMsgSeq = 64
 
-// Roughly 5 bytes per txn needed for a bloom filter
-var maxBloomFilterSize = config.GetDefaultLocal().TxPoolSize * 5
-var maxEncodedTransactionGroupBytes = config.GetDefaultLocal().TxPoolSize * 200
+// set in init() in service.go
+var maxBloomFilterSize int
+var maxEncodedTransactionGroupBytes int
+
 var maxProposalSize = 350000
 
 type transactionBlockMessage struct {

--- a/txnsync/exchange.go
+++ b/txnsync/exchange.go
@@ -17,15 +17,18 @@
 package txnsync
 
 import (
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 )
 
 const txnBlockMessageVersion = 1
-const maxBloomFilterSize = 100000
 const maxAcceptedMsgSeq = 64
-const maxEncodedTransactionGroupBytes = 10000000
-const maxProposalSize = 350000
+
+// Roughly 5 bytes per txn needed for a bloom filter
+var maxBloomFilterSize = config.GetDefaultLocal().TxPoolSize * 5
+var maxEncodedTransactionGroupBytes = config.GetDefaultLocal().TxPoolSize * 200
+var maxProposalSize = 350000
 
 type transactionBlockMessage struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"` //nolint:structcheck,unused

--- a/txnsync/incoming.go
+++ b/txnsync/incoming.go
@@ -59,7 +59,7 @@ func (s *syncState) asyncIncomingMessageHandler(networkPeer interface{}, peer *P
 	_, err = incomingMessage.message.UnmarshalMsg(message)
 	if err != nil {
 		// if we received a message that we cannot parse, disconnect.
-		s.log.Infof("received unparsable transaction sync message from peer. disconnecting from peer: %v, bytes: %v", err, len(message))
+		s.log.Infof("received unparsable transaction sync message from peer. disconnecting from peer: %v, bytes: %d", err, len(message))
 		s.incomingMessagesQ.erase(peer, networkPeer)
 		return err
 	}

--- a/txnsync/incoming.go
+++ b/txnsync/incoming.go
@@ -59,7 +59,7 @@ func (s *syncState) asyncIncomingMessageHandler(networkPeer interface{}, peer *P
 	_, err = incomingMessage.message.UnmarshalMsg(message)
 	if err != nil {
 		// if we received a message that we cannot parse, disconnect.
-		s.log.Infof("received unparsable transaction sync message from peer. disconnecting from peer.")
+		s.log.Infof("received unparsable transaction sync message from peer. disconnecting from peer: %v, bytes: %v", err, len(message))
 		s.incomingMessagesQ.erase(peer, networkPeer)
 		return err
 	}

--- a/txnsync/service.go
+++ b/txnsync/service.go
@@ -51,17 +51,22 @@ func MakeTransactionSyncService(log logging.Logger, conn NodeConnector, isRelay 
 	}
 	s.state.service = s
 	s.state.xorBuilder.MaxIterations = 10
-	if cfg.TxPoolSize > maxEncodedTransactionGroups {
-		maxEncodedTransactionGroups = cfg.TxPoolSize
-		maxEncodedTransactionGroupEntries = cfg.TxPoolSize
-		maxBitmaskSize = (maxEncodedTransactionGroupEntries+7)/8 + 1
-		maxSignatureBytes = maxEncodedTransactionGroupEntries * len(crypto.Signature{})
-		maxAddressBytes = maxEncodedTransactionGroupEntries * crypto.DigestSize
 
-		maxBloomFilterSize = cfg.TxPoolSize * 5
-		maxEncodedTransactionGroupBytes = cfg.TxPoolSize * 200
+	if cfg.TxPoolSize > maxEncodedTransactionGroups {
+		setTransactionSyncVariables(cfg)
 	}
 	return s
+}
+
+func setTransactionSyncVariables(cfg config.Local) {
+	maxEncodedTransactionGroups = cfg.TxPoolSize
+	maxEncodedTransactionGroupEntries = cfg.TxPoolSize
+	maxBitmaskSize = (maxEncodedTransactionGroupEntries+7)/8 + 1
+	maxSignatureBytes = maxEncodedTransactionGroupEntries * len(crypto.Signature{})
+	maxAddressBytes = maxEncodedTransactionGroupEntries * crypto.DigestSize
+
+	maxBloomFilterSize = cfg.TxPoolSize * 5
+	maxEncodedTransactionGroupBytes = cfg.TxPoolSize * 200
 }
 
 // Start starts the transaction sync

--- a/txnsync/service.go
+++ b/txnsync/service.go
@@ -57,6 +57,9 @@ func MakeTransactionSyncService(log logging.Logger, conn NodeConnector, isRelay 
 		maxBitmaskSize = (maxEncodedTransactionGroupEntries+7)/8 + 1
 		maxSignatureBytes = maxEncodedTransactionGroupEntries * len(crypto.Signature{})
 		maxAddressBytes = maxEncodedTransactionGroupEntries * crypto.DigestSize
+
+		maxBloomFilterSize = cfg.TxPoolSize * 5
+		maxEncodedTransactionGroupBytes = cfg.TxPoolSize * 200
 	}
 	return s
 }

--- a/txnsync/service.go
+++ b/txnsync/service.go
@@ -51,6 +51,13 @@ func MakeTransactionSyncService(log logging.Logger, conn NodeConnector, isRelay 
 	}
 	s.state.service = s
 	s.state.xorBuilder.MaxIterations = 10
+	if cfg.TxPoolSize > maxEncodedTransactionGroups {
+		maxEncodedTransactionGroups = cfg.TxPoolSize
+		maxEncodedTransactionGroupEntries = cfg.TxPoolSize
+		maxBitmaskSize = (maxEncodedTransactionGroupEntries+7)/8 + 1
+		maxSignatureBytes = maxEncodedTransactionGroupEntries * len(crypto.Signature{})
+		maxAddressBytes = maxEncodedTransactionGroupEntries * crypto.DigestSize
+	}
 	return s
 }
 

--- a/txnsync/txngroups.go
+++ b/txnsync/txngroups.go
@@ -191,7 +191,7 @@ func decodeTransactionGroups(ptg packedTransactionGroups, genesisID string, gene
 
 func decompressTransactionGroupsBytes(data []byte, lenDecompressedBytes uint64) (decoded []byte, err error) {
 	compressionRatio := lenDecompressedBytes / uint64(len(data)) // data should have been compressed between 0 and 95%
-	if lenDecompressedBytes > maxEncodedTransactionGroupBytes || compressionRatio <= 0 || compressionRatio >= maxCompressionRatio {
+	if lenDecompressedBytes > uint64(maxEncodedTransactionGroupBytes) || compressionRatio <= 0 || compressionRatio >= maxCompressionRatio {
 		return nil, fmt.Errorf("invalid lenDecompressedBytes: %d, len(data): %d", lenDecompressedBytes, len(data))
 	}
 

--- a/txnsync/txngroups.go
+++ b/txnsync/txngroups.go
@@ -152,7 +152,7 @@ func decodeTransactionGroups(ptg packedTransactionGroups, genesisID string, gene
 		return nil, err
 	}
 
-	if stub.TransactionGroupCount > maxEncodedTransactionGroups {
+	if stub.TransactionGroupCount > uint64(maxEncodedTransactionGroups) {
 		return nil, errors.New("invalid TransactionGroupCount")
 	}
 

--- a/txnsync/txngroups_test.go
+++ b/txnsync/txngroups_test.go
@@ -232,7 +232,7 @@ func txnGroupsData(numBlocks int) (txnGroups []pooldata.SignedTxGroup, genesisID
 func TestTxnGroupEncodingLarge(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	txnGroups, genesisID, genesisHash, err := txnGroupsData(969)
+	txnGroups, genesisID, genesisHash, err := txnGroupsData(500)
 	require.NoError(t, err)
 
 	var s syncState
@@ -268,10 +268,10 @@ func TestTxnGroupEncodingLarge(t *testing.T) {
 		}
 	}
 	require.Equal(t, 2, len(count))
-	require.Equal(t, 18351, count["axfer"])
-	require.Equal(t, 1663, count["pay"])
-	require.Equal(t, 20005, sigs)
-	require.Equal(t, 9, msigs)
+	require.Equal(t, 9834, count["axfer"])
+	require.Equal(t, 850, count["pay"])
+	require.Equal(t, 10678, sigs)
+	require.Equal(t, 6, msigs)
 	require.Equal(t, 0, lsigs)
 }
 


### PR DESCRIPTION
## Summary

Change constants in the txnsync around message size limits into variables based on maxTxPoolSize. This will allow for support of larger message sizes when dealing with larger load.

## Test Plan

Reran existing tests
