### PR TITLE
CircleCI: Fix cached Results issue in self-hosted runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,111 +102,111 @@ workflows:
           context: slack-secrets
           <<: *slack-fail-post-step
 
-      # - test_nightly:
-      #     name: << matrix.platform >>_test_nightly
-      #     matrix:
-      #       <<: *matrix-nightly
-      #     requires:
-      #       - << matrix.platform >>_build_nightly
-      #     context: slack-secrets
-      #     <<: *slack-fail-post-step
+      - test_nightly:
+          name: << matrix.platform >>_test_nightly
+          matrix:
+            <<: *matrix-nightly
+          requires:
+            - << matrix.platform >>_build_nightly
+          context: slack-secrets
+          <<: *slack-fail-post-step
 
-      # - integration:
-      #     name: << matrix.platform >>_integration
-      #     matrix:
-      #       <<: *matrix-default
-      #     filters:
-      #       <<: *filters-default
-      #     context: slack-secrets
-      #     <<: *slack-fail-post-step
+      - integration:
+          name: << matrix.platform >>_integration
+          matrix:
+            <<: *matrix-default
+          filters:
+            <<: *filters-default
+          context: slack-secrets
+          <<: *slack-fail-post-step
 
-      # - integration_nightly:
-      #     name: << matrix.platform >>_integration_nightly
-      #     matrix:
-      #       <<: *matrix-nightly
-      #     requires:
-      #       - << matrix.platform >>_build_nightly
-      #     context: slack-secrets
-      #     <<: *slack-fail-post-step
+      - integration_nightly:
+          name: << matrix.platform >>_integration_nightly
+          matrix:
+            <<: *matrix-nightly
+          requires:
+            - << matrix.platform >>_build_nightly
+          context: slack-secrets
+          <<: *slack-fail-post-step
 
-      # - e2e_expect:
-      #     name: << matrix.platform >>_e2e_expect
-      #     matrix:
-      #       <<: *matrix-default
-      #     filters:
-      #       <<: *filters-default
-      #     context: slack-secrets
-      #     <<: *slack-fail-post-step
+      - e2e_expect:
+          name: << matrix.platform >>_e2e_expect
+          matrix:
+            <<: *matrix-default
+          filters:
+            <<: *filters-default
+          context: slack-secrets
+          <<: *slack-fail-post-step
 
-      # - e2e_expect_nightly:
-      #     name: << matrix.platform >>_e2e_expect_nightly
-      #     matrix:
-      #       <<: *matrix-nightly
-      #     requires:
-      #       - << matrix.platform >>_build_nightly
-      #     context: slack-secrets
-      #     <<: *slack-fail-post-step
+      - e2e_expect_nightly:
+          name: << matrix.platform >>_e2e_expect_nightly
+          matrix:
+            <<: *matrix-nightly
+          requires:
+            - << matrix.platform >>_build_nightly
+          context: slack-secrets
+          <<: *slack-fail-post-step
 
-      # - e2e_subs:
-      #     name: << matrix.platform >>_e2e_subs
-      #     matrix:
-      #       <<: *matrix-default
-      #     filters:
-      #       <<: *filters-default
-      #     context: slack-secrets
-      #     <<: *slack-fail-post-step
+      - e2e_subs:
+          name: << matrix.platform >>_e2e_subs
+          matrix:
+            <<: *matrix-default
+          filters:
+            <<: *filters-default
+          context: slack-secrets
+          <<: *slack-fail-post-step
 
-      # - e2e_subs_nightly:
-      #     name: << matrix.platform >>_e2e_subs_nightly
-      #     matrix:
-      #       <<: *matrix-nightly
-      #     requires:
-      #       - << matrix.platform >>_build_nightly
-      #     context:
-      #       - slack-secrets
-      #       - aws-secrets
-      #     <<: *slack-fail-post-step
+      - e2e_subs_nightly:
+          name: << matrix.platform >>_e2e_subs_nightly
+          matrix:
+            <<: *matrix-nightly
+          requires:
+            - << matrix.platform >>_build_nightly
+          context:
+            - slack-secrets
+            - aws-secrets
+          <<: *slack-fail-post-step
 
-      # - tests_verification_job:
-      #     name: << matrix.platform >>_<< matrix.job_type >>_verification
-      #     matrix:
-      #       parameters:
-      #         platform: ["amd64", "arm64"]
-      #         job_type: ["test", "integration", "e2e_expect"]
-      #     requires:
-      #       - << matrix.platform >>_<< matrix.job_type >>
-      #     context: slack-secrets
-      #     <<: *slack-fail-post-step
+      - tests_verification_job:
+          name: << matrix.platform >>_<< matrix.job_type >>_verification
+          matrix:
+            parameters:
+              platform: ["amd64", "arm64"]
+              job_type: ["test", "integration", "e2e_expect"]
+          requires:
+            - << matrix.platform >>_<< matrix.job_type >>
+          context: slack-secrets
+          <<: *slack-fail-post-step
 
-      # - tests_verification_job_nightly:
-      #     name: << matrix.platform >>_<< matrix.job_type >>_verification
-      #     matrix:
-      #       parameters:
-      #         platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
-      #         job_type: ["test_nightly", "integration_nightly", "e2e_expect_nightly"]
-      #     requires:
-      #       - << matrix.platform >>_<< matrix.job_type >>
-      #     context: slack-secrets
-      #     <<: *slack-fail-post-step
+      - tests_verification_job_nightly:
+          name: << matrix.platform >>_<< matrix.job_type >>_verification
+          matrix:
+            parameters:
+              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
+              job_type: ["test_nightly", "integration_nightly", "e2e_expect_nightly"]
+          requires:
+            - << matrix.platform >>_<< matrix.job_type >>
+          context: slack-secrets
+          <<: *slack-fail-post-step
 
