### PR TITLE
Perf test: Transaction group handle/verify

### DIFF
--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -122,6 +122,8 @@ func reencode(stxns []transactions.SignedTxn) []byte {
 // backlogWorker is the worker go routine that process the incoming messages from the postVerificationQueue and backlogQueue channels
 // and dispatches them further.
 func (handler *TxHandler) backlogWorker() {
+	// Note: TestIncomingTxHandle and TestIncomingTxGroupHandle emulate this function.
+	// Changes to the behavior in this function should be reflected in the test.
 	defer handler.backlogWg.Done()
 	for {
 		// prioritize the postVerificationQueue

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -384,7 +384,6 @@ func incomingTxHandlerProcessing(maxGroupSize int, t *testing.T) {
 		defer func() {
 			t.Logf("processed %d txn groups (%d txns)\n", groupCounter, txnCounter)
 		}()
-		tt := time.Now()
 		for wi := range outChan {
 			txnCounter = txnCounter + len(wi.unverifiedTxGroup)
 			groupCounter++

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -17,6 +17,7 @@
 package data
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 	"math/rand"
@@ -247,4 +248,178 @@ func BenchmarkTxHandlerDecoderMsgp(b *testing.B) {
 		}
 		require.Equal(b, benchTxnNum, idx)
 	}
+}
+
+func BenchmarkIncomingTxHandlerProcessing(b *testing.B) {
+	const numUsers = 100
+	log := logging.TestingLog(b)
+	log.SetLevel(logging.Warn)
+	secrets := make([]*crypto.SignatureSecrets, numUsers)
+	addresses := make([]basics.Address, numUsers)
+
+	genesis := make(map[basics.Address]basics.AccountData)
+	for i := 0; i < numUsers; i++ {
+		secret := keypair()
+		addr := basics.Address(secret.SignatureVerifier)
+		secrets[i] = secret
+		addresses[i] = addr
+		genesis[addr] = basics.AccountData{
+			Status:     basics.Online,
+			MicroAlgos: basics.MicroAlgos{Raw: 10000000000000},
+		}
+	}
+
+	genesis[poolAddr] = basics.AccountData{
+		Status:     basics.NotParticipating,
+		MicroAlgos: basics.MicroAlgos{Raw: config.Consensus[protocol.ConsensusCurrentVersion].MinBalance},
+	}
+
+	require.Equal(b, len(genesis), numUsers+1)
+	genBal := bookkeeping.MakeGenesisBalances(genesis, sinkAddr, poolAddr)
+	ledgerName := fmt.Sprintf("%s-mem-%d", b.Name(), b.N)
+	const inMem = true
+	cfg := config.GetDefaultLocal()
+	cfg.Archival = true
+	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, nil, cfg)
+	require.NoError(b, err)
+
+	l := ledger
+
+	cfg.TxPoolSize = 75000
+	cfg.EnableProcessBlockStats = false
+	tp := pools.MakeTransactionPool(l.Ledger, cfg, logging.Base())
+	backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)
+	txHandler := MakeTxHandler(tp, l, &mocks.MockNetwork{}, "", crypto.Digest{}, backlogPool)
+
+	outChan := make(chan *txBacklogMsg, 10)
+
+	// Make a test backlog worker, which is simiar to backlogWorker, but sends the results
+	// through the outChan instead of passing it to postprocessCheckedTxn
+	go func() {
+		for {
+			// prioritize the postVerificationQueue
+			select {
+			case wi, ok := <-txHandler.postVerificationQueue:
+				if !ok {
+					return
+				}
+				outChan <- wi
+				// restart the loop so that we could empty out the post verification queue.
+				continue
+			default:
+			}
+
+			// we have no more post verification items. wait for either backlog queue item or post verification item.
+			select {
+			case wi, ok := <-txHandler.backlogQueue:
+				if !ok {
+					return
+				}
+				if txHandler.checkAlreadyCommitted(wi) {
+					continue
+				}
+
+			// enqueue the task to the verification pool.
+			txHandler.txVerificationPool.EnqueueBacklog(txHandler.ctx, txHandler.asyncVerifySignature, wi, nil)
+
+			case wi, ok := <-txHandler.postVerificationQueue:
+				if !ok {
+					return
+				}
+				outChan <- wi
+
+			case <-txHandler.ctx.Done():
+				return
+			}
+		}
+	}()
+
+	goodTxnGroups := make(map[uint64]interface{})
+	badTxnGroups := make(map[uint64]interface{})
+	makeSignedTxnGroups := func(N int) [][]transactions.SignedTxn {
+		maxGrpSize := proto.MaxTxGroupSize
+		ret := make([][]transactions.SignedTxn, 0, N)
+		for u := 0; u < N; u++ {
+			grpSize := rand.Intn(maxGrpSize-1) + 1
+			var txGroup transactions.TxGroup
+			txns := make([]transactions.Transaction, 0, grpSize)
+			for g := 0; g < grpSize; g++ {
+				// generate transactions
+				noteField := make([]byte, binary.MaxVarintLen64)
+				binary.PutUvarint(noteField, uint64(u))
+				tx := transactions.Transaction{
+					Type: protocol.PaymentTx,
+					Header: transactions.Header{
+						Sender:      addresses[(u+g)%numUsers],
+						Fee:         basics.MicroAlgos{Raw: proto.MinTxnFee * 2},
+						FirstValid:  0,
+						LastValid:   basics.Round(proto.MaxTxnLife),
+						GenesisHash: genesisHash,
+						Note:        noteField,
+					},
+					PaymentTxnFields: transactions.PaymentTxnFields{
+						Receiver: addresses[(u+g+1)%numUsers],
+						Amount:   basics.MicroAlgos{Raw: mockBalancesMinBalance + (rand.Uint64() % 10000)},
+					},
+				}
+				txGroup.TxGroupHashes = append(txGroup.TxGroupHashes, crypto.Digest(tx.ID()))
+				txns = append(txns, tx)
+			}
+			groupHash := crypto.HashObj(txGroup)
+			signedTxGroup := make([]transactions.SignedTxn, 0, grpSize)
+			for g, txn := range txns {
+				txn.Group = groupHash
+				signedTx := txn.Sign(secrets[(u+g)%numUsers])
+				signedTx.Txn = txn
+				signedTxGroup = append(signedTxGroup, signedTx)
+			}
+			// randomly make bad signatures
+			if rand.Float32() < 0.3 {
+				tinGrp := rand.Intn(grpSize)
+				signedTxGroup[tinGrp].Sig[0] = signedTxGroup[tinGrp].Sig[0] + 1
+				badTxnGroups[uint64(u)] = struct{}{}
+			} else {
+				goodTxnGroups[uint64(u)] = struct{}{}
+			}
+			ret = append(ret, signedTxGroup)
+		}
+		return ret
+	}
+
+	signedTransactionGroups := makeSignedTxnGroups(b.N)
+	encodedSignedTransactionGroups := make([]network.IncomingMessage, 0, b.N)
+	for _, stxngrp := range signedTransactionGroups {
+		data := make([]byte, 0)
+		for _, stxn := range stxngrp {
+			data = append(data, protocol.Encode(&stxn)...)
+		}
+		encodedSignedTransactionGroups =
+			append(encodedSignedTransactionGroups, network.IncomingMessage{Data: data})
+	}
+
+	for _, tg := range encodedSignedTransactionGroups {
+		txHandler.processIncomingTxn(tg)
+	}
+
+	go func() {
+		defer close(txHandler.postVerificationQueue)
+		counter := 0
+		b.ResetTimer()
+		for wi := range outChan {
+			counter++
+			u, _ := binary.Uvarint(wi.unverifiedTxGroup[0].Txn.Note)
+			if wi.verificationErr == nil {
+				if _, found := goodTxnGroups[u]; !found {
+					fmt.Printf("wrong!")
+				}
+			} else {
+				if _, found := badTxnGroups[u]; !found {
+					fmt.Printf("wrong!")
+				}
+			}
+			if counter == b.N {
+				break
+			}
+		}
+	}()
 }

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -341,6 +341,7 @@ func BenchmarkIncomingTxHandlerProcessing(b *testing.B) {
 		ret := make([][]transactions.SignedTxn, 0, N)
 		for u := 0; u < N; u++ {
 			grpSize := rand.Intn(maxGrpSize-1) + 1
+			grpSize = 1
 			var txGroup transactions.TxGroup
 			txns := make([]transactions.Transaction, 0, grpSize)
 			for g := 0; g < grpSize; g++ {

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -373,9 +373,9 @@ func BenchmarkIncomingTxHandlerProcessing(b *testing.B) {
 			fmt.Printf("processed %d txns\n", counter)
 		}()
 		b.ResetTimer()
+		tt := time.Now()
 		for wi := range outChan {
 			counter++
-
 			u, _ := binary.Uvarint(wi.unverifiedTxGroup[0].Txn.Note)
 			_, inBad := badTxnGroups[u]
 			if wi.verificationErr == nil {
@@ -384,6 +384,7 @@ func BenchmarkIncomingTxHandlerProcessing(b *testing.B) {
 				require.True(b, inBad, "Error for good signature")
 			}
 		}
+		fmt.Printf("TPS: %d\n", uint64(counter)*1000000000/uint64(time.Since(tt)))
 	}()
 
 	// Send the transactions to the verifier

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -254,7 +254,8 @@ func BenchmarkTxHandlerDecoderMsgp(b *testing.B) {
 }
 
 // BenchmarkIncomingTxHandlerProcessing sends singed transactions to be handled and verified
-// It reports the number of dropped transactions
+// It reports the number of dropped transactions. This includes the decoding of the
+// messages, and emulating the backlog processing.
 func BenchmarkIncomingTxHandlerProcessing(b *testing.B) {
 	const numUsers = 100
 	log := logging.TestingLog(b)
@@ -391,7 +392,6 @@ func BenchmarkIncomingTxHandlerProcessing(b *testing.B) {
 
 	// Send the transactions to the verifier
 	for _, tg := range encodedSignedTransactionGroups {
-		// time the streaming of the txns to at most 6000 tps
 		handler.processIncomingTxn(tg)
 		randduration := time.Duration(uint64(((1 + rand.Float32()) * 3)))
 		time.Sleep(randduration * time.Microsecond)
@@ -452,7 +452,7 @@ func makeSignedTxnGroups(N, numUsers int, addresses []basics.Address,
 			signedTxGroup = append(signedTxGroup, signedTx)
 		}
 		// randomly make bad signatures
-		if rand.Float32() < 0.1 {
+		if rand.Float32() < 0.0001 {
 			tinGrp := rand.Intn(grpSize)
 			signedTxGroup[tinGrp].Sig[0] = signedTxGroup[tinGrp].Sig[0] + 1
 			badTxnGroups[uint64(u)] = struct{}{}
@@ -460,4 +460,97 @@ func makeSignedTxnGroups(N, numUsers int, addresses []basics.Address,
 		ret = append(ret, signedTxGroup)
 	}
 	return
+}
+
+// BenchmarkHandler sends singed transactions to be handled and verified
+func BenchmarkHandler(b *testing.B) {
+	const numUsers = 100
+	log := logging.TestingLog(b)
+	log.SetLevel(logging.Warn)
+	addresses := make([]basics.Address, numUsers)
+	secrets := make([]*crypto.SignatureSecrets, numUsers)
+
+	// prepare the accounts
+	genesis := make(map[basics.Address]basics.AccountData)
+	for i := 0; i < numUsers; i++ {
+		secret := keypair()
+		addr := basics.Address(secret.SignatureVerifier)
+		secrets[i] = secret
+		addresses[i] = addr
+		genesis[addr] = basics.AccountData{
+			Status:     basics.Online,
+			MicroAlgos: basics.MicroAlgos{Raw: 10000000000000},
+		}
+	}
+	genesis[poolAddr] = basics.AccountData{
+		Status:     basics.NotParticipating,
+		MicroAlgos: basics.MicroAlgos{Raw: config.Consensus[protocol.ConsensusCurrentVersion].MinBalance},
+	}
+
+	require.Equal(b, len(genesis), numUsers+1)
+	genBal := bookkeeping.MakeGenesisBalances(genesis, sinkAddr, poolAddr)
+	ledgerName := fmt.Sprintf("%s-mem-%d", b.Name(), b.N)
+	const inMem = true
+	cfg := config.GetDefaultLocal()
+	cfg.Archival = true
+	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, nil, cfg)
+	require.NoError(b, err)
+
+	l := ledger
+	tp := pools.MakeTransactionPool(l.Ledger, cfg, logging.Base())
+	backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)
+	handler := MakeTxHandler(tp, l, &mocks.MockNetwork{}, "", crypto.Digest{}, backlogPool)
+	defer handler.ctxCancel()
+
+	// Prepare the transactions
+	signedTransactionGroups, badTxnGroups := makeSignedTxnGroups(b.N, numUsers, addresses, secrets)
+	outChan := handler.postVerificationQueue
+	wg := sync.WaitGroup{}
+
+	// Process the results and make sure they are correct
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		groupCounter := 0
+		txnCounter := 0
+		invalidCounter := 0
+		defer func() {
+			fmt.Printf("processed %d txn groups (%d txns)\n", groupCounter, txnCounter)
+		}()
+		b.ResetTimer()
+		tt := time.Now()
+		for wi := range outChan {
+			txnCounter = txnCounter + len(wi.unverifiedTxGroup)
+			groupCounter++
+			u, _ := binary.Uvarint(wi.unverifiedTxGroup[0].Txn.Note)
+			_, inBad := badTxnGroups[u]
+			if wi.verificationErr == nil {
+				require.False(b, inBad, "No error for invalid signature")
+			} else {
+				invalidCounter++
+				require.True(b, inBad, "Error for good signature")
+			}
+		}
+		fmt.Printf("TPS: %d\n", uint64(txnCounter)*1000000000/uint64(time.Since(tt)))
+		fmt.Printf("Txn groups with invalid sigs: %d\n", invalidCounter)
+	}()
+
+	for _, stxngrp := range signedTransactionGroups {
+		blm := txBacklogMsg{rawmsg: nil, unverifiedTxGroup: stxngrp}
+		handler.txVerificationPool.EnqueueBacklog(handler.ctx, handler.asyncVerifySignature, &blm, nil)
+	}
+	// shut down to end the test
+	handler.txVerificationPool.Shutdown()
+	close(handler.postVerificationQueue)
+	close(handler.backlogQueue)
+	wg.Wait()
+
+	// Report the number of transactions dropped because the backlog was busy
+	var buf strings.Builder
+	metrics.DefaultRegistry().WriteMetrics(&buf, "")
+	str := buf.String()
+	x := strings.Index(str, "\nalgod_transaction_messages_dropped_backlog")
+	str = str[x+44 : x+44+strings.Index(str[x+44:], "\n")]
+	str = strings.TrimSpace(strings.ReplaceAll(str, "}", " "))
+	fmt.Printf("dropped %s txn gropus\n", str)
 }

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -261,11 +261,8 @@ func TestIncomingTxGroupHandle(t *testing.T) {
 	incomingTxHandlerProcessing(proto.MaxTxGroupSize, t)
 }
 
-// incomingTxHandlerProcessing is comprehensive transaction handling test, emulating
-// the production code as much as possible.
-// sends singed transactions to be handled and verified
-// It reports the number of dropped transactions. This includes the decoding of the
-// messages, and emulating the backlog processing.
+// incomingTxHandlerProcessing is a comprehensive transaction handling test
+// It handles the singed transactions by passing them to the backlog for verification
 func incomingTxHandlerProcessing(maxGroupSize int, t *testing.T) {
 	const numUsers = 100
 	numberOfTransactionGroups := 1000
@@ -418,8 +415,9 @@ func incomingTxHandlerProcessing(maxGroupSize int, t *testing.T) {
 	t.Logf("dropped %s txn gropus\n", str)
 }
 
-// Prepare N transaction groups of random sizes with randomly invalid signatures
-func makeSignedTxnGroups(N, numUsers, maxGroupSize int, invalid float32, addresses []basics.Address,
+// makeSignedTxnGroups prepares N transaction groups of random (maxGroupSize) sizes with random
+// invalid signatures of a given probability (invalidProb)
+func makeSignedTxnGroups(N, numUsers, maxGroupSize int, invalidProb float32, addresses []basics.Address,
 	secrets []*crypto.SignatureSecrets) (ret [][]transactions.SignedTxn,
 	badTxnGroups map[uint64]interface{}) {
 	badTxnGroups = make(map[uint64]interface{})
@@ -464,7 +462,7 @@ func makeSignedTxnGroups(N, numUsers, maxGroupSize int, invalid float32, address
 			signedTxGroup = append(signedTxGroup, signedTx)
 		}
 		// randomly make bad signatures
-		if rand.Float32() < invalid {
+		if rand.Float32() < invalidProb {
 			tinGrp := rand.Intn(grpSize)
 			signedTxGroup[tinGrp].Sig[0] = signedTxGroup[tinGrp].Sig[0] + 1
 			badTxnGroups[uint64(u)] = struct{}{}
@@ -474,17 +472,19 @@ func makeSignedTxnGroups(N, numUsers, maxGroupSize int, invalid float32, address
 	return
 }
 
-// BenchmarkHandler sends singed transactions to be handled and verified
+// BenchmarkHandler sends singed transactions the the verifier
 func BenchmarkHandleTxns(b *testing.B) {
 	b.N = b.N * proto.MaxTxGroupSize / 2
 	runHandlerBenchmark(1, b)
 }
 
-// BenchmarkHandler sends singed transaction groups to be handled and verified
+// BenchmarkHandler sends singed transaction groups to the verifier
 func BenchmarkHandleTxnGroups(b *testing.B) {
 	runHandlerBenchmark(proto.MaxTxGroupSize, b)
 }
 
+// runHandlerBenchmark has a similar workflow to incomingTxHandlerProcessing,
+// but bypasses the backlog, and sends the transactions directly to the verifier
 func runHandlerBenchmark(maxGroupSize int, b *testing.B) {
 	const numUsers = 100
 	log := logging.TestingLog(b)

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -274,7 +274,6 @@ func BenchmarkIncomingTxHandlerProcessing(b *testing.B) {
 			MicroAlgos: basics.MicroAlgos{Raw: 10000000000000},
 		}
 	}
-
 	genesis[poolAddr] = basics.AccountData{
 		Status:     basics.NotParticipating,
 		MicroAlgos: basics.MicroAlgos{Raw: config.Consensus[protocol.ConsensusCurrentVersion].MinBalance},
@@ -296,9 +295,7 @@ func BenchmarkIncomingTxHandlerProcessing(b *testing.B) {
 	defer handler.ctxCancel()
 
 	outChan := make(chan *txBacklogMsg, 10)
-
 	wg := sync.WaitGroup{}
-
 	wg.Add(1)
 	// Make a test backlog worker, which is simiar to backlogWorker, but sends the results
 	// through the outChan instead of passing it to postprocessCheckedTxn
@@ -411,7 +408,6 @@ func BenchmarkIncomingTxHandlerProcessing(b *testing.B) {
 func makeSignedTxnGroups(N, numUsers int, addresses []basics.Address,
 	secrets []*crypto.SignatureSecrets) (ret [][]transactions.SignedTxn,
 	badTxnGroups map[uint64]interface{}) {
-
 	badTxnGroups = make(map[uint64]interface{})
 
 	maxGrpSize := proto.MaxTxGroupSize


### PR DESCRIPTION
Performance test for incoming transaction group handling/verifying.
Prepares transaction groups of random sizes, sends them to the handler, which verifies and returns the results.
The transaction group sizes are random. Introduces 10% invalid signatures and makes sure they are properly reported. 