### PR TITLE
interactive mode for e2e testing

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -46,14 +46,9 @@ optional arguments:
   --version Future|vXX   selects the network template file
 ```
 
-To run a specific test:
+To run a specific test, run e2e.sh with -i interactive flag, and follow the instructions:
 ```
-~$ ./e2e_client_runner.py /full/path/to/e2e_subs/test_script.sh
-```
-
-Make sure to install the Algorand Python SDK before running:
-```
-pip install py-algorand-sdk
+test/scripts/e2e.sh -i
 ```
 
 Tests in the `e2e_subs/serial` directory are executed serially instead of in parallel. This should only be used when absolutely necessary.

--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -24,7 +24,7 @@ Options:
     -n        Run tests without building binaries (Binaries are expected in PATH)
 "
 NO_BUILD=false
-while getopts ":c:nh" opt; do
+while getopts ":c:nhi" opt; do
   case ${opt} in
     c ) CHANNEL=$OPTARG
       ;;
@@ -33,7 +33,11 @@ while getopts ":c:nh" opt; do
       ;;
     h ) echo "${HELP}"
         exit 0
-      ;;
+	;;
+    i ) echo "  Interactive session"
+	echo "######################################################################"
+	INTERACTIVE=true
+	;;
     \? ) echo "${HELP}"
         exit 2
       ;;
@@ -121,6 +125,19 @@ if [ -z "$E2E_TEST_FILTER" ] || [ "$E2E_TEST_FILTER" == "SCRIPTS" ]; then
     "${TEMPDIR}/ve/bin/pip3" install --upgrade pip
     "${TEMPDIR}/ve/bin/pip3" install --upgrade py-algorand-sdk cryptography
     duration "e2e client setup"
+
+    if [ $INTERACTIVE ]; then
+	echo "********** READY **********"
+	echo "The test environment is now set. Run the tests using the following command on a different terminal."
+	echo "${TEMPDIR}/ve/bin/python3" test/scripts/e2e_client_runner.py ${RUN_KMD_WITH_UNSAFE_SCRYPT} "$SRCROOT"/test/scripts/e2e_subs/SCRIPT_FILE_NAME
+
+	echo "Press enter to shut down the test environment..."
+	read a
+	echo -n "deactivating..."
+	deactivate
+	echo "done"
+	exit
+    fi
 
     "${TEMPDIR}/ve/bin/python3" e2e_client_runner.py ${RUN_KMD_WITH_UNSAFE_SCRYPT} "$SRCROOT"/test/scripts/e2e_subs/*.{sh,py}
     duration "parallel client runner"

--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -128,9 +128,13 @@ if [ -z "$E2E_TEST_FILTER" ] || [ "$E2E_TEST_FILTER" == "SCRIPTS" ]; then
 
     if [ $INTERACTIVE ]; then
 	echo "********** READY **********"
-	echo "The test environment is now set. Run the tests using the following command on a different terminal."
+	echo "The test environment is now set. Run the tests using the following command on a different terminal after setting the path."
+	echo ""
+	echo "export VIRTUAL_ENV=\"${TEMPDIR}/ve\""
+	echo "export PATH=\"\$VIRTUAL_ENV/bin:\$PATH\""
+	echo ""
 	echo "${TEMPDIR}/ve/bin/python3" test/scripts/e2e_client_runner.py ${RUN_KMD_WITH_UNSAFE_SCRYPT} "$SRCROOT"/test/scripts/e2e_subs/SCRIPT_FILE_NAME
-
+	echo ""
 	echo "Press enter to shut down the test environment..."
 	read a
 	echo -n "deactivating..."


### PR DESCRIPTION


## Summary
Some e2e tests require a python environment for testing.
Unfortunately, setting up that environment adequately similar to the testing environment may not be trivial.
This change introduces an interactive mode to the e2e.sh script which stops at the point of running the tests, and allows the user to run the tests from the same testing environment.


## Test Plan
No tests needed. Tested the script locally.

