### PR TITLE
txHandler: disable canonical hashmap by default

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -586,7 +586,7 @@ func TestLocal_TxFiltering(t *testing.T) {
 
 	// ensure the default
 	require.True(t, cfg.TxFilterRawMsgEnabled())
-	require.True(t, cfg.TxFilterCanonicalEnabled())
+	require.False(t, cfg.TxFilterCanonicalEnabled())
 
 	cfg.TxIncomingFilteringFlags = 0
 	require.False(t, cfg.TxFilterRawMsgEnabled())

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -466,7 +466,7 @@ type Local struct {
 	// 0x00 - disabled
 	// 0x01 (txFilterRawMsg) - check for raw tx message duplicates
 	// 0x02 (txFilterCanonical) - check for canonical tx group duplicates
-	TxIncomingFilteringFlags uint32 `version[26]:"3"`
+	TxIncomingFilteringFlags uint32 `version[26]:"1"`
 }
 
 // DNSBootstrapArray returns an array of one or more DNS Bootstrap identifiers

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -119,7 +119,7 @@ var defaultLocal = Local{
 	TelemetryToLog:                             true,
 	TransactionSyncDataExchangeRate:            0,
 	TransactionSyncSignificantMessageThreshold: 0,
-	TxIncomingFilteringFlags:                   3,
+	TxIncomingFilteringFlags:                   1,
 	TxPoolExponentialIncreaseFactor:            2,
 	TxPoolSize:                                 75000,
 	TxSyncIntervalSeconds:                      60,

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -935,6 +935,7 @@ func TestTxHandlerProcessIncomingCacheTxPoolDrop(t *testing.T) {
 	const inMem = true
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
+	cfg.TxIncomingFilteringFlags = 3 // txFilterRawMsg + txFilterCanonical
 	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, nil, cfg)
 	require.NoError(t, err)
 

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -98,7 +98,7 @@
     "TelemetryToLog": true,
     "TransactionSyncDataExchangeRate": 0,
     "TransactionSyncSignificantMessageThreshold": 0,
-    "TxIncomingFilteringFlags": 3,
+    "TxIncomingFilteringFlags": 1,
     "TxPoolExponentialIncreaseFactor": 2,
     "TxPoolSize": 75000,
     "TxSyncIntervalSeconds": 60,

--- a/test/testdata/configs/config-v26.json
+++ b/test/testdata/configs/config-v26.json
@@ -98,7 +98,7 @@
     "TelemetryToLog": true,
     "TransactionSyncDataExchangeRate": 0,
     "TransactionSyncSignificantMessageThreshold": 0,
-    "TxIncomingFilteringFlags": 3,
+    "TxIncomingFilteringFlags": 1,
     "TxPoolExponentialIncreaseFactor": 2,
     "TxPoolSize": 75000,
     "TxSyncIntervalSeconds": 60,


### PR DESCRIPTION
## Summary

Disabled the second level check after performance concerns and TX vs agreement messages processing competition.

## Test Plan

Existing tests