### PR TITLE
crypto: Variable-time implementation of VRF verify

### DIFF
--- a/crypto/libsodium-fork/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c
+++ b/crypto/libsodium-fork/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c
@@ -803,6 +803,246 @@ ge25519_double_scalarmult_vartime(ge25519_p2 *r, const unsigned char *a,
     }
 }
 
+/*
+ r = - a * A + b * B
+ where a = a[0]+256*a[1]+...+256^31 a[31].
+ and b = b[0]+256*b[1]+...+256^31 b[31].
+ B is the Ed25519 base point (x,4/5) with x positive.
+
+ Only used for VRF verification.
+
+ Same as ge25519_double_scalarmult_vartime
+ but with a minus "-" before a
+ */
+
+void
+ge25519_double_sub_scalarmult_vartime(ge25519_p2 *r, const unsigned char *a,
+                                  const ge25519_p3 *A, const unsigned char *b)
+{
+    static const ge25519_precomp Bi[8] = {
+#ifdef HAVE_TI_MODE
+# include "fe_51/base2.h"
+#else
+# include "fe_25_5/base2.h"
+#endif
+    };
+    signed char    aslide[256];
+    signed char    bslide[256];
+    ge25519_cached Ai[8]; /* A,3A,5A,7A,9A,11A,13A,15A */
+    ge25519_p1p1   t;
+    ge25519_p3     u;
+    ge25519_p3     A2;
+    int            i;
+
+    slide_vartime(aslide, a);
+    slide_vartime(bslide, b);
+
+    ge25519_p3_to_cached(&Ai[0], A);
+
+    ge25519_p3_dbl(&t, A);
+    ge25519_p1p1_to_p3(&A2, &t);
+
+    ge25519_add(&t, &A2, &Ai[0]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Ai[1], &u);
+
+    ge25519_add(&t, &A2, &Ai[1]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Ai[2], &u);
+
+    ge25519_add(&t, &A2, &Ai[2]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Ai[3], &u);
+
+    ge25519_add(&t, &A2, &Ai[3]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Ai[4], &u);
+
+    ge25519_add(&t, &A2, &Ai[4]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Ai[5], &u);
+
+    ge25519_add(&t, &A2, &Ai[5]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Ai[6], &u);
+
+    ge25519_add(&t, &A2, &Ai[6]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Ai[7], &u);
+
+    ge25519_p2_0(r);
+
+    for (i = 255; i >= 0; --i) {
+        if (aslide[i] || bslide[i]) {
+            break;
+        }
+    }
+
+    for (; i >= 0; --i) {
+        ge25519_p2_dbl(&t, r);
+
+        if (aslide[i] > 0) {
+            ge25519_p1p1_to_p3(&u, &t);
+            // this is where we do -a * A, instead of a * A
+            // we use sub instead of add
+            ge25519_sub(&t, &u, &Ai[aslide[i] / 2]);
+        } else if (aslide[i] < 0) {
+            ge25519_p1p1_to_p3(&u, &t);
+            // this is where we do -a * A, instead of a * A
+            // we use add instead of sub
+            ge25519_add(&t, &u, &Ai[(-aslide[i]) / 2]);
+        }
+
+        if (bslide[i] > 0) {
+            ge25519_p1p1_to_p3(&u, &t);
+            ge25519_madd(&t, &u, &Bi[bslide[i] / 2]);
+        } else if (bslide[i] < 0) {
+            ge25519_p1p1_to_p3(&u, &t);
+            ge25519_msub(&t, &u, &Bi[(-bslide[i]) / 2]);
+        }
+
+        ge25519_p1p1_to_p2(r, &t);
+    }
+}
+
+/*
+ r = - a * A + b * B
+ where a = a[0]+256*a[1]+...+256^31 a[31].
+ and b = b[0]+256*b[1]+...+256^31 b[31].
+ where contrary to
+ ge25519_double_sub_scalarmult_vartime
+ B is not necessarily the base
+
+ Non-constant time
+
+ Only used for VRF verification.
+ */
+
+void
+ge25519_double_sub_nonbase_scalarmult_vartime(ge25519_p2 *r, const unsigned char *a,
+                                  const ge25519_p3 *A, const unsigned char *b,
+                                  const ge25519_p3 *B)
+{
+    signed char    aslide[256];
+    signed char    bslide[256];
+    ge25519_cached Ai[8]; /* A,3A,5A,7A,9A,11A,13A,15A */
+    ge25519_cached Bi[8]; /* B,3B,5B,7B,9B,11B,13B,15B */
+    ge25519_p1p1   t;
+    ge25519_p3     u;
+    ge25519_p3     A2, B2;
+    int            i;
+
+    slide_vartime(aslide, a);
+    slide_vartime(bslide, b);
+
+    // Compute Ai
+
+    ge25519_p3_to_cached(&Ai[0], A);
+
+    ge25519_p3_dbl(&t, A);
+    ge25519_p1p1_to_p3(&A2, &t);
+
+    ge25519_add(&t, &A2, &Ai[0]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Ai[1], &u);
+
+    ge25519_add(&t, &A2, &Ai[1]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Ai[2], &u);
+
+    ge25519_add(&t, &A2, &Ai[2]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Ai[3], &u);
+
+    ge25519_add(&t, &A2, &Ai[3]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Ai[4], &u);
+
+    ge25519_add(&t, &A2, &Ai[4]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Ai[5], &u);
+
+    ge25519_add(&t, &A2, &Ai[5]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Ai[6], &u);
+
+    ge25519_add(&t, &A2, &Ai[6]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Ai[7], &u);
+
+    // Compute Bi (same as Ai)
+    // This looks to me like too much copy-pasting
+    // but libsodium contains such copy-pasting
+    // all over the place so I'm keeping it this way
+
+    ge25519_p3_to_cached(&Bi[0], B);
+
+    ge25519_p3_dbl(&t, B);
+    ge25519_p1p1_to_p3(&B2, &t);
+
+    ge25519_add(&t, &B2, &Bi[0]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Bi[1], &u);
+
+    ge25519_add(&t, &B2, &Bi[1]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Bi[2], &u);
+
+    ge25519_add(&t, &B2, &Bi[2]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Bi[3], &u);
+
+    ge25519_add(&t, &B2, &Bi[3]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Bi[4], &u);
+
+    ge25519_add(&t, &B2, &Bi[4]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Bi[5], &u);
+
+    ge25519_add(&t, &B2, &Bi[5]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Bi[6], &u);
+
+    ge25519_add(&t, &B2, &Bi[6]);
+    ge25519_p1p1_to_p3(&u, &t);
+    ge25519_p3_to_cached(&Bi[7], &u);
+
+    ge25519_p2_0(r);
+
+    for (i = 255; i >= 0; --i) {
+        if (aslide[i] || bslide[i]) {
+            break;
+        }
+    }
+
+    for (; i >= 0; --i) {
+        ge25519_p2_dbl(&t, r);
+
+        if (aslide[i] > 0) {
+            ge25519_p1p1_to_p3(&u, &t);
+            // this is where we do -a * A, instead of a * A
+            // we use sub instead of add
+            ge25519_sub(&t, &u, &Ai[aslide[i] / 2]);
+        } else if (aslide[i] < 0) {
+            ge25519_p1p1_to_p3(&u, &t);
+            // this is where we do -a * A, instead of a * A
+            // we use add instead of sub
+            ge25519_add(&t, &u, &Ai[(-aslide[i]) / 2]);
+        }
+
+        if (bslide[i] > 0) {
+            ge25519_p1p1_to_p3(&u, &t);
+            ge25519_add(&t, &u, &Bi[bslide[i] / 2]);
+        } else if (bslide[i] < 0) {
+            ge25519_p1p1_to_p3(&u, &t);
+            ge25519_sub(&t, &u, &Bi[(-bslide[i]) / 2]);
+        }
+
+        ge25519_p1p1_to_p2(r, &t);
+    }
+}
+
 
 /*
  r = a * A + b * B

--- a/crypto/libsodium-fork/src/libsodium/crypto_vrf/crypto_vrf.c
+++ b/crypto/libsodium-fork/src/libsodium/crypto_vrf/crypto_vrf.c
@@ -45,7 +45,7 @@ crypto_vrf_keypair(unsigned char *pk, unsigned char *sk)
 
 int
 crypto_vrf_keypair_from_seed(unsigned char *pk, unsigned char *sk,
-			     const unsigned char *seed)
+                             const unsigned char *seed)
 {
     return crypto_vrf_ietfdraft03_keypair_from_seed(pk, sk, seed);
 }
@@ -58,17 +58,25 @@ crypto_vrf_is_valid_key(const unsigned char *pk)
 
 int
 crypto_vrf_prove(unsigned char *proof, const unsigned char *skpk,
-		 const unsigned char *m, const unsigned long long mlen)
+                 const unsigned char *m, const unsigned long long mlen)
 {
     return crypto_vrf_ietfdraft03_prove(proof, skpk, m, mlen);
 }
 
 int
 crypto_vrf_verify(unsigned char *output, const unsigned char *pk,
-		  const unsigned char *proof, const unsigned char *m,
-		  const unsigned long long mlen)
+                  const unsigned char *proof, const unsigned char *m,
+                  const unsigned long long mlen)
 {
     return crypto_vrf_ietfdraft03_verify(output, pk, proof, m, mlen);
+}
+
+int
+crypto_vrf_verify_vartime(unsigned char *output, const unsigned char *pk,
+                          const unsigned char *proof, const unsigned char *m,
+                          const unsigned long long mlen)
+{
+    return crypto_vrf_ietfdraft03_verify_vartime(output, pk, proof, m, mlen);
 }
 
 int

--- a/crypto/libsodium-fork/src/libsodium/crypto_vrf/ietfdraft03/convert.c
+++ b/crypto/libsodium-fork/src/libsodium/crypto_vrf/ietfdraft03/convert.c
@@ -39,6 +39,14 @@ _vrf_ietfdraft03_point_to_string(unsigned char string[32], const ge25519_p3 *poi
     ge25519_p3_tobytes(string, point);
 }
 
+/* Same as _vrf_ietfdraft03_point_to_string but for p2 points instead
+ */
+void
+_vrf_ietfdraft03_point_p2_to_string(unsigned char string[32], const ge25519_p2 *point)
+{
+    ge25519_tobytes(string, point);
+}
+
 /* Decode elliptic curve point from 32-byte octet string per RFC8032 section
  * 5.1.3.
  *
@@ -101,6 +109,26 @@ _vrf_ietfdraft03_hash_points(unsigned char c[16], const ge25519_p3 *P1,
     _vrf_ietfdraft03_point_to_string(str+2+32*1, P2);
     _vrf_ietfdraft03_point_to_string(str+2+32*2, P3);
     _vrf_ietfdraft03_point_to_string(str+2+32*3, P4);
+    crypto_hash_sha512(c1, str, sizeof str);
+    memmove(c, c1, 16);
+    sodium_memzero(c1, 64);
+}
+
+/* Same as _vrf_ietfdraft03_hash_points but for ge25519_p2 points instead
+ * for the last two points */
+void
+_vrf_ietfdraft03_hash_points_p3p2(unsigned char c[16], const ge25519_p3 *P1,
+                                const ge25519_p3 *P2, const ge25519_p2 *P3,
+                                const ge25519_p2 *P4)
+{
+    unsigned char str[2+32*4], c1[64];
+
+    str[0] = SUITE;
+    str[1] = TWO;
+    _vrf_ietfdraft03_point_to_string(str+2+32*0, P1);
+    _vrf_ietfdraft03_point_to_string(str+2+32*1, P2);
+    _vrf_ietfdraft03_point_p2_to_string(str+2+32*2, P3);
+    _vrf_ietfdraft03_point_p2_to_string(str+2+32*3, P4);
     crypto_hash_sha512(c1, str, sizeof str);
     memmove(c, c1, 16);
     sodium_memzero(c1, 64);

--- a/crypto/libsodium-fork/src/libsodium/crypto_vrf/ietfdraft03/vrf_ietfdraft03.h
+++ b/crypto/libsodium-fork/src/libsodium/crypto_vrf/ietfdraft03/vrf_ietfdraft03.h
@@ -26,22 +26,26 @@ SOFTWARE.
 static const unsigned char SUITE = 0x04; /* ECVRF-ED25519-SHA512-Elligator2 */
 
 void _vrf_ietfdraft03_point_to_string(unsigned char string[32],
-				      const ge25519_p3 *point);
+                                      const ge25519_p3 *point);
 
 int _vrf_ietfdraft03_string_to_point(ge25519_p3 *point,
-				     const unsigned char string[32]);
+                                     const unsigned char string[32]);
 
 int _vrf_ietfdraft03_decode_proof(ge25519_p3 *Gamma, unsigned char c[16],
-				  unsigned char s[32],
-				  const unsigned char pi[80]);
+                                  unsigned char s[32],
+                                  const unsigned char pi[80]);
 
 void _vrf_ietfdraft03_hash_to_curve_elligator2_25519(unsigned char H_string[32],
-						     const ge25519_p3 *Y_point,
-						     const unsigned char *alpha,
-						     const unsigned long long alphalen);
+                                                     const ge25519_p3 *Y_point,
+                                                     const unsigned char *alpha,
+                                                     const unsigned long long alphalen);
 
 void _vrf_ietfdraft03_hash_points(unsigned char c[16], const ge25519_p3 *P1,
-				  const ge25519_p3 *P2, const ge25519_p3 *P3,
-				  const ge25519_p3 *P4);
+                                  const ge25519_p3 *P2, const ge25519_p3 *P3,
+                                  const ge25519_p3 *P4);
+
+void _vrf_ietfdraft03_hash_points_p3p2(unsigned char c[16], const ge25519_p3 *P1,
+                                       const ge25519_p3 *P2, const ge25519_p2 *P3,
+                                       const ge25519_p2 *P4);
 
 #endif

