### PR TITLE
agreement: add AgreementDeadlineTimeoutPeriod0 parameter

### DIFF
--- a/agreement/types.go
+++ b/agreement/types.go
@@ -39,7 +39,10 @@ func FilterTimeout(p period, v protocol.ConsensusVersion) time.Duration {
 }
 
 // DeadlineTimeout is the duration of the second agreement step.
-func DeadlineTimeout() time.Duration {
+func DeadlineTimeout(p period, v protocol.ConsensusVersion) time.Duration {
+	if p == 0 {
+		return config.Consensus[v].AgreementDeadlineTimeoutPeriod0
+	}
 	return deadlineTimeout
 }
 

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -114,7 +114,7 @@ func MakeService(log logging.Logger, config config.Local, net network.GossipNode
 	s.unmatchedPendingCertificates = unmatchedPendingCertificates
 	s.log = log.With("Context", "sync")
 	s.parallelBlocks = config.CatchupParallelBlocks
-	s.deadlineTimeout = agreement.DeadlineTimeout()
+	s.deadlineTimeout = agreement.DeadlineTimeout(1, protocol.ConsensusCurrentVersion)
 	s.blockValidationPool = blockValidationPool
 
 	return s

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -160,6 +160,8 @@ type ConsensusParams struct {
 	// critical path
 	AgreementFilterTimeoutPeriod0 time.Duration
 
+	AgreementDeadlineTimeoutPeriod0 time.Duration
+
 	FastRecoveryLambda time.Duration // time between fast recovery attempts
 
 	// how to commit to the payset: flat or merkle tree
@@ -701,6 +703,8 @@ func initConsensusProtocols() {
 
 		AgreementFilterTimeout:        4 * time.Second,
 		AgreementFilterTimeoutPeriod0: 4 * time.Second,
+
+		AgreementDeadlineTimeoutPeriod0: 17 * time.Second, // BigLambda + SmallLambda
 
 		FastRecoveryLambda: 5 * time.Minute,
 


### PR DESCRIPTION
## Summary

This introduces a new consensus variable, AgreementDeadlineTimeoutPeriod0, similar to AgreementFilterTimeoutPeriod0 but for the second agreement step. It sets it to the current hard-coded default of 17 seconds.

## Test Plan

Existing tests should pass — may add new ones.