### PR TITLE
Ledger: Initialize the accountUpdatesLedgerEvaluator properly

### DIFF
--- a/ledger/internal/double_test.go
+++ b/ledger/internal/double_test.go
@@ -129,6 +129,11 @@ func (dl *DoubleLedger) endBlock() *ledgercore.ValidatedBlock {
 	return vb
 }
 
+func (dl *DoubleLedger) reloadLedgers() {
+	require.NoError(dl.t, dl.generator.ReloadLedger())
+	require.NoError(dl.t, dl.validator.ReloadLedger())
+}
+
 func checkBlock(t *testing.T, checkLedger *ledger.Ledger, vb *ledgercore.ValidatedBlock) {
 	bl := vb.Block()
 	msg := bl.MarshalMsg(nil)

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -167,6 +167,12 @@ func OpenLedger(
 	return l, nil
 }
 
+// ReloadLedger is exported for the benefit of tests in the internal
+// package. Revisit this when we rename / restructure that thing
+func (l *Ledger) ReloadLedger() error {
+	return l.reloadLedger()
+}
+
 func (l *Ledger) reloadLedger() error {
 	// similar to the Close function, we want to start by closing the blockQ first. The
 	// blockQ is having a sync goroutine which indirectly calls other trackers. We want to eliminate that go-routine first,

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -553,8 +553,9 @@ func (tr *trackerRegistry) replay(l ledgerForTracker) (err error) {
 	}
 
 	accLedgerEval := accountUpdatesLedgerEvaluator{
-		au: tr.accts,
-		ao: tr.acctsOnline,
+		au:   tr.accts,
+		ao:   tr.acctsOnline,
+		tail: tr.tail,
 	}
 
 	if lastBalancesRound < lastestBlockRound {


### PR DESCRIPTION
This fixes the purestake issue on betanet and includes an easy way to test for similar bugs.