### PR TITLE
Goal: Test ABI reference arguments during creation

### DIFF
--- a/test/scripts/e2e_subs/e2e-app-abi-method.sh
+++ b/test/scripts/e2e_subs/e2e-app-abi-method.sh
@@ -79,7 +79,7 @@ if [[ $RES != *"${EXPECTED}"* ]]; then
     false
 fi
 
-# Foreign reference test
+# Foreign reference test during non-creation call. A creation test is further down.
 RES=$(${gcmd} app method --method "referenceTest(account,application,account,asset,account,asset,asset,application,application)uint8[9]" --arg KGTOR3F3Q74JP4LB5M3SOCSJ4BOPOKZ2GPSLMLLGCWYWRXZJNN4LYQJXXU --arg $APPID --arg $ACCOUNT --arg 10 --arg KGTOR3F3Q74JP4LB5M3SOCSJ4BOPOKZ2GPSLMLLGCWYWRXZJNN4LYQJXXU --arg 11 --arg 10 --arg 20 --arg 21 --app-account 2R5LMPTYLVMWYEG4RPI26PJAM7ARTGUB7LZSONQPGLUWTPOP6LQCJTQZVE --foreign-app 21 --foreign-asset 10 --app-id $APPID --from $ACCOUNT 2>&1 || true)
 EXPECTED="method referenceTest(account,application,account,asset,account,asset,asset,application,application)uint8[9] succeeded with output: [2,0,2,0,2,1,0,1,0]"
 if [[ $RES != *"${EXPECTED}"* ]]; then
