### PR TITLE
320 rounds: fix more data races in catchpoint tracker tests.

### DIFF
--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -532,7 +532,9 @@ func TestReproducibleCatchpointLabels(t *testing.T) {
 			blk.CurrentProtocol = testProtocolVersion
 			delta := roundDeltas[i]
 
+			ml2.trackers.mu.Lock()
 			ml2.trackers.lastFlushTime = time.Time{}
+			ml2.trackers.mu.Unlock()
 			ml2.trackers.newBlock(blk, delta)
 			ml2.trackers.committedUpTo(i)
 
@@ -906,7 +908,9 @@ func TestFirstStageInfoPruning(t *testing.T) {
 		}
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, 0, 0)
 
+		ml.trackers.mu.Lock()
 		ml.trackers.lastFlushTime = time.Time{}
+		ml.trackers.mu.Unlock()
 		ml.trackers.newBlock(blk, delta)
 		ml.trackers.committedUpTo(i)
 		ml.addMockBlock(blockEntry{block: blk}, delta)


### PR DESCRIPTION
## Summary

Similar to https://github.com/algorand/go-algorand/pull/4042.

## Test Plan

Test code is changed.