### PR TITLE
Catchup: exporting functions to increase use case of universalFetcher and peerSelector

### DIFF
--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -274,7 +274,7 @@ func (cs *CatchpointCatchupService) processStageLedgerDownload() (err error) {
 	}
 
 	// download balances file.
-	peerSelector := makePeerSelector(cs.net, []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookRelays}})
+	peerSelector := MakePeerSelector(cs.net, []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookRelays}})
 	ledgerFetcher := makeLedgerFetcher(cs.net, cs.ledgerAccessor, cs.log, cs, cs.config)
 	attemptsCount := 0
 
@@ -621,8 +621,8 @@ func (cs *CatchpointCatchupService) fetchBlock(round basics.Round, retryCount ui
 		}
 		return nil, time.Duration(0), psp, true, cs.abort(fmt.Errorf("fetchBlock: recurring non-HTTP peer was provided by the peer selector"))
 	}
-	fetcher := makeUniversalBlockFetcher(cs.log, cs.net, cs.config)
-	blk, _, downloadDuration, err = fetcher.fetchBlock(cs.ctx, round, httpPeer)
+	fetcher := MakeUniversalBlockFetcher(cs.log, cs.net, cs.config)
+	blk, _, downloadDuration, err = fetcher.FetchBlock(cs.ctx, round, httpPeer)
 	if err != nil {
 		if cs.ctx.Err() != nil {
 			return nil, time.Duration(0), psp, true, cs.stopOrAbort()
@@ -743,14 +743,14 @@ func (cs *CatchpointCatchupService) updateBlockRetrievalStatistics(aquiredBlocks
 
 func (cs *CatchpointCatchupService) initDownloadPeerSelector() {
 	if cs.config.EnableCatchupFromArchiveServers {
-		cs.blocksDownloadPeerSelector = makePeerSelector(
+		cs.blocksDownloadPeerSelector = MakePeerSelector(
 			cs.net,
 			[]peerClass{
 				{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
 				{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
 			})
 	} else {
-		cs.blocksDownloadPeerSelector = makePeerSelector(
+		cs.blocksDownloadPeerSelector = MakePeerSelector(
 			cs.net,
 			[]peerClass{
 				{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookRelays},

--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -274,7 +274,7 @@ func (cs *CatchpointCatchupService) processStageLedgerDownload() (err error) {
 	}
 
 	// download balances file.
-	peerSelector := MakePeerSelector(cs.net, []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookRelays}})
+	peerSelector := makePeerSelector(cs.net, []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookRelays}})
 	ledgerFetcher := makeLedgerFetcher(cs.net, cs.ledgerAccessor, cs.log, cs, cs.config)
 	attemptsCount := 0
 
@@ -743,17 +743,17 @@ func (cs *CatchpointCatchupService) updateBlockRetrievalStatistics(aquiredBlocks
 
 func (cs *CatchpointCatchupService) initDownloadPeerSelector() {
 	if cs.config.EnableCatchupFromArchiveServers {
-		cs.blocksDownloadPeerSelector = MakePeerSelector(
+		cs.blocksDownloadPeerSelector = makePeerSelector(
 			cs.net,
-			[]PeerClass{
-				{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
-				{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays},
+			[]peerClass{
+				{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
+				{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
 			})
 	} else {
-		cs.blocksDownloadPeerSelector = MakePeerSelector(
+		cs.blocksDownloadPeerSelector = makePeerSelector(
 			cs.net,
-			[]PeerClass{
-				{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookRelays},
+			[]peerClass{
+				{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookRelays},
 			})
 	}
 }

--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -274,7 +274,7 @@ func (cs *CatchpointCatchupService) processStageLedgerDownload() (err error) {
 	}
 
 	// download balances file.
-	peerSelector := MakePeerSelector(cs.net, []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookRelays}})
+	peerSelector := MakePeerSelector(cs.net, []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookRelays}})
 	ledgerFetcher := makeLedgerFetcher(cs.net, cs.ledgerAccessor, cs.log, cs, cs.config)
 	attemptsCount := 0
 
@@ -745,15 +745,15 @@ func (cs *CatchpointCatchupService) initDownloadPeerSelector() {
 	if cs.config.EnableCatchupFromArchiveServers {
 		cs.blocksDownloadPeerSelector = MakePeerSelector(
 			cs.net,
-			[]peerClass{
-				{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
-				{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
+			[]PeerClass{
+				{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
+				{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays},
 			})
 	} else {
 		cs.blocksDownloadPeerSelector = MakePeerSelector(
 			cs.net,
-			[]peerClass{
-				{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookRelays},
+			[]PeerClass{
+				{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookRelays},
 			})
 	}
 }

--- a/catchup/peerSelector.go
+++ b/catchup/peerSelector.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/algorand/go-deadlock"
 
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/network"
 )
@@ -78,12 +79,6 @@ type PeerSelectorPeer struct {
 type peerClass struct {
 	initialRank int
 	peerClass   network.PeerOption
-}
-
-// PeerClassExported exports peerClass struct
-type PeerClassExported struct {
-	InitialRank int
-	PeerClass   network.PeerOption
 }
 
 // the peersRetriever is a subset of the network.GossipNode used to ensure that we can create an instance of the PeerSelector
@@ -274,17 +269,9 @@ func (hs *historicStats) push(value int, counter uint64, class peerClass) (avera
 	return bounded
 }
 
-// MakePeerSelectorExported exports makePeerSelector function
-func MakePeerSelectorExported(net peersRetriever, initialPeersClasses []PeerClassExported) *PeerSelector {
-	var peerClasses []peerClass
-	for _, v := range initialPeersClasses {
-		peerClasses = append(peerClasses, peerClass{initialRank: v.InitialRank, peerClass: v.PeerClass})
-	}
-	selector := &PeerSelector{
-		net:         net,
-		peerClasses: peerClasses,
-	}
-	return selector
+// NewPeerSelector exports makePeerSelector function using createPeerSelector
+func NewPeerSelector(net peersRetriever, cfg config.Local, pipelineFetch bool) *PeerSelector {
+	return createPeerSelector(net, cfg, pipelineFetch)
 }
 
 // makePeerSelector creates a PeerSelector, given a peersRetriever and peerClass array.

--- a/catchup/peerSelector.go
+++ b/catchup/peerSelector.go
@@ -80,9 +80,7 @@ type peerClass struct {
 	peerClass   network.PeerOption
 }
 
-// PeerClassExported defines the type of peer we want to have in a particular "class",
-// and define the network.PeerOption that would be used to retrieve that type of
-// peer. Its an exported peerClass struct
+// PeerClassExported exports peerClass struct
 type PeerClassExported struct {
 	InitialRank int
 	PeerClass   network.PeerOption
@@ -276,6 +274,7 @@ func (hs *historicStats) push(value int, counter uint64, class peerClass) (avera
 	return bounded
 }
 
+// MakePeerSelectorExported exports makePeerSelector function
 func MakePeerSelectorExported(net peersRetriever, initialPeersClasses []PeerClassExported) *PeerSelector {
 	var peerClasses []peerClass
 	for _, v := range initialPeersClasses {

--- a/catchup/peerSelector.go
+++ b/catchup/peerSelector.go
@@ -72,10 +72,18 @@ type PeerSelectorPeer struct {
 	peerClass network.PeerOption
 }
 
-// PeerClass defines the type of peer we want to have in a particular "class",
+// peerClass defines the type of peer we want to have in a particular "class",
 // and define the network.PeerOption that would be used to retrieve that type of
 // peer
-type PeerClass struct {
+type peerClass struct {
+	initialRank int
+	peerClass   network.PeerOption
+}
+
+// PeerClassExported defines the type of peer we want to have in a particular "class",
+// and define the network.PeerOption that would be used to retrieve that type of
+// peer. Its an exported peerClass struct
+type PeerClassExported struct {
 	InitialRank int
 	PeerClass   network.PeerOption
 }
@@ -91,7 +99,7 @@ type peersRetriever interface {
 // the underlying network peer as well as the peer class.
 type peerPoolEntry struct {
 	peer    network.Peer
-	class   PeerClass
+	class   peerClass
 	history *historicStats
 }
 
@@ -108,7 +116,7 @@ type peerPool struct {
 type PeerSelector struct {
 	mu          deadlock.Mutex
 	net         peersRetriever
-	peerClasses []PeerClass
+	peerClasses []peerClass
 	pools       []peerPool
 	counter     uint64
 }
@@ -130,7 +138,7 @@ type historicStats struct {
 	downloadFailures int
 }
 
-func makeHistoricStatus(windowSize int, class PeerClass) *historicStats {
+func makeHistoricStatus(windowSize int, class peerClass) *historicStats {
 	// Initialize the window (rankSamples) with zeros but rankSum with the equivalent sum of class initial rank.
 	// This way, every peer will slowly build up its profile.
 	// Otherwise, if the best peer gets a bad download the first time,
@@ -139,10 +147,10 @@ func makeHistoricStatus(windowSize int, class PeerClass) *historicStats {
 		windowSize:  windowSize,
 		rankSamples: make([]int, windowSize, windowSize),
 		requestGaps: make([]uint64, 0, windowSize),
-		rankSum:     uint64(class.InitialRank) * uint64(windowSize),
+		rankSum:     uint64(class.initialRank) * uint64(windowSize),
 		gapSum:      0.0}
 	for i := 0; i < windowSize; i++ {
-		hs.rankSamples[i] = class.InitialRank
+		hs.rankSamples[i] = class.initialRank
 	}
 	return &hs
 }
@@ -176,7 +184,7 @@ func (hs *historicStats) updateRequestPenalty(counter uint64) float64 {
 // resetRequestPenalty removes steps least recent gaps and recomputes the new penalty.
 // Returns the new rank calculated with the new penalty.
 // If steps is 0, it is a full reset i.e. drops all gap values.
-func (hs *historicStats) resetRequestPenalty(steps int, initialRank int, class PeerClass) (rank int) {
+func (hs *historicStats) resetRequestPenalty(steps int, initialRank int, class peerClass) (rank int) {
 	if len(hs.requestGaps) == 0 {
 		return initialRank
 	}
@@ -205,7 +213,7 @@ func (hs *historicStats) resetRequestPenalty(steps int, initialRank int, class P
 // push pushes a new rank to the historicStats, and returns the new
 // rank based on the average of ranks in the windowSize window and the
 // penlaty.
-func (hs *historicStats) push(value int, counter uint64, class PeerClass) (averagedRank int) {
+func (hs *historicStats) push(value int, counter uint64, class peerClass) (averagedRank int) {
 
 	// This is the lowest ranking class, and is not subject to giving another chance.
 	// Do not modify this value with historical data.
@@ -268,8 +276,20 @@ func (hs *historicStats) push(value int, counter uint64, class PeerClass) (avera
 	return bounded
 }
 
-// MakePeerSelector creates a PeerSelector, given a peersRetriever and peerClass array.
-func MakePeerSelector(net peersRetriever, initialPeersClasses []PeerClass) *PeerSelector {
+func MakePeerSelectorExported(net peersRetriever, initialPeersClasses []PeerClassExported) *PeerSelector {
+	var peerClasses []peerClass
+	for _, v := range initialPeersClasses {
+		peerClasses = append(peerClasses, peerClass{initialRank: v.InitialRank, peerClass: v.PeerClass})
+	}
+	selector := &PeerSelector{
+		net:         net,
+		peerClasses: peerClasses,
+	}
+	return selector
+}
+
+// makePeerSelector creates a PeerSelector, given a peersRetriever and peerClass array.
+func makePeerSelector(net peersRetriever, initialPeersClasses []peerClass) *PeerSelector {
 	selector := &PeerSelector{
 		net:         net,
 		peerClasses: initialPeersClasses,
@@ -291,7 +311,7 @@ func (ps *PeerSelector) GetNextPeer() (psp *PeerSelectorPeer, err error) {
 			// provide the needed test.
 			// pick one of the peers from this pool at random
 			peerIdx := crypto.RandUint64() % uint64(len(pool.peers))
-			psp = &PeerSelectorPeer{pool.peers[peerIdx].peer, pool.peers[peerIdx].class.PeerClass}
+			psp = &PeerSelectorPeer{pool.peers[peerIdx].peer, pool.peers[peerIdx].class.peerClass}
 			return
 		}
 	}
@@ -376,7 +396,7 @@ func (ps *PeerSelector) peerDownloadDurationToRank(psp *PeerSelectorPeer, blockD
 		return peerRankInvalidDownload
 	}
 
-	switch ps.pools[poolIdx].peers[peerIdx].class.InitialRank {
+	switch ps.pools[poolIdx].peers[peerIdx].class.initialRank {
 	case peerRankInitialFirstPriority:
 		return downloadDurationToRank(blockDownloadDuration, lowBlockDownloadThreshold, highBlockDownloadThreshold, peerRank0LowBlockTime, peerRank0HighBlockTime)
 	case peerRankInitialSecondPriority:
@@ -391,7 +411,7 @@ func (ps *PeerSelector) peerDownloadDurationToRank(psp *PeerSelectorPeer, blockD
 // addToPool adds a given peer to the correct group. If no group exists for that peer's rank,
 // a new group is created.
 // The method return true if a new group was created ( suggesting that the pools list would need to be re-ordered ), or false otherwise.
-func (ps *PeerSelector) addToPool(peer network.Peer, rank int, class PeerClass, peerHistory *historicStats) bool {
+func (ps *PeerSelector) addToPool(peer network.Peer, rank int, class peerClass, peerHistory *historicStats) bool {
 	// see if we already have a list with that rank:
 	for i, pool := range ps.pools {
 		if pool.rank == rank {
@@ -431,28 +451,28 @@ func (ps *PeerSelector) refreshAvailablePeers() {
 		for _, localPeer := range pool.peers {
 			if peerAddress := peerAddress(localPeer.peer); peerAddress != "" {
 				// Init the existingPeers map
-				if _, has := existingPeers[localPeer.class.PeerClass]; !has {
-					existingPeers[localPeer.class.PeerClass] = make(map[string]bool)
+				if _, has := existingPeers[localPeer.class.peerClass]; !has {
+					existingPeers[localPeer.class.peerClass] = make(map[string]bool)
 				}
-				existingPeers[localPeer.class.PeerClass][peerAddress] = true
+				existingPeers[localPeer.class.peerClass][peerAddress] = true
 			}
 		}
 	}
 	sortNeeded := false
 	for _, initClass := range ps.peerClasses {
-		peers := ps.net.GetPeers(initClass.PeerClass)
+		peers := ps.net.GetPeers(initClass.peerClass)
 		for _, peer := range peers {
 			peerAddress := peerAddress(peer)
 			if peerAddress == "" {
 				continue
 			}
-			if _, has := existingPeers[initClass.PeerClass][peerAddress]; has {
+			if _, has := existingPeers[initClass.peerClass][peerAddress]; has {
 				// Setting to false instead of deleting the element to be safe against duplicate peer addresses.
-				existingPeers[initClass.PeerClass][peerAddress] = false
+				existingPeers[initClass.peerClass][peerAddress] = false
 				continue
 			}
 			// it's an entry which we did not have before.
-			sortNeeded = ps.addToPool(peer, initClass.InitialRank, initClass, makeHistoricStatus(peerHistoryWindowSize, initClass)) || sortNeeded
+			sortNeeded = ps.addToPool(peer, initClass.initialRank, initClass, makeHistoricStatus(peerHistoryWindowSize, initClass)) || sortNeeded
 		}
 	}
 
@@ -462,7 +482,7 @@ func (ps *PeerSelector) refreshAvailablePeers() {
 		for peerIdx := len(pool.peers) - 1; peerIdx >= 0; peerIdx-- {
 			peer := pool.peers[peerIdx].peer
 			if peerAddress := peerAddress(peer); peerAddress != "" {
-				if toRemove := existingPeers[pool.peers[peerIdx].class.PeerClass][peerAddress]; toRemove {
+				if toRemove := existingPeers[pool.peers[peerIdx].class.peerClass][peerAddress]; toRemove {
 					// need to be removed.
 					pool.peers = append(pool.peers[:peerIdx], pool.peers[peerIdx+1:]...)
 				}
@@ -491,7 +511,7 @@ func (ps *PeerSelector) findPeer(psp *PeerSelectorPeer) (poolIdx, peerIdx int) {
 	for i, pool := range ps.pools {
 		for j, localPeerEntry := range pool.peers {
 			if peerAddress(localPeerEntry.peer) == peerAddr &&
-				localPeerEntry.class.PeerClass == psp.peerClass {
+				localPeerEntry.class.peerClass == psp.peerClass {
 				return i, j
 			}
 		}
@@ -512,8 +532,8 @@ func downloadDurationToRank(downloadDuration, minDownloadDuration, maxDownloadDu
 	return
 }
 
-func lowerBound(class PeerClass) int {
-	switch class.InitialRank {
+func lowerBound(class peerClass) int {
+	switch class.initialRank {
 	case peerRankInitialFirstPriority:
 		return peerRank0LowBlockTime
 	case peerRankInitialSecondPriority:
@@ -525,8 +545,8 @@ func lowerBound(class PeerClass) int {
 	}
 }
 
-func upperBound(class PeerClass) int {
-	switch class.InitialRank {
+func upperBound(class peerClass) int {
+	switch class.initialRank {
 	case peerRankInitialFirstPriority:
 		return peerRank0HighBlockTime
 	case peerRankInitialSecondPriority:
@@ -538,7 +558,7 @@ func upperBound(class PeerClass) int {
 	}
 }
 
-func boundRankByClass(rank int, class PeerClass) int {
+func boundRankByClass(rank int, class peerClass) int {
 	if rank < lowerBound(class) {
 		return lowerBound(class)
 	}

--- a/catchup/peerSelector.go
+++ b/catchup/peerSelector.go
@@ -462,7 +462,7 @@ func (ps *PeerSelector) refreshAvailablePeers() {
 		for peerIdx := len(pool.peers) - 1; peerIdx >= 0; peerIdx-- {
 			peer := pool.peers[peerIdx].peer
 			if peerAddress := peerAddress(peer); peerAddress != "" {
-				if toRemove, _ := existingPeers[pool.peers[peerIdx].class.PeerClass][peerAddress]; toRemove {
+				if toRemove := existingPeers[pool.peers[peerIdx].class.PeerClass][peerAddress]; toRemove {
 					// need to be removed.
 					pool.peers = append(pool.peers[:peerIdx], pool.peers[peerIdx+1:]...)
 				}

--- a/catchup/peerSelector.go
+++ b/catchup/peerSelector.go
@@ -268,8 +268,8 @@ func (hs *historicStats) push(value int, counter uint64, class peerClass) (avera
 	return bounded
 }
 
-// makePeerSelector creates a peerSelector, given a peersRetriever and peerClass array.
-func makePeerSelector(net peersRetriever, initialPeersClasses []peerClass) *peerSelector {
+// MakePeerSelector creates a peerSelector, given a peersRetriever and peerClass array.
+func MakePeerSelector(net peersRetriever, initialPeersClasses []peerClass) *peerSelector {
 	selector := &peerSelector{
 		net:         net,
 		peerClasses: initialPeersClasses,

--- a/catchup/peerSelector_test.go
+++ b/catchup/peerSelector_test.go
@@ -129,7 +129,7 @@ func TestPeerSelector(t *testing.T) {
 	peerSelector := MakePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) []network.Peer {
 			return peers
-		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers}},
+		}), []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers}},
 	)
 
 	psp, err := peerSelector.GetNextPeer()
@@ -197,8 +197,8 @@ func TestPeerDownloadRanking(t *testing.T) {
 				}
 			}
 			return
-		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
-			{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays}},
+		}), []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
+			{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays}},
 	)
 	archivalPeer, err := peerSelector.GetNextPeer()
 	require.NoError(t, err)
@@ -238,7 +238,7 @@ func TestFindMissingPeer(t *testing.T) {
 	peerSelector := MakePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) []network.Peer {
 			return []network.Peer{}
-		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers}},
+		}), []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers}},
 	)
 
 	poolIdx, peerIdx := peerSelector.findPeer(&PeerSelectorPeer{mockHTTPPeer{address: "abcd"}, 0})
@@ -262,8 +262,8 @@ func TestHistoricData(t *testing.T) {
 				}
 			}
 			return
-		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
-			{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays}},
+		}), []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
+			{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays}},
 	)
 
 	var counters [5]int
@@ -335,8 +335,8 @@ func TestPeersDownloadFailed(t *testing.T) {
 				}
 			}
 			return
-		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
-			{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays}},
+		}), []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
+			{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays}},
 	)
 
 	var counters [5]int
@@ -410,8 +410,8 @@ func TestPenalty(t *testing.T) {
 				}
 			}
 			return
-		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
-			{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays}},
+		}), []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
+			{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays}},
 	)
 
 	var counters [5]int
@@ -474,10 +474,10 @@ func TestPeerDownloadDurationToRank(t *testing.T) {
 				}
 			}
 			return
-		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
-			{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
-			{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersConnectedOut},
-			{initialRank: peerRankInitialFourthPriority, peerClass: network.PeersConnectedIn}},
+		}), []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
+			{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays},
+			{InitialRank: peerRankInitialThirdPriority, PeerClass: network.PeersConnectedOut},
+			{InitialRank: peerRankInitialFourthPriority, PeerClass: network.PeersConnectedIn}},
 	)
 
 	_, err := peerSelector.GetNextPeer()
@@ -496,10 +496,10 @@ func TestPeerDownloadDurationToRank(t *testing.T) {
 func TestLowerUpperBounds(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	classes := []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
-		{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
-		{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersConnectedOut},
-		{initialRank: peerRankInitialFourthPriority, peerClass: network.PeersConnectedIn}}
+	classes := []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
+		{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays},
+		{InitialRank: peerRankInitialThirdPriority, PeerClass: network.PeersConnectedOut},
+		{InitialRank: peerRankInitialFourthPriority, PeerClass: network.PeersConnectedIn}}
 
 	require.Equal(t, peerRank0LowBlockTime, lowerBound(classes[0]))
 	require.Equal(t, peerRank1LowBlockTime, lowerBound(classes[1]))
@@ -515,7 +515,7 @@ func TestLowerUpperBounds(t *testing.T) {
 func TestFullResetRequestPenalty(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	class := peerClass{initialRank: 10, peerClass: network.PeersPhonebookArchivers}
+	class := PeerClass{InitialRank: 10, PeerClass: network.PeersPhonebookArchivers}
 	hs := makeHistoricStatus(10, class)
 	hs.push(5, 1, class)
 	require.Equal(t, 1, len(hs.requestGaps))
@@ -531,7 +531,7 @@ func TestClassUpperBound(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}}
-	pClass := peerClass{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookArchivers}
+	pClass := PeerClass{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookArchivers}
 	peerSelector := MakePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
@@ -540,7 +540,7 @@ func TestClassUpperBound(t *testing.T) {
 				}
 			}
 			return
-		}), []peerClass{pClass})
+		}), []PeerClass{pClass})
 
 	_, err := peerSelector.GetNextPeer()
 	require.NoError(t, err)
@@ -560,12 +560,12 @@ func TestClassUpperBound(t *testing.T) {
 
 // TestClassLowerBound makes sure the peer rank does not go under the class lower bound
 // This was a bug where the resetRequestPenalty was not bounding the returned rank, and the rankSum was not
-// initialized to give the average of class.initialRank
+// initialized to give the average of class.InitialRank
 func TestClassLowerBound(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}}
-	pClass := peerClass{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookArchivers}
+	pClass := PeerClass{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookArchivers}
 	peerSelector := MakePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
@@ -574,7 +574,7 @@ func TestClassLowerBound(t *testing.T) {
 				}
 			}
 			return
-		}), []peerClass{pClass})
+		}), []PeerClass{pClass})
 
 	_, err := peerSelector.GetNextPeer()
 	require.NoError(t, err)
@@ -584,7 +584,7 @@ func TestClassLowerBound(t *testing.T) {
 		peerSelector.RankPeer(psp, lowerBound(pClass))
 
 		for _, pool := range peerSelector.pools {
-			require.GreaterOrEqual(t, pool.rank, pool.peers[0].class.initialRank)
+			require.GreaterOrEqual(t, pool.rank, pool.peers[0].class.InitialRank)
 		}
 	}
 }
@@ -606,8 +606,8 @@ func TestEvictionAndUpgrade(t *testing.T) {
 				}
 			}
 			return
-		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
-			{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays}},
+		}), []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
+			{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays}},
 	)
 
 	_, err := peerSelector.GetNextPeer()

--- a/catchup/peerSelector_test.go
+++ b/catchup/peerSelector_test.go
@@ -126,10 +126,10 @@ func TestPeerSelector(t *testing.T) {
 
 	peers := []network.Peer{&mockHTTPPeer{address: "12345"}}
 
-	peerSelector := MakePeerSelector(
+	peerSelector := makePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) []network.Peer {
 			return peers
-		}), []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers}},
+		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers}},
 	)
 
 	psp, err := peerSelector.GetNextPeer()
