### PR TITLE
tests: close ledger after TestCatchupUnmatchedCertificate

### DIFF
--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -791,6 +791,7 @@ func TestCatchupUnmatchedCertificate(t *testing.T) {
 		t.Fatal(err)
 		return
 	}
+	defer remote.Close()
 	addBlocks(t, remote, blk, numBlocks-1)
 
 	// Create a network and block service


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

Tests that open up a ledger sometime cause a panic since not all the goroutines are closed after the `TestCatchupUnmatchedCertificate` test and the goroutines print more logging messages. This pr closes the ledger after finishing the test to fix this issue.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

Reran test 100 times, observed no failures. Before there would consistently be failures within 10 runs.
