### PR TITLE
Specblockasm

### DIFF
--- a/agreement/demux.go
+++ b/agreement/demux.go
@@ -265,8 +265,6 @@ func (d *demux) next(s *Service, deadline time.Duration, fastDeadline time.Durat
 		speculationDeadlineCh = s.Clock.TimeoutAt(speculationDeadline)
 	}
 
-	//d.log.Infof("demux deadline %d, fastD %d, specD %d, d.monitor %v", deadline, fastDeadline, speculationDeadline, d.monitor) // not threadsafe in some tests
-
 	d.UpdateEventsQueue(eventQueueDemux, 0)
 	d.monitor.dec(demuxCoserviceType)
 

--- a/agreement/events.go
+++ b/agreement/events.go
@@ -122,6 +122,7 @@ const (
 	// period.
 	//
 	// fastTimeout is like timeout but for fast partition recovery.
+	//
 	// speculation timeout marks when the player should start speculative
 	// block assembly.
 	timeout
@@ -374,7 +375,7 @@ func (e roundInterruptionEvent) AttachConsensusVersion(v ConsensusVersionView) e
 }
 
 type timeoutEvent struct {
-	// {timeout,fastTimeout,speculationTimeout}
+	// T in {timeout,fastTimeout,speculationTimeout}
 	T eventType
 
 	RandomEntropy uint64

--- a/agreement/player.go
+++ b/agreement/player.go
@@ -130,7 +130,7 @@ func (p *player) handle(r routerHandle, e event) []action {
 	}
 }
 
-// handleSpeculationTimeout TODO: rename this 'timeout' is the START of speculative assembly.
+// handleSpeculationTimeout  is when to _start_ speculative assembly.
 func (p *player) handleSpeculationTimeout(r routerHandle, e timeoutEvent) []action {
 	if e.Proto.Err != nil {
 		r.t.log.Errorf("failed to read protocol version for speculationTimeout event (proto %v): %v", e.Proto.Version, e.Proto.Err)
@@ -178,7 +178,6 @@ func (p *player) issueSoftVote(r routerHandle) (actions []action) {
 		// If we arrive due to fast-forward/soft threshold; then answer.Bottom = false and answer.Proposal = bottom
 		// and we should soft-vote normally (not based on the starting value)
 		a.Proposal = nextStatus.Proposal
-		// TODO: how do we speculative block assemble based on nextStatus.Proposal?
 		return append(actions, a)
 	}
 
@@ -626,9 +625,10 @@ func (p *player) handleMessageEvent(r routerHandle, e messageEvent) (actions []a
 			actions = append(actions, a)
 		}
 
-		// StartSpeculativeBlockAssembly every time we validate a proposal
-		// TODO: maybe only do this if after speculation has started; interrupt speculation on a block when we get a better block
-		// TODO: maybe don't do this at all and just delete it?
+		// StartSpeculativeBlockAssembly when we validate a
+		// proposal, but only re-start when we're finding a
+		// better proposal than what we had when we started
+		// due to timer.
 		if ef.t() == payloadAccepted {
 			actions = p.startSpeculativeBlockAsm(r, actions, true)
 		}

--- a/logging/telemetryspec/metric.go
+++ b/logging/telemetryspec/metric.go
@@ -65,6 +65,7 @@ type AssembleBlockStats struct {
 	BlockGenerationDuration   uint64
 	TransactionsLoopStartTime int64
 	StateProofNextRound       uint64 // next round for which state proof if expected
+	Speculative               bool   // started as speculative block assembly
 	StateProofStats           StateProofStats
 }
 

--- a/rpcs/txService.go
+++ b/rpcs/txService.go
@@ -191,9 +191,10 @@ func (txs *TxService) updateTxCache() (pendingTxGroups [][]transactions.SignedTx
 
 	// we need to check again, since we released and took the lock.
 	if txs.lastUpdate == 0 || txs.lastUpdate+updateInterval < currentUnixTime {
-		// The txs.pool.PendingTxGroups() function allocates a new array on every call. That means that the old
-		// array ( if being used ) is still valid. There is no risk of data race here since
-		// the txs.pendingTxGroups is a slice (hence a pointer to the array) and not the array itself.
+		// This takes a reference to TransactionPool internal
+		// memory, but that is safe as long as
+		// TransactionPool.pendingTxGroups only gets append()
+		// or replaced.
 		txs.pendingTxGroups = txs.pool.PendingTxGroups()
 		txs.lastUpdate = currentUnixTime
 	}


### PR DESCRIPTION
## Summary

Speculative block can now continue to receive txns that arrive at outer context .Remember() after speculation has started.

Lots of misc cleanup.

## Test Plan

Cluster tests and existing unit and integration tests.

Probably could use a couple more new tests but it does have some around speculative block assembly.