### PR TITLE
CI:  Re-introduce build_nightly workflow to persist artifacts for upload_binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,18 @@ workflows:
   version: 2
   "circleci_build_and_test":
     jobs:
+      - build_nightly:
+          name: << matrix.platform >>_build_nightly
+          matrix: &matrix-nightly
+            parameters:
+              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
+          filters: &filters-nightly
+            branches:
+              only:
+                - /rel\/.*/
+                - << pipeline.parameters.valid_nightly_branch >>
+          context: slack-secrets
+
       - test:
           name: << matrix.platform >>_test
           matrix: &matrix-default
@@ -77,14 +89,10 @@ workflows:
 
       - test_nightly:
           name: << matrix.platform >>_test_nightly
-          matrix: &matrix-nightly
-            parameters:
-              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
-          filters: &filters-nightly
-            branches:
-              only:
-                - /rel\/.*/
-                - << pipeline.parameters.valid_nightly_branch >>
+          matrix:
+            <<: *matrix-nightly
+          requires:
+            - << matrix.platform >>_build_nightly
           context: slack-secrets
 
       - integration:
@@ -98,8 +106,8 @@ workflows:
           name: << matrix.platform >>_integration_nightly
           matrix:
             <<: *matrix-nightly
-          filters:
-            <<: *filters-nightly
+          requires:
+            - << matrix.platform >>_build_nightly
           context: slack-secrets
 
       - e2e_expect:
@@ -113,8 +121,8 @@ workflows:
           name: << matrix.platform >>_e2e_expect_nightly
           matrix:
             <<: *matrix-nightly
-          filters:
-            <<: *filters-nightly
+          requires:
+            - << matrix.platform >>_build_nightly
           context: slack-secrets
 
       - e2e_subs:
@@ -128,8 +136,8 @@ workflows:
           name: << matrix.platform >>_e2e_subs_nightly
           matrix:
             <<: *matrix-nightly
-          filters:
-            <<: *filters-nightly
+          requires:
+            - << matrix.platform >>_build_nightly
           context:
             - slack-secrets
             - aws-secrets
@@ -469,6 +477,29 @@ commands:
                     scripts/travis/test_release.sh
 
 jobs:
+  build_nightly:
+    description: "Persists build artifacts to workspace in order to support `upload_binaries`."
+    parameters:
+      platform:
+        type: string
+      build_dir:
+        type: string
+        default: << pipeline.parameters.build_dir >>
+    executor: << parameters.platform >>_medium
+    working_directory: << pipeline.parameters.build_dir >>/project
+    steps:
+      - generic_build
+      - persist_to_workspace:
+          root: << parameters.build_dir >>
+          paths:
+            - project
+            - go
+            - gimme
+            - .gimme
+      - slack/notify: &slack-fail-event
+          event: fail
+          template: basic_fail_1
+
   test:
     parameters:
       platform:


### PR DESCRIPTION
## Summary

Attempts to fix a regression in the nightly build introduced in https://github.com/algorand/go-algorand/pull/4426/.

Notes:
* Example failure:  https://app.circleci.com/pipelines/github/algorand/go-algorand/8989/workflows/bca22a16-2fa2-4cda-b487-0b1fad6f42f4/jobs/161778
* Since #4426 no longer persists build artifacts to the workspace, the downstream `upload_binaries` workflow fails to find artifacts to upload.
* The PR re-introduces a version of `build_nightly` workflow that builds + persists artifacts to the workspace.  The approach mirrors the prior behavior (https://github.com/algorand/go-algorand/blob/0b9580b3cca20753f89956bd295910209163a025/.circleci/config.yml#L263-L269).  The PR deliberately avoids branching in favor of a unique set of steps under the assumption that it's easier to follow/maintain.

## Test Plan

Sanity checked config changes via `circleci config validate`.
