### PR TITLE
Removed hard-coded constant in `sortition.go`.

### DIFF
--- a/data/committee/sortition/sortition.go
+++ b/data/committee/sortition/sortition.go
@@ -36,7 +36,7 @@ func Select(money uint64, totalMoney uint64, expectedSize float64, vrfOutput cry
 	binomialP := expectedSize / float64(totalMoney)
 
 	precision := uint(8 * (len(vrfOutput) + 1))
-	maxFloatString := fmt.Sprintf("0x%s", strings.Repeat("f", crypto.DigestSize*2+1))
+	maxFloatString := fmt.Sprintf("0x%s", strings.Repeat("f", crypto.DigestSize*2))
 	max, b, err := big.ParseFloat(maxFloatString, 0, precision, big.ToNearestEven)
 	if b != 16 || err != nil {
 		panic("failed to parse big float constant in sortition")

--- a/data/committee/sortition/sortition.go
+++ b/data/committee/sortition/sortition.go
@@ -30,13 +30,14 @@ import (
 	"github.com/algorand/go-algorand/crypto"
 )
 
+var maxFloatString string = fmt.Sprintf("0x%s", strings.Repeat("f", crypto.DigestSize*2))
+
 // Select runs the sortition function and returns the number of time the key was selected
 func Select(money uint64, totalMoney uint64, expectedSize float64, vrfOutput crypto.Digest) uint64 {
 	binomialN := float64(money)
 	binomialP := expectedSize / float64(totalMoney)
 
 	precision := uint(8 * (len(vrfOutput) + 1))
-	maxFloatString := fmt.Sprintf("0x%s", strings.Repeat("f", crypto.DigestSize*2))
 	max, b, err := big.ParseFloat(maxFloatString, 0, precision, big.ToNearestEven)
 	if b != 16 || err != nil {
 		panic("failed to parse big float constant in sortition")

--- a/data/committee/sortition/sortition.go
+++ b/data/committee/sortition/sortition.go
@@ -23,7 +23,9 @@ package sortition
 // #include "sortition.h"
 import "C"
 import (
+	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/algorand/go-algorand/crypto"
 )
@@ -33,14 +35,15 @@ func Select(money uint64, totalMoney uint64, expectedSize float64, vrfOutput cry
 	binomialN := float64(money)
 	binomialP := expectedSize / float64(totalMoney)
 
-	t := &big.Int{}
-	t.SetBytes(vrfOutput[:])
-
 	precision := uint(8 * (len(vrfOutput) + 1))
-	max, b, err := big.ParseFloat("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 0, precision, big.ToNearestEven)
+	maxFloatString := fmt.Sprintf("0x%s", strings.Repeat("f", crypto.DigestSize*2+1))
+	max, b, err := big.ParseFloat(maxFloatString, 0, precision, big.ToNearestEven)
 	if b != 16 || err != nil {
 		panic("failed to parse big float constant in sortition")
 	}
+
+	t := &big.Int{}
+	t.SetBytes(vrfOutput[:])
 
 	h := big.Float{}
 	h.SetPrec(precision)

--- a/data/committee/sortition/sortition.go
+++ b/data/committee/sortition/sortition.go
@@ -56,7 +56,7 @@ func Select(money uint64, totalMoney uint64, expectedSize float64, vrfOutput cry
 func init() {
 	var b int
 	var err error
-	maxFloatString := fmt.Sprintf("0x%s", strings.Repeat("f", crypto.DigestSize*2))
+	maxFloatString := fmt.Sprintf("0x%s", strings.Repeat("ff", crypto.DigestSize))
 	maxFloat, b, err = big.ParseFloat(maxFloatString, 0, precision, big.ToNearestEven)
 	if b != 16 || err != nil {
 		err = fmt.Errorf("failed to parse big float constant in sortition : %w", err)


### PR DESCRIPTION
## Summary

Remove a hardcoded constant in sortition.go which was
used as the denominator in determining the selection ratio.

This clarifies what the maximum possible output size is of
the output VRF based on the SHA algorithm used to generate it.

## Purpose

This is simply a code quality change to make it easier to read and
understand without any focus on new functionality or performance.

It is unlikely that the VRF SHA length used by Algorand will changed,
so the generalization to a dynamic length based on the length of the
Crypto digest is only for the reader.

The use of an `init` function to initialize the `maxFloat` once rather than
anytime `sortition` runs is a minor optimization, but likely to be neglibile
in the grand scheme of things.

## Test Plan

Due to the usage of C src code, a simple `go test -v ./data/committee/sortition/`
cannot be executed without the proper configurations. However, circle CI
should be able to execute the unit tests automatically and verify the changes.

Recommendation: Running the recommended make targets to test the changes
did not automatically due to missing dependencies, so potentially a Dockerfile
could help resolve this for future contributors.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->
