### PR TITLE
320 rounds: memory optimizations

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -4114,6 +4114,10 @@ func (iterator *encodedAccountsBatchIter) Close() {
 		iterator.accountsRows.Close()
 		iterator.accountsRows = nil
 	}
+	if iterator.resourcesRows != nil {
+		iterator.resourcesRows.Close()
+		iterator.resourcesRows = nil
+	}
 }
 
 // orderedAccountsIterStep is used by orderedAccountsIter to define the current step

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -4842,6 +4842,8 @@ type catchpointFirstStageInfo struct {
 	// Total number of chunks in the catchpoint data file. Only set when catchpoint
 	// data files are generated.
 	TotalChunks uint64 `codec:"chunksCount"`
+	// BiggestChunkLen is used when re-packing.
+	BiggestChunkLen uint64 `codec:"biggestChunk"`
 }
 
 func insertCatchpointFirstStageInfo(e db.Executable, round basics.Round, info *catchpointFirstStageInfo) error {

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -4183,10 +4183,11 @@ func processAllResources(
 	callback func(addr basics.Address, creatableIdx basics.CreatableIndex, resData *resourcesData, encodedResourceData []byte) error,
 ) (pendingRow, error) {
 	var err error
+	var buf []byte
+	var addrid int64
+	var aidx basics.CreatableIndex
+	var resData resourcesData
 	for {
-		var buf []byte
-		var addrid int64
-		var aidx basics.CreatableIndex
 		if pr.addrid != 0 {
 			// some accounts may not have resources, consider the following case:
 			// acct 1 and 3 has resources, account 2 does not
@@ -4224,7 +4225,7 @@ func processAllResources(
 				return pendingRow{addrid, aidx, buf}, err
 			}
 		}
-		var resData resourcesData
+		resData = resourcesData{}
 		err = protocol.Decode(buf, &resData)
 		if err != nil {
 			return pendingRow{}, err
@@ -4248,10 +4249,12 @@ func processAllBaseAccountRecords(
 	var prevAddr basics.Address
 	var err error
 	count := 0
+
+	var accountData baseAccountData
+	var addrbuf []byte
+	var buf []byte
+	var rowid int64
 	for baseRows.Next() {
-		var addrbuf []byte
-		var buf []byte
-		var rowid int64
 		err = baseRows.Scan(&rowid, &addrbuf, &buf)
 		if err != nil {
 			return 0, pendingRow{}, err
@@ -4264,7 +4267,7 @@ func processAllBaseAccountRecords(
 
 		copy(addr[:], addrbuf)
 
-		var accountData baseAccountData
+		accountData = baseAccountData{}
 		err = protocol.Decode(buf, &accountData)
 		if err != nil {
 			return 0, pendingRow{}, err

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -451,6 +451,7 @@ func prepareNormalizedBalancesV6(bals []encodedBalanceRecordV6, proto config.Con
 // makeCompactResourceDeltas takes an array of AccountDeltas ( one array entry per round ), and compacts the resource portions of the arrays into a single
 // data structure that contains all the resources deltas changes. While doing that, the function eliminate any intermediate resources changes.
 // It counts the number of changes each account get modified across the round range by specifying it in the nAcctDeltas field of the resourcesDeltas.
+// As an optimization, accountDeltas is passed as a slice and must not be modified
 func makeCompactResourceDeltas(accountDeltas []ledgercore.AccountDeltas, baseRound basics.Round, setUpdateRound bool, baseAccounts lruAccounts, baseResources lruResources) (outResourcesDeltas compactResourcesDeltas) {
 	if len(accountDeltas) == 0 {
 		return
@@ -668,6 +669,7 @@ func (a *compactResourcesDeltas) updateOld(idx int, old persistedResourcesData) 
 // makeCompactAccountDeltas takes an array of account AccountDeltas ( one array entry per round ), and compacts the arrays into a single
 // data structure that contains all the account deltas changes. While doing that, the function eliminate any intermediate account changes.
 // It counts the number of changes each account get modified across the round range by specifying it in the nAcctDeltas field of the accountDeltaCount/modifiedCreatable.
+// As an optimization, accountDeltas is passed as a slice and must not be modified
 func makeCompactAccountDeltas(accountDeltas []ledgercore.AccountDeltas, baseRound basics.Round, setUpdateRound bool, baseAccounts lruAccounts) (outAccountDeltas compactAccountDeltas) {
 	if len(accountDeltas) == 0 {
 		return

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -4104,6 +4104,9 @@ func processAllResources(
 	callback func(addr basics.Address, creatableIdx basics.CreatableIndex, resData *resourcesData, encodedResourceData []byte) error,
 ) (pendingRow, error) {
 	var err error
+
+	// Declare variabled outside of the loop to prevent allocations per iteration.
+	// At least resData is resolved as "escaped" because of passing it by a pointer to protocol.Decode()
 	var buf []byte
 	var addrid int64
 	var aidx basics.CreatableIndex

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -4847,7 +4847,7 @@ type catchpointFirstStageInfo struct {
 	// Total number of chunks in the catchpoint data file. Only set when catchpoint
 	// data files are generated.
 	TotalChunks uint64 `codec:"chunksCount"`
-	// BiggestChunkLen is used when re-packing.
+	// BiggestChunkLen is the size in the bytes of the largest chunk, used when re-packing.
 	BiggestChunkLen uint64 `codec:"biggestChunk"`
 }
 

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -668,7 +668,7 @@ func (a *compactResourcesDeltas) updateOld(idx int, old persistedResourcesData) 
 // makeCompactAccountDeltas takes an array of account AccountDeltas ( one array entry per round ), and compacts the arrays into a single
 // data structure that contains all the account deltas changes. While doing that, the function eliminate any intermediate account changes.
 // It counts the number of changes each account get modified across the round range by specifying it in the nAcctDeltas field of the accountDeltaCount/modifiedCreatable.
-// As an optimization, accountDeltas is passed as a slice and must not be modified
+// As an optimization, accountDeltas is passed as a slice and must not be modified.
 func makeCompactAccountDeltas(accountDeltas []ledgercore.AccountDeltas, baseRound basics.Round, setUpdateRound bool, baseAccounts lruAccounts) (outAccountDeltas compactAccountDeltas) {
 	if len(accountDeltas) == 0 {
 		return

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -450,7 +450,7 @@ func prepareNormalizedBalancesV6(bals []encodedBalanceRecordV6, proto config.Con
 // makeCompactResourceDeltas takes an array of AccountDeltas ( one array entry per round ), and compacts the resource portions of the arrays into a single
 // data structure that contains all the resources deltas changes. While doing that, the function eliminate any intermediate resources changes.
 // It counts the number of changes each account get modified across the round range by specifying it in the nAcctDeltas field of the resourcesDeltas.
-// As an optimization, accountDeltas is passed as a slice and must not be modified
+// As an optimization, accountDeltas is passed as a slice and must not be modified.
 func makeCompactResourceDeltas(accountDeltas []ledgercore.AccountDeltas, baseRound basics.Round, setUpdateRound bool, baseAccounts lruAccounts, baseResources lruResources) (outResourcesDeltas compactResourcesDeltas) {
 	if len(accountDeltas) == 0 {
 		return

--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -498,6 +498,13 @@ func (ao *onlineAccounts) postCommit(ctx context.Context, dcc *deferredCommitCon
 			})
 	}
 
+	const deltasClearThreshold = 1000
+	if offset > deltasClearThreshold {
+		for i := uint64(0); i < offset; i++ {
+			ao.deltas[i] = ledgercore.AccountDeltas{}
+		}
+	}
+
 	ao.deltas = ao.deltas[offset:]
 	ao.deltasAccum = ao.deltasAccum[offset:]
 	ao.cachedDBRoundOnline = newBase

--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -467,6 +467,7 @@ func (ao *onlineAccounts) postCommit(ctx context.Context, dcc *deferredCommitCon
 			})
 	}
 
+	// clear the backing array to let GC collect data
 	const deltasClearThreshold = 1000
 	if offset > deltasClearThreshold {
 		for i := uint64(0); i < offset; i++ {

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1448,12 +1448,11 @@ func (au *accountUpdates) postCommit(ctx context.Context, dcc *deferredCommitCon
 		}
 	}
 
-	// clear baking array to let GC collect data
+	// clear the backing array to let GC collect data
 	const deltasClearThreshold = 1000
 	if offset > deltasClearThreshold {
 		for i := uint64(0); i < offset; i++ {
 			au.deltas[i] = ledgercore.AccountDeltas{}
-			au.roundTotals[i] = ledgercore.AccountTotals{}
 			au.creatableDeltas[i] = nil
 		}
 	}

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -549,6 +549,7 @@ func repackCatchpoint(header CatchpointFileHeader, dataPath string, outPath stri
 
 // Create a catchpoint (a label and possibly a file with db record).
 func (ct *catchpointTracker) createCatchpoint(accountsRound basics.Round, round basics.Round, dataInfo catchpointFirstStageInfo, blockHash crypto.Digest) error {
+	startTime := time.Now()
 	label := ledgercore.MakeCatchpointLabel(
 		round, blockHash, dataInfo.TrieBalancesHash, dataInfo.Totals).String()
 
@@ -615,6 +616,13 @@ func (ct *catchpointTracker) createCatchpoint(accountsRound basics.Round, round 
 	if err != nil {
 		return err
 	}
+
+	ct.log.With("accountsRound", accountsRound).
+		With("writingDuration", uint64(time.Since(startTime).Nanoseconds())).
+		With("accountsCount", dataInfo.TotalAccounts).
+		With("fileSize", fileInfo.Size()).
+		With("catchpointLabel", label).
+		Infof("Catchpoint file was created")
 
 	return nil
 }

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -500,13 +500,7 @@ func repackCatchpoint(header CatchpointFileHeader, dataPath string, outPath stri
 	}
 	defer fin.Close()
 
-	gzipIn, err := gzip.NewReader(fin)
-	if err != nil {
-		return err
-	}
-	defer gzipIn.Close()
-
-	tarIn := tar.NewReader(gzipIn)
+	tarIn := tar.NewReader(fin)
 
 	fout, err := os.OpenFile(outPath, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
@@ -514,7 +508,10 @@ func repackCatchpoint(header CatchpointFileHeader, dataPath string, outPath stri
 	}
 	defer fout.Close()
 
-	gzipOut := gzip.NewWriter(fout)
+	gzipOut, err := gzip.NewWriterLevel(fout, gzip.BestSpeed)
+	if err != nil {
+		return err
+	}
 	defer gzipOut.Close()
 
 	tarOut := tar.NewWriter(gzipOut)
@@ -538,11 +535,6 @@ func repackCatchpoint(header CatchpointFileHeader, dataPath string, outPath stri
 	}
 
 	err = fout.Close()
-	if err != nil {
-		return err
-	}
-
-	err = gzipIn.Close()
 	if err != nil {
 		return err
 	}

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -446,7 +446,7 @@ func (ct *catchpointTracker) postCommit(ctx context.Context, dcc *deferredCommit
 	}
 }
 
-func doRepackCatchpoint(header CatchpointFileHeader, dataInfo catchpointFirstStageInfo, in *tar.Reader, out *tar.Writer) error {
+func doRepackCatchpoint(header CatchpointFileHeader, biggestChunkLen uint64, in *tar.Reader, out *tar.Writer) error {
 	{
 		bytes := protocol.Encode(&header)
 
@@ -466,7 +466,7 @@ func doRepackCatchpoint(header CatchpointFileHeader, dataInfo catchpointFirstSta
 	}
 
 	// make buffer for re-use that can fit biggest chunk
-	buf := make([]byte, dataInfo.BiggestChunkLen)
+	buf := make([]byte, biggestChunkLen)
 	for {
 		header, err := in.Next()
 		if err != nil {
@@ -522,7 +522,7 @@ func repackCatchpoint(header CatchpointFileHeader, dataInfo catchpointFirstStage
 	defer tarOut.Close()
 
 	// Repack.
-	err = doRepackCatchpoint(header, dataInfo, tarIn, tarOut)
+	err = doRepackCatchpoint(header, dataInfo.BiggestChunkLen, tarIn, tarOut)
 	if err != nil {
 		return err
 	}

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -504,7 +504,7 @@ func doRepackCatchpoint(header CatchpointFileHeader, biggestChunkLen uint64, in 
 	}
 }
 
-func repackCatchpoint(header CatchpointFileHeader, dataInfo catchpointFirstStageInfo, dataPath string, outPath string) error {
+func repackCatchpoint(header CatchpointFileHeader, biggestChunkLen uint64, dataPath string, outPath string) error {
 	// Initialize streams.
 	fin, err := os.OpenFile(dataPath, os.O_RDONLY, 0666)
 	if err != nil {
@@ -530,7 +530,7 @@ func repackCatchpoint(header CatchpointFileHeader, dataInfo catchpointFirstStage
 	defer tarOut.Close()
 
 	// Repack.
-	err = doRepackCatchpoint(header, dataInfo.BiggestChunkLen, tarIn, tarOut)
+	err = doRepackCatchpoint(header, biggestChunkLen, tarIn, tarOut)
 	if err != nil {
 		return err
 	}
@@ -613,7 +613,7 @@ func (ct *catchpointTracker) createCatchpoint(accountsRound basics.Round, round 
 		return err
 	}
 
-	err = repackCatchpoint(header, dataInfo, catchpointDataFilePath, absCatchpointFilePath)
+	err = repackCatchpoint(header, dataInfo.BiggestChunkLen, catchpointDataFilePath, absCatchpointFilePath)
 	if err != nil {
 		return err
 	}

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -475,12 +475,7 @@ func doRepackCatchpoint(header CatchpointFileHeader, in *tar.Reader, out *tar.Wr
 		}
 
 		buf := make([]byte, header.Size)
-		bytesRead := int64(0)
-		for (err == nil) && (bytesRead < header.Size) {
-			var x int
-			x, err = in.Read(buf[bytesRead:])
-			bytesRead += int64(x)
-		}
+		_, err = io.ReadFull(in, buf)
 		if (err != nil) && (err != io.EOF) {
 			return err
 		}

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -315,7 +315,7 @@ func TestRecordCatchpointFile(t *testing.T) {
 	for _, round := range []basics.Round{2000000, 3000010, 3000015, 3000020} {
 		accountsRound := round - 1
 
-		_, _, err := ct.generateCatchpointData(
+		_, _, _, err := ct.generateCatchpointData(
 			context.Background(), accountsRound, time.Second)
 		require.NoError(t, err)
 

--- a/ledger/catchpointwriter.go
+++ b/ledger/catchpointwriter.go
@@ -51,6 +51,7 @@ type catchpointWriter struct {
 	balancesChunk    catchpointFileBalancesChunkV6
 	balancesChunkNum uint64
 	writtenBytes     int64
+	biggestChunkLen  uint64
 	accountsIterator encodedAccountsBatchIter
 }
 
@@ -214,6 +215,9 @@ func (cw *catchpointWriter) asyncWriter(balances chan catchpointFileBalancesChun
 			response <- err
 			break
 		}
+		if chunkLen := uint64(len(encodedChunk)); cw.biggestChunkLen < chunkLen {
+			cw.biggestChunkLen = chunkLen
+		}
 
 		if len(bc.Balances) < BalancesPerCatchpointFileChunk || balancesChunkNum == cw.totalChunks {
 			cw.tar.Close()
@@ -247,6 +251,10 @@ func (cw *catchpointWriter) GetTotalAccounts() uint64 {
 
 func (cw *catchpointWriter) GetTotalChunks() uint64 {
 	return cw.totalChunks
+}
+
+func (cw *catchpointWriter) GetBiggestChunkLen() uint64 {
+	return cw.biggestChunkLen
 }
 
 // hasContextDeadlineExceeded examine the given context and see if it was canceled or timed-out.

--- a/ledger/catchpointwriter.go
+++ b/ledger/catchpointwriter.go
@@ -99,7 +99,10 @@ func makeCatchpointWriter(ctx context.Context, filePath string, tx *sql.Tx) (*ca
 	if err != nil {
 		return nil, err
 	}
-	gzip := gzip.NewWriter(file)
+	gzip, err := gzip.NewWriterLevel(file, gzip.NoCompression)
+	if err != nil {
+		return nil, err
+	}
 	tar := tar.NewWriter(gzip)
 
 	res := &catchpointWriter{

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -305,6 +305,7 @@ func TestFullCatchpointWriter(t *testing.T) {
 	readDb := ml.trackerDB().Rdb
 	var totalAccounts uint64
 	var totalChunks uint64
+	var biggestChunkLen uint64
 	var accountsRnd basics.Round
 	var totals ledgercore.AccountTotals
 	err = readDb.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
@@ -321,6 +322,7 @@ func TestFullCatchpointWriter(t *testing.T) {
 		}
 		totalAccounts = writer.GetTotalAccounts()
 		totalChunks = writer.GetTotalChunks()
+		biggestChunkLen = writer.GetBiggestChunkLen()
 		accountsRnd, err = accountsRound(tx)
 		if err != nil {
 			return
@@ -342,8 +344,15 @@ func TestFullCatchpointWriter(t *testing.T) {
 		Catchpoint:        catchpointLabel,
 		BlockHeaderDigest: blockHeaderDigest,
 	}
+	dataInfo := catchpointFirstStageInfo{
+		Totals:           totals,
+		TrieBalancesHash: crypto.Digest{}, // this test does not make a valid balances hash
+		TotalAccounts:    totalAccounts,
+		TotalChunks:      totalChunks,
+		BiggestChunkLen:  biggestChunkLen,
+	}
 	err = repackCatchpoint(
-		catchpointFileHeader, catchpointDataFilePath, catchpointFilePath)
+		catchpointFileHeader, dataInfo, catchpointDataFilePath, catchpointFilePath)
 	require.NoError(t, err)
 
 	// create a ledger.

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -239,10 +239,7 @@ func TestBasicCatchpointWriter(t *testing.T) {
 	// load the file from disk.
 	fileContent, err := ioutil.ReadFile(fileName)
 	require.NoError(t, err)
-	gzipReader, err := gzip.NewReader(bytes.NewBuffer(fileContent))
-	require.NoError(t, err)
-	tarReader := tar.NewReader(gzipReader)
-	defer gzipReader.Close()
+	tarReader := tar.NewReader(bytes.NewBuffer(fileContent))
 
 	header, err := tarReader.Next()
 	require.NoError(t, err)

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -341,15 +341,8 @@ func TestFullCatchpointWriter(t *testing.T) {
 		Catchpoint:        catchpointLabel,
 		BlockHeaderDigest: blockHeaderDigest,
 	}
-	dataInfo := catchpointFirstStageInfo{
-		Totals:           totals,
-		TrieBalancesHash: crypto.Digest{}, // this test does not make a valid balances hash
-		TotalAccounts:    totalAccounts,
-		TotalChunks:      totalChunks,
-		BiggestChunkLen:  biggestChunkLen,
-	}
 	err = repackCatchpoint(
-		catchpointFileHeader, dataInfo, catchpointDataFilePath, catchpointFilePath)
+		catchpointFileHeader, biggestChunkLen, catchpointDataFilePath, catchpointFilePath)
 	require.NoError(t, err)
 
 	// create a ledger.

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/algorand/go-algorand/data/account"
 	"github.com/algorand/go-algorand/util/db"
+	"github.com/algorand/go-deadlock"
 
 	"github.com/stretchr/testify/require"
 
@@ -1577,12 +1578,13 @@ func TestLedgerMemoryLeak(t *testing.T) {
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
 	log := logging.TestingLog(t)
-	log.SetLevel(logging.Info) // prevent spamming with ledger.AddValidatedBlock debug message
+	log.SetLevel(logging.Info)   // prevent spamming with ledger.AddValidatedBlock debug message
+	deadlock.Opts.Disable = true // catchpoint writing might take long
 	l, err := OpenLedger(log, dbName, inMem, genesisInitState, cfg)
 	require.NoError(t, err)
 	defer l.Close()
 
-	const maxBlocks = 10000
+	const maxBlocks = 1_000_000
 	nftPerAcct := make(map[basics.Address]int)
 	lastBlock, err := l.Block(l.Latest())
 	require.NoError(t, err)
@@ -1687,20 +1689,22 @@ func TestLedgerMemoryLeak(t *testing.T) {
 			l.WaitForCommit(latest)
 		}
 		if latest%1000 == 0 || i%1000 == 0 && i > 0 {
+			// pct := debug.SetGCPercent(-1) // prevent CG in between memory stats reading and heap profiling
+
 			var rtm runtime.MemStats
 			runtime.ReadMemStats(&rtm)
 			const meg = 1024 * 1024
 			fmt.Printf("%5d\t%14d\t%13d\t%7d\n", latest, rtm.TotalAlloc/meg, rtm.HeapAlloc/meg, rtm.Mallocs-rtm.Frees)
 
 			// Use the code below to generate memory profile if needed for debugging
-			// memprofile := fmt.Sprintf("%s-memprof-%d", t.Name(), i)
+			// memprofile := fmt.Sprintf("%s-memprof-%d", t.Name(), latest)
 			// f, err := os.Create(memprofile)
 			// require.NoError(t, err)
 			// err = pprof.WriteHeapProfile(f)
 			// require.NoError(t, err)
 			// f.Close()
-			// fmt.Printf("Profile %s created\n", memprofile)
 
+			// debug.SetGCPercent(pct)
 		}
 	}
 }

--- a/ledger/msgp_gen.go
+++ b/ledger/msgp_gen.go
@@ -2453,8 +2453,8 @@ func (z *catchpointFileBalancesChunkV6) MsgIsZero() bool {
 func (z *catchpointFirstStageInfo) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0001Len := uint32(4)
-	var zb0001Mask uint8 /* 5 bits */
+	zb0001Len := uint32(5)
+	var zb0001Mask uint8 /* 6 bits */
 	if (*z).Totals.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x2
@@ -2463,13 +2463,17 @@ func (z *catchpointFirstStageInfo) MarshalMsg(b []byte) (o []byte) {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if (*z).TotalChunks == 0 {
+	if (*z).BiggestChunkLen == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
-	if (*z).TrieBalancesHash.MsgIsZero() {
+	if (*z).TotalChunks == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x10
+	}
+	if (*z).TrieBalancesHash.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x20
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -2485,11 +2489,16 @@ func (z *catchpointFirstStageInfo) MarshalMsg(b []byte) (o []byte) {
 			o = msgp.AppendUint64(o, (*z).TotalAccounts)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
+			// string "biggestChunk"
+			o = append(o, 0xac, 0x62, 0x69, 0x67, 0x67, 0x65, 0x73, 0x74, 0x43, 0x68, 0x75, 0x6e, 0x6b)
+			o = msgp.AppendUint64(o, (*z).BiggestChunkLen)
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "chunksCount"
 			o = append(o, 0xab, 0x63, 0x68, 0x75, 0x6e, 0x6b, 0x73, 0x43, 0x6f, 0x75, 0x6e, 0x74)
 			o = msgp.AppendUint64(o, (*z).TotalChunks)
 		}
-		if (zb0001Mask & 0x10) == 0 { // if not empty
+		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "trieBalancesHash"
 			o = append(o, 0xb0, 0x74, 0x72, 0x69, 0x65, 0x42, 0x61, 0x6c, 0x61, 0x6e, 0x63, 0x65, 0x73, 0x48, 0x61, 0x73, 0x68)
 			o = (*z).TrieBalancesHash.MarshalMsg(o)
@@ -2549,6 +2558,14 @@ func (z *catchpointFirstStageInfo) UnmarshalMsg(bts []byte) (o []byte, err error
 			}
 		}
 		if zb0001 > 0 {
+			zb0001--
+			(*z).BiggestChunkLen, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "BiggestChunkLen")
+				return
+			}
+		}
+		if zb0001 > 0 {
 			err = msgp.ErrTooManyArrayFields(zb0001)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array")
@@ -2595,6 +2612,12 @@ func (z *catchpointFirstStageInfo) UnmarshalMsg(bts []byte) (o []byte, err error
 					err = msgp.WrapError(err, "TotalChunks")
 					return
 				}
+			case "biggestChunk":
+				(*z).BiggestChunkLen, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "BiggestChunkLen")
+					return
+				}
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2615,13 +2638,13 @@ func (_ *catchpointFirstStageInfo) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *catchpointFirstStageInfo) Msgsize() (s int) {
-	s = 1 + 14 + (*z).Totals.Msgsize() + 17 + (*z).TrieBalancesHash.Msgsize() + 14 + msgp.Uint64Size + 12 + msgp.Uint64Size
+	s = 1 + 14 + (*z).Totals.Msgsize() + 17 + (*z).TrieBalancesHash.Msgsize() + 14 + msgp.Uint64Size + 12 + msgp.Uint64Size + 13 + msgp.Uint64Size
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *catchpointFirstStageInfo) MsgIsZero() bool {
-	return ((*z).Totals.MsgIsZero()) && ((*z).TrieBalancesHash.MsgIsZero()) && ((*z).TotalAccounts == 0) && ((*z).TotalChunks == 0)
+	return ((*z).Totals.MsgIsZero()) && ((*z).TrieBalancesHash.MsgIsZero()) && ((*z).TotalAccounts == 0) && ((*z).TotalChunks == 0) && ((*z).BiggestChunkLen == 0)
 }
 
 // MarshalMsg implements msgp.Marshaler

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -231,7 +231,6 @@ type deferredCommitContext struct {
 
 	genesisProto config.ConsensusParams
 
-	deltas                   []ledgercore.AccountDeltas
 	roundTotals              ledgercore.AccountTotals
 	onlineRoundParams        []ledgercore.OnlineRoundParamsData
 	onlineTotalsForgetBefore basics.Round


### PR DESCRIPTION
List of tweaks:
1. Do not gzip catchpoint data file
2. Preallocate chunks buffer for catchpoint repacking
3. Fix sql.Rows leak in encodedAccountsBatchIter
4. Move resourcesData variable out of accounts reading loop
5. Clear au and ao deltas before slicing
6. Get rid of dcc.deltas
