### PR TITLE
agreement: fix fuzzer test NetworkFacade Clock implementation

### DIFF
--- a/agreement/fuzzer/networkFacade_test.go
+++ b/agreement/fuzzer/networkFacade_test.go
@@ -372,6 +372,9 @@ func (n *NetworkFacade) Rezero() {
 	}
 }
 
+// Since implements the Clock interface.
+func (n *NetworkFacade) Since() time.Duration { return 0 }
+
 func (n *NetworkFacade) TimeoutAt(d time.Duration) <-chan time.Time {
 	defer n.timeoutAtInitOnce.Do(func() {
 		n.timeoutAtInitWait.Done()


### PR DESCRIPTION
## Summary

There was one Clock implementation not updated in #3703 in the agreement fuzzer testing package's NetworkFacade type. This updates it to fully implement the Clock interface.