-      # - upload_binaries:
-      #     name: << matrix.platform >>_upload_binaries
-      #     matrix:
-      #       <<: *matrix-nightly
-      #     requires:
-      #       - << matrix.platform >>_test_nightly_verification
-      #       - << matrix.platform >>_integration_nightly_verification
-      #       - << matrix.platform >>_e2e_expect_nightly_verification
-      #       - << matrix.platform >>_e2e_subs_nightly
-      #     filters:
-      #       branches:
-      #         only:
-      #           - /rel\/.*/
-      #           - << pipeline.parameters.valid_nightly_branch >>
-      #     context:
-      #       - slack-secrets
-      #       - aws-secrets
-      #     <<: *slack-fail-post-step
+      - upload_binaries:
+          name: << matrix.platform >>_upload_binaries
+          matrix:
+            <<: *matrix-nightly
+          requires:
+            - << matrix.platform >>_test_nightly_verification
+            - << matrix.platform >>_integration_nightly_verification
+            - << matrix.platform >>_e2e_expect_nightly_verification
+            - << matrix.platform >>_e2e_subs_nightly
+          filters:
+            branches:
+              only:
+                - /rel\/.*/
+                - << pipeline.parameters.valid_nightly_branch >>
+          context:
+            - slack-secrets
+            - aws-secrets
+          <<: *slack-fail-post-step
 
       #- windows_x64_build
 
@@ -705,9 +705,7 @@ commands:
                 TestAlgohWithExpect \
                 TestGoalWithExpect \
                 TestTealdbgWithExpect
-      - store_artifacts:
-          path: << parameters.result_path >>/<< parameters.result_subdir >>
-          destination: << parameters.result_subdir >>/combined-test-results
+            sudo rm -rf << parameters.result_path >>
 
   upload_binaries_command:
     description: save build artifacts for potential deployments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -705,11 +705,6 @@ commands:
                 TestAlgohWithExpect \
                 TestGoalWithExpect \
                 TestTealdbgWithExpect
-      - run:
-          name: Remove Results folder
-          working_directory: /tmp
-          command: |
-            sudo rm -rf << parameters.result_path >>/<< parameters.result_subdir >>
 
   upload_binaries_command:
     description: save build artifacts for potential deployments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -705,7 +705,7 @@ commands:
                 TestAlgohWithExpect \
                 TestGoalWithExpect \
                 TestTealdbgWithExpect
-            sudo rm -rf << parameters.result_path >>
+            sudo rm -rf << parameters.result_path >>/<< parameters.result_subdir >>
 
   upload_binaries_command:
     description: save build artifacts for potential deployments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -705,8 +705,7 @@ commands:
                 TestAlgohWithExpect \
                 TestGoalWithExpect \
                 TestTealdbgWithExpect
-      - run: |
-          sudo rm -rf << parameters.result_path >>/<< parameters.result_subdir >>
+            rm -rf << parameters.result_path >>/<< parameters.result_subdir >>
 
   upload_binaries_command:
     description: save build artifacts for potential deployments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -709,7 +709,7 @@ commands:
           name: Remove Results folder
           working_directory: /tmp
           command: |
-            rm -rf << parameters.result_path >>/<< parameters.result_subdir >>
+            sudo rm -rf << parameters.result_path >>/<< parameters.result_subdir >>
 
   upload_binaries_command:
     description: save build artifacts for potential deployments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ parameters:
     default: "/opt/cibuild"
   result_path:
     type: string
-    default: "/tmp/build_test_results_${CIRCLE_BUILD_NUM}"
+    default: "/tmp/build_test_results"
   valid_nightly_branch:
     type: string
     default: /hotfix\/.*/
@@ -573,9 +573,9 @@ commands:
         default: << pipeline.parameters.result_path >>
     steps:
       - run: |
-          mkdir -p << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
-          touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml
-          touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json
+          mkdir -p << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
+          touch << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml
+          touch << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json
       - run:
           name: Run build tests
           no_output_timeout: << parameters.no_output_timeout >>
@@ -597,14 +597,14 @@ commands:
             export PACKAGE_NAMES=$(echo $PACKAGES | tr -d '\n')
             export PARTITION_TOTAL=${CIRCLE_NODE_TOTAL}
             export PARTITION_ID=${CIRCLE_NODE_INDEX}
-            gotestsum --format standard-verbose --junitfile << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml --jsonfile << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" << parameters.short_test_flag >> -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 1 $PACKAGE_NAMES
+            gotestsum --format standard-verbose --junitfile << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml --jsonfile << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" << parameters.short_test_flag >> -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 1 $PACKAGE_NAMES
       - store_artifacts:
-          path: << parameters.result_path >>
+          path: << parameters.result_path >>/${CIRCLE_BUILD_NUM}
           destination: test-results
       - store_test_results:
-          path: << parameters.result_path >>
+          path: << parameters.result_path >>/${CIRCLE_BUILD_NUM}
       - persist_to_workspace:
-          root: << parameters.result_path >>
+          root: << parameters.result_path >>/${CIRCLE_BUILD_NUM}
           paths:
             - << parameters.result_subdir >>
 
@@ -638,9 +638,9 @@ commands:
         default: << pipeline.parameters.result_path >>
     steps:
       - run: |
