### PR TITLE
Tests:  Attempt to make TestBasicCatchpointCatchup more deterministic

### DIFF
--- a/test/framework/fixtures/restClientFixture.go
+++ b/test/framework/fixtures/restClientFixture.go
@@ -92,7 +92,7 @@ func (f *RestClientFixture) ClientWaitForRound(client client.RestClient, round u
 		}
 		select {
 		case <-timeout.C:
-			return fmt.Errorf("timeout waiting for round %v", round)
+			return fmt.Errorf("timeout waiting for round %v with last round = %v", round, status.LastRound)
 		case <-time.After(200 * time.Millisecond):
 		}
 	}


### PR DESCRIPTION
Attempts to address `TestBasicCatchpointCatchup` failures by making test invocation more deterministic.

I'm generally unfamiliar with the problem space, so take the PR with a grain of salt.  I tested via `gotestsum -- ./test/e2e-go/features/catchup -count=1  -run "TestBasicCatchpointCatchup"`.

I do _not_ think the PR resolves all issues though I hope it's an improvement.  And I'm trying to gauge if others have seen the class of issue described in _notes_.

Notes:
* Example build failure:  https://app.circleci.com/pipelines/github/algorand/go-algorand/8092/workflows/8f01bcf4-8ff0-4474-9eb8-56e0416eb1d3/jobs/145450.  For reasons unclear to me, the issue appears to _only_ impact arm64 processor builds.
* Changes made:
  * During my inspection, I observed failed catchups targeting a round > 37.  Since the test implies catching up to round = 37 is sufficient, I modified the test to pass when catching up to _at least_ round 37.
  * Additionally, I assume it's prudent to ensure _no_ error when invoking `Catchup`.
    * With the assertion added, the test _unreliably_ fails due to an HTTP 404 response.  Example below.

```
    testingLogger.go:38: time="2022-07-25T15:20:11.240524 -0400" level=info msg="Second node catching up to round 1" file=catchpointCatchup_test.go function=github.com/algorand/go-algorand/test/e2e-go/features/catchup.TestBasicCatchpointCatchup line=206
    testingLogger.go:38: time="2022-07-25T15:20:11.241357 -0400" level=info msg=" - done catching up!\n" file=catchpointCatchup_test.go function=github.com/algorand/go-algorand/test/e2e-go/features/catchup.TestBasicCatchpointCatchup line=216
    testingLogger.go:38: time="2022-07-25T15:20:11.259622 -0400" level=info msg="primary node latest catchpoint - !\n" file=catchpointCatchup_test.go function=github.com/algorand/go-algorand/test/e2e-go/features/catchup.TestBasicCatchpointCatchup line=220
    fixture.go:119:
        	Error Trace:	catchpointCatchup_test.go:222
        	Error:      	Received unexpected error:
        	            	HTTP 404 Not Found: {"message":"Not Found"}
        	Test:       	TestBasicCatchpointCatchup
```