@@ -108,5 +108,13 @@ RES=$(${gcmd} app method --method "delete()void" --on-completion deleteapplicati
 EXPECTED="method delete()void succeeded"
 if [[ $RES != *"${EXPECTED}"* ]]; then
     date '+app-abi-method-test FAIL the method call to delete()void should not fail %Y%m%d_%H%M%S'
+    false
+fi
+
+# Foreign reference test during creation
+RES=$(${gcmd} app method --create --approval-prog ${DIR}/tealprogs/app-abi-method-example.teal --clear-prog ${TEMPDIR}/simple-v2.teal --global-byteslices 0 --global-ints 0 --local-byteslices 1 --local-ints 0 --extra-pages 0 --on-completion deleteapplication --method "referenceTest(account,application,account,asset,account,asset,asset,application,application)uint8[9]" --arg KGTOR3F3Q74JP4LB5M3SOCSJ4BOPOKZ2GPSLMLLGCWYWRXZJNN4LYQJXXU --arg 0 --arg $ACCOUNT --arg 10 --arg KGTOR3F3Q74JP4LB5M3SOCSJ4BOPOKZ2GPSLMLLGCWYWRXZJNN4LYQJXXU --arg 11 --arg 10 --arg 20 --arg 21 --app-account 2R5LMPTYLVMWYEG4RPI26PJAM7ARTGUB7LZSONQPGLUWTPOP6LQCJTQZVE --foreign-app 21 --foreign-asset 10 --from $ACCOUNT 2>&1 || true)
+EXPECTED="method referenceTest(account,application,account,asset,account,asset,asset,application,application)uint8[9] succeeded with output: [2,0,2,0,2,1,0,1,0]"
+if [[ $RES != *"${EXPECTED}"* ]]; then
+    date '+app-abi-method-test FAIL the creation method call to referenceTest(account,application,account,asset,account,asset,asset,application,application)uint8[9] should not fail %Y%m%d_%H%M%S'
     false
 fi

--- a/test/scripts/e2e_subs/tealprogs/app-abi-method-example.teal
+++ b/test/scripts/e2e_subs/tealprogs/app-abi-method-example.teal
@@ -1,154 +1,313 @@
-// generated from https://gist.github.com/jasonpaulos/99e4f8a75f2fc2ec9b8073c064530359/b4d37519ccc67383042b6c0fb8b7b26a2e538738
+// generated from https://gist.github.com/jasonpaulos/99e4f8a75f2fc2ec9b8073c064530359/bf36d82afaea0e5974fa172415153e77c3b5d42a
 #pragma version 5
-txn ApplicationID
+txn NumAppArgs
 int 0
 ==
+bnz main_l20
+txna ApplicationArgs 0
+method "create(uint64)uint64"
+==
+bnz main_l19
+txna ApplicationArgs 0
+method "update()void"
+==
 bnz main_l18
-txn OnCompletion
-int UpdateApplication
-==
 txna ApplicationArgs 0
-byte 0xa0e81872
+method "optIn(string)string"
 ==
-&&
 bnz main_l17
-txn OnCompletion
-int OptIn
-==
 txna ApplicationArgs 0
-byte 0xcfa68e36
+method "closeOut()string"
 ==
-&&
 bnz main_l16
-txn OnCompletion
-int CloseOut
-==
 txna ApplicationArgs 0
-byte 0xa9f42b3d
+method "delete()void"
 ==
-&&
 bnz main_l15
+txna ApplicationArgs 0
+method "add(uint64,uint64)uint64"
+==
+bnz main_l14
+txna ApplicationArgs 0
+method "empty()void"
+==
+bnz main_l13
+txna ApplicationArgs 0
+method "payment(pay,uint64)bool"
+==
+bnz main_l12
+txna ApplicationArgs 0
+method "referenceTest(account,application,account,asset,account,asset,asset,application,application)uint8[9]"
+==
+bnz main_l11
+err
+main_l11:
+txn OnCompletion
+int NoOp
+==
 txn OnCompletion
 int DeleteApplication
 ==
-txna ApplicationArgs 0
-byte 0x24378d3c
-==
-&&
-bnz main_l14
-txn OnCompletion
-int NoOp
-==
-txna ApplicationArgs 0
-byte 0xfe6bdf69
-==
-&&
-bnz main_l13
-txn OnCompletion
-int NoOp
-==
-txna ApplicationArgs 0
-byte 0xa88c26a5
-==
-&&
-bnz main_l12
-txn OnCompletion
-int NoOp
-==
-txna ApplicationArgs 0
-byte 0x3e3b3d28
-==
-&&
-bnz main_l11
-txn OnCompletion
-int NoOp
-==
-txna ApplicationArgs 0
-byte 0x0df0050f
-==
-&&
-bnz main_l10
+txn ApplicationID
 int 0
-return
-main_l10:
+==
+&&
+||
+assert
 txna ApplicationArgs 1
+int 0
+getbyte
+store 13
 txna ApplicationArgs 2
+int 0
+getbyte
+store 14
 txna ApplicationArgs 3
+int 0
+getbyte
+store 15
 txna ApplicationArgs 4
+int 0
+getbyte
+store 16
 txna ApplicationArgs 5
+int 0
+getbyte
+store 17
 txna ApplicationArgs 6
+int 0
+getbyte
+store 18
 txna ApplicationArgs 7
+int 0
+getbyte
+store 19
 txna ApplicationArgs 8
+int 0
+getbyte
+store 20
 txna ApplicationArgs 9
-callsub sub8
-int 1
-return
-main_l11:
-txna ApplicationArgs 1
-callsub sub7
+int 0
+getbyte
+store 21
+load 13
+load 14
+load 15
+load 16
+load 17
+load 18
+load 19
+load 20
+load 21
+callsub referenceTest_8
+store 22
+byte 0x151f7c75
+load 22
+concat
+log
 int 1
 return
 main_l12:
-callsub sub6
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+btoi
+store 10
+txn GroupIndex
+int 1
+-
+store 9
+load 9
+gtxns TypeEnum
+int pay
+==
+assert
+load 9
+load 10
+callsub payment_7
+store 11
+byte 0x151f7c75
+byte 0x00
+int 0
+load 11
+setbit
+concat
+log
 int 1
 return
 main_l13:
-txna ApplicationArgs 1
-txna ApplicationArgs 2
-callsub sub5
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+callsub empty_6
 int 1
 return
 main_l14:
-callsub sub4
-int 1
-return
-main_l15:
-callsub sub3
-int 1
-return
-main_l16:
-txna ApplicationArgs 1
-callsub sub2
-int 1
-return
-main_l17:
-callsub sub1
-int 1
-return
-main_l18:
-txn NumAppArgs
-int 0
->
-bnz main_l20
-main_l19:
-int 1
-return
-main_l20:
-txna ApplicationArgs 0
-byte 0x43464101
+txn OnCompletion
+int NoOp
 ==
+txn ApplicationID
+int 0
+!=
+&&
 assert
 txna ApplicationArgs 1
-callsub sub0
-b main_l19
-sub0: // create
-store 0
-byte 0x151f7c75
-load 0
 btoi
-int 2
-*
+store 6
+txna ApplicationArgs 2
+btoi
+store 7
+load 6
+load 7
+callsub add_5
+store 8
+byte 0x151f7c75
+load 8
 itob
 concat
 log
-retsub
-sub1: // update
-retsub
-sub2: // optIn
+int 1
+return
+main_l15:
+txn OnCompletion
+int DeleteApplication
+==
+assert
+callsub delete_4
+int 1
+return
+main_l16:
+txn OnCompletion
+int CloseOut
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+callsub closeOut_3
+store 4
+byte 0x151f7c75
+load 4
+concat
+log
+int 1
+return
+main_l17:
+txn OnCompletion
+int OptIn
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+callsub optIn_2
 store 1
+byte 0x151f7c75
+load 1
+concat
+log
+int 1
+return
+main_l18:
+txn OnCompletion
+int UpdateApplication
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+callsub update_1
+int 1
+return
+main_l19:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+==
+&&
+txn OnCompletion
+int OptIn
+==
+txn ApplicationID
+int 0
+==
+&&
+||
+txn OnCompletion
+int UpdateApplication
+==
+txn ApplicationID
+int 0
+==
+&&
+||
+txn OnCompletion
+int DeleteApplication
+==
+txn ApplicationID
+int 0
+==
+&&
+||
+assert
+txna ApplicationArgs 1
+btoi
+callsub create_0
+store 0
+byte 0x151f7c75
+load 0
+itob
+concat
+log
+int 1
+return
+main_l20:
+txn OnCompletion
+int NoOp
+==
+bnz main_l22
+err
+main_l22:
+txn ApplicationID
+int 0
+==
+assert
+int 1
+return
+
+// create
+create_0:
+int 2
+*
+retsub
+
+// update
+update_1:
+retsub
+
+// optIn
+optIn_2:
+store 2
 int 0
 byte "name"
-load 1
+load 2
 extract 2 0
 app_local_put
 byte "hello "
@@ -156,111 +315,169 @@ int 0
 byte "name"
 app_local_get
 concat
-store 2
-byte 0x151f7c75
-load 2
+store 3
+load 3
 len
 itob
-extract 6 2
+extract 6 0
+load 3
 concat
-load 2
-concat
-log
+store 3
+load 3
 retsub
-sub3: // closeOut
+
+// closeOut
+closeOut_3:
 byte "goodbye "
 int 0
 byte "name"
 app_local_get
 concat
-store 3
-byte 0x151f7c75
-load 3
+store 5
+load 5
 len
 itob
-extract 6 2
+extract 6 0
+load 5
 concat
-load 3
-concat
-log
+store 5
+load 5
 retsub
-sub4: // deleteApp
+
+// delete
+delete_4:
 txn Sender
 global CreatorAddress
 ==
 assert
 retsub
-sub5: // add
-store 5
-store 4
-byte 0x151f7c75
-load 4
-btoi
-load 5
-btoi
+
+// add
+add_5:
 +
-itob
-concat
-log
 retsub
-sub6: // empty
+
+// empty
+empty_6:
 byte "random inconsequential log"
 log
 retsub
-sub7: // payment
-store 6
-txn GroupIndex
-int 1
--
-gtxns TypeEnum
-int pay
-==
-assert
-byte 0x151f7c75
-txn GroupIndex
-int 1
--
-gtxns Amount
-load 6
-btoi
-==
-bnz sub7_l2
-byte 0x00
-b sub7_l3
-sub7_l2:
-byte 0x80
-sub7_l3:
-concat
-log
-retsub
-sub8: // referenceTest
-store 15
-store 14
-store 13
+
+// payment
+payment_7:
 store 12
-store 11
-store 10
-store 9
-store 8
-store 7
-byte 0x151f7c75
-load 7
-concat
-load 9
-concat
-load 11
-concat
-load 8
-concat
-load 14
-concat
-load 15
-concat
-load 10
-concat
+gtxns Amount
 load 12
+==
+!
+!
+retsub
+
+// referenceTest
+referenceTest_8:
+store 30
+store 29
+store 28
+store 27
+store 26
+store 25
+store 24
+store 23
+store 31
+load 31
+int 256
+<
+assert
+load 24
+store 32
+load 32
+int 256
+<
+assert
+load 26
+store 33
+load 33
+int 256
+<
+assert
+load 23
+store 34
+load 34
+int 256
+<
+assert
+load 29
+store 35
+load 35
+int 256
+<
+assert
+load 30
+store 36
+load 36
+int 256
+<
+assert
+load 25
+store 37
+load 37
+int 256
+<
+assert
+load 27
+store 38
+load 38
+int 256
+<
+assert
+load 28
+store 39
+load 39
+int 256
+<
+assert
+byte 0x00
+int 0
+load 31
+setbyte
+byte 0x00
+int 0
+load 32
+setbyte
 concat
-load 13
+byte 0x00
+int 0
+load 33
+setbyte
 concat
-log
+byte 0x00
+int 0
+load 34
+setbyte
+concat
+byte 0x00
+int 0
+load 35
+setbyte
+concat
+byte 0x00
+int 0
+load 36
+setbyte
+concat
+byte 0x00
+int 0
+load 37
+setbyte
+concat
+byte 0x00
+int 0
+load 38
+setbyte
+concat
+byte 0x00
+int 0
+load 39
+setbyte
+concat
 retsub


### PR DESCRIPTION
## Summary

This PR adds a new e2e test to cover calling an ABI method with reference types during an application creation.

Due to the bug pointed out in https://github.com/algorand/py-algorand-sdk/pull/406, we want increase coverage for that scenario in goal and the SDKs.

As part of this work, I also updated the PyTeal contract at https://gist.github.com/jasonpaulos/99e4f8a75f2fc2ec9b8073c064530359 to use the ABI router, since the prior contract did not perfectly follow ARC-4 routing rules. This caused the changes in `test/scripts/e2e_subs/tealprogs/app-abi-method-example.teal`.

## Test Plan

New test added
