### PR TITLE
320 rounds: fix restoring from a catchpoint

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -2383,14 +2383,14 @@ func resetAccountHashes(tx *sql.Tx) (err error) {
 	return
 }
 
-func accountsReset(tx *sql.Tx) error {
+func accountsReset(ctx context.Context, tx *sql.Tx) error {
 	for _, stmt := range accountsResetExprs {
-		_, err := tx.Exec(stmt)
+		_, err := tx.ExecContext(ctx, stmt)
 		if err != nil {
 			return err
 		}
 	}
-	_, err := db.SetUserVersion(context.Background(), tx, 0)
+	_, err := db.SetUserVersion(ctx, tx, 0)
 	return err
 }
 

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -1085,8 +1085,6 @@ func resetCatchpointStagingBalances(ctx context.Context, tx *sql.Tx, newCatchup 
 		"DROP TABLE IF EXISTS catchpointaccounthashes",
 		"DROP TABLE IF EXISTS catchpointpendinghashes",
 		"DROP TABLE IF EXISTS catchpointresources",
-		"DROP TABLE IF EXISTS catchpointtxtail",
-		"DROP TABLE IF EXISTS catchpointonlineaccounts",
 		"DELETE FROM accounttotals where id='catchpointStaging'",
 	}
 
@@ -1100,7 +1098,6 @@ func resetCatchpointStagingBalances(ctx context.Context, tx *sql.Tx, newCatchup 
 		now := time.Now().UnixNano()
 		idxnameBalances := fmt.Sprintf("onlineaccountbals_idx_%d", now)
 		idxnameAddress := fmt.Sprintf("accountbase_address_idx_%d", now)
-		idxnameOnlineBalances := fmt.Sprintf("onlineaccountnorm_idx_%d", now)
 
 		s = append(s,
 			"CREATE TABLE IF NOT EXISTS catchpointassetcreators (asset integer primary key, creator blob, ctype integer)",
@@ -1108,11 +1105,8 @@ func resetCatchpointStagingBalances(ctx context.Context, tx *sql.Tx, newCatchup 
 			"CREATE TABLE IF NOT EXISTS catchpointpendinghashes (data blob)",
 			"CREATE TABLE IF NOT EXISTS catchpointaccounthashes (id integer primary key, data blob)",
 			"CREATE TABLE IF NOT EXISTS catchpointresources (addrid INTEGER NOT NULL, aidx INTEGER NOT NULL, data BLOB NOT NULL, PRIMARY KEY (addrid, aidx) ) WITHOUT ROWID",
-			"CREATE TABLE IF NOT EXISTS catchpointonlineaccounts (address blob NOT NULL, updround INTEGER, normalizedonlinebalance INTEGER NOT NULL, votelastvalid INTEGER NOT NULL, data blob NOT NULL, PRIMARY KEY (address, updround) )",
-			"CREATE TABLE IF NOT EXISTS catchpointtxtail (round INTEGER PRIMARY KEY NOT NULL, data blob)",
 			createNormalizedOnlineBalanceIndex(idxnameBalances, "catchpointbalances"), // should this be removed ?
 			createUniqueAddressBalanceIndex(idxnameAddress, "catchpointbalances"),
-			createNormalizedOnlineBalanceIndexOnline(idxnameOnlineBalances, "catchpointonlineaccounts"),
 		)
 	}
 
@@ -1130,26 +1124,15 @@ func resetCatchpointStagingBalances(ctx context.Context, tx *sql.Tx, newCatchup 
 // tables and update the correct balance round. This is the final step in switching onto the new catchpoint round.
 func applyCatchpointStagingBalances(ctx context.Context, tx *sql.Tx, balancesRound basics.Round, merkleRootRound basics.Round) (err error) {
 	stmts := []string{
-		"ALTER TABLE accountbase RENAME TO accountbase_old",
-		"ALTER TABLE assetcreators RENAME TO assetcreators_old",
-		"ALTER TABLE accounthashes RENAME TO accounthashes_old",
-		"ALTER TABLE resources RENAME TO resources_old",
-		"ALTER TABLE onlineaccounts RENAME TO onlineaccounts_old",
-		"ALTER TABLE txtail RENAME TO txtail_old",
+		"DROP TABLE IF EXISTS accountbase",
+		"DROP TABLE IF EXISTS assetcreators",
+		"DROP TABLE IF EXISTS accounthashes",
+		"DROP TABLE IF EXISTS resources",
 
 		"ALTER TABLE catchpointbalances RENAME TO accountbase",
 		"ALTER TABLE catchpointassetcreators RENAME TO assetcreators",
 		"ALTER TABLE catchpointaccounthashes RENAME TO accounthashes",
 		"ALTER TABLE catchpointresources RENAME TO resources",
-		"ALTER TABLE catchpointonlineaccounts RENAME TO onlineaccounts",
-		"ALTER TABLE catchpointtxtail RENAME TO txtail",
-
-		"DROP TABLE IF EXISTS accountbase_old",
-		"DROP TABLE IF EXISTS assetcreators_old",
-		"DROP TABLE IF EXISTS accounthashes_old",
-		"DROP TABLE IF EXISTS resources_old",
-		"DROP TABLE IF EXISTS onlineaccounts_old",
-		"DROP TABLE IF EXISTS txtail_old",
 	}
 
 	for _, stmt := range stmts {

--- a/ledger/catchupaccessor.go
+++ b/ledger/catchupaccessor.go
@@ -821,7 +821,12 @@ func (c *CatchpointCatchupAccessorImpl) finishBalances(ctx context.Context) (err
 			}
 		}
 
-		// Reset the database to version 6.
+		// Reset the database to version 6. For now, we create a version 6 database from
+		// the catchpoint and let `reloadLedger()` run the normal database migration.
+		// When implementing a new catchpoint format (e.g. adding a new table),
+		// it might be necessary to restore it into the latest database version. To do that, one
+		// will need to run the 6->7 migration code manually here or in a similar function to create
+		// onlineaccounts and other V7 tables.
 		// TODO: pass ctx.
 		err = accountsReset(tx)
 		if err != nil {
@@ -835,7 +840,7 @@ func (c *CatchpointCatchupAccessorImpl) finishBalances(ctx context.Context) (err
 				dbPathPrefix:      c.ledger.catchpoint.dbDirectory,
 				blockDb:           c.ledger.blockDBs,
 			}
-			_, err = runMigrations(ctx, tx, tp, c.ledger.log, 6)
+			_, err = runMigrations(ctx, tx, tp, c.ledger.log, 6 /*target database version*/)
 			if err != nil {
 				return err
 			}

--- a/ledger/catchupaccessor.go
+++ b/ledger/catchupaccessor.go
@@ -827,8 +827,7 @@ func (c *CatchpointCatchupAccessorImpl) finishBalances(ctx context.Context) (err
 		// it might be necessary to restore it into the latest database version. To do that, one
 		// will need to run the 6->7 migration code manually here or in a similar function to create
 		// onlineaccounts and other V7 tables.
-		// TODO: pass ctx.
-		err = accountsReset(tx)
+		err = accountsReset(ctx, tx)
 		if err != nil {
 			return err
 		}

--- a/ledger/trackerdb.go
+++ b/ledger/trackerdb.go
@@ -84,7 +84,7 @@ func trackerDBInitialize(l ledgerForTracker, catchpointEnabled bool, dbPathPrefi
 			blockDb:           bdbs,
 		}
 		var err0 error
-		mgr, err0 = trackerDBInitializeImpl(ctx, tx, tp, log)
+		mgr, err0 = runMigrations(ctx, tx, tp, log, accountDBVersion)
 		if err0 != nil {
 			return err0
 		}
@@ -99,7 +99,7 @@ func trackerDBInitialize(l ledgerForTracker, catchpointEnabled bool, dbPathPrefi
 			if err0 != nil {
 				return err0
 			}
-			mgr, err0 = trackerDBInitializeImpl(ctx, tx, tp, log)
+			mgr, err0 = runMigrations(ctx, tx, tp, log, accountDBVersion)
 			if err0 != nil {
 				return err0
 			}
@@ -110,10 +110,10 @@ func trackerDBInitialize(l ledgerForTracker, catchpointEnabled bool, dbPathPrefi
 	return
 }
 
-// trackerDBInitializeImpl initializes the accounts DB if needed and return current account round.
+// runMigrations initializes the accounts DB if needed and return current account round.
 // as part of the initialization, it tests the current database schema version, and perform upgrade
 // procedures to bring it up to the database schema supported by the binary.
-func trackerDBInitializeImpl(ctx context.Context, tx *sql.Tx, params trackerDBParams, log logging.Logger) (mgr trackerDBInitParams, err error) {
+func runMigrations(ctx context.Context, tx *sql.Tx, params trackerDBParams, log logging.Logger, targetVersion int32) (mgr trackerDBInitParams, err error) {
 	// check current database version.
 	dbVersion, err := db.GetUserVersion(ctx, tx)
 	if err != nil {
@@ -128,15 +128,15 @@ func trackerDBInitializeImpl(ctx context.Context, tx *sql.Tx, params trackerDBPa
 
 	// if database version is greater than supported by current binary, write a warning. This would keep the existing
 	// fallback behavior where we could use an older binary iff the schema happen to be backward compatible.
-	if tu.version() > accountDBVersion {
-		tu.log.Warnf("trackerDBInitialize database schema version is %d, but algod supports only %d", tu.version(), accountDBVersion)
+	if tu.version() > targetVersion {
+		tu.log.Warnf("trackerDBInitialize database schema version is %d, but migration target version is %d", tu.version(), targetVersion)
 	}
 
-	if tu.version() < accountDBVersion {
-		tu.log.Infof("trackerDBInitialize upgrading database schema from version %d to version %d", tu.version(), accountDBVersion)
+	if tu.version() < targetVersion {
+		tu.log.Infof("trackerDBInitialize upgrading database schema from version %d to version %d", tu.version(), targetVersion)
 		// newDatabase is determined during the tables creations. If we're filling the database with accounts,
 		// then we set this variable to true, allowing some of the upgrades to be skipped.
-		for tu.version() < accountDBVersion {
+		for tu.version() < targetVersion {
 			tu.log.Infof("trackerDBInitialize performing upgrade from version %d", tu.version())
 			// perform the initialization/upgrade
 			switch tu.version() {

--- a/ledger/trackerdb.go
+++ b/ledger/trackerdb.go
@@ -95,7 +95,7 @@ func trackerDBInitialize(l ledgerForTracker, catchpointEnabled bool, dbPathPrefi
 		// Check for blocks DB and tracker DB un-sync
 		if lastBalancesRound > lastestBlockRound {
 			log.Warnf("trackerDBInitialize: resetting accounts DB (on round %v, but blocks DB's latest is %v)", lastBalancesRound, lastestBlockRound)
-			err0 = accountsReset(tx)
+			err0 = accountsReset(ctx, tx)
 			if err0 != nil {
 				return err0
 			}


### PR DESCRIPTION
## Summary

Restore catchpoints into a V6 database and let the migration update the database.

## Test Plan

Manually ran fast catchup.