### PR TITLE
tests: fix unstable TestREDCongestionManagerShouldntDrop

### DIFF
--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -579,6 +579,9 @@ func (handler *TxHandler) processIncomingTxn(rawmsg network.IncomingMessage) net
 	var capguard *util.ErlCapacityGuard
 	if handler.erl != nil {
 		// consume a capacity unit
+		// if the elastic rate limiter cannot vend a capacity, the error it returns
+		// is sufficient to indicate that we should enable Congestion Control, because
+		// an issue in vending capacity indicates the underlying resource (TXBacklog) is full
 		capguard, err = handler.erl.ConsumeCapacity(rawmsg.Sender.(util.ErlClient))
 		if err != nil {
 			handler.erl.EnableCongestionControl()

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -299,12 +299,6 @@ type UnicastPeer interface {
 	Respond(ctx context.Context, reqMsg IncomingMessage, topics Topics) (e error)
 }
 
-// A PeerCloseRegistrar is an interface for the opaque Peer which can allow for extra execution
-// whena  peer closes.
-type PeerCloseRegistrar interface {
-	OnClose(func())
-}
-
 // Create a wsPeerCore object
 func makePeerCore(net *WebsocketNetwork, rootURL string, roundTripper http.RoundTripper, originAddress string) wsPeerCore {
 	return wsPeerCore{

--- a/util/rateLimit.go
+++ b/util/rateLimit.go
@@ -168,6 +168,9 @@ func (erl *ElasticRateLimiter) DisableCongestionControl() {
 
 // ConsumeCapacity will dispense one capacity from either the resource's reservedCapacity,
 // and will return a guard who can return capacity when the client is ready
+// Returns an error if the capacity could not be vended, which could be:
+// - there is not sufficient free capacity to assign a reserved capacity block
+// - there is no reserved or shared capacity available for the client
 func (erl *ElasticRateLimiter) ConsumeCapacity(c ErlClient) (*ErlCapacityGuard, error) {
 	var q capacityQueue
 	var err error


### PR DESCRIPTION
Addresses a flaky Unit Test by not overloading the component under test (previously, 5k messages were driven as-fast-as-possible. Now, 10k messages are driven in batches of 500 with a 100ms delay). The new behavior is more accurate to a realistic usage pattern, as well.

This also addresses some deletable code and adds comments where requested from some post-merge requests on pull #4797.

## Testing

Reproduced instability by running
```
 x=0; while [[ $x -lt 12 ]]; do go test ./util -run TestREDCongestionManagerShouldntDrop -count=100 & sleep 1; x=`expr $x + 1` done
```

Then made my edits and reran. None of the results failed after making my changes.

Additionally,
```
make build
make fmt
make lint
go test ./util --race
```
