### PR TITLE
CICD: add m1 to integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,8 @@ workflows:
       - build:
           name: mac_arm64_build
           matrix: &matrix-mac-arm64
-            parameters: ["mac_arm64"]
+            parameters:
+              platform: ["mac_arm64"]
           filters: &filters-mac-arm64
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,17 +45,17 @@ executors:
     resource_class: large
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "true"
-  darwin_arm64: &darwin_arm64
+  mac_arm64: &mac-arm64-executor
     machine: true
     resource_class: algorand/macstadium-m1
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "true"
   # these are required b/c jobs explicitly assign sizes to the executors
   # for `mac_arm64` there is only one size
-  darwin_arm64_medium:
-    <<: *darwin_arm64
-  darwin_arm64_large:
-    <<: *darwin_arm64
+  mac_arm64_medium:
+    <<: *mac-arm64-executor
+  mac_arm64_large:
+    <<: *mac-arm64-executor
 
 workflows:
   version: 2
@@ -67,7 +67,17 @@ workflows:
           name: << matrix.platform >>_build
           matrix: &matrix-default
             parameters:
-              platform: ["amd64", "arm64", "mac_amd64", "darwin_arm64"]
+              platform: ["amd64", "arm64", "mac_amd64"]
+
+      - build:
+          name: mac_arm64_build
+          matrix: &matrix-mac-arm64
+            parameters: ["mac_arm64"]
+          filters: &filters-mac-arm64
+            branches:
+              only:
+                - /rel\/.*/
+                - master
 
       - test:
           name: << matrix.platform >>_test
@@ -80,6 +90,15 @@ workflows:
               ignore:
                 - /rel\/.*/
                 - /hotfix\/.*/
+
+      - test:
+          name: mac_arm64_test
+          matrix:
+            <<: *matrix-mac-arm64
+          requires:
+            - mac_arm64_build
+          filters:
+            <<: *filters-mac-arm64
 
       - test_nightly:
           name: << matrix.platform >>_test_nightly
@@ -103,6 +122,15 @@ workflows:
           filters:
             <<: *filters-default
 
+      - integration:
+          name: mac_arm64_integration
+          matrix:
+            <<: *matrix-mac-arm64
+          requires:
+            - mac_arm64_build
+          filters:
+            <<: *filters-mac-arm64
+
       - integration_nightly:
           name: << matrix.platform >>_integration_nightly
           matrix:
@@ -121,6 +149,15 @@ workflows:
             - << matrix.platform >>_build
           filters:
             <<: *filters-default
+
+      - e2e_expect:
+          name: mac_arm64_e2e_expect
+          matrix:
+            <<: *matrix-mac-arm64
+          requires:
+            - mac_arm64_build
+          filters:
+            <<: *filters-mac-arm64
 
       - e2e_expect_nightly:
           name: << matrix.platform >>_e2e_expect_nightly
@@ -141,6 +178,15 @@ workflows:
           filters:
             <<: *filters-default
 
+      - e2e_subs:
+          name: mac_arm64_e2e_subs
+          matrix:
+            <<: *matrix-mac-arm64
+          requires:
+            - mac_arm64_build
+          filters:
+            <<: *filters-mac-arm64
+
       - e2e_subs_nightly:
           name: << matrix.platform >>_e2e_subs_nightly
           matrix:
@@ -157,10 +203,21 @@ workflows:
           name: << matrix.platform >>_<< matrix.job_type >>_verification
           matrix:
             parameters:
