### PR TITLE
ledger refactoring: tealdbg + dryrun tests fixes

### DIFF
--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -862,10 +862,10 @@ func (v2 *Handlers) GetAssetByID(ctx echo.Context, assetID uint64) error {
 		return internalError(ctx, err, errFailedLookingUpLedger, v2.Log)
 	}
 
-	if record.AssetParam == nil {
+	if record.AssetParams == nil {
 		return notFound(ctx, errors.New(errAssetDoesNotExist), errAssetDoesNotExist, v2.Log)
 	}
-	assetParams := *record.AssetParam
+	assetParams := *record.AssetParams
 	asset := AssetParamsToAsset(creator.String(), assetIdx, &assetParams)
 	response := generated.AssetResponse(asset)
 	return ctx.JSON(http.StatusOK, response)

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -179,7 +179,7 @@ func (prd *persistedResourcesData) AccountResource() ledgercore.AccountResource 
 		}
 		if prd.data.IsOwning() {
 			assetParams := prd.data.GetAssetParams()
-			ret.AssetParam = &assetParams
+			ret.AssetParams = &assetParams
 		}
 	}
 	if prd.data.IsApp() {

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -816,7 +816,7 @@ func (au *accountUpdates) newBlockImpl(blk bookkeeping.Block, delta ledgercore.S
 			index:   basics.CreatableIndex(params.Aidx),
 		}
 		mres := au.resources[key]
-		mres.resource.AssetParam = params.Params
+		mres.resource.AssetParams = params.Params
 		mres.ndeltas++
 		au.resources[key] = mres
 	}

--- a/ledger/evalindexer.go
+++ b/ledger/evalindexer.go
@@ -127,7 +127,7 @@ func toAccountResource(ad basics.AccountData, aidx basics.CreatableIndex, ctype 
 			ret.AssetHolding = &a
 		}
 		if a, ok := ad.AssetParams[basics.AssetIndex(aidx)]; ok {
-			ret.AssetParam = &a
+			ret.AssetParams = &a
 		}
 	}
 	return ret

--- a/ledger/internal/eval.go
+++ b/ledger/internal/eval.go
@@ -184,10 +184,10 @@ func (x *roundCowBase) lookup(addr basics.Address) (ledgercore.AccountData, erro
 
 func (x *roundCowBase) updateAssetResourceCache(aa ledgercore.AccountAsset, r ledgercore.AccountResource) {
 	// cache AssetParams and AssetHolding returned by LookupResource
-	if r.AssetParam == nil {
+	if r.AssetParams == nil {
 		x.assetParams[aa] = cachedAssetParams{exists: false}
 	} else {
-		x.assetParams[aa] = cachedAssetParams{value: *r.AssetParam, exists: true}
+		x.assetParams[aa] = cachedAssetParams{value: *r.AssetParams, exists: true}
 	}
 	if r.AssetHolding == nil {
 		x.assets[aa] = cachedAssetHolding{exists: false}
@@ -242,10 +242,10 @@ func (x *roundCowBase) lookupAssetParams(addr basics.Address, aidx basics.AssetI
 
 	x.updateAssetResourceCache(aa, resourceData)
 
-	if resourceData.AssetParam == nil {
+	if resourceData.AssetParams == nil {
 		return basics.AssetParams{}, false, nil
 	}
-	return *resourceData.AssetParam, true, nil
+	return *resourceData.AssetParams, true, nil
 }
 
 func (x *roundCowBase) lookupAppLocalState(addr basics.Address, aidx basics.AppIndex) (basics.AppLocalState, bool, error) {

--- a/ledger/internal/eval_test.go
+++ b/ledger/internal/eval_test.go
@@ -517,7 +517,7 @@ func (ledger *evalTestLedger) LookupResource(rnd basics.Round, addr basics.Addre
 		}
 	} else if ctype == basics.AssetCreatable {
 		if params, ok := ad.AssetParams[basics.AssetIndex(cidx)]; ok {
-			res.AssetParam = &params
+			res.AssetParams = &params
 		}
 		if h, ok := ad.Assets[basics.AssetIndex(cidx)]; ok {
 			res.AssetHolding = &h

--- a/ledger/ledgercore/accountresource.go
+++ b/ledger/ledgercore/accountresource.go
@@ -25,7 +25,7 @@ type AccountResource struct {
 	CreatableIndex basics.CreatableIndex
 	CreatableType  basics.CreatableType
 
-	AssetParam    *basics.AssetParams
+	AssetParams   *basics.AssetParams
 	AssetHolding  *basics.AssetHolding
 	AppLocalState *basics.AppLocalState
 	AppParams     *basics.AppParams

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -402,7 +402,7 @@ func (ad NewAccountDeltas) GetResource(addr basics.Address, aidx basics.Creatabl
 		aa := AccountAsset{addr, basics.AssetIndex(aidx)}
 		paramsIdx, okParams := ad.assetParamsCache[aa]
 		if okParams {
-			ret.AssetParam = ad.assetParams[paramsIdx].Params
+			ret.AssetParams = ad.assetParams[paramsIdx].Params
 		}
 		holdingIdx, okHolding := ad.assetHoldingsCache[aa]
 		if okHolding {


### PR DESCRIPTION
## Summary

Fix tealdbg and dryrun tests by implementing `LookupResource`.
Rename  `AccountResource.AssetParam` to `AccountResource.AssetParams` for consistency