### PR TITLE
util/s3: improve patch number capacity in version comparison

### DIFF
--- a/cmd/updater/version_test.go
+++ b/cmd/updater/version_test.go
@@ -31,8 +31,9 @@ func TestGetVersion(t *testing.T) {
 
 	testValidVersion(t, "algonode_update_0.1.0.log", uint64(0x01000000))
 	testValidVersion(t, "algo_update_0.1.0", uint64(0x01000000))
-	testValidVersion(t, "algo_update_65535.1.0", uint64(0x00FFFF000001000000))
-	testValidVersion(t, "algo_update_65535.65535.65535", uint64(0x00FFFF00FFFF00FFFF))
+	testValidVersion(t, "algo_update_65535.1.0", uint64(0x00FFFF0001000000))
+	testValidVersion(t, "algo_update_65535.65535.65535", uint64(0xFFFFFFFF00FFFF))
+	testValidVersion(t, "algo_update_65535.65535.16777215", uint64(0xFFFFFFFFFFFFFF))
 
 	testInvalidVersion(t, "algo_update_0.-1.0")
 	testInvalidVersion(t, "algo_update_1e5.0.0")

--- a/cmd/updater/version_test.go
+++ b/cmd/updater/version_test.go
@@ -29,10 +29,10 @@ func TestGetVersion(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	testValidVersion(t, "algonode_update_0.1.0.log", uint64(0x00010000))
-	testValidVersion(t, "algo_update_0.1.0", uint64(0x00010000))
-	testValidVersion(t, "algo_update_65535.1.0", uint64(0xFFFF00010000))
-	testValidVersion(t, "algo_update_65535.65535.65535", uint64(0xFFFFFFFFFFFF))
+	testValidVersion(t, "algonode_update_0.1.0.log", uint64(0x01000000))
+	testValidVersion(t, "algo_update_0.1.0", uint64(0x01000000))
+	testValidVersion(t, "algo_update_65535.1.0", uint64(0x00FFFF000001000000))
+	testValidVersion(t, "algo_update_65535.65535.65535", uint64(0x00FFFF00FFFF00FFFF))
 
 	testInvalidVersion(t, "algo_update_0.-1.0")
 	testInvalidVersion(t, "algo_update_1e5.0.0")

--- a/util/s3/s3Helper.go
+++ b/util/s3/s3Helper.go
@@ -245,15 +245,15 @@ func GetVersionFromName(name string) (version uint64, err error) {
 		return
 	}
 	var val uint64
-	for index, match := range submatchAll[0] {
-		if index > 0 {
-			version <<= 24
-			val, err = strconv.ParseUint(match, 10, 0)
-			if err != nil {
-				return
-			}
-			version += val
+	submatch := submatchAll[0][1:] // skip the first match which is the whole string
+	offsets := []int{0, 16, 24}    // some bits for major (not really restricted), 16 bits for minor, 24 bits for patch
+	for index, match := range submatch {
+		version <<= offsets[index]
+		val, err = strconv.ParseUint(match, 10, 0)
+		if err != nil {
+			return
 		}
+		version += val
 	}
 	return
 }
@@ -262,15 +262,15 @@ func GetVersionFromName(name string) (version uint64, err error) {
 func GetVersionPartsFromVersion(version uint64) (major uint64, minor uint64, patch uint64, err error) {
 	val := version
 
-	if val < 1<<48 {
+	if val < 1<<40 {
 		err = errors.New("versions below 1.0.0 not supported")
 		return
 	}
 
 	patch = val & 0xffffff
 	val >>= 24
-	minor = val & 0xffffff
-	val >>= 24
+	minor = val & 0xffff
+	val >>= 16
 	major = val
 	return
 }

--- a/util/s3/s3Helper.go
+++ b/util/s3/s3Helper.go
@@ -247,7 +247,7 @@ func GetVersionFromName(name string) (version uint64, err error) {
 	var val uint64
 	for index, match := range submatchAll[0] {
 		if index > 0 {
-			version <<= 16
+			version <<= 24
 			val, err = strconv.ParseUint(match, 10, 0)
 			if err != nil {
 				return

--- a/util/s3/s3Helper.go
+++ b/util/s3/s3Helper.go
@@ -262,15 +262,15 @@ func GetVersionFromName(name string) (version uint64, err error) {
 func GetVersionPartsFromVersion(version uint64) (major uint64, minor uint64, patch uint64, err error) {
 	val := version
 
-	if val < 1<<32 {
+	if val < 1<<48 {
 		err = errors.New("versions below 1.0.0 not supported")
 		return
 	}
 
-	patch = val & 0xffff
-	val >>= 16
-	minor = val & 0xffff
-	val >>= 16
+	patch = val & 0xffffff
+	val >>= 24
+	minor = val & 0xffffff
+	val >>= 24
 	major = val
 	return
 }

--- a/util/s3/s3Helper_test.go
+++ b/util/s3/s3Helper_test.go
@@ -183,12 +183,12 @@ func TestGetVersionFromName(t *testing.T) {
 		expected uint64
 	}
 	tests := []args{
-		{name: "test 1 (major)", version: "_1.0.0", expected: 1 * 1 << 48},
-		{name: "test 2 (major)", version: "_2.0.0", expected: 2 * 1 << 48},
-		{name: "test 3 (minor)", version: "_1.1.0", expected: 1*1<<48 + 1*1<<24},
-		{name: "test 4 (minor)", version: "_1.2.0", expected: 1*1<<48 + 2*1<<24},
-		{name: "test 5 (patch)", version: "_1.0.1", expected: 1*1<<48 + 1},
-		{name: "test 6 (patch)", version: "_1.0.2", expected: 1*1<<48 + 2},
+		{name: "test 1 (major)", version: "_1.0.0", expected: 1 * 1 << 40},
+		{name: "test 2 (major)", version: "_2.0.0", expected: 2 * 1 << 40},
+		{name: "test 3 (minor)", version: "_1.1.0", expected: 1*1<<40 + 1*1<<24},
+		{name: "test 4 (minor)", version: "_1.2.0", expected: 1*1<<40 + 2*1<<24},
+		{name: "test 5 (patch)", version: "_1.0.1", expected: 1*1<<40 + 1},
+		{name: "test 6 (patch)", version: "_1.0.2", expected: 1*1<<40 + 2},
 	}
 
 	for _, test := range tests {
@@ -225,12 +225,12 @@ func TestGetPartsFromVersion(t *testing.T) {
 		expPatch uint64
 	}
 	tests := []args{
-		{name: "test 1 (major)", version: 1 * 1 << 48, expMajor: 1, expMinor: 0, expPatch: 0},
-		{name: "test 2 (major)", version: 2 * 1 << 48, expMajor: 2, expMinor: 0, expPatch: 0},
-		{name: "test 3 (minor)", version: 1*1<<48 + 1*1<<24, expMajor: 1, expMinor: 1, expPatch: 0},
-		{name: "test 4 (minor)", version: 1*1<<48 + 2*1<<24, expMajor: 1, expMinor: 2, expPatch: 0},
-		{name: "test 5 (patch)", version: 1*1<<48 + 1, expMajor: 1, expMinor: 0, expPatch: 1},
-		{name: "test 6 (patch)", version: 1*1<<48 + 2, expMajor: 1, expMinor: 0, expPatch: 2},
+		{name: "test 1 (major)", version: 1 * 1 << 40, expMajor: 1, expMinor: 0, expPatch: 0},
+		{name: "test 2 (major)", version: 2 * 1 << 40, expMajor: 2, expMinor: 0, expPatch: 0},
+		{name: "test 3 (minor)", version: 1*1<<40 + 1*1<<24, expMajor: 1, expMinor: 1, expPatch: 0},
+		{name: "test 4 (minor)", version: 1*1<<40 + 2*1<<24, expMajor: 1, expMinor: 2, expPatch: 0},
+		{name: "test 5 (patch)", version: 1*1<<40 + 1, expMajor: 1, expMinor: 0, expPatch: 1},
+		{name: "test 6 (patch)", version: 1*1<<40 + 2, expMajor: 1, expMinor: 0, expPatch: 2},
 	}
 
 	for _, test := range tests {
@@ -241,7 +241,7 @@ func TestGetPartsFromVersion(t *testing.T) {
 		require.Equal(t, test.expPatch, actualPatch, test.name)
 	}
 
-	_, _, _, err := GetVersionPartsFromVersion(1<<48 - 1)
+	_, _, _, err := GetVersionPartsFromVersion(1<<40 - 1)
 	require.Error(t, err, "Versions less than 1.0.0 should not be parsed.")
 }
 

--- a/util/s3/s3Helper_test.go
+++ b/util/s3/s3Helper_test.go
@@ -174,6 +174,7 @@ func TestMakeS3SessionForDownloadWithBucket(t *testing.T) {
 
 func TestGetVersionFromName(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	type args struct {
 		name     string
@@ -181,12 +182,12 @@ func TestGetVersionFromName(t *testing.T) {
 		expected uint64
 	}
 	tests := []args{
-		{name: "test 1 (major)", version: "_1.0.0", expected: 1 * 1 << 32},
-		{name: "test 2 (major)", version: "_2.0.0", expected: 2 * 1 << 32},
-		{name: "test 3 (minor)", version: "_1.1.0", expected: 1*1<<32 + 1*1<<16},
-		{name: "test 4 (minor)", version: "_1.2.0", expected: 1*1<<32 + 2*1<<16},
-		{name: "test 5 (patch)", version: "_1.0.1", expected: 1*1<<32 + 1},
-		{name: "test 6 (patch)", version: "_1.0.2", expected: 1*1<<32 + 2},
+		{name: "test 1 (major)", version: "_1.0.0", expected: 1 * 1 << 48},
+		{name: "test 2 (major)", version: "_2.0.0", expected: 2 * 1 << 48},
+		{name: "test 3 (minor)", version: "_1.1.0", expected: 1*1<<48 + 1*1<<24},
+		{name: "test 4 (minor)", version: "_1.2.0", expected: 1*1<<48 + 2*1<<24},
+		{name: "test 5 (patch)", version: "_1.0.1", expected: 1*1<<48 + 1},
+		{name: "test 6 (patch)", version: "_1.0.2", expected: 1*1<<48 + 2},
 	}
 
 	for _, test := range tests {
@@ -194,6 +195,21 @@ func TestGetVersionFromName(t *testing.T) {
 		require.NoError(t, err, test.name)
 		require.Equal(t, test.expected, actual, test.name)
 	}
+}
+
+func TestGetVersionFromNameCompare(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	name1 := "config_3.13.170018.tar.gz"
+	name2 := "config_3.15.157.tar.gz"
+
+	ver1, err := GetVersionFromName(name1)
+	require.NoError(t, err)
+	ver2, err := GetVersionFromName(name2)
+	require.NoError(t, err)
+
+	require.Less(t, ver1, ver2)
 }
 
 func TestGetPartsFromVersion(t *testing.T) {


### PR DESCRIPTION
## Summary

Local builds could produce packages with higher than build number than the comparator in `updater` can handle.
This affects both updater and nodecfg.

## Test Plan

Added unit test