### PR TITLE
ledger: make voters a regular tracker

### DIFF
--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -228,6 +228,10 @@ func (ml *mockLedgerForTracker) GenesisAccounts() map[basics.Address]basics.Acco
 	return ml.accts
 }
 
+func (ml *mockLedgerForTracker) OnlineTop(rnd basics.Round, voteRnd basics.Round, n uint64) ([]*ledgercore.OnlineAccount, error) {
+	return nil, nil
+}
+
 // this function used to be in acctupdates.go, but we were never using it for production purposes. This
 // function has a conceptual flaw in that it attempts to load the entire balances into memory. This might
 // not work if we have large number of balances. On these unit testing, however, it's not the case, and it's

--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -101,6 +101,10 @@ func (wl *wrappedLedger) GenesisAccounts() map[basics.Address]basics.AccountData
 	return wl.l.GenesisAccounts()
 }
 
+func (wl *wrappedLedger) OnlineTop(rnd basics.Round, voteRnd basics.Round, n uint64) ([]*ledgercore.OnlineAccount, error) {
+	return wl.l.OnlineTop(rnd, voteRnd, n)
+}
+
 func getInitState() (genesisInitState ledgercore.InitState) {
 	blk := bookkeeping.Block{}
 	blk.CurrentProtocol = protocol.ConsensusCurrentVersion

--- a/ledger/bulletin.go
+++ b/ledger/bulletin.go
@@ -17,8 +17,6 @@
 package ledger
 
 import (
-	"context"
-	"database/sql"
 	"sync/atomic"
 
 	"github.com/algorand/go-deadlock"
@@ -49,6 +47,7 @@ func (notifier *notifier) notify() {
 // bulletin provides an easy way to wait on a round to be written to the ledger.
 // To use it, call <-Wait(round)
 type bulletin struct {
+	trivialTracker
 	mu                          deadlock.Mutex
 	pendingNotificationRequests map[basics.Round]notifier
 	latestRound                 basics.Round
@@ -107,25 +106,4 @@ func (b *bulletin) committedUpTo(rnd basics.Round) (retRound, lookback basics.Ro
 
 	b.latestRound = rnd
 	return rnd, basics.Round(0)
-}
-
-func (b *bulletin) prepareCommit(dcc *deferredCommitContext) error {
-	return nil
-}
-
-func (b *bulletin) commitRound(context.Context, *sql.Tx, *deferredCommitContext) error {
-	return nil
-}
-
-func (b *bulletin) postCommit(ctx context.Context, dcc *deferredCommitContext) {
-}
-
-func (b *bulletin) postCommitUnlocked(ctx context.Context, dcc *deferredCommitContext) {
-}
-
-func (b *bulletin) handleUnorderedCommit(*deferredCommitContext) {
-}
-
-func (b *bulletin) produceCommittingTask(committedRound basics.Round, dbRound basics.Round, dcr *deferredCommitRange) *deferredCommitRange {
-	return dcr
 }

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -17,9 +17,6 @@
 package ledger
 
 import (
-	"context"
-	"database/sql"
-
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
@@ -27,6 +24,7 @@ import (
 )
 
 type metricsTracker struct {
+	trivialTracker
 	ledgerTransactionsTotal *metrics.Counter
 	ledgerRewardClaimsTotal *metrics.Counter
 	ledgerRound             *metrics.Gauge
@@ -60,29 +58,4 @@ func (mt *metricsTracker) newBlock(blk bookkeeping.Block, delta ledgercore.State
 	mt.ledgerTransactionsTotal.Add(float64(len(blk.Payset)), map[string]string{})
 	// TODO rewards: need to provide meaningful metric here.
 	mt.ledgerRewardClaimsTotal.Add(float64(1), map[string]string{})
-}
-
-func (mt *metricsTracker) committedUpTo(committedRnd basics.Round) (retRound, lookback basics.Round) {
-	return committedRnd, basics.Round(0)
-}
-
-func (mt *metricsTracker) prepareCommit(dcc *deferredCommitContext) error {
-	return nil
-}
-
-func (mt *metricsTracker) commitRound(context.Context, *sql.Tx, *deferredCommitContext) error {
-	return nil
-}
-
-func (mt *metricsTracker) postCommit(ctx context.Context, dcc *deferredCommitContext) {
-}
-
-func (mt *metricsTracker) postCommitUnlocked(ctx context.Context, dcc *deferredCommitContext) {
-}
-
-func (mt *metricsTracker) handleUnorderedCommit(*deferredCommitContext) {
-}
-
-func (mt *metricsTracker) produceCommittingTask(committedRound basics.Round, dbRound basics.Round, dcr *deferredCommitRange) *deferredCommitRange {
-	return dcr
 }

--- a/ledger/notifier.go
+++ b/ledger/notifier.go
@@ -17,8 +17,6 @@
 package ledger
 
 import (
-	"context"
-	"database/sql"
 	"sync"
 
 	"github.com/algorand/go-deadlock"
@@ -39,6 +37,7 @@ type blockDeltaPair struct {
 }
 
 type blockNotifier struct {
+	trivialTracker
 	mu            deadlock.Mutex
 	cond          *sync.Cond
 	listeners     []BlockListener
@@ -108,29 +107,4 @@ func (bn *blockNotifier) newBlock(blk bookkeeping.Block, delta ledgercore.StateD
 	defer bn.mu.Unlock()
 	bn.pendingBlocks = append(bn.pendingBlocks, blockDeltaPair{block: blk, delta: delta})
 	bn.cond.Broadcast()
-}
-
-func (bn *blockNotifier) committedUpTo(rnd basics.Round) (retRound, lookback basics.Round) {
-	return rnd, basics.Round(0)
-}
-
-func (bn *blockNotifier) prepareCommit(dcc *deferredCommitContext) error {
-	return nil
-}
-
-func (bn *blockNotifier) commitRound(context.Context, *sql.Tx, *deferredCommitContext) error {
-	return nil
-}
-
-func (bn *blockNotifier) postCommit(ctx context.Context, dcc *deferredCommitContext) {
-}
-
-func (bn *blockNotifier) postCommitUnlocked(ctx context.Context, dcc *deferredCommitContext) {
-}
-
-func (bn *blockNotifier) handleUnorderedCommit(*deferredCommitContext) {
-}
-
-func (bn *blockNotifier) produceCommittingTask(committedRound basics.Round, dbRound basics.Round, dcr *deferredCommitRange) *deferredCommitRange {
-	return dcr
 }

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -680,3 +680,33 @@ func (tr *trackerRegistry) initializeTrackerCaches(l ledgerForTracker) (err erro
 	return
 
 }
+
+// trivialTracker has default implementation of committing functions from ledgerTracker interface.
+// It does not implement loadFromDisk, close and newBlock b/c these functions must be implemented for any tracker.
+type trivialTracker struct {
+}
+
+func (tt *trivialTracker) committedUpTo(committedRnd basics.Round) (retRound, lookback basics.Round) {
+	return committedRnd, basics.Round(0)
+}
+
+func (tt *trivialTracker) produceCommittingTask(committedRound basics.Round, dbRound basics.Round, dcr *deferredCommitRange) *deferredCommitRange {
+	return dcr
+}
+
+func (tt *trivialTracker) prepareCommit(*deferredCommitContext) error {
+	return nil
+}
+
+func (tt *trivialTracker) commitRound(context.Context, *sql.Tx, *deferredCommitContext) error {
+	return nil
+}
+
+func (tt *trivialTracker) postCommit(context.Context, *deferredCommitContext) {
+}
+
+func (tt *trivialTracker) postCommitUnlocked(context.Context, *deferredCommitContext) {
+}
+
+func (tt *trivialTracker) handleUnorderedCommit(*deferredCommitContext) {
+}

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -265,10 +265,11 @@ func (tr *trackerRegistry) initialize(l ledgerForTracker, trackers []ledgerTrack
 	for _, tracker := range tr.trackers {
 		if accts, ok := tracker.(*accountUpdates); ok {
 			tr.accts = accts
-			break
+			continue
 		}
 		if vt, ok := tracker.(*votersTracker); ok {
 			tr.voters = vt
+			continue
 		}
 	}
 	return

--- a/ledger/voters.go
+++ b/ledger/voters.go
@@ -17,8 +17,6 @@
 package ledger
 
 import (
-	"context"
-	"database/sql"
 	"fmt"
 	"sync"
 
@@ -40,6 +38,7 @@ import (
 // rather than a direct ledger tracker.  We don't have an explicit interface
 // for such an "accounts tracker" yet, however.
 type votersTracker struct {
+	trivialTracker
 	// round contains the top online accounts in a given round.
 	//
 	// To avoid increasing block latency, we include a Merkle commitment
@@ -195,27 +194,6 @@ func (vt *votersTracker) committedUpTo(committedRound basics.Round) (minRound, l
 	}
 
 	return vt.lowestRound(committedRound), basics.Round(proto.CompactCertVotersLookback)
-}
-
-func (vt *votersTracker) produceCommittingTask(committedRound basics.Round, dbRound basics.Round, dcr *deferredCommitRange) *deferredCommitRange {
-	return dcr
-}
-
-func (vt *votersTracker) prepareCommit(*deferredCommitContext) error {
-	return nil
-}
-
-func (vt *votersTracker) commitRound(context.Context, *sql.Tx, *deferredCommitContext) error {
-	return nil
-}
-
-func (vt *votersTracker) postCommit(context.Context, *deferredCommitContext) {
-}
-
-func (vt *votersTracker) postCommitUnlocked(context.Context, *deferredCommitContext) {
-}
-
-func (vt *votersTracker) handleUnorderedCommit(*deferredCommitContext) {
 }
 
 // lowestRound() returns the lowest round state (blocks and accounts) needed by

--- a/ledger/voters.go
+++ b/ledger/voters.go
@@ -79,7 +79,7 @@ func votersRoundForCertRound(certRnd basics.Round, proto config.ConsensusParams)
 	return certRnd.SubSaturate(basics.Round(proto.CompactCertRounds)).SubSaturate(basics.Round(proto.CompactCertVotersLookback))
 }
 
-func (vt *votersTracker) loadFromDisk(l ledgerForTracker, _ basics.Round) error {
+func (vt *votersTracker) loadFromDisk(l ledgerForTracker, dbRound basics.Round) error {
 	vt.l = l
 	vt.round = make(map[basics.Round]*ledgercore.VotersForRound)
 
@@ -96,6 +96,7 @@ func (vt *votersTracker) loadFromDisk(l ledgerForTracker, _ basics.Round) error 
 	}
 
 	startR := votersRoundForCertRound(hdr.CompactCert[protocol.CompactCertBasic].CompactCertNextRound, proto)
+	l.trackerLog().Warnf("voters loadFromDisk: latest = %d, dbRound = %d, nextRound = %d, startR = %d ", latest, dbRound, hdr.CompactCert[protocol.CompactCertBasic].CompactCertNextRound, startR)
 
 	// Sanity check: we should never underflow or even reach 0.
 	if startR == 0 {
@@ -161,8 +162,7 @@ func (vt *votersTracker) newBlock(blk bookkeeping.Block, _ ledgercore.StateDelta
 		// No compact certs.
 		return
 	}
-
-	hdr := blk.BlockHeader
+	vt.l.trackerLog().Warnf("voters newBlock: blk.Round = %d, nextRound = %d", hdr.Round, hdr.CompactCert[protocol.CompactCertBasic].CompactCertNextRound)
 
 	// Check if any blocks can be forgotten because the compact cert is available.
 	for r, tr := range vt.round {

--- a/test/e2e-go/features/compactcert/compactcert_test.go
+++ b/test/e2e-go/features/compactcert/compactcert_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto/compactcert"
-	"github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
+	v1 "github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/protocol"
@@ -38,7 +38,7 @@ func TestCompactCerts(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	defer fixtures.ShutdownSynchronizedTest(t)
 
-	t.Skip("Disabling since they need work and shouldn't block releases")
+	// t.Skip("Disabling since they need work and shouldn't block releases")
 	t.Parallel()
 	r := require.New(fixtures.SynchronizedTest(t))
 


### PR DESCRIPTION
## Summary

Move voters out of account updates.
Fixed the issue with growing number of non-committed changes because of resetting  newBase by`vt.lowestRound`.
Now it is called in `committedUpTo` and controls block queue preserved rounds.

## Test Plan

Use existing tests.