### PR TITLE
CI:  Speed up CircleCI by folding build workflow downstream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,7 @@ workflows:
           matrix: &matrix-default
             parameters:
               platform: ["amd64", "arm64"]
+          filters: &filters-default
 
       - test_nightly:
           name: << matrix.platform >>_test_nightly
@@ -108,6 +109,7 @@ workflows:
           matrix: &matrix-default
             parameters:
               platform: ["amd64", "arm64"]
+          filters: &filters-default
 #          requires:
 #            - << matrix.platform >>_build
 
@@ -124,6 +126,7 @@ workflows:
           matrix: &matrix-default
             parameters:
               platform: ["amd64", "arm64"]
+          filters: &filters-default
 #          requires:
 #            - << matrix.platform >>_build
 
@@ -140,6 +143,7 @@ workflows:
           matrix: &matrix-default
             parameters:
               platform: ["amd64", "arm64"]
+          filters: &filters-default
 #          requires:
 #            - << matrix.platform >>_build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,71 +89,47 @@ workflows:
 
       - integration:
           name: << matrix.platform >>_integration
-          matrix: &matrix-default
-            parameters:
-              platform: ["amd64", "arm64"]
-          filters: &filters-default
-            branches:
-              ignore:
-                - /rel\/.*/
-                - << pipeline.parameters.valid_nightly_branch >>
+          matrix:
+            <<: *matrix-default
+          filters:
+            <<: *filters-default
 
       - integration_nightly:
           name: << matrix.platform >>_integration_nightly
-          matrix: &matrix-nightly
-            parameters:
-              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
-          filters: &filters-nightly
-            branches:
-              only:
-                - /rel\/.*/
-                - << pipeline.parameters.valid_nightly_branch >>
+          matrix:
+            <<: *matrix-nightly
+          filters:
+            <<: *filters-nightly
           context: slack-secrets
 
       - e2e_expect:
           name: << matrix.platform >>_e2e_expect
-          matrix: &matrix-default
-            parameters:
-              platform: ["amd64", "arm64"]
-          filters: &filters-default
-            branches:
-              ignore:
-                - /rel\/.*/
-                - << pipeline.parameters.valid_nightly_branch >>
+          matrix:
+            <<: *matrix-default
+          filters:
+            <<: *filters-default
 
       - e2e_expect_nightly:
           name: << matrix.platform >>_e2e_expect_nightly
-          matrix: &matrix-nightly
-            parameters:
-              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
-          filters: &filters-nightly
-            branches:
-              only:
-                - /rel\/.*/
-                - << pipeline.parameters.valid_nightly_branch >>
+          matrix:
+            <<: *matrix-nightly
+          filters:
+            <<: *filters-nightly
           context: slack-secrets
 
       - e2e_subs:
           name: << matrix.platform >>_e2e_subs
-          matrix: &matrix-default
-            parameters:
-              platform: ["amd64", "arm64"]
-          filters: &filters-default
-            branches:
-              ignore:
-                - /rel\/.*/
-                - << pipeline.parameters.valid_nightly_branch >>
+          matrix:
+            <<: *matrix-default
+          filters:
+            <<: *filters-default
 
       - e2e_subs_nightly:
           name: << matrix.platform >>_e2e_subs_nightly
-          matrix: &matrix-nightly
-            parameters:
-              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
-          filters: &filters-nightly
-            branches:
-              only:
-                - /rel\/.*/
-                - << pipeline.parameters.valid_nightly_branch >>
+          matrix:
+            <<: *matrix-nightly
+          filters:
+            <<: *filters-nightly
           context:
             - slack-secrets
             - aws-secrets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,16 +66,16 @@ workflows:
     jobs:
       - codegen_verification
 
-      - build:
-          name: << matrix.platform >>_build
-          matrix: &matrix-default
-            parameters:
-              platform: ["amd64", "arm64"]
-          filters: &filters-default
-            branches:
-              ignore:
-                - /rel\/.*/
-                - << pipeline.parameters.valid_nightly_branch >>
+#      - build:
+#          name: << matrix.platform >>_build
+#          matrix: &matrix-default
+#            parameters:
+#              platform: ["amd64", "arm64"]
+#          filters: &filters-default
+#            branches:
+#              ignore:
+#                - /rel\/.*/
+#                - << pipeline.parameters.valid_nightly_branch >>
 
       - build_nightly:
           name: << matrix.platform >>_build_nightly
