### PR TITLE
Misc: Add helper functions to genesis.

### DIFF
--- a/cmd/buildtools/genesis.go
+++ b/cmd/buildtools/genesis.go
@@ -152,8 +152,7 @@ var dumpGenesisHashCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		hash := crypto.HashObj(genesis)
-		fmt.Print(hash.String())
+		fmt.Print(genesis.Hash().String())
 	},
 }
 
@@ -237,7 +236,7 @@ func ensureReleaseGenesis(src bookkeeping.Genesis, releaseFile string) (err erro
 		return fmt.Errorf("error saving file: %v", err)
 	}
 
-	hash := crypto.HashObj(releaseGenesis)
+	hash := releaseGenesis.Hash()
 	err = ioutil.WriteFile(releaseFileHash, []byte(hash.String()), 0666)
 	if err != nil {
 		return fmt.Errorf("error saving hash file '%s': %v", releaseFileHash, err)
@@ -261,8 +260,20 @@ func verifyReleaseGenesis(src bookkeeping.Genesis, releaseFile string) (updateGe
 func verifyGenesisHashes(src, release bookkeeping.Genesis, hashFile string) (err error) {
 	src.Timestamp = release.Timestamp
 
-	srcHash := crypto.HashObj(src)
-	releaseHash := crypto.HashObj(release)
+	srcHash := src.Hash()
+	releaseHash := release.Hash()
+
+	srcHashCrypo := crypto.HashObj(src)
+	releaseHashCrypto := crypto.HashObj(release)
+
+	if srcHash != srcHashCrypo {
+		return fmt.Errorf("source hashes differ - genesis.json our hashing function isn't consistent")
+	}
+
+	if releaseHash != releaseHashCrypto {
+		return fmt.Errorf("release hashes differ - genesis.json our hashing function isn't consistent")
+	}
+
 	if srcHash != releaseHash {
 		return fmt.Errorf("source and release hashes differ - genesis.json may have diverge from released version")
 	}

--- a/data/bookkeeping/genesis_test.go
+++ b/data/bookkeeping/genesis_test.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package bookkeeping
 
 import (

--- a/data/bookkeeping/genesis_test.go
+++ b/data/bookkeeping/genesis_test.go
@@ -1,0 +1,141 @@
+package bookkeeping
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/test/partitiontest"
+)
+
+func TestGenesis_Balances(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	containsErrorFunc := func(str string) assert.ErrorAssertionFunc {
+		return func(_ assert.TestingT, err error, i ...interface{}) bool {
+			require.ErrorContains(t, err, str)
+			return true
+		}
+	}
+	mustAddr := func(addr string) basics.Address {
+		address, err := basics.UnmarshalChecksumAddress(addr)
+		require.NoError(t, err)
+		return address
+	}
+	makeAddr := func(addr uint64) basics.Address {
+		var address basics.Address
+		address[0] = byte(addr)
+		return address
+	}
+	acctWith := func(algos uint64, addr string) GenesisAllocation {
+		return GenesisAllocation{
+			_struct: struct{}{},
+			Address: addr,
+			Comment: "",
+			State: basics.AccountData{
+				MicroAlgos: basics.MicroAlgos{Raw: algos},
+			},
+		}
+	}
+	goodAddr := makeAddr(100)
+	allocation1 := acctWith(1000, makeAddr(1).String())
+	allocation2 := acctWith(2000, makeAddr(2).String())
+	badAllocation := acctWith(1234, "El Toro Loco")
+	type fields struct {
+		Allocation  []GenesisAllocation
+		FeeSink     string
+		RewardsPool string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    GenesisBalances
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "basic test",
+			fields: fields{
+				Allocation:  []GenesisAllocation{allocation1},
+				FeeSink:     goodAddr.String(),
+				RewardsPool: goodAddr.String(),
+			},
+			want: GenesisBalances{
+				Balances: map[basics.Address]basics.AccountData{
+					mustAddr(allocation1.Address): allocation1.State,
+				},
+				FeeSink:     goodAddr,
+				RewardsPool: goodAddr,
+				Timestamp:   0,
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "two test",
+			fields: fields{
+				Allocation:  []GenesisAllocation{allocation1, allocation2},
+				FeeSink:     goodAddr.String(),
+				RewardsPool: goodAddr.String(),
+			},
+			want: GenesisBalances{
+				Balances: map[basics.Address]basics.AccountData{
+					mustAddr(allocation1.Address): allocation1.State,
+					mustAddr(allocation2.Address): allocation2.State,
+				},
+				FeeSink:     goodAddr,
+				RewardsPool: goodAddr,
+				Timestamp:   0,
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "bad fee sink",
+			fields: fields{
+				Allocation:  []GenesisAllocation{allocation1, allocation2},
+				RewardsPool: goodAddr.String(),
+			},
+			wantErr: containsErrorFunc("cannot parse fee sink addr"),
+		},
+		{
+			name: "bad rewards pool",
+			fields: fields{
+				Allocation: []GenesisAllocation{allocation1, allocation2},
+				FeeSink:    goodAddr.String(),
+			},
+			wantErr: containsErrorFunc("cannot parse rewards pool addr"),
+		},
+		{
+			name: "bad genesis addr",
+			fields: fields{
+				Allocation:  []GenesisAllocation{badAllocation},
+				FeeSink:     goodAddr.String(),
+				RewardsPool: goodAddr.String(),
+			},
+			wantErr: containsErrorFunc("cannot parse genesis addr"),
+		},
+		{
+			name: "repeat address",
+			fields: fields{
+				Allocation:  []GenesisAllocation{allocation1, allocation1},
+				FeeSink:     goodAddr.String(),
+				RewardsPool: goodAddr.String(),
+			},
+			wantErr: containsErrorFunc("repeated allocation to"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			genesis := Genesis{
+				Allocation:  tt.fields.Allocation,
+				FeeSink:     tt.fields.FeeSink,
+				RewardsPool: tt.fields.RewardsPool,
+			}
+			got, err := genesis.Balances()
+			if tt.wantErr(t, err, fmt.Sprintf("Balances()")) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "Balances()")
+		})
+	}
+}

--- a/netdeploy/remote/deployedNetwork.go
+++ b/netdeploy/remote/deployedNetwork.go
@@ -394,7 +394,7 @@ func (cfg DeployedNetwork) GenerateDatabaseFiles(fileCfgs BootstrappedNetwork, g
 		roundTxnCnt:   fileCfgs.RoundTransactionsCount,
 		round:         basics.Round(0),
 		genesisID:     genesis.ID(),
-		genesisHash:   crypto.HashObj(genesis),
+		genesisHash:   genesis.Hash(),
 		poolAddr:      poolAddr,
 		sinkAddr:      sinkAddr,
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -166,7 +166,7 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 	node.rootDir = rootDir
 	node.log = log.With("name", cfg.NetAddress)
 	node.genesisID = genesis.ID()
-	node.genesisHash = crypto.HashObj(genesis)
+	node.genesisHash = genesis.Hash()
 	node.devMode = genesis.DevMode
 
 	if node.devMode {
@@ -195,8 +195,7 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 		log.Errorf("Unable to create genesis directory: %v", err)
 		return nil, err
 	}
-	var genalloc bookkeeping.GenesisBalances
-	genalloc, err = bootstrapData(genesis, log)
+	genalloc, err := genesis.Balances()
 	if err != nil {
 		log.Errorf("Cannot load genesis allocation: %v", err)
 		return nil, err
@@ -311,40 +310,6 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 	node.compactCert = compactcert.NewWorker(compactCertAccess, node.log, node.accountManager, node.ledger.Ledger, node.net, node)
 
 	return node, err
-}
-
-func bootstrapData(genesis bookkeeping.Genesis, log logging.Logger) (bookkeeping.GenesisBalances, error) {
-	genalloc := make(map[basics.Address]basics.AccountData)
-	for _, entry := range genesis.Allocation {
-		addr, err := basics.UnmarshalChecksumAddress(entry.Address)
-		if err != nil {
-			log.Errorf("Cannot parse genesis addr %s: %v", entry.Address, err)
-			return bookkeeping.GenesisBalances{}, err
-		}
-
-		_, present := genalloc[addr]
-		if present {
-			err = fmt.Errorf("repeated allocation to %s", entry.Address)
-			log.Error(err)
-			return bookkeeping.GenesisBalances{}, err
-		}
-
-		genalloc[addr] = entry.State
-	}
-
-	feeSink, err := basics.UnmarshalChecksumAddress(genesis.FeeSink)
-	if err != nil {
-		log.Errorf("Cannot parse fee sink addr %s: %v", genesis.FeeSink, err)
-		return bookkeeping.GenesisBalances{}, err
-	}
-
-	rewardsPool, err := basics.UnmarshalChecksumAddress(genesis.RewardsPool)
-	if err != nil {
-		log.Errorf("Cannot parse rewards pool addr %s: %v", genesis.RewardsPool, err)
-		return bookkeeping.GenesisBalances{}, err
-	}
-
-	return bookkeeping.MakeTimestampedGenesisBalances(genalloc, feeSink, rewardsPool, genesis.Timestamp), nil
 }
 
 // Config returns a copy of the node's Local configuration

--- a/test/e2e-go/features/participation/overlappingParticipationKeys_test.go
+++ b/test/e2e-go/features/participation/overlappingParticipationKeys_test.go
@@ -83,7 +83,7 @@ func TestOverlappingParticipationKeys(t *testing.T) {
 
 	genesis, err := bookkeeping.LoadGenesisFromFile(filepath.Join(fixture.PrimaryDataDir(), "genesis.json"))
 	a.NoError(err)
-	genesisHash := crypto.HashObj(genesis)
+	genesisHash := genesis.Hash()
 	rootKeys := make(map[int]*account.Root)
 	regTransactions := make(map[int]transactions.SignedTxn)
 	lastRound := uint64(39) // check 3 rounds of keys rotations


### PR DESCRIPTION
## Summary

While working on Indexer we found some of the genesis operations to require duplicate or awkward code. Adding these methods to the genesis object simplifies things.

## Test Plan

New unit test and existing regression tests.