### PR TITLE
tests: fix TestAssetValidRounds

### DIFF
--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -819,7 +819,7 @@ var changeOnlineCmd = &cobra.Command{
 			}
 		}
 
-		firstTxRound, lastTxRound, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		firstTxRound, lastTxRound, _, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf(err.Error())
 		}
@@ -1430,7 +1430,7 @@ var markNonparticipatingCmd = &cobra.Command{
 
 		dataDir := ensureSingleDataDir()
 		client := ensureFullClient(dataDir)
-		firstTxRound, lastTxRound, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		firstTxRound, lastTxRound, _, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf(errorConstructingTX, err)
 		}

--- a/cmd/goal/application.go
+++ b/cmd/goal/application.go
@@ -461,7 +461,7 @@ var createAppCmd = &cobra.Command{
 		tx.Lease = parseLease(cmd)
 
 		// Fill in rounds, fee, etc.
-		fv, lv, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		fv, lv, _, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf("Cannot determine last valid round: %s", err)
 		}
@@ -536,7 +536,7 @@ var updateAppCmd = &cobra.Command{
 		tx.Lease = parseLease(cmd)
 
 		// Fill in rounds, fee, etc.
-		fv, lv, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		fv, lv, _, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf("Cannot determine last valid round: %s", err)
 		}
@@ -606,7 +606,7 @@ var optInAppCmd = &cobra.Command{
 		tx.Lease = parseLease(cmd)
 
 		// Fill in rounds, fee, etc.
-		fv, lv, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		fv, lv, _, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf("Cannot determine last valid round: %s", err)
 		}
@@ -676,7 +676,7 @@ var closeOutAppCmd = &cobra.Command{
 		tx.Lease = parseLease(cmd)
 
 		// Fill in rounds, fee, etc.
-		fv, lv, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		fv, lv, _, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf("Cannot determine last valid round: %s", err)
 		}
@@ -746,7 +746,7 @@ var clearAppCmd = &cobra.Command{
 		tx.Lease = parseLease(cmd)
 
 		// Fill in rounds, fee, etc.
-		fv, lv, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		fv, lv, _, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf("Cannot determine last valid round: %s", err)
 		}
@@ -816,7 +816,7 @@ var callAppCmd = &cobra.Command{
 		tx.Lease = parseLease(cmd)
 
 		// Fill in rounds, fee, etc.
-		fv, lv, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		fv, lv, _, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf("Cannot determine last valid round: %s", err)
 		}
@@ -886,7 +886,7 @@ var deleteAppCmd = &cobra.Command{
 		tx.Lease = parseLease(cmd)
 
 		// Fill in rounds, fee, etc.
-		fv, lv, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		fv, lv, _, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf("Cannot determine last valid round: %s", err)
 		}
@@ -1307,7 +1307,7 @@ var methodAppCmd = &cobra.Command{
 		appCallTxn.Lease = parseLease(cmd)
 
 		// Fill in rounds, fee, etc.
-		fv, lv, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		fv, lv, _, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf("Cannot determine last valid round: %s", err)
 		}

--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -283,7 +283,7 @@ var createAssetCmd = &cobra.Command{
 		tx.Note = parseNoteField(cmd)
 		tx.Lease = parseLease(cmd)
 
-		fv, lv, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		fv, lv, _, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf("Cannot determine last valid round: %s", err)
 		}
@@ -362,7 +362,7 @@ var destroyAssetCmd = &cobra.Command{
 		tx.Note = parseNoteField(cmd)
 		tx.Lease = parseLease(cmd)
 
-		firstValid, lastValid, err = client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		firstValid, lastValid, _, err = client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf("Cannot determine last valid round: %s", err)
 		}
@@ -455,7 +455,7 @@ var configAssetCmd = &cobra.Command{
 		tx.Note = parseNoteField(cmd)
 		tx.Lease = parseLease(cmd)
 
-		firstValid, lastValid, err = client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		firstValid, lastValid, _, err = client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf("Cannot determine last valid round: %s", err)
 		}
@@ -540,7 +540,7 @@ var sendAssetCmd = &cobra.Command{
 		tx.Note = parseNoteField(cmd)
 		tx.Lease = parseLease(cmd)
 
-		firstValid, lastValid, err = client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		firstValid, lastValid, _, err = client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf("Cannot determine last valid round: %s", err)
 		}
@@ -611,7 +611,7 @@ var freezeAssetCmd = &cobra.Command{
 		tx.Note = parseNoteField(cmd)
 		tx.Lease = parseLease(cmd)
 
-		firstValid, lastValid, err = client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		firstValid, lastValid, _, err = client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf("Cannot determine last valid round: %s", err)
 		}
@@ -698,7 +698,7 @@ var optinAssetCmd = &cobra.Command{
 		tx.Note = parseNoteField(cmd)
 		tx.Lease = parseLease(cmd)
 
-		firstValid, lastValid, err = client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		firstValid, lastValid, _, err = client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf("Cannot determine last valid round: %s", err)
 		}

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -384,7 +384,7 @@ var sendCmd = &cobra.Command{
 			}
 		}
 		client := ensureFullClient(dataDir)
