### PR TITLE
Enhancement: Re-enable `fillBytes` method in ABI and eval.go implementation

### DIFF
--- a/data/abi/abi_encode_test.go
+++ b/data/abi/abi_encode_test.go
@@ -83,8 +83,8 @@ func TestEncodeValid(t *testing.T) {
 			randomInt, err := rand.Int(rand.Reader, upperLimit)
 			require.NoError(t, err, "cryptographic random int init fail")
 
-			expected, err := bigIntToBytes(randomInt, uint(intSize/8))
-			require.NoError(t, err, "big int to byte conversion error")
+			expected := make([]byte, intSize/8)
+			randomInt.FillBytes(expected)
 
 			uintEncode, err := uintType.Encode(randomInt)
 			require.NoError(t, err, "encoding from uint type fail")
@@ -122,9 +122,8 @@ func TestEncodeValid(t *testing.T) {
 				encodedUfixed, err := typeUfixed.Encode(randomInt)
 				require.NoError(t, err, "ufixed encode fail")
 
-				expected, err := bigIntToBytes(randomInt, uint(size/8))
-				require.NoError(t, err, "big int to byte conversion error")
-
+				expected := make([]byte, size/8)
+				randomInt.FillBytes(expected)
 				require.Equal(t, expected, encodedUfixed, "encode ufixed not match with expected")
 			}
 			// (2^[bitSize] - 1) / (10^[precision]) test
@@ -142,8 +141,8 @@ func TestEncodeValid(t *testing.T) {
 		randomAddrInt, err := rand.Int(rand.Reader, upperLimit)
 		require.NoError(t, err, "cryptographic random int init fail")
 
-		addrBytesExpected, err := bigIntToBytes(randomAddrInt, uint(addressByteSize))
-		require.NoError(t, err, "big int to byte conversion error")
+		addrBytesExpected := make([]byte, addressByteSize)
+		randomAddrInt.FillBytes(addrBytesExpected)
 
 		addrBytesActual, err := addressType.Encode(addrBytesExpected)
 		require.NoError(t, err, "address encode fail")
@@ -422,8 +421,8 @@ func TestDecodeValid(t *testing.T) {
 		randomAddrInt, err := rand.Int(rand.Reader, upperLimit)
 		require.NoError(t, err, "cryptographic random int init fail")
 
-		expected, err := bigIntToBytes(randomAddrInt, uint(addressByteSize))
-		require.NoError(t, err, "big int to byte conversion error")
+		expected := make([]byte, addressByteSize)
+		randomAddrInt.FillBytes(expected)
 
 		actual, err := addressType.Decode(expected)
 		require.NoError(t, err, "decoding address should not return error")
@@ -952,10 +951,8 @@ func addPrimitiveRandomValues(t *testing.T, pool *map[BaseType][]testUnit) {
 	for i := 0; i < addressTestCaseCount; i++ {
 		randAddrVal, err := rand.Int(rand.Reader, maxAddress)
 		require.NoError(t, err, "generate random value for address, should be no error")
-
-		addrBytes, err := bigIntToBytes(randAddrVal, uint(addressByteSize))
-		require.NoError(t, err, "big int to byte conversion error")
-
+		addrBytes := make([]byte, addressByteSize)
+		randAddrVal.FillBytes(addrBytes)
 		(*pool)[Address][i] = testUnit{serializedType: addressType.String(), value: addrBytes}
 	}
 	categorySelfRoundTripTest(t, (*pool)[Address])
@@ -1165,7 +1162,7 @@ func TestParseArgJSONtoByteSlice(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("index=%d", i), func(t *testing.T) {
-			applicationArgs := make([][]byte, 0)
+			applicationArgs := [][]byte{}
 			err := ParseArgJSONtoByteSlice(test.argTypes, test.jsonArgs, &applicationArgs)
 			require.NoError(t, err)
 			require.Equal(t, test.expectedAppArgs, applicationArgs)

--- a/data/abi/abi_json_test.go
+++ b/data/abi/abi_json_test.go
@@ -31,17 +31,14 @@ func TestRandomAddressEquality(t *testing.T) {
 
 	upperLimit := new(big.Int).Lsh(big.NewInt(1), addressByteSize<<3)
 	var addrBasics basics.Address
-	var addrABI = make([]byte, addressByteSize)
+	var addrABI []byte = make([]byte, addressByteSize)
 
 	for testCaseIndex := 0; testCaseIndex < addressTestCaseCount; testCaseIndex++ {
 		randomAddrInt, err := rand.Int(rand.Reader, upperLimit)
 		require.NoError(t, err, "cryptographic random int init fail")
 
-		expected, err := bigIntToBytes(randomAddrInt, uint(addressByteSize))
-		require.NoError(t, err, "big int to byte conversion error")
-
-		copy(addrABI[:], expected)
-		copy(addrBasics[:], expected)
+		randomAddrInt.FillBytes(addrBasics[:])
+		randomAddrInt.FillBytes(addrABI)
 
 		checkSumBasics := addrBasics.GetChecksum()
 		checkSumABI, err := addressCheckSum(addrABI)

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -2918,9 +2918,9 @@ func opEd25519VerifyBare(cx *EvalContext) error {
 }
 
 func leadingZeros(size int, b *big.Int) ([]byte, error) {
-	data := b.Bytes()
-	if size < len(data) {
-		return nil, fmt.Errorf("insufficient buffer size: %d < %d", size, len(data))
+	byteLength := (b.BitLen() + 7) / 8
+	if size < byteLength {
+		return nil, fmt.Errorf("insufficient buffer size: %d < %d", size, byteLength)
 	}
 	buf := make([]byte, size)
 	b.FillBytes(buf)

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -2927,57 +2927,6 @@ func leadingZeros(size int, b *big.Int) ([]byte, error) {
 	return buf, nil
 }
 
-// polynomial returns x³ - 3x + b.
-//
-// TODO: remove this when go-algorand is updated to go 1.15+
-func polynomial(curve *elliptic.CurveParams, x *big.Int) *big.Int {
-	x3 := new(big.Int).Mul(x, x)
-	x3.Mul(x3, x)
-
-	threeX := new(big.Int).Lsh(x, 1)
-	threeX.Add(threeX, x)
-
-	x3.Sub(x3, threeX)
-	x3.Add(x3, curve.B)
-	x3.Mod(x3, curve.P)
-
-	return x3
-}
-
-// unmarshalCompressed converts a point, serialized by MarshalCompressed, into an x, y pair.
-// It is an error if the point is not in compressed form or is not on the curve.
-// On error, x = nil.
-//
-// TODO: remove this and replace usage with elliptic.UnmarshallCompressed when go-algorand is
-// updated to go 1.15+
-func unmarshalCompressed(curve elliptic.Curve, data []byte) (x, y *big.Int) {
-	byteLen := (curve.Params().BitSize + 7) / 8
-	if len(data) != 1+byteLen {
-		return nil, nil
-	}
-	if data[0] != 2 && data[0] != 3 { // compressed form
-		return nil, nil
-	}
-	p := curve.Params().P
-	x = new(big.Int).SetBytes(data[1:])
-	if x.Cmp(p) >= 0 {
-		return nil, nil
-	}
-	// y² = x³ - 3x + b
-	y = polynomial(curve.Params(), x)
-	y = y.ModSqrt(y, p)
-	if y == nil {
-		return nil, nil
-	}
-	if byte(y.Bit(0)) != data[0]&1 {
-		y.Neg(y).Mod(y, p)
-	}
-	if !curve.IsOnCurve(x, y) {
-		return nil, nil
-	}
-	return
-}
-
 var ecdsaVerifyCosts = map[byte]int{
 	byte(Secp256k1): 1700,
 	byte(Secp256r1): 2500,
@@ -3065,7 +3014,7 @@ func opEcdsaPkDecompress(cx *EvalContext) error {
 			return fmt.Errorf("invalid pubkey")
 		}
 	} else if fs.field == Secp256r1 {
-		x, y = unmarshalCompressed(elliptic.P256(), pubkey)
+		x, y = elliptic.UnmarshalCompressed(elliptic.P256(), pubkey)
 		if x == nil {
 			return fmt.Errorf("invalid compressed pubkey")
 		}

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -2917,18 +2917,13 @@ func opEd25519VerifyBare(cx *EvalContext) error {
 	return nil
 }
 
-// leadingZeros needs to be replaced by big.Int.FillBytes
 func leadingZeros(size int, b *big.Int) ([]byte, error) {
 	data := b.Bytes()
 	if size < len(data) {
 		return nil, fmt.Errorf("insufficient buffer size: %d < %d", size, len(data))
 	}
-	if size == len(data) {
-		return data, nil
-	}
-
 	buf := make([]byte, size)
-	copy(buf[size-len(data):], data)
+	b.FillBytes(buf)
 	return buf, nil
 }
 

--- a/data/transactions/logic/evalCrypto_test.go
+++ b/data/transactions/logic/evalCrypto_test.go
@@ -173,23 +173,10 @@ ed25519verify_bare`, pkStr), v)
 	}
 }
 
-// bitIntFillBytes is a replacement for big.Int.FillBytes from future Go
-func bitIntFillBytes(b *big.Int, buf []byte) []byte {
-	for i := range buf {
-		buf[i] = 0
-	}
-	bytes := b.Bytes()
-	if len(bytes) > len(buf) {
-		panic(fmt.Sprintf("bitIntFillBytes: has %d but got %d buffer", len(bytes), len(buf)))
-	}
-	copy(buf[len(buf)-len(bytes):], bytes)
-	return buf
-}
-
 func keyToByte(tb testing.TB, b *big.Int) []byte {
 	k := make([]byte, 32)
 	require.NotPanics(tb, func() {
-		k = bitIntFillBytes(b, k)
+		b.FillBytes(k)
 	})
 	return k
 }
@@ -381,18 +368,6 @@ ecdsa_verify Secp256k1`, hex.EncodeToString(r), hex.EncodeToString(s), hex.Encod
 	require.True(t, pass)
 }
 
-// MarshalCompressed converts a point on the curve into the compressed form
-// specified in section 4.3.6 of ANSI X9.62.
-//
-// TODO: replace with elliptic.MarshalCompressed when updating to go 1.15+
-func marshalCompressed(curve elliptic.Curve, x, y *big.Int) []byte {
-	byteLen := (curve.Params().BitSize + 7) / 8
-	compressed := make([]byte, 1+byteLen)
-	compressed[0] = byte(y.Bit(0)) | 2
-	bitIntFillBytes(x, compressed[1:])
-	return compressed
-}
-
 func TestEcdsaWithSecp256r1(t *testing.T) {
 	if LogicVersion < fidoVersion {
 		return
@@ -403,7 +378,7 @@ func TestEcdsaWithSecp256r1(t *testing.T) {
 
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
-	pk := marshalCompressed(elliptic.P256(), key.X, key.Y)
+	pk := elliptic.MarshalCompressed(elliptic.P256(), key.X, key.Y)
 	x := keyToByte(t, key.PublicKey.X)
 	y := keyToByte(t, key.PublicKey.Y)
 
@@ -676,7 +651,7 @@ func benchmarkEcdsaGenData(b *testing.B, curve EcdsaCurve) (data []benchmarkEcds
 		if curve == Secp256k1 {
 			data[i].pk = secp256k1.CompressPubkey(key.PublicKey.X, key.PublicKey.Y)
 		} else if curve == Secp256r1 {
-			data[i].pk = marshalCompressed(elliptic.P256(), key.PublicKey.X, key.PublicKey.Y)
+			data[i].pk = elliptic.MarshalCompressed(elliptic.P256(), key.PublicKey.X, key.PublicKey.Y)
 		}
 
 		d := []byte("testdata")


### PR DESCRIPTION
# Description

The current go-algorand build is over golang 1.16, which means we can revert #3498.

#3498 is introduced for the sake of downgrading golang for perf issues, now we should lift back to earlier implementation.

We also re-enable `FillBytes` in `leadingZero` implementation, and update `elliptic.(un)marshalCompressed` for #2852 . 