### PR TITLE
AVM: Document what the field _is_ rather than pointer to table

### DIFF
--- a/data/transactions/logic/README.md
+++ b/data/transactions/logic/README.md
@@ -441,7 +441,7 @@ Some of these have immediate data in the byte or bytes after the opcode.
 | 13 | VoteLast | uint64 |      | The last round that the participation key is valid. |
 | 14 | VoteKeyDilution | uint64 |      | Dilution for the 2-level participation key |
 | 15 | Type | []byte |      | Transaction type as bytes |
-| 16 | TypeEnum | uint64 |      | See table below |
+| 16 | TypeEnum | uint64 |      | Transaction type as integer |
 | 17 | XferAsset | uint64 |      | Asset ID |
 | 18 | AssetAmount | uint64 |      | value in Asset's units |
 | 19 | AssetSender | []byte |      | 32 byte address. Moves asset from AssetSender if Sender is the Clawback address of the asset. |

--- a/data/transactions/logic/TEAL_opcodes.md
+++ b/data/transactions/logic/TEAL_opcodes.md
@@ -377,7 +377,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 | 13 | VoteLast | uint64 |      | The last round that the participation key is valid. |
 | 14 | VoteKeyDilution | uint64 |      | Dilution for the 2-level participation key |
 | 15 | Type | []byte |      | Transaction type as bytes |
-| 16 | TypeEnum | uint64 |      | See table below |
+| 16 | TypeEnum | uint64 |      | Transaction type as integer |
 | 17 | XferAsset | uint64 |      | Asset ID |
 | 18 | AssetAmount | uint64 |      | value in Asset's units |
 | 19 | AssetSender | []byte |      | 32 byte address. Moves asset from AssetSender if Sender is the Clawback address of the asset. |

--- a/data/transactions/logic/fields.go
+++ b/data/transactions/logic/fields.go
@@ -283,7 +283,7 @@ var txnFieldSpecs = [...]txnFieldSpec{
 	{VoteLast, StackUint64, false, 0, 6, false, "The last round that the participation key is valid."},
 	{VoteKeyDilution, StackUint64, false, 0, 6, false, "Dilution for the 2-level participation key"},
 	{Type, StackBytes, false, 0, 5, false, "Transaction type as bytes"},
-	{TypeEnum, StackUint64, false, 0, 5, false, "See table below"},
+	{TypeEnum, StackUint64, false, 0, 5, false, "Transaction type as integer"},
 	{XferAsset, StackUint64, false, 0, 5, false, "Asset ID"},
 	{AssetAmount, StackUint64, false, 0, 5, false, "value in Asset's units"},
 	{AssetSender, StackBytes, false, 0, 5, false,


### PR DESCRIPTION
doc change only (table has been moved, so pointer to it was wrong) better to describe the field anyway