### PR TITLE
API: bump max size of teal source and dryrun

### DIFF
--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -51,8 +51,14 @@ import (
 	"github.com/algorand/go-codec/codec"
 )
 
-const maxTealSourceBytes = 1e5
-const maxTealDryrunBytes = 1e5
+// max compiled teal program is currently 8k
+// but we allow for comments, spacing, and repeated consts
+// in the source teal, allow up to 200kb
+const maxTealSourceBytes = 2e5
+
+// With the ability to hold unlimited assets DryrunRequests can
+// become quite large, allow up to 1mb
+const maxTealDryrunBytes = 1e6
 
 // Handlers is an implementation to the V2 route handler interface defined by the generated code.
 type Handlers struct {

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -54,7 +54,7 @@ import (
 // max compiled teal program is currently 8k
 // but we allow for comments, spacing, and repeated consts
 // in the source teal, allow up to 200kb
-const maxTealSourceBytes = 2e5
+const maxTealSourceBytes = 200_000
 
 // With the ability to hold unlimited assets DryrunRequests can
 // become quite large, allow up to 1mb

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -58,7 +58,7 @@ const maxTealSourceBytes = 200_000
 
 // With the ability to hold unlimited assets DryrunRequests can
 // become quite large, allow up to 1mb
-const maxTealDryrunBytes = 1e6
+const maxTealDryrunBytes = 1_000_000
 
 // Handlers is an implementation to the V2 route handler interface defined by the generated code.
 type Handlers struct {


### PR DESCRIPTION
addresses #4632 