### PR TITLE
telemetry: Count and report the number of duplicate proposals and MsgDigestSkipTag messages received

### DIFF
--- a/agreement/proposalStore.go
+++ b/agreement/proposalStore.go
@@ -18,7 +18,15 @@ package agreement
 
 import (
 	"fmt"
+
+	"github.com/algorand/go-algorand/util/metrics"
 )
+
+var proposalAlreadyFilledCounter = metrics.MakeCounter(
+	metrics.MetricName{Name: "algod_agreement_proposal_already_filled", Description: "Number of times a duplicate proposal payload was received before validation"})
+
+var proposalAlreadyAssembledCounter = metrics.MakeCounter(
+	metrics.MetricName{Name: "algod_agreement_proposal_already_assembled", Description: "Number of times a duplicate proposal payload was received after validation"})
 
 // An blockAssembler contains the proposal data associated with some
 // proposal-value.
@@ -52,10 +60,12 @@ type blockAssembler struct {
 // an error if the pipelining operation is redundant.
 func (a blockAssembler) pipeline(p unauthenticatedProposal) (blockAssembler, error) {
 	if a.Assembled {
+		proposalAlreadyAssembledCounter.Inc(nil)
 		return a, fmt.Errorf("blockAssembler.pipeline: already assembled")
 	}
 
 	if a.Filled {
+		proposalAlreadyFilledCounter.Inc(nil)
 		return a, fmt.Errorf("blockAssembler.pipeline: already filled")
 	}
 

--- a/logging/telemetryspec/event.go
+++ b/logging/telemetryspec/event.go
@@ -300,6 +300,8 @@ type PeerConnectionDetails struct {
 	Endpoint string `json:",omitempty"`
 	// MessageDelay is the avarage relative message delay. Not being used for incoming connection.
 	MessageDelay int64 `json:",omitempty"`
+	// DuplicateFilterCount is the number of times this peer has sent us a message hash to filter that it had already sent before.
+	DuplicateFilterCount int64
 }
 
 // CatchpointGenerationEvent event

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1749,9 +1749,10 @@ func (wn *WebsocketNetwork) sendPeerConnectionsTelemetryStatus() {
 	var connectionDetails telemetryspec.PeersConnectionDetails
 	for _, peer := range peers {
 		connDetail := telemetryspec.PeerConnectionDetails{
-			ConnectionDuration: uint(now.Sub(peer.createTime).Seconds()),
-			TelemetryGUID:      peer.TelemetryGUID,
-			InstanceName:       peer.InstanceName,
+			ConnectionDuration:   uint(now.Sub(peer.createTime).Seconds()),
+			TelemetryGUID:        peer.TelemetryGUID,
+			InstanceName:         peer.InstanceName,
+			DuplicateFilterCount: peer.duplicateFilterCount,
 		}
 		if peer.outgoing {
 			connDetail.Address = justHost(peer.conn.RemoteAddr().String())

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -49,6 +49,8 @@ var (
 	DuplicateNetworkMessageReceivedTotal = MetricName{Name: "algod_network_duplicate_message_received_total", Description: "Total number of duplicate messages that were received from the network"}
 	// DuplicateNetworkMessageReceivedBytesTotal The total number ,in bytes, of the duplicate messages that were received from the network
 	DuplicateNetworkMessageReceivedBytesTotal = MetricName{Name: "algod_network_duplicate_message_received_bytes_total", Description: "The total number ,in bytes, of the duplicate messages that were received from the network"}
+	// DuplicateNetworkFilterReceivedTotal Total number of duplicate filter messages (tag MsgDigestSkipTag) that were received from the network
+	DuplicateNetworkFilterReceivedTotal = MetricName{Name: "algod_network_duplicate_filter_received_total", Description: "Total number of duplicate filter messages that were received from the network"}
 	// OutgoingNetworkMessageFilteredOutTotal Total number of messages that were not sent per peer request
 	OutgoingNetworkMessageFilteredOutTotal = MetricName{Name: "algod_outgoing_network_message_filtered_out_total", Description: "Total number of messages that were not sent per peer request"}
 	// OutgoingNetworkMessageFilteredOutBytesTotal Total number of bytes saved by not sending messages that were asked not to be sent by peer


### PR DESCRIPTION
## Summary

Message filtering is used to reduce the number of duplicate large messages (>5000 bytes) sent between peers. After a large message is received, the node sends a filter message (protocol tag `MsgDigestSkipTag`) containing the message's hash to all its peers, telling them not to send them any messages with this hash. However this does not prevent a node from receiving the same large message concurrently from several peers, since it must fully receive the first large message before broadcasting the filter message.

This counts the number of duplicate filter messages received by a peer. Nodes do not track their outgoing filter messages, but receiving nodes must track the hashes, and so this wires up a counter to `messageFilter.CheckDigest` which "checks if the given digest already in the collection, and returns true if it was there before the call."

This also adds to agreement two new counters that count the number of times a duplicate payloadPresent event occurs, meaning the same proposal payload was received by agreement and sent to the proposalStore. There are two cases counted, for before and after proposal validation is complete.

## Test Plan

Telemetry only — existing tests should pass.