### PR TITLE
AVM: Go19 curve check

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -483,6 +483,10 @@ type ConsensusParams struct {
 	// the rewardsLevel, but the rewardsLevel has no meaning because the account
 	// has fewer than RewardUnit algos.
 	UnfundedSenders bool
+
+	// EnablePrecheckECDSACurve means that ecdsa_verify opcode will bail early,
+	// returning false, if pubkey is not on the curve.
+	EnablePrecheckECDSACurve bool
 }
 
 // PaysetCommitType enumerates possible ways for the block header to commit to
@@ -1249,6 +1253,7 @@ func initConsensusProtocols() {
 	vFuture.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 
 	vFuture.LogicSigVersion = 9 // When moving this to a release, put a new higher LogicSigVersion here
+	vFuture.EnablePrecheckECDSACurve = true
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -3382,6 +3382,8 @@ var ecdsaVerifyCosts = []int{
 	Secp256r1: 2500,
 }
 
+var secp256r1 = elliptic.P256()
+
 func opEcdsaVerify(cx *EvalContext) error {
 	ecdsaCurve := EcdsaCurve(cx.program[cx.pc+1])
 	fs, ok := ecdsaCurveSpecByField(ecdsaCurve)
@@ -3421,11 +3423,9 @@ func opEcdsaVerify(cx *EvalContext) error {
 		pubkey := secp256k1.S256().Marshal(x, y)
 		result = secp256k1.VerifySignature(pubkey, msg, signature)
 	} else if fs.field == Secp256r1 {
-		curve := elliptic.P256()
-
-		if !cx.Proto.EnablePrecheckECDSACurve || curve.IsOnCurve(x, y) {
+		if !cx.Proto.EnablePrecheckECDSACurve || secp256r1.IsOnCurve(x, y) {
 			pubkey := ecdsa.PublicKey{
-				Curve: curve,
+				Curve: secp256r1,
 				X:     x,
 				Y:     y,
 			}

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -3423,13 +3423,17 @@ func opEcdsaVerify(cx *EvalContext) error {
 	} else if fs.field == Secp256r1 {
 		r := new(big.Int).SetBytes(sigR)
 		s := new(big.Int).SetBytes(sigS)
+		curve := elliptic.P256()
 
-		pubkey := ecdsa.PublicKey{
-			Curve: elliptic.P256(),
-			X:     x,
-			Y:     y,
+		// if not on curve, result remains false
+		if curve.IsOnCurve(x, y) {
+			pubkey := ecdsa.PublicKey{
+				Curve: curve,
+				X:     x,
+				Y:     y,
+			}
+			result = ecdsa.Verify(&pubkey, msg, r, s)
 		}
-		result = ecdsa.Verify(&pubkey, msg, r, s)
 	}
 
 	cx.stack[fifth] = boolToSV(result)

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -3421,17 +3421,16 @@ func opEcdsaVerify(cx *EvalContext) error {
 		pubkey := secp256k1.S256().Marshal(x, y)
 		result = secp256k1.VerifySignature(pubkey, msg, signature)
 	} else if fs.field == Secp256r1 {
-		r := new(big.Int).SetBytes(sigR)
-		s := new(big.Int).SetBytes(sigS)
 		curve := elliptic.P256()
 
-		// if not on curve, result remains false
-		if curve.IsOnCurve(x, y) {
+		if !cx.Proto.EnablePrecheckECDSACurve || curve.IsOnCurve(x, y) {
 			pubkey := ecdsa.PublicKey{
 				Curve: curve,
 				X:     x,
 				Y:     y,
 			}
+			r := new(big.Int).SetBytes(sigR)
+			s := new(big.Int).SetBytes(sigS)
 			result = ecdsa.Verify(&pubkey, msg, r, s)
 		}
 	}


### PR DESCRIPTION
Go 1.19 has changed the semantics of ecdsa.Verify to panic if the public key is not on the appropriate curve.  This change prepares for supporting Go 1.19 by first establishing a new rule for the AVM opcode ecdsa_verify. By doing this in a consensus upgrade while still using Go 1.17, we force the change to occur across all nodes at once, and we ensure no changes occur in evaluating old blocks.