### PR TITLE
Consistent struct tests

### DIFF
--- a/data/basics/fields_test.go
+++ b/data/basics/fields_test.go
@@ -17,133 +17,38 @@
 package basics_test
 
 import (
-	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/test/partitiontest"
-	"github.com/stretchr/testify/require"
+	"github.com/algorand/go-algorand/test/reflectionhelpers"
 )
 
-type typePath []string
-
-func (p typePath) addMapKey() typePath {
-	return append(p, "map_key")
-}
-
-func (p typePath) addValue() typePath {
-	return append(p, "value")
-}
-
-func (p typePath) addField(fieldName string) typePath {
-	return append(p, "field "+fieldName)
-}
-
-func (p typePath) validatePathFrom(t reflect.Type) error {
-	if len(p) == 0 {
-		// path is empty, so it's vacuously valid
-		return nil
-	}
-
-	value := p[0]
-	switch {
-	case value == "map_key":
-		return p[1:].validatePathFrom(t.Key())
-	case value == "value":
-		return p[1:].validatePathFrom(t.Elem())
-	case strings.HasPrefix(value, "field "):
-		fieldName := value[len("field "):]
-		fieldType, ok := t.FieldByName(fieldName)
-		if !ok {
-			return fmt.Errorf("Type '%s' does not have the field '%s'", t.Name(), fieldName)
-		}
-		return p[1:].validatePathFrom(fieldType.Type)
-	default:
-		return fmt.Errorf("Unexpected item in path: %s", value)
-	}
-}
-
-func (p typePath) Equals(other typePath) bool {
-	if len(p) != len(other) {
-		return false
-	}
-	for i := range p {
-		if p[i] != other[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func (p typePath) String() string {
-	return strings.Join(p, "->")
-}
-
-func checkReferencedTypes(seen map[reflect.Type]bool, path typePath, typeStack []reflect.Type, check func(path typePath, stack []reflect.Type) bool) {
-	currentType := typeStack[len(typeStack)-1]
-
-	if _, seenType := seen[currentType]; seenType {
-		return
-	}
-
-	if !check(path, typeStack) {
-		// if currentType is not ok, don't visit its children
-		return
-	}
-
-	// add currentType to seen set, to avoid infinite recursion if currentType references itself
-	seen[currentType] = true
-
-	// after currentType's children are visited, "forget" the type, so we can examine it again if needed
-	// if this didn't happen, only 1 error per invalid type would get reported
-	defer delete(seen, currentType)
-
-	switch currentType.Kind() {
-	case reflect.Map:
-		newPath := path.addMapKey()
-		newStack := append(typeStack, currentType.Key())
-		checkReferencedTypes(seen, newPath, newStack, check)
-		fallthrough
-	case reflect.Array, reflect.Slice, reflect.Ptr:
-		newPath := path.addValue()
-		newStack := append(typeStack, currentType.Elem())
-		checkReferencedTypes(seen, newPath, newStack, check)
-	case reflect.Struct:
-		for i := 0; i < currentType.NumField(); i++ {
-			field := currentType.Field(i)
-			newPath := path.addField(field.Name)
-			newStack := append(typeStack, field.Type)
-			checkReferencedTypes(seen, newPath, newStack, check)
-		}
-	}
-}
-
-func makeTypeCheckFunction(t *testing.T, exceptions []typePath, startType reflect.Type) func(path typePath, stack []reflect.Type) bool {
+func makeTypeCheckFunction(t *testing.T, exceptions []reflectionhelpers.TypePath, startType reflect.Type) reflectionhelpers.ReferencedTypesIterationAction {
 	for _, exception := range exceptions {
-		err := exception.validatePathFrom(startType)
-		require.NoError(t, err)
+		// ensure all exceptions can resolve without panicking
+		exception.ResolveType(startType)
 	}
 
-	return func(path typePath, stack []reflect.Type) bool {
+	return func(path reflectionhelpers.TypePath, stack []reflect.Type) bool {
 		currentType := stack[len(stack)-1]
 
 		for _, exception := range exceptions {
 			if path.Equals(exception) {
-				t.Logf("Skipping exception for path: %s", path.String())
+				t.Logf("Skipping exception for path: %s", path)
 				return true
 			}
 		}
 
 		switch currentType.Kind() {
 		case reflect.String:
-			t.Errorf("Invalid string type referenced from %s. Use []byte instead. Full path: %s", startType.Name(), path.String())
+			t.Errorf("Invalid string type referenced from %v. Use []byte instead. Full path: %s", startType, path)
 			return false
 		case reflect.Chan, reflect.Func, reflect.Interface, reflect.UnsafePointer:
 			// raise an error if one of these strange types is referenced too
-			t.Errorf("Invalid type %s referenced from %s. Full path: %s", currentType.Name(), startType.Name(), path.String())
+			t.Errorf("Invalid type %v referenced from %v. Full path: %s", currentType, startType, path)
 			return false
 		default:
 			return true
@@ -157,26 +62,24 @@ func TestBlockFields(t *testing.T) {
 	typeToCheck := reflect.TypeOf(bookkeeping.Block{})
 
 	// These exceptions are for pre-existing usages of string. Only add to this list if you really need to use string.
-	exceptions := []typePath{
-		typePath{}.addField("BlockHeader").addField("GenesisID"),
-		typePath{}.addField("BlockHeader").addField("UpgradeState").addField("CurrentProtocol"),
-		typePath{}.addField("BlockHeader").addField("UpgradeState").addField("NextProtocol"),
-		typePath{}.addField("BlockHeader").addField("UpgradeVote").addField("UpgradePropose"),
-		typePath{}.addField("Payset").addValue().addField("SignedTxnWithAD").addField("SignedTxn").addField("Txn").addField("Type"),
-		typePath{}.addField("Payset").addValue().addField("SignedTxnWithAD").addField("SignedTxn").addField("Txn").addField("Header").addField("GenesisID"),
-		typePath{}.addField("Payset").addValue().addField("SignedTxnWithAD").addField("SignedTxn").addField("Txn").addField("AssetConfigTxnFields").addField("AssetParams").addField("UnitName"),
-		typePath{}.addField("Payset").addValue().addField("SignedTxnWithAD").addField("SignedTxn").addField("Txn").addField("AssetConfigTxnFields").addField("AssetParams").addField("AssetName"),
-		typePath{}.addField("Payset").addValue().addField("SignedTxnWithAD").addField("SignedTxn").addField("Txn").addField("AssetConfigTxnFields").addField("AssetParams").addField("URL"),
-		typePath{}.addField("Payset").addValue().addField("SignedTxnWithAD").addField("ApplyData").addField("EvalDelta").addField("GlobalDelta").addMapKey(),
-		typePath{}.addField("Payset").addValue().addField("SignedTxnWithAD").addField("ApplyData").addField("EvalDelta").addField("GlobalDelta").addValue().addField("Bytes"),
-		typePath{}.addField("Payset").addValue().addField("SignedTxnWithAD").addField("ApplyData").addField("EvalDelta").addField("LocalDeltas").addValue().addMapKey(),
-		typePath{}.addField("Payset").addValue().addField("SignedTxnWithAD").addField("ApplyData").addField("EvalDelta").addField("LocalDeltas").addValue().addValue().addField("Bytes"),
-		typePath{}.addField("Payset").addValue().addField("SignedTxnWithAD").addField("ApplyData").addField("EvalDelta").addField("Logs").addValue(),
+	exceptions := []reflectionhelpers.TypePath{
+		reflectionhelpers.TypePath{}.AddField("BlockHeader").AddField("GenesisID"),
+		reflectionhelpers.TypePath{}.AddField("BlockHeader").AddField("UpgradeState").AddField("CurrentProtocol"),
+		reflectionhelpers.TypePath{}.AddField("BlockHeader").AddField("UpgradeState").AddField("NextProtocol"),
+		reflectionhelpers.TypePath{}.AddField("BlockHeader").AddField("UpgradeVote").AddField("UpgradePropose"),
+		reflectionhelpers.TypePath{}.AddField("Payset").AddValue().AddField("SignedTxnWithAD").AddField("SignedTxn").AddField("Txn").AddField("Type"),
+		reflectionhelpers.TypePath{}.AddField("Payset").AddValue().AddField("SignedTxnWithAD").AddField("SignedTxn").AddField("Txn").AddField("Header").AddField("GenesisID"),
+		reflectionhelpers.TypePath{}.AddField("Payset").AddValue().AddField("SignedTxnWithAD").AddField("SignedTxn").AddField("Txn").AddField("AssetConfigTxnFields").AddField("AssetParams").AddField("UnitName"),
+		reflectionhelpers.TypePath{}.AddField("Payset").AddValue().AddField("SignedTxnWithAD").AddField("SignedTxn").AddField("Txn").AddField("AssetConfigTxnFields").AddField("AssetParams").AddField("AssetName"),
+		reflectionhelpers.TypePath{}.AddField("Payset").AddValue().AddField("SignedTxnWithAD").AddField("SignedTxn").AddField("Txn").AddField("AssetConfigTxnFields").AddField("AssetParams").AddField("URL"),
+		reflectionhelpers.TypePath{}.AddField("Payset").AddValue().AddField("SignedTxnWithAD").AddField("ApplyData").AddField("EvalDelta").AddField("GlobalDelta").AddMapKey(),
+		reflectionhelpers.TypePath{}.AddField("Payset").AddValue().AddField("SignedTxnWithAD").AddField("ApplyData").AddField("EvalDelta").AddField("GlobalDelta").AddValue().AddField("Bytes"),
+		reflectionhelpers.TypePath{}.AddField("Payset").AddValue().AddField("SignedTxnWithAD").AddField("ApplyData").AddField("EvalDelta").AddField("LocalDeltas").AddValue().AddMapKey(),
+		reflectionhelpers.TypePath{}.AddField("Payset").AddValue().AddField("SignedTxnWithAD").AddField("ApplyData").AddField("EvalDelta").AddField("LocalDeltas").AddValue().AddValue().AddField("Bytes"),
+		reflectionhelpers.TypePath{}.AddField("Payset").AddValue().AddField("SignedTxnWithAD").AddField("ApplyData").AddField("EvalDelta").AddField("Logs").AddValue(),
 	}
 
-	seen := make(map[reflect.Type]bool)
-
-	checkReferencedTypes(seen, nil, []reflect.Type{typeToCheck}, makeTypeCheckFunction(t, exceptions, typeToCheck))
+	reflectionhelpers.IterateReferencedTypes(typeToCheck, makeTypeCheckFunction(t, exceptions, typeToCheck))
 }
 
 func TestAccountDataFields(t *testing.T) {
@@ -185,17 +88,15 @@ func TestAccountDataFields(t *testing.T) {
 	typeToCheck := reflect.TypeOf(basics.AccountData{})
 
 	// These exceptions are for pre-existing usages of string. Only add to this list if you really need to use string.
-	exceptions := []typePath{
-		typePath{}.addField("AssetParams").addValue().addField("UnitName"),
-		typePath{}.addField("AssetParams").addValue().addField("AssetName"),
-		typePath{}.addField("AssetParams").addValue().addField("URL"),
-		typePath{}.addField("AppLocalStates").addValue().addField("KeyValue").addMapKey(),
-		typePath{}.addField("AppLocalStates").addValue().addField("KeyValue").addValue().addField("Bytes"),
-		typePath{}.addField("AppParams").addValue().addField("GlobalState").addMapKey(),
-		typePath{}.addField("AppParams").addValue().addField("GlobalState").addValue().addField("Bytes"),
+	exceptions := []reflectionhelpers.TypePath{
+		reflectionhelpers.TypePath{}.AddField("AssetParams").AddValue().AddField("UnitName"),
+		reflectionhelpers.TypePath{}.AddField("AssetParams").AddValue().AddField("AssetName"),
+		reflectionhelpers.TypePath{}.AddField("AssetParams").AddValue().AddField("URL"),
+		reflectionhelpers.TypePath{}.AddField("AppLocalStates").AddValue().AddField("KeyValue").AddMapKey(),
+		reflectionhelpers.TypePath{}.AddField("AppLocalStates").AddValue().AddField("KeyValue").AddValue().AddField("Bytes"),
+		reflectionhelpers.TypePath{}.AddField("AppParams").AddValue().AddField("GlobalState").AddMapKey(),
+		reflectionhelpers.TypePath{}.AddField("AppParams").AddValue().AddField("GlobalState").AddValue().AddField("Bytes"),
 	}
 
-	seen := make(map[reflect.Type]bool)
-
-	checkReferencedTypes(seen, nil, []reflect.Type{typeToCheck}, makeTypeCheckFunction(t, exceptions, typeToCheck))
+	reflectionhelpers.IterateReferencedTypes(typeToCheck, makeTypeCheckFunction(t, exceptions, typeToCheck))
 }

--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -2131,6 +2131,179 @@ func TestResourcesDataSetData(t *testing.T) {
 	}
 }
 
+// TestResourceDataRoundtripConversion ensures that basics.AppLocalState, basics.AppParams,
+// basics.AssetHolding, and basics.AssetParams can be converted to resourcesData and back without
+// losing any data. It uses reflection to be sure that no new fields are omitted.
+//
+// In other words, this test makes sure any new fields in basics.AppLocalState, basics.AppParams,
+// basics.AssetHolding, or basics.AssetParam also get added to resourcesData.
+func TestResourceDataRoundtripConversion(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	t.Run("basics.AppLocalState", func(t *testing.T) {
+		t.Parallel()
+		for i := 0; i < 1000; i++ {
+			randObj, _ := protocol.RandomizeObject(&basics.AppLocalState{})
+			basicsAppLocalState := *randObj.(*basics.AppLocalState)
+
+			var data resourcesData
+			data.SetAppLocalState(basicsAppLocalState)
+			roundTripAppLocalState := data.GetAppLocalState()
+
+			require.Equal(t, basicsAppLocalState, roundTripAppLocalState)
+		}
+	})
+
+	t.Run("basics.AppParams", func(t *testing.T) {
+		t.Parallel()
+		for i := 0; i < 1000; i++ {
+			randObj, _ := protocol.RandomizeObject(&basics.AppParams{})
+			basicsAppParams := *randObj.(*basics.AppParams)
+
+			var data resourcesData
+			data.SetAppParams(basicsAppParams, false)
+			roundTripAppLocalState := data.GetAppParams()
+
+			require.Equal(t, basicsAppParams, roundTripAppLocalState)
+		}
+	})
+
+	t.Run("basics.AssetHolding", func(t *testing.T) {
+		t.Parallel()
+		for i := 0; i < 1000; i++ {
+			randObj, _ := protocol.RandomizeObject(&basics.AssetHolding{})
+			basicsAssetHolding := *randObj.(*basics.AssetHolding)
+
+			var data resourcesData
+			data.SetAssetHolding(basicsAssetHolding)
+			roundTripAppLocalState := data.GetAssetHolding()
+
+			require.Equal(t, basicsAssetHolding, roundTripAppLocalState)
+		}
+	})
+
+	t.Run("basics.AssetParams", func(t *testing.T) {
+		t.Parallel()
+		for i := 0; i < 1000; i++ {
+			randObj, _ := protocol.RandomizeObject(&basics.AssetParams{})
+			basicsAssetParams := *randObj.(*basics.AssetParams)
+
+			var data resourcesData
+			data.SetAssetParams(basicsAssetParams, false)
+			roundTripAppLocalState := data.GetAssetParams()
+
+			require.Equal(t, basicsAssetParams, roundTripAppLocalState)
+		}
+	})
+}
+
+// TestBaseAccountDataRoundtripConversion ensures that baseAccountData can be converted to
+// ledgercore.AccountData and basics.AccountData and back without losing any data. It uses
+// reflection to be sure that no new fields are omitted.
+//
+// In other words, this test makes sure any new fields in baseAccountData also get added to
+// ledgercore.AccountData and basics.AccountData. You should add a manual override in this test if
+// the field really only belongs in baseAccountData.
+func TestBaseAccountDataRoundtripConversion(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	t.Run("ledercore.AccountData", func(t *testing.T) {
+		t.Parallel()
+		for i := 0; i < 1000; i++ {
+			randObj, _ := protocol.RandomizeObject(&baseAccountData{})
+			baseAccount := *randObj.(*baseAccountData)
+
+			ledercoreAccount := baseAccount.GetLedgerCoreAccountData()
+			var roundTripAccount baseAccountData
+			roundTripAccount.SetCoreAccountData(&ledercoreAccount)
+
+			// Manually set UpdateRound, since it is lost in GetLedgerCoreAccountData
+			roundTripAccount.UpdateRound = baseAccount.UpdateRound
+
+			require.Equal(t, baseAccount, roundTripAccount)
+		}
+	})
+
+	t.Run("basics.AccountData", func(t *testing.T) {
+		t.Parallel()
+		for i := 0; i < 1000; i++ {
+			randObj, _ := protocol.RandomizeObject(&baseAccountData{})
+			baseAccount := *randObj.(*baseAccountData)
+
+			basicsAccount := baseAccount.GetAccountData()
+			var roundTripAccount baseAccountData
+			roundTripAccount.SetAccountData(&basicsAccount)
+
+			// Manually set UpdateRound, since it is lost in GetAccountData
+			roundTripAccount.UpdateRound = baseAccount.UpdateRound
+
+			// Manually set resources, since resource information is lost in GetAccountData
+			roundTripAccount.TotalAssetParams = baseAccount.TotalAssetParams
+			roundTripAccount.TotalAssets = baseAccount.TotalAssets
+			roundTripAccount.TotalAppLocalStates = baseAccount.TotalAppLocalStates
+			roundTripAccount.TotalAppParams = baseAccount.TotalAppParams
+
+			require.Equal(t, baseAccount, roundTripAccount)
+		}
+	})
+}
+
+// TestBasicsAccountDataRoundtripConversion ensures that basics.AccountData can be converted to
+// baseAccountData and back without losing any data. It uses reflection to be sure that this test is
+// always up-to-date with new fields.
+//
+// In other words, this test makes sure any new fields in basics.AccountData also get added to
+// baseAccountData.
+func TestBasicsAccountDataRoundtripConversion(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	for i := 0; i < 1000; i++ {
+		randObj, _ := protocol.RandomizeObject(&basics.AccountData{})
+		basicsAccount := *randObj.(*basics.AccountData)
+
+		var baseAccount baseAccountData
+		baseAccount.SetAccountData(&basicsAccount)
+		roundTripAccount := baseAccount.GetAccountData()
+
+		// Manually set resources, since GetAccountData doesn't attempt to restore them
+		roundTripAccount.AssetParams = basicsAccount.AssetParams
+		roundTripAccount.Assets = basicsAccount.Assets
+		roundTripAccount.AppLocalStates = basicsAccount.AppLocalStates
+		roundTripAccount.AppParams = basicsAccount.AppParams
+
+		require.Equal(t, basicsAccount, roundTripAccount)
+		require.Equal(t, uint64(len(roundTripAccount.AssetParams)), baseAccount.TotalAssetParams)
+		require.Equal(t, uint64(len(roundTripAccount.Assets)), baseAccount.TotalAssets)
+		require.Equal(t, uint64(len(roundTripAccount.AppLocalStates)), baseAccount.TotalAppLocalStates)
+		require.Equal(t, uint64(len(roundTripAccount.AppParams)), baseAccount.TotalAppParams)
+	}
+}
+
+// TestLedgercoreAccountDataRoundtripConversion ensures that ledgercore.AccountData can be converted
+// to baseAccountData and back without losing any data. It uses reflection to be sure that no new
+// fields are omitted.
+//
+// In other words, this test makes sure any new fields in ledgercore.AccountData also get added to
+// baseAccountData.
+func TestLedgercoreAccountDataRoundtripConversion(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	for i := 0; i < 1000; i++ {
+		randObj, _ := protocol.RandomizeObject(&ledgercore.AccountData{})
+		ledgercoreAccount := *randObj.(*ledgercore.AccountData)
+
+		var baseAccount baseAccountData
+		baseAccount.SetCoreAccountData(&ledgercoreAccount)
+		roundTripAccount := baseAccount.GetLedgerCoreAccountData()
+
+		require.Equal(t, ledgercoreAccount, roundTripAccount)
+	}
+}
+
 func TestBaseAccountDataIsEmpty(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	positiveTesting := func(t *testing.T) {

--- a/ledger/ledgercore/accountdata_test.go
+++ b/ledger/ledgercore/accountdata_test.go
@@ -1,0 +1,87 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package ledgercore
+
+import (
+	"testing"
+
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBasicsAccountDataRoundtripConversion ensures that basics.AccountData can be converted to
+// ledgercore.AccountData and back without losing any data. It uses reflection to be sure that this
+// test is always up-to-date with new fields.
+//
+// In other words, this test makes sure any new fields in basics.AccountData also get added to
+// ledgercore.AccountData.
+func TestBasicsAccountDataRoundtripConversion(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	for i := 0; i < 1000; i++ {
+		randObj, _ := protocol.RandomizeObject(&basics.AccountData{})
+		basicsAccount := *randObj.(*basics.AccountData)
+
+		ledgercoreAccount := ToAccountData(basicsAccount)
+		var roundTripAccount basics.AccountData
+		AssignAccountData(&roundTripAccount, ledgercoreAccount)
+
+		// Manually set resources, since AssignAccountData doesn't attempt to restore them
+		roundTripAccount.AssetParams = basicsAccount.AssetParams
+		roundTripAccount.Assets = basicsAccount.Assets
+		roundTripAccount.AppLocalStates = basicsAccount.AppLocalStates
+		roundTripAccount.AppParams = basicsAccount.AppParams
+
+		require.Equal(t, basicsAccount, roundTripAccount)
+		require.Equal(t, uint64(len(roundTripAccount.AssetParams)), ledgercoreAccount.TotalAssetParams)
+		require.Equal(t, uint64(len(roundTripAccount.Assets)), ledgercoreAccount.TotalAssets)
+		require.Equal(t, uint64(len(roundTripAccount.AppLocalStates)), ledgercoreAccount.TotalAppLocalStates)
+		require.Equal(t, uint64(len(roundTripAccount.AppParams)), ledgercoreAccount.TotalAppParams)
+	}
+}
+
+// TestLedgercoreAccountDataRoundtripConversion ensures that ledgercore.AccountData can be converted
+// to basics.AccountData and back without losing any data. It uses reflection to be sure that no
+// new fields are omitted.
+//
+// In other words, this test makes sure any new fields in ledgercore.AccountData also get added to
+// basics.AccountData. You should add a manual override in this test if the field really only
+// belongs in ledgercore.AccountData.
+func TestLedgercoreAccountDataRoundtripConversion(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	for i := 0; i < 1000; i++ {
+		randObj, _ := protocol.RandomizeObject(&AccountData{})
+		ledgercoreAccount := *randObj.(*AccountData)
+
+		var basicsAccount basics.AccountData
+		AssignAccountData(&basicsAccount, ledgercoreAccount)
+		roundTripAccount := ToAccountData(basicsAccount)
+
+		// Manually set resources, since resource information is lost in AssignAccountData
+		roundTripAccount.TotalAssetParams = ledgercoreAccount.TotalAssetParams
+		roundTripAccount.TotalAssets = ledgercoreAccount.TotalAssets
+		roundTripAccount.TotalAppLocalStates = ledgercoreAccount.TotalAppLocalStates
+		roundTripAccount.TotalAppParams = ledgercoreAccount.TotalAppParams
+
+		require.Equal(t, ledgercoreAccount, roundTripAccount)
+	}
+}

--- a/ledger/testing/randomAccounts.go
+++ b/ledger/testing/randomAccounts.go
@@ -88,15 +88,31 @@ func RandomAssetParams() basics.AssetParams {
 		Total:         crypto.RandUint64(),
 		Decimals:      uint32(crypto.RandUint64() % 20),
 		DefaultFrozen: crypto.RandUint64()%2 == 0,
-		UnitName:      fmt.Sprintf("un%x", uint32(crypto.RandUint64()%0x7fffffff)),
-		AssetName:     fmt.Sprintf("an%x", uint32(crypto.RandUint64()%0x7fffffff)),
-		URL:           fmt.Sprintf("url%x", uint32(crypto.RandUint64()%0x7fffffff)),
 	}
-	crypto.RandBytes(ap.MetadataHash[:])
-	crypto.RandBytes(ap.Manager[:])
-	crypto.RandBytes(ap.Reserve[:])
-	crypto.RandBytes(ap.Freeze[:])
-	crypto.RandBytes(ap.Clawback[:])
+	if crypto.RandUint64()%5 != 0 {
+		ap.UnitName = fmt.Sprintf("un%x", uint32(crypto.RandUint64()%0x7fffffff))
+	}
+	if crypto.RandUint64()%5 != 0 {
+		ap.AssetName = fmt.Sprintf("an%x", uint32(crypto.RandUint64()%0x7fffffff))
+	}
+	if crypto.RandUint64()%5 != 0 {
+		ap.URL = fmt.Sprintf("url%x", uint32(crypto.RandUint64()%0x7fffffff))
+	}
+	if crypto.RandUint64()%5 != 0 {
+		crypto.RandBytes(ap.MetadataHash[:])
+	}
+	if crypto.RandUint64()%5 != 0 {
+		crypto.RandBytes(ap.Manager[:])
+	}
+	if crypto.RandUint64()%5 != 0 {
+		crypto.RandBytes(ap.Reserve[:])
+	}
+	if crypto.RandUint64()%5 != 0 {
+		crypto.RandBytes(ap.Freeze[:])
+	}
+	if crypto.RandUint64()%5 != 0 {
+		crypto.RandBytes(ap.Clawback[:])
+	}
 	return ap
 }
 
@@ -108,8 +124,13 @@ func RandomAssetHolding(forceFrozen bool) basics.AssetHolding {
 		frozen = true
 	}
 
+	var amount uint64
+	if crypto.RandUint64()%5 != 0 {
+		amount = crypto.RandUint64()
+	}
+
 	ah := basics.AssetHolding{
-		Amount: crypto.RandUint64(),
+		Amount: amount,
 		Frozen: frozen,
 	}
 	return ah
@@ -117,20 +138,26 @@ func RandomAssetHolding(forceFrozen bool) basics.AssetHolding {
 
 // RandomAppParams creates a random basics.AppParams
 func RandomAppParams() basics.AppParams {
+	var schemas basics.StateSchemas
+	if crypto.RandUint64()%10 != 0 {
+		schemas = basics.StateSchemas{
+			LocalStateSchema: basics.StateSchema{
+				NumUint:      crypto.RandUint64() % 5,
+				NumByteSlice: crypto.RandUint64() % 5,
+			},
+			GlobalStateSchema: basics.StateSchema{
+				NumUint:      crypto.RandUint64() % 5,
+				NumByteSlice: crypto.RandUint64() % 5,
+			},
+		}
+	}
+
 	ap := basics.AppParams{
 		ApprovalProgram:   make([]byte, int(crypto.RandUint63())%config.MaxAppProgramLen),
 		ClearStateProgram: make([]byte, int(crypto.RandUint63())%config.MaxAppProgramLen),
 		GlobalState:       make(basics.TealKeyValue),
-		StateSchemas: basics.StateSchemas{
-			LocalStateSchema: basics.StateSchema{
-				NumUint:      crypto.RandUint64()%5 + 1,
-				NumByteSlice: crypto.RandUint64() % 5,
-			},
-			GlobalStateSchema: basics.StateSchema{
-				NumUint:      crypto.RandUint64()%5 + 1,
-				NumByteSlice: crypto.RandUint64() % 5,
-			},
-		},
+		StateSchemas:      schemas,
+		ExtraProgramPages: uint32(crypto.RandUint64() % 4),
 	}
 	if len(ap.ApprovalProgram) > 0 {
 		crypto.RandBytes(ap.ApprovalProgram[:])
@@ -143,22 +170,36 @@ func RandomAppParams() basics.AppParams {
 		ap.ClearStateProgram = nil
 	}
 
-	for i := uint64(0); i < ap.StateSchemas.LocalStateSchema.NumUint+ap.StateSchemas.GlobalStateSchema.NumUint; i++ {
-		appName := fmt.Sprintf("tapp%x-%x", crypto.RandUint64(), i)
-		ap.GlobalState[appName] = basics.TealValue{
+	for i := uint64(0); i < ap.StateSchemas.GlobalStateSchema.NumUint; i++ {
+		var keyName string
+		if crypto.RandUint64()%5 != 0 {
+			keyName = fmt.Sprintf("tapp%x-%x", crypto.RandUint64(), i)
+		}
+		var value uint64
+		if crypto.RandUint64()%5 != 0 {
+			value = crypto.RandUint64()
+		}
+		ap.GlobalState[keyName] = basics.TealValue{
 			Type: basics.TealUintType,
-			Uint: crypto.RandUint64(),
+			Uint: value,
 		}
 	}
-	for i := uint64(0); i < ap.StateSchemas.LocalStateSchema.NumByteSlice+ap.StateSchemas.GlobalStateSchema.NumByteSlice; i++ {
-		appName := fmt.Sprintf("tapp%x-%x", crypto.RandUint64(), i)
-		tv := basics.TealValue{
-			Type: basics.TealBytesType,
+	for i := uint64(0); i < ap.StateSchemas.GlobalStateSchema.NumByteSlice; i++ {
+		var keyName string
+		if crypto.RandUint64()%5 != 0 {
+			keyName = fmt.Sprintf("tapp%x-%x", crypto.RandUint64(), i)
 		}
-		bytes := make([]byte, crypto.RandUint64()%uint64(config.MaxBytesKeyValueLen))
-		crypto.RandBytes(bytes[:])
-		tv.Bytes = string(bytes)
-		ap.GlobalState[appName] = tv
+
+		var bytes []byte
+		if crypto.RandUint64()%5 != 0 {
+			bytes = make([]byte, crypto.RandUint64()%uint64(config.MaxBytesKeyValueLen-len(keyName)))
+			crypto.RandBytes(bytes[:])
+		}
+
+		ap.GlobalState[keyName] = basics.TealValue{
+			Type:  basics.TealBytesType,
+			Bytes: string(bytes),
+		}
 	}
 	if len(ap.GlobalState) == 0 {
 		ap.GlobalState = nil
@@ -170,28 +211,41 @@ func RandomAppParams() basics.AppParams {
 func RandomAppLocalState() basics.AppLocalState {
 	ls := basics.AppLocalState{
 		Schema: basics.StateSchema{
-			NumUint:      crypto.RandUint64()%5 + 1,
+			NumUint:      crypto.RandUint64() % 5,
 			NumByteSlice: crypto.RandUint64() % 5,
 		},
 		KeyValue: make(map[string]basics.TealValue),
 	}
 
 	for i := uint64(0); i < ls.Schema.NumUint; i++ {
-		appName := fmt.Sprintf("lapp%x-%x", crypto.RandUint64(), i)
-		ls.KeyValue[appName] = basics.TealValue{
+		var keyName string
+		if crypto.RandUint64()%5 != 0 {
+			keyName = fmt.Sprintf("tapp%x-%x", crypto.RandUint64(), i)
+		}
+		var value uint64
+		if crypto.RandUint64()%5 != 0 {
+			value = crypto.RandUint64()
+		}
+		ls.KeyValue[keyName] = basics.TealValue{
 			Type: basics.TealUintType,
-			Uint: crypto.RandUint64(),
+			Uint: value,
 		}
 	}
 	for i := uint64(0); i < ls.Schema.NumByteSlice; i++ {
-		appName := fmt.Sprintf("lapp%x-%x", crypto.RandUint64(), i)
-		tv := basics.TealValue{
-			Type: basics.TealBytesType,
+		var keyName string
+		if crypto.RandUint64()%5 != 0 {
+			keyName = fmt.Sprintf("tapp%x-%x", crypto.RandUint64(), i)
 		}
-		bytes := make([]byte, crypto.RandUint64()%uint64(config.MaxBytesKeyValueLen-len(appName)))
-		crypto.RandBytes(bytes[:])
-		tv.Bytes = string(bytes)
-		ls.KeyValue[appName] = tv
+		var bytes []byte
+		if crypto.RandUint64()%5 != 0 {
+			bytes = make([]byte, crypto.RandUint64()%uint64(config.MaxBytesKeyValueLen-len(keyName)))
+			crypto.RandBytes(bytes[:])
+		}
+
+		ls.KeyValue[keyName] = basics.TealValue{
+			Type:  basics.TealBytesType,
+			Bytes: string(bytes),
+		}
 	}
 	if len(ls.KeyValue) == 0 {
 		ls.KeyValue = nil
@@ -282,6 +336,7 @@ func RandomFullAccountData(rewardsLevel uint64, lastCreatableID *basics.Creatabl
 			NumUint:      crypto.RandUint64() % 50,
 			NumByteSlice: crypto.RandUint64() % 50,
 		}
+		data.TotalExtraAppPages = uint32(crypto.RandUint64() % 50)
 	}
 
 	return data

--- a/ledger/testing/randomAccounts_test.go
+++ b/ledger/testing/randomAccounts_test.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package testing
 
 import (

--- a/ledger/testing/randomAccounts_test.go
+++ b/ledger/testing/randomAccounts_test.go
@@ -1,0 +1,125 @@
+package testing
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/algorand/go-algorand/test/reflectionhelpers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccounts(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	accountDataType := reflect.TypeOf(basics.AccountData{})
+
+	referencedAccountTypes := make([]reflectionhelpers.TypePath, 0)
+	reflectionhelpers.IterateReferencedTypes(accountDataType, func(path reflectionhelpers.TypePath, stack []reflect.Type) bool {
+		if len(path) == 0 {
+			return true
+		}
+		if path[len(path)-1].FieldName == "_struct" && stack[len(stack)-1] == reflect.TypeOf(struct{}{}) {
+			return true
+		}
+		referencedAccountTypes = append(referencedAccountTypes, path.Clone())
+		return true
+	})
+
+	// If this test becomes flaky, increase niter
+	niter := 1000
+
+	accountFieldSeenZero := make([]bool, len(referencedAccountTypes))
+	accountFieldSeenNonzero := make([]bool, len(referencedAccountTypes))
+
+	accounts := RandomAccounts(niter, false)
+	for _, account := range accounts {
+		accountValue := reflect.ValueOf(account)
+		for i, typePath := range referencedAccountTypes {
+			values := typePath.ResolveValues(accountValue)
+
+			for _, value := range values {
+				isZero := value.IsZero()
+				if value.Kind() == reflect.Slice || value.Kind() == reflect.Map {
+					fieldLen := value.Len()
+					isZero = fieldLen == 0
+				}
+				if !accountFieldSeenZero[i] && isZero {
+					accountFieldSeenZero[i] = true
+				}
+				if !accountFieldSeenNonzero[i] && !isZero {
+					accountFieldSeenNonzero[i] = true
+				}
+			}
+		}
+	}
+
+	// It's ok for these fields to never be the zero value
+	zeroValueExceptions := []reflectionhelpers.TypePath{
+		reflectionhelpers.TypePath{}.AddField("MicroAlgos"),
+		reflectionhelpers.TypePath{}.AddField("MicroAlgos").AddField("Raw"),
+		reflectionhelpers.TypePath{}.AddField("AssetParams").AddMapKey(),
+		reflectionhelpers.TypePath{}.AddField("AssetParams").AddValue(),
+		reflectionhelpers.TypePath{}.AddField("AssetParams").AddValue().AddField("Total"),
+		reflectionhelpers.TypePath{}.AddField("Assets").AddMapKey(),
+		reflectionhelpers.TypePath{}.AddField("Assets").AddValue(),
+		reflectionhelpers.TypePath{}.AddField("AppLocalStates").AddMapKey(),
+		reflectionhelpers.TypePath{}.AddField("AppLocalStates").AddValue(),
+		reflectionhelpers.TypePath{}.AddField("AppLocalStates").AddValue().AddField("KeyValue").AddValue(),
+		reflectionhelpers.TypePath{}.AddField("AppLocalStates").AddValue().AddField("KeyValue").AddValue().AddField("Type"),
+		reflectionhelpers.TypePath{}.AddField("AppParams").AddMapKey(),
+		reflectionhelpers.TypePath{}.AddField("AppParams").AddValue(),
+		reflectionhelpers.TypePath{}.AddField("AppParams").AddValue().AddField("ApprovalProgram"),
+		reflectionhelpers.TypePath{}.AddField("AppParams").AddValue().AddField("ClearStateProgram"),
+		reflectionhelpers.TypePath{}.AddField("AppParams").AddValue().AddField("GlobalState").AddValue(),
+		reflectionhelpers.TypePath{}.AddField("AppParams").AddValue().AddField("GlobalState").AddValue().AddField("Type"),
+	}
+
+	for _, exception := range zeroValueExceptions {
+		// ensure all exceptions can resolve without panicking
+		exception.ResolveType(accountDataType)
+	}
+
+	// It's ok for these fields to always be the zero value
+	nonzeroValueExceptions := []reflectionhelpers.TypePath{
+		reflectionhelpers.TypePath{}.AddField("RewardsBase"),
+		// It would be great to have these fields NOT always be zero, but ledger/accountdb_test.go
+		// currently depends on this.
+		reflectionhelpers.TypePath{}.AddField("RewardedMicroAlgos"),
+		reflectionhelpers.TypePath{}.AddField("RewardedMicroAlgos").AddField("Raw"),
+	}
+
+	for _, exception := range nonzeroValueExceptions {
+		// ensure all exceptions can resolve without panicking
+		exception.ResolveType(accountDataType)
+	}
+
+	for i, typePath := range referencedAccountTypes {
+		skipZeroValueCheck := false
+		for _, exception := range zeroValueExceptions {
+			if exception.Equals(typePath) {
+				skipZeroValueCheck = true
+				break
+			}
+		}
+
+		skipNonZeroValueCheck := false
+		for _, exception := range nonzeroValueExceptions {
+			if exception.Equals(typePath) {
+				skipNonZeroValueCheck = true
+				break
+			}
+		}
+
+		referencedType := typePath.ResolveType(accountDataType)
+
+		if !skipZeroValueCheck {
+			assert.Truef(t, accountFieldSeenZero[i], "Path '%s' (type %v) was never seen with a zero value", typePath, referencedType)
+		}
+		if !skipNonZeroValueCheck {
+			assert.Truef(t, accountFieldSeenNonzero[i], "Path '%s' (type %v) was always seen with a zero value", typePath, referencedType)
+		}
+	}
+}

--- a/test/reflectionhelpers/helpers.go
+++ b/test/reflectionhelpers/helpers.go
@@ -1,0 +1,253 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package reflectionhelpers
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// TypeSegmentKind is a enum for the types of TypeSegment
+type TypeSegmentKind int
+
+const (
+	// FieldSegmentKind represents a referenced field type on a Go type
+	FieldSegmentKind TypeSegmentKind = iota
+	// MapKeySegmentKind represents the key type of a Go map
+	MapKeySegmentKind
+	// ValueSegmentKind represents the value type of a Go map, array, or slice
+	ValueSegmentKind
+)
+
+// TypeSegment represents a single segment in a TypePath. This segment is a single reference from
+// one reflect.Type to another reflect.Type.
+type TypeSegment struct {
+	Kind TypeSegmentKind
+	// If Kind is FieldSegmentKind, then FieldName contains the name of the referenced field.
+	FieldName string
+}
+
+func (s TypeSegment) String() string {
+	switch s.Kind {
+	case FieldSegmentKind:
+		return "field " + s.FieldName
+	case MapKeySegmentKind:
+		return "map_key"
+	case ValueSegmentKind:
+		return "value"
+	default:
+		panic(fmt.Sprintf("Unknown TypeSegmentKind: %v", s.Kind))
+	}
+}
+
+// TypePath represents a path of referenced types starting from an origin reflect.Type. Note the
+// origin reflect.Type is not contained in TypePath.
+type TypePath []TypeSegment
+
+// Clone creates a deep copy of a TypePath
+func (p TypePath) Clone() TypePath {
+	cloned := make(TypePath, len(p))
+	copy(cloned, p)
+	return cloned
+}
+
+// AddMapKey adds a map key segment to a TypePath. The modification is done using append, so this
+// action may mutate the input TypePath.
+//
+// NOTE: There is no guarantee that this constructed TypePath is valid. Use ResolveType to verify
+// that after construction.
+func (p TypePath) AddMapKey() TypePath {
+	return append(p, TypeSegment{Kind: MapKeySegmentKind})
+}
+
+// AddValue adds a map, array, or slice value segment to a TypePath. The modification is done using
+// append, so this action may mutate the input TypePath.
+//
+// NOTE: There is no guarantee that this constructed TypePath is valid. Use ResolveType to verify
+// that after construction.
+func (p TypePath) AddValue() TypePath {
+	return append(p, TypeSegment{Kind: ValueSegmentKind})
+}
+
+// AddField adds a named field segment to a TypePath. The modification is done using append, so this
+// action may mutate the input TypePath.
+//
+// NOTE: There is no guarantee that this constructed TypePath is valid. Use ResolveType to verify
+// that after construction.
+func (p TypePath) AddField(fieldName string) TypePath {
+	return append(p, TypeSegment{Kind: FieldSegmentKind, FieldName: fieldName})
+}
+
+// ResolveType follows the TypePath to its end and returns the reflect.Type of the last referenced
+// type. The initial type, base, must be provided, since TypePath is a relative path. If the
+// TypePath represents a chain of type references that is not valid, this will panic.
+func (p TypePath) ResolveType(base reflect.Type) reflect.Type {
+	resolved := base
+	for _, segment := range p {
+		switch segment.Kind {
+		case MapKeySegmentKind:
+			resolved = resolved.Key()
+		case ValueSegmentKind:
+			resolved = resolved.Elem()
+		case FieldSegmentKind:
+			fieldType, ok := resolved.FieldByName(segment.FieldName)
+			if !ok {
+				panic(fmt.Errorf("Type '%v' does not have the field '%s'", resolved, segment.FieldName))
+			}
+			resolved = fieldType.Type
+		default:
+			panic(fmt.Errorf("Unexpected segment kind: %v", segment.Kind))
+		}
+	}
+	return resolved
+}
+
+// ResolveValues follows the TypePath to its end and returns a slice of all the values at that
+// location. The initial value, base, must have the type of the origin reflect.Type this TypePath
+// was made for. If the TypePath represents a chain of type references that is not valid, this will
+// panic.
+//
+// This function returns a slice of values because some segments may map to many values. Field
+// segments always map to a single value, but map key and (map, slice, or array) value segments may
+// map to zero or more values, depending on the value of the input argument.
+func (p TypePath) ResolveValues(base reflect.Value) []reflect.Value {
+	if len(p) == 0 {
+		return nil
+	}
+
+	var resolved []reflect.Value
+
+	segment := p[0]
+	switch segment.Kind {
+	case MapKeySegmentKind:
+		resolved = base.MapKeys()
+	case ValueSegmentKind:
+		switch base.Kind() {
+		case reflect.Map:
+			iter := base.MapRange()
+			for iter.Next() {
+				resolved = append(resolved, iter.Value())
+			}
+		case reflect.Array, reflect.Slice:
+			for i := 0; i < base.Len(); i++ {
+				resolved = append(resolved, base.Index(i))
+			}
+		default:
+			panic(fmt.Errorf("Unexpected kind %v", base.Kind()))
+		}
+	case FieldSegmentKind:
+		_, ok := base.Type().FieldByName(segment.FieldName)
+		if !ok {
+			panic(fmt.Errorf("Type '%v' does not have the field '%s'", base.Type(), segment.FieldName))
+		}
+		resolved = []reflect.Value{base.FieldByName(segment.FieldName)}
+	default:
+		panic(fmt.Errorf("Unexpected segment kind: %v", segment.Kind))
+	}
+
+	if len(p) > 1 {
+		rest := p[1:]
+		intermediateResolved := resolved
+		resolved = nil
+
+		for _, ir := range intermediateResolved {
+			resolvedToEnd := rest.ResolveValues(ir)
+			resolved = append(resolved, resolvedToEnd...)
+		}
+	}
+
+	return resolved
+}
+
+// Equals returns true if and only if the input TypePath has the exact same segments as this
+// TypePath.
+func (p TypePath) Equals(other TypePath) bool {
+	if len(p) != len(other) {
+		return false
+	}
+	for i := range p {
+		if p[i] != other[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (p TypePath) String() string {
+	segments := make([]string, len(p))
+	for i, s := range p {
+		segments[i] = s.String()
+	}
+	return strings.Join(segments, "->")
+}
+
+// ReferencedTypesIterationAction represents an action to be taken on each iteration of
+// IterateReferencedTypes. This function should return true to go deeper into the current type's
+// referenced types, or false to look no deeper at the current type's referenced types.
+//
+// NOTE: The TypePath argument this function receives is passed by reference. If you intend to save
+// this value for use after this function returns, you MUST call the Clone() method to keep a copy
+// of the TypePath as you currently see it.
+type ReferencedTypesIterationAction func(path TypePath, stack []reflect.Type) bool
+
+// IterateReferencedTypes recursively iterates over all referenced types from an initial
+// reflect.Type. The ReferencedTypesIterationAction argument is called for each referenced type.
+// This argument can also control whether the iteration goes deeper into a type or not.
+func IterateReferencedTypes(start reflect.Type, action ReferencedTypesIterationAction) {
+	seen := make(map[reflect.Type]bool)
+	iterateReferencedTypes(seen, nil, []reflect.Type{start}, action)
+}
+
+func iterateReferencedTypes(seen map[reflect.Type]bool, path TypePath, typeStack []reflect.Type, action ReferencedTypesIterationAction) {
+	currentType := typeStack[len(typeStack)-1]
+
+	if _, seenType := seen[currentType]; seenType {
+		return
+	}
+
+	if !action(path, typeStack) {
+		// if action returns false, don't visit its children
+		return
+	}
+
+	// add currentType to seen set, to avoid infinite recursion if currentType references itself
+	seen[currentType] = true
+
+	// after currentType's children are visited, "forget" the type, so we can examine it again if needed
+	// if this didn't happen, we would ignore any additional occurrences of this type
+	defer delete(seen, currentType)
+
+	switch currentType.Kind() {
+	case reflect.Map:
+		newPath := path.AddMapKey()
+		newStack := append(typeStack, currentType.Key())
+		iterateReferencedTypes(seen, newPath, newStack, action)
+		fallthrough
+	case reflect.Array, reflect.Slice, reflect.Ptr:
+		newPath := path.AddValue()
+		newStack := append(typeStack, currentType.Elem())
+		iterateReferencedTypes(seen, newPath, newStack, action)
+	case reflect.Struct:
+		for i := 0; i < currentType.NumField(); i++ {
+			field := currentType.Field(i)
+			newPath := path.AddField(field.Name)
+			newStack := append(typeStack, field.Type)
+			iterateReferencedTypes(seen, newPath, newStack, action)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds new unit tests that use reflection to ensure the following sets of structs have consistent fields:
* `resourcesData` (from `ledger/accountdb.go`) has all fields from `basics.AppLocalState`, `basics.AppParams`, `basics.AssetHolding`, and `basics.AssetParams`
* `baseAccountData` (from `ledger/accountdb.go`), `ledercore.AccountData`, and `basics.AccountData` all have consistent fields.

When introducing a new account or resource field, it's all too easy to forgot to update all of these structs. These tests will fail if that's not done properly.

Additionally, this PR also adds `ledger/testing/randomAccounts_test.go`, which ensures the distribution of random accounts from [`RandomAccounts`](https://github.com/algorand/go-algorand/blob/62dc9ba78d3976feb6774a99cd7cc15ea99a3f2b/ledger/testing/randomAccounts.go#L346) adheres to the following property: for every field in `basics.AccountData`, there is high probability that at least one randomly generated account will have a nonzero value for that field, and another randomly generated account will have a zero value for that field. This property ensures that `RandomAccounts` is aware of all fields in `basics.AccountData`, and that each field may or may not be present in an account (with some exceptions).

On the implementation side, I added to the existing reflection testing infrastructure from `data/basics/fields_test.go` and moved it into its own package.

## Test Plan

New tests added.
