### PR TITLE
algod: turn off cadaver trace file by default

### DIFF
--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -41,7 +41,7 @@ type Local struct {
 	// Version tracks the current version of the defaults so we can migrate old -> new
 	// This is specifically important whenever we decide to change the default value
 	// for an existing parameter. This field tag must be updated any time we add a new version.
-	Version uint32 `version[0]:"0" version[1]:"1" version[2]:"2" version[3]:"3" version[4]:"4" version[5]:"5" version[6]:"6" version[7]:"7" version[8]:"8" version[9]:"9" version[10]:"10" version[11]:"11" version[12]:"12" version[13]:"13" version[14]:"14" version[15]:"15" version[16]:"16" version[17]:"17" version[18]:"18" version[19]:"19" version[20]:"20" version[21]:"21" version[22]:"22" version[23]:"23"`
+	Version uint32 `version[0]:"0" version[1]:"1" version[2]:"2" version[3]:"3" version[4]:"4" version[5]:"5" version[6]:"6" version[7]:"7" version[8]:"8" version[9]:"9" version[10]:"10" version[11]:"11" version[12]:"12" version[13]:"13" version[14]:"14" version[15]:"15" version[16]:"16" version[17]:"17" version[18]:"18" version[19]:"19" version[20]:"20" version[21]:"21" version[22]:"22" version[23]:"23" version[24]:"24"`
 
 	// environmental (may be overridden)
 	// When enabled, stores blocks indefinitely, otherwise, only the most recent blocks
@@ -71,7 +71,7 @@ type Local struct {
 	// Logging
 	BaseLoggerDebugLevel uint32 `version[0]:"1" version[1]:"4"`
 	// if this is 0, do not produce agreement.cadaver
-	CadaverSizeTarget uint64 `version[0]:"1073741824"`
+	CadaverSizeTarget uint64 `version[0]:"1073741824" version[24]:"0"`
 
 	// IncomingConnectionsLimit specifies the max number of long-lived incoming
 	// connections. 0 means no connections allowed. Must be non-negative.

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -20,7 +20,7 @@
 package config
 
 var defaultLocal = Local{
-	Version:                                    23,
+	Version:                                    24,
 	AccountUpdatesStatsInterval:                5000000000,
 	AccountsRebuildSynchronousMode:             1,
 	AgreementIncomingBundlesQueueLength:        7,
@@ -31,7 +31,7 @@ var defaultLocal = Local{
 	BaseLoggerDebugLevel:                       4,
 	BlockServiceCustomFallbackEndpoints:        "",
 	BroadcastConnectionsLimit:                  -1,
-	CadaverSizeTarget:                          1073741824,
+	CadaverSizeTarget:                          0,
 	CatchpointFileHistoryLength:                365,
 	CatchpointInterval:                         10000,
 	CatchpointTracking:                         0,

--- a/test/testdata/configs/config-v24.json
+++ b/test/testdata/configs/config-v24.json
@@ -1,5 +1,5 @@
 {
-    "Version": 23,
+    "Version": 24,
     "AccountUpdatesStatsInterval": 5000000000,
     "AccountsRebuildSynchronousMode": 1,
     "AgreementIncomingBundlesQueueLength": 7,

--- a/test/testdata/configs/config-v24.json
+++ b/test/testdata/configs/config-v24.json
@@ -1,5 +1,5 @@
 {
-    "Version": 24,
+    "Version": 23,
     "AccountUpdatesStatsInterval": 5000000000,
     "AccountsRebuildSynchronousMode": 1,
     "AgreementIncomingBundlesQueueLength": 7,
@@ -63,8 +63,8 @@
     "LogArchiveMaxAge": "",
     "LogArchiveName": "node.archive.log",
     "LogSizeLimit": 1073741824,
-    "MaxAPIResourcesPerAccount": 100000,
     "MaxAcctLookback": 4,
+    "MaxAPIResourcesPerAccount": 100000,
     "MaxCatchpointDownloadDuration": 7200000000000,
     "MaxConnectionsPerIP": 30,
     "MinCatchpointFileDownloadBytesPerSecond": 20480,


### PR DESCRIPTION
## Summary

Turn off the 'cadaver' trace file by default. It was used extensively in debugging years ago but hasn't been used much recently, and it significantly decreases performance. It can be re-enabled for debug clusters.

## Test Plan

Many test clusters have been run with this disabled.