### PR TITLE
test: wait until new block is committed to `BlockQueue`

### DIFF
--- a/ledger/internal/eval_blackbox_test.go
+++ b/ledger/internal/eval_blackbox_test.go
@@ -533,6 +533,14 @@ func endBlock(t testing.TB, ledger *ledger.Ledger, eval *internal.BlockEvaluator
 	require.NoError(t, err)
 	err = ledger.AddValidatedBlock(*validatedBlock, agreement.Certificate{})
 	require.NoError(t, err)
+	// `rndBQ` gives the latest known block round added to the ledger
+	// we should wait until `rndBQ` block to be committed to blockQueue,
+	// in case there is a data race, noted in
+	// https://github.com/algorand/go-algorand/issues/4349
+	// where writing to `callTxnGroup` after `dl.fullBlock` caused data race,
+	// because the underlying async goroutine `go bq.syncer()` is reading `callTxnGroup`.
+	// A solution here would be wait until all new added blocks are committed,
+	// then we return the result and continue the execution.
 	rndBQ := ledger.Latest()
 	ledger.WaitForCommit(rndBQ)
 	return validatedBlock

--- a/ledger/internal/eval_blackbox_test.go
+++ b/ledger/internal/eval_blackbox_test.go
@@ -533,6 +533,8 @@ func endBlock(t testing.TB, ledger *ledger.Ledger, eval *internal.BlockEvaluator
 	require.NoError(t, err)
 	err = ledger.AddValidatedBlock(*validatedBlock, agreement.Certificate{})
 	require.NoError(t, err)
+	rndBQ := ledger.Latest()
+	ledger.WaitForCommit(rndBQ)
 	return validatedBlock
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

By https://github.com/algorand/go-algorand/issues/4349, we noticed a datarace in `testMaxInnerTxnSingleAppCall`. This PR waits the ledger to commit every new blocks in `blockQueue` to be committed in function `endBlock`.
