### PR TITLE
Report assembly error strings for compile API endpoint 

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -922,7 +922,7 @@ func assembleFile(fname string) (program []byte) {
 	}
 	ops, err := logic.AssembleString(string(text))
 	if err != nil {
-		ops.ReportProblems(fname)
+		ops.ReportProblems(fname, os.Stderr)
 		reportErrorf("%s: %s", fname, err)
 	}
 	_, params := getProto(protoVersion)

--- a/cmd/goal/multisig.go
+++ b/cmd/goal/multisig.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -163,7 +164,7 @@ var signProgramCmd = &cobra.Command{
 			}
 			ops, err := logic.AssembleString(string(text))
 			if err != nil {
-				ops.ReportProblems(programSource)
+				ops.ReportProblems(programSource, os.Stderr)
 				reportErrorf("%s: %s", programSource, err)
 			}
 			if outname == "" {

--- a/cmd/pingpong/runCmd.go
+++ b/cmd/pingpong/runCmd.go
@@ -242,7 +242,7 @@ var runCmd = &cobra.Command{
 			}
 			ops, err := logic.AssembleString(programStr)
 			if err != nil {
-				ops.ReportProblems(teal)
+				ops.ReportProblems(teal, os.Stderr)
 				reportErrorf("Internal error, cannot assemble %v \n", programStr)
 			}
 			cfg.Program = ops.Program

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -754,7 +755,9 @@ func (v2 *Handlers) TealCompile(ctx echo.Context) error {
 	source := buf.String()
 	ops, err := logic.AssembleString(source)
 	if err != nil {
-		return badRequest(ctx, err, ops.ReportProblemsString(), v2.Log)
+		sb := strings.Builder{}
+		ops.ReportProblems("", &sb)
+		return badRequest(ctx, err, sb.String(), v2.Log)
 	}
 	pd := logic.HashProgram(ops.Program)
 	addr := basics.Address(pd)

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -754,7 +754,7 @@ func (v2 *Handlers) TealCompile(ctx echo.Context) error {
 	source := buf.String()
 	ops, err := logic.AssembleString(source)
 	if err != nil {
-		return badRequest(ctx, err, err.Error(), v2.Log)
+		return badRequest(ctx, err, ops.ReportProblemsString(), v2.Log)
 	}
 	pd := logic.HashProgram(ops.Program)
 	addr := basics.Address(pd)

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -2130,9 +2130,6 @@ func (ops *OpStream) ReportProblems(fname string, writer io.Writer) {
 			fmt.Fprintf(writer, "%s: %s\n", fname, w)
 		}
 	}
-	if fname == "" {
-		fmt.Fprintf(writer, "%d errors", len(ops.Errors))
-	}
 }
 
 // AssembleString takes an entire program in a string and assembles it to bytecode using AssemblerDefaultVersion

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -2125,6 +2125,25 @@ func (ops *OpStream) ReportProblems(fname string) {
 	}
 }
 
+// ReportProblemsString issues accumulated warnings and outputs an error string.
+func (ops *OpStream) ReportProblemsString() string {
+	sb := strings.Builder{}
+	fmt.Fprintf(&sb, "%d errors\n", len(ops.Errors))
+	for i, e := range ops.Errors {
+		if i > 9 {
+			break
+		}
+		fmt.Fprintf(&sb, "%s\n", e)
+	}
+	for i, w := range ops.Warnings {
+		if i > 9 {
+			break
+		}
+		fmt.Fprintf(&sb, "%s\n", w)
+	}
+	return sb.String()
+}
+
 // AssembleString takes an entire program in a string and assembles it to bytecode using AssemblerDefaultVersion
 func AssembleString(text string) (*OpStream, error) {
 	return AssembleStringWithVersion(text, assemblerNoVersion)

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -2128,7 +2128,6 @@ func (ops *OpStream) ReportProblems(fname string) {
 // ReportProblemsString issues accumulated warnings and outputs an error string.
 func (ops *OpStream) ReportProblemsString() string {
 	sb := strings.Builder{}
-	fmt.Fprintf(&sb, "%d errors\n", len(ops.Errors))
 	for i, e := range ops.Errors {
 		if i > 9 {
 			break
@@ -2141,6 +2140,7 @@ func (ops *OpStream) ReportProblemsString() string {
 		}
 		fmt.Fprintf(&sb, "%s\n", w)
 	}
+	fmt.Fprintf(&sb, "%d errors", len(ops.Errors))
 	return sb.String()
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

This PR adds the assembly error strings so developers can see which errors were present in the program when calling the API. Prior to this change, the API only reported the number of errors in the program.

Closes #3082 .

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

Tested on sandbox.
Example program:
``` 
#pragma version 7
int v
```

Example response:
```
algosdk.error.AlgodHTTPError: 1: unsupported version: 7
2: strconv.ParseUint: parsing "v": invalid syntax
```
