### PR TITLE
network: proposal payload compression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 )
 
 require (
+	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/chrismcguire/gobberish v0.0.0-20150821175641-1d8adb509a0e // indirect
 	github.com/cpuguy83/go-md2man v1.0.8 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
+github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/algorand/avm-abi v0.1.0 h1:znZFQXpSUVYz37vXbaH5OZG2VK4snTyXwnc/tV9CVr4=
 github.com/algorand/avm-abi v0.1.0/go.mod h1:+CgwM46dithy850bpTeHh9MC99zpn2Snirb3QTl2O/g=
 github.com/algorand/falcon v0.0.0-20220727072124-02a2a64c4414 h1:nwYN+GQ7Z5OOfZwqBO1ma7DSlP7S1YrKWICOyjkwqrc=

--- a/network/msgCompressor.go
+++ b/network/msgCompressor.go
@@ -103,7 +103,7 @@ func (dec zstdProposalDecompressor) accept(data []byte) bool {
 func (dec zstdProposalDecompressor) convert(data []byte) ([]byte, error) {
 	r := zstd.NewReader(bytes.NewReader(data))
 	defer r.Close()
-	b := make([]byte, 0, 1024)
+	b := make([]byte, 0, 3*len(data))
 	for {
 		if len(b) == cap(b) {
 			// grow capacity, retain length

--- a/network/msgCompressor.go
+++ b/network/msgCompressor.go
@@ -109,9 +109,8 @@ func (c *wsPeerMsgDataConverter) convert(tag protocol.Tag, data []byte) ([]byte,
 		// in this case it sends non-compressed payload - the receiver decompress only if it is compressed.
 		if len(data) > 4 && bytes.Equal(data[:4], zstdCompressionMagic[:]) {
 			return c.zstdDecompress(data)
-		} else {
-			c.log.Warnf("peer %s supported zstd but sent non-compressed data", c.origin)
 		}
+		c.log.Warnf("peer %s supported zstd but sent non-compressed data", c.origin)
 	}
 	return data, nil
 }

--- a/network/msgCompressor.go
+++ b/network/msgCompressor.go
@@ -32,23 +32,21 @@ var zstdCompressionMagic = [4]byte{0x28, 0xb5, 0x2f, 0xfd}
 const zstdCompressionLevel = zstd.BestSpeed
 
 // checkCanCompress checks if there is an proposal payload message and peers supporting compression
-func checkCanCompress(request broadcastRequest, prio bool, peers []*wsPeer) bool {
+func checkCanCompress(request broadcastRequest, peers []*wsPeer) bool {
 	canCompress := false
-	if prio {
-		hasPP := false
-		for _, tag := range request.tags {
-			if tag == protocol.ProposalPayloadTag {
-				hasPP = true
-				break
-			}
+	hasPP := false
+	for _, tag := range request.tags {
+		if tag == protocol.ProposalPayloadTag {
+			hasPP = true
+			break
 		}
-		// if have proposal payload check if there are any peers supporting compression
-		if hasPP {
-			for _, peer := range peers {
-				if peer.vfCompressedProposalSupported() {
-					canCompress = true
-					break
-				}
+	}
+	// if have proposal payload check if there are any peers supporting compression
+	if hasPP {
+		for _, peer := range peers {
+			if peer.vfCompressedProposalSupported() {
+				canCompress = true
+				break
 			}
 		}
 	}
@@ -108,6 +106,7 @@ func (dec zstdProposalDecompressor) convert(data []byte) ([]byte, error) {
 	b := make([]byte, 0, 1024)
 	for {
 		if len(b) == cap(b) {
+			// grow capacity, retain length
 			b = append(b, 0)[:len(b)]
 		}
 		n, err := r.Read(b[len(b):cap(b)])

--- a/network/msgCompressor.go
+++ b/network/msgCompressor.go
@@ -1,0 +1,125 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/DataDog/zstd"
+
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/protocol"
+)
+
+var zstdCompressionMagic = [4]byte{0x28, 0xb5, 0x2f, 0xfd}
+
+// checkCanCompress checks if there is an proposal payload message and peers supporting compression
+func checkCanCompress(request broadcastRequest, prio bool, peers []*wsPeer) bool {
+	canCompress := false
+	if prio {
+		hasPP := false
+		for _, tag := range request.tags {
+			if tag == protocol.ProposalPayloadTag {
+				hasPP = true
+				break
+			}
+		}
+		// if have proposal payload check if there are any peers supporting compression
+		if hasPP {
+			for _, peer := range peers {
+				if peer.vfCompressedProposalSupported() {
+					canCompress = true
+					break
+				}
+			}
+		}
+	}
+	return canCompress
+}
+
+// zstdCompressMsg returns a concatenation of a tag and compressed data
+func zstdCompressMsg(tbytes []byte, d []byte) ([]byte, string) {
+	bound := zstd.CompressBound(len(d))
+	mbytesComp := make([]byte, len(tbytes)+bound)
+	copy(mbytesComp, tbytes)
+	comp, err := zstd.Compress(mbytesComp[len(tbytes):], d)
+	if err != nil {
+		// fallback and reuse non-compressed original data
+		logMsg := fmt.Sprintf("failed to compress into buffer of len %d: %v", len(d), err)
+		copied := copy(mbytesComp[len(tbytes):], d)
+		return mbytesComp[:len(tbytes)+copied], logMsg
+	}
+	mbytesComp = mbytesComp[:len(tbytes)+len(comp)]
+	return mbytesComp, ""
+}
+
+// MaxDecompressedMessageSize defines a maximum decompressed data size
+// to prevent zip bombs
+const MaxDecompressedMessageSize = 20 * 1024 * 1024 // some large enough value
+
+// wsPeerMsgDataConverter performs optional incoming messages conversion.
+// At the moment it only supports zstd decompression for payload proposal
+type wsPeerMsgDataConverter struct {
+	log                             logging.Logger
+	origin                          string
+	shouldDecompressProposalPayload bool
+}
+
+func (c *wsPeerMsgDataConverter) zstdDecompress(data []byte) ([]byte, error) {
+	r := zstd.NewReader(bytes.NewReader(data))
+	defer r.Close()
+	b := make([]byte, 0, 1024)
+	for {
+		if len(b) == cap(b) {
+			b = append(b, 0)[:len(b)]
+		}
+		n, err := r.Read(b[len(b):cap(b)])
+		b = b[:len(b)+n]
+		if err != nil {
+			if err == io.EOF {
+				return b, nil
+			}
+			return nil, err
+		}
+		if len(b) > MaxDecompressedMessageSize {
+			return nil, fmt.Errorf("proposal from peer %s data is too large: %d", c.origin, len(b))
+		}
+	}
+}
+
+func (c *wsPeerMsgDataConverter) convert(tag protocol.Tag, data []byte) ([]byte, error) {
+	if tag == protocol.ProposalPayloadTag && c.shouldDecompressProposalPayload {
+		// sender might support compressed payload but fail to compress for whatever reason,
+		// in this case it sends non-compressed payload - the receiver decompress only if it is compressed.
+		if len(data) > 4 && bytes.Equal(data[:4], zstdCompressionMagic[:]) {
+			return c.zstdDecompress(data)
+		} else {
+			c.log.Warnf("peer %s supported zstd but sent non-compressed data", c.origin)
+		}
+	}
+	return data, nil
+}
+
+func makeWsPeerMsgDataConverter(wp *wsPeer) *wsPeerMsgDataConverter {
+	return &wsPeerMsgDataConverter{
+		log:                             wp.net.log,
+		origin:                          wp.originAddress,
+		shouldDecompressProposalPayload: wp.vfCompressedProposalSupported(),
+	}
+}

--- a/network/msgCompressor.go
+++ b/network/msgCompressor.go
@@ -44,7 +44,7 @@ func checkCanCompress(request broadcastRequest, peers []*wsPeer) bool {
 	// if have proposal payload check if there are any peers supporting compression
 	if hasPP {
 		for _, peer := range peers {
-			if peer.vfCompressedProposalSupported() {
+			if peer.pfProposalCompressionSupported() {
 				canCompress = true
 				break
 			}
@@ -147,7 +147,7 @@ func makeWsPeerMsgDataConverter(wp *wsPeer) *wsPeerMsgDataConverter {
 		origin: wp.originAddress,
 	}
 
-	if wp.vfCompressedProposalSupported() {
+	if wp.pfProposalCompressionSupported() {
 		c.ppdec = zstdProposalDecompressor{
 			active: true,
 		}

--- a/network/msgCompressor_test.go
+++ b/network/msgCompressor_test.go
@@ -51,36 +51,31 @@ func TestZstdDecompress(t *testing.T) {
 func TestCheckCanCompress(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	prio := false
 	req := broadcastRequest{}
 	peers := []*wsPeer{}
-	r := checkCanCompress(req, prio, peers)
-	require.False(t, r)
-
-	prio = true
-	r = checkCanCompress(req, prio, peers)
+	r := checkCanCompress(req, peers)
 	require.False(t, r)
 
 	req.tags = []protocol.Tag{protocol.AgreementVoteTag}
-	r = checkCanCompress(req, prio, peers)
+	r = checkCanCompress(req, peers)
 	require.False(t, r)
 
 	req.tags = []protocol.Tag{protocol.AgreementVoteTag, protocol.ProposalPayloadTag}
-	r = checkCanCompress(req, prio, peers)
+	r = checkCanCompress(req, peers)
 	require.False(t, r)
 
 	peer1 := wsPeer{
 		features: 0,
 	}
 	peers = []*wsPeer{&peer1}
-	r = checkCanCompress(req, prio, peers)
+	r = checkCanCompress(req, peers)
 	require.False(t, r)
 
 	peer2 := wsPeer{
 		features: vfCompressedProposal,
 	}
 	peers = []*wsPeer{&peer1, &peer2}
-	r = checkCanCompress(req, prio, peers)
+	r = checkCanCompress(req, peers)
 	require.True(t, r)
 }
 

--- a/network/msgCompressor_test.go
+++ b/network/msgCompressor_test.go
@@ -1,0 +1,146 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DataDog/zstd"
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZstdDecompress(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	// happy case - small message
+	msg := []byte(strings.Repeat("1", 2048))
+	compressed, err := zstd.Compress(nil, msg)
+	require.NoError(t, err)
+	c := wsPeerMsgDataConverter{}
+	decompressed, err := c.zstdDecompress(compressed)
+	require.NoError(t, err)
+	require.Equal(t, msg, decompressed)
+
+	// error case - large message
+	msg = []byte(strings.Repeat("1", MaxDecompressedMessageSize+10))
+	compressed, err = zstd.Compress(nil, msg)
+	require.NoError(t, err)
+	decompressed, err = c.zstdDecompress(compressed)
+	require.Error(t, err)
+	require.Nil(t, decompressed)
+}
+
+func TestCheckCanCompress(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	prio := false
+	req := broadcastRequest{}
+	peers := []*wsPeer{}
+	r := checkCanCompress(req, prio, peers)
+	require.False(t, r)
+
+	prio = true
+	r = checkCanCompress(req, prio, peers)
+	require.False(t, r)
+
+	req.tags = []protocol.Tag{protocol.AgreementVoteTag}
+	r = checkCanCompress(req, prio, peers)
+	require.False(t, r)
+
+	req.tags = []protocol.Tag{protocol.AgreementVoteTag, protocol.ProposalPayloadTag}
+	r = checkCanCompress(req, prio, peers)
+	require.False(t, r)
+
+	peer1 := wsPeer{
+		features: 0,
+	}
+	peers = []*wsPeer{&peer1}
+	r = checkCanCompress(req, prio, peers)
+	require.False(t, r)
+
+	peer2 := wsPeer{
+		features: vfCompressedProposal,
+	}
+	peers = []*wsPeer{&peer1, &peer2}
+	r = checkCanCompress(req, prio, peers)
+	require.True(t, r)
+}
+
+func TestZstdCompressMsg(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	ppt := len(protocol.ProposalPayloadTag)
+	data := []byte("data")
+	comp, msg := zstdCompressMsg([]byte(protocol.ProposalPayloadTag), data)
+	require.Empty(t, msg)
+	require.Equal(t, []byte(protocol.ProposalPayloadTag), comp[:ppt])
+	require.Equal(t, zstdCompressionMagic[:], comp[ppt:ppt+len(zstdCompressionMagic)])
+	c := wsPeerMsgDataConverter{}
+	decompressed, err := c.zstdDecompress(comp[ppt:])
+	require.NoError(t, err)
+	require.Equal(t, data, decompressed)
+}
+
+type converterTestLogger struct {
+	logging.Logger
+	WarnfCallback func(string, ...interface{})
+	warnMsgCount  int
+}
+
+func (cl *converterTestLogger) Warnf(s string, args ...interface{}) {
+	cl.warnMsgCount++
+}
+
+func TestWsPeerMsgDataConverterConvert(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	c := wsPeerMsgDataConverter{}
+	tag := protocol.AgreementVoteTag
+	data := []byte("data")
+
+	r, err := c.convert(tag, data)
+	require.NoError(t, err)
+	require.Equal(t, data, r)
+
+	tag = protocol.ProposalPayloadTag
+	r, err = c.convert(tag, data)
+	require.NoError(t, err)
+	require.Equal(t, data, r)
+
+	l := converterTestLogger{}
+	c.log = &l
+	c.shouldDecompressProposalPayload = true
+	r, err = c.convert(tag, data)
+	require.NoError(t, err)
+	require.Equal(t, data, r)
+	require.Equal(t, 1, l.warnMsgCount)
+
+	l = converterTestLogger{}
+	c.log = &l
+
+	comp, err := zstd.Compress(nil, data)
+	require.NoError(t, err)
+
+	r, err = c.convert(tag, comp)
+	require.NoError(t, err)
+	require.Equal(t, data, r)
+	require.Equal(t, 0, l.warnMsgCount)
+}

--- a/network/msgCompressor_test.go
+++ b/network/msgCompressor_test.go
@@ -72,7 +72,7 @@ func TestCheckCanCompress(t *testing.T) {
 	require.False(t, r)
 
 	peer2 := wsPeer{
-		features: vfCompressedProposal,
+		features: pfCompressedProposal,
 	}
 	peers = []*wsPeer{&peer1, &peer2}
 	r = checkCanCompress(req, peers)

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1492,10 +1492,8 @@ func (wn *WebsocketNetwork) innerBroadcast(request broadcastRequest, prio bool, 
 	digests := make([]crypto.Digest, len(request.data))
 	data := make([][]byte, len(request.data))
 	var dataCompressed [][]byte
-	var digestsCompressed []crypto.Digest
 	if needCompressedData {
 		dataCompressed = make([][]byte, len(request.data))
-		digestsCompressed = make([]crypto.Digest, len(request.data))
 	}
 	for i, d := range request.data {
 		tbytes := []byte(request.tags[i])
@@ -1515,9 +1513,6 @@ func (wn *WebsocketNetwork) innerBroadcast(request broadcastRequest, prio bool, 
 				// otherwise reuse non-compressed from above
 				dataCompressed[i] = mbytes
 			}
-			if request.tags[i] != protocol.MsgDigestSkipTag && len(d) >= messageFilterSize {
-				digestsCompressed[i] = crypto.Hash(dataCompressed[i])
-			}
 		}
 	}
 
@@ -1532,7 +1527,7 @@ func (wn *WebsocketNetwork) innerBroadcast(request broadcastRequest, prio bool, 
 		}
 		var ok bool
 		if peer.features&vfCompressedProposal != 0 && needCompressedData {
-			ok = peer.writeNonBlockMsgs(request.ctx, dataCompressed, prio, digestsCompressed, request.enqueueTime)
+			ok = peer.writeNonBlockMsgs(request.ctx, dataCompressed, prio, digests, request.enqueueTime)
 		} else {
 			ok = peer.writeNonBlockMsgs(request.ctx, data, prio, digests, request.enqueueTime)
 		}

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1511,7 +1511,7 @@ func (wn *WebsocketNetwork) innerBroadcast(request broadcastRequest, prio bool, 
 			continue
 		}
 		var ok bool
-		if peer.vfCompressedProposalSupported() && len(dataWithCompression) > 0 {
+		if peer.pfProposalCompressionSupported() && len(dataWithCompression) > 0 {
 			// if this peer supports compressed proposals and compressed data batch is filled out, use it
 			ok = peer.writeNonBlockMsgs(request.ctx, dataWithCompression, prio, digests, request.enqueueTime)
 			if prio {

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -2142,6 +2142,7 @@ func (wn *WebsocketNetwork) tryConnect(addr, gossipAddr string) {
 		connMonitor:                 wn.connPerfMonitor,
 		throttledOutgoingConnection: throttledConnection,
 		version:                     matchingVersion,
+		features:                    versionToFeatures(matchingVersion),
 	}
 	peer.TelemetryGUID, peer.InstanceName, _ = getCommonHeaders(response.Header)
 	peer.init(wn.config, wn.outgoingMessagesBufferSize)

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1436,7 +1436,10 @@ func (wn *WebsocketNetwork) peerSnapshot(dest []*wsPeer) ([]*wsPeer, int32) {
 // It performs optional zstd compression for proposal massages
 func (wn *WebsocketNetwork) preparePeerData(request broadcastRequest, prio bool, peers []*wsPeer) ([][]byte, [][]byte, []crypto.Digest) {
 	// determine if there is a payload proposal and peers supporting compressed payloads
-	wantCompression := checkCanCompress(request, prio, peers)
+	wantCompression := false
+	if prio {
+		wantCompression = checkCanCompress(request, peers)
+	}
 
 	digests := make([]crypto.Digest, len(request.data))
 	data := make([][]byte, len(request.data))

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -2714,7 +2714,7 @@ func TestPreparePeerData(t *testing.T) {
 		features: 0,
 	}
 	peer2 := wsPeer{
-		features: vfCompressedProposal,
+		features: pfCompressedProposal,
 	}
 	peers = []*wsPeer{&peer1, &peer2}
 	data, comp, digests = wn.preparePeerData(req, true, peers)

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -480,9 +480,6 @@ func (wp *wsPeer) readLoop() {
 		msg.processing = wp.processed
 		msg.Received = time.Now().UnixNano()
 		msg.Data = slurper.Bytes()
-		if msg.Tag == protocol.ProposalPayloadTag {
-			fmt.Printf("%v\n", msg.Data)
-		}
 		if msg.Tag == protocol.ProposalPayloadTag &&
 			wp.features&vfCompressedProposal != 0 &&
 			len(msg.Data) > 4 &&

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -480,8 +480,12 @@ func (wp *wsPeer) readLoop() {
 		msg.processing = wp.processed
 		msg.Received = time.Now().UnixNano()
 		msg.Data = slurper.Bytes()
+		if msg.Tag == protocol.ProposalPayloadTag {
+			fmt.Printf("%v\n", msg.Data)
+		}
 		if msg.Tag == protocol.ProposalPayloadTag &&
 			wp.features&vfCompressedProposal != 0 &&
+			len(msg.Data) > 4 &&
 			bytes.Equal(msg.Data[:4], zstdCompressionMagic[:]) {
 			msg.Data, err = zstd.Decompress(nil, msg.Data)
 			if err != nil {

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -942,7 +942,7 @@ func (wp *wsPeer) sendMessagesOfInterest(messagesOfInterestGeneration uint32, me
 	}
 }
 
-func (wp *wsPeer) vfCompressedProposalSupported() bool {
+func (wp *wsPeer) pfProposalCompressionSupported() bool {
 	return wp.features&pfCompressedProposal != 0
 }
 


### PR DESCRIPTION
## Summary

Inproduce proposal payload compression in protocol version 2.2.

Acceptance:
1. Unit tests incl 2.1 and 2.2 peers mix
2. All e2e tests pass
3. Manual test master and feature nodes on TwoNodes50Each template

## Testing

- [x] Unit test checking old + new ws protocol combinations
- [x] Manual TwoNotes50Each test with master (m) + feature (f)
- [x] Manual ThreeNodesEvenDist test with [m]m+f, m+f[f] where [r] is a relay node
- [x] Perf test

## Possible optimization

If all peers support compressed proposals, do not allocate memory for non-compressed data batch. Possibly in another PR.