### PR TITLE
Tests: Add start anchor to paralleltest exclusion regex

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,61 +117,61 @@ issues:
         - staticcheck
         - typecheck
     # Ignore missing parallel tests in existing packages
-    - path: agreement.*_test\.go
+    - path: ^agreement.*_test\.go
       linters:
         - paralleltest
-    - path: catchup.*_test\.go
+    - path: ^catchup.*_test\.go
       linters:
         - paralleltest
-    - path: cmd.*_test\.go
+    - path: ^cmd.*_test\.go
       linters:
         - paralleltest
-    - path: config.*_test\.go
+    - path: ^config.*_test\.go
       linters:
         - paralleltest
-    - path: crypto.*_test\.go
+    - path: ^crypto.*_test\.go
       linters:
         - paralleltest
-    - path: daemon.*_test\.go
+    - path: ^daemon.*_test\.go
       linters:
         - paralleltest
-    - path: data.*_test\.go
+    - path: ^data.*_test\.go
       linters:
         - paralleltest
-    - path: gen.*_test\.go
+    - path: ^gen.*_test\.go
       linters:
         - paralleltest
-    - path: ledger.*_test\.go
+    - path: ^ledger.*_test\.go
       linters:
         - paralleltest
-    - path: logging.*_test\.go
+    - path: ^logging.*_test\.go
       linters:
         - paralleltest
-    - path: netdeploy.*_test\.go
+    - path: ^netdeploy.*_test\.go
       linters:
         - paralleltest
-    - path: network.*_test\.go
+    - path: ^network.*_test\.go
       linters:
         - paralleltest
-    - path: node.*_test\.go
+    - path: ^node.*_test\.go
       linters:
         - paralleltest
-    - path: protocol.*_test\.go
+    - path: ^protocol.*_test\.go
       linters:
         - paralleltest
-    - path: rpcs.*_test\.go
+    - path: ^rpcs.*_test\.go
       linters:
         - paralleltest
-    - path: stateproof.*_test\.go
+    - path: ^stateproof.*_test\.go
       linters:
         - paralleltest
-    - path: test.*_test\.go
+    - path: ^test.*_test\.go
       linters:
         - paralleltest
-    - path: tools.*_test\.go
+    - path: ^tools.*_test\.go
       linters:
         - paralleltest
-    - path: util.*_test\.go
+    - path: ^util.*_test\.go
       linters:
         - paralleltest
     # Add all linters here -- Comment this block out for testing linters


### PR DESCRIPTION
## Summary

This PR adds a start anchor to the paralleltest exclusion regex within golang CI's configuration file. This fixes incorrect behavior that excluded test files that match package names in subdirectories, such as `network_test.go` within the `netdeploy` package.

Paralleltest exclusion regex currently follows a pattern similar to `network.*_test\.go` to exclude package directories, but this meant that `network_test.go` was excluded because it began with `network`. Adding `^` to the start of the regex fixed this issue.

## Test Plan

I discovered this behavior while reviewing #4993. I confirmed locally that `make lint 2>/dev/null | grep "paralleltest"` had no output before these changes and that it now correctly identifies missing parallel flags within `netdeploy/network_test.go`.
