### PR TITLE
Fix: Correct GeneratedAccountsMnemonics Check

### DIFF
--- a/cmd/pingpong/runCmd.go
+++ b/cmd/pingpong/runCmd.go
@@ -438,7 +438,9 @@ var runCmd = &cobra.Command{
 			cfg.GeneratedAccountSampleMethod = generatedAccountSampleMethod
 		}
 		// check if numAccounts is greater than the length of the mnemonic list, if provided
-		if cfg.DeterministicKeys && cfg.NumPartAccounts > uint32(len(cfg.GeneratedAccountsMnemonics)) {
+		if cfg.DeterministicKeys &&
+			len(cfg.GeneratedAccountsMnemonics) > 0 &&
+			cfg.NumPartAccounts > uint32(len(cfg.GeneratedAccountsMnemonics)) {
 			reportErrorf("numAccounts is greater than number of account mnemonics provided")
 		}
 


### PR DESCRIPTION
This check, as the comment above it states, should only apply when the GeneratedAccountsMnemonics list is supplied.