### PR TITLE
test: un-shadow loadgen privateKeys var

### DIFF
--- a/cmd/loadgenerator/main.go
+++ b/cmd/loadgenerator/main.go
@@ -137,7 +137,7 @@ func main() {
 		}
 	} else if len(algodDir) > 0 {
 		// get test cluster local unlocked wallet
-		privateKeys := findRootKeys(algodDir)
+		privateKeys = findRootKeys(algodDir)
 		if len(privateKeys) == 0 {
 			fmt.Fprintf(os.Stderr, "%s: found no root keys\n", algodDir)
 			os.Exit(1)


### PR DESCRIPTION
## Summary

I am sad that `go vet` didn't have a warning about this shadowing of a variable name.

## Test Plan

Manual test tool was tested manually.