### PR TITLE
metrics: fix TestGetValue

### DIFF
--- a/util/metrics/counter_test.go
+++ b/util/metrics/counter_test.go
@@ -203,6 +203,8 @@ func TestGetValue(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	c := MakeCounter(MetricName{Name: "testname", Description: "testhelp"})
+	c.Deregister(nil)
+
 	require.Equal(t, uint64(0), c.GetUint64Value())
 	c.Inc(nil)
 	require.Equal(t, uint64(1), c.GetUint64Value())


### PR DESCRIPTION
## Summary

TestGetValue registers a new metric that breaks other tests expectations on number of metrics. This might not be caught be CI because of sharding.

## Test Plan

This is a test fix.