### PR TITLE
Fix flaky test in randomized ABI encoding test

### DIFF
--- a/data/abi/abi_encode_test.go
+++ b/data/abi/abi_encode_test.go
@@ -19,7 +19,6 @@ package abi
 import (
 	"crypto/rand"
 	"encoding/binary"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -873,27 +872,26 @@ func categorySelfRoundTripTest(t *testing.T, category []testUnit) {
 		require.NoError(t, err, "failure to deserialize type: "+testObj.serializedType)
 		encodedValue, err := abiType.Encode(testObj.value)
 		require.NoError(t, err,
-			fmt.Sprintf("failure to encode value %#v over type %s", testObj.value, testObj.serializedType),
+			"failure to encode value %#v over type %s", testObj.value, testObj.serializedType,
 		)
 		actual, err := abiType.Decode(encodedValue)
 		require.NoError(t, err,
-			fmt.Sprintf("failure to decode value %#v for type %s", encodedValue, testObj.serializedType),
+			"failure to decode value %#v for type %s", encodedValue, testObj.serializedType,
 		)
 		require.Equal(t, testObj.value, actual,
-			fmt.Sprintf("decoded value %#v not equal to expected value %#v", actual, testObj.value),
+			"decoded value %#v not equal to expected value %#v", actual, testObj.value,
 		)
 		jsonEncodedValue, err := abiType.MarshalToJSON(testObj.value)
 		require.NoError(t, err,
-			fmt.Sprintf("failure to encode value %#v to JSON type", testObj.value),
+			"failure to encode value %#v to JSON type", testObj.value,
 		)
 		jsonActual, err := abiType.UnmarshalFromJSON(jsonEncodedValue)
 		require.NoError(t, err,
-			fmt.Sprintf("failure to decode JSON value %s back for type %s",
-				string(jsonEncodedValue), testObj.serializedType,
-			),
+			"failure to decode JSON value %s back for type %s",
+			string(jsonEncodedValue), testObj.serializedType,
 		)
 		require.Equal(t, testObj.value, jsonActual,
-			fmt.Sprintf("decode JSON value %s not equal to expected %s", jsonActual, testObj.value),
+			"decode JSON value %s not equal to expected %s", jsonActual, testObj.value,
 		)
 	}
 }

--- a/data/abi/abi_encode_test.go
+++ b/data/abi/abi_encode_test.go
@@ -19,6 +19,7 @@ package abi
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -869,17 +870,31 @@ type testUnit struct {
 func categorySelfRoundTripTest(t *testing.T, category []testUnit) {
 	for _, testObj := range category {
 		abiType, err := TypeOf(testObj.serializedType)
-		require.NoError(t, err, "failure to deserialize type")
+		require.NoError(t, err, "failure to deserialize type: "+testObj.serializedType)
 		encodedValue, err := abiType.Encode(testObj.value)
-		require.NoError(t, err, "failure to encode value")
+		require.NoError(t, err,
+			fmt.Sprintf("failure to encode value %#v over type %s", testObj.value, testObj.serializedType),
+		)
 		actual, err := abiType.Decode(encodedValue)
-		require.NoError(t, err, "failure to decode value")
-		require.Equal(t, testObj.value, actual, "decoded value not equal to expected")
+		require.NoError(t, err,
+			fmt.Sprintf("failure to decode value %#v for type %s", encodedValue, testObj.serializedType),
+		)
+		require.Equal(t, testObj.value, actual,
+			fmt.Sprintf("decoded value %#v not equal to expected value %#v", actual, testObj.value),
+		)
 		jsonEncodedValue, err := abiType.MarshalToJSON(testObj.value)
-		require.NoError(t, err, "failure to encode value to JSON type")
+		require.NoError(t, err,
+			fmt.Sprintf("failure to encode value %#v to JSON type", testObj.value),
+		)
 		jsonActual, err := abiType.UnmarshalFromJSON(jsonEncodedValue)
-		require.NoError(t, err, "failure to decode JSON value back")
-		require.Equal(t, testObj.value, jsonActual, "decode JSON value not equal to expected")
+		require.NoError(t, err,
+			fmt.Sprintf("failure to decode JSON value %s back for type %s",
+				string(jsonEncodedValue), testObj.serializedType,
+			),
+		)
+		require.Equal(t, testObj.value, jsonActual,
+			fmt.Sprintf("decode JSON value %s not equal to expected %s", jsonActual, testObj.value),
+		)
 	}
 }
 


### PR DESCRIPTION
## Summary

Previously @cce noticed that there's a flaky test in ABI encoding.

> Chris Erway: just encountered a PR of mine failing due to what looks like a new flaky test related to encoding randomly generated values? https://app.circleci.com/pipelines/github/algorand/go-algorand/3937/workflows/7bd0914e-57f8-4d7e-9fa9-026f74c831bf/jobs/58162
> ![](https://user-images.githubusercontent.com/291133/147157643-b7593f49-f5d8-41c2-9afa-910d545ebbb0.png)

The reason for the flaky test is that we randomly generate variables to test ABI encoding, and it turns out that the generated ABI-encoding bytes is larger than `uint16` limit. The encoder would just throw an error complaining `encode length exceeds uint16 maximum`.

The solution is to scale down the parameters for generating random variables, to decrease the generated bytes length, not to reach the `2^16` length limit.

We gathered the constants in test scripts for better readability.

## Test Plan

We should expect that the modification eliminate the flaky test chance...