### PR TITLE
netdeploy: Allow empty private network directory.

### DIFF
--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -131,7 +131,7 @@ const (
 	loggingNotEnabled    = "Remote logging is current disabled"
 	loggingEnabled       = "Remote logging is enabled.  Node = %s, Guid = %s"
 
-	infoNetworkAlreadyExists = "Network Root Directory '%s' already exists"
+	infoNetworkAlreadyExists = "Network Root Directory '%s' already exists and is not empty"
 	errorCreateNetwork       = "Error creating private network: %s"
 	infoNetworkCreated       = "Network %s created under %s"
 	errorLoadingNetwork      = "Error loading deployed network: %s"

--- a/cmd/goal/network.go
+++ b/cmd/goal/network.go
@@ -85,9 +85,8 @@ var networkCreateCmd = &cobra.Command{
 		if err != nil {
 			panic(err)
 		}
-		// Make sure target directory doesn't already exist
-		exists := util.FileExists(networkRootDir)
-		if exists {
+		// Make sure target directory does not exist or is empty
+		if util.FileExists(networkRootDir) && !util.IsEmpty(networkRootDir) {
 			reportErrorf(infoNetworkAlreadyExists, networkRootDir)
 		}
 

--- a/netdeploy/networkTemplate.go
+++ b/netdeploy/networkTemplate.go
@@ -74,13 +74,14 @@ func (t NetworkTemplate) createNodeDirectories(targetFolder string, binDir strin
 		nodeDir := filepath.Join(targetFolder, cfg.Name)
 		err = os.Mkdir(nodeDir, os.ModePerm)
 		if err != nil {
-			if os.IsExist(err) {
-				// allow some flexibility around pre-existing directories to support docker and pre-mounted volumes.
-				if !util.IsEmpty(nodeDir) {
-					err = fmt.Errorf("duplicate node directory detected: %w", err)
-					return
-				}
-			} else {
+			if !os.IsExist(err) {
+				return
+			}
+
+			// allow some flexibility around pre-existing directories to
+			// support docker and pre-mounted volumes.
+			if !util.IsEmpty(nodeDir) {
+				err = fmt.Errorf("duplicate node directory detected: %w", err)
 				return
 			}
 		}

--- a/netdeploy/networkTemplate.go
+++ b/netdeploy/networkTemplate.go
@@ -74,7 +74,15 @@ func (t NetworkTemplate) createNodeDirectories(targetFolder string, binDir strin
 		nodeDir := filepath.Join(targetFolder, cfg.Name)
 		err = os.Mkdir(nodeDir, os.ModePerm)
 		if err != nil {
-			return
+			if os.IsExist(err) {
+				// allow some flexibility around pre-existing directories to support docker and pre-mounted volumes.
+				if !util.IsEmpty(nodeDir) {
+					err = fmt.Errorf("duplicate node directory detected: %w", err)
+					return
+				}
+			} else {
+				return
+			}
 		}
 
 		_, err = util.CopyFile(genesisFile, filepath.Join(nodeDir, genesisFileName))

--- a/util/io.go
+++ b/util/io.go
@@ -59,6 +59,17 @@ func FileExists(filePath string) bool {
 	return fileExists
 }
 
+// IsEmpty recursively check path for files and returns true if there are none.
+func IsEmpty(path string) bool {
+	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+		return os.ErrExist
+	})
+	return err == nil
+}
+
 // ExeDir returns the absolute path to the current executing binary (not including the filename)
 func ExeDir() (string, error) {
 	ex, err := os.Executable()

--- a/util/io_test.go
+++ b/util/io_test.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package util
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/algorand/go-algorand/test/partitiontest"
+)
+
+func TestIsEmpty(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	testPath := path.Join(os.TempDir(), "this", "is", "a", "long", "path")
+	err := os.MkdirAll(testPath, os.ModePerm)
+	assert.NoError(t, err)
+	defer os.RemoveAll(testPath)
+	assert.True(t, IsEmpty(testPath))
+
+	_, err = os.Create(path.Join(testPath, "file.txt"))
+	assert.NoError(t, err)
+	assert.False(t, IsEmpty(testPath))
+}


### PR DESCRIPTION
## Summary

In order to run private networks in docker, it is convenient to mount
the data directory. By disallowing the network directory to exist it is
not possible to mount the node directory ahead of time.

## Test Plan

Unit test for new utility function.
