### PR TITLE
testing: fix a data race in app tests

### DIFF
--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -34,7 +34,10 @@ import (
 )
 
 func commitRound(offset uint64, dbRound basics.Round, l *Ledger) {
+	l.trackers.mu.Lock()
 	l.trackers.lastFlushTime = time.Time{}
+	l.trackers.mu.Unlock()
+
 	l.trackers.scheduleCommit(l.Latest(), l.Latest()-(dbRound+basics.Round(offset)))
 	l.trackers.waitAccountsWriting()
 }


### PR DESCRIPTION
## Summary

A test helper function `commitRound` accessed `l.trackers.lastFlushTime` without taking a lock. Fixed.

## Test Plan

```
go test ./ledger -run TestAppEmpty -race -count=50
ok      github.com/algorand/go-algorand/ledger  4.078s
```