### PR TITLE
e2e tests: Fixes for e2e test runs

### DIFF
--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -165,7 +165,7 @@ if [ -z "$E2E_TEST_FILTER" ] || [ "$E2E_TEST_FILTER" == "SCRIPTS" ]; then
     # If the platform is arm64, we want to pass "--keep-temps" into e2e_client_runner.py
     # so that we can keep the temporary test artifact for use in the indexer e2e tests.
     # The file is located at ${TEMPDIR}/net_done.tar.bz2
-    if [ $E2E_PLATFORM == "arm64" ]; then
+    if [ "$E2E_PLATFORM" == "arm64" ]; then
       KEEP_TEMPS_CMD_STR="--keep-temps"
     fi
 

--- a/test/scripts/e2e_client_runner.py
+++ b/test/scripts/e2e_client_runner.py
@@ -372,6 +372,7 @@ def xrun(cmd, *args, **kwargs):
     timeout = kwargs.pop('timeout', None)
     kwargs['stdout'] = subprocess.PIPE
     kwargs['stderr'] = subprocess.STDOUT
+    stdout = stderr = None
     try:
         p = subprocess.Popen(cmd, *args, **kwargs)
     except Exception as e:


### PR DESCRIPTION
A couple of small quality of life fixes for e2e tests that I've run into issues with.

## Summary

1. In `e2e.sh` when we fail to set the `E2E_PLATFORM` variable, the shell will complain that we are using a binary operator (`==`) on a single argument. Setting the left side of the test statement to a string with variable interpolation fixes this.
2. The e2e python client runner does not initialize the `stdout` and `stderr` variables which causes an exception in `reportcomms(p, stdout, stderr)` when the except block runs after `p.communicate` raises an exception. Initializing to None fixes this.

## Test Plan

Found and fixed while running e2e tests in failure scenarios.
