### PR TITLE
DevMode: create a block for external txns only

### DIFF
--- a/compactcert/abstractions.go
+++ b/compactcert/abstractions.go
@@ -32,7 +32,7 @@ import (
 // TransactionSender is an interface that captures the node's ability
 // to broadcast a new transaction.
 type TransactionSender interface {
-	BroadcastCompactCertSignedTxGroup([]transactions.SignedTxn) error
+	BroadcastInternalSignedTxGroup([]transactions.SignedTxn) error
 }
 
 // Ledger captures the aspects of the ledger that are used by this package.

--- a/compactcert/abstractions.go
+++ b/compactcert/abstractions.go
@@ -32,7 +32,7 @@ import (
 // TransactionSender is an interface that captures the node's ability
 // to broadcast a new transaction.
 type TransactionSender interface {
-	BroadcastSignedTxGroup([]transactions.SignedTxn) error
+	BroadcastCompactCertSignedTxGroup([]transactions.SignedTxn) error
 }
 
 // Ledger captures the aspects of the ledger that are used by this package.

--- a/compactcert/builder.go
+++ b/compactcert/builder.go
@@ -347,7 +347,7 @@ func (ccw *Worker) tryBuilding() {
 		stxn.Txn.GenesisHash = ccw.ledger.GenesisHash()
 		stxn.Txn.CertRound = rnd
 		stxn.Txn.Cert = *cert
-		err = ccw.txnSender.BroadcastSignedTxGroup([]transactions.SignedTxn{stxn})
+		err = ccw.txnSender.BroadcastCompactCertSignedTxGroup([]transactions.SignedTxn{stxn})
 		if err != nil {
 			ccw.log.Warnf("ccw.tryBuilding: broadcasting compact cert txn for %d: %v", rnd, err)
 		}

--- a/compactcert/builder.go
+++ b/compactcert/builder.go
@@ -347,7 +347,7 @@ func (ccw *Worker) tryBuilding() {
 		stxn.Txn.GenesisHash = ccw.ledger.GenesisHash()
 		stxn.Txn.CertRound = rnd
 		stxn.Txn.Cert = *cert
-		err = ccw.txnSender.BroadcastCompactCertSignedTxGroup([]transactions.SignedTxn{stxn})
+		err = ccw.txnSender.BroadcastInternalSignedTxGroup([]transactions.SignedTxn{stxn})
 		if err != nil {
 			ccw.log.Warnf("ccw.tryBuilding: broadcasting compact cert txn for %d: %v", rnd, err)
 		}

--- a/compactcert/worker_test.go
+++ b/compactcert/worker_test.go
@@ -196,7 +196,7 @@ func (s *testWorkerStubs) Broadcast(ctx context.Context, tag protocol.Tag, data 
 	return nil
 }
 
-func (s *testWorkerStubs) BroadcastSignedTxGroup(tx []transactions.SignedTxn) error {
+func (s *testWorkerStubs) BroadcastCompactCertSignedTxGroup(tx []transactions.SignedTxn) error {
 	require.Equal(s.t, len(tx), 1)
 	s.txmsg <- tx[0]
 	return nil

--- a/compactcert/worker_test.go
+++ b/compactcert/worker_test.go
@@ -196,7 +196,7 @@ func (s *testWorkerStubs) Broadcast(ctx context.Context, tag protocol.Tag, data 
 	return nil
 }
 
-func (s *testWorkerStubs) BroadcastCompactCertSignedTxGroup(tx []transactions.SignedTxn) error {
+func (s *testWorkerStubs) BroadcastInternalSignedTxGroup(tx []transactions.SignedTxn) error {
 	require.Equal(s.t, len(tx), 1)
 	s.txmsg <- tx[0]
 	return nil

--- a/node/node.go
+++ b/node/node.go
@@ -514,9 +514,9 @@ func (node *AlgorandFullNode) BroadcastSignedTxGroup(txgroup []transactions.Sign
 	return node.broadcastSignedTxGroup(txgroup)
 }
 
-// BroadcastCompactCertSignedTxGroup broadcasts a transaction group that has already been signed.
-// In DevMode, it will not advance the round.
-func (node *AlgorandFullNode) BroadcastCompactCertSignedTxGroup(txgroup []transactions.SignedTxn) (err error) {
+// BroadcastInternalSignedTxGroup broadcasts a transaction group that has already been signed.
+// It is originated internally, and in DevMode, it will not advance the round.
+func (node *AlgorandFullNode) BroadcastInternalSignedTxGroup(txgroup []transactions.SignedTxn) (err error) {
 	return node.broadcastSignedTxGroup(txgroup)
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -511,7 +511,16 @@ func (node *AlgorandFullNode) BroadcastSignedTxGroup(txgroup []transactions.Sign
 			node.mu.Unlock()
 		}()
 	}
+	return node.broadcastSignedTxGroup(txgroup)
+}
 
+// BroadcastCompactCertSignedTxGroup broadcasts a transaction group that has already been signed.
+func (node *AlgorandFullNode) BroadcastCompactCertSignedTxGroup(txgroup []transactions.SignedTxn) (err error) {
+	return node.broadcastSignedTxGroup(txgroup)
+}
+
+// broadcastSignedTxGroup broadcasts a transaction group that has already been signed.
+func (node *AlgorandFullNode) broadcastSignedTxGroup(txgroup []transactions.SignedTxn) (err error) {
 	lastRound := node.ledger.Latest()
 	var b bookkeeping.BlockHeader
 	b, err = node.ledger.BlockHdr(lastRound)

--- a/node/node.go
+++ b/node/node.go
@@ -515,6 +515,7 @@ func (node *AlgorandFullNode) BroadcastSignedTxGroup(txgroup []transactions.Sign
 }
 
 // BroadcastCompactCertSignedTxGroup broadcasts a transaction group that has already been signed.
+// In DevMode, it will not advance the round.
 func (node *AlgorandFullNode) BroadcastCompactCertSignedTxGroup(txgroup []transactions.SignedTxn) (err error) {
 	return node.broadcastSignedTxGroup(txgroup)
 }


### PR DESCRIPTION
In DevMode, do not create a block for internal events (i.e. compact-cert creation).
This is to assure reproducibility and eliminate the random shifts in round numbers. 
