### PR TITLE
CICD: update build pipeline for darwin-amd64

### DIFF
--- a/test/muleCI/mule.yaml
+++ b/test/muleCI/mule.yaml
@@ -239,7 +239,7 @@ jobs:
       - stash.Stash.darwin-arm64
   build-darwin-amd64:
     tasks:
-      - shell.make.build.darwin-amd64
+      - shell.Make.build.darwin-amd64
       - stash.Stash.darwin-amd64
   build-linux-amd64:
     tasks:

--- a/test/muleCI/mule.yaml
+++ b/test/muleCI/mule.yaml
@@ -109,6 +109,9 @@ tasks:
   - task: shell.Make
     name: build.darwin-arm64
     target: ci-build
+  - task: shell.Make
+    name: build.darwin-amd64
+    target: ci-build
   - task: docker.Make
     name: build.amd64
     agent: cicd.ubuntu.amd64
@@ -234,6 +237,10 @@ jobs:
     tasks:
       - shell.Make.build.darwin-arm64
       - stash.Stash.darwin-arm64
+  build-darwin-amd64:
+    tasks:
+      - shell.make.build.darwin-amd64
+      - stash.Stash.darwin-amd64
   build-linux-amd64:
     tasks:
       - docker.Make.build.amd64
@@ -252,6 +259,7 @@ jobs:
       - stash.Unstash.linux-arm64
       - stash.Unstash.linux-arm
       - stash.Unstash.darwin-arm64
+      - stash.Unstash.darwin-amd64
       - docker.Make.deb.amd64
       - docker.Make.rpm.amd64
       - stash.Stash.packages


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

- updates the build pipeline to incorporate darwin `amd64` builds into the internal build pipeline
