### PR TITLE
docker container: dockerfile update 

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -20,7 +20,7 @@ By default the following config.json overrides are applied:
 
 The following environment variables can be supplied. Except when noted, it is possible to reconfigure deployments even after the data directory has been initialized.
 
-| Variable | Description |                                                                                                                                        
+| Variable | Description |
 | -------- | ----------- |
 | NETWORK        | Leave blank for a private network, otherwise specify one of mainnet, betanet, testnet, or devnet. Only used during a data directory initialization. |
 | FAST_CATCHUP   | If set to 1 on a public network, attempt to start fast-catchup during initial config.                                                               |

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,18 +20,18 @@ By default the following config.json overrides are applied:
 
 The following environment variables can be supplied. Except when noted, it is possible to reconfigure deployments even after the data directory has been initialized.
 
-| Variable | Description                                                                                                                                         |
-| -------- |-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| NETWORK       | Leave blank for a private network, otherwise specify one of mainnet, betanet, testnet, or devnet. Only used during a data directory initialization. |
-| FAST_CATCHUP  | If set to 1 on a public network, attempt to start fast-catchup during initial config.                                                               |
-| TELEMETRY_NAME| If set on a public network, telemetry is reported with this name.                                                                                   |
-| DEV_MODE      | If set to 1 on a private network, enable dev mode. Only used during data directory initialization.                                                  |
-| NUM_ROUNDS    | If set on a private network, override default of 30000 participation keys.                                                                          |
-| TOKEN         | If set, overrides the REST API token.                                                                                                               |
-| ADMIN_TOKEN   | If set, overrides the REST API admin token.                                                                                                         |
-| KMD_TOKEN | If set along with `START_KMD`, override the KMD REST API token.                                                                                     |
-| START_KMD | When set to 1, start kmd service with no timeout. THIS SHOULD NOT BE USED IN PRODUCTION.                                                            |
-| PEER_ADDRESS | If set, override phonebook with peer ip:port (or semicolon separated list: ip:port;ip:port;ip:port...)                                              |
+| Variable       | Description |                                                                                                                                        
+| -------- | ----------- |
+| NETWORK        | Leave blank for a private network, otherwise specify one of mainnet, betanet, testnet, or devnet. Only used during a data directory initialization. |
+| FAST_CATCHUP   | If set to 1 on a public network, attempt to start fast-catchup during initial config.                                                               |
+| TELEMETRY_NAME | If set on a public network, telemetry is reported with this name.                                                                                   |
+| DEV_MODE       | If set to 1 on a private network, enable dev mode. Only used during data directory initialization.                                                  |
+| NUM_ROUNDS     | If set on a private network, override default of 30000 participation keys.                                                                          |
+| TOKEN          | If set, overrides the REST API token.                                                                                                               |
+| ADMIN_TOKEN    | If set, overrides the REST API admin token.                                                                                                         |
+| KMD_TOKEN      | If set along with `START_KMD`, override the KMD REST API token.                                                                                     |
+| START_KMD      | When set to 1, start kmd service with no timeout. THIS SHOULD NOT BE USED IN PRODUCTION.                                                            |
+| PEER_ADDRESS   | If set, override phonebook with peer ip:port (or semicolon separated list: ip:port;ip:port;ip:port...)                                              |
 
 ### Special Files
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,7 +20,7 @@ By default the following config.json overrides are applied:
 
 The following environment variables can be supplied. Except when noted, it is possible to reconfigure deployments even after the data directory has been initialized.
 
-| Variable       | Description |                                                                                                                                        
+| Variable | Description |                                                                                                                                        
 | -------- | ----------- |
 | NETWORK        | Leave blank for a private network, otherwise specify one of mainnet, betanet, testnet, or devnet. Only used during a data directory initialization. |
 | FAST_CATCHUP   | If set to 1 on a public network, attempt to start fast-catchup during initial config.                                                               |

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,6 +31,7 @@ The following environment variables can be supplied. Except when noted, it is po
 | ADMIN_TOKEN   | If set, overrides the REST API admin token. |
 | KMD_TOKEN | If set along with `START_KMD`, override the KMD REST API token. |
 | START_KMD | When set to 1, start kmd service with no timeout. THIS SHOULD NOT BE USED IN PRODUCTION. |
