### PR TITLE
batchverifier: preserve the memory until the end

### DIFF
--- a/crypto/batchverifier.go
+++ b/crypto/batchverifier.go
@@ -154,9 +154,6 @@ func batchVerificationImpl(messages [][]byte, publicKeys []SignatureVerifier, si
 		C.free(publicKeysAllocation)
 		C.free(signaturesAllocation)
 		C.free(valid)
-		runtime.KeepAlive(messages)
-		runtime.KeepAlive(publicKeys)
-		runtime.KeepAlive(signatures)
 	}()
 
 	// load all the data pointers into the array pointers.
@@ -175,6 +172,10 @@ func batchVerificationImpl(messages [][]byte, publicKeys []SignatureVerifier, si
 		(**C.uchar)(unsafe.Pointer(signaturesAllocation)),
 		C.size_t(len(messages)),
 		(*C.int)(unsafe.Pointer(valid)))
+
+	runtime.KeepAlive(messages)
+	runtime.KeepAlive(publicKeys)
+	runtime.KeepAlive(signatures)
 
 	failed = make([]bool, numberOfSignatures)
 	for i := 0; i < numberOfSignatures; i++ {

--- a/crypto/batchverifier.go
+++ b/crypto/batchverifier.go
@@ -38,6 +38,7 @@ package crypto
 import "C"
 import (
 	"errors"
+	"runtime"
 	"unsafe"
 )
 
@@ -153,6 +154,9 @@ func batchVerificationImpl(messages [][]byte, publicKeys []SignatureVerifier, si
 		C.free(publicKeysAllocation)
 		C.free(signaturesAllocation)
 		C.free(valid)
+		runtime.KeepAlive(messages)
+		runtime.KeepAlive(publicKeys)
+		runtime.KeepAlive(signatures)
 	}()
 
 	// load all the data pointers into the array pointers.


### PR DESCRIPTION
In batchVerificationImpl, the signatures, messages and publicKeys are not copied. The memory from the Go slice is used by the C code, by creating C pointers to these memory location. However, Go is not aware of this usage, and can recover the memory used by these, since no Go variable is referencing them. This may happen when the C code is evaluating them, resulting is accessing corrupted memory. 
This fix tells Go to keep alive these references.