### PR TITLE
feat: remove any potential accounts with 0-byte len

### DIFF
--- a/ledger/store/trackerdb/sqlitedriver/accountsV2_test.go
+++ b/ledger/store/trackerdb/sqlitedriver/accountsV2_test.go
@@ -92,6 +92,8 @@ func TestRowidsToChunkedArgs(t *testing.T) {
 }
 
 func TestMigration10to11ZeroBytesAccounts(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	dbs, _ := DbOpenTrackerTest(t, true)
 	defer dbs.Close()
 	dbs.SetLogger(logging.TestingLog(t))

--- a/ledger/store/trackerdb/sqlitedriver/schema.go
+++ b/ledger/store/trackerdb/sqlitedriver/schema.go
@@ -851,46 +851,16 @@ func removeEmptyAccountData(tx *sql.Tx, queryAddresses bool) (num int64, address
 
 // removeZeroBytesAccountData removes empty AccountData with 0 bytes from the db
 // and optionally returns list of addresses that were eliminated
-func removeZeroBytesAccountData(tx *sql.Tx, queryAddresses bool) (num int64, addresses []basics.Address, err error) {
-	if queryAddresses {
-		rows, err := tx.Query("SELECT address FROM accountbase where length(data) = 0 or data IS NULL")
-		if err != nil {
-			return 0, nil, err
-		}
-		defer rows.Close()
-
-		for rows.Next() {
-			var addrbuf []byte
-			err = rows.Scan(&addrbuf)
-			if err != nil {
-				return 0, nil, err
-			}
-			var addr basics.Address
-			if len(addrbuf) != len(addr) {
-				err = fmt.Errorf("account DB address length mismatch: %d != %d", len(addrbuf), len(addr))
-				return 0, nil, err
-			}
-			copy(addr[:], addrbuf)
-			addresses = append(addresses, addr)
-		}
-
-		// if the above loop was abrupted by an error, test it now.
-		if err = rows.Err(); err != nil {
-			return 0, nil, err
-		}
-	}
-
+func removeZeroBytesAccountData(tx *sql.Tx) (num int64, err error) {
 	result, err := tx.Exec("DELETE from accountbase where length(data) = 0 or data IS NULL")
 	if err != nil {
-		return 0, nil, err
+		return 0, err
 	}
 	num, err = result.RowsAffected()
 	if err != nil {
-		// something wrong on getting rows count but data deleted, ignore the error
-		num = int64(len(addresses))
-		err = nil
+		return 0, err
 	}
-	return num, addresses, err
+	return num, err
 }
 
 // reencodeAccounts reads all the accounts in the accountbase table, decode and reencode the account data.

--- a/ledger/store/trackerdb/sqlitedriver/schema.go
+++ b/ledger/store/trackerdb/sqlitedriver/schema.go
@@ -853,7 +853,7 @@ func removeEmptyAccountData(tx *sql.Tx, queryAddresses bool) (num int64, address
 // and optionally returns list of addresses that were eliminated
 func removeZeroBytesAccountData(tx *sql.Tx, queryAddresses bool) (num int64, addresses []basics.Address, err error) {
 	if queryAddresses {
-		rows, err := tx.Query("SELECT address FROM accountbase where length(data) = 0")
+		rows, err := tx.Query("SELECT address FROM accountbase where length(data) = 0 or data IS NULL")
 		if err != nil {
 			return 0, nil, err
 		}
@@ -880,7 +880,7 @@ func removeZeroBytesAccountData(tx *sql.Tx, queryAddresses bool) (num int64, add
 		}
 	}
 
-	result, err := tx.Exec("DELETE from accountbase where length(data) = 0")
+	result, err := tx.Exec("DELETE from accountbase where length(data) = 0 or data IS NULL")
 	if err != nil {
 		return 0, nil, err
 	}

--- a/ledger/store/trackerdb/sqlitedriver/trackerdbV2.go
+++ b/ledger/store/trackerdb/sqlitedriver/trackerdbV2.go
@@ -513,7 +513,7 @@ func (tu *trackerDBSchemaInitializer) upgradeDatabaseSchema9(ctx context.Context
 // this does not change the schema but verifies there are no accounts with 0 bytes in the data field,
 // and removes any if found.
 func (tu *trackerDBSchemaInitializer) upgradeDatabaseSchema10(ctx context.Context, tx *sql.Tx) (err error) {
-	_, _, err = removeZeroBytesAccountData(tx, tu.CatchpointEnabled)
+	_, err = removeZeroBytesAccountData(tx)
 	if err != nil {
 		return err
 	}

--- a/ledger/store/trackerdb/sqlitedriver/trackerdbV2.go
+++ b/ledger/store/trackerdb/sqlitedriver/trackerdbV2.go
@@ -137,6 +137,12 @@ func RunMigrations(ctx context.Context, tx *sql.Tx, params trackerdb.Params, log
 					tu.log.Warnf("trackerDBInitialize failed to upgrade accounts database (ledger.tracker.sqlite) from schema 9 : %v", err)
 					return
 				}
+			case 10:
+				err = tu.upgradeDatabaseSchema10(ctx, tx)
+				if err != nil {
+					tu.log.Warnf("trackerDBInitialize failed to upgrade accounts database (ledger.tracker.sqlite) from schema 10 : %v", err)
+					return
+				}
 			default:
 				return trackerdb.InitParams{}, fmt.Errorf("trackerDBInitialize unable to upgrade database from schema version %d", tu.schemaVersion)
 			}
@@ -501,6 +507,19 @@ func (tu *trackerDBSchemaInitializer) upgradeDatabaseSchema9(ctx context.Context
 
 	// update version
 	return tu.setVersion(ctx, tx, 10)
+}
+
+// upgradeDatabaseSchema10 upgrades the database schema from version 10 to version 11,
+// this does not change the schema but verifies there are no accounts with 0 bytes in the data field,
+// and removes any if found.
+func (tu *trackerDBSchemaInitializer) upgradeDatabaseSchema10(ctx context.Context, tx *sql.Tx) (err error) {
+	_, _, err = removeZeroBytesAccountData(tx, tu.CatchpointEnabled)
+	if err != nil {
+		return err
+	}
+
+	// update version
+	return tu.setVersion(ctx, tx, 11)
 }
 
 func removeEmptyDirsOnSchemaUpgrade(dbDirectory string) (err error) {

--- a/ledger/store/trackerdb/version.go
+++ b/ledger/store/trackerdb/version.go
@@ -19,4 +19,4 @@ package trackerdb
 // AccountDBVersion is the database version that this binary would know how to support and how to upgrade to.
 // details about the content of each of the versions can be found in the upgrade functions upgradeDatabaseSchemaXXXX
 // and their descriptions.
-var AccountDBVersion = int32(10)
+var AccountDBVersion = int32(11)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

A new db migration has been added.
It removes any potential accounts with 0-byte length in the db. 
This is not a valid state.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

A new test was added to verify the specific migration removed only the desired accounts.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
