### PR TITLE
updater.sh: Fail updater.sh on error

### DIFF
--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # shellcheck disable=2009,2093,2164
 
 UPDATER_MIN_VERSION="3.12.2"


### PR DESCRIPTION


## Summary

The script does not exist non-zero when supplied with an invalid directory. The following, for example, will exit 0 even though a normal user doesn't have permission on `/`.

```
./update.sh -i -c nightly -n -d ./ -p /go/bin
```

## Test Plan

Just manual testing--I'm working on integrating the updater script into Indexer's CI in order to install binaries for the e2e tests.
