### PR TITLE
log: stderr offending large log messages

### DIFF
--- a/logging/cyclicWriter.go
+++ b/logging/cyclicWriter.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"text/template"
 	"time"
@@ -124,6 +125,16 @@ func (cyclic *CyclicFileWriter) Write(p []byte) (n int, err error) {
 
 	if uint64(len(p)) > cyclic.limit {
 		// there's no hope for writing this entry to the log
+
+		// for the large lines this is a clear indication something does wrong, dump data into stderr
+		const minDebugLogLineSize = 10 * 1024 * 1024
+		if len(p) >= minDebugLogLineSize {
+			buf := make([]byte, 16*1024)
+			stlen := runtime.Stack(buf, false)
+			fmt.Fprintf(os.Stderr, "Attempt to write a large log line:\n%s\n", string(buf[:stlen]))
+			fmt.Fprintf(os.Stderr, "The offending line:\n%s\n", string(p[:4096]))
+		}
+
 		return 0, fmt.Errorf("CyclicFileWriter: input too long to write. Len = %v", len(p))
 	}
 


### PR DESCRIPTION
## Summary

There is a possibility someone might log very large error messages, and they are lost if exceed the log rotation file size.
To prevent this, dump part of the message into stderr as well as callstack to see the caller. 

## Test Plan

Existing tests