### PR TITLE
use large VMs for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -704,6 +704,5 @@ jobs:
       - prepare_go
       - upload_binaries_command:
           platform: << parameters.platform >>
-      - slack/notify: &slack-fail-event
-          event: fail
-          template: basic_fail_1
+      - slack/notify:
+          <<: *slack-fail-event

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,7 +557,7 @@ jobs:
     parameters:
       platform:
         type: string
-    executor: << parameters.platform >>_medium
+    executor: << parameters.platform >>_large
     working_directory: << pipeline.parameters.build_dir >>/project
     parallelism: 2
     environment:


### PR DESCRIPTION
## Summary

Integration tests (specifically, e2e-go tests) seem to be having resource issues lately, so this returns integration tests to using large instances (4 cores, ~16GB RAM) after they were downsized to medium (2 cores ~8GB RAM) in #3095. Nightly integration tests are already using large VMs.

## Test Plan

Hopefully this will improve integration test performance and reduce flakiness by giving E2E go tests (which typically involve spinning up multiple algod processes) more CPU and RAM.