### PR TITLE
Disable parallelism for e2e-go tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,6 @@ commands:
             export PACKAGE_NAMES=$(echo $PACKAGES | tr -d '\n')
             export PARTITION_TOTAL=${CIRCLE_NODE_TOTAL}
             export PARTITION_ID=${CIRCLE_NODE_INDEX}
-            export PARALLEL_FLAG="-p 1"
             gotestsum --format testname --junitfile << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml --jsonfile << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" << parameters.short_test_flag >> -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 1 $PACKAGE_NAMES
       - store_artifacts:
           path: << parameters.result_path >>
@@ -432,6 +431,7 @@ commands:
             export TEST_RESULTS=<< parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
             export PARTITION_TOTAL=${CIRCLE_NODE_TOTAL}
             export PARTITION_ID=${CIRCLE_NODE_INDEX}
+            export PARALLEL_FLAG="-p 1"
             test/scripts/run_integration_tests.sh
       - store_artifacts:
           path: << parameters.result_path >>

--- a/test/scripts/e2e_go_tests.sh
+++ b/test/scripts/e2e_go_tests.sh
@@ -101,7 +101,6 @@ cd ${SRCROOT}/test/e2e-go
 
 # ARM64 has some memory related issues with fork. Since we don't really care
 # about testing the forking capabilities, we're just run the tests one at a time.
-PARALLEL_FLAG=""
 ARCHTYPE=$("${SRCROOT}/scripts/archtype.sh")
 echo "ARCHTYPE:    ${ARCHTYPE}"
 if [[ "${ARCHTYPE}" = arm* ]]; then


### PR DESCRIPTION
## Summary

This sets `-p 1` for the e2e-go tests, intended to make them more deterministic when running on a VM with relatively constrained resources. Since each e2e-go test might spin up a few nodes, it seems like it would help to avoid resource contention.

## Test Plan

Tests should run as before. Desired effect can be verified by looking at the test output where the value of PARALLEL_FLAG is printed out before tests are run.