### PR TITLE
Tests: Cast consensus version to string before equality assert

### DIFF
--- a/test/e2e-go/features/participation/participationExpiration_test.go
+++ b/test/e2e-go/features/participation/participationExpiration_test.go
@@ -152,7 +152,7 @@ func testExpirationAccounts(t *testing.T, fixture *fixtures.RestClientFixture, f
 
 	blk, err := sClient.BookkeepingBlock(latestRound)
 	a.NoError(err)
-	a.Equal(blk.CurrentProtocol, protocolCheck)
+	a.Equal(string(blk.CurrentProtocol), protocolCheck)
 
 	sendMoneyTxn := fixture.SendMoneyAndWait(latestRound, amountToSendInitial, transactionFee, richAccount, sAccount, "")
 

--- a/test/framework/fixtures/restClientFixture.go
+++ b/test/framework/fixtures/restClientFixture.go
@@ -23,7 +23,6 @@ import (
 	"unicode"
 
 	"github.com/algorand/go-algorand/data/basics"
-	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/protocol"
 
 	"github.com/stretchr/testify/require"
@@ -279,15 +278,8 @@ func (f *RestClientFixture) WaitForAllTxnsToConfirm(roundTimeout uint64, txidsAn
 		_, err := f.WaitForConfirmedTxn(roundTimeout, addr, txid)
 		if err != nil {
 			f.t.Logf("txn failed to confirm: ", addr, txid)
-			response, err := f.AlgodClient.GetRawPendingTransactions(0)
+			pendingTxns, err := f.LibGoalClient.GetParsedPendingTransactions(0)
 			if err == nil {
-				// Parse pending transaction response
-				var pendingTxns struct {
-					TopTransactions   []transactions.SignedTxn
-					TotalTransactions uint64
-				}
-				err = protocol.DecodeReflect(response, &pendingTxns)
-				require.NoError(f.t, err)
 				pendingTxids := make([]string, 0, pendingTxns.TotalTransactions)
 				for _, txn := range pendingTxns.TopTransactions {
 					pendingTxids = append(pendingTxids, txn.Txn.ID().String())


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

This PR casts the `CurrentProtocol` to a string before asserting equality with another string in the tests, and changes the REST fixture tests to use the libgoal client to get parsed `PendingTransaction` information.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

This should fix the nightly builds. 