### PR TITLE
AVM: Add proper opcode costs for json_ref

### DIFF
--- a/data/transactions/logic/TEAL_opcodes.md
+++ b/data/transactions/logic/TEAL_opcodes.md
@@ -751,7 +751,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 - Opcode: 0x5c {uint8 encoding index}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - decode A which was base64-encoded using _encoding_ E. Fail if A is not base64 encoded with encoding E
-- **Cost**: 1 + 1 per 16 bytes
+- **Cost**: 1 + 1 per 16 bytes of A
 - Availability: v7
 
 `base64` Encodings:
@@ -769,7 +769,7 @@ Decodes A using the base64 encoding E. Specify the encoding with an immediate ar
 - Opcode: 0x5d {string return type}
 - Stack: ..., A: []byte, B: []byte &rarr; ..., any
 - return key B's value from a [valid](jsonspec.md) utf-8 encoded json object A
-- **Cost**: 25 + 2 per 7 bytes
+- **Cost**: 25 + 2 per 7 bytes of A
 - Availability: v7
 
 `json_ref` Types:

--- a/data/transactions/logic/TEAL_opcodes.md
+++ b/data/transactions/logic/TEAL_opcodes.md
@@ -769,6 +769,7 @@ Decodes A using the base64 encoding E. Specify the encoding with an immediate ar
 - Opcode: 0x5d {string return type}
 - Stack: ..., A: []byte, B: []byte &rarr; ..., any
 - return key B's value from a [valid](jsonspec.md) utf-8 encoded json object A
+- **Cost**: 25 + 2 per 7 bytes
 - Availability: v7
 
 `json_ref` Types:

