### PR TITLE
updater: use more-recent installer package

### DIFF
--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # shellcheck disable=2009,2093,2164
 
-UPDATER_MIN_VERSION="3.8.0"
+UPDATER_MIN_VERSION="3.12.0"
 UPDATER_CHANNEL="stable"
 FILENAME=$(basename -- "$0")
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"

--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # shellcheck disable=2009,2093,2164
 
-UPDATER_MIN_VERSION="3.12.0"
+UPDATER_MIN_VERSION="3.12.2"
 UPDATER_CHANNEL="stable"
 FILENAME=$(basename -- "$0")
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

- this updates `UPDATER_MIN_VERSION` to use a more recent version of the install package. `3.12.2` is important b/c it's the release where we recently renewed the signing keys.