@@ -91,10 +91,9 @@ workflows:
 
       - test:
           name: << matrix.platform >>_test
-          matrix:
-            <<: *matrix-default
-          requires:
-            - << matrix.platform >>_build
+          matrix: &matrix-default
+            parameters:
+              platform: ["amd64", "arm64"]
 
       - test_nightly:
           name: << matrix.platform >>_test_nightly
@@ -106,10 +105,11 @@ workflows:
 
       - integration:
           name: << matrix.platform >>_integration
-          matrix:
-            <<: *matrix-default
-          requires:
-            - << matrix.platform >>_build
+          matrix: &matrix-default
+            parameters:
+              platform: ["amd64", "arm64"]
+#          requires:
+#            - << matrix.platform >>_build
 
       - integration_nightly:
           name: << matrix.platform >>_integration_nightly
@@ -121,10 +121,11 @@ workflows:
 
       - e2e_expect:
           name: << matrix.platform >>_e2e_expect
-          matrix:
-            <<: *matrix-default
-          requires:
-            - << matrix.platform >>_build
+          matrix: &matrix-default
+            parameters:
+              platform: ["amd64", "arm64"]
+#          requires:
+#            - << matrix.platform >>_build
 
       - e2e_expect_nightly:
           name: << matrix.platform >>_e2e_expect_nightly
@@ -136,10 +137,11 @@ workflows:
 
       - e2e_subs:
           name: << matrix.platform >>_e2e_subs
-          matrix:
-            <<: *matrix-default
-          requires:
-            - << matrix.platform >>_build
+          matrix: &matrix-default
+            parameters:
+              platform: ["amd64", "arm64"]
+#          requires:
+#            - << matrix.platform >>_build
 
       - e2e_subs_nightly:
           name: << matrix.platform >>_e2e_subs_nightly
@@ -227,6 +229,42 @@ commands:
             export mingw64="$msys2 -mingw64 -full-path -here -c "\"\$@"\" --"
             export msys2+=" -msys2 -c "\"\$@"\" --"
             $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain mingw-w64-x86_64-libtool unzip autoconf automake
+
+  generic_build_consolidated:
+    description: TBD
+    parameters:
+      build_dir:
+        type: string
+        default: << pipeline.parameters.build_dir >>
+    steps:
+      - restore_libsodium
+      - restore_cache:
+          keys:
+            - 'go-mod-1.17.9-v3-{{ arch }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}'
+      - restore_cache:
+          keys:
+            - 'go-cache-v3-{{ arch }}-{{ .Branch }}-{{ .Revision }}'
+            - 'go-cache-v3-{{ arch }}-{{ .Branch }}-'
+            - 'go-cache-v3-{{ arch }}-'
+      - run:
+          name: scripts/travis/build.sh --make_debug
+          command: |
+            export PATH=$(echo "$PATH" | sed -e "s|:${HOME}/\.go_workspace/bin||g" | sed -e 's|:/usr/local/go/bin||g')
+            export GOPATH="<< parameters.build_dir >>/go"
+            export ALGORAND_DEADLOCK=enable
+            export GIMME_INSTALL_DIR=<< parameters.build_dir >>
+            export GIMME_ENV_PREFIX=<< parameters.build_dir >>/.gimme/envs
+            export GIMME_VERSION_PREFIX=<< parameters.build_dir >>/.gimme/versions
+            scripts/travis/build.sh --make_debug
+      - cache_libsodium
+      - save_cache:
+          key: 'go-mod-1.17.9-v3-{{ arch }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}'
+          paths:
+            - << parameters.build_dir >>/go/pkg/mod
+      - save_cache:
+          key: 'go-cache-v3-{{ arch }}-{{ .Branch }}-{{ .Revision }}'
+          paths:
+            - tmp/go-cache
 
   generic_build:
     description: Run basic build and store in workspace for re-use by different architectures
@@ -316,17 +354,17 @@ commands:
         type: string
         default: << pipeline.parameters.result_path >>
     steps:
