### PR TITLE
Add test coverage for app local/global put errors

### DIFF
--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -1564,7 +1564,7 @@ int 1
 
 func TestAppLocalGlobalErrorCases(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	// t.Parallel() // No - Modifies Proto
+	// t.Parallel() No! Modifies Proto
 
 	ep, tx, ledger := makeSampleEnv()
 	ledger.NewApp(tx.Sender, 888, basics.AppParams{})

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -1564,7 +1564,7 @@ int 1
 
 func TestAppLocalGlobalErrorCases(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	// t.Parallel() No! Modifies Proto
+	t.Parallel()
 
 	ep, tx, ledger := makeSampleEnv()
 	ledger.NewApp(tx.Sender, 888, basics.AppParams{})
@@ -1586,7 +1586,7 @@ func TestAppLocalGlobalErrorCases(t *testing.T) {
 
 	testApp(t, fmt.Sprintf(`int 0; byte "foo"; byte "%v"; app_local_put; int 1`, strings.Repeat("v", ep.Proto.MaxAppBytesValueLen)), ep)
 
-	ep.Proto.MaxAppSumKeyValueLens = 2
+	ep.Proto.MaxAppSumKeyValueLens = 2 // Override to generate error.
 	testApp(t, `byte "foo"; byte "foo"; app_global_put; int 1`, ep, "key/value total too long for key")
 
 	testApp(t, `int 0; byte "foo"; byte "foo"; app_local_put; int 1`, ep, "key/value total too long for key")

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -1562,6 +1562,36 @@ int 1
 	require.Equal(t, uint64(0x79), vd.Uint)
 }
 
+func TestAppLocalGlobalErrorCases(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	// t.Parallel() // No - Modifies Proto
+
+	ep, tx, ledger := makeSampleEnv()
+	ledger.NewApp(tx.Sender, 888, basics.AppParams{})
+
+	testApp(t, fmt.Sprintf(`byte "%v"; int 1; app_global_put; int 1`, strings.Repeat("v", ep.Proto.MaxAppKeyLen+1)), ep, "key too long")
+
+	testApp(t, fmt.Sprintf(`byte "%v"; int 1; app_global_put; int 1`, strings.Repeat("v", ep.Proto.MaxAppKeyLen)), ep)
+
+	ledger.NewLocals(tx.Sender, 888)
+	testApp(t, fmt.Sprintf(`int 0; byte "%v"; int 1; app_local_put; int 1`, strings.Repeat("v", ep.Proto.MaxAppKeyLen+1)), ep, "key too long")
+
+	testApp(t, fmt.Sprintf(`int 0; byte "%v"; int 1; app_local_put; int 1`, strings.Repeat("v", ep.Proto.MaxAppKeyLen)), ep)
+
+	testApp(t, fmt.Sprintf(`byte "foo"; byte "%v"; app_global_put; int 1`, strings.Repeat("v", ep.Proto.MaxAppBytesValueLen+1)), ep, "value too long for key")
+
+	testApp(t, fmt.Sprintf(`byte "foo"; byte "%v"; app_global_put; int 1`, strings.Repeat("v", ep.Proto.MaxAppBytesValueLen)), ep)
+
+	testApp(t, fmt.Sprintf(`int 0; byte "foo"; byte "%v"; app_local_put; int 1`, strings.Repeat("v", ep.Proto.MaxAppBytesValueLen+1)), ep, "value too long for key")
+
+	testApp(t, fmt.Sprintf(`int 0; byte "foo"; byte "%v"; app_local_put; int 1`, strings.Repeat("v", ep.Proto.MaxAppBytesValueLen)), ep)
+
+	ep.Proto.MaxAppSumKeyValueLens = 2
+	testApp(t, `byte "foo"; byte "foo"; app_global_put; int 1`, ep, "key/value total too long for key")
+
+	testApp(t, `int 0; byte "foo"; byte "foo"; app_local_put; int 1`, ep, "key/value total too long for key")
+}
+
 func TestAppGlobalReadWriteDeleteErrors(t *testing.T) {
 	partitiontest.PartitionTest(t)
 


### PR DESCRIPTION
Attempts to address https://github.com/algorand/go-algorand/pull/4149#discussion_r997164706 by adding unit tests covering `app_global_put` and `app_local_put` error cases.