@@ -187,7 +187,7 @@ func TestPeerDownloadRanking(t *testing.T) {
 	peers1 := []network.Peer{&mockHTTPPeer{address: "1234"}, &mockHTTPPeer{address: "5678"}}
 	peers2 := []network.Peer{&mockHTTPPeer{address: "abcd"}, &mockHTTPPeer{address: "efgh"}}
 
-	peerSelector := MakePeerSelector(
+	peerSelector := makePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivers {
@@ -197,8 +197,8 @@ func TestPeerDownloadRanking(t *testing.T) {
 				}
 			}
 			return
-		}), []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
-			{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays}},
+		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
+			{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays}},
 	)
 	archivalPeer, err := peerSelector.GetNextPeer()
 	require.NoError(t, err)
@@ -235,10 +235,10 @@ func TestPeerDownloadRanking(t *testing.T) {
 func TestFindMissingPeer(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	peerSelector := MakePeerSelector(
+	peerSelector := makePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) []network.Peer {
 			return []network.Peer{}
-		}), []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers}},
+		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers}},
 	)
 
 	poolIdx, peerIdx := peerSelector.findPeer(&PeerSelectorPeer{mockHTTPPeer{address: "abcd"}, 0})
@@ -252,7 +252,7 @@ func TestHistoricData(t *testing.T) {
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}, &mockHTTPPeer{address: "a3"}}
 	peers2 := []network.Peer{&mockHTTPPeer{address: "b1"}, &mockHTTPPeer{address: "b2"}}
 
