### PR TITLE
signer.KeyDilution need not depend on config package

### DIFF
--- a/agreement/cryptoVerifier_test.go
+++ b/agreement/cryptoVerifier_test.go
@@ -72,7 +72,7 @@ func makeUnauthenticatedVote(l Ledger, sender basics.Address, selection *crypto.
 
 	m, _ := membership(l, rv.Sender, rv.Round, rv.Period, rv.Step)
 	cred := committee.MakeCredential(&selection.SK, m.Selector)
-	ephID := basics.OneTimeIDForRound(rv.Round, voting.KeyDilution(config.Consensus[protocol.ConsensusCurrentVersion]))
+	ephID := basics.OneTimeIDForRound(rv.Round, voting.KeyDilution(config.Consensus[protocol.ConsensusCurrentVersion].DefaultKeyDilution))
 	sig := voting.Sign(ephID, rv)
 
 	return unauthenticatedVote{

--- a/agreement/vote.go
+++ b/agreement/vote.go
@@ -172,7 +172,7 @@ func makeVote(rv rawVote, voting crypto.OneTimeSigner, selection *crypto.VRFSecr
 		}
 	}
 
-	ephID := basics.OneTimeIDForRound(rv.Round, voting.KeyDilution(proto))
+	ephID := basics.OneTimeIDForRound(rv.Round, voting.KeyDilution(proto.DefaultKeyDilution))
 	sig := voting.Sign(ephID, rv)
 	if (sig == crypto.OneTimeSignature{}) {
 		return unauthenticatedVote{}, fmt.Errorf("makeVote: got back empty signature for vote")

--- a/crypto/onetimesig.go
+++ b/crypto/onetimesig.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 
 	"github.com/algorand/go-deadlock"
-
-	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 )
@@ -432,10 +430,10 @@ type OneTimeSigner struct {
 }
 
 // KeyDilution returns the appropriate key dilution value for a OneTimeSigner.
-func (ots OneTimeSigner) KeyDilution(params config.ConsensusParams) uint64 {
+func (ots OneTimeSigner) KeyDilution(defaultKeyDilution uint64 ) uint64 {
 	if ots.OptionalKeyDilution != 0 {
 		return ots.OptionalKeyDilution
 	}
 
-	return params.DefaultKeyDilution
+	return defaultKeyDilution
 }

--- a/crypto/onetimesig.go
+++ b/crypto/onetimesig.go
@@ -20,9 +20,9 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/algorand/go-deadlock"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-deadlock"
 )
 
 // A OneTimeSignature is a cryptographic signature that is produced a limited
@@ -430,7 +430,7 @@ type OneTimeSigner struct {
 }
 
 // KeyDilution returns the appropriate key dilution value for a OneTimeSigner.
-func (ots OneTimeSigner) KeyDilution(defaultKeyDilution uint64 ) uint64 {
+func (ots OneTimeSigner) KeyDilution(defaultKeyDilution uint64) uint64 {
 	if ots.OptionalKeyDilution != 0 {
 		return ots.OptionalKeyDilution
 	}

--- a/node/netprio.go
+++ b/node/netprio.go
@@ -97,7 +97,7 @@ func (node *AlgorandFullNode) MakePrioResponse(challenge string) []byte {
 	}
 
 	signer := maxPart.VotingSigner()
-	ephID := basics.OneTimeIDForRound(voteRound, signer.KeyDilution(proto))
+	ephID := basics.OneTimeIDForRound(voteRound, signer.KeyDilution(proto.DefaultKeyDilution))
 
 	rs.Round = voteRound
 	rs.Sender = maxPart.Address()


### PR DESCRIPTION
## Summary
crypto package need not depend on config.
There is an unnecessary dependency on config.

signer.KeyDilution takes the `config.ConsensusParams` as argument to pick the DefaultKeyDilution from it. 
This introduces dependency from the crypto package to config package. 
Instead, only the DefaultKeyDilution value can be passed to signer.KeyDilution.

## Test Plan
No impact on testing. 
