### PR TITLE
logging: add TestingLogWithFilter to filter in-mem db locked warnings

### DIFF
--- a/ledger/acctonline_test.go
+++ b/ledger/acctonline_test.go
@@ -1406,7 +1406,9 @@ func TestAcctOnlineTop(t *testing.T) {
 	genesisAccts[0][allAccts[i].Addr] = allAccts[i].AccountData
 	addSinkAndPoolAccounts(genesisAccts)
 
-	ml := makeMockLedgerForTracker(t, true, 1, protocol.ConsensusCurrentVersion, genesisAccts)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
+	proto := protocol.ConsensusCurrentVersion
+	ml := makeMockLedgerForTrackerWithLogger(t, true, 1, proto, genesisAccts, log)
 	defer ml.Close()
 
 	conf := config.GetDefaultLocal()

--- a/ledger/acctonline_test.go
+++ b/ledger/acctonline_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/ledger/store"
 	ledgertesting "github.com/algorand/go-algorand/ledger/testing"
+	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/stretchr/testify/require"
@@ -1253,7 +1254,9 @@ func TestAcctOnlineVotersLongerHistory(t *testing.T) {
 		delete(config.Consensus, testProtocolVersion)
 	}()
 
-	ml := makeMockLedgerForTracker(t, true, 1, testProtocolVersion, genesisAccts)
+	log := logging.TestingLogWithFilter(t, []logging.Filter{{Msg: "database table is locked"}})
+	log.SetLevel(logging.Warn)
+	ml := makeMockLedgerForTrackerWithLogger(t, true, 1, testProtocolVersion, genesisAccts, log)
 	defer ml.Close()
 	conf := config.GetDefaultLocal()
 

--- a/ledger/acctonline_test.go
+++ b/ledger/acctonline_test.go
@@ -1254,7 +1254,7 @@ func TestAcctOnlineVotersLongerHistory(t *testing.T) {
 		delete(config.Consensus, testProtocolVersion)
 	}()
 
-	log := logging.TestingLogWithFilter(t, []logging.Filter{{Msg: "database table is locked"}})
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	log.SetLevel(logging.Warn)
 	ml := makeMockLedgerForTrackerWithLogger(t, true, 1, testProtocolVersion, genesisAccts, log)
 	defer ml.Close()

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -2532,7 +2532,8 @@ func TestAcctUpdatesLookupLatestCacheRetry(t *testing.T) {
 	testProtocolVersion := protocol.ConsensusCurrentVersion
 	protoParams := config.Consensus[testProtocolVersion]
 
-	ml := makeMockLedgerForTracker(t, true, 1, testProtocolVersion, accts)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
+	ml := makeMockLedgerForTrackerWithLogger(t, true, 1, testProtocolVersion, accts, log)
 	defer ml.Close()
 
 	conf := config.GetDefaultLocal()

--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -176,7 +176,8 @@ return`
 	}
 
 	cfg := config.GetDefaultLocal()
-	l, err := OpenLedger(logging.Base(), "TestAppAccountData", true, genesisInitState, cfg)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
+	l, err := OpenLedger(log, "TestAppAccountData", true, genesisInitState, cfg)
 	a.NoError(err)
 	defer l.Close()
 
@@ -402,7 +403,9 @@ return`
 	a.Contains(genesisInitState.Accounts, userLocal)
 
 	cfg := config.GetDefaultLocal()
-	l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
+	log.SetLevel(logging.Info)
+	l, err := OpenLedger(log, t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
 	defer l.Close()
 
@@ -645,7 +648,9 @@ return`
 	a.Contains(genesisInitState.Accounts, userLocal)
 
 	cfg := config.GetDefaultLocal()
-	l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
+	log.SetLevel(logging.Info)
+	l, err := OpenLedger(log, t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
 	defer l.Close()
 
@@ -799,7 +804,9 @@ return`
 	a.Contains(genesisInitState.Accounts, userLocal)
 
 	cfg := config.GetDefaultLocal()
-	l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
+	log.SetLevel(logging.Info)
+	l, err := OpenLedger(log, t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
 	defer l.Close()
 
@@ -995,7 +1002,9 @@ func testAppAccountDeltaIndicesCompatibility(t *testing.T, source string, accoun
 	a.Contains(genesisInitState.Accounts, userLocal)
 
 	cfg := config.GetDefaultLocal()
-	l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
+	log.SetLevel(logging.Info)
+	l, err := OpenLedger(log, t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
 	defer l.Close()
 
@@ -1135,7 +1144,9 @@ int 1
 			a.Contains(genesisInitState.Accounts, userLocal)
 
 			cfg := config.GetDefaultLocal()
-			l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+			log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
+			log.SetLevel(logging.Info)
+			l, err := OpenLedger(log, t.Name(), true, genesisInitState, cfg)
 			a.NoError(err)
 			defer l.Close()
 
@@ -1262,7 +1273,9 @@ int 1
 	a.Contains(genesisInitState.Accounts, funder)
 
 	cfg := config.GetDefaultLocal()
-	l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
+	log.SetLevel(logging.Info)
+	l, err := OpenLedger(log, t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
 	defer l.Close()
 
@@ -1343,7 +1356,9 @@ return
 
 	cfg := config.GetDefaultLocal()
 	cfg.MaxAcctLookback = 2
-	l1, err := OpenLedger(logging.Base(), dbPrefix, false, genesisInitState, cfg)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
+	log.SetLevel(logging.Info)
+	l1, err := OpenLedger(log, dbPrefix, false, genesisInitState, cfg)
 	a.NoError(err)
 	defer l1.Close()
 
@@ -1404,7 +1419,8 @@ return
 	// restart
 	l1.Close()
 
-	l2, err := OpenLedger(logging.Base(), dbPrefix, false, genesisInitState, cfg)
+	log = logging.TestingLog(t)
+	l2, err := OpenLedger(log, dbPrefix, false, genesisInitState, cfg)
 	a.NoError(err)
 	defer l2.Close()
 

--- a/ledger/apptxn_test.go
+++ b/ledger/apptxn_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/data/txntest"
 	ledgertesting "github.com/algorand/go-algorand/ledger/testing"
-	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
@@ -354,7 +353,7 @@ func TestClawbackAction(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	asaIndex := basics.AssetIndex(1)
@@ -440,7 +439,7 @@ func TestRekeyAction(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	appIndex := basics.AppIndex(1)
@@ -545,7 +544,7 @@ func TestRekeyActionCloseAccount(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	appIndex := basics.AppIndex(1)
@@ -621,7 +620,7 @@ func TestDuplicatePayAction(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	appIndex := basics.AppIndex(1)
@@ -697,7 +696,7 @@ func TestInnerTxnCount(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	create := txntest.Txn{
@@ -746,7 +745,7 @@ func TestAcfgAction(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	appIndex := basics.AppIndex(1)
@@ -923,7 +922,7 @@ func TestAsaDuringInit(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	appIndex := basics.AppIndex(2)
@@ -977,7 +976,7 @@ func TestRekey(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	app := txntest.Txn{
@@ -1029,7 +1028,7 @@ func TestNote(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	app := txntest.Txn{
@@ -1078,7 +1077,7 @@ func TestKeyreg(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	app := txntest.Txn{
@@ -1179,7 +1178,7 @@ func TestInnerAppCall(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	app0 := txntest.Txn{
@@ -1247,9 +1246,7 @@ func TestInnerAppManipulate(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	log := logging.TestingLogWithFilter(t, []logging.Filter{{Msg: "database table is locked"}})
-	log.SetLevel(logging.Warn)
-	l := newTestLedgerWithLogger(t, genBalances, log)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	calleeIndex := basics.AppIndex(1)
@@ -1522,7 +1519,7 @@ func TestIndirectReentry(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	app0 := txntest.Txn{
@@ -1587,7 +1584,7 @@ func TestValidAppReentry(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	app0 := txntest.Txn{
@@ -1777,7 +1774,7 @@ func TestAbortWhenInnerAppCallFails(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	app0 := txntest.Txn{
@@ -1971,7 +1968,7 @@ func TestAppVersionMatching(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	four, err := logic.AssembleStringWithVersion("int 1", 4)
@@ -2130,7 +2127,7 @@ func TestCreatedAppsAreAvailable(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	ops, err := logic.AssembleStringWithVersion("int 1\nint 1\nassert", logic.AssemblerMaxVersion)
@@ -2196,7 +2193,7 @@ func TestInvalidAppsNotAccessible(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	app0 := txntest.Txn{
@@ -2253,7 +2250,7 @@ func TestInvalidAssetsNotAccessible(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	createapp := txntest.Txn{
@@ -2413,7 +2410,7 @@ func TestInnerClearState(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	// inner will be an app that we opt into, then clearstate
@@ -2502,7 +2499,7 @@ func TestInnerClearStateBadCallee(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	// badCallee tries to run down your budget, so an inner clear must be
@@ -2604,7 +2601,7 @@ func TestInnerClearStateBadCaller(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	inner := txntest.Txn{
@@ -2839,7 +2836,7 @@ func TestGlobalChangesAcrossApps(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	appA := txntest.Txn{
@@ -2948,7 +2945,7 @@ func TestLocalChangesAcrossApps(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	l := newTestFilteredLedger(t, genBalances)
 	defer l.Close()
 
 	appA := txntest.Txn{

--- a/ledger/apptxn_test.go
+++ b/ledger/apptxn_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/data/txntest"
 	ledgertesting "github.com/algorand/go-algorand/ledger/testing"
+	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
@@ -1246,7 +1247,9 @@ func TestInnerAppManipulate(t *testing.T) {
 	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
-	l := newTestLedger(t, genBalances)
+	log := logging.TestingLogWithFilter(t, []logging.Filter{{Msg: "database table is locked"}})
+	log.SetLevel(logging.Warn)
+	l := newTestLedgerWithLogger(t, genBalances, log)
 	defer l.Close()
 
 	calleeIndex := basics.AppIndex(1)

--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -199,7 +199,9 @@ func TestArchivalRestart(t *testing.T) {
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
 
-	l, err := OpenLedger(logging.Base(), dbPrefix, inMem, genesisInitState, cfg)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
+	log.SetLevel(logging.Info)
+	l, err := OpenLedger(log, dbPrefix, inMem, genesisInitState, cfg)
 	require.NoError(t, err)
 	blk := genesisInitState.Block
 
@@ -225,7 +227,8 @@ func TestArchivalRestart(t *testing.T) {
 	require.Equal(t, basics.Round(0), earliest)
 	// close and reopen the same DB, ensure latest/earliest are not changed
 	l.Close()
-	l, err = OpenLedger(logging.Base(), dbPrefix, inMem, genesisInitState, cfg)
+	log = logging.TestingLog(t)
+	l, err = OpenLedger(log, dbPrefix, inMem, genesisInitState, cfg)
 	require.NoError(t, err)
 	defer l.Close()
 
@@ -370,7 +373,9 @@ func TestArchivalCreatables(t *testing.T) {
 	const inMem = false // use persistent storage
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	l, err := OpenLedger(logging.Base(), dbPrefix, inMem, genesisInitState, cfg)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
+	log.SetLevel(logging.Info)
+	l, err := OpenLedger(log, dbPrefix, inMem, genesisInitState, cfg)
 	require.NoError(t, err)
 	blk := genesisInitState.Block
 
@@ -475,7 +480,9 @@ func TestArchivalCreatables(t *testing.T) {
 
 	// close and reopen the same DB
 	l.Close()
-	l, err = OpenLedger(logging.Base(), dbPrefix, inMem, genesisInitState, cfg)
+	log = logging.TestingLog(t)
+	log.SetLevel(logging.Info)
+	l, err = OpenLedger(log, dbPrefix, inMem, genesisInitState, cfg)
 	require.NoError(t, err)
 
 	// check that we can fetch creator for all created assets and can't for
@@ -618,7 +625,8 @@ func TestArchivalCreatables(t *testing.T) {
 
 	// close and reopen the same DB
 	l.Close()
-	l, err = OpenLedger(logging.Base(), dbPrefix, inMem, genesisInitState, cfg)
+	log = logging.TestingLog(t)
+	l, err = OpenLedger(log, dbPrefix, inMem, genesisInitState, cfg)
 	require.NoError(t, err)
 	defer l.Close()
 

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -1482,11 +1482,14 @@ func TestCatchpointFastUpdates(t *testing.T) {
 	addSinkAndPoolAccounts(accts)
 	rewardsLevels := []uint64{0}
 
+	log := logging.TestingLog(t)
+	log.SetLevel(logging.Warn)
+
 	conf := config.GetDefaultLocal()
 	conf.CatchpointInterval = 1
 	conf.CatchpointTracking = 1
 	initialBlocksCount := int(conf.MaxAcctLookback)
-	ml := makeMockLedgerForTracker(t, true, initialBlocksCount, protocol.ConsensusCurrentVersion, accts)
+	ml := makeMockLedgerForTrackerWithLogger(t, true, initialBlocksCount, protocol.ConsensusCurrentVersion, accts, log)
 	defer ml.Close()
 
 	ct := newCatchpointTracker(t, ml, conf, ".")
@@ -1494,7 +1497,7 @@ func TestCatchpointFastUpdates(t *testing.T) {
 	ao := ml.trackers.acctsOnline
 
 	// Remove the txtail from the list of trackers since it causes a data race that
-	// wouldn't be observed under normal execution because commitedUpTo and newBlock
+	// wouldn't be observed under normal execution because committedUpTo and newBlock
 	// are protected by the tracker mutex.
 	trackers := make([]ledgerTracker, 0, len(ml.trackers.trackers))
 	for _, tracker := range ml.trackers.trackers {

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -528,7 +528,9 @@ func testNewLedgerFromCatchpoint(t *testing.T, catchpointWriterReadAccess store.
 	var initState ledgercore.InitState
 	initState.Block.CurrentProtocol = protocol.ConsensusCurrentVersion
 	conf := config.GetDefaultLocal()
-	l, err := OpenLedger(logging.TestingLog(t), t.Name()+"FromCatchpoint", true, initState, conf)
+	log := logging.TestingLogWithFilter(t, []logging.Filter{{Msg: "database table is locked"}})
+	log.SetLevel(logging.Warn)
+	l, err := OpenLedger(log, t.Name()+"FromCatchpoint", true, initState, conf)
 	require.NoError(t, err)
 	accessor := MakeCatchpointCatchupAccessor(l, l.log)
 

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -528,7 +528,7 @@ func testNewLedgerFromCatchpoint(t *testing.T, catchpointWriterReadAccess store.
 	var initState ledgercore.InitState
 	initState.Block.CurrentProtocol = protocol.ConsensusCurrentVersion
 	conf := config.GetDefaultLocal()
-	log := logging.TestingLogWithFilter(t, []logging.Filter{{Msg: "database table is locked"}})
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	log.SetLevel(logging.Warn)
 	l, err := OpenLedger(log, t.Name()+"FromCatchpoint", true, initState, conf)
 	require.NoError(t, err)

--- a/ledger/evalindexer_test.go
+++ b/ledger/evalindexer_test.go
@@ -312,7 +312,7 @@ func newTestLedger(t testing.TB, balances bookkeeping.GenesisBalances) *Ledger {
 }
 
 func newTestFilteredLedger(t testing.TB, balances bookkeeping.GenesisBalances) *Ledger {
-	log := logging.TestingLogWithFilter(t, []logging.Filter{{Msg: "database table is locked"}})
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	log.SetLevel(logging.Warn)
 	return newTestLedgerWithLogger(t, balances, log)
 }

--- a/ledger/evalindexer_test.go
+++ b/ledger/evalindexer_test.go
@@ -132,7 +132,8 @@ func TestEvalForIndexerCustomProtocolParams(t *testing.T) {
 	dbName := t.Name()
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	l, err := OpenLedger(logging.Base(), dbName, true, ledgercore.InitState{
+	log := logging.TestingLog(t)
+	l, err := OpenLedger(log, dbName, true, ledgercore.InitState{
 		Block:       block,
 		Accounts:    genesisBalances.Balances,
 		GenesisHash: genHash,
@@ -234,7 +235,8 @@ func TestEvalForIndexerForExpiredAccounts(t *testing.T) {
 	dbName := t.Name()
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	l, err := OpenLedger(logging.Base(), dbName, true, ledgercore.InitState{
+	log := logging.TestingLog(t)
+	l, err := OpenLedger(log, dbName, true, ledgercore.InitState{
 		Block:       block,
 		Accounts:    genesisBalances.Balances,
 		GenesisHash: genHash,

--- a/ledger/evalindexer_test.go
+++ b/ledger/evalindexer_test.go
@@ -311,6 +311,12 @@ func newTestLedger(t testing.TB, balances bookkeeping.GenesisBalances) *Ledger {
 	return newTestLedgerWithLogger(t, balances, log)
 }
 
+func newTestFilteredLedger(t testing.TB, balances bookkeeping.GenesisBalances) *Ledger {
+	log := logging.TestingLogWithFilter(t, []logging.Filter{{Msg: "database table is locked"}})
+	log.SetLevel(logging.Warn)
+	return newTestLedgerWithLogger(t, balances, log)
+}
+
 // Test that preloading data in cow base works as expected.
 func TestResourceCaching(t *testing.T) {
 	partitiontest.PartitionTest(t)
@@ -332,7 +338,7 @@ func TestResourceCaching(t *testing.T) {
 		RewardsPool: testPoolAddr,
 		Timestamp:   0,
 	}
-	l := newTestLedger(t, genesisBalances)
+	l := newTestFilteredLedger(t, genesisBalances)
 	defer l.Close()
 
 	genesisBlockHeader, err := l.BlockHdr(basics.Round(0))

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -1037,6 +1037,7 @@ func testLedgerSingleTxApplyData(t *testing.T, version protocol.ConsensusVersion
 	genesisInitState, initSecrets := ledgertesting.GenerateInitState(t, version, 100)
 	const inMem = true
 	log := logging.TestingLog(t)
+	log.SetLevel(logging.Warn)
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
 	l, err := OpenLedger(log, t.Name(), inMem, genesisInitState, cfg)
@@ -1737,7 +1738,7 @@ func TestLedgerKeepsOldBlocksForStateProof(t *testing.T) {
 	}
 	genesisInitState.Accounts = accountsWithValid
 
-	const inMem = true
+	const inMem = false
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = false
 	log := logging.TestingLog(t)
@@ -2998,7 +2999,7 @@ func TestVotersReloadFromDiskPassRecoveryPeriod(t *testing.T) {
 	dbName := fmt.Sprintf("%s.%d", t.Name(), crypto.RandUint64())
 	genesisInitState := getInitState()
 	genesisInitState.Block.CurrentProtocol = protocol.ConsensusCurrentVersion
-	const inMem = true
+	const inMem = false
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = false
 	cfg.MaxAcctLookback = proto.StateProofInterval - proto.StateProofVotersLookback - 10

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -219,7 +219,8 @@ func TestLedgerBlockHeaders(t *testing.T) {
 	const inMem = true
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	l, err := OpenLedger(logging.Base(), t.Name(), inMem, genesisInitState, cfg)
+	log := logging.TestingLog(t)
+	l, err := OpenLedger(log, t.Name(), inMem, genesisInitState, cfg)
 	a.NoError(err, "could not open ledger")
 	defer l.Close()
 
@@ -363,7 +364,7 @@ func TestLedgerSingleTx(t *testing.T) {
 	// The genesis for mainnet is at V17
 	genesisInitState, initSecrets := ledgertesting.GenerateInitState(t, protocol.ConsensusV15, 100)
 	const inMem = true
-	log := logging.TestingLog(t)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
 	l, err := OpenLedger(log, t.Name(), inMem, genesisInitState, cfg)
@@ -566,7 +567,7 @@ func TestLedgerSingleTxV24(t *testing.T) {
 	protoName := protocol.ConsensusV24
 	genesisInitState, initSecrets := ledgertesting.GenerateInitState(t, protoName, 100)
 	const inMem = true
-	log := logging.TestingLog(t)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
 	l, err := OpenLedger(log, t.Name(), inMem, genesisInitState, cfg)
@@ -741,7 +742,7 @@ func TestLedgerAppCrossRoundWrites(t *testing.T) {
 	protoName := protocol.ConsensusV24
 	genesisInitState, initSecrets := ledgertesting.GenerateInitState(t, protoName, 100)
 	const inMem = true
-	log := logging.TestingLog(t)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
 	l, err := OpenLedger(log, t.Name(), inMem, genesisInitState, cfg)
@@ -875,7 +876,7 @@ func TestLedgerAppMultiTxnWrites(t *testing.T) {
 	protoName := protocol.ConsensusV24
 	genesisInitState, initSecrets := ledgertesting.GenerateInitState(t, protoName, 100)
 	const inMem = true
-	log := logging.TestingLog(t)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
 	l, err := OpenLedger(log, t.Name(), inMem, genesisInitState, cfg)
@@ -1036,7 +1037,7 @@ func testLedgerSingleTxApplyData(t *testing.T, version protocol.ConsensusVersion
 
 	genesisInitState, initSecrets := ledgertesting.GenerateInitState(t, version, 100)
 	const inMem = true
-	log := logging.TestingLog(t)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	log.SetLevel(logging.Warn)
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
@@ -1326,7 +1327,7 @@ func testLedgerRegressionFaultyLeaseFirstValidCheck2f3880f7(t *testing.T, versio
 	const inMem = true
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	log := logging.TestingLog(t)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	l, err := OpenLedger(log, t.Name(), inMem, genesisInitState, cfg)
 	a.NoError(err, "could not open ledger")
 	defer l.Close()
@@ -1390,7 +1391,7 @@ func TestLedgerBlockHdrCaching(t *testing.T) {
 	const inMem = true
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	log := logging.TestingLog(t)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	log.SetLevel(logging.Info)
 	l, err := OpenLedger(log, dbName, inMem, genesisInitState, cfg)
 	a.NoError(err)
@@ -1512,7 +1513,7 @@ func TestLedgerReload(t *testing.T) {
 	const inMem = true
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	log := logging.TestingLog(t)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	log.SetLevel(logging.Info)
 	l, err := OpenLedger(log, dbName, inMem, genesisInitState, cfg)
 	require.NoError(t, err)
@@ -1656,7 +1657,7 @@ func TestListAssetsAndApplications(t *testing.T) {
 	//initLedger
 	genesisInitState, _ := ledgertesting.GenerateInitState(t, protocol.ConsensusCurrentVersion, 100)
 	const inMem = true
-	log := logging.TestingLog(t)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
 	ledger, err := OpenLedger(log, t.Name(), inMem, genesisInitState, cfg)
@@ -2702,7 +2703,7 @@ func TestLedgerTxTailCachedBlockHeaders(t *testing.T) {
 	genesisInitState, _ := ledgertesting.GenerateInitState(t, protocol.ConsensusFuture, 10_000_000_000)
 	const inMem = true
 	cfg := config.GetDefaultLocal()
-	log := logging.TestingLog(t)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	log.SetLevel(logging.Info) // prevent spamming with ledger.AddValidatedBlock debug message
 	l, err := OpenLedger(log, t.Name(), inMem, genesisInitState, cfg)
 	require.NoError(t, err)
@@ -2895,7 +2896,7 @@ func TestVotersReloadFromDisk(t *testing.T) {
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = false
 	cfg.MaxAcctLookback = proto.StateProofInterval - proto.StateProofVotersLookback - 10
-	log := logging.TestingLog(t)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	log.SetLevel(logging.Info)
 	l, err := OpenLedger(log, dbName, inMem, genesisInitState, cfg)
 	require.NoError(t, err)
@@ -2943,7 +2944,7 @@ func TestVotersReloadFromDiskAfterOneStateProofCommitted(t *testing.T) {
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = false
 	cfg.MaxAcctLookback = proto.StateProofInterval - proto.StateProofVotersLookback - 10
-	log := logging.TestingLog(t)
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	log.SetLevel(logging.Info)
 	l, err := OpenLedger(log, dbName, inMem, genesisInitState, cfg)
 	require.NoError(t, err)

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -1738,10 +1738,10 @@ func TestLedgerKeepsOldBlocksForStateProof(t *testing.T) {
 	}
 	genesisInitState.Accounts = accountsWithValid
 
-	const inMem = false
+	const inMem = true
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = false
-	log := logging.TestingLog(t)
+	log := logging.TestingLogWithFilter(t, []logging.Filter{{Msg: "database table is locked"}})
 	log.SetLevel(logging.Info)
 	l, err := OpenLedger(log, dbName, inMem, genesisInitState, cfg)
 	require.NoError(t, err)
@@ -2999,11 +2999,11 @@ func TestVotersReloadFromDiskPassRecoveryPeriod(t *testing.T) {
 	dbName := fmt.Sprintf("%s.%d", t.Name(), crypto.RandUint64())
 	genesisInitState := getInitState()
 	genesisInitState.Block.CurrentProtocol = protocol.ConsensusCurrentVersion
-	const inMem = false
+	const inMem = true
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = false
 	cfg.MaxAcctLookback = proto.StateProofInterval - proto.StateProofVotersLookback - 10
-	log := logging.TestingLog(t)
+	log := logging.TestingLogWithFilter(t, []logging.Filter{{Msg: "database table is locked"}})
 	log.SetLevel(logging.Info)
 	l, err := OpenLedger(log, dbName, inMem, genesisInitState, cfg)
 	require.NoError(t, err)

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -1741,7 +1741,7 @@ func TestLedgerKeepsOldBlocksForStateProof(t *testing.T) {
 	const inMem = true
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = false
-	log := logging.TestingLogWithFilter(t, []logging.Filter{{Msg: "database table is locked"}})
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	log.SetLevel(logging.Info)
 	l, err := OpenLedger(log, dbName, inMem, genesisInitState, cfg)
 	require.NoError(t, err)
@@ -3003,7 +3003,7 @@ func TestVotersReloadFromDiskPassRecoveryPeriod(t *testing.T) {
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = false
 	cfg.MaxAcctLookback = proto.StateProofInterval - proto.StateProofVotersLookback - 10
-	log := logging.TestingLogWithFilter(t, []logging.Filter{{Msg: "database table is locked"}})
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	log.SetLevel(logging.Info)
 	l, err := OpenLedger(log, dbName, inMem, genesisInitState, cfg)
 	require.NoError(t, err)

--- a/ledger/simple_test.go
+++ b/ledger/simple_test.go
@@ -49,7 +49,7 @@ func newSimpleLedgerFull(t testing.TB, balances bookkeeping.GenesisBalances, cv 
 	dbName := fmt.Sprintf("%s.%d", t.Name(), crypto.RandUint64())
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	log := logging.TestingLogWithFilter(t, []logging.Filter{{Msg: "database table is locked"}})
+	log := logging.TestingLogWithFilter(t, logging.DBLockedFilter)
 	log.SetLevel(logging.Warn)
 	l, err := OpenLedger(log, dbName, true, ledgercore.InitState{
 		Block:       genBlock,

--- a/ledger/simple_test.go
+++ b/ledger/simple_test.go
@@ -35,10 +35,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newSimpleLedger(t testing.TB, balances bookkeeping.GenesisBalances) *Ledger {
-	return newSimpleLedgerWithConsensusVersion(t, balances, protocol.ConsensusFuture)
-}
-
 func newSimpleLedgerWithConsensusVersion(t testing.TB, balances bookkeeping.GenesisBalances, cv protocol.ConsensusVersion) *Ledger {
 	var genHash crypto.Digest
 	crypto.RandBytes(genHash[:])
@@ -53,7 +49,9 @@ func newSimpleLedgerFull(t testing.TB, balances bookkeeping.GenesisBalances, cv 
 	dbName := fmt.Sprintf("%s.%d", t.Name(), crypto.RandUint64())
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	l, err := OpenLedger(logging.Base(), dbName, true, ledgercore.InitState{
+	log := logging.TestingLogWithFilter(t, []logging.Filter{{Msg: "database table is locked"}})
+	log.SetLevel(logging.Warn)
+	l, err := OpenLedger(log, dbName, true, ledgercore.InitState{
 		Block:       genBlock,
 		Accounts:    balances.Balances,
 		GenesisHash: genHash,

--- a/logging/testingLogger.go
+++ b/logging/testingLogger.go
@@ -25,8 +25,12 @@ import (
 // Being an io.Writer lets us pass it to Logger.SetOutput() in testing code -- this way if we want we can use Go's built-in testing log instead of making a new base.log file for each test.
 // As a bonus, the detailed logs produced in a Travis test are now easily accessible and are printed if and only if that particular test fails.
 type TestLogWriter struct {
-	testing.TB
+	logWriter
 	filters []Filter
+}
+
+type logWriter interface {
+	Log(args ...interface{})
 }
 
 func (tb TestLogWriter) Write(p []byte) (n int, err error) {
@@ -59,10 +63,10 @@ func TestingLog(tb testing.TB) Logger {
 }
 
 // TestingLogWithFilter is a test-only convenience function to configure logging for testing with filtering
-func TestingLogWithFilter(tb testing.TB, filters []Filter) Logger {
+func TestingLogWithFilter(lw logWriter, filters []Filter) Logger {
 	l := NewLogger()
 	l.SetLevel(Debug)
-	writer := TestLogWriter{tb, filters}
+	writer := TestLogWriter{lw, filters}
 	l.SetOutput(writer)
 	return l
 }

--- a/logging/testingLogger.go
+++ b/logging/testingLogger.go
@@ -33,6 +33,8 @@ type logWriter interface {
 	Log(args ...interface{})
 }
 
+var DBLockedFilter = []Filter{{Msg: "database table is locked"}}
+
 func (tb TestLogWriter) Write(p []byte) (n int, err error) {
 	if len(p) == 0 {
 		return 0, nil

--- a/logging/testingLogger.go
+++ b/logging/testingLogger.go
@@ -33,6 +33,7 @@ type logWriter interface {
 	Log(args ...interface{})
 }
 
+// DBLockedFilter is filter for "database table is locked" message as the most common
 var DBLockedFilter = []Filter{{Msg: "database table is locked"}}
 
 func (tb TestLogWriter) Write(p []byte) (n int, err error) {

--- a/logging/testingLogger_test.go
+++ b/logging/testingLogger_test.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2019-2023 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package logging
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/test/partitiontest"
+)
+
+type bufWriter struct {
+	data string
+}
+
+func (bw *bufWriter) Log(args ...interface{}) {
+	bw.data += fmt.Sprintln(args...)
+}
+
+func TestTestingLogger(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	a := require.New(t)
+
+	var bw bufWriter
+	log := TestingLogWithFilter(&bw, DBLockedFilter)
+	log.Warn("db.LoggedRetry: 13 retries (last err: database table is locked: acctrounds)")
+	a.Empty(bw.data)
+
+	log.Warn("test data")
+	a.NotEmpty(bw.data)
+	a.Contains(bw.data, "level=warning msg=\"test data\"")
+}


### PR DESCRIPTION
## Summary

Running `go test ./ledger -v` produces lots of `database table is locked` warnings from double ledger and other tests.
Added `TestingLogWithFilter("database table is locked")` to filter it out from the output.
I also tried to switch double ledger to use disk DB but it makes these tests very long.

## Test Plan

This is test related code.