### PR TITLE
Util:  Print dbutil.go error in stderr

### DIFF
--- a/util/db/dbutil.go
+++ b/util/db/dbutil.go
@@ -25,6 +25,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"runtime"
 	"strings"
@@ -232,7 +233,7 @@ func (db *Accessor) atomic(fn idemFn, extras ...interface{}) (err error) {
 				buf := make([]byte, 16*1024)
 				stlen := runtime.Stack(buf, false)
 				errstr := string(buf[:stlen])
-				fmt.Printf("recovered panic in atomic: %s", errstr)
+				fmt.Fprintf(os.Stderr, "recovered panic in atomic: %s", errstr)
 
 			}
 		}()


### PR DESCRIPTION
Addresses https://github.com/algorand/go-algorand/pull/4149#discussion_r1009657663 by switching from stdout to stderr.