### PR TITLE
Fixing rpm package name for alphanet

### DIFF
--- a/scripts/compute_package_name.sh
+++ b/scripts/compute_package_name.sh
@@ -10,14 +10,12 @@
 CHANNEL=${1:-stable}
 NAME=${2:-algorand}
 
-if [ ! -z ${PACKAGE_NAME_EXTENSION} ]; then
+if [ -n "${PACKAGE_NAME_EXTENSION}" ]; then
   NAME="${NAME}-${PACKAGE_NAME_EXTENSION}"
 fi
 
-if [ "$CHANNEL" = beta ]; then
-    echo "$NAME-beta"
-elif [ "$CHANNEL" = nightly ]; then
-    echo "$NAME-nightly"
-else
+if [ "$CHANNEL" = stable ]; then
     echo "$NAME"
+else
+    echo "$NAME-$CHANNEL"
 fi


### PR DESCRIPTION
Currently alphanet rpm packages are missing -alpha. I believe this changes the logic so that channel is always included in package name unless it's stable channel.