### PR TITLE
tests: Change truncate to dd for mac amd tests

### DIFF
--- a/test/scripts/e2e_subs/e2e-app-simulate.sh
+++ b/test/scripts/e2e_subs/e2e-app-simulate.sh
@@ -22,7 +22,7 @@ CONST_FALSE="false"
 
 # First, try to send an extremely large "transaction" in the request body.
 # This should fail with a 413 error.
-truncate -s 11MB "${TEMPDIR}/toolarge.tx"
+dd if=/dev/zero of=${TEMPDIR}/toolarge.tx bs=1M count=11
 RES=$(${gcmd} clerk simulate -t "${TEMPDIR}/toolarge.tx" 2>&1 || true)
 EXPERROR="simulation error: HTTP 413 Request Entity Too Large:"
 if [[ $RES != *"${EXPERROR}"* ]]; then

--- a/test/scripts/e2e_subs/e2e-app-simulate.sh
+++ b/test/scripts/e2e_subs/e2e-app-simulate.sh
@@ -22,7 +22,7 @@ CONST_FALSE="false"
 
 # First, try to send an extremely large "transaction" in the request body.
 # This should fail with a 413 error.
-dd if=/dev/zero of=${TEMPDIR}/toolarge.tx bs=11M count=1
+dd if=/dev/zero of="${TEMPDIR}/toolarge.tx" bs=11M count=1
 RES=$(${gcmd} clerk simulate -t "${TEMPDIR}/toolarge.tx" 2>&1 || true)
 EXPERROR="simulation error: HTTP 413 Request Entity Too Large:"
 if [[ $RES != *"${EXPERROR}"* ]]; then
@@ -34,13 +34,13 @@ fi
 # WE FIRST TEST TRANSACTION GROUP SIMULATION #
 ##############################################
 
-${gcmd} clerk send -a 10000 -f ${ACCOUNT} -t ${ACCOUNT} -o pay1.tx
-${gcmd} clerk send -a 10000 -f ${ACCOUNT} -t ${ACCOUNT} -o pay2.tx
+${gcmd} clerk send -a 10000 -f ${ACCOUNT} -t ${ACCOUNT} -o "${TEMPDIR}/pay1.tx"
+${gcmd} clerk send -a 10000 -f ${ACCOUNT} -t ${ACCOUNT} -o "${TEMPDIR}/pay2.tx"
 
-cat pay1.tx pay2.tx | ${gcmd} clerk group -i - -o grouped.tx
+cat "${TEMPDIR}/pay1.tx" "${TEMPDIR}/pay2.tx" | ${gcmd} clerk group -i - -o "${TEMPDIR}/grouped.tx"
 
 # We test transaction group simulation WITHOUT signatures
-RES=$(${gcmd} clerk simulate -t grouped.tx)
+RES=$(${gcmd} clerk simulate -t "${TEMPDIR}/grouped.tx")
 
 if [[ $(echo "$RES" | jq '."would-succeed"') != $CONST_FALSE ]]; then
     date '+app-simulate-test FAIL the simulation transaction group without signatures should not succeed %Y%m%d_%H%M%S'
