### PR TITLE
CI: use 1.16.15 instead of 1.16.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ commands:
           shell: bash.exe
           command: |
             choco install -y msys2 pacman make wget --force
-            choco install -y golang --version=1.16.11 --force
+            choco install -y golang --version=1.16.15 --force
             choco install -y python3 --version=3.7.3 --force
             export msys2='cmd //C RefreshEnv.cmd '
             export msys2+='& set MSYS=winsymlinks:nativestrict '

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.11'
+          go-version: '1.16.15'
       - name: Build Test
         run: |
           export ALGORAND_DEADLOCK=enable

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install specific golang
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.11'
+          go-version: '1.16.15'
       - name: Create folders for golangci-lint
         run: mkdir -p cicdtmp/golangci-lint
       - name: Check if custom golangci-lint is already built

--- a/scripts/get_golang_version.sh
+++ b/scripts/get_golang_version.sh
@@ -11,7 +11,7 @@
 # Our build task-runner `mule` will refer to this script and will automatically
 # build a new image whenever the version number has been changed.
 
-BUILD=1.16.11
+BUILD=1.16.15
  MIN=1.16
  GO_MOD_SUPPORT=1.16
 


### PR DESCRIPTION
## Summary

The recent PR #3803 added back the upgrade to Go 1.16.11 in #2825 but since then there have been more 1.16 patch releases up to 1.16.15, and this uses the latest.

## Test Plan

Existing tests should all pass.