### PR TITLE
tools: remove algorand replacement from nodecfg

### DIFF
--- a/netdeploy/remote/nodecfg/nodeDir.go
+++ b/netdeploy/remote/nodecfg/nodeDir.go
@@ -308,9 +308,5 @@ func (nd *nodeDir) configureDNSBootstrap() (err error) {
 		return
 	}
 
-	if nd.config.DNSBootstrapID == config.GetDefaultLocal().DNSBootstrapID {
-		nd.config.DNSBootstrapID = strings.Replace(nd.config.DNSBootstrapID, "algorand", "algodev", -1)
-		err = nd.saveConfig()
-	}
 	return
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

this removes a replacement that's apart of `nodecfg`. if the `DNSBootstrapID` of the config contains `algorand` then it's replaced with `algodev`. this means that if you try to use it to spin up a node for testnet or mainnet, they will never be properly configured. 

should this be that restrictive? 

I was trying to spin up a `testnet` network with algonet and the nodes would always be configured with `algodev.network` and were unable to advance. 

## Test Plan

- I've been testing with the loadgenerator pipeline. 
