### PR TITLE
teal: optimize CheckSignature

### DIFF
--- a/data/transactions/logic/evalBench_test.go
+++ b/data/transactions/logic/evalBench_test.go
@@ -1,0 +1,48 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package logic_test
+
+import (
+	"testing"
+
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/data/transactions/logic"
+	"github.com/algorand/go-algorand/data/txntest"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkCheckSignature(b *testing.B) {
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	txns := txntest.CreateTinyManTxGroup(b, true)
+	ops, err := logic.AssembleString(txntest.TmLsig)
+	require.NoError(b, err)
+	stxns := []transactions.SignedTxn{{Txn: txns[3].Txn(), Lsig: transactions.LogicSig{Logic: ops.Program}}}
+	txgroup := transactions.WrapSignedTxnsWithAD(stxns)
+	ep := logic.EvalParams{
+		Proto:     &proto,
+		TxnGroup:  txgroup,
+		SigLedger: &logic.NoHeaderLedger{},
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		err = logic.CheckSignature(0, &ep)
+		require.NoError(b, err)
+	}
+}

--- a/data/txntest/defi.go
+++ b/data/txntest/defi.go
@@ -79,12 +79,8 @@ func CreateTinyManTxGroup(tb testing.TB, randNote bool) []Txn {
 	return []Txn{fees, *appcall, deposit, withdraw}
 }
 
-// CreateTinyManSignedTxGroup repro this tx group by tinyman
-// https://algoexplorer.io/tx/group/d1bUcqFbNZDMIdcreM9Vw2jzOIZIa2UzDgTTlr2Sl4o%3D
-// which is an algo to USDC swap. The source code below is extracted from
-// algoexplorer, which adds some unusual stuff as comments
-func CreateTinyManSignedTxGroup(tb testing.TB, txns []Txn) ([]transactions.SignedTxn, []*crypto.SignatureSecrets) {
-	lsig := `
+// TmLsig is a tinyman lsig contract used in tests/benchmarks
+const TmLsig = `
 	#pragma version 4
 	intcblock 1 0 0 31566704 3 4 5 6
 	intc_3 // 31566704
@@ -521,7 +517,13 @@ label8:
 	>=
 	return
 `
-	ops, err := logic.AssembleString(lsig)
+
+// CreateTinyManSignedTxGroup repro this tx group by tinyman
+// https://algoexplorer.io/tx/group/d1bUcqFbNZDMIdcreM9Vw2jzOIZIa2UzDgTTlr2Sl4o%3D
+// which is an algo to USDC swap. The source code below is extracted from
+// algoexplorer, which adds some unusual stuff as comments
+func CreateTinyManSignedTxGroup(tb testing.TB, txns []Txn) ([]transactions.SignedTxn, []*crypto.SignatureSecrets) {
+	ops, err := logic.AssembleString(TmLsig)
 	require.NoError(tb, err)
 
 	stxns := SignedTxns(&txns[0], &txns[1], &txns[2], &txns[3])

--- a/data/txntest/txn.go
+++ b/data/txntest/txn.go
@@ -14,22 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
 
-// Copyright (C) 2021 Algorand, Inc.
-// This file is part of go-algorand
-//
-// go-algorand is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as
-// published by the Free Software Foundation, either version 3 of the
-// License, or (at your option) any later version.
-//
-// go-algorand is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
-
 package txntest
 
 import (


### PR DESCRIPTION
## Summary

Make `CheckSignature` ~5 times faster but replacing maps of branches/instructions by arrays/slices.

```
Before:
BenchmarkCheckSignature-8   	   28983	     43515 ns/op

After:
BenchmarkCheckSignature-8   	  120871	      9765 ns/op
```

## Test Plan

Existing metrics