### PR TITLE
ledger refactoring: measure and log performance during fast catchup

### DIFF
--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -288,10 +288,14 @@ func (cs *CatchpointCatchupService) processStageLedgerDownload() (err error) {
 			return cs.abort(err)
 		}
 		peer := psp.Peer
+		start := time.Now()
 		err = ledgerFetcher.downloadLedger(cs.ctx, peer, round)
 		if err == nil {
+			cs.log.Infof("ledger downloaded in %d seconds", time.Since(start)/time.Second)
+			start = time.Now()
 			err = cs.ledgerAccessor.BuildMerkleTrie(cs.ctx, cs.updateVerifiedAccounts)
 			if err == nil {
+				cs.log.Infof("built merkle trie in %d seconds", time.Since(start)/time.Second)
 				break
 			}
 			// failed to build the merkle trie for the above catchpoint file.


### PR DESCRIPTION
## Summary

Add logs in catchpoint service measuring the time it takes to
- write catchpoint balances to disk
- write catchpoint creatables to disk
- write catchpoint hashes to disk
- write all catchpoint data to disk
- download the catchpoint + write all catchpoint data to disk
- build the merkle trie

## Test Plan

I ran fast catchup and verified that logs are printed.