--- a/crypto/libsodium-fork/src/libsodium/include/sodium/crypto_vrf.h
+++ b/crypto/libsodium-fork/src/libsodium/include/sodium/crypto_vrf.h
@@ -50,22 +50,29 @@ int crypto_vrf_keypair(unsigned char *pk, unsigned char *sk);
 
 SODIUM_EXPORT
 int crypto_vrf_keypair_from_seed(unsigned char *pk, unsigned char *sk,
-				 const unsigned char *seed);
+                                 const unsigned char *seed);
 
 SODIUM_EXPORT
 int crypto_vrf_is_valid_key(const unsigned char *pk)
-            __attribute__ ((warn_unused_result));
+__attribute__ ((warn_unused_result));
 
 SODIUM_EXPORT
 int crypto_vrf_prove(unsigned char *proof, const unsigned char *sk,
-		     const unsigned char *m, unsigned long long mlen);
+                     const unsigned char *m, unsigned long long mlen);
 
 SODIUM_EXPORT
 int crypto_vrf_verify(unsigned char *output,
-		      const unsigned char *pk,
-		      const unsigned char *proof,
-		      const unsigned char *m, unsigned long long mlen)
-            __attribute__ ((warn_unused_result));
+                      const unsigned char *pk,
+                      const unsigned char *proof,
+                      const unsigned char *m, unsigned long long mlen)
+__attribute__ ((warn_unused_result));
+
+SODIUM_EXPORT
+int crypto_vrf_verify_vartime(unsigned char *output,
+                              const unsigned char *pk,
+                              const unsigned char *proof,
+                              const unsigned char *m, unsigned long long mlen)
+__attribute__ ((warn_unused_result));
 
 SODIUM_EXPORT
 int crypto_vrf_proof_to_hash(unsigned char *hash, const unsigned char *proof);

