### PR TITLE
ledger: Update onlineAccounts lookup methods for slightly easier reading

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -2450,12 +2450,12 @@ func onlineAccountsInitDbQueries(r db.Queryable) (*onlineAccountsDbQueries, erro
 	var err error
 	qs := &onlineAccountsDbQueries{}
 
-	qs.lookupOnlineStmt, err = r.Prepare("SELECT onlineaccounts.rowid, updround, rnd, data FROM acctrounds LEFT JOIN onlineaccounts ON address=? AND updround <= ? WHERE id='acctbase' ORDER BY updround DESC LIMIT 1")
+	qs.lookupOnlineStmt, err = r.Prepare("SELECT onlineaccounts.rowid, onlineaccounts.updround, acctrounds.rnd, onlineaccounts.data FROM acctrounds LEFT JOIN onlineaccounts ON address=? AND updround <= ? WHERE id='acctbase' ORDER BY updround DESC LIMIT 1")
 	if err != nil {
 		return nil, err
 	}
 
-	qs.lookupOnlineHistoryStmt, err = r.Prepare("SELECT onlineaccounts.rowid, updround, rnd, data FROM acctrounds LEFT JOIN onlineaccounts ON address=? WHERE id='acctbase' ORDER BY updround ASC")
+	qs.lookupOnlineHistoryStmt, err = r.Prepare("SELECT onlineaccounts.rowid, onlineaccounts.updround, acctrounds.rnd, onlineaccounts.data FROM acctrounds LEFT JOIN onlineaccounts ON address=? WHERE id='acctbase' ORDER BY updround ASC")
 	if err != nil {
 		return nil, err
 	}

--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -656,20 +656,27 @@ func (ao *onlineAccounts) lookupOnlineAccountData(rnd basics.Round, addr basics.
 			// no such online account, return empty
 			return ledgercore.OnlineAccountData{}, err
 		}
-		// lookupOnlineHistory fetches the account DB round from the acctrounds table (returned as validThrough)
-		// We load the entire history of this account to fill the onlineAccountsCache, so that the next lookup for
-		// this online account will not hit the on-disk DB.
+		// Now we load the entire history of this account to fill the onlineAccountsCache, so that the
+		// next lookup for this online account will not hit the on-disk DB.
+		//
+		// lookupOnlineHistory fetches the account DB round from the acctrounds table (validThrough) to
+		// distinguish between different cases involving the last-observed value of ao.cachedDBRoundOnline.
+		// 1. Updates to ao.onlineAccountsCache happen with ao.accountsMu taken below, as well as in postCommit()
+		// 2. If we started reading the history (lookupOnlineHistory)
+		//   1. before commitRound or while it is running => OK, read what is in DB and then add new entries in postCommit
+		//     * if commitRound deletes some history after, the cache has additional entries and updRound comparison gets a right value
+		//   2. after commitRound but before postCommit => OK, read full history, ignore the update from postCommit in writeFront's updRound comparison
+		//   3. after postCommit => OK, postCommit does not add new entry with writeFrontIfExist, but here all the full history is loaded
 		persistedDataHistory, validThrough, err := ao.accountsq.lookupOnlineHistory(addr)
 		if err != nil || len(persistedDataHistory) == 0 {
 			return ledgercore.OnlineAccountData{}, err
 		}
-		// onlineAccountsCache update happens with ao.accountsMu taken below, and in postCommit
-		// After we finished reading the history (lookupOnlineHistory), either
-		//   1. db has not advanced (validThrough == currentDbRound) => OK
+		// 3. After we finished reading the history (lookupOnlineHistory), either
+		//   1. The DB round has not advanced (validThrough == currentDbRound) => OK
 		//   2. after commitRound but before postCommit (currentDeltaLen == len(ao.deltas)) => OK, the cache gets populated and postCommit updates the new entry
 		//   3. after commitRound and after postCommit => problem, postCommit does not add a new entry, but the cache that would get constructed would miss the latest entry, retry
-		// In order to resolve this lookupOnlineHistory returns dbRound value (validThrough) and determine what happened
-		// So handle case 1 and case 2 here, and case 3 below
+		// In order to resolve this lookupOnlineHistory returns dbRound value (as validThrough) and determine what happened
+		// So handle cases 3.1 and 3.2 here, and 3.3 below
 		ao.accountsMu.Lock()
 		if validThrough == currentDbRound || currentDbRound >= ao.cachedDBRoundOnline && currentDeltaLen == len(ao.deltas) {
 			// not advanced or postCommit not called yet, write to the cache and return the value
@@ -692,7 +699,7 @@ func (ao *onlineAccounts) lookupOnlineAccountData(rnd basics.Round, addr basics.
 			ao.accountsMu.Unlock()
 			return persistedData.accountData.GetOnlineAccountData(rewardsProto, rewardsLevel), nil
 		}
-		// case 3: retry (for loop iterates and queries again)
+		// case 3.3: retry (for loop iterates and queries again)
 		ao.accountsMu.Unlock()
 
 		if validThrough < currentDbRound {

--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -673,8 +673,10 @@ func (ao *onlineAccounts) lookupOnlineAccountData(rnd basics.Round, addr basics.
 		}
 		// 3. After we finished reading the history (lookupOnlineHistory), either
 		//   1. The DB round has not advanced (validThrough == currentDbRound) => OK
-		//   2. after commitRound but before postCommit (currentDeltaLen == len(ao.deltas)) => OK, the cache gets populated and postCommit updates the new entry
-		//   3. after commitRound and after postCommit => problem, postCommit does not add a new entry, but the cache that would get constructed would miss the latest entry, retry
+		//   2. after commitRound but before postCommit (currentDbRound >= ao.cachedDBRoundOnline && currentDeltaLen == len(ao.deltas)) => OK
+		//      the cache gets populated and postCommit updates the new entry
+		//   3. after commitRound and after postCommit => problem
+		//      postCommit does not add a new entry, but the cache that would get constructed would miss the latest entry, retry
 		// In order to resolve this lookupOnlineHistory returns dbRound value (as validThrough) and determine what happened
 		// So handle cases 3.1 and 3.2 here, and 3.3 below
 		ao.accountsMu.Lock()


### PR DESCRIPTION
## Summary

Was reviewing onlineAccounts.lookupOnlineAccountData and onlineTop with @algoidan and @algorandskiy and made some changes for comments and clarity.

## Test Plan

Existing tests should pass.