### PR TITLE
Build: Update build image from arm32v6 to arm32v7

### DIFF
--- a/docker/build/cicd.ubuntu.Dockerfile
+++ b/docker/build/cicd.ubuntu.Dockerfile
@@ -3,11 +3,12 @@ ARG ARCH="amd64"
 FROM ${ARCH}/ubuntu:18.04
 ARG GOLANG_VERSION
 ARG ARCH="amd64"
+ARG GOARCH="amd64"
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y build-essential git libboost-all-dev wget sqlite3 autoconf jq bsdmainutils shellcheck awscli
 WORKDIR /root
-RUN wget https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH%v*}.tar.gz \
-    && tar -xvf go${GOLANG_VERSION}.linux-${ARCH%v*}.tar.gz && \
+RUN wget https://dl.google.com/go/go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz \
+    && tar -xvf go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz && \
     mv go /usr/local
 ENV GOROOT=/usr/local/go \
     GOPATH=$HOME/go \

--- a/test/muleCI/mule.yaml
+++ b/test/muleCI/mule.yaml
@@ -13,6 +13,7 @@ agents:
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
       - ARCH=amd64
+      - GOARCH=amd64
   - name: cicd.centos.amd64
     dockerFilePath: docker/build/cicd.centos.Dockerfile
     image: algorand/go-algorand-ci-linux-centos
@@ -41,11 +42,12 @@ agents:
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
       - ARCH=arm64v8
-  - name: cicd.alpine.arm
-    dockerFilePath: docker/build/cicd.alpine.Dockerfile
+      - GOARCH=arm64
+  - name: cicd.ubuntu.arm
+    dockerFilePath: docker/build/cicd.ubuntu.Dockerfile
     image: algorand/go-algorand-ci-linux
     version: scripts/configure_dev-deps.sh
-    arch: arm32v6
+    arch: arm32v7
     env:
       - TRAVIS_BRANCH=${GIT_BRANCH}
       - NETWORK=$NETWORK
@@ -54,7 +56,8 @@ agents:
       - GOHOSTARCH=arm
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
-      - ARCH=arm32v6
+      - ARCH=arm32v7
+      - GOARCH=armv6l
   - name: docker-ubuntu
     dockerFilePath: docker/build/docker.ubuntu.Dockerfile
     image: algorand/go-algorand-docker-linux-ubuntu
@@ -96,7 +99,7 @@ tasks:
     target: ci-build
   - task: docker.Make
     name: build.arm
-    agent: cicd.alpine.arm
+    agent: cicd.ubuntu.arm
     target: ci-build
 
   - task: docker.Make


### PR DESCRIPTION
## Summary
There's an issue with DNS resolution with the arm32v6/golang1.16.15-alpine image. It isn't able to resolve `apk update` on the cluster. Instead, we'll switch to building the arm32 image with arm32v7/ubuntu:18.04 image instead.

## Attention
We will lose arm32v6 support for Raspberry Pi 1 with this change.

## Testing
Tested both locally and on the build pipeline with [pull/3930](https://github.com/algorand/go-algorand/pull/3930) changes and the results looks good.