### PR TITLE
build: update C++ flags for recent Mac compiler warnings

### DIFF
--- a/data/committee/sortition/sortition.go
+++ b/data/committee/sortition/sortition.go
@@ -17,7 +17,7 @@
 package sortition
 
 // #cgo CFLAGS: -O3
-// #cgo CXXFLAGS: -std=c++11
+// #cgo CXXFLAGS: -std=c++11 -Wno-deprecated
 // #include <stdint.h>
 // #include <stdlib.h>
 // #include "sortition.h"


### PR DESCRIPTION
## Summary

A recent release to the Mac C/C++ build tools have caused warnings about sprintf to appear when building the data/committee/sortition package while parsing a Boost header that uses sprintf. This silences those warnings, as our usage of Boost's boost::math::binomial_distribution should not invoke these sprintf calls.

## Test Plan

Existing tests should pass