### PR TITLE
apply: update keyreg txn handling of StateProofID when going offline

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -440,6 +440,9 @@ type ConsensusParams struct {
 	// This new header is in addition to the existing SHA512_256 merkle root.
 	// It is useful for verifying transaction on different blockchains, as some may not support SHA512_256 OPCODE natively but SHA256 is common.
 	EnableSHA256TxnCommitmentHeader bool
+
+	// ClearOfflineStateProofID tells the ledger to clear the account's StateProofID when a keyreg transaction marks it offline.
+	ClearOfflineStateProofID bool
 }
 
 // PaysetCommitType enumerates possible ways for the block header to commit to
@@ -1150,6 +1153,7 @@ func initConsensusProtocols() {
 	vFuture.UnifyInnerTxIDs = true
 
 	vFuture.EnableSHA256TxnCommitmentHeader = true
+	vFuture.ClearOfflineStateProofID = true
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 }

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -441,8 +441,8 @@ type ConsensusParams struct {
 	// It is useful for verifying transaction on different blockchains, as some may not support SHA512_256 OPCODE natively but SHA256 is common.
 	EnableSHA256TxnCommitmentHeader bool
 
-	// ClearOfflineStateProofID tells the ledger to clear the account's StateProofID when a keyreg transaction marks it offline.
-	ClearOfflineStateProofID bool
+	// EnableOnlineAccountCatchpoints specifies when to re-enable catchpoints after the online account table migration has occurred.
+	EnableOnlineAccountCatchpoints bool
 }
 
 // PaysetCommitType enumerates possible ways for the block header to commit to
@@ -1153,7 +1153,7 @@ func initConsensusProtocols() {
 	vFuture.UnifyInnerTxIDs = true
 
 	vFuture.EnableSHA256TxnCommitmentHeader = true
-	vFuture.ClearOfflineStateProofID = true
+	vFuture.EnableOnlineAccountCatchpoints = true
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 }

