### PR TITLE
Partition tests to spread load in CI

### DIFF
--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -1081,6 +1081,9 @@ func BenchmarkWriteCatchpointStagingBalances(b *testing.B) {
 }
 
 func TestKeyPrefixIntervalPreprocessing(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
 	testCases := []struct {
 		input            []byte
 		outputPrefix     []byte
@@ -1102,6 +1105,9 @@ func TestKeyPrefixIntervalPreprocessing(t *testing.T) {
 }
 
 func TestLookupKeysByPrefix(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
 	dbs, fn := dbOpenTest(t, false)
 	setDbLogging(t, dbs)
 	defer cleanupTestDb(dbs, fn, false)
@@ -1149,7 +1155,8 @@ func TestLookupKeysByPrefix(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	tx.Commit()
+	err = tx.Commit()
+	require.NoError(t, err)
 	writer.close()
 
 	testCases := []struct {


### PR DESCRIPTION
## Summary

Adds test partitioning for recently added tests to distribute load during CI runs.  Also adds `t.Parallel()` under the assumption that these tests can safely run in parallel.

## Test Plan

`go test ./ledger`