### PR TITLE
prefetcher: ensure the groupTask.incompleteCount is allocated on a 64-bit aligned address

### DIFF
--- a/ledger/internal/prefetcher/prefetcher.go
+++ b/ledger/internal/prefetcher/prefetcher.go
@@ -100,6 +100,12 @@ func PrefetchAccounts(ctx context.Context, l Ledger, rnd basics.Round, groups []
 
 // groupTask helps to organize the account loading for each transaction group.
 type groupTask struct {
+	// incompleteCount is the number of resources+balances still pending and need to be loaded
+	// this variable is used by as atomic variable to synchronize the readiness of the group taks.
+	// in order to ensure support on 32-bit platforms, this variable need to be 64-bit aligned.
+	incompleteCount int64
+	// the group task index - aligns with the index of the transaction group in the
+	// provided groups slice.
 	groupTaskIndex int
 	// balances contains the loaded balances each transaction group have
 	balances []LoadedAccountDataEntry
@@ -109,9 +115,6 @@ type groupTask struct {
 	resources []LoadedResourcesEntry
 	// resourcesCount is the number of resources that nees to be loaded per transaction group
 	resourcesCount int
-	// incompleteCount is the number of resources+balances still pending and need to be loaded
-	// this variable is used by as atomic variable to synchronize the readiness of the group taks.
-	incompleteCount int64
 }
 
 // preloaderTask manage the loading of a single element, whether it's a resource or an account address.

--- a/ledger/internal/prefetcher/prefetcher_whitebox_test.go
+++ b/ledger/internal/prefetcher/prefetcher_whitebox_test.go
@@ -24,7 +24,7 @@ func BenchmarkChannelWrites(b *testing.B) {
 	b.Run("groupTaskDone", func(b *testing.B) {
 		c := make(chan groupTaskDone, b.N)
 		for i := 0; i < b.N; i++ {
-			c <- groupTaskDone{groupIdx: i}
+			c <- groupTaskDone{groupIdx: int64(i)}
 		}
 	})
 


### PR DESCRIPTION
## Summary

prefetcher: ensure the groupTask.incompleteCount is allocated on a 64-bit aligned address.

This is required in order to avoid the following on a ARM32:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xb541efb0]

goroutine 4220 [running]:
runtime/internal/atomic.goLoad64(0x8ae33be4, 0xb67e0fec, 0x8cf54500)
	runtime/internal/atomic/atomic_arm.go:131 +0x1c
github.com/algorand/go-algorand/ledger/internal.(*accountPrefetcher).prefetch(0x8cf54500, 0xb68023f0, 0x8cf532c0)
	github.com/algorand/go-algorand/ledger/internal/evalprefetcher.go:384 +0x1268
created by github.com/algorand/go-algorand/ledger/internal.prefetchAccounts
	github.com/algorand/go-algorand/ledger/internal/evalprefetcher.go:87 +0x128
```

## Test Plan

Test manually.