### PR TITLE
320 rounds: online accounts DB support

### DIFF
--- a/crypto/msgp_gen.go
+++ b/crypto/msgp_gen.go
@@ -882,6 +882,9 @@ func (z *HashFactory) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	o = bts
+	if err = z.Validate(); err != nil {
+		return
+	}
 	return
 }
 

--- a/crypto/msgp_gen.go
+++ b/crypto/msgp_gen.go
@@ -882,9 +882,6 @@ func (z *HashFactory) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	o = bts
-	if err = z.Validate(); err != nil {
-		return
-	}
 	return
 }
 

--- a/data/basics/userBalance.go
+++ b/data/basics/userBalance.go
@@ -97,6 +97,7 @@ func UnmarshalStatus(value string) (s Status, err error) {
 	return
 }
 
+// VotingData holds voting-related data
 type VotingData struct {
 	VoteID       crypto.OneTimeSignatureVerifier
 	SelectionID  crypto.VRFVerifier

--- a/data/basics/userBalance.go
+++ b/data/basics/userBalance.go
@@ -97,17 +97,21 @@ func UnmarshalStatus(value string) (s Status, err error) {
 	return
 }
 
-// OnlineAccountData contains the voting information for a single account.
-//msgp:ignore OnlineAccountData
-type OnlineAccountData struct {
-	MicroAlgosWithRewards MicroAlgos
-
-	VoteID      crypto.OneTimeSignatureVerifier
-	SelectionID crypto.VRFVerifier
+type VotingData struct {
+	VoteID       crypto.OneTimeSignatureVerifier
+	SelectionID  crypto.VRFVerifier
+	StateProofID merklesignature.Verifier
 
 	VoteFirstValid  Round
 	VoteLastValid   Round
 	VoteKeyDilution uint64
+}
+
+// OnlineAccountData contains the voting information for a single account.
+//msgp:ignore OnlineAccountData
+type OnlineAccountData struct {
+	MicroAlgosWithRewards MicroAlgos
+	VotingData
 }
 
 // AccountData contains the data associated with a given address.
@@ -522,12 +526,14 @@ func (u AccountData) OnlineAccountData() OnlineAccountData {
 
 	return OnlineAccountData{
 		MicroAlgosWithRewards: u.MicroAlgos,
-
-		VoteID:          u.VoteID,
-		SelectionID:     u.SelectionID,
-		VoteFirstValid:  u.VoteFirstValid,
-		VoteLastValid:   u.VoteLastValid,
-		VoteKeyDilution: u.VoteKeyDilution,
+		VotingData: VotingData{
+			VoteID:          u.VoteID,
+			SelectionID:     u.SelectionID,
+			StateProofID:    u.StateProofID,
+			VoteFirstValid:  u.VoteFirstValid,
+			VoteLastValid:   u.VoteLastValid,
+			VoteKeyDilution: u.VoteKeyDilution,
+		},
 	}
 }
 

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -2713,15 +2713,6 @@ WHERE updround <= ?
 GROUP BY address HAVING normalizedonlinebalance > 0
 ORDER BY normalizedonlinebalance DESC, address DESC LIMIT ? OFFSET ?`, rnd, n, offset)
 
-	// TODO: make it as a test
-	// sqlite> create table t (a char, b int, r int, primary key(a, b) );
-	// sqlite> insert into t (a, b, r) values ('a', 100, 1), ('a', 0, 2), ('b', 200, 1);
-	// sqlite> select a, b, max(r) from t WHERE r <= 1 group by a HAVING b > 0 order by b desc;
-	// b|200|1
-	// a|100|1
-	// sqlite> select a, b, max(r) from t WHERE r <= 2 group by a HAVING b > 0 order by b desc;
-	// b|200|1
-
 	if err != nil {
 		return nil, err
 	}
@@ -2755,7 +2746,12 @@ ORDER BY normalizedonlinebalance DESC, address DESC LIMIT ? OFFSET ?`, rnd, n, o
 		}
 
 		copy(addr[:], addrbuf)
-		oa := data.GetOnlineAccount(addr, uint64(normBal.Int64))
+		// TODO: figure out protocol to use for rewards
+		// The original implementation uses current proto to recalculate norm balance
+		// In the same time, in accountsNewRound genesis protocol is used to fill norm balance value
+		// In order to be consistent with the original implementation recalculate the balance with current proto
+		normBalance := basics.NormalizedOnlineAccountBalance(basics.Online, data.RewardsBase, data.MicroAlgos, proto)
+		oa := data.GetOnlineAccount(addr, normBalance)
 		res[addr] = &oa
 	}
 

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -1335,12 +1335,6 @@ func (ba *baseAccountData) SetCoreAccountData(ad *ledgercore.AccountData) {
 	ba.MicroAlgos = ad.MicroAlgos
 	ba.RewardsBase = ad.RewardsBase
 	ba.RewardedMicroAlgos = ad.RewardedMicroAlgos
-	// ba.VoteID = ad.VoteID
-	// ba.SelectionID = ad.SelectionID
-	// ba.StateProofID = ad.StateProofID
-	// ba.VoteFirstValid = ad.VoteFirstValid
-	// ba.VoteLastValid = ad.VoteLastValid
-	// ba.VoteKeyDilution = ad.VoteKeyDilution
 	ba.AuthAddr = ad.AuthAddr
 	ba.TotalAppSchemaNumUint = ad.TotalAppSchema.NumUint
 	ba.TotalAppSchemaNumByteSlice = ad.TotalAppSchema.NumByteSlice
@@ -1356,12 +1350,6 @@ func (ba *baseAccountData) SetAccountData(ad *basics.AccountData) {
 	ba.MicroAlgos = ad.MicroAlgos
 	ba.RewardsBase = ad.RewardsBase
 	ba.RewardedMicroAlgos = ad.RewardedMicroAlgos
-	// ba.VoteID = ad.VoteID
-	// ba.SelectionID = ad.SelectionID
-	// ba.StateProofID = ad.StateProofID
-	// ba.VoteFirstValid = ad.VoteFirstValid
-	// ba.VoteLastValid = ad.VoteLastValid
-	// ba.VoteKeyDilution = ad.VoteKeyDilution
 	ba.AuthAddr = ad.AuthAddr
 	ba.TotalAppSchemaNumUint = ad.TotalAppSchema.NumUint
 	ba.TotalAppSchemaNumByteSlice = ad.TotalAppSchema.NumByteSlice
@@ -1403,13 +1391,7 @@ func (ba *baseAccountData) GetAccountData() basics.AccountData {
 		MicroAlgos:         ba.MicroAlgos,
 		RewardsBase:        ba.RewardsBase,
 		RewardedMicroAlgos: ba.RewardedMicroAlgos,
-		// VoteID:             ba.VoteID,
-		// SelectionID:        ba.SelectionID,
-		// StateProofID:       ba.StateProofID,
-		// VoteFirstValid:     ba.VoteFirstValid,
-		// VoteLastValid:      ba.VoteLastValid,
-		// VoteKeyDilution:    ba.VoteKeyDilution,
-		AuthAddr: ba.AuthAddr,
+		AuthAddr:           ba.AuthAddr,
 		TotalAppSchema: basics.StateSchema{
 			NumUint:      ba.TotalAppSchemaNumUint,
 			NumByteSlice: ba.TotalAppSchemaNumByteSlice,

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -2142,6 +2142,7 @@ func performOnlineAccountsTableMigration(ctx context.Context, tx *sql.Tx, log fu
 			baseOnlineAD := ba.baseOnlineAccountData
 			// TODO: recalculate MicroAlgos/RewardsBase?
 			// Probably it is OK to proceed since lookup functions will apply pending reward anyway
+			baseOnlineAD.MicroAlgos = ba.baseAccountData.MicroAlgos
 			baseOnlineAD.RewardsBase = ba.baseAccountData.RewardsBase
 			encodedOnlineAcctData := protocol.Encode(&baseOnlineAD)
 			insertRes, err = insertOnlineAcct.ExecContext(ctx, addrbuf, encodedOnlineAcctData, normBal.Int64, ba.UpdateRound, baseOnlineAD.VoteLastValid)

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -1372,32 +1372,28 @@ func (ba *baseAccountData) SetAccountData(ad *basics.AccountData) {
 	ba.TotalAppLocalStates = uint64(len(ad.AppLocalStates))
 }
 
-func (ba *baseAccountData) GetLedgerCoreAccountData() ledgercore.AccountData {
+func (ba baseAccountData) GetLedgerCoreAccountData() ledgercore.AccountData {
 	return ledgercore.AccountData{
-		AccountBaseData: ledgercore.AccountBaseData{
-			Status:             ba.Status,
-			MicroAlgos:         ba.MicroAlgos,
-			RewardsBase:        ba.RewardsBase,
-			RewardedMicroAlgos: ba.RewardedMicroAlgos,
-			AuthAddr:           ba.AuthAddr,
-			TotalAppSchema: basics.StateSchema{
-				NumUint:      ba.TotalAppSchemaNumUint,
-				NumByteSlice: ba.TotalAppSchemaNumByteSlice,
-			},
-			TotalExtraAppPages:  ba.TotalExtraAppPages,
-			TotalAppParams:      ba.TotalAppParams,
-			TotalAppLocalStates: ba.TotalAppLocalStates,
-			TotalAssetParams:    ba.TotalAssetParams,
-			TotalAssets:         ba.TotalAssets,
+		AccountBaseData: ba.GetLedgerCoreAccountBaseData(),
+	}
+}
+
+func (ba baseAccountData) GetLedgerCoreAccountBaseData() ledgercore.AccountBaseData {
+	return ledgercore.AccountBaseData{
+		Status:             ba.Status,
+		MicroAlgos:         ba.MicroAlgos,
+		RewardsBase:        ba.RewardsBase,
+		RewardedMicroAlgos: ba.RewardedMicroAlgos,
+		AuthAddr:           ba.AuthAddr,
+		TotalAppSchema: basics.StateSchema{
+			NumUint:      ba.TotalAppSchemaNumUint,
+			NumByteSlice: ba.TotalAppSchemaNumByteSlice,
 		},
-		// VotingData: ledgercore.VotingData{
-		// 	VoteID:          ba.VoteID,
-		// 	SelectionID:     ba.SelectionID,
-		// 	StateProofID:    ba.StateProofID,
-		// 	VoteFirstValid:  ba.VoteFirstValid,
-		// 	VoteLastValid:   ba.VoteLastValid,
-		// 	VoteKeyDilution: ba.VoteKeyDilution,
-		// },
+		TotalExtraAppPages:  ba.TotalExtraAppPages,
+		TotalAppParams:      ba.TotalAppParams,
+		TotalAppLocalStates: ba.TotalAppLocalStates,
+		TotalAssetParams:    ba.TotalAssetParams,
+		TotalAssets:         ba.TotalAssets,
 	}
 }
 
@@ -1453,18 +1449,21 @@ func (ba baseOnlineAccountData) GetOnlineAccount(addr basics.Address, normBalanc
 
 // GetOnlineAccountData returns basics.OnlineAccountData for lookup agreement
 // TODO: unify with GetOnlineAccount/ledgercore.OnlineAccount
-func (ba baseOnlineAccountData) GetOnlineAccountData(proto config.ConsensusParams, rewardsLevel uint64) basics.OnlineAccountData {
+func (ba baseOnlineAccountData) GetOnlineAccountData(proto config.ConsensusParams, rewardsLevel uint64) ledgercore.OnlineAccountData {
 	microAlgos, _, _ := basics.WithUpdatedRewards(
 		proto, basics.Online, ba.MicroAlgos, basics.MicroAlgos{}, ba.RewardsBase, rewardsLevel,
 	)
 
-	return basics.OnlineAccountData{
+	return ledgercore.OnlineAccountData{
 		MicroAlgosWithRewards: microAlgos,
-		VoteID:                ba.VoteID,
-		SelectionID:           ba.SelectionID,
-		VoteFirstValid:        ba.VoteFirstValid,
-		VoteLastValid:         ba.VoteLastValid,
-		VoteKeyDilution:       ba.VoteKeyDilution,
+		VotingData: ledgercore.VotingData{
+			VoteID:          ba.VoteID,
+			SelectionID:     ba.SelectionID,
+			StateProofID:    ba.StateProofID,
+			VoteFirstValid:  ba.VoteFirstValid,
+			VoteLastValid:   ba.VoteLastValid,
+			VoteKeyDilution: ba.VoteKeyDilution,
+		},
 	}
 }
 

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -2919,9 +2919,6 @@ func TestAccountOnlineQueries(t *testing.T) {
 
 		err = updateAccountsRound(tx, rnd)
 		require.NoError(t, err)
-
-		err = updateOnlineAccountsRound(tx, rnd)
-		require.NoError(t, err)
 	}
 
 	addRound(1, delta1)

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -290,7 +290,8 @@ func TestAccountDBRound(t *testing.T) {
 		}
 		require.Equal(t, resourceUpdatesCnt.len(), numResUpdates)
 
-		updatedOnlineAccts, err := onlineAccountsNewRound(tx, updatesOnlineCnt, proto, basics.Round(i))
+		// TODO: check expirations?
+		updatedOnlineAccts, _, err := onlineAccountsNewRound(tx, updatesOnlineCnt, proto, basics.Round(i))
 		require.NoError(t, err)
 
 		err = updateAccountsRound(tx, basics.Round(i))
@@ -2913,7 +2914,7 @@ func TestAccountOnlineQueries(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, updatesCnt.len(), len(updatedAccts))
 
-		updatedOnlineAccts, err := onlineAccountsNewRound(tx, updatesOnlineCnt, proto, rnd)
+		updatedOnlineAccts, _, err := onlineAccountsNewRound(tx, updatesOnlineCnt, proto, rnd)
 		require.NoError(t, err)
 		require.NotEmpty(t, updatedOnlineAccts)
 

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -2819,7 +2819,7 @@ func TestAccountOnlineQueries(t *testing.T) {
 	require.NoError(t, err)
 	defer tx.Rollback()
 
-	accts := ledgertesting.RandomAccounts(0, true)
+	var accts map[basics.Address]basics.AccountData
 	accountsInitTest(t, tx, accts, proto)
 	totals, err := accountsTotals(tx, false)
 	require.NoError(t, err)
@@ -2902,11 +2902,6 @@ func TestAccountOnlineQueries(t *testing.T) {
 
 		err = updatesOnlineCnt.accountsLoadOld(tx)
 		require.NoError(t, err)
-
-		knownAddresses := make(map[basics.Address]int64)
-		for _, delta := range updatesCnt.deltas {
-			knownAddresses[delta.oldAcct.addr] = delta.oldAcct.rowid
-		}
 
 		err = accountsPutTotals(tx, totals, false)
 		require.NoError(t, err)
@@ -3033,4 +3028,154 @@ func TestAccountOnlineQueries(t *testing.T) {
 	require.Equal(t, addrC, paod.addr)
 	require.Equal(t, dataC3.AccountBaseData.MicroAlgos, paod.accountData.MicroAlgos)
 	require.Equal(t, voteIDC, paod.accountData.VoteID)
+}
+
+func TestAccountOnlineAccountsExpirations(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+
+	dbs, _ := dbOpenTest(t, true)
+	setDbLogging(t, dbs)
+	defer dbs.Close()
+
+	addrA := ledgertesting.RandomAddress()
+	addrB := ledgertesting.RandomAddress()
+	addrC := ledgertesting.RandomAddress()
+	getAccounts := func(status basics.Status) map[basics.Address]basics.AccountData {
+		result := make(map[basics.Address]basics.AccountData, 3)
+		var voteID crypto.OneTimeSignatureVerifier
+		if status == basics.Online {
+			crypto.RandBytes(voteID[:])
+		}
+		for i, addr := range []basics.Address{addrA, addrB, addrC} {
+			result[addr] = basics.AccountData{Status: status, MicroAlgos: basics.MicroAlgos{Raw: uint64(i+1) * 100_000_000}, VoteID: voteID}
+		}
+
+		return result
+	}
+
+	// not great but looks like the only way to test the onlineAccountsExpirations query on precrafted data
+	addAccounts := func(t *testing.T, tx *sql.Tx, accts map[basics.Address]basics.AccountData, updRound int64) {
+		insertStmt, err := tx.Prepare("INSERT INTO onlineaccounts (address, normalizedonlinebalance, data, updround, votelastvalid) VALUES (?, ?, ?, ?, ?)")
+		require.NoError(t, err)
+		for addr, ad := range accts {
+			if ad.Status == basics.Offline {
+				_, err = insertStmt.Exec(addr[:], 0, []byte{}, updRound, 0)
+				require.NoError(t, err)
+			} else if ad.Status == basics.Online {
+				_, err = insertStmt.Exec(addr[:], ad.MicroAlgos.Raw, []byte{}, updRound, 0)
+				require.NoError(t, err)
+			}
+		}
+	}
+
+	t.Run("online-at-zero", func(t *testing.T) {
+		tx, err := dbs.Wdb.Handle.Begin()
+		require.NoError(t, err)
+		defer tx.Rollback()
+
+		accts := getAccounts(basics.Online)
+		accountsInitTest(t, tx, accts, proto)
+
+		result, err := onlineAccountsExpirations(tx, proto.MaxBalLookback)
+		require.NoError(t, err)
+		require.Empty(t, result)
+
+		top, err := accountsOnlineTop(tx, 0, 0, 10, proto)
+		require.NoError(t, err)
+		require.Len(t, top, 3)
+	})
+
+	t.Run("offline-at-zero", func(t *testing.T) {
+		tx, err := dbs.Wdb.Handle.Begin()
+		require.NoError(t, err)
+		defer tx.Rollback()
+
+		accountsInitTest(t, tx, map[basics.Address]basics.AccountData{}, proto)
+		accts := getAccounts(basics.Offline)
+		addAccounts(t, tx, accts, 0)
+
+		result, err := onlineAccountsExpirations(tx, proto.MaxBalLookback)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, proto.MaxBalLookback, uint64(result[0].rnd))
+		require.Len(t, result[0].rowids, 3)
+	})
+
+	t.Run("offline-online-offline-single", func(t *testing.T) {
+		tx, err := dbs.Wdb.Handle.Begin()
+		require.NoError(t, err)
+		defer tx.Rollback()
+
+		accountsInitTest(t, tx, map[basics.Address]basics.AccountData{}, proto)
+		accts := getAccounts(basics.Offline)
+		addAccounts(t, tx, accts, 0)
+		accts = getAccounts(basics.Online)
+		addAccounts(t, tx, accts, 1)
+
+		// offline entries expire at round they become offline
+		result, err := onlineAccountsExpirations(tx, proto.MaxBalLookback)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, proto.MaxBalLookback, uint64(result[0].rnd))
+		require.Len(t, result[0].rowids, 3)
+
+		// make account A offline
+		ad := accts[addrA]
+		ad.Status = basics.Offline
+		addAccounts(t, tx, map[basics.Address]basics.AccountData{addrA: ad}, 2)
+
+		// expect 3 expirations for the first offline -> online switch
+		// and two offline expirations for A (online -> offline)
+		result, err = onlineAccountsExpirations(tx, proto.MaxBalLookback)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		require.Equal(t, proto.MaxBalLookback, uint64(result[0].rnd))
+		require.Len(t, result[0].rowids, 3)
+		require.Equal(t, proto.MaxBalLookback+2, uint64(result[1].rnd))
+		require.Len(t, result[1].rowids, 2)
+	})
+
+	t.Run("online-online-online", func(t *testing.T) {
+		tx, err := dbs.Wdb.Handle.Begin()
+		require.NoError(t, err)
+		defer tx.Rollback()
+
+		accountsInitTest(t, tx, map[basics.Address]basics.AccountData{}, proto)
+		for updRound := int64(0); updRound < 3; updRound++ {
+			accts := getAccounts(basics.Online)
+			addAccounts(t, tx, accts, updRound)
+		}
+
+		// expect 2 expirations per each of two accounts
+		// expiration round is the round of the latest online (2+lookback)
+		result, err := onlineAccountsExpirations(tx, proto.MaxBalLookback)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, proto.MaxBalLookback+2, uint64(result[0].rnd))
+		require.Len(t, result[0].rowids, 6)
+	})
+
+	t.Run("online-offline-online", func(t *testing.T) {
+		tx, err := dbs.Wdb.Handle.Begin()
+		require.NoError(t, err)
+		defer tx.Rollback()
+
+		accountsInitTest(t, tx, map[basics.Address]basics.AccountData{}, proto)
+		accts := getAccounts(basics.Online)
+		addAccounts(t, tx, accts, 0)
+		accts = getAccounts(basics.Offline)
+		addAccounts(t, tx, accts, 1)
+		accts = getAccounts(basics.Online)
+		addAccounts(t, tx, accts, 2)
+
+		// expect 2 expirations per account at offline round
+		// and two offline expirations for A (online -> offline)
+		result, err := onlineAccountsExpirations(tx, proto.MaxBalLookback)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, proto.MaxBalLookback+1, uint64(result[0].rnd))
+		require.Len(t, result[0].rowids, 6)
+	})
 }

--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -145,7 +145,7 @@ func (ao *onlineAccounts) initializeFromDisk(l ledgerForTracker, lastBalancesRou
 
 		ao.roundTotals = []ledgercore.AccountTotals{totals}
 
-		ao.expirations, err0 = onlineAccountsExpiration(tx, lastBalancesRound, l.Latest(), proto.MaxBalLookback)
+		ao.expirations, err0 = onlineAccountsExpirations(tx, proto.MaxBalLookback)
 		if err0 != nil {
 			return err0
 		}

--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -578,7 +578,7 @@ func (ao *onlineAccounts) onlineTop(rnd basics.Round, voteRnd basics.Round, n ui
 			start := time.Now()
 			ledgerAccountsonlinetopCount.Inc(nil)
 			err = ao.dbs.Rdb.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
-				accts, err = accountsOnlineTop(tx, batchOffset, batchSize, genesisProto)
+				accts, err = accountsOnlineTop(tx, rnd, batchOffset, batchSize, genesisProto)
 				if err != nil {
 					return
 				}

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -285,11 +285,6 @@ func (au *accountUpdates) close() {
 	au.baseResources.prune(0)
 }
 
-// // LookupOnlineAccountData returns the online account data for a given address at a given round.
-// func (au *accountUpdates) LookupOnlineAccountData(rnd basics.Round, addr basics.Address) (data basics.OnlineAccountData, err error) {
-// 	return au.lookupOnlineAccountData(rnd, addr)
-// }
-
 func (au *accountUpdates) LookupResource(rnd basics.Round, addr basics.Address, aidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.AccountResource, basics.Round, error) {
 	return au.lookupResource(rnd, addr, aidx, ctype, true /* take lock */)
 }
@@ -1322,7 +1317,7 @@ func (au *accountUpdates) commitRound(ctx context.Context, tx *sql.Tx, dcc *defe
 		dcc.stats.OldAccountPreloadDuration = time.Duration(time.Now().UnixNano())
 	}
 
-	err = dcc.compactAccountDeltas.accountsLoadOld(tx, "accountbase")
+	err = dcc.compactAccountDeltas.accountsLoadOld(tx)
 	if err != nil {
 		return err
 	}

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -840,7 +840,7 @@ func (au *accountUpdates) lookupLatest(addr basics.Address) (data basics.Account
 		if macct, has := au.accounts[addr]; has {
 			// This is the most recent round, so we can
 			// use a cache of the most recent account state.
-			ad = macct.data
+			ad = macct.data.ClearVotingData()
 			foundAccount = true
 		} else if pad, has := au.baseAccounts.read(addr); has && pad.round == currentDbRound {
 			// we don't technically need this, since it's already in the baseAccounts, however, writing this over
@@ -1075,7 +1075,7 @@ func (au *accountUpdates) lookupWithoutRewards(rnd basics.Round, addr basics.Add
 			// Check if this is the most recent round, in which case, we can
 			// use a cache of the most recent account state.
 			if offset == uint64(len(au.deltas)) {
-				return macct.data, rnd, rewardsVersion, rewardsLevel, nil
+				return macct.data.ClearVotingData(), rnd, rewardsVersion, rewardsLevel, nil
 			}
 			// the account appears in the deltas, but we don't know if it appears in the
 			// delta range of [0..offset], so we'll need to check :
@@ -1087,7 +1087,7 @@ func (au *accountUpdates) lookupWithoutRewards(rnd basics.Round, addr basics.Add
 				if ok {
 					// the returned validThrough here is not optimal, but it still correct. We could get a more accurate value by scanning
 					// the deltas forward, but this would be time consuming loop, which might not pay off.
-					return d, rnd, rewardsVersion, rewardsLevel, nil
+					return d.ClearVotingData(), rnd, rewardsVersion, rewardsLevel, nil
 				}
 			}
 		} else {

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -2383,10 +2383,20 @@ func TestAcctUpdatesLookupLatestRetry(t *testing.T) {
 				break
 			}
 
+			withoutVotingData := func(ad basics.AccountData) basics.AccountData {
+				ad.VoteID = crypto.OneTimeSignatureVerifier{}
+				ad.SelectionID = crypto.VRFVerifier{}
+				ad.StateProofID = merklesignature.Verifier{}
+				ad.VoteKeyDilution = 0
+				ad.VoteFirstValid = 0
+				ad.VoteLastValid = 0
+				return ad
+			}
+
 			// issue a LookupWithoutRewards while persistedData.round != au.cachedDBRound
 			d, validThrough, withoutRewards, err := au.lookupLatest(addr)
 			require.NoError(t, err)
-			require.Equal(t, accts[validThrough][addr].WithUpdatedRewards(proto, rewardsLevels[validThrough]), d)
+			require.Equal(t, withoutVotingData(accts[validThrough][addr].WithUpdatedRewards(proto, rewardsLevels[validThrough])), d)
 			require.Equal(t, accts[validThrough][addr].MicroAlgos, withoutRewards)
 			require.GreaterOrEqualf(t, uint64(validThrough), uint64(rnd), "validThrough: %v rnd :%v", validThrough, rnd)
 		})

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -389,11 +389,21 @@ func TestFullCatchpointWriter(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	withoutVotingData := func(ad basics.AccountData) basics.AccountData {
+		ad.VoteID = crypto.OneTimeSignatureVerifier{}
+		ad.SelectionID = crypto.VRFVerifier{}
+		ad.StateProofID = merklesignature.Verifier{}
+		ad.VoteKeyDilution = 0
+		ad.VoteFirstValid = 0
+		ad.VoteLastValid = 0
+		return ad
+	}
+
 	// verify that the account data aligns with what we originally stored :
 	for addr, acct := range accts {
 		acctData, validThrough, _, err := l.LookupLatest(addr)
 		require.NoErrorf(t, err, "failed to lookup for account %v after restoring from catchpoint", addr)
-		require.Equal(t, acct, acctData)
+		require.Equal(t, withoutVotingData(acct), acctData)
 		require.Equal(t, basics.Round(0), validThrough)
 	}
 }

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -215,7 +215,7 @@ func TestBasicCatchpointWriter(t *testing.T) {
 	conf := config.GetDefaultLocal()
 	conf.CatchpointInterval = 1
 	conf.Archival = true
-	au := newAcctUpdates(t, ml, conf, ".")
+	au, _ := newAcctUpdates(t, ml, conf, ".")
 	err := au.loadFromDisk(ml, 0)
 	require.NoError(t, err)
 	au.close()
@@ -313,7 +313,7 @@ func TestFullCatchpointWriter(t *testing.T) {
 	conf := config.GetDefaultLocal()
 	conf.CatchpointInterval = 1
 	conf.Archival = true
-	au := newAcctUpdates(t, ml, conf, ".")
+	au, _ := newAcctUpdates(t, ml, conf, ".")
 	err := au.loadFromDisk(ml, 0)
 	require.NoError(t, err)
 	au.close()

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -478,9 +478,10 @@ func (l *Ledger) LookupLatest(addr basics.Address) (basics.AccountData, basics.R
 	if err != nil {
 		return basics.AccountData{}, basics.Round(0), basics.MicroAlgos{}, err
 	}
-	// TODO: add StateProofID, it is not in basics.OnlineAccountData
-	data.SelectionID = onlineData.SelectionID
+
 	data.VoteID = onlineData.VoteID
+	data.SelectionID = onlineData.SelectionID
+	data.StateProofID = onlineData.StateProofID
 	data.VoteKeyDilution = onlineData.VoteKeyDilution
 	data.VoteFirstValid = onlineData.VoteFirstValid
 	data.VoteLastValid = onlineData.VoteLastValid
@@ -498,26 +499,23 @@ func (l *Ledger) LookupAccount(round basics.Round, addr basics.Address) (data le
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()
 
-	data, rnd, rewardsVersion, rewardsLevel, err := l.accts.lookupWithoutRewards(round, addr, true /* take lock */)
+	baseData, rnd, rewardsVersion, rewardsLevel, err := l.accts.lookupWithoutRewards(round, addr, true /* take lock */)
 	if err != nil {
 		return ledgercore.AccountData{}, basics.Round(0), basics.MicroAlgos{}, err
 	}
 
 	// Intentionally apply (pending) rewards up to rnd, remembering the old value
 	withoutRewards = data.MicroAlgos
-	data = data.WithUpdatedRewards(config.Consensus[rewardsVersion], rewardsLevel)
 
 	// mixin online data
 	onlineData, err := l.acctsOnline.lookupOnlineAccountData(rnd, addr)
 	if err != nil {
 		return ledgercore.AccountData{}, basics.Round(0), basics.MicroAlgos{}, err
 	}
-	// TODO: add StateProofID, it is not in basics.OnlineAccountData
-	data.SelectionID = onlineData.SelectionID
-	data.VoteID = onlineData.VoteID
-	data.VoteKeyDilution = onlineData.VoteKeyDilution
-	data.VoteFirstValid = onlineData.VoteFirstValid
-	data.VoteLastValid = onlineData.VoteLastValid
+	data.AccountBaseData = baseData
+	data.VotingData = onlineData.VotingData
+
+	data = data.WithUpdatedRewards(config.Consensus[rewardsVersion], rewardsLevel)
 
 	return data, rnd, withoutRewards, nil
 }
@@ -568,7 +566,9 @@ func (l *Ledger) LookupWithoutRewards(rnd basics.Round, addr basics.Address) (le
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()
 
-	data, validThrough, err := l.accts.LookupWithoutRewards(rnd, addr)
+	var result ledgercore.AccountData
+
+	baseData, validThrough, err := l.accts.LookupWithoutRewards(rnd, addr)
 	if err != nil {
 		return ledgercore.AccountData{}, basics.Round(0), err
 	}
@@ -578,14 +578,11 @@ func (l *Ledger) LookupWithoutRewards(rnd basics.Round, addr basics.Address) (le
 	if err != nil {
 		return ledgercore.AccountData{}, basics.Round(0), err
 	}
-	// TODO: add StateProofID, it is not in basics.OnlineAccountData
-	data.SelectionID = onlineData.SelectionID
-	data.VoteID = onlineData.VoteID
-	data.VoteKeyDilution = onlineData.VoteKeyDilution
-	data.VoteFirstValid = onlineData.VoteFirstValid
-	data.VoteLastValid = onlineData.VoteLastValid
 
-	return data, validThrough, nil
+	result.AccountBaseData = baseData
+	result.VotingData = onlineData.VotingData
+
+	return result, validThrough, nil
 }
 
 // LatestTotals returns the totals of all accounts for the most recent round, as well as the round number.

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -473,6 +473,18 @@ func (l *Ledger) LookupLatest(addr basics.Address) (basics.AccountData, basics.R
 		return basics.AccountData{}, basics.Round(0), basics.MicroAlgos{}, err
 	}
 
+	// mixin online data
+	onlineData, err := l.acctsOnline.lookupOnlineAccountData(rnd, addr)
+	if err != nil {
+		return basics.AccountData{}, basics.Round(0), basics.MicroAlgos{}, err
+	}
+	// TODO: add StateProofID, it is not in basics.OnlineAccountData
+	data.SelectionID = onlineData.SelectionID
+	data.VoteID = onlineData.VoteID
+	data.VoteKeyDilution = onlineData.VoteKeyDilution
+	data.VoteFirstValid = onlineData.VoteFirstValid
+	data.VoteLastValid = onlineData.VoteLastValid
+
 	return data, rnd, withoutRewards, nil
 }
 
@@ -494,6 +506,18 @@ func (l *Ledger) LookupAccount(round basics.Round, addr basics.Address) (data le
 	// Intentionally apply (pending) rewards up to rnd, remembering the old value
 	withoutRewards = data.MicroAlgos
 	data = data.WithUpdatedRewards(config.Consensus[rewardsVersion], rewardsLevel)
+
+	// mixin online data
+	onlineData, err := l.acctsOnline.lookupOnlineAccountData(rnd, addr)
+	if err != nil {
+		return ledgercore.AccountData{}, basics.Round(0), basics.MicroAlgos{}, err
+	}
+	// TODO: add StateProofID, it is not in basics.OnlineAccountData
+	data.SelectionID = onlineData.SelectionID
+	data.VoteID = onlineData.VoteID
+	data.VoteKeyDilution = onlineData.VoteKeyDilution
+	data.VoteFirstValid = onlineData.VoteFirstValid
+	data.VoteLastValid = onlineData.VoteLastValid
 
 	return data, rnd, withoutRewards, nil
 }
@@ -548,6 +572,18 @@ func (l *Ledger) LookupWithoutRewards(rnd basics.Round, addr basics.Address) (le
 	if err != nil {
 		return ledgercore.AccountData{}, basics.Round(0), err
 	}
+
+	// mixin online data
+	onlineData, err := l.acctsOnline.lookupOnlineAccountData(rnd, addr)
+	if err != nil {
+		return ledgercore.AccountData{}, basics.Round(0), err
+	}
+	// TODO: add StateProofID, it is not in basics.OnlineAccountData
+	data.SelectionID = onlineData.SelectionID
+	data.VoteID = onlineData.VoteID
+	data.VoteKeyDilution = onlineData.VoteKeyDilution
+	data.VoteFirstValid = onlineData.VoteFirstValid
+	data.VoteLastValid = onlineData.VoteLastValid
 
 	return data, validThrough, nil
 }

--- a/ledger/ledgercore/accountdata.go
+++ b/ledger/ledgercore/accountdata.go
@@ -59,8 +59,11 @@ type VotingData struct {
 	VoteFirstValid  basics.Round
 	VoteLastValid   basics.Round
 	VoteKeyDilution uint64
+}
 
-	// MicroAlgosWithReward basics.MicroAlgos
+type OnlineAccountData struct {
+	MicroAlgosWithRewards basics.MicroAlgos
+	VotingData
 }
 
 // ToAccountData returns ledgercore.AccountData from basics.AccountData
@@ -151,33 +154,29 @@ func (u AccountData) Money(proto config.ConsensusParams, rewardsLevel uint64) (m
 }
 
 // OnlineAccountData calculates the online account data given an AccountData, by adding the rewards.
-func (u *AccountData) OnlineAccountData(proto config.ConsensusParams, rewardsLevel uint64) basics.OnlineAccountData {
+func (u *AccountData) OnlineAccountData(proto config.ConsensusParams, rewardsLevel uint64) OnlineAccountData {
 	if u.Status != basics.Online {
 		// if the account is not Online and agreement requests it for some reason, clear it out
-		return basics.OnlineAccountData{}
+		return OnlineAccountData{}
 	}
 
 	microAlgos, _, _ := basics.WithUpdatedRewards(
 		proto, u.Status, u.MicroAlgos, u.RewardedMicroAlgos, u.RewardsBase, rewardsLevel,
 	)
-	return basics.OnlineAccountData{
+	return OnlineAccountData{
 		MicroAlgosWithRewards: microAlgos,
-		VoteID:                u.VoteID,
-		SelectionID:           u.SelectionID,
-		VoteFirstValid:        u.VoteFirstValid,
-		VoteLastValid:         u.VoteLastValid,
-		VoteKeyDilution:       u.VoteKeyDilution,
+		VotingData: VotingData{
+			VoteID:          u.VoteID,
+			SelectionID:     u.SelectionID,
+			StateProofID:    u.StateProofID,
+			VoteFirstValid:  u.VoteFirstValid,
+			VoteLastValid:   u.VoteLastValid,
+			VoteKeyDilution: u.VoteKeyDilution,
+		},
 	}
 }
 
 // NormalizedOnlineBalance wraps basics.NormalizedOnlineAccountBalance
 func (u *AccountData) NormalizedOnlineBalance(genesisProto config.ConsensusParams) uint64 {
 	return basics.NormalizedOnlineAccountBalance(u.Status, u.RewardsBase, u.MicroAlgos, genesisProto)
-}
-
-// ClearVotingData clears VotingData component
-// TODO: remove / reorg AccountData
-func (u AccountData) ClearVotingData() AccountData {
-	u.VotingData = VotingData{}
-	return u
 }

--- a/ledger/ledgercore/accountdata.go
+++ b/ledger/ledgercore/accountdata.go
@@ -61,6 +61,7 @@ type VotingData struct {
 	VoteKeyDilution uint64
 }
 
+// OnlineAccountData holds MicroAlgosWithRewards and VotingData as needed for agreement
 type OnlineAccountData struct {
 	MicroAlgosWithRewards basics.MicroAlgos
 	VotingData

--- a/ledger/ledgercore/accountdata.go
+++ b/ledger/ledgercore/accountdata.go
@@ -174,3 +174,10 @@ func (u *AccountData) OnlineAccountData(proto config.ConsensusParams, rewardsLev
 func (u *AccountData) NormalizedOnlineBalance(genesisProto config.ConsensusParams) uint64 {
 	return basics.NormalizedOnlineAccountBalance(u.Status, u.RewardsBase, u.MicroAlgos, genesisProto)
 }
+
+// ClearVotingData clears VotingData component
+// TODO: remove / reorg AccountData
+func (u AccountData) ClearVotingData() AccountData {
+	u.VotingData = VotingData{}
+	return u
+}

--- a/ledger/msgp_gen.go
+++ b/ledger/msgp_gen.go
@@ -35,6 +35,14 @@ import (
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
 //
+// baseAccountDataMigrate
+//            |-----> (*) MarshalMsg
+//            |-----> (*) CanMarshalMsg
+//            |-----> (*) UnmarshalMsg
+//            |-----> (*) CanUnmarshalMsg
+//            |-----> (*) Msgsize
+//            |-----> (*) MsgIsZero
+//
 // baseOnlineAccountData
 //           |-----> (*) MarshalMsg
 //           |-----> (*) CanMarshalMsg
@@ -417,178 +425,124 @@ func (z *CatchpointFileHeader) MsgIsZero() bool {
 func (z *baseAccountData) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0001Len := uint32(19)
-	var zb0001Mask uint32 /* 21 bits */
-	if (*z).baseOnlineAccountData.VoteID.MsgIsZero() {
-		zb0001Len--
-		zb0001Mask |= 0x1
-	}
-	if (*z).baseOnlineAccountData.SelectionID.MsgIsZero() {
+	zb0001Len := uint32(13)
+	var zb0001Mask uint16 /* 14 bits */
+	if (*z).Status.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x2
 	}
-	if (*z).baseOnlineAccountData.VoteFirstValid.MsgIsZero() {
+	if (*z).MicroAlgos.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if (*z).baseOnlineAccountData.VoteLastValid.MsgIsZero() {
+	if (*z).RewardsBase == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
-	if (*z).baseOnlineAccountData.VoteKeyDilution == 0 {
+	if (*z).RewardedMicroAlgos.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x10
 	}
-	if (*z).baseOnlineAccountData.StateProofID.MsgIsZero() {
+	if (*z).AuthAddr.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x20
 	}
-	if (*z).Status.MsgIsZero() {
-		zb0001Len--
-		zb0001Mask |= 0x100
-	}
-	if (*z).MicroAlgos.MsgIsZero() {
-		zb0001Len--
-		zb0001Mask |= 0x200
-	}
-	if (*z).RewardsBase == 0 {
-		zb0001Len--
-		zb0001Mask |= 0x400
-	}
-	if (*z).RewardedMicroAlgos.MsgIsZero() {
-		zb0001Len--
-		zb0001Mask |= 0x800
-	}
-	if (*z).AuthAddr.MsgIsZero() {
-		zb0001Len--
-		zb0001Mask |= 0x1000
-	}
 	if (*z).TotalAppSchemaNumUint == 0 {
 		zb0001Len--
-		zb0001Mask |= 0x2000
+		zb0001Mask |= 0x40
 	}
 	if (*z).TotalAppSchemaNumByteSlice == 0 {
 		zb0001Len--
-		zb0001Mask |= 0x4000
+		zb0001Mask |= 0x80
 	}
 	if (*z).TotalExtraAppPages == 0 {
 		zb0001Len--
-		zb0001Mask |= 0x8000
+		zb0001Mask |= 0x100
 	}
 	if (*z).TotalAssetParams == 0 {
 		zb0001Len--
-		zb0001Mask |= 0x10000
+		zb0001Mask |= 0x200
 	}
 	if (*z).TotalAssets == 0 {
 		zb0001Len--
-		zb0001Mask |= 0x20000
+		zb0001Mask |= 0x400
 	}
 	if (*z).TotalAppParams == 0 {
 		zb0001Len--
-		zb0001Mask |= 0x40000
+		zb0001Mask |= 0x800
 	}
 	if (*z).TotalAppLocalStates == 0 {
 		zb0001Len--
-		zb0001Mask |= 0x80000
+		zb0001Mask |= 0x1000
 	}
 	if (*z).UpdateRound == 0 {
 		zb0001Len--
-		zb0001Mask |= 0x100000
+		zb0001Mask |= 0x2000
 	}
 	// variable map header, size zb0001Len
-	o = msgp.AppendMapHeader(o, zb0001Len)
+	o = append(o, 0x80|uint8(zb0001Len))
 	if zb0001Len != 0 {
-		if (zb0001Mask & 0x1) == 0 { // if not empty
-			// string "A"
-			o = append(o, 0xa1, 0x41)
-			o = (*z).baseOnlineAccountData.VoteID.MarshalMsg(o)
-		}
 		if (zb0001Mask & 0x2) == 0 { // if not empty
-			// string "B"
-			o = append(o, 0xa1, 0x42)
-			o = (*z).baseOnlineAccountData.SelectionID.MarshalMsg(o)
-		}
-		if (zb0001Mask & 0x4) == 0 { // if not empty
-			// string "C"
-			o = append(o, 0xa1, 0x43)
-			o = (*z).baseOnlineAccountData.VoteFirstValid.MarshalMsg(o)
-		}
-		if (zb0001Mask & 0x8) == 0 { // if not empty
-			// string "D"
-			o = append(o, 0xa1, 0x44)
-			o = (*z).baseOnlineAccountData.VoteLastValid.MarshalMsg(o)
-		}
-		if (zb0001Mask & 0x10) == 0 { // if not empty
-			// string "E"
-			o = append(o, 0xa1, 0x45)
-			o = msgp.AppendUint64(o, (*z).baseOnlineAccountData.VoteKeyDilution)
-		}
-		if (zb0001Mask & 0x20) == 0 { // if not empty
-			// string "F"
-			o = append(o, 0xa1, 0x46)
-			o = (*z).baseOnlineAccountData.StateProofID.MarshalMsg(o)
-		}
-		if (zb0001Mask & 0x100) == 0 { // if not empty
 			// string "a"
 			o = append(o, 0xa1, 0x61)
 			o = (*z).Status.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x200) == 0 { // if not empty
+		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "b"
 			o = append(o, 0xa1, 0x62)
 			o = (*z).MicroAlgos.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x400) == 0 { // if not empty
+		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "c"
 			o = append(o, 0xa1, 0x63)
 			o = msgp.AppendUint64(o, (*z).RewardsBase)
 		}
-		if (zb0001Mask & 0x800) == 0 { // if not empty
+		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "d"
 			o = append(o, 0xa1, 0x64)
 			o = (*z).RewardedMicroAlgos.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x1000) == 0 { // if not empty
+		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "e"
 			o = append(o, 0xa1, 0x65)
 			o = (*z).AuthAddr.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x2000) == 0 { // if not empty
+		if (zb0001Mask & 0x40) == 0 { // if not empty
 			// string "f"
 			o = append(o, 0xa1, 0x66)
 			o = msgp.AppendUint64(o, (*z).TotalAppSchemaNumUint)
 		}
-		if (zb0001Mask & 0x4000) == 0 { // if not empty
+		if (zb0001Mask & 0x80) == 0 { // if not empty
 			// string "g"
 			o = append(o, 0xa1, 0x67)
 			o = msgp.AppendUint64(o, (*z).TotalAppSchemaNumByteSlice)
 		}
-		if (zb0001Mask & 0x8000) == 0 { // if not empty
+		if (zb0001Mask & 0x100) == 0 { // if not empty
 			// string "h"
 			o = append(o, 0xa1, 0x68)
 			o = msgp.AppendUint32(o, (*z).TotalExtraAppPages)
 		}
-		if (zb0001Mask & 0x10000) == 0 { // if not empty
+		if (zb0001Mask & 0x200) == 0 { // if not empty
 			// string "i"
 			o = append(o, 0xa1, 0x69)
 			o = msgp.AppendUint64(o, (*z).TotalAssetParams)
 		}
-		if (zb0001Mask & 0x20000) == 0 { // if not empty
+		if (zb0001Mask & 0x400) == 0 { // if not empty
 			// string "j"
 			o = append(o, 0xa1, 0x6a)
 			o = msgp.AppendUint64(o, (*z).TotalAssets)
 		}
-		if (zb0001Mask & 0x40000) == 0 { // if not empty
+		if (zb0001Mask & 0x800) == 0 { // if not empty
 			// string "k"
 			o = append(o, 0xa1, 0x6b)
 			o = msgp.AppendUint64(o, (*z).TotalAppParams)
 		}
-		if (zb0001Mask & 0x80000) == 0 { // if not empty
+		if (zb0001Mask & 0x1000) == 0 { // if not empty
 			// string "l"
 			o = append(o, 0xa1, 0x6c)
 			o = msgp.AppendUint64(o, (*z).TotalAppLocalStates)
 		}
-		if (zb0001Mask & 0x100000) == 0 { // if not empty
+		if (zb0001Mask & 0x2000) == 0 { // if not empty
 			// string "z"
 			o = append(o, 0xa1, 0x7a)
 			o = msgp.AppendUint64(o, (*z).UpdateRound)
@@ -713,54 +667,6 @@ func (z *baseAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0001 > 0 {
 			zb0001--
-			bts, err = (*z).baseOnlineAccountData.VoteID.UnmarshalMsg(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "VoteID")
-				return
-			}
-		}
-		if zb0001 > 0 {
-			zb0001--
-			bts, err = (*z).baseOnlineAccountData.SelectionID.UnmarshalMsg(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "SelectionID")
-				return
-			}
-		}
-		if zb0001 > 0 {
-			zb0001--
-			bts, err = (*z).baseOnlineAccountData.VoteFirstValid.UnmarshalMsg(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "VoteFirstValid")
-				return
-			}
-		}
-		if zb0001 > 0 {
-			zb0001--
-			bts, err = (*z).baseOnlineAccountData.VoteLastValid.UnmarshalMsg(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "VoteLastValid")
-				return
-			}
-		}
-		if zb0001 > 0 {
-			zb0001--
-			(*z).baseOnlineAccountData.VoteKeyDilution, bts, err = msgp.ReadUint64Bytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "VoteKeyDilution")
-				return
-			}
-		}
-		if zb0001 > 0 {
-			zb0001--
-			bts, err = (*z).baseOnlineAccountData.StateProofID.UnmarshalMsg(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "StateProofID")
-				return
-			}
-		}
-		if zb0001 > 0 {
-			zb0001--
 			(*z).UpdateRound, bts, err = msgp.ReadUint64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "UpdateRound")
@@ -862,6 +768,530 @@ func (z *baseAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "TotalAppLocalStates")
 					return
 				}
+			case "z":
+				(*z).UpdateRound, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "UpdateRound")
+					return
+				}
+			default:
+				err = msgp.ErrNoField(string(field))
+				if err != nil {
+					err = msgp.WrapError(err)
+					return
+				}
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (_ *baseAccountData) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*baseAccountData)
+	return ok
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *baseAccountData) Msgsize() (s int) {
+	s = 1 + 2 + (*z).Status.Msgsize() + 2 + (*z).MicroAlgos.Msgsize() + 2 + msgp.Uint64Size + 2 + (*z).RewardedMicroAlgos.Msgsize() + 2 + (*z).AuthAddr.Msgsize() + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint32Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size
+	return
+}
+
+// MsgIsZero returns whether this is a zero value
+func (z *baseAccountData) MsgIsZero() bool {
+	return ((*z).Status.MsgIsZero()) && ((*z).MicroAlgos.MsgIsZero()) && ((*z).RewardsBase == 0) && ((*z).RewardedMicroAlgos.MsgIsZero()) && ((*z).AuthAddr.MsgIsZero()) && ((*z).TotalAppSchemaNumUint == 0) && ((*z).TotalAppSchemaNumByteSlice == 0) && ((*z).TotalExtraAppPages == 0) && ((*z).TotalAssetParams == 0) && ((*z).TotalAssets == 0) && ((*z).TotalAppParams == 0) && ((*z).TotalAppLocalStates == 0) && ((*z).UpdateRound == 0)
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *baseAccountDataMigrate) MarshalMsg(b []byte) (o []byte) {
+	o = msgp.Require(b, z.Msgsize())
+	// omitempty: check for empty values
+	zb0001Len := uint32(21)
+	var zb0001Mask uint32 /* 24 bits */
+	if (*z).baseOnlineAccountData.VoteID.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if (*z).baseOnlineAccountData.SelectionID.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if (*z).baseOnlineAccountData.VoteFirstValid.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if (*z).baseOnlineAccountData.VoteLastValid.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if (*z).baseOnlineAccountData.VoteKeyDilution == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if (*z).baseOnlineAccountData.StateProofID.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if (*z).baseOnlineAccountData.MicroAlgos.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if (*z).baseOnlineAccountData.RewardsBase == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	if (*z).baseAccountData.Status.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x800
+	}
+	if (*z).baseAccountData.MicroAlgos.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x1000
+	}
+	if (*z).baseAccountData.RewardsBase == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2000
+	}
+	if (*z).baseAccountData.RewardedMicroAlgos.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x4000
+	}
+	if (*z).baseAccountData.AuthAddr.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x8000
+	}
+	if (*z).baseAccountData.TotalAppSchemaNumUint == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x10000
+	}
+	if (*z).baseAccountData.TotalAppSchemaNumByteSlice == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x20000
+	}
+	if (*z).baseAccountData.TotalExtraAppPages == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x40000
+	}
+	if (*z).baseAccountData.TotalAssetParams == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80000
+	}
+	if (*z).baseAccountData.TotalAssets == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x100000
+	}
+	if (*z).baseAccountData.TotalAppParams == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x200000
+	}
+	if (*z).baseAccountData.TotalAppLocalStates == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x400000
+	}
+	if (*z).baseAccountData.UpdateRound == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x800000
+	}
+	// variable map header, size zb0001Len
+	o = msgp.AppendMapHeader(o, zb0001Len)
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not empty
+			// string "A"
+			o = append(o, 0xa1, 0x41)
+			o = (*z).baseOnlineAccountData.VoteID.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not empty
+			// string "B"
+			o = append(o, 0xa1, 0x42)
+			o = (*z).baseOnlineAccountData.SelectionID.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not empty
+			// string "C"
+			o = append(o, 0xa1, 0x43)
+			o = (*z).baseOnlineAccountData.VoteFirstValid.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not empty
+			// string "D"
+			o = append(o, 0xa1, 0x44)
+			o = (*z).baseOnlineAccountData.VoteLastValid.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not empty
+			// string "E"
+			o = append(o, 0xa1, 0x45)
+			o = msgp.AppendUint64(o, (*z).baseOnlineAccountData.VoteKeyDilution)
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not empty
+			// string "F"
+			o = append(o, 0xa1, 0x46)
+			o = (*z).baseOnlineAccountData.StateProofID.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not empty
+			// string "G"
+			o = append(o, 0xa1, 0x47)
+			o = (*z).baseOnlineAccountData.MicroAlgos.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not empty
+			// string "H"
+			o = append(o, 0xa1, 0x48)
+			o = msgp.AppendUint64(o, (*z).baseOnlineAccountData.RewardsBase)
+		}
+		if (zb0001Mask & 0x800) == 0 { // if not empty
+			// string "a"
+			o = append(o, 0xa1, 0x61)
+			o = (*z).baseAccountData.Status.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x1000) == 0 { // if not empty
+			// string "b"
+			o = append(o, 0xa1, 0x62)
+			o = (*z).baseAccountData.MicroAlgos.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x2000) == 0 { // if not empty
+			// string "c"
+			o = append(o, 0xa1, 0x63)
+			o = msgp.AppendUint64(o, (*z).baseAccountData.RewardsBase)
+		}
+		if (zb0001Mask & 0x4000) == 0 { // if not empty
+			// string "d"
+			o = append(o, 0xa1, 0x64)
+			o = (*z).baseAccountData.RewardedMicroAlgos.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x8000) == 0 { // if not empty
+			// string "e"
+			o = append(o, 0xa1, 0x65)
+			o = (*z).baseAccountData.AuthAddr.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x10000) == 0 { // if not empty
+			// string "f"
+			o = append(o, 0xa1, 0x66)
+			o = msgp.AppendUint64(o, (*z).baseAccountData.TotalAppSchemaNumUint)
+		}
+		if (zb0001Mask & 0x20000) == 0 { // if not empty
+			// string "g"
+			o = append(o, 0xa1, 0x67)
+			o = msgp.AppendUint64(o, (*z).baseAccountData.TotalAppSchemaNumByteSlice)
+		}
+		if (zb0001Mask & 0x40000) == 0 { // if not empty
+			// string "h"
+			o = append(o, 0xa1, 0x68)
+			o = msgp.AppendUint32(o, (*z).baseAccountData.TotalExtraAppPages)
+		}
+		if (zb0001Mask & 0x80000) == 0 { // if not empty
+			// string "i"
+			o = append(o, 0xa1, 0x69)
+			o = msgp.AppendUint64(o, (*z).baseAccountData.TotalAssetParams)
+		}
+		if (zb0001Mask & 0x100000) == 0 { // if not empty
+			// string "j"
+			o = append(o, 0xa1, 0x6a)
+			o = msgp.AppendUint64(o, (*z).baseAccountData.TotalAssets)
+		}
+		if (zb0001Mask & 0x200000) == 0 { // if not empty
+			// string "k"
+			o = append(o, 0xa1, 0x6b)
+			o = msgp.AppendUint64(o, (*z).baseAccountData.TotalAppParams)
+		}
+		if (zb0001Mask & 0x400000) == 0 { // if not empty
+			// string "l"
+			o = append(o, 0xa1, 0x6c)
+			o = msgp.AppendUint64(o, (*z).baseAccountData.TotalAppLocalStates)
+		}
+		if (zb0001Mask & 0x800000) == 0 { // if not empty
+			// string "z"
+			o = append(o, 0xa1, 0x7a)
+			o = msgp.AppendUint64(o, (*z).baseAccountData.UpdateRound)
+		}
+	}
+	return
+}
+
+func (_ *baseAccountDataMigrate) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(*baseAccountDataMigrate)
+	return ok
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *baseAccountDataMigrate) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 int
+	var zb0002 bool
+	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if _, ok := err.(msgp.TypeError); ok {
+		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).baseAccountData.Status.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Status")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).baseAccountData.MicroAlgos.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "MicroAlgos")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			(*z).baseAccountData.RewardsBase, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "RewardsBase")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).baseAccountData.RewardedMicroAlgos.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "RewardedMicroAlgos")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).baseAccountData.AuthAddr.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "AuthAddr")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			(*z).baseAccountData.TotalAppSchemaNumUint, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "TotalAppSchemaNumUint")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			(*z).baseAccountData.TotalAppSchemaNumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "TotalAppSchemaNumByteSlice")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			(*z).baseAccountData.TotalExtraAppPages, bts, err = msgp.ReadUint32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "TotalExtraAppPages")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			(*z).baseAccountData.TotalAssetParams, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "TotalAssetParams")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			(*z).baseAccountData.TotalAssets, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "TotalAssets")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			(*z).baseAccountData.TotalAppParams, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "TotalAppParams")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			(*z).baseAccountData.TotalAppLocalStates, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "TotalAppLocalStates")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			(*z).baseAccountData.UpdateRound, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "UpdateRound")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).baseOnlineAccountData.VoteID.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "VoteID")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).baseOnlineAccountData.SelectionID.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "SelectionID")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).baseOnlineAccountData.VoteFirstValid.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "VoteFirstValid")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).baseOnlineAccountData.VoteLastValid.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "VoteLastValid")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			(*z).baseOnlineAccountData.VoteKeyDilution, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "VoteKeyDilution")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).baseOnlineAccountData.StateProofID.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "StateProofID")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).baseOnlineAccountData.MicroAlgos.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "MicroAlgos")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			(*z).baseOnlineAccountData.RewardsBase, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "RewardsBase")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			err = msgp.ErrTooManyArrayFields(zb0001)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array")
+				return
+			}
+		}
+	} else {
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0002 {
+			(*z) = baseAccountDataMigrate{}
+		}
+		for zb0001 > 0 {
+			zb0001--
+			field, bts, err = msgp.ReadMapKeyZC(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+			switch string(field) {
+			case "a":
+				bts, err = (*z).baseAccountData.Status.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Status")
+					return
+				}
+			case "b":
+				bts, err = (*z).baseAccountData.MicroAlgos.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "MicroAlgos")
+					return
+				}
+			case "c":
+				(*z).baseAccountData.RewardsBase, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "RewardsBase")
+					return
+				}
+			case "d":
+				bts, err = (*z).baseAccountData.RewardedMicroAlgos.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "RewardedMicroAlgos")
+					return
+				}
+			case "e":
+				bts, err = (*z).baseAccountData.AuthAddr.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "AuthAddr")
+					return
+				}
+			case "f":
+				(*z).baseAccountData.TotalAppSchemaNumUint, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "TotalAppSchemaNumUint")
+					return
+				}
+			case "g":
+				(*z).baseAccountData.TotalAppSchemaNumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "TotalAppSchemaNumByteSlice")
+					return
+				}
+			case "h":
+				(*z).baseAccountData.TotalExtraAppPages, bts, err = msgp.ReadUint32Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "TotalExtraAppPages")
+					return
+				}
+			case "i":
+				(*z).baseAccountData.TotalAssetParams, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "TotalAssetParams")
+					return
+				}
+			case "j":
+				(*z).baseAccountData.TotalAssets, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "TotalAssets")
+					return
+				}
+			case "k":
+				(*z).baseAccountData.TotalAppParams, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "TotalAppParams")
+					return
+				}
+			case "l":
+				(*z).baseAccountData.TotalAppLocalStates, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "TotalAppLocalStates")
+					return
+				}
+			case "z":
+				(*z).baseAccountData.UpdateRound, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "UpdateRound")
+					return
+				}
 			case "A":
 				bts, err = (*z).baseOnlineAccountData.VoteID.UnmarshalMsg(bts)
 				if err != nil {
@@ -898,10 +1328,16 @@ func (z *baseAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "StateProofID")
 					return
 				}
