### PR TITLE
NPN no TX: use channel instead of OnNetworkAdvance to notify network about new blocks

### DIFF
--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -2041,6 +2041,8 @@ func TestWebsocketNetworkTXMessageOfInterestNPN(t *testing.T) {
 	netB := makeTestWebsocketNodeWithConfig(t, bConfig)
 	netB.config.GossipFanout = 1
 	netB.config.EnablePingHandler = false
+	netBnewBlockNotify := make(chan struct{}, 1)
+	netB.newBlockNotify = netBnewBlockNotify
 	addrA, postListen := netA.Address()
 	require.True(t, postListen)
 	t.Log(addrA)
@@ -2087,6 +2089,7 @@ func TestWebsocketNetworkTXMessageOfInterestNPN(t *testing.T) {
 	waitReady(t, netB, readyTimeout.C)
 
 	netB.OnNetworkAdvance()
+	netBnewBlockNotify <- struct{}{}
 	// TODO: better event driven thing for netB sending new MOI
 	time.Sleep(10 * time.Millisecond)
 	require.Equal(t, uint32(wantTXGossipNo), netB.wantTXGossip)
@@ -2139,6 +2142,8 @@ func TestWebsocketNetworkTXMessageOfInterestPN(t *testing.T) {
 	netB.nodeInfo = &participatingNodeInfo{}
 	netB.config.GossipFanout = 1
 	netB.config.EnablePingHandler = false
+	netBnewBlockNotify := make(chan struct{}, 1)
+	netB.newBlockNotify = netBnewBlockNotify
 	addrA, postListen := netA.Address()
 	require.True(t, postListen)
 	t.Log(addrA)
@@ -2185,6 +2190,7 @@ func TestWebsocketNetworkTXMessageOfInterestPN(t *testing.T) {
 	waitReady(t, netB, readyTimeout.C)
 
 	netB.OnNetworkAdvance()
+	netBnewBlockNotify <- struct{}{}
 	// TODO: better event driven thing for netB sending new MOI
 	time.Sleep(10 * time.Millisecond)
 	require.Equal(t, uint32(wantTXGossipYes), netB.wantTXGossip)


### PR DESCRIPTION
quick POC after writing this comment https://github.com/algorand/go-algorand/pull/3918/files#r892999137 and wondering if it was possible to make the MessagesOfInterest filter updating not have to be synchronously called by agreement (via OnNetworkAdvance).
> Is it possible that OnNetworkAdvance could take too long, and what would be the impact if it did? Agreement synchronously waits for OnNetworkAdvance to finish at the end of every round, when calling the node's EnsureBlock/EnsureValidatedBlock methods. This means the performance of OnNetworkAdvance will delay the start of agreement beginning the next round.

Flipped checking whether to update the MOI to be asynchronous and event-driven (versus synchronously called by agreement every round), based on how BlockListener is hooked up to the node's oldKeyDeletionThread via asynchronously sending to a channel, which makes it OK for the oldKeyDeletionThread to fall behind block notifications.

updated TestWebsocketNetworkTXMessageOfInterestNPN and TestWebsocketNetworkTXMessageOfInterestPN so that they pass, but didn't look at other tests.