### PR TITLE
test: Fix TestWorkerHandleSigCorrupt

### DIFF
--- a/stateproof/worker_test.go
+++ b/stateproof/worker_test.go
@@ -1239,9 +1239,11 @@ func TestWorkerHandleSigCorrupt(t *testing.T) {
 
 	msg := sigFromAddr{}
 	msgBytes := protocol.Encode(&msg)
-	crypto.RandBytes(msgBytes[:])
+	msgBytes[0] = 55 // arbitrary value to fail protocol.Decode
 
-	// since the handler ignores messages for already approved state proof (and does not disconnect the peer), we need to have a fixed round number to check for disconnection
+	// since the handler ignores messages for already approved
+	// state proof (and does not disconnect the peer), we need to
+	// have a fixed round number to check for disconnection
 	msg.Round = s.blocks[s.latest].StateProofTracking[protocol.StateProofBasic].StateProofNextRound +
 		basics.Round(config.Consensus[s.blocks[s.latest].CurrentProtocol].StateProofInterval)
 


### PR DESCRIPTION
The test is randomly failing. The test expects the message decoding to fail. The message is random bytes, but occasionally, the random bytes are accepted by the decoder, causing the test to fail.

The fix is setting the buffer to an arbitrary number instead of generating random bytes each time. 
