### PR TITLE
tests: fix esingle-payer-swap e2e subs test

### DIFF
--- a/test/scripts/e2e_subs/single-payer-swap.sh
+++ b/test/scripts/e2e_subs/single-payer-swap.sh
@@ -40,10 +40,10 @@ ${gcmd} clerk send -a 100 -f "${MOOCHER}" -t "${PAYER}" --fee 0 -o cheap.txn
 # Since goal was modified to allow zero when this feature was added, let's confirm
 # that it's not encoded (should be "omitempty")
 set +e
-FOUND=$(msgpacktool -d < cheap.txn | grep fee)
+FOUND=$(msgpacktool -d < cheap.txn | grep '"fee"')
 set -e
 if [[ $FOUND != "" ]]; then
-    date "+{scriptname} FAIL fee was improperly encoded $FOUND %Y%m%d_%H%M%S"
+    date "+${scriptname} FAIL fee was improperly encoded $FOUND %Y%m%d_%H%M%S"
     false
 fi
 


### PR DESCRIPTION
## Summary

Prevent [test failure ](https://app.circleci.com/pipelines/github/algorand/go-algorand/13050/workflows/ee45db08-f15a-4e98-803f-c579bb5dd53d/jobs/215240) when base64 encoded fields have `"fee"` substring.

## Test Plan

This is a test fix