### PR TITLE
Tests: Extend TestCatchpointAfterTxns to catch catchpoint write corruption

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -132,7 +132,7 @@ var createResourcesTable = []string{
 		PRIMARY KEY (addrid, aidx) ) WITHOUT ROWID`,
 }
 
-var kvStoreTable = []string{
+var createKVStoreTable = []string{
 	`CREATE TABLE IF NOT EXISTS kvstore (
 		key blob primary key,
 		value blob)`,
@@ -1421,7 +1421,7 @@ func accountsCreateBoxTable(ctx context.Context, tx *sql.Tx) error {
 	if err != sql.ErrNoRows {
 		return err
 	}
-	for _, stmt := range kvStoreTable {
+	for _, stmt := range createKVStoreTable {
 		_, err = tx.ExecContext(ctx, stmt)
 		if err != nil {
 			return err

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -132,7 +132,7 @@ var createResourcesTable = []string{
 		PRIMARY KEY (addrid, aidx) ) WITHOUT ROWID`,
 }
 
-var createBoxTable = []string{
+var kvStoreTable = []string{
 	`CREATE TABLE IF NOT EXISTS kvstore (
 		key blob primary key,
 		value blob)`,
@@ -1421,7 +1421,7 @@ func accountsCreateBoxTable(ctx context.Context, tx *sql.Tx) error {
 	if err != sql.ErrNoRows {
 		return err
 	}
-	for _, stmt := range createBoxTable {
+	for _, stmt := range kvStoreTable {
 		_, err = tx.ExecContext(ctx, stmt)
 		if err != nil {
 			return err

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -235,7 +235,7 @@ func testWriteCatchpoint(t *testing.T, rdb db.Accessor, datapath string, filepat
 		datapath, filepath)
 	require.NoError(t, err)
 
-	l := testNewLedgerFromCatchpoint(t, filepath, rdb)
+	l := testNewLedgerFromCatchpoint(t, rdb, filepath)
 	defer l.Close()
 
 	return catchpointFileHeader
@@ -442,7 +442,7 @@ func TestFullCatchpointWriterOverflowAccounts(t *testing.T) {
 	const maxResourcesPerChunk = 5
 	testWriteCatchpoint(t, ml.trackerDB().Rdb, catchpointDataFilePath, catchpointFilePath, maxResourcesPerChunk)
 
-	l := testNewLedgerFromCatchpoint(t, catchpointFilePath, ml.trackerDB().Rdb)
+	l := testNewLedgerFromCatchpoint(t, ml.trackerDB().Rdb, catchpointFilePath)
 	defer l.Close()
 
 	// verify that the account data aligns with what we originally stored :
@@ -515,7 +515,7 @@ func TestFullCatchpointWriterOverflowAccounts(t *testing.T) {
 	require.Equal(t, h1, h2)
 }
 
-func testNewLedgerFromCatchpoint(t *testing.T, filepath string, catchpointWriterReadAccess db.Accessor) *Ledger {
+func testNewLedgerFromCatchpoint(t *testing.T, catchpointWriterReadAccess db.Accessor, filepath string) *Ledger {
 	// create a ledger.
 	var initState ledgercore.InitState
 	initState.Block.CurrentProtocol = protocol.ConsensusCurrentVersion
@@ -635,7 +635,7 @@ func TestFullCatchpointWriter(t *testing.T) {
 	catchpointFilePath := filepath.Join(temporaryDirectory, "15.catchpoint")
 	testWriteCatchpoint(t, ml.trackerDB().Rdb, catchpointDataFilePath, catchpointFilePath, 0)
 
-	l := testNewLedgerFromCatchpoint(t, catchpointFilePath, ml.trackerDB().Rdb)
+	l := testNewLedgerFromCatchpoint(t, ml.trackerDB().Rdb, catchpointFilePath)
 	defer l.Close()
 	// verify that the account data aligns with what we originally stored :
 	for addr, acct := range accts {
@@ -684,7 +684,7 @@ func TestExactAccountChunk(t *testing.T) {
 	cph := testWriteCatchpoint(t, dl.validator.trackerDB().Rdb, catchpointDataFilePath, catchpointFilePath, 0)
 	require.EqualValues(t, cph.TotalChunks, 1)
 
-	l := testNewLedgerFromCatchpoint(t, catchpointFilePath, dl.generator.trackerDB().Rdb)
+	l := testNewLedgerFromCatchpoint(t, dl.generator.trackerDB().Rdb, catchpointFilePath)
 	defer l.Close()
 }
 
@@ -736,7 +736,7 @@ func TestCatchpointAfterTxns(t *testing.T) {
 		cph := testWriteCatchpoint(t, dl.validator.trackerDB().Rdb, catchpointDataFilePath, catchpointFilePath, 0)
 		require.EqualValues(t, 2, cph.TotalChunks)
 
-		l := testNewLedgerFromCatchpoint(t, catchpointFilePath, dl.validator.trackerDB().Rdb)
+		l := testNewLedgerFromCatchpoint(t, dl.validator.trackerDB().Rdb, catchpointFilePath)
 		defer l.Close()
 		values, err := l.LookupKeysByPrefix(l.Latest(), "bx:", 10)
 		require.NoError(t, err)
@@ -754,7 +754,7 @@ func TestCatchpointAfterTxns(t *testing.T) {
 
 		// Drive home the point that `last` is _not_ included in the catchpoint by inspecting balance read from catchpoint.
 		{
-			l = testNewLedgerFromCatchpoint(t, catchpointFilePath, dl.validator.trackerDB().Rdb)
+			l = testNewLedgerFromCatchpoint(t, dl.validator.trackerDB().Rdb, catchpointFilePath)
 			defer l.Close()
 			_, _, algos, err := l.LookupLatest(last)
 			require.NoError(t, err)
@@ -768,7 +768,7 @@ func TestCatchpointAfterTxns(t *testing.T) {
 		cph = testWriteCatchpoint(t, dl.validator.trackerDB().Rdb, catchpointDataFilePath, catchpointFilePath, 0)
 		require.EqualValues(t, cph.TotalChunks, 3)
 
-		l = testNewLedgerFromCatchpoint(t, catchpointFilePath, dl.validator.trackerDBs.Rdb)
+		l = testNewLedgerFromCatchpoint(t, dl.validator.trackerDB().Rdb, catchpointFilePath)
 		defer l.Close()
 		values, err = l.LookupKeysByPrefix(l.Latest(), "bx:", 10)
 		require.NoError(t, err)
@@ -854,7 +854,7 @@ func TestCatchpointAfterTxns(t *testing.T) {
 		cph := testWriteCatchpoint(t, dl.generator.trackerDB().Rdb, catchpointDataFilePath, catchpointFilePath, 0)
 		require.EqualValues(t, 2, cph.TotalChunks)
 
-		l := testNewLedgerFromCatchpoint(t, catchpointFilePath, dl.generator.trackerDB().Rdb)
+		l := testNewLedgerFromCatchpoint(t, dl.generator.trackerDB().Rdb, catchpointFilePath)
 		defer l.Close()
 
 		values, err := l.LookupKeysByPrefix(l.Latest(), "bx:", 10)

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -692,115 +692,178 @@ func TestCatchpointAfterTxns(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	dl := NewDoubleLedger(t, genBalances, protocol.ConsensusFuture)
-	defer dl.Close()
+	// Exercises interactions between transaction evaluation and catchpoint
+	// generation to confirm catchpoints include expected transactions.
+	t.Run("chunks", func(t *testing.T) {
+		genBalances, addrs, _ := ledgertesting.NewTestGenesis()
+		dl := NewDoubleLedger(t, genBalances, protocol.ConsensusFuture)
+		defer dl.Close()
 
-	boxApp := dl.fundedApp(addrs[1], 1_000_000, boxAppSource)
-	callBox := txntest.Txn{
-		Type:          "appl",
-		Sender:        addrs[2],
-		ApplicationID: boxApp,
-	}
+		boxApp := dl.fundedApp(addrs[1], 1_000_000, boxAppSource)
+		callBox := txntest.Txn{
+			Type:          "appl",
+			Sender:        addrs[2],
+			ApplicationID: boxApp,
+		}
 
-	makeBox := callBox.Args("create", "xxx")
-	makeBox.Boxes = []transactions.BoxRef{{Index: 0, Name: []byte("xxx")}}
-	dl.fullBlock(makeBox)
+		makeBox := callBox.Args("create", "xxx")
+		makeBox.Boxes = []transactions.BoxRef{{Index: 0, Name: []byte("xxx")}}
+		dl.txn(makeBox)
 
-	setBox := callBox.Args("set", "xxx", strings.Repeat("f", 24))
-	setBox.Boxes = []transactions.BoxRef{{Index: 0, Name: []byte("xxx")}}
-	dl.fullBlock(setBox)
+		pay := txntest.Txn{
+			Type:     "pay",
+			Sender:   addrs[0],
+			Receiver: addrs[1],
+			Amount:   100000,
+		}
+		// There are 12 accounts in the NewTestGenesis, plus 1 app account, so we
+		// create more so that we have exactly one chunk's worth, to make sure that
+		// works without an empty chunk between accounts and kvstore.
+		for i := 0; i < (BalancesPerCatchpointFileChunk - 13); i++ {
+			newacctpay := pay
+			newacctpay.Receiver = ledgertesting.RandomAddress()
+			dl.fullBlock(&newacctpay)
+		}
+		for i := 0; i < 40; i++ {
+			dl.fullBlock(pay.Noted(strconv.Itoa(i)))
+		}
 
-	pay := txntest.Txn{
-		Type:     "pay",
-		Sender:   addrs[0],
-		Receiver: addrs[1],
-		Amount:   100000,
-	}
+		tempDir := t.TempDir()
 
-	// There are 12 accounts in the NewTestGenesis, plus 1 app account, so we
-	// create more so that we have exactly one chunk's worth, to make sure that
-	// works without an empty chunk between accounts and kvstore.
-	for i := 0; i < (BalancesPerCatchpointFileChunk - 13); i++ {
-		newacctpay := pay
-		newacctpay.Receiver = ledgertesting.RandomAddress()
-		dl.fullBlock(&newacctpay)
-	}
-	for i := 0; i < 40; i++ {
-		dl.fullBlock(pay.Noted(strconv.Itoa(i)))
-	}
+		catchpointDataFilePath := filepath.Join(tempDir, t.Name()+".data")
+		catchpointFilePath := filepath.Join(tempDir, t.Name()+".catchpoint.tar.gz")
 
-	resetBox := callBox.Args("set", "xxx", strings.Repeat("z", 24))
-	resetBox.Boxes = []transactions.BoxRef{{Index: 0, Name: []byte("xxx")}}
-	dl.fullBlock(resetBox)
+		cph := testWriteCatchpoint(t, dl.validator.trackerDB().Rdb, catchpointDataFilePath, catchpointFilePath, 0)
+		require.EqualValues(t, 2, cph.TotalChunks)
 
-	for i := 0; i < 40; i++ {
-		dl.fullBlock(pay.Noted(strconv.Itoa(i)))
-	}
-
-	dl.fullBlock(setBox.Noted("reset back to f's"))
-	for i := 0; i < 40; i++ {
-		dl.fullBlock(pay.Noted(strconv.Itoa(i)))
-	}
-
-	tempDir := t.TempDir()
-
-	catchpointDataFilePath := filepath.Join(tempDir, t.Name()+".data")
-	catchpointFilePath := filepath.Join(tempDir, t.Name()+".catchpoint.tar.gz")
-
-	cph := testWriteCatchpoint(t, dl.generator.trackerDB().Rdb, catchpointDataFilePath, catchpointFilePath, 0)
-	require.EqualValues(t, 2, cph.TotalChunks)
-
-	l := testNewLedgerFromCatchpoint(t, catchpointFilePath, dl.generator.trackerDB().Rdb)
-	defer l.Close()
-
-	values, err := l.LookupKeysByPrefix(l.Latest(), "bx:", 10)
-	require.NoError(t, err)
-	require.Len(t, values, 1)
-	v, err := l.LookupKv(l.Latest(), logic.MakeBoxKey(boxApp, "xxx"))
-	require.NoError(t, err)
-	require.Equal(t, strings.Repeat("f", 24), string(v))
-
-	// Add one more account
-	newacctpay := pay
-	last := ledgertesting.RandomAddress()
-	newacctpay.Receiver = last
-	dl.fullBlock(&newacctpay)
-
-	// Write and read back in, and ensure even the last effect exists.
-	cph = testWriteCatchpoint(t, dl.validator.trackerDB().Rdb, catchpointDataFilePath, catchpointFilePath, 0)
-	require.EqualValues(t, cph.TotalChunks, 2) // Still only 2 chunks, as last was in a recent block
-
-	// Drive home the point that `last` is _not_ included in the catchpoint by inspecting balance read from catchpoint.
-	{
-		l = testNewLedgerFromCatchpoint(t, catchpointFilePath, dl.generator.trackerDB().Rdb)
+		l := testNewLedgerFromCatchpoint(t, catchpointFilePath, dl.validator.trackerDB().Rdb)
 		defer l.Close()
-		_, _, algos, err := l.LookupLatest(last)
+		values, err := l.LookupKeysByPrefix(l.Latest(), "bx:", 10)
 		require.NoError(t, err)
-		require.Equal(t, basics.MicroAlgos{}, algos)
-	}
+		require.Len(t, values, 1)
 
-	for i := 0; i < 40; i++ { // Advance so catchpoint sees the txns
-		dl.fullBlock(pay.Noted(strconv.Itoa(i)))
-	}
+		// Add one more account
+		newacctpay := pay
+		last := ledgertesting.RandomAddress()
+		newacctpay.Receiver = last
+		dl.fullBlock(&newacctpay)
 
-	cph = testWriteCatchpoint(t, dl.validator.trackerDB().Rdb, catchpointDataFilePath, catchpointFilePath, 0)
-	require.EqualValues(t, cph.TotalChunks, 3)
+		// Write and read back in, and ensure even the last effect exists.
+		cph = testWriteCatchpoint(t, dl.validator.trackerDB().Rdb, catchpointDataFilePath, catchpointFilePath, 0)
+		require.EqualValues(t, cph.TotalChunks, 2) // Still only 2 chunks, as last was in a recent block
 
-	l = testNewLedgerFromCatchpoint(t, catchpointFilePath, dl.generator.trackerDB().Rdb)
-	defer l.Close()
-	values, err = l.LookupKeysByPrefix(l.Latest(), "bx:", 10)
-	require.NoError(t, err)
-	require.Len(t, values, 1)
+		// Drive home the point that `last` is _not_ included in the catchpoint by inspecting balance read from catchpoint.
+		{
+			l = testNewLedgerFromCatchpoint(t, catchpointFilePath, dl.validator.trackerDB().Rdb)
+			defer l.Close()
+			_, _, algos, err := l.LookupLatest(last)
+			require.NoError(t, err)
+			require.Equal(t, basics.MicroAlgos{}, algos)
+		}
 
-	// Confirm `last` balance is now available in the catchpoint.
-	{
-		// Since fast catchup consists of multiple steps and the test only performs catchpoint reads, the resulting ledger is incomplete.
-		// That's why the assertion ignores rewards and does _not_ use `LookupLatest`.
-		ad, _, err := l.LookupWithoutRewards(0, last)
+		for i := 0; i < 40; i++ { // Advance so catchpoint sees the txns
+			dl.fullBlock(pay.Noted(strconv.Itoa(i)))
+		}
+
+		cph = testWriteCatchpoint(t, dl.validator.trackerDB().Rdb, catchpointDataFilePath, catchpointFilePath, 0)
+		require.EqualValues(t, cph.TotalChunks, 3)
+
+		l = testNewLedgerFromCatchpoint(t, catchpointFilePath, dl.validator.trackerDBs.Rdb)
+		defer l.Close()
+		values, err = l.LookupKeysByPrefix(l.Latest(), "bx:", 10)
 		require.NoError(t, err)
-		require.Equal(t, basics.MicroAlgos{Raw: 100_000}, ad.MicroAlgos)
-	}
+		require.Len(t, values, 1)
+		v, err := l.LookupKv(l.Latest(), logic.MakeBoxKey(boxApp, "xxx"))
+		require.NoError(t, err)
+		require.Equal(t, strings.Repeat("\x00", 24), string(v))
+
+		// Confirm `last` balance is now available in the catchpoint.
+		{
+			// Since fast catchup consists of multiple steps and the test only performs catchpoint reads, the resulting ledger is incomplete.
+			// That's why the assertion ignores rewards and does _not_ use `LookupLatest`.
+			ad, _, err := l.LookupWithoutRewards(0, last)
+			require.NoError(t, err)
+			require.Equal(t, basics.MicroAlgos{Raw: 100_000}, ad.MicroAlgos)
+		}
+	})
+
+	// Exercises a sequence of box modifications that caused a bug in
+	// catchpoint writes.
+	//
+	// The problematic sequence of values is:  v1 -> v2 -> v1.  Where each
+	// box value is:
+	// * Part of a transaction that does _not_ modify global/local state.
+	// * Written to `balancesTrie`.
+	t.Run("box_reset", func(t *testing.T) {
+		genBalances, addrs, _ := ledgertesting.NewTestGenesis()
+		dl := NewDoubleLedger(t, genBalances, protocol.ConsensusFuture)
+		defer dl.Close()
+
+		boxApp := dl.fundedApp(addrs[1], 1_000_000, boxAppSource)
+		callBox := txntest.Txn{
+			Type:          "appl",
+			Sender:        addrs[2],
+			ApplicationID: boxApp,
+		}
+
+		makeBox := callBox.Args("create", "xxx")
+		makeBox.Boxes = []transactions.BoxRef{{Index: 0, Name: []byte("xxx")}}
+		dl.fullBlock(makeBox)
+
+		setBox := callBox.Args("set", "xxx", strings.Repeat("f", 24))
+		setBox.Boxes = []transactions.BoxRef{{Index: 0, Name: []byte("xxx")}}
+		dl.fullBlock(setBox)
+
+		pay := txntest.Txn{
+			Type:     "pay",
+			Sender:   addrs[0],
+			Receiver: addrs[1],
+			Amount:   100000,
+		}
+
+		// There are 12 accounts in the NewTestGenesis, plus 1 app account, so we
+		// create more so that we have exactly one chunk's worth, to make sure that
+		// works without an empty chunk between accounts and kvstore.
+		for i := 0; i < (BalancesPerCatchpointFileChunk - 13); i++ {
+			newacctpay := pay
+			newacctpay.Receiver = ledgertesting.RandomAddress()
+			dl.fullBlock(&newacctpay)
+		}
+		for i := 0; i < 40; i++ {
+			dl.fullBlock(pay.Noted(strconv.Itoa(i)))
+		}
+
+		resetBox := callBox.Args("set", "xxx", strings.Repeat("z", 24))
+		resetBox.Boxes = []transactions.BoxRef{{Index: 0, Name: []byte("xxx")}}
+		dl.fullBlock(resetBox)
+
+		for i := 0; i < 40; i++ {
+			dl.fullBlock(pay.Noted(strconv.Itoa(i)))
+		}
+
+		dl.fullBlock(setBox.Noted("reset back to f's"))
+		for i := 0; i < 40; i++ {
+			dl.fullBlock(pay.Noted(strconv.Itoa(i)))
+		}
+
+		tempDir := t.TempDir()
+
+		catchpointDataFilePath := filepath.Join(tempDir, t.Name()+".data")
+		catchpointFilePath := filepath.Join(tempDir, t.Name()+".catchpoint.tar.gz")
+
+		cph := testWriteCatchpoint(t, dl.generator.trackerDB().Rdb, catchpointDataFilePath, catchpointFilePath, 0)
+		require.EqualValues(t, 2, cph.TotalChunks)
+
+		l := testNewLedgerFromCatchpoint(t, catchpointFilePath, dl.generator.trackerDB().Rdb)
+		defer l.Close()
+
+		values, err := l.LookupKeysByPrefix(l.Latest(), "bx:", 10)
+		require.NoError(t, err)
+		require.Len(t, values, 1)
+		v, err := l.LookupKv(l.Latest(), logic.MakeBoxKey(boxApp, "xxx"))
+		require.NoError(t, err)
+		require.Equal(t, strings.Repeat("f", 24), string(v))
+	})
 }
 
 func TestEncodedKVRecordV6Allocbounds(t *testing.T) {


### PR DESCRIPTION
Extends catchpoint tests to help catch regressions:
* Enriches `testNewLedgerFromCatchpoint` to confirm the writer and reader merkle tries match by comparing merkle trie stats.
* Adds a test case to `TestCatchpointAfterTxns` isolating a scenario that fails _prior to_ https://github.com/algorand/go-algorand/pull/4804.

Notes:
* If folks prefer to _not_ have an isolated test case, I can revert to the initial commit (https://github.com/algorand/go-algorand/commit/a7766298dd6a32a341cea4e1b6d630ce46d2fc0f).
* I ran out of time to convert existing test usage from mocks to `DoubleLedger`.  As is, the PR contains a kludgey if-statement (`Skip invariant check for tests using mocks`).   Even as is, I _think_ the PR presents a value add.