### PR TITLE
Moving to centos stream 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,13 +50,13 @@ workflows:
   version: 2
   "circleci_build_and_test":
     jobs:
-      # - codegen_verification
+      - codegen_verification
 
       - build:
           name: << matrix.platform >>_build
           matrix: &matrix-default
             parameters:
-              platform: ["amd64"] #, "arm64", "mac_amd64"]
+              platform: ["amd64", "arm64", "mac_amd64"]
 
       - test:
           name: << matrix.platform >>_test
@@ -69,20 +69,19 @@ workflows:
               ignore:
                 - /rel\/.*/
                 - /hotfix\/.*/
-                - /Moving\-to\-centos\-stream\-8/
 
-      # - test_nightly:
-      #     name: << matrix.platform >>_test_nightly
-      #     matrix:
-      #       <<: *matrix-default
-      #     requires:
-      #       - << matrix.platform >>_build
-      #     filters: &filters-nightly
-      #       branches:
-      #         only:
-      #           - /rel\/.*/
-      #           - /hotfix\/.*/
-      #     context: slack-secrets
+      - test_nightly:
+          name: << matrix.platform >>_test_nightly
+          matrix:
+            <<: *matrix-default
+          requires:
+            - << matrix.platform >>_build
+          filters: &filters-nightly
+            branches:
+              only:
+                - /rel\/.*/
+                - /hotfix\/.*/
+          context: slack-secrets
 
       - integration:
           name: << matrix.platform >>_integration
@@ -93,15 +92,15 @@ workflows:
           filters:
             <<: *filters-default
 
-      # - integration_nightly:
-      #     name: << matrix.platform >>_integration_nightly
-      #     matrix:
-      #       <<: *matrix-default
-      #     requires:
-      #       - << matrix.platform >>_build
-      #     filters:
-      #       <<: *filters-nightly
-      #     context: slack-secrets
+      - integration_nightly:
+          name: << matrix.platform >>_integration_nightly
+          matrix:
+            <<: *matrix-default
+          requires:
+            - << matrix.platform >>_build
+          filters:
+            <<: *filters-nightly
+          context: slack-secrets
 
       - e2e_expect:
           name: << matrix.platform >>_e2e_expect
@@ -112,15 +111,15 @@ workflows:
           filters:
             <<: *filters-default
 
-      # - e2e_expect_nightly:
-      #     name: << matrix.platform >>_e2e_expect_nightly
-      #     matrix:
-      #       <<: *matrix-default
-      #     requires:
-      #       - << matrix.platform >>_build
-      #     filters:
-      #       <<: *filters-nightly
-      #     context: slack-secrets
+      - e2e_expect_nightly:
+          name: << matrix.platform >>_e2e_expect_nightly
+          matrix:
+            <<: *matrix-default
+          requires:
+            - << matrix.platform >>_build
+          filters:
+            <<: *filters-nightly
+          context: slack-secrets
 
       - e2e_subs:
           name: << matrix.platform >>_e2e_subs
@@ -131,41 +130,39 @@ workflows:
           filters:
             <<: *filters-default
 
-      # - e2e_subs_nightly:
-      #     name: << matrix.platform >>_e2e_subs_nightly
-      #     matrix:
-      #       <<: *matrix-default
-      #     requires:
-      #       - << matrix.platform >>_build
-      #     filters:
-      #       <<: *filters-nightly
-      #     context: slack-secrets
+      - e2e_subs_nightly:
+          name: << matrix.platform >>_e2e_subs_nightly
+          matrix:
+            <<: *matrix-default
+          requires:
+            - << matrix.platform >>_build
+          filters:
+            <<: *filters-nightly
+          context: slack-secrets
 
