### PR TITLE
network: make txBacklogSize responsive to block size

### DIFF
--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"sync"
 
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/pools"
@@ -38,7 +39,8 @@ import (
 // The size txBacklogSize used to determine the size of the backlog that is used to store incoming transaction messages before starting dropping them.
 // It should be configured to be higher then the number of CPU cores, so that the execution pool get saturated, but not too high to avoid lockout of the
 // execution pool for a long duration of time.
-const txBacklogSize = 1000
+// Set backlog at 'approximately one block' by dividing block size by a typical transaction size.
+var txBacklogSize = config.Consensus[protocol.ConsensusCurrentVersion].MaxTxnBytesPerBlock / 200
 
 var transactionMessagesHandled = metrics.MakeCounter(metrics.TransactionMessagesHandled)
 var transactionMessagesDroppedFromBacklog = metrics.MakeCounter(metrics.TransactionMessagesDroppedFromBacklog)


### PR DESCRIPTION
## Summary

Make a channel length `txBacklogSize` responsive to up coming changes in block size. Hold approximately one block of txns in channel. Manual testing has shown that `txBacklogSize` needs to be increased from its original size of 1000.

## Test Plan

Manually experimented and verified in cluster tests.