### PR TITLE
testing: avoid generating large output on TestDeadlockLogging

### DIFF
--- a/daemon/algod/deadlockLogger.go
+++ b/daemon/algod/deadlockLogger.go
@@ -56,7 +56,8 @@ func captureCallstack() []byte {
 	bufferSize := 256 * 1024
 	for {
 		buf = make([]byte, bufferSize)
-		if runtime.Stack(buf, true) < bufferSize {
+		if writtenBytes := runtime.Stack(buf, true); writtenBytes < bufferSize {
+			buf = buf[:writtenBytes]
 			break
 		}
 		bufferSize *= 2


### PR DESCRIPTION
## Summary

The TestDeadlockLogging was generating large amount of "junk" on top of the expected stack trace.
This PR addresses that by dropping the redundant data.

Example: https://circleci.com/api/v1.1/project/github/algorand/go-algorand/92568/output/106/0?file=true&allocation-id=622fb105959ff4390b6b098f-0-build%2F5VSI2HBA
## Test Plan

Unit test exists.