### PR TITLE
CI: don't run container GHA workflow on forks

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -11,6 +11,7 @@ jobs:
   build-and-push:
     name: Build and Push to DockerHub
     runs-on: ubuntu-latest
+    if: github.repository == 'algorand/go-algorand'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

I noticed [Github Actions errors](https://github.com/AlgoAxel/go-algorand/actions/runs/4088268996) coming from the "container" workflow when forks use branch names like feature/XXX, which unintentionally triggers this workflow. However it fails because the docker hub secrets are not available to forks.

## Test Plan

Existing tests should pass, and forks should not see this issue anymore.