### PR TITLE
Ledger: Correct off by one logic in txTail.recent trim loop

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -463,6 +463,11 @@ type ConsensusParams struct {
 	// the rewardsLevel, but the rewardsLevel has no meaning because the account
 	// has fewer than RewardUnit algos.
 	UnfundedSenders bool
+
+	// TXTailRecentsFix modifies the logic of the txtail's comittedUpTo function to address an off-by-one-error
+	// txtail previously trimmed up to (but not including) round `r + maxlife`. Doing this left 1001 transaction objects after trimming.
+	// the intention is to have only 1000 items after trim, so the logic is modified to trim *including* round `r + maxlife`
+	TXTailRecentsFix bool
 }
 
 // PaysetCommitType enumerates possible ways for the block header to commit to
@@ -534,7 +539,7 @@ var MaxBytesKeyValueLen int
 var MaxExtraAppProgramLen int
 
 // MaxAvailableAppProgramLen is the largest supported app program size include the extra pages
-//supported supported by any of the consensus protocols. used for decoding purposes.
+// supported supported by any of the consensus protocols. used for decoding purposes.
 var MaxAvailableAppProgramLen int
 
 // MaxProposedExpiredOnlineAccounts is the maximum number of online accounts, which need
@@ -1214,6 +1219,8 @@ func initConsensusProtocols() {
 	vFuture.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 
 	vFuture.LogicSigVersion = 8 // When moving this to a release, put a new higher LogicSigVersion here
+
+	vFuture.TXTailRecentsFix = true
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 

--- a/ledger/txtail.go
+++ b/ledger/txtail.go
@@ -228,11 +228,22 @@ func (t *txTail) committedUpTo(rnd basics.Round) (retRound, lookback basics.Roun
 	proto := t.recent[rnd].proto
 	maxlife := basics.Round(proto.MaxTxnLife)
 
-	for r := range t.recent {
-		if r+maxlife < rnd {
-			delete(t.recent, r)
+	// TXTailRecentsFix corrects the logic of trimming `recent` to result in 1000 items remaining
+	// the previous implementation was off-by-one, leaving 1001 items
+	if proto.TXTailRecentsFix {
+		for r := range t.recent {
+			if r+maxlife <= rnd {
+				delete(t.recent, r)
+			}
+		}
+	} else {
+		for r := range t.recent {
+			if r+maxlife < rnd {
+				delete(t.recent, r)
+			}
 		}
 	}
+
 	for ; t.lowWaterMark < rnd; t.lowWaterMark++ {
 		delete(t.lastValid, t.lowWaterMark)
 	}

--- a/ledger/txtail_test.go
+++ b/ledger/txtail_test.go
@@ -293,6 +293,12 @@ func TestTxTailDeltaTracking(t *testing.T) {
 				}
 				err = txtail.prepareCommit(dcc)
 				require.NoError(t, err)
+				proto := config.Consensus[protoVersion]
+				if proto.TXTailRecentsFix {
+					require.Equal(t, 1000, len(txtail.recent))
+				} else {
+					require.Equal(t, 1001, len(txtail.recent))
+				}
 
 				tx, err := ledger.trackerDBs.Wdb.Handle.Begin()
 				require.NoError(t, err)
@@ -300,7 +306,6 @@ func TestTxTailDeltaTracking(t *testing.T) {
 				err = txtail.commitRound(context.Background(), tx, dcc)
 				require.NoError(t, err)
 				tx.Commit()
-				proto := config.Consensus[protoVersion]
 				retainSize := proto.MaxTxnLife + proto.DeeperBlockHeaderHistory
 				if uint64(i) > proto.MaxTxnLife*2 {
 					// validate internal storage length.


### PR DESCRIPTION
## Summary
### What
This change modifies the loop condition for trimming txTail's `recent` list during `comittedUpTo` calls.

### Why
It was pointed out that the equality check used was avoiding deletion of one entry, leaving 1001 entries in the list. The expectation is that only 1000 entries would remain after being trimmed.

### How
I duplicated the loop which handles deletion, and added a consensus flag to control which version is used. If consensus is on future, it will use the modified logic, and trim down to 1000 entries. Else, the existing behavior is retained.

Presumably, once this feature is adopted via consensus, we can remove the branched logic and consensus flag.

## Test Plan
✅  `make generate`
✅  `make sanity`
✅  `make test`
✅  `make integration` (still running, but all look good so far)

**Unit Test**: I added an explicit length check to an existing unit test for txTail, which confirms that the length is correct to the consensus version which is selected.

Additionally: I logged the length of `txtail.recent` before and after the affected loop, and also logged any deletion actions taken.
Before
```
before: 1002","name":"","time":"2022-09-28T16:06:16.435378-04:00"}
deleted 24428225","name":"","time":"2022-09-28T16:06:16.435465-04:00"}
after: 1001","name":"","time":"2022-09-28T16:06:16.435492-04:00"}
```
After
```
before: 1001","name":"","time":"2022-09-28T16:08:55.860060-04:00"}
deleted 24428270","name":"","time":"2022-09-28T16:08:55.860285-04:00"}
after: 1000","name":"","time":"2022-09-28T16:08:55.860342-04:00"}
```