### PR TITLE
Catchpoint:  Fix broken merge between #4818 and #4835

### DIFF
--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -582,7 +582,7 @@ func testNewLedgerFromCatchpoint(t *testing.T, catchpointWriterReadAccess db.Acc
 	balanceTrieStats := func(db db.Accessor) merkletrie.Stats {
 		var stats merkletrie.Stats
 		err = db.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
-			committer, err := MakeMerkleCommitter(tx, false)
+			committer, err := store.MakeMerkleCommitter(tx, false)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes broken merge between #4818 and #4835. 

Prior to the PR, `master` fails compilation with: `ledger/catchpointwriter_test.go:585:22: undefined: MakeMerkleCommitter`.