### PR TITLE
ParticipationRegistry - StateProof loading methods

### DIFF
--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -192,8 +192,8 @@ type ParticipationRegistry interface {
 	// GetAll of the participation records.
 	GetAll() []ParticipationRecord
 
-	// GetWithSecrets fetches a record with all secrets for a particular round.
-	GetWithSecrets(id ParticipationID, round basics.Round) (ParticipationRecordForRound, error)
+	// GetForRound fetches a record with all secrets for a particular round.
+	GetForRound(id ParticipationID, round basics.Round) (ParticipationRecordForRound, error)
 
 	// Register updates the EffectiveFirst and EffectiveLast fields. If there are multiple records for the account
 	// then it is possible for multiple records to be updated.
@@ -863,8 +863,8 @@ func (db *participationDB) GetAll() []ParticipationRecord {
 	return results
 }
 
-// GetWithSecrets fetches a record with all secrets for a particular round.
-func (db *participationDB) GetWithSecrets(id ParticipationID, round basics.Round) (ParticipationRecordForRound, error) {
+// GetForRound fetches a record with all secrets for a particular round.
+func (db *participationDB) GetForRound(id ParticipationID, round basics.Round) (ParticipationRecordForRound, error) {
 	var result ParticipationRecordForRound
 	result.ParticipationRecord = db.Get(id)
 	if result.ParticipationRecord.IsZero() {

--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -297,7 +297,7 @@ const (
 		FROM Keysets k
 		INNER JOIN Rolling r
 		ON k.pk = r.pk`
-	selectStateProofKeys   = `SELECT s.key
+	selectStateProofKeys = `SELECT s.key
 		FROM StateProofKeys s
 		WHERE round=?
 		   AND pk IN (SELECT pk FROM Keysets WHERE participationID=?)`
@@ -703,14 +703,11 @@ func (db *participationDB) AppendKeys(id ParticipationID, keys map[uint64]StateP
 		keyCopy[k] = v // PKI TODO: Deep copy?
 	}
 
-	// Write to the DB asynchronously.
+	// Update the DB asynchronously.
 	db.writeQueue <- partDBWriteRecord{
 		insertID: id,
 		keys:     keyCopy,
 	}
-
-	// Keys not stored in cache, no more work to do.
-
 	return nil
 }
 

--- a/data/account/participationRegistryBench_test.go
+++ b/data/account/participationRegistryBench_test.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package account
 
 import (

--- a/data/account/participationRegistryBench_test.go
+++ b/data/account/participationRegistryBench_test.go
@@ -1,0 +1,64 @@
+package account
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/util/db"
+)
+
+func benchmarkKeyRegistration(numKeys int, b *testing.B) {
+	// setup
+	rootDB, err := db.OpenPair(b.Name(), true)
+	if err != nil {
+		b.Fail()
+	}
+	registry, err := makeParticipationRegistry(rootDB, logging.TestingLog(b))
+	if err != nil {
+		b.Fail()
+	}
+
+	// Insert records so that we can t
+	b.Run(fmt.Sprintf("KeyInsert_%d", numKeys), func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			for key := 0; key < numKeys; key++ {
+				p := makeTestParticipation(key, basics.Round(0), basics.Round(1000000), 3)
+				registry.Insert(p)
+			}
+		}
+	})
+
+	// The first call to Register updates the DB.
+	b.Run(fmt.Sprintf("KeyRegistered_%d", numKeys), func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			for key := 0; key < numKeys; key++ {
+				p := makeTestParticipation(key, basics.Round(0), basics.Round(1000000), 3)
+
+				// Unfortunately we need to repeatedly clear out the registration fields to ensure the
+				// db update runs each time this is called.
+				record := registry.cache[p.ID()]
+				record.EffectiveFirst = 0
+				record.EffectiveLast = 0
+				registry.cache[p.ID()] = record
+				registry.Register(p.ID(), 50)
+			}
+		}
+	})
+
+	// The keys should now be updated, so Register is a no-op.
+	b.Run(fmt.Sprintf("NoOp_%d", numKeys), func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			for key := 0; key < numKeys; key++ {
+				p := makeTestParticipation(key, basics.Round(0), basics.Round(1000000), 3)
+				registry.Register(p.ID(), 50)
+			}
+		}
+	})
+}
+
+func BenchmarkKeyRegistration1(b *testing.B)  { benchmarkKeyRegistration(1, b) }
+func BenchmarkKeyRegistration5(b *testing.B)  { benchmarkKeyRegistration(5, b) }
+func BenchmarkKeyRegistration10(b *testing.B) { benchmarkKeyRegistration(10, b) }
+func BenchmarkKeyRegistration50(b *testing.B) { benchmarkKeyRegistration(50, b) }

