### PR TITLE
Draft: Refactor Test-Only Storage Packaging

### DIFF
--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -267,7 +267,8 @@ func (au *accountUpdates) allBalances(rnd basics.Round) (bals map[basics.Address
 		if err != nil {
 			return err
 		}
-		bals, err0 = arw.AccountsAllTest()
+		testArw := arw.(store.TestAccountsReaderExt)
+		bals, err0 = testArw.AccountsAllTest()
 		return err0
 	})
 	if err != nil {
@@ -1005,11 +1006,12 @@ func TestListCreatables(t *testing.T) {
 		proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
 		accts := make(map[basics.Address]basics.AccountData)
-		_ = tx.AccountsInitTest(t, accts, protocol.ConsensusCurrentVersion)
+		testTx := tx.(store.TransactionTestScope)
+		_ = testTx.AccountsInitTest(t, accts, protocol.ConsensusCurrentVersion)
 		require.NoError(t, err)
 
 		au := &accountUpdates{}
-		au.accountsq, err = tx.MakeAccountsOptimizedReader()
+		au.accountsq, err = testTx.MakeAccountsOptimizedReader()
 		require.NoError(t, err)
 
 		// ******* All results are obtained from the cache. Empty database *******

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -2346,7 +2346,8 @@ func TestLedgerReloadTxTailHistoryAccess(t *testing.T) {
 
 	// drop new tables
 	// reloadLedger should migrate db properly
-	err = l.trackerDBs.ResetToV6Test(context.Background())
+	testStore := l.trackerDBs.(store.TestTrackerStore)
+	err = testStore.ResetToV6Test(context.Background())
 	require.NoError(t, err)
 
 	err = l.reloadLedger()
@@ -2633,7 +2634,8 @@ func TestLedgerMigrateV6ShrinkDeltas(t *testing.T) {
 	cfg.MaxAcctLookback = shorterLookback
 	store.AccountDBVersion = 7
 	// delete tables since we want to check they can be made from other data
-	err = trackerDB.ResetToV6Test(context.Background())
+	testTrackerDB := trackerDB.(store.TestTrackerStore)
+	err = testTrackerDB.ResetToV6Test(context.Background())
 	require.NoError(t, err)
 
 	l2, err := OpenLedger(log, dbName, inMem, genesisInitState, cfg)

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -2286,6 +2286,7 @@ func TestLedgerReloadTxTailHistoryAccess(t *testing.T) {
 	// reset tables and re-init again, similary to the catchpount apply code
 	// since the ledger has only genesis accounts, this recreates them
 	err = l.trackerDBs.Batch(func(ctx context.Context, tx store.BatchScope) error {
+		testTx := tx.(store.BatchTestScope)
 		arw, err := tx.MakeAccountsWriter()
 		if err != nil {
 			return err
@@ -2304,12 +2305,12 @@ func TestLedgerReloadTxTailHistoryAccess(t *testing.T) {
 			DbPathPrefix:      l.catchpoint.dbDirectory,
 			BlockDb:           l.blockDBs,
 		}
-		_, err0 = tx.RunMigrations(ctx, tp, l.log, preReleaseDBVersion /*target database version*/)
+		_, err0 = testTx.RunMigrations(ctx, tp, l.log, preReleaseDBVersion /*target database version*/)
 		if err0 != nil {
 			return err0
 		}
 
-		if err0 := tx.AccountsUpdateSchemaTest(ctx); err != nil {
+		if err0 := testTx.AccountsUpdateSchemaTest(ctx); err != nil {
 			return err0
 		}
 
@@ -2455,7 +2456,8 @@ func TestLedgerMigrateV6ShrinkDeltas(t *testing.T) {
 	}()
 	// create tables so online accounts can still be written
 	err = trackerDB.Batch(func(ctx context.Context, tx store.BatchScope) error {
-		if err := tx.AccountsUpdateSchemaTest(ctx); err != nil {
+		testTx := tx.(store.BatchTestScope)
+		if err := testTx.AccountsUpdateSchemaTest(ctx); err != nil {
 			return err
 		}
 		return nil

--- a/ledger/store/accountsV2.go
+++ b/ledger/store/accountsV2.go
@@ -22,7 +22,6 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
-	"testing"
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
@@ -30,7 +29,6 @@ import (
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/util/db"
-	"github.com/stretchr/testify/require"
 )
 
 type accountsV2Reader struct {
@@ -84,81 +82,6 @@ func (r *accountsV2Reader) AccountsTotals(ctx context.Context, catchpointStaging
 		&totals.RewardsLevel)
 
 	return
-}
-
-// AccountsAllTest iterates the account table and returns a map of the data
-// It is meant only for testing purposes - it is heavy and has no production use case.
-func (r *accountsV2Reader) AccountsAllTest() (bals map[basics.Address]basics.AccountData, err error) {
-	rows, err := r.q.Query("SELECT rowid, address, data FROM accountbase")
-	if err != nil {
-		return
-	}
-	defer rows.Close()
-
-	bals = make(map[basics.Address]basics.AccountData)
-	for rows.Next() {
-		var addrbuf []byte
-		var buf []byte
-		var rowid sql.NullInt64
-		err = rows.Scan(&rowid, &addrbuf, &buf)
-		if err != nil {
-			return
-		}
-
-		var data BaseAccountData
-		err = protocol.Decode(buf, &data)
-		if err != nil {
-			return
-		}
-
-		var addr basics.Address
-		if len(addrbuf) != len(addr) {
-			err = fmt.Errorf("account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
-			return
-		}
-		copy(addr[:], addrbuf)
-
-		var ad basics.AccountData
-		ad, err = r.LoadFullAccount(context.Background(), "resources", addr, rowid.Int64, data)
-		if err != nil {
-			return
-		}
-
-		bals[addr] = ad
-	}
-
-	err = rows.Err()
-	return
-}
-
-func (r *accountsV2Reader) CheckCreatablesTest(t *testing.T,
-	iteration int,
-	expectedDbImage map[basics.CreatableIndex]ledgercore.ModifiedCreatable) {
-	stmt, err := r.q.Prepare("SELECT asset, creator, ctype FROM assetcreators")
-	require.NoError(t, err)
-
-	defer stmt.Close()
-	rows, err := stmt.Query()
-	if err != sql.ErrNoRows {
-		require.NoError(t, err)
-	}
-	defer rows.Close()
-	counter := 0
-	for rows.Next() {
-		counter++
-		mc := ledgercore.ModifiedCreatable{}
-		var buf []byte
-		var asset basics.CreatableIndex
-		err := rows.Scan(&asset, &buf, &mc.Ctype)
-		require.NoError(t, err)
-		copy(mc.Creator[:], buf)
-
-		require.NotNil(t, expectedDbImage[asset])
-		require.Equal(t, expectedDbImage[asset].Creator, mc.Creator)
-		require.Equal(t, expectedDbImage[asset].Ctype, mc.Ctype)
-		require.True(t, expectedDbImage[asset].Created)
-	}
-	require.Equal(t, len(expectedDbImage), counter)
 }
 
 // AccountsRound returns the tracker balances round number

--- a/ledger/store/interface.go
+++ b/ledger/store/interface.go
@@ -18,7 +18,6 @@ package store
 
 import (
 	"context"
-	"testing"
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
@@ -90,8 +89,6 @@ type AccountsReaderExt interface {
 	TotalAccounts(ctx context.Context) (total uint64, err error)
 	TotalKVs(ctx context.Context) (total uint64, err error)
 	AccountsRound() (rnd basics.Round, err error)
-	AccountsAllTest() (bals map[basics.Address]basics.AccountData, err error)
-	CheckCreatablesTest(t *testing.T, iteration int, expectedDbImage map[basics.CreatableIndex]ledgercore.ModifiedCreatable)
 	LookupOnlineAccountDataByAddress(addr basics.Address) (rowid int64, data []byte, err error)
 	AccountsOnlineTop(rnd basics.Round, offset uint64, n uint64, proto config.ConsensusParams) (map[basics.Address]*ledgercore.OnlineAccount, error)
 	AccountsOnlineRoundParams() (onlineRoundParamsData []ledgercore.OnlineRoundParamsData, endRound basics.Round, err error)

--- a/ledger/store/store.go
+++ b/ledger/store/store.go
@@ -43,11 +43,7 @@ type BatchScope interface {
 	MakeAccountsWriter() (AccountsWriterExt, error)
 	MakeAccountsOptimizedWriter(hasAccounts, hasResources, hasKvPairs, hasCreatables bool) (AccountsWriter, error)
 
-	RunMigrations(ctx context.Context, params TrackerDBParams, log logging.Logger, targetVersion int32) (mgr TrackerDBInitParams, err error)
 	ResetTransactionWarnDeadline(ctx context.Context, deadline time.Time) (prevDeadline time.Time, err error)
-
-	AccountsInitTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool)
-	AccountsUpdateSchemaTest(ctx context.Context) (err error)
 }
 type sqlBatchScope struct {
 	tx *sql.Tx
@@ -297,20 +293,8 @@ func (bs sqlBatchScope) MakeAccountsOptimizedWriter(hasAccounts, hasResources, h
 	return MakeAccountsSQLWriter(bs.tx, hasAccounts, hasResources, hasKvPairs, hasCreatables)
 }
 
-func (bs sqlBatchScope) RunMigrations(ctx context.Context, params TrackerDBParams, log logging.Logger, targetVersion int32) (mgr TrackerDBInitParams, err error) {
-	return RunMigrations(ctx, bs.tx, params, log, targetVersion)
-}
-
 func (bs sqlBatchScope) ResetTransactionWarnDeadline(ctx context.Context, deadline time.Time) (prevDeadline time.Time, err error) {
 	return db.ResetTransactionWarnDeadline(ctx, bs.tx, deadline)
-}
-
-func (bs sqlBatchScope) AccountsInitTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool) {
-	return AccountsInitTest(tb, bs.tx, initAccounts, proto)
-}
-
-func (bs sqlBatchScope) AccountsUpdateSchemaTest(ctx context.Context) (err error) {
-	return AccountsUpdateSchemaTest(ctx, bs.tx)
 }
 
 func (ss sqlSnapshotScope) MakeAccountsReader() (AccountsReaderExt, error) {

--- a/ledger/store/testinterfaces.go
+++ b/ledger/store/testinterfaces.go
@@ -2,12 +2,22 @@ package store
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
+	"os"
 	"testing"
 
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
+	"github.com/stretchr/testify/require"
 )
+
+// testinterfaces.go contains interface extensions for the store package
+// to use test-only functionality, cast your Interface to the test-version, eg:
+// testTx := tx.(TransactionTestScope)
 
 type BatchTestScope interface {
 	BatchScope
@@ -17,14 +27,164 @@ type BatchTestScope interface {
 	RunMigrations(ctx context.Context, params TrackerDBParams, log logging.Logger, targetVersion int32) (mgr TrackerDBInitParams, err error)
 }
 
+// implements BatchTestScope for sql TX Scopes
 func (bs sqlBatchScope) AccountsInitTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool) {
 	return AccountsInitTest(tb, bs.tx, initAccounts, proto)
 }
 
+// implements BatchTestScope for sql TX Scopes
 func (bs sqlBatchScope) AccountsUpdateSchemaTest(ctx context.Context) (err error) {
 	return AccountsUpdateSchemaTest(ctx, bs.tx)
 }
 
+// implements BatchTestScope for sql TX Scopes
 func (bs sqlBatchScope) RunMigrations(ctx context.Context, params TrackerDBParams, log logging.Logger, targetVersion int32) (mgr TrackerDBInitParams, err error) {
 	return RunMigrations(ctx, bs.tx, params, log, targetVersion)
+}
+
+type TransactionTestScope interface {
+	TransactionScope
+
+	MakeAccountsOptimizedReader() (AccountsReader, error)
+	MakeOnlineAccountsOptimizedReader() (OnlineAccountsReader, error)
+	AccountsInitTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool)
+	AccountsInitLightTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto config.ConsensusParams) (newDatabase bool, err error)
+}
+
+// implements TransactionTestScope for sql TX Scopes
+func (txs sqlTransactionScope) MakeAccountsOptimizedReader() (AccountsReader, error) {
+	return AccountsInitDbQueries(txs.tx)
+}
+
+// implements TransactionTestScope for sql TX Scopes
+func (txs sqlTransactionScope) MakeOnlineAccountsOptimizedReader() (r OnlineAccountsReader, err error) {
+	return OnlineAccountsInitDbQueries(txs.tx)
+}
+
+// implements TransactionTestScope for sql TX Scopes
+func (txs sqlTransactionScope) AccountsInitTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool) {
+	return AccountsInitTest(tb, txs.tx, initAccounts, proto)
+}
+
+// implements TransactionTestScope for sql TX Scopes
+func (txs sqlTransactionScope) AccountsInitLightTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto config.ConsensusParams) (newDatabase bool, err error) {
+	return AccountsInitLightTest(tb, txs.tx, initAccounts, proto)
+}
+
+type TestAccountsReaderExt interface {
+	AccountsReaderExt
+
+	AccountsAllTest() (bals map[basics.Address]basics.AccountData, err error)
+	CheckCreatablesTest(t *testing.T, iteration int, expectedDbImage map[basics.CreatableIndex]ledgercore.ModifiedCreatable)
+}
+
+// AccountsAllTest iterates the account table and returns a map of the data
+// It is meant only for testing purposes - it is heavy and has no production use case.
+// implements TestAccountsReaderExt for V2 Readers
+func (r *accountsV2Reader) AccountsAllTest() (bals map[basics.Address]basics.AccountData, err error) {
+	rows, err := r.q.Query("SELECT rowid, address, data FROM accountbase")
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+
+	bals = make(map[basics.Address]basics.AccountData)
+	for rows.Next() {
+		var addrbuf []byte
+		var buf []byte
+		var rowid sql.NullInt64
+		err = rows.Scan(&rowid, &addrbuf, &buf)
+		if err != nil {
+			return
+		}
+
+		var data BaseAccountData
+		err = protocol.Decode(buf, &data)
+		if err != nil {
+			return
+		}
+
+		var addr basics.Address
+		if len(addrbuf) != len(addr) {
+			err = fmt.Errorf("account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
+			return
+		}
+		copy(addr[:], addrbuf)
+
+		var ad basics.AccountData
+		ad, err = r.LoadFullAccount(context.Background(), "resources", addr, rowid.Int64, data)
+		if err != nil {
+			return
+		}
+
+		bals[addr] = ad
+	}
+
+	err = rows.Err()
+	return
+}
+
+// meant only for testing purposes - it is heavy and has no production use case.
+// implements TestAccountsReaderExt for V2 Readers
+func (r *accountsV2Reader) CheckCreatablesTest(t *testing.T,
+	iteration int,
+	expectedDbImage map[basics.CreatableIndex]ledgercore.ModifiedCreatable) {
+	stmt, err := r.q.Prepare("SELECT asset, creator, ctype FROM assetcreators")
+	require.NoError(t, err)
+
+	defer stmt.Close()
+	rows, err := stmt.Query()
+	if err != sql.ErrNoRows {
+		require.NoError(t, err)
+	}
+	defer rows.Close()
+	counter := 0
+	for rows.Next() {
+		counter++
+		mc := ledgercore.ModifiedCreatable{}
+		var buf []byte
+		var asset basics.CreatableIndex
+		err := rows.Scan(&asset, &buf, &mc.Ctype)
+		require.NoError(t, err)
+		copy(mc.Creator[:], buf)
+
+		require.NotNil(t, expectedDbImage[asset])
+		require.Equal(t, expectedDbImage[asset].Creator, mc.Creator)
+		require.Equal(t, expectedDbImage[asset].Ctype, mc.Ctype)
+		require.True(t, expectedDbImage[asset].Created)
+	}
+	require.Equal(t, len(expectedDbImage), counter)
+}
+
+type TestTrackerStore interface {
+	TrackerStore
+
+	CleanupTest(dbName string, inMemory bool)
+	ResetToV6Test(ctx context.Context) error
+}
+
+func (s *trackerSQLStore) CleanupTest(dbName string, inMemory bool) {
+	s.pair.Close()
+	if !inMemory {
+		os.Remove(dbName)
+	}
+}
+
+func (s *trackerSQLStore) ResetToV6Test(ctx context.Context) error {
+	var resetExprs = []string{
+		`DROP TABLE IF EXISTS onlineaccounts`,
+		`DROP TABLE IF EXISTS txtail`,
+		`DROP TABLE IF EXISTS onlineroundparamstail`,
+		`DROP TABLE IF EXISTS catchpointfirststageinfo`,
+	}
+
+	return s.pair.Wdb.AtomicContext(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		for _, stmt := range resetExprs {
+			_, err := tx.ExecContext(ctx, stmt)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }

--- a/ledger/store/testinterfaces.go
+++ b/ledger/store/testinterfaces.go
@@ -1,0 +1,30 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/protocol"
+)
+
+type BatchTestScope interface {
+	BatchScope
+
+	AccountsInitTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool)
+	AccountsUpdateSchemaTest(ctx context.Context) (err error)
+	RunMigrations(ctx context.Context, params TrackerDBParams, log logging.Logger, targetVersion int32) (mgr TrackerDBInitParams, err error)
+}
+
+func (bs sqlBatchScope) AccountsInitTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool) {
+	return AccountsInitTest(tb, bs.tx, initAccounts, proto)
+}
+
+func (bs sqlBatchScope) AccountsUpdateSchemaTest(ctx context.Context) (err error) {
+	return AccountsUpdateSchemaTest(ctx, bs.tx)
+}
+
+func (bs sqlBatchScope) RunMigrations(ctx context.Context, params TrackerDBParams, log logging.Logger, targetVersion int32) (mgr TrackerDBInitParams, err error) {
+	return RunMigrations(ctx, bs.tx, params, log, targetVersion)
+}

--- a/ledger/txtail_test.go
+++ b/ledger/txtail_test.go
@@ -154,6 +154,7 @@ func (t *txTailTestLedger) initialize(ts *testing.T, protoVersion protocol.Conse
 	t.protoVersion = protoVersion
 
 	err := t.trackerDBs.Batch(func(transactionCtx context.Context, tx store.BatchScope) (err error) {
+		testTx := tx.(store.BatchTestScope)
 		arw, err := tx.MakeAccountsWriter()
 		if err != nil {
 			return err
@@ -161,7 +162,7 @@ func (t *txTailTestLedger) initialize(ts *testing.T, protoVersion protocol.Conse
 
 		accts := ledgertesting.RandomAccounts(20, true)
 		proto := config.Consensus[protoVersion]
-		newDB := tx.AccountsInitTest(ts, accts, protoVersion)
+		newDB := testTx.AccountsInitTest(ts, accts, protoVersion)
 		require.True(ts, newDB)
 
 		roundData := make([][]byte, 0, proto.MaxTxnLife)


### PR DESCRIPTION
Done:
* Moved all test-only functions from interfaces to a "Test" version of that interface
* Moved implementations for test-only functions into that same file
* Updated callers to typecast appropriately when-needed. All typecasting is in unit testing *only*. Production should never typecast, as it never needs the test interface.

Still to come:
* Folder restructure to sub-package testing things
* Potential reduction of test-only functions (I see a few which could maybe be removed)
* Revival of `TestAcctOnlineTopDBBehindMemRound` unit test