### PR TITLE
Catchpoint:  Add context to block mismatch error in VerifyCatchpoint

### DIFF
--- a/ledger/catchupaccessor.go
+++ b/ledger/catchupaccessor.go
@@ -851,7 +851,7 @@ func (c *catchpointCatchupAccessorImpl) VerifyCatchpoint(ctx context.Context, bl
 		return err
 	}
 	if blockRound != blk.Round() {
-		return fmt.Errorf("block round in block header doesn't match block round in catchpoint")
+		return fmt.Errorf("block round in block header doesn't match block round in catchpoint:  %d != %d", blockRound, blk.Round())
 	}
 
 	catchpointLabelMaker := ledgercore.MakeCatchpointLabel(blockRound, blk.Digest(), balancesHash, totals)


### PR DESCRIPTION
While working on #4818, I landed in an intermediate state where it was helpful to add context to a `VerifyCatchpoint` error message.  I present the PR optionally - I don't feel strongly about retaining the minor change.