### PR TITLE
ledger refactoring: remove index and type from `ledgercore.AccountResource`

### DIFF
--- a/cmd/tealdbg/localLedger.go
+++ b/cmd/tealdbg/localLedger.go
@@ -290,7 +290,7 @@ func (l *localLedger) LookupResource(rnd basics.Round, addr basics.Address, aidx
 	if !ok {
 		return ledgercore.AccountResource{}, nil
 	}
-	result := ledgercore.AccountResource{CreatableIndex: aidx, CreatableType: ctype}
+	var result ledgercore.AccountResource
 	if ctype == basics.AppCreatable {
 		if p, ok := ad.AppParams[basics.AppIndex(aidx)]; ok {
 			result.AppParams = &p

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -318,7 +318,7 @@ func (dl *dryrunLedger) LookupResource(rnd basics.Round, addr basics.Address, ai
 	if err != nil {
 		return ledgercore.AccountResource{}, err
 	}
-	result := ledgercore.AccountResource{CreatableIndex: aidx, CreatableType: ctype}
+	var result ledgercore.AccountResource
 	if ctype == basics.AppCreatable {
 		if p, ok := ad.AppParams[basics.AppIndex(aidx)]; ok {
 			result.AppParams = &p

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -173,10 +173,7 @@ type persistedResourcesData struct {
 }
 
 func (prd *persistedResourcesData) AccountResource() ledgercore.AccountResource {
-	ret := ledgercore.AccountResource{
-		CreatableIndex: prd.aidx,
-		CreatableType:  prd.rtype,
-	}
+	var ret ledgercore.AccountResource
 	if prd.data.IsAsset() {
 		if prd.data.IsHolding() {
 			holding := prd.data.GetAssetHolding()

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -2277,8 +2277,6 @@ func (m *mockAccountWriter) insertResource(addrid int64, aidx basics.CreatableIn
 	// use persistedResourcesData.AccountResource for conversion
 	prd := persistedResourcesData{data: data}
 	new := prd.AccountResource()
-	new.CreatableIndex = 0
-	new.CreatableType = 0
 	m.resources[key] = new
 	return 1, nil
 }
@@ -2301,8 +2299,6 @@ func (m *mockAccountWriter) updateResource(addrid int64, aidx basics.CreatableIn
 	// use persistedResourcesData.AccountResource for conversion
 	prd := persistedResourcesData{data: data}
 	new := prd.AccountResource()
-	new.CreatableIndex = 0
-	new.CreatableType = 0
 	if new == old {
 		return 0, nil
 	}

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -244,16 +244,16 @@ func (r resourcesUpdates) get(ac accountCreatable) (m modifiedResource, ok bool)
 	return
 }
 
-func (r resourcesUpdates) getForAddress(addr basics.Address) (ret []modifiedResource) {
-	if len(r) == 0 {
-		return
-	}
-	for ac, mres := range r {
-		if ac.address == addr {
-			ret = append(ret, mres)
+func (r resourcesUpdates) getForAddress(addr basics.Address) map[basics.CreatableIndex]modifiedResource {
+	res := make(map[basics.CreatableIndex]modifiedResource)
+
+	for k, v := range r {
+		if k.address == addr {
+			res[k.index] = v
 		}
 	}
-	return
+
+	return res
 }
 
 // initialize initializes the accountUpdates structure
@@ -817,8 +817,6 @@ func (au *accountUpdates) newBlockImpl(blk bookkeeping.Block, delta ledgercore.S
 		mres, _ := au.resources.get(key)
 		mres.resource.AssetHolding = res.Holding.Holding
 		mres.resource.AssetParams = res.Params.Params
-		mres.resource.CreatableIndex = basics.CreatableIndex(res.Aidx)
-		mres.resource.CreatableType = basics.AssetCreatable
 		mres.ndeltas++
 		au.resources.set(key, mres)
 	}
@@ -830,8 +828,6 @@ func (au *accountUpdates) newBlockImpl(blk bookkeeping.Block, delta ledgercore.S
 		mres, _ := au.resources.get(key)
 		mres.resource.AppLocalState = res.State.LocalState
 		mres.resource.AppParams = res.Params.Params
-		mres.resource.CreatableIndex = basics.CreatableIndex(res.Aidx)
-		mres.resource.CreatableType = basics.AppCreatable
 		mres.ndeltas++
 		au.resources.set(key, mres)
 	}
@@ -889,7 +885,7 @@ func (au *accountUpdates) lookupLatest(addr basics.Address) (data basics.Account
 		if !ok { // first time seeing this cidx
 			resourceCount++
 			foundResources[cidx] = round
-			res.AssignAccountData(&data)
+			ledgercore.AssignAccountResourceToAccountData(cidx, res, &data)
 			return nil
 		}
 		// is this newer than current "found" rnd for this resource?
@@ -987,8 +983,8 @@ func (au *accountUpdates) lookupLatest(addr basics.Address) (data basics.Account
 		}
 
 		// check for resources modified in the past rounds, in the deltas
-		for _, mr := range au.resources.getForAddress(addr) {
-			if err := addResource(mr.resource.CreatableIndex, rnd, mr.resource); err != nil {
+		for cidx, mr := range au.resources.getForAddress(addr) {
+			if err := addResource(cidx, rnd, mr.resource); err != nil {
 				return basics.AccountData{}, basics.Round(0), err
 			}
 		}

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -373,8 +373,6 @@ func checkAcctUpdatesConsistency(t *testing.T, au *accountUpdates, rnd basics.Ro
 			entry, _ := resources.get(key)
 			entry.resource.AppLocalState = rec.State.LocalState
 			entry.resource.AppParams = rec.Params.Params
-			entry.resource.CreatableIndex = basics.CreatableIndex(rec.Aidx)
-			entry.resource.CreatableType = basics.AppCreatable
 			entry.ndeltas++
 			resources[key] = entry
 		}
@@ -383,8 +381,6 @@ func checkAcctUpdatesConsistency(t *testing.T, au *accountUpdates, rnd basics.Ro
 			entry, _ := resources.get(key)
 			entry.resource.AssetHolding = rec.Holding.Holding
 			entry.resource.AssetParams = rec.Params.Params
-			entry.resource.CreatableIndex = basics.CreatableIndex(rec.Aidx)
-			entry.resource.CreatableType = basics.AssetCreatable
 			entry.ndeltas++
 			resources[key] = entry
 		}

--- a/ledger/evalindexer.go
+++ b/ledger/evalindexer.go
@@ -113,7 +113,7 @@ func (l indexerLedgerConnector) LookupWithoutRewards(round basics.Round, address
 
 // toAccountResource returns ledgercore.AccountResource for a creatable in basics.AccountData
 func toAccountResource(ad basics.AccountData, aidx basics.CreatableIndex, ctype basics.CreatableType) ledgercore.AccountResource {
-	ret := ledgercore.AccountResource{CreatableIndex: aidx, CreatableType: ctype}
+	var ret ledgercore.AccountResource
 	switch ctype {
 	case basics.AppCreatable:
 		if a, ok := ad.AppLocalStates[basics.AppIndex(aidx)]; ok {

--- a/ledger/ledgercore/accountresource.go
+++ b/ledger/ledgercore/accountresource.go
@@ -22,44 +22,37 @@ import (
 
 // AccountResource used to retrieve a generic resource information from the data tier
 type AccountResource struct {
-	CreatableIndex basics.CreatableIndex
-	CreatableType  basics.CreatableType
-
 	AssetParams   *basics.AssetParams
 	AssetHolding  *basics.AssetHolding
 	AppLocalState *basics.AppLocalState
 	AppParams     *basics.AppParams
 }
 
-// AssignAccountData assigned the Asset/App params/holdings contained in the AccountResource
-// to the given basics.AccountData, creating maps if necessary.
-func (r *AccountResource) AssignAccountData(ad *basics.AccountData) {
-	switch r.CreatableType {
-	case basics.AssetCreatable:
-		if r.AssetParams != nil {
-			if ad.AssetParams == nil {
-				ad.AssetParams = make(map[basics.AssetIndex]basics.AssetParams)
-			}
-			ad.AssetParams[basics.AssetIndex(r.CreatableIndex)] = *r.AssetParams
+// AssignAccountResourceToAccountData assignes the Asset/App params/holdings contained
+// in the AccountResource to the given basics.AccountData, creating maps if necessary.
+func AssignAccountResourceToAccountData(cindex basics.CreatableIndex, resource AccountResource, ad *basics.AccountData) {
+	if resource.AssetParams != nil {
+		if ad.AssetParams == nil {
+			ad.AssetParams = make(map[basics.AssetIndex]basics.AssetParams)
 		}
-		if r.AssetHolding != nil {
-			if ad.Assets == nil {
-				ad.Assets = make(map[basics.AssetIndex]basics.AssetHolding)
-			}
-			ad.Assets[basics.AssetIndex(r.CreatableIndex)] = *r.AssetHolding
+		ad.AssetParams[basics.AssetIndex(cindex)] = *resource.AssetParams
+	}
+	if resource.AssetHolding != nil {
+		if ad.Assets == nil {
+			ad.Assets = make(map[basics.AssetIndex]basics.AssetHolding)
 		}
-	case basics.AppCreatable:
-		if r.AppParams != nil {
-			if ad.AppParams == nil {
-				ad.AppParams = make(map[basics.AppIndex]basics.AppParams)
-			}
-			ad.AppParams[basics.AppIndex(r.CreatableIndex)] = *r.AppParams
+		ad.Assets[basics.AssetIndex(cindex)] = *resource.AssetHolding
+	}
+	if resource.AppParams != nil {
+		if ad.AppParams == nil {
+			ad.AppParams = make(map[basics.AppIndex]basics.AppParams)
 		}
-		if r.AppLocalState != nil {
-			if ad.AppLocalStates == nil {
-				ad.AppLocalStates = make(map[basics.AppIndex]basics.AppLocalState)
-			}
-			ad.AppLocalStates[basics.AppIndex(r.CreatableIndex)] = *r.AppLocalState
+		ad.AppParams[basics.AppIndex(cindex)] = *resource.AppParams
+	}
+	if resource.AppLocalState != nil {
+		if ad.AppLocalStates == nil {
+			ad.AppLocalStates = make(map[basics.AppIndex]basics.AppLocalState)
 		}
+		ad.AppLocalStates[basics.AppIndex(cindex)] = *resource.AppLocalState
 	}
 }

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -304,8 +304,6 @@ func (ad *NewAccountDeltas) MergeAccounts(other NewAccountDeltas) {
 
 // GetResource looks up a pair of app or asset resources, given its index and type.
 func (ad NewAccountDeltas) GetResource(addr basics.Address, aidx basics.CreatableIndex, ctype basics.CreatableType) (ret AccountResource, ok bool) {
-	ret.CreatableIndex = aidx
-	ret.CreatableType = ctype
 	switch ctype {
 	case basics.AssetCreatable:
 		aa := AccountAsset{addr, basics.AssetIndex(aidx)}


### PR DESCRIPTION
## Summary

The ledger for evaluator interface's `LookupResource()` returns creatable index and type inside `ledgercore.AccountResource` even though the caller knows what they are. This PR removes these redundant fields.

## Test Plan

This is just refactoring.