### PR TITLE
Algod: remove batch verification flag from the compact certs struct

### DIFF
--- a/crypto/compactcert/structs.go
+++ b/crypto/compactcert/structs.go
@@ -29,8 +29,6 @@ type Params struct {
 	ProvenWeight uint64          // Weight threshold proven by the certificate
 	SigRound     basics.Round    // The round for which the ephemeral key is committed to
 	SecKQ        uint64          // Security parameter (k+q) from analysis document
-
-	EnableBatchVerification bool // whether ED25519 batch verification is enabled
 }
 
 // CompactOneTimeSignature is crypto.OneTimeSignature with omitempty

--- a/ledger/internal/compactcert.go
+++ b/ledger/internal/compactcert.go
@@ -136,8 +136,6 @@ func CompactCertParams(votersHdr bookkeeping.BlockHeader, hdr bookkeeping.BlockH
 		ProvenWeight: provenWeight,
 		SigRound:     hdr.Round,
 		SecKQ:        proto.CompactCertSecKQ,
-
-		EnableBatchVerification: proto.EnableBatchVerification,
 	}
 	return
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Nodes create the compact cert using falcon keys so the batch verification flag (related to the ed25519 scheme) is no longer necessary.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