--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -356,8 +356,8 @@ func OpAllCosts(opName string) []VerCost {
 		if !ok {
 			continue
 		}
-		argLength := len(spec.Arg.Types)
-		cost := spec.OpDetails.docCost(argLength)
+		argLen := len(spec.Arg.Types)
+		cost := spec.OpDetails.docCost(argLen)
 		if costs == nil || cost != costs[len(costs)-1].Cost {
 			costs = append(costs, VerCost{v, v, cost})
 		} else {

--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -356,7 +356,8 @@ func OpAllCosts(opName string) []VerCost {
 		if !ok {
 			continue
 		}
-		cost := spec.OpDetails.docCost()
+		argLength := len(spec.Arg.Types)
+		cost := spec.OpDetails.docCost(argLength)
 		if costs == nil || cost != costs[len(costs)-1].Cost {
 			costs = append(costs, VerCost{v, v, cost})
 		} else {

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -4780,7 +4780,7 @@ func isPrimitiveJSON(jsonText []byte) (bool, error) {
 
 func parseJSON(jsonText []byte) (map[string]json.RawMessage, error) {
 	// parse JSON with Algorand's standard JSON library
-	var parsed map[string]json.RawMessage
+	var parsed map[interface{}]json.RawMessage
 	err := protocol.DecodeJSON(jsonText, &parsed)
 
 	if err != nil {
@@ -4797,7 +4797,17 @@ func parseJSON(jsonText []byte) (map[string]json.RawMessage, error) {
 		return nil, fmt.Errorf("invalid json text")
 	}
 
-	return parsed, nil
+	// check whether any keys are not strings
+	stringMap := make(map[string]json.RawMessage)
+	for k, v := range parsed {
+		key, ok := k.(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid json text")
+		}
+		stringMap[key] = v
+	}
+
+	return stringMap, nil
 }
 
 func opJSONRef(cx *EvalContext) error {

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1033,13 +1033,13 @@ func (cx *EvalContext) step() error {
 	return nil
 }
 
-// oneBlank is a boring stack provided to deets.Cost during checkStep. It is
+// blankStack is a boring stack provided to deets.Cost during checkStep. It is
 // good enough to allow Cost() to not crash. It would be incorrect to provide
 // this stack if there were linear cost opcodes before backBranchEnabledVersion,
 // because the static cost would be wrong. But then again, a static cost model
 // wouldn't work before backBranchEnabledVersion, so such an opcode is already
 // unacceptable. TestLinearOpcodes ensures.
-var oneBlank = []stackValue{{Bytes: []byte{}}}
+var blankStack = make([]stackValue, 5)
 
 func (cx *EvalContext) checkStep() (int, error) {
 	cx.instructionStarts[cx.pc] = true
@@ -1055,8 +1055,6 @@ func (cx *EvalContext) checkStep() (int, error) {
 	if deets.Size != 0 && (cx.pc+deets.Size > len(cx.program)) {
 		return 0, fmt.Errorf("%s program ends short of immediate values", spec.Name)
 	}
-	minStackDepth := deets.FullCost.depth + 1
-	blankStack := make([]stackValue, minStackDepth)
 	opcost := deets.Cost(cx.program, cx.pc, blankStack)
 	if opcost <= 0 {
 		return 0, fmt.Errorf("%s reported non-positive cost", spec.Name)

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -4792,10 +4792,12 @@ func parseJSON(jsonText []byte) (map[string]json.RawMessage, error) {
 	err = protocol.DecodeJSON(jsonText, &parsed)
 
 	if err != nil {
-		// confirm that the error was not a "duplicate key found" error before throwing
-		if !strings.Contains(err.Error(), "cannot decode into a non-pointer value") {
-			return nil, fmt.Errorf("invalid json text")
+		// if the error was caused by duplicate keys
+		if strings.Contains(err.Error(), "cannot decode into a non-pointer value") {
+			return nil, fmt.Errorf("invalid json text, duplicate keys not allowed")
 		}
+
+		return nil, fmt.Errorf("invalid json text")
 	}
 
 	return parsed, nil

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1055,7 +1055,9 @@ func (cx *EvalContext) checkStep() (int, error) {
 	if deets.Size != 0 && (cx.pc+deets.Size > len(cx.program)) {
 		return 0, fmt.Errorf("%s program ends short of immediate values", spec.Name)
 	}
-	opcost := deets.Cost(cx.program, cx.pc, oneBlank)
+	minStackDepth := deets.FullCost.depth + 1
+	blankStack := make([]stackValue, minStackDepth)
+	opcost := deets.Cost(cx.program, cx.pc, blankStack)
 	if opcost <= 0 {
 		return 0, fmt.Errorf("%s reported non-positive cost", spec.Name)
 	}

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -5062,6 +5062,9 @@ func TestOpJSONRef(t *testing.T) {
 		pass, _, err := EvalContract(ops.Program, 0, 888, ep)
 		require.NoError(t, err)
 		require.True(t, pass)
+
+		// reset pooled budget for new "app call"
+		*ep.PooledApplicationBudget = ep.Proto.MaxAppProgramCost
 	}
 
 	failedCases := []struct {
@@ -5254,6 +5257,9 @@ func TestOpJSONRef(t *testing.T) {
 		require.False(t, pass)
 		require.Error(t, err)
 		require.EqualError(t, err, s.error)
+
+		// reset pooled budget for new "app call"
+		*ep.PooledApplicationBudget = ep.Proto.MaxAppProgramCost
 	}
 
 }

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -5037,44 +5037,6 @@ func TestOpJSONRef(t *testing.T) {
 			==`,
 			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
 		},
-		// verify that the first key dominates
-		{
-			source: `byte  "{\"key0\": 0,\"key1\": \"algo\",\"key2\":{\"key3\": \"teal\", \"key4\": {\"key40\": 10, \"key40\": \"string val\"}}}";
-			byte "key2";
-			json_ref JSONObject;
-			byte "key4";
-			json_ref JSONObject;
-			byte "key40";
-			json_ref JSONUint64;
-			int 10;
-			==`,
-			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}, {9, "unknown opcode: json_ref"}, {13, "unknown opcode: json_ref"}},
-		},
-		{
-			source: `byte  "{\"key0\": 0,\"key1\": \"algo\",\"key2\":{\"key3\": \"teal\", \"key4\": {\"key40\": \"string val\", \"key40\": 10}}}";
-			byte "key2";
-			json_ref JSONObject;
-			byte "key4";
-			json_ref JSONObject;
-			byte "key40";
-			json_ref JSONString;
-			byte "string val";
-			==
-			`,
-			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}, {9, "unknown opcode: json_ref"}, {13, "unknown opcode: json_ref"}},
-		},
-		// verify that maps work as expected
-		{
-			source: `byte  "{\"key0\": {\"key1\": 1}, \"key0\": {\"key2\": 2}}";
-			byte "key0";
-			json_ref JSONObject;
-			byte "key1";
-			json_ref JSONUint64;
-			int 1;
-			==
-			`,
-			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
-		},
 	}
 
 	for _, s := range testCases {
@@ -5207,18 +5169,22 @@ func TestOpJSONRef(t *testing.T) {
 			error:              "error while parsing JSON text, invalid json text",
 			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
 		},
-		// verify that keys are not merged (which is default Go behavior)
 		{
-			source: `byte  "{\"key0\": {\"key1\": 1}, \"key0\": {\"key2\": 2}}";
-			byte "key0";
-			json_ref JSONObject;
+			source:             `byte  "{\"key0\": 1, \"key0\": \"3\"}"; byte "key0"; json_ref JSONString;`,
+			error:              "error while parsing JSON text, invalid json text, duplicate keys not allowed",
+			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+		},
+		{
+			source: `byte  "{\"key0\": 0,\"key1\": \"algo\",\"key2\":{\"key3\": \"teal\", \"key4\": {\"key40\": 10, \"key40\": \"should fail!\"}}}";
 			byte "key2";
-			json_ref JSONUint64;
-			int 2;
-			==
+			json_ref JSONObject;
+			byte "key4";
+			json_ref JSONObject;
+			byte "key40";
+			json_ref JSONString
 			`,
-			error:              "key key2 not found in JSON text",
-			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
+			error:              "error while parsing JSON text, invalid json text, duplicate keys not allowed",
+			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}, {9, "unknown opcode: json_ref"}, {13, "unknown opcode: json_ref"}},
 		},
 		{
 			source: `byte  "[1,2,3]";

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -114,7 +114,7 @@ func benchmarkEvalParams(txn *transactions.SignedTxn) *EvalParams {
 	ep := defaultEvalParamsWithVersion(txn, LogicVersion)
 	ep.Trace = nil // Tracing would slow down benchmarks
 	clone := *ep.Proto
-	bigBudget := 1000 * 1000 // Allow long run times
+	bigBudget := 2 * 1000 * 1000 // Allow long run times
 	clone.LogicSigMaxCost = uint64(bigBudget)
 	clone.MaxAppProgramCost = bigBudget
 	ep.Proto = &clone

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -260,6 +260,22 @@ func TestWrongProtoVersion(t *testing.T) {
 	}
 }
 
+func TestBlankStackSufficient(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	t.Parallel()
+	for v := 0; v <= LogicVersion; v++ {
+		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
+			for i := 0; i < 256; i++ {
+				spec := opsByOpcode[v][i]
+				argLen := len(spec.Arg.Types)
+				blankStackLen := len(blankStack)
+				require.GreaterOrEqual(t, blankStackLen, argLen)
+			}
+		})
+	}
+}
+
 func TestSimpleMath(t *testing.T) {
 	partitiontest.PartitionTest(t)
 

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -5077,6 +5077,24 @@ func TestOpJSONRef(t *testing.T) {
 			==`,
 			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
 		},
+		// JavaScript MAX_SAFE_INTEGER
+		{
+			source: `byte "{\"maxSafeInt\": 9007199254740991}";
+			byte "maxSafeInt";
+			json_ref JSONUint64;
+			int 9007199254740991;
+			==`,
+			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
+		},
+		// maximum uint64
+		{
+			source: `byte "{\"maxUint64\": 18446744073709551615}";
+			byte "maxUint64";
+			json_ref JSONUint64;
+			int 18446744073709551615;
+			==`,
+			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
+		},
 	}
 
 	for _, s := range testCases {
@@ -5276,6 +5294,16 @@ func TestOpJSONRef(t *testing.T) {
 			byte "shouldn't work";
 			==`,
 			error:              "error while parsing JSON text, invalid json text",
+			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
+		},
+		// max uint64 + 1 should fail
+		{
+			source: `byte "{\"tooBig\": 18446744073709551616}";
+			byte "tooBig";
+			json_ref JSONUint64;
+			int 1;
+			return`,
+			error:              "json: cannot unmarshal number 18446744073709551616 into Go value of type uint64",
 			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
 		},
 	}

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -5081,6 +5081,15 @@ func TestOpJSONRef(t *testing.T) {
 			==`,
 			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
 		},
+		// larger-than-uint64s are allowed if not requested
+		{
+			source: `byte "{\"maxUint64\": 18446744073709551616, \"smallUint64\": 0}";
+			byte "smallUint64";
+			json_ref JSONUint64;
+			int 0;
+			==`,
+			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
+		},
 	}
 
 	for _, s := range testCases {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -5063,30 +5063,6 @@ func TestOpJSONRef(t *testing.T) {
 			==`,
 			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
 		},
-		{
-			source: `byte "{002: \"num key\"}";
-			byte "002";
-			json_ref JSONString;
-			byte "num key";
-			==`,
-			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
-		},
-		{
-			source: `byte "{0.2: \"dec key\"}";
-			byte "0.2";
-			json_ref JSONString;
-			byte "dec key";
-			==`,
-			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
-		},
-		{
-			source: `byte "{1e16: \"dec key\"}";
-			byte "1e16";
-			json_ref JSONString;
-			byte "dec key";
-			==`,
-			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
-		},
 		// JavaScript MAX_SAFE_INTEGER
 		{
 			source: `byte "{\"maxSafeInt\": 9007199254740991}";

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -5053,6 +5053,30 @@ func TestOpJSONRef(t *testing.T) {
 			==`,
 			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
 		},
+		{
+			source: `byte "{002: \"num key\"}";
+			byte "002";
+			json_ref JSONString;
+			byte "num key";
+			==`,
+			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
+		},
+		{
+			source: `byte "{0.2: \"dec key\"}";
+			byte "0.2";
+			json_ref JSONString;
+			byte "dec key";
+			==`,
+			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
+		},
+		{
+			source: `byte "{1e16: \"dec key\"}";
+			byte "1e16";
+			json_ref JSONString;
+			byte "dec key";
+			==`,
+			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
+		},
 	}
 
 	for _, s := range testCases {
@@ -5243,6 +5267,15 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONUint64
 			`,
 			error:              "error while parsing JSON text, invalid json text, only json object is allowed",
+			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
+		},
+		{
+			source: `byte "{noquotes: \"shouldn't work\"}";
+			byte "noquotes";
+			json_ref JSONString;
+			byte "shouldn't work";
+			==`,
+			error:              "error while parsing JSON text, invalid json text",
 			previousVersErrors: []Expect{{5, "unknown opcode: json_ref"}},
 		},
 	}

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -4914,6 +4915,15 @@ func TestIsPrimitive(t *testing.T) {
 		require.Nil(t, err)
 		require.False(t, primitive)
 	}
+}
+
+func TestProtocolParseDuplicateErrMsg(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	text := `{"key0": "algo", "key0": "algo"}`
+	var parsed map[string]json.RawMessage
+	err := protocol.DecodeJSON([]byte(text), &parsed)
+	require.Contains(t, err.Error(), "cannot decode into a non-pointer value")
+	require.Error(t, err)
 }
 
 func TestOpJSONRef(t *testing.T) {

--- a/data/transactions/logic/jsonspec.md
+++ b/data/transactions/logic/jsonspec.md
@@ -132,37 +132,3 @@ replaced by U+FFFD
 ```json
 {"key0": "\uD800\uD800n"}
 ```
-
-### Keys
-
-- keys can be strings or numbers
-- strings must be quoted
-- number keys behave as quoted strings
-
-#### Example
-  
-```json
-{"key0": "value0"}
-```
-
-The following are interpreted equivalently
-
-```json
-{1: 1}
-{"1": 1}
-```
-
-```json
-{002: 2}
-{"002": 2}
-```
-
-```json
-{0.2: 3}
-{"0.2": 3}
-```
-
-```json
-{1e16: 1}
-{"1e16": 1}
-```

--- a/data/transactions/logic/jsonspec.md
+++ b/data/transactions/logic/jsonspec.md
@@ -22,6 +22,24 @@ Additional specifications used by **json_ref** that are extensions to the RFC715
 {"key0": "\uFF"}
 ```
 
+### Object
+
+#### duplicate key
+
+Duplicate keys at the top level result in an error; however, duplicate keys nested at a lower level are ignored.
+
+#### Invalid JSON text
+
+```json
+{"key0": 1,"key0": 2}
+```
+
+#### Acceptable JSON text
+
+```json
+{"key0": 1,"key1": {"key2":2,"key2":"10"}}
+```
+
 ### Numbers
 
 #### Range

--- a/data/transactions/logic/jsonspec.md
+++ b/data/transactions/logic/jsonspec.md
@@ -151,3 +151,18 @@ The following are interpreted equivalently
 {1: 1}
 {"1": 1}
 ```
+
+```json
+{002: 2}
+{"002": 2}
+```
+
+```json
+{0.2: 3}
+{"0.2": 3}
+```
+
+```json
+{1e16: 1}
+{"1e16": 1}
+```

--- a/data/transactions/logic/jsonspec.md
+++ b/data/transactions/logic/jsonspec.md
@@ -12,7 +12,7 @@ Additional specifications used by **json_ref** that are extensions to the RFC715
 - The byte order mark (BOM), "\uFEFF", is not allowed at the beginning of a JSON text
 - Raw non-unicode characters not accepted
 
-## Invalid JSON text
+### Invalid JSON text
 
 ```json
 \uFEFF{"key0": 1}
@@ -20,24 +20,6 @@ Additional specifications used by **json_ref** that are extensions to the RFC715
 
 ```json
 {"key0": "\uFF"}
-```
-
-### Object
-
-#### duplicate key
-
-Duplicate keys at the top level result in an error; however, duplicate keys nested at a lower level are ignored.
-
-#### Invalid JSON text
-
-```json
-{"key0": 1,"key0": 2}
-```
-
-#### Acceptable JSON text
-
-```json
-{"key0": 1,"key1": {"key2":2,"key2":"10"}}
 ```
 
 ### Numbers
@@ -105,10 +87,6 @@ Comment blocks are not accepted.
 ```
 
 ```json
-{"key0": "algo"}/*comment*/
-```
-
-```json
 {"key0": [1,/*comment*/,3]}
 ```
 
@@ -135,4 +113,23 @@ replaced by U+FFFD
 
 ```json
 {"key0": "\uD800\uD800n"}
+```
+
+### Keys
+
+- keys can be strings or numbers
+- strings must be quoted
+- number keys behave as quoted strings
+
+#### Example
+  
+```json
+{"key0": "value0"}
+```
+
+The following are interpreted equivalently
+
+```json
+{1: 1}
+{"1": 1}
 ```

--- a/data/transactions/logic/jsonspec_test.go
+++ b/data/transactions/logic/jsonspec_test.go
@@ -186,6 +186,9 @@ func TestParseKeys(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "1", string(parsed["\u0061"]))
 	require.Equal(t, "1", string(parsed["a"]))
+	text = `{"key0": 1,"key0": 2}`
+	_, err = parseJSON([]byte(text))
+	require.Error(t, err)
 	text = `{"key0": 1,"key1": {"key2":2,"key2":"10"}}`
 	_, err = parseJSON([]byte(text))
 	require.NoError(t, err)

--- a/data/transactions/logic/jsonspec_test.go
+++ b/data/transactions/logic/jsonspec_test.go
@@ -58,9 +58,6 @@ func TestParseComments(t *testing.T) {
 	text := `{"key0": /*comment*/"algo"}`
 	_, err := parseJSON([]byte(text))
 	require.Error(t, err)
-	text = `{"key0": "algo"}/*comment*/`
-	_, err = parseJSON([]byte(text))
-	require.Error(t, err)
 	text = `{"key0": [1,/*comment*/,3]}`
 	_, err = parseJSON([]byte(text))
 	require.Error(t, err)
@@ -189,9 +186,6 @@ func TestParseKeys(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "1", string(parsed["\u0061"]))
 	require.Equal(t, "1", string(parsed["a"]))
-	text = `{"key0": 1,"key0": 2}`
-	_, err = parseJSON([]byte(text))
-	require.Error(t, err)
 	text = `{"key0": 1,"key1": {"key2":2,"key2":"10"}}`
 	_, err = parseJSON([]byte(text))
 	require.NoError(t, err)
@@ -207,10 +201,6 @@ func TestParseKeys(t *testing.T) {
 	text = `{"key0": 'algo'}`
 	_, err = parseJSON([]byte(text))
 	require.Error(t, err)
-	text = `{1: 1}`
-	_, err = parseJSON([]byte(text))
-	require.Error(t, err)
-
 }
 
 func TestParseFileEncoding(t *testing.T) {

--- a/data/transactions/logic/jsonspec_test.go
+++ b/data/transactions/logic/jsonspec_test.go
@@ -204,6 +204,9 @@ func TestParseKeys(t *testing.T) {
 	text = `{"key0": 'algo'}`
 	_, err = parseJSON([]byte(text))
 	require.Error(t, err)
+	text = `{1: 1}`
+	_, err = parseJSON([]byte(text))
+	require.Error(t, err)
 }
 
 func TestParseFileEncoding(t *testing.T) {

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -491,7 +491,7 @@ var OpSpecs = []OpSpec{
 	{0x5a, "extract_uint32", opExtract32Bits, proto("bi:i"), 5, opDefault()},
 	{0x5b, "extract_uint64", opExtract64Bits, proto("bi:i"), 5, opDefault()},
 	{0x5c, "base64_decode", opBase64Decode, proto("b:b"), fidoVersion, field("e", &Base64Encodings).costByLength(1, 1, 16)},
-	{0x5d, "json_ref", opJSONRef, proto("bb:a"), fidoVersion, field("r", &JSONRefTypes)},
+	{0x5d, "json_ref", opJSONRef, proto("bb:a"), fidoVersion, field("r", &JSONRefTypes).costByLength(25, 2, 7)},
 
 	{0x60, "balance", opBalance, proto("i:i"), 2, only(modeApp)},
 	{0x60, "balance", opBalance, proto("a:i"), directRefEnabledVersion, only(modeApp)},

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -90,14 +90,14 @@ func (lc *linearCost) compute(stack []stackValue) int {
 	return cost
 }
 
-func (lc *linearCost) docCost(argLength int) string {
+func (lc *linearCost) docCost(argLen int) string {
 	if *lc == (linearCost{}) {
 		return ""
 	}
 	if lc.chunkCost == 0 {
 		return strconv.Itoa(lc.baseCost)
 	}
-	idxFromStart := argLength - lc.depth - 1
+	idxFromStart := argLen - lc.depth - 1
 	stackArg := rune(int('A') + idxFromStart)
 	if lc.chunkSize == 1 {
 		return fmt.Sprintf("%d + %d per byte of %c", lc.baseCost, lc.chunkCost, stackArg)
@@ -121,8 +121,8 @@ type OpDetails struct {
 	Immediates []immediate // details of each immediate arg to opcode
 }
 
-func (d *OpDetails) docCost(argLength int) string {
-	cost := d.FullCost.docCost(argLength)
+func (d *OpDetails) docCost(argLen int) string {
+	cost := d.FullCost.docCost(argLen)
 	if cost != "" {
 		return cost
 	}

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -90,17 +90,19 @@ func (lc *linearCost) compute(stack []stackValue) int {
 	return cost
 }
 
-func (lc *linearCost) docCost() string {
+func (lc *linearCost) docCost(argLength int) string {
 	if *lc == (linearCost{}) {
 		return ""
 	}
 	if lc.chunkCost == 0 {
 		return strconv.Itoa(lc.baseCost)
 	}
+	idxFromStart := argLength - lc.depth - 1
+	stackArg := rune(int('A') + idxFromStart)
 	if lc.chunkSize == 1 {
-		return fmt.Sprintf("%d + %d per byte", lc.baseCost, lc.chunkCost)
+		return fmt.Sprintf("%d + %d per byte of %c", lc.baseCost, lc.chunkCost, stackArg)
 	}
-	return fmt.Sprintf("%d + %d per %d bytes", lc.baseCost, lc.chunkCost, lc.chunkSize)
+	return fmt.Sprintf("%d + %d per %d bytes of %c", lc.baseCost, lc.chunkCost, lc.chunkSize, stackArg)
 }
 
 // OpDetails records details such as non-standard costs, immediate arguments, or
@@ -119,8 +121,8 @@ type OpDetails struct {
 	Immediates []immediate // details of each immediate arg to opcode
 }
 
-func (d *OpDetails) docCost() string {
-	cost := d.FullCost.docCost()
+func (d *OpDetails) docCost(argLength int) string {
+	cost := d.FullCost.docCost(argLength)
 	if cost != "" {
 		return cost
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

This PR switches the `json_ref` JSON parser from `encoding/json` to Algorand's `protocol` JSON parser for performance improvements and benchmarks the opcode's running time to determine its linear cost.

While setting a linear cost for the opcode, it was necessary to amend the `linearCost` structure with a stack depth, since `json_ref`'s cost is dependent on the second element in the stack and not the first.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

1. `json_ref` benchmarking on the first and last keys of JSON objects with:
    * only one short key and one short value
    * many keys (100)
    * a long key, short value, followed by short key, short value
    * a short key, long value, followed by short key, short value
    * 200 nested keys (`{"key1": {"key2": { ... }}}`)
3. Test against existing `json_spec` tests and remove ones which no longer apply within the new JSON parser.
4. Test against existing `json_ref` opcode tests.
5. Tested the `isPrimitiveJSON` method on several primitive JSON strings.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
