### PR TITLE
AVM: Don't parallelize tests that use shared for loop var

### DIFF
--- a/data/transactions/logic/evalAppTxn_test.go
+++ b/data/transactions/logic/evalAppTxn_test.go
@@ -1752,7 +1752,7 @@ int 1
 
 	for _, unified := range []bool{true, false} {
 		t.Run(fmt.Sprintf("unified=%t", unified), func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel() NO! unified variable is actually shared
 
 			ep, parentTx, ledger := MakeSampleEnv()
 			ep.Proto.UnifyInnerTxIDs = unified
@@ -2204,7 +2204,7 @@ func TestInnerTxIDCaching(t *testing.T) {
 
 	for _, unified := range []bool{true, false} {
 		t.Run(fmt.Sprintf("unified=%t", unified), func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel() NO! unified variable is actually shared
 
 			ep, parentTx, ledger := MakeSampleEnv()
 			ep.Proto.UnifyInnerTxIDs = unified


### PR DESCRIPTION
Fix to run tests properly, no non-test changes.