### PR TITLE
diagcfg: Allow diagcfg to create logging.config in data directory.

### DIFF
--- a/logging/telemetry.go
+++ b/logging/telemetry.go
@@ -109,14 +109,14 @@ func ReadTelemetryConfigOrDefault(dataDir string, genesisID string) (cfg Telemet
 
 		configPath, err = config.GetConfigFilePath(TelemetryConfigFilename)
 		if err != nil {
-			// In this case we don't know what to do since we couldn't
-			// create the directory.  Just create an ephemeral config.
+			// In this case we don't know what to do since we couldn't read
+			// from the global directory. Just create an ephemeral config, if
+			// the data directory was provided it can be persisted there later.
 			cfg = createTelemetryConfig()
-			return
+		} else {
+			// Load the telemetry from the default config path
+			cfg, err = LoadTelemetryConfig(configPath)
 		}
-
-		// Load the telemetry from the default config path
-		cfg, err = LoadTelemetryConfig(configPath)
 	}
 
 	// If there was some error loading the configuration from the config path...

--- a/logging/telemetry.go
+++ b/logging/telemetry.go
@@ -109,10 +109,8 @@ func ReadTelemetryConfigOrDefault(dataDir string, genesisID string) (cfg Telemet
 
 		configPath, err = config.GetConfigFilePath(TelemetryConfigFilename)
 		if err != nil {
-			// In this case we don't know what to do since we couldn't read
-			// from the global directory. Just create an ephemeral config, if
-			// the data directory was provided it can be persisted there later.
-			cfg = createTelemetryConfig()
+			// If the path could not be opened do nothing, the IsNotExist error
+			// is handled below.
 		} else {
 			// Load the telemetry from the default config path
 			cfg, err = LoadTelemetryConfig(configPath)


### PR DESCRIPTION
## Summary

When running diagcfg as a user without a home directory, the missing global default directory prevents diagcfg from writing `logging.config`. With this change, the error is cleared out so that the file can be created as usual.

The only risk is if the global logging file was being used, and is for some reason temporarily inaccessible, those defaults would not be copied into the new file.

## Test Plan

Manual testing.

Run diagcfg with ALGORAND_DATA and -d, the file is created in the data directory.
Run diagcfg without ALGORAND_DATA or -d, the file is created in the default global directory.

Also tested on a docker environment where the user did not have a home directory (or default global directory), the logging file is created in the data directory.