### PR TITLE
ledger refactoring: acct new round fix + test

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -2273,40 +2273,211 @@ func accountsPutTotals(tx *sql.Tx, totals ledgercore.AccountTotals, catchpointSt
 	return err
 }
 
-// accountsNewRound updates the accountbase and assetcreators tables by applying the provided deltas to the accounts / creatables.
-// The function returns a persistedAccountData for the modified accounts which can be stored in the base cache.
+type accountsWriter interface {
+	insertAccount(addr basics.Address, normBalance uint64, data baseAccountData) (rowid int64, err error)
+	deleteAccount(rowid int64) (rowsAffected int64, err error)
+	updateAccount(rowid int64, normBalance uint64, data baseAccountData) (rowsAffected int64, err error)
+
+	insertResource(addrid int64, aidx basics.CreatableIndex, rtype basics.CreatableType, data resourcesData) (rowid int64, err error)
+	deleteResource(addrid int64, aidx basics.CreatableIndex) (rowsAffected int64, err error)
+	updateResource(addrid int64, aidx basics.CreatableIndex, data resourcesData) (rowsAffected int64, err error)
+
+	insertCreatable(cidx basics.CreatableIndex, ctype basics.CreatableType, creator []byte) (rowid int64, err error)
+	deleteCreatable(cidx basics.CreatableIndex, ctype basics.CreatableType) (rowsAffected int64, err error)
+
+	close()
+}
+
+type accountsSqlWriter struct {
+	insertCreatableIdxStmt, deleteCreatableIdxStmt             *sql.Stmt
+	deleteByRowIDStmt, insertStmt, updateStmt                  *sql.Stmt
+	deleteResourceStmt, insertResourceStmt, updateResourceStmt *sql.Stmt
+}
+
+func (w *accountsSqlWriter) close() {
+	if w.deleteByRowIDStmt != nil {
+		w.deleteByRowIDStmt.Close()
+		w.deleteByRowIDStmt = nil
+	}
+	if w.insertStmt != nil {
+		w.insertStmt.Close()
+		w.insertStmt = nil
+	}
+	if w.updateStmt != nil {
+		w.updateStmt.Close()
+		w.updateStmt = nil
+	}
+	if w.deleteResourceStmt != nil {
+		w.deleteResourceStmt.Close()
+		w.deleteResourceStmt = nil
+	}
+	if w.insertResourceStmt != nil {
+		w.insertResourceStmt.Close()
+		w.insertResourceStmt = nil
+	}
+	if w.updateResourceStmt != nil {
+		w.updateResourceStmt.Close()
+		w.updateResourceStmt = nil
+	}
+	if w.insertCreatableIdxStmt != nil {
+		w.insertCreatableIdxStmt.Close()
+		w.insertCreatableIdxStmt = nil
+	}
+	if w.deleteCreatableIdxStmt != nil {
+		w.deleteCreatableIdxStmt.Close()
+		w.deleteCreatableIdxStmt = nil
+	}
+}
+
+func makeAccountsSqlWriter(tx *sql.Tx, hasAccounts bool, hasResources bool, hasCreatables bool) (w *accountsSqlWriter, err error) {
+	w = new(accountsSqlWriter)
+
+	if hasAccounts {
+		w.deleteByRowIDStmt, err = tx.Prepare("DELETE FROM accountbase WHERE rowid=?")
+		if err != nil {
+			return
+		}
+
+		w.insertStmt, err = tx.Prepare("INSERT INTO accountbase (address, normalizedonlinebalance, data) VALUES (?, ?, ?)")
+		if err != nil {
+			return
+		}
+
+		w.updateStmt, err = tx.Prepare("UPDATE accountbase SET normalizedonlinebalance = ?, data = ? WHERE rowid = ?")
+		if err != nil {
+			return
+		}
+	}
+
+	if hasResources {
+		w.deleteResourceStmt, err = tx.Prepare("DELETE FROM resources WHERE addrid = ? AND aidx = ?")
+		if err != nil {
+			return
+		}
+
+		w.insertResourceStmt, err = tx.Prepare("INSERT INTO resources(addrid, aidx, rtype, data) VALUES(?, ?, ?, ?)")
+		if err != nil {
+			return
+		}
+
+		w.updateResourceStmt, err = tx.Prepare("UPDATE resources SET data = ? WHERE addrid = ? AND aidx = ?")
+		if err != nil {
+			return
+		}
+	}
+
+	if hasCreatables {
+		w.insertCreatableIdxStmt, err = tx.Prepare("INSERT INTO assetcreators (asset, creator, ctype) VALUES (?, ?, ?)")
+		if err != nil {
+			return
+		}
+
+		w.deleteCreatableIdxStmt, err = tx.Prepare("DELETE FROM assetcreators WHERE asset=? AND ctype=?")
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+func (w accountsSqlWriter) insertAccount(addr basics.Address, normBalance uint64, data baseAccountData) (rowid int64, err error) {
+	result, err := w.insertStmt.Exec(addr[:], normBalance, protocol.Encode(&data))
+	if err != nil {
+		return
+	}
+	rowid, err = result.LastInsertId()
+	return
+}
+
+func (w accountsSqlWriter) deleteAccount(rowid int64) (rowsAffected int64, err error) {
+	result, err := w.deleteByRowIDStmt.Exec(rowid)
+	if err != nil {
+		return
+	}
+	rowsAffected, err = result.RowsAffected()
+	return
+}
+
+func (w accountsSqlWriter) updateAccount(rowid int64, normBalance uint64, data baseAccountData) (rowsAffected int64, err error) {
+	result, err := w.updateStmt.Exec(normBalance, protocol.Encode(&data), rowid)
+	if err != nil {
+		return
+	}
+	rowsAffected, err = result.RowsAffected()
+	return
+}
+
+func (w accountsSqlWriter) insertResource(addrid int64, aidx basics.CreatableIndex, rtype basics.CreatableType, data resourcesData) (rowid int64, err error) {
+	result, err := w.insertResourceStmt.Exec(addrid, aidx, rtype, protocol.Encode(&data))
+	if err != nil {
+		return
+	}
+	rowid, err = result.LastInsertId()
+	return
+}
+
+func (w accountsSqlWriter) deleteResource(addrid int64, aidx basics.CreatableIndex) (rowsAffected int64, err error) {
+	result, err := w.deleteResourceStmt.Exec(addrid, aidx)
+	if err != nil {
+		return
+	}
+	rowsAffected, err = result.RowsAffected()
+	return
+}
+
+func (w accountsSqlWriter) updateResource(addrid int64, aidx basics.CreatableIndex, data resourcesData) (rowsAffected int64, err error) {
+	result, err := w.updateResourceStmt.Exec(protocol.Encode(&data), addrid, aidx)
+	if err != nil {
+		return
+	}
+	rowsAffected, err = result.RowsAffected()
+	return
+}
+
+func (w accountsSqlWriter) insertCreatable(cidx basics.CreatableIndex, ctype basics.CreatableType, creator []byte) (rowid int64, err error) {
+	result, err := w.insertCreatableIdxStmt.Exec(cidx, creator, ctype)
+	if err != nil {
+		return
+	}
+	rowid, err = result.LastInsertId()
+	return
+}
+
+func (w accountsSqlWriter) deleteCreatable(cidx basics.CreatableIndex, ctype basics.CreatableType) (rowsAffected int64, err error) {
+	result, err := w.deleteCreatableIdxStmt.Exec(cidx, ctype)
+	if err != nil {
+		return
+	}
+	rowsAffected, err = result.RowsAffected()
+	return
+}
+
+// accountsNewRound is a convenience wrapper for accountsNewRoundImpl
 func accountsNewRound(
 	tx *sql.Tx,
 	updates compactAccountDeltas, resources compactResourcesDeltas, creatables map[basics.CreatableIndex]ledgercore.ModifiedCreatable,
 	proto config.ConsensusParams, lastUpdateRound basics.Round,
 ) (updatedAccounts []persistedAccountData, updatedResources map[basics.Address][]persistedResourcesData, err error) {
-
-	var (
-		insertCreatableIdxStmt, deleteCreatableIdxStmt             *sql.Stmt
-		deleteByRowIDStmt, insertStmt, updateStmt                  *sql.Stmt
-		deleteResourceStmt, insertResourceStmt, updateResourceStmt *sql.Stmt
-	)
-
-	deleteByRowIDStmt, err = tx.Prepare("DELETE FROM accountbase WHERE rowid=?")
+	hasAccounts := updates.len() > 0
+	hasResources := resources.len() > 0
+	hasCreatables := len(creatables) > 0
+	writer, err := makeAccountsSqlWriter(tx, hasAccounts, hasResources, hasCreatables)
 	if err != nil {
 		return
 	}
-	defer deleteByRowIDStmt.Close()
+	defer writer.close()
 
-	insertStmt, err = tx.Prepare("INSERT INTO accountbase (address, normalizedonlinebalance, data) VALUES (?, ?, ?)")
-	if err != nil {
-		return
-	}
-	defer insertStmt.Close()
+	return accountsNewRoundImpl(writer, updates, resources, creatables, proto, lastUpdateRound)
+}
 
-	updateStmt, err = tx.Prepare("UPDATE accountbase SET normalizedonlinebalance = ?, data = ? WHERE rowid = ?")
-	if err != nil {
-		return
-	}
-	defer updateStmt.Close()
+// accountsNewRoundImpl updates the accountbase and assetcreators tables by applying the provided deltas to the accounts / creatables.
+// The function returns a persistedAccountData for the modified accounts which can be stored in the base cache.
+func accountsNewRoundImpl(
+	writer accountsWriter,
+	updates compactAccountDeltas, resources compactResourcesDeltas, creatables map[basics.CreatableIndex]ledgercore.ModifiedCreatable,
+	proto config.ConsensusParams, lastUpdateRound basics.Round,
+) (updatedAccounts []persistedAccountData, updatedResources map[basics.Address][]persistedResourcesData, err error) {
 
-	var result sql.Result
-	var rowsAffected int64
 	updatedAccounts = make([]persistedAccountData, updates.len())
 	updatedAccountIdx := 0
 	newAddressesRowIDs := make(map[basics.Address]int64)
@@ -2320,11 +2491,10 @@ func accountsNewRound(
 				// if we didn't had it before, and we don't have anything now, just skip it.
 			} else {
 				// create a new entry.
+				var rowid int64
 				normBalance := data.newAcct.NormalizedOnlineBalance(proto)
-				result, err = insertStmt.Exec(data.address[:], normBalance, protocol.Encode(&data.newAcct))
+				rowid, err = writer.insertAccount(data.address, normBalance, data.newAcct)
 				if err == nil {
-					var rowid int64
-					rowid, err = result.LastInsertId()
 					updatedAccounts[updatedAccountIdx].rowid = rowid
 					updatedAccounts[updatedAccountIdx].accountData = data.newAcct
 					newAddressesRowIDs[data.address] = rowid
@@ -2334,24 +2504,24 @@ func accountsNewRound(
 			// non-zero rowid means we had a previous value.
 			if data.newAcct.IsEmpty() {
 				// new value is zero, which means we need to delete the current value.
-				result, err = deleteByRowIDStmt.Exec(data.oldAcct.rowid)
+				var rowsAffected int64
+				rowsAffected, err = writer.deleteAccount(data.oldAcct.rowid)
 				if err == nil {
 					// we deleted the entry successfully.
 					updatedAccounts[updatedAccountIdx].rowid = 0
 					updatedAccounts[updatedAccountIdx].accountData = baseAccountData{}
-					rowsAffected, err = result.RowsAffected()
 					if rowsAffected != 1 {
 						err = fmt.Errorf("failed to delete accountbase row for account %v, rowid %d", data.address, data.oldAcct.rowid)
 					}
 				}
 			} else {
+				var rowsAffected int64
 				normBalance := data.newAcct.NormalizedOnlineBalance(proto)
-				result, err = updateStmt.Exec(normBalance, protocol.Encode(&data.newAcct), data.oldAcct.rowid)
+				rowsAffected, err = writer.updateAccount(data.oldAcct.rowid, normBalance, data.newAcct)
 				if err == nil {
 					// rowid doesn't change on update.
 					updatedAccounts[updatedAccountIdx].rowid = data.oldAcct.rowid
 					updatedAccounts[updatedAccountIdx].accountData = data.newAcct
-					rowsAffected, err = result.RowsAffected()
 					if rowsAffected != 1 {
 						err = fmt.Errorf("failed to update accountbase row for account %v, rowid %d", data.address, data.oldAcct.rowid)
 					}
@@ -2368,24 +2538,6 @@ func accountsNewRound(
 		updatedAccounts[updatedAccountIdx].addr = data.address
 		updatedAccountIdx++
 	}
-
-	deleteResourceStmt, err = tx.Prepare("DELETE FROM resources WHERE addrid = ? AND aidx = ?")
-	if err != nil {
-		return
-	}
-	defer deleteResourceStmt.Close()
-
-	insertResourceStmt, err = tx.Prepare("INSERT INTO resources(addrid, aidx, rtype, data) VALUES(?, ?, ?, ?)")
-	if err != nil {
-		return
-	}
-	defer insertResourceStmt.Close()
-
-	updateResourceStmt, err = tx.Prepare("UPDATE resources SET data = ? WHERE addrid = ? AND aidx = ?")
-	if err != nil {
-		return
-	}
-	defer updateResourceStmt.Close()
 
 	updatedResources = make(map[basics.Address][]persistedResourcesData)
 	for i := 0; i < resources.len(); i++ {
@@ -2425,7 +2577,7 @@ func accountsNewRound(
 					err = fmt.Errorf("unknown creatable for addr %s (%d), aidx %d, data %v", addr.String(), addrid, aidx, data.newResource)
 					return
 				}
-				_, err = insertResourceStmt.Exec(addrid, aidx, rtype, protocol.Encode(&data.newResource))
+				_, err = writer.insertResource(addrid, aidx, rtype, data.newResource)
 				if err == nil {
 					// set the returned persisted account states so that we could store that as the baseResources in commitRound
 					entry = persistedResourcesData{addrid: addrid, aidx: aidx, rtype: rtype, data: data.newResource, round: lastUpdateRound}
@@ -2435,13 +2587,13 @@ func accountsNewRound(
 			// non-zero rowid means we had a previous value.
 			if data.newResource.IsEmpty() {
 				// new value is zero, which means we need to delete the current value.
-				result, err = deleteResourceStmt.Exec(addrid, aidx)
+				var rowsAffected int64
+				rowsAffected, err = writer.deleteResource(addrid, aidx)
 				if err == nil {
 					// we deleted the entry successfully.
 					// set zero addrid to mark this entry invalid for subsequent addr to addrid resolution
 					// because the base account might gone.
 					entry = persistedResourcesData{addrid: 0, aidx: aidx, rtype: 0, data: makeResourcesData(0), round: lastUpdateRound}
-					rowsAffected, err = result.RowsAffected()
 					if rowsAffected != 1 {
 						err = fmt.Errorf("failed to delete resources row for addr %s (%d), aidx %d", addr.String(), addrid, aidx)
 					}
@@ -2456,12 +2608,11 @@ func accountsNewRound(
 					err = fmt.Errorf("unknown creatable for addr %s (%d), aidx %d, data %v", addr.String(), addrid, aidx, data.newResource)
 					return
 				}
-
-				result, err = updateResourceStmt.Exec(protocol.Encode(&data.newResource), addrid, aidx)
+				var rowsAffected int64
+				rowsAffected, err = writer.updateResource(addrid, aidx, data.newResource)
 				if err == nil {
 					// rowid doesn't change on update.
 					entry = persistedResourcesData{addrid: addrid, aidx: aidx, rtype: rtype, data: data.newResource, round: lastUpdateRound}
-					rowsAffected, err = result.RowsAffected()
 					if rowsAffected != 1 {
 						err = fmt.Errorf("failed to update resources row for addr %s (%d), aidx %d", addr, addrid, aidx)
 					}
@@ -2479,23 +2630,11 @@ func accountsNewRound(
 	}
 
 	if len(creatables) > 0 {
-		insertCreatableIdxStmt, err = tx.Prepare("INSERT INTO assetcreators (asset, creator, ctype) VALUES (?, ?, ?)")
-		if err != nil {
-			return
-		}
-		defer insertCreatableIdxStmt.Close()
-
-		deleteCreatableIdxStmt, err = tx.Prepare("DELETE FROM assetcreators WHERE asset=? AND ctype=?")
-		if err != nil {
-			return
-		}
-		defer deleteCreatableIdxStmt.Close()
-
 		for cidx, cdelta := range creatables {
 			if cdelta.Created {
-				_, err = insertCreatableIdxStmt.Exec(cidx, cdelta.Creator[:], cdelta.Ctype)
+				_, err = writer.insertCreatable(cidx, cdelta.Ctype, cdelta.Creator[:])
 			} else {
-				_, err = deleteCreatableIdxStmt.Exec(cidx, cdelta.Ctype)
+				_, err = writer.deleteCreatable(cidx, cdelta.Ctype)
 			}
 			if err != nil {
 				return

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -2289,13 +2289,13 @@ type accountsWriter interface {
 	close()
 }
 
-type accountsSqlWriter struct {
+type accountsSQLWriter struct {
 	insertCreatableIdxStmt, deleteCreatableIdxStmt             *sql.Stmt
 	deleteByRowIDStmt, insertStmt, updateStmt                  *sql.Stmt
 	deleteResourceStmt, insertResourceStmt, updateResourceStmt *sql.Stmt
 }
 
-func (w *accountsSqlWriter) close() {
+func (w *accountsSQLWriter) close() {
 	if w.deleteByRowIDStmt != nil {
 		w.deleteByRowIDStmt.Close()
 		w.deleteByRowIDStmt = nil
@@ -2330,8 +2330,8 @@ func (w *accountsSqlWriter) close() {
 	}
 }
 
-func makeAccountsSqlWriter(tx *sql.Tx, hasAccounts bool, hasResources bool, hasCreatables bool) (w *accountsSqlWriter, err error) {
-	w = new(accountsSqlWriter)
+func makeAccountsSQLWriter(tx *sql.Tx, hasAccounts bool, hasResources bool, hasCreatables bool) (w *accountsSQLWriter, err error) {
+	w = new(accountsSQLWriter)
 
 	if hasAccounts {
 		w.deleteByRowIDStmt, err = tx.Prepare("DELETE FROM accountbase WHERE rowid=?")
@@ -2381,7 +2381,7 @@ func makeAccountsSqlWriter(tx *sql.Tx, hasAccounts bool, hasResources bool, hasC
 	return
 }
 
-func (w accountsSqlWriter) insertAccount(addr basics.Address, normBalance uint64, data baseAccountData) (rowid int64, err error) {
+func (w accountsSQLWriter) insertAccount(addr basics.Address, normBalance uint64, data baseAccountData) (rowid int64, err error) {
 	result, err := w.insertStmt.Exec(addr[:], normBalance, protocol.Encode(&data))
 	if err != nil {
 		return
@@ -2390,7 +2390,7 @@ func (w accountsSqlWriter) insertAccount(addr basics.Address, normBalance uint64
 	return
 }
 
-func (w accountsSqlWriter) deleteAccount(rowid int64) (rowsAffected int64, err error) {
+func (w accountsSQLWriter) deleteAccount(rowid int64) (rowsAffected int64, err error) {
 	result, err := w.deleteByRowIDStmt.Exec(rowid)
 	if err != nil {
 		return
@@ -2399,7 +2399,7 @@ func (w accountsSqlWriter) deleteAccount(rowid int64) (rowsAffected int64, err e
 	return
 }
 
-func (w accountsSqlWriter) updateAccount(rowid int64, normBalance uint64, data baseAccountData) (rowsAffected int64, err error) {
+func (w accountsSQLWriter) updateAccount(rowid int64, normBalance uint64, data baseAccountData) (rowsAffected int64, err error) {
 	result, err := w.updateStmt.Exec(normBalance, protocol.Encode(&data), rowid)
 	if err != nil {
 		return
@@ -2408,7 +2408,7 @@ func (w accountsSqlWriter) updateAccount(rowid int64, normBalance uint64, data b
 	return
 }
 
-func (w accountsSqlWriter) insertResource(addrid int64, aidx basics.CreatableIndex, rtype basics.CreatableType, data resourcesData) (rowid int64, err error) {
+func (w accountsSQLWriter) insertResource(addrid int64, aidx basics.CreatableIndex, rtype basics.CreatableType, data resourcesData) (rowid int64, err error) {
 	result, err := w.insertResourceStmt.Exec(addrid, aidx, rtype, protocol.Encode(&data))
 	if err != nil {
 		return
@@ -2417,7 +2417,7 @@ func (w accountsSqlWriter) insertResource(addrid int64, aidx basics.CreatableInd
 	return
 }
 
-func (w accountsSqlWriter) deleteResource(addrid int64, aidx basics.CreatableIndex) (rowsAffected int64, err error) {
+func (w accountsSQLWriter) deleteResource(addrid int64, aidx basics.CreatableIndex) (rowsAffected int64, err error) {
 	result, err := w.deleteResourceStmt.Exec(addrid, aidx)
 	if err != nil {
 		return
@@ -2426,7 +2426,7 @@ func (w accountsSqlWriter) deleteResource(addrid int64, aidx basics.CreatableInd
 	return
 }
 
-func (w accountsSqlWriter) updateResource(addrid int64, aidx basics.CreatableIndex, data resourcesData) (rowsAffected int64, err error) {
+func (w accountsSQLWriter) updateResource(addrid int64, aidx basics.CreatableIndex, data resourcesData) (rowsAffected int64, err error) {
 	result, err := w.updateResourceStmt.Exec(protocol.Encode(&data), addrid, aidx)
 	if err != nil {
 		return
@@ -2435,7 +2435,7 @@ func (w accountsSqlWriter) updateResource(addrid int64, aidx basics.CreatableInd
 	return
 }
 
-func (w accountsSqlWriter) insertCreatable(cidx basics.CreatableIndex, ctype basics.CreatableType, creator []byte) (rowid int64, err error) {
+func (w accountsSQLWriter) insertCreatable(cidx basics.CreatableIndex, ctype basics.CreatableType, creator []byte) (rowid int64, err error) {
 	result, err := w.insertCreatableIdxStmt.Exec(cidx, creator, ctype)
 	if err != nil {
 		return
@@ -2444,7 +2444,7 @@ func (w accountsSqlWriter) insertCreatable(cidx basics.CreatableIndex, ctype bas
 	return
 }
 
-func (w accountsSqlWriter) deleteCreatable(cidx basics.CreatableIndex, ctype basics.CreatableType) (rowsAffected int64, err error) {
+func (w accountsSQLWriter) deleteCreatable(cidx basics.CreatableIndex, ctype basics.CreatableType) (rowsAffected int64, err error) {
 	result, err := w.deleteCreatableIdxStmt.Exec(cidx, ctype)
 	if err != nil {
 		return
@@ -2462,7 +2462,7 @@ func accountsNewRound(
 	hasAccounts := updates.len() > 0
 	hasResources := resources.len() > 0
 	hasCreatables := len(creatables) > 0
-	writer, err := makeAccountsSqlWriter(tx, hasAccounts, hasResources, hasCreatables)
+	writer, err := makeAccountsSQLWriter(tx, hasAccounts, hasResources, hasCreatables)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Summary

Compact accounts and resources delta might be out of sync order. To cope with this fact and rowids reusage by SQLite, resources writing was split into two phases: detecting reused rowids, updating rows with reused rowids, and deleting non-reused.

## Test Plan

The original accountsNewRound replaced by accountsNewRoundImpl that takes accountWriter interface as the first argument instead of sql.Tx object.
accountsNewRound is preserved as a convenience wrapper for accountsNewRoundImpl with SQLWriter.

This change allowed to implement a fake writer that reuses all rowids and simulate the bug we found by running on real data.

This replaces #3510 and #3515
