### PR TITLE
tests: Add logging to libgoal fixture on failure

### DIFF
--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -311,6 +311,10 @@ func (f *LibGoalFixture) ShutdownImpl(preserveData bool) {
 	f.NC.StopKMD()
 	if preserveData {
 		f.network.Stop(f.binDir)
+		f.dumpLogs(f.PrimaryDataDir())
+		for _, nodeDir := range f.NodeDataDirs() {
+			f.dumpLogs(nodeDir)
+		}
 	} else {
 		f.network.Delete(f.binDir)
 
@@ -322,6 +326,22 @@ func (f *LibGoalFixture) ShutdownImpl(preserveData bool) {
 			os.Remove(f.testDir)
 		}
 	}
+}
+
+// dumpLogs prints out node.log files for the running nodes
+func (f *LibGoalFixture) dumpLogs(dataDir string) {
+	file, err := os.Open(dataDir + "/node.log")
+	if err != nil {
+		f.t.Logf("could not open %s node.log", dataDir)
+		return
+	}
+	b, err := ioutil.ReadAll(file)
+	if err != nil {
+		f.t.Logf("could not read %s node.log", dataDir)
+		return
+	}
+	fmt.Println("node.log for ", dataDir)
+	fmt.Print(string(b))
 }
 
 // intercept baseFixture.failOnError so we can clean up any algods that are still alive

--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -313,12 +313,8 @@ func (f *LibGoalFixture) ShutdownImpl(preserveData bool) {
 	if preserveData {
 		f.network.Stop(f.binDir)
 		f.dumpLogs(f.PrimaryDataDir() + "/node.log")
-		f.dumpLogs(f.PrimaryDataDir() + "/algod-err.log")
-		f.dumpLogs(f.PrimaryDataDir() + "/algod-out.log")
 		for _, nodeDir := range f.NodeDataDirs() {
 			f.dumpLogs(nodeDir + "/node.log")
-			f.dumpLogs(nodeDir + "/algod-err.log")
-			f.dumpLogs(nodeDir + "/algod-out.log")
 		}
 	} else {
 		f.network.Delete(f.binDir)
@@ -333,11 +329,11 @@ func (f *LibGoalFixture) ShutdownImpl(preserveData bool) {
 	}
 }
 
-// dumpLogs prints out node.log files for the running nodes
+// dumpLogs prints out log files for the running nodes
 func (f *LibGoalFixture) dumpLogs(filePath string) {
 	file, err := os.Open(filePath)
 	if err != nil {
-		f.t.Logf("could not open %s node.log", filePath)
+		f.t.Logf("could not open %s", filePath)
 		return
 	}
 	var lines []string

--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -336,19 +336,14 @@ func (f *LibGoalFixture) dumpLogs(filePath string) {
 		f.t.Logf("could not open %s", filePath)
 		return
 	}
-	var lines []string
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
-	}
-	//if len(lines) > 100 {
-	//	lines = lines[len(lines)-100:]
-	//}
-	f.t.Log("=================================")
+	defer file.Close()
+
+	f.t.Log("=================================\n")
 	parts := strings.Split(filePath, "/")
 	f.t.Logf("%s/%s:", parts[len(parts)-2], parts[len(parts)-1]) // Primary/node.log
-	for _, line := range lines {
-		f.t.Logf(line)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		f.t.Logf(scanner.Text())
 	}
 }
 

--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -312,9 +312,9 @@ func (f *LibGoalFixture) ShutdownImpl(preserveData bool) {
 	f.NC.StopKMD()
 	if preserveData {
 		f.network.Stop(f.binDir)
-		f.dumpLogs(f.PrimaryDataDir() + "/node.log")
+		f.dumpLogs(filepath.Join(f.PrimaryDataDir(), "node.log"))
 		for _, nodeDir := range f.NodeDataDirs() {
-			f.dumpLogs(nodeDir + "/node.log")
+			f.dumpLogs(filepath.Join(nodeDir, "node.log"))
 		}
 	} else {
 		f.network.Delete(f.binDir)

--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -341,10 +341,10 @@ func (f *LibGoalFixture) dumpLogs(filePath string) {
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())
 	}
-	if len(lines) > 100 {
-		lines = lines[len(lines)-100:]
-	}
-	f.t.Logln("=================================")
+	//if len(lines) > 100 {
+	//	lines = lines[len(lines)-100:]
+	//}
+	f.t.Log("=================================")
 	parts := strings.Split(filePath, "/")
 	f.t.Logf("%s/%s:", parts[len(parts)-2], parts[len(parts)-1]) // Primary/node.log
 	for _, line := range lines {

--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -344,7 +344,9 @@ func (f *LibGoalFixture) dumpLogs(filePath string) {
 	if len(lines) > 100 {
 		lines = lines[len(lines)-100:]
 	}
-	f.t.Logf("contents of ", filePath)
+	f.t.Logln("=================================")
+	parts := strings.Split(filePath, "/")
+	f.t.Logf("%s/%s:", parts[len(parts)-2], parts[len(parts)-1]) // Primary/node.log
 	for _, line := range lines {
 		f.t.Logf(line)
 	}

--- a/test/framework/fixtures/restClientFixture.go
+++ b/test/framework/fixtures/restClientFixture.go
@@ -268,10 +268,19 @@ func (f *RestClientFixture) WaitForAllTxnsToConfirm(roundTimeout uint64, txidsAn
 			f.t.Logf("txn failed to confirm: ", addr, txid)
 			pendingTxns, err := f.AlgodClient.GetPendingTransactions(0)
 			if err == nil {
-				f.t.Logf("pending: ", pendingTxns)
+				pendingTxids := make([]string, 0, pendingTxns.TotalTxns)
+				for _, txn := range pendingTxns.TruncatedTxns.Transactions {
+					pendingTxids = append(pendingTxids, txn.TxID)
+				}
+				f.t.Logf("pending txids: ", pendingTxids)
 			} else {
 				f.t.Logf("unable to log pending txns, ", err)
 			}
+			allTxids := make([]string, 0, len(txidsAndAddresses))
+			for txID := range txidsAndAddresses {
+				allTxids = append(allTxids, txID)
+			}
+			f.t.Logf("all txids: ", allTxids)
 			return false
 		}
 	}

--- a/test/framework/fixtures/restClientFixture.go
+++ b/test/framework/fixtures/restClientFixture.go
@@ -265,6 +265,13 @@ func (f *RestClientFixture) WaitForAllTxnsToConfirm(roundTimeout uint64, txidsAn
 	for txid, addr := range txidsAndAddresses {
 		_, err := f.WaitForConfirmedTxn(roundTimeout, addr, txid)
 		if err != nil {
+			f.t.Logf("txn failed to confirm: ", addr, txid)
+			pendingTxns, err := f.AlgodClient.GetPendingTransactions(0)
+			if err == nil {
+				f.t.Logf("pending: ", pendingTxns)
+			} else {
+				f.t.Logf("unable to log pending txns, ", err)
+			}
 			return false
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

When a test running the libgoal fixture, flakes, it is difficult for us to diagnose the problem. Print out node.log to the test console so we can analyze the problem.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Purposely failed test to check whether logs were dumped.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
