### PR TITLE
Revert `fillBytes` method to `bigIntToBytes` for lower golang version

### DIFF
--- a/data/abi/abi_encode.go
+++ b/data/abi/abi_encode.go
@@ -26,7 +26,7 @@ import (
 )
 
 // bigIntToBytes casts non-negative big integer to byte slice with specific byte length
-// NOTE: THIS IS A WORKAROUND FOR `fillBytes` METHOD BEFOER GOLANG 1.15+
+// NOTE: THIS IS A WORKAROUND FOR `fillBytes` METHOD BEFORE GOLANG 1.15+
 //       SHOULD BE REMOVED AFTER WE MOVE TO HIGHER VERSION
 func bigIntToBytes(x *big.Int, byteLen uint) ([]byte, error) {
 	if x.Cmp(big.NewInt(0)) < 0 {

--- a/data/abi/abi_encode.go
+++ b/data/abi/abi_encode.go
@@ -26,7 +26,7 @@ import (
 )
 
 // bigIntToBytes casts non-negative big integer to byte slice with specific byte length
-// NOTE: THIS IS A WORKAROUND FOR `fillBytes` METHOD BEFORE GOLANG 1.15+
+// DEPRECATED: THIS IS A WORKAROUND FOR `fillBytes` METHOD BEFORE GOLANG 1.15+
 //       SHOULD BE REMOVED AFTER WE MOVE TO HIGHER VERSION
 func bigIntToBytes(x *big.Int, byteLen uint) ([]byte, error) {
 	if x.Cmp(big.NewInt(0)) < 0 {

--- a/data/abi/abi_encode.go
+++ b/data/abi/abi_encode.go
@@ -38,9 +38,7 @@ func bigIntToBytes(x *big.Int, byteLen uint) ([]byte, error) {
 
 	buffer := make([]byte, byteLen)
 	intBytes := x.Bytes()
-	for i := 0; i < len(intBytes); i++ {
-		buffer[len(buffer)-1-i] = intBytes[len(intBytes)-1-i]
-	}
+	copy(buffer[int(byteLen)-len(intBytes):], intBytes)
 	return buffer, nil
 }
 

--- a/data/abi/abi_encode.go
+++ b/data/abi/abi_encode.go
@@ -25,6 +25,25 @@ import (
 	"strings"
 )
 
+// bigIntToBytes casts non-negative big integer to byte slice with specific byte length
+// NOTE: THIS IS A WORKAROUND FOR `fillBytes` METHOD BEFOER GOLANG 1.15+
+//       SHOULD BE REMOVED AFTER WE MOVE TO HIGHER VERSION
+func bigIntToBytes(x *big.Int, byteLen uint) ([]byte, error) {
+	if x.Cmp(big.NewInt(0)) < 0 {
+		return nil, fmt.Errorf("ABI: big Int To Bytes error: should pass in non-negative integer")
+	}
+	if uint(x.BitLen()) > byteLen*8 {
+		return nil, fmt.Errorf("ABI: big Int To Bytes error: integer byte length > given byte length")
+	}
+
+	buffer := make([]byte, byteLen)
+	intBytes := x.Bytes()
+	for i := 0; i < len(intBytes); i++ {
+		buffer[len(buffer)-1-i] = intBytes[len(intBytes)-1-i]
+	}
+	return buffer, nil
+}
+
 // typeCastToTuple cast an array-like ABI type into an ABI tuple type.
 func (t Type) typeCastToTuple(tupLen ...int) (Type, error) {
 	var childT []Type
@@ -170,13 +189,14 @@ func encodeInt(intValue interface{}, bitSize uint16) ([]byte, error) {
 		return nil, fmt.Errorf("passed in numeric value should be non negative")
 	}
 
-	castedBytes := make([]byte, bitSize/8)
-
 	if bigInt.Cmp(new(big.Int).Lsh(big.NewInt(1), uint(bitSize))) >= 0 {
 		return nil, fmt.Errorf("input value bit size %d > abi type bit size %d", bigInt.BitLen(), bitSize)
 	}
 
-	bigInt.FillBytes(castedBytes)
+	castedBytes, err := bigIntToBytes(bigInt, uint(bitSize/8))
+	if err != nil {
+		return nil, err
+	}
 	return castedBytes, nil
 }
 

--- a/data/abi/abi_json_test.go
+++ b/data/abi/abi_json_test.go
@@ -31,14 +31,18 @@ func TestRandomAddressEquality(t *testing.T) {
 
 	upperLimit := new(big.Int).Lsh(big.NewInt(1), addressByteSize<<3)
 	var addrBasics basics.Address
-	var addrABI []byte = make([]byte, addressByteSize)
+	var addrABI = make([]byte, addressByteSize)
 
 	for testCaseIndex := 0; testCaseIndex < addressTestCaseCount; testCaseIndex++ {
 		randomAddrInt, err := rand.Int(rand.Reader, upperLimit)
 		require.NoError(t, err, "cryptographic random int init fail")
 
-		randomAddrInt.FillBytes(addrBasics[:])
-		randomAddrInt.FillBytes(addrABI)
+		expected, err := bigIntToBytes(randomAddrInt, uint(addressByteSize))
+		require.NoError(t, err, "big int to byte conversion error")
+		for i := 0; i < addressByteSize; i++ {
+			addrBasics[i] = expected[i]
+			addrABI[i] = expected[i]
+		}
 
 		checkSumBasics := addrBasics.GetChecksum()
 		checkSumABI, err := addressCheckSum(addrABI)

--- a/data/abi/abi_json_test.go
+++ b/data/abi/abi_json_test.go
@@ -39,10 +39,9 @@ func TestRandomAddressEquality(t *testing.T) {
 
 		expected, err := bigIntToBytes(randomAddrInt, uint(addressByteSize))
 		require.NoError(t, err, "big int to byte conversion error")
-		for i := 0; i < addressByteSize; i++ {
-			addrBasics[i] = expected[i]
-			addrABI[i] = expected[i]
-		}
+
+		copy(addrABI[:], expected)
+		copy(addrBasics[:], expected)
 
 		checkSumBasics := addrBasics.GetChecksum()
 		checkSumABI, err := addressCheckSum(addrABI)


### PR DESCRIPTION
# Summary

We are probably not going to higher golang version (1.15+) at this point, while `fillBytes` from `big.Int` is introduced in 1.15.
Changing all the `fillBytes` in `ABI` to self-made `bigIntToBytes` in favor of lower go version.