### PR TITLE
Enhancement: Migrate goal account commands to REST API

### DIFF
--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -825,7 +826,7 @@ var changeOnlineCmd = &cobra.Command{
 			reportErrorf(err.Error())
 		}
 		err = changeAccountOnlineStatus(
-			accountAddress, part, online, statusChangeTxFile, walletName,
+			accountAddress, online, statusChangeTxFile, walletName,
 			firstTxRound, lastTxRound, transactionFee, scLeaseBytes(cmd), dataDir, client,
 		)
 		if err != nil {
@@ -834,12 +835,12 @@ var changeOnlineCmd = &cobra.Command{
 	},
 }
 
-func changeAccountOnlineStatus(acct string, part *algodAcct.Participation, goOnline bool, txFile string, wallet string, firstTxRound, lastTxRound, fee uint64, leaseBytes [32]byte, dataDir string, client libgoal.Client) error {
+func changeAccountOnlineStatus(acct string, goOnline bool, txFile string, wallet string, firstTxRound, lastTxRound, fee uint64, leaseBytes [32]byte, dataDir string, client libgoal.Client) error {
 	// Generate an unsigned online/offline tx
 	var utx transactions.Transaction
 	var err error
 	if goOnline {
-		utx, err = client.MakeUnsignedGoOnlineTx(acct, part, firstTxRound, lastTxRound, fee, leaseBytes)
+		utx, err = client.MakeUnsignedGoOnlineTx(acct, firstTxRound, lastTxRound, fee, leaseBytes)
 	} else {
 		utx, err = client.MakeUnsignedGoOfflineTx(acct, firstTxRound, lastTxRound, fee, leaseBytes)
 	}
@@ -870,8 +871,8 @@ func changeAccountOnlineStatus(acct string, part *algodAcct.Participation, goOnl
 
 var addParticipationKeyCmd = &cobra.Command{
 	Use:   "addpartkey",
-	Short: "Generate a participation key for the specified account",
-	Long:  `Generate a participation key for the specified account. This participation key can then be used for going online and participating in consensus.`,
+	Short: "Generate and install participation key for the specified account",
+	Long:  `Generate and install participation key for the specified account. This participation key can then be used for going online and participating in consensus.`,
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, args []string) {
 		dataDir := ensureSingleDataDir()
@@ -886,8 +887,9 @@ var addParticipationKeyCmd = &cobra.Command{
 		reportInfof("Please stand by while generating keys. This might take a few minutes...")
 
 		var err error
+		var part algodAcct.Participation
 		participationGen := func() {
-			_, _, err = client.GenParticipationKeysTo(accountAddress, roundFirstValid, roundLastValid, keyDilution, partKeyOutDir)
+			part, _, err = client.GenParticipationKeysTo(accountAddress, roundFirstValid, roundLastValid, keyDilution, partKeyOutDir)
 		}
 
 		util.RunFuncWithSpinningCursor(participationGen)
@@ -895,7 +897,7 @@ var addParticipationKeyCmd = &cobra.Command{
 			reportErrorf(errorRequestFail, err)
 		}
 
-		reportInfof("Participation key generation successful")
+		fmt.Printf("Participation key generation successful. Participation ID: %s\n", part.ID())
 	},
 }
 
@@ -922,11 +924,22 @@ No --delete-input flag specified, exiting without installing key.`)
 		dataDir := ensureSingleDataDir()
 
 		client := ensureAlgodClient(dataDir)
-		_, _, err := client.InstallParticipationKeys(partKeyFile)
+		addResponse, err := client.AddParticipationKey(partKeyFile)
 		if err != nil {
 			reportErrorf(errorRequestFail, err)
 		}
-		fmt.Println("Participation key installed successfully")
+		// In an abundance of caution, check for ourselves that the key has been installed.
+		if err := client.VerifyParticipationKey(time.Minute, addResponse.PartId); err != nil {
+			err = fmt.Errorf("unable to verify key installation. Verify key installation with 'goal account partkeyinfo' and delete '%s', or retry the command. Error: %w", partKeyFile, err)
+			reportErrorf(errorRequestFail, err)
+		}
+
+		fmt.Printf("Participation key installed successfully, Participation ID: %s\n", addResponse.PartId)
+
+		// Delete partKeyFile
+		if nil != os.Remove(partKeyFile) {
+			reportErrorf("An error occurred while removing the partkey file, please delete it manually: %s", err)
+		}
 	},
 }
 
@@ -957,14 +970,14 @@ var renewParticipationKeyCmd = &cobra.Command{
 		txRoundLastValid := currentRound + proto.MaxTxnLife
 
 		// Make sure we don't already have a partkey valid for (or after) specified roundLastValid
-		parts, err := client.ListParticipationKeyFiles()
+		parts, err := client.ListParticipationKeys()
 		if err != nil {
 			reportErrorf(errorRequestFail, err)
 		}
 		for _, part := range parts {
-			if part.Address().String() == accountAddress {
-				if part.LastValid >= basics.Round(roundLastValid) {
-					reportErrorf(errExistingPartKey, roundLastValid, part.LastValid)
+			if part.Address == accountAddress {
+				if part.Key.VoteLastValid >= roundLastValid {
+					reportErrorf(errExistingPartKey, roundLastValid, part.Key.VoteLastValid)
 				}
 			}
 		}
@@ -982,7 +995,7 @@ func generateAndRegisterPartKey(address string, currentRound, keyLastValidRound,
 	var keyPath string
 	var err error
 	genFunc := func() {
-		part, keyPath, err = client.GenParticipationKeysTo(address, currentRound, keyLastValidRound, dilution, "")
+		part, keyPath, err = client.GenParticipationKeys(address, currentRound, keyLastValidRound, dilution)
 		if err != nil {
 			err = fmt.Errorf(errorRequestFail, err)
 		}
@@ -997,12 +1010,13 @@ func generateAndRegisterPartKey(address string, currentRound, keyLastValidRound,
 	// Now register it as our new online participation key
 	goOnline := true
 	txFile := ""
-	err = changeAccountOnlineStatus(address, &part, goOnline, txFile, wallet, currentRound, txLastValidRound, fee, leaseBytes, dataDir, client)
+	err = changeAccountOnlineStatus(address, goOnline, txFile, wallet, currentRound, txLastValidRound, fee, leaseBytes, dataDir, client)
 	if err != nil {
 		os.Remove(keyPath)
 		fmt.Fprintf(os.Stderr, "  Error registering keys - deleting newly-generated key file: %s\n", keyPath)
 	}
-	return err
+	fmt.Printf("Participation key installed successfully, Participation ID: %s\n", part.ID())
+	return nil
 }
 
 var renewAllParticipationKeyCmd = &cobra.Command{
@@ -1025,19 +1039,19 @@ func renewPartKeysInDir(dataDir string, lastValidRound uint64, fee uint64, lease
 	client := ensureAlgodClient(dataDir)
 
 	// Build list of accounts to renew from all accounts with part keys present
-	parts, err := client.ListParticipationKeyFiles()
+	parts, err := client.ListParticipationKeys()
 	if err != nil {
 		return fmt.Errorf(errorRequestFail, err)
 	}
-	renewAccounts := make(map[basics.Address]algodAcct.Participation)
+	renewAccounts := make(map[string]generatedV2.ParticipationKey)
 	for _, part := range parts {
-		if existing, has := renewAccounts[part.Address()]; has {
-			if existing.LastValid >= part.LastValid {
+		if existing, has := renewAccounts[part.Address]; has {
+			if existing.Key.VoteFirstValid >= part.Key.VoteLastValid {
 				// We already saw a partkey that expires later
 				continue
 			}
 		}
-		renewAccounts[part.Address()] = part
+		renewAccounts[part.Address] = part
 	}
 
 	currentRound, err := client.CurrentRound()
@@ -1062,18 +1076,18 @@ func renewPartKeysInDir(dataDir string, lastValidRound uint64, fee uint64, lease
 	// at least through lastValidRound, generate a new key and register it.
 	// Make sure we don't already have a partkey valid for (or after) specified roundLastValid
 	for _, renewPart := range renewAccounts {
-		if renewPart.LastValid >= basics.Round(lastValidRound) {
-			fmt.Printf("  Skipping account %s: Already has a part key valid beyond %d (currently %d)\n", renewPart.Address(), lastValidRound, renewPart.LastValid)
+		if renewPart.Key.VoteLastValid >= lastValidRound {
+			fmt.Printf("  Skipping account %s: Already has a part key valid beyond %d (currently %d)\n", renewPart.Address, lastValidRound, renewPart.Key.VoteLastValid)
 			continue
 		}
 
 		// If the account's latest partkey expired before the current round, don't automatically renew and instead instruct the user to explicitly renew it.
-		if renewPart.LastValid < basics.Round(lastValidRound) {
-			fmt.Printf("  Skipping account %s: This account has part keys that have expired.  Please renew this account explicitly using 'renewpartkey'\n", renewPart.Address())
+		if renewPart.Key.VoteLastValid < lastValidRound {
+			fmt.Printf("  Skipping account %s: This account has part keys that have expired.  Please renew this account explicitly using 'renewpartkey'\n", renewPart.Address)
 			continue
 		}
 
-		address := renewPart.Address().String()
+		address := renewPart.Address
 		err = generateAndRegisterPartKey(address, currentRound, lastValidRound, txLastValidRound, fee, leaseBytes, dilution, wallet, dataDir, client)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "  Error renewing part key for account %s: %v\n", address, err)
@@ -1095,53 +1109,6 @@ func maxRound(current uint64, next *uint64) uint64 {
 
 func uintToStr(number uint64) string {
 	return fmt.Sprintf("%d", number)
-}
-
-// legacyListParticipationKeysCommand prints key information in the same
-// format as earlier versions of goal. Some users are using this information
-// in scripts and need some extra time to migrate to the REST API.
-// DEPRECATED
-func legacyListParticipationKeysCommand() {
-	dataDir := ensureSingleDataDir()
-
-	client := ensureGoalClient(dataDir, libgoal.DynamicClient)
-	parts, err := client.ListParticipationKeyFiles()
-	if err != nil {
-		reportErrorf(errorRequestFail, err)
-	}
-
-	var filenames []string
-	for fn := range parts {
-		filenames = append(filenames, fn)
-	}
-	sort.Strings(filenames)
-
-	rowFormat := "%-10s\t%-80s\t%-60s\t%12s\t%12s\t%12s\n"
-	fmt.Printf(rowFormat, "Registered", "Filename", "Parent address", "First round", "Last round", "First key")
-	for _, fn := range filenames {
-		onlineInfoStr := "unknown"
-		onlineAccountInfo, err := client.AccountInformation(parts[fn].Address().GetUserAddress())
-		if err == nil {
-			votingBytes := parts[fn].Voting.OneTimeSignatureVerifier
-			vrfBytes := parts[fn].VRF.PK
-			if onlineAccountInfo.Participation != nil &&
-				(string(onlineAccountInfo.Participation.ParticipationPK) == string(votingBytes[:])) &&
-				(string(onlineAccountInfo.Participation.VRFPK) == string(vrfBytes[:])) &&
-				(onlineAccountInfo.Participation.VoteFirst == uint64(parts[fn].FirstValid)) &&
-				(onlineAccountInfo.Participation.VoteLast == uint64(parts[fn].LastValid)) &&
-				(onlineAccountInfo.Participation.VoteKeyDilution == parts[fn].KeyDilution) {
-				onlineInfoStr = "yes"
-			} else {
-				onlineInfoStr = "no"
-			}
-		}
-		// it's okay to proceed without algod info
-		first, last := parts[fn].ValidInterval()
-		fmt.Printf(rowFormat, onlineInfoStr, fn, parts[fn].Address().GetUserAddress(),
-			fmt.Sprintf("%d", first),
-			fmt.Sprintf("%d", last),
-			fmt.Sprintf("%d.%d", parts[fn].Voting.FirstBatch, parts[fn].Voting.FirstOffset))
-	}
 }
 
 var listParticipationKeysCmd = &cobra.Command{
@@ -1396,47 +1363,6 @@ func strOrNA(value *uint64) string {
 	return uintToStr(*value)
 }
 
-// legacyPartkeyInfoCommand prints key information in the same
-// format as earlier versions of goal. Some users are using this information
-// in scripts and need some extra time to migrate to alternatives.
-// DEPRECATED
-func legacyPartkeyInfoCommand() {
-	type partkeyInfo struct {
-		_struct         struct{}                        `codec:",omitempty,omitemptyarray"`
-		Address         string                          `codec:"acct"`
-		FirstValid      basics.Round                    `codec:"first"`
-		LastValid       basics.Round                    `codec:"last"`
-		VoteID          crypto.OneTimeSignatureVerifier `codec:"vote"`
-		SelectionID     crypto.VRFVerifier              `codec:"sel"`
-		VoteKeyDilution uint64                          `codec:"voteKD"`
-	}
-
-	onDataDirs(func(dataDir string) {
-		fmt.Printf("Dumping participation key info from %s...\n", dataDir)
-		client := ensureGoalClient(dataDir, libgoal.DynamicClient)
-
-		// Make sure we don't already have a partkey valid for (or after) specified roundLastValid
-		parts, err := client.ListParticipationKeyFiles()
-		if err != nil {
-			reportErrorf(errorRequestFail, err)
-		}
-
-		for filename, part := range parts {
-			fmt.Println("------------------------------------------------------------------")
-			info := partkeyInfo{
-				Address:         part.Address().String(),
-				FirstValid:      part.FirstValid,
-				LastValid:       part.LastValid,
-				VoteID:          part.VotingSecrets().OneTimeSignatureVerifier,
-				SelectionID:     part.VRFSecrets().PK,
-				VoteKeyDilution: part.KeyDilution,
-			}
-			infoString := protocol.EncodeJSON(&info)
-			fmt.Printf("File: %s\n%s\n", filename, string(infoString))
-		}
-	})
-}
-
 var partkeyInfoCmd = &cobra.Command{
 	Use:   "partkeyinfo",
 	Short: "Output details about all available part keys",
@@ -1527,4 +1453,139 @@ var markNonparticipatingCmd = &cobra.Command{
 			reportErrorf("error waiting for transaction to be committed: %v", err)
 		}
 	},
+}
+
+// listParticipationKeyFiles returns the available participation keys,
+// as a map from database filename to Participation key object.
+// DEPRECATED
+func listParticipationKeyFiles(c *libgoal.Client) (partKeyFiles map[string]algodAcct.Participation, err error) {
+	genID, err := c.GenesisID()
+	if err != nil {
+		return
+	}
+
+	// Get a list of files in the participation keys directory
+	keyDir := filepath.Join(c.DataDir(), genID)
+	files, err := ioutil.ReadDir(keyDir)
+	if err != nil {
+		return
+	}
+
+	partKeyFiles = make(map[string]algodAcct.Participation)
+	for _, file := range files {
+		// If it can't be a participation key database, skip it
+		if !config.IsPartKeyFilename(file.Name()) {
+			continue
+		}
+
+		filename := file.Name()
+
+		// Fetch a handle to this database
+		handle, err := db.MakeErasableAccessor(filepath.Join(keyDir, filename))
+		if err != nil {
+			// Couldn't open it, skip it
+			continue
+		}
+
+		// Fetch an account.Participation from the database
+		part, err := algodAcct.RestoreParticipation(handle)
+		if err != nil {
+			// Couldn't read it, skip it
+			handle.Close()
+			continue
+		}
+
+		partKeyFiles[filename] = part.Participation
+		part.Close()
+	}
+
+	return
+}
+
+// legacyListParticipationKeysCommand prints key information in the same
+// format as earlier versions of goal. Some users are using this information
+// in scripts and need some extra time to migrate to the REST API.
+// DEPRECATED
+func legacyListParticipationKeysCommand() {
+	dataDir := ensureSingleDataDir()
+
+	client := ensureGoalClient(dataDir, libgoal.DynamicClient)
+	parts, err := listParticipationKeyFiles(&client)
+	if err != nil {
+		reportErrorf(errorRequestFail, err)
+	}
+
+	var filenames []string
+	for fn := range parts {
+		filenames = append(filenames, fn)
+	}
+	sort.Strings(filenames)
+
+	rowFormat := "%-10s\t%-80s\t%-60s\t%12s\t%12s\t%12s\n"
+	fmt.Printf(rowFormat, "Registered", "Filename", "Parent address", "First round", "Last round", "First key")
+	for _, fn := range filenames {
+		onlineInfoStr := "unknown"
+		onlineAccountInfo, err := client.AccountInformation(parts[fn].Address().GetUserAddress())
+		if err == nil {
+			votingBytes := parts[fn].Voting.OneTimeSignatureVerifier
+			vrfBytes := parts[fn].VRF.PK
+			if onlineAccountInfo.Participation != nil &&
+				(string(onlineAccountInfo.Participation.ParticipationPK) == string(votingBytes[:])) &&
+				(string(onlineAccountInfo.Participation.VRFPK) == string(vrfBytes[:])) &&
+				(onlineAccountInfo.Participation.VoteFirst == uint64(parts[fn].FirstValid)) &&
+				(onlineAccountInfo.Participation.VoteLast == uint64(parts[fn].LastValid)) &&
+				(onlineAccountInfo.Participation.VoteKeyDilution == parts[fn].KeyDilution) {
+				onlineInfoStr = "yes"
+			} else {
+				onlineInfoStr = "no"
+			}
+		}
+		// it's okay to proceed without algod info
+		first, last := parts[fn].ValidInterval()
+		fmt.Printf(rowFormat, onlineInfoStr, fn, parts[fn].Address().GetUserAddress(),
+			fmt.Sprintf("%d", first),
+			fmt.Sprintf("%d", last),
+			fmt.Sprintf("%d.%d", parts[fn].Voting.FirstBatch, parts[fn].Voting.FirstOffset))
+	}
+}
+
+// legacyPartkeyInfoCommand prints key information in the same
+// format as earlier versions of goal. Some users are using this information
+// in scripts and need some extra time to migrate to alternatives.
+// DEPRECATED
+func legacyPartkeyInfoCommand() {
+	type partkeyInfo struct {
+		_struct         struct{}                        `codec:",omitempty,omitemptyarray"`
+		Address         string                          `codec:"acct"`
+		FirstValid      basics.Round                    `codec:"first"`
+		LastValid       basics.Round                    `codec:"last"`
+		VoteID          crypto.OneTimeSignatureVerifier `codec:"vote"`
+		SelectionID     crypto.VRFVerifier              `codec:"sel"`
+		VoteKeyDilution uint64                          `codec:"voteKD"`
+	}
+
+	onDataDirs(func(dataDir string) {
+		fmt.Printf("Dumping participation key info from %s...\n", dataDir)
+		client := ensureGoalClient(dataDir, libgoal.DynamicClient)
+
+		// Make sure we don't already have a partkey valid for (or after) specified roundLastValid
+		parts, err := listParticipationKeyFiles(&client)
+		if err != nil {
+			reportErrorf(errorRequestFail, err)
+		}
+
+		for filename, part := range parts {
+			fmt.Println("------------------------------------------------------------------")
+			info := partkeyInfo{
+				Address:         part.Address().String(),
+				FirstValid:      part.FirstValid,
+				LastValid:       part.LastValid,
+				VoteID:          part.VotingSecrets().OneTimeSignatureVerifier,
+				SelectionID:     part.VRFSecrets().PK,
+				VoteKeyDilution: part.KeyDilution,
+			}
+			infoString := protocol.EncodeJSON(&info)
+			fmt.Printf("File: %s\n%s\n", filename, string(infoString))
+		}
+	})
 }

--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -897,7 +897,7 @@ var addParticipationKeyCmd = &cobra.Command{
 			reportErrorf(errorRequestFail, err)
 		}
 
-		fmt.Printf("Participation key generation successful. Participation ID: %s\n", part.ID())
+		reportInfof("Participation key generation successful. Participation ID: %s\n", part.ID())
 	},
 }
 
@@ -934,7 +934,7 @@ No --delete-input flag specified, exiting without installing key.`)
 			reportErrorf(errorRequestFail, err)
 		}
 
-		fmt.Printf("Participation key installed successfully, Participation ID: %s\n", addResponse.PartId)
+		reportInfof("Participation key installed successfully, Participation ID: %s\n", addResponse.PartId)
 
 		// Delete partKeyFile
 		if nil != os.Remove(partKeyFile) {

--- a/libgoal/participation.go
+++ b/libgoal/participation.go
@@ -38,7 +38,7 @@ func (c *Client) chooseParticipation(address basics.Address, round basics.Round)
 	}
 
 	// Loop through each of the participation keys; pick the one that expires farthest in the future.
-	var expiry uint64
+	var expiry uint64 = 0
 	for _, info := range parts {
 		// Choose the Participation valid for this round that relates to the passed address
 		// that expires farthest in the future.
@@ -108,9 +108,9 @@ func (c *Client) GenParticipationKeysTo(address string, firstValid, lastValid, k
 
 	// If the key is being installed, remove it afterwards.
 	if install {
-		// Explicitly any errors
+		// Explicitly ignore any errors
 		defer func(name string) {
-			_ = os.RemoveAll(name)
+			_ = os.Remove(name)
 		}(partKeyPath)
 	}
 

--- a/libgoal/participation.go
+++ b/libgoal/participation.go
@@ -139,8 +139,6 @@ func (c *Client) GenParticipationKeysTo(address string, firstValid, lastValid, k
 	return part, partKeyPath, err
 }
 
-
-
 // ListParticipationKeys returns the available participation keys,
 // as a response object.
 func (c *Client) ListParticipationKeys() (partKeyFiles generated.ParticipationKeysResponse, err error) {

--- a/libgoal/participation.go
+++ b/libgoal/participation.go
@@ -128,6 +128,11 @@ func (c *Client) GenParticipationKeysTo(address string, firstValid, lastValid, k
 	newPart, err := account.FillDBWithParticipationKeys(partdb, parsedAddr, firstRound, lastRound, keyDilution)
 	part = newPart.Participation
 	partdb.Close()
+
+	if err != nil {
+		return part, partKeyPath, err
+	}
+
 	if install {
 		_, err = c.AddParticipationKey(partKeyPath)
 	}

--- a/libgoal/participation.go
+++ b/libgoal/participation.go
@@ -97,7 +97,7 @@ func (c *Client) GenParticipationKeysTo(address string, firstValid, lastValid, k
 
 	firstRound, lastRound := basics.Round(firstValid), basics.Round(lastValid)
 
-	// If output directory wasn't specified, store it in the current ledger directory.
+	// If we are installing, generate in the temp dir
 	if install {
 		outDir = os.TempDir()
 	}

--- a/libgoal/participation.go
+++ b/libgoal/participation.go
@@ -18,7 +18,6 @@ package libgoal
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -27,76 +26,43 @@ import (
 	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
 	"github.com/algorand/go-algorand/data/account"
 	"github.com/algorand/go-algorand/data/basics"
-	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/util/db"
 )
 
 // chooseParticipation chooses which participation keys to use for going online
 // based on the address, round number, and available participation databases
-func (c *Client) chooseParticipation(address basics.Address, round basics.Round) (part account.Participation, err error) {
-	genID, err := c.GenesisID()
+func (c *Client) chooseParticipation(address basics.Address, round basics.Round) (part generated.ParticipationKey, err error) {
+	parts, err := c.ListParticipationKeys()
 	if err != nil {
 		return
 	}
 
-	// Get a list of files in the participation keys directory
-	keyDir := filepath.Join(c.DataDir(), genID)
-	files, err := ioutil.ReadDir(keyDir)
-	if err != nil {
-		return
-	}
 	// This lambda will be used for finding the desired file.
-	checkIfFileIsDesiredKey := func(file os.FileInfo, expiresAfter basics.Round) (part account.Participation, err error) {
-		var handle db.Accessor
-		var partCandidate account.PersistedParticipation
-
-		// If it can't be a participation key database, skip it
-		if !config.IsPartKeyFilename(file.Name()) {
-			return
-		}
-
-		filename := file.Name()
-
-		// Fetch a handle to this database
-		handle, err = db.MakeErasableAccessor(filepath.Join(keyDir, filename))
-		if err != nil {
-			// Couldn't open it, skip it
-			return
-		}
-
-		// Fetch an account.Participation from the database
-		partCandidate, err = account.RestoreParticipation(handle)
-		if err != nil {
-			// Couldn't read it, skip it
-			handle.Close()
-			return
-		}
-		defer partCandidate.Close()
-
+	checkIfFileIsDesiredKey := func(partCandidate generated.ParticipationKey, expiresAfter uint64) (part generated.ParticipationKey, err error) {
 		// Return the Participation valid for this round that relates to the passed address
 		// that expires farthest in the future.
 		// Note that algod will sign votes with all possible Participations. so any should work
 		// in the short-term.
 		// In the future we should allow the user to specify exactly which partkeys to register.
-		if partCandidate.FirstValid <= round && round <= partCandidate.LastValid && partCandidate.Parent == address && partCandidate.LastValid > expiresAfter {
-			part = partCandidate.Participation
+		if partCandidate.Key.VoteFirstValid <= uint64(round) && uint64(round) <= partCandidate.Key.VoteLastValid && partCandidate.Address == address.String() && partCandidate.Key.VoteLastValid > expiresAfter {
+			part = partCandidate
 		}
 		return
 	}
 
 	// Loop through each of the files; pick the one that expires farthest in the future.
-	var expiry basics.Round
-	for _, info := range files {
+	var expiry uint64
+	for _, info := range parts {
 		// Use above lambda so the deferred handle closure happens each loop
 		partCandidate, err := checkIfFileIsDesiredKey(info, expiry)
-		if err == nil && (!partCandidate.Parent.IsZero()) {
+		if err == nil && partCandidate.Address != "" {
 			part = partCandidate
-			expiry = part.LastValid
+			expiry = part.Key.VoteLastValid
 		}
 	}
-	if part.Parent.IsZero() {
+	if part.Address == "" {
 		// Couldn't find one
-		err = fmt.Errorf("Couldn't find a participation key database for address %v valid at round %v in directory %v", address.GetUserAddress(), round, keyDir)
+		err = fmt.Errorf("couldn't find a participation key database for address %v valid at round %v in participation registry", address.GetUserAddress(), round)
 		return
 	}
 	return
@@ -117,8 +83,12 @@ func (c *Client) GenParticipationKeys(address string, firstValid, lastValid, key
 }
 
 // GenParticipationKeysTo creates a .partkey database for a given address, fills
-// it with keys, and saves it in the specified output directory.
+// it with keys, and saves it in the specified output directory. If the output
+// directory is empty, the key will be installed.
 func (c *Client) GenParticipationKeysTo(address string, firstValid, lastValid, keyDilution uint64, outDir string) (part account.Participation, filePath string, err error) {
+
+	install := outDir == ""
+
 	// Parse the address
 	parsedAddr, err := basics.UnmarshalChecksumAddress(address)
 	if err != nil {
@@ -128,15 +98,8 @@ func (c *Client) GenParticipationKeysTo(address string, firstValid, lastValid, k
 	firstRound, lastRound := basics.Round(firstValid), basics.Round(lastValid)
 
 	// If output directory wasn't specified, store it in the current ledger directory.
-	if outDir == "" {
-		// Get the GenesisID for use in the participation key path
-		var genID string
-		genID, err = c.GenesisID()
-		if err != nil {
-			return
-		}
-
-		outDir = filepath.Join(c.DataDir(), genID)
+	if install {
+		outDir = os.TempDir()
 	}
 	// Connect to the database
 	partKeyPath, err := participationKeysPath(outDir, parsedAddr, firstRound, lastRound)
@@ -165,80 +128,13 @@ func (c *Client) GenParticipationKeysTo(address string, firstValid, lastValid, k
 	newPart, err := account.FillDBWithParticipationKeys(partdb, parsedAddr, firstRound, lastRound, keyDilution)
 	part = newPart.Participation
 	partdb.Close()
+	if install {
+		_, err = c.AddParticipationKey(partKeyPath)
+	}
 	return part, partKeyPath, err
 }
 
-// InstallParticipationKeys creates a .partkey database for a given address,
-// based on an existing database from inputfile.  On successful install, it
-// deletes the input file.
-func (c *Client) InstallParticipationKeys(inputfile string) (part account.Participation, filePath string, err error) {
-	proto, ok := c.consensus[protocol.ConsensusCurrentVersion]
-	if !ok {
-		err = fmt.Errorf("Unknown consensus protocol %s", protocol.ConsensusCurrentVersion)
-		return
-	}
 
-	// Get the GenesisID for use in the participation key path
-	var genID string
-	genID, err = c.GenesisID()
-	if err != nil {
-		return
-	}
-
-	outDir := filepath.Join(c.DataDir(), genID)
-
-	inputdb, err := db.MakeErasableAccessor(inputfile)
-	if err != nil {
-		return
-	}
-	defer inputdb.Close()
-
-	partkey, err := account.RestoreParticipationWithSecrets(inputdb)
-	if err != nil {
-		return
-	}
-
-	if partkey.Parent == (basics.Address{}) {
-		err = fmt.Errorf("Cannot install partkey with missing (zero) parent address")
-		return
-	}
-
-	newdbpath, err := participationKeysPath(outDir, partkey.Parent, partkey.FirstValid, partkey.LastValid)
-	if err != nil {
-		return
-	}
-
-	newdb, err := db.MakeErasableAccessor(newdbpath)
-	if err != nil {
-		return
-	}
-
-	newpartkey := partkey
-	newpartkey.Store = newdb
-	err = newpartkey.PersistWithSecrets()
-	if err != nil {
-		newpartkey.Close()
-		return
-	}
-
-	// After successful install, remove the input copy of the
-	// partkey so that old keys cannot be recovered after they
-	// are used by algod.  We try to delete the data inside
-	// sqlite first, so the key material is zeroed out from
-	// disk blocks, but regardless of whether that works, we
-	// delete the input file.  The consensus protocol version
-	// is irrelevant for the maxuint64 round number we pass in.
-	errCh := partkey.DeleteOldKeys(basics.Round(math.MaxUint64), proto)
-	err = <-errCh
-	if err != nil {
-		newpartkey.Close()
-		return
-	}
-	os.Remove(inputfile)
-	part = newpartkey.Participation
-	newpartkey.Close()
-	return part, newdbpath, nil
-}
 
 // ListParticipationKeys returns the available participation keys,
 // as a response object.
@@ -247,51 +143,5 @@ func (c *Client) ListParticipationKeys() (partKeyFiles generated.ParticipationKe
 	if err == nil {
 		partKeyFiles, err = algod.GetParticipationKeys()
 	}
-	return
-}
-
-// ListParticipationKeyFiles returns the available participation keys,
-// as a map from database filename to Participation key object.
-func (c *Client) ListParticipationKeyFiles() (partKeyFiles map[string]account.Participation, err error) {
-	genID, err := c.GenesisID()
-	if err != nil {
-		return
-	}
-
-	// Get a list of files in the participation keys directory
-	keyDir := filepath.Join(c.DataDir(), genID)
-	files, err := ioutil.ReadDir(keyDir)
-	if err != nil {
-		return
-	}
-
-	partKeyFiles = make(map[string]account.Participation)
-	for _, file := range files {
-		// If it can't be a participation key database, skip it
-		if !config.IsPartKeyFilename(file.Name()) {
-			continue
-		}
-
-		filename := file.Name()
-
-		// Fetch a handle to this database
-		handle, err := db.MakeErasableAccessor(filepath.Join(keyDir, filename))
-		if err != nil {
-			// Couldn't open it, skip it
-			continue
-		}
-
-		// Fetch an account.Participation from the database
-		part, err := account.RestoreParticipation(handle)
-		if err != nil {
-			// Couldn't read it, skip it
-			handle.Close()
-			continue
-		}
-
-		partKeyFiles[filename] = part.Participation
-		part.Close()
-	}
-
 	return
 }

--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -19,10 +19,10 @@ package libgoal
 import (
 	"errors"
 	"fmt"
+	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
 
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
-	"github.com/algorand/go-algorand/data/account"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/protocol"
@@ -191,8 +191,51 @@ func (c *Client) SignAndBroadcastTransaction(walletHandle, pw []byte, utx transa
 	return c.BroadcastTransaction(stx)
 }
 
+// generateRegistrationTransaction returns a transaction object for registering a Participation with its parent this is
+// similar to account.Participation.GenerateRegistrationTransaction.
+func generateRegistrationTransaction(part generated.ParticipationKey, fee basics.MicroAlgos, txnFirstValid, txnLastValid basics.Round, leaseBytes [32]byte) (transactions.Transaction, error) {
+	addr, err := basics.UnmarshalChecksumAddress(part.Address)
+	if err != nil {
+		return transactions.Transaction{}, err
+	}
+
+	if len(part.Key.VoteParticipationKey) != 32 {
+		return transactions.Transaction{}, fmt.Errorf("voting key is the wrong size, should be 32 but it is %d", len(part.Key.VoteParticipationKey))
+	}
+
+	var votePk [32]byte
+	copy(votePk[:], part.Key.VoteParticipationKey[:])
+
+	if len(part.Key.SelectionParticipationKey) != 32 {
+		return transactions.Transaction{}, fmt.Errorf("selection key is the wrong size, should be 32 but it is %d", len(part.Key.VoteParticipationKey))
+	}
+
+	var selectionPk [32]byte
+	copy(selectionPk[:], part.Key.SelectionParticipationKey[:])
+
+	t := transactions.Transaction{
+		Type: protocol.KeyRegistrationTx,
+		Header: transactions.Header{
+			Sender:     addr,
+			Fee:        fee,
+			FirstValid: txnFirstValid,
+			LastValid:  txnLastValid,
+			Lease:      leaseBytes,
+		},
+		KeyregTxnFields: transactions.KeyregTxnFields{
+			VotePK:      votePk,
+			SelectionPK: selectionPk,
+		},
+	}
+	t.KeyregTxnFields.VoteFirst = basics.Round(part.Key.VoteFirstValid)
+	t.KeyregTxnFields.VoteLast = basics.Round(part.Key.VoteLastValid)
+	t.KeyregTxnFields.VoteKeyDilution = part.Key.VoteKeyDilution
+
+	return t, nil
+}
+
 // MakeUnsignedGoOnlineTx creates a transaction that will bring an address online using available participation keys
-func (c *Client) MakeUnsignedGoOnlineTx(address string, part *account.Participation, firstValid, lastValid, fee uint64, leaseBytes [32]byte) (transactions.Transaction, error) {
+func (c *Client) MakeUnsignedGoOnlineTx(address string, firstValid, lastValid, fee uint64, leaseBytes [32]byte) (transactions.Transaction, error) {
 	// Parse the address
 	parsedAddr, err := basics.UnmarshalChecksumAddress(address)
 	if err != nil {
@@ -217,19 +260,19 @@ func (c *Client) MakeUnsignedGoOnlineTx(address string, part *account.Participat
 
 	// Choose which participation keys to go online with;
 	// need to do this after filling in the round number.
-	if part == nil {
-		bestPart, err := c.chooseParticipation(parsedAddr, basics.Round(firstValid))
-		if err != nil {
-			return transactions.Transaction{}, err
-		}
-		part = &bestPart
+	part, err := c.chooseParticipation(parsedAddr, basics.Round(firstValid))
+	if err != nil {
+		return transactions.Transaction{}, err
 	}
 
 	parsedFrstValid := basics.Round(firstValid)
 	parsedLastValid := basics.Round(lastValid)
 	parsedFee := basics.MicroAlgos{Raw: fee}
 
-	goOnlineTransaction := part.GenerateRegistrationTransaction(parsedFee, parsedFrstValid, parsedLastValid, leaseBytes, cparams.EnableStateProofKeyregCheck)
+	goOnlineTransaction, err := generateRegistrationTransaction(part, parsedFee, parsedFrstValid, parsedLastValid, leaseBytes)
+	if err != nil {
+		return transactions.Transaction{}, err
+	}
 	if cparams.SupportGenesisHash {
 		var genHash crypto.Digest
 		copy(genHash[:], params.GenesisHash)

--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -19,13 +19,13 @@ package libgoal
 import (
 	"errors"
 	"fmt"
-	"github.com/algorand/go-algorand/config"
-	"github.com/algorand/go-algorand/data/account"
 
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/merklesignature"
 	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
 	"github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
+	"github.com/algorand/go-algorand/data/account"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/protocol"

--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -19,10 +19,10 @@ package libgoal
 import (
 	"errors"
 	"fmt"
-	"github.com/algorand/go-algorand/crypto/merklesignature"
-	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
 
 	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/crypto/merklesignature"
+	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
 	"github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -218,7 +218,7 @@ func generateRegistrationTransaction(part generated.ParticipationKey, fee basics
 		return transactions.Transaction{}, fmt.Errorf("state proof key pointer is nil")
 	}
 
-	if len(*part.Key.StateProofKey) != len(merklesignature.Verifier{}){
+	if len(*part.Key.StateProofKey) != len(merklesignature.Verifier{}) {
 		return transactions.Transaction{}, fmt.Errorf("state proof key is the wrong size, should be %d but it is %d", len(merklesignature.Verifier{}), len(*part.Key.StateProofKey))
 	}
 
@@ -235,16 +235,14 @@ func generateRegistrationTransaction(part generated.ParticipationKey, fee basics
 			Lease:      leaseBytes,
 		},
 		KeyregTxnFields: transactions.KeyregTxnFields{
-			VotePK:      votePk,
-			SelectionPK: selectionPk,
+			VotePK:       votePk,
+			SelectionPK:  selectionPk,
 			StateProofPK: stateProofPk,
 		},
 	}
 	t.KeyregTxnFields.VoteFirst = basics.Round(part.Key.VoteFirstValid)
 	t.KeyregTxnFields.VoteLast = basics.Round(part.Key.VoteLastValid)
 	t.KeyregTxnFields.VoteKeyDilution = part.Key.VoteKeyDilution
-
-
 
 	return t, nil
 }

--- a/test/e2e-go/features/participation/accountParticipationTransitions_test.go
+++ b/test/e2e-go/features/participation/accountParticipationTransitions_test.go
@@ -22,6 +22,7 @@ package participation
 
 import (
 	"fmt"
+	"github.com/algorand/go-algorand/data/basics"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -60,8 +61,12 @@ func registerParticipationAndWait(t *testing.T, client libgoal.Client, part acco
 	sAccount := part.Address().String()
 	sWH, err := client.GetUnencryptedWalletHandle()
 	require.NoError(t, err)
-	goOnlineTx, err := client.MakeUnsignedGoOnlineTx(sAccount, &part, txParams.LastRound+1, txParams.LastRound+1, txParams.Fee, [32]byte{})
-	require.NoError(t, err)
+	goOnlineTx := part.GenerateRegistrationTransaction(
+		basics.MicroAlgos{Raw: txParams.Fee},
+		basics.Round(txParams.LastRound+1),
+		basics.Round(txParams.LastRound+1),
+		[32]byte{},
+		true)
 	require.Equal(t, sAccount, goOnlineTx.Src().String())
 	onlineTxID, err := client.SignAndBroadcastTransaction(sWH, nil, goOnlineTx)
 	require.NoError(t, err)

--- a/test/e2e-go/features/participation/accountParticipationTransitions_test.go
+++ b/test/e2e-go/features/participation/accountParticipationTransitions_test.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
 	"github.com/algorand/go-algorand/data/account"
-	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/libgoal"
 	"github.com/algorand/go-algorand/test/framework/fixtures"
 	"github.com/algorand/go-algorand/test/partitiontest"
@@ -61,12 +60,8 @@ func registerParticipationAndWait(t *testing.T, client libgoal.Client, part acco
 	sAccount := part.Address().String()
 	sWH, err := client.GetUnencryptedWalletHandle()
 	require.NoError(t, err)
-	goOnlineTx := part.GenerateRegistrationTransaction(
-		basics.MicroAlgos{Raw: txParams.Fee},
-		basics.Round(txParams.LastRound+1),
-		basics.Round(txParams.LastRound+1),
-		[32]byte{},
-		true)
+	goOnlineTx, err := client.MakeRegistrationTransactionWithGenesisID(part, txParams.Fee, txParams.LastRound+1, txParams.LastRound+1, [32]byte{}, true)
+	assert.NoError(t, err)
 	require.Equal(t, sAccount, goOnlineTx.Src().String())
 	onlineTxID, err := client.SignAndBroadcastTransaction(sWH, nil, goOnlineTx)
 	require.NoError(t, err)

--- a/test/e2e-go/features/participation/accountParticipationTransitions_test.go
+++ b/test/e2e-go/features/participation/accountParticipationTransitions_test.go
@@ -22,7 +22,6 @@ package participation
 
 import (
 	"fmt"
-	"github.com/algorand/go-algorand/data/basics"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -34,6 +33,7 @@ import (
 
 	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
 	"github.com/algorand/go-algorand/data/account"
+	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/libgoal"
 	"github.com/algorand/go-algorand/test/framework/fixtures"
 	"github.com/algorand/go-algorand/test/partitiontest"

--- a/test/e2e-go/features/participation/onlineOfflineParticipation_test.go
+++ b/test/e2e-go/features/participation/onlineOfflineParticipation_test.go
@@ -181,7 +181,11 @@ func TestNewAccountCanGoOnlineAndParticipate(t *testing.T) {
 	a.NoError(err, "rest client should be able to add participation key to new account")
 	a.Equal(newAccount, partkeyResponse.Parent.String(), "partkey response should echo queried account")
 	// account uses part key to go online
-	goOnlineTx, err := client.MakeUnsignedGoOnlineTx(newAccount, &partkeyResponse, 0, 0, transactionFee, [32]byte{})
+	goOnlineTx := partkeyResponse.GenerateRegistrationTransaction(
+		basics.MicroAlgos{Raw: transactionFee},
+		basics.Round(0),
+		basics.Round(0),
+		[32]byte{}, true)
 	a.NoError(err, "should be able to make go online tx")
 	a.Equal(newAccount, goOnlineTx.Src().String(), "go online response should echo queried account")
 	onlineTxID, err := client.SignAndBroadcastTransaction(wh, nil, goOnlineTx)
@@ -290,7 +294,11 @@ func TestAccountGoesOnlineForShortPeriod(t *testing.T) {
 	a.NoError(err, "rest client should be able to add participation key to new account")
 	a.Equal(newAccount, partkeyResponse.Parent.String(), "partkey response should echo queried account")
 	// account uses part key to go online
-	goOnlineTx, err := client.MakeUnsignedGoOnlineTx(newAccount, &partkeyResponse, partKeyFirstValid, partKeyLastValid, transactionFee, [32]byte{})
+	goOnlineTx := partkeyResponse.GenerateRegistrationTransaction(
+		basics.MicroAlgos{Raw: transactionFee},
+		basics.Round(0),
+		basics.Round(0),
+		[32]byte{}, true)
 	a.Equal(goOnlineTx.KeyregTxnFields.StateProofPK.IsEmpty(), false, "stateproof key should not be zero")
 	a.NoError(err, "should be able to make go online tx")
 	a.Equal(newAccount, goOnlineTx.Src().String(), "go online response should echo queried account")

--- a/test/e2e-go/features/participation/onlineOfflineParticipation_test.go
+++ b/test/e2e-go/features/participation/onlineOfflineParticipation_test.go
@@ -188,22 +188,7 @@ func TestNewAccountCanGoOnlineAndParticipate(t *testing.T) {
 	a.NoError(err, "rest client should be able to add participation key to new account")
 	a.Equal(newAccount, partkeyResponse.Parent.String(), "partkey response should echo queried account")
 	// account uses part key to go online
-	goOnlineTx := partkeyResponse.GenerateRegistrationTransaction(
-		basics.MicroAlgos{Raw: transactionFee},
-		basics.Round(partKeyFirstValid),
-		basics.Round(partKeyLastValid),
-		[32]byte{}, true)
-
-	txnParams, err := client.SuggestedParams()
-	a.NoError(err, "no error grabbing the genesis id")
-
-	goOnlineTx.Header.GenesisID = txnParams.GenesisID
-
-	// Check if the protocol supports genesis hash
-	if config.Consensus[protocol.ConsensusFuture].SupportGenesisHash {
-		copy(goOnlineTx.Header.GenesisHash[:], txnParams.GenesisHash)
-	}
-
+	goOnlineTx, err := client.MakeRegistrationTransactionWithGenesisID(partkeyResponse, transactionFee, partKeyFirstValid, partKeyLastValid, [32]byte{}, true)
 	a.NoError(err, "should be able to make go online tx")
 	a.Equal(newAccount, goOnlineTx.Src().String(), "go online response should echo queried account")
 	onlineTxID, err := client.SignAndBroadcastTransaction(wh, nil, goOnlineTx)
@@ -312,22 +297,8 @@ func TestAccountGoesOnlineForShortPeriod(t *testing.T) {
 	a.NoError(err, "rest client should be able to add participation key to new account")
 	a.Equal(newAccount, partkeyResponse.Parent.String(), "partkey response should echo queried account")
 	// account uses part key to go online
-	goOnlineTx := partkeyResponse.GenerateRegistrationTransaction(
-		basics.MicroAlgos{Raw: transactionFee},
-		basics.Round(partKeyFirstValid),
-		basics.Round(partKeyLastValid),
-		[32]byte{}, true)
-
-	params, err := client.SuggestedParams()
-	a.NoError(err, "no error grabbing the genesis id")
-
-	goOnlineTx.Header.GenesisID = params.GenesisID
-
-	// Check if the protocol supports genesis hash
-	if config.Consensus[protocol.ConsensusFuture].SupportGenesisHash {
-		copy(goOnlineTx.Header.GenesisHash[:], params.GenesisHash)
-	}
-
+	goOnlineTx, err := client.MakeRegistrationTransactionWithGenesisID(partkeyResponse, transactionFee, partKeyFirstValid, partKeyLastValid, [32]byte{}, true)
+	a.NoError(err)
 	a.Equal(goOnlineTx.KeyregTxnFields.StateProofPK.IsEmpty(), false, "stateproof key should not be zero")
 	a.NoError(err, "should be able to make go online tx")
 	a.Equal(newAccount, goOnlineTx.Src().String(), "go online response should echo queried account")

--- a/test/e2e-go/features/participation/participationExpiration_test.go
+++ b/test/e2e-go/features/participation/participationExpiration_test.go
@@ -84,8 +84,11 @@ func testExpirationAccounts(t *testing.T, fixture *fixtures.RestClientFixture, f
 		a.Equal(sAccount, partkeyResponse.Parent.String())
 
 		// account uses part key to go online
-		goOnlineTx, err := sClient.MakeUnsignedGoOnlineTx(sAccount, &partkeyResponse, 0, 0, transactionFee, [32]byte{})
-		a.NoError(err)
+		goOnlineTx := partkeyResponse.GenerateRegistrationTransaction(
+			basics.MicroAlgos{Raw: transactionFee},
+			basics.Round(0),
+			basics.Round(0),
+			[32]byte{}, true)
 
 		a.Equal(sAccount, goOnlineTx.Src().String())
 		onlineTxID, err = sClient.SignAndBroadcastTransaction(sWH, nil, goOnlineTx)

--- a/test/e2e-go/features/participation/participationExpiration_test.go
+++ b/test/e2e-go/features/participation/participationExpiration_test.go
@@ -84,11 +84,8 @@ func testExpirationAccounts(t *testing.T, fixture *fixtures.RestClientFixture, f
 		a.Equal(sAccount, partkeyResponse.Parent.String())
 
 		// account uses part key to go online
-		goOnlineTx := partkeyResponse.GenerateRegistrationTransaction(
-			basics.MicroAlgos{Raw: transactionFee},
-			basics.Round(0),
-			basics.Round(0),
-			[32]byte{}, true)
+		goOnlineTx, err := sClient.MakeRegistrationTransactionWithGenesisID(partkeyResponse, transactionFee, 0, 0, [32]byte{}, true)
+		a.NoError(err)
 
 		a.Equal(sAccount, goOnlineTx.Src().String())
 		onlineTxID, err = sClient.SignAndBroadcastTransaction(sWH, nil, goOnlineTx)

--- a/test/e2e-go/features/transactions/onlineStatusChange_test.go
+++ b/test/e2e-go/features/transactions/onlineStatusChange_test.go
@@ -18,6 +18,8 @@ package transactions
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -86,7 +88,7 @@ func testAccountsCanChangeOnlineState(t *testing.T, templatePath string) {
 	a.NoError(err, "should be no errors when creating partkeys")
 	a.Equal(initiallyOffline, partkeyResponse.Address().String(), "successful partkey creation should echo account")
 
-	goOnlineUTx, err := client.MakeUnsignedGoOnlineTx(initiallyOffline, nil, curRound, curRound+transactionValidityPeriod, transactionFee, [32]byte{})
+	goOnlineUTx, err := client.MakeUnsignedGoOnlineTx(initiallyOffline, curRound, curRound+transactionValidityPeriod, transactionFee, [32]byte{})
 	a.NoError(err, "should be able to make go online tx")
 	wh, err := client.GetUnencryptedWalletHandle()
 	a.NoError(err, "should be able to get unencrypted wallet handle")
@@ -168,13 +170,20 @@ func TestCloseOnError(t *testing.T) {
 	// get the current round for partkey creation
 	_, curRound := fixture.GetBalanceAndRound(initiallyOnline)
 
+	tempDir, err := ioutil.TempDir(os.TempDir(), "test-close-on-error")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	var partkeyFile string
+	_, partkeyFile, err = client.GenParticipationKeysTo(initiallyOffline, 0, curRound+1000, 0, tempDir)
+
 	// make a participation key for initiallyOffline
-	_, _, err = client.GenParticipationKeys(initiallyOffline, 0, curRound+1000, 0)
+	_, err = client.AddParticipationKey(partkeyFile)
 	a.NoError(err)
 	// check duplicate keys does not crash
-	_, _, err = client.GenParticipationKeys(initiallyOffline, 0, curRound+1000, 0)
-	errMsg := fmt.Sprintf("ParticipationKeys exist for the range 0 to %d", curRound+1000)
-	a.Equal(errMsg, err.Error())
+	_, err = client.AddParticipationKey(partkeyFile)
+	a.Error(err)
+	a.Contains(err.Error(), "cannot register duplicate participation key")
 	// check lastValid < firstValid does not crash
 	_, _, err = client.GenParticipationKeys(initiallyOffline, curRound+1001, curRound+1000, 0)
 	expected := fmt.Sprintf("FillDBWithParticipationKeys: firstValid %d is after lastValid %d", int(curRound+1001), int(curRound+1000))

--- a/test/e2e-go/stress/transactions/createManyAndGoOnline_test.go
+++ b/test/e2e-go/stress/transactions/createManyAndGoOnline_test.go
@@ -128,7 +128,7 @@ func TestManyAccountsCanGoOnline(t *testing.T) {
 		partkeyResponse, _, err := client.GenParticipationKeys(account, curRound-10, curRound+1000, 0)
 		a.NoError(err, "should be no errors when creating many partkeys, creation number %v", i)
 		a.Equal(account, partkeyResponse.Address, "successful partkey creation should echo account")
-		goOnlineUTx, err := client.MakeUnsignedGoOnlineTx(account, nil, curRound, curRound+transactionValidityPeriod, transactionFee, [32]byte{})
+		goOnlineUTx, err := client.MakeUnsignedGoOnlineTx(account, curRound, curRound+transactionValidityPeriod, transactionFee, [32]byte{})
 		a.NoError(err, "should be able to make go online tx %v", i)
 		wh, err := client.GetUnencryptedWalletHandle()
 		a.NoError(err, "should be able to get unencrypted wallet handle")
@@ -149,7 +149,7 @@ func TestManyAccountsCanGoOnline(t *testing.T) {
 		a.NoError(err, "should be no errors when creating many partkeys, creation number %v", i)
 		a.Equal(account, partkeyResponse.Address, "successful partkey creation should echo account")
 
-		goOnlineUTx, err := client.MakeUnsignedGoOnlineTx(account, nil, curRound, curRound+transactionValidityPeriod, transactionFee, [32]byte{})
+		goOnlineUTx, err := client.MakeUnsignedGoOnlineTx(account, curRound, curRound+transactionValidityPeriod, transactionFee, [32]byte{})
 		a.NoError(err, "should be able to make go online tx %v", i)
 		wh, err := client.GetUnencryptedWalletHandle()
 		a.NoError(err, "should be able to get unencrypted wallet handle")

--- a/test/scripts/e2e_subs/goal-partkey-commands.sh
+++ b/test/scripts/e2e_subs/goal-partkey-commands.sh
@@ -63,7 +63,7 @@ verify_registered_state () {
   fi
 
   # looking for yes/no, and the 8 character head of participation id in this line:
-  # yes         LFMT...RHJQ  4UPT6AQC...               4            0     3000000
+  # yes         LFMT...RHJQ  4UPT6AQC...               4            0     3000
   if ! goal account listpartkeys | grep -q "$1.*$(echo "$2" | cut -c1-8)\.\.\."; then
     fail_test "Unexpected key state: $3"
   fi

--- a/test/scripts/e2e_subs/goal-partkey-commands.sh
+++ b/test/scripts/e2e_subs/goal-partkey-commands.sh
@@ -45,3 +45,54 @@ if [[ "$OUTPUT" != "2" ]]; then echo "Two Participation IDs should have been fou
 OUTPUT=$(goal account listpartkeys -d "$ALGORAND_DATA" -d "$ALGORAND_DATA2" 2>&1)
 EXPECTED_ERR="Only one data directory can be specified for this command."
 if [[ "$OUTPUT" != "$EXPECTED_ERR" ]]; then echo -e "Unexpected output from multiple data directories with 'listpartkeys': \n$OUTPUT"; exit 1; fi
+
+create_and_fund_account () {
+  local TEMP_ACCT=$(${gcmd} account new|awk '{ print $6 }')
+  ${gcmd} clerk send -f "$INITIAL_ACCOUNT" -t "$TEMP_ACCT" -a 1000000 > /dev/null
+  echo "$TEMP_ACCT"
+}
+
+# given key should be installed and have the expected yes/no state
+# $1 - yes or no
+# $2 - a participation id
+# $3 - error message
+verify_registered_state () {
+  # look for participation ID anywhere in the partkeyinfo output
+  if ! goal account partkeyinfo | grep -q "$2"; then
+    fail_test "Key was not installed properly: $3"
+  fi
+
+  # looking for yes/no, and the 8 character head of participation id in this line:
+  # yes         LFMT...RHJQ  4UPT6AQC...               4            0     3000000
+  if ! goal account listpartkeys | grep -q "$1.*$(echo "$2" | cut -c1-8)\.\.\."; then
+    fail_test "Unexpected key state: $3"
+  fi
+}
+
+# goal account installpartkey
+# install manually generated participation keys (do not register)
+NEW_ACCOUNT_1=$(create_and_fund_account)
+algokey part generate --keyfile test_partkey --first 0 --last 3000 --parent "$NEW_ACCOUNT_1"
+PARTICIPATION_ID_1=$(goal account installpartkey --delete-input --partkey test_partkey|awk '{ print $7 }')
+verify_registered_state "no" "$PARTICIPATION_ID_1" "goal account installpartkey"
+
+# goal account addpartkey
+# generate and install participation keys (do not register)
+NEW_ACCOUNT_2=$(create_and_fund_account)
+PARTICIPATION_ID_2=$(goal account addpartkey -a "$NEW_ACCOUNT_2" --roundFirstValid 0 --roundLastValid 3000|awk '{ print $7 }')
+verify_registered_state "no" "$PARTICIPATION_ID_2" "goal account addpartkey"
+
+# goal account renewpartkeys
+# generate, install, and register
+NEW_ACCOUNT_3=$(create_and_fund_account)
+PARTICIPATION_ID_3=$(${gcmd} account renewpartkey --roundLastValid 3000 -a "$NEW_ACCOUNT_3"|tail -n 1|awk '{ print $7 }')
+verify_registered_state "yes" "$PARTICIPATION_ID_3" "goal account renewpartkey"
+
+# goal account changeonlinstatus (--account)
+verify_registered_state "no" "$PARTICIPATION_ID_1" "goal account installpartkey (before)"
+${gcmd} account changeonlinestatus -a "$NEW_ACCOUNT_1"
+verify_registered_state "yes" "$PARTICIPATION_ID_1" "goal account installpartkey (after)"
+
+# goal account renewallpartkeys
+# goal account changeonlinstatus (--partkey)
+# These do not work as I expected them to. Do they work? I don't know, we should try to remove it.


### PR DESCRIPTION
Resolves #2594

Goal account commands now use the REST API

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
