### PR TITLE
enumerate conditions that might cause this fetchAndWrite to return false

### DIFF
--- a/catchup/service.go
+++ b/catchup/service.go
@@ -199,7 +199,7 @@ func (s *Service) innerFetch(r basics.Round, peer network.Peer) (blk *bookkeepin
 //  - If the context is canceled (e.g. if the node is shutting down)
 //  - If we couldn't fetch the block (e.g. if there are no peers available or we've reached the catchupRetryLimit)
 //  - If the block is already in the ledger (e.g. if agreement service has already written it)
-//  - If there is an issue validating the block (e.g. if we receive a malformed block)
+//  - If the retrieval of the previous block was unsuccessful
 func (s *Service) fetchAndWrite(r basics.Round, prevFetchCompleteChan chan bool, lookbackComplete chan bool, peerSelector *peerSelector) bool {
 	i := 0
 	hasLookback := false

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -195,7 +195,11 @@ func (s *Service) innerFetch(r basics.Round, peer network.Peer) (blk *bookkeepin
 }
 
 // fetchAndWrite fetches a block, checks the cert, and writes it to the ledger. Cert checking and ledger writing both wait for the ledger to advance if necessary.
-// Returns false if we couldn't fetch or write (i.e., if we failed even after a given number of retries or if we were told to abort.)
+// Returns false if we should stop trying to catch up.  This may occur for several reasons:
+//  - If the context is canceled (e.g. if the node is shutting down)
+//  - If we couldn't fetch the block (e.g. if there are no peers available or we've reached the catchupRetryLimit)
+//  - If the block is already in the ledger (e.g. if agreement service has already written it)
+//  - If there is an issue validating the block (e.g. if we receive a malformed block)
 func (s *Service) fetchAndWrite(r basics.Round, prevFetchCompleteChan chan bool, lookbackComplete chan bool, peerSelector *peerSelector) bool {
 	i := 0
 	hasLookback := false


### PR DESCRIPTION
## Summary

The fetchAndWrite function contains some complex logic to ultimately determine if we should continue trying to catch up.  The conditions that might cause it to return false should be more explicitly enumerated.

## Test Plan

Just comments
