### PR TITLE
Tools: Add 'algokey part keyreg'

### DIFF
--- a/cmd/algokey/keyreg.go
+++ b/cmd/algokey/keyreg.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/account"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/util"
+	"github.com/algorand/go-algorand/util/db"
+)
+
+var keyregCmd *cobra.Command
+
+type keyregCmdParams struct {
+	fee         uint64
+	firstValid  uint64
+	lastValid   uint64
+	network     string
+	online      bool
+	txFile      string
+	partkeyFile string
+	addr        string
+}
+
+type networkGenesis struct {
+	id   string
+	hash crypto.Digest
+}
+
+const (
+	txnLife uint64 = 1000
+	minFee  uint64 = 1000
+)
+
+func init() {
+	var params keyregCmdParams
+
+	keyregCmd = &cobra.Command{
+		Use:   "keyreg",
+		Short: "Make key registration transaction",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
+			err := Run(params)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, err.Error())
+				os.Exit(1)
+			}
+		},
+	}
+
+	keyregCmd.Flags().Uint64Var(&params.fee, "fee", minFee, "transaction fee")
+	keyregCmd.Flags().Uint64Var(&params.firstValid, "first-valid", 0, "first round where the transaction may be committed to the ledger")
+	keyregCmd.MarkFlagRequired("first-valid")
+	keyregCmd.Flags().Uint64Var(&params.lastValid, "last-valid", 0, fmt.Sprintf("last round where the generated transaction may be committed to the ledger, defaults to first-valid + %d", txnLife))
+	keyregCmd.Flags().StringVar(&params.network, "network", "mainnet", "the network where the provided keys will be registered, one of mainnet/testnet/betanet")
+	keyregCmd.MarkFlagRequired("network")
+	keyregCmd.Flags().BoolVar(&params.online, "online", true, "set account to online or offline")
+	keyregCmd.Flags().StringVar(&params.txFile, "tx-file", "", fmt.Sprintf("write signed transaction to this file, or '%s' to write to stdout", stdoutFilenameValue))
+	keyregCmd.MarkFlagRequired("tx-file")
+	keyregCmd.Flags().StringVar(&params.partkeyFile, "partkey-file", "", "participation keys to register, file is opened to fetch metadata for the transaction, mutually exclusive with account")
+	keyregCmd.Flags().StringVar(&params.addr, "account", "", "account address to bring offline, mutually exclusive with partkey-file")
+}
+
+func mustConvertB64ToDigest(b64 string) (digest crypto.Digest) {
+	data, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to decode digest: %w", err)
+		os.Exit(1)
+	}
+	copy(digest[:], data)
+	return
+}
+
+func Run(params keyregCmdParams) error {
+	// TODO: move 'bundleGenesisInject' into something that can be imported here.
+	validNetworks := map[string]networkGenesis{
+		"mainnet": {
+			id:   "mainnet-v1",
+			hash: mustConvertB64ToDigest("wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=")},
+		"testnet": {
+			id:   "testnet-v1",
+			hash: mustConvertB64ToDigest("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=")},
+		"betanet": {
+			id:   "betanet-v1",
+			hash: mustConvertB64ToDigest("mFgazF+2uRS1tMiL9dsj01hJGySEmPN28B/TjjvpVW0=")},
+		"devnet": {
+			id:   "devnet-v1",
+			hash: mustConvertB64ToDigest("")},
+	}
+
+	validNetworkList := make([]string, 0, len(validNetworks))
+	for k, _ := range validNetworks {
+		validNetworkList = append(validNetworkList, k)
+	}
+
+	// Implicit last valid
+	if params.lastValid == 0 {
+		params.lastValid = params.firstValid + txnLife
+	}
+
+	if params.online {
+		if params.partkeyFile == "" {
+			return errors.New("must provide --partkey-file when registering participation keys")
+		}
+		if params.addr != "" {
+			return errors.New("do not provide --address when registering participation keys")
+		}
+	} else {
+		if params.addr != "" {
+			return errors.New("must provide --address when bringing an account offline")
+		}
+		if params.partkeyFile != "" {
+			return errors.New("do not provide --partkey-file when bringing an account offline")
+		}
+	}
+
+	var accountAddress basics.Address
+	if params.addr != "" {
+		var err error
+		accountAddress, err = basics.UnmarshalChecksumAddress(params.addr)
+		if err != nil {
+			return fmt.Errorf("unable to parse --address: %w", err)
+		}
+	}
+
+	if !util.FileExists(params.partkeyFile) {
+		return fmt.Errorf("cannot access partkey-file '%s'", params.partkeyFile)
+	}
+
+	if util.FileExists(params.txFile) || params.txFile == stdoutFilenameValue {
+		return fmt.Errorf("tx-file '%s' already exists", params.partkeyFile)
+	}
+
+	// Lookup information from partkey file
+	var part *account.Participation
+	if params.partkeyFile != "" {
+		partdb, err := db.MakeErasableAccessor(params.partkeyFile)
+		if err != nil {
+			return fmt.Errorf("cannot open partkey %s: %v", params.partkeyFile, err)
+		}
+
+		partkey, err := account.RestoreParticipation(partdb)
+		if err != nil {
+			return fmt.Errorf("Cannot load partkey %s: %v", params.partkeyFile, err)
+		}
+
+		part = &partkey.Participation
+		//accountAddress = part.Parent
+		//keyFirstValid = part.FirstValid
+		//keyLastValid = part.LastValid
+	}
+
+	if params.firstValid < uint64(part.FirstValid) {
+		return fmt.Errorf("first-valid (%d) is earlier than the key first valid (%d)", params.firstValid, part.FirstValid)
+	}
+
+	validRange := params.lastValid - params.firstValid
+	if validRange > txnLife {
+		return fmt.Errorf("first-valid (%d) is %d greater than last-valid (%d). last-valid may not be greater than first-valid + %d", params.firstValid, validRange, params.lastValid, txnLife)
+	}
+
+	var txn transactions.Transaction
+	if params.online {
+		// Generate go-online transaction
+		txn = part.GenerateRegistrationTransaction(
+			basics.MicroAlgos{Raw: params.fee},
+			basics.Round(params.firstValid),
+			basics.Round(params.lastValid),
+			[32]byte{},
+			part.StateProofSecrets != nil)
+	} else {
+		// Generate go-offline transaction
+		txn = transactions.Transaction{
+			Type: protocol.KeyRegistrationTx,
+			Header: transactions.Header{
+				Sender:     accountAddress,
+				Fee:        basics.MicroAlgos{Raw: params.fee},
+				FirstValid: basics.Round(params.firstValid),
+				LastValid:  basics.Round(params.lastValid),
+			},
+		}
+	}
+
+	gen, ok := validNetworks[strings.ToLower(params.network)]
+	if !ok {
+		return fmt.Errorf("unknown network '%s' provided. Supported networks: %s",
+			params.network,
+			strings.Join(validNetworkList, ", "))
+	}
+
+	txn.GenesisID = gen.id
+	txn.GenesisHash = gen.hash
+
+	// Wrap in a transactions.SignedTxn with an empty sig.
+	// This way protocol.Encode will encode the transaction type
+	stxn, err := transactions.AssembleSignedTxn(txn, crypto.Signature{}, crypto.MultisigSig{})
+	if err != nil {
+		return fmt.Errorf("failed to assemble transaction: %w", err)
+	}
+
+	data := protocol.Encode(&stxn)
+	if params.txFile == stdoutFilenameValue {
+		// Write to Stdout
+		if _, err = os.Stdout.Write(data); err != nil {
+			return fmt.Errorf("failed to write transaction to stdout: %w", err)
+		}
+	} else {
+		ioutil.WriteFile(params.txFile, data, 0600)
+	}
+
+	return nil
+}

