### PR TITLE
Refactoring:  Remove unused logicSigBatchVerify parameter:  batchVerifier

### DIFF
--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -238,7 +238,7 @@ func stxnVerifyCore(s *transactions.SignedTxn, txnIdx int, groupCtx *GroupContex
 		return errors.New("multisig validation failed")
 	}
 	if hasLogicSig {
-		return logicSigBatchVerify(s, txnIdx, groupCtx, batchVerifier)
+		return logicSigBatchVerify(s, txnIdx, groupCtx)
 	}
 	return errors.New("has one mystery sig. WAT?")
 }
@@ -336,7 +336,7 @@ func LogicSigSanityCheckBatchVerify(txn *transactions.SignedTxn, groupIndex int,
 
 // logicSigBatchVerify checks that the signature is valid, executing the program.
 // it is the caller responsibility to call batchVerifier.verify()
-func logicSigBatchVerify(txn *transactions.SignedTxn, groupIndex int, groupCtx *GroupContext, batchverifier *crypto.BatchVerifier) error {
+func logicSigBatchVerify(txn *transactions.SignedTxn, groupIndex int, groupCtx *GroupContext) error {
 	err := LogicSigSanityCheck(txn, groupIndex, groupCtx)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

Following discussion in https://github.com/algorand/go-algorand/pull/4322#discussion_r938212627, removes unused `batchVerifier` parameter in `logicSigBatchVerify`.

## Test Plan

`gotestsum -- ./data/transactions/verify`
