### PR TITLE
pingpong: fix config check for GeneratedAccountsMnemonics

### DIFF
--- a/cmd/pingpong/runCmd.go
+++ b/cmd/pingpong/runCmd.go
@@ -394,7 +394,7 @@ var runCmd = &cobra.Command{
 			cfg.GeneratedAccountSampleMethod = generatedAccountSampleMethod
 		}
 		// check if numAccounts is greater than the length of the mnemonic list, if provided
-		if cfg.NumPartAccounts > uint32(len(cfg.GeneratedAccountsMnemonics)) {
+		if cfg.DeterministicKeys && cfg.NumPartAccounts > uint32(len(cfg.GeneratedAccountsMnemonics)) {
 			reportErrorf("numAccounts is greater than number of account mnemonics provided")
 		}
 


### PR DESCRIPTION
## Summary

In #4628 I added a configuration check on the list of account mnemonics without conditionalizing it on whether you were using that feature. This fixes that check.