### PR TITLE
ledger: test OnlineAccountData

### DIFF
--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -1689,6 +1689,52 @@ func TestLedgerMemoryLeak(t *testing.T) {
 	}
 }
 
+// TestLookupAgreement ensures LookupAgreement return an empty data for offline accounts
+func TestLookupAgreement(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	genesisInitState, _ := ledgertesting.GenerateInitState(t, protocol.ConsensusCurrentVersion, 100)
+	var addrOnline, addrOffline basics.Address
+	for addr, ad := range genesisInitState.Accounts {
+		if addrOffline.IsZero() {
+			addrOffline = addr
+			ad.Status = basics.Offline
+			crypto.RandBytes(ad.VoteID[:]) // this is invalid but we set VoteID to ensure the account gets cleared
+			genesisInitState.Accounts[addr] = ad
+		} else if ad.Status == basics.Online {
+			addrOnline = addr
+			crypto.RandBytes(ad.VoteID[:])
+			genesisInitState.Accounts[addr] = ad
+			break
+		}
+	}
+
+	const inMem = true
+	log := logging.TestingLog(t)
+	cfg := config.GetDefaultLocal()
+	cfg.Archival = true
+	ledger, err := OpenLedger(log, t.Name(), inMem, genesisInitState, cfg)
+	require.NoError(t, err, "could not open ledger")
+	defer ledger.Close()
+
+	oad, err := ledger.LookupAgreement(0, addrOnline)
+	require.NoError(t, err)
+	require.NotEmpty(t, oad)
+	ad, _, _, err := ledger.LookupLatest(addrOnline)
+	require.NoError(t, err)
+	require.NotEmpty(t, ad)
+	require.Equal(t, oad, ad.OnlineAccountData())
+
+	require.NoError(t, err)
+	oad, err = ledger.LookupAgreement(0, addrOffline)
+	require.NoError(t, err)
+	require.Empty(t, oad)
+	ad, _, _, err = ledger.LookupLatest(addrOffline)
+	require.NoError(t, err)
+	require.NotEmpty(t, ad)
+	require.Equal(t, oad, ad.OnlineAccountData())
+}
+
 func BenchmarkLedgerStartup(b *testing.B) {
 	log := logging.TestingLog(b)
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "BenchmarkLedgerStartup")

--- a/ledger/ledgercore/accountdata.go
+++ b/ledger/ledgercore/accountdata.go
@@ -152,6 +152,11 @@ func (u AccountData) Money(proto config.ConsensusParams, rewardsLevel uint64) (m
 
 // OnlineAccountData calculates the online account data given an AccountData, by adding the rewards.
 func (u *AccountData) OnlineAccountData(proto config.ConsensusParams, rewardsLevel uint64) basics.OnlineAccountData {
+	if u.Status != basics.Online {
+		// if the account is not Online and agreement requests it for some reason, clear it out
+		return basics.OnlineAccountData{}
+	}
+
 	microAlgos, _, _ := basics.WithUpdatedRewards(
 		proto, u.Status, u.MicroAlgos, u.RewardedMicroAlgos, u.RewardsBase, rewardsLevel,
 	)


### PR DESCRIPTION
## Summary

* This is a prerequisite test before retiring AccountData.OnlineAccountData()
that is used only in tests agreement and committee tests.
* Historically all these tests depends on genesis data that is basic.AccountData.
* Our GA genesis files have stake, status and voting data and never had resources
basic.AccountData can be reduced to the original stake + voting data state and
a new basic.AccountDataEx can be introduced for using in REST API
* Ledger tests and test network generation tools need to be updated to
accept a new reduced (original) basic.AccountData as genesis and resource records
for assets and apps needed for tests after the ledger initialization.

## Test Plan

This is a test PR