### PR TITLE
Add sanity check tests for AppCallBytes

### DIFF
--- a/data/transactions/logic/parsing_test.go
+++ b/data/transactions/logic/parsing_test.go
@@ -17,6 +17,13 @@
 package logic
 
 import (
+	"encoding/base32"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"github.com/algorand/avm-abi/abi"
+	"github.com/algorand/go-algorand/data/basics"
+	"math"
 	"testing"
 
 	"github.com/algorand/go-algorand/test/partitiontest"
@@ -27,23 +34,117 @@ func TestNewAppCallBytes(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	acb, err := NewAppCallBytes("str:hello")
-	require.NoError(t, err)
-	require.Equal(t, "str", acb.Encoding)
-	require.Equal(t, "hello", acb.Value)
-	_, err = acb.Raw()
-	require.NoError(t, err)
+	t.Run("errors", func(t *testing.T) {
+		_, err := NewAppCallBytes("hello")
+		require.Error(t, err)
 
-	acb, err = NewAppCallBytes("hello")
-	require.Error(t, err)
+		for _, v := range []string{":x", "int:-1"} {
+			acb, err := NewAppCallBytes(v)
+			_, err = acb.Raw()
+			require.Error(t, err)
+		}
+	})
 
-	acb, err = NewAppCallBytes("str:1:2")
-	require.Equal(t, "str", acb.Encoding)
-	require.Equal(t, "1:2", acb.Value)
-	_, err = acb.Raw()
-	require.NoError(t, err)
+	for _, v := range []string{"hello", "1:2"} {
+		for _, e := range []string{"str", "string"} {
+			t.Run(fmt.Sprintf("encoding=%v,value=%v", e, v), func(t *testing.T) {
+				acb, err := NewAppCallBytes(fmt.Sprintf("%v:%v", e, v))
+				require.NoError(t, err)
+				r, err := acb.Raw()
+				require.NoError(t, err)
+				require.Equal(t, v, string(r))
+			})
+		}
 
-	acb, err = NewAppCallBytes(":x")
-	_, err = acb.Raw()
-	require.Error(t, err)
+		for _, e := range []string{"b32", "base32", "byte base32"} {
+			ve := base32.StdEncoding.EncodeToString([]byte(v))
+			t.Run(fmt.Sprintf("encoding=%v,value=%v", e, ve), func(t *testing.T) {
+				acb, err := NewAppCallBytes(fmt.Sprintf("%v:%v", e, ve))
+				require.NoError(t, err)
+				r, err := acb.Raw()
+				require.NoError(t, err)
+				require.Equal(t, ve, base32.StdEncoding.EncodeToString(r))
+			})
+		}
+
+		for _, e := range []string{"b64", "base64", "byte base64"} {
+			ve := base64.StdEncoding.EncodeToString([]byte(v))
+			t.Run(fmt.Sprintf("encoding=%v,value=%v", e, ve), func(t *testing.T) {
+				acb, err := NewAppCallBytes(fmt.Sprintf("%v:%v", e, ve))
+				require.NoError(t, err)
+				r, err := acb.Raw()
+				require.NoError(t, err)
+				require.Equal(t, ve, base64.StdEncoding.EncodeToString(r))
+			})
+		}
+	}
+
+	for _, v := range []uint64{1, 0, math.MaxUint64} {
+		for _, e := range []string{"int", "integer"} {
+			t.Run(fmt.Sprintf("encoding=%v,value=%v", e, v), func(t *testing.T) {
+				acb, err := NewAppCallBytes(fmt.Sprintf("%v:%v", e, v))
+				require.NoError(t, err)
+				r, err := acb.Raw()
+				require.NoError(t, err)
+				require.Equal(t, v, binary.BigEndian.Uint64(r))
+			})
+		}
+	}
+
+	for _, v := range []uint64{1, 0, math.MaxUint64} {
+		for _, e := range []string{"int", "integer"} {
+			t.Run(fmt.Sprintf("encoding=%v,value=%v", e, v), func(t *testing.T) {
+				acb, err := NewAppCallBytes(fmt.Sprintf("%v:%v", e, v))
+				require.NoError(t, err)
+				r, err := acb.Raw()
+				require.NoError(t, err)
+				require.Equal(t, v, binary.BigEndian.Uint64(r))
+			})
+		}
+	}
+
+	for _, v := range []string{"737777777777777777777777777777777777777777777777777UFEJ2CI"} {
+		for _, e := range []string{"addr", "address"} {
+			t.Run(fmt.Sprintf("encoding=%v,value=%v", e, v), func(t *testing.T) {
+				acb, err := NewAppCallBytes(fmt.Sprintf("%v:%v", e, v))
+				require.NoError(t, err)
+				r, err := acb.Raw()
+				require.NoError(t, err)
+				addr, err := basics.UnmarshalChecksumAddress(v)
+				require.NoError(t, err)
+				expectedBytes := []byte{}
+				expectedBytes = addr[:]
+				require.Equal(t, expectedBytes, r)
+			})
+		}
+	}
+
+	type abiCase struct {
+		abiType, rawValue string
+	}
+	for _, v := range []abiCase{
+		{
+			`(uint64,string,bool[])`,
+			`[399,"should pass",[true,false,false,true]]`,
+		}} {
+		for _, e := range []string{"abi"} {
+			t.Run(fmt.Sprintf("encoding=%v,value=%v", e, v), func(t *testing.T) {
+				acb, err := NewAppCallBytes(fmt.Sprintf(
+					"%v:%v:%v", e, v.abiType, v.rawValue))
+				require.NoError(t, err)
+				r, err := acb.Raw()
+				require.NoError(t, err)
+				require.NotEmpty(t, r)
+
+				// Confirm round-trip works.
+				abiType, err := abi.TypeOf(v.abiType)
+				require.NoError(t, err)
+				d, err := abiType.Decode(r)
+				require.NoError(t, err)
+				vv, err := abiType.Encode(d)
+				require.NoError(t, err)
+				require.Equal(t, r, vv)
+			})
+		}
+	}
 }

--- a/test/e2e-go/restAPI/restClient_test.go
+++ b/test/e2e-go/restAPI/restClient_test.go
@@ -1231,7 +1231,7 @@ func TestBoxNamesByAppID(t *testing.T) {
 	testClient := localFixture.LibGoalClient
 
 	testClient.WaitForRound(1)
-	
+
 	wh, err := testClient.GetUnencryptedWalletHandle()
 	a.NoError(err)
 	addresses, err := testClient.ListAddresses(wh)


### PR DESCRIPTION
Addresses https://github.com/algorand/go-algorand/pull/4149#discussion_r997224776 by adding basic unit tests for `AppCallBytes` to confirm existing code paths are exercised.