### PR TITLE
Rename isFull to supportsAppEval

### DIFF
--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -146,7 +146,8 @@ func defaultEvalParamsWithVersion(version uint64, txns ...transactions.SignedTxn
 	return ep
 }
 
-func (ep *EvalParams) isFull() bool {
+// `supportsAppEval` is test helper method for disambiguating whe `EvalParams` is suitable for logicsig vs app evaluations.
+func (ep *EvalParams) supportsAppEval() bool {
 	return ep.available != nil
 }
 
@@ -4091,7 +4092,7 @@ func TestAnyRekeyToOrApplicationRaisesMinAvmVersion(t *testing.T) {
 			expected := fmt.Sprintf("program version must be >= %d", cse.validFromVersion)
 			for v := uint64(0); v < cse.validFromVersion; v++ {
 				ops := testProg(t, source, v)
-				if ep.isFull() {
+				if ep.supportsAppEval() {
 					testAppBytes(t, ops.Program, ep, expected, expected)
 				}
 				testLogicBytes(t, ops.Program, ep, expected, expected)
@@ -4100,7 +4101,7 @@ func TestAnyRekeyToOrApplicationRaisesMinAvmVersion(t *testing.T) {
 			// Should succeed for all versions >= validFromVersion
 			for v := cse.validFromVersion; v <= AssemblerMaxVersion; v++ {
 				ops := testProg(t, source, v)
-				if ep.isFull() {
+				if ep.supportsAppEval() {
 					testAppBytes(t, ops.Program, ep)
 				}
 				testLogicBytes(t, ops.Program, ep)


### PR DESCRIPTION
Addresses https://github.com/algorand/go-algorand/pull/4149#discussion_r997207560 by renaming `isFull` to a more intent-revealing name (`supportsAppEval`).