### PR TITLE
crypto: call batchVerificationImpl from OneTimeSignatureVerifier.Verify

### DIFF
--- a/crypto/onetimesig.go
+++ b/crypto/onetimesig.go
@@ -319,6 +319,14 @@ func (v OneTimeSignatureVerifier) Verify(id OneTimeSignatureIdentifier, message 
 		Batch:    id.Batch,
 	}
 
+	if batchVersionCompatible {
+		return batchVerificationImpl(
+			[][]byte{HashRep(batchID), HashRep(offsetID), HashRep(message)},
+			[]PublicKey{PublicKey(v), PublicKey(batchID.SubKeyPK), PublicKey(offsetID.SubKeyPK)},
+			[]Signature{Signature(sig.PK2Sig), Signature(sig.PK1Sig), Signature(sig.Sig)},
+		)
+	}
+
 	if !ed25519Verify(ed25519PublicKey(v), HashRep(batchID), sig.PK2Sig, batchVersionCompatible) {
 		return false
 	}


### PR DESCRIPTION
## Summary

The ed25519 batch verification implementation in https://github.com/algorand/go-algorand/pull/3031 provides a performance improvement for validating multiple signatures (such as multiple transaction signatures). Since each OneTimeSignature used by agreement votes is actually 3 ed25519 signatures, this hooks up the verifier to the batch verification implementation, yielding a ~12% performance improvement in the included benchmark on my computer.

## Test Plan

Added benchmark, existing tests should pass.
