### PR TITLE
ledger: eternalData trackers concept

### DIFF
--- a/ledger/README.md
+++ b/ledger/README.md
@@ -61,6 +61,10 @@ interface:
   for recent blocks, if the tracker's state depends only on recent blocks
   (e.g., for the tracker that keeps track of the recently committed
   transactions).
+  `loadFromDisk` is expected to reconstruct a tracker from scratch with one
+  exception: `eternalData` might be survive between `loadFromDisk` calls
+  without being loaded from disk that is especially actual for non-persisting
+  trackers.
 
 - `newBlock(rnd, delta)` tells the tracker about a new block added to
   the ledger.  `delta` describes the changes made by this block; this

--- a/ledger/README.md
+++ b/ledger/README.md
@@ -62,9 +62,9 @@ interface:
   (e.g., for the tracker that keeps track of the recently committed
   transactions).
   `loadFromDisk` is expected to reconstruct a tracker from scratch with one
-  exception: `eternalData` might be survive between `loadFromDisk` calls
-  without being loaded from disk that is especially actual for non-persisting
-  trackers.
+  exception: `eternalData` might survive between `loadFromDisk` calls
+  without being loaded from disk. This is especially useful for trackers
+  that don't rely on the tracker DB.
 
 - `newBlock(rnd, delta)` tells the tracker about a new block added to
   the ledger.  `delta` describes the changes made by this block; this

