### PR TITLE
Confirm make generate fails with stale changes

### DIFF
--- a/scripts/travis/codegen_verification.sh
+++ b/scripts/travis/codegen_verification.sh
@@ -33,8 +33,8 @@ echo "Running check_license..."
 echo "Rebuild swagger.json files"
 make rebuild_swagger
 
-echo "Regenerate config files"
-go generate ./config
+echo "Regenerate for stringer et el."
+make generate
 
 echo "Running fixcheck"
 GOPATH=$(go env GOPATH)


### PR DESCRIPTION
Confirms https://github.com/algorand/go-algorand/pull/4865 fails with stale generated source changes.  Will close once codegen verification fails.