### PR TITLE
Closing nil db on error

### DIFF
--- a/libgoal/participation.go
+++ b/libgoal/participation.go
@@ -165,6 +165,9 @@ func (c *Client) GenParticipationKeysTo(address string, firstValid, lastValid, k
 
 	// Fill the database with new participation keys
 	newPart, err := account.FillDBWithParticipationKeys(partdb, parsedAddr, firstRound, lastRound, keyDilution)
+	if err != nil {
+		return
+	}
 	part = newPart.Participation
 	newPart.Close()
 	return part, partKeyPath, err


### PR DESCRIPTION
When account.FillDBWithParticipationKeys fails and returns an error, e.g. if the key already exists, newPart will be invalid and should not be closed.
When Close is called, it will panic.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