-			case "z":
-				(*z).UpdateRound, bts, err = msgp.ReadUint64Bytes(bts)
+			case "G":
+				bts, err = (*z).baseOnlineAccountData.MicroAlgos.UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "UpdateRound")
+					err = msgp.WrapError(err, "MicroAlgos")
+					return
+				}
+			case "H":
+				(*z).baseOnlineAccountData.RewardsBase, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "RewardsBase")
 					return
 				}
 			default:
@@ -917,28 +1353,28 @@ func (z *baseAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
-func (_ *baseAccountData) CanUnmarshalMsg(z interface{}) bool {
-	_, ok := (z).(*baseAccountData)
+func (_ *baseAccountDataMigrate) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*baseAccountDataMigrate)
 	return ok
 }
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z *baseAccountData) Msgsize() (s int) {
-	s = 3 + 2 + (*z).Status.Msgsize() + 2 + (*z).MicroAlgos.Msgsize() + 2 + msgp.Uint64Size + 2 + (*z).RewardedMicroAlgos.Msgsize() + 2 + (*z).AuthAddr.Msgsize() + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint32Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + (*z).baseOnlineAccountData.VoteID.Msgsize() + 2 + (*z).baseOnlineAccountData.SelectionID.Msgsize() + 2 + (*z).baseOnlineAccountData.VoteFirstValid.Msgsize() + 2 + (*z).baseOnlineAccountData.VoteLastValid.Msgsize() + 2 + msgp.Uint64Size + 2 + (*z).baseOnlineAccountData.StateProofID.Msgsize() + 2 + msgp.Uint64Size
+func (z *baseAccountDataMigrate) Msgsize() (s int) {
+	s = 3 + 2 + (*z).baseAccountData.Status.Msgsize() + 2 + (*z).baseAccountData.MicroAlgos.Msgsize() + 2 + msgp.Uint64Size + 2 + (*z).baseAccountData.RewardedMicroAlgos.Msgsize() + 2 + (*z).baseAccountData.AuthAddr.Msgsize() + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint32Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + (*z).baseOnlineAccountData.VoteID.Msgsize() + 2 + (*z).baseOnlineAccountData.SelectionID.Msgsize() + 2 + (*z).baseOnlineAccountData.VoteFirstValid.Msgsize() + 2 + (*z).baseOnlineAccountData.VoteLastValid.Msgsize() + 2 + msgp.Uint64Size + 2 + (*z).baseOnlineAccountData.StateProofID.Msgsize() + 2 + (*z).baseOnlineAccountData.MicroAlgos.Msgsize() + 2 + msgp.Uint64Size
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
-func (z *baseAccountData) MsgIsZero() bool {
-	return ((*z).Status.MsgIsZero()) && ((*z).MicroAlgos.MsgIsZero()) && ((*z).RewardsBase == 0) && ((*z).RewardedMicroAlgos.MsgIsZero()) && ((*z).AuthAddr.MsgIsZero()) && ((*z).TotalAppSchemaNumUint == 0) && ((*z).TotalAppSchemaNumByteSlice == 0) && ((*z).TotalExtraAppPages == 0) && ((*z).TotalAssetParams == 0) && ((*z).TotalAssets == 0) && ((*z).TotalAppParams == 0) && ((*z).TotalAppLocalStates == 0) && ((*z).baseOnlineAccountData.VoteID.MsgIsZero()) && ((*z).baseOnlineAccountData.SelectionID.MsgIsZero()) && ((*z).baseOnlineAccountData.VoteFirstValid.MsgIsZero()) && ((*z).baseOnlineAccountData.VoteLastValid.MsgIsZero()) && ((*z).baseOnlineAccountData.VoteKeyDilution == 0) && ((*z).baseOnlineAccountData.StateProofID.MsgIsZero()) && ((*z).UpdateRound == 0)
+func (z *baseAccountDataMigrate) MsgIsZero() bool {
+	return ((*z).baseAccountData.Status.MsgIsZero()) && ((*z).baseAccountData.MicroAlgos.MsgIsZero()) && ((*z).baseAccountData.RewardsBase == 0) && ((*z).baseAccountData.RewardedMicroAlgos.MsgIsZero()) && ((*z).baseAccountData.AuthAddr.MsgIsZero()) && ((*z).baseAccountData.TotalAppSchemaNumUint == 0) && ((*z).baseAccountData.TotalAppSchemaNumByteSlice == 0) && ((*z).baseAccountData.TotalExtraAppPages == 0) && ((*z).baseAccountData.TotalAssetParams == 0) && ((*z).baseAccountData.TotalAssets == 0) && ((*z).baseAccountData.TotalAppParams == 0) && ((*z).baseAccountData.TotalAppLocalStates == 0) && ((*z).baseAccountData.UpdateRound == 0) && ((*z).baseOnlineAccountData.VoteID.MsgIsZero()) && ((*z).baseOnlineAccountData.SelectionID.MsgIsZero()) && ((*z).baseOnlineAccountData.VoteFirstValid.MsgIsZero()) && ((*z).baseOnlineAccountData.VoteLastValid.MsgIsZero()) && ((*z).baseOnlineAccountData.VoteKeyDilution == 0) && ((*z).baseOnlineAccountData.StateProofID.MsgIsZero()) && ((*z).baseOnlineAccountData.MicroAlgos.MsgIsZero()) && ((*z).baseOnlineAccountData.RewardsBase == 0)
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z *baseOnlineAccountData) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0001Len := uint32(6)
-	var zb0001Mask uint8 /* 7 bits */
+	zb0001Len := uint32(8)
+	var zb0001Mask uint16 /* 9 bits */
 	if (*z).VoteID.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x1
@@ -962,6 +1398,14 @@ func (z *baseOnlineAccountData) MarshalMsg(b []byte) (o []byte) {
 	if (*z).StateProofID.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x20
+	}
+	if (*z).MicroAlgos.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if (*z).RewardsBase == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -995,6 +1439,16 @@ func (z *baseOnlineAccountData) MarshalMsg(b []byte) (o []byte) {
 			// string "F"
 			o = append(o, 0xa1, 0x46)
 			o = (*z).StateProofID.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not empty
+			// string "G"
+			o = append(o, 0xa1, 0x47)
+			o = (*z).MicroAlgos.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not empty
+			// string "H"
+			o = append(o, 0xa1, 0x48)
+			o = msgp.AppendUint64(o, (*z).RewardsBase)
 		}
 	}
 	return
@@ -1067,6 +1521,22 @@ func (z *baseOnlineAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 		}
 		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).MicroAlgos.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "MicroAlgos")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			(*z).RewardsBase, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "RewardsBase")
