### PR TITLE
ledger refactoring: fix catchpoint tracker

### DIFF
--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -297,7 +297,7 @@ func (ct *catchpointTracker) prepareCommit(dcc *deferredCommitContext) error {
 	ct.catchpointsMu.RLock()
 	defer ct.catchpointsMu.RUnlock()
 	if dcc.isCatchpointRound {
-		dcc.committedRoundDigest = ct.roundDigest[dcc.offset+uint64(dcc.lookback)-1]
+		dcc.committedRoundDigest = ct.roundDigest[dcc.offset+uint64(dcc.lookback)]
 	}
 	return nil
 }

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -159,6 +159,12 @@ func (ct *catchpointTracker) loadFromDisk(l ledgerForTracker, lastBalancesRound 
 	ct.log = l.trackerLog()
 	ct.dbs = l.trackerDB()
 
+	ct.roundDigest = nil
+	ct.catchpointWriting = 0
+	// keep these channel closed if we're not generating catchpoint
+	ct.catchpointSlowWriting = make(chan struct{}, 1)
+	close(ct.catchpointSlowWriting)
+
 	err = ct.dbs.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 		err0 := ct.accountsInitializeHashes(ctx, tx, lastBalancesRound)
 		if err0 != nil {
@@ -181,7 +187,6 @@ func (ct *catchpointTracker) loadFromDisk(l ledgerForTracker, lastBalancesRound 
 		return
 	}
 
-	ct.roundDigest = nil
 	writingCatchpointRound, _, err := ct.accountsq.readCatchpointStateUint64(context.Background(), catchpointStateWritingCatchpoint)
 	if err != nil {
 		return err
@@ -207,11 +212,6 @@ func (ct *catchpointTracker) loadFromDisk(l ledgerForTracker, lastBalancesRound 
 		return err
 	}
 	blockHeaderDigest := blk.Digest()
-
-	ct.catchpointWriting = 0
-	// keep these channel closed if we're not generating catchpoint
-	ct.catchpointSlowWriting = make(chan struct{}, 1)
-	close(ct.catchpointSlowWriting)
 
 	ct.generateCatchpoint(context.Background(), basics.Round(writingCatchpointRound), ct.lastCatchpointLabel, blockHeaderDigest, time.Duration(0))
 	return nil

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -181,6 +181,7 @@ func (ct *catchpointTracker) loadFromDisk(l ledgerForTracker, lastBalancesRound 
 		return
 	}
 
+	ct.roundDigest = nil
 	writingCatchpointRound, _, err := ct.accountsq.readCatchpointStateUint64(context.Background(), catchpointStateWritingCatchpoint)
 	if err != nil {
 		return err
@@ -197,6 +198,7 @@ func (ct *catchpointTracker) loadFromDisk(l ledgerForTracker, lastBalancesRound 
 	if err != nil {
 		return err
 	}
+
 	if dbRound != basics.Round(writingCatchpointRound) {
 		return nil
 	}
@@ -211,7 +213,6 @@ func (ct *catchpointTracker) loadFromDisk(l ledgerForTracker, lastBalancesRound 
 	// keep these channel closed if we're not generating catchpoint
 	ct.catchpointSlowWriting = make(chan struct{}, 1)
 	close(ct.catchpointSlowWriting)
-	ct.roundDigest = nil
 
 	ct.generateCatchpoint(context.Background(), basics.Round(writingCatchpointRound), ct.lastCatchpointLabel, blockHeaderDigest, time.Duration(0))
 	return nil
@@ -297,7 +298,7 @@ func (ct *catchpointTracker) prepareCommit(dcc *deferredCommitContext) error {
 	ct.catchpointsMu.RLock()
 	defer ct.catchpointsMu.RUnlock()
 	if dcc.isCatchpointRound {
-		dcc.committedRoundDigest = ct.roundDigest[dcc.offset+uint64(dcc.lookback)]
+		dcc.committedRoundDigest = ct.roundDigest[dcc.offset+uint64(dcc.lookback)-1]
 	}
 	return nil
 }

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -198,7 +198,6 @@ func (ct *catchpointTracker) loadFromDisk(l ledgerForTracker, lastBalancesRound 
 	if err != nil {
 		return err
 	}
-
 	if dbRound != basics.Round(writingCatchpointRound) {
 		return nil
 	}

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -380,12 +380,12 @@ func TestCatchpointTrackerPrepareCommit(t *testing.T) {
 	ct := &catchpointTracker{}
 	const maxOffset = 40
 	const maxLookback = 320
-	ct.roundDigest = make([]crypto.Digest, maxOffset+maxLookback+1)
+	ct.roundDigest = make([]crypto.Digest, maxOffset+maxLookback)
 	for i := 0; i < len(ct.roundDigest); i++ {
 		ct.roundDigest[i] = crypto.Hash([]byte{byte(i), byte(i / 256)})
 	}
 	dcc := &deferredCommitContext{}
-	for offset := uint64(0); offset < maxOffset; offset++ {
+	for offset := uint64(1); offset < maxOffset; offset++ {
 		dcc.offset = offset
 		for lookback := basics.Round(0); lookback < maxLookback; lookback += 20 {
 			dcc.lookback = lookback
@@ -393,7 +393,8 @@ func TestCatchpointTrackerPrepareCommit(t *testing.T) {
 				dcc.isCatchpointRound = isCatchpointRound
 				require.NoError(t, ct.prepareCommit(dcc))
 				if isCatchpointRound {
-					expectedHash := crypto.Hash([]byte{byte(offset + uint64(lookback)), byte((offset + uint64(lookback)) / 256)})
+					expectedRound := offset + uint64(lookback) - 1
+					expectedHash := crypto.Hash([]byte{byte(expectedRound), byte(expectedRound / 256)})
 					require.Equal(t, expectedHash[:], dcc.committedRoundDigest[:])
 				}
 			}

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -372,6 +372,18 @@ func TestReproducibleCatchpointLabels(t *testing.T) {
 			}
 		}
 	}
+
+	// test to see that after loadFromDisk, all the tracker content is lost ( as expected )
+	require.NotZero(t, len(ct.roundDigest))
+	require.NoError(t, ct.loadFromDisk(ml, ml.Latest()))
+	require.Zero(t, len(ct.roundDigest))
+	require.Zero(t, ct.catchpointWriting)
+	select {
+	case _, closed := <-ct.catchpointSlowWriting:
+		require.False(t, closed)
+	default:
+		require.FailNow(t, "The catchpointSlowWriting should have been a closed channel; it seems to be a nil ?!")
+	}
 }
 
 func TestCatchpointTrackerPrepareCommit(t *testing.T) {


### PR DESCRIPTION
## Summary

When implementing the catchpoint tracker, I missed the re-initilization location for some of the local variables.
This would generate incorrect catchpoint labels after a node completes a fast-catchup.

https://github.com/algorand/go-algorand/pull/3085

## Test Plan

- [x] Add unit tests
- [x] Perform manual testing