### PR TITLE
Bug-fix: txhandler does not start after node catching up #4775

### DIFF
--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -91,13 +91,12 @@ func MakeTxHandler(txPool *pools.TransactionPool, ledger *Ledger, net network.Go
 		postVerificationQueue: make(chan *txBacklogMsg, txBacklogSize),
 		net:                   net,
 	}
-
-	handler.ctx, handler.ctxCancel = context.WithCancel(context.Background())
 	return handler
 }
 
 // Start enables the processing of incoming messages at the transaction handler
 func (handler *TxHandler) Start() {
+	handler.ctx, handler.ctxCancel = context.WithCancel(context.Background())
 	handler.net.RegisterHandlers([]network.TaggedMessageHandler{
 		{Tag: protocol.TxnTag, MessageHandler: network.HandlerFunc(handler.processIncomingTxn)},
 	})

--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -385,7 +385,6 @@ func TestCatchpointLabelGeneration(t *testing.T) {
 					break
 				}
 				currentRound++
-
 			}
 			log.Infof("done building!\n")
 
@@ -399,4 +398,303 @@ func TestCatchpointLabelGeneration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNodeTxSyncRestart(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
+
+	if testing.Short() {
+		t.Skip()
+	}
+	a := require.New(fixtures.SynchronizedTest(t))
+	// Overview of this test:
+	// Start a two-node and one relay network
+	// Wait until a catchpoint is created
+	// Let the primary node have the majority of the stake
+	// Stop the primary node to miss the next transaction
+	// Send a transaction from the second node
+	// Start the primary node, and immediately after start the catchup
+	// The transaction will be confirmed only when the TxSync of the pools passes the transaction to the primary node
+
+	consensus := make(config.ConsensusProtocols)
+	protoVersion := protocol.ConsensusCurrentVersion
+	catchpointCatchupProtocol := config.Consensus[protoVersion]
+	catchpointCatchupProtocol.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	// MaxBalLookback  =  2 x SeedRefreshInterval x SeedLookback
+	// ref. https://github.com/algorandfoundation/specs/blob/master/dev/abft.md
+	catchpointCatchupProtocol.SeedLookback = 2
+	catchpointCatchupProtocol.SeedRefreshInterval = 2
+	catchpointCatchupProtocol.MaxBalLookback = 2 * catchpointCatchupProtocol.SeedLookback * catchpointCatchupProtocol.SeedRefreshInterval // 8
+	catchpointCatchupProtocol.CatchpointLookback = catchpointCatchupProtocol.MaxBalLookback
+	catchpointCatchupProtocol.EnableOnlineAccountCatchpoints = true
+	catchpointCatchupProtocol.StateProofInterval = 0
+	if runtime.GOOS == "darwin" || runtime.GOARCH == "amd64" {
+		// amd64/macos platforms are generally quite capable, so accelerate the round times to make the test run faster.
+		catchpointCatchupProtocol.AgreementFilterTimeoutPeriod0 = 1 * time.Second
+		catchpointCatchupProtocol.AgreementFilterTimeout = 1 * time.Second
+	}
+	consensus[protoVersion] = catchpointCatchupProtocol
+
+	var fixture fixtures.RestClientFixture
+	fixture.SetConsensus(consensus)
+	fixture.SetupNoStart(t, filepath.Join("nettemplates", "TwoNodes50EachWithRelay.json"))
+
+	// Get primary node
+	primaryNode, err := fixture.GetNodeController("Node1")
+	a.NoError(err)
+	// Get secondary node
+	secondNode, err := fixture.GetNodeController("Node2")
+	a.NoError(err)
+	// Get the relay
+	relayNode, err := fixture.GetNodeController("Relay")
+	a.NoError(err)
+
+	// prepare it's configuration file to set it to generate a catchpoint every 4 rounds.
+	cfg, err := config.LoadConfigFromDisk(primaryNode.GetDataDir())
+	a.NoError(err)
+	const catchpointInterval = 16
+	cfg.CatchpointInterval = catchpointInterval
+	cfg.CatchpointTracking = 2
+	cfg.MaxAcctLookback = 2
+	cfg.Archival = false
+
+	// Shorten the txn sync interval so the test can run faster
+	cfg.TxSyncIntervalSeconds = 2
+
+	cfg.SaveToDisk(primaryNode.GetDataDir())
+	cfg.SaveToDisk(secondNode.GetDataDir())
+
+	cfg, err = config.LoadConfigFromDisk(relayNode.GetDataDir())
+	a.NoError(err)
+	cfg.TxSyncIntervalSeconds = 2
+	cfg.SaveToDisk(relayNode.GetDataDir())
+
+	fixture.Start()
+
+	client1 := fixture.GetLibGoalClientFromNodeController(primaryNode)
+	client2 := fixture.GetLibGoalClientFromNodeController(secondNode)
+	wallet1, err := client1.GetUnencryptedWalletHandle()
+	a.NoError(err)
+	wallet2, err := client2.GetUnencryptedWalletHandle()
+	a.NoError(err)
+	addrs1, err := client1.ListAddresses(wallet1)
+	a.NoError(err)
+	addrs2, err := client2.ListAddresses(wallet2)
+	a.NoError(err)
+
+	// let the second node have insufficient stake for proposing a block
+	tx, err := client2.SendPaymentFromUnencryptedWallet(addrs2[0], addrs1[0], 1000, 4999999999000000, nil)
+	a.NoError(err)
+	status, err := client1.Status()
+	a.NoError(err)
+	_, err = fixture.WaitForConfirmedTxn(status.LastRound+100, addrs1[0], tx.ID().String())
+	a.NoError(err)
+	targetCatchpointRound := status.LastRound
+
+	// ensure the catchpoint is created for targetCatchpointRound
+	timer := time.NewTimer(100 * time.Second)
+outer:
+	for {
+		status, err = client1.Status()
+		a.NoError(err)
+
+		var round basics.Round
+		if status.LastCatchpoint != nil && len(*status.LastCatchpoint) > 0 {
+			round, _, err = ledgercore.ParseCatchpointLabel(*status.LastCatchpoint)
+			a.NoError(err)
+			if uint64(round) >= targetCatchpointRound {
+				break
+			}
+		}
+		select {
+		case <-timer.C:
+			a.Failf("timeout waiting a catchpoint", "target: %d, got %d", targetCatchpointRound, round)
+			break outer
+		default:
+			time.Sleep(250 * time.Millisecond)
+		}
+	}
+
+	// stop the primary node
+	client1.FullStop()
+
+	// let the 2nd client send a transaction
+	tx, err = client2.SendPaymentFromUnencryptedWallet(addrs2[0], addrs1[0], 1000, 50000, nil)
+	a.NoError(err)
+
+	// now that the primary missed the transaction, start it, and let it catchup
+	_, err = fixture.StartNode(primaryNode.GetDataDir())
+	a.NoError(err)
+	// let the primary node catchup
+	err = client1.Catchup(*status.LastCatchpoint)
+	a.NoError(err)
+
+	// the transaction should not be confirmed yet
+	_, err = fixture.WaitForConfirmedTxn(0, addrs2[0], tx.ID().String())
+	a.Error(err)
+
+	// Wait for the catchup
+	for t := 0; t < 10; t++ {
+		status1, err := client1.Status()
+		a.NoError(err)
+		status2, err := client2.Status()
+		a.NoError(err)
+
+		if status1.LastRound+1 >= status2.LastRound {
+			// if the primary node is within 1 round of the secondary node, then it has
+			// caught up
+			break
+		}
+		time.Sleep(catchpointCatchupProtocol.AgreementFilterTimeout)
+	}
+
+	status, err = client2.Status()
+	a.NoError(err)
+	_, err = fixture.WaitForConfirmedTxn(status.LastRound+50, addrs2[0], tx.ID().String())
+	a.NoError(err)
+}
+
+func TestNodeTxHandlerRestart(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
+
+	if testing.Short() {
+		t.Skip()
+	}
+	a := require.New(fixtures.SynchronizedTest(t))
+	// Overview of this test:
+	// Start a two-node and one relay network
+	// Wait until a catchpoint is created
+	// Let the primary node have the majority of the stake
+	// Stop the primary node to miss the next transaction
+	// Send a transaction from the second node
+	// Start the primary node, and immediately after start the catchup
+	// The transaction will be confirmed only when the TxSync of the pools passes the transaction to the primary node
+
+	consensus := make(config.ConsensusProtocols)
+	protoVersion := protocol.ConsensusCurrentVersion
+	catchpointCatchupProtocol := config.Consensus[protoVersion]
+	catchpointCatchupProtocol.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	// MaxBalLookback  =  2 x SeedRefreshInterval x SeedLookback
+	// ref. https://github.com/algorandfoundation/specs/blob/master/dev/abft.md
+	catchpointCatchupProtocol.SeedLookback = 2
+	catchpointCatchupProtocol.SeedRefreshInterval = 2
+	catchpointCatchupProtocol.MaxBalLookback = 2 * catchpointCatchupProtocol.SeedLookback * catchpointCatchupProtocol.SeedRefreshInterval // 8
+	catchpointCatchupProtocol.CatchpointLookback = catchpointCatchupProtocol.MaxBalLookback
+	catchpointCatchupProtocol.EnableOnlineAccountCatchpoints = true
+	catchpointCatchupProtocol.StateProofInterval = 0
+	if runtime.GOOS == "darwin" || runtime.GOARCH == "amd64" {
+		// amd64/macos platforms are generally quite capable, so accelerate the round times to make the test run faster.
+		catchpointCatchupProtocol.AgreementFilterTimeoutPeriod0 = 1 * time.Second
+		catchpointCatchupProtocol.AgreementFilterTimeout = 1 * time.Second
+	}
+	consensus[protoVersion] = catchpointCatchupProtocol
+
+	var fixture fixtures.RestClientFixture
+	fixture.SetConsensus(consensus)
+	fixture.SetupNoStart(t, filepath.Join("nettemplates", "TwoNodes50EachWithRelay.json"))
+
+	// Get primary node
+	primaryNode, err := fixture.GetNodeController("Node1")
+	a.NoError(err)
+	// Get secondary node
+	secondNode, err := fixture.GetNodeController("Node2")
+	a.NoError(err)
+	// Get the relay
+	relayNode, err := fixture.GetNodeController("Relay")
+	a.NoError(err)
+
+	// prepare it's configuration file to set it to generate a catchpoint every 4 rounds.
+	cfg, err := config.LoadConfigFromDisk(primaryNode.GetDataDir())
+	a.NoError(err)
+	const catchpointInterval = 16
+	cfg.CatchpointInterval = catchpointInterval
+	cfg.CatchpointTracking = 2
+	cfg.MaxAcctLookback = 2
+	cfg.Archival = false
+
+	cfg.TxSyncIntervalSeconds = 200000 // disable txSync
+
+	cfg.SaveToDisk(primaryNode.GetDataDir())
+	cfg.SaveToDisk(secondNode.GetDataDir())
+
+	cfg, err = config.LoadConfigFromDisk(relayNode.GetDataDir())
+	a.NoError(err)
+	cfg.TxSyncIntervalSeconds = 200000 // disable txSync
+	cfg.SaveToDisk(relayNode.GetDataDir())
+
+	fixture.Start()
+
+	client1 := fixture.GetLibGoalClientFromNodeController(primaryNode)
+	client2 := fixture.GetLibGoalClientFromNodeController(secondNode)
+	wallet1, err := client1.GetUnencryptedWalletHandle()
+	a.NoError(err)
+	wallet2, err := client2.GetUnencryptedWalletHandle()
+	a.NoError(err)
+	addrs1, err := client1.ListAddresses(wallet1)
+	a.NoError(err)
+	addrs2, err := client2.ListAddresses(wallet2)
+	a.NoError(err)
+
+	// let the second node have insufficient stake for proposing a block
+	tx, err := client2.SendPaymentFromUnencryptedWallet(addrs2[0], addrs1[0], 1000, 4999999999000000, nil)
+	a.NoError(err)
+	status, err := client1.Status()
+	a.NoError(err)
+	_, err = fixture.WaitForConfirmedTxn(status.LastRound+100, addrs1[0], tx.ID().String())
+	a.NoError(err)
+	targetCatchpointRound := status.LastRound
+
+	// ensure the catchpoint is created for targetCatchpointRound
+	timer := time.NewTimer(100 * time.Second)
+outer:
+	for {
+		status, err = client1.Status()
+		a.NoError(err)
+
+		var round basics.Round
+		if status.LastCatchpoint != nil && len(*status.LastCatchpoint) > 0 {
+			round, _, err = ledgercore.ParseCatchpointLabel(*status.LastCatchpoint)
+			a.NoError(err)
+			if uint64(round) >= targetCatchpointRound {
+				break
+			}
+		}
+		select {
+		case <-timer.C:
+			a.Failf("timeout waiting a catchpoint", "target: %d, got %d", targetCatchpointRound, round)
+			break outer
+		default:
+			time.Sleep(250 * time.Millisecond)
+		}
+	}
+
+	// let the primary node catchup
+	err = client1.Catchup(*status.LastCatchpoint)
+	a.NoError(err)
+
+	// Wait for the network to start making progress again
+	for t := 0; t < 10; t++ {
+		status1, err := client1.Status()
+		a.NoError(err)
+		status2, err := client2.Status()
+		a.NoError(err)
+
+		if status1.LastRound+1 >= status2.LastRound {
+			// if the primary node is within 1 round of the secondary node, then it has
+			// caught up
+			break
+		}
+		time.Sleep(catchpointCatchupProtocol.AgreementFilterTimeout)
+	}
+
+	// let the 2nd client send a transaction
+	tx, err = client2.SendPaymentFromUnencryptedWallet(addrs2[0], addrs1[0], 1000, 50000, nil)
+	a.NoError(err)
+
+	status, err = client2.Status()
+	a.NoError(err)
+	_, err = fixture.WaitForConfirmedTxn(status.LastRound+500, addrs2[0], tx.ID().String())
+	a.NoError(err)
 }

