### PR TITLE
build: Add install_buildtools.sh to check_deps.sh error message

### DIFF
--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -70,7 +70,7 @@ if [ $MISSING -eq 0 ]
 then
     echo "$GREEN_FG[$0]$END_FG_COLOR Required dependencies installed."
 else
-    echo -e "$RED_FG[$0]$END_FG_COLOR Required dependencies missing. Run \`${TEAL_FG}./scripts/configure_dev.sh$END_FG_COLOR\` to install."
+    echo -e "$RED_FG[$0]$END_FG_COLOR Required dependencies missing. Run \`${TEAL_FG}./scripts/configure_dev.sh$END_FG_COLOR\` and/or \`${TEAL_FG}./scripts/buildtools/install_buildtools.sh$END_FG_COLOR\` to install."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Adds `scripts/buildtools/install_buildtools.sh` to the list of suggested remediations when `check_deps.sh` fails.


## Test Plan

`golint`, `stringer`, and `msgp` are checked via this script, but are installed by `install_buildtools.sh` and not `configure_dev.sh`.
