### PR TITLE
Algod: add support for SHA256 in merkle tree

### DIFF
--- a/compactcert/signer.go
+++ b/compactcert/signer.go
@@ -126,7 +126,7 @@ func GenerateStateProofMessage(ledger Ledger, compactCertRound basics.Round, com
 	}
 
 	// Build merkle tree from encoded headers
-	tree, err := merklearray.BuildVectorCommitmentTree(blkHdrArr, crypto.HashFactory{HashType: crypto.Sha512_256})
+	tree, err := merklearray.BuildVectorCommitmentTree(blkHdrArr, crypto.HashFactory{HashType: crypto.Sha256})
 	if err != nil {
 		return nil, err
 	}

--- a/crypto/compactcert/structs.go
+++ b/crypto/compactcert/structs.go
@@ -25,10 +25,12 @@ import (
 
 // Params defines common parameters for the verifier and builder.
 type Params struct {
-	Msg          []byte       // Message to be cerified
+	Msg          []byte       // Message to be certified
 	ProvenWeight uint64       // Weight threshold proven by the certificate
 	SigRound     basics.Round // The round for which the ephemeral key is committed to
 	SecKQ        uint64       // Security parameter (k+q) from analysis document
+
+	EnableBatchVerification bool // whether ED25519 batch verification is enabled
 }
 
 // CompactOneTimeSignature is crypto.OneTimeSignature with omitempty

--- a/crypto/hashes.go
+++ b/crypto/hashes.go
@@ -17,6 +17,7 @@
 package crypto
 
 import (
+	"crypto/sha256"
 	"crypto/sha512"
 	"errors"
 	"fmt"
@@ -41,7 +42,7 @@ func (h HashType) Validate() error {
 const (
 	Sha512_256 HashType = iota
 	Sumhash
-
+	Sha256
 	MaxHashType
 )
 
@@ -53,6 +54,7 @@ const MaxHashDigestSize = SumhashDigestSize
 const (
 	Sha512_256Size    = sha512.Size256
 	SumhashDigestSize = sumhash.Sumhash512DigestSize
+	Sha256Size        = sha256.Size
 )
 
 // HashFactory is responsible for generating new hashes accordingly to the type it stores.
@@ -71,6 +73,8 @@ func (h HashType) String() string {
 		return "sha512_256"
 	case Sumhash:
 		return "sumhash"
+	case Sha256:
+		return "sha256"
 	default:
 		return ""
 	}
@@ -83,6 +87,8 @@ func UnmarshalHashType(s string) (HashType, error) {
 		return Sha512_256, nil
 	case "sumhash":
 		return Sumhash, nil
+	case "sha256":
+		return Sha256, nil
 	default:
 		return 0, fmt.Errorf("HashType not supported: %s", s)
 	}
@@ -96,6 +102,8 @@ func (z HashFactory) NewHash() hash.Hash {
 		return sha512.New512_256()
 	case Sumhash:
 		return sumhash.New512(nil)
+	case Sha256:
+		return sha256.New()
 	// This shouldn't be reached, when creating a new hash, one would know the type of hash they wanted,
 	// in addition to that, unmarshalling of the hashFactory verifies the HashType of the factory.
 	default:

--- a/crypto/hashes_test.go
+++ b/crypto/hashes_test.go
@@ -37,6 +37,9 @@ func TestHashFactoryCreatingNewHashes(t *testing.T) {
 	a.NotNil(h)
 	a.Equal(SumhashDigestSize, h.Size())
 
+	h = HashFactory{HashType: Sha256}.NewHash()
+	a.NotNil(h)
+	a.Equal(Sha256Size, h.Size())
 }
 
 func TestHashSum(t *testing.T) {


### PR DESCRIPTION
This is required for the Ethereum light client to be able to verify a block header and transaction proofs