### PR TITLE
tests: fix TestAcctUpdateslookupLatestCacheRetry

### DIFF
--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -2448,7 +2448,8 @@ func TestAcctUpdatesLookupLatestCacheRetry(t *testing.T) {
 
 	newBlock := func(au *accountUpdates, rnd basics.Round, base map[basics.Address]basics.AccountData, updates ledgercore.AccountDeltas) {
 		rewardLevel := uint64(0)
-		prevTotals, err := au.Totals(basics.Round(rnd - 1))
+		prevRound, prevTotals, err := au.LatestTotals()
+		require.Equal(t, rnd-1, prevRound)
 		require.NoError(t, err)
 
 		newTotals := ledgertesting.CalculateNewRoundAccountTotals(t, updates, rewardLevel, protoParams, base, prevTotals)


### PR DESCRIPTION
## Summary

The changes in #3770 didn't include the changes in #3769 and so tests don't compile on master currently — this updates another test that uses `Totals` to use `LatestTotals` instead.

## Test Plan

Fixes tests.