### PR TITLE
agreement: report proposal and vote message buffer sizes at end of round

### DIFF
--- a/agreement/actions.go
+++ b/agreement/actions.go
@@ -237,6 +237,8 @@ func (a ensureAction) do(ctx context.Context, s *Service) {
 			Round:        uint64(a.Certificate.Round),
 			ValidatedAt:  a.Payload.validatedAt,
 			PreValidated: true,
+			PropBufLen:   uint64(len(s.demux.rawProposals)),
+			VoteBufLen:   uint64(len(s.demux.rawVotes)),
 		})
 		s.Ledger.EnsureValidatedBlock(a.Payload.ve, a.Certificate)
 	} else {
@@ -249,6 +251,8 @@ func (a ensureAction) do(ctx context.Context, s *Service) {
 			Round:        uint64(a.Certificate.Round),
 			ValidatedAt:  a.Payload.validatedAt,
 			PreValidated: false,
+			PropBufLen:   uint64(len(s.demux.rawProposals)),
+			VoteBufLen:   uint64(len(s.demux.rawVotes)),
 		})
 		s.Ledger.EnsureBlock(block, a.Certificate)
 	}

--- a/logging/telemetryspec/event.go
+++ b/logging/telemetryspec/event.go
@@ -85,6 +85,8 @@ type BlockAcceptedEventDetails struct {
 	Round        uint64
 	ValidatedAt  time.Duration
 	PreValidated bool
+	PropBufLen   uint64
+	VoteBufLen   uint64
 }
 
 // TopAccountsEvent event


### PR DESCRIPTION
## Summary

This adds to the BlockAccepted telemetry event the size of the rawVotes and rawProposals buffered channels. This provides a snapshot in time of how many unprocessed votes and proposals had not been handled yet by agreement at the end of a round (when a block is certified and validated).

## Test Plan

Existing tests should pass.