### PR TITLE
Bug Fix: Adds validity round check for failing tests

### DIFF
--- a/test/e2e-go/features/participation/participationExpiration_test.go
+++ b/test/e2e-go/features/participation/participationExpiration_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
-func testExpirationAccounts(t *testing.T, fixture *fixtures.RestClientFixture, finalStatus basics.Status, protocolCheck string) {
+func testExpirationAccounts(t *testing.T, fixture *fixtures.RestClientFixture, finalStatus basics.Status, protocolCheck string, includeStateProofs bool) {
 
 	a := require.New(fixtures.SynchronizedTest(t))
 	pClient := fixture.GetLibGoalClientForNamedNode("Primary")
@@ -84,7 +84,7 @@ func testExpirationAccounts(t *testing.T, fixture *fixtures.RestClientFixture, f
 		a.Equal(sAccount, partkeyResponse.Parent.String())
 
 		// account uses part key to go online
-		goOnlineTx, err := sClient.MakeRegistrationTransactionWithGenesisID(partkeyResponse, transactionFee, 0, 0, [32]byte{}, true)
+		goOnlineTx, err := sClient.MakeRegistrationTransactionWithGenesisID(partkeyResponse, transactionFee, 0, 0, [32]byte{}, includeStateProofs)
 		a.NoError(err)
 
 		a.Equal(sAccount, goOnlineTx.Src().String())
@@ -191,7 +191,7 @@ func TestParticipationAccountsExpirationFuture(t *testing.T) {
 	fixture.Start()
 	defer fixture.Shutdown()
 
-	testExpirationAccounts(t, &fixture, basics.Offline, "future")
+	testExpirationAccounts(t, &fixture, basics.Offline, "future", true)
 }
 
 // TestParticipationAccountsExpirationNonFuture tests that sending a transaction to an account with
@@ -214,5 +214,5 @@ func TestParticipationAccountsExpirationNonFuture(t *testing.T) {
 	fixture.Start()
 	defer fixture.Shutdown()
 
-	testExpirationAccounts(t, &fixture, basics.Online, string(protocol.ConsensusV29))
+	testExpirationAccounts(t, &fixture, basics.Online, string(protocol.ConsensusV29), false)
 }


### PR DESCRIPTION
Resolves [#2088](https://github.com/algorand/go-algorand-internal/issues/2088)

Currently these tests are failing:

TestParticipationAccountsExpirationFuture
TestParticipationAccountsExpirationNonFuture

Add validity round checks so that rounds are appropriately set when generating the registration transaction.
