### PR TITLE
Comments:  Add AVM release comment about bumping constants

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1202,7 +1202,7 @@ func initConsensusProtocols() {
 	vFuture := v34
 	vFuture.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 
-	vFuture.LogicSigVersion = 8 // When moving this to a release, put a new higher LogicSigVersion here + LogicVersion in data/transactions/logic/opcodes.go
+	vFuture.LogicSigVersion = 8 // When moving this to a release, put a new higher LogicSigVersion here + LogicVersion in data/transactions/logic/opcodes.go + docVersion in cmd/opdoc/opdoc.go.
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 }

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1202,7 +1202,7 @@ func initConsensusProtocols() {
 	vFuture := v34
 	vFuture.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 
-	vFuture.LogicSigVersion = 8 // When moving this to a release, put a new higher LogicSigVersion here
+	vFuture.LogicSigVersion = 8 // When moving this to a release, put a new higher LogicSigVersion here + LogicVersion in data/transactions/logic/opcodes.go
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 }


### PR DESCRIPTION
Adds an AVM release note about bumping constants to properly target a new AVM version.