### PR TITLE
CI: add simple codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+codecov:
+  require_ci_to_pass: yes
+
+ignore:
+  - "**/*_gen.go"
+  - "**/*_gen_test.go"
+  - "**/generated"
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        informational: true

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,3 +12,7 @@ coverage:
       default:
         target: auto
         informational: true
+    patch:
+      default:
+        target: auto
+        informational: true


### PR DESCRIPTION
## Summary

Since the codecov app was enabled, it is showing up in PR status checks. This adds a quick configuration based on https://docs.codecov.com/docs/commit-status that we can refine more later.

## Test Plan

Status check should pick up changes.