### PR TITLE
AVM: inner appls can call v4

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -301,6 +301,10 @@ type ConsensusParams struct {
 	// provide greater isolation for clear state programs
 	IsolateClearState bool
 
+	// should inner appl txns be allowed to call v4 (and v5) applications?
+	// this also disallows application downgrades
+	AllowV4InnerAppls bool
+
 	// maximum number of applications a single account can create and store
 	// AppParams for at once
 	MaxAppsCreated int
@@ -1133,6 +1137,7 @@ func initConsensusProtocols() {
 	vFuture.CompactCertSecKQ = 128
 
 	vFuture.LogicSigVersion = 7
+	vFuture.AllowV4InnerAppls = true
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 }

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -4525,7 +4525,7 @@ func opItxnSubmit(cx *EvalContext) error {
 						return err
 					}
 					if v < 4 {
-						return fmt.Errorf("inner app call opt-in with CSP v %d < 4", v)
+						return fmt.Errorf("inner app call opt-in with CSP v%d < v4", v)
 					}
 				}
 			}

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -176,10 +176,8 @@ func stackValueFromTealValue(tv basics.TealValue) (sv stackValue, err error) {
 // newly-introduced transaction fields from breaking assumptions made by older
 // versions of TEAL. If one of the transactions in a group will execute a TEAL
 // program whose version predates a given field, that field must not be set
-// anywhere in the transaction group, or the group will be rejected. In
-// addition, inner app calls must not call teal from before inner app calls were
-// introduced.
-func ComputeMinTealVersion(group []transactions.SignedTxnWithAD, inner bool) uint64 {
+// anywhere in the transaction group, or the group will be rejected.
+func ComputeMinTealVersion(group []transactions.SignedTxnWithAD) uint64 {
 	var minVersion uint64
 	for _, txn := range group {
 		if !txn.Txn.RekeyTo.IsZero() {
@@ -190,11 +188,6 @@ func ComputeMinTealVersion(group []transactions.SignedTxnWithAD, inner bool) uin
 		if txn.Txn.Type == protocol.ApplicationCallTx {
 			if minVersion < appsEnabledVersion {
 				minVersion = appsEnabledVersion
-			}
-		}
-		if inner {
-			if minVersion < innerAppsEnabledVersion {
-				minVersion = innerAppsEnabledVersion
 			}
 		}
 	}
@@ -311,7 +304,7 @@ func NewEvalParams(txgroup []transactions.SignedTxnWithAD, proto *config.Consens
 		}
 	}
 
-	minTealVersion := ComputeMinTealVersion(txgroup, false)
+	minTealVersion := ComputeMinTealVersion(txgroup)
 
 	var pooledApplicationBudget *int
 	var pooledAllowedInners *int
@@ -363,7 +356,7 @@ func feeCredit(txgroup []transactions.SignedTxnWithAD, minFee uint64) uint64 {
 
 // NewInnerEvalParams creates an EvalParams to be used while evaluating an inner group txgroup
 func NewInnerEvalParams(txg []transactions.SignedTxnWithAD, caller *EvalContext) *EvalParams {
-	minTealVersion := ComputeMinTealVersion(txg, true)
+	minTealVersion := ComputeMinTealVersion(txg)
 	// Can't happen currently, since innerAppsEnabledVersion > than any minimum
 	// imposed otherwise.  But is correct to check, in case of future restriction.
 	if minTealVersion < *caller.MinTealVersion {
@@ -813,7 +806,7 @@ func versionCheck(program []byte, params *EvalParams) (uint64, int, error) {
 	}
 
 	if params.MinTealVersion == nil {
-		minVersion := ComputeMinTealVersion(params.TxnGroup, params.caller != nil)
+		minVersion := ComputeMinTealVersion(params.TxnGroup)
 		params.MinTealVersion = &minVersion
 	}
 	if version < *params.MinTealVersion {
@@ -4495,7 +4488,7 @@ func opItxnSubmit(cx *EvalContext) error {
 			return err
 		}
 
-		// Disallow reentrancy and limit inner app call depth
+		// Disallow reentrancy, limit inner app call depth, and do version checks
 		if cx.subtxns[itx].Txn.Type == protocol.ApplicationCallTx {
 			if cx.appID == cx.subtxns[itx].Txn.ApplicationID {
 				return fmt.Errorf("attempt to self-call")
@@ -4511,9 +4504,7 @@ func opItxnSubmit(cx *EvalContext) error {
 				return fmt.Errorf("appl depth (%d) exceeded", depth)
 			}
 
-			// Can't call version < innerAppsEnabledVersion, and apps with such
-			// versions will always match, so just check approval program
-			// version.
+			// Can't call old versions in inner apps.
 			program := cx.subtxns[itx].Txn.ApprovalProgram
 			if cx.subtxns[itx].Txn.ApplicationID != 0 {
 				app, _, err := cx.Ledger.AppParams(cx.subtxns[itx].Txn.ApplicationID)
@@ -4521,13 +4512,33 @@ func opItxnSubmit(cx *EvalContext) error {
 					return err
 				}
 				program = app.ApprovalProgram
+				if cx.subtxns[itx].Txn.OnCompletion == transactions.ClearStateOC {
+					program = app.ClearStateProgram
+				}
+				// Don't allow opt-in if the CSP is not runnable as an inner.
+				// This test can only fail after proto.AllowV4InnerAppls starts
+				// allowing calls of pre-6 programs, which might, in turn, have
+				// even older CSPs. Post-5, programs are version synchronized.
+				if cx.subtxns[itx].Txn.OnCompletion == transactions.OptInOC {
+					v, _, err := transactions.ProgramVersion(app.ClearStateProgram)
+					if err != nil {
+						return err
+					}
+					if v < 4 {
+						return fmt.Errorf("inner app call opt-in with CSP v %d < 4", v)
+					}
+				}
 			}
 			v, _, err := transactions.ProgramVersion(program)
 			if err != nil {
 				return err
 			}
-			if v < innerAppsEnabledVersion {
-				return fmt.Errorf("inner app call with version %d < %d", v, innerAppsEnabledVersion)
+			allowableVersion := uint64(innerAppsEnabledVersion)
+			if cx.Proto.AllowV4InnerAppls {
+				allowableVersion = 4
+			}
+			if v < allowableVersion {
+				return fmt.Errorf("inner app call with version %d < %d", v, allowableVersion)
 			}
 		}
 

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -3761,7 +3761,7 @@ func TestAnyRekeyToOrApplicationRaisesMinTealVersion(t *testing.T) {
 			ep.TxnGroup = transactions.WrapSignedTxnsWithAD(cse.group)
 
 			// Computed MinTealVersion should be == validFromVersion
-			calc := ComputeMinTealVersion(ep.TxnGroup, false)
+			calc := ComputeMinTealVersion(ep.TxnGroup)
 			require.Equal(t, calc, cse.validFromVersion)
 
 			// Should fail for all versions < validFromVersion

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -750,7 +750,7 @@ func CheckContractVersions(approval []byte, clear []byte, previous basics.AppPar
 		}
 	}
 	if len(previous.ClearStateProgram) != 0 {
-		pcv, _, err := ProgramVersion(previous.ApprovalProgram)
+		pcv, _, err := ProgramVersion(previous.ClearStateProgram)
 		if err != nil {
 			return err
 		}

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -85,7 +85,7 @@ func PrepareGroupContext(group []transactions.SignedTxn, contextHdr bookkeeping.
 		},
 		consensusVersion: contextHdr.CurrentProtocol,
 		consensusParams:  consensusParams,
-		minTealVersion:   logic.ComputeMinTealVersion(transactions.WrapSignedTxnsWithAD(group), false),
+		minTealVersion:   logic.ComputeMinTealVersion(transactions.WrapSignedTxnsWithAD(group)),
 		signedGroupTxns:  group,
 	}, nil
 }

--- a/data/transactions/verify/verifiedTxnCache.go
+++ b/data/transactions/verify/verifiedTxnCache.go
@@ -128,7 +128,7 @@ func (v *verifiedTransactionCache) GetUnverifiedTranscationGroups(txnGroups [][]
 	for txnGroupIndex := 0; txnGroupIndex < len(txnGroups); txnGroupIndex++ {
 		signedTxnGroup := txnGroups[txnGroupIndex]
 		verifiedTxn := 0
-		groupCtx.minTealVersion = logic.ComputeMinTealVersion(transactions.WrapSignedTxnsWithAD(signedTxnGroup), false)
+		groupCtx.minTealVersion = logic.ComputeMinTealVersion(transactions.WrapSignedTxnsWithAD(signedTxnGroup))
 
 		baseBucket := v.base
 		for txnIdx := 0; txnIdx < len(signedTxnGroup); txnIdx++ {

--- a/ledger/apply/application.go
+++ b/ledger/apply/application.go
@@ -385,7 +385,7 @@ func ApplicationCall(ac transactions.ApplicationCallTxnFields, header transactio
 	// If this txn is going to set new programs (either for creation or
 	// update), check that the programs are valid and not too expensive
 	if ac.ApplicationID == 0 || ac.OnCompletion == transactions.UpdateApplicationOC {
-		err := transactions.CheckContractVersions(ac.ApprovalProgram, ac.ClearStateProgram, params)
+		err := transactions.CheckContractVersions(ac.ApprovalProgram, ac.ClearStateProgram, params, evalParams.Proto)
 		if err != nil {
 			return err
 		}

--- a/ledger/internal/apptxn_test.go
+++ b/ledger/internal/apptxn_test.go
@@ -90,7 +90,7 @@ func TestPayAction(t *testing.T) {
 		Accounts:      []basics.Address{addrs[1]}, // pay self
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &create, &fund, &payout1)
 	vb := endBlock(t, l, eval)
 
@@ -111,11 +111,11 @@ func TestPayAction(t *testing.T) {
 
 	// Build up Residue in RewardsState so it's ready to pay
 	for i := 1; i < 10; i++ {
-		eval = nextBlock(t, l, true, nil)
+		eval = nextBlock(t, l)
 		endBlock(t, l, eval)
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	payout2 := txntest.Txn{
 		Type:          "appl",
 		Sender:        addrs[1],
@@ -162,17 +162,17 @@ func TestPayAction(t *testing.T) {
 		Receiver: ai.Address(),
 		Amount:   10 * 1000 * 1000000, // account min balance, plus fees
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &tenkalgos)
 	endBlock(t, l, eval)
 	beforepay := micros(t, l, ai.Address())
 
 	// Build up Residue in RewardsState so it's ready to pay again
 	for i := 1; i < 10; i++ {
-		eval = nextBlock(t, l, true, nil)
+		eval = nextBlock(t, l)
 		endBlock(t, l, eval)
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, payout2.Noted("2"))
 	vb = endBlock(t, l, eval)
 
@@ -245,7 +245,7 @@ submit:  itxn_submit
 `),
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &asa, &app)
 	vb := endBlock(t, l, eval)
 
@@ -262,7 +262,7 @@ submit:  itxn_submit
 		// stay under 1M, to avoid rewards complications
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &fund)
 	endBlock(t, l, eval)
 
@@ -275,7 +275,7 @@ submit:  itxn_submit
 	}
 
 	// Fail, because app account is not opted in.
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &fundgold, fmt.Sprintf("asset %d missing", asaIndex))
 	endBlock(t, l, eval)
 
@@ -292,7 +292,7 @@ submit:  itxn_submit
 	}
 
 	// Tell the app to opt itself in.
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &optin)
 	endBlock(t, l, eval)
 
@@ -301,7 +301,7 @@ submit:  itxn_submit
 	require.Equal(t, amount, uint64(0))
 
 	// Now, suceed, because opted in.
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &fundgold)
 	endBlock(t, l, eval)
 
@@ -317,7 +317,7 @@ submit:  itxn_submit
 		ForeignAssets:   []basics.AssetIndex{asaIndex},
 		Accounts:        []basics.Address{addrs[0]},
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &withdraw)
 	endBlock(t, l, eval)
 
@@ -325,7 +325,7 @@ submit:  itxn_submit
 	require.True(t, in)
 	require.Equal(t, amount, uint64(10000))
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, withdraw.Noted("2"))
 	endBlock(t, l, eval)
 
@@ -333,7 +333,7 @@ submit:  itxn_submit
 	require.True(t, in) // Zero left, but still opted in
 	require.Equal(t, amount, uint64(0))
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, withdraw.Noted("3"), "underflow on subtracting")
 	endBlock(t, l, eval)
 
@@ -350,7 +350,7 @@ submit:  itxn_submit
 		Accounts:        []basics.Address{addrs[0]},
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &close)
 	endBlock(t, l, eval)
 
@@ -359,13 +359,13 @@ submit:  itxn_submit
 	require.Equal(t, amount, uint64(0))
 
 	// Now, fail again, opted out
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, fundgold.Noted("2"), fmt.Sprintf("asset %d missing", asaIndex))
 	endBlock(t, l, eval)
 
 	// Do it all again, so we can test closeTo when we have a non-zero balance
 	// Tell the app to opt itself in.
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, optin.Noted("a"), fundgold.Noted("a"))
 	endBlock(t, l, eval)
 
@@ -373,7 +373,7 @@ submit:  itxn_submit
 	require.Equal(t, uint64(20000), amount)
 	left, _ := holding(t, l, addrs[0], asaIndex)
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, close.Noted("a"))
 	endBlock(t, l, eval)
 
@@ -390,6 +390,10 @@ func newTestLedger(t testing.TB, balances bookkeeping.GenesisBalances) *ledger.L
 func newTestLedgerWithConsensusVersion(t testing.TB, balances bookkeeping.GenesisBalances, cv protocol.ConsensusVersion) *ledger.Ledger {
 	var genHash crypto.Digest
 	crypto.RandBytes(genHash[:])
+	return newTestLedgerFull(t, balances, cv, genHash)
+}
+
+func newTestLedgerFull(t testing.TB, balances bookkeeping.GenesisBalances, cv protocol.ConsensusVersion, genHash crypto.Digest) *ledger.Ledger {
 	genBlock, err := bookkeeping.MakeGenesisBlock(cv, balances, "test", genHash)
 	require.NoError(t, err)
 	require.False(t, genBlock.FeeSink.IsZero())
@@ -461,7 +465,7 @@ func TestClawbackAction(t *testing.T) {
 		AssetReceiver: addrs[1],
 		XferAsset:     asaIndex,
 	}
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &asa, &app, &optin)
 	vb := endBlock(t, l, eval)
 
@@ -482,7 +486,7 @@ func TestClawbackAction(t *testing.T) {
 		ForeignAssets: []basics.AssetIndex{asaIndex},
 		Accounts:      []basics.Address{addrs[0], addrs[1]},
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	err := txgroup(t, l, eval, &overpay, &clawmove)
 	require.NoError(t, err)
 	endBlock(t, l, eval)
@@ -531,7 +535,7 @@ skipclose:
 		RekeyTo:  appIndex.Address(),
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &ezpayer, &rekey)
 	endBlock(t, l, eval)
 
@@ -541,7 +545,7 @@ skipclose:
 		ApplicationID: appIndex,
 		Accounts:      []basics.Address{addrs[0], addrs[2]}, // pay 2 from 0 (which was rekeyed)
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &useacct)
 	endBlock(t, l, eval)
 
@@ -558,7 +562,7 @@ skipclose:
 		ApplicationID: appIndex,
 		Accounts:      []basics.Address{addrs[2], addrs[0]}, // pay 0 from 2
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &baduse, "unauthorized")
 	endBlock(t, l, eval)
 
@@ -571,7 +575,7 @@ skipclose:
 		ApplicationID: appIndex,
 		Accounts:      []basics.Address{addrs[0], addrs[2], addrs[3]}, // close to 3
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &close)
 	endBlock(t, l, eval)
 
@@ -583,13 +587,13 @@ skipclose:
 		Receiver: addrs[0],
 		Amount:   10_000_000,
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &payback)
 	endBlock(t, l, eval)
 
 	require.Equal(t, uint64(10_000_000), micros(t, l, addrs[0]))
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, useacct.Noted("2"), "unauthorized")
 	endBlock(t, l, eval)
 }
@@ -655,7 +659,7 @@ func TestRekeyActionCloseAccount(t *testing.T) {
 		Amount:   1_000_000,
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &create, &rekey, &fund)
 	endBlock(t, l, eval)
 
@@ -665,7 +669,7 @@ func TestRekeyActionCloseAccount(t *testing.T) {
 		ApplicationID: appIndex,
 		Accounts:      []basics.Address{addrs[0], addrs[2]},
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &useacct, "unauthorized")
 	endBlock(t, l, eval)
 }
@@ -716,7 +720,7 @@ func TestDuplicatePayAction(t *testing.T) {
 		Accounts:      []basics.Address{addrs[1]}, // pay self
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &create, &fund, &paytwice, create.Noted("in same block"))
 	vb := endBlock(t, l, eval)
 
@@ -737,7 +741,7 @@ func TestDuplicatePayAction(t *testing.T) {
 	require.Equal(t, 188000, int(app))
 
 	// Now create another app, and see if it gets the index we expect.
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, create.Noted("again"))
 	vb = endBlock(t, l, eval)
 
@@ -782,12 +786,12 @@ func TestInnerTxnCount(t *testing.T) {
 		Accounts:      []basics.Address{addrs[1]}, // pay self
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &create, &fund)
 	vb := endBlock(t, l, eval)
 	require.Equal(t, 2, int(vb.Block().TxnCounter))
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, &payout1)
 	vb = endBlock(t, l, eval)
 	require.Equal(t, 4, int(vb.Block().TxnCounter))
@@ -907,7 +911,7 @@ submit:  itxn_submit
 		Amount:   200_000, // exactly account min balance + one asset
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &app, &fund)
 	endBlock(t, l, eval)
 
@@ -918,7 +922,7 @@ submit:  itxn_submit
 		ApplicationArgs: [][]byte{[]byte("create")},
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	// Can't create an asset if you have exactly 200,000 and need to pay fee
 	txn(t, l, eval, &createAsa, "balance 199000 below min 200000")
 	// fund it some more and try again
@@ -947,7 +951,7 @@ submit:  itxn_submit
 			ApplicationArgs: [][]byte{[]byte(a), []byte("junkjunkjunkjunkjunkjunkjunkjunk")},
 			ForeignAssets:   []basics.AssetIndex{asaIndex},
 		}
-		eval = nextBlock(t, l, true, nil)
+		eval = nextBlock(t, l)
 		t.Log(a)
 		txn(t, l, eval, &check)
 		endBlock(t, l, eval)
@@ -960,7 +964,7 @@ submit:  itxn_submit
 		ApplicationArgs: [][]byte{[]byte("freeze"), []byte("junkjunkjunkjunkjunkjunkjunkjunk")},
 		ForeignAssets:   []basics.AssetIndex{asaIndex},
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &nodice, "this transaction should be issued by the manager")
 	endBlock(t, l, eval)
 
@@ -1013,7 +1017,7 @@ func TestAsaDuringInit(t *testing.T) {
 `,
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &prefund, &app)
 	vb := endBlock(t, l, eval)
 
@@ -1050,7 +1054,7 @@ func TestRekey(t *testing.T) {
 `),
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &app)
 	vb := endBlock(t, l, eval)
 	appIndex := vb.Block().Payset[0].ApplicationID
@@ -1067,7 +1071,7 @@ func TestRekey(t *testing.T) {
 		Sender:        addrs[1],
 		ApplicationID: appIndex,
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, &fund, &rekey)
 	txn(t, l, eval, rekey.Noted("2"), "unauthorized")
 	endBlock(t, l, eval)
@@ -1098,7 +1102,7 @@ func TestNote(t *testing.T) {
 `),
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &app)
 	vb := endBlock(t, l, eval)
 	appIndex := vb.Block().Payset[0].ApplicationID
@@ -1115,7 +1119,7 @@ func TestNote(t *testing.T) {
 		Sender:        addrs[1],
 		ApplicationID: appIndex,
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, &fund, &note)
 	vb = endBlock(t, l, eval)
 	alphabet := vb.Block().Payset[1].EvalDelta.InnerTxns[0].Txn.Note
@@ -1158,7 +1162,7 @@ nonpart:
 	}
 
 	// Create the app
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &app)
 	vb := endBlock(t, l, eval)
 	appIndex := vb.Block().Payset[0].ApplicationID
@@ -1171,7 +1175,7 @@ nonpart:
 		Receiver: appIndex.Address(),
 		Amount:   1_000_000_000,
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &fund)
 	endBlock(t, l, eval)
 
@@ -1179,7 +1183,7 @@ nonpart:
 
 	// Build up Residue in RewardsState so it's ready to pay
 	for i := 1; i < 10; i++ {
-		eval := nextBlock(t, l, true, nil)
+		eval := nextBlock(t, l)
 		endBlock(t, l, eval)
 	}
 
@@ -1190,7 +1194,7 @@ nonpart:
 		ApplicationID:   appIndex,
 		ApplicationArgs: [][]byte{[]byte("pay")},
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &pay)
 	endBlock(t, l, eval)
 	// 2000 was earned in rewards (- 1000 fee, -1 pay)
@@ -1203,7 +1207,7 @@ nonpart:
 		ApplicationID:   appIndex,
 		ApplicationArgs: [][]byte{[]byte("nonpart")},
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &nonpart)
 	endBlock(t, l, eval)
 	require.Equal(t, 999_999_999, int(micros(t, l, appIndex.Address())))
@@ -1211,10 +1215,10 @@ nonpart:
 	// Build up Residue in RewardsState so it's ready to pay AGAIN
 	// But expect no rewards
 	for i := 1; i < 100; i++ {
-		eval := nextBlock(t, l, true, nil)
+		eval := nextBlock(t, l)
 		endBlock(t, l, eval)
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, pay.Noted("again"))
 	txn(t, l, eval, nonpart.Noted("again"), "cannot change online/offline")
 	endBlock(t, l, eval)
@@ -1243,7 +1247,7 @@ func TestInnerAppCall(t *testing.T) {
   itxn_submit
 `),
 	}
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txn(t, l, eval, &app0)
 	vb := endBlock(t, l, eval)
 	index0 := vb.Block().Payset[0].ApplicationID
@@ -1261,7 +1265,7 @@ func TestInnerAppCall(t *testing.T) {
 `),
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, &app1)
 	vb = endBlock(t, l, eval)
 	index1 := vb.Block().Payset[0].ApplicationID
@@ -1281,7 +1285,7 @@ func TestInnerAppCall(t *testing.T) {
 		ApplicationID: index1,
 		ForeignApps:   []basics.AppIndex{index0},
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, &fund0, &fund1, &call1)
 	endBlock(t, l, eval)
 
@@ -1332,7 +1336,7 @@ next2:
 		Receiver: calleeIndex.Address(),
 		Amount:   1_000_000,
 	}
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &callee, &fund)
 	vb := endBlock(t, l, eval)
 	require.Equal(t, calleeIndex, vb.Block().Payset[0].ApplicationID)
@@ -1363,7 +1367,7 @@ next2:
 	}
 	fund.Receiver = callerIndex.Address()
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, &caller, &fund)
 	vb = endBlock(t, l, eval)
 	require.Equal(t, callerIndex, vb.Block().Payset[0].ApplicationID)
@@ -1374,7 +1378,7 @@ next2:
 		ApplicationID: callerIndex,
 		ForeignApps:   []basics.AppIndex{calleeIndex},
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, &call)
 	vb = endBlock(t, l, eval)
 	tib := vb.Block().Payset[0]
@@ -1445,7 +1449,7 @@ func TestCreateAndUse(t *testing.T) {
 		//ForeignAssets: []basics.AssetIndex{asaIndex},
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txn(t, l, eval, &createapp)
 	txn(t, l, eval, &fund)
 	err := txgroup(t, l, eval, &createasa, &use)
@@ -1482,7 +1486,7 @@ func TestGtxnEffects(t *testing.T) {
 		Amount:   1_000_000,
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &createapp, &fund)
 
 	createasa := txntest.Txn{
@@ -1531,7 +1535,7 @@ func TestBasicReentry(t *testing.T) {
   itxn_submit
 `),
 	}
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txn(t, l, eval, &app0)
 	vb := endBlock(t, l, eval)
 	index0 := vb.Block().Payset[0].ApplicationID
@@ -1542,7 +1546,7 @@ func TestBasicReentry(t *testing.T) {
 		ApplicationID: index0,
 		ForeignApps:   []basics.AppIndex{index0},
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &call1, "self-call")
 	endBlock(t, l, eval)
 }
@@ -1568,7 +1572,7 @@ func TestIndirectReentry(t *testing.T) {
   itxn_submit
 `),
 	}
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txn(t, l, eval, &app0)
 	vb := endBlock(t, l, eval)
 	index0 := vb.Block().Payset[0].ApplicationID
@@ -1592,7 +1596,7 @@ func TestIndirectReentry(t *testing.T) {
   itxn_submit
 `),
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, &app1, &fund)
 	vb = endBlock(t, l, eval)
 	index1 := vb.Block().Payset[0].ApplicationID
@@ -1603,7 +1607,7 @@ func TestIndirectReentry(t *testing.T) {
 		ApplicationID: index0,
 		ForeignApps:   []basics.AppIndex{index1, index0},
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &call1, "attempt to re-enter")
 	endBlock(t, l, eval)
 }
@@ -1639,7 +1643,7 @@ func TestValidAppReentry(t *testing.T) {
   itxn_submit
 `),
 	}
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txn(t, l, eval, &app0)
 	vb := endBlock(t, l, eval)
 	index0 := vb.Block().Payset[0].ApplicationID
@@ -1661,7 +1665,7 @@ func TestValidAppReentry(t *testing.T) {
   assert
 `),
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, &app1, &fund0)
 	vb = endBlock(t, l, eval)
 	index1 := vb.Block().Payset[0].ApplicationID
@@ -1678,7 +1682,7 @@ func TestValidAppReentry(t *testing.T) {
   itxn_submit
 `),
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &app2)
 	vb = endBlock(t, l, eval)
 	index2 := vb.Block().Payset[0].ApplicationID
@@ -1690,7 +1694,7 @@ func TestValidAppReentry(t *testing.T) {
 		Amount:   1_000_000,
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &fund2)
 	_ = endBlock(t, l, eval)
 
@@ -1700,243 +1704,8 @@ func TestValidAppReentry(t *testing.T) {
 		ApplicationID: index0,
 		ForeignApps:   []basics.AppIndex{index2, index1, index0},
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &call1)
-	endBlock(t, l, eval)
-}
-
-func TestMaxInnerTxFanOut(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
-	defer l.Close()
-
-	app0 := txntest.Txn{
-		Type:   "appl",
-		Sender: addrs[0],
-		ApprovalProgram: main(`
-  itxn_begin
-   int appl
-   itxn_field TypeEnum
-   txn Applications 1
-   itxn_field ApplicationID
-  itxn_submit
-
-  itxn_begin
-   int appl
-   itxn_field TypeEnum
-   txn Applications 1
-   itxn_field ApplicationID
-  itxn_submit
-
-  itxn_begin
-   int appl
-   itxn_field TypeEnum
-   txn Applications 1
-   itxn_field ApplicationID
-  itxn_submit
-
-  itxn_begin
-   int appl
-   itxn_field TypeEnum
-   txn Applications 1
-   itxn_field ApplicationID
-  itxn_submit
-
-  itxn_begin
-   int appl
-   itxn_field TypeEnum
-   txn Applications 1
-   itxn_field ApplicationID
-  itxn_submit
-
-  itxn_begin
-   int appl
-   itxn_field TypeEnum
-   txn Applications 1
-   itxn_field ApplicationID
-  itxn_submit
-
-  itxn_begin
-   int appl
-   itxn_field TypeEnum
-   txn Applications 1
-   itxn_field ApplicationID
-  itxn_submit
-
-  itxn_begin
-   int appl
-   itxn_field TypeEnum
-   txn Applications 1
-   itxn_field ApplicationID
-  itxn_submit
-
-  itxn_begin
-   int appl
-   itxn_field TypeEnum
-   txn Applications 1
-   itxn_field ApplicationID
-  itxn_submit
-
-  itxn_begin
-   int appl
-   itxn_field TypeEnum
-   txn Applications 1
-   itxn_field ApplicationID
-  itxn_submit
-
-  itxn_begin
-   int appl
-   itxn_field TypeEnum
-   txn Applications 1
-   itxn_field ApplicationID
-  itxn_submit
-
-  itxn_begin
-   int appl
-   itxn_field TypeEnum
-   txn Applications 1
-   itxn_field ApplicationID
-  itxn_submit
-
-  itxn_begin
-   int appl
-   itxn_field TypeEnum
-   txn Applications 1
-   itxn_field ApplicationID
-  itxn_submit
-
-  itxn_begin
-   int appl
-   itxn_field TypeEnum
-   txn Applications 1
-   itxn_field ApplicationID
-  itxn_submit
-
-  itxn_begin
-   int appl
-   itxn_field TypeEnum
-   txn Applications 1
-   itxn_field ApplicationID
-  itxn_submit
-
-  itxn_begin
-   int appl
-   itxn_field TypeEnum
-   txn Applications 1
-   itxn_field ApplicationID
-  itxn_submit
-`),
-	}
-	eval := nextBlock(t, l, true, nil)
-	txn(t, l, eval, &app0)
-	vb := endBlock(t, l, eval)
-	index0 := vb.Block().Payset[0].ApplicationID
-
-	fund0 := txntest.Txn{
-		Type:     "pay",
-		Sender:   addrs[0],
-		Receiver: index0.Address(),
-		Amount:   1_000_000,
-	}
-
-	app1 := txntest.Txn{
-		Type:   "appl",
-		Sender: addrs[0],
-		ApprovalProgram: main(`
-  int 3
-  int 3
-  ==
-  assert
-`),
-	}
-	eval = nextBlock(t, l, true, nil)
-	txns(t, l, eval, &app1, &fund0)
-	vb = endBlock(t, l, eval)
-	index1 := vb.Block().Payset[0].ApplicationID
-
-	callTxGroup := make([]txntest.Txn, 16)
-	for i := 0; i < 16; i++ {
-		callTxGroup[i] = txntest.Txn{
-			Type:          "appl",
-			Sender:        addrs[0],
-			ApplicationID: index0,
-			ForeignApps:   []basics.AppIndex{index1},
-		}
-	}
-	eval = nextBlock(t, l, true, nil)
-	err := txgroup(t, l, eval, &callTxGroup[0], &callTxGroup[1], &callTxGroup[2], &callTxGroup[3], &callTxGroup[4], &callTxGroup[5], &callTxGroup[6], &callTxGroup[7], &callTxGroup[8], &callTxGroup[9], &callTxGroup[10], &callTxGroup[11], &callTxGroup[12], &callTxGroup[13], &callTxGroup[14], &callTxGroup[15])
-	require.NoError(t, err)
-
-	endBlock(t, l, eval)
-}
-
-func TestExceedMaxInnerTxFanOut(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
-	defer l.Close()
-
-	var program string
-	for i := 0; i < 17; i++ {
-		program += `
-  itxn_begin
-    int appl
-    itxn_field TypeEnum
-	txn Applications 1
-	itxn_field ApplicationID
-  itxn_submit
-`
-	}
-
-	// 17 inner txns
-	app0 := txntest.Txn{
-		Type:            "appl",
-		Sender:          addrs[0],
-		ApprovalProgram: main(program),
-	}
-	eval := nextBlock(t, l, true, nil)
-	txn(t, l, eval, &app0)
-	vb := endBlock(t, l, eval)
-	index0 := vb.Block().Payset[0].ApplicationID
-
-	fund0 := txntest.Txn{
-		Type:     "pay",
-		Sender:   addrs[0],
-		Receiver: index0.Address(),
-		Amount:   1_000_000,
-	}
-
-	app1 := txntest.Txn{
-		Type:   "appl",
-		Sender: addrs[0],
-		ApprovalProgram: main(`
-  int 3
-  int 3
-  ==
-  assert
-`),
-	}
-	eval = nextBlock(t, l, true, nil)
-	txns(t, l, eval, &app1, &fund0)
-	vb = endBlock(t, l, eval)
-	index1 := vb.Block().Payset[0].ApplicationID
-
-	callTxGroup := make([]txntest.Txn, 16)
-	for i := 0; i < 16; i++ {
-		callTxGroup[i] = txntest.Txn{
-			Type:          "appl",
-			Sender:        addrs[0],
-			ApplicationID: index0,
-			ForeignApps:   []basics.AppIndex{index1},
-		}
-	}
-	eval = nextBlock(t, l, true, nil)
-	err := txgroup(t, l, eval, &callTxGroup[0], &callTxGroup[1], &callTxGroup[2], &callTxGroup[3], &callTxGroup[4], &callTxGroup[5], &callTxGroup[6], &callTxGroup[7], &callTxGroup[8], &callTxGroup[9], &callTxGroup[10], &callTxGroup[11], &callTxGroup[12], &callTxGroup[13], &callTxGroup[14], &callTxGroup[15])
-	require.Error(t, err)
-
 	endBlock(t, l, eval)
 }
 
@@ -1944,10 +1713,15 @@ func TestMaxInnerTxForSingleAppCall(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
-	defer l.Close()
+	// v31 = inner appl
+	testConsensusRange(t, 31, 0, func(t *testing.T, ver int) {
+		dl := NewDoubleLedger(t, genBalances, consensusByNumber[ver])
+		defer dl.Close()
 
-	program := `
+		program := `
+txn ApplicationArgs 0
+btoi
+store 0
 int 1
 loop:
 itxn_begin
@@ -1959,149 +1733,74 @@ itxn_submit
 int 1
 +
 dup
-int 256
+load 0
 <=
 bnz loop
-int 257
-==
-assert
-`
-
-	// 256 inner txns
-	app0 := txntest.Txn{
-		Type:            "appl",
-		Sender:          addrs[0],
-		ApprovalProgram: main(program),
-	}
-	eval := nextBlock(t, l, true, nil)
-	txn(t, l, eval, &app0)
-	vb := endBlock(t, l, eval)
-	index0 := vb.Block().Payset[0].ApplicationID
-
-	fund0 := txntest.Txn{
-		Type:     "pay",
-		Sender:   addrs[0],
-		Receiver: index0.Address(),
-		Amount:   1_000_000,
-	}
-
-	app1 := txntest.Txn{
-		Type:   "appl",
-		Sender: addrs[0],
-		ApprovalProgram: main(`
-  int 3
-  int 3
-  ==
-  assert
-`),
-	}
-	eval = nextBlock(t, l, true, nil)
-	txns(t, l, eval, &app1, &fund0)
-	vb = endBlock(t, l, eval)
-	index1 := vb.Block().Payset[0].ApplicationID
-
-	callTxGroup := make([]txntest.Txn, 16)
-	callTxGroup[0] = txntest.Txn{
-		Type:          "appl",
-		Sender:        addrs[0],
-		ApplicationID: index0,
-		ForeignApps:   []basics.AppIndex{index1},
-	}
-	for i := 1; i < 16; i++ {
-		callTxGroup[i] = txntest.Txn{
-			Type:          "appl",
-			Sender:        addrs[0],
-			ApplicationID: index1,
-			ForeignApps:   []basics.AppIndex{},
-		}
-	}
-	eval = nextBlock(t, l, true, nil)
-	err := txgroup(t, l, eval, &callTxGroup[0], &callTxGroup[1], &callTxGroup[2], &callTxGroup[3], &callTxGroup[4], &callTxGroup[5], &callTxGroup[6], &callTxGroup[7], &callTxGroup[8], &callTxGroup[9], &callTxGroup[10], &callTxGroup[11], &callTxGroup[12], &callTxGroup[13], &callTxGroup[14], &callTxGroup[15])
-	require.NoError(t, err)
-
-	endBlock(t, l, eval)
-}
-
-func TestExceedMaxInnerTxForSingleAppCall(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
-	defer l.Close()
-
-	program := `
-int 1
-loop:
-itxn_begin
-  int appl
-  itxn_field TypeEnum
-  txn Applications 1
-  itxn_field ApplicationID
-itxn_submit
+load 0
 int 1
 +
-dup
-int 257
-<=
-bnz loop
-int 258
 ==
 assert
 `
 
-	// 257 inner txns
-	app0 := txntest.Txn{
-		Type:            "appl",
-		Sender:          addrs[0],
-		ApprovalProgram: main(program),
-	}
-	eval := nextBlock(t, l, true, nil)
-	txn(t, l, eval, &app0)
-	vb := endBlock(t, l, eval)
-	index0 := vb.Block().Payset[0].ApplicationID
+		app0 := txntest.Txn{
+			Type:            "appl",
+			Sender:          addrs[0],
+			ApprovalProgram: main(program),
+		}
+		vb := dl.fullBlock(&app0)
+		index0 := vb.Block().Payset[0].ApplicationID
 
-	fund0 := txntest.Txn{
-		Type:     "pay",
-		Sender:   addrs[0],
-		Receiver: index0.Address(),
-		Amount:   1_000_000,
-	}
+		fund0 := txntest.Txn{
+			Type:     "pay",
+			Sender:   addrs[0],
+			Receiver: index0.Address(),
+			Amount:   1_000_000,
+		}
 
-	app1 := txntest.Txn{
-		Type:   "appl",
-		Sender: addrs[0],
-		ApprovalProgram: main(`
+		app1 := txntest.Txn{
+			Type:   "appl",
+			Sender: addrs[0],
+			ApprovalProgram: main(`
   int 3
   int 3
   ==
   assert
 `),
-	}
-	eval = nextBlock(t, l, true, nil)
-	txns(t, l, eval, &app1, &fund0)
-	vb = endBlock(t, l, eval)
-	index1 := vb.Block().Payset[0].ApplicationID
-
-	callTxGroup := make([]txntest.Txn, 16)
-	callTxGroup[0] = txntest.Txn{
-		Type:          "appl",
-		Sender:        addrs[0],
-		ApplicationID: index0,
-		ForeignApps:   []basics.AppIndex{index1},
-	}
-	for i := 1; i < 16; i++ {
-		callTxGroup[i] = txntest.Txn{
-			Type:          "appl",
-			Sender:        addrs[0],
-			ApplicationID: index1,
-			ForeignApps:   []basics.AppIndex{},
 		}
-	}
-	eval = nextBlock(t, l, true, nil)
-	err := txgroup(t, l, eval, &callTxGroup[0], &callTxGroup[1], &callTxGroup[2], &callTxGroup[3], &callTxGroup[4], &callTxGroup[5], &callTxGroup[6], &callTxGroup[7], &callTxGroup[8], &callTxGroup[9], &callTxGroup[10], &callTxGroup[11], &callTxGroup[12], &callTxGroup[13], &callTxGroup[14], &callTxGroup[15])
-	require.Error(t, err)
 
-	endBlock(t, l, eval)
+		vb = dl.fullBlock(&app1, &fund0)
+		index1 := vb.Block().Payset[0].ApplicationID
+
+		callTxGroup := make([]*txntest.Txn, 16)
+		callTxGroup[0] = &txntest.Txn{
+			Type:            "appl",
+			Sender:          addrs[0],
+			ApplicationID:   index0,
+			ForeignApps:     []basics.AppIndex{index1},
+			ApplicationArgs: [][]byte{{1, 0}}, // 256 inner calls
+		}
+		for i := 1; i < 16; i++ {
+			callTxGroup[i] = &txntest.Txn{
+				Type:          "appl",
+				Sender:        addrs[0],
+				ApplicationID: index1,
+				Note:          []byte{byte(i)},
+			}
+		}
+		dl.txgroup("", callTxGroup...)
+
+		// Can't do it twice in a single group
+		dl.txgroup("too many inner", callTxGroup[0], callTxGroup[0].Noted("another"))
+
+		// Don't need all those extra top-levels to be allowed to do 256 in tx0
+		callTxGroup[0].Group = crypto.Digest{}
+		dl.fullBlock(callTxGroup[0])
+
+		// Can't do 257 txns
+		callTxGroup[0].ApplicationArgs[0][1] = 1
+		dl.txn(callTxGroup[0], "too many inner")
+	})
 }
 
 func TestAbortWhenInnerAppCallFails(t *testing.T) {
@@ -2127,7 +1826,7 @@ int 1
 assert
 `),
 	}
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txn(t, l, eval, &app0)
 	vb := endBlock(t, l, eval)
 	index0 := vb.Block().Payset[0].ApplicationID
@@ -2149,7 +1848,7 @@ assert
   assert
 `),
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, &app1, &fund0)
 	vb = endBlock(t, l, eval)
 	index1 := vb.Block().Payset[0].ApplicationID
