### PR TITLE
DevOps: Fix bandwidth testing

### DIFF
--- a/test/testdata/deployednettemplates/recipes/custom/configs/node.json
+++ b/test/testdata/deployednettemplates/recipes/custom/configs/node.json
@@ -10,6 +10,8 @@
     "ConfigJSONOverride": "{ \"TxPoolExponentialIncreaseFactor\": 1, \"DNSBootstrapID\": \"<network>.algodev.network\", \"DeadlockDetection\": -1, \"PeerPingPeriodSeconds\": 30, \"BaseLoggerDebugLevel\": 4, \"EnableProfiler\": true, \"CadaverSizeTarget\": 0 }",
     "AltConfigs": [
         {
+            "NetAddress": "{{NetworkPort}}",
+            "APIEndpoint": "{{APIEndpoint}}",
             "APIToken": "{{APIToken}}",
             "EnableBlockStats": true,
             "EnableTelemetry": true,

--- a/test/testdata/deployednettemplates/recipes/custom/configs/node.json
+++ b/test/testdata/deployednettemplates/recipes/custom/configs/node.json
@@ -1,4 +1,6 @@
 {
+    "NetAddress": "{{NetworkPort}}",
+    "APIEndpoint": "{{APIEndpoint}}",
     "APIToken": "{{APIToken}}",
     "EnableBlockStats": false,
     "EnableTelemetry": false,

--- a/test/testdata/deployednettemplates/recipes/custom/configs/nonPartNode.json
+++ b/test/testdata/deployednettemplates/recipes/custom/configs/nonPartNode.json
@@ -1,4 +1,5 @@
 {
+    "NetAddress": "{{NetworkPort}}",
     "APIEndpoint": "{{APIEndpoint}}",
     "APIToken": "{{APIToken}}",
     "ConfigJSONOverride": "{ \"TxPoolExponentialIncreaseFactor\": 1, \"DNSBootstrapID\": \"<network>.algodev.network\", \"DeadlockDetection\": -1, \"BaseLoggerDebugLevel\": 4, \"CadaverSizeTarget\": 0  }"

--- a/test/testdata/deployednettemplates/recipes/scenario2/node.json
+++ b/test/testdata/deployednettemplates/recipes/scenario2/node.json
@@ -1,4 +1,6 @@
 {
+    "NetAddress": "{{NetworkPort}}",
+    "APIEndpoint": "{{APIEndpoint}}",
     "APIToken": "{{APIToken}}",
     "EnableBlockStats": true,
     "EnableTelemetry": true,

--- a/test/testdata/deployednettemplates/recipes/scenario2/nonPartNode.json
+++ b/test/testdata/deployednettemplates/recipes/scenario2/nonPartNode.json
@@ -1,4 +1,5 @@
 {
+    "NetAddress": "{{NetworkPort}}",
     "APIEndpoint": "{{APIEndpoint}}",
     "APIToken": "{{APIToken}}",
     "ConfigJSONOverride": "{ \"TxPoolExponentialIncreaseFactor\": 1, \"DNSBootstrapID\": \"<network>.algodev.network\", \"DeadlockDetection\": -1, \"BaseLoggerDebugLevel\": 4, \"CadaverSizeTarget\": 0  }"


### PR DESCRIPTION
Fixed problem running bandwidth performance testing with the custom and scenario2 recipes by enabling the API endpoints for nodes and nonparticipating nodes.

## Summary

Allow bandwidth testing with custom and scenario 2 recipes. 

## Test Plan

Tested using the updated custom recipe.  The performance pipeline was completed successfully and the datadog bandwidth chart was updated.

![image](https://user-images.githubusercontent.com/9044640/154214915-6d83626f-889a-4d9d-95f9-dffa83aee39a.png)

