### PR TITLE
CI: remove buildpulse upload step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,9 +337,6 @@ commands:
           key: 'go-cache-v2-{{ .Environment.CIRCLE_STAGE }}-{{ .Environment.CIRCLE_BUILD_NUM }}'
           paths:
             - tmp/go-cache
-      - upload_to_buildpulse:
-          platform: << parameters.platform >>
-          path: << parameters.result_path >>/<< parameters.result_subdir>>
 
   upload_coverage:
     description: Collect coverage reports and upload them
@@ -349,40 +346,6 @@ commands:
           no_output_timeout: 10m
           command: |
             scripts/travis/upload_coverage.sh || true
-
-  upload_to_buildpulse:
-    description: Collect build reports and upload them
-    parameters:
-      platform:
-        type: string
-      path:
-        type: string
-    steps:
-      - run:
-          name: Send test results to BuildPulse
-          when: always
-          command: |
-            set -e
-            if ! ls << parameters.path >>/*/*.xml &> /dev/null; then exit 0; fi
-            sed -i"" -e 's/classname="/classname="<< parameters.platform >>-/' << parameters.path >>/*/*.xml
-            case "<< parameters.platform >>" in
-              arm64)
-                URL=https://github.com/buildpulse/test-reporter/releases/download/v0.21.0-pre/test-reporter-linux-arm64
-                SUM=53f94c29ad162c2b9ebb1f4a2f967f5262c0459ee4a0c34332977d8c89aafc18
-                ;;
-              amd64)
-                URL=https://github.com/buildpulse/test-reporter/releases/download/v0.21.0-pre/test-reporter-linux-amd64
-                SUM=4655e54d756580c0de0112cab488e6e08d0af75e9fc8caea2d63f9e13be8beb5
-                ;;
-              mac_amd64)
-                URL=https://github.com/buildpulse/test-reporter/releases/download/v0.21.0-pre/test-reporter-darwin-amd64
-                SUM=2f9e20a6f683c80f35d04e36bc57ecfe605bb48fee5a1b8d8f7c45094028eea3
-                ;;
-            esac
-            curl -fsSL --retry 3 --retry-connrefused $URL > ./buildpulse-test-reporter
-            echo "$SUM *buildpulse-test-reporter" | shasum -a 256 -c --status
-            chmod +x ./buildpulse-test-reporter
-            ./buildpulse-test-reporter submit << parameters.path >> --account-id 23182699 --repository-id 191266671 || true
 
   generic_integration:
     description: Run integration tests from build workspace, for re-use by diferent architectures
@@ -444,9 +407,6 @@ commands:
           root: << parameters.result_path >>
           paths:
             - << parameters.result_subdir >>
-      - upload_to_buildpulse:
-          platform: << parameters.platform >>
-          path: << parameters.result_path >>/<< parameters.result_subdir>>
 
   tests_verification_command:
     description: Check if all tests were run at least once and only once across all parallel runs


### PR DESCRIPTION
## Summary

Remove old CI analysis upload step.

## Test Plan

Existing tests should pass.