### PR TITLE
AVM: Added the TypeEnum table back to docs

### DIFF
--- a/data/transactions/logic/README.md
+++ b/data/transactions/logic/README.md
@@ -441,7 +441,7 @@ Some of these have immediate data in the byte or bytes after the opcode.
 | 13 | VoteLast | uint64 |      | The last round that the participation key is valid. |
 | 14 | VoteKeyDilution | uint64 |      | Dilution for the 2-level participation key |
 | 15 | Type | []byte |      | Transaction type as bytes |
-| 16 | TypeEnum | uint64 |      | See table below |
+| 16 | TypeEnum | uint64 |      | Transaction type as enum |
 | 17 | XferAsset | uint64 |      | Asset ID |
 | 18 | AssetAmount | uint64 |      | value in Asset's units |
 | 19 | AssetSender | []byte |      | 32 byte address. Moves asset from AssetSender if Sender is the Clawback address of the asset. |

--- a/data/transactions/logic/TEAL_opcodes.md
+++ b/data/transactions/logic/TEAL_opcodes.md
@@ -431,6 +431,19 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 | 67 | NumClearStateProgramPages | uint64 | v7  | Number of ClearState Program pages |
 
 
+TypeEnum mapping:
+
+| Index | "Type" string | Description |
+| --- | --- | --- |
+| 0 | unknown | Unknown type. Invalid transaction |
+| 1 | pay | Payment |
+| 2 | keyreg | KeyRegistration |
+| 3 | acfg | AssetConfig |
+| 4 | axfer | AssetTransfer |
+| 5 | afrz | AssetFreeze |
+| 6 | appl | ApplicationCall |
+
+
 FirstValidTime causes the program to fail. The field is reserved for future use.
 
 ## global f

--- a/data/transactions/logic/TEAL_opcodes.md
+++ b/data/transactions/logic/TEAL_opcodes.md
@@ -377,7 +377,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 | 13 | VoteLast | uint64 |      | The last round that the participation key is valid. |
 | 14 | VoteKeyDilution | uint64 |      | Dilution for the 2-level participation key |
 | 15 | Type | []byte |      | Transaction type as bytes |
-| 16 | TypeEnum | uint64 |      | See table below |
+| 16 | TypeEnum | uint64 |      | Transaction type as enum |
 | 17 | XferAsset | uint64 |      | Asset ID |
 | 18 | AssetAmount | uint64 |      | value in Asset's units |
 | 19 | AssetSender | []byte |      | 32 byte address. Moves asset from AssetSender if Sender is the Clawback address of the asset. |
@@ -431,20 +431,9 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 | 67 | NumClearStateProgramPages | uint64 | v7  | Number of ClearState Program pages |
 
 
-TypeEnum mapping:
-
-| Index | "Type" string | Description |
-| --- | --- | --- |
-| 0 | unknown | Unknown type. Invalid transaction |
-| 1 | pay | Payment |
-| 2 | keyreg | KeyRegistration |
-| 3 | acfg | AssetConfig |
-| 4 | axfer | AssetTransfer |
-| 5 | afrz | AssetFreeze |
-| 6 | appl | ApplicationCall |
-
-
 FirstValidTime causes the program to fail. The field is reserved for future use.
+
+For TypeEnum values see <a href="https://developer.algorand.org/docs/get-details/dapps/avm/teal/specification/#typeenum-constants">Named Integer Constants</a> (TypeEnum constants).
 
 ## global f
 

--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -284,7 +284,7 @@ var opDocExtras = map[string]string{
 	"bitlen":              "bitlen interprets arrays as big-endian integers, unlike setbit/getbit",
 	"divw":                "The notation A,B indicates that A and B are interpreted as a uint128 value, with A as the high uint64 and B the low.",
 	"divmodw":             "The notation J,K indicates that two uint64 values J and K are interpreted as a uint128 value, with J as the high uint64 and K the low.",
-	"txn":                 "FirstValidTime causes the program to fail. The field is reserved for future use.",
+	"txn":                 "FirstValidTime causes the program to fail. The field is reserved for future use.\n\nFor TypeEnum values see <a href=\"https://developer.algorand.org/docs/get-details/dapps/avm/teal/specification/#typeenum-constants\">Named Integer Constants</a> (TypeEnum constants).",
 	"gtxn":                "for notes on transaction fields available, see `txn`. If this transaction is _i_ in the group, `gtxn i field` is equivalent to `txn field`.",
 	"gtxns":               "for notes on transaction fields available, see `txn`. If top of stack is _i_, `gtxns field` is equivalent to `gtxn _i_ field`. gtxns exists so that _i_ can be calculated, often based on the index of the current transaction.",
 	"gload":               "`gload` fails unless the requested transaction is an ApplicationCall and T < GroupIndex.",

--- a/data/transactions/logic/fields.go
+++ b/data/transactions/logic/fields.go
@@ -283,7 +283,7 @@ var txnFieldSpecs = [...]txnFieldSpec{
 	{VoteLast, StackUint64, false, 0, 6, false, "The last round that the participation key is valid."},
 	{VoteKeyDilution, StackUint64, false, 0, 6, false, "Dilution for the 2-level participation key"},
 	{Type, StackBytes, false, 0, 5, false, "Transaction type as bytes"},
-	{TypeEnum, StackUint64, false, 0, 5, false, "See table below"},
+	{TypeEnum, StackUint64, false, 0, 5, false, "Transaction type as enum"},
 	{XferAsset, StackUint64, false, 0, 5, false, "Asset ID"},
 	{AssetAmount, StackUint64, false, 0, 5, false, "value in Asset's units"},
 	{AssetSender, StackBytes, false, 0, 5, false,

--- a/data/transactions/logic/langspec.json
+++ b/data/transactions/logic/langspec.json
@@ -616,7 +616,7 @@
       ],
       "ArgEnumTypes": "BUUUUBBBUBBBUUUBUUUBBBUBUUBUBUBBBUUUUBBBBBBBBUBUUUUUUUUUUUBUUUBBBUBU",
       "Doc": "field F of current transaction",
-      "DocExtra": "FirstValidTime causes the program to fail. The field is reserved for future use.",
+      "DocExtra": "FirstValidTime causes the program to fail. The field is reserved for future use.\n\nFor TypeEnum values see \u003ca href=\"https://developer.algorand.org/docs/get-details/dapps/avm/teal/specification/#typeenum-constants\"\u003eNamed Integer Constants\u003c/a\u003e (TypeEnum constants).",
       "ImmediateNote": "{uint8 transaction field index}",
       "Groups": [
         "Loading Values"


### PR DESCRIPTION
The TypeEnum table appears to have been removed in https://github.com/algorand/go-algorand/commit/95c5b0ec466214c73c5108343635738e13360700 which I believe was a mistake?