### PR TITLE
Fix handling of empty local state in TestResourcesDataApp

### DIFF
--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -1282,205 +1282,221 @@ func TestCompactResourceDeltas(t *testing.T) {
 
 func TestResourcesDataApp(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := require.New(t)
 
-	rd := resourcesData{}
-	a.False(rd.IsApp())
-	a.True(rd.IsEmpty())
+	// Since some steps use randomly generated input, the test is run N times
+	// to cover a larger search space of inputs.
+	for i := 0; i < 1000; i++ {
+		rd := resourcesData{}
+		a.False(rd.IsApp())
+		a.True(rd.IsEmpty())
 
-	rd = makeResourcesData(1)
-	a.False(rd.IsApp())
-	a.False(rd.IsHolding())
-	a.False(rd.IsOwning())
-	a.True(rd.IsEmpty())
+		rd = makeResourcesData(1)
+		a.False(rd.IsApp())
+		a.False(rd.IsHolding())
+		a.False(rd.IsOwning())
+		a.True(rd.IsEmpty())
 
-	// check empty
-	appParamsEmpty := basics.AppParams{}
-	rd = resourcesData{}
-	rd.SetAppParams(appParamsEmpty, false)
-	a.True(rd.IsApp())
-	a.True(rd.IsOwning())
-	a.True(rd.IsEmptyAppFields())
-	a.False(rd.IsEmpty())
-	a.Equal(appParamsEmpty, rd.GetAppParams())
+		// check empty
+		appParamsEmpty := basics.AppParams{}
+		rd = resourcesData{}
+		rd.SetAppParams(appParamsEmpty, false)
+		a.True(rd.IsApp())
+		a.True(rd.IsOwning())
+		a.True(rd.IsEmptyAppFields())
+		a.False(rd.IsEmpty())
+		a.Equal(appParamsEmpty, rd.GetAppParams())
 
-	appLocalEmpty := basics.AppLocalState{}
-	rd = resourcesData{}
-	rd.SetAppLocalState(appLocalEmpty)
-	a.True(rd.IsApp())
-	a.True(rd.IsHolding())
-	a.True(rd.IsEmptyAppFields())
-	a.False(rd.IsEmpty())
-	a.Equal(appLocalEmpty, rd.GetAppLocalState())
+		appLocalEmpty := basics.AppLocalState{}
+		rd = resourcesData{}
+		rd.SetAppLocalState(appLocalEmpty)
+		a.True(rd.IsApp())
+		a.True(rd.IsHolding())
+		a.True(rd.IsEmptyAppFields())
+		a.False(rd.IsEmpty())
+		a.Equal(appLocalEmpty, rd.GetAppLocalState())
 
-	// check both empty
-	rd = resourcesData{}
-	rd.SetAppLocalState(appLocalEmpty)
-	rd.SetAppParams(appParamsEmpty, true)
-	a.True(rd.IsApp())
-	a.True(rd.IsOwning())
-	a.True(rd.IsHolding())
-	a.True(rd.IsEmptyAppFields())
-	a.False(rd.IsEmpty())
-	a.Equal(appParamsEmpty, rd.GetAppParams())
-	a.Equal(appLocalEmpty, rd.GetAppLocalState())
+		// check both empty
+		rd = resourcesData{}
+		rd.SetAppLocalState(appLocalEmpty)
+		rd.SetAppParams(appParamsEmpty, true)
+		a.True(rd.IsApp())
+		a.True(rd.IsOwning())
+		a.True(rd.IsHolding())
+		a.True(rd.IsEmptyAppFields())
+		a.False(rd.IsEmpty())
+		a.Equal(appParamsEmpty, rd.GetAppParams())
+		a.Equal(appLocalEmpty, rd.GetAppLocalState())
 
-	// check empty states + non-empty params
-	appParams := ledgertesting.RandomAppParams()
-	rd = resourcesData{}
-	rd.SetAppLocalState(appLocalEmpty)
-	rd.SetAppParams(appParams, true)
-	a.True(rd.IsApp())
-	a.True(rd.IsOwning())
-	a.True(rd.IsHolding())
-	a.False(rd.IsEmptyAppFields())
-	a.False(rd.IsEmpty())
-	a.Equal(appParams, rd.GetAppParams())
-	a.Equal(appLocalEmpty, rd.GetAppLocalState())
+		// check empty states + non-empty params
+		appParams := ledgertesting.RandomAppParams()
+		rd = resourcesData{}
+		rd.SetAppLocalState(appLocalEmpty)
+		rd.SetAppParams(appParams, true)
+		a.True(rd.IsApp())
+		a.True(rd.IsOwning())
+		a.True(rd.IsHolding())
+		a.False(rd.IsEmptyAppFields())
+		a.False(rd.IsEmpty())
+		a.Equal(appParams, rd.GetAppParams())
+		a.Equal(appLocalEmpty, rd.GetAppLocalState())
 
-	appState := ledgertesting.RandomAppLocalState()
-	rd.SetAppLocalState(appState)
-	a.True(rd.IsApp())
-	a.True(rd.IsOwning())
-	a.True(rd.IsHolding())
-	a.False(rd.IsEmptyAppFields())
-	a.False(rd.IsEmpty())
-	a.Equal(appParams, rd.GetAppParams())
-	a.Equal(appState, rd.GetAppLocalState())
+		appState := ledgertesting.RandomAppLocalState()
+		rd.SetAppLocalState(appState)
+		a.True(rd.IsApp())
+		a.True(rd.IsOwning())
+		a.True(rd.IsHolding())
+		a.False(rd.IsEmptyAppFields())
+		a.False(rd.IsEmpty())
+		a.Equal(appParams, rd.GetAppParams())
+		a.Equal(appState, rd.GetAppLocalState())
 
-	// check ClearAppLocalState
-	rd.ClearAppLocalState()
-	a.True(rd.IsApp())
-	a.True(rd.IsOwning())
-	a.False(rd.IsHolding())
-	a.False(rd.IsEmptyAppFields())
-	a.False(rd.IsEmpty())
-	a.Equal(appParams, rd.GetAppParams())
-	a.Equal(appLocalEmpty, rd.GetAppLocalState())
+		// check ClearAppLocalState
+		rd.ClearAppLocalState()
+		a.True(rd.IsApp())
+		a.True(rd.IsOwning())
+		a.False(rd.IsHolding())
+		a.False(rd.IsEmptyAppFields())
+		a.False(rd.IsEmpty())
+		a.Equal(appParams, rd.GetAppParams())
+		a.Equal(appLocalEmpty, rd.GetAppLocalState())
 
-	// check ClearAppParams
-	rd.SetAppLocalState(appState)
-	rd.ClearAppParams()
-	a.True(rd.IsApp())
-	a.False(rd.IsOwning())
-	a.True(rd.IsHolding())
-	a.False(rd.IsEmptyAppFields())
-	a.False(rd.IsEmpty())
-	a.Equal(appParamsEmpty, rd.GetAppParams())
-	a.Equal(appState, rd.GetAppLocalState())
+		// check ClearAppParams
+		rd.SetAppLocalState(appState)
+		rd.ClearAppParams()
+		a.True(rd.IsApp())
+		a.False(rd.IsOwning())
+		a.True(rd.IsHolding())
+		if appState.Schema.NumEntries() == 0 {
+			a.True(rd.IsEmptyAppFields())
+		} else {
+			a.False(rd.IsEmptyAppFields())
+		}
+		a.False(rd.IsEmpty())
+		a.Equal(appParamsEmpty, rd.GetAppParams())
+		a.Equal(appState, rd.GetAppLocalState())
 
-	// check both clear
-	rd.ClearAppLocalState()
-	a.False(rd.IsApp())
-	a.False(rd.IsOwning())
-	a.False(rd.IsHolding())
-	a.True(rd.IsEmptyAppFields())
-	a.True(rd.IsEmpty())
-	a.Equal(appParamsEmpty, rd.GetAppParams())
-	a.Equal(appLocalEmpty, rd.GetAppLocalState())
+		// check both clear
+		rd.ClearAppLocalState()
+		a.False(rd.IsApp())
+		a.False(rd.IsOwning())
+		a.False(rd.IsHolding())
+		a.True(rd.IsEmptyAppFields())
+		a.True(rd.IsEmpty())
+		a.Equal(appParamsEmpty, rd.GetAppParams())
+		a.Equal(appLocalEmpty, rd.GetAppLocalState())
 
-	// check params clear when non-empty params and empty holding
-	rd = resourcesData{}
-	rd.SetAppLocalState(appLocalEmpty)
-	rd.SetAppParams(appParams, true)
-	rd.ClearAppParams()
-	a.True(rd.IsApp())
-	a.False(rd.IsOwning())
-	a.True(rd.IsHolding())
-	a.True(rd.IsEmptyAppFields())
-	a.False(rd.IsEmpty())
-	a.Equal(appParamsEmpty, rd.GetAppParams())
-	a.Equal(appLocalEmpty, rd.GetAppLocalState())
+		// check params clear when non-empty params and empty holding
+		rd = resourcesData{}
+		rd.SetAppLocalState(appLocalEmpty)
+		rd.SetAppParams(appParams, true)
+		rd.ClearAppParams()
+		a.True(rd.IsApp())
+		a.False(rd.IsOwning())
+		a.True(rd.IsHolding())
+		a.True(rd.IsEmptyAppFields())
+		a.False(rd.IsEmpty())
+		a.Equal(appParamsEmpty, rd.GetAppParams())
+		a.Equal(appLocalEmpty, rd.GetAppLocalState())
 
-	rd = resourcesData{}
-	rd.SetAppLocalState(appLocalEmpty)
-	a.True(rd.IsEmptyAppFields())
-	a.True(rd.IsApp())
-	a.False(rd.IsEmpty())
-	a.Equal(rd.ResourceFlags, resourceFlagsEmptyApp)
-	rd.ClearAppLocalState()
-	a.False(rd.IsApp())
-	a.True(rd.IsEmptyAppFields())
-	a.True(rd.IsEmpty())
-	a.Equal(rd.ResourceFlags, resourceFlagsNotHolding)
+		rd = resourcesData{}
+		rd.SetAppLocalState(appLocalEmpty)
+		a.True(rd.IsEmptyAppFields())
+		a.True(rd.IsApp())
+		a.False(rd.IsEmpty())
+		a.Equal(rd.ResourceFlags, resourceFlagsEmptyApp)
+		rd.ClearAppLocalState()
+		a.False(rd.IsApp())
+		a.True(rd.IsEmptyAppFields())
+		a.True(rd.IsEmpty())
+		a.Equal(rd.ResourceFlags, resourceFlagsNotHolding)
 
-	// check migration flow (accountDataResources)
-	// 1. both exist and empty
-	rd = makeResourcesData(0)
-	rd.SetAppLocalState(appLocalEmpty)
-	rd.SetAppParams(appParamsEmpty, true)
-	a.True(rd.IsApp())
-	a.True(rd.IsOwning())
-	a.True(rd.IsHolding())
-	a.True(rd.IsEmptyAppFields())
-	a.False(rd.IsEmpty())
+		// check migration flow (accountDataResources)
+		// 1. both exist and empty
+		rd = makeResourcesData(0)
+		rd.SetAppLocalState(appLocalEmpty)
+		rd.SetAppParams(appParamsEmpty, true)
+		a.True(rd.IsApp())
+		a.True(rd.IsOwning())
+		a.True(rd.IsHolding())
+		a.True(rd.IsEmptyAppFields())
+		a.False(rd.IsEmpty())
 
-	// 2. both exist and not empty
-	rd = makeResourcesData(0)
-	rd.SetAppLocalState(appState)
-	rd.SetAppParams(appParams, true)
-	a.True(rd.IsApp())
-	a.True(rd.IsOwning())
-	a.True(rd.IsHolding())
-	a.False(rd.IsEmptyAppFields())
-	a.False(rd.IsEmpty())
+		// 2. both exist and not empty
+		rd = makeResourcesData(0)
+		rd.SetAppLocalState(appState)
+		rd.SetAppParams(appParams, true)
+		a.True(rd.IsApp())
+		a.True(rd.IsOwning())
+		a.True(rd.IsHolding())
+		a.False(rd.IsEmptyAppFields())
+		a.False(rd.IsEmpty())
 
-	// 3. both exist: holding not empty, param is empty
-	rd = makeResourcesData(0)
-	rd.SetAppLocalState(appState)
-	rd.SetAppParams(appParamsEmpty, true)
-	a.True(rd.IsApp())
-	a.True(rd.IsOwning())
-	a.True(rd.IsHolding())
-	a.False(rd.IsEmptyAppFields())
-	a.False(rd.IsEmpty())
+		// 3. both exist: holding not empty, param is empty
+		rd = makeResourcesData(0)
+		rd.SetAppLocalState(appState)
+		rd.SetAppParams(appParamsEmpty, true)
+		a.True(rd.IsApp())
+		a.True(rd.IsOwning())
+		a.True(rd.IsHolding())
+		if appState.Schema.NumEntries() == 0 {
+			a.True(rd.IsEmptyAppFields())
+		} else {
+			a.False(rd.IsEmptyAppFields())
+		}
+		a.False(rd.IsEmpty())
 
-	// 4. both exist: holding empty, param is not empty
-	rd = makeResourcesData(0)
-	rd.SetAppLocalState(appLocalEmpty)
-	rd.SetAppParams(appParams, true)
-	a.True(rd.IsApp())
-	a.True(rd.IsOwning())
-	a.True(rd.IsHolding())
-	a.False(rd.IsEmptyAppFields())
-	a.False(rd.IsEmpty())
+		// 4. both exist: holding empty, param is not empty
+		rd = makeResourcesData(0)
+		rd.SetAppLocalState(appLocalEmpty)
+		rd.SetAppParams(appParams, true)
+		a.True(rd.IsApp())
+		a.True(rd.IsOwning())
+		a.True(rd.IsHolding())
+		a.False(rd.IsEmptyAppFields())
+		a.False(rd.IsEmpty())
 
-	// 5. holding does not exist and params is empty
-	rd = makeResourcesData(0)
-	rd.SetAppParams(appParamsEmpty, false)
-	a.True(rd.IsApp())
-	a.True(rd.IsOwning())
-	a.False(rd.IsHolding())
-	a.True(rd.IsEmptyAppFields())
-	a.False(rd.IsEmpty())
+		// 5. holding does not exist and params is empty
+		rd = makeResourcesData(0)
+		rd.SetAppParams(appParamsEmpty, false)
+		a.True(rd.IsApp())
+		a.True(rd.IsOwning())
+		a.False(rd.IsHolding())
+		a.True(rd.IsEmptyAppFields())
+		a.False(rd.IsEmpty())
 
-	// 6. holding does not exist and params is not empty
-	rd = makeResourcesData(0)
-	rd.SetAppParams(appParams, false)
-	a.True(rd.IsApp())
-	a.True(rd.IsOwning())
-	a.False(rd.IsHolding())
-	a.False(rd.IsEmptyAppFields())
-	a.False(rd.IsEmpty())
+		// 6. holding does not exist and params is not empty
+		rd = makeResourcesData(0)
+		rd.SetAppParams(appParams, false)
+		a.True(rd.IsApp())
+		a.True(rd.IsOwning())
+		a.False(rd.IsHolding())
+		a.False(rd.IsEmptyAppFields())
+		a.False(rd.IsEmpty())
 
-	// 7. holding exist and not empty and params does not exist
-	rd = makeResourcesData(0)
-	rd.SetAppLocalState(appState)
-	a.True(rd.IsApp())
-	a.False(rd.IsOwning())
-	a.True(rd.IsHolding())
-	a.False(rd.IsEmptyAppFields())
-	a.False(rd.IsEmpty())
+		// 7. holding exist and not empty and params does not exist
+		rd = makeResourcesData(0)
+		rd.SetAppLocalState(appState)
+		a.True(rd.IsApp())
+		a.False(rd.IsOwning())
+		a.True(rd.IsHolding())
+		if appState.Schema.NumEntries() == 0 {
+			a.True(rd.IsEmptyAppFields())
+		} else {
+			a.False(rd.IsEmptyAppFields())
+		}
+		a.False(rd.IsEmpty())
 
-	// 8. both do not exist
-	rd = makeResourcesData(0)
-	a.False(rd.IsApp())
-	a.False(rd.IsOwning())
-	a.False(rd.IsHolding())
-	a.True(rd.IsEmptyAppFields())
-	a.True(rd.IsEmpty())
-
+		// 8. both do not exist
+		rd = makeResourcesData(0)
+		a.False(rd.IsApp())
+		a.False(rd.IsOwning())
+		a.False(rd.IsHolding())
+		a.True(rd.IsEmptyAppFields())
+		a.True(rd.IsEmpty())
+	}
 }
 
 func TestResourcesDataAsset(t *testing.T) {


### PR DESCRIPTION
Fixes the failed `TestResourcesDataApp` test run from https://app.circleci.com/pipelines/github/algorand/go-algorand/10048/workflows/dab1223e-f91d-4865-8824-ab00327a41f1/jobs/176490 by modifying the test to account for empty local state.

Notes:
* https://github.com/algorand/go-algorand/pull/4669/files#diff-f98dee0358238dafbdeae29c761862fbc496f0af2335d85cdec69954a82ba848R214 generates an input that was previously _not_ generated:  `NumUint = 0` and `NumByteSlice = 0`.
* With `NumUint = 0` and `NumByteSlice = 0`, `IsEmptyAppFields` returns `true`.  I assume that's the _intended_ behavior.
* Rather than change the input generation scheme for the test, I chose to branch the test on `appState.Schema.NumEntries() == 0`.
* Additionally - I coarsely wrapped the test invocation in a for-loop to run N-times due to the usage of randomly generated inputs.  
  * If folks prefer, I can remove the wrapping for-loop.  I think it'll help catch regressions, but I'm not tied to it.
  * I did consider other refactorings, but settled on the shown approach because I didn't feel more effort was warranted now.  If folks wish to discuss, I can elaborate on alternatives.


