### PR TITLE
agreement: dedup AV messages

### DIFF
--- a/agreement/abstractions.go
+++ b/agreement/abstractions.go
@@ -281,7 +281,7 @@ type Network interface {
 
 	// Start notifies the network that the agreement service is ready
 	// to start receiving messages.
-	Start()
+	Start(context.Context)
 }
 
 // RandomSource is an abstraction over the random number generator.

--- a/agreement/gossip/networkFull_test.go
+++ b/agreement/gossip/networkFull_test.go
@@ -17,6 +17,7 @@
 package gossip
 
 import (
+	"context"
 	"os"
 	"sync"
 	"testing"
@@ -81,7 +82,7 @@ func spinNetwork(t *testing.T, nodesCount int, cfg config.Local) ([]*networkImpl
 	for _, gossipNode := range gossipNodes {
 		networkImpl := WrapNetwork(gossipNode, log, cfg).(*networkImpl)
 		networkImpls = append(networkImpls, networkImpl)
-		networkImpl.Start()
+		networkImpl.Start(context.Background())
 		msgCounter := startMessageCounter(networkImpl)
 		msgCounters = append(msgCounters, msgCounter)
 	}

--- a/agreement/gossip/networkFull_test.go
+++ b/agreement/gossip/networkFull_test.go
@@ -116,7 +116,7 @@ func shutdownNetwork(nets []*networkImpl, counters []*messageCounter) {
 			defer wg.Done()
 			net.ClearHandlers()
 			net.Stop()
-		}(net.net)
+		}(net.net.(network.GossipNode))
 	}
 	for _, counter := range counters {
 		counter.stop()
@@ -348,10 +348,10 @@ func testNetworkImplRebroadcast(t *testing.T, nodesCount int, cfg config.Local) 
 }
 
 func writeDetailedErrorInfo(t *testing.T, i int, nets []*networkImpl) {
-	address, _ := nets[i].net.Address()
+	address, _ := nets[i].net.(network.GossipNode).Address()
 	t.Errorf("failed on i=%d address %+v\n", i, address)
 	for _, n := range nets {
-		address, _ := n.net.Address()
+		address, _ := n.net.(network.GossipNode).Address()
 		t.Errorf("node %v\n", address)
 	}
 }

