### PR TITLE
Avoid printing genesis path in error message.

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -786,7 +786,7 @@ func (node *AlgorandFullNode) loadParticipationKeys() error {
 	genesisDir := filepath.Join(node.rootDir, node.genesisID)
 	files, err := ioutil.ReadDir(genesisDir)
 	if err != nil {
-		return fmt.Errorf("AlgorandFullNode.loadPartitipationKeys: could not read genesis directory: %v", err)
+		return fmt.Errorf("AlgorandFullNode.loadPartitipationKeys: could not read genesis directory")
 	}
 
 	// For each of these files

--- a/node/node.go
+++ b/node/node.go
@@ -786,7 +786,7 @@ func (node *AlgorandFullNode) loadParticipationKeys() error {
 	genesisDir := filepath.Join(node.rootDir, node.genesisID)
 	files, err := ioutil.ReadDir(genesisDir)
 	if err != nil {
-		return fmt.Errorf("AlgorandFullNode.loadPartitipationKeys: could not read directory %v: %v", genesisDir, err)
+		return fmt.Errorf("AlgorandFullNode.loadPartitipationKeys: could not read genesis directory: %v", err)
 	}
 
 	// For each of these files


### PR DESCRIPTION
## Summary

Small formatting change to prevent leaking personal information into node.log.