### PR TITLE
Enhancement: Detect when valid partkeys represent an offline or closed account

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -1380,27 +1380,21 @@ func (node *AlgorandFullNode) VotingKeys(votingRound, keysRound basics.Round) []
 			continue
 		}
 		if warningFlags&bitMismatchingVotingKey == bitMismatchingVotingKey {
-
-			logStr := fmt.Sprintf("node.VotingKeys: Account %v not participating on round %d: on chain voting key differ from participation voting key for round %d", mismatchingAddr, votingRound, keysRound)
-
 			// If we are closed, upgrade this to info so we don't spam telemetry reporting
 			if warningFlags&bitAccountIsClosed == bitAccountIsClosed {
-				node.log.Info(logStr)
+				node.log.Infof("node.VotingKeys: Address: %v - Account was closed but still has a participation key active.", mismatchingAddr)
 			} else {
-				node.log.Warnf(logStr)
+				node.log.Warnf("node.VotingKeys: Account %v not participating on round %d: on chain voting key differ from participation voting key for round %d", mismatchingAddr, votingRound, keysRound)
 			}
 
 			continue
 		}
 		if warningFlags&bitMismatchingSelectionKey == bitMismatchingSelectionKey {
-
-			logStr := fmt.Sprintf("node.VotingKeys: Account %v not participating on round %d: on chain selection key differ from participation selection key for round %d", mismatchingAddr, votingRound, keysRound)
-
 			// If we are closed, upgrade this to info so we don't spam telemetry reporting
 			if warningFlags&bitAccountIsClosed == bitAccountIsClosed {
-				node.log.Info(logStr)
+				node.log.Infof("node.VotingKeys: Address: %v - Account was closed but still has a participation key active.", mismatchingAddr)
 			} else {
-				node.log.Warn(logStr)
+				node.log.Warnf("node.VotingKeys: Account %v not participating on round %d: on chain voting key differ from participation voting key for round %d", mismatchingAddr, votingRound, keysRound)
 			}
 			continue
 		}

--- a/node/node.go
+++ b/node/node.go
@@ -1327,10 +1327,12 @@ func (node *AlgorandFullNode) VotingKeys(votingRound, keysRound basics.Round) []
 	accountsData := make(map[basics.Address]basics.OnlineAccountData, len(parts))
 	matchingAccountsKeys := make(map[basics.Address]bool)
 	mismatchingAccountsKeys := make(map[basics.Address]int)
