### PR TITLE
network: compression followup fixes

### DIFF
--- a/network/msgCompressor.go
+++ b/network/msgCompressor.go
@@ -75,7 +75,8 @@ func zstdCompressMsg(tbytes []byte, d []byte) ([]byte, string) {
 }
 
 // MaxDecompressedMessageSize defines a maximum decompressed data size
-// to prevent zip bombs
+// to prevent zip bombs. This depends on MaxTxnBytesPerBlock consensus parameter
+// and should be larger.
 const MaxDecompressedMessageSize = 20 * 1024 * 1024 // some large enough value
 
 // wsPeerMsgDataConverter performs optional incoming messages conversion.

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1464,7 +1464,7 @@ func (wn *WebsocketNetwork) preparePeerData(request broadcastRequest, prio bool,
 		}
 
 		if prio && request.tags[i] == protocol.ProposalPayloadTag {
-			networkPrioPPNonCompressedSize.Add(float64(len(d)), nil)
+			networkPrioPPNonCompressedSize.AddUint64(uint64(len(d)), nil)
 		}
 
 		if wantCompression {
@@ -1473,7 +1473,7 @@ func (wn *WebsocketNetwork) preparePeerData(request broadcastRequest, prio bool,
 				if len(logMsg) > 0 {
 					wn.log.Warn(logMsg)
 				} else {
-					networkPrioPPCompressedSize.Add(float64(len(compressed)), nil)
+					networkPrioPPCompressedSize.AddUint64(uint64(len(compressed)), nil)
 				}
 				dataCompressed[i] = compressed
 			} else {


### PR DESCRIPTION
## Summary

* Better comment for max compressed proposal message
* Use `AddUint64` instead of `Add` for integer metric

## Test Plan

Rely on existing tests