### PR TITLE
remove dead code from apply.Balances

### DIFF
--- a/ledger/apply/apply.go
+++ b/ledger/apply/apply.go
@@ -39,29 +39,24 @@ type Balances interface {
 	CloseAccount(basics.Address) error
 
 	// Methods for accessing app and asset data:
-	// CountX returns the number of AppParams, AppLocalState, AssetHolding, or AssetParams associated with an account.
 	// GetX returns the app or asset data associated with a given address and app/asset index.
 	// HasX checks when an account has data associated with a given address and app/asset index.
 	// PutX updates or creates app or asset data for an address and app/asset index.
 	// DeleteX deletes the app or asset data associated with an address and app/asset index.
 
-	// CountAppParams(addr basics.Address) (int, error)
 	GetAppParams(addr basics.Address, aidx basics.AppIndex) (basics.AppParams, bool, error)
 	PutAppParams(addr basics.Address, aidx basics.AppIndex, params basics.AppParams) error
 	DeleteAppParams(addr basics.Address, aidx basics.AppIndex) error
 
-	// CountAppLocalState(addr basics.Address) (int, error)
 	GetAppLocalState(addr basics.Address, aidx basics.AppIndex) (basics.AppLocalState, bool, error)
 	HasAppLocalState(addr basics.Address, aidx basics.AppIndex) (bool, error)
 	PutAppLocalState(addr basics.Address, aidx basics.AppIndex, state basics.AppLocalState) error
 	DeleteAppLocalState(addr basics.Address, aidx basics.AppIndex) error
 
-	// CountAssetHolding(addr basics.Address) (int, error)
 	GetAssetHolding(addr basics.Address, aidx basics.AssetIndex) (basics.AssetHolding, bool, error)
 	PutAssetHolding(addr basics.Address, aidx basics.AssetIndex, data basics.AssetHolding) error
 	DeleteAssetHolding(addr basics.Address, aidx basics.AssetIndex) error
 
-	// CountAssetParams(addr basics.Address) (int, error)
 	GetAssetParams(addr basics.Address, aidx basics.AssetIndex) (basics.AssetParams, bool, error)
 	HasAssetParams(addr basics.Address, aidx basics.AssetIndex) (bool, error)
 	PutAssetParams(addr basics.Address, aidx basics.AssetIndex, data basics.AssetParams) error

--- a/ledger/apply/mockBalances_test.go
+++ b/ledger/apply/mockBalances_test.go
@@ -128,35 +128,6 @@ type accountDataAccessor interface {
 	getAccount(addr basics.Address, withRewards bool) (basics.AccountData, error)
 }
 
-func (b *mockCreatableBalances) CountAppParams(addr basics.Address) (int, error) {
-	acct, err := b.access.getAccount(addr, false)
-	if err != nil {
-		return 0, err
-	}
-	return len(acct.AppParams), nil
-}
-func (b *mockCreatableBalances) CountAppLocalState(addr basics.Address) (int, error) {
-	acct, err := b.access.getAccount(addr, false)
-	if err != nil {
-		return 0, err
-	}
-	return len(acct.AppLocalStates), nil
-}
-func (b *mockCreatableBalances) CountAssetHolding(addr basics.Address) (int, error) {
-	acct, err := b.access.getAccount(addr, false)
-	if err != nil {
-		return 0, err
-	}
-	return len(acct.Assets), nil
-}
-func (b *mockCreatableBalances) CountAssetParams(addr basics.Address) (int, error) {
-	acct, err := b.access.getAccount(addr, false)
-	if err != nil {
-		return 0, err
-	}
-	return len(acct.AssetParams), nil
-}
-
 func (b *mockCreatableBalances) GetAppParams(addr basics.Address, aidx basics.AppIndex) (ret basics.AppParams, ok bool, err error) {
 	acct, err := b.access.getAccount(addr, false)
 	if err != nil {

--- a/ledger/internal/cow_creatables.go
+++ b/ledger/internal/cow_creatables.go
@@ -26,38 +26,6 @@ import (
 // These functions ensure roundCowState satisfies the methods for
 // accessing asset and app data in the apply.Balances interface.
 
-func (cs *roundCowState) CountAppParams(addr basics.Address) (int, error) {
-	acct, err := cs.lookup(addr)
-	if err != nil {
-		return 0, err
-	}
-	return int(acct.TotalAppParams), nil
-}
-
-func (cs *roundCowState) CountAppLocalState(addr basics.Address) (int, error) {
-	acct, err := cs.lookup(addr)
-	if err != nil {
-		return 0, err
-	}
-	return int(acct.TotalAppLocalStates), nil
-}
-
-func (cs *roundCowState) CountAssetHolding(addr basics.Address) (int, error) {
-	acct, err := cs.lookup(addr)
-	if err != nil {
-		return 0, err
-	}
-	return int(acct.TotalAssets), nil
-}
-
-func (cs *roundCowState) CountAssetParams(addr basics.Address) (int, error) {
-	acct, err := cs.lookup(addr)
-	if err != nil {
-		return 0, err
-	}
-	return int(acct.TotalAssetParams), nil
-}
-
 func (cs *roundCowState) GetAppParams(addr basics.Address, aidx basics.AppIndex) (ret basics.AppParams, ok bool, err error) {
 	var d ledgercore.AppParamsDelta
 	d, ok, err = cs.lookupAppParams(addr, aidx, false)


### PR DESCRIPTION
## Summary

I had been meaning to remove this bit of dead code — unused CountX methods in apply.Balances.

## Test Plan

Existing tests should pass.