### PR TITLE
catchpoints: skip first account hash if ExpectingMoreEntries is true

### DIFF
--- a/ledger/catchupaccessor.go
+++ b/ledger/catchupaccessor.go
@@ -487,7 +487,7 @@ func (c *CatchpointCatchupAccessorImpl) processStagingBalances(ctx context.Conte
 		defer wg.Done()
 		errHashes = wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 			start := time.Now()
-			err := writeCatchpointStagingHashes(ctx, tx, normalizedAccountBalances)
+			err := writeCatchpointStagingHashes(ctx, tx, normalizedAccountBalances, expectingMoreEntries)
 			durHashes = time.Since(start)
 			return err
 		})


### PR DESCRIPTION
## Summary

When an account is split over multiple catchpoint file chunks, we attempt to add its account hash to the catchpoint merkle trie twice, yielding a database error when processing the catchpoint. This attempts to fix that issue.

## Test Plan

Needs testing