### PR TITLE
codec: new TxHandler byte decoder

### DIFF
--- a/cmd/algokey/multisig.go
+++ b/cmd/algokey/multisig.go
@@ -73,7 +73,7 @@ var multisigCmd = &cobra.Command{
 		}
 
 		var outBytes []byte
-		dec := protocol.NewDecoderBytes(txdata)
+		dec := protocol.NewMsgpDecoderBytes(txdata)
 		for {
 			var stxn transactions.SignedTxn
 			err = dec.Decode(&stxn)
@@ -123,7 +123,7 @@ var appendAuthAddrCmd = &cobra.Command{
 		}
 
 		var outBytes []byte
-		dec := protocol.NewDecoderBytes(txdata)
+		dec := protocol.NewMsgpDecoderBytes(txdata)
 
 		var stxn transactions.SignedTxn
 		err = dec.Decode(&stxn)

--- a/cmd/algokey/sign.go
+++ b/cmd/algokey/sign.go
@@ -59,7 +59,7 @@ var signCmd = &cobra.Command{
 		}
 
 		var outBytes []byte
-		dec := protocol.NewDecoderBytes(txdata)
+		dec := protocol.NewMsgpDecoderBytes(txdata)
 		for {
 			var stxn transactions.SignedTxn
 			err = dec.Decode(&stxn)

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -544,7 +544,7 @@ var rawsendCmd = &cobra.Command{
 			reportErrorf(fileReadError, txFilename, err)
 		}
 
-		dec := protocol.NewDecoderBytes(data)
+		dec := protocol.NewMsgpDecoderBytes(data)
 		client := ensureAlgodClient(ensureSingleDataDir())
 
 		txnIDs := make(map[transactions.Txid]transactions.SignedTxn)
@@ -673,7 +673,7 @@ var inspectCmd = &cobra.Command{
 				reportErrorf(fileReadError, txFilename, err)
 			}
 
-			dec := protocol.NewDecoderBytes(data)
+			dec := protocol.NewMsgpDecoderBytes(data)
 			count := 0
 			for {
 				var txn transactions.SignedTxn
@@ -773,7 +773,7 @@ var signCmd = &cobra.Command{
 		}
 
 		var outData []byte
-		dec := protocol.NewDecoderBytes(data)
+		dec := protocol.NewMsgpDecoderBytes(data)
 		// read the entire file and prepare in-memory copy of each signed transaction, with grouping.
 		txnGroups := make(map[crypto.Digest][]*transactions.SignedTxn)
 		var groupsOrder []crypto.Digest
@@ -868,7 +868,7 @@ var groupCmd = &cobra.Command{
 			reportErrorf(fileReadError, txFilename, err)
 		}
 
-		dec := protocol.NewDecoderBytes(data)
+		dec := protocol.NewMsgpDecoderBytes(data)
 
 		var stxns []transactions.SignedTxn
 		var group transactions.TxGroup
@@ -920,7 +920,7 @@ var splitCmd = &cobra.Command{
 			reportErrorf(fileReadError, txFilename, err)
 		}
 
-		dec := protocol.NewDecoderBytes(data)
+		dec := protocol.NewMsgpDecoderBytes(data)
 
 		var txns []transactions.SignedTxn
 		for {
@@ -1120,7 +1120,7 @@ var dryrunCmd = &cobra.Command{
 		if err != nil {
 			reportErrorf(fileReadError, txFilename, err)
 		}
-		dec := protocol.NewDecoderBytes(data)
+		dec := protocol.NewMsgpDecoderBytes(data)
 		stxns := make([]transactions.SignedTxn, 0, 10)
 		for {
 			var txn transactions.SignedTxn

--- a/cmd/goal/multisig.go
+++ b/cmd/goal/multisig.go
@@ -96,7 +96,7 @@ var addSigCmd = &cobra.Command{
 		wh, pw := ensureWalletHandleMaybePassword(dataDir, walletName, true)
 
 		var outData []byte
-		dec := protocol.NewDecoderBytes(data)
+		dec := protocol.NewMsgpDecoderBytes(data)
 		for {
 			var stxn transactions.SignedTxn
 			err = dec.Decode(&stxn)
@@ -245,7 +245,7 @@ var mergeSigCmd = &cobra.Command{
 				reportErrorf(fileReadError, arg, err)
 			}
 
-			dec := protocol.NewDecoderBytes(data)
+			dec := protocol.NewMsgpDecoderBytes(data)
 			var txns []transactions.SignedTxn
 			for {
 				var txn transactions.SignedTxn

--- a/cmd/tealdbg/local.go
+++ b/cmd/tealdbg/local.go
@@ -73,7 +73,7 @@ func txnGroupFromParams(dp *DebugParams) (txnGroup []transactions.SignedTxn, err
 	}
 
 	// 3. Attempt msgp - array of transactions
-	dec := protocol.NewDecoderBytes(data)
+	dec := protocol.NewMsgpDecoderBytes(data)
 	for {
 		var txn transactions.SignedTxn
 		err = dec.Decode(&txn)
@@ -124,7 +124,7 @@ func balanceRecordsFromParams(dp *DebugParams) (records []basics.BalanceRecord, 
 	}
 
 	// 3. Attempt msgp - a array of records
-	dec := protocol.NewDecoderBytes(data)
+	dec := protocol.NewMsgpDecoderBytes(data)
 	for {
 		var record basics.BalanceRecord
 		err = dec.Decode(&record)

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -265,11 +265,13 @@ func (handler *TxHandler) processIncomingTxn(rawmsg network.IncomingMessage) net
 // Note that this also checks the consistency of the transaction's group hash,
 // which is required for safe transaction signature caching behavior.
 func (handler *TxHandler) checkAlreadyCommitted(tx *txBacklogMsg) (processingDone bool) {
-	txids := make([]transactions.Txid, len(tx.unverifiedTxGroup))
-	for i := range tx.unverifiedTxGroup {
-		txids[i] = tx.unverifiedTxGroup[i].ID()
+	if logging.Base().IsLevelEnabled(logging.Debug) {
+		txids := make([]transactions.Txid, len(tx.unverifiedTxGroup))
+		for i := range tx.unverifiedTxGroup {
+			txids[i] = tx.unverifiedTxGroup[i].ID()
+		}
+		logging.Base().Debugf("got a tx group with IDs %v", txids)
 	}
-	logging.Base().Debugf("got a tx group with IDs %v", txids)
 
 	// do a quick test to check that this transaction could potentially be committed, to reject dup pending transactions
 	err := handler.txPool.Test(tx.unverifiedTxGroup)

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -219,7 +219,7 @@ func (handler *TxHandler) asyncVerifySignature(arg interface{}) interface{} {
 }
 
 func (handler *TxHandler) processIncomingTxn(rawmsg network.IncomingMessage) network.OutgoingMessage {
-	dec := protocol.NewDecoderBytes(rawmsg.Data)
+	dec := protocol.NewMsgpDecoderBytes(rawmsg.Data)
 	ntx := 0
 	unverifiedTxGroup := make([]transactions.SignedTxn, 1)
 	for {

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -35,13 +35,13 @@ import (
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/algorand/go-algorand/util/execpool"
 )
 
 func BenchmarkTxHandlerProcessDecoded(b *testing.B) {
 	b.StopTimer()
 	b.ResetTimer()
-	const numRounds = 10
 	const numUsers = 100
 	log := logging.TestingLog(b)
 	log.SetLevel(logging.Warn)
@@ -156,6 +156,8 @@ func makeRandomTransactions(num int) ([]transactions.SignedTxn, []byte) {
 }
 
 func TestTxHandlerProcessIncomingTxn(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	const numTxns = 11
 	handler := TxHandler{
 		backlogQueue: make(chan *txBacklogMsg, 1),

--- a/protocol/codec.go
+++ b/protocol/codec.go
@@ -47,11 +47,6 @@ type Decoder interface {
 	Decode(objptr interface{}) error
 }
 
-// MsgpDecoder is our interface for a thing that can msgp-decode objects.
-type MsgpDecoder interface {
-	Decode(objptr msgp.Unmarshaler) error
-}
-
 func init() {
 	CodecHandle = new(codec.MsgpackHandle)
 	CodecHandle.ErrorIfNoField = true
@@ -253,18 +248,18 @@ func NewDecoderBytes(b []byte) Decoder {
 
 // NewMsgpDecoderBytes returns a decoder object reading bytes from [b].
 // that works with msgp-serialized objects
-func NewMsgpDecoderBytes(b []byte) MsgpDecoder {
-	return &MsgpDecoderBytes{b: b, pos: 0}
+func NewMsgpDecoderBytes(b []byte) *msgpDecoderBytes {
+	return &msgpDecoderBytes{b: b, pos: 0}
 }
 
-// MsgpDecoderBytes is a []byte decoder into msgp-encoded objects
-type MsgpDecoderBytes struct {
+// msgpDecoderBytes is a []byte decoder into msgp-encoded objects
+type msgpDecoderBytes struct {
 	b   []byte
 	pos int
 }
 
 // Decode an objptr from from a byte stream
-func (d *MsgpDecoderBytes) Decode(objptr msgp.Unmarshaler) error {
+func (d *msgpDecoderBytes) Decode(objptr msgp.Unmarshaler) error {
 	if !objptr.CanUnmarshalMsg(objptr) {
 		return fmt.Errorf("object %T cannot be msgp-unmashalled", objptr)
 	}

--- a/protocol/codec.go
+++ b/protocol/codec.go
@@ -47,6 +47,11 @@ type Decoder interface {
 	Decode(objptr interface{}) error
 }
 
+// MsgpDecoder is our interface for a thing that can msgp-decode objects.
+type MsgpDecoder interface {
+	Decode(objptr msgp.Unmarshaler) error
+}
+
 func init() {
 	CodecHandle = new(codec.MsgpackHandle)
 	CodecHandle.ErrorIfNoField = true
@@ -248,11 +253,7 @@ func NewDecoderBytes(b []byte) Decoder {
 
 // NewMsgpDecoderBytes returns a decoder object reading bytes from [b].
 // that works with msgp-serialized objects
-func NewMsgpDecoderBytes(b []byte) *MsgpDecoderBytes {
-	return newMsgpDecoderBytes(b, CodecHandle)
-}
-
-func newMsgpDecoderBytes(b []byte, h codec.Handle) *MsgpDecoderBytes {
+func NewMsgpDecoderBytes(b []byte) MsgpDecoder {
 	return &MsgpDecoderBytes{b: b, pos: 0}
 }
 

--- a/protocol/codec.go
+++ b/protocol/codec.go
@@ -246,6 +246,37 @@ func NewDecoderBytes(b []byte) Decoder {
 	return codec.NewDecoderBytes(b, CodecHandle)
 }
 
+// NewMsgpDecoderBytes returns a decoder object reading bytes from [b].
+// that works with msgp-serialized objects
+func NewMsgpDecoderBytes(b []byte) *MsgpDecoderBytes {
+	return newMsgpDecoderBytes(b, CodecHandle)
+}
+
+func newMsgpDecoderBytes(b []byte, h codec.Handle) *MsgpDecoderBytes {
+	return &MsgpDecoderBytes{b: b, pos: 0}
+}
+
+type MsgpDecoderBytes struct {
+	b   []byte
+	pos int
+}
+
+func (d *MsgpDecoderBytes) Decode(objptr msgp.Unmarshaler) error {
+	if !objptr.CanUnmarshalMsg(objptr) {
+		return fmt.Errorf("object %T cannot be msgp-unmashalled", objptr)
+	}
+	if d.pos >= len(d.b) {
+		return io.EOF
+	}
+
+	rem, err := objptr.UnmarshalMsg(d.b[d.pos:])
+	if err != nil {
+		return err
+	}
+	d.pos = (len(d.b) - len(rem))
+	return nil
+}
+
 // encodingPool holds temporary byte slice buffers used for encoding messages.
 var encodingPool = sync.Pool{
 	New: func() interface{} {

--- a/protocol/codec.go
+++ b/protocol/codec.go
@@ -256,11 +256,13 @@ func newMsgpDecoderBytes(b []byte, h codec.Handle) *MsgpDecoderBytes {
 	return &MsgpDecoderBytes{b: b, pos: 0}
 }
 
+// MsgpDecoderBytes is a []byte decoder into msgp-encoded objects
 type MsgpDecoderBytes struct {
 	b   []byte
 	pos int
 }
 
+// Decode an objptr from from a byte stream
 func (d *MsgpDecoderBytes) Decode(objptr msgp.Unmarshaler) error {
 	if !objptr.CanUnmarshalMsg(objptr) {
 		return fmt.Errorf("object %T cannot be msgp-unmashalled", objptr)

--- a/protocol/codec.go
+++ b/protocol/codec.go
@@ -248,18 +248,18 @@ func NewDecoderBytes(b []byte) Decoder {
 
 // NewMsgpDecoderBytes returns a decoder object reading bytes from [b].
 // that works with msgp-serialized objects
-func NewMsgpDecoderBytes(b []byte) *msgpDecoderBytes {
-	return &msgpDecoderBytes{b: b, pos: 0}
+func NewMsgpDecoderBytes(b []byte) *MsgpDecoderBytes {
+	return &MsgpDecoderBytes{b: b, pos: 0}
 }
 
-// msgpDecoderBytes is a []byte decoder into msgp-encoded objects
-type msgpDecoderBytes struct {
+// MsgpDecoderBytes is a []byte decoder into msgp-encoded objects
+type MsgpDecoderBytes struct {
 	b   []byte
 	pos int
 }
 
 // Decode an objptr from from a byte stream
-func (d *msgpDecoderBytes) Decode(objptr msgp.Unmarshaler) error {
+func (d *MsgpDecoderBytes) Decode(objptr msgp.Unmarshaler) error {
 	if !objptr.CanUnmarshalMsg(objptr) {
 		return fmt.Errorf("object %T cannot be msgp-unmashalled", objptr)
 	}

--- a/protocol/codec_test.go
+++ b/protocol/codec_test.go
@@ -204,6 +204,8 @@ func TestEncodeJSON(t *testing.T) {
 }
 
 func TestMsgpDecode(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	var tag Tag = "test"
 	dec := NewMsgpDecoderBytes([]byte{1, 2, 3})
 	err := dec.Decode(&tag)

--- a/protocol/codec_tester.go
+++ b/protocol/codec_tester.go
@@ -150,7 +150,7 @@ func checkMsgpAllocBoundDirective(dataType reflect.Type) bool {
 		if err != nil {
 			continue
 		}
-		if strings.Index(string(fileBytes), fmt.Sprintf("msgp:allocbound %s", dataType.Name())) != -1 {
+		if strings.Contains(string(fileBytes), fmt.Sprintf("msgp:allocbound %s", dataType.Name())) {
 			// message pack alloc bound definition was found.
 			return true
 		}

--- a/test/e2e-go/cli/goal/expect/goalFormattingTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalFormattingTest.exp
@@ -26,7 +26,7 @@ if { [catch {
             set NON_PRINTABLE_CHARS_WARNING 1
             exp_continue
         }
-        {Cannot decode transactions from *: msgpack decode error \[pos 33\]: no matching struct field found when decoding stream map with key \[0G\[0K\[33munexpected_key\[0m} {
+        {Cannot decode transactions from *: Unknown field: \[0G\[0K\[33munexpected_key\[0m} {
             set CANNOT_DECODE_MESSAGE 1
             exp_continue
         }

--- a/tools/debug/algodump/main.go
+++ b/tools/debug/algodump/main.go
@@ -99,7 +99,7 @@ func (dh *dumpHandler) Handle(msg network.IncomingMessage) network.OutgoingMessa
 		data = fmt.Sprintf("proposal %s", shortdigest(crypto.Digest(p.Block.Hash())))
 
 	case protocol.TxnTag:
-		dec := protocol.NewDecoderBytes(msg.Data)
+		dec := protocol.NewMsgpDecoderBytes(msg.Data)
 		for {
 			var stx transactions.SignedTxn
 			err := dec.Decode(&stx)


### PR DESCRIPTION
## Summary

Use msgp marshaller instead of reflect in TxHandler

```
BenchmarkTxHandlerDecoder-8       	      68	  17116004 ns/op	 3335105 B/op	   51105 allocs/op
BenchmarkTxHandlerDecoderMsgp-8   	     122	  10213123 ns/op	 1189860 B/op	     614 allocs/op
```

```
BenchmarkTxHandlerProcessDecoded-8   	   62826	     19184 ns/op	    8956 B/op	      57 allocs/op
vs old
BenchmarkTxHandlerProcessDecoded-8   	   47414	     21560 ns/op	    8957 B/op	      57 allocs/op
```

## Test Plan

TODO: write tests