### PR TITLE
util/s3: remove extra println

### DIFF
--- a/util/s3/s3Helper.go
+++ b/util/s3/s3Helper.go
@@ -138,10 +138,6 @@ func makeS3Session(bucket string) (helper Helper, err error) {
 		sess.Config.Credentials = credentials.AnonymousCredentials
 	}
 
-	if reflect.DeepEqual(sess.Config.Credentials, credentials.AnonymousCredentials) {
-		fmt.Println("Using anonymous credentials")
-	}
-
 	helper = Helper{
 		session: sess,
 		bucket:  bucket,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

- removes the extra println from `util/s3` since older `update.sh` scripts use an exact line number to get the version. this was introduced in https://github.com/algorand/go-algorand/pull/4929

