### PR TITLE
ledger: move catchpoint sql code into storage package

### DIFF
--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -3173,43 +3173,45 @@ func TestUnfinishedCatchpointsTable(t *testing.T) {
 	dbs, _ := dbOpenTest(t, true)
 	defer dbs.Close()
 
+	cts := store.NewCatchpointSQLReaderWriter(dbs.Wdb.Handle)
+
 	err := accountsCreateUnfinishedCatchpointsTable(
 		context.Background(), dbs.Wdb.Handle)
 	require.NoError(t, err)
 
 	var d3 crypto.Digest
 	rand.Read(d3[:])
-	err = insertUnfinishedCatchpoint(context.Background(), dbs.Wdb.Handle, 3, d3)
+	err = cts.InsertUnfinishedCatchpoint(context.Background(), 3, d3)
 	require.NoError(t, err)
 
 	var d5 crypto.Digest
 	rand.Read(d5[:])
-	err = insertUnfinishedCatchpoint(context.Background(), dbs.Wdb.Handle, 5, d5)
+	err = cts.InsertUnfinishedCatchpoint(context.Background(), 5, d5)
 	require.NoError(t, err)
 
-	ret, err := selectUnfinishedCatchpoints(context.Background(), dbs.Rdb.Handle)
+	ret, err := cts.SelectUnfinishedCatchpoints(context.Background())
 	require.NoError(t, err)
-	expected := []unfinishedCatchpointRecord{
+	expected := []store.UnfinishedCatchpointRecord{
 		{
-			round:     3,
-			blockHash: d3,
+			Round:     3,
+			BlockHash: d3,
 		},
 		{
-			round:     5,
-			blockHash: d5,
+			Round:     5,
+			BlockHash: d5,
 		},
 	}
 	require.Equal(t, expected, ret)
 
-	err = deleteUnfinishedCatchpoint(context.Background(), dbs.Wdb.Handle, 3)
+	err = cts.DeleteUnfinishedCatchpoint(context.Background(), 3)
 	require.NoError(t, err)
 
-	ret, err = selectUnfinishedCatchpoints(context.Background(), dbs.Rdb.Handle)
+	ret, err = cts.SelectUnfinishedCatchpoints(context.Background())
 	require.NoError(t, err)
-	expected = []unfinishedCatchpointRecord{
+	expected = []store.UnfinishedCatchpointRecord{
 		{
-			round:     5,
-			blockHash: d5,
+			Round:     5,
+			BlockHash: d5,
 		},
 	}
 	require.Equal(t, expected, ret)

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -97,6 +97,11 @@ func catchpointStage1Decoder(r io.Reader) (io.ReadCloser, error) {
 	return snappyReadCloser{snappy.NewReader(r)}, nil
 }
 
+type catchpointStore interface {
+	store.CatchpointWriter
+	store.CatchpointReader
+}
+
 type catchpointTracker struct {
 	// dbDirectory is the directory where the ledger and block sql file resides as well as the parent directory for the catchup files to be generated
 	dbDirectory string
@@ -118,7 +123,8 @@ type catchpointTracker struct {
 	log logging.Logger
 
 	// Connection to the database.
-	dbs db.Pair
+	dbs             db.Pair
+	catchpointStore catchpointStore
 
 	// The last catchpoint label that was written to the database. Should always align with what's in the database.
 	// note that this is the last catchpoint *label* and not the catchpoint file.
@@ -231,13 +237,14 @@ func (ct *catchpointTracker) finishFirstStage(ctx context.Context, dbRound basic
 	}
 
 	f := func(ctx context.Context, tx *sql.Tx) error {
+		cps := store.NewCatchpointSQLReaderWriter(tx)
 		err := ct.recordFirstStageInfo(ctx, tx, dbRound, totalKVs, totalAccounts, totalChunks, biggestChunkLen)
 		if err != nil {
 			return err
 		}
 
 		// Clear the db record.
-		return writeCatchpointStateUint64(ctx, tx, catchpointStateWritingFirstStageInfo, 0)
+		return cps.WriteCatchpointStateUint64(ctx, catchpointStateWritingFirstStageInfo, 0)
 	}
 	return ct.dbs.Wdb.Atomic(f)
 }
@@ -245,8 +252,8 @@ func (ct *catchpointTracker) finishFirstStage(ctx context.Context, dbRound basic
 // Possibly finish generating first stage catchpoint db record and data file after
 // a crash.
 func (ct *catchpointTracker) finishFirstStageAfterCrash(dbRound basics.Round) error {
-	v, err := readCatchpointStateUint64(
-		context.Background(), ct.dbs.Rdb.Handle, catchpointStateWritingFirstStageInfo)
+	v, err := ct.catchpointStore.ReadCatchpointStateUint64(
+		context.Background(), catchpointStateWritingFirstStageInfo)
 	if err != nil {
 		return err
 	}
@@ -267,7 +274,7 @@ func (ct *catchpointTracker) finishFirstStageAfterCrash(dbRound basics.Round) er
 }
 
 func (ct *catchpointTracker) finishCatchpointsAfterCrash(catchpointLookback uint64) error {
-	records, err := selectUnfinishedCatchpoints(context.Background(), ct.dbs.Rdb.Handle)
+	records, err := ct.catchpointStore.SelectUnfinishedCatchpoints(context.Background())
 	if err != nil {
 		return err
 	}
@@ -276,14 +283,14 @@ func (ct *catchpointTracker) finishCatchpointsAfterCrash(catchpointLookback uint
 		// First, delete the unfinished catchpoint file.
 		relCatchpointFilePath := filepath.Join(
 			CatchpointDirName,
-			makeCatchpointFilePath(basics.Round(record.round)))
+			makeCatchpointFilePath(basics.Round(record.Round)))
 		err = removeSingleCatchpointFileFromDisk(ct.dbDirectory, relCatchpointFilePath)
 		if err != nil {
 			return err
 		}
 
 		err = ct.finishCatchpoint(
-			context.Background(), record.round, record.blockHash, catchpointLookback)
+			context.Background(), record.Round, record.BlockHash, catchpointLookback)
 		if err != nil {
 			return err
 		}
@@ -300,8 +307,8 @@ func (ct *catchpointTracker) recoverFromCrash(dbRound basics.Round) error {
 
 	ctx := context.Background()
 
-	catchpointLookback, err := readCatchpointStateUint64(
-		ctx, ct.dbs.Rdb.Handle, catchpointStateCatchpointLookback)
+	catchpointLookback, err := ct.catchpointStore.ReadCatchpointStateUint64(
+		ctx, catchpointStateCatchpointLookback)
 	if err != nil {
 		return err
 	}
@@ -332,6 +339,7 @@ func (ct *catchpointTracker) recoverFromCrash(dbRound basics.Round) error {
 func (ct *catchpointTracker) loadFromDisk(l ledgerForTracker, dbRound basics.Round) (err error) {
 	ct.log = l.trackerLog()
 	ct.dbs = l.trackerDB()
+	ct.catchpointStore = store.NewCatchpointSQLReaderWriter(l.trackerDB().Wdb.Handle)
 
 	ct.roundDigest = nil
 	ct.catchpointDataWriting = 0
@@ -351,8 +359,8 @@ func (ct *catchpointTracker) loadFromDisk(l ledgerForTracker, dbRound basics.Rou
 		return
 	}
 
-	ct.lastCatchpointLabel, err = readCatchpointStateString(
-		context.Background(), ct.dbs.Rdb.Handle, catchpointStateLastCatchpoint)
+	ct.lastCatchpointLabel, err = ct.catchpointStore.ReadCatchpointStateString(
+		context.Background(), catchpointStateLastCatchpoint)
 	if err != nil {
 		return
 	}
@@ -509,6 +517,8 @@ func (ct *catchpointTracker) commitRound(ctx context.Context, tx *sql.Tx, dcc *d
 		}
 	}()
 
+	cps := store.NewCatchpointSQLReaderWriter(tx)
+
 	if ct.catchpointEnabled() {
 		var mc *MerkleCommitter
 		mc, err = MakeMerkleCommitter(tx, false)
@@ -550,21 +560,19 @@ func (ct *catchpointTracker) commitRound(ctx context.Context, tx *sql.Tx, dcc *d
 	}
 
 	if dcc.catchpointFirstStage {
-		err = writeCatchpointStateUint64(ctx, tx, catchpointStateWritingFirstStageInfo, 1)
+		err = cps.WriteCatchpointStateUint64(ctx, catchpointStateWritingFirstStageInfo, 1)
 		if err != nil {
 			return err
 		}
 	}
 
-	err = writeCatchpointStateUint64(
-		ctx, tx, catchpointStateCatchpointLookback, dcc.catchpointLookback)
+	err = cps.WriteCatchpointStateUint64(ctx, catchpointStateCatchpointLookback, dcc.catchpointLookback)
 	if err != nil {
 		return err
 	}
 
 	for _, round := range ct.calculateCatchpointRounds(dcc) {
-		err = insertUnfinishedCatchpoint(
-			ctx, tx, round, dcc.committedRoundDigests[round-dcc.oldBase-1])
+		err = cps.InsertUnfinishedCatchpoint(ctx, round, dcc.committedRoundDigests[round-dcc.oldBase-1])
 		if err != nil {
 			return err
 		}
@@ -729,8 +737,8 @@ func (ct *catchpointTracker) createCatchpoint(ctx context.Context, accountsRound
 		"creating catchpoint round: %d accountsRound: %d label: %s",
 		round, accountsRound, label)
 
-	err := writeCatchpointStateString(
-		ctx, ct.dbs.Wdb.Handle, catchpointStateLastCatchpoint, label)
+	err := ct.catchpointStore.WriteCatchpointStateString(
+		ctx, catchpointStateLastCatchpoint, label)
 	if err != nil {
 		return err
 	}
@@ -789,11 +797,12 @@ func (ct *catchpointTracker) createCatchpoint(ctx context.Context, accountsRound
 	}
 
 	err = ct.dbs.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
+		cps := store.NewCatchpointSQLReaderWriter(tx)
 		err = ct.recordCatchpointFile(ctx, tx, round, relCatchpointFilePath, fileInfo.Size())
 		if err != nil {
 			return err
 		}
-		return deleteUnfinishedCatchpoint(ctx, tx, round)
+		return cps.DeleteUnfinishedCatchpoint(ctx, round)
 	})
 	if err != nil {
 		return err
@@ -824,7 +833,7 @@ func (ct *catchpointTracker) finishCatchpoint(ctx context.Context, round basics.
 	}
 
 	if !exists {
-		return deleteUnfinishedCatchpoint(ctx, ct.dbs.Wdb.Handle, round)
+		return ct.catchpointStore.DeleteUnfinishedCatchpoint(ctx, round)
 	}
 	return ct.createCatchpoint(ctx, accountsRound, round, dataInfo, blockHash)
 }
@@ -1236,7 +1245,7 @@ func makeCatchpointFilePath(round basics.Round) string {
 // database and storage realign.
 func (ct *catchpointTracker) recordCatchpointFile(ctx context.Context, e db.Executable, round basics.Round, relCatchpointFilePath string, fileSize int64) (err error) {
 	if ct.catchpointFileHistoryLength != 0 {
-		err = storeCatchpoint(ctx, e, round, relCatchpointFilePath, "", fileSize)
+		err = ct.catchpointStore.StoreCatchpoint(ctx, round, relCatchpointFilePath, "", fileSize)
 		if err != nil {
 			ct.log.Warnf("catchpointTracker.recordCatchpointFile() unable to save catchpoint: %v", err)
 			return
@@ -1251,8 +1260,11 @@ func (ct *catchpointTracker) recordCatchpointFile(ctx context.Context, e db.Exec
 	if ct.catchpointFileHistoryLength == -1 {
 		return
 	}
+
+	cps := store.NewCatchpointSQLReaderWriter(e)
+
 	var filesToDelete map[basics.Round]string
-	filesToDelete, err = getOldestCatchpointFiles(ctx, e, 2, ct.catchpointFileHistoryLength)
+	filesToDelete, err = cps.GetOldestCatchpointFiles(ctx, 2, ct.catchpointFileHistoryLength)
 	if err != nil {
 		return fmt.Errorf("unable to delete catchpoint file, getOldestCatchpointFiles failed : %v", err)
 	}
@@ -1261,7 +1273,7 @@ func (ct *catchpointTracker) recordCatchpointFile(ctx context.Context, e db.Exec
 		if err != nil {
 			return err
 		}
-		err = storeCatchpoint(ctx, e, round, "", "", 0)
+		err = cps.StoreCatchpoint(ctx, round, "", "", 0)
 		if err != nil {
 			return fmt.Errorf("unable to delete old catchpoint entry '%s' : %v", fileToDelete, err)
 		}
@@ -1275,8 +1287,10 @@ func (ct *catchpointTracker) GetCatchpointStream(round basics.Round) (ReadCloseS
 	fileSize := int64(0)
 	start := time.Now()
 	ledgerGetcatchpointCount.Inc(nil)
+	// TODO: we need to generalize this, check @cce PoC PR, he has something
+	//       somewhat broken for some KVs..
 	err := ct.dbs.Rdb.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
-		dbFileName, _, fileSize, err = getCatchpoint(ctx, tx, round)
+		dbFileName, _, fileSize, err = ct.catchpointStore.GetCatchpoint(ctx, round)
 		return
 	})
 	ledgerGetcatchpointMicros.AddMicrosecondsSince(start, nil)
@@ -1334,9 +1348,10 @@ func (ct *catchpointTracker) GetCatchpointStream(round basics.Round) (ReadCloseS
 // deleteStoredCatchpoints iterates over the storedcatchpoints table and deletes all the files stored on disk.
 // once all the files have been deleted, it would go ahead and remove the entries from the table.
 func deleteStoredCatchpoints(ctx context.Context, e db.Executable, dbDirectory string) (err error) {
+	cps := store.NewCatchpointSQLReaderWriter(e)
 	catchpointsFilesChunkSize := 50
 	for {
-		fileNames, err := getOldestCatchpointFiles(ctx, e, catchpointsFilesChunkSize, 0)
+		fileNames, err := cps.GetOldestCatchpointFiles(ctx, catchpointsFilesChunkSize, 0)
 		if err != nil {
 			return err
 		}
@@ -1350,7 +1365,7 @@ func deleteStoredCatchpoints(ctx context.Context, e db.Executable, dbDirectory s
 				return err
 			}
 			// clear the entry from the database
-			err = storeCatchpoint(ctx, e, round, "", "", 0)
+			err = cps.StoreCatchpoint(ctx, round, "", "", 0)
 			if err != nil {
 				return err
 			}

--- a/ledger/catchupaccessor.go
+++ b/ledger/catchupaccessor.go
@@ -32,6 +32,7 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
+	"github.com/algorand/go-algorand/ledger/store"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/util/db"
@@ -134,7 +135,8 @@ func (w *stagingWriterImpl) isShared() bool {
 
 // catchpointCatchupAccessorImpl is the concrete implementation of the CatchpointCatchupAccessor interface
 type catchpointCatchupAccessorImpl struct {
-	ledger *Ledger
+	ledger          *Ledger
+	catchpointStore catchpointStore
 
 	stagingWriter stagingWriter
 
@@ -179,16 +181,17 @@ type CatchupAccessorClientLedger interface {
 // MakeCatchpointCatchupAccessor creates a CatchpointCatchupAccessor given a ledger
 func MakeCatchpointCatchupAccessor(ledger *Ledger, log logging.Logger) CatchpointCatchupAccessor {
 	return &catchpointCatchupAccessorImpl{
-		ledger:        ledger,
-		stagingWriter: &stagingWriterImpl{wdb: ledger.trackerDB().Wdb},
-		log:           log,
+		ledger:          ledger,
+		catchpointStore: store.NewCatchpointSQLReaderWriter(ledger.trackerDB().Wdb.Handle),
+		stagingWriter:   &stagingWriterImpl{wdb: ledger.trackerDB().Wdb},
+		log:             log,
 	}
 }
 
 // GetState returns the current state of the catchpoint catchup
 func (c *catchpointCatchupAccessorImpl) GetState(ctx context.Context) (state CatchpointCatchupState, err error) {
 	var istate uint64
-	istate, err = readCatchpointStateUint64(ctx, c.ledger.trackerDB().Rdb.Handle, catchpointStateCatchupState)
+	istate, err = c.catchpointStore.ReadCatchpointStateUint64(ctx, catchpointStateCatchupState)
 	if err != nil {
 		return 0, fmt.Errorf("unable to read catchpoint catchup state '%s': %v", catchpointStateCatchupState, err)
 	}
@@ -201,7 +204,7 @@ func (c *catchpointCatchupAccessorImpl) SetState(ctx context.Context, state Catc
 	if state < CatchpointCatchupStateInactive || state > catchpointCatchupStateLast {
 		return fmt.Errorf("invalid catchpoint catchup state provided : %d", state)
 	}
-	err = writeCatchpointStateUint64(ctx, c.ledger.trackerDB().Wdb.Handle, catchpointStateCatchupState, uint64(state))
+	err = c.catchpointStore.WriteCatchpointStateUint64(ctx, catchpointStateCatchupState, uint64(state))
 	if err != nil {
 		return fmt.Errorf("unable to write catchpoint catchup state '%s': %v", catchpointStateCatchupState, err)
 	}
@@ -210,7 +213,7 @@ func (c *catchpointCatchupAccessorImpl) SetState(ctx context.Context, state Catc
 
 // GetLabel returns the current catchpoint catchup label
 func (c *catchpointCatchupAccessorImpl) GetLabel(ctx context.Context) (label string, err error) {
-	label, err = readCatchpointStateString(ctx, c.ledger.trackerDB().Rdb.Handle, catchpointStateCatchupLabel)
+	label, err = c.catchpointStore.ReadCatchpointStateString(ctx, catchpointStateCatchupLabel)
 	if err != nil {
 		return "", fmt.Errorf("unable to read catchpoint catchup state '%s': %v", catchpointStateCatchupLabel, err)
 	}
@@ -224,7 +227,7 @@ func (c *catchpointCatchupAccessorImpl) SetLabel(ctx context.Context, label stri
 	if err != nil {
 		return
 	}
-	err = writeCatchpointStateString(ctx, c.ledger.trackerDB().Wdb.Handle, catchpointStateCatchupLabel, label)
+	err = c.catchpointStore.WriteCatchpointStateString(ctx, catchpointStateCatchupLabel, label)
 	if err != nil {
 		return fmt.Errorf("unable to write catchpoint catchup state '%s': %v", catchpointStateCatchupLabel, err)
 	}
@@ -240,26 +243,27 @@ func (c *catchpointCatchupAccessorImpl) ResetStagingBalances(ctx context.Context
 	start := time.Now()
 	ledgerResetstagingbalancesCount.Inc(nil)
 	err = wdb.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
+		cps := store.NewCatchpointSQLReaderWriter(tx)
 		err = resetCatchpointStagingBalances(ctx, tx, newCatchup)
 		if err != nil {
 			return fmt.Errorf("unable to reset catchpoint catchup balances : %v", err)
 		}
 		if !newCatchup {
-			err = writeCatchpointStateUint64(ctx, tx, catchpointStateCatchupBalancesRound, 0)
+			err = cps.WriteCatchpointStateUint64(ctx, catchpointStateCatchupBalancesRound, 0)
 			if err != nil {
 				return err
 			}
 
-			err = writeCatchpointStateUint64(ctx, tx, catchpointStateCatchupBlockRound, 0)
+			err = cps.WriteCatchpointStateUint64(ctx, catchpointStateCatchupBlockRound, 0)
 			if err != nil {
 				return err
 			}
 
-			err = writeCatchpointStateString(ctx, tx, catchpointStateCatchupLabel, "")
+			err = cps.WriteCatchpointStateString(ctx, catchpointStateCatchupLabel, "")
 			if err != nil {
 				return err
 			}
-			err = writeCatchpointStateUint64(ctx, tx, catchpointStateCatchupState, 0)
+			err = cps.WriteCatchpointStateUint64(ctx, catchpointStateCatchupState, 0)
 			if err != nil {
 				return fmt.Errorf("unable to write catchpoint catchup state '%s': %v", catchpointStateCatchupState, err)
 			}
@@ -329,12 +333,13 @@ func (c *catchpointCatchupAccessorImpl) processStagingContent(ctx context.Contex
 	start := time.Now()
 	ledgerProcessstagingcontentCount.Inc(nil)
 	err = wdb.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
-		err = writeCatchpointStateUint64(ctx, tx, catchpointStateCatchupBlockRound, uint64(fileHeader.BlocksRound))
+		cps := store.NewCatchpointSQLReaderWriter(tx)
+		err = cps.WriteCatchpointStateUint64(ctx, catchpointStateCatchupBlockRound, uint64(fileHeader.BlocksRound))
 		if err != nil {
 			return fmt.Errorf("CatchpointCatchupAccessorImpl::processStagingContent: unable to write catchpoint catchup state '%s': %v", catchpointStateCatchupBlockRound, err)
 		}
 		if fileHeader.Version == CatchpointFileVersionV6 {
-			err = writeCatchpointStateUint64(ctx, tx, catchpointStateCatchupHashRound, uint64(fileHeader.BlocksRound))
+			err = cps.WriteCatchpointStateUint64(ctx, catchpointStateCatchupHashRound, uint64(fileHeader.BlocksRound))
 			if err != nil {
 				return fmt.Errorf("CatchpointCatchupAccessorImpl::processStagingContent: unable to write catchpoint catchup state '%s': %v", catchpointStateCatchupHashRound, err)
 			}
@@ -794,7 +799,7 @@ func (c *catchpointCatchupAccessorImpl) BuildMerkleTrie(ctx context.Context, pro
 // GetCatchupBlockRound returns the latest block round matching the current catchpoint
 func (c *catchpointCatchupAccessorImpl) GetCatchupBlockRound(ctx context.Context) (round basics.Round, err error) {
 	var iRound uint64
-	iRound, err = readCatchpointStateUint64(ctx, c.ledger.trackerDB().Rdb.Handle, catchpointStateCatchupBlockRound)
+	iRound, err = c.catchpointStore.ReadCatchpointStateUint64(ctx, catchpointStateCatchupBlockRound)
 	if err != nil {
 		return 0, fmt.Errorf("unable to read catchpoint catchup state '%s': %v", catchpointStateCatchupBlockRound, err)
 	}
@@ -809,13 +814,13 @@ func (c *catchpointCatchupAccessorImpl) VerifyCatchpoint(ctx context.Context, bl
 	var totals ledgercore.AccountTotals
 	var catchpointLabel string
 
-	catchpointLabel, err = readCatchpointStateString(ctx, rdb.Handle, catchpointStateCatchupLabel)
+	catchpointLabel, err = c.catchpointStore.ReadCatchpointStateString(ctx, catchpointStateCatchupLabel)
 	if err != nil {
 		return fmt.Errorf("unable to read catchpoint catchup state '%s': %v", catchpointStateCatchupLabel, err)
 	}
 
 	var iRound uint64
-	iRound, err = readCatchpointStateUint64(ctx, rdb.Handle, catchpointStateCatchupBlockRound)
+	iRound, err = c.catchpointStore.ReadCatchpointStateUint64(ctx, catchpointStateCatchupBlockRound)
 	if err != nil {
 		return fmt.Errorf("unable to read catchpoint catchup state '%s': %v", catchpointStateCatchupBlockRound, err)
 	}
@@ -876,7 +881,8 @@ func (c *catchpointCatchupAccessorImpl) StoreBalancesRound(ctx context.Context, 
 	start := time.Now()
 	ledgerStorebalancesroundCount.Inc(nil)
 	err = wdb.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
-		err = writeCatchpointStateUint64(ctx, tx, catchpointStateCatchupBalancesRound, uint64(balancesRound))
+		cps := store.NewCatchpointSQLReaderWriter(tx)
+		err = cps.WriteCatchpointStateUint64(ctx, catchpointStateCatchupBalancesRound, uint64(balancesRound))
 		if err != nil {
 			return fmt.Errorf("CatchpointCatchupAccessorImpl::StoreBalancesRound: unable to write catchpoint catchup state '%s': %v", catchpointStateCatchupBalancesRound, err)
 		}
@@ -972,15 +978,17 @@ func (c *catchpointCatchupAccessorImpl) finishBalances(ctx context.Context) (err
 	start := time.Now()
 	ledgerCatchpointFinishBalsCount.Inc(nil)
 	err = wdb.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
+		cps := store.NewCatchpointSQLReaderWriter(tx)
+
 		var balancesRound, hashRound uint64
 		var totals ledgercore.AccountTotals
 
-		balancesRound, err = readCatchpointStateUint64(ctx, tx, catchpointStateCatchupBalancesRound)
+		balancesRound, err = cps.ReadCatchpointStateUint64(ctx, catchpointStateCatchupBalancesRound)
 		if err != nil {
 			return err
 		}
 
-		hashRound, err = readCatchpointStateUint64(ctx, tx, catchpointStateCatchupHashRound)
+		hashRound, err = cps.ReadCatchpointStateUint64(ctx, catchpointStateCatchupHashRound)
 		if err != nil {
 			return err
 		}
@@ -1038,29 +1046,29 @@ func (c *catchpointCatchupAccessorImpl) finishBalances(ctx context.Context) (err
 			return err
 		}
 
-		err = writeCatchpointStateUint64(ctx, tx, catchpointStateCatchupBalancesRound, 0)
+		err = cps.WriteCatchpointStateUint64(ctx, catchpointStateCatchupBalancesRound, 0)
 		if err != nil {
 			return err
 		}
 
-		err = writeCatchpointStateUint64(ctx, tx, catchpointStateCatchupBlockRound, 0)
+		err = cps.WriteCatchpointStateUint64(ctx, catchpointStateCatchupBlockRound, 0)
 		if err != nil {
 			return err
 		}
 
-		err = writeCatchpointStateString(ctx, tx, catchpointStateCatchupLabel, "")
+		err = cps.WriteCatchpointStateString(ctx, catchpointStateCatchupLabel, "")
 		if err != nil {
 			return err
 		}
 
 		if hashRound != 0 {
-			err = writeCatchpointStateUint64(ctx, tx, catchpointStateCatchupHashRound, 0)
+			err = cps.WriteCatchpointStateUint64(ctx, catchpointStateCatchupHashRound, 0)
 			if err != nil {
 				return err
 			}
 		}
 
-		err = writeCatchpointStateUint64(ctx, tx, catchpointStateCatchupState, 0)
+		err = cps.WriteCatchpointStateUint64(ctx, catchpointStateCatchupState, 0)
 		if err != nil {
 			return fmt.Errorf("unable to write catchpoint catchup state '%s': %v", catchpointStateCatchupState, err)
 		}

--- a/ledger/msgp_gen.go
+++ b/ledger/msgp_gen.go
@@ -52,14 +52,6 @@ import (
 //             |-----> (*) Msgsize
 //             |-----> (*) MsgIsZero
 //
-// catchpointState
-//        |-----> MarshalMsg
-//        |-----> CanMarshalMsg
-//        |-----> (*) UnmarshalMsg
-//        |-----> (*) CanUnmarshalMsg
-//        |-----> Msgsize
-//        |-----> MsgIsZero
-//
 // encodedBalanceRecordV5
 //            |-----> (*) MarshalMsg
 //            |-----> (*) CanMarshalMsg
@@ -1436,52 +1428,6 @@ func (z *catchpointFirstStageInfo) Msgsize() (s int) {
 // MsgIsZero returns whether this is a zero value
 func (z *catchpointFirstStageInfo) MsgIsZero() bool {
 	return ((*z).Totals.MsgIsZero()) && ((*z).TrieBalancesHash.MsgIsZero()) && ((*z).TotalAccounts == 0) && ((*z).TotalKVs == 0) && ((*z).TotalChunks == 0) && ((*z).BiggestChunkLen == 0)
-}
-
-// MarshalMsg implements msgp.Marshaler
-func (z catchpointState) MarshalMsg(b []byte) (o []byte) {
-	o = msgp.Require(b, z.Msgsize())
-	o = msgp.AppendString(o, string(z))
-	return
-}
-
-func (_ catchpointState) CanMarshalMsg(z interface{}) bool {
-	_, ok := (z).(catchpointState)
-	if !ok {
-		_, ok = (z).(*catchpointState)
-	}
-	return ok
-}
-
-// UnmarshalMsg implements msgp.Unmarshaler
-func (z *catchpointState) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	{
-		var zb0001 string
-		zb0001, bts, err = msgp.ReadStringBytes(bts)
-		if err != nil {
-			err = msgp.WrapError(err)
-			return
-		}
-		(*z) = catchpointState(zb0001)
-	}
-	o = bts
-	return
-}
-
-func (_ *catchpointState) CanUnmarshalMsg(z interface{}) bool {
-	_, ok := (z).(*catchpointState)
-	return ok
-}
-
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z catchpointState) Msgsize() (s int) {
-	s = msgp.StringPrefixSize + len(string(z))
-	return
-}
-
-// MsgIsZero returns whether this is a zero value
-func (z catchpointState) MsgIsZero() bool {
-	return z == ""
 }
 
 // MarshalMsg implements msgp.Marshaler

--- a/ledger/store/catchpoint.go
+++ b/ledger/store/catchpoint.go
@@ -26,6 +26,8 @@ import (
 )
 
 // CatchpointState is used to store catchpoint related variables into the catchpointstate table.
+//
+//msgp:ignore CatchpointState
 type CatchpointState string
 
 // UnfinishedCatchpointRecord represents a stored record of an unfinished catchpoint.

--- a/ledger/store/catchpoint.go
+++ b/ledger/store/catchpoint.go
@@ -1,0 +1,228 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package store
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/util/db"
+)
+
+// CatchpointState is used to store catchpoint related variables into the catchpointstate table.
+type CatchpointState string
+
+// UnfinishedCatchpointRecord represents a stored record of an unfinished catchpoint.
+type UnfinishedCatchpointRecord struct {
+	Round     basics.Round
+	BlockHash crypto.Digest
+}
+
+type catchpointReader struct {
+	q db.Queryable
+}
+
+type catchpointWriter struct {
+	e db.Executable
+}
+
+type catchpointReaderWriter struct {
+	catchpointReader
+	catchpointWriter
+}
+
+// NewCatchpointSQLReaderWriter creates a Catchpoint SQL reader+writer
+func NewCatchpointSQLReaderWriter(e db.Executable) *catchpointReaderWriter {
+	return &catchpointReaderWriter{
+		catchpointReader{q: e},
+		catchpointWriter{e: e},
+	}
+}
+
+func (cr *catchpointReader) GetCatchpoint(ctx context.Context, round basics.Round) (fileName string, catchpoint string, fileSize int64, err error) {
+	err = cr.q.QueryRowContext(ctx, "SELECT filename, catchpoint, filesize FROM storedcatchpoints WHERE round=?", int64(round)).Scan(&fileName, &catchpoint, &fileSize)
+	return
+}
+
+func (cr *catchpointReader) GetOldestCatchpointFiles(ctx context.Context, fileCount int, filesToKeep int) (fileNames map[basics.Round]string, err error) {
+	err = db.Retry(func() (err error) {
+		query := "SELECT round, filename FROM storedcatchpoints WHERE pinned = 0 and round <= COALESCE((SELECT round FROM storedcatchpoints WHERE pinned = 0 ORDER BY round DESC LIMIT ?, 1),0) ORDER BY round ASC LIMIT ?"
+		rows, err := cr.q.QueryContext(ctx, query, filesToKeep, fileCount)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		fileNames = make(map[basics.Round]string)
+		for rows.Next() {
+			var fileName string
+			var round basics.Round
+			err = rows.Scan(&round, &fileName)
+			if err != nil {
+				return err
+			}
+			fileNames[round] = fileName
+		}
+
+		return rows.Err()
+	})
+	if err != nil {
+		fileNames = nil
+	}
+	return
+}
+
+func (cr *catchpointReader) ReadCatchpointStateUint64(ctx context.Context, stateName CatchpointState) (val uint64, err error) {
+	err = db.Retry(func() (err error) {
+		query := "SELECT intval FROM catchpointstate WHERE id=?"
+		var v sql.NullInt64
+		err = cr.q.QueryRowContext(ctx, query, stateName).Scan(&v)
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if v.Valid {
+			val = uint64(v.Int64)
+		}
+		return nil
+	})
+	return val, err
+}
+
+func (cr *catchpointReader) ReadCatchpointStateString(ctx context.Context, stateName CatchpointState) (val string, err error) {
+	err = db.Retry(func() (err error) {
+		query := "SELECT strval FROM catchpointstate WHERE id=?"
+		var v sql.NullString
+		err = cr.q.QueryRowContext(ctx, query, stateName).Scan(&v)
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if v.Valid {
+			val = v.String
+		}
+		return nil
+	})
+	return val, err
+}
+
+func (cr *catchpointReader) SelectUnfinishedCatchpoints(ctx context.Context) ([]UnfinishedCatchpointRecord, error) {
+	var res []UnfinishedCatchpointRecord
+
+	f := func() error {
+		query := "SELECT round, blockhash FROM unfinishedcatchpoints ORDER BY round"
+		rows, err := cr.q.QueryContext(ctx, query)
+		if err != nil {
+			return err
+		}
+
+		// Clear `res` in case this function is repeated.
+		res = res[:0]
+		for rows.Next() {
+			var record UnfinishedCatchpointRecord
+			var blockHash []byte
+			err = rows.Scan(&record.Round, &blockHash)
+			if err != nil {
+				return err
+			}
+			copy(record.BlockHash[:], blockHash)
+			res = append(res, record)
+		}
+
+		return nil
+	}
+	err := db.Retry(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (cw *catchpointWriter) StoreCatchpoint(ctx context.Context, round basics.Round, fileName string, catchpoint string, fileSize int64) (err error) {
+	err = db.Retry(func() (err error) {
+		query := "DELETE FROM storedcatchpoints WHERE round=?"
+		_, err = cw.e.ExecContext(ctx, query, round)
+		if err != nil || (fileName == "" && catchpoint == "" && fileSize == 0) {
+			return err
+		}
+
+		query = "INSERT INTO storedcatchpoints(round, filename, catchpoint, filesize, pinned) VALUES(?, ?, ?, ?, 0)"
+		_, err = cw.e.ExecContext(ctx, query, round, fileName, catchpoint, fileSize)
+		return err
+	})
+	return
+}
+
+func (cw *catchpointWriter) WriteCatchpointStateUint64(ctx context.Context, stateName CatchpointState, setValue uint64) (err error) {
+	err = db.Retry(func() (err error) {
+		if setValue == 0 {
+			return deleteCatchpointStateImpl(ctx, cw.e, stateName)
+		}
+
+		// we don't know if there is an entry in the table for this state, so we'll insert/replace it just in case.
+		query := "INSERT OR REPLACE INTO catchpointstate(id, intval) VALUES(?, ?)"
+		_, err = cw.e.ExecContext(ctx, query, stateName, setValue)
+		return err
+	})
+	return err
+}
+
+func (cw *catchpointWriter) WriteCatchpointStateString(ctx context.Context, stateName CatchpointState, setValue string) (err error) {
+	err = db.Retry(func() (err error) {
+		if setValue == "" {
+			return deleteCatchpointStateImpl(ctx, cw.e, stateName)
+		}
+
+		// we don't know if there is an entry in the table for this state, so we'll insert/replace it just in case.
+		query := "INSERT OR REPLACE INTO catchpointstate(id, strval) VALUES(?, ?)"
+		_, err = cw.e.ExecContext(ctx, query, stateName, setValue)
+		return err
+	})
+	return err
+}
+
+func (cw *catchpointWriter) InsertUnfinishedCatchpoint(ctx context.Context, round basics.Round, blockHash crypto.Digest) error {
+	f := func() error {
+		query := "INSERT INTO unfinishedcatchpoints(round, blockhash) VALUES(?, ?)"
+		_, err := cw.e.ExecContext(ctx, query, round, blockHash[:])
+		return err
+	}
+	return db.Retry(f)
+}
+
+func (cw *catchpointWriter) DeleteUnfinishedCatchpoint(ctx context.Context, round basics.Round) error {
+	f := func() error {
+		query := "DELETE FROM unfinishedcatchpoints WHERE round = ?"
+		_, err := cw.e.ExecContext(ctx, query, round)
+		return err
+	}
+	return db.Retry(f)
+}
+
+func deleteCatchpointStateImpl(ctx context.Context, e db.Executable, stateName CatchpointState) error {
+	query := "DELETE FROM catchpointstate WHERE id=?"
+	_, err := e.ExecContext(ctx, query, stateName)
+	return err
+}

--- a/ledger/store/interface.go
+++ b/ledger/store/interface.go
@@ -16,7 +16,12 @@
 
 package store
 
-import "github.com/algorand/go-algorand/data/basics"
+import (
+	"context"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
+)
 
 // AccountsWriter is the write interface for:
 // - accounts, resources, app kvs, creatables
@@ -72,4 +77,28 @@ type OnlineAccountsReader interface {
 	LookupOnlineHistory(addr basics.Address) (result []PersistedOnlineAccountData, rnd basics.Round, err error)
 
 	Close()
+}
+
+// CatchpointWriter is the write interface for:
+// - catchpoints
+type CatchpointWriter interface {
+	StoreCatchpoint(ctx context.Context, round basics.Round, fileName string, catchpoint string, fileSize int64) (err error)
+
+	WriteCatchpointStateUint64(ctx context.Context, stateName CatchpointState, setValue uint64) (err error)
+	WriteCatchpointStateString(ctx context.Context, stateName CatchpointState, setValue string) (err error)
+
+	InsertUnfinishedCatchpoint(ctx context.Context, round basics.Round, blockHash crypto.Digest) error
+	DeleteUnfinishedCatchpoint(ctx context.Context, round basics.Round) error
+}
+
+// CatchpointReader is the read interface for:
+// - catchpoints
+type CatchpointReader interface {
+	GetCatchpoint(ctx context.Context, round basics.Round) (fileName string, catchpoint string, fileSize int64, err error)
+	GetOldestCatchpointFiles(ctx context.Context, fileCount int, filesToKeep int) (fileNames map[basics.Round]string, err error)
+
+	ReadCatchpointStateUint64(ctx context.Context, stateName CatchpointState) (val uint64, err error)
+	ReadCatchpointStateString(ctx context.Context, stateName CatchpointState) (val string, err error)
+
+	SelectUnfinishedCatchpoints(ctx context.Context) ([]UnfinishedCatchpointRecord, error)
 }

--- a/ledger/store/msgp_gen.go
+++ b/ledger/store/msgp_gen.go
@@ -33,6 +33,14 @@ import (
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
 //
+// CatchpointState
+//        |-----> MarshalMsg
+//        |-----> CanMarshalMsg
+//        |-----> (*) UnmarshalMsg
+//        |-----> (*) CanUnmarshalMsg
+//        |-----> Msgsize
+//        |-----> MsgIsZero
+//
 // ResourceFlags
 //       |-----> MarshalMsg
 //       |-----> CanMarshalMsg
@@ -1102,6 +1110,52 @@ func (z *BaseVotingData) Msgsize() (s int) {
 // MsgIsZero returns whether this is a zero value
 func (z *BaseVotingData) MsgIsZero() bool {
 	return ((*z).VoteID.MsgIsZero()) && ((*z).SelectionID.MsgIsZero()) && ((*z).VoteFirstValid.MsgIsZero()) && ((*z).VoteLastValid.MsgIsZero()) && ((*z).VoteKeyDilution == 0) && ((*z).StateProofID.MsgIsZero())
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z CatchpointState) MarshalMsg(b []byte) (o []byte) {
+	o = msgp.Require(b, z.Msgsize())
+	o = msgp.AppendString(o, string(z))
+	return
+}
+
+func (_ CatchpointState) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(CatchpointState)
+	if !ok {
+		_, ok = (z).(*CatchpointState)
+	}
+	return ok
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *CatchpointState) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	{
+		var zb0001 string
+		zb0001, bts, err = msgp.ReadStringBytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		(*z) = CatchpointState(zb0001)
+	}
+	o = bts
+	return
+}
+
+func (_ *CatchpointState) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*CatchpointState)
+	return ok
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z CatchpointState) Msgsize() (s int) {
+	s = msgp.StringPrefixSize + len(string(z))
+	return
+}
+
+// MsgIsZero returns whether this is a zero value
+func (z CatchpointState) MsgIsZero() bool {
+	return z == ""
 }
 
 // MarshalMsg implements msgp.Marshaler

--- a/ledger/store/msgp_gen.go
+++ b/ledger/store/msgp_gen.go
@@ -33,14 +33,6 @@ import (
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
 //
-// CatchpointState
-//        |-----> MarshalMsg
-//        |-----> CanMarshalMsg
-//        |-----> (*) UnmarshalMsg
-//        |-----> (*) CanUnmarshalMsg
-//        |-----> Msgsize
-//        |-----> MsgIsZero
-//
 // ResourceFlags
 //       |-----> MarshalMsg
 //       |-----> CanMarshalMsg
@@ -1110,52 +1102,6 @@ func (z *BaseVotingData) Msgsize() (s int) {
 // MsgIsZero returns whether this is a zero value
 func (z *BaseVotingData) MsgIsZero() bool {
 	return ((*z).VoteID.MsgIsZero()) && ((*z).SelectionID.MsgIsZero()) && ((*z).VoteFirstValid.MsgIsZero()) && ((*z).VoteLastValid.MsgIsZero()) && ((*z).VoteKeyDilution == 0) && ((*z).StateProofID.MsgIsZero())
-}
-
-// MarshalMsg implements msgp.Marshaler
-func (z CatchpointState) MarshalMsg(b []byte) (o []byte) {
-	o = msgp.Require(b, z.Msgsize())
-	o = msgp.AppendString(o, string(z))
-	return
-}
-
-func (_ CatchpointState) CanMarshalMsg(z interface{}) bool {
-	_, ok := (z).(CatchpointState)
-	if !ok {
-		_, ok = (z).(*CatchpointState)
-	}
-	return ok
-}
-
-// UnmarshalMsg implements msgp.Unmarshaler
-func (z *CatchpointState) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	{
-		var zb0001 string
-		zb0001, bts, err = msgp.ReadStringBytes(bts)
-		if err != nil {
-			err = msgp.WrapError(err)
-			return
-		}
-		(*z) = CatchpointState(zb0001)
-	}
-	o = bts
-	return
-}
-
-func (_ *CatchpointState) CanUnmarshalMsg(z interface{}) bool {
-	_, ok := (z).(*CatchpointState)
-	return ok
-}
-
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z CatchpointState) Msgsize() (s int) {
-	s = msgp.StringPrefixSize + len(string(z))
-	return
-}
-
-// MsgIsZero returns whether this is a zero value
-func (z CatchpointState) MsgIsZero() bool {
-	return z == ""
 }
 
 // MarshalMsg implements msgp.Marshaler


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Moving some of the catchpoint sql queries into the store package. 

**Previous parts of this refactor:**
- part 1 - #4776


<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Existing tests.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
