### PR TITLE
CI: Four missing partiontest calls. And minor doc update.

### DIFF
--- a/data/transactions/logic/README.md
+++ b/data/transactions/logic/README.md
@@ -615,7 +615,7 @@ Account fields used in the `acct_params_get` opcode.
 | `app_params_get f` | X is field F from app A. Y is 1 if A exists, else 0 |
 | `acct_params_get f` | X is field F from account A. Y is 1 if A owns positive algos, else 0 |
 | `log` | write A to log state of the current application |
-| `block f` | field F of block A. Fail unless A falls between txn.LastValid-1002 and the current round (exclusive) |
+| `block f` | field F of block A. Fail unless A falls between txn.LastValid-1002 and txn.FirstValid (exclusive) |
 
 ### Inner Transactions
 

--- a/data/transactions/logic/TEAL_opcodes.md
+++ b/data/transactions/logic/TEAL_opcodes.md
@@ -1401,7 +1401,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 - Opcode: 0xd1 {uint8 block field}
 - Stack: ..., A: uint64 &rarr; ..., any
-- field F of block A. Fail unless A falls between txn.LastValid-1002 and the current round (exclusive)
+- field F of block A. Fail unless A falls between txn.LastValid-1002 and txn.FirstValid (exclusive)
 - Availability: v7
 
 `block` Fields:

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -479,6 +479,9 @@ var experiments = []uint64{pairingVersion}
 // intended to release the opcodes, they should have been removed from
 // `experiments`.
 func TestExperimental(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
 	futureV := config.Consensus[protocol.ConsensusFuture].LogicSigVersion
 	for _, v := range experiments {
 		// Allows less, so we can push something out, even before vFuture has been updated.

--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -192,7 +192,7 @@ var opDocByName = map[string]string{
 	"itxn_submit": "execute the current inner transaction group. Fail if executing this group would exceed the inner transaction limit, or if any transaction in the group fails.",
 
 	"vrf_verify": "Verify the proof B of message A against pubkey C. Returns vrf output and verification flag.",
-	"block":      "field F of block A. Fail unless A falls between txn.LastValid-1002 and the current round (exclusive)",
+	"block":      "field F of block A. Fail unless A falls between txn.LastValid-1002 and txn.FirstValid (exclusive)",
 }
 
 // OpDoc returns a description of the op

--- a/data/transactions/logic/evalCrypto_test.go
+++ b/data/transactions/logic/evalCrypto_test.go
@@ -109,6 +109,9 @@ byte 0x%s
 }
 
 func TestVrfVerify(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
 	ep, _, _ := makeSampleEnv()
 	testApp(t, notrack("int 1; int 2; int 3; vrf_verify VrfAlgorand"), ep, "arg 0 wanted")
 	testApp(t, notrack("byte 0x1122; int 2; int 3; vrf_verify VrfAlgorand"), ep, "arg 1 wanted")

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -2536,6 +2536,9 @@ func TestLatestTimestamp(t *testing.T) {
 }
 
 func TestBlockSeed(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
 	ep, txn, l := makeSampleEnv()
 
 	// makeSampleEnv creates txns with fv, lv that don't actually fit the round

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -5510,6 +5510,9 @@ func TestOpJSONRef(t *testing.T) {
 }
 
 func TestTypeComplaints(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
 	testProg(t, "err; store 0", AssemblerMaxVersion)
 	testProg(t, "int 1; return; store 0", AssemblerMaxVersion)
 }

--- a/data/transactions/logic/langspec.json
+++ b/data/transactions/logic/langspec.json
@@ -2297,7 +2297,7 @@
       "Args": "U",
       "Returns": ".",
       "Size": 2,
-      "Doc": "field F of block A. Fail unless A falls between txn.LastValid-1002 and the current round (exclusive)",
+      "Doc": "field F of block A. Fail unless A falls between txn.LastValid-1002 and txn.FirstValid (exclusive)",
       "ImmediateNote": "{uint8 block field}",
       "Groups": [
         "State Access"


### PR DESCRIPTION
We were missing some partitiontest calls. I don't know why the checking didn't fail. It DID see the problem
<img width="1346" alt="Screen Shot 2022-08-11 at 9 38 45 AM" src="https://user-images.githubusercontent.com/442319/184146523-b439c176-7f66-41fe-99dd-6a0a4bcebd1e.png">

It seems to me that a) The linter was supposed to complain. and b) the test checker should have failed.
