### PR TITLE
testing: fix bug in TestAssetGroupCreateSendDestroy

### DIFF
--- a/test/e2e-go/features/transactions/asset_test.go
+++ b/test/e2e-go/features/transactions/asset_test.go
@@ -632,9 +632,18 @@ func TestAssetGroupCreateSendDestroy(t *testing.T) {
 	err = client0.BroadcastTransactionGroup(stxns)
 	a.NoError(err)
 
-	_, curRound := fixture.GetBalanceAndRound(account0)
-	confirmed := fixture.WaitForAllTxnsToConfirm(curRound+5, txids)
+	status0, err := fixture.LibGoalClient.Status()
+	a.NoError(err)
+
+	confirmed := fixture.WaitForAllTxnsToConfirm(status0.LastRound+5, txids)
 	a.True(confirmed)
+
+	status0, err = fixture.LibGoalClient.Status()
+	a.NoError(err)
+
+	// wait for client1 to reach the same round as client0
+	_, err = client1.WaitForRound(status0.LastRound)
+	a.NoError(err)
 
 	txids = make(map[string]string)
 
@@ -651,9 +660,17 @@ func TestAssetGroupCreateSendDestroy(t *testing.T) {
 	a.NoError(err)
 	txids[txid] = account0
 
-	_, curRound = fixture.GetBalanceAndRound(account0)
-	confirmed = fixture.WaitForAllTxnsToConfirm(curRound+5, txids)
+	status0, err = fixture.LibGoalClient.Status()
+	a.NoError(err)
+	confirmed = fixture.WaitForAllTxnsToConfirm(status0.LastRound+5, txids)
 	a.True(confirmed)
+
+	status0, err = fixture.LibGoalClient.Status()
+	a.NoError(err)
+
+	// wait for client1 to reach the same round as client0
+	_, err = client1.WaitForRound(status0.LastRound)
+	a.NoError(err)
 
 	// asset 3 (create + destroy) not available
 	_, err = client1.AssetInformation(assetID3)

--- a/test/e2e-go/features/transactions/asset_test.go
+++ b/test/e2e-go/features/transactions/asset_test.go
@@ -632,13 +632,13 @@ func TestAssetGroupCreateSendDestroy(t *testing.T) {
 	err = client0.BroadcastTransactionGroup(stxns)
 	a.NoError(err)
 
-	status0, err := fixture.LibGoalClient.Status()
+	status0, err := client0.Status()
 	a.NoError(err)
 
 	confirmed := fixture.WaitForAllTxnsToConfirm(status0.LastRound+5, txids)
 	a.True(confirmed)
 
-	status0, err = fixture.LibGoalClient.Status()
+	status0, err = client0.Status()
 	a.NoError(err)
 
 	// wait for client1 to reach the same round as client0
@@ -660,12 +660,12 @@ func TestAssetGroupCreateSendDestroy(t *testing.T) {
 	a.NoError(err)
 	txids[txid] = account0
 
-	status0, err = fixture.LibGoalClient.Status()
+	status0, err = client0.Status()
 	a.NoError(err)
 	confirmed = fixture.WaitForAllTxnsToConfirm(status0.LastRound+5, txids)
 	a.True(confirmed)
 
-	status0, err = fixture.LibGoalClient.Status()
+	status0, err = client0.Status()
 	a.NoError(err)
 
 	// wait for client1 to reach the same round as client0


### PR DESCRIPTION
## Summary

Fix a bug in TestAssetGroupCreateSendDestroy. The test uses two nodes, sending transaction to one and checking the state on the other. Before checking, the test need to verify that both nodes successfully reached the same round number.

## Test Plan

This is a test.