### PR TITLE
catchpointdump: allow print filters

### DIFF
--- a/cmd/catchpointdump/database.go
+++ b/cmd/catchpointdump/database.go
@@ -58,7 +58,7 @@ var databaseCmd = &cobra.Command{
 			}
 			defer outFile.Close()
 		}
-		err = printAccountsDatabase(ledgerTrackerFilename, ledger.CatchpointFileHeader{}, outFile)
+		err = printAccountsDatabase(ledgerTrackerFilename, ledger.CatchpointFileHeader{}, outFile, nil)
 		if err != nil {
 			reportErrorf("Unable to print account database : %v", err)
 		}

--- a/cmd/catchpointdump/net.go
+++ b/cmd/catchpointdump/net.go
@@ -277,7 +277,7 @@ func makeFileDump(addr string, tarFile string) error {
 	if err != nil {
 		return err
 	}
-	err = printAccountsDatabase("./ledger.tracker.sqlite", fileHeader, outFile)
+	err = printAccountsDatabase("./ledger.tracker.sqlite", fileHeader, outFile, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/goal/common.go
+++ b/cmd/goal/common.go
@@ -17,10 +17,9 @@
 package main
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/spf13/cobra"
+
+	cmdutil "github.com/algorand/go-algorand/cmd/util"
 )
 
 const (
@@ -52,7 +51,7 @@ var (
 	dumpForDryrunAccts []string
 )
 
-var dumpForDryrunFormat cobraStringValue = *makeCobraStringValue("json", []string{"msgp"})
+var dumpForDryrunFormat cmdutil.CobraStringValue = *cmdutil.MakeCobraStringValue("json", []string{"msgp"})
 
 func addTxnFlags(cmd *cobra.Command) {
 	cmd.Flags().Uint64Var(&fee, "fee", 0, "The transaction fee (automatically determined by default), in microAlgos")
@@ -68,40 +67,4 @@ func addTxnFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&dumpForDryrun, "dryrun-dump", false, "Dump in dryrun format acceptable by dryrun REST api")
 	cmd.Flags().Var(&dumpForDryrunFormat, "dryrun-dump-format", "Dryrun dump format: "+dumpForDryrunFormat.AllowedString())
 	cmd.Flags().StringSliceVar(&dumpForDryrunAccts, "dryrun-accounts", nil, "additional accounts to include into dryrun request obj")
-}
-
-type cobraStringValue struct {
-	value   string
-	allowed []string
-	isSet   bool
-}
-
-func makeCobraStringValue(value string, others []string) *cobraStringValue {
-	c := new(cobraStringValue)
-	c.value = value
-	c.allowed = make([]string, 0, len(others)+1)
-	c.allowed = append(c.allowed, value)
-	for _, s := range others {
-		c.allowed = append(c.allowed, s)
-	}
-	return c
-}
-
-func (c *cobraStringValue) String() string { return c.value }
-func (c *cobraStringValue) Type() string   { return "string" }
-func (c *cobraStringValue) IsSet() bool    { return c.isSet }
-
-func (c *cobraStringValue) Set(other string) error {
-	for _, s := range c.allowed {
-		if other == s {
-			c.value = other
-			c.isSet = true
-			return nil
-		}
-	}
-	return fmt.Errorf("value %s not allowed", other)
-}
-
-func (c *cobraStringValue) AllowedString() string {
-	return strings.Join(c.allowed, ", ")
 }

--- a/cmd/tealdbg/main.go
+++ b/cmd/tealdbg/main.go
@@ -17,14 +17,14 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
+
+	cmdutil "github.com/algorand/go-algorand/cmd/util"
 )
 
 func main() {
@@ -65,49 +65,12 @@ var remoteCmd = &cobra.Command{
 	},
 }
 
