### PR TITLE
pingpong: improve transaction scheduling

### DIFF
--- a/cmd/pingpong/runCmd.go
+++ b/cmd/pingpong/runCmd.go
@@ -43,9 +43,7 @@ var minFee uint64
 var randomFee, noRandomFee bool
 var randomAmount, noRandomAmount bool
 var randomDst bool
-var delayBetween string
 var runTime string
-var restTime string
 var refreshTime string
 var saveConfig bool
 var useDefault bool
@@ -84,9 +82,7 @@ func init() {
 	runCmd.Flags().BoolVar(&randomFee, "rf", false, "Set to enable random fees (between minf and mf)")
 	runCmd.Flags().BoolVar(&noRandomFee, "nrf", false, "Set to disable random fees")
 	runCmd.Flags().BoolVar(&randomDst, "rd", false, "Send money to randomly-generated addresses")
-	runCmd.Flags().StringVar(&delayBetween, "delay", "", "Delay (ms) between every transaction (0 means none)")
 	runCmd.Flags().StringVar(&runTime, "run", "", "Duration of time (seconds) to run transfers before resting (0 means non-stop)")
-	runCmd.Flags().StringVar(&restTime, "rest", "", "Duration of time (seconds) to rest between transfer periods (0 means no rest)")
 	runCmd.Flags().StringVar(&refreshTime, "refresh", "", "Duration of time (seconds) between refilling accounts with money (0 means no refresh)")
 	runCmd.Flags().StringVar(&logicProg, "program", "", "File containing the compiled program to include as a logic sig")
 	runCmd.Flags().BoolVar(&saveConfig, "save", false, "Save the effective configuration to disk")
@@ -187,26 +183,12 @@ var runCmd = &cobra.Command{
 		}
 		cfg.RandomizeDst = randomDst
 		cfg.Quiet = quietish
-		if delayBetween != "" {
-			val, err := strconv.ParseUint(delayBetween, 10, 32)
-			if err != nil {
-				reportErrorf("Invalid value specified for --delay: %v\n", err)
-			}
-			cfg.DelayBetweenTxn = time.Duration(uint32(val)) * time.Millisecond
-		}
 		if runTime != "" {
 			val, err := strconv.ParseUint(runTime, 10, 32)
 			if err != nil {
 				reportErrorf("Invalid value specified for --run: %v\n", err)
 			}
 			cfg.RunTime = time.Duration(uint32(val)) * time.Second
-		}
-		if restTime != "" {
-			val, err := strconv.ParseUint(restTime, 10, 32)
-			if err != nil {
-				reportErrorf("Invalid value specified for --rest: %v\n", err)
-			}
-			cfg.RestTime = time.Duration(uint32(val)) * time.Second
 		}
 		if refreshTime != "" {
 			val, err := strconv.ParseUint(refreshTime, 10, 32)

--- a/shared/pingpong/config.go
+++ b/shared/pingpong/config.go
@@ -31,7 +31,6 @@ const ConfigFilename = "ppconfig.json"
 // PpConfig defines configuration structure for
 type PpConfig struct {
 	SrcAccount      string
-	DelayBetweenTxn time.Duration
 	RandomizeFee    bool
 	RandomizeAmt    bool
 	RandomizeDst    bool
@@ -41,7 +40,6 @@ type PpConfig struct {
 	TxnPerSec       uint64
 	NumPartAccounts uint32
 	RunTime         time.Duration
-	RestTime        time.Duration
 	RefreshTime     time.Duration
 	MinAccountFunds uint64
 	Quiet           bool
@@ -71,7 +69,6 @@ type PpConfig struct {
 // DefaultConfig object for Ping Pong
 var DefaultConfig = PpConfig{
 	SrcAccount:      "",
-	DelayBetweenTxn: 100,
 	RandomizeFee:    false,
 	RandomizeAmt:    false,
 	RandomizeDst:    false,
@@ -81,7 +78,6 @@ var DefaultConfig = PpConfig{
 	TxnPerSec:       200,
 	NumPartAccounts: 10,
 	RunTime:         10 * time.Second,
-	RestTime:        1 * time.Hour, // Long default rest to avoid accidental DoS
 	RefreshTime:     10 * time.Second,
 	MinAccountFunds: 100000,
 	GroupSize:       1,

--- a/shared/pingpong/pingpong.go
+++ b/shared/pingpong/pingpong.go
@@ -269,8 +269,7 @@ func schedule(tps uint64, nextSendTime *time.Time) {
 		time.Sleep(dur)
 	}
 
-	*nextSendTime = nextSendTime.Add(
-		time.Duration((1.0 / float64(tps)) * float64(time.Second)))
+	*nextSendTime = nextSendTime.Add(time.Second / time.Duration(tps))
 }
 
 func (pps *WorkerState) fundAccounts(accounts map[string]*pingPongAccount, client libgoal.Client, cfg PpConfig) error {

--- a/shared/pingpong/pingpong.go
+++ b/shared/pingpong/pingpong.go
@@ -262,6 +262,17 @@ func computeAccountMinBalance(client libgoal.Client, cfg PpConfig) (fundingRequi
 	return
 }
 
+// Wait for `*nextSendTime` and update it afterwards.
+func schedule(tps uint64, nextSendTime *time.Time) {
+	dur := time.Until(*nextSendTime)
+	if dur > 0 {
+		time.Sleep(dur)
+	}
+
+	*nextSendTime = nextSendTime.Add(
+		time.Duration((1.0 / float64(tps)) * float64(time.Second)))
+}
+
 func (pps *WorkerState) fundAccounts(accounts map[string]*pingPongAccount, client libgoal.Client, cfg PpConfig) error {
 	var srcFunds, minFund uint64
 	var err error
@@ -272,7 +283,6 @@ func (pps *WorkerState) fundAccounts(accounts map[string]*pingPongAccount, clien
 		return err
 	}
 
-	startTime := time.Now()
 	var totalSent uint64
 
 	// Fee of 0 will make cause the function to use the suggested one by network
@@ -282,12 +292,12 @@ func (pps *WorkerState) fundAccounts(accounts map[string]*pingPongAccount, clien
 	if err != nil {
 		return err
 	}
-
 	fmt.Printf("adjusting account balance to %d\n", minFund)
+
+	nextSendTime := time.Now()
 	for {
 		accountsAdjusted := 0
 		for addr, acct := range accounts {
-
 			if addr == pps.cfg.SrcAccount {
 				continue
 			}
@@ -307,6 +317,7 @@ func (pps *WorkerState) fundAccounts(accounts map[string]*pingPongAccount, clien
 				fmt.Printf("adjusting balance of account %v by %d\n ", addr, toSend)
 			}
 
+			schedule(cfg.TxnPerSec, &nextSendTime)
 			tx, err = pps.sendPaymentFromSourceAccount(client, addr, fee, toSend)
 			if err != nil {
 				if strings.Contains(err.Error(), "broadcast queue full") {
@@ -323,7 +334,6 @@ func (pps *WorkerState) fundAccounts(accounts map[string]*pingPongAccount, clien
 			}
 
 			totalSent++
-			throttleTransactionRate(startTime, cfg, totalSent)
 		}
 		accounts[cfg.SrcAccount].setBalance(srcFunds)
 		// wait until all the above transactions are sent, or that we have no more transactions
@@ -462,7 +472,6 @@ func (pps *WorkerState) RunPingPong(ctx context.Context, ac libgoal.Client) {
 	if cfg.MaxRuntime > 0 {
 		endTime = time.Now().Add(cfg.MaxRuntime)
 	}
-	restTime := cfg.RestTime
 	refreshTime := time.Now().Add(cfg.RefreshTime)
 
 	var nftThrottler *throttler
@@ -473,6 +482,7 @@ func (pps *WorkerState) RunPingPong(ctx context.Context, ac libgoal.Client) {
 	lastLog := time.Now()
 	nextLog := lastLog.Add(logPeriod)
 
+	nextSendTime := time.Now()
 	for {
 		if ctx.Err() != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "error bad context in RunPingPong: %v\n", ctx.Err())
@@ -520,7 +530,7 @@ func (pps *WorkerState) RunPingPong(ctx context.Context, ac libgoal.Client) {
 			}
 			toList := listSufficientAccounts(pps.accounts, minimumAmount, cfg.SrcAccount)
 
-			sent, succeeded, err := pps.sendFromTo(fromList, toList, ac)
+			sent, succeeded, err := pps.sendFromTo(fromList, toList, ac, &nextSendTime)
 			totalSent += sent
 			totalSucceeded += succeeded
 			if err != nil {
@@ -535,16 +545,10 @@ func (pps *WorkerState) RunPingPong(ctx context.Context, ac libgoal.Client) {
 
 				refreshTime = refreshTime.Add(cfg.RefreshTime)
 			}
-
-			throttleTransactionRate(startTime, cfg, totalSent)
 		}
 
 		timeDelta := time.Since(startTime)
 		_, _ = fmt.Fprintf(os.Stdout, "Sent %d transactions (%d attempted) in %d seconds\n", totalSucceeded, totalSent, int(math.Round(timeDelta.Seconds())))
-		if cfg.RestTime > 0 {
-			_, _ = fmt.Fprintf(os.Stdout, "Pausing %d seconds before sending more transactions\n", int(math.Round(cfg.RestTime.Seconds())))
-			time.Sleep(restTime)
-		}
 	}
 }
 
@@ -672,7 +676,7 @@ func (pps *WorkerState) makeNftTraffic(client libgoal.Client) (sentCount uint64,
 
 func (pps *WorkerState) sendFromTo(
 	fromList, toList []string,
-	client libgoal.Client,
+	client libgoal.Client, nextSendTime *time.Time,
 ) (sentCount, successCount uint64, err error) {
 	accounts := pps.accounts
 	cinfo := pps.cinfo
@@ -693,8 +697,6 @@ func (pps *WorkerState) sendFromTo(
 		*ap = p
 		assetsByCreator[c] = append(assetsByCreator[c], ap)
 	}
-	lastTransactionTime := time.Now()
-	timeCredit := time.Duration(0)
 	for i := 0; i < len(fromList); i = (i + 1) % len(fromList) {
 		from := fromList[i]
 
@@ -770,6 +772,7 @@ func (pps *WorkerState) sendFromTo(
 				return
 			}
 
+			schedule(cfg.TxnPerSec, nextSendTime)
 			sentCount++
 			_, sendErr = client.BroadcastTransaction(stxn)
 		} else {
@@ -856,6 +859,7 @@ func (pps *WorkerState) sendFromTo(
 				}
 			}
 
+			schedule(cfg.TxnPerSec, nextSendTime)
 			sentCount++
 			sendErr = client.BroadcastTransactionGroup(stxGroup)
 		}
@@ -871,30 +875,6 @@ func (pps *WorkerState) sendFromTo(
 		accounts[from].addBalance(fromBalanceChange)
 		// avoid updating the "to" account.
 
-		// the logic here would sleep for the remaining of time to match the desired cfg.DelayBetweenTxn
-		if cfg.DelayBetweenTxn > 0 {
-			time.Sleep(cfg.DelayBetweenTxn)
-		}
-		if cfg.TxnPerSec > 0 {
-			timeCredit += time.Second / time.Duration(cfg.TxnPerSec)
-
-			now := time.Now()
-			took := now.Sub(lastTransactionTime)
-			timeCredit -= took
-			if timeCredit > 0 {
-				time.Sleep(timeCredit)
-				timeCredit -= time.Since(now)
-			} else if timeCredit < -1000*time.Millisecond {
-				// cap the "time debt" to 1000 ms.
-				timeCredit = -1000 * time.Millisecond
-			}
-			lastTransactionTime = time.Now()
-
-			// since we just slept enough here, we can take it off the counters
-			sentCount--
-			successCount--
-			// fmt.Printf("itration took %v\n", took)
-		}
 	}
 	return
 }


### PR DESCRIPTION
## Summary

Currently the transaction scheduling logic in pingpong is lots of complicated sleep calls. Some sleeps were definitely extra and were hurting tps; this PR deprecates them. The whole scheduling logic is replaced with a much simpler one. Let timestamp sequence `{t}_{i >= 0} = {currenttime + 1 / tps * i}`. Then transaction `i` is sent at time `t_i` with best effort.

In my tests `./pingpong run --tps 115 --rest 0 --refresh 1800 --numaccounts 500` produced 440 txns per block. Now `./pingpong run --tps 115 --refresh 1800 --numaccounts 500` produces 475 txns per block. (`--rest` was deprecated)

Related to https://github.com/algorand/go-algorand-internal/issues/1833.

## Test Plan

I ran it.