### PR TITLE
race condition: Add lock around catchpointsMu to avoid race condition

### DIFF
--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -413,20 +413,18 @@ func (ct *catchpointTracker) postCommit(ctx context.Context, dcc *deferredCommit
 		}
 	}
 
+	ct.catchpointsMu.Lock()
+	ct.roundDigest = ct.roundDigest[dcc.offset:]
 	if dcc.isCatchpointRound && dcc.catchpointLabel != "" {
 		ct.lastCatchpointLabel = dcc.catchpointLabel
 	}
+	ct.catchpointsMu.Unlock()
+
 	dcc.updatingBalancesDuration = time.Since(dcc.flushTime)
 
 	if dcc.updateStats {
 		dcc.stats.MemoryUpdatesDuration = time.Duration(time.Now().UnixNano())
 	}
-
-	ct.catchpointsMu.Lock()
-
-	ct.roundDigest = ct.roundDigest[dcc.offset:]
-
-	ct.catchpointsMu.Unlock()
 }
 
 func (ct *catchpointTracker) postCommitUnlocked(ctx context.Context, dcc *deferredCommitContext) {


### PR DESCRIPTION
## Summary

While upgrading to golang 1.17.9 I've run into a couple of race conditions which have been detected during E2E tests. This fixes one of them during which a write happens at https://github.com/algorand/go-algorand/blob/master/ledger/catchpointtracker.go#L417 and a read happens at https://github.com/algorand/go-algorand/blob/master/ledger/catchpointtracker.go#L173

## Test Plan

e2e tests
