### PR TITLE
alphanet: update vAlpha5 to point to v36

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1276,6 +1276,12 @@ func initConsensusProtocols() {
 	vAlpha4.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 	Consensus[protocol.ConsensusVAlpha4] = vAlpha4
 	vAlpha3.ApprovedUpgrades[protocol.ConsensusVAlpha4] = 10000
+
+	// vAlpha5 uses the same parameters as v36
+	vAlpha5 := v36
+	vAlpha5.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	Consensus[protocol.ConsensusVAlpha5] = vAlpha5
+	vAlpha4.ApprovedUpgrades[protocol.ConsensusVAlpha5] = 10000
 }
 
 // Global defines global Algorand protocol parameters which should not be overridden.

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -217,6 +217,9 @@ const ConsensusVAlpha3 = ConsensusVersion("alpha3")
 // ConsensusVAlpha4 uses the same parameters as ConsensusV34.
 const ConsensusVAlpha4 = ConsensusVersion("alpha4")
 
+// ConsensusVAlpha5 uses the same parameters as ConsensusV36.
+const ConsensusVAlpha5 = ConsensusVersion("alpha5")
+
 // !!! ********************* !!!
 // !!! *** Please update ConsensusCurrentVersion when adding new protocol versions *** !!!
 // !!! ********************* !!!


### PR DESCRIPTION
This adds a new consensus version to add vAlpha5, which points to v36 (with boxes)