+				return
+			}
+		}
+		if zb0001 > 0 {
 			err = msgp.ErrTooManyArrayFields(zb0001)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array")
@@ -1125,6 +1595,18 @@ func (z *baseOnlineAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "StateProofID")
 					return
 				}
+			case "G":
+				bts, err = (*z).MicroAlgos.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "MicroAlgos")
+					return
+				}
+			case "H":
+				(*z).RewardsBase, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "RewardsBase")
+					return
+				}
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1145,13 +1627,13 @@ func (_ *baseOnlineAccountData) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *baseOnlineAccountData) Msgsize() (s int) {
-	s = 1 + 2 + (*z).VoteID.Msgsize() + 2 + (*z).SelectionID.Msgsize() + 2 + (*z).VoteFirstValid.Msgsize() + 2 + (*z).VoteLastValid.Msgsize() + 2 + msgp.Uint64Size + 2 + (*z).StateProofID.Msgsize()
+	s = 1 + 2 + (*z).VoteID.Msgsize() + 2 + (*z).SelectionID.Msgsize() + 2 + (*z).VoteFirstValid.Msgsize() + 2 + (*z).VoteLastValid.Msgsize() + 2 + msgp.Uint64Size + 2 + (*z).StateProofID.Msgsize() + 2 + (*z).MicroAlgos.Msgsize() + 2 + msgp.Uint64Size
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *baseOnlineAccountData) MsgIsZero() bool {
-	return ((*z).VoteID.MsgIsZero()) && ((*z).SelectionID.MsgIsZero()) && ((*z).VoteFirstValid.MsgIsZero()) && ((*z).VoteLastValid.MsgIsZero()) && ((*z).VoteKeyDilution == 0) && ((*z).StateProofID.MsgIsZero())
+	return ((*z).VoteID.MsgIsZero()) && ((*z).SelectionID.MsgIsZero()) && ((*z).VoteFirstValid.MsgIsZero()) && ((*z).VoteLastValid.MsgIsZero()) && ((*z).VoteKeyDilution == 0) && ((*z).StateProofID.MsgIsZero()) && ((*z).MicroAlgos.MsgIsZero()) && ((*z).RewardsBase == 0)
 }
 
 // MarshalMsg implements msgp.Marshaler

