### PR TITLE
add unit test to verify merkle array root size 

### DIFF
--- a/crypto/merklesignature/merkleSignatureScheme.go
+++ b/crypto/merklesignature/merkleSignatureScheme.go
@@ -143,10 +143,9 @@ func (s *Secrets) GetVerifier() *Verifier {
 
 // GetVerifier can be used to store the commitment and verifier for this signer.
 func (s *SignerContext) GetVerifier() *Verifier {
-	ver := [MerkleSignatureSchemeRootSize]byte{}
-	ss := s.Tree.Root().ToSlice()
-	copy(ver[:], ss)
-	return (*Verifier)(&ver)
+	var ver Verifier
+	copy(ver[:], s.Tree.Root())
+	return &ver
 }
 
 // Sign signs a hash of a given message. The signature is valid on a specific round

--- a/crypto/merklesignature/merkleSignatureScheme_test.go
+++ b/crypto/merklesignature/merkleSignatureScheme_test.go
@@ -498,3 +498,20 @@ func copyProof(proof merklearray.SingleLeafProof) merklearray.SingleLeafProof {
 }
 
 //#endregion
+
+func TestTreeRootHashLength(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+	interval := uint64(256)
+	numOfKeys := uint64(1 << 8)
+	validPeriod := numOfKeys*interval - 1
+
+	firstValid := uint64(1000)
+	lastValid := validPeriod + 1000
+	s, err := New(firstValid, lastValid, interval)
+	a.NoError(err)
+	a.Equal(numOfKeys, uint64(len(s.ephemeralKeys)))
+
+	a.Equal(MerkleSignatureSchemeRootSize, len(s.Tree.Root()))
+	a.Equal(MerkleSignatureSchemeRootSize, len(Verifier{}))
+}

--- a/libgoal/participation.go
+++ b/libgoal/participation.go
@@ -157,7 +157,11 @@ func (c *Client) GenParticipationKeysTo(address string, firstValid, lastValid, k
 	}
 	_, err = os.Stat(partKeyPath)
 	if !os.IsNotExist(err) {
-		err = fmt.Errorf("ParticipationKeys exist for the range %d to %d", firstRound, lastRound)
+		if err != nil {
+			err = fmt.Errorf("participation key file '%s' cannot be accessed : %w", partKeyPath, err)
+		} else {
+			err = fmt.Errorf("ParticipationKeys exist for the range %d to %d", firstRound, lastRound)
+		}
 		return
 	}
 


### PR DESCRIPTION
## Summary

Instead of performing a check in `SignerContext.GetVerifier`, I've added a unit test to verify that the output of the merklearray root has the same length as the Verifier object.

## Test Plan

Unit test.