@@ -2161,7 +1860,7 @@ assert
 		ForeignApps:   []basics.AppIndex{index1},
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &callTx, "logic eval error")
 	endBlock(t, l, eval)
 }
@@ -2171,53 +1870,58 @@ func TestInnerAppVersionCalling(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
-	defer l.Close()
 
-	five, err := logic.AssembleStringWithVersion("int 1", 5)
-	require.NoError(t, err)
-	six, err := logic.AssembleStringWithVersion("int 1", 6)
-	require.NoError(t, err)
+	// 31 allowed inner appls. vFuture enables proto.AllowV4InnerAppls (presumed v33, below)
+	testConsensusRange(t, 31, 0, func(t *testing.T, ver int) {
+		dl := NewDoubleLedger(t, genBalances, consensusByNumber[ver])
+		defer dl.Close()
 
-	create5 := txntest.Txn{
-		Type:              "appl",
-		Sender:            addrs[0],
-		ApprovalProgram:   five.Program,
-		ClearStateProgram: five.Program,
-	}
+		five, err := logic.AssembleStringWithVersion("int 1", 5)
+		require.NoError(t, err)
+		six, err := logic.AssembleStringWithVersion("int 1", 6)
+		require.NoError(t, err)
 
-	create6 := txntest.Txn{
-		Type:              "appl",
-		Sender:            addrs[0],
-		ApprovalProgram:   six.Program,
-		ClearStateProgram: six.Program,
-	}
+		create5 := txntest.Txn{
+			Type:              "appl",
+			Sender:            addrs[0],
+			ApprovalProgram:   five.Program,
+			ClearStateProgram: five.Program,
+		}
 
-	eval := nextBlock(t, l, true, nil)
-	txns(t, l, eval, &create5, &create6)
-	vb := endBlock(t, l, eval)
-	v5id := vb.Block().Payset[0].ApplicationID
-	v6id := vb.Block().Payset[1].ApplicationID
+		create6 := txntest.Txn{
+			Type:              "appl",
+			Sender:            addrs[0],
+			ApprovalProgram:   six.Program,
+			ClearStateProgram: six.Program,
+		}
 
-	call := txntest.Txn{
-		Type:   "appl",
-		Sender: addrs[0],
-		// don't use main. do the test at creation time
-		ApprovalProgram: `
+		vb := dl.fullBlock(&create5, &create6)
+		v5id := vb.Block().Payset[0].ApplicationID
+		v6id := vb.Block().Payset[1].ApplicationID
+
+		call := txntest.Txn{
+			Type:   "appl",
+			Sender: addrs[0],
+			// don't use main. do the test at creation time
+			ApprovalProgram: `
 itxn_begin
 	int appl
 	itxn_field TypeEnum
 	txn Applications 1
 	itxn_field ApplicationID
 itxn_submit`,
-		ForeignApps: []basics.AppIndex{v5id},
-	}
+			ForeignApps: []basics.AppIndex{v5id},
+		}
 
-	eval = nextBlock(t, l, true, nil)
-	txn(t, l, eval, &call, "inner app call with version 5")
-	call.ForeignApps[0] = v6id
-	txn(t, l, eval, &call, "overspend") // it tried to execute, but test doesn't bother funding
-	endBlock(t, l, eval)
+		if ver <= 32 {
+			dl.txn(&call, "inner app call with version 5")
+			call.ForeignApps[0] = v6id
+			dl.txn(&call, "overspend") // it tried to execute, but test doesn't bother funding
+		} else {
+			// after 32 proto.AllowV4InnerAppls should be in effect
+			dl.txn(&call, "overspend") // it tried to execute, but test doesn't bother funding
+		}
+	})
 
 }
 
@@ -2242,42 +1946,38 @@ func TestAppVersionMatching(t *testing.T) {
 		ClearStateProgram: five.Program,
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txn(t, l, eval, &create)
 	endBlock(t, l, eval)
 
 	create.ClearStateProgram = six.Program
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &create, "version mismatch")
 	endBlock(t, l, eval)
 
 	create.ApprovalProgram = six.Program
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &create)
 	endBlock(t, l, eval)
 
 	create.ClearStateProgram = four.Program
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &create, "version mismatch")
 	endBlock(t, l, eval)
 
 	// four doesn't match five, but it doesn't have to
 	create.ApprovalProgram = five.Program
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &create)
 	endBlock(t, l, eval)
 }
 
 func TestAppDowngrade(t *testing.T) {
 	partitiontest.PartitionTest(t)
-
-	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
-	defer l.Close()
 
 	four, err := logic.AssembleStringWithVersion("int 1", 4)
 	require.NoError(t, err)
@@ -2286,55 +1986,63 @@ func TestAppDowngrade(t *testing.T) {
 	six, err := logic.AssembleStringWithVersion("int 1", 6)
 	require.NoError(t, err)
 
-	create := txntest.Txn{
-		Type:              "appl",
-		Sender:            addrs[0],
-		ApprovalProgram:   four.Program,
-		ClearStateProgram: four.Program,
-	}
+	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
+	testConsensusRange(t, 31, 0, func(t *testing.T, ver int) {
 
-	eval := nextBlock(t, l, true, nil)
-	txn(t, l, eval, &create)
-	vb := endBlock(t, l, eval)
-	app := vb.Block().Payset[0].ApplicationID
+		dl := NewDoubleLedger(t, genBalances, consensusByNumber[ver])
+		defer dl.Close()
 
-	update := txntest.Txn{
-		Type:              "appl",
-		ApplicationID:     app,
-		OnCompletion:      transactions.UpdateApplicationOC,
-		Sender:            addrs[0],
-		ApprovalProgram:   four.Program,
-		ClearStateProgram: four.Program,
-	}
+		create := txntest.Txn{
+			Type:              "appl",
+			Sender:            addrs[0],
+			ApprovalProgram:   four.Program,
+			ClearStateProgram: four.Program,
+		}
 
-	// No change - legal
-	eval = nextBlock(t, l, true, nil)
-	txn(t, l, eval, &update)
+		vb := dl.fullBlock(&create)
+		app := vb.Block().Payset[0].ApplicationID
 
-	// Upgrade just the approval. Sure (because under 6, no need to match)
-	update.ApprovalProgram = five.Program
-	txn(t, l, eval, &update)
+		update := txntest.Txn{
+			Type:              "appl",
+			ApplicationID:     app,
+			OnCompletion:      transactions.UpdateApplicationOC,
+			Sender:            addrs[0],
+			ApprovalProgram:   four.Program,
+			ClearStateProgram: four.Program,
+		}
 
-	// Upgrade just the clear state. Now they match
-	update.ClearStateProgram = five.Program
-	txn(t, l, eval, &update)
+		// No change - legal
+		dl.fullBlock(&update)
 
-	// Downgrade (allowed pre 6)
-	update.ClearStateProgram = four.Program
-	txn(t, l, eval, update.Noted("actually a repeat of first upgrade"))
+		// Upgrade just the approval. Sure (because under 6, no need to match)
+		update.ApprovalProgram = five.Program
+		dl.fullBlock(&update)
 
-	// Try to upgrade (at 6, must match)
-	update.ApprovalProgram = six.Program
-	txn(t, l, eval, &update, "version mismatch")
+		// Upgrade just the clear state. Now they match
+		update.ClearStateProgram = five.Program
+		dl.fullBlock(&update)
 
-	// Do both
-	update.ClearStateProgram = six.Program
-	txn(t, l, eval, &update)
+		// Downgrade (allowed for pre 6 programs until AllowV4InnerAppls)
+		update.ClearStateProgram = four.Program
+		if ver <= 32 {
+			dl.fullBlock(update.Noted("actually a repeat of first upgrade"))
+		} else {
+			dl.txn(update.Noted("actually a repeat of first upgrade"), "clearstate program version downgrade")
+		}
 
-	// Try to downgrade. Fails because it was 6.
-	update.ApprovalProgram = five.Program
-	update.ClearStateProgram = five.Program
-	txn(t, l, eval, update.Noted("repeat of 3rd update"), "downgrade")
+		// Try to upgrade (at 6, must match)
+		update.ApprovalProgram = six.Program
+		dl.txn(&update, "version mismatch")
+
+		// Do both
+		update.ClearStateProgram = six.Program
+		dl.fullBlock(&update)
+
+		// Try to downgrade. Fails because it was 6.
+		update.ApprovalProgram = five.Program
+		update.ClearStateProgram = five.Program
+		dl.txn(update.Noted("repeat of 3rd update"), "downgrade")
+	})
 }
 
 func TestCreatedAppsAreAvailable(t *testing.T) {
@@ -2362,7 +2070,7 @@ func TestCreatedAppsAreAvailable(t *testing.T) {
 		itxn_submit`),
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txn(t, l, eval, &createapp)
 	vb := endBlock(t, l, eval)
 	index0 := vb.Block().Payset[0].ApplicationID
@@ -2374,7 +2082,7 @@ func TestCreatedAppsAreAvailable(t *testing.T) {
 		Amount:   1_000_000,
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &fund0)
 	endBlock(t, l, eval)
 
@@ -2385,7 +2093,7 @@ func TestCreatedAppsAreAvailable(t *testing.T) {
 		ForeignApps:   []basics.AppIndex{},
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &callTx)
 	endBlock(t, l, eval)
 	index1 := basics.AppIndex(1)
@@ -2397,7 +2105,7 @@ func TestCreatedAppsAreAvailable(t *testing.T) {
 		ForeignApps:   []basics.AppIndex{},
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &callTx)
 	endBlock(t, l, eval)
 }
@@ -2420,7 +2128,7 @@ itxn_begin
 	itxn_field ApplicationID
 itxn_submit`),
 	}
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txn(t, l, eval, &app0)
 	vb := endBlock(t, l, eval)
 	index0 := vb.Block().Payset[0].ApplicationID
@@ -2442,7 +2150,7 @@ int 2
 assert
 `),
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, &app1, &fund0)
 	endBlock(t, l, eval)
 
