### PR TITLE
goal: fix for goal node status crash - no longer getting block

### DIFF
--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -772,12 +772,6 @@ func (v2 *Handlers) GetStatus(ctx echo.Context) error {
 		return internalError(ctx, err, errFailedRetrievingNodeStatus, v2.Log)
 	}
 
-	ledger := v2.Node.LedgerForAPI()
-	latestBlkHdr, err := ledger.BlockHdr(ledger.Latest())
-	if err != nil {
-		return internalError(ctx, err, errFailedRetrievingLatestBlockHeaderStatus, v2.Log)
-	}
-
 	response := model.NodeStatusResponse{
 		LastRound:                   uint64(stat.LastRound),
 		LastVersion:                 string(stat.LastVersion),
@@ -813,7 +807,7 @@ func (v2 *Handlers) GetStatus(ctx echo.Context) error {
 		votesNo := votes - votesYes
 		upgradeDelay := uint64(stat.UpgradeDelay)
 		response.UpgradeVotesRequired = &upgradeThreshold
-		response.UpgradeNodeVote = &latestBlkHdr.UpgradeApprove
+		response.UpgradeNodeVote = &stat.UpgradeApprove
 		response.UpgradeDelay = &upgradeDelay
 		response.UpgradeVotes = &votes
 		response.UpgradeYesVotes = &votesYes


### PR DESCRIPTION
## Summary

Avoid extra call to `ledger.BlockHdr`. It is unnecessary and seemed to lead to a crash in some edge cases.
