### PR TITLE
Change ConsensusParams.MaxBalLookback.

### DIFF
--- a/catchup/service.go
+++ b/catchup/service.go
@@ -331,7 +331,7 @@ func (s *Service) fetchAndWrite(r basics.Round, prevFetchCompleteChan chan bool,
 				ledgerBacklogRound := r.SubSaturate(basics.Round(proto.MaxBalLookback))
 				select {
 				case <-s.ledger.Wait(ledgerBacklogRound):
-					// i.e. round r-320 is no longer in the blockqueue, so it's account data is either being currently written, or it was already written.
+					// i.e. round r-MaxBalLookback is no longer in the blockqueue, so it's account data is either being currently written, or it was already written.
 				case <-s.ctx.Done():
 					s.log.Debugf("fetchAndWrite(%d): Aborted while waiting for ledger to complete writing up to round %d", r, ledgerBacklogRound)
 					return false

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1126,6 +1126,9 @@ func initConsensusProtocols() {
 
 	vFuture.LogicSigVersion = 7
 
+	// Decrease ledger's max balance lookback. TODO: revisit the value in the future.
+	vFuture.MaxBalLookback = 16;
+
 	Consensus[protocol.ConsensusFuture] = vFuture
 }
 

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -395,14 +395,14 @@ func (ad *AccountDeltas) UpsertAssetResource(addr basics.Address, aidx basics.As
 // OptimizeAllocatedMemory by reallocating maps to needed capacity
 // For each data structure, reallocate if it would save us at least 50MB aggregate
 func (sd *StateDelta) OptimizeAllocatedMemory(proto config.ConsensusParams) {
-	// accts takes up 232 bytes per entry, and is saved for 320 rounds
+	// accts takes up 232 bytes per entry, and is saved for MaxBalLookback rounds
 	if uint64(cap(sd.Accts.accts)-len(sd.Accts.accts))*accountArrayEntrySize*proto.MaxBalLookback > stateDeltaTargetOptimizationThreshold {
 		accts := make([]NewBalanceRecord, len(sd.Accts.acctsCache))
 		copy(accts, sd.Accts.accts)
 		sd.Accts.accts = accts
 	}
 
-	// acctsCache takes up 64 bytes per entry, and is saved for 320 rounds
+	// acctsCache takes up 64 bytes per entry, and is saved for MaxBalLookback rounds
 	// realloc if original allocation capacity greater than length of data, and space difference is significant
 	if 2*sd.initialTransactionsCount > len(sd.Accts.acctsCache) &&
 		uint64(2*sd.initialTransactionsCount-len(sd.Accts.acctsCache))*accountMapCacheEntrySize*proto.MaxBalLookback > stateDeltaTargetOptimizationThreshold {
@@ -423,7 +423,7 @@ func (sd *StateDelta) OptimizeAllocatedMemory(proto config.ConsensusParams) {
 		sd.Txleases = txLeases
 	}
 
-	// Creatables takes up 100 bytes per entry, and is saved for 320 rounds
+	// Creatables takes up 100 bytes per entry, and is saved for MaxBalLookback rounds
 	if uint64(len(sd.Creatables))*creatablesEntrySize*proto.MaxBalLookback > stateDeltaTargetOptimizationThreshold {
 		creatableDeltas := make(map[basics.CreatableIndex]ModifiedCreatable, len(sd.Creatables))
 		for k, v := range sd.Creatables {

--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -101,11 +101,9 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 	const consensusCatchpointCatchupTestProtocol = protocol.ConsensusVersion("catchpointtestingprotocol")
 	catchpointCatchupProtocol := config.Consensus[protocol.ConsensusCurrentVersion]
 	catchpointCatchupProtocol.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
-	// MaxBalLookback  =  2 x SeedRefreshInterval x SeedLookback
-	// ref. https://github.com/algorandfoundation/specs/blob/master/dev/abft.md
 	catchpointCatchupProtocol.SeedLookback = 2
 	catchpointCatchupProtocol.SeedRefreshInterval = 8
-	catchpointCatchupProtocol.MaxBalLookback = 2 * catchpointCatchupProtocol.SeedLookback * catchpointCatchupProtocol.SeedRefreshInterval // 32
+	catchpointCatchupProtocol.MaxBalLookback = 16
 	catchpointCatchupProtocol.MaxTxnLife = 33
 
 	if runtime.GOARCH == "amd64" {

--- a/test/e2e-go/features/transactions/asset_test.go
+++ b/test/e2e-go/features/transactions/asset_test.go
@@ -1001,17 +1001,13 @@ func TestAssetCreateWaitBalLookbackDelete(t *testing.T) {
 
 	consensusVersion := protocol.ConsensusVersion("test-shorter-lookback")
 
-	// Setting the testShorterLookback parameters derived from ConsensusCurrentVersion
-	// Will result in MaxBalLookback = 32
 	// Used to run tests faster where past MaxBalLookback values are checked
 	consensusParams := config.Consensus[protocol.ConsensusCurrentVersion]
 	consensusParams.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 
-	// MaxBalLookback  =  2 x SeedRefreshInterval x SeedLookback
-	// ref. https://github.com/algorandfoundation/specs/blob/master/dev/abft.md
 	consensusParams.SeedLookback = 2
 	consensusParams.SeedRefreshInterval = 8
-	consensusParams.MaxBalLookback = 2 * consensusParams.SeedLookback * consensusParams.SeedRefreshInterval // 32
+	consensusParams.MaxBalLookback = 16
 
 	configurableConsensus[consensusVersion] = consensusParams
 


### PR DESCRIPTION
## Summary

We no longer need to store 320 rounds, but we don't want to remove the lookback completely because the L2 contracts project uses it. This PR changes the value and updates comments/tests.

## Test Plan
