### PR TITLE
Test: Get rid of references and uses of `go lint` and `go vet`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,8 +35,10 @@ linters-settings:
     - (*github.com/algorand/go-algorand/data/transactions/logic.OpStream).warn
 
 issues:
-  # use these new lint checks on code since #2574
-  new-from-rev: eb019291beed556ec6ac1ceb4a15114ce4df0c57
+  # Work our way back over time to be clean against all these
+  # checkers.  If you'd like to contribute, raise the number after ~,
+  # run the linter and dig in.
+  new-from-rev: eb019291beed556ec6ac1ceb4a15114ce4df0c57~25
 
   # Disable default exclude rules listed in `golangci-lint run --help` (selectively re-enable some below)
   exclude-use-default: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Again, if you have a patch for a critical security vulnerability, please use our
 
 For Go code we use the [Golang guidelines defined here](https://golang.org/doc/effective_go.html).
 * Code must adhere to the official Go formatting guidelines (i.e. uses gofmt).
-* We use **gofmt** and **golint**. Also make sure to run `make sanity` and `make generate` before opening a pull request.
+* We use **gofmt** and **golangci-lint**. Also make sure to run `make sanity` and `make generate` before opening a pull request.
 * Code must be documented adhering to the official Go commentary guidelines.
 
 For JavaScript code we use the [MDN formatting rules](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Guidelines/Code_guidelines/JavaScript).

--- a/Makefile
+++ b/Makefile
@@ -102,13 +102,10 @@ fix: build
 lint: deps
 	$(GOPATH1)/bin/golangci-lint run -c .golangci.yml 
 
-vet:
-	go vet ./...
-
 check_shell:
 	find . -type f -name "*.sh" -exec shellcheck {} +
 
-sanity: vet fix lint fmt
+sanity: fix lint fmt
 
 cover:
 	go test $(GOTAGS) -coverprofile=cover.out $(UNIT_TEST_SOURCES)
@@ -331,7 +328,7 @@ dump: $(addprefix gen/,$(addsuffix /genesis.dump, $(NETWORKS)))
 install: build
 	scripts/dev_install.sh -p $(GOPATH1)/bin
 
-.PHONY: default fmt vet lint check_shell sanity cover prof deps build test fulltest shorttest clean cleango deploy node_exporter install %gen gen NONGO_BIN check-go-version rebuild_swagger
+.PHONY: default fmt lint check_shell sanity cover prof deps build test fulltest shorttest clean cleango deploy node_exporter install %gen gen NONGO_BIN check-go-version rebuild_swagger
 
 ###### TARGETS FOR CICD PROCESS ######
 include ./scripts/release/mule/Makefile.mule

--- a/scripts/buildtools/install_buildtools.sh
+++ b/scripts/buildtools/install_buildtools.sh
@@ -87,7 +87,6 @@ if [[ "${BUILDTOOLS_INSTALL}" != "ALL" ]]; then
   exit 0
 fi
 
-install_go_module golang.org/x/lint golang.org/x/lint/golint
 install_go_module golang.org/x/tools golang.org/x/tools/cmd/stringer
 install_go_module github.com/go-swagger/go-swagger github.com/go-swagger/go-swagger/cmd/swagger
 install_go_module github.com/algorand/msgp

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -35,7 +35,6 @@ missing_dep() {
 }
 
 GO_DEPS=(
-    "$GO_BIN/golint"
     "$GO_BIN/stringer"
     "$GO_BIN/msgp"
     "$GO_BIN/golangci-lint"

--- a/scripts/travis/codegen_verification.sh
+++ b/scripts/travis/codegen_verification.sh
@@ -47,7 +47,7 @@ function runGoLint() {
         return 0
     fi
 
-    echo >&2 "golint must be clean.  Please run the following to list issues(${warningCount}):"
+    echo >&2 "golangci-lint must be clean.  Please run the following to list issues(${warningCount}):"
     echo >&2 " make lint"
 
     # run the linter again to output the actual issues
@@ -55,13 +55,10 @@ function runGoLint() {
     return 1
 }
 
-echo "Running go vet..."
-make vet
-
 echo "Running gofmt..."
 runGoFmt
 
-echo "Running golint..."
+echo "Running golangci-lint..."
 runGoLint
 
 echo "Running check_license..."


### PR DESCRIPTION
golangci-lint subsumes both of these tools
