### PR TITLE
node: Fix disabled node tests

### DIFF
--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -214,6 +214,9 @@ type GossipNode interface {
 	// GetPeerData returns a value stored by SetPeerData
 	GetPeerData(peer Peer, key string) interface{}
 
+	// ExtendPeerList sets the peer data in the phonebook
+	ExtendPeerList(peers ...string)
+
 	// SetPeerData attaches a piece of data to a peer.
 	// Other services inside go-algorand may attach data to a peer that gets garbage collected when the peer is closed.
 	SetPeerData(peer Peer, key string, value interface{})
@@ -681,6 +684,11 @@ func (wn *WebsocketNetwork) GetPeers(options ...PeerOption) []Peer {
 		}
 	}
 	return outPeers
+}
+
+// ExtendPeerList is used for testing the node w/ manual phonebook configurations
+func (wn *WebsocketNetwork) ExtendPeerList(peers ...string) {
+	wn.phonebook.ExtendPeerList(peers, wn.config.DNSBootstrapID, PhoneBookEntryRelayRole)
 }
 
 // find the max value across the given uint64 numbers.

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -214,9 +214,6 @@ type GossipNode interface {
 	// GetPeerData returns a value stored by SetPeerData
 	GetPeerData(peer Peer, key string) interface{}
 
-	// ExtendPeerList sets the peer data in the phonebook
-	ExtendPeerList(peers ...string)
-
 	// SetPeerData attaches a piece of data to a peer.
 	// Other services inside go-algorand may attach data to a peer that gets garbage collected when the peer is closed.
 	SetPeerData(peer Peer, key string, value interface{})
@@ -684,11 +681,6 @@ func (wn *WebsocketNetwork) GetPeers(options ...PeerOption) []Peer {
 		}
 	}
 	return outPeers
-}
-
-// ExtendPeerList is used for testing the node w/ manual phonebook configurations
-func (wn *WebsocketNetwork) ExtendPeerList(peers ...string) {
-	wn.phonebook.ExtendPeerList(peers, wn.config.DNSBootstrapID, PhoneBookEntryRelayRole)
 }
 
 // find the max value across the given uint64 numbers.

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/config"
-	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data"
 	"github.com/algorand/go-algorand/data/account"
 	"github.com/algorand/go-algorand/data/basics"
@@ -141,6 +140,10 @@ func setupFullNodes(t *testing.T, proto protocol.ConsensusVersion, verificationP
 		short := root.Address()
 		genesis[short] = data
 	}
+	genesis[poolAddr] = basics.AccountData{
+		Status:     basics.Online,
+		MicroAlgos: basics.MicroAlgos{Raw: uint64(100000)},
+	}
 
 	bootstrap := bookkeeping.MakeGenesisBalances(genesis, sinkAddr, poolAddr)
 
@@ -158,7 +161,7 @@ func setupFullNodes(t *testing.T, proto protocol.ConsensusVersion, verificationP
 		cfg, err := config.LoadConfigFromDisk(rootDirectory)
 		require.NoError(t, err)
 		cfg.Archival = true
-		_, err = data.LoadLedger(logging.Base().With("name", nodeID), ledgerFilenamePrefix, inMem, g.Proto, bootstrap, "", crypto.Digest{}, nil, cfg)
+		_, err = data.LoadLedger(logging.Base().With("name", nodeID), ledgerFilenamePrefix, inMem, g.Proto, bootstrap, g.ID(), g.Hash(), nil, cfg)
 		require.NoError(t, err)
 	}
 
