### PR TITLE
testing: extend transactions signature verification testing

### DIFF
--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -505,7 +505,7 @@ byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
 	dummyLedger := DummyLedgerForSignature{}
 	_, err = TxnGroup(txnGroups[0], blkHdr, nil, &dummyLedger)
 	require.NoError(t, err)
-	
+
 	///// no sig
 	tmpSig := txnGroups[0][0].Sig
 	txnGroups[0][0].Sig = crypto.Signature{}
@@ -617,7 +617,7 @@ func TestTxnGroupCacheUpdate(t *testing.T) {
 	verifyGroup(t, txnGroups, blkHdr, breakSignatureFunc, restoreSignatureFunc, crypto.ErrBatchVerificationFailed.Error())
 }
 
-func TestTxnGroupCacheUpdateWithMultiSig(t *testing.T) {
+func TestTxnGroupCacheUpdateMultiSig(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	_, signedTxn, _, _ := generateMultiSigTxn(100, 30, 50, t)
@@ -647,10 +647,7 @@ func TestTxnGroupCacheUpdateWithMultiSig(t *testing.T) {
 	verifyGroup(t, txnGroups, blkHdr, breakSignatureFunc, restoreSignatureFunc, crypto.ErrBatchVerificationFailed.Error())
 }
 
-// TestTxnGroupCacheUpdate uses TxnGroup to verify txns and add them to the
-// cache. Then makes sure that only the valid txns are verified and added to
-// the cache.
-func TestTxnGroupCacheFailLogic(t *testing.T) {
+func TestTxnGroupCacheUpdateFailLogic(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	_, signedTxn, _, _ := generateTestObjects(100, 20, 50)

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -494,6 +494,8 @@ func TestTxnGroupMixedSignatures(t *testing.T) {
 		},
 	}
 
+	// add a simple logic that verifies this condition:
+	// sha256(arg0) == base64decode(5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=)
 	op, err := logic.AssembleString(`arg 0
 sha256
 byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
@@ -665,6 +667,8 @@ func TestTxnGroupCacheUpdateFailLogic(t *testing.T) {
 
 	// sign the transcation with logic
 	for i := 0; i < len(signedTxn); i++ {
+		// add a simple logic that verifies this condition:
+		// sha256(arg0) == base64decode(5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=)
 		op, err := logic.AssembleString(`arg 0
 sha256
 byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
@@ -710,6 +714,8 @@ func TestTxnGroupCacheUpdateLogicWithSig(t *testing.T) {
 	}
 
 	for i := 0; i < len(signedTxn); i++ {
+		// add a simple logic that verifies this condition:
+		// sha256(arg0) == base64decode(5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=)
 		op, err := logic.AssembleString(`arg 0
 sha256
 byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
@@ -781,7 +787,8 @@ func TestTxnGroupCacheUpdateLogicWithMultiSig(t *testing.T) {
 				Amount:   basics.MicroAlgos{Raw: uint64(a)},
 			},
 		}
-
+		// add a simple logic that verifies this condition:
+		// sha256(arg0) == base64decode(5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=)
 		op, err := logic.AssembleString(`arg 0
 sha256
 byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
@@ -857,6 +864,7 @@ func verifyGroup(t *testing.T, txnGroups [][]transactions.SignedTxn, blkHdr book
 	unverifiedGroups = cache.GetUnverifiedTransactionGroups(txnGroups[:2], spec, protocol.ConsensusCurrentVersion)
 	require.Len(t, unverifiedGroups, 0)
 
+	cache = MakeVerifiedTransactionCache(1000)
 	// Break a random signature
 	txgIdx := rand.Intn(len(txnGroups))
 	txIdx := rand.Intn(len(txnGroups[txgIdx]))

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -373,17 +373,7 @@ func TestPaysetGroups(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	_, signedTxn, secrets, addrs := generateTestObjects(10000, 20, 50)
-	blkHdr := bookkeeping.BlockHeader{
-		Round:       50,
-		GenesisHash: crypto.Hash([]byte{1, 2, 3, 4, 5}),
-		UpgradeState: bookkeeping.UpgradeState{
-			CurrentProtocol: protocol.ConsensusCurrentVersion,
-		},
-		RewardsState: bookkeeping.RewardsState{
-			FeeSink:     feeSink,
-			RewardsPool: poolAddr,
-		},
-	}
+	blkHdr := createDummyBlockHeader()
 
 	execPool := execpool.MakePool(t)
 	verificationPool := execpool.MakeBacklog(execPool, 64, execpool.LowPriority, t)
@@ -453,17 +443,7 @@ func BenchmarkPaysetGroups(b *testing.B) {
 		b.N = 2000
 	}
 	_, signedTxn, secrets, addrs := generateTestObjects(b.N, 20, 50)
-	blkHdr := bookkeeping.BlockHeader{
-		Round:       50,
-		GenesisHash: crypto.Hash([]byte{1, 2, 3, 4, 5}),
-		UpgradeState: bookkeeping.UpgradeState{
-			CurrentProtocol: protocol.ConsensusCurrentVersion,
-		},
-		RewardsState: bookkeeping.RewardsState{
-			FeeSink:     feeSink,
-			RewardsPool: poolAddr,
-		},
-	}
+	blkHdr := createDummyBlockHeader()
 
 	execPool := execpool.MakePool(b)
 	verificationPool := execpool.MakeBacklog(execPool, 64, execpool.LowPriority, b)
@@ -482,17 +462,7 @@ func TestTxnGroupMixedSignatures(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	_, signedTxn, secrets, addrs := generateTestObjects(1, 20, 50)
-	blkHdr := bookkeeping.BlockHeader{
-		Round:       50,
-		GenesisHash: crypto.Hash([]byte{1, 2, 3, 4, 5}),
-		UpgradeState: bookkeeping.UpgradeState{
-			CurrentProtocol: protocol.ConsensusCurrentVersion,
-		},
-		RewardsState: bookkeeping.RewardsState{
-			FeeSink:     feeSink,
-			RewardsPool: poolAddr,
-		},
-	}
+	blkHdr := createDummyBlockHeader()
 
 	// add a simple logic that verifies this condition:
 	// sha256(arg0) == base64decode(5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=)
@@ -597,17 +567,7 @@ func TestTxnGroupCacheUpdate(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	_, signedTxn, secrets, addrs := generateTestObjects(100, 20, 50)
-	blkHdr := bookkeeping.BlockHeader{
-		Round:       50,
-		GenesisHash: crypto.Hash([]byte{1, 2, 3, 4, 5}),
-		UpgradeState: bookkeeping.UpgradeState{
-			CurrentProtocol: protocol.ConsensusCurrentVersion,
-		},
-		RewardsState: bookkeeping.RewardsState{
-			FeeSink:     feeSink,
-			RewardsPool: poolAddr,
-		},
-	}
+	blkHdr := createDummyBlockHeader()
 
 	txnGroups := generateTransactionGroups(signedTxn, secrets, addrs)
 	breakSignatureFunc := func(txn *transactions.SignedTxn) {
@@ -625,17 +585,7 @@ func TestTxnGroupCacheUpdateMultiSig(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	_, signedTxn, _, _ := generateMultiSigTxn(100, 30, 50, t)
-	blkHdr := bookkeeping.BlockHeader{
-		Round:       50,
-		GenesisHash: crypto.Hash([]byte{1, 2, 3, 4, 5}),
-		UpgradeState: bookkeeping.UpgradeState{
-			CurrentProtocol: protocol.ConsensusCurrentVersion,
-		},
-		RewardsState: bookkeeping.RewardsState{
-			FeeSink:     feeSink,
-			RewardsPool: poolAddr,
-		},
-	}
+	blkHdr := createDummyBlockHeader()
 
 	txnGroups := make([][]transactions.SignedTxn, len(signedTxn))
 	for i := 0; i < len(txnGroups); i++ {
@@ -657,17 +607,7 @@ func TestTxnGroupCacheUpdateFailLogic(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	_, signedTxn, _, _ := generateTestObjects(100, 20, 50)
-	blkHdr := bookkeeping.BlockHeader{
-		Round:       50,
-		GenesisHash: crypto.Hash([]byte{1, 2, 3, 4, 5}),
-		UpgradeState: bookkeeping.UpgradeState{
-			CurrentProtocol: protocol.ConsensusCurrentVersion,
-		},
-		RewardsState: bookkeeping.RewardsState{
-			FeeSink:     feeSink,
-			RewardsPool: poolAddr,
-		},
-	}
+	blkHdr := createDummyBlockHeader()
 
 	// sign the transcation with logic
 	for i := 0; i < len(signedTxn); i++ {
@@ -708,17 +648,7 @@ func TestTxnGroupCacheUpdateLogicWithSig(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	_, signedTxn, secrets, addresses := generateTestObjects(100, 20, 50)
-	blkHdr := bookkeeping.BlockHeader{
-		Round:       50,
-		GenesisHash: crypto.Hash([]byte{1, 2, 3, 4, 5}),
-		UpgradeState: bookkeeping.UpgradeState{
-			CurrentProtocol: protocol.ConsensusCurrentVersion,
-		},
-		RewardsState: bookkeeping.RewardsState{
-			FeeSink:     feeSink,
-			RewardsPool: poolAddr,
-		},
-	}
+	blkHdr := createDummyBlockHeader()
 
 	for i := 0; i < len(signedTxn); i++ {
 		// add a simple logic that verifies this condition:
@@ -770,17 +700,7 @@ func TestTxnGroupCacheUpdateLogicWithMultiSig(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	secrets, _, pks, multiAddress := generateMultiSigAccounts(t, 30)
-	blkHdr := bookkeeping.BlockHeader{
-		Round:       50,
-		GenesisHash: crypto.Hash([]byte{1, 2, 3, 4, 5}),
-		UpgradeState: bookkeeping.UpgradeState{
-			CurrentProtocol: protocol.ConsensusCurrentVersion,
-		},
-		RewardsState: bookkeeping.RewardsState{
-			FeeSink:     feeSink,
-			RewardsPool: poolAddr,
-		},
-	}
+	blkHdr := createDummyBlockHeader()
 
 	const numOfTxn = 20
 	signedTxn := make([]transactions.SignedTxn, numOfTxn)
@@ -844,7 +764,7 @@ byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
 	restoreSignatureFunc := func(txn *transactions.SignedTxn) {
 		txn.Lsig.Msig.Subsigs[0].Sig[0]--
 	}
-	
+
 	verifyGroup(t, txnGroups, blkHdr, breakSignatureFunc, restoreSignatureFunc, crypto.ErrBatchVerificationFailed.Error())
 	// signature is correct and logic fails
 	breakSignatureFunc = func(txn *transactions.SignedTxn) {
@@ -854,6 +774,20 @@ byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
 		txn.Lsig.Args[0][0]--
 	}
 	verifyGroup(t, txnGroups, blkHdr, breakSignatureFunc, restoreSignatureFunc, "rejected by logic")
+}
+
+func createDummyBlockHeader() bookkeeping.BlockHeader {
+	return bookkeeping.BlockHeader{
+		Round:       50,
+		GenesisHash: crypto.Hash([]byte{1, 2, 3, 4, 5}),
+		UpgradeState: bookkeeping.UpgradeState{
+			CurrentProtocol: protocol.ConsensusCurrentVersion,
+		},
+		RewardsState: bookkeeping.RewardsState{
+			FeeSink:     feeSink,
+			RewardsPool: poolAddr,
+		},
+	}
 }
 
 // verifyGroup uses TxnGroup to verify txns and add them to the

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -609,10 +609,10 @@ func TestTxnGroupCacheUpdate(t *testing.T) {
 
 	txnGroups := generateTransactionGroups(signedTxn, secrets, addrs)
 	breakSignatureFunc := func(txn *transactions.SignedTxn) {
-		txn.Sig[0] += 1
+		txn.Sig[0]++
 	}
 	restoreSignatureFunc := func(txn *transactions.SignedTxn) {
-		txn.Sig[0] -= 1
+		txn.Sig[0]--
 	}
 	verifyGroup(t, txnGroups, blkHdr, breakSignatureFunc, restoreSignatureFunc, crypto.ErrBatchVerificationFailed.Error())
 }
@@ -639,10 +639,10 @@ func TestTxnGroupCacheUpdateMultiSig(t *testing.T) {
 		txnGroups[i][0] = signedTxn[i]
 	}
 	breakSignatureFunc := func(txn *transactions.SignedTxn) {
-		txn.Msig.Subsigs[0].Sig[0] += 1
+		txn.Msig.Subsigs[0].Sig[0]++
 	}
 	restoreSignatureFunc := func(txn *transactions.SignedTxn) {
-		txn.Msig.Subsigs[0].Sig[0] -= 1
+		txn.Msig.Subsigs[0].Sig[0]--
 	}
 	verifyGroup(t, txnGroups, blkHdr, breakSignatureFunc, restoreSignatureFunc, crypto.ErrBatchVerificationFailed.Error())
 }
@@ -684,10 +684,10 @@ byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
 	}
 
 	breakSignatureFunc := func(txn *transactions.SignedTxn) {
-		txn.Lsig.Args[0][0] += 1
+		txn.Lsig.Args[0][0]++
 	}
 	restoreSignatureFunc := func(txn *transactions.SignedTxn) {
-		txn.Lsig.Args[0][0] -= 1
+		txn.Lsig.Args[0][0]--
 	}
 	verifyGroup(t, txnGroups, blkHdr, breakSignatureFunc, restoreSignatureFunc, "rejected by logic")
 
@@ -733,10 +733,10 @@ byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
 	}
 
 	breakSignatureFunc := func(txn *transactions.SignedTxn) {
-		txn.Lsig.Sig[0] += 1
+		txn.Lsig.Sig[0]++
 	}
 	restoreSignatureFunc := func(txn *transactions.SignedTxn) {
-		txn.Lsig.Sig[0] -= 1
+		txn.Lsig.Sig[0]--
 	}
 	verifyGroup(t, txnGroups, blkHdr, breakSignatureFunc, restoreSignatureFunc, crypto.ErrBatchVerificationFailed.Error())
 }
@@ -813,10 +813,10 @@ byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
 	}
 
 	breakSignatureFunc := func(txn *transactions.SignedTxn) {
-		txn.Lsig.Msig.Subsigs[0].Sig[0] += 1
+		txn.Lsig.Msig.Subsigs[0].Sig[0]++
 	}
 	restoreSignatureFunc := func(txn *transactions.SignedTxn) {
-		txn.Lsig.Msig.Subsigs[0].Sig[0] -= 1
+		txn.Lsig.Msig.Subsigs[0].Sig[0]--
 	}
 	verifyGroup(t, txnGroups, blkHdr, breakSignatureFunc, restoreSignatureFunc, crypto.ErrBatchVerificationFailed.Error())
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Add several unit tests for verifying types of signatures on transactions. including: regular signature, multisignature and logicsignature

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
