### PR TITLE
unlimited assets : fix bug in AccountApplicationInformation handler

### DIFF
--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -480,7 +480,7 @@ func (v2 *Handlers) AccountApplicationInformation(ctx echo.Context, address stri
 	ledger := v2.Node.LedgerForAPI()
 
 	lastRound := ledger.Latest()
-	record, err := ledger.LookupResource(lastRound, addr, basics.CreatableIndex(applicationID), basics.AssetCreatable)
+	record, err := ledger.LookupResource(lastRound, addr, basics.CreatableIndex(applicationID), basics.AppCreatable)
 	if err != nil {
 		return internalError(ctx, err, errFailedLookingUpLedger, v2.Log)
 	}


### PR DESCRIPTION
## Summary

AccountApplicationInformation was calling `ledger.LookupResource` with `basics.AssetCreatable` instead of `basics.AppCreatable`, resulting in a consistent failure.

## Test Plan

Unit test will follow on a subsequent PR.