### PR TITLE
stateproof: check for latest round after Wait in Worker.builder

### DIFF
--- a/stateproof/builder.go
+++ b/stateproof/builder.go
@@ -267,9 +267,11 @@ func (spw *Worker) builder(latest basics.Round) {
 
 		// See if any new state proofs were formed, according to
 		// the new block, which would mean we can clean up some builders.
-		hdr, err := spw.ledger.BlockHdr(nextrnd)
+		newLatest := spw.ledger.Latest()
+		hdr, err := spw.ledger.BlockHdr(newLatest)
+
 		if err != nil {
-			spw.log.Warnf("spw.builder: BlockHdr(%d): %v", nextrnd, err)
+			spw.log.Warnf("spw.builder: BlockHdr(%d): %v", newLatest, err)
 			continue
 		}
 
@@ -281,7 +283,6 @@ func (spw *Worker) builder(latest basics.Round) {
 		// for block R, nodes will have already verified block R, because
 		// block R+1 has been formed.
 		proto := config.Consensus[hdr.CurrentProtocol]
-		newLatest := spw.ledger.Latest()
 		for r := latest; r < newLatest; r++ {
 			// Wait for the signer to catch up; mostly relevant in tests.
 			spw.waitForSignature(r)


### PR DESCRIPTION
## Summary

Excerpted from #4803, this handles the case when ledger.Wait(nextRnd) advances beyond nextRnd and no block header is available for the old round that was being waited on. This can happen during fast catchup for example.

## Test Plan

Existing tests should pass; maybe a new test could be written that implemented a mock ledger.Wait() & ledger.Latest() that produced this issue.