### PR TITLE
node: Add logging thread to node monitoring wg

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -400,7 +400,7 @@ func (node *AlgorandFullNode) startMonitoringRoutines() {
 
 	if node.config.EnableUsageLog {
 		node.monitoringRoutinesWaitGroup.Add(1)
-		go logging.UsageLogThread(node.ctx, node.log, 100*time.Millisecond, nil)
+		go logging.UsageLogThread(node.ctx, node.log, 100*time.Millisecond, &node.monitoringRoutinesWaitGroup)
 	}
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -399,6 +399,7 @@ func (node *AlgorandFullNode) startMonitoringRoutines() {
 	go node.oldKeyDeletionThread(node.ctx.Done())
 
 	if node.config.EnableUsageLog {
+		node.monitoringRoutinesWaitGroup.Add(1)
 		go logging.UsageLogThread(node.ctx, node.log, 100*time.Millisecond, nil)
 	}
 }


### PR DESCRIPTION


## Summary

[This commit](https://github.com/algorand/go-algorand/commit/a3e90ad357dab65c8796d7070662333ecf8b423a#diff-375d57e386f20eaa5f09f02bb9d28bfc48ac3dca18d0325f59492208219e5618R388) runs a goroutine without adding it to the monitoring wg.