### PR TITLE
Fix panic on closing nil db 

### DIFF
--- a/data/account/participation.go
+++ b/data/account/participation.go
@@ -164,7 +164,7 @@ func (part PersistedParticipation) PersistNewParent() error {
 // FillDBWithParticipationKeys initializes the passed database with participation keys
 func FillDBWithParticipationKeys(store db.Accessor, address basics.Address, firstValid, lastValid basics.Round, keyDilution uint64) (part PersistedParticipation, err error) {
 	if lastValid < firstValid {
-		err = fmt.Errorf("FillDBWithParticipationKeys: lastValid %d is after firstValid %d", lastValid, firstValid)
+		err = fmt.Errorf("FillDBWithParticipationKeys: firstValid %d is after lastValid %d", firstValid, lastValid)
 		return
 	}
 

--- a/libgoal/participation.go
+++ b/libgoal/participation.go
@@ -165,6 +165,9 @@ func (c *Client) GenParticipationKeysTo(address string, firstValid, lastValid, k
 
 	// Fill the database with new participation keys
 	newPart, err := account.FillDBWithParticipationKeys(partdb, parsedAddr, firstRound, lastRound, keyDilution)
+	if err != nil {
+		return
+	}
 	part = newPart.Participation
 	newPart.Close()
 	return part, partKeyPath, err

--- a/libgoal/participation.go
+++ b/libgoal/participation.go
@@ -165,11 +165,8 @@ func (c *Client) GenParticipationKeysTo(address string, firstValid, lastValid, k
 
 	// Fill the database with new participation keys
 	newPart, err := account.FillDBWithParticipationKeys(partdb, parsedAddr, firstRound, lastRound, keyDilution)
-	if err != nil {
-		return
-	}
 	part = newPart.Participation
-	newPart.Close()
+	partdb.Close()
 	return part, partKeyPath, err
 }
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -129,10 +129,10 @@ func setupFullNodes(t *testing.T, proto protocol.ConsensusVersion, verificationP
 			panic(err)
 		}
 		part, err := account.FillDBWithParticipationKeys(access, root.Address(), firstRound, lastRound, config.Consensus[protocol.ConsensusCurrentVersion].DefaultKeyDilution)
-		access.Close()
 		if err != nil {
 			panic(err)
 		}
+		access.Close()
 
 		data := basics.AccountData{
 			Status:      basics.Online,

--- a/test/e2e-go/features/transactions/onlineStatusChange_test.go
+++ b/test/e2e-go/features/transactions/onlineStatusChange_test.go
@@ -176,6 +176,6 @@ func TestCloseOnError(t *testing.T) {
 	a.Equal("PersistedParticipation.Persist: failed to install database: table ParticipationAccount already exists", err.Error())
 	// check lastValid < firstValid does not crash
 	_, _, err = client.GenParticipationKeys(initiallyOffline, curRound+1001, curRound+1000, 0)
-	expected:= fmt.Sprintf("FillDBWithParticipationKeys: firstValid %d is after lastValid %d", int(curRound+1001), int(curRound+1000))
+	expected := fmt.Sprintf("FillDBWithParticipationKeys: firstValid %d is after lastValid %d", int(curRound+1001), int(curRound+1000))
 	a.Equal(expected, err.Error())
 }

--- a/test/e2e-go/features/transactions/onlineStatusChange_test.go
+++ b/test/e2e-go/features/transactions/onlineStatusChange_test.go
@@ -147,6 +147,7 @@ func testAccountsCanChangeOnlineState(t *testing.T, templatePath string) {
 }
 
 func TestCloseOnError(t *testing.T) {
+	partitiontest.PartitionTest(t)
 
 	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))

--- a/test/e2e-go/features/transactions/onlineStatusChange_test.go
+++ b/test/e2e-go/features/transactions/onlineStatusChange_test.go
@@ -145,3 +145,34 @@ func testAccountsCanChangeOnlineState(t *testing.T, templatePath string) {
 		a.Equal(unmarkedAccountStatus.Status, basics.NotParticipating.String())
 	}
 }
+
+func TestCloseOnError(t *testing.T) {
+
+	t.Parallel()
+	a := require.New(fixtures.SynchronizedTest(t))
+
+	var fixture fixtures.RestClientFixture
+	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodesPartlyOfflineVFuture.json"))
+	defer fixture.Shutdown()
+	client := fixture.LibGoalClient
+
+	// Capture the account we're tracking
+	accountList, err := fixture.GetWalletsSortedByBalance()
+	a.NoError(err)
+
+	initiallyOnline := accountList[0].Address  // 35% stake
+	initiallyOffline := accountList[1].Address // 20% stake
+
+	// get the current round for partkey creation
+	_, curRound := fixture.GetBalanceAndRound(initiallyOnline)
+
+	// make a participation key for initiallyOffline
+	_, _, err = client.GenParticipationKeys(initiallyOffline, 0, curRound+1000, 0)
+	a.NoError(err)
+	// check duplicate keys does not crash
+	_, _, err = client.GenParticipationKeys(initiallyOffline, 0, curRound+1000, 0)
+	a.Equal("PersistedParticipation.Persist: failed to install database: table ParticipationAccount already exists", err.Error())
+	// check lastValid < firstValid does not crash
+	_, _, err = client.GenParticipationKeys(initiallyOffline, curRound+1001, curRound+1000, 0)
+	a.Equal("FillDBWithParticipationKeys: lastValid 1000 is after firstValid 1001", err.Error())
+}

--- a/test/e2e-go/features/transactions/onlineStatusChange_test.go
+++ b/test/e2e-go/features/transactions/onlineStatusChange_test.go
@@ -17,6 +17,7 @@
 package transactions
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -175,5 +176,6 @@ func TestCloseOnError(t *testing.T) {
 	a.Equal("PersistedParticipation.Persist: failed to install database: table ParticipationAccount already exists", err.Error())
 	// check lastValid < firstValid does not crash
 	_, _, err = client.GenParticipationKeys(initiallyOffline, curRound+1001, curRound+1000, 0)
-	a.Equal("FillDBWithParticipationKeys: lastValid 1000 is after firstValid 1001", err.Error())
+	expected:= fmt.Sprintf("FillDBWithParticipationKeys: firstValid %d is after lastValid %d", int(curRound+1001), int(curRound+1000))
+	a.Equal(expected, err.Error())
 }


### PR DESCRIPTION
## Summary

FillDBWithParticipationKeys will return empty PersistedParticipation when lastValid is less than firstValid.
When this happens, newPart will not have partdb in newPart.Store, instead, will have an empty object.
Calling Close on the empty object will call close on nil Accessor pointer and panic.

This change avoids using the returned object with non-nil error, and properly closes the db with the valid object.
## Test Plan

Added test to verify the proper handling of the different errors returned from FillDBWithParticipationKeys and handled by GenParticipationKeysTo.
