### PR TITLE
performance: use *[]byte with protocol.encodingPool

### DIFF
--- a/protocol/codec.go
+++ b/protocol/codec.go
@@ -278,7 +278,7 @@ func (d *MsgpDecoderBytes) Decode(objptr msgp.Unmarshaler) error {
 // encodingPool holds temporary byte slice buffers used for encoding messages.
 var encodingPool = sync.Pool{
 	New: func() interface{} {
-		return []byte{}
+		return &[]byte{}
 	},
 }
 
@@ -287,12 +287,12 @@ var encodingPool = sync.Pool{
 // non-zero capacity.  The caller gets full ownership of the byte slice,
 // but is encouraged to return it using PutEncodingBuf().
 func GetEncodingBuf() []byte {
-	return encodingPool.Get().([]byte)[:0]
+	return (*encodingPool.Get().(*[]byte))[:0]
 }
 
 // PutEncodingBuf places a byte slice into the pool of temporary buffers
 // for encoding.  The caller gives up ownership of the byte slice when
 // passing it to PutEncodingBuf().
 func PutEncodingBuf(s []byte) {
-	encodingPool.Put(s)
+	encodingPool.Put(&s)
 }


### PR DESCRIPTION
## Summary

Using a `[]byte` with sync.Pool requires allocating a copy of each `[]byte` when converting it into an `interface{}` to pass to sync.Put. This should reduce the number of allocations required by our usage of sync.Pool.

## Test Plan

Existing tests should pass, will look for existing benchmarks to show improvement and add as a comment, or write one.