### PR TITLE
Algod: Remove unused 404 resp in simulate endpoint

### DIFF
--- a/daemon/algod/api/algod.oas2.json
+++ b/daemon/algod/api/algod.oas2.json
@@ -1254,9 +1254,6 @@
               "$ref": "#/definitions/ErrorResponse"
             }
           },
-          "404": {
-            "description": "Transaction simulator not enabled"
-          },
           "500": {
             "description": "Internal Error",
             "schema": {

--- a/daemon/algod/api/algod.oas3.yml
+++ b/daemon/algod/api/algod.oas3.yml
@@ -5803,10 +5803,6 @@
             },
             "description": "Invalid API Token"
           },
-          "404": {
-            "content": {},
-            "description": "Transaction simulator not enabled"
-          },
           "500": {
             "content": {
               "application/json": {

--- a/daemon/algod/api/server/v2/generated/nonparticipating/public/routes.go
+++ b/daemon/algod/api/server/v2/generated/nonparticipating/public/routes.go
@@ -797,10 +797,9 @@ var swaggerSpec = []string{
 	"48ARsco6T17m6GHBwxCd2NlyZ/Oo9Ki1CRWGPBsjx+F7M2bfK3I86pUSDVLPa98ui5zmGYlj4UKUeZao",
 	"Mk0h5qFxHPWaqpbaFOBwLCu7uQEhI1kpbWVsQlNdYg2aKebFFLbkFOXr5vWPtbuEDPJnEkoUm3OqSwlj",
 	"uzb0FJsCQYPjJOI+07rcG9d0sPM1Stuo2Ed5gdtjcHsM/nzHoHPpvHVEMmupEixlhAT4pyoMUWeOO3Il",
-	"Ntq50f6sRSL61clus4W8TtXZ9Zdi+JTPi0+9mk/1WvFsXBGK9X5DTtDKpmgZA1WEacctp0DgnOYlclOX",
-	"L9694SfktOa1lZd4qVwa03RBGXfZa6p4BoRDu1TL2ud23JdCk17oFXf6TMs2UZFpsAFpKZle40OGFuy3",
-	"MzD/f29eArb+qH3jlDIfHY4WWheHBwdYsn8hlD4YfRyH31Tr4/sK/A/+eVJIdo4VfN5//P8BAAD//6G6",
-	"O0DCSQEA",
+	"Ntq50W7r0n/WBRU+5SPhU6/mU705PDNWhGLV3vA8t3Ii2uNNFWHa8bwpEDineYk80WV9dy/xCTmtOWbl",
+	"610ql4w0XVDGXQ6aKioB4dAuYbL2GRr3pZakF3rFnVbSMj9URxpsQFpKptf4HKEF++0MzP/fG3neVhG1",
+	"L5VS5qPD0ULr4vDgAAvvL4TSB6OP4/Cban18X4H/wT8yCsnOsQ7P+4//PwAA//+FikGliEkBAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

As I was reading https://github.com/algorand/go-algorand/pull/5159/, I noticed an addition of 404 response to `/v2/transactions/simulate`, while `handler.go` impl does not have `notFound` return.

So I remove the 404 response, as it is unused here.