-	peerSelector := MakePeerSelector(
+	peerSelector := makePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivers {
@@ -262,8 +262,8 @@ func TestHistoricData(t *testing.T) {
 				}
 			}
 			return
-		}), []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
-			{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays}},
+		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
+			{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays}},
 	)
 
 	var counters [5]int
@@ -325,7 +325,7 @@ func TestPeersDownloadFailed(t *testing.T) {
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}, &mockHTTPPeer{address: "a3"}}
 	peers2 := []network.Peer{&mockHTTPPeer{address: "b1"}, &mockHTTPPeer{address: "b2"}}
 
-	peerSelector := MakePeerSelector(
+	peerSelector := makePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivers {
@@ -335,8 +335,8 @@ func TestPeersDownloadFailed(t *testing.T) {
 				}
 			}
 			return
-		}), []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
-			{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays}},
+		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
+			{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays}},
 	)
 
 	var counters [5]int
@@ -400,7 +400,7 @@ func TestPenalty(t *testing.T) {
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}, &mockHTTPPeer{address: "a3"}}
 	peers2 := []network.Peer{&mockHTTPPeer{address: "b1"}, &mockHTTPPeer{address: "b2"}}
 
-	peerSelector := MakePeerSelector(
+	peerSelector := makePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivers {
@@ -410,8 +410,8 @@ func TestPenalty(t *testing.T) {
 				}
 			}
 			return
-		}), []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
-			{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays}},
+		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
+			{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays}},
 	)
 
 	var counters [5]int
