### PR TITLE
ledger: replace Ledger.LookupResource with Lookup{Application,Asset}

### DIFF
--- a/cmd/tealdbg/localLedger.go
+++ b/cmd/tealdbg/localLedger.go
@@ -285,26 +285,33 @@ func (l *localLedger) CheckDup(config.ConsensusParams, basics.Round, basics.Roun
 	return nil
 }
 
-func (l *localLedger) LookupResource(rnd basics.Round, addr basics.Address, aidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.AccountResource, error) {
+func (l *localLedger) LookupAsset(rnd basics.Round, addr basics.Address, aidx basics.AssetIndex) (ledgercore.AssetResource, error) {
 	ad, ok := l.balances[addr]
 	if !ok {
-		return ledgercore.AccountResource{}, nil
+		return ledgercore.AssetResource{}, nil
 	}
-	var result ledgercore.AccountResource
-	if ctype == basics.AppCreatable {
-		if p, ok := ad.AppParams[basics.AppIndex(aidx)]; ok {
-			result.AppParams = &p
-		}
-		if s, ok := ad.AppLocalStates[basics.AppIndex(aidx)]; ok {
-			result.AppLocalState = &s
-		}
-	} else if ctype == basics.AssetCreatable {
-		if p, ok := ad.AssetParams[basics.AssetIndex(aidx)]; ok {
-			result.AssetParams = &p
-		}
-		if p, ok := ad.Assets[basics.AssetIndex(aidx)]; ok {
-			result.AssetHolding = &p
-		}
+	var result ledgercore.AssetResource
+	if p, ok := ad.AssetParams[basics.AssetIndex(aidx)]; ok {
+		result.AssetParams = &p
+	}
+	if p, ok := ad.Assets[basics.AssetIndex(aidx)]; ok {
+		result.AssetHolding = &p
+	}
+
+	return result, nil
+}
+
+func (l *localLedger) LookupApplication(rnd basics.Round, addr basics.Address, aidx basics.AppIndex) (ledgercore.AppResource, error) {
+	ad, ok := l.balances[addr]
+	if !ok {
+		return ledgercore.AppResource{}, nil
+	}
+	var result ledgercore.AppResource
+	if p, ok := ad.AppParams[basics.AppIndex(aidx)]; ok {
+		result.AppParams = &p
+	}
+	if s, ok := ad.AppLocalStates[basics.AppIndex(aidx)]; ok {
+		result.AppLocalState = &s
 	}
 
 	return result, nil

--- a/daemon/algod/api/server/v1/handlers/handlers.go
+++ b/daemon/algod/api/server/v1/handlers/handlers.go
@@ -1314,7 +1314,7 @@ func AssetInformation(ctx lib.ReqContext, context echo.Context) {
 	}
 
 	lastRound := ledger.Latest()
-	resource, err := ledger.LookupResource(lastRound, creator, basics.CreatableIndex(aidx), basics.AssetCreatable)
+	resource, err := ledger.LookupAsset(lastRound, creator, aidx)
 	if err != nil {
 		lib.ErrorResponse(w, http.StatusInternalServerError, err, errFailedLookingUpLedger, ctx.Log)
 		return
@@ -1414,7 +1414,7 @@ func Assets(ctx lib.ReqContext, context echo.Context) {
 	var result v1.AssetList
 	for _, aloc := range alocs {
 		// Fetch the asset parameters
-		record, err := ledger.LookupResource(lastRound, aloc.Creator, aloc.Index, basics.AssetCreatable)
+		record, err := ledger.LookupAsset(lastRound, aloc.Creator, basics.AssetIndex(aloc.Index))
 		if err != nil {
 			lib.ErrorResponse(w, http.StatusInternalServerError, err, errFailedLookingUpLedger, ctx.Log)
 			return

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -310,26 +310,32 @@ func (dl *dryrunLedger) LookupWithoutRewards(rnd basics.Round, addr basics.Addre
 	return ledgercore.ToAccountData(ad), rnd, nil
 }
 
-func (dl *dryrunLedger) LookupResource(rnd basics.Round, addr basics.Address, aidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.AccountResource, error) {
+func (dl *dryrunLedger) LookupApplication(rnd basics.Round, addr basics.Address, aidx basics.AppIndex) (ledgercore.AppResource, error) {
 	ad, _, err := dl.lookup(rnd, addr)
 	if err != nil {
-		return ledgercore.AccountResource{}, err
+		return ledgercore.AppResource{}, err
 	}
-	var result ledgercore.AccountResource
-	if ctype == basics.AppCreatable {
-		if p, ok := ad.AppParams[basics.AppIndex(aidx)]; ok {
-			result.AppParams = &p
-		}
-		if s, ok := ad.AppLocalStates[basics.AppIndex(aidx)]; ok {
-			result.AppLocalState = &s
-		}
-	} else if ctype == basics.AssetCreatable {
-		if p, ok := ad.AssetParams[basics.AssetIndex(aidx)]; ok {
-			result.AssetParams = &p
-		}
-		if p, ok := ad.Assets[basics.AssetIndex(aidx)]; ok {
-			result.AssetHolding = &p
-		}
+	var result ledgercore.AppResource
+	if p, ok := ad.AppParams[basics.AppIndex(aidx)]; ok {
+		result.AppParams = &p
+	}
+	if s, ok := ad.AppLocalStates[basics.AppIndex(aidx)]; ok {
+		result.AppLocalState = &s
+	}
+	return result, nil
+}
+
+func (dl *dryrunLedger) LookupAsset(rnd basics.Round, addr basics.Address, aidx basics.AssetIndex) (ledgercore.AssetResource, error) {
+	ad, _, err := dl.lookup(rnd, addr)
+	if err != nil {
+		return ledgercore.AssetResource{}, err
+	}
+	var result ledgercore.AssetResource
+	if p, ok := ad.AssetParams[basics.AssetIndex(aidx)]; ok {
+		result.AssetParams = &p
+	}
+	if p, ok := ad.Assets[basics.AssetIndex(aidx)]; ok {
+		result.AssetHolding = &p
 	}
 	return result, nil
 }

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -64,7 +64,8 @@ type LedgerForAPI interface {
 	LookupLatest(addr basics.Address) (basics.AccountData, basics.Round, basics.MicroAlgos, error)
 	ConsensusParams(r basics.Round) (config.ConsensusParams, error)
 	Latest() basics.Round
-	LookupResource(rnd basics.Round, addr basics.Address, aidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.AccountResource, error)
+	LookupAsset(rnd basics.Round, addr basics.Address, aidx basics.AssetIndex) (ledgercore.AssetResource, error)
+	LookupApplication(rnd basics.Round, addr basics.Address, aidx basics.AppIndex) (ledgercore.AppResource, error)
 	BlockCert(rnd basics.Round) (blk bookkeeping.Block, cert agreement.Certificate, err error)
 	LatestTotals() (basics.Round, ledgercore.AccountTotals, error)
 	BlockHdr(rnd basics.Round) (blk bookkeeping.BlockHeader, err error)
@@ -427,7 +428,7 @@ func (v2 *Handlers) AccountAssetInformation(ctx echo.Context, address string, as
 	ledger := v2.Node.LedgerForAPI()
 
 	lastRound := ledger.Latest()
-	record, err := ledger.LookupResource(lastRound, addr, basics.CreatableIndex(assetID), basics.AssetCreatable)
+	record, err := ledger.LookupAsset(lastRound, addr, basics.AssetIndex(assetID))
 	if err != nil {
 		return internalError(ctx, err, errFailedLookingUpLedger, v2.Log)
 	}
@@ -438,7 +439,7 @@ func (v2 *Handlers) AccountAssetInformation(ctx echo.Context, address string, as
 
 	// return msgpack response
 	if handle == protocol.CodecHandle {
-		data, err := encode(handle, model.AccountResourceToAccountAssetModel(record))
+		data, err := encode(handle, model.AssetResourceToAccountAssetModel(record))
 		if err != nil {
 			return internalError(ctx, err, errFailedToEncodeResponse, v2.Log)
 		}
@@ -480,7 +481,7 @@ func (v2 *Handlers) AccountApplicationInformation(ctx echo.Context, address stri
 	ledger := v2.Node.LedgerForAPI()
 
 	lastRound := ledger.Latest()
-	record, err := ledger.LookupResource(lastRound, addr, basics.CreatableIndex(applicationID), basics.AppCreatable)
+	record, err := ledger.LookupApplication(lastRound, addr, basics.AppIndex(applicationID))
 	if err != nil {
 		return internalError(ctx, err, errFailedLookingUpLedger, v2.Log)
 	}
@@ -491,7 +492,7 @@ func (v2 *Handlers) AccountApplicationInformation(ctx echo.Context, address stri
 
 	// return msgpack response
 	if handle == protocol.CodecHandle {
-		data, err := encode(handle, model.AccountResourceToAccountApplicationModel(record))
+		data, err := encode(handle, model.AppResourceToAccountApplicationModel(record))
 		if err != nil {
 			return internalError(ctx, err, errFailedToEncodeResponse, v2.Log)
 		}
@@ -501,7 +502,7 @@ func (v2 *Handlers) AccountApplicationInformation(ctx echo.Context, address stri
 	// prepare JSON response
 	response := generated.AccountApplicationResponse{Round: uint64(lastRound)}
 
-	if record.AssetParams != nil {
+	if record.AppParams != nil {
 		app := AppParamsToApplication(addr.String(), basics.AppIndex(applicationID), record.AppParams)
 		response.CreatedApp = &app.Params
 	}
@@ -1063,7 +1064,7 @@ func (v2 *Handlers) GetApplicationByID(ctx echo.Context, applicationID uint64) e
 
 	lastRound := ledger.Latest()
 
-	record, err := ledger.LookupResource(lastRound, creator, basics.CreatableIndex(applicationID), basics.AppCreatable)
+	record, err := ledger.LookupApplication(lastRound, creator, basics.AppIndex(applicationID))
 	if err != nil {
 		return internalError(ctx, err, errFailedLookingUpLedger, v2.Log)
 	}
@@ -1091,7 +1092,7 @@ func (v2 *Handlers) GetAssetByID(ctx echo.Context, assetID uint64) error {
 	}
 
 	lastRound := ledger.Latest()
-	record, err := ledger.LookupResource(lastRound, creator, basics.CreatableIndex(assetID), basics.AssetCreatable)
+	record, err := ledger.LookupAsset(lastRound, creator, basics.AssetIndex(assetID))
 	if err != nil {
 		return internalError(ctx, err, errFailedLookingUpLedger, v2.Log)
 	}

--- a/daemon/algod/api/server/v2/test/handlers_resources_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_resources_test.go
@@ -63,7 +63,10 @@ func (l *mockLedger) ConsensusParams(r basics.Round) (config.ConsensusParams, er
 
 func (l *mockLedger) Latest() basics.Round { return l.latest }
 
-func (l *mockLedger) LookupResource(rnd basics.Round, addr basics.Address, aidx basics.CreatableIndex, ctype basics.CreatableType) (ar ledgercore.AccountResource, err error) {
+func (l *mockLedger) LookupAsset(rnd basics.Round, addr basics.Address, aidx basics.AssetIndex) (ledgercore.AssetResource, error) {
+	panic("not implemented")
+}
+func (l *mockLedger) LookupApplication(rnd basics.Round, addr basics.Address, aidx basics.AppIndex) (ledgercore.AppResource, error) {
 	panic("not implemented")
 }
 func (l *mockLedger) BlockCert(rnd basics.Round) (blk bookkeeping.Block, cert agreement.Certificate, err error) {

--- a/daemon/algod/api/spec/v2/model.go
+++ b/daemon/algod/api/spec/v2/model.go
@@ -38,16 +38,16 @@ type AccountApplicationModel struct {
 	AppParams     *basics.AppParams     `codec:"app-params"`
 }
 
-// AccountResourceToAccountAssetModel converts AccountResource to AccountAssetModel
-func AccountResourceToAccountAssetModel(resource ledgercore.AccountResource) AccountAssetModel {
+// AssetResourceToAccountAssetModel converts AssetResource to AccountAssetModel
+func AssetResourceToAccountAssetModel(resource ledgercore.AssetResource) AccountAssetModel {
 	return AccountAssetModel{
 		AssetParams:  resource.AssetParams,
 		AssetHolding: resource.AssetHolding,
 	}
 }
 
-// AccountResourceToAccountApplicationModel converts AccountResource to AccountApplicationModel
-func AccountResourceToAccountApplicationModel(resource ledgercore.AccountResource) AccountApplicationModel {
+// AppResourceToAccountApplicationModel converts AppResource to AccountApplicationModel
+func AppResourceToAccountApplicationModel(resource ledgercore.AppResource) AccountApplicationModel {
 	return AccountApplicationModel{
 		AppParams:     resource.AppParams,
 		AppLocalState: resource.AppLocalState,

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -713,9 +713,14 @@ func (aul *accountUpdatesLedgerEvaluator) LookupWithoutRewards(rnd basics.Round,
 	return data, validThrough, err
 }
 
-func (aul *accountUpdatesLedgerEvaluator) LookupResource(rnd basics.Round, addr basics.Address, aidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.AccountResource, error) {
-	r, _, err := aul.au.lookupResource(rnd, addr, aidx, ctype, false /* don't sync */)
-	return r, err
+func (aul *accountUpdatesLedgerEvaluator) LookupApplication(rnd basics.Round, addr basics.Address, aidx basics.AppIndex) (ledgercore.AppResource, error) {
+	r, _, err := aul.au.lookupResource(rnd, addr, basics.CreatableIndex(aidx), basics.AppCreatable, false /* don't sync */)
+	return ledgercore.AppResource{AppParams: r.AppParams, AppLocalState: r.AppLocalState}, err
+}
+
+func (aul *accountUpdatesLedgerEvaluator) LookupAsset(rnd basics.Round, addr basics.Address, aidx basics.AssetIndex) (ledgercore.AssetResource, error) {
+	r, _, err := aul.au.lookupResource(rnd, addr, basics.CreatableIndex(aidx), basics.AssetCreatable, false /* don't sync */)
+	return ledgercore.AssetResource{AssetParams: r.AssetParams, AssetHolding: r.AssetHolding}, err
 }
 
 // GetCreatorForRound returns the asset/app creator for a given asset/app index at a given round

--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -286,7 +286,7 @@ return`
 	a.Equal(basics.Round(4), dbRound)
 	a.Equal(expectedUserLocalResource, buf)
 
-	ar, err := l.LookupResource(dbRound, userLocal, basics.CreatableIndex(appIdx), basics.AppCreatable)
+	ar, err := l.LookupApplication(dbRound, userLocal, appIdx)
 	a.NoError(err)
 	a.Equal("local", ar.AppLocalState.KeyValue["lk"].Bytes)
 

--- a/ledger/evalindexer.go
+++ b/ledger/evalindexer.go
@@ -115,7 +115,17 @@ func (l indexerLedgerConnector) LookupWithoutRewards(round basics.Round, address
 	return *accountData, round, nil
 }
 
-func (l indexerLedgerConnector) LookupResource(round basics.Round, address basics.Address, aidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.AccountResource, error) {
+func (l indexerLedgerConnector) LookupApplication(rnd basics.Round, addr basics.Address, aidx basics.AppIndex) (ledgercore.AppResource, error) {
+	r, err := l.lookupResource(rnd, addr, basics.CreatableIndex(aidx), basics.AppCreatable)
+	return ledgercore.AppResource{AppParams: r.AppParams, AppLocalState: r.AppLocalState}, err
+}
+
+func (l indexerLedgerConnector) LookupAsset(rnd basics.Round, addr basics.Address, aidx basics.AssetIndex) (ledgercore.AssetResource, error) {
+	r, err := l.lookupResource(rnd, addr, basics.CreatableIndex(aidx), basics.AssetCreatable)
+	return ledgercore.AssetResource{AssetParams: r.AssetParams, AssetHolding: r.AssetHolding}, err
+}
+
+func (l indexerLedgerConnector) lookupResource(round basics.Round, address basics.Address, aidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.AccountResource, error) {
 	// check to see if the account data in the cache.
 	if creatableMap, ok := l.roundResources.Resources[address]; ok {
 		if resource, ok := creatableMap[Creatable{aidx, ctype}]; ok {

--- a/ledger/evalindexer_test.go
+++ b/ledger/evalindexer_test.go
@@ -83,7 +83,7 @@ func (il indexerLedgerForEvalImpl) LookupResources(addresses map[basics.Address]
 			}
 
 			c[creatable], err =
-				il.l.LookupResource(il.latestRound, address, creatable.Index, creatable.Type)
+				il.l.lookupResource(il.latestRound, address, creatable.Index, creatable.Type)
 			if err != nil {
 				return nil, err
 			}
@@ -359,8 +359,8 @@ func TestResourceCaching(t *testing.T) {
 		assert.Equal(t, basics.Round(0), rnd)
 	}
 	{
-		accountResource, err := ilc.LookupResource(
-			basics.Round(0), address, basics.CreatableIndex(7), basics.AssetCreatable)
+		accountResource, err := ilc.LookupAsset(
+			basics.Round(0), address, basics.AssetIndex(7))
 		require.NoError(t, err)
 		expected := ledgercore.AccountResource{
 			AssetParams: &basics.AssetParams{

--- a/ledger/evalindexer_test.go
+++ b/ledger/evalindexer_test.go
@@ -362,7 +362,7 @@ func TestResourceCaching(t *testing.T) {
 		accountResource, err := ilc.LookupAsset(
 			basics.Round(0), address, basics.AssetIndex(7))
 		require.NoError(t, err)
-		expected := ledgercore.AccountResource{
+		expected := ledgercore.AssetResource{
 			AssetParams: &basics.AssetParams{
 				Total: 8,
 			},

--- a/ledger/internal/appcow_test.go
+++ b/ledger/internal/appcow_test.go
@@ -971,7 +971,7 @@ func TestApplyStorageDelta(t *testing.T) {
 		}},
 	)
 	baseCow := makeRoundCowBase(nil, 0, 0, 0, config.ConsensusParams{})
-	baseCow.updateAppResourceCache(ledgercore.AccountApp{Address: addr, App: 1}, ledgercore.AccountResource{})
+	baseCow.updateAppResourceCache(ledgercore.AccountApp{Address: addr, App: 1}, ledgercore.AppResource{})
 	cow.lookupParent = baseCow
 
 	err := applyStorageDelta(cow, addr, storagePtr{1, true}, &sd)

--- a/ledger/internal/eval.go
+++ b/ledger/internal/eval.go
@@ -42,7 +42,8 @@ type LedgerForCowBase interface {
 	BlockHdr(basics.Round) (bookkeeping.BlockHeader, error)
 	CheckDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, ledgercore.Txlease) error
 	LookupWithoutRewards(basics.Round, basics.Address) (ledgercore.AccountData, basics.Round, error)
-	LookupResource(basics.Round, basics.Address, basics.CreatableIndex, basics.CreatableType) (ledgercore.AccountResource, error)
+	LookupAsset(basics.Round, basics.Address, basics.AssetIndex) (ledgercore.AssetResource, error)
+	LookupApplication(basics.Round, basics.Address, basics.AppIndex) (ledgercore.AppResource, error)
 	GetCreatorForRound(basics.Round, basics.CreatableIndex, basics.CreatableType) (basics.Address, bool, error)
 }
 
@@ -182,7 +183,7 @@ func (x *roundCowBase) lookup(addr basics.Address) (ledgercore.AccountData, erro
 	return ad, err
 }
 
-func (x *roundCowBase) updateAssetResourceCache(aa ledgercore.AccountAsset, r ledgercore.AccountResource) {
+func (x *roundCowBase) updateAssetResourceCache(aa ledgercore.AccountAsset, r ledgercore.AssetResource) {
 	// cache AssetParams and AssetHolding returned by LookupResource
 	if r.AssetParams == nil {
 		x.assetParams[aa] = cachedAssetParams{exists: false}
@@ -196,7 +197,7 @@ func (x *roundCowBase) updateAssetResourceCache(aa ledgercore.AccountAsset, r le
 	}
 }
 
-func (x *roundCowBase) updateAppResourceCache(aa ledgercore.AccountApp, r ledgercore.AccountResource) {
+func (x *roundCowBase) updateAppResourceCache(aa ledgercore.AccountApp, r ledgercore.AppResource) {
 	// cache AppParams and AppLocalState returned by LookupResource
 	if r.AppParams == nil {
 		x.appParams[aa] = cachedAppParams{exists: false}
@@ -223,7 +224,7 @@ func (x *roundCowBase) lookupAppParams(addr basics.Address, aidx basics.AppIndex
 		return ledgercore.AppParamsDelta{}, false, fmt.Errorf("lookupAppParams couldn't find addr %s aidx %d in cache: %w", addr.String(), aidx, ErrNotInCowCache)
 	}
 
-	resourceData, err := x.l.LookupResource(x.rnd, addr, basics.CreatableIndex(aidx), basics.AppCreatable)
+	resourceData, err := x.l.LookupApplication(x.rnd, addr, aidx)
 	if err != nil {
 		return ledgercore.AppParamsDelta{}, false, err
 	}
@@ -249,7 +250,7 @@ func (x *roundCowBase) lookupAssetParams(addr basics.Address, aidx basics.AssetI
 		return ledgercore.AssetParamsDelta{}, false, fmt.Errorf("lookupAssetParams couldn't find addr %s aidx %d in cache: %w", addr.String(), aidx, ErrNotInCowCache)
 	}
 
-	resourceData, err := x.l.LookupResource(x.rnd, addr, basics.CreatableIndex(aidx), basics.AssetCreatable)
+	resourceData, err := x.l.LookupAsset(x.rnd, addr, aidx)
 	if err != nil {
 		return ledgercore.AssetParamsDelta{}, false, err
 	}
@@ -275,7 +276,7 @@ func (x *roundCowBase) lookupAppLocalState(addr basics.Address, aidx basics.AppI
 		return ledgercore.AppLocalStateDelta{}, false, fmt.Errorf("lookupAppLocalState couldn't find addr %s aidx %d in cache: %w", addr.String(), aidx, ErrNotInCowCache)
 	}
 
-	resourceData, err := x.l.LookupResource(x.rnd, addr, basics.CreatableIndex(aidx), basics.AppCreatable)
+	resourceData, err := x.l.LookupApplication(x.rnd, addr, aidx)
 	if err != nil {
 		return ledgercore.AppLocalStateDelta{}, false, err
 	}
@@ -301,7 +302,7 @@ func (x *roundCowBase) lookupAssetHolding(addr basics.Address, aidx basics.Asset
 		return ledgercore.AssetHoldingDelta{}, false, fmt.Errorf("lookupAssetHolding couldn't find addr %s aidx %d in cache: %w", addr.String(), aidx, ErrNotInCowCache)
 	}
 
-	resourceData, err := x.l.LookupResource(x.rnd, addr, basics.CreatableIndex(aidx), basics.AssetCreatable)
+	resourceData, err := x.l.LookupAsset(x.rnd, addr, aidx)
 	if err != nil {
 		return ledgercore.AssetHoldingDelta{}, false, err
 	}

--- a/ledger/internal/eval_test.go
+++ b/ledger/internal/eval_test.go
@@ -529,38 +529,31 @@ func (ledger *evalTestLedger) LookupWithoutRewards(rnd basics.Round, addr basics
 }
 
 func (ledger *evalTestLedger) LookupApplication(rnd basics.Round, addr basics.Address, aidx basics.AppIndex) (ledgercore.AppResource, error) {
-	r, err := ledger.lookupResource(rnd, addr, basics.CreatableIndex(aidx), basics.AppCreatable)
-	return ledgercore.AppResource{AppParams: r.AppParams, AppLocalState: r.AppLocalState}, err
-}
-
-func (ledger *evalTestLedger) LookupAsset(rnd basics.Round, addr basics.Address, aidx basics.AssetIndex) (ledgercore.AssetResource, error) {
-	r, err := ledger.lookupResource(rnd, addr, basics.CreatableIndex(aidx), basics.AssetCreatable)
-	return ledgercore.AssetResource{AssetParams: r.AssetParams, AssetHolding: r.AssetHolding}, err
-}
-
-// lookupResource loads resources the requested round rnd.
-func (ledger *evalTestLedger) lookupResource(rnd basics.Round, addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.AccountResource, error) {
-	res := ledgercore.AccountResource{}
+	res := ledgercore.AppResource{}
 	ad, ok := ledger.roundBalances[rnd][addr]
 	if !ok {
 		return res, fmt.Errorf("no such account %s", addr.String())
 	}
-	if ctype == basics.AppCreatable {
-		if params, ok := ad.AppParams[basics.AppIndex(cidx)]; ok {
-			res.AppParams = &params
-		}
-		if ls, ok := ad.AppLocalStates[basics.AppIndex(cidx)]; ok {
-			res.AppLocalState = &ls
-		}
-	} else if ctype == basics.AssetCreatable {
-		if params, ok := ad.AssetParams[basics.AssetIndex(cidx)]; ok {
-			res.AssetParams = &params
-		}
-		if h, ok := ad.Assets[basics.AssetIndex(cidx)]; ok {
-			res.AssetHolding = &h
-		}
-	} else {
-		return res, fmt.Errorf("unknown ctype %d", ctype)
+	if params, ok := ad.AppParams[aidx]; ok {
+		res.AppParams = &params
+	}
+	if ls, ok := ad.AppLocalStates[aidx]; ok {
+		res.AppLocalState = &ls
+	}
+	return res, nil
+}
+
+func (ledger *evalTestLedger) LookupAsset(rnd basics.Round, addr basics.Address, aidx basics.AssetIndex) (ledgercore.AssetResource, error) {
+	res := ledgercore.AssetResource{}
+	ad, ok := ledger.roundBalances[rnd][addr]
+	if !ok {
+		return res, fmt.Errorf("no such account %s", addr.String())
+	}
+	if params, ok := ad.AssetParams[aidx]; ok {
+		res.AssetParams = &params
+	}
+	if h, ok := ad.Assets[aidx]; ok {
+		res.AssetHolding = &h
 	}
 	return res, nil
 }
@@ -736,17 +729,11 @@ func (l *testCowBaseLedger) LookupWithoutRewards(basics.Round, basics.Address) (
 }
 
 func (l *testCowBaseLedger) LookupApplication(rnd basics.Round, addr basics.Address, aidx basics.AppIndex) (ledgercore.AppResource, error) {
-	r, err := l.lookupResource(rnd, addr, basics.CreatableIndex(aidx), basics.AppCreatable)
-	return ledgercore.AppResource{AppParams: r.AppParams, AppLocalState: r.AppLocalState}, err
+	return ledgercore.AppResource{}, errors.New("not implemented")
 }
 
 func (l *testCowBaseLedger) LookupAsset(rnd basics.Round, addr basics.Address, aidx basics.AssetIndex) (ledgercore.AssetResource, error) {
-	r, err := l.lookupResource(rnd, addr, basics.CreatableIndex(aidx), basics.AssetCreatable)
-	return ledgercore.AssetResource{AssetParams: r.AssetParams, AssetHolding: r.AssetHolding}, err
-}
-
-func (l *testCowBaseLedger) lookupResource(rnd basics.Round, addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.AccountResource, error) {
-	return ledgercore.AccountResource{}, errors.New("not implemented")
+	return ledgercore.AssetResource{}, errors.New("not implemented")
 }
 
 func (l *testCowBaseLedger) GetCreatorForRound(_ basics.Round, cindex basics.CreatableIndex, ctype basics.CreatableType) (basics.Address, bool, error) {

--- a/ledger/internal/eval_test.go
+++ b/ledger/internal/eval_test.go
@@ -528,8 +528,18 @@ func (ledger *evalTestLedger) LookupWithoutRewards(rnd basics.Round, addr basics
 	return ledgercore.ToAccountData(ad), rnd, nil
 }
 
-// LookupResource loads resources the requested round rnd.
-func (ledger *evalTestLedger) LookupResource(rnd basics.Round, addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.AccountResource, error) {
+func (ledger *evalTestLedger) LookupApplication(rnd basics.Round, addr basics.Address, aidx basics.AppIndex) (ledgercore.AppResource, error) {
+	r, err := ledger.lookupResource(rnd, addr, basics.CreatableIndex(aidx), basics.AppCreatable)
+	return ledgercore.AppResource{AppParams: r.AppParams, AppLocalState: r.AppLocalState}, err
+}
+
+func (ledger *evalTestLedger) LookupAsset(rnd basics.Round, addr basics.Address, aidx basics.AssetIndex) (ledgercore.AssetResource, error) {
+	r, err := ledger.lookupResource(rnd, addr, basics.CreatableIndex(aidx), basics.AssetCreatable)
+	return ledgercore.AssetResource{AssetParams: r.AssetParams, AssetHolding: r.AssetHolding}, err
+}
+
+// lookupResource loads resources the requested round rnd.
+func (ledger *evalTestLedger) lookupResource(rnd basics.Round, addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.AccountResource, error) {
 	res := ledgercore.AccountResource{}
 	ad, ok := ledger.roundBalances[rnd][addr]
 	if !ok {
@@ -725,7 +735,17 @@ func (l *testCowBaseLedger) LookupWithoutRewards(basics.Round, basics.Address) (
 	return ledgercore.AccountData{}, basics.Round(0), errors.New("not implemented")
 }
 
-func (l *testCowBaseLedger) LookupResource(rnd basics.Round, addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.AccountResource, error) {
+func (l *testCowBaseLedger) LookupApplication(rnd basics.Round, addr basics.Address, aidx basics.AppIndex) (ledgercore.AppResource, error) {
+	r, err := l.lookupResource(rnd, addr, basics.CreatableIndex(aidx), basics.AppCreatable)
+	return ledgercore.AppResource{AppParams: r.AppParams, AppLocalState: r.AppLocalState}, err
+}
+
+func (l *testCowBaseLedger) LookupAsset(rnd basics.Round, addr basics.Address, aidx basics.AssetIndex) (ledgercore.AssetResource, error) {
+	r, err := l.lookupResource(rnd, addr, basics.CreatableIndex(aidx), basics.AssetCreatable)
+	return ledgercore.AssetResource{AssetParams: r.AssetParams, AssetHolding: r.AssetHolding}, err
+}
+
+func (l *testCowBaseLedger) lookupResource(rnd basics.Round, addr basics.Address, cidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.AccountResource, error) {
 	return ledgercore.AccountResource{}, errors.New("not implemented")
 }
 

--- a/ledger/internal/evalprefetcher.go
+++ b/ledger/internal/evalprefetcher.go
@@ -508,7 +508,17 @@ func (p *accountPrefetcher) asyncPrefetchRoutine(queue *preloaderTaskQueue, task
 			task.address = &creator
 		}
 		var resource ledgercore.AccountResource
-		resource, err = p.ledger.LookupResource(p.rnd, *task.address, task.creatableIndex, task.creatableType)
+		if task.creatableType == basics.AppCreatable {
+			var appResource ledgercore.AppResource
+			appResource, err = p.ledger.LookupApplication(p.rnd, *task.address, basics.AppIndex(task.creatableIndex))
+			resource.AppParams = appResource.AppParams
+			resource.AppLocalState = appResource.AppLocalState
+		} else {
+			var assetResource ledgercore.AssetResource
+			assetResource, err = p.ledger.LookupAsset(p.rnd, *task.address, basics.AssetIndex(task.creatableIndex))
+			resource.AssetParams = assetResource.AssetParams
+			resource.AssetHolding = assetResource.AssetHolding
+		}
 		if err != nil {
 			// there was an error loading that entry.
 			break

--- a/ledger/internal/evalprefetcher_test.go
+++ b/ledger/internal/evalprefetcher_test.go
@@ -50,8 +50,11 @@ func (l *prefetcherTestLedger) LookupWithoutRewards(_ basics.Round, addr basics.
 	}
 	return ledgercore.AccountData{}, l.round, nil
 }
-func (l *prefetcherTestLedger) LookupResource(basics.Round, basics.Address, basics.CreatableIndex, basics.CreatableType) (ledgercore.AccountResource, error) {
-	return ledgercore.AccountResource{}, nil
+func (l *prefetcherTestLedger) LookupApplication(rnd basics.Round, addr basics.Address, aidx basics.AppIndex) (ledgercore.AppResource, error) {
+	return ledgercore.AppResource{}, nil
+}
+func (l *prefetcherTestLedger) LookupAsset(rnd basics.Round, addr basics.Address, aidx basics.AssetIndex) (ledgercore.AssetResource, error) {
+	return ledgercore.AssetResource{}, nil
 }
 func (l *prefetcherTestLedger) GetCreatorForRound(_ basics.Round, cidx basics.CreatableIndex, _ basics.CreatableType) (basics.Address, bool, error) {
 	if addr, has := l.creators[cidx]; has {

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -495,8 +495,20 @@ func (l *Ledger) LookupAccount(round basics.Round, addr basics.Address) (data le
 	return data, rnd, withoutRewards, nil
 }
 
-// LookupResource loads a resource that matches the request parameters from the accounts update
-func (l *Ledger) LookupResource(rnd basics.Round, addr basics.Address, aidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.AccountResource, error) {
+// LookupApplication loads an application resource that matches the request parameters from the ledger.
+func (l *Ledger) LookupApplication(rnd basics.Round, addr basics.Address, aidx basics.AppIndex) (ledgercore.AppResource, error) {
+	r, err := l.lookupResource(rnd, addr, basics.CreatableIndex(aidx), basics.AppCreatable)
+	return ledgercore.AppResource{AppParams: r.AppParams, AppLocalState: r.AppLocalState}, err
+}
+
+// LookupAsset loads an asset resource that matches the request parameters from the ledger.
+func (l *Ledger) LookupAsset(rnd basics.Round, addr basics.Address, aidx basics.AssetIndex) (ledgercore.AssetResource, error) {
+	r, err := l.lookupResource(rnd, addr, basics.CreatableIndex(aidx), basics.AssetCreatable)
+	return ledgercore.AssetResource{AssetParams: r.AssetParams, AssetHolding: r.AssetHolding}, err
+}
+
+// lookupResource loads a resource that matches the request parameters from the accounts update
+func (l *Ledger) lookupResource(rnd basics.Round, addr basics.Address, aidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.AccountResource, error) {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()
 

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -19,13 +19,14 @@ package ledger
 import (
 	"context"
 	"fmt"
-	"github.com/algorand/go-algorand/data/account"
-	"github.com/algorand/go-algorand/util/db"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"runtime/pprof"
 	"testing"
+
+	"github.com/algorand/go-algorand/data/account"
+	"github.com/algorand/go-algorand/util/db"
 
 	"github.com/stretchr/testify/require"
 
@@ -801,7 +802,7 @@ int 1
 	var appIdx basics.AppIndex = 1
 
 	rnd := l.Latest()
-	acctRes, err := l.LookupResource(rnd, creator, basics.CreatableIndex(appIdx), basics.AppCreatable)
+	acctRes, err := l.LookupApplication(rnd, creator, appIdx)
 	a.NoError(err)
 	a.Equal(basics.TealValue{Type: basics.TealUintType, Uint: 1}, acctRes.AppParams.GlobalState["counter"])
 
@@ -832,17 +833,17 @@ int 1
 	a.NoError(l.appendUnvalidatedTx(t, initAccounts, initSecrets, appcall, ad))
 
 	rnd = l.Latest()
-	acctworRes, err := l.LookupResource(rnd, creator, basics.CreatableIndex(appIdx), basics.AppCreatable)
+	acctworRes, err := l.LookupApplication(rnd, creator, appIdx)
 	a.NoError(err)
 	a.Equal(basics.TealValue{Type: basics.TealUintType, Uint: 2}, acctworRes.AppParams.GlobalState["counter"])
 
 	addEmptyValidatedBlock(t, l, initAccounts)
 
-	acctworRes, err = l.LookupResource(l.Latest()-1, creator, basics.CreatableIndex(appIdx), basics.AppCreatable)
+	acctworRes, err = l.LookupApplication(l.Latest()-1, creator, appIdx)
 	a.NoError(err)
 	a.Equal(basics.TealValue{Type: basics.TealUintType, Uint: 2}, acctworRes.AppParams.GlobalState["counter"])
 
-	acctRes, err = l.LookupResource(rnd, user, basics.CreatableIndex(appIdx), basics.AppCreatable)
+	acctRes, err = l.LookupApplication(rnd, user, appIdx)
 	a.NoError(err)
 	a.Equal(basics.TealValue{Type: basics.TealUintType, Uint: 1}, acctRes.AppLocalState.KeyValue["counter"])
 }
@@ -925,7 +926,7 @@ int 1                   // [1]
 	var appIdx basics.AppIndex = 1
 
 	rnd := l.Latest()
-	acctRes, err := l.LookupResource(rnd, creator, basics.CreatableIndex(appIdx), basics.AppCreatable)
+	acctRes, err := l.LookupApplication(rnd, creator, appIdx)
 	a.NoError(err)
 	a.Equal(basics.TealValue{Type: basics.TealUintType, Uint: uint64(value)}, acctRes.AppParams.GlobalState["key"])
 
@@ -1002,7 +1003,7 @@ int 1                   // [1]
 
 			expected := uint64(base + value1 + value2)
 			rnd = l.Latest()
-			acctworRes, err := l.LookupResource(rnd, creator, basics.CreatableIndex(appIdx), basics.AppCreatable)
+			acctworRes, err := l.LookupApplication(rnd, creator, appIdx)
 			a.NoError(err)
 			a.Equal(basics.TealValue{Type: basics.TealUintType, Uint: expected}, acctworRes.AppParams.GlobalState["key"])
 		})

--- a/ledger/ledgercore/accountresource.go
+++ b/ledger/ledgercore/accountresource.go
@@ -28,6 +28,18 @@ type AccountResource struct {
 	AppParams     *basics.AppParams
 }
 
+// AssetResource used to retrieve a generic asset resource information from the data tier
+type AssetResource struct {
+	AssetParams  *basics.AssetParams
+	AssetHolding *basics.AssetHolding
+}
+
+// AppResource used to retrieve a generic app resource information from the data tier
+type AppResource struct {
+	AppLocalState *basics.AppLocalState
+	AppParams     *basics.AppParams
+}
+
 // AssignAccountResourceToAccountData assignes the Asset/App params/holdings contained
 // in the AccountResource to the given basics.AccountData, creating maps if necessary.
 func AssignAccountResourceToAccountData(cindex basics.CreatableIndex, resource AccountResource, ad *basics.AccountData) {


### PR DESCRIPTION
## Summary

This replaces the various Ledger interfaces' `LookupResource` method with two more specific `LookupApplication` and `LookupAsset` methods. Following up on code review feedback from #3652.

## Test Plan

Existing tests should pass, including the ones that implement their own mock ledger.