### PR TITLE
Tests: Fix txid-string comparison

### DIFF
--- a/test/e2e-go/features/transactions/accountv2_test.go
+++ b/test/e2e-go/features/transactions/accountv2_test.go
@@ -312,7 +312,7 @@ int 1
 		resp, err := client.GetParsedPendingTransactions(2)
 		a.NoError(err)
 		if resp.TotalTransactions == 1 {
-			a.Equal(resp.TopTransactions[0].Txn.ID(), txid)
+			a.Equal(resp.TopTransactions[0].Txn.ID().String(), txid)
 			continue
 		}
 		a.Equal(uint64(0), resp.TotalTransactions)

--- a/test/e2e-go/upgrades/application_support_test.go
+++ b/test/e2e-go/upgrades/application_support_test.go
@@ -452,24 +452,9 @@ int 1
 	a.NoError(err)
 
 	// Try polling 10 rounds to ensure txn is committed.
-	isCommitted := false
-	for i := 0; i < 10; i++ {
-		round, err = client.CurrentRound()
-		a.NoError(err)
-		_, err = client.WaitForRound(round + 1)
-		a.NoError(err)
-		// Ensure the txn committed
-		resp, err := client.GetParsedPendingTransactions(2)
-		a.NoError(err)
-		if resp.TotalTransactions == 1 {
-			pendingTxn := resp.TopTransactions[0]
-			a.Equal(pendingTxn.Txn.ID().String(), txid)
-			continue
-		}
-		a.Equal(uint64(0), resp.TotalTransactions)
-		isCommitted = true
-		break
-	}
+	round, err = client.CurrentRound()
+	a.NoError(err)
+	isCommitted := fixture.WaitForTxnConfirmation(round+10, creator, txid)
 	a.True(isCommitted)
 
 	// check creator's balance record for the app entry and the state changes

--- a/test/e2e-go/upgrades/application_support_test.go
+++ b/test/e2e-go/upgrades/application_support_test.go
@@ -450,7 +450,10 @@ int 1
 	a.NoError(err)
 	txid, err := client.BroadcastTransaction(signedTxn)
 	a.NoError(err)
-	for {
+
+	// Try polling 10 rounds to ensure txn is committed.
+	isCommitted := false
+	for i := 0; i < 10; i++ {
 		round, err = client.CurrentRound()
 		a.NoError(err)
 		_, err = client.WaitForRound(round + 1)
@@ -464,8 +467,10 @@ int 1
 			continue
 		}
 		a.Equal(uint64(0), resp.TotalTransactions)
+		isCommitted = true
 		break
 	}
+	a.True(isCommitted)
 
 	// check creator's balance record for the app entry and the state changes
 	ad, err = client.AccountData(creator)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

This PR fixes the [build](https://app.circleci.com/pipelines/github/algorand/go-algorand/10565/workflows/68dd4267-ed96-46e6-b4c2-8df49a5dfaa9/jobs/182847) where there was a type mismatch in an assertion between the TxID bytes and string. One [existing test failed](https://app.circleci.com/pipelines/github/algorand/go-algorand/10565/workflows/68dd4267-ed96-46e6-b4c2-8df49a5dfaa9/jobs/182843) if the transaction was not committed in the next 2 rounds, so this PR adds a loop to wait if that is the case.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

Re-run tests. 