### PR TITLE
agreement: Add validatedAt to proposal type and BlockAcceptedEventDetails message

### DIFF
--- a/agreement/actions.go
+++ b/agreement/actions.go
@@ -232,10 +232,11 @@ func (a ensureAction) do(ctx context.Context, s *Service) {
 		logEvent.Type = logspec.RoundConcluded
 		s.log.with(logEvent).Infof("committed round %d with pre-validated block %v", a.Certificate.Round, a.Certificate.Proposal)
 		s.log.EventWithDetails(telemetryspec.Agreement, telemetryspec.BlockAcceptedEvent, telemetryspec.BlockAcceptedEventDetails{
-			Address:     a.Certificate.Proposal.OriginalProposer.String(),
-			Hash:        a.Certificate.Proposal.BlockDigest.String(),
-			Round:       uint64(a.Certificate.Round),
-			ValidatedAt: a.Payload.validatedAt,
+			Address:      a.Certificate.Proposal.OriginalProposer.String(),
+			Hash:         a.Certificate.Proposal.BlockDigest.String(),
+			Round:        uint64(a.Certificate.Round),
+			ValidatedAt:  a.Payload.validatedAt,
+			PreValidated: true,
 		})
 		s.Ledger.EnsureValidatedBlock(a.Payload.ve, a.Certificate)
 	} else {
@@ -243,10 +244,11 @@ func (a ensureAction) do(ctx context.Context, s *Service) {
 		logEvent.Type = logspec.RoundConcluded
 		s.log.with(logEvent).Infof("committed round %d with block %v", a.Certificate.Round, a.Certificate.Proposal)
 		s.log.EventWithDetails(telemetryspec.Agreement, telemetryspec.BlockAcceptedEvent, telemetryspec.BlockAcceptedEventDetails{
-			Address:     a.Certificate.Proposal.OriginalProposer.String(),
-			Hash:        a.Certificate.Proposal.BlockDigest.String(),
-			Round:       uint64(a.Certificate.Round),
-			ValidatedAt: a.Payload.validatedAt,
+			Address:      a.Certificate.Proposal.OriginalProposer.String(),
+			Hash:         a.Certificate.Proposal.BlockDigest.String(),
+			Round:        uint64(a.Certificate.Round),
+			ValidatedAt:  a.Payload.validatedAt,
+			PreValidated: false,
 		})
 		s.Ledger.EnsureBlock(block, a.Certificate)
 	}

--- a/agreement/actions.go
+++ b/agreement/actions.go
@@ -232,9 +232,10 @@ func (a ensureAction) do(ctx context.Context, s *Service) {
 		logEvent.Type = logspec.RoundConcluded
 		s.log.with(logEvent).Infof("committed round %d with pre-validated block %v", a.Certificate.Round, a.Certificate.Proposal)
 		s.log.EventWithDetails(telemetryspec.Agreement, telemetryspec.BlockAcceptedEvent, telemetryspec.BlockAcceptedEventDetails{
-			Address: a.Certificate.Proposal.OriginalProposer.String(),
-			Hash:    a.Certificate.Proposal.BlockDigest.String(),
-			Round:   uint64(a.Certificate.Round),
+			Address:     a.Certificate.Proposal.OriginalProposer.String(),
+			Hash:        a.Certificate.Proposal.BlockDigest.String(),
+			Round:       uint64(a.Certificate.Round),
+			ValidatedAt: a.Payload.validatedAt,
 		})
 		s.Ledger.EnsureValidatedBlock(a.Payload.ve, a.Certificate)
 	} else {
@@ -242,9 +243,10 @@ func (a ensureAction) do(ctx context.Context, s *Service) {
 		logEvent.Type = logspec.RoundConcluded
 		s.log.with(logEvent).Infof("committed round %d with block %v", a.Certificate.Round, a.Certificate.Proposal)
 		s.log.EventWithDetails(telemetryspec.Agreement, telemetryspec.BlockAcceptedEvent, telemetryspec.BlockAcceptedEventDetails{
-			Address: a.Certificate.Proposal.OriginalProposer.String(),
-			Hash:    a.Certificate.Proposal.BlockDigest.String(),
-			Round:   uint64(a.Certificate.Round),
+			Address:     a.Certificate.Proposal.OriginalProposer.String(),
+			Hash:        a.Certificate.Proposal.BlockDigest.String(),
+			Round:       uint64(a.Certificate.Round),
+			ValidatedAt: a.Payload.validatedAt,
 		})
 		s.Ledger.EnsureBlock(block, a.Certificate)
 	}

--- a/agreement/agreementtest/simulate.go
+++ b/agreement/agreementtest/simulate.go
@@ -82,6 +82,10 @@ func (i *instant) Zero() timers.Clock {
 	return i
 }
 
+func (i *instant) DurationUntil(t time.Time) time.Duration {
+	return 0
+}
+
 func (i *instant) runRound(r basics.Round) {
 	<-i.Z1 // wait until Zero is called
 	<-i.timeoutAtCalled

--- a/agreement/agreementtest/simulate.go
+++ b/agreement/agreementtest/simulate.go
@@ -82,7 +82,7 @@ func (i *instant) Zero() timers.Clock {
 	return i
 }
 
-func (i *instant) DurationUntil(t time.Time) time.Duration {
+func (i *instant) Since() time.Duration {
 	return 0
 }
 

--- a/agreement/demux.go
+++ b/agreement/demux.go
@@ -190,7 +190,7 @@ func (d *demux) next(s *Service, deadline time.Duration, fastDeadline time.Durat
 		e = e.AttachConsensusVersion(ConsensusVersionView{Err: makeSerErr(err), Version: proto})
 
 		if e.t() == payloadVerified {
-			e = e.(messageEvent).AttachValidatedAt(s.Clock.DurationUntil(time.Now()))
+			e = e.(messageEvent).AttachValidatedAt(s.Clock.Since())
 		}
 	}()
 

--- a/agreement/demux.go
+++ b/agreement/demux.go
@@ -188,6 +188,10 @@ func (d *demux) next(s *Service, deadline time.Duration, fastDeadline time.Durat
 		}
 		proto, err := d.ledger.ConsensusVersion(ParamsRound(e.ConsensusRound()))
 		e = e.AttachConsensusVersion(ConsensusVersionView{Err: makeSerErr(err), Version: proto})
+
+		if e.t() == payloadVerified {
+			e = e.(messageEvent).AttachValidatedAt(s.Clock.DurationUntil(time.Now()))
+		}
 	}()
 
 	var pseudonodeEvents <-chan externalEvent

--- a/agreement/demux_test.go
+++ b/agreement/demux_test.go
@@ -456,7 +456,7 @@ func (t *demuxTester) Decode([]byte) (timers.Clock, error) {
 }
 
 // implement timers.Clock
-func (t *demuxTester) DurationUntil(_ time.Time) time.Duration {
+func (t *demuxTester) Since(_ time.Time) time.Duration {
 	return 0
 }
 

--- a/agreement/demux_test.go
+++ b/agreement/demux_test.go
@@ -456,7 +456,7 @@ func (t *demuxTester) Decode([]byte) (timers.Clock, error) {
 }
 
 // implement timers.Clock
-func (t *demuxTester) Since(_ time.Time) time.Duration {
+func (t *demuxTester) Since() time.Duration {
 	return 0
 }
 

--- a/agreement/demux_test.go
+++ b/agreement/demux_test.go
@@ -455,6 +455,11 @@ func (t *demuxTester) Decode([]byte) (timers.Clock, error) {
 	return t, nil
 }
 
+// implement timers.Clock
+func (t *demuxTester) DurationUntil(_ time.Time) time.Duration {
+	return 0
+}
+
 // implement Ledger
 func (t *demuxTester) NextRound() basics.Round {
 	return 1234

--- a/agreement/events.go
+++ b/agreement/events.go
@@ -18,6 +18,7 @@ package agreement
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
@@ -930,5 +931,10 @@ func (e checkpointEvent) ConsensusRound() round {
 }
 
 func (e checkpointEvent) AttachConsensusVersion(v ConsensusVersionView) externalEvent {
+	return e
+}
+
+func (e messageEvent) AttachValidatedAt(d time.Duration) messageEvent {
+	e.Input.Proposal.validatedAt = d
 	return e
 }

--- a/agreement/msgp_gen.go
+++ b/agreement/msgp_gen.go
@@ -1356,7 +1356,7 @@ func (z *proposal) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0004Len := uint32(28)
-	var zb0004Mask uint64 /* 34 bits */
+	var zb0004Mask uint64 /* 35 bits */
 	if len((*z).unauthenticatedProposal.Block.BlockHeader.CompactCert) == 0 {
 		zb0004Len--
 		zb0004Mask |= 0x20

--- a/agreement/proposal.go
+++ b/agreement/proposal.go
@@ -19,6 +19,7 @@ package agreement
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
@@ -88,6 +89,11 @@ type proposal struct {
 	// to disk, so after a crash, we will fall back to applying the
 	// raw Block to the ledger (and re-computing the state delta).
 	ve ValidatedBlock
+
+	// validatedAt indicates the time at which this proposal was
+	// validated (and thus was ready to be delivered to the state
+	// machine), relative to the zero of that round.
+	validatedAt time.Duration
 }
 
 func makeProposal(ve ValidatedBlock, pf crypto.VrfProof, origPer period, origProp basics.Address) proposal {

--- a/agreement/service_test.go
+++ b/agreement/service_test.go
@@ -71,7 +71,7 @@ func (c *testingClock) Zero() timers.Clock {
 	return c
 }
 
-func (c *testingClock) DurationUntil(t time.Time) time.Duration {
+func (c *testingClock) Since() time.Duration {
 	return 0
 }
 

--- a/agreement/service_test.go
+++ b/agreement/service_test.go
@@ -71,6 +71,10 @@ func (c *testingClock) Zero() timers.Clock {
 	return c
 }
 
+func (c *testingClock) DurationUntil(t time.Time) time.Duration {
+	return 0
+}
+
 func (c *testingClock) TimeoutAt(d time.Duration) <-chan time.Time {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/logging/telemetryspec/event.go
+++ b/logging/telemetryspec/event.go
@@ -73,9 +73,10 @@ const BlockAcceptedEvent Event = "BlockAccepted"
 
 // BlockAcceptedEventDetails contains details for the BlockAcceptedEvent
 type BlockAcceptedEventDetails struct {
-	Address string
-	Hash    string
-	Round   uint64
+	Address     string
+	Hash        string
+	Round       uint64
+	ValidatedAt time.Duration
 }
 
 // TopAccountsEvent event

--- a/logging/telemetryspec/event.go
+++ b/logging/telemetryspec/event.go
@@ -73,10 +73,11 @@ const BlockAcceptedEvent Event = "BlockAccepted"
 
 // BlockAcceptedEventDetails contains details for the BlockAcceptedEvent
 type BlockAcceptedEventDetails struct {
-	Address     string
-	Hash        string
-	Round       uint64
-	ValidatedAt time.Duration
+	Address      string
+	Hash         string
+	Round        uint64
+	ValidatedAt  time.Duration
+	PreValidated bool
 }
 
 // TopAccountsEvent event

--- a/util/timers/frozen.go
+++ b/util/timers/frozen.go
@@ -55,3 +55,8 @@ func (m *Frozen) Decode([]byte) (Clock, error) {
 func (m *Frozen) String() string {
 	return ""
 }
+
+// DurationUntil implements the Clock interface.
+func (m *Frozen) DurationUntil(t time.Time) time.Duration {
+	return 0
+}

--- a/util/timers/frozen.go
+++ b/util/timers/frozen.go
@@ -56,7 +56,7 @@ func (m *Frozen) String() string {
 	return ""
 }
 
-// DurationUntil implements the Clock interface.
-func (m *Frozen) DurationUntil(t time.Time) time.Duration {
+// Since implements the Clock interface.
+func (m *Frozen) Since() time.Duration {
 	return 0
 }

--- a/util/timers/interface.go
+++ b/util/timers/interface.go
@@ -27,8 +27,9 @@ type Clock interface {
 	// at which Zero was called as their reference point.
 	Zero() Clock
 
-	// DurationUntil returns the duration elapsed from this clock's zero to t.
-	DurationUntil(t time.Time) time.Duration
+	// Since returns the time spent between the last time the clock was zeroed out and the current
+	// wall clock time.
+	Since() time.Duration
 
 	// TimeoutAt returns a channel that fires delta time after Zero was called.
 	// If delta has already passed, it returns a closed channel.

--- a/util/timers/interface.go
+++ b/util/timers/interface.go
@@ -27,6 +27,9 @@ type Clock interface {
 	// at which Zero was called as their reference point.
 	Zero() Clock
 
+	// DurationUntil returns the duration elapsed from this clock's zero to t.
+	DurationUntil(t time.Time) time.Duration
+
 	// TimeoutAt returns a channel that fires delta time after Zero was called.
 	// If delta has already passed, it returns a closed channel.
 	//

--- a/util/timers/monotonic.go
+++ b/util/timers/monotonic.go
@@ -87,7 +87,7 @@ func (m *Monotonic) String() string {
 	return time.Time(m.zero).String()
 }
 
-// DurationUntil implements the Clock interface.
-func (m *Monotonic) DurationUntil(t time.Time) time.Duration {
-	return t.Sub(m.zero)
+// Since returns the time that has passed between the time the clock was last zeroed out and now
+func (m *Monotonic) Since() time.Duration {
+	return time.Since(m.zero)
 }

--- a/util/timers/monotonic.go
+++ b/util/timers/monotonic.go
@@ -86,3 +86,8 @@ func (m *Monotonic) Decode(data []byte) (Clock, error) {
 func (m *Monotonic) String() string {
 	return time.Time(m.zero).String()
 }
+
+// DurationUntil implements the Clock interface.
+func (m *Monotonic) DurationUntil(t time.Time) time.Duration {
+	return t.Sub(m.zero)
+}


### PR DESCRIPTION
## Summary

This pulls a bit of code from the the [pipelining branch](https://github.com/algorand/go-algorand/tree/feature/pipeline) to add a "validatedAt" duration field to the agreement.proposal type. This is used to provide an extra field in the BlockAcceptedEventDetails message describing how soon into the round each block was validated.

## Test Plan

Existing tests should pass, and a new test might be helpful to show that the value is getting filled in correctly.