### PR TITLE
tests: Change `dd` argument to use a bytes value

### DIFF
--- a/test/scripts/e2e_subs/e2e-app-simulate.sh
+++ b/test/scripts/e2e_subs/e2e-app-simulate.sh
@@ -22,7 +22,10 @@ CONST_FALSE="false"
 
 # First, try to send an extremely large "transaction" in the request body.
 # This should fail with a 413 error.
-dd if=/dev/zero of="${TEMPDIR}/toolarge.tx" bs=11m count=1
+# Some of our MacOS nightly tests fail for specifying the bs (block size)
+# value in capital letters (i.e. 11M), so just specify it as 1024 bytes and
+# allocate 11K blocks so we get a 11MB sized file. 
+dd if=/dev/zero of="${TEMPDIR}/toolarge.tx" bs=1024 count=11000
 RES=$(${gcmd} clerk simulate -t "${TEMPDIR}/toolarge.tx" 2>&1 || true)
 EXPERROR="simulation error: HTTP 413 Request Entity Too Large:"
 if [[ $RES != *"${EXPERROR}"* ]]; then

--- a/test/scripts/e2e_subs/e2e-app-simulate.sh
+++ b/test/scripts/e2e_subs/e2e-app-simulate.sh
@@ -22,7 +22,7 @@ CONST_FALSE="false"
 
 # First, try to send an extremely large "transaction" in the request body.
 # This should fail with a 413 error.
-dd if=/dev/zero of="${TEMPDIR}/toolarge.tx" bs=11M count=1
+dd if=/dev/zero of="${TEMPDIR}/toolarge.tx" bs=11m count=1
 RES=$(${gcmd} clerk simulate -t "${TEMPDIR}/toolarge.tx" 2>&1 || true)
 EXPERROR="simulation error: HTTP 413 Request Entity Too Large:"
 if [[ $RES != *"${EXPERROR}"* ]]; then


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Changes `dd`'s `bs` argument to a bytes value to work on both macOS (specifically, CircleCI's macOS 11) and linux. Also added a comment above the line to justify this:

```
# Some of our MacOS nightly tests fail for specifying the bs (block size)
# value in capital letters (i.e. 11M), so just specify it as 1024 bytes and
# allocate 11K blocks so we get a 11MB sized file. 
```


Nightly integration tests seem to pass now: https://app.circleci.com/pipelines/github/algorand/go-algorand/13522/workflows/2cca47be-d835-48c3-897e-7f713e521534