### PR TITLE
Refactor: Push test-only functionality of storage interfaces into test-interface.

### DIFF
--- a/ledger/acctdeltas_test.go
+++ b/ledger/acctdeltas_test.go
@@ -59,7 +59,7 @@ func checkAccounts(t *testing.T, tx trackerdb.TransactionScope, rnd basics.Round
 	require.NoError(t, err)
 	require.Equal(t, r, rnd)
 
-	aor, err := tx.MakeAccountsOptimizedReader()
+	aor, err := tx.Testing().MakeAccountsOptimizedReader()
 	require.NoError(t, err)
 
 	var totalOnline, totalOffline, totalNotPart uint64
@@ -83,7 +83,7 @@ func checkAccounts(t *testing.T, tx trackerdb.TransactionScope, rnd basics.Round
 		}
 	}
 
-	all, err := arw.AccountsAllTest()
+	all, err := arw.Testing().AccountsAllTest()
 	require.NoError(t, err)
 	require.Equal(t, all, accts)
 
@@ -155,12 +155,12 @@ func TestAccountDBInit(t *testing.T) {
 
 	err := dbs.Transaction(func(ctx context.Context, tx trackerdb.TransactionScope) (err error) {
 		accts := ledgertesting.RandomAccounts(20, true)
-		newDB := tx.AccountsInitTest(t, accts, protocol.ConsensusCurrentVersion)
+		newDB := tx.Testing().AccountsInitTest(t, accts, protocol.ConsensusCurrentVersion)
 		require.True(t, newDB)
 
 		checkAccounts(t, tx, 0, accts)
 
-		newDB, err = tx.AccountsInitLightTest(t, accts, proto)
+		newDB, err = tx.Testing().AccountsInitLightTest(t, accts, proto)
 		require.NoError(t, err)
 		require.False(t, newDB)
 		checkAccounts(t, tx, 0, accts)
@@ -219,7 +219,7 @@ func TestAccountDBRound(t *testing.T) {
 		require.NoError(t, err)
 
 		accts := ledgertesting.RandomAccounts(20, true)
-		tx.AccountsInitTest(t, accts, protocol.ConsensusCurrentVersion)
+		tx.Testing().AccountsInitTest(t, accts, protocol.ConsensusCurrentVersion)
 		checkAccounts(t, tx, 0, accts)
 		totals, err := arw.AccountsTotals(context.Background(), false)
 		require.NoError(t, err)
@@ -297,7 +297,7 @@ func TestAccountDBRound(t *testing.T) {
 			require.NotEmpty(t, updatedOnlineAccts)
 
 			checkAccounts(t, tx, basics.Round(i), accts)
-			arw.CheckCreatablesTest(t, i, expectedDbImage)
+			arw.Testing().CheckCreatablesTest(t, i, expectedDbImage)
 		}
 
 		// test the accounts totals
@@ -372,7 +372,7 @@ func TestAccountDBInMemoryAcct(t *testing.T) {
 
 		dbs.Transaction(func(ctx context.Context, tx trackerdb.TransactionScope) error {
 			accts := ledgertesting.RandomAccounts(1, true)
-			tx.AccountsInitTest(t, accts, protocol.ConsensusCurrentVersion)
+			tx.Testing().AccountsInitTest(t, accts, protocol.ConsensusCurrentVersion)
 			addr := ledgertesting.RandomAddress()
 
 			// lastCreatableID stores asset or app max used index to get rid of conflicts
@@ -443,7 +443,7 @@ func TestAccountStorageWithStateProofID(t *testing.T) {
 
 	dbs.Transaction(func(ctx context.Context, tx trackerdb.TransactionScope) (err error) {
 		accts := ledgertesting.RandomAccounts(20, false)
-		_ = tx.AccountsInitTest(t, accts, protocol.ConsensusCurrentVersion)
+		_ = tx.Testing().AccountsInitTest(t, accts, protocol.ConsensusCurrentVersion)
 		checkAccounts(t, tx, 0, accts)
 		require.True(t, allAccountsHaveStateProofPKs(accts))
 		return nil
@@ -600,7 +600,7 @@ func generateRandomTestingAccountBalances(numAccounts int) (updates map[basics.A
 
 func benchmarkInitBalances(b testing.TB, numAccounts int, tx trackerdb.TransactionScope, proto protocol.ConsensusVersion) (updates map[basics.Address]basics.AccountData) {
 	updates = generateRandomTestingAccountBalances(numAccounts)
-	tx.AccountsInitTest(b, updates, proto)
+	tx.Testing().AccountsInitTest(b, updates, proto)
 	return
 }
 
@@ -626,7 +626,7 @@ func benchmarkReadingAllBalances(b *testing.B, inMemory bool) {
 		b.ResetTimer()
 		// read all the balances in the database.
 		var err2 error
-		bal, err2 = arw.AccountsAllTest()
+		bal, err2 = arw.Testing().AccountsAllTest()
 		require.NoError(b, err2)
 		return nil
 	})
@@ -2091,7 +2091,7 @@ func TestAccountOnlineQueries(t *testing.T) {
 		}
 
 		var accts map[basics.Address]basics.AccountData
-		tx.AccountsInitTest(t, accts, protocol.ConsensusCurrentVersion)
+		tx.Testing().AccountsInitTest(t, accts, protocol.ConsensusCurrentVersion)
 		totals, err := arw.AccountsTotals(context.Background(), false)
 		require.NoError(t, err)
 
@@ -2194,7 +2194,7 @@ func TestAccountOnlineQueries(t *testing.T) {
 		addRound(2, ledgercore.StateDelta{Accts: delta2})
 		addRound(3, ledgercore.StateDelta{Accts: delta3})
 
-		queries, err := tx.MakeOnlineAccountsOptimizedReader()
+		queries, err := tx.Testing().MakeOnlineAccountsOptimizedReader()
 		require.NoError(t, err)
 
 		// check round 1

--- a/ledger/acctonline_test.go
+++ b/ledger/acctonline_test.go
@@ -1611,6 +1611,99 @@ func TestAcctOnlineTopBetweenCommitAndPostCommit(t *testing.T) {
 	}
 }
 
+func TestAcctOnlineTopDBBehindMemRound(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	const numAccts = 20
+	allAccts := make([]basics.BalanceRecord, numAccts)
+	genesisAccts := []map[basics.Address]basics.AccountData{{}}
+	genesisAccts[0] = make(map[basics.Address]basics.AccountData, numAccts)
+
+	for i := 0; i < numAccts; i++ {
+		allAccts[i] = basics.BalanceRecord{
+			Addr: ledgertesting.RandomAddress(),
+			AccountData: basics.AccountData{
+				MicroAlgos:     basics.MicroAlgos{Raw: uint64(i + 1)},
+				Status:         basics.Online,
+				VoteLastValid:  1000,
+				VoteFirstValid: 0,
+				RewardsBase:    0},
+		}
+		genesisAccts[0][allAccts[i].Addr] = allAccts[i].AccountData
+	}
+	addSinkAndPoolAccounts(genesisAccts)
+
+	ml := makeMockLedgerForTracker(t, true, 1, protocol.ConsensusCurrentVersion, genesisAccts)
+	defer ml.Close()
+
+	stallingTracker := &blockingTracker{
+		postCommitUnlockedEntryLock:   make(chan struct{}),
+		postCommitUnlockedReleaseLock: make(chan struct{}),
+		postCommitEntryLock:           make(chan struct{}),
+		postCommitReleaseLock:         make(chan struct{}),
+		alwaysLock:                    false,
+		shouldLockPostCommit:          false,
+	}
+
+	conf := config.GetDefaultLocal()
+	au, oa := newAcctUpdates(t, ml, conf)
+	defer oa.close()
+	ml.trackers.trackers = append([]ledgerTracker{stallingTracker}, ml.trackers.trackers...)
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	top, _, err := oa.TopOnlineAccounts(0, 0, 5, &proto, 0)
+	a.NoError(err)
+	compareTopAccounts(a, top, allAccts)
+
+	_, totals, err := au.LatestTotals()
+	require.NoError(t, err)
+
+	// apply some rounds so the db round will make progress (not be 0) - i.e since the max lookback in memory is 8. deltas
+	// will get committed at round 9
+	i := 1
+	for ; i < 10; i++ {
+		var updates ledgercore.AccountDeltas
+		updates.Upsert(allAccts[numAccts-1].Addr, ledgercore.AccountData{
+			AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: ledgercore.VotingData{}})
+		newBlockWithUpdates(genesisAccts, updates, totals, t, ml, i, oa)
+	}
+
+	stallingTracker.shouldLockPostCommit = true
+
+	updateAccountsRoutine := func() {
+		var updates ledgercore.AccountDeltas
+		updates.Upsert(allAccts[numAccts-1].Addr, ledgercore.AccountData{
+			AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: ledgercore.VotingData{}})
+		newBlockWithUpdates(genesisAccts, updates, totals, t, ml, i, oa)
+	}
+
+	// This go routine will trigger a commit producer. we added a special blockingTracker that will case our
+	// onlineAccoutsTracker to be "stuck" between commit and Post commit .
+	// thus, when we call onlineTop - it should wait for the post commit to happen.
+	// in a different go routine we will wait 2 sec and release the commit.
+	go updateAccountsRoutine()
+
+	select {
+	case <-stallingTracker.postCommitEntryLock:
+		go func() {
+			time.Sleep(2 * time.Second)
+			// tweak the database to move backwards
+			err = oa.dbs.Batch(func(ctx context.Context, tx trackerdb.BatchScope) (err error) {
+				return tx.Testing().ModifyAcctBaseTest()
+			})
+			stallingTracker.postCommitReleaseLock <- struct{}{}
+		}()
+
+		_, _, err = oa.TopOnlineAccounts(2, 2, 5, &proto, 0)
+		a.Error(err)
+		a.Contains(err.Error(), "is behind in-memory round")
+
+	case <-time.After(1 * time.Minute):
+		a.FailNow("timedout while waiting for post commit")
+	}
+}
+
 func TestAcctOnlineTop_ChangeOnlineStake(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	a := require.New(t)

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -268,7 +268,7 @@ func (au *accountUpdates) allBalances(rnd basics.Round) (bals map[basics.Address
 		if err != nil {
 			return err
 		}
-		bals, err0 = arw.AccountsAllTest()
+		bals, err0 = arw.Testing().AccountsAllTest()
 		return err0
 	})
 	if err != nil {
@@ -1006,11 +1006,11 @@ func TestListCreatables(t *testing.T) {
 		proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
 		accts := make(map[basics.Address]basics.AccountData)
-		_ = tx.AccountsInitTest(t, accts, protocol.ConsensusCurrentVersion)
+		_ = tx.Testing().AccountsInitTest(t, accts, protocol.ConsensusCurrentVersion)
 		require.NoError(t, err)
 
 		au := &accountUpdates{}
-		au.accountsq, err = tx.MakeAccountsOptimizedReader()
+		au.accountsq, err = tx.Testing().MakeAccountsOptimizedReader()
 		require.NoError(t, err)
 
 		// ******* All results are obtained from the cache. Empty database *******

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -2304,12 +2304,12 @@ func TestLedgerReloadTxTailHistoryAccess(t *testing.T) {
 			DbPathPrefix:      l.catchpoint.dbDirectory,
 			BlockDb:           l.blockDBs,
 		}
-		_, err0 = tx.RunMigrations(ctx, tp, l.log, preReleaseDBVersion /*target database version*/)
+		_, err0 = tx.Testing().RunMigrations(ctx, tp, l.log, preReleaseDBVersion /*target database version*/)
 		if err0 != nil {
 			return err0
 		}
 
-		if err0 := tx.AccountsUpdateSchemaTest(ctx); err != nil {
+		if err0 := tx.Testing().AccountsUpdateSchemaTest(ctx); err != nil {
 			return err0
 		}
 
@@ -2455,7 +2455,7 @@ func TestLedgerMigrateV6ShrinkDeltas(t *testing.T) {
 	}()
 	// create tables so online accounts can still be written
 	err = trackerDB.Batch(func(ctx context.Context, tx trackerdb.BatchScope) error {
-		if err := tx.AccountsUpdateSchemaTest(ctx); err != nil {
+		if err := tx.Testing().AccountsUpdateSchemaTest(ctx); err != nil {
 			return err
 		}
 		return nil

--- a/ledger/store/trackerdb/interface.go
+++ b/ledger/store/trackerdb/interface.go
@@ -18,7 +18,6 @@ package trackerdb
 
 import (
 	"context"
-	"testing"
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
@@ -91,14 +90,13 @@ type AccountsReaderExt interface {
 	TotalAccounts(ctx context.Context) (total uint64, err error)
 	TotalKVs(ctx context.Context) (total uint64, err error)
 	AccountsRound() (rnd basics.Round, err error)
-	AccountsAllTest() (bals map[basics.Address]basics.AccountData, err error)
-	CheckCreatablesTest(t *testing.T, iteration int, expectedDbImage map[basics.CreatableIndex]ledgercore.ModifiedCreatable)
 	LookupOnlineAccountDataByAddress(addr basics.Address) (rowid int64, data []byte, err error)
 	AccountsOnlineTop(rnd basics.Round, offset uint64, n uint64, proto config.ConsensusParams) (map[basics.Address]*ledgercore.OnlineAccount, error)
 	AccountsOnlineRoundParams() (onlineRoundParamsData []ledgercore.OnlineRoundParamsData, endRound basics.Round, err error)
 	OnlineAccountsAll(maxAccounts uint64) ([]PersistedOnlineAccountData, error)
 	LoadTxTail(ctx context.Context, dbRound basics.Round) (roundData []*TxTailRound, roundHash []crypto.Digest, baseRound basics.Round, err error)
 	LoadAllFullAccounts(ctx context.Context, balancesTable string, resourcesTable string, acctCb func(basics.Address, basics.AccountData)) (count int, err error)
+	Testing() TestAccountsReaderExt
 }
 
 // AccountsReaderWriter is AccountsReader+AccountsWriter

--- a/ledger/store/trackerdb/sqlitedriver/accountsV2.go
+++ b/ledger/store/trackerdb/sqlitedriver/accountsV2.go
@@ -56,6 +56,11 @@ func NewAccountsSQLReaderWriter(e db.Executable) *accountsV2ReaderWriter {
 	}
 }
 
+// Testing returns this reader, exposed as an interface with test functions
+func (r *accountsV2Reader) Testing() trackerdb.TestAccountsReaderExt {
+	return r
+}
+
 func (r *accountsV2Reader) getOrPrepare(queryString string) (stmt *sql.Stmt, err error) {
 	// fetch statement (use the query as the key)
 	if stmt, ok := r.preparedStatements[queryString]; ok {

--- a/ledger/store/trackerdb/sqlitedriver/accountsV2.go
+++ b/ledger/store/trackerdb/sqlitedriver/accountsV2.go
@@ -94,6 +94,7 @@ func (r *accountsV2Reader) AccountsTotals(ctx context.Context, catchpointStaging
 
 // AccountsAllTest iterates the account table and returns a map of the data
 // It is meant only for testing purposes - it is heavy and has no production use case.
+// implements Testing interface
 func (r *accountsV2Reader) AccountsAllTest() (bals map[basics.Address]basics.AccountData, err error) {
 	rows, err := r.q.Query("SELECT rowid, address, data FROM accountbase")
 	if err != nil {
@@ -137,6 +138,7 @@ func (r *accountsV2Reader) AccountsAllTest() (bals map[basics.Address]basics.Acc
 	return
 }
 
+// implements Testing interface
 func (r *accountsV2Reader) CheckCreatablesTest(t *testing.T,
 	iteration int,
 	expectedDbImage map[basics.CreatableIndex]ledgercore.ModifiedCreatable) {

--- a/ledger/store/trackerdb/sqlitedriver/store_sqlite_impl.go
+++ b/ledger/store/trackerdb/sqlitedriver/store_sqlite_impl.go
@@ -170,6 +170,7 @@ func (txs sqlTransactionScope) MakeAccountsReaderWriter() (trackerdb.AccountsRea
 	return NewAccountsSQLReaderWriter(txs.tx), nil
 }
 
+// implements Testing interface
 func (txs sqlTransactionScope) MakeAccountsOptimizedReader() (trackerdb.AccountsReader, error) {
 	return AccountsInitDbQueries(txs.tx)
 }
@@ -182,6 +183,7 @@ func (txs sqlTransactionScope) MakeOnlineAccountsOptimizedWriter(hasAccounts boo
 	return MakeOnlineAccountsSQLWriter(txs.tx, hasAccounts)
 }
 
+// implements Testing interface
 func (txs sqlTransactionScope) MakeOnlineAccountsOptimizedReader() (r trackerdb.OnlineAccountsReader, err error) {
 	return OnlineAccountsInitDbQueries(txs.tx)
 }
@@ -210,10 +212,12 @@ func (txs sqlTransactionScope) ResetTransactionWarnDeadline(ctx context.Context,
 	return db.ResetTransactionWarnDeadline(ctx, txs.tx, deadline)
 }
 
+// implements Testing interface
 func (txs sqlTransactionScope) AccountsInitTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool) {
 	return AccountsInitTest(tb, txs.tx, initAccounts, proto)
 }
 
+// implements Testing interface
 func (txs sqlTransactionScope) AccountsInitLightTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto config.ConsensusParams) (newDatabase bool, err error) {
 	return AccountsInitLightTest(tb, txs.tx, initAccounts, proto)
 }
@@ -235,6 +239,7 @@ func (bs sqlBatchScope) MakeAccountsOptimizedWriter(hasAccounts, hasResources, h
 	return MakeAccountsSQLWriter(bs.tx, hasAccounts, hasResources, hasKvPairs, hasCreatables)
 }
 
+// implements Testing interface
 func (bs sqlBatchScope) RunMigrations(ctx context.Context, params trackerdb.Params, log logging.Logger, targetVersion int32) (mgr trackerdb.InitParams, err error) {
 	return RunMigrations(ctx, bs.tx, params, log, targetVersion)
 }
@@ -243,10 +248,17 @@ func (bs sqlBatchScope) ResetTransactionWarnDeadline(ctx context.Context, deadli
 	return db.ResetTransactionWarnDeadline(ctx, bs.tx, deadline)
 }
 
+// implements Testing interface
 func (bs sqlBatchScope) AccountsInitTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool) {
 	return AccountsInitTest(tb, bs.tx, initAccounts, proto)
 }
 
+// implements Testing interface
+func (bs sqlBatchScope) ModifyAcctBaseTest() error {
+	return ModifyAcctBaseTest(bs.tx)
+}
+
+// implements Testing interface
 func (bs sqlBatchScope) AccountsUpdateSchemaTest(ctx context.Context) (err error) {
 	return AccountsUpdateSchemaTest(ctx, bs.tx)
 }

--- a/ledger/store/trackerdb/sqlitedriver/store_sqlite_impl.go
+++ b/ledger/store/trackerdb/sqlitedriver/store_sqlite_impl.go
@@ -157,6 +157,11 @@ func (s *trackerSQLStore) Close() {
 	s.pair.Close()
 }
 
+// Testing returns this scope, exposed as an interface with test functions
+func (txs sqlTransactionScope) Testing() trackerdb.TestTransactionScope {
+	return txs
+}
+
 func (txs sqlTransactionScope) MakeCatchpointReaderWriter() (trackerdb.CatchpointReaderWriter, error) {
 	return NewCatchpointSQLReaderWriter(txs.tx), nil
 }
@@ -211,6 +216,11 @@ func (txs sqlTransactionScope) AccountsInitTest(tb testing.TB, initAccounts map[
 
 func (txs sqlTransactionScope) AccountsInitLightTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto config.ConsensusParams) (newDatabase bool, err error) {
 	return AccountsInitLightTest(tb, txs.tx, initAccounts, proto)
+}
+
+// Testing returns this scope, exposed as an interface with test functions
+func (s sqlBatchScope) Testing() trackerdb.TestBatchScope {
+	return s
 }
 
 func (bs sqlBatchScope) MakeCatchpointWriter() (trackerdb.CatchpointWriter, error) {

--- a/ledger/store/trackerdb/sqlitedriver/store_sqlite_impl.go
+++ b/ledger/store/trackerdb/sqlitedriver/store_sqlite_impl.go
@@ -255,7 +255,7 @@ func (bs sqlBatchScope) AccountsInitTest(tb testing.TB, initAccounts map[basics.
 
 // implements Testing interface
 func (bs sqlBatchScope) ModifyAcctBaseTest() error {
-	return ModifyAcctBaseTest(bs.tx)
+	return modifyAcctBaseTest(bs.tx)
 }
 
 // implements Testing interface

--- a/ledger/store/trackerdb/sqlitedriver/store_sqlite_impl.go
+++ b/ledger/store/trackerdb/sqlitedriver/store_sqlite_impl.go
@@ -223,8 +223,8 @@ func (txs sqlTransactionScope) AccountsInitLightTest(tb testing.TB, initAccounts
 }
 
 // Testing returns this scope, exposed as an interface with test functions
-func (s sqlBatchScope) Testing() trackerdb.TestBatchScope {
-	return s
+func (bs sqlBatchScope) Testing() trackerdb.TestBatchScope {
+	return bs
 }
 
 func (bs sqlBatchScope) MakeCatchpointWriter() (trackerdb.CatchpointWriter, error) {

--- a/ledger/store/trackerdb/sqlitedriver/testing.go
+++ b/ledger/store/trackerdb/sqlitedriver/testing.go
@@ -50,18 +50,22 @@ func SetDbTrackerTestLogging(t testing.TB, dbs trackerdb.TrackerStore) {
 }
 
 // AccountsInitLightTest initializes an empty database for testing without the extra methods being called.
+// implements Testing interface, test function only
 func AccountsInitLightTest(tb testing.TB, tx *sql.Tx, initAccounts map[basics.Address]basics.AccountData, proto config.ConsensusParams) (newDatabase bool, err error) {
 	newDB, err := accountsInit(tx, initAccounts, proto)
 	require.NoError(tb, err)
 	return newDB, err
 }
 
+// ModifyAcctBaseTest tweaks the database to move backards.
+// implements Testing interface, test function only
 func ModifyAcctBaseTest(tx *sql.Tx) error {
 	_, err := tx.Exec("update acctrounds set rnd = 1 WHERE id='acctbase' ")
 	return err
 }
 
 // AccountsInitTest initializes an empty database for testing.
+// implements Testing interface, test function only
 func AccountsInitTest(tb testing.TB, tx *sql.Tx, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool) {
 	newDB, err := accountsInit(tx, initAccounts, config.Consensus[proto])
 	require.NoError(tb, err)

--- a/ledger/store/trackerdb/sqlitedriver/testing.go
+++ b/ledger/store/trackerdb/sqlitedriver/testing.go
@@ -57,9 +57,9 @@ func AccountsInitLightTest(tb testing.TB, tx *sql.Tx, initAccounts map[basics.Ad
 	return newDB, err
 }
 
-// ModifyAcctBaseTest tweaks the database to move backards.
+// modifyAcctBaseTest tweaks the database to move backards.
 // implements Testing interface, test function only
-func ModifyAcctBaseTest(tx *sql.Tx) error {
+func modifyAcctBaseTest(tx *sql.Tx) error {
 	_, err := tx.Exec("update acctrounds set rnd = 1 WHERE id='acctbase' ")
 	return err
 }

--- a/ledger/store/trackerdb/sqlitedriver/testing.go
+++ b/ledger/store/trackerdb/sqlitedriver/testing.go
@@ -56,6 +56,11 @@ func AccountsInitLightTest(tb testing.TB, tx *sql.Tx, initAccounts map[basics.Ad
 	return newDB, err
 }
 
+func ModifyAcctBaseTest(tx *sql.Tx) error {
+	_, err := tx.Exec("update acctrounds set rnd = 1 WHERE id='acctbase' ")
+	return err
+}
+
 // AccountsInitTest initializes an empty database for testing.
 func AccountsInitTest(tb testing.TB, tx *sql.Tx, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool) {
 	newDB, err := accountsInit(tx, initAccounts, config.Consensus[proto])

--- a/ledger/store/trackerdb/store.go
+++ b/ledger/store/trackerdb/store.go
@@ -18,13 +18,9 @@ package trackerdb
 
 import (
 	"context"
-	"testing"
 	"time"
 
-	"github.com/algorand/go-algorand/config"
-	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/logging"
-	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/util/db"
 )
 
@@ -33,19 +29,14 @@ type BatchScope interface {
 	MakeCatchpointWriter() (CatchpointWriter, error)
 	MakeAccountsWriter() (AccountsWriterExt, error)
 	MakeAccountsOptimizedWriter(hasAccounts, hasResources, hasKvPairs, hasCreatables bool) (AccountsWriter, error)
-
-	RunMigrations(ctx context.Context, params Params, log logging.Logger, targetVersion int32) (mgr InitParams, err error)
 	ResetTransactionWarnDeadline(ctx context.Context, deadline time.Time) (prevDeadline time.Time, err error)
-
-	AccountsInitTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool)
-	AccountsUpdateSchemaTest(ctx context.Context) (err error)
+	Testing() TestBatchScope
 }
 
 // SnapshotScope is the read scope to the store.
 type SnapshotScope interface {
 	MakeAccountsReader() (AccountsReaderExt, error)
 	MakeCatchpointReader() (CatchpointReader, error)
-
 	MakeCatchpointPendingHashesIterator(hashCount int) CatchpointPendingHashesIter
 }
 
@@ -53,22 +44,15 @@ type SnapshotScope interface {
 type TransactionScope interface {
 	MakeCatchpointReaderWriter() (CatchpointReaderWriter, error)
 	MakeAccountsReaderWriter() (AccountsReaderWriter, error)
-	MakeAccountsOptimizedReader() (AccountsReader, error)
 	MakeAccountsOptimizedWriter(hasAccounts, hasResources, hasKvPairs, hasCreatables bool) (AccountsWriter, error)
 	MakeOnlineAccountsOptimizedWriter(hasAccounts bool) (w OnlineAccountsWriter, err error)
-	MakeOnlineAccountsOptimizedReader() (OnlineAccountsReader, error)
-
 	MakeMerkleCommitter(staging bool) (MerkleCommitter, error)
-
 	MakeOrderedAccountsIter(accountCount int) OrderedAccountsIter
 	MakeKVsIter(ctx context.Context) (KVsIter, error)
 	MakeEncodedAccoutsBatchIter() EncodedAccountsBatchIter
-
 	RunMigrations(ctx context.Context, params Params, log logging.Logger, targetVersion int32) (mgr InitParams, err error)
 	ResetTransactionWarnDeadline(ctx context.Context, deadline time.Time) (prevDeadline time.Time, err error)
-
-	AccountsInitTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool)
-	AccountsInitLightTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto config.ConsensusParams) (newDatabase bool, err error)
+	Testing() TestTransactionScope
 }
 
 // BatchFn is the callback lambda used in `Batch`.

--- a/ledger/store/trackerdb/testinterface.go
+++ b/ledger/store/trackerdb/testinterface.go
@@ -21,6 +21,7 @@ type TestBatchScope interface {
 	AccountsInitTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool)
 	AccountsUpdateSchemaTest(ctx context.Context) (err error)
 	RunMigrations(ctx context.Context, params Params, log logging.Logger, targetVersion int32) (mgr InitParams, err error)
+	ModifyAcctBaseTest() error
 }
 
 type TestTransactionScope interface {

--- a/ledger/store/trackerdb/testinterface.go
+++ b/ledger/store/trackerdb/testinterface.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2023 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package trackerdb
 
 import (
@@ -11,9 +27,12 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 )
 
-// testinterfaces.go contains interface extensions for the store package
-// to use test-only functionality, cast your Interface to the test-version, eg:
-// testTx := tx.(TransactionTestScope)
+// testinterface.go contains interface extensions specific to testing
+// testing interfaces should be made accessable by calling the Testing() method
+// on the related interface. Example:
+// testTx := tx.Testing()
+// these can also be inlined:
+// tx.Testing.AccountsInitTest(...)
 
 type TestBatchScope interface {
 	BatchScope

--- a/ledger/store/trackerdb/testinterface.go
+++ b/ledger/store/trackerdb/testinterface.go
@@ -1,0 +1,40 @@
+package trackerdb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/protocol"
+)
+
+// testinterfaces.go contains interface extensions for the store package
+// to use test-only functionality, cast your Interface to the test-version, eg:
+// testTx := tx.(TransactionTestScope)
+
+type TestBatchScope interface {
+	BatchScope
+
+	AccountsInitTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool)
+	AccountsUpdateSchemaTest(ctx context.Context) (err error)
+	RunMigrations(ctx context.Context, params Params, log logging.Logger, targetVersion int32) (mgr InitParams, err error)
+}
+
+type TestTransactionScope interface {
+	TransactionScope
+
+	MakeAccountsOptimizedReader() (AccountsReader, error)
+	MakeOnlineAccountsOptimizedReader() (OnlineAccountsReader, error)
+	AccountsInitTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool)
+	AccountsInitLightTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto config.ConsensusParams) (newDatabase bool, err error)
+}
+
+type TestAccountsReaderExt interface {
+	AccountsReaderExt
+
+	AccountsAllTest() (bals map[basics.Address]basics.AccountData, err error)
+	CheckCreatablesTest(t *testing.T, iteration int, expectedDbImage map[basics.CreatableIndex]ledgercore.ModifiedCreatable)
+}

--- a/ledger/store/trackerdb/testinterface.go
+++ b/ledger/store/trackerdb/testinterface.go
@@ -28,12 +28,13 @@ import (
 )
 
 // testinterface.go contains interface extensions specific to testing
-// testing interfaces should be made accessable by calling the Testing() method
+// testing interfaces should be made accessible by calling the Testing() method
 // on the related interface. Example:
 // testTx := tx.Testing()
 // these can also be inlined:
 // tx.Testing.AccountsInitTest(...)
 
+// TestBatchScope is an interface to extend BatchScope with test-only methods
 type TestBatchScope interface {
 	BatchScope
 
@@ -43,6 +44,7 @@ type TestBatchScope interface {
 	ModifyAcctBaseTest() error
 }
 
+// TestTransactionScope is an interface to extend TransactionScope with test-only methods
 type TestTransactionScope interface {
 	TransactionScope
 
@@ -52,6 +54,7 @@ type TestTransactionScope interface {
 	AccountsInitLightTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto config.ConsensusParams) (newDatabase bool, err error)
 }
 
+// TestAccountsReaderExt is an interface to extend AccountsReaderExt with test-only methods
 type TestAccountsReaderExt interface {
 	AccountsReaderExt
 

--- a/ledger/txtail_test.go
+++ b/ledger/txtail_test.go
@@ -162,7 +162,7 @@ func (t *txTailTestLedger) initialize(ts *testing.T, protoVersion protocol.Conse
 
 		accts := ledgertesting.RandomAccounts(20, true)
 		proto := config.Consensus[protoVersion]
-		newDB := tx.AccountsInitTest(ts, accts, protoVersion)
+		newDB := tx.Testing().AccountsInitTest(ts, accts, protoVersion)
 		require.True(ts, newDB)
 
 		roundData := make([][]byte, 0, proto.MaxTxnLife)


### PR DESCRIPTION
* Moves test-only interface definitions to a `testinterface.go` file
* Adds ".Testing()" to any interface with extra Testing functionality. The implementation will return itself as a test-interface. If the interface isn't satisfied, that will be caught as a compilation error (in your IDE), so no typeCasting at play here :)
* Restores the "TestAcctOnlineTopDBBehindMemRound" test. in doing so I added one new test function to abstract away the SQL in the test.
* Marked any test-only functions with a note that they implement the testing interface.

testing implementations still live in their original files, which I decided looked cleaner now that the `Testing()` function is able to enforce interface satisfaction -- if you need to add a test method, but don't supply an implementation, you'll get IDE warnings right away.