### PR TITLE
stateproof: always set StateProofNextRound in metric

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -859,15 +859,13 @@ func (pool *TransactionPool) AssembleBlock(round basics.Round, deadline time.Tim
 						}
 					}
 					stats.TotalLength += uint64(encodedLen)
-					stats.StateProofNextRound = uint64(assembled.Block().StateProofTracking[protocol.StateProofBasic].StateProofNextRound)
 					if txib.Txn.Type == protocol.StateProofTx {
 						stats.StateProofStats = pool.getStateProofStats(&txib, encodedLen)
 					}
 				}
-
 				stats.AverageFee = totalFees / uint64(stats.IncludedCount)
 			}
-
+			stats.StateProofNextRound = uint64(assembled.Block().StateProofTracking[protocol.StateProofBasic].StateProofNextRound)
 			var details struct {
 				Round uint64
 			}

--- a/data/pools/transactionPool_test.go
+++ b/data/pools/transactionPool_test.go
@@ -1432,11 +1432,17 @@ func TestStateProofLogging(t *testing.T) {
 		lines = append(lines, scanner.Text())
 	}
 	fmt.Println(lines[len(lines)-1])
+	// Verify that the StateProofNextRound is added when there are no transactions
+	var int1, nextRound uint64
+	var str1 string
+	partsNext := strings.Split(lines[len(lines)-10], "TransactionsLoopStartTime:")
+	fmt.Sscanf(partsNext[1], "%d, StateProofNextRound:%d, %s", &int1, &nextRound, &str1)
+	require.Equal(t, int(512), int(nextRound))
+
 	parts := strings.Split(lines[len(lines)-1], "StateProofNextRound:")
 
 	// Verify the Metrics is correct
-	var nextRound, pWeight, signedWeight, numReveals, posToReveal, txnSize uint64
-	var str1 string
+	var pWeight, signedWeight, numReveals, posToReveal, txnSize uint64
 	fmt.Sscanf(parts[1], "%d, ProvenWeight:%d, SignedWeight:%d, NumReveals:%d, NumPosToReveal:%d, TxnSize:%d\"%s",
 		&nextRound, &pWeight, &signedWeight, &numReveals, &posToReveal, &txnSize, &str1)
 	require.Equal(t, uint64(768), nextRound)


### PR DESCRIPTION
Set the StateProofNextRound to metric stats when the block payset is empty.

Added a check for this in the logging test.