### PR TITLE
Tests:  Fix variable application in verifyAssetParameters

### DIFF
--- a/test/e2e-go/features/transactions/asset_test.go
+++ b/test/e2e-go/features/transactions/asset_test.go
@@ -1186,8 +1186,8 @@ func verifyAssetParameters(asset v1.AssetParams,
 	unitName, assetName, manager, reserve, freeze, clawback string,
 	metadataHash []byte, assetURL string, asser *require.Assertions) {
 
-	asser.Equal(asset.UnitName, "test")
-	asser.Equal(asset.AssetName, "testunit")
+	asser.Equal(asset.UnitName, unitName)
+	asser.Equal(asset.AssetName, assetName)
 	asser.Equal(asset.ManagerAddr, manager)
 	asser.Equal(asset.ReserveAddr, reserve)
 	asser.Equal(asset.FreezeAddr, freeze)


### PR DESCRIPTION
## Summary

While catching up on https://github.com/algorand/go-algorand/pull/4400, I discovered `verifyAssetParameters` does _not_ use all of its parameters.  The PR assumes the desired usage is to assert using the provided parameters.

## Test Plan
`gotestsum -- ./test/e2e-go/features/transactions -count=1 -run "TestAssetCreateWaitRestartDelete"`
