### PR TITLE
goal: user defined scheme to connect to remote host

### DIFF
--- a/nodecontrol/algodControl.go
+++ b/nodecontrol/algodControl.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/algorand/go-algorand/config"
@@ -84,6 +85,13 @@ func (nc NodeController) ServerURL() (url.URL, error) {
 	addr, err := nc.GetHostAddress()
 	if err != nil {
 		return url.URL{}, err
+	}
+	if strings.HasPrefix(addr, "http:") || strings.HasPrefix(addr, "https:") {
+		u, err := url.Parse(addr)
+		if err != nil {
+			return url.URL{}, err
+		}
+		return *u, nil
 	}
 	return url.URL{Scheme: "http", Host: addr}, nil
 }


### PR DESCRIPTION
Related to https://github.com/algorand/go-algorand/issues/2904

I use this patch to connect to a remote node

for example, connecting to https://algonode.io/api/

```sh
$ echo https://mainnet-api.algonode.cloud > algod.net
$ echo 0000000000000000000000000000000000000000000000000000000000000000 > algod.token
$ goal -d $PWD account info -a ZW3ISEHZUHPO7OZGMKLKIIMKVICOUDRCERI454I3DB2BH52HGLSO67W754
Created Assets:
	ID 473073010, PW:GOV1, supply 3198752 PW_GOV1, https://bit.ly/3FouyUR
	ID 815226506, PW:GOV2, supply 10855648 PW_GOV2, https://www.planetwatch.io/governance-vote-type-2-rewards/
	ID 850324927, PW:GOV3, supply 10101621 PW_GOV3, https://www.planetwatch.io/governance-vote-recycle-bins-data-streams-recording
	ID 864913853, PW:GOV4, supply 9865201 PW_GOV4, https://www.planetwatch.io/governance-vote-extending-voting-rights-to-planet-holders/
	ID 963327370, PW:GOV5, supply 11000000 PW_GOV5, https://www.planetwatch.io/governance-vote-token-model-update/
Held Assets:
	ID 27165954, PLANET, balance 64959512.528857 Planets
	ID 395684495, PLANET Recycled Token, balance 3377426128.001016 PW_BIN
	ID 473073010, PW:GOV1, balance 2451323 PW_GOV1
	ID 815226506, PW:GOV2, balance 9658818 PW_GOV2
	ID 850324927, PW:GOV3, balance 9405236 PW_GOV3
	ID 864913853, PW:GOV4, balance 8851732 PW_GOV4
	ID 963327370, PW:GOV5, balance 9756771 PW_GOV5
Created Apps:
	<none>
Opted In Apps:
	<none>
Minimum Balance:	800000 microAlgos
```