### PR TITLE
daemon: pool error messages and old txn expiration

### DIFF
--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -1019,7 +1019,8 @@ func (v2 *Handlers) PendingTransactionInformation(ctx echo.Context, txid string,
 
 	// Encoding wasn't working well without embedding "real" objects.
 	response := PreEncodedTxInfo{
-		Txn: txn.Txn,
+		Txn:       txn.Txn,
+		PoolError: txn.PoolError,
 	}
 
 	if txn.ConfirmedRound != 0 {


### PR DESCRIPTION
## Summary

Transaction pools might store failed transactions for quite a long time on its StatusCache.
When someone requests a pending transaction and it gets retrieved from the StatusCache,
there is no indication it actually failed. A user might have an impression the txn is fine but stuck.
In order to give a correct feedback, report any errors from the StatusCache via REST API.
