### PR TITLE
Document rationale for disallowing clear state program inner transactions

### DIFF
--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -4062,6 +4062,13 @@ func opTxBegin(cx *EvalContext) {
 		cx.err = errors.New("itxn_begin without itxn_submit")
 		return
 	}
+
+	// Product decision - Prevent clear state programs (CSPs) from issuing inner
+	// transactions to minimize complexity.
+	// * If CSPs support inner transactions, downstream program errors may
+	//   complicate CSP guarantees for opting out accounts from apps.
+	// * Since the team felt CSP inner transactions are a narrow(er) use case,
+	//   the complexity tradeoff did _not_ feel justified.
 	if cx.Proto.IsolateClearState && cx.Txn.Txn.OnCompletion == transactions.ClearStateOC {
 		cx.err = errors.New("clear state programs can not issue inner transactions")
 		return


### PR DESCRIPTION
## Summary
Adds inline comment explaining how the team decided to drop support for inner transactions in a clear state program.

* Relates to https://github.com/algorand/go-algorand/pull/3556/.
* Consider the PR optional.  As a new team member, I felt the comment benefits future readers' comprehension.  If folks feel the explanation is obvious, then I welcome closing the PR.  

## Test Plan
N/A - Only changes comments.
