### PR TITLE
320 rounds: Add LRU cache into online accounts tracker

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -181,11 +181,11 @@ type persistedAccountData struct {
 }
 
 type persistedOnlineAccountData struct {
-	addr              basics.Address
-	accountData       baseOnlineAccountData
-	rowid             int64
-	round             basics.Round
-	normalizedBalance basics.MicroAlgos
+	addr        basics.Address
+	accountData baseOnlineAccountData
+	rowid       int64
+	round       basics.Round
+	// normalizedBalance basics.MicroAlgos
 }
 
 //msgp:ignore persistedResourcesData
@@ -783,7 +783,7 @@ func (a *compactAccountDeltas) updateOld(idx int, old persistedAccountData) {
 // makeCompactAccountDeltas takes an array of account AccountDeltas ( one array entry per round ), and compacts the arrays into a single
 // data structure that contains all the account deltas changes. While doing that, the function eliminate any intermediate account changes.
 // It counts the number of changes each account get modified across the round range by specifying it in the nAcctDeltas field of the accountDeltaCount/modifiedCreatable.
-func makeCompactOnlineAccountDeltas(accountDeltas []ledgercore.AccountDeltas, baseRound basics.Round, baseAccounts lruAccounts) (outAccountDeltas compactOnlineAccountDeltas) {
+func makeCompactOnlineAccountDeltas(accountDeltas []ledgercore.AccountDeltas, baseRound basics.Round, baseOnlineAccounts lruOnlineAccounts) (outAccountDeltas compactOnlineAccountDeltas) {
 	if len(accountDeltas) == 0 {
 		return
 	}
@@ -819,13 +819,14 @@ func makeCompactOnlineAccountDeltas(accountDeltas []ledgercore.AccountDeltas, ba
 					newStatus:   acctDelta.Status,
 				}
 				newEntry.newAcct.SetCoreAccountData(acctDelta)
-				// TODO: find and use the latest (updround) entry
-				// if baseOnlineAccountData, has := baseAccounts.read(addr); has {
-				// 	newEntry.oldAcct = baseOnlineAccountData
-				// 	outAccountDeltas.insert(newEntry) // insert instead of upsert economizes one map lookup
-				// } else {
-				outAccountDeltas.insertMissing(newEntry)
-				// }
+				// the cache always has the most recent data,
+				// including deleted/expired online accounts with empty voting data
+				if baseOnlineAccountData, has := baseOnlineAccounts.read(addr); has {
+					newEntry.oldAcct = baseOnlineAccountData
+					outAccountDeltas.insert(newEntry)
+				} else {
+					outAccountDeltas.insertMissing(newEntry)
+				}
 			}
 		}
 	}
