### PR TITLE
Compatibility mode for partkeyinfo.

### DIFF
--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -1368,23 +1368,21 @@ func strOrNA(value *uint64) string {
 	return uintToStr(*value)
 }
 
-// DEPRECATED
-type partkeyInfo struct {
-	_struct         struct{}                        `codec:",omitempty,omitemptyarray"`
-	Address         string                          `codec:"acct"`
-	FirstValid      basics.Round                    `codec:"first"`
-	LastValid       basics.Round                    `codec:"last"`
-	VoteID          crypto.OneTimeSignatureVerifier `codec:"vote"`
-	SelectionID     crypto.VRFVerifier              `codec:"sel"`
-	VoteKeyDilution uint64                          `codec:"voteKD"`
-}
-
-
 // legacyPartkeyInfoCommand prints key information in the same
 // format as earlier versions of goal. Some users are using this information
 // in scripts and need some extra time to migrate to alternatives.
 // DEPRECATED
 func legacyPartkeyInfoCommand() {
+	type partkeyInfo struct {
+		_struct         struct{}                        `codec:",omitempty,omitemptyarray"`
+		Address         string                          `codec:"acct"`
+		FirstValid      basics.Round                    `codec:"first"`
+		LastValid       basics.Round                    `codec:"last"`
+		VoteID          crypto.OneTimeSignatureVerifier `codec:"vote"`
+		SelectionID     crypto.VRFVerifier              `codec:"sel"`
+		VoteKeyDilution uint64                          `codec:"voteKD"`
+	}
+
 	onDataDirs(func(dataDir string) {
 		fmt.Printf("Dumping participation key info from %s...\n", dataDir)
 		client := ensureGoalClient(dataDir, libgoal.DynamicClient)

--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -59,7 +59,7 @@ var (
 	partKeyOutDir      string
 	partKeyFile        string
 	partKeyDeleteInput bool
-	listpartkeyCompat  bool
+	partkeyCompat      bool
 	importDefault      bool
 	mnemonic           string
 	dumpOutFile        string
@@ -167,7 +167,10 @@ func init() {
 	installParticipationKeyCmd.Flags().BoolVar(&partKeyDeleteInput, "delete-input", false, "Acknowledge that installpartkey will delete the input key file")
 
 	// listpartkey flags
-	listParticipationKeysCmd.Flags().BoolVarP(&listpartkeyCompat, "compatibility", "c", false, "Print output in compatibility mode. This option will be removed in a future release, please use REST API for tooling.")
+	listParticipationKeysCmd.Flags().BoolVarP(&partkeyCompat, "compatibility", "c", false, "Print output in compatibility mode. This option will be removed in a future release, please use REST API for tooling.")
+
+	// partkeyinfo flags
+	partkeyInfoCmd.Flags().BoolVarP(&partkeyCompat, "compatibility", "c", false, "Print output in compatibility mode. This option will be removed in a future release, please use REST API for tooling.")
 
 	// import flags
 	importCmd.Flags().BoolVarP(&importDefault, "default", "f", false, "Set this account as the default one")
@@ -1069,6 +1072,7 @@ func uintToStr(number uint64) string {
 // legacyListParticipationKeysCommand prints key information in the same
 // format as earlier versions of goal. Some users are using this information
 // in scripts and need some extra time to migrate to the REST API.
+// DEPRECATED
 func legacyListParticipationKeysCommand() {
 	dataDir := ensureSingleDataDir()
 
@@ -1118,7 +1122,7 @@ var listParticipationKeysCmd = &cobra.Command{
 	Long:  `List all participation keys tracked by algod along with summary of additional information. For detailed key information use 'partkeyinfo'.`,
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, args []string) {
-		if listpartkeyCompat {
+		if partkeyCompat {
 			legacyListParticipationKeysCommand()
 			return
 		}
@@ -1364,12 +1368,59 @@ func strOrNA(value *uint64) string {
 	return uintToStr(*value)
 }
 
+// DEPRECATED
+type partkeyInfo struct {
+	_struct         struct{}                        `codec:",omitempty,omitemptyarray"`
+	Address         string                          `codec:"acct"`
+	FirstValid      basics.Round                    `codec:"first"`
+	LastValid       basics.Round                    `codec:"last"`
+	VoteID          crypto.OneTimeSignatureVerifier `codec:"vote"`
+	SelectionID     crypto.VRFVerifier              `codec:"sel"`
+	VoteKeyDilution uint64                          `codec:"voteKD"`
+}
+
+
+// legacyPartkeyInfoCommand prints key information in the same
+// format as earlier versions of goal. Some users are using this information
+// in scripts and need some extra time to migrate to alternatives.
+// DEPRECATED
+func legacyPartkeyInfoCommand() {
+	onDataDirs(func(dataDir string) {
+		fmt.Printf("Dumping participation key info from %s...\n", dataDir)
+		client := ensureGoalClient(dataDir, libgoal.DynamicClient)
+
+		// Make sure we don't already have a partkey valid for (or after) specified roundLastValid
+		parts, err := client.ListParticipationKeyFiles()
+		if err != nil {
+			reportErrorf(errorRequestFail, err)
+		}
+
+		for filename, part := range parts {
+			fmt.Println("------------------------------------------------------------------")
+			info := partkeyInfo{
+				Address:         part.Address().String(),
+				FirstValid:      part.FirstValid,
+				LastValid:       part.LastValid,
+				VoteID:          part.VotingSecrets().OneTimeSignatureVerifier,
+				SelectionID:     part.VRFSecrets().PK,
+				VoteKeyDilution: part.KeyDilution,
+			}
+			infoString := protocol.EncodeJSON(&info)
+			fmt.Printf("File: %s\n%s\n", filename, string(infoString))
+		}
+	})
+}
+
 var partkeyInfoCmd = &cobra.Command{
 	Use:   "partkeyinfo",
 	Short: "Output details about all available part keys",
 	Long:  `Output details about all available part keys in the specified data directory(ies), such as key validity period.`,
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, args []string) {
+		if partkeyCompat {
+			legacyPartkeyInfoCommand()
+			return
+		}
 
 		onDataDirs(func(dataDir string) {
 			fmt.Printf("Dumping participation key info from %s...\n", dataDir)


### PR DESCRIPTION
## Summary

Compatibility for `partkeyinfo` was also needed by some users. In addition to the different format, the old command also allows printing key information when the node is not running

Workarounds:
1) use an older `goal` binary.
2) use `algokey part info --keyfile <file>`

## Test Plan

Tested manually:
```
~$ goal account partkeyinfo -d /tmp/private_network/Node/
Dumping participation key info from /tmp/private_network/Node/...

Participation ID:          CPLHRU3WEY3PE7XTPPSIE7BGJYWAIFPS7DL3HZNC4OKQRQ5YAYUA
Parent address:            DGS6VNX2BRMKGKVAS2LTREMYG33TOCYPFLPCQ3DUTJULQU6P6S7KJCDNTU
Last vote round:           1
Last block proposal round: 2
Effective first round:     1
Effective last round:      3000000
First round:               0
Last round:                3000000
Key dilution:              10000
Selection key:             5QRrTgzSUTqqym43QVsBus1/AOwGR5zE+I7FGwA14vQ=
Voting key:                PK0NMyZ4BKSjPQ9JuT7dQBLdTpjLQv2txuDYDKhkuqs=

~$ goal account partkeyinfo -d /tmp/private_network/Node/ -c
Dumping participation key info from /tmp/private_network/Node/...
------------------------------------------------------------------
File: Wallet2.0.3000000.partkey
{
  "acct": "DGS6VNX2BRMKGKVAS2LTREMYG33TOCYPFLPCQ3DUTJULQU6P6S7KJCDNTU",
  "last": 3000000,
  "sel": "5QRrTgzSUTqqym43QVsBus1/AOwGR5zE+I7FGwA14vQ=",
  "vote": "PK0NMyZ4BKSjPQ9JuT7dQBLdTpjLQv2txuDYDKhkuqs=",
  "voteKD": 10000
}
```