### PR TITLE
add version to coin-generator

### DIFF
--- a/crypto/stateproof/coinGenerator.go
+++ b/crypto/stateproof/coinGenerator.go
@@ -29,7 +29,7 @@ import (
 // the index of the coin to reveal as part of the state proof.
 type coinChoiceSeed struct {
 	// the ToBeHashed function should be updated when fields are added to this structure
-
+	version        byte
 	partCommitment crypto.GenericDigest
 	lnProvenWeight uint64
 	sigCommitment  crypto.GenericDigest
@@ -48,7 +48,8 @@ func (cc *coinChoiceSeed) ToBeHashed() (protocol.HashID, []byte) {
 	lnProvenWtAsBytes := make([]byte, 8)
 	binary.LittleEndian.PutUint64(lnProvenWtAsBytes, cc.lnProvenWeight)
 
-	coinChoiceBytes := make([]byte, 0, len(cc.partCommitment)+len(lnProvenWtAsBytes)+len(cc.sigCommitment)+len(signedWtAsBytes)+len(cc.data))
+	coinChoiceBytes := make([]byte, 0, 1+len(cc.partCommitment)+len(lnProvenWtAsBytes)+len(cc.sigCommitment)+len(signedWtAsBytes)+len(cc.data))
+	coinChoiceBytes = append(coinChoiceBytes, cc.version)
 	coinChoiceBytes = append(coinChoiceBytes, cc.partCommitment...)
 	coinChoiceBytes = append(coinChoiceBytes, lnProvenWtAsBytes...)
 	coinChoiceBytes = append(coinChoiceBytes, cc.sigCommitment...)
@@ -71,6 +72,7 @@ type coinGenerator struct {
 // Shake(coinChoiceSeed)
 // we extract 64 bits from shake for each coin flip and divide it by signedWeight
 func makeCoinGenerator(choice *coinChoiceSeed) coinGenerator {
+	choice.version = VersionForCoinGenerator
 	rep := crypto.HashRep(choice)
 	shk := sha3.NewShake256()
 	shk.Write(rep)

--- a/crypto/stateproof/coinGenerator_test.go
+++ b/crypto/stateproof/coinGenerator_test.go
@@ -51,7 +51,7 @@ func TestCoinFixedLengthHash(t *testing.T) {
 	}
 
 	rep := crypto.HashRep(&choice)
-	a.Equal(179, len(rep))
+	a.Equal(180, len(rep))
 }
 
 func TestHashCoin(t *testing.T) {

--- a/crypto/stateproof/const.go
+++ b/crypto/stateproof/const.go
@@ -27,4 +27,7 @@ const (
 	precisionBits       = uint8(16)     // number of bits used for log approximation. This should not exceed 63
 	ln2IntApproximation = uint64(45427) // the value of the ln(2) with 16 bits of precision (i.e  ln2IntApproximation = ceil( 2^precisionBits * ln(2) ))
 	MaxReveals          = 1024          // MaxReveals is a bound on allocation and on numReveals to limit log computation
+	// VersionForCoinGenerator is used as part of the seed for Fiat-Shamir. We would change this
+	// value if the state proof verifier algorithm changes. This will allow us to make different coins for different state proof verification algorithms
+	VersionForCoinGenerator = byte(0)
 )


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

In order to support changes in the stateproof verifier, we need to add a version number to the coinChoiceSeed structure so that Fiat-Shamir could be used safely in the future.


<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
