### PR TITLE
Move online queries into onlineAccountsDbQueries

### DIFF
--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -2949,7 +2949,7 @@ func TestAccountOnlineQueries(t *testing.T) {
 	addRound(2, delta2)
 	addRound(3, delta3)
 
-	queries, err := accountsInitDbQueries(tx, tx)
+	queries, err := onlineAccountsInitDbQueries(tx, tx)
 	require.NoError(t, err)
 
 	// check round 1

--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -63,7 +63,7 @@ type onlineAccounts struct {
 	dbs db.Pair
 
 	// Prepared SQL statements for fast accounts DB lookups.
-	accountsq *accountsDbQueries
+	accountsq *onlineAccountsDbQueries
 
 	// cachedDBRoundOnline is always exactly tracker DB round (and therefore, onlineAccountsRound()),
 	// cached to use in lookup functions
@@ -181,7 +181,7 @@ func (ao *onlineAccounts) initializeFromDisk(l ledgerForTracker, lastBalancesRou
 		return
 	}
 
-	ao.accountsq, err = accountsInitDbQueries(ao.dbs.Rdb.Handle, ao.dbs.Wdb.Handle)
+	ao.accountsq, err = onlineAccountsInitDbQueries(ao.dbs.Rdb.Handle, ao.dbs.Wdb.Handle)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This will allow to write a migration unit test - the old schema uses accountbase and its queries, and the new - the new queries from a separate class and without the "onlineaccounts table does not exist" error.