### PR TITLE
Refactor to linearize ledger lookup in GetApplicationBoxes

### DIFF
--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -1152,6 +1152,7 @@ func applicationBoxesMaxKeys(requestedMax uint64, algodMax uint64) uint64 {
 	if requestedMax <= algodMax || algodMax == 0 {
 		return requestedMax // requested limit dominates
 	}
+
 	return algodMax + 1 // API limit dominates.  Increments by 1 to test if more than max supported results exist.
 }
 

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -1142,15 +1142,17 @@ func (v2 *Handlers) GetApplicationByID(ctx echo.Context, applicationID uint64) e
 }
 
 func applicationBoxesMaxKeys(requestedMax uint64, algodMax uint64) uint64 {
-	algodSupportsUnlimitedResults := algodMax == 0
-	noRequestProvidedLimit := requestedMax == 0
-	dominatedByQryParams := requestedMax > 0 && (algodMax >= requestedMax || algodSupportsUnlimitedResults)
-	returnsAll := noRequestProvidedLimit && algodSupportsUnlimitedResults
-
-	if dominatedByQryParams || returnsAll {
-		return requestedMax
+	if requestedMax == 0 {
+		if algodMax == 0 {
+			return 0 // unlimited results when both requested and algod max are 0
+		}
+		return algodMax + 1 // API limit dominates
 	}
-	return algodMax + 1
+
+	if requestedMax <= algodMax || algodMax == 0 {
+		return requestedMax // requested limit dominates
+	}
+	return algodMax + 1 // API limit dominates
 }
 
 // GetApplicationBoxes returns the box names of an application

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -1146,13 +1146,13 @@ func applicationBoxesMaxKeys(requestedMax uint64, algodMax uint64) uint64 {
 		if algodMax == 0 {
 			return 0 // unlimited results when both requested and algod max are 0
 		}
-		return algodMax + 1 // API limit dominates
+		return algodMax + 1 // API limit dominates.  Increments by 1 to test if more than max supported results exist.
 	}
 
 	if requestedMax <= algodMax || algodMax == 0 {
 		return requestedMax // requested limit dominates
 	}
-	return algodMax + 1 // API limit dominates
+	return algodMax + 1 // API limit dominates.  Increments by 1 to test if more than max supported results exist.
 }
 
 // GetApplicationBoxes returns the box names of an application

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -1153,8 +1153,9 @@ func (v2 *Handlers) GetApplicationBoxes(ctx echo.Context, applicationID uint64, 
 	castedMax := nilToZero(params.Max)
 	maxBoxThreshold := v2.Node.Config().MaxAPIBoxPerApplication
 
+	algodSupportsUnlimitedResults := maxBoxThreshold == 0
+
 	maxKeys := func() uint64 {
-		algodSupportsUnlimitedResults := maxBoxThreshold == 0
 		noRequestProvidedLimit := castedMax == 0
 		dominatedByQryParams := castedMax > 0 && (maxBoxThreshold >= castedMax || algodSupportsUnlimitedResults)
 		returnsAll := noRequestProvidedLimit && algodSupportsUnlimitedResults
@@ -1170,7 +1171,7 @@ func (v2 *Handlers) GetApplicationBoxes(ctx echo.Context, applicationID uint64, 
 		return internalError(ctx, err, errFailedLookingUpLedger, v2.Log)
 	}
 
-	if uint64(len(boxKeys)) > maxBoxThreshold {
+	if !algodSupportsUnlimitedResults && uint64(len(boxKeys)) > maxBoxThreshold {
 		v2.Log.Info("MaxAPIBoxPerApplication limit %d exceeded", maxBoxThreshold)
 		return ctx.JSON(http.StatusBadRequest, generated.ErrorResponse{
 			Message: "Result limit exceeded",

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -1166,7 +1166,7 @@ func (v2 *Handlers) GetApplicationBoxes(ctx echo.Context, applicationID uint64, 
 	// cast param.Max to zero, if param.Max points to some value, we keep the value
 	castedMax := nilToZero(params.Max)
 	maxBoxThreshold := v2.Node.Config().MaxAPIBoxPerApplication
-	algodLimitsResults := maxBoxThreshold >= 0
+	algodLimitsResults := maxBoxThreshold > 0
 
 	boxKeys, err := ledger.LookupKeysByPrefix(lastRound, keyPrefix, applicationBoxesMaxKeys(castedMax, maxBoxThreshold))
 	if err != nil {

--- a/daemon/algod/api/server/v2/handlers_test.go
+++ b/daemon/algod/api/server/v2/handlers_test.go
@@ -59,9 +59,9 @@ func TestApplicationBoxesMaxKeys(t *testing.T) {
 
 	// Response size limited by algod max.
 	{
-		requestedMax := randomUint64(3, math.MaxUint64)
-		algodMax := requestedMax - 2 // algodMax > 0
-		equals(algodMax+1, example{requestedMax, algodMax})
+		requestedMax := randomUint64(0, math.MaxUint64-1)
+		algodMax := requestedMax + 1 // algodMax > 0
+		equals(requestedMax, example{requestedMax, algodMax})
 	}
 
 	// Response size _not_ limited

--- a/daemon/algod/api/server/v2/handlers_test.go
+++ b/daemon/algod/api/server/v2/handlers_test.go
@@ -1,0 +1,73 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package v2
+
+import (
+	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/stretchr/testify/require"
+	"math"
+	"math/rand"
+	"testing"
+)
+
+func TestApplicationBoxesMaxKeys(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	type example struct {
+		requestedMax uint64
+		algodMax     uint64
+	}
+
+	randomUint64 := func(min, max uint64) uint64 {
+		r := rand.Uint64()
+		if r > max {
+			return max
+		} else if r < min {
+			return min
+		}
+		return r
+	}
+
+	equals := func(expected uint64, e example) {
+		require.Equal(t, expected, applicationBoxesMaxKeys(e.requestedMax, e.algodMax), "failing example = %+v", e)
+	}
+
+	// Response size limited by request supplied value.
+	{
+		requestedMax := randomUint64(1, math.MaxUint64-1)
+		algodMax := requestedMax + 1
+		equals(requestedMax, example{requestedMax, algodMax})
+
+		algodMax = uint64(0)
+		equals(requestedMax, example{requestedMax, algodMax})
+	}
+
+	// Response size limited by algod max.
+	{
+		requestedMax := randomUint64(3, math.MaxUint64)
+		algodMax := requestedMax - 2 // algodMax > 0
+		equals(algodMax+1, example{requestedMax, algodMax})
+	}
+
+	// Response size _not_ limited
+	{
+		requestedMax := uint64(0)
+		algodMax := uint64(0)
+		equals(algodMax, example{requestedMax, algodMax})
+	}
+}

--- a/daemon/algod/api/server/v2/handlers_test.go
+++ b/daemon/algod/api/server/v2/handlers_test.go
@@ -19,8 +19,6 @@ package v2
 import (
 	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/stretchr/testify/require"
-	"math"
-	"math/rand"
 	"testing"
 )
 
@@ -33,35 +31,30 @@ func TestApplicationBoxesMaxKeys(t *testing.T) {
 		algodMax     uint64
 	}
 
-	randomUint64 := func(min, max uint64) uint64 {
-		r := rand.Uint64()
-		if r > max {
-			return max
-		} else if r < min {
-			return min
-		}
-		return r
-	}
-
 	equals := func(expected uint64, e example) {
 		require.Equal(t, expected, applicationBoxesMaxKeys(e.requestedMax, e.algodMax), "failing example = %+v", e)
 	}
 
 	// Response size limited by request supplied value.
 	{
-		requestedMax := randomUint64(1, math.MaxUint64-1)
-		algodMax := requestedMax + 1
+		requestedMax := uint64(5)
+		algodMax := uint64(7)
 		equals(requestedMax, example{requestedMax, algodMax})
 
+		requestedMax = uint64(5)
 		algodMax = uint64(0)
 		equals(requestedMax, example{requestedMax, algodMax})
 	}
 
 	// Response size limited by algod max.
 	{
-		requestedMax := randomUint64(0, math.MaxUint64-1)
-		algodMax := requestedMax + 1 // algodMax > 0
-		equals(requestedMax, example{requestedMax, algodMax})
+		requestedMax := uint64(5)
+		algodMax := uint64(1)
+		equals(algodMax+1, example{requestedMax, algodMax})
+
+		requestedMax = uint64(0)
+		algodMax = uint64(1)
+		equals(algodMax+1, example{requestedMax, algodMax})
 	}
 
 	// Response size _not_ limited


### PR DESCRIPTION
Attempts to address https://github.com/algorand/go-algorand/pull/4149#discussion_r968624423 by linearizing invocation of `ledger.LookupKeysByPrefix`.