### PR TITLE
Add comment to help explain txntest.Txn rationale

### DIFF
--- a/data/txntest/txn.go
+++ b/data/txntest/txn.go
@@ -45,8 +45,10 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 )
 
-// Txn exists purely to make it easier to write a
-// transaction.Transaction in Go source.
+// Txn exists to simplify writing tests where transaction.Transaction might be unwieldy.
+// Txn simplifies testing in these ways:
+// * Provides a flat structure to simplify object construction.
+// * Defines convenience methods to help setup test state.
 type Txn struct {
 	Type protocol.TxType
 


### PR DESCRIPTION
## Summary
Adds commentary based on context found in https://github.com/algorand/go-algorand/pull/2730.  For developers new to _go-algorand_, the context helps to explain _how_ `txntest.Txn` simplifies testing.

## Test Plan
N/A - Only changes comments.
