### PR TITLE
testing: fix TestParticipationDB_Locking

### DIFF
--- a/data/account/participationRegistry_test.go
+++ b/data/account/participationRegistry_test.go
@@ -17,6 +17,7 @@
 package account
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/binary"
@@ -26,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync/atomic"
 
 	"strings"
 	"sync"
@@ -1047,10 +1049,16 @@ func TestParticipationDB_Locking(t *testing.T) {
 
 	dbName := strings.Replace(t.Name(), "/", "_", -1)
 
-	dbfile, err := db.OpenErasablePair(dbName + ".sqlite3")
+	dbpair, err := db.OpenErasablePair(dbName + ".sqlite3")
 	a.NoError(err)
 
-	registry, err := makeParticipationRegistry(dbfile, logging.TestingLog(t))
+	var bufNewLogger bytes.Buffer
+	log := logging.NewLogger()
+	log.SetLevel(logging.Warn)
+	log.SetOutput(&bufNewLogger)
+	dbpair.Rdb.SetLogger(log)
+
+	registry, err := makeParticipationRegistry(dbpair, logging.TestingLog(t))
 	require.NoError(t, err)
 	require.NotNil(t, registry)
 
@@ -1069,20 +1077,40 @@ func TestParticipationDB_Locking(t *testing.T) {
 		a.Equal(id, part.ID())
 	}
 
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	var flushCount int32
+	const targetFlushes = 5
 	go func() {
-		for i := 0; i < 100; i++ {
+		for i := 0; i < 25; i++ {
 			registry.DeleteExpired(basics.Round(i), config.Consensus[protocol.ConsensusFuture])
 			registry.Flush(defaultTimeout)
+			if atomic.LoadInt32(&flushCount) < targetFlushes {
+				atomic.AddInt32(&flushCount, 1)
+			}
 		}
+		wg.Done()
 	}()
 
-	for i := 0; i < 50; i++ {
-		time.Sleep(time.Second / 2)
+	for i := 0; i < 25; i++ {
+	repeat:
+		// to not start lookup until deleted some keys
+		if atomic.LoadInt32(&flushCount) < targetFlushes {
+			time.Sleep(time.Second)
+			goto repeat
+		}
 		_, err = registry.GetStateProofForRound(id2, basics.Round(256))
 		// The error we're trying to avoid is "database is locked", since we're reading from StateProofKeys table,
 		// while the main thread is updating the Rolling table.
 		a.NoError(err)
+		time.Sleep(100 * time.Millisecond)
 	}
+
+	warnings := bufNewLogger.String()
+	deadlineCount := strings.Count(warnings, "tx surpassed expected deadline")
+	a.Empty(deadlineCount, fmt.Sprintf("found %d messages 'tx surpassed expected deadline' but expected 0", deadlineCount))
+	wg.Wait()
 }
 
 // based on BenchmarkOldKeysDeletion


### PR DESCRIPTION
## Summary

* Prevent the main thread quitting before the flush routine
* Make the test more robust by counting warning messages
* Cut the execution time few times by reducing number of iterations

## Test Plan

This is a test fix.