### PR TITLE
goal: allow for relative dataDir via -d cmd option

### DIFF
--- a/cmd/goal/commands.go
+++ b/cmd/goal/commands.go
@@ -278,8 +278,13 @@ func resolveDataDir() string {
 	// Figure out what data directory to tell algod to use.
 	// If not specified on cmdline with '-d', look for default in environment.
 	var dir string
-	if len(dataDirs) > 0 {
-		dir = dataDirs[0]
+	if (len(dataDirs) > 0) && (dataDirs[0] != "") {
+		// calculate absolute path, see https://github.com/algorand/go-algorand/issues/589
+		absDir, err := filepath.Abs(dataDirs[0])
+		if err != nil {
+			reportErrorf("Absolute path conversion error: %s", err)
+		}
+		dir = absDir
 	}
 	if dir == "" {
 		dir = os.Getenv("ALGORAND_DATA")

--- a/cmd/goal/commands_test.go
+++ b/cmd/goal/commands_test.go
@@ -31,3 +31,47 @@ func TestEnsureDataDirReturnsWhenDataDirIsProvided(t *testing.T) {
 	actualDir := ensureFirstDataDir()
 	require.Equal(t, expectedDir, actualDir)
 }
+
+func TestEnsureDataDirReturnsWhenWorkDirIsProvided(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	expectedDir, err := os.Getwd()
+	if err != nil {
+		reportErrorf("Error getting work dir: %s", err)
+	}
+	dataDirs[0] = "."
+	actualDir := ensureFirstDataDir()
+	require.Equal(t, expectedDir, actualDir)
+}
+
+func TestEnsureDataDirReturnsWhenRelPath1IsProvided(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	expectedDir, err := os.Getwd()
+	if err != nil {
+		reportErrorf("Error getting work dir: %s", err)
+	}
+	dataDirs[0] = "./../goal"
+	actualDir := ensureFirstDataDir()
+	require.Equal(t, expectedDir, actualDir)
+}
+
+func TestEnsureDataDirReturnsWhenRelPath2IsProvided(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	expectedDir, err := os.Getwd()
+	if err != nil {
+		reportErrorf("Error getting work dir: %s", err)
+	}
+	dataDirs[0] = "../goal"
+	actualDir := ensureFirstDataDir()
+	require.Equal(t, expectedDir, actualDir)
+}
+
+func TestEnsureDataDirReturnsWhenRelPath3IsProvided(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	expectedDir, err := os.Getwd()
+	if err != nil {
+		reportErrorf("Error getting work dir: %s", err)
+	}
+	dataDirs[0] = "../../cmd/goal"
+	actualDir := ensureFirstDataDir()
+	require.Equal(t, expectedDir, actualDir)
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Allow relative data-dir, as described within #589

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

existent tests pass, added some more tests

```sh
go test -v ./cmd/goal
```
