### PR TITLE
catchup: pause on round api endpoint

### DIFF
--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -567,6 +567,12 @@ func (client RestClient) Shutdown() (err error) {
 	return
 }
 
+// ChangePauseAtRound starts catching up and pauses at the block number rnd
+func (client RestClient) ChangePauseAtRound(rnd string) (response privateV2.PauseAtRoundResponse, err error) {
+	err = client.submitForm(&response, fmt.Sprintf("/v2/pausecatchup/%s", rnd), nil, "POST", false, true)
+	return
+}
+
 // AbortCatchup aborts the currently running catchup
 func (client RestClient) AbortCatchup(catchpointLabel string) (response privateV2.CatchpointAbortResponse, err error) {
 	err = client.submitForm(&response, fmt.Sprintf("/v2/catchup/%s", catchpointLabel), nil, "DELETE", false, true)

--- a/daemon/algod/api/server/v2/generated/private/routes.go
+++ b/daemon/algod/api/server/v2/generated/private/routes.go
@@ -22,8 +22,8 @@ type ServerInterface interface {
 	// Aborts a catchpoint catchup.
 	// (DELETE /v2/catchup/{catchpoint})
 	AbortCatchup(ctx echo.Context, catchpoint string) error
-	// Changes PauseAtRound variable in catchup service.
-	// (POST /v2/changepauseatround/{rnd})
+	// Pauses catchup service at block number rnd.
+	// (POST /v2/pausecatchup/{rnd})
 	ChangePauseAtRound(ctx echo.Context, rnd uint64) error
 	// Starts a catchpoint catchup.
 	// (POST /v2/catchup/{catchpoint})
@@ -82,6 +82,7 @@ func (w *ServerInterfaceWrapper) AbortCatchup(ctx echo.Context) error {
 	err = w.Handler.AbortCatchup(ctx, catchpoint)
 	return err
 }
+
 // ChangePauseAtRound converts echo context to params.
 func (w *ServerInterfaceWrapper) ChangePauseAtRound(ctx echo.Context) error {
 

--- a/daemon/algod/api/server/v2/generated/private/types.go
+++ b/daemon/algod/api/server/v2/generated/private/types.go
@@ -611,7 +611,7 @@ type CatchpointStartResponse struct {
 // ChangePauseAtRoundResponse defines model for PauseAtRoundResponse.
 type PauseAtRoundResponse struct {
 
-	// Catchup start response string
+	// Change Pause round number response string
 	PauseAtRoundMessage string `json:"pauseatround-message"`
 }
 

--- a/daemon/algod/api/server/v2/generated/private/types.go
+++ b/daemon/algod/api/server/v2/generated/private/types.go
@@ -608,6 +608,13 @@ type CatchpointStartResponse struct {
 	CatchupMessage string `json:"catchup-message"`
 }
 
+// ChangePauseAtRoundResponse defines model for PauseAtRoundResponse.
+type PauseAtRoundResponse struct {
+
+	// Catchup start response string
+	PauseAtRoundMessage string `json:"pauseatround-message"`
+}
+
 // CompileResponse defines model for CompileResponse.
 type CompileResponse struct {
 

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -1166,7 +1166,7 @@ func (v2 *Handlers) GetPendingTransactionsByAddress(ctx echo.Context, addr strin
 	return v2.getPendingTransactions(ctx, params.Max, params.Format, &addr)
 }
 
-//  Given a block number, it starts catching up and pauses at this block number
+// ChangePauseAtRound Given a block number, it starts catching up and pauses at this block number
 // (POST /v2/pausecatchup/{rnd})
 func (v2 *Handlers) ChangePauseAtRound(ctx echo.Context, rnd uint64) error {
 	return v2.changePauseAtRound(ctx, rnd)

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -1167,7 +1167,7 @@ func (v2 *Handlers) GetPendingTransactionsByAddress(ctx echo.Context, addr strin
 }
 
 //  Given a block number, it starts catching up and pauses at this block number
-// (POST /v2/changepauseatround/{rnd})
+// (POST /v2/pausecatchup/{rnd})
 func (v2 *Handlers) ChangePauseAtRound(ctx echo.Context, rnd uint64) error {
 	return v2.changePauseAtRound(ctx, rnd)
 }

--- a/daemon/algod/api/server/v2/test/helpers.go
+++ b/daemon/algod/api/server/v2/test/helpers.go
@@ -200,6 +200,10 @@ func (m mockNode) AssembleBlock(round basics.Round) (agreement.ValidatedBlock, e
 	return nil, fmt.Errorf("assemble block not implemented")
 }
 
+func (m mockNode) ChangePauseAtRound(rnd uint64) error {
+	return m.err
+}
+
 func (m mockNode) StartCatchup(catchpoint string) error {
 	return m.err
 }

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -1035,6 +1035,19 @@ func (c *Client) AbortCatchup() error {
 	return nil
 }
 
+// ChangePauseAtRound starts catching up and pauses at the block number rnd
+func (c *Client) ChangePauseAtRound(rnd string) error {
+	algod, err := c.ensureAlgodClient()
+	if err != nil {
+		return err
+	}
+	_, err = algod.ChangePauseAtRound(rnd)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Catchup start catching up to the give catchpoint label.
 func (c *Client) Catchup(catchpointLabel string) error {
 	algod, err := c.ensureAlgodClient()

--- a/node/node.go
+++ b/node/node.go
@@ -1162,6 +1162,16 @@ func (node *AlgorandFullNode) GetTransactionByID(txid transactions.Txid, rnd bas
 	}, nil
 }
 
+// ChangePauseAtRound calls pause or resume functionality implemented in catchup service
+// this function is intended to be called externally via the REST api interface.
+func (node *AlgorandFullNode) ChangePauseAtRound(rnd uint64) error {
+	if node.catchpointCatchupService == nil {
+		err := node.catchupService.PauseOrResume(rnd)
+		return err
+	}
+	return errors.New("catching up to a catchpoint, cannot pause")
+}
+
 // StartCatchup starts the catchpoint mode and attempt to get to the provided catchpoint
 // this function is intended to be called externally via the REST api interface.
 func (node *AlgorandFullNode) StartCatchup(catchpoint string) error {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->
Pause on round can be invoked as follows
`goal node catchup pause <round>` pauses catchup service at block number `<round>`
`goal node catchup pause 0` resumes catchup service

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
