### PR TITLE
Stop stateproof worker on catchpoint cathcup and restart when done.

### DIFF
--- a/ledger/bulletin.go
+++ b/ledger/bulletin.go
@@ -81,10 +81,7 @@ func (b *bulletin) Wait(round basics.Round) chan struct{} {
 }
 
 func (b *bulletin) loadFromDisk(l ledgerForTracker, _ basics.Round) error {
-	// We want to keep existing notification requests in memory if this flow is triggered by reloadLedger.
-	if b.pendingNotificationRequests == nil {
-		b.pendingNotificationRequests = make(map[basics.Round]notifier)
-	}
+	b.pendingNotificationRequests = make(map[basics.Round]notifier)
 	b.latestRound = l.Latest()
 	return nil
 }

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -410,6 +410,13 @@ func (l *Ledger) RegisterVotersCommitListener(listener ledgercore.VotersCommitLi
 	l.acctsOnline.voters.registerPrepareCommitListener(listener)
 }
 
+// UnregisterVotersCommitListener unregisters the commit listener.
+func (l *Ledger) UnregisterVotersCommitListener() {
+	l.trackerMu.RLock()
+	defer l.trackerMu.RUnlock()
+	l.acctsOnline.voters.unregisterPrepareCommitListener()
+}
+
 // notifyCommit informs the trackers that all blocks up to r have been
 // written to disk.  Returns the minimum block number that must be kept
 // in the database.

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -1541,36 +1541,6 @@ func TestLedgerReload(t *testing.T) {
 	}
 }
 
