### PR TITLE
alphanet: define consensus version vAlpha3

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1186,6 +1186,14 @@ func initConsensusProtocols() {
 
 	// vAlpha1 can be upgraded to vAlpha2, with a short update delay of a few hours
 	vAlpha1.ApprovedUpgrades[protocol.ConsensusVAlpha2] = 10000
+
+	vAlpha3 := vAlpha2
+	vAlpha3.AgreementFilterTimeoutPeriod0 = 3400 * time.Millisecond
+
+	Consensus[protocol.ConsensusVAlpha3] = vAlpha3
+
+	// vAlpha2 can be upgraded to vAlpha3, with a short update delay of a few hours
+	vAlpha2.ApprovedUpgrades[protocol.ConsensusVAlpha3] = 10000
 }
 
 // Global defines global Algorand protocol parameters which should not be overridden.

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -194,6 +194,12 @@ const ConsensusVAlpha2 = ConsensusVersion(
 	"alpha2",
 )
 
+// ConsensusVAlpha3 is the second consensus protocol for AlphaNet, which increases the
+// filter timeout to 3.4 seconds.
+const ConsensusVAlpha3 = ConsensusVersion(
+	"alpha3",
+)
+
 // !!! ********************* !!!
 // !!! *** Please update ConsensusCurrentVersion when adding new protocol versions *** !!!
 // !!! ********************* !!!


### PR DESCRIPTION
## Summary

This defines vAlpha3, which sets the period 0 filter timeout to 3.4s.
