### PR TITLE
REST API: Check for pending transactions in most recent rounds first.

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -654,7 +654,7 @@ func (node *AlgorandFullNode) GetPendingTransaction(txID transactions.Txid) (res
 	maxRound := latest
 	minRound := maxRound.SubSaturate(maxLife)
 
-	for r := minRound; r <= maxRound; r++ {
+	for r := maxRound; r >= minRound; r-- {
 		tx, found, err := node.ledger.LookupTxid(txID, r)
 		if err != nil || !found {
 			continue

--- a/node/node.go
+++ b/node/node.go
@@ -640,7 +640,7 @@ func (node *AlgorandFullNode) GetPendingTransaction(txID transactions.Txid) (res
 		}
 		found = true
 
-		// Keep looking in the ledger..
+		// Keep looking in the ledger.
 	}
 
 	var maxLife basics.Round
@@ -651,8 +651,15 @@ func (node *AlgorandFullNode) GetPendingTransaction(txID transactions.Txid) (res
 	} else {
 		node.log.Errorf("node.GetPendingTransaction: cannot get consensus params for latest round %v", latest)
 	}
+
+	// Search from newest to oldest round up to the max life of a transaction.
 	maxRound := latest
 	minRound := maxRound.SubSaturate(maxLife)
+
+	// Since we're using uint64, if the minRound is 0, we need to check for an underflow.
+	if minRound == 0 {
+		minRound++
+	}
 
 	for r := maxRound; r >= minRound; r-- {
 		tx, found, err := node.ledger.LookupTxid(txID, r)


### PR DESCRIPTION
## Summary

More efficient check for pending transactions. In most cases, the check will be done right away, so it would be in a recent round. The check starts at the oldest round, which is the opposite of what would normally happen.

## Test Plan

Existing unit tests.