### PR TITLE
Illustrate why TestResourcesDataApp fails

### DIFF
--- a/ledger/testing/randomAccounts.go
+++ b/ledger/testing/randomAccounts.go
@@ -211,7 +211,7 @@ func RandomAppParams() basics.AppParams {
 func RandomAppLocalState() basics.AppLocalState {
 	ls := basics.AppLocalState{
 		Schema: basics.StateSchema{
-			NumUint:      crypto.RandUint64() % 5,
+			NumUint:      crypto.RandUint64()%5 + 1,
 			NumByteSlice: crypto.RandUint64() % 5,
 		},
 		KeyValue: make(map[string]basics.TealValue),


### PR DESCRIPTION
Illustrates why `TestResourcesDataApp` fails in https://app.circleci.com/pipelines/github/algorand/go-algorand/10048/workflows/dab1223e-f91d-4865-8824-ab00327a41f1/jobs/176490 by reverting https://github.com/algorand/go-algorand/pull/4669/files#diff-f98dee0358238dafbdeae29c761862fbc496f0af2335d85cdec69954a82ba848R214.  The PR intends to generate discussion + agree on desired behavior.

Notes:
* With this PR, `go test ./ledger -run "TestResourcesDataApp" -count=1000` passes.  Without the PR, it consistently fails. 
* Prior to this PR, `TestResourcesDataApp` fails because it assumes a randomly generated `AppLocalState` contains either a non-zero `NumUint` or non-zero `NumByteSlice`. 
* Though it's not immediately clear to me if the generator of test design needs to be changed (**bolded is my assumption**).
  * **If https://github.com/algorand/go-algorand/pull/4669 is correct, then `TestResourcesDataApp` test design must be modified.**
  * Otherwise, the generator should be reverted by merging this PR.