### PR TITLE
Algod: Return immediately in dev mode if pending transaction is found

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -610,6 +610,12 @@ func (node *AlgorandFullNode) GetPendingTransaction(txID transactions.Txid) (res
 		// Keep looking in the ledger.
 	}
 
+	// If we're in dev mode we can safely return immediately
+	// with the found transaction
+	if found && node.devMode {
+		return
+	}
+
 	var maxLife basics.Round
 	latest := node.ledger.Latest()
 	proto, err := node.ledger.ConsensusParams(latest)


### PR DESCRIPTION
There was some hesitation to allowing immediate return after finding the transaction locally but in dev-mode its probably safe and especially useful for speeding up testing
