### PR TITLE
Add catchpointdump into tools package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,6 +29,7 @@ cmd/updater/updater
 tmp/dev_pkg
 tmp/out
 tmp/node_pkgs
+tmp/go-cache
 
 # Ignore vim backup and swap files
 *~

--- a/scripts/build_package.sh
+++ b/scripts/build_package.sh
@@ -106,7 +106,7 @@ TOOLS_ROOT=${PKG_ROOT}/tools
 
 echo "Staging tools package files"
 
-bin_files=("algons" "coroner" "dispenser" "netgoal" "nodecfg" "pingpong" "cc_service" "cc_agent" "cc_client" "loadgenerator" "COPYING" "dsign")
+bin_files=("algons" "coroner" "dispenser" "netgoal" "nodecfg" "pingpong" "cc_service" "cc_agent" "cc_client" "loadgenerator" "COPYING" "dsign" "catchpointdump")
 mkdir -p ${TOOLS_ROOT}
 for bin in "${bin_files[@]}"; do
     cp ${GOPATHBIN}/${bin} ${TOOLS_ROOT}

--- a/scripts/create_and_deploy_recipe.sh
+++ b/scripts/create_and_deploy_recipe.sh
@@ -27,7 +27,8 @@ if [[ "${AWS_ACCESS_KEY_ID}" = "" || "${AWS_SECRET_ACCESS_KEY}" = "" ]]; then
 fi
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-export GOPATH=$(go env GOPATH)
+GOPATH=$(go env GOPATH)
+export GOPATH=${GOPATH%:*}
 
 # Anchor our repo root reference location
 REPO_ROOT=${SCRIPTPATH}/..


### PR DESCRIPTION
## Summary

Having `catchpointdump` in tools looks as not a bad idea in general.
In particular I need a linux build of `catchpointdump` on my Mac machine in order
to plug it into algonet linux network. The only way to make such a cross build is calling
`deploy_linux_version.sh` that builds and upload packages in a docker container.

Modified `create_and_deploy_recipe.sh` to support multicomponent `GOPATH`

## Test Plan

Tested manually and it works as expected:
1. catchpointdump is in tools package
2. Multicomponent GOPATH supported well
3. Content of tmp/go-cache is not sent into docker