-      # - tests_verification_job:
-      #     name: << matrix.platform >>_<< matrix.job_type >>_verification
-      #     matrix:
-      #       parameters:
-      #         platform: ["amd64"] #, "arm64", "mac_amd64"]
-      #         job_type: ["test_nightly"] #["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
-      #     requires:
-      #       - << matrix.platform >>_<< matrix.job_type >>
+      - tests_verification_job:
+          name: << matrix.platform >>_<< matrix.job_type >>_verification
+          matrix:
+            parameters:
+              platform: ["amd64", "arm64", "mac_amd64"]
+              job_type: ["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
+          requires:
+            - << matrix.platform >>_<< matrix.job_type >>
 
       - upload_binaries:
           name: << matrix.platform >>_upload_binaries
           matrix:
             <<: *matrix-default
           requires:
-            - amd64_build
-            # - << matrix.platform >>_test_nightly_verification
-            # - << matrix.platform >>_integration_nightly_verification
-            # - << matrix.platform >>_e2e_expect_nightly_verification
-            # - << matrix.platform >>_e2e_subs_nightly
-            # - codegen_verification
+            - << matrix.platform >>_test_nightly_verification
+            - << matrix.platform >>_integration_nightly_verification
+            - << matrix.platform >>_e2e_expect_nightly_verification
+            - << matrix.platform >>_e2e_subs_nightly
+            - codegen_verification
           filters:
             branches:
               only:
                 - /rel\/.*/
-                - /Moving\-to\-centos\-stream\-8/
           context:
             - slack-secrets
             - aws-secrets
@@ -482,7 +479,7 @@ commands:
         - run:
             name: Upload Binaries << parameters.platform >>
             command: |
-              if [ "${CIRCLE_BRANCH}" = "Moving-to-centos-stream-8" ]
+              if [ "${CIRCLE_BRANCH}" = "rel/nightly" ]
               then
                 export NO_BUILD="true"
               fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,19 +71,18 @@ workflows:
                 - /hotfix\/.*/
                 - /Moving\-to\-centos\-stream\-8/
 
-      - test_nightly:
-          name: << matrix.platform >>_test_nightly
-          matrix:
-            <<: *matrix-default
-          requires:
-            - << matrix.platform >>_build
-          filters: &filters-nightly
-            branches:
-              only:
-                - /rel\/.*/
-                - /hotfix\/.*/
-                - /Moving\-to\-centos\-stream\-8/
-          context: slack-secrets
+      # - test_nightly:
+      #     name: << matrix.platform >>_test_nightly
+      #     matrix:
+      #       <<: *matrix-default
+      #     requires:
+      #       - << matrix.platform >>_build
+      #     filters: &filters-nightly
+      #       branches:
+      #         only:
+      #           - /rel\/.*/
+      #           - /hotfix\/.*/
+      #     context: slack-secrets
 
       - integration:
           name: << matrix.platform >>_integration
@@ -156,11 +155,12 @@ workflows:
           matrix:
             <<: *matrix-default
           requires:
-            - << matrix.platform >>_test_nightly_verification
+            - amd64_build
+            # - << matrix.platform >>_test_nightly_verification
             # - << matrix.platform >>_integration_nightly_verification
             # - << matrix.platform >>_e2e_expect_nightly_verification
             # - << matrix.platform >>_e2e_subs_nightly
-            - codegen_verification
+            # - codegen_verification
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,14 +141,14 @@ workflows:
       #       <<: *filters-nightly
       #     context: slack-secrets
 
-      - tests_verification_job:
-          name: << matrix.platform >>_<< matrix.job_type >>_verification
-          matrix:
-            parameters:
-              platform: ["amd64"] #, "arm64", "mac_amd64"]
-              job_type: ["test_nightly"] #["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
-          requires:
-            - << matrix.platform >>_<< matrix.job_type >>
+      # - tests_verification_job:
+      #     name: << matrix.platform >>_<< matrix.job_type >>_verification
+      #     matrix:
+      #       parameters:
+      #         platform: ["amd64"] #, "arm64", "mac_amd64"]
+      #         job_type: ["test_nightly"] #["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
+      #     requires:
+      #       - << matrix.platform >>_<< matrix.job_type >>
 
       - upload_binaries:
           name: << matrix.platform >>_upload_binaries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ workflows:
           name: << matrix.platform >>_build
           matrix: &matrix-default
             parameters:
-              platform: ["amd64", "arm64", "mac_amd64"]
+              platform: ["amd64"] #, "arm64", "mac_amd64"]
 
       - test:
           name: << matrix.platform >>_test
@@ -69,6 +69,7 @@ workflows:
               ignore:
                 - /rel\/.*/
                 - /hotfix\/.*/
+                - /Moving-to-centos-stream-8\/.*/
 
       - test_nightly:
           name: << matrix.platform >>_test_nightly
@@ -81,6 +82,7 @@ workflows:
               only:
                 - /rel\/.*/
                 - /hotfix\/.*/
+                - /Moving-to-centos-stream-8\/.*/
           context: slack-secrets
 
       - integration:
@@ -92,15 +94,15 @@ workflows:
           filters:
             <<: *filters-default
 
-      - integration_nightly:
-          name: << matrix.platform >>_integration_nightly
-          matrix:
-            <<: *matrix-default
-          requires:
-            - << matrix.platform >>_build
-          filters:
-            <<: *filters-nightly
-          context: slack-secrets
+      # - integration_nightly:
+      #     name: << matrix.platform >>_integration_nightly
+      #     matrix:
+      #       <<: *matrix-default
+      #     requires:
+      #       - << matrix.platform >>_build
+      #     filters:
+      #       <<: *filters-nightly
+      #     context: slack-secrets
 
       - e2e_expect:
           name: << matrix.platform >>_e2e_expect
@@ -111,15 +113,15 @@ workflows:
           filters:
             <<: *filters-default
 
-      - e2e_expect_nightly:
-          name: << matrix.platform >>_e2e_expect_nightly
-          matrix:
-            <<: *matrix-default
-          requires:
-            - << matrix.platform >>_build
-          filters:
-            <<: *filters-nightly
-          context: slack-secrets
+      # - e2e_expect_nightly:
+      #     name: << matrix.platform >>_e2e_expect_nightly
+      #     matrix:
+      #       <<: *matrix-default
+      #     requires:
+      #       - << matrix.platform >>_build
+      #     filters:
+      #       <<: *filters-nightly
+      #     context: slack-secrets
 
       - e2e_subs:
           name: << matrix.platform >>_e2e_subs
@@ -130,22 +132,22 @@ workflows:
           filters:
             <<: *filters-default
 
-      - e2e_subs_nightly:
-          name: << matrix.platform >>_e2e_subs_nightly
-          matrix:
-            <<: *matrix-default
-          requires:
-            - << matrix.platform >>_build
-          filters:
-            <<: *filters-nightly
-          context: slack-secrets
+      # - e2e_subs_nightly:
+      #     name: << matrix.platform >>_e2e_subs_nightly
+      #     matrix:
+      #       <<: *matrix-default
+      #     requires:
+      #       - << matrix.platform >>_build
+      #     filters:
+      #       <<: *filters-nightly
+      #     context: slack-secrets
 
       - tests_verification_job:
           name: << matrix.platform >>_<< matrix.job_type >>_verification
           matrix:
             parameters:
-              platform: ["amd64", "arm64", "mac_amd64"]
-              job_type: ["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
+              platform: ["amd64"] #, "arm64", "mac_amd64"]
+              job_type: ["test_nightly"] #["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
           requires:
             - << matrix.platform >>_<< matrix.job_type >>
 
@@ -155,14 +157,15 @@ workflows:
             <<: *matrix-default
           requires:
             - << matrix.platform >>_test_nightly_verification
-            - << matrix.platform >>_integration_nightly_verification
-            - << matrix.platform >>_e2e_expect_nightly_verification
-            - << matrix.platform >>_e2e_subs_nightly
+            # - << matrix.platform >>_integration_nightly_verification
+            # - << matrix.platform >>_e2e_expect_nightly_verification
+            # - << matrix.platform >>_e2e_subs_nightly
             - codegen_verification
           filters:
             branches:
               only:
                 - /rel\/.*/
+                - /Moving-to-centos-stream-8\/.*/
           context:
             - slack-secrets
             - aws-secrets
@@ -479,7 +482,7 @@ commands:
         - run:
             name: Upload Binaries << parameters.platform >>
             command: |
-              if [ "${CIRCLE_BRANCH}" = "rel/nightly" ]
+              if [ "${CIRCLE_BRANCH}" = "Moving-to-centos-stream-8" ]
               then
                 export NO_BUILD="true"
               fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ workflows:
               ignore:
                 - /rel\/.*/
                 - /hotfix\/.*/
-                - /Moving-to-centos-stream-8\/.*/
+                - /Moving\-to\-centos\-stream\-8/
 
       - test_nightly:
           name: << matrix.platform >>_test_nightly
@@ -82,7 +82,7 @@ workflows:
               only:
                 - /rel\/.*/
                 - /hotfix\/.*/
-                - /Moving-to-centos-stream-8\/.*/
+                - /Moving\-to\-centos\-stream\-8/
           context: slack-secrets
 
       - integration:
@@ -165,7 +165,7 @@ workflows:
             branches:
               only:
                 - /rel\/.*/
-                - /Moving-to-centos-stream-8\/.*/
+                - /Moving\-to\-centos\-stream\-8/
           context:
             - slack-secrets
             - aws-secrets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ workflows:
   version: 2
   "circleci_build_and_test":
     jobs:
-      - codegen_verification
+      # - codegen_verification
 
       - build:
           name: << matrix.platform >>_build

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -70,7 +70,7 @@ This section briefly describes the expected outcomes of the current build pipeli
     - The packages are built from the correct branch and channel and are the correct version.  This done by running `algod -v`.
         + This is done for the following docker containers:
             - centos:7
-            - centos:8
+            - quay.io/centos/centos:stream8
             - fedora:28
             - ubuntu:16.04
             - ubuntu:18.04

--- a/scripts/release/test/util/test_package.sh
+++ b/scripts/release/test/util/test_package.sh
@@ -9,7 +9,7 @@ set -ex
 
 OS_LIST=(
     centos:7
-    centos:8
+    quay.io/centos/centos:stream8
     fedora:28
     ubuntu:16.04
     ubuntu:18.04

--- a/test/packages/test_release.sh
+++ b/test/packages/test_release.sh
@@ -16,7 +16,7 @@ fi
 
 OS_LIST=(
     centos:7
-    centos:8
+    quay.io/centos/centos:stream8
     fedora:28
     ubuntu:16.04
     ubuntu:18.04

--- a/test/platform/test_linux_amd64_compatibility.sh
+++ b/test/platform/test_linux_amd64_compatibility.sh
@@ -8,7 +8,7 @@ END_FG_COLOR=$(tput sgr0 2>/dev/null)
 
 OS_LIST=(
     centos:7
-    centos:8
+    quay.io/centos/centos:stream8
     fedora:28
     ubuntu:16.04
     ubuntu:18.04


### PR DESCRIPTION
our nightly pipeline broke because of centos:8 reaching end of life and deprecating their package repo AppStream. Switching to official new version Centos Stream 8.

Tested it here: https://app.circleci.com/pipelines/github/algorand/go-algorand/4716/workflows/e32173a7-e08b-47f0-a098-c2c32fb0c1ee/jobs/73893

More info: https://www.centos.org/centos-linux-eol/

Break that was fixed by this: https://app.circleci.com/pipelines/github/algorand/go-algorand/4699/workflows/8ebe3bc6-c029-49e1-8bb2-45d6061226c5/jobs/73675