-          mkdir -p << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
-          touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml
-          touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json
+          mkdir -p << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
+          touch << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml
+          touch << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json
       - run:
           name: Run integration tests
           no_output_timeout: << parameters.no_output_timeout >>
@@ -661,19 +661,19 @@ commands:
             scripts/buildtools/install_buildtools.sh -o "gotest.tools/gotestsum"
             export ALGOTEST=1
             export SHORTTEST=<< parameters.short_test_flag >>
-            export TEST_RESULTS=<< parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
+            export TEST_RESULTS=<< parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
             export PARTITION_TOTAL=${CIRCLE_NODE_TOTAL}
             export PARTITION_ID=${CIRCLE_NODE_INDEX}
             export PARALLEL_FLAG="-p 1"
             test/scripts/run_integration_tests.sh
 
       - store_artifacts:
-          path: << parameters.result_path >>
+          path: << parameters.result_path >>/${CIRCLE_BUILD_NUM}
           destination: test-results
       - store_test_results:
-          path: << parameters.result_path >>
+          path: << parameters.result_path >>/${CIRCLE_BUILD_NUM}
       - persist_to_workspace:
-          root: << parameters.result_path >>
+          root: << parameters.result_path >>/${CIRCLE_BUILD_NUM}
           paths:
             - << parameters.result_subdir >>
 
@@ -687,7 +687,7 @@ commands:
         type: string
     steps:
       - attach_workspace:
-          at: << parameters.result_path >>
+          at: << parameters.result_path >>/${CIRCLE_BUILD_NUM}
       - run:
           name: Check if all tests were run
           # Add to --ignored-tests when a test should _not_ be considered.
@@ -697,15 +697,15 @@ commands:
           # these tests, `check_tests.py` won't provide conflicting advice to
           # partition the parent tests.
           command: |
-            cat << parameters.result_path >>/<< parameters.result_subdir >>/**/testresults.json > << parameters.result_path >>/<< parameters.result_subdir >>/combined_testresults.json
+            cat << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/**/testresults.json > << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/combined_testresults.json
             python3 scripts/buildtools/check_tests.py \
-              --tests-results-filepath << parameters.result_path >>/<< parameters.result_subdir >>/combined_testresults.json \
+              --tests-results-filepath << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/combined_testresults.json \
               --ignored-tests \
                 TestAlgodWithExpect \
                 TestAlgohWithExpect \
                 TestGoalWithExpect \
                 TestTealdbgWithExpect
-            rm -rf << parameters.result_path >>
+            sudo rm -rf << parameters.result_path >>/${CIRCLE_BUILD_NUM}
 
   upload_binaries_command:
     description: save build artifacts for potential deployments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ parameters:
     default: "/opt/cibuild"
   result_path:
     type: string
-    default: "/tmp/build_test_results_${CIRCLE_BUILD_NUM}"
+    default: "/tmp/build_test_results"
   valid_nightly_branch:
     type: string
     default: /hotfix\/.*/
@@ -102,111 +102,111 @@ workflows:
           context: slack-secrets
           <<: *slack-fail-post-step
 
-      # - test_nightly:
-      #     name: << matrix.platform >>_test_nightly
-      #     matrix:
-      #       <<: *matrix-nightly
-      #     requires:
-      #       - << matrix.platform >>_build_nightly
-      #     context: slack-secrets
-      #     <<: *slack-fail-post-step
+      - test_nightly:
+          name: << matrix.platform >>_test_nightly
+          matrix:
+            <<: *matrix-nightly
+          requires:
+            - << matrix.platform >>_build_nightly
+          context: slack-secrets
+          <<: *slack-fail-post-step
 
-      # - integration:
-      #     name: << matrix.platform >>_integration
-      #     matrix:
-      #       <<: *matrix-default
-      #     filters:
-      #       <<: *filters-default
-      #     context: slack-secrets
-      #     <<: *slack-fail-post-step
+      - integration:
+          name: << matrix.platform >>_integration
+          matrix:
+            <<: *matrix-default
+          filters:
+            <<: *filters-default
+          context: slack-secrets
+          <<: *slack-fail-post-step
 
-      # - integration_nightly:
-      #     name: << matrix.platform >>_integration_nightly
-      #     matrix:
-      #       <<: *matrix-nightly
-      #     requires:
-      #       - << matrix.platform >>_build_nightly
-      #     context: slack-secrets
-      #     <<: *slack-fail-post-step
+      - integration_nightly:
+          name: << matrix.platform >>_integration_nightly
+          matrix:
+            <<: *matrix-nightly
+          requires:
+            - << matrix.platform >>_build_nightly
+          context: slack-secrets
+          <<: *slack-fail-post-step
 
-      # - e2e_expect:
-      #     name: << matrix.platform >>_e2e_expect
-      #     matrix:
-      #       <<: *matrix-default
-      #     filters:
-      #       <<: *filters-default
-      #     context: slack-secrets
-      #     <<: *slack-fail-post-step
+      - e2e_expect:
+          name: << matrix.platform >>_e2e_expect
+          matrix:
+            <<: *matrix-default
+          filters:
+            <<: *filters-default
+          context: slack-secrets
+          <<: *slack-fail-post-step
 
