### PR TITLE
Tests: Disable TestResolver in CircleCI due to DNS resolution issue

### DIFF
--- a/tools/network/resolver_test.go
+++ b/tools/network/resolver_test.go
@@ -19,6 +19,8 @@ package network
 import (
 	"context"
 	"net"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +30,10 @@ import (
 
 func TestResolver(t *testing.T) {
 	partitiontest.PartitionTest(t)
+
+	if strings.ToUpper(os.Getenv("CIRCLECI")) == "TRUE" {
+		t.Skip("Disabled on CircleCI while investigating Cloudflare DNS resolution issue")
+	}
 
 	// start with a resolver that has no specific DNS address defined.
 	// we want to make sure that it will go to the default DNS server ( 8.8.8.8 )


### PR DESCRIPTION
Disables `TestResolver` to unblock builds while out-of-band investigation occurs.