### PR TITLE
devmode: Allow DevMode + FollowMode configurations.

### DIFF
--- a/netdeploy/networkTemplate.go
+++ b/netdeploy/networkTemplate.go
@@ -27,15 +27,12 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/algorand/go-codec/codec"
-
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/gen"
 	"github.com/algorand/go-algorand/libgoal"
 	"github.com/algorand/go-algorand/netdeploy/remote"
-	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/util"
 )
 
@@ -240,7 +237,7 @@ func (t NetworkTemplate) Validate() error {
 	// Follow nodes cannot be relays
 	for _, cfg := range t.Nodes {
 		if cfg.IsRelay && isEnableFollowMode(cfg.ConfigJSONOverride) {
-			return fmt.Errorf("invalid template: follow nodes may not be relays")
+			return fmt.Errorf("invalid template: follower nodes may not be relays")
 		}
 	}
 
@@ -251,7 +248,7 @@ func (t NetworkTemplate) Validate() error {
 
 		for _, cfg := range t.Nodes {
 			if !cfg.IsRelay && !isEnableFollowMode(cfg.ConfigJSONOverride) {
-				return fmt.Errorf("invalid template: devmode configurations may only contain 1 relay and follow nodes")
+				return fmt.Errorf("invalid template: devmode configurations may only contain one relay and follower nodes")
 			}
 		}
 	}
@@ -279,7 +276,8 @@ func countRelayNodes(nodeCfgs []remote.NodeConfigGoal) (relayCount int) {
 func decodeJSONOverride(override string, cfg *config.Local) error {
 	if override != "" {
 		reader := strings.NewReader(override)
-		dec := codec.NewDecoder(reader, protocol.JSONHandle)
+		dec := json.NewDecoder(reader)
+		dec.DisallowUnknownFields()
 		if err := dec.Decode(&cfg); err != nil {
 			return err
 		}

--- a/netdeploy/networkTemplate.go
+++ b/netdeploy/networkTemplate.go
@@ -311,7 +311,10 @@ func createConfigFile(node remote.NodeConfigGoal, configFile string, numNodes in
 		cfg.DeadlockDetection = node.DeadlockDetection
 	}
 
-	decodeJSONOverride(node.ConfigJSONOverride, &cfg)
+	err := decodeJSONOverride(node.ConfigJSONOverride, &cfg)
+	if err != nil {
+		return err
+	}
 
 	return cfg.SaveToFile(configFile)
 }

--- a/netdeploy/networkTemplates_test.go
+++ b/netdeploy/networkTemplates_test.go
@@ -203,6 +203,28 @@ func TestDevModeValidate(t *testing.T) {
 		// this one is fine.
 		require.NoError(t, tmpl.Validate())
 	})
+
+	t.Run("Valid two-follower DevMode", func(t *testing.T) {
+		t.Parallel()
+		tmpl := NetworkTemplate{
+			Genesis: devmodeGenesis,
+			Nodes: []remote.NodeConfigGoal{
+				{
+					IsRelay: true,
+				},
+				{
+					IsRelay:            false,
+					ConfigJSONOverride: "{\"EnableFollowMode\":true}",
+				},
+				{
+					IsRelay:            false,
+					ConfigJSONOverride: "{\"EnableFollowMode\":true}",
+				},
+			},
+		}
+		// this one is fine.
+		require.NoError(t, tmpl.Validate())
+	})
 }
 
 type overlayTestStruct struct {

--- a/netdeploy/networkTemplates_test.go
+++ b/netdeploy/networkTemplates_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/gen"
+	"github.com/algorand/go-algorand/netdeploy/remote"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
@@ -96,6 +98,111 @@ func TestValidate(t *testing.T) {
 	template, _ = loadTemplate(filepath.Join(templateDir, "TwoNodesOneRelay1000Accounts.json"))
 	err = template.Validate()
 	a.NoError(err)
+}
+
+func TestDevModeValidate(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	// same genesis configuration for all tests.
+	devmodeGenesis := gen.GenesisData{
+		DevMode: true,
+		Wallets: []gen.WalletData{
+			{
+				Stake: 100,
+			},
+		},
+	}
+
+	t.Run("DevMode two relays", func(t *testing.T) {
+		t.Parallel()
+		tmpl := NetworkTemplate{
+			Genesis: devmodeGenesis,
+			Nodes: []remote.NodeConfigGoal{
+				{
+					IsRelay: true,
+				},
+				{
+					IsRelay: true,
+				},
+			},
+		}
+		require.ErrorContains(t, tmpl.Validate(), "devmode configurations may have at most one relay")
+	})
+
+	t.Run("FollowMode relay", func(t *testing.T) {
+		t.Parallel()
+		tmpl := NetworkTemplate{
+			Genesis: devmodeGenesis,
+			Nodes: []remote.NodeConfigGoal{
+				{
+					IsRelay:            true,
+					ConfigJSONOverride: "{\"EnableFollowMode\":true}",
+				},
+			},
+		}
+		require.ErrorContains(t, tmpl.Validate(), "follow nodes may not be relays")
+	})
+
+	t.Run("DevMode multiple regular nodes", func(t *testing.T) {
+		t.Parallel()
+		tmpl := NetworkTemplate{
+			Genesis: devmodeGenesis,
+			Nodes: []remote.NodeConfigGoal{
+				{
+					IsRelay: true,
+				},
+				{},
+			},
+		}
+		require.ErrorContains(t, tmpl.Validate(), "devmode configurations may only contain 1 relay and follow nodes")
+	})
+
+	t.Run("ConfigJSONOverride does not parse", func(t *testing.T) {
+		t.Parallel()
+		tmpl := NetworkTemplate{
+			Genesis: devmodeGenesis,
+			Nodes: []remote.NodeConfigGoal{
+				{
+					IsRelay:            false,
+					ConfigJSONOverride: "DOES NOT PARSE",
+				},
+			},
+		}
+		require.ErrorContains(t, tmpl.Validate(), "unable to decode JSONOverride")
+	})
+
+	t.Run("ConfigJSONOverride unknown key", func(t *testing.T) {
+		t.Parallel()
+		tmpl := NetworkTemplate{
+			Genesis: devmodeGenesis,
+			Nodes: []remote.NodeConfigGoal{
+				{
+					IsRelay:            false,
+					ConfigJSONOverride: "{\"Unknown Key\": \"Valid JSON\"}",
+				},
+			},
+		}
+		require.ErrorContains(t, tmpl.Validate(), "no matching struct field found")
+	})
+
+	t.Run("Valid multi-node DevMode", func(t *testing.T) {
+		t.Parallel()
+		tmpl := NetworkTemplate{
+			Genesis: devmodeGenesis,
+			Nodes: []remote.NodeConfigGoal{
+				{
+					IsRelay: true,
+				},
+				{
+					IsRelay:            false,
+					ConfigJSONOverride: "{\"EnableFollowMode\":true}",
+				},
+			},
+		}
+		// this one is fine.
+		require.NoError(t, tmpl.Validate())
+	})
 }
 
 type overlayTestStruct struct {

--- a/netdeploy/networkTemplates_test.go
+++ b/netdeploy/networkTemplates_test.go
@@ -141,7 +141,7 @@ func TestDevModeValidate(t *testing.T) {
 				},
 			},
 		}
-		require.ErrorContains(t, tmpl.Validate(), "follow nodes may not be relays")
+		require.ErrorContains(t, tmpl.Validate(), "follower nodes may not be relays")
 	})
 
 	t.Run("DevMode multiple regular nodes", func(t *testing.T) {
@@ -155,7 +155,7 @@ func TestDevModeValidate(t *testing.T) {
 				{},
 			},
 		}
-		require.ErrorContains(t, tmpl.Validate(), "devmode configurations may only contain 1 relay and follow nodes")
+		require.ErrorContains(t, tmpl.Validate(), "devmode configurations may only contain one relay and follower nodes")
 	})
 
 	t.Run("ConfigJSONOverride does not parse", func(t *testing.T) {
@@ -183,7 +183,7 @@ func TestDevModeValidate(t *testing.T) {
 				},
 			},
 		}
