### PR TITLE
lint: add unnecessary conversions linter to automated PR advice

### DIFF
--- a/.golangci-warnings.yml
+++ b/.golangci-warnings.yml
@@ -8,8 +8,8 @@ linters:
     - deadcode
     - partitiontest
     - structcheck
-    - typecheck
     - varcheck
+    - unconvert
     - unused
 
 
@@ -52,24 +52,19 @@ issues:
     # be more lenient with test code
     - path: _test\.go
       linters:
-        - staticcheck
-        - structcheck
-        - typecheck
-        - varcheck
         - deadcode
-        - gosimple
+        - structcheck
+        - varcheck
+        - unconvert
         - unused
     # Add all linters here -- Comment this block out for testing linters
     - path: test/linttest/lintissues\.go
       linters:
-        - staticcheck
-        - structcheck
-        - typecheck
-        - varcheck
         - deadcode
-        - gosimple
+        - structcheck
+        - varcheck
+        - unconvert
         - unused
-        - partitiontest
     - path: crypto/secp256k1/secp256_test\.go
       linters:
         - partitiontest


### PR DESCRIPTION
## Summary

This adds the unconvert linter to the .golangci-warnings.yml configuration, which is used by Github Actions & reviewdog to provide automated advice on new lines added that provides linter output, but does not block a PR.

## Test Plan

No change besides linter settings.