### PR TITLE
Add `SqliteReadConcurrency` parameter

### DIFF
--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -430,6 +430,9 @@ type Local struct {
 	// The http server does not accept new connections as long we have this many
 	// (hard limit) connections already.
 	RestConnectionsHardLimit uint64 `version[20]:"2048"`
+
+	// How many times tracker and block sqlite dbs can be open for reading simultaneously.
+	SqliteReadConcurrency uint64 `version[20]:"128"`
 }
 
 // DNSBootstrapArray returns an array of one or more DNS Bootstrap identifiers

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -104,6 +104,7 @@ var defaultLocal = Local{
 	RestReadTimeoutSeconds:                     15,
 	RestWriteTimeoutSeconds:                    120,
 	RunHosted:                                  false,
+	SqliteReadConcurrency:                      128,
 	SuggestedFeeBlockHistory:                   3,
 	SuggestedFeeSlidingWindowSize:              50,
 	TLSCertFile:                                "",

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -83,6 +83,7 @@
     "RestReadTimeoutSeconds": 15,
     "RestWriteTimeoutSeconds": 120,
     "RunHosted": false,
+    "SqliteReadConcurrency": 128,
     "SuggestedFeeBlockHistory": 3,
     "SuggestedFeeSlidingWindowSize": 50,
     "TLSCertFile": "",

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -137,7 +137,7 @@ func OpenLedger(
 	l.blockDBs.Rdb.SetLogger(log)
 	l.blockDBs.Wdb.SetLogger(log)
 
-	if cfg.SqliteReadConcurrency > uint64((^uint(0)) >> 1) {
+	if cfg.SqliteReadConcurrency > uint64((^uint(0))>>1) {
 		return nil, fmt.Errorf(
 			"OpenLedger() cfg.SqliteReadConcurrency: %d is larger than max int",
 			cfg.SqliteReadConcurrency)

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"math"
 	"os"
 	"time"
 
@@ -138,7 +137,7 @@ func OpenLedger(
 	l.blockDBs.Rdb.SetLogger(log)
 	l.blockDBs.Wdb.SetLogger(log)
 
-	if cfg.SqliteReadConcurrency > math.MaxInt {
+	if cfg.SqliteReadConcurrency > uint64((^uint(0)) >> 1) {
 		return nil, fmt.Errorf(
 			"OpenLedger() cfg.SqliteReadConcurrency: %d is larger than max int",
 			cfg.SqliteReadConcurrency)

--- a/test/testdata/configs/config-v20.json
+++ b/test/testdata/configs/config-v20.json
@@ -83,6 +83,7 @@
     "RestReadTimeoutSeconds": 15,
     "RestWriteTimeoutSeconds": 120,
     "RunHosted": false,
+    "SqliteReadConcurrency": 128,
     "SuggestedFeeBlockHistory": 3,
     "SuggestedFeeSlidingWindowSize": 50,
     "TLSCertFile": "",


### PR DESCRIPTION
## Summary

Add `SqliteReadConcurrency` parameter to local config and take it into account when calculating the number of available file descriptors required. `SqliteReadConcurrency` is then used to limit number of read "connections" to the block and tracker databases.

Each database "connection" will create 3 file descriptors for opening the database: .sqlite, sqlite-shm and .sqlite-wal. The current FD budgeting doesn't account for this.

## Test Plan

None.