### PR TITLE
fix(gha): disable update-repo-description

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -52,18 +52,19 @@ jobs:
             URL=${{ github.server_url }}/${{ github.repository }}.git
             BRANCH=${{ github.ref_name }}
 
-  update-repo-description:
-    name: Update DockerHub Repository Description
-    runs-on: ubuntu-latest
-    if: github.ref == format('refs/heads/{0}', 'master')
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
+  # TODO: uncomment when https://github.com/docker/hub-tool/issues/172 is complete
+  # update-repo-description:
+  #   name: Update DockerHub Repository Description
+  #   runs-on: ubuntu-latest
+  #   if: github.ref == format('refs/heads/{0}', 'master')
+  #   steps:
+  #     - name: Checkout Code
+  #       uses: actions/checkout@v3
 
-      - name: Update DockerHub Repository Description
-        uses: peter-evans/dockerhub-description@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ github.repository_owner }}/algod
-          readme-filepath: ./docker/README.md
+  #     - name: Update DockerHub Repository Description
+  #       uses: peter-evans/dockerhub-description@v3
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
+  #         repository: ${{ github.repository_owner }}/algod
+  #         readme-filepath: ./docker/README.md


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

disables `update-repo-description` job until DockerHub supports tokens for API auth. 
