### PR TITLE
test: fix TestAccountsCanSendMoney #2

### DIFF
--- a/test/e2e-go/features/transactions/sendReceive_test.go
+++ b/test/e2e-go/features/transactions/sendReceive_test.go
@@ -139,24 +139,25 @@ func testAccountsCanSendMoney(t *testing.T, templatePath string, numberOfSends i
 	curStatus, _ := pongClient.Status()
 	curRound := curStatus.LastRound
 
-	if waitForTransaction {
-		fixture.AlgodClient = fixture.GetAlgodClientForController(fixture.GetNodeControllerForDataDir(pongClient.DataDir()))
-		fixture.WaitForAllTxnsToConfirm(curRound+uint64(5), pingTxidsToAddresses)
-		fixture.WaitForAllTxnsToConfirm(curRound+uint64(5), pongTxidsToAddresses)
-	}
+	fixture.AlgodClient = fixture.GetAlgodClientForController(fixture.GetNodeControllerForDataDir(pongClient.DataDir()))
+	fixture.WaitForAllTxnsToConfirm(curRound+uint64(5), pingTxidsToAddresses)
+	fixture.WaitForAllTxnsToConfirm(curRound+uint64(5), pongTxidsToAddresses)
 
-	pingBalance, _ = fixture.GetBalanceAndRound(pingAccount)
-	pongBalance, _ = fixture.GetBalanceAndRound(pongAccount)
+	pingBalance, err = pongClient.GetBalance(pingAccount)
+	a.NoError(err)
+	pongBalance, err = pongClient.GetBalance(pongAccount)
+	a.NoError(err)
 	a.True(expectedPingBalance <= pingBalance, "ping balance is different than expected.")
 	a.True(expectedPongBalance <= pongBalance, "pong balance is different than expected.")
 
-	if waitForTransaction {
-		fixture.AlgodClient = fixture.GetAlgodClientForController(fixture.GetNodeControllerForDataDir(pingClient.DataDir()))
-		fixture.WaitForAllTxnsToConfirm(curRound+uint64(5), pongTxidsToAddresses)
-	}
+	fixture.AlgodClient = fixture.GetAlgodClientForController(fixture.GetNodeControllerForDataDir(pingClient.DataDir()))
+	fixture.WaitForAllTxnsToConfirm(curRound+uint64(5), pingTxidsToAddresses)
+	fixture.WaitForAllTxnsToConfirm(curRound+uint64(5), pongTxidsToAddresses)
 
-	pingBalance, _ = fixture.GetBalanceAndRound(pingAccount)
-	pongBalance, _ = fixture.GetBalanceAndRound(pongAccount)
+	pingBalance, err = pingClient.GetBalance(pingAccount)
+	a.NoError(err)
+	pongBalance, err = pingClient.GetBalance(pongAccount)
+	a.NoError(err)
 	a.True(expectedPingBalance <= pingBalance, "ping balance is different than expected.")
 	a.True(expectedPongBalance <= pongBalance, "pong balance is different than expected.")
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

The TestAccountsCanSendMoney test is still flaky and this pr aims to fix it. Another problem observed was that the test aims to check the balances of both accounts are correct on both ping and pong nodes by calling the `fixture.GetBalanceAndRound` function. However this function always calls the ping node and never the pong node. Thus we have logic which first ensures that the txns are confirmed on the pong node, then incorrectly checks the balances on the ping node instead of the pong node. The ping node may be out of sync and return the wrong balances.

This pr corrects this by checking the balance on the pong node instead of the ping node.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

This is a test.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
