### PR TITLE
tealdbg:  Replace LocalRunner.Run with LocalRunner.RunAll

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.7.1
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=


### PR DESCRIPTION
## Summary

Removes `LocalRunner.Run` in favor of `LocalRunner.RunAll` to ensure tests follow the same debugging logic as `tealdbg` execution.

* While reviewing https://github.com/algorand/go-algorand/pull/3653 (https://github.com/algorand/go-algorand/pull/3653#discussion_r828332450), I realized `LocalRunner.Run` exists _only_ for testing purposes.   Since there's no (known) reason to retain 2 paths for the same logic, I opted to remove `Run`.
* The majority of changes focus on updating tests to reflect `RunAll`'s different method signature.  I made attempts to introduce testing facilities that I felt simplify test writing and may later be useful in other tests.  As a nascent Go programmer, it's unclear to me if I defined helper functions in _reasonable_ places.   I welcome reviewer feedback.     
* The PR updates _testify_ to take advantage of `ErrorContains`.  Diff:  https://github.com/stretchr/testify/compare/v1.7.0...v1.7.1.

## Test Plan
Ran `tealdbg` tests.