--- a/crypto/libsodium-fork/src/libsodium/include/sodium/crypto_vrf_ietfdraft03.h
+++ b/crypto/libsodium-fork/src/libsodium/include/sodium/crypto_vrf_ietfdraft03.h
@@ -98,6 +98,17 @@ int crypto_vrf_ietfdraft03_verify(unsigned char *output,
 				  unsigned long long mlen)
             __attribute__ ((warn_unused_result));
 
+// Verify a VRF proof (for a given a public key and message) and validate the
+// public key like crypto_vrf_ietfdraft03_verify except the verification
+// is not ensured to take a constant time
+SODIUM_EXPORT
+int crypto_vrf_ietfdraft03_verify_vartime(unsigned char *output,
+                   const unsigned char *pk,
+                   const unsigned char *proof,
+                   const unsigned char *m,
+                   unsigned long long mlen)
+             __attribute__ ((warn_unused_result));
+
 // Convert a VRF proof to a VRF output.
 //
 // This function does not verify the proof.

--- a/crypto/libsodium-fork/src/libsodium/include/sodium/private/ed25519_ref10.h
+++ b/crypto/libsodium-fork/src/libsodium/include/sodium/private/ed25519_ref10.h
@@ -107,6 +107,13 @@ void ge25519_double_scalarmult_vartime(ge25519_p2 *r, const unsigned char *a,
                                        const ge25519_p3 *A,
                                        const unsigned char *b);
 
