### PR TITLE
Change dryrun cost field to signed int from unsigned in

### DIFF
--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -538,7 +538,7 @@ func doDryrunRequest(dr *DryrunRequest, response *generated.DryrunResponse) {
 						err = fmt.Errorf("cost budget exceeded: budget is %d but program cost was %d", allowedBudget-cumulativeCost, cost)
 					}
 				}
-				cost64 := uint64(cost)
+				cost64 := int64(cost)
 				result.Cost = &cost64
 				maxCurrentBudget = pooledAppBudget
 				cumulativeCost += cost

--- a/daemon/algod/api/server/v2/dryrun_test.go
+++ b/daemon/algod/api/server/v2/dryrun_test.go
@@ -1257,12 +1257,12 @@ func TestDryrunCost(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.msg, func(t *testing.T) {
-			costs := make([]uint64, 2)
+			costs := make([]int64, 2)
 
 			ops, err := logic.AssembleString("#pragma version 5\nbyte 0x41\n" + strings.Repeat("keccak256\n", test.numHashes) + "pop\nint 1\n")
 			require.NoError(t, err)
 			approval := ops.Program
-			costs[0] = 3 + uint64(test.numHashes)*130
+			costs[0] = 3 + int64(test.numHashes)*130
 
 			ops, err = logic.AssembleString("int 1")
 			require.NoError(t, err)

--- a/daemon/algod/api/server/v2/generated/types.go
+++ b/daemon/algod/api/server/v2/generated/types.go
@@ -317,7 +317,7 @@ type DryrunTxnResult struct {
 	AppCallTrace    *[]DryrunState `json:"app-call-trace,omitempty"`
 
 	// Execution cost of app call transaction
-	Cost *uint64 `json:"cost,omitempty"`
+	Cost *int64 `json:"cost,omitempty"`
 
 	// Disassembled program line by line.
 	Disassembly []string `json:"disassembly"`


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Simple fix to allow for negative execution cost. This is needed for testing the use of inner app calls to increase the available budget.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Updated unit test to enforce the the correct negative execution cost is reported.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