-func TestWaitLedgerReload(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	a := require.New(t)
-
-	dbName := fmt.Sprintf("%s.%d", t.Name(), crypto.RandUint64())
-	genesisInitState, _ := ledgertesting.GenerateInitState(t, protocol.ConsensusCurrentVersion, 100)
-	const inMem = true
-	cfg := config.GetDefaultLocal()
-	cfg.MaxAcctLookback = 0
-	log := logging.TestingLog(t)
-	log.SetLevel(logging.Info)
-	l, err := OpenLedger(log, dbName, inMem, genesisInitState, cfg)
-	require.NoError(t, err)
-	defer l.Close()
-
-	waitRound := l.Latest() + 1
-	waitChannel := l.Wait(waitRound)
-
-	err = l.reloadLedger()
-	a.NoError(err)
-	triggerTrackerFlush(t, l, genesisInitState)
-
-	select {
-	case <-waitChannel:
-		return
-	default:
-		a.Failf("", "Wait channel did not receive an expected signal for round %d", waitRound)
-	}
-}
-
 // TestGetLastCatchpointLabel tests ledger.GetLastCatchpointLabel is returning the correct value.
 func TestGetLastCatchpointLabel(t *testing.T) {
 	partitiontest.PartitionTest(t)

--- a/ledger/voters.go
+++ b/ledger/voters.go
@@ -313,7 +313,7 @@ func (vt *votersTracker) registerPrepareCommitListener(commitListener ledgercore
 	defer vt.commitListenerMu.Unlock()
 
 	if vt.commitListener != nil {
-		vt.l.trackerLog().Error("votersTracker.registerPrepareCommitListener: overriding existing listener! commitListener should have been nil'd on stateproof.Worker.Shutdown().")
+		vt.l.trackerLog().Error("votersTracker.registerPrepareCommitListener: overriding existing listener.")
 	}
 	vt.commitListener = commitListener
 }

--- a/ledger/voters.go
+++ b/ledger/voters.go
@@ -312,7 +312,21 @@ func (vt *votersTracker) registerPrepareCommitListener(commitListener ledgercore
 	vt.commitListenerMu.Lock()
 	defer vt.commitListenerMu.Unlock()
 
+	if vt.commitListener != nil {
+		vt.l.trackerLog().Error("votersTracker.registerPrepareCommitListener: overriding existing listener! commitListener should have been nil'd on stateproof.Worker.Shutdown().")
+	}
 	vt.commitListener = commitListener
+}
+
+func (vt *votersTracker) unregisterPrepareCommitListener() {
+	vt.commitListenerMu.Lock()
+	defer vt.commitListenerMu.Unlock()
+
+	if vt.commitListener == nil {
+		vt.l.trackerLog().Warn("votersTracker.unregisterPrepareCommitListener: no listener was registered.")
+	} else {
+		vt.commitListener = nil
+	}
 }
 
 func (vt *votersTracker) getVoters(round basics.Round) (*ledgercore.VotersForRound, bool) {

--- a/ledger/voters.go
+++ b/ledger/voters.go
@@ -322,11 +322,7 @@ func (vt *votersTracker) unregisterPrepareCommitListener() {
 	vt.commitListenerMu.Lock()
 	defer vt.commitListenerMu.Unlock()
 
-	if vt.commitListener == nil {
-		vt.l.trackerLog().Warn("votersTracker.unregisterPrepareCommitListener: no listener was registered.")
-	} else {
-		vt.commitListener = nil
-	}
+	vt.commitListener = nil
 }
 
 func (vt *votersTracker) getVoters(round basics.Round) (*ledgercore.VotersForRound, bool) {

--- a/node/node.go
+++ b/node/node.go
@@ -422,11 +422,10 @@ func (node *AlgorandFullNode) Stop() {
 	defer func() {
 		node.mu.Unlock()
 		node.waitMonitoringRoutines()
-		node.stateProofWorker.Stop()
-		node.stateProofWorker = nil
 	}()
 
 	node.net.ClearHandlers()
+	node.stateProofWorker.Stop()
 	if !node.config.DisableNetworking {
 		node.net.Stop()
 	}
@@ -1186,13 +1185,13 @@ func (node *AlgorandFullNode) SetCatchpointCatchupMode(catchpointCatchupMode boo
 				node.waitMonitoringRoutines()
 			}()
 			node.net.ClearHandlers()
+			node.stateProofWorker.Stop()
 			node.txHandler.Stop()
 			node.agreementService.Shutdown()
 			node.catchupService.Stop()
 			node.txPoolSyncerService.Stop()
 			node.blockService.Stop()
 			node.ledgerService.Stop()
-			node.stateProofWorker.Stop()
 
 			prevNodeCancelFunc := node.cancelCtx
 

--- a/node/node.go
+++ b/node/node.go
@@ -433,7 +433,7 @@ func (node *AlgorandFullNode) Stop() {
 	defer func() {
 		node.mu.Unlock()
 		node.waitMonitoringRoutines()
-		node.stateProofWorker.Shutdown()
+		node.stateProofWorker.Stop()
 		node.stateProofWorker = nil
 	}()
 
@@ -1203,7 +1203,7 @@ func (node *AlgorandFullNode) SetCatchpointCatchupMode(catchpointCatchupMode boo
 			node.txPoolSyncerService.Stop()
 			node.blockService.Stop()
 			node.ledgerService.Stop()
-			node.stateProofWorker.Shutdown()
+			node.stateProofWorker.Stop()
 
 			prevNodeCancelFunc := node.cancelCtx
 

--- a/node/node.go
+++ b/node/node.go
@@ -1203,8 +1203,7 @@ func (node *AlgorandFullNode) SetCatchpointCatchupMode(catchpointCatchupMode boo
 			node.txPoolSyncerService.Stop()
 			node.blockService.Stop()
 			node.ledgerService.Stop()
-			// As for now, the state proof services handles catchpoint mode
-			// so we don't need to stop it.
+			node.stateProofWorker.Shutdown()
 
 			prevNodeCancelFunc := node.cancelCtx
 
@@ -1224,6 +1223,7 @@ func (node *AlgorandFullNode) SetCatchpointCatchupMode(catchpointCatchupMode boo
 		node.blockService.Start()
 		node.ledgerService.Start()
 		node.txHandler.Start()
+		node.stateProofWorker.Start()
 
 		// start indexer
 		if idx, err := node.Indexer(); err == nil {

--- a/node/node.go
+++ b/node/node.go
@@ -330,18 +330,7 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 	node.tracer = messagetracer.NewTracer(log).Init(cfg)
 	gossip.SetTrace(agreementParameters.Network, node.tracer)
 
-	// Delete the deprecated database file if it exists. This can be removed in future updates since this file should not exist by then.
-	oldCompactCertPath := filepath.Join(genesisDir, "compactcert.sqlite")
-	os.Remove(oldCompactCertPath)
-
-	stateProofPathname := filepath.Join(genesisDir, config.StateProofFileName)
-	stateProofAccess, err := db.MakeAccessor(stateProofPathname, false, false)
-	if err != nil {
-		log.Errorf("Cannot load state proof data: %v", err)
-		return nil, err
-	}
-
-	node.stateProofWorker = stateproof.NewWorker(stateProofAccess, node.log, node.accountManager, node.ledger.Ledger, node.net, node)
+	node.stateProofWorker = stateproof.NewWorker(genesisDir, node.log, node.accountManager, node.ledger.Ledger, node.net, node)
 
 	return node, err
 }

--- a/stateproof/abstractions.go
+++ b/stateproof/abstractions.go
@@ -42,6 +42,7 @@ type Ledger interface {
 	BlockHdr(basics.Round) (bookkeeping.BlockHeader, error)
 	VotersForStateProof(basics.Round) (*ledgercore.VotersForRound, error)
 	RegisterVotersCommitListener(listener ledgercore.VotersCommitListener)
+	UnregisterVotersCommitListener()
 }
 
 // Network captures the aspects of the gossip network protocol that are

--- a/stateproof/builder.go
+++ b/stateproof/builder.go
@@ -211,6 +211,7 @@ func (spw *Worker) initBuilders() {
 	spw.mu.Lock()
 	defer spw.mu.Unlock()
 
+	spw.builders = make(map[basics.Round]builder)
 	rnds, err := spw.getAllOnlineBuilderRounds()
 	if err != nil {
 		spw.log.Errorf("initBuilders: failed to load rounds: %v", err)

--- a/stateproof/builder.go
+++ b/stateproof/builder.go
@@ -231,8 +231,6 @@ func (spw *Worker) initBuilders() {
 		}
 		spw.builders[rnd] = buildr
 	}
-
-	spw.ledger.RegisterVotersCommitListener(spw)
 }
 
 func (spw *Worker) getAllOnlineBuilderRounds() ([]basics.Round, error) {

--- a/stateproof/db.go
+++ b/stateproof/db.go
@@ -48,7 +48,6 @@ const (
 	createSigsIdx = `CREATE INDEX IF NOT EXISTS sigs_from_this_node ON sigs (from_this_node)`
 
 	// builders table stored a serialization of each BuilderForRound data, without the sigs (stored separately)
-	// This table is only used when the TODO flag is specified in startup (relay nodes only)
 	createBuildersTable = `CREATE TABLE IF NOT EXISTS builders (
     	round INTEGER PRIMARY KEY NOT NULL,
     	builder BLOB NOT NULL

--- a/stateproof/stateproofMessageGenerator_test.go
+++ b/stateproof/stateproofMessageGenerator_test.go
@@ -223,7 +223,7 @@ func TestStateProofMessage(t *testing.T) {
 	s.addBlockWithStateProofHeaders(2 * basics.Round(proto.StateProofInterval))
 
 	w.Start()
-	defer w.Shutdown()
+	defer w.Stop()
 
 	s.advanceLatest(proto.StateProofInterval + proto.StateProofInterval/2)
 
@@ -372,7 +372,7 @@ func TestGenerateBlockProof(t *testing.T) {
 	s.addBlockWithStateProofHeaders(2 * basics.Round(proto.StateProofInterval))
 
 	w.Start()
-	defer w.Shutdown()
+	defer w.Stop()
 
 	s.advanceLatest(proto.StateProofInterval + proto.StateProofInterval/2)
 

--- a/stateproof/stateproofMessageGenerator_test.go
+++ b/stateproof/stateproofMessageGenerator_test.go
@@ -17,13 +17,11 @@
 package stateproof
 
 import (
-	"context"
+	"github.com/algorand/go-algorand/data/stateproofmsg"
+	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
-
-	"github.com/algorand/go-deadlock"
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
@@ -32,174 +30,10 @@ import (
 	"github.com/algorand/go-algorand/data/account"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
-	"github.com/algorand/go-algorand/data/stateproofmsg"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
-	"github.com/algorand/go-algorand/logging"
-	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/protocol"
-	"github.com/algorand/go-algorand/test/partitiontest"
 )
-
-type workerForStateProofMessageTests struct {
-	w *testWorkerStubs
-}
-
-func (s *workerForStateProofMessageTests) StateProofKeys(round basics.Round) []account.StateProofSecretsForRound {
-	return s.w.StateProofKeys(round)
-}
-
-func (s *workerForStateProofMessageTests) DeleteStateProofKey(id account.ParticipationID, round basics.Round) error {
-	return s.w.DeleteStateProofKey(id, round)
-}
-
-func (s *workerForStateProofMessageTests) DeleteStateProofKeysForExpiredAccounts(currentRound basics.Round) {
-	s.w.DeleteStateProofKeysForExpiredAccounts(currentRound)
-}
-
-func (s *workerForStateProofMessageTests) Latest() basics.Round {
-	return s.w.Latest()
-}
-
-func (s *workerForStateProofMessageTests) Wait(round basics.Round) chan struct{} {
-	return s.w.Wait(round)
-}
-
-func (s *workerForStateProofMessageTests) GenesisHash() crypto.Digest {
-	return s.w.GenesisHash()
-}
-
-func (s *workerForStateProofMessageTests) BlockHdr(round basics.Round) (bookkeeping.BlockHeader, error) {
-	s.w.mu.Lock()
-	defer s.w.mu.Unlock()
-
-	element, ok := s.w.blocks[round]
-	if !ok {
-		return bookkeeping.BlockHeader{}, ledgercore.ErrNoEntry{Round: round}
-	}
-	return element, nil
-}
-
-func (s *workerForStateProofMessageTests) StateProofVerificationContext(stateProofLastAttestedRound basics.Round) (*ledgercore.StateProofVerificationContext, error) {
-	dummyContext := ledgercore.StateProofVerificationContext{
-		LastAttestedRound: stateProofLastAttestedRound,
-		VotersCommitment:  crypto.GenericDigest{0x1},
-		OnlineTotalWeight: basics.MicroAlgos{},
-		Version:           protocol.ConsensusCurrentVersion,
-	}
-
-	return &dummyContext, nil
-}
-
-func (s *workerForStateProofMessageTests) VotersForStateProof(round basics.Round) (*ledgercore.VotersForRound, error) {
-	voters := &ledgercore.VotersForRound{
-		Proto:     config.Consensus[protocol.ConsensusCurrentVersion],
-		AddrToPos: make(map[basics.Address]uint64),
-	}
-
-	wt := uint64(0)
-	for i, k := range s.w.keysForVoters {
-		partWe := uint64((len(s.w.keysForVoters) + int(round) - i) * 10000)
-		voters.AddrToPos[k.Parent] = uint64(i)
-		voters.Participants = append(voters.Participants, basics.Participant{
-			PK:     *k.StateProofSecrets.GetVerifier(),
-			Weight: partWe,
-		})
-		wt += partWe
-	}
-
-	tree, err := merklearray.BuildVectorCommitmentTree(voters.Participants, crypto.HashFactory{HashType: stateproof.HashType})
-	if err != nil {
-		return nil, err
-	}
-
-	voters.Tree = tree
-	voters.TotalWeight = basics.MicroAlgos{Raw: wt}
-	return voters, nil
-}
-
-func (s *workerForStateProofMessageTests) RegisterVotersCommitListener(listener ledgercore.VotersCommitListener) {
-	s.w.RegisterVotersCommitListener(listener)
-}
-
-func (s *workerForStateProofMessageTests) UnregisterVotersCommitListener() {
-	s.w.UnregisterVotersCommitListener()
-}
-
-func (s *workerForStateProofMessageTests) Broadcast(ctx context.Context, tag protocol.Tag, bytes []byte, b bool, peer network.Peer) error {
-	return s.w.Broadcast(ctx, tag, bytes, b, peer)
-}
-
-func (s *workerForStateProofMessageTests) RegisterHandlers(handlers []network.TaggedMessageHandler) {
-	s.w.RegisterHandlers(handlers)
-}
-
-func (s *workerForStateProofMessageTests) BroadcastInternalSignedTxGroup(txns []transactions.SignedTxn) error {
-	return s.w.BroadcastInternalSignedTxGroup(txns)
-}
-
-func (s *workerForStateProofMessageTests) addBlockWithStateProofHeaders(ccNextRound basics.Round) {
-	s.w.latest++
-
-	hdr := bookkeeping.BlockHeader{}
-	hdr.Round = s.w.latest
-	hdr.CurrentProtocol = protocol.ConsensusCurrentVersion
-
-	var ccBasic = bookkeeping.StateProofTrackingData{
-		StateProofVotersCommitment:  make([]byte, stateproof.HashSize),
-		StateProofOnlineTotalWeight: basics.MicroAlgos{},
-		StateProofNextRound:         0,
-	}
-
-	if uint64(hdr.Round)%config.Consensus[hdr.CurrentProtocol].StateProofInterval == 0 {
-		voters, _ := s.VotersForStateProof(hdr.Round.SubSaturate(basics.Round(config.Consensus[hdr.CurrentProtocol].StateProofVotersLookback)))
-		ccBasic.StateProofVotersCommitment = voters.Tree.Root()
-		ccBasic.StateProofOnlineTotalWeight = voters.TotalWeight
-
-	}
-
-	ccBasic.StateProofNextRound = ccNextRound
-	hdr.StateProofTracking = map[protocol.StateProofType]bookkeeping.StateProofTrackingData{
-		protocol.StateProofBasic: ccBasic,
-	}
-
-	s.w.blocks[s.w.latest] = hdr
-
-	s.w.waitersCount[s.w.latest] = 0
-	if s.w.waiters[s.w.latest] != nil {
-		close(s.w.waiters[s.w.latest])
-		s.w.waiters[s.w.latest] = nil
-	}
-}
-
-func newWorkerForStateProofMessageStubs(keys []account.Participation, totalWeight int) *workerForStateProofMessageTests {
-	s := &testWorkerStubs{
-		t:                         nil,
-		mu:                        deadlock.Mutex{},
-		listenerMu:                deadlock.RWMutex{},
-		latest:                    0,
-		waiters:                   make(map[basics.Round]chan struct{}),
-		waitersCount:              make(map[basics.Round]int),
-		blocks:                    make(map[basics.Round]bookkeeping.BlockHeader),
-		keys:                      keys,
-		keysForVoters:             keys,
-		sigmsg:                    make(chan []byte, 1024),
-		txmsg:                     make(chan transactions.SignedTxn, 1024),
-		totalWeight:               totalWeight,
-		deletedKeysBeforeRoundMap: map[account.ParticipationID]basics.Round{},
-	}
-	sm := workerForStateProofMessageTests{w: s}
-	return &sm
-}
-
-func (s *workerForStateProofMessageTests) advanceLatest(delta uint64) {
-	s.w.mu.Lock()
-	defer s.w.mu.Unlock()
-
-	for r := uint64(0); r < delta; r++ {
-		s.addBlockWithStateProofHeaders(s.w.blocks[s.w.latest].StateProofTracking[protocol.StateProofBasic].StateProofNextRound)
-	}
-}
 
 func TestStateProofMessage(t *testing.T) {
 	partitiontest.PartitionTest(t)
@@ -214,51 +48,41 @@ func TestStateProofMessage(t *testing.T) {
 		keys = append(keys, p.Participation)
 	}
 
-	s := newWorkerForStateProofMessageStubs(keys, len(keys))
-	dbs, _ := dbOpenTest(t, true)
-	w := NewWorker(dbs.Wdb, logging.TestingLog(t), s, s, s, s)
-
-	proto := config.Consensus[protocol.ConsensusCurrentVersion]
-	s.w.latest--
-	s.addBlockWithStateProofHeaders(2 * basics.Round(proto.StateProofInterval))
-
+	s := newWorkerStubsWithChannel(t, keys, len(keys))
+	s.sigmsg = nil
+	w := newTestWorker(t, s)
 	w.Start()
 	defer w.Stop()
 
-	s.advanceLatest(proto.StateProofInterval + proto.StateProofInterval/2)
-
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	s.advanceRoundsWithoutStateProof(t, 1)
 	var lastMessage stateproofmsg.Message
+	for i := 0; i < 5; i++ {
+		s.advanceRoundsWithoutStateProof(t, proto.StateProofInterval-1)
 
-	for iter := uint64(0); iter < 5; iter++ {
-		s.advanceLatest(proto.StateProofInterval)
-
+		var tx transactions.SignedTxn
+		// there will be several state proof txn. we extract them
 		for {
-			tx, err := s.w.waitOnTxnWithTimeout(time.Second * 5)
+			var err error
+			tx, err = s.waitOnTxnWithTimeout(time.Second * 5)
 			a.NoError(err)
-
-			a.Equal(tx.Txn.Type, protocol.StateProofTx)
-
-			lastAttestedRound := basics.Round(tx.Txn.Message.LastAttestedRound)
-			if lastAttestedRound < basics.Round(iter+2)*basics.Round(proto.StateProofInterval) {
-				continue
+			if lastMessage.LastAttestedRound == 0 || lastMessage.LastAttestedRound < tx.Txn.Message.LastAttestedRound {
+				break
 			}
 
-			a.Equal(lastAttestedRound, basics.Round(iter+2)*basics.Round(proto.StateProofInterval))
-			a.Equal(tx.Txn.Message.FirstAttestedRound, (iter+1)*proto.StateProofInterval+1)
-
-			verifySha256BlockHeadersCommitments(a, tx.Txn.Message, s.w.blocks)
-
-			if !lastMessage.MsgIsZero() {
-				verifier := stateproof.MkVerifierWithLnProvenWeight(lastMessage.VotersCommitment, lastMessage.LnProvenWeight, proto.StateProofStrengthTarget)
-
-				err := verifier.Verify(uint64(lastAttestedRound), tx.Txn.Message.Hash(), &tx.Txn.StateProof)
-				a.NoError(err)
-
-			}
-
-			lastMessage = tx.Txn.Message
-			break
 		}
+
+		verifySha256BlockHeadersCommitments(a, tx.Txn.Message, s.blocks)
+		if !lastMessage.MsgIsZero() {
+			verifier := stateproof.MkVerifierWithLnProvenWeight(lastMessage.VotersCommitment, lastMessage.LnProvenWeight, proto.StateProofStrengthTarget)
+
+			err := verifier.Verify(tx.Txn.Message.LastAttestedRound, tx.Txn.Message.Hash(), &tx.Txn.StateProof)
+			a.NoError(err)
+		}
+		// since a state proof txn was created, we update the header with the next state proof round
+		// i.e network has accepted the state proof.
+		s.addBlock(basics.Round(tx.Txn.Message.LastAttestedRound + proto.StateProofInterval))
+		lastMessage = tx.Txn.Message
 	}
 }
 
@@ -288,12 +112,11 @@ func TestGenerateStateProofMessageForSmallRound(t *testing.T) {
 		keys = append(keys, p.Participation)
 	}
 
-	s := newWorkerForStateProofMessageStubs(keys[:], len(keys))
+	s := newWorkerStubAtGenesis(t, keys[:], len(keys))
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
-	s.w.latest--
-	s.addBlockWithStateProofHeaders(2 * basics.Round(proto.StateProofInterval))
+	s.addBlock(2 * basics.Round(proto.StateProofInterval))
 
-	_, err := GenerateStateProofMessage(s, s.w.latest)
+	_, err := GenerateStateProofMessage(s, s.latest)
 	a.ErrorIs(err, errInvalidParams)
 }
 
@@ -310,16 +133,17 @@ func TestMessageLnApproxError(t *testing.T) {
 		keys = append(keys, p.Participation)
 	}
 
-	s := newWorkerForStateProofMessageStubs(keys[:], len(keys))
-	proto := config.Consensus[protocol.ConsensusCurrentVersion]
-	s.w.latest--
-	s.addBlockWithStateProofHeaders(2 * basics.Round(proto.StateProofInterval))
+	s := newWorkerStubs(t, keys[:], len(keys))
+	w := newTestWorker(t, s)
+	w.Start()
+	defer w.Stop()
 
-	s.advanceLatest(2*proto.StateProofInterval + proto.StateProofInterval/2)
-	tracking := s.w.blocks[512].StateProofTracking[protocol.StateProofBasic]
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	s.advanceRoundsWithoutStateProof(t, proto.StateProofInterval)
+	tracking := s.blocks[512].StateProofTracking[protocol.StateProofBasic]
 	tracking.StateProofOnlineTotalWeight = basics.MicroAlgos{}
 	newtracking := tracking
-	s.w.blocks[512].StateProofTracking[protocol.StateProofBasic] = newtracking
+	s.blocks[512].StateProofTracking[protocol.StateProofBasic] = newtracking
 
 	_, err := GenerateStateProofMessage(s, basics.Round(2*proto.StateProofInterval))
 	a.ErrorIs(err, stateproof.ErrIllegalInputForLnApprox)
@@ -338,16 +162,17 @@ func TestMessageMissingHeaderOnInterval(t *testing.T) {
 		keys = append(keys, p.Participation)
 	}
 
-	s := newWorkerForStateProofMessageStubs(keys[:], len(keys))
-	s.w.latest--
-	proto := config.Consensus[protocol.ConsensusCurrentVersion]
-	s.addBlockWithStateProofHeaders(2 * basics.Round(proto.StateProofInterval))
+	s := newWorkerStubs(t, keys[:], len(keys))
+	w := newTestWorker(t, s)
+	w.Start()
+	defer w.Stop()
 
-	s.advanceLatest(2*proto.StateProofInterval + proto.StateProofInterval/2)
-	delete(s.w.blocks, 510)
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	s.advanceRoundsWithoutStateProof(t, proto.StateProofInterval)
+	delete(s.blocks, 510)
 
 	_, err := GenerateStateProofMessage(s, basics.Round(2*proto.StateProofInterval))
-	a.ErrorIs(err, ledgercore.ErrNoEntry{Round: 510})
+	a.ErrorIs(err, ledgercore.ErrNoEntry{Round: 510, Latest: s.latest, Committed: s.latest})
 }
 
 func TestGenerateBlockProof(t *testing.T) {
@@ -363,34 +188,36 @@ func TestGenerateBlockProof(t *testing.T) {
 		keys = append(keys, p.Participation)
 	}
 
-	s := newWorkerForStateProofMessageStubs(keys, len(keys))
-	dbs, _ := dbOpenTest(t, true)
-	w := NewWorker(dbs.Wdb, logging.TestingLog(t), s, s, s, s)
-
-	proto := config.Consensus[protocol.ConsensusCurrentVersion]
-	s.w.latest--
-	s.addBlockWithStateProofHeaders(2 * basics.Round(proto.StateProofInterval))
-
+	s := newWorkerStubsWithChannel(t, keys, len(keys))
+	s.sigmsg = nil
+	w := newTestWorker(t, s)
 	w.Start()
 	defer w.Stop()
 
-	s.advanceLatest(proto.StateProofInterval + proto.StateProofInterval/2)
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	s.advanceRoundsWithoutStateProof(t, 1)
+	var lastAttestedRound basics.Round
+	for i := 0; i < 5; i++ {
+		s.advanceRoundsWithoutStateProof(t, proto.StateProofInterval-1)
 
-	for iter := uint64(0); iter < 5; iter++ {
-		s.advanceLatest(proto.StateProofInterval)
+		var tx transactions.SignedTxn
+		// there will be several state proof txn. we extract them
+		for {
+			var err error
+			tx, err = s.waitOnTxnWithTimeout(time.Second * 5)
+			a.NoError(err)
+			if lastAttestedRound == 0 || lastAttestedRound < basics.Round(tx.Txn.Message.LastAttestedRound) {
+				break
+			}
 
-		tx := <-s.w.txmsg
-		// we have a new tx. now attempt to fetch a block proof.
-		firstAttestedRound := tx.Txn.Message.FirstAttestedRound
-		lastAttestedRound := tx.Txn.Message.LastAttestedRound
-
-		headers, err := FetchLightHeaders(s, proto.StateProofInterval, basics.Round(lastAttestedRound))
+		}
+		headers, err := FetchLightHeaders(s, proto.StateProofInterval, basics.Round(tx.Txn.Message.LastAttestedRound))
 		a.NoError(err)
 		a.Equal(proto.StateProofInterval, uint64(len(headers)))
 
 		// attempting to get block proof for every block in the interval
-		for i := firstAttestedRound; i < lastAttestedRound; i++ {
-			headerIndex := i - firstAttestedRound
+		for j := tx.Txn.Message.FirstAttestedRound; j < tx.Txn.Message.LastAttestedRound; j++ {
+			headerIndex := j - tx.Txn.Message.FirstAttestedRound
 			proof, err := GenerateProofOfLightBlockHeaders(proto.StateProofInterval, headers, headerIndex)
 			a.NoError(err)
 			a.NotNil(proof)
@@ -403,6 +230,9 @@ func TestGenerateBlockProof(t *testing.T) {
 
 			a.NoError(err)
 		}
+
+		s.addBlock(basics.Round(tx.Txn.Message.LastAttestedRound + proto.StateProofInterval))
+		lastAttestedRound = basics.Round(tx.Txn.Message.LastAttestedRound)
 	}
 }
 
@@ -411,7 +241,7 @@ func TestGenerateBlockProofOnSmallArray(t *testing.T) {
 	a := require.New(t)
 
 	var keys []account.Participation
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 2; i++ {
 		var parent basics.Address
 		crypto.RandBytes(parent[:])
 		p := newPartKey(t, parent)
@@ -419,13 +249,13 @@ func TestGenerateBlockProofOnSmallArray(t *testing.T) {
 		keys = append(keys, p.Participation)
 	}
 
-	s := newWorkerForStateProofMessageStubs(keys, len(keys))
+	s := newWorkerStubs(t, keys[:], len(keys))
+	w := newTestWorker(t, s)
+	w.Start()
+	defer w.Stop()
+
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
-
-	s.w.latest--
-	s.addBlockWithStateProofHeaders(2 * basics.Round(proto.StateProofInterval))
-
-	s.advanceLatest(2 * proto.StateProofInterval)
+	s.advanceRoundsWithoutStateProof(t, proto.StateProofInterval)
 	headers, err := FetchLightHeaders(s, proto.StateProofInterval, basics.Round(2*proto.StateProofInterval))
 	a.NoError(err)
 	headers = headers[1:]

--- a/stateproof/stateproofMessageGenerator_test.go
+++ b/stateproof/stateproofMessageGenerator_test.go
@@ -122,6 +122,10 @@ func (s *workerForStateProofMessageTests) RegisterVotersCommitListener(listener 
 	s.w.RegisterVotersCommitListener(listener)
 }
 
+func (s *workerForStateProofMessageTests) UnregisterVotersCommitListener() {
+	s.w.UnregisterVotersCommitListener()
+}
+
 func (s *workerForStateProofMessageTests) Broadcast(ctx context.Context, tag protocol.Tag, bytes []byte, b bool, peer network.Peer) error {
 	return s.w.Broadcast(ctx, tag, bytes, b, peer)
 }

--- a/stateproof/worker.go
+++ b/stateproof/worker.go
@@ -148,7 +148,8 @@ func (spw *Worker) initDb(inMemory bool) error {
 	return nil
 }
 
-// Stop stops any goroutines associated with this worker.
+// Stop stops any goroutines associated with this worker. It is the caller responsibility to remove the register
+// network handlers
 func (spw *Worker) Stop() {
 	spw.shutdown()
 	spw.wg.Wait()

--- a/stateproof/worker.go
+++ b/stateproof/worker.go
@@ -118,6 +118,8 @@ func (spw *Worker) Start() {
 
 	spw.initBuilders()
 
+	spw.ledger.RegisterVotersCommitListener(spw)
+
 	handlers := []network.TaggedMessageHandler{
 		{Tag: protocol.StateProofSigTag, MessageHandler: network.HandlerFunc(spw.handleSigMessage)},
 	}

--- a/stateproof/worker.go
+++ b/stateproof/worker.go
@@ -122,6 +122,7 @@ func (spw *Worker) Start() {
 func (spw *Worker) Shutdown() {
 	spw.shutdown()
 	spw.wg.Wait()
+	spw.ledger.UnregisterVotersCommitListener()
 	spw.db.Close()
 }
 

--- a/stateproof/worker.go
+++ b/stateproof/worker.go
@@ -118,8 +118,8 @@ func (spw *Worker) Start() {
 	go spw.builder(latest)
 }
 
-// Shutdown stops any goroutines associated with this worker.
-func (spw *Worker) Shutdown() {
+// Stop stops any goroutines associated with this worker.
+func (spw *Worker) Stop() {
 	spw.shutdown()
 	spw.wg.Wait()
 	spw.ledger.UnregisterVotersCommitListener()

--- a/stateproof/worker.go
+++ b/stateproof/worker.go
@@ -18,10 +18,14 @@ package stateproof
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/algorand/go-deadlock"
 
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto/stateproof"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
@@ -57,12 +61,13 @@ type Worker struct {
 	// from the network stack.
 	mu deadlock.Mutex
 
-	db        db.Accessor
-	log       logging.Logger
-	accts     Accounts
-	ledger    Ledger
-	net       Network
-	txnSender TransactionSender
+	spDbFileName string
+	db           db.Accessor
+	log          logging.Logger
+	accts        Accounts
+	ledger       Ledger
+	net          Network
+	txnSender    TransactionSender
 
 	// builders is indexed by the round of the block being signed.
 	builders map[basics.Round]builder
@@ -77,30 +82,42 @@ type Worker struct {
 }
 
 // NewWorker constructs a new Worker, as used by the node.
-func NewWorker(db db.Accessor, log logging.Logger, accts Accounts, ledger Ledger, net Network, txnSender TransactionSender) *Worker {
-	ctx, cancel := context.WithCancel(context.Background())
+func NewWorker(genesisDir string, log logging.Logger, accts Accounts, ledger Ledger, net Network, txnSender TransactionSender) *Worker {
+	// Delete the deprecated database file if it exists. This can be removed in future updates since this file should not exist by then.
+	oldCompactCertPath := filepath.Join(genesisDir, "compactcert.sqlite")
+	os.Remove(oldCompactCertPath)
 
+	// todo will config.StateProofFileName gets updated ?
+	stateProofPathname := filepath.Join(genesisDir, config.StateProofFileName)
+
+	// todo this might be a mistake aslo, start and stop should create a new ctx
+	ctx, cancel := context.WithCancel(context.Background())
 	return &Worker{
-		db:        db,
-		log:       log,
-		accts:     accts,
-		ledger:    ledger,
-		net:       net,
-		txnSender: txnSender,
-		builders:  make(map[basics.Round]builder),
-		ctx:       ctx,
-		shutdown:  cancel,
-		signedCh:  make(chan struct{}, 1),
+		spDbFileName: stateProofPathname,
+		log:          log,
+		accts:        accts,
+		ledger:       ledger,
+		net:          net,
+		txnSender:    txnSender,
+		builders:     nil,
+		ctx:          ctx,
+		shutdown:     cancel,
+		signedCh:     make(chan struct{}, 1),
 	}
 }
 
 // Start starts the goroutines for the worker.
 func (spw *Worker) Start() {
-	err := makeStateProofDB(spw.db)
+	err := spw.initDb()
 	if err != nil {
-		spw.log.Warnf("spw.Start(): initDB: %v", err)
+		spw.log.Warn(err)
 		return
 	}
+
+	// todo this might be a mistake aslo, start and stop should create a new ctx
+	ctx, cancel := context.WithCancel(context.Background())
+	spw.ctx = ctx
+	spw.shutdown = cancel
 
 	spw.initBuilders()
 
@@ -118,11 +135,27 @@ func (spw *Worker) Start() {
 	go spw.builder(latest)
 }
 
+func (spw *Worker) initDb() error {
+	stateProofAccess, err := db.MakeAccessor(spw.spDbFileName, false, false)
+	if err != nil {
+		return fmt.Errorf("cannot load state proof data: %v", err)
+
+	}
+
+	spw.db = stateProofAccess
+	err = makeStateProofDB(spw.db)
+	if err != nil {
+		fmt.Errorf("spw.Start(): initDB: %v", err)
+	}
+	return nil
+}
+
 // Stop stops any goroutines associated with this worker.
 func (spw *Worker) Stop() {
 	spw.shutdown()
 	spw.wg.Wait()
 	spw.ledger.UnregisterVotersCommitListener()
+	spw.builders = nil
 	spw.db.Close()
 }
 

--- a/stateproof/worker.go
+++ b/stateproof/worker.go
@@ -90,7 +90,6 @@ func NewWorker(genesisDir string, log logging.Logger, accts Accounts, ledger Led
 	oldCompactCertPath := filepath.Join(genesisDir, "compactcert.sqlite")
 	os.Remove(oldCompactCertPath)
 
-	// todo will config.StateProofFileName gets updated ?
 	stateProofPathname := filepath.Join(genesisDir, config.StateProofFileName)
 
 	return &Worker{
@@ -136,14 +135,14 @@ func (spw *Worker) Start() {
 func (spw *Worker) initDb(inMemory bool) error {
 	stateProofAccess, err := db.MakeAccessor(spw.spDbFileName, false, inMemory)
 	if err != nil {
-		return fmt.Errorf("cannot load state proof data: %w", err)
+		return fmt.Errorf("spw.initDb(): cannot load state proof data: %w", err)
 
 	}
 
 	spw.db = stateProofAccess
 	err = makeStateProofDB(spw.db)
 	if err != nil {
-		return fmt.Errorf("spw.initDb(): initDB: %w", err)
+		return fmt.Errorf("spw.initDb(): makeStateProofDB failed: %w", err)
 	}
 	return nil
 }

--- a/stateproof/worker_test.go
+++ b/stateproof/worker_test.go
@@ -553,7 +553,7 @@ func TestWorkerAllSigs(t *testing.T) {
 	s := newWorkerStubsWithChannel(t, keys, len(keys))
 	w := newTestWorker(t, s)
 	w.Start()
-	defer w.Shutdown()
+	defer w.Stop()
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
@@ -617,7 +617,7 @@ func TestWorkerPartialSigs(t *testing.T) {
 	s := newWorkerStubsWithChannel(t, keys, 10)
 	w := newTestWorker(t, s)
 	w.Start()
-	defer w.Shutdown()
+	defer w.Stop()
 
 	// at this point the ledger is at round 511 - we push add one block, so it will start to create state proofs
 	s.advanceRoundsWithoutStateProof(t, 1)
@@ -679,7 +679,7 @@ func TestWorkerInsufficientSigs(t *testing.T) {
 	s := newWorkerStubsWithChannel(t, keys, 10)
 	w := newTestWorker(t, s)
 	w.Start()
-	defer w.Shutdown()
+	defer w.Stop()
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	s.advanceRoundsWithoutStateProof(t, 3*proto.StateProofInterval)
@@ -738,7 +738,7 @@ func TestWorkerRestart(t *testing.T) {
 		case <-time.After(time.Second):
 		}
 
-		w.Shutdown()
+		w.Stop()
 	}
 
 	a.Greater(formedAt, 1)
@@ -760,7 +760,7 @@ func TestWorkerHandleSig(t *testing.T) {
 	s := newWorkerStubsWithChannel(t, keys, 10)
 	w := newTestWorker(t, s)
 	w.Start()
-	defer w.Shutdown()
+	defer w.Stop()
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	s.advanceRoundsWithoutStateProof(t, 3*proto.StateProofInterval)
@@ -796,7 +796,7 @@ func TestWorkerIgnoresSignatureForNonCacheBuilders(t *testing.T) {
 	s := newWorkerStubs(t, keys, 10)
 	w := newTestWorker(t, s)
 	w.Start()
-	defer w.Shutdown()
+	defer w.Stop()
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	targetRound := (buildersCacheLength + 1) * proto.StateProofInterval
@@ -862,7 +862,7 @@ func TestKeysRemoveOnlyAfterStateProofAccepted(t *testing.T) {
 	firstExpectedStateproof := basics.Round(proto.StateProofInterval * 2)
 
 	keys, s, w := createWorkerAndParticipants(t, protocol.ConsensusCurrentVersion, proto)
-	defer w.Shutdown()
+	defer w.Stop()
 
 	s.advanceRoundsWithoutStateProof(t, expectedNumberOfStateProofs*proto.StateProofInterval)
 
@@ -901,7 +901,7 @@ func TestKeysRemoveOnlyAfterStateProofAcceptedSmallIntervals(t *testing.T) {
 	firstExpectedStateproof := basics.Round(proto.StateProofInterval * 2)
 
 	keys, s, w := createWorkerAndParticipants(t, smallIntervalVersionName, proto)
-	defer w.Shutdown()
+	defer w.Stop()
 
 	s.advanceRoundsWithoutStateProof(t, expectedNumberOfStateProofs*proto.StateProofInterval)
 
@@ -940,7 +940,7 @@ func TestKeysRemoveOnlyAfterStateProofAcceptedLargeIntervals(t *testing.T) {
 	firstExpectedStateproof := basics.Round(proto.StateProofInterval * 2)
 
 	keys, s, w := createWorkerAndParticipants(t, protocol.ConsensusCurrentVersion, proto)
-	defer w.Shutdown()
+	defer w.Stop()
 
 	s.advanceRoundsWithoutStateProof(t, expectedNumberOfStateProofs*proto.StateProofInterval)
 	// since no state proof was confirmed (i.e the next state proof round == firstExpectedStateproof), we expect a node
@@ -978,7 +978,7 @@ func TestWorkersBuildersCacheAndSignatures(t *testing.T) {
 	s := newWorkerStubs(t, keys, len(keys))
 	w := newTestWorker(t, s)
 	w.Start()
-	defer w.Shutdown()
+	defer w.Stop()
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
@@ -1057,7 +1057,7 @@ func TestSignatureBroadcastPolicy(t *testing.T) {
 	s := newWorkerStubs(t, keys, len(keys))
 	w := newTestWorker(t, s)
 	w.Start()
-	defer w.Shutdown()
+	defer w.Stop()
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
@@ -1116,7 +1116,7 @@ func TestWorkerDoesNotLimitBuildersAndSignaturesOnDisk(t *testing.T) {
 	s := newWorkerStubs(t, keys, len(keys))
 	w := newTestWorker(t, s)
 	w.Start()
-	defer w.Shutdown()
+	defer w.Stop()
 
 	for iter := uint64(0); iter < proto.StateProofMaxRecoveryIntervals+1; iter++ {
 		s.advanceRoundsWithoutStateProof(t, proto.StateProofInterval)
@@ -1301,7 +1301,7 @@ func TestBuilderGeneratesValidStateProofTXN(t *testing.T) {
 	s := newWorkerStubsWithChannel(t, keys, len(keys))
 	w := newTestWorker(t, s)
 	w.Start()
-	defer w.Shutdown()
+	defer w.Stop()
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
@@ -1421,7 +1421,7 @@ func TestWorkerHandleSigRoundNotInLedger(t *testing.T) {
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	intervalRound := basics.Round(proto.StateProofInterval)
 	_, w, msg, msgBytes := setBlocksAndMessage(t, intervalRound*10)
-	defer w.Shutdown()
+	defer w.Stop()
 
 	reply := w.handleSigMessage(network.IncomingMessage{
 		Data: msgBytes,
@@ -1505,7 +1505,7 @@ func TestWorkerHandleSigAlreadyIn(t *testing.T) {
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	lastRound := proto.StateProofInterval * 2
 	s, w, msg, _ := setBlocksAndMessage(t, basics.Round(lastRound))
-	defer w.Shutdown()
+	defer w.Stop()
 
 	stateproofMessage, err := GenerateStateProofMessage(w.ledger, basics.Round(lastRound))
 	require.NoError(t, err)
@@ -1545,7 +1545,7 @@ func TestWorkerHandleSigExceptionsDbError(t *testing.T) {
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	lastRound := proto.StateProofInterval * 2
 	s, w, msg, _ := setBlocksAndMessage(t, basics.Round(lastRound))
-	defer w.Shutdown()
+	defer w.Stop()
 
 	stateproofMessage, err := GenerateStateProofMessage(w.ledger, basics.Round(lastRound))
 	require.NoError(t, err)
@@ -1580,7 +1580,7 @@ func TestWorkerHandleSigCantMakeBuilder(t *testing.T) {
 
 	s := newWorkerStubs(t, []account.Participation{p.Participation}, 10)
 	w := newTestWorker(t, s)
-	defer w.Shutdown()
+	defer w.Stop()
 
 	s.mu.Lock()
 	s.addBlock(basics.Round(proto.StateProofInterval * 2))
@@ -1738,14 +1738,14 @@ func TestWorkerCacheAndDiskAfterRestart(t *testing.T) {
 	a.Equal(buildersCacheLength, len(roundSigs)) // Number of broadcasted sigs should be the same as number of (online) cached builders.
 
 	// restart worker
-	w.Shutdown()
+	w.Stop()
 	// we make sure that the worker will not be able to create a builder by disabling the mock ledger
 	s.keysForVoters = []account.Participation{}
 
 	dbs, _ = dbOpenTestRand(t, true, dbRand)
 	w = newTestWorkerDB(t, s, dbs.Wdb)
 	w.Start()
-	defer w.Shutdown()
+	defer w.Stop()
 
 	a.Equal(buildersCacheLength, len(w.builders))
 	countDB, err = countBuildersInDB(w.db)
@@ -1799,7 +1799,7 @@ func TestWorkerInitOnlySignaturesInDatabase(t *testing.T) {
 	a.Equal(buildersCacheLength, len(roundSigs)) // Number of broadcasted sigs should be the same as number of (online) cached builders.
 
 	// restart worker
-	w.Shutdown()
+	w.Stop()
 
 	dbs, _ = dbOpenTestRand(t, true, dbRand)
 	w = newTestWorkerDB(t, s, dbs.Wdb)
@@ -1809,7 +1809,7 @@ func TestWorkerInitOnlySignaturesInDatabase(t *testing.T) {
 		return err
 	}))
 	w.Start()
-	defer w.Shutdown()
+	defer w.Stop()
 
 	a.Equal(buildersCacheLength, len(w.builders))
 	countDB, err = countBuildersInDB(w.db)
@@ -1893,7 +1893,7 @@ func TestWorkerCreatesBuildersOnCommit(t *testing.T) {
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
 	_, s, w := createWorkerAndParticipants(t, protocol.ConsensusCurrentVersion, proto)
-	defer w.Shutdown()
+	defer w.Stop()
 
 	// We remove the signer's keys to stop it from generating builders.
 	s.keys = []account.Participation{}
@@ -1951,7 +1951,7 @@ func TestSignerUsesPersistedBuilderLatestProto(t *testing.T) {
 	w.wg.Wait()
 	w = newTestWorkerDB(t, s, oldDb)
 	w.Start()
-	defer w.Shutdown()
+	defer w.Stop()
 
 	// We advance another round to allow us to wait for the signer, allowing it time to finish signing.
 	s.advanceRoundsWithoutStateProof(t, 1)
@@ -1991,7 +1991,7 @@ func TestRegisterCommitListener(t *testing.T) {
 	}
 	s.advanceRoundsAndCreateStateProofs(t, proto.StateProofInterval/2)
 
-	w.Shutdown()
+	w.Stop()
 
 	a.Nil(s.commitListener)
 }


### PR DESCRIPTION
Revert changes to bulletin keeping round notifiers in memory at reloadLedger.