### PR TITLE
Removed hard-coded constant in `sortition.go`

### DIFF
--- a/data/committee/sortition/sortition.go
+++ b/data/committee/sortition/sortition.go
@@ -33,15 +33,17 @@ func Select(money uint64, totalMoney uint64, expectedSize float64, vrfOutput cry
 	binomialN := float64(money)
 	binomialP := expectedSize / float64(totalMoney)
 
-	t := &big.Int{}
-	t.SetBytes(vrfOutput[:])
-
+	maxFloatString := fmt.Sprintf("0x%s", strings.Repeat("f", crypto.DigestSize*2+1))
 	precision := uint(8 * (len(vrfOutput) + 1))
-	max, b, err := big.ParseFloat("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 0, precision, big.ToNearestEven)
+
+	max, b, err := big.ParseFloat(maxFloatString, 0, precision, big.ToNearestEven)
 	if b != 16 || err != nil {
 		panic("failed to parse big float constant in sortition")
 	}
 
+	t := &big.Int{}
+	t.SetBytes(vrfOutput[:])	
+	
 	h := big.Float{}
 	h.SetPrec(precision)
 	h.SetInt(t)


### PR DESCRIPTION
Remove a hardcoded constant in sortition.go which was
used as the denominator in determining the selection ratio.

This clarifies what the maximum possible output size is of
the output VRF based on the SHA algorithm used to generate it.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
