### PR TITLE
stateproofs: Make SP e2e tests easier for arm.

### DIFF
--- a/test/testdata/nettemplates/RichAccountStateProofSmall.json
+++ b/test/testdata/nettemplates/RichAccountStateProofSmall.json
@@ -1,0 +1,20 @@
+{
+    "Genesis": {
+        "NetworkName": "tbd",
+        "ConsensusProtocol": "test-fast-stateproofs",
+        "LastPartKeyRound": 100,
+        "Wallets": [
+            { "Name": "richWallet", "Stake": 99, "Online": true },
+            { "Name": "poorWallet", "Stake": 1, "Online": true }
+        ]
+    },
+    "Nodes": [
+        {
+            "Name": "Relay0",
+            "IsRelay": true,
+            "Wallets": []
+        },
+        { "Name": "richNode", "Wallets": [ { "Name": "richWallet", "ParticipationOnly": false } ] },
+        { "Name": "poorNode", "Wallets": [ { "Name": "poorWallet", "ParticipationOnly": false } ] }
+    ]
+}

--- a/test/testdata/nettemplates/StateProofSmall.json
+++ b/test/testdata/nettemplates/StateProofSmall.json
@@ -1,0 +1,20 @@
+{
+    "Genesis": {
+        "NetworkName": "tbd",
+        "ConsensusProtocol": "test-fast-stateproofs",
+        "LastPartKeyRound": 100,
+        "Wallets": [
+            { "Name": "Wallet0", "Stake": 50, "Online": true },
+            { "Name": "Wallet1", "Stake": 50, "Online": true }
+        ]
+    },
+    "Nodes": [
+        {
+            "Name": "Relay0",
+            "IsRelay": true,
+            "Wallets": []
+        },
+        { "Name": "Node0", "Wallets": [ { "Name": "Wallet0", "ParticipationOnly": false } ] },
+        { "Name": "Node1", "Wallets": [ { "Name": "Wallet1", "ParticipationOnly": false } ] }
+    ]
+}


### PR DESCRIPTION
Rarely, SP e2e tests may fail on ARM. This is because the tests spins around 7 nodes, which may overwhelm the ARM. 
Making some of the tests run on smaller network, others not run on ARM. 
