### PR TITLE
e2e tests: log pending transactions in case of failure

### DIFF
--- a/test/framework/fixtures/restClientFixture.go
+++ b/test/framework/fixtures/restClientFixture.go
@@ -276,22 +276,41 @@ func (f *RestClientFixture) WaitForAllTxnsToConfirm(roundTimeout uint64, txidsAn
 	for txid, addr := range txidsAndAddresses {
 		_, err := f.WaitForConfirmedTxn(roundTimeout, addr, txid)
 		if err != nil {
-			f.t.Logf("txn failed to confirm: ", addr, txid)
+			f.t.Logf("txn failed to confirm: addr=%s, txid=%s", addr, txid)
 			pendingTxns, err := f.LibGoalClient.GetParsedPendingTransactions(0)
 			if err == nil {
 				pendingTxids := make([]string, 0, pendingTxns.TotalTransactions)
 				for _, txn := range pendingTxns.TopTransactions {
 					pendingTxids = append(pendingTxids, txn.Txn.ID().String())
 				}
-				f.t.Logf("pending txids: ", pendingTxids)
+				f.t.Logf("pending txids: %v", pendingTxids)
 			} else {
-				f.t.Logf("unable to log pending txns, ", err)
+				f.t.Logf("unable to log pending txns: %v", err)
 			}
 			allTxids := make([]string, 0, len(txidsAndAddresses))
 			for txID := range txidsAndAddresses {
 				allTxids = append(allTxids, txID)
 			}
-			f.t.Logf("all txids: ", allTxids)
+			f.t.Logf("all txids: %s", allTxids)
+
+			dataDirs := f.network.NodeDataDirs()
+			for _, nodedir := range dataDirs {
+				client, err := libgoal.MakeClientWithBinDir(f.binDir, nodedir, nodedir, libgoal.FullClient)
+				if err != nil {
+					f.t.Logf("failed to make a node client for %s: %v", nodedir, err)
+					continue
+				}
+				pendingTxns, err := client.GetParsedPendingTransactions(0)
+				if err != nil {
+					f.t.Logf("failed to get pending txns for %s: %v", nodedir, err)
+					continue
+				}
+				pendingTxids := make([]string, 0, pendingTxns.TotalTransactions)
+				for _, txn := range pendingTxns.TopTransactions {
+					pendingTxids = append(pendingTxids, txn.Txn.ID().String())
+				}
+				f.t.Logf("pending txids at node %s: %v", nodedir, pendingTxids)
+			}
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary

Time to time some e2e tests fails on waiting for txn go get included into a block. This change adds more logging for such failures to ensure txns are at least propagated to all nodes.

## Test Plan

This is a test fixture change.