### PR TITLE
Replace isFull check by initializing EvalParams

### DIFF
--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -375,9 +375,10 @@ func NewEvalParams(txgroup []transactions.SignedTxnWithAD, proto *config.Consens
 	// Make a simpler EvalParams that is good enough to evaluate LogicSigs.
 	if apps == 0 {
 		return &EvalParams{
-			TxnGroup: txgroup,
-			Proto:    proto,
-			Specials: specials,
+			TxnGroup:  txgroup,
+			Proto:     proto,
+			Specials:  specials,
+			available: &resources{},
 		}
 	}
 

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -146,10 +146,6 @@ func defaultEvalParamsWithVersion(version uint64, txns ...transactions.SignedTxn
 	return ep
 }
 
-func (ep *EvalParams) isFull() bool {
-	return ep.available != nil
-}
-
 // reset puts an ep back into its original state.  This is in *_test.go because
 // no real code should ever need this. EvalParams should be created to evaluate
 // a group, and then thrown away.
@@ -4090,18 +4086,14 @@ func TestAnyRekeyToOrApplicationRaisesMinAvmVersion(t *testing.T) {
 			expected := fmt.Sprintf("program version must be >= %d", cse.validFromVersion)
 			for v := uint64(0); v < cse.validFromVersion; v++ {
 				ops := testProg(t, source, v)
-				if ep.isFull() {
-					testAppBytes(t, ops.Program, ep, expected, expected)
-				}
+				testAppBytes(t, ops.Program, ep, expected, expected)
 				testLogicBytes(t, ops.Program, ep, expected, expected)
 			}
 
 			// Should succeed for all versions >= validFromVersion
 			for v := cse.validFromVersion; v <= AssemblerMaxVersion; v++ {
 				ops := testProg(t, source, v)
-				if ep.isFull() {
-					testAppBytes(t, ops.Program, ep)
-				}
+				testAppBytes(t, ops.Program, ep)
 				testLogicBytes(t, ops.Program, ep)
 			}
 		})


### PR DESCRIPTION
Responds to https://github.com/algorand/go-algorand/pull/4149#discussion_r968739722 by proposing a way to remove the `isFull` branching.

While I think the PR _works_, it's unclear to me if the change is desired and complete.  I expect reviewers to help assess scope.

https://github.com/algorand/go-algorand/pull/4149#discussion_r968739722 caught my attention because the branching felt _strange_.  I deduced the following from history inspection:
* https://github.com/algorand/go-algorand/commit/af3b5d384371cfd3493de331a1c86c297806f9ec#diff-7efbb393ce12c86b88888ff627dd385ba50ec9937b26082263ef580068080d27R302-R310 introduced the `EvalParams` construction that breaks now.
* From reading the associated inline comments, the intent is logicsig only, but the tests in question exercise apps.  It's unclear to me why the branching was implemented rather than something like this PR.

PR notes:
* I'm _assuming_ the PR presents a more robust alternative by ensuring unintended usage does _not_ panic.
* I'm trusting the absence of failing tests to suggest that the change is complete.  Perhaps reviewers will identify other obvious initialization that ought to happen.