### PR TITLE
netdeploy: Add override to enable devmode for a network template.

### DIFF
--- a/cmd/goal/network.go
+++ b/cmd/goal/network.go
@@ -34,6 +34,7 @@ var networkTemplateFile string
 var startNode string
 var noImportKeys bool
 var noClean bool
+var devModeOverride bool
 
 func init() {
 	networkCmd.AddCommand(networkCreateCmd)
@@ -46,6 +47,7 @@ func init() {
 	networkCreateCmd.MarkFlagRequired("template")
 	networkCreateCmd.Flags().BoolVarP(&noImportKeys, "noimportkeys", "K", false, "Do not import root keys when creating the network (by default will import)")
 	networkCreateCmd.Flags().BoolVar(&noClean, "noclean", false, "Prevents auto-cleanup on error - for diagnosing problems")
+	networkCreateCmd.Flags().BoolVar(&devModeOverride, "devMode", false, "Forces the configuration to enable DevMode, returns an error if the template is not compatible with DevMode.")
 
 	networkStartCmd.Flags().StringVarP(&startNode, "node", "n", "", "Specify the name of a specific node to start")
 
@@ -101,7 +103,7 @@ var networkCreateCmd = &cobra.Command{
 			consensus, _ = config.PreloadConfigurableConsensusProtocols(dataDir)
 		}
 
-		network, err := netdeploy.CreateNetworkFromTemplate(networkName, networkRootDir, networkTemplateFile, binDir, !noImportKeys, nil, consensus)
+		network, err := netdeploy.CreateNetworkFromTemplate(networkName, networkRootDir, networkTemplateFile, binDir, !noImportKeys, nil, consensus, devModeOverride)
 		if err != nil {
 			if noClean {
 				reportInfof(" ** failed ** - Preserving network rootdir '%s'", networkRootDir)

--- a/netdeploy/network.go
+++ b/netdeploy/network.go
@@ -59,7 +59,7 @@ type Network struct {
 
 // CreateNetworkFromTemplate uses the specified template to deploy a new private network
 // under the specified root directory.
-func CreateNetworkFromTemplate(name, rootDir, templateFile, binDir string, importKeys bool, nodeExitCallback nodecontrol.AlgodExitErrorCallback, consensus config.ConsensusProtocols) (Network, error) {
+func CreateNetworkFromTemplate(name, rootDir, templateFile, binDir string, importKeys bool, nodeExitCallback nodecontrol.AlgodExitErrorCallback, consensus config.ConsensusProtocols, overrideDevMode bool) (Network, error) {
 	n := Network{
 		rootDir:          rootDir,
 		nodeExitCallback: nodeExitCallback,
@@ -69,6 +69,12 @@ func CreateNetworkFromTemplate(name, rootDir, templateFile, binDir string, impor
 
 	template, err := loadTemplate(templateFile)
 	if err == nil {
+		if overrideDevMode {
+			template.Genesis.DevMode = true
+			if len(template.Nodes) > 0 {
+				template.Nodes[0].IsRelay = false
+			}
+		}
 		err = template.Validate()
 	}
 	if err != nil {

--- a/netdeploy/networkTemplate.go
+++ b/netdeploy/networkTemplate.go
@@ -212,6 +212,11 @@ func (t NetworkTemplate) Validate() error {
 	if len(t.Nodes) > 1 && countRelayNodes(t.Nodes) == 0 {
 		return fmt.Errorf("invalid template: at least one relay is required when more than a single node presents")
 	}
+
+	if t.Genesis.DevMode && len(t.Nodes) != 1 {
+		return fmt.Errorf("invalid template: DevMode should only have a single node")
+	}
+
 	return nil
 }
 

--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -93,7 +93,7 @@ func (f *LibGoalFixture) setup(test TestingTB, testName string, templateFile str
 	os.RemoveAll(f.rootDir)
 	templateFile = filepath.Join(f.testDataDir, templateFile)
 	importKeys := false // Don't automatically import root keys when creating folders, we'll import on-demand
-	network, err := netdeploy.CreateNetworkFromTemplate("test", f.rootDir, templateFile, f.binDir, importKeys, f.nodeExitWithError, f.consensus)
+	network, err := netdeploy.CreateNetworkFromTemplate("test", f.rootDir, templateFile, f.binDir, importKeys, f.nodeExitWithError, f.consensus, false)
 	f.failOnError(err, "CreateNetworkFromTemplate failed: %v")
 	f.network = network
 


### PR DESCRIPTION
## Summary

Thinking out loud a little bit with this PR.

Rather than requiring a separate network configuration, this flag lets you run an existing single node network template in dev mode. This would allow tools like sandbox to ship with a single template instead of two.

## Test Plan

Ran manually with `OneNodeFuture.json` template.