### PR TITLE
Use gc to avoid trashing.

### DIFF
--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -730,7 +730,11 @@ func TestArchivalFromNonArchival(t *testing.T) {
 	require.NoError(t, err)
 	blk := genesisInitState.Block
 
-	const maxBlocks = 1500
+	// The next operations are heavy on the memory.
+	// Garbage collection helps prevent trashing
+	runtime.GC()
+
+	const maxBlocks = 2000
 	for i := 0; i < maxBlocks; i++ {
 		blk.BlockHeader.Round++
 		blk.BlockHeader.TimeStamp += int64(crypto.RandUint64() % 100 * 1000)
@@ -784,6 +788,9 @@ func TestArchivalFromNonArchival(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, basics.Round(0), earliest)
 	require.Equal(t, basics.Round(0), latest)
+
+	// Minimize the impact of the memory consumption here on other tests.
+	runtime.GC()
 }
 
 func checkTrackers(t *testing.T, wl *wrappedLedger, rnd basics.Round) (basics.Round, error) {


### PR DESCRIPTION
TestArchivalFromNonArchival was sporadically failing, particularly on the feature/dilithium-scheme-integration branch. 
The most likely reason for the slowdown is narrowed down to system trashing. 

This fix seems to fix the issue by invoking GC before the test to have maximum amount of memory available, and after the test to minimize the memory impact on subsequent tests.

This fix is also necessary to confirm the memory hypothesis. 

The memory consumption is high because of the existing ledger design, which is skewed in this test by creating a large number of asset creation transactions. This behavior is changing with the upcoming ledger refactoring project. 


Resolves https://github.com/algorand/go-algorand/issues/3334