### PR TITLE
tests: add more logging to expect test

### DIFF
--- a/netdeploy/networkTemplate.go
+++ b/netdeploy/networkTemplate.go
@@ -133,14 +133,17 @@ func (t NetworkTemplate) createNodeDirectories(targetFolder string, binDir strin
 		if importKeys && hasWallet {
 			var client libgoal.Client
 			client, err = libgoal.MakeClientWithBinDir(binDir, nodeDir, "", libgoal.KmdClient)
+			if err != nil {
+				return
+			}
 			_, err = client.CreateWallet(libgoal.UnencryptedWalletName, nil, crypto.MasterDerivationKey{})
 			if err != nil {
 				return
 			}
 
-			_, _, err = util.ExecAndCaptureOutput(importKeysCmd, "account", "importrootkey", "-w", string(libgoal.UnencryptedWalletName), "-d", nodeDir)
+			stdout, stderr, err := util.ExecAndCaptureOutput(importKeysCmd, "account", "importrootkey", "-w", string(libgoal.UnencryptedWalletName), "-d", nodeDir)
 			if err != nil {
-				return
+				return nil, nil, fmt.Errorf("goal account importrootkey failed: %w\nstdout: %s\nstderr: %s", err, stdout, stderr)
 			}
 		}
 

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -64,6 +64,13 @@ proc ::AlgorandGoal::Abort { ERROR } {
             set nodeLog [exec -- tail -n 50 $NODE_DATA_DIR/node.log]
             puts "\n$NODE_DATA_DIR/node.log:\r\n$nodeLog"
             set LOGS_COLLECTED 1
+
+            set outLog [exec cat $NODE_DATA_DIR/kmd-v0.5/kmd-out.log]
+            puts "\n$NODE_DATA_DIR/kmd-v0.5/kmd-out.log:\r\n$outLog"
+            set errLog [exec cat $NODE_DATA_DIR/kmd-v0.5/kmd-err.log]
+            puts "\n$NODE_DATA_DIR/kmd-v0.5/kmd-err.log:\r\n$errLog"
+            set kmdLog [exec -- tail -n 50 $NODE_DATA_DIR/kmd-v0.5/kmd.log]
+            puts "\n$NODE_DATA_DIR/kmd-v0.5/kmd.log:\r\n$kmdLog"
         }
         set NODE_DATA_DIR $::GLOBAL_TEST_ROOT_DIR/Node
         puts "Node path $NODE_DATA_DIR"
@@ -75,6 +82,13 @@ proc ::AlgorandGoal::Abort { ERROR } {
             set nodeLog [exec -- tail -n 50 $NODE_DATA_DIR/node.log]
             puts "\n$NODE_DATA_DIR/node.log:\r\n$nodeLog"
             set LOGS_COLLECTED 1
+
+            set outLog [exec cat $NODE_DATA_DIR/kmd-v0.5/kmd-out.log]
+            puts "\n$NODE_DATA_DIR/kmd-v0.5/kmd-out.log:\r\n$outLog"
+            set errLog [exec cat $NODE_DATA_DIR/kmd-v0.5/kmd-err.log]
+            puts "\n$NODE_DATA_DIR/kmd-v0.5/kmd-err.log:\r\n$errLog"
+            set kmdLog [exec -- tail -n 50 $NODE_DATA_DIR/kmd-v0.5/kmd.log]
+            puts "\n$NODE_DATA_DIR/kmd-v0.5/kmd.log:\r\n$kmdLog"
         }
     }
 
@@ -91,6 +105,13 @@ proc ::AlgorandGoal::Abort { ERROR } {
             puts "\n$::GLOBAL_TEST_ALGO_DIR/algod-err.log:\r\n$errLog"
             set nodeLog [exec -- tail -n 50 $::GLOBAL_TEST_ALGO_DIR/node.log]
             puts "\n$::GLOBAL_TEST_ALGO_DIR/node.log:\r\n$nodeLog"
+
+            set outLog [exec cat $GLOBAL_TEST_ALGO_DIR/kmd-v0.5/kmd-out.log]
+            puts "\n$GLOBAL_TEST_ALGO_DIR/kmd-v0.5/kmd-out.log:\r\n$outLog"
+            set errLog [exec cat $GLOBAL_TEST_ALGO_DIR/kmd-v0.5/kmd-err.log]
+            puts "\n$GLOBAL_TEST_ALGO_DIR/kmd-v0.5/kmd-err.log:\r\n$errLog"
+            set kmdLog [exec -- tail -n 50 $GLOBAL_TEST_ALGO_DIR/kmd-v0.5/kmd.log]
+            puts "\n$GLOBAL_TEST_ALGO_DIR/kmd-v0.5/kmd.log:\r\n$kmdLog"
         }
     }
 


### PR DESCRIPTION
## Summary

More kmd logging in expect test runner to diagnose sporadic expect test failures.
Added "goal account import key" logging in net template code to diagnose "Error creating private network: exit status 1" errors.

## Test Plan

This is test-related code
