### PR TITLE
build: adding valid_nightly_branch var to upload_binaries step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,7 @@ workflows:
             branches:
               only:
                 - /rel\/.*/
+                - << pipeline.parameters.valid_nightly_branch >>
           context:
             - slack-secrets
             - aws-secrets


### PR DESCRIPTION
making that variable be in all nightly steps.

Doc on how to use that var (by Barbara):
https://algorand.atlassian.net/wiki/spaces/DEVOPS/pages/2459893761/How+to+Run+Nightly+Tests+on+go-algorand

tested with custom branch:
https://app.circleci.com/pipelines/github/algorand/go-algorand/9011/workflows/72c36c87-93ab-466b-b932-6f9b7c886b9f