### PR TITLE
Optimization: Use bits package for Muldiv. 266x speedup

### DIFF
--- a/data/basics/overflow.go
+++ b/data/basics/overflow.go
@@ -18,7 +18,7 @@ package basics
 
 import (
 	"math"
-	"math/big"
+	"math/bits"
 )
 
 // OverflowTracker is used to track when an operation causes an overflow
@@ -200,17 +200,10 @@ func (t *OverflowTracker) ScalarMulA(a MicroAlgos, b uint64) MicroAlgos {
 // Muldiv computes a*b/c.  The overflow flag indicates that
 // the result was 2^64 or greater.
 func Muldiv(a uint64, b uint64, c uint64) (res uint64, overflow bool) {
-	var aa big.Int
-	aa.SetUint64(a)
-
-	var bb big.Int
-	bb.SetUint64(b)
-
-	var cc big.Int
-	cc.SetUint64(c)
-
-	aa.Mul(&aa, &bb)
-	aa.Div(&aa, &cc)
-
-	return aa.Uint64(), !aa.IsUint64()
+	hi, lo := bits.Mul64(a, b)
+	if c <= hi {
+		return 0, true
+	}
+	quo, _ := bits.Div64(hi, lo, c)
+	return quo, false
 }

--- a/data/basics/units_test.go
+++ b/data/basics/units_test.go
@@ -18,6 +18,7 @@ package basics
 
 import (
 	"math"
+	"math/big"
 	"testing"
 
 	"github.com/algorand/go-algorand/test/partitiontest"
@@ -68,4 +69,64 @@ func TestRoundUpToMultipleOf(t *testing.T) {
 			require.True(t, prevMul < r)
 		}
 	}
+}
+
+func OldMuldiv(a uint64, b uint64, c uint64) (res uint64, overflow bool) {
+	var aa big.Int
+	aa.SetUint64(a)
+
+	var bb big.Int
+	bb.SetUint64(b)
+
+	var cc big.Int
+	cc.SetUint64(c)
+
+	aa.Mul(&aa, &bb)
+	aa.Div(&aa, &cc)
+
+	return aa.Uint64(), !aa.IsUint64()
+}
+
+func BenchmarkOldMuldiv(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		u64 := uint64(i + 1)
+		OldMuldiv(u64, u64, u64)
+		OldMuldiv(math.MaxUint64, u64, u64)
+		OldMuldiv(u64, math.MaxUint64, u64)
+		OldMuldiv(math.MaxInt64, math.MaxInt64, u64)
+	}
+}
+
+func BenchmarkNewMuldiv(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		u64 := uint64(i + 1)
+		Muldiv(u64, u64, u64)
+		Muldiv(math.MaxUint64, u64, u64)
+		Muldiv(u64, math.MaxUint64, u64)
+		Muldiv(math.MaxInt64, math.MaxInt64, u64)
+	}
+}
+
+func TestNewMuldiv(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	test := func(a, b, c uint64) {
+		r1, o1 := OldMuldiv(a, b, c)
+		r2, o2 := Muldiv(a, b, c)
+		require.Equal(t, o1, o2)
+		// implementations differ in r1,r2 if overflow. old implemention is
+		// returning an unspecified value
+		if !o1 {
+			require.Equal(t, r1, r2)
+		}
+	}
+	test(1, 2, 3)
+	test(1000000000, 2000000000, 1)
+	test(math.MaxUint64, 3, 4)
+	test(math.MaxUint64, 4, 3)
+	test(3, math.MaxUint64, 4)
+	test(4, math.MaxUint64, 3)
+	test(math.MaxUint64, math.MaxUint64, math.MaxUint64)
+	test(math.MaxUint64, math.MaxUint64, 5)
 }


### PR DESCRIPTION
go test -run ^NOTHING -bench 'BenchmarkOldMulDiv|BenchmarkNewMulDiv'
goos: darwin
goarch: amd64
pkg: github.com/algorand/go-algorand/data/basics
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkOldMulDiv-8   	 2501655	       479.3 ns/op
BenchmarkNewMulDiv-8   	653492884	         1.801 ns/op
