### PR TITLE
goal: Set default key dilution to be the same as algokey

### DIFF
--- a/cmd/algokey/part.go
+++ b/cmd/algokey/part.go
@@ -180,7 +180,7 @@ func init() {
 	partGenerateCmd.Flags().StringVar(&partKeyfile, "keyfile", "", "Participation key filename")
 	partGenerateCmd.Flags().Uint64Var(&partFirstRound, "first", 0, "First round for participation key")
 	partGenerateCmd.Flags().Uint64Var(&partLastRound, "last", 0, "Last round for participation key")
-	partGenerateCmd.Flags().Uint64Var(&partKeyDilution, "dilution", 0, "Key dilution (defaults to sqrt of validity window)")
+	partGenerateCmd.Flags().Uint64Var(&partKeyDilution, "dilution", 0, "Key dilution for two-level participation keys (defaults to sqrt of validity window)")
 	partGenerateCmd.Flags().StringVar(&partParent, "parent", "", "Address of parent account")
 	partGenerateCmd.MarkFlagRequired("first")
 	partGenerateCmd.MarkFlagRequired("last")

--- a/cmd/algokey/part.go
+++ b/cmd/algokey/part.go
@@ -180,7 +180,7 @@ func init() {
 	partGenerateCmd.Flags().StringVar(&partKeyfile, "keyfile", "", "Participation key filename")
 	partGenerateCmd.Flags().Uint64Var(&partFirstRound, "first", 0, "First round for participation key")
 	partGenerateCmd.Flags().Uint64Var(&partLastRound, "last", 0, "Last round for participation key")
-	partGenerateCmd.Flags().Uint64Var(&partKeyDilution, "dilution", 0, "Key dilution (default to sqrt of validity window)")
+	partGenerateCmd.Flags().Uint64Var(&partKeyDilution, "dilution", 0, "Key dilution (defaults to sqrt of validity window)")
 	partGenerateCmd.Flags().StringVar(&partParent, "parent", "", "Address of parent account")
 	partGenerateCmd.MarkFlagRequired("first")
 	partGenerateCmd.MarkFlagRequired("last")

--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -161,7 +161,7 @@ func init() {
 	addParticipationKeyCmd.Flags().Uint64VarP(&roundLastValid, "roundLastValid", "", 0, "The last round for which the generated partkey will be valid")
 	addParticipationKeyCmd.MarkFlagRequired("roundLastValid")
 	addParticipationKeyCmd.Flags().StringVarP(&partKeyOutDir, "outdir", "o", "", "Save participation key file to specified output directory to (for offline creation)")
-	addParticipationKeyCmd.Flags().Uint64VarP(&keyDilution, "keyDilution", "", 0, "Key dilution for two-level participation keys")
+	addParticipationKeyCmd.Flags().Uint64VarP(&keyDilution, "keyDilution", "", 0, "Key dilution for two-level participation keys (defaults to sqrt of validity window)")
 
 	// installParticipationKey flags
 	installParticipationKeyCmd.Flags().StringVar(&partKeyFile, "partkey", "", "Participation key file to install")

--- a/libgoal/participation.go
+++ b/libgoal/participation.go
@@ -170,7 +170,7 @@ func (c *Client) GenParticipationKeysTo(address string, firstValid, lastValid, k
 	}
 
 	if keyDilution == 0 {
-		keyDilution = proto.DefaultKeyDilution
+		keyDilution = 1 + uint64(math.Sqrt(float64(lastRound-firstRound)))
 	}
 
 	// Fill the database with new participation keys

--- a/libgoal/participation.go
+++ b/libgoal/participation.go
@@ -127,18 +127,6 @@ func (c *Client) GenParticipationKeysTo(address string, firstValid, lastValid, k
 
 	firstRound, lastRound := basics.Round(firstValid), basics.Round(lastValid)
 
-	// Get the current protocol for ephemeral key parameters
-	stat, err := c.Status()
-	if err != nil {
-		return
-	}
-
-	proto, ok := c.consensus[protocol.ConsensusVersion(stat.LastVersion)]
-	if !ok {
-		err = fmt.Errorf("consensus protocol %s not supported", stat.LastVersion)
-		return
-	}
-
 	// If output directory wasn't specified, store it in the current ledger directory.
 	if outDir == "" {
 		// Get the GenesisID for use in the participation key path


### PR DESCRIPTION
## Summary

@algonoah and I noticed that `algokey part generate` sets the default key dilution parameter to the square root of the round range, but `goal account addpartkey` sets the default key dilution parameter to 10000. This updates goal to use the same formula as algokey.

This is also used by `goal account renewpartkey` and `renewallpartkeys`.

from algokey part generate:
https://github.com/algorand/go-algorand/blob/6b7dfb635d100d20c67259f091f0390e4498d9c3/cmd/algokey/part.go#L59-L61

## Test Plan

Existing tests should pass.