-	const bitMismatchingVotingKey = 1
-	const bitMismatchingSelectionKey = 2
-	const bitAccountOffline = 4
-	const bitAccountIsClosed = 8
+	const (
+		bitMismatchingVotingKey = 1 << iota
+		bitMismatchingSelectionKey
+		bitAccountOffline
+		bitAccountIsClosed
+	)
 	for _, p := range parts {
 		acctData, hasAccountData := accountsData[p.Account]
 		if !hasAccountData {

--- a/node/node.go
+++ b/node/node.go
@@ -1390,7 +1390,7 @@ func (node *AlgorandFullNode) VotingKeys(votingRound, keysRound basics.Round) []
 		if matchingAccountsKeys[mismatchingAddr] {
 			continue
 		}
-		if warningFlags&bitMismatchingVotingKey != 0 {
+		if warningFlags&bitMismatchingVotingKey != 0 || warningFlags&bitMismatchingSelectionKey != 0 {
 			// If we are closed, upgrade this to info so we don't spam telemetry reporting
 			if warningFlags&bitAccountIsClosed != 0 {
 				node.log.Infof("node.VotingKeys: Address: %v - Account was closed but still has a participation key active.", mismatchingAddr)
@@ -1405,20 +1405,7 @@ func (node *AlgorandFullNode) VotingKeys(votingRound, keysRound basics.Round) []
 
 			continue
 		}
-		if warningFlags&bitMismatchingSelectionKey != 0 {
-			// If we are closed, upgrade this to info so we don't spam telemetry reporting
-			if warningFlags&bitAccountIsClosed != 0 {
-				node.log.Infof("node.VotingKeys: Address: %v - Account was closed but still has a participation key active.", mismatchingAddr)
-			} else if warningFlags&bitAccountOffline != 0 {
-				// If account is offline, then warn that no registration transaction has been issued or that previous registration transaction is expired.
-				node.log.Warnf("node.VotingKeys: Address: %v - Account is offline.  No registration transaction has been issued or a previous registration transaction has expired", mismatchingAddr)
-			} else {
-				// If the account isn't closed/offline and has a valid participation key, then this key may have been generated
-				// on a different node.
-				node.log.Warnf("node.VotingKeys: Account %v not participating on round %d: on chain voting key differ from participation voting key for round %d. Consider regenerating the participation key for this node.", mismatchingAddr, votingRound, keysRound)
-			}
-			continue
-		}
+
 	}
 	return participations
 }

--- a/node/node.go
+++ b/node/node.go
@@ -1385,7 +1385,7 @@ func (node *AlgorandFullNode) VotingKeys(votingRound, keysRound basics.Round) []
 				node.log.Infof("node.VotingKeys: Address: %v - Account was closed but still has a participation key active.", mismatchingAddr)
 			} else if warningFlags&bitAccountOffline != 0 {
 				// If account is offline, then warn that no registration transaction has been issued or that previous registration transaction is expired.
-				node.log.Warnf("node.VotingKeys: Account is offline.  No registration transaction has been issued or a previous registration transaction has expired")
+				node.log.Warnf("node.VotingKeys: Address: %v - Account is offline.  No registration transaction has been issued or a previous registration transaction has expired", mismatchingAddr)
 			} else {
 				// If the account isn't closed/offline and has a valid participation key, then this key may have been generated
 				// on a different node.
@@ -1400,7 +1400,7 @@ func (node *AlgorandFullNode) VotingKeys(votingRound, keysRound basics.Round) []
 				node.log.Infof("node.VotingKeys: Address: %v - Account was closed but still has a participation key active.", mismatchingAddr)
 			} else if warningFlags&bitAccountOffline != 0 {
 				// If account is offline, then warn that no registration transaction has been issued or that previous registration transaction is expired.
-				node.log.Warnf("node.VotingKeys: Account is offline.  No registration transaction has been issued or a previous registration transaction has expired")
+				node.log.Warnf("node.VotingKeys: Address: %v - Account is offline.  No registration transaction has been issued or a previous registration transaction has expired", mismatchingAddr)
 			} else {
 				// If the account isn't closed/offline and has a valid participation key, then this key may have been generated
 				// on a different node.

--- a/node/node.go
+++ b/node/node.go
@@ -1383,8 +1383,13 @@ func (node *AlgorandFullNode) VotingKeys(votingRound, keysRound basics.Round) []
 			// If we are closed, upgrade this to info so we don't spam telemetry reporting
 			if warningFlags&bitAccountIsClosed == bitAccountIsClosed {
 				node.log.Infof("node.VotingKeys: Address: %v - Account was closed but still has a participation key active.", mismatchingAddr)
+			} else if warningFlags&bitAccountOffline == bitAccountOffline {
+				// If account is offline, then warn that no registration transaction has been issued or that previous registration transaction is expired.
+				node.log.Warnf("node.VotingKeys: Account is offline.  No registration transaction has been issued or a previous registration transaction has expired")
 			} else {
-				node.log.Warnf("node.VotingKeys: Account %v not participating on round %d: on chain voting key differ from participation voting key for round %d", mismatchingAddr, votingRound, keysRound)
+				// If the account isn't closed/offline and has a valid participation key, then this key may have been generated
+				// on a different node.
+				node.log.Warnf("node.VotingKeys: Account %v not participating on round %d: on chain voting key differ from participation voting key for round %d. Consider regenerating the participation key for this node.", mismatchingAddr, votingRound, keysRound)
 			}
 
 			continue
@@ -1393,8 +1398,13 @@ func (node *AlgorandFullNode) VotingKeys(votingRound, keysRound basics.Round) []
 			// If we are closed, upgrade this to info so we don't spam telemetry reporting
 			if warningFlags&bitAccountIsClosed == bitAccountIsClosed {
 				node.log.Infof("node.VotingKeys: Address: %v - Account was closed but still has a participation key active.", mismatchingAddr)
+			} else if warningFlags&bitAccountOffline == bitAccountOffline {
+				// If account is offline, then warn that no registration transaction has been issued or that previous registration transaction is expired.
+				node.log.Warnf("node.VotingKeys: Account is offline.  No registration transaction has been issued or a previous registration transaction has expired")
 			} else {
-				node.log.Warnf("node.VotingKeys: Account %v not participating on round %d: on chain voting key differ from participation voting key for round %d", mismatchingAddr, votingRound, keysRound)
+				// If the account isn't closed/offline and has a valid participation key, then this key may have been generated
+				// on a different node.
+				node.log.Warnf("node.VotingKeys: Account %v not participating on round %d: on chain voting key differ from participation voting key for round %d. Consider regenerating the participation key for this node.", mismatchingAddr, votingRound, keysRound)
 			}
 			continue
 		}

--- a/node/node.go
+++ b/node/node.go
@@ -1321,7 +1321,6 @@ func (node *AlgorandFullNode) AssembleBlock(round basics.Round) (agreement.Valid
 	return validatedBlock{vb: lvb}, nil
 }
 
-
 // getOfflineClosedStatus will return an int with the appropriate bit(s) set if it is offline and/or online
 func getOfflineClosedStatus(acctData basics.OnlineAccountData) int {
 	rval := 0

--- a/node/node.go
+++ b/node/node.go
@@ -1379,11 +1379,11 @@ func (node *AlgorandFullNode) VotingKeys(votingRound, keysRound basics.Round) []
 		if matchingAccountsKeys[mismatchingAddr] {
 			continue
 		}
-		if warningFlags&bitMismatchingVotingKey == bitMismatchingVotingKey {
+		if warningFlags&bitMismatchingVotingKey != 0 {
 			// If we are closed, upgrade this to info so we don't spam telemetry reporting
-			if warningFlags&bitAccountIsClosed == bitAccountIsClosed {
+			if warningFlags&bitAccountIsClosed != 0 {
 				node.log.Infof("node.VotingKeys: Address: %v - Account was closed but still has a participation key active.", mismatchingAddr)
-			} else if warningFlags&bitAccountOffline == bitAccountOffline {
+			} else if warningFlags&bitAccountOffline != 0 {
 				// If account is offline, then warn that no registration transaction has been issued or that previous registration transaction is expired.
 				node.log.Warnf("node.VotingKeys: Account is offline.  No registration transaction has been issued or a previous registration transaction has expired")
 			} else {
@@ -1394,11 +1394,11 @@ func (node *AlgorandFullNode) VotingKeys(votingRound, keysRound basics.Round) []
 
 			continue
 		}
-		if warningFlags&bitMismatchingSelectionKey == bitMismatchingSelectionKey {
+		if warningFlags&bitMismatchingSelectionKey != 0 {
 			// If we are closed, upgrade this to info so we don't spam telemetry reporting
-			if warningFlags&bitAccountIsClosed == bitAccountIsClosed {
+			if warningFlags&bitAccountIsClosed != 0 {
 				node.log.Infof("node.VotingKeys: Address: %v - Account was closed but still has a participation key active.", mismatchingAddr)
-			} else if warningFlags&bitAccountOffline == bitAccountOffline {
+			} else if warningFlags&bitAccountOffline != 0 {
 				// If account is offline, then warn that no registration transaction has been issued or that previous registration transaction is expired.
 				node.log.Warnf("node.VotingKeys: Account is offline.  No registration transaction has been issued or a previous registration transaction has expired")
 			} else {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -554,8 +554,8 @@ func TestAsyncRecord(t *testing.T) {
 	require.Equal(t, 20000, int(records[0].LastBlockProposal))
 }
 
-// OfflineOnlineClosedBitStatusTest a test that validates that the correct bits are being set
-func OfflineOnlineClosedBitStatusTest(t *testing.T) {
+// TestOfflineOnlineClosedBitStatus a test that validates that the correct bits are being set
+func TestOfflineOnlineClosedBitStatus(t *testing.T) {
 	tests := []struct {
 		name        string
 		acctData    basics.OnlineAccountData

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -556,6 +556,8 @@ func TestAsyncRecord(t *testing.T) {
 
 // TestOfflineOnlineClosedBitStatus a test that validates that the correct bits are being set
 func TestOfflineOnlineClosedBitStatus(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	tests := []struct {
 		name        string
 		acctData    basics.OnlineAccountData

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -553,3 +553,22 @@ func TestAsyncRecord(t *testing.T) {
 	require.Equal(t, 10000, int(records[0].LastVote))
 	require.Equal(t, 20000, int(records[0].LastBlockProposal))
 }
+
+// OfflineOnlineClosedBitStatusTest a test that validates that the correct bits are being set 
+func OfflineOnlineClosedBitStatusTest(t *testing.T) {
+	tests := []struct {
+		name        string
+		acctData    basics.OnlineAccountData
+		expectedInt int
+	}{
+		{"online 1", basics.OnlineAccountData{VoteFirstValid: 1, VoteLastValid: 100, MicroAlgosWithRewards: basics.MicroAlgos{Raw: 0}}, 0},
+		{"online 2", basics.OnlineAccountData{VoteFirstValid: 1, VoteLastValid: 100, MicroAlgosWithRewards: basics.MicroAlgos{Raw: 1}}, 0},
+		{"offline & not closed", basics.OnlineAccountData{VoteFirstValid: 0, VoteLastValid: 0, MicroAlgosWithRewards: basics.MicroAlgos{Raw: 1}}, 0 | bitAccountOffline},
+		{"offline & closed", basics.OnlineAccountData{VoteFirstValid: 0, VoteLastValid: 0, MicroAlgosWithRewards: basics.MicroAlgos{Raw: 0}}, 0 | bitAccountOffline | bitAccountIsClosed},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expectedInt, getOfflineClosedStatus(test.acctData))
+		})
+	}
+}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -554,7 +554,7 @@ func TestAsyncRecord(t *testing.T) {
 	require.Equal(t, 20000, int(records[0].LastBlockProposal))
 }
 
-// OfflineOnlineClosedBitStatusTest a test that validates that the correct bits are being set 
+// OfflineOnlineClosedBitStatusTest a test that validates that the correct bits are being set
 func OfflineOnlineClosedBitStatusTest(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
Resolves #2060

Resolves all scenarios described below:

Scenario 1 (S1): Address is closed, but has a participation key that is still registered and valid given the current round number.
Scenario 2 (S2): Address is offline. Could imply no registration txn or an expired one.
Scenario 3 (S3): Address is online, with a valid participation key.

The breakdown of the scenarios by count is as follows:

S1: 7 addresses
S2: 43 addresses
S3: 2 addresses

The following actions are recommended for each scenario:

S1

Check that account is closed for the on-chain data. If account is closed, silently ignore since this account has been officially closed.

S2

Check that account is offline. If account is offline, return error indicating that no registration transaction has been issued or that previous registration transaction is expired.

S3

Recommend that error message indicates that user should regenerate participation key for the node.