### PR TITLE
State Proof Recoverability: state proof verification tracking

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -5041,7 +5041,7 @@ func deleteUnfinishedCatchpoint(ctx context.Context, e db.Executable, round basi
 	return db.Retry(f)
 }
 
-func insertStateProofVerificationData(ctx context.Context, tx *sql.Tx, data *[]verificationCommitData) error {
+func insertStateProofVerificationData(ctx context.Context, tx *sql.Tx, data []verificationCommitData) error {
 	insertStmt, err := tx.PrepareContext(ctx, "INSERT INTO stateproofverification(targetstateproofround, verificationdata) VALUES(?, ?)")
 
 	if err != nil {
@@ -5050,7 +5050,7 @@ func insertStateProofVerificationData(ctx context.Context, tx *sql.Tx, data *[]v
 
 	defer insertStmt.Close()
 
-	for _, commitData := range *data {
+	for _, commitData := range data {
 		verificationData := commitData.verificationData
 		f := func() error {
 			_, err = insertStmt.ExecContext(ctx, verificationData.TargetStateProofRound, protocol.Encode(&verificationData))

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -5061,9 +5061,9 @@ func insertStateProofVerificationData(ctx context.Context, tx *sql.Tx, data *[]l
 	return nil
 }
 
-func deleteOldStateProofVerificationData(ctx context.Context, tx *sql.Tx, targetRound basics.Round) error {
+func deleteOldStateProofVerificationData(ctx context.Context, tx *sql.Tx, stateProofNextRound basics.Round) error {
 	f := func() error {
-		_, err := tx.ExecContext(ctx, "DELETE FROM stateproofverification WHERE targetstateproofround <= ?", targetRound)
+		_, err := tx.ExecContext(ctx, "DELETE FROM stateproofverification WHERE targetstateproofround < ?", stateProofNextRound)
 		return err
 	}
 	return db.Retry(f)

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -5061,7 +5061,7 @@ func insertStateProofVerificationData(ctx context.Context, tx *sql.Tx, data *[]l
 	return nil
 }
 
-func pruneOldStateProofVerificationData(ctx context.Context, tx *sql.Tx, targetRound basics.Round) error {
+func deleteOldStateProofVerificationData(ctx context.Context, tx *sql.Tx, targetRound basics.Round) error {
 	f := func() error {
 		_, err := tx.ExecContext(ctx, "DELETE FROM stateproofverification WHERE targetstateproofround <= ?", targetRound)
 		return err

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -5063,7 +5063,7 @@ func insertStateProofVerificationData(ctx context.Context, tx *sql.Tx, data *[]l
 
 func pruneOldStateProofVerificationData(ctx context.Context, tx *sql.Tx, targetRound basics.Round) error {
 	f := func() error {
-		_, err := tx.ExecContext(ctx, "DELETE FROM stateproofverification WHERE round <= ?", targetRound)
+		_, err := tx.ExecContext(ctx, "DELETE FROM stateproofverification WHERE targetstateproofround <= ?", targetRound)
 		return err
 	}
 	return db.Retry(f)

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -168,7 +168,7 @@ const createUnfinishedCatchpointsTable = `
 	round integer primary key NOT NULL,
 	blockhash blob NOT NULL)`
 
-const createStateProofVerificationTable = `
+const createStateProofVerificationTableQuery = `
 	CREATE TABLE IF NOT EXISTS stateproofverification (
 	targetstateproofround integer primary key NOT NULL,
 	verificationdata blob NOT NULL)`
@@ -1376,8 +1376,8 @@ func accountsCreateCatchpointFirstStageInfoTable(ctx context.Context, e db.Execu
 	return err
 }
 
-func accountsCreateStateProofVerificationTable(ctx context.Context, e db.Executable) error {
-	_, err := e.ExecContext(ctx, createStateProofVerificationTable)
+func createStateProofVerificationTable(ctx context.Context, e db.Executable) error {
+	_, err := e.ExecContext(ctx, createStateProofVerificationTableQuery)
 	return err
 }
 

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -5041,7 +5041,7 @@ func deleteUnfinishedCatchpoint(ctx context.Context, e db.Executable, round basi
 	return db.Retry(f)
 }
 
-func insertStateProofVerificationData(ctx context.Context, tx *sql.Tx, data *[]ledgercore.StateProofVerificationData) error {
+func insertStateProofVerificationData(ctx context.Context, tx *sql.Tx, data *[]verificationCommitData) error {
 	insertStmt, err := tx.PrepareContext(ctx, "INSERT INTO stateproofverification(targetstateproofround, verificationdata) VALUES(?, ?)")
 
 	if err != nil {
@@ -5051,7 +5051,8 @@ func insertStateProofVerificationData(ctx context.Context, tx *sql.Tx, data *[]l
 	defer insertStmt.Close()
 
 	// TODO: wrap with db retry?
-	for _, verificationData := range *data {
+	for _, commitData := range *data {
+		verificationData := commitData.verificationData
 		_, err := insertStmt.ExecContext(ctx, verificationData.TargetStateProofRound, protocol.Encode(&verificationData))
 		if err != nil {
 			return err

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -5070,9 +5070,9 @@ func insertStateProofVerificationData(ctx context.Context, tx *sql.Tx, data []ve
 	return nil
 }
 
-func deleteOldStateProofVerificationData(ctx context.Context, tx *sql.Tx, stateProofNextRound basics.Round) error {
+func deleteOldStateProofVerificationData(ctx context.Context, tx *sql.Tx, earliestTrackStateProofRound basics.Round) error {
 	f := func() error {
-		_, err := tx.ExecContext(ctx, "DELETE FROM stateproofverification WHERE targetstateproofround < ?", stateProofNextRound)
+		_, err := tx.ExecContext(ctx, "DELETE FROM stateproofverification WHERE targetstateproofround < ?", earliestTrackStateProofRound)
 		return err
 	}
 	return db.Retry(f)

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -5042,6 +5042,10 @@ func deleteUnfinishedCatchpoint(ctx context.Context, e db.Executable, round basi
 }
 
 func insertStateProofVerificationData(ctx context.Context, tx *sql.Tx, data []verificationCommitData) error {
+	if len(data) == 0 {
+		return nil
+	}
+
 	insertStmt, err := tx.PrepareContext(ctx, "INSERT INTO stateproofverification(targetstateproofround, verificationdata) VALUES(?, ?)")
 
 	if err != nil {

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -454,11 +454,12 @@ func (l *Ledger) VotersForStateProof(rnd basics.Round) (*ledgercore.VotersForRou
 	return l.acctsOnline.voters.getVoters(rnd)
 }
 
-// StateProofVerificationData returns the data required to verify state proofs
-func (l *Ledger) StateProofVerificationData(rnd basics.Round) (*ledgercore.StateProofVerificationData, error) {
-	// TODO: input check
-	// TODO: locks
-	return l.stateProofVerification.LookupVerificationData(rnd)
+// StateProofVerificationData returns the data required to verify the state proof whose last attested round is
+// stateProofLastAttestedRound.
+func (l *Ledger) StateProofVerificationData(stateProofLastAttestedRound basics.Round) (*ledgercore.StateProofVerificationData, error) {
+	l.trackerMu.RLock()
+	defer l.trackerMu.RUnlock()
+	return l.stateProofVerification.LookupVerificationData(stateProofLastAttestedRound)
 }
 
 // ListAssets takes a maximum asset index and maximum result length, and

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -454,6 +454,13 @@ func (l *Ledger) VotersForStateProof(rnd basics.Round) (*ledgercore.VotersForRou
 	return l.acctsOnline.voters.getVoters(rnd)
 }
 
+// StateProofVerificationData returns the data required to verify state proofs
+func (l *Ledger) StateProofVerificationData(rnd basics.Round) (*ledgercore.StateProofVerificationData, error) {
+	// TODO: input check
+	// TODO: locks
+	return l.stateProofVerification.LookupVerificationData(rnd)
+}
+
 // ListAssets takes a maximum asset index and maximum result length, and
 // returns up to that many CreatableLocators from the database where app idx is
 // less than or equal to the maximum.

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -3029,7 +3029,7 @@ func verifyStateProofTrackingLedger(t *testing.T, l *Ledger, startRound basics.R
 		if dataPresenceExpected {
 			a.NoError(err)
 		} else {
-			a.True(errors.Is(err, sql.ErrNoRows) || errors.Is(err, errStateProofVerificationDataNotFoundInMemory))
+			a.True(errors.Is(err, sql.ErrNoRows) || errors.Is(err, errStateProofVerificationDataNotFound))
 		}
 	}
 }
@@ -3051,33 +3051,57 @@ func TestStateProofVerificationTracker(t *testing.T) {
 	defer l.Close()
 
 	numOfStateProofs := uint64(3)
-	firstStateProofDataRound := proto.StateProofInterval * 2
-	lastStateProofDataRound := firstStateProofDataRound + proto.StateProofInterval*(numOfStateProofs-1)
+	firstStateProofDataConfirmedRound := proto.StateProofInterval
+	firstStateProofDataTargetRound := firstStateProofDataConfirmedRound + proto.StateProofInterval
+
+	lastStateProofDataConfirmedRound := firstStateProofDataConfirmedRound + proto.StateProofInterval*(numOfStateProofs-1)
+	lastStateProofDataTargetRound := lastStateProofDataConfirmedRound + proto.StateProofInterval
 
 	blk := genesisInitState.Block
 	var sp bookkeeping.StateProofTrackingData
-	sp.StateProofNextRound = basics.Round(firstStateProofDataRound)
+	sp.StateProofNextRound = basics.Round(firstStateProofDataTargetRound)
 	blk.BlockHeader.StateProofTracking = map[protocol.StateProofType]bookkeeping.StateProofTrackingData{
 		protocol.StateProofBasic: sp,
 	}
 
-	for i := uint64(0); i < lastStateProofDataRound; i++ {
+	for i := uint64(0); i < firstStateProofDataConfirmedRound-1; i++ {
 		blk.BlockHeader.Round++
 		blk.BlockHeader.TimeStamp += 10
 		err = l.AddBlock(blk, agreement.Certificate{})
 		require.NoError(t, err)
 	}
 
-	verifyStateProofTrackingLedger(t, l, basics.Round(firstStateProofDataRound),
-		numOfStateProofs, proto.StateProofInterval, true)
+	verifyStateProofVerificationTracking(t, &l.stateProofVerification, basics.Round(firstStateProofDataTargetRound),
+		1, proto.StateProofInterval, false, any)
+
+	blk.BlockHeader.Round++
+	blk.BlockHeader.TimeStamp += 10
+	err = l.AddBlock(blk, agreement.Certificate{})
+	require.NoError(t, err)
+
+	verifyStateProofVerificationTracking(t, &l.stateProofVerification, basics.Round(firstStateProofDataTargetRound),
+		1, proto.StateProofInterval, true, trackerMemory)
+
+	for i := firstStateProofDataConfirmedRound; i < lastStateProofDataConfirmedRound; i++ {
+		blk.BlockHeader.Round++
+		blk.BlockHeader.TimeStamp += 10
+		err = l.AddBlock(blk, agreement.Certificate{})
+		require.NoError(t, err)
+	}
+
+	verifyStateProofVerificationTracking(t, &l.stateProofVerification, basics.Round(firstStateProofDataTargetRound),
+		numOfStateProofs-1, proto.StateProofInterval, true, trackerDB)
+	// Last one should be in memory as a result of cfg.MaxAcctLookback not being equal to 0.
+	verifyStateProofVerificationTracking(t, &l.stateProofVerification, basics.Round(lastStateProofDataTargetRound),
+		1, proto.StateProofInterval, true, trackerMemory)
 
 	l.WaitForCommit(blk.BlockHeader.Round)
 
-	verifyStateProofTrackingLedger(t, l, basics.Round(firstStateProofDataRound),
+	verifyStateProofTrackingLedger(t, l, basics.Round(firstStateProofDataTargetRound),
 		numOfStateProofs, proto.StateProofInterval, true)
 
 	var stateProofReceived bookkeeping.StateProofTrackingData
-	stateProofReceived.StateProofNextRound = basics.Round(firstStateProofDataRound + proto.StateProofInterval)
+	stateProofReceived.StateProofNextRound = basics.Round(firstStateProofDataTargetRound + proto.StateProofInterval)
 	blk.BlockHeader.StateProofTracking = map[protocol.StateProofType]bookkeeping.StateProofTrackingData{
 		protocol.StateProofBasic: stateProofReceived,
 	}
@@ -3102,8 +3126,8 @@ func TestStateProofVerificationTracker(t *testing.T) {
 
 	l.WaitForCommit(blk.BlockHeader.Round)
 
-	verifyStateProofTrackingLedger(t, l, basics.Round(firstStateProofDataRound),
+	verifyStateProofTrackingLedger(t, l, basics.Round(firstStateProofDataTargetRound),
 		1, proto.StateProofInterval, false)
-	verifyStateProofTrackingLedger(t, l, basics.Round(firstStateProofDataRound+proto.StateProofInterval),
+	verifyStateProofTrackingLedger(t, l, basics.Round(firstStateProofDataTargetRound+proto.StateProofInterval),
 		numOfStateProofs-1, proto.StateProofInterval, true)
 }

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -2253,7 +2253,7 @@ func TestLedgerReloadTxTailHistoryAccess(t *testing.T) {
 		if err0 := accountsCreateCatchpointFirstStageInfoTable(ctx, tx); err0 != nil {
 			return err0
 		}
-		if err0 := accountsCreateStateProofVerificationTable(ctx, tx); err0 != nil {
+		if err0 := createStateProofVerificationTable(ctx, tx); err0 != nil {
 			return err0
 		}
 
@@ -2426,7 +2426,7 @@ func TestLedgerMigrateV6ShrinkDeltas(t *testing.T) {
 		if err := accountsCreateCatchpointFirstStageInfoTable(ctx, tx); err != nil {
 			return err
 		}
-		if err := accountsCreateStateProofVerificationTable(ctx, tx); err != nil {
+		if err := createStateProofVerificationTable(ctx, tx); err != nil {
 			return err
 		}
 		return nil

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -2252,6 +2252,9 @@ func TestLedgerReloadTxTailHistoryAccess(t *testing.T) {
 		if err0 := accountsCreateCatchpointFirstStageInfoTable(ctx, tx); err0 != nil {
 			return err0
 		}
+		if err0 := accountsCreateStateProofVerificationTable(ctx, tx); err0 != nil {
+			return err0
+		}
 
 		return nil
 	})

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -3029,7 +3029,7 @@ func verifyStateProofTrackingLedger(t *testing.T, l *Ledger, startRound basics.R
 		if dataPresenceExpected {
 			a.NoError(err)
 		} else {
-			a.True(errors.Is(err, sql.ErrNoRows) || errors.Is(err, errStateProofVerificationDataNotFound))
+			a.True(errors.Is(err, sql.ErrNoRows) || errors.Is(err, errStateProofVerificationDataNotFoundInMemory))
 		}
 	}
 }

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -3088,7 +3088,6 @@ func TestStateProofVerificationTracker(t *testing.T) {
 	// to the ledger.
 	delta, err := internal.Eval(context.Background(), l, blk, false, l.verifiedTxnCache, nil)
 	delta.StateProofNext = stateProofReceived.StateProofNextRound
-	delta.OptimizeAllocatedMemory(l.cfg.MaxAcctLookback)
 	vb := ledgercore.MakeValidatedBlock(blk, delta)
 	err = l.AddValidatedBlock(vb, agreement.Certificate{})
 

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -2382,9 +2382,11 @@ int %d // 10001000
 func TestLedgerMigrateV6ShrinkDeltas(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
+	defaultAccountDBVersion := accountDBVersion
 	accountDBVersion = 6
+
 	defer func() {
-		accountDBVersion = 7
+		accountDBVersion = defaultAccountDBVersion
 	}()
 	dbName := fmt.Sprintf("%s.%d", t.Name(), crypto.RandUint64())
 	testProtocolVersion := protocol.ConsensusVersion("test-protocol-migrate-shrink-deltas")
@@ -2418,6 +2420,9 @@ func TestLedgerMigrateV6ShrinkDeltas(t *testing.T) {
 			return err
 		}
 		if err := accountsCreateCatchpointFirstStageInfoTable(ctx, tx); err != nil {
+			return err
+		}
+		if err := accountsCreateStateProofVerificationTable(ctx, tx); err != nil {
 			return err
 		}
 		return nil

--- a/ledger/ledgercore/msgp_gen.go
+++ b/ledger/ledgercore/msgp_gen.go
@@ -952,7 +952,7 @@ func (z *StateProofVerificationData) MarshalMsg(b []byte) (o []byte) {
 	// omitempty: check for empty values
 	zb0001Len := uint32(3)
 	var zb0001Mask uint8 /* 4 bits */
-	if (*z).ProvenWeight.MsgIsZero() {
+	if (*z).OnlineTotalWeight.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x2
 	}
@@ -970,7 +970,7 @@ func (z *StateProofVerificationData) MarshalMsg(b []byte) (o []byte) {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
 			// string "pw"
 			o = append(o, 0xa2, 0x70, 0x77)
-			o = (*z).ProvenWeight.MarshalMsg(o)
+			o = (*z).OnlineTotalWeight.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "spround"
@@ -1022,9 +1022,9 @@ func (z *StateProofVerificationData) UnmarshalMsg(bts []byte) (o []byte, err err
 		}
 		if zb0001 > 0 {
 			zb0001--
-			bts, err = (*z).ProvenWeight.UnmarshalMsg(bts)
+			bts, err = (*z).OnlineTotalWeight.UnmarshalMsg(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "ProvenWeight")
+				err = msgp.WrapError(err, "struct-from-array", "OnlineTotalWeight")
 				return
 			}
 		}
@@ -1064,9 +1064,9 @@ func (z *StateProofVerificationData) UnmarshalMsg(bts []byte) (o []byte, err err
 					return
 				}
 			case "pw":
-				bts, err = (*z).ProvenWeight.UnmarshalMsg(bts)
+				bts, err = (*z).OnlineTotalWeight.UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "ProvenWeight")
+					err = msgp.WrapError(err, "OnlineTotalWeight")
 					return
 				}
 			default:
@@ -1089,11 +1089,11 @@ func (_ *StateProofVerificationData) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *StateProofVerificationData) Msgsize() (s int) {
-	s = 1 + 8 + (*z).TargetStateProofRound.Msgsize() + 3 + (*z).VotersCommitment.Msgsize() + 3 + (*z).ProvenWeight.Msgsize()
+	s = 1 + 8 + (*z).TargetStateProofRound.Msgsize() + 3 + (*z).VotersCommitment.Msgsize() + 3 + (*z).OnlineTotalWeight.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *StateProofVerificationData) MsgIsZero() bool {
-	return ((*z).TargetStateProofRound.MsgIsZero()) && ((*z).VotersCommitment.MsgIsZero()) && ((*z).ProvenWeight.MsgIsZero())
+	return ((*z).TargetStateProofRound.MsgIsZero()) && ((*z).VotersCommitment.MsgIsZero()) && ((*z).OnlineTotalWeight.MsgIsZero())
 }

--- a/ledger/ledgercore/msgp_gen.go
+++ b/ledger/ledgercore/msgp_gen.go
@@ -950,43 +950,34 @@ func (z *OnlineRoundParamsData) MsgIsZero() bool {
 func (z *StateProofVerificationData) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0001Len := uint32(4)
-	var zb0001Mask uint8 /* 5 bits */
-	if (*z).GeneratedRound.MsgIsZero() {
+	zb0001Len := uint32(3)
+	var zb0001Mask uint8 /* 4 bits */
+	if (*z).ProvenWeight.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x2
 	}
-	if (*z).ProvenWeight.MsgIsZero() {
+	if (*z).TargetStateProofRound.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if (*z).TargetStateProofRound.MsgIsZero() {
-		zb0001Len--
-		zb0001Mask |= 0x8
-	}
 	if (*z).VotersCommitment.MsgIsZero() {
 		zb0001Len--
-		zb0001Mask |= 0x10
+		zb0001Mask |= 0x8
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
 	if zb0001Len != 0 {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
-			// string "genround"
-			o = append(o, 0xa8, 0x67, 0x65, 0x6e, 0x72, 0x6f, 0x75, 0x6e, 0x64)
-			o = (*z).GeneratedRound.MarshalMsg(o)
-		}
-		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "pw"
 			o = append(o, 0xa2, 0x70, 0x77)
 			o = (*z).ProvenWeight.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x8) == 0 { // if not empty
+		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "spround"
 			o = append(o, 0xa7, 0x73, 0x70, 0x72, 0x6f, 0x75, 0x6e, 0x64)
 			o = (*z).TargetStateProofRound.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x10) == 0 { // if not empty
+		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "vc"
 			o = append(o, 0xa2, 0x76, 0x63)
 			o = (*z).VotersCommitment.MarshalMsg(o)
@@ -1012,14 +1003,6 @@ func (z *StateProofVerificationData) UnmarshalMsg(bts []byte) (o []byte, err err
 		if err != nil {
 			err = msgp.WrapError(err)
 			return
-		}
-		if zb0001 > 0 {
-			zb0001--
-			bts, err = (*z).GeneratedRound.UnmarshalMsg(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "GeneratedRound")
-				return
-			}
 		}
 		if zb0001 > 0 {
 			zb0001--
@@ -1068,12 +1051,6 @@ func (z *StateProofVerificationData) UnmarshalMsg(bts []byte) (o []byte, err err
 				return
 			}
 			switch string(field) {
-			case "genround":
-				bts, err = (*z).GeneratedRound.UnmarshalMsg(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "GeneratedRound")
-					return
-				}
 			case "spround":
 				bts, err = (*z).TargetStateProofRound.UnmarshalMsg(bts)
 				if err != nil {
@@ -1112,11 +1089,11 @@ func (_ *StateProofVerificationData) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *StateProofVerificationData) Msgsize() (s int) {
-	s = 1 + 9 + (*z).GeneratedRound.Msgsize() + 8 + (*z).TargetStateProofRound.Msgsize() + 3 + (*z).VotersCommitment.Msgsize() + 3 + (*z).ProvenWeight.Msgsize()
+	s = 1 + 8 + (*z).TargetStateProofRound.Msgsize() + 3 + (*z).VotersCommitment.Msgsize() + 3 + (*z).ProvenWeight.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *StateProofVerificationData) MsgIsZero() bool {
-	return ((*z).GeneratedRound.MsgIsZero()) && ((*z).TargetStateProofRound.MsgIsZero()) && ((*z).VotersCommitment.MsgIsZero()) && ((*z).ProvenWeight.MsgIsZero())
+	return ((*z).TargetStateProofRound.MsgIsZero()) && ((*z).VotersCommitment.MsgIsZero()) && ((*z).ProvenWeight.MsgIsZero())
 }

--- a/ledger/ledgercore/msgp_gen.go
+++ b/ledger/ledgercore/msgp_gen.go
@@ -950,34 +950,43 @@ func (z *OnlineRoundParamsData) MsgIsZero() bool {
 func (z *StateProofVerificationData) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0001Len := uint32(3)
-	var zb0001Mask uint8 /* 4 bits */
-	if (*z).ProvenWeight.MsgIsZero() {
+	zb0001Len := uint32(4)
+	var zb0001Mask uint8 /* 5 bits */
+	if (*z).GeneratedRound.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x2
 	}
-	if (*z).TargetStateProofRound.MsgIsZero() {
+	if (*z).ProvenWeight.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if (*z).VotersCommitment.MsgIsZero() {
+	if (*z).TargetStateProofRound.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x8
+	}
+	if (*z).VotersCommitment.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x10
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
 	if zb0001Len != 0 {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
+			// string "genround"
+			o = append(o, 0xa8, 0x67, 0x65, 0x6e, 0x72, 0x6f, 0x75, 0x6e, 0x64)
+			o = (*z).GeneratedRound.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not empty
 			// string "pw"
 			o = append(o, 0xa2, 0x70, 0x77)
 			o = (*z).ProvenWeight.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x4) == 0 { // if not empty
+		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "spround"
 			o = append(o, 0xa7, 0x73, 0x70, 0x72, 0x6f, 0x75, 0x6e, 0x64)
 			o = (*z).TargetStateProofRound.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x8) == 0 { // if not empty
+		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "vc"
 			o = append(o, 0xa2, 0x76, 0x63)
 			o = (*z).VotersCommitment.MarshalMsg(o)
@@ -1003,6 +1012,14 @@ func (z *StateProofVerificationData) UnmarshalMsg(bts []byte) (o []byte, err err
 		if err != nil {
 			err = msgp.WrapError(err)
 			return
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).GeneratedRound.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "GeneratedRound")
+				return
+			}
 		}
 		if zb0001 > 0 {
 			zb0001--
@@ -1051,6 +1068,12 @@ func (z *StateProofVerificationData) UnmarshalMsg(bts []byte) (o []byte, err err
 				return
 			}
 			switch string(field) {
+			case "genround":
+				bts, err = (*z).GeneratedRound.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "GeneratedRound")
+					return
+				}
 			case "spround":
 				bts, err = (*z).TargetStateProofRound.UnmarshalMsg(bts)
 				if err != nil {
@@ -1089,11 +1112,11 @@ func (_ *StateProofVerificationData) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *StateProofVerificationData) Msgsize() (s int) {
-	s = 1 + 8 + (*z).TargetStateProofRound.Msgsize() + 3 + (*z).VotersCommitment.Msgsize() + 3 + (*z).ProvenWeight.Msgsize()
+	s = 1 + 9 + (*z).GeneratedRound.Msgsize() + 8 + (*z).TargetStateProofRound.Msgsize() + 3 + (*z).VotersCommitment.Msgsize() + 3 + (*z).ProvenWeight.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *StateProofVerificationData) MsgIsZero() bool {
-	return ((*z).TargetStateProofRound.MsgIsZero()) && ((*z).VotersCommitment.MsgIsZero()) && ((*z).ProvenWeight.MsgIsZero())
+	return ((*z).GeneratedRound.MsgIsZero()) && ((*z).TargetStateProofRound.MsgIsZero()) && ((*z).VotersCommitment.MsgIsZero()) && ((*z).ProvenWeight.MsgIsZero())
 }

--- a/ledger/ledgercore/stateproofverification.go
+++ b/ledger/ledgercore/stateproofverification.go
@@ -22,7 +22,7 @@ import (
 )
 
 // TODO: test?
-// TODO: might be able to get rid of GeneratedRound using proto
+// TODO: GeneratedRound doesn't have to be saved in the DB
 
 type StateProofVerificationData struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`

--- a/ledger/ledgercore/stateproofverification.go
+++ b/ledger/ledgercore/stateproofverification.go
@@ -25,7 +25,12 @@ import (
 type StateProofVerificationData struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	TargetStateProofRound basics.Round         `codec:"spround"`
-	VotersCommitment      crypto.GenericDigest `codec:"vc"`
-	ProvenWeight          basics.MicroAlgos    `codec:"pw"`
+	// TargetStateProofRound is the last attested round of the state proof verified using this data.
+	TargetStateProofRound basics.Round `codec:"spround"`
+
+	// VotersCommitment is the vector commitment root of the top N accounts to sign the next state proof.
+	VotersCommitment crypto.GenericDigest `codec:"vc"`
+
+	// ProvenWeight is the total amount of stake attesting to the next state proof.
+	ProvenWeight basics.MicroAlgos `codec:"pw"`
 }

--- a/ledger/ledgercore/stateproofverification.go
+++ b/ledger/ledgercore/stateproofverification.go
@@ -21,13 +21,9 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 )
 
-// TODO: test?
-// TODO: GeneratedRound doesn't have to be saved in the DB
-
 type StateProofVerificationData struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	GeneratedRound        basics.Round         `codec:"genround"`
 	TargetStateProofRound basics.Round         `codec:"spround"`
 	VotersCommitment      crypto.GenericDigest `codec:"vc"`
 	ProvenWeight          basics.MicroAlgos    `codec:"pw"`

--- a/ledger/ledgercore/stateproofverification.go
+++ b/ledger/ledgercore/stateproofverification.go
@@ -21,6 +21,7 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 )
 
+// StateProofVerificationData represents the data provided by the ledger to verify a state proof transaction.
 type StateProofVerificationData struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 

--- a/ledger/ledgercore/stateproofverification.go
+++ b/ledger/ledgercore/stateproofverification.go
@@ -22,6 +22,7 @@ import (
 )
 
 // TODO: test?
+// TODO: might be able to get rid of GeneratedRound using proto
 
 type StateProofVerificationData struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`

--- a/ledger/ledgercore/stateproofverification.go
+++ b/ledger/ledgercore/stateproofverification.go
@@ -26,6 +26,7 @@ import (
 type StateProofVerificationData struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
+	GeneratedRound        basics.Round         `codec:"genround"`
 	TargetStateProofRound basics.Round         `codec:"spround"`
 	VotersCommitment      crypto.GenericDigest `codec:"vc"`
 	ProvenWeight          basics.MicroAlgos    `codec:"pw"`

--- a/ledger/ledgercore/stateproofverification.go
+++ b/ledger/ledgercore/stateproofverification.go
@@ -31,6 +31,6 @@ type StateProofVerificationData struct {
 	// VotersCommitment is the vector commitment root of the top N accounts to sign the next state proof.
 	VotersCommitment crypto.GenericDigest `codec:"vc"`
 
-	// ProvenWeight is the total amount of stake attesting to the next state proof.
-	ProvenWeight basics.MicroAlgos `codec:"pw"`
+	// OnlineTotalWeight is the total amount of stake attesting to the next state proof.
+	OnlineTotalWeight basics.MicroAlgos `codec:"pw"`
 }

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -184,7 +184,7 @@ func (spt *stateProofVerificationTracker) LookupVerificationData(stateProofLastA
 		return spt.lookupDataInTrackedMemory(stateProofLastAttestedRound)
 	}
 
-	return &ledgercore.StateProofVerificationData{}, errStateProofVerificationDataNotYetGenerated
+	return &ledgercore.StateProofVerificationData{}, fmt.Errorf("lookup failed for round %d: %w", stateProofLastAttestedRound, errStateProofVerificationDataNotYetGenerated
 }
 
 func (spt *stateProofVerificationTracker) lookupDataInTrackedMemory(stateProofLastAttestedRound basics.Round) (*ledgercore.StateProofVerificationData, error) {

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -45,8 +45,6 @@ type verificationCommitData struct {
 	verificationData ledgercore.StateProofVerificationData
 }
 
-// TODO: Add locks where needed
-
 type stateProofVerificationTracker struct {
 	dbQueries stateProofVerificationDbQueries
 
@@ -54,6 +52,130 @@ type stateProofVerificationTracker struct {
 	trackedDeleteData []verificationDeleteData
 
 	stateProofVerificationMu deadlock.RWMutex
+}
+
+func (spt *stateProofVerificationTracker) loadFromDisk(l ledgerForTracker, _ basics.Round) error {
+	spt.stateProofVerificationMu.Lock()
+	defer spt.stateProofVerificationMu.Unlock()
+
+	preparedDbQueries, err := stateProofVerificationInitDbQueries(l.trackerDB().Rdb.Handle)
+	if err != nil {
+		return err
+	}
+
+	spt.dbQueries = *preparedDbQueries
+
+	latestRoundInLedger := l.Latest()
+	latestBlockHeader, err := l.BlockHdr(latestRoundInLedger)
+
+	if err != nil {
+		return err
+	}
+
+	proto := config.Consensus[latestBlockHeader.CurrentProtocol]
+
+	// Starting from StateProofMaxRecoveryIntervals provides the order of magnitude for expected state proof chain delay,
+	// and is thus a good size to start from.
+	spt.trackedCommitData = make([]verificationCommitData, 0, proto.StateProofMaxRecoveryIntervals)
+	spt.trackedDeleteData = make([]verificationDeleteData, 0, proto.StateProofMaxRecoveryIntervals)
+
+	return nil
+}
+
+func (spt *stateProofVerificationTracker) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {
+	spt.stateProofVerificationMu.Lock()
+	defer spt.stateProofVerificationMu.Unlock()
+
+	currentStateProofInterval := basics.Round(blk.ConsensusProtocol().StateProofInterval)
+
+	if currentStateProofInterval == 0 {
+		return
+	}
+
+	if blk.Round()%currentStateProofInterval == 0 {
+		spt.insertCommitData(&blk)
+	}
+
+	if delta.StateProofNext != 0 {
+		spt.insertDeleteData(&blk, &delta)
+	}
+}
+
+func (spt *stateProofVerificationTracker) committedUpTo(round basics.Round) (minRound, lookback basics.Round) {
+	return round, 0
+}
+
+func (spt *stateProofVerificationTracker) produceCommittingTask(_ basics.Round, _ basics.Round, dcr *deferredCommitRange) *deferredCommitRange {
+	return dcr
+}
+
+func (spt *stateProofVerificationTracker) prepareCommit(dcc *deferredCommitContext) error {
+	spt.stateProofVerificationMu.RLock()
+	defer spt.stateProofVerificationMu.RUnlock()
+
+	lastDataToCommitIndex := spt.committedRoundToLatestCommitDataIndex(dcc.newBase)
+	dcc.stateProofVerificationCommitData = make([]verificationCommitData, lastDataToCommitIndex+1)
+	copy(dcc.stateProofVerificationCommitData, spt.trackedCommitData[:lastDataToCommitIndex+1])
+
+	dcc.stateProofVerificationLatestDeleteDataIndex = spt.committedRoundToLatestDeleteDataIndex(dcc.newBase)
+	if dcc.stateProofVerificationLatestDeleteDataIndex > 0 {
+		dcc.stateProofVerificationDeleteData = spt.trackedDeleteData[dcc.stateProofVerificationLatestDeleteDataIndex]
+	}
+
+	return nil
+}
+
+func (spt *stateProofVerificationTracker) commitRound(ctx context.Context, tx *sql.Tx, dcc *deferredCommitContext) (err error) {
+	err = insertStateProofVerificationData(ctx, tx, &dcc.stateProofVerificationCommitData)
+	if err != nil {
+		return err
+	}
+
+	if dcc.stateProofVerificationLatestDeleteDataIndex > 0 {
+		err = deleteOldStateProofVerificationData(ctx, tx, dcc.stateProofVerificationDeleteData.stateProofNextRound)
+	}
+
+	return err
+
+}
+
+func (spt *stateProofVerificationTracker) postCommit(_ context.Context, dcc *deferredCommitContext) {
+	spt.stateProofVerificationMu.Lock()
+	defer spt.stateProofVerificationMu.Unlock()
+
+	spt.trackedCommitData = spt.trackedCommitData[len(dcc.stateProofVerificationCommitData):]
+	spt.trackedDeleteData = spt.trackedDeleteData[dcc.stateProofVerificationLatestDeleteDataIndex+1:]
+}
+
+func (spt *stateProofVerificationTracker) postCommitUnlocked(context.Context, *deferredCommitContext) {
+
+}
+
+func (spt *stateProofVerificationTracker) handleUnorderedCommit(*deferredCommitContext) {
+
+}
+
+func (spt *stateProofVerificationTracker) close() {
+	spt.dbQueries.lookupStateProofVerificationData.Close()
+}
+
+// TODO: additional data in error messages
+// TODO: caching mechanism for oldest data?
+
+func (spt *stateProofVerificationTracker) LookupVerificationData(stateProofLastAttestedRound basics.Round) (*ledgercore.StateProofVerificationData, error) {
+	spt.stateProofVerificationMu.RLock()
+	defer spt.stateProofVerificationMu.RUnlock()
+
+	if len(spt.trackedCommitData) == 0 || stateProofLastAttestedRound < spt.trackedCommitData[0].verificationData.TargetStateProofRound {
+		return spt.dbQueries.lookupData(stateProofLastAttestedRound)
+	}
+
+	if stateProofLastAttestedRound <= spt.trackedCommitData[len(spt.trackedCommitData)-1].verificationData.TargetStateProofRound {
+		verificationData, err := spt.lookupDataInTrackedMemory(stateProofLastAttestedRound)
+		return &verificationData, err
+	}
+
+	return &ledgercore.StateProofVerificationData{}, errStateProofVerificationDataNotYetGenerated
 }
 
 // TODO: How to combine these two functions using interfaces?
@@ -91,31 +213,6 @@ func (spt *stateProofVerificationTracker) lookupDataInTrackedMemory(stateProofLa
 	return ledgercore.StateProofVerificationData{}, errStateProofVerificationDataNotFound
 }
 
-func (spt *stateProofVerificationTracker) loadFromDisk(l ledgerForTracker, _ basics.Round) error {
-	preparedDbQueries, err := stateProofVerificationInitDbQueries(l.trackerDB().Rdb.Handle)
-	if err != nil {
-		return err
-	}
-
-	spt.dbQueries = *preparedDbQueries
-
-	latestRoundInLedger := l.Latest()
-	latestBlockHeader, err := l.BlockHdr(latestRoundInLedger)
-
-	if err != nil {
-		return err
-	}
-
-	proto := config.Consensus[latestBlockHeader.CurrentProtocol]
-
-	// Starting from StateProofMaxRecoveryIntervals provides the order of magnitude for expected state proof chain delay,
-	// and is thus a good size to start from.
-	spt.trackedCommitData = make([]verificationCommitData, 0, proto.StateProofMaxRecoveryIntervals)
-	spt.trackedDeleteData = make([]verificationDeleteData, 0, proto.StateProofMaxRecoveryIntervals)
-
-	return nil
-}
-
 func (spt *stateProofVerificationTracker) insertCommitData(blk *bookkeeping.Block) {
 	verificationData := ledgercore.StateProofVerificationData{
 		VotersCommitment:      blk.StateProofTracking[protocol.StateProofBasic].StateProofVotersCommitment,
@@ -136,91 +233,4 @@ func (spt *stateProofVerificationTracker) insertDeleteData(blk *bookkeeping.Bloc
 		stateProofNextRound: delta.StateProofNext,
 	}
 	spt.trackedDeleteData = append(spt.trackedDeleteData, deletionData)
-}
-
-func (spt *stateProofVerificationTracker) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {
-	currentStateProofInterval := basics.Round(blk.ConsensusProtocol().StateProofInterval)
-
-	if currentStateProofInterval == 0 {
-		return
-	}
-
-	if blk.Round()%currentStateProofInterval == 0 {
-		spt.insertCommitData(&blk)
-	}
-
-	if delta.StateProofNext != 0 {
-		spt.insertDeleteData(&blk, &delta)
-	}
-}
-
-func (spt *stateProofVerificationTracker) committedUpTo(round basics.Round) (minRound, lookback basics.Round) {
-	return round, 0
-}
-
-func (spt *stateProofVerificationTracker) produceCommittingTask(_ basics.Round, _ basics.Round, dcr *deferredCommitRange) *deferredCommitRange {
-	return dcr
-}
-
-func (spt *stateProofVerificationTracker) prepareCommit(dcc *deferredCommitContext) error {
-	lastDataToCommitIndex := spt.committedRoundToLatestCommitDataIndex(dcc.newBase)
-	dcc.stateProofVerificationCommitData = make([]verificationCommitData, lastDataToCommitIndex+1)
-	copy(dcc.stateProofVerificationCommitData, spt.trackedCommitData[:lastDataToCommitIndex+1])
-
-	dcc.stateProofVerificationLatestDeleteDataIndex = spt.committedRoundToLatestDeleteDataIndex(dcc.newBase)
-	if dcc.stateProofVerificationLatestDeleteDataIndex > 0 {
-		dcc.stateProofVerificationDeleteData = spt.trackedDeleteData[dcc.stateProofVerificationLatestDeleteDataIndex]
-	}
-
-	return nil
-}
-
-func (spt *stateProofVerificationTracker) commitRound(ctx context.Context, tx *sql.Tx, dcc *deferredCommitContext) (err error) {
-	err = insertStateProofVerificationData(ctx, tx, &dcc.stateProofVerificationCommitData)
-	if err != nil {
-		return err
-	}
-
-	// TODO: can this be in postCommitUnlocked?
-	if dcc.stateProofVerificationLatestDeleteDataIndex > 0 {
-		err = deleteOldStateProofVerificationData(ctx, tx, dcc.stateProofVerificationDeleteData.stateProofNextRound)
-	}
-
-	return err
-
-}
-
-func (spt *stateProofVerificationTracker) postCommit(_ context.Context, dcc *deferredCommitContext) {
-	// TODO: can this be in postCommitUnlocked?
-	spt.trackedCommitData = spt.trackedCommitData[len(dcc.stateProofVerificationCommitData):]
-	spt.trackedDeleteData = spt.trackedDeleteData[dcc.stateProofVerificationLatestDeleteDataIndex+1:]
-}
-
-func (spt *stateProofVerificationTracker) postCommitUnlocked(context.Context, *deferredCommitContext) {
-
-}
-
-func (spt *stateProofVerificationTracker) handleUnorderedCommit(*deferredCommitContext) {
-
-}
-
-func (spt *stateProofVerificationTracker) close() {
-	spt.dbQueries.lookupStateProofVerificationData.Close()
-}
-
-// TODO: must lock here
-// TODO: additional data in error messages
-// TODO: caching mechanism for oldest data?
-
-func (spt *stateProofVerificationTracker) LookupVerificationData(stateProofLastAttestedRound basics.Round) (*ledgercore.StateProofVerificationData, error) {
-	if len(spt.trackedCommitData) == 0 || stateProofLastAttestedRound < spt.trackedCommitData[0].verificationData.TargetStateProofRound {
-		return spt.dbQueries.lookupData(stateProofLastAttestedRound)
-	}
-
-	if stateProofLastAttestedRound <= spt.trackedCommitData[len(spt.trackedCommitData)-1].verificationData.TargetStateProofRound {
-		verificationData, err := spt.lookupDataInTrackedMemory(stateProofLastAttestedRound)
-		return &verificationData, err
-	}
-
-	return &ledgercore.StateProofVerificationData{}, errStateProofVerificationDataNotYetGenerated
 }

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/algorand/go-deadlock"
 
-	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
@@ -69,7 +68,7 @@ type stateProofVerificationTracker struct {
 	log logging.Logger
 }
 
-func (spt *stateProofVerificationTracker) loadFromDisk(l ledgerForTracker, dbRound basics.Round) error {
+func (spt *stateProofVerificationTracker) loadFromDisk(l ledgerForTracker, _ basics.Round) error {
 	preparedDbQueries, err := stateProofVerificationInitDbQueries(l.trackerDB().Rdb.Handle)
 	if err != nil {
 		return err
@@ -77,23 +76,18 @@ func (spt *stateProofVerificationTracker) loadFromDisk(l ledgerForTracker, dbRou
 
 	spt.dbQueries = *preparedDbQueries
 
-	latestBlockHeader, err := l.BlockHdr(dbRound)
-
 	if err != nil {
 		return err
 	}
-
-	proto := config.Consensus[latestBlockHeader.CurrentProtocol]
 
 	spt.log = l.trackerLog()
 
 	spt.stateProofVerificationMu.Lock()
 	defer spt.stateProofVerificationMu.Unlock()
 
-	// Starting from StateProofMaxRecoveryIntervals provides the order of magnitude for expected state proof chain delay,
-	// and is thus a good size to start from.
-	spt.trackedCommitData = make([]verificationCommitData, 0, proto.StateProofMaxRecoveryIntervals)
-	spt.trackedDeleteData = make([]verificationDeleteData, 0, proto.StateProofMaxRecoveryIntervals)
+	const initialDataArraySize = 10
+	spt.trackedCommitData = make([]verificationCommitData, 0, initialDataArraySize)
+	spt.trackedDeleteData = make([]verificationDeleteData, 0, initialDataArraySize)
 
 	return nil
 }

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	
+
 	"github.com/algorand/go-deadlock"
 
 	"github.com/algorand/go-algorand/config"
@@ -65,7 +65,7 @@ type stateProofVerificationTracker struct {
 	stateProofVerificationMu deadlock.RWMutex
 }
 
-func (spt *stateProofVerificationTracker) loadFromDisk(l ledgerForTracker, _ basics.Round) error {
+func (spt *stateProofVerificationTracker) loadFromDisk(l ledgerForTracker, dbRound basics.Round) error {
 	preparedDbQueries, err := stateProofVerificationInitDbQueries(l.trackerDB().Rdb.Handle)
 	if err != nil {
 		return err
@@ -73,8 +73,7 @@ func (spt *stateProofVerificationTracker) loadFromDisk(l ledgerForTracker, _ bas
 
 	spt.dbQueries = *preparedDbQueries
 
-	latestRoundInLedger := l.Latest()
-	latestBlockHeader, err := l.BlockHdr(latestRoundInLedger)
+	latestBlockHeader, err := l.BlockHdr(dbRound)
 
 	if err != nil {
 		return err

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -136,7 +136,7 @@ func (spt *stateProofVerificationTracker) prepareCommit(dcc *deferredCommitConte
 }
 
 func (spt *stateProofVerificationTracker) commitRound(ctx context.Context, tx *sql.Tx, dcc *deferredCommitContext) (err error) {
-	err = insertStateProofVerificationData(ctx, tx, &dcc.stateProofVerificationCommitData)
+	err = insertStateProofVerificationData(ctx, tx, dcc.stateProofVerificationCommitData)
 	if err != nil {
 		return err
 	}

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -45,12 +45,23 @@ type verificationCommitData struct {
 	verificationData ledgercore.StateProofVerificationData
 }
 
+// stateProofVerificationTracker is in charge of tracking data required to verify state proofs until such a time
+// as the data is no longer needed.
 type stateProofVerificationTracker struct {
+	// dbQueries are the pre-generated queries used to query the database, if needed,
+	// to lookup state proof verification data.
 	dbQueries stateProofVerificationDbQueries
 
+	// trackedCommitData represents the part of the tracked verification data currently in memory. Each element in this
+	// array contains both the data required to verify a single state proof and data to decide whether it's possible to
+	// commit the verification data to the database.
 	trackedCommitData []verificationCommitData
+
+	// trackedDeleteData represents the data required to delete committed state proof verification data from the
+	// database.
 	trackedDeleteData []verificationDeleteData
 
+	// stateProofVerificationMu protects trackedCommitData and trackedDeleteData.
 	stateProofVerificationMu deadlock.RWMutex
 }
 

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -35,8 +35,8 @@ var (
 // TODO: Add locks where needed
 
 type verificationDeletionData struct {
-	stateProofLastAttestedRound basics.Round
 	stateProofTransactionRound  basics.Round
+	stateProofLastAttestedRound basics.Round
 }
 
 type stateProofVerificationTracker struct {
@@ -83,7 +83,7 @@ func (spt *stateProofVerificationTracker) lookupDataInTrackedMemory(stateProofLa
 	return ledgercore.StateProofVerificationData{}, errStateProofVerificationDataNotFound
 }
 
-func (spt *stateProofVerificationTracker) loadFromDisk(l ledgerForTracker, round basics.Round) error {
+func (spt *stateProofVerificationTracker) loadFromDisk(l ledgerForTracker, _ basics.Round) error {
 	preparedDbQueries, err := stateProofVerificationInitDbQueries(l.trackerDB().Rdb.Handle)
 	if err != nil {
 		return err
@@ -126,10 +126,7 @@ func (spt *stateProofVerificationTracker) committedUpTo(round basics.Round) (min
 	return round, 0
 }
 
-// TODO: Rewrite this function after understanding tracker interaction better
 func (spt *stateProofVerificationTracker) produceCommittingTask(committedRound basics.Round, dbRound basics.Round, dcr *deferredCommitRange) *deferredCommitRange {
-	var offset uint64
-
 	if committedRound < dcr.lookback {
 		return nil
 	}
@@ -140,12 +137,9 @@ func (spt *stateProofVerificationTracker) produceCommittingTask(committedRound b
 		return nil
 	}
 
-	// TODO: Our own panic and offset calculation
-	//if newBase > dbRound+basics.Round(len(au.deltas)) {
-	//	au.log.Panicf("produceCommittingTask: block %d too far in the future, lookback %d, dbRound %d (cached %d), deltas %d", committedRound, dcr.lookback, dbRound, au.cachedDBRound, len(au.deltas))
-	//}
+	// TODO: Should I add a check here for out of bounds?
 
-	offset = uint64(newBase - dbRound)
+	offset := uint64(newBase - dbRound)
 
 	dcr.oldBase = dbRound
 	dcr.offset = offset

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -224,7 +224,7 @@ func (spt *stateProofVerificationTracker) lookupDataInTrackedMemory(stateProofLa
 func (spt *stateProofVerificationTracker) insertCommitData(blk *bookkeeping.Block) {
 	verificationData := ledgercore.StateProofVerificationData{
 		VotersCommitment:      blk.StateProofTracking[protocol.StateProofBasic].StateProofVotersCommitment,
-		ProvenWeight:          blk.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight,
+		OnlineTotalWeight:     blk.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight,
 		TargetStateProofRound: blk.Round() + basics.Round(blk.ConsensusProtocol().StateProofInterval),
 	}
 

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -166,7 +166,9 @@ func (spt *stateProofVerificationTracker) handleUnorderedCommit(*deferredCommitC
 }
 
 func (spt *stateProofVerificationTracker) close() {
-	spt.dbQueries.lookupStateProofVerificationData.Close()
+	if spt.dbQueries.lookupStateProofVerificationData != nil {
+		spt.dbQueries.lookupStateProofVerificationData.Close()
+	}
 }
 
 // TODO: additional data in error messages

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	
 	"github.com/algorand/go-deadlock"
 
 	"github.com/algorand/go-algorand/config"

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -135,7 +135,7 @@ func (spt *stateProofVerificationTracker) prepareCommit(dcc *deferredCommitConte
 
 	dcc.stateProofVerificationLatestDeleteDataIndex = spt.committedRoundToLatestDeleteDataIndex(dcc.newBase)
 	if dcc.stateProofVerificationLatestDeleteDataIndex > -1 {
-		dcc.stateProofVerificationDeleteData = spt.trackedDeleteData[dcc.stateProofVerificationLatestDeleteDataIndex]
+		dcc.stateProofVerificationEarliestTrackStateProofRound = spt.trackedDeleteData[dcc.stateProofVerificationLatestDeleteDataIndex].stateProofNextRound
 	}
 
 	return nil
@@ -148,7 +148,7 @@ func (spt *stateProofVerificationTracker) commitRound(ctx context.Context, tx *s
 	}
 
 	if dcc.stateProofVerificationLatestDeleteDataIndex > -1 {
-		err = deleteOldStateProofVerificationData(ctx, tx, dcc.stateProofVerificationDeleteData.stateProofNextRound)
+		err = deleteOldStateProofVerificationData(ctx, tx, dcc.stateProofVerificationEarliestTrackStateProofRound)
 	}
 
 	return err

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -147,7 +147,7 @@ func (spt *stateProofVerificationTracker) prepareCommit(dcc *deferredCommitConte
 	dcc.latestStateProofDeletionDataIndex = spt.roundToLatestDeletionIndex(dcc.newBase)
 	dcc.latestStateProofRoundToDelete = 0
 	if dcc.latestStateProofDeletionDataIndex >= 0 {
-		dcc.latestStateProofRoundToDelete = spt.trackedDeletionData[dcc.latestStateProofRoundToDelete].stateProofLastAttestedRound
+		dcc.latestStateProofRoundToDelete = spt.trackedDeletionData[dcc.latestStateProofDeletionDataIndex].stateProofLastAttestedRound
 	}
 
 	return nil

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-
 	"github.com/algorand/go-deadlock"
 
 	"github.com/algorand/go-algorand/config"
@@ -129,7 +128,7 @@ func (spt *stateProofVerificationTracker) prepareCommit(dcc *deferredCommitConte
 	copy(dcc.stateProofVerificationCommitData, spt.trackedCommitData[:lastDataToCommitIndex+1])
 
 	dcc.stateProofVerificationLatestDeleteDataIndex = spt.committedRoundToLatestDeleteDataIndex(dcc.newBase)
-	if dcc.stateProofVerificationLatestDeleteDataIndex > 0 {
+	if dcc.stateProofVerificationLatestDeleteDataIndex > -1 {
 		dcc.stateProofVerificationDeleteData = spt.trackedDeleteData[dcc.stateProofVerificationLatestDeleteDataIndex]
 	}
 
@@ -142,7 +141,7 @@ func (spt *stateProofVerificationTracker) commitRound(ctx context.Context, tx *s
 		return err
 	}
 
-	if dcc.stateProofVerificationLatestDeleteDataIndex > 0 {
+	if dcc.stateProofVerificationLatestDeleteDataIndex > -1 {
 		err = deleteOldStateProofVerificationData(ctx, tx, dcc.stateProofVerificationDeleteData.stateProofNextRound)
 	}
 

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -38,8 +38,8 @@ var (
 // TODO: Add locks where needed
 
 type verificationDeletionData struct {
-	stateProofTransactionRound  basics.Round
-	stateProofLastAttestedRound basics.Round
+	stateProofTransactionRound basics.Round
+	stateProofNextRound        basics.Round
 }
 
 type stateProofVerificationTracker struct {
@@ -129,8 +129,8 @@ func (spt *stateProofVerificationTracker) newBlock(blk bookkeeping.Block, delta 
 
 	if delta.StateProofNext != 0 {
 		deletionData := verificationDeletionData{
-			stateProofLastAttestedRound: delta.StateProofNext.SubSaturate(currentStateProofInterval),
-			stateProofTransactionRound:  blk.Round(),
+			stateProofNextRound:        delta.StateProofNext,
+			stateProofTransactionRound: blk.Round(),
 		}
 		spt.trackedDeletionData = append(spt.trackedDeletionData, deletionData)
 	}
@@ -180,7 +180,7 @@ func (spt *stateProofVerificationTracker) commitRound(ctx context.Context, tx *s
 
 	// TODO: can this be in postCommitUnlocked?
 	if dcc.latestStateProofVerificationDeletionDataIndex > 0 {
-		err = deleteOldStateProofVerificationData(ctx, tx, dcc.latestStateProofVerificationDeletionData.stateProofLastAttestedRound)
+		err = deleteOldStateProofVerificationData(ctx, tx, dcc.latestStateProofVerificationDeletionData.stateProofNextRound)
 	}
 
 	// TODO: caching mechanism for oldest data?

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -170,7 +170,6 @@ func (spt *stateProofVerificationTracker) close() {
 }
 
 // TODO: additional data in error messages
-// TODO: caching mechanism for oldest data?
 
 func (spt *stateProofVerificationTracker) LookupVerificationData(stateProofLastAttestedRound basics.Round) (*ledgercore.StateProofVerificationData, error) {
 	spt.stateProofVerificationMu.RLock()

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -103,7 +103,7 @@ func (spt *stateProofVerificationTracker) loadFromDisk(l ledgerForTracker, _ bas
 
 	proto := config.Consensus[latestBlockHeader.CurrentProtocol]
 
-	// Starting from StateProofMaxRecoveryIntervals provides the order of magnitude for state proof chain delay,
+	// Starting from StateProofMaxRecoveryIntervals provides the order of magnitude for expected state proof chain delay,
 	// and is thus a good size to start from.
 	spt.trackedData = make([]ledgercore.StateProofVerificationData, 0, proto.StateProofMaxRecoveryIntervals)
 	spt.trackedDeletionData = make([]verificationDeletionData, 0, proto.StateProofMaxRecoveryIntervals)
@@ -151,6 +151,7 @@ func (spt *stateProofVerificationTracker) produceCommittingTask(committedRound b
 		return nil
 	}
 
+	// TODO: warn on what basically amounts to interval change?
 	offset := uint64(newBase - dbRound)
 
 	dcr.oldBase = dbRound

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -36,12 +36,12 @@ var (
 )
 
 type verificationDeleteData struct {
-	generatedRound      basics.Round
+	confirmedRound      basics.Round
 	stateProofNextRound basics.Round
 }
 
 type verificationCommitData struct {
-	generatedRound   basics.Round
+	confirmedRound   basics.Round
 	verificationData ledgercore.StateProofVerificationData
 }
 
@@ -189,12 +189,11 @@ func (spt *stateProofVerificationTracker) LookupVerificationData(stateProofLastA
 	return &ledgercore.StateProofVerificationData{}, errStateProofVerificationDataNotYetGenerated
 }
 
-// TODO: How to combine these two functions using interfaces?
 func (spt *stateProofVerificationTracker) committedRoundToLatestCommitDataIndex(committedRound basics.Round) int {
 	latestCommittedDataIndex := -1
 
 	for index, data := range spt.trackedCommitData {
-		if data.generatedRound <= committedRound {
+		if data.confirmedRound <= committedRound {
 			latestCommittedDataIndex = index
 		}
 	}
@@ -206,7 +205,7 @@ func (spt *stateProofVerificationTracker) committedRoundToLatestDeleteDataIndex(
 	latestCommittedDataIndex := -1
 
 	for index, data := range spt.trackedDeleteData {
-		if data.generatedRound <= committedRound {
+		if data.confirmedRound <= committedRound {
 			latestCommittedDataIndex = index
 		}
 	}
@@ -232,7 +231,7 @@ func (spt *stateProofVerificationTracker) insertCommitData(blk *bookkeeping.Bloc
 	}
 
 	commitData := verificationCommitData{
-		generatedRound:   blk.Round(),
+		confirmedRound:   blk.Round(),
 		verificationData: verificationData,
 	}
 	spt.trackedCommitData = append(spt.trackedCommitData, commitData)
@@ -240,7 +239,7 @@ func (spt *stateProofVerificationTracker) insertCommitData(blk *bookkeeping.Bloc
 
 func (spt *stateProofVerificationTracker) insertDeleteData(blk *bookkeeping.Block, delta *ledgercore.StateDelta) {
 	deletionData := verificationDeleteData{
-		generatedRound:      blk.Round(),
+		confirmedRound:      blk.Round(),
 		stateProofNextRound: delta.StateProofNext,
 	}
 	spt.trackedDeleteData = append(spt.trackedDeleteData, deletionData)

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -193,6 +193,8 @@ func (spt *stateProofVerificationTracker) committedRoundToLatestCommitDataIndex(
 	for index, data := range spt.trackedCommitData {
 		if data.confirmedRound <= committedRound {
 			latestCommittedDataIndex = index
+		} else {
+			break
 		}
 	}
 
@@ -205,6 +207,8 @@ func (spt *stateProofVerificationTracker) committedRoundToLatestDeleteDataIndex(
 	for index, data := range spt.trackedDeleteData {
 		if data.confirmedRound <= committedRound {
 			latestCommittedDataIndex = index
+		} else {
+			break
 		}
 	}
 

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -235,9 +235,8 @@ func (spt *stateProofVerificationTracker) insertCommitData(blk *bookkeeping.Bloc
 	if len(spt.trackedCommitData) > 0 {
 		lastCommitConfirmedRound := spt.trackedCommitData[len(spt.trackedCommitData)-1].confirmedRound
 		if blk.Round() <= lastCommitConfirmedRound {
-			spt.log.Errorf("state proof verification: attempted to insert commit data confirmed earlier than latest"+
+			spt.log.Panicf("state proof verification: attempted to insert commit data confirmed earlier than latest"+
 				"commit data, round: %d, last confirmed commit data round: %d", blk.Round(), lastCommitConfirmedRound)
-			return
 		}
 	}
 
@@ -259,9 +258,8 @@ func (spt *stateProofVerificationTracker) insertDeleteData(blk *bookkeeping.Bloc
 	if len(spt.trackedDeleteData) > 0 {
 		lastDeleteConfirmedRound := spt.trackedDeleteData[len(spt.trackedDeleteData)-1].confirmedRound
 		if blk.Round() <= lastDeleteConfirmedRound {
-			spt.log.Errorf("state proof verification: attempted to insert delete data confirmed earlier than latest"+
+			spt.log.Panicf("state proof verification: attempted to insert delete data confirmed earlier than latest"+
 				"delete data, round: %d, last confirmed delete data round: %d", blk.Round(), lastDeleteConfirmedRound)
-			return
 		}
 	}
 

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -184,7 +184,7 @@ func (spt *stateProofVerificationTracker) LookupVerificationData(stateProofLastA
 		return spt.lookupDataInTrackedMemory(stateProofLastAttestedRound)
 	}
 
-	return &ledgercore.StateProofVerificationData{}, fmt.Errorf("lookup failed for round %d: %w", stateProofLastAttestedRound, errStateProofVerificationDataNotYetGenerated
+	return &ledgercore.StateProofVerificationData{}, fmt.Errorf("lookup failed for round %d: %w", stateProofLastAttestedRound, errStateProofVerificationDataNotYetGenerated)
 }
 
 func (spt *stateProofVerificationTracker) lookupDataInTrackedMemory(stateProofLastAttestedRound basics.Round) (*ledgercore.StateProofVerificationData, error) {

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -99,9 +99,6 @@ func (spt *stateProofVerificationTracker) newBlock(blk bookkeeping.Block, delta 
 		return
 	}
 
-	spt.stateProofVerificationMu.Lock()
-	defer spt.stateProofVerificationMu.Unlock()
-
 	if blk.Round()%currentStateProofInterval == 0 {
 		spt.insertCommitData(&blk)
 	}
@@ -240,6 +237,9 @@ func (spt *stateProofVerificationTracker) committedRoundToLatestDeleteDataIndex(
 }
 
 func (spt *stateProofVerificationTracker) insertCommitData(blk *bookkeeping.Block) {
+	spt.stateProofVerificationMu.Lock()
+	defer spt.stateProofVerificationMu.Unlock()
+
 	if len(spt.trackedCommitData) > 0 {
 		lastCommitConfirmedRound := spt.trackedCommitData[len(spt.trackedCommitData)-1].confirmedRound
 		if blk.Round() <= lastCommitConfirmedRound {
@@ -263,6 +263,9 @@ func (spt *stateProofVerificationTracker) insertCommitData(blk *bookkeeping.Bloc
 }
 
 func (spt *stateProofVerificationTracker) insertDeleteData(blk *bookkeeping.Block, delta *ledgercore.StateDelta) {
+	spt.stateProofVerificationMu.Lock()
+	defer spt.stateProofVerificationMu.Unlock()
+
 	if len(spt.trackedDeleteData) > 0 {
 		lastDeleteConfirmedRound := spt.trackedDeleteData[len(spt.trackedDeleteData)-1].confirmedRound
 		if blk.Round() <= lastDeleteConfirmedRound {

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -140,22 +140,7 @@ func (spt *stateProofVerificationTracker) committedUpTo(round basics.Round) (min
 	return round, 0
 }
 
-func (spt *stateProofVerificationTracker) produceCommittingTask(committedRound basics.Round, dbRound basics.Round, dcr *deferredCommitRange) *deferredCommitRange {
-	if committedRound < dcr.lookback {
-		return nil
-	}
-
-	newBase := committedRound - dcr.lookback
-	if newBase <= dbRound {
-		// Already forgotten
-		return nil
-	}
-
-	// TODO: warn on what basically amounts to interval change?
-	offset := uint64(newBase - dbRound)
-
-	dcr.oldBase = dbRound
-	dcr.offset = offset
+func (spt *stateProofVerificationTracker) produceCommittingTask(_ basics.Round, _ basics.Round, dcr *deferredCommitRange) *deferredCommitRange {
 	return dcr
 }
 
@@ -203,6 +188,7 @@ func (spt *stateProofVerificationTracker) handleUnorderedCommit(*deferredCommitC
 }
 
 func (spt *stateProofVerificationTracker) close() {
+	spt.dbQueries.lookupStateProofVerificationData.Close()
 }
 
 // TODO: must lock here

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	errStateProofVerificationDataNotFound        = errors.New("requested state proof verification data not found in memory")
-	errStateProofVerificationDataNotYetGenerated = errors.New("requested state proof verification data is in a future block")
+	errStateProofVerificationDataNotYetGenerated = errors.New("requested state proof verification data later than latest data available")
 )
 
 type verificationDeleteData struct {
@@ -170,8 +170,6 @@ func (spt *stateProofVerificationTracker) close() {
 		spt.dbQueries.lookupStateProofVerificationData.Close()
 	}
 }
-
-// TODO: additional data in error messages
 
 func (spt *stateProofVerificationTracker) LookupVerificationData(stateProofLastAttestedRound basics.Round) (*ledgercore.StateProofVerificationData, error) {
 	spt.stateProofVerificationMu.RLock()

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -76,10 +76,6 @@ func (spt *stateProofVerificationTracker) loadFromDisk(l ledgerForTracker, _ bas
 
 	spt.dbQueries = *preparedDbQueries
 
-	if err != nil {
-		return err
-	}
-
 	spt.log = l.trackerLog()
 
 	spt.stateProofVerificationMu.Lock()

--- a/ledger/stateproofverificationtracker_test.go
+++ b/ledger/stateproofverificationtracker_test.go
@@ -166,7 +166,7 @@ func verifyStateProofVerificationTracking(t *testing.T, spt *stateProofVerificat
 			expectedNotFoundErr = sql.ErrNoRows
 		case trackerMemory:
 			_, err = spt.lookupDataInTrackedMemory(targetStateProofRound)
-			expectedNotFoundErr = errStateProofVerificationDataNotFound
+			expectedNotFoundErr = errStateProofVerificationDataNotFoundInMemory
 		}
 
 		if dataPresenceExpected {
@@ -446,5 +446,5 @@ func TestStateProofVerificationTracker_LookupVerificationData(t *testing.T) {
 	// This error shouldn't happen in normal flow - we force it to happen for the test.
 	spt.trackedCommitData[0].verificationData.TargetStateProofRound = 0
 	_, err = spt.LookupVerificationData(memoryDataRound)
-	a.ErrorIs(err, errStateProofVerificationDataNotFound)
+	a.ErrorIs(err, errStateProofVerificationDataNotFoundInMemory)
 }

--- a/ledger/stateproofverificationtracker_test.go
+++ b/ledger/stateproofverificationtracker_test.go
@@ -430,7 +430,7 @@ func TestStateProofVerificationTracker_LookupVerificationData(t *testing.T) {
 
 	lastStateProofRound := basics.Round(defaultStateProofInterval + dataToAdd*defaultStateProofInterval)
 	_, err = spt.LookupVerificationData(lastStateProofRound + basics.Round(defaultStateProofInterval))
-	a.ErrorIs(err, errStateProofVerificationDataNotYetGenerated)
+	a.ErrorIs(err, errStateProofVerificationDataOutOfBounds)
 
 	dbDataRound := basics.Round(defaultStateProofInterval + expectedDataInDbNum*defaultStateProofInterval)
 	dbData, err := spt.LookupVerificationData(dbDataRound)

--- a/ledger/stateproofverificationtracker_test.go
+++ b/ledger/stateproofverificationtracker_test.go
@@ -216,29 +216,6 @@ func TestStateProofVerificationTracker_StateProofsNotStuck(t *testing.T) {
 	verifyStateProofVerificationTracking(t, spt, lastStateProofTargetRound, 1, defaultStateProofInterval, true, any)
 }
 
-func TestStateProofVerificationTracker_LoadFromDisk(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	a := require.New(t)
-
-	ml, spt := initializeLedgerSpt(t)
-	defer ml.Close()
-	defer spt.close()
-
-	expectedDataNum := uint64(10)
-
-	lastBlock := feedBlocksUpToRound(spt, genesisBlock(), basics.Round(expectedDataNum*defaultStateProofInterval),
-		defaultStateProofInterval, true)
-
-	mockCommit(t, spt, ml, 0, lastBlock.block.Round())
-
-	spt.close()
-	err := spt.loadFromDisk(ml, unusedByStateProofTracker)
-	a.NoError(err)
-	
-	verifyStateProofVerificationTracking(t, spt, defaultFirstStateProofDataRound, expectedDataNum, defaultStateProofInterval, false, trackerMemory)
-	verifyStateProofVerificationTracking(t, spt, defaultFirstStateProofDataRound, expectedDataNum, defaultStateProofInterval, true, trackerDB)
-}
-
 func TestStateProofVerificationTracker_CommitFUllDbFlush(t *testing.T) {
 	partitiontest.PartitionTest(t)
 

--- a/ledger/stateproofverificationtracker_test.go
+++ b/ledger/stateproofverificationtracker_test.go
@@ -162,7 +162,7 @@ func verifyStateProofVerificationTracking(t *testing.T, spt *stateProofVerificat
 			_, err = spt.LookupVerificationData(targetStateProofRound)
 			expectedNotFoundErr = sql.ErrNoRows
 		case trackerDB:
-			_, err = spt.dbQueries.lookupData(targetStateProofRound)
+			_, err = spt.lookupDataInDB(targetStateProofRound)
 			expectedNotFoundErr = sql.ErrNoRows
 		case trackerMemory:
 			_, err = spt.lookupDataInTrackedMemory(targetStateProofRound)

--- a/ledger/stateproofverificationtracker_test.go
+++ b/ledger/stateproofverificationtracker_test.go
@@ -362,7 +362,7 @@ func TestStateProofVerificationTracker_CommitNoDbPruning(t *testing.T) {
 	mockCommit(t, spt, ml, 0, lastStuckBlockRound)
 
 	verifyStateProofVerificationTracking(t, spt, firstStateProofRound, dataToAdd, defaultStateProofInterval, true, trackerDB)
-	a.Equal(maxStateProofsToGenerate, uint64(len(spt.trackedDeletionData)))
+	a.Equal(maxStateProofsToGenerate, uint64(len(spt.trackedDeleteData)))
 }
 
 func TestStateProofVerificationTracker_StateProofIntervalChange(t *testing.T) {

--- a/ledger/stateproofverificationtracker_test.go
+++ b/ledger/stateproofverificationtracker_test.go
@@ -154,8 +154,8 @@ func TestStateProofVerificationTracker_StateProofsNotStuck(t *testing.T) {
 	ml.trackers.committedUpTo(lastBlock.block.Round())
 	ml.trackers.waitAccountsWriting()
 
-	// The last verification data should still be in the DB since the state proof it is used to verify has not
-	// yet been committed.
+	// The last verification data should still be in the DB since the round with the state proof transaction it is used
+	// to verify has not yet been committed.
 	expectedRemainingDataNum := expectedDataNum - 1
 	verifyTrackerDB(t, spt, 0, expectedRemainingDataNum, false)
 }

--- a/ledger/stateproofverificationtracker_test.go
+++ b/ledger/stateproofverificationtracker_test.go
@@ -216,6 +216,29 @@ func TestStateProofVerificationTracker_StateProofsNotStuck(t *testing.T) {
 	verifyStateProofVerificationTracking(t, spt, lastStateProofTargetRound, 1, defaultStateProofInterval, true, any)
 }
 
+func TestStateProofVerificationTracker_LoadFromDisk(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	ml, spt := initializeLedgerSpt(t)
+	defer ml.Close()
+	defer spt.close()
+
+	expectedDataNum := uint64(10)
+
+	lastBlock := feedBlocksUpToRound(spt, genesisBlock(), basics.Round(expectedDataNum*defaultStateProofInterval),
+		defaultStateProofInterval, true)
+
+	mockCommit(t, spt, ml, 0, lastBlock.block.Round())
+
+	spt.close()
+	err := spt.loadFromDisk(ml, unusedByStateProofTracker)
+	a.NoError(err)
+	
+	verifyStateProofVerificationTracking(t, spt, defaultFirstStateProofDataRound, expectedDataNum, defaultStateProofInterval, false, trackerMemory)
+	verifyStateProofVerificationTracking(t, spt, defaultFirstStateProofDataRound, expectedDataNum, defaultStateProofInterval, true, trackerDB)
+}
+
 func TestStateProofVerificationTracker_CommitFUllDbFlush(t *testing.T) {
 	partitiontest.PartitionTest(t)
 

--- a/ledger/stateproofverificationtracker_test.go
+++ b/ledger/stateproofverificationtracker_test.go
@@ -183,7 +183,6 @@ func TestStateProofVerificationTracker_Removal(t *testing.T) {
 // TODO: Test addition and removal after exceeding initial capacity
 // TODO: Test interval size change
 // TODO: Test state proofs disabled
-// TODO: Test state proofs happy flow
 // TODO: Test commit not all state proofs
 // TODO: Test disk initialization
 // TODO: Test stress

--- a/ledger/stateproofverificationtracker_test.go
+++ b/ledger/stateproofverificationtracker_test.go
@@ -447,3 +447,19 @@ func TestStateProofVerificationTracker_LookupVerificationData(t *testing.T) {
 	a.ErrorIs(err, errStateProofVerificationDataNotFound)
 	a.ErrorContains(err, "memory lookup failed")
 }
+
+func TestStateProofVerificationTracker_PanicInvalidBlockInsertion(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	ml, spt := initializeLedgerSpt(t)
+	defer ml.Close()
+	defer spt.close()
+
+	dataToAdd := uint64(1)
+	_ = feedBlocksUpToRound(spt, genesisBlock(), basics.Round(dataToAdd*defaultStateProofInterval),
+		defaultStateProofInterval, true)
+
+	pastBlock := randomBlock(0)
+	a.Panics(func() { spt.insertCommitData(&pastBlock.block) })
+}

--- a/ledger/stateproofverificationtracker_test.go
+++ b/ledger/stateproofverificationtracker_test.go
@@ -17,8 +17,9 @@
 package ledger
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+	
+	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/basics"

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -269,9 +269,12 @@ type deferredCommitContext struct {
 	stats       telemetryspec.AccountsUpdateMetrics
 	updateStats bool
 
-	stateProofVerificationDeleteData            verificationDeleteData
+	// state proof verification deletion information
 	stateProofVerificationLatestDeleteDataIndex int
-	stateProofVerificationCommitData            []verificationCommitData
+	stateProofVerificationDeleteData            verificationDeleteData
+
+	// state proof verification commit information
+	stateProofVerificationCommitData []verificationCommitData
 }
 
 var errMissingAccountUpdateTracker = errors.New("initializeTrackerCaches : called without a valid accounts update tracker")

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -269,9 +269,9 @@ type deferredCommitContext struct {
 	stats       telemetryspec.AccountsUpdateMetrics
 	updateStats bool
 
-	latestStateProofDeletionDataIndex   int
-	latestStateProofRoundToDelete       basics.Round
-	committedStateProofVerificationData []ledgercore.StateProofVerificationData
+	latestStateProofVerificationDeletionData      verificationDeletionData
+	latestStateProofVerificationDeletionDataIndex int
+	committedStateProofVerificationData           []ledgercore.StateProofVerificationData
 }
 
 var errMissingAccountUpdateTracker = errors.New("initializeTrackerCaches : called without a valid accounts update tracker")

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -270,8 +270,8 @@ type deferredCommitContext struct {
 	updateStats bool
 
 	// state proof verification deletion information
-	stateProofVerificationLatestDeleteDataIndex int
-	stateProofVerificationDeleteData            verificationDeleteData
+	stateProofVerificationLatestDeleteDataIndex        int
+	stateProofVerificationEarliestTrackStateProofRound basics.Round
 
 	// state proof verification commit information
 	stateProofVerificationCommitData []verificationCommitData

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -269,7 +269,8 @@ type deferredCommitContext struct {
 	stats       telemetryspec.AccountsUpdateMetrics
 	updateStats bool
 
-	lastPruneStateProof                 basics.Round
+	latestStateProofDeletionDataIndex   int
+	latestStateProofRoundToDelete       basics.Round
 	committedStateProofVerificationData []ledgercore.StateProofVerificationData
 }
 

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -268,6 +268,9 @@ type deferredCommitContext struct {
 
 	stats       telemetryspec.AccountsUpdateMetrics
 	updateStats bool
+
+	staleStateProofRound                basics.Round
+	committedStateProofVerificationData []ledgercore.StateProofVerificationData
 }
 
 var errMissingAccountUpdateTracker = errors.New("initializeTrackerCaches : called without a valid accounts update tracker")

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -269,9 +269,9 @@ type deferredCommitContext struct {
 	stats       telemetryspec.AccountsUpdateMetrics
 	updateStats bool
 
-	latestStateProofVerificationDeletionData      verificationDeletionData
-	latestStateProofVerificationDeletionDataIndex int
-	committedStateProofVerificationData           []ledgercore.StateProofVerificationData
+	stateProofVerificationDeleteData            verificationDeletionData
+	stateProofVerificationLatestDeleteDataIndex int
+	stateProofVerificationCommitData            []verificationCommitData
 }
 
 var errMissingAccountUpdateTracker = errors.New("initializeTrackerCaches : called without a valid accounts update tracker")

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -269,7 +269,7 @@ type deferredCommitContext struct {
 	stats       telemetryspec.AccountsUpdateMetrics
 	updateStats bool
 
-	stateProofVerificationDeleteData            verificationDeletionData
+	stateProofVerificationDeleteData            verificationDeleteData
 	stateProofVerificationLatestDeleteDataIndex int
 	stateProofVerificationCommitData            []verificationCommitData
 }

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -269,7 +269,7 @@ type deferredCommitContext struct {
 	stats       telemetryspec.AccountsUpdateMetrics
 	updateStats bool
 
-	staleStateProofRound                basics.Round
+	lastPruneStateProof                 basics.Round
 	committedStateProofVerificationData []ledgercore.StateProofVerificationData
 }
 

--- a/ledger/trackerdb.go
+++ b/ledger/trackerdb.go
@@ -512,7 +512,7 @@ func (tu *trackerDBSchemaInitializer) upgradeDatabaseSchema6(ctx context.Context
 // upgradeDatabaseSchema7 upgrades the database schema from version 7 to version 8,
 // adding a new stateproofverification table
 func (tu *trackerDBSchemaInitializer) upgradeDatabaseSchema7(ctx context.Context, tx *sql.Tx) (err error) {
-	err = accountsCreateStateProofVerificationTable(ctx, tx)
+	err = createStateProofVerificationTable(ctx, tx)
 	if err != nil {
 		return err
 	}

--- a/scripts/dump_genesis.sh
+++ b/scripts/dump_genesis.sh
@@ -76,6 +76,9 @@ for LEDGER in $LEDGERS; do
       unfinishedcatchpoints)
         SORT=round
         ;;
+      stateproofverification)
+        SORT=targetstateproofround
+        ;;
       *)
         echo "Unknown table $T" >&2
         exit 1


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->
Created a tracker to track the data required for state proof verification, until such a time as the expected state proof is agreed upon. 
Includes unit tests and a sanity ledger test.
