### PR TITLE
Update ledger README reference to trackers

### DIFF
--- a/ledger/README.md
+++ b/ledger/README.md
@@ -46,7 +46,7 @@ all blocks from the beginning of the blockchain.  As an optimization,
 the ledger allows trackers to store persistent state, so that they can
 reconstruct their state quickly, without considering every block.
 
-The interface between ledger and trackers is defined in `trackers.go`.
+The interface between ledger and trackers is defined in `tracker.go`.
 
 Trackers have access to the ledger through a restricted API defined by
 `ledgerForTracker`.  This allows trackers to access the ledger's SQLite


### PR DESCRIPTION
## Summary
Updates ledger README reference to tracker source code.

Since `trackers.go` does _not_ exist, I _assume_ the appropriate reference is `tracker.go`.

## Test Plan

Since the change _only_ impacts docs, I visually confirmed Markdown rendering.
