### PR TITLE
telemetry: don't report ES client errors

### DIFF
--- a/logging/telemetryhook.go
+++ b/logging/telemetryhook.go
@@ -222,9 +222,9 @@ func (el elasticClientLogger) Printf(format string, v ...interface{}) {
 	case logrus.InfoLevel:
 		el.logger.Infof(format, v...)
 	case logrus.WarnLevel:
-		el.logger.Warnf(format, v...)
+		el.logger.WithFields(Fields{"TelemetryError": true}).Warnf(format, v...)
 	default:
-		el.logger.Errorf(format, v...)
+		el.logger.WithFields(Fields{"TelemetryError": true}).Errorf(format, v...)
 	}
 }
 


### PR DESCRIPTION
## Summary

Following on https://github.com/algorand/go-algorand/pull/4932 this also keeps ES client warnings and error logs from being reported back to telemetry.

## Test Plan

Existing tests should pass.