@@ -460,7 +460,7 @@ func TestPeerDownloadDurationToRank(t *testing.T) {
 	peers3 := []network.Peer{&mockHTTPPeer{address: "c1"}, &mockHTTPPeer{address: "c2"}}
 	peers4 := []network.Peer{&mockHTTPPeer{address: "d1"}, &mockHTTPPeer{address: "b2"}}
 
-	peerSelector := MakePeerSelector(
+	peerSelector := makePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivers {
@@ -474,10 +474,10 @@ func TestPeerDownloadDurationToRank(t *testing.T) {
 				}
 			}
 			return
-		}), []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
-			{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays},
-			{InitialRank: peerRankInitialThirdPriority, PeerClass: network.PeersConnectedOut},
-			{InitialRank: peerRankInitialFourthPriority, PeerClass: network.PeersConnectedIn}},
+		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
+			{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
+			{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersConnectedOut},
+			{initialRank: peerRankInitialFourthPriority, peerClass: network.PeersConnectedIn}},
 	)
 
 	_, err := peerSelector.GetNextPeer()
@@ -496,10 +496,10 @@ func TestPeerDownloadDurationToRank(t *testing.T) {
 func TestLowerUpperBounds(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	classes := []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
-		{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays},
-		{InitialRank: peerRankInitialThirdPriority, PeerClass: network.PeersConnectedOut},
-		{InitialRank: peerRankInitialFourthPriority, PeerClass: network.PeersConnectedIn}}
+	classes := []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
+		{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
+		{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersConnectedOut},
+		{initialRank: peerRankInitialFourthPriority, peerClass: network.PeersConnectedIn}}
 
 	require.Equal(t, peerRank0LowBlockTime, lowerBound(classes[0]))
 	require.Equal(t, peerRank1LowBlockTime, lowerBound(classes[1]))
@@ -515,7 +515,7 @@ func TestLowerUpperBounds(t *testing.T) {
 func TestFullResetRequestPenalty(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	class := PeerClass{InitialRank: 10, PeerClass: network.PeersPhonebookArchivers}
+	class := peerClass{initialRank: 10, peerClass: network.PeersPhonebookArchivers}
 	hs := makeHistoricStatus(10, class)
 	hs.push(5, 1, class)
 	require.Equal(t, 1, len(hs.requestGaps))
@@ -531,8 +531,8 @@ func TestClassUpperBound(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}}
-	pClass := PeerClass{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookArchivers}
-	peerSelector := MakePeerSelector(
+	pClass := peerClass{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookArchivers}
+	peerSelector := makePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivers {
@@ -540,7 +540,7 @@ func TestClassUpperBound(t *testing.T) {
 				}
 			}
 			return
-		}), []PeerClass{pClass})
+		}), []peerClass{pClass})
 
 	_, err := peerSelector.GetNextPeer()
 	require.NoError(t, err)
@@ -560,13 +560,13 @@ func TestClassUpperBound(t *testing.T) {
 
 // TestClassLowerBound makes sure the peer rank does not go under the class lower bound
 // This was a bug where the resetRequestPenalty was not bounding the returned rank, and the rankSum was not
-// initialized to give the average of class.InitialRank
+// initialized to give the average of class.initialRank
 func TestClassLowerBound(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}}
-	pClass := PeerClass{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookArchivers}
-	peerSelector := MakePeerSelector(
+	pClass := peerClass{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookArchivers}
+	peerSelector := makePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivers {
@@ -574,7 +574,7 @@ func TestClassLowerBound(t *testing.T) {
 				}
 			}
 			return
-		}), []PeerClass{pClass})
+		}), []peerClass{pClass})
 
 	_, err := peerSelector.GetNextPeer()
 	require.NoError(t, err)
@@ -584,7 +584,7 @@ func TestClassLowerBound(t *testing.T) {
 		peerSelector.RankPeer(psp, lowerBound(pClass))
 
 		for _, pool := range peerSelector.pools {
-			require.GreaterOrEqual(t, pool.rank, pool.peers[0].class.InitialRank)
+			require.GreaterOrEqual(t, pool.rank, pool.peers[0].class.initialRank)
 		}
 	}
 }
@@ -596,7 +596,7 @@ func TestEvictionAndUpgrade(t *testing.T) {
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}}
 	peers2 := []network.Peer{&mockHTTPPeer{address: "a1"}}
 
-	peerSelector := MakePeerSelector(
+	peerSelector := makePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivers {
@@ -606,8 +606,8 @@ func TestEvictionAndUpgrade(t *testing.T) {
 				}
 			}
 			return
-		}), []PeerClass{{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
-			{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays}},
+		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
+			{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays}},
 	)
 
 	_, err := peerSelector.GetNextPeer()

--- a/catchup/peerSelector_test.go
+++ b/catchup/peerSelector_test.go
@@ -126,7 +126,7 @@ func TestPeerSelector(t *testing.T) {
 
 	peers := []network.Peer{&mockHTTPPeer{address: "12345"}}
 
-	peerSelector := makePeerSelector(
+	peerSelector := MakePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) []network.Peer {
 			return peers
 		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers}},