-      # - e2e_expect_nightly:
-      #     name: << matrix.platform >>_e2e_expect_nightly
-      #     matrix:
-      #       <<: *matrix-nightly
-      #     requires:
-      #       - << matrix.platform >>_build_nightly
-      #     context: slack-secrets
-      #     <<: *slack-fail-post-step
+      - e2e_expect_nightly:
+          name: << matrix.platform >>_e2e_expect_nightly
+          matrix:
+            <<: *matrix-nightly
+          requires:
+            - << matrix.platform >>_build_nightly
+          context: slack-secrets
+          <<: *slack-fail-post-step
 
-      # - e2e_subs:
-      #     name: << matrix.platform >>_e2e_subs
-      #     matrix:
-      #       <<: *matrix-default
-      #     filters:
-      #       <<: *filters-default
-      #     context: slack-secrets
-      #     <<: *slack-fail-post-step
+      - e2e_subs:
+          name: << matrix.platform >>_e2e_subs
+          matrix:
+            <<: *matrix-default
+          filters:
+            <<: *filters-default
+          context: slack-secrets
+          <<: *slack-fail-post-step
 
-      # - e2e_subs_nightly:
-      #     name: << matrix.platform >>_e2e_subs_nightly
-      #     matrix:
-      #       <<: *matrix-nightly
-      #     requires:
-      #       - << matrix.platform >>_build_nightly
-      #     context:
-      #       - slack-secrets
-      #       - aws-secrets
-      #     <<: *slack-fail-post-step
+      - e2e_subs_nightly:
+          name: << matrix.platform >>_e2e_subs_nightly
+          matrix:
+            <<: *matrix-nightly
+          requires:
+            - << matrix.platform >>_build_nightly
+          context:
+            - slack-secrets
+            - aws-secrets
+          <<: *slack-fail-post-step
 
-      # - tests_verification_job:
-      #     name: << matrix.platform >>_<< matrix.job_type >>_verification
-      #     matrix:
-      #       parameters:
-      #         platform: ["amd64", "arm64"]
-      #         job_type: ["test", "integration", "e2e_expect"]
-      #     requires:
-      #       - << matrix.platform >>_<< matrix.job_type >>
-      #     context: slack-secrets
-      #     <<: *slack-fail-post-step
+      - tests_verification_job:
+          name: << matrix.platform >>_<< matrix.job_type >>_verification
+          matrix:
+            parameters:
+              platform: ["amd64", "arm64"]
+              job_type: ["test", "integration", "e2e_expect"]
+          requires:
+            - << matrix.platform >>_<< matrix.job_type >>
+          context: slack-secrets
+          <<: *slack-fail-post-step
 
-      # - tests_verification_job_nightly:
-      #     name: << matrix.platform >>_<< matrix.job_type >>_verification
-      #     matrix:
-      #       parameters:
-      #         platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
-      #         job_type: ["test_nightly", "integration_nightly", "e2e_expect_nightly"]
-      #     requires:
-      #       - << matrix.platform >>_<< matrix.job_type >>
-      #     context: slack-secrets
-      #     <<: *slack-fail-post-step
+      - tests_verification_job_nightly:
+          name: << matrix.platform >>_<< matrix.job_type >>_verification
+          matrix:
+            parameters:
+              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
+              job_type: ["test_nightly", "integration_nightly", "e2e_expect_nightly"]
+          requires:
+            - << matrix.platform >>_<< matrix.job_type >>
+          context: slack-secrets
+          <<: *slack-fail-post-step
 
-      # - upload_binaries:
-      #     name: << matrix.platform >>_upload_binaries
-      #     matrix:
-      #       <<: *matrix-nightly
-      #     requires:
-      #       - << matrix.platform >>_test_nightly_verification
-      #       - << matrix.platform >>_integration_nightly_verification
-      #       - << matrix.platform >>_e2e_expect_nightly_verification
-      #       - << matrix.platform >>_e2e_subs_nightly
-      #     filters:
-      #       branches:
-      #         only:
-      #           - /rel\/.*/
-      #           - << pipeline.parameters.valid_nightly_branch >>
-      #     context:
-      #       - slack-secrets
-      #       - aws-secrets
-      #     <<: *slack-fail-post-step
+      - upload_binaries:
+          name: << matrix.platform >>_upload_binaries
+          matrix:
+            <<: *matrix-nightly
+          requires:
+            - << matrix.platform >>_test_nightly_verification
+            - << matrix.platform >>_integration_nightly_verification
+            - << matrix.platform >>_e2e_expect_nightly_verification
+            - << matrix.platform >>_e2e_subs_nightly
+          filters:
+            branches:
+              only:
+                - /rel\/.*/
+                - << pipeline.parameters.valid_nightly_branch >>
+          context:
+            - slack-secrets
+            - aws-secrets
+          <<: *slack-fail-post-step
 
       #- windows_x64_build
 
@@ -705,7 +705,9 @@ commands:
                 TestAlgohWithExpect \
                 TestGoalWithExpect \
                 TestTealdbgWithExpect
-            rm -rf << parameters.result_path >>
+      - store_artifacts:
+          path: << parameters.result_path >>/<< parameters.result_subdir >>
+          destination: << parameters.result_subdir >>/combined-test-results
 
   upload_binaries_command:
     description: save build artifacts for potential deployments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -705,7 +705,7 @@ commands:
                 TestAlgohWithExpect \
                 TestGoalWithExpect \
                 TestTealdbgWithExpect
-            sudo rm -rf << parameters.result_path >>/<< parameters.result_subdir >>
+            rm -rf << parameters.result_path >>/<< parameters.result_subdir >>
 
   upload_binaries_command:
     description: save build artifacts for potential deployments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ parameters:
     default: "/opt/cibuild"
   result_path:
     type: string
