### PR TITLE
test: TestSlowPeerDisconnect less flakey

### DIFF
--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -1467,7 +1467,7 @@ func TestSlowPeerDisconnection(t *testing.T) {
 	now := time.Now()
 	expire := now.Add(5 * time.Second)
 	for {
-		time.Sleep(time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 		if len(peer.sendBufferHighPrio)+len(peer.sendBufferBulk) == 0 {
 			break
 		}


### PR DESCRIPTION
## Summary

sleeping 1ms can still starve other processes sometimes.
sleep 10ms to let the test run.
test used to fail about 1/200; haven't seen a failure in several thousand now.

## Test Plan

This is a test. It should be less flakey now.