### PR TITLE
alphanet: define vAlpha2 consensus parameters

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1156,6 +1156,15 @@ func initConsensusProtocols() {
 	vAlpha1.MaxTxnBytesPerBlock = 5000000
 
 	Consensus[protocol.ConsensusVAlpha1] = vAlpha1
+
+	vAlpha2 := vAlpha1
+	vAlpha2.AgreementFilterTimeoutPeriod0 = 3500 * time.Millisecond
+	vAlpha2.MaxTxnBytesPerBlock = 5 * 1024 * 1024
+
+	Consensus[protocol.ConsensusVAlpha2] = vAlpha2
+
+	// vAlpha1 can be upgraded to vAlpha2, with a short update delay of a few hours
+	vAlpha1.ApprovedUpgrades[protocol.ConsensusVAlpha2] = 5000
 }
 
 // Global defines global Algorand protocol parameters which should not be overridden.

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1166,7 +1166,7 @@ func initConsensusProtocols() {
 	Consensus[protocol.ConsensusVAlpha2] = vAlpha2
 
 	// vAlpha1 can be upgraded to vAlpha2, with a short update delay of a few hours
-	vAlpha1.ApprovedUpgrades[protocol.ConsensusVAlpha2] = 5000
+	vAlpha1.ApprovedUpgrades[protocol.ConsensusVAlpha2] = 10000
 }
 
 // Global defines global Algorand protocol parameters which should not be overridden.

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1152,6 +1152,8 @@ func initConsensusProtocols() {
 	Consensus[protocol.ConsensusFuture] = vFuture
 
 	vAlpha1 := v32
+	vAlpha1.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+
 	vAlpha1.AgreementFilterTimeoutPeriod0 = 2 * time.Second
 	vAlpha1.MaxTxnBytesPerBlock = 5000000
 

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -188,6 +188,12 @@ const ConsensusVAlpha1 = ConsensusVersion(
 	"alpha1",
 )
 
+// ConsensusVAlpha2 is the second consensus protocol for AlphaNet, which increases the
+// filter timeout to 3.5 seconds and uses 5MiB blocks.
+const ConsensusVAlpha2 = ConsensusVersion(
+	"alpha2",
+)
+
 // !!! ********************* !!!
 // !!! *** Please update ConsensusCurrentVersion when adding new protocol versions *** !!!
 // !!! ********************* !!!


### PR DESCRIPTION
## Summary

This defines a vAlpha2 consensus protocol, with 3.5s filter timeout and 5MiB block size.
