### PR TITLE
Temporary disable empty voting data check

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -3533,8 +3533,9 @@ func onlineAccountsNewRoundImpl(
 								prevAcct = updated
 							}
 						}
-					} else if !newAcct.IsVotingEmpty() {
-						err = fmt.Errorf("non-empty voting data for non-online account %s: %v", data.address.String(), newAcct)
+						// TODO: restore after migrating offline accounts and clearing state proof PK
+						// } else if !newAcct.IsVotingEmpty() {
+						// 	err = fmt.Errorf("non-empty voting data for non-online account %s: %v", data.address.String(), newAcct)
 					}
 				}
 			} else {

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -3295,12 +3295,13 @@ func TestAccountOnlineAccountsNewRound(t *testing.T) {
 	_, err = onlineAccountsNewRoundImpl(writer, updates, proto, lastUpdateRound)
 	require.Error(t, err)
 
-	// check errors: new non-online with non-empty voting data
-	deltaB.newStatus[0] = basics.Offline
-	deltaB.newAcct[0].VoteFirstValid = 1
-	updates.deltas = []onlineAccountDelta{deltaB}
-	_, err = onlineAccountsNewRoundImpl(writer, updates, proto, lastUpdateRound)
-	require.Error(t, err)
+	// TODO: restore after migrating offline accounts and clearing state proof PK
+	// // check errors: new non-online with non-empty voting data
+	// deltaB.newStatus[0] = basics.Offline
+	// deltaB.newAcct[0].VoteFirstValid = 1
+	// updates.deltas = []onlineAccountDelta{deltaB}
+	// _, err = onlineAccountsNewRoundImpl(writer, updates, proto, lastUpdateRound)
+	// require.Error(t, err)
 
 	// check errors: new online with empty voting data
 	deltaD.newStatus[0] = basics.Online


### PR DESCRIPTION
Mainnet testing revealed some offline accounts with non-empty StateProofPK.
This would prevent us from running tests so I temporary disabled the check.
To enable:
1. Clear StateProofPK in apply: https://github.com/algorand/go-algorand/pull/4092
2. Migrate existing offline accounts with non-empty StateProofPK
3. Disable catchpoints until the next consensus version
4. Rollback this PR