### PR TITLE
Algokey: Add -v flag to get the version

### DIFF
--- a/cmd/algokey/main.go
+++ b/cmd/algokey/main.go
@@ -22,13 +22,21 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
+
+	"github.com/algorand/go-algorand/config"
 )
+
+var versionCheck bool
 
 var rootCmd = &cobra.Command{
 	Use:   "algokey",
 	Short: "CLI for managing Algorand keys",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
+		if versionCheck {
+			fmt.Println(config.FormatVersionAndLicense())
+			return
+		}
 		// If no arguments passed, we should fallback to help
 		cmd.HelpFunc()(cmd, args)
 	},
@@ -41,6 +49,7 @@ func init() {
 	rootCmd.AddCommand(signCmd)
 	rootCmd.AddCommand(multisigCmd)
 	rootCmd.AddCommand(partCmd)
+	rootCmd.Flags().BoolVarP(&versionCheck, "version", "v", false, "Display and write current build version and exit")
 }
 
 func main() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
Algokey was missing a way to tell what version it's using. One should be able to run `algokey -v` and get the same output as `goal -v`.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan
`algokey -v` gives the same output as `goal -v`
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
