### PR TITLE
Txhandler: Improve dedupe hit rate

### DIFF
--- a/data/txDupCache.go
+++ b/data/txDupCache.go
@@ -244,6 +244,13 @@ func (c *txSaltedCache) CheckAndPut(msg []byte) (*crypto.Digest, bool) {
 		d = &dn
 	}
 
+	if _, found := c.cur[*d]; found {
+		return nil, true
+	}
+	if _, found := c.prev[*d]; found {
+		return nil, true
+	}
+
 	c.cur[*d] = struct{}{}
 	return d, false
 }

--- a/data/txDupCache.go
+++ b/data/txDupCache.go
@@ -244,11 +244,13 @@ func (c *txSaltedCache) CheckAndPut(msg []byte) (*crypto.Digest, bool) {
 		d = &dn
 	}
 
+	// Do a final check to see if another copy of the transaction got to the write lock at the same time.
+	// No need to rehash since we have it already
 	if _, found := c.cur[*d]; found {
-		return nil, true
+		return d, true
 	}
 	if _, found := c.prev[*d]; found {
-		return nil, true
+		return d, true
 	}
 
 	c.cur[*d] = struct{}{}

--- a/data/txDupCache.go
+++ b/data/txDupCache.go
@@ -228,12 +228,12 @@ func (c *txSaltedCache) CheckAndPut(msg []byte) (*crypto.Digest, bool) {
 			// already added to cache between RUnlock() and Lock(), return
 			return d, found
 		}
-	}
-
-	// Do another check to see if another copy of the transaction won the race to write it to the cache
-	// Only check current to save a lookup since swaps are rare and no need to re-hash
-	if _, found := c.cur[*d]; found {
-		return d, found
+	} else {
+		// Do another check to see if another copy of the transaction won the race to write it to the cache
+		// Only check current to save a lookup since swaps are rare and no need to re-hash
+		if _, found := c.cur[*d]; found {
+			return d, found
+		}
 	}
 
 	if len(c.cur) >= c.maxSize {


### PR DESCRIPTION
## Summary

Add a check in the cache without rehashing before writing and  returning to avoid the race condition that allows close to simultaneous received transactions to miss the cache due to a race condition. 

Currently checks both caches but could reasonably only check the current cache if we wanted to trade some time cost for slightly lower hit rate.
## Test Plan

Existing tests should pass.

Benchmark results:

Old:

```
BenchmarkDigestCaches/data.digestCacheMaker/threads=1-10         	 1620752	       773.7 ns/op	     200 B/op	       2 allocs/op
BenchmarkDigestCaches/data.saltedCacheMaker/threads=1-10         	 1000000	      1030 ns/op	     220 B/op	       4 allocs/op
BenchmarkDigestCaches/data.digestCacheMaker/threads=4-10         	 2157205	       591.4 ns/op	     165 B/op	       2 allocs/op
BenchmarkDigestCaches/data.saltedCacheMaker/threads=4-10         	  994120	      1312 ns/op	     221 B/op	       4 allocs/op
BenchmarkDigestCaches/data.digestCacheMaker/threads=16-10        	 1668930	       782.4 ns/op	     195 B/op	       2 allocs/op
BenchmarkDigestCaches/data.saltedCacheMaker/threads=16-10        	  991202	      1313 ns/op	     221 B/op	       4 allocs/op
BenchmarkDigestCaches/data.digestCacheMaker/threads=128-10       	 1564032	       811.0 ns/op	     205 B/op	       2 allocs/op
BenchmarkDigestCaches/data.saltedCacheMaker/threads=128-10       	  989119	      1320 ns/op	     222 B/op	       4 allocs/op
```

New:

```
BenchmarkDigestCaches/data.digestCacheMaker/threads=1-10         	 1630840	       770.9 ns/op	     199 B/op	       2 allocs/op
BenchmarkDigestCaches/data.saltedCacheMaker/threads=1-10         	 1000000	      1121 ns/op	     220 B/op	       4 allocs/op
BenchmarkDigestCaches/data.digestCacheMaker/threads=4-10         	 2179699	       586.2 ns/op	     164 B/op	       2 allocs/op
BenchmarkDigestCaches/data.saltedCacheMaker/threads=4-10         	  929139	      1438 ns/op	     229 B/op	       4 allocs/op
BenchmarkDigestCaches/data.digestCacheMaker/threads=16-10        	 1500031	       813.2 ns/op	     212 B/op	       2 allocs/op
BenchmarkDigestCaches/data.saltedCacheMaker/threads=16-10        	  925924	      1429 ns/op	     229 B/op	       4 allocs/op
BenchmarkDigestCaches/data.digestCacheMaker/threads=128-10       	 1600089	       808.9 ns/op	     202 B/op	       2 allocs/op
BenchmarkDigestCaches/data.saltedCacheMaker/threads=128-10       	  891339	      1475 ns/op	     234 B/op	       4 allocs/op

```
