### PR TITLE
CI:  Expose configuration to ignore parent E2E expect test runner invocations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -443,6 +443,12 @@ commands:
           at: << parameters.result_path >>
       - run:
           name: Check if all tests were run
+          # Add to --ignored-tests when a test should _not_ be considered.
+          # * For example, E2E expect test runners (e.g. `TestAlgodWithExpect`)
+          # produce partitioned subtests.
+          # * The parent tests are deliberately _not_ partitioned.  By ignoring
+          # these tests, `check_tests.py` won't provide conflicting advice to
+          # partition the parent tests.
           command: |
             cat << parameters.result_path >>/<< parameters.result_subdir >>/**/testresults.json > << parameters.result_path >>/<< parameters.result_subdir >>/combined_testresults.json
             python3 scripts/buildtools/check_tests.py \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,7 +445,13 @@ commands:
           name: Check if all tests were run
           command: |
             cat << parameters.result_path >>/<< parameters.result_subdir >>/**/testresults.json > << parameters.result_path >>/<< parameters.result_subdir >>/combined_testresults.json
-            python3 scripts/buildtools/check_tests.py << parameters.result_path >>/<< parameters.result_subdir >>/combined_testresults.json
+            python3 scripts/buildtools/check_tests.py \
+              --tests-results-filepath << parameters.result_path >>/<< parameters.result_subdir >>/combined_testresults.json \
+              --ignored-tests \
+                TestAlgodWithExpect \
+                TestAlgohWithExpect \
+                TestGoalWithExpect \
+                TestTealdbgWithExpect
       - store_artifacts:
           path: << parameters.result_path >>/<< parameters.result_subdir >>
           destination: << parameters.result_subdir >>/combined-test-results

--- a/scripts/buildtools/check_tests.py
+++ b/scripts/buildtools/check_tests.py
@@ -6,8 +6,9 @@ import argparse
 
 # Arguments parsing / help menu
 parser = argparse.ArgumentParser(description='Check test results for intentionally and unintentionally skipped tests, as well as tests that ran multiple times.')
-parser.add_argument('tests_results_filepath', metavar='RESULTS_FILE',
-    help='json format test results file path (e.g. /tmp/results/testresults.json)')
+parser.add_argument('--tests-results-filepath', metavar='RESULTS_FILE',
+    help='json format test results file path (e.g. /tmp/results/testresults.json)', required=True)
+parser.add_argument('--ignored-tests', nargs = '*', help='Exact test names to ignore during verification')
 args = parser.parse_args()
 
 # Go through the given file one json object at a time, and record into a dict
@@ -17,7 +18,10 @@ with open(args.tests_results_filepath) as f:
         testDict = json.loads(jsonObj)
         if 'Test' not in testDict:
             continue
-        
+
+        if args.ignored_tests and testDict['Test'] in args.ignored_tests:
+            continue
+
         fullTestName = testDict['Package'] + ' ' + testDict['Test']
         if fullTestName not in AllTestResults:
             AllTestResults[fullTestName] = {}


### PR DESCRIPTION
## Summary

Extends `scripts/buildtools/check_tests.py` to customize tests to ignore via `--ignored-tests`.  The motivation is to acquiesce `check_tests.py` warnings about E2E expect tests run multiple times.

In another branch, I saw warnings in https://app.circleci.com/pipelines/github/algorand/go-algorand/8787/workflows/a566ab26-42ad-48de-940d-08d504ce1c15/jobs/158801?invite=true#step-103-7.  Reproduced below for convenience:
```
=========== RAN MULTIPLE TIMES ===================
The above 4 tests ran multiple times:
github.com/algorand/go-algorand/test/e2e-go/cli/algod/expect TestAlgodWithExpect -- ran 10 times. (Can probably be fixed by adding "partitiontest.PartitionTest()")
github.com/algorand/go-algorand/test/e2e-go/cli/algoh/expect TestAlgohWithExpect -- ran 10 times. (Can probably be fixed by adding "partitiontest.PartitionTest()")
github.com/algorand/go-algorand/test/e2e-go/cli/goal/expect TestGoalWithExpect -- ran 10 times. (Can probably be fixed by adding "partitiontest.PartitionTest()")
github.com/algorand/go-algorand/test/e2e-go/cli/tealdbg/expect TestTealdbgWithExpect -- ran 10 times. (Can probably be fixed by adding "partitiontest.PartitionTest()")
The above 4 tests ran multiple times:
==================================================
```

Upon inspection, I realized these tests are parent E2E test runners for expect tests.  They're invoked multiple times by-design and the advice to add partitioning does _not_ apply.

As a band aid, the PR exposes a way to ignore these tests.  See the PR's builds for proof that the warnings disappear.
* Treat the PR optionally.  I didn't see a way to prevent the tests from reporting via `go test` flags.  I _can_ envision managing the ignore list as worse than the status quo.
* I realize the verification step happens for all test types.  The configuration relies on test name uniqueness.
* For the PR's scope, I'm gauging if the band aid is deemed a net positive.  If it isn't, I'd prefer to close and move on.

## Test Plan

Run CI.
