### PR TITLE
Algod: Fix issue with nil accounts in local-deltas array

### DIFF
--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -511,7 +511,7 @@ func doDryrunRequest(dr *DryrunRequest, response *generated.DryrunResponse) {
 				result.AppCallTrace = &debug.history
 				result.GlobalDelta = StateDeltaToStateDelta(delta.GlobalDelta)
 				if len(delta.LocalDeltas) > 0 {
-					localDeltas := []generated.AccountStateDelta{}
+					localDeltas := make([]generated.AccountStateDelta, 0, len(delta.LocalDeltas))
 					for k, v := range delta.LocalDeltas {
 						ldaddr, err2 := stxn.Txn.AddressByIndex(k, stxn.Txn.Sender)
 						if err2 != nil {

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -511,7 +511,7 @@ func doDryrunRequest(dr *DryrunRequest, response *generated.DryrunResponse) {
 				result.AppCallTrace = &debug.history
 				result.GlobalDelta = StateDeltaToStateDelta(delta.GlobalDelta)
 				if len(delta.LocalDeltas) > 0 {
-					localDeltas := make([]generated.AccountStateDelta, len(delta.LocalDeltas))
+					localDeltas := []generated.AccountStateDelta{}
 					for k, v := range delta.LocalDeltas {
 						ldaddr, err2 := stxn.Txn.AddressByIndex(k, stxn.Txn.Sender)
 						if err2 != nil {

--- a/daemon/algod/api/server/v2/dryrun_test.go
+++ b/daemon/algod/api/server/v2/dryrun_test.go
@@ -563,27 +563,27 @@ func TestDryrunLocal1(t *testing.T) {
 	if response.Txns[0].LocalDeltas == nil {
 		t.Fatal("empty local delta")
 	}
-	addrFound := false
-	valueFound := false
-	for _, lds := range *response.Txns[0].LocalDeltas {
-		if lds.Address == "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ" {
-			addrFound = true
-			for _, ld := range lds.Delta {
-				if ld.Key == b64("foo") {
-					valueFound = true
-					assert.Equal(t, ld.Value.Action, uint64(basics.SetBytesAction))
-					assert.Equal(t, *ld.Value.Bytes, b64("bar"))
 
-				}
-			}
+	// Should be a single account
+	assert.Len(t, *response.Txns[0].LocalDeltas, 1)
+
+	lds := (*response.Txns[0].LocalDeltas)[0]
+	assert.Equal(t, lds.Address, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ")
+
+	valueFound := false
+	for _, ld := range lds.Delta {
+		if ld.Key == b64("foo") {
+			valueFound = true
+			assert.Equal(t, ld.Value.Action, uint64(basics.SetBytesAction))
+			assert.Equal(t, *ld.Value.Bytes, b64("bar"))
+
 		}
 	}
-	if !addrFound {
-		t.Error("no local delta for AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ")
-	}
+
 	if !valueFound {
 		t.Error("no local delta for value foo")
 	}
+
 	if t.Failed() {
 		logResponse(t, &response)
 	}
@@ -644,24 +644,22 @@ func TestDryrunLocal1A(t *testing.T) {
 	if response.Txns[0].LocalDeltas == nil {
 		t.Fatal("empty local delta")
 	}
-	addrFound := false
-	valueFound := false
-	for _, lds := range *response.Txns[0].LocalDeltas {
-		if lds.Address == "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ" {
-			addrFound = true
-			for _, ld := range lds.Delta {
-				if ld.Key == b64("foo") {
-					valueFound = true
-					assert.Equal(t, ld.Value.Action, uint64(basics.SetBytesAction))
-					assert.Equal(t, *ld.Value.Bytes, b64("bar"))
 
-				}
-			}
+	assert.Len(t, *response.Txns[0].LocalDeltas, 1)
+
+	lds := (*response.Txns[0].LocalDeltas)[0]
+	assert.Equal(t, lds.Address, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ")
+
+	valueFound := false
+	for _, ld := range lds.Delta {
+		if ld.Key == b64("foo") {
+			valueFound = true
+			assert.Equal(t, ld.Value.Action, uint64(basics.SetBytesAction))
+			assert.Equal(t, *ld.Value.Bytes, b64("bar"))
+
 		}
 	}
-	if !addrFound {
-		t.Error("no local delta for AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ")
-	}
+
 	if !valueFound {
 		t.Error("no local delta for value foo")
 	}


### PR DESCRIPTION
This is the second issue with making a slice of a given length but then appending to it instead of setting elements by index. 

We probably should look through to see where/if this is done elsewhere.

Result of this bug prior to the fix, note txns[0]['local-deltas'][0] here:
https://raw.githubusercontent.com/algorand/algorand-sdk-testing/131b0d90f5a1c4c93b43b7f5b4126c568dc29613/features/resources/v2algodclient_responsejsons/largeDryrunResponse.json