-    default: "/tmp/build_test_results"
+    default: "/tmp/build_test_results_<< pipeline.id >>"
   valid_nightly_branch:
     type: string
     default: /hotfix\/.*/
@@ -102,111 +102,111 @@ workflows:
           context: slack-secrets
           <<: *slack-fail-post-step
 
-      - test_nightly:
-          name: << matrix.platform >>_test_nightly
-          matrix:
-            <<: *matrix-nightly
-          requires:
-            - << matrix.platform >>_build_nightly
-          context: slack-secrets
-          <<: *slack-fail-post-step
+      # - test_nightly:
+      #     name: << matrix.platform >>_test_nightly
+      #     matrix:
+      #       <<: *matrix-nightly
+      #     requires:
+      #       - << matrix.platform >>_build_nightly
+      #     context: slack-secrets
+      #     <<: *slack-fail-post-step
 
-      - integration:
-          name: << matrix.platform >>_integration
-          matrix:
-            <<: *matrix-default
-          filters:
-            <<: *filters-default
-          context: slack-secrets
-          <<: *slack-fail-post-step
+      # - integration:
+      #     name: << matrix.platform >>_integration
+      #     matrix:
+      #       <<: *matrix-default
+      #     filters:
+      #       <<: *filters-default
+      #     context: slack-secrets
+      #     <<: *slack-fail-post-step
 
-      - integration_nightly:
-          name: << matrix.platform >>_integration_nightly
-          matrix:
-            <<: *matrix-nightly
-          requires:
-            - << matrix.platform >>_build_nightly
-          context: slack-secrets
-          <<: *slack-fail-post-step
+      # - integration_nightly:
+      #     name: << matrix.platform >>_integration_nightly
+      #     matrix:
+      #       <<: *matrix-nightly
+      #     requires:
+      #       - << matrix.platform >>_build_nightly
+      #     context: slack-secrets
+      #     <<: *slack-fail-post-step
 
-      - e2e_expect:
-          name: << matrix.platform >>_e2e_expect
-          matrix:
-            <<: *matrix-default
-          filters:
-            <<: *filters-default
-          context: slack-secrets
-          <<: *slack-fail-post-step
+      # - e2e_expect:
+      #     name: << matrix.platform >>_e2e_expect
+      #     matrix:
+      #       <<: *matrix-default
+      #     filters:
+      #       <<: *filters-default
+      #     context: slack-secrets
+      #     <<: *slack-fail-post-step
 
-      - e2e_expect_nightly:
-          name: << matrix.platform >>_e2e_expect_nightly
-          matrix:
-            <<: *matrix-nightly
-          requires:
-            - << matrix.platform >>_build_nightly
-          context: slack-secrets
-          <<: *slack-fail-post-step
+      # - e2e_expect_nightly:
+      #     name: << matrix.platform >>_e2e_expect_nightly
+      #     matrix:
+      #       <<: *matrix-nightly
+      #     requires:
+      #       - << matrix.platform >>_build_nightly
+      #     context: slack-secrets
+      #     <<: *slack-fail-post-step
 
-      - e2e_subs:
-          name: << matrix.platform >>_e2e_subs
-          matrix:
-            <<: *matrix-default
-          filters:
-            <<: *filters-default
-          context: slack-secrets
-          <<: *slack-fail-post-step
+      # - e2e_subs:
+      #     name: << matrix.platform >>_e2e_subs
+      #     matrix:
+      #       <<: *matrix-default
+      #     filters:
+      #       <<: *filters-default
+      #     context: slack-secrets
+      #     <<: *slack-fail-post-step
 
-      - e2e_subs_nightly:
-          name: << matrix.platform >>_e2e_subs_nightly
-          matrix:
-            <<: *matrix-nightly
-          requires:
-            - << matrix.platform >>_build_nightly
-          context:
-            - slack-secrets
-            - aws-secrets
-          <<: *slack-fail-post-step
+      # - e2e_subs_nightly:
+      #     name: << matrix.platform >>_e2e_subs_nightly
+      #     matrix:
+      #       <<: *matrix-nightly
+      #     requires:
+      #       - << matrix.platform >>_build_nightly
+      #     context:
+      #       - slack-secrets
+      #       - aws-secrets
+      #     <<: *slack-fail-post-step
 
-      - tests_verification_job:
-          name: << matrix.platform >>_<< matrix.job_type >>_verification
-          matrix:
-            parameters:
-              platform: ["amd64", "arm64"]
-              job_type: ["test", "integration", "e2e_expect"]
-          requires:
-            - << matrix.platform >>_<< matrix.job_type >>
-          context: slack-secrets
-          <<: *slack-fail-post-step
+      # - tests_verification_job:
+      #     name: << matrix.platform >>_<< matrix.job_type >>_verification
+      #     matrix:
+      #       parameters:
+      #         platform: ["amd64", "arm64"]
+      #         job_type: ["test", "integration", "e2e_expect"]
+      #     requires:
+      #       - << matrix.platform >>_<< matrix.job_type >>
+      #     context: slack-secrets
+      #     <<: *slack-fail-post-step
 
-      - tests_verification_job_nightly:
-          name: << matrix.platform >>_<< matrix.job_type >>_verification
-          matrix:
-            parameters:
-              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
-              job_type: ["test_nightly", "integration_nightly", "e2e_expect_nightly"]
-          requires:
-            - << matrix.platform >>_<< matrix.job_type >>
-          context: slack-secrets
-          <<: *slack-fail-post-step
+      # - tests_verification_job_nightly:
+      #     name: << matrix.platform >>_<< matrix.job_type >>_verification
+      #     matrix:
+      #       parameters:
+      #         platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
+      #         job_type: ["test_nightly", "integration_nightly", "e2e_expect_nightly"]
+      #     requires:
+      #       - << matrix.platform >>_<< matrix.job_type >>
+      #     context: slack-secrets
+      #     <<: *slack-fail-post-step
 
