### PR TITLE
AVM: Updates to `data/abi` code 

### DIFF
--- a/data/abi/abi_json_test.go
+++ b/data/abi/abi_json_test.go
@@ -26,8 +26,11 @@ import (
 )
 
 func TestAddress(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
 	t.Run("valid", func(t *testing.T) {
-		partitiontest.PartitionTest(t)
+		t.Parallel()
 		testCases := []struct {
 			addressString   string
 			addressBytes    [32]byte
@@ -63,6 +66,7 @@ func TestAddress(t *testing.T) {
 	})
 
 	t.Run("invalid", func(t *testing.T) {
+		t.Parallel()
 		testCases := []struct {
 			addressString string
 			expectedError string
@@ -100,6 +104,7 @@ func TestAddress(t *testing.T) {
 
 func TestUnmarshalFromJSON(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	var testCases = []struct {
 		input    string
 		typeStr  string
@@ -184,24 +189,26 @@ func TestUnmarshalFromJSON(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		abiT, err := TypeOf(testCase.typeStr)
-		require.NoError(t, err, "fail to construct ABI type: %s", testCase.typeStr)
+		t.Run(testCase.input, func(t *testing.T) {
+			abiT, err := TypeOf(testCase.typeStr)
+			require.NoError(t, err, "fail to construct ABI type: %s", testCase.typeStr)
 
-		res, err := abiT.UnmarshalFromJSON([]byte(testCase.input))
-		require.NoError(t, err, "fail to unmarshal JSON to interface: (%s): %v", testCase.input, err)
-		require.Equal(t, testCase.expected, res, "%v not matching with expected value %v", res, testCase.expected)
+			res, err := abiT.UnmarshalFromJSON([]byte(testCase.input))
+			require.NoError(t, err, "fail to unmarshal JSON to interface: (%s): %v", testCase.input, err)
+			require.Equal(t, testCase.expected, res, "%v not matching with expected value %v", res, testCase.expected)
 
-		resEncoded, err := abiT.Encode(res)
-		require.NoError(t, err, "fail to encode %v to ABI bytes: %v", res, err)
-		resDecoded, err := abiT.Decode(resEncoded)
-		require.NoError(t, err, "fail to decode ABI bytes of %v: %v", res, err)
-		require.Equal(t, res, resDecoded, "ABI encode-decode round trip: %v not match with expected %v", resDecoded, res)
+			resEncoded, err := abiT.Encode(res)
+			require.NoError(t, err, "fail to encode %v to ABI bytes: %v", res, err)
+			resDecoded, err := abiT.Decode(resEncoded)
+			require.NoError(t, err, "fail to decode ABI bytes of %v: %v", res, err)
+			require.Equal(t, res, resDecoded, "ABI encode-decode round trip: %v not match with expected %v", resDecoded, res)
+		})
 	}
 }
 
 func TestMarshalToJSON(t *testing.T) {
 	partitiontest.PartitionTest(t)
-
+	t.Parallel()
 	var testCases = []struct {
 		input    interface{}
 		typeStr  string

--- a/data/abi/abi_json_test.go
+++ b/data/abi/abi_json_test.go
@@ -324,10 +324,10 @@ func TestMarshalToJSON(t *testing.T) {
 			abiT, err := TypeOf(testCase.typeStr)
 			require.NoError(t, err, "fail to construct ABI type: %s", testCase.typeStr)
 
-			actualJson, err := abiT.MarshalToJSON(testCase.input)
+			actualJSON, err := abiT.MarshalToJSON(testCase.input)
 			require.NoError(t, err)
 
-			require.Equal(t, testCase.expected, string(actualJson))
+			require.Equal(t, testCase.expected, string(actualJSON))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

This PR makes changes to `data/abi` code in preparation for it to be moved to a new repo. Specifically, these change are contained in this PR:

* I found a bug in `Type.MarshalToJSON` when it's called on an `address` with a `[32]byte` as an input. In this case, the code copied the input to a nil slice, then raised an error since the slice's length was not 32.
* Added `TestMarshalToJSON` to test the failing case, and a few other scenarios.
* Removed the testing dependency on `data/basics`. Instead of generating random addresses and ensuring the `data/abi` address code produces the same result as the `data/basics` code, I've manually created tests cases for verification.
* (Minor) Updated some error messages to use `%w` instead of `%v` to wrap errors when appropriate.

I am not looking to merge this PR into go-algorand. Instead, I want to achieve consensus on this changeset before the code is moved to a new repo.

## Test Plan

New tests added.
