### PR TITLE
Goal: Add check for signer passed in the case of logic sig rekeyed account

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -797,7 +797,6 @@ var signCmd = &cobra.Command{
 						}
 						txn.AuthAddr = addr
 					}
-
 				}
 				txnGroup = append(txnGroup, *txn)
 			}

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -743,7 +743,7 @@ var signCmd = &cobra.Command{
 			dataDir := ensureSingleDataDir()
 			client = ensureKmdClient(dataDir)
 			wh, pw = ensureWalletHandleMaybePassword(dataDir, walletName, true)
-		} else {
+		} else if signerAddress != "" {
 			authAddr, err = basics.UnmarshalChecksumAddress(signerAddress)
 			if err != nil {
 				reportErrorf("Signer invalid (%s): %v", signerAddress, err)

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -787,9 +787,17 @@ var signCmd = &cobra.Command{
 
 		for _, group := range groupsOrder {
 			txnGroup := []transactions.SignedTxn{}
-			for _, txn := range txnGroups[group] {
+			for idx, txn := range txnGroups[group] {
 				if lsig.Logic != nil {
 					txn.Lsig = lsig
+					if signerAddress != "" {
+						addr, err := basics.UnmarshalChecksumAddress(signerAddress)
+						if err != nil {
+							reportErrorf("Signer invalid txn[%d]: %v", idx, err)
+						}
+						txn.AuthAddr = addr
+					}
+
 				}
 				txnGroup = append(txnGroup, *txn)
 			}

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -724,7 +724,7 @@ var signCmd = &cobra.Command{
 		}
 
 		var lsig transactions.LogicSig
-
+		var authAddr basics.Address
 		var client libgoal.Client
 		var wh []byte
 		var pw []byte
@@ -743,6 +743,11 @@ var signCmd = &cobra.Command{
 			dataDir := ensureSingleDataDir()
 			client = ensureKmdClient(dataDir)
 			wh, pw = ensureWalletHandleMaybePassword(dataDir, walletName, true)
+		} else {
+			authAddr, err = basics.UnmarshalChecksumAddress(signerAddress)
+			if err != nil {
+				reportErrorf("Signer invalid (%s): %v", signerAddress, err)
+			}
 		}
 
 		var outData []byte
@@ -787,15 +792,11 @@ var signCmd = &cobra.Command{
 
 		for _, group := range groupsOrder {
 			txnGroup := []transactions.SignedTxn{}
-			for idx, txn := range txnGroups[group] {
+			for _, txn := range txnGroups[group] {
 				if lsig.Logic != nil {
 					txn.Lsig = lsig
 					if signerAddress != "" {
-						addr, err := basics.UnmarshalChecksumAddress(signerAddress)
-						if err != nil {
-							reportErrorf("Signer invalid txn[%d]: %v", idx, err)
-						}
-						txn.AuthAddr = addr
+						txn.AuthAddr = authAddr
 					}
 				}
 				txnGroup = append(txnGroup, *txn)


### PR DESCRIPTION
## Summary
When trying to sign a transaction file with goal, if the sender is a normal address but the signer is a logic program, the call fails with an error message like:

`send.txn: txn[0] error LogicNot signed and not a Logic-only account`


The error message comes from https://github.com/algorand/go-algorand/blob/33b87c432065d3be0ce1fdad682604f416676133/data/transactions/verify/txn.go#L314


It notes that a valid case is when Auth is set to the hash of the program but we aren't setting the auth on the transaction even if the -S flag is passed

## Test Plan
Made a txn where sender is a regular account and signed it with

```sh
goal clerk sign -i tmp.txn -o tmp.txn -S BJATCHES5YJZJ7JITYMVLSSIQAVAWBQRVGPQUDT5AZ2QSLDSXWWM46THOY -p tmp.teal
```

I borked the git history on the last one #3459 so just nuked it and starting over here.

Left it at @tsachiherman wanting better tests for this https://github.com/algorand/go-algorand/pull/3459#discussion_r798039208