### PR TITLE
tests: make ledger tests ~20 sec faster

### DIFF
--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -4591,10 +4591,7 @@ func TestRemoveOfflineStateProofID(t *testing.T) {
 	}
 }
 
-func TestEncodedBaseAccountDataSize(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-
+func randomBaseAccountData() baseAccountData {
 	vd := baseVotingData{
 		VoteFirstValid:  basics.Round(crypto.RandUint64()),
 		VoteLastValid:   basics.Round(crypto.RandUint64()),
@@ -4621,14 +4618,27 @@ func TestEncodedBaseAccountDataSize(t *testing.T) {
 		UpdateRound:                crypto.RandUint64(),
 	}
 
+	return baseAD
+}
+
+func TestEncodedBaseAccountDataSize(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	baseAD := randomBaseAccountData()
 	encoded := baseAD.MarshalMsg(nil)
 	require.GreaterOrEqual(t, MaxEncodedBaseAccountDataSize, len(encoded))
 }
 
-func TestEncodedBaseResourceSize(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
+func makeString(len int) string {
+	s := ""
+	for i := 0; i < len; i++ {
+		s += string(byte(i))
+	}
+	return s
+}
 
+func randomAssetResourceData() resourcesData {
 	currentConsensusParams := config.Consensus[protocol.ConsensusCurrentVersion]
 
 	// resourcesData is suiteable for keeping asset params, holding, app params, app local state
@@ -4650,6 +4660,12 @@ func TestEncodedBaseResourceSize(t *testing.T) {
 		Frozen: true,
 	}
 	crypto.RandBytes(rdAsset.MetadataHash[:])
+
+	return rdAsset
+}
+
+func randomAppResourceData() resourcesData {
+	currentConsensusParams := config.Consensus[protocol.ConsensusCurrentVersion]
 
 	rdApp := resourcesData{
 
@@ -4702,6 +4718,18 @@ func TestEncodedBaseResourceSize(t *testing.T) {
 
 	rdApp.GlobalState = maxGlobalState
 	rdApp.KeyValue = maxLocalState
+
+	return rdApp
+}
+
+func TestEncodedBaseResourceSize(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	// resourcesData is suiteable for keeping asset params, holding, app params, app local state
+	// but only asset + holding or app + local state can appear there
+	rdAsset := randomAssetResourceData()
+	rdApp := randomAppResourceData()
 
 	encodedAsset := rdAsset.MarshalMsg(nil)
 	encodedApp := rdApp.MarshalMsg(nil)

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -2390,7 +2390,7 @@ func TestLedgerMigrateV6ShrinkDeltas(t *testing.T) {
 	dbName := fmt.Sprintf("%s.%d", t.Name(), crypto.RandUint64())
 	testProtocolVersion := protocol.ConsensusVersion("test-protocol-migrate-shrink-deltas")
 	proto := config.Consensus[protocol.ConsensusV31]
-	proto.RewardsRateRefreshInterval = 500
+	proto.RewardsRateRefreshInterval = 200
 	config.Consensus[testProtocolVersion] = proto
 	defer func() {
 		delete(config.Consensus, testProtocolVersion)
@@ -2452,7 +2452,7 @@ func TestLedgerMigrateV6ShrinkDeltas(t *testing.T) {
 	l.trackers.acctsOnline = nil
 	l.acctsOnline = onlineAccounts{}
 
-	maxBlocks := 2000
+	maxBlocks := 1000
 	accounts := make(map[basics.Address]basics.AccountData, len(genesisInitState.Accounts))
 	keys := make(map[basics.Address]*crypto.SignatureSecrets, len(initKeys))
 	// regular addresses: all init accounts minus pools


### PR DESCRIPTION
## Summary

1. Make TestCatchpointFileBalancesChunkEncoding smaller. It does not check limits now but only encode-decode trip.
2. Make TestLedgerMigrateV6ShrinkDeltas smaller.

## Test Plan

These are tests