### PR TITLE
Test notification on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ executors:
 slack-fail-stop-step: &slack-fail-post-step
   post-steps:
     - slack/notify:
-        branch_pattern: "master,rel/beta,rel/nightly,rel/stable"
+        branch_pattern: "master,rel/beta,rel/nightly,rel/stable,notify_on_failure_test"
         event: fail
         template: basic_fail_1
 

--- a/data/transactions/logic/box.go
+++ b/data/transactions/logic/box.go
@@ -165,7 +165,7 @@ func opBoxReplace(cx *EvalContext) error {
 	prev := last - 1          // start
 	pprev := prev - 1         // name
 
-	replacement := cx.stack[last].Bytes
+	replacement := cx.stack[last].Byte
 	start := cx.stack[prev].Uint
 	name := string(cx.stack[pprev].Bytes)
 


### PR DESCRIPTION
Extends https://github.com/algorand/go-algorand/pull/4789 with a test illustrating failure notification works on a failed step.

The PR deliberately introduces a compile-time error + adds the PR's branch to the notification allowlist.

PR is opened only for testing illustration and will be closed when the parent PR is closed/merged.