### PR TITLE
build: compile with golang 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ commands:
           shell: bash.exe
           command: |
             choco install -y msys2 pacman make wget --force
-            choco install -y golang --version=1.14.7 --force
+            choco install -y golang --version=1.16.11 --force
             choco install -y python3 --version=3.7.3 --force
             export msys2='cmd //C RefreshEnv.cmd '
             export msys2+='& set MSYS=winsymlinks:nativestrict '

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v2
         with:
-          go-version: '1.14.7'
+          go-version: '1.16.11'
       - name: Build Test
         run: |
           export ALGORAND_DEADLOCK=enable

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install specific golang
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.6'
+          go-version: '1.16.11'
       - name: Create folders for golangci-lint
         run: mkdir -p cicdtmp/golangci-lint
       - name: Check if custom golangci-lint is already built

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ else
 export GOPATH := $(shell go env GOPATH)
 GOPATH1 := $(firstword $(subst :, ,$(GOPATH)))
 endif
-export GO111MODULE	:= on
 export GOPROXY := direct
 SRCPATH     := $(shell pwd)
 ARCH        := $(shell ./scripts/archtype.sh)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/algorand/go-algorand
 
-go 1.14
+go 1.16
 
 require (
 	github.com/algorand/falcon v0.0.0-20220130164023-c9e1d466f123

--- a/network/dialer.go
+++ b/network/dialer.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/algorand/go-algorand/tools/network/dnssec"
+	"github.com/algorand/go-algorand/util"
 )
 
 type netDialer interface {
@@ -79,7 +80,7 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case <-time.After(waitTime):
+		case <-util.NanoAfter(waitTime):
 		}
 	}
 	conn, err := d.innerDialContext(ctx, network, address)

--- a/network/rateLimitingTransport.go
+++ b/network/rateLimitingTransport.go
@@ -67,7 +67,7 @@ func (r *rateLimitingTransport) RoundTrip(req *http.Request) (res *http.Response
 		}
 		waitDeadline := time.Now().Add(waitTime)
 		if waitDeadline.Before(queueingDeadline) {
-			util.Nanosleep(waitTime.Nanoseconds())
+			util.NanoSleep(waitTime.Nanoseconds())
 			continue
 		}
 		return nil, ErrConnectionQueueingTimeout

--- a/network/rateLimitingTransport.go
+++ b/network/rateLimitingTransport.go
@@ -67,7 +67,7 @@ func (r *rateLimitingTransport) RoundTrip(req *http.Request) (res *http.Response
 		}
 		waitDeadline := time.Now().Add(waitTime)
 		if waitDeadline.Before(queueingDeadline) {
-			util.NanoSleep(waitTime.Nanoseconds())
+			util.NanoSleep(waitTime)
 			continue
 		}
 		return nil, ErrConnectionQueueingTimeout

--- a/network/rateLimitingTransport.go
+++ b/network/rateLimitingTransport.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"net/http"
 	"time"
+
+	"github.com/algorand/go-algorand/util"
 )
 
 // rateLimitingTransport is the transport for execute a single HTTP transaction, obtaining the Response for a given Request.
