### PR TITLE
BatchVerifier: Rename and unexport local functions in verify/txn

### DIFF
--- a/catchup/universalFetcher.go
+++ b/catchup/universalFetcher.go
@@ -187,8 +187,8 @@ func (w *wsFetcherClient) requestBlock(ctx context.Context, round basics.Round) 
 	return blockCertBytes, nil
 }
 
-// set max fetcher size to 5MB, this is enough to fit the block and certificate
-const fetcherMaxBlockBytes = 5 << 20
+// set max fetcher size to 10MB, this is enough to fit the block and certificate
+const fetcherMaxBlockBytes = 10 << 20
 
 var errNoBlockForRound = errors.New("No block available for given round")
 

--- a/crypto/batchverifier.go
+++ b/crypto/batchverifier.go
@@ -53,7 +53,6 @@ const minBatchVerifierAlloc = 16
 // Batch verifications errors
 var (
 	ErrBatchVerificationFailed = errors.New("At least one signature didn't pass verification")
-	ErrZeroTransactionInBatch  = errors.New("Could not validate empty signature set")
 )
 
 //export ed25519_randombytes_unsafe
@@ -113,7 +112,7 @@ func (b *BatchVerifier) GetNumberOfEnqueuedSignatures() int {
 // if the batch is zero an appropriate error is return.
 func (b *BatchVerifier) Verify() error {
 	if b.GetNumberOfEnqueuedSignatures() == 0 {
-		return ErrZeroTransactionInBatch
+		return nil
 	}
 
 	var messages = make([][]byte, b.GetNumberOfEnqueuedSignatures())

--- a/crypto/batchverifier.go
+++ b/crypto/batchverifier.go
@@ -103,19 +103,19 @@ func (b *BatchVerifier) expand() {
 	b.signatures = signatures
 }
 
-// GetNumberOfEnqueuedSignatures returns the number of signatures current enqueue onto the bacth verifier object
-func (b *BatchVerifier) GetNumberOfEnqueuedSignatures() int {
+// getNumberOfEnqueuedSignatures returns the number of signatures current enqueue onto the bacth verifier object
+func (b *BatchVerifier) getNumberOfEnqueuedSignatures() int {
 	return len(b.messages)
 }
 
 // Verify verifies that all the signatures are valid. in that case nil is returned
 // if the batch is zero an appropriate error is return.
 func (b *BatchVerifier) Verify() error {
-	if b.GetNumberOfEnqueuedSignatures() == 0 {
+	if b.getNumberOfEnqueuedSignatures() == 0 {
 		return nil
 	}
 
-	var messages = make([][]byte, b.GetNumberOfEnqueuedSignatures())
+	var messages = make([][]byte, b.getNumberOfEnqueuedSignatures())
 	for i, m := range b.messages {
 		messages[i] = HashRep(m)
 	}

--- a/crypto/batchverifier_test.go
+++ b/crypto/batchverifier_test.go
@@ -62,7 +62,7 @@ func TestBatchVerifierBulk(t *testing.T) {
 			sig := sigSecrets.Sign(msg)
 			bv.EnqueueSignature(sigSecrets.SignatureVerifier, msg, sig)
 		}
-		require.Equal(t, n, bv.GetNumberOfEnqueuedSignatures())
+		require.Equal(t, n, bv.getNumberOfEnqueuedSignatures())
 		require.NoError(t, bv.Verify())
 	}
 

--- a/crypto/batchverifier_test.go
+++ b/crypto/batchverifier_test.go
@@ -122,5 +122,5 @@ func BenchmarkBatchVerifier(b *testing.B) {
 func TestEmpty(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	bv := MakeBatchVerifier()
-	require.Error(t, bv.Verify())
+	require.NoError(t, bv.Verify())
 }

--- a/crypto/multisig.go
+++ b/crypto/multisig.go
@@ -216,33 +216,23 @@ func MultisigAssemble(unisig []MultisigSig) (msig MultisigSig, err error) {
 }
 
 // MultisigVerify verifies an assembled MultisigSig
-func MultisigVerify(msg Hashable, addr Digest, sig MultisigSig) (verified bool, err error) {
+func MultisigVerify(msg Hashable, addr Digest, sig MultisigSig) (err error) {
 	batchVerifier := MakeBatchVerifier()
 
-	if verified, err = MultisigBatchPrep(msg, addr, sig, batchVerifier); err != nil {
+	if err = MultisigBatchPrep(msg, addr, sig, batchVerifier); err != nil {
 		return
 	}
-	if !verified {
-		return
-	}
-	if batchVerifier.GetNumberOfEnqueuedSignatures() == 0 {
-		return true, nil
-	}
-	if err = batchVerifier.Verify(); err != nil {
-		return false, err
-	}
-	return true, nil
+	err = batchVerifier.Verify()
+	return
 }
 
-// MultisigBatchPrep verifies an assembled MultisigSig.
-// it is the caller responsibility to call batchVerifier.verify()
-func MultisigBatchPrep(msg Hashable, addr Digest, sig MultisigSig, batchVerifier *BatchVerifier) (verified bool, err error) {
-	verified = false
+// MultisigBatchPrep performs checks on the assembled MultisigSig and adds to the batch.
+// The caller must call batchVerifier.verify() to verify it.
+func MultisigBatchPrep(msg Hashable, addr Digest, sig MultisigSig, batchVerifier *BatchVerifier) (err error) {
 	// short circuit: if msig doesn't have subsigs or if Subsigs are empty
 	// then terminate (the upper layer should now verify the unisig)
 	if (len(sig.Subsigs) == 0 || sig.Subsigs[0] == MultisigSubsig{}) {
-		err = errInvalidNumberOfSignature
-		return
+		return errInvalidNumberOfSignature
 	}
 
 	// check the address is correct
@@ -251,20 +241,17 @@ func MultisigBatchPrep(msg Hashable, addr Digest, sig MultisigSig, batchVerifier
 		return
 	}
 	if addr != addrnew {
-		err = errInvalidAddress
-		return
+		return errInvalidAddress
 	}
 
 	// check that we don't have too many multisig subsigs
 	if len(sig.Subsigs) > maxMultisig {
-		err = errInvalidNumberOfSignature
-		return
+		return errInvalidNumberOfSignature
 	}
 
 	// check that we don't have too few multisig subsigs
 	if len(sig.Subsigs) < int(sig.Threshold) {
-		err = errInvalidNumberOfSignature
-		return
+		return errInvalidNumberOfSignature
 	}
 
 	// checks the number of non-blank signatures is no less than threshold
@@ -275,8 +262,7 @@ func MultisigBatchPrep(msg Hashable, addr Digest, sig MultisigSig, batchVerifier
 		}
 	}
 	if counter < sig.Threshold {
-		err = errInvalidNumberOfSignature
-		return
+		return errInvalidNumberOfSignature
 	}
 
 	// checks individual signature verifies
@@ -291,11 +277,8 @@ func MultisigBatchPrep(msg Hashable, addr Digest, sig MultisigSig, batchVerifier
 	// sanity check. if we get here then every non-blank subsig should have
 	// been verified successfully, and we should have had enough of them
 	if verifiedCount < int(sig.Threshold) {
-		err = errInvalidNumberOfSignature
-		return
+		return errInvalidNumberOfSignature
 	}
-
-	verified = true
 	return
 }
 

--- a/crypto/multisig.go
+++ b/crypto/multisig.go
@@ -266,17 +266,17 @@ func MultisigBatchPrep(msg Hashable, addr Digest, sig MultisigSig, batchVerifier
 	}
 
 	// checks individual signature verifies
-	var verifiedCount int
+	var sigCount int
 	for _, subsigi := range sig.Subsigs {
 		if (subsigi.Sig != Signature{}) {
 			batchVerifier.EnqueueSignature(subsigi.Key, msg, subsigi.Sig)
-			verifiedCount++
+			sigCount++
 		}
 	}
 
 	// sanity check. if we get here then every non-blank subsig should have
 	// been verified successfully, and we should have had enough of them
-	if verifiedCount < int(sig.Threshold) {
+	if sigCount < int(sig.Threshold) {
 		return errInvalidNumberOfSignature
 	}
 	return

--- a/crypto/multisig.go
+++ b/crypto/multisig.go
@@ -219,7 +219,7 @@ func MultisigAssemble(unisig []MultisigSig) (msig MultisigSig, err error) {
 func MultisigVerify(msg Hashable, addr Digest, sig MultisigSig) (verified bool, err error) {
 	batchVerifier := MakeBatchVerifier()
 
-	if verified, err = MultisigBatchVerify(msg, addr, sig, batchVerifier); err != nil {
+	if verified, err = MultisigBatchVerifyPrep(msg, addr, sig, batchVerifier); err != nil {
 		return
 	}
 	if !verified {
@@ -236,7 +236,7 @@ func MultisigVerify(msg Hashable, addr Digest, sig MultisigSig) (verified bool, 
 
 // MultisigBatchVerify verifies an assembled MultisigSig.
 // it is the caller responsibility to call batchVerifier.verify()
-func MultisigBatchVerify(msg Hashable, addr Digest, sig MultisigSig, batchVerifier *BatchVerifier) (verified bool, err error) {
+func MultisigBatchVerifyPrep(msg Hashable, addr Digest, sig MultisigSig, batchVerifier *BatchVerifier) (verified bool, err error) {
 	verified = false
 	// short circuit: if msig doesn't have subsigs or if Subsigs are empty
 	// then terminate (the upper layer should now verify the unisig)

--- a/crypto/multisig.go
+++ b/crypto/multisig.go
@@ -234,7 +234,7 @@ func MultisigVerify(msg Hashable, addr Digest, sig MultisigSig) (verified bool, 
 	return true, nil
 }
 
-// MultisigBatchVerify verifies an assembled MultisigSig.
+// MultisigBatchVerifyPrep verifies an assembled MultisigSig.
 // it is the caller responsibility to call batchVerifier.verify()
 func MultisigBatchVerifyPrep(msg Hashable, addr Digest, sig MultisigSig, batchVerifier *BatchVerifier) (verified bool, err error) {
 	verified = false

--- a/crypto/multisig.go
+++ b/crypto/multisig.go
@@ -219,7 +219,7 @@ func MultisigAssemble(unisig []MultisigSig) (msig MultisigSig, err error) {
 func MultisigVerify(msg Hashable, addr Digest, sig MultisigSig) (verified bool, err error) {
 	batchVerifier := MakeBatchVerifier()
 
-	if verified, err = MultisigBatchVerifyPrep(msg, addr, sig, batchVerifier); err != nil {
+	if verified, err = MultisigBatchPrep(msg, addr, sig, batchVerifier); err != nil {
 		return
 	}
 	if !verified {
@@ -234,9 +234,9 @@ func MultisigVerify(msg Hashable, addr Digest, sig MultisigSig) (verified bool, 
 	return true, nil
 }
 
-// MultisigBatchVerifyPrep verifies an assembled MultisigSig.
+// MultisigBatchPrep verifies an assembled MultisigSig.
 // it is the caller responsibility to call batchVerifier.verify()
-func MultisigBatchVerifyPrep(msg Hashable, addr Digest, sig MultisigSig, batchVerifier *BatchVerifier) (verified bool, err error) {
+func MultisigBatchPrep(msg Hashable, addr Digest, sig MultisigSig, batchVerifier *BatchVerifier) (verified bool, err error) {
 	verified = false
 	// short circuit: if msig doesn't have subsigs or if Subsigs are empty
 	// then terminate (the upper layer should now verify the unisig)

--- a/crypto/multisig_test.go
+++ b/crypto/multisig_test.go
@@ -142,7 +142,7 @@ func TestMultisig(t *testing.T) {
 
 	//test3: use the batch verification
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchVerifyPrep(txid, addr, msig, br)
+	verify, err = MultisigBatchPrep(txid, addr, msig, br)
 	require.NoError(t, err, "Multisig: unexpected verification failure with err")
 	require.True(t, verify, "Multisig: verification failed, verify flag was false")
 	res := br.Verify()
@@ -258,7 +258,7 @@ func TestEmptyMultisig(t *testing.T) {
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchVerifyPrep(txid, addr, emptyMutliSig, br)
+	verify, err = MultisigBatchPrep(txid, addr, emptyMutliSig, br)
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 }
@@ -286,7 +286,7 @@ func TestIncorrectAddrresInMultisig(t *testing.T) {
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchVerifyPrep(txid, addr, MutliSig, br)
+	verify, err = MultisigBatchPrep(txid, addr, MutliSig, br)
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 
@@ -325,7 +325,7 @@ func TestMoreThanMaxSigsInMultisig(t *testing.T) {
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchVerifyPrep(txid, addr, msig, br)
+	verify, err = MultisigBatchPrep(txid, addr, msig, br)
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 }
@@ -364,7 +364,7 @@ func TestOneSignatureIsEmpty(t *testing.T) {
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchVerifyPrep(txid, addr, msig, br)
+	verify, err = MultisigBatchPrep(txid, addr, msig, br)
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 }
@@ -405,7 +405,7 @@ func TestOneSignatureIsInvalid(t *testing.T) {
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchVerifyPrep(txid, addr, msig, br)
+	verify, err = MultisigBatchPrep(txid, addr, msig, br)
 	require.NoError(t, err, "Multisig: did not return error as expected")
 	require.True(t, verify, "Multisig: verification succeeded, it should failed")
 	res := br.Verify()

--- a/crypto/multisig_test.go
+++ b/crypto/multisig_test.go
@@ -142,7 +142,7 @@ func TestMultisig(t *testing.T) {
 
 	//test3: use the batch verification
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchVerify(txid, addr, msig, br)
+	verify, err = MultisigBatchVerifyPrep(txid, addr, msig, br)
 	require.NoError(t, err, "Multisig: unexpected verification failure with err")
 	require.True(t, verify, "Multisig: verification failed, verify flag was false")
 	res := br.Verify()
@@ -258,7 +258,7 @@ func TestEmptyMultisig(t *testing.T) {
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchVerify(txid, addr, emptyMutliSig, br)
+	verify, err = MultisigBatchVerifyPrep(txid, addr, emptyMutliSig, br)
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 }
@@ -286,7 +286,7 @@ func TestIncorrectAddrresInMultisig(t *testing.T) {
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchVerify(txid, addr, MutliSig, br)
+	verify, err = MultisigBatchVerifyPrep(txid, addr, MutliSig, br)
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 
@@ -325,7 +325,7 @@ func TestMoreThanMaxSigsInMultisig(t *testing.T) {
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchVerify(txid, addr, msig, br)
+	verify, err = MultisigBatchVerifyPrep(txid, addr, msig, br)
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 }
@@ -364,7 +364,7 @@ func TestOneSignatureIsEmpty(t *testing.T) {
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchVerify(txid, addr, msig, br)
+	verify, err = MultisigBatchVerifyPrep(txid, addr, msig, br)
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 }
@@ -405,7 +405,7 @@ func TestOneSignatureIsInvalid(t *testing.T) {
 	require.False(t, verify, "Multisig: verification succeeded, it should failed")
 	require.Error(t, err, "Multisig: did not return error as expected")
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchVerify(txid, addr, msig, br)
+	verify, err = MultisigBatchVerifyPrep(txid, addr, msig, br)
 	require.NoError(t, err, "Multisig: did not return error as expected")
 	require.True(t, verify, "Multisig: verification succeeded, it should failed")
 	res := br.Verify()

--- a/crypto/multisig_test.go
+++ b/crypto/multisig_test.go
@@ -136,15 +136,13 @@ func TestMultisig(t *testing.T) {
 	require.NoError(t, err, "Multisig: unexpected failure in generating sig from pk 2")
 	msig, err = MultisigAssemble(sigs)
 	require.NoError(t, err, "Multisig: unexpected failure when assembling multisig")
-	verify, err := MultisigVerify(txid, addr, msig)
+	err = MultisigVerify(txid, addr, msig)
 	require.NoError(t, err, "Multisig: unexpected verification failure with err")
-	require.True(t, verify, "Multisig: verification failed, verify flag was false")
 
 	//test3: use the batch verification
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchPrep(txid, addr, msig, br)
+	err = MultisigBatchPrep(txid, addr, msig, br)
 	require.NoError(t, err, "Multisig: unexpected verification failure with err")
-	require.True(t, verify, "Multisig: verification failed, verify flag was false")
 	res := br.Verify()
 	require.NoError(t, res, "Multisig: batch verification failed")
 }
@@ -200,8 +198,7 @@ func TestMultisigAddAndMerge(t *testing.T) {
 	require.NoError(t, err, "Multisig: unexpected failure signing with pk 2")
 	err = MultisigAdd(sigs, &msig1)
 	require.NoError(t, err, "Multisig: unexpected err adding pk 2 signature to that of pk 0 and 1")
-	verify, err := MultisigVerify(txid, addr, msig1)
-	require.True(t, verify, "Multisig: verification failed, verify flag was false")
+	err = MultisigVerify(txid, addr, msig1)
 	require.NoError(t, err, "Multisig: unexpected verification failure with err")
 
 	// msig2 = {sig3, sig4}
@@ -215,9 +212,8 @@ func TestMultisigAddAndMerge(t *testing.T) {
 	// merge two msigs and then verify
 	msigt, err := MultisigMerge(msig1, msig2)
 	require.NoError(t, err, "Multisig: unexpected failure merging multisig messages {0, 1, 2} and {3, 4}")
-	verify, err = MultisigVerify(txid, addr, msigt)
+	err = MultisigVerify(txid, addr, msigt)
 	require.NoError(t, err, "Multisig: unexpected verification failure with err")
-	require.True(t, verify, "Multisig: verification failed, verify flag was false")
 
 	// create a valid duplicate on purpose
 	// msig1 = {sig0, sig1, sig2}
@@ -230,9 +226,8 @@ func TestMultisigAddAndMerge(t *testing.T) {
 	require.NoError(t, err, "Multisig: unexpected failure adding pk 2 signature to that of pk 3 and 4")
 	msigt, err = MultisigMerge(msig1, msig2)
 	require.NoError(t, err, "Multisig: unexpected failure merging multisig messages {0, 1, 2} and {2, 3, 4}")
-	verify, err = MultisigVerify(txid, addr, msigt)
+	err = MultisigVerify(txid, addr, msigt)
 	require.NoError(t, err, "Multisig: unexpected verification failure with err")
-	require.True(t, verify, "Multisig: verification failed, verify flag was false")
 
 	return
 }
@@ -254,12 +249,10 @@ func TestEmptyMultisig(t *testing.T) {
 	addr, err := MultisigAddrGen(version, threshold, pks)
 	require.NoError(t, err, "Multisig: unexpected failure generating message digest")
 	emptyMutliSig := MultisigSig{Version: version, Threshold: threshold, Subsigs: make([]MultisigSubsig, 0)}
-	verify, err := MultisigVerify(txid, addr, emptyMutliSig)
-	require.False(t, verify, "Multisig: verification succeeded, it should failed")
+	err = MultisigVerify(txid, addr, emptyMutliSig)
 	require.Error(t, err, "Multisig: did not return error as expected")
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchPrep(txid, addr, emptyMutliSig, br)
-	require.False(t, verify, "Multisig: verification succeeded, it should failed")
+	err = MultisigBatchPrep(txid, addr, emptyMutliSig, br)
 	require.Error(t, err, "Multisig: did not return error as expected")
 }
 
@@ -282,12 +275,10 @@ func TestIncorrectAddrresInMultisig(t *testing.T) {
 	MutliSig, err := MultisigSign(txid, addr, version, threshold, pks, *secrets)
 	require.NoError(t, err, "Multisig: could not create mutlisig")
 	addr[0] = addr[0] + 1
-	verify, err := MultisigVerify(txid, addr, MutliSig)
-	require.False(t, verify, "Multisig: verification succeeded, it should failed")
+	err = MultisigVerify(txid, addr, MutliSig)
 	require.Error(t, err, "Multisig: did not return error as expected")
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchPrep(txid, addr, MutliSig, br)
-	require.False(t, verify, "Multisig: verification succeeded, it should failed")
+	err = MultisigBatchPrep(txid, addr, MutliSig, br)
 	require.Error(t, err, "Multisig: did not return error as expected")
 
 }
@@ -321,12 +312,10 @@ func TestMoreThanMaxSigsInMultisig(t *testing.T) {
 
 	msig, err := MultisigAssemble(sigs)
 	require.NoError(t, err, "Multisig: error assmeble multisig")
-	verify, err := MultisigVerify(txid, addr, msig)
-	require.False(t, verify, "Multisig: verification succeeded, it should failed")
+	err = MultisigVerify(txid, addr, msig)
 	require.Error(t, err, "Multisig: did not return error as expected")
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchPrep(txid, addr, msig, br)
-	require.False(t, verify, "Multisig: verification succeeded, it should failed")
+	err = MultisigBatchPrep(txid, addr, msig, br)
 	require.Error(t, err, "Multisig: did not return error as expected")
 }
 
@@ -360,12 +349,10 @@ func TestOneSignatureIsEmpty(t *testing.T) {
 	msig, err := MultisigAssemble(sigs)
 	require.NoError(t, err, "Multisig: error assmeble multisig")
 	msig.Subsigs[0].Sig = Signature{}
-	verify, err := MultisigVerify(txid, addr, msig)
-	require.False(t, verify, "Multisig: verification succeeded, it should failed")
+	err = MultisigVerify(txid, addr, msig)
 	require.Error(t, err, "Multisig: did not return error as expected")
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchPrep(txid, addr, msig, br)
-	require.False(t, verify, "Multisig: verification succeeded, it should failed")
+	err = MultisigBatchPrep(txid, addr, msig, br)
 	require.Error(t, err, "Multisig: did not return error as expected")
 }
 
@@ -401,13 +388,11 @@ func TestOneSignatureIsInvalid(t *testing.T) {
 	sigs[1].Subsigs[1].Sig[5] = sigs[1].Subsigs[1].Sig[5] + 1
 	msig, err := MultisigAssemble(sigs)
 	require.NoError(t, err, "Multisig: error assmeble multisig")
-	verify, err := MultisigVerify(txid, addr, msig)
-	require.False(t, verify, "Multisig: verification succeeded, it should failed")
+	err = MultisigVerify(txid, addr, msig)
 	require.Error(t, err, "Multisig: did not return error as expected")
 	br := MakeBatchVerifier()
-	verify, err = MultisigBatchPrep(txid, addr, msig, br)
+	err = MultisigBatchPrep(txid, addr, msig, br)
 	require.NoError(t, err, "Multisig: did not return error as expected")
-	require.True(t, verify, "Multisig: verification succeeded, it should failed")
 	res := br.Verify()
 	require.Error(t, res, "Multisig: batch verification passed on broken signature")
 
@@ -455,15 +440,13 @@ func TestMultisigLessThanTrashold(t *testing.T) {
 	msig, err = MultisigAssemble(sigs)
 	require.NoError(t, err, "should be able to detect insufficient signatures for assembling")
 	msig.Subsigs[1].Sig = BlankSignature
-	verify, err := MultisigVerify(txid, addr, msig)
-	require.False(t, verify, "Multisig: verification passed, should have failed")
+	err = MultisigVerify(txid, addr, msig)
 	require.Error(t, err, "Multisig: expected verification failure with err")
 
 	msig, err = MultisigAssemble(sigs)
 	require.NoError(t, err, "should be able to detect insufficient signatures for assembling")
 	msig.Subsigs = msig.Subsigs[:len(msig.Subsigs)-1]
-	verify, err = MultisigVerify(txid, addr, msig)
-	require.False(t, verify, "Multisig: verification passed, should have failed")
+	err = MultisigVerify(txid, addr, msig)
 	require.Error(t, err, "Multisig: expected verification failure with err")
 
 }

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -122,10 +122,6 @@ func TxnGroup(stxs []transactions.SignedTxn, contextHdr bookkeeping.BlockHeader,
 		return nil, err
 	}
 
-	if batchVerifier.GetNumberOfEnqueuedSignatures() == 0 {
-		return groupCtx, nil
-	}
-
 	if err := batchVerifier.Verify(); err != nil {
 		return nil, err
 	}
@@ -212,7 +208,7 @@ func stxnCoreChecks(s *transactions.SignedTxn, txnIdx int, groupCtx *GroupContex
 		return nil
 	}
 	if hasMsig {
-		if ok, _ := crypto.MultisigBatchVerify(s.Txn,
+		if ok, _ := crypto.MultisigBatchVerifyPrep(s.Txn,
 			crypto.Digest(s.Authorizer()),
 			s.Msig,
 			batchVerifier); ok {
@@ -308,7 +304,7 @@ func logicSigSanityCheckBatchVerifyPrep(txn *transactions.SignedTxn, groupIndex 
 		batchVerifier.EnqueueSignature(crypto.PublicKey(txn.Authorizer()), &program, lsig.Sig)
 	} else {
 		program := logic.Program(lsig.Logic)
-		if ok, _ := crypto.MultisigBatchVerify(&program, crypto.Digest(txn.Authorizer()), lsig.Msig, batchVerifier); !ok {
+		if ok, _ := crypto.MultisigBatchVerifyPrep(&program, crypto.Digest(txn.Authorizer()), lsig.Msig, batchVerifier); !ok {
 			return errors.New("logic multisig validation failed")
 		}
 	}

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -227,12 +227,6 @@ func LogicSigSanityCheck(txn *transactions.SignedTxn, groupIndex int, groupCtx *
 	if err := logicSigSanityCheckBatchPrep(txn, groupIndex, groupCtx, batchVerifier); err != nil {
 		return err
 	}
-
-	// in case of contract account the signature len might 0. that's ok
-	if batchVerifier.GetNumberOfEnqueuedSignatures() == 0 {
-		return nil
-	}
-
 	return batchVerifier.Verify()
 }
 
@@ -387,11 +381,9 @@ func PaysetGroups(ctx context.Context, payset [][]transactions.SignedTxn, blkHea
 							return grpErr
 						}
 					}
-					if batchVerifier.GetNumberOfEnqueuedSignatures() != 0 {
-						verifyErr := batchVerifier.Verify()
-						if verifyErr != nil {
-							return verifyErr
-						}
+					verifyErr := batchVerifier.Verify()
+					if verifyErr != nil {
+						return verifyErr
 					}
 					cache.AddPayset(txnGroups, groupCtxs)
 					return nil

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -315,6 +315,7 @@ func logicSigSanityCheckBatchVerifyPrep(txn *transactions.SignedTxn, groupIndex 
 	return nil
 }
 
+// logicSigVerify checks that the signature is valid, executing the program.
 func logicSigVerify(txn *transactions.SignedTxn, groupIndex int, groupCtx *GroupContext) error {
 	err := LogicSigSanityCheck(txn, groupIndex, groupCtx)
 	if err != nil {

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -475,17 +475,17 @@ func TestTxnGroupCacheUpdate(t *testing.T) {
 
 	// The txns should not be in the cache
 	unverifiedGroups := cache.GetUnverifiedTransactionGroups(txnGroups[:1], spec, protocol.ConsensusCurrentVersion)
-	require.Equal(t, 1, len(unverifiedGroups))
+	require.Len(t, unverifiedGroups, 1)
 
 	unverifiedGroups = cache.GetUnverifiedTransactionGroups(txnGroups[:2], spec, protocol.ConsensusCurrentVersion)
-	require.Equal(t, 2, len(unverifiedGroups))
+	require.Len(t, unverifiedGroups, 2)
 
 	_, err = TxnGroup(txnGroups[1], blkHdr, cache, nil)
 	require.NoError(t, err)
 
 	// Only the second txn should be in the cache
 	unverifiedGroups = cache.GetUnverifiedTransactionGroups(txnGroups[:2], spec, protocol.ConsensusCurrentVersion)
-	require.Equal(t, 1, len(unverifiedGroups))
+	require.Len(t, unverifiedGroups, 1)
 
 	// Fix the signature
 	txnGroups[0][0].Sig[0] = txnGroups[0][0].Sig[0] - 1
@@ -495,7 +495,7 @@ func TestTxnGroupCacheUpdate(t *testing.T) {
 
 	// Both transactions should be in the cache
 	unverifiedGroups = cache.GetUnverifiedTransactionGroups(txnGroups[:2], spec, protocol.ConsensusCurrentVersion)
-	require.Equal(t, 0, len(unverifiedGroups))
+	require.Len(t, unverifiedGroups, 0)
 
 	// Break a random signature
 	txgIdx := rand.Intn(len(txnGroups))
@@ -515,7 +515,7 @@ func TestTxnGroupCacheUpdate(t *testing.T) {
 
 	// Onle one transaction should not be in cache
 	unverifiedGroups = cache.GetUnverifiedTransactionGroups(txnGroups, spec, protocol.ConsensusCurrentVersion)
-	require.Equal(t, 1, len(unverifiedGroups))
+	require.Len(t, unverifiedGroups, 1)
 
 	require.Equal(t, unverifiedGroups[0], txnGroups[txgIdx])
 }

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -54,7 +54,7 @@ var spec = transactions.SpecialAddresses{
 func verifyTxn(s *transactions.SignedTxn, txnIdx int, groupCtx *GroupContext) error {
 	batchVerifier := crypto.MakeBatchVerifier()
 
-	if err := txnBatchVerifyPrep(s, txnIdx, groupCtx, batchVerifier); err != nil {
+	if err := txnBatchPrep(s, txnIdx, groupCtx, batchVerifier); err != nil {
 		return err
 	}
 

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -51,6 +51,20 @@ var spec = transactions.SpecialAddresses{
 	RewardsPool: poolAddr,
 }
 
+func verifyTxn(s *transactions.SignedTxn, txnIdx int, groupCtx *GroupContext) error {
+	batchVerifier := crypto.MakeBatchVerifier()
+
+	if err := txnBatchVerifyPrep(s, txnIdx, groupCtx, batchVerifier); err != nil {
+		return err
+	}
+
+	// this case is used for comapact certificate where no signature is supplied
+	if batchVerifier.GetNumberOfEnqueuedSignatures() == 0 {
+		return nil
+	}
+	return batchVerifier.Verify()
+}
+
 func keypair() *crypto.SignatureSecrets {
 	var seed crypto.Seed
 	crypto.RandBytes(seed[:])
@@ -117,14 +131,14 @@ func TestSignedPayment(t *testing.T) {
 	groupCtx, err := PrepareGroupContext(stxns, blockHeader, nil)
 	require.NoError(t, err)
 	require.NoError(t, payment.WellFormed(spec, proto), "generateTestObjects generated an invalid payment")
-	require.NoError(t, Txn(&stxn, 0, groupCtx), "generateTestObjects generated a bad signedtxn")
+	require.NoError(t, verifyTxn(&stxn, 0, groupCtx), "generateTestObjects generated a bad signedtxn")
 
 	stxn2 := payment.Sign(secret)
 	require.Equal(t, stxn2.Sig, stxn.Sig, "got two different signatures for the same transaction (our signing function is deterministic)")
 
 	stxn2.MessUpSigForTesting()
 	require.Equal(t, stxn.ID(), stxn2.ID(), "changing sig caused txid to change")
-	require.Error(t, Txn(&stxn2, 0, groupCtx), "verify succeeded with bad sig")
+	require.Error(t, verifyTxn(&stxn2, 0, groupCtx), "verify succeeded with bad sig")
 
 	require.True(t, crypto.SignatureVerifier(addr).Verify(payment, stxn.Sig), "signature on the transaction is not the signature of the hash of the transaction under the spender's key")
 }
@@ -137,7 +151,7 @@ func TestTxnValidationEncodeDecode(t *testing.T) {
 	for _, txn := range signed {
 		groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{txn}, blockHeader, nil)
 		require.NoError(t, err)
-		if Txn(&txn, 0, groupCtx) != nil {
+		if verifyTxn(&txn, 0, groupCtx) != nil {
 			t.Errorf("signed transaction %#v did not verify", txn)
 		}
 
@@ -145,7 +159,7 @@ func TestTxnValidationEncodeDecode(t *testing.T) {
 		var signedTx transactions.SignedTxn
 		protocol.Decode(x, &signedTx)
 
-		if Txn(&signedTx, 0, groupCtx) != nil {
+		if verifyTxn(&signedTx, 0, groupCtx) != nil {
 			t.Errorf("signed transaction %#v did not verify", txn)
 		}
 	}
@@ -159,14 +173,14 @@ func TestTxnValidationEmptySig(t *testing.T) {
 	for _, txn := range signed {
 		groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{txn}, blockHeader, nil)
 		require.NoError(t, err)
-		if Txn(&txn, 0, groupCtx) != nil {
+		if verifyTxn(&txn, 0, groupCtx) != nil {
 			t.Errorf("signed transaction %#v did not verify", txn)
 		}
 
 		txn.Sig = crypto.Signature{}
 		txn.Msig = crypto.MultisigSig{}
 		txn.Lsig = transactions.LogicSig{}
-		if Txn(&txn, 0, groupCtx) == nil {
+		if verifyTxn(&txn, 0, groupCtx) == nil {
 			t.Errorf("transaction %#v verified without sig", txn)
 		}
 	}
@@ -205,13 +219,13 @@ func TestTxnValidationStateProof(t *testing.T) {
 	groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{stxn}, blockHeader, nil)
 	require.NoError(t, err)
 
-	err = Txn(&stxn, 0, groupCtx)
+	err = verifyTxn(&stxn, 0, groupCtx)
 	require.NoError(t, err, "state proof txn %#v did not verify", stxn)
 
 	stxn2 := stxn
 	stxn2.Txn.Type = protocol.PaymentTx
 	stxn2.Txn.Header.Fee = basics.MicroAlgos{Raw: proto.MinTxnFee}
-	err = Txn(&stxn2, 0, groupCtx)
+	err = verifyTxn(&stxn2, 0, groupCtx)
 	require.Error(t, err, "payment txn %#v verified from StateProofSender", stxn2)
 
 	secret := keypair()
@@ -219,28 +233,28 @@ func TestTxnValidationStateProof(t *testing.T) {
 	stxn2.Txn.Header.Sender = basics.Address(secret.SignatureVerifier)
 	stxn2.Txn.Header.Fee = basics.MicroAlgos{Raw: proto.MinTxnFee}
 	stxn2 = stxn2.Txn.Sign(secret)
-	err = Txn(&stxn2, 0, groupCtx)
+	err = verifyTxn(&stxn2, 0, groupCtx)
 	require.Error(t, err, "state proof txn %#v verified from non-StateProofSender", stxn2)
 
 	// state proof txns are not allowed to have non-zero values for many fields
 	stxn2 = stxn
 	stxn2.Txn.Header.Fee = basics.MicroAlgos{Raw: proto.MinTxnFee}
-	err = Txn(&stxn2, 0, groupCtx)
+	err = verifyTxn(&stxn2, 0, groupCtx)
 	require.Error(t, err, "state proof txn %#v verified", stxn2)
 
 	stxn2 = stxn
 	stxn2.Txn.Header.Note = []byte{'A'}
-	err = Txn(&stxn2, 0, groupCtx)
+	err = verifyTxn(&stxn2, 0, groupCtx)
 	require.Error(t, err, "state proof txn %#v verified", stxn2)
 
 	stxn2 = stxn
 	stxn2.Txn.Lease[0] = 1
-	err = Txn(&stxn2, 0, groupCtx)
+	err = verifyTxn(&stxn2, 0, groupCtx)
 	require.Error(t, err, "state proof txn %#v verified", stxn2)
 
 	stxn2 = stxn
 	stxn2.Txn.RekeyTo = basics.Address(secret.SignatureVerifier)
-	err = Txn(&stxn2, 0, groupCtx)
+	err = verifyTxn(&stxn2, 0, groupCtx)
 	require.Error(t, err, "state proof txn %#v verified", stxn2)
 }
 
@@ -258,7 +272,7 @@ func TestDecodeNil(t *testing.T) {
 		// This used to panic when run on a zero value of SignedTxn.
 		groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{st}, blockHeader, nil)
 		require.NoError(t, err)
-		Txn(&st, 0, groupCtx)
+		verifyTxn(&st, 0, groupCtx)
 	}
 }
 
@@ -425,7 +439,7 @@ func BenchmarkTxn(b *testing.B) {
 		groupCtx, err := PrepareGroupContext(txnGroup, blk.BlockHeader, nil)
 		require.NoError(b, err)
 		for i, txn := range txnGroup {
-			err := Txn(&txn, i, groupCtx)
+			err := verifyTxn(&txn, i, groupCtx)
 			require.NoError(b, err)
 		}
 	}

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -57,10 +57,6 @@ func verifyTxn(s *transactions.SignedTxn, txnIdx int, groupCtx *GroupContext) er
 	if err := txnBatchPrep(s, txnIdx, groupCtx, batchVerifier); err != nil {
 		return err
 	}
-
-	if batchVerifier.GetNumberOfEnqueuedSignatures() == 0 {
-		return nil
-	}
 	return batchVerifier.Verify()
 }
 

--- a/test/e2e-go/kmd/e2e_kmd_wallet_multisig_test.go
+++ b/test/e2e-go/kmd/e2e_kmd_wallet_multisig_test.go
@@ -440,7 +440,6 @@ func TestMultisigSignProgram(t *testing.T) {
 	err = protocol.Decode(resp3.Multisig, &msig)
 	a.NoError(err)
 
-	ok, err := crypto.MultisigVerify(logic.Program(program), crypto.Digest(msigAddr), msig)
+	err = crypto.MultisigVerify(logic.Program(program), crypto.Digest(msigAddr), msig)
 	a.NoError(err)
-	a.True(ok)
 }

--- a/test/e2e-go/upgrades/rekey_support_test.go
+++ b/test/e2e-go/upgrades/rekey_support_test.go
@@ -128,8 +128,8 @@ func TestRekeyUpgrade(t *testing.T) {
 	_, err = client.BroadcastTransaction(rekeyed)
 	// non empty err means the upgrade have not happened yet (as expected), ensure the error
 	if err != nil {
-		// should be either "nonempty AuthAddr but rekeying not supported" or "txn dead"
-		if !strings.Contains(err.Error(), "nonempty AuthAddr but rekeying not supported") &&
+		// should be either "nonempty AuthAddr but rekeying is not supported" or "txn dead"
+		if !strings.Contains(err.Error(), "nonempty AuthAddr but rekeying is not supported") &&
 			!strings.Contains(err.Error(), "txn dead") {
 			a.NoErrorf(err, "error message should be one of :\n%s\n%s", "nonempty AuthAddr but rekeying not supported", "txn dead")
 		}

--- a/test/e2e-go/upgrades/rekey_support_test.go
+++ b/test/e2e-go/upgrades/rekey_support_test.go
@@ -131,7 +131,7 @@ func TestRekeyUpgrade(t *testing.T) {
 		// should be either "nonempty AuthAddr but rekeying is not supported" or "txn dead"
 		if !strings.Contains(err.Error(), "nonempty AuthAddr but rekeying is not supported") &&
 			!strings.Contains(err.Error(), "txn dead") {
-			a.NoErrorf(err, "error message should be one of :\n%s\n%s", "nonempty AuthAddr but rekeying not supported", "txn dead")
+			a.NoErrorf(err, "error message should be one of :\n%s\n%s", "nonempty AuthAddr but rekeying is not supported", "txn dead")
 		}
 	} else {
 		// if we had no error it must mean that we've upgraded already. Verify that.


### PR DESCRIPTION
Rename and make local functions which are internal to the package. 
The purpose is to enhance the code readability. 
Also removing a function which is not used.