### PR TITLE
Testing: Lint for unparallelized tests without explicit reason

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - revive
     - staticcheck
     - typecheck
+    - paralleltest
 
 severity:
   default-severity: error

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -116,6 +116,10 @@ issues:
         # - revive
         - staticcheck
         - typecheck
+    # Ignore missing parallel tests in existing packages
+    - path: (agreement|catchup|cmd|config|crypto|daemon|data|ledger|logging|network|node|protocol|rpcs|shared|stateproof|test|util).*_test.go
+      linters:
+        - paralleltest
     # Add all linters here -- Comment this block out for testing linters
     - path: test/linttest/lintissues\.go
       linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,7 +117,7 @@ issues:
         - staticcheck
         - typecheck
     # Ignore missing parallel tests in existing packages
-    - path: (agreement|catchup|cmd|config|crypto|daemon|data|ledger|logging|network|node|protocol|rpcs|shared|stateproof|test|util).*_test.go
+    - path: (agreement|catchup|cmd|config|crypto|daemon|data|gen|ledger|logging|netdeploy|network|node|protocol|rpcs|shared|stateproof|test|tools|util).*_test.go
       linters:
         - paralleltest
     # Add all linters here -- Comment this block out for testing linters

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2800,10 +2800,8 @@ func TestGetSpec(t *testing.T) {
 	require.Equal(t, "unknown opcode: nonsense", ops.Errors[1].Err.Error())
 }
 
-func TestAddPseudoDocTags(t *testing.T) {
+func TestAddPseudoDocTags(t *testing.T) { //nolint:paralleltest // Not parallel because it modifies pseudoOps and opDocByName which are global maps
 	partitiontest.PartitionTest(t)
-	// Not parallel because it modifies pseudoOps and opDocByName which are global maps
-	// t.Parallel()
 	defer func() {
 		delete(pseudoOps, "tests")
 		delete(opDocByName, "multiple")

--- a/data/transactions/logic/evalAppTxn_test.go
+++ b/data/transactions/logic/evalAppTxn_test.go
@@ -1761,9 +1761,7 @@ int 1
 `
 
 	for _, unified := range []bool{true, false} {
-		t.Run(fmt.Sprintf("unified=%t", unified), func(t *testing.T) {
-			// t.Parallel() NO! unified variable is actually shared
-
+		t.Run(fmt.Sprintf("unified=%t", unified), func(t *testing.T) { //nolint:paralleltest // NO t.Parallel(). unified variable is actually shared
 			ep, parentTx, ledger := MakeSampleEnv()
 			ep.Proto.UnifyInnerTxIDs = unified
 
@@ -2226,10 +2224,8 @@ func TestInnerTxIDCaching(t *testing.T) {
 	parentAppID := basics.AppIndex(888)
 	childAppID := basics.AppIndex(222)
 
-	for _, unified := range []bool{true, false} {
+	for _, unified := range []bool{true, false} { //nolint:paralleltest // NO t.Parallel(). unified variable is actually shared
 		t.Run(fmt.Sprintf("unified=%t", unified), func(t *testing.T) {
-			// t.Parallel() NO! unified variable is actually shared
-
 			ep, parentTx, ledger := MakeSampleEnv()
 			ep.Proto.UnifyInnerTxIDs = unified
 


### PR DESCRIPTION
## Summary

This PR starts the process of improving unit test parallelization by enabling the [paralleltest linter](https://golangci-lint.run/usage/linters/#paralleltest) within golang ci. Fixing missing `t.Parallel`'s will require careful consideration and so, in this initial PR, packages currently failing the paralleltest linter are excluded.

Future PRs will incrementally add the `t.Parallel()` flag to tests in existing packages and disable that package's exclusion within `.golangci.yml`. As a result, tests added to that package in the future will fail the linter if the parallel signal is not present and a reason is not given as to why it is missing. For more information regarding the process of finding and fixing incorrect tests within a particular package, refer to the additional information below.

## Additional Information

A large part of the work related to this PR involved brainstorming a path toward fixing unparallelized tests within existing packages. I've listed some additional information and answers to common questions below.

<details>
<summary>
<b>I want to start fixing missing instances of `t.Parallel` in a specific package. How can I find all the parlleltest errors associated with that package?</b>
</summary>
<br />

**1. Adjust the `.golangci.yml` configuration file to not exclude the particular package.**

For example, to reveal errors within the `ledger` package, remove `ledger` from [the exclusion filter](https://github.com/algorand/go-algorand/commit/5bbc0b4261102e784cb9df4d211faf5d38dc089f#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9R120):

`path: (data|ledger|logging).*_test.go` becomes `path: (data|logging).*_test.go`

**2. Temporarily disable the `new-from-rev` configuration within `.golangci.yml` by commenting it out.**

A majority of the tests without `t.Parallel()` were committed before the set revision so we must disable this configuration to let through every instance of the error within the particular package.

**3. Lint and filter by `paralleltest` errors specifically**

```
> make lint | grep paralleltest
```

We must filter specifically for paralleltest errors here because many more errors will creep through once we ignore the `new-from-rev` argument.
</details>

<details>
<summary>
<b>How can I mark tests to show that they shouldn't be run in parallel?</b>
</summary>
<br/>

If you find yourself in a situation where using `t.Parallel()` is impossible, put a `//nolint:paralleltest` comment on the line where the error is caught and **be sure to include an explanation for why the test could not be parallelized**.

For an example of how this looks in practice, please refer to examples in [this commit](https://github.com/algorand/go-algorand/commit/5a022d654d75845071860da27e1716115173b37a).
</details>

<details>
<summary>
<b>Will new tests in excluded packages be caught by the linter?</b>
</summary>
<br/>

Unfortunately, new tests without the parallel flag will not be caught by the linter as I could not find any way within the golangci lint configuration to demarcate that specific linters should be run against particular revisions. In other words, the `new-from-rev` flag applies to all linters and cannot be set individually.

This is why future PRs that fix existing errors within packages will be necessary to make enabling this linter worthwhile. Once existing tests missing the parallel flag have been fixed, the exclusion rule for that package can be removed and new tests after that point will be caught.
</details>

## Test Plan

These are primarily linter changes that do not benefit from tests. 
