### PR TITLE
ledger refactoring: fix lookupResources

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -1978,7 +1978,6 @@ func (qs *accountsDbQueries) lookupResources(addr basics.Address, aidx basics.Cr
 
 		// this should never happen; it indicates that we don't have a current round in the acctrounds table.
 		if err == sql.ErrNoRows {
-			data.data = makeResourcesData(0)
 			// Return the zero value of data
 			return fmt.Errorf("unable to query resource data for address %v aidx %v ctype %v : %w", addr, aidx, ctype, err)
 		}

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -1963,6 +1963,7 @@ func (qs *accountsDbQueries) lookupResources(addr basics.Address, aidx basics.Cr
 	err = db.Retry(func() error {
 		var buf []byte
 		var rowid sql.NullInt64
+		data.data = makeResourcesData(0)
 		err := qs.lookupResourcesStmt.QueryRow(addr[:], aidx, ctype).Scan(&rowid, &data.round, &buf)
 		if err == nil {
 			data.aidx = aidx

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -1963,7 +1963,6 @@ func (qs *accountsDbQueries) lookupResources(addr basics.Address, aidx basics.Cr
 	err = db.Retry(func() error {
 		var buf []byte
 		var rowid sql.NullInt64
-		data.data = makeResourcesData(0)
 		err := qs.lookupResourcesStmt.QueryRow(addr[:], aidx, ctype).Scan(&rowid, &data.round, &buf)
 		if err == nil {
 			data.aidx = aidx
@@ -1972,12 +1971,14 @@ func (qs *accountsDbQueries) lookupResources(addr basics.Address, aidx basics.Cr
 				data.addrid = rowid.Int64
 				return protocol.Decode(buf, &data.data)
 			}
+			data.data = makeResourcesData(0)
 			// we don't have that account, just return the database round.
 			return nil
 		}
 
 		// this should never happen; it indicates that we don't have a current round in the acctrounds table.
 		if err == sql.ErrNoRows {
+			data.data = makeResourcesData(0)
 			// Return the zero value of data
 			return fmt.Errorf("unable to query resource data for address %v aidx %v ctype %v : %w", addr, aidx, ctype, err)
 		}

--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -736,7 +736,8 @@ return`
 	prd, err := l.accts.accountsq.lookupResources(userLocal, basics.CreatableIndex(appIdx), basics.AppCreatable)
 	a.NoError(err)
 	a.Zero(prd.addrid)
-	a.Empty(prd.data)
+	emptyResourceData := makeResourcesData(0)
+	a.Equal(emptyResourceData, prd.data)
 }
 
 func TestAppEmptyAccountsGlobal(t *testing.T) {
@@ -871,7 +872,8 @@ return`
 	prd, err := l.accts.accountsq.lookupResources(creator, basics.CreatableIndex(appIdx), basics.AppCreatable)
 	a.NoError(err)
 	a.Zero(prd.addrid)
-	a.Empty(prd.data)
+	emptyResourceData := makeResourcesData(0)
+	a.Equal(emptyResourceData, prd.data)
 }
 
 func TestAppAccountDeltaIndicesCompatibility1(t *testing.T) {


### PR DESCRIPTION
## Summary

The lookupResources had a small bug: it wasn't returning the correct persistedResourcesData in case the requested account did not had any holding of the requested asset. That, in turn got stored into the resources cache, triggering
issues down the road.

## Test Plan

Existing unit tests were updated.