### PR TITLE
Tests: Enable more parallel tests in data/transactions/logic/evalAppTxn_test.go

### DIFF
--- a/data/transactions/logic/evalAppTxn_test.go
+++ b/data/transactions/logic/evalAppTxn_test.go
@@ -1798,8 +1798,10 @@ itxn_submit
 int 1
 `
 
-	for _, unified := range []bool{true, false} { //nolint:paralleltest // NO t.Parallel(). unified variable is actually shared
+	for _, unified := range []bool{true, false} {
+		unified := unified
 		t.Run(fmt.Sprintf("unified=%t", unified), func(t *testing.T) {
+			t.Parallel()
 			ep, parentTx, ledger := MakeSampleEnv()
 			ep.Proto.UnifyInnerTxIDs = unified
 
@@ -2124,8 +2126,10 @@ log
 int 1
 `
 
-	for _, unified := range []bool{true, false} { //nolint:paralleltest // NO t.Parallel(). unified variable is actually shared
+	for _, unified := range []bool{true, false} {
+		unified := unified
 		t.Run(fmt.Sprintf("unified=%t", unified), func(t *testing.T) {
+			t.Parallel()
 			ep, parentTx, ledger := MakeSampleEnv()
 			ep.Proto.UnifyInnerTxIDs = unified
 
@@ -2260,8 +2264,10 @@ func TestInnerTxIDCaching(t *testing.T) {
 	parentAppID := basics.AppIndex(888)
 	childAppID := basics.AppIndex(222)
 
-	for _, unified := range []bool{true, false} { //nolint:paralleltest // NO t.Parallel(). unified variable is actually shared
+	for _, unified := range []bool{true, false} {
+		unified := unified
 		t.Run(fmt.Sprintf("unified=%t", unified), func(t *testing.T) {
+			t.Parallel()
 			ep, parentTx, ledger := MakeSampleEnv()
 			ep.Proto.UnifyInnerTxIDs = unified
 


### PR DESCRIPTION
Extends https://github.com/algorand/go-algorand/pull/4931 to remove `nolint:paralleltest` in several cases where I think it's safe.

During my inspection, I didn't see the mentioned shared usage. As a sanity check, I ran each changed test numerous times to check for non-determinism (e.g. `go test ./data/transactions/logic -run "TestInnerTxIDCaching" -count=1000`).