### PR TITLE
goal: Change asset commands to use AccountAssetInformation

### DIFF
--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/libgoal"
 )
@@ -790,22 +789,11 @@ var infoAssetCmd = &cobra.Command{
 			asset.Params.Reserve = &asset.Params.Creator
 		}
 
-		reserve, err := client.AccountInformationV2(*asset.Params.Reserve, true)
+		reserve, err := client.AccountAssetInformation(*asset.Params.Reserve, assetID)
 		if err != nil {
 			reportErrorf(errorRequestFail, err)
 		}
-
-		var res generated.AssetHolding
-		if reserve.Assets != nil {
-			for _, reserveAsset := range *reserve.Assets {
-				if assetID == reserveAsset.AssetId {
-					res = reserveAsset
-					break
-				}
-			}
-		} else {
-			reportErrorf(errorRequestFail, "cannot find asset ID in account")
-		}
+		res := reserve.AssetHolding
 
 		fmt.Printf("Asset ID:         %d\n", assetID)
 		fmt.Printf("Creator:          %s\n", asset.Params.Creator)

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -868,7 +868,7 @@ func (c *Client) EncodedBlockCert(round uint64) (blockCert rpcs.EncodedBlockCert
 		var resp []byte
 		resp, err = algod.RawBlock(round)
 		if err == nil {
-			err = protocol.DecodeReflect(resp, &blockCert)
+			err = protocol.Decode(resp, &blockCert)
 			if err != nil {
 				return
 			}

--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -707,27 +707,15 @@ func (c *Client) MakeUnsignedAssetConfigTx(creator string, index uint64, newMana
 	var tx transactions.Transaction
 	var err error
 
-	// If the creator was passed in blank, look up asset info by index
-	var params generated.AssetParams
-	if creator == "" {
-		asset, err := c.AssetInformationV2(index)
-		if err != nil {
-			return tx, err
-		}
-		params = asset.Params
-	} else {
-		// Fetch the current state, to fill in as a template
-		current, err := c.AccountAssetInformation(creator, index)
-		if err != nil {
-			return tx, err
-		}
+	asset, err := c.AssetInformationV2(index)
+	if err != nil {
+		return tx, err
+	}
+	params := asset.Params
 
-		// Search for the asset index in the CreatedAssets array
-		if current.CreatedAsset != nil {
-			params = *current.CreatedAsset
-		} else {
-			return tx, fmt.Errorf("asset ID %d not found in account %s", index, creator)
-		}
+	// If creator was passed in, check that the asset params match.
+	if creator != "" && creator != params.Creator {
+		return tx, fmt.Errorf("creator %s does not match asset ID %d", creator, index)
 	}
 
 	if newManager == nil {

--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -717,24 +717,14 @@ func (c *Client) MakeUnsignedAssetConfigTx(creator string, index uint64, newMana
 		params = asset.Params
 	} else {
 		// Fetch the current state, to fill in as a template
-		current, err := c.AccountInformationV2(creator, true)
+		current, err := c.AccountAssetInformation(creator, index)
 		if err != nil {
 			return tx, err
 		}
 
 		// Search for the asset index in the CreatedAssets array
-		assetFound := false
-		if current.CreatedAssets != nil {
-			for _, asset := range *current.CreatedAssets {
-				if index == asset.Index {
-					params = asset.Params
-					assetFound = true
-					break
-				}
-			}
-			if !assetFound {
-				return tx, fmt.Errorf("asset ID %d not found in account %s", index, creator)
-			}
+		if current.CreatedAsset != nil {
+			params = *current.CreatedAsset
 		} else {
 			return tx, fmt.Errorf("asset ID %d not found in account %s", index, creator)
 		}

--- a/test/scripts/e2e_subs/asset-misc.sh
+++ b/test/scripts/e2e_subs/asset-misc.sh
@@ -103,7 +103,9 @@ fi
 ${gcmd} asset create --creator "${ACCOUNT}" --manager "${ACCOUNTB}" --reserve "${ACCOUNTC}" --freezer "${ACCOUNTD}" --clawback "${ACCOUNTE}" --name "${ASSET_NAME}" --unitname dma --total 1000000000000 --asseturl "${ASSET_URL}"
 
 # case 3a: asset info should fail if reserve address has not opted into the asset.
-if $(${gcmd} asset info --creator $ACCOUNT --unitname dma); then
+EXPERROR='account asset info not found'
+RES=$(${gcmd} asset info --creator $ACCOUNT --unitname dma 2>&1 || true)
+if [[ $RES != *"${EXPERROR}"* ]]; then
     date '+asset-misc FAIL asset info should fail unless reserve account was opted in %Y%m%d_%H%M%S'
     exit 1
 else

--- a/test/scripts/e2e_subs/asset-misc.sh
+++ b/test/scripts/e2e_subs/asset-misc.sh
@@ -102,6 +102,16 @@ fi
 # case 3: asset created with manager, reserve, freezer, and clawback different from the creator
 ${gcmd} asset create --creator "${ACCOUNT}" --manager "${ACCOUNTB}" --reserve "${ACCOUNTC}" --freezer "${ACCOUNTD}" --clawback "${ACCOUNTE}" --name "${ASSET_NAME}" --unitname dma --total 1000000000000 --asseturl "${ASSET_URL}"
 
+# case 3a: asset info should fail if reserve address has not opted into the asset.
+if $(${gcmd} asset info --creator $ACCOUNT --unitname dma); then
+    date '+asset-misc FAIL asset info should fail unless reserve account was opted in %Y%m%d_%H%M%S'
+    exit 1
+else
+    echo ok
+fi
+
+# case 3b: Reserve address opts into the the asset, and gets asset info successfully.
+${gcmd} asset optin --creator "${ACCOUNT}" --asset dma --account ${ACCOUNTC}
 DIFF_MANAGER_ASSET_ID=$(${gcmd} asset info --creator $ACCOUNT --unitname dma|grep 'Asset ID'|awk '{ print $3 }')
 
 DMA_MANAGER_ADDRESS=$(${gcmd} asset info --assetid ${DIFF_MANAGER_ASSET_ID} |grep 'Manager address'|awk '{ print $3 }')


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

This PR addresses some open comments made in https://github.com/algorand/go-algorand/pull/4684

Addresses three things:
* Change `EncodedBlockCert` decoding to use `Decode` instead of `DecodeReflect`
* Use `AccountAssetInformation` API in `goal asset info`. This changes behavior in `goal asset info` that looked like a bug regarding reserve addresses: the command now returns an error if a reserve asset is not opted into the asset, whereas previously, the command returned zero-ed values without failing. One test was changed to reflect this behavior.
* Refactor `libgoal` to use `AccountAssetInformation` instead of `AccountInformationV2`

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

CI tests.
