### PR TITLE
ledger: turn deferredCommitContext.newBase into a function

### DIFF
--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -380,7 +380,7 @@ func (ao *onlineAccounts) prepareCommit(dcc *deferredCommitContext) error {
 	if err != nil {
 		return err
 	}
-	end, err := ao.roundParamsOffset(dcc.newBase)
+	end, err := ao.roundParamsOffset(dcc.newBase())
 	if err != nil {
 		return err
 	}
@@ -388,7 +388,7 @@ func (ao *onlineAccounts) prepareCommit(dcc *deferredCommitContext) error {
 	dcc.onlineRoundParams = ao.onlineRoundParamsData[start+1 : end+1]
 
 	maxOnlineLookback := basics.Round(ao.maxBalLookback())
-	dcc.onlineAccountsForgetBefore = (dcc.newBase + 1).SubSaturate(maxOnlineLookback)
+	dcc.onlineAccountsForgetBefore = (dcc.newBase() + 1).SubSaturate(maxOnlineLookback)
 	if dcc.lowestRound > 0 && dcc.lowestRound < dcc.onlineAccountsForgetBefore {
 		// extend history as needed
 		dcc.onlineAccountsForgetBefore = dcc.lowestRound
@@ -440,7 +440,7 @@ func (ao *onlineAccounts) commitRound(ctx context.Context, tx *sql.Tx, dcc *defe
 
 func (ao *onlineAccounts) postCommit(ctx context.Context, dcc *deferredCommitContext) {
 	offset := dcc.offset
-	newBase := dcc.newBase
+	newBase := dcc.newBase()
 
 	ao.accountsMu.Lock()
 	// Drop reference counts to modified accounts, and evict them

--- a/ledger/acctonline_test.go
+++ b/ledger/acctonline_test.go
@@ -50,8 +50,6 @@ func commitSync(t *testing.T, oa *onlineAccounts, ml *mockLedgerForTracker, rnd 
 			ml.trackers.accountsWriting.Add(1)
 
 			// do not take any locks since all operations are synchronous
-			newBase := basics.Round(dcc.offset) + dcc.oldBase
-			dcc.newBase = newBase
 			err := ml.trackers.commitRound(dcc)
 			require.NoError(t, err)
 		}()
@@ -73,8 +71,7 @@ func commitSyncPartial(t *testing.T, oa *onlineAccounts, ml *mockLedgerForTracke
 			ml.trackers.accountsWriting.Add(1)
 
 			// do not take any locks since all operations are synchronous
-			newBase := basics.Round(dcc.offset) + dcc.oldBase
-			dcc.newBase = newBase
+			newBase := dcc.newBase()
 			dcc.flushTime = time.Now()
 
 			for _, lt := range ml.trackers.trackers {
@@ -102,7 +99,7 @@ func commitSyncPartial(t *testing.T, oa *onlineAccounts, ml *mockLedgerForTracke
 func commitSyncPartialComplete(t *testing.T, oa *onlineAccounts, ml *mockLedgerForTracker, dcc *deferredCommitContext) {
 	defer ml.trackers.accountsWriting.Done()
 
-	ml.trackers.dbRound = dcc.newBase
+	ml.trackers.dbRound = dcc.newBase()
 	for _, lt := range ml.trackers.trackers {
 		lt.postCommit(ml.trackers.ctx, dcc)
 	}

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1729,7 +1729,7 @@ func (au *accountUpdates) postCommit(ctx context.Context, dcc *deferredCommitCon
 
 	offset := dcc.offset
 	dbRound := dcc.oldBase
-	newBase := dcc.newBase
+	newBase := dcc.newBase()
 
 	dcc.updatingBalancesDuration = time.Since(dcc.flushTime)
 

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -2183,8 +2183,7 @@ func TestAcctUpdatesResources(t *testing.T) {
 				defer ml.trackers.accountsWriting.Done()
 
 				// do not take any locks since all operations are synchronous
-				newBase := basics.Round(dcc.offset) + dcc.oldBase
-				dcc.newBase = newBase
+				newBase := dcc.newBase()
 
 				err := au.prepareCommit(dcc)
 				require.NoError(t, err)
@@ -2467,8 +2466,7 @@ func auCommitSync(t *testing.T, rnd basics.Round, au *accountUpdates, ml *mockLe
 			defer ml.trackers.accountsWriting.Done()
 
 			// do not take any locks since all operations are synchronous
-			newBase := basics.Round(dcc.offset) + dcc.oldBase
-			dcc.newBase = newBase
+			newBase := dcc.newBase()
 
 			err := au.prepareCommit(dcc)
 			require.NoError(t, err)

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -518,7 +518,7 @@ func (ct *catchpointTracker) commitRound(ctx context.Context, tx *sql.Tx, dcc *d
 		dcc.stats.MerkleTrieUpdateDuration = time.Duration(time.Now().UnixNano())
 	}
 
-	err = ct.accountsUpdateBalances(dcc.compactAccountDeltas, dcc.compactResourcesDeltas, dcc.compactKvDeltas, dcc.oldBase, dcc.newBase)
+	err = ct.accountsUpdateBalances(dcc.compactAccountDeltas, dcc.compactResourcesDeltas, dcc.compactKvDeltas, dcc.oldBase, dcc.newBase())
 	if err != nil {
 		return err
 	}
@@ -867,11 +867,11 @@ func (ct *catchpointTracker) pruneFirstStageRecordsData(ctx context.Context, max
 
 func (ct *catchpointTracker) postCommitUnlocked(ctx context.Context, dcc *deferredCommitContext) {
 	if dcc.catchpointFirstStage {
-		err := ct.finishFirstStage(ctx, dcc.newBase, dcc.updatingBalancesDuration)
+		err := ct.finishFirstStage(ctx, dcc.newBase(), dcc.updatingBalancesDuration)
 		if err != nil {
 			ct.log.Warnf(
 				"error finishing catchpoint's first stage dcc.newBase: %d err: %v",
-				dcc.newBase, err)
+				dcc.newBase(), err)
 		}
 	}
 
@@ -885,13 +885,13 @@ func (ct *catchpointTracker) postCommitUnlocked(ctx context.Context, dcc *deferr
 	}
 
 	// Prune first stage catchpoint records from the database.
-	if uint64(dcc.newBase) >= dcc.catchpointLookback {
+	if uint64(dcc.newBase()) >= dcc.catchpointLookback {
 		err := ct.pruneFirstStageRecordsData(
-			ctx, dcc.newBase-basics.Round(dcc.catchpointLookback))
+			ctx, dcc.newBase()-basics.Round(dcc.catchpointLookback))
 		if err != nil {
 			ct.log.Warnf(
 				"error pruning first stage records and data dcc.newBase: %d err: %v",
-				dcc.newBase, err)
+				dcc.newBase(), err)
 		}
 	}
 }

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -233,7 +233,6 @@ type deferredCommitRange struct {
 type deferredCommitContext struct {
 	deferredCommitRange
 
-	newBase   basics.Round
 	flushTime time.Time
 
 	genesisProto config.ConsensusParams
@@ -271,6 +270,10 @@ type deferredCommitContext struct {
 
 	stats       telemetryspec.AccountsUpdateMetrics
 	updateStats bool
+}
+
+func (dcc deferredCommitContext) newBase() basics.Round {
+	return dcc.oldBase + basics.Round(dcc.offset)
 }
 
 var errMissingAccountUpdateTracker = errors.New("initializeTrackerCaches : called without a valid accounts update tracker")
@@ -495,7 +498,6 @@ func (tr *trackerRegistry) commitRound(dcc *deferredCommitContext) error {
 
 	dcc.offset = offset
 	dcc.oldBase = dbRound
-	dcc.newBase = newBase
 	dcc.flushTime = time.Now()
 
 	for _, lt := range tr.trackers {

--- a/ledger/txtail_test.go
+++ b/ledger/txtail_test.go
@@ -294,7 +294,6 @@ func TestTxTailDeltaTracking(t *testing.T) {
 						offset:               1,
 						catchpointFirstStage: true,
 					},
-					newBase: basics.Round(i),
 				}
 				err = txtail.prepareCommit(dcc)
 				require.NoError(t, err)
@@ -363,12 +362,11 @@ func BenchmarkTxTailBlockHeaderCache(b *testing.B) {
 					oldBase:  dbRound,
 					lookback: lookback,
 				},
-				newBase: dbRound + basics.Round(offset),
 			}
 			err := tail.prepareCommit(dcc)
 			require.NoError(b, err)
 			tail.postCommit(context.Background(), dcc)
-			dbRound = dcc.newBase
+			dbRound = dcc.newBase()
 			require.Less(b, len(tail.blockHeaderData), 1001+10)
 		}
 	}


### PR DESCRIPTION
## Summary

Based on observations from #4419 it seems like deferredCommitContext.newBase is always set to the value of oldBase + offset, and is only stored on the DCC struct for code deduplication / convenience reasons. To enforce the invariant that newBase is always oldBase+offset and guard against bugs if this were not true, this turns it into a function rather than an assigned struct field.

## Test Plan

Existing tests updated and should pass.