### PR TITLE
algocfg: Clarify config file loading error.

### DIFF
--- a/cmd/algocfg/getCommand.go
+++ b/cmd/algocfg/getCommand.go
@@ -46,7 +46,7 @@ var getCmd = &cobra.Command{
 		onDataDirs(func(dataDir string) {
 			cfg, err := config.LoadConfigFromDisk(dataDir)
 			if err != nil && !os.IsNotExist(err) {
-				reportWarnf("Error loading config file from '%s'", dataDir)
+				reportWarnf("Error loading config file from '%s' - %s", dataDir, err)
 				anyError = true
 				return
 			}

--- a/cmd/algocfg/resetCommand.go
+++ b/cmd/algocfg/resetCommand.go
@@ -48,7 +48,7 @@ var resetCmd = &cobra.Command{
 		onDataDirs(func(dataDir string) {
 			cfg, err := config.LoadConfigFromDisk(dataDir)
 			if err != nil && !os.IsNotExist(err) {
-				reportWarnf("Error loading config file from '%s'", dataDir)
+				reportWarnf("Error loading config file from '%s' - %s", dataDir, err)
 				anyError = true
 				return
 			}

--- a/cmd/algocfg/setCommand.go
+++ b/cmd/algocfg/setCommand.go
@@ -52,7 +52,7 @@ var setCmd = &cobra.Command{
 		onDataDirs(func(dataDir string) {
 			cfg, err := config.LoadConfigFromDisk(dataDir)
 			if err != nil && !os.IsNotExist(err) {
-				reportWarnf("Error loading config file from '%s'", dataDir)
+				reportWarnf("Error loading config file from '%s' - %s", dataDir, err)
 				anyError = true
 				return
 			}


### PR DESCRIPTION
## Summary

This error was being triggered by the new docker container. The working theory is that a newer config file is sometimes used with an older version of algocfg. This error message would clarify what is going wrong.
