### PR TITLE
Tests:  Squelch macOS accept incoming network connections notifications

### DIFF
--- a/catchup/fetcher_test.go
+++ b/catchup/fetcher_test.go
@@ -148,7 +148,7 @@ func (b *basicRPCNode) RegisterHandlers(dispatch []network.TaggedMessageHandler)
 
 func (b *basicRPCNode) start() bool {
 	var err error
-	b.listener, err = net.Listen("tcp", "")
+	b.listener, err = net.Listen("tcp", "127.0.0.1:")
 	if err != nil {
 		logging.Base().Error("tcp listen", err)
 		return false

--- a/rpcs/txService_test.go
+++ b/rpcs/txService_test.go
@@ -91,7 +91,7 @@ func (b *basicRPCNode) RegisterHandlers(dispatch []network.TaggedMessageHandler)
 
 func (b *basicRPCNode) start() bool {
 	var err error
-	b.listener, err = net.Listen("tcp", "")
+	b.listener, err = net.Listen("tcp", "127.0.0.1:")
 	if err != nil {
 		logging.Base().Error("tcp listen", err)
 		return false

--- a/util/metrics/counter_test.go
+++ b/util/metrics/counter_test.go
@@ -39,7 +39,7 @@ func TestMetricCounter(t *testing.T) {
 	}
 
 	// create a http listener.
-	port := test.createListener(":0")
+	port := test.createListener("127.0.0.1:0")
 
 	metricService := MakeMetricService(&ServiceConfig{
 		NodeExporterListenAddress: fmt.Sprintf("localhost:%d", port),
@@ -85,7 +85,7 @@ func TestMetricCounterFastInts(t *testing.T) {
 	}
 
 	// create a http listener.
-	port := test.createListener(":0")
+	port := test.createListener("127.0.0.1:0")
 
 	metricService := MakeMetricService(&ServiceConfig{
 		NodeExporterListenAddress: fmt.Sprintf("localhost:%d", port),
@@ -132,7 +132,7 @@ func TestMetricCounterMixed(t *testing.T) {
 	}
 
 	// create a http listener.
-	port := test.createListener(":0")
+	port := test.createListener("127.0.0.1:0")
 
 	metricService := MakeMetricService(&ServiceConfig{
 		NodeExporterListenAddress: fmt.Sprintf("localhost:%d", port),

--- a/util/metrics/gauge_test.go
+++ b/util/metrics/gauge_test.go
@@ -38,7 +38,7 @@ func TestMetricGauge(t *testing.T) {
 		MetricTest: NewMetricTest(),
 	}
 	// create a http listener.
-	port := test.createListener(":0")
+	port := test.createListener("127.0.0.1:0")
 
 	metricService := MakeMetricService(&ServiceConfig{
 		NodeExporterListenAddress: fmt.Sprintf("localhost:%d", port),


### PR DESCRIPTION
Running unit tests on macOS results in several firewall-related accept/deny prompts asking:  _Do you want the application X to accept incoming network connections?_  The PR prevents these pop-ups by applying https://apple.stackexchange.com/a/405967 to affected tests.
