### PR TITLE
ledger: fix TestCatchpointReadDatabaseOverflowSingleAccount

### DIFF
--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -426,6 +426,7 @@ func TestCatchpointReadDatabaseOverflowSingleAccount(t *testing.T) {
 
 	accts := ledgertesting.RandomAccounts(1, false)
 	// force acct to have overflowing number of resources
+	assetIndex := 1000
 	for addr, acct := range accts {
 		if acct.AssetParams == nil {
 			acct.AssetParams = make(map[basics.AssetIndex]basics.AssetParams, 0)
@@ -433,7 +434,8 @@ func TestCatchpointReadDatabaseOverflowSingleAccount(t *testing.T) {
 		}
 		for i := uint64(0); i < 20; i++ {
 			ap := ledgertesting.RandomAssetParams()
-			acct.AssetParams[basics.AssetIndex(i+100)] = ap
+			acct.AssetParams[basics.AssetIndex(assetIndex)] = ap
+			assetIndex++
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Fixed the TestCatchpointReadDatabaseOverflowSingleAccount test. It was failing due to the same reason as the TestCatchpointReadDatabaseOverflowAccounts test. The fix is exactly the same as https://github.com/algorand/go-algorand/pull/4480.



## Test Plan

This is a test. 

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
