### PR TITLE
Three new globals for to help contract-to-contract usability

### DIFF
--- a/data/transactions/logic/README.md
+++ b/data/transactions/logic/README.md
@@ -341,6 +341,9 @@ Global fields are fields that are common to all the transactions in the group. I
 | 9 | CreatorAddress | []byte | Address of the creator of the current application. Fails if no such application is executing. LogicSigVersion >= 3. |
 | 10 | CurrentApplicationAddress | []byte | Address that the current application controls. Fails in LogicSigs. LogicSigVersion >= 5. |
 | 11 | GroupID | []byte | ID of the transaction group. 32 zero bytes if the transaction is not part of a group. LogicSigVersion >= 5. |
+| 12 | OpcodeBudget | uint64 | The remaining cost that can be spent by opcodes in this program. LogicSigVersion >= 6. |
+| 13 | CallerApplicationID | uint64 | The application ID of the application that called this application. 0 if this application is at the top-level. LogicSigVersion >= 6. |
+| 14 | CallerApplicationAddress | []byte | The application address of the application that called this application. ZeroAddress if this application is at the top-level. LogicSigVersion >= 6. |
 
 
 **Asset Fields**

--- a/data/transactions/logic/TEAL_opcodes.md
+++ b/data/transactions/logic/TEAL_opcodes.md
@@ -524,6 +524,9 @@ FirstValidTime causes the program to fail. The field is reserved for future use.
 | 9 | CreatorAddress | []byte | Address of the creator of the current application. Fails if no such application is executing. LogicSigVersion >= 3. |
 | 10 | CurrentApplicationAddress | []byte | Address that the current application controls. Fails in LogicSigs. LogicSigVersion >= 5. |
 | 11 | GroupID | []byte | ID of the transaction group. 32 zero bytes if the transaction is not part of a group. LogicSigVersion >= 5. |
+| 12 | OpcodeBudget | uint64 | The remaining cost that can be spent by opcodes in this program. LogicSigVersion >= 6. |
+| 13 | CallerApplicationID | uint64 | The application ID of the application that called this application. 0 if this application is at the top-level. LogicSigVersion >= 6. |
+| 14 | CallerApplicationAddress | []byte | The application address of the application that called this application. ZeroAddress if this application is at the top-level. LogicSigVersion >= 6. |
 
 
 ## gtxn t f

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -1315,6 +1315,9 @@ global LatestTimestamp
 global CurrentApplicationID
 global CreatorAddress
 global GroupID
+global OpcodeBudget
+global CallerApplicationID
+global CallerApplicationAddress
 txn Sender
 txn Fee
 bnz label1

--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -463,6 +463,9 @@ var globalFieldDocs = map[string]string{
 	"CreatorAddress":            "Address of the creator of the current application. Fails if no such application is executing",
 	"CurrentApplicationAddress": "Address that the current application controls. Fails in LogicSigs",
 	"GroupID":                   "ID of the transaction group. 32 zero bytes if the transaction is not part of a group.",
+	"OpcodeBudget":              "The remaining cost that can be spent by opcodes in this program.",
+	"CallerApplicationID":       "The application ID of the application that called this application. 0 if this application is at the top-level.",
+	"CallerApplicationAddress":  "The application address of the application that called this application. ZeroAddress if this application is at the top-level.",
 }
 
 // GlobalFieldDocs are notes on fields available in `global` with extra versioning info if any

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -2636,6 +2636,22 @@ func (cx *EvalContext) globalFieldToValue(fs globalFieldSpec) (sv stackValue, er
 		sv.Bytes, err = cx.getCreatorAddress()
 	case GroupID:
 		sv.Bytes = cx.Txn.Txn.Group[:]
+	case OpcodeBudget:
+		sv.Uint = uint64(cx.budget() - cx.cost)
+	case CallerApplicationID:
+		if cx.caller != nil {
+			sv.Uint, err = cx.caller.getApplicationID()
+		} else {
+			sv.Uint = 0
+		}
+	case CallerApplicationAddress:
+		if cx.caller != nil {
+			var addr basics.Address
+			addr, err = cx.caller.getApplicationAddress()
+			sv.Bytes = addr[:]
+		} else {
+			sv.Bytes = zeroAddress[:]
+		}
 	default:
 		err = fmt.Errorf("invalid global field %d", fs.field)
 	}

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -2419,3 +2419,18 @@ func TestAppAddress(t *testing.T) {
 	source = fmt.Sprintf("int 0; app_params_get AppAddress; assert; addr %s; ==;", a)
 	testApp(t, source, ep)
 }
+
+func TestBudget(t *testing.T) {
+	ep, tx, ledger := makeSampleEnv()
+	ledger.NewApp(tx.Receiver, 888, basics.AppParams{})
+	source := `
+global OpcodeBudget
+int 699
+==
+assert
+global OpcodeBudget
+int 695
+==
+`
+	testApp(t, source, ep)
+}

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -930,7 +930,17 @@ byte 0x0706000000000000000000000000000000000000000000000000000000000000
 `
 
 const globalV6TestProgram = globalV5TestProgram + `
