### PR TITLE
metrics: add TransactionGroupTxSyncHandled

### DIFF
--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -58,6 +58,7 @@ var transactionMessagesBacklogErr = metrics.MakeCounter(metrics.TransactionMessa
 var transactionMessagesRemember = metrics.MakeCounter(metrics.TransactionMessagesRemember)
 var transactionMessagesBacklogSizeGauge = metrics.MakeGauge(metrics.TransactionMessagesBacklogSize)
 
+var transactionGroupTxSyncHandled = metrics.MakeCounter(metrics.TransactionGroupTxSyncHandled)
 var transactionGroupTxSyncRemember = metrics.MakeCounter(metrics.TransactionGroupTxSyncRemember)
 var transactionGroupTxSyncAlreadyCommitted = metrics.MakeCounter(metrics.TransactionGroupTxSyncAlreadyCommitted)
 
@@ -350,6 +351,8 @@ func (handler *TxHandler) processDecoded(unverifiedTxGroup []transactions.Signed
 	tx := &txBacklogMsg{
 		unverifiedTxGroup: unverifiedTxGroup,
 	}
+	transactionGroupTxSyncHandled.Inc(nil)
+
 	if handler.checkAlreadyCommitted(tx) {
 		transactionGroupTxSyncAlreadyCommitted.Inc(nil)
 		return network.OutgoingMessage{}, true

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -112,7 +112,9 @@ var (
 	// TransactionMessagesBacklogSize "Number of transaction messages in the TX handler backlog queue"
 	TransactionMessagesBacklogSize = MetricName{Name: "algod_transaction_messages_backlog_size", Description: "Number of transaction messages in the TX handler backlog queue"}
 
-	// TransactionGroupTxSyncRemember "Number of transaction groups remembered via tx sync"
+	// TransactionGroupTxSyncHandled "Number of transaction groups handled via txsync"
+	TransactionGroupTxSyncHandled = MetricName{Name: "algod_transaction_group_txsync_handled", Description: "Number of transaction groups handled via txsync"}
+	// TransactionGroupTxSyncRemember "Number of transaction groups remembered via txsync"
 	TransactionGroupTxSyncRemember = MetricName{Name: "algod_transaction_group_txsync_remember", Description: "Number of transaction groups remembered via txsync"}
 	// TransactionGroupTxSyncAlreadyCommitted "Number of duplicate or error transaction groups received via txsync"
 	TransactionGroupTxSyncAlreadyCommitted = MetricName{Name: "algod_transaction_group_txsync_err_or_committed", Description: "Number of duplicate or error transaction groups received via txsync"}


### PR DESCRIPTION
## Summary

Follows #4786 by tallying the total handled TxSyncer messages, to better understand the Remember and AlreadyCommitted counters.
