### PR TITLE
ledger: Add LookupOldAccount to AccountsReader interface

### DIFF
--- a/ledger/acctdeltas.go
+++ b/ledger/acctdeltas.go
@@ -466,7 +466,7 @@ func (a *compactAccountDeltas) accountsLoadOld(tx trackerdb.TransactionScope) (e
 	if len(a.misses) == 0 {
 		return nil
 	}
-	arw, err := tx.MakeAccountsReaderWriter()
+	arw, err := tx.MakeAccountsOptimizedReader()
 	if err != nil {
 		return err
 	}
@@ -476,29 +476,13 @@ func (a *compactAccountDeltas) accountsLoadOld(tx trackerdb.TransactionScope) (e
 	}()
 	for _, idx := range a.misses {
 		addr := a.deltas[idx].address
-		ref, acctDataBuf, err := arw.LookupAccountDataByAddress(addr)
-		switch err {
-		case nil:
-			if len(acctDataBuf) > 0 {
-				persistedAcctData := &trackerdb.PersistedAccountData{Addr: addr, Ref: ref}
-				err = protocol.Decode(acctDataBuf, &persistedAcctData.AccountData)
-				if err != nil {
-					return err
-				}
-				a.updateOld(idx, *persistedAcctData)
-			} else {
-				// to retain backward compatibility, we will treat this condition as if we don't have the account.
-				a.updateOld(idx, trackerdb.PersistedAccountData{Addr: addr, Ref: ref})
-			}
-		case sql.ErrNoRows:
-			// we don't have that account, just return an empty record.
-			a.updateOld(idx, trackerdb.PersistedAccountData{Addr: addr})
-			// Note: the err will be ignored in this case since `err` is being shadowed.
-			// this behaviour is equivalent to `err = nil`
-		default:
+		data, err := arw.LookupAccount(addr)
+		if err != nil {
 			// unexpected error - let the caller know that we couldn't complete the operation.
 			return err
 		}
+		// update the account
+		a.updateOld(idx, data)
 	}
 	return
 }

--- a/ledger/acctdeltas.go
+++ b/ledger/acctdeltas.go
@@ -476,7 +476,7 @@ func (a *compactAccountDeltas) accountsLoadOld(tx trackerdb.TransactionScope) (e
 	}()
 	for _, idx := range a.misses {
 		addr := a.deltas[idx].address
-		data, err := arw.LookupAccount(addr)
+		data, err := arw.LookupOldAccount(addr)
 		if err != nil {
 			// unexpected error - let the caller know that we couldn't complete the operation.
 			return err

--- a/ledger/acctdeltas_test.go
+++ b/ledger/acctdeltas_test.go
@@ -59,7 +59,7 @@ func checkAccounts(t *testing.T, tx trackerdb.TransactionScope, rnd basics.Round
 	require.NoError(t, err)
 	require.Equal(t, r, rnd)
 
-	aor, err := tx.Testing().MakeAccountsOptimizedReader()
+	aor, err := tx.MakeAccountsOptimizedReader()
 	require.NoError(t, err)
 
 	var totalOnline, totalOffline, totalNotPart uint64

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1027,7 +1027,7 @@ func TestListCreatables(t *testing.T) {
 		require.NoError(t, err)
 
 		au := &accountUpdates{}
-		au.accountsq, err = tx.Testing().MakeAccountsOptimizedReader()
+		au.accountsq, err = tx.MakeAccountsOptimizedReader()
 		require.NoError(t, err)
 
 		// ******* All results are obtained from the cache. Empty database *******

--- a/ledger/store/trackerdb/interface.go
+++ b/ledger/store/trackerdb/interface.go
@@ -85,6 +85,7 @@ type AccountsReader interface {
 	ListCreatables(maxIdx basics.CreatableIndex, maxResults uint64, ctype basics.CreatableType) (results []basics.CreatableLocator, dbRound basics.Round, err error)
 
 	LookupAccount(addr basics.Address) (data PersistedAccountData, err error)
+	LookupOldAccount(addr basics.Address) (data PersistedAccountData, err error)
 
 	LookupResources(addr basics.Address, aidx basics.CreatableIndex, ctype basics.CreatableType) (data PersistedResourcesData, err error)
 	LookupAllResources(addr basics.Address) (data []PersistedResourcesData, rnd basics.Round, err error)
@@ -103,7 +104,6 @@ type AccountsReaderExt interface {
 	AccountsTotals(ctx context.Context, catchpointStaging bool) (totals ledgercore.AccountTotals, err error)
 	AccountsHashRound(ctx context.Context) (hashrnd basics.Round, err error)
 	LookupAccountAddressFromAddressID(ctx context.Context, ref AccountRef) (address basics.Address, err error)
-	LookupAccountDataByAddress(basics.Address) (ref AccountRef, data []byte, err error)
 	LookupAccountRowID(basics.Address) (ref AccountRef, err error)
 	LookupResourceDataByAddrID(accountRef AccountRef, aidx basics.CreatableIndex) (data []byte, err error)
 	TotalResources(ctx context.Context) (total uint64, err error)

--- a/ledger/store/trackerdb/sqlitedriver/accountsV2.go
+++ b/ledger/store/trackerdb/sqlitedriver/accountsV2.go
@@ -389,15 +389,9 @@ func (r *accountsV2Reader) LookupAccountAddressFromAddressID(ctx context.Context
 	return
 }
 
-func (r *accountsV2Reader) LookupAccountDataByAddress(addr basics.Address) (ref trackerdb.AccountRef, data []byte, err error) {
-	// optimize this query for repeated usage
-	selectStmt, err := r.getOrPrepare("SELECT rowid, data FROM accountbase WHERE address=?")
-	if err != nil {
-		return
-	}
-
+func (qs *accountsDbQueries) lookupAccountDataByAddress(addr basics.Address) (ref trackerdb.AccountRef, data []byte, err error) {
 	var rowid int64
-	err = selectStmt.QueryRow(addr[:]).Scan(&rowid, &data)
+	err = qs.lookupOldAccountStmt.QueryRow(addr[:]).Scan(&rowid, &data)
 	if err != nil {
 		return
 	}

--- a/ledger/store/trackerdb/store.go
+++ b/ledger/store/trackerdb/store.go
@@ -48,6 +48,7 @@ type TransactionScope interface {
 	MakeCatchpointReaderWriter() (CatchpointReaderWriter, error)
 	MakeAccountsReaderWriter() (AccountsReaderWriter, error)
 	MakeAccountsOptimizedWriter(hasAccounts, hasResources, hasKvPairs, hasCreatables bool) (AccountsWriter, error)
+	MakeAccountsOptimizedReader() (AccountsReader, error)
 	MakeOnlineAccountsOptimizedWriter(hasAccounts bool) (w OnlineAccountsWriter, err error)
 	MakeMerkleCommitter(staging bool) (MerkleCommitter, error)
 	MakeOrderedAccountsIter(accountCount int) OrderedAccountsIter

--- a/ledger/store/trackerdb/testinterface.go
+++ b/ledger/store/trackerdb/testinterface.go
@@ -48,7 +48,6 @@ type TestBatchScope interface {
 type TestTransactionScope interface {
 	TransactionScope
 
-	MakeAccountsOptimizedReader() (AccountsReader, error)
 	MakeOnlineAccountsOptimizedReader() (OnlineAccountsReader, error)
 	AccountsInitTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto protocol.ConsensusVersion) (newDatabase bool)
 	AccountsInitLightTest(tb testing.TB, initAccounts map[basics.Address]basics.AccountData, proto config.ConsensusParams) (newDatabase bool, err error)


### PR DESCRIPTION
## Summary

Based on #5216 this presents an option where the sqlitedriver hides the legacy behavior of accountsLoadOld's lookups behind a new AccountsReader method LookupOldAccounts.

## Test Plan

Existing tests should pass.