@@ -57,17 +59,18 @@ func makeRateLimitingTransport(phonebook Phonebook, queueingTimeout time.Duratio
 func (r *rateLimitingTransport) RoundTrip(req *http.Request) (res *http.Response, err error) {
 	var waitTime time.Duration
 	var provisionalTime time.Time
-	queueingTimedOut := time.After(r.queueingTimeout)
+	queueingDeadline := time.Now().Add(r.queueingTimeout)
 	for {
 		_, waitTime, provisionalTime = r.phonebook.GetConnectionWaitTime(req.Host)
 		if waitTime == 0 {
 			break // break out of the loop and proceed to the connection
 		}
-		select {
-		case <-time.After(waitTime):
-		case <-queueingTimedOut:
-			return nil, ErrConnectionQueueingTimeout
+		waitDeadline := time.Now().Add(waitTime)
+		if waitDeadline.Before(queueingDeadline) {
+			util.Nanosleep(waitTime.Nanoseconds())
+			continue
 		}
+		return nil, ErrConnectionQueueingTimeout
 	}
 	res, err = r.innerTransport.RoundTrip(req)
 	r.phonebook.UpdateConnectionTime(req.Host, provisionalTime)

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -48,6 +48,7 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 	tools_network "github.com/algorand/go-algorand/tools/network"
 	"github.com/algorand/go-algorand/tools/network/dnssec"
+	"github.com/algorand/go-algorand/util"
 	"github.com/algorand/go-algorand/util/metrics"
 )
 
@@ -1274,7 +1275,7 @@ func (wn *WebsocketNetwork) broadcastThread() {
 				}
 			}
 			select {
-			case <-time.After(sleepDuration):
+			case <-util.NanoAfter(sleepDuration):
 				if (request != nil) && time.Now().After(requestDeadline) {
 					// message time have elapsed.
 					return true

--- a/scripts/buildtools/go.mod
+++ b/scripts/buildtools/go.mod
@@ -1,6 +1,6 @@
 module github.com/algorand/go-algorand/scripts/buildtools
 
-go 1.14
+go 1.16
 
 require (
 	github.com/algorand/msgp v1.1.49

--- a/scripts/buildtools/install_buildtools.sh
+++ b/scripts/buildtools/install_buildtools.sh
@@ -70,16 +70,14 @@ function install_go_module {
     # Check for version to go.mod version
     VERSION=$(get_go_version "$1")
 
-    # TODO: When we switch to 1.16 this should be changed to use 'go install'
-    #       instead of 'go get': https://tip.golang.org/doc/go1.16#modules
     if [ -z "$VERSION" ]; then
         echo "Unable to install requested package '$1' (${MODULE}): no version listed in ${SCRIPTPATH}/go.mod"
         exit 1
     else
-        OUTPUT=$(GO111MODULE=on go get "${MODULE}@${VERSION}" 2>&1)
+        OUTPUT=$(go install "${MODULE}@${VERSION}" 2>&1)
     fi
     if [ $? != 0 ]; then
-        echo "error: executing \"go get ${MODULE}\" failed : ${OUTPUT}"
+        echo "error: executing \"go install ${MODULE}\" failed : ${OUTPUT}"
         exit 1
     fi
 }

--- a/scripts/get_golang_version.sh
+++ b/scripts/get_golang_version.sh
@@ -11,9 +11,9 @@
 # Our build task-runner `mule` will refer to this script and will automatically
 # build a new image whenever the version number has been changed.
 
-BUILD=1.14.7
-MIN=1.14
-GO_MOD_SUPPORT=1.12
+BUILD=1.16.11
+ MIN=1.16
+ GO_MOD_SUPPORT=1.16
 
 if [ "$1" = all ]
 then

--- a/scripts/travis/before_build.sh
+++ b/scripts/travis/before_build.sh
@@ -12,7 +12,6 @@ set -e
 
 GOPATH=$(go env GOPATH)
 export GOPATH
-export GO111MODULE=on
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 OS=$("${SCRIPTPATH}"/../ostype.sh)

--- a/shared/pingpong/accounts.go
+++ b/shared/pingpong/accounts.go
@@ -18,7 +18,6 @@ package pingpong
 
 import (
 	"fmt"
-	"github.com/algorand/go-algorand/util"
 	"io/ioutil"
 	"math"
 	"math/rand"
@@ -37,6 +36,7 @@ import (
 	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/libgoal"
 	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/util"
 	"github.com/algorand/go-algorand/util/db"
 )
 

--- a/shared/pingpong/accounts.go
+++ b/shared/pingpong/accounts.go
@@ -139,7 +139,7 @@ func throttleTransactionRate(startTime time.Time, cfg PpConfig, totalSent uint64
 	if currentTps > float64(cfg.TxnPerSec) {
 		sleepSec := float64(totalSent)/float64(cfg.TxnPerSec) - localTimeDelta.Seconds()
 		sleepTime := time.Duration(int64(math.Round(sleepSec*1000))) * time.Millisecond
-		util.NanoSleep(sleepTime.Nanoseconds())
+		util.NanoSleep(sleepTime)
 	}
 }
 

--- a/shared/pingpong/accounts.go
+++ b/shared/pingpong/accounts.go
@@ -18,6 +18,7 @@ package pingpong
 
 import (
 	"fmt"
+	"github.com/algorand/go-algorand/util"
 	"io/ioutil"
 	"math"
 	"math/rand"
@@ -138,7 +139,7 @@ func throttleTransactionRate(startTime time.Time, cfg PpConfig, totalSent uint64
 	if currentTps > float64(cfg.TxnPerSec) {
 		sleepSec := float64(totalSent)/float64(cfg.TxnPerSec) - localTimeDelta.Seconds()
 		sleepTime := time.Duration(int64(math.Round(sleepSec*1000))) * time.Millisecond
-		time.Sleep(sleepTime)
+		util.NanoSleep(sleepTime.Nanoseconds())
 	}
 }
 

--- a/shared/pingpong/pingpong.go
+++ b/shared/pingpong/pingpong.go
@@ -882,7 +882,7 @@ func (pps *WorkerState) sendFromTo(
 			timeCredit -= took
 			if timeCredit > 0 {
 				time.Sleep(timeCredit)
-				timeCredit = time.Duration(0)
+				timeCredit -= time.Since(now)
 			} else if timeCredit < -1000*time.Millisecond {
 				// cap the "time debt" to 1000 ms.
 				timeCredit = -1000 * time.Millisecond

--- a/shared/pingpong/pingpong.go
+++ b/shared/pingpong/pingpong.go
@@ -1233,7 +1233,7 @@ func (t *throttler) maybeSleep(count int) {
 		desiredSeconds := float64(countsum) / t.xps
 		extraSeconds := desiredSeconds - dt.Seconds()
 		t.iterm += 0.1 * extraSeconds / float64(len(t.times))
-		util.NanoSleep(int64(1000000000.0 * (extraSeconds + t.iterm) / float64(len(t.times))))
+		util.NanoSleep(time.Duration(1000000000.0 * (extraSeconds + t.iterm) / float64(len(t.times))))
 
 	} else {
 		t.iterm *= 0.95

--- a/shared/pingpong/pingpong.go
+++ b/shared/pingpong/pingpong.go
@@ -36,6 +36,7 @@ import (
 	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/libgoal"
 	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/util"
 )
 
 // CreatablesInfo has information about created assets, apps and opting in
@@ -1232,7 +1233,7 @@ func (t *throttler) maybeSleep(count int) {
 		desiredSeconds := float64(countsum) / t.xps
 		extraSeconds := desiredSeconds - dt.Seconds()
 		t.iterm += 0.1 * extraSeconds / float64(len(t.times))
-		time.Sleep(time.Duration(int64(1000000000.0 * (extraSeconds + t.iterm) / float64(len(t.times)))))
+		util.NanoSleep(int64(1000000000.0 * (extraSeconds + t.iterm) / float64(len(t.times))))
 
 	} else {
 		t.iterm *= 0.95

--- a/test/e2e-go/features/participation/participationRewards_test.go
+++ b/test/e2e-go/features/participation/participationRewards_test.go
@@ -358,7 +358,7 @@ func TestRewardRateRecalculation(t *testing.T) {
 	r.NoError(fixture.WaitForRoundWithTimeout(rewardRecalcRound - 1))
 	balanceOfRewardsPool, roundQueried := fixture.GetBalanceAndRound(rewardsAccount)
 	if roundQueried != rewardRecalcRound-1 {
-		r.FailNow("got rewards pool balance on round %d but wanted the balance on round %d, failing out", rewardRecalcRound-1, roundQueried)
+		r.FailNow("", "got rewards pool balance on round %d but wanted the balance on round %d, failing out", rewardRecalcRound-1, roundQueried)
 	}
 	lastRoundBeforeRewardRecals, err := client.Block(rewardRecalcRound - 1)
 	r.NoError(err)
@@ -381,7 +381,7 @@ func TestRewardRateRecalculation(t *testing.T) {
 	r.NoError(fixture.WaitForRoundWithTimeout(rewardRecalcRound - 1))
 	balanceOfRewardsPool, roundQueried = fixture.GetBalanceAndRound(rewardsAccount)
 	if roundQueried != rewardRecalcRound-1 {
-		r.FailNow("got rewards pool balance on round %d but wanted the balance on round %d, failing out", rewardRecalcRound-1, roundQueried)
+		r.FailNow("", "got rewards pool balance on round %d but wanted the balance on round %d, failing out", rewardRecalcRound-1, roundQueried)
 	}
 	lastRoundBeforeRewardRecals, err = client.Block(rewardRecalcRound - 1)
 	r.NoError(err)

--- a/test/scripts/e2e_go_tests.sh
+++ b/test/scripts/e2e_go_tests.sh
@@ -6,7 +6,6 @@ set -e
 set -o pipefail
 
 export GOPATH=$(go env GOPATH)
-export GO111MODULE=on
 
 # Needed for now because circleci doesn't use makefile yet
 if [ -z "$(which gotestsum)" ]; then

--- a/util/condvar/timedwait.go
+++ b/util/condvar/timedwait.go
@@ -44,7 +44,7 @@ func TimedWait(c *sync.Cond, timeout time.Duration) {
 			// thread hasn't gotten around to calling c.Wait()
 			// yet, so the c.Broadcast() did not wake it up.
 			// Sleep for a second and check again.
-			<-time.After(time.Second)
+			time.Sleep(time.Second)
 		}
 	}()
 

--- a/util/condvar/timedwait.go
+++ b/util/condvar/timedwait.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/algorand/go-algorand/util"
 )
 
 // TimedWait waits for sync.Cond c to be signaled, with a timeout.
@@ -33,7 +35,7 @@ func TimedWait(c *sync.Cond, timeout time.Duration) {
 	var done int32
 
 	go func() {
-		<-time.After(timeout)
+		util.NanoSleep(timeout.Nanoseconds())
 
 		for atomic.LoadInt32(&done) == 0 {
 			c.Broadcast()

--- a/util/condvar/timedwait.go
+++ b/util/condvar/timedwait.go
@@ -35,7 +35,7 @@ func TimedWait(c *sync.Cond, timeout time.Duration) {
 	var done int32
 
 	go func() {
-		util.NanoSleep(timeout.Nanoseconds())
+		util.NanoSleep(timeout)
 
 		for atomic.LoadInt32(&done) == 0 {
 			c.Broadcast()

--- a/util/sleep.go
+++ b/util/sleep.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+// +build !linux
+
+package util
+
+import (
+	"time"
+)
+
+// Nanosleep sleeps for the given ns in nanoseconds.
+func Nanosleep(ns int64) {
+	time.Sleep(time.Duration(ns))
+}

--- a/util/sleep.go
+++ b/util/sleep.go
@@ -26,3 +26,8 @@ import (
 func Nanosleep(ns int64) {
 	time.Sleep(time.Duration(ns))
 }
+
+// NanoAfter waits for the duration to elapse and then sends the current time on the returned channel.
+func NanoAfter(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}

--- a/util/sleep.go
+++ b/util/sleep.go
@@ -22,9 +22,9 @@ import (
 	"time"
 )
 
-// NanoSleep sleeps for the given ns in nanoseconds.
-func NanoSleep(ns int64) {
-	time.Sleep(time.Duration(ns))
+// NanoSleep sleeps for the given d duration.
+func NanoSleep(d time.Duration) {
+	time.Sleep(d)
 }
 
 // NanoAfter waits for the duration to elapse and then sends the current time on the returned channel.

--- a/util/sleep.go
+++ b/util/sleep.go
@@ -22,8 +22,8 @@ import (
 	"time"
 )
 
-// Nanosleep sleeps for the given ns in nanoseconds.
-func Nanosleep(ns int64) {
+// NanoSleep sleeps for the given ns in nanoseconds.
+func NanoSleep(ns int64) {
 	time.Sleep(time.Duration(ns))
 }
 

--- a/util/sleep_linux.go
+++ b/util/sleep_linux.go
@@ -23,7 +23,10 @@ import (
 
 // NanoSleep sleeps for the given d duration.
 func NanoSleep(d time.Duration) {
-	syscall.Nanosleep(&syscall.Timespec{Nsec: d.Nanoseconds() % time.Second.Nanoseconds(), Sec: d.Nanoseconds() / time.Second.Nanoseconds()}, nil) // nolint:errcheck
+	syscall.Nanosleep(&syscall.Timespec{
+		Nsec: d.Nanoseconds() % time.Second.Nanoseconds(),
+		Sec:  d.Nanoseconds() / time.Second.Nanoseconds()},
+		nil) // nolint:errcheck
 }
 
 // NanoAfter waits for the duration to elapse and then sends the current time on the returned channel.

--- a/util/sleep_linux.go
+++ b/util/sleep_linux.go
@@ -23,7 +23,7 @@ import (
 
 // NanoSleep sleeps for the given ns in nanoseconds.
 func NanoSleep(ns int64) {
-	syscall.Nanosleep(&syscall.Timespec{Nsec: ns}, nil) // nolint:errcheck
+	syscall.Nanosleep(&syscall.Timespec{Nsec: ns % time.Second.Nanoseconds(), Sec: ns / time.Second.Nanoseconds()}, nil) // nolint:errcheck
 }
 
 // NanoAfter waits for the duration to elapse and then sends the current time on the returned channel.

--- a/util/sleep_linux.go
+++ b/util/sleep_linux.go
@@ -23,10 +23,11 @@ import (
 
 // NanoSleep sleeps for the given d duration.
 func NanoSleep(d time.Duration) {
-	syscall.Nanosleep(&syscall.Timespec{
+	timeSpec := &syscall.Timespec{
 		Nsec: d.Nanoseconds() % time.Second.Nanoseconds(),
-		Sec:  d.Nanoseconds() / time.Second.Nanoseconds()},
-		nil) // nolint:errcheck
+		Sec:  d.Nanoseconds() / time.Second.Nanoseconds(),
+	}
+	syscall.Nanosleep(timeSpec, nil) // nolint:errcheck
 }
 
 // NanoAfter waits for the duration to elapse and then sends the current time on the returned channel.

--- a/util/sleep_linux.go
+++ b/util/sleep_linux.go
@@ -22,5 +22,5 @@ import (
 
 // Nanosleep sleeps for the given ns in nanoseconds.
 func Nanosleep(ns int64) {
-	syscall.Nanosleep(&Timespec{Nsec: ns}, nil)
+	syscall.Nanosleep(&syscall.Timespec{Nsec: ns}, nil)
 }

--- a/util/sleep_linux.go
+++ b/util/sleep_linux.go
@@ -22,5 +22,5 @@ import (
 
 // Nanosleep sleeps for the given ns in nanoseconds.
 func Nanosleep(ns int64) {
-	syscall.Nanosleep(&syscall.Timespec{Nsec: ns}, nil)
+	syscall.Nanosleep(&syscall.Timespec{Nsec: ns}, nil) // nolint:errcheck
 }

--- a/util/sleep_linux.go
+++ b/util/sleep_linux.go
@@ -21,9 +21,9 @@ import (
 	"time"
 )
 
-// NanoSleep sleeps for the given ns in nanoseconds.
-func NanoSleep(ns int64) {
-	syscall.Nanosleep(&syscall.Timespec{Nsec: ns % time.Second.Nanoseconds(), Sec: ns / time.Second.Nanoseconds()}, nil) // nolint:errcheck
+// NanoSleep sleeps for the given d duration.
+func NanoSleep(d time.Duration) {
+	syscall.Nanosleep(&syscall.Timespec{Nsec: d.Nanoseconds(), Sec: d.Nanoseconds() / time.Second.Nanoseconds()}, nil) // nolint:errcheck
 }
 
 // NanoAfter waits for the duration to elapse and then sends the current time on the returned channel.
@@ -34,7 +34,7 @@ func NanoAfter(d time.Duration) <-chan time.Time {
 	}
 	c := make(chan time.Time, 1)
 	go func() {
-		NanoSleep(d.Nanoseconds())
+		NanoSleep(d)
 		c <- time.Now()
 	}()
 	return c

--- a/util/sleep_linux.go
+++ b/util/sleep_linux.go
@@ -21,20 +21,20 @@ import (
 	"time"
 )
 
-// Nanosleep sleeps for the given ns in nanoseconds.
-func Nanosleep(ns int64) {
+// NanoSleep sleeps for the given ns in nanoseconds.
+func NanoSleep(ns int64) {
 	syscall.Nanosleep(&syscall.Timespec{Nsec: ns}, nil) // nolint:errcheck
 }
 
 // NanoAfter waits for the duration to elapse and then sends the current time on the returned channel.
 func NanoAfter(d time.Duration) <-chan time.Time {
-	// The folowing is a workaround for the go 1.16 bug, where timers are rounded up to the next millisecond resolution.
+	// The following is a workaround for the go 1.16 bug, where timers are rounded up to the next millisecond resolution.
 	if d > 10*time.Millisecond {
 		return time.After(d)
 	}
 	c := make(chan time.Time, 1)
 	go func() {
-		Nanosleep(d.Nanoseconds())
+		NanoSleep(d.Nanoseconds())
 		c <- time.Now()
 	}()
 	return c

--- a/util/sleep_linux.go
+++ b/util/sleep_linux.go
@@ -23,7 +23,7 @@ import (
 
 // NanoSleep sleeps for the given d duration.
 func NanoSleep(d time.Duration) {
-	syscall.Nanosleep(&syscall.Timespec{Nsec: d.Nanoseconds(), Sec: d.Nanoseconds() / time.Second.Nanoseconds()}, nil) // nolint:errcheck
+	syscall.Nanosleep(&syscall.Timespec{Nsec: d.Nanoseconds() % time.Second.Nanoseconds(), Sec: d.Nanoseconds() / time.Second.Nanoseconds()}, nil) // nolint:errcheck
 }
 
 // NanoAfter waits for the duration to elapse and then sends the current time on the returned channel.

--- a/util/sleep_linux.go
+++ b/util/sleep_linux.go
@@ -33,6 +33,10 @@ func NanoSleep(d time.Duration) {
 // NanoAfter waits for the duration to elapse and then sends the current time on the returned channel.
 func NanoAfter(d time.Duration) <-chan time.Time {
 	// The following is a workaround for the go 1.16 bug, where timers are rounded up to the next millisecond resolution.
+	// Go implementation for "time.After" avoids creating the go-routine until it's needed for writing the time
+	// to the channel. This is a pretty impressive implementation compared to the one below, since it's much more
+	// resource-efficient. For that reason, we'll keep calling the efficient implementation when timing is not
+	// critical ( i.e. > 10ms ).
 	if d > 10*time.Millisecond {
 		return time.After(d)
 	}

--- a/util/sleep_linux.go
+++ b/util/sleep_linux.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package util
+
+import (
+	"syscall"
+)
+
+// Nanosleep sleeps for the given ns in nanoseconds.
+func Nanosleep(ns int64) {
+	syscall.Nanosleep(&Timespec{Nsec: ns}, nil)
+}


### PR DESCRIPTION
## Summary

This PR upgrade the go-algorand repository to use go 1.16 while adding workarounds for https://github.com/golang/go/issues/44343.

## Test Plan

Use performance testing to verify no regressions.