### PR TITLE
Adjust the DNS Bootstrap Id for Alphanet

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,9 @@ const Devnet protocol.NetworkID = "devnet"
 // Betanet identifies the 'beta network' use for early releases of feature to the public prior to releasing these to mainnet/testnet
 const Betanet protocol.NetworkID = "betanet"
 
+// Alphanet identifies the 'alpha network' use for performance releases of feature/alphanet to the public prior to releasing these to mainnet/testnet
+const Alphanet protocol.NetworkID = "alphanet"
+
 // Devtestnet identifies the 'development network for tests' use for running tests against development and not generally accessible publicly
 const Devtestnet protocol.NetworkID = "devtestnet"
 

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -472,6 +472,8 @@ func (cfg Local) DNSBootstrap(network protocol.NetworkID) string {
 			return "devnet.algodev.network"
 		} else if network == Betanet {
 			return "betanet.algodev.network"
+		} else if network == Alphanet {
+			return "alphanet.algodev.network"
 		}
 	}
 	return strings.Replace(cfg.DNSBootstrapID, "<network>", string(network), -1)


### PR DESCRIPTION

## Summary

If network is alphanet, then set DNS BootStrapId to "alphanet.algodev.network".

## Test Plan

Built and tested locally.  Verified that node was increasing rounds. 
