### PR TITLE
accountdb: add migration 8 for resetting accounthashes on betanet

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -193,7 +193,7 @@ var accountsResetExprs = []string{
 // accountDBVersion is the database version that this binary would know how to support and how to upgrade to.
 // details about the content of each of the versions can be found in the upgrade functions upgradeDatabaseSchemaXXXX
 // and their descriptions.
-var accountDBVersion = int32(8)
+var accountDBVersion = int32(9)
 
 // persistedAccountData is used for representing a single account stored on the disk. In addition to the
 // basics.AccountData, it also stores complete referencing information used to maintain the base accounts

--- a/ledger/catchupaccessor.go
+++ b/ledger/catchupaccessor.go
@@ -1012,6 +1012,7 @@ func (c *catchpointCatchupAccessorImpl) finishBalances(ctx context.Context) (err
 				initAccounts:      c.ledger.GenesisAccounts(),
 				initProto:         c.ledger.GenesisProtoVersion(),
 				genesisHash:       c.ledger.GenesisHash(),
+				fromCatchpoint:    true,
 				catchpointEnabled: c.ledger.catchpoint.catchpointEnabled(),
 				dbPathPrefix:      c.ledger.catchpoint.dbDirectory,
 				blockDb:           c.ledger.blockDBs,

--- a/ledger/catchupaccessor.go
+++ b/ledger/catchupaccessor.go
@@ -1011,6 +1011,7 @@ func (c *catchpointCatchupAccessorImpl) finishBalances(ctx context.Context) (err
 			tp := trackerDBParams{
 				initAccounts:      c.ledger.GenesisAccounts(),
 				initProto:         c.ledger.GenesisProtoVersion(),
+				genesisHash:       c.ledger.GenesisHash(),
 				catchpointEnabled: c.ledger.catchpoint.catchpointEnabled(),
 				dbPathPrefix:      c.ledger.catchpoint.dbDirectory,
 				blockDb:           c.ledger.blockDBs,

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -2230,6 +2230,7 @@ func TestLedgerReloadTxTailHistoryAccess(t *testing.T) {
 		tp := trackerDBParams{
 			initAccounts:      l.GenesisAccounts(),
 			initProto:         l.GenesisProtoVersion(),
+			genesisHash:       l.GenesisHash(),
 			catchpointEnabled: l.catchpoint.catchpointEnabled(),
 			dbPathPrefix:      l.catchpoint.dbDirectory,
 			blockDb:           l.blockDBs,

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -2231,6 +2231,7 @@ func TestLedgerReloadTxTailHistoryAccess(t *testing.T) {
 			initAccounts:      l.GenesisAccounts(),
 			initProto:         l.GenesisProtoVersion(),
 			genesisHash:       l.GenesisHash(),
+			fromCatchpoint:    true,
 			catchpointEnabled: l.catchpoint.catchpointEnabled(),
 			dbPathPrefix:      l.catchpoint.dbDirectory,
 			blockDb:           l.blockDBs,

--- a/ledger/trackerdb.go
+++ b/ledger/trackerdb.go
@@ -539,7 +539,7 @@ func (tu *trackerDBSchemaInitializer) upgradeDatabaseSchema8(ctx context.Context
 			return fmt.Errorf("upgradeDatabaseSchema8 unable to reset acctrounds table 'hashbase' round : %v", err)
 		}
 	}
-	return tu.setVersion(ctx, tx, 8)
+	return tu.setVersion(ctx, tx, 9)
 }
 
 // isDirEmpty returns if a given directory is empty or not.

--- a/ledger/trackerdb.go
+++ b/ledger/trackerdb.go
@@ -40,6 +40,7 @@ type trackerDBParams struct {
 	initAccounts      map[basics.Address]basics.AccountData
 	initProto         protocol.ConsensusVersion
 	genesisHash       crypto.Digest
+	fromCatchpoint    bool
 	catchpointEnabled bool
 	dbPathPrefix      string
 	blockDb           db.Pair
@@ -532,7 +533,7 @@ func (tu *trackerDBSchemaInitializer) upgradeDatabaseSchema7(ctx context.Context
 // forcing a rebuild of the accounthashes table on betanet nodes. Otherwise it has no effect.
 func (tu *trackerDBSchemaInitializer) upgradeDatabaseSchema8(ctx context.Context, tx *sql.Tx) (err error) {
 	betanetGenesisHash, _ := crypto.DigestFromString("TBMBVTC7W24RJNNUZCF7LWZD2NMESGZEQSMPG5XQD7JY4O7JKVWQ")
-	if tu.genesisHash == betanetGenesisHash {
+	if tu.genesisHash == betanetGenesisHash && !tu.fromCatchpoint {
 		// reset hash round to 0, forcing catchpointTracker.initializeHashes to rebuild accounthashes
 		err = updateAccountsHashRound(ctx, tx, 0)
 		if err != nil {

--- a/ledger/trackerdb.go
+++ b/ledger/trackerdb.go
@@ -84,6 +84,7 @@ func trackerDBInitialize(l ledgerForTracker, catchpointEnabled bool, dbPathPrefi
 			initAccounts:      l.GenesisAccounts(),
 			initProto:         l.GenesisProtoVersion(),
 			genesisHash:       l.GenesisHash(),
+			fromCatchpoint:    false,
 			catchpointEnabled: catchpointEnabled,
 			dbPathPrefix:      dbPathPrefix,
 			blockDb:           bdbs,


### PR DESCRIPTION
## Summary

Following on #4804 and #4812, this migration rebuilds the accounthashes table for betanet nodes.

## Test Plan

Existing tests should pass, manual tests can confirm table is rebuilt.