### PR TITLE
network: add OutgoingMessage disconnectReason field

### DIFF
--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -3255,10 +3255,22 @@ func TestWebsocketNetworkTXMessageOfInterestPN(t *testing.T) {
 // Plan:
 // Network A will be sending messages to network B.
 // Network B will respond with another message for the first 4 messages. When it receive the 5th message, it would close the connection.
-// We want to get an event with disconnectRequestReceived
 func TestWebsocketDisconnection(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
+	// We want to get an event with disconnectRequestReceived
+	testWebsocketDisconnection(t, func(wn *WebsocketNetwork, _ *OutgoingMessage) {
+		wn.DisconnectPeers()
+	}, disconnectRequestReceived)
+
+	// We want to get an event with the provided reason
+	testWebsocketDisconnection(t, func(_ *WebsocketNetwork, out *OutgoingMessage) {
+		out.Action = Disconnect
+		out.reason = "MyCustomDisconnectReason"
+	}, "MyCustomDisconnectReason")
+}
+
+func testWebsocketDisconnection(t *testing.T, disconnectFunc func(wn *WebsocketNetwork, out *OutgoingMessage), expectedDisconnectReason disconnectReason) {
 	netA := makeTestWebsocketNode(t)
 	netA.config.GossipFanout = 1
 	netA.config.EnablePingHandler = false


### PR DESCRIPTION
## Summary

Following up on feedback from #4695, this adds an unexported disconnectReason field to the OutgoingMessage field for use with tracking internal network handlers' reasons for disconnecting.

## Test Plan

Extended TestWebsocketDisconnection to use this new feature and assert the correct reason was reported.