### PR TITLE
ci: use tag to determine channel if possible

### DIFF
--- a/scripts/compute_branch.sh
+++ b/scripts/compute_branch.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 
-if [ -z "${TRAVIS_BRANCH}" ]; then
-    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ -n $(git status --porcelain) ]]; then
+    # If the branch isn't clean, default to HEAD to match old behavior.
+    BRANCH="HEAD"
+elif [ -z "${TRAVIS_BRANCH}" ]; then
+    # if there is no travis branch, set based on tag or branch
+    case "$(git describe --tags)" in
+      *"beta")    BRANCH="rel/beta" ;;
+      *"stable")  BRANCH="rel/stable" ;;
+      *"nightly") BRANCH="rel/nightly" ;;
+      *)          BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    esac
 else
     BRANCH="${TRAVIS_BRANCH}"
 fi


### PR DESCRIPTION
## Summary

This addresses a problem when building a release based on checking out a tagged commits. I noticed the problem when automating some docker container builds, I'd check out each tagged commit and the channel was being set to `dev`.

Our build channel scripts were unable to determine the correct channel. With this change, the script will check if the tag ends with one of the known tags and set the "BRANCH" variable such that the other scripts will properly detect the channel.

## Test Plan

Manual tested by checking out different tags / commits and making sure things look correct.