@@ -178,7 +181,9 @@ func setupFullNodes(t *testing.T, proto protocol.ConsensusVersion, verificationP
 func TestSyncingFullNode(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	t.Skip("This is failing randomly again - PLEASE FIX!")
+	if testing.Short() {
+		t.Skip("Test takes ~80 seconds.")
+	}
 
 	backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)
 	defer backlogPool.Shutdown()
@@ -236,7 +241,9 @@ func TestSyncingFullNode(t *testing.T) {
 func TestInitialSync(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	t.Skip("flaky TestInitialSync ")
+	if testing.Short() {
+		t.Skip("Test takes ~25 seconds.")
+	}
 
 	backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)
 	defer backlogPool.Shutdown()
@@ -269,8 +276,9 @@ func TestInitialSync(t *testing.T) {
 
 func TestSimpleUpgrade(t *testing.T) {
 	partitiontest.PartitionTest(t)
-
-	t.Skip("Randomly failing: node_test.go:~330 : no block notification for account. Re-enable after agreement bug-fix pass")
+	if testing.Short() {
+		t.Skip("This test takes ~80 seconds.")
+	}
 
 	backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)
 	defer backlogPool.Shutdown()
@@ -286,6 +294,7 @@ func TestSimpleUpgrade(t *testing.T) {
 	configurableConsensus := make(config.ConsensusProtocols)
 
 	testParams0 := config.Consensus[protocol.ConsensusCurrentVersion]
+	testParams0.MinUpgradeWaitRounds = 0
 	testParams0.SupportGenesisHash = false
 	testParams0.UpgradeVoteRounds = 2
 	testParams0.UpgradeThreshold = 1
@@ -299,6 +308,7 @@ func TestSimpleUpgrade(t *testing.T) {
 	configurableConsensus[consensusTest0] = testParams0
 
 	testParams1 := config.Consensus[protocol.ConsensusCurrentVersion]
+	testParams1.MinUpgradeWaitRounds = 0
 	testParams1.SupportGenesisHash = false
 	testParams1.UpgradeVoteRounds = 10
 	testParams1.UpgradeThreshold = 8
@@ -395,7 +405,7 @@ func connectPeers(nodes []*AlgorandFullNode) {
 	}
 
 	for _, node := range nodes {
-		//		node.ExtendPeerList(neighbors...)
+		node.net.ExtendPeerList(neighbors...)
 		node.net.RequestConnectOutgoing(false, nil)
 	}
 }
@@ -410,11 +420,15 @@ func delayStartNode(node *AlgorandFullNode, peers []*AlgorandFullNode, delay tim
 	}()
 	wg.Wait()
 
-	//	node0Addr := node.config.NetAddress
+	node0Addr := node.config.NetAddress
+	node0Neighbors := make([]string, 0)
 	for _, peer := range peers {
-		//		peer.ExtendPeerList(node0Addr)
+		node0Neighbors = append(node0Neighbors, peer.config.NetAddress)
+		node.net.ExtendPeerList(node0Addr)
 		peer.net.RequestConnectOutgoing(false, nil)
 	}
+	node.net.ExtendPeerList(node0Neighbors...)
+	node.net.RequestConnectOutgoing(false, nil)
 }
 
 func TestStatusReport_TimeSinceLastRound(t *testing.T) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -167,7 +167,6 @@ func setupFullNodes(t *testing.T, proto protocol.ConsensusVersion, verificationP
 
 	for i := range nodes {
 		var nodeNeighbors []string
-		copy(nodeNeighbors, neighbors)
 		nodeNeighbors = append(nodeNeighbors, neighbors[:i]...)
 		nodeNeighbors = append(nodeNeighbors, neighbors[i+1:]...)
 		rootDirectory := rootDirs[i]

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -166,11 +166,14 @@ func setupFullNodes(t *testing.T, proto protocol.ConsensusVersion, verificationP
 	}
 
 	for i := range nodes {
+		var nodeNeighbors []string
+		copy(nodeNeighbors, neighbors)
+		nodeNeighbors = append(nodeNeighbors, neighbors[:i]...)
+		nodeNeighbors = append(nodeNeighbors, neighbors[i+1:]...)
 		rootDirectory := rootDirs[i]
 		cfg, err := config.LoadConfigFromDisk(rootDirectory)
 		require.NoError(t, err)
-
-		node, err := MakeFull(logging.Base().With("source", t.Name()+strconv.Itoa(i)), rootDirectory, cfg, append(neighbors[:i], neighbors[i+1:]...), g)
+		node, err := MakeFull(logging.Base().With("source", t.Name()+strconv.Itoa(i)), rootDirectory, cfg, nodeNeighbors, g)
 		nodes[i] = node
 		require.NoError(t, err)
 	}


### PR DESCRIPTION


## Summary

These node tests look like they've been disabled for a very long time--some of them since the initial commit.

I've fixed these tests with some caveats.  
* They take a long time to run so I've allowed us to opt into skipping them with `-short`
* I had to add phonebook's `ExtendPeerList` method to the `GossipNode`. The tests originally required this which wasn't an issue because the phonebook was located in the mode, but when it got moved out we lost the ability to update the phonebook peers manually.

## Test Plan

Unit tests.
