### PR TITLE
Voters tracker

### DIFF
--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -306,10 +306,6 @@ func (ao *onlineAccounts) produceCommittingTask(committedRound basics.Round, dbR
 		ao.log.Panicf("produceCommittingTask: block %d too far in the future, lookback %d, dbRound %d (cached %d), deltas %d", committedRound, dcr.lookback, dbRound, ao.cachedDBRoundOnline, len(ao.deltas))
 	}
 
-	if ao.voters != nil {
-		dcr.lowestRound = ao.voters.computeForgettableRounds(newBase)
-	}
-
 	offset = uint64(newBase - dbRound)
 	offset = ao.consecutiveVersion(offset)
 
@@ -318,6 +314,10 @@ func (ao *onlineAccounts) produceCommittingTask(committedRound basics.Round, dbR
 		dcr.offset = offset
 	}
 	dcr.oldBase = dbRound
+
+	if ao.voters != nil {
+		dcr.lowestRound = ao.voters.computeForgettableRounds(newBase)
+	}
 	return dcr
 }
 

--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -138,7 +138,7 @@ func (ao *onlineAccounts) loadFromDisk(l ledgerForTracker, lastBalancesRound bas
 
 	// the votes have a special dependency on the online accounts, so we need to initialize these separately.
 	ao.voters = &votersTracker{}
-	err = ao.voters.loadFromDisk(l, ao)
+	err = ao.voters.loadFromDisk(l, ao.cachedDBRoundOnline, ao.onlineTop)
 	if err != nil {
 		err = fmt.Errorf("voters tracker failed to loadFromDisk : %w", err)
 	}

--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -137,8 +137,8 @@ func (ao *onlineAccounts) loadFromDisk(l ledgerForTracker, lastBalancesRound bas
 	}
 
 	// the votes have a special dependency on the online accounts, so we need to initialize these separately.
-	ao.voters = &votersTracker{}
-	err = ao.voters.loadFromDisk(l, ao.cachedDBRoundOnline, ao.onlineTop)
+	ao.voters = &votersTracker{onlineTopFunction: ao.onlineTop}
+	err = ao.voters.loadFromDisk(l, lastBalancesRound)
 	if err != nil {
 		err = fmt.Errorf("voters tracker failed to loadFromDisk : %w", err)
 	}

--- a/ledger/acctonline_test.go
+++ b/ledger/acctonline_test.go
@@ -1181,13 +1181,10 @@ func TestAcctOnlineVotersLongerHistory(t *testing.T) {
 		base := genesisAccts[i-1]
 		newAccts := applyPartialDeltas(base, updates)
 		totals = newBlock(t, ml, totals, testProtocolVersion, protoParams, basics.Round(i), base, updates, totals)
-		// in this test we simulate that the stateproof is stalled, thus we want every header to state: nextStateProof = 12:
+		// the voterTracker needs access to headers.
 		ml.blocks[len(ml.blocks)-1].block.BlockHeader.StateProofTracking = map[protocol.StateProofType]bookkeeping.StateProofTrackingData{}
 		ml.blocks[len(ml.blocks)-1].block.BlockHeader.Round = basics.Round(i)
 
-		//ml.blocks[len(ml.blocks)-1].block.BlockHeader.StateProofTracking[protocol.StateProofBasic] = bookkeeping.StateProofTrackingData{
-		//	StateProofNextRound: 0,
-		//}
 		genesisAccts = append(genesisAccts, newAccts)
 		commitSync(t, oa, ml, basics.Round(i))
 	}

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -22,16 +22,13 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/algorand/go-algorand/data/account"
-	"github.com/algorand/go-algorand/util/db"
-	"github.com/algorand/go-deadlock"
-	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"runtime"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/config"

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -2796,6 +2796,9 @@ func TestVotersReloadFromDiskPassRecoveryPeriod(t *testing.T) {
 		blk.BlockHeader.TimeStamp += 10
 		err = l.AddBlock(blk, agreement.Certificate{})
 		require.NoError(t, err)
+
+		l.trackers.scheduleCommit(blk.BlockHeader.Round, 1)
+		l.trackers.waitAccountsWriting()
 	}
 
 	// the voters tracker should give up on voters for round 512

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -2663,6 +2663,8 @@ func TestVotersReloadFromDisk(t *testing.T) {
 	}
 	vtBefore := l.acctsOnline.voters.votersForRoundCache
 	err = l.reloadLedger()
+	require.NoError(t, err)
+
 	require.Equal(t, len(vtBefore), len(l.acctsOnline.voters.votersForRoundCache))
 	for k, v := range l.acctsOnline.voters.votersForRoundCache {
 		require.NoError(t, v.Wait())
@@ -2704,9 +2706,11 @@ func TestVotersReloadFromDiskAfterOneStateProofCommitted(t *testing.T) {
 		err = l.AddBlock(blk, agreement.Certificate{})
 		require.NoError(t, err)
 	}
-	
+
 	vtBefore := l.acctsOnline.voters.votersForRoundCache
 	err = l.reloadLedger()
+	require.NoError(t, err)
+
 	require.Equal(t, len(vtBefore), len(l.acctsOnline.voters.votersForRoundCache))
 	for k, v := range l.acctsOnline.voters.votersForRoundCache {
 		require.NoError(t, v.Wait())

--- a/ledger/voters.go
+++ b/ledger/voters.go
@@ -183,11 +183,14 @@ func (vt *votersTracker) newBlock(hdr bookkeeping.BlockHeader) {
 }
 
 // lowestRound() returns the lowest votersForRoundCache state (blocks and accounts) needed by
-// the votersTracker in case of a restart.  The accountUpdates tracker will
-// not delete account state before this round, so that after a restart, it's
+// the votersTracker in case of a restart.
+// 	 NOTE: use with caution! lowestRound should be used ONLY with committed base rounds.
+//	 Otherwise, user receive the false impression of blocks it can remove
+// The online tracker will not delete account state before this round, so that after a restart, it's
 // possible to reconstruct the votersTracker.  If votersTracker does
 // not need any blocks, it returns base.
 func (vt *votersTracker) lowestRound(base basics.Round) basics.Round {
+	// TODO: isn't safe if the base > committedRound. Should i panic I log an error here in case someone gave a different base?
 	minRound := base
 	for r := range vt.votersForRoundCache {
 		if r < minRound {

--- a/ledger/voters.go
+++ b/ledger/voters.go
@@ -84,8 +84,7 @@ func (vt *votersTracker) loadFromDisk(l ledgerForTracker, latestDbRound basics.R
 	vt.onlineTopFunction = onlineTopFunc
 	vt.votersForRoundCache = make(map[basics.Round]*ledgercore.VotersForRound)
 
-	latest := latestDbRound
-	hdr, err := l.BlockHdr(latest)
+	hdr, err := l.BlockHdr(latestDbRound)
 	if err != nil {
 		return err
 	}
@@ -107,13 +106,7 @@ func (vt *votersTracker) loadFromDisk(l ledgerForTracker, latestDbRound basics.R
 			hdr.StateProofTracking[protocol.StateProofBasic].StateProofNextRound, proto.StateProofInterval, proto.StateProofVotersLookback, startR)
 	}
 
-	// Sanity check: we should never underflow or even reach 0.
-	if startR == 0 {
-		return fmt.Errorf("votersTracker: underflow: %d - %d - %d = %d",
-			hdr.StateProofTracking[protocol.StateProofBasic].StateProofNextRound, proto.StateProofInterval, proto.StateProofVotersLookback, startR)
-	}
-
-	for r := startR; r <= latest; r += basics.Round(proto.StateProofInterval) {
+	for r := startR; r <= latestDbRound; r += basics.Round(proto.StateProofInterval) {
 		hdr, err = l.BlockHdr(r)
 		if err != nil {
 			return err

--- a/ledger/voters.go
+++ b/ledger/voters.go
@@ -90,15 +90,12 @@ func (vt *votersTracker) loadFromDisk(l ledgerForTracker, latestDbRound basics.R
 	}
 	proto := config.Consensus[hdr.CurrentProtocol]
 
-	if proto.StateProofInterval == 0 {
+	if proto.StateProofInterval == 0 || hdr.StateProofTracking[protocol.StateProofBasic].StateProofNextRound == 0 {
 		// Disabled, nothing to load.
 		return nil
 	}
 
-	startR := basics.Round(proto.StateProofInterval).SubSaturate(basics.Round(proto.StateProofVotersLookback))
-	if hdr.StateProofTracking[protocol.StateProofBasic].StateProofNextRound != 0 {
-		startR = votersRoundForStateProofRound(hdr.StateProofTracking[protocol.StateProofBasic].StateProofNextRound, proto)
-	}
+	startR := votersRoundForStateProofRound(hdr.StateProofTracking[protocol.StateProofBasic].StateProofNextRound, proto)
 
 	// Sanity check: we should never underflow or even reach 0.
 	if startR == 0 {
@@ -108,9 +105,9 @@ func (vt *votersTracker) loadFromDisk(l ledgerForTracker, latestDbRound basics.R
 
 	for r := startR; r <= latestDbRound; r += basics.Round(proto.StateProofInterval) {
 		hdr, err = l.BlockHdr(r)
-		if err != nil {
-			return err
-		}
+		//if err != nil {
+		//	return err
+		//}
 
 		vt.loadTree(hdr)
 	}

--- a/ledger/voters.go
+++ b/ledger/voters.go
@@ -256,13 +256,11 @@ func (vt *votersTracker) computeForgettableRounds(newBase basics.Round) basics.R
 	earliestRoundToRecover := getEarliestRoundToRecover(hdr.Round, proto)
 	confirmedStateProof := getPreviousStateProofRound(hdr, proto)
 
-	forfeitRound := max(
+	return max(
 		vt.lowestRound(newBase),
 		earliestRoundToRecover.SubSaturate(basics.Round(proto.StateProofVotersLookback)),
 		confirmedStateProof.SubSaturate(basics.Round(proto.StateProofVotersLookback)),
 	)
-
-	return forfeitRound
 }
 
 func getPreviousStateProofRound(hdr bookkeeping.BlockHeader, proto config.ConsensusParams) basics.Round {

--- a/ledger/voters.go
+++ b/ledger/voters.go
@@ -79,9 +79,8 @@ func votersRoundForStateProofRound(stateProofRnd basics.Round, proto config.Cons
 	return stateProofRnd.SubSaturate(basics.Round(proto.StateProofInterval)).SubSaturate(basics.Round(proto.StateProofVotersLookback))
 }
 
-func (vt *votersTracker) loadFromDisk(l ledgerForTracker, latestDbRound basics.Round, onlineTopFunc ledgercore.TopOnlineAccounts) error {
+func (vt *votersTracker) loadFromDisk(l ledgerForTracker, latestDbRound basics.Round) error {
 	vt.l = l
-	vt.onlineTopFunction = onlineTopFunc
 	vt.votersForRoundCache = make(map[basics.Round]*ledgercore.VotersForRound)
 
 	hdr, err := l.BlockHdr(latestDbRound)

--- a/ledger/voters_test.go
+++ b/ledger/voters_test.go
@@ -18,6 +18,8 @@ package ledger
 
 import (
 	"context"
+	"testing"
+
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto/merklesignature"
 	"github.com/algorand/go-algorand/data/basics"
@@ -27,7 +29,6 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func addBlockToAccountsUpdate(blk bookkeeping.Block, ao *onlineAccounts) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
Issue with tracker might've caused the whole node not to load, verified in the following manual test:
failure in recovering after state proofs were stalled, but the network has not.
The test is performed as follows:
1. We are setting up the network with the following templates:  4 wallets where we have wallet 1 (with stake 20) on node `1`, wallet 2,3 (with stakes 30, 35) on node `2`, and wallet 4 (with stake 15) on node 3. 
furthermore, we have two `relays`: node `1` and node `4` (every wallet is defined as online)
2. We are setting the consensus params in the future version with a few alterations: reducing the interval to 64. state proof needs 90% of the stake. State proof strength target is 4, and the recovery interval is 5.
3. We are reducing the time per block to one second.
4. We let one state proof be published (for round 128).
5. We drop node named `3`.
6. We wait for the network to reach 1193 or more rounds.
7. We start node `3` again.
8. We stop node `3` again.
9. We try, and fail, to start node `3`.
The error message should now be in the `algod-err.log` file of node `3`.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
