### PR TITLE
CICD: reduce mmnet LastPartKeyRound to 50k

### DIFF
--- a/test/testdata/deployednettemplates/recipes/mmnet/genesis.json
+++ b/test/testdata/deployednettemplates/recipes/mmnet/genesis.json
@@ -3,7 +3,7 @@
 	"VersionModifier": "",
 	"ConsensusProtocol": "",
 	"FirstPartKeyRound": 0,
-	"LastPartKeyRound": 3000000,
+	"LastPartKeyRound": 50000,
 	"PartKeyDilution": 0,
 	"Wallets": [
 		{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

- this changes the `LastParKeyRound` of the `mmnet` recipe to 50,000 instead of 3,000,000.  this should speed up network bootstrapping. 