### PR TITLE
participation key registry : complete cleanup

### DIFF
--- a/components/mocks/mockParticipationRegistry.go
+++ b/components/mocks/mockParticipationRegistry.go
@@ -19,6 +19,7 @@ package mocks
 import (
 	"time"
 
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/account"
 	"github.com/algorand/go-algorand/data/basics"
 )
@@ -44,7 +45,7 @@ func (m *MockParticipationRegistry) Delete(id account.ParticipationID) error {
 }
 
 // DeleteExpired removes all records from storage which are expired on the given round.
-func (m *MockParticipationRegistry) DeleteExpired(round basics.Round) error {
+func (m *MockParticipationRegistry) DeleteExpired(latestRound basics.Round, agreementProto config.ConsensusParams) error {
 	return nil
 }
 

--- a/data/accountManager.go
+++ b/data/accountManager.go
@@ -18,7 +18,6 @@ package data
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/algorand/go-deadlock"
 
@@ -28,7 +27,6 @@ import (
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/logging/telemetryspec"
-	"github.com/algorand/go-algorand/protocol"
 )
 
 // AccountManager loads and manages accounts for the node
@@ -159,9 +157,7 @@ func (manager *AccountManager) AddParticipation(participation account.PersistedP
 
 // DeleteOldKeys deletes all accounts' ephemeral keys strictly older than the
 // next round needed for each account.
-func (manager *AccountManager) DeleteOldKeys(latestHdr bookkeeping.BlockHeader, ccSigs map[basics.Address]basics.Round, agreementProto config.ConsensusParams) {
-	latestProto := config.Consensus[latestHdr.CurrentProtocol]
-
+func (manager *AccountManager) DeleteOldKeys(latestHdr bookkeeping.BlockHeader, agreementProto config.ConsensusParams) {
 	manager.mu.Lock()
 	pendingItems := make(map[string]<-chan error, len(manager.partKeys))
 
@@ -173,22 +169,6 @@ func (manager *AccountManager) DeleteOldKeys(latestHdr bookkeeping.BlockHeader, 
 	for _, part := range partKeys {
 		// We need a key for round r+1 for agreement.
 		nextRound := latestHdr.Round + 1
-
-		if latestHdr.CompactCert[protocol.CompactCertBasic].CompactCertNextRound > 0 {
-			// We need a key for the next compact cert round.
-			// This would be CompactCertNextRound+1 (+1 because compact
-			// cert code uses the next round's ephemeral key), except
-			// if we already used that key to produce a signature (as
-			// reported in ccSigs).
-			nextCC := latestHdr.CompactCert[protocol.CompactCertBasic].CompactCertNextRound + 1
-			if ccSigs[part.Parent] >= nextCC {
-				nextCC = ccSigs[part.Parent] + basics.Round(latestProto.CompactCertRounds) + 1
-			}
-
-			if nextCC < nextRound {
-				nextRound = nextCC
-			}
-		}
 
 		// we pre-create the reported error string here, so that we won't need to have the participation key object if error is detected.
 		first, last := part.ValidInterval()
@@ -207,10 +187,8 @@ func (manager *AccountManager) DeleteOldKeys(latestHdr bookkeeping.BlockHeader, 
 		}
 	}
 
-	// PKI TODO: This needs to update the partkeys also, see the 'DeleteOldKeys' function above, it's part
-	//       is part of PersistedParticipation, but just calls 'part.Voting.DeleteBeforeFineGrained'
 	// Delete expired records from participation registry.
-	if err := manager.registry.DeleteExpired(latestHdr.Round); err != nil {
+	if err := manager.registry.DeleteExpired(latestHdr.Round, agreementProto); err != nil {
 		manager.log.Warnf("error while deleting expired records from participation registry: %w", err)
 	}
 }
@@ -218,14 +196,6 @@ func (manager *AccountManager) DeleteOldKeys(latestHdr bookkeeping.BlockHeader, 
 // Registry fetches the ParticipationRegistry.
 func (manager *AccountManager) Registry() account.ParticipationRegistry {
 	return manager.registry
-}
-
-// FlushRegistry tells the underlying participation registry to flush it's change cache to the DB.
-func (manager *AccountManager) FlushRegistry(timeout time.Duration) {
-	err := manager.registry.Flush(timeout)
-	if err != nil {
-		manager.log.Warnf("error while flushing the registry: %w", err)
-	}
 }
 
 // Record asynchronously records a participation key usage event.

--- a/node/node.go
+++ b/node/node.go
@@ -57,6 +57,10 @@ import (
 	"github.com/algorand/go-deadlock"
 )
 
+const (
+	participationRegistryFlushMaxWaitDuration = 30 * time.Second
+)
+
 // StatusReport represents the current basic status of the node
 type StatusReport struct {
 	LastRound                          basics.Round
@@ -753,7 +757,7 @@ func (node *AlgorandFullNode) GetPendingTxnsFromPool() ([]transactions.SignedTxn
 // ensureParticipationDB opens or creates a participation DB.
 func ensureParticipationDB(genesisDir string, log logging.Logger) (account.ParticipationRegistry, error) {
 	accessorFile := filepath.Join(genesisDir, config.ParticipationRegistryFilename)
-	accessor, err := db.OpenPair(accessorFile, false)
+	accessor, err := db.OpenErasablePair(accessorFile)
 	if err != nil {
 		return nil, err
 	}
@@ -818,10 +822,7 @@ func (node *AlgorandFullNode) RemoveParticipationKey(partKeyID account.Participa
 		return err
 	}
 
-	// PKI TODO: pick a better timeout, this is just something short. This could also be removed if we change
-	// POST /v2/participation and DELETE /v2/participation to return "202 OK Accepted" instead of waiting and getting
-	// the error message.
-	err = node.accountManager.Registry().Flush(500 * time.Millisecond)
+	err = node.accountManager.Registry().Flush(participationRegistryFlushMaxWaitDuration)
 	if err != nil {
 		return err
 	}
@@ -839,10 +840,7 @@ func (node *AlgorandFullNode) AppendParticipationKeys(partKeyID account.Particip
 		return err
 	}
 
-	// PKI TODO: pick a better timeout, this is just something short. This could also be removed if we change
-	// POST /v2/participation and DELETE /v2/participation to return "202 OK Accepted" instead of waiting and getting
-	// the error message.
-	return node.accountManager.Registry().Flush(500 * time.Millisecond)
+	return node.accountManager.Registry().Flush(participationRegistryFlushMaxWaitDuration)
 }
 
 func createTemporaryParticipationKey(outDir string, partKeyBinary []byte) (string, error) {
@@ -914,10 +912,7 @@ func (node *AlgorandFullNode) InstallParticipationKey(partKeyBinary []byte) (acc
 	// Tell the AccountManager about the Participation (dupes don't matter) so we ignore the return value
 	_ = node.accountManager.AddParticipation(partkey)
 
-	// PKI TODO: pick a better timeout, this is just something short. This could also be removed if we change
-	// POST /v2/participation and DELETE /v2/participation to return "202 OK Accepted" instead of waiting and getting
-	// the error message.
-	err = node.accountManager.Registry().Flush(500 * time.Millisecond)
+	err = node.accountManager.Registry().Flush(participationRegistryFlushMaxWaitDuration)
 	if err != nil {
 		return account.ParticipationID{}, err
 	}
@@ -1083,16 +1078,6 @@ func (node *AlgorandFullNode) oldKeyDeletionThread() {
 			continue
 		}
 
-		// If compact certs are enabled, we need to determine what signatures
-		// we already computed, since we can then delete ephemeral keys that
-		// were already used to compute a signature (stored in the compact
-		// cert db).
-		ccSigs, err := node.compactCert.LatestSigsFromThisNode()
-		if err != nil {
-			node.log.Warnf("Cannot look up latest compact cert sigs: %v", err)
-			continue
-		}
-
 		// We need to find the consensus protocol used to agree on block r,
 		// since that determines the params used for ephemeral keys in block
 		// r.  The params come from agreement.ParamsRound(r), which is r-2.
@@ -1110,12 +1095,14 @@ func (node *AlgorandFullNode) oldKeyDeletionThread() {
 		agreementProto := config.Consensus[hdr.CurrentProtocol]
 
 		node.mu.Lock()
-		node.accountManager.DeleteOldKeys(latestHdr, ccSigs, agreementProto)
+		node.accountManager.DeleteOldKeys(latestHdr, agreementProto)
 		node.mu.Unlock()
 
-		// PKI TODO: Maybe we don't even need to flush the registry.
-		// Persist participation registry metrics.
-		node.accountManager.FlushRegistry(2 * time.Second)
+		// Persist participation registry updates to last-used round and voting key changes.
+		err = node.accountManager.Registry().Flush(participationRegistryFlushMaxWaitDuration)
+		if err != nil {
+			node.log.Warnf("error while flushing the registry: %w", err)
+		}
 	}
 }
 

--- a/util/db/dbpair.go
+++ b/util/db/dbpair.go
@@ -47,3 +47,20 @@ func OpenPair(filename string, memory bool) (p Pair, err error) {
 
 	return
 }
+
+// OpenErasablePair opens the filename with both reading and writing accessors
+// with the secure_delete pragma set, using MakeErasableAccessor.
+func OpenErasablePair(filename string) (p Pair, err error) {
+	p.Rdb, err = makeErasableAccessor(filename, true)
+	if err != nil {
+		return
+	}
+
+	p.Wdb, err = makeErasableAccessor(filename, false)
+	if err != nil {
+		p.Rdb.Close()
+		return
+	}
+
+	return
+}

--- a/util/db/dbutil.go
+++ b/util/db/dbutil.go
@@ -87,7 +87,11 @@ func MakeAccessor(dbfilename string, readOnly bool, inMemory bool) (Accessor, er
 // see https://www.sqlite.org/pragma.html#pragma_secure_delete
 // It is not read-only and not in-memory (otherwise, erasability doesn't matter)
 func MakeErasableAccessor(dbfilename string) (Accessor, error) {
-	return makeAccessorImpl(dbfilename, false, false, []string{"_secure_delete=on"})
+	return makeErasableAccessor(dbfilename, false)
+}
+
+func makeErasableAccessor(dbfilename string, readOnly bool) (Accessor, error) {
+	return makeAccessorImpl(dbfilename, readOnly, false, []string{"_secure_delete=on"})
 }
 
 func makeAccessorImpl(dbfilename string, readOnly bool, inMemory bool, params []string) (Accessor, error) {


### PR DESCRIPTION
## Summary

This PR completes the previous started efforts and ensure all the requests are tunneled directly to the participation registry for optimal performance.

## Test Plan

Unit tests added.
