### PR TITLE
cleanup: replace crypto.HashObj(Transaction) with Transaction.ID()

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -874,7 +874,7 @@ var groupCmd = &cobra.Command{
 			}
 
 			stxns = append(stxns, stxn)
-			group.TxGroupHashes = append(group.TxGroupHashes, stxn.ID())
+			group.TxGroupHashes = append(group.TxGroupHashes, crypto.Digest(stxn.ID()))
 			transactionIdx++
 		}
 

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -874,7 +874,7 @@ var groupCmd = &cobra.Command{
 			}
 
 			stxns = append(stxns, stxn)
-			group.TxGroupHashes = append(group.TxGroupHashes, crypto.HashObj(stxn.Txn))
+			group.TxGroupHashes = append(group.TxGroupHashes, stxn.ID())
 			transactionIdx++
 		}
 

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -161,6 +161,7 @@ type TxGroup struct {
 	// together, sequentially, in a block in order for the group to be
 	// valid.  Each hash in the list is a hash of a transaction with
 	// the `Group` field omitted.
+	// These are all `Txid` which is equivalent to `crypto.Digest`
 	TxGroupHashes []crypto.Digest `codec:"txlist,allocbound=config.MaxTxGroupSize"`
 }
 

--- a/data/transactions/transaction_test.go
+++ b/data/transactions/transaction_test.go
@@ -552,6 +552,24 @@ func TestWellFormedErrors(t *testing.T) {
 	}
 }
 
+// TestTransactionHash checks that Transaction.ID() is equivalent to the old simpler crypto.HashObj() implementation.
+func TestTransactionHash(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	var txn Transaction
+	txn.Sender[1] = 3
+	txn.Fee.Raw = 1234
+	txid := txn.ID()
+	txid2 := Txid(crypto.HashObj(txn))
+	require.Equal(t, txid, txid2)
+
+	txn.LastValid = 4321
+	txid3 := txn.ID()
+	txid2 = Txid(crypto.HashObj(txn))
+	require.NotEqual(t, txid, txid3)
+	require.Equal(t, txid3, txid2)
+}
+
 var generateFlag = flag.Bool("generate", false, "")
 
 // running test with -generate would generate the matrix used in the test ( without the "correct" errors )

--- a/data/txntest/txn.go
+++ b/data/txntest/txn.go
@@ -269,19 +269,20 @@ func SignedTxns(txns ...*Txn) []transactions.SignedTxn {
 	txgroup := transactions.TxGroup{
 		TxGroupHashes: make([]crypto.Digest, len(txns)),
 	}
-	for i, txn := range txns {
-		txn.Group = crypto.Digest{}
-		txgroup.TxGroupHashes[i] = crypto.HashObj(txn.Txn())
-	}
-	group := crypto.HashObj(txgroup)
-	for _, txn := range txns {
-		txn.Group = group
-	}
-
 	stxns := make([]transactions.SignedTxn, len(txns))
 	for i, txn := range txns {
 		stxns[i] = txn.SignedTxn()
 	}
+	for i, txn := range stxns {
+		txn.Txn.Group = crypto.Digest{}
+		txgroup.TxGroupHashes[i] = crypto.Digest(txn.ID())
+	}
+	group := crypto.HashObj(txgroup)
+	for i, txn := range txns {
+		txn.Group = group
+		stxns[i].Txn.Group = group
+	}
+
 	return stxns
 
 }

--- a/ledger/internal/eval.go
+++ b/ledger/internal/eval.go
@@ -871,7 +871,7 @@ func (eval *BlockEvaluator) TestTransactionGroup(txgroup []transactions.SignedTx
 			txWithoutGroup := txn.Txn
 			txWithoutGroup.Group = crypto.Digest{}
 
-			group.TxGroupHashes = append(group.TxGroupHashes, crypto.HashObj(txWithoutGroup))
+			group.TxGroupHashes = append(group.TxGroupHashes, crypto.Digest(txWithoutGroup.ID()))
 		} else if len(txgroup) > 1 {
 			return fmt.Errorf("transactionGroup: [%d] had zero Group but was submitted in a group of %d", gi, len(txgroup))
 		}
@@ -981,7 +981,7 @@ func (eval *BlockEvaluator) transactionGroup(txgroup []transactions.SignedTxnWit
 			txWithoutGroup := txad.SignedTxn.Txn
 			txWithoutGroup.Group = crypto.Digest{}
 
-			group.TxGroupHashes = append(group.TxGroupHashes, crypto.HashObj(txWithoutGroup))
+			group.TxGroupHashes = append(group.TxGroupHashes, crypto.Digest(txWithoutGroup.ID()))
 		} else if len(txgroup) > 1 {
 			return fmt.Errorf("transactionGroup: [%d] had zero Group but was submitted in a group of %d", gi, len(txgroup))
 		}

--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -752,7 +752,7 @@ func (c *Client) GroupID(txgroup []transactions.Transaction) (gid crypto.Digest,
 			return
 		}
 
-		group.TxGroupHashes = append(group.TxGroupHashes, crypto.Digest((tx.ID())))
+		group.TxGroupHashes = append(group.TxGroupHashes, crypto.Digest(tx.ID()))
 	}
 
 	return crypto.HashObj(group), nil

--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -752,7 +752,7 @@ func (c *Client) GroupID(txgroup []transactions.Transaction) (gid crypto.Digest,
 			return
 		}
 
-		group.TxGroupHashes = append(group.TxGroupHashes, crypto.HashObj(tx))
+		group.TxGroupHashes = append(group.TxGroupHashes, crypto.Digest((tx.ID())))
 	}
 
 	return crypto.HashObj(group), nil


### PR DESCRIPTION
## Summary

For clarity, always use Transaction.ID() when generating the txid hash of a Transaction. `crypto.HashObj(txn)` is equivalent but less commonly used and can lead one on a wild goose chase to determine, "wait, is that equivalent?"

## Test Plan

No functional change should be in this change. No new features. Should just pass existing tests.