### PR TITLE
faster txnMerkleToRaw implementation

### DIFF
--- a/data/bookkeeping/txn_merkle.go
+++ b/data/bookkeeping/txn_merkle.go
@@ -70,10 +70,11 @@ type txnMerkleElem struct {
 	stib transactions.SignedTxnInBlock
 }
 
-func txnMerkleToRaw(txid []byte, stib []byte) []byte {
-	buf := make([]byte, 0, 2*crypto.DigestSize)
-	buf = append(buf, txid...)
-	return append(buf, stib...)
+func txnMerkleToRaw(txid []byte, stib []byte) (buf []byte) {
+	buf = make([]byte, 2*crypto.DigestSize)
+	copy(buf[:], txid[:])
+	copy(buf[crypto.DigestSize:], stib[:])
+	return
 }
 
 // ToBeHashed implements the crypto.Hashable interface.

--- a/data/bookkeeping/txn_merkle_test.go
+++ b/data/bookkeeping/txn_merkle_test.go
@@ -142,3 +142,24 @@ func BenchmarkTxnRoots(b *testing.B) {
 
 	_ = r
 }
+
+func BenchmarkTxnMerkleToRaw(b *testing.B) {
+	digest1 := crypto.Hash([]byte{1, 2, 3})
+	digest2 := crypto.Hash([]byte{4, 5, 6})
+	txnMerkleToRawAppend := func(txid []byte, stib []byte) []byte {
+		buf := make([]byte, 0, 2*crypto.DigestSize)
+		buf = append(buf, txid...)
+		return append(buf, stib...)
+	}
+
+	b.Run("copy", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			txnMerkleToRaw(digest1[:], digest2[:])
+		}
+	})
+	b.Run("append", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			txnMerkleToRawAppend(digest1[:], digest2[:])
+		}
+	})
+}

--- a/test/e2e-go/features/transactions/proof_test.go
+++ b/test/e2e-go/features/transactions/proof_test.go
@@ -34,10 +34,11 @@ type TxnMerkleElemRaw struct {
 	Stib []byte // hash value of transactions.SignedTxnInBlock
 }
 
-func txnMerkleToRaw(txid []byte, stib []byte) []byte {
-	buf := make([]byte, 0, 2*crypto.DigestSize)
-	buf = append(buf, txid...)
-	return append(buf, stib...)
+func txnMerkleToRaw(txid []byte, stib []byte) (buf []byte) {
+	buf = make([]byte, 2*crypto.DigestSize)
+	copy(buf[:], txid[:])
+	copy(buf[crypto.DigestSize:], stib[:])
+	return
 }
 
 // ToBeHashed implements the crypto.Hashable interface.


### PR DESCRIPTION
## Summary

Implementation wasn't efficient; added benchmark to demonstrate old vs. new.

## Test Plan
Benchmark results:
```
goos: darwin
goarch: amd64
pkg: github.com/algorand/go-algorand/data/bookkeeping
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkTxnMerkleToRaw/copy-8         	250695009	         4.699 ns/op
BenchmarkTxnMerkleToRaw/append-8       	33929052	        31.42 ns/op
PASS
ok  	github.com/algorand/go-algorand/data/bookkeeping	2.981s
```

effective gains : ~x5
