### PR TITLE
Avoid copying during baseAccountData.IsEmpty

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -1180,6 +1180,27 @@ type baseAccountData struct {
 	UpdateRound uint64 `codec:"z"`
 }
 
+// IsEmpty return true if any of the fields other then the UpdateRound are non-zero.
+func (ba *baseAccountData) IsEmpty() bool {
+	return ba.Status == 0 &&
+		ba.MicroAlgos.Raw == 0 &&
+		ba.RewardsBase == 0 &&
+		ba.RewardedMicroAlgos.Raw == 0 &&
+		ba.AuthAddr.IsZero() &&
+		ba.TotalAppSchemaNumUint == 0 &&
+		ba.TotalAppSchemaNumByteSlice == 0 &&
+		ba.TotalExtraAppPages == 0 &&
+		ba.TotalAssetParams == 0 &&
+		ba.TotalAssets == 0 &&
+		ba.TotalAppParams == 0 &&
+		ba.TotalAppLocalStates == 0 &&
+		ba.VoteID.MsgIsZero() &&
+		ba.SelectionID.MsgIsZero() &&
+		ba.VoteFirstValid == 0 &&
+		ba.VoteLastValid == 0 &&
+		ba.VoteKeyDilution == 0
+}
+
 func (ba *baseAccountData) NormalizedOnlineBalance(proto config.ConsensusParams) uint64 {
 	return basics.NormalizedOnlineAccountBalance(ba.Status, ba.RewardsBase, ba.MicroAlgos, proto)
 }
