### PR TITLE
testing: fix random data race in TestAppAccountDataStorage

### DIFF
--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -51,7 +51,6 @@ func commitRound(offset uint64, dbRound basics.Round, l *Ledger) {
 		time.Sleep(time.Millisecond)
 
 	}
-	//l.trackers.waitAccountsWriting()
 }
 
 // test ensures that

--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -39,7 +39,19 @@ func commitRound(offset uint64, dbRound basics.Round, l *Ledger) {
 	l.trackers.mu.Unlock()
 
 	l.trackers.scheduleCommit(l.Latest(), l.Latest()-(dbRound+basics.Round(offset)))
-	l.trackers.waitAccountsWriting()
+	// wait for the operation to complete. Once it does complete, the tr.lastFlushTime is going to be updated, so we can
+	// use that as an indicator.
+	for {
+		l.trackers.mu.Lock()
+		isDone := (!l.trackers.lastFlushTime.IsZero()) && (len(l.trackers.deferredCommits) == 0)
+		l.trackers.mu.Unlock()
+		if isDone {
+			break
+		}
+		time.Sleep(time.Millisecond)
+
+	}
+	//l.trackers.waitAccountsWriting()
 }
 
 // test ensures that


### PR DESCRIPTION
## Summary

When running TestAppAccountDataStorage, we would randomly have a data race:
```golang
Failed
=== RUN   TestAppAccountDataStorage
==================
WARNING: DATA RACE
Write at 0x00c02966cad8 by goroutine 43:
  internal/race.Write()
      /opt/cibuild/.gimme/versions/go1.16.11.darwin.amd64/src/internal/race/race.go:41 +0x125
  sync.(*WaitGroup).Wait()
      /opt/cibuild/.gimme/versions/go1.16.11.darwin.amd64/src/sync/waitgroup.go:128 +0x126
  github.com/algorand/go-algorand/ledger.(*trackerRegistry).waitAccountsWriting()
      /opt/cibuild/project/ledger/tracker.go:346 +0x58
  github.com/algorand/go-algorand/ledger.commitRound()
      /opt/cibuild/project/ledger/applications_test.go:42 +0x118
  github.com/algorand/go-algorand/ledger.TestAppAccountDataStorage()
      /opt/cibuild/project/ledger/applications_test.go:191 +0x14f6
  testing.tRunner()
      /opt/cibuild/.gimme/versions/go1.16.11.darwin.amd64/src/testing/testing.go:1193 +0x202

Previous read at 0x00c02966cad8 by goroutine 73:
  internal/race.Read()
      /opt/cibuild/.gimme/versions/go1.16.11.darwin.amd64/src/internal/race/race.go:37 +0x206
  sync.(*WaitGroup).Add()
      /opt/cibuild/.gimme/versions/go1.16.11.darwin.amd64/src/sync/waitgroup.go:71 +0x219
  github.com/algorand/go-algorand/ledger.(*trackerRegistry).scheduleCommit()
      /opt/cibuild/project/ledger/tracker.go:339 +0x3da
  github.com/algorand/go-algorand/ledger.(*trackerRegistry).committedUpTo()
      /opt/cibuild/project/ledger/tracker.go:302 +0x1b6
  github.com/algorand/go-algorand/ledger.(*Ledger).notifyCommit()
      /opt/cibuild/project/ledger/ledger.go:398 +0xd1
  github.com/algorand/go-algorand/ledger.(*blockQueue).syncer()
      /opt/cibuild/project/ledger/blockqueue.go:145 +0x728

Goroutine 43 (running) created at:
  testing.(*T).Run()
      /opt/cibuild/.gimme/versions/go1.16.11.darwin.amd64/src/testing/testing.go:1238 +0x5d7
  testing.runTests.func1()
      /opt/cibuild/.gimme/versions/go1.16.11.darwin.amd64/src/testing/testing.go:1511 +0xa6
  testing.tRunner()
      /opt/cibuild/.gimme/versions/go1.16.11.darwin.amd64/src/testing/testing.go:1193 +0x202
  testing.runTests()
      /opt/cibuild/.gimme/versions/go1.16.11.darwin.amd64/src/testing/testing.go:1509 +0x612
  testing.(*M).Run()
      /opt/cibuild/.gimme/versions/go1.16.11.darwin.amd64/src/testing/testing.go:1417 +0x3b3
  main.main()
      _testmain.go:427 +0x356

Goroutine 73 (running) created at:
  github.com/algorand/go-algorand/ledger.bqInit()
      /opt/cibuild/project/ledger/blockqueue.go:72 +0x43a
  github.com/algorand/go-algorand/ledger.(*Ledger).reloadLedger()
      /opt/cibuild/project/ledger/ledger.go:186 +0x158
  github.com/algorand/go-algorand/ledger.OpenLedger()
      /opt/cibuild/project/ledger/ledger.go:160 +0x12a8
  github.com/algorand/go-algorand/ledger.TestAppAccountDataStorage()
      /opt/cibuild/project/ledger/applications_test.go:134 +0xc57
  testing.tRunner()
      /opt/cibuild/.gimme/versions/go1.16.11.darwin.amd64/src/testing/testing.go:1193 +0x202
==================
time="2021-12-15T03:17:39.783933 +0000" level=warning msg="out of order deferred commit: offset 0, dbRound 0 but current tracker DB round is 3" file=tracker.go function="github.com/algorand/go-algorand/ledger.(*trackerRegistry).commitRound" line=406
    testing.go:1092: race detected during execution of test
--- FAIL: TestAppAccountDataStorage (0.16s)
```

## Test Plan

This is a test.