### PR TITLE
tests: fix debug output in expect test harness

### DIFF
--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -53,10 +53,10 @@ proc ::AlgorandGoal::Abort { ERROR } {
         puts "GLOBAL_NETWORK_NAME $::GLOBAL_NETWORK_NAME"
 
         # dump system and processes information to check memory consumption and if algod procs are still alive
-        if { $tcl_platform(os) == "Darwin" } {
-            exec top -l 1
-        } elseif { $tcl_platform(os) == "Linux" } {
-            exec top -n 1
+        if { $::tcl_platform(os) == "Darwin" } {
+            exec >@stdout 2>@stderr top -l 1
+        } elseif { $::tcl_platform(os) == "Linux" } {
+            exec >@stdout 2>@stderr top -n 1
         } else {
             # no logging for other platforms
         }


### PR DESCRIPTION
## Summary

The original implementation had scoping issue with `tcp_platform` global var as[ this build](https://app.circleci.com/pipelines/github/algorand/go-algorand/12833/workflows/df76b559-ebef-48a9-a76e-48c03c7eebfa/jobs/211941) indicated.
Additionally added stdout redirect for `exec` since its behavior in a script differs from REPL where I tested the original code.

## Test Plan

This is a test harness change.