### PR TITLE
tools: update catchpointdump 'database' and 'database check' commands to handle staging tables and KVs

### DIFF
--- a/cmd/catchpointdump/database.go
+++ b/cmd/catchpointdump/database.go
@@ -65,7 +65,7 @@ var databaseCmd = &cobra.Command{
 		if err != nil {
 			reportErrorf("Unable to print account database : %v", err)
 		}
-		err = printKeyValueStore(ledgerTrackerFilename, ledgerTrackerStaging, ledger.CatchpointFileHeader{}, outFile)
+		err = printKeyValueStore(ledgerTrackerFilename, ledgerTrackerStaging, outFile)
 		if err != nil {
 			reportErrorf("Unable to print key value store : %v", err)
 		}
@@ -115,10 +115,10 @@ func checkDatabase(databaseName string, outFile *os.File) error {
 			return err
 		}
 		root, err := trie.RootHash()
-		fmt.Fprintf(outFile, " Root: %s\n", root.String())
 		if err != nil {
 			return err
 		}
+		fmt.Fprintf(outFile, " Root: %s\n", root)
 		stats, err = trie.GetStats()
 		if err != nil {
 			return err

--- a/cmd/catchpointdump/net.go
+++ b/cmd/catchpointdump/net.go
@@ -357,7 +357,7 @@ func loadAndDump(addr string, tarFile string, genesisInitState ledgercore.InitSt
 		if err != nil {
 			return err
 		}
-		err = printKeyValueStore("./ledger.tracker.sqlite", true, fileHeader, outFile)
+		err = printKeyValueStore("./ledger.tracker.sqlite", true, outFile)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

The catchpointdump "database" and "database check" commands did not handle KVs or unlimited assets very well, and this updates them to add a "--staging" flag allow dumping/checking both the catchpoint staging tables and the regular tables.

## Test Plan

Tested manually.