### PR TITLE
PKI: 3924 handle stateproof in rest api goal

### DIFF
--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -978,8 +978,6 @@ func (c *Client) AddParticipationKey(keyfile string) (resp generated.PostPartici
 	}
 
 	return algod.PostParticipationKey(data)
-
-	// PKI TODO: Install state proof keys here.
 }
 
 // GetParticipationKeys gets the currently installed participation keys.

--- a/node/node.go
+++ b/node/node.go
@@ -931,6 +931,12 @@ func (node *AlgorandFullNode) InstallParticipationKey(partKeyBinary []byte) (acc
 	if !added {
 		return account.ParticipationID{}, fmt.Errorf("ParticipationRegistry: cannot register duplicate participation key")
 	}
+
+	err = insertStateProofToRegistry(partkey, node)
+	if err != nil {
+		return account.ParticipationID{}, err
+	}
+
 	err = node.accountManager.Registry().Flush(participationRegistryFlushMaxWaitDuration)
 	if err != nil {
 		return account.ParticipationID{}, err

--- a/node/node.go
+++ b/node/node.go
@@ -893,7 +893,7 @@ func (node *AlgorandFullNode) InstallParticipationKey(partKeyBinary []byte) (acc
 	}
 	defer inputdb.Close()
 
-	partkey, err := account.RestoreParticipation(inputdb)
+	partkey, err := account.RestoreParticipationWithSecrets(inputdb)
 	if err != nil {
 		return account.ParticipationID{}, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -404,8 +404,7 @@ func (node *AlgorandFullNode) Start() {
 // startMonitoringRoutines starts the internal monitoring routines used by the node.
 func (node *AlgorandFullNode) startMonitoringRoutines() {
 	node.monitoringRoutinesWaitGroup.Add(2)
-
-	go node.txPoolGaugeThread(node.ctx.Done())
+	go node.txPoolGaugeThread()
 	// Delete old participation keys
 	go node.oldKeyDeletionThread(node.ctx.Done())
 

--- a/node/node.go
+++ b/node/node.go
@@ -899,17 +899,6 @@ func (node *AlgorandFullNode) InstallParticipationKey(partKeyBinary []byte) (acc
 	}
 	defer partkey.Close()
 
-	// We want to make sure that the state proof keys are included in the participation key
-
-	if partkey.StateProofSecrets == nil {
-		return account.ParticipationID{}, fmt.Errorf("cannot install partkey with missing state proof keys")
-	}
-
-	// A slightly different error message to help with debugging
-	if len(partkey.StateProofSecrets.GetAllKeys()) == 0 {
-		return account.ParticipationID{}, fmt.Errorf("cannot install partkey with no state proof keys")
-	}
-
 	if partkey.Parent == (basics.Address{}) {
 		return account.ParticipationID{}, fmt.Errorf("cannot install partkey with missing (zero) parent address")
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -905,8 +905,9 @@ func (node *AlgorandFullNode) InstallParticipationKey(partKeyBinary []byte) (acc
 		return account.ParticipationID{}, fmt.Errorf("cannot install partkey with missing state proof keys")
 	}
 
+	// A slightly different error message to help with debugging
 	if len(partkey.StateProofSecrets.GetAllKeys()) == 0 {
-		return account.ParticipationID{}, fmt.Errorf("cannot install partkey with missing state proof keys")
+		return account.ParticipationID{}, fmt.Errorf("cannot install partkey with no state proof keys")
 	}
 
 	if partkey.Parent == (basics.Address{}) {


### PR DESCRIPTION
  ### Remove Node Key Monitoring Function
  
Resolves #2596

Removes function which calls loadParticipationKeys() every 60 seconds
since MakeFull() for the FullNode does the same thing


### Install State Proof Keys
  
Resolves #3924

Installs state proof keys inside of algod after getting the binary blob

### Removes temp file generation

Resolves #3106 

Removes the ability to create temporary files from the REST interface.