### PR TITLE
Specify GOARCH for golang download in Dockerfile

### DIFF
--- a/docker/build/cicd.ubuntu.Dockerfile
+++ b/docker/build/cicd.ubuntu.Dockerfile
@@ -6,9 +6,12 @@ ARG ARCH="amd64"
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y build-essential git libboost-all-dev wget sqlite3 autoconf jq bsdmainutils shellcheck awscli
 WORKDIR /root
-RUN wget https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH%v*}.tar.gz \
+RUN if [ "${ARCH}" = "arm32v7" ]; then wget https://dl.google.com/go/go${GOLANG_VERSION}.linux-armv6l.tar.gz \
+    && tar -xvf go${GOLANG_VERSION}.linux-armv6l.tar.gz && \
+    mv go /usr/local; else \
+    wget https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH%v*}.tar.gz \
     && tar -xvf go${GOLANG_VERSION}.linux-${ARCH%v*}.tar.gz && \
-    mv go /usr/local
+    mv go /usr/local; fi
 ENV GOROOT=/usr/local/go \
     GOPATH=$HOME/go \
     ARCH_TYPE=${ARCH}

--- a/docker/build/cicd.ubuntu.Dockerfile
+++ b/docker/build/cicd.ubuntu.Dockerfile
@@ -3,15 +3,13 @@ ARG ARCH="amd64"
 FROM ${ARCH}/ubuntu:18.04
 ARG GOLANG_VERSION
 ARG ARCH="amd64"
+ARG GOARCH="amd64"
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y build-essential git libboost-all-dev wget sqlite3 autoconf jq bsdmainutils shellcheck awscli
 WORKDIR /root
-RUN if [ "${ARCH}" = "arm32v7" ]; then wget https://dl.google.com/go/go${GOLANG_VERSION}.linux-armv6l.tar.gz \
-    && tar -xvf go${GOLANG_VERSION}.linux-armv6l.tar.gz && \
-    mv go /usr/local; else \
-    wget https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH%v*}.tar.gz \
-    && tar -xvf go${GOLANG_VERSION}.linux-${ARCH%v*}.tar.gz && \
-    mv go /usr/local; fi
+RUN wget https://dl.google.com/go/go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz \
+    && tar -xvf go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz && \
+    mv go /usr/local
 ENV GOROOT=/usr/local/go \
     GOPATH=$HOME/go \
     ARCH_TYPE=${ARCH}

--- a/test/muleCI/mule.yaml
+++ b/test/muleCI/mule.yaml
@@ -13,6 +13,7 @@ agents:
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
       - ARCH=amd64
+      - GOARCH=amd64
   - name: cicd.centos.amd64
     dockerFilePath: docker/build/cicd.centos.Dockerfile
     image: algorand/go-algorand-ci-linux-centos
@@ -41,6 +42,7 @@ agents:
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
       - ARCH=arm64v8
+      - GOARCH=arm64
   - name: cicd.ubuntu.arm
     dockerFilePath: docker/build/cicd.ubuntu.Dockerfile
     image: algorand/go-algorand-ci-linux
@@ -55,6 +57,7 @@ agents:
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
       - ARCH=arm32v7
+      - GOARCH=armv6l
   - name: docker-ubuntu
     dockerFilePath: docker/build/docker.ubuntu.Dockerfile
     image: algorand/go-algorand-docker-linux-ubuntu


### PR DESCRIPTION
## Summary

Specify the arch file name for the golang download.

## Test Plan

Tested locally with `mule -f test/muleCI/mule.yaml build-linux-arm32 `
and got `2022-01-20 17:04:11,504 - INFO - Built docker image algorand/go-algorand-ci-linux:arm32v7-65af9d7d196a44479ec08e951bbc8e989dbb3a24 from docker/build/cicd.ubuntu.Dockerfile`
