### PR TITLE
CI:  Run Windows build nightly to speed up PR CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: "Build workflow"
 on:
-  pull_request:
+  schedule:
+    - cron: "7 2 * * *" # Choose haphazard minute to minimize Github scheduling delays.
 jobs:
   build-test-windows:
     runs-on: windows-2022


### PR DESCRIPTION
Runs `build-test-windows` nightly instead of on each PR commit in order to speed up PR CI builds.

Presuming we merge #4427, `build-test-windows` becomes the bottleneck.  We estimate #4427 reduces build time to ~15min while `build-test-windows` takes ~25min.

Since we recently migrated Mac builds to nightly, the PR proposes a similar treatment for Windows.  I'm unfamiliar with the history here and am opening the PR to gauge comfort levels.