### PR TITLE
ledger refactoring: add unique index on address to catchpointbalances

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -101,6 +101,10 @@ func createNormalizedOnlineBalanceIndex(idxname string, tablename string) string
 		WHERE normalizedonlinebalance>0`, idxname, tablename)
 }
 
+func createUniqueAddressBalanceIndex(idxname string, tablename string) string {
+	return fmt.Sprintf(`CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s (address)`, idxname, tablename)
+}
+
 var createOnlineAccountIndex = []string{
 	`ALTER TABLE accountbase
 		ADD COLUMN normalizedonlinebalance INTEGER`,
@@ -859,7 +863,9 @@ func resetCatchpointStagingBalances(ctx context.Context, tx *sql.Tx, newCatchup 
 		// to "accountbase".  To construct a unique index name, we
 		// use the current time.
 		// Apply the same logic to
-		idxnameBalances := fmt.Sprintf("onlineaccountbals_idx_%d", time.Now().UnixNano())
+		now := time.Now().UnixNano()
+		idxnameBalances := fmt.Sprintf("onlineaccountbals_idx_%d", now)
+		idxnameAddress := fmt.Sprintf("accountbase_resources_migration_address_idx_%d", now)
 
 		s = append(s,
 			"CREATE TABLE IF NOT EXISTS catchpointassetcreators (asset integer primary key, creator blob, ctype integer)",
@@ -868,6 +874,7 @@ func resetCatchpointStagingBalances(ctx context.Context, tx *sql.Tx, newCatchup 
 			"CREATE TABLE IF NOT EXISTS catchpointaccounthashes (id integer primary key, data blob)",
 			"CREATE TABLE IF NOT EXISTS catchpointresources (addrid INTEGER NOT NULL, aidx INTEGER NOT NULL, rtype INTEGER NOT NULL, data BLOB NOT NULL, PRIMARY KEY (addrid, aidx, rtype) ) WITHOUT ROWID",
 			createNormalizedOnlineBalanceIndex(idxnameBalances, "catchpointbalances"),
+			createUniqueAddressBalanceIndex(idxnameAddress, "catchpointbalances"),
 		)
 	}
 
@@ -1601,7 +1608,9 @@ func accountDataResources(
 
 // performResourceTableMigration migrate the database to use the resources table.
 func performResourceTableMigration(ctx context.Context, tx *sql.Tx, log func(processed, total uint64)) (err error) {
-	idxnameBalances := fmt.Sprintf("onlineaccountbals_idx_%d", time.Now().UnixNano())
+	now := time.Now().UnixNano()
+	idxnameBalances := fmt.Sprintf("onlineaccountbals_idx_%d", now)
+	idxnameAddress := fmt.Sprintf("accountbase_resources_migration_address_idx_%d", now)
 
 	createNewAcctBase := []string{
 		`CREATE TABLE IF NOT EXISTS accountbase_resources_migration (
@@ -1610,7 +1619,7 @@ func performResourceTableMigration(ctx context.Context, tx *sql.Tx, log func(pro
 		data blob,
 		normalizedonlinebalance INTEGER )`,
 		createNormalizedOnlineBalanceIndex(idxnameBalances, "accountbase_resources_migration"),
-		fmt.Sprintf(`CREATE UNIQUE INDEX accountbase_resources_migration_address_idx_%d ON accountbase_resources_migration(address)`, time.Now().UnixNano()),
+		createUniqueAddressBalanceIndex(idxnameAddress, "accountbase_resources_migration"),
 	}
 
 	applyNewAcctBase := []string{

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -865,7 +865,7 @@ func resetCatchpointStagingBalances(ctx context.Context, tx *sql.Tx, newCatchup 
 		// Apply the same logic to
 		now := time.Now().UnixNano()
 		idxnameBalances := fmt.Sprintf("onlineaccountbals_idx_%d", now)
-		idxnameAddress := fmt.Sprintf("accountbase_resources_migration_address_idx_%d", now)
+		idxnameAddress := fmt.Sprintf("accountbase_address_idx_%d", now)
 
 		s = append(s,
 			"CREATE TABLE IF NOT EXISTS catchpointassetcreators (asset integer primary key, creator blob, ctype integer)",
@@ -1610,7 +1610,7 @@ func accountDataResources(
 func performResourceTableMigration(ctx context.Context, tx *sql.Tx, log func(processed, total uint64)) (err error) {
 	now := time.Now().UnixNano()
 	idxnameBalances := fmt.Sprintf("onlineaccountbals_idx_%d", now)
-	idxnameAddress := fmt.Sprintf("accountbase_resources_migration_address_idx_%d", now)
+	idxnameAddress := fmt.Sprintf("accountbase_address_idx_%d", now)
 
 	createNewAcctBase := []string{
 		`CREATE TABLE IF NOT EXISTS accountbase_resources_migration (


### PR DESCRIPTION
This index was in the migration schema but not the catchpoint restore schema.