### PR TITLE
Tests: Fix t.Parallel() errors in `node` package

### DIFF
--- a/node/assemble_test.go
+++ b/node/assemble_test.go
@@ -174,6 +174,7 @@ func (cl callbackLogger) Warnf(s string, args ...interface{}) {
 
 func TestAssembleBlockTransactionPoolBehind(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	const numUsers = 100
 	expectingLog := false

--- a/node/indexer/indexer_test.go
+++ b/node/indexer/indexer_test.go
@@ -160,6 +160,7 @@ func (s *IndexSuite) TestIndexer_Asset() {
 
 func TestExampleTestSuite(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	suite.Run(t, new(IndexSuite))
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -184,6 +184,7 @@ func setupFullNodes(t *testing.T, proto protocol.ConsensusVersion, verificationP
 
 func TestSyncingFullNode(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	t.Skip("Flaky in nightly test environment")
 
@@ -240,7 +241,7 @@ func TestSyncingFullNode(t *testing.T) {
 	}
 }
 
-func TestInitialSync(t *testing.T) {
+func TestInitialSync(t *testing.T) { //nolint:paralleltest // Too heavy to parallelize
 	partitiontest.PartitionTest(t)
 
 	if testing.Short() {
@@ -281,7 +282,7 @@ func TestInitialSync(t *testing.T) {
 	}
 }
 
-func TestSimpleUpgrade(t *testing.T) {
+func TestSimpleUpgrade(t *testing.T) { //nolint:paralleltest // The test is skipped.
 	partitiontest.PartitionTest(t)
 
 	t.Skip("Flaky in nightly test environment.")
@@ -428,6 +429,7 @@ func delayStartNode(node *AlgorandFullNode, peers []*AlgorandFullNode, delay tim
 
 func TestStatusReport_TimeSinceLastRound(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	type fields struct {
 		LastRoundTimestamp time.Time
@@ -458,7 +460,9 @@ func TestStatusReport_TimeSinceLastRound(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			status := StatusReport{
 				LastRoundTimestamp: tt.fields.LastRoundTimestamp,
 			}
@@ -486,6 +490,7 @@ func (m mismatchingDirectroyPermissionsLog) Errorf(fmts string, args ...interfac
 // TestMismatchingGenesisDirectoryPermissions tests to see that the os.MkDir check we have in MakeFull works as expected. It tests both the return error as well as the logged error.
 func TestMismatchingGenesisDirectoryPermissions(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	testDirectroy := t.TempDir()
 
@@ -514,6 +519,7 @@ func TestMismatchingGenesisDirectoryPermissions(t *testing.T) {
 // TestOfflineOnlineClosedBitStatus a test that validates that the correct bits are being set
 func TestOfflineOnlineClosedBitStatus(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	tests := []struct {
 		name        string
@@ -534,7 +540,9 @@ func TestOfflineOnlineClosedBitStatus(t *testing.T) {
 			MicroAlgosWithRewards: basics.MicroAlgos{Raw: 0}}, 0 | bitAccountOffline | bitAccountIsClosed},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, test.expectedInt, getOfflineClosedStatus(test.acctData))
 		})
 	}

--- a/nodecontrol/algodControl_test.go
+++ b/nodecontrol/algodControl_test.go
@@ -26,6 +26,7 @@ import (
 
 func TestStopAlgodErrorNotRunning(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	nodeController := MakeNodeController("", ".")
 	err := nodeController.StopAlgod()
@@ -35,6 +36,7 @@ func TestStopAlgodErrorNotRunning(t *testing.T) {
 
 func TestStopAlgodErrorInvalidDirectory(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	nodeController := MakeNodeController("", "[][]")
 	err := nodeController.StopAlgod()


### PR DESCRIPTION
## Summary

This PR enables https://github.com/kunwardeep/paralleltest on `node` by fixing linter warnings. These changes improve test parallelization to reduce test durations.

Notes:
* The PR does _not_ intend to rework all sequential tests into parallel tests. The objective is to enable already available parallelism throughout go-algorand. And then make a pass through remaining sequential tests to see if/where more parallelism exists. 


## Test Plan

I vetted for flakiness by running the following. Note that I first had to disable the `TestInitialSync` with `t.Skip()` as it was flaky on `master` even before making the changes in this PR.

```
go test -race -count 10 ./node/...
```
