### PR TITLE
Revert a small change related to contexts in catchpoint tracker

### DIFF
--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -1044,7 +1044,7 @@ func (ct *catchpointTracker) generateCatchpointData(ctx context.Context, account
 	var catchpointWriter *catchpointWriter
 	start := time.Now()
 	ledgerGeneratecatchpointCount.Inc(nil)
-	err := ct.dbs.Rdb.Atomic(func(_ context.Context, tx *sql.Tx) (err error) {
+	err := ct.dbs.Rdb.Atomic(func(dbCtx context.Context, tx *sql.Tx) (err error) {
 		catchpointWriter, err = makeCatchpointWriter(ctx, catchpointDataFilePath, tx)
 		if err != nil {
 			return
@@ -1060,7 +1060,7 @@ func (ct *catchpointTracker) generateCatchpointData(ctx context.Context, account
 				// we just wrote some data, but there is more to be written.
 				// go to sleep for while.
 				// before going to sleep, extend the transaction timeout so that we won't get warnings:
-				_, err0 := db.ResetTransactionWarnDeadline(ctx, tx, time.Now().Add(1*time.Second))
+				_, err0 := db.ResetTransactionWarnDeadline(dbCtx, tx, time.Now().Add(1*time.Second))
 				if err0 != nil {
 					ct.log.Warnf("catchpointTracker: generateCatchpoint: failed to reset transaction warn deadline : %v", err0)
 				}


### PR DESCRIPTION
## Summary

The current code generates
```
{"file":"catchpointtracker.go","function":"github.com/algorand/go-algorand/ledger.(*catchpointTracker).generateCatchpointData.func1","level":"warning","line":1065,"msg":"catchpointTracker: generateCatchpoint: failed to reset transaction warn deadline : the provided tx does not have a valid txExecutionContext object in it's context","name":"","time":"2022-06-09T16:25:34.781302-04:00"}
```

## Test Plan

None.