### PR TITLE
scripts(compute_branch): fix incorrect conditional

### DIFF
--- a/scripts/compute_branch.sh
+++ b/scripts/compute_branch.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 BRANCH="${BRANCH:-}"
-if [ -n "$BRANCH" ]; then
+if [ -z "$BRANCH" ]; then
     if [[ -n $(git status --porcelain) ]]; then
         # If the branch isn't clean, default to HEAD to match old behavior.
         BRANCH="HEAD"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

_this was introduced in https://github.com/algorand/go-algorand/pull/4927_

- updates the conditional in compute_branch.sh to use the `-z` operator, otherwise it works opposite as it was intended. 

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

- ci 
- locally (see below)

Executing `make build` you should see the `-X github.com/algorand/go-algorand/config.Branch=fix/compute-branch-condition`

![image](https://user-images.githubusercontent.com/105239720/211388474-111c3746-d104-4e55-9b54-4a9a96d6c51c.png)

this is what we see on `rel/nightly` (it's empty)

<img width="1529" alt="image" src="https://user-images.githubusercontent.com/105239720/211388584-55be4188-dacd-4023-977b-3b375ea533e5.png">

