### PR TITLE
algocfg: Fix algocfg get for non-string parameters.

### DIFF
--- a/cmd/algocfg/getCommand.go
+++ b/cmd/algocfg/getCommand.go
@@ -51,14 +51,14 @@ var getCmd = &cobra.Command{
 				return
 			}
 
-			val, err := getObjectProperty(cfg, getParameterArg)
+			val, err := serializeObjectProperty(cfg, getParameterArg)
 			if err != nil {
 				reportWarnf("Error retrieving property '%s' - %s", getParameterArg, err)
 				anyError = true
 				return
 			}
 
-			fmt.Printf("%v", val)
+			fmt.Printf(val)
 		})
 		if anyError {
 			os.Exit(1)
@@ -66,14 +66,14 @@ var getCmd = &cobra.Command{
 	},
 }
 
-func getObjectProperty(object interface{}, property string) (ret interface{}, err error) {
+func serializeObjectProperty(object interface{}, property string) (ret string, err error) {
 	v := reflect.ValueOf(object)
 	val := reflect.Indirect(v)
 	f := val.FieldByName(property)
 
 	if !f.IsValid() {
-		return object, fmt.Errorf("unknown property named '%s'", property)
+		return "", fmt.Errorf("unknown property named '%s'", property)
 	}
 
-	return f.Interface(), nil
+	return fmt.Sprintf("%v", f.Interface()), nil
 }

--- a/cmd/algocfg/getCommand.go
+++ b/cmd/algocfg/getCommand.go
@@ -58,7 +58,7 @@ var getCmd = &cobra.Command{
 				return
 			}
 
-			fmt.Printf("%s", val)
+			fmt.Printf("%v", val)
 		})
 		if anyError {
 			os.Exit(1)

--- a/cmd/algocfg/getCommand.go
+++ b/cmd/algocfg/getCommand.go
@@ -58,7 +58,7 @@ var getCmd = &cobra.Command{
 				return
 			}
 
-			fmt.Printf(val)
+			fmt.Print(val)
 		})
 		if anyError {
 			os.Exit(1)

--- a/cmd/algocfg/getCommand_test.go
+++ b/cmd/algocfg/getCommand_test.go
@@ -23,9 +23,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
 func TestPrint(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	testcases := []struct {
 		input    interface{}
 		expected string

--- a/cmd/algocfg/getCommand_test.go
+++ b/cmd/algocfg/getCommand_test.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package main
 
 import (

--- a/cmd/algocfg/getCommand_test.go
+++ b/cmd/algocfg/getCommand_test.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"testing"
 	"time"
@@ -35,27 +34,27 @@ func TestPrint(t *testing.T) {
 		expected string
 	}{
 		{
-			input:    uint64(1234),
+			input:    struct{ Field uint64 }{uint64(1234)},
 			expected: "1234",
 		},
 		{
-			input:    int64(-1234),
+			input:    struct{ Field int64 }{int64(-1234)},
 			expected: "-1234",
 		},
 		{
-			input:    true,
+			input:    struct{ Field bool }{true},
 			expected: "true",
 		},
 		{
-			input:    time.Second,
+			input:    struct{ Field time.Duration }{time.Second},
 			expected: "1s",
 		},
 	}
 	for i, tc := range testcases {
 		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
-			var buf bytes.Buffer
-			fmt.Fprintf(&buf, "%v", tc.input)
-			assert.Equal(t, tc.expected, buf.String())
+			ret, err := serializeObjectProperty(tc.input, "Field")
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, ret)
 		})
 	}
 }

--- a/cmd/algocfg/getCommand_test.go
+++ b/cmd/algocfg/getCommand_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrint(t *testing.T) {
+	testcases := []struct {
+		input    interface{}
+		expected string
+	}{
+		{
+			input:    uint64(1234),
+			expected: "1234",
+		},
+		{
+			input:    int64(-1234),
+			expected: "-1234",
+		},
+		{
+			input:    true,
+			expected: "true",
+		},
+		{
+			input:    time.Second,
+			expected: "1s",
+		},
+	}
+	for i, tc := range testcases {
+		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
+			var buf bytes.Buffer
+			fmt.Fprintf(&buf, "%v", tc.input)
+			assert.Equal(t, tc.expected, buf.String())
+		})
+	}
+}

--- a/cmd/algocfg/getCommand_test.go
+++ b/cmd/algocfg/getCommand_test.go
@@ -30,29 +30,33 @@ func TestPrint(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	testcases := []struct {
-		input    interface{}
+		Input    interface{}
 		expected string
 	}{
 		{
-			input:    struct{ Field uint64 }{uint64(1234)},
+			Input:    "string",
+			expected: "string",
+		},
+		{
+			Input:    uint64(1234),
 			expected: "1234",
 		},
 		{
-			input:    struct{ Field int64 }{int64(-1234)},
+			Input:    int64(-1234),
 			expected: "-1234",
 		},
 		{
-			input:    struct{ Field bool }{true},
+			Input:    true,
 			expected: "true",
 		},
 		{
-			input:    struct{ Field time.Duration }{time.Second},
+			Input:    time.Second,
 			expected: "1s",
 		},
 	}
 	for i, tc := range testcases {
 		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
-			ret, err := serializeObjectProperty(tc.input, "Field")
+			ret, err := serializeObjectProperty(tc, "Input")
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, ret)
 		})


### PR DESCRIPTION
## Summary

algocfg was returning values like `%!s(uint64=16)` and `%!s(bool=true)`, with this change those are fixed to return `16` and `true`.

## Test Plan

Seemed silly to unit test a built in function, but  I went ahead and did it anyway.