-// No new globals in v6
+global OpcodeBudget
+int 0
+>
+&&
+global CallerApplicationAddress
+global ZeroAddress
+==
+&&
+global CallerApplicationID
+!
+&&
 `
 
 func TestGlobal(t *testing.T) {
@@ -941,6 +951,7 @@ func TestGlobal(t *testing.T) {
 		lastField GlobalField
 		program   string
 	}
+	// Associate the highest allowed global constant with each version's test program
 	tests := map[uint64]desc{
 		0: {GroupSize, globalV1TestProgram},
 		1: {GroupSize, globalV1TestProgram},
@@ -948,10 +959,11 @@ func TestGlobal(t *testing.T) {
 		3: {CreatorAddress, globalV3TestProgram},
 		4: {CreatorAddress, globalV4TestProgram},
 		5: {GroupID, globalV5TestProgram},
-		6: {GroupID, globalV6TestProgram},
+		6: {CallerApplicationAddress, globalV6TestProgram},
 	}
 	// tests keys are versions so they must be in a range 1..AssemblerMaxVersion plus zero version
 	require.LessOrEqual(t, len(tests), AssemblerMaxVersion+1)
+	require.Len(t, globalFieldSpecs, int(invalidGlobalField))
 
 	ledger := MakeLedger(nil)
 	addr, err := basics.UnmarshalChecksumAddress(testAddr)
@@ -963,13 +975,13 @@ func TestGlobal(t *testing.T) {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			last := tests[v].lastField
 			testProgram := tests[v].program
-			for _, globalField := range GlobalFieldNames[:last] {
+			for _, globalField := range GlobalFieldNames[:last+1] {
 				if !strings.Contains(testProgram, globalField) {
 					t.Errorf("TestGlobal missing field %v", globalField)
 				}
 			}
 
-			var txn transactions.SignedTxn
+			txn := transactions.SignedTxn{}
 			txn.Txn.Group = crypto.Digest{0x07, 0x06}
 
 			proto := config.ConsensusParams{

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -1036,9 +1036,7 @@ int %s
 ==
 &&`, symbol, string(tt))
 					ops := testProg(t, text, v)
-					if v < appsEnabledVersion && tt == protocol.ApplicationCallTx {
-					}
-					var txn transactions.SignedTxn
+					txn := transactions.SignedTxn{}
 					txn.Txn.Type = tt
 					if v < appsEnabledVersion && tt == protocol.ApplicationCallTx {
 						testLogicBytes(t, ops.Program, defaultEvalParams(&txn),

--- a/data/transactions/logic/fields.go
+++ b/data/transactions/logic/fields.go
@@ -371,6 +371,17 @@ const (
 	// GroupID [32]byte
 	GroupID
 
+	// v6
+
+	// OpcodeBudget The remaining budget available for execution
+	OpcodeBudget
+
+	// CallerApplicationID
+	CallerApplicationID
+
+	// CallerApplicationAddress
+	CallerApplicationAddress
+
 	invalidGlobalField
 )
 
@@ -400,6 +411,9 @@ var globalFieldSpecs = []globalFieldSpec{
 	{CreatorAddress, StackBytes, runModeApplication, 3},
 	{CurrentApplicationAddress, StackBytes, runModeApplication, 5},
 	{GroupID, StackBytes, modeAny, 5},
+	{OpcodeBudget, StackUint64, runModeApplication, 6},
+	{CallerApplicationID, StackUint64, runModeApplication, 6},
+	{CallerApplicationAddress, StackBytes, runModeApplication, 6},
 }
 
 // GlobalFieldSpecByField maps GlobalField to spec

--- a/data/transactions/logic/fields.go
+++ b/data/transactions/logic/fields.go
@@ -376,10 +376,10 @@ const (
 	// OpcodeBudget The remaining budget available for execution
 	OpcodeBudget
 
-	// CallerApplicationID
+	// CallerApplicationID The ID of the caller app, else 0
 	CallerApplicationID
 
-	// CallerApplicationAddress
+	// CallerApplicationAddress The Address of the caller app, else ZeroAddress
 	CallerApplicationAddress
 
 	invalidGlobalField

--- a/data/transactions/logic/fields_string.go
+++ b/data/transactions/logic/fields_string.go
@@ -99,12 +99,15 @@ func _() {
 	_ = x[CreatorAddress-9]
 	_ = x[CurrentApplicationAddress-10]
 	_ = x[GroupID-11]
-	_ = x[invalidGlobalField-12]
+	_ = x[OpcodeBudget-12]
+	_ = x[CallerApplicationID-13]
+	_ = x[CallerApplicationAddress-14]
+	_ = x[invalidGlobalField-15]
 }
 
-const _GlobalField_name = "MinTxnFeeMinBalanceMaxTxnLifeZeroAddressGroupSizeLogicSigVersionRoundLatestTimestampCurrentApplicationIDCreatorAddressCurrentApplicationAddressGroupIDinvalidGlobalField"
+const _GlobalField_name = "MinTxnFeeMinBalanceMaxTxnLifeZeroAddressGroupSizeLogicSigVersionRoundLatestTimestampCurrentApplicationIDCreatorAddressCurrentApplicationAddressGroupIDOpcodeBudgetCallerApplicationIDCallerApplicationAddressinvalidGlobalField"
 
-var _GlobalField_index = [...]uint8{0, 9, 19, 29, 40, 49, 64, 69, 84, 104, 118, 143, 150, 168}
+var _GlobalField_index = [...]uint8{0, 9, 19, 29, 40, 49, 64, 69, 84, 104, 118, 143, 150, 162, 181, 205, 223}
 
 func (i GlobalField) String() string {
 	if i >= GlobalField(len(_GlobalField_index)-1) {

--- a/ledger/internal/apptxn_test.go
+++ b/ledger/internal/apptxn_test.go
@@ -475,7 +475,8 @@ func TestClawbackAction(t *testing.T) {
 		Accounts:      []basics.Address{addrs[0], addrs[1]},
 	}
 	eval = nextBlock(t, l, true, nil)
-	txgroup(t, l, eval, &overpay, &clawmove)
+	err := txgroup(t, l, eval, &overpay, &clawmove)
+	require.NoError(t, err)
 	endBlock(t, l, eval)
 
 	amount, _ := holding(t, l, addrs[1], asaIndex)


### PR DESCRIPTION
Globals for opcode budget remaining, and info about calling application.
