### PR TITLE
pass fixture by pointer instead of by value, since it contains a mutex

### DIFF
--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -81,7 +81,7 @@ func (ec *nodeExitErrorCollector) Print() {
 }
 
 // awaitCatchpointCreation attempts catchpoint retrieval with retries when the catchpoint is not yet available.
-func awaitCatchpointCreation(client algodclient.RestClient, fixture fixtures.RestClientFixture, roundWaitCount uint8) (generatedV2.NodeStatusResponse, error) {
+func awaitCatchpointCreation(client algodclient.RestClient, fixture *fixtures.RestClientFixture, roundWaitCount uint8) (generatedV2.NodeStatusResponse, error) {
 	s, err := client.Status()
 	if err != nil {
 		return generatedV2.NodeStatusResponse{}, err
@@ -240,7 +240,7 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 	}
 	log.Infof(" - done catching up!\n")
 
-	status, err := awaitCatchpointCreation(primaryNodeRestClient, fixture, 3)
+	status, err := awaitCatchpointCreation(primaryNodeRestClient, &fixture, 3)
 	a.NoError(err)
 
 	log.Infof("primary node latest catchpoint - %s!\n", status.LastCatchpoint)


### PR DESCRIPTION
`make sanity` fails for this reason. It is not caught by the codegen_verification script as it skips verifying e2e tests:
```
echo "Running go vet..."
go vet $(go list ./... | grep -v /test/e2e-go/)
```