### PR TITLE
tools: goal logging send fixes

### DIFF
--- a/cmd/goal/logging.go
+++ b/cmd/goal/logging.go
@@ -123,6 +123,8 @@ var loggingSendCmd = &cobra.Command{
 
 		modifier := ""
 		counter := uint(1)
+		errcount := 0
+		var firsterr error = nil
 		onDataDirs(func(dataDir string) {
 			cfg, err := logging.EnsureTelemetryConfig(&dataDir, "")
 			if err != nil {
@@ -138,9 +140,16 @@ var loggingSendCmd = &cobra.Command{
 
 			for err := range logging.CollectAndUploadData(dataDir, name, targetFolder) {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
+				if firsterr == nil {
+					firsterr = err
+				}
+				errcount++
 			}
 			modifier = fmt.Sprintf("-%d", counter)
 			counter++
 		})
+		if errcount != 0 {
+			reportErrorf("had %d errors, first: %v", errcount, firsterr)
+		}
 	},
 }

--- a/logging/collector.go
+++ b/logging/collector.go
@@ -131,7 +131,7 @@ func addFile(tw *tar.Writer, filePath string) error {
 			return err
 		}
 		// copy the file data to the tarball
-		if _, err := io.Copy(tw, file); err != nil {
+		if _, err := io.CopyN(tw, file, stat.Size()); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

Send only as many bytes as exist in the log when we stat() it (log may still be growing) otherwise S3 breaks.
If any action within `goal logging send` fails, return error and exit with error.

## Test Plan

Problems found during development. Development tool works better now.