### PR TITLE
chore: Rename ModStateProofNextRound to StateProofNext.

### DIFF
--- a/ledger/apply/stateproof_test.go
+++ b/ledger/apply/stateproof_test.go
@@ -270,6 +270,6 @@ func TestApplyStateProof(t *testing.T) {
 	// transaction should be applied without stateproof validation (no context, blockheader or valid stateproof needed as it represents a node catching up)
 	err = StateProof(stateProofTx, atRound, applier, false)
 	a.NoError(err)
-	// make sure that the ModStateProofNextRound was updated correctly after applying
+	// make sure that the StateProofNext was updated correctly after applying
 	a.Equal(basics.Round(512+config.Consensus[protocol.ConsensusFuture].StateProofInterval), applier.GetStateProofNextRound())
 }

--- a/ledger/apply/stateproof_test.go
+++ b/ledger/apply/stateproof_test.go
@@ -270,6 +270,6 @@ func TestApplyStateProof(t *testing.T) {
 	// transaction should be applied without stateproof validation (no context, blockheader or valid stateproof needed as it represents a node catching up)
 	err = StateProof(stateProofTx, atRound, applier, false)
 	a.NoError(err)
-	// make sure that the ModStateProofNextRound was updated correctly after applying
+	// make sure that the StateProofNextRound was updated correctly after applying
 	a.Equal(basics.Round(512+config.Consensus[protocol.ConsensusFuture].StateProofInterval), applier.GetStateProofNextRound())
 }

--- a/ledger/apply/stateproof_test.go
+++ b/ledger/apply/stateproof_test.go
@@ -270,6 +270,6 @@ func TestApplyStateProof(t *testing.T) {
 	// transaction should be applied without stateproof validation (no context, blockheader or valid stateproof needed as it represents a node catching up)
 	err = StateProof(stateProofTx, atRound, applier, false)
 	a.NoError(err)
-	// make sure that the StateProofNextRound was updated correctly after applying
+	// make sure that the ModStateProofNextRound was updated correctly after applying
 	a.Equal(basics.Round(512+config.Consensus[protocol.ConsensusFuture].StateProofInterval), applier.GetStateProofNextRound())
 }