@@ -187,7 +187,7 @@ func TestPeerDownloadRanking(t *testing.T) {
 	peers1 := []network.Peer{&mockHTTPPeer{address: "1234"}, &mockHTTPPeer{address: "5678"}}
 	peers2 := []network.Peer{&mockHTTPPeer{address: "abcd"}, &mockHTTPPeer{address: "efgh"}}
 
-	peerSelector := makePeerSelector(
+	peerSelector := MakePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivers {
@@ -235,7 +235,7 @@ func TestPeerDownloadRanking(t *testing.T) {
 func TestFindMissingPeer(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	peerSelector := makePeerSelector(
+	peerSelector := MakePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) []network.Peer {
 			return []network.Peer{}
 		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers}},
@@ -252,7 +252,7 @@ func TestHistoricData(t *testing.T) {
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}, &mockHTTPPeer{address: "a3"}}
 	peers2 := []network.Peer{&mockHTTPPeer{address: "b1"}, &mockHTTPPeer{address: "b2"}}
 
-	peerSelector := makePeerSelector(
+	peerSelector := MakePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivers {
@@ -325,7 +325,7 @@ func TestPeersDownloadFailed(t *testing.T) {
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}, &mockHTTPPeer{address: "a3"}}
 	peers2 := []network.Peer{&mockHTTPPeer{address: "b1"}, &mockHTTPPeer{address: "b2"}}
 
-	peerSelector := makePeerSelector(
+	peerSelector := MakePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivers {
@@ -400,7 +400,7 @@ func TestPenalty(t *testing.T) {
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}, &mockHTTPPeer{address: "a3"}}
 	peers2 := []network.Peer{&mockHTTPPeer{address: "b1"}, &mockHTTPPeer{address: "b2"}}
 
-	peerSelector := makePeerSelector(
+	peerSelector := MakePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivers {
@@ -460,7 +460,7 @@ func TestPeerDownloadDurationToRank(t *testing.T) {
 	peers3 := []network.Peer{&mockHTTPPeer{address: "c1"}, &mockHTTPPeer{address: "c2"}}
 	peers4 := []network.Peer{&mockHTTPPeer{address: "d1"}, &mockHTTPPeer{address: "b2"}}
 
-	peerSelector := makePeerSelector(
+	peerSelector := MakePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivers {
@@ -532,7 +532,7 @@ func TestClassUpperBound(t *testing.T) {
 
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}}
 	pClass := peerClass{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookArchivers}
-	peerSelector := makePeerSelector(
+	peerSelector := MakePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivers {
@@ -566,7 +566,7 @@ func TestClassLowerBound(t *testing.T) {
 
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}}
 	pClass := peerClass{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookArchivers}
-	peerSelector := makePeerSelector(
+	peerSelector := MakePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivers {
@@ -596,7 +596,7 @@ func TestEvictionAndUpgrade(t *testing.T) {
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}}
 	peers2 := []network.Peer{&mockHTTPPeer{address: "a1"}}
 
-	peerSelector := makePeerSelector(
+	peerSelector := MakePeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivers {

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -425,7 +425,7 @@ func (s *Service) pipelinedFetch(seedLookback uint64) {
 		close(completed)
 	}()
 
-	peerSelector := s.createPeerSelector(true)
+	peerSelector := createPeerSelector(s.net, s.cfg, true)
 
 	if _, err := peerSelector.GetNextPeer(); err == errPeerSelectorNoPeerPoolsAvailable {
 		s.log.Debugf("pipelinedFetch: was unable to obtain a peer to retrieve the block from")
@@ -653,7 +653,7 @@ func (s *Service) fetchRound(cert agreement.Certificate, verifier *agreement.Asy
 	}
 
 	blockHash := bookkeeping.BlockHash(cert.Proposal.BlockDigest) // semantic digest (i.e., hash of the block header), not byte-for-byte digest
-	peerSelector := s.createPeerSelector(false)
+	peerSelector := createPeerSelector(s.net, s.cfg, false)
 	for s.ledger.LastRound() < cert.Round {
 		psp, getPeerErr := peerSelector.GetNextPeer()
 		if getPeerErr != nil {
@@ -755,11 +755,11 @@ func (s *Service) handleUnsupportedRound(nextUnsupportedRound basics.Round) {
 	}
 }
 
-func (s *Service) createPeerSelector(pipelineFetch bool) *PeerSelector {
+func createPeerSelector(net peersRetriever, cfg config.Local, pipelineFetch bool) *PeerSelector {
 	var peerClasses []peerClass
-	if s.cfg.EnableCatchupFromArchiveServers {
+	if cfg.EnableCatchupFromArchiveServers {
 		if pipelineFetch {
-			if s.cfg.NetAddress != "" { // Relay node
+			if cfg.NetAddress != "" { // Relay node
 				peerClasses = []peerClass{
 					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
 					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookArchivers},
@@ -774,7 +774,7 @@ func (s *Service) createPeerSelector(pipelineFetch bool) *PeerSelector {
 				}
 			}
 		} else {
-			if s.cfg.NetAddress != "" { // Relay node
+			if cfg.NetAddress != "" { // Relay node
 				peerClasses = []peerClass{
 					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
 					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersConnectedIn},
@@ -791,7 +791,7 @@ func (s *Service) createPeerSelector(pipelineFetch bool) *PeerSelector {
 		}
 	} else {
 		if pipelineFetch {
-			if s.cfg.NetAddress != "" { // Relay node
+			if cfg.NetAddress != "" { // Relay node
 				peerClasses = []peerClass{
 					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
 					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
@@ -804,7 +804,7 @@ func (s *Service) createPeerSelector(pipelineFetch bool) *PeerSelector {
 				}
 			}
 		} else {
-			if s.cfg.NetAddress != "" { // Relay node
+			if cfg.NetAddress != "" { // Relay node
 				peerClasses = []peerClass{
 					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
 					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersConnectedIn},
@@ -818,5 +818,5 @@ func (s *Service) createPeerSelector(pipelineFetch bool) *PeerSelector {
 			}
 		}
 	}
-	return makePeerSelector(s.net, peerClasses)
+	return makePeerSelector(net, peerClasses)
 }

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -170,7 +170,7 @@ func (s *Service) innerFetch(r basics.Round, peer network.Peer) (blk *bookkeepin
 	}
 
 	ctx, cf := context.WithCancel(s.ctx)
-	fetcher := makeUniversalBlockFetcher(s.log, s.net, s.cfg)
+	fetcher := MakeUniversalBlockFetcher(s.log, s.net, s.cfg)
 	defer cf()
 	stopWaitingForLedgerRound := make(chan struct{})
 	defer close(stopWaitingForLedgerRound)
@@ -181,7 +181,7 @@ func (s *Service) innerFetch(r basics.Round, peer network.Peer) (blk *bookkeepin
 			cf()
 		}
 	}()
-	blk, cert, ddur, err = fetcher.fetchBlock(ctx, r, peer)
+	blk, cert, ddur, err = fetcher.FetchBlock(ctx, r, peer)
 	// check to see if we aborted due to ledger.
 	if err != nil {
 		select {
@@ -818,5 +818,5 @@ func (s *Service) createPeerSelector(pipelineFetch bool) *peerSelector {
 			}
 		}
 	}
-	return makePeerSelector(s.net, peerClasses)
+	return MakePeerSelector(s.net, peerClasses)
 }

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -756,64 +756,64 @@ func (s *Service) handleUnsupportedRound(nextUnsupportedRound basics.Round) {
 }
 
 func (s *Service) createPeerSelector(pipelineFetch bool) *PeerSelector {
-	var peerClasses []peerClass
+	var peerClasses []PeerClass
 	if s.cfg.EnableCatchupFromArchiveServers {
 		if pipelineFetch {
 			if s.cfg.NetAddress != "" { // Relay node
-				peerClasses = []peerClass{
-					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
-					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookArchivers},
-					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookRelays},
-					{initialRank: peerRankInitialFourthPriority, peerClass: network.PeersConnectedIn},
+				peerClasses = []PeerClass{
+					{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersConnectedOut},
+					{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookArchivers},
+					{InitialRank: peerRankInitialThirdPriority, PeerClass: network.PeersPhonebookRelays},
+					{InitialRank: peerRankInitialFourthPriority, PeerClass: network.PeersConnectedIn},
 				}
 			} else {
-				peerClasses = []peerClass{
-					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
-					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersConnectedOut},
-					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookRelays},
+				peerClasses = []PeerClass{
+					{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
+					{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersConnectedOut},
+					{InitialRank: peerRankInitialThirdPriority, PeerClass: network.PeersPhonebookRelays},
 				}
 			}
 		} else {
 			if s.cfg.NetAddress != "" { // Relay node
-				peerClasses = []peerClass{
-					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
-					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersConnectedIn},
-					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookRelays},
-					{initialRank: peerRankInitialFourthPriority, peerClass: network.PeersPhonebookArchivers},
+				peerClasses = []PeerClass{
+					{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersConnectedOut},
+					{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersConnectedIn},
+					{InitialRank: peerRankInitialThirdPriority, PeerClass: network.PeersPhonebookRelays},
+					{InitialRank: peerRankInitialFourthPriority, PeerClass: network.PeersPhonebookArchivers},
 				}
 			} else {
-				peerClasses = []peerClass{
-					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
-					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
-					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookArchivers},
+				peerClasses = []PeerClass{
+					{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersConnectedOut},
+					{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays},
+					{InitialRank: peerRankInitialThirdPriority, PeerClass: network.PeersPhonebookArchivers},
 				}
 			}
 		}
 	} else {
 		if pipelineFetch {
 			if s.cfg.NetAddress != "" { // Relay node
-				peerClasses = []peerClass{
-					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
-					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
-					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersConnectedIn},
+				peerClasses = []PeerClass{
+					{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersConnectedOut},
+					{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays},
+					{InitialRank: peerRankInitialThirdPriority, PeerClass: network.PeersConnectedIn},
 				}
 			} else {
-				peerClasses = []peerClass{
-					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
-					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
+				peerClasses = []PeerClass{
+					{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersConnectedOut},
+					{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays},
 				}
 			}
 		} else {
 			if s.cfg.NetAddress != "" { // Relay node
-				peerClasses = []peerClass{
-					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
-					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersConnectedIn},
-					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookRelays},
+				peerClasses = []PeerClass{
+					{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersConnectedOut},
+					{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersConnectedIn},
+					{InitialRank: peerRankInitialThirdPriority, PeerClass: network.PeersPhonebookRelays},
 				}
 			} else {
-				peerClasses = []peerClass{
-					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
-					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
+				peerClasses = []PeerClass{
+					{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersConnectedOut},
+					{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays},
 				}
 			}
 		}

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -756,67 +756,67 @@ func (s *Service) handleUnsupportedRound(nextUnsupportedRound basics.Round) {
 }
 
 func (s *Service) createPeerSelector(pipelineFetch bool) *PeerSelector {
-	var peerClasses []PeerClass
+	var peerClasses []peerClass
 	if s.cfg.EnableCatchupFromArchiveServers {
 		if pipelineFetch {
 			if s.cfg.NetAddress != "" { // Relay node
-				peerClasses = []PeerClass{
-					{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersConnectedOut},
-					{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookArchivers},
-					{InitialRank: peerRankInitialThirdPriority, PeerClass: network.PeersPhonebookRelays},
-					{InitialRank: peerRankInitialFourthPriority, PeerClass: network.PeersConnectedIn},
+				peerClasses = []peerClass{
+					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
+					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookArchivers},
+					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookRelays},
+					{initialRank: peerRankInitialFourthPriority, peerClass: network.PeersConnectedIn},
 				}
 			} else {
-				peerClasses = []PeerClass{
-					{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersPhonebookArchivers},
-					{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersConnectedOut},
-					{InitialRank: peerRankInitialThirdPriority, PeerClass: network.PeersPhonebookRelays},
+				peerClasses = []peerClass{
+					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
+					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersConnectedOut},
+					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookRelays},
 				}
 			}
 		} else {
 			if s.cfg.NetAddress != "" { // Relay node
-				peerClasses = []PeerClass{
-					{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersConnectedOut},
-					{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersConnectedIn},
-					{InitialRank: peerRankInitialThirdPriority, PeerClass: network.PeersPhonebookRelays},
-					{InitialRank: peerRankInitialFourthPriority, PeerClass: network.PeersPhonebookArchivers},
+				peerClasses = []peerClass{
+					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
+					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersConnectedIn},
+					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookRelays},
+					{initialRank: peerRankInitialFourthPriority, peerClass: network.PeersPhonebookArchivers},
 				}
 			} else {
-				peerClasses = []PeerClass{
-					{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersConnectedOut},
-					{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays},
-					{InitialRank: peerRankInitialThirdPriority, PeerClass: network.PeersPhonebookArchivers},
+				peerClasses = []peerClass{
+					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
+					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
+					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookArchivers},
 				}
 			}
 		}
 	} else {
 		if pipelineFetch {
 			if s.cfg.NetAddress != "" { // Relay node
-				peerClasses = []PeerClass{
-					{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersConnectedOut},
-					{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays},
-					{InitialRank: peerRankInitialThirdPriority, PeerClass: network.PeersConnectedIn},
+				peerClasses = []peerClass{
+					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
+					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
+					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersConnectedIn},
 				}
 			} else {
-				peerClasses = []PeerClass{
-					{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersConnectedOut},
-					{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays},
+				peerClasses = []peerClass{
+					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
+					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
 				}
 			}
 		} else {
 			if s.cfg.NetAddress != "" { // Relay node
-				peerClasses = []PeerClass{
-					{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersConnectedOut},
-					{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersConnectedIn},
-					{InitialRank: peerRankInitialThirdPriority, PeerClass: network.PeersPhonebookRelays},
+				peerClasses = []peerClass{
+					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
+					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersConnectedIn},
+					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookRelays},
 				}
 			} else {
-				peerClasses = []PeerClass{
-					{InitialRank: peerRankInitialFirstPriority, PeerClass: network.PeersConnectedOut},
-					{InitialRank: peerRankInitialSecondPriority, PeerClass: network.PeersPhonebookRelays},
+				peerClasses = []peerClass{
+					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
+					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
 				}
 			}
 		}
 	}
-	return MakePeerSelector(s.net, peerClasses)
+	return makePeerSelector(s.net, peerClasses)
 }

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -834,15 +834,15 @@ func TestCreatePeerSelector(t *testing.T) {
 	s := MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
 	ps := s.createPeerSelector(true)
 	require.Equal(t, 4, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].InitialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].InitialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].InitialRank)
-	require.Equal(t, peerRankInitialFourthPriority, ps.peerClasses[3].InitialRank)
+	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
+	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
+	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
+	require.Equal(t, peerRankInitialFourthPriority, ps.peerClasses[3].initialRank)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].PeerClass)
-	require.Equal(t, network.PeersPhonebookArchivers, ps.peerClasses[1].PeerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].PeerClass)
-	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[3].PeerClass)
+	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
+	require.Equal(t, network.PeersPhonebookArchivers, ps.peerClasses[1].peerClass)
+	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].peerClass)
+	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[3].peerClass)
 
 	// cfg.EnableCatchupFromArchiveServers = true; cfg.NetAddress == ""; pipelineFetch = true;
 	cfg.EnableCatchupFromArchiveServers = true
@@ -850,13 +850,13 @@ func TestCreatePeerSelector(t *testing.T) {
 	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
 	ps = s.createPeerSelector(true)
 	require.Equal(t, 3, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].InitialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].InitialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].InitialRank)
+	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
+	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
+	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
 
-	require.Equal(t, network.PeersPhonebookArchivers, ps.peerClasses[0].PeerClass)
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[1].PeerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].PeerClass)
+	require.Equal(t, network.PeersPhonebookArchivers, ps.peerClasses[0].peerClass)
+	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[1].peerClass)
+	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].peerClass)
 
 	// cfg.EnableCatchupFromArchiveServers = true;  cfg.NetAddress != ""; pipelineFetch = false
 	cfg.EnableCatchupFromArchiveServers = true
@@ -865,15 +865,15 @@ func TestCreatePeerSelector(t *testing.T) {
 	ps = s.createPeerSelector(false)
 
 	require.Equal(t, 4, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].InitialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].InitialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].InitialRank)
-	require.Equal(t, peerRankInitialFourthPriority, ps.peerClasses[3].InitialRank)
+	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
+	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
+	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
+	require.Equal(t, peerRankInitialFourthPriority, ps.peerClasses[3].initialRank)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].PeerClass)
-	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[1].PeerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].PeerClass)
-	require.Equal(t, network.PeersPhonebookArchivers, ps.peerClasses[3].PeerClass)
+	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
+	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[1].peerClass)
+	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].peerClass)
+	require.Equal(t, network.PeersPhonebookArchivers, ps.peerClasses[3].peerClass)
 
 	// cfg.EnableCatchupFromArchiveServers = true; cfg.NetAddress == ""; pipelineFetch = false
 	cfg.EnableCatchupFromArchiveServers = true
