### PR TITLE
Tests: Fix t.Parallel() errors in `node` package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -135,9 +135,6 @@ issues:
     - path: daemon.*_test\.go
       linters:
         - paralleltest
-    - path: data.*_test\.go
-      linters:
-        - paralleltest
     - path: gen.*_test\.go
       linters:
         - paralleltest

--- a/data/account/participationRegistry_test.go
+++ b/data/account/participationRegistry_test.go
@@ -145,6 +145,7 @@ func registryCloseTest(t testing.TB, registry *participationDB, dbfilePrefix str
 // Insert participation records and make sure they can be fetched.
 func TestParticipation_InsertGet(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -198,6 +199,7 @@ func TestParticipation_InsertGet(t *testing.T) {
 // Insert participation records and make sure they can be fetched.
 func TestParticipation_InsertGetWithoutEmptyStateproof(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -238,6 +240,7 @@ func TestParticipation_InsertGetWithoutEmptyStateproof(t *testing.T) {
 // Make sure a record can be deleted by id.
 func TestParticipation_Delete(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistryImpl(t, false, true) // inMem=false, erasable=true
 	defer registryCloseTest(t, registry, dbfile)
@@ -276,6 +279,7 @@ func (m testMessage) ToBeHashed() (protocol.HashID, []byte) {
 
 func TestParticipation_DeleteExpired(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistryImpl(t, false, true) // inMem=false, erasable=true
 	defer registryCloseTest(t, registry, dbfile)
@@ -321,6 +325,7 @@ func TestParticipation_DeleteExpired(t *testing.T) {
 
 func TestParticipation_CleanupTablesAfterDeleteExpired(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistryImpl(t, false, true) // inMem=false, erasable=true
 	defer registryCloseTest(t, registry, dbfile)
@@ -383,6 +388,7 @@ func TestParticipation_CleanupTablesAfterDeleteExpired(t *testing.T) {
 // Make sure the register function properly sets effective first/last for all effected records.
 func TestParticipation_Register(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -421,6 +427,7 @@ func TestParticipation_Register(t *testing.T) {
 // Test error when registering a non-existing participation ID.
 func TestParticipation_RegisterInvalidID(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -434,6 +441,7 @@ func TestParticipation_RegisterInvalidID(t *testing.T) {
 // Test error attempting to register a key with an invalid range.
 func TestParticipation_RegisterInvalidRange(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -452,6 +460,7 @@ func TestParticipation_RegisterInvalidRange(t *testing.T) {
 // Test the recording function.
 func TestParticipation_Record(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -506,6 +515,7 @@ func TestParticipation_Record(t *testing.T) {
 // Test that attempting to record an invalid action generates an error.
 func TestParticipation_RecordInvalidActionAndOutOfRange(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -528,6 +538,7 @@ func TestParticipation_RecordInvalidActionAndOutOfRange(t *testing.T) {
 
 func TestParticipation_RecordNoKey(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -540,6 +551,7 @@ func TestParticipation_RecordNoKey(t *testing.T) {
 // This would only happen if the DB was in an inconsistent state.
 func TestParticipation_RecordMultipleUpdates(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -590,6 +602,7 @@ func TestParticipation_RecordMultipleUpdates(t *testing.T) {
 
 func TestParticipation_MultipleInsertError(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -609,6 +622,7 @@ func TestParticipation_MultipleInsertError(t *testing.T) {
 // it should be detected as quickly as possible.
 func TestParticipation_RecordMultipleUpdates_DB(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, _ := getRegistry(t)
 
@@ -711,6 +725,7 @@ func TestParticipation_RecordMultipleUpdates_DB(t *testing.T) {
 
 func TestParticipation_NoKeyToUpdate(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := assert.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -734,6 +749,7 @@ func TestParticipation_NoKeyToUpdate(t *testing.T) {
 // TestParticipion_Blobs adds some secrets to the registry and makes sure the same ones are returned.
 func TestParticipion_Blobs(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -777,6 +793,7 @@ func TestParticipion_Blobs(t *testing.T) {
 // TestParticipion_EmptyBlobs makes sure empty blobs are set to nil
 func TestParticipion_EmptyBlobs(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := assert.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -821,6 +838,7 @@ func TestParticipion_EmptyBlobs(t *testing.T) {
 
 func TestRegisterUpdatedEvent(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -879,6 +897,7 @@ func TestFlushDeadlock(t *testing.T) {
 	var wg sync.WaitGroup
 
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
 
@@ -907,6 +926,7 @@ func TestFlushDeadlock(t *testing.T) {
 
 func TestAddStateProofKeys(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -959,6 +979,7 @@ func TestAddStateProofKeys(t *testing.T) {
 
 func TestGetRoundSecretsWithNilStateProofVerifier(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := assert.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -989,6 +1010,7 @@ func TestGetRoundSecretsWithNilStateProofVerifier(t *testing.T) {
 
 func TestSecretNotFound(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -1008,6 +1030,7 @@ func TestSecretNotFound(t *testing.T) {
 
 func TestAddingSecretTwice(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := assert.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -1046,6 +1069,7 @@ func TestAddingSecretTwice(t *testing.T) {
 
 func TestGetRoundSecretsWithoutStateProof(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := assert.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -1104,6 +1128,7 @@ func (k keypairs) findPairForSpecificRound(round uint64) merklesignature.KeyRoun
 
 func TestDeleteStateProofKeys(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -1173,6 +1198,7 @@ func TestDeleteStateProofKeys(t *testing.T) {
 // test that sets up an error that should come up while flushing, and ensures that flush resets the last error
 func TestFlushResetsLastError(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := assert.New(t)
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
@@ -1211,6 +1237,7 @@ func TestFlushResetsLastError(t *testing.T) {
 // Makes sure the table is not locked for reading while a different one is locked for writing.
 func TestParticipationDB_Locking(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 
 	dbName := strings.Replace(t.Name(), "/", "_", -1)
@@ -1281,6 +1308,7 @@ func TestParticipationDB_Locking(t *testing.T) {
 
 func TestParticipationDBInstallWhileReading(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 
 	if testing.Short() {

--- a/data/account/participation_test.go
+++ b/data/account/participation_test.go
@@ -40,6 +40,7 @@ var partableColumnNames = [...]string{"parent", "vrf", "voting", "stateProof", "
 
 func TestParticipation_NewDB(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := require.New(t)
 
@@ -115,6 +116,7 @@ func getSchemaVersions(db db.Accessor) (versions map[string]int, err error) {
 
 func TestOverlapsInterval(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	const before = basics.Round(95)
 	const start = basics.Round(100)
@@ -189,6 +191,7 @@ func BenchmarkOldKeysDeletion(b *testing.B) {
 
 func TestRetrieveFromDB(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 	part, rootDB, partDB, err := setupParticipationKey(t, a)
 	a.NoError(err)
@@ -205,6 +208,7 @@ func TestRetrieveFromDB(t *testing.T) {
 
 func TestRetrieveFromDBAtVersion1(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := require.New(t)
 	ppart := setupkeyWithNoDBS(t, a)
@@ -227,6 +231,7 @@ func TestRetrieveFromDBAtVersion1(t *testing.T) {
 
 func TestRetrieveFromDBAtVersion2(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := require.New(t)
 
@@ -256,6 +261,7 @@ func TestRetrieveFromDBAtVersion2(t *testing.T) {
 
 func TestKeyRegCreation(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := require.New(t)
 
@@ -289,6 +295,7 @@ func assertionForRestoringFromDBAtLowVersion(a *require.Assertions, retrivedPart
 
 func TestMigrateFromVersion1(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := require.New(t)
 	part := setupkeyWithNoDBS(t, a).Participation
@@ -304,6 +311,7 @@ func TestMigrateFromVersion1(t *testing.T) {
 
 func TestMigrationFromVersion2(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := require.New(t)
 	part := setupkeyWithNoDBS(t, a).Participation
@@ -498,6 +506,7 @@ func createMerkleSignatureSchemeTestDB(a *require.Assertions) *db.Accessor {
 
 func TestKeyregValidityOverLimit(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 
 	maxValidPeriod := config.Consensus[protocol.ConsensusCurrentVersion].MaxKeyregValidPeriod
@@ -516,6 +525,7 @@ func TestKeyregValidityOverLimit(t *testing.T) {
 
 func TestFillDBWithParticipationKeys(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 
 	dilution := config.Consensus[protocol.ConsensusCurrentVersion].DefaultKeyDilution

--- a/data/accountManager_test.go
+++ b/data/accountManager_test.go
@@ -89,9 +89,9 @@ func registryCloseTest(t testing.TB, registry account.ParticipationRegistry, dbf
 	}
 }
 
-func TestAccountManagerKeysRegistry(t *testing.T) {
+func TestAccountManagerKeysRegistry(t *testing.T) { //nolint:paralleltest // Too heavy to parallelize
 	partitiontest.PartitionTest(t)
-	t.Parallel() // can be parallelized despite file system manipulation because db files have different test names
+
 	if testing.Short() {
 		t.Log("this is a long test and skipping for -short")
 		return

--- a/data/accountManager_test.go
+++ b/data/accountManager_test.go
@@ -43,6 +43,7 @@ import (
 
 func TestAccountManagerKeys(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel() // can be parallelized despite file system manipulation because db files have different test names
 	if testing.Short() {
 		t.Log("this is a long test and skipping for -short")
 		return
@@ -90,6 +91,7 @@ func registryCloseTest(t testing.TB, registry account.ParticipationRegistry, dbf
 
 func TestAccountManagerKeysRegistry(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel() // can be parallelized despite file system manipulation because db files have different test names
 	if testing.Short() {
 		t.Log("this is a long test and skipping for -short")
 		return
@@ -191,6 +193,7 @@ func testAccountManagerKeys(t *testing.T, registry account.ParticipationRegistry
 
 func TestAccountManagerOverlappingStateProofKeys(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel() // can be parallelized despite file system manipulation because db files have different test names
 	a := assert.New(t)
 
 	registry, dbName := getRegistryImpl(t, false, true)
@@ -212,7 +215,8 @@ func TestAccountManagerOverlappingStateProofKeys(t *testing.T) {
 	}()
 
 	// Generate 2 participations under the same account
-	store, err := db.MakeAccessor("stateprooftest", false, true)
+	dbfilename := t.Name() + "_stateprooftest"
+	store, err := db.MakeAccessor(dbfilename, false, true)
 	a.NoError(err)
 	root, err := account.GenerateRoot(store)
 	a.NoError(err)
@@ -220,7 +224,7 @@ func TestAccountManagerOverlappingStateProofKeys(t *testing.T) {
 	a.NoError(err)
 	store.Close()
 
-	store, err = db.MakeAccessor("stateprooftest", false, true)
+	store, err = db.MakeAccessor(dbfilename, false, true)
 	a.NoError(err)
 	part2, err := account.FillDBWithParticipationKeys(store, root.Address(), basics.Round(merklesignature.KeyLifetimeDefault), basics.Round(merklesignature.KeyLifetimeDefault*3), 3)
 	a.NoError(err)
@@ -263,6 +267,7 @@ func TestAccountManagerOverlappingStateProofKeys(t *testing.T) {
 
 func TestGetStateProofKeysDontLogErrorOnNilStateProof(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel() // can be parallelized despite file system manipulation because db files have different test names
 	a := assert.New(t)
 
 	registry, dbName := getRegistryImpl(t, false, true)
@@ -285,7 +290,8 @@ func TestGetStateProofKeysDontLogErrorOnNilStateProof(t *testing.T) {
 	}()
 
 	// Generate 2 participations under the same account
-	store, err := db.MakeAccessor("stateprooftest", false, true)
+	dbfilename := t.Name() + "_stateprooftest"
+	store, err := db.MakeAccessor(dbfilename, false, true)
 	a.NoError(err)
 	root, err := account.GenerateRoot(store)
 	a.NoError(err)

--- a/data/basics/address_test.go
+++ b/data/basics/address_test.go
@@ -28,6 +28,7 @@ import (
 
 func TestChecksumAddress_Unmarshal(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	address := crypto.Hash([]byte("randomString"))
 	shortAddress := Address(address)
@@ -41,6 +42,7 @@ func TestChecksumAddress_Unmarshal(t *testing.T) {
 
 func TestAddressChecksumMalformedWrongChecksum(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	address := crypto.Hash([]byte("randomString"))
 	shortAddress := Address(address)
@@ -53,6 +55,7 @@ func TestAddressChecksumMalformedWrongChecksum(t *testing.T) {
 
 func TestAddressChecksumShort(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var address string
 	_, err := UnmarshalChecksumAddress(address)
@@ -61,6 +64,7 @@ func TestAddressChecksumShort(t *testing.T) {
 
 func TestAddressChecksumMalformedWrongChecksumSpace(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	address := crypto.Hash([]byte("randomString"))
 	shortAddress := Address(address)
@@ -73,6 +77,7 @@ func TestAddressChecksumMalformedWrongChecksumSpace(t *testing.T) {
 
 func TestAddressChecksumMalformedWrongAddress(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	address := crypto.Hash([]byte("randomString"))
 	shortAddress := Address(address)
@@ -85,6 +90,7 @@ func TestAddressChecksumMalformedWrongAddress(t *testing.T) {
 
 func TestAddressChecksumMalformedWrongAddressSpaces(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	address := crypto.Hash([]byte("randomString"))
 	shortAddress := Address(address)
@@ -97,6 +103,7 @@ func TestAddressChecksumMalformedWrongAddressSpaces(t *testing.T) {
 
 func TestAddressChecksumCanonical(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	addr := "J5YDZLPOHWB5O6MVRHNFGY4JXIQAYYM6NUJWPBSYBBIXH5ENQ4Z5LTJELU"
 	nonCanonical := "J5YDZLPOHWB5O6MVRHNFGY4JXIQAYYM6NUJWPBSYBBIXH5ENQ4Z5LTJELV"
@@ -114,6 +121,7 @@ type TestOb struct {
 
 func TestAddressMarshalUnmarshal(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var addr Address
 	crypto.RandBytes(addr[:])

--- a/data/basics/fields_test.go
+++ b/data/basics/fields_test.go
@@ -58,6 +58,7 @@ func makeTypeCheckFunction(t *testing.T, exceptions []reflectionhelpers.TypePath
 
 func TestBlockFields(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	typeToCheck := reflect.TypeOf(bookkeeping.Block{})
 
@@ -84,6 +85,7 @@ func TestBlockFields(t *testing.T) {
 
 func TestAccountDataFields(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	typeToCheck := reflect.TypeOf(basics.AccountData{})
 

--- a/data/basics/teal_test.go
+++ b/data/basics/teal_test.go
@@ -29,6 +29,7 @@ import (
 
 func TestStateDeltaValid(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := require.New(t)
 
@@ -86,6 +87,7 @@ func TestStateDeltaValid(t *testing.T) {
 
 func TestStateDeltaValidV24(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := require.New(t)
 
@@ -109,6 +111,7 @@ func TestStateDeltaValidV24(t *testing.T) {
 
 func TestStateDeltaEqual(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := require.New(t)
 

--- a/data/basics/units_test.go
+++ b/data/basics/units_test.go
@@ -27,6 +27,7 @@ import (
 
 func TestSubSaturate(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := Round(1)
 	b := Round(2)
@@ -37,6 +38,7 @@ func TestSubSaturate(t *testing.T) {
 
 func TestSubSaturate32(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	require.Equal(t, uint32(0), SubSaturate32(0, 1))
 	require.Equal(t, uint32(0), SubSaturate32(1, 2))
@@ -48,6 +50,7 @@ func TestSubSaturate32(t *testing.T) {
 
 func TestAddSaturate32(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	require.Equal(t, uint32(1), AddSaturate32(0, 1))
 	require.Equal(t, uint32(math.MaxUint32-1), AddSaturate32(math.MaxUint32-2, 1))
@@ -58,6 +61,7 @@ func TestAddSaturate32(t *testing.T) {
 
 func TestRoundUpToMultipleOf(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	r := Round(24)
 	for n := Round(1); n < Round(100); n++ {

--- a/data/basics/userBalance_test.go
+++ b/data/basics/userBalance_test.go
@@ -32,6 +32,7 @@ import (
 
 func TestEmptyEncoding(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var ub BalanceRecord
 	require.Equal(t, 1, len(protocol.Encode(&ub)))
@@ -39,6 +40,7 @@ func TestEmptyEncoding(t *testing.T) {
 
 func TestRewards(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	accountAlgos := []MicroAlgos{{Raw: 0}, {Raw: 8000}, {Raw: 13000}, {Raw: 83000}}
@@ -61,9 +63,11 @@ func TestRewards(t *testing.T) {
 
 func TestWithUpdatedRewardsPanics(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	t.Run("AlgoPanic", func(t *testing.T) {
+		t.Parallel()
 		paniced := false
 		func() {
 			defer func() {
@@ -87,6 +91,7 @@ func TestWithUpdatedRewardsPanics(t *testing.T) {
 	})
 
 	t.Run("RewardsOverflow", func(t *testing.T) {
+		t.Parallel()
 		a := AccountData{
 			Status:             Online,
 			MicroAlgos:         MicroAlgos{Raw: 80000000},
@@ -133,6 +138,7 @@ func getSampleAccountData() AccountData {
 
 func TestEncodedAccountAllocationBounds(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	// ensure that all the supported protocols have value limits less or
 	// equal to their corresponding codec allocbounds
@@ -158,6 +164,7 @@ func TestEncodedAccountAllocationBounds(t *testing.T) {
 
 func TestAppIndexHashing(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	i := AppIndex(12)
 	prefix, buf := i.ToBeHashed()
@@ -177,6 +184,7 @@ func TestAppIndexHashing(t *testing.T) {
 
 func TestOnlineAccountData(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	ad := getSampleAccountData()
 	ad.MicroAlgos.Raw = 1000000

--- a/data/bookkeeping/block_test.go
+++ b/data/bookkeeping/block_test.go
@@ -67,6 +67,7 @@ func init() {
 
 func TestUpgradeVote(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	s := UpgradeState{
 		CurrentProtocol: proto1,
@@ -130,6 +131,7 @@ func TestUpgradeVote(t *testing.T) {
 
 func TestUpgradeVariableDelay(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	s := UpgradeState{
 		CurrentProtocol: protoDelay,
@@ -156,6 +158,7 @@ func TestUpgradeVariableDelay(t *testing.T) {
 
 func TestMakeBlockUpgrades(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var b Block
 	b.BlockHeader.GenesisID = t.Name()
@@ -223,6 +226,7 @@ func TestBlockUnsupported(t *testing.T) { //nolint:paralleltest // Not parallel 
 
 func TestTime(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var prev Block
 	prev.BlockHeader.GenesisID = t.Name()
@@ -252,6 +256,7 @@ func TestTime(t *testing.T) {
 
 func TestRewardsLevel(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var buf bytes.Buffer
 	log := logging.NewLogger()
@@ -272,6 +277,7 @@ func TestRewardsLevel(t *testing.T) {
 
 func TestRewardsLevelWithResidue(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var buf bytes.Buffer
 	log := logging.NewLogger()
@@ -294,6 +300,7 @@ func TestRewardsLevelWithResidue(t *testing.T) {
 
 func TestRewardsLevelNoUnits(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var buf bytes.Buffer
 	log := logging.NewLogger()
@@ -315,6 +322,7 @@ func TestRewardsLevelNoUnits(t *testing.T) {
 
 func TestTinyLevel(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var buf bytes.Buffer
 	log := logging.NewLogger()
@@ -335,6 +343,7 @@ func TestTinyLevel(t *testing.T) {
 
 func TestRewardsRate(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var buf bytes.Buffer
 	log := logging.NewLogger()
@@ -360,6 +369,7 @@ func TestRewardsRate(t *testing.T) {
 
 func TestRewardsRateRefresh(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var buf bytes.Buffer
 	log := logging.NewLogger()
@@ -385,6 +395,7 @@ func TestRewardsRateRefresh(t *testing.T) {
 
 func TestEncodeDecodeSignedTxn(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var b Block
 	b.BlockHeader.GenesisID = "foo"
@@ -405,6 +416,7 @@ func TestEncodeDecodeSignedTxn(t *testing.T) {
 
 func TestEncodeMalformedSignedTxn(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var b Block
 	b.BlockHeader.GenesisID = "foo"
@@ -430,6 +442,7 @@ func TestEncodeMalformedSignedTxn(t *testing.T) {
 
 func TestDecodeMalformedSignedTxn(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var b Block
 	b.BlockHeader.GenesisID = "foo"
@@ -451,6 +464,7 @@ func TestDecodeMalformedSignedTxn(t *testing.T) {
 // running the rounds in the same way eval() is executing them over RewardsRateRefreshInterval rounds.
 func TestInitialRewardsRateCalculation(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	consensusParams := config.Consensus[protocol.ConsensusCurrentVersion]
 	consensusParams.RewardsCalculationFix = false
@@ -553,6 +567,7 @@ func performRewardsRateCalculation(
 
 func TestNextRewardsRateWithFix(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	proto, ok := config.Consensus[protocol.ConsensusCurrentVersion]
 	require.True(t, ok)
@@ -581,7 +596,9 @@ func TestNextRewardsRateWithFix(t *testing.T) {
 			proto.MinBalance + 500000000000 /* 5*10^11 */, 1, 1000000, false},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			curRewardsState := RewardsState{
 				RewardsLevel:              test.rewardsLevel,
 				RewardsResidue:            test.rewardsResidue,
@@ -598,6 +615,7 @@ func TestNextRewardsRateWithFix(t *testing.T) {
 
 func TestNextRewardsRateFailsWithoutFix(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	proto, ok := config.Consensus[protocol.ConsensusCurrentVersion]
 	require.True(t, ok)
@@ -617,6 +635,7 @@ func TestNextRewardsRateFailsWithoutFix(t *testing.T) {
 
 func TestNextRewardsRateWithFixUsesNewRate(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	proto, ok := config.Consensus[protocol.ConsensusCurrentVersion]
 	require.True(t, ok)
@@ -651,6 +670,7 @@ func TestNextRewardsRateWithFixUsesNewRate(t *testing.T) {
 
 func TestNextRewardsRateWithFixPoolBalanceInsufficient(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	proto, ok := config.Consensus[protocol.ConsensusCurrentVersion]
 	require.True(t, ok)
@@ -685,6 +705,7 @@ func TestNextRewardsRateWithFixPoolBalanceInsufficient(t *testing.T) {
 
 func TestNextRewardsRateWithFixMaxSpentOverOverflow(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	proto, ok := config.Consensus[protocol.ConsensusCurrentVersion]
 	require.True(t, ok)
@@ -721,6 +742,7 @@ func TestNextRewardsRateWithFixMaxSpentOverOverflow(t *testing.T) {
 
 func TestNextRewardsRateWithFixRewardsWithResidueOverflow(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	proto, ok := config.Consensus[protocol.ConsensusCurrentVersion]
 	require.True(t, ok)
@@ -747,6 +769,7 @@ func TestNextRewardsRateWithFixRewardsWithResidueOverflow(t *testing.T) {
 
 func TestNextRewardsRateWithFixNextRewardLevelOverflow(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	proto, ok := config.Consensus[protocol.ConsensusCurrentVersion]
 	require.True(t, ok)
@@ -773,6 +796,7 @@ func TestNextRewardsRateWithFixNextRewardLevelOverflow(t *testing.T) {
 
 func TestBlock_ContentsMatchHeader(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 
 	// Create a block without SHA256 TxnCommitments
@@ -860,6 +884,7 @@ func TestBlock_ContentsMatchHeader(t *testing.T) {
 
 func TestBlockHeader_Serialization(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 
 	// This serialized block header was generated from V32 e2e test, using the old BlockHeader struct which contains only TxnCommitments SHA512_256 value

--- a/data/bookkeeping/encoding_test.go
+++ b/data/bookkeeping/encoding_test.go
@@ -29,6 +29,7 @@ import (
 
 func TestEmptyEncoding(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var b Block
 	require.Equal(t, 1, len(protocol.Encode(&b)))
@@ -39,6 +40,7 @@ func TestEmptyEncoding(t *testing.T) {
 
 func TestBlockWithTxnEncoding(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	txn := transactions.Transaction{
 		Type: protocol.PaymentTx,

--- a/data/bookkeeping/lightBlockHeader_test.go
+++ b/data/bookkeeping/lightBlockHeader_test.go
@@ -30,6 +30,7 @@ import (
 
 func TestConvertSha256Header(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 
 	var gh crypto.Digest
@@ -47,6 +48,7 @@ func TestConvertSha256Header(t *testing.T) {
 
 func TestFirstFieldsAreCommitteeSeed(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	a := require.New(t)
 
 	var gh crypto.Digest

--- a/data/bookkeeping/txn_merkle_test.go
+++ b/data/bookkeeping/txn_merkle_test.go
@@ -32,6 +32,7 @@ import (
 
 func TestTxnMerkleElemHash(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var tme txnMerkleElem
 	crypto.RandBytes(tme.stib.SignedTxn.Txn.Header.Sender[:])
@@ -40,6 +41,7 @@ func TestTxnMerkleElemHash(t *testing.T) {
 
 func TestTxnMerkle(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	for ntxn := uint64(0); ntxn < 128; ntxn++ {
 		var b Block
@@ -91,6 +93,7 @@ func TestTxnMerkle(t *testing.T) {
 
 func TestBlock_TxnMerkleTreeSHA256(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	for ntxn := uint64(0); ntxn < 128; ntxn++ {
 		var b Block

--- a/data/committee/credential_test.go
+++ b/data/committee/credential_test.go
@@ -30,6 +30,7 @@ import (
 // and then set balance to 0 and test not SelfCheckSelected
 func TestAccountSelected(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	N := 1
 	for i := 0; i < N; i++ {
@@ -90,6 +91,7 @@ func TestAccountSelected(t *testing.T) {
 
 func TestRichAccountSelected(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 10, 2000)
 
@@ -143,6 +145,7 @@ func TestRichAccountSelected(t *testing.T) {
 
 func TestPoorAccountSelectedLeaders(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	N := 2
 	failsLeaders := 0
@@ -188,6 +191,7 @@ func TestPoorAccountSelectedLeaders(t *testing.T) {
 
 func TestPoorAccountSelectedCommittee(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	N := 1
 	committee := uint64(0)
@@ -228,6 +232,7 @@ func TestPoorAccountSelectedCommittee(t *testing.T) {
 
 func TestNoMoneyAccountNotSelected(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	N := 1
 	for i := 0; i < N; i++ {
@@ -261,6 +266,7 @@ func TestNoMoneyAccountNotSelected(t *testing.T) {
 
 func TestLeadersSelected(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000)
 
@@ -293,6 +299,7 @@ func TestLeadersSelected(t *testing.T) {
 
 func TestCommitteeSelected(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000)
 
@@ -325,6 +332,7 @@ func TestCommitteeSelected(t *testing.T) {
 
 func TestAccountNotSelected(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000)
 	period := Period(0)

--- a/data/committee/encoding_test.go
+++ b/data/committee/encoding_test.go
@@ -27,6 +27,7 @@ import (
 
 func TestEmptyEncoding(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var c Credential
 	require.Equal(t, 1, len(protocol.Encode(&c)))

--- a/data/committee/sortition/sortition_test.go
+++ b/data/committee/sortition/sortition_test.go
@@ -38,6 +38,7 @@ func BenchmarkSortition(b *testing.B) {
 
 func TestSortitionBasic(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	hitcount := uint64(0)
 	const N = 1000
 	const expectedSize = 20

--- a/data/pools/transactionPool_test.go
+++ b/data/pools/transactionPool_test.go
@@ -879,9 +879,8 @@ func TestRemove(t *testing.T) {
 	require.Equal(t, transactionPool.PendingTxGroups(), [][]transactions.SignedTxn{{signedTx}})
 }
 
-func TestLogicSigOK(t *testing.T) {
+func TestLogicSigOK(t *testing.T) { //nolint:paralleltest // Not parallel because it modifies config.Consensus
 	partitiontest.PartitionTest(t)
-	t.Parallel()
 
 	oparams := config.Consensus[protocol.ConsensusCurrentVersion]
 	params := oparams

--- a/data/pools/transactionPool_test.go
+++ b/data/pools/transactionPool_test.go
@@ -149,6 +149,7 @@ const testPoolSize = 1000
 
 func TestMinBalanceOK(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfAccounts := 5
 	// Generate accounts
@@ -192,6 +193,7 @@ func TestMinBalanceOK(t *testing.T) {
 
 func TestSenderGoesBelowMinBalance(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfAccounts := 5
 	// Generate accounts
@@ -235,6 +237,7 @@ func TestSenderGoesBelowMinBalance(t *testing.T) {
 
 func TestSenderGoesBelowMinBalanceDueToAssets(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfAccounts := 5
 	// Generate accounts
@@ -307,6 +310,7 @@ func TestSenderGoesBelowMinBalanceDueToAssets(t *testing.T) {
 
 func TestCloseAccount(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfAccounts := 5
 	// Generate accounts
@@ -370,6 +374,7 @@ func TestCloseAccount(t *testing.T) {
 
 func TestCloseAccountWhileTxIsPending(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfAccounts := 5
 	// Generate accounts
@@ -433,6 +438,7 @@ func TestCloseAccountWhileTxIsPending(t *testing.T) {
 
 func TestClosingAccountBelowMinBalance(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfAccounts := 5
 	// Generate accounts
@@ -478,6 +484,7 @@ func TestClosingAccountBelowMinBalance(t *testing.T) {
 
 func TestRecipientGoesBelowMinBalance(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfAccounts := 5
 	// Generate accounts
@@ -521,6 +528,7 @@ func TestRecipientGoesBelowMinBalance(t *testing.T) {
 
 func TestRememberForget(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfAccounts := 5
 	// Generate accounts
@@ -588,6 +596,7 @@ func TestRememberForget(t *testing.T) {
 //	Test that clean up works
 func TestCleanUp(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfAccounts := 10
 	// Generate accounts
@@ -667,6 +676,7 @@ func TestCleanUp(t *testing.T) {
 
 func TestFixOverflowOnNewBlock(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfAccounts := 10
 	// Generate accounts
@@ -763,6 +773,7 @@ func TestFixOverflowOnNewBlock(t *testing.T) {
 
 func TestOverspender(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfAccounts := 2
 	// Generate accounts
@@ -826,6 +837,7 @@ func TestOverspender(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfAccounts := 2
 	// Generate accounts
@@ -869,6 +881,7 @@ func TestRemove(t *testing.T) {
 
 func TestLogicSigOK(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	oparams := config.Consensus[protocol.ConsensusCurrentVersion]
 	params := oparams
@@ -929,6 +942,7 @@ func TestLogicSigOK(t *testing.T) {
 
 func TestTransactionPool_CurrentFeePerByte(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfAccounts := 5
 	// Generate accounts
@@ -1304,6 +1318,7 @@ func BenchmarkTransactionPoolSteadyState(b *testing.B) {
 
 func TestTxPoolSizeLimits(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfAccounts := 2
 	// Generate accounts
@@ -1390,6 +1405,7 @@ func TestTxPoolSizeLimits(t *testing.T) {
 
 func TestStateProofLogging(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 

--- a/data/transactions/application_test.go
+++ b/data/transactions/application_test.go
@@ -29,6 +29,7 @@ import (
 
 func TestApplicationCallFieldsNotChanged(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	af := ApplicationCallTxnFields{}
 	s := reflect.ValueOf(&af).Elem()
@@ -42,6 +43,7 @@ func TestApplicationCallFieldsNotChanged(t *testing.T) {
 
 func TestApplicationCallFieldsEmpty(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := require.New(t)
 
@@ -103,6 +105,7 @@ func TestApplicationCallFieldsEmpty(t *testing.T) {
 
 func TestEncodedAppTxnAllocationBounds(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	// ensure that all the supported protocols have value limits less or
 	// equal to their corresponding codec allocbounds
@@ -127,6 +130,7 @@ func TestEncodedAppTxnAllocationBounds(t *testing.T) {
 
 func TestIDByIndex(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := require.New(t)
 	ac := ApplicationCallTxnFields{}
@@ -141,6 +145,7 @@ func TestIDByIndex(t *testing.T) {
 
 func TestIndexByID(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := require.New(t)
 	ac := ApplicationCallTxnFields{}

--- a/data/transactions/json_test.go
+++ b/data/transactions/json_test.go
@@ -47,6 +47,7 @@ func compact(data []byte) string {
 // TestJsonMarshal ensures that BoxRef names are b64 encoded, since they may not be characters.
 func TestJsonMarshal(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	marshal := protocol.EncodeJSON(transactions.BoxRef{Index: 4, Name: []byte("joe")})
 	require.Equal(t, `{"i":4,"n":"am9l"}`, compact(marshal))
@@ -64,6 +65,8 @@ func TestJsonMarshal(t *testing.T) {
 // TestJsonUnmarshal ensures that BoxRef unmarshaling expects b64 names
 func TestJsonUnmarshal(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
+
 	var br transactions.BoxRef
 
 	decode(t, `{"i":4,"n":"am9l"}`, &br)
@@ -87,6 +90,7 @@ func TestJsonUnmarshal(t *testing.T) {
 // the same for the sake of REST API compatibility.
 func TestTxnJson(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	txn := txntest.Txn{
 		Sender: basics.Address{0x01, 0x02, 0x03},

--- a/data/transactions/payment_test.go
+++ b/data/transactions/payment_test.go
@@ -36,6 +36,7 @@ func keypair() *crypto.SignatureSecrets {
 
 func TestAlgosEncoding(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var a basics.MicroAlgos
 	var b basics.MicroAlgos

--- a/data/transactions/payset_test.go
+++ b/data/transactions/payset_test.go
@@ -37,6 +37,7 @@ func preparePayset(txnCount, acctCount int) Payset {
 }
 func TestPaysetCommitsToTxnOrder(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	payset := preparePayset(50, 50)
 	commit1 := payset.CommitFlat()
@@ -47,6 +48,7 @@ func TestPaysetCommitsToTxnOrder(t *testing.T) {
 
 func TestEmptyPaysetCommitment(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	const nilFlatPaysetHash = "WRS2VL2OQ5LPWBYLNBCZV3MEQ4DACSRDES6IUKHGOWYQERJRWC5A"
 	const emptyFlatPaysetHash = "E54GFMNS2LISPG5VUGOQ3B2RR7TRKAHRE24LUM3HOW6TJGQ6PNZQ"

--- a/data/transactions/signedtxn_test.go
+++ b/data/transactions/signedtxn_test.go
@@ -28,6 +28,7 @@ import (
 
 func TestEncoding(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	secrets := keypair()
 	zeroPayment := Transaction{Type: protocol.PaymentTx}
@@ -64,6 +65,7 @@ func TestEncoding(t *testing.T) {
 
 func TestDecodeNil(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	// This is a regression test for improper decoding of a nil SignedTxn.
 	// This is a subtle case because decoding a msgpack nil does not run
@@ -80,6 +82,7 @@ func TestDecodeNil(t *testing.T) {
 
 func TestSignedTxnInBlockHash(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var stib SignedTxnInBlock
 	crypto.RandBytes(stib.Txn.Sender[:])

--- a/data/transactions/teal_test.go
+++ b/data/transactions/teal_test.go
@@ -28,6 +28,7 @@ import (
 
 func TestEvalDeltaEqual(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := require.New(t)
 
@@ -200,6 +201,7 @@ func TestEvalDeltaEqual(t *testing.T) {
 // had better be the case that such messages cannot be emitted in old code.)
 func TestUnchangedAllocBounds(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	delta := &EvalDelta{}
 	max := 256 // Hardcodes config.MaxEvalDeltaAccounts

--- a/data/transactions/transaction_test.go
+++ b/data/transactions/transaction_test.go
@@ -36,6 +36,7 @@ import (
 
 func TestTransaction_EstimateEncodedSize(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	addr, err := basics.UnmarshalChecksumAddress("NDQCJNNY5WWWFLP4GFZ7MEF2QJSMZYK6OWIV2AQ7OMAVLEFCGGRHFPKJJA")
 	require.NoError(t, err)
@@ -88,6 +89,7 @@ func generateDummyGoNonparticpatingTransaction(addr basics.Address) (tx Transact
 
 func TestGoOnlineGoNonparticipatingContradiction(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	// addr has no significance here other than being a normal valid address
 	addr, err := basics.UnmarshalChecksumAddress("NDQCJNNY5WWWFLP4GFZ7MEF2QJSMZYK6OWIV2AQ7OMAVLEFCGGRHFPKJJA")
@@ -112,6 +114,7 @@ func TestGoOnlineGoNonparticipatingContradiction(t *testing.T) {
 
 func TestGoNonparticipatingWellFormed(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	// addr has no significance here other than being a normal valid address
 	addr, err := basics.UnmarshalChecksumAddress("NDQCJNNY5WWWFLP4GFZ7MEF2QJSMZYK6OWIV2AQ7OMAVLEFCGGRHFPKJJA")
@@ -136,6 +139,7 @@ func TestGoNonparticipatingWellFormed(t *testing.T) {
 
 func TestAppCallCreateWellFormed(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	feeSink := basics.Address{0x7, 0xda, 0xcb, 0x4b, 0x6d, 0x9e, 0xd1, 0x41, 0xb1, 0x75, 0x76, 0xbd, 0x45, 0x9a, 0xe6, 0x42, 0x1d, 0x48, 0x6d, 0xa3, 0xd4, 0xef, 0x22, 0x47, 0xc4, 0x9, 0xa3, 0x96, 0xb8, 0x2e, 0xa2, 0x21}
 	curProto := config.Consensus[protocol.ConsensusCurrentVersion]
@@ -252,7 +256,9 @@ func TestAppCallCreateWellFormed(t *testing.T) {
 		},
 	}
 	for i, usecase := range usecases {
+		usecase := usecase
 		t.Run(fmt.Sprintf("i=%d", i), func(t *testing.T) {
+			t.Parallel()
 			err := usecase.tx.WellFormed(SpecialAddresses{FeeSink: feeSink}, usecase.proto)
 			if usecase.expectedError != "" {
 				require.Error(t, err)
@@ -266,6 +272,7 @@ func TestAppCallCreateWellFormed(t *testing.T) {
 
 func TestWellFormedErrors(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	feeSink := basics.Address{0x7, 0xda, 0xcb, 0x4b, 0x6d, 0x9e, 0xd1, 0x41, 0xb1, 0x75, 0x76, 0xbd, 0x45, 0x9a, 0xe6, 0x42, 0x1d, 0x48, 0x6d, 0xa3, 0xd4, 0xef, 0x22, 0x47, 0xc4, 0x9, 0xa3, 0x96, 0xb8, 0x2e, 0xa2, 0x21}
 	specialAddr := SpecialAddresses{FeeSink: feeSink}
@@ -576,6 +583,7 @@ func TestWellFormedErrors(t *testing.T) {
 // TestTransactionHash checks that Transaction.ID() is equivalent to the old simpler crypto.HashObj() implementation.
 func TestTransactionHash(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	var txn Transaction
 	txn.Sender[1] = 3
@@ -596,6 +604,7 @@ var generateFlag = flag.Bool("generate", false, "")
 // running test with -generate would generate the matrix used in the test ( without the "correct" errors )
 func TestWellFormedKeyRegistrationTx(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	flag.Parse()
 
@@ -1300,6 +1309,7 @@ func (s *stateproofTxnTestCase) runIsWellFormedForTestCase() error {
 
 func TestWellFormedStateProofTxn(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	// want to create different Txns, run on all of these cases the check, and have an expected result
 	cases := []stateproofTxnTestCase{
 		/* 0 */ {expectedError: errStateProofNotSupported}, // StateProofInterval == 0 leads to error
@@ -1322,6 +1332,7 @@ func TestWellFormedStateProofTxn(t *testing.T) {
 
 func TestStateProofTxnShouldBeZero(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	addr1, err := basics.UnmarshalChecksumAddress("NDQCJNNY5WWWFLP4GFZ7MEF2QJSMZYK6OWIV2AQ7OMAVLEFCGGRHFPKJJA")
 	require.NoError(t, err)

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -449,9 +449,8 @@ pushint 1`)
 	require.Equal(t, expectedEvents, mockTracer.Events)
 }
 
-func TestPaysetGroups(t *testing.T) {
+func TestPaysetGroups(t *testing.T) { //nolint:paralleltest // Not parallel because it reads `config.Consensus` within the execution pool, causing a race condition with `TestTxnValidationStateProof`
 	partitiontest.PartitionTest(t)
-	t.Parallel()
 
 	if testing.Short() {
 		t.Log("this is a long test and skipping for -short")

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -208,6 +208,7 @@ func generateTestObjects(numTxs, numAccs, noteOffset int, blockRound basics.Roun
 
 func TestSignedPayment(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
@@ -231,6 +232,7 @@ func TestSignedPayment(t *testing.T) {
 
 func TestTxnValidationEncodeDecode(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	_, signed, _, _ := generateTestObjects(100, 50, 0, 0)
 
@@ -253,6 +255,7 @@ func TestTxnValidationEncodeDecode(t *testing.T) {
 
 func TestTxnValidationEmptySig(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	_, signed, _, _ := generateTestObjects(100, 50, 0, 0)
 
@@ -346,6 +349,7 @@ func TestTxnValidationStateProof(t *testing.T) { //nolint:paralleltest // Not pa
 
 func TestDecodeNil(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	// This is a regression test for improper decoding of a nil SignedTxn.
 	// This is a subtle case because decoding a msgpack nil does not run
@@ -447,6 +451,7 @@ pushint 1`)
 
 func TestPaysetGroups(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	if testing.Short() {
 		t.Log("this is a long test and skipping for -short")
@@ -541,6 +546,7 @@ func BenchmarkPaysetGroups(b *testing.B) {
 
 func TestTxnGroupMixedSignatures(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	_, signedTxn, secrets, addrs := generateTestObjects(1, 20, 0, 50)
 	blkHdr := createDummyBlockHeader()
@@ -655,6 +661,7 @@ func generateTransactionGroups(maxGroupSize int, signedTxns []transactions.Signe
 
 func TestTxnGroupCacheUpdate(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	_, signedTxn, secrets, addrs := generateTestObjects(100, 20, 0, 50)
 	blkHdr := createDummyBlockHeader()
@@ -673,6 +680,7 @@ func TestTxnGroupCacheUpdate(t *testing.T) {
 // is valid (and added to the cache) only if all signatures in the multisig are correct
 func TestTxnGroupCacheUpdateMultiSig(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	_, signedTxn, _, _ := generateMultiSigTxn(100, 30, 50, t)
 	blkHdr := createDummyBlockHeader()
@@ -695,6 +703,7 @@ func TestTxnGroupCacheUpdateMultiSig(t *testing.T) {
 // is valid (and added to the cache) only if logic passes
 func TestTxnGroupCacheUpdateFailLogic(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	_, signedTxn, _, _ := generateTestObjects(100, 20, 0, 50)
 	blkHdr := createDummyBlockHeader()
@@ -738,6 +747,7 @@ byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
 // for this, we will break the signature and make sure that txn verification fails.
 func TestTxnGroupCacheUpdateLogicWithSig(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	_, signedTxn, secrets, addresses := generateTestObjects(100, 20, 0, 50)
 	blkHdr := createDummyBlockHeader()
@@ -790,6 +800,7 @@ byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
 // for this, we will break one of the multisig and the logic and make sure that txn verification fails.
 func TestTxnGroupCacheUpdateLogicWithMultiSig(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	secrets, _, pks, multiAddress := generateMultiSigAccounts(t, 30)
 	blkHdr := createDummyBlockHeader()
@@ -1094,6 +1105,7 @@ func getSignedTransactions(numOfTxns, maxGrpSize, noteOffset int, badTxnProb flo
 // TestStreamVerifier tests the basic functionality
 func TestStreamVerifier(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfTxns := 4000
 	txnGroups, badTxnGroups := getSignedTransactions(numOfTxns, protoMaxGroupSize, 0, 0.5)
@@ -1105,6 +1117,7 @@ func TestStreamVerifier(t *testing.T) {
 // TestStreamVerifierCases tests various valid and invalid transaction signature cases
 func TestStreamVerifierCases(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfTxns := 10
 	txnGroups, badTxnGroups := getSignedTransactions(numOfTxns, 1, 0, 0)
@@ -1207,6 +1220,7 @@ byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
 // TestStreamVerifierIdel starts the verifer and sends nothing, to trigger the timer, then sends a txn
 func TestStreamVerifierIdel(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfTxns := 1
 	txnGroups, badTxnGroups := getSignedTransactions(numOfTxns, protoMaxGroupSize, 0, 0.5)
@@ -1217,6 +1231,7 @@ func TestStreamVerifierIdel(t *testing.T) {
 
 func TestGetNumberOfBatchableSigsInGroup(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfTxns := 10
 	txnGroups, _ := getSignedTransactions(numOfTxns, 1, 0, 0)
@@ -1375,6 +1390,7 @@ func TestStreamVerifierPoolShutdown(t *testing.T) { //nolint:paralleltest // Not
 // TestStreamVerifierRestart tests what happens when the context is canceled
 func TestStreamVerifierRestart(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	numOfTxns := 1000
 	txnGroups, badTxnGroups := getSignedTransactions(numOfTxns, 1, 0, 0.5)
@@ -1436,6 +1452,7 @@ func TestStreamVerifierRestart(t *testing.T) {
 // TestBlockWatcher runs multiple goroutines to check the concurency and correctness of the block watcher
 func TestStreamVerifierBlockWatcher(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	blkHdr := createDummyBlockHeader()
 	nbw := MakeNewBlockWatcher(blkHdr)
 	startingRound := blkHdr.Round
@@ -1498,6 +1515,7 @@ func getSaturatedExecPool(t *testing.T) (execpool.BacklogPool, chan interface{})
 // passed to the exec pool yet, but is in batchingLoop
 func TestStreamVerifierCtxCancel(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	verificationPool, holdTasks := getSaturatedExecPool(t)
 	defer verificationPool.Shutdown()
@@ -1624,6 +1642,7 @@ func TestStreamVerifierCtxCancelPoolQueue(t *testing.T) { //nolint:paralleltest 
 // transactions is blocked, and checks droppedFromPool counter to confirm the drops
 func TestStreamVerifierPostVBlocked(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	// prepare the stream verifier
 	verificationPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, t)
@@ -1710,6 +1729,7 @@ func TestStreamVerifierPostVBlocked(t *testing.T) {
 
 func TestStreamVerifierMakeStreamVerifierErr(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	_, err := MakeStreamVerifier(nil, nil, nil, &DummyLedgerForSignature{badHdr: true}, nil, nil)
 	require.Error(t, err)
 }
@@ -1718,6 +1738,7 @@ func TestStreamVerifierMakeStreamVerifierErr(t *testing.T) {
 // task is queued to the exec pool and before the task is executed in the pool
 func TestStreamVerifierCancelWhenPooled(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 	numOfTxns := 1000
 	txnGroups, badTxnGroups := getSignedTransactions(numOfTxns, 1, 0, 0.5)
 

--- a/data/transactions/verify/verifiedTxnCache_test.go
+++ b/data/transactions/verify/verifiedTxnCache_test.go
@@ -29,6 +29,7 @@ import (
 
 func TestAddingToCache(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	icache := MakeVerifiedTransactionCache(500)
 	impl := icache.(*verifiedTransactionCache)
@@ -47,6 +48,7 @@ func TestAddingToCache(t *testing.T) {
 
 func TestBucketCycling(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	bucketCount := 3
 	entriesPerBucket := 100
@@ -78,6 +80,7 @@ func TestBucketCycling(t *testing.T) {
 
 func TestGetUnverifiedTransactionGroups50(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	size := 300
 	icache := MakeVerifiedTransactionCache(size * 2)
@@ -136,6 +139,7 @@ func BenchmarkGetUnverifiedTransactionGroups50(b *testing.B) {
 
 func TestUpdatePinned(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	size := 100
 	icache := MakeVerifiedTransactionCache(size * 10)
@@ -165,6 +169,7 @@ func TestUpdatePinned(t *testing.T) {
 
 func TestPinningTransactions(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	size := 100
 	icache := MakeVerifiedTransactionCache(size)

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -602,7 +602,9 @@ func TestTxHandlerProcessIncomingGroup(t *testing.T) {
 	}
 
 	for _, check := range checks {
+		check := check
 		t.Run(fmt.Sprintf("%d-%d", check.inputSize, check.numDecoded), func(t *testing.T) {
+			t.Parallel()
 			handler := TxHandler{
 				backlogQueue: make(chan *txBacklogMsg, 1),
 			}
@@ -677,6 +679,7 @@ func TestTxHandlerProcessIncomingCensoring(t *testing.T) {
 	}
 
 	t.Run("single", func(t *testing.T) {
+		t.Parallel()
 		handler := makeTestTxHandlerOrphanedWithContext(context.Background(), txBacklogSize, txBacklogSize, txHandlerConfig{true, true}, 0)
 		stxns, blob := makeRandomTransactions(1)
 		stxn := stxns[0]
@@ -702,6 +705,7 @@ func TestTxHandlerProcessIncomingCensoring(t *testing.T) {
 	})
 
 	t.Run("group", func(t *testing.T) {
+		t.Parallel()
 		handler := makeTestTxHandlerOrphanedWithContext(context.Background(), txBacklogSize, txBacklogSize, txHandlerConfig{true, true}, 0)
 		num := rand.Intn(config.MaxTxGroupSize-1) + 2 // 2..config.MaxTxGroupSize
 		require.LessOrEqual(t, num, config.MaxTxGroupSize)
@@ -890,6 +894,7 @@ func TestTxHandlerProcessIncomingCacheRotation(t *testing.T) {
 	}
 
 	t.Run("scheduled", func(t *testing.T) {
+		t.Parallel()
 		// double enqueue a single txn message, ensure it discarded
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		handler := makeTestTxHandlerOrphanedWithContext(ctx, txBacklogSize, txBacklogSize, txHandlerConfig{true, true}, 10*time.Millisecond)
@@ -911,6 +916,7 @@ func TestTxHandlerProcessIncomingCacheRotation(t *testing.T) {
 	})
 
 	t.Run("manual", func(t *testing.T) {
+		t.Parallel()
 		// double enqueue a single txn message, ensure it discarded
 		handler := makeTestTxHandlerOrphaned(txBacklogSize)
 		var action network.OutgoingMessage
@@ -953,6 +959,7 @@ func TestTxHandlerProcessIncomingCacheRotation(t *testing.T) {
 // TestTxHandlerProcessIncomingCacheBacklogDrop checks if dropped messages are also removed from caches
 func TestTxHandlerProcessIncomingCacheBacklogDrop(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	handler := makeTestTxHandlerOrphanedWithContext(context.Background(), 1, 20, txHandlerConfig{true, true}, 0)
 
@@ -980,6 +987,7 @@ func TestTxHandlerProcessIncomingCacheBacklogDrop(t *testing.T) {
 
 func TestTxHandlerProcessIncomingCacheTxPoolDrop(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	const numUsers = 100
 	log := logging.TestingLog(t)
@@ -2312,6 +2320,8 @@ func TestTxHandlerRememberReportErrorsWithTxPool(t *testing.T) { //nolint:parall
 
 func TestMakeTxHandlerErrors(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
+
 	opts := TxHandlerOpts{
 		nil, nil, nil, &mocks.MockNetwork{}, "", crypto.Digest{}, config.Local{},
 	}


### PR DESCRIPTION
## Summary

This PR enables https://github.com/kunwardeep/paralleltest on `node` by fixing linter warnings. These changes improve test parallelization to reduce test durations.

Notes:
* The PR does _not_ intend to rework all sequential tests into parallel tests.  The objective is to enable already available parallelism throughout go-algorand.  And then make a pass through remaining sequential tests to see if/where more parallelism exists. 


## Test Plan

I vetted for flakiness by running the following. I first marked `TestInitialSync` to be skipped with `t.Skip()` since it was flaky on `master` even before making the changes within this PR.

```
go test -race -count 10 ./node/...
```
