### PR TITLE
Copy TestNullString to illustrate conversion process

### DIFF
--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -4422,3 +4422,25 @@ func TestRemoveOfflineStateProofID(t *testing.T) {
 		}
 	}
 }
+
+// Adapted from https://github.com/golang/go/blob/go1.17.9/src/database/sql/convert_test.go#L287-L303.
+func TestNullString(t *testing.T) {
+	var ns sql.NullString
+	err := ns.Scan([]byte("foo"))
+	require.NoError(t, err)
+	if !ns.Valid {
+		t.Errorf("expecting not null")
+	}
+	if ns.String != "foo" {
+		t.Errorf("expecting foo; got %q", ns.String)
+	}
+
+	err = ns.Scan(nil)
+	require.NoError(t, err)
+	if ns.Valid {
+		t.Errorf("expecting null on nil")
+	}
+	if ns.String != "" {
+		t.Errorf("expecting blank on nil; got %q", ns.String)
+	}
+}


### PR DESCRIPTION
Not intended for merge - Adds a temporary test to help respond to https://github.com/algorand/go-algorand/pull/4149#discussion_r995072208.

Copies a test from golang source to make it easier to debug locally.  By stepping through execution, I confirmed conversion to `NullString` happens in https://github.com/golang/go/blob/go1.17.9/src/database/sql/convert.go#L245-L250.  

* Since there's no character encoding logic, it _feels_ safe to me to keep as is.  
* The `*RawBytes` marshalling happens on ln 263.  It looks equivalent to me from a performance perspective.

_If_ we decide that we prefer `*RawBytes`, I can open a PR.  I have changes made locally in another branch.