### PR TITLE
Enhancement: use assert.Eventually to wait for peering to settle

### DIFF
--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -1322,7 +1322,7 @@ func TestPeeringWithIdentityChallenge(t *testing.T) {
 	assert.Equal(t, 2, netA.identityTracker.(*mockIdentityTracker).getSetCount())
 	assert.Equal(t, 1, netA.identityTracker.(*mockIdentityTracker).getInsertCount())
 	// it is possible for NetB to be in the process of doing addPeer while
-	// the underlying conneciton is being closed. In this case, the read loop
+	// the underlying connection is being closed. In this case, the read loop
 	// on the peer will detect and close the peer. Since this is asynchronous,
 	// we wait and check regularly to allow the connection to settle
 	assert.Eventually(
@@ -1879,7 +1879,7 @@ func TestPeeringWithBadIdentityChallengeResponse(t *testing.T) {
 		assert.Equal(t, tc.totalOutA, len(netA.GetPeers(PeersConnectedOut)))
 		assert.Equal(t, tc.totalOutB, len(netB.GetPeers(PeersConnectedOut)))
 		// it is possible for NetB to be in the process of doing addPeer while
-		// the underlying conneciton is being closed. In this case, the read loop
+		// the underlying connection is being closed. In this case, the read loop
 		// on the peer will detect and close the peer. Since this is asynchronous,
 		// we wait and check regularly to allow the connection to settle
 		assert.Eventually(
@@ -2038,7 +2038,7 @@ func TestPeeringWithBadIdentityVerification(t *testing.T) {
 		assert.Equal(t, tc.totalOutA, len(netA.GetPeers(PeersConnectedOut)))
 		assert.Equal(t, tc.totalOutB, len(netB.GetPeers(PeersConnectedOut)))
 		// it is possible for NetB to be in the process of doing addPeer while
-		// the underlying conneciton is being closed. In this case, the read loop
+		// the underlying connection is being closed. In this case, the read loop
 		// on the peer will detect and close the peer. Since this is asynchronous,
 		// we wait and check regularly to allow the connection to settle
 		assert.Eventually(


### PR DESCRIPTION
Use `assert.Eventually` in three places where we need to wait for an asynchronous test value.

Explanation:
Let netA be the "initiating" peer who calls tryConnect
Let netB be the "receiving" peer who calls serveHTTP

In identity peering (and all peering), if netA disconnects from netB at any point after netB has sent the first httpResponse, netB continues on to addPeer. This is acceptable, since the underlying connection on the peer is closed, and the readloop on the peer will discover this and clean up the peering.

However, in testing, we initiate a peering and then check that the incoming/outgoing peer quantities are correct. This check can sometimes fail if the assert happens before the peer has been cleaned up. This was observed once in PR, where it was resolved with slightly longer timeouts, after which point it could not be reproduced. However, we've now seen it in a nightly test. We can confirm in all these cases that the connection between peers is closed because associated logging shows us that the connection is closed.

This introduces an eventual check which waits for *up to* 5 seconds before determining the test has failed. This provides ample time for the peerings to settle. "eventually" will also advance the test early if the condition check passes. This check is applied only to places where this `addPeer(closedConn)` may happen (situations where netB responds and netA closes).

### Testing
Ran unit tests locally -> still pass