### PR TITLE
Ledger: remove txtail from data race test

### DIFF
--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -608,7 +608,9 @@ func TestAcctUpdatesFastUpdates(t *testing.T) {
 	defer au.close()
 	defer ao.close()
 
-	// remove the txtail from the list of trackers
+	// Remove the txtail from the list of trackers since it causes a data race that
+	// wouldn't be observed under normal execution because commitedUpTo and newBlock
+	// are protected by the tracker mutex.
 	ml.trackers.trackers = ml.trackers.trackers[:2]
 
 	// cover 10 genesis blocks

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -608,6 +608,9 @@ func TestAcctUpdatesFastUpdates(t *testing.T) {
 	defer au.close()
 	defer ao.close()
 
+	// remove the txtail from the list of trackers
+	ml.trackers.trackers = ml.trackers.trackers[:2]
+
 	// cover 10 genesis blocks
 	rewardLevel := uint64(0)
 	for i := 1; i < initialBlocksCount; i++ {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

The `TestAcctUpdatesFastUpdates` test calls `committedUpTo` and `newBlock` asynchronously with no locking, which causes a data race in the txtail. Since under normal operation these calls are protected by the tracker mutex, we can simply remove the txtail in this test to avoid test failure.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

This is a test

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
