### PR TITLE
refactor: accountdb.go into a store package (11 of N) 

### DIFF
--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -1431,15 +1431,13 @@ func (ct *catchpointTracker) initializeHashes(ctx context.Context, tx *sql.Tx, r
 
 		// Now add the kvstore hashes
 		pendingTrieHashes = 0
-		kvs, err := tx.QueryContext(ctx, "SELECT key, value FROM kvstore")
+		kvs, err := store.MakeKVsIter(ctx, tx)
 		if err != nil {
 			return err
 		}
 		defer kvs.Close()
 		for kvs.Next() {
-			var k []byte
-			var v []byte
-			err := kvs.Scan(&k, &v)
+			k, v, err := kvs.KeyValue()
 			if err != nil {
 				return err
 			}

--- a/ledger/catchpointwriter.go
+++ b/ledger/catchpointwriter.go
@@ -61,7 +61,13 @@ type catchpointWriter struct {
 	accountsIterator     accountsBatchIter
 	maxResourcesPerChunk int
 	accountsDone         bool
-	kvRows               *sql.Rows
+	kvRows               kvIter
+}
+
+type kvIter interface {
+	Next() bool
+	KeyValue() ([]byte, []byte, error)
+	Close()
 }
 
 type accountsBatchIter interface {
@@ -280,7 +286,7 @@ func (cw *catchpointWriter) readDatabaseStep(ctx context.Context, tx *sql.Tx) er
 
 	// Create the *Rows iterator JIT
 	if cw.kvRows == nil {
-		rows, err := tx.QueryContext(ctx, "SELECT key, value FROM kvstore")
+		rows, err := store.MakeKVsIter(ctx, tx)
 		if err != nil {
 			return err
 		}
@@ -289,9 +295,7 @@ func (cw *catchpointWriter) readDatabaseStep(ctx context.Context, tx *sql.Tx) er
 
 	kvrs := make([]encoded.KVRecordV6, 0, BalancesPerCatchpointFileChunk)
 	for cw.kvRows.Next() {
-		var k []byte
-		var v []byte
-		err := cw.kvRows.Scan(&k, &v)
+		k, v, err := cw.kvRows.KeyValue()
 		if err != nil {
 			return err
 		}

--- a/ledger/store/kvsIter.go
+++ b/ledger/store/kvsIter.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package store
+
+import (
+	"context"
+	"database/sql"
+)
+
+type kvsIter struct {
+	tx   *sql.Tx
+	rows *sql.Rows
+}
+
+// MakeKVsIter creates a KV iterator.
+func MakeKVsIter(ctx context.Context, tx *sql.Tx) (*kvsIter, error) {
+	rows, err := tx.QueryContext(ctx, "SELECT key, value FROM kvstore")
+	if err != nil {
+		return nil, err
+	}
+
+	return &kvsIter{
+		tx:   tx,
+		rows: rows,
+	}, nil
+}
+
+func (iter *kvsIter) Next() bool {
+	return iter.rows.Next()
+}
+
+func (iter *kvsIter) KeyValue() (k []byte, v []byte, err error) {
+	err = iter.rows.Scan(&k, &v)
+	return k, v, err
+}
+
+func (iter *kvsIter) Close() {
+	iter.rows.Close()
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Handles the last remaining queries left in `ledger` used in production code.
A few sql statements remain in specific tests.

**Previous parts of this refactor:**
- part 1 - #4776
- part 2 - #4813
- part 3 - #4830
- part 4 - #4835
- part 5 - #4836 
- part 6 - #4841 
- part 7 - #4846 
- part 8 - #4860 
- part 9 - #4864 
- part 10 - #4874 

**What remains to be moved out:**
- [ ] misc queries left in `ledger` 
    - [ ] `acctdeltas_test.go`
    - [ ] `acctupdates_test.go`
    - [x] `catchpointtracker.go`
    - [x] `catchpointwriter.go`
    - [ ] `catchpointwriter_test.go`

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Existing tests.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->