@@ -4454,6 +4455,12 @@ func (pac *persistedAccountData) before(other *persistedAccountData) bool {
 // happened before the other.
 func (prd *persistedResourcesData) before(other *persistedResourcesData) bool {
 	return prd.round < other.round
+}
+
+// before compares the round numbers of two persistedAccountData and determines if the current persistedAccountData
+// happened before the other.
+func (pac *persistedOnlineAccountData) before(other *persistedOnlineAccountData) bool {
+	return pac.round < other.round
 }
 
 // txTailRoundLease is used as part of txTailRound for storing

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -258,9 +258,11 @@ func TestAccountDBRound(t *testing.T) {
 	expectedDbImage := make(map[basics.CreatableIndex]ledgercore.ModifiedCreatable)
 	var baseAccounts lruAccounts
 	var baseResources lruResources
+	var baseOnlineAccounts lruOnlineAccounts
 	var newacctsTotals map[basics.Address]ledgercore.AccountData
 	baseAccounts.init(nil, 100, 80)
 	baseResources.init(nil, 100, 80)
+	baseOnlineAccounts.init(nil, 100, 80)
 	for i := 1; i < 10; i++ {
 		var updates ledgercore.AccountDeltas
 		updates, newacctsTotals, _, lastCreatableID = ledgertesting.RandomDeltasFull(20, accts, 0, lastCreatableID)
@@ -272,7 +274,7 @@ func TestAccountDBRound(t *testing.T) {
 		oldBase := i - 1
 		updatesCnt := makeCompactAccountDeltas([]ledgercore.AccountDeltas{updates}, basics.Round(oldBase), true, baseAccounts)
 		resourceUpdatesCnt := makeCompactResourceDeltas([]ledgercore.AccountDeltas{updates}, basics.Round(oldBase), true, baseAccounts, baseResources)
-		updatesOnlineCnt := makeCompactOnlineAccountDeltas([]ledgercore.AccountDeltas{updates}, basics.Round(oldBase), baseAccounts)
+		updatesOnlineCnt := makeCompactOnlineAccountDeltas([]ledgercore.AccountDeltas{updates}, basics.Round(oldBase), baseOnlineAccounts)
 
 		err = updatesCnt.accountsLoadOld(tx)
 		require.NoError(t, err)
@@ -2835,8 +2837,10 @@ func TestAccountOnlineQueries(t *testing.T) {
 
 	var baseAccounts lruAccounts
 	var baseResources lruResources
+	var baseOnlineAccounts lruOnlineAccounts
 	baseAccounts.init(nil, 100, 80)
 	baseResources.init(nil, 100, 80)
+	baseOnlineAccounts.init(nil, 100, 80)
 
 	addrA := ledgertesting.RandomAddress()
 	addrB := ledgertesting.RandomAddress()
@@ -2904,7 +2908,7 @@ func TestAccountOnlineQueries(t *testing.T) {
 
 		oldBase := rnd - 1
 		updatesCnt := makeCompactAccountDeltas([]ledgercore.AccountDeltas{updates}, oldBase, true, baseAccounts)
-		updatesOnlineCnt := makeCompactOnlineAccountDeltas([]ledgercore.AccountDeltas{updates}, oldBase, baseAccounts)
+		updatesOnlineCnt := makeCompactOnlineAccountDeltas([]ledgercore.AccountDeltas{updates}, oldBase, baseOnlineAccounts)
 
 		err = updatesCnt.accountsLoadOld(tx)
 		require.NoError(t, err)

--- a/ledger/acctonline_test.go
+++ b/ledger/acctonline_test.go
@@ -1,0 +1,281 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
+	ledgertesting "github.com/algorand/go-algorand/ledger/testing"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAcctOnline checks the online accounts tracker correctly stores accont change history
+// 1. Start with 1000 online accounts
+// 2. Every round set one of them offline
+// 3. Ensure the DB and the base cache are up to date (report them offline)
+// 4. Ensure expiration works
+func TestAcctOnline(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	const seedLookback = 1
+	const seedInteval = 1
+	const maxBalLookback = 2 * seedLookback * seedInteval
+	const maxDeltaLookback = maxBalLookback // TODO: change
+
+	const numAccts = maxBalLookback * 10
+	allAccts := make([]basics.BalanceRecord, numAccts)
+	genesisAccts := []map[basics.Address]basics.AccountData{{}}
+	genesisAccts[0] = make(map[basics.Address]basics.AccountData, numAccts)
+	for i := 0; i < numAccts; i++ {
+		allAccts[i] = basics.BalanceRecord{
+			Addr:        ledgertesting.RandomAddress(),
+			AccountData: ledgertesting.RandomOnlineAccountData(0),
+		}
+		genesisAccts[0][allAccts[i].Addr] = allAccts[i].AccountData
+	}
+
+	pooldata := basics.AccountData{}
+	pooldata.MicroAlgos.Raw = 100 * 1000 * 1000 * 1000 * 1000
+	pooldata.Status = basics.NotParticipating
+	genesisAccts[0][testPoolAddr] = pooldata
+
+	sinkdata := basics.AccountData{}
+	sinkdata.MicroAlgos.Raw = 1000 * 1000 * 1000 * 1000
+	sinkdata.Status = basics.NotParticipating
+	genesisAccts[0][testSinkAddr] = sinkdata
+
+	testProtocolVersion := protocol.ConsensusVersion("test-protocol-TestAcctOnline")
+	protoParams := config.Consensus[protocol.ConsensusCurrentVersion]
+	protoParams.MaxBalLookback = maxBalLookback
+	protoParams.SeedLookback = seedLookback
+	protoParams.SeedRefreshInterval = seedInteval
+	config.Consensus[testProtocolVersion] = protoParams
+	defer func() {
+		delete(config.Consensus, testProtocolVersion)
+	}()
+
+	ml := makeMockLedgerForTracker(t, true, 1, testProtocolVersion, genesisAccts)
+	defer ml.Close()
+
+	conf := config.GetDefaultLocal()
+	au, oa := newAcctUpdates(t, ml, conf, ".")
+	defer oa.close()
+
+	_, totals, err := au.LatestTotals()
+	require.NoError(t, err)
+
+	for _, bal := range allAccts {
+		data, err := oa.accountsq.lookupOnline(bal.Addr, 0)
+		require.NoError(t, err)
+		require.Equal(t, bal.Addr, data.addr)
+		require.Equal(t, basics.Round(0), data.round)
+		require.Equal(t, bal.AccountData.MicroAlgos, data.accountData.MicroAlgos)
+		require.Equal(t, bal.AccountData.RewardsBase, data.accountData.RewardsBase)
+		require.Equal(t, bal.AccountData.VoteFirstValid, data.accountData.VoteFirstValid)
+		require.Equal(t, bal.AccountData.VoteLastValid, data.accountData.VoteLastValid)
+
+		oad, err := oa.lookupOnlineAccountData(0, bal.Addr)
+		require.NoError(t, err)
+		require.NotEmpty(t, oad)
+	}
+
+	commitSync := func(rnd basics.Round) {
+		_, maxLookback := oa.committedUpTo(rnd)
+		dcc := &deferredCommitContext{
+			deferredCommitRange: deferredCommitRange{
+				lookback: maxLookback,
+			},
+		}
+		cdr := ml.trackers.produceCommittingTask(rnd, ml.trackers.dbRound, &dcc.deferredCommitRange)
+		if cdr != nil {
+			func() {
+				dcc.deferredCommitRange = *cdr
+				ml.trackers.accountsWriting.Add(1)
+
+				// do not take any locks since all operations are synchronous
+				newBase := basics.Round(dcc.offset) + dcc.oldBase
+				dcc.newBase = newBase
+				err = ml.trackers.commitRound(dcc)
+				require.NoError(t, err)
+			}()
+
+		}
+	}
+
+	newBlock := func(rnd basics.Round, base map[basics.Address]basics.AccountData, updates ledgercore.AccountDeltas, prevTotals ledgercore.AccountTotals) (newTotals ledgercore.AccountTotals) {
+		rewardLevel := uint64(0)
+		newTotals = ledgertesting.CalculateNewRoundAccountTotals(t, updates, rewardLevel, protoParams, base, prevTotals)
+
+		blk := bookkeeping.Block{
+			BlockHeader: bookkeeping.BlockHeader{
+				Round: basics.Round(rnd),
+			},
+		}
+		blk.RewardsLevel = rewardLevel
+		blk.CurrentProtocol = testProtocolVersion
+		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
+		delta.Accts.MergeAccounts(updates)
+		delta.Totals = totals
+
+		ml.trackers.newBlock(blk, delta)
+
+		return newTotals
+	}
+
+	// the test 1 requires 2 blocks with different resource state,
+	// oa requires MaxBalLookback block to start persisting
+	// TODO: change MaxBalLookback to the actual lookback parameter
+	const numAcctsStage1 = 10
+	numConsumedStage1 := basics.Round(maxDeltaLookback) + numAcctsStage1
+	targetRound := numConsumedStage1
+	for i := basics.Round(1); i <= targetRound; i++ {
+		var updates ledgercore.AccountDeltas
+		acctIdx := int(i) - 1
+
+		updates.Upsert(allAccts[acctIdx].Addr, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: ledgercore.VotingData{}})
+
+		base := genesisAccts[i-1]
+		newAccts := applyPartialDeltas(base, updates)
+		genesisAccts = append(genesisAccts, newAccts)
+
+		// prepare block
+		totals = newBlock(i, base, updates, totals)
+
+		// commit changes synchroniously
+		commitSync(i)
+
+		// check the table data and the cache
+		// data gets committed after maxDeltaLookback
+		if i > maxDeltaLookback {
+			rnd := i - maxDeltaLookback
+			acctIdx := int(rnd) - 1
+			bal := allAccts[acctIdx]
+			data, err := oa.accountsq.lookupOnline(bal.Addr, rnd)
+			require.NoError(t, err)
+			require.Equal(t, bal.Addr, data.addr)
+			require.NotEmpty(t, data.rowid)
+			require.Equal(t, oa.cachedDBRoundOnline, data.round)
+			require.Empty(t, data.accountData)
+
+			data, has := oa.baseOnlineAccounts.read(bal.Addr)
+			require.True(t, has)
+			require.NotEmpty(t, data.rowid)
+			require.Empty(t, data.accountData)
+
+			oad, err := oa.lookupOnlineAccountData(rnd, bal.Addr)
+			require.NoError(t, err)
+			require.Empty(t, oad)
+
+			// check the prev original row is still there
+			data, err = oa.accountsq.lookupOnline(bal.Addr, rnd-1)
+			require.NoError(t, err)
+			require.Equal(t, bal.Addr, data.addr)
+			require.NotEmpty(t, data.rowid)
+			require.Equal(t, oa.cachedDBRoundOnline, data.round)
+			require.NotEmpty(t, data.accountData)
+		}
+
+		// check data gets expired and removed from the DB
+		// account 0 is set to Offline at round 1
+		// and set expired at X = 1 + MaxBalLookback (= 3)
+		// actual removal happens when X is committed i.e. at round X + maxDeltaLookback (= 5)
+		if i > maxDeltaLookback+maxDeltaLookback {
+			rnd := i - (maxDeltaLookback + maxDeltaLookback)
+			acctIdx := int(rnd) - 1
+			bal := allAccts[acctIdx]
+			data, err := oa.accountsq.lookupOnline(bal.Addr, rnd)
+			require.NoError(t, err)
+			require.Equal(t, bal.Addr, data.addr)
+			require.Empty(t, data.rowid)
+			require.Equal(t, oa.cachedDBRoundOnline, data.round)
+			require.Empty(t, data.accountData)
+
+			data, has := oa.baseOnlineAccounts.read(bal.Addr)
+			require.True(t, has)
+			require.NotEmpty(t, data.rowid) // TODO: FIXME: set rowid to empty for these items
+			require.Empty(t, data.accountData)
+
+			// TODO: restore after introducing lookback
+			// roundOffset fails with round 1 before dbRound 3
+			// oad, err := oa.lookupOnlineAccountData(rnd, bal.Addr)
+			// require.NoError(t, err)
+			// require.Empty(t, oad)
+		}
+	}
+
+	// ensure rounds
+	require.Equal(t, targetRound, au.latest())
+	require.Equal(t, basics.Round(numAcctsStage1), oa.cachedDBRoundOnline)
+
+	// at this point we should have maxBalLookback last accounts of numAcctsStage1
+	// to be in the DB and in the cache and not yet removed
+	for i := numAcctsStage1 - maxBalLookback; i < numAcctsStage1; i++ {
+		bal := allAccts[i]
+		// we expire account i at round i+1
+		data, err := oa.accountsq.lookupOnline(bal.Addr, basics.Round(i+1))
+		require.NoError(t, err)
+		require.Equal(t, bal.Addr, data.addr)
+		require.NotEmpty(t, data.rowid)
+		require.Equal(t, oa.cachedDBRoundOnline, data.round)
+		require.Empty(t, data.accountData)
+
+		data, has := oa.baseOnlineAccounts.read(bal.Addr)
+		require.True(t, has)
+		require.NotEmpty(t, data.rowid)
+		require.Empty(t, data.accountData)
+
+		// TODO: restore after introducing lookback
+		// oad, err := oa.lookupOnlineAccountData(basics.Round(i+1), bal.Addr)
+		// require.NoError(t, err)
+		// require.Empty(t, oad)
+
+		// ensure the online entry is still in the DB for the round i
+		data, err = oa.accountsq.lookupOnline(bal.Addr, basics.Round(i))
+		require.NoError(t, err)
+		require.Equal(t, bal.Addr, data.addr)
+		require.NotEmpty(t, data.rowid)
+		require.Equal(t, oa.cachedDBRoundOnline, data.round)
+		require.NotEmpty(t, data.accountData)
+	}
+
+	// check maxDeltaLookback accounts in in-memory deltas, check it
+	for i := numAcctsStage1; i < numAcctsStage1+maxDeltaLookback; i++ {
+		bal := allAccts[i]
+		oad, err := oa.lookupOnlineAccountData(basics.Round(i+1), bal.Addr)
+		require.NoError(t, err)
+		require.Empty(t, oad)
+
+		// the table has old values b/c not committed yet
+		data, err := oa.accountsq.lookupOnline(bal.Addr, basics.Round(i))
+		require.NoError(t, err)
+		require.Equal(t, bal.Addr, data.addr)
+		require.NotEmpty(t, data.rowid)
+		require.Equal(t, oa.cachedDBRoundOnline, data.round)
+		require.NotEmpty(t, data.accountData)
+
+		// the base cache also does not have such entires
+		data, has := oa.baseOnlineAccounts.read(bal.Addr)
+		require.False(t, has)
+		require.Empty(t, data)
+	}
+}

--- a/ledger/lruonlineaccts.go
+++ b/ledger/lruonlineaccts.go
@@ -1,0 +1,121 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package ledger
+
+import (
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/logging"
+)
+
+// lruAccounts provides a storage class for the most recently used accounts data.
+// It doesn't have any synchronization primitive on it's own and require to be
+// synchronized by the caller.
+type lruOnlineAccounts struct {
+	// accountsList contain the list of persistedAccountData, where the front ones are the most "fresh"
+	// and the ones on the back are the oldest.
+	accountsList *persistedOnlineAccountDataList
+	// accounts provides fast access to the various elements in the list by using the account address
+	accounts map[basics.Address]*persistedOnlineAccountDataListNode
+	// pendingAccounts are used as a way to avoid taking a write-lock. When the caller needs to "materialize" these,
+	// it would call flushPendingWrites and these would be merged into the accounts/accountsList
+	pendingAccounts chan persistedOnlineAccountData
+	// log interface; used for logging the threshold event.
+	log logging.Logger
+	// pendingWritesWarnThreshold is the threshold beyond we would write a warning for exceeding the number of pendingAccounts entries
+	pendingWritesWarnThreshold int
+}
+
+// init initializes the lruAccounts for use.
+// thread locking semantics : write lock
+func (m *lruOnlineAccounts) init(log logging.Logger, pendingWrites int, pendingWritesWarnThreshold int) {
+	m.accountsList = newPersistedOnlineAccountList().allocateFreeNodes(pendingWrites)
+	m.accounts = make(map[basics.Address]*persistedOnlineAccountDataListNode, pendingWrites)
+	m.pendingAccounts = make(chan persistedOnlineAccountData, pendingWrites)
+	m.log = log
+	m.pendingWritesWarnThreshold = pendingWritesWarnThreshold
+}
+
+// read the persistedAccountData object that the lruAccounts has for the given address.
+// thread locking semantics : read lock
+func (m *lruOnlineAccounts) read(addr basics.Address) (data persistedOnlineAccountData, has bool) {
+	if el := m.accounts[addr]; el != nil {
+		return *el.Value, true
+	}
+	return persistedOnlineAccountData{}, false
+}
+
+// flushPendingWrites flushes the pending writes to the main lruAccounts cache.
+// thread locking semantics : write lock
+func (m *lruOnlineAccounts) flushPendingWrites() {
+	pendingEntriesCount := len(m.pendingAccounts)
+	if pendingEntriesCount >= m.pendingWritesWarnThreshold {
+		m.log.Warnf("lruOnlineAccounts: number of entries in pendingAccounts(%d) exceed the warning threshold of %d", pendingEntriesCount, m.pendingWritesWarnThreshold)
+	}
+	for ; pendingEntriesCount > 0; pendingEntriesCount-- {
+		select {
+		case pendingAccountData := <-m.pendingAccounts:
+			m.write(pendingAccountData)
+		default:
+			return
+		}
+	}
+}
+
+// writePending write a single persistedOnlineAccountData entry to the pendingAccounts buffer.
+// the function doesn't block, and in case of a buffer overflow the entry would not be added.
+// thread locking semantics : no lock is required.
+func (m *lruOnlineAccounts) writePending(acct persistedOnlineAccountData) {
+	select {
+	case m.pendingAccounts <- acct:
+	default:
+	}
+}
+
+// write a single persistedAccountData to the lruAccounts cache.
+// when writing the entry, the round number would be used to determine if it's a newer
+// version of what's already on the cache or not. In all cases, the entry is going
+// to be promoted to the front of the list.
+// thread locking semantics : write lock
+func (m *lruOnlineAccounts) write(acctData persistedOnlineAccountData) {
+	if el := m.accounts[acctData.addr]; el != nil {
+		// already exists; is it a newer ?
+		if el.Value.before(&acctData) {
+			// we update with a newer version.
+			el.Value = &acctData
+		}
+		m.accountsList.moveToFront(el)
+	} else {
+		// new entry.
+		m.accounts[acctData.addr] = m.accountsList.pushFront(&acctData)
+	}
+}
+
+// prune adjust the current size of the lruAccounts cache, by dropping the least
+// recently used entries.
+// thread locking semantics : write lock
+func (m *lruOnlineAccounts) prune(newSize int) (removed int) {
+	for {
+		if len(m.accounts) <= newSize {
+			break
+		}
+		back := m.accountsList.back()
+		delete(m.accounts, back.Value.addr)
+		m.accountsList.remove(back)
+		removed++
+	}
+	return
+}

--- a/ledger/lruonlineaccts_test.go
+++ b/ledger/lruonlineaccts_test.go
@@ -1,0 +1,196 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package ledger
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/test/partitiontest"
+)
+
+func TestLRUOnlineAccountsBasic(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	var baseOnlineAcct lruOnlineAccounts
+	baseOnlineAcct.init(logging.TestingLog(t), 10, 5)
+
+	accountsNum := 50
+	// write 50 accounts
+	for i := 0; i < accountsNum; i++ {
+		acct := persistedOnlineAccountData{
+			addr:        basics.Address(crypto.Hash([]byte{byte(i)})),
+			round:       basics.Round(i),
+			rowid:       int64(i),
+			accountData: baseOnlineAccountData{MicroAlgos: basics.MicroAlgos{Raw: uint64(i)}},
+		}
+		baseOnlineAcct.write(acct)
+	}
+
+	// verify that all these accounts are truly there.
+	for i := 0; i < accountsNum; i++ {
+		addr := basics.Address(crypto.Hash([]byte{byte(i)}))
+		acct, has := baseOnlineAcct.read(addr)
+		require.True(t, has)
+		require.Equal(t, basics.Round(i), acct.round)
+		require.Equal(t, addr, acct.addr)
+		require.Equal(t, uint64(i), acct.accountData.MicroAlgos.Raw)
+		require.Equal(t, int64(i), acct.rowid)
+	}
+
+	// verify expected missing entries
+	for i := accountsNum; i < accountsNum*2; i++ {
+		addr := basics.Address(crypto.Hash([]byte{byte(i)}))
+		acct, has := baseOnlineAcct.read(addr)
+		require.False(t, has)
+		require.Equal(t, persistedOnlineAccountData{}, acct)
+	}
+
+	baseOnlineAcct.prune(accountsNum / 2)
+
+	// verify expected (missing/existing) entries
+	for i := 0; i < accountsNum*2; i++ {
+		addr := basics.Address(crypto.Hash([]byte{byte(i)}))
+		acct, has := baseOnlineAcct.read(addr)
+
+		if i >= accountsNum/2 && i < accountsNum {
+			// expected to have it.
+			require.True(t, has)
+			require.Equal(t, basics.Round(i), acct.round)
+			require.Equal(t, addr, acct.addr)
+			require.Equal(t, uint64(i), acct.accountData.MicroAlgos.Raw)
+			require.Equal(t, int64(i), acct.rowid)
+		} else {
+			require.False(t, has)
+			require.Equal(t, persistedOnlineAccountData{}, acct)
+		}
+	}
+}
+
+func TestLRUOnlineAccountsPendingWrites(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	var baseOnlineAcct lruOnlineAccounts
+	accountsNum := 250
+	baseOnlineAcct.init(logging.TestingLog(t), accountsNum*2, accountsNum)
+
+	for i := 0; i < accountsNum; i++ {
+		go func(i int) {
+			time.Sleep(time.Duration((crypto.RandUint64() % 50)) * time.Millisecond)
+			acct := persistedOnlineAccountData{
+				addr:        basics.Address(crypto.Hash([]byte{byte(i)})),
+				round:       basics.Round(i),
+				rowid:       int64(i),
+				accountData: baseOnlineAccountData{MicroAlgos: basics.MicroAlgos{Raw: uint64(i)}},
+			}
+			baseOnlineAcct.writePending(acct)
+		}(i)
+	}
+	testStarted := time.Now()
+	for {
+		baseOnlineAcct.flushPendingWrites()
+		// check if all accounts were loaded into "main" cache.
+		allAccountsLoaded := true
+		for i := 0; i < accountsNum; i++ {
+			addr := basics.Address(crypto.Hash([]byte{byte(i)}))
+			_, has := baseOnlineAcct.read(addr)
+			if !has {
+				allAccountsLoaded = false
+				break
+			}
+		}
+		if allAccountsLoaded {
+			break
+		}
+		if time.Since(testStarted).Seconds() > 20 {
+			require.Fail(t, "failed after waiting for 20 second")
+		}
+		// not yet, keep looping.
+	}
+}
+
+func TestLRUOnlineAccountsPendingWritesWarning(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	var baseOnlineAcct lruOnlineAccounts
+	pendingWritesBuffer := 50
+	pendingWritesThreshold := 40
+	log := &lruAccountsTestLogger{Logger: logging.TestingLog(t)}
+	baseOnlineAcct.init(log, pendingWritesBuffer, pendingWritesThreshold)
+	for j := 0; j < 50; j++ {
+		for i := 0; i < j; i++ {
+			acct := persistedOnlineAccountData{
+				addr:        basics.Address(crypto.Hash([]byte{byte(i)})),
+				round:       basics.Round(i),
+				rowid:       int64(i),
+				accountData: baseOnlineAccountData{MicroAlgos: basics.MicroAlgos{Raw: uint64(i)}},
+			}
+			baseOnlineAcct.writePending(acct)
+		}
+		baseOnlineAcct.flushPendingWrites()
+		if j >= pendingWritesThreshold {
+			// expect a warning in the log
+			require.Equal(t, 1+j-pendingWritesThreshold, log.warnMsgCount)
+		}
+	}
+}
+
+func TestLRUOnlineAccountsOmittedPendingWrites(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	var baseOnlineAcct lruOnlineAccounts
+	pendingWritesBuffer := 50
+	pendingWritesThreshold := 40
+	log := &lruAccountsTestLogger{Logger: logging.TestingLog(t)}
+	baseOnlineAcct.init(log, pendingWritesBuffer, pendingWritesThreshold)
+
+	for i := 0; i < pendingWritesBuffer*2; i++ {
+		acct := persistedOnlineAccountData{
+			addr:        basics.Address(crypto.Hash([]byte{byte(i)})),
+			round:       basics.Round(i),
+			rowid:       int64(i),
+			accountData: baseOnlineAccountData{MicroAlgos: basics.MicroAlgos{Raw: uint64(i)}},
+		}
+		baseOnlineAcct.writePending(acct)
+	}
+
+	baseOnlineAcct.flushPendingWrites()
+
+	// verify that all these accounts are truly there.
+	for i := 0; i < pendingWritesBuffer; i++ {
+		addr := basics.Address(crypto.Hash([]byte{byte(i)}))
+		acct, has := baseOnlineAcct.read(addr)
+		require.True(t, has)
+		require.Equal(t, basics.Round(i), acct.round)
+		require.Equal(t, addr, acct.addr)
+		require.Equal(t, uint64(i), acct.accountData.MicroAlgos.Raw)
+		require.Equal(t, int64(i), acct.rowid)
+	}
+
+	// verify expected missing entries
+	for i := pendingWritesBuffer; i < pendingWritesBuffer*2; i++ {
+		addr := basics.Address(crypto.Hash([]byte{byte(i)}))
+		acct, has := baseOnlineAcct.read(addr)
+		require.False(t, has)
+		require.Equal(t, persistedOnlineAccountData{}, acct)
+	}
+}

--- a/ledger/persistedonlineaccts_list.go
+++ b/ledger/persistedonlineaccts_list.go
@@ -1,0 +1,144 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package ledger
+
+// persistedOnlineAccountDataList represents a doubly linked list.
+// must initiate with newPersistedAccountList.
+type persistedOnlineAccountDataList struct {
+	root     persistedOnlineAccountDataListNode  // sentinel list element, only &root, root.prev, and root.next are used
+	freeList *persistedOnlineAccountDataListNode // preallocated nodes location
+}
+
+type persistedOnlineAccountDataListNode struct {
+	// Next and previous pointers in the doubly-linked list of elements.
+	// To simplify the implementation, internally a list l is implemented
+	// as a ring, such that &l.root is both the next element of the last
+	// list element (l.Back()) and the previous element of the first list
+	// element (l.Front()).
+	next, prev *persistedOnlineAccountDataListNode
+
+	Value *persistedOnlineAccountData
+}
+
+func newPersistedOnlineAccountList() *persistedOnlineAccountDataList {
+	l := new(persistedOnlineAccountDataList)
+	l.root.next = &l.root
+	l.root.prev = &l.root
+	// used as a helper but does not store value
+	l.freeList = new(persistedOnlineAccountDataListNode)
+
+	return l
+}
+
+func (l *persistedOnlineAccountDataList) insertNodeToFreeList(otherNode *persistedOnlineAccountDataListNode) {
+	otherNode.next = l.freeList.next
+	otherNode.prev = nil
+	otherNode.Value = nil
+
+	l.freeList.next = otherNode
+}
+
+func (l *persistedOnlineAccountDataList) getNewNode() *persistedOnlineAccountDataListNode {
+	if l.freeList.next == nil {
+		return new(persistedOnlineAccountDataListNode)
+	}
+	newNode := l.freeList.next
+	l.freeList.next = newNode.next
+
+	return newNode
+}
+
+func (l *persistedOnlineAccountDataList) allocateFreeNodes(numAllocs int) *persistedOnlineAccountDataList {
+	if l.freeList == nil {
+		return l
+	}
+	for i := 0; i < numAllocs; i++ {
+		l.insertNodeToFreeList(new(persistedOnlineAccountDataListNode))
+	}
+
+	return l
+}
+
+// Back returns the last element of list l or nil if the list is empty.
+func (l *persistedOnlineAccountDataList) back() *persistedOnlineAccountDataListNode {
+	isEmpty := func(list *persistedOnlineAccountDataList) bool {
+		// assumes we are inserting correctly to the list - using pushFront.
+		return list.root.next == &list.root
+	}
+
+	if isEmpty(l) {
+		return nil
+	}
+	return l.root.prev
+}
+
+// remove removes e from l if e is an element of list l.
+// It returns the element value e.Value.
+// The element must not be nil.
+func (l *persistedOnlineAccountDataList) remove(e *persistedOnlineAccountDataListNode) {
+	e.prev.next = e.next
+	e.next.prev = e.prev
+	e.next = nil // avoid memory leaks
+	e.prev = nil // avoid memory leaks
+
+	l.insertNodeToFreeList(e)
+}
+
+// pushFront inserts a new element e with value v at the front of list l and returns e.
+func (l *persistedOnlineAccountDataList) pushFront(v *persistedOnlineAccountData) *persistedOnlineAccountDataListNode {
+	newNode := l.getNewNode()
+	newNode.Value = v
+	return l.insertValue(newNode, &l.root)
+}
+
+// insertValue inserts e after at, increments l.len, and returns e.
+func (l *persistedOnlineAccountDataList) insertValue(newNode *persistedOnlineAccountDataListNode, at *persistedOnlineAccountDataListNode) *persistedOnlineAccountDataListNode {
+	n := at.next
+	at.next = newNode
+	newNode.prev = at
+	newNode.next = n
+	n.prev = newNode
+
+	return newNode
+}
+
+// moveToFront moves element e to the front of list l.
+// If e is not an element of l, the list is not modified.
+// The element must not be nil.
+func (l *persistedOnlineAccountDataList) moveToFront(e *persistedOnlineAccountDataListNode) {
+	if l.root.next == e {
+		return
+	}
+	l.move(e, &l.root)
+}
+
+// move moves e to next to at and returns e.
+func (l *persistedOnlineAccountDataList) move(e, at *persistedOnlineAccountDataListNode) *persistedOnlineAccountDataListNode {
+	if e == at {
+		return e
+	}
+	e.prev.next = e.next
+	e.next.prev = e.prev
+
+	n := at.next
+	at.next = e
+	e.prev = at
+	e.next = n
+	n.prev = e
+
+	return e
+}

--- a/ledger/persistedonlineaccts_list_test.go
+++ b/ledger/persistedonlineaccts_list_test.go
@@ -1,0 +1,176 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/test/partitiontest"
+)
+
+func (l *persistedOnlineAccountDataList) getRoot() dataListNode {
+	return &l.root
+}
+
+func (l *persistedOnlineAccountDataListNode) getNext() dataListNode {
+	// get rid of returning nil wrapped into an interface to let i = x.getNext(); i != nil work.
+	if l.next == nil {
+		return nil
+	}
+	return l.next
+}
+
+func (l *persistedOnlineAccountDataListNode) getPrev() dataListNode {
+	if l.prev == nil {
+		return nil
+	}
+	return l.prev
+}
+
+func TestRemoveFromListOAD(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	l := newPersistedOnlineAccountList()
+	e1 := l.pushFront(&persistedOnlineAccountData{addr: basics.Address{1}})
+	e2 := l.pushFront(&persistedOnlineAccountData{addr: basics.Address{2}})
+	e3 := l.pushFront(&persistedOnlineAccountData{addr: basics.Address{3}})
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e3, e2, e1})
+
+	l.remove(e2)
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e3, e1})
+	l.remove(e3)
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e1})
+}
+
+func TestAddingNewNodeWithAllocatedFreeListOAD(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	l := newPersistedOnlineAccountList().allocateFreeNodes(10)
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{})
+	if countListSize(l.freeList) != 10 {
+		t.Errorf("free list did not allocate nodes")
+		return
+	}
+	// test elements
+	e1 := l.pushFront(&persistedOnlineAccountData{addr: basics.Address{1}})
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e1})
+
+	if countListSize(l.freeList) != 9 {
+		t.Errorf("free list did not provide a node on new list entry")
+		return
+	}
+}
+
+// inspect that the list seems like the array
+func checkListPointersOAD(t *testing.T, l *persistedOnlineAccountDataList, es []*persistedOnlineAccountDataListNode) {
+	es2 := make([]dataListNode, len(es))
+	for i, el := range es {
+		es2[i] = el
+	}
+
+	checkListPointers(t, l, es2)
+}
+
+func TestMultielementListPositioningOAD(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	l := newPersistedOnlineAccountList()
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{})
+	// test elements
+	e2 := l.pushFront(&persistedOnlineAccountData{addr: basics.Address{2}})
+	e1 := l.pushFront(&persistedOnlineAccountData{addr: basics.Address{1}})
+	e3 := l.pushFront(&persistedOnlineAccountData{addr: basics.Address{3}})
+	e4 := l.pushFront(&persistedOnlineAccountData{addr: basics.Address{4}})
+	e5 := l.pushFront(&persistedOnlineAccountData{addr: basics.Address{5}})
+
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e5, e4, e3, e1, e2})
+
+	l.move(e4, e1)
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e5, e3, e1, e4, e2})
+
+	l.remove(e5)
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e3, e1, e4, e2})
+
+	l.move(e1, e4) // swap in middle
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e3, e4, e1, e2})
+
+	l.moveToFront(e4)
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e4, e3, e1, e2})
+
+	l.remove(e2)
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e4, e3, e1})
+
+	l.moveToFront(e3) // move from middle
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e3, e4, e1})
+
+	l.moveToFront(e1) // move from end
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e1, e3, e4})
+
+	l.moveToFront(e1) // no movement
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e1, e3, e4})
+
+	e2 = l.pushFront(&persistedOnlineAccountData{addr: basics.Address{2}})
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e2, e1, e3, e4})
+
+	l.remove(e3) // removing from middle
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e2, e1, e4})
+
+	l.remove(e4) // removing from end
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e2, e1})
+
+	l.move(e2, e1) // swapping between two elements
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e1, e2})
+
+	l.remove(e1) // removing front
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e2})
+
+	l.move(e2, l.back()) // swapping element with itself.
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e2})
+
+	l.remove(e2) // remove last one
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{})
+}
+
+func TestSingleElementListPositioningOD(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	l := newPersistedOnlineAccountList()
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{})
+	e := l.pushFront(&persistedOnlineAccountData{addr: basics.Address{1}})
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e})
+	l.moveToFront(e)
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e})
+	l.remove(e)
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{})
+}
+
+func TestRemovedNodeShouldBeMovedToFreeListOAD(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	l := newPersistedOnlineAccountList()
+	e1 := l.pushFront(&persistedOnlineAccountData{addr: basics.Address{1}})
+	e2 := l.pushFront(&persistedOnlineAccountData{addr: basics.Address{2}})
+
+	checkListPointersOAD(t, l, []*persistedOnlineAccountDataListNode{e2, e1})
+
+	e := l.back()
+	l.remove(e)
+
+	for i := l.freeList.next; i != nil; i = i.next {
+		if i == e {
+			// stopping the tst with good results:
+			return
+		}
+	}
+	t.Error("expected the removed node to appear at the freelist")
+}

