### PR TITLE
ledger refactoring: normalize verified accounts

### DIFF
--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -41,15 +41,16 @@ type CatchpointCatchupNodeServices interface {
 
 // CatchpointCatchupStats is used for querying and reporting the current state of the catchpoint catchup process
 type CatchpointCatchupStats struct {
-	CatchpointLabel   string
-	TotalAccounts     uint64
-	ProcessedAccounts uint64
-	VerifiedAccounts  uint64
-	TotalBlocks       uint64
-	AcquiredBlocks    uint64
-	VerifiedBlocks    uint64
-	ProcessedBytes    uint64
-	StartTime         time.Time
+	CatchpointLabel    string
+	TotalAccounts      uint64
+	ProcessedAccounts  uint64
+	VerifiedAccounts   uint64
+	TotalBlocks        uint64
+	AcquiredBlocks     uint64
+	VerifiedBlocks     uint64
+	ProcessedBytes     uint64
+	TotalAccountHashes uint64
+	StartTime          time.Time
 }
 
 // CatchpointCatchupService represents the catchpoint catchup service.
@@ -321,10 +322,12 @@ func (cs *CatchpointCatchupService) processStageLedgerDownload() (err error) {
 }
 
 // updateVerifiedAccounts update the user's statistics for the given verified accounts
-func (cs *CatchpointCatchupService) updateVerifiedAccounts(verifiedAccounts uint64) {
+func (cs *CatchpointCatchupService) updateVerifiedAccounts(addedTrieHashes uint64) {
 	cs.statsMu.Lock()
 	defer cs.statsMu.Unlock()
-	cs.stats.VerifiedAccounts = verifiedAccounts
+	if cs.stats.TotalAccountHashes > 0 {
+		cs.stats.VerifiedAccounts = cs.stats.TotalAccounts * addedTrieHashes / cs.stats.TotalAccountHashes
+	}
 }
 
 // processStageLastestBlockDownload is the third catchpoint catchup stage. It downloads the latest block and verify that against the previously downloaded ledger.
@@ -701,6 +704,7 @@ func (cs *CatchpointCatchupService) updateLedgerFetcherProgress(fetcherStats *le
 	cs.stats.TotalAccounts = fetcherStats.TotalAccounts
 	cs.stats.ProcessedAccounts = fetcherStats.ProcessedAccounts
 	cs.stats.ProcessedBytes = fetcherStats.ProcessedBytes
+	cs.stats.TotalAccountHashes = fetcherStats.TotalAccountHashes
 }
 
 // GetStatistics returns a copy of the current catchpoint catchup statistics

--- a/ledger/catchupaccessor.go
+++ b/ledger/catchupaccessor.go
@@ -226,12 +226,13 @@ func (c *CatchpointCatchupAccessorImpl) ResetStagingBalances(ctx context.Context
 
 // CatchpointCatchupAccessorProgress is used by the caller of ProgressStagingBalances to obtain progress information
 type CatchpointCatchupAccessorProgress struct {
-	TotalAccounts     uint64
-	ProcessedAccounts uint64
-	ProcessedBytes    uint64
-	TotalChunks       uint64
-	SeenHeader        bool
-	Version           uint64
+	TotalAccounts      uint64
+	ProcessedAccounts  uint64
+	ProcessedBytes     uint64
+	TotalChunks        uint64
+	SeenHeader         bool
+	Version            uint64
+	TotalAccountHashes uint64
 
 	// Having the cachedTrie here would help to accelerate the catchup process since the trie maintain an internal cache of nodes.
 	// While rebuilding the trie, we don't want to force and reload (some) of these nodes into the cache for each catchpoint file chunk.
@@ -433,6 +434,9 @@ func (c *CatchpointCatchupAccessorImpl) processStagingBalances(ctx context.Conte
 	if err == nil {
 		progress.ProcessedAccounts += uint64(len(normalizedAccountBalances))
 		progress.ProcessedBytes += uint64(len(bytes))
+		for _, acctBal := range normalizedAccountBalances {
+			progress.TotalAccountHashes += uint64(len(acctBal.accountHashes))
+		}
 	}
 
 	// not strictly required, but clean up the pointer in case of either a failure or when we're done.


### PR DESCRIPTION
## Summary

During the fast catchup process, the node's reported status presents information similar to the following:
```
Last committed block: 8059
Sync Time: 929.6s
Catchpoint: 18630001#V4CQ2LXRIKL5XKTBE33ZDGBP23G4U2ENZQURY2XS75IHRBWHYJEQ
Catchpoint total accounts: 8357134
Catchpoint accounts processed: 8357134
Catchpoint accounts verified: 29869214
Genesis ID: mainnet-v1.0
Genesis hash: wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=
```

The reported "Catchpoint accounts verified" is above the "Catchpoint total accounts", which is clearly wrong.
The sounds for this conflict is that with the resources separation, the merkle trie contains more entries. The reported number is the number of added merkle trie entries.

This is a user-interface only issue. To work around that, this PR normalize the added entries to the range of the total accounts. That would preserve the existing user look and feel.

## Test Plan

Tested manually.
