### PR TITLE
telemetry: add StartupEventDetails.Overrides

### DIFF
--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -327,13 +327,17 @@ func run() int {
 		}
 
 		currentVersion := config.GetCurrentVersion()
+		var overrides []telemetryspec.NameValue
+		for name, val := range config.GetNonDefaultConfigValues(cfg, startupConfigCheckFields) {
+			overrides = append(overrides, telemetryspec.NameValue{Name: name, Value: val})
+		}
 		startupDetails := telemetryspec.StartupEventDetails{
 			Version:      currentVersion.String(),
 			CommitHash:   currentVersion.CommitHash,
 			Branch:       currentVersion.Branch,
 			Channel:      currentVersion.Channel,
 			InstanceHash: crypto.Hash([]byte(absolutePath)).String(),
-			Overrides:    config.GetNonDefaultConfigValues(cfg, startupConfigCheckFields),
+			Overrides:    overrides,
 		}
 
 		log.EventWithDetails(telemetryspec.ApplicationState, telemetryspec.StartupEvent, startupDetails)

--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -333,6 +333,7 @@ func run() int {
 			Branch:       currentVersion.Branch,
 			Channel:      currentVersion.Channel,
 			InstanceHash: crypto.Hash([]byte(absolutePath)).String(),
+			Overrides:    config.GetNonDefaultConfigValues(cfg, startupConfigCheckFields),
 		}
 
 		log.EventWithDetails(telemetryspec.ApplicationState, telemetryspec.StartupEvent, startupDetails)
@@ -367,6 +368,30 @@ func run() int {
 
 	s.Start()
 	return 0
+}
+
+var startupConfigCheckFields = []string{
+	"AgreementIncomingBundlesQueueLength",
+	"AgreementIncomingProposalsQueueLength",
+	"AgreementIncomingVotesQueueLength",
+	"BroadcastConnectionsLimit",
+	"CatchupBlockValidateMode",
+	"ConnectionsRateLimitingCount",
+	"ConnectionsRateLimitingWindowSeconds",
+	"GossipFanout",
+	"IncomingConnectionsLimit",
+	"IncomingMessageFilterBucketCount",
+	"IncomingMessageFilterBucketSize",
+	"LedgerSynchronousMode",
+	"MaxAcctLookback",
+	"MaxConnectionsPerIP",
+	"OutgoingMessageFilterBucketCount",
+	"OutgoingMessageFilterBucketSize",
+	"ProposalAssemblyTime",
+	"ReservedFDs",
+	"TxPoolExponentialIncreaseFactor",
+	"TxPoolSize",
+	"VerifiedTranscationsCacheSize",
 }
 
 func resolveDataDir() string {

--- a/config/migrate.go
+++ b/config/migrate.go
@@ -198,3 +198,25 @@ func getVersionedDefaultLocalConfig(version uint32) (local Local) {
 	}
 	return
 }
+
+// GetNonDefaultConfigValues takes a provided cfg and list of field names, and returns a map of all values in cfg
+// that are not set to the default for the latest version.
+func GetNonDefaultConfigValues(cfg Local, fieldNames []string) map[string]interface{} {
+	defCfg := GetDefaultLocal()
+	ret := make(map[string]interface{})
+
+	for _, fieldName := range fieldNames {
+		defField := reflect.ValueOf(defCfg).FieldByName(fieldName)
+		if !defField.IsValid() {
+			continue
+		}
+		cfgField := reflect.ValueOf(cfg).FieldByName(fieldName)
+		if !cfgField.IsValid() {
+			continue
+		}
+		if !reflect.DeepEqual(defField.Interface(), cfgField.Interface()) {
+			ret[fieldName] = cfgField.Interface()
+		}
+	}
+	return ret
+}

--- a/logging/telemetryspec/event.go
+++ b/logging/telemetryspec/event.go
@@ -36,6 +36,7 @@ type StartupEventDetails struct {
 	Branch       string
 	Channel      string
 	InstanceHash string
+	Overrides    map[string]interface{}
 }
 
 // HeartbeatEvent is sent periodically to indicate node is running

--- a/logging/telemetryspec/event.go
+++ b/logging/telemetryspec/event.go
@@ -29,6 +29,12 @@ type Event string
 // StartupEvent event
 const StartupEvent Event = "Startup"
 
+// NameValue defines a named value, for use in an array reported to telemetry.
+type NameValue struct {
+	Name  string
+	Value interface{}
+}
+
 // StartupEventDetails contains details for the StartupEvent
 type StartupEventDetails struct {
 	Version      string
@@ -36,7 +42,7 @@ type StartupEventDetails struct {
 	Branch       string
 	Channel      string
 	InstanceHash string
-	Overrides    map[string]interface{}
+	Overrides    []NameValue
 }
 
 // HeartbeatEvent is sent periodically to indicate node is running


### PR DESCRIPTION
## Summary

For nodes with telemetry enabled, this adds some additional information at startup time about performance-sensitive configuration defaults that have been overridden.

## Test Plan

Added unit test.