### PR TITLE
ledger refactoring: addrid lookup fix

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -1614,7 +1614,7 @@ func accountDataResources(
 				rd.SetAppParams(ap, true)
 				delete(accountData.AppParams, aidx)
 			}
-			err := cb(ctx, rowid, basics.CreatableIndex(aidx), basics.AssetCreatable, &rd)
+			err := cb(ctx, rowid, basics.CreatableIndex(aidx), basics.AppCreatable, &rd)
 			if err != nil {
 				return err
 			}
@@ -1622,7 +1622,7 @@ func accountDataResources(
 		for aidx, aparams := range accountData.AppParams {
 			var rd resourcesData
 			rd.SetAppParams(aparams, false)
-			err := cb(ctx, rowid, basics.CreatableIndex(aidx), basics.AssetCreatable, &rd)
+			err := cb(ctx, rowid, basics.CreatableIndex(aidx), basics.AppCreatable, &rd)
 			if err != nil {
 				return err
 			}

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -404,9 +404,11 @@ func makeCompactResourceDeltas(accountDeltas []ledgercore.NewAccountDeltas, base
 					// meaning empty asset hodling (or app local state)
 					newEntry.newResource.ClearAssetHolding()
 				}
-				if baseResourceData, has := baseResources.read(assetHold.Addr, basics.CreatableIndex(assetHold.Aidx)); has {
+				baseResourceData, has := baseResources.read(assetHold.Addr, basics.CreatableIndex(assetHold.Aidx))
+				existingAcctCacheEntry := has && baseResourceData.addrid != 0
+				if existingAcctCacheEntry {
 					newEntry.oldResource = baseResourceData
-					outResourcesDeltas.insert(newEntry) // insert instead of upsert economizes one map lookup
+					outResourcesDeltas.insert(newEntry)
 				} else {
 					if pad, has := baseAccounts.read(assetHold.Addr); has {
 						newEntry.oldResource = persistedResourcesData{addrid: pad.rowid}
@@ -450,9 +452,11 @@ func makeCompactResourceDeltas(accountDeltas []ledgercore.NewAccountDeltas, base
 					// meaning empty asset hodling (or app local state)
 					newEntry.newResource.ClearAssetHolding()
 				}
-				if baseResourceData, has := baseResources.read(assetParams.Addr, basics.CreatableIndex(assetParams.Aidx)); has {
+				baseResourceData, has := baseResources.read(assetParams.Addr, basics.CreatableIndex(assetParams.Aidx))
+				existingAcctCacheEntry := has && baseResourceData.addrid != 0
+				if existingAcctCacheEntry {
 					newEntry.oldResource = baseResourceData
-					outResourcesDeltas.insert(newEntry) // insert instead of upsert economizes one map lookup
+					outResourcesDeltas.insert(newEntry)
 				} else {
 					if pad, has := baseAccounts.read(assetParams.Addr); has {
 						newEntry.oldResource = persistedResourcesData{addrid: pad.rowid}
@@ -497,9 +501,11 @@ func makeCompactResourceDeltas(accountDeltas []ledgercore.NewAccountDeltas, base
 					// meaning empty asset hodling (or app local state)
 					newEntry.newResource.ClearAppLocalState()
 				}
-				if baseResourceData, has := baseResources.read(localState.Addr, basics.CreatableIndex(localState.Aidx)); has {
+				baseResourceData, has := baseResources.read(localState.Addr, basics.CreatableIndex(localState.Aidx))
+				existingAcctCacheEntry := has && baseResourceData.addrid != 0
+				if existingAcctCacheEntry {
 					newEntry.oldResource = baseResourceData
-					outResourcesDeltas.insert(newEntry) // insert instead of upsert economizes one map lookup
+					outResourcesDeltas.insert(newEntry)
 				} else {
 					if pad, has := baseAccounts.read(localState.Addr); has {
 						newEntry.oldResource = persistedResourcesData{addrid: pad.rowid}
@@ -544,9 +550,11 @@ func makeCompactResourceDeltas(accountDeltas []ledgercore.NewAccountDeltas, base
 					// meaning empty asset hodling (or app local state)
 					newEntry.newResource.ClearAppLocalState()
 				}
-				if baseResourceData, has := baseResources.read(appParams.Addr, basics.CreatableIndex(appParams.Aidx)); has {
+				baseResourceData, has := baseResources.read(appParams.Addr, basics.CreatableIndex(appParams.Aidx))
+				existingAcctCacheEntry := has && baseResourceData.addrid != 0
+				if existingAcctCacheEntry {
 					newEntry.oldResource = baseResourceData
-					outResourcesDeltas.insert(newEntry) // insert instead of upsert economizes one map lookup
+					outResourcesDeltas.insert(newEntry)
 				} else {
 					if pad, has := baseAccounts.read(appParams.Addr); has {
 						newEntry.oldResource = persistedResourcesData{addrid: pad.rowid}

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1397,7 +1397,7 @@ func (au *accountUpdates) commitRound(ctx context.Context, tx *sql.Tx, dcc *defe
 		return err
 	}
 
-	knownAddresses := make(map[basics.Address]int64)
+	knownAddresses := make(map[basics.Address]int64, len(dcc.compactAccountDeltas.deltas))
 	for _, delta := range dcc.compactAccountDeltas.deltas {
 		knownAddresses[delta.oldAcct.addr] = delta.oldAcct.rowid
 	}

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -619,7 +619,15 @@ func (bt *blockingTracker) close() {
 func TestCatchpointTrackerNonblockingCatchpointWriting(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	genesisInitState, _ := ledgertesting.GenerateInitState(t, protocol.ConsensusCurrentVersion, 10)
+	testProtocolVersion := protocol.ConsensusVersion("test-protocol-TestReproducibleCatchpointLabels")
+	protoParams := config.Consensus[protocol.ConsensusCurrentVersion]
+	protoParams.EnableAccountDataResourceSeparation = true
+	config.Consensus[testProtocolVersion] = protoParams
+	defer func() {
+		delete(config.Consensus, testProtocolVersion)
+	}()
+
+	genesisInitState, _ := ledgertesting.GenerateInitState(t, testProtocolVersion, 10)
 	const inMem = true
 	log := logging.TestingLog(t)
 	log.SetLevel(logging.Warn)

--- a/ledger/evalindexer_test.go
+++ b/ledger/evalindexer_test.go
@@ -323,7 +323,7 @@ func TestResourceCaching(t *testing.T) {
 	{
 		accountData, rnd, err := ilc.LookupWithoutRewards(basics.Round(0), address)
 		require.NoError(t, err)
-		assert.Equal(t, basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 5}}, accountData)
+		assert.Equal(t, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{MicroAlgos: basics.MicroAlgos{Raw: 5}}}, accountData)
 		assert.Equal(t, basics.Round(0), rnd)
 	}
 	{


### PR DESCRIPTION
Storing `resourceData` in `baseResources` cache for non-existing resources breaks addr to addrid resolution in makeCompactResourcesDelta. Improved the code by skipping empty addrids. This was discovered by TestAppAccountDataStorage.

Fixed some additional tests