### PR TITLE
network: increase max incoming connections limit

### DIFF
--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -59,7 +59,7 @@ type Local struct {
 	// what we should tell people to connect to
 	PublicAddress string `version[0]:""`
 
-	MaxConnectionsPerIP int `version[3]:"30"`
+	MaxConnectionsPerIP int `version[3]:"30" version[27]:"15"`
 
 	// 0 == disable
 	PeerPingPeriodSeconds int `version[0]:"0"`

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -75,8 +75,8 @@ type Local struct {
 
 	// IncomingConnectionsLimit specifies the max number of long-lived incoming
 	// connections. 0 means no connections allowed. Must be non-negative.
-	// Estimating 5MB per incoming connection, 5MB*800 = 4GB
-	IncomingConnectionsLimit int `version[0]:"-1" version[1]:"10000" version[17]:"800"`
+	// Estimating 1.5MB per incoming connection, 1.5MB*2400 = 3.6GB
+	IncomingConnectionsLimit int `version[0]:"-1" version[1]:"10000" version[17]:"800" version[27]:"2400"`
 
 	// BroadcastConnectionsLimit specifies the number of connections that
 	// will receive broadcast (gossip) messages from this node.  If the

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -92,7 +92,7 @@ var defaultLocal = Local{
 	MaxAPIResourcesPerAccount:                  100000,
 	MaxAcctLookback:                            4,
 	MaxCatchpointDownloadDuration:              7200000000000,
-	MaxConnectionsPerIP:                        30,
+	MaxConnectionsPerIP:                        15,
 	MinCatchpointFileDownloadBytesPerSecond:    20480,
 	NetAddress:                                 "",
 	NetworkMessageTraceServer:                  "",

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -80,7 +80,7 @@ var defaultLocal = Local{
 	ForceRelayMessages:                         false,
 	GossipFanout:                               4,
 	HeartbeatUpdateInterval:                    600,
-	IncomingConnectionsLimit:                   800,
+	IncomingConnectionsLimit:                   2400,
 	IncomingMessageFilterBucketCount:           5,
 	IncomingMessageFilterBucketSize:            512,
 	IsIndexerActive:                            false,

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -59,7 +59,7 @@
     "ForceRelayMessages": false,
     "GossipFanout": 4,
     "HeartbeatUpdateInterval": 600,
-    "IncomingConnectionsLimit": 800,
+    "IncomingConnectionsLimit": 2400,
     "IncomingMessageFilterBucketCount": 5,
     "IncomingMessageFilterBucketSize": 512,
     "IsIndexerActive": false,

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -71,7 +71,7 @@
     "MaxAPIResourcesPerAccount": 100000,
     "MaxAcctLookback": 4,
     "MaxCatchpointDownloadDuration": 7200000000000,
-    "MaxConnectionsPerIP": 30,
+    "MaxConnectionsPerIP": 15,
     "MinCatchpointFileDownloadBytesPerSecond": 20480,
     "NetAddress": "",
     "NetworkMessageTraceServer": "",

--- a/test/testdata/configs/config-v27.json
+++ b/test/testdata/configs/config-v27.json
@@ -60,7 +60,7 @@
     "ForceRelayMessages": false,
     "GossipFanout": 4,
     "HeartbeatUpdateInterval": 600,
-    "IncomingConnectionsLimit": 800,
+    "IncomingConnectionsLimit": 2400,
     "IncomingMessageFilterBucketCount": 5,
     "IncomingMessageFilterBucketSize": 512,
     "IsIndexerActive": false,

--- a/test/testdata/configs/config-v27.json
+++ b/test/testdata/configs/config-v27.json
@@ -72,7 +72,7 @@
     "MaxAPIBoxPerApplication": 100000,
     "MaxAPIResourcesPerAccount": 100000,
     "MaxCatchpointDownloadDuration": 7200000000000,
-    "MaxConnectionsPerIP": 30,
+    "MaxConnectionsPerIP": 15,
     "MinCatchpointFileDownloadBytesPerSecond": 20480,
     "NetAddress": "",
     "NetworkMessageTraceServer": "",


### PR DESCRIPTION
## Summary

According to the latest measurement a single connection consumes about 1 MiB of RAM (calculated 600 KiB measured lower bound is 800 KiB, upper bound is 1.5 MiB).
Setting `IncomingConnectionsLimit` to 2400 should have a total memory footprint of 3.6 GiB.
Also decreased `MaxConnectionsPerIP` to 15 as a best guess based on a fact only fraction of nodes report hitting this limit.

## Test Plan

Existing tests