### PR TITLE
Test: touch fields_string.go so everything is rebuilt in codegen verification

### DIFF
--- a/scripts/travis/codegen_verification.sh
+++ b/scripts/travis/codegen_verification.sh
@@ -78,6 +78,7 @@ GOPATH=$(go env GOPATH)
 "$GOPATH"/bin/algofix -error */
 
 echo "Updating TEAL Specs"
+touch data/transactions/logic/fields_string.go # ensure rebuild
 make -C data/transactions/logic
 
 echo "Regenerate REST server"


### PR DESCRIPTION
Since we commit some products of the `make`, but our goal is to ensure those products are exactly what would be generated, we have to force the generation to actually happen.
