### PR TITLE
320 rounds: Online Accounts Cache

### DIFF
--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -475,7 +475,7 @@ func (ao *onlineAccounts) postCommit(ctx context.Context, dcc *deferredCommitCon
 		for j := 0; j < roundDelta.Len(); j++ {
 			addr, acctDelta := roundDelta.GetByIdx(j)
 			persistedAcct := persistedOnlineAccountData{
-				addr: addr,
+				addr:  addr,
 				round: ao.cachedDBRoundOnline + basics.Round(i+1),
 			}
 			persistedAcct.accountData.SetCoreAccountData(acctDelta)

--- a/ledger/acctonline_test.go
+++ b/ledger/acctonline_test.go
@@ -438,7 +438,7 @@ func TestAcctOnlineCache(t *testing.T) {
 		var updates ledgercore.AccountDeltas
 		acctIdx := (int(i) - 1) % numAccts
 
-		if int(i) % 2 == 0 {
+		if int(i)%2 == 0 {
 			updates.Upsert(allAccts[acctIdx].Addr, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: ledgercore.VotingData{}})
 		} else {
 			updates.Upsert(allAccts[acctIdx].Addr, ledgercore.ToAccountData(allAccts[acctIdx].AccountData))
@@ -465,7 +465,7 @@ func TestAcctOnlineCache(t *testing.T) {
 			require.Equal(t, bal.Addr, data.addr)
 			require.NotEmpty(t, data.rowid)
 			require.Equal(t, oa.cachedDBRoundOnline, data.round)
-			if int(i) %2 == 0 {
+			if int(i)%2 == 0 {
 				require.Empty(t, data.accountData)
 			} else {
 				require.NotEmpty(t, data.accountData)
@@ -474,7 +474,7 @@ func TestAcctOnlineCache(t *testing.T) {
 			data, has := oa.onlineAccountsCache.read(bal.Addr, rnd)
 			require.True(t, has)
 			require.Empty(t, data.rowid)
-			if int(i) %2 == 0 {
+			if int(i)%2 == 0 {
 				require.Empty(t, data.accountData)
 			} else {
 				require.NotEmpty(t, data.accountData)
@@ -482,7 +482,7 @@ func TestAcctOnlineCache(t *testing.T) {
 
 			oad, err := oa.lookupOnlineAccountData(rnd, bal.Addr)
 			require.NoError(t, err)
-			if int(i) %2 == 0 {
+			if int(i)%2 == 0 {
 				require.Empty(t, oad)
 			} else {
 				require.NotEmpty(t, oad)
@@ -499,7 +499,7 @@ func TestAcctOnlineCache(t *testing.T) {
 			require.Equal(t, bal.Addr, data.addr)
 			require.Empty(t, data.rowid)
 			require.Equal(t, oa.cachedDBRoundOnline, data.round)
-			if int(i) %2 == 0 {
+			if int(i)%2 == 0 {
 				require.Empty(t, data.accountData)
 			} else {
 				require.NotEmpty(t, data.accountData)
@@ -508,7 +508,7 @@ func TestAcctOnlineCache(t *testing.T) {
 			data, has := oa.onlineAccountsCache.read(bal.Addr, rnd)
 			require.True(t, has)
 			require.Empty(t, data.rowid)
-			if int(i) %2 == 0 {
+			if int(i)%2 == 0 {
 				require.Empty(t, data.accountData)
 			} else {
 				require.NotEmpty(t, data.accountData)
@@ -518,7 +518,7 @@ func TestAcctOnlineCache(t *testing.T) {
 			// lookup should correctly return data for earlist round dbRound - maxBalLookback + 1
 			oad, err := oa.lookupOnlineAccountData(rnd+1, bal.Addr)
 			require.NoError(t, err)
-			if int(i) %2 == 0 {
+			if int(i)%2 == 0 {
 				require.Empty(t, oad)
 			} else {
 				require.NotEmpty(t, oad)

--- a/ledger/onlineaccountscache.go
+++ b/ledger/onlineaccountscache.go
@@ -1,7 +1,6 @@
 package ledger
 
 import (
-	"fmt"
 	"github.com/algorand/go-algorand/data/basics"
 )
 
@@ -38,39 +37,27 @@ func (o *onlineAccountsCache) read(addr basics.Address, rnd basics.Round) (data 
 // write a single persistedAccountData to the cache
 // thread locking semantics : write lock
 func (o *onlineAccountsCache) writeFront(acctData persistedOnlineAccountData) {
-	fmt.Println(acctData.addr, "front", acctData.round)
 	if _, ok := o.accounts[acctData.addr]; !ok {
 		o.accounts[acctData.addr] = newPersistedOnlineAccountList()
 	}
 	list := o.accounts[acctData.addr]
 	if list.root.next != &list.root && acctData.round <= list.root.next.Value.round {
-		fmt.Println(acctData.round, list.root.next.Value.round)
-		//panic("VERY BAD")
 		return
 	}
 	o.accounts[acctData.addr].pushFront(&acctData)
-	if o.accounts[acctData.addr].root.prev.Value == nil {
-		panic("what?")
-	}
 }
 
 // write a single persistedAccountData to the cache
 // thread locking semantics : write lock
 func (o *onlineAccountsCache) writeBack(acctData persistedOnlineAccountData) {
-	fmt.Println(acctData.addr, "back", acctData.round)
 	if _, ok := o.accounts[acctData.addr]; !ok {
 		o.accounts[acctData.addr] = newPersistedOnlineAccountList()
 	}
 	list := o.accounts[acctData.addr]
 	if list.root.prev != &list.root && acctData.round >= list.root.prev.Value.round {
-		fmt.Println(acctData.round, list.root.prev.Value.round)
-		//panic("SUPER BAD")
 		return
 	}
 	o.accounts[acctData.addr].pushBack(&acctData)
-	if o.accounts[acctData.addr].root.prev.Value == nil {
-		panic("huh?")
-	}
 }
 
 // prune trims the onlineaccountscache by only keeping entries that would give account state

--- a/ledger/onlineaccountscache.go
+++ b/ledger/onlineaccountscache.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package ledger
 
 import (

--- a/ledger/onlineaccountscache.go
+++ b/ledger/onlineaccountscache.go
@@ -1,0 +1,91 @@
+package ledger
+
+import (
+	"fmt"
+	"github.com/algorand/go-algorand/data/basics"
+)
+
+type onlineAccountsCache struct {
+	accounts map[basics.Address]*persistedOnlineAccountDataList
+}
+
+// init initializes the onlineAccountsCache for use.
+// thread locking semantics : write lock
+func (o *onlineAccountsCache) init() {
+	o.accounts = make(map[basics.Address]*persistedOnlineAccountDataList)
+}
+
+// read the persistedAccountData object that the cache has for the given address.
+// thread locking semantics : read lock
+func (o *onlineAccountsCache) read(addr basics.Address, rnd basics.Round) (data persistedOnlineAccountData, has bool) {
+	if list := o.accounts[addr]; list != nil {
+		node := list.back()
+		if node.Value.round > rnd {
+			return persistedOnlineAccountData{}, false
+		}
+		for node.prev != &list.root {
+			node = node.prev
+			// only need one entry that is targetRound or older
+			if node.Value.round > rnd {
+				return *node.next.Value, true
+			}
+		}
+		return *node.Value, true
+	}
+	return persistedOnlineAccountData{}, false
+}
+
+// write a single persistedAccountData to the cache
+// thread locking semantics : write lock
+func (o *onlineAccountsCache) writeFront(acctData persistedOnlineAccountData) {
+	fmt.Println(acctData.addr, "front", acctData.round)
+	if _, ok := o.accounts[acctData.addr]; !ok {
+		o.accounts[acctData.addr] = newPersistedOnlineAccountList()
+	}
+	list := o.accounts[acctData.addr]
+	if list.root.next != &list.root && acctData.round <= list.root.next.Value.round {
+		fmt.Println(acctData.round, list.root.next.Value.round)
+		//panic("VERY BAD")
+		return
+	}
+	o.accounts[acctData.addr].pushFront(&acctData)
+	if o.accounts[acctData.addr].root.prev.Value == nil {
+		panic("what?")
+	}
+}
+
+// write a single persistedAccountData to the cache
+// thread locking semantics : write lock
+func (o *onlineAccountsCache) writeBack(acctData persistedOnlineAccountData) {
+	fmt.Println(acctData.addr, "back", acctData.round)
+	if _, ok := o.accounts[acctData.addr]; !ok {
+		o.accounts[acctData.addr] = newPersistedOnlineAccountList()
+	}
+	list := o.accounts[acctData.addr]
+	if list.root.prev != &list.root && acctData.round >= list.root.prev.Value.round {
+		fmt.Println(acctData.round, list.root.prev.Value.round)
+		//panic("SUPER BAD")
+		return
+	}
+	o.accounts[acctData.addr].pushBack(&acctData)
+	if o.accounts[acctData.addr].root.prev.Value == nil {
+		panic("huh?")
+	}
+}
+
+// prune trims the onlineaccountscache by only keeping entries that would give account state
+// of rounds past targetRound
+// thread locking semantics : write lock
+func (o *onlineAccountsCache) prune(targetRound basics.Round) {
+	for _, list := range o.accounts {
+		node := list.back()
+		for node.prev != &list.root {
+			node = node.prev
+			// only need one entry that is targetRound or older
+			if node.Value.round <= targetRound {
+				list.remove(node.next)
+			}
+		}
+	}
+	return
+}

--- a/ledger/onlineaccountscache_test.go
+++ b/ledger/onlineaccountscache_test.go
@@ -72,4 +72,7 @@ func TestOnlineAccountsCacheBasic(t *testing.T) {
 		require.Equal(t, uint64(i), acct.accountData.MicroAlgos.Raw)
 		require.Equal(t, int64(i), acct.rowid)
 	}
+
+	_, has = oac.read(addr, basics.Round(0))
+	require.False(t, has)
 }

--- a/ledger/onlineaccountscache_test.go
+++ b/ledger/onlineaccountscache_test.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package ledger
 
 import (
@@ -43,7 +59,7 @@ func TestOnlineAccountsCacheBasic(t *testing.T) {
 		require.Equal(t, int64(i), acct.rowid)
 	}
 
-	for i := proto.MaxBalLookback; i < uint64(accountsNum) + proto.MaxBalLookback; i++ {
+	for i := proto.MaxBalLookback; i < uint64(accountsNum)+proto.MaxBalLookback; i++ {
 		acct := persistedOnlineAccountData{
 			addr:        addr,
 			round:       basics.Round(i),
@@ -53,7 +69,7 @@ func TestOnlineAccountsCacheBasic(t *testing.T) {
 		oac.writeFront(acct)
 	}
 
-	oac.prune(basics.Round(proto.MaxBalLookback-1))
+	oac.prune(basics.Round(proto.MaxBalLookback - 1))
 
 	// verify that all these accounts are truly there.
 	acct, has := oac.read(addr, basics.Round(proto.MaxBalLookback-1))
@@ -63,8 +79,7 @@ func TestOnlineAccountsCacheBasic(t *testing.T) {
 	require.Equal(t, uint64(accountsNum-1), acct.accountData.MicroAlgos.Raw)
 	require.Equal(t, int64(accountsNum-1), acct.rowid)
 
-
-	for i := proto.MaxBalLookback; i < uint64(accountsNum) + proto.MaxBalLookback; i++ {
+	for i := proto.MaxBalLookback; i < uint64(accountsNum)+proto.MaxBalLookback; i++ {
 		acct, has := oac.read(addr, basics.Round(i))
 		require.True(t, has)
 		require.Equal(t, basics.Round(i), acct.round)

--- a/ledger/onlineaccountscache_test.go
+++ b/ledger/onlineaccountscache_test.go
@@ -1,0 +1,75 @@
+package ledger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/test/partitiontest"
+)
+
+func TestOnlineAccountsCacheBasic(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+
+	var oac onlineAccountsCache
+	oac.init()
+
+	addr := basics.Address(crypto.Hash([]byte{byte(0)}))
+
+	accountsNum := 50
+	for i := 0; i < accountsNum; i++ {
+		acct := persistedOnlineAccountData{
+			addr:        addr,
+			round:       basics.Round(i),
+			rowid:       int64(i),
+			accountData: baseOnlineAccountData{MicroAlgos: basics.MicroAlgos{Raw: uint64(i)}},
+		}
+		oac.writeFront(acct)
+	}
+
+	// verify that all these accounts are truly there.
+	for i := 0; i < accountsNum; i++ {
+		acct, has := oac.read(addr, basics.Round(i))
+		require.True(t, has)
+		require.Equal(t, basics.Round(i), acct.round)
+		require.Equal(t, addr, acct.addr)
+		require.Equal(t, uint64(i), acct.accountData.MicroAlgos.Raw)
+		require.Equal(t, int64(i), acct.rowid)
+	}
+
+	for i := proto.MaxBalLookback; i < uint64(accountsNum) + proto.MaxBalLookback; i++ {
+		acct := persistedOnlineAccountData{
+			addr:        addr,
+			round:       basics.Round(i),
+			rowid:       int64(i),
+			accountData: baseOnlineAccountData{MicroAlgos: basics.MicroAlgos{Raw: i}},
+		}
+		oac.writeFront(acct)
+	}
+
+	oac.prune(basics.Round(proto.MaxBalLookback-1))
+
+	// verify that all these accounts are truly there.
+	acct, has := oac.read(addr, basics.Round(proto.MaxBalLookback-1))
+	require.True(t, has)
+	require.Equal(t, basics.Round(accountsNum-1), acct.round)
+	require.Equal(t, addr, acct.addr)
+	require.Equal(t, uint64(accountsNum-1), acct.accountData.MicroAlgos.Raw)
+	require.Equal(t, int64(accountsNum-1), acct.rowid)
+
+
+	for i := proto.MaxBalLookback; i < uint64(accountsNum) + proto.MaxBalLookback; i++ {
+		acct, has := oac.read(addr, basics.Round(i))
+		require.True(t, has)
+		require.Equal(t, basics.Round(i), acct.round)
+		require.Equal(t, addr, acct.addr)
+		require.Equal(t, uint64(i), acct.accountData.MicroAlgos.Raw)
+		require.Equal(t, int64(i), acct.rowid)
+	}
+}

--- a/ledger/persistedonlineaccts_list.go
+++ b/ledger/persistedonlineaccts_list.go
@@ -105,6 +105,17 @@ func (l *persistedOnlineAccountDataList) pushFront(v *persistedOnlineAccountData
 	return l.insertValue(newNode, &l.root)
 }
 
+// pushFront inserts a new element e with value v at the back of list l and returns e.
+func (l *persistedOnlineAccountDataList) pushBack(v *persistedOnlineAccountData) *persistedOnlineAccountDataListNode {
+	newNode := l.getNewNode()
+	newNode.Value = v
+	newNode.prev = l.root.prev
+	newNode.next = &l.root
+	l.root.prev.next = newNode
+	l.root.prev = newNode
+	return newNode
+}
+
 // insertValue inserts e after at, increments l.len, and returns e.
 func (l *persistedOnlineAccountDataList) insertValue(newNode *persistedOnlineAccountDataListNode, at *persistedOnlineAccountDataListNode) *persistedOnlineAccountDataListNode {
 	n := at.next

--- a/ledger/persistedonlineaccts_list.go
+++ b/ledger/persistedonlineaccts_list.go
@@ -109,11 +109,7 @@ func (l *persistedOnlineAccountDataList) pushFront(v *persistedOnlineAccountData
 func (l *persistedOnlineAccountDataList) pushBack(v *persistedOnlineAccountData) *persistedOnlineAccountDataListNode {
 	newNode := l.getNewNode()
 	newNode.Value = v
-	newNode.prev = l.root.prev
-	newNode.next = &l.root
-	l.root.prev.next = newNode
-	l.root.prev = newNode
-	return newNode
+	return l.insertValue(newNode, l.root.prev)
 }
 
 // insertValue inserts e after at, increments l.len, and returns e.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

Implemented cache for storing online account data in memory for 320 rounds so we do not have to fetch data from db.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

Wrote additional unit tests