-// cobraStringValue is a cobra's string flag with restricted values
-type cobraStringValue struct {
-	value   string
-	allowed []string
-	isSet   bool
-}
-
-func makeCobraStringValue(value string, others []string) *cobraStringValue {
-	c := new(cobraStringValue)
-	c.value = value
-	c.allowed = make([]string, 0, len(others)+1)
-	c.allowed = append(c.allowed, value)
-	for _, s := range others {
-		c.allowed = append(c.allowed, s)
-	}
-	return c
-}
-
-func (c *cobraStringValue) String() string { return c.value }
-func (c *cobraStringValue) Type() string   { return "string" }
-func (c *cobraStringValue) IsSet() bool    { return c.isSet }
-
-func (c *cobraStringValue) Set(other string) error {
-	for _, s := range c.allowed {
-		if other == s {
-			c.value = other
-			c.isSet = true
-			return nil
-		}
-	}
-	return fmt.Errorf("value %s not allowed", other)
-}
-
-func (c *cobraStringValue) AllowedString() string {
-	return strings.Join(c.allowed, ", ")
-}
-
 type frontendValue struct {
-	*cobraStringValue
+	*cmdutil.CobraStringValue
 }
 
 func (f *frontendValue) Make(router *mux.Router, appAddress string) (da DebugAdapter) {
-	switch f.value {
+	switch f.String() {
 	case "web":
 		wa := MakeWebPageFrontend(&WebPageFrontendParams{router, appAddress})
 		return wa
@@ -120,10 +83,10 @@ func (f *frontendValue) Make(router *mux.Router, appAddress string) (da DebugAda
 }
 
 type runModeValue struct {
-	*cobraStringValue
+	*cmdutil.CobraStringValue
 }
 
-var frontend frontendValue = frontendValue{makeCobraStringValue("cdt", []string{"web"})}
+var frontend frontendValue = frontendValue{cmdutil.MakeCobraStringValue("cdt", []string{"web"})}
 var proto string
 var txnFile string
 var groupIndex int
@@ -133,7 +96,7 @@ var indexerURL string
 var indexerToken string
 var roundNumber uint64
 var timestamp int64
-var runMode runModeValue = runModeValue{makeCobraStringValue("auto", []string{"signature", "application"})}
+var runMode runModeValue = runModeValue{cmdutil.MakeCobraStringValue("auto", []string{"signature", "application"})}
 var port int
 var iface string
 var noFirstRun bool

--- a/cmd/tealdbg/main.go
+++ b/cmd/tealdbg/main.go
@@ -69,8 +69,12 @@ type frontendValue struct {
 	*cmdutil.CobraStringValue
 }
 
+func (f *frontendValue) value() string {
+	return f.CobraStringValue.String()
+}
+
 func (f *frontendValue) Make(router *mux.Router, appAddress string) (da DebugAdapter) {
-	switch f.String() {
+	switch f.value() {
 	case "web":
 		wa := MakeWebPageFrontend(&WebPageFrontendParams{router, appAddress})
 		return wa

--- a/cmd/util/cmd.go
+++ b/cmd/util/cmd.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 )
 
+// CobraStringValue is similar to spf13.pflag.stringValue but enforces allowed values
 type CobraStringValue struct {
 	value   string
 	allowed []string
@@ -39,8 +40,12 @@ func MakeCobraStringValue(value string, others []string) *CobraStringValue {
 }
 
 func (c *CobraStringValue) String() string { return c.value }
-func (c *CobraStringValue) Type() string   { return "string" }
-func (c *CobraStringValue) IsSet() bool    { return c.isSet }
+
+// Type returns the value type as a string
+func (c *CobraStringValue) Type() string { return "string" }
+
+// IsSet returns a boolean flag indicating of the value was changed from defaults
+func (c *CobraStringValue) IsSet() bool { return c.isSet }
 
 // Set sets a value and fails if it is not allowed
 func (c *CobraStringValue) Set(other string) error {
@@ -59,6 +64,7 @@ func (c *CobraStringValue) AllowedString() string {
 	return strings.Join(c.allowed, ", ")
 }
 
+// CobraStringSliceValue is similar to spf13.pflag.stringSliceValue but enforces allowed values
 type CobraStringSliceValue struct {
 	value      []string
 	allowed    []string
@@ -92,8 +98,12 @@ func MakeCobraStringSliceValue(value *[]string, others []string) *CobraStringSli
 }
 
 func (c *CobraStringSliceValue) String() string { return "[" + strings.Join(c.value, ", ") + "]" }
-func (c *CobraStringSliceValue) Type() string   { return "stringSlice" }
-func (c *CobraStringSliceValue) IsSet() bool    { return c.isSet }
+
+// Type returns the value type as a string
+func (c *CobraStringSliceValue) Type() string { return "stringSlice" }
+
+// IsSet returns a boolean flag indicating of the value was changed from defaults
+func (c *CobraStringSliceValue) IsSet() bool { return c.isSet }
 
 // Set sets a value and fails if it is not allowed
 func (c *CobraStringSliceValue) Set(values string) error {
@@ -115,6 +125,7 @@ func (c *CobraStringSliceValue) AllowedString() string {
 	return strings.Join(c.allowed, ", ")
 }
 
-func (s *CobraStringSliceValue) GetSlice() []string {
-	return s.value
+// GetSlice returns a current value as a string slice
+func (c *CobraStringSliceValue) GetSlice() []string {
+	return c.value
 }

--- a/cmd/util/cmd.go
+++ b/cmd/util/cmd.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package cmdutil
+
+import (
+	"fmt"
+	"strings"
+)
+
+type CobraStringValue struct {
+	value   string
+	allowed []string
+	isSet   bool
+}
+
+// MakeCobraStringValue creates a string value (satisfying spf13/pflag.Value interface)
+// for a limited number of valid options
+func MakeCobraStringValue(value string, others []string) *CobraStringValue {
+	c := new(CobraStringValue)
+	c.value = value
+	c.allowed = make([]string, 0, len(others)+1)
+	c.allowed = append(c.allowed, value)
+	c.allowed = append(c.allowed, others...)
+	return c
+}
+
+func (c *CobraStringValue) String() string { return c.value }
+func (c *CobraStringValue) Type() string   { return "string" }
+func (c *CobraStringValue) IsSet() bool    { return c.isSet }
+
+// Set sets a value and fails if it is not allowed
+func (c *CobraStringValue) Set(other string) error {
+	for _, s := range c.allowed {
+		if other == s {
+			c.value = other
+			c.isSet = true
+			return nil
+		}
+	}
+	return fmt.Errorf("value %s not allowed", other)
+}
+
+// AllowedString returns a comma-separated string of allowed values
+func (c *CobraStringValue) AllowedString() string {
+	return strings.Join(c.allowed, ", ")
+}


### PR DESCRIPTION
## Summary

Added a new option `--exclude-fields` to `file` subcommand.
This simplifies large dumps comparison by excluding all exclude some header fields.
Also moved some shared cmd code into a new cmdutil package.

## Test Plan

Tested manually