### PR TITLE
dispenser: add input validation

### DIFF
--- a/cmd/dispenser/index.html.tpl
+++ b/cmd/dispenser/index.html.tpl
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+  <head>
+    <title>Algorand dispenser</title>
+    <script src='https://www.google.com/recaptcha/api.js'>
+    </script>
+    <script src="https://code.jquery.com/jquery-3.3.1.min.js"
+      integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+      crossorigin="anonymous">
+    </script>
+    <script>
+      var ADDRESS_REGEX = /[A-Z0-9]{58}/
+
+      function sanitize(string) {
+        const entityMap = {
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#39;',
+          '/': '&#x2F;',
+          '`': '&#x60;',
+          '=': '&#x3D;'
+        };
+        return String(string).replace(/[&<>"'`=\/]/g, function (s) {
+          return entityMap[s];
+        });
+      }
+
+      function loadparam() {
+        const queryString = window.location.search;
+        const urlParams = new URLSearchParams(queryString);
+        const account = sanitize(urlParams.get('account'))
+
+        if (ADDRESS_REGEX.test(account)) {
+          $('#target').val(account);
+        }
+      }
+
+      function onload() {
+        loadparam();
+        $('#dispense').click(function(e) {
+          var recaptcha = grecaptcha.getResponse();
+          var target = sanitize($('#target').val());
+
+          if (ADDRESS_REGEX.test(target)) {
+            $('#status').html('Sending request..');
+            var req = $.post('/dispense', {
+              recaptcha: recaptcha,
+              target: target,
+            }, function(data) {
+              $('#status').text('Code ' + req.status + ' ' + req.statusText + ': ' + req.responseText);
+            }).fail(function() {
+              $('#status').text('Code ' + req.status + ' ' + req.statusText + ': ' + req.responseText);
+            });
+          }
+          else {
+            $('#status').text('Please enter a valid Algorand address')
+          }
+        });
+      }
+    </script>
+  </head>
+  <body onload="onload()">
+    <h1>Algorand dispenser</h1>
+    <div class="g-recaptcha" data-sitekey="{{.RecaptchaSiteKey}}">
+    </div>
+    <div>
+      <p>The dispensed Algos have no monetary value and should only be used to test applications.</p>
+      <p>This service is gracefully provided to enable development on the Algorand blockchain test networks.</p>
+      <p>Please do not abuse it by requesting more Algos than needed.</p>
+    </div>
+    <div>
+      <input id="target" placeholder="target address" size="80">
+      <button id="dispense">Dispense</button>
+    </div>
+    <div>
+      Status: <span id="status"></span>
+    </div>
+  </body>
+</html>

--- a/cmd/dispenser/server.go
+++ b/cmd/dispenser/server.go
@@ -17,6 +17,9 @@
 package main
 
 import (
+	_ "embed"
+	"html"
+
 	// "bytes"
 	"encoding/json"
 	"flag"
@@ -63,61 +66,8 @@ type dispenserSiteConfig struct {
 	topPage string
 }
 
-const topPageTemplate = `
-<html>
-  <head>
-    <title>Algorand dispenser</title>
-    <script src='https://www.google.com/recaptcha/api.js'>
-    </script>
-    <script src="https://code.jquery.com/jquery-3.3.1.min.js"
-    integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
-    crossorigin="anonymous">
-    </script>
-    <script>
-      function loadparam() {
-        const queryString = window.location.search;
-        const urlParams = new URLSearchParams(queryString);
-        $('#target').val(urlParams.get('account'));
-      }
-
-      function onload() {
-        loadparam();
-        $('#dispense').click(function(e) {
-          var recaptcha = grecaptcha.getResponse();
-          var target = $('#target').val();
-
-          $('#status').html('Sending request..');
-          var req = $.post('/dispense', {
-            recaptcha: recaptcha,
-            target: target,
-          }, function(data) {
-            $('#status').html('Code ' + req.status + ' ' + req.statusText + ': ' + req.responseText);
-          }).fail(function() {
-            $('#status').html('Code ' + req.status + ' ' + req.statusText + ': ' + req.responseText);
-          });
-        });
-      }
-    </script>
-  </head>
-  <body onload="onload()">
-    <h1>Algorand dispenser</h1>
-    <div class="g-recaptcha" data-sitekey="{{.RecaptchaSiteKey}}">
-    </div>
-    <div>
-      <p>The dispensed Algos have no monetary value and should only be used to test applications.</p>
-      <p>This service is gracefully provided to enable development on the Algorand blockchain test networks.</p>
-      <p>Please do not abuse it by requesting more Algos than needed.</p>
-    </div>
-    <div>
-      <input id="target" placeholder="target address" size="80">
-      <button id="dispense">Dispense</button>
-    </div>
-    <div>
-      Status: <span id="status"></span>
-    </div>
-  </body>
-</html>
-`
+//go:embed index.html.tpl
+var topPageTemplate string
 
 func getConfig(r *http.Request) dispenserSiteConfig {
 	return configMap[r.Host]
@@ -190,7 +140,7 @@ func dispense(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	target := targets[0]
+	target := html.EscapeString(targets[0])
 
 	c, ok := client[r.Host]
 	if !ok {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

- adds some input validation to dispenser, 
  - by first sanitizing the string to encode HTML tags
  - then a quick regular expression test to make sure it's at least something that resembles a wallet/address
- moves the template to a separate file and embeds it instead
- does some encoding on the server side to strip out any HTML tags
- updates onload to use `text()` instead of `html()`

## References

- https://stackoverflow.com/a/12034334
- https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#output-encoding
