### PR TITLE
add StateProofID to AccountData.ClearOnlineState()

### DIFF
--- a/data/basics/userBalance.go
+++ b/data/basics/userBalance.go
@@ -420,6 +420,7 @@ func (u *AccountData) ClearOnlineState() {
 	u.VoteKeyDilution = 0
 	u.VoteID = crypto.OneTimeSignatureVerifier{}
 	u.SelectionID = crypto.VRFVerifier{}
+	u.StateProofID = merklesignature.Verifier{}
 }
 
 // Money returns the amount of MicroAlgos associated with the user's account

--- a/ledger/internal/eval_test.go
+++ b/ledger/internal/eval_test.go
@@ -760,6 +760,8 @@ func TestEvalFunctionForExpiredAccounts(t *testing.T) {
 		}
 		tmp := genesisInitState.Accounts[addr]
 		tmp.Status = basics.Online
+		crypto.RandBytes(tmp.StateProofID[:])
+		crypto.RandBytes(tmp.SelectionID[:])
 		genesisInitState.Accounts[addr] = tmp
 	}
 
@@ -819,6 +821,11 @@ func TestEvalFunctionForExpiredAccounts(t *testing.T) {
 
 	_, err = Eval(context.Background(), l, validatedBlock.Block(), false, nil, nil)
 	require.NoError(t, err)
+
+	acctData, _ := blkEval.state.lookup(recvAddr)
+
+	require.Equal(t, merklesignature.Verifier{}, acctData.StateProofID)
+	require.Equal(t, crypto.VRFVerifier{}, acctData.SelectionID)
 
 	badBlock := *validatedBlock
 

--- a/ledger/internal/eval_test.go
+++ b/ledger/internal/eval_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/compactcert"
+	"github.com/algorand/go-algorand/crypto/merklesignature"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -986,7 +987,16 @@ func TestExpiredAccountGeneration(t *testing.T) {
 			continue
 		}
 		tmp := genesisInitState.Accounts[addr]
+
+		// make up online account data
 		tmp.Status = basics.Online
+		tmp.VoteFirstValid = basics.Round(1)
+		tmp.VoteLastValid = basics.Round(100)
+		tmp.VoteKeyDilution = 0x1234123412341234
+		crypto.RandBytes(tmp.SelectionID[:])
+		crypto.RandBytes(tmp.VoteID[:])
+		crypto.RandBytes(tmp.StateProofID[:])
+
 		genesisInitState.Accounts[addr] = tmp
 	}
 
@@ -1057,5 +1067,5 @@ func TestExpiredAccountGeneration(t *testing.T) {
 	require.Equal(t, recvAcct.VoteKeyDilution, uint64(0))
 	require.Equal(t, recvAcct.VoteID, crypto.OneTimeSignatureVerifier{})
 	require.Equal(t, recvAcct.SelectionID, crypto.VRFVerifier{})
-
+	require.Equal(t, recvAcct.StateProofID, merklesignature.Verifier{})
 }


### PR DESCRIPTION
## Summary

Clear out AccountData.StateProofID when ClearOnlineState() is called, by resetExpiredOnlineAccountsParticipationKeys (as part of #2924)

## Test Plan

Updated TestExpiredAccountGeneration to generate random online account data, so that it fails without this change.