### PR TITLE
AVM: change "logic eval error" message to "AVM logic eval error"

### DIFF
--- a/ledger/ledgercore/error.go
+++ b/ledger/ledgercore/error.go
@@ -89,7 +89,7 @@ type LogicEvalError struct {
 
 // Error satisfies builtin interface `error`
 func (err LogicEvalError) Error() string {
-	msg := fmt.Sprintf("logic eval error: %v", err.Err)
+	msg := fmt.Sprintf("AVM logic eval error: %v", err.Err)
 	if len(err.Details) > 0 {
 		msg = fmt.Sprintf("%s. Details: %s", msg, err.Details)
 	}


### PR DESCRIPTION
## Summary

To make it a little more clear, this changes the error message "logic eval error" to "AVM logic eval error" so it is more clear that these errors are coming from evaluating programs that run in the AVM, rather than an error coming from algod's own logic.

## Test Plan

Existing tests should pass.