### PR TITLE
tests: debug flaky expect test

### DIFF
--- a/test/e2e-go/cli/goal/expect/catchpointCatchupTest.exp
+++ b/test/e2e-go/cli/goal/expect/catchpointCatchupTest.exp
@@ -182,7 +182,7 @@ if { [catch {
     # once the node is started we can clear the ::GLOBAL_TEST_ALGO_DIR, so that shutdown would be done as a network.
     set ::GLOBAL_TEST_ALGO_DIR ""
 
-    ::AlgorandGoal::WaitForRound 38 $TEST_ROOT_DIR/Node
+    ::AlgorandGoal::WaitForRound $CATCHPOINT_ROUND $TEST_ROOT_DIR/Node
 
     ::AlgorandGoal::StopNode $TEST_ROOT_DIR/Node
 

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -52,11 +52,13 @@ proc ::AlgorandGoal::Abort { ERROR } {
         puts "GLOBAL_TEST_ROOT_DIR $::GLOBAL_TEST_ROOT_DIR"
         puts "GLOBAL_NETWORK_NAME $::GLOBAL_NETWORK_NAME"
 
-        # dump system and processes into to check memory consumption and if algod procs are still alive
+        # dump system and processes information to check memory consumption and if algod procs are still alive
         if { $tcl_platform(os) == "Darwin" } {
             exec top -l 1
-        } else {
+        } elseif { $tcl_platform(os) == "Linux" } {
             exec top -n 1
+        } else {
+            # no logging for other platforms
         }
 
         ::AlgorandGoal::StopNetwork $::GLOBAL_NETWORK_NAME $::GLOBAL_TEST_ROOT_DIR

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -52,6 +52,13 @@ proc ::AlgorandGoal::Abort { ERROR } {
         puts "GLOBAL_TEST_ROOT_DIR $::GLOBAL_TEST_ROOT_DIR"
         puts "GLOBAL_NETWORK_NAME $::GLOBAL_NETWORK_NAME"
 
+        # dump system and processes into to check memory consumption and if algod procs are still alive
+        if { $tcl_platform(os) == "Darwin" } {
+            exec top -l 1
+        } else {
+            exec top -n 1
+        }
+
         ::AlgorandGoal::StopNetwork $::GLOBAL_NETWORK_NAME $::GLOBAL_TEST_ROOT_DIR
 
         log_user 1
@@ -935,7 +942,7 @@ proc ::AlgorandGoal::StartCatchup { NODE_DATA_DIR CATCHPOINT } {
     return $CATCHPOINT
 }
 
-# Wait for node to get into catchup mode
+# Wait for node to get into fast catchup mode
 proc ::AlgorandGoal::WaitCatchup { TEST_PRIMARY_NODE_DIR WAIT_DURATION_SEC } {
     if { [catch {
         set i 0


### PR DESCRIPTION
## Summary

Catchpoint test exists like algod process was killed, so added `top` invocation to monitor algod processes presence as well as machine memory usage.
Additionally fixed a wrong hardcoded wait round number in this test - it would not cause a failure but still a small inconsistency. 

## Test Plan

This is test-related code