### PR TITLE
telemetry: fine-grained breakdown of AssembleBlockStats.StopReason

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -888,7 +888,7 @@ func (pool *TransactionPool) AssembleBlock(round basics.Round, deadline time.Tim
 	// if the transaction pool is more than two rounds behind, we don't want to wait.
 	if pool.assemblyResults.roundStartedEvaluating <= round.SubSaturate(2) {
 		pool.log.Infof("AssembleBlock: requested round is more than a single round ahead of the transaction pool %d <= %d-2", pool.assemblyResults.roundStartedEvaluating, round)
-		stats.StopReason = telemetryspec.AssembleBlockEmpty
+		stats.StopReason = telemetryspec.AssembleBlockPoolBehind
 		pool.assemblyMu.Unlock()
 		return pool.assembleEmptyBlock(round)
 	}
@@ -935,7 +935,7 @@ func (pool *TransactionPool) AssembleBlock(round basics.Round, deadline time.Tim
 		if !pool.assemblyResults.ok {
 			// it didn't. Lucky us - we already prepared an empty block, so we can return this right now.
 			pool.log.Warnf("AssembleBlock: ran out of time for round %d", round)
-			stats.StopReason = telemetryspec.AssembleBlockTimeout
+			stats.StopReason = telemetryspec.AssembleBlockTimeoutEmpty
 			if emptyBlockErr != nil {
 				emptyBlockErr = fmt.Errorf("AssembleBlock: failed to construct empty block : %w", emptyBlockErr)
 			}
@@ -955,7 +955,7 @@ func (pool *TransactionPool) AssembleBlock(round basics.Round, deadline time.Tim
 		return nil, ErrStaleBlockAssemblyRequest
 	} else if pool.assemblyResults.roundStartedEvaluating == round.SubSaturate(1) {
 		pool.log.Warnf("AssembleBlock: assembled block round did not catch up to requested round: %d != %d", pool.assemblyResults.roundStartedEvaluating, round)
-		stats.StopReason = telemetryspec.AssembleBlockTimeout
+		stats.StopReason = telemetryspec.AssembleBlockEvalOld
 		return pool.assembleEmptyBlock(round)
 	} else if pool.assemblyResults.roundStartedEvaluating < round {
 		return nil, fmt.Errorf("AssembleBlock: assembled block round much behind requested round: %d != %d",

--- a/logging/telemetryspec/metric.go
+++ b/logging/telemetryspec/metric.go
@@ -77,21 +77,30 @@ type StateProofStats struct {
 	TxnSize        int
 }
 
-// AssembleBlockTimeout represents AssemblePayset exiting due to timeout
+// AssembleBlockTimeout represents AssembleBlock exiting due to timeout
 const AssembleBlockTimeout = "timeout"
 
-// AssembleBlockFull represents AssemblePayset exiting due to block being full
+// AssembleBlockTimeout represents AssembleBlock giving up after a timeout and returning an empty block
+const AssembleBlockTimeoutEmpty = "timeout-empty"
+
+// AssembleBlockFull represents AssembleBlock exiting due to block being full
 const AssembleBlockFull = "block-full"
 
-// AssembleBlockEmpty represents AssemblePayset exiting due to no more txns
+// AssembleBlockEmpty represents AssembleBlock exiting due to no more txns
 const AssembleBlockEmpty = "pool-empty"
+
+// AssembleBlockPoolBehind represents the transaction pool being more than two roudns behind
+const AssembleBlockPoolBehind = "pool-behind"
+
+// AssembleBlockEvalOld represents the assembled block that was returned being a round too old
+const AssembleBlockEvalOld = "eval-old"
 
 // AssembleBlockAbandon represents the block generation being abandoned since it won't be needed.
 const AssembleBlockAbandon = "block-abandon"
 
 const assembleBlockMetricsIdentifier Metric = "AssembleBlock"
 
-// AssembleBlockMetrics is the set of metrics captured when we compute AssemblePayset
+// AssembleBlockMetrics is the set of metrics captured when we compute AssembleBlock
 type AssembleBlockMetrics struct {
 	AssembleBlockStats
 }


### PR DESCRIPTION
## Summary

Some of the AssembleBlockStats StopReason codes (especially AssembleBlockTimeout) are overloaded and catch multiple cases of block assembly completing. This splits out each case into a unique StopReason.

## Test Plan

Telemetry only change, existing tests should pass.