### PR TITLE
txHandler: make dedup working set independent from ERL

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -72,7 +72,7 @@ const StateProofFileName = "stateproof.sqlite"
 // It is used for tracking participation key metadata.
 const ParticipationRegistryFilename = "partregistry.sqlite"
 
-// ConfigurableConsensusProtocolsFilename defines a set of consensus prototocols that
+// ConfigurableConsensusProtocolsFilename defines a set of consensus protocols that
 // are to be loaded from the data directory ( if present ), to override the
 // built-in supported consensus protocols.
 const ConfigurableConsensusProtocolsFilename = "consensus.json"

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -122,7 +122,6 @@ type TxHandler struct {
 	net                   network.GossipNode
 	msgCache              *txSaltedCache
 	txCanonicalCache      *digestCache
-	cacheConfig           txHandlerConfig
 	ctx                   context.Context
 	ctxCancel             context.CancelFunc
 	streamVerifier        *execpool.StreamToBatch
@@ -140,12 +139,6 @@ type TxHandlerOpts struct {
 	GenesisID     string
 	GenesisHash   crypto.Digest
 	Config        config.Local
-}
-
-// txHandlerConfig is a subset of tx handler related options from config.Local
-type txHandlerConfig struct {
-	enableFilteringRawMsg    bool
-	enableFilteringCanonical bool
 }
 
 // MakeTxHandler makes a new handler for transaction messages
@@ -174,17 +167,16 @@ func MakeTxHandler(opts TxHandlerOpts) (*TxHandler, error) {
 		backlogQueue:          make(chan *txBacklogMsg, txBacklogSize),
 		postVerificationQueue: make(chan *verify.VerificationResult, txBacklogSize),
 		net:                   opts.Net,
-		cacheConfig:           txHandlerConfig{opts.Config.TxFilterRawMsgEnabled(), opts.Config.TxFilterCanonicalEnabled()},
 		streamVerifierChan:    make(chan execpool.InputJob),
 		streamVerifierDropped: make(chan *verify.UnverifiedTxnSigJob),
 	}
 
 	// use defaultBacklogSize = approx number of txns in a full block as a parameter for the dedup cache size
 	defaultBacklogSize := config.GetDefaultLocal().TxBacklogSize
-	if handler.cacheConfig.enableFilteringRawMsg {
+	if opts.Config.TxFilterRawMsgEnabled() {
 		handler.msgCache = makeSaltedCache(2 * defaultBacklogSize)
 	}
-	if handler.cacheConfig.enableFilteringCanonical {
+	if opts.Config.TxFilterCanonicalEnabled() {
 		handler.txCanonicalCache = makeDigestCache(2 * defaultBacklogSize)
 	}
 
@@ -508,11 +500,11 @@ func (handler *TxHandler) postProcessCheckedTxn(wi *txBacklogMsg) {
 }
 
 func (handler *TxHandler) deleteFromCaches(msgKey *crypto.Digest, canonicalKey *crypto.Digest) {
-	if handler.cacheConfig.enableFilteringCanonical && canonicalKey != nil {
+	if handler.txCanonicalCache != nil && canonicalKey != nil {
 		handler.txCanonicalCache.Delete(canonicalKey)
 	}
 
-	if handler.cacheConfig.enableFilteringRawMsg && msgKey != nil {
+	if handler.msgCache != nil && msgKey != nil {
 		handler.msgCache.DeleteByKey(msgKey)
 	}
 }
@@ -572,7 +564,7 @@ func (handler *TxHandler) dedupCanonical(ntx int, unverifiedTxGroup []transactio
 func (handler *TxHandler) processIncomingTxn(rawmsg network.IncomingMessage) network.OutgoingMessage {
 	var msgKey *crypto.Digest
 	var isDup bool
-	if handler.cacheConfig.enableFilteringRawMsg {
+	if handler.msgCache != nil {
 		// check for duplicate messages
 		// this helps against relaying duplicates
 		if msgKey, isDup = handler.msgCache.CheckAndPut(rawmsg.Data); isDup {
@@ -643,7 +635,7 @@ func (handler *TxHandler) processIncomingTxn(rawmsg network.IncomingMessage) net
 	}
 
 	var canonicalKey *crypto.Digest
-	if handler.cacheConfig.enableFilteringCanonical {
+	if handler.txCanonicalCache != nil {
 		if canonicalKey, isDup = handler.dedupCanonical(ntx, unverifiedTxGroup, consumed); isDup {
 			transactionMessagesDupCanonical.Inc(nil)
 			return network.OutgoingMessage{Action: network.Ignore}
@@ -664,10 +656,10 @@ func (handler *TxHandler) processIncomingTxn(rawmsg network.IncomingMessage) net
 		transactionMessagesDroppedFromBacklog.Inc(nil)
 
 		// additionally, remove the txn from duplicate caches to ensure it can be re-submitted
-		if handler.cacheConfig.enableFilteringCanonical && canonicalKey != nil {
+		if handler.txCanonicalCache != nil && canonicalKey != nil {
 			handler.txCanonicalCache.Delete(canonicalKey)
 		}
-		if handler.cacheConfig.enableFilteringRawMsg && msgKey != nil {
+		if handler.msgCache != nil && msgKey != nil {
 			handler.msgCache.DeleteByKey(msgKey)
 		}
 	}

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -174,11 +174,18 @@ func MakeTxHandler(opts TxHandlerOpts) (*TxHandler, error) {
 		backlogQueue:          make(chan *txBacklogMsg, txBacklogSize),
 		postVerificationQueue: make(chan *verify.VerificationResult, txBacklogSize),
 		net:                   opts.Net,
-		msgCache:              makeSaltedCache(2 * txBacklogSize),
-		txCanonicalCache:      makeDigestCache(2 * txBacklogSize),
 		cacheConfig:           txHandlerConfig{opts.Config.TxFilterRawMsgEnabled(), opts.Config.TxFilterCanonicalEnabled()},
 		streamVerifierChan:    make(chan execpool.InputJob),
 		streamVerifierDropped: make(chan *verify.UnverifiedTxnSigJob),
+	}
+
+	// use defaultBacklogSize = approx number of txns in a full block as a parameter for the dedup cache size
+	defaultBacklogSize := config.GetDefaultLocal().TxBacklogSize
+	if handler.cacheConfig.enableFilteringRawMsg {
+		handler.msgCache = makeSaltedCache(2 * defaultBacklogSize)
+	}
+	if handler.cacheConfig.enableFilteringCanonical {
+		handler.txCanonicalCache = makeDigestCache(2 * defaultBacklogSize)
 	}
 
 	if opts.Config.EnableTxBacklogRateLimiting {
@@ -191,7 +198,7 @@ func MakeTxHandler(opts TxHandlerOpts) (*TxHandler, error) {
 		handler.erl = rateLimiter
 	}
 
-	// prepare the transaction stream verifer
+	// prepare the transaction stream verifier
 	var err error
 	txnElementProcessor, err := verify.MakeSigVerifyJobProcessor(handler.ledger, handler.ledger.VerifiedTransactionCache(),
 		handler.postVerificationQueue, handler.streamVerifierDropped)
@@ -219,7 +226,9 @@ func (handler *TxHandler) droppedTxnWatcher() {
 // Start enables the processing of incoming messages at the transaction handler
 func (handler *TxHandler) Start() {
 	handler.ctx, handler.ctxCancel = context.WithCancel(context.Background())
-	handler.msgCache.Start(handler.ctx, 60*time.Second)
+	if handler.msgCache != nil {
+		handler.msgCache.Start(handler.ctx, 60*time.Second)
+	}
 	handler.net.RegisterHandlers([]network.TaggedMessageHandler{
 		{Tag: protocol.TxnTag, MessageHandler: network.HandlerFunc(handler.processIncomingTxn)},
 	})
@@ -240,7 +249,9 @@ func (handler *TxHandler) Stop() {
 	}
 	handler.backlogWg.Wait()
 	handler.streamVerifier.WaitForStop()
-	handler.msgCache.WaitForStop()
+	if handler.msgCache != nil {
+		handler.msgCache.WaitForStop()
+	}
 }
 
 func reencode(stxns []transactions.SignedTxn) []byte {
@@ -653,10 +664,10 @@ func (handler *TxHandler) processIncomingTxn(rawmsg network.IncomingMessage) net
 		transactionMessagesDroppedFromBacklog.Inc(nil)
 
 		// additionally, remove the txn from duplicate caches to ensure it can be re-submitted
-		if canonicalKey != nil {
+		if handler.cacheConfig.enableFilteringCanonical && canonicalKey != nil {
 			handler.txCanonicalCache.Delete(canonicalKey)
 		}
-		if msgKey != nil {
+		if handler.cacheConfig.enableFilteringRawMsg && msgKey != nil {
 			handler.msgCache.DeleteByKey(msgKey)
 		}
 	}

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -467,6 +467,7 @@ func TestReproducibleCatchpointLabels(t *testing.T) {
 		if (uint64(i) >= cfg.MaxAcctLookback) && (uint64(i)-cfg.MaxAcctLookback > protoParams.CatchpointLookback) && ((uint64(i)-cfg.MaxAcctLookback)%cfg.CatchpointInterval == 0) {
 			ml.trackers.waitAccountsWriting()
 			catchpointLabels[i] = ct.GetLastCatchpointLabel()
+			require.NotEmpty(t, catchpointLabels[i])
 			require.NotEqual(t, lastCatchpointLabel, catchpointLabels[i])
 			lastCatchpointLabel = catchpointLabels[i]
 			ledgerHistory[i] = ml.fork(t)


### PR DESCRIPTION
## Summary

Fine tuning ERL might affect the dedup working set size in a negative way. This PR fixes that.
Additionally, make dedup creation optional (only if enabled). This is not important but looks a right thing to do.
Plus couple non-related small comment/assert noted along the way.

## Test Plan

Existing tests