### PR TITLE
Illustrate how to halt processing for specific DB round

### DIFF
--- a/catchup/service.go
+++ b/catchup/service.go
@@ -194,6 +194,8 @@ func (s *Service) innerFetch(r basics.Round, peer network.Peer) (blk *bookkeepin
 	return
 }
 
+var stopRound basics.Round = 21969684
+
 // fetchAndWrite fetches a block, checks the cert, and writes it to the ledger. Cert checking and ledger writing both wait for the ledger to advance if necessary.
 // Returns false if we should stop trying to catch up.  This may occur for several reasons:
 //  - If the context is canceled (e.g. if the node is shutting down)
@@ -201,6 +203,10 @@ func (s *Service) innerFetch(r basics.Round, peer network.Peer) (blk *bookkeepin
 //  - If the block is already in the ledger (e.g. if agreement service has already written it)
 //  - If the retrieval of the previous block was unsuccessful
 func (s *Service) fetchAndWrite(r basics.Round, prevFetchCompleteChan chan bool, lookbackComplete chan bool, peerSelector *peerSelector) bool {
+	// if r > stopRound {
+	// 	s.log.Warnf("not downloading any blocks beyond %d", stopRound)
+	// 	return false
+	// }
 	i := 0
 	hasLookback := false
 	for true {

--- a/cmd/catchpointdump/database.go
+++ b/cmd/catchpointdump/database.go
@@ -30,13 +30,16 @@ import (
 )
 
 var ledgerTrackerFilename string
+var ledgerTrackerStaging bool
 
 func init() {
 	databaseCmd.Flags().StringVarP(&ledgerTrackerFilename, "tracker", "t", "", "Specify the ledger tracker file name ( i.e. ./ledger.tracker.sqlite )")
 	databaseCmd.Flags().StringVarP(&outFileName, "output", "o", "", "Specify an outfile for the dump ( i.e. ledger.dump.txt )")
+	databaseCmd.Flags().BoolVarP(&ledgerTrackerStaging, "staging", "s", false, "Specify whether to look in the catchpoint staging or regular tables. (default false)")
 	databaseCmd.AddCommand(checkCmd)
 
 	checkCmd.Flags().StringVarP(&ledgerTrackerFilename, "tracker", "t", "", "Specify the ledger tracker file name ( i.e. ./ledger.tracker.sqlite )")
+	checkCmd.Flags().BoolVarP(&ledgerTrackerStaging, "staging", "s", false, "Specify whether to look in the catchpoint staging or regular tables. (default false)")
 }
 
 var databaseCmd = &cobra.Command{
@@ -58,9 +61,13 @@ var databaseCmd = &cobra.Command{
 			}
 			defer outFile.Close()
 		}
-		err = printAccountsDatabase(ledgerTrackerFilename, ledger.CatchpointFileHeader{}, outFile, nil)
+		err = printAccountsDatabase(ledgerTrackerFilename, ledgerTrackerStaging, ledger.CatchpointFileHeader{}, outFile, nil)
 		if err != nil {
 			reportErrorf("Unable to print account database : %v", err)
+		}
+		err = printKeyValueStore(ledgerTrackerFilename, ledgerTrackerStaging, ledger.CatchpointFileHeader{}, outFile)
+		if err != nil {
+			reportErrorf("Unable to print key value store : %v", err)
 		}
 	},
 }
@@ -99,11 +106,16 @@ func checkDatabase(databaseName string, outFile *os.File) error {
 
 	var stats merkletrie.Stats
 	err = dbAccessor.Atomic(func(ctx context.Context, tx *sql.Tx) (err error) {
-		committer, err := ledger.MakeMerkleCommitter(tx, false)
+		committer, err := ledger.MakeMerkleCommitter(tx, ledgerTrackerStaging)
 		if err != nil {
 			return err
 		}
 		trie, err := merkletrie.MakeTrie(committer, ledger.TrieMemoryConfig)
+		if err != nil {
+			return err
+		}
+		root, err := trie.RootHash()
+		fmt.Fprintf(outFile, " Root: %s\n", root.String())
 		if err != nil {
 			return err
 		}

--- a/cmd/catchpointdump/file.go
+++ b/cmd/catchpointdump/file.go
@@ -126,11 +126,11 @@ var fileCmd = &cobra.Command{
 				defer outFile.Close()
 			}
 
-			err = printAccountsDatabase("./ledger.tracker.sqlite", fileHeader, outFile, excludedFields.GetSlice())
+			err = printAccountsDatabase("./ledger.tracker.sqlite", true, fileHeader, outFile, excludedFields.GetSlice())
 			if err != nil {
 				reportErrorf("Unable to print account database : %v", err)
 			}
-			err = printKeyValueStore("./ledger.tracker.sqlite", outFile)
+			err = printKeyValueStore("./ledger.tracker.sqlite", true, fileHeader, outFile)
 			if err != nil {
 				reportErrorf("Unable to print key value store : %v", err)
 			}
@@ -210,7 +210,7 @@ func printDumpingCatchpointProgressLine(progress int, barLength int, dld int64) 
 	fmt.Printf(escapeCursorUp + escapeDeleteLine + outString + "\n")
 }
 
-func printAccountsDatabase(databaseName string, fileHeader ledger.CatchpointFileHeader, outFile *os.File, excludeFields []string) error {
+func printAccountsDatabase(databaseName string, stagingTables bool, fileHeader ledger.CatchpointFileHeader, outFile *os.File, excludeFields []string) error {
 	lastProgressUpdate := time.Now()
 	progress := uint64(0)
 	defer printDumpingCatchpointProgressLine(0, 0, 0)
@@ -286,6 +286,9 @@ func printAccountsDatabase(databaseName string, fileHeader ledger.CatchpointFile
 		if fileHeader.Version == 0 {
 			var totals ledgercore.AccountTotals
 			id := ""
+			if stagingTables {
+				id = "catchpointStaging"
+			}
 			row := tx.QueryRow("SELECT online, onlinerewardunits, offline, offlinerewardunits, notparticipating, notparticipatingrewardunits, rewardslevel FROM accounttotals WHERE id=?", id)
 			err = row.Scan(&totals.Online.Money.Raw, &totals.Online.RewardUnits,
 				&totals.Offline.Money.Raw, &totals.Offline.RewardUnits,
@@ -303,7 +306,7 @@ func printAccountsDatabase(databaseName string, fileHeader ledger.CatchpointFile
 
 		balancesTable := "accountbase"
 		resourcesTable := "resources"
-		if fileHeader.Version != 0 {
+		if stagingTables {
 			balancesTable = "catchpointbalances"
 			resourcesTable = "catchpointresources"
 		}
@@ -329,60 +332,21 @@ func printAccountsDatabase(databaseName string, fileHeader ledger.CatchpointFile
 			return nil
 		}
 
-		if fileHeader.Version < ledger.CatchpointFileVersionV6 {
-			var rows *sql.Rows
-			rows, err = tx.Query(fmt.Sprintf("SELECT address, data FROM %s order by address", balancesTable))
+		acctCount := 0
+		acctCb := func(addr basics.Address, data basics.AccountData) {
+			err = printer(addr, data, progress)
 			if err != nil {
 				return
 			}
-			defer rows.Close()
-
-			for rows.Next() {
-				var addrbuf []byte
-				var buf []byte
-				err = rows.Scan(&addrbuf, &buf)
-				if err != nil {
-					return
-				}
-
-				var addr basics.Address
-				if len(addrbuf) != len(addr) {
-					err = fmt.Errorf("account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
-					return
-				}
-				copy(addr[:], addrbuf)
-
-				var data basics.AccountData
-				err = protocol.Decode(buf, &data)
-				if err != nil {
-					return
-				}
-
-				err = printer(addr, data, progress)
-				if err != nil {
-					return
-				}
-
-				progress++
-			}
-			err = rows.Err()
-		} else {
-			acctCount := 0
-			acctCb := func(addr basics.Address, data basics.AccountData) {
-				err = printer(addr, data, progress)
-				if err != nil {
-					return
-				}
-				progress++
-				acctCount++
-			}
-			_, err = ledger.LoadAllFullAccounts(context.Background(), tx, balancesTable, resourcesTable, acctCb)
-			if err != nil {
-				return
-			}
-			if acctCount != int(rowsCount) {
-				return fmt.Errorf("expected %d accounts but got only %d", rowsCount, acctCount)
-			}
+			progress++
+			acctCount++
+		}
+		_, err = ledger.LoadAllFullAccounts(context.Background(), tx, balancesTable, resourcesTable, acctCb)
+		if err != nil {
+			return
+		}
+		if acctCount != int(rowsCount) {
+			return fmt.Errorf("expected %d accounts but got only %d", rowsCount, acctCount)
 		}
 
 		// increase the deadline warning to disable the warning message.
@@ -403,7 +367,7 @@ func printKeyValue(writer *bufio.Writer, key, value []byte) {
 	fmt.Fprintf(writer, "%s : %v\n", pretty, base64.StdEncoding.EncodeToString(value))
 }
 
-func printKeyValueStore(databaseName string, outFile *os.File) error {
+func printKeyValueStore(databaseName string, stagingTables bool, fileHeader ledger.CatchpointFileHeader, outFile *os.File) error {
 	fmt.Printf("\n")
 	printDumpingCatchpointProgressLine(0, 50, 0)
 	lastProgressUpdate := time.Now()
@@ -418,15 +382,20 @@ func printKeyValueStore(databaseName string, outFile *os.File) error {
 		return err
 	}
 
+	kvTable := "kvstore"
+	if stagingTables {
+		kvTable = "catchpointkvstore"
+	}
+
 	return dbAccessor.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 		var rowsCount int64
-		err := tx.QueryRow("SELECT count(*) from catchpointkvstore").Scan(&rowsCount)
+		err := tx.QueryRow(fmt.Sprintf("SELECT count(*) from %s", kvTable)).Scan(&rowsCount)
 		if err != nil {
 			return err
 		}
 
 		// ordered to make dumps more "diffable"
-		rows, err := tx.Query("SELECT key, value FROM catchpointkvstore order by key")
+		rows, err := tx.Query(fmt.Sprintf("SELECT key, value FROM %s order by key", kvTable))
 		if err != nil {
 			return err
 		}

--- a/cmd/catchpointdump/net.go
+++ b/cmd/catchpointdump/net.go
@@ -353,11 +353,11 @@ func loadAndDump(addr string, tarFile string, genesisInitState ledgercore.InitSt
 			return err
 		}
 		defer outFile.Close()
-		err = printAccountsDatabase("./ledger.tracker.sqlite", fileHeader, outFile, excludedFields.GetSlice())
+		err = printAccountsDatabase("./ledger.tracker.sqlite", true, fileHeader, outFile, excludedFields.GetSlice())
 		if err != nil {
 			return err
 		}
-		err = printKeyValueStore("./ledger.tracker.sqlite", outFile)
+		err = printKeyValueStore("./ledger.tracker.sqlite", true, fileHeader, outFile)
 		if err != nil {
 			return err
 		}

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -4720,6 +4720,7 @@ func LoadAllFullAccounts(
 		var data baseAccountData
 		err = protocol.Decode(buf, &data)
 		if err != nil {
+			fmt.Printf("\n\ngot protocol.Decode err in LoadAllFullAccounts %v\n\n", err)
 			return
 		}
 

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1846,9 +1846,10 @@ func compactKvDeltas(kvDeltas []map[string]ledgercore.KvValueDelta) map[string]m
 		return nil
 	}
 	outKvDeltas := make(map[string]modifiedKvValue)
-	for _, roundKv := range kvDeltas {
+	for i, roundKv := range kvDeltas {
 		for key, current := range roundKv {
 			prev, ok := outKvDeltas[key]
+			logging.Base().Infof("compactKvDeltas i %d saw key %v current %+v prev %+v ok %v", i, key, current, prev, ok)
 			if !ok { // Record only the first OldData
 				prev.oldData = current.OldData
 			}

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -1011,6 +1011,7 @@ func (ct *catchpointTracker) accountsUpdateBalances(accountsDeltas compactAccoun
 	}
 
 	for key, mv := range kvDeltas {
+		ct.log.Infof("kvDeltas oldBase %d newBase %d key %s data %s oldData %s ndeltas %d", oldBase, newBase, key, mv.data, mv.oldData, mv.ndeltas)
 		if mv.oldData == nil && mv.data == nil { // Came and went within the delta span
 			continue
 		}
@@ -1019,12 +1020,13 @@ func (ct *catchpointTracker) accountsUpdateBalances(accountsDeltas compactAccoun
 				continue // changed back within the delta span
 			}
 			deleteHash := kvHashBuilderV6(key, mv.oldData)
+			ct.log.Infof("Deleting kv hash %s oldBase %d newBase %d for key %s oldData %s", hex.EncodeToString(deleteHash), oldBase, newBase, key, mv.oldData)
 			deleted, err = ct.balancesTrie.Delete(deleteHash)
 			if err != nil {
-				return fmt.Errorf("failed to delete kv hash '%s' from merkle trie for key %v: %w", hex.EncodeToString(deleteHash), key, err)
+				return fmt.Errorf("failed to delete kv hash '%s' oldBase %d newBase %d from merkle trie for key %v: %w", hex.EncodeToString(deleteHash), oldBase, newBase, key, err)
 			}
 			if !deleted {
-				ct.log.Warnf("failed to delete kv hash '%s' from merkle trie for key %v", hex.EncodeToString(deleteHash), key)
+				ct.log.Warnf("failed to delete kv hash '%s' oldBase %d newBase %d from merkle trie for key %v", hex.EncodeToString(deleteHash), oldBase, newBase, key)
 			} else {
 				accumulatedChanges++
 			}
@@ -1032,12 +1034,13 @@ func (ct *catchpointTracker) accountsUpdateBalances(accountsDeltas compactAccoun
 
 		if mv.data != nil {
 			addHash := kvHashBuilderV6(key, mv.data)
+			ct.log.Infof("Adding kv hash %s oldBase %d newBase %d for key %s data %s", hex.EncodeToString(addHash), oldBase, newBase, key, mv.data)
 			added, err = ct.balancesTrie.Add(addHash)
 			if err != nil {
-				return fmt.Errorf("attempted to add duplicate kv hash '%s' from merkle trie for key %v: %w", hex.EncodeToString(addHash), key, err)
+				return fmt.Errorf("attempted to add duplicate kv hash '%s' oldBase %d newBase %d from merkle trie for key %v: %w", hex.EncodeToString(addHash), oldBase, newBase, key, err)
 			}
 			if !added {
-				ct.log.Warnf("attempted to add duplicate kv hash '%s' from merkle trie for key %v", hex.EncodeToString(addHash), key)
+				ct.log.Warnf("attempted to add duplicate kv hash '%s' oldBase %d newBase %d rom merkle trie for key %v", hex.EncodeToString(addHash), oldBase, newBase, key)
 			} else {
 				accumulatedChanges++
 			}

--- a/ledger/catchupaccessor.go
+++ b/ledger/catchupaccessor.go
@@ -833,7 +833,7 @@ func (c *catchpointCatchupAccessorImpl) VerifyCatchpoint(ctx context.Context, bl
 	catchpointLabelMaker := ledgercore.MakeCatchpointLabel(blockRound, blk.Digest(), balancesHash, totals)
 
 	if catchpointLabel != catchpointLabelMaker.String() {
-		return fmt.Errorf("catchpoint hash mismatch; expected %s, calculated %s", catchpointLabel, catchpointLabelMaker.String())
+		return fmt.Errorf("catchpoint hash mismatch; expected %s, calculated %s with balancesHash %s", catchpointLabel, catchpointLabelMaker.String(), balancesHash)
 	}
 	return nil
 }

--- a/ledger/internal/cow.go
+++ b/ledger/internal/cow.go
@@ -24,7 +24,9 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
+	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -131,7 +133,9 @@ func (cb *roundCowState) deltas() ledgercore.StateDelta {
 
 	// Populate old values by looking through parent
 	for key, value := range cb.mods.KvMods {
+		ai, rest, _ := logic.SplitBoxKey(key)
 		old, _, err := cb.lookupParent.kvGet(key) // Because of how boxes are prefetched, value will be cached
+		logging.Base().Infof("rcs.deltas() looked up oldData %v oldisnil %v for key %s ai %v rest %v value %v", old, old == nil, key, ai, rest, value)
 		if err != nil {
 			panic(fmt.Errorf("Error looking up %v : %w", key, err))
 		}


### PR DESCRIPTION
Illustrates a kludge for halting processing at a specified DB round in `ledger/tracker.go`.  This kind of one-off change is helpful when debugging a problem that requires freezing the database at a specific round.