@@ -60,14 +60,14 @@ if [[ $(echo "$RES" | jq '."txn-groups"[0]."txn-results"[1]."missing-signature"'
 fi
 
 # We then test transaction group simulation WITH signatures
-${gcmd} clerk split -i grouped.tx -o grouped.tx
+${gcmd} clerk split -i "${TEMPDIR}/grouped.tx" -o "${TEMPDIR}/grouped.tx"
 
-${gcmd} clerk sign -i grouped-0.tx -o grouped-0.stx
-${gcmd} clerk sign -i grouped-1.tx -o grouped-1.stx
+${gcmd} clerk sign -i "${TEMPDIR}/grouped-0.tx" -o "${TEMPDIR}/grouped-0.stx"
+${gcmd} clerk sign -i "${TEMPDIR}/grouped-1.tx" -o "${TEMPDIR}/grouped-1.stx"
 
-cat grouped-0.stx grouped-1.stx > grouped.stx
+cat "${TEMPDIR}/grouped-0.stx" "${TEMPDIR}/grouped-1.stx" > "${TEMPDIR}/grouped.stx"
 
-RES=$(${gcmd} clerk simulate -t grouped.stx | jq '."would-succeed"')
+RES=$(${gcmd} clerk simulate -t "${TEMPDIR}/grouped.stx" | jq '."would-succeed"')
 
 if [[ $RES != $CONST_TRUE ]]; then
     date '+app-simulate-test FAIL should pass to simulate self pay transaction group %Y%m%d_%H%M%S'
@@ -78,19 +78,19 @@ fi
 # WE ALSO TEST OVERSPEND IN TRANSACTION GROUP #
 ###############################################
 
-${gcmd} clerk send -a 1000000000000 -f ${ACCOUNT} -t ${ACCOUNT} -o pay1.tx
-${gcmd} clerk send -a 10000 -f ${ACCOUNT} -t ${ACCOUNT} -o pay2.tx
+${gcmd} clerk send -a 1000000000000 -f ${ACCOUNT} -t ${ACCOUNT} -o "${TEMPDIR}/pay1.tx"
+${gcmd} clerk send -a 10000 -f ${ACCOUNT} -t ${ACCOUNT} -o "${TEMPDIR}/pay2.tx"
 
-cat pay1.tx pay2.tx | ${gcmd} clerk group -i - -o grouped.tx
+cat "${TEMPDIR}/pay1.tx" "${TEMPDIR}/pay2.tx" | ${gcmd} clerk group -i - -o "${TEMPDIR}/grouped.tx"
 
-${gcmd} clerk split -i grouped.tx -o grouped.tx
+${gcmd} clerk split -i "${TEMPDIR}/grouped.tx" -o "${TEMPDIR}/grouped.tx"
 
-${gcmd} clerk sign -i grouped-0.tx -o grouped-0.stx
-${gcmd} clerk sign -i grouped-1.tx -o grouped-1.stx
+${gcmd} clerk sign -i "${TEMPDIR}/grouped-0.tx" -o "${TEMPDIR}/grouped-0.stx"
+${gcmd} clerk sign -i "${TEMPDIR}/grouped-1.tx" -o "${TEMPDIR}/grouped-1.stx"
 
-cat grouped-0.stx grouped-1.stx > grouped.stx
+cat "${TEMPDIR}/grouped-0.stx" "${TEMPDIR}/grouped-1.stx" > "${TEMPDIR}/grouped.stx"
 
-RES=$(${gcmd} clerk simulate -t grouped.stx)
+RES=$(${gcmd} clerk simulate -t "${TEMPDIR}/grouped.stx")
 
 if [[ $(echo "$RES" | jq '."would-succeed"') != $CONST_FALSE ]]; then
     data '+app-simulate-test FAIL should FAIL for overspending in simulate self pay transaction group %Y%m%d_%H%M%S'
@@ -121,10 +121,10 @@ fi
 APPID=$(echo "$RES" | grep Created | awk '{ print $6 }')
 
 # SIMULATION! empty()void
-${gcmd} app method --method "empty()void" --app-id $APPID --from $ACCOUNT 2>&1 -o empty.tx
+${gcmd} app method --method "empty()void" --app-id $APPID --from $ACCOUNT 2>&1 -o "${TEMPDIR}/empty.tx"
 
 # SIMULATE without a signature first
-RES=$(${gcmd} clerk simulate -t empty.tx)
+RES=$(${gcmd} clerk simulate -t "${TEMPDIR}/empty.tx")
 
 # confirm that without signature, the simulation should fail
 if [[ $(echo "$RES" | jq '."would-succeed"') != $CONST_FALSE ]]; then
@@ -139,8 +139,8 @@ if [[ $(echo "$RES" | jq '."txn-groups"[0]."txn-results"[0]."missing-signature"'
 fi
 
 # SIMULATE with a signature
-${gcmd} clerk sign -i empty.tx -o empty.stx
-RES=$(${gcmd} clerk simulate -t empty.stx | jq '."would-succeed"')
+${gcmd} clerk sign -i "${TEMPDIR}/empty.tx" -o "${TEMPDIR}/empty.stx"
+RES=$(${gcmd} clerk simulate -t "${TEMPDIR}/empty.stx" | jq '."would-succeed"')
 
 # with signature, simulation app-call should succeed
 if [[ $RES != $CONST_TRUE ]]; then

--- a/test/scripts/e2e_subs/e2e-app-simulate.sh
+++ b/test/scripts/e2e_subs/e2e-app-simulate.sh
@@ -22,7 +22,7 @@ CONST_FALSE="false"
 
 # First, try to send an extremely large "transaction" in the request body.
 # This should fail with a 413 error.
-dd if=/dev/zero of=${TEMPDIR}/toolarge.tx bs=1M count=11
+dd if=/dev/zero of=${TEMPDIR}/toolarge.tx bs=11M count=1
 RES=$(${gcmd} clerk simulate -t "${TEMPDIR}/toolarge.tx" 2>&1 || true)
 EXPERROR="simulation error: HTTP 413 Request Entity Too Large:"
 if [[ $RES != *"${EXPERROR}"* ]]; then


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

This PR changes use of `truncate` to `dd` when create large zero-ed files. This was due to a breaking nightly build in `mac_amd64`, since the `truncate` command was not available there. 

Also adds all simulate test artifacts to the tempdir so they can be cleaned up at the end of the test. Locally checked that test files were being cleaned up by running `./test/scripts/e2e.sh`
