### PR TITLE
enhancement: Return a 404 when a block is not found.

### DIFF
--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -120,7 +120,8 @@ func TestGetBlock(t *testing.T) {
 
 	getBlockTest(t, 0, "json", 200)
 	getBlockTest(t, 0, "msgpack", 200)
-	getBlockTest(t, 1, "json", 500)
+	getBlockTest(t, 1, "json", 404)
+	getBlockTest(t, 1, "msgpack", 404)
 	getBlockTest(t, 0, "bad format", 400)
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Return a 404 instead of 500 when /v2/blocks/{round} fails due to a missing block.

## Test Plan

Update handler test
