### PR TITLE
Add comment to help explain txntest.Txn rationale

### DIFF
--- a/data/txntest/txn.go
+++ b/data/txntest/txn.go
@@ -47,6 +47,7 @@ import (
 
 // Txn exists purely to make it easier to write a
 // transaction.Transaction in Go source.
+// To better understand Txn rationale, see https://github.com/algorand/go-algorand/pull/2730.
 type Txn struct {
 	Type protocol.TxType
 


### PR DESCRIPTION
## Summary

Adds inline comment linking to the PR that created `txntest.Txn`.  For developers new to _go-algorand_, the originating PR provides context to help understand _how_ `txntest.Txn` simplifies life.

## Test Plan
N/A - Only changes comments.
