### PR TITLE
CICD: remove unused genesis in stash

### DIFF
--- a/test/muleCI/mule.yaml
+++ b/test/muleCI/mule.yaml
@@ -144,54 +144,36 @@ tasks:
     stashId: ${JENKINS_JOB_CACHE_ID}/darwin-arm64
     globSpecs:
       - tmp/node_pkgs/**/*
-      - installer/genesis/devnet/genesis.json
-      - installer/genesis/testnet/genesis.json
-      - installer/genesis/mainnet/genesis.json
   - task: stash.Stash
     name: linux-amd64
     bucketName: go-algorand-ci-cache
     stashId: ${JENKINS_JOB_CACHE_ID}/linux-amd64
     globSpecs:
       - tmp/node_pkgs/**/*
-      - installer/genesis/devnet/genesis.json
-      - installer/genesis/testnet/genesis.json
-      - installer/genesis/mainnet/genesis.json
   - task: stash.Stash
     name: darwin-amd64
     bucketName: go-algorand-ci-cache
     stashId: ${JENKINS_JOB_CACHE_ID}/darwin-amd64
     globSpecs:
       - tmp/node_pkgs/**/*
-      - installer/genesis/devnet/genesis.json
-      - installer/genesis/testnet/genesis.json
-      - installer/genesis/mainnet/genesis.json
   - task: stash.Stash
     name: linux-arm64
     bucketName: go-algorand-ci-cache
     stashId: ${JENKINS_JOB_CACHE_ID}/linux-arm64
     globSpecs:
       - tmp/node_pkgs/**/*
-      - installer/genesis/devnet/genesis.json
-      - installer/genesis/testnet/genesis.json
-      - installer/genesis/mainnet/genesis.json
   - task: stash.Stash
     name: linux-arm
     bucketName: go-algorand-ci-cache
     stashId: ${JENKINS_JOB_CACHE_ID}/linux-arm
     globSpecs:
       - tmp/node_pkgs/**/*
-      - installer/genesis/devnet/genesis.json
-      - installer/genesis/testnet/genesis.json
-      - installer/genesis/mainnet/genesis.json
   - task: stash.Stash
     name: packages
     bucketName: go-algorand-ci-cache
     stashId: ${JENKINS_JOB_CACHE_ID}/packages
     globSpecs:
       - tmp/node_pkgs/**/*
-      - installer/genesis/devnet/genesis.json
-      - installer/genesis/testnet/genesis.json
-      - installer/genesis/mainnet/genesis.json
 
     # Unstash tasks
   - task: stash.Unstash


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

- removes the `installer/` genesis files from the stash steps because it was determined that they were used for integration tests, and those tests are no longer being done in that pipeline
