### PR TITLE
netgoal: start with at least 20GB RootStorage

### DIFF
--- a/netdeploy/remote/deployedNetwork.go
+++ b/netdeploy/remote/deployedNetwork.go
@@ -1047,7 +1047,7 @@ func extractPublicPort(address string) (port int, err error) {
 func computeRootStorage(nodeCount, relayCount int) int {
 	// For now, we'll just use root storage -- assume short-lived instances
 	// 10 per node should be good for a week (add relayCount * 0 so param is used)
-	minGB := 10 + nodeCount*10 + (relayCount * 50)
+	minGB := 20 + (nodeCount * 10) + (relayCount * 50)
 	return minGB
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

- bumps the constant when calculating required storage for instances using `netgoal` to `20`
    - for instance, with a single NPN and no relays, the return value changes from `20` to `30`
    - this was highlighted when spinning up `mainnet` NPNs and running fast-catchup, the data directories are approaching, if not exceeding, 20GB

## Test Plan

- load generator pipeline
