### PR TITLE
ledger refactoring: refactor NormalizedOnlineBalance

### DIFF
--- a/data/basics/userBalance.go
+++ b/data/basics/userBalance.go
@@ -553,25 +553,48 @@ func (u AccountData) IsZero() bool {
 // compounding).  However, online accounts have to periodically renew
 // participation keys, so the scale of the inconsistency is small.
 func (u AccountData) NormalizedOnlineBalance(proto config.ConsensusParams) uint64 {
-	if u.Status != Online {
+	return NormalizedOnlineAccountBalance(u.Status, u.RewardsBase, u.MicroAlgos, proto)
+}
+
+// NormalizedOnlineAccountBalance returns a ``normalized'' balance for an account
+// with the given parameters.
+//
+// The normalization compensates for rewards that have not yet been applied,
+// by computing a balance normalized to round 0.  To normalize, we estimate
+// the microalgo balance that an account should have had at round 0, in order
+// to end up at its current balance when rewards are included.
+//
+// The benefit of the normalization procedure is that an account's normalized
+// balance does not change over time (unlike the actual algo balance that includes
+// rewards).  This makes it possible to compare normalized balances between two
+// accounts, to sort them, and get results that are close to what we would get
+// if we computed the exact algo balance of the accounts at a given round number.
+//
+// The normalization can lead to some inconsistencies in comparisons between
+// account balances, because the growth rate of rewards for accounts depends
+// on how recently the account has been touched (our rewards do not implement
+// compounding).  However, online accounts have to periodically renew
+// participation keys, so the scale of the inconsistency is small.
+func NormalizedOnlineAccountBalance(status Status, rewardsBase uint64, microAlgos MicroAlgos, proto config.ConsensusParams) uint64 {
+	if status != Online {
 		return 0
 	}
 
 	// If this account had one RewardUnit of microAlgos in round 0, it would
 	// have perRewardUnit microAlgos at the account's current rewards level.
-	perRewardUnit := u.RewardsBase + proto.RewardUnit
+	perRewardUnit := rewardsBase + proto.RewardUnit
 
 	// To normalize, we compute, mathematically,
 	// u.MicroAlgos / perRewardUnit * proto.RewardUnit, as
 	// (u.MicroAlgos * proto.RewardUnit) / perRewardUnit.
-	norm, overflowed := Muldiv(u.MicroAlgos.ToUint64(), proto.RewardUnit, perRewardUnit)
+	norm, overflowed := Muldiv(microAlgos.ToUint64(), proto.RewardUnit, perRewardUnit)
 
 	// Mathematically should be impossible to overflow
 	// because perRewardUnit >= proto.RewardUnit, as long
 	// as u.RewardBase isn't huge enough to cause overflow..
 	if overflowed {
 		logging.Base().Panicf("overflow computing normalized balance %d * %d / (%d + %d)",
-			u.MicroAlgos.ToUint64(), proto.RewardUnit, u.RewardsBase, proto.RewardUnit)
+			microAlgos.ToUint64(), proto.RewardUnit, rewardsBase, proto.RewardUnit)
 	}
 
 	return norm


### PR DESCRIPTION
## Summary

extract the logic of NormalizedOnlineBalance into NormalizedOnlineAccountBalance.
The change is quite benign, but would allow future PRs to complete the calculation of the normalized balance without having an AccountData object.

## Test Plan

Use existing unit tests.
