### PR TITLE
REST client: always set Exclude value in accountInformationParams

### DIFF
--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -422,7 +422,7 @@ func (client RestClient) AccountInformation(address string) (response v1.Account
 func (client RestClient) AccountInformationV2(address string, includeCreatables bool) (response generatedV2.Account, err error) {
 	var infoParams accountInformationParams
 	if includeCreatables {
-		infoParams = accountInformationParams{Exclude: "", Format: "json"}
+		infoParams = accountInformationParams{Exclude: "none", Format: "json"}
 	} else {
 		infoParams = accountInformationParams{Exclude: "all", Format: "json"}
 	}

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -687,7 +687,7 @@ func (c *Client) RawAccountApplicationInformation(accountAddress string, applica
 	return
 }
 
-// AccountAssetInformation gets account information about a given app.
+// AccountAssetInformation gets account information about a given asset.
 func (c *Client) AccountAssetInformation(accountAddress string, assetID uint64) (resp generatedV2.AccountAssetResponse, err error) {
 	algod, err := c.ensureAlgodClient()
 	if err == nil {
@@ -696,7 +696,7 @@ func (c *Client) AccountAssetInformation(accountAddress string, assetID uint64) 
 	return
 }
 
-// RawAccountAssetInformation gets account information about a given app.
+// RawAccountAssetInformation gets account information about a given asset.
 func (c *Client) RawAccountAssetInformation(accountAddress string, assetID uint64) (accountResource modelV2.AccountAssetModel, err error) {
 	algod, err := c.ensureAlgodClient()
 	if err == nil {


### PR DESCRIPTION
## Summary

Small tweak, this sets the "exclude" parameter for both all/none cases used by the algod RestClient.AccountInformationV2 method, rather than an empty string for one of the cases.

## Test Plan

Existing tests should pass.