### PR TITLE
tools: Don't use strings.Title in chopper

### DIFF
--- a/tools/debug/chopper/main.go
+++ b/tools/debug/chopper/main.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/logging/telemetryspec"
@@ -131,7 +133,7 @@ type reportData struct {
 
 // report prints out stats about matched and mismatched roots or labels
 func report(rd reportData) {
-	fmt.Printf("%s in first: %d, second: %d\n", strings.Title(rd.what), rd.size1, rd.size2)
+	fmt.Printf("%s in first: %d, second: %d\n", cases.Title(language.English).String(rd.what), rd.size1, rd.size2)
 
 	const matchedStr = "Matched %s: %d"
 	c := yellow


### PR DESCRIPTION


## Summary

I'm running go1.18 locally and the lint check fails because `strings.Title` is deprecated in go1.18.

```
tools/debug/chopper/main.go:134:46: SA1019: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead. (staticcheck)
	fmt.Printf("%s in first: %d, second: %d\n", strings.Title(rd.what), rd.size1, rd.size2)
```

Replaced it with `cases.Title` for English which looks to have the same behavior.

## Test Plan

Ran a basic test and it looks correct from what I can tell.

```
go run ./tools/debug/chopper/main.go ./log_copy.log ~/.algorand/node.
log 
Roots in first: 45, second: 45
Matched roots: 45
Mismatched roots: 0
Other roots in first: 0, second: 0
```

