### PR TITLE
ledger refactoring: delete resources table on accountsReset

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -128,6 +128,7 @@ var accountsResetExprs = []string{
 	`DROP TABLE IF EXISTS storedcatchpoints`,
 	`DROP TABLE IF EXISTS catchpointstate`,
 	`DROP TABLE IF EXISTS accounthashes`,
+	`DROP TABLE IF EXISTS resources`,
 }
 
 // accountDBVersion is the database version that this binary would know how to support and how to upgrade to.


### PR DESCRIPTION
## Summary

The `resources` table needs to be dropped during `accountsReset`. Without that, the entries there would not be eliminated during the reset process.

## Test Plan

Tested manually.