### PR TITLE
catchup: increase HTTPFetcher fetcherMaxBlockBytes for larger block size

### DIFF
--- a/catchup/universalFetcher.go
+++ b/catchup/universalFetcher.go
@@ -187,8 +187,8 @@ func (w *wsFetcherClient) requestBlock(ctx context.Context, round basics.Round) 
 	return blockCertBytes, nil
 }
 
-// set max fetcher size to 5MB, this is enough to fit the block and certificate
-const fetcherMaxBlockBytes = 5 << 20
+// set max fetcher size to 10MB, this is enough to fit the block and certificate
+const fetcherMaxBlockBytes = 10 << 20
 
 var errNoBlockForRound = errors.New("No block available for given round")
 


### PR DESCRIPTION
## Summary

When we grew the block size we did not adjust `fetcherMaxBlockBytes` to match, and it looks like we are running into this given errors like: `response too large: 5265295 > 5242880`.

## Test Plan

Existing tests should pass.
