### PR TITLE
TestEcdsa: fix flaky "tampering" of public key

### DIFF
--- a/data/transactions/logic/evalCrypto_test.go
+++ b/data/transactions/logic/evalCrypto_test.go
@@ -212,9 +212,9 @@ byte 0x%s
 &&`
 	pkTampered1 := make([]byte, len(pk))
 	copy(pkTampered1, pk)
-	pkTampered1[0] += byte(1) // intentional overflow
-	pkTampered2 := make([]byte, len(pk))
-	copy(pkTampered2, pk[1:])
+	pkTampered1[0] = 0                     // first byte is a prefix of either 0x02 or 0x03
+	pkTampered2 := make([]byte, len(pk)-1) // must be 33 bytes length
+	copy(pkTampered2, pk)
 
 	var decompressTests = []struct {
 		key  []byte
@@ -224,8 +224,9 @@ byte 0x%s
 		{pkTampered1, false},
 		{pkTampered2, false},
 	}
-	for _, test := range decompressTests {
+	for i, test := range decompressTests {
 		t.Run(fmt.Sprintf("decompress/pass=%v", test.pass), func(t *testing.T) {
+			t.Log("decompressTests i", i)
 			src := fmt.Sprintf(source, hex.EncodeToString(test.key), hex.EncodeToString(x), hex.EncodeToString(y))
 			if test.pass {
 				testAccepts(t, src, 5)
@@ -255,7 +256,7 @@ ecdsa_verify Secp256k1
 	v := int(sign[64])
 
 	rTampered := make([]byte, len(r))
-	copy(rTampered, pk)
+	copy(rTampered, r)
 	rTampered[0] += byte(1) // intentional overflow
 
 	var verifyTests = []struct {

--- a/data/transactions/logic/evalCrypto_test.go
+++ b/data/transactions/logic/evalCrypto_test.go
@@ -212,7 +212,7 @@ byte 0x%s
 &&`
 	pkTampered1 := make([]byte, len(pk))
 	copy(pkTampered1, pk)
-	pkTampered1[0] += byte(1)
+	pkTampered1[0] += byte(1) // intentional overflow
 	pkTampered2 := make([]byte, len(pk))
 	copy(pkTampered2, pk[1:])
 

--- a/data/transactions/logic/evalCrypto_test.go
+++ b/data/transactions/logic/evalCrypto_test.go
@@ -256,7 +256,7 @@ ecdsa_verify Secp256k1
 
 	rTampered := make([]byte, len(r))
 	copy(rTampered, pk)
-	rTampered[0] = 0
+	rTampered[0] += byte(1) // intentional overflow
 
 	var verifyTests = []struct {
 		data string

--- a/data/transactions/logic/evalCrypto_test.go
+++ b/data/transactions/logic/evalCrypto_test.go
@@ -212,7 +212,7 @@ byte 0x%s
 &&`
 	pkTampered1 := make([]byte, len(pk))
 	copy(pkTampered1, pk)
-	pkTampered1[0] = 0
+	pkTampered1[0] += byte(1)
 	pkTampered2 := make([]byte, len(pk))
 	copy(pkTampered2, pk[1:])
 


### PR DESCRIPTION
## Summary

This test (TestEcdsa) tests the ecdsa_pk_decompress opcode and intentionally "tampers" with the public key by setting the first byte to zero. Occasionally this test is failing, likely because the first byte was already zero. (The test failures are for the cases where failure is expected, `pass=false`)

## Test Plan

Existing test should pass, occasional flakiness should go away.