### PR TITLE
fun: StateProofSender vanity address.

### DIFF
--- a/data/transactions/stateproof.go
+++ b/data/transactions/stateproof.go
@@ -17,7 +17,6 @@
 package transactions
 
 import (
-	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/stateproof"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/stateproofmsg"
@@ -41,18 +40,13 @@ func (sp StateProofTxnFields) Empty() bool {
 		sp.Message.MsgIsZero()
 }
 
-//msgp:ignore specialAddr
-// specialAddr is used to form a unique address that will send out state proofs.
-type specialAddr string
-
-// ToBeHashed implements the crypto.Hashable interface
-func (a specialAddr) ToBeHashed() (protocol.HashID, []byte) {
-	return protocol.SpecialAddr, []byte(a)
-}
-
 // StateProofSender is the computed address for sending out state proofs.
 var StateProofSender basics.Address
 
 func init() {
-	StateProofSender = basics.Address(crypto.HashObj(specialAddr("StateProofSender")))
+	var err error
+	StateProofSender, err = basics.UnmarshalChecksumAddress("STATEPROOF7777777BJVASCJJZMDX3567PX3JEYBGEHUJY4FAAAN6DXNRU")
+	if err != nil {
+		panic(err)
+	}
 }

--- a/protocol/hash.go
+++ b/protocol/hash.go
@@ -58,7 +58,6 @@ const (
 	ProposerSeed                     HashID = "PS"
 	ParticipationKeys                HashID = "PK"
 	Seed                             HashID = "SD"
-	SpecialAddr                      HashID = "SpecialAddr"
 	SignedTxnInBlock                 HashID = "STIB"
 
 	StateProofCoin    HashID = "spc"

--- a/test/e2e-go/features/stateproofs/stateproofs_test.go
+++ b/test/e2e-go/features/stateproofs/stateproofs_test.go
@@ -965,12 +965,6 @@ func TestAtMostOneSPFullPool(t *testing.T) {
 	require.Less(t, round, consensusParams.StateProofInterval*10)
 }
 
-type specialAddr string
-
-func (a specialAddr) ToBeHashed() (protocol.HashID, []byte) {
-	return protocol.SpecialAddr, []byte(a)
-}
-
 // TestSPWithCounterReset tests if the state proof transaction is getting into the pool and eventually
 // at most one SP is getting into the block when the transaction pool is full.
 // Bad SP and payment transaction traffic is added to increase the odds of getting SP txn into the pool


### PR DESCRIPTION
## Summary

Using a vanity address makes it clearer that this address is probably not a real one. Also, there are some easter eggs in this address :)

## Test Plan

CI