-      - upload_binaries:
-          name: << matrix.platform >>_upload_binaries
-          matrix:
-            <<: *matrix-nightly
-          requires:
-            - << matrix.platform >>_test_nightly_verification
-            - << matrix.platform >>_integration_nightly_verification
-            - << matrix.platform >>_e2e_expect_nightly_verification
-            - << matrix.platform >>_e2e_subs_nightly
-          filters:
-            branches:
-              only:
-                - /rel\/.*/
-                - << pipeline.parameters.valid_nightly_branch >>
-          context:
-            - slack-secrets
-            - aws-secrets
-          <<: *slack-fail-post-step
+      # - upload_binaries:
+      #     name: << matrix.platform >>_upload_binaries
+      #     matrix:
+      #       <<: *matrix-nightly
+      #     requires:
+      #       - << matrix.platform >>_test_nightly_verification
+      #       - << matrix.platform >>_integration_nightly_verification
+      #       - << matrix.platform >>_e2e_expect_nightly_verification
+      #       - << matrix.platform >>_e2e_subs_nightly
+      #     filters:
+      #       branches:
+      #         only:
+      #           - /rel\/.*/
+      #           - << pipeline.parameters.valid_nightly_branch >>
+      #     context:
+      #       - slack-secrets
+      #       - aws-secrets
+      #     <<: *slack-fail-post-step
 
       #- windows_x64_build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -705,7 +705,8 @@ commands:
                 TestAlgohWithExpect \
                 TestGoalWithExpect \
                 TestTealdbgWithExpect
-            rm -rf << parameters.result_path >>/<< parameters.result_subdir >>
+      - run: |
+          sudo rm -rf << parameters.result_path >>/<< parameters.result_subdir >>
 
   upload_binaries_command:
     description: save build artifacts for potential deployments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ parameters:
     default: "/opt/cibuild"
   result_path:
     type: string
-    default: "/tmp/build_test_results"
+    default: "/tmp/build_test_results_${CIRCLE_BUILD_NUM}"
   valid_nightly_branch:
     type: string
     default: /hotfix\/.*/
@@ -573,9 +573,9 @@ commands:
         default: << pipeline.parameters.result_path >>
     steps:
       - run: |
-          mkdir -p << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
-          touch << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml
-          touch << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json
+          mkdir -p << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
+          touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml
+          touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json
       - run:
           name: Run build tests
           no_output_timeout: << parameters.no_output_timeout >>
@@ -597,14 +597,14 @@ commands:
             export PACKAGE_NAMES=$(echo $PACKAGES | tr -d '\n')
             export PARTITION_TOTAL=${CIRCLE_NODE_TOTAL}
             export PARTITION_ID=${CIRCLE_NODE_INDEX}
-            gotestsum --format standard-verbose --junitfile << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml --jsonfile << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" << parameters.short_test_flag >> -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 1 $PACKAGE_NAMES
+            gotestsum --format standard-verbose --junitfile << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml --jsonfile << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" << parameters.short_test_flag >> -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 1 $PACKAGE_NAMES
       - store_artifacts:
-          path: << parameters.result_path >>/${CIRCLE_BUILD_NUM}
+          path: << parameters.result_path >>
           destination: test-results
       - store_test_results:
-          path: << parameters.result_path >>/${CIRCLE_BUILD_NUM}
+          path: << parameters.result_path >>
       - persist_to_workspace:
-          root: << parameters.result_path >>/${CIRCLE_BUILD_NUM}
+          root: << parameters.result_path >>
           paths:
             - << parameters.result_subdir >>
 
@@ -638,9 +638,9 @@ commands:
         default: << pipeline.parameters.result_path >>
     steps:
       - run: |
-          mkdir -p << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
-          touch << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml
-          touch << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json
+          mkdir -p << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
+          touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml
+          touch << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json
       - run:
           name: Run integration tests
           no_output_timeout: << parameters.no_output_timeout >>
@@ -661,19 +661,19 @@ commands:
             scripts/buildtools/install_buildtools.sh -o "gotest.tools/gotestsum"
             export ALGOTEST=1
             export SHORTTEST=<< parameters.short_test_flag >>
-            export TEST_RESULTS=<< parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
+            export TEST_RESULTS=<< parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}
             export PARTITION_TOTAL=${CIRCLE_NODE_TOTAL}
             export PARTITION_ID=${CIRCLE_NODE_INDEX}
             export PARALLEL_FLAG="-p 1"
             test/scripts/run_integration_tests.sh
 
       - store_artifacts:
-          path: << parameters.result_path >>/${CIRCLE_BUILD_NUM}
+          path: << parameters.result_path >>
           destination: test-results
       - store_test_results:
-          path: << parameters.result_path >>/${CIRCLE_BUILD_NUM}
+          path: << parameters.result_path >>
       - persist_to_workspace:
-          root: << parameters.result_path >>/${CIRCLE_BUILD_NUM}
+          root: << parameters.result_path >>
           paths:
             - << parameters.result_subdir >>
 
@@ -687,7 +687,7 @@ commands:
         type: string
     steps:
       - attach_workspace:
