### PR TITLE
Add mainnet-model custom network template

### DIFF
--- a/test/testdata/deployednettemplates/generate-recipe/generate_network_tpl.py
+++ b/test/testdata/deployednettemplates/generate-recipe/generate_network_tpl.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+generate_network_tpl.py
+
+reads a network_performance_rules file and returns a network-tpl.json that can be used by generate_recipe.py.
+
+v2 format:
+
+    ```
+    group1 group2 minrtt
+    ```
+
+    > group1 and group2 are referring to individual hosts (e.g. R1 and R2), so there should be one group per host.
+
+"""
+import argparse
+import json
+import math
+
+
+DEFAULT_NETWORK_TPL = 'network-tpl.default.json'
+DEFAULT_NUM_N = 5
+DEFAULT_NUM_NPN = 5
+
+
+def main():
+    args = parse_args()
+
+    # initialize network_tpl with defaults
+    network_tpl = get_default_network_tpl()
+
+    groups = []
+
+    if args.network_rules_file is not None:
+        network_tpl_from_rules = gen_network_tpl_from_rules_v2(args.network_rules_file)
+        # merging overrides groups, so save the defaults before merging
+        default_groups = network_tpl['groups']
+        merge(network_tpl_from_rules, network_tpl)
+        for v in default_groups:
+            network_tpl['groups'].append(v)
+
+    # write network_tpl to file
+    with open(args.out, 'w') as out:
+        out.write(json.dumps(network_tpl, indent=2))
+        out.write('\n')
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Generate a network-tpl.json file for generate_network.py'
+    )
+    parser.add_argument('-n', '--network-rules-file', help='Path of network_performance_rules file', required=True)
+    parser.add_argument('-o', '--out', help='Path to write output', default='network-tpl.json')
+    return parser.parse_args()
+
+
+def get_default_network_tpl():
+    return {
+        'network': {
+            'wallets': 5
+        },
+        'instances': {
+            'relays': {
+                'config': './configs/relay.json',
+                'type': 'c5.xlarge',
+                'count': 5
+            },
+            'participatingNodes': {
+                'config': './configs/node.json',
+                'type': 'c5.xlarge',
+                'count': 5
+            },
+            'nonParticipatingNodes': {
+                'config': './configs/nonPartNode.json',
+                'type': 'c5.xlarge',
+                'count': 5
+            }
+        },
+        'groups': [
+            {
+                'name': 'n',
+                'percent': {
+                    'relays': 0,
+                    'nonParticipatingNodes': 100,
+                    'participatingNodes': 100
+                },
+                'region': 'us-west-1'
+            }
+        ]
+    }
+
+    with open(DEFAULT_NETWORK_TPL) as default_tpl:
+        return json.load(default_tpl)
+
+
+def merge(source, destination):
+    for key, value in source.items():
+        if isinstance(value, dict):
+            # get node or create one
+            node = destination.setdefault(key, {})
+            merge(value, node)
+        else:
+            destination[key] = value
+
+    return destination
+
+
+def gen_network_tpl_from_rules_v2(path):
+    """
+        Loads network_performance_rules v2 file, and generates a network-tpl.json file
+        @param path: the filesystem path to the network_performance_rules file
+        @return list of network-tpl.json groups
+    """
+    groups = []
+
+    with open(path) as network_performance_rules:
+        npr = network_performance_rules.readlines()
+
+    found = []
+    num_relays = 0
+    num_npn = 0
+    num_n = 0
+
+    # loop over rules and get counts of types of instances
+    for rule in npr:
+        # algonet retrieves groups from terraform-inventory and they are lowercase
+        name = rule.split(' ')[0].lower()
+        relays = 0
+        nonParticipatingNodes = 0
+        participatingNodes = 0
+
+        if name in found:
+            continue
+
+        found.append(name)
+
+        if name.startswith('r'):
+            num_relays += 1
+        elif name.startswith('npn'):
+            num_npn += 1
+        else:
+            num_n += 1
+
+    if num_n == 0:
+        num_n = DEFAULT_NUM_N
+
+    if num_npn == 0:
+        num_npn = DEFAULT_NUM_NPN
+
+    for item in found:
+        group = {'name': item}
+        percent = {}
+        if item.startswith('r'):
+            percent = {
+                'relays': math.ceil(1 / num_relays * 100),
+                'nonParticipatingNodes': 0,
+                'participatingNodes': 0
+            }
+        elif item.startswith('npn'):
+            percent = {
+                'relays': 0,
+                'nonParticipatingNodes': math.ceil(1 / num_npn * 100),
+                'participatingNodes': 0
+            }
+        else:
+            percent = {
+                'relays': 0,
+                'nonParticipatingNodes': 0,
+                'participatingNodes': math.ceil(1 / num_n * 100)
+            }
+
+        group['percent'] = percent
+        group['region'] = 'us-west-1'
+
+        groups.append(group)
+
+    network = {
+        'relays': num_relays,
+        'nodes': num_n,
+        'npn': num_npn
+    }
+
+    instances = {
+        'relays': {
+            'count': num_relays
+        },
+        'participatingNodes': {
+            'count': num_n
+        },
+        'nonParticipatingNodes': {
+            'count': num_npn
+        }
+    }
+
+    return {
+        'network': network,
+        'instances': instances,
+        'groups': groups
+    }
+
+
+if __name__ == '__main__':
+    main()

--- a/test/testdata/deployednettemplates/recipes/custom/network_templates/mainnet-model.json
+++ b/test/testdata/deployednettemplates/recipes/custom/network_templates/mainnet-model.json
@@ -1,0 +1,1080 @@
+{
+  "network": {
+    "wallets": 5,
+    "relays": 116,
+    "nodes": 5,
+    "npn": 5
+  },
+  "instances": {
+    "relays": {
+      "config": "./configs/relay.json",
+      "type": "c5.xlarge",
+      "count": 116
+    },
+    "participatingNodes": {
+      "config": "./configs/node.json",
+      "type": "c5.xlarge",
+      "count": 5
+    },
+    "nonParticipatingNodes": {
+      "config": "./configs/nonPartNode.json",
+      "type": "c5.xlarge",
+      "count": 5
+    }
+  },
+  "groups": [
+    {
+      "name": "r1",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r2",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r3",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r4",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r5",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r6",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r7",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r8",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r9",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r10",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r11",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r12",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r13",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r14",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r15",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r16",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r17",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r116",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r18",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r19",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r20",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r21",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r113",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r22",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r23",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r24",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r25",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r26",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r27",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r28",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r29",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r30",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r31",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r32",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r33",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r34",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r35",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r36",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r37",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r38",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r39",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r40",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r41",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r42",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r43",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r44",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r45",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r46",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r47",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r48",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r49",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r115",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r50",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r51",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r52",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r53",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r54",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r55",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r56",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r57",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r58",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r59",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r60",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r61",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r62",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r63",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r64",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r65",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r66",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r67",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r68",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r69",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r70",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r114",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r71",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r72",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r73",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r74",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r75",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r76",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r77",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r78",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r79",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r80",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r81",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r82",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r83",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r84",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r85",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r86",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r87",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r88",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r89",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r90",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r91",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r92",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r93",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r94",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r95",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r96",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r97",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r98",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r99",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r100",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r101",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r102",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r103",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r104",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r105",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r106",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r107",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r108",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r109",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r110",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r111",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "r112",
+      "percent": {
+        "relays": 1,
+        "nonParticipatingNodes": 0,
+        "participatingNodes": 0
+      },
+      "region": "us-west-1"
+    },
+    {
+      "name": "n",
+      "percent": {
+        "relays": 0,
+        "nonParticipatingNodes": 100,
+        "participatingNodes": 100
+      },
+      "region": "us-west-1"
+    }
+  ]
+}


### PR DESCRIPTION
(this is from algolucky's forked repo + branch)
## Summary
- Adds a python script that generates a json template that can be used by the "custom" recipe.
- Saves the newly generated template in `test/testdata/deployednettemplates/recipes/custom/network_templates/mainnet-model.json`

## Test Plan

- Tested out using it via Jenkins pipeline and running the python script manually.
