### PR TITLE
metrics: Remove labels from gauge metrics

### DIFF
--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -56,7 +56,7 @@ func (mt *metricsTracker) close() {
 
 func (mt *metricsTracker) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {
 	rnd := blk.Round()
-	mt.ledgerRound.Set(float64(rnd), map[string]string{})
+	mt.ledgerRound.Set(float64(rnd))
 	mt.ledgerTransactionsTotal.Add(float64(len(blk.Payset)), map[string]string{})
 	// TODO rewards: need to provide meaningful metric here.
 	mt.ledgerRewardClaimsTotal.Add(float64(1), map[string]string{})

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1162,8 +1162,8 @@ func (wn *WebsocketNetwork) ServeHTTP(response http.ResponseWriter, request *htt
 
 	wn.maybeSendMessagesOfInterest(peer, nil)
 
-	peers.Set(float64(wn.NumPeers()), nil)
-	incomingPeers.Set(float64(wn.numIncomingPeers()), nil)
+	peers.Set(float64(wn.NumPeers()))
+	incomingPeers.Set(float64(wn.numIncomingPeers()))
 }
 
 func (wn *WebsocketNetwork) maybeSendMessagesOfInterest(peer *wsPeer, messagesOfInterestEnc []byte) {
@@ -2103,8 +2103,8 @@ func (wn *WebsocketNetwork) tryConnect(addr, gossipAddr string) {
 
 	wn.maybeSendMessagesOfInterest(peer, nil)
 
-	peers.Set(float64(wn.NumPeers()), nil)
-	outgoingPeers.Set(float64(wn.numOutgoingPeers()), nil)
+	peers.Set(float64(wn.NumPeers()))
+	outgoingPeers.Set(float64(wn.numOutgoingPeers()))
 
 	if wn.prioScheme != nil {
 		challenge := response.Header.Get(PriorityChallengeHeader)
@@ -2217,9 +2217,9 @@ func (wn *WebsocketNetwork) removePeer(peer *wsPeer, reason disconnectReason) {
 			Reason:           string(reason),
 		})
 
-	peers.Set(float64(wn.NumPeers()), nil)
-	incomingPeers.Set(float64(wn.numIncomingPeers()), nil)
-	outgoingPeers.Set(float64(wn.numOutgoingPeers()), nil)
+	peers.Set(float64(wn.NumPeers()))
+	incomingPeers.Set(float64(wn.numIncomingPeers()))
+	outgoingPeers.Set(float64(wn.numOutgoingPeers()))
 
 	wn.peersLock.Lock()
 	defer wn.peersLock.Unlock()
@@ -2284,8 +2284,8 @@ func (wn *WebsocketNetwork) countPeersSetGauges() {
 			numIn++
 		}
 	}
-	networkIncomingConnections.Set(float64(numIn), nil)
-	networkOutgoingConnections.Set(float64(numOut), nil)
+	networkIncomingConnections.Set(float64(numIn))
+	networkOutgoingConnections.Set(float64(numOut))
 }
 
 func justHost(hostPort string) string {

--- a/node/node.go
+++ b/node/node.go
@@ -984,7 +984,7 @@ func insertStateProofToRegistry(part account.PersistedParticipation, node *Algor
 
 }
 
-var txPoolGuage = metrics.MakeGauge(metrics.MetricName{Name: "algod_tx_pool_count", Description: "current number of available transactions in pool"})
+var txPoolGauge = metrics.MakeGauge(metrics.MetricName{Name: "algod_tx_pool_count", Description: "current number of available transactions in pool"})
 
 func (node *AlgorandFullNode) txPoolGaugeThread(done <-chan struct{}) {
 	defer node.monitoringRoutinesWaitGroup.Done()
@@ -993,7 +993,7 @@ func (node *AlgorandFullNode) txPoolGaugeThread(done <-chan struct{}) {
 	for true {
 		select {
 		case <-ticker.C:
-			txPoolGuage.Set(float64(node.transactionPool.PendingCount()), nil)
+			txPoolGauge.Set(float64(node.transactionPool.PendingCount()))
 		case <-done:
 			return
 		}

--- a/util/metrics/gauge.go
+++ b/util/metrics/gauge.go
@@ -17,7 +17,6 @@
 package metrics
 
 import (
-	"math"
 	"strconv"
 	"strings"
 
@@ -27,25 +26,16 @@ import (
 // Gauge represent a single gauge variable.
 type Gauge struct {
 	deadlock.Mutex
-	name          string
-	description   string
-	labels        map[string]int       // map each label ( i.e. httpErrorCode ) to an index.
-	valuesIndices map[int]*gaugeValues // maps each set of labels into a concrete gauge
-}
-
-type gaugeValues struct {
-	gauge           float64
-	labels          map[string]string
-	formattedLabels string
+	name        string
+	description string
+	value       float64
 }
 
 // MakeGauge create a new gauge with the provided name and description.
 func MakeGauge(metric MetricName) *Gauge {
 	c := &Gauge{
-		description:   metric.Description,
-		name:          metric.Name,
-		labels:        make(map[string]int),
-		valuesIndices: make(map[int]*gaugeValues),
+		description: metric.Description,
+		name:        metric.Name,
 	}
 	c.Register(nil)
 	return c
@@ -70,76 +60,17 @@ func (gauge *Gauge) Deregister(reg *Registry) {
 }
 
 // Add increases gauge by x
-func (gauge *Gauge) Add(x float64, labels map[string]string) {
+func (gauge *Gauge) Add(x float64) {
 	gauge.Lock()
 	defer gauge.Unlock()
-
-	labelIndex := gauge.findLabelIndex(labels)
-
-	// find where we have the same labels.
-	if gaugeObj, has := gauge.valuesIndices[labelIndex]; !has {
-		// we need to add a new gauge.
-		val := &gaugeValues{
-			gauge:  x,
-			labels: labels,
-		}
-		val.createFormattedLabel()
-		gauge.valuesIndices[labelIndex] = val
-	} else {
-		// update existing value.
-		gaugeObj.gauge += x
-	}
+	gauge.value += x
 }
 
 // Set sets gauge to x
-func (gauge *Gauge) Set(x float64, labels map[string]string) {
+func (gauge *Gauge) Set(x float64) {
 	gauge.Lock()
 	defer gauge.Unlock()
-
-	labelIndex := gauge.findLabelIndex(labels)
-
-	// find where we have the same labels.
-	if gaugeObj, has := gauge.valuesIndices[labelIndex]; !has {
-		// we need to add a new gauge.
-		val := &gaugeValues{
-			gauge:  x,
-			labels: labels,
-		}
-		val.createFormattedLabel()
-		gauge.valuesIndices[labelIndex] = val
-	} else {
-		// update existing value.
-		gaugeObj.gauge = x
-	}
-}
-
-func (gauge *Gauge) findLabelIndex(labels map[string]string) int {
-	accumulatedIndex := 0
-	for k, v := range labels {
-		t := k + ":" + v
-		// do we already have this key ( label ) in our map ?
-		if i, has := gauge.labels[t]; has {
-			// yes, we do. use this index.
-			accumulatedIndex += i
-		} else {
-			// no, we don't have it.
-			gauge.labels[t] = int(math.Exp2(float64(len(gauge.labels))))
-			accumulatedIndex += gauge.labels[t]
-		}
-	}
-	return accumulatedIndex
-}
-
-func (cv *gaugeValues) createFormattedLabel() {
-	var buf strings.Builder
-	if len(cv.labels) < 1 {
-		return
-	}
-	for k, v := range cv.labels {
-		buf.WriteString("," + k + "=\"" + v + "\"")
-	}
-
-	cv.formattedLabels = buf.String()[1:]
+	gauge.value = x
 }
 
 // WriteMetric writes the metric into the output stream
@@ -147,9 +78,6 @@ func (gauge *Gauge) WriteMetric(buf *strings.Builder, parentLabels string) {
 	gauge.Lock()
 	defer gauge.Unlock()
 
-	if len(gauge.valuesIndices) < 1 {
-		return
-	}
 	buf.WriteString("# HELP ")
 	buf.WriteString(gauge.name)
 	buf.WriteString(" ")
@@ -157,20 +85,14 @@ func (gauge *Gauge) WriteMetric(buf *strings.Builder, parentLabels string) {
 	buf.WriteString("\n# TYPE ")
 	buf.WriteString(gauge.name)
 	buf.WriteString(" gauge\n")
-	for _, l := range gauge.valuesIndices {
-		buf.WriteString(gauge.name)
-		buf.WriteString("{")
-		if len(parentLabels) > 0 {
-			buf.WriteString(parentLabels)
-			if len(l.formattedLabels) > 0 {
-				buf.WriteString(",")
-			}
-		}
-		buf.WriteString(l.formattedLabels)
-		buf.WriteString("} ")
-		buf.WriteString(strconv.FormatFloat(l.gauge, 'f', -1, 32))
-		buf.WriteString("\n")
+	buf.WriteString(gauge.name)
+	buf.WriteString("{")
+	if len(parentLabels) > 0 {
+		buf.WriteString(parentLabels)
 	}
+	buf.WriteString("} ")
+	buf.WriteString(strconv.FormatFloat(gauge.value, 'f', -1, 32))
+	buf.WriteString("\n")
 }
 
 // AddMetric adds the metric into the map
@@ -178,15 +100,5 @@ func (gauge *Gauge) AddMetric(values map[string]float64) {
 	gauge.Lock()
 	defer gauge.Unlock()
 
-	if len(gauge.valuesIndices) < 1 {
-		return
-	}
-
-	for _, l := range gauge.valuesIndices {
-		var suffix string
-		if len(l.formattedLabels) > 0 {
-			suffix = ":" + l.formattedLabels
-		}
-		values[sanitizeTelemetryName(gauge.name+suffix)] = l.gauge
-	}
+	values[sanitizeTelemetryName(gauge.name)] = gauge.value
 }


### PR DESCRIPTION
## Summary

Gauges have optional, currently unused, arguments allowing user to set labels on multiple values per single gauge struct. This has potential to leak memory if unbound datasets were used as labels.

Closes #3040 

## Test Plan

Current tests pass as well as the new modified one. The format of a line of output from `WriteMetric` is the same except for the labels added by the test:

old:
`metric_test_name1{pid="5824",host="algo-suvak-mbp.lan",host_name="host_one",session_id="AFX-229",pid="123",data_host="host0"}:150`
new
`gauge_0{host_name="host_one",session_id="AFX-229",pid="5229",host="algo-suvak-mbp.lan"}:606`
