### PR TITLE
CICD: upgrade xcode on circleci macos executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,13 +35,13 @@ executors:
     resource_class: arm.large
   mac_amd64_medium:
     macos:
-      xcode: 12.0.1
+      xcode: 13.4.1
     resource_class: medium
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "true"
   mac_amd64_large:
     macos:
-      xcode: 12.0.1
+      xcode: 13.4.1
     resource_class: large
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "true"

--- a/test/e2e-go/cli/goal/expect/testInfraTest.exp
+++ b/test/e2e-go/cli/goal/expect/testInfraTest.exp
@@ -53,7 +53,7 @@ proc checkProcessReturnedCodeTest {} {
     }
 
     # test close sending sighup
-    spawn /bin/bash -c "echo 44; sleep 2s; kill -11 $$"
+    spawn /bin/bash -c "echo 44; sleep 2; kill -11 $$"
     expect {
 	44 {
 	    close
@@ -67,7 +67,7 @@ proc checkProcessReturnedCodeTest {} {
     }
 
     # same, without close. should get to segv
-    spawn /bin/bash -c "echo 44; sleep 2s; kill -11 $$"
+    spawn /bin/bash -c "echo 44; sleep 2; kill -11 $$"
     expect {
 	44 {
 	    puts "not closing"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

- upgrades `xcode` to `13.4.1` since CircleCI is planning to deprecate the version we are using

- removes `s` from `sleep` commands in `testInfraTest.exp` expect tests b/c newer versions of macos do not allow that syntax anymore

- [CircleCI Forum Discussion on Xcode Deprecation](https://discuss.circleci.com/t/xcode-image-deprecation/44294/1?mkt_tok=NDg1LVpNSC02MjYAAAGFSZXgsHTICuosKRkrrxHGCK-SAogChAwfy_DisiqWPFLTeSMU4WlPOQrLjO_-Fn94GHt46tYVydmYIgleXEorwXwTcGaJJxciUXabDaUHGxqW2A)

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

- see circleci tests
