### PR TITLE
CI: add test partitioning based on partition test verifier output

### DIFF
--- a/crypto/secp256k1/secp256_test.go
+++ b/crypto/secp256k1/secp256_test.go
@@ -63,6 +63,8 @@ func compactSigCheck(t *testing.T, sig []byte) {
 }
 
 func TestSignatureValidity(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	pubkey, seckey := generateKeyPair()
 	msg := csprngEntropy(32)
 	sig, err := Sign(msg, seckey)

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2381,6 +2381,7 @@ func TestUncoverAsm(t *testing.T) {
 }
 
 func TestTxTypes(t *testing.T) {
+	partitiontest.PartitionTest(t)
 	testProg(t, "itxn_begin; itxn_field Sender", 5, Expect{2, "itxn_field Sender expects 1 stack argument..."})
 	testProg(t, "itxn_begin; int 1; itxn_field Sender", 5, Expect{3, "...wanted type []byte got uint64"})
 	testProg(t, "itxn_begin; byte 0x56127823; itxn_field Sender", 5)

--- a/data/transactions/logic/evalCrypto_test.go
+++ b/data/transactions/logic/evalCrypto_test.go
@@ -505,6 +505,8 @@ ecdsa_verify Secp256r1`, hex.EncodeToString(r), hex.EncodeToString(s), hex.Encod
 
 // test compatibility with ethereum signatures
 func TestEcdsaEthAddress(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	/*
 		pip install eth-keys pycryptodome
 		from eth_keys import keys
@@ -532,6 +534,8 @@ byte 0x5ce9454909639d2d17a3f753ce7d93fa0b9ab12e // addr
 }
 
 func TestEcdsaCostVariation(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	// Doesn't matter if it passes or fails. Just confirm the cost depends on curve.
 	source := `
 global ZeroAddress				// need 32 bytes

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -2577,6 +2577,8 @@ func appAddr(id int) basics.Address {
 }
 
 func TestAppInfo(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	ep, tx, ledger := makeSampleEnv()
 	require.Equal(t, 888, int(tx.ApplicationID))
 	ledger.NewApp(tx.Receiver, 888, basics.AppParams{})
@@ -2595,6 +2597,8 @@ func TestAppInfo(t *testing.T) {
 }
 
 func TestBudget(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	ep := defaultEvalParams(nil)
 	source := `
 global OpcodeBudget
@@ -2609,6 +2613,8 @@ int 695
 }
 
 func TestSelfMutate(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	ep, _, ledger := makeSampleEnv()
 
 	/* In order to test the added protection of mutableAccountReference, we're

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -697,6 +697,8 @@ int 1
 }
 
 func TestMulDiv(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	// Demonstrate a "function" that expects three u64s on stack,
 	// and calculates B*C/A. (Following opcode documentation
 	// convention, C is top-of-stack, B is below it, and A is

--- a/data/transactions/logic/opcodes_test.go
+++ b/data/transactions/logic/opcodes_test.go
@@ -77,13 +77,15 @@ func TestOpcodesByVersionReordered(t *testing.T) {
 	OpSpecs[1] = OpSpecs[4]
 	OpSpecs[4] = tmp
 
-	t.Run("TestOpcodesByVersion", TestOpcodesByVersion)
+	t.Run("TestOpcodesByVersion", testOpcodesByVersion)
 }
 
 func TestOpcodesByVersion(t *testing.T) {
-	// partitiontest.PartitionTest(t)
-	// has partitioning in the TestOpcodesByVersionReordered()
+	partitiontest.PartitionTest(t)
+	testOpcodesByVersion(t)
+}
 
+func testOpcodesByVersion(t *testing.T) {
 	// Make a copy of the OpSpecs to check if OpcodesByVersion will change it
 	OpSpecs2 := make([]OpSpec, len(OpSpecs))
 	for idx, opspec := range OpSpecs {

--- a/ledger/internal/eval_blackbox_test.go
+++ b/ledger/internal/eval_blackbox_test.go
@@ -422,11 +422,11 @@ ok:
 	return eval, addrs[0], err
 }
 
-// TestEvalAppStateCountsWithTxnGroup ensures txns in a group can't violate app state schema limits
+// TestEvalAppStateCountsWithTxnGroupBlackbox ensures txns in a group can't violate app state schema limits
 // the test ensures that
 // commitToParent -> applyChild copies child's cow state usage counts into parent
 // and the usage counts correctly propagated from parent cow to child cow and back
-func TestEvalAppStateCountsWithTxnGroup(t *testing.T) {
+func TestEvalAppStateCountsWithTxnGroupBlackbox(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	_, _, err := testEvalAppGroup(t, basics.StateSchema{NumByteSlice: 1})
@@ -434,9 +434,9 @@ func TestEvalAppStateCountsWithTxnGroup(t *testing.T) {
 	require.Contains(t, err.Error(), "store bytes count 2 exceeds schema bytes count 1")
 }
 
-// TestEvalAppAllocStateWithTxnGroup ensures roundCowState.deltas and applyStorageDelta
+// TestEvalAppAllocStateWithTxnGroupBlackbox ensures roundCowState.deltas and applyStorageDelta
 // produce correct results when a txn group has storage allocate and storage update actions
-func TestEvalAppAllocStateWithTxnGroup(t *testing.T) {
+func TestEvalAppAllocStateWithTxnGroupBlackbox(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	eval, addr, err := testEvalAppGroup(t, basics.StateSchema{NumByteSlice: 2})

--- a/test/e2e-go/cli/goal/account_test.go
+++ b/test/e2e-go/cli/goal/account_test.go
@@ -22,12 +22,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/test/framework/fixtures"
+	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
 const statusOffline = "[offline]"
 const statusOnline = "[online]"
 
 func TestAccountNew(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	defer fixtures.ShutdownSynchronizedTest(t)
 	defer fixture.SetTestContext(t)()
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -54,6 +57,8 @@ func TestAccountNew(t *testing.T) {
 }
 
 func TestAccountNewDuplicateFails(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	defer fixtures.ShutdownSynchronizedTest(t)
 	defer fixture.SetTestContext(t)()
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -70,6 +75,8 @@ func TestAccountNewDuplicateFails(t *testing.T) {
 }
 
 func TestAccountRename(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	defer fixtures.ShutdownSynchronizedTest(t)
 	defer fixture.SetTestContext(t)()
 	a := require.New(fixtures.SynchronizedTest(t))
@@ -101,6 +108,8 @@ func TestAccountRename(t *testing.T) {
 
 // Importing an account multiple times should not be considered an error by goal
 func TestAccountMultipleImportRootKey(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	defer fixtures.ShutdownSynchronizedTest(t)
 	defer fixture.SetTestContext(t)()
 	a := require.New(fixtures.SynchronizedTest(t))

--- a/test/e2e-go/cli/goal/clerk_test.go
+++ b/test/e2e-go/cli/goal/clerk_test.go
@@ -24,9 +24,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/test/framework/fixtures"
+	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
 func TestClerkSendNoteEncoding(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	defer fixtures.ShutdownSynchronizedTest(t)
 	defer fixture.SetTestContext(t)()
 	a := require.New(fixtures.SynchronizedTest(t))

--- a/test/e2e-go/cli/goal/node_cleanup_test.go
+++ b/test/e2e-go/cli/goal/node_cleanup_test.go
@@ -23,9 +23,12 @@ import (
 
 	"github.com/algorand/go-algorand/nodecontrol"
 	"github.com/algorand/go-algorand/test/framework/fixtures"
+	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
 func TestGoalNodeCleanup(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	defer fixtures.ShutdownSynchronizedTest(t)
 	defer fixture.SetTestContext(t)()
 

--- a/test/e2e-go/features/transactions/sendReceive_test.go
+++ b/test/e2e-go/features/transactions/sendReceive_test.go
@@ -55,6 +55,7 @@ func TestAccountsCanSendMoney(t *testing.T) {
 // this test checks that two accounts' balances stay up to date
 // as they send each other money many times
 func TestDevModeAccountsCanSendMoney(t *testing.T) {
+	partitiontest.PartitionTest(t)
 	defer fixtures.ShutdownSynchronizedTest(t)
 
 	numberOfSends := 25


### PR DESCRIPTION
## Summary

We have a test partitioning system that uses calls to partitiontest.PartitionTest(t) to shard tests. There is also a verification job to check for accidentally skipped or unnecessarily multiply-run tests. This cleans up some of the "RAN MULTIPLE TIMES" warnings of unnecessarily multiply-run tests from output like https://app.circleci.com/pipelines/github/algorand/go-algorand/5910/workflows/d5620b33-8dd4-4211-a1b1-1780a792126a/jobs/99253 and https://app.circleci.com/pipelines/github/algorand/go-algorand/5907/workflows/ee653582-9329-43f2-87fc-51dc047d2e3d/jobs/99171

## Test Plan

Existing tests should pass, and there should be fewer "RAN MULTIPLE TIMES" warnings in the verification job output. There should be no "UNINTENTIONALLY SKIPPED" errors in the output (this would trigger a CI error).