### PR TITLE
revert golang1.16 arm32 changes

### DIFF
--- a/docker/build/cicd.ubuntu.Dockerfile
+++ b/docker/build/cicd.ubuntu.Dockerfile
@@ -3,12 +3,11 @@ ARG ARCH="amd64"
 FROM ${ARCH}/ubuntu:18.04
 ARG GOLANG_VERSION
 ARG ARCH="amd64"
-ARG GOARCH="amd64"
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y build-essential git libboost-all-dev wget sqlite3 autoconf jq bsdmainutils shellcheck awscli
 WORKDIR /root
-RUN wget https://dl.google.com/go/go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz \
-    && tar -xvf go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz && \
+RUN wget https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH%v*}.tar.gz \
+    && tar -xvf go${GOLANG_VERSION}.linux-${ARCH%v*}.tar.gz && \
     mv go /usr/local
 ENV GOROOT=/usr/local/go \
     GOPATH=$HOME/go \

--- a/test/muleCI/mule.yaml
+++ b/test/muleCI/mule.yaml
@@ -13,7 +13,6 @@ agents:
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
       - ARCH=amd64
-      - GOARCH=amd64
   - name: cicd.centos.amd64
     dockerFilePath: docker/build/cicd.centos.Dockerfile
     image: algorand/go-algorand-ci-linux-centos
@@ -42,12 +41,11 @@ agents:
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
       - ARCH=arm64v8
-      - GOARCH=arm64
-  - name: cicd.ubuntu.arm
-    dockerFilePath: docker/build/cicd.ubuntu.Dockerfile
+  - name: cicd.alpine.arm
+    dockerFilePath: docker/build/cicd.alpine.Dockerfile
     image: algorand/go-algorand-ci-linux
     version: scripts/configure_dev-deps.sh
-    arch: arm32v7
+    arch: arm32v6
     env:
       - TRAVIS_BRANCH=${GIT_BRANCH}
       - NETWORK=$NETWORK
@@ -56,8 +54,7 @@ agents:
       - GOHOSTARCH=arm
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
-      - ARCH=arm32v7
-      - GOARCH=armv6l
+      - ARCH=arm32v6
   - name: docker-ubuntu
     dockerFilePath: docker/build/docker.ubuntu.Dockerfile
     image: algorand/go-algorand-docker-linux-ubuntu
@@ -99,7 +96,7 @@ tasks:
     target: ci-build
   - task: docker.Make
     name: build.arm
-    agent: cicd.ubuntu.arm
+    agent: cicd.alpine.arm
     target: ci-build
 
   - task: docker.Make
@@ -208,7 +205,7 @@ jobs:
   build-linux-arm32:
     tasks:
       - docker.Make.build.arm
-      - stash.Stash.linux-arm
+      # - stash.Stash.linux-arm
   package-linux-amd64:
     tasks:
       - stash.Unstash.linux-amd64

--- a/test/muleCI/mule.yaml
+++ b/test/muleCI/mule.yaml
@@ -205,7 +205,7 @@ jobs:
   build-linux-arm32:
     tasks:
       - docker.Make.build.arm
-      # - stash.Stash.linux-arm
+      - stash.Stash.linux-arm
   package-linux-amd64:
     tasks:
       - stash.Unstash.linux-amd64


### PR DESCRIPTION
## Summary

Reverts changes made in arm32 build to support golang1.16. 

## Test Plan

Tested it locally.