@@ -2453,7 +2161,7 @@ assert
 		ForeignApps:   []basics.AppIndex{},
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &callTx, "invalid App reference 2")
 	endBlock(t, l, eval)
 }
@@ -2499,7 +2207,7 @@ func TestInvalidAssetsNotAccessible(t *testing.T) {
 		},
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &createapp, &fund, &createasa)
 	endBlock(t, l, eval)
 
@@ -2509,7 +2217,7 @@ func TestInvalidAssetsNotAccessible(t *testing.T) {
 		ApplicationID: basics.AppIndex(1),
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &use, "invalid Asset reference 3")
 	endBlock(t, l, eval)
 }
@@ -2594,7 +2302,7 @@ func executeMegaContract(b *testing.B) {
 		}
 	}
 
-	eval := nextBlock(b, l, true, nil)
+	eval := nextBlock(b, l)
 	txns(b, l, eval, funds...)
 	endBlock(b, l, eval)
 
@@ -2604,7 +2312,7 @@ func executeMegaContract(b *testing.B) {
 		ApprovalProgram: `int 1`,
 	}
 
-	eval = nextBlock(b, l, true, nil)
+	eval = nextBlock(b, l)
 	err := txgroup(b, l, eval, &createapp, &app1, &app1, &app1, &app1, &app1, &app1)
 	require.NoError(b, err)
 	endBlock(b, l, eval)
