### PR TITLE
CI:  Notify when GHA workflow fails on master

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -49,3 +49,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           alert-threshold: '200%'
           comment-on-alert: true
+      - name: Slack Notification
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: |
+          curl -X POST --data-urlencode "payload={\"text\": \"Benchmark workflow failed. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \"}" $SLACK_WEBHOOK
+        if: ${{ failure() && (contains(github.base_ref, 'rel/nightly') || contains(github.base_ref, 'rel/beta') || contains(github.base_ref, 'rel/stable') || contains(github.base_ref, 'master')) }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,5 +44,5 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: |
-          curl -X POST --data-urlencode "payload={\"text\": \"Nightly windows build test on Github failed. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \"}" $SLACK_WEBHOOK
-        if: ${{ failure() && (contains(github.base_ref, 'rel/nightly') || contains(github.base_ref, 'rel/beta') || contains(github.base_ref, 'rel/stable')) }}
+          curl -X POST --data-urlencode "payload={\"text\": \"Build windows failed. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \"}" $SLACK_WEBHOOK
+        if: ${{ failure() && (contains(github.base_ref, 'rel/nightly') || contains(github.base_ref, 'rel/beta') || contains(github.base_ref, 'rel/stable') || contains(github.base_ref, 'master')) }}

--- a/.github/workflows/codegen_verification.yml
+++ b/.github/workflows/codegen_verification.yml
@@ -20,3 +20,9 @@ jobs:
           export GOPATH="${GITHUB_WORKSPACE}/go"
           cd go-algorand
           scripts/travis/codegen_verification.sh
+      - name: Slack Notification
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: |
+          curl -X POST --data-urlencode "payload={\"text\": \"Codegen verification failed. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \"}" $SLACK_WEBHOOK
+        if: ${{ failure() && (contains(github.base_ref, 'rel/nightly') || contains(github.base_ref, 'rel/beta') || contains(github.base_ref, 'rel/stable') || contains(github.base_ref, 'master')) }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -92,3 +92,9 @@ jobs:
           -filter-mode=added
           -fail-on-error=false
           -level=warning
+      - name: Slack Notification
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: |
+          curl -X POST --data-urlencode "payload={\"text\": \"Reviewdog failed. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \"}" $SLACK_WEBHOOK
+        if: ${{ failure() && (contains(github.base_ref, 'rel/nightly') || contains(github.base_ref, 'rel/beta') || contains(github.base_ref, 'rel/stable') || contains(github.base_ref, 'master')) }}


### PR DESCRIPTION
Accompanies https://github.com/algorand/go-algorand/pull/4789 to add Slack notifications for failed Github Action (GHA) workflows in `master`.  Like #4789, the rationale is to be aware of a failed build in our development branch as soon as possible.

Notes:
* In practice, I expect the workflows modified by the PR to rarely, if ever, fail in `master`.  
* There might be a way to streamline the notification definition through plugin usage.  For the PR's purpose, I copy-pasted the approach in .github/workflows/build.yml.  For a more thorough treatment, I'd prefer to create a ticket out-of-band to the PR. 