### PR TITLE
metrics: add appcall and assembly block hash metrics

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -875,6 +875,7 @@ func (pool *TransactionPool) AssembleBlock(round basics.Round, deadline time.Tim
 				stats.AverageFee = totalFees / uint64(stats.IncludedCount)
 			}
 			stats.StateProofNextRound = uint64(assembled.Block().StateProofTracking[protocol.StateProofBasic].StateProofNextRound)
+			stats.BlockHash = assembled.Block().Digest().String()
 			var details struct {
 				Round uint64
 			}

--- a/logging/telemetryspec/metric.go
+++ b/logging/telemetryspec/metric.go
@@ -53,8 +53,6 @@ type AssembleBlockStats struct {
 	AverageFee                uint64
 	MinLength                 int
 	MaxLength                 int
-	MinPriority               uint64
-	MaxPriority               uint64
 	CommittedCount            int // number of transaction blocks that are included in a block
 	StopReason                string
 	TotalLength               uint64
@@ -62,6 +60,7 @@ type AssembleBlockStats struct {
 	Nanoseconds               int64
 	ProcessingTime            transactionProcessingTimeDistibution
 	BlockGenerationDuration   uint64
+	BlockHash                 string
 	TransactionsLoopStartTime int64
 	StateProofNextRound       uint64 // next round for which state proof if expected
 	StateProofStats           StateProofStats
@@ -113,8 +112,6 @@ func (m AssembleBlockStats) String() string {
 	b.WriteString(fmt.Sprintf("AverageFee:%d, ", m.AverageFee))
 	b.WriteString(fmt.Sprintf("MinLength:%d, ", m.MinLength))
 	b.WriteString(fmt.Sprintf("MaxLength:%d, ", m.MaxLength))
-	b.WriteString(fmt.Sprintf("MinPriority:%d, ", m.MinPriority))
-	b.WriteString(fmt.Sprintf("MaxPriority:%d, ", m.MaxPriority))
 	b.WriteString(fmt.Sprintf("CommittedCount:%d, ", m.CommittedCount))
 	b.WriteString(fmt.Sprintf("StopReason:%s, ", m.StopReason))
 	b.WriteString(fmt.Sprintf("TotalLength:%d, ", m.TotalLength))
@@ -122,6 +119,7 @@ func (m AssembleBlockStats) String() string {
 	b.WriteString(fmt.Sprintf("Nanoseconds:%d, ", m.Nanoseconds))
 	b.WriteString(fmt.Sprintf("ProcessingTime:%v, ", m.ProcessingTime))
 	b.WriteString(fmt.Sprintf("BlockGenerationDuration:%d, ", m.BlockGenerationDuration))
+	b.WriteString(fmt.Sprintf("BlockHash:%s, ", m.BlockHash))
 	b.WriteString(fmt.Sprintf("TransactionsLoopStartTime:%d, ", m.TransactionsLoopStartTime))
 	b.WriteString(fmt.Sprintf("StateProofNextRound:%d, ", m.StateProofNextRound))
 	emptySPStats := StateProofStats{}


### PR DESCRIPTION
## Summary

* AssmbleBlock stats now has block digest
* StatefulEval reports app call good/rej/err/cost metrics similarly to logicsig

## Test Plan

Existing tests