-      - attach_workspace:
-          at: << parameters.build_dir >>
-      - run: |
-          mkdir -p << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
-          touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml
-          touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json
-      - restore_cache:
-          keys:
-            - 'go-cache-v3-{{ arch }}-{{ .Branch }}-{{ .Revision }}'
-            - 'go-cache-v3-{{ arch }}-{{ .Branch }}-'
-            - 'go-cache-v3-{{ arch }}-'
+#      - attach_workspace:
+#          at: << parameters.build_dir >>
+#      - run: |
+#          mkdir -p << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
+#          touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml
+#          touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json
+#      - restore_cache:
+#          keys:
+#            - 'go-cache-v3-{{ arch }}-{{ .Branch }}-{{ .Revision }}'
+#            - 'go-cache-v3-{{ arch }}-{{ .Branch }}-'
+#            - 'go-cache-v3-{{ arch }}-'
       - run:
           name: Run build tests
           no_output_timeout: << parameters.no_output_timeout >>
@@ -388,8 +426,8 @@ commands:
         type: string
         default: << pipeline.parameters.result_path >>
     steps:
-      - attach_workspace:
-          at: << parameters.build_dir >>
+#      - attach_workspace:
+#          at: << parameters.build_dir >>
       - run: |
           mkdir -p << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
           touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml
@@ -528,6 +566,7 @@ jobs:
     working_directory: << pipeline.parameters.build_dir >>/project
     parallelism: 4
     steps:
+      - generic_build_consolidated
       - prepare_build_dir
       - prepare_go
       - generic_test:
@@ -564,6 +603,7 @@ jobs:
     environment:
       E2E_TEST_FILTER: "GO"
     steps:
+      - generic_build_consolidated
       - prepare_build_dir
       - prepare_go
       - generic_integration:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -564,7 +564,7 @@ jobs:
         type: string
     executor: << parameters.platform >>_medium
     working_directory: << pipeline.parameters.build_dir >>/project
-    parallelism: 4
+    parallelism: 32
     steps:
       - prepare_build_dir
       - checkout
@@ -598,9 +598,9 @@ jobs:
     parameters:
       platform:
         type: string
-    executor: << parameters.platform >>_large
+    executor: << parameters.platform >>_medium
     working_directory: << pipeline.parameters.build_dir >>/project
-    parallelism: 2
+    parallelism: 8
     environment:
       E2E_TEST_FILTER: "GO"
     steps:
@@ -638,7 +638,7 @@ jobs:
         type: string
     executor: << parameters.platform >>_medium
     working_directory: << pipeline.parameters.build_dir >>/project
-    parallelism: 2
+    parallelism: 10
     environment:
       E2E_TEST_FILTER: "EXPECT"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -599,7 +599,7 @@ jobs:
         type: string
     executor: << parameters.platform >>_medium
     working_directory: << pipeline.parameters.build_dir >>/project
-    parallelism: 8
+    parallelism: 16
     environment:
       E2E_TEST_FILTER: "GO"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,10 +356,10 @@ commands:
     steps:
 #      - attach_workspace:
 #          at: << parameters.build_dir >>
-#      - run: |
-#          mkdir -p << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
-#          touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml
-#          touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json
+      - run: |
+          mkdir -p << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
+          touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml
+          touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json
 #      - restore_cache:
 #          keys:
 #            - 'go-cache-v3-{{ arch }}-{{ .Branch }}-{{ .Revision }}'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,17 +291,10 @@ commands:
         type: string
         default: << pipeline.parameters.result_path >>
     steps:
-#      - attach_workspace:
-#          at: << parameters.build_dir >>
       - run: |
           mkdir -p << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
           touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml
           touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json
-#      - restore_cache:
-#          keys:
-#            - 'go-cache-v3-{{ arch }}-{{ .Branch }}-{{ .Revision }}'
-#            - 'go-cache-v3-{{ arch }}-{{ .Branch }}-'
-#            - 'go-cache-v3-{{ arch }}-'
       - run:
           name: Run build tests
           no_output_timeout: << parameters.no_output_timeout >>
@@ -363,8 +356,6 @@ commands:
         type: string
         default: << pipeline.parameters.result_path >>
     steps:
-#      - attach_workspace:
-#          at: << parameters.build_dir >>
       - run: |
           mkdir -p << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
           touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -566,9 +566,10 @@ jobs:
     working_directory: << pipeline.parameters.build_dir >>/project
     parallelism: 4
     steps:
-      - generic_build_consolidated
       - prepare_build_dir
+      - checkout
       - prepare_go
