### PR TITLE
tools: add validation for version[1]:"foo" tags in localTemplate.go

### DIFF
--- a/config/migrate_test.go
+++ b/config/migrate_test.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckTag(t *testing.T) {
+	require.NoError(t, checkTag(`wat:"bar" baz:"foo"`))
+	require.Error(t, checkTag(`w at:"bar" baz:"foo"`))
+	require.Error(t, checkTag(`wat:"bar" baz:needsquotes`))
+	require.Error(t, checkTag(`wat:"bar" baz:"foo" garbage`))
+	require.Error(t, checkTag(`wat:"bar" garbage baz:"foo"`))
+}
+
+func TestLocalTemplateTags(t *testing.T) {
+	require.NoError(t, checkLocalTags())
+}


### PR DESCRIPTION
## Summary

localTemplate.go default values in struct tags would silently fail if malformed. Add unit test validation for struct tags.

## Test Plan

This is itself additional testing. I added a bad tag to my localTemplate.go and the unit test failed.