### PR TITLE
CI: upgrade test_nightly infra to large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ jobs:
     parameters:
       platform:
         type: string
-    executor: << parameters.platform >>_medium
+    executor: << parameters.platform >>_large
     working_directory: << pipeline.parameters.build_dir >>/project
     parallelism: 4
     steps:


### PR DESCRIPTION
## Summary

This increases the test_nightly build resource class from medium (2 cores) to large (4 cores) as an alternative to #5053.

## Test Plan

Existing tests should pass, nightly tests should also perform better.