### PR TITLE
apply.balances part2: cow to acct update changes

### DIFF
--- a/cmd/catchpointdump/file.go
+++ b/cmd/catchpointdump/file.go
@@ -158,7 +158,7 @@ func loadCatchpointIntoDatabase(ctx context.Context, catchupAccessor ledger.Catc
 			// we already know it's valid, since we validated that above.
 			protocol.Decode(balancesBlockBytes, &fileHeader)
 		}
-		if time.Now().Sub(lastProgressUpdate) > 50*time.Millisecond && len(fileBytes) > 0 {
+		if time.Since(lastProgressUpdate) > 50*time.Millisecond && len(fileBytes) > 0 {
 			lastProgressUpdate = time.Now()
 			printLoadCatchpointProgressLine(int(float64(progress)*50.0/float64(len(fileBytes))), 50, int64(progress))
 		}
@@ -262,7 +262,7 @@ func printAccountsDatabase(databaseName string, fileHeader ledger.CatchpointFile
 
 			var addr basics.Address
 			if len(addrbuf) != len(addr) {
-				err = fmt.Errorf("Account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
+				err = fmt.Errorf("account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
 				return
 			}
 			copy(addr[:], addrbuf)
@@ -273,7 +273,7 @@ func printAccountsDatabase(databaseName string, fileHeader ledger.CatchpointFile
 
 			fmt.Fprintf(fileWriter, "%v : %s\n", addr, string(jsonData))
 
-			if time.Now().Sub(lastProgressUpdate) > 50*time.Millisecond && rowsCount > 0 {
+			if time.Since(lastProgressUpdate) > 50*time.Millisecond && rowsCount > 0 {
 				lastProgressUpdate = time.Now()
 				printDumpingCatchpointProgressLine(int(float64(progress)*50.0/float64(rowsCount)), 50, int64(progress))
 			}

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -163,9 +163,10 @@ type compactAccountDeltas struct {
 }
 
 type accountDelta struct {
-	old     persistedAccountData
-	new     basics.AccountData
-	ndeltas int
+	old      persistedAccountData        // old account data from DB
+	new      basics.AccountData          // new fully updated account data
+	newDelta ledgercore.NewAccountDeltas // partial deltas to resolve in accountsLoadOld
+	ndeltas  int
 }
 
 // catchpointState is used to store catchpoint related variables into the catchpointstate table.
@@ -217,7 +218,7 @@ func prepareNormalizedBalances(bals []encodedBalanceRecord, proto config.Consens
 // makeCompactAccountDeltas takes an array of account AccountDeltas ( one array entry per round ), and compacts the arrays into a single
 // data structure that contains all the account deltas changes. While doing that, the function eliminate any intermediate account changes.
 // It counts the number of changes per round by specifying it in the ndeltas field of the accountDeltaCount/modifiedCreatable.
-func makeCompactAccountDeltas(accountDeltas []ledgercore.AccountDeltas, baseAccounts lruAccounts) (outAccountDeltas compactAccountDeltas) {
+func makeCompactAccountDeltas(accountDeltas []ledgercore.NewAccountDeltas, baseAccounts lruAccounts) (outAccountDeltas compactAccountDeltas) {
 	if len(accountDeltas) == 0 {
 		return
 	}
@@ -228,25 +229,44 @@ func makeCompactAccountDeltas(accountDeltas []ledgercore.AccountDeltas, baseAcco
 	outAccountDeltas.deltas = make([]accountDelta, 0, size)
 	outAccountDeltas.misses = make([]int, 0, size)
 
+	// TODO: remove
+	// convert partial deltas to full deltas
 	for _, roundDelta := range accountDeltas {
-		for i := 0; i < roundDelta.Len(); i++ {
-			addr, acctDelta := roundDelta.GetByIdx(i)
+		addresses := roundDelta.ModifiedAccounts()
+		for _, addr := range addresses {
 			if prev, idx := outAccountDeltas.get(addr); idx != -1 {
-				outAccountDeltas.update(idx, accountDelta{ // update instead of upsert economizes one map lookup
-					old:     prev.old,
-					new:     acctDelta,
-					ndeltas: prev.ndeltas + 1,
-				})
+				// TODO: remove
+				// partial deltas support
+				if !prev.old.accountData.IsZero() {
+					// old is loaded from base accounts and new is a fully updated basics account
+					new := roundDelta.ApplyToBasicsAccountData(addr, prev.new)
+					outAccountDeltas.update(idx, accountDelta{
+						old:     prev.old,
+						new:     new,
+						ndeltas: prev.ndeltas + 1,
+					})
+				} else {
+					// old is unknown, merge partial deltas into newDelta
+					newDelta := roundDelta.ApplyToPrevDelta(addr, prev.newDelta)
+					outAccountDeltas.update(idx, accountDelta{
+						ndeltas:  prev.ndeltas + 1,
+						newDelta: newDelta,
+					})
+				}
 			} else {
 				// it's a new entry.
 				newEntry := accountDelta{
-					new:     acctDelta,
 					ndeltas: 1,
 				}
 				if baseAccountData, has := baseAccounts.read(addr); has {
 					newEntry.old = baseAccountData
-					outAccountDeltas.insert(addr, newEntry) // insert instead of upsert economizes one map lookup
+					// TODO: remove
+					// partial delta support: apply partial delta into a full basics ad
+					// another conversion happens in accountsLoadOld -> updateOld
+					newEntry.new = roundDelta.ApplyToBasicsAccountData(addr, baseAccountData.accountData)
+					outAccountDeltas.insert(addr, newEntry)
 				} else {
+					newEntry.newDelta = roundDelta.ExtractDelta(addr)
 					outAccountDeltas.insertMissing(addr, newEntry)
 				}
 			}
@@ -353,7 +373,11 @@ func (a *compactAccountDeltas) insertMissing(addr basics.Address, delta accountD
 func (a *compactAccountDeltas) upsertOld(old persistedAccountData) {
 	addr := old.addr
 	if idx, exist := a.cache[addr]; exist {
-		a.deltas[idx].old = old
+		delta := a.deltas[idx]
+		delta.old = old
+		delta.new = delta.newDelta.ApplyToBasicsAccountData(addr, old.accountData)
+		delta.newDelta = ledgercore.NewAccountDeltas{}
+		a.deltas[idx] = delta
 		return
 	}
 	a.insert(addr, accountDelta{old: old})
@@ -361,7 +385,11 @@ func (a *compactAccountDeltas) upsertOld(old persistedAccountData) {
 
 // updateOld updates existing or inserts a new partial entry with only old field filled
 func (a *compactAccountDeltas) updateOld(idx int, old persistedAccountData) {
-	a.deltas[idx].old = old
+	delta := a.deltas[idx]
+	delta.old = old
+	delta.new = delta.newDelta.ApplyToBasicsAccountData(old.addr, old.accountData)
+	delta.newDelta = ledgercore.NewAccountDeltas{}
+	a.deltas[idx] = delta
 }
 
 // writeCatchpointStagingBalances inserts all the account balances in the provided array into the catchpoint balance staging table catchpointbalances.
@@ -567,7 +595,8 @@ func accountsInit(tx *sql.Tx, initAccounts map[basics.Address]basics.AccountData
 				return true, err
 			}
 
-			totals.AddAccount(proto, data, &ot)
+			ad := ledgercore.ToAccountData(data)
+			totals.AddAccount(proto, ad, &ot)
 		}
 
 		if ot.Overflowed {
@@ -1374,7 +1403,7 @@ func (qs *accountsDbQueries) readCatchpointStateString(ctx context.Context, stat
 	var val sql.NullString
 	err = db.Retry(func() (err error) {
 		err = qs.selectCatchpointStateString.QueryRowContext(ctx, stateName).Scan(&val)
-		if err == sql.ErrNoRows || (err == nil && false == val.Valid) {
+		if err == sql.ErrNoRows || (err == nil && !val.Valid) {
 			val.String = "" // default to empty string
 			err = nil
 			def = true

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -201,7 +201,7 @@ type normalizedAccountBalance struct {
 
 // prepareNormalizedBalances converts an array of encodedBalanceRecord into an equal size array of normalizedAccountBalances.
 func prepareNormalizedBalances(bals []encodedBalanceRecord, proto config.ConsensusParams) (normalizedAccountBalances []normalizedAccountBalance, err error) {
-	normalizedAccountBalances = make([]normalizedAccountBalance, len(bals), len(bals))
+	normalizedAccountBalances = make([]normalizedAccountBalance, len(bals))
 	for i, balance := range bals {
 		normalizedAccountBalances[i].address = balance.Address
 		err = protocol.Decode(balance.AccountData, &(normalizedAccountBalances[i].accountData))
@@ -1099,7 +1099,7 @@ func removeEmptyAccountData(tx *sql.Tx, queryAddresses bool) (num int64, address
 			}
 			var addr basics.Address
 			if len(addrbuf) != len(addr) {
-				err = fmt.Errorf("Account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
+				err = fmt.Errorf("account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
 				return 0, nil, err
 			}
 			copy(addr[:], addrbuf)
@@ -1371,7 +1371,7 @@ func (qs *accountsDbQueries) readCatchpointStateUint64(ctx context.Context, stat
 	var val sql.NullInt64
 	err = db.Retry(func() (err error) {
 		err = qs.selectCatchpointStateUint64.QueryRowContext(ctx, stateName).Scan(&val)
-		if err == sql.ErrNoRows || (err == nil && false == val.Valid) {
+		if err == sql.ErrNoRows || (err == nil && !val.Valid) {
 			val.Int64 = 0 // default to zero.
 			err = nil
 			def = true
@@ -1485,7 +1485,7 @@ func accountsOnlineTop(tx *sql.Tx, offset, n uint64, proto config.ConsensusParam
 
 		var addr basics.Address
 		if len(addrbuf) != len(addr) {
-			err = fmt.Errorf("Account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
+			err = fmt.Errorf("account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
 			return nil, err
 		}
 
@@ -1731,7 +1731,7 @@ func reencodeAccounts(ctx context.Context, tx *sql.Tx) (modifiedAccounts uint, e
 		}
 
 		if len(addrbuf) != len(addr) {
-			err = fmt.Errorf("Account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
+			err = fmt.Errorf("account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
 			return
 		}
 		copy(addr[:], addrbuf[:])
@@ -1744,7 +1744,7 @@ func reencodeAccounts(ctx context.Context, tx *sql.Tx) (modifiedAccounts uint, e
 			return
 		}
 		reencodedAccountData := protocol.Encode(&decodedAccountData)
-		if bytes.Compare(preencodedAccountData, reencodedAccountData) == 0 {
+		if bytes.Equal(preencodedAccountData, reencodedAccountData) {
 			// these are identical, no need to store re-encoded account data
 			continue
 		}
@@ -1852,7 +1852,7 @@ func (iterator *encodedAccountsBatchIter) Next(ctx context.Context, tx *sql.Tx, 
 		}
 
 		if len(addrbuf) != len(addr) {
-			err = fmt.Errorf("Account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
+			err = fmt.Errorf("account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
 			return
 		}
 
@@ -1990,7 +1990,7 @@ func (iterator *orderedAccountsIter) Next(ctx context.Context) (acct []accountAd
 			}
 
 			if len(addrbuf) != len(addr) {
-				err = fmt.Errorf("Account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
+				err = fmt.Errorf("account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
 				iterator.Close(ctx)
 				return
 			}
@@ -2061,7 +2061,7 @@ func (iterator *orderedAccountsIter) Next(ctx context.Context) (acct []accountAd
 			}
 
 			if len(addrbuf) != len(addr) {
-				err = fmt.Errorf("Account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
+				err = fmt.Errorf("account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
 				iterator.Close(ctx)
 				return
 			}

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -618,6 +618,7 @@ func BenchmarkWritingRandomBalancesDisk(b *testing.B) {
 
 		// read all the accounts to obtain the addrs.
 		rows, err := tx.Query("SELECT rowid, address FROM accountbase")
+		require.NoError(b, err)
 		defer rows.Close()
 		for rows.Next() {
 			var addrbuf []byte
@@ -660,7 +661,7 @@ func BenchmarkWritingRandomBalancesDisk(b *testing.B) {
 			}
 
 		}
-		b.ReportMetric(float64(int(time.Now().Sub(startTime))/b.N), "ns/acct_update")
+		b.ReportMetric(float64(int(time.Since(startTime))/b.N), "ns/acct_update")
 	})
 
 	b.Run("ByRowID", func(b *testing.B) {
@@ -686,7 +687,7 @@ func BenchmarkWritingRandomBalancesDisk(b *testing.B) {
 				}
 			}
 		}
-		b.ReportMetric(float64(int(time.Now().Sub(startTime))/b.N), "ns/acct_update")
+		b.ReportMetric(float64(int(time.Since(startTime))/b.N), "ns/acct_update")
 
 	})
 
@@ -859,7 +860,7 @@ func benchmarkWriteCatchpointStagingBalancesSub(b *testing.B, ascendingOrder boo
 			}
 			balances.Balances[i] = randomAccount
 		}
-		balanceLoopDuration := time.Now().Sub(balancesLoopStart)
+		balanceLoopDuration := time.Since(balancesLoopStart)
 		last64KAccountCreationTime += balanceLoopDuration
 		accountsGenerationDuration += balanceLoopDuration
 
@@ -875,13 +876,13 @@ func benchmarkWriteCatchpointStagingBalancesSub(b *testing.B, ascendingOrder boo
 		accountsLoaded += chunkSize
 	}
 	if !last64KStart.IsZero() {
-		last64KDuration := time.Now().Sub(last64KStart) - last64KAccountCreationTime
+		last64KDuration := time.Since(last64KStart) - last64KAccountCreationTime
 		fmt.Printf("%-82s%-7d (last 64k) %-6d ns/account       %d accounts/sec\n", b.Name(), last64KSize, (last64KDuration / time.Duration(last64KSize)).Nanoseconds(), int(float64(last64KSize)/float64(last64KDuration.Seconds())))
 	}
 	stats, err := l.trackerDBs.Wdb.Vacuum(context.Background())
 	require.NoError(b, err)
 	fmt.Printf("%-82sdb fragmentation   %.1f%%\n", b.Name(), float32(stats.PagesBefore-stats.PagesAfter)*100/float32(stats.PagesBefore))
-	b.ReportMetric(float64(b.N)/float64((time.Now().Sub(accountsWritingStarted)-accountsGenerationDuration).Seconds()), "accounts/sec")
+	b.ReportMetric(float64(b.N)/float64((time.Since(accountsWritingStarted)-accountsGenerationDuration).Seconds()), "accounts/sec")
 }
 
 func BenchmarkWriteCatchpointStagingBalances(b *testing.B) {

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -62,9 +61,6 @@ func checkAccounts(t *testing.T, tx *sql.Tx, rnd basics.Round, accts map[basics.
 		pad, err := aq.lookup(addr)
 		require.NoError(t, err)
 		d := pad.accountData
-		if !reflect.DeepEqual(d, data) {
-			fmt.Println("not equal", addr.String())
-		}
 		require.Equal(t, d, data)
 
 		switch d.Status {

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -59,8 +60,11 @@ func checkAccounts(t *testing.T, tx *sql.Tx, rnd basics.Round, accts map[basics.
 
 	for addr, data := range accts {
 		pad, err := aq.lookup(addr)
-		d := pad.accountData
 		require.NoError(t, err)
+		d := pad.accountData
+		if !reflect.DeepEqual(d, data) {
+			fmt.Println("not equal", addr.String())
+		}
 		require.Equal(t, d, data)
 
 		switch d.Status {
@@ -159,14 +163,14 @@ func TestAccountDBInit(t *testing.T) {
 }
 
 // creatablesFromUpdates calculates creatables from updates
-func creatablesFromUpdates(base map[basics.Address]basics.AccountData, updates ledgercore.AccountDeltas, seen map[basics.CreatableIndex]bool) map[basics.CreatableIndex]ledgercore.ModifiedCreatable {
+func creatablesFromUpdates(base map[basics.Address]basics.AccountData, updates ledgercore.NewAccountDeltas, seen map[basics.CreatableIndex]bool) map[basics.CreatableIndex]ledgercore.ModifiedCreatable {
 	creatables := make(map[basics.CreatableIndex]ledgercore.ModifiedCreatable)
-	for i := 0; i < updates.Len(); i++ {
-		addr, update := updates.GetByIdx(i)
+	converted := updates.ToBasicsAccountDataMap()
+	for addr, update := range converted {
 		// no sets in Go, so iterate over
 		if ad, ok := base[addr]; ok {
-			for idx := range ad.Assets {
-				if _, ok := update.Assets[idx]; !ok {
+			for idx := range ad.AssetParams {
+				if _, ok := update.AssetParams[idx]; !ok {
 					creatables[basics.CreatableIndex(idx)] = ledgercore.ModifiedCreatable{
 						Ctype:   basics.AssetCreatable,
 						Created: false, // exists in base, not in new => deleted
@@ -184,13 +188,13 @@ func creatablesFromUpdates(base map[basics.Address]basics.AccountData, updates l
 				}
 			}
 		}
-		for idx := range update.Assets {
+		for idx := range update.AssetParams {
 			if seen[basics.CreatableIndex(idx)] {
 				continue
 			}
 			ad, found := base[addr]
 			if found {
-				if _, ok := ad.Assets[idx]; !ok {
+				if _, ok := ad.AssetParams[idx]; !ok {
 					found = false
 				}
 			}
@@ -226,6 +230,25 @@ func creatablesFromUpdates(base map[basics.Address]basics.AccountData, updates l
 	return creatables
 }
 
+func applyPartialDeltas(base map[basics.Address]basics.AccountData, deltas ledgercore.NewAccountDeltas) map[basics.Address]basics.AccountData {
+	result := make(map[basics.Address]basics.AccountData, len(base)+deltas.Len())
+	for addr, ad := range base {
+		result[addr] = ad
+	}
+
+	for i := 0; i < deltas.Len(); i++ {
+		addr, _ := deltas.GetByIdx(i)
+		ad, ok := result[addr]
+		if !ok {
+			ad, _ = deltas.GetBasicsAccountData(addr)
+		} else {
+			ad = deltas.ApplyToBasicsAccountData(addr, ad)
+		}
+		result[addr] = ad
+	}
+	return result
+}
+
 func TestAccountDBRound(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
@@ -247,39 +270,42 @@ func TestAccountDBRound(t *testing.T) {
 	require.NoError(t, err)
 
 	// used to determine how many creatables element will be in the test per iteration
-	numElementsPerSegement := 10
+	numElementsPerSegment := 10
 
 	// lastCreatableID stores asset or app max used index to get rid of conflicts
 	lastCreatableID := crypto.RandUint64() % 512
-	ctbsList, randomCtbs := randomCreatables(numElementsPerSegement)
+	ctbsList, randomCtbs := randomCreatables(numElementsPerSegment)
 	expectedDbImage := make(map[basics.CreatableIndex]ledgercore.ModifiedCreatable)
 	var baseAccounts lruAccounts
-	var newaccts map[basics.Address]basics.AccountData
+	var newacctsTotals map[basics.Address]ledgercore.AccountData
 	baseAccounts.init(nil, 100, 80)
 	for i := 1; i < 10; i++ {
-		var updates ledgercore.AccountDeltas
-		updates, newaccts, _, lastCreatableID = ledgertesting.RandomDeltasFull(20, accts, 0, lastCreatableID)
+		var updates ledgercore.NewAccountDeltas
+		updates, newacctsTotals, _, lastCreatableID = ledgertesting.RandomDeltasFull(20, accts, 0, lastCreatableID)
 		totals = ledgertesting.CalculateNewRoundAccountTotals(t, updates, 0, proto, accts, totals)
-		accts = newaccts
+		accts = applyPartialDeltas(accts, updates)
 		ctbsWithDeletes := randomCreatableSampling(i, ctbsList, randomCtbs,
-			expectedDbImage, numElementsPerSegement)
+			expectedDbImage, numElementsPerSegment)
 
-		updatesCnt := makeCompactAccountDeltas([]ledgercore.AccountDeltas{updates}, baseAccounts)
+		updatesCnt := makeCompactAccountDeltas([]ledgercore.NewAccountDeltas{updates}, baseAccounts)
 		err = updatesCnt.accountsLoadOld(tx)
 		require.NoError(t, err)
+
 		err = accountsPutTotals(tx, totals, false)
 		require.NoError(t, err)
-		_, err = accountsNewRound(tx, updatesCnt, ctbsWithDeletes, proto, basics.Round(i))
+		updatedAccts, err := accountsNewRound(tx, updatesCnt, ctbsWithDeletes, proto, basics.Round(i))
 		require.NoError(t, err)
+		require.Equal(t, updatesCnt.len(), len(updatedAccts))
 		err = updateAccountsRound(tx, basics.Round(i))
 		require.NoError(t, err)
+
 		checkAccounts(t, tx, basics.Round(i), accts)
 		checkCreatables(t, tx, i, expectedDbImage)
 	}
 
 	// test the accounts totals
-	var updates ledgercore.AccountDeltas
-	for addr, acctData := range newaccts {
+	var updates ledgercore.NewAccountDeltas
+	for addr, acctData := range newacctsTotals {
 		updates.Upsert(addr, acctData)
 	}
 
@@ -838,6 +864,7 @@ func benchmarkWriteCatchpointStagingBalancesSub(b *testing.B, ascendingOrder boo
 		accountsGenerationDuration += balanceLoopDuration
 
 		normalizedAccountBalances, err := prepareNormalizedBalances(balances.Balances, proto)
+		require.NoError(b, err)
 		b.StartTimer()
 		err = l.trackerDBs.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
 			err = writeCatchpointStagingBalances(ctx, tx, normalizedAccountBalances)
@@ -902,7 +929,10 @@ func TestCompactAccountDeltas(t *testing.T) {
 	a.Equal(addr, address)
 	a.Equal(sample1, data)
 
-	sample2 := accountDelta{new: basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 456}}}
+	delta := ledgercore.MakeNewAccountDeltas(1)
+	delta.Upsert(addr, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{MicroAlgos: basics.MicroAlgos{Raw: 456}}})
+	// sample2 := accountDelta{new: basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 456}}}
+	sample2 := accountDelta{newDelta: delta}
 	ad.upsert(addr, sample2)
 	data, idx = ad.get(addr)
 	a.NotEqual(-1, idx)
@@ -928,7 +958,9 @@ func TestCompactAccountDeltas(t *testing.T) {
 	a.Equal(1, ad.len())
 	address, data = ad.getByIdx(0)
 	a.Equal(addr, address)
-	a.Equal(accountDelta{new: sample2.new, old: old1}, data)
+	new1, ok := delta.GetBasicsAccountData(addr)
+	a.True(ok)
+	a.Equal(accountDelta{new: new1, old: old1, newDelta: ledgercore.NewAccountDeltas{}}, data)
 
 	addr1 := ledgertesting.RandomAddress()
 	old2 := persistedAccountData{addr: addr1, accountData: basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 789}}}
@@ -936,17 +968,19 @@ func TestCompactAccountDeltas(t *testing.T) {
 	a.Equal(2, ad.len())
 	address, data = ad.getByIdx(0)
 	a.Equal(addr, address)
-	a.Equal(accountDelta{new: sample2.new, old: old1}, data)
+	a.Equal(accountDelta{new: new1, old: old1, newDelta: ledgercore.NewAccountDeltas{}}, data)
 
 	address, data = ad.getByIdx(1)
 	a.Equal(addr1, address)
 	a.Equal(accountDelta{old: old2}, data)
 
+	// apply old on empty delta object, expect no changes
 	ad.updateOld(0, old2)
 	a.Equal(2, ad.len())
 	address, data = ad.getByIdx(0)
 	a.Equal(addr, address)
-	a.Equal(accountDelta{new: sample2.new, old: old2}, data)
+	new2 := old2.accountData
+	a.Equal(accountDelta{new: new2, old: old2, newDelta: ledgercore.NewAccountDeltas{}}, data)
 
 	addr2 := ledgertesting.RandomAddress()
 	idx = ad.insert(addr2, sample2)

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1394,7 +1394,7 @@ func (au *accountUpdates) vacuumDatabase(ctx context.Context) (err error) {
 		au.log.Warnf("Vacuuming account database failed : %v", err)
 		return err
 	}
-	vacuumElapsedTime := time.Now().Sub(startTime)
+	vacuumElapsedTime := time.Since(startTime)
 	ledgerVacuumMicros.AddUint64(uint64(vacuumElapsedTime.Microseconds()), nil)
 
 	au.log.Infof("Vacuuming accounts database completed within %v, reducing number of pages from %d to %d and size from %d to %d", vacuumElapsedTime, vacuumStats.PagesBefore, vacuumStats.PagesAfter, vacuumStats.SizeBefore, vacuumStats.SizeAfter)

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -84,7 +84,7 @@ const accountsUpdatePerRoundHighWatermark = 1 * time.Second
 type modifiedAccount struct {
 	// data stores the most recent AccountData for this modified
 	// account.
-	data basics.AccountData
+	delta ledgercore.NewAccountDeltas
 
 	// ndelta keeps track of how many times this account appears in
 	// accountUpdates.deltas.  This is used to evict modifiedAccount
@@ -112,7 +112,7 @@ type accountUpdates struct {
 	cachedDBRound basics.Round
 
 	// deltas stores updates for every round after dbRound.
-	deltas []ledgercore.AccountDeltas
+	deltas []ledgercore.NewAccountDeltas
 
 	// accounts stores the most recent account state for every
 	// address that appears in deltas.
@@ -164,12 +164,6 @@ type accountUpdates struct {
 
 	// lastMetricsLogTime is the time when the previous metrics logging occurred
 	lastMetricsLogTime time.Time
-}
-
-type deferredCommit struct {
-	offset   uint64
-	dbRound  basics.Round
-	lookback basics.Round
 }
 
 // RoundOffsetError is an error for when requested round is behind earliest stored db entry
@@ -381,7 +375,9 @@ func (au *accountUpdates) onlineTop(rnd basics.Round, voteRnd basics.Round, n ui
 					continue
 				}
 
-				modifiedAccounts[addr] = accountDataToOnline(addr, &d, proto)
+				ad := basics.AccountData{}
+				ledgercore.AssignAccountData(&ad, d)
+				modifiedAccounts[addr] = accountDataToOnline(addr, &ad, proto)
 			}
 		}
 
@@ -735,18 +731,27 @@ func (au *accountUpdates) newBlockImpl(blk bookkeeping.Block, delta ledgercore.S
 	if rnd != au.latest()+1 {
 		au.log.Panicf("accountUpdates: newBlockImpl %d too far in the future, dbRound %d, deltas %d", rnd, au.cachedDBRound, len(au.deltas))
 	}
-	au.deltas = append(au.deltas, delta.Accts)
+
+	// Partial delta support
+	// Make delta cumulative: for all accounts in delta.NewAccts get params/holdings/states from prev deltas and combine
+	newAccts := delta.NewAccts.Clone()
+	for i := len(au.deltas) - 1; i >= 0; i-- {
+		newAccts.MergeInMatchingAccounts(au.deltas[i])
+	}
+
+	au.deltas = append(au.deltas, newAccts)
 	au.versions = append(au.versions, blk.CurrentProtocol)
 	au.creatableDeltas = append(au.creatableDeltas, delta.Creatables)
-	au.deltasAccum = append(au.deltasAccum, delta.Accts.Len()+au.deltasAccum[len(au.deltasAccum)-1])
+	au.deltasAccum = append(au.deltasAccum, delta.NewAccts.Len()+au.deltasAccum[len(au.deltasAccum)-1])
 
 	au.baseAccounts.flushPendingWrites()
 
-	for i := 0; i < delta.Accts.Len(); i++ {
-		addr, data := delta.Accts.GetByIdx(i)
+	for i := 0; i < newAccts.Len(); i++ {
+		addr, _ := newAccts.GetByIdx(i)
+		delta := newAccts.ExtractDelta(addr)
 		macct := au.accounts[addr]
 		macct.ndeltas++
-		macct.data = data
+		macct.delta = delta
 		au.accounts[addr] = macct
 	}
 
@@ -809,12 +814,30 @@ func (au *accountUpdates) lookupWithRewards(rnd basics.Round, addr basics.Addres
 		}
 
 		// check if we've had this address modified in the past rounds. ( i.e. if it's in the deltas )
-		macct, indeltas := au.accounts[addr]
+		md, indeltas := au.accounts[addr]
 		if indeltas {
 			// Check if this is the most recent round, in which case, we can
 			// use a cache of the most recent account state.
 			if offset == uint64(len(au.deltas)) {
-				return macct.data, nil
+				// Partial delta handling:
+				// - load full delta
+				// - update with data from the delta
+				// Remove after switching to a new partial schema
+				var result basics.AccountData
+				if bacct, has := au.baseAccounts.read(addr); has && bacct.round == currentDbRound {
+					result = md.delta.ApplyToBasicsAccountData(addr, bacct.accountData)
+				} else {
+					persistedData, err = au.accountsq.lookup(addr)
+					if persistedData.round == currentDbRound {
+						au.baseAccounts.writePending(persistedData)
+						result = md.delta.ApplyToBasicsAccountData(addr, persistedData.accountData)
+					} else {
+						au.accountsMu.RUnlock()
+						needUnlock = false
+						goto repeat
+					}
+				}
+				return result, nil
 			}
 			// the account appears in the deltas, but we don't know if it appears in the
 			// delta range of [0..offset], so we'll need to check :
@@ -822,9 +845,27 @@ func (au *accountUpdates) lookupWithRewards(rnd basics.Round, addr basics.Addres
 			// priority if present.
 			for offset > 0 {
 				offset--
-				d, ok := au.deltas[offset].Get(addr)
+				_, ok := au.deltas[offset].GetData(addr)
+				// Partial delta handling:
+				// - load full delta
+				// - update with data from the delta
+				// Remove after switching to a new partial schema
 				if ok {
-					return d, nil
+					var result basics.AccountData
+					if bacct, has := au.baseAccounts.read(addr); has && bacct.round == currentDbRound {
+						result = au.deltas[offset].ApplyToBasicsAccountData(addr, bacct.accountData)
+					} else {
+						persistedData, err = au.accountsq.lookup(addr)
+						if persistedData.round == currentDbRound {
+							au.baseAccounts.writePending(persistedData)
+							result = au.deltas[offset].ApplyToBasicsAccountData(addr, persistedData.accountData)
+						} else {
+							au.accountsMu.RUnlock()
+							needUnlock = false
+							goto repeat
+						}
+					}
+					return result, nil
 				}
 			}
 		}
@@ -850,7 +891,7 @@ func (au *accountUpdates) lookupWithRewards(rnd basics.Round, addr basics.Addres
 			au.baseAccounts.writePending(persistedData)
 			return persistedData.accountData, err
 		}
-
+	repeat:
 		if persistedData.round < currentDbRound {
 			au.log.Errorf("accountUpdates.lookupWithRewards: database round %d is behind in-memory round %d", persistedData.round, currentDbRound)
 			return basics.AccountData{}, &StaleDatabaseRoundError{databaseRound: persistedData.round, memoryRound: currentDbRound}
@@ -886,12 +927,32 @@ func (au *accountUpdates) lookupWithoutRewards(rnd basics.Round, addr basics.Add
 		}
 
 		// check if we've had this address modified in the past rounds. ( i.e. if it's in the deltas )
-		macct, indeltas := au.accounts[addr]
+		md, indeltas := au.accounts[addr]
 		if indeltas {
 			// Check if this is the most recent round, in which case, we can
 			// use a cache of the most recent account state.
 			if offset == uint64(len(au.deltas)) {
-				return macct.data, rnd, nil
+				// Partial delta handling:
+				// - load full delta
+				// - update with data from the delta
+				// Remove after switching to a new partial schema
+				var result basics.AccountData
+				if bacct, has := au.baseAccounts.read(addr); has && bacct.round == currentDbRound {
+					result = md.delta.ApplyToBasicsAccountData(addr, bacct.accountData)
+				} else {
+					persistedData, err = au.accountsq.lookup(addr)
+					if persistedData.round == currentDbRound {
+						au.baseAccounts.writePending(persistedData)
+						result = md.delta.ApplyToBasicsAccountData(addr, persistedData.accountData)
+					} else {
+						if synchronized {
+							au.accountsMu.RUnlock()
+							needUnlock = false
+						}
+						goto repeat
+					}
+				}
+				return result, rnd, nil
 			}
 			// the account appears in the deltas, but we don't know if it appears in the
 			// delta range of [0..offset], so we'll need to check :
@@ -899,11 +960,33 @@ func (au *accountUpdates) lookupWithoutRewards(rnd basics.Round, addr basics.Add
 			// priority if present.
 			for offset > 0 {
 				offset--
-				d, ok := au.deltas[offset].Get(addr)
+				// d, ok := au.deltas[offset].GetBasicsAccountData(addr)
+				_, ok := au.deltas[offset].GetData(addr)
 				if ok {
 					// the returned validThrough here is not optimal, but it still correct. We could get a more accurate value by scanning
 					// the deltas forward, but this would be time consuming loop, which might not pay off.
-					return d, rnd, nil
+
+					// Partial delta handling:
+					// - load full delta
+					// - update with data from the delta
+					// Remove after switching to a new partial schema
+					var result basics.AccountData
+					if bacct, has := au.baseAccounts.read(addr); has && bacct.round == currentDbRound {
+						result = au.deltas[offset].ApplyToBasicsAccountData(addr, bacct.accountData)
+					} else {
+						persistedData, err = au.accountsq.lookup(addr)
+						if persistedData.round == currentDbRound {
+							au.baseAccounts.writePending(persistedData)
+							result = au.deltas[offset].ApplyToBasicsAccountData(addr, persistedData.accountData)
+						} else {
+							if synchronized {
+								au.accountsMu.RUnlock()
+								needUnlock = false
+							}
+							goto repeat
+						}
+					}
+					return result, rnd, nil
 				}
 			}
 		} else {
@@ -936,6 +1019,7 @@ func (au *accountUpdates) lookupWithoutRewards(rnd basics.Round, addr basics.Add
 			au.baseAccounts.writePending(persistedData)
 			return persistedData.accountData, rnd, err
 		}
+	repeat:
 		if synchronized {
 			if persistedData.round < currentDbRound {
 				au.log.Errorf("accountUpdates.lookupWithoutRewards: database round %d is behind in-memory round %d", persistedData.round, currentDbRound)
@@ -1064,7 +1148,7 @@ func (au *accountUpdates) prepareCommit(dcc *deferredCommitContext) error {
 	au.accountsMu.RLock()
 
 	// create a copy of the deltas, round totals and protos for the range we're going to flush.
-	dcc.deltas = make([]ledgercore.AccountDeltas, offset)
+	dcc.deltas = make([]ledgercore.NewAccountDeltas, offset)
 	creatableDeltas := make([]map[basics.CreatableIndex]ledgercore.ModifiedCreatable, offset)
 	dcc.roundTotals = au.roundTotals[offset]
 	copy(dcc.deltas, au.deltas[:offset])

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -653,7 +653,7 @@ func BenchmarkBalancesChanges(b *testing.B) {
 		ml.trackers.committedUpTo(basics.Round(i))
 	}
 	ml.trackers.waitAccountsWriting()
-	deltaTime := time.Now().Sub(startTime)
+	deltaTime := time.Since(startTime)
 	if deltaTime > time.Second {
 		return
 	}
@@ -818,7 +818,7 @@ func TestAcctUpdatesUpdatesCorrectness(t *testing.T) {
 		var moneyAccounts []basics.Address
 
 		for addr := range accts[0] {
-			if bytes.Compare(addr[:], testPoolAddr[:]) == 0 || bytes.Compare(addr[:], testSinkAddr[:]) == 0 {
+			if bytes.Equal(addr[:], testPoolAddr[:]) || bytes.Equal(addr[:], testSinkAddr[:]) {
 				continue
 			}
 			moneyAccounts = append(moneyAccounts, addr)
@@ -1152,7 +1152,7 @@ func accountsAll(tx *sql.Tx) (bals map[basics.Address]basics.AccountData, err er
 
 		var addr basics.Address
 		if len(addrbuf) != len(addr) {
-			err = fmt.Errorf("Account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
+			err = fmt.Errorf("account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
 			return
 		}
 
@@ -1258,8 +1258,8 @@ func TestCompactDeltas(t *testing.T) {
 		addrs[i] = basics.Address(crypto.Hash([]byte{byte(i % 256), byte((i / 256) % 256), byte(i / 65536)}))
 	}
 
-	accountDeltas := make([]ledgercore.NewAccountDeltas, 1, 1)
-	creatableDeltas := make([]map[basics.CreatableIndex]ledgercore.ModifiedCreatable, 1, 1)
+	accountDeltas := make([]ledgercore.NewAccountDeltas, 1)
+	creatableDeltas := make([]map[basics.CreatableIndex]ledgercore.ModifiedCreatable, 1)
 	creatableDeltas[0] = make(map[basics.CreatableIndex]ledgercore.ModifiedCreatable)
 	accountDeltas[0].Upsert(addrs[0], ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{MicroAlgos: basics.MicroAlgos{Raw: 2}}})
 	creatableDeltas[0][100] = ledgercore.ModifiedCreatable{Creator: addrs[2], Created: true}

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -345,10 +345,10 @@ func checkAcctUpdates(t *testing.T, au *accountUpdates, base basics.Round, lates
 			require.Equal(t, d, basics.AccountData{})
 		}
 	}
-	checkAcctUpdatesConsistency(t, au)
+	checkAcctUpdatesConsistency(t, au, latestRnd)
 }
 
-func checkAcctUpdatesConsistency(t *testing.T, au *accountUpdates) {
+func checkAcctUpdatesConsistency(t *testing.T, au *accountUpdates, rnd basics.Round) {
 	accounts := make(map[basics.Address]modifiedAccount)
 
 	for _, rdelta := range au.deltas {
@@ -363,6 +363,17 @@ func checkAcctUpdatesConsistency(t *testing.T, au *accountUpdates) {
 	}
 
 	require.Equal(t, au.accounts, accounts)
+
+	latest := au.deltas[len(au.deltas)-1]
+	for i := 0; i < latest.Len(); i++ {
+		addr, acct := latest.GetByIdx(i)
+		d, _, err := au.LookupWithoutRewards(rnd, addr)
+		require.NoError(t, err)
+		require.Equal(t, int(acct.TotalAppParams), len(d.AppParams))
+		require.Equal(t, int(acct.TotalAssetParams), len(d.AssetParams))
+		require.Equal(t, int(acct.TotalAppLocalStates), len(d.AppLocalStates))
+		require.Equal(t, int(acct.TotalAssets), len(d.Assets))
+	}
 }
 
 func TestAcctUpdates(t *testing.T) {

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -62,7 +62,7 @@ type mockLedgerForTracker struct {
 	trackers trackerRegistry
 }
 
-func accumulateTotals(t testing.TB, consensusVersion protocol.ConsensusVersion, accts []map[basics.Address]basics.AccountData, rewardLevel uint64) (totals ledgercore.AccountTotals) {
+func accumulateTotals(t testing.TB, consensusVersion protocol.ConsensusVersion, accts []map[basics.Address]ledgercore.AccountData, rewardLevel uint64) (totals ledgercore.AccountTotals) {
 	var ot basics.OverflowTracker
 	proto := config.Consensus[consensusVersion]
 	totals.RewardsLevel = rewardLevel
@@ -84,7 +84,16 @@ func makeMockLedgerForTracker(t testing.TB, inMemory bool, initialBlocksCount in
 
 	blocks := randomInitChain(consensusVersion, initialBlocksCount)
 	deltas := make([]ledgercore.StateDelta, initialBlocksCount)
-	totals := accumulateTotals(t, consensusVersion, accts, 0)
+
+	newAccts := make([]map[basics.Address]ledgercore.AccountData, len(accts))
+	for idx, update := range accts {
+		newAcct := make(map[basics.Address]ledgercore.AccountData, len(update))
+		for addr, bad := range update {
+			newAcct[addr] = ledgercore.ToAccountData(bad)
+		}
+		newAccts[idx] = newAcct
+	}
+	totals := accumulateTotals(t, consensusVersion, newAccts, 0)
 	for i := range deltas {
 		deltas[i] = ledgercore.StateDelta{
 			Hdr:    &bookkeeping.BlockHeader{},
@@ -119,7 +128,7 @@ func (ml *mockLedgerForTracker) fork(t testing.TB) *mockLedgerForTracker {
 	copy(newLedgerTracker.blocks, ml.blocks)
 	copy(newLedgerTracker.deltas, ml.deltas)
 
-	// calling Vacuum implies flushing the datbaase content to disk..
+	// calling Vacuum implies flushing the database content to disk..
 	ml.dbs.Wdb.Vacuum(context.Background())
 	// copy the database files.
 	for _, ext := range []string{"", "-shm", "-wal"} {
@@ -236,10 +245,8 @@ func (au *accountUpdates) allBalances(rnd basics.Round) (bals map[basics.Address
 	}
 
 	for offset := uint64(0); offset < offsetLimit; offset++ {
-		for i := 0; i < au.deltas[offset].Len(); i++ {
-			addr, delta := au.deltas[offset].GetByIdx(i)
-			bals[addr] = delta
-		}
+		deltas := au.deltas[offset]
+		bals = applyPartialDeltas(bals, deltas)
 	}
 	return
 }
@@ -346,9 +353,10 @@ func checkAcctUpdatesConsistency(t *testing.T, au *accountUpdates) {
 
 	for _, rdelta := range au.deltas {
 		for i := 0; i < rdelta.Len(); i++ {
-			addr, adelta := rdelta.GetByIdx(i)
+			addr, _ := rdelta.GetByIdx(i)
+			adelta := rdelta.ExtractDelta(addr)
 			macct := accounts[addr]
-			macct.data = adelta
+			macct.delta = adelta
 			macct.ndeltas++
 			accounts[addr] = macct
 		}
@@ -401,8 +409,8 @@ func TestAcctUpdates(t *testing.T) {
 	for i := basics.Round(10); i < basics.Round(proto.MaxBalLookback+15); i++ {
 		rewardLevelDelta := crypto.RandUint64() % 5
 		rewardLevel += rewardLevelDelta
-		var updates ledgercore.AccountDeltas
-		var totals map[basics.Address]basics.AccountData
+		var updates ledgercore.NewAccountDeltas
+		var totals map[basics.Address]ledgercore.AccountData
 		base := accts[i-1]
 		updates, totals, lastCreatableID = ledgertesting.RandomDeltasBalancedFull(1, base, rewardLevel, lastCreatableID)
 		prevTotals, err := au.Totals(basics.Round(i - 1))
@@ -412,6 +420,7 @@ func TestAcctUpdates(t *testing.T) {
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
 		updates.Upsert(testPoolAddr, newPool)
 		totals[testPoolAddr] = newPool
+		newAccts := applyPartialDeltas(base, updates)
 
 		blk := bookkeeping.Block{
 			BlockHeader: bookkeeping.BlockHeader{
@@ -422,11 +431,12 @@ func TestAcctUpdates(t *testing.T) {
 		blk.CurrentProtocol = protocol.ConsensusCurrentVersion
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
-		delta.Accts.MergeAccounts(updates)
+		delta.NewAccts.MergeAccounts(updates)
 		delta.Creatables = creatablesFromUpdates(base, updates, knownCreatables)
-		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
+
+		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]ledgercore.AccountData{totals}, rewardLevel)
 		au.newBlock(blk, delta)
-		accts = append(accts, totals)
+		accts = append(accts, newAccts)
 		rewardsLevels = append(rewardsLevels, rewardLevel)
 
 		checkAcctUpdates(t, au, 0, i, accts, rewardsLevels, proto)
@@ -449,9 +459,9 @@ func TestAcctUpdates(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	var updates ledgercore.AccountDeltas
+	var updates ledgercore.NewAccountDeltas
 	for addr, acctData := range accts[dbRound] {
-		updates.Upsert(addr, acctData)
+		updates.Upsert(addr, ledgercore.ToAccountData(acctData))
 	}
 
 	expectedTotals := ledgertesting.CalculateNewRoundAccountTotals(t, updates, rewardsLevels[dbRound], proto, nil, ledgercore.AccountTotals{})
@@ -507,7 +517,6 @@ func TestAcctUpdatesFastUpdates(t *testing.T) {
 		rewardLevelDelta := crypto.RandUint64() % 5
 		rewardLevel += rewardLevelDelta
 		updates, totals := ledgertesting.RandomDeltasBalanced(1, accts[i-1], rewardLevel)
-
 		prevTotals, err := au.Totals(basics.Round(i - 1))
 		require.NoError(t, err)
 
@@ -515,6 +524,7 @@ func TestAcctUpdatesFastUpdates(t *testing.T) {
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
 		updates.Upsert(testPoolAddr, newPool)
 		totals[testPoolAddr] = newPool
+		newAccts := applyPartialDeltas(accts[i-1], updates)
 
 		blk := bookkeeping.Block{
 			BlockHeader: bookkeeping.BlockHeader{
@@ -525,9 +535,9 @@ func TestAcctUpdatesFastUpdates(t *testing.T) {
 		blk.CurrentProtocol = protocol.ConsensusCurrentVersion
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
-		delta.Accts.MergeAccounts(updates)
+		delta.NewAccts.MergeAccounts(updates)
 		au.newBlock(blk, delta)
-		accts = append(accts, totals)
+		accts = append(accts, newAccts)
 		rewardsLevels = append(rewardsLevels, rewardLevel)
 
 		wg.Add(1)
@@ -602,6 +612,7 @@ func BenchmarkBalancesChanges(b *testing.B) {
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
 		updates.Upsert(testPoolAddr, newPool)
 		totals[testPoolAddr] = newPool
+		newAccts := applyPartialDeltas(accts[i-1], updates)
 
 		blk := bookkeeping.Block{
 			BlockHeader: bookkeeping.BlockHeader{
@@ -612,9 +623,9 @@ func BenchmarkBalancesChanges(b *testing.B) {
 		blk.CurrentProtocol = protocolVersion
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
-		delta.Accts.MergeAccounts(updates)
+		delta.NewAccts.MergeAccounts(updates)
 		au.newBlock(blk, delta)
-		accts = append(accts, totals)
+		accts = append(accts, newAccts)
 		rewardsLevels = append(rewardsLevels, rewardLevel)
 	}
 	for i := proto.MaxBalLookback; i < proto.MaxBalLookback+initialRounds; i++ {
@@ -729,6 +740,7 @@ func TestLargeAccountCountCatchpointGeneration(t *testing.T) {
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
 		updates.Upsert(testPoolAddr, newPool)
 		totals[testPoolAddr] = newPool
+		newAccts := applyPartialDeltas(accts[i-1], updates)
 
 		blk := bookkeeping.Block{
 			BlockHeader: bookkeeping.BlockHeader{
@@ -739,9 +751,9 @@ func TestLargeAccountCountCatchpointGeneration(t *testing.T) {
 		blk.CurrentProtocol = testProtocolVersion
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
-		delta.Accts.MergeAccounts(updates)
+		delta.NewAccts.MergeAccounts(updates)
 		au.newBlock(blk, delta)
-		accts = append(accts, totals)
+		accts = append(accts, newAccts)
 		rewardsLevels = append(rewardsLevels, rewardLevel)
 
 		ml.trackers.committedUpTo(i)
@@ -900,7 +912,7 @@ func TestAcctUpdatesUpdatesCorrectness(t *testing.T) {
 
 			delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, len(updates), 0)
 			for addr, ad := range updates {
-				delta.Accts.Upsert(addr, ad)
+				delta.NewAccts.Upsert(addr, ledgercore.ToAccountData(ad))
 			}
 			au.newBlock(blk, delta)
 			ml.trackers.committedUpTo(i)
@@ -1203,7 +1215,7 @@ func BenchmarkCompactDeltas(b *testing.B) {
 			b.N = 500
 		}
 		window := 5000
-		accountDeltas := make([]ledgercore.AccountDeltas, b.N)
+		accountDeltas := make([]ledgercore.NewAccountDeltas, b.N)
 		addrs := make([]basics.Address, b.N*window)
 		for i := 0; i < len(addrs); i++ {
 			addrs[i] = basics.Address(crypto.Hash([]byte{byte(i % 256), byte((i / 256) % 256), byte(i / 65536)}))
@@ -1215,7 +1227,7 @@ func BenchmarkCompactDeltas(b *testing.B) {
 				start = window/2 + (rnd-1)*window
 			}
 			for k := start; k < start+window; k++ {
-				accountDeltas[rnd].Upsert(addrs[k], basics.AccountData{})
+				accountDeltas[rnd].Upsert(addrs[k], ledgercore.AccountData{})
 				m[addrs[k]] = basics.AccountData{}
 			}
 		}
@@ -1235,10 +1247,10 @@ func TestCompactDeltas(t *testing.T) {
 		addrs[i] = basics.Address(crypto.Hash([]byte{byte(i % 256), byte((i / 256) % 256), byte(i / 65536)}))
 	}
 
-	accountDeltas := make([]ledgercore.AccountDeltas, 1, 1)
+	accountDeltas := make([]ledgercore.NewAccountDeltas, 1, 1)
 	creatableDeltas := make([]map[basics.CreatableIndex]ledgercore.ModifiedCreatable, 1, 1)
 	creatableDeltas[0] = make(map[basics.CreatableIndex]ledgercore.ModifiedCreatable)
-	accountDeltas[0].Upsert(addrs[0], basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 2}})
+	accountDeltas[0].Upsert(addrs[0], ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{MicroAlgos: basics.MicroAlgos{Raw: 2}}})
 	creatableDeltas[0][100] = ledgercore.ModifiedCreatable{Creator: addrs[2], Created: true}
 	var baseAccounts lruAccounts
 	baseAccounts.init(nil, 100, 80)
@@ -1249,21 +1261,34 @@ func TestCompactDeltas(t *testing.T) {
 	require.Equal(t, len(creatableDeltas[0]), len(outCreatableDeltas))
 	require.Equal(t, accountDeltas[0].Len(), len(outAccountDeltas.misses))
 
+	// check deltas with missing accounts
 	delta, _ := outAccountDeltas.get(addrs[0])
 	require.Equal(t, persistedAccountData{}, delta.old)
-	require.Equal(t, basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 2}}, delta.new)
+	require.Equal(t, basics.AccountData{}, delta.new)
+	require.NotEmpty(t, delta.newDelta)
 	require.Equal(t, ledgercore.ModifiedCreatable{Creator: addrs[2], Created: true, Ndeltas: 1}, outCreatableDeltas[100])
 
+	// check deltas without missing accounts
+	baseAccounts.write(persistedAccountData{addr: addrs[0], accountData: basics.AccountData{}})
+	outAccountDeltas = makeCompactAccountDeltas(accountDeltas, baseAccounts)
+	delta, _ = outAccountDeltas.get(addrs[0])
+	require.Equal(t, persistedAccountData{addr: addrs[0]}, delta.old)
+	require.Equal(t, basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 2}}, delta.new)
+	require.Empty(t, delta.newDelta)
+	require.Equal(t, ledgercore.ModifiedCreatable{Creator: addrs[2], Created: true, Ndeltas: 1}, outCreatableDeltas[100])
+	baseAccounts.init(nil, 100, 80)
+
 	// add another round
-	accountDeltas = append(accountDeltas, ledgercore.AccountDeltas{})
+	accountDeltas = append(accountDeltas, ledgercore.NewAccountDeltas{})
 	creatableDeltas = append(creatableDeltas, make(map[basics.CreatableIndex]ledgercore.ModifiedCreatable))
-	accountDeltas[1].Upsert(addrs[0], basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 3}})
-	accountDeltas[1].Upsert(addrs[3], basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 8}})
+	accountDeltas[1].Upsert(addrs[0], ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{MicroAlgos: basics.MicroAlgos{Raw: 3}}})
+	accountDeltas[1].Upsert(addrs[3], ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{MicroAlgos: basics.MicroAlgos{Raw: 8}}})
 
 	creatableDeltas[1][100] = ledgercore.ModifiedCreatable{Creator: addrs[2], Created: false}
 	creatableDeltas[1][101] = ledgercore.ModifiedCreatable{Creator: addrs[4], Created: true}
 
 	baseAccounts.write(persistedAccountData{addr: addrs[0], accountData: basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 1}}})
+	baseAccounts.write(persistedAccountData{addr: addrs[3], accountData: basics.AccountData{}})
 	outAccountDeltas = makeCompactAccountDeltas(accountDeltas, baseAccounts)
 	outCreatableDeltas = compactCreatableDeltas(creatableDeltas)
 
@@ -1340,6 +1365,7 @@ func TestCachesInitialization(t *testing.T) {
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
 		updates.Upsert(testPoolAddr, newPool)
 		totals[testPoolAddr] = newPool
+		newAccts := applyPartialDeltas(accts[i-1], updates)
 
 		blk := bookkeeping.Block{
 			BlockHeader: bookkeeping.BlockHeader{
@@ -1350,13 +1376,13 @@ func TestCachesInitialization(t *testing.T) {
 		blk.CurrentProtocol = protocolVersion
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
-		delta.Accts.MergeAccounts(updates)
-		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
+		delta.NewAccts.MergeAccounts(updates)
+		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]ledgercore.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
 		ml.trackers.committedUpTo(basics.Round(i))
 		ml.trackers.waitAccountsWriting()
-		accts = append(accts, totals)
+		accts = append(accts, newAccts)
 		rewardsLevels = append(rewardsLevels, rewardLevel)
 	}
 	au.close()
@@ -1439,6 +1465,7 @@ func TestSplittingConsensusVersionCommits(t *testing.T) {
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
 		updates.Upsert(testPoolAddr, newPool)
 		totals[testPoolAddr] = newPool
+		newAccts := applyPartialDeltas(accts[i-1], updates)
 
 		blk := bookkeeping.Block{
 			BlockHeader: bookkeeping.BlockHeader{
@@ -1449,11 +1476,11 @@ func TestSplittingConsensusVersionCommits(t *testing.T) {
 		blk.CurrentProtocol = initProtocolVersion
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
-		delta.Accts.MergeAccounts(updates)
-		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
+		delta.NewAccts.MergeAccounts(updates)
+		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]ledgercore.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
-		accts = append(accts, totals)
+		accts = append(accts, newAccts)
 		rewardsLevels = append(rewardsLevels, rewardLevel)
 	}
 
@@ -1474,6 +1501,7 @@ func TestSplittingConsensusVersionCommits(t *testing.T) {
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
 		updates.Upsert(testPoolAddr, newPool)
 		totals[testPoolAddr] = newPool
+		newAccts := applyPartialDeltas(accts[i-1], updates)
 
 		blk := bookkeeping.Block{
 			BlockHeader: bookkeeping.BlockHeader{
@@ -1484,11 +1512,11 @@ func TestSplittingConsensusVersionCommits(t *testing.T) {
 		blk.CurrentProtocol = newVersion
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
-		delta.Accts.MergeAccounts(updates)
-		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
+		delta.NewAccts.MergeAccounts(updates)
+		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]ledgercore.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
-		accts = append(accts, totals)
+		accts = append(accts, newAccts)
 		rewardsLevels = append(rewardsLevels, rewardLevel)
 	}
 	// now, commit and verify that the produceCommittingTask method broken the range correctly.
@@ -1556,6 +1584,7 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
 		updates.Upsert(testPoolAddr, newPool)
 		totals[testPoolAddr] = newPool
+		newAccts := applyPartialDeltas(accts[i-1], updates)
 
 		blk := bookkeeping.Block{
 			BlockHeader: bookkeeping.BlockHeader{
@@ -1566,11 +1595,11 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 		blk.CurrentProtocol = initProtocolVersion
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
-		delta.Accts.MergeAccounts(updates)
-		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
+		delta.NewAccts.MergeAccounts(updates)
+		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]ledgercore.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
-		accts = append(accts, totals)
+		accts = append(accts, newAccts)
 		rewardsLevels = append(rewardsLevels, rewardLevel)
 	}
 
@@ -1590,6 +1619,7 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
 		updates.Upsert(testPoolAddr, newPool)
 		totals[testPoolAddr] = newPool
+		newAccts := applyPartialDeltas(accts[i-1], updates)
 
 		blk := bookkeeping.Block{
 			BlockHeader: bookkeeping.BlockHeader{
@@ -1600,11 +1630,11 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 		blk.CurrentProtocol = newVersion
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
-		delta.Accts.MergeAccounts(updates)
-		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
+		delta.NewAccts.MergeAccounts(updates)
+		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]ledgercore.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
-		accts = append(accts, totals)
+		accts = append(accts, newAccts)
 		rewardsLevels = append(rewardsLevels, rewardLevel)
 	}
 	// now, commit and verify that the produceCommittingTask method broken the range correctly.
@@ -1626,6 +1656,7 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 		newPool.MicroAlgos.Raw -= prevTotals.RewardUnits() * rewardLevelDelta
 		updates.Upsert(testPoolAddr, newPool)
 		totals[testPoolAddr] = newPool
+		newAccts := applyPartialDeltas(accts[i-1], updates)
 
 		blk := bookkeeping.Block{
 			BlockHeader: bookkeeping.BlockHeader{
@@ -1636,11 +1667,11 @@ func TestSplittingConsensusVersionCommitsBoundry(t *testing.T) {
 		blk.CurrentProtocol = newVersion
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
-		delta.Accts.MergeAccounts(updates)
-		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{totals}, rewardLevel)
+		delta.NewAccts.MergeAccounts(updates)
+		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]ledgercore.AccountData{totals}, rewardLevel)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
 		au.newBlock(blk, delta)
-		accts = append(accts, totals)
+		accts = append(accts, newAccts)
 		rewardsLevels = append(rewardsLevels, rewardLevel)
 	}
 	ml.trackers.committedUpTo(endOfFirstNewProtocolSegment + basics.Round(extraRounds))

--- a/ledger/apply/application.go
+++ b/ledger/apply/application.go
@@ -154,13 +154,13 @@ func deleteApplication(balances Balances, creator basics.Address, appIdx basics.
 		record.TotalExtraAppPages = totalExtraPages
 	}
 
-	// Delete the AppParams
-	err = balances.DeleteAppParams(creator, appIdx)
+	err = balances.Put(creator, record)
 	if err != nil {
 		return err
 	}
 
-	err = balances.Put(creator, record)
+	// Delete the AppParams
+	err = balances.DeleteAppParams(creator, appIdx)
 	if err != nil {
 		return err
 	}
@@ -287,14 +287,14 @@ func closeOutApplication(balances Balances, sender basics.Address, appIdx basics
 	record.TotalAppSchema = totalSchema
 	record.TotalAppLocalStates = basics.SubSaturate32(record.TotalAppLocalStates, 1)
 
-	// Delete the local state
-	err = balances.DeleteAppLocalState(sender, appIdx)
+	// Write closed-out user back to cow
+	err = balances.Put(sender, record)
 	if err != nil {
 		return err
 	}
 
-	// Write closed-out user back to cow
-	err = balances.Put(sender, record)
+	// Delete the local state
+	err = balances.DeleteAppLocalState(sender, appIdx)
 	if err != nil {
 		return err
 	}

--- a/ledger/apply/application.go
+++ b/ledger/apply/application.go
@@ -64,14 +64,14 @@ func createApplication(ac *transactions.ApplicationCallTxnFields, balances Balan
 	}
 
 	// look up how many apps they have
-	totalAppParams, err := balances.CountAppParams(creator)
+	totalAppParams := record.TotalAppParams
 	if err != nil {
 		return
 	}
 
 	// Make sure the creator isn't already at the app creation max
 	maxAppsCreated := balances.ConsensusParams().MaxAppsCreated
-	if totalAppParams >= maxAppsCreated {
+	if totalAppParams >= uint32(maxAppsCreated) {
 		err = fmt.Errorf("cannot create app for %s: max created apps per acct is %d", creator.String(), maxAppsCreated)
 		return
 	}
@@ -94,6 +94,7 @@ func createApplication(ac *transactions.ApplicationCallTxnFields, balances Balan
 	totalSchema := record.TotalAppSchema
 	totalSchema = totalSchema.AddSchema(ac.GlobalStateSchema)
 	record.TotalAppSchema = totalSchema
+	record.TotalAppParams = basics.AddSaturate32(record.TotalAppParams, 1)
 
 	// Update the cached TotalExtraAppPages for this account, used
 	// when computing MinBalance
@@ -140,6 +141,7 @@ func deleteApplication(balances Balances, creator basics.Address, appIdx basics.
 	globalSchema := params.GlobalStateSchema
 	totalSchema = totalSchema.SubSchema(globalSchema)
 	record.TotalAppSchema = totalSchema
+	record.TotalAppParams = basics.SubSaturate32(record.TotalAppParams, 1)
 
 	// Delete app's extra program pages
 	totalExtraPages := record.TotalExtraAppPages
@@ -218,14 +220,14 @@ func optInApplication(balances Balances, sender basics.Address, appIdx basics.Ap
 		return fmt.Errorf("account %s has already opted in to app %d", sender.String(), appIdx)
 	}
 
-	totalAppLocalState, err := balances.CountAppLocalState(sender)
+	totalAppLocalState := record.TotalAppLocalStates
 	if err != nil {
 		return err
 	}
 
 	// Make sure the user isn't already at the app opt-in max
 	maxAppsOptedIn := balances.ConsensusParams().MaxAppsOptedIn
-	if totalAppLocalState >= maxAppsOptedIn {
+	if totalAppLocalState >= uint32(maxAppsOptedIn) {
 		return fmt.Errorf("cannot opt in app %d for %s: max opted-in apps per acct is %d", appIdx, sender.String(), maxAppsOptedIn)
 	}
 
@@ -239,6 +241,7 @@ func optInApplication(balances Balances, sender basics.Address, appIdx basics.Ap
 	totalSchema := record.TotalAppSchema
 	totalSchema = totalSchema.AddSchema(params.LocalStateSchema)
 	record.TotalAppSchema = totalSchema
+	record.TotalAppLocalStates = basics.AddSaturate32(record.TotalAppLocalStates, 1)
 
 	// Write opted-in user back to cow
 	err = balances.Put(sender, record)
@@ -282,6 +285,7 @@ func closeOutApplication(balances Balances, sender basics.Address, appIdx basics
 	totalSchema := record.TotalAppSchema
 	totalSchema = totalSchema.SubSchema(localState.Schema)
 	record.TotalAppSchema = totalSchema
+	record.TotalAppLocalStates = basics.SubSaturate32(record.TotalAppLocalStates, 1)
 
 	// Delete the local state
 	err = balances.DeleteAppLocalState(sender, appIdx)

--- a/ledger/apply/application_test.go
+++ b/ledger/apply/application_test.go
@@ -160,9 +160,9 @@ func newTestBalancesPass() *testBalancesPass {
 const appIdxError basics.AppIndex = 0x11223344
 const appIdxOk basics.AppIndex = 1
 
-func (b *testBalances) Get(addr basics.Address, withPendingRewards bool) (AccountData, error) {
+func (b *testBalances) Get(addr basics.Address, withPendingRewards bool) (ledgercore.AccountData, error) {
 	acct, err := b.getAccount(addr, withPendingRewards)
-	return ToApplyAccountData(acct), err
+	return ledgercore.ToAccountData(acct), err
 }
 
 func (b *testBalances) getAccount(addr basics.Address, withPendingRewards bool) (basics.AccountData, error) {
@@ -179,10 +179,10 @@ func (b *testBalances) getAccount(addr basics.Address, withPendingRewards bool) 
 	return ad, nil
 }
 
-func (b *testBalances) Put(addr basics.Address, ad AccountData) error {
+func (b *testBalances) Put(addr basics.Address, ad ledgercore.AccountData) error {
 	b.put++
 	a, _ := b.getAccount(addr, false) // ignoring not found error
-	AssignAccountData(&a, ad)
+	ledgercore.AssignAccountData(&a, ad)
 	return b.putAccount(addr, a)
 }
 
@@ -279,9 +279,9 @@ func (b *testBalances) StatefulEval(params logic.EvalParams, aidx basics.AppInde
 	return b.pass, b.delta, b.err
 }
 
-func (b *testBalancesPass) Get(addr basics.Address, withPendingRewards bool) (AccountData, error) {
+func (b *testBalancesPass) Get(addr basics.Address, withPendingRewards bool) (ledgercore.AccountData, error) {
 	acct, err := b.getAccount(addr, withPendingRewards)
-	return ToApplyAccountData(acct), err
+	return ledgercore.ToAccountData(acct), err
 }
 
 func (b *testBalancesPass) getAccount(addr basics.Address, withPendingRewards bool) (basics.AccountData, error) {
@@ -292,9 +292,9 @@ func (b *testBalancesPass) getAccount(addr basics.Address, withPendingRewards bo
 	return ad, nil
 }
 
-func (b *testBalancesPass) Put(addr basics.Address, ad AccountData) error {
+func (b *testBalancesPass) Put(addr basics.Address, ad ledgercore.AccountData) error {
 	a, _ := b.getAccount(addr, false) // ignoring not found error
-	AssignAccountData(&a, ad)
+	ledgercore.AssignAccountData(&a, ad)
 	return b.putAccount(addr, a)
 }
 

--- a/ledger/apply/apply.go
+++ b/ledger/apply/apply.go
@@ -18,71 +18,11 @@ package apply
 
 import (
 	"github.com/algorand/go-algorand/config"
-	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/data/transactions/logic"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 )
-
-// AccountData provides users of the Balances interface per-account data (like basics.AccountData)
-// but without any maps containing AppParams, AppLocalState, AssetHolding, or AssetParams. This
-// ensures that transaction evaluation must retrieve and mutate account, asset, and application data
-// separately, to better support on-disk and in-memory schemas that do not store them together.
-type AccountData struct {
-	Status             basics.Status
-	MicroAlgos         basics.MicroAlgos
-	RewardsBase        uint64
-	RewardedMicroAlgos basics.MicroAlgos
-
-	VoteID          crypto.OneTimeSignatureVerifier
-	SelectionID     crypto.VRFVerifier
-	VoteFirstValid  basics.Round
-	VoteLastValid   basics.Round
-	VoteKeyDilution uint64
-
-	AuthAddr           basics.Address
-	TotalAppSchema     basics.StateSchema
-	TotalExtraAppPages uint32
-}
-
-// ToApplyAccountData returns apply.AccountData from basics.AccountData
-func ToApplyAccountData(acct basics.AccountData) AccountData {
-	return AccountData{
-		Status:             acct.Status,
-		MicroAlgos:         acct.MicroAlgos,
-		RewardsBase:        acct.RewardsBase,
-		RewardedMicroAlgos: acct.RewardedMicroAlgos,
-
-		VoteID:          acct.VoteID,
-		SelectionID:     acct.SelectionID,
-		VoteFirstValid:  acct.VoteFirstValid,
-		VoteLastValid:   acct.VoteLastValid,
-		VoteKeyDilution: acct.VoteKeyDilution,
-
-		AuthAddr:           acct.AuthAddr,
-		TotalAppSchema:     acct.TotalAppSchema,
-		TotalExtraAppPages: acct.TotalExtraAppPages,
-	}
-}
-
-// AssignAccountData assigns the contents of apply.AccountData to the fields in basics.AccountData,
-// but does not touch the AppParams, AppLocalState, AssetHolding, or AssetParams data.
-func AssignAccountData(a *basics.AccountData, acct AccountData) {
-	a.Status = acct.Status
-	a.MicroAlgos = acct.MicroAlgos
-	a.RewardsBase = acct.RewardsBase
-	a.RewardedMicroAlgos = acct.RewardedMicroAlgos
-
-	a.VoteID = acct.VoteID
-	a.SelectionID = acct.SelectionID
-	a.VoteFirstValid = acct.VoteFirstValid
-	a.VoteLastValid = acct.VoteLastValid
-	a.VoteKeyDilution = acct.VoteKeyDilution
-
-	a.AuthAddr = acct.AuthAddr
-	a.TotalAppSchema = acct.TotalAppSchema
-	a.TotalExtraAppPages = acct.TotalExtraAppPages
-}
 
 // Balances allow to move MicroAlgos from one address to another and to update balance records, or to access and modify individual balance records
 // After a call to Put (or Move), future calls to Get or Move will reflect the updated balance record(s)
@@ -91,9 +31,9 @@ type Balances interface {
 	// If the account is known to be empty, then err should be nil and the returned balance record should have the given address and empty AccountData
 	// withPendingRewards specifies whether pending rewards should be applied.
 	// A non-nil error means the lookup is impossible (e.g., if the database doesn't have necessary state anymore)
-	Get(addr basics.Address, withPendingRewards bool) (AccountData, error)
+	Get(addr basics.Address, withPendingRewards bool) (ledgercore.AccountData, error)
 
-	Put(basics.Address, AccountData) error
+	Put(basics.Address, ledgercore.AccountData) error
 
 	// CloseAccount is used by payment.go to delete an account, after ensuring no balance, asset or app state remains.
 	CloseAccount(basics.Address) error
@@ -105,23 +45,23 @@ type Balances interface {
 	// PutX updates or creates app or asset data for an address and app/asset index.
 	// DeleteX deletes the app or asset data associated with an address and app/asset index.
 
-	CountAppParams(addr basics.Address) (int, error)
+	// CountAppParams(addr basics.Address) (int, error)
 	GetAppParams(addr basics.Address, aidx basics.AppIndex) (basics.AppParams, bool, error)
 	PutAppParams(addr basics.Address, aidx basics.AppIndex, params basics.AppParams) error
 	DeleteAppParams(addr basics.Address, aidx basics.AppIndex) error
 
-	CountAppLocalState(addr basics.Address) (int, error)
+	// CountAppLocalState(addr basics.Address) (int, error)
 	GetAppLocalState(addr basics.Address, aidx basics.AppIndex) (basics.AppLocalState, bool, error)
 	HasAppLocalState(addr basics.Address, aidx basics.AppIndex) (bool, error)
 	PutAppLocalState(addr basics.Address, aidx basics.AppIndex, state basics.AppLocalState) error
 	DeleteAppLocalState(addr basics.Address, aidx basics.AppIndex) error
 
-	CountAssetHolding(addr basics.Address) (int, error)
+	// CountAssetHolding(addr basics.Address) (int, error)
 	GetAssetHolding(addr basics.Address, aidx basics.AssetIndex) (basics.AssetHolding, bool, error)
 	PutAssetHolding(addr basics.Address, aidx basics.AssetIndex, data basics.AssetHolding) error
 	DeleteAssetHolding(addr basics.Address, aidx basics.AssetIndex) error
 
-	CountAssetParams(addr basics.Address) (int, error)
+	// CountAssetParams(addr basics.Address) (int, error)
 	GetAssetParams(addr basics.Address, aidx basics.AssetIndex) (basics.AssetParams, bool, error)
 	HasAssetParams(addr basics.Address, aidx basics.AssetIndex) (bool, error)
 	PutAssetParams(addr basics.Address, aidx basics.AssetIndex, data basics.AssetParams) error

--- a/ledger/apply/keyreg_test.go
+++ b/ledger/apply/keyreg_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/data/transactions/logic"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/stretchr/testify/require"
@@ -47,9 +48,9 @@ func newKeyregTestBalances() *keyregTestBalances {
 	return b
 }
 
-func (balances keyregTestBalances) Get(addr basics.Address, withPendingRewards bool) (AccountData, error) {
+func (balances keyregTestBalances) Get(addr basics.Address, withPendingRewards bool) (ledgercore.AccountData, error) {
 	acct, err := balances.getAccount(addr, withPendingRewards)
-	return ToApplyAccountData(acct), err
+	return ledgercore.ToAccountData(acct), err
 }
 
 func (balances keyregTestBalances) getAccount(addr basics.Address, withPendingRewards bool) (basics.AccountData, error) {
@@ -60,9 +61,9 @@ func (balances keyregTestBalances) GetCreator(cidx basics.CreatableIndex, ctype 
 	return basics.Address{}, true, nil
 }
 
-func (balances keyregTestBalances) Put(addr basics.Address, ad AccountData) error {
+func (balances keyregTestBalances) Put(addr basics.Address, ad ledgercore.AccountData) error {
 	a, _ := balances.getAccount(addr, false) // ignoring not found error
-	AssignAccountData(&a, ad)
+	ledgercore.AssignAccountData(&a, ad)
 	return balances.putAccount(addr, a)
 }
 

--- a/ledger/apply/mockBalances_test.go
+++ b/ledger/apply/mockBalances_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/data/transactions/logic"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -75,9 +76,9 @@ func (balances mockBalances) StatefulEval(logic.EvalParams, basics.AppIndex, []b
 	return false, transactions.EvalDelta{}, nil
 }
 
-func (balances mockBalances) Get(addr basics.Address, withPendingRewards bool) (AccountData, error) {
+func (balances mockBalances) Get(addr basics.Address, withPendingRewards bool) (ledgercore.AccountData, error) {
 	acct, err := balances.getAccount(addr, withPendingRewards)
-	return ToApplyAccountData(acct), err
+	return ledgercore.ToAccountData(acct), err
 }
 
 func (balances mockBalances) getAccount(addr basics.Address, withPendingRewards bool) (basics.AccountData, error) {
@@ -88,9 +89,9 @@ func (balances mockBalances) GetCreator(idx basics.CreatableIndex, ctype basics.
 	return basics.Address{}, true, nil
 }
 
-func (balances mockBalances) Put(addr basics.Address, acct AccountData) error {
+func (balances mockBalances) Put(addr basics.Address, acct ledgercore.AccountData) error {
 	a := balances.b[addr]
-	AssignAccountData(&a, acct)
+	ledgercore.AssignAccountData(&a, acct)
 	return balances.putAccount(addr, a)
 }
 

--- a/ledger/apply/payment.go
+++ b/ledger/apply/payment.go
@@ -80,18 +80,12 @@ func Payment(payment transactions.PaymentTxnFields, header transactions.Header, 
 		}
 
 		// Confirm that there is no asset-related state in the account
-		totalAssets, err := balances.CountAssetHolding(header.Sender)
-		if err != nil {
-			return err
-		}
+		totalAssets := rec.TotalAssets
 		if totalAssets > 0 {
 			return fmt.Errorf("cannot close: %d outstanding assets", totalAssets)
 		}
 
-		totalAssetParams, err := balances.CountAssetParams(header.Sender)
-		if err != nil {
-			return err
-		}
+		totalAssetParams := rec.TotalAssetParams
 		if totalAssetParams > 0 {
 			// This should be impossible because every asset created
 			// by an account (in AssetParams) must also appear in Assets,
@@ -100,19 +94,13 @@ func Payment(payment transactions.PaymentTxnFields, header transactions.Header, 
 		}
 
 		// Confirm that there is no application-related state remaining
-		totalAppLocalStates, err := balances.CountAppLocalState(header.Sender)
-		if err != nil {
-			return err
-		}
+		totalAppLocalStates := rec.TotalAppLocalStates
 		if totalAppLocalStates > 0 {
 			return fmt.Errorf("cannot close: %d outstanding applications opted in. Please opt out or clear them", totalAppLocalStates)
 		}
 
 		// Can't have created apps remaining either
-		totalAppParams, err := balances.CountAppParams(header.Sender)
-		if err != nil {
-			return err
-		}
+		totalAppParams := rec.TotalAppParams
 		if totalAppParams > 0 {
 			return fmt.Errorf("cannot close: %d outstanding created applications", totalAppParams)
 		}

--- a/ledger/apptxn_test.go
+++ b/ledger/apptxn_test.go
@@ -264,7 +264,7 @@ func TestPayAction(t *testing.T) {
 	vb = l.endBlock(t, eval)
 
 	deltas := vb.Delta()
-	for _, addr := range deltas.Accts.ModifiedAccounts() {
+	for _, addr := range deltas.NewAccts.ModifiedAccounts() {
 		if addr == addrs[2] {
 			found = true
 		}
@@ -440,7 +440,7 @@ submit:  itxn_submit
 	require.True(t, in)
 	require.Equal(t, amount, uint64(0))
 
-	// Now, suceed, because opted in.
+	// Now, succeed, because opted in.
 	eval = testingEvaluator{l.nextBlock(t), l}
 	eval.txn(t, &fundgold)
 	l.endBlock(t, eval)

--- a/ledger/catchupaccessor_test.go
+++ b/ledger/catchupaccessor_test.go
@@ -125,7 +125,7 @@ func benchmarkRestoringFromCatchpointFileHelper(b *testing.B) {
 		last64KIndex--
 	}
 	if !last64KStart.IsZero() {
-		last64KDuration := time.Now().Sub(last64KStart)
+		last64KDuration := time.Since(last64KStart)
 		b.ReportMetric(float64(last64KDuration.Nanoseconds())/float64(64*1024), "ns/last_64k_account")
 	}
 }

--- a/ledger/catchupaccessor_test.go
+++ b/ledger/catchupaccessor_test.go
@@ -140,7 +140,7 @@ func BenchmarkRestoringFromCatchpointFile(b *testing.B) {
 	}
 }
 
-func TestCatchupAcessorFoo(t *testing.T) {
+func TestCatchupAccessorFoo(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	log := logging.TestingLog(t)

--- a/ledger/evalindexer_test.go
+++ b/ledger/evalindexer_test.go
@@ -18,7 +18,6 @@ package ledger
 
 import (
 	"errors"
-	"fmt"
 	"math/rand"
 	"testing"
 
@@ -94,8 +93,9 @@ func TestEvalForIndexerCustomProtocolParams(t *testing.T) {
 	crypto.RandBytes(genHash[:])
 	block, err := bookkeeping.MakeGenesisBlock(protocol.ConsensusV24,
 		genesisBalances, "test", genHash)
+	require.NoError(t, err)
 
-	dbName := fmt.Sprintf("%s", t.Name())
+	dbName := t.Name()
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
 	l, err := OpenLedger(logging.Base(), dbName, true, ledgercore.InitState{
@@ -195,8 +195,9 @@ func TestEvalForIndexerForExpiredAccounts(t *testing.T) {
 	crypto.RandBytes(genHash[:])
 	block, err := bookkeeping.MakeGenesisBlock(protocol.ConsensusFuture,
 		genesisBalances, "test", genHash)
+	require.NoError(t, err)
 
-	dbName := fmt.Sprintf("%s", t.Name())
+	dbName := t.Name()
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
 	l, err := OpenLedger(logging.Base(), dbName, true, ledgercore.InitState{

--- a/ledger/internal/appcow.go
+++ b/ledger/internal/appcow.go
@@ -655,7 +655,7 @@ func applyStorageDelta(cb *roundCowState, addr basics.Address, aapp storagePtr, 
 			params, exist, err := cb.lookupAppParams(addr, aapp.aidx)
 			// params, ok := owned[aapp.aidx]
 			if err != nil {
-				return fmt.Errorf("fetching storage (global=%v) failed for (%s, %d): %s", aapp.global, addr.String(), aapp.aidx, err.Error())
+				return fmt.Errorf("fetching storage (global=%v) failed for (%s, %d): %w", aapp.global, addr.String(), aapp.aidx, err)
 			}
 			if !exist {
 				return fmt.Errorf("could not find existing params for %v", aapp.aidx)
@@ -690,7 +690,7 @@ func applyStorageDelta(cb *roundCowState, addr basics.Address, aapp storagePtr, 
 			// or the account has opted in before and local states are pre-allocated
 			states, exist, err := cb.lookupAppLocalState(addr, aapp.aidx)
 			if err != nil {
-				return fmt.Errorf("fetching storage (global=%v) failed for (%s, %d): %s", aapp.global, addr.String(), aapp.aidx, err.Error())
+				return fmt.Errorf("fetching storage (global=%v) failed for (%s, %d): %w", aapp.global, addr.String(), aapp.aidx, err)
 			}
 			if !exist {
 				return fmt.Errorf("could not find existing states for %v", aapp.aidx)

--- a/ledger/internal/appcow.go
+++ b/ledger/internal/appcow.go
@@ -641,31 +641,28 @@ func (lsd *storageDelta) applyChild(child *storageDelta) {
 // applyStorageDelta saves in-mem storageDelta into AccountData
 // cow stores app data separately from AccountData to minimize potentially large AccountData copying/reallocations.
 // When cow is done applyStorageDelta offloads app stores into AccountData
-func applyStorageDelta(data basics.AccountData, aapp storagePtr, store *storageDelta) (basics.AccountData, error) {
+func applyStorageDelta(cb *roundCowState, addr basics.Address, aapp storagePtr, storeDelta *storageDelta) error {
 	// duplicate code in branches is proven to be a bit faster than
 	// having basics.AppParams and basics.AppLocalState under a common interface with additional loops and type assertions
 	if aapp.global {
-		var owned map[basics.AppIndex]basics.AppParams
-		if len(data.AppParams) > 0 {
-			owned = make(map[basics.AppIndex]basics.AppParams, len(data.AppParams))
-			for k, v := range data.AppParams {
-				owned[k] = v
-			}
-		}
-
-		switch store.action {
+		switch storeDelta.action {
 		case deallocAction:
-			delete(owned, aapp.aidx)
+			cb.mods.NewAccts.UpsertAppParams(addr, aapp.aidx, nil)
+			// delete(owned, aapp.aidx)
 		case allocAction, remainAllocAction:
 			// note: these should always exist because they were
 			// at least preceded by a call to Put()
-			params, ok := owned[aapp.aidx]
-			if !ok {
-				return basics.AccountData{}, fmt.Errorf("could not find existing params for %v", aapp.aidx)
+			params, exist, err := cb.lookupAppParams(addr, aapp.aidx)
+			// params, ok := owned[aapp.aidx]
+			if err != nil {
+				return fmt.Errorf("fetching storage (global=%v) failed for (%s, %d): %s", aapp.global, addr.String(), aapp.aidx, err.Error())
+			}
+			if !exist {
+				return fmt.Errorf("could not find existing params for %v", aapp.aidx)
 			}
 			params = params.Clone()
-			if (store.action == allocAction && len(store.kvCow) > 0) ||
-				(store.action == remainAllocAction && params.GlobalState == nil) {
+			if (storeDelta.action == allocAction && len(storeDelta.kvCow) > 0) ||
+				(storeDelta.action == remainAllocAction && params.GlobalState == nil) {
 				// allocate KeyValue for
 				// 1) app creation and global write in the same app call
 				// 2) global state writing into empty global state
@@ -673,41 +670,35 @@ func applyStorageDelta(data basics.AccountData, aapp storagePtr, store *storageD
 			}
 			// note: if this is an allocAction, there will be no
 			// DeleteActions below
-			for k, v := range store.kvCow {
+			for k, v := range storeDelta.kvCow {
 				if !v.newExists {
 					delete(params.GlobalState, k)
 				} else {
 					params.GlobalState[k] = v.new
 				}
 			}
-			owned[aapp.aidx] = params
+			cb.mods.NewAccts.UpsertAppParams(addr, aapp.aidx, &params)
 		}
-
-		data.AppParams = owned
-
 	} else {
-		var owned map[basics.AppIndex]basics.AppLocalState
-		if len(data.AppLocalStates) > 0 {
-			owned = make(map[basics.AppIndex]basics.AppLocalState, len(data.AppLocalStates))
-			for k, v := range data.AppLocalStates {
-				owned[k] = v
-			}
-		}
-
-		switch store.action {
+		switch storeDelta.action {
 		case deallocAction:
-			delete(owned, aapp.aidx)
+			cb.mods.NewAccts.UpsertAppLocalState(addr, aapp.aidx, nil)
+			// delete(owned, aapp.aidx)
 		case allocAction, remainAllocAction:
 			// note: these should always exist because they were
 			// at least preceded by a call to Put (opting in),
 			// or the account has opted in before and local states are pre-allocated
-			states, ok := owned[aapp.aidx]
-			if !ok {
-				return basics.AccountData{}, fmt.Errorf("could not find existing states for %v", aapp.aidx)
+			states, exist, err := cb.lookupAppLocalState(addr, aapp.aidx)
+			if err != nil {
+				return fmt.Errorf("fetching storage (global=%v) failed for (%s, %d): %s", aapp.global, addr.String(), aapp.aidx, err.Error())
 			}
+			if !exist {
+				return fmt.Errorf("could not find existing states for %v", aapp.aidx)
+			}
+
 			states = states.Clone()
-			if (store.action == allocAction && len(store.kvCow) > 0) ||
-				(store.action == remainAllocAction && states.KeyValue == nil) {
+			if (storeDelta.action == allocAction && len(storeDelta.kvCow) > 0) ||
+				(storeDelta.action == remainAllocAction && states.KeyValue == nil) {
 				// allocate KeyValue for
 				// 1) opting in and local state write in the same app call
 				// 2) local state writing into empty local state (opted in)
@@ -715,17 +706,15 @@ func applyStorageDelta(data basics.AccountData, aapp storagePtr, store *storageD
 			}
 			// note: if this is an allocAction, there will be no
 			// DeleteActions below
-			for k, v := range store.kvCow {
+			for k, v := range storeDelta.kvCow {
 				if !v.newExists {
 					delete(states.KeyValue, k)
 				} else {
 					states.KeyValue[k] = v.new
 				}
 			}
-			owned[aapp.aidx] = states
+			cb.mods.NewAccts.UpsertAppLocalState(addr, aapp.aidx, &states)
 		}
-
-		data.AppLocalStates = owned
 	}
-	return data, nil
+	return nil
 }

--- a/ledger/internal/applications.go
+++ b/ledger/internal/applications.go
@@ -23,6 +23,7 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger/apply"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -33,7 +34,7 @@ type logicLedger struct {
 }
 
 type cowForLogicLedger interface {
-	Get(addr basics.Address, withPendingRewards bool) (apply.AccountData, error)
+	Get(addr basics.Address, withPendingRewards bool) (ledgercore.AccountData, error)
 	GetAppParams(addr basics.Address, aidx basics.AppIndex) (basics.AppParams, bool, error)
 	GetAssetParams(addr basics.Address, aidx basics.AssetIndex) (basics.AssetParams, bool, error)
 	GetAssetHolding(addr basics.Address, aidx basics.AssetIndex) (basics.AssetHolding, bool, error)

--- a/ledger/internal/applications_test.go
+++ b/ledger/internal/applications_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
-	"github.com/algorand/go-algorand/ledger/apply"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 	ledgertesting "github.com/algorand/go-algorand/ledger/testing"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
@@ -49,9 +49,9 @@ type mockCowForLogicLedger struct {
 	txc    uint64
 }
 
-func (c *mockCowForLogicLedger) Get(addr basics.Address, withPendingRewards bool) (apply.AccountData, error) {
+func (c *mockCowForLogicLedger) Get(addr basics.Address, withPendingRewards bool) (ledgercore.AccountData, error) {
 	acct, err := c.getAccount(addr, withPendingRewards)
-	return apply.ToApplyAccountData(acct), err
+	return ledgercore.ToAccountData(acct), err
 }
 
 func (c *mockCowForLogicLedger) getAccount(addr basics.Address, withPendingRewards bool) (basics.AccountData, error) {

--- a/ledger/internal/compactcert_test.go
+++ b/ledger/internal/compactcert_test.go
@@ -169,6 +169,7 @@ func TestCompactCertParams(t *testing.T) {
 
 	hdr.Round = 4
 	res, err = CompactCertParams(votersHdr, hdr)
+	require.NoError(t, err)
 	require.Equal(t, hdr.Round+1, res.SigRound)
 
 	// Covers all cases except overflow

--- a/ledger/internal/cow.go
+++ b/ledger/internal/cow.go
@@ -38,7 +38,12 @@ import (
 //                  ||     ||
 
 type roundCowParent interface {
-	lookup(basics.Address) (basics.AccountData, error)
+	lookup(basics.Address) (ledgercore.AccountData, error)
+	lookupAppParams(addr basics.Address, aidx basics.AppIndex) (basics.AppParams, bool, error)
+	lookupAssetParams(addr basics.Address, aidx basics.AssetIndex) (basics.AssetParams, bool, error)
+	lookupAppLocalState(addr basics.Address, aidx basics.AppIndex) (basics.AppLocalState, bool, error)
+	lookupAssetHolding(addr basics.Address, aidx basics.AssetIndex) (basics.AssetHolding, bool, error)
+
 	checkDup(basics.Round, basics.Round, transactions.Txid, ledgercore.Txlease) error
 	txnCounter() uint64
 	getCreator(cidx basics.CreatableIndex, ctype basics.CreatableType) (basics.Address, bool, error)
@@ -108,7 +113,6 @@ func makeRoundCowState(b roundCowParent, hdr bookkeeping.BlockHeader, proto conf
 }
 
 func (cb *roundCowState) deltas() ledgercore.StateDelta {
-	var err error
 	if len(cb.sdeltas) == 0 {
 		return cb.mods
 	}
@@ -118,21 +122,21 @@ func (cb *roundCowState) deltas() ledgercore.StateDelta {
 	//    SetKey/DelKey work only with sdeltas, so need to pull missing accounts
 	// 2. Call applyStorageDelta for every delta per account
 	for addr, smap := range cb.sdeltas {
-		var delta basics.AccountData
-		var exist bool
-		if delta, exist = cb.mods.Accts.Get(addr); !exist {
-			ad, err := cb.lookup(addr)
-			if err != nil {
-				panic(fmt.Sprintf("fetching account data failed for addr %s: %s", addr.String(), err.Error()))
-			}
-			delta = ad
-		}
 		for aapp, storeDelta := range smap {
-			if delta, err = applyStorageDelta(delta, aapp, storeDelta); err != nil {
+			// app params and app local states might be accessed without touching base account record
+			// from TEAL by writing/deleting KV store
+			// so store the base account to deltas here
+			// TODO: remove after the schema switch
+			acct, err := cb.lookup(addr)
+			if err != nil {
+				panic(fmt.Sprintf("delta lookup failed for addr %s app %d: %s", addr.String(), aapp.aidx, err.Error()))
+			}
+			cb.Put(addr, acct)
+
+			if err := applyStorageDelta(cb, addr, aapp, storeDelta); err != nil {
 				panic(fmt.Sprintf("applying storage delta failed for addr %s app %d: %s", addr.String(), aapp.aidx, err.Error()))
 			}
 		}
-		cb.mods.Accts.Upsert(addr, delta)
 	}
 	return cb.mods
 }
@@ -164,13 +168,61 @@ func (cb *roundCowState) getCreator(cidx basics.CreatableIndex, ctype basics.Cre
 	return cb.lookupParent.getCreator(cidx, ctype)
 }
 
-func (cb *roundCowState) lookup(addr basics.Address) (data basics.AccountData, err error) {
-	d, ok := cb.mods.Accts.Get(addr)
+func (cb *roundCowState) lookup(addr basics.Address) (data ledgercore.AccountData, err error) {
+	d, ok := cb.mods.NewAccts.GetData(addr)
 	if ok {
 		return d, nil
 	}
 
 	return cb.lookupParent.lookup(addr)
+}
+
+func (cb *roundCowState) lookupAppParams(addr basics.Address, aidx basics.AppIndex) (basics.AppParams, bool, error) {
+	params, ok := cb.mods.NewAccts.GetAppParams(addr, aidx)
+	if ok {
+		if params == nil {
+			return basics.AppParams{}, false, nil
+		}
+		return *params, ok, nil
+	}
+
+	return cb.lookupParent.lookupAppParams(addr, aidx)
+}
+
+func (cb *roundCowState) lookupAssetParams(addr basics.Address, aidx basics.AssetIndex) (basics.AssetParams, bool, error) {
+	params, ok := cb.mods.NewAccts.GetAssetParams(addr, aidx)
+	if ok {
+		if params == nil {
+			return basics.AssetParams{}, false, nil
+		}
+		return *params, ok, nil
+	}
+
+	return cb.lookupParent.lookupAssetParams(addr, aidx)
+}
+
+func (cb *roundCowState) lookupAppLocalState(addr basics.Address, aidx basics.AppIndex) (basics.AppLocalState, bool, error) {
+	state, ok := cb.mods.NewAccts.GetAppLocalState(addr, aidx)
+	if ok {
+		if state == nil {
+			return basics.AppLocalState{}, false, nil
+		}
+		return *state, ok, nil
+	}
+
+	return cb.lookupParent.lookupAppLocalState(addr, aidx)
+}
+
+func (cb *roundCowState) lookupAssetHolding(addr basics.Address, aidx basics.AssetIndex) (basics.AssetHolding, bool, error) {
+	holding, ok := cb.mods.NewAccts.GetAssetHolding(addr, aidx)
+	if ok {
+		if holding == nil {
+			return basics.AssetHolding{}, false, nil
+		}
+		return *holding, ok, nil
+	}
+
+	return cb.lookupParent.lookupAssetHolding(addr, aidx)
 }
 
 func (cb *roundCowState) checkDup(firstValid, lastValid basics.Round, txid transactions.Txid, txl ledgercore.Txlease) error {
@@ -252,7 +304,7 @@ func (cb *roundCowState) setGroupIdx(txnIdx int) {
 }
 
 func (cb *roundCowState) commitToParent() {
-	cb.commitParent.mods.Accts.MergeAccounts(cb.mods.Accts)
+	cb.commitParent.mods.NewAccts.MergeAccounts(cb.mods.NewAccts)
 
 	for txid, lv := range cb.mods.Txids {
 		cb.commitParent.mods.Txids[txid] = lv
@@ -289,7 +341,7 @@ func (cb *roundCowState) commitToParent() {
 }
 
 func (cb *roundCowState) modifiedAccounts() []basics.Address {
-	return cb.mods.Accts.ModifiedAccounts()
+	return cb.mods.NewAccts.ModifiedAccounts()
 }
 
 // errUnsupportedChildCowTotalCalculation is returned by CalculateTotals when called by a child roundCowState instance
@@ -307,8 +359,8 @@ func (cb *roundCowState) CalculateTotals() error {
 	var ot basics.OverflowTracker
 	totals.ApplyRewards(cb.mods.Hdr.RewardsLevel, &ot)
 
-	for i := 0; i < cb.mods.Accts.Len(); i++ {
-		accountAddr, updatedAccountData := cb.mods.Accts.GetByIdx(i)
+	for i := 0; i < cb.mods.NewAccts.Len(); i++ {
+		accountAddr, updatedAccountData := cb.mods.NewAccts.GetByIdx(i)
 		previousAccountData, lookupError := cb.lookupParent.lookup(accountAddr)
 		if lookupError != nil {
 			return fmt.Errorf("roundCowState.CalculateTotals unable to load account data for address %v", accountAddr)

--- a/ledger/internal/cow.go
+++ b/ledger/internal/cow.go
@@ -131,7 +131,10 @@ func (cb *roundCowState) deltas() ledgercore.StateDelta {
 			if err != nil {
 				panic(fmt.Sprintf("delta lookup failed for addr %s app %d: %s", addr.String(), aapp.aidx, err.Error()))
 			}
-			cb.Put(addr, acct)
+			err = cb.Put(addr, acct)
+			if err != nil {
+				panic(fmt.Sprintf("delta saving failed for addr %s app %d: %s", addr.String(), aapp.aidx, err.Error()))
+			}
 
 			if err := applyStorageDelta(cb, addr, aapp, storeDelta); err != nil {
 				panic(fmt.Sprintf("applying storage delta failed for addr %s app %d: %s", addr.String(), aapp.aidx, err.Error()))

--- a/ledger/internal/eval.go
+++ b/ledger/internal/eval.go
@@ -92,10 +92,10 @@ type roundCowBase struct {
 	// The accounts that we're already accessed during this round evaluation. This is a caching
 	// buffer used to avoid looking up the same account data more than once during a single evaluator
 	// execution. The AccountData is always an historical one, then therefore won't be changing.
-	// The underlying (accountupdates) infrastucture may provide additional cross-round caching which
+	// The underlying (accountupdates) infrastructure may provide additional cross-round caching which
 	// are beyond the scope of this cache.
 	// The account data store here is always the account data without the rewards.
-	accounts map[basics.Address]basics.AccountData
+	accounts map[basics.Address]ledgercore.AccountData
 
 	// Similar cache for asset/app creators.
 	creators map[creatable]foundAddress
@@ -108,7 +108,7 @@ func makeRoundCowBase(l LedgerForCowBase, rnd basics.Round, txnCount uint64, com
 		txnCount:           txnCount,
 		compactCertNextRnd: compactCertNextRnd,
 		proto:              proto,
-		accounts:           make(map[basics.Address]basics.AccountData),
+		accounts:           make(map[basics.Address]ledgercore.AccountData),
 		creators:           make(map[creatable]foundAddress),
 	}
 }
@@ -133,16 +133,60 @@ func (x *roundCowBase) getCreator(cidx basics.CreatableIndex, ctype basics.Creat
 // lookup returns the non-rewarded account data for the provided account address. It uses the internal per-round cache
 // first, and if it cannot find it there, it would defer to the underlaying implementation.
 // note that errors in accounts data retrivals are not cached as these typically cause the transaction evaluation to fail.
-func (x *roundCowBase) lookup(addr basics.Address) (basics.AccountData, error) {
+func (x *roundCowBase) lookup(addr basics.Address) (ledgercore.AccountData, error) {
 	if accountData, found := x.accounts[addr]; found {
 		return accountData, nil
 	}
 
 	accountData, _, err := x.l.LookupWithoutRewards(x.rnd, addr)
-	if err == nil {
-		x.accounts[addr] = accountData
+	if err != nil {
+		return ledgercore.AccountData{}, err
 	}
-	return accountData, err
+
+	ad := ledgercore.ToAccountData(accountData)
+	x.accounts[addr] = ad
+	return ad, err
+}
+
+func (x *roundCowBase) lookupAppParams(addr basics.Address, aidx basics.AppIndex) (basics.AppParams, bool, error) {
+	accountData, _, err := x.l.LookupWithoutRewards(x.rnd, addr)
+	if err != nil {
+		return basics.AppParams{}, false, err
+	}
+
+	// TODO: cache
+	params, ok := accountData.AppParams[aidx]
+	return params, ok, nil
+}
+
+func (x *roundCowBase) lookupAssetParams(addr basics.Address, aidx basics.AssetIndex) (basics.AssetParams, bool, error) {
+	accountData, _, err := x.l.LookupWithoutRewards(x.rnd, addr)
+	if err != nil {
+		return basics.AssetParams{}, false, err
+	}
+
+	params, ok := accountData.AssetParams[aidx]
+	return params, ok, nil
+}
+
+func (x *roundCowBase) lookupAppLocalState(addr basics.Address, aidx basics.AppIndex) (basics.AppLocalState, bool, error) {
+	accountData, _, err := x.l.LookupWithoutRewards(x.rnd, addr)
+	if err != nil {
+		return basics.AppLocalState{}, false, err
+	}
+
+	ls, ok := accountData.AppLocalStates[aidx]
+	return ls, ok, nil
+}
+
+func (x *roundCowBase) lookupAssetHolding(addr basics.Address, aidx basics.AssetIndex) (basics.AssetHolding, bool, error) {
+	accountData, _, err := x.l.LookupWithoutRewards(x.rnd, addr)
+	if err != nil {
+		return basics.AssetHolding{}, false, err
+	}
+
+	holding, ok := accountData.Assets[aidx]
+	return holding, ok, nil
 }
 
 func (x *roundCowBase) checkDup(firstValid, lastValid basics.Round, txid transactions.Txid, txl ledgercore.Txlease) error {
@@ -162,40 +206,40 @@ func (x *roundCowBase) blockHdr(r basics.Round) (bookkeeping.BlockHeader, error)
 }
 
 func (x *roundCowBase) allocated(addr basics.Address, aidx basics.AppIndex, global bool) (bool, error) {
-	acct, err := x.lookup(addr)
-	if err != nil {
-		return false, err
-	}
-
 	// For global, check if app params exist
 	if global {
-		_, ok := acct.AppParams[aidx]
-		return ok, nil
+		_, ok, err := x.lookupAppParams(addr, aidx)
+		return ok, err
 	}
 
 	// Otherwise, check app local states
-	_, ok := acct.AppLocalStates[aidx]
-	return ok, nil
+	_, ok, err := x.lookupAppLocalState(addr, aidx)
+	return ok, err
 }
 
 // getKey gets the value for a particular key in some storage
 // associated with an application globally or locally
 func (x *roundCowBase) getKey(addr basics.Address, aidx basics.AppIndex, global bool, key string, accountIdx uint64) (basics.TealValue, bool, error) {
-	ad, err := x.lookup(addr)
-	if err != nil {
-		return basics.TealValue{}, false, err
-	}
-
+	var err error
 	exist := false
 	kv := basics.TealKeyValue{}
 	if global {
 		var app basics.AppParams
-		if app, exist = ad.AppParams[aidx]; exist {
+		app, exist, err = x.lookupAppParams(addr, aidx)
+		if err != nil {
+			return basics.TealValue{}, false, err
+		}
+		if exist {
 			kv = app.GlobalState
 		}
 	} else {
 		var ls basics.AppLocalState
-		if ls, exist = ad.AppLocalStates[aidx]; exist {
+		ls, exist, err = x.lookupAppLocalState(addr, aidx)
+		if err != nil {
+			return basics.TealValue{}, false, err
+		}
+
+		if exist {
 			kv = ls.KeyValue
 		}
 	}
@@ -211,22 +255,26 @@ func (x *roundCowBase) getKey(addr basics.Address, aidx basics.AppIndex, global 
 // getStorageCounts counts the storage types used by some account
 // associated with an application globally or locally
 func (x *roundCowBase) getStorageCounts(addr basics.Address, aidx basics.AppIndex, global bool) (basics.StateSchema, error) {
-	ad, err := x.lookup(addr)
-	if err != nil {
-		return basics.StateSchema{}, err
-	}
-
+	var err error
 	count := basics.StateSchema{}
 	exist := false
 	kv := basics.TealKeyValue{}
 	if global {
 		var app basics.AppParams
-		if app, exist = ad.AppParams[aidx]; exist {
+		app, exist, err = x.lookupAppParams(addr, aidx)
+		if err != nil {
+			return basics.StateSchema{}, err
+		}
+		if exist {
 			kv = app.GlobalState
 		}
 	} else {
 		var ls basics.AppLocalState
-		if ls, exist = ad.AppLocalStates[aidx]; exist {
+		ls, exist, err = x.lookupAppLocalState(addr, aidx)
+		if err != nil {
+			return basics.StateSchema{}, err
+		}
+		if exist {
 			kv = ls.KeyValue
 		}
 	}
@@ -255,12 +303,10 @@ func (x *roundCowBase) getStorageLimits(addr basics.Address, aidx basics.AppInde
 		return basics.StateSchema{}, nil
 	}
 
-	record, err := x.lookup(creator)
+	params, ok, err := x.lookupAppParams(creator, aidx)
 	if err != nil {
 		return basics.StateSchema{}, err
 	}
-
-	params, ok := record.AppParams[aidx]
 	if !ok {
 		// This should never happen. If app exists then we should have
 		// found the creator successfully.
@@ -275,15 +321,15 @@ func (x *roundCowBase) getStorageLimits(addr basics.Address, aidx basics.AppInde
 }
 
 // wrappers for roundCowState to satisfy the (current) apply.Balances interface
-func (cs *roundCowState) Get(addr basics.Address, withPendingRewards bool) (apply.AccountData, error) {
+func (cs *roundCowState) Get(addr basics.Address, withPendingRewards bool) (ledgercore.AccountData, error) {
 	acct, err := cs.lookup(addr)
 	if err != nil {
-		return apply.AccountData{}, err
+		return ledgercore.AccountData{}, err
 	}
 	if withPendingRewards {
 		acct = acct.WithUpdatedRewards(cs.proto, cs.rewardsLevel())
 	}
-	return apply.ToApplyAccountData(acct), nil
+	return acct, nil
 }
 
 func (cs *roundCowState) GetCreatableID(groupIdx int) basics.CreatableIndex {
@@ -294,21 +340,16 @@ func (cs *roundCowState) GetCreator(cidx basics.CreatableIndex, ctype basics.Cre
 	return cs.getCreator(cidx, ctype)
 }
 
-func (cs *roundCowState) Put(addr basics.Address, acct apply.AccountData) error {
-	a, err := cs.lookup(addr)
-	if err != nil {
-		return err
-	}
-	apply.AssignAccountData(&a, acct)
-	return cs.putAccount(addr, a)
+func (cs *roundCowState) Put(addr basics.Address, acct ledgercore.AccountData) error {
+	return cs.putAccount(addr, acct)
 }
 
 func (cs *roundCowState) CloseAccount(addr basics.Address) error {
-	return cs.putAccount(addr, basics.AccountData{})
+	return cs.putAccount(addr, ledgercore.AccountData{})
 }
 
-func (cs *roundCowState) putAccount(addr basics.Address, acct basics.AccountData) error {
-	cs.mods.Accts.Upsert(addr, acct)
+func (cs *roundCowState) putAccount(addr basics.Address, acct ledgercore.AccountData) error {
+	cs.mods.NewAccts.Upsert(addr, acct)
 	return nil
 }
 
@@ -618,7 +659,7 @@ func StartEvaluator(l LedgerForEvaluator, hdr bookkeeping.BlockHeader, evalOpts 
 
 // hotfix for testnet stall 08/26/2019; move some algos from testnet bank to rewards pool to give it enough time until protocol upgrade occur.
 // hotfix for testnet stall 11/07/2019; do the same thing
-func (eval *BlockEvaluator) workaroundOverspentRewards(rewardPoolBalance apply.AccountData, headerRound basics.Round) (poolOld apply.AccountData, err error) {
+func (eval *BlockEvaluator) workaroundOverspentRewards(rewardPoolBalance ledgercore.AccountData, headerRound basics.Round) (poolOld ledgercore.AccountData, err error) {
 	// verify that we patch the correct round.
 	if headerRound != 1499995 && headerRound != 2926564 {
 		return rewardPoolBalance, nil
@@ -892,7 +933,7 @@ func (eval *BlockEvaluator) checkMinBalance(cow *roundCowState) error {
 		effectiveMinBalance := dataNew.MinBalance(&eval.proto)
 		if dataNew.MicroAlgos.Raw < effectiveMinBalance.Raw {
 			return fmt.Errorf("account %v balance %d below min %d (%d assets)",
-				addr, dataNew.MicroAlgos.Raw, effectiveMinBalance.Raw, len(dataNew.Assets))
+				addr, dataNew.MicroAlgos.Raw, effectiveMinBalance.Raw, dataNew.TotalAssets)
 		}
 
 		// Check if we have exceeded the maximum minimum balance
@@ -1038,7 +1079,7 @@ func (eval *BlockEvaluator) applyTransaction(tx transactions.Transaction, balanc
 		}
 
 	default:
-		err = fmt.Errorf("Unknown transaction type %v", tx.Type)
+		err = fmt.Errorf("unknown transaction type %v", tx.Type)
 	}
 
 	// If the protocol does not support rewards in ApplyData,
@@ -1181,14 +1222,14 @@ func (eval *BlockEvaluator) generateExpiredOnlineAccountsList() {
 	// Then we are going to go through each modified account and
 	// see if it meets the criteria for adding it to the expired
 	// participation accounts list.
-	modifiedAccounts := eval.state.mods.Accts.ModifiedAccounts()
+	modifiedAccounts := eval.state.mods.NewAccts.ModifiedAccounts()
 	currentRound := eval.Round()
 
 	expectedMaxNumberOfExpiredAccounts := eval.proto.MaxProposedExpiredOnlineAccounts
 
 	for i := 0; i < len(modifiedAccounts) && len(eval.block.ParticipationUpdates.ExpiredParticipationAccounts) < expectedMaxNumberOfExpiredAccounts; i++ {
 		accountAddr := modifiedAccounts[i]
-		acctDelta, found := eval.state.mods.Accts.Get(accountAddr)
+		acctDelta, found := eval.state.mods.NewAccts.GetData(accountAddr)
 		if !found {
 			continue
 		}
@@ -1434,7 +1475,8 @@ transactionGroupLoop:
 			}
 
 			for _, br := range txgroup.balances {
-				base.accounts[br.Addr] = br.AccountData
+				// TODO: create cache of params as well
+				base.accounts[br.Addr] = ledgercore.ToAccountData(br.AccountData)
 			}
 			err = eval.TransactionGroup(txgroup.group)
 			if err != nil {

--- a/ledger/internal/eval_blackbox_test.go
+++ b/ledger/internal/eval_blackbox_test.go
@@ -63,6 +63,7 @@ func TestBlockEvaluator(t *testing.T) {
 	defer l.Close()
 
 	genesisBlockHeader, err := l.BlockHdr(basics.Round(0))
+	require.NoError(t, err)
 	newBlock := bookkeeping.MakeBlock(genesisBlockHeader)
 	eval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0)
 	require.NoError(t, err)

--- a/ledger/internal/eval_blackbox_test.go
+++ b/ledger/internal/eval_blackbox_test.go
@@ -446,8 +446,8 @@ func TestEvalAppAllocStateWithTxnGroup(t *testing.T) {
 	require.NoError(t, err)
 	deltas := vb.Delta()
 
-	ad, _ := deltas.Accts.Get(addr)
-	state := ad.AppParams[1].GlobalState
+	params, _ := deltas.NewAccts.GetAppParams(addr, 1)
+	state := params.GlobalState
 	require.Equal(t, basics.TealValue{Type: basics.TealBytesType, Bytes: string(addr[:])}, state["caller"])
 	require.Equal(t, basics.TealValue{Type: basics.TealBytesType, Bytes: string(addr[:])}, state["creator"])
 }
@@ -860,6 +860,14 @@ func TestModifiedAppLocalStates(t *testing.T) {
 		created, ok := vb.Delta().ModifiedAppLocalStates[aa]
 		require.True(t, ok)
 		assert.True(t, created)
+
+		state, ok := vb.Delta().NewAccts.GetAppLocalState(addrs[1], appid)
+		require.True(t, ok)
+		require.NotNil(t, state)
+
+		params, ok := vb.Delta().NewAccts.GetAppParams(addrs[0], appid)
+		require.True(t, ok)
+		require.NotNil(t, params)
 	}
 
 	optOutTxn := txntest.Txn{

--- a/ledger/internal/eval_test.go
+++ b/ledger/internal/eval_test.go
@@ -67,6 +67,7 @@ func TestBlockEvaluatorFeeSink(t *testing.T) {
 	l := newTestLedger(t, genesisBalances)
 
 	genesisBlockHeader, err := l.BlockHdr(basics.Round(0))
+	require.NoError(t, err)
 	newBlock := bookkeeping.MakeBlock(genesisBlockHeader)
 	eval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0)
 	require.NoError(t, err)

--- a/ledger/internal/eval_test.go
+++ b/ledger/internal/eval_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/data/transactions/verify"
 	"github.com/algorand/go-algorand/data/txntest"
-	"github.com/algorand/go-algorand/ledger/apply"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	ledgertesting "github.com/algorand/go-algorand/ledger/testing"
 	"github.com/algorand/go-algorand/protocol"
@@ -271,7 +270,7 @@ func TestTestnetFixup(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	eval := &BlockEvaluator{}
-	var rewardPoolBalance apply.AccountData
+	var rewardPoolBalance ledgercore.AccountData
 	rewardPoolBalance.MicroAlgos.Raw = 1234
 	var headerRound basics.Round
 	testnetGenesisHash, _ := crypto.DigestFromString("JBR3KGFEWPEE5SAQ6IWU6EEBZMHXD4CZU6WCBXWGF57XBZIJHIRA")
@@ -308,7 +307,7 @@ func testnetFixupExecution(t *testing.T, headerRound basics.Round, poolBonus uin
 	genesisInitState.Block.BlockHeader.GenesisID = "testnet"
 	genesisInitState.GenesisHash = testnetGenesisHash
 
-	rewardPoolBalance := apply.ToApplyAccountData(genesisInitState.Accounts[testPoolAddr])
+	rewardPoolBalance := ledgercore.ToAccountData(genesisInitState.Accounts[testPoolAddr])
 	nextPoolBalance := rewardPoolBalance.MicroAlgos.Raw + poolBonus
 
 	l := newTestLedger(t, bookkeeping.GenesisBalances{
@@ -435,7 +434,7 @@ func newTestLedger(t testing.TB, balances bookkeeping.GenesisBalances) *evalTest
 	var ot basics.OverflowTracker
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	for _, acctData := range balances.Balances {
-		l.latestTotals.AddAccount(proto, acctData, &ot)
+		l.latestTotals.AddAccount(proto, ledgercore.ToAccountData(acctData), &ot)
 	}
 
 	require.False(t, genBlock.FeeSink.IsZero())
@@ -526,8 +525,8 @@ func (ledger *evalTestLedger) AddValidatedBlock(vb ledgercore.ValidatedBlock, ce
 	}
 	// update
 	deltas := vb.Delta()
-	for _, addr := range deltas.Accts.ModifiedAccounts() {
-		accountData, _ := deltas.Accts.Get(addr)
+	balances := deltas.NewAccts.ToBasicsAccountDataMap()
+	for addr, accountData := range balances {
 		newBalances[addr] = accountData
 	}
 	ledger.roundBalances[vb.Block().Round()] = newBalances
@@ -840,8 +839,8 @@ type failRoundCowParent struct {
 	roundCowBase
 }
 
-func (p *failRoundCowParent) lookup(basics.Address) (basics.AccountData, error) {
-	return basics.AccountData{}, fmt.Errorf("disk I/O fail (on purpose)")
+func (p *failRoundCowParent) lookup(basics.Address) (ledgercore.AccountData, error) {
+	return ledgercore.AccountData{}, fmt.Errorf("disk I/O fail (on purpose)")
 }
 
 // TestExpiredAccountGenerationWithDiskFailure tests edge cases where disk failures can lead to ledger look up failures
@@ -922,10 +921,8 @@ func TestExpiredAccountGenerationWithDiskFailure(t *testing.T) {
 	err = eval.endOfBlock()
 	require.Error(t, err)
 
-	eval.block.ExpiredParticipationAccounts = []basics.Address{
-		basics.Address{},
-	}
-	eval.state.mods.Accts = ledgercore.AccountDeltas{}
+	eval.block.ExpiredParticipationAccounts = []basics.Address{{}}
+	eval.state.mods.NewAccts = ledgercore.NewAccountDeltas{}
 	eval.state.lookupParent = &failRoundCowParent{}
 	err = eval.endOfBlock()
 	require.Error(t, err)

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -274,7 +274,7 @@ func openLedgerDB(dbPathPrefix string, dbMem bool) (trackerDBs db.Pair, blockDBs
 			// before launch, we used to have both blocks and tracker
 			// state in a single SQLite db file. We don't have that anymore,
 			// and we want to fail when that's the case.
-			err = fmt.Errorf("A single ledger database file '%s' was detected. This is no longer supported by current binary", commonDBFilename)
+			err = fmt.Errorf("a single ledger database file '%s' was detected. This is no longer supported by current binary", commonDBFilename)
 			return
 		}
 	}

--- a/ledger/ledger_perf_test.go
+++ b/ledger/ledger_perf_test.go
@@ -290,6 +290,7 @@ func benchmarkFullBlocks(params testParams, b *testing.B) {
 					stxn.Txn = tx
 					stxn.Sig = crypto.Signature{1}
 					err = eval.Transaction(stxn, transactions.ApplyData{})
+					require.NoError(b, err)
 				}
 				break
 			}
@@ -404,7 +405,7 @@ func init() {
 
 	params = testParams{
 		testType: "app",
-		name:     fmt.Sprintf("int-1"),
+		name:     "int-1",
 		program:  ops.Program,
 	}
 	testCases[params.name] = params
@@ -412,7 +413,7 @@ func init() {
 	// Int 1 many apps
 	params = testParams{
 		testType: "app",
-		name:     fmt.Sprintf("int-1-many-apps"),
+		name:     "int-1-many-apps",
 		program:  ops.Program,
 		numApps:  10,
 	}

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -795,7 +795,7 @@ int 1
 	var appIdx basics.AppIndex = 1
 
 	rnd := l.Latest()
-	acct, _, err := l.LookupWithoutRewards(l.Latest(), creator)
+	acct, _, err := l.LookupWithoutRewards(rnd, creator)
 	a.NoError(err)
 	a.Equal(basics.TealValue{Type: basics.TealUintType, Uint: 1}, acct.AppParams[appIdx].GlobalState["counter"])
 

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -1519,6 +1519,7 @@ func TestListAssetsAndApplications(t *testing.T) {
 	require.Equal(t, 2, len(results))
 	// Check the max asset id limit
 	results, err = ledger.ListAssets(basics.AssetIndex(maxAsset), 100)
+	require.NoError(t, err)
 	assetCount := 0
 	for id, ctb := range randomCtbs {
 		if ctb.Ctype == basics.AssetCreatable &&
@@ -1537,6 +1538,7 @@ func TestListAssetsAndApplications(t *testing.T) {
 	require.Equal(t, 2, len(results))
 	// Check the max application id limit
 	results, err = ledger.ListApplications(basics.AppIndex(maxApp), 100)
+	require.NoError(t, err)
 	appCount := 0
 	for id, ctb := range randomCtbs {
 		if ctb.Ctype == basics.AppCreatable &&

--- a/ledger/ledgercore/accountdata.go
+++ b/ledger/ledgercore/accountdata.go
@@ -1,0 +1,180 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package ledgercore
+
+import (
+	"reflect"
+
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
+)
+
+// AccountData provides users of the Balances interface per-account data (like basics.AccountData)
+// but without any maps containing AppParams, AppLocalState, AssetHolding, or AssetParams. This
+// ensures that transaction evaluation must retrieve and mutate account, asset, and application data
+// separately, to better support on-disk and in-memory schemas that do not store them together.
+type AccountData struct {
+	AccountBaseData
+	VotingData
+}
+
+// AccountBaseData contains base account info like balance, status and total number of resources
+type AccountBaseData struct {
+	Status             basics.Status
+	MicroAlgos         basics.MicroAlgos
+	RewardsBase        uint64
+	RewardedMicroAlgos basics.MicroAlgos
+	AuthAddr           basics.Address
+
+	TotalAppSchema      basics.StateSchema
+	TotalExtraAppPages  uint32
+	TotalAppParams      uint32
+	TotalAppLocalStates uint32
+	TotalAssetParams    uint32
+	TotalAssets         uint32
+}
+
+// VotingData holds participation information
+type VotingData struct {
+	VoteID      crypto.OneTimeSignatureVerifier
+	SelectionID crypto.VRFVerifier
+
+	VoteFirstValid  basics.Round
+	VoteLastValid   basics.Round
+	VoteKeyDilution uint64
+
+	// MicroAlgosWithReward basics.MicroAlgos
+}
+
+// ToAccountData returns apply.AccountData from basics.AccountData
+func ToAccountData(acct basics.AccountData) AccountData {
+	return AccountData{
+		AccountBaseData: AccountBaseData{
+			Status:             acct.Status,
+			MicroAlgos:         acct.MicroAlgos,
+			RewardsBase:        acct.RewardsBase,
+			RewardedMicroAlgos: acct.RewardedMicroAlgos,
+
+			AuthAddr: acct.AuthAddr,
+
+			TotalAppSchema:      acct.TotalAppSchema,
+			TotalExtraAppPages:  acct.TotalExtraAppPages,
+			TotalAssetParams:    uint32(len(acct.AssetParams)),
+			TotalAssets:         uint32(len(acct.Assets)),
+			TotalAppParams:      uint32(len(acct.AppParams)),
+			TotalAppLocalStates: uint32(len(acct.AppLocalStates)),
+		},
+		VotingData: VotingData{
+			VoteID:          acct.VoteID,
+			SelectionID:     acct.SelectionID,
+			VoteFirstValid:  acct.VoteFirstValid,
+			VoteLastValid:   acct.VoteLastValid,
+			VoteKeyDilution: acct.VoteKeyDilution,
+		},
+	}
+}
+
+// AssignAccountData assigns the contents of AccountData to the fields in basics.AccountData,
+// but does not touch the AppParams, AppLocalState, AssetHolding, or AssetParams data.
+func AssignAccountData(a *basics.AccountData, acct AccountData) {
+	a.Status = acct.Status
+	a.MicroAlgos = acct.MicroAlgos
+	a.RewardsBase = acct.RewardsBase
+	a.RewardedMicroAlgos = acct.RewardedMicroAlgos
+
+	a.VoteID = acct.VoteID
+	a.SelectionID = acct.SelectionID
+	a.VoteFirstValid = acct.VoteFirstValid
+	a.VoteLastValid = acct.VoteLastValid
+	a.VoteKeyDilution = acct.VoteKeyDilution
+
+	a.AuthAddr = acct.AuthAddr
+	a.TotalAppSchema = acct.TotalAppSchema
+	a.TotalExtraAppPages = acct.TotalExtraAppPages
+}
+
+// WithUpdatedRewards calls basics account data WithUpdatedRewards
+func (ad AccountData) WithUpdatedRewards(proto config.ConsensusParams, rewardsLevel uint64) AccountData {
+	u := basics.AccountData{
+		Status:             ad.Status,
+		MicroAlgos:         ad.MicroAlgos,
+		RewardsBase:        ad.RewardsBase,
+		RewardedMicroAlgos: ad.RewardedMicroAlgos,
+	}
+	u = u.WithUpdatedRewards(proto, rewardsLevel)
+
+	ad.MicroAlgos = u.MicroAlgos
+	ad.RewardsBase = u.RewardsBase
+	ad.RewardedMicroAlgos = u.RewardedMicroAlgos
+	return ad
+}
+
+// ClearOnlineState resets the account's fields to indicate that the account is an offline account
+func (u *AccountData) ClearOnlineState() {
+	u.Status = basics.Offline
+	u.VoteFirstValid = basics.Round(0)
+	u.VoteLastValid = basics.Round(0)
+	u.VoteKeyDilution = 0
+	u.VoteID = crypto.OneTimeSignatureVerifier{}
+	u.SelectionID = crypto.VRFVerifier{}
+}
+
+// MinBalance computes the minimum balance requirements for an account based on
+// some consensus parameters. MinBalance should correspond roughly to how much
+// storage the account is allowed to store on disk.
+func (u AccountData) MinBalance(proto *config.ConsensusParams) (res basics.MicroAlgos) {
+	var min uint64
+
+	// First, base MinBalance
+	min = proto.MinBalance
+
+	// MinBalance for each Asset
+	assetCost := basics.MulSaturate(proto.MinBalance, uint64(u.TotalAssets))
+	min = basics.AddSaturate(min, assetCost)
+
+	// Base MinBalance for each created application
+	appCreationCost := basics.MulSaturate(proto.AppFlatParamsMinBalance, uint64(u.TotalAppParams))
+	min = basics.AddSaturate(min, appCreationCost)
+
+	// Base MinBalance for each opted in application
+	appOptInCost := basics.MulSaturate(proto.AppFlatOptInMinBalance, uint64(u.TotalAppLocalStates))
+	min = basics.AddSaturate(min, appOptInCost)
+
+	// MinBalance for state usage measured by LocalStateSchemas and
+	// GlobalStateSchemas
+	schemaCost := u.TotalAppSchema.MinBalance(proto)
+	min = basics.AddSaturate(min, schemaCost.Raw)
+
+	// MinBalance for each extra app program page
+	extraAppProgramLenCost := basics.MulSaturate(proto.AppFlatParamsMinBalance, uint64(u.TotalExtraAppPages))
+	min = basics.AddSaturate(min, extraAppProgramLenCost)
+
+	res.Raw = min
+	return res
+}
+
+// IsZero checks if an AccountData value is the same as its zero value.
+func (u AccountData) IsZero() bool {
+	return reflect.DeepEqual(u, AccountData{})
+}
+
+// Money is similar to basics account data Money function
+func (u AccountData) Money(proto config.ConsensusParams, rewardsLevel uint64) (money basics.MicroAlgos, rewards basics.MicroAlgos) {
+	e := u.WithUpdatedRewards(proto, rewardsLevel)
+	return e.MicroAlgos, e.RewardedMicroAlgos
+}

--- a/ledger/ledgercore/accountdata.go
+++ b/ledger/ledgercore/accountdata.go
@@ -109,19 +109,19 @@ func AssignAccountData(a *basics.AccountData, acct AccountData) {
 }
 
 // WithUpdatedRewards calls basics account data WithUpdatedRewards
-func (ad AccountData) WithUpdatedRewards(proto config.ConsensusParams, rewardsLevel uint64) AccountData {
-	u := basics.AccountData{
-		Status:             ad.Status,
-		MicroAlgos:         ad.MicroAlgos,
-		RewardsBase:        ad.RewardsBase,
-		RewardedMicroAlgos: ad.RewardedMicroAlgos,
+func (u AccountData) WithUpdatedRewards(proto config.ConsensusParams, rewardsLevel uint64) AccountData {
+	bad := basics.AccountData{
+		Status:             u.Status,
+		MicroAlgos:         u.MicroAlgos,
+		RewardsBase:        u.RewardsBase,
+		RewardedMicroAlgos: u.RewardedMicroAlgos,
 	}
-	u = u.WithUpdatedRewards(proto, rewardsLevel)
+	bad = bad.WithUpdatedRewards(proto, rewardsLevel)
 
-	ad.MicroAlgos = u.MicroAlgos
-	ad.RewardsBase = u.RewardsBase
-	ad.RewardedMicroAlgos = u.RewardedMicroAlgos
-	return ad
+	u.MicroAlgos = bad.MicroAlgos
+	u.RewardsBase = bad.RewardsBase
+	u.RewardedMicroAlgos = bad.RewardedMicroAlgos
+	return u
 }
 
 // ClearOnlineState resets the account's fields to indicate that the account is an offline account

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -17,6 +17,8 @@
 package ledgercore
 
 import (
+	"fmt"
+
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
@@ -69,7 +71,10 @@ type Txlease struct {
 // StateDelta describes the delta between a given round to the previous round
 type StateDelta struct {
 	// modified accounts
-	Accts AccountDeltas
+	// Accts AccountDeltas
+
+	// modified new accounts
+	NewAccts NewAccountDeltas
 
 	// new Txids for the txtail and TxnCounter, mapped to txn.LastValid
 	Txids map[transactions.Txid]basics.Round
@@ -103,12 +108,32 @@ type StateDelta struct {
 }
 
 // AccountDeltas stores ordered accounts and allows fast lookup by address
-type AccountDeltas struct {
+// type AccountDeltas struct {
+// 	// Actual data. If an account is deleted, `accts` contains a balance record
+// 	// with empty `AccountData`.
+// 	accts []basics.BalanceRecord
+// 	// cache for addr to deltas index resolution
+// 	acctsCache map[basics.Address]int
+// }
+
+type newBalanceRecord struct {
+	Addr basics.Address
+
+	AccountData
+}
+
+// NewAccountDeltas stores ordered accounts and allows fast lookup by address
+type NewAccountDeltas struct {
 	// Actual data. If an account is deleted, `accts` contains a balance record
 	// with empty `AccountData`.
-	accts []basics.BalanceRecord
+	accts []newBalanceRecord
 	// cache for addr to deltas index resolution
 	acctsCache map[basics.Address]int
+
+	appParams      map[AccountApp]*basics.AppParams
+	appLocalStates map[AccountApp]*basics.AppLocalState
+	assetParams    map[AccountAsset]*basics.AssetParams
+	assets         map[AccountAsset]*basics.AssetHolding
 }
 
 // MakeStateDelta creates a new instance of StateDelta.
@@ -116,10 +141,7 @@ type AccountDeltas struct {
 // This does not play well for AssetConfig and ApplicationCall transactions on scale
 func MakeStateDelta(hdr *bookkeeping.BlockHeader, prevTimestamp int64, hint int, compactCertNext basics.Round) StateDelta {
 	return StateDelta{
-		Accts: AccountDeltas{
-			accts:      make([]basics.BalanceRecord, 0, hint*2),
-			acctsCache: make(map[basics.Address]int, hint*2),
-		},
+		NewAccts: MakeNewAccountDeltas(hint),
 		Txids:    make(map[transactions.Txid]basics.Round, hint),
 		Txleases: make(map[Txlease]basics.Round, hint),
 		// asset or application creation are considered as rare events so do not pre-allocate space for them
@@ -133,56 +155,271 @@ func MakeStateDelta(hdr *bookkeeping.BlockHeader, prevTimestamp int64, hint int,
 	}
 }
 
+func MakeNewAccountDeltas(hint int) NewAccountDeltas {
+	return NewAccountDeltas{
+		accts:      make([]newBalanceRecord, 0, hint*2),
+		acctsCache: make(map[basics.Address]int, hint*2),
+
+		appParams:      make(map[AccountApp]*basics.AppParams),
+		appLocalStates: make(map[AccountApp]*basics.AppLocalState),
+		assetParams:    make(map[AccountAsset]*basics.AssetParams),
+		assets:         make(map[AccountAsset]*basics.AssetHolding),
+	}
+}
+
+// // Get lookups AccountData by address
+// func (ad *AccountDeltas) Get(addr basics.Address) (basics.AccountData, bool) {
+// 	idx, ok := ad.acctsCache[addr]
+// 	if !ok {
+// 		return basics.AccountData{}, false
+// 	}
+// 	return ad.accts[idx].AccountData, true
+// }
+
 // Get lookups AccountData by address
-func (ad *AccountDeltas) Get(addr basics.Address) (basics.AccountData, bool) {
+func (ad NewAccountDeltas) GetData(addr basics.Address) (AccountData, bool) {
 	idx, ok := ad.acctsCache[addr]
 	if !ok {
-		return basics.AccountData{}, false
+		return AccountData{}, false
 	}
 	return ad.accts[idx].AccountData, true
 }
 
+func (ad NewAccountDeltas) GetAppParams(addr basics.Address, aidx basics.AppIndex) (*basics.AppParams, bool) {
+	params, ok := ad.appParams[AccountApp{addr, aidx}]
+	return params, ok
+	// if !ok {
+	// 	return basics.AppParams{}, false
+	// }
+	// return *params, true
+}
+
+func (ad NewAccountDeltas) GetAssetParams(addr basics.Address, aidx basics.AssetIndex) (*basics.AssetParams, bool) {
+	params, ok := ad.assetParams[AccountAsset{addr, aidx}]
+	return params, ok
+	// if !ok || params == nil {
+	// 	return basics.AssetParams{}, false
+	// }
+	// return *params, true
+}
+
+func (ad NewAccountDeltas) GetAppLocalState(addr basics.Address, aidx basics.AppIndex) (*basics.AppLocalState, bool) {
+	ls, ok := ad.appLocalStates[AccountApp{addr, aidx}]
+	return ls, ok
+	// if !ok || ls == nil {
+	// 	return basics.AppLocalState{}, false
+	// }
+	// return *ls, true
+}
+
+func (ad NewAccountDeltas) GetAssetHolding(addr basics.Address, aidx basics.AssetIndex) (*basics.AssetHolding, bool) {
+	holding, ok := ad.assets[AccountAsset{addr, aidx}]
+	return holding, ok
+	// if !ok || holding == nil {
+	// 	return basics.AssetHolding{}, false
+	// }
+	// return *holding, true
+}
+
 // ModifiedAccounts returns list of addresses of modified accounts
-func (ad *AccountDeltas) ModifiedAccounts() []basics.Address {
+func (ad NewAccountDeltas) ModifiedAccounts() []basics.Address {
 	result := make([]basics.Address, len(ad.accts))
 	for i := 0; i < len(ad.accts); i++ {
 		result[i] = ad.accts[i].Addr
 	}
+
+	// consistency check: ensure all addresses in params/holdings/states are also in base account
+	for aapp := range ad.appParams {
+		if _, ok := ad.acctsCache[aapp.Address]; !ok {
+			panic(fmt.Sprintf("account app param delta: addr %s not in base account", aapp.Address))
+		}
+	}
+	for aapp := range ad.appLocalStates {
+		if _, ok := ad.acctsCache[aapp.Address]; !ok {
+			panic(fmt.Sprintf("account app state delta: addr %s not in base account", aapp.Address))
+		}
+	}
+	for aapp := range ad.assetParams {
+		if _, ok := ad.acctsCache[aapp.Address]; !ok {
+			panic(fmt.Sprintf("account asset param delta: addr %s not in base account", aapp.Address))
+		}
+	}
+	for aapp := range ad.assets {
+		if _, ok := ad.acctsCache[aapp.Address]; !ok {
+			panic(fmt.Sprintf("account asset holding delta: addr %s not in base account", aapp.Address))
+		}
+	}
+
 	return result
 }
 
 // MergeAccounts applies other accounts into this StateDelta accounts
-func (ad *AccountDeltas) MergeAccounts(other AccountDeltas) {
+func (ad *NewAccountDeltas) MergeAccounts(other NewAccountDeltas) {
 	for new := range other.accts {
-		ad.upsert(other.accts[new])
+		addr := other.accts[new].Addr
+		acct := other.accts[new].AccountData
+		ad.Upsert(addr, acct)
+	}
+
+	for aapp, params := range other.appParams {
+		ad.UpsertAppParams(aapp.Address, aapp.App, params)
+	}
+	for aapp, state := range other.appLocalStates {
+		ad.UpsertAppLocalState(aapp.Address, aapp.App, state)
+	}
+	for aapp, params := range other.assetParams {
+		ad.UpsertAssetParams(aapp.Address, aapp.Asset, params)
+	}
+	for aapp, holding := range other.assets {
+		ad.UpsertAssetHolding(aapp.Address, aapp.Asset, holding)
+	}
+}
+
+// Clone copies all map in NewAccountDeltas but does not reallocates inner arrays like addresses or metadata inside asset params
+func (ad NewAccountDeltas) Clone() NewAccountDeltas {
+	clone := NewAccountDeltas{
+		accts:      make([]newBalanceRecord, len(ad.accts)),
+		acctsCache: make(map[basics.Address]int, len(ad.acctsCache)),
+
+		appParams:      make(map[AccountApp]*basics.AppParams, len(ad.appParams)),
+		appLocalStates: make(map[AccountApp]*basics.AppLocalState, len(ad.appLocalStates)),
+		assetParams:    make(map[AccountAsset]*basics.AssetParams, len(ad.assetParams)),
+		assets:         make(map[AccountAsset]*basics.AssetHolding, len(ad.assets)),
+	}
+
+	for idx := range ad.accts {
+		clone.accts[idx] = ad.accts[idx]
+	}
+
+	for addr, idx := range ad.acctsCache {
+		clone.acctsCache[addr] = idx
+	}
+
+	for aapp, val := range ad.appParams {
+		if val == nil {
+			clone.appParams[aapp] = nil
+		} else {
+			cp := *val
+			clone.appParams[aapp] = &cp
+		}
+	}
+
+	for aapp, val := range ad.appLocalStates {
+		if val == nil {
+			clone.appLocalStates[aapp] = nil
+		} else {
+			cp := *val
+			clone.appLocalStates[aapp] = &cp
+		}
+	}
+
+	for aapp, val := range ad.assetParams {
+		if val == nil {
+			clone.assetParams[aapp] = nil
+		} else {
+			cp := *val
+			clone.assetParams[aapp] = &cp
+		}
+	}
+
+	for aapp, val := range ad.assets {
+		if val == nil {
+			clone.assets[aapp] = nil
+		} else {
+			cp := *val
+			clone.assets[aapp] = &cp
+		}
+	}
+
+	return clone
+}
+
+// MergeInMatchingAccounts adds data from other for matching addresses.
+// It assumes ad is newer than other
+func (ad NewAccountDeltas) MergeInMatchingAccounts(other NewAccountDeltas) {
+	// do not update accts/acctsCache because ad is newer
+
+	// find missing params/holdings/states to add into newer delta
+	for aapp, val := range other.appParams {
+		addr := aapp.Address
+		if _, ok := ad.acctsCache[addr]; ok {
+			// address is in newer delta, add params if needed
+			if _, ok := ad.appParams[aapp]; !ok {
+				if val == nil {
+					ad.appParams[aapp] = nil
+				} else {
+					cp := *val
+					ad.appParams[aapp] = &cp
+				}
+			}
+		}
+	}
+
+	for aapp, val := range other.appLocalStates {
+		addr := aapp.Address
+		if _, ok := ad.acctsCache[addr]; ok {
+			// address is in newer delta, add params if needed
+			if _, ok := ad.appLocalStates[aapp]; !ok {
+				if val == nil {
+					ad.appLocalStates[aapp] = nil
+				} else {
+					cp := *val
+					ad.appLocalStates[aapp] = &cp
+				}
+			}
+		}
+	}
+
+	for aapp, val := range other.assetParams {
+		addr := aapp.Address
+		if _, ok := ad.acctsCache[addr]; ok {
+			// address is in newer delta, add params if needed
+			if _, ok := ad.assetParams[aapp]; !ok {
+				if val == nil {
+					ad.assetParams[aapp] = nil
+				} else {
+					cp := *val
+					ad.assetParams[aapp] = &cp
+				}
+			}
+		}
+	}
+
+	for aapp, val := range other.assets {
+		addr := aapp.Address
+		if _, ok := ad.acctsCache[addr]; ok {
+			// address is in newer delta, add params if needed
+			if _, ok := ad.assets[aapp]; !ok {
+				if val == nil {
+					ad.assets[aapp] = nil
+				} else {
+					cp := *val
+					ad.assets[aapp] = &cp
+				}
+			}
+		}
 	}
 }
 
 // Len returns number of stored accounts
-func (ad *AccountDeltas) Len() int {
+func (ad *NewAccountDeltas) Len() int {
 	return len(ad.accts)
 }
 
 // GetByIdx returns address and AccountData
 // It does NOT check boundaries.
-func (ad *AccountDeltas) GetByIdx(i int) (basics.Address, basics.AccountData) {
+func (ad *NewAccountDeltas) GetByIdx(i int) (basics.Address, AccountData) {
 	return ad.accts[i].Addr, ad.accts[i].AccountData
 }
 
-// Upsert adds new or updates existing account account
-func (ad *AccountDeltas) Upsert(addr basics.Address, data basics.AccountData) {
-	ad.upsert(basics.BalanceRecord{Addr: addr, AccountData: data})
-}
-
-func (ad *AccountDeltas) upsert(br basics.BalanceRecord) {
-	addr := br.Addr
+func (ad *NewAccountDeltas) Upsert(addr basics.Address, data AccountData) {
 	if idx, exist := ad.acctsCache[addr]; exist { // nil map lookup is OK
-		ad.accts[idx] = br
+		ad.accts[idx] = newBalanceRecord{Addr: addr, AccountData: data}
 		return
 	}
 
 	last := len(ad.accts)
-	ad.accts = append(ad.accts, br)
+	ad.accts = append(ad.accts, newBalanceRecord{Addr: addr, AccountData: data})
 
 	if ad.acctsCache == nil {
 		ad.acctsCache = make(map[basics.Address]int)
@@ -190,25 +427,41 @@ func (ad *AccountDeltas) upsert(br basics.BalanceRecord) {
 	ad.acctsCache[addr] = last
 }
 
+func (ad *NewAccountDeltas) UpsertAppParams(addr basics.Address, aidx basics.AppIndex, params *basics.AppParams) {
+	ad.appParams[AccountApp{addr, aidx}] = params
+}
+
+func (ad *NewAccountDeltas) UpsertAssetParams(addr basics.Address, aidx basics.AssetIndex, params *basics.AssetParams) {
+	ad.assetParams[AccountAsset{addr, aidx}] = params
+}
+
+func (ad *NewAccountDeltas) UpsertAppLocalState(addr basics.Address, aidx basics.AppIndex, ls *basics.AppLocalState) {
+	ad.appLocalStates[AccountApp{addr, aidx}] = ls
+}
+
+func (ad *NewAccountDeltas) UpsertAssetHolding(addr basics.Address, aidx basics.AssetIndex, holding *basics.AssetHolding) {
+	ad.assets[AccountAsset{addr, aidx}] = holding
+}
+
 // OptimizeAllocatedMemory by reallocating maps to needed capacity
 // For each data structure, reallocate if it would save us at least 50MB aggregate
 func (sd *StateDelta) OptimizeAllocatedMemory(proto config.ConsensusParams) {
 	// accts takes up 232 bytes per entry, and is saved for 320 rounds
-	if uint64(cap(sd.Accts.accts)-len(sd.Accts.accts))*accountArrayEntrySize*proto.MaxBalLookback > stateDeltaTargetOptimizationThreshold {
-		accts := make([]basics.BalanceRecord, len(sd.Accts.acctsCache))
-		copy(accts, sd.Accts.accts)
-		sd.Accts.accts = accts
+	if uint64(cap(sd.NewAccts.accts)-len(sd.NewAccts.accts))*accountArrayEntrySize*proto.MaxBalLookback > stateDeltaTargetOptimizationThreshold {
+		accts := make([]newBalanceRecord, len(sd.NewAccts.acctsCache))
+		copy(accts, sd.NewAccts.accts)
+		sd.NewAccts.accts = accts
 	}
 
 	// acctsCache takes up 64 bytes per entry, and is saved for 320 rounds
 	// realloc if original allocation capacity greater than length of data, and space difference is significant
-	if 2*sd.initialTransactionsCount > len(sd.Accts.acctsCache) &&
-		uint64(2*sd.initialTransactionsCount-len(sd.Accts.acctsCache))*accountMapCacheEntrySize*proto.MaxBalLookback > stateDeltaTargetOptimizationThreshold {
-		acctsCache := make(map[basics.Address]int, len(sd.Accts.acctsCache))
-		for k, v := range sd.Accts.acctsCache {
+	if 2*sd.initialTransactionsCount > len(sd.NewAccts.acctsCache) &&
+		uint64(2*sd.initialTransactionsCount-len(sd.NewAccts.acctsCache))*accountMapCacheEntrySize*proto.MaxBalLookback > stateDeltaTargetOptimizationThreshold {
+		acctsCache := make(map[basics.Address]int, len(sd.NewAccts.acctsCache))
+		for k, v := range sd.NewAccts.acctsCache {
 			acctsCache[k] = v
 		}
-		sd.Accts.acctsCache = acctsCache
+		sd.NewAccts.acctsCache = acctsCache
 	}
 
 	// TxLeases takes up 112 bytes per entry, and is saved for 1000 rounds
@@ -229,4 +482,377 @@ func (sd *StateDelta) OptimizeAllocatedMemory(proto config.ConsensusParams) {
 		}
 		sd.Creatables = creatableDeltas
 	}
+}
+
+// GetBasicsAccountData returns basics account data for some specific address
+func (ad NewAccountDeltas) GetBasicsAccountData(addr basics.Address) (basics.AccountData, bool) {
+	idx, ok := ad.acctsCache[addr]
+	if !ok {
+		return basics.AccountData{}, false
+	}
+
+	result := basics.AccountData{}
+	acct := ad.accts[idx].AccountData
+	AssignAccountData(&result, acct)
+
+	if len(ad.appParams) > 0 {
+		result.AppParams = make(map[basics.AppIndex]basics.AppParams)
+		for aapp, val := range ad.appParams {
+			if aapp.Address == addr {
+				if val == nil {
+					delete(result.AppParams, aapp.App)
+				} else {
+					result.AppParams[aapp.App] = *val
+				}
+			}
+		}
+		if len(result.AppParams) == 0 {
+			result.AppParams = nil
+		}
+	}
+
+	if len(ad.appLocalStates) > 0 {
+		result.AppLocalStates = make(map[basics.AppIndex]basics.AppLocalState)
+		for aapp, val := range ad.appLocalStates {
+			if aapp.Address == addr {
+				if val == nil {
+					delete(result.AppLocalStates, aapp.App)
+				} else {
+					result.AppLocalStates[aapp.App] = *val
+				}
+			}
+		}
+		if len(result.AppLocalStates) == 0 {
+			result.AppLocalStates = nil
+		}
+	}
+
+	if len(ad.assetParams) > 0 {
+		result.AssetParams = make(map[basics.AssetIndex]basics.AssetParams)
+		for aapp, val := range ad.assetParams {
+			if aapp.Address == addr {
+				if val == nil {
+					delete(result.AssetParams, aapp.Asset)
+				} else {
+					result.AssetParams[aapp.Asset] = *val
+				}
+			}
+		}
+		if len(result.AssetParams) == 0 {
+			result.AssetParams = nil
+		}
+	}
+
+	if len(ad.assets) > 0 {
+		result.Assets = make(map[basics.AssetIndex]basics.AssetHolding)
+		for aapp, val := range ad.assets {
+			if aapp.Address == addr {
+				if val == nil {
+					delete(result.Assets, aapp.Asset)
+				} else {
+					result.Assets[aapp.Asset] = *val
+				}
+			}
+		}
+		if len(result.Assets) == 0 {
+			result.Assets = nil
+		}
+	}
+
+	return result, true
+}
+
+func (ad NewAccountDeltas) ToBasicsAccountDataMap() map[basics.Address]basics.AccountData {
+	result := make(map[basics.Address]basics.AccountData, ad.Len())
+	for addr, idx := range ad.acctsCache {
+		acct := ad.accts[idx].AccountData
+		acctData := basics.AccountData{}
+		AssignAccountData(&acctData, acct)
+		result[addr] = acctData
+	}
+
+	for aapp, val := range ad.appParams {
+		acctData, ok := result[aapp.Address]
+		// TODO: remove after the schema switch
+		if !ok {
+			panic(fmt.Sprintf("ToBasicAccountData: app params for (%s, %d) not in base deltas", aapp.Address.String(), aapp.App))
+		}
+		if val == nil {
+			delete(acctData.AppParams, aapp.App)
+		} else {
+			if acctData.AppParams == nil {
+				acctData.AppParams = make(map[basics.AppIndex]basics.AppParams)
+			}
+			acctData.AppParams[aapp.App] = *val
+		}
+		result[aapp.Address] = acctData
+	}
+
+	for aapp, val := range ad.appLocalStates {
+		acctData, ok := result[aapp.Address]
+		// TODO: remove after the schema switch
+		if !ok {
+			panic(fmt.Sprintf("ToBasicAccountData: app states for (%s, %d) not in base deltas", aapp.Address.String(), aapp.App))
+		}
+		if val == nil {
+			delete(acctData.AppLocalStates, aapp.App)
+		} else {
+			if acctData.AppLocalStates == nil {
+				acctData.AppLocalStates = make(map[basics.AppIndex]basics.AppLocalState)
+			}
+			acctData.AppLocalStates[aapp.App] = *val
+		}
+		result[aapp.Address] = acctData
+	}
+
+	for aapp, val := range ad.assetParams {
+		acctData, ok := result[aapp.Address]
+		// TODO: remove after the schema switch
+		if !ok {
+			panic(fmt.Sprintf("ToBasicAccountData: asset params for (%s, %d) not in base deltas", aapp.Address.String(), aapp.Asset))
+		}
+		if val == nil {
+			delete(acctData.AssetParams, aapp.Asset)
+		} else {
+			if acctData.AssetParams == nil {
+				acctData.AssetParams = make(map[basics.AssetIndex]basics.AssetParams)
+			}
+			acctData.AssetParams[aapp.Asset] = *val
+		}
+		result[aapp.Address] = acctData
+	}
+
+	for aapp, val := range ad.assets {
+		acctData, ok := result[aapp.Address]
+		// TODO: remove after the schema switch
+		if !ok {
+			panic(fmt.Sprintf("ToBasicAccountData: asset holding for (%s, %d) not in base deltas", aapp.Address.String(), aapp.Asset))
+		}
+		if val == nil {
+			delete(acctData.Assets, aapp.Asset)
+		} else {
+			if acctData.Assets == nil {
+				acctData.Assets = make(map[basics.AssetIndex]basics.AssetHolding)
+			}
+			acctData.Assets[aapp.Asset] = *val
+		}
+		result[aapp.Address] = acctData
+	}
+
+	return result
+}
+
+// ApplyToPartialDelta applies partial delta from "ad" to a full account data "prev" and returns a deep copy
+func (ad NewAccountDeltas) ApplyToBasicsAccountData(addr basics.Address, prev basics.AccountData) (result basics.AccountData) {
+	// set the base part of account data (balance, status, voting data...)
+	acct, ok := ad.GetData(addr)
+	if !ok {
+		return prev
+	}
+
+	AssignAccountData(&result, acct)
+
+	if acct.TotalAssetParams > 0 || prev.AssetParams != nil {
+		result.AssetParams = make(map[basics.AssetIndex]basics.AssetParams)
+		for aidx, params := range prev.AssetParams {
+			result.AssetParams[aidx] = params
+		}
+		for aapp, val := range ad.assetParams {
+			if aapp.Address == addr {
+				if val == nil {
+					delete(result.AssetParams, aapp.Asset)
+				} else {
+					result.AssetParams[aapp.Asset] = *val
+				}
+			}
+		}
+		if len(result.AssetParams) == 0 {
+			result.AssetParams = nil
+		}
+	}
+
+	if acct.TotalAssets > 0 || prev.Assets != nil {
+		result.Assets = make(map[basics.AssetIndex]basics.AssetHolding)
+		for aidx, params := range prev.Assets {
+			result.Assets[aidx] = params
+		}
+		for aapp, val := range ad.assets {
+			if aapp.Address == addr {
+				if val == nil {
+					delete(result.Assets, aapp.Asset)
+				} else {
+					result.Assets[aapp.Asset] = *val
+				}
+			}
+		}
+		if len(result.Assets) == 0 {
+			result.Assets = nil
+		}
+	}
+
+	if acct.TotalAppParams > 0 || prev.AppParams != nil {
+		result.AppParams = make(map[basics.AppIndex]basics.AppParams)
+		for aidx, params := range prev.AppParams {
+			result.AppParams[aidx] = params
+		}
+		for aapp, val := range ad.appParams {
+			if aapp.Address == addr {
+				if val == nil {
+					delete(result.AppParams, aapp.App)
+				} else {
+					result.AppParams[aapp.App] = *val
+				}
+			}
+		}
+		if len(result.AppParams) == 0 {
+			result.AppParams = nil
+		}
+	}
+
+	if acct.TotalAppLocalStates > 0 || prev.AppLocalStates != nil {
+		result.AppLocalStates = make(map[basics.AppIndex]basics.AppLocalState)
+		for aidx, state := range prev.AppLocalStates {
+			result.AppLocalStates[aidx] = state
+		}
+		for aapp, val := range ad.appLocalStates {
+			if aapp.Address == addr {
+				if val == nil {
+					delete(result.AppLocalStates, aapp.App)
+				} else {
+					result.AppLocalStates[aapp.App] = *val
+				}
+			}
+		}
+		if len(result.AppLocalStates) == 0 {
+			result.AppLocalStates = nil
+		}
+	}
+
+	return result
+}
+
+// ApplyToPrevDelta adds changes from "ad" delta into "prev" delta for specific address
+func (ad NewAccountDeltas) ApplyToPrevDelta(addr basics.Address, prev NewAccountDeltas) (result NewAccountDeltas) {
+	result = prev.Clone()
+
+	acct, ok := ad.GetData(addr)
+	if ok {
+		result.Upsert(addr, acct)
+
+		for aapp, val := range ad.assetParams {
+			if aapp.Address == addr {
+				if val == nil {
+					result.assetParams[aapp] = nil
+				} else {
+					v := *val
+					result.assetParams[aapp] = &v
+				}
+			}
+		}
+
+		for aapp, val := range ad.assets {
+			if aapp.Address == addr {
+				if val == nil {
+					result.assets[aapp] = nil
+				} else {
+					v := *val
+					result.assets[aapp] = &v
+				}
+			}
+		}
+
+		for aapp, val := range ad.appParams {
+			if aapp.Address == addr {
+				if val == nil {
+					result.appParams[aapp] = nil
+				} else {
+					v := *val
+					result.appParams[aapp] = &v
+				}
+			}
+		}
+
+		for aapp, val := range ad.appLocalStates {
+			if aapp.Address == addr {
+				if val == nil {
+					result.appLocalStates[aapp] = nil
+				} else {
+					v := *val
+					result.appLocalStates[aapp] = &v
+				}
+			}
+		}
+	}
+	return result
+}
+
+// ExtractDelta extracts only data belonging to a specific address
+func (ad NewAccountDeltas) ExtractDelta(addr basics.Address) (result NewAccountDeltas) {
+	acct, ok := ad.GetData(addr)
+	if ok {
+		result = MakeNewAccountDeltas(1)
+		result.Upsert(addr, acct)
+
+		for aapp, val := range ad.assetParams {
+			if aapp.Address == addr {
+				if val == nil {
+					result.assetParams[aapp] = nil
+				} else {
+					v := *val
+					result.assetParams[aapp] = &v
+				}
+			}
+		}
+
+		for aapp, val := range ad.assets {
+			if aapp.Address == addr {
+				if val == nil {
+					result.assets[aapp] = nil
+				} else {
+					v := *val
+					result.assets[aapp] = &v
+				}
+			}
+		}
+
+		for aapp, val := range ad.appParams {
+			if aapp.Address == addr {
+				if val == nil {
+					result.appParams[aapp] = nil
+				} else {
+					v := *val
+					result.appParams[aapp] = &v
+				}
+			}
+		}
+
+		for aapp, val := range ad.appLocalStates {
+			if aapp.Address == addr {
+				if val == nil {
+					result.appLocalStates[aapp] = nil
+				} else {
+					v := *val
+					result.appLocalStates[aapp] = &v
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+func (ad NewAccountDeltas) GetAllAppParams() map[AccountApp]*basics.AppParams {
+	return ad.appParams
+}
+
+func (ad NewAccountDeltas) GetAllAssetParams() map[AccountAsset]*basics.AssetParams {
+	return ad.assetParams
+}
+
+func (ad NewAccountDeltas) GetAllAppLocalState() map[AccountApp]*basics.AppLocalState {
+	return ad.appLocalStates
+}
+
+func (ad NewAccountDeltas) GetAllAssetHolding() map[AccountAsset]*basics.AssetHolding {
+	return ad.assets
 }

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -168,7 +168,7 @@ func MakeNewAccountDeltas(hint int) NewAccountDeltas {
 	}
 }
 
-// Get lookups AccountData by address
+// GetData lookups AccountData by address
 func (ad NewAccountDeltas) GetData(addr basics.Address) (AccountData, bool) {
 	idx, ok := ad.acctsCache[addr]
 	if !ok {

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -470,6 +470,7 @@ func (sd *StateDelta) OptimizeAllocatedMemory(proto config.ConsensusParams) {
 }
 
 // GetBasicsAccountData returns basics account data for some specific address
+// Currently is only used in tests
 func (ad NewAccountDeltas) GetBasicsAccountData(addr basics.Address) (basics.AccountData, bool) {
 	idx, ok := ad.acctsCache[addr]
 	if !ok {
@@ -484,9 +485,7 @@ func (ad NewAccountDeltas) GetBasicsAccountData(addr basics.Address) (basics.Acc
 		result.AppParams = make(map[basics.AppIndex]basics.AppParams)
 		for aapp, val := range ad.appParams {
 			if aapp.Address == addr {
-				if val == nil {
-					delete(result.AppParams, aapp.App)
-				} else {
+				if val != nil {
 					result.AppParams[aapp.App] = *val
 				}
 			}
@@ -500,9 +499,7 @@ func (ad NewAccountDeltas) GetBasicsAccountData(addr basics.Address) (basics.Acc
 		result.AppLocalStates = make(map[basics.AppIndex]basics.AppLocalState)
 		for aapp, val := range ad.appLocalStates {
 			if aapp.Address == addr {
-				if val == nil {
-					delete(result.AppLocalStates, aapp.App)
-				} else {
+				if val != nil {
 					result.AppLocalStates[aapp.App] = *val
 				}
 			}
@@ -516,9 +513,7 @@ func (ad NewAccountDeltas) GetBasicsAccountData(addr basics.Address) (basics.Acc
 		result.AssetParams = make(map[basics.AssetIndex]basics.AssetParams)
 		for aapp, val := range ad.assetParams {
 			if aapp.Address == addr {
-				if val == nil {
-					delete(result.AssetParams, aapp.Asset)
-				} else {
+				if val != nil {
 					result.AssetParams[aapp.Asset] = *val
 				}
 			}
@@ -532,9 +527,7 @@ func (ad NewAccountDeltas) GetBasicsAccountData(addr basics.Address) (basics.Acc
 		result.Assets = make(map[basics.AssetIndex]basics.AssetHolding)
 		for aapp, val := range ad.assets {
 			if aapp.Address == addr {
-				if val == nil {
-					delete(result.Assets, aapp.Asset)
-				} else {
+				if val != nil {
 					result.Assets[aapp.Asset] = *val
 				}
 			}

--- a/ledger/ledgercore/statedelta_test.go
+++ b/ledger/ledgercore/statedelta_test.go
@@ -37,24 +37,24 @@ func TestAccountDeltas(t *testing.T) {
 
 	a := require.New(t)
 
-	ad := AccountDeltas{}
-	data, ok := ad.Get(basics.Address{})
+	ad := NewAccountDeltas{}
+	data, ok := ad.GetData(basics.Address{})
 	a.False(ok)
-	a.Equal(basics.AccountData{}, data)
+	a.Equal(AccountData{}, data)
 
 	addr := randomAddress()
-	data, ok = ad.Get(addr)
+	data, ok = ad.GetData(addr)
 	a.False(ok)
-	a.Equal(basics.AccountData{}, data)
+	a.Equal(AccountData{}, data)
 
 	a.Equal(0, ad.Len())
 	a.Panics(func() { ad.GetByIdx(0) })
 
 	a.Equal([]basics.Address{}, ad.ModifiedAccounts())
 
-	sample1 := basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 123}}
+	sample1 := AccountData{AccountBaseData: AccountBaseData{MicroAlgos: basics.MicroAlgos{Raw: 123}}}
 	ad.Upsert(addr, sample1)
-	data, ok = ad.Get(addr)
+	data, ok = ad.GetData(addr)
 	a.True(ok)
 	a.Equal(sample1, data)
 
@@ -63,9 +63,9 @@ func TestAccountDeltas(t *testing.T) {
 	a.Equal(addr, address)
 	a.Equal(sample1, data)
 
-	sample2 := basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 456}}
+	sample2 := AccountData{AccountBaseData: AccountBaseData{MicroAlgos: basics.MicroAlgos{Raw: 456}}}
 	ad.Upsert(addr, sample2)
-	data, ok = ad.Get(addr)
+	data, ok = ad.GetData(addr)
 	a.True(ok)
 	a.Equal(sample2, data)
 
@@ -76,7 +76,7 @@ func TestAccountDeltas(t *testing.T) {
 
 	a.Equal([]basics.Address{addr}, ad.ModifiedAccounts())
 
-	ad2 := AccountDeltas{}
+	ad2 := NewAccountDeltas{}
 	ad2.Upsert(addr, sample2)
 	ad.MergeAccounts(ad2)
 	a.Equal(1, ad.Len())

--- a/ledger/ledgercore/totals.go
+++ b/ledger/ledgercore/totals.go
@@ -69,7 +69,7 @@ func (at *AccountTotals) statusField(status basics.Status) *AlgoCount {
 }
 
 // AddAccount adds an account algos from the total money
-func (at *AccountTotals) AddAccount(proto config.ConsensusParams, data basics.AccountData, ot *basics.OverflowTracker) {
+func (at *AccountTotals) AddAccount(proto config.ConsensusParams, data AccountData, ot *basics.OverflowTracker) {
 	sum := at.statusField(data.Status)
 	algos, _ := data.Money(proto, at.RewardsLevel)
 	sum.Money = ot.AddA(sum.Money, algos)
@@ -77,7 +77,7 @@ func (at *AccountTotals) AddAccount(proto config.ConsensusParams, data basics.Ac
 }
 
 // DelAccount removes an account algos from the total money
-func (at *AccountTotals) DelAccount(proto config.ConsensusParams, data basics.AccountData, ot *basics.OverflowTracker) {
+func (at *AccountTotals) DelAccount(proto config.ConsensusParams, data AccountData, ot *basics.OverflowTracker) {
 	sum := at.statusField(data.Status)
 	algos, _ := data.Money(proto, at.RewardsLevel)
 	sum.Money = ot.SubA(sum.Money, algos)

--- a/ledger/lruaccts.go
+++ b/ledger/lruaccts.go
@@ -73,7 +73,6 @@ func (m *lruAccounts) flushPendingWrites() {
 			return
 		}
 	}
-	return
 }
 
 // writePending write a single persistedAccountData entry to the pendingAccounts buffer.

--- a/ledger/onlinetopheap.go
+++ b/ledger/onlinetopheap.go
@@ -47,11 +47,7 @@ func (h *onlineTopHeap) Less(i, j int) bool {
 	}
 
 	bcmp := bytes.Compare(h.accts[i].Address[:], h.accts[j].Address[:])
-	if bcmp > 0 {
-		return true
-	}
-
-	return false
+	return bcmp > 0
 }
 
 // Swap implements sort.Interface

--- a/ledger/testing/accountsTotals.go
+++ b/ledger/testing/accountsTotals.go
@@ -27,13 +27,14 @@ import (
 )
 
 // CalculateNewRoundAccountTotals calculates the accounts totals for a given round
-func CalculateNewRoundAccountTotals(t *gotesting.T, newRoundDeltas ledgercore.AccountDeltas, newRoundRewardLevel uint64, newRoundConsensusParams config.ConsensusParams, prevRoundBalances map[basics.Address]basics.AccountData, prevRoundTotals ledgercore.AccountTotals) (newTotals ledgercore.AccountTotals) {
+func CalculateNewRoundAccountTotals(t *gotesting.T, newRoundDeltas ledgercore.NewAccountDeltas, newRoundRewardLevel uint64, newRoundConsensusParams config.ConsensusParams, prevRoundBalances map[basics.Address]basics.AccountData, prevRoundTotals ledgercore.AccountTotals) (newTotals ledgercore.AccountTotals) {
 	newTotals = prevRoundTotals
 	var ot basics.OverflowTracker
 	newTotals.ApplyRewards(newRoundRewardLevel, &ot)
 	for i := 0; i < newRoundDeltas.Len(); i++ {
 		addr, ad := newRoundDeltas.GetByIdx(i)
-		newTotals.DelAccount(newRoundConsensusParams, prevRoundBalances[addr], &ot)
+		prevBal := ledgercore.ToAccountData(prevRoundBalances[addr])
+		newTotals.DelAccount(newRoundConsensusParams, prevBal, &ot)
 		newTotals.AddAccount(newRoundConsensusParams, ad, &ot)
 	}
 	require.False(t, ot.Overflowed)

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -191,7 +191,7 @@ type deferredCommitRange struct {
 
 	isCatchpointRound bool
 
-	// catchpointWriting is a pointer to a varible with the same name in the catchpointTracker.
+	// catchpointWriting is a pointer to a variable with the same name in the catchpointTracker.
 	// it's used in order to reset the catchpointWriting flag from the acctupdates's
 	// prepareCommit/commitRound ( which is called before the corresponding catchpoint tracker method )
 	catchpointWriting *int32
@@ -207,7 +207,7 @@ type deferredCommitContext struct {
 
 	genesisProto config.ConsensusParams
 
-	deltas                 []ledgercore.AccountDeltas
+	deltas                 []ledgercore.NewAccountDeltas
 	roundTotals            ledgercore.AccountTotals
 	compactAccountDeltas   compactAccountDeltas
 	compactCreatableDeltas map[basics.CreatableIndex]ledgercore.ModifiedCreatable

--- a/ledger/voters.go
+++ b/ledger/voters.go
@@ -150,7 +150,7 @@ func (vt *votersTracker) loadTree(hdr bookkeeping.BlockHeader) {
 	return
 }
 
-// close waits until all the internal spawned go-rouines are done before returning, allowing clean
+// close waits until all the internal spawned go-routines are done before returning, allowing clean
 // shutdown.
 func (vt *votersTracker) close() {
 	vt.loadWaitGroup.Wait()


### PR DESCRIPTION
## Summary

Part 2 of `apply.balances` and `cow` changes. This PR introduces partial deltas (`NewAccountDelta`) and some glue to make it work with existing old schema. Most of this glue code must be removed when a new schema is enabled.

## Test Plan

- [x] Existing tests
- [x] Add `Total*` fields validation test
