### PR TITLE
Removing C/crypto dependencies from `data/abi` package

### DIFF
--- a/data/abi/abi_encode.go
+++ b/data/abi/abi_encode.go
@@ -201,7 +201,7 @@ func inferToSlice(value interface{}) ([]interface{}, error) {
 
 // encodeTuple encodes slice-of-interface of golang values to bytes, following ABI encoding rules
 func encodeTuple(value interface{}, childT []Type) ([]byte, error) {
-	if len(childT) >= (1 << 16) {
+	if len(childT) >= abiEncodingLengthLimit {
 		return nil, fmt.Errorf("abi child type number exceeds uint16 maximum")
 	}
 	values, err := inferToSlice(value)
@@ -277,7 +277,7 @@ func encodeTuple(value interface{}, childT []Type) ([]byte, error) {
 		if isDynamicIndex[i] {
 			// calculate where the index of dynamic value encoding byte start
 			headValue := headLength + tailCurrLength
-			if headValue >= (1 << 16) {
+			if headValue >= abiEncodingLengthLimit {
 				return nil, fmt.Errorf("cannot encode abi tuple: encode length exceeds uint16 maximum")
 			}
 			binary.BigEndian.PutUint16(heads[i], uint16(headValue))

--- a/data/abi/abi_encode.go
+++ b/data/abi/abi_encode.go
@@ -170,14 +170,14 @@ func encodeInt(intValue interface{}, bitSize uint16) ([]byte, error) {
 		return nil, fmt.Errorf("passed in numeric value should be non negative")
 	}
 
-	bytes := bigInt.Bytes()
-	if len(bytes) > int(bitSize/8) {
-		return nil, fmt.Errorf("input value bit size %d > abi type bit size %d", len(bytes)*8, bitSize)
+	castedBytes := make([]byte, bitSize/8)
+
+	if bigInt.Cmp(new(big.Int).Lsh(big.NewInt(1), uint(bitSize))) >= 0 {
+		return nil, fmt.Errorf("input value bit size %d > abi type bit size %d", bigInt.BitLen(), bitSize)
 	}
 
-	zeroPadding := make([]byte, bitSize/8-uint16(len(bytes)))
-	buffer := append(zeroPadding, bytes...)
-	return buffer, nil
+	bigInt.FillBytes(castedBytes)
+	return castedBytes, nil
 }
 
 // inferToSlice infers an interface element to a slice of interface{}, returns error if it cannot infer successfully

--- a/data/abi/abi_encode_test.go
+++ b/data/abi/abi_encode_test.go
@@ -29,21 +29,21 @@ import (
 )
 
 const (
-	UintStepLength             = 8
-	UintBegin                  = 8
-	UintEnd                    = 512
-	UintRandomTestPoints       = 1000
-	UintTestCaseCount          = 200
-	UfixedPrecision            = 160
-	UfixedRandomTestPoints     = 20
-	TupleMaxLength             = 10
-	ByteTestCaseCount          = 1 << 8
-	BoolTestCaseCount          = 2
-	AddressTestCaseCount       = 300
-	StringTestCaseCount        = 10
-	StringTestCaseSpecLenCount = 5
-	TakeNum                    = 10
-	TupleTestCaseCount         = 100
+	uintStepLength             = 8
+	uintBegin                  = 8
+	uintEnd                    = 512
+	uintRandomTestPoints       = 1000
+	uintTestCaseCount          = 200
+	ufixedPrecision            = 160
+	ufixedRandomTestPoints     = 20
+	tupleMaxLength             = 10
+	byteTestCaseCount          = 1 << 8
+	boolTestCaseCount          = 2
+	addressTestCaseCount       = 300
+	stringTestCaseCount        = 10
+	stringTestCaseSpecLenCount = 5
+	takeNum                    = 10
+	tupleTestCaseCount         = 100
 )
 
 /*
@@ -74,12 +74,12 @@ func TestEncodeValid(t *testing.T) {
 
 	// encoding test for uint type, iterating through all uint sizes
 	// randomly pick 1000 valid uint values and check if encoded value match with expected
-	for intSize := UintBegin; intSize <= UintEnd; intSize += UintStepLength {
+	for intSize := uintBegin; intSize <= uintEnd; intSize += uintStepLength {
 		upperLimit := big.NewInt(0).Lsh(big.NewInt(1), uint(intSize))
 		uintType, err := makeUintType(intSize)
 		require.NoError(t, err, "make uint type fail")
 
-		for i := 0; i < UintRandomTestPoints; i++ {
+		for i := 0; i < uintRandomTestPoints; i++ {
 			randomInt, err := rand.Int(rand.Reader, upperLimit)
 			require.NoError(t, err, "cryptographic random int init fail")
 
@@ -106,17 +106,17 @@ func TestEncodeValid(t *testing.T) {
 	// encoding test for ufixed, iterating through all the valid ufixed bitSize and precision
 	// randomly generate 10 big int values for ufixed numerator and check if encoded value match with expected
 	// also check if ufixed can fit max numerator (2^bitSize - 1) under specific byte bitSize
-	for size := UintBegin; size <= UintEnd; size += UintStepLength {
+	for size := uintBegin; size <= uintEnd; size += uintStepLength {
 		upperLimit := big.NewInt(0).Lsh(big.NewInt(1), uint(size))
 		largest := big.NewInt(0).Add(
 			upperLimit,
 			big.NewInt(1).Neg(big.NewInt(1)),
 		)
-		for precision := 1; precision <= UfixedPrecision; precision++ {
+		for precision := 1; precision <= ufixedPrecision; precision++ {
 			typeUfixed, err := makeUfixedType(size, precision)
 			require.NoError(t, err, "make ufixed type fail")
 
-			for i := 0; i < UfixedRandomTestPoints; i++ {
+			for i := 0; i < ufixedRandomTestPoints; i++ {
 				randomInt, err := rand.Int(rand.Reader, upperLimit)
 				require.NoError(t, err, "cryptographic random int init fail")
 
@@ -139,7 +139,7 @@ func TestEncodeValid(t *testing.T) {
 	// encoding test for address, since address is 32 byte, it can be considered as 256 bit uint
 	// randomly generate 1000 uint256 and make address values, check if encoded value match with expected
 	upperLimit := big.NewInt(0).Lsh(big.NewInt(1), addressByteSize<<3)
-	for i := 0; i < UintRandomTestPoints; i++ {
+	for i := 0; i < uintRandomTestPoints; i++ {
 		randomAddrInt, err := rand.Int(rand.Reader, upperLimit)
 		require.NoError(t, err, "cryptographic random int init fail")
 
@@ -153,7 +153,7 @@ func TestEncodeValid(t *testing.T) {
 	}
 
 	// encoding test for bool values
-	for i := 0; i < BoolTestCaseCount; i++ {
+	for i := 0; i < boolTestCaseCount; i++ {
 		boolEncode, err := boolType.Encode(i == 1)
 		require.NoError(t, err, "bool encode fail")
 		expected := []byte{0x00}
@@ -164,7 +164,7 @@ func TestEncodeValid(t *testing.T) {
 	}
 
 	// encoding test for byte values
-	for i := 0; i < ByteTestCaseCount; i++ {
+	for i := 0; i < byteTestCaseCount; i++ {
 		byteEncode, err := byteType.Encode(byte(i))
 		require.NoError(t, err, "byte encode fail")
 		expected := []byte{byte(i)}
@@ -175,8 +175,8 @@ func TestEncodeValid(t *testing.T) {
 	// we use `gobberish` to generate random utf-8 symbols
 	// randomly generate utf-8 str from length 1 to 100, each length draw 10 random strs
 	// check if encoded ABI str match with expected value
-	for length := 1; length <= StringTestCaseCount; length++ {
-		for i := 0; i < StringTestCaseSpecLenCount; i++ {
+	for length := 1; length <= stringTestCaseCount; length++ {
+		for i := 0; i < stringTestCaseSpecLenCount; i++ {
 			// generate utf8 strings from `gobberish` at some length
 			utf8Str := gobberish.GenerateString(length)
 			// since string is just type alias of `byte[]`, we need to store number of bytes in encoding
@@ -898,20 +898,20 @@ func categorySelfRoundTripTest(t *testing.T, category []testUnit) {
 }
 
 func addPrimitiveRandomValues(t *testing.T, pool *map[BaseType][]testUnit) {
-	(*pool)[Uint] = make([]testUnit, UintTestCaseCount*UintEnd/UintStepLength)
-	(*pool)[Ufixed] = make([]testUnit, UfixedPrecision*UintEnd/UintStepLength)
+	(*pool)[Uint] = make([]testUnit, uintTestCaseCount*uintEnd/uintStepLength)
+	(*pool)[Ufixed] = make([]testUnit, ufixedPrecision*uintEnd/uintStepLength)
 
 	uintIndex := 0
 	ufixedIndex := 0
 
-	for bitSize := UintBegin; bitSize <= UintEnd; bitSize += UintStepLength {
+	for bitSize := uintBegin; bitSize <= uintEnd; bitSize += uintStepLength {
 		max := new(big.Int).Lsh(big.NewInt(1), uint(bitSize))
 
 		uintT, err := makeUintType(bitSize)
 		require.NoError(t, err, "make uint type failure")
 		uintTstr := uintT.String()
 
-		for j := 0; j < UintTestCaseCount; j++ {
+		for j := 0; j < uintTestCaseCount; j++ {
 			randVal, err := rand.Int(rand.Reader, max)
 			require.NoError(t, err, "generate random uint, should be no error")
 
@@ -922,7 +922,7 @@ func addPrimitiveRandomValues(t *testing.T, pool *map[BaseType][]testUnit) {
 			uintIndex++
 		}
 
-		for precision := 1; precision <= UfixedPrecision; precision++ {
+		for precision := 1; precision <= ufixedPrecision; precision++ {
 			randVal, err := rand.Int(rand.Reader, max)
 			require.NoError(t, err, "generate random ufixed, should be no error")
 
@@ -939,20 +939,20 @@ func addPrimitiveRandomValues(t *testing.T, pool *map[BaseType][]testUnit) {
 	categorySelfRoundTripTest(t, (*pool)[Uint])
 	categorySelfRoundTripTest(t, (*pool)[Ufixed])
 
-	(*pool)[Byte] = make([]testUnit, ByteTestCaseCount)
-	for i := 0; i < ByteTestCaseCount; i++ {
+	(*pool)[Byte] = make([]testUnit, byteTestCaseCount)
+	for i := 0; i < byteTestCaseCount; i++ {
 		(*pool)[Byte][i] = testUnit{serializedType: byteType.String(), value: byte(i)}
 	}
 	categorySelfRoundTripTest(t, (*pool)[Byte])
 
-	(*pool)[Bool] = make([]testUnit, BoolTestCaseCount)
+	(*pool)[Bool] = make([]testUnit, boolTestCaseCount)
 	(*pool)[Bool][0] = testUnit{serializedType: boolType.String(), value: false}
 	(*pool)[Bool][1] = testUnit{serializedType: boolType.String(), value: true}
 	categorySelfRoundTripTest(t, (*pool)[Bool])
 
 	maxAddress := new(big.Int).Lsh(big.NewInt(1), addressByteSize<<3)
-	(*pool)[Address] = make([]testUnit, AddressTestCaseCount)
-	for i := 0; i < AddressTestCaseCount; i++ {
+	(*pool)[Address] = make([]testUnit, addressTestCaseCount)
+	for i := 0; i < addressTestCaseCount; i++ {
 		randAddrVal, err := rand.Int(rand.Reader, maxAddress)
 		require.NoError(t, err, "generate random value for address, should be no error")
 		addrBytes := randAddrVal.Bytes()
@@ -962,10 +962,10 @@ func addPrimitiveRandomValues(t *testing.T, pool *map[BaseType][]testUnit) {
 	}
 	categorySelfRoundTripTest(t, (*pool)[Address])
 
-	(*pool)[String] = make([]testUnit, StringTestCaseCount*StringTestCaseSpecLenCount)
+	(*pool)[String] = make([]testUnit, stringTestCaseCount*stringTestCaseSpecLenCount)
 	stringIndex := 0
-	for length := 1; length <= StringTestCaseCount; length++ {
-		for i := 0; i < StringTestCaseSpecLenCount; i++ {
+	for length := 1; length <= stringTestCaseCount; length++ {
+		for i := 0; i < stringTestCaseSpecLenCount; i++ {
 			(*pool)[String][stringIndex] = testUnit{
 				serializedType: stringType.String(),
 				value:          gobberish.GenerateString(length),
@@ -1000,21 +1000,21 @@ func takeSomeFromCategoryAndGenerateArray(
 }
 
 func addArrayRandomValues(t *testing.T, pool *map[BaseType][]testUnit) {
-	for intIndex := 0; intIndex < len((*pool)[Uint]); intIndex += UintTestCaseCount {
-		takeSomeFromCategoryAndGenerateArray(t, Uint, intIndex, TakeNum, pool)
+	for intIndex := 0; intIndex < len((*pool)[Uint]); intIndex += uintTestCaseCount {
+		takeSomeFromCategoryAndGenerateArray(t, Uint, intIndex, takeNum, pool)
 	}
-	takeSomeFromCategoryAndGenerateArray(t, Byte, 0, TakeNum, pool)
-	takeSomeFromCategoryAndGenerateArray(t, Address, 0, TakeNum, pool)
-	takeSomeFromCategoryAndGenerateArray(t, String, 0, TakeNum, pool)
-	takeSomeFromCategoryAndGenerateArray(t, Bool, 0, TakeNum, pool)
+	takeSomeFromCategoryAndGenerateArray(t, Byte, 0, takeNum, pool)
+	takeSomeFromCategoryAndGenerateArray(t, Address, 0, takeNum, pool)
+	takeSomeFromCategoryAndGenerateArray(t, String, 0, takeNum, pool)
+	takeSomeFromCategoryAndGenerateArray(t, Bool, 0, takeNum, pool)
 
 	categorySelfRoundTripTest(t, (*pool)[ArrayStatic])
 	categorySelfRoundTripTest(t, (*pool)[ArrayDynamic])
 }
 
 func addTupleRandomValues(t *testing.T, slotRange BaseType, pool *map[BaseType][]testUnit) {
-	for i := 0; i < TupleTestCaseCount; i++ {
-		tupleLenBig, err := rand.Int(rand.Reader, big.NewInt(TupleMaxLength))
+	for i := 0; i < tupleTestCaseCount; i++ {
+		tupleLenBig, err := rand.Int(rand.Reader, big.NewInt(tupleMaxLength))
 		require.NoError(t, err, "generate random tuple length should not return error")
 		tupleLen := tupleLenBig.Int64() + 1
 		testUnits := make([]testUnit, tupleLen)

--- a/data/abi/abi_json.go
+++ b/data/abi/abi_json.go
@@ -25,6 +25,9 @@ import (
 	"math/big"
 )
 
+// NOTE: discussion about go-algorand-sdk
+// https://github.com/algorand/go-algorand/pull/3375#issuecomment-1007536841
+
 var base32Encoder = base32.StdEncoding.WithPadding(base32.NoPadding)
 
 func addressCheckSum(addressBytes []byte) ([]byte, error) {

--- a/data/abi/abi_json.go
+++ b/data/abi/abi_json.go
@@ -18,11 +18,15 @@ package abi
 
 import (
 	"bytes"
+	"encoding/base32"
 	"encoding/json"
 	"fmt"
-	"github.com/algorand/go-algorand/data/basics"
 	"math/big"
+
+	"github.com/algorand/go-algorand/crypto"
 )
+
+var base32Encoder = base32.StdEncoding.WithPadding(base32.NoPadding)
 
 func castBigIntToNearestPrimitive(num *big.Int, bitSize uint16) (interface{}, error) {
 	if num.BitLen() > int(bitSize) {
@@ -74,17 +78,21 @@ func (t Type) MarshalToJSON(value interface{}) ([]byte, error) {
 		}
 		return json.Marshal(byteValue)
 	case Address:
-		var addressInternal basics.Address
+		var addressValueInternal []byte
 		switch valueCasted := value.(type) {
 		case []byte:
-			copy(addressInternal[:], valueCasted[:])
-			return json.Marshal(addressInternal.String())
+			if len(valueCasted) != addressByteSize {
+				return nil, fmt.Errorf("address byte slice length not equal to 32 byte")
+			}
+			addressValueInternal = valueCasted
 		case [addressByteSize]byte:
-			addressInternal = valueCasted
-			return json.Marshal(addressInternal.String())
+			copy(addressValueInternal[:], valueCasted[:])
 		default:
 			return nil, fmt.Errorf("cannot infer to byte slice/array for marshal to JSON")
 		}
+		checksum := crypto.Hash(addressValueInternal)
+		addressValueInternal = append(addressValueInternal, checksum[addressByteSize-checksumByteSize:]...)
+		return json.Marshal(base32Encoder.EncodeToString(addressValueInternal))
 	case ArrayStatic, ArrayDynamic:
 		values, err := inferToSlice(value)
 		if err != nil {
@@ -175,13 +183,26 @@ func (t Type) UnmarshalFromJSON(jsonEncoded []byte) (interface{}, error) {
 	case Address:
 		var addrStr string
 		if err := json.Unmarshal(jsonEncoded, &addrStr); err != nil {
-			return nil, fmt.Errorf("cannot cast JSON encoded to string: %v", err)
+			return nil, fmt.Errorf("cannot cast JSON encoded to address string: %v", err)
 		}
-		addr, err := basics.UnmarshalChecksumAddress(addrStr)
+		decoded, err := base32Encoder.DecodeString(addrStr)
 		if err != nil {
-			return nil, fmt.Errorf("cannot cast JSON encoded (%s) to address: %v", string(jsonEncoded), err)
+			return nil,
+				fmt.Errorf("cannot cast JSON encoded address string (%s) to address: %v", addrStr, err)
 		}
-		return addr[:], nil
+		if len(decoded) != addressByteSize+checksumByteSize {
+			return nil,
+				fmt.Errorf(
+					"cannot cast JSON encoded address string (%s) to address: "+
+						"decoded byte length should equal to 36 with address and checksum",
+					string(jsonEncoded),
+				)
+		}
+		checksum := crypto.Hash(decoded[:addressByteSize])
+		if !bytes.Equal(checksum[addressByteSize-checksumByteSize:], decoded[addressByteSize:]) {
+			return nil, fmt.Errorf("cannot cast JSON encoded address string (%s) to address: decoded checksum unmatch", addrStr)
+		}
+		return decoded[:addressByteSize], nil
 	case ArrayStatic, ArrayDynamic:
 		if t.childTypes[0].abiTypeID == Byte && bytes.HasPrefix(jsonEncoded, []byte{'"'}) {
 			var byteArr []byte

--- a/data/abi/abi_json.go
+++ b/data/abi/abi_json.go
@@ -35,7 +35,7 @@ func addressCheckSum(addressBytes []byte) ([]byte, error) {
 		return nil, fmt.Errorf("address bytes should be of length 32")
 	}
 	hashed := sha512.Sum512_256(addressBytes[:])
-	return hashed[:checksumByteSize], nil
+	return hashed[addressByteSize-checksumByteSize:], nil
 }
 
 func castBigIntToNearestPrimitive(num *big.Int, bitSize uint16) (interface{}, error) {

--- a/data/abi/abi_json_test.go
+++ b/data/abi/abi_json_test.go
@@ -23,6 +23,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRandomAddressEquality(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	for testCaseIndex := 0; testCaseIndex < 100; testCaseIndex++ {
+		// Generate random 32 byte address pk
+		// compute checksum of `basics.Address`
+		// compute checksum of abi's Address
+	}
+}
+
 func TestJSONtoInterfaceValid(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	var testCases = []struct {

--- a/data/abi/abi_type.go
+++ b/data/abi/abi_type.go
@@ -60,6 +60,14 @@ const (
 	Tuple
 )
 
+const (
+	addressByteSize      = 32
+	checksumByteSize     = 4
+	singleByteSize       = 1
+	singleBoolSize       = 1
+	lengthEncodeByteSize = 2
+)
+
 // Type is the struct that stores information about an ABI value's type.
 type Type struct {
 	abiTypeID  BaseType
@@ -404,14 +412,6 @@ func findBoolLR(typeList []Type, index int, delta int) int {
 	}
 	return until
 }
-
-const (
-	addressByteSize      = 32
-	checksumByteSize     = 4
-	singleByteSize       = 1
-	singleBoolSize       = 1
-	lengthEncodeByteSize = 2
-)
 
 // ByteLen method calculates the byte length of a static ABI type.
 func (t Type) ByteLen() (int, error) {

--- a/data/abi/abi_type.go
+++ b/data/abi/abi_type.go
@@ -61,11 +61,12 @@ const (
 )
 
 const (
-	addressByteSize      = 32
-	checksumByteSize     = 4
-	singleByteSize       = 1
-	singleBoolSize       = 1
-	lengthEncodeByteSize = 2
+	addressByteSize        = 32
+	checksumByteSize       = 4
+	singleByteSize         = 1
+	singleBoolSize         = 1
+	lengthEncodeByteSize   = 2
+	abiEncodingLengthLimit = 1 << 16
 )
 
 // Type is the struct that stores information about an ABI value's type.

--- a/data/abi/abi_type.go
+++ b/data/abi/abi_type.go
@@ -407,6 +407,7 @@ func findBoolLR(typeList []Type, index int, delta int) int {
 
 const (
 	addressByteSize      = 32
+	checksumByteSize     = 4
 	singleByteSize       = 1
 	singleBoolSize       = 1
 	lengthEncodeByteSize = 2

--- a/data/basics/address.go
+++ b/data/basics/address.go
@@ -24,6 +24,23 @@ import (
 	"github.com/algorand/go-algorand/crypto"
 )
 
+// NOTE: Another (partial) implementation of `basics.Address` is in `data/abi`.
+//       The reason of not using this `Address` in `data/abi` is that:
+//       - `data/basics` has C dependencies (`go-algorand/crypto`)
+//       - `go-algorand-sdk` has dependency to `go-algorand` for `ABI`
+//       - if `go-algorand`'s ABI uses `basics.Address`, then it would be
+//         impossible to up the version of `go-algorand` in `go-algorand-sdk`
+
+// This is discussed in:
+// - ISSUE https://github.com/algorand/go-algorand/issues/3355
+// - PR https://github.com/algorand/go-algorand/pull/3375
+
+// There are two solutions:
+// - One is to refactoring `crypto.Digest`, `crypto.Hash` and `basics.Address`
+//   into packages that does not need `libsodium` crypto dependency
+// - The other is wrapping `libsodium` in a driver interface to make crypto
+//   package importable (even if `libsodium` does not exist)
+
 type (
 	// Address is a unique identifier corresponding to ownership of money
 	Address crypto.Digest


### PR DESCRIPTION
## Summary

We want to remove C/crypto dependencies from `data/abi` package, because the previous commit https://github.com/algorand/go-algorand/commit/d3bbe62caa11a2608c318919122457d4512045c5 introduced dependencies to crypto package with C dependencies (`SHA512/256` needed). This led to go-algorand-sdk cannot  easily update go-algorand past that commit.

The current solution is: "rewrite" the checksum function for address in `data/abi` package, which removes dependencies to `data/basics` and `algorand/crypto`, and sets dependency to `crypto` (golang).

Refactor the `data/abi` package to avoid referencing `data/basics`, closes #3355.