### PR TITLE
debug: unmarshal and print transaction distribution

### DIFF
--- a/logging/telemetryspec/metric.go
+++ b/logging/telemetryspec/metric.go
@@ -61,7 +61,7 @@ type AssembleBlockStats struct {
 	TotalLength               uint64
 	EarlyCommittedCount       uint64 // number of transaction groups that were pending on the transaction pool but have been included in previous block
 	Nanoseconds               int64
-	ProcessingTime            transactionProcessingTimeDistibution
+	ProcessingTime            transactionProcessingTimeDistribution
 	BlockGenerationDuration   uint64
 	TransactionsLoopStartTime int64
 	StateProofNextRound       uint64 // next round for which state proof if expected
@@ -216,7 +216,7 @@ func (m AccountsUpdateMetrics) Identifier() Metric {
 	return accountsUpdateMetricsIdentifier
 }
 
-type transactionProcessingTimeDistibution struct {
+type transactionProcessingTimeDistribution struct {
 	// 10 buckets: 0-100Kns, 100Kns-200Kns .. 900Kns-1ms
 	// 9 buckets: 1ms-2ms .. 9ms-10ms
 	// 9 buckets: 10ms-20ms .. 90ms-100ms
@@ -227,7 +227,7 @@ type transactionProcessingTimeDistibution struct {
 
 // MarshalJSON supports json.Marshaler interface
 // generate comma delimited text representing the transaction processing timing
-func (t transactionProcessingTimeDistibution) MarshalJSON() ([]byte, error) {
+func (t transactionProcessingTimeDistribution) MarshalJSON() ([]byte, error) {
 	var outStr strings.Builder
 	outStr.WriteString("[")
 	for i, bucket := range t.transactionBuckets {
@@ -240,7 +240,7 @@ func (t transactionProcessingTimeDistibution) MarshalJSON() ([]byte, error) {
 	return []byte(outStr.String()), nil
 }
 
-func (t *transactionProcessingTimeDistibution) AddTransaction(duration time.Duration) {
+func (t *transactionProcessingTimeDistribution) AddTransaction(duration time.Duration) {
 	var idx int64
 	if duration < 10*time.Millisecond {
 		if duration < time.Millisecond {
@@ -262,7 +262,7 @@ func (t *transactionProcessingTimeDistibution) AddTransaction(duration time.Dura
 	}
 }
 
-func (t *transactionProcessingTimeDistibution) UnmarshalJSON(data []byte) error {
+func (t *transactionProcessingTimeDistribution) UnmarshalJSON(data []byte) error {
 	var arr []json.Number
 	if err := json.Unmarshal(data, &arr); err != nil {
 		return err
@@ -280,7 +280,7 @@ func (t *transactionProcessingTimeDistibution) UnmarshalJSON(data []byte) error 
 	return nil
 }
 
-func (t *transactionProcessingTimeDistibution) MarshalString() string {
+func (t *transactionProcessingTimeDistribution) MarshalString() string {
 	var out strings.Builder
 	var offset int
 	var base, mul time.Duration

--- a/logging/telemetryspec/metric_test.go
+++ b/logging/telemetryspec/metric_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
-func TestTransactionProcessingTimeDistibutionFormatting(t *testing.T) {
+func TestTransactionProcessingTimeDistributionFormatting(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	var processingTime transactionProcessingTimeDistibution
+	var processingTime transactionProcessingTimeDistribution
 	processingTime.AddTransaction(50000 * time.Nanosecond)
 	processingTime.AddTransaction(80000 * time.Nanosecond)
 	processingTime.AddTransaction(120000 * time.Nanosecond)
@@ -42,12 +42,12 @@ func TestTransactionProcessingTimeDistibutionFormatting(t *testing.T) {
 	expected := "[2,3,0,0,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]"
 	require.Equal(t, []byte(expected), bytes)
 
-	var decPT transactionProcessingTimeDistibution
+	var decPT transactionProcessingTimeDistribution
 	require.NoError(t, json.Unmarshal([]byte(expected), &decPT))
 	require.Equal(t, processingTime, decPT)
 
 	container := struct {
-		ProcessingTime transactionProcessingTimeDistibution
+		ProcessingTime transactionProcessingTimeDistribution
 	}{ProcessingTime: processingTime}
 
 	bytes, err = json.Marshal(container)
@@ -55,8 +55,8 @@ func TestTransactionProcessingTimeDistibutionFormatting(t *testing.T) {
 	require.Equal(t, []byte("{\"ProcessingTime\":[2,3,0,0,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}"), bytes)
 }
 
-func TestTransactionProcessingTimeDistibutionPrint(t *testing.T) {
-	var decPT transactionProcessingTimeDistibution
+func TestTransactionProcessingTimeDistributionPrint(t *testing.T) {
+	var decPT transactionProcessingTimeDistribution
 	expected := "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38]"
 	require.NoError(t, json.Unmarshal([]byte(expected), &decPT))
 	t.Log("\n" + decPT.MarshalString())

--- a/logging/telemetryspec/metric_test.go
+++ b/logging/telemetryspec/metric_test.go
@@ -39,7 +39,12 @@ func TestTransactionProcessingTimeDistibutionFormatting(t *testing.T) {
 	processingTime.AddTransaction(2 * time.Millisecond)
 	bytes, err := processingTime.MarshalJSON()
 	require.NoError(t, err)
-	require.Equal(t, []byte("[2,3,0,0,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]"), bytes)
+	expected := "[2,3,0,0,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]"
+	require.Equal(t, []byte(expected), bytes)
+
+	var decPT transactionProcessingTimeDistibution
+	require.NoError(t, json.Unmarshal([]byte(expected), &decPT))
+	require.Equal(t, processingTime, decPT)
 
 	container := struct {
 		ProcessingTime transactionProcessingTimeDistibution
@@ -48,6 +53,13 @@ func TestTransactionProcessingTimeDistibutionFormatting(t *testing.T) {
 	bytes, err = json.Marshal(container)
 	require.NoError(t, err)
 	require.Equal(t, []byte("{\"ProcessingTime\":[2,3,0,0,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}"), bytes)
+}
+
+func TestTransactionProcessingTimeDistibutionPrint(t *testing.T) {
+	var decPT transactionProcessingTimeDistibution
+	expected := "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38]"
+	require.NoError(t, json.Unmarshal([]byte(expected), &decPT))
+	t.Log("\n" + decPT.MarshalString())
 }
 
 func TestAssembleBlockStatsString(t *testing.T) {


### PR DESCRIPTION
## Summary

Support for parsing and printing the transaction processing time histogram buckets in an easier-to-read format.

## Test Plan

Updated tests in metrics_test