### PR TITLE
algocfg(profile): Add file name to config file conflict message.

### DIFF
--- a/cmd/algocfg/profileCommand.go
+++ b/cmd/algocfg/profileCommand.go
@@ -143,7 +143,7 @@ var setProfileCmd = &cobra.Command{
 			}
 			file := filepath.Join(dataDir, config.ConfigFilename)
 			if _, err := os.Stat(file); !forceUpdate && err == nil {
-				fmt.Printf("A config.json file already exists for this data directory. Would you like to overwrite it? (Y/n)")
+				fmt.Printf("A config.json file already exists at %s\nWould you like to overwrite it? (Y/n)", file)
 				reader := bufio.NewReader(os.Stdin)
 				resp, err := reader.ReadString('\n')
 				resp = strings.TrimSpace(resp)


### PR DESCRIPTION
## Summary

Add additional information when prompting to overwrite a config.json file. This should help in the event that `algocfg profile set conduit -d ""` falls back to the `ALGORAND_DATA` environment variable. This case is probably not very common for a normal installation, but could occur with testing scripts where a parameterized data directory is not properly set.

## Test Plan

Manual testing.