### PR TITLE
Algod: state-proof key deletion safety

### DIFF
--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -232,7 +232,7 @@ type ParticipationRegistry interface {
 	// once, an error will occur when the data is flushed when inserting a duplicate key.
 	AppendKeys(id ParticipationID, keys StateProofKeys) error
 
-	// DeleteStateProofKeys removes all stateproof keys preceding a given round (excluded)
+	// DeleteStateProofKeys removes all stateproof keys up to, and not including, a given round
 	DeleteStateProofKeys(id ParticipationID, round basics.Round) error
 
 	// Delete removes a record from storage.

--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -232,7 +232,7 @@ type ParticipationRegistry interface {
 	// once, an error will occur when the data is flushed when inserting a duplicate key.
 	AppendKeys(id ParticipationID, keys StateProofKeys) error
 
-	// DeleteStateProofKeys removes all stateproof keys preceding a given round (including)
+	// DeleteStateProofKeys removes all stateproof keys preceding a given round (excluded)
 	DeleteStateProofKeys(id ParticipationID, round basics.Round) error
 
 	// Delete removes a record from storage.
@@ -347,7 +347,7 @@ const (
 	insertKeysetQuery         = `INSERT INTO Keysets (participationID, account, firstValidRound, lastValidRound, keyDilution, vrf, stateProof) VALUES (?, ?, ?, ?, ?, ?, ?)`
 	insertRollingQuery        = `INSERT INTO Rolling (pk, voting) VALUES (?, ?)`
 	appendStateProofKeysQuery = `INSERT INTO StateProofKeys (pk, round, key) VALUES(?, ?, ?)`
-	deleteStateProofKeysQuery = `DELETE FROM StateProofKeys WHERE pk=? AND round<=?`
+	deleteStateProofKeysQuery = `DELETE FROM StateProofKeys WHERE pk=? AND round<?`
 
 	// SELECT pk FROM Keysets WHERE participationID = ?
 	selectPK      = `SELECT pk FROM Keysets WHERE participationID = ? LIMIT 1`

--- a/data/accountManager.go
+++ b/data/accountManager.go
@@ -45,8 +45,8 @@ type AccountManager struct {
 	log      logging.Logger
 }
 
-// DeleteStateProofKey deletes all keys connected to ParticipationID that came before the given round.
-// The round is excluded.
+// DeleteStateProofKey deletes keys related to a ParticipationID. The function removes
+// all keys up to, and not including, a given round the given round.
 func (manager *AccountManager) DeleteStateProofKey(id account.ParticipationID, round basics.Round) error {
 	return manager.registry.DeleteStateProofKeys(id, round)
 }
@@ -62,14 +62,14 @@ func MakeAccountManager(log logging.Logger, registry account.ParticipationRegist
 	return manager
 }
 
-// RemoveStateProofKeysForExpiredAccounts removes ephemeral keys for every expired account
-func (manager *AccountManager) RemoveStateProofKeysForExpiredAccounts(currentRound basics.Round) {
+// DeleteStateProofKeysForExpiredAccounts removes ephemeral keys for every expired account
+func (manager *AccountManager) DeleteStateProofKeysForExpiredAccounts(currentRound basics.Round) {
 	for _, part := range manager.registry.GetAll() {
 		if currentRound <= part.LastValid {
 			continue
 		}
 		// since DeleteStateProofKeys doesn't remove the last round, we add one to make sure all secrets are being removed
-		if err := manager.registry.DeleteStateProofKeys(part.ParticipationID, part.LastValid+1); err != nil {
+		if err := manager.DeleteStateProofKey(part.ParticipationID, part.LastValid+1); err != nil {
 			manager.log.Warnf("error while removing state proof keys for participant %v on round %v: %v", part.ParticipationID, part.LastValid+1, err)
 		}
 	}

--- a/data/accountManager.go
+++ b/data/accountManager.go
@@ -45,7 +45,8 @@ type AccountManager struct {
 	log      logging.Logger
 }
 
-// DeleteStateProofKey deletes all keys connected to ParticipationID that came before (including) the given round.
+// DeleteStateProofKey deletes all keys connected to ParticipationID that came before the given round.
+// The round is excluded.
 func (manager *AccountManager) DeleteStateProofKey(id account.ParticipationID, round basics.Round) error {
 	return manager.registry.DeleteStateProofKeys(id, round)
 }

--- a/data/accountManager.go
+++ b/data/accountManager.go
@@ -96,7 +96,7 @@ func (manager *AccountManager) StateProofKeys(rnd basics.Round) (out []account.S
 		if part.StateProof != nil && part.OverlapsInterval(rnd, rnd) {
 			partRndSecrets, err := manager.registry.GetStateProofSecretsForRound(part.ParticipationID, rnd)
 			if err != nil {
-				manager.log.Errorf("error while loading round secrets from participation registry: %v", err)
+				manager.log.Warnf("could not load state proof keys from participation registry: %v", err)
 				continue
 			}
 			out = append(out, partRndSecrets)

--- a/data/accountManager_test.go
+++ b/data/accountManager_test.go
@@ -250,6 +250,63 @@ func TestAccountManagerOverlappingStateProofKeys(t *testing.T) {
 	a.Equal(1, len(res))
 }
 
+func TestAccountManagerRemoveStateProofKeysForExpiredAccounts(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := assert.New(t)
+
+	registry, dbName := getRegistryImpl(t, false, true)
+	defer registryCloseTest(t, registry, dbName)
+
+	log := logging.TestingLog(t)
+	log.SetLevel(logging.Error)
+
+	acctManager := MakeAccountManager(log, registry)
+
+	databaseFiles := make([]string, 0)
+	defer func() {
+		for _, fileName := range databaseFiles {
+			os.Remove(fileName)
+			os.Remove(fileName + "-shm")
+			os.Remove(fileName + "-wal")
+			os.Remove(fileName + "-journal")
+		}
+	}()
+
+	store, err := db.MakeAccessor("stateprooftest", false, true)
+	a.NoError(err)
+	root, err := account.GenerateRoot(store)
+	a.NoError(err)
+	part1, err := account.FillDBWithParticipationKeys(store, root.Address(), 0, basics.Round(merklesignature.KeyLifetimeDefault*2), 3)
+	a.NoError(err)
+	store.Close()
+
+	keys1 := part1.StateProofSecrets.GetAllKeys()
+
+	// Add participations to the registry and append StateProof keys as well
+	part1ID, err := acctManager.registry.Insert(part1.Participation)
+	a.NoError(err)
+	err = registry.AppendKeys(part1ID, keys1)
+	a.NoError(err)
+
+	err = acctManager.registry.Flush(10 * time.Second)
+	a.NoError(err)
+
+	for i := 1; i <= 2; i++ {
+		res := acctManager.StateProofKeys(basics.Round(i * merklesignature.KeyLifetimeDefault))
+		a.Equal(1, len(res))
+	}
+
+	acctManager.DeleteStateProofKeysForExpiredAccounts(part1.LastValid + 1)
+	err = acctManager.registry.Flush(10 * time.Second)
+	a.NoError(err)
+
+	for i := 1; i <= 2; i++ {
+		res := acctManager.StateProofKeys(basics.Round(i * merklesignature.KeyLifetimeDefault))
+		a.Equal(0, len(res))
+	}
+
+}
+
 func TestGetStateProofKeysDontLogErrorOnNilStateProof(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	a := assert.New(t)

--- a/stateproof/abstractions.go
+++ b/stateproof/abstractions.go
@@ -55,6 +55,7 @@ type Network interface {
 type Accounts interface {
 	StateProofKeys(basics.Round) []account.StateProofSecretsForRound
 	DeleteStateProofKey(id account.ParticipationID, round basics.Round) error
+	RemoveStateProofKeysForExpiredAccounts(currentRound basics.Round)
 }
 
 // BlockHeaderFetcher captures the aspects of the Ledger that is used to fetch block headers

--- a/stateproof/abstractions.go
+++ b/stateproof/abstractions.go
@@ -55,7 +55,7 @@ type Network interface {
 type Accounts interface {
 	StateProofKeys(basics.Round) []account.StateProofSecretsForRound
 	DeleteStateProofKey(id account.ParticipationID, round basics.Round) error
-	RemoveStateProofKeysForExpiredAccounts(currentRound basics.Round)
+	DeleteStateProofKeysForExpiredAccounts(currentRound basics.Round)
 }
 
 // BlockHeaderFetcher captures the aspects of the Ledger that is used to fetch block headers

--- a/stateproof/builder.go
+++ b/stateproof/builder.go
@@ -477,7 +477,6 @@ func (spw *Worker) deleteOldKeys(currentHdr *bookkeeping.BlockHeader) {
 			spw.log.Warnf("deleteOldKeys: could not remove key for round %s %v %v", key.ParticipationID, oldestRoundToRemove, err)
 		}
 	}
-
 }
 
 func (spw *Worker) deleteOldBuilders(currentHdr *bookkeeping.BlockHeader) {
@@ -496,8 +495,8 @@ func (spw *Worker) deleteOldBuilders(currentHdr *bookkeeping.BlockHeader) {
 		return deleteBuilders(tx, oldestRoundToRemove)
 	})
 	if err != nil {
+		spw.log.Warnf("deleteOldBuilders: failed to delete builders from database: %v", err)
 	}
-	spw.log.Warnf("deleteOldBuilders: failed to delete builders from database: %v", err)
 }
 
 func (spw *Worker) tryBroadcast() {

--- a/stateproof/builder.go
+++ b/stateproof/builder.go
@@ -473,8 +473,13 @@ func (spw *Worker) deleteOldKeys(currentHdr *bookkeeping.BlockHeader) {
 
 	keys := spw.accts.StateProofKeys(oldestRoundToRemove)
 	for _, key := range keys {
-		if err := spw.accts.DeleteStateProofKey(key.ParticipationID, oldestRoundToRemove); err != nil {
-			spw.log.Warnf("deleteOldKeys: could not remove key for round %s %v %v", key.ParticipationID, oldestRoundToRemove, err)
+		roundToRemove, err := key.StateProofSecrets.FirstRoundInKeyLifetime()
+		if err != nil {
+			spw.log.Warnf("deleteOldKeys: could not calculate keylifetime for account %v on round %s:  %v", key.ParticipationID, roundToRemove, err)
+		}
+		err = spw.accts.DeleteStateProofKey(key.ParticipationID, basics.Round(roundToRemove))
+		if err != nil {
+			spw.log.Warnf("deleteOldKeys: could not remove key for account %v on round %s: %v", key.ParticipationID, roundToRemove, err)
 		}
 	}
 }

--- a/stateproof/builder.go
+++ b/stateproof/builder.go
@@ -488,6 +488,7 @@ func (spw *Worker) deleteStaleKeys(latestRoundToKeep basics.Round) {
 			spw.log.Warnf("deleteOldKeys: could not remove key for account %v on round %s: %v", key.ParticipationID, roundToRemove, err)
 		}
 	}
+	spw.accts.RemoveStateProofKeysForExpiredAccounts(latestRoundToKeep)
 }
 
 func (spw *Worker) deleteStaleBuilders(latestRoundToKeep basics.Round) {

--- a/stateproof/builder.go
+++ b/stateproof/builder.go
@@ -469,9 +469,7 @@ func (spw *Worker) deleteOldKeys(currentHdr *bookkeeping.BlockHeader) {
 		return
 	}
 
-	oldestRoundToRemove := stateProofNextRound.SubSaturate(basics.Round(proto.StateProofInterval))
-
-	keys := spw.accts.StateProofKeys(oldestRoundToRemove)
+	keys := spw.accts.StateProofKeys(stateProofNextRound)
 	for _, key := range keys {
 		roundToRemove, err := key.StateProofSecrets.FirstRoundInKeyLifetime()
 		if err != nil {

--- a/stateproof/signer.go
+++ b/stateproof/signer.go
@@ -41,7 +41,7 @@ type sigFromAddr struct {
 func (spw *Worker) signer(latest basics.Round) {
 	nextRnd := spw.nextStateProofRound(latest)
 	// at this point there isn't any known stateproof by the signer, set as 0 to ensure no keys will be deleted.
-	prevStateProof := basics.Round(0)
+	prevStateProof := nextRnd
 	for { // Start signing StateProofs from nextRnd onwards
 		select {
 		case <-spw.ledger.Wait(nextRnd):

--- a/stateproof/signer.go
+++ b/stateproof/signer.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto/merklesignature"
-	"github.com/algorand/go-algorand/data/account"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/protocol"
@@ -138,8 +137,6 @@ func (spw *Worker) signStateProof(hdr bookkeeping.BlockHeader) {
 	}
 
 	sigs := make([]sigFromAddr, 0, len(keys))
-	ids := make([]account.ParticipationID, 0, len(keys))
-	usedSigners := make([]*merklesignature.Signer, 0, len(keys))
 
 	stateproofMessage, err := GenerateStateProofMessage(spw.ledger, uint64(votersHdr.Round), hdr)
 	if err != nil {
@@ -176,8 +173,6 @@ func (spw *Worker) signStateProof(hdr bookkeeping.BlockHeader) {
 			Round:         hdr.Round,
 			Sig:           sig,
 		})
-		ids = append(ids, key.ParticipationID)
-		usedSigners = append(usedSigners, key.StateProofSecrets)
 	}
 
 	// any error in handle sig indicates the signature wasn't stored in disk, thus we cannot delete the key.

--- a/stateproof/signer.go
+++ b/stateproof/signer.go
@@ -69,14 +69,11 @@ func (spw *Worker) signer(latest basics.Round) {
 	}
 }
 
+// attempts to delete any key that its first valid is <= (prevStateproofRound - lifetime)
 func (spw *Worker) attemptKeyDeletionPriorToRound(prevStateproofRound basics.Round) {
 	for _, key := range spw.accts.StateProofKeys(prevStateproofRound) {
-		keyContext := key.StateProofSecrets.SignerContext
-		if basics.Round(keyContext.FirstValid+keyContext.KeyLifetime) > prevStateproofRound {
-			continue
-		}
-
-		if err := spw.accts.DeleteStateProofKey(key.ParticipationID, prevStateproofRound); err != nil {
+		latestRndToDelete := prevStateproofRound - basics.Round(key.StateProofSecrets.SignerContext.KeyLifetime)
+		if err := spw.accts.DeleteStateProofKey(key.ParticipationID, latestRndToDelete); err != nil {
 			spw.log.Warnf("spw.signBlock(%d): Couldn't delete StateProof keys: %v", prevStateproofRound, err)
 		}
 	}

--- a/stateproof/signer.go
+++ b/stateproof/signer.go
@@ -73,6 +73,9 @@ func (spw *Worker) signer(latest basics.Round) {
 func (spw *Worker) attemptKeyDeletionPriorToRound(prevStateproofRound basics.Round) {
 	for _, key := range spw.accts.StateProofKeys(prevStateproofRound) {
 		latestRndToDelete := prevStateproofRound - basics.Round(key.StateProofSecrets.SignerContext.KeyLifetime)
+		if latestRndToDelete > prevStateproofRound {
+			continue
+		}
 		if err := spw.accts.DeleteStateProofKey(key.ParticipationID, latestRndToDelete); err != nil {
 			spw.log.Warnf("spw.signBlock(%d): Couldn't delete StateProof keys: %v", prevStateproofRound, err)
 		}

--- a/stateproof/stateproofMessageGenerator_test.go
+++ b/stateproof/stateproofMessageGenerator_test.go
@@ -53,8 +53,8 @@ func (s *workerForStateProofMessageTests) DeleteStateProofKey(id account.Partici
 	return s.w.DeleteStateProofKey(id, round)
 }
 
-func (s *workerForStateProofMessageTests) RemoveStateProofKeysForExpiredAccounts(currentRound basics.Round) {
-	s.w.RemoveStateProofKeysForExpiredAccounts(currentRound)
+func (s *workerForStateProofMessageTests) DeleteStateProofKeysForExpiredAccounts(currentRound basics.Round) {
+	s.w.DeleteStateProofKeysForExpiredAccounts(currentRound)
 }
 
 func (s *workerForStateProofMessageTests) Latest() basics.Round {

--- a/stateproof/stateproofMessageGenerator_test.go
+++ b/stateproof/stateproofMessageGenerator_test.go
@@ -149,18 +149,18 @@ func (s *workerForStateProofMessageTests) addBlockWithStateProofHeaders(ccNextRo
 
 func newWorkerForStateProofMessageStubs(keys []account.Participation, totalWeight int) *workerForStateProofMessageTests {
 	s := &testWorkerStubs{
-		t:                     nil,
-		mu:                    deadlock.Mutex{},
-		latest:                0,
-		waiters:               make(map[basics.Round]chan struct{}),
-		waitersCount:          make(map[basics.Round]int),
-		blocks:                make(map[basics.Round]bookkeeping.BlockHeader),
-		keys:                  keys,
-		keysForVoters:         keys,
-		sigmsg:                make(chan []byte, 1024),
-		txmsg:                 make(chan transactions.SignedTxn, 1024),
-		totalWeight:           totalWeight,
-		deletedStateProofKeys: map[account.ParticipationID]basics.Round{},
+		t:                         nil,
+		mu:                        deadlock.Mutex{},
+		latest:                    0,
+		waiters:                   make(map[basics.Round]chan struct{}),
+		waitersCount:              make(map[basics.Round]int),
+		blocks:                    make(map[basics.Round]bookkeeping.BlockHeader),
+		keys:                      keys,
+		keysForVoters:             keys,
+		sigmsg:                    make(chan []byte, 1024),
+		txmsg:                     make(chan transactions.SignedTxn, 1024),
+		totalWeight:               totalWeight,
+		deletedKeysBeforeRoundMap: map[account.ParticipationID]basics.Round{},
 	}
 	sm := workerForStateProofMessageTests{w: s}
 	return &sm

--- a/stateproof/stateproofMessageGenerator_test.go
+++ b/stateproof/stateproofMessageGenerator_test.go
@@ -53,6 +53,10 @@ func (s *workerForStateProofMessageTests) DeleteStateProofKey(id account.Partici
 	return s.w.DeleteStateProofKey(id, round)
 }
 
+func (s *workerForStateProofMessageTests) RemoveStateProofKeysForExpiredAccounts(currentRound basics.Round) {
+	s.w.RemoveStateProofKeysForExpiredAccounts(currentRound)
+}
+
 func (s *workerForStateProofMessageTests) Latest() basics.Round {
 	return s.w.Latest()
 }

--- a/stateproof/worker.go
+++ b/stateproof/worker.go
@@ -65,8 +65,9 @@ type Worker struct {
 	shutdown context.CancelFunc
 	wg       sync.WaitGroup
 
-	signed   basics.Round
-	signedCh chan struct{}
+	signed           basics.Round
+	signedCh         chan struct{}
+	LastCleanupRound basics.Round
 }
 
 // NewWorker constructs a new Worker, as used by the node.

--- a/stateproof/worker_test.go
+++ b/stateproof/worker_test.go
@@ -161,7 +161,7 @@ func (s *testWorkerStubs) StateProofKeys(rnd basics.Round) (out []account.StateP
 	return
 }
 
-func (s *testWorkerStubs) RemoveStateProofKeysForExpiredAccounts(currentRound basics.Round) {
+func (s *testWorkerStubs) DeleteStateProofKeysForExpiredAccounts(currentRound basics.Round) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, part := range s.keys {

--- a/stateproof/worker_test.go
+++ b/stateproof/worker_test.go
@@ -839,7 +839,7 @@ func TestWorkerRemoveBuildersAndSignatures(t *testing.T) {
 	a.Equal(3, len(roundSigs))
 }
 
-func TestWorkerBuildersRecoveryLimit(t *testing.T) {
+func TestWorkerBuildersRecoveryIsNotLimited(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	a := require.New(t)
 
@@ -903,18 +903,19 @@ func TestWorkerBuildersRecoveryLimit(t *testing.T) {
 	err = waitForBuilderAndSignerToWaitOnRound(s)
 	a.NoError(err)
 
-	// should not give up on rounds
-	a.Equal(proto.StateProofMaxRecoveryIntervals+1, uint64(len(w.builders)))
+	// Although the max recovery has passed the worker will not delete
+	// builder and signatures
+	a.Equal(proto.StateProofMaxRecoveryIntervals+2, uint64(len(w.builders)))
 	countDB, err = countBuildersInDB(w.db)
 	a.NoError(err)
-	a.Equal(proto.StateProofMaxRecoveryIntervals+1, uint64(countDB))
+	a.Equal(proto.StateProofMaxRecoveryIntervals+2, uint64(countDB))
 
 	roundSigs = make(map[basics.Round][]pendingSig)
 	err = w.db.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
 		roundSigs, err = getPendingSigs(tx)
 		return
 	})
-	a.Equal(proto.StateProofMaxRecoveryIntervals+1, uint64(len(roundSigs)))
+	a.Equal(proto.StateProofMaxRecoveryIntervals+2, uint64(len(roundSigs)))
 }
 
 func waitForBuilderAndSignerToWaitOnRound(s *testWorkerStubs) error {

--- a/stateproof/worker_test.go
+++ b/stateproof/worker_test.go
@@ -66,11 +66,11 @@ type testWorkerStubs struct {
 }
 
 func newWorkerStubs(t testing.TB, keys []account.Participation, totalWeight int) *testWorkerStubs {
-	version := config.Consensus[protocol.ConsensusCurrentVersion]
-	return newWorkerStubsWithVersion(t, keys, protocol.ConsensusCurrentVersion, version, totalWeight)
+	return newWorkerStubsWithVersion(t, keys, protocol.ConsensusCurrentVersion, totalWeight)
 }
 
-func newWorkerStubsWithVersion(t testing.TB, keys []account.Participation, version protocol.ConsensusVersion, params config.ConsensusParams, totalWeight int) *testWorkerStubs {
+func newWorkerStubsWithVersion(t testing.TB, keys []account.Participation, version protocol.ConsensusVersion, totalWeight int) *testWorkerStubs {
+	proto := config.Consensus[version]
 	s := &testWorkerStubs{
 		t:                     nil,
 		mu:                    deadlock.Mutex{},
@@ -87,7 +87,7 @@ func newWorkerStubsWithVersion(t testing.TB, keys []account.Participation, versi
 		version:               version,
 	}
 	s.latest--
-	s.addBlock(2 * basics.Round(params.StateProofInterval))
+	s.addBlock(2 * basics.Round(proto.StateProofInterval))
 	return s
 }
 
@@ -589,7 +589,14 @@ func TestWorkerHandleSig(t *testing.T) {
 	}
 }
 
-func TestSignerDeletesUnneededStateProofKeys(t *testing.T) {
+//func TestSignerDeletesUnneededStateProofKeys(t *testing.T) {
+//	for i := 0; i < 300; i++ {
+//		TestSignerDeletesUnneededStateProofKeys1(t)
+//	}
+//
+//}
+
+func TestSignerDeletesUnneededStateProofKeys1(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	var keys []account.Participation
@@ -648,7 +655,7 @@ func createWorkerAndParticipants(t *testing.T, version protocol.ConsensusVersion
 		keys = append(keys, p.Participation)
 	}
 
-	s := newWorkerStubsWithVersion(t, keys, version, proto, 10)
+	s := newWorkerStubsWithVersion(t, keys, version, 10)
 	dbs, _ := dbOpenTest(t, true)
 
 	logger := logging.NewLogger()

--- a/stateproof/worker_test.go
+++ b/stateproof/worker_test.go
@@ -653,7 +653,7 @@ func TestKeysRemoveOnlyAfterStateProofAccepted(t *testing.T) {
 	requireDeletedKeysToBeDeletedBefore(t, s, firstExpectedStateproof+basics.Round(proto.StateProofInterval))
 	checkedKeys = s.StateProofKeys(firstExpectedStateproof)
 	require.Equal(t, 0, len(checkedKeys))
-	checkedKeys = s.StateProofKeys(basics.Round(3 * proto.StateProofInterval))
+	checkedKeys = s.StateProofKeys(firstExpectedStateproof + basics.Round(proto.StateProofInterval))
 	require.Equal(t, len(keys), len(checkedKeys))
 }
 
@@ -696,7 +696,7 @@ func TestKeysRemoveOnlyAfterStateProofAcceptedSmallIntervals(t *testing.T) {
 
 	checkedKeys = s.StateProofKeys(firstExpectedStateproof)
 	require.Equal(t, len(keys), len(checkedKeys))
-	checkedKeys = s.StateProofKeys(basics.Round(3 * proto.StateProofInterval))
+	checkedKeys = s.StateProofKeys(firstExpectedStateproof + basics.Round(proto.StateProofInterval))
 	require.Equal(t, len(keys), len(checkedKeys))
 }
 
@@ -736,7 +736,7 @@ func TestKeysRemoveOnlyAfterStateProofAcceptedLargeIntervals(t *testing.T) {
 
 	checkedKeys = s.StateProofKeys(firstExpectedStateproof)
 	require.Equal(t, 0, len(checkedKeys))
-	checkedKeys = s.StateProofKeys(basics.Round(3 * proto.StateProofInterval))
+	checkedKeys = s.StateProofKeys(firstExpectedStateproof + basics.Round(proto.StateProofInterval))
 	require.Equal(t, len(keys), len(checkedKeys))
 }
 

--- a/stateproof/worker_test.go
+++ b/stateproof/worker_test.go
@@ -241,7 +241,6 @@ func (s *testWorkerStubs) BroadcastInternalSignedTxGroup(tx []transactions.Signe
 func (s *testWorkerStubs) RegisterHandlers([]network.TaggedMessageHandler) {
 }
 
-// TODO: understand why using the other function fails multiple tests.
 func (s *testWorkerStubs) advanceLatestWithoutStateProof(delta uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -251,6 +250,7 @@ func (s *testWorkerStubs) advanceLatestWithoutStateProof(delta uint64) {
 	}
 }
 
+// used to simulate to workers that rounds have advanced, and stateproofs were created.
 func (s *testWorkerStubs) advanceLatestAndStateProofs(delta uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -586,10 +586,8 @@ func TestSignerDeletesUnneededStateProofKeys(t *testing.T) {
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	s.advanceLatestAndStateProofs(1 * proto.StateProofInterval) // going to rnd 256
-	// Expect all signatures to be broadcast.
-
 	require.Zero(t, s.GetNumDeletedKeys())
-	w.signStateProof(s.blocks[basics.Round(proto.StateProofInterval)])
+
 	s.advanceLatestAndStateProofs(2 * proto.StateProofInterval) // advancing rounds up to 768
 
 	// chose 513 because that is the next round, and the signer must've passed through the deletion function by now.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Due to StateProof keys' lifetime, the signer might delete the key while not all signatures are present in the DB. 
This critical error might occur when the DB fails to record a signature and a new signature arrives from the same key. 

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
