### PR TITLE
telemetry: don't report let asyncTelemetryHook wrap and log its own errors

### DIFF
--- a/logging/telemetryhook.go
+++ b/logging/telemetryhook.go
@@ -88,7 +88,7 @@ func createAsyncHookLevels(wrappedHook logrus.Hook, channelDepth uint, maxQueueD
 					if entry != nil {
 						err := hook.wrappedHook.Fire(entry)
 						if err != nil {
-							Base().Warnf("Unable to write event %#v to telemetry : %v", entry, err)
+							Base().WithFields(Fields{"TelemetryError": true}).Warnf("Unable to write event %#v to telemetry : %v", entry, err)
 						}
 						hook.wg.Done()
 					} else {
@@ -146,7 +146,7 @@ func (hook *asyncTelemetryHook) waitForEventAndReady() bool {
 
 // Fire is required to implement logrus hook interface
 func (hook *asyncTelemetryHook) Fire(entry *logrus.Entry) error {
-	if entry.Data["file"] == "telemetryhook.go" {
+	if _, ok := entry.Data["TelemetryError"]; ok {
 		return nil
 	}
 	hook.wg.Add(1)

--- a/logging/telemetryhook.go
+++ b/logging/telemetryhook.go
@@ -146,6 +146,9 @@ func (hook *asyncTelemetryHook) waitForEventAndReady() bool {
 
 // Fire is required to implement logrus hook interface
 func (hook *asyncTelemetryHook) Fire(entry *logrus.Entry) error {
+	if entry.Data["file"] == "telemetryhook.go" {
+		return nil
+	}
 	hook.wg.Add(1)
 	select {
 	case <-hook.quit:

--- a/logging/telemetryhook_test.go
+++ b/logging/telemetryhook_test.go
@@ -229,3 +229,34 @@ func TestAsyncTelemetryHook_QueueDepth(t *testing.T) {
 	// be one higher then the maxDepth.
 	require.LessOrEqual(t, hookEntries, maxDepth+1)
 }
+
+// Ensure that errors from inside the telemetryhook.go implementation are not reported to telemetry.
+func TestAsyncTelemetryHook_SelfReporting(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	const entryCount = 100
+	const maxDepth = 10
+
+	filling := make(chan struct{})
+
+	testHook := makeMockTelemetryHook(logrus.DebugLevel)
+	testHook.cb = func(entry *logrus.Entry) {
+		<-filling // Block while filling
+	}
+
+	hook := createAsyncHook(&testHook, 100, 10)
+	hook.ready = true
+	for i := 0; i < entryCount; i++ {
+		selfEntry := logrus.Entry{
+			Level:   logrus.ErrorLevel,
+			Data:    logrus.Fields{"file": "telemetryhook.go", "line": "123"},
+			Message: "Unable to write event",
+		}
+		hook.Fire(&selfEntry)
+	}
+	close(filling)
+	hook.Close()
+
+	require.Len(t, testHook.entries(), 0)
+}

--- a/logging/telemetryhook_test.go
+++ b/logging/telemetryhook_test.go
@@ -250,7 +250,7 @@ func TestAsyncTelemetryHook_SelfReporting(t *testing.T) {
 	for i := 0; i < entryCount; i++ {
 		selfEntry := logrus.Entry{
 			Level:   logrus.ErrorLevel,
-			Data:    logrus.Fields{"file": "telemetryhook.go", "line": "123"},
+			Data:    logrus.Fields{"TelemetryError": true},
 			Message: "Unable to write event",
 		}
 		hook.Fire(&selfEntry)


### PR DESCRIPTION
## Summary

The asyncTelemetryHook implementation (in telemetryhook.go) uses logging in a single place, when it encounters an error reporting an event. This should ensure the asyncTelemetryHook drops any events reported inside its own implementation, so it does not re-wrap and re-report events unnecessarily.

## Test Plan

Added TestAsyncTelemetryHook_SelfReporting