### PR TITLE
cleanup: remove redundant method LookupAccountDataByAddress

### DIFF
--- a/ledger/acctdeltas.go
+++ b/ledger/acctdeltas.go
@@ -466,7 +466,7 @@ func (a *compactAccountDeltas) accountsLoadOld(tx trackerdb.TransactionScope) (e
 	if len(a.misses) == 0 {
 		return nil
 	}
-	arw, err := tx.Testing().MakeAccountsOptimizedReader()
+	arw, err := tx.MakeAccountsOptimizedReader()
 	if err != nil {
 		return err
 	}

--- a/ledger/acctdeltas_test.go
+++ b/ledger/acctdeltas_test.go
@@ -59,7 +59,7 @@ func checkAccounts(t *testing.T, tx trackerdb.TransactionScope, rnd basics.Round
 	require.NoError(t, err)
 	require.Equal(t, r, rnd)
 
-	aor, err := tx.Testing().MakeAccountsOptimizedReader()
+	aor, err := tx.MakeAccountsOptimizedReader()
 	require.NoError(t, err)
 
 	var totalOnline, totalOffline, totalNotPart uint64

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1010,7 +1010,7 @@ func TestListCreatables(t *testing.T) {
 		require.NoError(t, err)
 
 		au := &accountUpdates{}
-		au.accountsq, err = tx.Testing().MakeAccountsOptimizedReader()
+		au.accountsq, err = tx.MakeAccountsOptimizedReader()
 		require.NoError(t, err)
 
 		// ******* All results are obtained from the cache. Empty database *******

--- a/ledger/store/trackerdb/data_test.go
+++ b/ledger/store/trackerdb/data_test.go
@@ -1079,6 +1079,8 @@ func TestLedgercoreAccountDataRoundtripConversion(t *testing.T) {
 
 func TestBaseAccountDataIsEmpty(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
+
 	positiveTesting := func(t *testing.T) {
 		var ba BaseAccountData
 		require.True(t, ba.IsEmpty())
@@ -1110,11 +1112,11 @@ func TestBaseAccountDataIsEmpty(t *testing.T) {
 	t.Run("Positive", positiveTesting)
 	t.Run("Negative", negativeTesting)
 	t.Run("Structure", structureTesting)
-
 }
 
 func TestBaseOnlineAccountDataIsEmpty(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	positiveTesting := func(t *testing.T) {
 		var ba BaseOnlineAccountData
@@ -1162,6 +1164,7 @@ func TestBaseOnlineAccountDataIsEmpty(t *testing.T) {
 
 func TestBaseOnlineAccountDataGettersSetters(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	addr := ledgertesting.RandomAddress()
@@ -1216,6 +1219,7 @@ func TestBaseOnlineAccountDataGettersSetters(t *testing.T) {
 
 func TestBaseVotingDataGettersSetters(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	data := ledgertesting.RandomAccountData(1)
 	data.Status = basics.Online
@@ -1243,18 +1247,23 @@ func TestBaseVotingDataGettersSetters(t *testing.T) {
 
 func TestBaseOnlineAccountDataReflect(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	require.Equal(t, 4, reflect.TypeOf(BaseOnlineAccountData{}).NumField(), "update all getters and setters for baseOnlineAccountData and change the field count")
 }
 
 func TestBaseVotingDataReflect(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	require.Equal(t, 7, reflect.TypeOf(BaseVotingData{}).NumField(), "update all getters and setters for baseVotingData and change the field count")
 }
 
 // TestBaseAccountDataDecodeEmpty ensures no surprises when decoding nil/empty data.
 func TestBaseAccountDataDecodeEmpty(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
 	var b BaseAccountData
 
 	err := protocol.Decode([]byte{}, &b)

--- a/ledger/store/trackerdb/data_test.go
+++ b/ledger/store/trackerdb/data_test.go
@@ -1252,3 +1252,17 @@ func TestBaseVotingDataReflect(t *testing.T) {
 
 	require.Equal(t, 7, reflect.TypeOf(BaseVotingData{}).NumField(), "update all getters and setters for baseVotingData and change the field count")
 }
+
+// TestBaseAccountDataDecodeEmpty ensures no surprises when decoding nil/empty data.
+func TestBaseAccountDataDecodeEmpty(t *testing.T) {
+	var b BaseAccountData
+
+	err := protocol.Decode([]byte{}, &b)
+	require.Error(t, err)
+
+	err = protocol.Decode(nil, &b)
+	require.Error(t, err)
+
+	err = protocol.Decode([]byte{0x80}, &b)
+	require.NoError(t, err)
+}

--- a/ledger/store/trackerdb/interface.go
+++ b/ledger/store/trackerdb/interface.go
@@ -103,7 +103,6 @@ type AccountsReaderExt interface {
 	AccountsTotals(ctx context.Context, catchpointStaging bool) (totals ledgercore.AccountTotals, err error)
 	AccountsHashRound(ctx context.Context) (hashrnd basics.Round, err error)
 	LookupAccountAddressFromAddressID(ctx context.Context, ref AccountRef) (address basics.Address, err error)
-	LookupAccountDataByAddress(basics.Address) (ref AccountRef, data []byte, err error)
 	LookupAccountRowID(basics.Address) (ref AccountRef, err error)
 	LookupResourceDataByAddrID(accountRef AccountRef, aidx basics.CreatableIndex) (data []byte, err error)
 	TotalResources(ctx context.Context) (total uint64, err error)

--- a/ledger/store/trackerdb/sqlitedriver/accountsV2.go
+++ b/ledger/store/trackerdb/sqlitedriver/accountsV2.go
@@ -389,21 +389,6 @@ func (r *accountsV2Reader) LookupAccountAddressFromAddressID(ctx context.Context
 	return
 }
 
-func (r *accountsV2Reader) LookupAccountDataByAddress(addr basics.Address) (ref trackerdb.AccountRef, data []byte, err error) {
-	// optimize this query for repeated usage
-	selectStmt, err := r.getOrPrepare("SELECT rowid, data FROM accountbase WHERE address=?")
-	if err != nil {
-		return
-	}
-
-	var rowid int64
-	err = selectStmt.QueryRow(addr[:]).Scan(&rowid, &data)
-	if err != nil {
-		return
-	}
-	return sqlRowRef{rowid}, data, err
-}
-
 // LookupOnlineAccountDataByAddress looks up online account data by address.
 func (r *accountsV2Reader) LookupOnlineAccountDataByAddress(addr basics.Address) (ref trackerdb.OnlineAccountRef, data []byte, err error) {
 	// optimize this query for repeated usage

--- a/ledger/store/trackerdb/sqlitedriver/sql.go
+++ b/ledger/store/trackerdb/sqlitedriver/sql.go
@@ -23,6 +23,7 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/ledger/store/trackerdb"
+	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/util/db"
 )
@@ -476,6 +477,9 @@ func (qs *accountsDbQueries) LookupAccount(addr basics.Address) (data trackerdb.
 				data.Ref = sqlRowRef{rowid.Int64}
 				err = protocol.Decode(buf, &data.AccountData)
 				return err
+			} else if len(buf) == 0 && rowid.Valid {
+				// explicit condition: if the account row exists AND it has no data in it
+				logging.Base().Warnf("account %s exists but has no data in the database", addr)
 			}
 			// we don't have that account, just return the database round.
 			return nil

--- a/ledger/store/trackerdb/sqlitedriver/sql.go
+++ b/ledger/store/trackerdb/sqlitedriver/sql.go
@@ -23,7 +23,6 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/ledger/store/trackerdb"
-	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/util/db"
 )
@@ -478,8 +477,8 @@ func (qs *accountsDbQueries) LookupAccount(addr basics.Address) (data trackerdb.
 				err = protocol.Decode(buf, &data.AccountData)
 				return err
 			} else if len(buf) == 0 && rowid.Valid {
-				// explicit condition: if the account row exists AND it has no data in it
-				logging.Base().Warnf("account %v exists but has no data in the database", addr)
+				// we are sure empty valid accounts do not exist in the database.
+				return fmt.Errorf("account %v exists but has no data in the database", addr)
 			}
 			// we don't have that account, just return the database round.
 			return nil

--- a/ledger/store/trackerdb/sqlitedriver/sql.go
+++ b/ledger/store/trackerdb/sqlitedriver/sql.go
@@ -479,7 +479,7 @@ func (qs *accountsDbQueries) LookupAccount(addr basics.Address) (data trackerdb.
 				return err
 			} else if len(buf) == 0 && rowid.Valid {
 				// explicit condition: if the account row exists AND it has no data in it
-				logging.Base().Warnf("account %s exists but has no data in the database", addr)
+				logging.Base().Warnf("account %v exists but has no data in the database", addr)
 			}
 			// we don't have that account, just return the database round.
 			return nil

--- a/ledger/store/trackerdb/store.go
+++ b/ledger/store/trackerdb/store.go
@@ -45,6 +45,7 @@ type TransactionScope interface {
 	MakeCatchpointReaderWriter() (CatchpointReaderWriter, error)
 	MakeAccountsReaderWriter() (AccountsReaderWriter, error)
 	MakeAccountsOptimizedWriter(hasAccounts, hasResources, hasKvPairs, hasCreatables bool) (AccountsWriter, error)
+	MakeAccountsOptimizedReader() (AccountsReader, error)
 	MakeOnlineAccountsOptimizedWriter(hasAccounts bool) (w OnlineAccountsWriter, err error)
 	MakeMerkleCommitter(staging bool) (MerkleCommitter, error)
 	MakeOrderedAccountsIter(accountCount int) OrderedAccountsIter

--- a/ledger/store/trackerdb/testinterface.go
+++ b/ledger/store/trackerdb/testinterface.go
@@ -48,7 +48,6 @@ type TestBatchScope interface {
 type TestTransactionScope interface {
 	TransactionScope
 
-	MakeAccountsOptimizedReader() (AccountsReader, error)
 	MakeOnlineAccountsOptimizedReader() (OnlineAccountsReader, error)
 	AccountsInitTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool)
 	AccountsInitLightTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto config.ConsensusParams) (newDatabase bool, err error)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

`LookupAccountDataByAddress` was only used in one place and was repeating the same logic as in `LookupAccount`. 
The difference between the two was that `LookupAccountDataByAddress` returned raw bytes instead  of decoding the account data. 

- `LookupAccountDataByAddress` was removed from the interface and the call site was  changed to used `LookupAccount` instead. 

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Existing tests.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
