### PR TITLE
docker: disable rewards in devmode template

### DIFF
--- a/docker/files/run/devmode_template.json
+++ b/docker/files/run/devmode_template.json
@@ -21,7 +21,8 @@
                 "Online": true
             }
         ],
-        "DevMode": true
+        "DevMode": true,
+        "RewardsPoolBalance": 0
     },
     "Nodes": [
         {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Disables rewards pool in the default devmode template. I imagine this is what most expect when running devmode, especially since it's disabled in the devmode template for sandbox.  

## Test Plan

1. Run network with devmode enabled
2. Verify rewards are disabled