### PR TITLE
goal: Make the -n flag (network name) optional. Get it from template file

### DIFF
--- a/cmd/goal/network.go
+++ b/cmd/goal/network.go
@@ -42,7 +42,6 @@ func init() {
 	networkCmd.MarkPersistentFlagRequired("rootdir")
 
 	networkCreateCmd.Flags().StringVarP(&networkName, "network", "n", "", "Specify the name to use for the private network")
-	networkCreateCmd.MarkFlagRequired("network")
 	networkCreateCmd.Flags().StringVarP(&networkTemplateFile, "template", "t", "", "Specify the path to the template file for the network")
 	networkCreateCmd.MarkFlagRequired("template")
 	networkCreateCmd.Flags().BoolVarP(&noImportKeys, "noimportkeys", "K", false, "Do not import root keys when creating the network (by default will import)")

--- a/netdeploy/network.go
+++ b/netdeploy/network.go
@@ -81,13 +81,20 @@ func CreateNetworkFromTemplate(name, rootDir, templateFile, binDir string, impor
 		return n, err
 	}
 
+	if n.cfg.Name == "" {
+		n.cfg.Name = template.Genesis.NetworkName
+	}
+	if n.cfg.Name == "" {
+		return n, fmt.Errorf("unnamed network. Use the \"network\" flag or \"Genesis.NetworkName\" in the network template")
+	}
+
 	// Create the network root directory so we can generate genesis.json and prepare node data directories
 	err = os.MkdirAll(rootDir, os.ModePerm)
 	if err != nil {
 		return n, err
 	}
 	template.Consensus = consensus
-	err = template.generateGenesisAndWallets(rootDir, name, binDir)
+	err = template.generateGenesisAndWallets(rootDir, n.cfg.Name, binDir)
 	if err != nil {
 		return n, err
 	}


### PR DESCRIPTION
`goal network create` required a `-n` flag to specify the network
name.  But the name can be set in the template file.  Now we error
only if neither place specifies a network name.
