### PR TITLE
tests: disable TestInitialSync on CI

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -21,7 +21,9 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -243,6 +245,11 @@ func TestInitialSync(t *testing.T) {
 
 	if testing.Short() {
 		t.Skip("Test takes ~25 seconds.")
+	}
+
+	if (runtime.GOARCH == "arm" || runtime.GOARCH == "arm64") &&
+		strings.ToUpper(os.Getenv("CIRCLECI")) == "TRUE" {
+		t.Skip("Test is too heavy for amd64 builder running in parallel with other packages")
 	}
 
 	backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)


### PR DESCRIPTION
## Summary

TestInitialSync creates 10 full nodes that is too much for CI builder.

## Test Plan

This is a test