### PR TITLE
Deprecate `FastPartitionRecovery` from `ConsensusParams`

### DIFF
--- a/agreement/demux.go
+++ b/agreement/demux.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/logging/logspec"
 	"github.com/algorand/go-algorand/protocol"
@@ -236,22 +235,7 @@ func (d *demux) next(s *Service, deadline time.Duration, fastDeadline time.Durat
 
 	ledgerNextRoundCh := s.Ledger.Wait(nextRound)
 	deadlineCh := s.Clock.TimeoutAt(deadline)
-	var fastDeadlineCh <-chan time.Time
-
-	fastPartitionRecoveryEnabled := false
-	if proto, err := d.ledger.ConsensusVersion(ParamsRound(currentRound)); err != nil {
-		logging.Base().Warnf("demux: could not get consensus parameters for round %d: %v", ParamsRound(currentRound), err)
-		// this might happen during catchup, since the Ledger.Wait fires as soon as a new block is received by the ledger, which could be
-		// far before it's being committed. In these cases, it should be safe to default to the current consensus version. On subsequent
-		// iterations, it will get "corrected" since the ledger would finish flushing the blocks to disk.
-		fastPartitionRecoveryEnabled = config.Consensus[protocol.ConsensusCurrentVersion].FastPartitionRecovery
-	} else {
-		fastPartitionRecoveryEnabled = config.Consensus[proto].FastPartitionRecovery
-	}
-
-	if fastPartitionRecoveryEnabled {
-		fastDeadlineCh = s.Clock.TimeoutAt(fastDeadline)
-	}
+	fastDeadlineCh := s.Clock.TimeoutAt(fastDeadline)
 
 	d.UpdateEventsQueue(eventQueueDemux, 0)
 	d.monitor.dec(demuxCoserviceType)

--- a/agreement/vote.go
+++ b/agreement/vote.go
@@ -152,23 +152,14 @@ func makeVote(rv rawVote, voting crypto.OneTimeSigner, selection *crypto.VRFSecr
 		return unauthenticatedVote{}, fmt.Errorf("makeVote: could not get consensus params for round %d: %v", ParamsRound(rv.Round), err)
 	}
 
-	if proto.FastPartitionRecovery {
-		switch rv.Step {
-		case propose, soft, cert, late, redo:
-			if rv.Proposal == bottom {
-				logging.Base().Panicf("makeVote: votes from step %d cannot validate bottom", rv.Step)
-			}
-		case down:
-			if rv.Proposal != bottom {
-				logging.Base().Panicf("makeVote: votes from step %d must validate bottom", rv.Step)
-			}
+	switch rv.Step {
+	case propose, soft, cert, late, redo:
+		if rv.Proposal == bottom {
+			logging.Base().Panicf("makeVote: votes from step %d cannot validate bottom", rv.Step)
 		}
-	} else {
-		switch rv.Step {
-		case propose, soft, cert:
-			if rv.Proposal == bottom {
-				logging.Base().Panicf("makeVote: votes from step %d cannot validate bottom", rv.Step)
-			}
+	case down:
+		if rv.Proposal != bottom {
+			logging.Base().Panicf("makeVote: votes from step %d must validate bottom", rv.Step)
 		}
 	}
 

--- a/agreement/voteAggregator.go
+++ b/agreement/voteAggregator.go
@@ -19,7 +19,6 @@ package agreement
 import (
 	"fmt"
 
-	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 )
@@ -227,7 +226,7 @@ func voteStepFresh(descr string, proto protocol.ConsensusVersion, mine, vote ste
 		// always propagate first recovery vote to ensure synchronous block of periods after partition
 		return nil
 	}
-	if config.Consensus[proto].FastPartitionRecovery && vote >= late {
+	if vote >= late {
 		// always propagate fast partition recovery votes
 		return nil
 	}

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -153,7 +153,6 @@ type ConsensusParams struct {
 	AgreementFilterTimeoutPeriod0 time.Duration
 
 	FastRecoveryLambda    time.Duration // time between fast recovery attempts
-	FastPartitionRecovery bool          // set when fast partition recovery is enabled
 
 	// how to commit to the payset: flat or merkle tree
 	PaysetCommit PaysetCommitType
@@ -708,7 +707,6 @@ func initConsensusProtocols() {
 
 	// v10 introduces fast partition recovery (and also raises NumProposers).
 	v10 := v9
-	v10.FastPartitionRecovery = true
 	v10.NumProposers = 20
 	v10.LateCommitteeSize = 500
 	v10.LateCommitteeThreshold = 320

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -152,7 +152,7 @@ type ConsensusParams struct {
 	// critical path
 	AgreementFilterTimeoutPeriod0 time.Duration
 
-	FastRecoveryLambda    time.Duration // time between fast recovery attempts
+	FastRecoveryLambda time.Duration // time between fast recovery attempts
 
 	// how to commit to the payset: flat or merkle tree
 	PaysetCommit PaysetCommitType

--- a/test/testdata/consensus/catchpointtestingprotocol.json
+++ b/test/testdata/consensus/catchpointtestingprotocol.json
@@ -36,7 +36,6 @@
     "AgreementFilterTimeout": 1000000000,
     "AgreementFilterTimeoutPeriod0": 1000000000,
     "FastRecoveryLambda": 300000000000,
-    "FastPartitionRecovery": true,
     "PaysetCommit": 1,
     "MaxTimestampIncrement": 25,
     "SupportSignedTxnInBlock": true,


### PR DESCRIPTION
## Summary

This PR removes `FastPartitionRecovery` option from consensus parameters. The code now acts as if this value is set to true.

Closes https://github.com/algorand/go-algorand-internal/issues/1830.

## Test Plan

None.