### PR TITLE
adding version to langspec

### DIFF
--- a/cmd/opdoc/opdoc.go
+++ b/cmd/opdoc/opdoc.go
@@ -248,6 +248,7 @@ type OpRecord struct {
 	Doc           string
 	DocExtra      string `json:",omitempty"`
 	ImmediateNote string `json:",omitempty"`
+	Version       int
 	Groups        []string
 }
 
@@ -332,6 +333,7 @@ func buildLanguageSpec(opGroups map[string][]string) *LanguageSpec {
 		records[i].DocExtra = logic.OpDocExtra(spec.Name)
 		records[i].ImmediateNote = logic.OpImmediateNote(spec.Name)
 		records[i].Groups = opGroups[spec.Name]
+		records[i].Version = int(spec.Version)
 	}
 	return &LanguageSpec{
 		EvalMaxVersion:  docVersion,


### PR DESCRIPTION
For tooling purposes, it'd be nice to have the version a given op was introduced in the `langspec.json` file.

The cost would be nice too but no easy way to add that as far as I can tell given some ops depend on version and input size.