### PR TITLE
agreement: fix typo in bandwidthFilter_test

### DIFF
--- a/agreement/fuzzer/bandwidthFilter_test.go
+++ b/agreement/fuzzer/bandwidthFilter_test.go
@@ -167,7 +167,7 @@ func (n *BandwidthFilter) Tick(newClockTime int) bool {
 	n.downstreamMutex.Lock()
 	if n.downstreamDataSize < 0 && n.downstreamQueue.Len() == 0 {
 		if n.debugMessageLevel >= 1 {
-			fmt.Printf("node: %d, tick: %d, reseting queued downstream capacity %d -> 0\n", n.nodeID, n.currentTick, n.upstreamDataSize)
+			fmt.Printf("node: %d, tick: %d, resetting queued downstream capacity %d -> 0\n", n.nodeID, n.currentTick, n.upstreamDataSize)
 		}
 		n.downstreamDataSize = 0
 	}
@@ -179,7 +179,7 @@ func (n *BandwidthFilter) Tick(newClockTime int) bool {
 	// adjust the upstream size.
 	if n.upstreamDataSize < 0 && n.upstreamQueue.Len() == 0 {
 		if n.debugMessageLevel >= 1 {
-			fmt.Printf("node: %d, tick: %d, reseting queued upstream capacity %d -> 0\n", n.nodeID, n.currentTick, n.upstreamDataSize)
+			fmt.Printf("node: %d, tick: %d, resetting queued upstream capacity %d -> 0\n", n.nodeID, n.currentTick, n.upstreamDataSize)
 		}
 		n.upstreamDataSize = 0
 	}


### PR DESCRIPTION


<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Fixed typo.
```
reseting -> resetting
```