### PR TITLE
test: fix TestAccountsCanSendMoney

### DIFF
--- a/test/e2e-go/features/transactions/sendReceive_test.go
+++ b/test/e2e-go/features/transactions/sendReceive_test.go
@@ -124,12 +124,11 @@ func testAccountsCanSendMoney(t *testing.T, templatePath string, numberOfSends i
 		expectedPongBalance = expectedPongBalance - transactionFee - amountPongSendsPing + amountPingSendsPong
 
 		var pongTxInfo, pingTxInfo v1.Transaction
-		pongTxInfo, err = pingClient.PendingTransactionInformation(pongTx.ID().String())
+		pongTxInfo, err = pongClient.PendingTransactionInformation(pongTx.ID().String())
 		if err == nil {
 			pingTxInfo, err = pingClient.PendingTransactionInformation(pingTx.ID().String())
 		}
 		waitForTransaction = err != nil || pongTxInfo.ConfirmedRound == 0 || pingTxInfo.ConfirmedRound == 0
-
 		if waitForTransaction {
 			curStatus, _ := pongClient.Status()
 			curRound := curStatus.LastRound
@@ -143,6 +142,7 @@ func testAccountsCanSendMoney(t *testing.T, templatePath string, numberOfSends i
 	if waitForTransaction {
 		fixture.AlgodClient = fixture.GetAlgodClientForController(fixture.GetNodeControllerForDataDir(pongClient.DataDir()))
 		fixture.WaitForAllTxnsToConfirm(curRound+uint64(5), pingTxidsToAddresses)
+		fixture.WaitForAllTxnsToConfirm(curRound+uint64(5), pongTxidsToAddresses)
 	}
 
 	pingBalance, _ = fixture.GetBalanceAndRound(pingAccount)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

The TestAccountsCanSendMoney test flakes and sometimes returns that an account has a different balance than expected. This happens because we don't wait for all txns to confirm, only a set of them. Fix it such that we wait for all txns to confirm.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

This is a test.