@@ -2637,7 +2345,7 @@ func TestInnerClearState(t *testing.T) {
 		},
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txn(t, l, eval, &inner)
 	vb := endBlock(t, l, eval)
 	innerId := vb.Block().Payset[0].ApplicationID
@@ -2662,7 +2370,7 @@ itxn_submit
 		ForeignApps: []basics.AppIndex{innerId},
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &outer)
 	vb = endBlock(t, l, eval)
 	outerId := vb.Block().Payset[0].ApplicationID
@@ -2681,7 +2389,7 @@ itxn_submit
 		ApplicationArgs: [][]byte{{byte(transactions.OptInOC)}},
 		ForeignApps:     []basics.AppIndex{innerId},
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, &fund, &call)
 	endBlock(t, l, eval)
 
@@ -2693,7 +2401,7 @@ itxn_submit
 	})
 
 	call.ApplicationArgs = [][]byte{{byte(transactions.ClearStateOC)}}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &call)
 	endBlock(t, l, eval)
 
@@ -2725,7 +2433,7 @@ b top
 `,
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txn(t, l, eval, &badCallee)
 	vb := endBlock(t, l, eval)
 	badId := vb.Block().Payset[0].ApplicationID
@@ -2767,7 +2475,7 @@ skip:
 		ForeignApps: []basics.AppIndex{badId},
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &outer)
 	vb = endBlock(t, l, eval)
 	outerId := vb.Block().Payset[0].ApplicationID
@@ -2786,7 +2494,7 @@ skip:
 		ApplicationArgs: [][]byte{{byte(transactions.OptInOC)}},
 		ForeignApps:     []basics.AppIndex{badId},
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, &fund, &call)
 	endBlock(t, l, eval)
 
@@ -2795,7 +2503,7 @@ skip:
 
 	// When doing a clear state, `call` checks that budget wasn't stolen
 	call.ApplicationArgs = [][]byte{{byte(transactions.ClearStateOC)}}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &call)
 	endBlock(t, l, eval)
 
@@ -2855,7 +2563,7 @@ log
 		},
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &inner, &waster)
 	vb := endBlock(t, l, eval)
 	innerId := vb.Block().Payset[0].ApplicationID
@@ -2888,7 +2596,7 @@ itxn_submit
 `),
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &grouper)
 	vb = endBlock(t, l, eval)
 	grouperId := vb.Block().Payset[0].ApplicationID
