### PR TITLE
txsync: compress msgOrderingHeap

### DIFF
--- a/txnsync/incoming.go
+++ b/txnsync/incoming.go
@@ -34,6 +34,7 @@ type incomingMessage struct {
 	networkPeer       interface{}
 	message           transactionBlockMessage
 	sequenceNumber    uint64
+	nextSequenceNumber uint64
 	peer              *Peer
 	encodedSize       int // the byte length of the incoming network message
 	bloomFilter       *testableBloomFilter
@@ -187,7 +188,7 @@ incomingMessageLoop:
 		}
 
 		// increase the message sequence number, since we're processing this message.
-		peer.nextReceivedMessageSeq++
+		peer.nextReceivedMessageSeq = incomingMsg.nextSequenceNumber
 
 		// skip txnsync messages with proposalData for now
 		if !incomingMsg.message.RelayedProposal.MsgIsZero() {

--- a/txnsync/msgorderingheap.go
+++ b/txnsync/msgorderingheap.go
@@ -69,9 +69,10 @@ func (p *messageOrderingHeap) Less(i, j int) bool {
 func (p *messageOrderingHeap) enqueue(msg incomingMessage) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	msg.nextSequenceNumber = msg.sequenceNumber + 1
 	if len(p.messages) >= messageOrderingHeapLimit {
 		// try compressing the msgorderingheap first
-		p.compress()
+		p.compact()
 		if len(p.messages) >= messageOrderingHeapLimit {
 			// return an error if still can't enqueue
 			return errHeapReachedCapacity
@@ -84,6 +85,10 @@ func (p *messageOrderingHeap) enqueue(msg incomingMessage) error {
 func (p *messageOrderingHeap) popSequence(sequenceNumber uint64) (msg incomingMessage, heapSequenceNumber uint64, err error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	return p.popSequenceUnsafe(sequenceNumber)
+}
+
+func (p *messageOrderingHeap) popSequenceUnsafe(sequenceNumber uint64) (msg incomingMessage, heapSequenceNumber uint64, err error) {
 	if len(p.messages) == 0 {
 		return incomingMessage{}, 0, errHeapEmpty
 	}
@@ -97,6 +102,10 @@ func (p *messageOrderingHeap) popSequence(sequenceNumber uint64) (msg incomingMe
 func (p *messageOrderingHeap) pop() (msg incomingMessage, err error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	return p.popUnsafe()
+}
+
+func (p *messageOrderingHeap) popUnsafe() (msg incomingMessage, err error) {
 	if len(p.messages) == 0 {
 		return incomingMessage{}, errHeapEmpty
 	}
@@ -104,17 +113,16 @@ func (p *messageOrderingHeap) pop() (msg incomingMessage, err error) {
 	return incomingMessage(entry), nil
 }
 
-func (p *messageOrderingHeap) compress() {
-	if len(p.messages) == 0 {
+func (p *messageOrderingHeap) compact() {
+	compressedEntry, err := p.popUnsafe()
+	if err != nil {
 		return
 	}
-	compressedEntry := heap.Pop(p).(messageHeapItem)
 	expectedSeqNum := compressedEntry.sequenceNumber + 1
 	for len(p.messages) != 0 {
-		nextEntry := heap.Pop(p).(messageHeapItem)
+		nextEntry, _, err := p.popSequenceUnsafe(expectedSeqNum)
 		// compress only consecutive messages
-		if nextEntry.sequenceNumber != expectedSeqNum {
-			heap.Push(p, nextEntry)
+		if err != nil {
 			break
 		}
 		// use oldest transaction groups if possible
@@ -124,9 +132,10 @@ func (p *messageOrderingHeap) compress() {
 		if nextEntry.bloomFilter == nil {
 			nextEntry.bloomFilter = compressedEntry.bloomFilter
 		}
+		nextEntry.sequenceNumber = compressedEntry.sequenceNumber
 		compressedEntry = nextEntry
 		expectedSeqNum++
 	}
 	// return compressed message to heap
-	heap.Push(p, compressedEntry)
+	heap.Push(p, messageHeapItem(compressedEntry))
 }

--- a/txnsync/msgorderingheap.go
+++ b/txnsync/msgorderingheap.go
@@ -118,7 +118,7 @@ func (p *messageOrderingHeap) compact() {
 	if err != nil {
 		return
 	}
-	expectedSeqNum := compressedEntry.sequenceNumber + 1
+	expectedSeqNum := compressedEntry.nextSequenceNumber
 	for len(p.messages) != 0 {
 		nextEntry, _, err := p.popSequenceUnsafe(expectedSeqNum)
 		// compress only consecutive messages
@@ -134,7 +134,7 @@ func (p *messageOrderingHeap) compact() {
 		}
 		nextEntry.sequenceNumber = compressedEntry.sequenceNumber
 		compressedEntry = nextEntry
-		expectedSeqNum++
+		expectedSeqNum = compressedEntry.nextSequenceNumber
 	}
 	// return compressed message to heap
 	heap.Push(p, messageHeapItem(compressedEntry))

--- a/txnsync/msgorderingheap_test.go
+++ b/txnsync/msgorderingheap_test.go
@@ -282,16 +282,16 @@ func TestCompressHeap(t *testing.T) {
 		}
 		a.Nil(heap.enqueue(incomingMessage{sequenceNumber: uint64(i), transactionGroups: txnGroup}))
 	}
-	a.Nil(heap.enqueue(incomingMessage{sequenceNumber: uint64(messageOrderingHeapLimit)}))
+	a.Nil(heap.enqueue(incomingMessage{sequenceNumber: uint64(messageOrderingHeapLimit), }))
 
 	a.Equal(heap.Len(), int(messageOrderingHeapLimit))
 	a.Nil(heap.enqueue(incomingMessage{sequenceNumber: uint64(messageOrderingHeapLimit + 1)}))
 	a.Equal(heap.Len(), 3)
 
-
 	msg, err := heap.pop()
 	a.Nil(err)
-	a.Equal(msg.sequenceNumber, uint64(messageOrderingHeapLimit - 2))
+	a.Equal(uint64(0), msg.sequenceNumber)
+	a.Equal(uint64(messageOrderingHeapLimit-1), msg.nextSequenceNumber)
 	a.Equal(msg.transactionGroups, []pooldata.SignedTxGroup{
 		{
 			GroupTransactionID: transactions.Txid{byte(0)},
@@ -301,9 +301,13 @@ func TestCompressHeap(t *testing.T) {
 	msg, err = heap.pop()
 	a.Nil(err)
 	a.Equal(msg.sequenceNumber, uint64(messageOrderingHeapLimit))
+	a.Equal(uint64(messageOrderingHeapLimit), msg.sequenceNumber)
+	a.Equal(uint64(messageOrderingHeapLimit+1), msg.nextSequenceNumber)
 
 	msg, err = heap.pop()
 	a.Nil(err)
 	a.Equal(msg.sequenceNumber, uint64(messageOrderingHeapLimit + 1))
+	a.Equal(uint64(messageOrderingHeapLimit+1), msg.sequenceNumber)
+	a.Equal(uint64(messageOrderingHeapLimit+2), msg.nextSequenceNumber)
 
 }


### PR DESCRIPTION
## Summary

Whenever the msgOrderingHeap gets full, we would like to compress the messages inside of it instead of disconnecting from the corresponding peer.

## Test Plan

Wrote additional unit tests.
