### PR TITLE
320 rounds: implement catchpoint persistence

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -323,7 +323,9 @@ const (
 	// catchpointStateLastCatchpoint is written by a node once a catchpoint label is created for a round
 	catchpointStateLastCatchpoint = catchpointState("lastCatchpoint")
 	// This state variable is set to 1 if catchpoint's first stage is unfinished,
-	// and is 0 otherwise.
+	// and is 0 otherwise. Used to clear / restart the first stage after a crash.
+	// This key is set in the same db transaction as the account updates, so the
+	// unfinished first stage corresponds to the current db round.
 	catchpointStateWritingFirstStageInfo = catchpointState("writingFirstStageInfo")
 	// If there is an unfinished catchpoint, this state variable is set to
 	// the catchpoint's round. Otherwise, it is set to 0.
@@ -4600,15 +4602,6 @@ func loadTxTail(ctx context.Context, tx *sql.Tx, dbRound basics.Round) (roundDat
 		roundHash[i], roundHash[len(roundHash)-i-1] = roundHash[len(roundHash)-i-1], roundHash[i]
 	}
 	return roundData, roundHash, expectedRound + 1, nil
-}
-
-func deleteStoredCatchpoint(ctx context.Context, e db.Executable, round basics.Round) error {
-	f := func() error {
-		query := "DELETE FROM storedcatchpoints WHERE round=?"
-		_, err := e.ExecContext(ctx, query, round)
-		return err
-	}
-	return db.Retry(f)
 }
 
 func storeCatchpoint(ctx context.Context, e db.Executable, round basics.Round, fileName string, catchpoint string, fileSize int64) error {

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -43,19 +43,11 @@ import (
 // accountsDbQueries is used to cache a prepared SQL statement to look up
 // the state of a single account.
 type accountsDbQueries struct {
-	listCreatablesStmt          *sql.Stmt
-	lookupStmt                  *sql.Stmt
-	lookupResourcesStmt         *sql.Stmt
-	lookupAllResourcesStmt      *sql.Stmt
-	lookupCreatorStmt           *sql.Stmt
-	deleteStoredCatchpoint      *sql.Stmt
-	insertStoredCatchpoint      *sql.Stmt
-	selectOldestCatchpointFiles *sql.Stmt
-	selectCatchpointStateUint64 *sql.Stmt
-	deleteCatchpointState       *sql.Stmt
-	insertCatchpointStateUint64 *sql.Stmt
-	selectCatchpointStateString *sql.Stmt
-	insertCatchpointStateString *sql.Stmt
+	listCreatablesStmt     *sql.Stmt
+	lookupStmt             *sql.Stmt
+	lookupResourcesStmt    *sql.Stmt
+	lookupAllResourcesStmt *sql.Stmt
+	lookupCreatorStmt      *sql.Stmt
 }
 
 type onlineAccountsDbQueries struct {
@@ -162,6 +154,11 @@ const createCatchpointFirstStageInfoTable = `
 	CREATE TABLE IF NOT EXISTS catchpointfirststageinfo (
 	round integer primary key NOT NULL,
 	info blob NOT NULL)`
+
+const createUnfinishedCatchpointsTable = `
+	CREATE TABLE IF NOT EXISTS unfinishedcatchpoints (
+	round integer primary key NOT NULL,
+	blockhash blob NOT NULL)`
 
 var accountsResetExprs = []string{
 	`DROP TABLE IF EXISTS acctrounds`,
@@ -325,9 +322,12 @@ type catchpointState string
 const (
 	// catchpointStateLastCatchpoint is written by a node once a catchpoint label is created for a round
 	catchpointStateLastCatchpoint = catchpointState("lastCatchpoint")
-	// catchpointStateWritingCatchpoint is written by a node while a catchpoint file is being created. It gets deleted once the file
-	// creation is complete, and used as a way to record the fact that we've started generating the catchpoint file for that particular
-	// round.
+	// This state variable is set to 1 if catchpoint's first stage is unfinished,
+	// and is 0 otherwise.
+	catchpointStateWritingFirstStageInfo = catchpointState("writingFirstStageInfo")
+	// If there is an unfinished catchpoint, this state variable is set to
+	// the catchpoint's round. Otherwise, it is set to 0.
+	// DEPRECATED.
 	catchpointStateWritingCatchpoint = catchpointState("writingCatchpoint")
 	// catchpointCatchupState is the state of the catchup process. The variable is stored only during the catchpoint catchup process, and removed afterward.
 	catchpointStateCatchupState = catchpointState("catchpointCatchupState")
@@ -341,7 +341,8 @@ const (
 	// catchpointStateCatchupHashRound is the round that is associated with the hash of the merkle trie. Normally, it's identical to catchpointStateCatchupBalancesRound,
 	// however, it could differ when we catchup from a catchpoint that was created using a different version : in this case,
 	// we set it to zero in order to reset the merkle trie. This would force the merkle trie to be re-build on startup ( if needed ).
-	catchpointStateCatchupHashRound = catchpointState("catchpointCatchupHashRound")
+	catchpointStateCatchupHashRound   = catchpointState("catchpointCatchupHashRound")
+	catchpointStateCatchpointLookback = catchpointState("catchpointLookback")
 )
 
 // normalizedAccountBalance is a staging area for a catchpoint file account information before it's being added to the catchpoint staging tables.
@@ -1350,6 +1351,11 @@ func accountsCreateOnlineRoundParamsTable(ctx context.Context, tx *sql.Tx) (err 
 
 func accountsCreateCatchpointFirstStageInfoTable(ctx context.Context, e db.Executable) error {
 	_, err := e.ExecContext(ctx, createCatchpointFirstStageInfoTable)
+	return err
+}
+
+func accountsCreateUnfinishedCatchpointsTable(ctx context.Context, e db.Executable) error {
+	_, err := e.ExecContext(ctx, createUnfinishedCatchpointsTable)
 	return err
 }
 
@@ -2420,71 +2426,31 @@ func accountsHashRound(tx *sql.Tx) (hashrnd basics.Round, err error) {
 	return
 }
 
-func accountsInitDbQueries(r db.Queryable, w db.Queryable) (*accountsDbQueries, error) {
+func accountsInitDbQueries(q db.Queryable) (*accountsDbQueries, error) {
 	var err error
 	qs := &accountsDbQueries{}
 
-	qs.listCreatablesStmt, err = r.Prepare("SELECT rnd, asset, creator FROM acctrounds LEFT JOIN assetcreators ON assetcreators.asset <= ? AND assetcreators.ctype = ? WHERE acctrounds.id='acctbase' ORDER BY assetcreators.asset desc LIMIT ?")
+	qs.listCreatablesStmt, err = q.Prepare("SELECT rnd, asset, creator FROM acctrounds LEFT JOIN assetcreators ON assetcreators.asset <= ? AND assetcreators.ctype = ? WHERE acctrounds.id='acctbase' ORDER BY assetcreators.asset desc LIMIT ?")
 	if err != nil {
 		return nil, err
 	}
 
-	qs.lookupStmt, err = r.Prepare("SELECT accountbase.rowid, rnd, data FROM acctrounds LEFT JOIN accountbase ON address=? WHERE id='acctbase'")
+	qs.lookupStmt, err = q.Prepare("SELECT accountbase.rowid, rnd, data FROM acctrounds LEFT JOIN accountbase ON address=? WHERE id='acctbase'")
 	if err != nil {
 		return nil, err
 	}
 
-	qs.lookupResourcesStmt, err = r.Prepare("SELECT accountbase.rowid, rnd, resources.data FROM acctrounds LEFT JOIN accountbase ON accountbase.address = ? LEFT JOIN resources ON accountbase.rowid = resources.addrid AND resources.aidx = ? WHERE id='acctbase'")
+	qs.lookupResourcesStmt, err = q.Prepare("SELECT accountbase.rowid, rnd, resources.data FROM acctrounds LEFT JOIN accountbase ON accountbase.address = ? LEFT JOIN resources ON accountbase.rowid = resources.addrid AND resources.aidx = ? WHERE id='acctbase'")
 	if err != nil {
 		return nil, err
 	}
 
-	qs.lookupAllResourcesStmt, err = r.Prepare("SELECT accountbase.rowid, rnd, resources.aidx, resources.data FROM acctrounds LEFT JOIN accountbase ON accountbase.address = ? LEFT JOIN resources ON accountbase.rowid = resources.addrid WHERE id='acctbase'")
+	qs.lookupAllResourcesStmt, err = q.Prepare("SELECT accountbase.rowid, rnd, resources.aidx, resources.data FROM acctrounds LEFT JOIN accountbase ON accountbase.address = ? LEFT JOIN resources ON accountbase.rowid = resources.addrid WHERE id='acctbase'")
 	if err != nil {
 		return nil, err
 	}
 
-	qs.lookupCreatorStmt, err = r.Prepare("SELECT rnd, creator FROM acctrounds LEFT JOIN assetcreators ON asset = ? AND ctype = ? WHERE id='acctbase'")
-	if err != nil {
-		return nil, err
-	}
-
-	qs.deleteStoredCatchpoint, err = w.Prepare("DELETE FROM storedcatchpoints WHERE round=?")
-	if err != nil {
-		return nil, err
-	}
-
-	qs.insertStoredCatchpoint, err = w.Prepare("INSERT INTO storedcatchpoints(round, filename, catchpoint, filesize, pinned) VALUES(?, ?, ?, ?, 0)")
-	if err != nil {
-		return nil, err
-	}
-
-	qs.selectOldestCatchpointFiles, err = r.Prepare("SELECT round, filename FROM storedcatchpoints WHERE pinned = 0 and round <= COALESCE((SELECT round FROM storedcatchpoints WHERE pinned = 0 ORDER BY round DESC LIMIT ?, 1),0) ORDER BY round ASC LIMIT ?")
-	if err != nil {
-		return nil, err
-	}
-
-	qs.selectCatchpointStateUint64, err = r.Prepare("SELECT intval FROM catchpointstate WHERE id=?")
-	if err != nil {
-		return nil, err
-	}
-
-	qs.deleteCatchpointState, err = w.Prepare("DELETE FROM catchpointstate WHERE id=?")
-	if err != nil {
-		return nil, err
-	}
-
-	qs.insertCatchpointStateUint64, err = w.Prepare("INSERT OR REPLACE INTO catchpointstate(id, intval) VALUES(?, ?)")
-	if err != nil {
-		return nil, err
-	}
-
-	qs.insertCatchpointStateString, err = w.Prepare("INSERT OR REPLACE INTO catchpointstate(id, strval) VALUES(?, ?)")
-	if err != nil {
-		return nil, err
-	}
-
-	qs.selectCatchpointStateString, err = r.Prepare("SELECT strval FROM catchpointstate WHERE id=?")
+	qs.lookupCreatorStmt, err = q.Prepare("SELECT rnd, creator FROM acctrounds LEFT JOIN assetcreators ON asset = ? AND ctype = ? WHERE id='acctbase'")
 	if err != nil {
 		return nil, err
 	}
@@ -2732,109 +2698,6 @@ func (qs *onlineAccountsDbQueries) lookupOnlineHistory(addr basics.Address) (res
 	return
 }
 
-func (qs *accountsDbQueries) storeCatchpoint(ctx context.Context, round basics.Round, fileName string, catchpoint string, fileSize int64) (err error) {
-	err = db.Retry(func() (err error) {
-		_, err = qs.deleteStoredCatchpoint.ExecContext(ctx, round)
-
-		if err != nil || (fileName == "" && catchpoint == "" && fileSize == 0) {
-			return
-		}
-
-		_, err = qs.insertStoredCatchpoint.ExecContext(ctx, round, fileName, catchpoint, fileSize)
-		return
-	})
-	return
-}
-
-func (qs *accountsDbQueries) getOldestCatchpointFiles(ctx context.Context, fileCount int, filesToKeep int) (fileNames map[basics.Round]string, err error) {
-	err = db.Retry(func() (err error) {
-		var rows *sql.Rows
-		rows, err = qs.selectOldestCatchpointFiles.QueryContext(ctx, filesToKeep, fileCount)
-		if err != nil {
-			return
-		}
-		defer rows.Close()
-
-		fileNames = make(map[basics.Round]string)
-		for rows.Next() {
-			var fileName string
-			var round basics.Round
-			err = rows.Scan(&round, &fileName)
-			if err != nil {
-				return
-			}
-			fileNames[round] = fileName
-		}
-
-		err = rows.Err()
-		return
-	})
-	return
-}
-
-func (qs *accountsDbQueries) readCatchpointStateUint64(ctx context.Context, stateName catchpointState) (rnd uint64, def bool, err error) {
-	var val sql.NullInt64
-	err = db.Retry(func() (err error) {
-		err = qs.selectCatchpointStateUint64.QueryRowContext(ctx, stateName).Scan(&val)
-		if err == sql.ErrNoRows || (err == nil && !val.Valid) {
-			val.Int64 = 0 // default to zero.
-			err = nil
-			def = true
-			return
-		}
-		return err
-	})
-	return uint64(val.Int64), def, err
-}
-
-func (qs *accountsDbQueries) writeCatchpointStateUint64(ctx context.Context, stateName catchpointState, setValue uint64) (cleared bool, err error) {
-	err = db.Retry(func() (err error) {
-		if setValue == 0 {
-			_, err = qs.deleteCatchpointState.ExecContext(ctx, stateName)
-			cleared = true
-			return err
-		}
-
-		// we don't know if there is an entry in the table for this state, so we'll insert/replace it just in case.
-		_, err = qs.insertCatchpointStateUint64.ExecContext(ctx, stateName, setValue)
-		cleared = false
-		return err
-	})
-	return cleared, err
-
-}
-
-func (qs *accountsDbQueries) readCatchpointStateString(ctx context.Context, stateName catchpointState) (str string, def bool, err error) {
-	var val sql.NullString
-	err = db.Retry(func() (err error) {
-		err = qs.selectCatchpointStateString.QueryRowContext(ctx, stateName).Scan(&val)
-		if err == sql.ErrNoRows || (err == nil && !val.Valid) {
-			val.String = "" // default to empty string
-			err = nil
-			def = true
-			return
-		}
-		return err
-	})
-	return val.String, def, err
-}
-
-func (qs *accountsDbQueries) writeCatchpointStateString(ctx context.Context, stateName catchpointState, setValue string) (cleared bool, err error) {
-	err = db.Retry(func() (err error) {
-		if setValue == "" {
-			_, err = qs.deleteCatchpointState.ExecContext(ctx, stateName)
-			cleared = true
-			return err
-		}
-
-		// we don't know if there is an entry in the table for this state, so we'll insert/replace it just in case.
-		_, err = qs.insertCatchpointStateString.ExecContext(ctx, stateName, setValue)
-		cleared = false
-		return err
-	})
-	return cleared, err
-}
-
 func (qs *accountsDbQueries) close() {
 	preparedQueries := []**sql.Stmt{
 		&qs.listCreatablesStmt,
@@ -2842,14 +2705,6 @@ func (qs *accountsDbQueries) close() {
 		&qs.lookupResourcesStmt,
 		&qs.lookupAllResourcesStmt,
 		&qs.lookupCreatorStmt,
-		&qs.deleteStoredCatchpoint,
-		&qs.insertStoredCatchpoint,
-		&qs.selectOldestCatchpointFiles,
-		&qs.selectCatchpointStateUint64,
-		&qs.deleteCatchpointState,
-		&qs.insertCatchpointStateUint64,
-		&qs.selectCatchpointStateString,
-		&qs.insertCatchpointStateString,
 	}
 	for _, preparedQuery := range preparedQueries {
 		if (*preparedQuery) != nil {
@@ -4747,6 +4602,156 @@ func loadTxTail(ctx context.Context, tx *sql.Tx, dbRound basics.Round) (roundDat
 	return roundData, roundHash, expectedRound + 1, nil
 }
 
+func deleteStoredCatchpoint(ctx context.Context, e db.Executable, round basics.Round) error {
+	f := func() error {
+		query := "DELETE FROM storedcatchpoints WHERE round=?"
+		_, err := e.ExecContext(ctx, query, round)
+		return err
+	}
+	return db.Retry(f)
+}
+
+func storeCatchpoint(ctx context.Context, e db.Executable, round basics.Round, fileName string, catchpoint string, fileSize int64) error {
+	f := func() error {
+		query := "DELETE FROM storedcatchpoints WHERE round=?"
+		_, err := e.ExecContext(ctx, query, round)
+		if err != nil || (fileName == "" && catchpoint == "" && fileSize == 0) {
+			return err
+		}
+
+		query = "INSERT INTO storedcatchpoints(round, filename, catchpoint, filesize, pinned) VALUES(?, ?, ?, ?, 0)"
+		_, err = e.ExecContext(ctx, query, round, fileName, catchpoint, fileSize)
+		return err
+	}
+	return db.Retry(f)
+}
+
+func getOldestCatchpointFiles(ctx context.Context, q db.Queryable, fileCount int, filesToKeep int) (map[basics.Round]string /*fileNames*/, error) {
+	var res map[basics.Round]string
+
+	f := func() error {
+		query := "SELECT round, filename FROM storedcatchpoints WHERE pinned = 0 and round <= COALESCE((SELECT round FROM storedcatchpoints WHERE pinned = 0 ORDER BY round DESC LIMIT ?, 1),0) ORDER BY round ASC LIMIT ?"
+		rows, err := q.QueryContext(ctx, query, filesToKeep, fileCount)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		res = make(map[basics.Round]string)
+		for rows.Next() {
+			var fileName string
+			var round basics.Round
+			err = rows.Scan(&round, &fileName)
+			if err != nil {
+				return err
+			}
+			res[round] = fileName
+		}
+
+		return rows.Err()
+	}
+	err := db.Retry(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func readCatchpointStateUint64(ctx context.Context, q db.Queryable, stateName catchpointState) (uint64, error) {
+	var value uint64
+
+	f := func() error {
+		query := "SELECT intval FROM catchpointstate WHERE id=?"
+		var v sql.NullInt64
+		err := q.QueryRowContext(ctx, query, stateName).Scan(&v)
+		if err == sql.ErrNoRows {
+			value = 0
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if !v.Valid {
+			value = 0
+		} else {
+			value = uint64(v.Int64)
+		}
+		return nil
+	}
+	err := db.Retry(f)
+	if err != nil {
+		return 0, err
+	}
+
+	return value, nil
+}
+
+func deleteCatchpointStateImpl(ctx context.Context, e db.Executable, stateName catchpointState) error {
+	query := "DELETE FROM catchpointstate WHERE id=?"
+	_, err := e.ExecContext(ctx, query, stateName)
+	return err
+}
+
+func writeCatchpointStateUint64(ctx context.Context, e db.Executable, stateName catchpointState, setValue uint64) error {
+	f := func() error {
+		if setValue == 0 {
+			return deleteCatchpointStateImpl(ctx, e, stateName)
+		}
+
+		// we don't know if there is an entry in the table for this state, so we'll insert/replace it just in case.
+		query := "INSERT OR REPLACE INTO catchpointstate(id, intval) VALUES(?, ?)"
+		_, err := e.ExecContext(ctx, query, stateName, setValue)
+		return err
+	}
+	return db.Retry(f)
+}
+
+func readCatchpointStateString(ctx context.Context, q db.Queryable, stateName catchpointState) (string, error) {
+	var value string
+
+	f := func() error {
+		query := "SELECT strval FROM catchpointstate WHERE id=?"
+		var v sql.NullString
+		err := q.QueryRowContext(ctx, query, stateName).Scan(&v)
+		if err == sql.ErrNoRows {
+			value = ""
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if !v.Valid {
+			value = ""
+		} else {
+			value = v.String
+		}
+		return nil
+	}
+	err := db.Retry(f)
+	if err != nil {
+		return "", err
+	}
+
+	return value, nil
+}
+
+func writeCatchpointStateString(ctx context.Context, e db.Executable, stateName catchpointState, setValue string) error {
+	f := func() error {
+		if setValue == "" {
+			return deleteCatchpointStateImpl(ctx, e, stateName)
+		}
+
+		// we don't know if there is an entry in the table for this state, so we'll insert/replace it just in case.
+		query := "INSERT OR REPLACE INTO catchpointstate(id, strval) VALUES(?, ?)"
+		_, err := e.ExecContext(ctx, query, stateName, setValue)
+		return err
+	}
+	return db.Retry(f)
+}
+
 // For the `catchpointfirststageinfo` table.
 type catchpointFirstStageInfo struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
@@ -4761,10 +4766,10 @@ type catchpointFirstStageInfo struct {
 	TotalChunks uint64 `codec:"chunksCount"`
 }
 
-func insertCatchpointFirstStageInfo(e db.Executable, round basics.Round, info *catchpointFirstStageInfo) error {
+func insertOrReplaceCatchpointFirstStageInfo(e db.Executable, round basics.Round, info *catchpointFirstStageInfo) error {
 	infoSerialized := protocol.Encode(info)
 	f := func() error {
-		query := "INSERT INTO catchpointfirststageinfo(round, info) VALUES(?, ?)"
+		query := "INSERT OR REPLACE INTO catchpointfirststageinfo(round, info) VALUES(?, ?)"
 		_, err := e.Exec(query, round, infoSerialized)
 		return err
 	}
@@ -4835,6 +4840,62 @@ func deleteOldCatchpointFirstStageInfo(e db.Executable, maxRoundToDelete basics.
 	f := func() error {
 		query := "DELETE FROM catchpointfirststageinfo WHERE round <= ?"
 		_, err := e.Exec(query, maxRoundToDelete)
+		return err
+	}
+	return db.Retry(f)
+}
+
+func insertUnfinishedCatchpoint(ctx context.Context, e db.Executable, round basics.Round, blockHash crypto.Digest) error {
+	f := func() error {
+		query := "INSERT INTO unfinishedcatchpoints(round, blockhash) VALUES(?, ?)"
+		_, err := e.ExecContext(ctx, query, round, blockHash[:])
+		return err
+	}
+	return db.Retry(f)
+}
+
+type unfinishedCatchpointRecord struct {
+	round     basics.Round
+	blockHash crypto.Digest
+}
+
+func selectUnfinishedCatchpoints(ctx context.Context, q db.Queryable) ([]unfinishedCatchpointRecord, error) {
+	var res []unfinishedCatchpointRecord
+
+	f := func() error {
+		query := "SELECT round, blockhash FROM unfinishedcatchpoints"
+		rows, err := q.QueryContext(ctx, query)
+		if err != nil {
+			return err
+		}
+
+		// Clear `res` in case this function is repeated.
+		res = res[:0]
+		for rows.Next() {
+			var record unfinishedCatchpointRecord
+			var blockHash []byte
+			err = rows.Scan(&record.round, &blockHash)
+			if err != nil {
+				return err
+			}
+			copy(record.blockHash[:], blockHash)
+			res = append(res, record)
+		}
+
+		return nil
+	}
+	err := db.Retry(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func clearUnfinishedCatchpoints(ctx context.Context, e db.Executable) error {
+	f := func() error {
+		query := "DELETE FROM unfinishedcatchpoints"
+		_, err := e.ExecContext(ctx, query)
 		return err
 	}
 	return db.Retry(f)

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -4856,7 +4856,7 @@ func selectUnfinishedCatchpoints(ctx context.Context, q db.Queryable) ([]unfinis
 	var res []unfinishedCatchpointRecord
 
 	f := func() error {
-		query := "SELECT round, blockhash FROM unfinishedcatchpoints"
+		query := "SELECT round, blockhash FROM unfinishedcatchpoints ORDER BY round"
 		rows, err := q.QueryContext(ctx, query)
 		if err != nil {
 			return err
@@ -4885,10 +4885,10 @@ func selectUnfinishedCatchpoints(ctx context.Context, q db.Queryable) ([]unfinis
 	return res, nil
 }
 
-func clearUnfinishedCatchpoints(ctx context.Context, e db.Executable) error {
+func deleteUnfinishedCatchpoint(ctx context.Context, e db.Executable, round basics.Round) error {
 	f := func() error {
-		query := "DELETE FROM unfinishedcatchpoints"
-		_, err := e.ExecContext(ctx, query)
+		query := "DELETE FROM unfinishedcatchpoints WHERE round = ?"
+		_, err := e.ExecContext(ctx, query, round)
 		return err
 	}
 	return db.Retry(f)

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -3711,6 +3711,8 @@ func TestCatchpointFirstStageInfoTable(t *testing.T) {
 }
 
 func TestUnfinishedCatchpointsTable(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	dbs, _ := dbOpenTest(t, true)
 	defer dbs.Close()
 

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -3732,8 +3732,6 @@ func TestUnfinishedCatchpointsTable(t *testing.T) {
 
 	ret, err := selectUnfinishedCatchpoints(context.Background(), dbs.Rdb.Handle)
 	require.NoError(t, err)
-
-	sort.Slice(ret, func(i, j int) bool { return ret[i].round < ret[j].round })
 	expected := []unfinishedCatchpointRecord{
 		{
 			round:     3,
@@ -3746,10 +3744,16 @@ func TestUnfinishedCatchpointsTable(t *testing.T) {
 	}
 	require.Equal(t, expected, ret)
 
-	err = clearUnfinishedCatchpoints(context.Background(), dbs.Wdb.Handle)
+	err = deleteUnfinishedCatchpoint(context.Background(), dbs.Wdb.Handle, 3)
 	require.NoError(t, err)
 
 	ret, err = selectUnfinishedCatchpoints(context.Background(), dbs.Rdb.Handle)
 	require.NoError(t, err)
-	require.Empty(t, ret)
+	expected = []unfinishedCatchpointRecord{
+		{
+			round:     5,
+			blockHash: d5,
+		},
+	}
+	require.Equal(t, expected, ret)
 }

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -90,7 +90,7 @@ func checkAccounts(t *testing.T, tx *sql.Tx, rnd basics.Round, accts map[basics.
 	require.NoError(t, err)
 	require.Equal(t, r, rnd)
 
-	aq, err := accountsInitDbQueries(tx, tx)
+	aq, err := accountsInitDbQueries(tx)
 	require.NoError(t, err)
 	defer aq.close()
 
@@ -714,7 +714,7 @@ func benchmarkReadingRandomBalances(b *testing.B, inMemory bool) {
 
 	accounts := benchmarkInitBalances(b, b.N, dbs, protocol.ConsensusCurrentVersion)
 
-	qs, err := accountsInitDbQueries(dbs.Rdb.Handle, dbs.Wdb.Handle)
+	qs, err := accountsInitDbQueries(dbs.Rdb.Handle)
 	require.NoError(b, err)
 
 	// read all the balances in the database, shuffled
@@ -965,7 +965,7 @@ func TestAccountsDbQueriesCreateClose(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
-	qs, err := accountsInitDbQueries(dbs.Rdb.Handle, dbs.Wdb.Handle)
+	qs, err := accountsInitDbQueries(dbs.Rdb.Handle)
 	require.NoError(t, err)
 	require.NotNil(t, qs.listCreatablesStmt)
 	qs.close()
@@ -3679,7 +3679,7 @@ func TestCatchpointFirstStageInfoTable(t *testing.T) {
 		info := catchpointFirstStageInfo{
 			TotalAccounts: uint64(round) * 10,
 		}
-		err = insertCatchpointFirstStageInfo(dbs.Wdb.Handle, round, &info)
+		err = insertOrReplaceCatchpointFirstStageInfo(dbs.Wdb.Handle, round, &info)
 		require.NoError(t, err)
 	}
 
@@ -3708,4 +3708,46 @@ func TestCatchpointFirstStageInfoTable(t *testing.T) {
 	rounds, err = selectOldCatchpointFirstStageInfoRounds(dbs.Rdb.Handle, 9)
 	require.NoError(t, err)
 	require.Equal(t, []basics.Round{8}, rounds)
+}
+
+func TestUnfinishedCatchpointsTable(t *testing.T) {
+	dbs, _ := dbOpenTest(t, true)
+	defer dbs.Close()
+
+	err := accountsCreateUnfinishedCatchpointsTable(
+		context.Background(), dbs.Wdb.Handle)
+	require.NoError(t, err)
+
+	var d3 crypto.Digest
+	rand.Read(d3[:])
+	err = insertUnfinishedCatchpoint(context.Background(), dbs.Wdb.Handle, 3, d3)
+	require.NoError(t, err)
+
+	var d5 crypto.Digest
+	rand.Read(d5[:])
+	err = insertUnfinishedCatchpoint(context.Background(), dbs.Wdb.Handle, 5, d5)
+	require.NoError(t, err)
+
+	ret, err := selectUnfinishedCatchpoints(context.Background(), dbs.Rdb.Handle)
+	require.NoError(t, err)
+
+	sort.Slice(ret, func(i, j int) bool { return ret[i].round < ret[j].round })
+	expected := []unfinishedCatchpointRecord{
+		{
+			round:     3,
+			blockHash: d3,
+		},
+		{
+			round:     5,
+			blockHash: d5,
+		},
+	}
+	require.Equal(t, expected, ret)
+
+	err = clearUnfinishedCatchpoints(context.Background(), dbs.Wdb.Handle)
+	require.NoError(t, err)
+
+	ret, err = selectUnfinishedCatchpoints(context.Background(), dbs.Rdb.Handle)
+	require.NoError(t, err)
+	require.Empty(t, ret)
 }

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -638,7 +638,7 @@ func (au *accountUpdates) initializeFromDisk(l ledgerForTracker, lastBalancesRou
 		return
 	}
 
-	au.accountsq, err = accountsInitDbQueries(au.dbs.Rdb.Handle, au.dbs.Wdb.Handle)
+	au.accountsq, err = accountsInitDbQueries(au.dbs.Rdb.Handle)
 	if err != nil {
 		return
 	}

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1184,7 +1184,7 @@ func TestListCreatables(t *testing.T) {
 	require.NoError(t, err)
 
 	au := &accountUpdates{}
-	au.accountsq, err = accountsInitDbQueries(tx, tx)
+	au.accountsq, err = accountsInitDbQueries(tx)
 	require.NoError(t, err)
 
 	// ******* All results are obtained from the cache. Empty database *******

--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -296,7 +296,8 @@ return`
 	a.Equal("local", ar.AppLocalState.KeyValue["lk"].Bytes)
 
 	// ensure writing into empty global state works as well
-	l.reloadLedger()
+	err = l.reloadLedger()
+	a.NoError(err)
 	txHeader.Sender = creator
 	appCallFields = transactions.ApplicationCallTxnFields{
 		OnCompletion:    0,

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -251,7 +251,7 @@ func (ct *catchpointTracker) finishCatchpointsAfterCrash(catchpointLookback uint
 			"finishing abandoned catchpoint record.round: %d accountsRound: %d",
 			record.round, accountsRound)
 
-		// First, delete the unfinished data file.
+		// First, delete the unfinished catchpoint file.
 		catchpointFilePath := filepath.Join(ct.dbDirectory, CatchpointDirName)
 		catchpointFilePath = filepath.Join(
 			catchpointFilePath,

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -111,7 +111,7 @@ func TestGetCatchpointStream(t *testing.T) {
 		require.NoError(t, err)
 
 		// Store the catchpoint into the database
-		err := ct.accountsq.storeCatchpoint(context.Background(), basics.Round(i), fileName, "", int64(len(data)))
+		err := storeCatchpoint(context.Background(), ml.dbs.Wdb.Handle, basics.Round(i), fileName, "", int64(len(data)))
 		require.NoError(t, err)
 	}
 
@@ -138,7 +138,7 @@ func TestGetCatchpointStream(t *testing.T) {
 	require.Nil(t, reader)
 
 	// File on disk, but database lost the record
-	err = ct.accountsq.storeCatchpoint(context.Background(), basics.Round(3), "", "", 0)
+	err = storeCatchpoint(context.Background(), ml.dbs.Wdb.Handle, basics.Round(3), "", "", 0)
 	require.NoError(t, err)
 	reader, err = ct.GetCatchpointStream(basics.Round(3))
 	require.NoError(t, err)
@@ -148,7 +148,7 @@ func TestGetCatchpointStream(t *testing.T) {
 	outData = []byte{3, 4, 5}
 	require.Equal(t, outData, dataRead)
 
-	err = deleteStoredCatchpoints(context.Background(), ct.accountsq, ct.dbDirectory)
+	err = deleteStoredCatchpoints(context.Background(), ml.dbs.Wdb.Handle, ct.dbDirectory)
 	require.NoError(t, err)
 }
 
@@ -194,11 +194,11 @@ func TestAcctUpdatesDeleteStoredCatchpoints(t *testing.T) {
 		require.NoError(t, err)
 		err = f.Close()
 		require.NoError(t, err)
-		err = ct.accountsq.storeCatchpoint(context.Background(), basics.Round(i), file, "", 0)
+		err = storeCatchpoint(context.Background(), ml.dbs.Wdb.Handle, basics.Round(i), file, "", 0)
 		require.NoError(t, err)
 	}
 
-	err = deleteStoredCatchpoints(context.Background(), ct.accountsq, ct.dbDirectory)
+	err = deleteStoredCatchpoints(context.Background(), ml.dbs.Wdb.Handle, ct.dbDirectory)
 	require.NoError(t, err)
 
 	// ensure that all the files were deleted.
@@ -206,7 +206,7 @@ func TestAcctUpdatesDeleteStoredCatchpoints(t *testing.T) {
 		_, err := os.Open(file)
 		require.True(t, os.IsNotExist(err))
 	}
-	fileNames, err := ct.accountsq.getOldestCatchpointFiles(context.Background(), dummyCatchpointFilesToCreate, 0)
+	fileNames, err := getOldestCatchpointFiles(context.Background(), ml.dbs.Rdb.Handle, dummyCatchpointFilesToCreate, 0)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(fileNames))
 }

--- a/scripts/dump_genesis.sh
+++ b/scripts/dump_genesis.sh
@@ -69,6 +69,9 @@ for LEDGER in $LEDGERS; do
       catchpointfirststageinfo)
         SORT=round
         ;;
+      unfinishedcatchpoints)
+        SORT=round
+        ;;
       *)
         echo "Unknown table $T" >&2
         exit 1

--- a/util/db/interfaces.go
+++ b/util/db/interfaces.go
@@ -32,7 +32,9 @@ import (
 type Queryable interface {
 	Prepare(query string) (*sql.Stmt, error)
 	Query(query string, args ...interface{}) (*sql.Rows, error)
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
 	QueryRow(query string, args ...interface{}) *sql.Row
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 }
 
 // Executable is similar but has write methods as well.


### PR DESCRIPTION
## Summary

This PR ensures that algod crashes are handled correctly: first and second catchpoint stages are restarted, old catchpoint data files are deleted.

Some refactoring was done: catchpoint related sql query are no longer prepared statements in a go struct. This simplifies the code. Because catchpoint queries are rare, this doesn't hurt performance.

Closes #3969.

## Test Plan

Tested manually:
`os.Exit()` was inserted right before starting first or second catchpoint stage, then algod was executed in an infinite loop in a bash shell. Verified that catchpoint files are correct, old catchpoint data files and catchpoint files are deleted.