### PR TITLE
CI: use libboost-math-dev instead of libboost-all-dev

### DIFF
--- a/scripts/install_linux_deps.sh
+++ b/scripts/install_linux_deps.sh
@@ -5,7 +5,7 @@ set -e
 DISTRIB=$ID
 
 ARCH_DEPS="boost boost-libs expect jq autoconf shellcheck sqlite python-virtualenv"
-UBUNTU_DEPS="libboost-all-dev expect jq autoconf shellcheck sqlite3 python3-venv"
+UBUNTU_DEPS="libboost-math-dev expect jq autoconf shellcheck sqlite3 python3-venv"
 FEDORA_DEPS="boost-devel expect jq autoconf ShellCheck sqlite python-virtualenv"
 
 if [ "${DISTRIB}" = "arch" ]; then


### PR DESCRIPTION
## Summary

Small change: libboost-math-dev requires just 4 packages to install, while libboost-all-dev requires > 100. Only Debian/Ubuntu distributions provide fine-grained boost packages like this, but should shave a little time off the CI builds. (Our only boost include is boost/math/distributions/binomial.hpp.)

## Test Plan

Builds should pass as before. Now that we are no longer using Travis for Linux builds, the side effect of libboost-all-dev installing make and other missing build tools on Travis encountered in #2717 is no longer a concern.