### PR TITLE
tests: fix method name after typo correction

### DIFF
--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -136,7 +136,7 @@ func (vtCache) Add(txgroup []transactions.SignedTxn, groupCtx *verify.GroupConte
 func (vtCache) AddPayset(txgroup [][]transactions.SignedTxn, groupCtxs []*verify.GroupContext) error {
 	return nil
 }
-func (vtCache) GetUnverifiedTranscationGroups(payset [][]transactions.SignedTxn, CurrSpecAddrs transactions.SpecialAddresses, CurrProto protocol.ConsensusVersion) [][]transactions.SignedTxn {
+func (vtCache) GetUnverifiedTransactionGroups(payset [][]transactions.SignedTxn, CurrSpecAddrs transactions.SpecialAddresses, CurrProto protocol.ConsensusVersion) [][]transactions.SignedTxn {
 	return nil
 }
 func (vtCache) UpdatePinned(pinnedTxns map[transactions.Txid]transactions.SignedTxn) error {


### PR DESCRIPTION
## Summary

Fix method name after #4248