@@ -882,13 +882,13 @@ func TestCreatePeerSelector(t *testing.T) {
 	ps = s.createPeerSelector(false)
 
 	require.Equal(t, 3, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].InitialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].InitialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].InitialRank)
+	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
+	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
+	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].PeerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[1].PeerClass)
-	require.Equal(t, network.PeersPhonebookArchivers, ps.peerClasses[2].PeerClass)
+	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
+	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[1].peerClass)
+	require.Equal(t, network.PeersPhonebookArchivers, ps.peerClasses[2].peerClass)
 
 	// cfg.EnableCatchupFromArchiveServers = false; cfg.NetAddress != ""; pipelineFetch = true
 	cfg.EnableCatchupFromArchiveServers = false
@@ -897,13 +897,13 @@ func TestCreatePeerSelector(t *testing.T) {
 	ps = s.createPeerSelector(true)
 
 	require.Equal(t, 3, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].InitialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].InitialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].InitialRank)
+	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
+	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
+	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].PeerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[1].PeerClass)
-	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[2].PeerClass)
+	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
+	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[1].peerClass)
+	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[2].peerClass)
 
 	// cfg.EnableCatchupFromArchiveServers = false; cfg.NetAddress == ""; pipelineFetch = true
 	cfg.EnableCatchupFromArchiveServers = false
@@ -912,11 +912,11 @@ func TestCreatePeerSelector(t *testing.T) {
 	ps = s.createPeerSelector(true)
 
 	require.Equal(t, 2, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].InitialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].InitialRank)
+	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
+	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].PeerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[1].PeerClass)
+	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
+	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[1].peerClass)
 
 	// cfg.EnableCatchupFromArchiveServers = false; cfg.NetAddress != ""; pipelineFetch = false
 	cfg.EnableCatchupFromArchiveServers = false
@@ -925,13 +925,13 @@ func TestCreatePeerSelector(t *testing.T) {
 	ps = s.createPeerSelector(false)
 
 	require.Equal(t, 3, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].InitialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].InitialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].InitialRank)
+	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
+	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
+	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].PeerClass)
-	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[1].PeerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].PeerClass)
+	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
+	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[1].peerClass)
+	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].peerClass)
 
 	// cfg.EnableCatchupFromArchiveServers = false; cfg.NetAddress == ""; pipelineFetch = false
 	cfg.EnableCatchupFromArchiveServers = false
@@ -940,11 +940,11 @@ func TestCreatePeerSelector(t *testing.T) {
 	ps = s.createPeerSelector(false)
 
 	require.Equal(t, 2, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].InitialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].InitialRank)
+	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
+	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].PeerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[1].PeerClass)
+	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
+	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[1].peerClass)
 }
 
 func TestServiceStartStop(t *testing.T) {

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -287,9 +287,9 @@ func TestServiceFetchBlocksOneBlock(t *testing.T) {
 	require.Equal(t, lastRoundAtStart+basics.Round(numBlocks), local.LastRound())
 
 	// Get the same block we wrote
-	block, _, _, err := makeUniversalBlockFetcher(logging.Base(),
+	block, _, _, err := MakeUniversalBlockFetcher(logging.Base(),
 		net,
-		defaultConfig).fetchBlock(context.Background(), lastRoundAtStart+1, net.peers[0])
+		defaultConfig).FetchBlock(context.Background(), lastRoundAtStart+1, net.peers[0])
 
 	require.NoError(t, err)
 
@@ -396,7 +396,7 @@ func TestServiceFetchBlocksMultiBlocks(t *testing.T) {
 
 	// Make Service
 	syncer := MakeService(logging.Base(), defaultConfig, net, local, &mockedAuthenticator{errorRound: -1}, nil, nil)
-	fetcher := makeUniversalBlockFetcher(logging.Base(), net, defaultConfig)
+	fetcher := MakeUniversalBlockFetcher(logging.Base(), net, defaultConfig)
 
 	// Start the service ( dummy )
 	syncer.testStart()
@@ -409,7 +409,7 @@ func TestServiceFetchBlocksMultiBlocks(t *testing.T) {
 
 	for i := basics.Round(1); i <= numberOfBlocks; i++ {
 		// Get the same block we wrote
-		blk, _, _, err2 := fetcher.fetchBlock(context.Background(), i, net.GetPeers()[0])
+		blk, _, _, err2 := fetcher.FetchBlock(context.Background(), i, net.GetPeers()[0])
 		require.NoError(t, err2)
 
 		// Check we wrote the correct block

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -832,7 +832,7 @@ func TestCreatePeerSelector(t *testing.T) {
 
 	cfg.NetAddress = "someAddress"
 	s := MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
-	ps := s.createPeerSelector(true)
+	ps := createPeerSelector(s.net, s.cfg, true)
 	require.Equal(t, 4, len(ps.peerClasses))
 	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
 	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
@@ -848,7 +848,7 @@ func TestCreatePeerSelector(t *testing.T) {
 	cfg.EnableCatchupFromArchiveServers = true
 	cfg.NetAddress = ""
 	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
-	ps = s.createPeerSelector(true)
+	ps = createPeerSelector(s.net, s.cfg, true)
 	require.Equal(t, 3, len(ps.peerClasses))
 	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
 	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
@@ -862,7 +862,7 @@ func TestCreatePeerSelector(t *testing.T) {
 	cfg.EnableCatchupFromArchiveServers = true
 	cfg.NetAddress = "someAddress"
 	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
-	ps = s.createPeerSelector(false)
+	ps = createPeerSelector(s.net, s.cfg, false)
 
 	require.Equal(t, 4, len(ps.peerClasses))
 	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
@@ -879,7 +879,7 @@ func TestCreatePeerSelector(t *testing.T) {
 	cfg.EnableCatchupFromArchiveServers = true
 	cfg.NetAddress = ""
 	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
-	ps = s.createPeerSelector(false)
+	ps = createPeerSelector(s.net, s.cfg, false)
 
 	require.Equal(t, 3, len(ps.peerClasses))
 	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
@@ -894,7 +894,7 @@ func TestCreatePeerSelector(t *testing.T) {
 	cfg.EnableCatchupFromArchiveServers = false
 	cfg.NetAddress = "someAddress"
 	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
-	ps = s.createPeerSelector(true)
+	ps = createPeerSelector(s.net, s.cfg, true)
 
 	require.Equal(t, 3, len(ps.peerClasses))
 	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
@@ -909,7 +909,7 @@ func TestCreatePeerSelector(t *testing.T) {
 	cfg.EnableCatchupFromArchiveServers = false
 	cfg.NetAddress = ""
 	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
-	ps = s.createPeerSelector(true)
+	ps = createPeerSelector(s.net, s.cfg, true)
 
 	require.Equal(t, 2, len(ps.peerClasses))
 	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
@@ -922,7 +922,7 @@ func TestCreatePeerSelector(t *testing.T) {
 	cfg.EnableCatchupFromArchiveServers = false
 	cfg.NetAddress = "someAddress"
 	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
-	ps = s.createPeerSelector(false)
+	ps = createPeerSelector(s.net, s.cfg, false)
 
 	require.Equal(t, 3, len(ps.peerClasses))
 	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
@@ -937,7 +937,7 @@ func TestCreatePeerSelector(t *testing.T) {
 	cfg.EnableCatchupFromArchiveServers = false
 	cfg.NetAddress = ""
 	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
-	ps = s.createPeerSelector(false)
+	ps = createPeerSelector(s.net, s.cfg, false)
 
 	require.Equal(t, 2, len(ps.peerClasses))
 	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -834,15 +834,15 @@ func TestCreatePeerSelector(t *testing.T) {
 	s := MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
 	ps := s.createPeerSelector(true)
 	require.Equal(t, 4, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
-	require.Equal(t, peerRankInitialFourthPriority, ps.peerClasses[3].initialRank)
+	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].InitialRank)
+	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].InitialRank)
+	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].InitialRank)
+	require.Equal(t, peerRankInitialFourthPriority, ps.peerClasses[3].InitialRank)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
-	require.Equal(t, network.PeersPhonebookArchivers, ps.peerClasses[1].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].peerClass)
-	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[3].peerClass)
+	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].PeerClass)
+	require.Equal(t, network.PeersPhonebookArchivers, ps.peerClasses[1].PeerClass)
+	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].PeerClass)
+	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[3].PeerClass)
 
 	// cfg.EnableCatchupFromArchiveServers = true; cfg.NetAddress == ""; pipelineFetch = true;
 	cfg.EnableCatchupFromArchiveServers = true
@@ -850,13 +850,13 @@ func TestCreatePeerSelector(t *testing.T) {
 	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
 	ps = s.createPeerSelector(true)
 	require.Equal(t, 3, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
+	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].InitialRank)
+	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].InitialRank)
+	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].InitialRank)
 
