### PR TITLE
CI: Add parameter to run Nightly Test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,6 +399,7 @@ commands:
           no_output_timeout: << parameters.no_output_timeout >>
           command: |
             set -x
+            export CI_E2E_FILENAME="${CIRCLE_BRANCH}_nightly"
             export PATH=$(echo "$PATH" | sed -e "s|:${HOME}/\.go_workspace/bin||g" | sed -e 's|:/usr/local/go/bin||g')
             export KMD_NOUSB=True
             export GOPATH="<< parameters.build_dir >>/go"
@@ -653,7 +654,6 @@ jobs:
       # This platform is arbitrary, basically we just want to keep temps for
       # one of the platforms in the matrix.
       CI_KEEP_TEMP_PLATFORM: "amd64"
-      CI_E2E_FILENAME: "${CIRCLE_BRANCH}_nightly"
     steps:
       - prepare_build_dir
       - prepare_go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,9 +516,9 @@ jobs:
       - checkout
       - prepare_go
       - generic_build
-      # - slack/notify: &slack-fail-event
-      #     event: fail
-      #     template: basic_fail_1
+      - slack/notify: &slack-fail-event
+          event: fail
+          template: basic_fail_1
 
   test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,7 +399,7 @@ commands:
           no_output_timeout: << parameters.no_output_timeout >>
           command: |
             set -x
-            export CI_E2E_FILENAME="${CIRCLE_BRANCH/\//-}_nightly"
+            export CI_E2E_FILENAME="${CIRCLE_BRANCH/\//-}"
             export PATH=$(echo "$PATH" | sed -e "s|:${HOME}/\.go_workspace/bin||g" | sed -e 's|:/usr/local/go/bin||g')
             export KMD_NOUSB=True
             export GOPATH="<< parameters.build_dir >>/go"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -653,7 +653,7 @@ jobs:
       # This platform is arbitrary, basically we just want to keep temps for
       # one of the platforms in the matrix.
       CI_KEEP_TEMP_PLATFORM: "amd64"
-      CI_E2E_FILENAME: '{{ .Branch }}_nightly'
+      CI_E2E_FILENAME: "${CIRCLE_BRANCH}_nightly"
     steps:
       - prepare_build_dir
       - prepare_go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,7 +399,7 @@ commands:
           no_output_timeout: << parameters.no_output_timeout >>
           command: |
             set -x
-            export CI_E2E_FILENAME="${CIRCLE_BRANCH}_nightly"
+            export CI_E2E_FILENAME="${CIRCLE_BRANCH/\//-}_nightly"
             export PATH=$(echo "$PATH" | sed -e "s|:${HOME}/\.go_workspace/bin||g" | sed -e 's|:/usr/local/go/bin||g')
             export KMD_NOUSB=True
             export GOPATH="<< parameters.build_dir >>/go"
@@ -516,9 +516,9 @@ jobs:
       - checkout
       - prepare_go
       - generic_build
-      - slack/notify: &slack-fail-event
-          event: fail
-          template: basic_fail_1
+      # - slack/notify: &slack-fail-event
+      #     event: fail
+      #     template: basic_fail_1
 
   test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -650,8 +650,10 @@ jobs:
     environment:
       E2E_TEST_FILTER: "SCRIPTS"
       CI_PLATFORM: << parameters.platform >>
-      CI_KEEP_TEMP_PLATFORM: amd64
-      CI_E2E_FILENAME: nightly
+      # This platform is arbitrary, basically we just want to keep temps for
+      # one of the platforms in the matrix.
+      CI_KEEP_TEMP_PLATFORM: "amd64"
+      CI_E2E_FILENAME: '{{ .Branch }}_nightly'
     steps:
       - prepare_build_dir
       - prepare_go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -647,10 +647,8 @@ jobs:
     environment:
       E2E_TEST_FILTER: "SCRIPTS"
       CI_PLATFORM: << parameters.platform >>
-      # This platform is arbitrary, basically we just want to keep temps for
-      # one of the platforms in the matrix.
-      CI_KEEP_TEMP_PLATFORM: "amd64"
-      CI_E2E_FILENAME: "nightly"
+      CI_KEEP_TEMP_PLATFORM: amd64
+      CI_E2E_FILENAME: nightly
     steps:
       - prepare_build_dir
       - prepare_go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ parameters:
   result_path:
     type: string
     default: "/tmp/build_test_results"
+  valid_nightly_branch:
+    type: string
+    default: /hotfix\/.*/
 
 executors:
   amd64_medium:
@@ -72,7 +75,7 @@ workflows:
             branches:
               ignore:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - << pipeline.parameters.valid_nightly_branch >>
 
       - build_nightly:
           name: << matrix.platform >>_build_nightly
@@ -83,7 +86,7 @@ workflows:
             branches:
               only:
                 - /rel\/.*/
-                - /hotfix\/.*/
+                - << pipeline.parameters.valid_nightly_branch >>
           context: slack-secrets
 
       - test:

