### PR TITLE
Allow algod client to pass in max box-names number

### DIFF
--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -427,14 +427,12 @@ type applicationBoxesParams struct {
 }
 
 // ApplicationBoxes gets the BoxesResponse associated with the passed application ID
-func (client RestClient) ApplicationBoxes(appID uint64, optionalMaxBoxNum ...uint64) (response generatedV2.BoxesResponse, err error) {
-	if len(optionalMaxBoxNum) == 0 {
-		err = client.get(&response, fmt.Sprintf("/v2/applications/%d/boxes", appID), nil)
-	} else if len(optionalMaxBoxNum) == 1 {
-		err = client.get(&response, fmt.Sprintf("/v2/applications/%d/boxes", appID), applicationBoxesParams{&optionalMaxBoxNum[0]})
-	} else {
-		err = fmt.Errorf("unexpected argument numbers %d, only allowing at most 1 uint64 args for boxesLimit", len(optionalMaxBoxNum))
+func (client RestClient) ApplicationBoxes(appID uint64, maxBoxNum uint64) (response generatedV2.BoxesResponse, err error) {
+	var request interface{} = nil
+	if maxBoxNum > 0 {
+		request = applicationBoxesParams{&maxBoxNum}
 	}
+	err = client.get(&response, fmt.Sprintf("/v2/applications/%d/boxes", appID), request)
 	return
 }
 

--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -422,9 +422,19 @@ func (client RestClient) AccountInformation(address string) (response v1.Account
 	return
 }
 
+type applicationBoxesParams struct {
+	Max *uint64 `url:"max,omitempty"`
+}
+
 // ApplicationBoxes gets the BoxesResponse associated with the passed application ID
-func (client RestClient) ApplicationBoxes(appID uint64) (response generatedV2.BoxesResponse, err error) {
-	err = client.get(&response, fmt.Sprintf("/v2/applications/%d/boxes", appID), nil)
+func (client RestClient) ApplicationBoxes(appID uint64, optionalMaxBoxNum ...uint64) (response generatedV2.BoxesResponse, err error) {
+	if len(optionalMaxBoxNum) == 0 {
+		err = client.get(&response, fmt.Sprintf("/v2/applications/%d/boxes", appID), nil)
+	} else if len(optionalMaxBoxNum) == 1 {
+		err = client.get(&response, fmt.Sprintf("/v2/applications/%d/boxes", appID), applicationBoxesParams{&optionalMaxBoxNum[0]})
+	} else {
+		err = fmt.Errorf("unexpected argument numbers %d, only allowing at most 1 uint64 args for boxesLimit", len(optionalMaxBoxNum))
+	}
 	return
 }
 

--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -423,16 +423,12 @@ func (client RestClient) AccountInformation(address string) (response v1.Account
 }
 
 type applicationBoxesParams struct {
-	Max *uint64 `url:"max,omitempty"`
+	Max uint64 `url:"max,omitempty"`
 }
 
 // ApplicationBoxes gets the BoxesResponse associated with the passed application ID
 func (client RestClient) ApplicationBoxes(appID uint64, maxBoxNum uint64) (response generatedV2.BoxesResponse, err error) {
-	var request interface{} = nil
-	if maxBoxNum > 0 {
-		request = applicationBoxesParams{&maxBoxNum}
-	}
-	err = client.get(&response, fmt.Sprintf("/v2/applications/%d/boxes", appID), request)
+	err = client.get(&response, fmt.Sprintf("/v2/applications/%d/boxes", appID), applicationBoxesParams{maxBoxNum})
 	return
 }
 

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -777,10 +777,10 @@ func (c *Client) ApplicationInformation(index uint64) (resp generatedV2.Applicat
 }
 
 // ApplicationBoxes takes an app's index and returns the names of boxes under it
-func (c *Client) ApplicationBoxes(appID uint64, optionalMaxBoxNum ...uint64) (resp generatedV2.BoxesResponse, err error) {
+func (c *Client) ApplicationBoxes(appID uint64, maxBoxNum uint64) (resp generatedV2.BoxesResponse, err error) {
 	algod, err := c.ensureAlgodClient()
 	if err == nil {
-		resp, err = algod.ApplicationBoxes(appID, optionalMaxBoxNum...)
+		resp, err = algod.ApplicationBoxes(appID, maxBoxNum)
 	}
 	return
 }

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -777,10 +777,10 @@ func (c *Client) ApplicationInformation(index uint64) (resp generatedV2.Applicat
 }
 
 // ApplicationBoxes takes an app's index and returns the names of boxes under it
-func (c *Client) ApplicationBoxes(index uint64) (resp generatedV2.BoxesResponse, err error) {
+func (c *Client) ApplicationBoxes(appID uint64, optionalMaxBoxNum ...uint64) (resp generatedV2.BoxesResponse, err error) {
 	algod, err := c.ensureAlgodClient()
 	if err == nil {
-		resp, err = algod.ApplicationBoxes(index)
+		resp, err = algod.ApplicationBoxes(appID, optionalMaxBoxNum...)
 	}
 	return
 }

--- a/test/e2e-go/restAPI/restClient_test.go
+++ b/test/e2e-go/restAPI/restClient_test.go
@@ -1476,6 +1476,11 @@ end:
 		operateAndMatchRes("create", strSliceTest)
 	}
 
+	maxBoxNumToGet := uint64(10)
+	resp, err = testClient.ApplicationBoxes(uint64(createdAppID), maxBoxNumToGet)
+	a.NoError(err)
+	a.Len(resp.Boxes, int(maxBoxNumToGet))
+
 	for i := 0; i < len(testingBoxNames); i += 16 {
 		var strSliceTest []string
 		// grouping box names to operate, and delete such boxes

--- a/test/e2e-go/restAPI/restClient_test.go
+++ b/test/e2e-go/restAPI/restClient_test.go
@@ -1415,7 +1415,7 @@ end:
 		}
 
 		var resp generated.BoxesResponse
-		resp, err = testClient.ApplicationBoxes(uint64(createdAppID))
+		resp, err = testClient.ApplicationBoxes(uint64(createdAppID), 0)
 		a.NoError(err)
 		a.Equal(createdBoxCount, uint64(len(resp.Boxes)))
 		for _, b := range resp.Boxes {
@@ -1461,7 +1461,7 @@ end:
 		`∑´´˙©˚¬∆ßåƒ√¬`,
 	}
 
-	resp, err := testClient.ApplicationBoxes(uint64(createdAppID))
+	resp, err := testClient.ApplicationBoxes(uint64(createdAppID), 0)
 	a.NoError(err)
 	a.Empty(resp.Boxes)
 
@@ -1492,7 +1492,7 @@ end:
 		operateAndMatchRes("delete", strSliceTest)
 	}
 
-	resp, err = testClient.ApplicationBoxes(uint64(createdAppID))
+	resp, err = testClient.ApplicationBoxes(uint64(createdAppID), 0)
 	a.NoError(err)
 	a.Empty(resp.Boxes)
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

The discussion for passing in max box-names exists in here: https://github.com/algorand/go-algorand/pull/4165#discussion_r922398029

The goal of this PR is to extend restClient method `ApplicationBoxes` to accept argument `maxBoxNum` (if `maxBoxNum == 0`, then return all box names).