### PR TITLE
tests: stabilize TestAssetCreateWaitRestartDelete

### DIFF
--- a/test/e2e-go/features/transactions/asset_test.go
+++ b/test/e2e-go/features/transactions/asset_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -970,6 +971,13 @@ func TestAssetCreateWaitRestartDelete(t *testing.T) {
 	verifyAssetParameters(asset, "test", "testunit", manager, reserve, freeze, clawback,
 		assetMetadataHash, assetURL, a)
 
+	// Ensure manager is funded before submitting any transactions
+	currentRound, err := client.CurrentRound()
+	a.NoError(err)
+
+	err = fixture.WaitForAccountFunded(currentRound+5, manager)
+	a.NoError(err)
+
 	// Destroy the asset
 	tx, err := client.MakeUnsignedAssetDestroyTx(assetIndex)
 	a.NoError(err)
@@ -1009,6 +1017,8 @@ func TestAssetCreateWaitBalLookbackDelete(t *testing.T) {
 	consensusParams.SeedLookback = 2
 	consensusParams.SeedRefreshInterval = 8
 	consensusParams.MaxBalLookback = 2 * consensusParams.SeedLookback * consensusParams.SeedRefreshInterval // 32
+	consensusParams.AgreementFilterTimeoutPeriod0 = 400 * time.Millisecond
+	consensusParams.AgreementFilterTimeout = 400 * time.Millisecond
 
 	configurableConsensus[consensusVersion] = consensusParams
 
@@ -1058,6 +1068,13 @@ func TestAssetCreateWaitBalLookbackDelete(t *testing.T) {
 	}
 	verifyAssetParameters(asset, "test", "testunit", manager, reserve, freeze, clawback,
 		assetMetadataHash, assetURL, a)
+
+	// Ensure manager is funded before submitting any transactions
+	currentRound, err := client.CurrentRound()
+	a.NoError(err)
+
+	err = fixture.WaitForAccountFunded(currentRound+5, manager)
+	a.NoError(err)
 
 	// Destroy the asset
 	tx, err := client.MakeUnsignedAssetDestroyTx(assetIndex)

--- a/test/framework/fixtures/restClientFixture.go
+++ b/test/framework/fixtures/restClientFixture.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/daemon/algod/api/client"
-	"github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
+	v1 "github.com/algorand/go-algorand/daemon/algod/api/spec/v1"
 	"github.com/algorand/go-algorand/libgoal"
 	"github.com/algorand/go-algorand/nodecontrol"
 	"github.com/algorand/go-algorand/test/e2e-go/globals"
@@ -269,6 +269,34 @@ func (f *RestClientFixture) WaitForAllTxnsToConfirm(roundTimeout uint64, txidsAn
 		}
 	}
 	return true
+}
+
+// WaitForAccountFunded waits until either the passed account gets non-empty balance
+// or until the passed roundTimeout passes
+// or until waiting for a round to pass times out
+func (f *RestClientFixture) WaitForAccountFunded(roundTimeout uint64, accountAddress string) (err error) {
+	client := f.AlgodClient
+	for {
+		// Get current round information
+		curStatus, statusErr := client.Status()
+		require.NoError(f.t, statusErr, "fixture should be able to get node status")
+		curRound := curStatus.LastRound
+
+		// Check if we know about the transaction yet
+		acct, acctErr := client.AccountInformation(accountAddress)
+		require.NoError(f.t, acctErr, "fixture should be able to get account info")
+		if acct.Amount > 0 {
+			return nil
+		}
+
+		// Check if we should wait a round
+		if curRound > roundTimeout {
+			return fmt.Errorf("failed to see confirmed transaction by round %v", roundTimeout)
+		}
+		// Wait a round
+		err = f.WaitForRoundWithTimeout(curRound + 1)
+		require.NoError(f.t, err, "fixture should be able to wait for one round to pass")
+	}
 }
 
 // SendMoneyAndWait uses the rest client to send money and WaitForTxnConfirmation to wait for the send to confirm


### PR DESCRIPTION
* Ensure manager account is funded before running any operations with it
* Shave 2 minutes from TestAssetCreateWaitBalLookbackDelete
  by introducing faster rounds on a custom proto that is already in place