-		require.ErrorContains(t, tmpl.Validate(), "no matching struct field found")
+		require.ErrorContains(t, tmpl.Validate(), "json: unknown field \"Unknown Key\"")
 	})
 
 	t.Run("Valid multi-node DevMode", func(t *testing.T) {

--- a/node/follower_node.go
+++ b/node/follower_node.go
@@ -86,8 +86,7 @@ func MakeFollower(log logging.Logger, rootDir string, cfg config.Local, phoneboo
 	node.devMode = genesis.DevMode
 
 	if node.devMode {
-		log.Errorf("Cannot run follower node in devMode--submitting txns won't work")
-		return nil, fmt.Errorf("cannot run with both EnableFollowMode and DevMode")
+		log.Warn("Follower running on a devMode network. Must submit txns to a different node.")
 	}
 	node.config = cfg
 

--- a/node/follower_node_test.go
+++ b/node/follower_node_test.go
@@ -19,6 +19,8 @@ package node
 import (
 	"testing"
 
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/agreement"
@@ -32,10 +34,8 @@ import (
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
-func setupFollowNode(t *testing.T) *AlgorandFollowerNode {
-	cfg := config.GetDefaultLocal()
-	cfg.EnableFollowMode = true
-	genesis := bookkeeping.Genesis{
+func followNodeDefaultGenesis() bookkeeping.Genesis {
+	return bookkeeping.Genesis{
 		SchemaID:    "go-test-follower-node-genesis",
 		Proto:       protocol.ConsensusCurrentVersion,
 		Network:     config.Devtestnet,
@@ -50,6 +50,12 @@ func setupFollowNode(t *testing.T) *AlgorandFollowerNode {
 			},
 		},
 	}
+}
+
+func setupFollowNode(t *testing.T) *AlgorandFollowerNode {
+	cfg := config.GetDefaultLocal()
+	cfg.EnableFollowMode = true
+	genesis := followNodeDefaultGenesis()
 	node, err := MakeFollower(logging.Base(), t.TempDir(), cfg, []string{}, genesis)
 	require.NoError(t, err)
 	return node
@@ -94,4 +100,30 @@ func TestErrors(t *testing.T) {
 	require.Error(t, node.AppendParticipationKeys(account.ParticipationID{}, account.StateProofKeys{}))
 	_, err = node.InstallParticipationKey([]byte{})
 	require.Error(t, err)
+}
+
+func TestDevModeWarning(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	cfg := config.GetDefaultLocal()
+	cfg.EnableFollowMode = true
+	genesis := followNodeDefaultGenesis()
+	genesis.DevMode = true
+
+	logger, hook := test.NewNullLogger()
+	tlogger := logging.NewWrappedLogger(logger)
+	_, err := MakeFollower(tlogger, t.TempDir(), cfg, []string{}, genesis)
+	require.NoError(t, err)
+
+	// check for the warning
+	var foundEntry *logrus.Entry
+	entries := hook.AllEntries()
+	for i := range entries {
+		if entries[i].Level == logrus.WarnLevel {
+			foundEntry = entries[i]
+		}
+	}
+	require.NotNil(t, foundEntry)
+	require.Contains(t, foundEntry.Message, "Follower running on a devMode network. Must submit txns to a different node.")
 }

--- a/node/node.go
+++ b/node/node.go
@@ -183,10 +183,6 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 	node.genesisID = genesis.ID()
 	node.genesisHash = genesis.Hash()
 	node.devMode = genesis.DevMode
-
-	if node.devMode {
-		cfg.DisableNetworking = true
-	}
 	node.config = cfg
 
 	// tie network, block fetcher, and agreement services together
@@ -485,7 +481,7 @@ func (node *AlgorandFullNode) writeDevmodeBlock() (err error) {
 	}
 
 	// add the newly generated block to the ledger
-	err = node.ledger.AddValidatedBlock(*vb, agreement.Certificate{})
+	err = node.ledger.AddValidatedBlock(*vb, agreement.Certificate{Round: vb.Block().Round()})
 	return err
 }
 


### PR DESCRIPTION
## Summary

Allow multi-node devmode private networks with one DevMode relay and one or more FollowMode followers.

This is required to support Indexer running against a DevMode network.

Note: added `DisallowUnknownFields` to the JSON decoder so that we would fail to create a private network if one of the configurations is unknown.

## Test Plan

New unit tests.

In the future Sandbox would continuously integration test this configuration.

Manual test with the following configuration:
```
{
  "Genesis": {
    "LastPartKeyRound": 3000,
    "NetworkName": "tbd",
    "Wallets": [
      {
        "Name": "Wallet1",
        "Stake": 100,
        "Online": true
      }
    ],
    "DevMode": true
  },
  "Nodes": [
    {
      "Name": "Primary",
      "IsRelay": true,
      "Wallets": [
        {
          "Name": "Wallet1",
          "ParticipationOnly": false
        }
      ]
    },
    {
      "Name": "Follower",
      "Wallets": [],
      "ConfigJSONOverride": "{\"EnableFollowMode\":true,\"CatchupBlockValidateMode\":3}"
    }
  ]
}
```