### PR TITLE
Fix error shadowing in Eval

### DIFF
--- a/ledger/internal/eval.go
+++ b/ledger/internal/eval.go
@@ -1403,7 +1403,7 @@ transactionGroupLoop:
 			if !ok {
 				break transactionGroupLoop
 			} else if txgroup.err != nil {
-				return ledgercore.StateDelta{}, err
+				return ledgercore.StateDelta{}, txgroup.err
 			}
 
 			for _, br := range txgroup.balances {


### PR DESCRIPTION
## Summary

Error from account preloading was shadowed by returning a wrong err variable. This caused subsequent problems in account updates and masked the original failure.

## Test Plan

Use existing tests