### PR TITLE
config: add HeartbeatUpdateInterval

### DIFF
--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -344,7 +344,7 @@ func run() int {
 
 		// Send a heartbeat event every 10 minutes as a sign of life
 		go func() {
-			ticker := time.NewTicker(10 * time.Minute)
+			ticker := time.NewTicker(time.Second * time.Duration(cfg.HeartbeatUpdateInterval))
 			defer ticker.Stop()
 
 			sendHeartbeat := func() {

--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -344,7 +344,17 @@ func run() int {
 
 		// Send a heartbeat event every 10 minutes as a sign of life
 		go func() {
-			ticker := time.NewTicker(time.Second * time.Duration(cfg.HeartbeatUpdateInterval))
+			var interval time.Duration
+			defaultIntervalSecs := config.GetDefaultLocal().HeartbeatUpdateInterval
+			switch {
+			case cfg.HeartbeatUpdateInterval <= 0: // use default
+				interval = time.Second * time.Duration(defaultIntervalSecs)
+			case cfg.HeartbeatUpdateInterval < 60: // min frequency 1 minute
+				interval = time.Minute
+			default:
+				interval = time.Second * time.Duration(cfg.HeartbeatUpdateInterval)
+			}
+			ticker := time.NewTicker(interval)
 			defer ticker.Stop()
 
 			sendHeartbeat := func() {

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -263,7 +263,7 @@ type Local struct {
 
 	// HeartbeatUpdateInterval defines the interval at which the heartbeat information is being sent to the
 	// telemetry ( when enabled ). Defined in seconds.
-	HeartbeatUpdateInterval int `version[26]:"600"`
+	HeartbeatUpdateInterval int `version[27]:"600"`
 
 	// EnableProfiler enables the go pprof endpoints, should be false if
 	// the algod api will be exposed to untrusted individuals

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -262,7 +262,7 @@ type Local struct {
 	PeerConnectionsUpdateInterval int `version[5]:"3600"`
 
 	// HeartbeatUpdateInterval defines the interval at which the heartbeat information is being sent to the
-	// telemetry ( when enabled ). Defined in seconds.
+	// telemetry ( when enabled ). Defined in seconds. Minimum value is 60.
 	HeartbeatUpdateInterval int `version[27]:"600"`
 
 	// EnableProfiler enables the go pprof endpoints, should be false if

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -261,6 +261,10 @@ type Local struct {
 	// telemetry ( when enabled ). Defined in seconds.
 	PeerConnectionsUpdateInterval int `version[5]:"3600"`
 
+	// HeartbeatUpdateInterval defines the interval at which the heartbeat information is being sent to the
+	// telemetry ( when enabled ). Defined in seconds.
+	HeartbeatUpdateInterval int `version[26]:"600"`
+
 	// EnableProfiler enables the go pprof endpoints, should be false if
 	// the algod api will be exposed to untrusted individuals
 	EnableProfiler bool `version[0]:"false"`

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -79,6 +79,7 @@ var defaultLocal = Local{
 	ForceFetchTransactions:                     false,
 	ForceRelayMessages:                         false,
 	GossipFanout:                               4,
+	HeartbeatUpdateInterval:                    600,
 	IncomingConnectionsLimit:                   800,
 	IncomingMessageFilterBucketCount:           5,
 	IncomingMessageFilterBucketSize:            512,

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -58,6 +58,7 @@
     "ForceFetchTransactions": false,
     "ForceRelayMessages": false,
     "GossipFanout": 4,
+    "HeartbeatUpdateInterval": 600,
     "IncomingConnectionsLimit": 800,
     "IncomingMessageFilterBucketCount": 5,
     "IncomingMessageFilterBucketSize": 512,

--- a/test/testdata/configs/config-v26.json
+++ b/test/testdata/configs/config-v26.json
@@ -57,6 +57,7 @@
     "ForceFetchTransactions": false,
     "ForceRelayMessages": false,
     "GossipFanout": 4,
+    "HeartbeatUpdateInterval": 600,
     "IncomingConnectionsLimit": 800,
     "IncomingMessageFilterBucketCount": 5,
     "IncomingMessageFilterBucketSize": 512,

--- a/test/testdata/configs/config-v26.json
+++ b/test/testdata/configs/config-v26.json
@@ -57,7 +57,6 @@
     "ForceFetchTransactions": false,
     "ForceRelayMessages": false,
     "GossipFanout": 4,
-    "HeartbeatUpdateInterval": 600,
     "IncomingConnectionsLimit": 800,
     "IncomingMessageFilterBucketCount": 5,
     "IncomingMessageFilterBucketSize": 512,

--- a/test/testdata/configs/config-v27.json
+++ b/test/testdata/configs/config-v27.json
@@ -59,6 +59,7 @@
     "ForceFetchTransactions": false,
     "ForceRelayMessages": false,
     "GossipFanout": 4,
+    "HeartbeatUpdateInterval": 600,
     "IncomingConnectionsLimit": 800,
     "IncomingMessageFilterBucketCount": 5,
     "IncomingMessageFilterBucketSize": 512,


### PR DESCRIPTION
## Summary

Adds a configurable HeartbeatUpdateInterval to control how often the heartbeat telemetry event is sent, when telemetry is enabled.

## Test Plan

Existing tests should pass.