### PR TITLE
Test fix: flaky TestStreamVerifierCtxCancelPoolQueue

### DIFF
--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -1497,7 +1497,7 @@ func TestStreamVerifierCtxCancelPoolQueue(t *testing.T) {
 	// and the cancelation, 2 x waitForNextTxnDuration elapses (10ms)
 	time.Sleep(6 * waitForNextTxnDuration)
 	go func() {
-		// wait a bit before releasing the tasks, so that the verificationPool ctx first gets cancled
+		// wait a bit before releasing the tasks, so that the verificationPool ctx first gets canceled
 		time.Sleep(20 * time.Millisecond)
 		close(holdTasks)
 	}()


### PR DESCRIPTION
The test expects to have the stream verifier shut down after the EnqueueBacklog returns an error. 
To induce an error from EnqueueBacklog, the tests cancels the task ctx while the task is in the exec pool queue. 

However, the task ctx canceled is the same as the stream verifier ctx, and occasionally, the stream verifier shuts down because of the ctx before it gets the change to enqueue the task to EnqueueBacklog. When this happens, the tests fails, because the expected message does not get logged. 

To fix this,  never shut down the stream verifier ctx, instead, shut down the verification pool ctx to make sure the batch is rejected from the exec pool and not the batch ctx.