### PR TITLE
tests: fix TestBasicCatchpointCatchup

### DIFF
--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -19,9 +19,10 @@ package catchup
 import (
 	"context"
 	"fmt"
-	"github.com/algorand/go-algorand/stateproof"
 	"sync"
 	"time"
+
+	"github.com/algorand/go-algorand/stateproof"
 
 	"github.com/algorand/go-deadlock"
 
@@ -497,6 +498,7 @@ func (cs *CatchpointCatchupService) processStageBlocksDownload() (err error) {
 	if lookback < lookbackForStateProofSupport {
 		lookback = lookbackForStateProofSupport
 	}
+
 	// in case the effective lookback is going before our rounds count, trim it there.
 	// ( a catchpoint is generated starting round MaxBalLookback, and this is a possible in any round in the range of MaxBalLookback..MaxTxnLife)
 	if lookback >= uint64(topBlock.Round()) {
@@ -586,9 +588,12 @@ func (cs *CatchpointCatchupService) processStageBlocksDownload() (err error) {
 			return cs.abort(fmt.Errorf("processStageBlocksDownload: downloaded block content does not match downloaded block header"))
 		}
 
-		cs.updateBlockRetrievalStatistics(0, 1)
-		peerRank := cs.blocksDownloadPeerSelector.peerDownloadDurationToRank(psp, blockDownloadDuration)
-		cs.blocksDownloadPeerSelector.rankPeer(psp, peerRank)
+		if psp != nil {
+			// the block might have been retrieved from the local ledger, nothing to rank
+			cs.updateBlockRetrievalStatistics(0, 1)
+			peerRank := cs.blocksDownloadPeerSelector.peerDownloadDurationToRank(psp, blockDownloadDuration)
+			cs.blocksDownloadPeerSelector.rankPeer(psp, peerRank)
+		}
 
 		// all good, persist and move on.
 		err = cs.ledgerAccessor.StoreBlock(cs.ctx, blk)

--- a/test/e2e-go/cli/goal/expect/catchpointCatchupWebProxy/webproxy.go
+++ b/test/e2e-go/cli/goal/expect/catchpointCatchupWebProxy/webproxy.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/algorand/go-deadlock"
 
+	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/test/framework/fixtures"
 )
 
@@ -49,14 +50,15 @@ func main() {
 		return
 	}
 	var mu deadlock.Mutex
-	wp, err := fixtures.MakeWebProxy(*webProxyDestination, func(response http.ResponseWriter, request *http.Request, next http.HandlerFunc) {
+	log := logging.Base()
+	wp, err := fixtures.MakeWebProxy(*webProxyDestination, log, func(response http.ResponseWriter, request *http.Request, next http.HandlerFunc) {
 		mu.Lock()
 		time.Sleep(time.Duration(*webProxyRequestDelay) * time.Millisecond)
 		mu.Unlock()
 		// prevent requests for block #2 to go through.
 		if strings.HasSuffix(request.URL.String(), "/block/2") {
-			response.Write([]byte("webProxy prevents block 2 from serving"))
 			response.WriteHeader(http.StatusBadRequest)
+			response.Write([]byte("webProxy prevents block 2 from serving"))
 			return
 		}
 		if *webProxyLogFile != "" {

--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -18,7 +18,6 @@ package catchup
 
 import (
 	"fmt"
-	generatedV2 "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
 	"net/http"
 	"os/exec"
 	"path/filepath"
@@ -26,6 +25,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	generatedV2 "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
 
 	"github.com/algorand/go-deadlock"
 	"github.com/stretchr/testify/require"
@@ -116,11 +117,11 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 
 	// Overview of this test:
 	// Start a two-node network (primary has 100%, secondary has 0%)
-	// Nodes are having a consensus allowing balances history of 32 rounds and transaction history of 33 rounds.
-	// Let it run for 37 rounds.
-	// create a web proxy, and connect it to the primary node, blocking all requests for round #1. ( and allowing everything else )
-	// start a secondary node, and instuct it to catchpoint catchup from the proxy. ( which would be for round 36 )
-	// wait until the clone node cought up, skipping the "impossible" hole of round #1.
+	// Nodes are having a consensus allowing balances history of 8 rounds and transaction history of 13 rounds.
+	// Let it run for 21 rounds.
+	// create a web proxy, and connect it to the primary node, blocking all requests for round #2. ( and allowing everything else )
+	// start a secondary node, and instuct it to catchpoint catchup from the proxy. ( which would be for round 20 )
+	// wait until the clone node cought up, skipping the "impossible" hole of round #2.
 
 	consensus := make(config.ConsensusProtocols)
 	const consensusCatchpointCatchupTestProtocol = protocol.ConsensusVersion("catchpointtestingprotocol")
@@ -129,9 +130,9 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 	// MaxBalLookback  =  2 x SeedRefreshInterval x SeedLookback
 	// ref. https://github.com/algorandfoundation/specs/blob/master/dev/abft.md
 	catchpointCatchupProtocol.SeedLookback = 2
-	catchpointCatchupProtocol.SeedRefreshInterval = 8
-	catchpointCatchupProtocol.MaxBalLookback = 2 * catchpointCatchupProtocol.SeedLookback * catchpointCatchupProtocol.SeedRefreshInterval // 32
-	catchpointCatchupProtocol.MaxTxnLife = 33
+	catchpointCatchupProtocol.SeedRefreshInterval = 2
+	catchpointCatchupProtocol.MaxBalLookback = 2 * catchpointCatchupProtocol.SeedLookback * catchpointCatchupProtocol.SeedRefreshInterval // 8
+	catchpointCatchupProtocol.MaxTxnLife = 13
 	catchpointCatchupProtocol.CatchpointLookback = catchpointCatchupProtocol.MaxBalLookback
 	catchpointCatchupProtocol.EnableOnlineAccountCatchpoints = true
 
@@ -161,13 +162,16 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 	// prepare it's configuration file to set it to generate a catchpoint every 4 rounds.
 	cfg, err := config.LoadConfigFromDisk(primaryNode.GetDataDir())
 	a.NoError(err)
-	cfg.CatchpointInterval = 4
+	const catchpointInterval = 4
+	cfg.CatchpointInterval = catchpointInterval
 	cfg.MaxAcctLookback = 2
 	cfg.SaveToDisk(primaryNode.GetDataDir())
 	cfg.Archival = false
+	cfg.CatchpointInterval = 0
 	cfg.NetAddress = ""
 	cfg.EnableLedgerService = false
 	cfg.EnableBlockService = false
+	cfg.BaseLoggerDebugLevel = uint32(logging.Debug)
 	cfg.SaveToDisk(secondNode.GetDataDir())
 
 	// start the primary node
@@ -180,10 +184,14 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 		ExitErrorCallback: errorsCollector.nodeExitWithError,
 	})
 	a.NoError(err)
+	defer primaryNode.StopAlgod()
 
 	// Let the network make some progress
 	currentRound := uint64(1)
-	const targetRound = uint64(37)
+	expectedBlocksToDownload := catchpointCatchupProtocol.MaxTxnLife + catchpointCatchupProtocol.DeeperBlockHeaderHistory
+	const restrictedBlock = 2 // block number that is rejected to be downloaded to ensure fast catchup and not regular catchup is running
+	// calculate the target round: this is the next round after catchpoint that is greater than expectedBlocksToDownload before the restrictedBlock block number
+	targetRound := (uint64(expectedBlocksToDownload+restrictedBlock)/catchpointInterval+1)*catchpointInterval + 1 // 21
 	primaryNodeRestClient := fixture.GetAlgodClientForController(primaryNode)
 	primaryNodeRestClient.SetAPIVersionAffinity(algodclient.APIVersionV2)
 	log.Infof("Building ledger history..")
@@ -200,10 +208,11 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 	primaryListeningAddress, err := primaryNode.GetListeningAddress()
 	a.NoError(err)
 
-	wp, err := fixtures.MakeWebProxy(primaryListeningAddress, func(response http.ResponseWriter, request *http.Request, next http.HandlerFunc) {
+	wp, err := fixtures.MakeWebProxy(primaryListeningAddress, log, func(response http.ResponseWriter, request *http.Request, next http.HandlerFunc) {
 		// prevent requests for block #2 to go through.
 		if request.URL.String() == "/v1/test-v1/block/2" {
 			response.WriteHeader(http.StatusBadRequest)
+			response.Write([]byte("webProxy prevents block 2 from serving"))
 			return
 		}
 		next(response, request)
@@ -222,6 +231,7 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 		ExitErrorCallback: errorsCollector.nodeExitWithError,
 	})
 	a.NoError(err)
+	defer secondNode.StopAlgod()
 
 	// wait until node is caught up.
 	secondNodeRestClient := fixture.GetAlgodClientForController(secondNode)
@@ -243,7 +253,7 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 	status, err := awaitCatchpointCreation(primaryNodeRestClient, &fixture, 3)
 	a.NoError(err)
 
-	log.Infof("primary node latest catchpoint - %s!\n", status.LastCatchpoint)
+	log.Infof("primary node latest catchpoint - %s!\n", *status.LastCatchpoint)
 	_, err = secondNodeRestClient.Catchup(*status.LastCatchpoint)
 	a.NoError(err)
 
@@ -260,9 +270,6 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 		currentRound++
 	}
 	log.Infof("done catching up!\n")
-
-	secondNode.StopAlgod()
-	primaryNode.StopAlgod()
 }
 
 func TestCatchpointLabelGeneration(t *testing.T) {


### PR DESCRIPTION
## Summary

* After the protocol upgrade nodes required to have MaxTxnLife + DeeperBlockHeaderHistory
  blocks that violated the test's expectations.
* Fixed a rare case when a block exists in a local ledger but peer's stat is still updated
  even if no communications were made.

## Tests

Run the test multiple times