### PR TITLE
Support reference types in `goal app method`

### DIFF
--- a/cmd/goal/application.go
+++ b/cmd/goal/application.go
@@ -1113,16 +1113,16 @@ func populateMethodCallReferenceArgs(sender string, currentApp uint64, types []s
 				}
 			}
 		case abi.ApplicationReferenceType:
-			appId, err := strconv.ParseUint(value, 10, 64)
+			appID, err := strconv.ParseUint(value, 10, 64)
 			if err != nil {
 				return nil, fmt.Errorf("Unable to parse application ID '%s': %s", value, err)
 			}
-			if appId == currentApp {
+			if appID == currentApp {
 				resolved = 0
 			} else {
 				duplicate := false
 				for j, app := range *apps {
-					if appId == app {
+					if appID == app {
 						resolved = j + 1 // + 1 because 0 is the current app
 						duplicate = true
 						break
@@ -1130,17 +1130,17 @@ func populateMethodCallReferenceArgs(sender string, currentApp uint64, types []s
 				}
 				if !duplicate {
 					resolved = len(*apps) + 1
-					*apps = append(*apps, appId)
+					*apps = append(*apps, appID)
 				}
 			}
 		case abi.AssetReferenceType:
-			assetId, err := strconv.ParseUint(value, 10, 64)
+			assetID, err := strconv.ParseUint(value, 10, 64)
 			if err != nil {
 				return nil, fmt.Errorf("Unable to parse asset ID '%s': %s", value, err)
 			}
 			duplicate := false
 			for j, asset := range *assets {
-				if assetId == asset {
+				if assetID == asset {
 					resolved = j
 					duplicate = true
 					break
@@ -1148,7 +1148,7 @@ func populateMethodCallReferenceArgs(sender string, currentApp uint64, types []s
 			}
 			if !duplicate {
 				resolved = len(*assets)
-				*assets = append(*assets, assetId)
+				*assets = append(*assets, assetID)
 			}
 		default:
 			return nil, fmt.Errorf("Unknown reference type: %s", types[i])

--- a/cmd/goal/application.go
+++ b/cmd/goal/application.go
@@ -1074,7 +1074,7 @@ func populateMethodCallTxnArgs(types []string, values []string) ([]transactions.
 		}
 
 		expectedType := types[i]
-		if expectedType != "txn" && txn.Txn.Type != protocol.TxType(expectedType) {
+		if expectedType != abi.AnyTransactionType && txn.Txn.Type != protocol.TxType(expectedType) {
 			return nil, fmt.Errorf("Transaction from %s does not match method argument type. Expected %s, got %s", txFilename, expectedType, txn.Txn.Type)
 		}
 
@@ -1082,6 +1082,82 @@ func populateMethodCallTxnArgs(types []string, values []string) ([]transactions.
 	}
 
 	return loadedTxns, nil
+}
+
+// populateMethodCallReferenceArgs parses reference argument types and resolves them to an index
+// into the appropriate foreign array. Their placement will be as compact as possible, which means
+// values will be deduplicated and any value that is the sender or the current app will not be added
+// to the foreign array.
+func populateMethodCallReferenceArgs(sender string, currentApp uint64, types []string, values []string, accounts *[]string, apps *[]uint64, assets *[]uint64) ([]int, error) {
+	resolvedIndexes := make([]int, len(types))
+
+	for i, value := range values {
+		var resolved int
+
+		switch types[i] {
+		case abi.AccountReferenceType:
+			if value == sender {
+				resolved = 0
+			} else {
+				duplicate := false
+				for j, account := range *accounts {
+					if value == account {
+						resolved = j + 1 // + 1 because 0 is the sender
+						duplicate = true
+						break
+					}
+				}
+				if !duplicate {
+					resolved = len(*accounts) + 1
+					*accounts = append(*accounts, value)
+				}
+			}
+		case abi.ApplicationReferenceType:
+			appId, err := strconv.ParseUint(value, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("Unable to parse application ID '%s': %s", value, err)
+			}
+			if appId == currentApp {
+				resolved = 0
+			} else {
+				duplicate := false
+				for j, app := range *apps {
+					if appId == app {
+						resolved = j + 1 // + 1 because 0 is the current app
+						duplicate = true
+						break
+					}
+				}
+				if !duplicate {
+					resolved = len(*apps) + 1
+					*apps = append(*apps, appId)
+				}
+			}
+		case abi.AssetReferenceType:
+			assetId, err := strconv.ParseUint(value, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("Unable to parse asset ID '%s': %s", value, err)
+			}
+			duplicate := false
+			for j, asset := range *assets {
+				if assetId == asset {
+					resolved = j
+					duplicate = true
+					break
+				}
+			}
+			if !duplicate {
+				resolved = len(*assets)
+				*assets = append(*assets, assetId)
+			}
+		default:
+			return nil, fmt.Errorf("Unknown reference type: %s", types[i])
+		}
+
+		resolvedIndexes[i] = resolved
+	}
+
+	return resolvedIndexes, nil
 }
 
 var methodAppCmd = &cobra.Command{
@@ -1138,15 +1214,35 @@ var methodAppCmd = &cobra.Command{
 		var txnArgValues []string
 		var basicArgTypes []string
 		var basicArgValues []string
+		var refArgTypes []string
+		var refArgValues []string
+		refArgIndexToBasicArgIndex := make(map[int]int)
 		for i, argType := range argTypes {
 			argValue := methodArgs[i]
 			if abi.IsTransactionType(argType) {
 				txnArgTypes = append(txnArgTypes, argType)
 				txnArgValues = append(txnArgValues, argValue)
 			} else {
+				if abi.IsReferenceType(argType) {
+					refArgIndexToBasicArgIndex[len(refArgTypes)] = len(basicArgTypes)
+					refArgTypes = append(refArgTypes, argType)
+					refArgValues = append(refArgValues, argValue)
+					// treat the reference as a uint8 for encoding purposes
+					argType = "uint8"
+				}
 				basicArgTypes = append(basicArgTypes, argType)
 				basicArgValues = append(basicArgValues, argValue)
 			}
+		}
+
+		refArgsResolved, err := populateMethodCallReferenceArgs(account, appIdx, refArgTypes, refArgValues, &appAccounts, &foreignApps, &foreignAssets)
+		if err != nil {
+			reportErrorf("error populating reference arguments: %v", err)
+		}
+		for i, resolved := range refArgsResolved {
+			basicArgIndex := refArgIndexToBasicArgIndex[i]
+			// use the foreign array index as the encoded argument value
+			basicArgValues[basicArgIndex] = strconv.Itoa(resolved)
 		}
 
 		err = abi.ParseArgJSONtoByteSlice(basicArgTypes, basicArgValues, &applicationArgs)

--- a/data/abi/abi_encode.go
+++ b/data/abi/abi_encode.go
@@ -534,10 +534,9 @@ func ParseMethodSignature(methodSig string) (name string, argTypes []string, ret
 	argsEnd := -1
 	depth := 0
 	for index, char := range methodSig {
-		switch char {
-		case '(':
+		if char == '(' {
 			depth++
-		case ')':
+		} else if char == ')' {
 			if depth == 0 {
 				err = fmt.Errorf("Unpaired parenthesis in method signature: %s", methodSig)
 				return

--- a/data/abi/abi_encode_test.go
+++ b/data/abi/abi_encode_test.go
@@ -1001,3 +1001,53 @@ func TestRandomABIEncodeDecodeRoundTrip(t *testing.T) {
 	addTupleRandomValues(t, Tuple, &testValuePool)
 	categorySelfRoundTripTest(t, testValuePool[Tuple])
 }
+
+func TestParseMethodSignature(t *testing.T) {
+	tests := []struct {
+		signature  string
+		name       string
+		argTypes   []string
+		returnType string
+	}{
+		{
+			signature:  "add(uint8,uint16,pay,account,txn)uint32",
+			name:       "add",
+			argTypes:   []string{"uint8", "uint16", "pay", "account", "txn"},
+			returnType: "uint32",
+		},
+		{
+			signature:  "nothing()void",
+			name:       "nothing",
+			argTypes:   []string{},
+			returnType: "void",
+		},
+		{
+			signature:  "tupleArgs((uint8,uint128),account,(string,(bool,bool)))bool",
+			name:       "tupleArgs",
+			argTypes:   []string{"(uint8,uint128)", "account", "(string,(bool,bool))"},
+			returnType: "bool",
+		},
+		{
+			signature:  "tupleReturn(uint64)(bool,bool,bool)",
+			name:       "tupleReturn",
+			argTypes:   []string{"uint64"},
+			returnType: "(bool,bool,bool)",
+		},
+		{
+			signature:  "tupleArgsAndReturn((uint8,uint128),account,(string,(bool,bool)))(bool,bool,bool)",
+			name:       "tupleArgsAndReturn",
+			argTypes:   []string{"(uint8,uint128)", "account", "(string,(bool,bool))"},
+			returnType: "(bool,bool,bool)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.signature, func(t *testing.T) {
+			name, argTypes, returnType, err := ParseMethodSignature(test.signature)
+			require.NoError(t, err)
+			require.Equal(t, test.name, name)
+			require.Equal(t, test.argTypes, argTypes)
+			require.Equal(t, test.returnType, returnType)
+		})
+	}
+}

--- a/data/abi/abi_encode_test.go
+++ b/data/abi/abi_encode_test.go
@@ -1003,6 +1003,8 @@ func TestRandomABIEncodeDecodeRoundTrip(t *testing.T) {
 }
 
 func TestParseMethodSignature(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	tests := []struct {
 		signature  string
 		name       string

--- a/data/abi/abi_type.go
+++ b/data/abi/abi_type.go
@@ -458,11 +458,28 @@ func (t Type) ByteLen() (int, error) {
 	}
 }
 
+const AnyTransactionType = "txn"
+
 // IsTransactionType checks if a type string represents a transaction type
 // argument, such as "txn", "pay", "keyreg", etc.
 func IsTransactionType(s string) bool {
 	switch s {
-	case "txn", "pay", "keyreg", "acfg", "axfer", "afrz", "appl":
+	case AnyTransactionType, "pay", "keyreg", "acfg", "axfer", "afrz", "appl":
+		return true
+	default:
+		return false
+	}
+}
+
+const AccountReferenceType = "account"
+const AssetReferenceType = "asset"
+const ApplicationReferenceType = "application"
+
+// IsReferenceType checks if a type string represents a reference type argument,
+// such as "account", "asset", or "application".
+func IsReferenceType(s string) bool {
+	switch s {
+	case AccountReferenceType, AssetReferenceType, ApplicationReferenceType:
 		return true
 	default:
 		return false

--- a/data/abi/abi_type.go
+++ b/data/abi/abi_type.go
@@ -458,7 +458,7 @@ func (t Type) ByteLen() (int, error) {
 	}
 }
 
-// ABI argument type for a nonspecific transaction argument
+// AnyTransactionType is the ABI argument type string for a nonspecific transaction argument
 const AnyTransactionType = "txn"
 
 // IsTransactionType checks if a type string represents a transaction type
@@ -472,13 +472,13 @@ func IsTransactionType(s string) bool {
 	}
 }
 
-// ABI argument type for account references
+// AccountReferenceType is the ABI argument type string for account references
 const AccountReferenceType = "account"
 
-// ABI argument type for asset references
+// AssetReferenceType is the ABI argument type string for asset references
 const AssetReferenceType = "asset"
 
-// ABI argument type for application references
+// ApplicationReferenceType is the ABI argument type string for application references
 const ApplicationReferenceType = "application"
 
 // IsReferenceType checks if a type string represents a reference type argument,

--- a/data/abi/abi_type.go
+++ b/data/abi/abi_type.go
@@ -458,6 +458,7 @@ func (t Type) ByteLen() (int, error) {
 	}
 }
 
+// ABI argument type for a nonspecific transaction argument
 const AnyTransactionType = "txn"
 
 // IsTransactionType checks if a type string represents a transaction type
@@ -471,8 +472,13 @@ func IsTransactionType(s string) bool {
 	}
 }
 
+// ABI argument type for account references
 const AccountReferenceType = "account"
+
+// ABI argument type for asset references
 const AssetReferenceType = "asset"
+
+// ABI argument type for application references
 const ApplicationReferenceType = "application"
 
 // IsReferenceType checks if a type string represents a reference type argument,

--- a/test/scripts/e2e_subs/e2e-app-abi-method.sh
+++ b/test/scripts/e2e_subs/e2e-app-abi-method.sh
@@ -62,6 +62,14 @@ if [[ $RES != *"${EXPECTED}"* ]]; then
     false
 fi
 
+# Foreign reference test
+RES=$(${gcmd} app method --method "referenceTest(account,application,account,asset,account,asset,asset,application,application)uint8[9]" --arg KGTOR3F3Q74JP4LB5M3SOCSJ4BOPOKZ2GPSLMLLGCWYWRXZJNN4LYQJXXU --arg $APPID --arg $ACCOUNT --arg 10 --arg KGTOR3F3Q74JP4LB5M3SOCSJ4BOPOKZ2GPSLMLLGCWYWRXZJNN4LYQJXXU --arg 11 --arg 10 --arg 20 --arg 21 --app-account 2R5LMPTYLVMWYEG4RPI26PJAM7ARTGUB7LZSONQPGLUWTPOP6LQCJTQZVE --foreign-app 21 --foreign-asset 10 --app-id $APPID --from $ACCOUNT 2>&1 || true)
+EXPECTED="method referenceTest(account,application,account,asset,account,asset,asset,application,application)uint8[9] succeeded with output: [2,0,2,0,2,1,0,1,0]"
+if [[ $RES != *"${EXPECTED}"* ]]; then
+    date '+app-abi-method-test FAIL the method call to referenceTest(account,application,account,asset,account,asset,asset,application,application)uint8[9] should not fail %Y%m%d_%H%M%S'
+    false
+fi
+
 # Close out
 RES=$(${gcmd} app method --method "closeOut()string" --on-completion closeout --app-id $APPID --from $ACCOUNT 2>&1 || true)
 EXPECTED="method closeOut()string succeeded with output: \"goodbye Algorand Fan\""

--- a/test/scripts/e2e_subs/tealprogs/app-abi-method-example.teal
+++ b/test/scripts/e2e_subs/tealprogs/app-abi-method-example.teal
@@ -3,7 +3,7 @@
 txn ApplicationID
 int 0
 ==
-bnz main_l14
+bnz main_l16
 txn OnCompletion
 int OptIn
 ==
@@ -11,7 +11,7 @@ txna ApplicationArgs 0
 byte 0xcfa68e36
 ==
 &&
-bnz main_l13
+bnz main_l15
 txn OnCompletion
 int CloseOut
 ==
@@ -19,7 +19,7 @@ txna ApplicationArgs 0
 byte 0xa9f42b3d
 ==
 &&
-bnz main_l12
+bnz main_l14
 txn OnCompletion
 int DeleteApplication
 ==
@@ -27,7 +27,7 @@ txna ApplicationArgs 0
 byte 0x24378d3c
 ==
 &&
-bnz main_l11
+bnz main_l13
 txn OnCompletion
 int NoOp
 ==
@@ -35,7 +35,7 @@ txna ApplicationArgs 0
 byte 0xfe6bdf69
 ==
 &&
-bnz main_l10
+bnz main_l12
 txn OnCompletion
 int NoOp
 ==
@@ -43,7 +43,7 @@ txna ApplicationArgs 0
 byte 0xa88c26a5
 ==
 &&
-bnz main_l9
+bnz main_l11
 txn OnCompletion
 int NoOp
 ==
@@ -51,38 +51,59 @@ txna ApplicationArgs 0
 byte 0x3e3b3d28
 ==
 &&
-bnz main_l8
+bnz main_l10
+txn OnCompletion
+int NoOp
+==
+txna ApplicationArgs 0
+byte 0x0df0050f
+==
+&&
+bnz main_l9
 int 0
 return
-main_l8:
+main_l9:
+txna ApplicationArgs 1
+txna ApplicationArgs 2
+txna ApplicationArgs 3
+txna ApplicationArgs 4
+txna ApplicationArgs 5
+txna ApplicationArgs 6
+txna ApplicationArgs 7
+txna ApplicationArgs 8
+txna ApplicationArgs 9
+callsub sub6
+int 1
+return
+main_l10:
 txna ApplicationArgs 1
 callsub sub5
 int 1
 return
-main_l9:
+main_l11:
 callsub sub4
 int 1
 return
-main_l10:
+main_l12:
 txna ApplicationArgs 1
 txna ApplicationArgs 2
 callsub sub3
 int 1
 return
-main_l11:
+main_l13:
 callsub sub2
 int 1
 return
-main_l12:
+main_l14:
 callsub sub1
 int 1
 return
-main_l13:
+main_l15:
 txna ApplicationArgs 1
 callsub sub0
 int 1
 return
-main_l14:
+main_l16:
 int 1
 return
 sub0: // optIn
@@ -171,6 +192,37 @@ b sub5_l3
 sub5_l2:
 byte 0x80
 sub5_l3:
+concat
+log
+retsub
+sub6: // referenceTest
+store 14
+store 13
+store 12
+store 11
+store 10
+store 9
+store 8
+store 7
+store 6
+byte 0x151f7c75
+load 6
+concat
+load 8
+concat
+load 10
+concat
+load 7
+concat
+load 13
+concat
+load 14
+concat
+load 9
+concat
+load 11
+concat
+load 12
 concat
 log
 retsub


### PR DESCRIPTION
## Summary

Add support for the reference types `account`, `application`, and `asset` to the `goal app method` command.

### Details

The way I implemented it, the foreign arrays populated by the `--app-account`, `--foreign-app`, and `--foreign-asset` flags are extended with additional objects from the method arguments. The objects are added in a "compressed" way, meaning an object won't be added to the array if it's already present; rather, the same index will be used for the duplicate object. Additionally, if an `account` matches the transaction sender or an `application` matches the current app ID, it is not added to the foreign array and the index 0 is used as the index.

### Example

Consider this example from the e2e test:

```bash
goal app method --method "referenceTest(account,application,account,asset,account,asset,asset,application,application)uint8[9]" --arg KGTOR3F3Q74JP4LB5M3SOCSJ4BOPOKZ2GPSLMLLGCWYWRXZJNN4LYQJXXU --arg $APPID --arg $ACCOUNT --arg 10 --arg KGTOR3F3Q74JP4LB5M3SOCSJ4BOPOKZ2GPSLMLLGCWYWRXZJNN4LYQJXXU --arg 11 --arg 10 --arg 20 --arg 21 --app-account 2R5LMPTYLVMWYEG4RPI26PJAM7ARTGUB7LZSONQPGLUWTPOP6LQCJTQZVE --foreign-app 21 --foreign-asset 10 --app-id $APPID --from $ACCOUNT
```

The method arguments are:
1. Arbitrary account `KGTO...`
2. Current app ID
3. Sender account
4. Arbitrary asset ID `10`
5. Arbitrary account `KGTO...`
6. Arbitrary asset ID `11`
7. Arbitrary asset ID `10`
8. Arbitrary app ID `20`
9. Arbitrary app ID `21`

On top of the additional foreign objects:
1. Arbitrary account `2R5L...`
2. Arbitrary app ID `21`
3. Arbitrary asset ID `10`

So the resulting properties of the transaction should be:
* Foreign accounts: `[2R5L..., KGTO...]`
* Foreign apps: `[21, 20]`
* Foreign assets: `[10, 11]`
* App args: `[methodSelector, 2, 0, 0, 0, 2, 1, 0, 2, 1]`

The `referenceTest` method returns an array containing the account, application, and asset argument indexes in this order (meaning the first 3 are account indexes, the next 3 are application indexes, and the final 3 are asset indexes), so we should expect a return value of `[2, 0, 2, 0, 2, 1, 0, 1, 0]`.

### Bugfix

The first commit also fixes a bug in `ParseMethodSignature` which causes it to fail to parse signatures with tuple return types. The bug was that this `break` command was inside of a switch statement, so it did not break from the loop: https://github.com/algorand/go-algorand/blob/e466aa18d4d963868d6d15279b1c881977fa603f/data/abi/abi_encode.go#L548

Closes #3205

## Test Plan

e2e test added, plus unit tests for the bug I mentioned.
