### PR TITLE
agreement: fix receivedAt proposal performance timing

### DIFF
--- a/agreement/events.go
+++ b/agreement/events.go
@@ -947,6 +947,6 @@ func (e messageEvent) AttachValidatedAt(d time.Duration) messageEvent {
 }
 
 func (e messageEvent) AttachReceivedAt(d time.Duration) messageEvent {
-	e.Input.Proposal.receivedAt = d
+	e.Input.UnauthenticatedProposal.receivedAt = d
 	return e
 }

--- a/agreement/msgp_gen.go
+++ b/agreement/msgp_gen.go
@@ -3791,7 +3791,7 @@ func (z *proposal) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0004Len := uint32(29)
-	var zb0004Mask uint64 /* 38 bits */
+	var zb0004Mask uint64 /* 39 bits */
 	if (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsLevel == 0 {
 		zb0004Len--
 		zb0004Mask |= 0x40
@@ -3854,59 +3854,59 @@ func (z *proposal) MarshalMsg(b []byte) (o []byte) {
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.Round.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x400000
+		zb0004Mask |= 0x800000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRecalculationRound.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x800000
+		zb0004Mask |= 0x1000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsPool.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x1000000
+		zb0004Mask |= 0x2000000
 	}
 	if (*z).unauthenticatedProposal.SeedProof.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x2000000
+		zb0004Mask |= 0x4000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.Seed.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x4000000
+		zb0004Mask |= 0x8000000
 	}
 	if len((*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking) == 0 {
 		zb0004Len--
-		zb0004Mask |= 0x8000000
+		zb0004Mask |= 0x10000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.TxnCounter == 0 {
 		zb0004Len--
-		zb0004Mask |= 0x10000000
+		zb0004Mask |= 0x20000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.TimeStamp == 0 {
 		zb0004Len--
-		zb0004Mask |= 0x20000000
+		zb0004Mask |= 0x40000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.TxnCommitments.NativeSha512_256Commitment.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x40000000
+		zb0004Mask |= 0x80000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.TxnCommitments.Sha256Commitment.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x80000000
+		zb0004Mask |= 0x100000000
 	}
 	if (*z).unauthenticatedProposal.Block.Payset.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x100000000
+		zb0004Mask |= 0x200000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeDelay.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x200000000
+		zb0004Mask |= 0x400000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradePropose.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x400000000
+		zb0004Mask |= 0x800000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeApprove == false {
 		zb0004Len--
-		zb0004Mask |= 0x800000000
+		zb0004Mask |= 0x1000000000
 	}
 	// variable map header, size zb0004Len
 	o = msgp.AppendMapHeader(o, zb0004Len)
@@ -3993,32 +3993,32 @@ func (z *proposal) MarshalMsg(b []byte) (o []byte) {
 			o = append(o, 0xa4, 0x72, 0x61, 0x74, 0x65)
 			o = msgp.AppendUint64(o, (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRate)
 		}
-		if (zb0004Mask & 0x400000) == 0 { // if not empty
+		if (zb0004Mask & 0x800000) == 0 { // if not empty
 			// string "rnd"
 			o = append(o, 0xa3, 0x72, 0x6e, 0x64)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.Round.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x800000) == 0 { // if not empty
+		if (zb0004Mask & 0x1000000) == 0 { // if not empty
 			// string "rwcalr"
 			o = append(o, 0xa6, 0x72, 0x77, 0x63, 0x61, 0x6c, 0x72)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRecalculationRound.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x1000000) == 0 { // if not empty
+		if (zb0004Mask & 0x2000000) == 0 { // if not empty
 			// string "rwd"
 			o = append(o, 0xa3, 0x72, 0x77, 0x64)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsPool.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x2000000) == 0 { // if not empty
+		if (zb0004Mask & 0x4000000) == 0 { // if not empty
 			// string "sdpf"
 			o = append(o, 0xa4, 0x73, 0x64, 0x70, 0x66)
 			o = (*z).unauthenticatedProposal.SeedProof.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x4000000) == 0 { // if not empty
+		if (zb0004Mask & 0x8000000) == 0 { // if not empty
 			// string "seed"
 			o = append(o, 0xa4, 0x73, 0x65, 0x65, 0x64)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.Seed.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x8000000) == 0 { // if not empty
+		if (zb0004Mask & 0x10000000) == 0 { // if not empty
 			// string "spt"
 			o = append(o, 0xa3, 0x73, 0x70, 0x74)
 			if (*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking == nil {
@@ -4038,42 +4038,42 @@ func (z *proposal) MarshalMsg(b []byte) (o []byte) {
 				o = zb0002.MarshalMsg(o)
 			}
 		}
-		if (zb0004Mask & 0x10000000) == 0 { // if not empty
+		if (zb0004Mask & 0x20000000) == 0 { // if not empty
 			// string "tc"
 			o = append(o, 0xa2, 0x74, 0x63)
 			o = msgp.AppendUint64(o, (*z).unauthenticatedProposal.Block.BlockHeader.TxnCounter)
 		}
-		if (zb0004Mask & 0x20000000) == 0 { // if not empty
+		if (zb0004Mask & 0x40000000) == 0 { // if not empty
 			// string "ts"
 			o = append(o, 0xa2, 0x74, 0x73)
 			o = msgp.AppendInt64(o, (*z).unauthenticatedProposal.Block.BlockHeader.TimeStamp)
 		}
-		if (zb0004Mask & 0x40000000) == 0 { // if not empty
+		if (zb0004Mask & 0x80000000) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.TxnCommitments.NativeSha512_256Commitment.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x80000000) == 0 { // if not empty
+		if (zb0004Mask & 0x100000000) == 0 { // if not empty
 			// string "txn256"
 			o = append(o, 0xa6, 0x74, 0x78, 0x6e, 0x32, 0x35, 0x36)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.TxnCommitments.Sha256Commitment.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x100000000) == 0 { // if not empty
+		if (zb0004Mask & 0x200000000) == 0 { // if not empty
 			// string "txns"
 			o = append(o, 0xa4, 0x74, 0x78, 0x6e, 0x73)
 			o = (*z).unauthenticatedProposal.Block.Payset.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x200000000) == 0 { // if not empty
+		if (zb0004Mask & 0x400000000) == 0 { // if not empty
 			// string "upgradedelay"
 			o = append(o, 0xac, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x64, 0x65, 0x6c, 0x61, 0x79)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeDelay.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x400000000) == 0 { // if not empty
+		if (zb0004Mask & 0x800000000) == 0 { // if not empty
 			// string "upgradeprop"
 			o = append(o, 0xab, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x70, 0x72, 0x6f, 0x70)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradePropose.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x800000000) == 0 { // if not empty
+		if (zb0004Mask & 0x1000000000) == 0 { // if not empty
 			// string "upgradeyes"
 			o = append(o, 0xaa, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x79, 0x65, 0x73)
 			o = msgp.AppendBool(o, (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeApprove)
@@ -7839,7 +7839,7 @@ func (z *transmittedPayload) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0004Len := uint32(30)
-	var zb0004Mask uint64 /* 37 bits */
+	var zb0004Mask uint64 /* 38 bits */
 	if (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsLevel == 0 {
 		zb0004Len--
 		zb0004Mask |= 0x80
@@ -7906,59 +7906,59 @@ func (z *transmittedPayload) MarshalMsg(b []byte) (o []byte) {
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.Round.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x800000
+		zb0004Mask |= 0x1000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRecalculationRound.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x1000000
+		zb0004Mask |= 0x2000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsPool.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x2000000
+		zb0004Mask |= 0x4000000
 	}
 	if (*z).unauthenticatedProposal.SeedProof.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x4000000
+		zb0004Mask |= 0x8000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.Seed.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x8000000
+		zb0004Mask |= 0x10000000
 	}
 	if len((*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking) == 0 {
 		zb0004Len--
-		zb0004Mask |= 0x10000000
+		zb0004Mask |= 0x20000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.TxnCounter == 0 {
 		zb0004Len--
-		zb0004Mask |= 0x20000000
+		zb0004Mask |= 0x40000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.TimeStamp == 0 {
 		zb0004Len--
-		zb0004Mask |= 0x40000000
+		zb0004Mask |= 0x80000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.TxnCommitments.NativeSha512_256Commitment.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x80000000
+		zb0004Mask |= 0x100000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.TxnCommitments.Sha256Commitment.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x100000000
+		zb0004Mask |= 0x200000000
 	}
 	if (*z).unauthenticatedProposal.Block.Payset.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x200000000
+		zb0004Mask |= 0x400000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeDelay.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x400000000
+		zb0004Mask |= 0x800000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradePropose.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x800000000
+		zb0004Mask |= 0x1000000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeApprove == false {
 		zb0004Len--
-		zb0004Mask |= 0x1000000000
+		zb0004Mask |= 0x2000000000
 	}
 	// variable map header, size zb0004Len
 	o = msgp.AppendMapHeader(o, zb0004Len)
@@ -8050,32 +8050,32 @@ func (z *transmittedPayload) MarshalMsg(b []byte) (o []byte) {
 			o = append(o, 0xa4, 0x72, 0x61, 0x74, 0x65)
 			o = msgp.AppendUint64(o, (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRate)
 		}
-		if (zb0004Mask & 0x800000) == 0 { // if not empty
+		if (zb0004Mask & 0x1000000) == 0 { // if not empty
 			// string "rnd"
 			o = append(o, 0xa3, 0x72, 0x6e, 0x64)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.Round.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x1000000) == 0 { // if not empty
+		if (zb0004Mask & 0x2000000) == 0 { // if not empty
 			// string "rwcalr"
 			o = append(o, 0xa6, 0x72, 0x77, 0x63, 0x61, 0x6c, 0x72)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRecalculationRound.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x2000000) == 0 { // if not empty
+		if (zb0004Mask & 0x4000000) == 0 { // if not empty
 			// string "rwd"
 			o = append(o, 0xa3, 0x72, 0x77, 0x64)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsPool.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x4000000) == 0 { // if not empty
+		if (zb0004Mask & 0x8000000) == 0 { // if not empty
 			// string "sdpf"
 			o = append(o, 0xa4, 0x73, 0x64, 0x70, 0x66)
 			o = (*z).unauthenticatedProposal.SeedProof.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x8000000) == 0 { // if not empty
+		if (zb0004Mask & 0x10000000) == 0 { // if not empty
 			// string "seed"
 			o = append(o, 0xa4, 0x73, 0x65, 0x65, 0x64)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.Seed.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x10000000) == 0 { // if not empty
+		if (zb0004Mask & 0x20000000) == 0 { // if not empty
 			// string "spt"
 			o = append(o, 0xa3, 0x73, 0x70, 0x74)
 			if (*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking == nil {
@@ -8095,42 +8095,42 @@ func (z *transmittedPayload) MarshalMsg(b []byte) (o []byte) {
 				o = zb0002.MarshalMsg(o)
 			}
 		}
-		if (zb0004Mask & 0x20000000) == 0 { // if not empty
+		if (zb0004Mask & 0x40000000) == 0 { // if not empty
 			// string "tc"
 			o = append(o, 0xa2, 0x74, 0x63)
 			o = msgp.AppendUint64(o, (*z).unauthenticatedProposal.Block.BlockHeader.TxnCounter)
 		}
-		if (zb0004Mask & 0x40000000) == 0 { // if not empty
+		if (zb0004Mask & 0x80000000) == 0 { // if not empty
 			// string "ts"
 			o = append(o, 0xa2, 0x74, 0x73)
 			o = msgp.AppendInt64(o, (*z).unauthenticatedProposal.Block.BlockHeader.TimeStamp)
 		}
-		if (zb0004Mask & 0x80000000) == 0 { // if not empty
+		if (zb0004Mask & 0x100000000) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.TxnCommitments.NativeSha512_256Commitment.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x100000000) == 0 { // if not empty
+		if (zb0004Mask & 0x200000000) == 0 { // if not empty
 			// string "txn256"
 			o = append(o, 0xa6, 0x74, 0x78, 0x6e, 0x32, 0x35, 0x36)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.TxnCommitments.Sha256Commitment.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x200000000) == 0 { // if not empty
+		if (zb0004Mask & 0x400000000) == 0 { // if not empty
 			// string "txns"
 			o = append(o, 0xa4, 0x74, 0x78, 0x6e, 0x73)
 			o = (*z).unauthenticatedProposal.Block.Payset.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x400000000) == 0 { // if not empty
+		if (zb0004Mask & 0x800000000) == 0 { // if not empty
 			// string "upgradedelay"
 			o = append(o, 0xac, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x64, 0x65, 0x6c, 0x61, 0x79)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeDelay.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x800000000) == 0 { // if not empty
+		if (zb0004Mask & 0x1000000000) == 0 { // if not empty
 			// string "upgradeprop"
 			o = append(o, 0xab, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x70, 0x72, 0x6f, 0x70)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradePropose.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x1000000000) == 0 { // if not empty
+		if (zb0004Mask & 0x2000000000) == 0 { // if not empty
 			// string "upgradeyes"
 			o = append(o, 0xaa, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x79, 0x65, 0x73)
 			o = msgp.AppendBool(o, (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeApprove)
@@ -9415,7 +9415,7 @@ func (z *unauthenticatedProposal) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0004Len := uint32(29)
-	var zb0004Mask uint64 /* 35 bits */
+	var zb0004Mask uint64 /* 36 bits */
 	if (*z).Block.BlockHeader.RewardsState.RewardsLevel == 0 {
 		zb0004Len--
 		zb0004Mask |= 0x40
@@ -9478,59 +9478,59 @@ func (z *unauthenticatedProposal) MarshalMsg(b []byte) (o []byte) {
 	}
 	if (*z).Block.BlockHeader.Round.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x200000
+		zb0004Mask |= 0x400000
 	}
 	if (*z).Block.BlockHeader.RewardsState.RewardsRecalculationRound.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x400000
+		zb0004Mask |= 0x800000
 	}
 	if (*z).Block.BlockHeader.RewardsState.RewardsPool.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x800000
+		zb0004Mask |= 0x1000000
 	}
 	if (*z).SeedProof.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x1000000
+		zb0004Mask |= 0x2000000
 	}
 	if (*z).Block.BlockHeader.Seed.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x2000000
+		zb0004Mask |= 0x4000000
 	}
 	if len((*z).Block.BlockHeader.StateProofTracking) == 0 {
 		zb0004Len--
-		zb0004Mask |= 0x4000000
+		zb0004Mask |= 0x8000000
 	}
 	if (*z).Block.BlockHeader.TxnCounter == 0 {
 		zb0004Len--
-		zb0004Mask |= 0x8000000
+		zb0004Mask |= 0x10000000
 	}
 	if (*z).Block.BlockHeader.TimeStamp == 0 {
 		zb0004Len--
-		zb0004Mask |= 0x10000000
+		zb0004Mask |= 0x20000000
 	}
 	if (*z).Block.BlockHeader.TxnCommitments.NativeSha512_256Commitment.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x20000000
+		zb0004Mask |= 0x40000000
 	}
 	if (*z).Block.BlockHeader.TxnCommitments.Sha256Commitment.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x40000000
+		zb0004Mask |= 0x80000000
 	}
 	if (*z).Block.Payset.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x80000000
+		zb0004Mask |= 0x100000000
 	}
 	if (*z).Block.BlockHeader.UpgradeVote.UpgradeDelay.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x100000000
+		zb0004Mask |= 0x200000000
 	}
 	if (*z).Block.BlockHeader.UpgradeVote.UpgradePropose.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x200000000
+		zb0004Mask |= 0x400000000
 	}
 	if (*z).Block.BlockHeader.UpgradeVote.UpgradeApprove == false {
 		zb0004Len--
-		zb0004Mask |= 0x400000000
+		zb0004Mask |= 0x800000000
 	}
 	// variable map header, size zb0004Len
 	o = msgp.AppendMapHeader(o, zb0004Len)
@@ -9617,32 +9617,32 @@ func (z *unauthenticatedProposal) MarshalMsg(b []byte) (o []byte) {
 			o = append(o, 0xa4, 0x72, 0x61, 0x74, 0x65)
 			o = msgp.AppendUint64(o, (*z).Block.BlockHeader.RewardsState.RewardsRate)
 		}
-		if (zb0004Mask & 0x200000) == 0 { // if not empty
+		if (zb0004Mask & 0x400000) == 0 { // if not empty
 			// string "rnd"
 			o = append(o, 0xa3, 0x72, 0x6e, 0x64)
 			o = (*z).Block.BlockHeader.Round.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x400000) == 0 { // if not empty
+		if (zb0004Mask & 0x800000) == 0 { // if not empty
 			// string "rwcalr"
 			o = append(o, 0xa6, 0x72, 0x77, 0x63, 0x61, 0x6c, 0x72)
 			o = (*z).Block.BlockHeader.RewardsState.RewardsRecalculationRound.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x800000) == 0 { // if not empty
+		if (zb0004Mask & 0x1000000) == 0 { // if not empty
 			// string "rwd"
 			o = append(o, 0xa3, 0x72, 0x77, 0x64)
 			o = (*z).Block.BlockHeader.RewardsState.RewardsPool.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x1000000) == 0 { // if not empty
+		if (zb0004Mask & 0x2000000) == 0 { // if not empty
 			// string "sdpf"
 			o = append(o, 0xa4, 0x73, 0x64, 0x70, 0x66)
 			o = (*z).SeedProof.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x2000000) == 0 { // if not empty
+		if (zb0004Mask & 0x4000000) == 0 { // if not empty
 			// string "seed"
 			o = append(o, 0xa4, 0x73, 0x65, 0x65, 0x64)
 			o = (*z).Block.BlockHeader.Seed.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x4000000) == 0 { // if not empty
+		if (zb0004Mask & 0x8000000) == 0 { // if not empty
 			// string "spt"
 			o = append(o, 0xa3, 0x73, 0x70, 0x74)
 			if (*z).Block.BlockHeader.StateProofTracking == nil {
@@ -9662,42 +9662,42 @@ func (z *unauthenticatedProposal) MarshalMsg(b []byte) (o []byte) {
 				o = zb0002.MarshalMsg(o)
 			}
 		}
-		if (zb0004Mask & 0x8000000) == 0 { // if not empty
+		if (zb0004Mask & 0x10000000) == 0 { // if not empty
 			// string "tc"
 			o = append(o, 0xa2, 0x74, 0x63)
 			o = msgp.AppendUint64(o, (*z).Block.BlockHeader.TxnCounter)
 		}
-		if (zb0004Mask & 0x10000000) == 0 { // if not empty
+		if (zb0004Mask & 0x20000000) == 0 { // if not empty
 			// string "ts"
 			o = append(o, 0xa2, 0x74, 0x73)
 			o = msgp.AppendInt64(o, (*z).Block.BlockHeader.TimeStamp)
 		}
-		if (zb0004Mask & 0x20000000) == 0 { // if not empty
+		if (zb0004Mask & 0x40000000) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
 			o = (*z).Block.BlockHeader.TxnCommitments.NativeSha512_256Commitment.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x40000000) == 0 { // if not empty
+		if (zb0004Mask & 0x80000000) == 0 { // if not empty
 			// string "txn256"
 			o = append(o, 0xa6, 0x74, 0x78, 0x6e, 0x32, 0x35, 0x36)
 			o = (*z).Block.BlockHeader.TxnCommitments.Sha256Commitment.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x80000000) == 0 { // if not empty
+		if (zb0004Mask & 0x100000000) == 0 { // if not empty
 			// string "txns"
 			o = append(o, 0xa4, 0x74, 0x78, 0x6e, 0x73)
 			o = (*z).Block.Payset.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x100000000) == 0 { // if not empty
+		if (zb0004Mask & 0x200000000) == 0 { // if not empty
 			// string "upgradedelay"
 			o = append(o, 0xac, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x64, 0x65, 0x6c, 0x61, 0x79)
 			o = (*z).Block.BlockHeader.UpgradeVote.UpgradeDelay.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x200000000) == 0 { // if not empty
+		if (zb0004Mask & 0x400000000) == 0 { // if not empty
 			// string "upgradeprop"
 			o = append(o, 0xab, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x70, 0x72, 0x6f, 0x70)
 			o = (*z).Block.BlockHeader.UpgradeVote.UpgradePropose.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x400000000) == 0 { // if not empty
+		if (zb0004Mask & 0x800000000) == 0 { // if not empty
 			// string "upgradeyes"
 			o = append(o, 0xaa, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x79, 0x65, 0x73)
 			o = msgp.AppendBool(o, (*z).Block.BlockHeader.UpgradeVote.UpgradeApprove)

--- a/agreement/player_test.go
+++ b/agreement/player_test.go
@@ -19,6 +19,7 @@ package agreement
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -3230,6 +3231,93 @@ func TestPlayerAlwaysResynchsPinnedValue(t *testing.T) {
 
 	rePayloadEvent := ev(networkAction{T: broadcast, Tag: protocol.ProposalPayloadTag, CompoundMessage: compoundMessage{Proposal: payload.u()}})
 	require.Truef(t, trace.Contains(rePayloadEvent), "Player should relay payload even if not staged in previous period")
+}
+
+// test that ReceivedAt and ValidateAt timing information are retained in proposalStore
+// when the payloadPresent and payloadVerified events are processed, and that both timings
+// are available when the ensureAction is called for the block.
+func TestPlayerRetainsReceivedValidatedAt(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	const r = round(20239)
+	const p = period(1001)
+	pWhite, pM, helper := setupP(t, r-1, p, soft)
+	pP, pV := helper.MakeRandomProposalPayload(t, r-1)
+
+	t.Log("pP", pP.Digest().String())
+
+	// send a payload
+	// store an arbitrary proposal/payload
+	vVote := helper.MakeVerifiedVote(t, 0, r-1, p, propose, *pV)
+	inMsg := messageEvent{T: voteVerified, Input: message{Vote: vVote, UnauthenticatedVote: vVote.u()}}
+	err, panicErr := pM.transition(inMsg)
+	require.NoError(t, err)
+	require.NoError(t, panicErr)
+
+	// payloadPresent
+	m := message{UnauthenticatedProposal: pP.u()}
+	inMsg = messageEvent{T: payloadPresent, Input: m}
+	inMsg = inMsg.AttachReceivedAt(time.Second)
+	err, panicErr = pM.transition(inMsg)
+	require.NoError(t, err)
+	require.NoError(t, panicErr)
+
+	// make sure payload verify request
+	verifyEvent := ev(cryptoAction{T: verifyPayload, M: m, TaskIndex: 0})
+	require.Truef(t, pM.getTrace().Contains(verifyEvent), "Player should verify payload")
+
+	// payloadVerified
+	inMsg = messageEvent{T: payloadVerified, Input: message{Proposal: *pP}, Proto: ConsensusVersionView{Version: protocol.ConsensusCurrentVersion}}
+	inMsg = inMsg.AttachValidatedAt(2 * time.Second)
+	err, panicErr = pM.transition(inMsg)
+	require.NoError(t, err)
+	require.NoError(t, panicErr)
+
+	// gen cert to move into the next round
+	votes := make([]vote, int(cert.threshold(config.Consensus[protocol.ConsensusCurrentVersion])))
+	for i := 0; i < int(cert.threshold(config.Consensus[protocol.ConsensusCurrentVersion])); i++ {
+		votes[i] = helper.MakeVerifiedVote(t, i, r-1, p, cert, *pV)
+	}
+	bun := unauthenticatedBundle{
+		Round:    r - 1,
+		Period:   p,
+		Proposal: *pV,
+	}
+	inMsg = messageEvent{
+		T: bundleVerified,
+		Input: message{
+			Bundle: bundle{
+				U:     bun,
+				Votes: votes,
+			},
+			UnauthenticatedBundle: bun,
+		},
+		Proto: ConsensusVersionView{Version: protocol.ConsensusCurrentVersion},
+	}
+	err, panicErr = pM.transition(inMsg)
+	require.NoError(t, err)
+	require.NoError(t, panicErr)
+
+	require.Equalf(t, r, pWhite.Round, "player did not enter new round")
+	require.Equalf(t, period(0), pWhite.Period, "player did not enter period 0 in new round")
+	commitEvent := ev(ensureAction{Certificate: Certificate(bun), Payload: *pP})
+	require.Truef(t, pM.getTrace().Contains(commitEvent), "Player should try to ensure block/digest on ledger")
+
+	// find and unwrap ensureAction from trace
+	var ea ensureAction
+	var foundEA bool
+	for _, ev := range pM.getTrace().events {
+		if wae, ok := ev.(wrappedActionEvent); ok {
+			if wae.action.t() == ensure {
+				require.False(t, foundEA)
+				ea = wae.action.(ensureAction)
+				foundEA = true
+			}
+		}
+	}
+	require.True(t, foundEA)
+	require.Equal(t, 2*time.Second, ea.Payload.validatedAt)
+	require.Equal(t, time.Second, ea.Payload.receivedAt)
 }
 
 // todo: test pipelined rounds, and round interruption

--- a/agreement/player_test.go
+++ b/agreement/player_test.go
@@ -3244,8 +3244,6 @@ func TestPlayerRetainsReceivedValidatedAt(t *testing.T) {
 	pWhite, pM, helper := setupP(t, r-1, p, soft)
 	pP, pV := helper.MakeRandomProposalPayload(t, r-1)
 
-	t.Log("pP", pP.Digest().String())
-
 	// send a payload
 	// store an arbitrary proposal/payload
 	vVote := helper.MakeVerifiedVote(t, 0, r-1, p, propose, *pV)

--- a/agreement/proposal.go
+++ b/agreement/proposal.go
@@ -59,6 +59,11 @@ type unauthenticatedProposal struct {
 
 	OriginalPeriod   period         `codec:"oper"`
 	OriginalProposer basics.Address `codec:"oprop"`
+
+	// receivedAt indicates the time at which this proposal was
+	// delivered to the agreement package (as a messageEvent),
+	// relative to the zero of that round.
+	receivedAt time.Duration
 }
 
 // TransmittedPayload exported for dumping textual versions of messages

--- a/agreement/proposalStore.go
+++ b/agreement/proposalStore.go
@@ -86,6 +86,9 @@ func (a blockAssembler) bind(p proposal) (blockAssembler, error) {
 	a.Payload = p
 	a.Assembled = true
 
+	// remember when the original unauthenticatedProposal was received
+	a.Payload.receivedAt = a.Pipeline.receivedAt
+
 	return a, nil
 }
 


### PR DESCRIPTION
## Summary

In #4583 I tried to add a receivedAt proposal timing, following the pattern in #3703 for adding the validatedAt timing, but didn't correctly account for the receivedAt time needing to be attached to the `unauthenticatedProposal` while the validatedAt time is attached to the validated `proposal` type. So the receivedAt timing when reported at `ensureAction` time was 0.

The receivedAt and validatedAt timings are only used for telemetry reporting of performance information in the BlockAcceptedEventDetails message.

## Test Plan

Added a test `TestPlayerRetainsReceivedValidatedAt` to reproduce this behavior, then fixed it.