-	require.Equal(t, network.PeersPhonebookArchivers, ps.peerClasses[0].peerClass)
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[1].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].peerClass)
+	require.Equal(t, network.PeersPhonebookArchivers, ps.peerClasses[0].PeerClass)
+	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[1].PeerClass)
+	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].PeerClass)
 
 	// cfg.EnableCatchupFromArchiveServers = true;  cfg.NetAddress != ""; pipelineFetch = false
 	cfg.EnableCatchupFromArchiveServers = true
@@ -865,15 +865,15 @@ func TestCreatePeerSelector(t *testing.T) {
 	ps = s.createPeerSelector(false)
 
 	require.Equal(t, 4, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
-	require.Equal(t, peerRankInitialFourthPriority, ps.peerClasses[3].initialRank)
+	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].InitialRank)
+	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].InitialRank)
+	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].InitialRank)
+	require.Equal(t, peerRankInitialFourthPriority, ps.peerClasses[3].InitialRank)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
-	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[1].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].peerClass)
-	require.Equal(t, network.PeersPhonebookArchivers, ps.peerClasses[3].peerClass)
+	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].PeerClass)
+	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[1].PeerClass)
+	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].PeerClass)
+	require.Equal(t, network.PeersPhonebookArchivers, ps.peerClasses[3].PeerClass)
 
 	// cfg.EnableCatchupFromArchiveServers = true; cfg.NetAddress == ""; pipelineFetch = false
 	cfg.EnableCatchupFromArchiveServers = true
@@ -882,13 +882,13 @@ func TestCreatePeerSelector(t *testing.T) {
 	ps = s.createPeerSelector(false)
 
 	require.Equal(t, 3, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
+	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].InitialRank)
+	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].InitialRank)
+	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].InitialRank)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[1].peerClass)
-	require.Equal(t, network.PeersPhonebookArchivers, ps.peerClasses[2].peerClass)
+	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].PeerClass)
+	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[1].PeerClass)
+	require.Equal(t, network.PeersPhonebookArchivers, ps.peerClasses[2].PeerClass)
 
 	// cfg.EnableCatchupFromArchiveServers = false; cfg.NetAddress != ""; pipelineFetch = true
 	cfg.EnableCatchupFromArchiveServers = false
@@ -897,13 +897,13 @@ func TestCreatePeerSelector(t *testing.T) {
 	ps = s.createPeerSelector(true)
 
 	require.Equal(t, 3, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
+	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].InitialRank)
+	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].InitialRank)
+	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].InitialRank)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[1].peerClass)
-	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[2].peerClass)
+	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].PeerClass)
+	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[1].PeerClass)
+	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[2].PeerClass)
 
 	// cfg.EnableCatchupFromArchiveServers = false; cfg.NetAddress == ""; pipelineFetch = true
 	cfg.EnableCatchupFromArchiveServers = false
@@ -912,11 +912,11 @@ func TestCreatePeerSelector(t *testing.T) {
 	ps = s.createPeerSelector(true)
 
 	require.Equal(t, 2, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
+	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].InitialRank)
+	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].InitialRank)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[1].peerClass)
+	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].PeerClass)
+	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[1].PeerClass)
 
 	// cfg.EnableCatchupFromArchiveServers = false; cfg.NetAddress != ""; pipelineFetch = false
 	cfg.EnableCatchupFromArchiveServers = false
@@ -925,13 +925,13 @@ func TestCreatePeerSelector(t *testing.T) {
 	ps = s.createPeerSelector(false)
 
 	require.Equal(t, 3, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
+	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].InitialRank)
+	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].InitialRank)
+	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].InitialRank)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
-	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[1].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].peerClass)
+	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].PeerClass)
+	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[1].PeerClass)
+	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].PeerClass)
 
 	// cfg.EnableCatchupFromArchiveServers = false; cfg.NetAddress == ""; pipelineFetch = false
 	cfg.EnableCatchupFromArchiveServers = false
