### PR TITLE
Participation key tests

### DIFF
--- a/test/e2e-go/features/participation/participationExpiration_test.go
+++ b/test/e2e-go/features/participation/participationExpiration_test.go
@@ -145,6 +145,10 @@ func testExpirationAccounts(t *testing.T, fixture *fixtures.RestClientFixture, f
 
 	_, richAccountLatestRound = fixture.GetBalanceAndRound(richAccount)
 
+	// making certain sClient has the same blocks as pClient.
+	_, err = sClient.WaitForRound(richAccountLatestRound)
+	a.NoError(err)
+
 	blk, err := sClient.Block(richAccountLatestRound)
 	a.NoError(err)
 	a.Equal(blk.CurrentProtocol, protocolCheck)

--- a/test/e2e-go/features/participation/participationExpiration_test.go
+++ b/test/e2e-go/features/participation/participationExpiration_test.go
@@ -46,9 +46,9 @@ func testExpirationAccounts(t *testing.T, fixture *fixtures.RestClientFixture, f
 	accountList, err := fixture.GetWalletsSortedByBalance()
 	a.NoError(err)
 	richAccount := accountList[0].Address
-	_, initialRound := fixture.GetBalanceAndRound(richAccount)
+	_, richAccountLatestRound := fixture.GetBalanceAndRound(richAccount)
 
-	minTxnFee, minAcctBalance, err := fixture.MinFeeAndBalance(initialRound)
+	minTxnFee, minAcctBalance, err := fixture.MinFeeAndBalance(richAccountLatestRound)
 	a.NoError(err)
 
 	transactionFee := minTxnFee
@@ -57,7 +57,7 @@ func testExpirationAccounts(t *testing.T, fixture *fixtures.RestClientFixture, f
 	initialAmt, err := sClient.GetBalance(sAccount)
 	a.NoError(err)
 
-	fixture.SendMoneyAndWait(initialRound, amountToSendInitial, transactionFee, richAccount, sAccount, "")
+	fixture.SendMoneyAndWait(richAccountLatestRound, amountToSendInitial, transactionFee, richAccount, sAccount, "")
 
 	newAmt, err := sClient.GetBalance(sAccount)
 	a.NoError(err)
@@ -143,15 +143,15 @@ func testExpirationAccounts(t *testing.T, fixture *fixtures.RestClientFixture, f
 	// Now we want to send a transaction to the account and test that
 	// it was taken offline after we sent it something
 
-	_, initialRound = fixture.GetBalanceAndRound(richAccount)
+	_, richAccountLatestRound = fixture.GetBalanceAndRound(richAccount)
 
-	blk, err := sClient.Block(initialRound)
+	blk, err := sClient.Block(richAccountLatestRound)
 	a.NoError(err)
 	a.Equal(blk.CurrentProtocol, protocolCheck)
 
-	sendMoneyTxn := fixture.SendMoneyAndWait(initialRound, amountToSendInitial, transactionFee, richAccount, sAccount, "")
+	sendMoneyTxn := fixture.SendMoneyAndWait(richAccountLatestRound, amountToSendInitial, transactionFee, richAccount, sAccount, "")
 
-	txnConfirmed = fixture.WaitForTxnConfirmation(initialRound+maxRoundsToWaitForTxnConfirm, sAccount, sendMoneyTxn.TxID)
+	txnConfirmed = fixture.WaitForTxnConfirmation(richAccountLatestRound+maxRoundsToWaitForTxnConfirm, sAccount, sendMoneyTxn.TxID)
 	a.True(txnConfirmed)
 
 	newAccountStatus, err = pClient.AccountInformation(sAccount)


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
I've encountered an issue with the participation keys expiration test, which might cause flakiness. 

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan
I've managed to reproduce the same error as shown in 
https://app.circleci.com/pipelines/github/algorand/go-algorand/5013/workflows/8c1f10b2-c827-4c0a-81a3-cfe18ec0c794/jobs/78980
By halting the secondary prior to the request of sclient for the round the rich client has.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