--- a/cmd/algokey/keyreg.go
+++ b/cmd/algokey/keyreg.go
@@ -135,6 +135,10 @@ func run(params keyregCmdParams) error {
 		params.lastValid = params.firstValid + txnLife
 	}
 
+	if params.fee < minFee {
+		return fmt.Errorf("the provided transaction fee (%d) is too low, the minimum fee is %d", params.fee, minFee)
+	}
+
 	if !params.offline {
 		if params.partkeyFile == "" {
 			return errors.New("must provide --keyfile when registering participation keys")

--- a/cmd/algokey/part.go
+++ b/cmd/algokey/part.go
@@ -175,6 +175,7 @@ func init() {
 	partCmd.AddCommand(partGenerateCmd)
 	partCmd.AddCommand(partInfoCmd)
 	partCmd.AddCommand(partReparentCmd)
+	partCmd.AddCommand(keyregCmd)
 
 	partGenerateCmd.Flags().StringVar(&partKeyfile, "keyfile", "", "Participation key filename")
 	partGenerateCmd.Flags().Uint64Var(&partFirstRound, "first", 0, "First round for participation key")

--- a/test/scripts/e2e_subs/keyreg.sh
+++ b/test/scripts/e2e_subs/keyreg.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+date '+e2e_subs/keyreg.sh start %Y%m%d_%H%M%S'
+
+set -exo pipefail
+export SHELLOPTS
+
+WALLET=$1
+
+gcmd="goal -w ${WALLET}"
+
+ACCOUNT=$(${gcmd} account list|awk '{ print $3 }')
+ACCOUNTB=$(${gcmd} account new|awk '{ print $6 }')
+
+# secret algokey override
+export ALGOKEY_GENESIS_ID=$(goal node status | grep 'Genesis ID:'|awk '{ print $3 }')
+export ALGOKEY_GENESIS_HASH=$(goal node status | grep 'Genesis hash:'|awk '{ print $3 }')
+
+# Test key registration
+KEYS="${TEMPDIR}/foo.keys"
+TXN="${TEMPDIR}/keyreg.txn"
+STXN="${TEMPDIR}/keyreg.stxn"
+algokey part generate --first 1 --last 1000 --parent ${ACCOUNT} --keyfile "${KEYS}"
+algokey part keyreg --network placeholder --partkey-file "${KEYS}" --first-valid 1 --tx-file "${TXN}"
+# technically algokey could be used to sign at this point, that would require
+# exporting secrets from the wallet.
+${gcmd} clerk sign -i "${TXN}" -o "${STXN}"
+${gcmd} clerk rawsend -f "${STXN}"
+
+TXN2="${TEMPDIR}/keydereg.txn"
+STXN2="${TEMPDIR}/keydereg.stxn"
+# Test key de-registration
+algokey part keyreg --network placeholder --offline --account "${ACCOUNT}" --first-valid 1 --tx-file "${TXN2}"
+${gcmd} clerk sign -i "${TXN2}" -o "${STXN2}"
+${gcmd} clerk rawsend -f "${STXN2}"

--- a/test/scripts/e2e_subs/keyreg.sh
+++ b/test/scripts/e2e_subs/keyreg.sh
@@ -13,7 +13,6 @@ ACCOUNT=$(${gcmd} account list|awk '{ print $3 }')
 ACCOUNTB=$(${gcmd} account new|awk '{ print $6 }')
 
 # secret algokey override
-export ALGOKEY_GENESIS_ID=$(goal node status | grep 'Genesis ID:'|awk '{ print $3 }')
 export ALGOKEY_GENESIS_HASH=$(goal node status | grep 'Genesis hash:'|awk '{ print $3 }')
 
 # Test key registration
@@ -21,7 +20,7 @@ KEYS="${TEMPDIR}/foo.keys"
 TXN="${TEMPDIR}/keyreg.txn"
 STXN="${TEMPDIR}/keyreg.stxn"
 algokey part generate --first 1 --last 1000 --parent ${ACCOUNT} --keyfile "${KEYS}"
-algokey part keyreg --network placeholder --partkey-file "${KEYS}" --first-valid 1 --tx-file "${TXN}"
+algokey part keyreg --network placeholder --keyfile "${KEYS}" --firstvalid 1 --outputFile "${TXN}"
 # technically algokey could be used to sign at this point, that would require
 # exporting secrets from the wallet.
 ${gcmd} clerk sign -i "${TXN}" -o "${STXN}"
@@ -30,6 +29,6 @@ ${gcmd} clerk rawsend -f "${STXN}"
 TXN2="${TEMPDIR}/keydereg.txn"
 STXN2="${TEMPDIR}/keydereg.stxn"
 # Test key de-registration
-algokey part keyreg --network placeholder --offline --account "${ACCOUNT}" --first-valid 1 --tx-file "${TXN2}"
+algokey part keyreg --network placeholder --offline --account "${ACCOUNT}" --firstvalid 1 --outputFile "${TXN2}"
 ${gcmd} clerk sign -i "${TXN2}" -o "${STXN2}"
 ${gcmd} clerk rawsend -f "${STXN2}"

--- a/test/scripts/e2e_subs/keyreg.sh
+++ b/test/scripts/e2e_subs/keyreg.sh
@@ -10,16 +10,15 @@ WALLET=$1
 gcmd="goal -w ${WALLET}"
 
 ACCOUNT=$(${gcmd} account list|awk '{ print $3 }')
-ACCOUNTB=$(${gcmd} account new|awk '{ print $6 }')
 
 # secret algokey override
-export ALGOKEY_GENESIS_HASH=$(goal node status | grep 'Genesis hash:'|awk '{ print $3 }')
-
+ALGOKEY_GENESIS_HASH=$(goal node status | grep 'Genesis hash:'|awk '{ print $3 }')
+export ALGOKEY_GENESIS_HASH
 # Test key registration
 KEYS="${TEMPDIR}/foo.keys"
 TXN="${TEMPDIR}/keyreg.txn"
 STXN="${TEMPDIR}/keyreg.stxn"
-algokey part generate --first 1 --last 1000 --parent ${ACCOUNT} --keyfile "${KEYS}"
+algokey part generate --first 1 --last 1000 --parent "${ACCOUNT}" --keyfile "${KEYS}"
 algokey part keyreg --network placeholder --keyfile "${KEYS}" --firstvalid 1 --outputFile "${TXN}"
 # technically algokey could be used to sign at this point, that would require
 # exporting secrets from the wallet.


### PR DESCRIPTION
## Summary

New algokey subcommand to generate transactions for bringing an account online or offline.

Usage:
```
~$ algokey part keyreg -h
Make key registration transaction

Usage:
  algokey part keyreg [flags]

Flags:
      --account string      account address to bring offline, mutually exclusive with keyfile
      --fee uint            transaction fee (default 1000)
      --firstvalid uint     first round where the transaction may be committed to the ledger
  -h, --help                help for keyreg
      --keyfile string      participation keys to register, file is opened to fetch metadata for the transaction, mutually exclusive with account
      --lastvalid uint      last round where the generated transaction may be committed to the ledger, defaults to firstvalid + 1000
      --network string      the network where the provided keys will be registered, one of mainnet/testnet/betanet (default "mainnet")
      --offline             set to bring an account offline
  -o, --outputFile string   write signed transaction to this file, or '-' to write to stdout
```
## Test Plan

New e2e test.