### PR TITLE
txHandler: comment out expensive Debugf

### DIFF
--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -270,7 +270,7 @@ func (handler *TxHandler) checkAlreadyCommitted(tx *txBacklogMsg) (processingDon
 		for i := range tx.unverifiedTxGroup {
 			txids[i] = tx.unverifiedTxGroup[i].ID()
 		}
-		logging.Base().Debugf("got a tx group with IDs %v", txids)
+		//logging.Base().Debugf("got a tx group with IDs %v", txids)
 	}
 
 	// do a quick test to check that this transaction could potentially be committed, to reject dup pending transactions


### PR DESCRIPTION
## Summary

Looking at profiler output, this Debugf jumped out when looking at the alloc_objects profile (tracking object allocations per function).

## Test Plan

Existing tests should pass