--- a/agreement/gossip/network_test.go
+++ b/agreement/gossip/network_test.go
@@ -18,8 +18,6 @@ package gossip
 
 import (
 	"context"
-	"net"
-	"net/http"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -52,13 +50,15 @@ type whiteholeDomain struct {
 }
 
 type whiteholeNetwork struct {
-	network.GossipNode
+	AgreementGossipNode
 	peer         uint32
 	lastMsgRead  uint32
 	mux          *network.Multiplexer
 	quit         chan struct{}
 	domain       *whiteholeDomain
 	disconnected map[uint32]bool
+	ctx          context.Context
+	cancel       context.CancelFunc
 	log          logging.Logger
 }
 
@@ -116,7 +116,6 @@ func (w *whiteholeNetwork) innerBroadcast(tag network.Tag, data []byte) {
 		Sender: w.peer,
 	}
 	w.placeMsg(msg)
-	return
 }
 
 func (w *whiteholeNetwork) Broadcast(ctx context.Context, tag protocol.Tag, data []byte, wait bool, except network.Peer) error {
@@ -136,28 +135,8 @@ func (w *whiteholeNetwork) Relay(ctx context.Context, tag protocol.Tag, data []b
 func (w *whiteholeNetwork) BroadcastSimple(tag protocol.Tag, data []byte) error {
 	return w.Broadcast(context.Background(), tag, data, true, nil)
 }
+
 func (w *whiteholeNetwork) Disconnect(badnode network.Peer) {
-	return
-}
-func (w *whiteholeNetwork) DisconnectPeers() {
-	return
-}
-func (w *whiteholeNetwork) Ready() chan struct{} {
-	return make(chan struct{})
-}
-func (w *whiteholeNetwork) RegisterRPCName(name string, rcvr interface{}) {
-	return
-}
-func (w *whiteholeNetwork) RequestConnectOutgoing(replace bool, quit <-chan struct{}) {
-	return
-}
-func (w *whiteholeNetwork) GetPeers(options ...network.PeerOption) []network.Peer {
-	return nil
-}
-func (w *whiteholeNetwork) RegisterHTTPHandler(path string, handler http.Handler) {
-}
-func (w *whiteholeNetwork) GetHTTPRequestConnection(request *http.Request) (conn net.Conn) {
-	return nil
 }
 
 func (w *whiteholeNetwork) Start() {

--- a/agreement/gossip/network_test.go
+++ b/agreement/gossip/network_test.go
@@ -335,7 +335,7 @@ func spinNetworkImpl(domain *whiteholeDomain) (whiteholeNet *whiteholeNetwork, c
 	netImpl := WrapNetwork(whiteholeNet, logging.Base(), config.GetDefaultLocal()).(*networkImpl)
 	counter = startMessageCounter(netImpl)
 	whiteholeNet.Start()
-	netImpl.Start()
+	netImpl.Start(context.Background())
 	return
 }
 

--- a/agreement/service.go
+++ b/agreement/service.go
@@ -112,8 +112,8 @@ func (s *Service) SetTracerFilename(filename string) {
 
 // Start executing the agreement protocol.
 func (s *Service) Start() {
-	s.parameters.Network.Start()
 	ctx, quitFn := context.WithCancel(context.Background())
+	s.parameters.Network.Start(ctx)
 	s.quitFn = quitFn
 
 	s.quit = make(chan struct{})

--- a/agreement/service_test.go
+++ b/agreement/service_test.go
@@ -490,7 +490,7 @@ func (e *testingNetworkEndpoint) Disconnect(h MessageHandle) {
 	e.parent.disconnect(e.id, sourceID)
 }
 
-func (e *testingNetworkEndpoint) Start() {}
+func (e *testingNetworkEndpoint) Start(context.Context) {}
 
 type activityMonitor struct {
 	deadlock.Mutex

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -36,6 +36,7 @@ import (
 	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/util"
+	"github.com/algorand/go-algorand/util/dedup"
 	"github.com/algorand/go-algorand/util/execpool"
 	"github.com/algorand/go-algorand/util/metrics"
 )
@@ -120,8 +121,8 @@ type TxHandler struct {
 	postVerificationQueue chan *verify.VerificationResult
 	backlogWg             sync.WaitGroup
 	net                   network.GossipNode
-	msgCache              *txSaltedCache
-	txCanonicalCache      *digestCache
+	msgCache              *dedup.SaltedCache
+	txCanonicalCache      *dedup.DigestCache
 	cacheConfig           txHandlerConfig
 	ctx                   context.Context
 	ctxCancel             context.CancelFunc
@@ -174,8 +175,8 @@ func MakeTxHandler(opts TxHandlerOpts) (*TxHandler, error) {
 		backlogQueue:          make(chan *txBacklogMsg, txBacklogSize),
 		postVerificationQueue: make(chan *verify.VerificationResult, txBacklogSize),
 		net:                   opts.Net,
-		msgCache:              makeSaltedCache(2 * txBacklogSize),
-		txCanonicalCache:      makeDigestCache(2 * txBacklogSize),
+		msgCache:              dedup.MakeSaltedCache(2 * txBacklogSize),
+		txCanonicalCache:      dedup.MakeDigestCache(2 * txBacklogSize),
 		cacheConfig:           txHandlerConfig{opts.Config.TxFilterRawMsgEnabled(), opts.Config.TxFilterCanonicalEnabled()},
 		streamVerifierChan:    make(chan *verify.UnverifiedElement),
 		streamVerifierDropped: make(chan *verify.UnverifiedElement),

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/algorand/go-algorand/util/dedup"
 	"github.com/algorand/go-algorand/util/execpool"
 	"github.com/algorand/go-algorand/util/metrics"
 )
@@ -784,8 +785,8 @@ func makeTestTxHandlerOrphanedWithContext(ctx context.Context, backlogSize int, 
 	}
 	handler := &TxHandler{
 		backlogQueue:     make(chan *txBacklogMsg, backlogSize),
-		msgCache:         makeSaltedCache(cacheSize),
-		txCanonicalCache: makeDigestCache(cacheSize),
+		msgCache:         dedup.MakeSaltedCache(cacheSize),
+		txCanonicalCache: dedup.MakeDigestCache(cacheSize),
 		cacheConfig:      txHandlerConfig,
 	}
 	handler.msgCache.Start(ctx, refreshInterval)
@@ -885,8 +886,7 @@ func TestTxHandlerProcessIncomingCacheRotation(t *testing.T) {
 	require.Equal(t, 1, len(stxns1))
 
 	resetCanonical := func(handler *TxHandler) {
-		handler.txCanonicalCache.swap()
-		handler.txCanonicalCache.swap()
+		handler.txCanonicalCache.Reset()
 	}
 
 	t.Run("scheduled", func(t *testing.T) {

--- a/util/dedup/dedupCache.go
+++ b/util/dedup/dedupCache.go
@@ -40,6 +40,7 @@ type DigestCache struct {
 	mu      deadlock.RWMutex
 }
 
+// MakeDigestCache returns a new DigestCache with internal data storage upper bound of 2x size
 func MakeDigestCache(size int) *DigestCache {
 	c := &DigestCache{
 		cur:     map[crypto.Digest]struct{}{},
@@ -120,12 +121,15 @@ type SaltedCache struct {
 	wg       sync.WaitGroup
 }
 
+// MakeSaltedCache returns a new SaltedCache with internal data storage upper bound of 2x size
 func MakeSaltedCache(size int) *SaltedCache {
 	return &SaltedCache{
 		DigestCache: *MakeDigestCache(size),
 	}
 }
 
+// Start salter goroutine that rotates salt at refreshInterval.
+// Canceling the ctx context signals the goroutine to exit.
 func (c *SaltedCache) Start(ctx context.Context, refreshInterval time.Duration) {
 	c.ctx = ctx
 	if refreshInterval != 0 {
@@ -138,6 +142,7 @@ func (c *SaltedCache) Start(ctx context.Context, refreshInterval time.Duration) 
 	c.moreSalt()
 }
 
+// WaitForStop waits until the salter goroutine exits
 func (c *SaltedCache) WaitForStop() {
 	c.wg.Wait()
 }

--- a/util/dedup/dedupCache_test.go
+++ b/util/dedup/dedupCache_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
 
-package data
+package dedup
 
 import (
 	"context"
@@ -38,7 +38,7 @@ func TestTxHandlerDigestCache(t *testing.T) {
 	t.Parallel()
 
 	const size = 20
-	cache := makeDigestCache(size)
+	cache := MakeDigestCache(size)
 	require.Zero(t, cache.Len())
 
 	// add some unique random
@@ -108,7 +108,7 @@ func TestTxHandlerDigestCache(t *testing.T) {
 	require.Equal(t, 0, cache.Len())
 }
 
-func (c *txSaltedCache) check(msg []byte) bool {
+func (c *SaltedCache) check(msg []byte) bool {
 	_, found := c.innerCheck(msg)
 	return found
 }
@@ -119,7 +119,7 @@ func TestTxHandlerSaltedCacheBasic(t *testing.T) {
 	t.Parallel()
 
 	const size = 20
-	cache := makeSaltedCache(size)
+	cache := MakeSaltedCache(size)
 	cache.Start(context.Background(), 0)
 	require.Zero(t, cache.Len())
 
@@ -203,7 +203,7 @@ func TestTxHandlerSaltedCacheScheduled(t *testing.T) {
 
 	const size = 20
 	updateInterval := 1000 * time.Microsecond
-	cache := makeSaltedCache(size)
+	cache := MakeSaltedCache(size)
 	cache.Start(context.Background(), updateInterval)
 	require.Zero(t, cache.Len())
 
@@ -228,7 +228,7 @@ func TestTxHandlerSaltedCacheManual(t *testing.T) {
 	t.Parallel()
 
 	const size = 20
-	cache := makeSaltedCache(2 * size)
+	cache := MakeSaltedCache(2 * size)
 	cache.Start(context.Background(), 0)
 	require.Zero(t, cache.Len())
 
@@ -290,19 +290,19 @@ type digestCacheMaker struct{}
 type saltedCacheMaker struct{}
 
 func (m digestCacheMaker) make(size int) cachePusher {
-	return &digestCachePusher{c: makeDigestCache(size)}
+	return &digestCachePusher{c: MakeDigestCache(size)}
 }
 func (m saltedCacheMaker) make(size int) cachePusher {
-	scp := &saltedCachePusher{c: makeSaltedCache(size)}
+	scp := &saltedCachePusher{c: MakeSaltedCache(size)}
 	scp.c.Start(context.Background(), 0)
 	return scp
 }
 
 type digestCachePusher struct {
-	c *digestCache
+	c *DigestCache
 }
 type saltedCachePusher struct {
-	c *txSaltedCache
+	c *SaltedCache
 }
 
 func (p *digestCachePusher) push() {

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -84,6 +84,8 @@ var (
 	AgreementMessagesHandled = MetricName{Name: "algod_agreement_handled", Description: "Number of agreement messages handled"}
 	// AgreementMessagesDropped "Number of agreement messages dropped"
 	AgreementMessagesDropped = MetricName{Name: "algod_agreement_dropped", Description: "Number of agreement messages dropped"}
+	// AgreementMessagesDropped "Number of duplicate agreement vote messages dropped"
+	AgreementMessagesVoteDup = MetricName{Name: "algod_agreement_vote_dup_dropped", Description: "Number of duplicate agreement vote messages dropped"}
 
 	// TransactionMessagesHandled "Number of transaction messages handled"
 	TransactionMessagesHandled = MetricName{Name: "algod_transaction_messages_handled", Description: "Number of transaction messages handled"}

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -84,7 +84,7 @@ var (
 	AgreementMessagesHandled = MetricName{Name: "algod_agreement_handled", Description: "Number of agreement messages handled"}
 	// AgreementMessagesDropped "Number of agreement messages dropped"
 	AgreementMessagesDropped = MetricName{Name: "algod_agreement_dropped", Description: "Number of agreement messages dropped"}
-	// AgreementMessagesDropped "Number of duplicate agreement vote messages dropped"
+	// AgreementMessagesVoteDup "Number of duplicate agreement vote messages dropped"
 	AgreementMessagesVoteDup = MetricName{Name: "algod_agreement_vote_dup_dropped", Description: "Number of duplicate agreement vote messages dropped"}
 
 	// TransactionMessagesHandled "Number of transaction messages handled"


### PR DESCRIPTION
## Summary

Similarly to txHandler, add AV dedup cache/filter to AV messages handler.
Parameters:
```
// 20k
size := 2 * int(cfg.AgreementIncomingVotesQueueLength)
// 42 sec
refreshInterval := 2 * (config.Consensus[protocol.ConsensusCurrentVersion].AgreementFilterTimeout + agreement.DeadlineTimeout())
```

Additionally added `GossipAgreementNode` interface that is subset of `network.GossipNode` since agreement does not need all methods from `GossipNode`

## Test Plan

Added a unit test