### PR TITLE
Better Benchmarking DB query in avm-box

### DIFF
--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -1133,10 +1133,12 @@ func BenchmarkLookupKeyByPrefix(b *testing.B) {
 		nextDBSize *= increment
 
 		b.Run("lookupKVByPrefix-DBsize"+strconv.Itoa(currentDBSize), func(b *testing.B) {
-			results := make(map[string]bool)
-			_, err := qs.lookupKeysByPrefix(prefix, uint64(currentDBSize), results, 0)
-			require.NoError(b, err)
-			require.True(b, len(results) >= 1)
+			for i := 0; i < b.N; i++ {
+				results := make(map[string]bool)
+				_, err := qs.lookupKeysByPrefix(prefix, uint64(currentDBSize), results, 0)
+				require.NoError(b, err)
+				require.True(b, len(results) >= 1)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

Using `b.N` to rerun the benchmark test, such that the benchmark number looks more reasonable and consistent.

The benchmark result is more reasonable now:
```
go test -benchmem -run=^$ -bench ^BenchmarkLookupKeyByPrefix$ github.com/algorand/go-algorand/ledger
goos: darwin
goarch: arm64
pkg: github.com/algorand/go-algorand/ledger
BenchmarkLookupKeyByPrefix/lookupKVByPrefix-DBsize4-10         	  295464	      4067 ns/op	     992 B/op	      42 allocs/op
BenchmarkLookupKeyByPrefix/lookupKVByPrefix-DBsize16-10        	  245655	      4754 ns/op	     992 B/op	      42 allocs/op
BenchmarkLookupKeyByPrefix/lookupKVByPrefix-DBsize64-10        	  158940	      7450 ns/op	     992 B/op	      42 allocs/op
BenchmarkLookupKeyByPrefix/lookupKVByPrefix-DBsize256-10       	   66130	     18040 ns/op	     992 B/op	      42 allocs/op
BenchmarkLookupKeyByPrefix/lookupKVByPrefix-DBsize1024-10      	   19956	     60110 ns/op	     992 B/op	      42 allocs/op
BenchmarkLookupKeyByPrefix/lookupKVByPrefix-DBsize4096-10      	    4958	    236905 ns/op	     992 B/op	      42 allocs/op
BenchmarkLookupKeyByPrefix/lookupKVByPrefix-DBsize16384-10     	    1286	    921900 ns/op	     992 B/op	      42 allocs/op
BenchmarkLookupKeyByPrefix/lookupKVByPrefix-DBsize65536-10     	     325	   3663356 ns/op	     992 B/op	      42 allocs/op
BenchmarkLookupKeyByPrefix/lookupKVByPrefix-DBsize262144-10    	      76	  15481009 ns/op	     992 B/op	      42 allocs/op
BenchmarkLookupKeyByPrefix/lookupKVByPrefix-DBsize1048576-10   	      16	  63826320 ns/op	     993 B/op	      42 allocs/op
BenchmarkLookupKeyByPrefix/lookupKVByPrefix-DBsize4194304-10   	       4	 259755125 ns/op	     992 B/op	      42 allocs/op
PASS
ok  	github.com/algorand/go-algorand/ledger	44.107s
```