### PR TITLE
CICD: add m1 to integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,11 @@ executors:
     resource_class: large
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "true"
+  mac_arm64_medium: # adding `_medium` b/c `build` job explicitly declares it
+    machine: true
+    resource_class: algorand/macstadium-m1
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: "true"
 
 workflows:
   version: 2
@@ -56,7 +61,7 @@ workflows:
           name: << matrix.platform >>_build
           matrix: &matrix-default
             parameters:
-              platform: ["amd64", "arm64", "mac_amd64"]
+              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
 
       - test:
           name: << matrix.platform >>_test
@@ -146,7 +151,7 @@ workflows:
           name: << matrix.platform >>_<< matrix.job_type >>_verification
           matrix:
             parameters:
-              platform: ["amd64", "arm64", "mac_amd64"]
+              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
               job_type: ["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
           requires:
             - << matrix.platform >>_<< matrix.job_type >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,11 +45,17 @@ executors:
     resource_class: large
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "true"
-  mac_arm64_medium: # adding `_medium` b/c `build` job explicitly declares it
+  mac_arm64: &mac_arm64
     machine: true
     resource_class: algorand/macstadium-m1
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "true"
+  # these are required b/c jobs explicitly assign sizes to the executors
+  # for `mac_arm64` there is only one size
+  mac_arm64_medium:
+    <<: *mac_arm64
+  mac_arm64_large:
+    <<: *mac_arm64
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,17 +45,17 @@ executors:
     resource_class: large
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "true"
-  mac_arm64: &mac_arm64
+  darwin_arm64: &darwin_arm64
     machine: true
     resource_class: algorand/macstadium-m1
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "true"
   # these are required b/c jobs explicitly assign sizes to the executors
   # for `mac_arm64` there is only one size
-  mac_arm64_medium:
-    <<: *mac_arm64
-  mac_arm64_large:
-    <<: *mac_arm64
+  darwin_arm64_medium:
+    <<: *darwin_arm64
+  darwin_arm64_large:
+    <<: *darwin_arm64
 
 workflows:
   version: 2
@@ -67,7 +67,7 @@ workflows:
           name: << matrix.platform >>_build
           matrix: &matrix-default
             parameters:
-              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
+              platform: ["amd64", "arm64", "mac_amd64", "darwin_arm64"]
 
       - test:
           name: << matrix.platform >>_test
@@ -157,7 +157,7 @@ workflows:
           name: << matrix.platform >>_<< matrix.job_type >>_verification
           matrix:
             parameters:
-              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
+              platform: ["amd64", "arm64", "mac_amd64", "darwin_arm64"]
               job_type: ["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
           requires:
             - << matrix.platform >>_<< matrix.job_type >>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

- adds darwin arm64 to integration tests

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

- see CircleCI tests associated with this PR
