### PR TITLE
catchpointdump: set genesis proto version

### DIFF
--- a/cmd/catchpointdump/commands.go
+++ b/cmd/catchpointdump/commands.go
@@ -98,7 +98,6 @@ func main() {
 	}
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/cmd/catchpointdump/file.go
+++ b/cmd/catchpointdump/file.go
@@ -33,6 +33,7 @@ import (
 	cmdutil "github.com/algorand/go-algorand/cmd/util"
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/ledger"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/logging"
@@ -69,7 +70,15 @@ var fileCmd = &cobra.Command{
 		if tarSize == 0 {
 			reportErrorf("Empty file '%s' : %v", tarFile, err)
 		}
-		genesisInitState := ledgercore.InitState{}
+		// TODO: store CurrentProtocol in catchpoint file header.
+		// As a temporary workaround use a current protocol version.
+		genesisInitState := ledgercore.InitState{
+			Block: bookkeeping.Block{BlockHeader: bookkeeping.BlockHeader{
+				UpgradeState: bookkeeping.UpgradeState{
+					CurrentProtocol: protocol.ConsensusCurrentVersion,
+				},
+			}},
+		}
 		cfg := config.GetDefaultLocal()
 		l, err := ledger.OpenLedger(logging.Base(), "./ledger", false, genesisInitState, cfg)
 		if err != nil {

--- a/cmd/catchpointdump/file.go
+++ b/cmd/catchpointdump/file.go
@@ -66,7 +66,6 @@ var fileCmd = &cobra.Command{
 			reportErrorf("Unable to stat '%s' : %v", tarFile, err)
 		}
 		tarSize := stats.Size()
-
 		if tarSize == 0 {
 			reportErrorf("Empty file '%s' : %v", tarFile, err)
 		}


### PR DESCRIPTION
## Summary

Catchpointdump does not have access to a ledger and it does not know
which consensus params is to use as genesis state on rewards calculation
that can lead to division by zero panic.

This PR sets a hardcoded value to `ConsensusCurrentVersion`.

Additionally, let `net` subcommand to return non-zero exit code
to indicate nothing was downloaded.
To do that I converted it to `cobra.RunE`-style method in order  to use
a standard cobra's error reporting and exit code setter.

## Test Plan

Tested manually