### PR TITLE
Re-enable catchpoint expect test

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -2283,7 +2283,7 @@ func performOnlineAccountsTableMigration(ctx context.Context, tx *sql.Tx, log fu
 
 		// insert entries into online accounts table
 		if ba.Status == basics.Online {
-			if !normBal.Valid {
+			if ba.MicroAlgos.Raw > 0 && !normBal.Valid {
 				var addr basics.Address
 				copy(addr[:], addrbuf)
 				return fmt.Errorf("non valid norm balance for online account %s", addr.String())

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -392,7 +392,7 @@ func calculateFirstStageRounds(oldBase basics.Round, offset uint64, accountDataR
 			accountDataResourceSeparationRound - basics.Round(catchpointLookback)
 	}
 
-	// The smallest integer r >= dcr.minFirstStageRound such that
+	// The smallest integer r >= minFirstStageRound such that
 	// (r + catchpointLookback) % ct.catchpointInterval == 0.
 	first := (int64(minFirstStageRound)+int64(catchpointLookback)+
 		int64(catchpointInterval)-1)/

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -152,7 +152,6 @@ type trackerRegistry struct {
 	// these trackers have some exceptional usages in the tracker registry.
 	accts       *accountUpdates
 	acctsOnline *onlineAccounts
-	txtail      *txTail
 
 	// ctx is the context for the committing go-routine.
 	ctx context.Context

--- a/test/e2e-go/cli/goal/expect/catchpointCatchupTest.exp
+++ b/test/e2e-go/cli/goal/expect/catchpointCatchupTest.exp
@@ -64,12 +64,12 @@ if { [catch {
     ::AlgorandGoal::CreateNetwork $NETWORK_NAME $NETWORK_TEMPLATE $TEST_ALGO_DIR $TEST_ROOT_DIR
 
     # Update the Primary Node configuration
-    exec -- cat "$TEST_ROOT_DIR/Primary/config.json" | jq {. |= . + {"CatchpointInterval":4,"EnableRequestLogger":true}} > $TEST_ROOT_DIR/Primary/config.json.new
+    exec -- cat "$TEST_ROOT_DIR/Primary/config.json" | jq {. |= . + {"MaxAcctLookback": 2, "CatchpointInterval": 4,"EnableRequestLogger":true}} > $TEST_ROOT_DIR/Primary/config.json.new
     exec rm $TEST_ROOT_DIR/Primary/config.json
     exec mv $TEST_ROOT_DIR/Primary/config.json.new $TEST_ROOT_DIR/Primary/config.json
 
     # Update the Second Node configuration
-    exec -- cat "$TEST_ROOT_DIR/Node/config.json" | jq {. |= . + {"CatchupParallelBlocks":2}} > $TEST_ROOT_DIR/Node/config.json.new
+    exec -- cat "$TEST_ROOT_DIR/Node/config.json" | jq {. |= . + {"MaxAcctLookback": 2, "CatchupParallelBlocks":2}} > $TEST_ROOT_DIR/Node/config.json.new
     exec rm $TEST_ROOT_DIR/Node/config.json
     exec mv $TEST_ROOT_DIR/Node/config.json.new $TEST_ROOT_DIR/Node/config.json
 
@@ -83,6 +83,11 @@ if { [catch {
 
 
     # Wait until the primary node reaches round 37. At that point, the catchpoint for round 36 is already done.
+    # The rationale is the following:
+    # 1. MaxTxnLife = 33 so catchup would load blocks 3..36
+    # 2. Loading block 2 is blocked by the catchpoint proxy
+    # 3. Next block is 37 that would require balances from round 37-MaxBalLookback = 5 to be accessed, and this is
+    # within the expected range of 3...36
     ::AlgorandGoal::WaitForRound 37 $TEST_ROOT_DIR/Primary
 
     # Get primary node listening address:

--- a/test/e2e-go/cli/goal/expect/catchpointCatchupWebProxy/webproxy.go
+++ b/test/e2e-go/cli/goal/expect/catchpointCatchupWebProxy/webproxy.go
@@ -55,6 +55,7 @@ func main() {
 		mu.Unlock()
 		// prevent requests for block #2 to go through.
 		if strings.HasSuffix(request.URL.String(), "/block/2") {
+			response.Write([]byte("webProxy prevents block 2 from serving"))
 			response.WriteHeader(http.StatusBadRequest)
 			return
 		}

--- a/test/framework/fixtures/expectFixture.go
+++ b/test/framework/fixtures/expectFixture.go
@@ -145,7 +145,6 @@ func (ef *ExpectFixture) Run() {
 	disabledTest := map[string]string{
 		"pingpongTest.exp":                    "broken",
 		"listExpiredParticipationKeyTest.exp": "flaky",
-		"catchpointCatchupTest.exp":           "320-rounds-refactoring", // TODO: re-enable
 	}
 	for testName := range ef.expectFiles {
 		if match, _ := regexp.MatchString(ef.testFilter, testName); match {
@@ -164,7 +163,7 @@ func (ef *ExpectFixture) Run() {
 				cmd.Stdout = &outBuf
 
 				// Set stderr to be a file descriptor. In other way Go's exec.Cmd::writerDescriptor
-				// attaches goroutine reading that blocks on io.Copy from stderr.
+				// attaches a goroutine reading stderr that blocks on io.Copy from stderr.
 				// Cmd::CombinedOutput sets stderr to stdout and also blocks.
 				// Cmd::Start + Cmd::Wait with manual pipes redirection etc also blocks.
 				// Wrapping 'expect' with 'expect "$@" 2>&1' also blocks on stdout reading.

--- a/test/testdata/consensus/catchpointtestingprotocol.json
+++ b/test/testdata/consensus/catchpointtestingprotocol.json
@@ -55,6 +55,7 @@
     "MaxAssetUnitNameBytes": 8,
     "MaxAssetsPerAccount": 1000,
     "MaxBalLookback": 32,
+    "CatchpointLookback": 32,
     "MaxExtraAppProgramPages": 3,
     "MaxGlobalSchemaEntries": 64,
     "MaxInnerTransactions": 16,


### PR DESCRIPTION
Adjust new catchpoint-related parameters to let the test run properly:
1. Set `CatchpointLookback` to the same value as `MaxBalLookback`
2. Set `MaxAcctLookback` to a small value to allow second stage of the catchpoint generation complete fast.