### PR TITLE
ledger refactoring: fix linter detected issues

### DIFF
--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -2142,6 +2142,8 @@ func TestConsecutiveVersion(t *testing.T) {
 }
 
 func TestAcctUpdatesLookupLatest(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	accts := ledgertesting.RandomAccounts(10, false)
 	ml := makeMockLedgerForTracker(t, true, 10, protocol.ConsensusCurrentVersion, []map[basics.Address]basics.AccountData{accts})
 	defer ml.Close()

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -513,7 +513,7 @@ func (ct *catchpointTracker) accountsUpdateBalances(accountsDeltas compactAccoun
 			} else if resDelta.oldResource.data.IsApp() {
 				ctype = basics.AppCreatable
 			} else {
-				err = fmt.Errorf("unknown old creatable for addr %s (%d), aidx %d, data %v", addr.String(), resDelta.oldResource.addrid, resDelta.oldResource.aidx, resDelta.oldResource.data)
+				return fmt.Errorf("unknown old creatable for addr %s (%d), aidx %d, data %v", addr.String(), resDelta.oldResource.addrid, resDelta.oldResource.aidx, resDelta.oldResource.data)
 			}
 			deleteHash := resourcesHashBuilderV6(addr, resDelta.oldResource.aidx, ctype, uint64(resDelta.oldResource.data.UpdateRound), protocol.Encode(&resDelta.oldResource.data))
 			deleted, err = ct.balancesTrie.Delete(deleteHash)
@@ -534,7 +534,7 @@ func (ct *catchpointTracker) accountsUpdateBalances(accountsDeltas compactAccoun
 			} else if resDelta.newResource.IsApp() {
 				ctype = basics.AppCreatable
 			} else {
-				err = fmt.Errorf("unknown new creatable for addr %s, aidx %d, data %v", addr.String(), resDelta.oldResource.aidx, resDelta.newResource)
+				return fmt.Errorf("unknown new creatable for addr %s, aidx %d, data %v", addr.String(), resDelta.oldResource.aidx, resDelta.newResource)
 			}
 			addHash := resourcesHashBuilderV6(addr, resDelta.oldResource.aidx, ctype, uint64(resDelta.newResource.UpdateRound), protocol.Encode(&resDelta.newResource))
 			added, err = ct.balancesTrie.Add(addHash)

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"runtime"
 
-	//"runtime"
 	"sync/atomic"
 	"testing"
 	"time"


### PR DESCRIPTION
## Summary

This PR addresses 3 linter detected issues:
1. unneeded commented out import
2. missing `partitiontest.PartitionTest` call on unit test
3. the `accountsUpdateBalances` wasn't returning error correctly in some cases.

## Test Plan

Use existing unit tests.
