### PR TITLE
Bugfix: download more block to recover old state proofs

### DIFF
--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -473,8 +473,10 @@ func lookbackForStateproofsSupport(topBlock *bookkeeping.Block) uint64 {
 		return 0
 	}
 	lowestStateProofRound := stateproof.GetOldestExpectedStateProof(&topBlock.BlockHeader)
-	// in order to be able to confirm lowestStateProofRound we need to have round number: (lowestStateProofRound - stateproofInterval)
+	// in order to be able to confirm/build lowestStateProofRound we would need to reconstruct
+	// the corresponding voterForRound which is (lowestStateProofRound - stateproofInterval - VotersLookback)
 	lowestStateProofRound = lowestStateProofRound.SubSaturate(basics.Round(proto.StateProofInterval))
+	lowestStateProofRound = lowestStateProofRound.SubSaturate(basics.Round(proto.StateProofVotersLookback))
 	return uint64(topBlock.Round().SubSaturate(lowestStateProofRound))
 }
 

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -988,7 +988,7 @@ func TestDownloadBlocksToSupportStateProofs(t *testing.T) {
 
 	lookback := lookbackForStateproofsSupport(&topBlk)
 	oldestRound := topBlk.BlockHeader.Round.SubSaturate(basics.Round(lookback))
-	assert.Equal(t, uint64(oldestRound), 512-config.Consensus[protocol.ConsensusFuture].StateProofInterval)
+	assert.Equal(t, uint64(oldestRound), 512-config.Consensus[protocol.ConsensusFuture].StateProofInterval-config.Consensus[protocol.ConsensusFuture].StateProofVotersLookback)
 
 	// the network has made progress and now it is on round 8000. in this case we would not download blocks to cover 512.
 	// instead, we will download blocks to confirm only the recovery period lookback.
@@ -1002,7 +1002,9 @@ func TestDownloadBlocksToSupportStateProofs(t *testing.T) {
 	lookback = lookbackForStateproofsSupport(&topBlk)
 	oldestRound = topBlk.BlockHeader.Round.SubSaturate(basics.Round(lookback))
 
-	lowestRoundToRetain := 8000 - (8000 % 256) - (config.Consensus[protocol.ConsensusCurrentVersion].StateProofInterval * (config.Consensus[protocol.ConsensusCurrentVersion].StateProofMaxRecoveryIntervals + 1))
+	lowestRoundToRetain := 8000 - (8000 % config.Consensus[protocol.ConsensusCurrentVersion].StateProofInterval) -
+		config.Consensus[protocol.ConsensusCurrentVersion].StateProofInterval*(config.Consensus[protocol.ConsensusCurrentVersion].StateProofMaxRecoveryIntervals+1) - config.Consensus[protocol.ConsensusFuture].StateProofVotersLookback
+
 	assert.Equal(t, uint64(oldestRound), lowestRoundToRetain)
 
 	topBlk = bookkeeping.Block{}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

A fast-catchuped node should be able to be part of state proofs creation. In order to do that, it must download all necessary blocks. Currently, if the state proof chain is lagging the node download `lowestStateProofRound - stateproofInterval` rounds back on fast catchup. This is not accurate since the balances comes from `lowestStateProofRound - stateproofInterval - StateProofVotersLookback`

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Manual fast catchup test.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