+void ge25519_double_sub_scalarmult_vartime(ge25519_p2 *r, const unsigned char *a,
+                                           const ge25519_p3 *A, const unsigned char *b);
+
+void ge25519_double_sub_nonbase_scalarmult_vartime(ge25519_p2 *r, const unsigned char *a,
+                                                   const ge25519_p3 *A, const unsigned char *b,
+                                                   const ge25519_p3 *B);
+
 void ge25519_double_scalarmult_vartime_p3(ge25519_p3 *r, const unsigned char *a,
                                           const ge25519_p3 *A,
                                           const unsigned char *b);

--- a/crypto/libsodium-fork/test/default/vrf.c
+++ b/crypto/libsodium-fork/test/default/vrf.c
@@ -1,5 +1,6 @@
 
 #define TEST_NAME "vrf"
+
 #include "cmptest.h"
 
 typedef struct TestData_ {
@@ -44,10 +45,11 @@ static const TestData test_data[] = {
 {{0xac,0x21,0xb0,0x30,0x3e,0xd8,0xb5,0x12,0x3a,0xe3,0xbf,0x13,0xf2,0xc6,0x27,0xdc,0x9b,0x9c,0x2e,0x04,0xcf,0x1c,0x73,0x23,0x64,0xcf,0xe4,0x72,0xa5,0xf1,0x45,0xc2},{0x5b,0x14,0xfd,0xe6,0xdb,0x37,0xa5,0x30,0x2f,0x01,0x50,0xa7,0x3f,0x6a,0xda,0x5a,0x05,0xa8,0x10,0xa2,0x4c,0x65,0x64,0x82,0xcb,0xde,0xb5,0x10,0x20,0xe9,0x2f,0xe7},{0x31,0xcd,0xab,0x62,0x0b,0xdf,0x82,0x31,0xab,0xce,0xe3,0x2d,0x61,0x5a,0xf3,0x46,0x49,0xe6,0x9b,0x13,0x22,0x86,0xcc,0x59,0xf9,0x50,0xf2,0x35,0x52,0x84,0xd9,0x53,0xa6,0xb7,0xea,0x97,0x5a,0x2f,0xd8,0x9a,0xf4,0x43,0xa1,0x5c,0x07,0x63,0x99,0xf3,0x90,0xc9,0x4a,0x6a,0xa3,0xf5,0xdb,0xf8,0xe1,0x57,0x67,0x80,0xa7,0xe1,0x6f,0xa4,0x8c,0x3a,0x09,0x59,0x72,0xac,0x3a,0xb1,0xe1,0xaa,0x07,0x6d,0x92,0x46,0xac,0x09},{0x15,0x2d,0xca,0x76,0x91,0x2d,0x4a,0x38,0x60,0x6f,0x46,0xd9,0x0d,0x4b,0x87,0x8b,0x3e,0x60,0xb9,0xce,0xf8,0x74,0x0e,0xf3,0x22,0x29,0x0f,0x18,0xa6,0x7a,0xd4,0x8e,0x71,0x6f,0x41,0x2e,0x70,0x13,0xd5,0xe1,0xee,0x4c,0x4a,0xaf,0x5e,0x7f,0x86,0xd1,0x58,0x24,0x9b,0xcd,0x06,0x7f,0x5e,0x62,0xb6,0x2c,0x25,0xb7,0x16,0x6b,0x94,0x29},"\x23\x0d\xd4\xc8\x55\xc1\x33\xc5\xb3\xc2\x4a\x72\xaf\x9b\xbb\xc4\x82\x05\x98\x4e\xa4\xf2\x04\x5f\xea\xac\x17\xfe\x1a\xf9"},
 };
 
-static inline void printhex(const char *label, const unsigned char *c, size_t len){
+static inline void printhex(const char *label, const unsigned char *c, size_t len)
+{
 	size_t i;
 	printf("%s", label);
-	for (i = 0; i < len; i++){
+    for (i = 0; i < len; i++) {
 		printf("%02x", c[i]);
 	}
 	printf("\n");
@@ -73,7 +75,7 @@ int main(void)
 		memset(proof, 0, sizeof proof);
 		memset(output, 0, sizeof output);
 		crypto_vrf_keypair_from_seed(pk, sk, test_data[i].seed);
-		if (memcmp(pk, test_data[i].pk, crypto_vrf_PUBLICKEYBYTES) != 0){
+        if (memcmp(pk, test_data[i].pk, crypto_vrf_PUBLICKEYBYTES) != 0) {
 			printf("keypair_from_seed produced wrong pk: [%u]\n", i);
 			printhex("\tWanted: ", test_data[i].pk, crypto_vrf_PUBLICKEYBYTES);
 			printhex("\tGot:    ", pk, crypto_vrf_PUBLICKEYBYTES);
@@ -83,21 +85,26 @@ int main(void)
 			printf("crypto_vrf_is_valid_key() error: [%u]\n", i);
 			continue;
 		}
-		if (crypto_vrf_prove(proof, sk, (const unsigned char*) test_data[i].msg, i) != 0){
+        if (crypto_vrf_prove(proof, sk, (const unsigned char *) test_data[i].msg, i) != 0) {
 			printf("crypto_vrf_prove() error: [%u]\n", i);
 			continue;
 		}
-		if (memcmp(test_data[i].proof, proof, crypto_vrf_PROOFBYTES) != 0){
+        if (memcmp(test_data[i].proof, proof, crypto_vrf_PROOFBYTES) != 0) {
 			printf("proof error: [%u]\n", i);
 			printhex("\tWanted: ", test_data[i].proof, crypto_vrf_PROOFBYTES);
 			printhex("\tGot:    ", proof, crypto_vrf_PROOFBYTES);
 			continue;
 		}
-		if (crypto_vrf_verify(output, test_data[i].pk, proof, (const unsigned char*) test_data[i].msg, i) != 0){
+        if (crypto_vrf_verify(output, test_data[i].pk, proof, (const unsigned char *) test_data[i].msg, i) != 0) {
 			printf("verify error: [%u]\n", i);
 			continue;
 		}
-		if (memcmp(output, test_data[i].output, crypto_vrf_OUTPUTBYTES) != 0){
+        if (crypto_vrf_verify_vartime(output, test_data[i].pk, proof, (const unsigned char *) test_data[i].msg, i) !=
+            0) {
+            printf("verify_vartime error: [%u]\n", i);
+            continue;
+        }
+        if (memcmp(output, test_data[i].output, crypto_vrf_OUTPUTBYTES) != 0) {
 			printf("output wrong: [%u]\n", i);
 			printhex("\tWanted: ", test_data[i].output, crypto_vrf_OUTPUTBYTES);
 			printhex("\tGot:    ", output, crypto_vrf_OUTPUTBYTES);
@@ -105,32 +112,59 @@ int main(void)
 		}
 
 		proof[0] ^= 0x01;
-		if (crypto_vrf_verify(output, test_data[i].pk, proof, (const unsigned char*) test_data[i].msg, i) == 0){
+        if (crypto_vrf_verify(output, test_data[i].pk, proof, (const unsigned char *) test_data[i].msg, i) == 0) {
 			printf("verify succeeded with bad gamma: [%u]\n", i);
 			continue;
 		}
+        if (crypto_vrf_verify_vartime(output, test_data[i].pk, proof, (const unsigned char *) test_data[i].msg, i) ==
+            0) {
+            printf("verify_vartime succeeded with bad gamma: [%u]\n", i);
+            continue;
+        }
 		proof[0] ^= 0x01;
 		proof[32] ^= 0x01;
-		if (crypto_vrf_verify(output, test_data[i].pk, proof, (const unsigned char*) test_data[i].msg, i) == 0){
+        if (crypto_vrf_verify(output, test_data[i].pk, proof, (const unsigned char *) test_data[i].msg, i) == 0) {
 			printf("verify succeeded with bad c value: [%u]\n", i);
 			continue;
 		}
+        if (crypto_vrf_verify_vartime(output, test_data[i].pk, proof, (const unsigned char *) test_data[i].msg, i) ==
+            0) {
+            printf("verify_vartime succeeded with bad c value: [%u]\n", i);
+            continue;
+        }
 		proof[32] ^= 0x01;
 		proof[48] ^= 0x01;
-		if (crypto_vrf_verify(output, test_data[i].pk, proof, (const unsigned char*) test_data[i].msg, i) == 0){
+        if (crypto_vrf_verify(output, test_data[i].pk, proof, (const unsigned char *) test_data[i].msg, i) == 0) {
 			printf("verify succeeded with bad s value: [%u]\n", i);
 			continue;
 		}
+        if (crypto_vrf_verify_vartime(output, test_data[i].pk, proof, (const unsigned char *) test_data[i].msg, i) ==
+            0) {
+            printf("verify_vartime succeeded with bad s value: [%u]\n", i);
+            continue;
+        }
 		proof[48] ^= 0x01;
 		proof[79] ^= 0x80;
-		if (crypto_vrf_verify(output, test_data[i].pk, proof, (const unsigned char*) test_data[i].msg, i) == 0){
+        if (crypto_vrf_verify(output, test_data[i].pk, proof, (const unsigned char *) test_data[i].msg, i) == 0) {
 			printf("verify succeeded with bad s value (high-order-bit flipped): [%u]\n", i);
 			continue;
 		}
+        if (crypto_vrf_verify_vartime(output, test_data[i].pk, proof, (const unsigned char *) test_data[i].msg, i) ==
+            0) {
+            printf("verify_vartime succeeded with bad s value (high-order-bit flipped): [%u]\n", i);
+            continue;
+        }
 		proof[79] ^= 0x80;
 
 		if (i > 0) {
-			if (crypto_vrf_verify(output, test_data[i].pk, proof, (const unsigned char*) test_data[i].msg, i-1) == 0){
+            if (crypto_vrf_verify(output, test_data[i].pk, proof, (const unsigned char *) test_data[i].msg, i - 1) ==
+                0) {
+                printf("verify succeeded with truncated message: [%u]\n", i);
+                continue;
+            }
+            if (crypto_vrf_verify_vartime(output, test_data[i].pk, proof, (const unsigned char *) test_data[i].msg,
+                                          i - 1) ==
+                0) {
 				printf("verify succeeded with truncated message: [%u]\n", i);
 				continue;
 			}

--- a/crypto/vrf.go
+++ b/crypto/vrf.go
@@ -129,10 +129,27 @@ func (pk VrfPubkey) verifyBytes(proof VrfProof, msg []byte) (bool, VrfOutput) {
 	return ret == 0, out
 }
 
+// verifyVarTimeBytes is the same as verify Vartime except that it is not constant time
+func (pk VrfPubkey) verifyVarTimeBytes(proof VrfProof, msg []byte) (bool, VrfOutput) {
+	var out VrfOutput
+	// &msg[0] will make Go panic if msg is zero length
+	m := (*C.uchar)(C.NULL)
+	if len(msg) != 0 {
+		m = (*C.uchar)(&msg[0])
+	}
+	ret := C.crypto_vrf_verify_vartime((*C.uchar)(&out[0]), (*C.uchar)(&pk[0]), (*C.uchar)(&proof[0]), (*C.uchar)(m), (C.ulonglong)(len(msg)))
+	return ret == 0, out
+}
+
 // Verify checks a VRF proof of a given Hashable. If the proof is valid the pseudorandom VrfOutput will be returned.
 // For a given public key and message, there are potentially multiple valid proofs.
 // However, given a public key and message, all valid proofs will yield the same output.
 // Moreover, the output is indistinguishable from random to anyone without the proof or the secret key.
 func (pk VrfPubkey) Verify(p VrfProof, message Hashable) (bool, VrfOutput) {
 	return pk.verifyBytes(p, HashRep(message))
+}
+
+// VerifyVarTime is the same as Verify except it is not constant time
+func (pk VrfPubkey) VerifyVarTime(p VrfProof, message Hashable) (bool, VrfOutput) {
+	return pk.verifyVarTimeBytes(p, HashRep(message))
 }


### PR DESCRIPTION
## Summary

Current implementation is constant-time.
Constant-time is most likely not needed for most cases, as VRF inputs
are usually public.

There is quite a lot of copy-pasting in ed25519_ref10.c.
I usually strongly advocate against copy-pasting
but unfortunately the libsodium code seems to itself contain a lot of
copy-pasting so I just kept it as is.
But it may make sense to introduce functions.

Importantly: Note that this code has *not* been audited and the effect
of using non-constant-time VRF verification has *not* been studied in details.

## Test Plan

There is unit testing at 2 levels:

1. In Go, in `crypto/vrf_test.go` but it is quite limited
2. In libsodium itself, which I am not sure is run by CI/CD
but this can be run manually:
in `crypto/libsodium-fork`, run:

```
./autogen.sh
./configure --disable-shared
make
cd test/default
make vrf.log
```
(or just `make check`)

Note that the `make` in top-level of `go-algorand` copies the full
source tree of `libsodium-fork` inside
`crypto/copies/darwin/amd64/libsodium-fork`
(on macOS)

Regarding benchmarking, on my computer (single run), I get:

```
$ cd crypto
$ go test -bench '.*Verify.*' .
slice *crypto.OneTimeSignatureSecrets/OneTimeSignatureSecretsPersistent/Offsets have an unbounded allocbound defined
slice *crypto.OneTimeSignatureSecrets/OneTimeSignatureSecretsPersistent/Batches have an unbounded allocbound defined
slice *crypto.OneTimeSignatureSecretsPersistent/Offsets have an unbounded allocbound defined
slice *crypto.OneTimeSignatureSecretsPersistent/Batches have an unbounded allocbound defined
WARN[0004] tried to sign {[29 218 75 201 184 250 48 100 132 68 111 121 174 181 244 52 145 176 162 72]} with out-of-range one-time identifier {199 147} (firstbatch 201, len(batches) 799, firstoffset 147, len(offsets) 109)  file=onetimesig.go function="github.com/algorand/go-algorand/crypto.(*OneTimeSignatureSecrets).Sign" line=302
goos: darwin
goarch: amd64
pkg: github.com/algorand/go-algorand/crypto
cpu: Intel(R) Core(TM) i7-8559U CPU @ 2.70GHz
BenchmarkSignVerify-8         	   14564	     81885 ns/op
BenchmarkVerify-8             	   18763	     64014 ns/op
BenchmarkVrfVerify-8          	    5508	    215581 ns/op
BenchmarkVrfVerifyVarTime-8   	    7802	    152587 ns/op
PASS
ok  	github.com/algorand/go-algorand/crypto	13.787s
```

So essentially VRF verify is 2.5x slower than ed25519 verify
which is not too surprising as it requires two double scalar multiplications
(one very similar to ed25519 verify, with one of the element being the
pre-computed base; and one slightly slower where it is not the case).
This is about 30% faster than the current implementation.



