### PR TITLE
stateproofs: reorganize the full pool tests

### DIFF
--- a/test/e2e-go/features/stateproofs/stateproofs_test.go
+++ b/test/e2e-go/features/stateproofs/stateproofs_test.go
@@ -986,7 +986,7 @@ func TestSPWithCounterReset(t *testing.T) {
 	// Check that the first 2 stateproofs are added to the blockchain
 	round := uint64(0)
 	expectedSPRound := consensusParams.StateProofInterval * 2
-	for round < consensusParams.StateProofInterval*5 {
+	for round < consensusParams.StateProofInterval*6 {
 		round = params.LastRound
 
 		err := fixture.WaitForRound(round+1, 6*time.Second)
@@ -1023,7 +1023,7 @@ func TestSPWithCounterReset(t *testing.T) {
 		}
 	}
 	// If waited till round 20 and did not yet get the stateproof with last round 12, fail the test
-	require.Less(t, round, consensusParams.StateProofInterval*5)
+	require.Less(t, round, consensusParams.StateProofInterval*6)
 }
 
 func getWellformedSPTransaction(round uint64, genesisHash crypto.Digest, consensusParams config.ConsensusParams, t *testing.T) (stxn transactions.SignedTxn) {

--- a/test/e2e-go/features/stateproofs/stateproofs_test.go
+++ b/test/e2e-go/features/stateproofs/stateproofs_test.go
@@ -986,7 +986,7 @@ func TestSPWithCounterReset(t *testing.T) {
 	// Check that the first 2 stateproofs are added to the blockchain
 	round := uint64(0)
 	expectedSPRound := consensusParams.StateProofInterval * 2
-	for round < consensusParams.StateProofInterval*6 {
+	for round < consensusParams.StateProofInterval*10 {
 		round = params.LastRound
 
 		err := fixture.WaitForRound(round+1, 6*time.Second)
@@ -1023,7 +1023,7 @@ func TestSPWithCounterReset(t *testing.T) {
 		}
 	}
 	// If waited till round 20 and did not yet get the stateproof with last round 12, fail the test
-	require.Less(t, round, consensusParams.StateProofInterval*6)
+	require.Less(t, round, consensusParams.StateProofInterval*10)
 }
 
 func getWellformedSPTransaction(round uint64, genesisHash crypto.Digest, consensusParams config.ConsensusParams, t *testing.T) (stxn transactions.SignedTxn) {

--- a/test/e2e-go/features/stateproofs/stateproofs_test.go
+++ b/test/e2e-go/features/stateproofs/stateproofs_test.go
@@ -890,7 +890,7 @@ func TestSPWithTXPoolFull(t *testing.T) {
 // TestAtMostOneSPFullPool tests that there is at most one SP txn is admitted to the pool per roound
 // when the pool is full. Note that the test sets TxPoolSize to 0 to simulate a full pool, which
 // guarantees that no more than 1 SP txn get into a block. In normal configuration, it is
-// possible to have multiple SPs getting into the same block when the pool is full. 
+// possible to have multiple SPs getting into the same block when the pool is full.
 func TestAtMostOneSPFullPool(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	defer fixtures.ShutdownSynchronizedTest(t)
@@ -1102,7 +1102,7 @@ func TestAtMostOneSPFullPoolWithLoad(t *testing.T) {
 		}
 	}
 	// Do not check if the SPs were added to the block. TestAtMostOneSPFullPool checks it.
-	// In some environments (ARM) the high load may prevent it. 
+	// In some environments (ARM) the high load may prevent it.
 }
 
 func getWellformedSPTransaction(round uint64, genesisHash crypto.Digest, consensusParams config.ConsensusParams, t *testing.T) (stxn transactions.SignedTxn) {


### PR DESCRIPTION
Divide the test into two tests, one without load, and one with load. 
Skip the SP in block check for the latter. 