### PR TITLE
Bug-Fix: ABI inferToSlice nil testcases

### DIFF
--- a/data/abi/abi_encode_test.go
+++ b/data/abi/abi_encode_test.go
@@ -1272,7 +1272,7 @@ func TestInferToSlice(t *testing.T) {
 	assert.EqualError(
 		t, err,
 		"cannot infer an interface value as a slice of interface element",
-		"inferToSlice should return no error else other than interface type inference")
+		"inferToSlice should return type inference error when passed in nil with unexpected Kind")
 
 	var nilPt *uint64 = nil
 	_, err = inferToSlice(nilPt)
@@ -1280,5 +1280,5 @@ func TestInferToSlice(t *testing.T) {
 	assert.EqualError(
 		t, err,
 		"cannot infer an interface value as a slice of interface element",
-		"inferToSlice should return error type inference when passing argument type other than slice or array")
+		"inferToSlice should return type inference error when passing argument type other than slice or array")
 }

--- a/data/abi/abi_encode_test.go
+++ b/data/abi/abi_encode_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/chrismcguire/gobberish"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1269,7 +1268,7 @@ func TestInferToSlice(t *testing.T) {
 	// one more testcase for totally nil (with no type information) is bad, should not pass the test
 	_, err := inferToSlice(nil)
 	require.Error(t, err, "infer to Slice should not accept nil interface")
-	assert.EqualError(
+	require.EqualError(
 		t, err,
 		"cannot infer an interface value as a slice of interface element",
 		"inferToSlice should return type inference error when passed in nil with unexpected Kind")
@@ -1277,7 +1276,7 @@ func TestInferToSlice(t *testing.T) {
 	var nilPt *uint64 = nil
 	_, err = inferToSlice(nilPt)
 	require.Error(t, err, "infer to Slice should not accept nil interface")
-	assert.EqualError(
+	require.EqualError(
 		t, err,
 		"cannot infer an interface value as a slice of interface element",
 		"inferToSlice should return type inference error when passing argument type other than slice or array")

--- a/data/abi/abi_encode_test.go
+++ b/data/abi/abi_encode_test.go
@@ -1269,5 +1269,16 @@ func TestInferToSlice(t *testing.T) {
 	// one more testcase for totally nil (with no type information) is bad, should not pass the test
 	_, err := inferToSlice(nil)
 	require.Error(t, err, "infer to Slice should not accept nil interface")
-	assert.EqualError(t, err, "cannot infer an interface value as a slice of interface element", "inferToSlice should return no error else other than interface type inference")
+	assert.EqualError(
+		t, err,
+		"cannot infer an interface value as a slice of interface element",
+		"inferToSlice should return no error else other than interface type inference")
+
+	var nilPt *uint64 = nil
+	_, err = inferToSlice(nilPt)
+	require.Error(t, err, "infer to Slice should not accept nil interface")
+	assert.EqualError(
+		t, err,
+		"cannot infer an interface value as a slice of interface element",
+		"inferToSlice should return error type inference when passing argument type other than slice or array")
 }

--- a/data/abi/abi_encode_test.go
+++ b/data/abi/abi_encode_test.go
@@ -1272,6 +1272,7 @@ func TestInferToSlice(t *testing.T) {
 		"cannot infer an interface value as a slice of interface element",
 		"inferToSlice should return type inference error when passed in nil with unexpected Kind")
 
+	// one moar testcase for wrong typed nil is bad, should not pass the test
 	var nilPt *uint64 = nil
 	_, err = inferToSlice(nilPt)
 	require.EqualError(

--- a/data/abi/abi_encode_test.go
+++ b/data/abi/abi_encode_test.go
@@ -1267,7 +1267,6 @@ func TestInferToSlice(t *testing.T) {
 
 	// one more testcase for totally nil (with no type information) is bad, should not pass the test
 	_, err := inferToSlice(nil)
-	require.Error(t, err, "infer to Slice should not accept nil interface")
 	require.EqualError(
 		t, err,
 		"cannot infer an interface value as a slice of interface element",
@@ -1275,7 +1274,6 @@ func TestInferToSlice(t *testing.T) {
 
 	var nilPt *uint64 = nil
 	_, err = inferToSlice(nilPt)
-	require.Error(t, err, "infer to Slice should not accept nil interface")
 	require.EqualError(
 		t, err,
 		"cannot infer an interface value as a slice of interface element",

--- a/data/abi/abi_encode_test.go
+++ b/data/abi/abi_encode_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/chrismcguire/gobberish"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1264,4 +1265,9 @@ func TestInferToSlice(t *testing.T) {
 		require.NoError(t, err, "inferToSlice on testcase %d failed to successfully infer %v", i, test.toBeInferred)
 		require.Equal(t, test.length, len(inferredSlice), "inferToSlice on testcase %d inferred different length, expected %d", i, test.length)
 	}
+
+	// one more testcase for totally nil (with no type information) is bad, should not pass the test
+	_, err := inferToSlice(nil)
+	require.Error(t, err, "infer to Slice should not accept nil interface")
+	assert.EqualError(t, err, "cannot infer an interface value as a slice of interface element", "inferToSlice should return no error else other than interface type inference")
 }


### PR DESCRIPTION
## Description

A follow-up PR from #3823, adding one moar testcase to test `inferToSlice` will error when passing a `nil` with unexpected type (i.e., type other than slice or array).