### PR TITLE
bench: fix benchmarking after remerges

### DIFF
--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -1557,6 +1557,7 @@ func makeTxGenerator(tb testing.TB, numUsers, maxGroupSize int, invalidRate floa
 	return &txGenerator{
 		numUsers:     numUsers,
 		maxGroupSize: maxGroupSize,
+		invalidRate:  invalidRate,
 		addresses:    addresses,
 		secrets:      secrets,
 		genesis:      genesis,


### PR DESCRIPTION
## Summary

While running benchmarks found they do not produce invalid groups anymore. Fixed.

## Test Plan

This is a test/bench harness fix.