### PR TITLE
network: align duplicateFilterCount to prevent panic on 32-bit platforms

### DIFF
--- a/logging/telemetryspec/event.go
+++ b/logging/telemetryspec/event.go
@@ -301,7 +301,7 @@ type PeerConnectionDetails struct {
 	// MessageDelay is the avarage relative message delay. Not being used for incoming connection.
 	MessageDelay int64 `json:",omitempty"`
 	// DuplicateFilterCount is the number of times this peer has sent us a message hash to filter that it had already sent before.
-	DuplicateFilterCount int64
+	DuplicateFilterCount uint64
 }
 
 // CatchpointGenerationEvent event

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -177,6 +177,11 @@ type wsPeer struct {
 	// peer, or zero if no message is being written.
 	intermittentOutgoingMessageEnqueueTime int64
 
+	// duplicateFilterCount counts how many times the remote peer has sent us a message hash
+	// to filter that it had already sent before.
+	// this needs to be 64-bit aligned for use with atomic.AddInt64 on 32-bit platforms.
+	duplicateFilterCount int64
+
 	// Nonce used to uniquely identify requests
 	requestNonce uint64
 
@@ -203,9 +208,6 @@ type wsPeer struct {
 
 	incomingMsgFilter *messageFilter
 	outgoingMsgFilter *messageFilter
-	// duplicateFilterCount counts how many times the remote peer has sent us a message hash
-	// to filter that it had already sent before.
-	duplicateFilterCount int64
 
 	processed chan struct{}
 

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -182,8 +182,8 @@ type wsPeer struct {
 
 	// duplicateFilterCount counts how many times the remote peer has sent us a message hash
 	// to filter that it had already sent before.
-	// this needs to be 64-bit aligned for use with atomic.AddInt64 on 32-bit platforms.
-	duplicateFilterCount int64
+	// this needs to be 64-bit aligned for use with atomic.AddUint64 on 32-bit platforms.
+	duplicateFilterCount uint64
 
 	wsPeerCore
 
@@ -616,7 +616,7 @@ func (wp *wsPeer) handleFilterMessage(msg IncomingMessage) {
 		// large message concurrently from several peers, and then sent the filter message to us after
 		// each large message finished transferring.
 		duplicateNetworkFilterReceivedTotal.Inc(nil)
-		atomic.AddInt64(&wp.duplicateFilterCount, 1)
+		atomic.AddUint64(&wp.duplicateFilterCount, 1)
 	}
 }
 

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -177,13 +177,13 @@ type wsPeer struct {
 	// peer, or zero if no message is being written.
 	intermittentOutgoingMessageEnqueueTime int64
 
+	// Nonce used to uniquely identify requests
+	requestNonce uint64
+
 	// duplicateFilterCount counts how many times the remote peer has sent us a message hash
 	// to filter that it had already sent before.
 	// this needs to be 64-bit aligned for use with atomic.AddInt64 on 32-bit platforms.
 	duplicateFilterCount int64
-
-	// Nonce used to uniquely identify requests
-	requestNonce uint64
 
 	wsPeerCore
 

--- a/network/wsPeer_test.go
+++ b/network/wsPeer_test.go
@@ -103,6 +103,7 @@ func TestAtomicVariablesAlignment(t *testing.T) {
 	require.True(t, (unsafe.Offsetof(p.requestNonce)%8) == 0)
 	require.True(t, (unsafe.Offsetof(p.lastPacketTime)%8) == 0)
 	require.True(t, (unsafe.Offsetof(p.intermittentOutgoingMessageEnqueueTime)%8) == 0)
+	require.True(t, (unsafe.Offsetof(p.duplicateFilterCount)%8) == 0)
 }
 
 func TestTagCounterFiltering(t *testing.T) {


### PR DESCRIPTION
## Summary

This fixes #4631 by aligning a 64-bit counter when used on 32-bit platforms. 

## Test Plan

Updated TestAtomicVariablesAlignment.