### PR TITLE
algonet: use lower value of LastPartKeyRound for bootstrappedScenario

### DIFF
--- a/gen/generate.go
+++ b/gen/generate.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/algorand/go-deadlock"
 
@@ -301,6 +302,7 @@ func generateGenesisFiles(outDir string, protoVersion protocol.ConsensusVersion,
 		}()
 	}
 
+	createStart := time.Now()
 	creatingWalletsWaitGroup.Add(concurrentWalletGenerators)
 	for routinesCounter := 0; routinesCounter < concurrentWalletGenerators; routinesCounter++ {
 		go createWallet()
@@ -375,7 +377,7 @@ func generateGenesisFiles(outDir string, protoVersion protocol.ConsensusVersion,
 	err = ioutil.WriteFile(filepath.Join(outDir, config.GenesisJSONFile), append(jsonData, '\n'), 0666)
 
 	if (verbose) && (rootKeyCreated > 0 || partKeyCreated > 0) {
-		fmt.Printf("Created %d new rootkeys and %d new partkeys.\n", rootKeyCreated, partKeyCreated)
+		fmt.Printf("Created %d new rootkeys and %d new partkeys in %s.\n", rootKeyCreated, partKeyCreated, time.Since(createStart))
 		fmt.Printf("NOTICE: Participation keys are valid for a period of %d rounds. After this many rounds the network will stall unless new keys are registered.\n", lastWalletValid-firstWalletValid)
 	}
 

--- a/scripts/create_and_deploy_recipe.sh
+++ b/scripts/create_and_deploy_recipe.sh
@@ -20,6 +20,7 @@
 #           directory as the recipe file path.
 
 set -e
+set -x
 
 if [[ "${AWS_ACCESS_KEY_ID}" = "" || "${AWS_SECRET_ACCESS_KEY}" = "" ]]; then
     echo "You need to export your AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY for this to work"

--- a/test/testdata/deployednettemplates/recipes/bootstrappedScenario/genesis.json
+++ b/test/testdata/deployednettemplates/recipes/bootstrappedScenario/genesis.json
@@ -3,7 +3,7 @@
 	"VersionModifier": "",
 	"ConsensusProtocol": "",
 	"FirstPartKeyRound": 0,
-	"LastPartKeyRound": 3000000,
+	"LastPartKeyRound": 10000,
 	"PartKeyDilution": 0,
 	"Wallets": [
 		{

--- a/test/testdata/deployednettemplates/recipes/bootstrappedScenario/genesis.json
+++ b/test/testdata/deployednettemplates/recipes/bootstrappedScenario/genesis.json
@@ -3,7 +3,7 @@
 	"VersionModifier": "",
 	"ConsensusProtocol": "",
 	"FirstPartKeyRound": 0,
-	"LastPartKeyRound": 10000,
+	"LastPartKeyRound": 20000,
 	"PartKeyDilution": 0,
 	"Wallets": [
 		{


### PR DESCRIPTION
## Summary

The genesis.json file in the bootstrappedScenario specifies 3M for LastPartKeyRound, which can take many hours to generate 200 participation & falcon keys for a 3M round range when run in Jenkins. This lowers the round range to 20K which will only take a few minutes. It also modifies the genesis wallet generator to print out how long it took after generating all the keys, if verbose mode is on.

## Test Plan

Existing tests should pass.