### PR TITLE
AVM: Handle Teal programs with manual constant blocks better

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -224,12 +224,12 @@ type OpStream struct {
 
 	intc         []uint64       // observed ints in code. We'll put them into a intcblock
 	intcRefs     []intReference // references to int pseudo-op constants, used for optimization
-	hasIntcBlock bool           // prevent prepending intcblock because asm has one
+	cntIntcBlock int            // prevent prepending intcblock because asm has one
 	hasPseudoInt bool           // were any `int` pseudo ops used?
 
 	bytec         [][]byte        // observed bytes in code. We'll put them into a bytecblock
 	bytecRefs     []byteReference // references to byte/addr pseudo-op constants, used for optimization
-	hasBytecBlock bool            // prevent prepending bytecblock because asm has one
+	cntBytecBlock int             // prevent prepending bytecblock because asm has one
 	hasPseudoByte bool            // were any `byte` (or equivalent) pseudo ops used?
 
 	// tracks information we know to be true at the point being assembled
@@ -411,7 +411,7 @@ func (ops *OpStream) IntLiteral(val uint64) {
 	}
 
 	if !found {
-		if ops.hasIntcBlock {
+		if ops.cntIntcBlock > 0 {
 			ops.errorf("int %d used without %d in intcblock", val, val)
 		}
 		constIndex = uint(len(ops.intc))
@@ -464,7 +464,7 @@ func (ops *OpStream) ByteLiteral(val []byte) {
 		}
 	}
 	if !found {
-		if ops.hasBytecBlock {
+		if ops.cntBytecBlock > 0 {
 			ops.errorf("byte/addr/method used without value in bytecblock")
 		}
 		constIndex = uint(len(ops.bytec))
@@ -482,12 +482,27 @@ func asmInt(ops *OpStream, spec *OpSpec, args []string) error {
 		return ops.error("int needs one argument")
 	}
 
-	if ops.hasIntcBlock && ops.Version >= backBranchEnabledVersion {
+	// After backBranchEnabledVersion, control flow is confusing, so if there's
+	// a manual cblock, use push instead of trying to use what's given.
+	if ops.cntIntcBlock > 0 && ops.Version >= backBranchEnabledVersion {
 		// We don't understand control-flow, so use pushint
 		ops.warnf("int %s used with explicit intcblock. must pushint", args[0])
 		pushint := OpsByName[ops.Version]["pushint"]
 		return asmPushInt(ops, &pushint, args)
 	}
+
+	// There are no backjumps, but there are multiple cblocks. Maybe one is
+	// conditional skipped. Too confusing.
+	if ops.cntIntcBlock > 1 {
+		pushint, ok := OpsByName[ops.Version]["pushint"]
+		if ok {
+			return asmPushInt(ops, &pushint, args)
+		}
+		return ops.errorf("int %s used with manual intcblocks. Use intc.", args[0])
+	}
+
+	// In both of the above clauses, we _could_ track whether a particular
+	// intcblock dominates the current instruction. If so, we could use it.
 
 	// check txn type constants
 	i, ok := txnTypeMap[args[0]]
@@ -717,12 +732,29 @@ func asmByte(ops *OpStream, spec *OpSpec, args []string) error {
 	if len(args) == 0 {
 		return ops.errorf("%s operation needs byte literal argument", spec.Name)
 	}
-	if ops.hasBytecBlock && ops.Version >= backBranchEnabledVersion {
+
+	// After backBranchEnabledVersion, control flow is confusing, so if there's
+	// a manual cblock, use push instead of trying to use what's given.
+	if ops.cntBytecBlock > 0 && ops.Version >= backBranchEnabledVersion {
 		// We don't understand control-flow, so use pushbytes
 		ops.warnf("byte %s used with explicit bytecblock. must pushbytes", args[0])
 		pushbytes := OpsByName[ops.Version]["pushbytes"]
 		return asmPushBytes(ops, &pushbytes, args)
 	}
+
+	// There are no backjumps, but there are multiple cblocks. Maybe one is
+	// conditional skipped. Too confusing.
+	if ops.cntBytecBlock > 1 {
+		pushbytes, ok := OpsByName[ops.Version]["pushbytes"]
+		if ok {
+			return asmPushBytes(ops, &pushbytes, args)
+		}
+		return ops.errorf("byte %s used with manual bytecblocks. Use bytec.", args[0])
+	}
+
+	// In both of the above clauses, we _could_ track whether a particular
+	// bytecblock dominates the current instruction. If so, we could use it.
+
 	val, consumed, err := parseBinaryArgs(args)
 	if err != nil {
 		return ops.error(err)
@@ -777,12 +809,14 @@ func asmIntCBlock(ops *OpStream, spec *OpSpec, args []string) error {
 		}
 	}
 	if !ops.known.deadcode {
+		// If we previously processed an `int`, we thought we could insert our
+		// own intcblock, but now we see a manual one.
 		if ops.hasPseudoInt {
 			ops.error("intcblock following int")
 		}
 		ops.intcRefs = nil
 		ops.intc = ivals
-		ops.hasIntcBlock = true
+		ops.cntIntcBlock++
 	}
 
 	return nil
@@ -813,12 +847,14 @@ func asmByteCBlock(ops *OpStream, spec *OpSpec, args []string) error {
 		ops.pending.Write(bv)
 	}
 	if !ops.known.deadcode {
+		// If we previously processed a pseudo `byte`, we thought we could
+		// insert our own bytecblock, but now we see a manual one.
 		if ops.hasPseudoByte {
 			ops.error("bytecblock following byte/addr/method")
 		}
 		ops.bytecRefs = nil
 		ops.bytec = bvals
-		ops.hasBytecBlock = true
+		ops.cntBytecBlock++
 	}
 	return nil
 }
@@ -1680,22 +1716,12 @@ func (ops *OpStream) assemble(text string) error {
 		ops.error(err)
 	}
 
-	// backward compatibility: do not allow jumps behind last instruction in v1
+	// backward compatibility: do not allow jumps past last instruction in v1
 	if ops.Version <= 1 {
 		for label, dest := range ops.labels {
 			if dest == ops.pending.Len() {
 				ops.errorf("label %#v is too far away", label)
 			}
-		}
-	}
-
-	// Before back branches, the pseudo ops can and do complain during first pass
-	if ops.Version >= backBranchEnabledVersion {
-		if ops.hasIntcBlock && ops.hasPseudoInt {
-			ops.error("program has int instruction with a manual intcblock")
-		}
-		if ops.hasBytecBlock && ops.hasPseudoByte {
-			ops.error("program has byte instruction with a manual bytecblock")
 		}
 	}
 
@@ -1850,7 +1876,7 @@ func replaceBytes(s []byte, index, originalLen int, newBytes []byte) []byte {
 // This function only optimizes constants introduces by the int pseudo-op, not
 // preexisting intcblocks in the code.
 func (ops *OpStream) optimizeIntcBlock() error {
-	if ops.hasIntcBlock {
+	if ops.cntIntcBlock > 0 {
 		// don't optimize an existing intcblock, only int pseudo-ops
 		return nil
 	}
@@ -1893,7 +1919,7 @@ func (ops *OpStream) optimizeIntcBlock() error {
 // This function only optimizes constants introduces by the byte or addr
 // pseudo-ops, not preexisting bytecblocks in the code.
 func (ops *OpStream) optimizeBytecBlock() error {
-	if ops.hasBytecBlock {
+	if ops.cntBytecBlock > 0 {
 		// don't optimize an existing bytecblock, only byte/addr pseudo-ops
 		return nil
 	}
@@ -2068,7 +2094,7 @@ func (ops *OpStream) prependCBlocks() []byte {
 	prebytes := bytes.Buffer{}
 	vlen := binary.PutUvarint(scratch[:], ops.Version)
 	prebytes.Write(scratch[:vlen])
-	if len(ops.intc) > 0 && !ops.hasIntcBlock {
+	if len(ops.intc) > 0 && ops.cntIntcBlock == 0 {
 		prebytes.WriteByte(OpsByName[ops.Version]["intcblock"].Opcode)
 		vlen := binary.PutUvarint(scratch[:], uint64(len(ops.intc)))
 		prebytes.Write(scratch[:vlen])
@@ -2077,7 +2103,7 @@ func (ops *OpStream) prependCBlocks() []byte {
 			prebytes.Write(scratch[:vlen])
 		}
 	}
-	if len(ops.bytec) > 0 && !ops.hasBytecBlock {
+	if len(ops.bytec) > 0 && ops.cntBytecBlock == 0 {
 		prebytes.WriteByte(OpsByName[ops.Version]["bytecblock"].Opcode)
 		vlen := binary.PutUvarint(scratch[:], uint64(len(ops.bytec)))
 		prebytes.Write(scratch[:vlen])

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -771,6 +771,7 @@ func TestOpBytes(t *testing.T) {
 			require.NotNil(t, prog)
 			s := hex.EncodeToString(prog)
 			require.Equal(t, mutateProgVersion(v, "0126010661626364656628"), s)
+			testProg(t, "byte 0x7; len", v, Expect{1, "...odd length hex string"})
 		})
 	}
 }

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -17,6 +17,7 @@
 package logic
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -732,7 +733,7 @@ func TestOpUint(t *testing.T) {
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			ops := newOpStream(v)
-			ops.Uint(0xcafebabe)
+			ops.IntLiteral(0xcafebabe)
 			prog := ops.prependCBlocks()
 			require.NotNil(t, prog)
 			s := hex.EncodeToString(prog)
@@ -748,9 +749,8 @@ func TestOpUint64(t *testing.T) {
 
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
-			t.Parallel()
 			ops := newOpStream(v)
-			ops.Uint(0xcafebabecafebabe)
+			ops.IntLiteral(0xcafebabecafebabe)
 			prog := ops.prependCBlocks()
 			require.NotNil(t, prog)
 			s := hex.EncodeToString(prog)
@@ -876,6 +876,80 @@ func TestAssembleBytesString(t *testing.T) {
 			testLine(t, `byte "foo bar // not a comment"`, v, "")
 		})
 	}
+}
+
+func TestManualCBlocks(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	// Despite appearing twice, 500s are pushints because of manual intcblock
+	ops := testProg(t, "intcblock 1; int 500; int 500; ==", AssemblerMaxVersion)
+	require.Equal(t, ops.Program[4], OpsByName[ops.Version]["pushint"].Opcode)
+
+	ops = testProg(t, "intcblock 2 3; intcblock 4 10; int 5", AssemblerMaxVersion)
+	text, err := Disassemble(ops.Program)
+	require.NoError(t, err)
+	require.Contains(t, text, "pushint 5")
+
+	ops = testProg(t, "intcblock 2 3; intcblock 4 10; intc_3", AssemblerMaxVersion)
+	text, err = Disassemble(ops.Program)
+	require.NoError(t, err)
+	require.Contains(t, text, "intc_3\n") // That is, no commented value for intc_3 is shown
+
+	// In old straight-line versions, allow mixing int and intc if the ints all
+	// reference manual block.  Since conditionals do make it possible that
+	// different cblocks could be in effect depending on earlier path choices,
+	// maybe we should not even allow this.
+	checkSame(t, 3,
+		"intcblock 4 5 1; intc_0; intc_2; +; intc_1; ==",
+		"intcblock 4 5 1; int 4; int 1; +; intc_1; ==",
+		"intcblock 4 5 1; intc_0; int 1; +; int 5; ==")
+	checkSame(t, 3,
+		"bytecblock 0x44 0x55 0x4455; bytec_0; bytec_1; concat; bytec_2; ==",
+		"bytecblock 0x44 0x55 0x4455; byte 0x44; bytec_1; concat; byte 0x4455; ==",
+		"bytecblock 0x44 0x55 0x4455; bytec_0; byte 0x55; concat; bytec_2; ==")
+
+	// But complain if they do not
+	testProg(t, "intcblock 4; int 3;", 3, Expect{1, "int 3 used without 3 in intcblock"})
+	testProg(t, "bytecblock 0x44; byte 0x33;", 3, Expect{1, "byte/addr/method used without value in bytecblock"})
+
+	// Or if the ref comes before the constant block, even if they match
+	testProg(t, "int 5; intcblock 4;", 3, Expect{1, "intcblock following int"})
+	testProg(t, "int 4; intcblock 4;", 3, Expect{1, "intcblock following int"})
+	testProg(t, "addr RWXCBB73XJITATVQFOI7MVUUQOL2PFDDSDUMW4H4T2SNSX4SEUOQ2MM7F4; bytecblock 0x44", 3, Expect{1, "bytecblock following byte/addr/method"})
+
+	// But we can't complain precisely once backjumps are allowed, so we force
+	// compile to push*. (We don't analyze the CFG, so we don't know if we can
+	// use what is in the user defined block. Perhaps we could special case
+	// single cblocks at start of program.
+	checkSame(t, 4,
+		"intcblock 4 5 1; int 4; int 1; +; int 5; ==",
+		"intcblock 4 5 1; pushint 4; pushint 1; +; pushint 5; ==")
+	checkSame(t, 4,
+		"bytecblock 0x44 0x55 0x4455; byte 0x44; byte 0x55; concat; byte 0x4455; ==",
+		"bytecblock 0x44 0x55 0x4455; pushbytes 0x44; pushbytes 0x55; concat; pushbytes 0x4455; ==")
+	// Can't switch to push* after the fact.
+	testProg(t, "int 5; intcblock 4;", 4, Expect{1, "intcblock following int"})
+	testProg(t, "int 4; intcblock 4;", 4, Expect{1, "intcblock following int"})
+	testProg(t, "addr RWXCBB73XJITATVQFOI7MVUUQOL2PFDDSDUMW4H4T2SNSX4SEUOQ2MM7F4; bytecblock 0x44", 4, Expect{1, "bytecblock following byte/addr/method"})
+
+	// Ignore manually added cblocks in deadcode, so they can be added easily to
+	// existing programs. There are proposals to put metadata there.
+	ops = testProg(t, "int 4; int 4; +; int 8; ==; return; intcblock 10", AssemblerMaxVersion)
+	require.Equal(t, ops.Program[1], OpsByName[ops.Version]["intcblock"].Opcode)
+	require.EqualValues(t, ops.Program[3], 4) // <intcblock> 1 4 <intc_0>
+	require.Equal(t, ops.Program[4], OpsByName[ops.Version]["intc_0"].Opcode)
+	ops = testProg(t, "b skip; intcblock 10; skip: int 4; int 4; +; int 8; ==;", AssemblerMaxVersion)
+	require.Equal(t, ops.Program[1], OpsByName[ops.Version]["intcblock"].Opcode)
+	require.EqualValues(t, ops.Program[3], 4)
+
+	ops = testProg(t, "byte 0x44; byte 0x44; concat; len; return; bytecblock 0x11", AssemblerMaxVersion)
+	require.Equal(t, ops.Program[1], OpsByName[ops.Version]["bytecblock"].Opcode)
+	require.EqualValues(t, ops.Program[4], 0x44) // <bytecblock> 1 1 0x44 <bytec_0>
+	require.Equal(t, ops.Program[5], OpsByName[ops.Version]["bytec_0"].Opcode)
+	ops = testProg(t, "b skip; bytecblock 0x11; skip: byte 0x44; byte 0x44; concat; len; int 4; ==", AssemblerMaxVersion)
+	require.Equal(t, ops.Program[1], OpsByName[ops.Version]["bytecblock"].Opcode)
+	require.EqualValues(t, ops.Program[4], 0x44)
 }
 
 func TestAssembleOptimizedConstants(t *testing.T) {
@@ -2605,12 +2679,14 @@ func checkSame(t *testing.T, version uint64, first string, compares ...string) {
 	if version == 0 {
 		version = assemblerNoVersion
 	}
-	ops, err := AssembleStringWithVersion(first, version)
-	require.NoError(t, err, first)
+	ops := testProg(t, first, version)
 	for _, compare := range compares {
-		other, err := AssembleStringWithVersion(compare, version)
-		assert.NoError(t, err, compare)
-		assert.Equal(t, other.Program, ops.Program, "%s unlike %s", first, compare)
+		other := testProg(t, compare, version)
+		if bytes.Compare(other.Program, ops.Program) != 0 {
+			t.Log(Disassemble(ops.Program))
+			t.Log(Disassemble(other.Program))
+		}
+		assert.Equal(t, ops.Program, other.Program, "%s unlike %s", first, compare)
 	}
 }
 

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -896,6 +896,15 @@ func TestBytecTooFar(t *testing.T) {
 	testPanics(t, "byte 0x23; bytec_1; btoi", 1)
 }
 
+func TestManualCBlockEval(t *testing.T) {
+	// TestManualCBlock in assembler_test.go demonstrates that these will use
+	// an inserted constant block.
+	testAccepts(t, "int 4; int 4; +; int 8; ==; return; intcblock 10", 2)
+	testAccepts(t, "b skip; intcblock 10; skip: int 4; int 4; +; int 8; ==;", 2)
+	testAccepts(t, "byte 0x2222; byte 0x2222; concat; len; int 4; ==; return; bytecblock 0x11", 2)
+	testAccepts(t, "b skip; bytecblock 0x11; skip: byte 0x2222; byte 0x2222; concat; len; int 4; ==", 2)
+}
+
 func TestTxnBadField(t *testing.T) {
 	partitiontest.PartitionTest(t)
 

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -897,6 +897,9 @@ func TestBytecTooFar(t *testing.T) {
 }
 
 func TestManualCBlockEval(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
 	// TestManualCBlock in assembler_test.go demonstrates that these will use
 	// an inserted constant block.
 	testAccepts(t, "int 4; int 4; +; int 8; ==; return; intcblock 10", 2)


### PR DESCRIPTION
This PR fixes #4034, by forcing the use of "push*" when mixing manual
constant blocks with the int/byte/addr/method pseudo-ops. (And a
related disassembly bug).

However, to avoid this "deoptimization" when manual blocks are used to
add program metadata, deadcode constant blocks are ignored for this
check.

Tests for the problems in #4034 and additional tests for the deadcode were added.