### PR TITLE
refactor: remove `sql.Tx` from the transaction callback 

### DIFF
--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -498,7 +498,7 @@ func (ct *catchpointTracker) commitRound(ctx context.Context, tx *sql.Tx, dcc *d
 	arw := store.NewAccountsSQLReaderWriter(tx)
 
 	if ct.catchpointEnabled() {
-		var mc *store.MerkleCommitter
+		var mc store.MerkleCommitter
 		mc, err = store.MakeMerkleCommitter(tx, false)
 		if err != nil {
 			return

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -459,7 +459,7 @@ func TestFullCatchpointWriterOverflowAccounts(t *testing.T) {
 	// now manually construct the MT and ensure the reading makeOrderedAccountsIter works as expected:
 	// no errors on read, hashes match
 	ctx := context.Background()
-	// tx, err := l.trackerDBs.Wdb.Handle.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+
 	err = l.trackerDBs.TransactionContext(ctx, func(ctx context.Context, tx store.TransactionScope) (err error) {
 		arw, err := tx.CreateAccountsReaderWriter()
 		if err != nil {

--- a/ledger/store/interface.go
+++ b/ledger/store/interface.go
@@ -43,6 +43,13 @@ type AccountsWriter interface {
 	Close()
 }
 
+// AccountsWriterExt is the write interface used inside transactions and batch operations.
+type AccountsWriterExt interface {
+	ResetAccountHashes(ctx context.Context) (err error)
+	TxtailNewRound(ctx context.Context, baseRound basics.Round, roundData [][]byte, forgetBeforeRound basics.Round) error
+	UpdateAccountsRound(rnd basics.Round) (err error)
+}
+
 // AccountsReader is the read interface for:
 // - accounts, resources, app kvs, creatables
 type AccountsReader interface {
@@ -59,6 +66,13 @@ type AccountsReader interface {
 	LookupCreator(cidx basics.CreatableIndex, ctype basics.CreatableType) (addr basics.Address, ok bool, dbRound basics.Round, err error)
 
 	Close()
+}
+
+// AccountsReaderWriter is AccountsReader+AccountsWriter
+type AccountsReaderWriter interface {
+	// AccountsReader
+	// AccountsWriter
+	AccountsWriterExt
 }
 
 // OnlineAccountsWriter is the write interface for:
@@ -86,6 +100,11 @@ type CatchpointWriter interface {
 
 	WriteCatchpointStateUint64(ctx context.Context, stateName CatchpointState, setValue uint64) (err error)
 	WriteCatchpointStateString(ctx context.Context, stateName CatchpointState, setValue string) (err error)
+
+	WriteCatchpointStagingBalances(ctx context.Context, bals []NormalizedAccountBalance) error
+	WriteCatchpointStagingKVs(ctx context.Context, keys [][]byte, values [][]byte, hashes [][]byte) error
+	WriteCatchpointStagingCreatable(ctx context.Context, bals []NormalizedAccountBalance) error
+	WriteCatchpointStagingHashes(ctx context.Context, bals []NormalizedAccountBalance) error
 
 	InsertUnfinishedCatchpoint(ctx context.Context, round basics.Round, blockHash crypto.Digest) error
 	DeleteUnfinishedCatchpoint(ctx context.Context, round basics.Round) error

--- a/ledger/store/store.go
+++ b/ledger/store/store.go
@@ -29,14 +29,20 @@ type trackerSQLStore struct {
 	pair db.Pair
 }
 
-// TODO: maintain a SQL tx for now
 type batchFn func(ctx context.Context, tx *sql.Tx) error
 
-// TODO: maintain a SQL tx for now
 type snapshotFn func(ctx context.Context, tx *sql.Tx) error
 
-// TODO: maintain a SQL tx for now
-type transactionFn func(ctx context.Context, tx *sql.Tx) error
+type transactionFn func(ctx context.Context, tx TransactionScope) error
+type TransactionScope interface {
+	CreateCatchpointReaderWriter() (CatchpointReaderWriter, error)
+	CreateAccountsReaderWriter() (AccountsReaderWriter, error)
+	CreateMerkleCommitter(staging bool) (MerkleCommitter, error)
+	CreateOrderedAccountsIter(accountCount int) *orderedAccountsIter
+}
+type sqlTransactionScope struct {
+	tx *sql.Tx
+}
 
 // TrackerStore is the interface for the tracker db.
 type TrackerStore interface {
@@ -117,7 +123,7 @@ func (s *trackerSQLStore) Transaction(fn transactionFn) (err error) {
 
 func (s *trackerSQLStore) TransactionContext(ctx context.Context, fn transactionFn) (err error) {
 	return s.pair.Wdb.AtomicContext(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		return fn(ctx, tx)
+		return fn(ctx, sqlTransactionScope{tx})
 	})
 }
 
@@ -143,4 +149,20 @@ func (s *trackerSQLStore) Vacuum(ctx context.Context) (stats db.VacuumStats, err
 
 func (s *trackerSQLStore) Close() {
 	s.pair.Close()
+}
+
+func (txs sqlTransactionScope) CreateCatchpointReaderWriter() (CatchpointReaderWriter, error) {
+	return NewCatchpointSQLReaderWriter(txs.tx), nil
+}
+
+func (txs sqlTransactionScope) CreateAccountsReaderWriter() (AccountsReaderWriter, error) {
+	return NewAccountsSQLReaderWriter(txs.tx), nil
+}
+
+func (txs sqlTransactionScope) CreateMerkleCommitter(staging bool) (MerkleCommitter, error) {
+	return MakeMerkleCommitter(txs.tx, staging)
+}
+
+func (txs sqlTransactionScope) CreateOrderedAccountsIter(accountCount int) *orderedAccountsIter {
+	return MakeOrderedAccountsIter(txs.tx, accountCount)
 }

--- a/ledger/store/store.go
+++ b/ledger/store/store.go
@@ -34,6 +34,8 @@ type batchFn func(ctx context.Context, tx *sql.Tx) error
 type snapshotFn func(ctx context.Context, tx *sql.Tx) error
 
 type transactionFn func(ctx context.Context, tx TransactionScope) error
+
+// TransactionScope read/write scope to the store.
 type TransactionScope interface {
 	CreateCatchpointReaderWriter() (CatchpointReaderWriter, error)
 	CreateAccountsReaderWriter() (AccountsReaderWriter, error)

--- a/ledger/txtail_test.go
+++ b/ledger/txtail_test.go
@@ -154,7 +154,7 @@ func (t *txTailTestLedger) initialize(ts *testing.T, protoVersion protocol.Conse
 	t.trackerDBs, _ = store.DbOpenTrackerTest(ts, inMemory)
 	t.protoVersion = protoVersion
 
-	err := t.trackerDBs.Transaction(func(transactionCtx context.Context, tx *sql.Tx) (err error) {
+	err := t.trackerDBs.Batch(func(transactionCtx context.Context, tx *sql.Tx) (err error) {
 		arw := store.NewAccountsSQLReaderWriter(tx)
 
 		accts := ledgertesting.RandomAccounts(20, true)
@@ -299,7 +299,7 @@ func TestTxTailDeltaTracking(t *testing.T) {
 				err = txtail.prepareCommit(dcc)
 				require.NoError(t, err)
 
-				err := ledger.trackerDBs.Transaction(func(transactionCtx context.Context, tx *sql.Tx) (err error) {
+				err := ledger.trackerDBs.Batch(func(ctx context.Context, tx *sql.Tx) (err error) {
 					err = txtail.commitRound(context.Background(), tx, dcc)
 					require.NoError(t, err)
 					return nil


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

- removed the `sql.Tx` from the `.Transaction(..)` callback.  
- abstract merkle commiter creation
- abstract account iter creation

This PR is part of a series:
- 1/n #5021 

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Existing tests

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
