### PR TITLE
ledger refactoring: make changes per CR

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -1802,7 +1802,7 @@ func removeEmptyAccountData(tx *sql.Tx, queryAddresses bool) (num int64, address
 // the full AccountData because we need to store a large number of these
 // in memory (say, 1M), and storing that many AccountData could easily
 // cause us to run out of memory.
-func accountDataToOnline(address basics.Address, ad ledgercore.AccountData, proto config.ConsensusParams) *ledgercore.OnlineAccount {
+func accountDataToOnline(address basics.Address, ad *ledgercore.AccountData, proto config.ConsensusParams) *ledgercore.OnlineAccount {
 	return &ledgercore.OnlineAccount{
 		Address:                 address,
 		MicroAlgos:              ad.MicroAlgos,
@@ -2256,7 +2256,7 @@ func accountsOnlineTop(tx *sql.Tx, offset, n uint64, proto config.ConsensusParam
 
 		copy(addr[:], addrbuf)
 		ad := data.GetLedgerCoreAccountData()
-		res[addr] = accountDataToOnline(addr, ad, proto)
+		res[addr] = accountDataToOnline(addr, &ad, proto)
 	}
 
 	return res, rows.Err()

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -115,7 +115,7 @@ func checkAccounts(t *testing.T, tx *sql.Tx, rnd basics.Round, accts map[basics.
 	for addr, data := range accts {
 		if data.Status == basics.Online {
 			ad := ledgercore.ToAccountData(data)
-			onlineAccounts[addr] = accountDataToOnline(addr, ad, proto)
+			onlineAccounts[addr] = accountDataToOnline(addr, &ad, proto)
 		}
 	}
 

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -434,7 +434,7 @@ func (au *accountUpdates) onlineTop(rnd basics.Round, voteRnd basics.Round, n ui
 					continue
 				}
 
-				modifiedAccounts[addr] = accountDataToOnline(addr, d, proto)
+				modifiedAccounts[addr] = accountDataToOnline(addr, &d, proto)
 			}
 		}
 


### PR DESCRIPTION
## Summary

Pass the `ledgercore.AccountData` to the `accountDataToOnline` as a pointer rather then copy of the actual data.

## Test Plan

Update tests