### PR TITLE
network: faster node shutdown

### DIFF
--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -128,7 +128,7 @@ var outgoingPeers = metrics.MakeGauge(metrics.MetricName{Name: "algod_network_ou
 // peerDisconnectionAckDuration defines the time we would wait for the peer disconnection to compelete.
 const peerDisconnectionAckDuration time.Duration = 5 * time.Second
 
-// peerDisconnectionAckDuration defines the time we would wait for the peer disconnection to compelete during shutdown.
+// peerShutdownDisconnectionAckDuration defines the time we would wait for the peer disconnection to compelete during shutdown.
 const peerShutdownDisconnectionAckDuration time.Duration = 50 * time.Millisecond
 
 // Peer opaque interface for referring to a neighbor in the network

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -754,15 +754,15 @@ func (wp *wsPeer) internalClose(reason disconnectReason) {
 	if atomic.CompareAndSwapInt32(&wp.didSignalClose, 0, 1) {
 		wp.net.peerRemoteClose(wp, reason)
 	}
-	wp.Close()
+	wp.Close(time.Now().Add(peerDisconnectionAckDuration))
 }
 
 // called either here or from above enclosing node logic
-func (wp *wsPeer) Close() {
+func (wp *wsPeer) Close(deadline time.Time) {
 	atomic.StoreInt32(&wp.didSignalClose, 1)
 	if atomic.CompareAndSwapInt32(&wp.didInnerClose, 0, 1) {
 		close(wp.closing)
-		err := wp.conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), time.Now().Add(5*time.Second))
+		err := wp.conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), deadline)
 		if err != nil {
 			wp.net.log.Infof("failed to write CloseMessage to connection for %s", wp.conn.RemoteAddr().String())
 		}
@@ -774,8 +774,8 @@ func (wp *wsPeer) Close() {
 }
 
 // CloseAndWait internally calls Close() then waits for all peer activity to stop
-func (wp *wsPeer) CloseAndWait() {
-	wp.Close()
+func (wp *wsPeer) CloseAndWait(deadline time.Time) {
+	wp.Close(deadline)
 	wp.wg.Wait()
 }
 


### PR DESCRIPTION
## Summary

During the node shutdown, all the current outgoing connections are being disconnected.
Since these connections are web sockets, they require a close connection message to be sent.
However, sending this message can take a while, and in situations where the other party has already shut down, we might never get a response. That, in turn, would lead the node waiting until the deadline is reached.

The current deadline was 5 seconds. This PR changes the deadline during shutdown to be 50ms.

## Test Plan

Use existing unit tests.
