### PR TITLE
test: enable runtime metrics in custom templates

### DIFF
--- a/test/testdata/deployednettemplates/recipes/custom/configs/nonPartNode.json
+++ b/test/testdata/deployednettemplates/recipes/custom/configs/nonPartNode.json
@@ -1,5 +1,5 @@
 {
     "APIEndpoint": "{{APIEndpoint}}",
     "APIToken": "{{APIToken}}",
-    "ConfigJSONOverride": "{ \"TxPoolExponentialIncreaseFactor\": 1, \"DNSBootstrapID\": \"<network>.algodev.network\", \"DeadlockDetection\": -1, \"BaseLoggerDebugLevel\": 4, \"CadaverSizeTarget\": 0  }"
+    "ConfigJSONOverride": "{ \"TxPoolExponentialIncreaseFactor\": 1, \"DNSBootstrapID\": \"<network>.algodev.network\", \"DeadlockDetection\": -1, \"BaseLoggerDebugLevel\": 4, \"EnableRuntimeMetrics\": true, \"CadaverSizeTarget\": 0  }"
 }

--- a/test/testdata/deployednettemplates/recipes/custom/configs/relay.json
+++ b/test/testdata/deployednettemplates/recipes/custom/configs/relay.json
@@ -7,5 +7,5 @@
     "TelemetryURI": "{{TelemetryURI}}",
     "EnableMetrics": true,
     "MetricsURI": "{{MetricsURI}}",
-    "ConfigJSONOverride": "{ \"TxPoolExponentialIncreaseFactor\": 1, \"DNSBootstrapID\": \"<network>.algodev.network\", \"DeadlockDetection\": -1, \"EnableIncomingMessageFilter\": true, \"CadaverSizeTarget\": 0, \"PeerPingPeriodSeconds\": 30, \"EnableAgreementReporting\": true, \"EnableAgreementTimeMetrics\": true, \"EnableAssembleStats\": true, \"EnableProcessBlockStats\": true, \"BaseLoggerDebugLevel\": 4, \"EnableProfiler\": true }"
+    "ConfigJSONOverride": "{ \"TxPoolExponentialIncreaseFactor\": 1, \"DNSBootstrapID\": \"<network>.algodev.network\", \"DeadlockDetection\": -1, \"EnableIncomingMessageFilter\": true, \"EnableRuntimeMetrics\": true, \"CadaverSizeTarget\": 0, \"PeerPingPeriodSeconds\": 30, \"EnableAgreementReporting\": true, \"EnableAgreementTimeMetrics\": true, \"EnableAssembleStats\": true, \"EnableProcessBlockStats\": true, \"BaseLoggerDebugLevel\": 4, \"EnableProfiler\": true }"
 }


### PR DESCRIPTION
## Summary

Set `EnableRuntimeMetrics` to true in for custom templates (this includes mainnet model. This would provide more data about nodes performance when running large tests.