### PR TITLE
Make dev-mode tests less flaky.

### DIFF
--- a/test/e2e-go/features/devmode/devmode_test.go
+++ b/test/e2e-go/features/devmode/devmode_test.go
@@ -37,12 +37,11 @@ func TestDevMode(t *testing.T) {
 		t.Skip()
 	}
 
-	t.Parallel()
-
 	// Start devmode network, and make sure everything is primed by sending a transaction.
 	var fixture fixtures.RestClientFixture
 	fixture.SetupNoStart(t, filepath.Join("nettemplates", "DevModeNetwork.json"))
 	fixture.Start()
+	defer fixture.Shutdown()
 	sender, err := fixture.GetRichestAccount()
 	require.NoError(t, err)
 	key := crypto.GenerateSignatureSecrets(crypto.Seed{})
@@ -56,7 +55,7 @@ func TestDevMode(t *testing.T) {
 		txn = fixture.SendMoneyAndWait(firstRound+i, 100000, 1000, sender.Address, receiver.String(), "")
 		require.Equal(t, firstRound+i, txn.FirstRound)
 	}
-	require.True(t, time.Since(start) < 2*time.Second, "Transactions should be quickly confirmed.")
+	require.True(t, time.Since(start) < 8*time.Second, "Transactions should be quickly confirmed faster than usual.")
 
 	// Without transactions there should be no rounds even after a normal confirmation time.
 	time.Sleep(10 * time.Second)

--- a/test/e2e-go/features/participation/accountParticipationTransitions_test.go
+++ b/test/e2e-go/features/participation/accountParticipationTransitions_test.go
@@ -21,11 +21,14 @@ package participation
 // deterministic.
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
@@ -75,12 +78,21 @@ func TestKeyRegistration(t *testing.T) {
 		t.Skip()
 	}
 
-	t.Parallel()
+	checkKey := func(key generated.ParticipationKey, firstValid, lastValid, lastProposal uint64, msg string) {
+		require.NotNil(t, key.EffectiveFirstValid, fmt.Sprintf("%s.EffectiveFirstValid", msg))
+		require.NotNil(t, key.EffectiveLastValid, fmt.Sprintf("%s.EffectiveLastValid", msg))
+		require.NotNil(t, key.LastBlockProposal, fmt.Sprintf("%s.LastBlockProposal", msg))
+
+		assert.Equal(t, int(*(key.EffectiveFirstValid)), int(firstValid), fmt.Sprintf("%s.EffectiveFirstValid", msg))
+		assert.Equal(t, int(*(key.EffectiveLastValid)), int(lastValid), fmt.Sprintf("%s.EffectiveLastValid", msg))
+		assert.Equal(t, int(*(key.LastBlockProposal)), int(lastProposal), fmt.Sprintf("%s.LastBlockProposal", msg))
+	}
 
 	// Start devmode network and initialize things for the test.
 	var fixture fixtures.RestClientFixture
 	fixture.SetupNoStart(t, filepath.Join("nettemplates", "DevModeOneWallet.json"))
 	fixture.Start()
+	defer fixture.Shutdown()
 	sClient := fixture.GetLibGoalClientForNamedNode("Node")
 	minTxnFee, _, err := fixture.MinFeeAndBalance(0)
 	require.NoError(t, err)
@@ -92,7 +104,7 @@ func TestKeyRegistration(t *testing.T) {
 	last := uint64(6_000_000)
 	numNew := 2
 	for i := 0; i < numNew; i++ {
-		response, part, err := installParticipationKey(t, sClient, sAccount, 0, last)
+		response, part, err := installParticipationKey(t, sClient, sAccount, 0, last + uint64(i))
 		require.NoError(t, err)
 		require.NotNil(t, response)
 		registerParticipationAndWait(t, sClient, part)
@@ -111,16 +123,41 @@ func TestKeyRegistration(t *testing.T) {
 		fixture.SendMoneyAndWait(2+i, 0, minTxnFee, sAccount, sAccount, "")
 	}
 
-	keys, err = fixture.LibGoalClient.GetParticipationKeys()
-	require.Equal(t, *(keys[0].EffectiveFirstValid), uint64(1))
-	require.Equal(t, *(keys[0].EffectiveLastValid), lookback)
-	require.Equal(t, *(keys[0].LastBlockProposal), lookback)
+	// Wait until data has been persisted
+	ready := false
+	waitfor := time.After(1 * time.Minute)
+	for !ready {
+		select {
+		case <-waitfor:
+			ready = true
+		default:
+			keys, err = fixture.LibGoalClient.GetParticipationKeys()
+			ready = (len(keys) >= 3) &&
+				(keys[2].LastBlockProposal != nil) &&
+				(keys[2].EffectiveFirstValid != nil) &&
+				(keys[2].EffectiveLastValid != nil) &&
+				(keys[1].LastBlockProposal != nil) &&
+				(keys[1].EffectiveFirstValid != nil) &&
+				(keys[1].EffectiveLastValid != nil) &&
+				(keys[0].LastBlockProposal != nil) &&
+				(keys[0].EffectiveFirstValid != nil) &&
+				(keys[0].EffectiveLastValid != nil)
+			if !ready {
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+	}
 
-	require.Equal(t, *(keys[1].EffectiveFirstValid), lookback+1)
-	require.Equal(t, *(keys[1].EffectiveLastValid), lookback+1)
-	require.Equal(t, *(keys[1].LastBlockProposal), lookback+1)
-
-	require.Equal(t, *(keys[2].EffectiveFirstValid), lookback+2)
-	require.Equal(t, *(keys[2].EffectiveLastValid), last)
-	require.Equal(t, *(keys[2].LastBlockProposal), lookback+2)
+	// Verify results, order may vary, key off of the last valid field
+	require.Len(t, keys, 3)
+	for _, k := range keys {
+		switch k.Key.VoteLastValid {
+		case 3_000_000:
+			checkKey(k, 1, lookback, lookback, "keys[0]")
+		case last:
+			checkKey(k, lookback+1, lookback+1, lookback+1, "keys[1]")
+		case last+1:
+			checkKey(k, lookback+2, last+1, lookback+2, "keys[2]")
+		}
+	}
 }

--- a/test/e2e-go/features/participation/accountParticipationTransitions_test.go
+++ b/test/e2e-go/features/participation/accountParticipationTransitions_test.go
@@ -104,7 +104,7 @@ func TestKeyRegistration(t *testing.T) {
 	last := uint64(6_000_000)
 	numNew := 2
 	for i := 0; i < numNew; i++ {
-		response, part, err := installParticipationKey(t, sClient, sAccount, 0, last + uint64(i))
+		response, part, err := installParticipationKey(t, sClient, sAccount, 0, last+uint64(i))
 		require.NoError(t, err)
 		require.NotNil(t, response)
 		registerParticipationAndWait(t, sClient, part)
@@ -156,7 +156,7 @@ func TestKeyRegistration(t *testing.T) {
 			checkKey(k, 1, lookback, lookback, "keys[0]")
 		case last:
 			checkKey(k, lookback+1, lookback+1, lookback+1, "keys[1]")
-		case last+1:
+		case last + 1:
 			checkKey(k, lookback+2, last+1, lookback+2, "keys[2]")
 		}
 	}


### PR DESCRIPTION
## Summary

Fix a couple flaws in the new go-e2e tests built ontop of DevMode:
* Shutdown the fixture when finished.
* Don't run in parallel.
* Longer delays / better algorithms to wait for data flushing to complete.
* Check for "out of order" keys.

## Test Plan

N/A, this is a test.