### PR TITLE
logging: Add a way to inject an external logger.

### DIFF
--- a/logging/log.go
+++ b/logging/log.go
@@ -353,6 +353,11 @@ func Base() Logger {
 // NewLogger returns a new Logger logging to out.
 func NewLogger() Logger {
 	l := logrus.New()
+	return NewWrappedLogger(l)
+}
+
+// NewWrappedLogger returns a new Logger that wraps an external logrus logger.
+func NewWrappedLogger(l *logrus.Logger) Logger {
 	out := logger{
 		logrus.NewEntry(l),
 		&loggerState{},


### PR DESCRIPTION
## Summary

Indexer is using algod objects and we need a way to pass a regular logrus object into algod. This adds a simple way to initialize an algorand logger.