### PR TITLE
CI: use GHA for codegen_verification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,6 @@ workflows:
   version: 2
   "circleci_build_and_test":
     jobs:
-      - codegen_verification
-
       - build:
           name: << matrix.platform >>_build
           matrix: &matrix-default
@@ -179,7 +177,6 @@ workflows:
             - << matrix.platform >>_integration_nightly_verification
             - << matrix.platform >>_e2e_expect_nightly_verification
             - << matrix.platform >>_e2e_subs_nightly
-            - codegen_verification
           filters:
             branches:
               only:
@@ -483,16 +480,6 @@ commands:
                     scripts/travis/test_release.sh
 
 jobs:
-  codegen_verification:
-    executor: amd64_medium
-    steps:
-      - checkout
-      - prepare_go
-      - run: |
-          export PATH=$(echo "$PATH" | sed -e 's|:/home/circleci/\.go_workspace/bin||g' | sed -e 's|:/usr/local/go/bin||g')
-          export GOPATH="/home/circleci/go"
-          scripts/travis/codegen_verification.sh
-
   build:
     parameters:
       platform:

--- a/.github/workflows/codegen_verification.yml
+++ b/.github/workflows/codegen_verification.yml
@@ -8,6 +8,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           path: go-algorand
       - name: Install libraries
         run: sudo apt-get -y -q install libboost-math-dev

--- a/.github/workflows/codegen_verification.yml
+++ b/.github/workflows/codegen_verification.yml
@@ -1,0 +1,20 @@
+name: "codegen verification"
+on:
+  pull_request:
+jobs:
+  codegen_verification:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          path: go-algorand
+      - name: Install libraries
+        run: sudo apt-get -y -q install libboost-math-dev
+      - name: Uninstall existing go installation
+        run: sudo apt-get -y -q purge golang-go
+      - name: Run codegen_verification.sh
+        run: |
+          export GOPATH="${GITHUB_WORKSPACE}/go"
+          cd go-algorand
+          scripts/travis/codegen_verification.sh

--- a/.github/workflows/codegen_verification.yml
+++ b/.github/workflows/codegen_verification.yml
@@ -10,8 +10,6 @@ jobs:
         with:
           fetch-depth: 0
           path: go-algorand
-      - name: Install libraries
-        run: sudo apt-get -y -q install libboost-math-dev
       - name: Uninstall existing go installation
         run: sudo apt-get -y -q purge golang-go
       - name: Run codegen_verification.sh


### PR DESCRIPTION
This moves the codegen_verification task to Github Actions, as it is similar to the other types of static checks and linting jobs already in GHA.