--- a/ledger/apply/keyreg.go
+++ b/ledger/apply/keyreg.go
@@ -49,7 +49,7 @@ func Keyreg(keyreg transactions.KeyregTxnFields, header transactions.Header, bal
 	// (or, if the voting or selection keys are zero, offline/not-participating)
 	record.VoteID = keyreg.VotePK
 	record.SelectionID = keyreg.SelectionPK
-	if balances.ConsensusParams().EnableStateProofKeyregCheck {
+	if params := balances.ConsensusParams(); params.EnableStateProofKeyregCheck && params.ClearOfflineStateProofID {
 		record.StateProofID = keyreg.StateProofPK
 	}
 	if (keyreg.VotePK == crypto.OneTimeSignatureVerifier{} || keyreg.SelectionPK == crypto.VRFVerifier{}) {
@@ -79,6 +79,9 @@ func Keyreg(keyreg transactions.KeyregTxnFields, header transactions.Header, bal
 		record.VoteFirstValid = keyreg.VoteFirst
 		record.VoteLastValid = keyreg.VoteLast
 		record.VoteKeyDilution = keyreg.VoteKeyDilution
+		if params := balances.ConsensusParams(); params.EnableStateProofKeyregCheck && !params.ClearOfflineStateProofID {
+			record.StateProofID = keyreg.StateProofPK
+		}
 	}
 
 	// Write the updated entry

--- a/ledger/apply/keyreg.go
+++ b/ledger/apply/keyreg.go
@@ -45,16 +45,18 @@ func Keyreg(keyreg transactions.KeyregTxnFields, header transactions.Header, bal
 		return fmt.Errorf("cannot change online/offline status of non-participating account %v", header.Sender)
 	}
 
+	params := balances.ConsensusParams()
+
 	// Update the registered keys and mark account as online
 	// (or, if the voting or selection keys are zero, offline/not-participating)
 	record.VoteID = keyreg.VotePK
 	record.SelectionID = keyreg.SelectionPK
-	if params := balances.ConsensusParams(); params.EnableStateProofKeyregCheck && params.EnableOnlineAccountCatchpoints {
+	if params.EnableStateProofKeyregCheck && params.EnableOnlineAccountCatchpoints {
 		record.StateProofID = keyreg.StateProofPK
 	}
 	if (keyreg.VotePK == crypto.OneTimeSignatureVerifier{} || keyreg.SelectionPK == crypto.VRFVerifier{}) {
 		if keyreg.Nonparticipation {
-			if balances.ConsensusParams().SupportBecomeNonParticipatingTransactions {
+			if params.SupportBecomeNonParticipatingTransactions {
 				record.Status = basics.NotParticipating
 			} else {
 				return fmt.Errorf("transaction tries to mark an account as nonparticipating, but that transaction is not supported")
@@ -67,7 +69,7 @@ func Keyreg(keyreg transactions.KeyregTxnFields, header transactions.Header, bal
 		record.VoteKeyDilution = 0
 	} else {
 
-		if balances.ConsensusParams().EnableKeyregCoherencyCheck {
+		if params.EnableKeyregCoherencyCheck {
 			if keyreg.VoteLast <= round {
 				return errKeyregGoingOnlineExpiredParticipationKey
 			}
@@ -79,7 +81,7 @@ func Keyreg(keyreg transactions.KeyregTxnFields, header transactions.Header, bal
 		record.VoteFirstValid = keyreg.VoteFirst
 		record.VoteLastValid = keyreg.VoteLast
 		record.VoteKeyDilution = keyreg.VoteKeyDilution
-		if params := balances.ConsensusParams(); params.EnableStateProofKeyregCheck && !params.EnableOnlineAccountCatchpoints {
+		if params.EnableStateProofKeyregCheck && !params.EnableOnlineAccountCatchpoints {
 			record.StateProofID = keyreg.StateProofPK
 		}
 	}

--- a/ledger/apply/keyreg.go
+++ b/ledger/apply/keyreg.go
@@ -49,7 +49,7 @@ func Keyreg(keyreg transactions.KeyregTxnFields, header transactions.Header, bal
 	// (or, if the voting or selection keys are zero, offline/not-participating)
 	record.VoteID = keyreg.VotePK
 	record.SelectionID = keyreg.SelectionPK
-	if params := balances.ConsensusParams(); params.EnableStateProofKeyregCheck && params.ClearOfflineStateProofID {
+	if params := balances.ConsensusParams(); params.EnableStateProofKeyregCheck && params.EnableOnlineAccountCatchpoints {
 		record.StateProofID = keyreg.StateProofPK
 	}
 	if (keyreg.VotePK == crypto.OneTimeSignatureVerifier{} || keyreg.SelectionPK == crypto.VRFVerifier{}) {
@@ -79,7 +79,7 @@ func Keyreg(keyreg transactions.KeyregTxnFields, header transactions.Header, bal
 		record.VoteFirstValid = keyreg.VoteFirst
 		record.VoteLastValid = keyreg.VoteLast
 		record.VoteKeyDilution = keyreg.VoteKeyDilution
-		if params := balances.ConsensusParams(); params.EnableStateProofKeyregCheck && !params.ClearOfflineStateProofID {
+		if params := balances.ConsensusParams(); params.EnableStateProofKeyregCheck && !params.EnableOnlineAccountCatchpoints {
 			record.StateProofID = keyreg.StateProofPK
 		}
 	}

--- a/ledger/apply/keyreg.go
+++ b/ledger/apply/keyreg.go
@@ -49,6 +49,9 @@ func Keyreg(keyreg transactions.KeyregTxnFields, header transactions.Header, bal
 	// (or, if the voting or selection keys are zero, offline/not-participating)
 	record.VoteID = keyreg.VotePK
 	record.SelectionID = keyreg.SelectionPK
+	if balances.ConsensusParams().EnableStateProofKeyregCheck {
+		record.StateProofID = keyreg.StateProofPK
+	}
 	if (keyreg.VotePK == crypto.OneTimeSignatureVerifier{} || keyreg.SelectionPK == crypto.VRFVerifier{}) {
 		if keyreg.Nonparticipation {
 			if balances.ConsensusParams().SupportBecomeNonParticipatingTransactions {
@@ -76,9 +79,6 @@ func Keyreg(keyreg transactions.KeyregTxnFields, header transactions.Header, bal
 		record.VoteFirstValid = keyreg.VoteFirst
 		record.VoteLastValid = keyreg.VoteLast
 		record.VoteKeyDilution = keyreg.VoteKeyDilution
-		if balances.ConsensusParams().EnableStateProofKeyregCheck {
-			record.StateProofID = keyreg.StateProofPK
-		}
 	}
 
 	// Write the updated entry

--- a/ledger/apply/keyreg_test.go
+++ b/ledger/apply/keyreg_test.go
@@ -230,14 +230,32 @@ func TestStateProofPKKeyReg(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, acct.StateProofID.IsEmpty())
 
-	// go offline: StateProofID should be empty
+	// go offline in current consensus version: StateProofID should not be empty
 	emptyKeyreg := transactions.KeyregTxnFields{}
 	err = Keyreg(emptyKeyreg, tx.Header, mockBal, transactions.SpecialAddresses{FeeSink: feeSink}, nil, basics.Round(0))
 	require.NoError(t, err)
 
 	acct, err = mockBal.Get(tx.Src(), false)
 	require.NoError(t, err)
+	require.False(t, acct.StateProofID.IsEmpty())
+
+	// run same test using vFuture
+	mockBal = makeMockBalances(protocol.ConsensusFuture)
+	err = Keyreg(tx.KeyregTxnFields, tx.Header, mockBal, transactions.SpecialAddresses{FeeSink: feeSink}, nil, basics.Round(0))
+	require.NoError(t, err)
+
+	acct, err = mockBal.Get(tx.Src(), false)
+	require.NoError(t, err)
+	require.False(t, acct.StateProofID.IsEmpty())
+
+	// go offline in vFuture: StateProofID should be empty
+	err = Keyreg(emptyKeyreg, tx.Header, mockBal, transactions.SpecialAddresses{FeeSink: feeSink}, nil, basics.Round(0))
+	require.NoError(t, err)
+
+	acct, err = mockBal.Get(tx.Src(), false)
+	require.NoError(t, err)
 	require.True(t, acct.StateProofID.IsEmpty())
+
 }
 
 func createTestTxn(t *testing.T, src basics.Address, secretParticipation *crypto.SignatureSecrets, vrfSecrets *crypto.VRFSecrets) transactions.Transaction {

--- a/ledger/apply/keyreg_test.go
+++ b/ledger/apply/keyreg_test.go
@@ -229,6 +229,15 @@ func TestStateProofPKKeyReg(t *testing.T) {
 	acct, err = mockBal.Get(tx.Src(), false)
 	require.NoError(t, err)
 	require.False(t, acct.StateProofID.IsEmpty())
+
+	// go offline: StateProofID should be empty
+	emptyKeyreg := transactions.KeyregTxnFields{}
+	err = Keyreg(emptyKeyreg, tx.Header, mockBal, transactions.SpecialAddresses{FeeSink: feeSink}, nil, basics.Round(0))
+	require.NoError(t, err)
+
+	acct, err = mockBal.Get(tx.Src(), false)
+	require.NoError(t, err)
+	require.True(t, acct.StateProofID.IsEmpty())
 }
 
 func createTestTxn(t *testing.T, src basics.Address, secretParticipation *crypto.SignatureSecrets, vrfSecrets *crypto.VRFSecrets) transactions.Transaction {


### PR DESCRIPTION
## Summary

We are not setting record.StateProofID from the values in the keyreg transaction for the case when it is empty (and an account is going offline).

## Test Plan

Updated TestStateProofPKKeyReg to fail without this change.