### PR TITLE
Better error message for when an invalid txid is specified.

### DIFF
--- a/daemon/algod/api/server/v2/errors.go
+++ b/daemon/algod/api/server/v2/errors.go
@@ -34,7 +34,7 @@ var (
 	errFailedToParseSourcemap                  = "failed to parse sourcemap"
 	errFailedToEncodeResponse                  = "failed to encode response"
 	errInternalFailure                         = "internal failure"
-	errNoTxnSpecified                          = "no valid transaction ID was specified"
+	errNoValidTxnSpecified                     = "no valid transaction ID was specified"
 	errInvalidHashType                         = "invalid hash type"
 	errTransactionNotFound                     = "could not find the transaction in the transaction pool or in the last 1000 confirmed rounds"
 	errServiceShuttingDown                     = "operation aborted as server is shutting down"

--- a/daemon/algod/api/server/v2/errors.go
+++ b/daemon/algod/api/server/v2/errors.go
@@ -34,7 +34,7 @@ var (
 	errFailedToParseSourcemap                  = "failed to parse sourcemap"
 	errFailedToEncodeResponse                  = "failed to encode response"
 	errInternalFailure                         = "internal failure"
-	errNoTxnSpecified                          = "no transaction ID was specified"
+	errNoTxnSpecified                          = "no valid transaction ID was specified"
 	errInvalidHashType                         = "invalid hash type"
 	errTransactionNotFound                     = "could not find the transaction in the transaction pool or in the last 1000 confirmed rounds"
 	errServiceShuttingDown                     = "operation aborted as server is shutting down"

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -599,7 +599,7 @@ func (v2 *Handlers) GetProof(ctx echo.Context, round uint64, txid string, params
 	var txID transactions.Txid
 	err := txID.UnmarshalText([]byte(txid))
 	if err != nil {
-		return badRequest(ctx, err, errNoTxnSpecified, v2.Log)
+		return badRequest(ctx, err, errNoValidTxnSpecified, v2.Log)
 	}
 
 	if params.Hashtype != nil && *params.Hashtype != "sha512_256" && *params.Hashtype != "sha256" {
@@ -941,7 +941,7 @@ func (v2 *Handlers) PendingTransactionInformation(ctx echo.Context, txid string,
 
 	txID := transactions.Txid{}
 	if err := txID.UnmarshalText([]byte(txid)); err != nil {
-		return badRequest(ctx, err, errNoTxnSpecified, v2.Log)
+		return badRequest(ctx, err, errNoValidTxnSpecified, v2.Log)
 	}
 
 	txn, ok := v2.Node.GetPendingTransaction(txID)


### PR DESCRIPTION
## Summary

While collecting sample data for SDK tests I noticed this error message which could be improved. There was an extra period because I copy/pasted from goal... so the transaction ID is not valid but was specified:
```
~$ curl "localhost:4001/v2/blocks/1502/transactions/PBFTEOO4PFV2RR6KFD2JD5VSUTNVPB2F2GG5F63N4RD52PX47FOQ./proof?pretty" -H "X-Algo-API-Token: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
{
  "message": "no transaction ID was specified"
}
```