### PR TITLE
Refactor insertSigToBuilder and handleSig, avoid unused allocations

### DIFF
--- a/stateproof/builder.go
+++ b/stateproof/builder.go
@@ -27,6 +27,7 @@ import (
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto/stateproof"
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/stateproofmsg"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/logging"
@@ -117,6 +118,21 @@ func (spw *Worker) loadBuilderFromDB(rnd basics.Round) (builder, error) {
 	}
 
 	return buildr, nil
+}
+
+// loadMessageFromDB loads a StateProof Message from disk.
+func (spw *Worker) loadMessageFromDB(rnd basics.Round) (stateproofmsg.Message, error) {
+	var msg stateproofmsg.Message
+	err := spw.db.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		var err2 error
+		msg, err2 = getMessage(tx, rnd)
+		return err2
+	})
+	if err != nil {
+		return stateproofmsg.Message{}, err
+	}
+
+	return msg, nil
 }
 
 func (spw *Worker) loadSignaturesIntoBuilder(buildr *builder) error {

--- a/stateproof/builder.go
+++ b/stateproof/builder.go
@@ -398,11 +398,11 @@ func (spw *Worker) handleSig(sfa sigFromAddr, sender network.Peer) (network.Forw
 		// Safe to ignore this error as it means we already have a valid signature for this address
 		return network.Ignore, nil
 	}
-	if errors.Is(err, errFailedToAddSigAtPos) {
-		return network.Ignore, err
-	}
 	if errors.Is(err, errAddressNotInVoters) || errors.Is(err, errSignatureVerification) {
 		return network.Disconnect, err
+	}
+	if err != nil { // errFailedToAddSigAtPos and fallback in case of unknown error
+		return network.Ignore, err
 	}
 
 	err = spw.db.Atomic(func(ctx context.Context, tx *sql.Tx) error {

--- a/stateproof/builder.go
+++ b/stateproof/builder.go
@@ -131,7 +131,7 @@ func (spw *Worker) loadSignaturesIntoBuilder(buildr *builder) error {
 	}
 
 	for _, sig := range sigs {
-		err = buildr.insertSigToBuilder(&sig)
+		err = buildr.insertSig(&sig)
 		if err != nil {
 			spw.log.Warn(err)
 		}
@@ -255,14 +255,14 @@ func (spw *Worker) getAllOnlineBuilderRounds() ([]basics.Round, error) {
 	return rnds, err
 }
 
-func (builderForRound *builder) insertSigToBuilder(sig *pendingSig) error {
-	rnd := builderForRound.Round
-	pos, ok := builderForRound.AddrToPos[sig.signer]
+func (b *builder) insertSig(sig *pendingSig) error {
+	rnd := b.Round
+	pos, ok := b.AddrToPos[sig.signer]
 	if !ok {
 		return fmt.Errorf("insertSigToBuilder: cannot find %v in round %d", sig.signer, rnd)
 	}
 
-	isPresent, err := builderForRound.Present(pos)
+	isPresent, err := b.Present(pos)
 	if err != nil {
 		return fmt.Errorf("insertSigToBuilder: failed to invoke builderForRound.Present on pos %d - %w", pos, err)
 	}
@@ -270,10 +270,10 @@ func (builderForRound *builder) insertSigToBuilder(sig *pendingSig) error {
 		return fmt.Errorf("insertSigToBuilder: cannot add %v in round %d: position %d already added", sig.signer, rnd, pos)
 	}
 
-	if err := builderForRound.IsValid(pos, &sig.sig, false); err != nil {
+	if err := b.IsValid(pos, &sig.sig, false); err != nil {
 		return fmt.Errorf("insertSigToBuilder: cannot add %v in round %d: %w", sig.signer, rnd, err)
 	}
-	if err := builderForRound.Add(pos, sig.sig); err != nil {
+	if err := b.Add(pos, sig.sig); err != nil {
 		return fmt.Errorf("insertSigToBuilder: error while adding sig. inner error: %w", err)
 	}
 

--- a/stateproof/signer.go
+++ b/stateproof/signer.go
@@ -134,9 +134,9 @@ func (spw *Worker) getProtoLatest() (*config.ConsensusParams, error) {
 }
 
 func (spw *Worker) getStateProofMessage(round basics.Round, proto *config.ConsensusParams) (stateproofmsg.Message, error) {
-	dbBuilder, err := spw.loadBuilderFromDB(round)
+	msg, err := spw.loadMessageFromDB(round)
 	if err == nil {
-		return dbBuilder.Message, nil
+		return msg, nil
 	}
 
 	if !errors.Is(err, sql.ErrNoRows) {

--- a/stateproof/worker_test.go
+++ b/stateproof/worker_test.go
@@ -1533,7 +1533,7 @@ func TestWorkerHandleSigAlreadyIn(t *testing.T) {
 	})
 	require.Equal(t, network.OutgoingMessage{Action: network.Broadcast}, reply)
 
-	// The sig is already there. Shoud get error
+	// The sig is already there. Should get error
 	reply = w.handleSigMessage(network.IncomingMessage{
 		Data: msgBytes,
 	})

--- a/stateproof/worker_test.go
+++ b/stateproof/worker_test.go
@@ -1454,10 +1454,7 @@ func TestWorkerHandleSigWrongSignature(t *testing.T) {
 
 	fwd, err := w.handleSig(msg, msg.SignerAddress)
 	require.Equal(t, network.Disconnect, fwd)
-	expected2 := fmt.Errorf("%w: %v",
-		merklesignature.ErrSignatureSchemeVerificationFailed,
-		merklearray.ErrRootMismatch)
-	require.Equal(t, expected2, err)
+	require.ErrorIs(t, err, errSignatureVerification)
 }
 
 // relays reject signatures for address not in top N
@@ -1502,9 +1499,7 @@ func TestWorkerHandleSigAddrsNotInTopN(t *testing.T) {
 
 	fwd, err := w.handleSig(msg, msg.SignerAddress)
 	require.Equal(t, network.Disconnect, fwd)
-	expected3 := fmt.Errorf("handleSig: %v not in participants for %d",
-		msg.SignerAddress, msg.Round)
-	require.Equal(t, expected3, err)
+	require.ErrorIs(t, err, errAddressNotInCommittee)
 }
 
 // Signature already part of the builderForRound, ignore

--- a/stateproof/worker_test.go
+++ b/stateproof/worker_test.go
@@ -1499,7 +1499,7 @@ func TestWorkerHandleSigAddrsNotInTopN(t *testing.T) {
 
 	fwd, err := w.handleSig(msg, msg.SignerAddress)
 	require.Equal(t, network.Disconnect, fwd)
-	require.ErrorIs(t, err, errAddressNotInCommittee)
+	require.ErrorIs(t, err, errAddressNotInVoters)
 }
 
 // Signature already part of the builderForRound, ignore


### PR DESCRIPTION
- Change insertSigToBuilder from Worker method to builder method
- Reuse insertSig in handleSig as well, with the newly defined custom errors
- Implement getMessage to fetch stateproof message from DB instead of using getBuilder