### PR TITLE
CI:  Extend e2e_basic_start_stop.sh stop grace period to reduce flaky failures

### DIFF
--- a/test/scripts/e2e_basic_start_stop.sh
+++ b/test/scripts/e2e_basic_start_stop.sh
@@ -30,8 +30,8 @@ function verify_at_least_one_running() {
 function verify_none_running() {
     local datadir=$1
 
-    # Shutting down can take some time, so wait at least 5 seconds
-    for TRIES in 1 2 3 4 5; do
+    # Shutting down can take some time, so wait at least 10 seconds
+    for TRIES in $(seq 1 10); do
         update_running_count
         if [ ${RUNNING_COUNT} -eq 0 ]; then
             return 0


### PR DESCRIPTION
For `test/scripts/e2e_basic_start_stop.sh`, extends the stop grace period in an attempt to reduce flaky failures.

During my brief inspection, I'm unable to ascertain the issue root cause.  I can imagine adding (much more) verbose logging to gauge where shutdown hangs.
* Though it's unclear me if/how urgently we view the topic.  So, I'm offering the PR as a band aid to gauge appetite.
* As a reference point, I've observed < 5 build failures over a period of ~1 week.  It seems the problem happens infrequently and I've been unable to reproduce locally.  With the disclaimer that I consider my knowledge limited in this part of go-algorand, the low problem frequency biases me towards relaxing CI.

Notes:
* Failing example - https://app.circleci.com/pipelines/github/algorand/go-algorand/8764/workflows/3ecf5b7b-dcbd-4973-b725-2d5b7c927d2d/jobs/158471?invite=true#step-105-604
* Passing example - https://app.circleci.com/pipelines/github/algorand/go-algorand/8764/workflows/3ecf5b7b-dcbd-4973-b725-2d5b7c927d2d/jobs/158471?invite=true#step-105-603
* By searching git history, I discovered a prior version of the same class of problem:  https://github.com/algorand/go-algorand/pull/937/.