### PR TITLE
REST API: dryrun scratch slot type fix

### DIFF
--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -135,13 +135,11 @@ func (ddr *dryrunDebugReceiver) updateScratch() {
 	}
 
 	if any {
-		if ddr.scratchActive == nil {
-			ddr.scratchActive = make([]bool, maxActive, 256)
-		}
-		for i := len(ddr.scratchActive); i <= maxActive; i++ {
+		ddr.scratchActive = make([]bool, maxActive+1, 256)
+		for i := 0; i <= maxActive; i++ {
 			sv := (*ddr.history[lasti].Scratch)[i]
 			active := sv.Type != uint64(basics.TealUintType) || sv.Uint != 0
-			ddr.scratchActive = append(ddr.scratchActive, active)
+			ddr.scratchActive[i] = active
 		}
 	} else {
 		if ddr.scratchActive != nil {
@@ -152,7 +150,7 @@ func (ddr *dryrunDebugReceiver) updateScratch() {
 		}
 	}
 
-	scratchlen := maxActive
+	scratchlen := maxActive + 1
 	if len(ddr.scratchActive) > scratchlen {
 		scratchlen = len(ddr.scratchActive)
 	}

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -126,8 +126,12 @@ func (ddr *dryrunDebugReceiver) updateScratch() {
 		return
 	}
 
-	ddr.scratchActive = make([]bool, 256)
+	if ddr.scratchActive == nil {
+		ddr.scratchActive = make([]bool, 256)
+	}
+
 	for i, sv := range *ddr.history[lasti].Scratch {
+		ddr.scratchActive[i] = false
 		if sv.Type != uint64(basics.TealUintType) || sv.Uint != 0 {
 			ddr.scratchActive[i] = true
 			maxActive = i

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -136,7 +136,7 @@ func (ddr *dryrunDebugReceiver) updateScratch() {
 
 	if any {
 		if ddr.scratchActive == nil {
-			ddr.scratchActive = make([]bool, maxActive+1, 256)
+			ddr.scratchActive = make([]bool, maxActive, 256)
 		}
 		for i := len(ddr.scratchActive); i <= maxActive; i++ {
 			sv := (*ddr.history[lasti].Scratch)[i]
@@ -152,7 +152,7 @@ func (ddr *dryrunDebugReceiver) updateScratch() {
 		}
 	}
 
-	scratchlen := maxActive + 1
+	scratchlen := maxActive
 	if len(ddr.scratchActive) > scratchlen {
 		scratchlen = len(ddr.scratchActive)
 	}

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -141,9 +141,8 @@ func (ddr *dryrunDebugReceiver) updateScratch() {
 
 	*ddr.history[lasti].Scratch = (*ddr.history[lasti].Scratch)[:maxActive+1]
 	for i := range *ddr.history[lasti].Scratch {
-		// TODO: Still not sure why we need this?
 		if !ddr.scratchActive[i] {
-			(*ddr.history[lasti].Scratch)[i] = generated.TealValue{}
+			(*ddr.history[lasti].Scratch)[i].Type = 0
 		}
 	}
 }

--- a/daemon/algod/api/server/v2/dryrun_test.go
+++ b/daemon/algod/api/server/v2/dryrun_test.go
@@ -404,7 +404,7 @@ func checkAppCallScratchType(t *testing.T, response *generated.DryrunResponse, s
 				continue
 			}
 
-			if len(*traceLine.Scratch) >= slot {
+			if len(*traceLine.Scratch) > slot {
 				assert.Equal(t, tt, basics.TealType((*traceLine.Scratch)[slot].Type))
 			}
 		}
@@ -1556,6 +1556,12 @@ txn GroupIndex
 int 3
 ==
 bnz checkgload
+pushbytes "def"
+store 251
+pushint 123
+store 252
+pushbytes "abc"
+store 253
 txn GroupIndex
 store 254
 b exit
@@ -1611,7 +1617,13 @@ int 1`)
 	}
 	var response generated.DryrunResponse
 	doDryrunRequest(&dr, &response)
+
 	checkAppCallScratchType(t, &response, 254, basics.TealUintType)
+	checkAppCallScratchType(t, &response, 253, basics.TealBytesType)
+	checkAppCallScratchType(t, &response, 252, basics.TealUintType)
+	checkAppCallScratchType(t, &response, 251, basics.TealBytesType)
+	checkAppCallScratchType(t, &response, 250, basics.TealType(0))
+
 	checkAppCallPass(t, &response)
 	if t.Failed() {
 		logResponse(t, &response)

--- a/daemon/algod/api/server/v2/dryrun_test.go
+++ b/daemon/algod/api/server/v2/dryrun_test.go
@@ -400,18 +400,17 @@ type expectedSlotType struct {
 
 func checkAppCallScratchType(t *testing.T, response *generated.DryrunResponse, txnIdx int, expected []expectedSlotType) {
 	txn := response.Txns[txnIdx]
+	// We should have a trace
 	assert.NotNil(t, txn.AppCallTrace)
-	// First one should be nil
+	// The first stack entry should be nil since we haven't stored anything in scratch yet
 	assert.Nil(t, (*txn.AppCallTrace)[0].Scratch)
-
-	// Last one should be the length of the max scratch
+	// Last one should be not nil, we should have some number of scratch vars
 	traceLine := (*txn.AppCallTrace)[len(*txn.AppCallTrace)-1]
 	assert.NotNil(t, traceLine.Scratch)
-
 	for _, exp := range expected {
+		// The TealType at the given slot index should match what we expect
 		assert.Equal(t, exp.tt, basics.TealType((*traceLine.Scratch)[exp.slot].Type))
 	}
-
 }
 
 func TestDryrunGlobal1(t *testing.T) {

--- a/daemon/algod/api/server/v2/dryrun_test.go
+++ b/daemon/algod/api/server/v2/dryrun_test.go
@@ -393,6 +393,24 @@ func checkAppCallPass(t *testing.T, response *generated.DryrunResponse) {
 	}
 }
 
+func checkAppCallScratchType(t *testing.T, response *generated.DryrunResponse, slot int, tt basics.TealType) {
+	for _, txn := range response.Txns {
+		if txn.AppCallTrace == nil {
+			continue
+		}
+
+		for _, traceLine := range *txn.AppCallTrace {
+			if traceLine.Scratch == nil {
+				continue
+			}
+
+			if len(*traceLine.Scratch) >= slot {
+				assert.Equal(t, tt, basics.TealType((*traceLine.Scratch)[slot].Type))
+			}
+		}
+	}
+}
+
 func TestDryrunGlobal1(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	// {"txns":[{"lsig":{"l":"AiABASI="},"txn":{}}]}
@@ -1593,6 +1611,7 @@ int 1`)
 	}
 	var response generated.DryrunResponse
 	doDryrunRequest(&dr, &response)
+	checkAppCallScratchType(t, &response, 254, basics.TealUintType)
 	checkAppCallPass(t, &response)
 	if t.Failed() {
 		logResponse(t, &response)

--- a/daemon/algod/api/server/v2/dryrun_test.go
+++ b/daemon/algod/api/server/v2/dryrun_test.go
@@ -408,6 +408,7 @@ func checkAppCallScratchType(t *testing.T, response *generated.DryrunResponse, s
 				assert.Equal(t, tt, basics.TealType((*traceLine.Scratch)[slot].Type))
 			}
 		}
+
 	}
 }
 
@@ -1556,6 +1557,8 @@ txn GroupIndex
 int 3
 ==
 bnz checkgload
+pushint 123
+store 0
 pushbytes "def"
 store 251
 pushint 123
@@ -1618,11 +1621,12 @@ int 1`)
 	var response generated.DryrunResponse
 	doDryrunRequest(&dr, &response)
 
-	checkAppCallScratchType(t, &response, 254, basics.TealUintType)
-	checkAppCallScratchType(t, &response, 253, basics.TealBytesType)
-	checkAppCallScratchType(t, &response, 252, basics.TealUintType)
+	checkAppCallScratchType(t, &response, 0, basics.TealUintType)
+	checkAppCallScratchType(t, &response, 1, basics.TealType(0))
 	checkAppCallScratchType(t, &response, 251, basics.TealBytesType)
-	checkAppCallScratchType(t, &response, 250, basics.TealType(0))
+	checkAppCallScratchType(t, &response, 252, basics.TealUintType)
+	checkAppCallScratchType(t, &response, 253, basics.TealBytesType)
+	checkAppCallScratchType(t, &response, 254, basics.TealUintType)
 
 	checkAppCallPass(t, &response)
 	if t.Failed() {


### PR DESCRIPTION

## Summary

When performing a dryrun, if the program uses scratch space there is some logic to determine which slots are active and if inactive the type is set to 0.  

There seems to be an off-by-one bug where the types are offset by one element in the scratch slot array. This was causing output like:
```json
  "scratch": [
                        {
                            "bytes": "",
                            "type": 0,
                            "uint": 0
                        },
                        {
                            "bytes": "",
                            "type": 0,
                            "uint": 0
                        },
                        {
                            "bytes": "",
                            "type": 0,
                            "uint": 0
                        },
                        {
                            "bytes": "",
                            "type": 0,
                            "uint": 0
                        },
                        {
                            "bytes": "SW4gYXBwIGlkIDIzIHdoaWNoIHdhcyBjYWxsZWQgd2l0aCBhc3NldCBuYW1lIG9rYXk=",
                            "type": 0,
                            "uint": 0
                        },
                        {
                            "bytes": "SW4gYXBwIGlkIDIzIHdoaWNoIHdhcyBjYWxsZWQgd2l0aCBhc3NldCBuYW1lIG9rYXk=",
                            "type": 1,
                            "uint": 0
                        }
                    ],
```

Note that the N-1 element has its type set to 0.


## Test Plan

Modified existing test, without the change in the dryrun.go file, the test fails.

