### PR TITLE
320 rounds: fix flakiness in `TestReproducibleCatchpointLabels`

### DIFF
--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -357,6 +357,12 @@ func (ct *catchpointTracker) produceCommittingTask(committedRound basics.Round, 
 	dcr.catchpointDataWriting = &ct.catchpointDataWriting
 	dcr.enableGeneratingCatchpointFiles = ct.enableGeneratingCatchpointFiles
 
+	{
+		rounds := calculateCatchpointRounds(
+			dcr.oldBase+1, dcr.oldBase+basics.Round(dcr.offset), ct.catchpointInterval)
+		dcr.catchpointSecondStage = (len(rounds) > 0)
+	}
+
 	return dcr
 }
 

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -486,9 +486,6 @@ func TestReproducibleCatchpointLabels(t *testing.T) {
 		delta.Creatables = creatablesFromUpdates(base, updates, knownCreatables)
 		delta.Totals = newTotals
 
-		ml.trackers.mu.Lock()
-		ml.trackers.lastFlushTime = time.Time{}
-		ml.trackers.mu.Unlock()
 		ml.trackers.newBlock(blk, delta)
 		ml.trackers.committedUpTo(i)
 		ml.addMockBlock(blockEntry{block: blk}, delta)
@@ -532,9 +529,6 @@ func TestReproducibleCatchpointLabels(t *testing.T) {
 			blk.CurrentProtocol = testProtocolVersion
 			delta := roundDeltas[i]
 
-			ml2.trackers.mu.Lock()
-			ml2.trackers.lastFlushTime = time.Time{}
-			ml2.trackers.mu.Unlock()
 			ml2.trackers.newBlock(blk, delta)
 			ml2.trackers.committedUpTo(i)
 
@@ -908,9 +902,6 @@ func TestFirstStageInfoPruning(t *testing.T) {
 		}
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, 0, 0)
 
-		ml.trackers.mu.Lock()
-		ml.trackers.lastFlushTime = time.Time{}
-		ml.trackers.mu.Unlock()
 		ml.trackers.newBlock(blk, delta)
 		ml.trackers.committedUpTo(i)
 		ml.addMockBlock(blockEntry{block: blk}, delta)

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -219,6 +219,9 @@ type deferredCommitRange struct {
 
 	// enableGeneratingCatchpointFiles controls whether the node produces catchpoint files or not.
 	enableGeneratingCatchpointFiles bool
+
+	// True iff the commit range includes a catchpoint round.
+	catchpointSecondStage bool
 }
 
 // deferredCommitContext is used in order to syncornize the persistence of a given deferredCommitRange.
@@ -390,7 +393,7 @@ func (tr *trackerRegistry) scheduleCommit(blockqRound, maxLookback basics.Round)
 	// ( unless we're creating a catchpoint, in which case we want to flush it right away
 	//   so that all the instances of the catchpoint would contain exactly the same data )
 	flushTime := time.Now()
-	if dcc != nil && !flushTime.After(tr.lastFlushTime.Add(balancesFlushInterval)) && !dcc.catchpointFirstStage && dcc.pendingDeltas < pendingDeltasFlushThreshold {
+	if dcc != nil && !flushTime.After(tr.lastFlushTime.Add(balancesFlushInterval)) && !dcc.catchpointFirstStage && !dcc.catchpointSecondStage && dcc.pendingDeltas < pendingDeltasFlushThreshold {
 		dcc = nil
 	}
 	tr.mu.RUnlock()


### PR DESCRIPTION
## Summary

`lastFlushTime` was being updated concurrently by the commit cycle, so setting in to 0 does not guarantee the commit will not be skipped. This PR adds an additional check: if there is a catchpoint round, do not skip the commit.

## Test Plan

None.