--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -460,17 +460,18 @@ func TestNodeTxSyncRestart(t *testing.T) {
 	cfg.Archival = false
 
 	// Shorten the txn sync interval so the test can run faster
-	cfg.TxSyncIntervalSeconds = 2
+	cfg.TxSyncIntervalSeconds = 4
 
 	cfg.SaveToDisk(primaryNode.GetDataDir())
 	cfg.SaveToDisk(secondNode.GetDataDir())
 
 	cfg, err = config.LoadConfigFromDisk(relayNode.GetDataDir())
 	a.NoError(err)
-	cfg.TxSyncIntervalSeconds = 2
+	cfg.TxSyncIntervalSeconds = 4
 	cfg.SaveToDisk(relayNode.GetDataDir())
 
 	fixture.Start()
+	defer fixture.LibGoalFixture.Shutdown()
 
 	client1 := fixture.GetLibGoalClientFromNodeController(primaryNode)
 	client2 := fixture.GetLibGoalClientFromNodeController(secondNode)

--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -400,7 +400,7 @@ func TestCatchpointLabelGeneration(t *testing.T) {
 	}
 }
 
-func TestNodeTxSyncRestart(t *testing.T) {
+func TestNodeTxHandlerRestart(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	defer fixtures.ShutdownSynchronizedTest(t)
 
@@ -412,10 +412,8 @@ func TestNodeTxSyncRestart(t *testing.T) {
 	// Start a two-node and one relay network
 	// Wait until a catchpoint is created
 	// Let the primary node have the majority of the stake
-	// Stop the primary node to miss the next transaction
 	// Send a transaction from the second node
-	// Start the primary node, and immediately after start the catchup
-	// The transaction will be confirmed only when the TxSync of the pools passes the transaction to the primary node
+	// The transaction will be confirmed only if the txHandler gets the transaction
 
 	consensus := make(config.ConsensusProtocols)
 	protoVersion := protocol.ConsensusCurrentVersion
@@ -459,15 +457,14 @@ func TestNodeTxSyncRestart(t *testing.T) {
 	cfg.MaxAcctLookback = 2
 	cfg.Archival = false
 
-	// Shorten the txn sync interval so the test can run faster
-	cfg.TxSyncIntervalSeconds = 4
+	cfg.TxSyncIntervalSeconds = 200000 // disable txSync
 
 	cfg.SaveToDisk(primaryNode.GetDataDir())
 	cfg.SaveToDisk(secondNode.GetDataDir())
 
 	cfg, err = config.LoadConfigFromDisk(relayNode.GetDataDir())
 	a.NoError(err)
-	cfg.TxSyncIntervalSeconds = 4
+	cfg.TxSyncIntervalSeconds = 200000 // disable txSync
 	cfg.SaveToDisk(relayNode.GetDataDir())
 
 	fixture.Start()
@@ -517,174 +514,20 @@ outer:
 		}
 	}
 
-	// stop the primary node
-	client1.FullStop()
-
-	// let the 2nd client send a transaction
-	tx, err = client2.SendPaymentFromUnencryptedWallet(addrs2[0], addrs1[0], 1000, 50000, nil)
-	a.NoError(err)
-
-	// now that the primary missed the transaction, start it, and let it catchup
-	_, err = fixture.StartNode(primaryNode.GetDataDir())
-	a.NoError(err)
 	// let the primary node catchup
 	err = client1.Catchup(*status.LastCatchpoint)
 	a.NoError(err)
 
-	// the transaction should not be confirmed yet
-	_, err = fixture.WaitForConfirmedTxn(0, addrs2[0], tx.ID().String())
-	a.Error(err)
-
-	// Wait for the catchup
-	for t := 0; t < 10; t++ {
-		status1, err := client1.Status()
-		a.NoError(err)
-		status2, err := client2.Status()
-		a.NoError(err)
-
-		if status1.LastRound+1 >= status2.LastRound {
-			// if the primary node is within 1 round of the secondary node, then it has
-			// caught up
-			break
-		}
-		time.Sleep(catchpointCatchupProtocol.AgreementFilterTimeout)
-	}
-
-	status, err = client2.Status()
+	status1, err := client1.Status()
 	a.NoError(err)
-	_, err = fixture.WaitForConfirmedTxn(status.LastRound+50, addrs2[0], tx.ID().String())
-	a.NoError(err)
-}
-
-func TestNodeTxHandlerRestart(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	defer fixtures.ShutdownSynchronizedTest(t)
-
-	if testing.Short() {
-		t.Skip()
-	}
-	a := require.New(fixtures.SynchronizedTest(t))
-	// Overview of this test:
-	// Start a two-node and one relay network
-	// Wait until a catchpoint is created
-	// Let the primary node have the majority of the stake
-	// Stop the primary node to miss the next transaction
-	// Send a transaction from the second node
-	// Start the primary node, and immediately after start the catchup
-	// The transaction will be confirmed only when the TxSync of the pools passes the transaction to the primary node
-
-	consensus := make(config.ConsensusProtocols)
-	protoVersion := protocol.ConsensusCurrentVersion
-	catchpointCatchupProtocol := config.Consensus[protoVersion]
-	catchpointCatchupProtocol.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
-	// MaxBalLookback  =  2 x SeedRefreshInterval x SeedLookback
-	// ref. https://github.com/algorandfoundation/specs/blob/master/dev/abft.md
-	catchpointCatchupProtocol.SeedLookback = 2
-	catchpointCatchupProtocol.SeedRefreshInterval = 2
-	catchpointCatchupProtocol.MaxBalLookback = 2 * catchpointCatchupProtocol.SeedLookback * catchpointCatchupProtocol.SeedRefreshInterval // 8
-	catchpointCatchupProtocol.CatchpointLookback = catchpointCatchupProtocol.MaxBalLookback
-	catchpointCatchupProtocol.EnableOnlineAccountCatchpoints = true
-	catchpointCatchupProtocol.StateProofInterval = 0
-	if runtime.GOOS == "darwin" || runtime.GOARCH == "amd64" {
-		// amd64/macos platforms are generally quite capable, so accelerate the round times to make the test run faster.
-		catchpointCatchupProtocol.AgreementFilterTimeoutPeriod0 = 1 * time.Second
-		catchpointCatchupProtocol.AgreementFilterTimeout = 1 * time.Second
-	}
-	consensus[protoVersion] = catchpointCatchupProtocol
-
-	var fixture fixtures.RestClientFixture
-	fixture.SetConsensus(consensus)
-	fixture.SetupNoStart(t, filepath.Join("nettemplates", "TwoNodes50EachWithRelay.json"))
-
-	// Get primary node
-	primaryNode, err := fixture.GetNodeController("Node1")
-	a.NoError(err)
-	// Get secondary node
-	secondNode, err := fixture.GetNodeController("Node2")
-	a.NoError(err)
-	// Get the relay
-	relayNode, err := fixture.GetNodeController("Relay")
-	a.NoError(err)
-
-	// prepare it's configuration file to set it to generate a catchpoint every 4 rounds.
-	cfg, err := config.LoadConfigFromDisk(primaryNode.GetDataDir())
-	a.NoError(err)
-	const catchpointInterval = 16
-	cfg.CatchpointInterval = catchpointInterval
-	cfg.CatchpointTracking = 2
-	cfg.MaxAcctLookback = 2
-	cfg.Archival = false
-
-	cfg.TxSyncIntervalSeconds = 200000 // disable txSync
-
-	cfg.SaveToDisk(primaryNode.GetDataDir())
-	cfg.SaveToDisk(secondNode.GetDataDir())
-
-	cfg, err = config.LoadConfigFromDisk(relayNode.GetDataDir())
-	a.NoError(err)
-	cfg.TxSyncIntervalSeconds = 200000 // disable txSync
-	cfg.SaveToDisk(relayNode.GetDataDir())
-
-	fixture.Start()
-
-	client1 := fixture.GetLibGoalClientFromNodeController(primaryNode)
-	client2 := fixture.GetLibGoalClientFromNodeController(secondNode)
-	wallet1, err := client1.GetUnencryptedWalletHandle()
-	a.NoError(err)
-	wallet2, err := client2.GetUnencryptedWalletHandle()
-	a.NoError(err)
-	addrs1, err := client1.ListAddresses(wallet1)
-	a.NoError(err)
-	addrs2, err := client2.ListAddresses(wallet2)
-	a.NoError(err)
-
-	// let the second node have insufficient stake for proposing a block
-	tx, err := client2.SendPaymentFromUnencryptedWallet(addrs2[0], addrs1[0], 1000, 4999999999000000, nil)
-	a.NoError(err)
-	status, err := client1.Status()
-	a.NoError(err)
-	_, err = fixture.WaitForConfirmedTxn(status.LastRound+100, addrs1[0], tx.ID().String())
-	a.NoError(err)
-	targetCatchpointRound := status.LastRound
-
-	// ensure the catchpoint is created for targetCatchpointRound
-	timer := time.NewTimer(100 * time.Second)
-outer:
-	for {
-		status, err = client1.Status()
-		a.NoError(err)
-
-		var round basics.Round
-		if status.LastCatchpoint != nil && len(*status.LastCatchpoint) > 0 {
-			round, _, err = ledgercore.ParseCatchpointLabel(*status.LastCatchpoint)
-			a.NoError(err)
-			if uint64(round) >= targetCatchpointRound {
-				break
-			}
-		}
-		select {
-		case <-timer.C:
-			a.Failf("timeout waiting a catchpoint", "target: %d, got %d", targetCatchpointRound, round)
-			break outer
-		default:
-			time.Sleep(250 * time.Millisecond)
-		}
-	}
-
-	// let the primary node catchup
-	err = client1.Catchup(*status.LastCatchpoint)
-	a.NoError(err)
+	targetRound := status1.LastRound + 5
 
 	// Wait for the network to start making progress again
 	for t := 0; t < 10; t++ {
-		status1, err := client1.Status()
-		a.NoError(err)
-		status2, err := client2.Status()
+		status1, err = client1.Status()
 		a.NoError(err)
 
-		if status1.LastRound+1 >= status2.LastRound {
-			// if the primary node is within 1 round of the secondary node, then it has
-			// caught up
+		if status1.LastRound+1 > targetRound {
 			break
 		}
 		time.Sleep(catchpointCatchupProtocol.AgreementFilterTimeout)


### PR DESCRIPTION
The txHandler and txSyncer are stopped when catching up from a catchpoint, and start again afterwards.

But they never really start. The main loop of these services rely on a context to stop. That context is canceled when stopping. Then, when the services are started again, the contexts remain canceled, which leads for the service to immediately end.

The fix is to create a new context when starting these services.

This PR fixes the txHandler part of https://github.com/algorand/go-algorand/issues/4775