### PR TITLE
Make TestAcctUpdates faster

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -129,7 +129,6 @@ var accountsResetExprs = []string{
 // accountDBVersion is the database version that this binary would know how to support and how to upgrade to.
 // details about the content of each of the versions can be found in the upgrade functions upgradeDatabaseSchemaXXXX
 // and their descriptions.
-// TODO - this should be bumped to 6 if we want to enable the new database schema upgrade.
 var accountDBVersion = int32(6)
 
 // persistedAccountData is used for representing a single account stored on the disk. In addition to the
@@ -2621,7 +2620,7 @@ func reencodeAccounts(ctx context.Context, tx *sql.Tx) (modifiedAccounts uint, e
 			return
 		}
 		reencodedAccountData := protocol.Encode(&decodedAccountData)
-		if bytes.Compare(preencodedAccountData, reencodedAccountData) == 0 {
+		if bytes.Equal(preencodedAccountData, reencodedAccountData) {
 			// these are identical, no need to store re-encoded account data
 			continue
 		}
@@ -2646,7 +2645,7 @@ func reencodeAccounts(ctx context.Context, tx *sql.Tx) (modifiedAccounts uint, e
 	return
 }
 
-// MerkleCommitter todo
+// MerkleCommitter allows storing and loading merkletrie pages from a sqlite database.
 //msgp:ignore MerkleCommitter
 type MerkleCommitter struct {
 	tx         *sql.Tx

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -352,7 +352,7 @@ func randomCreatableSampling(iteration int, crtbsList []basics.CreatableIndex,
 		if ctb.Created &&
 			// Always delete the first element, to make sure at least one
 			// element is always deleted.
-			(i == delSegmentStart || 1 == (crypto.RandUint64()%2)) {
+			(i == delSegmentStart || (crypto.RandUint64()%2) == 1) {
 			ctb.Created = false
 			newSample[crtbsList[i]] = ctb
 			delete(expectedDbImage, crtbsList[i])

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -200,12 +200,6 @@ type accountUpdates struct {
 	lastMetricsLogTime time.Time
 }
 
-type deferredCommit struct {
-	offset   uint64
-	dbRound  basics.Round
-	lookback basics.Round
-}
-
 // RoundOffsetError is an error for when requested round is behind earliest stored db entry
 type RoundOffsetError struct {
 	round   basics.Round

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -493,7 +493,9 @@ func TestAcctUpdates(t *testing.T) {
 	lastCreatableID := crypto.RandUint64() % 512
 	knownCreatables := make(map[basics.CreatableIndex]bool)
 
-	for i := basics.Round(10); i < basics.Round(proto.MaxBalLookback+15); i++ {
+	start := basics.Round(10)
+	end := basics.Round(proto.MaxBalLookback + 15)
+	for i := start; i < end; i++ {
 		rewardLevelDelta := crypto.RandUint64() % 5
 		rewardLevel += rewardLevelDelta
 		var updates ledgercore.NewAccountDeltas
@@ -526,7 +528,11 @@ func TestAcctUpdates(t *testing.T) {
 		accts = append(accts, newAccts)
 		rewardsLevels = append(rewardsLevels, rewardLevel)
 
-		checkAcctUpdates(t, au, 0, i, accts, rewardsLevels, proto)
+		// checkAcctUpdates is kind of slow because of amount of data it needs to compare
+		// instead, compare at start, end in between approx 10 rounds
+		if i == start || i == end-1 || crypto.RandUint64()%10 == 0 {
+			checkAcctUpdates(t, au, 0, i, accts, rewardsLevels, proto)
+		}
 	}
 
 	for i := basics.Round(0); i < 15; i++ {

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -264,42 +264,6 @@ func newAcctUpdates(tb testing.TB, l *mockLedgerForTracker, conf config.Local, d
 	return au
 }
 
-// checkEqualAcctMaps is a low-memory version of map[basics.Address]basics.AccountData comparator.
-// It is slow (10s on TestAcctUpdates ) than require.Equal -> reflect.DeepEqual
-// but uses much less memory (0.9GB vs 4GB on TestAcctUpdates)
-func checkEqualAcctMaps(t *testing.T, all, bll map[basics.Address]basics.AccountData) {
-	require.Equal(t, len(all), len(bll))
-	for addr, ad := range all {
-		bd := bll[addr]
-		require.Equal(t, len(ad.AppParams), len(bd.AppParams))
-		require.Equal(t, len(ad.AppLocalStates), len(bd.AppLocalStates))
-		require.Equal(t, len(ad.AssetParams), len(bd.AssetParams))
-		require.Equal(t, len(ad.Assets), len(bd.Assets))
-		for aidx, a := range ad.AppParams {
-			require.Equal(t, a, bd.AppParams[aidx])
-		}
-		for aidx, a := range ad.AppLocalStates {
-			require.Equal(t, a, bd.AppLocalStates[aidx])
-		}
-		for aidx, a := range ad.AssetParams {
-			require.Equal(t, a, bd.AssetParams[aidx])
-		}
-		for aidx, a := range ad.Assets {
-			require.Equal(t, a, bd.Assets[aidx])
-		}
-		ad.AppParams = nil
-		ad.AppLocalStates = nil
-		ad.AssetParams = nil
-		ad.Assets = nil
-		bd.AppParams = nil
-		bd.AppLocalStates = nil
-		bd.AssetParams = nil
-		bd.Assets = nil
-
-		require.Equal(t, ad, bd)
-	}
-}
-
 func checkAcctUpdates(t *testing.T, au *accountUpdates, base basics.Round, latestRnd basics.Round, accts []map[basics.Address]basics.AccountData, rewards []uint64, proto config.ConsensusParams) {
 	latest := au.latest()
 	require.Equal(t, latestRnd, latest)

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -107,44 +107,34 @@ type StateDelta struct {
 	Totals AccountTotals
 }
 
-// AccountDeltas stores ordered accounts and allows fast lookup by address
-// type AccountDeltas struct {
-// 	// Actual data. If an account is deleted, `accts` contains a balance record
-// 	// with empty `AccountData`.
-// 	accts []basics.BalanceRecord
-// 	// cache for addr to deltas index resolution
-// 	acctsCache map[basics.Address]int
-// }
-
-// NewBalanceRecord todo
+// NewBalanceRecord is similar to basics.BalanceRecord but with decoupled base and voting data
 type NewBalanceRecord struct {
 	Addr basics.Address
-
 	AccountData
 }
 
-// AppParamsRecord todo
+// AppParamsRecord represents app params in deltas
 type AppParamsRecord struct {
 	Aidx   basics.AppIndex
 	Addr   basics.Address
 	Params *basics.AppParams
 }
 
-// AssetParamsRecord todo
+// AssetParamsRecord represents asset params in deltas
 type AssetParamsRecord struct {
 	Aidx   basics.AssetIndex
 	Addr   basics.Address
 	Params *basics.AssetParams
 }
 
-// AppLocalStateRecord todo
+// AppLocalStateRecord represents app local state in deltas
 type AppLocalStateRecord struct {
 	Aidx  basics.AppIndex
 	Addr  basics.Address
 	State *basics.AppLocalState
 }
 
-// AssetHoldingRecord TODO
+// AssetHoldingRecord represents asset holding in deltas
 type AssetHoldingRecord struct {
 	Aidx    basics.AssetIndex
 	Addr    basics.Address
@@ -822,22 +812,22 @@ func (ad NewAccountDeltas) ApplyToBasicsAccountData(addr basics.Address, prev ba
 	return result
 }
 
-// GetAllAppParams todo
+// GetAllAppParams returns all app params
 func (ad *NewAccountDeltas) GetAllAppParams() []AppParamsRecord {
 	return ad.appParams
 }
 
-// GetAllAppLocalStates todo
+// GetAllAppLocalStates returns all app local states
 func (ad *NewAccountDeltas) GetAllAppLocalStates() []AppLocalStateRecord {
 	return ad.appLocalStates
 }
 
-// GetAllAssetParams todo
+// GetAllAssetParams returns all asset params
 func (ad *NewAccountDeltas) GetAllAssetParams() []AssetParamsRecord {
 	return ad.assetParams
 }
 
-// GetAllAssetsHoldings todo
+// GetAllAssetsHoldings returns all asset holdings
 func (ad *NewAccountDeltas) GetAllAssetsHoldings() []AssetHoldingRecord {
 	return ad.assetHoldings
 }


### PR DESCRIPTION
* TestAcctUpdates used to compare acct updates content every round
  but this is slow due to amount of data needed to be compared.
* This fix suggest making comparison at first, end and approx every
  10 iterations.
