### PR TITLE
spec asm: Add race unit test

### DIFF
--- a/agreement/player.go
+++ b/agreement/player.go
@@ -56,8 +56,8 @@ type player struct {
 	// must be verified after some vote has been verified.
 	Pending proposalTable
 
-	// the current concensus version
-	ConcensusVersion protocol.ConsensusVersion
+	// the current consensus version
+	ConsensusVersion protocol.ConsensusVersion
 
 	// the time offset before the filter deadline to start speculative block assembly
 	SpeculativeAsmTimeDuration time.Duration
@@ -365,7 +365,7 @@ func (p *player) enterPeriod(r routerHandle, source thresholdEvent, target perio
 	p.FastRecoveryDeadline = 0 // set immediately
 	p.Deadline = FilterTimeout(target, source.Proto)
 	if target == 0 {
-		p.SpeculativeAssemblyDeadline = SpeculativeBlockAsmTime(target, p.ConcensusVersion, p.SpeculativeAsmTimeDuration)
+		p.SpeculativeAssemblyDeadline = SpeculativeBlockAsmTime(target, p.ConsensusVersion, p.SpeculativeAsmTimeDuration)
 	} else {
 		// only speculate on block assembly in period 0
 		p.SpeculativeAssemblyDeadline = 0
@@ -414,7 +414,7 @@ func (p *player) enterRound(r routerHandle, source event, target round) []action
 	p.Step = soft
 	p.Napping = false
 	p.FastRecoveryDeadline = 0 // set immediately
-	p.SpeculativeAssemblyDeadline = SpeculativeBlockAsmTime(0, p.ConcensusVersion, p.SpeculativeAsmTimeDuration)
+	p.SpeculativeAssemblyDeadline = SpeculativeBlockAsmTime(0, p.ConsensusVersion, p.SpeculativeAsmTimeDuration)
 
 	switch source := source.(type) {
 	case roundInterruptionEvent:

--- a/agreement/service.go
+++ b/agreement/service.go
@@ -224,9 +224,9 @@ func (s *Service) mainLoop(input <-chan externalEvent, output chan<- []action, r
 	// set speculative block assembly based on the current local configuration
 	status.SpeculativeAsmTimeDuration = s.parameters.Local.ProposalAssemblyTime + s.parameters.Local.SpeculativeBlockAssemblyGraceTime
 	for {
-		status.ConcensusVersion, err = s.Ledger.ConsensusVersion(status.Round)
+		status.ConsensusVersion, err = s.Ledger.ConsensusVersion(status.Round)
 		if err != nil {
-			s.Panicf("cannot read latest concensus version, round %d: %v", status.Round, err)
+			s.Panicf("cannot read latest consensus version, round %d: %v", status.Round, err)
 		}
 
 		output <- a

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -1095,7 +1095,7 @@ func testLedgerSingleTxApplyData(t *testing.T, version protocol.ConsensusVersion
 		VoteLast:        10000,
 	}
 
-	// depends on what the concensus is need to generate correct KeyregTxnFields.
+	// depends on what the consensus is need to generate correct KeyregTxnFields.
 	if proto.EnableStateProofKeyregCheck {
 		frst, lst := uint64(correctKeyregFields.VoteFirst), uint64(correctKeyregFields.VoteLast)
 		store, err := db.MakeAccessor("test-DB", false, true)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Add a unit testing that speculative assembly does not cause race conditions by running speculative assembly in parallel with adding new txns to the pool.
Also fixed some typos.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

This is a test

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
