### PR TITLE
Add logs in catchpoint service

### DIFF
--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -287,10 +287,14 @@ func (cs *CatchpointCatchupService) processStageLedgerDownload() (err error) {
 			return cs.abort(err)
 		}
 		peer := psp.Peer
+		start := time.Now()
 		err = ledgerFetcher.downloadLedger(cs.ctx, peer, round)
 		if err == nil {
+			cs.log.Infof("ledger downloaded in %d seconds", time.Since(start) / time.Second)
+			start = time.Now()
 			err = cs.ledgerAccessor.BuildMerkleTrie(cs.ctx, cs.updateVerifiedAccounts)
 			if err == nil {
+				cs.log.Infof("built merkle trie in %d seconds", time.Since(start) / time.Second)
 				break
 			}
 			// failed to build the merkle trie for the above catchpoint file.

--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -290,11 +290,11 @@ func (cs *CatchpointCatchupService) processStageLedgerDownload() (err error) {
 		start := time.Now()
 		err = ledgerFetcher.downloadLedger(cs.ctx, peer, round)
 		if err == nil {
-			cs.log.Infof("ledger downloaded in %d seconds", time.Since(start) / time.Second)
+			cs.log.Infof("ledger downloaded in %d seconds", time.Since(start)/time.Second)
 			start = time.Now()
 			err = cs.ledgerAccessor.BuildMerkleTrie(cs.ctx, cs.updateVerifiedAccounts)
 			if err == nil {
-				cs.log.Infof("built merkle trie in %d seconds", time.Since(start) / time.Second)
+				cs.log.Infof("built merkle trie in %d seconds", time.Since(start)/time.Second)
 				break
 			}
 			// failed to build the merkle trie for the above catchpoint file.

--- a/catchup/ledgerFetcher.go
+++ b/catchup/ledgerFetcher.go
@@ -146,7 +146,7 @@ func (lf *ledgerFetcher) getPeerLedger(ctx context.Context, peer network.HTTPPee
 			if err == io.EOF {
 				lf.log.Infof(
 					"writing catchpoint balances to disk took %d seconds",
-					writeDuration / time.Second)
+					writeDuration/time.Second)
 				return nil
 			}
 			return err

--- a/catchup/ledgerFetcher.go
+++ b/catchup/ledgerFetcher.go
@@ -139,10 +139,14 @@ func (lf *ledgerFetcher) getPeerLedger(ctx context.Context, peer network.HTTPPee
 	defer watchdogReader.Close()
 	tarReader := tar.NewReader(watchdogReader)
 	var downloadProgress ledger.CatchpointCatchupAccessorProgress
+	var writeDuration time.Duration
 	for {
 		header, err := tarReader.Next()
 		if err != nil {
 			if err == io.EOF {
+				lf.log.Infof(
+					"writing catchpoint balances to disk took %d seconds",
+					writeDuration / time.Second)
 				return nil
 			}
 			return err
@@ -166,20 +170,16 @@ func (lf *ledgerFetcher) getPeerLedger(ctx context.Context, peer network.HTTPPee
 				return err
 			}
 		}
+		start := time.Now()
 		err = lf.processBalancesBlock(ctx, header.Name, balancesBlockBytes, &downloadProgress)
 		if err != nil {
 			return err
 		}
+		writeDuration += time.Since(start)
 		if lf.reporter != nil {
 			lf.reporter.updateLedgerFetcherProgress(&downloadProgress)
 		}
-		if err = watchdogReader.Reset(); err != nil {
-			if err == io.EOF {
-				return nil
-			}
-			err = fmt.Errorf("getPeerLedger received the following error while reading the catchpoint file : %v", err)
-			return err
-		}
+		watchdogReader.Reset()
 	}
 }
 

--- a/cmd/catchpointdump/net.go
+++ b/cmd/catchpointdump/net.go
@@ -196,13 +196,7 @@ func downloadCatchpoint(addr string) ([]byte, error) {
 		} else {
 			outBytes = append(outBytes, tempBytes[:n]...)
 		}
-		err = wdReader.Reset()
-		if err != nil {
-			if err == io.EOF {
-				return outBytes, nil
-			}
-			return nil, err
-		}
+		wdReader.Reset()
 		if time.Now().Sub(lastProgressUpdate) > 50*time.Millisecond {
 			lastProgressUpdate = time.Now()
 			printDownloadProgressLine(progress, 50, url, int64(len(outBytes)))

--- a/util/watchdogStreamReader.go
+++ b/util/watchdogStreamReader.go
@@ -58,7 +58,7 @@ type watchdogStreamReader struct {
 
 // WatchdogStreamReader is the public interface for the watchdogStreamReader implementation.
 type WatchdogStreamReader interface {
-	Reset() error
+	Reset()
 	Read(p []byte) (n int, err error)
 	Close()
 }
@@ -82,18 +82,13 @@ func MakeWatchdogStreamReader(underlayingReader io.Reader, readSize uint64, read
 	return reader
 }
 
-// Reset extends the time and data limits by another "block", as well as returns an error code if the data stream has reached to it's end.
-func (r *watchdogStreamReader) Reset() error {
+// Reset extends the time and data limits by another "block".
+func (r *watchdogStreamReader) Reset() {
 	r.readerMu.Lock()
-	if r.readError != nil && len(r.stageBuffer) == 0 {
-		defer r.readerMu.Unlock()
-		return r.readError
-	}
 	r.maxDataSize = r.totalRead + r.readaheadSize
 	r.readerMu.Unlock()
 	r.tickerClose <- struct{}{}
 	go r.ticker()
-	return nil
 }
 
 // Read reads from the attached data stream, and aborts prematurally in case we've exceeed the data size or time allowed for the read to complete.


### PR DESCRIPTION
## Summary

Add logs in catchpoint service measuring the time it takes to
- write catchpoint balances to disk
- download the catchpoint + write balances to disk
- build the merkle trie

This PR also simplifies `util.WatchdogStreamReader`: `Reset()` now doesn't return an error. This allows us to delete redundant code on the user side. Also, exiting when `Reset()` returns an error in `catchup/ledgerFetcher.go` is not good because `tarReader` might still contain buffered data. The implementation of `tarReader` doesn't, but nothing in its specification says it doesn't.

## Test Plan

I ran fast catchup and verified that logs are printed.