### PR TITLE
ci: cleanup binaries after upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -739,3 +739,9 @@ commands:
                   command: |
                     export TRAVIS_BRANCH=${CIRCLE_BRANCH}
                     scripts/travis/test_release.sh
+
+        # make sure artifacts are cleaned up post build
+        - run:
+            name: Cleanup Binaries << parameters.platform >>
+            command: |
+              rm -rf << parameters.build_dir >>/node_pkg/*<< parameters.platform >>*<< parameters.arch >>*.tar.gz*


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

- adds a step to CI that cleans up the binaries after they are uploaded to S3
