### PR TITLE
AVM: Avoid panics in disassembly when branch instructions are short

### DIFF
--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -3490,6 +3490,9 @@ warning 2
 
 // TestDisassembleBadBranch ensures a clean error when a branch has no target.
 func TestDisassembleBadBranch(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
 	for _, br := range []byte{0x40, 0x41, 0x42} {
 		dis, err := Disassemble([]byte{2, br})
 		require.Error(t, err, dis)
@@ -3511,6 +3514,9 @@ func TestDisassembleBadBranch(t *testing.T) {
 
 // TestDisassembleBadSwitch ensures a clean error when a switch ends early
 func TestDisassembleBadSwitch(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
 	source := `
     int 1
 	switch label1 label2
@@ -3533,6 +3539,9 @@ func TestDisassembleBadSwitch(t *testing.T) {
 
 // TestDisassembleBadMatch ensures a clean error when a match ends early
 func TestDisassembleBadMatch(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
 	source := `
     int 40
     int 45

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -3500,7 +3500,7 @@ func TestDisassembleBadBranch(t *testing.T) {
 		require.Error(t, err, dis)
 
 		// It would be reasonable to error here, since it's a jump past the end.
-		dis, err = Disassemble([]byte{2, br, 0xff, 0x05})
+		dis, err = Disassemble([]byte{2, br, 0x00, 0x05})
 		require.NoError(t, err, dis)
 
 		// It would be reasonable to error here, since it's a back jump in v2.
@@ -3529,10 +3529,15 @@ func TestDisassembleBadSwitch(t *testing.T) {
 	dis, err := Disassemble(ops.Program)
 	require.NoError(t, err, dis)
 
-	// return the label count, but chop off the labels themselves
+	// chop off all the labels, but keep the label count
+	dis, err = Disassemble(ops.Program[:len(ops.Program)-4])
+	require.ErrorContains(t, err, "could not decode labels for switch", dis)
+
+	// chop off before the label count
 	dis, err = Disassemble(ops.Program[:len(ops.Program)-5])
 	require.ErrorContains(t, err, "could not decode label count for switch", dis)
 
+	// chop off half of a label
 	dis, err = Disassemble(ops.Program[:len(ops.Program)-1])
 	require.ErrorContains(t, err, "could not decode labels for switch", dis)
 }

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -3487,3 +3487,70 @@ warning 2
 	expected = "1 error: 42: super annoying error\n"
 	assertWithMsg(t, expected, b)
 }
+
+// TestDisassembleBadBranch ensures a clean error when a branch has no target.
+func TestDisassembleBadBranch(t *testing.T) {
+	for _, br := range []byte{0x40, 0x41, 0x42} {
+		dis, err := Disassemble([]byte{2, br})
+		require.Error(t, err, dis)
+		dis, err = Disassemble([]byte{2, br, 0x01})
+		require.Error(t, err, dis)
+
+		// It would be reasonable to error here, since it's a jump past the end.
+		dis, err = Disassemble([]byte{2, br, 0xff, 0x05})
+		require.NoError(t, err, dis)
+
+		// It would be reasonable to error here, since it's a back jump in v2.
+		dis, err = Disassemble([]byte{2, br, 0xff, 0x02})
+		require.NoError(t, err, dis)
+
+		dis, err = Disassemble([]byte{2, br, 0x00, 0x01, 0x00})
+		require.NoError(t, err)
+	}
+}
+
+// TestDisassembleBadSwitch ensures a clean error when a switch ends early
+func TestDisassembleBadSwitch(t *testing.T) {
+	source := `
+    int 1
+	switch label1 label2
+	label1:
+    label2:
+	`
+	ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
+	require.NoError(t, err)
+
+	dis, err := Disassemble(ops.Program)
+	require.NoError(t, err, dis)
+
+	// return the label count, but chop off the labels themselves
+	dis, err = Disassemble(ops.Program[:len(ops.Program)-5])
+	require.ErrorContains(t, err, "could not decode label count for switch", dis)
+
+	dis, err = Disassemble(ops.Program[:len(ops.Program)-1])
+	require.ErrorContains(t, err, "could not decode labels for switch", dis)
+}
+
+// TestDisassembleBadMatch ensures a clean error when a match ends early
+func TestDisassembleBadMatch(t *testing.T) {
+	source := `
+    int 40
+    int 45
+    int 40
+	match label1 label2
+	label1:
+    label2:
+	`
+	ops, err := AssembleStringWithVersion(source, AssemblerMaxVersion)
+	require.NoError(t, err)
+
+	dis, err := Disassemble(ops.Program)
+	require.NoError(t, err, dis)
+
+	// return the label count, but chop off the labels themselves
+	dis, err = Disassemble(ops.Program[:len(ops.Program)-5])
+	require.ErrorContains(t, err, "could not decode label count for match", dis)
+
+	dis, err = Disassemble(ops.Program[:len(ops.Program)-1])
+	require.ErrorContains(t, err, "could not decode labels for match", dis)
+}


### PR DESCRIPTION
Although it is not a security problem, it's poor form to panic rather than return a nice error when disassembling bad programs.  The disassembler was unconditionally trying to decode the labels of branching opcodes without checking to see if the program was long enough to hold them.