--- a/ledger/eval/cow.go
+++ b/ledger/eval/cow.go
@@ -235,8 +235,8 @@ func (cb *roundCowState) Counter() uint64 {
 }
 
 func (cb *roundCowState) GetStateProofNextRound() basics.Round {
-	if cb.mods.StateProofNextRound != 0 {
-		return cb.mods.StateProofNextRound
+	if cb.mods.ModStateProofNextRound != 0 {
+		return cb.mods.ModStateProofNextRound
 	}
 	return cb.lookupParent.GetStateProofNextRound()
 }
@@ -266,7 +266,7 @@ func (cb *roundCowState) addTx(txn transactions.Transaction, txid transactions.T
 }
 
 func (cb *roundCowState) SetStateProofNextRound(rnd basics.Round) {
-	cb.mods.StateProofNextRound = rnd
+	cb.mods.ModStateProofNextRound = rnd
 }
 
 func (cb *roundCowState) child(hint int) *roundCowState {
@@ -274,7 +274,7 @@ func (cb *roundCowState) child(hint int) *roundCowState {
 	ch.lookupParent = cb
 	ch.commitParent = cb
 	ch.proto = cb.proto
-	ch.mods.PopulateStateDelta(cb.mods.Hdr, cb.mods.PrevTimestamp, hint, cb.mods.StateProofNextRound)
+	ch.mods.PopulateStateDelta(cb.mods.Hdr, cb.mods.PrevTimestamp, hint, cb.mods.ModStateProofNextRound)
 
 	if ch.sdeltas == nil {
 		ch.sdeltas = make(map[basics.Address]map[storagePtr]*storageDelta)
@@ -318,7 +318,7 @@ func (cb *roundCowState) commitToParent() {
 			}
 		}
 	}
-	cb.commitParent.mods.StateProofNextRound = cb.mods.StateProofNextRound
+	cb.commitParent.mods.ModStateProofNextRound = cb.mods.ModStateProofNextRound
 
 	for key, value := range cb.mods.KvMods {
 		cb.commitParent.mods.AddKvMod(key, value)

--- a/ledger/eval/cow.go
+++ b/ledger/eval/cow.go
@@ -235,8 +235,8 @@ func (cb *roundCowState) Counter() uint64 {
 }
 
 func (cb *roundCowState) GetStateProofNextRound() basics.Round {
-	if cb.mods.ModStateProofNextRound != 0 {
-		return cb.mods.ModStateProofNextRound
+	if cb.mods.StateProofNextRound != 0 {
+		return cb.mods.StateProofNextRound
 	}
 	return cb.lookupParent.GetStateProofNextRound()
 }
@@ -266,7 +266,7 @@ func (cb *roundCowState) addTx(txn transactions.Transaction, txid transactions.T
 }
 
 func (cb *roundCowState) SetStateProofNextRound(rnd basics.Round) {
-	cb.mods.ModStateProofNextRound = rnd
+	cb.mods.StateProofNextRound = rnd
 }
 
 func (cb *roundCowState) child(hint int) *roundCowState {
@@ -274,7 +274,7 @@ func (cb *roundCowState) child(hint int) *roundCowState {
 	ch.lookupParent = cb
 	ch.commitParent = cb
 	ch.proto = cb.proto
-	ch.mods.PopulateStateDelta(cb.mods.Hdr, cb.mods.PrevTimestamp, hint, cb.mods.ModStateProofNextRound)
+	ch.mods.PopulateStateDelta(cb.mods.Hdr, cb.mods.PrevTimestamp, hint, cb.mods.StateProofNextRound)
 
 	if ch.sdeltas == nil {
 		ch.sdeltas = make(map[basics.Address]map[storagePtr]*storageDelta)
@@ -318,7 +318,7 @@ func (cb *roundCowState) commitToParent() {
 			}
 		}
 	}
-	cb.commitParent.mods.ModStateProofNextRound = cb.mods.ModStateProofNextRound
+	cb.commitParent.mods.StateProofNextRound = cb.mods.StateProofNextRound
 
 	for key, value := range cb.mods.KvMods {
 		cb.commitParent.mods.AddKvMod(key, value)

--- a/ledger/eval/cow.go
+++ b/ledger/eval/cow.go
@@ -235,8 +235,8 @@ func (cb *roundCowState) Counter() uint64 {
 }
 
 func (cb *roundCowState) GetStateProofNextRound() basics.Round {
-	if cb.mods.ModStateProofNextRound != 0 {
-		return cb.mods.ModStateProofNextRound
+	if cb.mods.StateProofNext != 0 {
+		return cb.mods.StateProofNext
 	}
 	return cb.lookupParent.GetStateProofNextRound()
 }
@@ -266,7 +266,7 @@ func (cb *roundCowState) addTx(txn transactions.Transaction, txid transactions.T
 }
 
 func (cb *roundCowState) SetStateProofNextRound(rnd basics.Round) {
-	cb.mods.ModStateProofNextRound = rnd
+	cb.mods.StateProofNext = rnd
 }
 
 func (cb *roundCowState) child(hint int) *roundCowState {
@@ -274,7 +274,7 @@ func (cb *roundCowState) child(hint int) *roundCowState {
 	ch.lookupParent = cb
 	ch.commitParent = cb
 	ch.proto = cb.proto
-	ch.mods.PopulateStateDelta(cb.mods.Hdr, cb.mods.PrevTimestamp, hint, cb.mods.ModStateProofNextRound)
+	ch.mods.PopulateStateDelta(cb.mods.Hdr, cb.mods.PrevTimestamp, hint, cb.mods.StateProofNext)
 
 	if ch.sdeltas == nil {
 		ch.sdeltas = make(map[basics.Address]map[storagePtr]*storageDelta)
@@ -318,7 +318,7 @@ func (cb *roundCowState) commitToParent() {
 			}
 		}
 	}
-	cb.commitParent.mods.ModStateProofNextRound = cb.mods.ModStateProofNextRound
+	cb.commitParent.mods.StateProofNext = cb.mods.StateProofNext
 
 	for key, value := range cb.mods.KvMods {
 		cb.commitParent.mods.AddKvMod(key, value)

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -3189,7 +3189,7 @@ func TestLedgerSPVerificationTracker(t *testing.T) {
 	// to the ledger.
 	delta, err := eval.Eval(context.Background(), l, blk, false, l.verifiedTxnCache, nil)
 	require.NoError(t, err)
-	delta.ModStateProofNextRound = stateProofReceived.StateProofNextRound
+	delta.StateProofNext = stateProofReceived.StateProofNextRound
 	vb := ledgercore.MakeValidatedBlock(blk, delta)
 	err = l.AddValidatedBlock(vb, agreement.Certificate{})
 	require.NoError(t, err)

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -3189,7 +3189,7 @@ func TestLedgerSPVerificationTracker(t *testing.T) {
 	// to the ledger.
 	delta, err := eval.Eval(context.Background(), l, blk, false, l.verifiedTxnCache, nil)
 	require.NoError(t, err)
-	delta.ModStateProofNextRound = stateProofReceived.StateProofNextRound
+	delta.StateProofNextRound = stateProofReceived.StateProofNextRound
 	vb := ledgercore.MakeValidatedBlock(blk, delta)
 	err = l.AddValidatedBlock(vb, agreement.Certificate{})
 	require.NoError(t, err)

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -3189,7 +3189,7 @@ func TestLedgerSPVerificationTracker(t *testing.T) {
 	// to the ledger.
 	delta, err := eval.Eval(context.Background(), l, blk, false, l.verifiedTxnCache, nil)
 	require.NoError(t, err)
-	delta.StateProofNextRound = stateProofReceived.StateProofNextRound
+	delta.ModStateProofNextRound = stateProofReceived.StateProofNextRound
 	vb := ledgercore.MakeValidatedBlock(blk, delta)
 	err = l.AddValidatedBlock(vb, agreement.Certificate{})
 	require.NoError(t, err)

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -110,10 +110,10 @@ type StateDelta struct {
 	// new block header; read-only
 	Hdr *bookkeeping.BlockHeader
 
-	// ModStateProofNextRound represents modification on StateProofNextRound field in the block header. If the block contains
+	// StateProofNextRound represents modification on StateProofNextRound field in the block header. If the block contains
 	// a valid state proof transaction, this field will contain the next round for state proof.
 	// otherwise it will be set to 0.
-	ModStateProofNextRound basics.Round
+	StateProofNextRound basics.Round
 
 	// previous block timestamp
 	PrevTimestamp int64
@@ -215,7 +215,7 @@ func (sd *StateDelta) PopulateStateDelta(hdr *bookkeeping.BlockHeader, prevTimes
 		sd.initialHint = hint
 	}
 	sd.Hdr = hdr
-	sd.ModStateProofNextRound = stateProofNext
+	sd.StateProofNextRound = stateProofNext
 	sd.PrevTimestamp = prevTimestamp
 }
 
@@ -248,7 +248,7 @@ func (sd *StateDelta) Reset() {
 	// these fields are going to be populated on next use but resetting them anyway for safety.
 	// we are not resetting sd.initialHint since it should only be reset if reallocating AccountDeltas
 	sd.Hdr = nil
-	sd.ModStateProofNextRound = basics.Round(0)
+	sd.StateProofNextRound = basics.Round(0)
 	sd.PrevTimestamp = 0
 }
 

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -88,6 +88,8 @@ type KvValueDelta struct {
 // If adding a new field not explicitly allocated by PopulateStateDelta, make sure to reset
 // it in .ReuseStateDelta to avoid dirty memory errors.
 // If adding fields make sure to add them to the .Reset() method to avoid dirty state
+//
+//msgp:ignore StateDelta
 type StateDelta struct {
 	// modified new accounts
 	Accts AccountDeltas

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -88,8 +88,6 @@ type KvValueDelta struct {
 // If adding a new field not explicitly allocated by PopulateStateDelta, make sure to reset
 // it in .ReuseStateDelta to avoid dirty memory errors.
 // If adding fields make sure to add them to the .Reset() method to avoid dirty state
-//
-//msgp:ignore StateDelta
 type StateDelta struct {
 	// modified new accounts
 	Accts AccountDeltas
@@ -112,10 +110,10 @@ type StateDelta struct {
 	// new block header; read-only
 	Hdr *bookkeeping.BlockHeader
 
-	// ModStateProofNextRound represents modification on StateProofNextRound field in the block header. If the block contains
+	// StateProofNext represents modification on StateProofNextRound field in the block header. If the block contains
 	// a valid state proof transaction, this field will contain the next round for state proof.
 	// otherwise it will be set to 0.
-	ModStateProofNextRound basics.Round `codec:"StateProofNext,omitempty"`
+	StateProofNext basics.Round
 
 	// previous block timestamp
 	PrevTimestamp int64

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -115,7 +115,7 @@ type StateDelta struct {
 	// ModStateProofNextRound represents modification on StateProofNextRound field in the block header. If the block contains
 	// a valid state proof transaction, this field will contain the next round for state proof.
 	// otherwise it will be set to 0.
-	ModStateProofNextRound basics.Round `codec:"StateProofNextRound,omitempty"`
+	ModStateProofNextRound basics.Round `codec:"StateProofNext,omitempty"`
 
 	// previous block timestamp
 	PrevTimestamp int64

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -215,7 +215,7 @@ func (sd *StateDelta) PopulateStateDelta(hdr *bookkeeping.BlockHeader, prevTimes
 		sd.initialHint = hint
 	}
 	sd.Hdr = hdr
-	sd.ModStateProofNextRound = stateProofNext
+	sd.StateProofNext = stateProofNext
 	sd.PrevTimestamp = prevTimestamp
 }
 
@@ -248,7 +248,7 @@ func (sd *StateDelta) Reset() {
 	// these fields are going to be populated on next use but resetting them anyway for safety.
 	// we are not resetting sd.initialHint since it should only be reset if reallocating AccountDeltas
 	sd.Hdr = nil
-	sd.ModStateProofNextRound = basics.Round(0)
+	sd.StateProofNext = basics.Round(0)
 	sd.PrevTimestamp = 0
 }
 

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -110,10 +110,10 @@ type StateDelta struct {
 	// new block header; read-only
 	Hdr *bookkeeping.BlockHeader
 
-	// StateProofNextRound represents modification on StateProofNextRound field in the block header. If the block contains
+	// ModStateProofNextRound represents modification on StateProofNextRound field in the block header. If the block contains
 	// a valid state proof transaction, this field will contain the next round for state proof.
 	// otherwise it will be set to 0.
-	StateProofNextRound basics.Round
+	ModStateProofNextRound basics.Round
 
 	// previous block timestamp
 	PrevTimestamp int64
@@ -215,7 +215,7 @@ func (sd *StateDelta) PopulateStateDelta(hdr *bookkeeping.BlockHeader, prevTimes
 		sd.initialHint = hint
 	}
 	sd.Hdr = hdr
-	sd.StateProofNextRound = stateProofNext
+	sd.ModStateProofNextRound = stateProofNext
 	sd.PrevTimestamp = prevTimestamp
 }
 
@@ -248,7 +248,7 @@ func (sd *StateDelta) Reset() {
 	// these fields are going to be populated on next use but resetting them anyway for safety.
 	// we are not resetting sd.initialHint since it should only be reset if reallocating AccountDeltas
 	sd.Hdr = nil
-	sd.StateProofNextRound = basics.Round(0)
+	sd.ModStateProofNextRound = basics.Round(0)
 	sd.PrevTimestamp = 0
 }
 

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -113,7 +113,7 @@ type StateDelta struct {
 	// ModStateProofNextRound represents modification on StateProofNextRound field in the block header. If the block contains
 	// a valid state proof transaction, this field will contain the next round for state proof.
 	// otherwise it will be set to 0.
-	ModStateProofNextRound basics.Round
+	ModStateProofNextRound basics.Round `codec:"StateProofNextRound,omitempty"`
 
 	// previous block timestamp
 	PrevTimestamp int64

--- a/ledger/ledgercore/statedelta_test.go
+++ b/ledger/ledgercore/statedelta_test.go
@@ -150,7 +150,7 @@ func TestStateDeltaReset(t *testing.T) {
 
 	// StateDeltas simple fields
 	require.Zero(t, sd.Hdr)
-	require.Zero(t, sd.StateProofNextRound)
+	require.Zero(t, sd.ModStateProofNextRound)
 	require.Zero(t, sd.PrevTimestamp)
 	require.Zero(t, sd.Totals)
 
@@ -184,16 +184,16 @@ func TestStateDeltaReflect(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	stateDeltaFieldNames := map[string]struct{}{
-		"Accts":               {},
-		"KvMods":              {},
-		"Txids":               {},
-		"Txleases":            {},
-		"Creatables":          {},
-		"Hdr":                 {},
-		"StateProofNextRound": {},
-		"PrevTimestamp":       {},
-		"initialHint":         {},
-		"Totals":              {},
+		"Accts":                  {},
+		"KvMods":                 {},
+		"Txids":                  {},
+		"Txleases":               {},
+		"Creatables":             {},
+		"Hdr":                    {},
+		"ModStateProofNextRound": {},
+		"PrevTimestamp":          {},
+		"initialHint":            {},
+		"Totals":                 {},
 	}
 
 	sd := StateDelta{}

--- a/ledger/ledgercore/statedelta_test.go
+++ b/ledger/ledgercore/statedelta_test.go
@@ -150,7 +150,7 @@ func TestStateDeltaReset(t *testing.T) {
 
 	// StateDeltas simple fields
 	require.Zero(t, sd.Hdr)
-	require.Zero(t, sd.ModStateProofNextRound)
+	require.Zero(t, sd.StateProofNextRound)
 	require.Zero(t, sd.PrevTimestamp)
 	require.Zero(t, sd.Totals)
 
@@ -184,16 +184,16 @@ func TestStateDeltaReflect(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	stateDeltaFieldNames := map[string]struct{}{
-		"Accts":                  {},
-		"KvMods":                 {},
-		"Txids":                  {},
-		"Txleases":               {},
-		"Creatables":             {},
-		"Hdr":                    {},
-		"ModStateProofNextRound": {},
-		"PrevTimestamp":          {},
-		"initialHint":            {},
-		"Totals":                 {},
+		"Accts":               {},
+		"KvMods":              {},
+		"Txids":               {},
+		"Txleases":            {},
+		"Creatables":          {},
+		"Hdr":                 {},
+		"StateProofNextRound": {},
+		"PrevTimestamp":       {},
+		"initialHint":         {},
+		"Totals":              {},
 	}
 
 	sd := StateDelta{}

--- a/ledger/ledgercore/statedelta_test.go
+++ b/ledger/ledgercore/statedelta_test.go
@@ -150,7 +150,7 @@ func TestStateDeltaReset(t *testing.T) {
 
 	// StateDeltas simple fields
 	require.Zero(t, sd.Hdr)
-	require.Zero(t, sd.ModStateProofNextRound)
+	require.Zero(t, sd.StateProofNext)
 	require.Zero(t, sd.PrevTimestamp)
 	require.Zero(t, sd.Totals)
 
@@ -184,16 +184,16 @@ func TestStateDeltaReflect(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	stateDeltaFieldNames := map[string]struct{}{
-		"Accts":                  {},
-		"KvMods":                 {},
-		"Txids":                  {},
-		"Txleases":               {},
-		"Creatables":             {},
-		"Hdr":                    {},
-		"ModStateProofNextRound": {},
-		"PrevTimestamp":          {},
-		"initialHint":            {},
-		"Totals":                 {},
+		"Accts":          {},
+		"KvMods":         {},
+		"Txids":          {},
+		"Txleases":       {},
+		"Creatables":     {},
+		"Hdr":            {},
+		"StateProofNext": {},
+		"PrevTimestamp":  {},
+		"initialHint":    {},
+		"Totals":         {},
 	}
 
 	sd := StateDelta{}

--- a/ledger/spverificationtracker.go
+++ b/ledger/spverificationtracker.go
@@ -96,7 +96,7 @@ func (spt *spVerificationTracker) newBlock(blk bookkeeping.Block, delta ledgerco
 		spt.appendCommitContext(&blk)
 	}
 
-	if delta.ModStateProofNextRound != 0 {
+	if delta.StateProofNext != 0 {
 		spt.appendDeleteContext(&blk, &delta)
 	}
 }
@@ -306,7 +306,7 @@ func (spt *spVerificationTracker) appendDeleteContext(blk *bookkeeping.Block, de
 
 	deletionContext := verificationDeleteContext{
 		confirmedRound:      blk.Round(),
-		stateProofNextRound: delta.ModStateProofNextRound,
+		stateProofNextRound: delta.StateProofNext,
 	}
 
 	spt.pendingDeleteContexts = append(spt.pendingDeleteContexts, deletionContext)

--- a/ledger/spverificationtracker.go
+++ b/ledger/spverificationtracker.go
@@ -96,7 +96,7 @@ func (spt *spVerificationTracker) newBlock(blk bookkeeping.Block, delta ledgerco
 		spt.appendCommitContext(&blk)
 	}
 
-	if delta.StateProofNextRound != 0 {
+	if delta.ModStateProofNextRound != 0 {
 		spt.appendDeleteContext(&blk, &delta)
 	}
 }
@@ -306,7 +306,7 @@ func (spt *spVerificationTracker) appendDeleteContext(blk *bookkeeping.Block, de
 
 	deletionContext := verificationDeleteContext{
 		confirmedRound:      blk.Round(),
-		stateProofNextRound: delta.StateProofNextRound,
+		stateProofNextRound: delta.ModStateProofNextRound,
 	}
 
 	spt.pendingDeleteContexts = append(spt.pendingDeleteContexts, deletionContext)

--- a/ledger/spverificationtracker.go
+++ b/ledger/spverificationtracker.go
@@ -96,7 +96,7 @@ func (spt *spVerificationTracker) newBlock(blk bookkeeping.Block, delta ledgerco
 		spt.appendCommitContext(&blk)
 	}
 
-	if delta.ModStateProofNextRound != 0 {
+	if delta.StateProofNextRound != 0 {
 		spt.appendDeleteContext(&blk, &delta)
 	}
 }
@@ -306,7 +306,7 @@ func (spt *spVerificationTracker) appendDeleteContext(blk *bookkeeping.Block, de
 
 	deletionContext := verificationDeleteContext{
 		confirmedRound:      blk.Round(),
-		stateProofNextRound: delta.ModStateProofNextRound,
+		stateProofNextRound: delta.StateProofNextRound,
 	}
 
 	spt.pendingDeleteContexts = append(spt.pendingDeleteContexts, deletionContext)

--- a/ledger/spverificationtracker_test.go
+++ b/ledger/spverificationtracker_test.go
@@ -141,7 +141,7 @@ func feedBlocksUpToRound(spt *spVerificationTracker, prevBlock *blockEntry, targ
 			stateProofDelta = currentStateProofNextRound
 		}
 
-		spt.newBlock(block.block, ledgercore.StateDelta{StateProofNextRound: stateProofDelta})
+		spt.newBlock(block.block, ledgercore.StateDelta{ModStateProofNextRound: stateProofDelta})
 		prevBlock = &block
 	}
 

--- a/ledger/spverificationtracker_test.go
+++ b/ledger/spverificationtracker_test.go
@@ -141,7 +141,7 @@ func feedBlocksUpToRound(spt *spVerificationTracker, prevBlock *blockEntry, targ
 			stateProofDelta = currentStateProofNextRound
 		}
 
-		spt.newBlock(block.block, ledgercore.StateDelta{ModStateProofNextRound: stateProofDelta})
+		spt.newBlock(block.block, ledgercore.StateDelta{StateProofNext: stateProofDelta})
 		prevBlock = &block
 	}
 

--- a/ledger/spverificationtracker_test.go
+++ b/ledger/spverificationtracker_test.go
@@ -141,7 +141,7 @@ func feedBlocksUpToRound(spt *spVerificationTracker, prevBlock *blockEntry, targ
 			stateProofDelta = currentStateProofNextRound
 		}
 
-		spt.newBlock(block.block, ledgercore.StateDelta{ModStateProofNextRound: stateProofDelta})
+		spt.newBlock(block.block, ledgercore.StateDelta{StateProofNextRound: stateProofDelta})
 		prevBlock = &block
 	}
 


### PR DESCRIPTION
## Summary

Remove `Mod` prefix because `ModStateProofNextRound` is an absolute round rather than some sort of mod/delta/offset.

## Test Plan

Non functional change, existing regression tests.