### PR TITLE
Update e2e_subs docs to reflect issue for process improvement

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -55,6 +55,6 @@ Tests in the `e2e_subs/serial` directory are executed serially instead of in par
 
 ### Updating Indexer E2E test input
 
-Indexer `make e2e` runs tests using the output of go-algorand `e2e_subs` tests as input.  The process for making new inputs available via S3 is manual.
+Indexer `make e2e` runs tests using the output of go-algorand `e2e_subs` tests as input.  Until [https://github.com/algorand/go-algorand-internal/issues/193](https://github.com/algorand/go-algorand-internal/issues/193) is closed, the process for making new inputs available via S3 is manual.
 
 Test modifiers _must_ make a best-effort attempt to remember to upload new artifacts to S3 when modifying tests.  Here's a step-by-step process overview:  [https://github.com/algorand/indexer/blob/develop/misc/README.md](https://github.com/algorand/indexer/blob/develop/misc/README.md).


### PR DESCRIPTION
## Summary

Update `e2e_subs` to leave pointer to proposed process improvement:  https://github.com/algorand/go-algorand-internal/issues/1933.  Link provides the reader context and makes it easier to identify where subsequent doc updates are needed.

## Test Plan

N/A