### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/algod/main_test.go
+++ b/cmd/algod/main_test.go
@@ -29,9 +29,7 @@ import (
 )
 
 func BenchmarkAlgodStartup(b *testing.B) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "BenchmarkAlgodStartup")
-	require.NoError(b, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := b.TempDir()
 	genesisFile, err := ioutil.ReadFile("../../installer/genesis/devnet/genesis.json")
 	require.NoError(b, err)
 

--- a/gen/generate_test.go
+++ b/gen/generate_test.go
@@ -18,8 +18,6 @@ package gen
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -37,9 +35,7 @@ import (
 func TestLoadMultiRootKeyConcurrent(t *testing.T) {
 	t.Skip() // skip in auto-test mode
 	a := require.New(t)
-	tempDir, err := ioutil.TempDir("", "loadkey-test-")
-	a.NoError(err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	const numThreads = 100
 	var wg sync.WaitGroup
@@ -78,9 +74,7 @@ func TestLoadMultiRootKeyConcurrent(t *testing.T) {
 func TestLoadSingleRootKeyConcurrent(t *testing.T) {
 	t.Skip() // skip in auto-test mode
 	a := require.New(t)
-	tempDir, err := ioutil.TempDir("", "loadkey-test-")
-	a.NoError(err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	wallet := filepath.Join(tempDir, "wallet1")
 	rootDB, err := db.MakeErasableAccessor(wallet)

--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -21,9 +21,7 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	mathrand "math/rand"
-	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -198,11 +196,8 @@ func TestArchivalRestart(t *testing.T) {
 		deadlock.Opts.Disable = deadlockDisable
 	}()
 
-	dbTempDir, err := ioutil.TempDir("", "testdir"+t.Name())
-	require.NoError(t, err)
 	dbName := fmt.Sprintf("%s.%d", t.Name(), crypto.RandUint64())
-	dbPrefix := filepath.Join(dbTempDir, dbName)
-	defer os.RemoveAll(dbTempDir)
+	dbPrefix := filepath.Join(t.TempDir(), dbName)
 
 	genesisInitState := getInitState()
 	const inMem = false // use persistent storage
@@ -348,11 +343,8 @@ func TestArchivalCreatables(t *testing.T) {
 		deadlock.Opts.Disable = deadlockDisable
 	}()
 
-	dbTempDir, err := ioutil.TempDir("", "testdir"+t.Name())
-	require.NoError(t, err)
 	dbName := fmt.Sprintf("%s.%d", t.Name(), crypto.RandUint64())
-	dbPrefix := filepath.Join(dbTempDir, dbName)
-	defer os.RemoveAll(dbTempDir)
+	dbPrefix := filepath.Join(t.TempDir(), dbName)
 
 	genesisInitState := getInitState()
 
@@ -380,7 +372,7 @@ func TestArchivalCreatables(t *testing.T) {
 	var creators []basics.Address
 	for i := 0; i < maxBlocks; i++ {
 		creator := basics.Address{}
-		_, err = rand.Read(creator[:])
+		_, err := rand.Read(creator[:])
 		require.NoError(t, err)
 		creators = append(creators, creator)
 		genesisInitState.Accounts[creator] = basics.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1234567890})
@@ -701,11 +693,9 @@ func TestArchivalFromNonArchival(t *testing.T) {
 	defer func() {
 		deadlock.Opts.Disable = deadlockDisable
 	}()
-	dbTempDir, err := ioutil.TempDir(os.TempDir(), "testdir")
-	require.NoError(t, err)
+
 	dbName := fmt.Sprintf("%s.%d", t.Name(), crypto.RandUint64())
-	dbPrefix := filepath.Join(dbTempDir, dbName)
-	defer os.RemoveAll(dbTempDir)
+	dbPrefix := filepath.Join(t.TempDir(), dbName)
 
 	genesisInitState := getInitState()
 
@@ -718,7 +708,7 @@ func TestArchivalFromNonArchival(t *testing.T) {
 
 	for i := 0; i < 50; i++ {
 		addr := basics.Address{}
-		_, err = rand.Read(addr[:])
+		_, err := rand.Read(addr[:])
 		require.NoError(t, err)
 		br := basics.BalanceRecord{AccountData: basics.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1234567890}), Addr: addr}
 		genesisInitState.Accounts[addr] = br.AccountData

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -27,7 +27,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-
 	"sync/atomic"
 	"testing"
 	"time"
@@ -92,13 +91,9 @@ func TestGetCatchpointStream(t *testing.T) {
 
 	filesToCreate := 4
 
-	temporaryDirectory, err := ioutil.TempDir(os.TempDir(), CatchpointDirName)
-	require.NoError(t, err)
-	defer func() {
-		os.RemoveAll(temporaryDirectory)
-	}()
+	temporaryDirectory := t.TempDir()
 	catchpointsDirectory := filepath.Join(temporaryDirectory, CatchpointDirName)
-	err = os.Mkdir(catchpointsDirectory, 0777)
+	err := os.Mkdir(catchpointsDirectory, 0777)
 	require.NoError(t, err)
 
 	ct.dbDirectory = temporaryDirectory
@@ -162,12 +157,7 @@ func TestAcctUpdatesDeleteStoredCatchpoints(t *testing.T) {
 
 	accts := []map[basics.Address]basics.AccountData{ledgertesting.RandomAccounts(20, true)}
 
-	temporaryDirectory, err := ioutil.TempDir(os.TempDir(), CatchpointDirName)
-
-	require.NoError(t, err)
-	defer func() {
-		os.RemoveAll(temporaryDirectory)
-	}()
+	temporaryDirectory := t.TempDir()
 	ml := makeMockLedgerForTracker(t, true, 10, protocol.ConsensusCurrentVersion, accts)
 	defer ml.Close()
 
@@ -198,7 +188,7 @@ func TestAcctUpdatesDeleteStoredCatchpoints(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	err = deleteStoredCatchpoints(context.Background(), ml.dbs.Wdb.Handle, ct.dbDirectory)
+	err := deleteStoredCatchpoints(context.Background(), ml.dbs.Wdb.Handle, ct.dbDirectory)
 	require.NoError(t, err)
 
 	// ensure that all the files were deleted.
@@ -221,16 +211,12 @@ func TestSchemaUpdateDeleteStoredCatchpoints(t *testing.T) {
 	if accountDBVersion < 6 {
 		return
 	}
-	temporaryDirectroy, err := ioutil.TempDir(os.TempDir(), CatchpointDirName)
-	require.NoError(t, err)
-	defer func() {
-		os.RemoveAll(temporaryDirectroy)
-	}()
+	temporaryDirectroy := t.TempDir()
 	tempCatchpointDir := filepath.Join(temporaryDirectroy, CatchpointDirName)
 
 	// creating empty catchpoint directories
 	emptyDirPath := path.Join(tempCatchpointDir, "2f", "e1")
-	err = os.MkdirAll(emptyDirPath, 0755)
+	err := os.MkdirAll(emptyDirPath, 0755)
 	require.NoError(t, err)
 	emptyDirPath = path.Join(tempCatchpointDir, "2e", "e1")
 	err = os.MkdirAll(emptyDirPath, 0755)
@@ -287,11 +273,7 @@ func getNumberOfCatchpointFilesInDir(catchpointDir string) (int, error) {
 func TestRecordCatchpointFile(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	temporaryDirectory, err := ioutil.TempDir(os.TempDir(), CatchpointDirName)
-	require.NoError(t, err)
-	defer func() {
-		os.RemoveAll(temporaryDirectory)
-	}()
+	temporaryDirectory := t.TempDir()
 
 	accts := []map[basics.Address]basics.AccountData{ledgertesting.RandomAccounts(20, true)}
 	ml := makeMockLedgerForTracker(t, true, 10, protocol.ConsensusCurrentVersion, accts)
@@ -306,7 +288,7 @@ func TestRecordCatchpointFile(t *testing.T) {
 	defer ct.close()
 	ct.dbDirectory = temporaryDirectory
 
-	_, err = trackerDBInitialize(ml, true, ct.dbDirectory)
+	_, err := trackerDBInitialize(ml, true, ct.dbDirectory)
 	require.NoError(t, err)
 
 	err = ct.loadFromDisk(ml, ml.Latest())
@@ -357,13 +339,9 @@ func BenchmarkLargeCatchpointDataWriting(b *testing.B) {
 	ct := catchpointTracker{}
 	ct.initialize(cfg, ".")
 
-	temporaryDirectroy, err := ioutil.TempDir(os.TempDir(), CatchpointDirName)
-	require.NoError(b, err)
-	defer func() {
-		os.RemoveAll(temporaryDirectroy)
-	}()
+	temporaryDirectroy := b.TempDir()
 	catchpointsDirectory := filepath.Join(temporaryDirectroy, CatchpointDirName)
-	err = os.Mkdir(catchpointsDirectory, 0777)
+	err := os.Mkdir(catchpointsDirectory, 0777)
 	require.NoError(b, err)
 
 	ct.dbDirectory = temporaryDirectroy
@@ -885,13 +863,9 @@ func TestFirstStageInfoPruning(t *testing.T) {
 	ct := newCatchpointTracker(t, ml, cfg, ".")
 	defer ct.close()
 
-	temporaryDirectory, err := ioutil.TempDir(os.TempDir(), CatchpointDirName)
-	require.NoError(t, err)
-	defer func() {
-		os.RemoveAll(temporaryDirectory)
-	}()
+	temporaryDirectory := t.TempDir()
 	catchpointsDirectory := filepath.Join(temporaryDirectory, CatchpointDirName)
-	err = os.Mkdir(catchpointsDirectory, 0777)
+	err := os.Mkdir(catchpointsDirectory, 0777)
 	require.NoError(t, err)
 
 	ct.dbDirectory = temporaryDirectory
@@ -978,11 +952,7 @@ func TestFirstStagePersistence(t *testing.T) {
 	ml := makeMockLedgerForTracker(t, false, 1, testProtocolVersion, accts)
 	defer ml.Close()
 
-	tempDirectory, err := ioutil.TempDir(os.TempDir(), CatchpointDirName)
-	require.NoError(t, err)
-	defer func() {
-		os.RemoveAll(tempDirectory)
-	}()
+	tempDirectory := t.TempDir()
 	catchpointsDirectory := filepath.Join(tempDirectory, CatchpointDirName)
 
 	cfg := config.GetDefaultLocal()
@@ -1084,11 +1054,7 @@ func TestSecondStagePersistence(t *testing.T) {
 	ml := makeMockLedgerForTracker(t, false, 1, testProtocolVersion, accts)
 	defer ml.Close()
 
-	tempDirectory, err := ioutil.TempDir(os.TempDir(), CatchpointDirName)
-	require.NoError(t, err)
-	defer func() {
-		os.RemoveAll(tempDirectory)
-	}()
+	tempDirectory := t.TempDir()
 	catchpointsDirectory := filepath.Join(tempDirectory, CatchpointDirName)
 
 	cfg := config.GetDefaultLocal()
@@ -1111,6 +1077,7 @@ func TestSecondStagePersistence(t *testing.T) {
 		if i == secondStageRound {
 			// Save first stage info and data file.
 			var exists bool
+			var err error
 			firstStageInfo, exists, err = selectCatchpointFirstStageInfo(
 				context.Background(), ml.dbs.Rdb.Handle, firstStageRound)
 			require.NoError(t, err)
@@ -1223,11 +1190,7 @@ func TestSecondStageDeletesUnfinishedCatchpointRecord(t *testing.T) {
 	ml := makeMockLedgerForTracker(t, false, 1, testProtocolVersion, accts)
 	defer ml.Close()
 
-	tempDirectory, err := ioutil.TempDir(os.TempDir(), CatchpointDirName)
-	require.NoError(t, err)
-	defer func() {
-		os.RemoveAll(tempDirectory)
-	}()
+	tempDirectory := t.TempDir()
 
 	cfg := config.GetDefaultLocal()
 	cfg.CatchpointInterval = 4

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -200,10 +199,9 @@ func TestBasicCatchpointWriter(t *testing.T) {
 	protoParams := config.Consensus[protocol.ConsensusCurrentVersion]
 	protoParams.CatchpointLookback = 32
 	config.Consensus[testProtocolVersion] = protoParams
-	temporaryDirectroy, _ := ioutil.TempDir(os.TempDir(), CatchpointDirName)
+	temporaryDirectroy := t.TempDir()
 	defer func() {
 		delete(config.Consensus, testProtocolVersion)
-		os.RemoveAll(temporaryDirectroy)
 	}()
 	accts := ledgertesting.RandomAccounts(300, false)
 
@@ -283,10 +281,9 @@ func TestFullCatchpointWriter(t *testing.T) {
 	protoParams := config.Consensus[protocol.ConsensusCurrentVersion]
 	protoParams.CatchpointLookback = 32
 	config.Consensus[testProtocolVersion] = protoParams
-	temporaryDirectory, _ := ioutil.TempDir(os.TempDir(), CatchpointDirName)
+	temporaryDirectory := t.TempDir()
 	defer func() {
 		delete(config.Consensus, testProtocolVersion)
-		os.RemoveAll(temporaryDirectory)
 	}()
 
 	accts := ledgertesting.RandomAccounts(BalancesPerCatchpointFileChunk*3, false)

--- a/ledger/ledger_perf_test.go
+++ b/ledger/ledger_perf_test.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -138,11 +136,9 @@ func benchmarkFullBlocks(params testParams, b *testing.B) {
 		deadlock.Opts.Disable = deadlockDisable
 	}()
 
-	dbTempDir, err := ioutil.TempDir("", "testdir"+b.Name())
-	require.NoError(b, err)
+	dbTempDir := b.TempDir()
 	dbName := fmt.Sprintf("%s.%d", b.Name(), crypto.RandUint64())
 	dbPrefix := filepath.Join(dbTempDir, dbName)
-	defer os.RemoveAll(dbTempDir)
 
 	genesisInitState := getInitState()
 
@@ -153,7 +149,7 @@ func benchmarkFullBlocks(params testParams, b *testing.B) {
 	genesisInitState.Block.BlockHeader.GenesisHash = crypto.Digest{1}
 
 	creator := basics.Address{}
-	_, err = rand.Read(creator[:])
+	_, err := rand.Read(creator[:])
 	require.NoError(b, err)
 	genesisInitState.Accounts[creator] = basics.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1234567890})
 

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"runtime"
@@ -1757,8 +1756,7 @@ func TestLookupAgreement(t *testing.T) {
 
 func BenchmarkLedgerStartup(b *testing.B) {
 	log := logging.TestingLog(b)
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "BenchmarkLedgerStartup")
-	require.NoError(b, err)
+	tmpDir := b.TempDir()
 	genesisInitState, _ := ledgertesting.GenerateInitState(b, protocol.ConsensusCurrentVersion, 100)
 
 	cfg := config.GetDefaultLocal()
@@ -1790,7 +1788,6 @@ func BenchmarkLedgerStartup(b *testing.B) {
 	b.Run("DiskDatabase/Archival", func(b *testing.B) {
 		testOpenLedger(b, false, cfg)
 	})
-	os.RemoveAll(tmpDir)
 }
 
 // TestLedgerReloadShrinkDeltas checks the ledger has correct account state

--- a/logging/telemetryConfig_test.go
+++ b/logging/telemetryConfig_test.go
@@ -18,7 +18,6 @@ package logging
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -65,7 +64,7 @@ func Test_CreateSaveLoadTelemetryConfig(t *testing.T) {
 	testDir := os.Getenv("TESTDIR")
 
 	if testDir == "" {
-		testDir, _ = ioutil.TempDir("", "tmp")
+		testDir = t.TempDir()
 	}
 
 	a := require.New(t)
@@ -143,7 +142,7 @@ func TestSaveTelemetryConfigBlankUsernamePassword(t *testing.T) {
 	testDir := os.Getenv("TESTDIR")
 
 	if testDir == "" {
-		testDir, _ = ioutil.TempDir("", "tmp")
+		testDir = t.TempDir()
 	}
 
 	a := require.New(t)

--- a/logging/telemetryhook_test.go
+++ b/logging/telemetryhook_test.go
@@ -17,7 +17,6 @@
 package logging
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,12 +45,10 @@ func TestLoadDefaultConfig(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	a := require.New(t)
 
-	configDir, err := ioutil.TempDir("", "testdir")
-	defer os.RemoveAll(configDir)
-	currentRoot := config.SetGlobalConfigFileRoot(configDir)
+	currentRoot := config.SetGlobalConfigFileRoot(t.TempDir())
 	defer config.SetGlobalConfigFileRoot(currentRoot)
 
-	_, err = EnsureTelemetryConfig(nil, "")
+	_, err := EnsureTelemetryConfig(nil, "")
 
 	a.Nil(err)
 
@@ -71,17 +68,15 @@ func TestLoggingConfigDataDirFirst(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	a := require.New(t)
 
-	globalConfigRoot, err := ioutil.TempDir("", "globalConfigRoot")
-	defer os.RemoveAll(globalConfigRoot)
+	globalConfigRoot := t.TempDir()
 	oldConfigRoot := config.SetGlobalConfigFileRoot(globalConfigRoot)
 	defer config.SetGlobalConfigFileRoot(oldConfigRoot)
 	globalLoggingPath := filepath.Join(globalConfigRoot, TelemetryConfigFilename)
 
-	dataDir, err := ioutil.TempDir("", "dataDir")
-	defer os.RemoveAll(dataDir)
+	dataDir := t.TempDir()
 	dataDirLoggingPath := filepath.Join(dataDir, TelemetryConfigFilename)
 
-	_, err = os.Stat(globalLoggingPath)
+	_, err := os.Stat(globalLoggingPath)
 	a.True(os.IsNotExist(err))
 	_, err = os.Stat(dataDirLoggingPath)
 	a.True(os.IsNotExist(err))
@@ -117,13 +112,12 @@ func TestLoggingConfigGlobalSecond(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	a := require.New(t)
 
-	globalConfigRoot, err := ioutil.TempDir("", "globalConfigRoot")
-	defer os.RemoveAll(globalConfigRoot)
+	globalConfigRoot := t.TempDir()
 	oldConfigRoot := config.SetGlobalConfigFileRoot(globalConfigRoot)
 	defer config.SetGlobalConfigFileRoot(oldConfigRoot)
 	globalLoggingPath := filepath.Join(globalConfigRoot, TelemetryConfigFilename)
 
-	_, err = os.Stat(globalLoggingPath)
+	_, err := os.Stat(globalLoggingPath)
 	a.True(os.IsNotExist(err))
 
 	cfgPath := "/missing-directory"
@@ -150,14 +144,12 @@ func TestSaveLoadConfig(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	a := require.New(t)
 
-	globalConfigRoot, err := ioutil.TempDir("", "globalConfigRoot")
-	defer os.RemoveAll(globalConfigRoot)
+	globalConfigRoot := t.TempDir()
 	oldConfigRoot := config.SetGlobalConfigFileRoot(globalConfigRoot)
 	defer config.SetGlobalConfigFileRoot(oldConfigRoot)
 
-	configDir, err := ioutil.TempDir("", "testdir")
-	os.RemoveAll(configDir)
-	err = os.Mkdir(configDir, 0777)
+	configDir := t.TempDir()
+	err := os.Mkdir(configDir, 0777)
 
 	cfg, err := EnsureTelemetryConfig(&configDir, "")
 	cfg.Name = "testname"
@@ -178,8 +170,6 @@ func TestSaveLoadConfig(t *testing.T) {
 	a.NoError(err)
 	a.Equal("testname", cfgLoad.Name)
 	a.Equal(cfgLoad, cfg)
-
-	os.RemoveAll(configDir)
 }
 
 func TestAsyncTelemetryHook_CloseDrop(t *testing.T) {

--- a/netdeploy/networkTemplates_test.go
+++ b/netdeploy/networkTemplates_test.go
@@ -17,7 +17,6 @@
 package netdeploy
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -60,12 +59,11 @@ func TestGenerateGenesis(t *testing.T) {
 	templateDir, _ := filepath.Abs("../test/testdata/nettemplates")
 	template, _ := loadTemplate(filepath.Join(templateDir, "David20.json"))
 
-	targetFolder, err := ioutil.TempDir("", "netroot")
-	defer os.RemoveAll(targetFolder)
+	targetFolder := t.TempDir()
 	networkName := "testGenGen"
 	binDir := os.ExpandEnv("${GOPATH}/bin")
 
-	err = template.generateGenesisAndWallets(targetFolder, networkName, binDir)
+	err := template.generateGenesisAndWallets(targetFolder, networkName, binDir)
 	a.NoError(err)
 	_, err = os.Stat(filepath.Join(targetFolder, config.GenesisJSONFile))
 	fileExists := err == nil

--- a/netdeploy/network_test.go
+++ b/netdeploy/network_test.go
@@ -17,7 +17,6 @@
 package netdeploy
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,8 +38,7 @@ func TestSaveNetworkCfg(t *testing.T) {
 		TemplateFile: "testTemplate",
 	}
 
-	tmpFolder, _ := ioutil.TempDir("", "tmp")
-	defer os.RemoveAll(tmpFolder)
+	tmpFolder := t.TempDir()
 	cfgFile := filepath.Join(tmpFolder, configFileName)
 	err := saveNetworkCfg(cfg, cfgFile)
 	a.Nil(err)
@@ -53,8 +51,7 @@ func TestSaveConsensus(t *testing.T) {
 
 	a := require.New(t)
 
-	tmpFolder, _ := ioutil.TempDir("", "tmp")
-	defer os.RemoveAll(tmpFolder)
+	tmpFolder := t.TempDir()
 	relayDir := filepath.Join(tmpFolder, "testRelayDir")
 	err := os.MkdirAll(relayDir, 0744)
 	a.NoError(err)

--- a/test/e2e-go/features/participation/accountParticipationTransitions_test.go
+++ b/test/e2e-go/features/participation/accountParticipationTransitions_test.go
@@ -22,8 +22,6 @@ package participation
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -40,12 +38,8 @@ import (
 
 // installParticipationKey generates a new key for a given account and installs it with the client.
 func installParticipationKey(t *testing.T, client libgoal.Client, addr string, firstValid, lastValid uint64) (resp generated.PostParticipationResponse, part account.Participation, err error) {
-	dir, err := ioutil.TempDir("", "temporary_partkey_dir")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
 	// Install overlapping participation keys...
-	part, filePath, err := client.GenParticipationKeysTo(addr, firstValid, lastValid, 100, dir)
+	part, filePath, err := client.GenParticipationKeysTo(addr, firstValid, lastValid, 100, t.TempDir())
 	require.NoError(t, err)
 	require.NotNil(t, filePath)
 	require.Equal(t, addr, part.Parent.String())

--- a/test/e2e-go/features/transactions/onlineStatusChange_test.go
+++ b/test/e2e-go/features/transactions/onlineStatusChange_test.go
@@ -18,8 +18,6 @@ package transactions
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -170,12 +168,8 @@ func TestCloseOnError(t *testing.T) {
 	// get the current round for partkey creation
 	_, curRound := fixture.GetBalanceAndRound(initiallyOnline)
 
-	tempDir, err := ioutil.TempDir(os.TempDir(), "test-close-on-error")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
-
 	var partkeyFile string
-	_, partkeyFile, err = client.GenParticipationKeysTo(initiallyOffline, 0, curRound+1000, 0, tempDir)
+	_, partkeyFile, err = client.GenParticipationKeysTo(initiallyOffline, 0, curRound+1000, 0, t.TempDir())
 
 	// make a participation key for initiallyOffline
 	_, err = client.AddParticipationKey(partkeyFile)

--- a/test/framework/fixtures/expectFixture.go
+++ b/test/framework/fixtures/expectFixture.go
@@ -19,7 +19,6 @@ package fixtures
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -46,8 +45,7 @@ func (ef *ExpectFixture) initialize(t *testing.T) (err error) {
 	ef.t = t
 	ef.testDir = os.Getenv("TESTDIR")
 	if ef.testDir == "" {
-		ef.testDir, _ = ioutil.TempDir("", "tmp")
-		ef.testDir = filepath.Join(ef.testDir, "expect")
+		ef.testDir = filepath.Join(t.TempDir(), "expect")
 		err = os.MkdirAll(ef.testDir, 0755)
 		if err != nil {
 			ef.t.Errorf("error creating test dir %s, with error %v", ef.testDir, err)

--- a/util/db/dbutil_test.go
+++ b/util/db/dbutil_test.go
@@ -21,7 +21,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -241,11 +240,7 @@ func TestDBConcurrencyRW(t *testing.T) {
 	dbFolder := "/dev/shm"
 	os := runtime.GOOS
 	if os == "darwin" {
-		var err error
-		dbFolder, err = ioutil.TempDir("", "TestDBConcurrencyRW")
-		if err != nil {
-			panic(err)
-		}
+		dbFolder = t.TempDir()
 	}
 
 	fn := fmt.Sprintf("/%s.%d.sqlite3", t.Name(), crypto.RandUint64())


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