+| PEER_ADDRESS | If set, override phonebook with peer ip:port |
 
 ### Special Files
 
@@ -42,8 +43,7 @@ Configuration can be modified by specifying certain files. These can be changed 
 | /etc/algorand/algod.token | Override default randomized REST API token. |
 | /etc/algorand/algod.admin.token | Override default randomized REST API admin token. |
 | /etc/algorand/logging.config | Use a custom [logging.config](https://developer.algorand.org/docs/run-a-node/reference/telemetry-config/#configuration) file for configuring telemetry. |
-
-TODO: `/etc/algorand/template.json` for overriding the private network topology.
+ | /etc/algorand/template.json | Override default private network topology. | 
 
 ## Example Configuration
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -43,7 +43,7 @@ Configuration can be modified by specifying certain files. These can be changed 
 | /etc/algorand/algod.token | Override default randomized REST API token. |
 | /etc/algorand/algod.admin.token | Override default randomized REST API admin token. |
 | /etc/algorand/logging.config | Use a custom [logging.config](https://developer.algorand.org/docs/run-a-node/reference/telemetry-config/#configuration) file for configuring telemetry. |
- | /etc/algorand/template.json | Override default private network topology. | 
+ | /etc/algorand/template.json | Override default private network topology. One of the nodes in the template must be named "data".| 
 
 ## Example Configuration
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,18 +20,18 @@ By default the following config.json overrides are applied:
 
 The following environment variables can be supplied. Except when noted, it is possible to reconfigure deployments even after the data directory has been initialized.
 
-| Variable | Description |
-| -------- | ----------- |
+| Variable | Description                                                                                                                                         |
+| -------- |-----------------------------------------------------------------------------------------------------------------------------------------------------|
 | NETWORK       | Leave blank for a private network, otherwise specify one of mainnet, betanet, testnet, or devnet. Only used during a data directory initialization. |
-| FAST_CATCHUP  | If set to 1 on a public network, attempt to start fast-catchup during initial config. |
-| TELEMETRY_NAME| If set on a public network, telemetry is reported with this name. |
-| DEV_MODE      | If set to 1 on a private network, enable dev mode. Only used during data directory initialization. |
-| NUM_ROUNDS    | If set on a private network, override default of 30000 participation keys. |
-| TOKEN         | If set, overrides the REST API token. |
-| ADMIN_TOKEN   | If set, overrides the REST API admin token. |
-| KMD_TOKEN | If set along with `START_KMD`, override the KMD REST API token. |
-| START_KMD | When set to 1, start kmd service with no timeout. THIS SHOULD NOT BE USED IN PRODUCTION. |
-| PEER_ADDRESS | If set, override phonebook with peer ip:port |
+| FAST_CATCHUP  | If set to 1 on a public network, attempt to start fast-catchup during initial config.                                                               |
+| TELEMETRY_NAME| If set on a public network, telemetry is reported with this name.                                                                                   |
+| DEV_MODE      | If set to 1 on a private network, enable dev mode. Only used during data directory initialization.                                                  |
+| NUM_ROUNDS    | If set on a private network, override default of 30000 participation keys.                                                                          |
+| TOKEN         | If set, overrides the REST API token.                                                                                                               |
+| ADMIN_TOKEN   | If set, overrides the REST API admin token.                                                                                                         |
+| KMD_TOKEN | If set along with `START_KMD`, override the KMD REST API token.                                                                                     |
+| START_KMD | When set to 1, start kmd service with no timeout. THIS SHOULD NOT BE USED IN PRODUCTION.                                                            |
+| PEER_ADDRESS | If set, override phonebook with peer ip:port (or semicolon separated list: ip:port;ip:port;ip:port...)                                              |
 
 ### Special Files
 

--- a/docker/files/run/followermode_template.json
+++ b/docker/files/run/followermode_template.json
@@ -1,0 +1,51 @@
+{
+  "Genesis": {
+    "ConsensusProtocol": "future",
+    "NetworkName": "followermodenet",
+    "FirstPartKeyRound": 0,
+    "LastPartKeyRound":  NUM_ROUNDS,
+    "Wallets": [
+      {
+        "Name": "Wallet1",
+        "Stake": 40,
+        "Online": true
+      },
+      {
+        "Name": "Wallet2",
+        "Stake": 40,
+        "Online": true
+      },
+      {
+        "Name": "Wallet3",
+        "Stake": 20,
+        "Online": true
+      }
+    ],
+    "DevMode": true
+  },
+  "Nodes": [
+    {
+      "Name": "data",
+      "IsRelay": true,
+      "Wallets": [
+        {
+          "Name": "Wallet1",
+          "ParticipationOnly": false
+        },
+        {
+          "Name": "Wallet2",
+          "ParticipationOnly": false
+        },
+        {
+          "Name": "Wallet3",
+          "ParticipationOnly": false
+        }
+      ]
+    },
+    {
+      "Name": "follower",
+      "IsRelay": false,
+      "ConfigJSONOverride": "{\"EnableFollowMode\":true,\"EndpointAddress\":\"0.0.0.0:8081\"}"
+    }
+  ]
+}

--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -64,12 +64,9 @@ function configure_data_dir() {
 
   # check for token overrides
   if [ "$TOKEN" != "" ]; then
-    # set token for relay node
-    echo "$TOKEN" >algod.token
-    # set token for follower node
-    if [ -d "${ALGORAND_DATA}/../follower/" ]; then
-       echo "$TOKEN" >"${ALGORAND_DATA}/../follower/algod.token"
-    fi
+    for dir in ${ALGORAND_DATA}/../*/; do
+      echo "$TOKEN" > "$dir/algod.token"
+    done
   fi
   if [ "$ADMIN_TOKEN" != "" ]; then
     echo "$ADMIN_TOKEN" >algod.admin.token

--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -35,8 +35,12 @@ function start_public_network() {
     catchup &
   fi
 
-  # redirect output to stdout
-  algod -o
+  if [ "$PEER_ADDRESS" != "" ]; then
+       algod -o -p $PEER_ADDRESS
+  else
+    # redirect output to stdout
+    algod -o
+  fi
 }
 
 function configure_data_dir() {
@@ -142,8 +146,12 @@ function start_private_network() {
 
 function start_new_private_network() {
   local TEMPLATE="template.json"
-  if [ "$DEV_MODE" = "1" ]; then
-    TEMPLATE="devmode_template.json"
+  if [ -f "/etc/algorand/template.json" ]; then
+      cp /etc/algorand/template.json template.json
+  else
+      if [ "$DEV_MODE" = "1" ]; then
+          TEMPLATE="devmode_template.json"
+      fi
   fi
   sed -i "s/NUM_ROUNDS/${NUM_ROUNDS:-30000}/" "/node/run/$TEMPLATE"
   goal network create --noclean -n dockernet -r "${ALGORAND_DATA}/.." -t "/node/run/$TEMPLATE"

--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -36,6 +36,7 @@ function start_public_network() {
   fi
 
   if [ "$PEER_ADDRESS" != "" ]; then
+       printf "$PEER_ADDRESS"
        algod -o -p $PEER_ADDRESS
   else
     # redirect output to stdout
@@ -67,7 +68,6 @@ function configure_data_dir() {
     echo "$TOKEN" >algod.token
     # set token for follower node
     if [ -d "${ALGORAND_DATA}/../follower/" ]; then
-      printf "follower dir!"
        echo "$TOKEN" >"${ALGORAND_DATA}/../follower/algod.token"
     fi
   fi

--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -63,7 +63,13 @@ function configure_data_dir() {
 
   # check for token overrides
   if [ "$TOKEN" != "" ]; then
+    # set token for relay node
     echo "$TOKEN" >algod.token
+    # set token for follower node
+    if [ -d "${ALGORAND_DATA}/../follower/" ]; then
+      printf "follower dir!"
+       echo "$TOKEN" >"${ALGORAND_DATA}/../follower/algod.token"
+    fi
   fi
   if [ "$ADMIN_TOKEN" != "" ]; then
     echo "$ADMIN_TOKEN" >algod.admin.token
@@ -147,7 +153,7 @@ function start_private_network() {
 function start_new_private_network() {
   local TEMPLATE="template.json"
   if [ -f "/etc/algorand/template.json" ]; then
-      cp /etc/algorand/template.json template.json
+      cp /etc/algorand/template.json "/node/run/$TEMPLATE"
   else
       if [ "$DEV_MODE" = "1" ]; then
           TEMPLATE="devmode_template.json"

--- a/docker/files/run/template.json
+++ b/docker/files/run/template.json
@@ -1,13 +1,12 @@
 {
     "Genesis": {
-        "ConsensusProtocol": "future",
-        "NetworkName": "followermodenet",
+        "NetworkName": "",
         "FirstPartKeyRound": 0,
         "LastPartKeyRound":  NUM_ROUNDS,
         "Wallets": [
             {
                 "Name": "Wallet1",
-                "Stake": 40,
+                "Stake": 10,
                 "Online": true
             },
             {
@@ -17,16 +16,19 @@
             },
             {
                 "Name": "Wallet3",
-                "Stake": 20,
-                "Online": true
+                "Stake": 40,
+                "Online": false
+            },
+            {
+                "Name": "Wallet4",
+                "Stake": 10,
+                "Online": false
             }
-        ],
-        "DevMode": true
+        ]
     },
     "Nodes": [
         {
-            "Name": "R1",
-            "IsRelay": true,
+            "Name": "data",
             "Wallets": [
                 {
                     "Name": "Wallet1",
@@ -39,13 +41,12 @@
                 {
                     "Name": "Wallet3",
                     "ParticipationOnly": false
+                },
+                {
+                    "Name": "Wallet4",
+                    "ParticipationOnly": false
                 }
             ]
-        },
-        {
-            "Name": "data",
-            "IsRelay": false,
-            "ConfigJSONOverride": "{\"EnableFollowMode\":true}"
         }
     ]
 }

--- a/docker/files/run/template.json
+++ b/docker/files/run/template.json
@@ -1,12 +1,13 @@
 {
     "Genesis": {
-        "NetworkName": "",
+        "ConsensusProtocol": "future",
+        "NetworkName": "followermodenet",
         "FirstPartKeyRound": 0,
         "LastPartKeyRound":  NUM_ROUNDS,
         "Wallets": [
             {
                 "Name": "Wallet1",
-                "Stake": 10,
+                "Stake": 40,
                 "Online": true
             },
             {
@@ -16,19 +17,16 @@
             },
             {
                 "Name": "Wallet3",
-                "Stake": 40,
-                "Online": false
-            },
-            {
-                "Name": "Wallet4",
-                "Stake": 10,
-                "Online": false
+                "Stake": 20,
+                "Online": true
             }
-        ]
+        ],
+        "DevMode": true
     },
     "Nodes": [
         {
-            "Name": "data",
+            "Name": "R1",
+            "IsRelay": true,
             "Wallets": [
                 {
                     "Name": "Wallet1",
@@ -41,12 +39,13 @@
                 {
                     "Name": "Wallet3",
                     "ParticipationOnly": false
-                },
-                {
-                    "Name": "Wallet4",
-                    "ParticipationOnly": false
                 }
             ]
+        },
+        {
+            "Name": "data",
+            "IsRelay": false,
+            "ConfigJSONOverride": "{\"EnableFollowMode\":true}"
         }
     ]
 }


### PR DESCRIPTION
updating dockerfile to support devmode + followermode container
- supporting private network topology override.  
- adding a new env var `PEER_ADDRESS` for running multiple containers. A follower node container can connect to the relay node container by setting the host:port in`PEER_ADDRESS` . 