### PR TITLE
Goal: Remove “contact us” from box name mismatch error

### DIFF
--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -102,7 +102,7 @@ const (
 	errorClearProgArgsRequired     = "Exactly one of --clear-prog or --clear-prog-raw is required"
 	errorMissingBoxName            = "Box --name is required"
 	errorInvalidBoxName            = "Failed to parse box name %s. It must have the same form as app-arg."
-	errorBoxNameMismatch           = "Inputted box name %s does not match box name %s received from algod, please contact us, this shouldn't happen"
+	errorBoxNameMismatch           = "Inputted box name %s does not match box name %s received from algod"
 
 	// Clerk
 	infoTxIssued               = "Sent %d MicroAlgos from account %s to address %s, transaction ID: %s. Fee set to %d"


### PR DESCRIPTION
## Summary

This PR removes language recommending that the user contact us when a particular error occurs. This change follows directly from [a conversation in the simulate endpoint PR](https://github.com/algorand/go-algorand/pull/4322#discussion_r937946084).
