### PR TITLE
refactor: accountdb.go into a store package (9 of N)

### DIFF
--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -317,7 +317,7 @@ func (a *compactResourcesDeltas) resourcesLoadOld(tx *sql.Tx, knownAddresses map
 		if delta.oldResource.Addrid != 0 {
 			addrid = delta.oldResource.Addrid
 		} else if addrid, ok = knownAddresses[addr]; !ok {
-			addrid, err = arw.LookupAccountRowId(addr)
+			addrid, err = arw.LookupAccountRowID(addr)
 			if err != nil {
 				if err != sql.ErrNoRows {
 					err = fmt.Errorf("base account cannot be read while processing resource for addr=%s, aidx=%d: %w", addr.String(), aidx, err)
@@ -330,7 +330,7 @@ func (a *compactResourcesDeltas) resourcesLoadOld(tx *sql.Tx, knownAddresses map
 				continue
 			}
 		}
-		resDataBuf, err = arw.LookupResourceDataByAddrId(addrid, aidx)
+		resDataBuf, err = arw.LookupResourceDataByAddrID(addrid, aidx)
 		switch err {
 		case nil:
 			if len(resDataBuf) > 0 {
@@ -624,7 +624,6 @@ func (a *compactOnlineAccountDeltas) accountsLoadOld(tx *sql.Tx) (err error) {
 		case sql.ErrNoRows:
 			// we don't have that account, just return an empty record.
 			a.updateOld(idx, store.PersistedOnlineAccountData{Addr: addr})
-			err = nil
 		default:
 			// unexpected error - let the caller know that we couldn't complete the operation.
 			return err

--- a/ledger/accountdb.go
+++ b/ledger/accountdb.go
@@ -301,17 +301,7 @@ func (a *compactResourcesDeltas) resourcesLoadOld(tx *sql.Tx, knownAddresses map
 	if len(a.misses) == 0 {
 		return nil
 	}
-	selectStmt, err := tx.Prepare("SELECT data FROM resources WHERE addrid = ? AND aidx = ?")
-	if err != nil {
-		return
-	}
-	defer selectStmt.Close()
-
-	addrRowidStmt, err := tx.Prepare("SELECT rowid FROM accountbase WHERE address=?")
-	if err != nil {
-		return
-	}
-	defer addrRowidStmt.Close()
+	arw := store.NewAccountsSQLReaderWriter(tx)
 
 	defer func() {
 		a.misses = nil
@@ -327,7 +317,7 @@ func (a *compactResourcesDeltas) resourcesLoadOld(tx *sql.Tx, knownAddresses map
 		if delta.oldResource.Addrid != 0 {
 			addrid = delta.oldResource.Addrid
 		} else if addrid, ok = knownAddresses[addr]; !ok {
-			err = addrRowidStmt.QueryRow(addr[:]).Scan(&addrid)
+			addrid, err = arw.LookupAccountRowId(addr)
 			if err != nil {
 				if err != sql.ErrNoRows {
 					err = fmt.Errorf("base account cannot be read while processing resource for addr=%s, aidx=%d: %w", addr.String(), aidx, err)
@@ -340,8 +330,7 @@ func (a *compactResourcesDeltas) resourcesLoadOld(tx *sql.Tx, knownAddresses map
 				continue
 			}
 		}
-		resDataBuf = nil
-		err = selectStmt.QueryRow(addrid, aidx).Scan(&resDataBuf)
+		resDataBuf, err = arw.LookupResourceDataByAddrId(addrid, aidx)
 		switch err {
 		case nil:
 			if len(resDataBuf) > 0 {
@@ -476,23 +465,17 @@ func (a *compactAccountDeltas) accountsLoadOld(tx *sql.Tx) (err error) {
 	if len(a.misses) == 0 {
 		return nil
 	}
-	selectStmt, err := tx.Prepare("SELECT rowid, data FROM accountbase WHERE address=?")
-	if err != nil {
-		return
-	}
-	defer selectStmt.Close()
+	arw := store.NewAccountsSQLReaderWriter(tx)
 	defer func() {
 		a.misses = nil
 	}()
-	var rowid sql.NullInt64
-	var acctDataBuf []byte
 	for _, idx := range a.misses {
 		addr := a.deltas[idx].address
-		err = selectStmt.QueryRow(addr[:]).Scan(&rowid, &acctDataBuf)
+		rowid, acctDataBuf, err := arw.LookupAccountDataByAddress(addr)
 		switch err {
 		case nil:
 			if len(acctDataBuf) > 0 {
-				persistedAcctData := &store.PersistedAccountData{Addr: addr, Rowid: rowid.Int64}
+				persistedAcctData := &store.PersistedAccountData{Addr: addr, Rowid: rowid}
 				err = protocol.Decode(acctDataBuf, &persistedAcctData.AccountData)
 				if err != nil {
 					return err
@@ -500,7 +483,7 @@ func (a *compactAccountDeltas) accountsLoadOld(tx *sql.Tx) (err error) {
 				a.updateOld(idx, *persistedAcctData)
 			} else {
 				// to retain backward compatibility, we will treat this condition as if we don't have the account.
-				a.updateOld(idx, store.PersistedAccountData{Addr: addr, Rowid: rowid.Int64})
+				a.updateOld(idx, store.PersistedAccountData{Addr: addr, Rowid: rowid})
 			}
 		case sql.ErrNoRows:
 			// we don't have that account, just return an empty record.
@@ -618,24 +601,17 @@ func (a *compactOnlineAccountDeltas) accountsLoadOld(tx *sql.Tx) (err error) {
 	if len(a.misses) == 0 {
 		return nil
 	}
-	// fetch the latest entry
-	selectStmt, err := tx.Prepare("SELECT rowid, data FROM onlineaccounts WHERE address=? ORDER BY updround DESC LIMIT 1")
-	if err != nil {
-		return
-	}
-	defer selectStmt.Close()
+	arw := store.NewAccountsSQLReaderWriter(tx)
 	defer func() {
 		a.misses = nil
 	}()
-	var rowid sql.NullInt64
-	var acctDataBuf []byte
 	for _, idx := range a.misses {
 		addr := a.deltas[idx].address
-		err = selectStmt.QueryRow(addr[:]).Scan(&rowid, &acctDataBuf)
+		rowid, acctDataBuf, err := arw.LookupOnlineAccountDataByAddress(addr)
 		switch err {
 		case nil:
 			if len(acctDataBuf) > 0 {
-				persistedAcctData := &store.PersistedOnlineAccountData{Addr: addr, Rowid: rowid.Int64}
+				persistedAcctData := &store.PersistedOnlineAccountData{Addr: addr, Rowid: rowid}
 				err = protocol.Decode(acctDataBuf, &persistedAcctData.AccountData)
 				if err != nil {
 					return err
@@ -643,7 +619,7 @@ func (a *compactOnlineAccountDeltas) accountsLoadOld(tx *sql.Tx) (err error) {
 				a.updateOld(idx, *persistedAcctData)
 			} else {
 				// empty data means offline account
-				a.updateOld(idx, store.PersistedOnlineAccountData{Addr: addr, Rowid: rowid.Int64})
+				a.updateOld(idx, store.PersistedOnlineAccountData{Addr: addr, Rowid: rowid})
 			}
 		case sql.ErrNoRows:
 			// we don't have that account, just return an empty record.

--- a/ledger/store/accountsV2.go
+++ b/ledger/store/accountsV2.go
@@ -53,7 +53,7 @@ func NewAccountsSQLReaderWriter(e db.Executable) *accountsV2ReaderWriter {
 	}
 }
 
-func (r *accountsV2Reader) get_or_prepare(key string, queryString string) (stmt *sql.Stmt, err error) {
+func (r *accountsV2Reader) getOrPrepare(key string, queryString string) (stmt *sql.Stmt, err error) {
 	// fetch statement
 	if stmt, ok := r.preparedStatements[key]; ok {
 		return stmt, nil
@@ -288,7 +288,7 @@ func (r *accountsV2Reader) LookupAccountAddressFromAddressID(ctx context.Context
 
 func (r *accountsV2Reader) LookupAccountDataByAddress(addr basics.Address) (rowid int64, data []byte, err error) {
 	// optimize this query for repeated usage
-	selectStmt, err := r.get_or_prepare("LookupAccountDataByAddress", "SELECT rowid, data FROM accountbase WHERE address=?")
+	selectStmt, err := r.getOrPrepare("LookupAccountDataByAddress", "SELECT rowid, data FROM accountbase WHERE address=?")
 	if err != nil {
 		return
 	}
@@ -300,9 +300,10 @@ func (r *accountsV2Reader) LookupAccountDataByAddress(addr basics.Address) (rowi
 	return rowid, data, err
 }
 
+// LookupOnlineAccountDataByAddress looks up online account data by address.
 func (r *accountsV2Reader) LookupOnlineAccountDataByAddress(addr basics.Address) (rowid int64, data []byte, err error) {
 	// optimize this query for repeated usage
-	selectStmt, err := r.get_or_prepare(
+	selectStmt, err := r.getOrPrepare(
 		"LookupOnlineAccountDataByAddress",
 		"SELECT rowid, data FROM onlineaccounts WHERE address=? ORDER BY updround DESC LIMIT 1",
 	)
@@ -317,9 +318,10 @@ func (r *accountsV2Reader) LookupOnlineAccountDataByAddress(addr basics.Address)
 	return rowid, data, err
 }
 
-func (r *accountsV2Reader) LookupAccountRowId(addr basics.Address) (rowid int64, err error) {
+// LookupAccountRowID looks up the rowid of an account based on its address.
+func (r *accountsV2Reader) LookupAccountRowID(addr basics.Address) (rowid int64, err error) {
 	// optimize this query for repeated usage
-	addrRowidStmt, err := r.get_or_prepare("LookupAccountRowId", "SELECT rowid FROM accountbase WHERE address=?")
+	addrRowidStmt, err := r.getOrPrepare("LookupAccountRowId", "SELECT rowid FROM accountbase WHERE address=?")
 	if err != nil {
 		return
 	}
@@ -331,9 +333,10 @@ func (r *accountsV2Reader) LookupAccountRowId(addr basics.Address) (rowid int64,
 	return rowid, err
 }
 
-func (r *accountsV2Reader) LookupResourceDataByAddrId(addrid int64, aidx basics.CreatableIndex) (data []byte, err error) {
+// LookupResourceDataByAddrID looks up the resource data by account rowid + resource aidx.
+func (r *accountsV2Reader) LookupResourceDataByAddrID(addrid int64, aidx basics.CreatableIndex) (data []byte, err error) {
 	// optimize this query for repeated usage
-	selectStmt, err := r.get_or_prepare("LookupResourceDataByAddrId", "SELECT data FROM resources WHERE addrid = ? AND aidx = ?")
+	selectStmt, err := r.getOrPrepare("LookupResourceDataByAddrId", "SELECT data FROM resources WHERE addrid = ? AND aidx = ?")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

This PR creates a few more methods needed by the deltas.

**Previous parts of this refactor:**
- part 1 - #4776
- part 2 - #4813
- part 3 - #4830
- part 4 - #4835
- part 5 - #4836 
- part 6 - #4841 
- part 7 - #4846 
- part 8 - #4860 

**What remains to be moved out:**
- [ ] iterators
    - [ ] `orderedAccountsIter`
    - [ ] `catchpointPendingHashesIterator`
- [x] deltas
    - [x] `accountsLoadOld` and `resourcesLoadOld` have a couple queries that we might want to move out to avoid pulling all the deltas into store

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Existing tests.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