--- a/ledger/bulletin.go
+++ b/ledger/bulletin.go
@@ -49,15 +49,13 @@ func (notifier *notifier) notify() {
 // bulletin provides an easy way to wait on a round to be written to the ledger.
 // To use it, call <-Wait(round)
 type bulletin struct {
-	mu                          deadlock.Mutex
-	pendingNotificationRequests map[basics.Round]notifier
-	latestRound                 basics.Round
-}
+	mu          deadlock.Mutex
+	latestRound basics.Round
 
-func makeBulletin() *bulletin {
-	b := new(bulletin)
-	b.pendingNotificationRequests = make(map[basics.Round]notifier)
-	return b
+	// eternalData survive tracker reloads
+	eternalData struct {
+		pendingNotificationRequests map[basics.Round]notifier
+	}
 }
 
 // Wait returns a channel which gets closed when the ledger reaches a given round.
@@ -72,18 +70,18 @@ func (b *bulletin) Wait(round basics.Round) chan struct{} {
 		return closed
 	}
 
-	signal, exists := b.pendingNotificationRequests[round]
+	signal, exists := b.eternalData.pendingNotificationRequests[round]
 	if !exists {
 		signal = makeNotifier()
-		b.pendingNotificationRequests[round] = signal
+		b.eternalData.pendingNotificationRequests[round] = signal
 	}
 	return signal.signal
 }
 
 func (b *bulletin) loadFromDisk(l ledgerForTracker, _ basics.Round) error {
 	// We want to keep existing notification requests in memory if this flow is triggered by reloadLedger.
-	if b.pendingNotificationRequests == nil {
-		b.pendingNotificationRequests = make(map[basics.Round]notifier)
+	if b.eternalData.pendingNotificationRequests == nil {
+		b.eternalData.pendingNotificationRequests = make(map[basics.Round]notifier)
 	}
 	b.latestRound = l.Latest()
 	return nil
@@ -99,12 +97,12 @@ func (b *bulletin) committedUpTo(rnd basics.Round) (retRound, lookback basics.Ro
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	for pending, signal := range b.pendingNotificationRequests {
+	for pending, signal := range b.eternalData.pendingNotificationRequests {
 		if pending > rnd {
 			continue
 		}
 
-		delete(b.pendingNotificationRequests, pending)
+		delete(b.eternalData.pendingNotificationRequests, pending)
 		signal.notify()
 	}
 

--- a/ledger/bulletin.go
+++ b/ledger/bulletin.go
@@ -52,7 +52,7 @@ type bulletin struct {
 	mu          deadlock.Mutex
 	latestRound basics.Round
 
-	// eternalData survive tracker reloads
+	// eternalData survives tracker reloads
 	eternalData struct {
 		pendingNotificationRequests map[basics.Round]notifier
 	}

--- a/ledger/bulletin_test.go
+++ b/ledger/bulletin_test.go
@@ -20,10 +20,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
 const epsilon = 5 * time.Millisecond
+
+func makeBulletin() *bulletin {
+	b := new(bulletin)
+	b.eternalData.pendingNotificationRequests = make(map[basics.Round]notifier)
+	return b
+}
 
 func TestBulletin(t *testing.T) {
 	partitiontest.PartitionTest(t)

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -404,10 +404,10 @@ func (l *Ledger) RegisterBlockListeners(listeners []ledgercore.BlockListener) {
 
 // RegisterVotersCommitListener registers a listener that will be called when a
 // commit is about to cover a round.
-func (l *Ledger) RegisterVotersCommitListener(listener ledgercore.VotersCommitListener) {
+func (l *Ledger) RegisterVotersCommitListener(listener ledgercore.VotersCommitListener) error {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()
-	l.acctsOnline.voters.registerPrepareCommitListener(listener)
+	return l.acctsOnline.voters.registerPrepareCommitListener(listener)
 }
 
 // notifyCommit informs the trackers that all blocks up to r have been

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -3093,13 +3093,13 @@ func TestVotersCallbackPersistsAfterLedgerReload(t *testing.T) {
 
 	commitListener := mockCommitListener{}
 	l.RegisterVotersCommitListener(&commitListener)
-	listenerBeforeReload := l.acctsOnline.voters.commitListener
+	listenerBeforeReload := l.acctsOnline.voters.eternalData.commitListener
 
 	require.NotNil(t, listenerBeforeReload)
 	err = l.reloadLedger()
 	require.NoError(t, err)
 
-	listenerAfterReload := l.acctsOnline.voters.commitListener
+	listenerAfterReload := l.acctsOnline.voters.eternalData.commitListener
 	require.Equal(t, listenerBeforeReload, listenerAfterReload)
 }
 

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -67,6 +67,10 @@ type ledgerTracker interface {
 	// ledger internals so that individual trackers can be tested
 	// in isolation. The provided round number represents the
 	// current accounts storage round number.
+	// loadFromDisk is expected to reconstruct a tracker from scratch with one
+	// exception: `eternalData` might survive between loadFromDisk calls
+	// without being loaded from disk. This is especially useful for trackers
+	// that don't rely on the tracker DB.
 	loadFromDisk(ledgerForTracker, basics.Round) error
 
 	// newBlock informs the tracker of a new block along with

--- a/stateproof/abstractions.go
+++ b/stateproof/abstractions.go
@@ -18,6 +18,7 @@ package stateproof
 
 import (
 	"context"
+
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/account"
 	"github.com/algorand/go-algorand/data/basics"
@@ -41,7 +42,7 @@ type Ledger interface {
 	GenesisHash() crypto.Digest
 	BlockHdr(basics.Round) (bookkeeping.BlockHeader, error)
 	VotersForStateProof(basics.Round) (*ledgercore.VotersForRound, error)
-	RegisterVotersCommitListener(listener ledgercore.VotersCommitListener)
+	RegisterVotersCommitListener(listener ledgercore.VotersCommitListener) error
 }
 
 // Network captures the aspects of the gossip network protocol that are

--- a/stateproof/builder.go
+++ b/stateproof/builder.go
@@ -242,7 +242,10 @@ func (spw *Worker) initBuilders() {
 		spw.builders[rnd] = buildr
 	}
 
-	spw.ledger.RegisterVotersCommitListener(spw)
+	err = spw.ledger.RegisterVotersCommitListener(spw)
+	if err != nil {
+		spw.log.Errorf("initBuilders: registering voters listener failed: %v", err)
+	}
 }
 
 func (spw *Worker) getAllOnlineBuilderRounds() ([]basics.Round, error) {

--- a/stateproof/stateproofMessageGenerator_test.go
+++ b/stateproof/stateproofMessageGenerator_test.go
@@ -118,8 +118,8 @@ func (s *workerForStateProofMessageTests) VotersForStateProof(round basics.Round
 	return voters, nil
 }
 
-func (s *workerForStateProofMessageTests) RegisterVotersCommitListener(listener ledgercore.VotersCommitListener) {
-	s.w.RegisterVotersCommitListener(listener)
+func (s *workerForStateProofMessageTests) RegisterVotersCommitListener(listener ledgercore.VotersCommitListener) error {
+	return s.w.RegisterVotersCommitListener(listener)
 }
 
 func (s *workerForStateProofMessageTests) Broadcast(ctx context.Context, tag protocol.Tag, bytes []byte, b bool, peer network.Peer) error {

--- a/stateproof/worker_test.go
+++ b/stateproof/worker_test.go
@@ -231,10 +231,11 @@ func (s *testWorkerStubs) BlockHdr(r basics.Round) (bookkeeping.BlockHeader, err
 
 var errEmptyVoters = errors.New("ledger does not have voters")
 
-func (s *testWorkerStubs) RegisterVotersCommitListener(listener ledgercore.VotersCommitListener) {
+func (s *testWorkerStubs) RegisterVotersCommitListener(listener ledgercore.VotersCommitListener) error {
 	s.listenerMu.Lock()
 	defer s.listenerMu.Unlock()
 	s.commitListener = listener
+	return nil
 }
 
 func (s *testWorkerStubs) VotersForStateProof(r basics.Round) (*ledgercore.VotersForRound, error) {


### PR DESCRIPTION
## Summary

Current `loadFromDisk` expectation it reconstructs a brand new tracker. `bulletin` and `voters` break this by allowing some state remain between reloads.
This PR documents this behavior and adds `eternalData` concept.

## Test Plan

Existing tests