@@ -2322,7 +2343,7 @@ func accountsNewRound(
 		data := updates.getByIdx(i)
 		if data.oldAcct.rowid == 0 {
 			// zero rowid means we don't have a previous value.
-			if data.newAcct.MsgIsZero() {
+			if data.newAcct.IsEmpty() {
 				// if we didn't had it before, and we don't have anything now, just skip it.
 			} else {
 				// create a new entry.
@@ -2338,7 +2359,7 @@ func accountsNewRound(
 			}
 		} else {
 			// non-zero rowid means we had a previous value.
-			if data.newAcct.MsgIsZero() {
+			if data.newAcct.IsEmpty() {
 				// new value is zero, which means we need to delete the current value.
 				result, err = deleteByRowIDStmt.Exec(data.oldAcct.rowid)
 				if err == nil {

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -1269,3 +1269,30 @@ func TestResourcesDataAsset(t *testing.T) {
 	a.Equal(assetParamsEmpty, rd.GetAssetParams())
 	a.Equal(assetHoldingEmpty, rd.GetAssetHolding())
 }
+
+func TestBaseAccountDataIsEmpty(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	positiveTesting := func(t *testing.T) {
+		var ba baseAccountData
+		require.True(t, ba.IsEmpty())
+		for i := 0; i < 20; i++ {
+			h := crypto.Hash([]byte{byte(i)})
+			rnd := binary.BigEndian.Uint64(h[:])
+			ba.UpdateRound = rnd
+			require.True(t, ba.IsEmpty())
+		}
+	}
+	var empty baseAccountData
+	negativeTesting := func(t *testing.T) {
+		for i := 0; i < 1000; i++ {
+			randObj, _ := protocol.RandomizeObject(&baseAccountData{})
+			ba := randObj.(*baseAccountData)
+			if *ba == empty {
+				return
+			}
+			require.False(t, ba.IsEmpty())
+		}
+	}
+	t.Run("Positive", positiveTesting)
+	t.Run("Negative", negativeTesting)
+}

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -1284,13 +1284,13 @@ func TestBaseAccountDataIsEmpty(t *testing.T) {
 	}
 	var empty baseAccountData
 	negativeTesting := func(t *testing.T) {
-		for i := 0; i < 1000; i++ {
-			randObj, _ := protocol.RandomizeObject(&baseAccountData{})
+		for i := 0; i < 10000; i++ {
+			randObj, _ := protocol.RandomizeObjectField(&baseAccountData{})
 			ba := randObj.(*baseAccountData)
-			if *ba == empty {
-				return
+			if *ba == empty || ba.UpdateRound != 0 {
+				continue
 			}
-			require.False(t, ba.IsEmpty())
+			require.False(t, ba.IsEmpty(), "base account : %v", ba)
 		}
 	}
 	t.Run("Positive", positiveTesting)

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
@@ -1293,6 +1294,14 @@ func TestBaseAccountDataIsEmpty(t *testing.T) {
 			require.False(t, ba.IsEmpty(), "base account : %v", ba)
 		}
 	}
+	structureTesting := func(t *testing.T) {
+		encoding, err := json.Marshal(&empty)
+		expectedEncoding := `{"Status":0,"MicroAlgos":{"Raw":0},"RewardsBase":0,"RewardedMicroAlgos":{"Raw":0},"AuthAddr":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ","TotalAppSchemaNumUint":0,"TotalAppSchemaNumByteSlice":0,"TotalExtraAppPages":0,"TotalAssetParams":0,"TotalAssets":0,"TotalAppParams":0,"TotalAppLocalStates":0,"VoteID":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"SelectionID":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"VoteFirstValid":0,"VoteLastValid":0,"VoteKeyDilution":0,"UpdateRound":0}`
+		require.NoError(t, err)
+		require.Equal(t, expectedEncoding, string(encoding))
+	}
 	t.Run("Positive", positiveTesting)
 	t.Run("Negative", negativeTesting)
+	t.Run("Structure", structureTesting)
+
 }

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -459,7 +459,7 @@ func (ct *catchpointTracker) accountsUpdateBalances(accountsDeltas compactAccoun
 
 	for i := 0; i < accountsDeltas.len(); i++ {
 		delta := accountsDeltas.getByIdx(i)
-		if !delta.oldAcct.accountData.MsgIsZero() {
+		if !delta.oldAcct.accountData.IsEmpty() {
 			deleteHash := accountHashBuilderV6(delta.address, &delta.oldAcct.accountData, protocol.Encode(&delta.oldAcct.accountData))
 			deleted, err = ct.balancesTrie.Delete(deleteHash)
 			if err != nil {
@@ -472,7 +472,7 @@ func (ct *catchpointTracker) accountsUpdateBalances(accountsDeltas compactAccoun
 			}
 		}
 
-		if !delta.newAcct.MsgIsZero() {
+		if !delta.newAcct.IsEmpty() {
 			addHash := accountHashBuilderV6(delta.address, &delta.newAcct, protocol.Encode(&delta.newAcct))
 			added, err = ct.balancesTrie.Add(addHash)
 			if err != nil {

--- a/protocol/codec_tester.go
+++ b/protocol/codec_tester.go
@@ -57,7 +57,7 @@ func RandomizeObject(template interface{}) (interface{}, error) {
 		return nil, fmt.Errorf("RandomizeObject: must be ptr")
 	}
 	v := reflect.New(tt.Elem())
-	changes := ^int(0)
+	changes := int(^uint(0) >> 1)
 	err := randomizeValue(v.Elem(), tt.String(), "", &changes)
 	return v.Interface(), err
 }

--- a/protocol/codec_tester.go
+++ b/protocol/codec_tester.go
@@ -57,7 +57,20 @@ func RandomizeObject(template interface{}) (interface{}, error) {
 		return nil, fmt.Errorf("RandomizeObject: must be ptr")
 	}
 	v := reflect.New(tt.Elem())
-	err := randomizeValue(v.Elem(), tt.String(), "")
+	changes := ^int(0)
+	err := randomizeValue(v.Elem(), tt.String(), "", &changes)
+	return v.Interface(), err
+}
+
+// RandomizeObjectField returns a random object of the same type as template where a single field was modified.
+func RandomizeObjectField(template interface{}) (interface{}, error) {
+	tt := reflect.TypeOf(template)
+	if tt.Kind() != reflect.Ptr {
+		return nil, fmt.Errorf("RandomizeObject: must be ptr")
+	}
+	v := reflect.New(tt.Elem())
+	changes := 1
+	err := randomizeValue(v.Elem(), tt.String(), "", &changes)
 	return v.Interface(), err
 }
 
@@ -197,11 +210,14 @@ func checkBoundsLimitingTag(val reflect.Value, datapath string, structTag string
 	return
 }
 
-func randomizeValue(v reflect.Value, datapath string, tag string) error {
-	if oneOf(5) {
-		// Leave zero value
+func randomizeValue(v reflect.Value, datapath string, tag string, remainingChanges *int) error {
+	if *remainingChanges == 0 {
 		return nil
 	}
+	/*if oneOf(5) {
+		// Leave zero value
+		return nil
+	}*/
 
 	/* Consider cutting off recursive structures by stopping at some datapath depth.
 
@@ -214,8 +230,10 @@ func randomizeValue(v reflect.Value, datapath string, tag string) error {
 	switch v.Kind() {
 	case reflect.Uint, reflect.Uintptr, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		v.SetUint(rand.Uint64())
+		*remainingChanges--
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		v.SetInt(int64(rand.Uint64()))
+		*remainingChanges--
 	case reflect.String:
 		var buf []byte
 		len := rand.Int() % 64
@@ -223,10 +241,13 @@ func randomizeValue(v reflect.Value, datapath string, tag string) error {
 			buf = append(buf, byte(rand.Uint32()))
 		}
 		v.SetString(string(buf))
+		*remainingChanges--
 	case reflect.Struct:
 		st := v.Type()
+		fieldsOrder := rand.Perm(v.NumField())
 		for i := 0; i < v.NumField(); i++ {
-			f := st.Field(i)
+			fieldIdx := fieldsOrder[i]
+			f := st.Field(fieldIdx)
 			tag := f.Tag
 
 			if f.PkgPath != "" && !f.Anonymous {
@@ -236,17 +257,26 @@ func randomizeValue(v reflect.Value, datapath string, tag string) error {
 			if rawMsgpType == f.Type {
 				return errSkipRawMsgpTesting
 			}
-			err := randomizeValue(v.Field(i), datapath+"/"+f.Name, string(tag))
+			err := randomizeValue(v.Field(fieldIdx), datapath+"/"+f.Name, string(tag), remainingChanges)
 			if err != nil {
 				return err
 			}
+			if *remainingChanges == 0 {
+				break
+			}
+			*remainingChanges--
 		}
 	case reflect.Array:
+		indicesOrder := rand.Perm(v.Len())
 		for i := 0; i < v.Len(); i++ {
-			err := randomizeValue(v.Index(i), fmt.Sprintf("%s/%d", datapath, i), "")
+			err := randomizeValue(v.Index(indicesOrder[i]), fmt.Sprintf("%s/%d", datapath, indicesOrder[i]), "", remainingChanges)
 			if err != nil {
 				return err
 			}
+			if *remainingChanges == 0 {
+				break
+			}
+			*remainingChanges--
 		}
 	case reflect.Slice:
 		hasAllocBound := checkBoundsLimitingTag(v, datapath, tag)
@@ -255,15 +285,21 @@ func randomizeValue(v reflect.Value, datapath string, tag string) error {
 			l = 1
 		}
 		s := reflect.MakeSlice(v.Type(), l, l)
+		indicesOrder := rand.Perm(l)
 		for i := 0; i < l; i++ {
-			err := randomizeValue(s.Index(i), fmt.Sprintf("%s/%d", datapath, i), "")
+			err := randomizeValue(s.Index(indicesOrder[i]), fmt.Sprintf("%s/%d", datapath, indicesOrder[i]), "", remainingChanges)
 			if err != nil {
 				return err
 			}
+			if *remainingChanges == 0 {
+				break
+			}
 		}
 		v.Set(s)
+		*remainingChanges--
 	case reflect.Bool:
 		v.SetBool(rand.Uint32()%2 == 0)
+		*remainingChanges--
 	case reflect.Map:
 		hasAllocBound := checkBoundsLimitingTag(v, datapath, tag)
 		mt := v.Type()
@@ -272,20 +308,24 @@ func randomizeValue(v reflect.Value, datapath string, tag string) error {
 		if hasAllocBound {
 			l = 1
 		}
+		indicesOrder := rand.Perm(l)
 		for i := 0; i < l; i++ {
 			mk := reflect.New(mt.Key())
-			err := randomizeValue(mk.Elem(), fmt.Sprintf("%s/%d", datapath, i), "")
+			err := randomizeValue(mk.Elem(), fmt.Sprintf("%s/%d", datapath, indicesOrder[i]), "", remainingChanges)
 			if err != nil {
 				return err
 			}
 
 			mv := reflect.New(mt.Elem())
-			err = randomizeValue(mv.Elem(), fmt.Sprintf("%s/%d", datapath, i), "")
+			err = randomizeValue(mv.Elem(), fmt.Sprintf("%s/%d", datapath, indicesOrder[i]), "", remainingChanges)
 			if err != nil {
 				return err
 			}
 
 			v.SetMapIndex(mk.Elem(), mv.Elem())
+			if *remainingChanges == 0 {
+				break
+			}
 		}
 	default:
 		return fmt.Errorf("unsupported object kind %v", v.Kind())


### PR DESCRIPTION
## Summary

Avoid copying during baseAccountData.IsEmpty.

## Test Plan

Unit test written to cover the IsEmpty functionality.