### PR TITLE
AVM: Fix opBytesLt for len(rhs) < len(lhs)

### DIFF
--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1843,7 +1843,14 @@ func opBytesLt(cx *EvalContext) error {
 	rhs := nonzero(cx.stack[last].Bytes)
 	lhs := nonzero(cx.stack[prev].Bytes)
 
-	cx.stack[prev] = boolToSV(len(lhs) < len(rhs) || bytes.Compare(lhs, rhs) < 0)
+	switch {
+	case len(lhs) < len(rhs):
+		cx.stack[prev] = boolToSV(true)
+	case len(lhs) > len(rhs):
+		cx.stack[prev] = boolToSV(false)
+	default:
+		cx.stack[prev] = boolToSV(bytes.Compare(lhs, rhs) < 0)
+	}
 
 	cx.stack = cx.stack[:last]
 	return nil

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -4918,6 +4918,9 @@ func TestBytesCompare(t *testing.T) {
 	testPanics(t, "byte 0x10; int 65; bzero; b>", 4)
 	testAccepts(t, "byte 0x1010; byte 0x10; b<; !", 4)
 
+	testAccepts(t, "byte 0x2000; byte 0x70; b<; !", 4)
+	testAccepts(t, "byte 0x7000; byte 0x20; b<; !", 4)
+
 	// All zero input are interesting, because they lead to bytes.Compare being
 	// called with nils.  Show that is correct.
 	testAccepts(t, "byte 0x10; byte 0x00; b<; !", 4)


### PR DESCRIPTION
Added test for old failing case.