### PR TITLE
scripts: enhance upload_config.sh

### DIFF
--- a/scripts/upload_config.sh
+++ b/scripts/upload_config.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+trap 'echo "ERROR: ${BASH_SOURCE}:${LINENO} ${BASH_COMMAND}"' ERR
 
 # upload_config.sh - Archives and uploads a netgoal configuration package from a specified directory
 #           NOTE: Will only work if you have the required AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY vars set
@@ -33,11 +34,11 @@ SRCPATH=${SCRIPTPATH}/..
 export CHANNEL=$2
 export FULLVERSION=$($SRCPATH/scripts/compute_build_number.sh -f)
 
-TEMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t "tmp")
+TEMPDIR=$(mktemp -d -t "upload_config.tmp.XXXXXX")
 TARFILE=${TEMPDIR}/config_${CHANNEL}_${FULLVERSION}.tar.gz
 
 cd $1
-tar -zcf ${TARFILE} * >/dev/null 2>&1
+tar -zcf ${TARFILE} * >/dev/null
 
 ${GOPATH}/bin/updater send -s ${TEMPDIR} -c ${CHANNEL} -b "${S3_RELEASE_BUCKET}"
 rm ${TARFILE}


### PR DESCRIPTION
* Adds `trap`
* Prevents `tar` from directing stderr to null
* Clarifies and corrects tmp directory creation

Made these changes while I worked on getting a config uploaded which silently failed due to tar errors.