### PR TITLE
tealdbg: increase intermediate reading/writing buffers

### DIFF
--- a/cmd/tealdbg/server.go
+++ b/cmd/tealdbg/server.go
@@ -31,8 +31,8 @@ import (
 )
 
 var upgrader = websocket.Upgrader{
-	ReadBufferSize:  20480,
-	WriteBufferSize: 20480,
+	ReadBufferSize:  20480 * 4,
+	WriteBufferSize: 20480 * 4,
 	CheckOrigin: func(r *http.Request) bool {
 		if len(r.Header.Get("Origin")) == 0 {
 			return true

--- a/cmd/tealdbg/server.go
+++ b/cmd/tealdbg/server.go
@@ -30,9 +30,18 @@ import (
 	"github.com/gorilla/mux"
 )
 
+const (
+	// WebSocketBufferSize is the size of the buffer for the
+	// tealdbg/cdt websocket session.
+	// A buffer that is too small will cause the session to choke
+	// during the `getScriptSource` call and the session cannot recover.
+	WebSocketReadBufferSize  = 81920
+	WebSocketWriteBufferSize = 81920
+)
+
 var upgrader = websocket.Upgrader{
-	ReadBufferSize:  20480 * 4,
-	WriteBufferSize: 20480 * 4,
+	ReadBufferSize:  WebSocketReadBufferSize,
+	WriteBufferSize: WebSocketWriteBufferSize,
 	CheckOrigin: func(r *http.Request) bool {
 		if len(r.Header.Get("Origin")) == 0 {
 			return true

--- a/cmd/tealdbg/server.go
+++ b/cmd/tealdbg/server.go
@@ -31,11 +31,15 @@ import (
 )
 
 const (
-	// WebSocketBufferSize is the size of the buffer for the
+	// WebSocketReadBufferSize is the size of the ReadBuffer for the
 	// tealdbg/cdt websocket session.
 	// A buffer that is too small will cause the session to choke
 	// during the `getScriptSource` call and the session cannot recover.
-	WebSocketReadBufferSize  = 81920
+	WebSocketReadBufferSize = 81920
+
+	// WebSocketWriteBufferSize is the size of the WriteBuffer for the
+	// tealdbg/cdt websocket session.
+	// The reasoning for the size is the same as above
 	WebSocketWriteBufferSize = 81920
 )
 


### PR DESCRIPTION
## Summary

Some large teal source files cause the tealdbg/cdt session to choke.  Upping the buffer size to allow for larger source files.

closes #3100 

## Test Plan

Run tealdbg with a large source teal file, ensure the source file makes it to cdt without choking.
