### PR TITLE
Bug-fix: return v2 spec from swagger endpoint

### DIFF
--- a/daemon/algod/api/server/common/handlers.go
+++ b/daemon/algod/api/server/common/handlers.go
@@ -67,7 +67,7 @@ func SwaggerJSON(ctx lib.ReqContext, context echo.Context) {
 	w := context.Response().Writer
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(api.SwaggerSpecJSONEmbed))
+	_, _ = w.Write([]byte(api.SwaggerSpecJSONEmbed))
 }
 
 // HealthCheck is an httpHandler for route GET /health

--- a/daemon/algod/api/server/common/handlers.go
+++ b/daemon/algod/api/server/common/handlers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/daemon/algod/api"
 	"github.com/algorand/go-algorand/daemon/algod/api/server/lib"
 	"github.com/algorand/go-algorand/daemon/algod/api/spec/common"
 )
@@ -66,7 +67,7 @@ func SwaggerJSON(ctx lib.ReqContext, context echo.Context) {
 	w := context.Response().Writer
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(lib.SwaggerSpecJSON))
+	w.Write([]byte(api.SwaggerSpecJSONEmbed))
 }
 
 // HealthCheck is an httpHandler for route GET /health

--- a/daemon/algod/api/swagger.go
+++ b/daemon/algod/api/swagger.go
@@ -1,0 +1,8 @@
+package api
+
+import _ "embed"
+
+// SwaggerSpecJSONEmbed is a string that is pulled from algod.oas2.json via go-embed
+// for use with the GET /swagger.json endpoint
+//go:embed algod.oas2.json
+var SwaggerSpecJSONEmbed string

--- a/daemon/algod/api/swagger.go
+++ b/daemon/algod/api/swagger.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package api
 
 import _ "embed"


### PR DESCRIPTION
Resolves #3698

Changes swagger endpoint to use algod.oas2.json content as output

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
