### PR TITLE
fix reviewdog linter error

### DIFF
--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -172,11 +172,11 @@ func (r ParticipationRecord) Duplicate() ParticipationRecord {
 }
 
 // OverlapsInterval returns true if the partkey is valid at all within the range of rounds (inclusive)
-func (part ParticipationRecord) OverlapsInterval(first, last basics.Round) bool {
+func (r ParticipationRecord) OverlapsInterval(first, last basics.Round) bool {
 	if last < first {
 		logging.Base().Panicf("Round interval should be ordered (first = %v, last = %v)", first, last)
 	}
-	if last < part.FirstValid || first > part.LastValid {
+	if last < r.FirstValid || first > r.LastValid {
 		return false
 	}
 	return true


### PR DESCRIPTION
## Summary

fix reviewdog linter error : rename function receiver name :
```golang
func (part ParticipationRecord) OverlapsInterval(first, last basics.Round) -> 
func (r ParticipationRecord) OverlapsInterval(first, last basics.Round)
```
## Test Plan

Use existing tests.