### PR TITLE
updater: cleanup key.pub

### DIFF
--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -272,7 +272,7 @@ function check_for_updater() {
 
         # try signature validation
         if [ "$GPG_VERIFY" = "1" ]; then
-            local UPDATER_SIGFILE="$UPDATER_TEMPDIR/updater.sig" UPDATER_PUBKEYFILE="key.pub"
+            local UPDATER_SIGFILE="$UPDATER_TEMPDIR/updater.sig" UPDATER_PUBKEYFILE="$UPDATER_TEMPDIR/key.pub"
             # try downloading public key
             if curl -sSL "$UPDATER_PUBKEYURL" -o "$UPDATER_PUBKEYFILE"; then
                 GNUPGHOME="$(mktemp -d)"; export GNUPGHOME


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

when providing the `-verify` flag to `update.sh`, the public GPG key is downloaded into the directory in which the script is called (PWD) and is never cleaned up. this makes it so that when the key is downloaded, it is placed in the temporary directory that gets cleaned up. otherwise, after execution, it's just hanging around. 

## Test Plan

I've been testing this with the following script

<details>
<summary>setup-algo-node.sh</summary>

```bash
#!/usr/bin/env bash

set -e

declare UPDATER_SCRIPT_URL="${UPDATER_SCRIPT_URL:-"https://raw.githubusercontent.com/algorand/go-algorand/master/cmd/updater/update.sh"}"
declare NETWORK="${NETWORK:-"mainnet"}"
declare CHANNEL="${CHANNEL:-"stable"}"

while getopts "c:n:u:" opt; do
	case "$opt" in
	c)
		CHANNEL="$OPTARG"
		;;
	n)
		NETWORK="$OPTARG"
		;;
	u)
		UPDATER_SCRIPT_URL="$OPTARG"
		;;
	*)
		echo "Unrecognized option"
		exit 1
		;;
	esac
done

declare -r _ALGORAND_ROOT="${_ALGORAND_ROOT:-"${HOME}/algorand"}"
declare -r ALGORAND_NETWORK_DIR="${_ALGORAND_ROOT}/${NETWORK}"
declare -r ALGORAND_DATA="${ALGORAND_DATA:-"${ALGORAND_NETWORK_DIR}/data"}"

# create temporary directory
TMP_DIR="$(mktemp -d)"
declare -r TMP_DIR
UPDATER_SCRIPT="${TMP_DIR}/update.sh"

# make sure network directory exists
mkdir -p "$ALGORAND_NETWORK_DIR"

# download updater script
curl -sSL "$UPDATER_SCRIPT_URL" -o "$UPDATER_SCRIPT"
chmod 0744 "$UPDATER_SCRIPT"

# execute updater script
"$UPDATER_SCRIPT" -i -c "$CHANNEL" -g "$NETWORK" -p "$ALGORAND_NETWORK_DIR" -d "$ALGORAND_DATA" -verify

# cleanup
rm -rf "$TMP_DIR"

```

</details>

using the following command

```bash
UPDATER_SCRIPT_URL=https://raw.githubusercontent.com/algolucky/go-algorand/updater/cleanup-pubkey-file/cmd/updater/update.sh setup-algo-node.sh -c stable -n testnet
```

