### PR TITLE
CI: set reviewdog golangci-lint go version

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -21,6 +21,7 @@ jobs:
       - name: reviewdog-golangci-lint
         uses: reviewdog/action-golangci-lint@v2
         with:
+          go_version_file: go.mod
           golangci_lint_version: "v1.47.3"
           golangci_lint_flags: "-c .golangci.yml --allow-parallel-runners"
           reporter: "github-pr-check"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,6 @@ linters-settings:
     # We do this 121 times and never check the error.
     - (*github.com/spf13/cobra.Command).MarkFlagRequired
   govet:
-#    check-shadowing: true
     settings:
       printf:
         # Comma-separated list of print function names to check (in addition to default, see `go tool vet help printf`).
@@ -119,11 +118,6 @@ issues:
         # - revive
         - staticcheck
         - typecheck
-    # allow shadowing in test code
-    - path: _test\.go
-      linters:
-        - govet
-      text: "shadows declaration at line"
     # Ignore missing parallel tests in existing packages
     - path: ^agreement.*_test\.go
       linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,7 @@ linters-settings:
     # We do this 121 times and never check the error.
     - (*github.com/spf13/cobra.Command).MarkFlagRequired
   govet:
+#    check-shadowing: true
     settings:
       printf:
         # Comma-separated list of print function names to check (in addition to default, see `go tool vet help printf`).
@@ -118,6 +119,11 @@ issues:
         # - revive
         - staticcheck
         - typecheck
+    # allow shadowing in test code
+    - path: _test\.go
+      linters:
+        - govet
+      text: "shadows declaration at line"
     # Ignore missing parallel tests in existing packages
     - path: ^agreement.*_test\.go
       linters:

--- a/ledger/internal/appcow.go
+++ b/ledger/internal/appcow.go
@@ -458,7 +458,7 @@ func (cb *roundCowState) StatefulEval(gi int, params *logic.EvalParams, aidx bas
 	calf := cb.child(1)
 	defer func() {
 		// get rid of references to the object that is about to be recycled
-		params.Ledger = nil 
+		params.Ledger = nil
 		params.SigLedger = nil
 		calf.recycle()
 	}()

--- a/logging/telemetryspec/metric.go
+++ b/logging/telemetryspec/metric.go
@@ -80,7 +80,7 @@ type StateProofStats struct {
 // AssembleBlockTimeout represents AssembleBlock exiting due to timeout
 const AssembleBlockTimeout = "timeout"
 
-// AssembleBlockTimeout represents AssembleBlock giving up after a timeout and returning an empty block
+// AssembleBlockTimeoutEmpty represents AssembleBlock giving up after a timeout and returning an empty block
 const AssembleBlockTimeoutEmpty = "timeout-empty"
 
 // AssembleBlockFull represents AssembleBlock exiting due to block being full


### PR DESCRIPTION
## Summary

The reviewdog runs for golangci-lint have recently been crashing with the error `panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt` and it seems pinning the Go version fixes it.
 
This also fixes two lint errors that snuck through recently.

## Test Plan

Reviewdog golangci-lint should run without crashing