### PR TITLE
db: add AtomicContext

### DIFF
--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -1107,7 +1107,7 @@ func (ct *catchpointTracker) generateCatchpointData(ctx context.Context, account
 	var catchpointWriter *catchpointWriter
 	start := time.Now()
 	ledgerGeneratecatchpointCount.Inc(nil)
-	err = ct.dbs.Rdb.AtomicContext(ctx, func(ctx context.Context, tx *sql.Tx) (err error) {
+	err := ct.dbs.Rdb.AtomicContext(ctx, func(ctx context.Context, tx *sql.Tx) (err error) {
 		catchpointWriter, err = makeCatchpointWriter(ctx, catchpointDataFilePath, tx, ResourcesPerCatchpointFileChunk)
 		if err != nil {
 			return

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -1107,7 +1107,7 @@ func (ct *catchpointTracker) generateCatchpointData(ctx context.Context, account
 	var catchpointWriter *catchpointWriter
 	start := time.Now()
 	ledgerGeneratecatchpointCount.Inc(nil)
-	err := ct.dbs.Rdb.Atomic(func(dbCtx context.Context, tx *sql.Tx) (err error) {
+	err = ct.dbs.Rdb.AtomicContext(ctx, func(ctx context.Context, tx *sql.Tx) (err error) {
 		catchpointWriter, err = makeCatchpointWriter(ctx, catchpointDataFilePath, tx, ResourcesPerCatchpointFileChunk)
 		if err != nil {
 			return
@@ -1123,7 +1123,7 @@ func (ct *catchpointTracker) generateCatchpointData(ctx context.Context, account
 				// we just wrote some data, but there is more to be written.
 				// go to sleep for while.
 				// before going to sleep, extend the transaction timeout so that we won't get warnings:
-				_, err0 := db.ResetTransactionWarnDeadline(dbCtx, tx, time.Now().Add(1*time.Second))
+				_, err0 := db.ResetTransactionWarnDeadline(ctx, tx, time.Now().Add(1*time.Second))
 				if err0 != nil {
 					ct.log.Warnf("catchpointTracker: generateCatchpoint: failed to reset transaction warn deadline : %v", err0)
 				}

--- a/util/db/dbutil.go
+++ b/util/db/dbutil.go
@@ -316,10 +316,6 @@ func (db *Accessor) AtomicContext(ctx context.Context, fn idemFn, extras ...inte
 	return
 }
 
-func (db *Accessor) Atomic(fn idemFn, extras ...interface{}) error {
-	return db.AtomicContext(context.Background(), fn, extras)
-}
-
 // ResetTransactionWarnDeadline allow the atomic function to extend its warn deadline by setting a new deadline.
 // The Accessor can be copied and therefore isn't suitable for multi-threading directly,
 // however, the transaction context and transaction object can be used to uniquely associate the request

--- a/util/db/dbutil.go
+++ b/util/db/dbutil.go
@@ -212,12 +212,13 @@ func (db *Accessor) IsSharedCacheConnection() bool {
 // The return error of fn should be a native sqlite3.Error type or an error wrapping it.
 // DO NOT return a custom error - the internal logic of Atomic expects an sqlite error and uses that value.
 func (db *Accessor) Atomic(fn idemFn, extras ...interface{}) (err error) {
-	return db.atomic(fn, extras...)
+	return db.AtomicContext(context.Background(), fn, extras...)
 }
 
-// Atomic executes a piece of code with respect to the database atomically.
+// AtomicContext executes a piece of code with respect to the database atomically.
 // For transactions where readOnly is false, sync determines whether or not to wait for the result.
-func (db *Accessor) atomic(fn idemFn, extras ...interface{}) (err error) {
+// Like for Atomic, the return error of fn should be a native sqlite3.Error type or an error wrapping it.
+func (db *Accessor) AtomicContext(ctx context.Context, fn idemFn, extras ...interface{}) (err error) {
 	atomicDeadline := time.Now().Add(time.Second)
 
 	// note that the sql library will drop panics inside an active transaction
@@ -244,7 +245,6 @@ func (db *Accessor) atomic(fn idemFn, extras ...interface{}) (err error) {
 
 	var tx *sql.Tx
 	var conn *sql.Conn
-	ctx := context.Background()
 
 	for i := 0; (i == 0) || dbretry(err); i++ {
 		if i > 0 {
@@ -314,6 +314,10 @@ func (db *Accessor) atomic(fn idemFn, extras ...interface{}) (err error) {
 		db.getDecoratedLogger(fn, extras).Warnf("dbatomic: tx surpassed expected deadline by %v", time.Now().Sub(atomicDeadline))
 	}
 	return
+}
+
+func (db *Accessor) Atomic(fn idemFn, extras ...interface{}) error {
+	return db.AtomicContext(context.Background(), fn, extras)
 }
 
 // ResetTransactionWarnDeadline allow the atomic function to extend its warn deadline by setting a new deadline.


### PR DESCRIPTION
## Summary

Atomic() doesn't accept a context, but always passes context.Background() to the callback fn.

This PR adds AtomicContext() that does accept a context and passes it to its callback.

Replaces #4104