### PR TITLE
ledger: move blockdb tests into a storage package (8 of N)

### DIFF
--- a/ledger/accountdb_test.go
+++ b/ledger/accountdb_test.go
@@ -148,8 +148,8 @@ func TestAccountDBInit(t *testing.T) {
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
-	dbs, _ := dbOpenTest(t, true)
-	setDbLogging(t, dbs)
+	dbs, _ := storetesting.DbOpenTest(t, true)
+	storetesting.SetDbLogging(t, dbs)
 	defer dbs.Close()
 
 	tx, err := dbs.Wdb.Handle.Begin()
@@ -209,8 +209,8 @@ func TestAccountDBRound(t *testing.T) {
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
-	dbs, _ := dbOpenTest(t, true)
-	setDbLogging(t, dbs)
+	dbs, _ := storetesting.DbOpenTest(t, true)
+	storetesting.SetDbLogging(t, dbs)
 	defer dbs.Close()
 
 	tx, err := dbs.Wdb.Handle.Begin()
@@ -365,8 +365,8 @@ func TestAccountDBInMemoryAcct(t *testing.T) {
 
 	for i, test := range tests {
 
-		dbs, _ := dbOpenTest(t, true)
-		setDbLogging(t, dbs)
+		dbs, _ := storetesting.DbOpenTest(t, true)
+		storetesting.SetDbLogging(t, dbs)
 		defer dbs.Close()
 
 		tx, err := dbs.Wdb.Handle.Begin()
@@ -437,8 +437,8 @@ func TestAccountDBInMemoryAcct(t *testing.T) {
 func TestAccountStorageWithStateProofID(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	dbs, _ := dbOpenTest(t, true)
-	setDbLogging(t, dbs)
+	dbs, _ := storetesting.DbOpenTest(t, true)
+	storetesting.SetDbLogging(t, dbs)
 	defer dbs.Close()
 
 	tx, err := dbs.Wdb.Handle.Begin()
@@ -651,8 +651,8 @@ func cleanupTestDb(dbs db.Pair, dbName string, inMemory bool) {
 }
 
 func benchmarkReadingAllBalances(b *testing.B, inMemory bool) {
-	dbs, fn := dbOpenTest(b, inMemory)
-	setDbLogging(b, dbs)
+	dbs, fn := storetesting.DbOpenTest(b, inMemory)
+	storetesting.SetDbLogging(b, dbs)
 	defer cleanupTestDb(dbs, fn, inMemory)
 
 	benchmarkInitBalances(b, b.N, dbs, protocol.ConsensusCurrentVersion)
@@ -682,8 +682,8 @@ func BenchmarkReadingAllBalancesDisk(b *testing.B) {
 }
 
 func benchmarkReadingRandomBalances(b *testing.B, inMemory bool) {
-	dbs, fn := dbOpenTest(b, inMemory)
-	setDbLogging(b, dbs)
+	dbs, fn := storetesting.DbOpenTest(b, inMemory)
+	storetesting.SetDbLogging(b, dbs)
 	defer cleanupTestDb(dbs, fn, inMemory)
 
 	accounts := benchmarkInitBalances(b, b.N, dbs, protocol.ConsensusCurrentVersion)
@@ -721,8 +721,8 @@ func BenchmarkWritingRandomBalancesDisk(b *testing.B) {
 	batchCount := 1000
 	startupAcct := 5
 	initDatabase := func() (*sql.Tx, func(), error) {
-		dbs, fn := dbOpenTest(b, false)
-		setDbLogging(b, dbs)
+		dbs, fn := storetesting.DbOpenTest(b, false)
+		storetesting.SetDbLogging(b, dbs)
 		cleanup := func() {
 			cleanupTestDb(dbs, fn, false)
 		}
@@ -963,8 +963,8 @@ func TestLookupKeysByPrefix(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	dbs, fn := dbOpenTest(t, false)
-	setDbLogging(t, dbs)
+	dbs, fn := storetesting.DbOpenTest(t, false)
+	storetesting.SetDbLogging(t, dbs)
 	defer cleanupTestDb(dbs, fn, false)
 
 	// return account data, initialize DB tables from AccountsInitTest
@@ -1144,8 +1144,8 @@ func TestLookupKeysByPrefix(t *testing.T) {
 func BenchmarkLookupKeyByPrefix(b *testing.B) {
 	// learn something from BenchmarkWritingRandomBalancesDisk
 
-	dbs, fn := dbOpenTest(b, false)
-	setDbLogging(b, dbs)
+	dbs, fn := storetesting.DbOpenTest(b, false)
+	storetesting.SetDbLogging(b, dbs)
 	defer cleanupTestDb(dbs, fn, false)
 
 	// return account data, initialize DB tables from AccountsInitTest
@@ -1422,8 +1422,8 @@ func TestCompactResourceDeltas(t *testing.T) {
 func TestLookupAccountAddressFromAddressID(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	dbs, _ := dbOpenTest(t, true)
-	setDbLogging(t, dbs)
+	dbs, _ := storetesting.DbOpenTest(t, true)
+	storetesting.SetDbLogging(t, dbs)
 	defer dbs.Close()
 
 	addrs := make([]basics.Address, 100)
@@ -2080,8 +2080,8 @@ func initBoxDatabase(b *testing.B, totalBoxes, boxSize int) (db.Pair, func(), er
 	}
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
-	dbs, fn := dbOpenTest(b, false)
-	setDbLogging(b, dbs)
+	dbs, fn := storetesting.DbOpenTest(b, false)
+	storetesting.SetDbLogging(b, dbs)
 	cleanup := func() {
 		cleanupTestDb(dbs, fn, false)
 	}
@@ -2219,8 +2219,8 @@ func TestAccountOnlineQueries(t *testing.T) {
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
-	dbs, _ := dbOpenTest(t, true)
-	setDbLogging(t, dbs)
+	dbs, _ := storetesting.DbOpenTest(t, true)
+	storetesting.SetDbLogging(t, dbs)
 	defer dbs.Close()
 
 	tx, err := dbs.Wdb.Handle.Begin()
@@ -2723,8 +2723,8 @@ func TestAccountOnlineAccountsNewRoundFlip(t *testing.T) {
 func TestAccountOnlineRoundParams(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	dbs, _ := dbOpenTest(t, true)
-	setDbLogging(t, dbs)
+	dbs, _ := storetesting.DbOpenTest(t, true)
+	storetesting.SetDbLogging(t, dbs)
 	defer dbs.Close()
 
 	tx, err := dbs.Wdb.Handle.Begin()
@@ -2776,8 +2776,8 @@ func TestAccountOnlineRoundParams(t *testing.T) {
 func TestOnlineAccountsDeletion(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	dbs, _ := dbOpenTest(t, true)
-	setDbLogging(t, dbs)
+	dbs, _ := storetesting.DbOpenTest(t, true)
+	storetesting.SetDbLogging(t, dbs)
 	defer dbs.Close()
 
 	tx, err := dbs.Wdb.Handle.Begin()

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/algorand/go-algorand/ledger/internal"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/ledger/store"
+	storetesting "github.com/algorand/go-algorand/ledger/store/testing"
 	ledgertesting "github.com/algorand/go-algorand/ledger/testing"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
@@ -93,7 +94,7 @@ func setupAccts(niter int) []map[basics.Address]basics.AccountData {
 }
 
 func makeMockLedgerForTrackerWithLogger(t testing.TB, inMemory bool, initialBlocksCount int, consensusVersion protocol.ConsensusVersion, accts []map[basics.Address]basics.AccountData, l logging.Logger) *mockLedgerForTracker {
-	dbs, fileName := dbOpenTest(t, inMemory)
+	dbs, fileName := storetesting.DbOpenTest(t, inMemory)
 	dbs.Rdb.SetLogger(l)
 	dbs.Wdb.SetLogger(l)
 
@@ -1149,8 +1150,8 @@ func TestListCreatables(t *testing.T) {
 	numElementsPerSegement := 25
 
 	// set up the database
-	dbs, _ := dbOpenTest(t, true)
-	setDbLogging(t, dbs)
+	dbs, _ := storetesting.DbOpenTest(t, true)
+	storetesting.SetDbLogging(t, dbs)
 	defer dbs.Close()
 
 	tx, err := dbs.Wdb.Handle.Begin()

--- a/ledger/blockqueue_test.go
+++ b/ledger/blockqueue_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	ledgertesting "github.com/algorand/go-algorand/ledger/testing"
@@ -33,6 +34,33 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
+
+func randomBlock(r basics.Round) blockEntry {
+	b := bookkeeping.Block{}
+	c := agreement.Certificate{}
+
+	b.BlockHeader.Round = r
+	b.BlockHeader.TimeStamp = int64(crypto.RandUint64())
+	b.RewardsPool = testPoolAddr
+	b.FeeSink = testSinkAddr
+	c.Round = r
+
+	return blockEntry{
+		block: b,
+		cert:  c,
+	}
+}
+
+func randomInitChain(proto protocol.ConsensusVersion, nblock int) []blockEntry {
+	res := make([]blockEntry, 0)
+	for i := 0; i < nblock; i++ {
+		blkent := randomBlock(basics.Round(i))
+		blkent.cert = agreement.Certificate{}
+		blkent.block.CurrentProtocol = proto
+		res = append(res, blkent)
+	}
+	return res
+}
 
 func TestPutBlockTooOld(t *testing.T) {
 	partitiontest.PartitionTest(t)

--- a/ledger/txtail_test.go
+++ b/ledger/txtail_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/ledger/store"
+	storetesting "github.com/algorand/go-algorand/ledger/store/testing"
 	ledgertesting "github.com/algorand/go-algorand/ledger/testing"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
@@ -148,8 +149,8 @@ func (t *txTailTestLedger) Block(r basics.Round) (bookkeeping.Block, error) {
 func (t *txTailTestLedger) initialize(ts *testing.T, protoVersion protocol.ConsensusVersion) error {
 	// create a corresponding blockdb.
 	inMemory := true
-	t.blockDBs, _ = dbOpenTest(ts, inMemory)
-	t.trackerDBs, _ = dbOpenTest(ts, inMemory)
+	t.blockDBs, _ = storetesting.DbOpenTest(ts, inMemory)
+	t.trackerDBs, _ = storetesting.DbOpenTest(ts, inMemory)
 	t.protoVersion = protoVersion
 
 	tx, err := t.trackerDBs.Wdb.Handle.Begin()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

This PR moves a left over test file to `blockdb`. 

**Previous parts of this refactor:**
- part 1 - #4776
- part 2 - #4813
- part 3 - #4830
- part 4 - #4835
- part 5 - #4836 
- part 6 - #4841 
- part 7 - #4846 

**What remains to be moved out:**
- [x] setup stuff
    - [x] table/index creations
    - [x] table deletions
    - [x] migrations
- [ ] iterators
    - [ ] `orderedAccountsIter`
    - [ ] `catchpointPendingHashesIterator`
- [ ] deltas
    - [ ] `accountsLoadOld` and `resourcesLoadOld` have a couple queries that we might want to move out to avoid pulling all the deltas into store

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Existing tests.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