@@ -940,11 +940,11 @@ func TestCreatePeerSelector(t *testing.T) {
 	ps = s.createPeerSelector(false)
 
 	require.Equal(t, 2, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
+	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].InitialRank)
+	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].InitialRank)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[1].peerClass)
+	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].PeerClass)
+	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[1].PeerClass)
 }
 
 func TestServiceStartStop(t *testing.T) {

--- a/catchup/universalFetcher.go
+++ b/catchup/universalFetcher.go
@@ -36,14 +36,14 @@ import (
 	"github.com/algorand/go-algorand/rpcs"
 )
 
-// UniversalFetcher fetches blocks either from an http peer or ws peer.
+// UniversalBlockFetcher fetches blocks either from an http peer or ws peer.
 type UniversalBlockFetcher struct {
 	config config.Local
 	net    network.GossipNode
 	log    logging.Logger
 }
 
-// makeUniversalFetcher returns a fetcher for http and ws peers.
+// MakeUniversalBlockFetcher returns a fetcher for http and ws peers.
 func MakeUniversalBlockFetcher(log logging.Logger, net network.GossipNode, config config.Local) *UniversalBlockFetcher {
 	return &UniversalBlockFetcher{
 		config: config,

--- a/catchup/universalFetcher.go
+++ b/catchup/universalFetcher.go
@@ -44,15 +44,15 @@ type universalBlockFetcher struct {
 }
 
 // makeUniversalFetcher returns a fetcher for http and ws peers.
-func makeUniversalBlockFetcher(log logging.Logger, net network.GossipNode, config config.Local) *universalBlockFetcher {
+func MakeUniversalBlockFetcher(log logging.Logger, net network.GossipNode, config config.Local) *universalBlockFetcher {
 	return &universalBlockFetcher{
 		config: config,
 		net:    net,
 		log:    log}
 }
 
-// fetchBlock returns a block from the peer. The peer can be either an http or ws peer.
-func (uf *universalBlockFetcher) fetchBlock(ctx context.Context, round basics.Round, peer network.Peer) (blk *bookkeeping.Block,
+// FetchBlock returns a block from the peer. The peer can be either an http or ws peer.
+func (uf *universalBlockFetcher) FetchBlock(ctx context.Context, round basics.Round, peer network.Peer) (blk *bookkeeping.Block,
 	cert *agreement.Certificate, downloadDuration time.Duration, err error) {
 
 	var fetchedBuf []byte

--- a/catchup/universalFetcher.go
+++ b/catchup/universalFetcher.go
@@ -37,22 +37,22 @@ import (
 )
 
 // UniversalFetcher fetches blocks either from an http peer or ws peer.
-type universalBlockFetcher struct {
+type UniversalBlockFetcher struct {
 	config config.Local
 	net    network.GossipNode
 	log    logging.Logger
 }
 
 // makeUniversalFetcher returns a fetcher for http and ws peers.
-func MakeUniversalBlockFetcher(log logging.Logger, net network.GossipNode, config config.Local) *universalBlockFetcher {
-	return &universalBlockFetcher{
+func MakeUniversalBlockFetcher(log logging.Logger, net network.GossipNode, config config.Local) *UniversalBlockFetcher {
+	return &UniversalBlockFetcher{
 		config: config,
 		net:    net,
 		log:    log}
 }
 
 // FetchBlock returns a block from the peer. The peer can be either an http or ws peer.
-func (uf *universalBlockFetcher) FetchBlock(ctx context.Context, round basics.Round, peer network.Peer) (blk *bookkeeping.Block,
+func (uf *UniversalBlockFetcher) FetchBlock(ctx context.Context, round basics.Round, peer network.Peer) (blk *bookkeeping.Block,
 	cert *agreement.Certificate, downloadDuration time.Duration, err error) {
 
 	var fetchedBuf []byte

--- a/catchup/universalFetcher_test.go
+++ b/catchup/universalFetcher_test.go
@@ -129,7 +129,7 @@ func TestUGetBlockHTTP(t *testing.T) {
 func TestUGetBlockUnsupported(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fetcher := universalBlockFetcher{}
+	fetcher := UniversalBlockFetcher{}
 	peer := ""
 	block, cert, duration, err := fetcher.FetchBlock(context.Background(), 1, peer)
 	require.Error(t, err)

--- a/catchup/universalFetcher_test.go
+++ b/catchup/universalFetcher_test.go
@@ -58,19 +58,19 @@ func TestUGetBlockWs(t *testing.T) {
 	ls := rpcs.MakeBlockService(logging.Base(), blockServiceConfig, ledger, net, "test genesisID")
 	ls.Start()
 
-	fetcher := makeUniversalBlockFetcher(logging.TestingLog(t), net, cfg)
+	fetcher := MakeUniversalBlockFetcher(logging.TestingLog(t), net, cfg)
 
 	var block *bookkeeping.Block
 	var cert *agreement.Certificate
 	var duration time.Duration
 
-	block, cert, _, err = fetcher.fetchBlock(context.Background(), next, up)
+	block, cert, _, err = fetcher.FetchBlock(context.Background(), next, up)
 
 	require.NoError(t, err)
 	require.Equal(t, &b, block)
 	require.GreaterOrEqual(t, int64(duration), int64(0))
 
-	block, cert, duration, err = fetcher.fetchBlock(context.Background(), next+1, up)
+	block, cert, duration, err = fetcher.FetchBlock(context.Background(), next+1, up)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "requested block is not available")
@@ -105,18 +105,18 @@ func TestUGetBlockHTTP(t *testing.T) {
 	rootURL := nodeA.rootURL()
 
 	net.addPeer(rootURL)
-	fetcher := makeUniversalBlockFetcher(logging.TestingLog(t), net, cfg)
+	fetcher := MakeUniversalBlockFetcher(logging.TestingLog(t), net, cfg)
 
 	var block *bookkeeping.Block
 	var cert *agreement.Certificate
 	var duration time.Duration
-	block, cert, duration, err = fetcher.fetchBlock(context.Background(), next, net.GetPeers()[0])
+	block, cert, duration, err = fetcher.FetchBlock(context.Background(), next, net.GetPeers()[0])
 
 	require.NoError(t, err)
 	require.Equal(t, &b, block)
 	require.GreaterOrEqual(t, int64(duration), int64(0))
 
-	block, cert, duration, err = fetcher.fetchBlock(context.Background(), next+1, net.GetPeers()[0])
+	block, cert, duration, err = fetcher.FetchBlock(context.Background(), next+1, net.GetPeers()[0])
 
 	require.Error(t, errNoBlockForRound, err)
 	require.Contains(t, err.Error(), "No block available for given round")
@@ -131,7 +131,7 @@ func TestUGetBlockUnsupported(t *testing.T) {
 
 	fetcher := universalBlockFetcher{}
 	peer := ""
-	block, cert, duration, err := fetcher.fetchBlock(context.Background(), 1, peer)
+	block, cert, duration, err := fetcher.FetchBlock(context.Background(), 1, peer)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "fetchBlock: UniversalFetcher only supports HTTPPeer and UnicastPeer")
 	require.Nil(t, block)
@@ -194,11 +194,11 @@ func TestRequestBlockBytesErrors(t *testing.T) {
 	ls.Start()
 	defer ls.Stop()
 
-	fetcher := makeUniversalBlockFetcher(logging.TestingLog(t), net, cfg)
+	fetcher := MakeUniversalBlockFetcher(logging.TestingLog(t), net, cfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, _, _, err = fetcher.fetchBlock(ctx, next, up)
+	_, _, _, err = fetcher.FetchBlock(ctx, next, up)
 	var wrfe errWsFetcherRequestFailed
 	require.True(t, errors.As(err, &wrfe), "unexpected err: %w", wrfe)
 	require.Equal(t, "context canceled", err.(errWsFetcherRequestFailed).cause)
@@ -208,14 +208,14 @@ func TestRequestBlockBytesErrors(t *testing.T) {
 	responseOverride := network.Response{Topics: network.Topics{network.MakeTopic(rpcs.BlockDataKey, make([]byte, 0))}}
 	up = makeTestUnicastPeerWithResponseOverride(net, t, &responseOverride)
 
-	_, _, _, err = fetcher.fetchBlock(ctx, next, up)
+	_, _, _, err = fetcher.FetchBlock(ctx, next, up)
 	require.True(t, errors.As(err, &wrfe))
 	require.Equal(t, "Cert data not found", err.(errWsFetcherRequestFailed).cause)
 
 	responseOverride = network.Response{Topics: network.Topics{network.MakeTopic(rpcs.CertDataKey, make([]byte, 0))}}
 	up = makeTestUnicastPeerWithResponseOverride(net, t, &responseOverride)
 
-	_, _, _, err = fetcher.fetchBlock(ctx, next, up)
+	_, _, _, err = fetcher.FetchBlock(ctx, next, up)
 	require.True(t, errors.As(err, &wrfe))
 	require.Equal(t, "Block data not found", err.(errWsFetcherRequestFailed).cause)
 }
@@ -255,29 +255,29 @@ func TestGetBlockBytesHTTPErrors(t *testing.T) {
 	rootURL := nodeA.rootURL()
 
 	net.addPeer(rootURL)
-	fetcher := makeUniversalBlockFetcher(logging.TestingLog(t), net, cfg)
+	fetcher := MakeUniversalBlockFetcher(logging.TestingLog(t), net, cfg)
 
 	ls.status = http.StatusBadRequest
-	_, _, _, err := fetcher.fetchBlock(context.Background(), 1, net.GetPeers()[0])
+	_, _, _, err := fetcher.FetchBlock(context.Background(), 1, net.GetPeers()[0])
 	var hre errHTTPResponse
 	require.True(t, errors.As(err, &hre))
 	require.Equal(t, "Response body '\x00'", err.(errHTTPResponse).cause)
 
 	ls.exceedLimit = true
-	_, _, _, err = fetcher.fetchBlock(context.Background(), 1, net.GetPeers()[0])
+	_, _, _, err = fetcher.FetchBlock(context.Background(), 1, net.GetPeers()[0])
 	require.True(t, errors.As(err, &hre))
 	require.Equal(t, "read limit exceeded", err.(errHTTPResponse).cause)
 
 	ls.status = http.StatusOK
 	ls.content = append(ls.content, "undefined")
-	_, _, _, err = fetcher.fetchBlock(context.Background(), 1, net.GetPeers()[0])
+	_, _, _, err = fetcher.FetchBlock(context.Background(), 1, net.GetPeers()[0])
 	var cte errHTTPResponseContentType
 	require.True(t, errors.As(err, &cte))
 	require.Equal(t, "undefined", err.(errHTTPResponseContentType).contentType)
 
 	ls.status = http.StatusOK
 	ls.content = append(ls.content, "undefined2")
-	_, _, _, err = fetcher.fetchBlock(context.Background(), 1, net.GetPeers()[0])
+	_, _, _, err = fetcher.FetchBlock(context.Background(), 1, net.GetPeers()[0])
 	require.True(t, errors.As(err, &cte))
 	require.Equal(t, 2, err.(errHTTPResponseContentType).contentTypeCount)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->
Exporting certain unexported functions from the package `catchup` will widen the use case of `universalFetcher` and `peerSelector` beyond just the catchup package. 

One such use case is explored in https://github.com/algorand/indexer/pull/1063. To run Indexer, blocks can be fetched directly from the gossip network instead of querying a specific `algod` node (usually local).

Proposed functions to be exported:
- from universalFetcher.go
    - `makeUniversalBlockFetcher`
    - `fetchBlock` 
- from peerSelector.go
    - `makePeerSelector` as a new constructor `NewPeerSelector` 
    - `getNextPeer`
    - `rankPeer`

Proposed structs to be exported:
- from universalFetcher.go
    - `universalBlockFetcher`
- from peerSelector.go
    - `peerSelector`
    - `peerSelectorPeer`
