### PR TITLE
ledger refactoring: restore fast rounds for catchpoint e2e test

### DIFF
--- a/test/testdata/consensus/catchpointtestingprotocol.json
+++ b/test/testdata/consensus/catchpointtestingprotocol.json
@@ -1,7 +1,7 @@
 {
   "catchpointtestingprotocol": {
-    "AgreementFilterTimeout": 4000000000,
-    "AgreementFilterTimeoutPeriod0": 4000000000,
+    "AgreementFilterTimeout": 1000000000,
+    "AgreementFilterTimeoutPeriod0": 1000000000,
     "AppFlatOptInMinBalance": 100000,
     "AppFlatParamsMinBalance": 100000,
     "Application": true,


### PR DESCRIPTION
The old values were incorrectly replaced by 4s default valus in #3195