### PR TITLE
320 rounds: fix another flakiness in `TestReproducibleCatchpointLabels`

### DIFF
--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -264,7 +264,7 @@ func TestAccountDBRound(t *testing.T) {
 	numElementsPerSegment := 10
 
 	// lastCreatableID stores asset or app max used index to get rid of conflicts
-	lastCreatableID := crypto.RandUint64() % 512
+	lastCreatableID := basics.CreatableIndex(crypto.RandUint64() % 512)
 	ctbsList, randomCtbs := randomCreatables(numElementsPerSegment)
 	expectedDbImage := make(map[basics.CreatableIndex]ledgercore.ModifiedCreatable)
 	var baseAccounts lruAccounts
@@ -276,7 +276,7 @@ func TestAccountDBRound(t *testing.T) {
 	baseOnlineAccounts.init(nil, 100, 80)
 	for i := 1; i < 10; i++ {
 		var updates ledgercore.AccountDeltas
-		updates, newacctsTotals, _, lastCreatableID = ledgertesting.RandomDeltasFull(20, accts, 0, lastCreatableID)
+		updates, newacctsTotals, _ = ledgertesting.RandomDeltasFull(20, accts, 0, &lastCreatableID)
 		totals = ledgertesting.CalculateNewRoundAccountTotals(t, updates, 0, proto, accts, totals)
 		accts = applyPartialDeltas(accts, updates)
 		ctbsWithDeletes := randomCreatableSampling(i, ctbsList, randomCtbs,

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -495,7 +495,7 @@ func TestAcctUpdates(t *testing.T) {
 			checkAcctUpdates(t, au, ao, 0, basics.Round(initialBlocksCount-1), accts, rewardsLevels, proto)
 
 			// lastCreatableID stores asset or app max used index to get rid of conflicts
-			lastCreatableID := crypto.RandUint64() % 512
+			lastCreatableID := basics.CreatableIndex(crypto.RandUint64() % 512)
 			knownCreatables := make(map[basics.CreatableIndex]bool)
 
 			maxLookback := conf.MaxAcctLookback
@@ -508,7 +508,7 @@ func TestAcctUpdates(t *testing.T) {
 				var updates ledgercore.AccountDeltas
 				var totals map[basics.Address]ledgercore.AccountData
 				base := accts[i-1]
-				updates, totals, lastCreatableID = ledgertesting.RandomDeltasBalancedFull(1, base, rewardLevel, lastCreatableID)
+				updates, totals = ledgertesting.RandomDeltasBalancedFull(1, base, rewardLevel, &lastCreatableID)
 				prevRound, prevTotals, err := au.LatestTotals()
 				require.Equal(t, i-1, prevRound)
 				require.NoError(t, err)
@@ -2257,7 +2257,7 @@ func testAcctUpdatesLookupRetry(t *testing.T, assertFn func(au *accountUpdates, 
 	checkAcctUpdates(t, au, ao, 0, basics.Round(initialBlocksCount)-1, accts, rewardsLevels, proto)
 
 	// lastCreatableID stores asset or app max used index to get rid of conflicts
-	lastCreatableID := crypto.RandUint64() % 512
+	lastCreatableID := basics.CreatableIndex(crypto.RandUint64() % 512)
 	knownCreatables := make(map[basics.CreatableIndex]bool)
 
 	for i := basics.Round(initialBlocksCount); i < basics.Round(conf.MaxAcctLookback+15); i++ {
@@ -2266,7 +2266,8 @@ func testAcctUpdatesLookupRetry(t *testing.T, assertFn func(au *accountUpdates, 
 		var updates ledgercore.AccountDeltas
 		var totals map[basics.Address]ledgercore.AccountData
 		base := accts[i-1]
-		updates, totals, lastCreatableID = ledgertesting.RandomDeltasBalancedFull(1, base, rewardLevel, lastCreatableID)
+		updates, totals = ledgertesting.RandomDeltasBalancedFull(
+			1, base, rewardLevel, &lastCreatableID)
 		prevRound, prevTotals, err := au.LatestTotals()
 		require.Equal(t, i-1, prevRound)
 		require.NoError(t, err)

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -444,7 +444,7 @@ func TestReproducibleCatchpointLabels(t *testing.T) {
 	const testCatchpointLabelsCount = 5
 
 	// lastCreatableID stores asset or app max used index to get rid of conflicts
-	lastCreatableID := crypto.RandUint64() % 512
+	lastCreatableID := basics.CreatableIndex(crypto.RandUint64() % 512)
 	knownCreatables := make(map[basics.CreatableIndex]bool)
 	catchpointLabels := make(map[basics.Round]string)
 	ledgerHistory := make(map[basics.Round]*mockLedgerForTracker)
@@ -458,7 +458,7 @@ func TestReproducibleCatchpointLabels(t *testing.T) {
 		var updates ledgercore.AccountDeltas
 		var totals map[basics.Address]ledgercore.AccountData
 		base := accts[i-1]
-		updates, totals, lastCreatableID = ledgertesting.RandomDeltasBalancedFull(1, base, rewardLevel, lastCreatableID)
+		updates, totals = ledgertesting.RandomDeltasBalancedFull(1, base, rewardLevel, &lastCreatableID)
 		prevRound, prevTotals, err := au.LatestTotals()
 		require.Equal(t, i-1, prevRound)
 		require.NoError(t, err)

--- a/ledger/testing/randomAccounts.go
+++ b/ledger/testing/randomAccounts.go
@@ -308,9 +308,9 @@ func RandomAccounts(niter int, simpleAccounts bool) map[basics.Address]basics.Ac
 
 // RandomDeltas generates a random set of accounts delta
 func RandomDeltas(niter int, base map[basics.Address]basics.AccountData, rewardsLevel uint64) (updates ledgercore.AccountDeltas, totals map[basics.Address]ledgercore.AccountData, imbalance int64) {
-	var lastCreatableId basics.CreatableIndex
+	var lastCreatableID basics.CreatableIndex
 	updates, totals, imbalance =
-		RandomDeltasImpl(niter, base, rewardsLevel, true, &lastCreatableId)
+		RandomDeltasImpl(niter, base, rewardsLevel, true, &lastCreatableID)
 	return
 }
 

--- a/ledger/testing/randomAccounts.go
+++ b/ledger/testing/randomAccounts.go
@@ -202,7 +202,7 @@ func RandomAppLocalState() basics.AppLocalState {
 const maxInt64 = int64((^uint64(0)) >> 1)
 
 // RandomFullAccountData generates a random AccountData
-func RandomFullAccountData(rewardsLevel uint64, knownCreatables map[basics.CreatableIndex]basics.CreatableType, lastCreatableID uint64) (basics.AccountData, map[basics.CreatableIndex]basics.CreatableType, uint64) {
+func RandomFullAccountData(rewardsLevel uint64, lastCreatableID *basics.CreatableIndex, assets map[basics.AssetIndex]struct{}, apps map[basics.AppIndex]struct{}) basics.AccountData {
 	data := RandomAccountData(rewardsLevel)
 
 	if data.Status == basics.Online {
@@ -226,28 +226,26 @@ func RandomFullAccountData(rewardsLevel uint64, knownCreatables map[basics.Creat
 		data.AssetParams = make(map[basics.AssetIndex]basics.AssetParams, createdAssetsCount)
 		for i := uint64(0); i < createdAssetsCount; i++ {
 			ap := RandomAssetParams()
-			lastCreatableID++
-			data.AssetParams[basics.AssetIndex(lastCreatableID)] = ap
-			knownCreatables[basics.CreatableIndex(lastCreatableID)] = basics.AssetCreatable
+			*lastCreatableID++
+			data.AssetParams[basics.AssetIndex(*lastCreatableID)] = ap
+			assets[basics.AssetIndex(*lastCreatableID)] = struct{}{}
 		}
 	}
-	if (crypto.RandUint64()%2) == 1 && lastCreatableID > 0 {
+	if (crypto.RandUint64()%2 == 1) && (len(assets) > 0) {
 		// if account owns assets
 		ownedAssetsCount := crypto.RandUint64()%20 + 1
 		data.Assets = make(map[basics.AssetIndex]basics.AssetHolding, ownedAssetsCount)
 		for i := uint64(0); i < ownedAssetsCount; i++ {
 			ah := RandomAssetHolding(false)
-			aidx := crypto.RandUint64() % lastCreatableID
+			var aidx basics.AssetIndex
 			for {
-				ctype, ok := knownCreatables[basics.CreatableIndex(aidx)]
-				if !ok || ctype == basics.AssetCreatable {
+				aidx = basics.AssetIndex(crypto.RandUint64()%uint64(*lastCreatableID) + 1)
+				if _, ok := assets[aidx]; ok {
 					break
 				}
-				aidx = crypto.RandUint64() % lastCreatableID
 			}
 
-			data.Assets[basics.AssetIndex(aidx)] = ah
-			knownCreatables[basics.CreatableIndex(aidx)] = basics.AssetCreatable
+			data.Assets[aidx] = ah
 		}
 	}
 	if (crypto.RandUint64() % 5) == 1 {
@@ -259,26 +257,24 @@ func RandomFullAccountData(rewardsLevel uint64, knownCreatables map[basics.Creat
 		data.AppParams = make(map[basics.AppIndex]basics.AppParams, appParamsCount)
 		for i := uint64(0); i < appParamsCount; i++ {
 			ap := RandomAppParams()
-			lastCreatableID++
-			data.AppParams[basics.AppIndex(lastCreatableID)] = ap
-			knownCreatables[basics.CreatableIndex(lastCreatableID)] = basics.AppCreatable
+			*lastCreatableID++
+			data.AppParams[basics.AppIndex(*lastCreatableID)] = ap
+			apps[basics.AppIndex(*lastCreatableID)] = struct{}{}
 		}
 	}
-	if (crypto.RandUint64()%3) == 1 && lastCreatableID > 0 {
+	if (crypto.RandUint64()%3 == 1) && (len(apps) > 0) {
 		appStatesCount := crypto.RandUint64()%20 + 1
 		data.AppLocalStates = make(map[basics.AppIndex]basics.AppLocalState, appStatesCount)
 		for i := uint64(0); i < appStatesCount; i++ {
 			ap := RandomAppLocalState()
-			aidx := crypto.RandUint64() % lastCreatableID
+			var aidx basics.AppIndex
 			for {
-				ctype, ok := knownCreatables[basics.CreatableIndex(aidx)]
-				if !ok || ctype == basics.AppCreatable {
+				aidx = basics.AppIndex(crypto.RandUint64()%uint64(*lastCreatableID) + 1)
+				if _, ok := apps[aidx]; ok {
 					break
 				}
-				aidx = crypto.RandUint64() % lastCreatableID
 			}
 			data.AppLocalStates[basics.AppIndex(aidx)] = ap
-			knownCreatables[basics.CreatableIndex(aidx)] = basics.AppCreatable
 		}
 	}
 
@@ -288,7 +284,8 @@ func RandomFullAccountData(rewardsLevel uint64, knownCreatables map[basics.Creat
 			NumByteSlice: crypto.RandUint64() % 50,
 		}
 	}
-	return data, knownCreatables, lastCreatableID
+
+	return data
 }
 
 // RandomAccounts generates a random set of accounts map
@@ -299,10 +296,11 @@ func RandomAccounts(niter int, simpleAccounts bool) map[basics.Address]basics.Ac
 			res[RandomAddress()] = RandomAccountData(0)
 		}
 	} else {
-		lastCreatableID := crypto.RandUint64() % 512
-		knownCreatables := make(map[basics.CreatableIndex]basics.CreatableType)
+		lastCreatableID := basics.CreatableIndex(crypto.RandUint64() % 512)
+		assets := make(map[basics.AssetIndex]struct{})
+		apps := make(map[basics.AppIndex]struct{})
 		for i := 0; i < niter; i++ {
-			res[RandomAddress()], knownCreatables, lastCreatableID = RandomFullAccountData(0, knownCreatables, lastCreatableID)
+			res[RandomAddress()] = RandomFullAccountData(0, &lastCreatableID, assets, apps)
 		}
 	}
 	return res
@@ -310,18 +308,20 @@ func RandomAccounts(niter int, simpleAccounts bool) map[basics.Address]basics.Ac
 
 // RandomDeltas generates a random set of accounts delta
 func RandomDeltas(niter int, base map[basics.Address]basics.AccountData, rewardsLevel uint64) (updates ledgercore.AccountDeltas, totals map[basics.Address]ledgercore.AccountData, imbalance int64) {
-	updates, totals, imbalance, _ = RandomDeltasImpl(niter, base, rewardsLevel, true, 0)
+	var lastCreatableId basics.CreatableIndex
+	updates, totals, imbalance =
+		RandomDeltasImpl(niter, base, rewardsLevel, true, &lastCreatableId)
 	return
 }
 
 // RandomDeltasFull generates a random set of accounts delta
-func RandomDeltasFull(niter int, base map[basics.Address]basics.AccountData, rewardsLevel uint64, lastCreatableIDIn uint64) (updates ledgercore.AccountDeltas, totals map[basics.Address]ledgercore.AccountData, imbalance int64, lastCreatableID uint64) {
-	updates, totals, imbalance, lastCreatableID = RandomDeltasImpl(niter, base, rewardsLevel, false, lastCreatableIDIn)
+func RandomDeltasFull(niter int, base map[basics.Address]basics.AccountData, rewardsLevel uint64, lastCreatableID *basics.CreatableIndex) (updates ledgercore.AccountDeltas, totals map[basics.Address]ledgercore.AccountData, imbalance int64) {
+	updates, totals, imbalance = RandomDeltasImpl(niter, base, rewardsLevel, false, lastCreatableID)
 	return
 }
 
 // RandomDeltasImpl generates a random set of accounts delta
-func RandomDeltasImpl(niter int, base map[basics.Address]basics.AccountData, rewardsLevel uint64, simple bool, lastCreatableIDIn uint64) (updates ledgercore.AccountDeltas, totals map[basics.Address]ledgercore.AccountData, imbalance int64, lastCreatableID uint64) {
+func RandomDeltasImpl(niter int, base map[basics.Address]basics.AccountData, rewardsLevel uint64, simple bool, lastCreatableID *basics.CreatableIndex) (updates ledgercore.AccountDeltas, totals map[basics.Address]ledgercore.AccountData, imbalance int64) {
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	totals = make(map[basics.Address]ledgercore.AccountData)
 
@@ -333,30 +333,21 @@ func RandomDeltasImpl(niter int, base map[basics.Address]basics.AccountData, rew
 	}
 
 	// if making a full delta then need to determine max asset/app id to get rid of conflicts
-	lastCreatableID = lastCreatableIDIn
-	knownCreatables := make(map[basics.CreatableIndex]basics.CreatableType)
+	assets := make(map[basics.AssetIndex]struct{})
+	apps := make(map[basics.AppIndex]struct{})
 	if !simple {
 		for _, ad := range base {
 			for aid := range ad.AssetParams {
-				if uint64(aid) > lastCreatableID {
-					lastCreatableID = uint64(aid)
-				}
-				knownCreatables[basics.CreatableIndex(aid)] = basics.AssetCreatable
+				assets[aid] = struct{}{}
 			}
 			for aid := range ad.Assets {
-				// do not check lastCreatableID since lastCreatableID is only incremented for new params
-				knownCreatables[basics.CreatableIndex(aid)] = basics.AssetCreatable
+				assets[aid] = struct{}{}
 			}
-
 			for aid := range ad.AppParams {
-				if uint64(aid) > lastCreatableID {
-					lastCreatableID = uint64(aid)
-				}
-				knownCreatables[basics.CreatableIndex(aid)] = basics.AppCreatable
+				apps[aid] = struct{}{}
 			}
 			for aid := range ad.AppLocalStates {
-				// do not check lastCreatableID since lastCreatableID is only incremented for new params
-				knownCreatables[basics.CreatableIndex(aid)] = basics.AppCreatable
+				apps[aid] = struct{}{}
 			}
 		}
 	}
@@ -381,7 +372,7 @@ func RandomDeltasImpl(niter int, base map[basics.Address]basics.AccountData, rew
 				new = ledgercore.ToAccountData(data)
 				updates.Upsert(addr, new)
 			} else {
-				data, knownCreatables, lastCreatableID = RandomFullAccountData(rewardsLevel, knownCreatables, lastCreatableID)
+				data = RandomFullAccountData(rewardsLevel, lastCreatableID, assets, apps)
 				new = ledgercore.ToAccountData(data)
 				updates.Upsert(addr, new)
 				appResources := make(map[basics.AppIndex]ledgercore.AppResourceRecord)
@@ -466,7 +457,7 @@ func RandomDeltasImpl(niter int, base map[basics.Address]basics.AccountData, rew
 			new = ledgercore.ToAccountData(data)
 			updates.Upsert(addr, new)
 		} else {
-			data, knownCreatables, lastCreatableID = RandomFullAccountData(rewardsLevel, knownCreatables, lastCreatableID)
+			data = RandomFullAccountData(rewardsLevel, lastCreatableID, assets, apps)
 			new = ledgercore.ToAccountData(data)
 			updates.Upsert(addr, new)
 			appResources := make(map[basics.AppIndex]ledgercore.AppResourceRecord)
@@ -513,23 +504,26 @@ func RandomDeltasImpl(niter int, base map[basics.Address]basics.AccountData, rew
 
 // RandomDeltasBalanced generates a random set of accounts delta
 func RandomDeltasBalanced(niter int, base map[basics.Address]basics.AccountData, rewardsLevel uint64) (updates ledgercore.AccountDeltas, totals map[basics.Address]ledgercore.AccountData) {
-	updates, totals, _ = RandomDeltasBalancedImpl(niter, base, rewardsLevel, true, 0)
+	var lastCreatableID basics.CreatableIndex
+	updates, totals = RandomDeltasBalancedImpl(
+		niter, base, rewardsLevel, true, &lastCreatableID)
 	return
 }
 
 // RandomDeltasBalancedFull generates a random set of accounts delta
-func RandomDeltasBalancedFull(niter int, base map[basics.Address]basics.AccountData, rewardsLevel uint64, lastCreatableIDIn uint64) (updates ledgercore.AccountDeltas, totals map[basics.Address]ledgercore.AccountData, lastCreatableID uint64) {
-	updates, totals, lastCreatableID = RandomDeltasBalancedImpl(niter, base, rewardsLevel, false, lastCreatableIDIn)
+func RandomDeltasBalancedFull(niter int, base map[basics.Address]basics.AccountData, rewardsLevel uint64, lastCreatableID *basics.CreatableIndex) (updates ledgercore.AccountDeltas, totals map[basics.Address]ledgercore.AccountData) {
+	updates, totals = RandomDeltasBalancedImpl(niter, base, rewardsLevel, false, lastCreatableID)
 	return
 }
 
 // RandomDeltasBalancedImpl generates a random set of accounts delta
-func RandomDeltasBalancedImpl(niter int, base map[basics.Address]basics.AccountData, rewardsLevel uint64, simple bool, lastCreatableIDIn uint64) (updates ledgercore.AccountDeltas, totals map[basics.Address]ledgercore.AccountData, lastCreatableID uint64) {
+func RandomDeltasBalancedImpl(niter int, base map[basics.Address]basics.AccountData, rewardsLevel uint64, simple bool, lastCreatableID *basics.CreatableIndex) (updates ledgercore.AccountDeltas, totals map[basics.Address]ledgercore.AccountData) {
 	var imbalance int64
 	if simple {
 		updates, totals, imbalance = RandomDeltas(niter, base, rewardsLevel)
 	} else {
-		updates, totals, imbalance, lastCreatableID = RandomDeltasFull(niter, base, rewardsLevel, lastCreatableIDIn)
+		updates, totals, imbalance =
+			RandomDeltasFull(niter, base, rewardsLevel, lastCreatableID)
 	}
 
 	oldPool := base[testPoolAddr]
@@ -540,5 +534,5 @@ func RandomDeltasBalancedImpl(niter int, base map[basics.Address]basics.AccountD
 	updates.Upsert(testPoolAddr, newPool)
 	totals[testPoolAddr] = newPool
 
-	return updates, totals, lastCreatableID
+	return updates, totals
 }


### PR DESCRIPTION
## Summary

`TestReproducibleCatchpointLabels` gets stuck sometimes. The problem is in https://github.com/algorand/go-algorand/blob/feature/320-rounds/ledger/testing/randomAccounts.go#L241-L247 and https://github.com/algorand/go-algorand/blob/feature/320-rounds/ledger/testing/randomAccounts.go#L273-L279. If there are no assets / apps, the loops never terminate.

## Test Plan

Ran `TestReproducibleCatchpointLabels` 1000 times.