### PR TITLE
Algod: Minor refactoring REST client `submitForm` from go-sdk PR #335

### DIFF
--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -609,10 +609,14 @@ func (client RestClient) Compile(program []byte, useSourceMap bool) (compiledPro
 	}
 	programHash = crypto.Digest(progAddr)
 
-	existenceOfSourceMap := compileResponse.Sourcemap != nil
+	// fast exit if we don't want sourcemap, then exit with what we have so far
+	if !useSourceMap {
+		return
+	}
 
-	if existenceOfSourceMap != useSourceMap {
-		return nil, crypto.Digest{}, nil, fmt.Errorf("useSourceMap arg %v not agreeing with existence of source-map %v", useSourceMap, existenceOfSourceMap)
+	// if we want sourcemap, then we convert the *map[string]interface{} into *logic.SourceMap
+	if compileResponse.Sourcemap == nil {
+		return nil, crypto.Digest{}, nil, fmt.Errorf("requesting for sourcemap but get nothing")
 	}
 
 	var srcMapInstance logic.SourceMap

--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -163,38 +163,52 @@ type RawResponse interface {
 	SetBytes([]byte)
 }
 
+// mergeRawQueries merges two raw queries, appending an "&" if both are non-empty
+func mergeRawQueries(q1, q2 string) string {
+	if q1 == "" {
+		return q2
+	}
+	if q2 == "" {
+		return q1
+	}
+	return q1 + "&" + q2
+}
+
 // submitForm is a helper used for submitting (ex.) GETs and POSTs to the server
 // if expectNoContent is true, then it is expected that the response received will have a content length of zero
-func (client RestClient) submitForm(response interface{}, path string, request interface{}, requestMethod string, encodeJSON bool, decodeJSON bool, expectNoContent bool) error {
+func (client RestClient) submitForm(
+	response interface{}, path string, params interface{}, body interface{},
+	requestMethod string, encodeJSON bool, decodeJSON bool, expectNoContent bool) error {
+
 	var err error
 	queryURL := client.serverURL
 	queryURL.Path = path
 
 	var req *http.Request
-	var body io.Reader
+	var bodyReader io.Reader
+	var v url.Values
 
-	if request != nil {
-		if rawRequestPaths[path] {
-			reqBytes, ok := request.([]byte)
-			if !ok {
-				return fmt.Errorf("couldn't decode raw request as bytes")
-			}
-			body = bytes.NewBuffer(reqBytes)
-		} else {
-			v, err := query.Values(request)
-			if err != nil {
-				return err
-			}
-
-			queryURL.RawQuery = v.Encode()
-			if encodeJSON {
-				jsonValue, _ := json.Marshal(request)
-				body = bytes.NewBuffer(jsonValue)
-			}
+	if params != nil {
+		v, err = query.Values(params)
+		if err != nil {
+			return err
 		}
 	}
 
-	req, err = http.NewRequest(requestMethod, queryURL.String(), body)
+	if requestMethod == "POST" && rawRequestPaths[path] {
+		reqBytes, ok := body.([]byte)
+		if !ok {
+			return fmt.Errorf("couldn't decode raw request as bytes")
+		}
+		bodyReader = bytes.NewBuffer(reqBytes)
+	} else if encodeJSON {
+		jsonValue, _ := json.Marshal(params)
+		bodyReader = bytes.NewBuffer(jsonValue)
+	}
+
+	queryURL.RawQuery = mergeRawQueries(queryURL.RawQuery, v.Encode())
+
+	req, err = http.NewRequest(requestMethod, queryURL.String(), bodyReader)
 	if err != nil {
 		return err
 	}
@@ -249,26 +263,26 @@ func (client RestClient) submitForm(response interface{}, path string, request i
 
 // get performs a GET request to the specific path against the server
 func (client RestClient) get(response interface{}, path string, request interface{}) error {
-	return client.submitForm(response, path, request, "GET", false /* encodeJSON */, true /* decodeJSON */, false)
+	return client.submitForm(response, path, request, nil, "GET", false /* encodeJSON */, true /* decodeJSON */, false)
 }
 
 // delete performs a DELETE request to the specific path against the server
 // when expectNoContent is true, then no content is expected to be returned from the endpoint
 func (client RestClient) delete(response interface{}, path string, request interface{}, expectNoContent bool) error {
-	return client.submitForm(response, path, request, "DELETE", false /* encodeJSON */, true /* decodeJSON */, expectNoContent)
+	return client.submitForm(response, path, request, nil, "DELETE", false /* encodeJSON */, true /* decodeJSON */, expectNoContent)
 }
 
 // getRaw behaves identically to get but doesn't json decode the response, and
 // the response must implement the RawResponse interface
 func (client RestClient) getRaw(response RawResponse, path string, request interface{}) error {
-	return client.submitForm(response, path, request, "GET", false /* encodeJSON */, false /* decodeJSON */, false)
+	return client.submitForm(response, path, request, nil, "GET", false /* encodeJSON */, false /* decodeJSON */, false)
 }
 
 // post sends a POST request to the given path with the given request object.
 // No query parameters will be sent if request is nil.
 // response must be a pointer to an object as post writes the response there.
-func (client RestClient) post(response interface{}, path string, request interface{}, expectNoContent bool) error {
-	return client.submitForm(response, path, request, "POST", true /* encodeJSON */, true /* decodeJSON */, expectNoContent)
+func (client RestClient) post(response interface{}, path string, params interface{}, body interface{}, expectNoContent bool) error {
+	return client.submitForm(response, path, params, body, "POST", true /* encodeJSON */, true /* decodeJSON */, expectNoContent)
 }
 
 // Status retrieves the StatusResponse from the running node
@@ -511,7 +525,7 @@ func (client RestClient) SuggestedParams() (response model.TransactionParameters
 
 // SendRawTransaction gets a SignedTxn and broadcasts it to the network
 func (client RestClient) SendRawTransaction(txn transactions.SignedTxn) (response model.PostTransactionsResponse, err error) {
-	err = client.post(&response, "/v2/transactions", protocol.Encode(&txn), false)
+	err = client.post(&response, "/v2/transactions", nil, protocol.Encode(&txn), false)
 	return
 }
 
@@ -525,7 +539,7 @@ func (client RestClient) SendRawTransactionGroup(txgroup []transactions.SignedTx
 	}
 
 	var response model.PostTransactionsResponse
-	return client.post(&response, "/v2/transactions", enc, false)
+	return client.post(&response, "/v2/transactions", nil, enc, false)
 }
 
 // Block gets the block info for the given round
@@ -545,19 +559,19 @@ func (client RestClient) RawBlock(round uint64) (response []byte, err error) {
 // Shutdown requests the node to shut itself down
 func (client RestClient) Shutdown() (err error) {
 	response := 1
-	err = client.post(&response, "/v2/shutdown", nil, false)
+	err = client.post(&response, "/v2/shutdown", nil, nil, false)
 	return
 }
 
 // AbortCatchup aborts the currently running catchup
 func (client RestClient) AbortCatchup(catchpointLabel string) (response model.CatchpointAbortResponse, err error) {
-	err = client.submitForm(&response, fmt.Sprintf("/v2/catchup/%s", catchpointLabel), nil, "DELETE", false, true, false)
+	err = client.submitForm(&response, fmt.Sprintf("/v2/catchup/%s", catchpointLabel), nil, nil, "DELETE", false, true, false)
 	return
 }
 
 // Catchup start catching up to the give catchpoint label
 func (client RestClient) Catchup(catchpointLabel string) (response model.CatchpointStartResponse, err error) {
-	err = client.submitForm(&response, fmt.Sprintf("/v2/catchup/%s", catchpointLabel), nil, "POST", false, true, false)
+	err = client.submitForm(&response, fmt.Sprintf("/v2/catchup/%s", catchpointLabel), nil, nil, "POST", false, true, false)
 	return
 }
 
@@ -575,7 +589,7 @@ func (client RestClient) GetGoRoutines(ctx context.Context) (goRoutines string, 
 // Compile compiles the given program and returned the compiled program
 func (client RestClient) Compile(program []byte) (compiledProgram []byte, programHash crypto.Digest, err error) {
 	var compileResponse model.CompileResponse
-	err = client.submitForm(&compileResponse, "/v2/teal/compile", program, "POST", false, true, false)
+	err = client.submitForm(&compileResponse, "/v2/teal/compile", nil, program, "POST", false, true, false)
 	if err != nil {
 		return nil, crypto.Digest{}, err
 	}
@@ -631,14 +645,14 @@ func (client RestClient) doGetWithQuery(ctx context.Context, path string, queryA
 // RawDryrun gets the raw DryrunResponse associated with the passed address
 func (client RestClient) RawDryrun(data []byte) (response []byte, err error) {
 	var blob Blob
-	err = client.submitForm(&blob, "/v2/teal/dryrun", data, "POST", false /* encodeJSON */, false /* decodeJSON */, false)
+	err = client.submitForm(&blob, "/v2/teal/dryrun", nil, data, "POST", false /* encodeJSON */, false /* decodeJSON */, false)
 	response = blob
 	return
 }
 
 // SimulateRawTransaction gets the raw transaction or raw transaction group, and returns relevant simulation results.
 func (client RestClient) SimulateRawTransaction(data []byte) (response model.SimulateResponse, err error) {
-	err = client.submitForm(&response, "/v2/transactions/simulate", data, "POST", false /* encodeJSON */, true /* decodeJSON */, false)
+	err = client.submitForm(&response, "/v2/transactions/simulate", nil, data, "POST", false /* encodeJSON */, true /* decodeJSON */, false)
 	return
 }
 
@@ -663,7 +677,7 @@ func (client RestClient) TransactionProof(txid string, round uint64, hashType cr
 
 // PostParticipationKey sends a key file to the node.
 func (client RestClient) PostParticipationKey(file []byte) (response model.PostParticipationResponse, err error) {
-	err = client.post(&response, "/v2/participation", file, false)
+	err = client.post(&response, "/v2/participation", nil, file, false)
 	return
 }
 
@@ -689,7 +703,7 @@ func (client RestClient) RemoveParticipationKeyByID(participationID string) (err
 
 // SetSyncRound sets the sync round for the catchup service
 func (client RestClient) SetSyncRound(round uint64) (err error) {
-	err = client.post(nil, fmt.Sprintf("/v2/ledger/sync/%d", round), nil, true)
+	err = client.post(nil, fmt.Sprintf("/v2/ledger/sync/%d", round), nil, nil, true)
 	return
 }
 

--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -166,11 +166,8 @@ type RawResponse interface {
 
 // mergeRawQueries merges two raw queries, appending an "&" if both are non-empty
 func mergeRawQueries(q1, q2 string) string {
-	if q1 == "" {
-		return q2
-	}
-	if q2 == "" {
-		return q1
+	if q1 == "" || q2 == "" {
+		return q1 + q2
 	}
 	return q1 + "&" + q2
 }

--- a/data/transactions/logic/sourcemap.go
+++ b/data/transactions/logic/sourcemap.go
@@ -27,7 +27,7 @@ const sourceMapVersion = 3
 const b64table string = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
 // SourceMap contains details from the source to assembly process.
-// Currently contains the map between TEAL source line to
+// Currently, contains the map between TEAL source line to
 // the assembled bytecode position and details about
 // the template variables contained in the source file.
 type SourceMap struct {

--- a/libgoal/teal.go
+++ b/libgoal/teal.go
@@ -18,10 +18,11 @@ package libgoal
 
 import (
 	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/transactions/logic"
 )
 
 // Compile compiles the given program and returned the compiled program
-func (c *Client) Compile(program []byte, useSourceMap bool) (compiledProgram []byte, compiledProgramHash crypto.Digest, sourcemap *map[string]interface{}, err error) {
+func (c *Client) Compile(program []byte, useSourceMap bool) (compiledProgram []byte, compiledProgramHash crypto.Digest, sourcemap *logic.SourceMap, err error) {
 	algod, err2 := c.ensureAlgodClient()
 	if err2 != nil {
 		return nil, crypto.Digest{}, nil, err2

--- a/libgoal/teal.go
+++ b/libgoal/teal.go
@@ -21,10 +21,10 @@ import (
 )
 
 // Compile compiles the given program and returned the compiled program
-func (c *Client) Compile(program []byte) (compiledProgram []byte, compiledProgramHash crypto.Digest, err error) {
+func (c *Client) Compile(program []byte, useSourceMap bool) (compiledProgram []byte, compiledProgramHash crypto.Digest, sourcemap *map[string]interface{}, err error) {
 	algod, err2 := c.ensureAlgodClient()
 	if err2 != nil {
-		return nil, crypto.Digest{}, err2
+		return nil, crypto.Digest{}, nil, err2
 	}
-	return algod.Compile(program)
+	return algod.Compile(program, useSourceMap)
 }

--- a/test/e2e-go/features/teal/compile_test.go
+++ b/test/e2e-go/features/teal/compile_test.go
@@ -50,7 +50,7 @@ func TestTealCompile(t *testing.T) {
 	// get lib goal client
 	libGoalClient := fixture.LibGoalFixture.GetLibGoalClientFromNodeController(primaryNode)
 
-	compiledProgram, _, err := libGoalClient.Compile([]byte(""))
+	compiledProgram, _, _, err := libGoalClient.Compile([]byte(""), false)
 	a.Nil(compiledProgram)
 	a.Equal(err.Error(), "HTTP 404 Not Found: /teal/compile was not enabled in the configuration file by setting the EnableDeveloperAPI to true")
 
@@ -65,19 +65,22 @@ func TestTealCompile(t *testing.T) {
 	fixture.Start()
 
 	var hash crypto.Digest
-	compiledProgram, hash, err = libGoalClient.Compile([]byte("int 1"))
+	var srcMap *map[string]interface{}
+	compiledProgram, hash, srcMap, err = libGoalClient.Compile([]byte("int 1"), true)
 	a.NotNil(compiledProgram)
 	a.NoError(err, "A valid v1 program should result in a compilation success")
+	a.NotNil(srcMap)
 	a.Equal([]byte{0x1, 0x20, 0x1, 0x1, 0x22}, compiledProgram)
 	a.Equal("6Z3C3LDVWGMX23BMSYMANACQOSINPFIRF77H7N3AWJZYV6OH6GWQ", hash.String())
 
-	compiledProgram, hash, err = libGoalClient.Compile([]byte("#pragma version 2\nint 1"))
+	compiledProgram, hash, srcMap, err = libGoalClient.Compile([]byte("#pragma version 2\nint 1"), true)
 	a.NotNil(compiledProgram)
 	a.NoError(err, "A valid v2 program should result in a compilation success")
+	a.NotNil(srcMap)
 	a.Equal([]byte{0x2, 0x20, 0x1, 0x1, 0x22}, compiledProgram)
 	a.Equal("YOE6C22GHCTKAN3HU4SE5PGIPN5UKXAJTXCQUPJ3KKF5HOAH646A", hash.String())
 
-	compiledProgram, hash, err = libGoalClient.Compile([]byte("bad program"))
+	compiledProgram, hash, _, err = libGoalClient.Compile([]byte("bad program"), false)
 	a.Error(err, "An invalid program should result in a compilation failure")
 	a.Nil(compiledProgram)
 	a.Equal(crypto.Digest{}, hash)

--- a/test/e2e-go/features/teal/compile_test.go
+++ b/test/e2e-go/features/teal/compile_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/test/framework/fixtures"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
@@ -65,7 +66,7 @@ func TestTealCompile(t *testing.T) {
 	fixture.Start()
 
 	var hash crypto.Digest
-	var srcMap *map[string]interface{}
+	var srcMap *logic.SourceMap
 	compiledProgram, hash, srcMap, err = libGoalClient.Compile([]byte("int 1"), true)
 	a.NotNil(compiledProgram)
 	a.NoError(err, "A valid v1 program should result in a compilation success")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

The motivation of this PR is that, we want to allow for algod to simulate with option of `unlimit-log`: see #5230.

We need to send transaction with auxiliary query parameters. The current implementation in `restClient` disallowed us for such feasibility, while https://github.com/algorand/go-algorand-sdk/pull/335 contain relevant modification, and this PR mimic the changes, by separating `request` into `params` and `body`.

We expect to use this for `simulation`, where `/v2/transactions/simulate` has query parameter `unlimit-log: bool`, with raw body of txn(-group). The simulation request body resembles the one in compilation, where `/v2/teal/compile` has query parameter `sourcemap: bool` and raw body of program source bytes.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

Implement `Compile` with sourcemap option, and check existence of `sourcemap` field, which can be controlled by request option `Sourcemap *bool`.
