### PR TITLE
agreement: update AttachReceivedAt to handle compound (PP) messages

### DIFF
--- a/agreement/demux.go
+++ b/agreement/demux.go
@@ -201,7 +201,7 @@ func (d *demux) next(s *Service, deadline time.Duration, fastDeadline time.Durat
 		switch e.t() {
 		case payloadVerified:
 			e = e.(messageEvent).AttachValidatedAt(s.Clock.Since())
-		case payloadPresent:
+		case payloadPresent, votePresent:
 			e = e.(messageEvent).AttachReceivedAt(s.Clock.Since())
 		}
 	}()

--- a/agreement/msgp_gen.go
+++ b/agreement/msgp_gen.go
@@ -3791,7 +3791,7 @@ func (z *proposal) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0004Len := uint32(29)
-	var zb0004Mask uint64 /* 39 bits */
+	var zb0004Mask uint64 /* 38 bits */
 	if (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsLevel == 0 {
 		zb0004Len--
 		zb0004Mask |= 0x40
@@ -3854,59 +3854,59 @@ func (z *proposal) MarshalMsg(b []byte) (o []byte) {
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.Round.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x800000
+		zb0004Mask |= 0x400000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRecalculationRound.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x1000000
+		zb0004Mask |= 0x800000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsPool.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x2000000
+		zb0004Mask |= 0x1000000
 	}
 	if (*z).unauthenticatedProposal.SeedProof.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x4000000
+		zb0004Mask |= 0x2000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.Seed.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x8000000
+		zb0004Mask |= 0x4000000
 	}
 	if len((*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking) == 0 {
 		zb0004Len--
-		zb0004Mask |= 0x10000000
+		zb0004Mask |= 0x8000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.TxnCounter == 0 {
 		zb0004Len--
-		zb0004Mask |= 0x20000000
+		zb0004Mask |= 0x10000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.TimeStamp == 0 {
 		zb0004Len--
-		zb0004Mask |= 0x40000000
+		zb0004Mask |= 0x20000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.TxnCommitments.NativeSha512_256Commitment.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x80000000
+		zb0004Mask |= 0x40000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.TxnCommitments.Sha256Commitment.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x100000000
+		zb0004Mask |= 0x80000000
 	}
 	if (*z).unauthenticatedProposal.Block.Payset.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x200000000
+		zb0004Mask |= 0x100000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeDelay.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x400000000
+		zb0004Mask |= 0x200000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradePropose.MsgIsZero() {
 		zb0004Len--
-		zb0004Mask |= 0x800000000
+		zb0004Mask |= 0x400000000
 	}
 	if (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeApprove == false {
 		zb0004Len--
-		zb0004Mask |= 0x1000000000
+		zb0004Mask |= 0x800000000
 	}
 	// variable map header, size zb0004Len
 	o = msgp.AppendMapHeader(o, zb0004Len)
@@ -3993,32 +3993,32 @@ func (z *proposal) MarshalMsg(b []byte) (o []byte) {
 			o = append(o, 0xa4, 0x72, 0x61, 0x74, 0x65)
 			o = msgp.AppendUint64(o, (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRate)
 		}
-		if (zb0004Mask & 0x800000) == 0 { // if not empty
+		if (zb0004Mask & 0x400000) == 0 { // if not empty
 			// string "rnd"
 			o = append(o, 0xa3, 0x72, 0x6e, 0x64)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.Round.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x1000000) == 0 { // if not empty
+		if (zb0004Mask & 0x800000) == 0 { // if not empty
 			// string "rwcalr"
 			o = append(o, 0xa6, 0x72, 0x77, 0x63, 0x61, 0x6c, 0x72)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRecalculationRound.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x2000000) == 0 { // if not empty
+		if (zb0004Mask & 0x1000000) == 0 { // if not empty
 			// string "rwd"
 			o = append(o, 0xa3, 0x72, 0x77, 0x64)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsPool.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x4000000) == 0 { // if not empty
+		if (zb0004Mask & 0x2000000) == 0 { // if not empty
 			// string "sdpf"
 			o = append(o, 0xa4, 0x73, 0x64, 0x70, 0x66)
 			o = (*z).unauthenticatedProposal.SeedProof.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x8000000) == 0 { // if not empty
+		if (zb0004Mask & 0x4000000) == 0 { // if not empty
 			// string "seed"
 			o = append(o, 0xa4, 0x73, 0x65, 0x65, 0x64)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.Seed.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x10000000) == 0 { // if not empty
+		if (zb0004Mask & 0x8000000) == 0 { // if not empty
 			// string "spt"
 			o = append(o, 0xa3, 0x73, 0x70, 0x74)
 			if (*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking == nil {
@@ -4038,42 +4038,42 @@ func (z *proposal) MarshalMsg(b []byte) (o []byte) {
 				o = zb0002.MarshalMsg(o)
 			}
 		}
-		if (zb0004Mask & 0x20000000) == 0 { // if not empty
+		if (zb0004Mask & 0x10000000) == 0 { // if not empty
 			// string "tc"
 			o = append(o, 0xa2, 0x74, 0x63)
 			o = msgp.AppendUint64(o, (*z).unauthenticatedProposal.Block.BlockHeader.TxnCounter)
 		}
-		if (zb0004Mask & 0x40000000) == 0 { // if not empty
+		if (zb0004Mask & 0x20000000) == 0 { // if not empty
 			// string "ts"
 			o = append(o, 0xa2, 0x74, 0x73)
 			o = msgp.AppendInt64(o, (*z).unauthenticatedProposal.Block.BlockHeader.TimeStamp)
 		}
-		if (zb0004Mask & 0x80000000) == 0 { // if not empty
+		if (zb0004Mask & 0x40000000) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.TxnCommitments.NativeSha512_256Commitment.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x100000000) == 0 { // if not empty
+		if (zb0004Mask & 0x80000000) == 0 { // if not empty
 			// string "txn256"
 			o = append(o, 0xa6, 0x74, 0x78, 0x6e, 0x32, 0x35, 0x36)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.TxnCommitments.Sha256Commitment.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x200000000) == 0 { // if not empty
+		if (zb0004Mask & 0x100000000) == 0 { // if not empty
 			// string "txns"
 			o = append(o, 0xa4, 0x74, 0x78, 0x6e, 0x73)
 			o = (*z).unauthenticatedProposal.Block.Payset.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x400000000) == 0 { // if not empty
+		if (zb0004Mask & 0x200000000) == 0 { // if not empty
 			// string "upgradedelay"
 			o = append(o, 0xac, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x64, 0x65, 0x6c, 0x61, 0x79)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeDelay.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x800000000) == 0 { // if not empty
+		if (zb0004Mask & 0x400000000) == 0 { // if not empty
 			// string "upgradeprop"
 			o = append(o, 0xab, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x70, 0x72, 0x6f, 0x70)
 			o = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradePropose.MarshalMsg(o)
 		}
-		if (zb0004Mask & 0x1000000000) == 0 { // if not empty
+		if (zb0004Mask & 0x800000000) == 0 { // if not empty
 			// string "upgradeyes"
 			o = append(o, 0xaa, 0x75, 0x70, 0x67, 0x72, 0x61, 0x64, 0x65, 0x79, 0x65, 0x73)
 			o = msgp.AppendBool(o, (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeApprove)

--- a/agreement/player_test.go
+++ b/agreement/player_test.go
@@ -3244,6 +3244,36 @@ func TestPlayerRetainsReceivedValidatedAt(t *testing.T) {
 	pWhite, pM, helper := setupP(t, r-1, p, soft)
 	pP, pV := helper.MakeRandomProposalPayload(t, r-1)
 
+	// send voteVerified message
+	vVote := helper.MakeVerifiedVote(t, 0, r-1, p, propose, *pV)
+	inMsg := messageEvent{T: voteVerified, Input: message{Vote: vVote, UnauthenticatedVote: vVote.u()}}
+	err, panicErr := pM.transition(inMsg)
+	require.NoError(t, err)
+	require.NoError(t, panicErr)
+
+	// send payloadPresent message
+	m := message{UnauthenticatedProposal: pP.u()}
+	inMsg = messageEvent{T: payloadPresent, Input: m}
+	inMsg = inMsg.AttachReceivedAt(time.Second)
+	err, panicErr = pM.transition(inMsg)
+	require.NoError(t, err)
+	require.NoError(t, panicErr)
+
+	assertCorrectReceivedAtSet(t, pWhite, pM, helper, r, p, pP, pV, m)
+}
+
+// test that ReceivedAt and ValidateAt timing information are retained in proposalStore
+// when the payloadPresent (as part of the CompoundMessage encoding used by PP messages)
+// and payloadVerified events are processed, and that both timings
+// are available when the ensureAction is called for the block.
+func TestPlayerRetainsReceivedValidatedAtPP(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	const r = round(20239)
+	const p = period(1001)
+	pWhite, pM, helper := setupP(t, r-1, p, soft)
+	pP, pV := helper.MakeRandomProposalPayload(t, r-1)
+
 	// create a PP message for an arbitrary proposal/payload similar to setupCompoundMessage
 	vVote := helper.MakeVerifiedVote(t, 0, r-1, p, propose, *pV)
 	voteMsg := message{Vote: vVote, UnauthenticatedVote: vVote.u()}
@@ -3265,15 +3295,19 @@ func TestPlayerRetainsReceivedValidatedAt(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, panicErr)
 
-	// make sure payload verify requests
-	verifyEvent = ev(cryptoAction{T: verifyPayload, M: proposalMsg})
-	tr := pM.getTrace()
-	require.Truef(t, tr.Contains(verifyEvent), "Player should verify payload: %s", tr.String())
+	assertCorrectReceivedAtSet(t, pWhite, pM, helper, r, p, pP, pV, proposalMsg)
+}
+
+func assertCorrectReceivedAtSet(t *testing.T, pWhite *player, pM ioAutomata, helper *voteMakerHelper,
+	r round, p period, pP *proposal, pV *proposalValue, m message) {
+	// make sure payload verify request
+	verifyEvent := ev(cryptoAction{T: verifyPayload, M: m}) // , TaskIndex: 0}
+	require.Truef(t, pM.getTrace().Contains(verifyEvent), "Player should verify payload")
 
 	// payloadVerified
-	inMsg = messageEvent{T: payloadVerified, Input: message{Proposal: *pP}, Proto: ConsensusVersionView{Version: protocol.ConsensusCurrentVersion}}
+	inMsg := messageEvent{T: payloadVerified, Input: message{Proposal: *pP}, Proto: ConsensusVersionView{Version: protocol.ConsensusCurrentVersion}}
 	inMsg = inMsg.AttachValidatedAt(2 * time.Second) // call AttachValidatedAt like demux would
-	err, panicErr = pM.transition(inMsg)
+	err, panicErr := pM.transition(inMsg)
 	require.NoError(t, err)
 	require.NoError(t, panicErr)
 

--- a/agreement/player_test.go
+++ b/agreement/player_test.go
@@ -3286,7 +3286,7 @@ func TestPlayerRetainsReceivedValidatedAtPP(t *testing.T) {
 	require.NoError(t, panicErr)
 
 	// make sure vote verify requests
-	verifyEvent := ev(cryptoAction{T: verifyVote, M: voteMsg, TaskIndex: 0})
+	verifyEvent := ev(cryptoAction{T: verifyVote, M: voteMsg, Round: r - 1, Period: p, Step: propose, TaskIndex: 1})
 	require.Truef(t, pM.getTrace().Contains(verifyEvent), "Player should verify vote")
 
 	// send voteVerified
@@ -3301,7 +3301,7 @@ func TestPlayerRetainsReceivedValidatedAtPP(t *testing.T) {
 func assertCorrectReceivedAtSet(t *testing.T, pWhite *player, pM ioAutomata, helper *voteMakerHelper,
 	r round, p period, pP *proposal, pV *proposalValue, m message) {
 	// make sure payload verify request
-	verifyEvent := ev(cryptoAction{T: verifyPayload, M: m}) // , TaskIndex: 0}
+	verifyEvent := ev(cryptoAction{T: verifyPayload, M: m, Round: r - 1, Period: p, Step: propose, TaskIndex: 0})
 	require.Truef(t, pM.getTrace().Contains(verifyEvent), "Player should verify payload")
 
 	// payloadVerified

--- a/agreement/proposal.go
+++ b/agreement/proposal.go
@@ -99,11 +99,6 @@ type proposal struct {
 	// validated (and thus was ready to be delivered to the state
 	// machine), relative to the zero of that round.
 	validatedAt time.Duration
-
-	// receivedAt indicates the time at which this proposal was
-	// delivered to the agreement package (as a messageEvent),
-	// relative to the zero of that round.
-	receivedAt time.Duration
 }
 
 func makeProposal(ve ValidatedBlock, pf crypto.VrfProof, origPer period, origProp basics.Address) proposal {


### PR DESCRIPTION
## Summary

PP messages in the first period are compound messages, containing both a vote and a proposal, which are converted into a special `messageEvent` by `setupCompoundMessage()` with a structure like this:
```
messageEvent{
    T: votePresent, 
    Input: voteMsg, 
    Tail: &messageEvent{
        T: payloadPresent, 
        Input: proposalMsg}}
```
In TestPlayerRetainsReceivedValidatedAt in #5041 I was only testing sending in two separate vote and proposal `messageEvent`s, not a single compound `messageEvent` like this, and so I missed this important case when attaching receivedAt timings.

## Test Plan

- [x] update TestPlayerRetainsReceivedValidatedAt to handle this compound message case.
- [x] add back additional test exercising separate messageEvents too, as was tested before. 
- [ ] ~~add some additional player tests that send in messageEvents with non-nil `Tail` fields for additional coverage~~ Will do this in separate PR — requires updating the rest of player_test.go
- [ ] ~~update testing helper function `getTrace().Contains(ev)` to do a more thorough job comparing all the fields of expected events/actions against the trace, instead of just the action type. This would have helped me catch this more quickly (for example complaining that the verifyVote action's TaskIndex was not the same as the expected value I was passing into `Contains()`)~~ Would require updating other player_test.go tests that rely on the current getTrace().Contains() behavior, will do in separate PR