--- a/data/account/participationRegistry_test.go
+++ b/data/account/participationRegistry_test.go
@@ -749,7 +749,7 @@ func TestAddStateProofKeys(t *testing.T) {
 
 	// Make sure we're able to fetch the same data that was put in.
 	for i := uint64(0); i <= max; i++ {
-		r, err := registry.GetWithSecrets(id, basics.Round(i))
+		r, err := registry.GetForRound(id, basics.Round(i))
 		a.NoError(err)
 		a.Equal(keys[i], r.StateProof)
 		number := binary.LittleEndian.Uint64(r.StateProof)
@@ -769,7 +769,7 @@ func TestSecretNotFound(t *testing.T) {
 	a.NoError(err)
 	a.Equal(p.ID(), id)
 
-	r, err := registry.GetWithSecrets(id, basics.Round(100))
+	r, err := registry.GetForRound(id, basics.Round(100))
 
 	a.True(r.IsZero())
 	a.Error(err)

--- a/data/account/participationRegistry_test.go
+++ b/data/account/participationRegistry_test.go
@@ -433,6 +433,7 @@ func TestParticipation_RecordMultipleUpdates_DB(t *testing.T) {
 				record.FirstValid,
 				record.LastValid,
 				record.KeyDilution,
+				nil,
 				nil)
 			if err != nil {
 				return fmt.Errorf("unable to insert keyset: %w", err)
@@ -714,56 +715,63 @@ func TestFlushDeadlock(t *testing.T) {
 	wg.Wait()
 }
 
-func benchmarkKeyRegistration(numKeys int, b *testing.B) {
-	// setup
-	rootDB, err := db.OpenPair(b.Name(), true)
-	if err != nil {
-		b.Fail()
+func TestAddStateProofKeys(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := assert.New(t)
+	registry := getRegistry(t)
+	defer registryCloseTest(t, registry)
+
+	// Install a key to add StateProof keys.
+	max := uint64(1000)
+	p := makeTestParticipation(1, 0, basics.Round(max), 3)
+	id, err := registry.Insert(p)
+	a.NoError(err)
+	a.Equal(p.ID(), id)
+
+	// Wait for async DB operations to finish.
+	err = registry.Flush(10 * time.Second)
+	a.NoError(err)
+
+	// Initialize keys array.
+	keys := make(map[uint64]StateProofKey)
+	for i := uint64(0); i <= max; i++ {
+		bs := make([]byte, 8)
+		binary.LittleEndian.PutUint64(bs, i)
+		keys[i] = bs
 	}
-	registry, err := makeParticipationRegistry(rootDB, logging.TestingLog(b))
-	if err != nil {
-		b.Fail()
+
+	err = registry.AppendKeys(id, keys)
+	a.NoError(err)
+
+	// Wait for async DB operations to finish.
+	err = registry.Flush(10 * time.Second)
+	a.NoError(err)
+
+	// Make sure we're able to fetch the same data that was put in.
+	for i := uint64(0); i <= max; i++ {
+		r, err := registry.GetWithSecrets(id, basics.Round(i))
+		a.NoError(err)
+		a.Equal(keys[i], r.StateProof)
+		number := binary.LittleEndian.Uint64(r.StateProof)
+		a.Equal(i, number)
 	}
-
-	// Insert records so that we can t
-	b.Run(fmt.Sprintf("KeyInsert_%d", numKeys), func(b *testing.B) {
-		for n := 0; n < b.N; n++ {
-			for key := 0; key < numKeys; key++ {
-				p := makeTestParticipation(key, basics.Round(0), basics.Round(1000000), 3)
-				registry.Insert(p)
-			}
-		}
-	})
-
-	// The first call to Register updates the DB.
-	b.Run(fmt.Sprintf("KeyRegistered_%d", numKeys), func(b *testing.B) {
-		for n := 0; n < b.N; n++ {
-			for key := 0; key < numKeys; key++ {
-				p := makeTestParticipation(key, basics.Round(0), basics.Round(1000000), 3)
-
-				// Unfortunately we need to repeatedly clear out the registration fields to ensure the
-				// db update runs each time this is called.
-				record := registry.cache[p.ID()]
-				record.EffectiveFirst = 0
-				record.EffectiveLast = 0
-				registry.cache[p.ID()] = record
-				registry.Register(p.ID(), 50)
-			}
-		}
-	})
-
-	// The keys should now be updated, so Register is a no-op.
-	b.Run(fmt.Sprintf("NoOp_%d", numKeys), func(b *testing.B) {
-		for n := 0; n < b.N; n++ {
-			for key := 0; key < numKeys; key++ {
-				p := makeTestParticipation(key, basics.Round(0), basics.Round(1000000), 3)
-				registry.Register(p.ID(), 50)
-			}
-		}
-	})
 }
 
-func BenchmarkKeyRegistration1(b *testing.B)  { benchmarkKeyRegistration(1, b) }
-func BenchmarkKeyRegistration5(b *testing.B)  { benchmarkKeyRegistration(5, b) }
-func BenchmarkKeyRegistration10(b *testing.B) { benchmarkKeyRegistration(10, b) }
-func BenchmarkKeyRegistration50(b *testing.B) { benchmarkKeyRegistration(50, b) }
+func TestSecretNotFound(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := assert.New(t)
+	registry := getRegistry(t)
+	defer registryCloseTest(t, registry)
+
+	// Install a key for testing
+	p := makeTestParticipation(1, 0, 2, 3)
+	id, err := registry.Insert(p)
+	a.NoError(err)
+	a.Equal(p.ID(), id)
+
+	r, err := registry.GetWithSecrets(id, basics.Round(100))
+
+	a.True(r.IsZero())
+	a.Error(err)
+	a.ErrorIs(err, ErrSecretNotFound)
+}

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31 h1:OXcKh35JaYsGMRzpvFkLv/MEyPuL49CThT1pZ8aSml4=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=


### PR DESCRIPTION
## Summary

Add ParticipationRegistry methods for setting and retrieving state proof keys. Since they aren't in master yet there is a `type StateProofKey []byte` stub which will need to be updated later.
 
## Test Plan

New unit tests.