### PR TITLE
ledger refactoring: improve merkle trie regeneration

### DIFF
--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -1013,9 +1013,14 @@ func (ct *catchpointTracker) accountsInitializeHashes(ctx context.Context, tx *s
 						return fmt.Errorf("accountsInitialize was unable to add changes to trie: %v", err)
 					}
 					if !added {
-						var addr basics.Address
-						copy(addr[:], acct.address)
-						ct.log.Warnf("accountsInitialize attempted to add duplicate hash '%s' to merkle trie for account %v", hex.EncodeToString(acct.digest), addr)
+						// we need to transalate the "addrid" into actual account address so that
+						// we can report the failure.
+						addr, err := lookupAccountAddressFromAddressID(ctx, tx, acct.addrid)
+						if err != nil {
+							ct.log.Warnf("accountsInitialize attempted to add duplicate hash '%s' to merkle trie for account id %d : %v", hex.EncodeToString(acct.digest), acct.addrid, err)
+						} else {
+							ct.log.Warnf("accountsInitialize attempted to add duplicate hash '%s' to merkle trie for account %v", hex.EncodeToString(acct.digest), addr)
+						}
 					}
 				}
 

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -991,9 +991,9 @@ func (ct *catchpointTracker) accountsInitializeHashes(ctx context.Context, tx *s
 		accountBuilderIt := makeOrderedAccountsIter(tx, trieRebuildAccountChunkSize)
 		defer accountBuilderIt.Close(ctx)
 		startTrieBuildTime := time.Now()
-		accountsCount := 0
+		trieHashCount := 0
 		lastRebuildTime := startTrieBuildTime
-		pendingAccounts := 0
+		pendingTrieHashes := 0
 		totalOrderedAccounts := 0
 		for {
 			accts, processedRows, err := accountBuilderIt.Next(ctx)
@@ -1005,31 +1005,33 @@ func (ct *catchpointTracker) accountsInitializeHashes(ctx context.Context, tx *s
 			}
 
 			if len(accts) > 0 {
-				accountsCount += len(accts)
-				pendingAccounts += len(accts)
+				trieHashCount += len(accts)
+				pendingTrieHashes += len(accts)
 				for _, acct := range accts {
 					added, err := trie.Add(acct.digest)
 					if err != nil {
 						return fmt.Errorf("accountsInitialize was unable to add changes to trie: %v", err)
 					}
 					if !added {
-						ct.log.Warnf("accountsInitialize attempted to add duplicate hash '%s' to merkle trie for account %v", hex.EncodeToString(acct.digest), acct.address)
+						var addr basics.Address
+						copy(addr[:], acct.address)
+						ct.log.Warnf("accountsInitialize attempted to add duplicate hash '%s' to merkle trie for account %v", hex.EncodeToString(acct.digest), addr)
 					}
 				}
 
-				if pendingAccounts >= trieRebuildCommitFrequency {
+				if pendingTrieHashes >= trieRebuildCommitFrequency {
 					// this trie Evict will commit using the current transaction.
 					// if anything goes wrong, it will still get rolled back.
 					_, err = trie.Evict(true)
 					if err != nil {
 						return fmt.Errorf("accountsInitialize was unable to commit changes to trie: %v", err)
 					}
-					pendingAccounts = 0
+					pendingTrieHashes = 0
 				}
 
 				if time.Since(lastRebuildTime) > 5*time.Second {
 					// let the user know that the trie is still being rebuilt.
-					ct.log.Infof("accountsInitialize still building the trie, and processed so far %d accounts", accountsCount)
+					ct.log.Infof("accountsInitialize still building the trie, and processed so far %d trie entries", trieHashCount)
 					lastRebuildTime = time.Now()
 				}
 			} else if processedRows > 0 {
@@ -1056,7 +1058,7 @@ func (ct *catchpointTracker) accountsInitializeHashes(ctx context.Context, tx *s
 			return fmt.Errorf("accountsInitialize was unable to update the account hash round to %d: %v", rnd, err)
 		}
 
-		ct.log.Infof("accountsInitialize rebuilt the merkle trie with %d entries in %v", accountsCount, time.Since(startTrieBuildTime))
+		ct.log.Infof("accountsInitialize rebuilt the merkle trie with %d entries in %v", trieHashCount, time.Since(startTrieBuildTime))
 	}
 	ct.balancesTrie = trie
 	return nil


### PR DESCRIPTION
## Summary

Few simple tweaks to try and squeeze some additional cycles out of the merkle trie regeneration logic:
- avoid using "append" and add directly to a preallocated array.
- load the value directly to their preallocated array positions.
- avoid using explicating address in temporary table. use the addid instead, and perform the translation
  only in case of an error.

## Performance

Merkle trie hashes writing time:
before: 20m:48s
after: 16m:11s

Note that the data size here is 32M.

## Test Plan

tested manually.