@@ -2907,7 +2615,7 @@ itxn_submit
 		ApplicationArgs: [][]byte{{byte(transactions.OptInOC)}, {byte(transactions.OptInOC)}},
 		ForeignApps:     []basics.AppIndex{wasterId, innerId},
 	}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, &fund, &call)
 	endBlock(t, l, eval)
 
@@ -2915,7 +2623,7 @@ itxn_submit
 	require.Len(t, gAcct.AppLocalStates, 2)
 
 	call.ApplicationArgs = [][]byte{{byte(transactions.CloseOutOC)}, {byte(transactions.ClearStateOC)}}
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txn(t, l, eval, &call, "ClearState execution with low OpcodeBudget")
 	vb = endBlock(t, l, eval)
 	require.Len(t, vb.Block().Payset, 0)
@@ -2970,7 +2678,7 @@ itxn_begin
 itxn_submit
 ` + test.approval,
 			}
-			eval := nextBlock(t, l, true, nil)
+			eval := nextBlock(t, l)
 			txn(t, l, eval, &app0)
 			vb := endBlock(t, l, eval)
 			index0 := vb.Block().Payset[0].ApplicationID
@@ -2989,7 +2697,7 @@ itxn_submit
 				OnCompletion:  transactions.OptInOC,
 			}
 
-			eval = nextBlock(t, l, true, nil)
+			eval = nextBlock(t, l)
 			txns(t, l, eval, &fund0, &optin)
 			vb = endBlock(t, l, eval)
 
@@ -3009,7 +2717,7 @@ itxn_submit
 				OnCompletion:  transactions.ClearStateOC,
 			}
 
-			eval = nextBlock(t, l, true, nil)
+			eval = nextBlock(t, l)
 			txns(t, l, eval, &clear)
 			vb = endBlock(t, l, eval)
 
@@ -3119,7 +2827,7 @@ check:
 `),
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &appA, &appB, &appC)
 	vb := endBlock(t, l, eval)
 	indexA := vb.Block().Payset[0].ApplicationID
