### PR TITLE
metrics: split alive check counter between early/dead

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -585,6 +585,7 @@ func (pool *TransactionPool) addToPendingBlockEvaluatorOnce(txgroup []transactio
 				Round:      r,
 				FirstValid: tx.Txn.FirstValid,
 				LastValid:  tx.Txn.LastValid,
+				Early:      false,
 			}
 		}
 	}

--- a/data/transactions/error.go
+++ b/data/transactions/error.go
@@ -41,6 +41,7 @@ type TxnDeadError struct {
 	Round      basics.Round
 	FirstValid basics.Round
 	LastValid  basics.Round
+	Early      bool
 }
 
 func (err *TxnDeadError) Error() string {

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -239,6 +239,7 @@ func (tx Header) Alive(tc TxnContext) error {
 			Round:      round,
 			FirstValid: tx.FirstValid,
 			LastValid:  tx.LastValid,
+			Early:      round < tx.FirstValid,
 		}
 	}
 


### PR DESCRIPTION
## Summary

This splits the "dead" txhandler counters between "early" and "dead" to track them separately.

## Test Plan

Update existing counter tests.