### PR TITLE
Few touchups for Secrets.Persist

### DIFF
--- a/crypto/merklesignature/persistentMerkleSignatureScheme.go
+++ b/crypto/merklesignature/persistentMerkleSignatureScheme.go
@@ -77,7 +77,7 @@ func (s *Secrets) Persist(store db.Accessor) error {
 
 		insertStmt, err := tx.PrepareContext(ctx, "INSERT INTO StateProofKeys (id, round, key) VALUES (?,?,?)")
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to prepare insert stateproofkeys statement: %w", err)
 		}
 		defer insertStmt.Close()
 


### PR DESCRIPTION
## Summary

Few touchups for Secrets.Persist:
- Move unneeded tests outside of the `Atomic` call.
- Improve encoding buffer alloc/release
- Call rows.Close

## Test Plan

Use existing unit tests.