+      - generic_build_consolidated
       - generic_test:
           platform: << parameters.platform >>
           result_subdir: << parameters.platform >>_test
@@ -603,9 +604,10 @@ jobs:
     environment:
       E2E_TEST_FILTER: "GO"
     steps:
-      - generic_build_consolidated
       - prepare_build_dir
+      - checkout
       - prepare_go
+      - generic_build_consolidated
       - generic_integration:
           platform: << parameters.platform >>
           result_subdir: << parameters.platform >>_integration
@@ -641,7 +643,9 @@ jobs:
       E2E_TEST_FILTER: "EXPECT"
     steps:
       - prepare_build_dir
+      - checkout
       - prepare_go
+      - generic_build_consolidated
       - generic_integration:
           platform: << parameters.platform >>
           result_subdir: << parameters.platform >>_e2e_expect
@@ -676,7 +680,9 @@ jobs:
       E2E_TEST_FILTER: "SCRIPTS"
     steps:
       - prepare_build_dir
+      - checkout
       - prepare_go
+      - generic_build_consolidated
       - generic_integration:
           platform: << parameters.platform >>
           result_subdir: << parameters.platform >>_e2e_subs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,7 +467,7 @@ jobs:
         type: string
     executor: << parameters.platform >>_medium
     working_directory: << pipeline.parameters.build_dir >>/project
-    parallelism: 32
+    parallelism: 4
     steps:
       - prepare_build_dir
       - checkout
@@ -504,9 +504,9 @@ jobs:
     parameters:
       platform:
         type: string
-    executor: << parameters.platform >>_medium
+    executor: << parameters.platform >>_large
     working_directory: << pipeline.parameters.build_dir >>/project
-    parallelism: 16
+    parallelism: 2
     environment:
       E2E_TEST_FILTER: "GO"
     steps:
@@ -546,7 +546,7 @@ jobs:
         type: string
     executor: << parameters.platform >>_medium
     working_directory: << pipeline.parameters.build_dir >>/project
-    parallelism: 10
+    parallelism: 2
     environment:
       E2E_TEST_FILTER: "EXPECT"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,9 @@ commands:
         type: string
         default: << pipeline.parameters.build_dir >>
     steps:
+      - prepare_build_dir
+      - checkout
+      - prepare_go
       - restore_libsodium
       - restore_cache:
           keys:
@@ -474,9 +477,6 @@ jobs:
     working_directory: << pipeline.parameters.build_dir >>/project
     parallelism: 4
     steps:
-      - prepare_build_dir
-      - checkout
-      - prepare_go
       - generic_build
       - generic_test:
           platform: << parameters.platform >>
@@ -492,9 +492,6 @@ jobs:
     working_directory: << pipeline.parameters.build_dir >>/project
     parallelism: 4
     steps:
-      - prepare_build_dir
-      - checkout
-      - prepare_go
       - generic_build
       - generic_test:
           platform: << parameters.platform >>
@@ -515,9 +512,6 @@ jobs:
     environment:
       E2E_TEST_FILTER: "GO"
     steps:
-      - prepare_build_dir
-      - checkout
-      - prepare_go
       - generic_build
       - generic_integration:
           platform: << parameters.platform >>
@@ -534,9 +528,6 @@ jobs:
     environment:
       E2E_TEST_FILTER: "GO"
     steps:
-      - prepare_build_dir
-      - checkout
-      - prepare_go
       - generic_build
       - generic_integration:
           platform: << parameters.platform >>
@@ -555,9 +546,6 @@ jobs:
     environment:
       E2E_TEST_FILTER: "EXPECT"
     steps:
-      - prepare_build_dir
-      - checkout
-      - prepare_go
       - generic_build
       - generic_integration:
           platform: << parameters.platform >>
@@ -574,9 +562,6 @@ jobs:
     environment:
       E2E_TEST_FILTER: "EXPECT"
     steps:
-      - prepare_build_dir
-      - checkout
-      - prepare_go
       - generic_build
       - generic_integration:
           platform: << parameters.platform >>
@@ -594,9 +579,6 @@ jobs:
     environment:
       E2E_TEST_FILTER: "SCRIPTS"
     steps:
-      - prepare_build_dir
-      - checkout
-      - prepare_go
       - generic_build
       - generic_integration:
           platform: << parameters.platform >>
@@ -616,9 +598,6 @@ jobs:
       # one of the platforms in the matrix.
       CI_KEEP_TEMP_PLATFORM: "amd64"
     steps:
