### PR TITLE
Global.LatestTimestamp is NOT available in LogicSig contracts

### DIFF
--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -454,7 +454,7 @@ var globalFieldDocs = map[string]string{
 	"GroupSize":                 "Number of transactions in this atomic transaction group. At least 1",
 	"LogicSigVersion":           "Maximum supported TEAL version",
 	"Round":                     "Current round number",
-	"LatestTimestamp":           "Last confirmed block UNIX timestamp. Fails if negative",
+	"LatestTimestamp":           "Last confirmed block UNIX timestamp. Fails if negative or in LogicSigs",
 	"CurrentApplicationID":      "ID of current application executing. Fails in LogicSigs",
 	"CreatorAddress":            "Address of the creator of the current application. Fails if no such application is executing",
 	"CurrentApplicationAddress": "Address that the current application controls. Fails in LogicSigs",


### PR DESCRIPTION
Any contract attempting to use Global.LatestTimestamp opCode will receive the following error from the network node with a 400 status:

```
global[7] not allowed in current mode
```

Looks like this will be resolved in the future, but for now I don't believe devs should be left thinking they can use this opcode.
https://github.com/algorand/go-algorand/pull/2789

Thank you @barnjamin for pointing me to the correct repo
