### PR TITLE
test: Use /v2/stateproofs API

### DIFF
--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -619,6 +619,12 @@ func (client RestClient) RawDryrun(data []byte) (response []byte, err error) {
 	return
 }
 
+// StateProofs gets a state proof that covers a given round
+func (client RestClient) StateProofs(round uint64) (response generatedV2.StateProofResponse, err error) {
+	err = client.get(&response, fmt.Sprintf("/v2/stateproofs/%d", round), nil)
+	return
+}
+
 // LightBlockHeaderProof gets a Merkle proof for the light block header of a given round.
 func (client RestClient) LightBlockHeaderProof(round uint64) (response generatedV2.LightBlockHeaderProofResponse, err error) {
 	err = client.get(&response, fmt.Sprintf("/v2/blocks/%d/lightheader/proof", round), nil)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

State proofs e2e tests should use the new `/v2/stateproofs`. This will support the migration from v1 to v2.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