-          at: << parameters.result_path >>/${CIRCLE_BUILD_NUM}
+          at: << parameters.result_path >>
       - run:
           name: Check if all tests were run
           # Add to --ignored-tests when a test should _not_ be considered.
@@ -697,15 +697,15 @@ commands:
           # these tests, `check_tests.py` won't provide conflicting advice to
           # partition the parent tests.
           command: |
-            cat << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/**/testresults.json > << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/combined_testresults.json
+            cat << parameters.result_path >>/<< parameters.result_subdir >>/**/testresults.json > << parameters.result_path >>/<< parameters.result_subdir >>/combined_testresults.json
             python3 scripts/buildtools/check_tests.py \
-              --tests-results-filepath << parameters.result_path >>/${CIRCLE_BUILD_NUM}/<< parameters.result_subdir >>/combined_testresults.json \
+              --tests-results-filepath << parameters.result_path >>/<< parameters.result_subdir >>/combined_testresults.json \
               --ignored-tests \
                 TestAlgodWithExpect \
                 TestAlgohWithExpect \
                 TestGoalWithExpect \
                 TestTealdbgWithExpect
-            sudo rm -rf << parameters.result_path >>/${CIRCLE_BUILD_NUM}
+            rm -rf << parameters.result_path >>
 
   upload_binaries_command:
     description: save build artifacts for potential deployments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ parameters:
     default: "/opt/cibuild"
   result_path:
     type: string
-    default: "/tmp/build_test_results"
+    default: "/tmp/build_test_results_${CIRCLE_BUILD_NUM}"
   valid_nightly_branch:
     type: string
     default: /hotfix\/.*/
@@ -102,111 +102,111 @@ workflows:
           context: slack-secrets
           <<: *slack-fail-post-step
 
-      - test_nightly:
-          name: << matrix.platform >>_test_nightly
-          matrix:
-            <<: *matrix-nightly
-          requires:
-            - << matrix.platform >>_build_nightly
-          context: slack-secrets
-          <<: *slack-fail-post-step
+      # - test_nightly:
+      #     name: << matrix.platform >>_test_nightly
+      #     matrix:
+      #       <<: *matrix-nightly
+      #     requires:
+      #       - << matrix.platform >>_build_nightly
+      #     context: slack-secrets
+      #     <<: *slack-fail-post-step
 
-      - integration:
-          name: << matrix.platform >>_integration
-          matrix:
-            <<: *matrix-default
-          filters:
-            <<: *filters-default
-          context: slack-secrets
-          <<: *slack-fail-post-step
+      # - integration:
+      #     name: << matrix.platform >>_integration
+      #     matrix:
+      #       <<: *matrix-default
+      #     filters:
+      #       <<: *filters-default
+      #     context: slack-secrets
+      #     <<: *slack-fail-post-step
 
-      - integration_nightly:
-          name: << matrix.platform >>_integration_nightly
-          matrix:
-            <<: *matrix-nightly
-          requires:
-            - << matrix.platform >>_build_nightly
-          context: slack-secrets
-          <<: *slack-fail-post-step
+      # - integration_nightly:
+      #     name: << matrix.platform >>_integration_nightly
+      #     matrix:
+      #       <<: *matrix-nightly
+      #     requires:
+      #       - << matrix.platform >>_build_nightly
+      #     context: slack-secrets
+      #     <<: *slack-fail-post-step
 
-      - e2e_expect:
-          name: << matrix.platform >>_e2e_expect
-          matrix:
-            <<: *matrix-default
-          filters:
-            <<: *filters-default
-          context: slack-secrets
-          <<: *slack-fail-post-step
+      # - e2e_expect:
+      #     name: << matrix.platform >>_e2e_expect
+      #     matrix:
+      #       <<: *matrix-default
+      #     filters:
+      #       <<: *filters-default
+      #     context: slack-secrets
+      #     <<: *slack-fail-post-step
 
-      - e2e_expect_nightly:
-          name: << matrix.platform >>_e2e_expect_nightly
-          matrix:
-            <<: *matrix-nightly
-          requires:
-            - << matrix.platform >>_build_nightly
-          context: slack-secrets
-          <<: *slack-fail-post-step
+      # - e2e_expect_nightly:
+      #     name: << matrix.platform >>_e2e_expect_nightly
+      #     matrix:
+      #       <<: *matrix-nightly
+      #     requires:
+      #       - << matrix.platform >>_build_nightly
+      #     context: slack-secrets
+      #     <<: *slack-fail-post-step
 
-      - e2e_subs:
-          name: << matrix.platform >>_e2e_subs
-          matrix:
-            <<: *matrix-default
-          filters:
-            <<: *filters-default
-          context: slack-secrets
-          <<: *slack-fail-post-step
+      # - e2e_subs:
+      #     name: << matrix.platform >>_e2e_subs
+      #     matrix:
+      #       <<: *matrix-default
+      #     filters:
+      #       <<: *filters-default
+      #     context: slack-secrets
+      #     <<: *slack-fail-post-step
 
-      - e2e_subs_nightly:
-          name: << matrix.platform >>_e2e_subs_nightly
-          matrix:
-            <<: *matrix-nightly
-          requires:
-            - << matrix.platform >>_build_nightly
-          context:
-            - slack-secrets
-            - aws-secrets
-          <<: *slack-fail-post-step
+      # - e2e_subs_nightly:
+      #     name: << matrix.platform >>_e2e_subs_nightly
+      #     matrix:
+      #       <<: *matrix-nightly
+      #     requires:
+      #       - << matrix.platform >>_build_nightly
+      #     context:
+      #       - slack-secrets
+      #       - aws-secrets
+      #     <<: *slack-fail-post-step
 
