### PR TITLE
config: Resource Cache Size Reduction

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -60,12 +60,12 @@ const baseAccountsPendingAccountsWarnThreshold = 85000
 
 // baseResourcesPendingAccountsBufferSize defines the size of the base resources pending accounts buffer size.
 // At the beginning of a new round, the entries from this buffer are being flushed into the base resources map.
-const baseResourcesPendingAccountsBufferSize = 100000
+const baseResourcesPendingAccountsBufferSize = 10000
 
 // baseResourcesPendingAccountsWarnThreshold defines the threshold at which the lruResources would generate a warning
 // after we've surpassed a given pending account resources size. The warning is being generated when the pending accounts data
 // is being flushed into the main base resources cache.
-const baseResourcesPendingAccountsWarnThreshold = 85000
+const baseResourcesPendingAccountsWarnThreshold = 8500
 
 // initializeCachesReadaheadBlocksStream defines how many block we're going to attempt to queue for the
 // initializeCaches method before it can process and store the account changes to disk.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Branched off of #4296. This PR reduces the LRU resource cache + buffer channel size to 10k from 100k. This change was informed by an investigation into the current value that determined it was higher than necessary for mainnet, where the number of live apps is ~60k, as per metrica. The introduction of box storage also requires extra memory usage so freeing up resources is an added bonus. Note: that the maximum size of the cache may be slightly larger depending on the quantity of resources in the in-memory state deltas. 

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Performance tests are currently being executed to identify any performance degradation. The PR will be updated when the results are available.
