### PR TITLE
testing: deterministic rand seed for stable unit test

### DIFF
--- a/rpcs/txSyncer_test.go
+++ b/rpcs/txSyncer_test.go
@@ -53,7 +53,7 @@ func init() {
 	testRand = rand.New(testSource)
 }
 
-func cryptoRandBytes(d []byte) {
+func testRandBytes(d []byte) {
 	// We don't need cryptographically strong random bytes for a
 	// unit test, we _do_ need deterministic 'random' bytes so
 	// that _sometimes_ a bloom filter doesn't fail on the data
@@ -69,7 +69,7 @@ func cryptoRandBytes(d []byte) {
 
 func makeMockPendingTxAggregate(txCount int) mockPendingTxAggregate {
 	var secret [32]byte
-	cryptoRandBytes(secret[:])
+	testRandBytes(secret[:])
 	sk := crypto.GenerateSignatureSecrets(crypto.Seed(secret))
 	mock := mockPendingTxAggregate{
 		txns: make([]transactions.SignedTxn, txCount),
@@ -77,7 +77,7 @@ func makeMockPendingTxAggregate(txCount int) mockPendingTxAggregate {
 
 	for i := 0; i < txCount; i++ {
 		var note [16]byte
-		cryptoRandBytes(note[:])
+		testRandBytes(note[:])
 		tx := transactions.Transaction{
 			Type: protocol.PaymentTx,
 			Header: transactions.Header{

--- a/rpcs/txSyncer_test.go
+++ b/rpcs/txSyncer_test.go
@@ -19,6 +19,7 @@ package rpcs
 import (
 	"context"
 	"errors"
+	"math/rand"
 	"net/http"
 	"net/rpc"
 	"strings"
@@ -44,9 +45,31 @@ type mockPendingTxAggregate struct {
 	txns []transactions.SignedTxn
 }
 
+var testSource rand.Source
+var testRand *rand.Rand
+
+func init() {
+	testSource = rand.NewSource(12345678)
+	testRand = rand.New(testSource)
+}
+
+func cryptoRandBytes(d []byte) {
+	// We don't need cryptographically strong random bytes for a
+	// unit test, we _do_ need deterministic 'random' bytes so
+	// that _sometimes_ a bloom filter doesn't fail on the data
+	// (e.g. TestSync() below).
+	n, err := testRand.Read(d)
+	if n != len(d) {
+		panic("short rand read")
+	}
+	if err != nil {
+		panic(err)
+	}
+}
+
 func makeMockPendingTxAggregate(txCount int) mockPendingTxAggregate {
 	var secret [32]byte
-	crypto.RandBytes(secret[:])
+	cryptoRandBytes(secret[:])
 	sk := crypto.GenerateSignatureSecrets(crypto.Seed(secret))
 	mock := mockPendingTxAggregate{
 		txns: make([]transactions.SignedTxn, txCount),
@@ -54,7 +77,7 @@ func makeMockPendingTxAggregate(txCount int) mockPendingTxAggregate {
 
 	for i := 0; i < txCount; i++ {
 		var note [16]byte
-		crypto.RandBytes(note[:])
+		cryptoRandBytes(note[:])
 		tx := transactions.Transaction{
 			Type: protocol.PaymentTx,
 			Header: transactions.Header{


### PR DESCRIPTION
## Summary

Putting random data into a bloom filter would sometimes fail the test. Set the random seed so that we have deterministic psuedo-random data.

## Test Plan

Ran this for a while with no errors. Used to fail within a few dozen tries.
`go test -c -race -o rpcs.test && while logwrapq ./rpcs.test -test.count 50 -test.timeout 5m -test.v -test.run TestSync; do date; done`