### PR TITLE
ledger: restore pointer receivers and args from #4003

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -1516,7 +1516,7 @@ func (ba *baseAccountData) GetAccountData() basics.AccountData {
 	}
 }
 
-// IsEmpty returns true if all of the fields other than UpdateRound are zero.
+// IsEmpty returns true if all of the fields are zero.
 func (bv *baseVotingData) IsEmpty() bool {
 	return bv.VoteID == crypto.OneTimeSignatureVerifier{} &&
 		bv.SelectionID == crypto.VRFVerifier{} &&

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -1522,6 +1522,7 @@ func (bv *baseVotingData) IsEmpty() bool {
 		bv.SelectionID == crypto.VRFVerifier{} &&
 		bv.VoteFirstValid == basics.Round(0) &&
 		bv.VoteLastValid == basics.Round(0) &&
+		bv.VoteKeyDilution == 0 &&
 		bv.StateProofID == merklesignature.Verifier{}
 }
 

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -1517,13 +1517,8 @@ func (ba *baseAccountData) GetAccountData() basics.AccountData {
 }
 
 // IsEmpty returns true if all of the fields are zero.
-func (bv *baseVotingData) IsEmpty() bool {
-	return bv.VoteID == crypto.OneTimeSignatureVerifier{} &&
-		bv.SelectionID == crypto.VRFVerifier{} &&
-		bv.VoteFirstValid == basics.Round(0) &&
-		bv.VoteLastValid == basics.Round(0) &&
-		bv.VoteKeyDilution == 0 &&
-		bv.StateProofID == merklesignature.Verifier{}
+func (bv baseVotingData) IsEmpty() bool {
+	return bv == baseVotingData{}
 }
 
 // SetCoreAccountData initializes baseVotingData from ledgercore.AccountData

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -2229,7 +2229,8 @@ func TestBaseOnlineAccountDataGettersSetters(t *testing.T) {
 	data.VoteKeyDilution = crypto.RandUint64()
 
 	var ba baseOnlineAccountData
-	ba.SetCoreAccountData(ledgercore.ToAccountData(data))
+	ad := ledgercore.ToAccountData(data)
+	ba.SetCoreAccountData(&ad)
 
 	require.Equal(t, data.MicroAlgos, ba.MicroAlgos)
 	require.Equal(t, data.RewardsBase, ba.RewardsBase)
@@ -2282,7 +2283,8 @@ func TestBaseVotingDataGettersSetters(t *testing.T) {
 	var bv baseVotingData
 	require.True(t, bv.IsEmpty())
 
-	bv.SetCoreAccountData(ledgercore.ToAccountData(data))
+	ad := ledgercore.ToAccountData(data)
+	bv.SetCoreAccountData(&ad)
 
 	require.False(t, bv.IsEmpty())
 	require.Equal(t, data.VoteID, bv.VoteID)
@@ -2450,7 +2452,7 @@ func (m *mockAccountWriter) lookup(addr basics.Address) (pad persistedAccountDat
 		err = fmt.Errorf("not found %s", addr.String())
 		return
 	}
-	pad.accountData.SetCoreAccountData(data)
+	pad.accountData.SetCoreAccountData(&data)
 	pad.addr = addr
 	pad.rowid = rowid
 	return

--- a/ledger/ledgercore/accountdata.go
+++ b/ledger/ledgercore/accountdata.go
@@ -17,8 +17,6 @@
 package ledgercore
 
 import (
-	"reflect"
-
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/merklesignature"
@@ -145,7 +143,7 @@ func (u AccountData) MinBalance(proto *config.ConsensusParams) (res basics.Micro
 
 // IsZero checks if an AccountData value is the same as its zero value.
 func (u AccountData) IsZero() bool {
-	return reflect.DeepEqual(u, AccountData{})
+	return u == AccountData{}
 }
 
 // Money is similar to basics account data Money function


### PR DESCRIPTION
## Summary

In #4003 some pointer receivers and pointer arguments were changed to pass by value and value receivers, which could lead to a performance regression. This changes them back.

There is a small discussion, including a benchmark, in https://github.com/algorand/go-algorand/pull/4003/files#r894844990 (a comment thread on ledger/accountdb.go line 1438)

## Test Plan

Existing tests should pass