### PR TITLE
API: Fix prove bug on API

### DIFF
--- a/crypto/merklearray/proof.go
+++ b/crypto/merklearray/proof.go
@@ -84,13 +84,15 @@ func (p *SingleLeafProof) ToProof() *Proof {
 }
 
 // GetConcatenatedProof concats the verification path to a single slice
-// This function converts an empty element (i.e has missing child)
-// into a sequence of 0s [0...0]
+// This function converts an empty element in the path (i.e occurs when the tree is not a full tree)
+// into a sequence of digest result of zero.
 func (p *SingleLeafProof) GetConcatenatedProof() []byte {
 	digestSize := p.HashFactory.NewHash().Size()
 	proofconcat := make([]byte, digestSize*int(p.TreeDepth))
 	for i := 0; i < int(p.TreeDepth); i++ {
-		copy(proofconcat[i*digestSize:(i+1)*digestSize], p.Path[i])
+		if p.Path[i] != nil {
+			copy(proofconcat[i*digestSize:(i+1)*digestSize], p.Path[i])
+		}
 	}
 	return proofconcat
 }

--- a/crypto/merklearray/proof.go
+++ b/crypto/merklearray/proof.go
@@ -82,3 +82,15 @@ func (p *SingleLeafProof) GetFixedLengthHashableRepresentation() []byte {
 func (p *SingleLeafProof) ToProof() *Proof {
 	return &p.Proof
 }
+
+// GetConcatenatedProof concats the verification path to a single slice
+// This function converts an empty element (i.e has missing child)
+// into a sequence of 0s [0...0]
+func (p *SingleLeafProof) GetConcatenatedProof() []byte {
+	digestSize := p.HashFactory.NewHash().Size()
+	proofconcat := make([]byte, digestSize*int(p.TreeDepth))
+	for i := 0; i < int(p.TreeDepth); i++ {
+		copy(proofconcat[i*digestSize:(i+1)*digestSize], p.Path[i])
+	}
+	return proofconcat
+}

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -388,20 +388,15 @@ func (v2 *Handlers) GetProof(ctx echo.Context, round uint64, txid string, params
 				return internalError(ctx, err, "building Merkle tree", v2.Log)
 			}
 
-			proof, err := tree.Prove([]uint64{uint64(idx)})
+			proof, err := tree.ProveSingleLeaf(uint64(idx))
 			if err != nil {
 				return internalError(ctx, err, "generating proof", v2.Log)
-			}
-
-			proofconcat := make([]byte, 0)
-			for _, proofelem := range proof.Path {
-				proofconcat = append(proofconcat, proofelem[:]...)
 			}
 
 			stibhash := block.Payset[idx].Hash()
 
 			response := generated.ProofResponse{
-				Proof:     proofconcat,
+				Proof:     proof.GetConcatenatedProof(),
 				Stibhash:  stibhash[:],
 				Idx:       uint64(idx),
 				Treedepth: uint64(proof.TreeDepth),

--- a/test/e2e-go/features/transactions/proof_test.go
+++ b/test/e2e-go/features/transactions/proof_test.go
@@ -50,6 +50,7 @@ func TestTxnMerkleProof(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	defer fixtures.ShutdownSynchronizedTest(t)
 
+	t.Parallel()
 	a := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture

--- a/test/e2e-go/features/transactions/proof_test.go
+++ b/test/e2e-go/features/transactions/proof_test.go
@@ -78,7 +78,7 @@ func TestTxnMerkleProof(t *testing.T) {
 	// Transfer some money to acct0, as well as other random accounts to
 	// fill up the Merkle tree with more than one element.
 	// we do not want to have a full tree in order the catch an empty element edge case
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 5; i++ {
 		accti, err := client.GenerateAddress(walletHandle)
 		a.NoError(err)
 
@@ -92,14 +92,6 @@ func TestTxnMerkleProof(t *testing.T) {
 	txid := tx.ID()
 	confirmedTx, err := fixture.WaitForConfirmedTxn(status.LastRound+10, baseAcct, txid.String())
 	a.NoError(err)
-
-	for i := 0; i < 4; i++ {
-		accti, err := client.GenerateAddress(walletHandle)
-		a.NoError(err)
-
-		_, err = client.SendPaymentFromUnencryptedWallet(baseAcct, accti, 1000, 10000000, nil)
-		a.NoError(err)
-	}
 
 	proofresp, err := client.TxnProof(txid.String(), confirmedTx.ConfirmedRound)
 	a.NoError(err)


### PR DESCRIPTION
## Summary

This PR fixes a bug on algod's API. When a tree contains a missing child (not a full tree), the api handler omits this from the proof response and leads to a root mismatch 

## Test Plan
Add unit tests as well as convert the e2e to test this edge case.

