### PR TITLE
CI: optimize caches used by CircleCI and GHA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,18 +234,7 @@ commands:
       - checkout
       - prepare_go
       - restore_libsodium
-      - restore_cache:
-          name: Restoring Go source cache
-          keys:
-            - 'go-mod-1.17.13-v4-{{ arch }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}'
-      - restore_cache:
-          name: Restoring Go build/test cache
-          keys:
-            - go-cache-v5-{{ arch }}-{{ .Branch }}-{{ checksum "go.sum" }}-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}
-            - go-cache-v5-{{ arch }}-{{ .Branch }}-{{ checksum "go.sum" }}-{{ .Environment.CIRCLE_JOB }}
-            - go-cache-v5-{{ arch }}-{{ .Branch }}-{{ checksum "go.sum" }}-
-            - go-cache-v5-{{ arch }}-{{ .Branch }}-
-            - go-cache-v5-{{ arch }}-master-
+      - restore_go_caches
       - run:
           name: scripts/travis/build.sh --make_debug
           command: |
@@ -257,11 +246,41 @@ commands:
             export GIMME_VERSION_PREFIX=<< parameters.build_dir >>/.gimme/versions
             scripts/travis/build.sh --make_debug
       - cache_libsodium
+      - save_go_caches
+
+  save_go_caches:
+    description: Cache Go source and build caches
+    parameters:
+      build_dir:
+        type: string
+        default: << pipeline.parameters.build_dir >>
+    steps:
       - save_cache:
-          name: Saving Go source cache
-          key: 'go-mod-1.17.13-v4-{{ arch }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}'
+          name: Saving Go mod source cache
+          key: go-mod-v5-{{ .Branch }}-{{ checksum "go.sum" }}
           paths:
             - << parameters.build_dir >>/go/pkg/mod
+      - save_cache:
+          name: Saving Go build cache
+          key: go-cache-v5-{{ arch }}-{{ .Branch }}-{{ checksum "go.sum" }}
+          paths:
+            - tmp/go-cache
+
+  restore_go_caches:
+    description: Restore Go source and build caches
+    steps:
+      - restore_cache:
+          name: Restoring Go mod source cache
+          keys:
+            - go-mod-v5-{{ .Branch }}-{{ checksum "go.sum" }}
+            - go-mod-v5-{{ .Branch }}-
+            - go-mod-v5-master-
+      - restore_cache:
+          name: Restoring Go build cache
+          keys:
+            - go-cache-v5-{{ arch }}-{{ .Branch }}-{{ checksum "go.sum" }}
+            - go-cache-v5-{{ arch }}-{{ .Branch }}-
+            - go-cache-v5-{{ arch }}-master-
 
   cache_libsodium:
     description: Cache libsodium for build
@@ -336,11 +355,6 @@ commands:
             export PARTITION_TOTAL=${CIRCLE_NODE_TOTAL}
             export PARTITION_ID=${CIRCLE_NODE_INDEX}
             gotestsum --format standard-verbose --junitfile << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml --jsonfile << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" << parameters.short_test_flag >> -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 1 $PACKAGE_NAMES
-      - save_cache:
-          name: Saving Go build/test cache
-          key: go-cache-v5-{{ arch }}-{{ .Branch }}-{{ checksum "go.sum" }}-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}
-          paths:
-            - tmp/go-cache
       - store_artifacts:
           path: << parameters.result_path >>
           destination: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,13 +227,17 @@ commands:
       - prepare_go
       - restore_libsodium
       - restore_cache:
+          name: Restoring Go source cache
           keys:
             - 'go-mod-1.17.9-v4-{{ arch }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}'
       - restore_cache:
+          name: Restoring Go build/test cache
           keys:
-            - 'go-cache-v4-{{ arch }}-{{ .Branch }}-{{ .Revision }}'
-            - 'go-cache-v4-{{ arch }}-{{ .Branch }}-'
-            - 'go-cache-v4-{{ arch }}-'
+            - go-cache-v5-{{ arch }}-{{ .Branch }}-{{ checksum "go.sum" }}-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}
+            - go-cache-v5-{{ arch }}-{{ .Branch }}-{{ checksum "go.sum" }}-{{ .Environment.CIRCLE_JOB }}
+            - go-cache-v5-{{ arch }}-{{ .Branch }}-{{ checksum "go.sum" }}-
+            - go-cache-v5-{{ arch }}-{{ .Branch }}-
+            - go-cache-v5-{{ arch }}-master-
       - run:
           name: scripts/travis/build.sh --make_debug
           command: |
@@ -246,13 +250,10 @@ commands:
             scripts/travis/build.sh --make_debug
       - cache_libsodium
       - save_cache:
+          name: Saving Go source cache
           key: 'go-mod-1.17.9-v4-{{ arch }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}'
           paths:
             - << parameters.build_dir >>/go/pkg/mod
-      - save_cache:
-          key: 'go-cache-v4-{{ arch }}-{{ .Branch }}-{{ .Revision }}'
-          paths:
-            - tmp/go-cache
 
   cache_libsodium:
     description: Cache libsodium for build
@@ -325,6 +326,11 @@ commands:
             export PARTITION_TOTAL=${CIRCLE_NODE_TOTAL}
             export PARTITION_ID=${CIRCLE_NODE_INDEX}
             gotestsum --format standard-verbose --junitfile << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml --jsonfile << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" << parameters.short_test_flag >> -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 1 $PACKAGE_NAMES
+      - save_cache:
+          name: Saving Go build/test cache
+          key: go-cache-v5-{{ arch }}-{{ .Branch }}-{{ checksum "go.sum" }}-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}
+          paths:
+            - tmp/go-cache
       - store_artifacts:
           path: << parameters.result_path >>
           destination: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,6 +272,7 @@ commands:
             mkdir -p tmp
             find crypto/libsodium-fork -type f -exec openssl md5 "{}" + > tmp/libsodium.md5
       - save_cache:
+          name: Save cached libsodium build
           key: 'libsodium-fork-v4-{{ arch }}-{{ checksum "tmp/libsodium.md5" }}'
           paths:
             - crypto/libs
@@ -285,6 +286,7 @@ commands:
             mkdir -p tmp
             find crypto/libsodium-fork -type f -exec openssl md5 "{}" + > tmp/libsodium.md5
       - restore_cache:
+          name: Restore cached libsodium build
           keys:
             - 'libsodium-fork-v4-{{ arch }}-{{ checksum "tmp/libsodium.md5" }}'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: "Build Windows"
 on:
+  push:
+    branches:
+      - master
   pull_request:
 jobs:
   build-windows:

--- a/.github/workflows/codegen_verification.yml
+++ b/.github/workflows/codegen_verification.yml
@@ -1,5 +1,8 @@
 name: "codegen verification"
 on:
+  push:
+    branches:
+      - master
   pull_request:
 jobs:
   codegen_verification:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,5 +1,8 @@
 name: "ReviewDog workflow"
 on:
+  push:
+    branches:
+      - master
   pull_request:
 jobs:
   # Blocking Errors Section


### PR DESCRIPTION
## Summary

This updates the CircleCI and Github Actions caches to make it possible to find cache hits more often, by tweaking the key scheme for Go mod source and build caches. 

For Github Actions, adding CI for merges to master, will ensure we are doing the same testing as on PRs, and also provide cached data on master that ensures the GHA cache will serve a hit from the master build for the first commit on a new branch PR.
>A workflow can access and restore a cache created in the current branch, the base branch (including base branches of forked repositories), or the default branch (usually main). For example, a cache created on the default branch would be accessible from any pull request. 
https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache

## Test Plan

Rerun this PR after changing some code.