### PR TITLE
Tests: Support e2e-go tests when repo is not installed in GOPATH.

### DIFF
--- a/test/framework/fixtures/baseFixture.go
+++ b/test/framework/fixtures/baseFixture.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
+	"runtime"
 	"testing"
 
 	"github.com/algorand/go-algorand/config"
@@ -33,6 +35,15 @@ type baseFixture struct {
 	testDir     string
 	testDirTmp  bool
 	instance    Fixture
+}
+
+func getTestDir() string {
+	_, filename, _, ok := runtime.Caller(0)
+	if ok {
+		return path.Join(path.Dir(filename), "..", "..")
+	}
+	// fallback to the legacy GOPATH location.
+	return os.ExpandEnv("${GOPATH}/src/github.com/algorand/go-algorand/test/")
 }
 
 func (f *baseFixture) initialize(instance Fixture) {
@@ -49,7 +60,7 @@ func (f *baseFixture) initialize(instance Fixture) {
 	}
 	f.testDataDir = os.Getenv("TESTDATADIR")
 	if f.testDataDir == "" {
-		f.testDataDir = os.ExpandEnv("${GOPATH}/src/github.com/algorand/go-algorand/test/testdata")
+		f.testDataDir = path.Join(getTestDir(), "testdata")
 	}
 }
 

--- a/test/framework/fixtures/expectFixture.go
+++ b/test/framework/fixtures/expectFixture.go
@@ -25,7 +25,6 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -58,9 +57,7 @@ func (ef *ExpectFixture) initialize(t *testing.T) (err error) {
 	}
 	ef.testDataDir = os.Getenv("TESTDATADIR")
 	if ef.testDataDir == "" {
-		// Default to test/testdata in the source tree being tested
-		_, path, _, _ := runtime.Caller(0)
-		ef.testDataDir = filepath.Join(filepath.Dir(path), "../../testdata")
+		ef.testDataDir = filepath.Join(getTestDir(), "testdata")
 	}
 
 	ef.testFilter = os.Getenv("TESTFILTER")


### PR DESCRIPTION
## Summary

Running e2e go tests fails when the repo is not cloned inside the GOPATH. This change looks up the current directory using `runtime.Caller` as an alternative to hard coding the GOPATH location.

note: the Makefile also solves this problem by setting the `TESTDATADIR` environment variable, but that doesn't work when running tests from an IDE.

## Test Plan

Existing tests cover this code path. Additionally I manually verified by running a number of e2e-go/expect tests locally