### PR TITLE
ledger refactoring: update compactResourcesDeltas / compactAccountDeltas

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1454,20 +1454,20 @@ func (au *accountUpdates) postCommit(ctx context.Context, dcc *deferredCommitCon
 	// Drop reference counts to modified accounts, and evict them
 	// from in-memory cache when no references remain.
 	for i := 0; i < dcc.compactAccountDeltas.len(); i++ {
-		addr, acctUpdate := dcc.compactAccountDeltas.getByIdx(i)
+		acctUpdate := dcc.compactAccountDeltas.getByIdx(i)
 		cnt := acctUpdate.nAcctDeltas
-		macct, ok := au.accounts[addr]
+		macct, ok := au.accounts[acctUpdate.address]
 		if !ok {
-			au.log.Panicf("inconsistency: flushed %d changes to %s, but not in au.accounts", cnt, addr)
+			au.log.Panicf("inconsistency: flushed %d changes to %s, but not in au.accounts", cnt, acctUpdate.address)
 		}
 
 		if cnt > macct.ndeltas {
-			au.log.Panicf("inconsistency: flushed %d changes to %s, but au.accounts had %d", cnt, addr, macct.ndeltas)
+			au.log.Panicf("inconsistency: flushed %d changes to %s, but au.accounts had %d", cnt, acctUpdate.address, macct.ndeltas)
 		} else if cnt == macct.ndeltas {
-			delete(au.accounts, addr)
+			delete(au.accounts, acctUpdate.address)
 		} else {
 			macct.ndeltas -= cnt
-			au.accounts[addr] = macct
+			au.accounts[acctUpdate.address] = macct
 		}
 		// todo : tsachi -
 		// remove the entries from au.resources as needed.

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -458,28 +458,28 @@ func (ct *catchpointTracker) accountsUpdateBalances(accountsDeltas compactAccoun
 	accumulatedChanges := 0
 
 	for i := 0; i < accountsDeltas.len(); i++ {
-		addr, delta := accountsDeltas.getByIdx(i)
+		delta := accountsDeltas.getByIdx(i)
 		if !delta.oldAcct.accountData.MsgIsZero() {
-			deleteHash := accountHashBuilderV6(addr, &delta.oldAcct.accountData, protocol.Encode(&delta.oldAcct.accountData))
+			deleteHash := accountHashBuilderV6(delta.address, &delta.oldAcct.accountData, protocol.Encode(&delta.oldAcct.accountData))
 			deleted, err = ct.balancesTrie.Delete(deleteHash)
 			if err != nil {
-				return fmt.Errorf("failed to delete hash '%s' from merkle trie for account %v: %w", hex.EncodeToString(deleteHash), addr, err)
+				return fmt.Errorf("failed to delete hash '%s' from merkle trie for account %v: %w", hex.EncodeToString(deleteHash), delta.address, err)
 			}
 			if !deleted {
-				ct.log.Warnf("failed to delete hash '%s' from merkle trie for account %v", hex.EncodeToString(deleteHash), addr)
+				ct.log.Warnf("failed to delete hash '%s' from merkle trie for account %v", hex.EncodeToString(deleteHash), delta.address)
 			} else {
 				accumulatedChanges++
 			}
 		}
 
 		if !delta.newAcct.MsgIsZero() {
-			addHash := accountHashBuilderV6(addr, &delta.newAcct, protocol.Encode(&delta.newAcct))
+			addHash := accountHashBuilderV6(delta.address, &delta.newAcct, protocol.Encode(&delta.newAcct))
 			added, err = ct.balancesTrie.Add(addHash)
 			if err != nil {
-				return fmt.Errorf("attempted to add duplicate hash '%s' to merkle trie for account %v: %w", hex.EncodeToString(addHash), addr, err)
+				return fmt.Errorf("attempted to add duplicate hash '%s' to merkle trie for account %v: %w", hex.EncodeToString(addHash), delta.address, err)
 			}
 			if !added {
-				ct.log.Warnf("attempted to add duplicate hash '%s' to merkle trie for account %v", hex.EncodeToString(addHash), addr)
+				ct.log.Warnf("attempted to add duplicate hash '%s' to merkle trie for account %v", hex.EncodeToString(addHash), delta.address)
 			} else {
 				accumulatedChanges++
 			}


### PR DESCRIPTION
## Summary

1. remove `addresses` slice from `compactAccountDeltas ` and add `address` field to `accountDelta`.
2. avoid passing {address, aidx} to `compactResourcesDeltas .insert/insertMissing` and extract these from `resourceDelta`.
3. avoid passing {address} to to `compactAccountDeltas.insert/insertMissing` and extract these from `accountDelta`
4. move `upsert` into test code.

## Test Plan

Use existing unit tests & update them.