-      - prepare_build_dir
-      - checkout
-      - prepare_go
       - generic_build
       - generic_integration:
           platform: << parameters.platform >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,12 @@ commands:
             $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain mingw-w64-x86_64-libtool unzip autoconf automake
 
   generic_build:
-    description: Run basic build
+    description: >
+      Run basic build.
+
+      If command execution time increases _appreciably_, revisit CI topology:
+      * Historically, the command executes _quickly_ (< 3m with resource class >= medium).
+      * Consequently, it's faster to embed the command in a combined build + test workflow rather than independent build and test workflows.
     parameters:
       build_dir:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,19 +64,19 @@ workflows:
   version: 2
   "circleci_build_and_test":
     jobs:
-#      - build:
-#          name: << matrix.platform >>_build
-#          matrix: &matrix-default
-#            parameters:
-#              platform: ["amd64", "arm64"]
-#          filters: &filters-default
-#            branches:
-#              ignore:
-#                - /rel\/.*/
-#                - << pipeline.parameters.valid_nightly_branch >>
+      - test:
+          name: << matrix.platform >>_test
+          matrix: &matrix-default
+            parameters:
+              platform: ["amd64", "arm64"]
+          filters: &filters-default
+            branches:
+              ignore:
+                - /rel\/.*/
+                - << pipeline.parameters.valid_nightly_branch >>
 
-      - build_nightly:
-          name: << matrix.platform >>_build_nightly
+      - test_nightly:
+          name: << matrix.platform >>_test_nightly
           matrix: &matrix-nightly
             parameters:
               platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
@@ -87,34 +87,27 @@ workflows:
                 - << pipeline.parameters.valid_nightly_branch >>
           context: slack-secrets
 
-      - test:
-          name: << matrix.platform >>_test
-          matrix: &matrix-default
-            parameters:
-              platform: ["amd64", "arm64"]
-
-      - test_nightly:
-          name: << matrix.platform >>_test_nightly
-          matrix:
-            <<: *matrix-nightly
-          requires:
-            - << matrix.platform >>_build_nightly
-          context: slack-secrets
-
       - integration:
           name: << matrix.platform >>_integration
           matrix: &matrix-default
             parameters:
               platform: ["amd64", "arm64"]
-#          requires:
-#            - << matrix.platform >>_build
+          filters: &filters-default
+            branches:
+              ignore:
+                - /rel\/.*/
+                - << pipeline.parameters.valid_nightly_branch >>
 
       - integration_nightly:
           name: << matrix.platform >>_integration_nightly
-          matrix:
-            <<: *matrix-nightly
-          requires:
-            - << matrix.platform >>_build_nightly
+          matrix: &matrix-nightly
+            parameters:
+              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
+          filters: &filters-nightly
+            branches:
+              only:
+                - /rel\/.*/
+                - << pipeline.parameters.valid_nightly_branch >>
           context: slack-secrets
 
       - e2e_expect:
@@ -122,15 +115,22 @@ workflows:
           matrix: &matrix-default
             parameters:
               platform: ["amd64", "arm64"]
-#          requires:
-#            - << matrix.platform >>_build
+          filters: &filters-default
+            branches:
+              ignore:
+                - /rel\/.*/
+                - << pipeline.parameters.valid_nightly_branch >>
 
       - e2e_expect_nightly:
           name: << matrix.platform >>_e2e_expect_nightly
-          matrix:
-            <<: *matrix-nightly
-          requires:
-            - << matrix.platform >>_build_nightly
+          matrix: &matrix-nightly
+            parameters:
+              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
+          filters: &filters-nightly
+            branches:
+              only:
+                - /rel\/.*/
+                - << pipeline.parameters.valid_nightly_branch >>
           context: slack-secrets
 
       - e2e_subs:
@@ -138,15 +138,22 @@ workflows:
           matrix: &matrix-default
             parameters:
               platform: ["amd64", "arm64"]
-#          requires:
-#            - << matrix.platform >>_build
+          filters: &filters-default
+            branches:
+              ignore:
+                - /rel\/.*/
+                - << pipeline.parameters.valid_nightly_branch >>
 
       - e2e_subs_nightly:
           name: << matrix.platform >>_e2e_subs_nightly