-      - tests_verification_job:
-          name: << matrix.platform >>_<< matrix.job_type >>_verification
-          matrix:
-            parameters:
-              platform: ["amd64", "arm64"]
-              job_type: ["test", "integration", "e2e_expect"]
-          requires:
-            - << matrix.platform >>_<< matrix.job_type >>
-          context: slack-secrets
-          <<: *slack-fail-post-step
+      # - tests_verification_job:
+      #     name: << matrix.platform >>_<< matrix.job_type >>_verification
+      #     matrix:
+      #       parameters:
+      #         platform: ["amd64", "arm64"]
+      #         job_type: ["test", "integration", "e2e_expect"]
+      #     requires:
+      #       - << matrix.platform >>_<< matrix.job_type >>
+      #     context: slack-secrets
+      #     <<: *slack-fail-post-step
 
-      - tests_verification_job_nightly:
-          name: << matrix.platform >>_<< matrix.job_type >>_verification
-          matrix:
-            parameters:
-              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
-              job_type: ["test_nightly", "integration_nightly", "e2e_expect_nightly"]
-          requires:
-            - << matrix.platform >>_<< matrix.job_type >>
-          context: slack-secrets
-          <<: *slack-fail-post-step
+      # - tests_verification_job_nightly:
+      #     name: << matrix.platform >>_<< matrix.job_type >>_verification
+      #     matrix:
+      #       parameters:
+      #         platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
+      #         job_type: ["test_nightly", "integration_nightly", "e2e_expect_nightly"]
+      #     requires:
+      #       - << matrix.platform >>_<< matrix.job_type >>
+      #     context: slack-secrets
+      #     <<: *slack-fail-post-step
 
-      - upload_binaries:
-          name: << matrix.platform >>_upload_binaries
-          matrix:
-            <<: *matrix-nightly
-          requires:
-            - << matrix.platform >>_test_nightly_verification
-            - << matrix.platform >>_integration_nightly_verification
-            - << matrix.platform >>_e2e_expect_nightly_verification
-            - << matrix.platform >>_e2e_subs_nightly
-          filters:
-            branches:
-              only:
-                - /rel\/.*/
-                - << pipeline.parameters.valid_nightly_branch >>
-          context:
-            - slack-secrets
-            - aws-secrets
-          <<: *slack-fail-post-step
+      # - upload_binaries:
+      #     name: << matrix.platform >>_upload_binaries
+      #     matrix:
+      #       <<: *matrix-nightly
+      #     requires:
+      #       - << matrix.platform >>_test_nightly_verification
+      #       - << matrix.platform >>_integration_nightly_verification
+      #       - << matrix.platform >>_e2e_expect_nightly_verification
+      #       - << matrix.platform >>_e2e_subs_nightly
+      #     filters:
+      #       branches:
+      #         only:
+      #           - /rel\/.*/
+      #           - << pipeline.parameters.valid_nightly_branch >>
+      #     context:
+      #       - slack-secrets
+      #       - aws-secrets
+      #     <<: *slack-fail-post-step
 
       #- windows_x64_build
 
@@ -705,9 +705,7 @@ commands:
                 TestAlgohWithExpect \
                 TestGoalWithExpect \
                 TestTealdbgWithExpect
-      - store_artifacts:
-          path: << parameters.result_path >>/<< parameters.result_subdir >>
-          destination: << parameters.result_subdir >>/combined-test-results
+            rm -rf << parameters.result_path >>
 
   upload_binaries_command:
     description: save build artifacts for potential deployments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -706,7 +706,8 @@ commands:
                 TestGoalWithExpect \
                 TestTealdbgWithExpect
       - run:
-          name: Remove the tmp files
+          name: Remove Results folder
+          working_directory: /tmp
           command: |
             rm -rf << parameters.result_path >>/<< parameters.result_subdir >>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -705,6 +705,9 @@ commands:
                 TestAlgohWithExpect \
                 TestGoalWithExpect \
                 TestTealdbgWithExpect
+      - run:
+          name: Remove the tmp files
+          command: |
             rm -rf << parameters.result_path >>/<< parameters.result_subdir >>
 
   upload_binaries_command:


### PR DESCRIPTION
## Summary
We were seeing an issue where the validation tests were sometimes showing tests that were running on other branches in our self-hosted CircleCI runners.

## Details
1. Make the results path unique with the circleci's unique pipeline id. This will prevent collision of test validation results
2. Removed the stored_artifacts line on the combined results because the artifact is not used anywhere afterwards.

## Caveats
The files will stay in `/tmp` on the self-hosted runner for 3 days until it gets cleaned up.

There's an issue with trying to clean up afterwards on the mac machines. I tried adding `rm -rf << parameters.result_path >>/<< parameters.result_subdir >>` but it didn't actually clean up the subfolder. Adding `sudo rm -rf << parameters.result_path >>/<< parameters.result_subdir >>` would return errors on not finding sudo.

I don't think this is a big issue since it mostly just consists of json and xml files in the folder and since it will be in the `/tmp` folder, it will get cleaned out after 3 days. The self-hosted runners are only used for nightly tests.

## Testing
Tested on PR and Nightly. The results will be added to the newly named folder with the unique pipeline ID added at the end, i.e. `/tmp/build_test_results_72bd628e-90c0-4e1f-a98a-deabadad7797/arm64_test/0/results.xml`