### PR TITLE
AVM:  Extract divideCeilUnsafely to help document opcode costing rationale

### DIFF
--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -69,10 +69,16 @@ type linearCost struct {
 	chunkSize int
 }
 
+// divideCeil provides `math.Ceil` semantics using integer division.  The technique avoids slower floating point operations as suggested in https://stackoverflow.com/a/2745086.
+func divideCeil(numerator int, denominator int) int {
+	return (numerator + denominator - 1) / denominator
+}
+
 func (lc *linearCost) compute(stack []stackValue) int {
 	cost := lc.baseCost
 	if lc.chunkCost != 0 && lc.chunkSize != 0 {
-		cost += lc.chunkCost * (len(stack[len(stack)-1].Bytes) + lc.chunkSize - 1) / lc.chunkSize
+		// Uses divideCeil rather than (len/size) to match how Ethereum discretizes hashing costs.
+		cost += divideCeil(lc.chunkCost*len(stack[len(stack)-1].Bytes), lc.chunkSize)
 	}
 	return cost
 }

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -69,16 +69,17 @@ type linearCost struct {
 	chunkSize int
 }
 
-// divideCeil provides `math.Ceil` semantics using integer division.  The technique avoids slower floating point operations as suggested in https://stackoverflow.com/a/2745086.
-func divideCeil(numerator int, denominator int) int {
+// divideCeilUnsafely provides `math.Ceil` semantics using integer division.  The technique avoids slower floating point operations as suggested in https://stackoverflow.com/a/2745086.
+// The method does _not_ check for divide-by-zero.
+func divideCeilUnsafely(numerator int, denominator int) int {
 	return (numerator + denominator - 1) / denominator
 }
 
 func (lc *linearCost) compute(stack []stackValue) int {
 	cost := lc.baseCost
 	if lc.chunkCost != 0 && lc.chunkSize != 0 {
-		// Uses divideCeil rather than (len/size) to match how Ethereum discretizes hashing costs.
-		cost += divideCeil(lc.chunkCost*len(stack[len(stack)-1].Bytes), lc.chunkSize)
+		// Uses divideCeilUnsafely rather than (len/size) to match how Ethereum discretizes hashing costs.
+		cost += divideCeilUnsafely(lc.chunkCost*len(stack[len(stack)-1].Bytes), lc.chunkSize)
 	}
 	return cost
 }


### PR DESCRIPTION
Extracts `divideCeilUnsafely` function to help document opcode costing rationale.  Stems from discussion in https://github.com/algorand/go-algorand/pull/3857#discussion_r844091506.


Analysis below shows `divideCellUnsafely` is inlined.  Implies there's _no_ overhead for adding the function.  The logs show `divideCell` because I renamed the method after an initial pass.
```
~/dev/go-algorand/data/transactions/logic divide_ceil !1 ?2 ───────────────────────────────────────────────────────────────────── 04:06:17 PM
❯ go build -gcflags=-m=2 . 2>&1  | grep opcodes.go | grep 'divideCeil'
./opcodes.go:73:6: can inline divideCeil with cost 8 as: func(int, int) int { return (numerator + denominator - 1) / denominator }
./opcodes.go:77:6: can inline (*linearCost).compute with cost 43 as: method(*linearCost) func([]stackValue) int { cost := lc.baseCost; if lc.chunkCost != 0 && lc.chunkSize != 0 { cost += divideCeil(lc.chunkCost * len(stack[len(stack) - 1].Bytes), lc.chunkSize) }; return cost }
./opcodes.go:81:21: inlining call to divideCeil func(int, int) int { return (numerator + denominator - 1) / denominator }
./opcodes.go:140:28: inlining call to (*linearCost).compute method(*linearCost) func([]stackValue) int { cost := lc.baseCost; if lc.chunkCost != 0 && lc.chunkSize != 0 { cost += divideCeil(lc.chunkCost * len(stack[len(stack) - 1].Bytes), lc.chunkSize) }; return cost }
./opcodes.go:140:28: inlining call to divideCeil func(int, int) int { return (numerator + denominator - 1) / denominator }
```

As intended, benchmarking shows _no_ meaningful change.
* Benchmark run:  `go test ./data/transactions/logic -bench=BenchmarkUintMath`
* [BenchmarkUintMath-diff.txt](https://github.com/algorand/go-algorand/files/8446181/BenchmarkUintMath-diff.txt) - _old_ = `master` and _new_ = the PR.
