### PR TITLE
catchpoints: don't make duplicate account hashes in prepareNormalizedBalances

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -427,12 +427,21 @@ func prepareNormalizedBalancesV6(bals []encodedBalanceRecordV6, proto config.Con
 			normalizedAccountBalances[i].accountData.MicroAlgos,
 			proto)
 		normalizedAccountBalances[i].encodedAccountData = balance.AccountData
-		normalizedAccountBalances[i].accountHashes = make([][]byte, 1+len(balance.Resources))
-		normalizedAccountBalances[i].accountHashes[0] = accountHashBuilderV6(balance.Address, &normalizedAccountBalances[i].accountData, balance.AccountData)
+		curHashIdx := 0
+		if balance.ExpectingMoreEntries {
+			// There is a single chunk in the catchpoint file with ExpectingMoreEntries
+			// set to false for this account. There may be multiple chunks with
+			// ExpectingMoreEntries set to true. In this case, we do not have to add the
+			// account's own hash to accountHashes.
+			normalizedAccountBalances[i].accountHashes = make([][]byte, len(balance.Resources))
+		} else {
+			normalizedAccountBalances[i].accountHashes = make([][]byte, 1+len(balance.Resources))
+			normalizedAccountBalances[i].accountHashes[0] = accountHashBuilderV6(balance.Address, &normalizedAccountBalances[i].accountData, balance.AccountData)
+			curHashIdx++
+		}
 		if len(balance.Resources) > 0 {
 			normalizedAccountBalances[i].resources = make(map[basics.CreatableIndex]resourcesData, len(balance.Resources))
 			normalizedAccountBalances[i].encodedResources = make(map[basics.CreatableIndex][]byte, len(balance.Resources))
-			resIdx := 0
 			for cidx, res := range balance.Resources {
 				var resData resourcesData
 				err = protocol.Decode(res, &resData)
@@ -447,10 +456,10 @@ func prepareNormalizedBalancesV6(bals []encodedBalanceRecordV6, proto config.Con
 				} else {
 					err = fmt.Errorf("unknown creatable for addr %s, aidx %d, data %v", balance.Address.String(), cidx, resData)
 				}
-				normalizedAccountBalances[i].accountHashes[resIdx+1] = resourcesHashBuilderV6(balance.Address, basics.CreatableIndex(cidx), ctype, resData.UpdateRound, res)
+				normalizedAccountBalances[i].accountHashes[curHashIdx] = resourcesHashBuilderV6(balance.Address, basics.CreatableIndex(cidx), ctype, resData.UpdateRound, res)
 				normalizedAccountBalances[i].resources[basics.CreatableIndex(cidx)] = resData
 				normalizedAccountBalances[i].encodedResources[basics.CreatableIndex(cidx)] = res
-				resIdx++
+				curHashIdx++
 			}
 		}
 	}

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -371,6 +371,8 @@ type normalizedAccountBalance struct {
 	normalizedBalance uint64
 	// encodedResources provides the encoded form of the resources
 	encodedResources map[basics.CreatableIndex][]byte
+	// partial balance indicates that the original account balance was split into multiple parts in catchpoint creation time
+	partialBalance bool
 }
 
 // prepareNormalizedBalancesV5 converts an array of encodedBalanceRecordV5 into an equal size array of normalizedAccountBalances.
