### PR TITLE
Enhancement: Added Keep Temps flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,6 +413,7 @@ commands:
           no_output_timeout: << parameters.no_output_timeout >>
           command: |
             set -x
+            export KEEP_TEMPS=True
             export PATH=$(echo "$PATH" | sed -e "s|:${HOME}/\.go_workspace/bin||g" | sed -e 's|:/usr/local/go/bin||g')
             export KMD_NOUSB=True
             export GOPATH="<< parameters.build_dir >>/go"


### PR DESCRIPTION
Resolves #940

Adds a keep temps flag to the build to allow for the indexer to have
updated test packages

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