--- a/ledger/msgp_gen_test.go
+++ b/ledger/msgp_gen_test.go
@@ -132,6 +132,66 @@ func BenchmarkUnmarshalbaseAccountData(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalbaseAccountDataMigrate(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	v := baseAccountDataMigrate{}
+	bts := v.MarshalMsg(nil)
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func TestRandomizedEncodingbaseAccountDataMigrate(t *testing.T) {
+	protocol.RunEncodingTest(t, &baseAccountDataMigrate{})
+}
+
+func BenchmarkMarshalMsgbaseAccountDataMigrate(b *testing.B) {
+	v := baseAccountDataMigrate{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgbaseAccountDataMigrate(b *testing.B) {
+	v := baseAccountDataMigrate{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalbaseAccountDataMigrate(b *testing.B) {
+	v := baseAccountDataMigrate{}
+	bts := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalbaseOnlineAccountData(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	v := baseOnlineAccountData{}

--- a/ledger/testing/initState.go
+++ b/ledger/testing/initState.go
@@ -65,7 +65,10 @@ func GenerateInitState(tb testing.TB, proto protocol.ConsensusVersion, baseAlgoP
 	for i := range genaddrs {
 		initKeys[genaddrs[i]] = gensecrets[i]
 		// Give each account quite a bit more balance than MinFee or MinBalance
-		initAccounts[genaddrs[i]] = basics.MakeAccountData(basics.Online, basics.MicroAlgos{Raw: uint64((i + baseAlgoPerAccount) * 100000)})
+		ad := basics.MakeAccountData(basics.Online, basics.MicroAlgos{Raw: uint64((i + baseAlgoPerAccount) * 100000)})
+		ad.VoteFirstValid = 1
+		ad.VoteLastValid = 100_000
+		initAccounts[genaddrs[i]] = ad
 	}
 	initKeys[poolAddr] = poolSecret
 	initAccounts[poolAddr] = basics.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 1234567})

--- a/ledger/testing/randomAccounts.go
+++ b/ledger/testing/randomAccounts.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/crypto/merklesignature"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/protocol"
 
@@ -56,15 +57,16 @@ func RandomAccountData(rewardsLevel uint64) basics.AccountData {
 	switch crypto.RandUint64() % 3 {
 	case 0:
 		data.Status = basics.Online
+		data.VoteLastValid = 1000
 	case 1:
 		data.Status = basics.Offline
+		data.VoteLastValid = 0
 	default:
 		data.Status = basics.NotParticipating
 	}
 
-	data.RewardsBase = rewardsLevel
 	data.VoteFirstValid = 0
-	data.VoteLastValid = 1000
+	data.RewardsBase = rewardsLevel
 	return data
 }
 
@@ -186,16 +188,27 @@ func RandomAppLocalState() basics.AppLocalState {
 	return ls
 }
 
+const maxInt64 = int64((^uint64(0)) >> 1)
+
 // RandomFullAccountData generates a random AccountData
 func RandomFullAccountData(rewardsLevel uint64, knownCreatables map[basics.CreatableIndex]basics.CreatableType, lastCreatableID uint64) (basics.AccountData, map[basics.CreatableIndex]basics.CreatableType, uint64) {
 	data := RandomAccountData(rewardsLevel)
 
-	crypto.RandBytes(data.VoteID[:])
-	crypto.RandBytes(data.SelectionID[:])
-	crypto.RandBytes(data.StateProofID[:])
-	data.VoteFirstValid = basics.Round(crypto.RandUint64())
-	data.VoteLastValid = basics.Round(crypto.RandUint64())
-	data.VoteKeyDilution = crypto.RandUint64()
+	if data.Status == basics.Online {
+		crypto.RandBytes(data.VoteID[:])
+		crypto.RandBytes(data.SelectionID[:])
+		crypto.RandBytes(data.StateProofID[:])
+		data.VoteFirstValid = basics.Round(crypto.RandUint64())
+		data.VoteLastValid = basics.Round(crypto.RandUint64() % uint64(maxInt64)) // int64 is the max sqlite can store
+		data.VoteKeyDilution = crypto.RandUint64()
+	} else {
+		data.VoteID = crypto.OneTimeSignatureVerifier{}
+		data.SelectionID = crypto.VRFVerifier{}
+		data.StateProofID = merklesignature.Verifier{}
+		data.VoteFirstValid = 0
+		data.VoteLastValid = 0
+		data.VoteKeyDilution = 0
+	}
 	if (crypto.RandUint64() % 2) == 1 {
 		// if account has created assets, have these defined.
 		createdAssetsCount := crypto.RandUint64()%20 + 1

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -230,6 +230,9 @@ type deferredCommitContext struct {
 
 	compactOnlineAccountDeltas     compactOnlineAccountDeltas
 	updatedPersistedOnlineAccounts []persistedOnlineAccountData
+	onlineAccountExpirations       []onlineAccountExpiration
+	onlineAccountExpiredRowids     []int64
+	expirationOffset               uint64
 
 	committedRoundDigest     crypto.Digest
 	trieBalancesHash         crypto.Digest
@@ -295,7 +298,7 @@ func (tr *trackerRegistry) loadFromDisk(l ledgerForTracker) error {
 		return fmt.Errorf("initializeTrackerCaches failed : %w", err)
 	}
 
-	// the votes have a special dependency on the account updates, so we need to initialize these separetly.
+	// the votes have a special dependency on the account updates, so we need to initialize these separately.
 	tr.acctsOnline.voters = &votersTracker{}
 	err = tr.acctsOnline.voters.loadFromDisk(l, tr.acctsOnline)
 	if err != nil {

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -236,8 +236,8 @@ type deferredCommitContext struct {
 	updatedPersistedAccounts  []persistedAccountData
 	updatedPersistedResources map[basics.Address][]persistedResourcesData
 
-	compactAccountDeltasOnline     compactAccountDeltas
-	updatedPersistedAccountsOnline []persistedAccountData
+	compactOnlineAccountDeltas     compactOnlineAccountDeltas
+	updatedPersistedOnlineAccounts []persistedOnlineAccountData
 
 	committedRoundDigest     crypto.Digest
 	trieBalancesHash         crypto.Digest

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -483,9 +483,7 @@ func (tr *trackerRegistry) commitRound(dcc *deferredCommitContext) {
 			}
 		}
 
-		err = updateAccountsRound(tx, dbRound+basics.Round(offset))
-		return err
-		return nil
+		return updateAccountsRound(tx, dbRound+basics.Round(offset))
 	})
 	ledgerCommitroundMicros.AddMicrosecondsSince(start, nil)
 

--- a/ledger/tracker_test.go
+++ b/ledger/tracker_test.go
@@ -118,12 +118,11 @@ func TestTrackerScheduleCommit(t *testing.T) {
 
 	cdr = ao.produceCommittingTask(blockqRound, dbRound, cdr)
 	a.NotNil(cdr)
-	a.Equal(expectedOffset, cdr.offsetOnline)
+	a.Equal(expectedOffset, cdr.offset)
 
 	// schedule the commit. au is expected to return offset 100 and
 	ml.trackers.mu.Lock()
 	ml.trackers.dbRound = dbRound
-	ml.trackers.dbRoundOnline = dbRound
 	ml.trackers.mu.Unlock()
 	ml.trackers.scheduleCommit(blockqRound, lookback)
 


### PR DESCRIPTION
## Summary

* migration accountbase -> onlineaccounts
* online account deltas, compact deltas, new round implementation
* baseOnlineAccountData new storage data structure
* deletion logic

## Test Plan

Adjusted some tests, added tests for new online accounts table queries.
Added expiration/deletion tests

## Next steps (separate PRs)
1. Totals as a table
2. Remove lookback param