### PR TITLE
Updater: fix update.sh parsing of latest version

### DIFF
--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -334,7 +334,7 @@ function check_for_updater() {
 function check_for_update() {
     determine_current_version
     check_for_updater
-    LATEST="$(${SCRIPTPATH}/updater ver check -c ${CHANNEL} ${BUCKET} | sed -n '2 p')"
+    LATEST="$(${SCRIPTPATH}/updater ver check -c ${CHANNEL} ${BUCKET} | tail -1)"
     if [ $? -ne 0 ]; then
         echo "No remote updates found"
         return 1


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

With the removal of S3 credential requirements, the updater script has an additional output line to indicate it's using anonymous credentials. This breaks the parsing of version. This changes the sed from counting lines to just taking the last line with tail.

## Test Plan

Verify that nightly integration works properly.
