### PR TITLE
Change test output format, turn up timeout from 30m to 60m for dilithium branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ commands:
         type: string
       no_output_timeout:
         type: string
-        default: 30m
+        default: 60m
       short_test_flag:
         type: string
         default: ""
@@ -396,7 +396,7 @@ commands:
         type: string
       no_output_timeout:
         type: string
-        default: 30m
+        default: 60m
       short_test_flag:
         type: string
         default: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,7 @@ commands:
             export PARTITION_TOTAL=${CIRCLE_NODE_TOTAL}
             export PARTITION_ID=${CIRCLE_NODE_INDEX}
             export PARALLEL_FLAG="-p 1"
-            gotestsum --format testname --junitfile << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml --jsonfile << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" << parameters.short_test_flag >> -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 1 $PACKAGE_NAMES
+            gotestsum --format standard-verbose --junitfile << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml --jsonfile << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" << parameters.short_test_flag >> -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 1 $PACKAGE_NAMES
       - store_artifacts:
           path: << parameters.result_path >>
           destination: test-results


### PR DESCRIPTION
## Summary

The dilithium branch has added tests that sometimes hits the no_output_default 30m timeout for test jobs. This lets those jobs complete so we can better understand their performance impacts. Otherwise we don't get much information to work with.

It also adds a change to gotestsum to print the name of the test before running it, so if your test does not finish, you will see its name rather than wait for it to complete (and be timed out before you see it).

## Test Plan

No change to tests, just more patience waiting for them to finish.