### PR TITLE
Reduce BytesPerBoxReference

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1196,7 +1196,7 @@ func initConsensusProtocols() {
 	vFuture.BoxFlatMinBalance = 2500
 	vFuture.BoxByteMinBalance = 400
 	vFuture.MaxAppBoxReferences = 8
-	vFuture.BytesPerBoxReference = 8096
+	vFuture.BytesPerBoxReference = 1024
 
 	vFuture.UnfundedSenders = true
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Performance testing and analysis indicated memory consumption concerns with the current value of `BytesPerBoxReference` of 8096. The proposed 1024 value, along with the reduction of the `MaxAcctLookback` parameter from 8 to 4, brings the theoretical memory usage well into acceptable territory.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Existing Unit Tests.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
