### PR TITLE
Fix Flaky Async Telemetry Test

### DIFF
--- a/logging/telemetryhook_test.go
+++ b/logging/telemetryhook_test.go
@@ -225,5 +225,10 @@ func TestAsyncTelemetryHook_QueueDepth(t *testing.T) {
 	close(filling)
 	hook.Close()
 
-	require.Equal(t, maxDepth, len(testHook.entries()))
+	hookEntries := len(testHook.entries())
+	require.GreaterOrEqual(t, hookEntries, maxDepth)
+	// the anonymous goroutine in createAsyncHookLevels might pull an entry off the pending list before
+	// writing it off to the underlying hook. when that happens, the total number of sent entries could
+	// be one higher then the maxDepth.
+	require.LessOrEqual(t, hookEntries, maxDepth+1)
 }


### PR DESCRIPTION
Resolves #2934 

https://github.com/algorand/go-algorand/issues/2394

Fix the unit test TestAsyncTelemetryHook_QueueDepth:

	// the anonymous goroutine in createAsyncHookLevels might pull an entry off the pending list before
	// writing it off to the underlying hook. when that happens, the total number of sent entries could
	// be one higher then the maxDepth.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