@@ -3140,7 +2848,7 @@ check:
 		ForeignApps:   []basics.AppIndex{indexB, indexC},
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, &fundA, &callA)
 	endBlock(t, l, eval)
 }
@@ -3232,7 +2940,7 @@ check:
 `),
 	}
 
-	eval := nextBlock(t, l, true, nil)
+	eval := nextBlock(t, l)
 	txns(t, l, eval, &appA, &appB, &appC)
 	vb := endBlock(t, l, eval)
 	indexA := vb.Block().Payset[0].ApplicationID
@@ -3253,7 +2961,7 @@ check:
 		ForeignApps:   []basics.AppIndex{indexB, indexC},
 	}
 
-	eval = nextBlock(t, l, true, nil)
+	eval = nextBlock(t, l)
 	txns(t, l, eval, &fundA, &callA)
 	endBlock(t, l, eval)
 }

--- a/ledger/internal/double_test.go
+++ b/ledger/internal/double_test.go
@@ -1,0 +1,166 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/data/txntest"
+	"github.com/algorand/go-algorand/ledger"
+	"github.com/algorand/go-algorand/ledger/internal"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+// DoubleLedger allows for easy "Double Entry bookkeeping" as a way to write
+// fairly extensive ledger tests. In addition to simplifiying the addition of
+// txns and txgroups to a ledger (and then allowing for inspection of the
+// created blocks), it also does a double check on correctness by marshalling
+// the created blocks, evaluating the transactions in a ledger copy, and
+// asserting that it comes out the same.  During the insertion of those
+// transactions, the validator ledger is not in `generate` mode - so it
+// evaluates and validates, checking that the ApplyDatas that come from the
+// first ledger match the ADs created by the second. The validator ledger is
+// then temporarily placed in `generate` mode so that the entire block can be
+// generated in the copy second ledger, and compared.
+type DoubleLedger struct {
+	t *testing.T
+
+	generator *ledger.Ledger
+	validator *ledger.Ledger
+
+	eval *internal.BlockEvaluator
+}
+
+func (dl DoubleLedger) Close() {
+	dl.generator.Close()
+	dl.validator.Close()
+}
+
+// NewDoubleLedger creates a new DoubleLedger with the supplied balances and consensus version.
+func NewDoubleLedger(t *testing.T, balances bookkeeping.GenesisBalances, cv protocol.ConsensusVersion) DoubleLedger {
+	g := newTestLedgerWithConsensusVersion(t, balances, cv)
+	v := newTestLedgerFull(t, balances, cv, g.GenesisHash())
+	return DoubleLedger{t, g, v, nil}
+}
+
+func (dl *DoubleLedger) beginBlock() *internal.BlockEvaluator {
+	dl.eval = nextBlock(dl.t, dl.generator)
+	return dl.eval
+}
+
+func (dl *DoubleLedger) txn(tx *txntest.Txn, problem ...string) {
+	dl.t.Helper()
+	if dl.eval == nil {
+		dl.beginBlock()
+		defer dl.endBlock()
+	}
+	txn(dl.t, dl.generator, dl.eval, tx, problem...)
+}
+
+func (dl *DoubleLedger) txns(txns ...*txntest.Txn) {
+	dl.t.Helper()
+	if dl.eval == nil {
+		dl.beginBlock()
+		defer dl.endBlock()
+	}
+	for _, tx := range txns {
+		dl.txn(tx)
+	}
+}
+
+func (dl *DoubleLedger) txgroup(problem string, txns ...*txntest.Txn) {
+	dl.t.Helper()
+	if dl.eval == nil {
+		dl.beginBlock()
+		defer dl.endBlock()
+	}
+	err := txgroup(dl.t, dl.generator, dl.eval, txns...)
+	if problem == "" {
+		require.NoError(dl.t, err)
+	} else {
+		require.Error(dl.t, err)
+		require.Contains(dl.t, err.Error(), problem)
+	}
+}
+
+func (dl *DoubleLedger) fullBlock(txs ...*txntest.Txn) *ledgercore.ValidatedBlock {
+	dl.t.Helper()
+	dl.beginBlock()
+	dl.txns(txs...)
+	return dl.endBlock()
+}
+
+func (dl *DoubleLedger) endBlock() *ledgercore.ValidatedBlock {
+	vb := endBlock(dl.t, dl.generator, dl.eval)
+	checkBlock(dl.t, dl.validator, vb)
+	dl.eval = nil // Ensure it's not used again
+	return vb
+}
+
+func checkBlock(t *testing.T, checkLedger *ledger.Ledger, vb *ledgercore.ValidatedBlock) {
+	bl := vb.Block()
+	msg := bl.MarshalMsg(nil)
+	var reconstituted bookkeeping.Block
+	_, err := reconstituted.UnmarshalMsg(msg)
+	require.NoError(t, err)
+
+	check := nextCheckBlock(t, checkLedger, reconstituted.RewardsState)
+	var group []transactions.SignedTxnWithAD
+	for _, stib := range reconstituted.Payset {
+		stxn, ad, err := reconstituted.BlockHeader.DecodeSignedTxn(stib)
+		require.NoError(t, err)
+		stad := transactions.SignedTxnWithAD{SignedTxn: stxn, ApplyData: ad}
+		// If txn we're looking at belongs in the current group, append
+		if group == nil || (!stxn.Txn.Group.IsZero() && group[0].Txn.Group == stxn.Txn.Group) {
+			group = append(group, stad)
+		} else if group != nil {
+			err := check.TransactionGroup(group)
+			require.NoError(t, err)
+			group = []transactions.SignedTxnWithAD{stad}
+		}
+	}
+	if group != nil {
+		err := check.TransactionGroup(group)
+		require.NoError(t, err, "%+v", reconstituted.Payset)
+	}
+	check.SetGenerate(true)
+	cb := endBlock(t, checkLedger, check)
+	check.SetGenerate(false)
+	require.Equal(t, vb.Block(), cb.Block())
+	require.Equal(t, vb.Delta(), cb.Delta())
+}
+
+func nextCheckBlock(t testing.TB, ledger *ledger.Ledger, rs bookkeeping.RewardsState) *internal.BlockEvaluator {
+	rnd := ledger.Latest()
+	hdr, err := ledger.BlockHdr(rnd)
+	require.NoError(t, err)
+
+	nextHdr := bookkeeping.MakeBlock(hdr).BlockHeader
+	nextHdr.RewardsState = rs
+	// follow nextBlock, which does this for determinism
+	nextHdr.TimeStamp = hdr.TimeStamp + 1
+	eval, err := internal.StartEvaluator(ledger, nextHdr, internal.EvaluatorOptions{
+		Generate: false,
+		Validate: true, // Do the complete checks that a new txn would be subject to
+	})
+	require.NoError(t, err)
+	return eval
+}

--- a/ledger/internal/eval_blackbox_test.go
+++ b/ledger/internal/eval_blackbox_test.go
@@ -493,6 +493,7 @@ func txn(t testing.TB, ledger *ledger.Ledger, eval *internal.BlockEvaluator, txn
 }
 
 func stxn(t testing.TB, ledger *ledger.Ledger, eval *internal.BlockEvaluator, stxn transactions.SignedTxn, problem ...string) {
+	t.Helper()
 	err := eval.TestTransactionGroup([]transactions.SignedTxn{stxn})
 	if err != nil {
 		if len(problem) == 1 {

--- a/ledger/internal/export_test.go
+++ b/ledger/internal/export_test.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package internal
+
+// Export for testing only.  See
+// https://medium.com/@robiplus/golang-trick-export-for-test-aa16cbd7b8cd for a
+// nice explanation. tl;dr: Since some of our testing is in logic_test package,
+// we export some extra things to make testing easier there. But we do it in a
+// _test.go file, so they are only exported during testing.
+
+// In order to generate a block
+func (eval *BlockEvaluator) SetGenerate(g bool) {
+	eval.generate = g
+}

--- a/ledger/internal/txnbench_test.go
+++ b/ledger/internal/txnbench_test.go
@@ -17,12 +17,15 @@
 package internal_test
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/data/txntest"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 	ledgertesting "github.com/algorand/go-algorand/ledger/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -30,210 +33,216 @@ import (
 // BenchmarkTxnTypes compares the execution time of various txn types
 func BenchmarkTxnTypes(b *testing.B) {
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(b, genBalances)
-	defer l.Close()
+	benchConsensusRange(b, 30, 0, func(b *testing.B, ver int) {
+		l := newTestLedgerWithConsensusVersion(b, genBalances, consensusByNumber[ver])
+		defer l.Close()
 
-	createasa := txntest.Txn{
-		Type:   "acfg",
-		Sender: addrs[0],
-		AssetParams: basics.AssetParams{
-			Total:     1000000,
-			Decimals:  3,
-			UnitName:  "oz",
-			AssetName: "Gold",
-			URL:       "https://gold.rush/",
-
-			Manager:  addrs[0],
-			Clawback: addrs[0],
-			Freeze:   addrs[0],
-			Reserve:  addrs[0],
-		},
-	}
-
-	eval := nextBlock(b, l, true, nil)
-	txn(b, l, eval, &createasa)
-	vb := endBlock(b, l, eval)
-	asa := vb.Block().Payset[0].ApplyData.ConfigAsset
-	require.Positive(b, asa)
-
-	optin1 := txntest.Txn{
-		Type:          "axfer",
-		Sender:        addrs[1],
-		AssetReceiver: addrs[1],
-		XferAsset:     asa,
-	}
-	optin2 := txntest.Txn{
-		Type:          "axfer",
-		Sender:        addrs[2],
-		AssetReceiver: addrs[2],
-		XferAsset:     asa,
-	}
-
-	eval = nextBlock(b, l, true, nil)
-	txns(b, l, eval, &optin1, &optin2)
-	endBlock(b, l, eval)
-
-	createapp1 := txntest.Txn{
-		Type:            "appl",
-		Sender:          addrs[0],
-		ApprovalProgram: "int 1",
-	}
-
-	eval = nextBlock(b, l, true, nil)
-	txn(b, l, eval, &createapp1)
-	vb = endBlock(b, l, eval)
-	app1 := vb.Block().Payset[0].ApplyData.ApplicationID
-	require.Positive(b, app1)
-
-	createapp10 := txntest.Txn{
-		Type:            "appl",
-		Sender:          addrs[0],
-		ApprovalProgram: strings.Repeat("int 1\npop\n", 5) + "int 1",
-	}
-
-	eval = nextBlock(b, l, true, nil)
-	txn(b, l, eval, &createapp10)
-	vb = endBlock(b, l, eval)
-	app10 := vb.Block().Payset[0].ApplyData.ApplicationID
-	require.Positive(b, app10)
-
-	createapp100 := txntest.Txn{
-		Type:            "appl",
-		Sender:          addrs[0],
-		ApprovalProgram: strings.Repeat("int 1\npop\n", 50) + "int 1",
-	}
-
-	eval = nextBlock(b, l, true, nil)
-	txn(b, l, eval, &createapp100)
-	vb = endBlock(b, l, eval)
-	app100 := vb.Block().Payset[0].ApplyData.ApplicationID
-	require.Positive(b, app100)
-
-	createapp700 := txntest.Txn{
-		Type:            "appl",
-		Sender:          addrs[0],
-		ApprovalProgram: strings.Repeat("int 1\npop\n", 349) + "int 1",
-	}
-
-	eval = nextBlock(b, l, true, nil)
-	txn(b, l, eval, &createapp700)
-	vb = endBlock(b, l, eval)
-	app700 := vb.Block().Payset[0].ApplyData.ApplicationID
-	require.Positive(b, app700)
-
-	createapp700s := txntest.Txn{
-		Type:            "appl",
-		Sender:          addrs[0],
-		ApprovalProgram: strings.Repeat("int 1\n", 350) + strings.Repeat("pop\n", 349),
-	}
-
-	eval = nextBlock(b, l, true, nil)
-	txn(b, l, eval, &createapp700s)
-	vb = endBlock(b, l, eval)
-	app700s := vb.Block().Payset[0].ApplyData.ApplicationID
-	require.Positive(b, app700s)
-
-	benches := []struct {
-		name string
-		txn  txntest.Txn
-	}{
-		{"pay-self", txntest.Txn{
-			Type:     "pay",
-			Sender:   addrs[0],
-			Receiver: addrs[0],
-		}},
-		{"pay-other", txntest.Txn{
-			Type:     "pay",
-			Sender:   addrs[0],
-			Receiver: addrs[1],
-		}},
-		{"asa-self", txntest.Txn{
-			Type:          "axfer",
-			Sender:        addrs[0],
-			AssetAmount:   1,
-			XferAsset:     asa,
-			AssetReceiver: addrs[0],
-		}},
-		{"asa-other", txntest.Txn{
-			Type:          "axfer",
-			Sender:        addrs[0],
-			XferAsset:     asa,
-			AssetAmount:   10,
-			AssetReceiver: addrs[1],
-		}},
-		{"asa-clawback", txntest.Txn{
-			Type:          "axfer",
-			Sender:        addrs[0],
-			XferAsset:     asa,
-			AssetAmount:   1,
-			AssetSender:   addrs[1],
-			AssetReceiver: addrs[2],
-		}},
-		{"afrz", txntest.Txn{
-			Type:          "afrz",
-			Sender:        addrs[0],
-			FreezeAsset:   asa,
-			AssetFrozen:   true,
-			FreezeAccount: addrs[1],
-		}},
-		{"acfg-big", txntest.Txn{
-			Type:        "acfg",
-			Sender:      addrs[0],
-			ConfigAsset: asa,
+		createasa := txntest.Txn{
+			Type:   "acfg",
+			Sender: addrs[0],
 			AssetParams: basics.AssetParams{
+				Total:     1000000,
+				Decimals:  3,
+				UnitName:  "oz",
+				AssetName: "Gold",
+				URL:       "https://gold.rush/",
+
 				Manager:  addrs[0],
 				Clawback: addrs[0],
 				Freeze:   addrs[0],
 				Reserve:  addrs[0],
 			},
-		}},
-		{"acfg-small", txntest.Txn{
-			Type:        "acfg",
-			Sender:      addrs[0],
-			ConfigAsset: asa,
-			AssetParams: basics.AssetParams{
-				Manager: addrs[0],
-			},
-		}},
-		{"call-1", txntest.Txn{
-			Type:          "appl",
-			Sender:        addrs[0],
-			ApplicationID: app1,
-		}},
-		{"call-10", txntest.Txn{
-			Type:          "appl",
-			Sender:        addrs[0],
-			ApplicationID: app10,
-		}},
-		{"call-100", txntest.Txn{
-			Type:          "appl",
-			Sender:        addrs[0],
-			ApplicationID: app100,
-		}},
-		{"call-700", txntest.Txn{
-			Type:          "appl",
-			Sender:        addrs[0],
-			ApplicationID: app700,
-		}},
-		{"call-700s", txntest.Txn{
-			Type:          "appl",
-			Sender:        addrs[0],
-			ApplicationID: app700s,
-		}},
-	}
+		}
 
-	for _, bench := range benches {
-		b.Run(bench.name, func(b *testing.B) {
-			b.ReportAllocs()
-			t := bench.txn
-			eval := nextBlock(b, l, true, nil)
-			fillDefaults(b, l, eval, &t)
-			signed := t.SignedTxn()
-			for n := 0; n < b.N; n++ {
-				signed.Txn.Note = []byte(strconv.Itoa(n))
-				stxn(b, l, eval, signed)
-			}
-			endBlock(b, l, eval)
-		})
-	}
+		eval := nextBlock(b, l)
+		txn(b, l, eval, &createasa)
+		vb := endBlock(b, l, eval)
+		asa := vb.Block().Payset[0].ApplyData.ConfigAsset
+		require.Positive(b, asa)
+
+		optin1 := txntest.Txn{
+			Type:          "axfer",
+			Sender:        addrs[1],
+			AssetReceiver: addrs[1],
+			XferAsset:     asa,
+		}
+		optin2 := txntest.Txn{
+			Type:          "axfer",
+			Sender:        addrs[2],
+			AssetReceiver: addrs[2],
+			XferAsset:     asa,
+		}
+
+		eval = nextBlock(b, l)
+		txns(b, l, eval, &optin1, &optin2)
+		endBlock(b, l, eval)
+
+		createapp1 := txntest.Txn{
+			Type:            "appl",
+			Sender:          addrs[0],
+			ApprovalProgram: "int 1",
+		}
+
+		eval = nextBlock(b, l)
+		txn(b, l, eval, &createapp1)
+		vb = endBlock(b, l, eval)
+		app1 := vb.Block().Payset[0].ApplyData.ApplicationID
+		require.Positive(b, app1)
+
+		createapp10 := txntest.Txn{
+			Type:            "appl",
+			Sender:          addrs[0],
+			ApprovalProgram: strings.Repeat("int 1\npop\n", 5) + "int 1",
+		}
+
+		eval = nextBlock(b, l)
+		txn(b, l, eval, &createapp10)
+		vb = endBlock(b, l, eval)
+		app10 := vb.Block().Payset[0].ApplyData.ApplicationID
+		require.Positive(b, app10)
+
+		createapp100 := txntest.Txn{
+			Type:            "appl",
+			Sender:          addrs[0],
+			ApprovalProgram: strings.Repeat("int 1\npop\n", 50) + "int 1",
+		}
+
+		eval = nextBlock(b, l)
+		txn(b, l, eval, &createapp100)
+		vb = endBlock(b, l, eval)
+		app100 := vb.Block().Payset[0].ApplyData.ApplicationID
+		require.Positive(b, app100)
+
+		createapp700 := txntest.Txn{
+			Type:            "appl",
+			Sender:          addrs[0],
+			ApprovalProgram: strings.Repeat("int 1\npop\n", 349) + "int 1",
+		}
+
+		eval = nextBlock(b, l)
+		txn(b, l, eval, &createapp700)
+		vb = endBlock(b, l, eval)
+		app700 := vb.Block().Payset[0].ApplyData.ApplicationID
+		require.Positive(b, app700)
+
+		createapp700s := txntest.Txn{
+			Type:            "appl",
+			Sender:          addrs[0],
+			ApprovalProgram: strings.Repeat("int 1\n", 350) + strings.Repeat("pop\n", 349),
+		}
+
+		eval = nextBlock(b, l)
+		txn(b, l, eval, &createapp700s)
+		vb = endBlock(b, l, eval)
+		app700s := vb.Block().Payset[0].ApplyData.ApplicationID
+		require.Positive(b, app700s)
+
+		benches := []struct {
+			name string
+			txn  txntest.Txn
+		}{
+			{"pay-self", txntest.Txn{
+				Type:     "pay",
+				Sender:   addrs[0],
+				Receiver: addrs[0],
+			}},
+			{"pay-other", txntest.Txn{
+				Type:     "pay",
+				Sender:   addrs[0],
+				Receiver: addrs[1],
+			}},
+			{"asa-self", txntest.Txn{
+				Type:          "axfer",
+				Sender:        addrs[0],
+				AssetAmount:   1,
+				XferAsset:     asa,
+				AssetReceiver: addrs[0],
+			}},
+			{"asa-other", txntest.Txn{
+				Type:          "axfer",
+				Sender:        addrs[0],
+				XferAsset:     asa,
+				AssetAmount:   10,
+				AssetReceiver: addrs[1],
+			}},
+			{"asa-clawback", txntest.Txn{
+				Type:          "axfer",
+				Sender:        addrs[0],
+				XferAsset:     asa,
+				AssetAmount:   1,
+				AssetSender:   addrs[1],
+				AssetReceiver: addrs[2],
+			}},
+			{"afrz", txntest.Txn{
+				Type:          "afrz",
+				Sender:        addrs[0],
+				FreezeAsset:   asa,
+				AssetFrozen:   true,
+				FreezeAccount: addrs[1],
+			}},
+			{"acfg-big", txntest.Txn{
+				Type:        "acfg",
+				Sender:      addrs[0],
+				ConfigAsset: asa,
+				AssetParams: basics.AssetParams{
+					Manager:  addrs[0],
+					Clawback: addrs[0],
+					Freeze:   addrs[0],
+					Reserve:  addrs[0],
+				},
+			}},
+			{"acfg-small", txntest.Txn{
+				Type:        "acfg",
+				Sender:      addrs[0],
+				ConfigAsset: asa,
+				AssetParams: basics.AssetParams{
+					Manager: addrs[0],
+				},
+			}},
+			{"call-1", txntest.Txn{
+				Type:          "appl",
+				Sender:        addrs[0],
+				ApplicationID: app1,
+			}},
+			{"call-10", txntest.Txn{
+				Type:          "appl",
+				Sender:        addrs[0],
+				ApplicationID: app10,
+			}},
+			{"call-100", txntest.Txn{
+				Type:          "appl",
+				Sender:        addrs[0],
+				ApplicationID: app100,
+			}},
+			{"call-700", txntest.Txn{
+				Type:          "appl",
+				Sender:        addrs[0],
+				ApplicationID: app700,
+			}},
+			{"call-700s", txntest.Txn{
+				Type:          "appl",
+				Sender:        addrs[0],
+				ApplicationID: app700s,
+			}},
+		}
+
+		for _, bench := range benches {
+			b.Run(bench.name, func(b *testing.B) {
+				b.ReportAllocs()
+				t := bench.txn
+				eval := nextBlock(b, l)
+				fillDefaults(b, l, eval, &t)
+				signed := t.SignedTxn()
+				for n := 0; n < b.N; n++ {
+					signed.Txn.Note = []byte(strconv.Itoa(n))
+					err := eval.Transaction(signed, transactions.ApplyData{})
+					if errors.Is(err, ledgercore.ErrNoSpace) {
+						endBlock(b, l, eval)
+						eval = nextBlock(b, l)
+					}
+				}
+				endBlock(b, l, eval)
+			})
+		}
+	})
 }


### PR DESCRIPTION
This PR allows inner app calls to v4 and v5 teal versions.  The following prohibitions were added to make this safe.

1. Inner app calls may not do an opt-in to an app that has a pre-v4 clear state program.
2. No app program may be downgraded.

Rule 1 ensures that an app can call the clearstate program as an inner.  Rule 2 prevents and end-run around rule #1, by preventing an app with v5 CSP from downgrading to v3 at a later time.

The PR also introduces a DoubleLedger and testConsensusRange to make it easier to write ledger tests that need to change over different consensus versions. It also makes it easy to write the tests in such a way that they continue to test the functionality they care about as we change the consensus version, but also continue to test the behavior on old version, to prevent regressions.