### PR TITLE
Ignore: replace machines for PR tests without changing parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,7 +505,7 @@ jobs:
     parameters:
       platform:
         type: string
-    executor: << parameters.platform >>_medium
+    executor: << parameters.platform >>_large
     working_directory: << pipeline.parameters.build_dir >>/project
     parallelism: 4
     steps:
@@ -572,7 +572,7 @@ jobs:
     parameters:
       platform:
         type: string
-    executor: << parameters.platform >>_medium
+    executor: << parameters.platform >>_large
     working_directory: << pipeline.parameters.build_dir >>/project
     parallelism: 2
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ executors:
   amd64_large:
     machine:
       image: << pipeline.parameters.ubuntu_image >>
-    resource_class: large
+    resource_class: xlarge
   arm64_medium:
     machine:
       image: << pipeline.parameters.ubuntu_image >>
@@ -35,7 +35,7 @@ executors:
   arm64_large:
     machine:
       image: << pipeline.parameters.ubuntu_image >>
-    resource_class: arm.large
+    resource_class: arm.xlarge
   mac_amd64_medium:
     macos:
       xcode: 13.2.1


### PR DESCRIPTION
## Summary
Testing the CircleCI PR tests with larger machines without modifying the previous parallelism and observing results.