### PR TITLE
Broken build:  Fix struct initialization with promoted field

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -556,10 +556,18 @@ func TestOfflineOnlineClosedBitStatus(t *testing.T) {
 		acctData    basics.OnlineAccountData
 		expectedInt int
 	}{
-		{"online 1", basics.OnlineAccountData{VoteFirstValid: 1, VoteLastValid: 100, MicroAlgosWithRewards: basics.MicroAlgos{Raw: 0}}, 0},
-		{"online 2", basics.OnlineAccountData{VoteFirstValid: 1, VoteLastValid: 100, MicroAlgosWithRewards: basics.MicroAlgos{Raw: 1}}, 0},
-		{"offline & not closed", basics.OnlineAccountData{VoteFirstValid: 0, VoteLastValid: 0, MicroAlgosWithRewards: basics.MicroAlgos{Raw: 1}}, 0 | bitAccountOffline},
-		{"offline & closed", basics.OnlineAccountData{VoteFirstValid: 0, VoteLastValid: 0, MicroAlgosWithRewards: basics.MicroAlgos{Raw: 0}}, 0 | bitAccountOffline | bitAccountIsClosed},
+		{"online 1", basics.OnlineAccountData{
+			VotingData:            basics.VotingData{VoteFirstValid: 1, VoteLastValid: 100},
+			MicroAlgosWithRewards: basics.MicroAlgos{Raw: 0}}, 0},
+		{"online 2", basics.OnlineAccountData{
+			VotingData:            basics.VotingData{VoteFirstValid: 1, VoteLastValid: 100},
+			MicroAlgosWithRewards: basics.MicroAlgos{Raw: 1}}, 0},
+		{"offline & not closed", basics.OnlineAccountData{
+			VotingData:            basics.VotingData{VoteFirstValid: 0, VoteLastValid: 0},
+			MicroAlgosWithRewards: basics.MicroAlgos{Raw: 1}}, 0 | bitAccountOffline},
+		{"offline & closed", basics.OnlineAccountData{
+			VotingData:            basics.VotingData{VoteFirstValid: 0, VoteLastValid: 0},
+			MicroAlgosWithRewards: basics.MicroAlgos{Raw: 0}}, 0 | bitAccountOffline | bitAccountIsClosed},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes the following test compile errors:

```
~/dev/go-algorand master ⇡65 ?13 ───────────────────────────────────────────────────────────────────────────────────── 02:17:34 PM
❯ gotestsum -- ./node
# github.com/algorand/go-algorand/node [github.com/algorand/go-algorand/node.test]
node/node_test.go:559:41: cannot use promoted field VotingData.VoteFirstValid in struct literal of type basics.OnlineAccountData
node/node_test.go:559:60: cannot use promoted field VotingData.VoteLastValid in struct literal of type basics.OnlineAccountData
node/node_test.go:560:41: cannot use promoted field VotingData.VoteFirstValid in struct literal of type basics.OnlineAccountData
node/node_test.go:560:60: cannot use promoted field VotingData.VoteLastValid in struct literal of type basics.OnlineAccountData
node/node_test.go:561:53: cannot use promoted field VotingData.VoteFirstValid in struct literal of type basics.OnlineAccountData
node/node_test.go:561:72: cannot use promoted field VotingData.VoteLastValid in struct literal of type basics.OnlineAccountData
node/node_test.go:562:49: cannot use promoted field VotingData.VoteFirstValid in struct literal of type basics.OnlineAccountData
node/node_test.go:562:68: cannot use promoted field VotingData.VoteLastValid in struct literal of type basics.OnlineAccountData
WARN invalid TestEvent: FAIL	github.com/algorand/go-algorand/node [build failed]
bad output from test2json: FAIL	github.com/algorand/go-algorand/node [build failed]

=== Errors
node/node_test.go:559:41: cannot use promoted field VotingData.VoteFirstValid in struct literal of type basics.OnlineAccountData
node/node_test.go:559:60: cannot use promoted field VotingData.VoteLastValid in struct literal of type basics.OnlineAccountData
node/node_test.go:560:41: cannot use promoted field VotingData.VoteFirstValid in struct literal of type basics.OnlineAccountData
node/node_test.go:560:60: cannot use promoted field VotingData.VoteLastValid in struct literal of type basics.OnlineAccountData
node/node_test.go:561:53: cannot use promoted field VotingData.VoteFirstValid in struct literal of type basics.OnlineAccountData
node/node_test.go:561:72: cannot use promoted field VotingData.VoteLastValid in struct literal of type basics.OnlineAccountData
node/node_test.go:562:49: cannot use promoted field VotingData.VoteFirstValid in struct literal of type basics.OnlineAccountData
node/node_test.go:562:68: cannot use promoted field VotingData.VoteLastValid in struct literal of type basics.OnlineAccountData

DONE 0 tests, 8 errors in 0.480s
```

Though I didn't research it, I presume the issue occurred due to interleaved merges to `master`.