### PR TITLE
algod: split SetFdSoftLimit calls for relay and non-relay nodes

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -633,13 +633,14 @@ func TestLocal_RecalculateConnectionLimits(t *testing.T) {
 		incomingExp int
 	}{
 		{100, 10, 20, 40, 50, false, 20, 40, 50},               // no change
-		{100, 10, 20, 50, 50, true, 10, 40, 50},                // borrow from rest
-		{100, 10, 25, 50, 50, true, 15, 40, 50},                // borrow from rest
-		{100, 10, 9, 19, 81, true, 10, 20, 70},                 // borrow from both rest and incoming
-		{100, 10, 10, 20, 80, true, 10, 20, 70},                // borrow from both rest and incoming
-		{100, 50, 10, 30, 40, true, 10, 20, 30},                // borrow from both rest and incoming
-		{100, 80, 10, 30, 40, true, 10, 20, 0},                 // borrow from both rest and incoming, clear incoming
-		{4096, 256, 1024, 2048, 2400, true, 416, 1440, 2400},   // real numbers
+		{100, 10, 20, 50, 50, true, 20, 40, 50},                // borrow from rest
+		{100, 10, 25, 50, 50, true, 25, 40, 50},                // borrow from rest
+		{100, 10, 50, 50, 50, true, 40, 40, 50},                // borrow from rest, update soft
+		{100, 10, 9, 19, 81, true, 9, 10, 80},                  // borrow from both rest and incoming
+		{100, 10, 10, 20, 80, true, 10, 10, 80},                // borrow from both rest and incoming
+		{100, 50, 10, 30, 40, true, 10, 10, 40},                // borrow from both rest and incoming
+		{100, 90, 10, 30, 40, true, 10, 10, 0},                 // borrow from both rest and incoming, clear incoming
+		{4096, 256, 1024, 2048, 2400, true, 1024, 1440, 2400},  // real numbers
 		{5000, 256, 1024, 2048, 2400, false, 1024, 2048, 2400}, // real numbers
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -605,3 +605,14 @@ func TestLocal_TxFiltering(t *testing.T) {
 	require.True(t, cfg.TxFilterRawMsgEnabled())
 	require.True(t, cfg.TxFilterCanonicalEnabled())
 }
+
+func TestLocal_IsGossipServer(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	cfg := GetDefaultLocal()
+	require.False(t, cfg.IsGossipServer())
+
+	cfg.NetAddress = ":4160"
+	require.True(t, cfg.IsGossipServer())
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -42,8 +42,9 @@ var defaultConfig = Local{
 	BaseLoggerDebugLevel:     1,  //Info level
 }
 
-func TestSaveThenLoad(t *testing.T) {
+func TestLocal_SaveThenLoad(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	c1, err := loadWithoutDefaults(defaultConfig)
 	require.NoError(t, err)
@@ -53,13 +54,10 @@ func TestSaveThenLoad(t *testing.T) {
 	ser1 := json.NewEncoder(&b1)
 	ser1.Encode(c1)
 
-	os.RemoveAll("testdir")
-	err = os.Mkdir("testdir", 0777)
-	require.NoError(t, err)
+	tempDir := t.TempDir()
+	c1.SaveToDisk(tempDir)
 
-	c1.SaveToDisk("testdir")
-
-	c2, err := LoadConfigFromDisk("testdir")
+	c2, err := LoadConfigFromDisk(tempDir)
 	require.NoError(t, err)
 
 	var b2 bytes.Buffer
@@ -67,23 +65,23 @@ func TestSaveThenLoad(t *testing.T) {
 	ser2.Encode(c2)
 
 	require.True(t, bytes.Equal(b1.Bytes(), b2.Bytes()))
-
-	os.RemoveAll("testdir")
 }
 
-func TestLoadMissing(t *testing.T) {
+func TestConfig_LoadMissing(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
-	os.RemoveAll("testdir")
-	_, err := LoadConfigFromDisk("testdir")
+	tempDir := t.TempDir()
+	os.RemoveAll(tempDir)
+	_, err := LoadConfigFromDisk(tempDir)
 	require.True(t, os.IsNotExist(err))
 }
 
-func TestMergeConfig(t *testing.T) {
+func TestLocal_MergeConfig(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
-	os.RemoveAll("testdir")
-	err := os.Mkdir("testdir", 0777)
+	tempDir := t.TempDir()
 
 	c1 := struct {
 		GossipFanout              int
@@ -98,7 +96,7 @@ func TestMergeConfig(t *testing.T) {
 	c1.NetAddress = testString
 
 	// write our reduced version of the Local struct
-	fileToMerge := filepath.Join("testdir", ConfigFilename)
+	fileToMerge := filepath.Join(tempDir, ConfigFilename)
 	f, err := os.OpenFile(fileToMerge, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err == nil {
 		enc := json.NewEncoder(f)
@@ -110,7 +108,7 @@ func TestMergeConfig(t *testing.T) {
 
 	// Take defaultConfig and merge with the saved custom settings.
 	// This should result in c2 being the same as defaultConfig except for the value(s) in our custom c1
-	c2, err := mergeConfigFromDir("testdir", defaultConfig)
+	c2, err := mergeConfigFromDir(tempDir, defaultConfig)
 
 	require.NoError(t, err)
 	require.Equal(t, defaultConfig.Archival || c1.NetAddress != "", c2.Archival)
@@ -119,12 +117,10 @@ func TestMergeConfig(t *testing.T) {
 
 	require.Equal(t, c1.NetAddress, c2.NetAddress)
 	require.Equal(t, c1.GossipFanout, c2.GossipFanout)
-
-	os.RemoveAll("testdir")
 }
 
-func saveFullPhonebook(phonebook phonebookBlackWhiteList) error {
-	filename := filepath.Join("testdir", PhonebookFilename)
+func saveFullPhonebook(phonebook phonebookBlackWhiteList, saveToDir string) error {
+	filename := filepath.Join(saveToDir, PhonebookFilename)
 	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err == nil {
 		defer f.Close()
@@ -142,52 +138,48 @@ var phonebookToMerge = phonebookBlackWhiteList{
 	Include: []string{"test1", "addThisOne"},
 }
 
-var expectedMerged = []string{
-	"test1", "test2", "addThisOne",
-}
-
 func TestLoadPhonebook(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
-	os.RemoveAll("testdir")
-	err := os.Mkdir("testdir", 0777)
+	tempDir := t.TempDir()
+
+	err := saveFullPhonebook(phonebook, tempDir)
 	require.NoError(t, err)
 
-	err = saveFullPhonebook(phonebook)
-	require.NoError(t, err)
-
-	phonebookEntries, err := LoadPhonebook("testdir")
+	phonebookEntries, err := LoadPhonebook(tempDir)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(phonebookEntries))
 	for index, entry := range phonebookEntries {
 		require.Equal(t, phonebook.Include[index], entry)
 	}
-	os.RemoveAll("testdir")
 }
 
 func TestLoadPhonebookMissing(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
-	os.RemoveAll("testdir")
-	_, err := LoadPhonebook("testdir")
+	tempDir := t.TempDir()
+	_, err := LoadPhonebook(tempDir)
 	require.True(t, os.IsNotExist(err))
 }
 
 func TestArchivalIfRelay(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	testArchivalIfRelay(t, true)
 }
 
 func TestArchivalIfNotRelay(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	testArchivalIfRelay(t, false)
 }
 
 func testArchivalIfRelay(t *testing.T, relay bool) {
-	os.RemoveAll("testdir")
-	err := os.Mkdir("testdir", 0777)
+	tempDir := t.TempDir()
 
 	c1 := struct {
 		NetAddress string
@@ -197,7 +189,7 @@ func testArchivalIfRelay(t *testing.T, relay bool) {
 	}
 
 	// write our reduced version of the Local struct
-	fileToMerge := filepath.Join("testdir", ConfigFilename)
+	fileToMerge := filepath.Join(tempDir, ConfigFilename)
 	f, err := os.OpenFile(fileToMerge, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err == nil {
 		enc := json.NewEncoder(f)
@@ -207,18 +199,16 @@ func testArchivalIfRelay(t *testing.T, relay bool) {
 	require.NoError(t, err)
 	require.False(t, defaultConfig.Archival, "Default should be non-archival")
 
-	c2, err := mergeConfigFromDir("testdir", defaultConfig)
+	c2, err := mergeConfigFromDir(tempDir, defaultConfig)
 	require.NoError(t, err)
 	if relay {
 		require.True(t, c2.Archival, "Relay should be archival")
 	} else {
 		require.False(t, c2.Archival, "Non-relay should still be non-archival")
 	}
-
-	os.RemoveAll("testdir")
 }
 
-func TestConfigExampleIsCorrect(t *testing.T) {
+func TestLocal_ConfigExampleIsCorrect(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	a := require.New(t)
@@ -261,7 +251,7 @@ func loadWithoutDefaults(cfg Local) (Local, error) {
 	return cfg, err
 }
 
-func TestConfigMigrate(t *testing.T) {
+func TestLocal_ConfigMigrate(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	a := require.New(t)
@@ -288,7 +278,7 @@ func TestConfigMigrate(t *testing.T) {
 	a.NotEqual(defaultLocal, c0Modified)
 }
 
-func TestConfigMigrateFromDisk(t *testing.T) {
+func TestLocal_ConfigMigrateFromDisk(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	a := require.New(t)
@@ -311,7 +301,7 @@ func TestConfigMigrateFromDisk(t *testing.T) {
 }
 
 // Verify that nobody is changing the shipping default configurations
-func TestConfigInvariant(t *testing.T) {
+func TestLocal_ConfigInvariant(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	a := require.New(t)
@@ -328,8 +318,9 @@ func TestConfigInvariant(t *testing.T) {
 	}
 }
 
-func TestConfigLatestVersion(t *testing.T) {
+func TestLocal_ConfigLatestVersion(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := require.New(t)
 
@@ -391,6 +382,7 @@ func TestConsensusLatestVersion(t *testing.T) {
 
 func TestLocal_DNSBootstrapArray(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	type fields struct {
 		DNSBootstrapID string
@@ -434,6 +426,7 @@ func TestLocal_DNSBootstrapArray(t *testing.T) {
 
 func TestLocal_DNSBootstrap(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	type fields struct {
 		DNSBootstrapID string
@@ -480,8 +473,9 @@ func TestLocal_DNSBootstrap(t *testing.T) {
 	}
 }
 
-func TestLocalStructTags(t *testing.T) {
+func TestLocal_StructTags(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	localType := reflect.TypeOf(Local{})
 
@@ -523,8 +517,9 @@ func TestLocalStructTags(t *testing.T) {
 	}
 }
 
-func TestGetVersionedDefaultLocalConfig(t *testing.T) {
+func TestLocal_GetVersionedDefaultLocalConfig(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	for i := uint32(0); i < getLatestConfigVersion(); i++ {
 		localVersion := getVersionedDefaultLocalConfig(i)
@@ -533,8 +528,9 @@ func TestGetVersionedDefaultLocalConfig(t *testing.T) {
 }
 
 // TestLocalVersionField - ensures the Version contains only versions tags, the versions are all contiguous, and that no non-version tags are included there.
-func TestLocalVersionField(t *testing.T) {
+func TestLocal_VersionField(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	localType := reflect.TypeOf(Local{})
 	field, ok := localType.FieldByName("Version")
@@ -553,8 +549,9 @@ func TestLocalVersionField(t *testing.T) {
 	require.Equal(t, expectedTag, string(field.Tag))
 }
 
-func TestGetNonDefaultConfigValues(t *testing.T) {
+func TestLocal_GetNonDefaultConfigValues(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	cfg := GetDefaultLocal()
 
@@ -583,6 +580,8 @@ func TestGetNonDefaultConfigValues(t *testing.T) {
 
 func TestLocal_TxFiltering(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
+
 	cfg := GetDefaultLocal()
 
 	// ensure the default

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -588,3 +588,9 @@ func (cfg Local) TxFilterRawMsgEnabled() bool {
 func (cfg Local) TxFilterCanonicalEnabled() bool {
 	return cfg.TxIncomingFilteringFlags&txFilterCanonical != 0
 }
+
+// IsGossipServer returns true if NetAddress is set and this node supposed
+// to start websocket server
+func (cfg Local) IsGossipServer() bool {
+	return cfg.NetAddress != ""
+}

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -606,15 +606,9 @@ func (cfg *Local) AdjustConnectionLimits(requiredFDs, maxFDs uint64) bool {
 	const reservedRESTConns = 10
 	diff := requiredFDs - maxFDs
 
-	if cfg.RestConnectionsSoftLimit <= diff+reservedRESTConns {
-		cfg.RestConnectionsSoftLimit = reservedRESTConns
-	} else {
-		cfg.RestConnectionsSoftLimit -= diff
-	}
-
-	if cfg.RestConnectionsHardLimit <= diff+2*reservedRESTConns {
-		restDelta := diff + 2*reservedRESTConns - cfg.RestConnectionsHardLimit
-		cfg.RestConnectionsHardLimit = 2 * reservedRESTConns
+	if cfg.RestConnectionsHardLimit <= diff+reservedRESTConns {
+		restDelta := diff + reservedRESTConns - cfg.RestConnectionsHardLimit
+		cfg.RestConnectionsHardLimit = reservedRESTConns
 		if cfg.IncomingConnectionsLimit > int(restDelta) {
 			cfg.IncomingConnectionsLimit -= int(restDelta)
 		} else {
@@ -623,5 +617,10 @@ func (cfg *Local) AdjustConnectionLimits(requiredFDs, maxFDs uint64) bool {
 	} else {
 		cfg.RestConnectionsHardLimit -= diff
 	}
+
+	if cfg.RestConnectionsSoftLimit > cfg.RestConnectionsHardLimit {
+		cfg.RestConnectionsSoftLimit = cfg.RestConnectionsHardLimit
+	}
+
 	return true
 }

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -128,6 +128,17 @@ func (s *Server) Initialize(cfg config.Local, phonebookAddresses []string, genes
 		if err != nil {
 			// do not fail but log the error
 			s.log.Errorf("Failed to set a new RLIMIT_NOFILE value to %d: %s", fdRequired, err.Error())
+			_, hard, err := util.GetFdLimits()
+			if err != nil {
+				s.log.Errorf("Failed to get RLIMIT_NOFILE values: %s", err.Error())
+			} else {
+				err = util.SetFdSoftLimit(hard)
+				if err != nil {
+					s.log.Errorf("Failed to set a new RLIMIT_NOFILE value to the max %d: %s", hard, err.Error())
+				} else {
+					s.log.Infof("Set RLIMIT_NOFILE to max value %d", hard)
+				}
+			}
 		}
 	}
 

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -119,12 +119,8 @@ func (s *Server) Initialize(cfg config.Local, phonebookAddresses []string, genes
 		return fmt.Errorf("Initialize() err: %w", err)
 	}
 	if cfg.IsGossipServer() {
-		cur, err := util.GetFdSoftLimit()
-		if err != nil {
-			return fmt.Errorf("Initialize() failed to obtain a current RLIMIT_NOFILE: %w", err)
-		}
 		var ot basics.OverflowTracker
-		fdRequired := ot.Add(cur, uint64(cfg.IncomingConnectionsLimit))
+		fdRequired := ot.Add(fdRequired, uint64(cfg.IncomingConnectionsLimit))
 		if ot.Overflowed {
 			return errors.New("Initialize() overflowed when adding up IncomingConnectionsLimit to the existing RLIMIT_NOFILE value; decrease RestConnectionsHardLimit or IncomingConnectionsLimit")
 		}

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -109,13 +109,10 @@ func (s *Server) Initialize(cfg config.Local, phonebookAddresses []string, genes
 
 	// Set large enough soft file descriptors limit.
 	var ot basics.OverflowTracker
-	fdRequired := ot.Add(
-		cfg.ReservedFDs,
-		ot.Add(uint64(cfg.IncomingConnectionsLimit), cfg.RestConnectionsHardLimit))
+	fdRequired := ot.Add(cfg.ReservedFDs, cfg.RestConnectionsHardLimit)
 	if ot.Overflowed {
 		return errors.New(
-			"Initialize() overflowed when adding up ReservedFDs, IncomingConnectionsLimit " +
-				"RestConnectionsHardLimit; decrease them")
+			"Initialize() overflowed when adding up ReservedFDs and RestConnectionsHardLimit; decrease them")
 	}
 	err = util.SetFdSoftLimit(fdRequired)
 	if err != nil {

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -42,7 +42,6 @@ import (
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
-	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/logging/telemetryspec"
 	"github.com/algorand/go-algorand/network/limitlistener"
@@ -728,23 +727,6 @@ func (wn *WebsocketNetwork) setup() {
 	wn.relayMessages = wn.config.IsGossipServer() || wn.config.ForceRelayMessages
 	if wn.relayMessages || wn.config.ForceFetchTransactions {
 		wn.wantTXGossip = wantTXGossipYes
-	}
-	if wn.config.IsGossipServer() {
-		cur, err := util.GetFdSoftLimit()
-		if err != nil {
-			wn.log.Errorf("Failed to obtain a current RLIMIT_NOFILE: %s", err.Error())
-		} else {
-			var ot basics.OverflowTracker
-			fdRequired := ot.Add(cur, uint64(wn.config.IncomingConnectionsLimit))
-			if ot.Overflowed {
-				wn.log.Errorf("overflowed when adding up IncomingConnectionsLimit to the existing RLIMIT_NOFILE value; decrease it")
-			} else {
-				err = util.SetFdSoftLimit(fdRequired)
-				if err != nil {
-					wn.log.Errorf("Failed to set a new RLIMIT_NOFILE value to %d: %s", fdRequired, err.Error())
-				}
-			}
-		}
 	}
 	// roughly estimate the number of messages that could be seen at any given moment.
 	// For the late/redo/down committee, which happen in parallel, we need to allocate

--- a/util/util.go
+++ b/util/util.go
@@ -26,6 +26,16 @@ import (
 
 /* misc */
 
+// GetFdLimits returns a current values for file descriptors limits.
+func GetFdLimits() (soft uint64, hard uint64, err error) {
+	var rLimit syscall.Rlimit
+	err = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		return 0, 0, fmt.Errorf("GetFdSoftLimit() err: %w", err)
+	}
+	return rLimit.Cur, rLimit.Max, nil
+}
+
 // SetFdSoftLimit sets a new file descriptors soft limit.
 func SetFdSoftLimit(newLimit uint64) error {
 	var rLimit syscall.Rlimit

--- a/util/util.go
+++ b/util/util.go
@@ -26,16 +26,6 @@ import (
 
 /* misc */
 
-// GetFdSoftLimit returns a current value for file descriptors soft limit.
-func GetFdSoftLimit() (uint64, error) {
-	var rLimit syscall.Rlimit
-	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
-	if err != nil {
-		return 0, fmt.Errorf("GetFdSoftLimit() err: %w", err)
-	}
-	return rLimit.Cur, nil
-}
-
 // SetFdSoftLimit sets a new file descriptors soft limit.
 func SetFdSoftLimit(newLimit uint64) error {
 	var rLimit syscall.Rlimit

--- a/util/util.go
+++ b/util/util.go
@@ -26,6 +26,7 @@ import (
 
 /* misc */
 
+// GetFdSoftLimit returns a current value for file descriptors soft limit.
 func GetFdSoftLimit() (uint64, error) {
 	var rLimit syscall.Rlimit
 	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)

--- a/util/util.go
+++ b/util/util.go
@@ -26,6 +26,15 @@ import (
 
 /* misc */
 
+func GetFdSoftLimit() (uint64, error) {
+	var rLimit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		return 0, fmt.Errorf("GetFdSoftLimit() err: %w", err)
+	}
+	return rLimit.Cur, nil
+}
+
 // SetFdSoftLimit sets a new file descriptors soft limit.
 func SetFdSoftLimit(newLimit uint64) error {
 	var rLimit syscall.Rlimit

--- a/util/util_windows.go
+++ b/util/util_windows.go
@@ -24,14 +24,14 @@ import (
 
 /* misc */
 
-// SetFdSoftLimit sets a new file descriptors soft limit.
-func SetFdSoftLimit(_ uint64) error {
-	return nil
+// GetFdSoftLimit returns a current value for file descriptors soft limit.
+func GetFdSoftLimit() (uint64, error) {
+	return 0, nil
 }
 
 // SetFdSoftLimit sets a new file descriptors soft limit.
-func GetFdSoftLimit() (uint64, error) {
-	return 0, nil
+func SetFdSoftLimit(_ uint64) error {
+	return nil
 }
 
 // Getrusage gets file descriptors usage statistics

--- a/util/util_windows.go
+++ b/util/util_windows.go
@@ -24,11 +24,6 @@ import (
 
 /* misc */
 
-// GetFdSoftLimit returns a current value for file descriptors soft limit.
-func GetFdSoftLimit() (uint64, error) {
-	return 0, nil
-}
-
 // SetFdSoftLimit sets a new file descriptors soft limit.
 func SetFdSoftLimit(_ uint64) error {
 	return nil

--- a/util/util_windows.go
+++ b/util/util_windows.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"errors"
+	"math"
 	"syscall"
 	"time"
 )
@@ -26,7 +27,7 @@ import (
 
 // GetFdLimits returns a current values for file descriptors limits.
 func GetFdLimits() (soft uint64, hard uint64, err error) {
-	return 0, 0, nil
+	return math.MaxUint64, math.MaxUint64, nil // syscall.RLIM_INFINITY
 }
 
 // SetFdSoftLimit sets a new file descriptors soft limit.

--- a/util/util_windows.go
+++ b/util/util_windows.go
@@ -29,6 +29,11 @@ func SetFdSoftLimit(_ uint64) error {
 	return nil
 }
 
+// SetFdSoftLimit sets a new file descriptors soft limit.
+func GetFdSoftLimit() (uint64, error) {
+	return 0, nil
+}
+
 // Getrusage gets file descriptors usage statistics
 func Getrusage(who int, rusage *syscall.Rusage) (err error) {
 	if rusage != nil {

--- a/util/util_windows.go
+++ b/util/util_windows.go
@@ -24,6 +24,11 @@ import (
 
 /* misc */
 
+// GetFdLimits returns a current values for file descriptors limits.
+func GetFdLimits() (soft uint64, hard uint64, err error) {
+	return 0, 0, nil
+}
+
 // SetFdSoftLimit sets a new file descriptors soft limit.
 func SetFdSoftLimit(_ uint64) error {
 	return nil


### PR DESCRIPTION
## Summary

algod sets RLIMIT_NOFILE to max possible value on startup. This might result the node failure on startup especially if it is a non-relaying node and does not need to listen for thousands of incoming connections.

Additionally enhanced config test since I opened the file:
* Replace shared "tempdir" by t.TempDir
* Make them parallel
* Make test naming consistent

## Test Plan

New test for `IsGossipServer` config helper. Existing tests for everything else.