### PR TITLE
lint: Update linter version

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -18,7 +18,7 @@ jobs:
       - name: reviewdog-golangci-lint
         uses: reviewdog/action-golangci-lint@v2
         with:
-          golangci_lint_version: "v1.41.1"
+          golangci_lint_version: "v1.47.3"
           golangci_lint_flags: "-c .golangci.yml --allow-parallel-runners"
           reporter: "github-pr-check"
           tool_name: "Lint Errors"
@@ -60,7 +60,7 @@ jobs:
         run: |
           cd cicdtmp/golangci-lint
           git clone https://github.com/golangci/golangci-lint.git .
-          git checkout tags/v1.41.1
+          git checkout tags/v1.47.3
           CGO_ENABLED=true go build -trimpath -o golangci-lint-cgo ./cmd/golangci-lint
           ./golangci-lint-cgo --version
           cd ../../

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,6 +62,8 @@ issues:
     - ineffective break statement. Did you mean to break out of the outer loop
     # revive: irrelevant error about naming
     - "var-naming: don't use leading k in Go names"
+    # staticcheck: we'll keep using ioutil for now
+    - 'SA1019: "io/ioutil" has been deprecated since Go 1.16'
 
   exclude-rules:
     # Add all linters here -- Comment this block out for testing linters

--- a/scripts/buildtools/versions
+++ b/scripts/buildtools/versions
@@ -4,4 +4,4 @@ github.com/algorand/msgp v1.1.52
 github.com/algorand/oapi-codegen v1.3.7
 github.com/go-swagger/go-swagger v0.25.0
 gotest.tools/gotestsum v1.6.4
-github.com/golangci/golangci-lint/cmd/golangci-lint v1.41.1
+github.com/golangci/golangci-lint/cmd/golangci-lint v1.47.3

--- a/scripts/travis/codegen_verification.sh
+++ b/scripts/travis/codegen_verification.sh
@@ -42,7 +42,7 @@ function runGoFmt() {
 }
 
 function runGoLint() {
-    warningCount=$("$GOPATH"/bin/golint $(go list ./... | grep -v /vendor/ | grep -v /test/e2e-go/) | wc -l | tr -d ' ')
+    warningCount=$("$GOPATH"/bin/golangci-lint -c .golangci.yml | wc -l | tr -d ' ')
     if [ "${warningCount}" = "0" ]; then
         return 0
     fi
@@ -51,7 +51,7 @@ function runGoLint() {
     echo >&2 " make lint"
 
     # run the linter again to output the actual issues
-    "$GOPATH"/bin/golint $(go list ./... | grep -v /vendor/ | grep -v /test/e2e-go/) >&2
+    "$GOPATH"/bin/golangci-lint -c .golangci.yml >&2
     return 1
 }
 


### PR DESCRIPTION
## Summary

Following on #4418 and #4241 this upgrades the version of golangci-lint to match the lint-cleanliness achieved in #4241. (Older versions of golangci-lint were producing false positives)

## Test Plan

All tests should pass.