-          matrix:
-            <<: *matrix-nightly
-          requires:
-            - << matrix.platform >>_build_nightly
+          matrix: &matrix-nightly
+            parameters:
+              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
+          filters: &filters-nightly
+            branches:
+              only:
+                - /rel\/.*/
+                - << pipeline.parameters.valid_nightly_branch >>
           context:
             - slack-secrets
             - aws-secrets
@@ -227,44 +234,8 @@ commands:
             export msys2+=" -msys2 -c "\"\$@"\" --"
             $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain mingw-w64-x86_64-libtool unzip autoconf automake
 
-  generic_build_consolidated:
-    description: TBD
-    parameters:
-      build_dir:
-        type: string
-        default: << pipeline.parameters.build_dir >>
-    steps:
-      - restore_libsodium
-      - restore_cache:
-          keys:
-            - 'go-mod-1.17.9-v3-{{ arch }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}'
-      - restore_cache:
-          keys:
-            - 'go-cache-v3-{{ arch }}-{{ .Branch }}-{{ .Revision }}'
-            - 'go-cache-v3-{{ arch }}-{{ .Branch }}-'
-            - 'go-cache-v3-{{ arch }}-'
-      - run:
-          name: scripts/travis/build.sh --make_debug
-          command: |
-            export PATH=$(echo "$PATH" | sed -e "s|:${HOME}/\.go_workspace/bin||g" | sed -e 's|:/usr/local/go/bin||g')
-            export GOPATH="<< parameters.build_dir >>/go"
-            export ALGORAND_DEADLOCK=enable
-            export GIMME_INSTALL_DIR=<< parameters.build_dir >>
-            export GIMME_ENV_PREFIX=<< parameters.build_dir >>/.gimme/envs
-            export GIMME_VERSION_PREFIX=<< parameters.build_dir >>/.gimme/versions
-            scripts/travis/build.sh --make_debug
-      - cache_libsodium
-      - save_cache:
-          key: 'go-mod-1.17.9-v3-{{ arch }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}'
-          paths:
-            - << parameters.build_dir >>/go/pkg/mod
-      - save_cache:
-          key: 'go-cache-v3-{{ arch }}-{{ .Branch }}-{{ .Revision }}'
-          paths:
-            - tmp/go-cache
-
   generic_build:
-    description: Run basic build and store in workspace for re-use by different architectures
+    description: Run basic build
     parameters:
       build_dir:
         type: string
@@ -298,13 +269,6 @@ commands:
           key: 'go-cache-v3-{{ arch }}-{{ .Branch }}-{{ .Revision }}'
           paths:
             - tmp/go-cache
-      - persist_to_workspace:
-          root: << parameters.build_dir >>
-          paths:
-            - project
-            - go
-            - gimme
-            - .gimme
 
   cache_libsodium:
     description: Cache libsodium for build
@@ -530,33 +494,6 @@ commands:
                     scripts/travis/test_release.sh
 
 jobs:
-  build:
-    parameters:
-      platform:
-        type: string
-    executor: << parameters.platform >>_medium
-    working_directory: << pipeline.parameters.build_dir >>/project
-    steps:
-      - prepare_build_dir
-      - checkout
-      - prepare_go
-      - generic_build
-
-  build_nightly:
-    parameters:
-      platform:
-        type: string
-    executor: << parameters.platform >>_medium
-    working_directory: << pipeline.parameters.build_dir >>/project
-    steps:
-      - prepare_build_dir
-      - checkout
-      - prepare_go
-      - generic_build
-      - slack/notify: &slack-fail-event
-          event: fail
-          template: basic_fail_1
-
   test:
     parameters:
       platform:
@@ -568,7 +505,7 @@ jobs:
       - prepare_build_dir
       - checkout
       - prepare_go
-      - generic_build_consolidated
+      - generic_build
       - generic_test:
           platform: << parameters.platform >>
           result_subdir: << parameters.platform >>_test
@@ -584,14 +521,17 @@ jobs:
     parallelism: 4
     steps:
       - prepare_build_dir
+      - checkout
       - prepare_go
+      - generic_build
       - generic_test:
           platform: << parameters.platform >>
           result_subdir: << parameters.platform >>_test_nightly
           no_output_timeout: 45m
       - upload_coverage
-      - slack/notify:
-          <<: *slack-fail-event
+      - slack/notify: &slack-fail-event
+          event: fail
+          template: basic_fail_1
 
   integration:
     parameters:
