### PR TITLE
ledger: fix catchpoint test

### DIFF
--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -511,7 +511,7 @@ func TestCatchpointReadDatabaseOverflowAccounts(t *testing.T) {
 
 	accts := ledgertesting.RandomAccounts(5, false)
 	// force each acct to have overflowing number of resources
-	assetIndex := 100
+	assetIndex := 1000
 	for addr, acct := range accts {
 		if acct.AssetParams == nil {
 			acct.AssetParams = make(map[basics.AssetIndex]basics.AssetParams, 0)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

Fixed the TestCatchpointReadDatabaseOverflowAccounts test. It was failing because multiple resources were being created with the same id, since the test first creates resources with id's as a random slice between 0 and 512, and then counting up from 100. This pr changes the latter set of resources to count up from 1000 to avoid the conflict.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

This is a test
