### PR TITLE
State Proof Recoverability: state proof verification tracking stores last verification data in memory

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -5367,13 +5367,13 @@ func stateProofVerificationInitDbQueries(r db.Queryable) (*stateProofVerificatio
 func getLatestVerificationData(handle *sql.DB) (ledgercore.StateProofVerificationData, error) {
 	row := handle.QueryRow("SELECT verificationdata FROM stateproofverification ORDER BY targetstateproofround DESC LIMIT 1")
 
-	var data []byte
-	if err := row.Scan(data); err != nil {
+	var buffer []byte
+	if err := row.Scan(&buffer); err != nil {
 		return ledgercore.StateProofVerificationData{}, err
 	}
 
 	var res ledgercore.StateProofVerificationData
-	if err := protocol.Decode(data, &res); err != nil {
+	if err := protocol.Decode(buffer, &res); err != nil {
 		return ledgercore.StateProofVerificationData{}, err
 	}
 

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -5364,6 +5364,22 @@ func stateProofVerificationInitDbQueries(r db.Queryable) (*stateProofVerificatio
 	return qs, nil
 }
 
+func getLatestVerificationData(handle *sql.DB) (ledgercore.StateProofVerificationData, error) {
+	row := handle.QueryRow("SELECT verificationdata FROM stateproofverification ORDER BY targetstateproofround DESC LIMIT 1")
+
+	var data []byte
+	if err := row.Scan(data); err != nil {
+		return ledgercore.StateProofVerificationData{}, err
+	}
+
+	var res ledgercore.StateProofVerificationData
+	if err := protocol.Decode(data, &res); err != nil {
+		return ledgercore.StateProofVerificationData{}, err
+	}
+
+	return res, nil
+}
+
 func (qs *stateProofVerificationDbQueries) lookupData(stateProofLastAttestedRound basics.Round) (*ledgercore.StateProofVerificationData, error) {
 	data := ledgercore.StateProofVerificationData{}
 	queryFunc := func() error {

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -88,6 +88,8 @@ func (spt *stateProofVerificationTracker) loadFromDisk(l ledgerForTracker, _ bas
 	spt.trackedCommitData = make([]verificationCommitData, 0, initialDataArraySize)
 	spt.trackedDeleteData = make([]verificationDeleteData, 0, initialDataArraySize)
 
+	// todo load latest from the DB.
+
 	return nil
 }
 
@@ -149,7 +151,6 @@ func (spt *stateProofVerificationTracker) commitRound(ctx context.Context, tx *s
 	}
 
 	return err
-
 }
 
 func (spt *stateProofVerificationTracker) postCommit(_ context.Context, dcc *deferredCommitContext) {
@@ -222,11 +223,11 @@ func (spt *stateProofVerificationTracker) committedRoundToLatestCommitDataIndex(
 	latestCommittedDataIndex := -1
 
 	for index, data := range spt.trackedCommitData {
-		if data.confirmedRound <= committedRound {
-			latestCommittedDataIndex = index
-		} else {
+		if data.confirmedRound > committedRound {
 			break
 		}
+
+		latestCommittedDataIndex = index
 	}
 
 	return latestCommittedDataIndex
@@ -236,11 +237,11 @@ func (spt *stateProofVerificationTracker) committedRoundToLatestDeleteDataIndex(
 	latestCommittedDataIndex := -1
 
 	for index, data := range spt.trackedDeleteData {
-		if data.confirmedRound <= committedRound {
-			latestCommittedDataIndex = index
-		} else {
+		if data.confirmedRound > committedRound {
 			break
 		}
+
+		latestCommittedDataIndex = index
 	}
 
 	return latestCommittedDataIndex

--- a/ledger/stateproofverificationtracker.go
+++ b/ledger/stateproofverificationtracker.go
@@ -182,7 +182,8 @@ func (spt *stateProofVerificationTracker) LookupVerificationData(stateProofLastA
 	spt.stateProofVerificationMu.RLock()
 	defer spt.stateProofVerificationMu.RUnlock()
 
-	if len(spt.trackedCommitData) > 0 && stateProofLastAttestedRound >= spt.trackedCommitData[0].verificationData.TargetStateProofRound &&
+	if len(spt.trackedCommitData) > 0 &&
+		stateProofLastAttestedRound >= spt.trackedCommitData[0].verificationData.TargetStateProofRound &&
 		stateProofLastAttestedRound <= spt.trackedCommitData[len(spt.trackedCommitData)-1].verificationData.TargetStateProofRound {
 		return spt.lookupDataInTrackedMemory(stateProofLastAttestedRound)
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
