### PR TITLE
algocfg: Bug fix - Add colon to indicate port specification

### DIFF
--- a/cmd/algocfg/profileCommand.go
+++ b/cmd/algocfg/profileCommand.go
@@ -70,7 +70,7 @@ var (
 			cfg.Archival = true
 			cfg.EnableLedgerService = true
 			cfg.EnableBlockService = true
-			cfg.NetAddress = "4160"
+			cfg.NetAddress = ":4160"
 			return cfg
 		},
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

The new profile uses `4160` for the `NetAddress` field, but this needs to specify a port. Changed this to `:4160`.

It'll fail to start catchup with the relay profile when set as is.

## Test Plan

Set config profile to relay and started a node, verified that it was catching up.
