### PR TITLE
Tests: Fixes saved from 4981 revert

### DIFF
--- a/data/account/participationRegistry_test.go
+++ b/data/account/participationRegistry_test.go
@@ -738,7 +738,7 @@ func TestParticipion_Blobs(t *testing.T) {
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
 
-	access, err := db.MakeAccessor("writetest_root", false, true)
+	access, err := db.MakeAccessor(t.Name()+"_writetest_root", false, true)
 	if err != nil {
 		panic(err)
 	}
@@ -746,7 +746,7 @@ func TestParticipion_Blobs(t *testing.T) {
 	access.Close()
 	a.NoError(err)
 
-	access, err = db.MakeAccessor("writetest", false, true)
+	access, err = db.MakeAccessor(t.Name()+"_writetest", false, true)
 	if err != nil {
 		panic(err)
 	}
@@ -781,7 +781,7 @@ func TestParticipion_EmptyBlobs(t *testing.T) {
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
 
-	access, err := db.MakeAccessor("writetest_root", false, true)
+	access, err := db.MakeAccessor(t.Name()+"_writetest_root", false, true)
 	if err != nil {
 		panic(err)
 	}
@@ -789,7 +789,7 @@ func TestParticipion_EmptyBlobs(t *testing.T) {
 	access.Close()
 	a.NoError(err)
 
-	access, err = db.MakeAccessor("writetest", false, true)
+	access, err = db.MakeAccessor(t.Name()+"_writetest", false, true)
 	if err != nil {
 		panic(err)
 	}
@@ -963,7 +963,7 @@ func TestGetRoundSecretsWithNilStateProofVerifier(t *testing.T) {
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
 
-	access, err := db.MakeAccessor("stateprooftest", false, true)
+	access, err := db.MakeAccessor(t.Name()+"_stateprooftest", false, true)
 	if err != nil {
 		panic(err)
 	}
@@ -1012,7 +1012,7 @@ func TestAddingSecretTwice(t *testing.T) {
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
 
-	access, err := db.MakeAccessor("stateprooftest", false, true)
+	access, err := db.MakeAccessor(t.Name()+"_stateprooftest", false, true)
 	if err != nil {
 		panic(err)
 	}
@@ -1050,7 +1050,7 @@ func TestGetRoundSecretsWithoutStateProof(t *testing.T) {
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
 
-	access, err := db.MakeAccessor("stateprooftest", false, true)
+	access, err := db.MakeAccessor(t.Name()+"_stateprooftest", false, true)
 	if err != nil {
 		panic(err)
 	}
@@ -1177,7 +1177,7 @@ func TestFlushResetsLastError(t *testing.T) {
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
 
-	access, err := db.MakeAccessor("stateprooftest", false, true)
+	access, err := db.MakeAccessor(t.Name()+"_stateprooftest", false, true)
 	a.NoError(err)
 
 	root, err := GenerateRoot(access)

--- a/data/account/participation_test.go
+++ b/data/account/participation_test.go
@@ -531,7 +531,7 @@ func TestFillDBWithParticipationKeys(t *testing.T) {
 	a.NoError(err)
 }
 
-func TestKeyregValidityPeriod(t *testing.T) {
+func TestKeyregValidityPeriod(t *testing.T) { //nolint:paralleltest // Not parallel because it modifies config.Consensus
 	partitiontest.PartitionTest(t)
 	a := require.New(t)
 

--- a/data/bookkeeping/block_test.go
+++ b/data/bookkeeping/block_test.go
@@ -206,7 +206,7 @@ func TestMakeBlockUpgrades(t *testing.T) {
 	require.Equal(t, bd2.NextProtocolSwitchOn-bd2.NextProtocolVoteBefore, basics.Round(5))
 }
 
-func TestBlockUnsupported(t *testing.T) {
+func TestBlockUnsupported(t *testing.T) { //nolint:paralleltest // Not parallel because it modifies config.Consensus
 	partitiontest.PartitionTest(t)
 
 	var b Block

--- a/data/transactions/json_test.go
+++ b/data/transactions/json_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/data/txntest"
 	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,6 +46,8 @@ func compact(data []byte) string {
 
 // TestJsonMarshal ensures that BoxRef names are b64 encoded, since they may not be characters.
 func TestJsonMarshal(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	marshal := protocol.EncodeJSON(transactions.BoxRef{Index: 4, Name: []byte("joe")})
 	require.Equal(t, `{"i":4,"n":"am9l"}`, compact(marshal))
 
@@ -60,6 +63,7 @@ func TestJsonMarshal(t *testing.T) {
 
 // TestJsonUnmarshal ensures that BoxRef unmarshaling expects b64 names
 func TestJsonUnmarshal(t *testing.T) {
+	partitiontest.PartitionTest(t)
 	var br transactions.BoxRef
 
 	decode(t, `{"i":4,"n":"am9l"}`, &br)
@@ -82,6 +86,8 @@ func TestJsonUnmarshal(t *testing.T) {
 // encoded. These things could change without breaking the protocol, should stay
 // the same for the sake of REST API compatibility.
 func TestTxnJson(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	txn := txntest.Txn{
 		Sender: basics.Address{0x01, 0x02, 0x03},
 	}

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -272,7 +272,7 @@ func TestTxnValidationEmptySig(t *testing.T) {
 
 const spProto = protocol.ConsensusVersion("test-state-proof-enabled")
 
-func TestTxnValidationStateProof(t *testing.T) {
+func TestTxnValidationStateProof(t *testing.T) { //nolint:paralleltest // Not parallel because it modifies config.Consensus
 	partitiontest.PartitionTest(t)
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
@@ -1195,7 +1195,7 @@ byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
 }
 
 // TestStreamVerifierPoolShutdown tests what happens when the exec pool shuts down
-func TestStreamVerifierPoolShutdown(t *testing.T) {
+func TestStreamVerifierPoolShutdown(t *testing.T) { //nolint:paralleltest // Not parallel because it depends on the default logger
 	partitiontest.PartitionTest(t)
 
 	// only one transaction should be sufficient for the batch verifier
@@ -1350,6 +1350,7 @@ func TestStreamVerifierRestart(t *testing.T) {
 
 // TestBlockWatcher runs multiple goroutines to check the concurency and correctness of the block watcher
 func TestStreamVerifierBlockWatcher(t *testing.T) {
+	partitiontest.PartitionTest(t)
 	blkHdr := createDummyBlockHeader()
 	nbw := MakeNewBlockWatcher(blkHdr)
 	startingRound := blkHdr.Round
@@ -1458,7 +1459,7 @@ func TestStreamVerifierCtxCancel(t *testing.T) {
 // so that the batch is sent to the pool. Since the pool is saturated,
 // the task will be stuck waiting to be queued when the context is canceled
 // everything should be gracefully terminated
-func TestStreamVerifierCtxCancelPoolQueue(t *testing.T) {
+func TestStreamVerifierCtxCancelPoolQueue(t *testing.T) { //nolint:paralleltest // Not parallel because it depends on the default logger
 	partitiontest.PartitionTest(t)
 
 	verificationPool, holdTasks := getSaturatedExecPool(t)
@@ -1537,6 +1538,7 @@ func TestStreamVerifierCtxCancelPoolQueue(t *testing.T) {
 // TestStreamVerifierPostVBlocked tests the behavior when the return channel (result chan) of verified
 // transactions is blocked, and checks droppedFromPool counter to confirm the drops
 func TestStreamVerifierPostVBlocked(t *testing.T) {
+	partitiontest.PartitionTest(t)
 
 	// prepare the stream verifier
 	verificationPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, t)
@@ -1622,6 +1624,7 @@ func TestStreamVerifierPostVBlocked(t *testing.T) {
 }
 
 func TestStreamVerifierMakeStreamVerifierErr(t *testing.T) {
+	partitiontest.PartitionTest(t)
 	_, err := MakeStreamVerifier(nil, nil, nil, &DummyLedgerForSignature{badHdr: true}, nil, nil)
 	require.Error(t, err)
 }

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -1109,7 +1109,7 @@ func BenchmarkTxHandlerDecoderMsgp(b *testing.B) {
 }
 
 // TestTxHandlerIncomingTxHandle checks the correctness with single txns
-func TestTxHandlerIncomingTxHandle(t *testing.T) {
+func TestTxHandlerIncomingTxHandle(t *testing.T) { //nolint:paralleltest // Not parallel because incomingTxHandlerProcessing mutates global metrics
 	partitiontest.PartitionTest(t)
 
 	numberOfTransactionGroups := 1000
@@ -1117,7 +1117,7 @@ func TestTxHandlerIncomingTxHandle(t *testing.T) {
 }
 
 // TestTxHandlerIncomingTxGroupHandle checks the correctness with txn groups
-func TestTxHandlerIncomingTxGroupHandle(t *testing.T) {
+func TestTxHandlerIncomingTxGroupHandle(t *testing.T) { //nolint:paralleltest // Not parallel because incomingTxHandlerProcessing mutates global metrics
 	partitiontest.PartitionTest(t)
 
 	numberOfTransactionGroups := 1000 / proto.MaxTxGroupSize
@@ -1125,7 +1125,7 @@ func TestTxHandlerIncomingTxGroupHandle(t *testing.T) {
 }
 
 // TestTxHandlerIncomingTxHandleDrops accounts for the dropped txns when the verifier/exec pool is saturated
-func TestTxHandlerIncomingTxHandleDrops(t *testing.T) {
+func TestTxHandlerIncomingTxHandleDrops(t *testing.T) { //nolint:paralleltest // Not parallel because it changes the backlog size
 	partitiontest.PartitionTest(t)
 
 	// use smaller backlog size to test the message drops
@@ -1903,7 +1903,7 @@ func runHandlerBenchmarkWithBacklog(b *testing.B, txGen txGenIf, tps int, useBac
 	handler.Stop() // cancel the handler ctx
 }
 
-func TestTxHandlerPostProcessError(t *testing.T) {
+func TestTxHandlerPostProcessError(t *testing.T) { //nolint:paralleltest // Not parallel because it mutates global metrics
 	partitiontest.PartitionTest(t)
 
 	defer func() {
@@ -1975,7 +1975,7 @@ func TestTxHandlerPostProcessError(t *testing.T) {
 	require.Len(t, result, expected+1)
 }
 
-func TestTxHandlerPostProcessErrorWithVerify(t *testing.T) {
+func TestTxHandlerPostProcessErrorWithVerify(t *testing.T) { //nolint:paralleltest // Not parallel because it mutates global metrics
 	partitiontest.PartitionTest(t)
 
 	defer func() {
@@ -2006,7 +2006,7 @@ func TestTxHandlerPostProcessErrorWithVerify(t *testing.T) {
 }
 
 // TestTxHandlerRememberReportErrors checks Is and As statements work as expected
-func TestTxHandlerRememberReportErrors(t *testing.T) {
+func TestTxHandlerRememberReportErrors(t *testing.T) { //nolint:paralleltest // Not parallel because incomingTxHandlerProcessing mutates global metrics
 	partitiontest.PartitionTest(t)
 
 	defer func() {
@@ -2079,7 +2079,7 @@ func (t *blockTicker) Wait() {
 	}
 }
 
-func TestTxHandlerRememberReportErrorsWithTxPool(t *testing.T) {
+func TestTxHandlerRememberReportErrorsWithTxPool(t *testing.T) { //nolint:paralleltest // Not parallel because it mutates global metrics
 	partitiontest.PartitionTest(t)
 	defer func() {
 		transactionMessageTxPoolRememberCounter = metrics.NewTagCounter(
@@ -2311,6 +2311,7 @@ func TestTxHandlerRememberReportErrorsWithTxPool(t *testing.T) {
 }
 
 func TestMakeTxHandlerErrors(t *testing.T) {
+	partitiontest.PartitionTest(t)
 	opts := TxHandlerOpts{
 		nil, nil, nil, &mocks.MockNetwork{}, "", crypto.Digest{}, config.Local{},
 	}
@@ -2330,7 +2331,8 @@ func TestMakeTxHandlerErrors(t *testing.T) {
 // TestTxHandlerRestartWithBacklogAndTxPool starts txHandler, sends transactions,
 // stops, starts in a loop, sends more transactions, and makes sure all the transactions
 // are accounted for. It uses the production backlog worker
-func TestTxHandlerRestartWithBacklogAndTxPool(t *testing.T) {
+func TestTxHandlerRestartWithBacklogAndTxPool(t *testing.T) { //nolint:paralleltest // Not parallel because it mutates global metrics
+	partitiontest.PartitionTest(t)
 	transactionMessagesDroppedFromBacklog = metrics.MakeCounter(metrics.TransactionMessagesDroppedFromBacklog)
 	transactionMessagesDroppedFromPool = metrics.MakeCounter(metrics.TransactionMessagesDroppedFromPool)
 	transactionMessagesTxnSigVerificationFailed = metrics.MakeCounter(metrics.TransactionMessagesTxnSigVerificationFailed)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Retain improvements made in #4981 PR that had been reverted due to instability. The changes here should net improve test reliability and rationale for why several are not marked parallel.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

Ran impacted tests locally several times.