### PR TITLE
goal: don't mark app-arg as hidden for account command

### DIFF
--- a/cmd/goal/application.go
+++ b/cmd/goal/application.go
@@ -191,7 +191,6 @@ func init() {
 
 	panicIfErr(methodAppCmd.MarkFlagRequired("method"))
 	panicIfErr(methodAppCmd.MarkFlagRequired("from"))
-	panicIfErr(appCmd.PersistentFlags().MarkHidden("app-arg"))
 }
 
 func panicIfErr(err error) {


### PR DESCRIPTION
## Summary

In #4241 I noticed an unhandled error calling `methodAppCmd.Flags().MarkHidden("app-arg")` in cmd/goal/application.go and I resolved it incorrectly by changing it to `appCmd.PersistentFlags().MarkHidden("app-arg")` and @nullun noticed this dropped it from the auto-generated docs in https://github.com/algorand/docs/pull/918. So I should have left it unhidden, as this PR does.

## Test Plan

Existing tests should pass