### PR TITLE
populate spver tracker from db on migration

### DIFF
--- a/ledger/apply/stateproof.go
+++ b/ledger/apply/stateproof.go
@@ -86,11 +86,6 @@ func gatherVerificationContextUsingBlockHeaders(sp StateProofsApplier, lastRound
 		return nil, err
 	}
 
-	verificationContext := ledgercore.StateProofVerificationContext{
-		LastAttestedRound: lastRoundInInterval,
-		VotersCommitment:  votersHdr.StateProofTracking[protocol.StateProofBasic].StateProofVotersCommitment,
-		OnlineTotalWeight: votersHdr.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight,
-		Version:           votersHdr.CurrentProtocol,
-	}
-	return &verificationContext, nil
+	verificationContext := ledgercore.MakeStateProofVerificationContext(votersHdr, lastRoundInInterval)
+	return verificationContext, nil
 }

--- a/ledger/catchpointwriter_test.go
+++ b/ledger/catchpointwriter_test.go
@@ -136,8 +136,8 @@ func verifyStateProofVerificationContextWrite(t *testing.T, data []ledgercore.St
 	fileName := filepath.Join(temporaryDirectory, "15.data")
 
 	mockCommitData := make([]verificationCommitContext, 0)
-	for _, element := range data {
-		mockCommitData = append(mockCommitData, verificationCommitContext{verificationContext: element})
+	for i := range data {
+		mockCommitData = append(mockCommitData, verificationCommitContext{verificationContext: &data[i]})
 	}
 
 	err = ml.dbs.Transaction(func(ctx context.Context, tx trackerdb.TransactionScope) error {
@@ -164,6 +164,7 @@ func verifyStateProofVerificationContextWrite(t *testing.T, data []ledgercore.St
 		}
 		return
 	})
+	require.NoError(t, err)
 
 	catchpointData := readCatchpointDataFile(t, fileName)
 	require.Equal(t, "stateProofVerificationContext.msgpack", catchpointData[0].headerName)
@@ -273,6 +274,7 @@ func TestBasicCatchpointWriter(t *testing.T) {
 		}
 		return
 	})
+	require.NoError(t, err)
 
 	catchpointContent := readCatchpointDataFile(t, fileName)
 	require.Equal(t, "balances.1.msgpack", catchpointContent[1].headerName)
@@ -480,12 +482,13 @@ func TestCatchpointReadDatabaseOverflowAccounts(t *testing.T) {
 	accts := ledgertesting.RandomAccounts(5, false)
 	// force each acct to have overflowing number of resources
 	assetIndex := 1000
+	const numAssetParams = 20
 	for addr, acct := range accts {
 		if acct.AssetParams == nil {
-			acct.AssetParams = make(map[basics.AssetIndex]basics.AssetParams, 0)
+			acct.AssetParams = make(map[basics.AssetIndex]basics.AssetParams, numAssetParams)
 			accts[addr] = acct
 		}
-		for i := uint64(0); i < 20; i++ {
+		for i := uint64(0); i < numAssetParams; i++ {
 			ap := ledgertesting.RandomAssetParams()
 			acct.AssetParams[basics.AssetIndex(assetIndex)] = ap
 			assetIndex++

--- a/ledger/ledgercore/stateproofverification.go
+++ b/ledger/ledgercore/stateproofverification.go
@@ -19,6 +19,7 @@ package ledgercore
 import (
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -37,4 +38,14 @@ type StateProofVerificationContext struct {
 
 	// Version is the protocol version that would be used to verify the state proof
 	Version protocol.ConsensusVersion `codec:"v"`
+}
+
+// MakeStateProofVerificationContext produces a new StateProofVerificationContext instance from a block header and last attested round
+func MakeStateProofVerificationContext(hdr bookkeeping.BlockHeader, lastAttested basics.Round) *StateProofVerificationContext {
+	return &StateProofVerificationContext{
+		VotersCommitment:  hdr.StateProofTracking[protocol.StateProofBasic].StateProofVotersCommitment,
+		OnlineTotalWeight: hdr.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight,
+		LastAttestedRound: lastAttested,
+		Version:           hdr.CurrentProtocol,
+	}
 }

--- a/ledger/store/trackerdb/sqlitedriver/trackerdbV2.go
+++ b/ledger/store/trackerdb/sqlitedriver/trackerdbV2.go
@@ -493,6 +493,13 @@ func (tu *trackerDBSchemaInitializer) upgradeDatabaseSchema9(ctx context.Context
 		return err
 	}
 
+	if !tu.newDatabase {
+		err = initializeStateProofVerificationTable(ctx, tx, tu.BlockDb.Rdb)
+		if err != nil {
+			return err
+		}
+	}
+
 	// update version
 	return tu.setVersion(ctx, tx, 10)
 }


### PR DESCRIPTION
## Summary

Initialize the stateproof context table with data from dblockdb on table creation. This would populate the table and have it ready to use.

Make the verification context creation as a shared helper function to use in tracker, apply, and migration code.

## Test

Added a unit test to simulate the following scenario:

1. Part node is upgraded at round v37 - 5 (5 rounds before a new consensus version is in effect)
2. Stateproof txn comes at round v37+5
2. The node have to use new tracker data
