### PR TITLE
performance: turn cache misses during assembly into cache hits during eval

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -328,6 +328,17 @@ func (au *accountUpdates) close() {
 	au.baseKVs.prune(0)
 }
 
+// flushCaches flushes any pending data in caches so that it is fully available during future lookups.
+func (au *accountUpdates) flushCaches() {
+	au.accountsMu.Lock()
+
+	au.baseAccounts.flushPendingWrites()
+	au.baseResources.flushPendingWrites()
+	au.baseKVs.flushPendingWrites()
+
+	au.accountsMu.Unlock()
+}
+
 func (au *accountUpdates) LookupResource(rnd basics.Round, addr basics.Address, aidx basics.CreatableIndex, ctype basics.CreatableType) (ledgercore.AccountResource, basics.Round, error) {
 	return au.lookupResource(rnd, addr, aidx, ctype, true /* take lock */)
 }
@@ -815,6 +826,8 @@ type accountUpdatesLedgerEvaluator struct {
 	// building the ledgercore.StateDelta, which requires a peek on the "previous" header information.
 	prevHeader bookkeeping.BlockHeader
 }
+
+func (aul *accountUpdatesLedgerEvaluator) FlushCaches() {}
 
 // GenesisHash returns the genesis hash
 func (aul *accountUpdatesLedgerEvaluator) GenesisHash() crypto.Digest {

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1327,6 +1327,12 @@ func (au *accountUpdates) lookupResource(rnd basics.Round, addr basics.Address, 
 			return macct.AccountResource(), rnd, nil
 		}
 
+		// check baseAccoiunts again to see if it does not exist
+		if au.baseResources.readNotFound(addr, aidx) {
+			// it seems the account doesnt exist
+			return ledgercore.AccountResource{}, rnd, nil
+		}
+
 		if synchronized {
 			au.accountsMu.RUnlock()
 			needUnlock = false
@@ -1346,6 +1352,7 @@ func (au *accountUpdates) lookupResource(rnd basics.Round, addr basics.Address, 
 				au.baseResources.writePending(persistedData, addr)
 				return persistedData.AccountResource(), rnd, nil
 			}
+			au.baseResources.writeNotFoundPending(addr, aidx)
 			// otherwise return empty
 			return ledgercore.AccountResource{}, rnd, nil
 		}
@@ -1428,6 +1435,12 @@ func (au *accountUpdates) lookupWithoutRewards(rnd basics.Round, addr basics.Add
 			return macct.accountData.GetLedgerCoreAccountData(), rnd, rewardsVersion, rewardsLevel, nil
 		}
 
+		// check baseAccoiunts again to see if it does not exist
+		if au.baseAccounts.readNotFound(addr) {
+			// it seems the account doesnt exist
+			return ledgercore.AccountData{}, rnd, rewardsVersion, rewardsLevel, nil
+		}
+
 		if synchronized {
 			au.accountsMu.RUnlock()
 			needUnlock = false
@@ -1447,6 +1460,7 @@ func (au *accountUpdates) lookupWithoutRewards(rnd basics.Round, addr basics.Add
 				au.baseAccounts.writePending(persistedData)
 				return persistedData.accountData.GetLedgerCoreAccountData(), rnd, rewardsVersion, rewardsLevel, nil
 			}
+			au.baseAccounts.writeNotFoundPending(addr)
 			// otherwise return empty
 			return ledgercore.AccountData{}, rnd, rewardsVersion, rewardsLevel, nil
 		}

--- a/ledger/evalindexer.go
+++ b/ledger/evalindexer.go
@@ -79,6 +79,8 @@ type indexerLedgerConnector struct {
 	roundResources EvalForIndexerResources
 }
 
+func (l indexerLedgerConnector) FlushCaches() {}
+
 // BlockHdr is part of LedgerForEvaluator interface.
 func (l indexerLedgerConnector) BlockHdr(round basics.Round) (bookkeeping.BlockHeader, error) {
 	if round != l.latestRound {

--- a/ledger/internal/eval.go
+++ b/ledger/internal/eval.go
@@ -603,6 +603,7 @@ type LedgerForEvaluator interface {
 	GenesisProto() config.ConsensusParams
 	LatestTotals() (basics.Round, ledgercore.AccountTotals, error)
 	VotersForStateProof(basics.Round) (*ledgercore.VotersForRound, error)
+	FlushCaches()
 }
 
 // EvaluatorOptions defines the evaluator creation options
@@ -1500,6 +1501,9 @@ func (validator *evalTxValidator) run() {
 // AddBlock: Eval(context.Background(), l, blk, false, txcache, nil)
 // tracker:  Eval(context.Background(), l, blk, false, txcache, nil)
 func Eval(ctx context.Context, l LedgerForEvaluator, blk bookkeeping.Block, validate bool, txcache verify.VerifiedTransactionCache, executionPool execpool.BacklogPool) (ledgercore.StateDelta, error) {
+	// flush the pending writes in the cache to make everything read so far available during eval
+	l.FlushCaches()
+
 	eval, err := StartEvaluator(l, blk.BlockHeader,
 		EvaluatorOptions{
 			PaysetHint: len(blk.Payset),

--- a/ledger/internal/eval_test.go
+++ b/ledger/internal/eval_test.go
@@ -519,6 +519,8 @@ func (ledger *evalTestLedger) StartEvaluator(hdr bookkeeping.BlockHeader, payset
 		})
 }
 
+func (ledger *evalTestLedger) FlushCaches() {}
+
 // GetCreatorForRound takes a CreatableIndex and a CreatableType and tries to
 // look up a creator address, setting ok to false if the query succeeded but no
 // creator was found.

--- a/ledger/internal/prefetcher/prefetcher_alignment_test.go
+++ b/ledger/internal/prefetcher/prefetcher_alignment_test.go
@@ -173,6 +173,7 @@ func (l *prefetcherAlignmentTestLedger) LatestTotals() (basics.Round, ledgercore
 func (l *prefetcherAlignmentTestLedger) VotersForStateProof(basics.Round) (*ledgercore.VotersForRound, error) {
 	return nil, nil
 }
+func (l *prefetcherAlignmentTestLedger) FlushCaches() {}
 
 func parseLoadedAccountDataEntries(loadedAccountDataEntries []prefetcher.LoadedAccountDataEntry) map[basics.Address]struct{} {
 	if len(loadedAccountDataEntries) == 0 {

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -812,6 +812,11 @@ func (l *Ledger) StartEvaluator(hdr bookkeeping.BlockHeader, paysetHint, maxTxnB
 		})
 }
 
+// FlushCaches flushes any pending data in caches so that it is fully available during future lookups.
+func (l *Ledger) FlushCaches() {
+	l.accts.flushCaches()
+}
+
 // Validate uses the ledger to validate block blk as a candidate next block.
 // It returns an error if blk is not the expected next block, or if blk is
 // not a valid block (e.g., it has duplicate transactions, overspends some

--- a/shared/pingpong/config.go
+++ b/shared/pingpong/config.go
@@ -36,6 +36,7 @@ type PpConfig struct {
 	RandomizeFee    bool
 	RandomizeAmt    bool
 	RandomizeDst    bool
+	MaxRandomDst    uint64
 	MaxFee          uint64
 	MinFee          uint64
 	MaxAmt          uint64
@@ -98,6 +99,7 @@ var DefaultConfig = PpConfig{
 	RandomizeFee:    false,
 	RandomizeAmt:    false,
 	RandomizeDst:    false,
+	MaxRandomDst:    200000,
 	MaxFee:          10000,
 	MinFee:          1000,
 	MaxAmt:          1000,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

```
Scenario:

1. Node accepts txns into tx pool
2. Node receives a proposal with the same txns and validates it

At 1, accounts are read and saved to LRU as pending
At 2, prefetcher loads accounts. Need to ensure LRU is hit.
```

The problem statement applies both to accounts and resources. 

Additionally, we taught the LRU to track accounts and resources that were not found in the DB. 
Thus avoiding repeated DB queries on objects that do not exist. 

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

- Pass existing tests. 
- Run load scenarios and compare performance.  

### Benchmark on `scenario-1s`

We run the scenario-1s with the default script and using a random destination (max200k) both on master and this branch.
The transactions per second (TPS) results are shown in figure 1.

![Page2](https://user-images.githubusercontent.com/2915919/197581627-f660ca90-09d7-47ac-b7f1-87532ab58829.png)
> figure 1: TPS comparison between this branch and master. 


<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

