### PR TITLE
add a fallback for missing state proof keys in participation file

### DIFF
--- a/crypto/merklesignature/persistentMerkleSignatureScheme.go
+++ b/crypto/merklesignature/persistentMerkleSignatureScheme.go
@@ -41,7 +41,8 @@ var (
 	errKeyDecodeError  = errors.New("failed to decode stateproof key")
 )
 
-func MerkleSignatureInstallDatabase(tx *sql.Tx) error {
+// InstallDatabase creates (or migrates if exists already) the StateProofKeys database table
+func InstallDatabase(tx *sql.Tx) error {
 	var schemaVersion sql.NullInt32
 	err := tx.QueryRow("SELECT version FROM schema where tablename = ?", merkleSignatureTableSchemaName).Scan(&schemaVersion)
 	switch err {
@@ -99,7 +100,7 @@ func (s *Secrets) Persist(store db.Accessor) error {
 	round := indexToRound(s.FirstValid, s.Interval, 0)
 	encodedKey := protocol.GetEncodingBuf()
 	err := store.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		err := MerkleSignatureInstallDatabase(tx) // assumes schema table already exists (created by partInstallDatabase)
+		err := InstallDatabase(tx) // assumes schema table already exists (created by partInstallDatabase)
 		if err != nil {
 			return err
 		}

--- a/crypto/merklesignature/persistentMerkleSignatureScheme.go
+++ b/crypto/merklesignature/persistentMerkleSignatureScheme.go
@@ -41,8 +41,8 @@ var (
 	errKeyDecodeError  = errors.New("failed to decode stateproof key")
 )
 
-// InstallDatabase creates (or migrates if exists already) the StateProofKeys database table
-func InstallDatabase(tx *sql.Tx) error {
+// InstallStateProofTable creates (or migrates if exists already) the StateProofKeys database table
+func InstallStateProofTable(tx *sql.Tx) error {
 	var schemaVersion sql.NullInt32
 	err := tx.QueryRow("SELECT version FROM schema where tablename = ?", merkleSignatureTableSchemaName).Scan(&schemaVersion)
 	switch err {
@@ -100,7 +100,7 @@ func (s *Secrets) Persist(store db.Accessor) error {
 	round := indexToRound(s.FirstValid, s.Interval, 0)
 	encodedKey := protocol.GetEncodingBuf()
 	err := store.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		err := InstallDatabase(tx) // assumes schema table already exists (created by partInstallDatabase)
+		err := InstallStateProofTable(tx) // assumes schema table already exists (created by partInstallDatabase)
 		if err != nil {
 			return err
 		}

--- a/crypto/merklesignature/persistentMerkleSignatureScheme.go
+++ b/crypto/merklesignature/persistentMerkleSignatureScheme.go
@@ -41,7 +41,7 @@ var (
 	errKeyDecodeError  = errors.New("failed to decode stateproof key")
 )
 
-func merkleSignatureInstallDatabase(tx *sql.Tx) error {
+func MerkleSignatureInstallDatabase(tx *sql.Tx) error {
 	var schemaVersion sql.NullInt32
 	err := tx.QueryRow("SELECT version FROM schema where tablename = ?", merkleSignatureTableSchemaName).Scan(&schemaVersion)
 	switch err {
@@ -99,7 +99,7 @@ func (s *Secrets) Persist(store db.Accessor) error {
 	round := indexToRound(s.FirstValid, s.Interval, 0)
 	encodedKey := protocol.GetEncodingBuf()
 	err := store.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		err := merkleSignatureInstallDatabase(tx) // assumes schema table already exists (created by partInstallDatabase)
+		err := MerkleSignatureInstallDatabase(tx) // assumes schema table already exists (created by partInstallDatabase)
 		if err != nil {
 			return err
 		}

--- a/crypto/merklesignature/persistentMerkleSignatureScheme_test.go
+++ b/crypto/merklesignature/persistentMerkleSignatureScheme_test.go
@@ -48,7 +48,7 @@ func TestSecretsDatabaseUpgrade(t *testing.T) {
 	a.NoError(err)
 
 	err = store.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		err := InstallDatabase(tx) // assumes schema table already exists (created by partInstallDatabase)
+		err := InstallStateProofTable(tx) // assumes schema table already exists (created by partInstallDatabase)
 		if err != nil {
 			return err
 		}
@@ -56,6 +56,9 @@ func TestSecretsDatabaseUpgrade(t *testing.T) {
 	})
 
 	a.NoError(err)
+	version, err := getStateProofTableSchemaVersions(*store)
+	a.NoError(err)
+	a.Equal(merkleSignatureSchemaVersion, version)
 }
 
 func TestFetchRestoreAllSecrets(t *testing.T) {
@@ -113,4 +116,20 @@ func createTestDB(a *require.Assertions) *db.Accessor {
 	a.NoError(err)
 
 	return &store
+}
+
+func getStateProofTableSchemaVersions(db db.Accessor) (int, error) {
+	var version int
+	err := db.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
+		row := tx.QueryRow("SELECT version FROM schema where tablename = ?", merkleSignatureTableSchemaName)
+
+		err = row.Scan(&version)
+		if err != nil {
+			return
+		}
+
+		return
+	})
+
+	return version, err
 }

--- a/crypto/merklesignature/persistentMerkleSignatureScheme_test.go
+++ b/crypto/merklesignature/persistentMerkleSignatureScheme_test.go
@@ -48,7 +48,7 @@ func TestSecretsDatabaseUpgrade(t *testing.T) {
 	a.NoError(err)
 
 	err = store.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		err := merkleSignatureInstallDatabase(tx) // assumes schema table already exists (created by partInstallDatabase)
+		err := MerkleSignatureInstallDatabase(tx) // assumes schema table already exists (created by partInstallDatabase)
 		if err != nil {
 			return err
 		}

--- a/crypto/merklesignature/persistentMerkleSignatureScheme_test.go
+++ b/crypto/merklesignature/persistentMerkleSignatureScheme_test.go
@@ -48,7 +48,7 @@ func TestSecretsDatabaseUpgrade(t *testing.T) {
 	a.NoError(err)
 
 	err = store.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		err := MerkleSignatureInstallDatabase(tx) // assumes schema table already exists (created by partInstallDatabase)
+		err := InstallDatabase(tx) // assumes schema table already exists (created by partInstallDatabase)
 		if err != nil {
 			return err
 		}

--- a/crypto/merklesignature/persistentMerkleSignatureScheme_test.go
+++ b/crypto/merklesignature/persistentMerkleSignatureScheme_test.go
@@ -122,14 +122,13 @@ func getStateProofTableSchemaVersions(db db.Accessor) (int, error) {
 	var version int
 	err := db.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
 		row := tx.QueryRow("SELECT version FROM schema where tablename = ?", merkleSignatureTableSchemaName)
-
-		err = row.Scan(&version)
-		if err != nil {
-			return
-		}
-
-		return
+		return row.Scan(&version)
 	})
-
-	return version, err
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return version, nil
 }

--- a/data/account/account.go
+++ b/data/account/account.go
@@ -196,10 +196,14 @@ func RestoreParticipation(store db.Accessor) (acc PersistedParticipation, err er
 
 // RestoreParticipationWithSecrets restores a Participation from a database
 // handle. In addition, this function also restores all stateproof secrets
-func RestoreParticipationWithSecrets(store db.Accessor) (acc PersistedParticipation, err error) {
+func RestoreParticipationWithSecrets(store db.Accessor) (PersistedParticipation, error) {
 	persistedParticipation, err := RestoreParticipation(store)
 	if err != nil {
 		return PersistedParticipation{}, err
+	}
+
+	if persistedParticipation.StateProofSecrets == nil { // no state proof keys to restore
+		return persistedParticipation, nil
 	}
 
 	err = persistedParticipation.StateProofSecrets.RestoreAllSecrets(store)

--- a/data/account/participation.go
+++ b/data/account/participation.go
@@ -303,7 +303,12 @@ func (part PersistedParticipation) Persist() error {
 // Calls through to the migration helper and returns the result.
 func Migrate(partDB db.Accessor) error {
 	return partDB.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		return partMigrate(tx)
+		err := partMigrate(tx)
+		if err != nil {
+			return err
+		}
+
+		return merklesignature.MerkleSignatureInstallDatabase(tx)
 	})
 }
 

--- a/data/account/participation.go
+++ b/data/account/participation.go
@@ -48,7 +48,7 @@ type Participation struct {
 
 	VRF    *crypto.VRFSecrets
 	Voting *crypto.OneTimeSignatureSecrets
-	// StateProofSecrets is used to sign compact certificates. might be nil
+	// StateProofSecrets is used to sign compact certificates. MIGHT BE NIL!
 	StateProofSecrets *merklesignature.Secrets
 
 	// The first and last rounds for which this account is valid, respectively.

--- a/data/account/participation.go
+++ b/data/account/participation.go
@@ -48,7 +48,7 @@ type Participation struct {
 
 	VRF    *crypto.VRFSecrets
 	Voting *crypto.OneTimeSignatureSecrets
-	// StateProofSecrets is used to sign compact certificates. MIGHT BE NIL!
+	// StateProofSecrets is used to sign compact certificates.
 	StateProofSecrets *merklesignature.Secrets
 
 	// The first and last rounds for which this account is valid, respectively.

--- a/data/account/participation.go
+++ b/data/account/participation.go
@@ -308,7 +308,7 @@ func Migrate(partDB db.Accessor) error {
 			return err
 		}
 
-		return merklesignature.MerkleSignatureInstallDatabase(tx)
+		return merklesignature.InstallDatabase(tx)
 	})
 }
 

--- a/data/account/participation.go
+++ b/data/account/participation.go
@@ -308,7 +308,7 @@ func Migrate(partDB db.Accessor) error {
 			return err
 		}
 
-		return merklesignature.InstallDatabase(tx)
+		return merklesignature.InstallStateProofTable(tx)
 	})
 }
 

--- a/data/account/participation_test.go
+++ b/data/account/participation_test.go
@@ -205,9 +205,15 @@ func TestRetrieveFromDBAtVersion1(t *testing.T) {
 	retrivedPart, err := RestoreParticipation(partDB)
 	a.NoError(err)
 	assertionForRestoringFromDBAtLowVersion(a, retrivedPart)
+	assertStateProofTablesExists(a, partDB)
+
+	retrivedPart, err = RestoreParticipationWithSecrets(partDB)
+	a.NoError(err)
+	assertionForRestoringFromDBAtLowVersion(a, retrivedPart)
+	assertStateProofTablesExists(a, partDB)
 }
 
-func TestRetriveFromDBAtVersion2(t *testing.T) {
+func TestRetrieveFromDBAtVersion2(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	a := require.New(t)
@@ -222,6 +228,18 @@ func TestRetriveFromDBAtVersion2(t *testing.T) {
 	retrivedPart, err := RestoreParticipation(partDB)
 	a.NoError(err)
 	assertionForRestoringFromDBAtLowVersion(a, retrivedPart)
+	assertStateProofTablesExists(a, partDB)
+	versions, err := getSchemaVersions(partDB)
+	a.NoError(err)
+	a.Equal(versions[PartTableSchemaName], PartTableSchemaVersion)
+
+	retrivedPart, err = RestoreParticipationWithSecrets(partDB)
+	a.NoError(err)
+	assertionForRestoringFromDBAtLowVersion(a, retrivedPart)
+	assertStateProofTablesExists(a, partDB)
+	versions, err = getSchemaVersions(partDB)
+	a.NoError(err)
+	a.Equal(versions[PartTableSchemaName], PartTableSchemaVersion)
 }
 
 func TestKeyRegCreation(t *testing.T) {
@@ -244,6 +262,14 @@ func closeDBS(dbAccessor ...db.Accessor) {
 	}
 }
 
+func assertStateProofTablesExists(a *require.Assertions, store db.Accessor) {
+	err := store.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.Exec("select count(*) From StateProofKeys;")
+		return err
+	})
+	a.NoError(err)
+
+}
 func assertionForRestoringFromDBAtLowVersion(a *require.Assertions, retrivedPart PersistedParticipation) {
 	a.NotNil(retrivedPart)
 	a.Nil(retrivedPart.StateProofSecrets)

--- a/node/node.go
+++ b/node/node.go
@@ -1006,6 +1006,10 @@ func (node *AlgorandFullNode) loadParticipationKeys() error {
 
 func insertStateProofToRegistry(part account.PersistedParticipation, node *AlgorandFullNode) error {
 	partID := part.ID()
+	// in case there are no state proof keys for that participant
+	if part.StateProofSecrets == nil {
+		return nil
+	}
 	keys := part.StateProofSecrets.GetAllKeys()
 	keysSinger := make(account.StateProofKeys, len(keys))
 	for i := uint64(0); i < uint64(len(keys)); i++ {

--- a/test/e2e-go/upgrades/stateproof_test.go
+++ b/test/e2e-go/upgrades/stateproof_test.go
@@ -85,11 +85,9 @@ func TestKeysWithoutStateProofKeyCanRegister(t *testing.T) {
 	defer fixtures.ShutdownSynchronizedTest(t)
 
 	a := require.New(fixtures.SynchronizedTest(t))
-	consensus := getStateProofConsensus()
 
 	var fixture fixtures.RestClientFixture
-	fixture.SetConsensus(consensus)
-	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodesWithoutStateProofPartkeys.json"))
+	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50EachV30.json"))
 	defer fixture.Shutdown()
 	lastValid := uint64(1000 * 5)
 


### PR DESCRIPTION
## Summary
Restoring participation has failed in the nightly build, since it was trying to query for StateProofKeys table which doesn't exist yet.

Made sure to call the migration in the correct places to fix this issue.

## Test Plan

Unit tests added.