### PR TITLE
AVM: Allow fido into a release with v7 on

### DIFF
--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -471,7 +471,7 @@ func TestAssemble(t *testing.T) {
 	}
 }
 
-var experiments = []uint64{fidoVersion, pairingVersion}
+var experiments = []uint64{pairingVersion}
 
 // TestExperimental forces a conscious choice to promote "experimental" opcode
 // groups. This will fail when we increment vFuture's LogicSigVersion. If we had

--- a/data/transactions/logic/evalCrypto_test.go
+++ b/data/transactions/logic/evalCrypto_test.go
@@ -449,10 +449,6 @@ ecdsa_verify Secp256k1`, hex.EncodeToString(r), hex.EncodeToString(s), hex.Encod
 }
 
 func TestEcdsaWithSecp256r1(t *testing.T) {
-	if LogicVersion < fidoVersion {
-		return
-	}
-
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 


### PR DESCRIPTION
This does not activate fido opcodes, but it makes it so that they _can_ be activated by moving LogicVersion=7 in a new consensus version.