### PR TITLE
Version downgrade check ported

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -910,6 +910,9 @@ func initConsensusProtocols() {
 	// Enable application support
 	v24.Application = true
 
+	// Although Inners were not allowed yet, this gates downgrade checks, which must be allowed
+	v24.MinInnerApplVersion = 6
+
 	// Enable rekeying
 	v24.SupportRekeying = true
 
@@ -1090,7 +1093,6 @@ func initConsensusProtocols() {
 	v31.LogicSigVersion = 6
 	v31.EnableInnerTransactionPooling = true
 	v31.IsolateClearState = true
-	v31.MinInnerApplVersion = 6
 
 	// stat proof key registration
 	v31.EnableStateProofKeyregCheck = true

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -726,9 +726,9 @@ func ProgramVersion(bytecode []byte) (version uint64, length int, err error) {
 // matching versions between approval and clearstate.
 const syncProgramsVersion = 6
 
-// CheckContractVersions ensures that for v6 and higher two programs are version
-// matched, and that they are not a downgrade.  If proto.AllowV4InnerAppls, then
-// no downgrades are allowed, regardless of version.
+// CheckContractVersions ensures that for syncProgramsVersion and higher, two programs are version
+// matched, and that they are not a downgrade.  If either the approval or clear state program version is
+// >= proto.MinInnerApplVersion, no downgrades are allowed.
 func CheckContractVersions(approval []byte, clear []byte, previous basics.AppParams, proto *config.ConsensusParams) error {
 	av, _, err := ProgramVersion(approval)
 	if err != nil {

--- a/ledger/internal/apptxn_test.go
+++ b/ledger/internal/apptxn_test.go
@@ -1890,7 +1890,7 @@ func TestInnerAppVersionCalling(t *testing.T) {
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
 
-	// 31 allowed inner appls. vFuture enables proto.AllowV4InnerAppls (presumed v33, below)
+	// 31 allowed inner appls. vFuture enables proto.MinInnerApplVersion (presumed v33, below)
 	testConsensusRange(t, 31, 0, func(t *testing.T, ver int) {
 		dl := NewDoubleLedger(t, genBalances, consensusByNumber[ver])
 		defer dl.Close()
@@ -1994,7 +1994,7 @@ itxn_submit`,
 			createAndOptin.ApplicationArgs = [][]byte{six.Program, six.Program}
 			dl.txn(&createAndOptin, "overspend") // passed the checks, but is an overspend
 		} else {
-			// after 32 proto.AllowV4InnerAppls should be in effect, so calls and optins to v5 are ok
+			// after 32 proto.MinInnerApplVersion should be in effect, so calls and optins to v5 are ok
 			dl.txn(&call, "overspend")         // it tried to execute, but test doesn't bother funding
 			dl.txn(&optin, "overspend")        // it tried to execute, but test doesn't bother funding
 			optin.ForeignApps[0] = v5withv3csp // but we can't optin to a v5 if it has an old csp
@@ -2150,7 +2150,7 @@ func TestAppDowngrade(t *testing.T) {
 		update.ClearStateProgram = five.Program
 		dl.fullBlock(&update)
 
-		// Downgrade (allowed for pre 6 programs until AllowV4InnerAppls)
+		// Downgrade (allowed for pre 6 programs until MinInnerApplVersion)
 		update.ClearStateProgram = four.Program
 		if ver <= 32 {
 			dl.fullBlock(update.Noted("actually a repeat of first upgrade"))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Applied JJ's fix for inner app downgrade version checking along with minor comment tweaks.
<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->


