### PR TITLE
tests: Fix account tests for calling pending txn endpoint and box tests

### DIFF
--- a/cmd/goal/box.go
+++ b/cmd/goal/box.go
@@ -65,7 +65,7 @@ var appBoxInfoCmd = &cobra.Command{
 		// Get box info
 		box, err := client.GetApplicationBoxByName(appIdx, boxName)
 		if err != nil {
-			if strings.Contains(err.Error(), `{"message":"box not found"}`) {
+			if strings.Contains(err.Error(), "box not found") {
 				reportErrorf("No box found for appid %d with name %s", appIdx, boxName)
 			}
 			reportErrorf(errorRequestFail, err)

--- a/test/e2e-go/features/transactions/accountv2_test.go
+++ b/test/e2e-go/features/transactions/accountv2_test.go
@@ -309,13 +309,13 @@ int 1
 		_, err = client.WaitForRound(round + 1)
 		a.NoError(err)
 		// Ensure the txn committed
-		resp, err = client.GetPendingTransactions(2)
+		resp, err := client.GetParsedPendingTransactions(2)
 		a.NoError(err)
-		if resp.TotalTxns == 1 {
-			a.Equal(resp.TruncatedTxns.Transactions[0].TxID, txid)
+		if resp.TotalTransactions == 1 {
+			a.Equal(resp.TopTransactions[0].Txn.ID(), txid)
 			continue
 		}
-		a.Equal(uint64(0), resp.TotalTxns)
+		a.Equal(uint64(0), resp.TotalTransactions)
 		break
 	}
 
@@ -547,7 +547,7 @@ int 1
 	// Ensure the txn committed
 	resp, err := client.GetPendingTransactions(2)
 	a.NoError(err)
-	a.Equal(uint64(0), resp.TotalTxns)
+	a.Equal(uint64(0), resp.TotalTransactions)
 	txinfo, err := client.TransactionInformation(signedTxn.Txn.Sender.String(), txid)
 	a.NoError(err)
 	a.True(txinfo.ConfirmedRound != 0)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

This PR changes some existing tests that call the GetPendingTransactions endpoint to use the v2 model instead of the v1 model. Also changes the `goal box` command to account for client-side error string handling. 

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

Integration tests.
