### PR TITLE
fix minor regression in txnMerkleToRaw

### DIFF
--- a/data/bookkeeping/txn_merkle.go
+++ b/data/bookkeeping/txn_merkle.go
@@ -70,7 +70,7 @@ type txnMerkleElem struct {
 	stib transactions.SignedTxnInBlock
 }
 
-func txnMerkleToRaw(txid []byte, stib []byte) (buf []byte) {
+func txnMerkleToRaw(txid [crypto.DigestSize]byte, stib [crypto.DigestSize]byte) (buf []byte) {
 	buf = make([]byte, 2*crypto.DigestSize)
 	copy(buf[:], txid[:])
 	copy(buf[crypto.DigestSize:], stib[:])
@@ -84,7 +84,7 @@ func (tme *txnMerkleElem) ToBeHashed() (protocol.HashID, []byte) {
 	txid := tme.txn.ID()
 	stib := tme.stib.Hash()
 
-	return protocol.TxnMerkleLeaf, txnMerkleToRaw(txid[:], stib[:])
+	return protocol.TxnMerkleLeaf, txnMerkleToRaw(txid, stib)
 }
 
 // Hash implements an optimized version of crypto.HashObj(tme).
@@ -99,6 +99,6 @@ func (tme *txnMerkleElem) HashRepresentation() []byte {
 	var buf [len(protocol.TxnMerkleLeaf) + 2*crypto.DigestSize]byte
 	s := buf[:0]
 	s = append(s, protocol.TxnMerkleLeaf...)
-	s = append(s, txnMerkleToRaw(txid[:], stib[:])...)
+	s = append(s, txnMerkleToRaw(txid, stib)...)
 	return s
 }

--- a/data/bookkeeping/txn_merkle_test.go
+++ b/data/bookkeeping/txn_merkle_test.go
@@ -143,23 +143,23 @@ func BenchmarkTxnRoots(b *testing.B) {
 	_ = r
 }
 
+func txnMerkleToRawAppend(txid [crypto.DigestSize]byte, stib [crypto.DigestSize]byte) []byte {
+	buf := make([]byte, 0, 2*crypto.DigestSize)
+	buf = append(buf, txid[:]...)
+	return append(buf, stib[:]...)
+}
 func BenchmarkTxnMerkleToRaw(b *testing.B) {
 	digest1 := crypto.Hash([]byte{1, 2, 3})
 	digest2 := crypto.Hash([]byte{4, 5, 6})
-	txnMerkleToRawAppend := func(txid []byte, stib []byte) []byte {
-		buf := make([]byte, 0, 2*crypto.DigestSize)
-		buf = append(buf, txid...)
-		return append(buf, stib...)
-	}
 
 	b.Run("copy", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			txnMerkleToRaw(digest1[:], digest2[:])
+			txnMerkleToRaw(digest1, digest2)
 		}
 	})
 	b.Run("append", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			txnMerkleToRawAppend(digest1[:], digest2[:])
+			txnMerkleToRawAppend(digest1, digest2)
 		}
 	})
 }

--- a/test/e2e-go/features/transactions/proof_test.go
+++ b/test/e2e-go/features/transactions/proof_test.go
@@ -30,8 +30,8 @@ import (
 
 // TxnMerkleElemRaw this struct helps creates a hashable struct from the bytes
 type TxnMerkleElemRaw struct {
-	Txn  []byte // txn id
-	Stib []byte // hash value of transactions.SignedTxnInBlock
+	Txn  crypto.Digest // txn id
+	Stib crypto.Digest // hash value of transactions.SignedTxnInBlock
 }
 
 func txnMerkleToRaw(txid [crypto.DigestSize]byte, stib [crypto.DigestSize]byte) (buf []byte) {
@@ -121,7 +121,8 @@ func TestTxnMerkleProof(t *testing.T) {
 	blk, err := client.BookkeepingBlock(confirmedTx.ConfirmedRound)
 	a.NoError(err)
 
-	element := TxnMerkleElemRaw{Txn: txid[:], Stib: proofresp.Stibhash}
+	element := TxnMerkleElemRaw{Txn: crypto.Digest(txid)}
+	copy(element.Stib[:], proofresp.Stibhash[:])
 
 	elems := make(map[uint64]crypto.Hashable)
 

--- a/test/e2e-go/features/transactions/proof_test.go
+++ b/test/e2e-go/features/transactions/proof_test.go
@@ -34,7 +34,7 @@ type TxnMerkleElemRaw struct {
 	Stib []byte // hash value of transactions.SignedTxnInBlock
 }
 
-func txnMerkleToRaw(txid []byte, stib []byte) (buf []byte) {
+func txnMerkleToRaw(txid [crypto.DigestSize]byte, stib [crypto.DigestSize]byte) (buf []byte) {
 	buf = make([]byte, 2*crypto.DigestSize)
 	copy(buf[:], txid[:])
 	copy(buf[crypto.DigestSize:], stib[:])


### PR DESCRIPTION
## Summary

My previous PR was causing a minor regression. Thanks to @jannotti comment, I think that I was able to fix the regression, and added a proper testing for that.

## Test Plan

New benchmark result ( no inner method anymore )
```
goos: darwin
goarch: amd64
pkg: github.com/algorand/go-algorand/data/bookkeeping
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkTxnMerkleToRaw/copy-8         	1000000000	         1.129 ns/op	       0 B/op	       0 allocs/op
BenchmarkTxnMerkleToRaw/append-8       	243079730	         4.886 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/algorand/go-algorand/data/bookkeeping	3.183s
```