### PR TITLE
api: lower default for MaxHeaderBytes.

### DIFF
--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -297,9 +297,10 @@ func (s *Server) Start() {
 
 	addr = listener.Addr().String()
 	server = http.Server{
-		Addr:         addr,
-		ReadTimeout:  time.Duration(cfg.RestReadTimeoutSeconds) * time.Second,
-		WriteTimeout: time.Duration(cfg.RestWriteTimeoutSeconds) * time.Second,
+		Addr:           addr,
+		ReadTimeout:    time.Duration(cfg.RestReadTimeoutSeconds) * time.Second,
+		WriteTimeout:   time.Duration(cfg.RestWriteTimeoutSeconds) * time.Second,
+		MaxHeaderBytes: 4096,
 	}
 
 	e := apiServer.NewRouter(

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -300,7 +300,7 @@ func (s *Server) Start() {
 		Addr:           addr,
 		ReadTimeout:    time.Duration(cfg.RestReadTimeoutSeconds) * time.Second,
 		WriteTimeout:   time.Duration(cfg.RestWriteTimeoutSeconds) * time.Second,
-		MaxHeaderBytes: 4096,
+		MaxHeaderBytes: 4096, // enough room to hold an api token
 	}
 
 	e := apiServer.NewRouter(

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -49,6 +49,9 @@ import (
 
 var server http.Server
 
+// maxHeaderBytes must have enough room to hold an api token
+const maxHeaderBytes = 4096
+
 // ServerNode is the required methods for any node the server fronts
 type ServerNode interface {
 	apiServer.APINodeInterface
@@ -300,7 +303,7 @@ func (s *Server) Start() {
 		Addr:           addr,
 		ReadTimeout:    time.Duration(cfg.RestReadTimeoutSeconds) * time.Second,
 		WriteTimeout:   time.Duration(cfg.RestWriteTimeoutSeconds) * time.Second,
-		MaxHeaderBytes: 4096, // enough room to hold an api token
+		MaxHeaderBytes: maxHeaderBytes,
 	}
 
 	e := apiServer.NewRouter(


### PR DESCRIPTION
## Summary

We only require an API token in the header, so a much lower default for MaxHeaderBytes can be used. The gossip network port already uses 4096 as the default.