### PR TITLE
Tests: Switch e2e_basic_start_stop from devnet to private network

### DIFF
--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -78,12 +78,15 @@ echo "RUN_KMD_WITH_UNSAFE_SCRYPT = ${RUN_KMD_WITH_UNSAFE_SCRYPT}"
 
 export BINDIR=${TEMPDIR}/bin
 export DATADIR=${TEMPDIR}/data
+export NETWORKDIR=${TEMPDIR}/net
 
 function reset_dirs() {
     rm -rf ${BINDIR}
     rm -rf ${DATADIR}
+    rm -rf ${NETWORKDIR}
     mkdir -p ${BINDIR}
     mkdir -p ${DATADIR}
+    mkdir -p ${NETWORKDIR}
 }
 
 # $1 - Message
@@ -155,8 +158,15 @@ if [ -z "$E2E_TEST_FILTER" ] || [ "$E2E_TEST_FILTER" == "SCRIPTS" ]; then
         exit
     fi
 
-    ./timeout 200 ./e2e_basic_start_stop.sh
+    goal network create \
+      -r $NETWORKDIR \
+      -n tbd \
+      -t ../testdata/nettemplates/TwoNodes50EachFuture.json
+
+    ./timeout 200 ./e2e_basic_start_stop.sh $NETWORKDIR
     duration "e2e_basic_start_stop.sh"
+
+    goal network delete -r $NETWORKDIR
 
     KEEP_TEMPS_CMD_STR=""
 

--- a/tools/network/resolver_test.go
+++ b/tools/network/resolver_test.go
@@ -19,6 +19,8 @@ package network
 import (
 	"context"
 	"net"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +30,10 @@ import (
 
 func TestResolver(t *testing.T) {
 	partitiontest.PartitionTest(t)
+
+	if strings.ToUpper(os.Getenv("CIRCLECI")) == "TRUE" {
+		t.Skip("Disabled on CircleCI while investigating Cloudflare DNS resolution issue")
+	}
 
 	// start with a resolver that has no specific DNS address defined.
 	// we want to make sure that it will go to the default DNS server ( 8.8.8.8 )


### PR DESCRIPTION
Extends #4941 to switch `e2e_basic_start_stop.sh` network from devnet to private network.

Using a private network ameliorates a CircleCI-specific DNS connectivity issue.  Additionally, we may wish to retain private network usage as a way to minimize dependencies for the basic start/stop sanity check.