### PR TITLE
Tests: Fix `t.Parallel()` errors in `data/transactions/logic` package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,7 +117,7 @@ issues:
         - staticcheck
         - typecheck
     # Ignore missing parallel tests in existing packages
-    - path: (agreement|catchup|cmd|config|crypto|daemon|data|gen|ledger|logging|netdeploy|network|node|protocol|rpcs|shared|stateproof|test|tools|util).*_test.go
+    - path: (agreement|catchup|cmd|config|crypto|daemon|data|gen|ledger|logging|netdeploy|network|node|protocol|rpcs|shared|stateproof|test|tools|util).*_test\.go
       linters:
         - paralleltest
     # Add all linters here -- Comment this block out for testing linters

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -1623,10 +1623,12 @@ func TestAssembleDisassembleCycle(t *testing.T) {
 	// catch any suprises.
 	require.LessOrEqual(t, LogicVersion, len(nonsense)) // Allow nonsense for future versions
 	for v, source := range nonsense {
+		v, source := v, source
 		if v > LogicVersion {
 			continue // We allow them to be set, but can't test assembly beyond LogicVersion
 		}
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
+			t.Parallel()
 			ops := testProg(t, source, v)
 			t2, err := Disassemble(ops.Program)
 			require.NoError(t, err)

--- a/data/transactions/logic/backwardCompat_test.go
+++ b/data/transactions/logic/backwardCompat_test.go
@@ -467,19 +467,24 @@ func TestBackwardCompatAssemble(t *testing.T) {
 	source := "int 1; int 1; bnz done; done:"
 
 	t.Run("v=default", func(t *testing.T) {
+		t.Parallel()
 		testProg(t, source, assemblerNoVersion, Expect{1, "label \"done\" is too far away"})
 	})
 
 	t.Run("v=default", func(t *testing.T) {
+		t.Parallel()
 		testProg(t, source, 0, Expect{1, "label \"done\" is too far away"})
 	})
 
 	t.Run("v=default", func(t *testing.T) {
+		t.Parallel()
 		testProg(t, source, 1, Expect{1, "label \"done\" is too far away"})
 	})
 
 	for v := uint64(2); v <= AssemblerMaxVersion; v++ {
+		v := v
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
+			t.Parallel()
 			testLogic(t, source, v, defaultEvalParams())
 		})
 	}
@@ -487,6 +492,7 @@ func TestBackwardCompatAssemble(t *testing.T) {
 
 func TestExplicitConstants(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	require.Equal(t, 4096, maxStringSize, "constant changed, make it version dependent")
 	require.Equal(t, 64, maxByteMathSize, "constant changed, move it version dependent")

--- a/data/transactions/logic/blackbox_test.go
+++ b/data/transactions/logic/blackbox_test.go
@@ -34,6 +34,7 @@ import (
 
 func TestNewAppEvalParams(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	params := []config.ConsensusParams{
 		{Application: true, MaxAppProgramCost: 700},
@@ -79,7 +80,9 @@ func TestNewAppEvalParams(t *testing.T) {
 
 	for i, param := range params {
 		for j, testCase := range cases {
+			i, j, param, testCase := i, j, param, testCase
 			t.Run(fmt.Sprintf("i=%d,j=%d", i, j), func(t *testing.T) {
+				t.Parallel()
 				ep := logic.NewEvalParams(testCase.group, &param, nil)
 				require.NotNil(t, ep)
 				require.Equal(t, ep.TxnGroup, testCase.group)

--- a/data/transactions/logic/blackbox_test.go
+++ b/data/transactions/logic/blackbox_test.go
@@ -79,6 +79,7 @@ func TestNewAppEvalParams(t *testing.T) {
 	}
 
 	for i, param := range params {
+		param := param
 		for j, testCase := range cases {
 			i, j, param, testCase := i, j, param, testCase
 			t.Run(fmt.Sprintf("i=%d,j=%d", i, j), func(t *testing.T) {

--- a/data/transactions/logic/box_test.go
+++ b/data/transactions/logic/box_test.go
@@ -34,10 +34,13 @@ func TestBoxNewDel(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	ep, txn, ledger := logic.MakeSampleEnv()
-
 	for _, size := range []int{24, 0} {
+		size := size
 		t.Run(fmt.Sprintf("box size=%d", size), func(t *testing.T) {
+			t.Parallel()
+
+			ep, txn, ledger := logic.MakeSampleEnv()
+
 			createSelf := fmt.Sprintf(`byte "self"; int %d; box_create;`, size)
 			createOther := fmt.Sprintf(`byte "other"; int %d; box_create;`, size)
 
@@ -218,7 +221,9 @@ func TestBoxUnavailableWithClearState(t *testing.T) {
 	}
 
 	for name, program := range tests {
+		name, program := name, program
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			ep, _, l := logic.MakeSampleEnv()
 			l.NewApp(basics.Address{}, 888, basics.AppParams{})
 			ep.TxnGroup[0].Txn.OnCompletion = transactions.ClearStateOC
@@ -521,18 +526,23 @@ func TestEarlyPanics(t *testing.T) {
 		"box_replace": `byte "%s"; int 0; byte "new"; box_replace`,
 	}
 
-	ep, _, l := logic.MakeSampleEnv()
-	l.NewApp(basics.Address{}, 888, basics.AppParams{})
-
 	for name, program := range tests {
+		name, program := name, program
 		t.Run(name+"/zero", func(t *testing.T) {
+			t.Parallel()
+			ep, _, l := logic.MakeSampleEnv()
+			l.NewApp(basics.Address{}, 888, basics.AppParams{})
 			logic.TestApp(t, fmt.Sprintf(program, ""), ep, "zero length")
 		})
 	}
 
 	big := strings.Repeat("x", 65)
 	for name, program := range tests {
+		name, program := name, program
 		t.Run(name+"/long", func(t *testing.T) {
+			t.Parallel()
+			ep, _, l := logic.MakeSampleEnv()
+			l.NewApp(basics.Address{}, 888, basics.AppParams{})
 			logic.TestApp(t, fmt.Sprintf(program, big), ep, "name too long")
 		})
 	}

--- a/data/transactions/logic/debugger_test.go
+++ b/data/transactions/logic/debugger_test.go
@@ -65,6 +65,7 @@ bytec 4
 
 func TestWebDebuggerManual(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	debugURL := os.Getenv("TEAL_DEBUGGER_URL")
 	if len(debugURL) == 0 {
@@ -111,6 +112,7 @@ func (d *testDbgHook) Complete(state *DebugState) error {
 
 func TestDebuggerHook(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	testDbg := testDbgHook{}
 	ep := defaultEvalParams()
@@ -125,6 +127,7 @@ func TestDebuggerHook(t *testing.T) {
 
 func TestLineToPC(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	dState := DebugState{
 		Disassembly: "abc\ndef\nghi",
@@ -162,6 +165,7 @@ func TestLineToPC(t *testing.T) {
 
 func TestValueDeltaToValueDelta(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	vDelta := basics.ValueDelta{
 		Action: basics.SetUintAction,
@@ -186,6 +190,7 @@ intc_0
 
 func TestParseCallstack(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	expectedCallFrames := []CallFrame{
 		{
@@ -210,6 +215,7 @@ func TestParseCallstack(t *testing.T) {
 
 func TestCallStackUpdate(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	expectedCallFrames := []CallFrame{
 		{

--- a/data/transactions/logic/doc_test.go
+++ b/data/transactions/logic/doc_test.go
@@ -27,6 +27,7 @@ import (
 
 func TestOpDocs(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	opsSeen := make(map[string]bool, len(OpSpecs))
 	for _, op := range OpSpecs {
@@ -50,6 +51,7 @@ func TestOpDocs(t *testing.T) {
 // around for non-existent opcodes, most likely from a rename.
 func TestDocStragglers(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	for op := range opDocExtras {
 		_, ok := opDocByName[op]
@@ -63,6 +65,7 @@ func TestDocStragglers(t *testing.T) {
 
 func TestOpGroupCoverage(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	opsSeen := make(map[string]bool, len(OpSpecs))
 	for _, op := range OpSpecs {
@@ -87,6 +90,7 @@ func TestOpGroupCoverage(t *testing.T) {
 
 func TestOpDoc(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	xd := OpDoc("txn")
 	require.NotEmpty(t, xd)
@@ -96,6 +100,7 @@ func TestOpDoc(t *testing.T) {
 
 func TestOpImmediateNote(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	xd := OpImmediateNote("txn")
 	require.NotEmpty(t, xd)
@@ -105,6 +110,7 @@ func TestOpImmediateNote(t *testing.T) {
 
 func TestAllImmediatesDocumented(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	for _, op := range OpSpecs {
 		count := len(op.Immediates)
@@ -135,6 +141,7 @@ func TestAllImmediatesDocumented(t *testing.T) {
 
 func TestOpDocExtra(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	xd := OpDocExtra("bnz")
 	require.NotEmpty(t, xd)
@@ -144,6 +151,7 @@ func TestOpDocExtra(t *testing.T) {
 
 func TestOpAllCosts(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := OpAllCosts("+")
 	require.Len(t, a, 1)
@@ -158,6 +166,7 @@ func TestOpAllCosts(t *testing.T) {
 
 func TestOnCompletionDescription(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	desc := OnCompletionDescription(0)
 	require.Equal(t, "Only execute the `ApprovalProgram` associated with this application ID, with no additional effects.", desc)

--- a/data/transactions/logic/evalAppTxn_test.go
+++ b/data/transactions/logic/evalAppTxn_test.go
@@ -35,6 +35,7 @@ import (
 
 func TestInnerTypesV5(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	v5, _, _ := MakeSampleEnvWithVersion(5)
 	// not alllowed in v5
@@ -47,6 +48,7 @@ func TestInnerTypesV5(t *testing.T) {
 
 func TestCurrentInnerTypes(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	TestApp(t, "itxn_submit; int 1;", ep, "itxn_submit without itxn_begin")
@@ -99,6 +101,7 @@ func TestCurrentInnerTypes(t *testing.T) {
 
 func TestFieldTypes(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, _, _ := MakeSampleEnv()
 	TestApp(t, "itxn_begin; byte \"pay\"; itxn_field Sender;", ep, "not an address")
@@ -129,6 +132,7 @@ func appAddr(id int) basics.Address {
 
 func TestAppPay(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	pay := `
   itxn_begin
@@ -176,6 +180,7 @@ func TestAppPay(t *testing.T) {
 
 func TestAppAssetOptIn(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	// Establish 888 as the app id, and fund it.
@@ -237,6 +242,7 @@ int 1
 
 func TestRekeyPay(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	pay := `
   itxn_begin
@@ -262,6 +268,7 @@ func TestRekeyPay(t *testing.T) {
 
 func TestRekeyBack(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	payAndUnkey := `
   itxn_begin
@@ -288,6 +295,7 @@ func TestRekeyBack(t *testing.T) {
 
 func TestDefaultSender(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	pay := `
   itxn_begin
@@ -309,6 +317,7 @@ func TestDefaultSender(t *testing.T) {
 
 func TestAppAxfer(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	axfer := `
   itxn_begin
@@ -372,6 +381,7 @@ func TestAppAxfer(t *testing.T) {
 
 func TestExtraFields(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	pay := `
   itxn_begin
@@ -394,6 +404,7 @@ func TestExtraFields(t *testing.T) {
 
 func TestBadFieldV5(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	pay := `
   itxn_begin
@@ -418,6 +429,7 @@ func TestBadFieldV5(t *testing.T) {
 
 func TestBadField(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	pay := `
   itxn_begin
@@ -443,6 +455,7 @@ func TestBadField(t *testing.T) {
 
 func TestNumInnerShallow(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	pay := `
   itxn_begin
@@ -485,6 +498,7 @@ func TestNumInnerShallow(t *testing.T) {
 // in a group.
 func TestNumInnerPooled(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	pay := `
   itxn_begin
@@ -523,6 +537,7 @@ func TestNumInnerPooled(t *testing.T) {
 
 func TestAssetCreate(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	create := `
   itxn_begin
@@ -551,6 +566,7 @@ func TestAssetCreate(t *testing.T) {
 
 func TestAssetFreeze(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	create := `
   itxn_begin
@@ -599,6 +615,7 @@ func TestAssetFreeze(t *testing.T) {
 
 func TestKeyReg(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	keyreg := `
   store 6 // StateProofPK
@@ -655,6 +672,7 @@ func TestKeyReg(t *testing.T) {
 `
 
 	t.Run("nonparticipating", func(t *testing.T) {
+		t.Parallel()
 		params := `
   int 0 // VoteFirst
   int 0 // VoteLast
@@ -671,6 +689,7 @@ func TestKeyReg(t *testing.T) {
 	})
 
 	t.Run("offline", func(t *testing.T) {
+		t.Parallel()
 		params := `
   int 0 // VoteFirst
   int 0 // VoteLast
@@ -687,6 +706,7 @@ func TestKeyReg(t *testing.T) {
 	})
 
 	t.Run("online without StateProofPK", func(t *testing.T) {
+		t.Parallel()
 		params := `
   int 100 // VoteFirst
   int 200 // VoteLast
@@ -704,6 +724,7 @@ func TestKeyReg(t *testing.T) {
 	})
 
 	t.Run("online with StateProofPK", func(t *testing.T) {
+		t.Parallel()
 		params := `
   int 100 // VoteFirst
   int 16777315 // VoteLast
@@ -722,6 +743,7 @@ func TestKeyReg(t *testing.T) {
 	})
 
 	t.Run("online with StateProofPK and too long validity period", func(t *testing.T) {
+		t.Parallel()
 		params := `
   int 100 // VoteFirst
   int 16777316 // VoteLast
@@ -742,6 +764,7 @@ func TestKeyReg(t *testing.T) {
 
 func TestFieldSetting(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	ledger.NewApp(tx.Receiver, 888, basics.AppParams{})
@@ -786,6 +809,7 @@ func TestFieldSetting(t *testing.T) {
 
 func TestInnerGroup(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	ep.FeeCredit = nil // default sample env starts at 401
@@ -808,6 +832,7 @@ txn Sender; itxn_field Receiver;
 
 func TestInnerFeePooling(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	ep.FeeCredit = nil // default sample env starts at 401
@@ -878,6 +903,7 @@ txn Sender; itxn_field Receiver;
 // immediate failures.
 func TestApplCreation(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, _ := MakeSampleEnv()
 
@@ -963,8 +989,6 @@ func TestBigApplCreation(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	ep, _, _ := MakeSampleEnv()
-
 	p := "itxn_begin;"
 	s := "; int 1"
 
@@ -974,7 +998,12 @@ func TestBigApplCreation(t *testing.T) {
 
 	// First, test normal accummulation
 	for _, pgm := range []string{"Approval", "ClearState"} {
+		pgm := pgm
 		t.Run(pgm, func(t *testing.T) {
+			t.Parallel()
+
+			ep, _, _ := MakeSampleEnv()
+
 			basic := "itxn_field " + pgm + "Program"
 			pages := "itxn_field " + pgm + "ProgramPages"
 			TestApp(t, p+`int 1000; bzero; `+pages+`
@@ -1062,6 +1091,7 @@ func TestApplSubmission(t *testing.T) {
 
 func TestInnerApplCreate(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	ledger.NewApp(tx.Receiver, 888, basics.AppParams{})
@@ -1129,6 +1159,7 @@ int 5000; app_params_get AppGlobalNumByteSlice; !; assert; !; assert; int 1
 
 func TestCreateOldAppFails(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	ledger.NewApp(tx.Receiver, 888, basics.AppParams{})
@@ -1191,6 +1222,7 @@ int 1
 
 func TestSelfReentrancy(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	ledger.NewApp(tx.Receiver, 888, basics.AppParams{})
@@ -1207,6 +1239,7 @@ int 1
 
 func TestIndirectReentrancy(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	call888 := TestProg(t, `itxn_begin
@@ -1236,6 +1269,7 @@ int 1
 // needlessly picky to test, but the appID used to be stored outside the cx.
 func TestInnerAppID(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	logID := TestProg(t, `global CurrentApplicationID; itob; log; int 1`, AssemblerMaxVersion)
@@ -1264,6 +1298,7 @@ int 222
 // about 690 (see next test).
 func TestInnerBudgetIncrement(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	gasup := TestProg(t, "pushint 1", AssemblerMaxVersion)
@@ -1293,6 +1328,7 @@ itxn_submit;
 
 func TestIncrementCheck(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	gasup := TestProg(t, "pushint 1", AssemblerMaxVersion)
@@ -1326,6 +1362,7 @@ int 1
 // TestInnerTxIDs confirms that TxIDs are available and different
 func TestInnerTxIDs(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	txid := TestProg(t, "txn TxID; log; int 1", AssemblerMaxVersion)
@@ -1421,6 +1458,7 @@ gitxn 1 TxID
 // but set and unique on non-singletons
 func TestInnerGroupIDs(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	gid := TestProg(t, "global GroupID; log; int 1", AssemblerMaxVersion)
@@ -1760,8 +1798,8 @@ itxn_submit
 int 1
 `
 
-	for _, unified := range []bool{true, false} {
-		t.Run(fmt.Sprintf("unified=%t", unified), func(t *testing.T) { //nolint:paralleltest // NO t.Parallel(). unified variable is actually shared
+	for _, unified := range []bool{true, false} { //nolint:paralleltest // NO t.Parallel(). unified variable is actually shared
+		t.Run(fmt.Sprintf("unified=%t", unified), func(t *testing.T) {
 			ep, parentTx, ledger := MakeSampleEnv()
 			ep.Proto.UnifyInnerTxIDs = unified
 
@@ -2086,10 +2124,8 @@ log
 int 1
 `
 
-	for _, unified := range []bool{true, false} {
+	for _, unified := range []bool{true, false} { //nolint:paralleltest // NO t.Parallel(). unified variable is actually shared
 		t.Run(fmt.Sprintf("unified=%t", unified), func(t *testing.T) {
-			// t.Parallel() NO! unified variable is actually shared
-
 			ep, parentTx, ledger := MakeSampleEnv()
 			ep.Proto.UnifyInnerTxIDs = unified
 
@@ -2321,6 +2357,7 @@ btoi
 // TestGtixn confirms access to itxn groups
 func TestGtixn(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	two := TestProg(t, "byte 0x22; log; int 1", AssemblerMaxVersion)
@@ -2407,6 +2444,7 @@ int 1
 // TestGtxnLog confirms that gtxn can now access previous txn's Logs.
 func TestGtxnLog(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	two := TestProg(t, "byte 0x22; log; int 1", AssemblerMaxVersion)
@@ -2436,6 +2474,7 @@ int 1
 // TestGtxnApps confirms that gtxn can now access previous txn's created app id.
 func TestGtxnApps(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	appcheck := TestProg(t, `
@@ -2483,6 +2522,7 @@ int 5001
 // TestGtxnAsa confirms that gtxn can now access previous txn's created asa id.
 func TestGtxnAsa(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	appcheck := TestProg(t, `
@@ -2520,6 +2560,7 @@ int 5001
 // TestCallerGlobals checks that a called app can see its caller.
 func TestCallerGlobals(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	globals := TestProg(t, fmt.Sprintf(`
@@ -2550,6 +2591,7 @@ int 1
 // transactions.
 func TestNumInnerDeep(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	pay := `
   itxn_begin
@@ -2600,6 +2642,7 @@ itxn_submit
 // foreign-arrays rules.
 func TestCreateAndUse(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	axfer := `
   itxn_begin
@@ -2715,6 +2758,7 @@ func hexProgram(t *testing.T, source string) string {
 // the address for it can be looked up.
 func TestCreateUseApp(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	pay5back := main(`
 itxn_begin
@@ -2749,6 +2793,7 @@ int 1
 // because of the strict adherence to the foreign-accounts rules.
 func TestCreateAndPay(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	pay5back := main(`
 itxn_begin
@@ -2792,6 +2837,7 @@ int 1
 // across multiple inner transaction groups
 func TestInnerGaid(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	ep.Proto.MaxInnerTransactions = 100
@@ -2983,6 +3029,7 @@ itxn_submit
 
 func TestForeignAppAccountAccess(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := MakeSampleEnv()
 	ledger.NewAccount(appAddr(888), 50_000)

--- a/data/transactions/logic/evalCrypto_test.go
+++ b/data/transactions/logic/evalCrypto_test.go
@@ -337,7 +337,9 @@ byte 0x%s
 		{pkTampered2, false},
 	}
 	for i, test := range decompressTests {
+		i, test, source := i, test, source
 		t.Run(fmt.Sprintf("decompress/pass=%v", test.pass), func(t *testing.T) {
+			t.Parallel()
 			t.Log("decompressTests i", i)
 			src := fmt.Sprintf(source, hex.EncodeToString(test.key), hex.EncodeToString(x), hex.EncodeToString(y))
 			if test.pass {
@@ -381,7 +383,9 @@ ecdsa_verify Secp256k1
 		{"testdata1", r, false},
 	}
 	for _, test := range verifyTests {
+		test, source := test, source
 		t.Run(fmt.Sprintf("verify/pass=%v", test.pass), func(t *testing.T) {
+			t.Parallel()
 			src := fmt.Sprintf(source, test.data, hex.EncodeToString(test.r), hex.EncodeToString(s), hex.EncodeToString(x), hex.EncodeToString(y))
 			if test.pass {
 				testAccepts(t, src, 5)
@@ -428,7 +432,9 @@ load 1
 	pkExpanded := secp256k1.S256().Marshal(key.PublicKey.X, key.PublicKey.Y)
 
 	for i, test := range recoverTests {
+		i, test, source := i, test, source
 		t.Run(fmt.Sprintf("recover/%d", i), func(t *testing.T) {
+			t.Parallel()
 			src := fmt.Sprintf(source, hex.EncodeToString(msg[:]), test.v, hex.EncodeToString(r), hex.EncodeToString(s), hex.EncodeToString(x), hex.EncodeToString(y), hex.EncodeToString(pkExpanded))
 			test.checker(t, src, 5)
 		})
@@ -487,7 +493,9 @@ byte 0x%s
 		{pkTampered2, false},
 	}
 	for i, test := range decompressTests {
+		i, test, source := i, test, source
 		t.Run(fmt.Sprintf("decompress/pass=%v", test.pass), func(t *testing.T) {
+			t.Parallel()
 			t.Log("decompressTests i", i)
 			src := fmt.Sprintf(source, hex.EncodeToString(test.key), hex.EncodeToString(x), hex.EncodeToString(y))
 			if test.pass {
@@ -530,7 +538,9 @@ ecdsa_verify Secp256r1
 		{"testdata1", r, false},
 	}
 	for _, test := range verifyTests {
+		test, source := test, source
 		t.Run(fmt.Sprintf("verify/pass=%v", test.pass), func(t *testing.T) {
+			t.Parallel()
 			src := fmt.Sprintf(source, test.data, hex.EncodeToString(test.r), hex.EncodeToString(s), hex.EncodeToString(x), hex.EncodeToString(y))
 			if test.pass {
 				testAccepts(t, src, fidoVersion)

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -2265,7 +2265,6 @@ int 1
 
 func TestEnumFieldErrors(t *testing.T) { // nolint:paralleltest // manipulates globalFieldSpecs
 	partitiontest.PartitionTest(t)
-	// NO! t.Parallel()
 
 	source := `txn Amount`
 	origSpec := txnFieldSpecs[Amount]

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -202,38 +202,41 @@ log
 		modeApp: opcodesRunModeAny + opcodesRunModeApplication,
 	}
 
-	ep, tx, ledger := makeSampleEnv()
-	ep.TxnGroup[0].Lsig.Args = [][]byte{
-		tx.Sender[:],
-		tx.Receiver[:],
-		tx.CloseRemainderTo[:],
-		tx.VotePK[:],
-		tx.SelectionPK[:],
-		tx.Note,
-	}
-	params := basics.AssetParams{
-		Total:         1000,
-		Decimals:      2,
-		DefaultFrozen: false,
-		UnitName:      "ALGO",
-		AssetName:     "",
-		URL:           string(protocol.PaymentTx),
-		Manager:       tx.Sender,
-		Reserve:       tx.Receiver,
-		Freeze:        tx.Receiver,
-		Clawback:      tx.Receiver,
-	}
-	algoValue := basics.TealValue{Type: basics.TealUintType, Uint: 0x77}
-	ledger.NewAccount(tx.Sender, 1)
-	ledger.NewApp(tx.Sender, 100, basics.AppParams{})
-	ledger.NewLocals(tx.Sender, 100)
-	ledger.NewLocal(tx.Sender, 100, "ALGO", algoValue)
-	ledger.NewAsset(tx.Sender, 5, params)
-
 	for mode, test := range tests {
+		mode, test := mode, test
 		t.Run(fmt.Sprintf("opcodes_mode=%d", mode), func(t *testing.T) {
+			t.Parallel()
+
+			ep, tx, ledger := makeSampleEnv()
+			ep.TxnGroup[0].Lsig.Args = [][]byte{
+				tx.Sender[:],
+				tx.Receiver[:],
+				tx.CloseRemainderTo[:],
+				tx.VotePK[:],
+				tx.SelectionPK[:],
+				tx.Note,
+			}
 			ep.TxnGroup[0].Txn.ApplicationID = 100
 			ep.TxnGroup[0].Txn.ForeignAssets = []basics.AssetIndex{5} // needed since v4
+			params := basics.AssetParams{
+				Total:         1000,
+				Decimals:      2,
+				DefaultFrozen: false,
+				UnitName:      "ALGO",
+				AssetName:     "",
+				URL:           string(protocol.PaymentTx),
+				Manager:       tx.Sender,
+				Reserve:       tx.Receiver,
+				Freeze:        tx.Receiver,
+				Clawback:      tx.Receiver,
+			}
+			algoValue := basics.TealValue{Type: basics.TealUintType, Uint: 0x77}
+			ledger.NewAccount(tx.Sender, 1)
+			ledger.NewApp(tx.Sender, 100, basics.AppParams{})
+			ledger.NewLocals(tx.Sender, 100)
+			ledger.NewLocal(tx.Sender, 100, "ALGO", algoValue)
+			ledger.NewAsset(tx.Sender, 5, params)
+
 			if mode == modeSig {
 				testLogic(t, test, AssemblerMaxVersion, ep)
 			} else {
@@ -295,6 +298,7 @@ log
 	}
 
 	for _, source := range statefulOpcodeCalls {
+		source := source
 		testLogic(t, source, AssemblerMaxVersion, defaultEvalParams(),
 			"not allowed in current mode", "not allowed in current mode")
 	}
@@ -1276,7 +1280,9 @@ intc_1
 		"delete": {sourceDelete, 12},
 	}
 	for name, cmdtest := range tests {
+		name, cmdtest := name, cmdtest
 		t.Run(fmt.Sprintf("test=%s", name), func(t *testing.T) {
+			t.Parallel()
 			source := cmdtest.source
 			firstCmdOffset := cmdtest.accNumOffset
 
@@ -1628,7 +1634,9 @@ int 1
 		"delete": sourceDelete,
 	}
 	for name, source := range tests {
+		name, source := name, source
 		t.Run(fmt.Sprintf("test=%s", name), func(t *testing.T) {
+			t.Parallel()
 			ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 			require.NoError(t, err)
 
@@ -2255,9 +2263,9 @@ int 1
 	require.Equal(t, 1, len(delta.LocalDeltas[0]))
 }
 
-func TestEnumFieldErrors(t *testing.T) {
+func TestEnumFieldErrors(t *testing.T) { // nolint:paralleltest // manipulates globalFieldSpecs
 	partitiontest.PartitionTest(t)
-	// t.Parallel() NO! manipulates globalFieldSpecs
+	// NO! t.Parallel()
 
 	source := `txn Amount`
 	origSpec := txnFieldSpecs[Amount]
@@ -2340,48 +2348,6 @@ func TestReturnTypes(t *testing.T) {
 		StackAny:    "int 1\n",
 		StackBytes:  "byte 0x33343536\n", // Which is the string "3456"
 	}
-	ep, tx, ledger := makeSampleEnv()
-
-	tx.Type = protocol.ApplicationCallTx
-	tx.ApplicationID = 1
-	tx.ForeignApps = []basics.AppIndex{tx.ApplicationID}
-	tx.ForeignAssets = []basics.AssetIndex{basics.AssetIndex(1), basics.AssetIndex(1)}
-	tx.Boxes = []transactions.BoxRef{{
-		Name: []byte("3456"),
-	}}
-	ep.TxnGroup[0].Lsig.Args = [][]byte{
-		[]byte("aoeu"),
-		[]byte("aoeu"),
-		[]byte("aoeu2"),
-		[]byte("aoeu3"),
-	}
-	// We are going to run with GroupIndex=1, so make tx1 interesting too (so
-	// txn can look at things)
-	ep.TxnGroup[1] = ep.TxnGroup[0]
-
-	ep.pastScratch[0] = &scratchSpace{} // for gload
-	ledger.NewAccount(tx.Sender, 1)
-	params := basics.AssetParams{
-		Total:         1000,
-		Decimals:      2,
-		DefaultFrozen: false,
-		UnitName:      "ALGO",
-		AssetName:     "",
-		URL:           string(protocol.PaymentTx),
-		Manager:       tx.Sender,
-		Reserve:       tx.Receiver,
-		Freeze:        tx.Receiver,
-		Clawback:      tx.Receiver,
-	}
-	ledger.NewAsset(tx.Sender, 1, params)
-	ledger.NewApp(tx.Sender, 1, basics.AppParams{})
-	ledger.NewAccount(tx.Receiver, 1000000)
-	ledger.NewLocals(tx.Receiver, 1)
-	key, err := hex.DecodeString("33343536")
-	require.NoError(t, err)
-	algoValue := basics.TealValue{Type: basics.TealUintType, Uint: 0x77}
-	ledger.NewLocal(tx.Receiver, 1, string(key), algoValue)
-	ledger.NewAccount(appAddr(1), 1000000)
 
 	// We try to form a snippet that will test every opcode, by sandwiching it
 	// between arguments that correspond to the opcode's input types, and then
@@ -2486,7 +2452,10 @@ func TestReturnTypes(t *testing.T) {
 			if skipCmd[name] || spec.trusted {
 				continue
 			}
+			m, name, spec := m, name, spec
 			t.Run(fmt.Sprintf("mode=%s,opcode=%s", m, name), func(t *testing.T) {
+				t.Parallel()
+
 				provideStackInput := true
 				cmd := name
 				if special, ok := specialCmd[name]; ok {
@@ -2529,6 +2498,49 @@ func TestReturnTypes(t *testing.T) {
 				sb.WriteString(cmd + "\n")
 				ops := testProg(t, sb.String(), AssemblerMaxVersion)
 
+				ep, tx, ledger := makeSampleEnv()
+
+				tx.Type = protocol.ApplicationCallTx
+				tx.ApplicationID = 1
+				tx.ForeignApps = []basics.AppIndex{tx.ApplicationID}
+				tx.ForeignAssets = []basics.AssetIndex{basics.AssetIndex(1), basics.AssetIndex(1)}
+				tx.Boxes = []transactions.BoxRef{{
+					Name: []byte("3456"),
+				}}
+				ep.TxnGroup[0].Lsig.Args = [][]byte{
+					[]byte("aoeu"),
+					[]byte("aoeu"),
+					[]byte("aoeu2"),
+					[]byte("aoeu3"),
+				}
+				// We are going to run with GroupIndex=1, so make tx1 interesting too (so
+				// txn can look at things)
+				ep.TxnGroup[1] = ep.TxnGroup[0]
+
+				ep.pastScratch[0] = &scratchSpace{} // for gload
+				ledger.NewAccount(tx.Sender, 1)
+				params := basics.AssetParams{
+					Total:         1000,
+					Decimals:      2,
+					DefaultFrozen: false,
+					UnitName:      "ALGO",
+					AssetName:     "",
+					URL:           string(protocol.PaymentTx),
+					Manager:       tx.Sender,
+					Reserve:       tx.Receiver,
+					Freeze:        tx.Receiver,
+					Clawback:      tx.Receiver,
+				}
+				ledger.NewAsset(tx.Sender, 1, params)
+				ledger.NewApp(tx.Sender, 1, basics.AppParams{})
+				ledger.NewAccount(tx.Receiver, 1000000)
+				ledger.NewLocals(tx.Receiver, 1)
+				key, err := hex.DecodeString("33343536")
+				require.NoError(t, err)
+				algoValue := basics.TealValue{Type: basics.TealUintType, Uint: 0x77}
+				ledger.NewLocal(tx.Receiver, 1, string(key), algoValue)
+				ledger.NewAccount(appAddr(1), 1000000)
+
 				ep.reset()                          // for Trace and budget isolation
 				ep.pastScratch[0] = &scratchSpace{} // for gload
 				// these allows the box_* opcodes that to work
@@ -2551,7 +2563,7 @@ func TestReturnTypes(t *testing.T) {
 				// is checked for typing, we can't get hung up on whether it is
 				// exactly one positive int. But if it fails for any *other*
 				// reason, we're not doing a good test.
-				_, err := eval(ops.Program, &cx)
+				_, err = eval(ops.Program, &cx)
 				if err != nil {
 					// Allow the kinds of errors we expect, but fail for stuff
 					// that indicates the opcode itself failed.
@@ -2710,6 +2722,7 @@ func appAddr(id int) basics.Address {
 
 func TestAppInfo(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ep, tx, ledger := makeSampleEnv()
 	require.Equal(t, 888, int(tx.ApplicationID))

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -229,6 +229,7 @@ func TestMinAvmVersionParamEvalCheckSignature(t *testing.T) {
 
 func TestTxnFieldToTealValue(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	txn := transactions.Transaction{}
 	groupIndex := 0
@@ -1809,7 +1810,9 @@ func TestTxn(t *testing.T) {
 	clearOps := testProg(t, "int 1", 1)
 
 	for v, source := range tests {
+		v, source := v, source
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
+			t.Parallel()
 			ops := testProg(t, source, v)
 			txn := makeSampleTxn()
 			if v >= appsEnabledVersion {
@@ -2072,7 +2075,9 @@ gtxn 0 Sender
 	}
 
 	for v, source := range tests {
+		v, source := v, source
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
+			t.Parallel()
 			txn := makeSampleTxn()
 			// RekeyTo not allowed in v1
 			if v < rekeyingEnabledVersion {
@@ -2726,7 +2731,9 @@ func TestGload(t *testing.T) {
 	}
 
 	for i, testCase := range cases {
+		i, testCase := i, testCase
 		t.Run(fmt.Sprintf("i=%d", i), func(t *testing.T) {
+			t.Parallel()
 			sources := testCase.tealSources
 
 			// Initialize txgroup
@@ -2772,7 +2779,9 @@ func TestGload(t *testing.T) {
 
 	failCases := []failureCase{nonAppCall, logicSigCall}
 	for j, failCase := range failCases {
+		j, failCase := j, failCase
 		t.Run(fmt.Sprintf("j=%d", j), func(t *testing.T) {
+			t.Parallel()
 
 			appcall := transactions.SignedTxn{
 				Txn: transactions.Transaction{
@@ -3106,7 +3115,9 @@ func TestShortBytecblock2(t *testing.T) {
 		"0026efbfbdefbfbd30",
 	}
 	for _, src := range sources {
+		src := src
 		t.Run(src, func(t *testing.T) {
+			t.Parallel()
 			program, err := hex.DecodeString(src)
 			require.NoError(t, err)
 			testLogicBytes(t, program, defaultEvalParams(), "const bytes list", "const bytes list")
@@ -3125,10 +3136,13 @@ func checkPanic(cx *EvalContext) error {
 
 func TestPanic(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	log := logging.TestingLog(t)
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
+		v := v
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
+			t.Parallel()
 			ops := testProg(t, `int 1`, v)
 			var hackedOpcode int
 			var oldSpec OpSpec
@@ -3300,7 +3314,9 @@ done:
 intc_1
 `
 	for _, line := range branches {
+		line := line
 		t.Run(fmt.Sprintf("branch=%s", line), func(t *testing.T) {
+			t.Parallel()
 			source := fmt.Sprintf(template, line)
 			ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
 			require.NoError(t, err)
@@ -4135,7 +4151,9 @@ func TestAnyRekeyToOrApplicationRaisesMinAvmVersion(t *testing.T) {
 	}
 
 	for ci, cse := range cases {
+		ci, cse := ci, cse
 		t.Run(fmt.Sprintf("ci=%d", ci), func(t *testing.T) {
+			t.Parallel()
 			ep := defaultEvalParams(cse.group...)
 
 			// Computed MinAvmVersion should be == validFromVersion
@@ -5036,7 +5054,9 @@ func TestPcDetails(t *testing.T) {
 		{"b end; end:", 4, ""},
 	}
 	for i, test := range tests {
+		i, test := i, test
 		t.Run(fmt.Sprintf("i=%d", i), func(t *testing.T) {
+			t.Parallel()
 			ops := testProg(t, test.source, LogicVersion)
 			ep, _, _ := makeSampleEnv()
 			ep.Trace = &strings.Builder{}

--- a/data/transactions/logic/jsonspec_test.go
+++ b/data/transactions/logic/jsonspec_test.go
@@ -32,6 +32,7 @@ import (
 
 func TestParseScalar(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	intScalar := `{"key0": 4160}`
 	_, err := parseJSON([]byte(intScalar))
 	require.NoError(t, err)
@@ -42,6 +43,7 @@ func TestParseScalar(t *testing.T) {
 
 func TestParseTrailingCommas(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	for i := 1; i <= 10; i++ {
 		commas := strings.Repeat(",", i)
 		intScalar := `{"key0": 4160` + commas + `}`
@@ -55,6 +57,7 @@ func TestParseTrailingCommas(t *testing.T) {
 
 func TestParseComments(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	text := `{"key0": /*comment*/"algo"}`
 	_, err := parseJSON([]byte(text))
 	require.Error(t, err)
@@ -65,6 +68,7 @@ func TestParseComments(t *testing.T) {
 
 func TestParseUnclosed(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	text := `{"key0": ["algo"}`
 	_, err := parseJSON([]byte(text))
 	require.Error(t, err)
@@ -84,6 +88,7 @@ func TestParseUnclosed(t *testing.T) {
 
 func TestParseNested(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	text := `{"key0": [[1,2,3],[4,5,6]], "key1":{"key10":{"key100":"algo"}}}`
 	_, err := parseJSON([]byte(text))
 	require.NoError(t, err)
@@ -91,6 +96,7 @@ func TestParseNested(t *testing.T) {
 
 func TestParseWhiteSpace(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	//empty text
 	text := ""
 	_, err := parseJSON([]byte(text))
@@ -107,6 +113,7 @@ func TestParseWhiteSpace(t *testing.T) {
 
 func TestParseSpecialValues(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	text := `{"key0": NaN}`
 	_, err := parseJSON([]byte(text))
 	require.Error(t, err)
@@ -129,6 +136,7 @@ func TestParseSpecialValues(t *testing.T) {
 
 func TestParseHexValue(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	text := `{"key0": 0x1}`
 	_, err := parseJSON([]byte(text))
 	require.Error(t, err)
@@ -139,6 +147,7 @@ func TestParseHexValue(t *testing.T) {
 
 func TestParseBigNum(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	// values in range uint64 parsed correctly
 	// parse 0
 	text := `{"key0":0}`
@@ -162,6 +171,7 @@ func TestParseBigNum(t *testing.T) {
 
 func TestParseArrays(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	text := `{"key0": [,1,]}`
 	_, err := parseJSON([]byte(text))
 	require.Error(t, err)
@@ -175,6 +185,7 @@ func TestParseArrays(t *testing.T) {
 
 func TestParseKeys(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	text := `{"": 1}`
 	_, err := parseJSON([]byte(text))
 	require.NoError(t, err)
@@ -211,6 +222,7 @@ func TestParseKeys(t *testing.T) {
 
 func TestParseFileEncoding(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	// create utf-8, utf-16, and utf-32 encoded text and check which is supported by json
 	// it appears that json only supports utf-8 encoded json text
 
@@ -250,6 +262,7 @@ func TestParseFileEncoding(t *testing.T) {
 
 func TestParseByteOrderMark(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	// byte order mark is not allowed at the beginning of a JSON text,
 	// it is treated as an error
 	text := "\uFEFF{\"key0\": 1}"
@@ -259,6 +272,7 @@ func TestParseByteOrderMark(t *testing.T) {
 
 func TestParseControlChar(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	// control chars (u0000 - u001F) must be escaped
 	for i := 0x0; i <= 0x1f; i++ {
 		text := fmt.Sprintf("{\"key0\":\"\\u%04X\"}", i)
@@ -269,6 +283,7 @@ func TestParseControlChar(t *testing.T) {
 
 func TestParseEscapeChar(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	// escaped control char
 	text := "{\"key0\": \"\\u0000\"}"
 	_, err := parseJSON([]byte(text))
@@ -287,6 +302,7 @@ func TestParseEscapeChar(t *testing.T) {
 
 func TestParseEscapedInvalidChar(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	// unicode escape sequence remains in string
 	// accepted surrogate pair
 	text := `{"key0": "\uD801\udc37"}`
@@ -307,6 +323,7 @@ func TestParseEscapedInvalidChar(t *testing.T) {
 
 func TestParseRawNonUnicodeChar(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	text := `{"key0": "πζθ"}`
 	_, err := parseJSON([]byte(text))
 	require.NoError(t, err)

--- a/data/transactions/logic/opcodes_test.go
+++ b/data/transactions/logic/opcodes_test.go
@@ -60,7 +60,6 @@ func (os *OpSpec) equals(oso *OpSpec) bool {
 
 func TestOpcodesByVersionReordered(t *testing.T) { // nolint:paralleltest // manipulates global OpSpecs
 	partitiontest.PartitionTest(t)
-	// NO! t.Parallel()
 
 	// Make a copy to restore to the original
 	OpSpecsOrig := make([]OpSpec, len(OpSpecs))

--- a/data/transactions/logic/opcodes_test.go
+++ b/data/transactions/logic/opcodes_test.go
@@ -58,8 +58,9 @@ func (os *OpSpec) equals(oso *OpSpec) bool {
 	return true
 }
 
-func TestOpcodesByVersionReordered(t *testing.T) {
+func TestOpcodesByVersionReordered(t *testing.T) { // nolint:paralleltest // manipulates global OpSpecs
 	partitiontest.PartitionTest(t)
+	// NO! t.Parallel()
 
 	// Make a copy to restore to the original
 	OpSpecsOrig := make([]OpSpec, len(OpSpecs))
@@ -82,6 +83,7 @@ func TestOpcodesByVersionReordered(t *testing.T) {
 
 func TestOpcodesByVersion(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	testOpcodesByVersion(t)
 }
 

--- a/data/transactions/logic/parsing_test.go
+++ b/data/transactions/logic/parsing_test.go
@@ -36,6 +36,7 @@ func TestNewAppCallBytes(t *testing.T) {
 	t.Parallel()
 
 	t.Run("errors", func(t *testing.T) {
+		t.Parallel()
 		_, err := NewAppCallBytes("hello")
 		require.Error(t, err)
 
@@ -48,7 +49,9 @@ func TestNewAppCallBytes(t *testing.T) {
 
 	for _, v := range []string{"hello", "1:2"} {
 		for _, e := range []string{"str", "string"} {
+			v, e := v, e
 			t.Run(fmt.Sprintf("encoding=%v,value=%v", e, v), func(t *testing.T) {
+				t.Parallel()
 				acb, err := NewAppCallBytes(fmt.Sprintf("%v:%v", e, v))
 				require.NoError(t, err)
 				r, err := acb.Raw()
@@ -59,6 +62,7 @@ func TestNewAppCallBytes(t *testing.T) {
 
 		for _, e := range []string{"b32", "base32", "byte base32"} {
 			ve := base32.StdEncoding.EncodeToString([]byte(v))
+			e := e
 			t.Run(fmt.Sprintf("encoding=%v,value=%v", e, ve), func(t *testing.T) {
 				acb, err := NewAppCallBytes(fmt.Sprintf("%v:%v", e, ve))
 				require.NoError(t, err)
@@ -70,7 +74,9 @@ func TestNewAppCallBytes(t *testing.T) {
 
 		for _, e := range []string{"b64", "base64", "byte base64"} {
 			ve := base64.StdEncoding.EncodeToString([]byte(v))
+			e := e
 			t.Run(fmt.Sprintf("encoding=%v,value=%v", e, ve), func(t *testing.T) {
+				t.Parallel()
 				acb, err := NewAppCallBytes(fmt.Sprintf("%v:%v", e, ve))
 				require.NoError(t, err)
 				r, err := acb.Raw()
@@ -82,7 +88,9 @@ func TestNewAppCallBytes(t *testing.T) {
 
 	for _, v := range []uint64{1, 0, math.MaxUint64} {
 		for _, e := range []string{"int", "integer"} {
+			v, e := v, e
 			t.Run(fmt.Sprintf("encoding=%v,value=%v", e, v), func(t *testing.T) {
+				t.Parallel()
 				acb, err := NewAppCallBytes(fmt.Sprintf("%v:%v", e, v))
 				require.NoError(t, err)
 				r, err := acb.Raw()
@@ -94,7 +102,9 @@ func TestNewAppCallBytes(t *testing.T) {
 
 	for _, v := range []string{"737777777777777777777777777777777777777777777777777UFEJ2CI"} {
 		for _, e := range []string{"addr", "address"} {
+			v, e := v, e
 			t.Run(fmt.Sprintf("encoding=%v,value=%v", e, v), func(t *testing.T) {
+				t.Parallel()
 				acb, err := NewAppCallBytes(fmt.Sprintf("%v:%v", e, v))
 				require.NoError(t, err)
 				r, err := acb.Raw()
@@ -117,7 +127,9 @@ func TestNewAppCallBytes(t *testing.T) {
 			`[399,"should pass",[true,false,false,true]]`,
 		}} {
 		for _, e := range []string{"abi"} {
+			v, e := v, e
 			t.Run(fmt.Sprintf("encoding=%v,value=%v", e, v), func(t *testing.T) {
+				t.Parallel()
 				acb, err := NewAppCallBytes(fmt.Sprintf(
 					"%v:%v:%v", e, v.abiType, v.rawValue))
 				require.NoError(t, err)

--- a/data/transactions/logic/sourcemap_test.go
+++ b/data/transactions/logic/sourcemap_test.go
@@ -26,6 +26,7 @@ import (
 
 func TestGetSourceMap(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 
 	sourceNames := []string{"test.teal"}
@@ -55,6 +56,7 @@ func TestGetSourceMap(t *testing.T) {
 
 func TestVLQ(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 
 	a.Equal("AAAA", MakeSourceMapLine(0, 0, 0, 0))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

This PR parallelizes existing tests within the logic package. Tests that could be parallelized and were missing the `t.Parallel()` demarcation have been fixed and tests that are unable to be parallelized were labelled accordingly.

This is the first PR of several that will reduce test times by parallelizing existing tests within the repository. These changes will be distributed across several smaller PRs so that benefits can be seen immediately, fewer changes need reviewing, and it is less likely that new tests are introduced while waiting for these PRs to be merged.

## Test Plan

All existing logic package tests passed locally and the golangci-lint paralleltest linter showed no paralleltest errors within the logic package since the initial commit.

<details>
<summary>
<b>Confirming This Locally</b>
</summary>
<br />
First, remove the revision configuration:

```
...
-        new-from-rev: eb019291beed556ec6ac1ceb4a15114ce4df0c57~25
+        # new-from-rev: eb019291beed556ec6ac1ceb4a15114ce4df0c57~25
...
```
And remove the `data` package exclusion within the `.golangci.yml`:
```
...
-        - path: (agreement|catchup|cmd|config|crypto|daemon|data|gen|ledger|logging|netdeploy|network|node|protocol|rpcs|shared|stateproof|test|tools|util).*_test\.go
+        - path: (agreement|catchup|cmd|config|crypto|daemon|gen|ledger|logging|netdeploy|network|node|protocol|rpcs|shared|stateproof|test|tools|util).*_test\.go
...
```

I then ran the paralleltest linter with the following command. If nothing is output, then no errors were found.
```sh
$ make lint 2>/dev/null | grep "data/transactions/logic" | grep "paralleltest"
```
</details>