@@ -606,7 +546,7 @@ jobs:
       - prepare_build_dir
       - checkout
       - prepare_go
-      - generic_build_consolidated
+      - generic_build
       - generic_integration:
           platform: << parameters.platform >>
           result_subdir: << parameters.platform >>_integration
@@ -623,7 +563,9 @@ jobs:
       E2E_TEST_FILTER: "GO"
     steps:
       - prepare_build_dir
+      - checkout
       - prepare_go
+      - generic_build
       - generic_integration:
           platform: << parameters.platform >>
           result_subdir: << parameters.platform >>_integration_nightly
@@ -644,7 +586,7 @@ jobs:
       - prepare_build_dir
       - checkout
       - prepare_go
-      - generic_build_consolidated
+      - generic_build
       - generic_integration:
           platform: << parameters.platform >>
           result_subdir: << parameters.platform >>_e2e_expect
@@ -661,7 +603,9 @@ jobs:
       E2E_TEST_FILTER: "EXPECT"
     steps:
       - prepare_build_dir
+      - checkout
       - prepare_go
+      - generic_build
       - generic_integration:
           platform: << parameters.platform >>
           result_subdir: << parameters.platform>>_e2e_expect_nightly
@@ -681,7 +625,7 @@ jobs:
       - prepare_build_dir
       - checkout
       - prepare_go
-      - generic_build_consolidated
+      - generic_build
       - generic_integration:
           platform: << parameters.platform >>
           result_subdir: << parameters.platform >>_e2e_subs
@@ -701,7 +645,9 @@ jobs:
       CI_KEEP_TEMP_PLATFORM: "amd64"
     steps:
       - prepare_build_dir
+      - checkout
       - prepare_go
+      - generic_build
       - generic_integration:
           platform: << parameters.platform >>
           result_subdir: << parameters.platform >>_e2e_subs_nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,6 @@ workflows:
           matrix: &matrix-default
             parameters:
               platform: ["amd64", "arm64"]
-          filters: &filters-default
 
       - test_nightly:
           name: << matrix.platform >>_test_nightly
@@ -109,7 +108,6 @@ workflows:
           matrix: &matrix-default
             parameters:
               platform: ["amd64", "arm64"]
-          filters: &filters-default
 #          requires:
 #            - << matrix.platform >>_build
 
@@ -126,7 +124,6 @@ workflows:
           matrix: &matrix-default
             parameters:
               platform: ["amd64", "arm64"]
-          filters: &filters-default
 #          requires:
 #            - << matrix.platform >>_build
 
@@ -143,7 +140,6 @@ workflows:
           matrix: &matrix-default
             parameters:
               platform: ["amd64", "arm64"]
-          filters: &filters-default
 #          requires:
 #            - << matrix.platform >>_build
 


### PR DESCRIPTION
Proposes to speed up CircleCI builds by consolidating `build` workflow steps into downstream workflows.

By _only_ changing the CI architecture without modifying resource class + parallelism, we see the following change:
<google-sheets-html-origin><!--td {border: 1px solid #ccc;}br {mso-data-placement:same-cell;}-->

  | Before | After | Change %
-- | -- | -- | --
Duration (min) | 35 | 27.4 | -22%
$ annually | $17,971 | $10,998 | -39%

Feels like a win-win.  The change saves money + saves time.   

Details:
* Result notes:
  * The sample size here is small (< 5), so it's prudent to assume _some_ variation.
  * The _$ annually_ cost assumes a flat credit rate ($ per credit = $0.0006) and uses a 90 day average CI invocation rate.  
  * There's a spread sheet with more detail for those interested:  https://docs.google.com/spreadsheets/d/13JM3vqOWFpzWrtI2hT02OpvojP2tdYm89GLR3aqY0t4/edit#gid=537120180.  Review benefits from a live walkthrough.
   * In practice, I presume the credit crate is lower because of CircleCI's variable pricing.  The salient point is both measurements use the same unit price.
* The PR's primary insight is that the `build` workflow spends >= 50% of its duration _persisting to workspace_ (e.g. https://app.circleci.com/pipelines/github/algorand/go-algorand/8736/workflows/8dedb6dc-c5c4-4c6a-83e5-f01219396acc/jobs/158031).  Since the `build` workflow is a pre-requisite to all downstream workflows, the PR proposes parallelizing the build step by folding it into downstream workflows.