@@ -434,6 +436,7 @@ func prepareNormalizedBalancesV6(bals []encodedBalanceRecordV6, proto config.Con
 			// ExpectingMoreEntries set to true. In this case, we do not have to add the
 			// account's own hash to accountHashes.
 			normalizedAccountBalances[i].accountHashes = make([][]byte, len(balance.Resources))
+			normalizedAccountBalances[i].partialBalance = true
 		} else {
 			normalizedAccountBalances[i].accountHashes = make([][]byte, 1+len(balance.Resources))
 			normalizedAccountBalances[i].accountHashes[0] = accountHashBuilderV6(balance.Address, &normalizedAccountBalances[i].accountData, balance.AccountData)

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -394,6 +394,9 @@ func TestFullCatchpointWriter(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	err = accessor.BuildMerkleTrie(context.Background(), nil)
+	require.NoError(t, err)
+
 	err = l.trackerDBs.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 		err := applyCatchpointStagingBalances(ctx, tx, 0, 0)
 		return err
@@ -700,6 +703,9 @@ func TestFullCatchpointWriterOverflowAccounts(t *testing.T) {
 		err = accessor.ProgressStagingBalances(context.Background(), header.Name, balancesBlockBytes, &catchupProgress)
 		require.NoError(t, err)
 	}
+
+	err = accessor.BuildMerkleTrie(context.Background(), nil)
+	require.NoError(t, err)
 
 	err = l.trackerDBs.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 		err := applyCatchpointStagingBalances(ctx, tx, 0, 0)

--- a/ledger/catchupaccessor.go
+++ b/ledger/catchupaccessor.go
@@ -537,10 +537,12 @@ func (c *catchpointCatchupAccessorImpl) processStagingBalances(ctx context.Conte
 	progress.HashesWriteDuration += durHashes
 
 	ledgerProcessstagingbalancesMicros.AddMicrosecondsSince(start, nil)
-	progress.ProcessedAccounts += uint64(len(normalizedAccountBalances))
 	progress.ProcessedBytes += uint64(len(bytes))
 	for _, acctBal := range normalizedAccountBalances {
 		progress.TotalAccountHashes += uint64(len(acctBal.accountHashes))
+		if !acctBal.partialBalance {
+			progress.ProcessedAccounts++
+		}
 	}
 
 	// not strictly required, but clean up the pointer when we're done.

--- a/ledger/catchupaccessor.go
+++ b/ledger/catchupaccessor.go
@@ -91,9 +91,45 @@ type CatchpointCatchupAccessor interface {
 	Ledger() (l CatchupAccessorClientLedger)
 }
 
-// CatchpointCatchupAccessorImpl is the concrete implementation of the CatchpointCatchupAccessor interface
-type CatchpointCatchupAccessorImpl struct {
+type stagingWriter interface {
+	writeBalances(context.Context, []normalizedAccountBalance) error
+	writeCreatables(context.Context, []normalizedAccountBalance) error
+	writeHashes(context.Context, []normalizedAccountBalance) error
+	isShared() bool
+}
+
+type stagingWriterImpl struct {
+	wdb db.Accessor
+}
+
+func (w *stagingWriterImpl) writeBalances(ctx context.Context, balances []normalizedAccountBalance) error {
+	return w.wdb.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
+		return writeCatchpointStagingBalances(ctx, tx, balances)
+	})
+}
+
+func (w *stagingWriterImpl) writeCreatables(ctx context.Context, balances []normalizedAccountBalance) error {
+	return w.wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		return writeCatchpointStagingCreatable(ctx, tx, balances)
+	})
+}
+
+func (w *stagingWriterImpl) writeHashes(ctx context.Context, balances []normalizedAccountBalance) error {
+	return w.wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		err := writeCatchpointStagingHashes(ctx, tx, balances)
+		return err
+	})
+}
+
+func (w *stagingWriterImpl) isShared() bool {
+	return w.wdb.IsSharedCacheConnection()
+}
+
+// catchpointCatchupAccessorImpl is the concrete implementation of the CatchpointCatchupAccessor interface
+type catchpointCatchupAccessorImpl struct {
 	ledger *Ledger
+
+	stagingWriter stagingWriter
 
 	// log copied from ledger
 	log logging.Logger
@@ -135,14 +171,15 @@ type CatchupAccessorClientLedger interface {
 
 // MakeCatchpointCatchupAccessor creates a CatchpointCatchupAccessor given a ledger
 func MakeCatchpointCatchupAccessor(ledger *Ledger, log logging.Logger) CatchpointCatchupAccessor {
-	return &CatchpointCatchupAccessorImpl{
-		ledger: ledger,
-		log:    log,
+	return &catchpointCatchupAccessorImpl{
+		ledger:        ledger,
+		stagingWriter: &stagingWriterImpl{wdb: ledger.trackerDB().Wdb},
+		log:           log,
 	}
 }
 
 // GetState returns the current state of the catchpoint catchup
-func (c *CatchpointCatchupAccessorImpl) GetState(ctx context.Context) (state CatchpointCatchupState, err error) {
+func (c *catchpointCatchupAccessorImpl) GetState(ctx context.Context) (state CatchpointCatchupState, err error) {
 	var istate uint64
 	istate, err = readCatchpointStateUint64(ctx, c.ledger.trackerDB().Rdb.Handle, catchpointStateCatchupState)
 	if err != nil {
@@ -153,7 +190,7 @@ func (c *CatchpointCatchupAccessorImpl) GetState(ctx context.Context) (state Cat
 }
 
 // SetState set the state of the catchpoint catchup
-func (c *CatchpointCatchupAccessorImpl) SetState(ctx context.Context, state CatchpointCatchupState) (err error) {
+func (c *catchpointCatchupAccessorImpl) SetState(ctx context.Context, state CatchpointCatchupState) (err error) {
 	if state < CatchpointCatchupStateInactive || state > catchpointCatchupStateLast {
 		return fmt.Errorf("invalid catchpoint catchup state provided : %d", state)
 	}
@@ -165,7 +202,7 @@ func (c *CatchpointCatchupAccessorImpl) SetState(ctx context.Context, state Catc
 }
 
 // GetLabel returns the current catchpoint catchup label
-func (c *CatchpointCatchupAccessorImpl) GetLabel(ctx context.Context) (label string, err error) {
+func (c *catchpointCatchupAccessorImpl) GetLabel(ctx context.Context) (label string, err error) {
 	label, err = readCatchpointStateString(ctx, c.ledger.trackerDB().Rdb.Handle, catchpointStateCatchupLabel)
 	if err != nil {
 		return "", fmt.Errorf("unable to read catchpoint catchup state '%s': %v", catchpointStateCatchupLabel, err)
@@ -174,7 +211,7 @@ func (c *CatchpointCatchupAccessorImpl) GetLabel(ctx context.Context) (label str
 }
 
 // SetLabel set the catchpoint catchup label
-func (c *CatchpointCatchupAccessorImpl) SetLabel(ctx context.Context, label string) (err error) {
+func (c *catchpointCatchupAccessorImpl) SetLabel(ctx context.Context, label string) (err error) {
 	// verify it's parsable :
 	_, _, err = ledgercore.ParseCatchpointLabel(label)
 	if err != nil {
@@ -188,7 +225,7 @@ func (c *CatchpointCatchupAccessorImpl) SetLabel(ctx context.Context, label stri
 }
 
 // ResetStagingBalances resets the current staging balances, preparing for a new set of balances to be added
-func (c *CatchpointCatchupAccessorImpl) ResetStagingBalances(ctx context.Context, newCatchup bool) (err error) {
+func (c *catchpointCatchupAccessorImpl) ResetStagingBalances(ctx context.Context, newCatchup bool) (err error) {
 	wdb := c.ledger.trackerDB().Wdb
 	if !newCatchup {
 		c.ledger.setSynchronousMode(ctx, c.ledger.synchronousMode)
@@ -246,7 +283,7 @@ type CatchpointCatchupAccessorProgress struct {
 }
 
 // ProgressStagingBalances deserialize the given bytes as a temporary staging balances
-func (c *CatchpointCatchupAccessorImpl) ProgressStagingBalances(ctx context.Context, sectionName string, bytes []byte, progress *CatchpointCatchupAccessorProgress) (err error) {
+func (c *catchpointCatchupAccessorImpl) ProgressStagingBalances(ctx context.Context, sectionName string, bytes []byte, progress *CatchpointCatchupAccessorProgress) (err error) {
 	if sectionName == "content.msgpack" {
 		return c.processStagingContent(ctx, bytes, progress)
 	}
@@ -259,7 +296,7 @@ func (c *CatchpointCatchupAccessorImpl) ProgressStagingBalances(ctx context.Cont
 }
 
 // processStagingContent deserialize the given bytes as a temporary staging balances content
-func (c *CatchpointCatchupAccessorImpl) processStagingContent(ctx context.Context, bytes []byte, progress *CatchpointCatchupAccessorProgress) (err error) {
+func (c *catchpointCatchupAccessorImpl) processStagingContent(ctx context.Context, bytes []byte, progress *CatchpointCatchupAccessorProgress) (err error) {
 	if progress.SeenHeader {
 		return fmt.Errorf("CatchpointCatchupAccessorImpl::processStagingContent: content chunk already seen")
 	}
@@ -307,12 +344,11 @@ func (c *CatchpointCatchupAccessorImpl) processStagingContent(ctx context.Contex
 }
 
 // processStagingBalances deserialize the given bytes as a temporary staging balances
-func (c *CatchpointCatchupAccessorImpl) processStagingBalances(ctx context.Context, bytes []byte, progress *CatchpointCatchupAccessorProgress) (err error) {
+func (c *catchpointCatchupAccessorImpl) processStagingBalances(ctx context.Context, bytes []byte, progress *CatchpointCatchupAccessorProgress) (err error) {
 	if !progress.SeenHeader {
 		return fmt.Errorf("CatchpointCatchupAccessorImpl::processStagingBalances: content chunk was missing")
 	}
 
-	wdb := c.ledger.trackerDB().Wdb
 	start := time.Now()
 	ledgerProcessstagingbalancesCount.Inc(nil)
 
@@ -440,16 +476,13 @@ func (c *CatchpointCatchupAccessorImpl) processStagingBalances(ctx context.Conte
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		errBalances = wdb.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
-			start := time.Now()
-			err = writeCatchpointStagingBalances(ctx, tx, normalizedAccountBalances)
-			durBalances = time.Since(start)
-			return err
-		})
+		start := time.Now()
+		errBalances = c.stagingWriter.writeBalances(ctx, normalizedAccountBalances)
+		durBalances = time.Since(start)
 	}()
 
 	// on a in-memory database, wait for the writer to finish before starting the new writer
-	if wdb.IsSharedCacheConnection() {
+	if c.stagingWriter.isShared() {
 		wg.Wait()
 	}
 
@@ -467,17 +500,14 @@ func (c *CatchpointCatchupAccessorImpl) processStagingBalances(ctx context.Conte
 			}
 		}
 		if hasCreatables {
-			errCreatables = wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-				start := time.Now()
-				err := writeCatchpointStagingCreatable(ctx, tx, normalizedAccountBalances)
-				durCreatables = time.Since(start)
-				return err
-			})
+			start := time.Now()
+			errCreatables = c.stagingWriter.writeCreatables(ctx, normalizedAccountBalances)
+			durCreatables = time.Since(start)
 		}
 	}()
 
 	// on a in-memory database, wait for the writer to finish before starting the new writer
-	if wdb.IsSharedCacheConnection() {
+	if c.stagingWriter.isShared() {
 		wg.Wait()
 	}
 
@@ -485,12 +515,9 @@ func (c *CatchpointCatchupAccessorImpl) processStagingBalances(ctx context.Conte
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		errHashes = wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-			start := time.Now()
-			err := writeCatchpointStagingHashes(ctx, tx, normalizedAccountBalances)
-			durHashes = time.Since(start)
-			return err
-		})
+		start := time.Now()
+		errHashes = c.stagingWriter.writeHashes(ctx, normalizedAccountBalances)
+		durHashes = time.Since(start)
 	}()
 
 	wg.Wait()
@@ -529,7 +556,7 @@ func (c *CatchpointCatchupAccessorImpl) processStagingBalances(ctx context.Conte
 }
 
 // BuildMerkleTrie would process the catchpointpendinghashes and insert all the items in it into the merkle trie
-func (c *CatchpointCatchupAccessorImpl) BuildMerkleTrie(ctx context.Context, progressUpdates func(uint64)) (err error) {
+func (c *catchpointCatchupAccessorImpl) BuildMerkleTrie(ctx context.Context, progressUpdates func(uint64)) (err error) {
 	wdb := c.ledger.trackerDB().Wdb
 	rdb := c.ledger.trackerDB().Rdb
 	err = wdb.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
@@ -708,7 +735,7 @@ func (c *CatchpointCatchupAccessorImpl) BuildMerkleTrie(ctx context.Context, pro
 }
 
 // GetCatchupBlockRound returns the latest block round matching the current catchpoint
-func (c *CatchpointCatchupAccessorImpl) GetCatchupBlockRound(ctx context.Context) (round basics.Round, err error) {
+func (c *catchpointCatchupAccessorImpl) GetCatchupBlockRound(ctx context.Context) (round basics.Round, err error) {
 	var iRound uint64
 	iRound, err = readCatchpointStateUint64(ctx, c.ledger.trackerDB().Rdb.Handle, catchpointStateCatchupBlockRound)
 	if err != nil {
@@ -718,7 +745,7 @@ func (c *CatchpointCatchupAccessorImpl) GetCatchupBlockRound(ctx context.Context
 }
 
 // VerifyCatchpoint verifies that the catchpoint is valid by reconstructing the label.
-func (c *CatchpointCatchupAccessorImpl) VerifyCatchpoint(ctx context.Context, blk *bookkeeping.Block) (err error) {
+func (c *catchpointCatchupAccessorImpl) VerifyCatchpoint(ctx context.Context, blk *bookkeeping.Block) (err error) {
 	rdb := c.ledger.trackerDB().Rdb
 	var balancesHash crypto.Digest
 	var blockRound basics.Round
@@ -780,7 +807,7 @@ func (c *CatchpointCatchupAccessorImpl) VerifyCatchpoint(ctx context.Context, bl
 
 // StoreBalancesRound calculates the balances round based on the first block and the associated consensus parameters, and
 // store that to the database
-func (c *CatchpointCatchupAccessorImpl) StoreBalancesRound(ctx context.Context, blk *bookkeeping.Block) (err error) {
+func (c *catchpointCatchupAccessorImpl) StoreBalancesRound(ctx context.Context, blk *bookkeeping.Block) (err error) {
 	// calculate the balances round and store it. It *should* be identical to the one in the catchpoint file header, but we don't want to
 	// trust the one in the catchpoint file header, so we'll calculate it ourselves.
 	catchpointLookback := config.Consensus[blk.CurrentProtocol].CatchpointLookback
@@ -803,7 +830,7 @@ func (c *CatchpointCatchupAccessorImpl) StoreBalancesRound(ctx context.Context, 
 }
 
 // StoreFirstBlock stores a single block to the blocks database.
-func (c *CatchpointCatchupAccessorImpl) StoreFirstBlock(ctx context.Context, blk *bookkeeping.Block) (err error) {
+func (c *catchpointCatchupAccessorImpl) StoreFirstBlock(ctx context.Context, blk *bookkeeping.Block) (err error) {
 	blockDbs := c.ledger.blockDB()
 	start := time.Now()
 	ledgerStorefirstblockCount.Inc(nil)
@@ -818,7 +845,7 @@ func (c *CatchpointCatchupAccessorImpl) StoreFirstBlock(ctx context.Context, blk
 }
 
 // StoreBlock stores a single block to the blocks database.
-func (c *CatchpointCatchupAccessorImpl) StoreBlock(ctx context.Context, blk *bookkeeping.Block) (err error) {
+func (c *catchpointCatchupAccessorImpl) StoreBlock(ctx context.Context, blk *bookkeeping.Block) (err error) {
 	blockDbs := c.ledger.blockDB()
 	start := time.Now()
 	ledgerCatchpointStoreblockCount.Inc(nil)
@@ -833,7 +860,7 @@ func (c *CatchpointCatchupAccessorImpl) StoreBlock(ctx context.Context, blk *boo
 }
 
 // FinishBlocks concludes the catchup of the blocks database.
-func (c *CatchpointCatchupAccessorImpl) FinishBlocks(ctx context.Context, applyChanges bool) (err error) {
+func (c *catchpointCatchupAccessorImpl) FinishBlocks(ctx context.Context, applyChanges bool) (err error) {
 	blockDbs := c.ledger.blockDB()
 	start := time.Now()
 	ledgerCatchpointFinishblocksCount.Inc(nil)
@@ -852,7 +879,7 @@ func (c *CatchpointCatchupAccessorImpl) FinishBlocks(ctx context.Context, applyC
 }
 
 // EnsureFirstBlock ensure that we have a single block in the staging block table, and returns that block
-func (c *CatchpointCatchupAccessorImpl) EnsureFirstBlock(ctx context.Context) (blk bookkeeping.Block, err error) {
+func (c *catchpointCatchupAccessorImpl) EnsureFirstBlock(ctx context.Context) (blk bookkeeping.Block, err error) {
 	blockDbs := c.ledger.blockDB()
 	start := time.Now()
 	ledgerCatchpointEnsureblock1Count.Inc(nil)
@@ -869,7 +896,7 @@ func (c *CatchpointCatchupAccessorImpl) EnsureFirstBlock(ctx context.Context) (b
 
 // CompleteCatchup completes the catchpoint catchup process by switching the databases tables around
 // and reloading the ledger.
-func (c *CatchpointCatchupAccessorImpl) CompleteCatchup(ctx context.Context) (err error) {
+func (c *catchpointCatchupAccessorImpl) CompleteCatchup(ctx context.Context) (err error) {
 	err = c.FinishBlocks(ctx, true)
 	if err != nil {
 		return err
@@ -883,7 +910,7 @@ func (c *CatchpointCatchupAccessorImpl) CompleteCatchup(ctx context.Context) (er
 }
 
 // finishBalances concludes the catchup of the balances(tracker) database.
-func (c *CatchpointCatchupAccessorImpl) finishBalances(ctx context.Context) (err error) {
+func (c *catchpointCatchupAccessorImpl) finishBalances(ctx context.Context) (err error) {
 	wdb := c.ledger.trackerDB().Wdb
 	start := time.Now()
 	ledgerCatchpointFinishBalsCount.Inc(nil)
@@ -986,7 +1013,7 @@ func (c *CatchpointCatchupAccessorImpl) finishBalances(ctx context.Context) (err
 }
 
 // Ledger returns ledger instance as CatchupAccessorClientLedger interface
-func (c *CatchpointCatchupAccessorImpl) Ledger() (l CatchupAccessorClientLedger) {
+func (c *catchpointCatchupAccessorImpl) Ledger() (l CatchupAccessorClientLedger) {
 	return c.ledger
 }
 

--- a/ledger/catchupaccessor_test.go
+++ b/ledger/catchupaccessor_test.go
@@ -468,6 +468,7 @@ func TestCatchupAccessorProcessStagingBalances(t *testing.T) {
 	log := logging.TestingLog(t)
 	writer := &testStagingWriter{hashes: make(map[[4 + crypto.DigestSize]byte]int)}
 	l := Ledger{
+		log:             log,
 		genesisProto:    config.Consensus[protocol.ConsensusCurrentVersion],
 		synchronousMode: db.SynchronousMode(100), // non-existing in order to skip the underlying db call in ledger.setSynchronousMode
 	}

--- a/ledger/catchupaccessor_test.go
+++ b/ledger/catchupaccessor_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 	"testing"
@@ -36,6 +37,8 @@ import (
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/algorand/go-algorand/util/db"
+	"github.com/algorand/msgp/msgp"
 )
 
 func createTestingEncodedChunks(accountsCount uint64) (encodedAccountChunks [][]byte, last64KIndex int) {
@@ -419,6 +422,142 @@ func TestCatchupAccessorResourceCountMismatch(t *testing.T) {
 	encodedAccounts := protocol.Encode(&balances)
 
 	// expect error since there is a resource count mismatch
-	err = catchpointAccessor.ProgressStagingBalances(context.Background(), "balances.XX.msgpack", encodedAccounts, &progress)
+	err = catchpointAccessor.ProgressStagingBalances(ctx, "balances.XX.msgpack", encodedAccounts, &progress)
 	require.Error(t, err)
+}
+
+type testStagingWriter struct {
+	hashes map[[4 + crypto.DigestSize]byte]int
+}
+
+func (w *testStagingWriter) writeBalances(ctx context.Context, balances []normalizedAccountBalance) error {
+	return nil
+}
+
+func (w *testStagingWriter) writeCreatables(ctx context.Context, balances []normalizedAccountBalance) error {
+	return nil
+}
+
+func (w *testStagingWriter) writeHashes(ctx context.Context, balances []normalizedAccountBalance) error {
+	for _, bal := range balances {
+		for _, hash := range bal.accountHashes {
+			var key [4 + crypto.DigestSize]byte
+			copy(key[:], hash)
+			w.hashes[key] = w.hashes[key] + 1
+		}
+	}
+	return nil
+}
+
+func (w *testStagingWriter) isShared() bool {
+	return false
+}
+
+// makeTestCatchpointCatchupAccessor creates a CatchpointCatchupAccessor given a ledger
+func makeTestCatchpointCatchupAccessor(ledger *Ledger, log logging.Logger, writer stagingWriter) *catchpointCatchupAccessorImpl {
+	return &catchpointCatchupAccessorImpl{
+		ledger:        ledger,
+		stagingWriter: writer,
+		log:           log,
+	}
+}
+
+func TestCatchupAccessorProcessStagingBalances(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	log := logging.TestingLog(t)
+	writer := &testStagingWriter{hashes: make(map[[4 + crypto.DigestSize]byte]int)}
+	l := Ledger{
+		genesisProto:    config.Consensus[protocol.ConsensusCurrentVersion],
+		synchronousMode: db.SynchronousMode(100), // non-existing in order to skip the underlying db call in ledger.setSynchronousMode
+	}
+	catchpointAccessor := makeTestCatchpointCatchupAccessor(&l, log, writer)
+
+	randomSimpleBaseAcct := func() baseAccountData {
+		accountData := baseAccountData{
+			RewardsBase: crypto.RandUint63(),
+			MicroAlgos:  basics.MicroAlgos{Raw: crypto.RandUint63()},
+			AuthAddr:    ledgertesting.RandomAddress(),
+		}
+		return accountData
+	}
+
+	encodedBalanceRecordFromBase := func(addr basics.Address, base baseAccountData, resources map[uint64]msgp.Raw, more bool) encodedBalanceRecordV6 {
+		ebr := encodedBalanceRecordV6{
+			Address:              addr,
+			AccountData:          protocol.Encode(&base),
+			Resources:            resources,
+			ExpectingMoreEntries: more,
+		}
+		return ebr
+	}
+
+	const numAccounts = 5
+	const acctXNumRes = 13
+	const expectHashes = numAccounts + acctXNumRes
+	progress := CatchpointCatchupAccessorProgress{
+		TotalAccounts: numAccounts,
+		TotalChunks:   2,
+		SeenHeader:    true,
+		Version:       CatchpointFileVersionV6,
+	}
+
+	// create some walking gentlemen
+	acctA := randomSimpleBaseAcct()
+	acctB := randomSimpleBaseAcct()
+	acctC := randomSimpleBaseAcct()
+	acctD := randomSimpleBaseAcct()
+
+	// prepare chunked account
+	addrX := ledgertesting.RandomAddress()
+	acctX := randomSimpleBaseAcct()
+	acctX.TotalAssets = acctXNumRes
+	acctXRes1 := make(map[uint64]msgp.Raw, acctXNumRes/2+1)
+	acctXRes2 := make(map[uint64]msgp.Raw, acctXNumRes/2)
+	emptyRes := resourcesData{ResourceFlags: resourceFlagsEmptyAsset}
+	emptyResEnc := protocol.Encode(&emptyRes)
+	for i := 0; i < acctXNumRes; i++ {
+		if i <= acctXNumRes/2 {
+			acctXRes1[rand.Uint64()] = emptyResEnc
+		} else {
+			acctXRes2[rand.Uint64()] = emptyResEnc
+		}
+	}
+
+	// make chunks
+	chunks := []catchpointFileBalancesChunkV6{
+		{
+			Balances: []encodedBalanceRecordV6{
+				encodedBalanceRecordFromBase(ledgertesting.RandomAddress(), acctA, nil, false),
+				encodedBalanceRecordFromBase(ledgertesting.RandomAddress(), acctB, nil, false),
+				encodedBalanceRecordFromBase(addrX, acctX, acctXRes1, true),
+			},
+		},
+		{
+			Balances: []encodedBalanceRecordV6{
+				encodedBalanceRecordFromBase(addrX, acctX, acctXRes2, false),
+				encodedBalanceRecordFromBase(ledgertesting.RandomAddress(), acctC, nil, false),
+				encodedBalanceRecordFromBase(ledgertesting.RandomAddress(), acctD, nil, false),
+			},
+		},
+	}
+
+	// process chunks
+	ctx := context.Background()
+	progress.SeenHeader = true
+	for _, chunk := range chunks {
+		blob := protocol.Encode(&chunk)
+		err := catchpointAccessor.processStagingBalances(ctx, blob, &progress)
+		require.NoError(t, err)
+	}
+
+	// compare account counts and hashes
+	require.Equal(t, progress.TotalAccounts, progress.ProcessedAccounts)
+
+	// ensure no duplicate hashes
+	require.Equal(t, uint64(expectHashes), progress.TotalAccountHashes)
+	require.Equal(t, expectHashes, len(writer.hashes))
+	for _, count := range writer.hashes {
+		require.Equal(t, 1, count)
+	}
 }

--- a/ledger/catchupaccessor_test.go
+++ b/ledger/catchupaccessor_test.go
@@ -427,6 +427,7 @@ func TestCatchupAccessorResourceCountMismatch(t *testing.T) {
 }
 
 type testStagingWriter struct {
+	t      *testing.T
 	hashes map[[4 + crypto.DigestSize]byte]int
 }
 
@@ -442,6 +443,7 @@ func (w *testStagingWriter) writeHashes(ctx context.Context, balances []normaliz
 	for _, bal := range balances {
 		for _, hash := range bal.accountHashes {
 			var key [4 + crypto.DigestSize]byte
+			require.Len(w.t, hash, 4+crypto.DigestSize)
 			copy(key[:], hash)
 			w.hashes[key] = w.hashes[key] + 1
 		}
@@ -466,7 +468,7 @@ func TestCatchupAccessorProcessStagingBalances(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	log := logging.TestingLog(t)
-	writer := &testStagingWriter{hashes: make(map[[4 + crypto.DigestSize]byte]int)}
+	writer := &testStagingWriter{t: t, hashes: make(map[[4 + crypto.DigestSize]byte]int)}
 	l := Ledger{
 		log:             log,
 		genesisProto:    config.Consensus[protocol.ConsensusCurrentVersion],


### PR DESCRIPTION
## Summary

When an account is split over multiple catchpoint file chunks, we attempt to add its account hash to the catchpoint merkle trie twice, yielding a database error when processing the catchpoint. This is an alternate method to #4666 for fixing this issue, that stops the duplicate merkle trie hash issue at the source, rather than later at insert time.

## Test Plan

New tests added to exercise accounts split over multiple catchpoint records/chunks.