### PR TITLE
Adding libtool to ubuntu deps

### DIFF
--- a/scripts/install_linux_deps.sh
+++ b/scripts/install_linux_deps.sh
@@ -5,7 +5,7 @@ set -e
 DISTRIB=$ID
 
 ARCH_DEPS="boost boost-libs expect jq autoconf shellcheck sqlite python-virtualenv"
-UBUNTU_DEPS="libboost-math-dev expect jq autoconf shellcheck sqlite3 python3-venv"
+UBUNTU_DEPS="libtool libboost-math-dev expect jq autoconf shellcheck sqlite3 python3-venv"
 FEDORA_DEPS="boost-devel expect jq autoconf ShellCheck sqlite python-virtualenv"
 
 if [ "${DISTRIB}" = "arch" ]; then


### PR DESCRIPTION
## Summary

The sandbox is not building with dev config using master branch https://github.com/algorand/sandbox/issues/85, complains about libtool not being installed

Guessing from this change https://github.com/algorand/go-algorand/pull/3223 

Adding libtool to UBUNTU_DEPS in install scripts

## Test Plan

Set config in sandbox to my branch
`sandbox up dev`
It built