--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -181,8 +181,8 @@ if [ -z "$E2E_TEST_FILTER" ] || [ "$E2E_TEST_FILTER" == "SCRIPTS" ]; then
         tar -j -c -f "${CI_E2E_FILENAME}.tar.bz2" --exclude node.log --exclude agreement.cdv net
         rm -rf "${TEMPDIR}/net"
         RSTAMP=$(TZ=UTC python -c 'import time; print("{:08x}".format(0xffffffff - int(time.time() - time.mktime((2020,1,1,0,0,0,-1,-1,-1)))))')
-        echo aws s3 cp --acl public-read "${TEMPDIR}/${CI_E2E_FILENAME}.tar.bz2" "s3://algorand-testdata/indexer/e2e4/${CI_E2E_FILENAME}_${RSTAMP}.tar.bz2"
-        aws s3 cp --acl public-read "${TEMPDIR}/${CI_E2E_FILENAME}.tar.bz2" "s3://algorand-testdata/indexer/e2e4/${CI_E2E_FILENAME}_${RSTAMP}.tar.bz2"
+        echo aws s3 cp --acl public-read "${TEMPDIR}/${CI_E2E_FILENAME}.tar.bz2" "s3://algorand-testdata/indexer/e2e4/${RSTAMP}/${CI_E2E_FILENAME}.tar.bz2"
+        aws s3 cp --acl public-read "${TEMPDIR}/${CI_E2E_FILENAME}.tar.bz2" "s3://algorand-testdata/indexer/e2e4/${RSTAMP}/${CI_E2E_FILENAME}.tar.bz2"
         popd
     fi
 

--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -122,11 +122,11 @@ if [ -z "$E2E_TEST_FILTER" ] || [ "$E2E_TEST_FILTER" == "SCRIPTS" ]; then
     . "${TEMPDIR}/ve/bin/activate"
     "${TEMPDIR}/ve/bin/pip3" install --upgrade pip
     "${TEMPDIR}/ve/bin/pip3" install --upgrade cryptograpy
-    
+
     # Pin a version of our python SDK's so that breaking changes don't spuriously break our tests.
     # Please update as necessary.
     "${TEMPDIR}/ve/bin/pip3" install py-algorand-sdk==1.9.0b1
-    
+
     # Enable remote debugging:
     "${TEMPDIR}/ve/bin/pip3" install --upgrade debugpy
     duration "e2e client setup"
@@ -181,8 +181,8 @@ if [ -z "$E2E_TEST_FILTER" ] || [ "$E2E_TEST_FILTER" == "SCRIPTS" ]; then
         tar -j -c -f "${CI_E2E_FILENAME}.tar.bz2" --exclude node.log --exclude agreement.cdv net
         rm -rf "${TEMPDIR}/net"
         RSTAMP=$(TZ=UTC python -c 'import time; print("{:08x}".format(0xffffffff - int(time.time() - time.mktime((2020,1,1,0,0,0,-1,-1,-1)))))')
-        echo aws s3 cp --acl public-read "${TEMPDIR}/${CI_E2E_FILENAME}.tar.bz2" "s3://algorand-testdata/indexer/e2e4/${RSTAMP}/${CI_E2E_FILENAME}.tar.bz2"
-        aws s3 cp --acl public-read "${TEMPDIR}/${CI_E2E_FILENAME}.tar.bz2" "s3://algorand-testdata/indexer/e2e4/${RSTAMP}/${CI_E2E_FILENAME}.tar.bz2"
+        echo aws s3 cp --acl public-read "${TEMPDIR}/${CI_E2E_FILENAME}.tar.bz2" "s3://algorand-testdata/indexer/e2e4/${CI_E2E_FILENAME}_${RSTAMP}.tar.bz2"
+        aws s3 cp --acl public-read "${TEMPDIR}/${CI_E2E_FILENAME}.tar.bz2" "s3://algorand-testdata/indexer/e2e4/${CI_E2E_FILENAME}_${RSTAMP}.tar.bz2"
         popd
     fi
 


### PR DESCRIPTION
## Summary

We want to easily run nightly test on any branch in the main repo.
Nightly tests remove the `-short` flag from tests. They are longer and more thorough. These tests are important especially for large feature branches.

With these changes, algorand devs can Trigger a pipeline on a branch in the go-algorand repo with:
1. Go to CircleCI and specify Project and Branch
2. Select "Trigger Pipeline"
3. Add Parameter: `valid_nightly_branch: {current_branch_name}`, e.g. `valid_nightly_branch: test/master-copy2`
4. During the amd_build_nightly test, it will upload to algorand-testdata/indexer/e2e4/fb2bec22/test-master-copy2.tar.bz2 

## Test Plan

Triggered the CircleCI job manually and provided the parameter. Made sure the filename is uploaded.
https://app.circleci.com/pipelines/github/algorand/go-algorand?branch=test%2Fmaster-copy2