-		firstValid, lastValid, err = client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		firstValid, lastValid, _, err = client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf(err.Error())
 		}

--- a/cmd/goal/interact.go
+++ b/cmd/goal/interact.go
@@ -596,7 +596,7 @@ var appExecuteCmd = &cobra.Command{
 		tx.Lease = parseLease(cmd)
 
 		// Fill in rounds, fee, etc.
-		fv, lv, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
+		fv, lv, _, err := client.ComputeValidityRounds(firstValid, lastValid, numValidRounds)
 		if err != nil {
 			reportErrorf("Cannot determine last valid round: %s", err)
 		}

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -513,7 +513,7 @@ func (c *Client) signAndBroadcastTransactionWithWallet(walletHandle, pw []byte, 
 // 		 M     |     0     | first + validRounds - 1
 // 		 M     |     M     | error
 //
-func (c *Client) ComputeValidityRounds(firstValid, lastValid, validRounds uint64) (uint64, uint64, uint64, error) {
+func (c *Client) ComputeValidityRounds(firstValid, lastValid, validRounds uint64) (first, last, latest uint64, err error) {
 	params, err := c.SuggestedParams()
 	if err != nil {
 		return 0, 0, 0, err
@@ -523,7 +523,7 @@ func (c *Client) ComputeValidityRounds(firstValid, lastValid, validRounds uint64
 		return 0, 0, 0, fmt.Errorf("cannot construct transaction: unknown consensus protocol %s", params.ConsensusVersion)
 	}
 
-	first, last, err := computeValidityRounds(firstValid, lastValid, validRounds, params.LastRound, cparams.MaxTxnLife)
+	first, last, err = computeValidityRounds(firstValid, lastValid, validRounds, params.LastRound, cparams.MaxTxnLife)
 	return first, last, params.LastRound, err
 }
 

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -513,17 +513,18 @@ func (c *Client) signAndBroadcastTransactionWithWallet(walletHandle, pw []byte, 
 // 		 M     |     0     | first + validRounds - 1
 // 		 M     |     M     | error
 //
-func (c *Client) ComputeValidityRounds(firstValid, lastValid, validRounds uint64) (uint64, uint64, error) {
+func (c *Client) ComputeValidityRounds(firstValid, lastValid, validRounds uint64) (uint64, uint64, uint64, error) {
 	params, err := c.SuggestedParams()
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	cparams, ok := c.consensus[protocol.ConsensusVersion(params.ConsensusVersion)]
 	if !ok {
-		return 0, 0, fmt.Errorf("cannot construct transaction: unknown consensus protocol %s", params.ConsensusVersion)
+		return 0, 0, 0, fmt.Errorf("cannot construct transaction: unknown consensus protocol %s", params.ConsensusVersion)
 	}
 
-	return computeValidityRounds(firstValid, lastValid, validRounds, params.LastRound, cparams.MaxTxnLife)
+	first, last, err := computeValidityRounds(firstValid, lastValid, validRounds, params.LastRound, cparams.MaxTxnLife)
+	return first, last, params.LastRound, err
 }
 
 func computeValidityRounds(firstValid, lastValid, validRounds, lastRound, maxTxnLife uint64) (uint64, uint64, error) {

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -52,7 +52,7 @@ proc ::AlgorandGoal::Abort { ERROR } {
         puts "GLOBAL_NETWORK_NAME $::GLOBAL_NETWORK_NAME"
 
         log_user 1
-        set NODE_DATA_DIR $GLOBAL_TEST_ROOT_DIR/Primary
+        set NODE_DATA_DIR $::GLOBAL_TEST_ROOT_DIR/Primary
         if { [info exists ::NODE_DATA_DIR] } {
             set outLog [exec cat $NODE_DATA_DIR/algod-out.log]
             puts "$NODE_DATA_DIR/algod-out.log :\r\n$outLog"
@@ -61,7 +61,7 @@ proc ::AlgorandGoal::Abort { ERROR } {
             set nodeLog [exec -- tail -n 30 $NODE_DATA_DIR/node.log]
             puts "$NODE_DATA_DIR/node.log :\r\n$nodeLog"
         }
-        set NODE_DATA_DIR $GLOBAL_TEST_ROOT_DIR/Node
+        set NODE_DATA_DIR $::GLOBAL_TEST_ROOT_DIR/Node
         if { [info exists ::NODE_DATA_DIR] } {
             set outLog [exec cat $NODE_DATA_DIR/algod-out.log]
             puts "$NODE_DATA_DIR/algod-out.log :\r\n$outLog"
@@ -78,12 +78,12 @@ proc ::AlgorandGoal::Abort { ERROR } {
         puts "GLOBAL_TEST_ALGO_DIR $::GLOBAL_TEST_ALGO_DIR"
 
         log_user 1
-        set outLog [exec cat $GLOBAL_TEST_ALGO_DIR/algod-out.log]
-        puts "$GLOBAL_TEST_ALGO_DIR/algod-out.log :\r\n$outLog"
-        set errLog [exec cat $GLOBAL_TEST_ALGO_DIR/algod-err.log]
+        set outLog [exec cat $::GLOBAL_TEST_ALGO_DIR/algod-out.log]
+        puts "$::GLOBAL_TEST_ALGO_DIR/algod-out.log :\r\n$outLog"
+        set errLog [exec cat $::GLOBAL_TEST_ALGO_DIR/algod-err.log]
         puts "$NODE_DATA_DIR/algod-err.log :\r\n$errLog"
-        set nodeLog [exec -- tail -n 30 $GLOBAL_TEST_ALGO_DIR/node.log]
-        puts "$GLOBAL_TEST_ALGO_DIR/node.log :\r\n$nodeLog"
+        set nodeLog [exec -- tail -n 30 $::GLOBAL_TEST_ALGO_DIR/node.log]
+        puts "$::GLOBAL_TEST_ALGO_DIR/node.log :\r\n$nodeLog"
 
         ::AlgorandGoal::StopNode $::GLOBAL_TEST_ALGO_DIR
     }

--- a/test/e2e-go/features/transactions/application_test.go
+++ b/test/e2e-go/features/transactions/application_test.go
@@ -66,7 +66,7 @@ func TestApplication(t *testing.T) {
 	a.NoError(err)
 
 	creator := accountList[0].Address
-	wh, err := client.GetUnencryptedWalletHandle()
+	_, err = client.GetUnencryptedWalletHandle()
 	a.NoError(err)
 
 	fee := uint64(1000)
@@ -101,7 +101,7 @@ log
 	a.NoError(err)
 	tx, err = client.FillUnsignedTxTemplate(creator, 0, 0, fee, tx)
 	a.NoError(err)
-	wh, err = client.GetUnencryptedWalletHandle()
+	wh, err := client.GetUnencryptedWalletHandle()
 	a.NoError(err)
 	signedTxn, err := client.SignTransactionWithWallet(wh, nil, tx)
 	a.NoError(err)
@@ -122,6 +122,7 @@ log
 	logs[31] = "c"
 
 	b, err := client.BookkeepingBlock(round)
+	a.NoError(err)
 	for _, ps := range b.Payset {
 		ed := ps.ApplyData.EvalDelta
 		ok = checkEqual(logs, ed.Logs)

--- a/test/e2e-go/features/transactions/onlineStatusChange_test.go
+++ b/test/e2e-go/features/transactions/onlineStatusChange_test.go
@@ -101,6 +101,7 @@ func testAccountsCanChangeOnlineState(t *testing.T, templatePath string) {
 	goOfflineUTx, err := client.MakeUnsignedGoOfflineTx(initiallyOnline, curRound, curRound+transactionValidityPeriod, transactionFee, [32]byte{})
 	a.NoError(err, "should be able to make go offline tx")
 	wh, err = client.GetUnencryptedWalletHandle()
+	a.NoError(err)
 	offlineTxID, err := client.SignAndBroadcastTransaction(wh, nil, goOfflineUTx)
 	a.NoError(err, "should be no errors when going offline")
 
@@ -112,6 +113,7 @@ func testAccountsCanChangeOnlineState(t *testing.T, templatePath string) {
 		becomeNonparticpatingUTx, err := client.MakeUnsignedBecomeNonparticipatingTx(becomesNonparticipating, curRound, curRound+transactionValidityPeriod, transactionFee)
 		a.NoError(err, "should be able to make become-nonparticipating tx")
 		wh, err = client.GetUnencryptedWalletHandle()
+		a.NoError(err)
 		nonparticipatingTxID, err = client.SignAndBroadcastTransaction(wh, nil, becomeNonparticpatingUTx)
 		a.NoError(err, "should be  no errors when marking nonparticipating")
 	}
@@ -170,6 +172,7 @@ func TestCloseOnError(t *testing.T) {
 
 	var partkeyFile string
 	_, partkeyFile, err = client.GenParticipationKeysTo(initiallyOffline, 0, curRound+1000, 0, t.TempDir())
+	a.NoError(err)
 
 	// make a participation key for initiallyOffline
 	_, err = client.AddParticipationKey(partkeyFile)

--- a/test/e2e-go/features/transactions/sendReceive_test.go
+++ b/test/e2e-go/features/transactions/sendReceive_test.go
@@ -93,7 +93,9 @@ func testAccountsCanSendMoney(t *testing.T, templatePath string, numberOfSends i
 	}
 
 	pingBalance, err := c.GetBalance(pingAccount)
+	a.NoError(err)
 	pongBalance, err := c.GetBalance(pongAccount)
+	a.NoError(err)
 
 	a.Equal(pingBalance, pongBalance, "both accounts should start with same balance")
 	a.NotEqual(pingAccount, pongAccount, "accounts under study should be different")


### PR DESCRIPTION
## Summary

* The test validates first/last valid against possible expired value of lastRound.
  Make ComputeValidityRounds returning lastValid to check validity range against it.
* Fix some linter warnings
* Modify all usages of ComputeValidityRounds

## Test Plan

This is a test