--- a/ledger/testing/randomAccounts.go
+++ b/ledger/testing/randomAccounts.go
@@ -48,7 +48,7 @@ func RandomNote() []byte {
 }
 
 // RandomAccountData generates a random AccountData
-func RandomAccountData(rewardsLevel uint64) basics.AccountData {
+func RandomAccountData(rewardsBase uint64) basics.AccountData {
 	var data basics.AccountData
 
 	// Avoid overflowing totals
@@ -66,7 +66,18 @@ func RandomAccountData(rewardsLevel uint64) basics.AccountData {
 	}
 
 	data.VoteFirstValid = 0
-	data.RewardsBase = rewardsLevel
+	data.RewardsBase = rewardsBase
+	return data
+}
+
+// RandomOnlineAccountData is similar to RandomAccountData but always creates online account
+func RandomOnlineAccountData(rewardsBase uint64) basics.AccountData {
+	var data basics.AccountData
+	data.MicroAlgos.Raw = crypto.RandUint64() % (1 << 32)
+	data.Status = basics.Online
+	data.VoteLastValid = 1000
+	data.VoteFirstValid = 0
+	data.RewardsBase = rewardsBase
 	return data
 }
 


### PR DESCRIPTION
* Added LRU cache to track the most recent updates into onlineaccounts table
* TODO: add another cache for looking up since accounts can change
        and we need answers about specific round, not the most recent write round
* Added online accounts tests for updates and expirations