-              platform: ["amd64", "arm64", "mac_amd64", "darwin_arm64"]
+              platform: ["amd64", "arm64", "mac_amd64"]
               job_type: ["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
           requires:
             - << matrix.platform >>_<< matrix.job_type >>
+
+      - tests_verification_job:
+          name: << matrix.platform >>_<< matrix.job_type >>_verification
+          matrix:
+            parameters:
+              platform: ["mac_arm64"]
+              job_type: ["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
+          requires:
+            - << matrix.platform >>_<< matrix.job_type >>
+          filters:
+            <<: *filters-mac-arm64
 
       - upload_binaries:
           name: << matrix.platform >>_upload_binaries
@@ -179,6 +236,25 @@ workflows:
           context:
             - slack-secrets
             - aws-secrets
+
+      - upload_binaries:
+          name: << matrix.platform >>_upload_binaries
+          matrix:
+            <<: *matrix-mac-arm64
+          requires:
+            - << matrix.platform >>_test_nightly_verification
+            - << matrix.platform >>_integration_nightly_verification
+            - << matrix.platform >>_e2e_expect_nightly_verification
+            - << matrix.platform >>_e2e_subs_nightly
+            - codegen_verification
+          filters:
+            branches:
+              only:
+                - /rel\/.*/
+          context:
+            - slack-secrets
+            - aws-secrets
+
       #- windows_x64_build
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,11 @@ executors:
     resource_class: large
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "true"
+  mac_arm64_medium: # adding `_medium` b/c `build` job explicitly declares it
+    machine: true
+    resource_class: algorand/macstadium-m1
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: "true"
 
 workflows:
   version: 2
@@ -56,7 +61,7 @@ workflows:
           name: << matrix.platform >>_build
           matrix: &matrix-default
             parameters:
-              platform: ["amd64", "arm64", "mac_amd64"]
+              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
 
       - test:
           name: << matrix.platform >>_test
@@ -146,7 +151,7 @@ workflows:
           name: << matrix.platform >>_<< matrix.job_type >>_verification
           matrix:
             parameters:
-              platform: ["amd64", "arm64", "mac_amd64"]
+              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
               job_type: ["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
           requires:
             - << matrix.platform >>_<< matrix.job_type >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,12 +74,12 @@ workflows:
                 - /rel\/.*/
                 - /hotfix\/.*/
 
-      - build:
+      - build_nightly:
           name: << matrix.platform >>_build_nightly
           matrix: &matrix-nightly
             parameters:
               platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
-          filters: &filters-mac-arm64
+          filters: &filters-nightly
             branches:
               only:
                 - /rel\/.*/
@@ -156,7 +156,7 @@ workflows:
           requires:
             - << matrix.platform >>_<< matrix.job_type >>
 
-      - tests_verification_job:
+      - tests_verification_job_nightly:
           name: << matrix.platform >>_<< matrix.job_type >>_verification
           matrix:
             parameters:
@@ -499,6 +499,21 @@ jobs:
       - prepare_go
       - generic_build
 
+  build_nightly:
+    parameters:
+      platform:
+        type: string
+    executor: << parameters.platform >>_medium
+    working_directory: << pipeline.parameters.build_dir >>/project
+    steps:
+      - prepare_build_dir
+      - checkout
+      - prepare_go
+      - generic_build
+      - slack/notify: &slack-fail-event
+          event: fail
+          template: basic_fail_1
+
   test:
     parameters:
       platform:
@@ -530,9 +545,8 @@ jobs:
           result_subdir: << parameters.platform >>_test_nightly
           no_output_timeout: 45m
       - upload_coverage
-      - slack/notify: &slack-fail-event
-          event: fail
-          template: basic_fail_1
+      - slack/notify:
+          <<: *slack-fail-event
 
   integration:
     parameters:
@@ -674,6 +688,23 @@ jobs:
       - checkout
       - tests_verification_command:
           result_subdir: << parameters.platform >>_<< parameters.job_type >>
+
+  tests_verification_job_nightly:
+    docker:
+      - image: python:3.9.6-alpine
+    resource_class: small
+    working_directory: << pipeline.parameters.build_dir >>/project
+    parameters:
+      platform: # platform: ["amd64", "arm64", "mac_amd64"]
+        type: string
+      job_type: # job_type: ["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
+        type: string
+    steps:
+      - checkout
+      - tests_verification_command:
+          result_subdir: << parameters.platform >>_<< parameters.job_type >>
+      - slack/notify:
+          <<: *slack-fail-event
 
   upload_binaries:
     working_directory: << pipeline.parameters.build_dir >>/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,6 @@ workflows:
               ignore:
                 - /rel\/.*/
                 - /hotfix\/.*/
-                - cicd/add-m1-to-intergration-tests
 
       - build_nightly:
           name: << matrix.platform >>_build_nightly
@@ -85,7 +84,6 @@ workflows:
               only:
                 - /rel\/.*/
                 - /hotfix\/.*/
-                - cicd/add-m1-to-intergration-tests
           context: slack-secrets
 
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ workflows:
               platform: ["amd64", "arm64", "mac_amd64"]
 
       - build:
-          name: mac_arm64_build
+          name: << matrix.platform >>_build
           matrix: &matrix-mac-arm64
             parameters:
               platform: ["mac_arm64"]
@@ -93,7 +93,7 @@ workflows:
                 - /hotfix\/.*/
 
       - test:
-          name: mac_arm64_test
+          name: << matrix.platform >>_test
           matrix:
             <<: *matrix-mac-arm64
           requires:
@@ -114,6 +114,19 @@ workflows:
                 - /hotfix\/.*/
           context: slack-secrets
 
+      - test_nightly:
+          name: << matrix.platform >>_test_nightly
+          matrix:
+            <<: *matrix-mac-arm64
+          requires:
+            - << matrix.platform >>_build
+          filters: &filters-nightly
+            branches:
+              only:
+                - /rel\/.*/
+                - /hotfix\/.*/
+          context: slack-secrets
+
       - integration:
           name: << matrix.platform >>_integration
           matrix:
@@ -124,7 +137,7 @@ workflows:
             <<: *filters-default
 
       - integration:
-          name: mac_arm64_integration
+          name: << matrix.platform >>_integration
           matrix:
             <<: *matrix-mac-arm64
           requires:
@@ -142,6 +155,16 @@ workflows:
             <<: *filters-nightly
           context: slack-secrets
 
+      - integration_nightly:
+          name: << matrix.platform >>_integration_nightly
+          matrix:
+            <<: *matrix-mac-arm64
+          requires:
+            - << matrix.platform >>_build
+          filters:
+            <<: *filters-nightly
+          context: slack-secrets
+
       - e2e_expect:
           name: << matrix.platform >>_e2e_expect
           matrix:
@@ -152,7 +175,7 @@ workflows:
             <<: *filters-default
 
       - e2e_expect:
-          name: mac_arm64_e2e_expect
+          name: << matrix.platform >>_e2e_expect
           matrix:
             <<: *matrix-mac-arm64
           requires:
@@ -170,6 +193,16 @@ workflows:
             <<: *filters-nightly
           context: slack-secrets
 
+      - e2e_expect_nightly:
+          name: << matrix.platform >>_e2e_expect_nightly
+          matrix:
+            <<: *matrix-mac-arm64
+          requires:
+            - << matrix.platform >>_build
+          filters:
+            <<: *filters-nightly
+          context: slack-secrets
+
       - e2e_subs:
           name: << matrix.platform >>_e2e_subs
           matrix:
@@ -180,7 +213,7 @@ workflows:
             <<: *filters-default
 
       - e2e_subs:
-          name: mac_arm64_e2e_subs
+          name: << matrix.platform >>_e2e_subs
           matrix:
             <<: *matrix-mac-arm64
           requires:
@@ -192,6 +225,18 @@ workflows:
           name: << matrix.platform >>_e2e_subs_nightly
           matrix:
             <<: *matrix-default
+          requires:
+            - << matrix.platform >>_build
+          filters:
+            <<: *filters-nightly
+          context:
+            - slack-secrets
+            - aws-secrets
+
+      - e2e_subs_nightly:
+          name: << matrix.platform >>_e2e_subs_nightly
+          matrix:
+            <<: *matrix-mac-arm64
           requires:
             - << matrix.platform >>_build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,6 +320,7 @@ commands:
       - run:
           working_directory: /tmp
           command: |
+            sudo rm -rf << parameters.build_dir >>
             sudo mkdir -p << parameters.build_dir >>
             sudo chown -R $USER:$GROUP << parameters.build_dir >>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,64 +68,36 @@ workflows:
           matrix: &matrix-default
             parameters:
               platform: ["amd64", "arm64", "mac_amd64"]
-
-      - build:
-          name: << matrix.platform >>_build
-          matrix: &matrix-mac-arm64
-            parameters:
-              platform: ["mac_arm64"]
-          filters: &filters-mac-arm64
-            branches:
-              only:
-                - /rel\/.*/
-                - master
-                - /hotfix\/.*/
-
-      - test:
-          name: << matrix.platform >>_test
-          matrix:
-            <<: *matrix-default
-          requires:
-            - << matrix.platform >>_build
           filters: &filters-default
             branches:
               ignore:
                 - /rel\/.*/
                 - /hotfix\/.*/
 
+      - build:
+          name: << matrix.platform >>_build_nightly
+          matrix: &matrix-nightly
+            parameters:
+              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
+          filters: &filters-mac-arm64
+            branches:
+              only:
+                - /rel\/.*/
+                - /hotfix\/.*/
+
       - test:
           name: << matrix.platform >>_test
           matrix:
-            <<: *matrix-mac-arm64
-          requires:
-            - mac_arm64_build
-          filters:
-            <<: *filters-mac-arm64
-
-      - test_nightly:
-          name: << matrix.platform >>_test_nightly
-          matrix:
             <<: *matrix-default
           requires:
             - << matrix.platform >>_build
-          filters: &filters-nightly
-            branches:
-              only:
-                - /rel\/.*/
-                - /hotfix\/.*/
-          context: slack-secrets
 
       - test_nightly:
           name: << matrix.platform >>_test_nightly
           matrix:
-            <<: *matrix-mac-arm64
+            <<: *matrix-nightly
           requires:
-            - << matrix.platform >>_build
-          filters: &filters-nightly
-            branches:
-              only:
-                - /rel\/.*/
-                - /hotfix\/.*/
+            - << matrix.platform >>_build_nightly
           context: slack-secrets
 
       - integration:
@@ -134,36 +106,13 @@ workflows:
             <<: *matrix-default
           requires:
             - << matrix.platform >>_build
-          filters:
-            <<: *filters-default
-
-      - integration:
-          name: << matrix.platform >>_integration
-          matrix:
-            <<: *matrix-mac-arm64
-          requires:
-            - mac_arm64_build
-          filters:
-            <<: *filters-mac-arm64
 
       - integration_nightly:
           name: << matrix.platform >>_integration_nightly
           matrix:
-            <<: *matrix-default
+            <<: *matrix-nightly
           requires:
-            - << matrix.platform >>_build
-          filters:
-            <<: *filters-nightly
-          context: slack-secrets
-
-      - integration_nightly:
-          name: << matrix.platform >>_integration_nightly
-          matrix:
-            <<: *matrix-mac-arm64
-          requires:
-            - << matrix.platform >>_build
-          filters:
-            <<: *filters-nightly
+            - << matrix.platform >>_build_nightly
           context: slack-secrets
 
       - e2e_expect:
@@ -172,36 +121,13 @@ workflows:
             <<: *matrix-default
           requires:
             - << matrix.platform >>_build
-          filters:
-            <<: *filters-default
-
-      - e2e_expect:
-          name: << matrix.platform >>_e2e_expect
-          matrix:
-            <<: *matrix-mac-arm64
-          requires:
-            - mac_arm64_build
-          filters:
-            <<: *filters-mac-arm64
 
       - e2e_expect_nightly:
           name: << matrix.platform >>_e2e_expect_nightly
           matrix:
-            <<: *matrix-default
+            <<: *matrix-nightly
           requires:
-            - << matrix.platform >>_build
-          filters:
-            <<: *filters-nightly
-          context: slack-secrets
-
-      - e2e_expect_nightly:
-          name: << matrix.platform >>_e2e_expect_nightly
-          matrix:
-            <<: *matrix-mac-arm64
-          requires:
-            - << matrix.platform >>_build
-          filters:
-            <<: *filters-nightly
+            - << matrix.platform >>_build_nightly
           context: slack-secrets
 
       - e2e_subs:
@@ -210,38 +136,13 @@ workflows:
             <<: *matrix-default
           requires:
             - << matrix.platform >>_build
-          filters:
-            <<: *filters-default
-
-      - e2e_subs:
-          name: << matrix.platform >>_e2e_subs
-          matrix:
-            <<: *matrix-mac-arm64
-          requires:
-            - mac_arm64_build
-          filters:
-            <<: *filters-mac-arm64
 
       - e2e_subs_nightly:
           name: << matrix.platform >>_e2e_subs_nightly
           matrix:
-            <<: *matrix-default
+            <<: *matrix-nightly
           requires:
-            - << matrix.platform >>_build
-          filters:
-            <<: *filters-nightly
-          context:
-            - slack-secrets
-            - aws-secrets
-
-      - e2e_subs_nightly:
-          name: << matrix.platform >>_e2e_subs_nightly
-          matrix:
-            <<: *matrix-mac-arm64
-          requires:
-            - << matrix.platform >>_build
-          filters:
-            <<: *filters-nightly
+            - << matrix.platform >>_build_nightly
           context:
             - slack-secrets
             - aws-secrets
@@ -251,7 +152,7 @@ workflows:
           matrix:
             parameters:
               platform: ["amd64", "arm64", "mac_amd64"]
-              job_type: ["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
+              job_type: ["test", "integration", "e2e_expect"]
           requires:
             - << matrix.platform >>_<< matrix.job_type >>
 
@@ -259,35 +160,15 @@ workflows:
           name: << matrix.platform >>_<< matrix.job_type >>_verification
           matrix:
             parameters:
-              platform: ["mac_arm64"]
-              job_type: ["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
+              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
+              job_type: ["test_nightly", "integration_nightly", "e2e_expect_nightly"]
           requires:
             - << matrix.platform >>_<< matrix.job_type >>
-          filters:
-            <<: *filters-mac-arm64
 
       - upload_binaries:
           name: << matrix.platform >>_upload_binaries
           matrix:
-            <<: *matrix-default
-          requires:
-            - << matrix.platform >>_test_nightly_verification
-            - << matrix.platform >>_integration_nightly_verification
-            - << matrix.platform >>_e2e_expect_nightly_verification
-            - << matrix.platform >>_e2e_subs_nightly
-            - codegen_verification
-          filters:
-            branches:
-              only:
-                - /rel\/.*/
-          context:
-            - slack-secrets
-            - aws-secrets
-
-      - upload_binaries:
-          name: << matrix.platform >>_upload_binaries
-          matrix:
-            <<: *matrix-mac-arm64
+            <<: *matrix-nightly
           requires:
             - << matrix.platform >>_test_nightly_verification
             - << matrix.platform >>_integration_nightly_verification

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -704,6 +704,7 @@ jobs:
           platform: << parameters.platform >>
           result_subdir: << parameters.platform >>_e2e_expect
           short_test_flag: "-short"
+          no_output_timeout: 45m
 
   e2e_expect_nightly:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ workflows:
               only:
                 - /rel\/.*/
                 - master
+                - /hotfix\/.*/
 
       - test:
           name: << matrix.platform >>_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,11 +74,11 @@ workflows:
           matrix: &matrix-mac-arm64
             parameters:
               platform: ["mac_arm64"]
-          # filters: &filters-mac-arm64
-          #   branches:
-          #     only:
-          #       - /rel\/.*/
-          #       - master
+          filters: &filters-mac-arm64
+            branches:
+              only:
+                - /rel\/.*/
+                - master
 
       - test:
           name: << matrix.platform >>_test
@@ -98,8 +98,8 @@ workflows:
             <<: *matrix-mac-arm64
           requires:
             - mac_arm64_build
-          # filters:
-          #   <<: *filters-mac-arm64
+          filters:
+            <<: *filters-mac-arm64
 
       - test_nightly:
           name: << matrix.platform >>_test_nightly
@@ -142,8 +142,8 @@ workflows:
             <<: *matrix-mac-arm64
           requires:
             - mac_arm64_build
-          # filters:
-          #   <<: *filters-mac-arm64
+          filters:
+            <<: *filters-mac-arm64
 
       - integration_nightly:
           name: << matrix.platform >>_integration_nightly
@@ -180,8 +180,8 @@ workflows:
             <<: *matrix-mac-arm64
           requires:
             - mac_arm64_build
-          # filters:
-          #   <<: *filters-mac-arm64
+          filters:
+            <<: *filters-mac-arm64
 
       - e2e_expect_nightly:
           name: << matrix.platform >>_e2e_expect_nightly
@@ -218,8 +218,8 @@ workflows:
             <<: *matrix-mac-arm64
           requires:
             - mac_arm64_build
-          # filters:
-          #   <<: *filters-mac-arm64
+          filters:
+            <<: *filters-mac-arm64
 
       - e2e_subs_nightly:
           name: << matrix.platform >>_e2e_subs_nightly
@@ -262,8 +262,8 @@ workflows:
               job_type: ["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
           requires:
             - << matrix.platform >>_<< matrix.job_type >>
-          # filters:
-          #   <<: *filters-mac-arm64
+          filters:
+            <<: *filters-mac-arm64
 
       - upload_binaries:
           name: << matrix.platform >>_upload_binaries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ workflows:
               ignore:
                 - /rel\/.*/
                 - /hotfix\/.*/
+                - cicd/add-m1-to-intergration-tests
 
       - build_nightly:
           name: << matrix.platform >>_build_nightly
@@ -84,6 +85,8 @@ workflows:
               only:
                 - /rel\/.*/
                 - /hotfix\/.*/
+                - cicd/add-m1-to-intergration-tests
+          context: slack-secrets
 
       - test:
           name: << matrix.platform >>_test
@@ -164,6 +167,7 @@ workflows:
               job_type: ["test_nightly", "integration_nightly", "e2e_expect_nightly"]
           requires:
             - << matrix.platform >>_<< matrix.job_type >>
+          context: slack-secrets
 
       - upload_binaries:
           name: << matrix.platform >>_upload_binaries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ executors:
     resource_class: large
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "true"
-  mac_arm64: &mac-arm64-executor
+  mac_arm64: &executor-mac-arm64
     machine: true
     resource_class: algorand/macstadium-m1
     environment:
@@ -53,9 +53,9 @@ executors:
   # these are required b/c jobs explicitly assign sizes to the executors
   # for `mac_arm64` there is only one size
   mac_arm64_medium:
-    <<: *mac-arm64-executor
+    <<: *executor-mac-arm64
   mac_arm64_large:
-    <<: *mac-arm64-executor
+    <<: *executor-mac-arm64
 
 workflows:
   version: 2
@@ -623,6 +623,8 @@ jobs:
     executor: << parameters.platform >>_medium
     working_directory: << pipeline.parameters.build_dir >>/project
     parallelism: 4
+    environment:
+      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go
@@ -639,6 +641,8 @@ jobs:
     executor: << parameters.platform >>_medium
     working_directory: << pipeline.parameters.build_dir >>/project
     parallelism: 4
+    environment:
+      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go
@@ -660,6 +664,7 @@ jobs:
     parallelism: 2
     environment:
       E2E_TEST_FILTER: "GO"
+      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go
@@ -677,6 +682,7 @@ jobs:
     parallelism: 4
     environment:
       E2E_TEST_FILTER: "GO"
+      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go
@@ -696,6 +702,7 @@ jobs:
     parallelism: 2
     environment:
       E2E_TEST_FILTER: "EXPECT"
+      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go
@@ -713,6 +720,7 @@ jobs:
     parallelism: 2
     environment:
       E2E_TEST_FILTER: "EXPECT"
+      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go
@@ -731,6 +739,7 @@ jobs:
     working_directory: << pipeline.parameters.build_dir >>/project
     environment:
       E2E_TEST_FILTER: "SCRIPTS"
+      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go
@@ -748,6 +757,7 @@ jobs:
     environment:
       E2E_TEST_FILTER: "SCRIPTS"
       E2E_PLATFORM: << parameters.platform >>
+      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go
@@ -787,6 +797,8 @@ jobs:
         type: string
       job_type: # job_type: ["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
         type: string
+    environment:
+      TAR_OPTIONS: --unlink-first
     steps:
       - checkout
       - tests_verification_command:
@@ -798,6 +810,8 @@ jobs:
       platform:
         type: string
     executor: << parameters.platform >>_medium
+    environment:
+      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,11 +74,11 @@ workflows:
           matrix: &matrix-mac-arm64
             parameters:
               platform: ["mac_arm64"]
-          filters: &filters-mac-arm64
-            branches:
-              only:
-                - /rel\/.*/
-                - master
+          # filters: &filters-mac-arm64
+          #   branches:
+          #     only:
+          #       - /rel\/.*/
+          #       - master
 
       - test:
           name: << matrix.platform >>_test
@@ -98,8 +98,8 @@ workflows:
             <<: *matrix-mac-arm64
           requires:
             - mac_arm64_build
-          filters:
-            <<: *filters-mac-arm64
+          # filters:
+          #   <<: *filters-mac-arm64
 
       - test_nightly:
           name: << matrix.platform >>_test_nightly
@@ -142,8 +142,8 @@ workflows:
             <<: *matrix-mac-arm64
           requires:
             - mac_arm64_build
-          filters:
-            <<: *filters-mac-arm64
+          # filters:
+          #   <<: *filters-mac-arm64
 
       - integration_nightly:
           name: << matrix.platform >>_integration_nightly
@@ -180,8 +180,8 @@ workflows:
             <<: *matrix-mac-arm64
           requires:
             - mac_arm64_build
-          filters:
-            <<: *filters-mac-arm64
+          # filters:
+          #   <<: *filters-mac-arm64
 
       - e2e_expect_nightly:
           name: << matrix.platform >>_e2e_expect_nightly
@@ -218,8 +218,8 @@ workflows:
             <<: *matrix-mac-arm64
           requires:
             - mac_arm64_build
-          filters:
-            <<: *filters-mac-arm64
+          # filters:
+          #   <<: *filters-mac-arm64
 
       - e2e_subs_nightly:
           name: << matrix.platform >>_e2e_subs_nightly
@@ -262,8 +262,8 @@ workflows:
               job_type: ["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
           requires:
             - << matrix.platform >>_<< matrix.job_type >>
-          filters:
-            <<: *filters-mac-arm64
+          # filters:
+          #   <<: *filters-mac-arm64
 
       - upload_binaries:
           name: << matrix.platform >>_upload_binaries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,11 +45,17 @@ executors:
     resource_class: large
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "true"
-  mac_arm64_medium: # adding `_medium` b/c `build` job explicitly declares it
+  mac_arm64: &mac_arm64
     machine: true
     resource_class: algorand/macstadium-m1
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "true"
+  # these are required b/c jobs explicitly assign sizes to the executors
+  # for `mac_arm64` there is only one size
+  mac_arm64_medium:
+    <<: *mac_arm64
+  mac_arm64_large:
+    <<: *mac_arm64
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -704,7 +704,6 @@ jobs:
           platform: << parameters.platform >>
           result_subdir: << parameters.platform >>_e2e_expect
           short_test_flag: "-short"
-          no_output_timeout: 45m
 
   e2e_expect_nightly:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,17 +45,17 @@ executors:
     resource_class: large
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "true"
-  mac_arm64: &mac_arm64
+  darwin_arm64: &darwin_arm64
     machine: true
     resource_class: algorand/macstadium-m1
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "true"
   # these are required b/c jobs explicitly assign sizes to the executors
   # for `mac_arm64` there is only one size
-  mac_arm64_medium:
-    <<: *mac_arm64
-  mac_arm64_large:
-    <<: *mac_arm64
+  darwin_arm64_medium:
+    <<: *darwin_arm64
+  darwin_arm64_large:
+    <<: *darwin_arm64
 
 workflows:
   version: 2
@@ -67,7 +67,7 @@ workflows:
           name: << matrix.platform >>_build
           matrix: &matrix-default
             parameters:
-              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
+              platform: ["amd64", "arm64", "mac_amd64", "darwin_arm64"]
 
       - test:
           name: << matrix.platform >>_test
@@ -157,7 +157,7 @@ workflows:
           name: << matrix.platform >>_<< matrix.job_type >>_verification
           matrix:
             parameters:
-              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
+              platform: ["amd64", "arm64", "mac_amd64", "darwin_arm64"]
               job_type: ["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
           requires:
             - << matrix.platform >>_<< matrix.job_type >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -624,8 +624,6 @@ jobs:
     executor: << parameters.platform >>_medium
     working_directory: << pipeline.parameters.build_dir >>/project
     parallelism: 4
-    environment:
-      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go
@@ -642,8 +640,6 @@ jobs:
     executor: << parameters.platform >>_medium
     working_directory: << pipeline.parameters.build_dir >>/project
     parallelism: 4
-    environment:
-      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go
@@ -665,7 +661,6 @@ jobs:
     parallelism: 2
     environment:
       E2E_TEST_FILTER: "GO"
-      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go
@@ -683,7 +678,6 @@ jobs:
     parallelism: 4
     environment:
       E2E_TEST_FILTER: "GO"
-      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go
@@ -703,7 +697,6 @@ jobs:
     parallelism: 2
     environment:
       E2E_TEST_FILTER: "EXPECT"
-      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go
@@ -721,7 +714,6 @@ jobs:
     parallelism: 2
     environment:
       E2E_TEST_FILTER: "EXPECT"
-      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go
@@ -740,7 +732,6 @@ jobs:
     working_directory: << pipeline.parameters.build_dir >>/project
     environment:
       E2E_TEST_FILTER: "SCRIPTS"
-      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go
@@ -758,7 +749,6 @@ jobs:
     environment:
       E2E_TEST_FILTER: "SCRIPTS"
       E2E_PLATFORM: << parameters.platform >>
-      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go
@@ -798,8 +788,6 @@ jobs:
         type: string
       job_type: # job_type: ["test", "test_nightly", "integration", "integration_nightly", "e2e_expect", "e2e_expect_nightly"]
         type: string
-    environment:
-      TAR_OPTIONS: --unlink-first
     steps:
       - checkout
       - tests_verification_command:
@@ -811,8 +799,6 @@ jobs:
       platform:
         type: string
     executor: << parameters.platform >>_medium
-    environment:
-      TAR_OPTIONS: --unlink-first
     steps:
       - prepare_build_dir
       - prepare_go


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

- adds new `mac_arm64` executor
- updates the nightly jobs to include the `mac_arm64` platform, this is because of the restrictions of self-hosted runners and the fact that they take longer to execute
- adds a step to `prepare_build` so that `/opt/cibuild` is cleaned up before the workspace/cache is pulled in, this isn't necessary on ephemeral instances, but runs into conflicts on non-ephemeral ones
- removes superfluous branch filters in `test_*` jobs since they can rely on the filters of their required jobs. This also required that a separate `build_nightly` and `test_verification_nightly` be created so that we get notified of those failures
 
## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

- see _all_ circleci runs, I've disabled the branch filters during testing and re-enabled them one last time before review. So the last run may not be indicative of what we are expecting since the goal is to only target `hostfix/*` and `rel/*`

## Notes

- `mac_arm64` jobs run in sequential order, even the tests that are parallelized. This pretty much doubles the time it takes to complete a single run.
