### PR TITLE
docker: Updated user and data dir handling.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,11 +49,9 @@ ENV PATH="/node/bin:${PATH}" ALGOD_PORT="8080" KMD_PORT="7833" ALGORAND_DATA="/a
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p "$ALGORAND_DATA" && \
-    groupadd --system algorand && \
-    useradd --no-log-init --create-home --system --gid algorand algorand && \
+    groupadd --gid=999 --system algorand && \
+    useradd --uid=999 --no-log-init --create-home --system --gid algorand algorand && \
     chown -R algorand:algorand /algod
-
-USER algorand
 
 COPY --chown=algorand:algorand --from=builder "/dist/bin/" "/node/bin/"
 COPY --chown=algorand:algorand --from=builder "/dist/files/run/" "/node/run/"

--- a/docker/README.md
+++ b/docker/README.md
@@ -80,7 +80,7 @@ The data directory located at `/algod/data`. Mounting a volume at that location 
 
 ### Volume Permissions
 
-The container executes in the context of the `algorand` user with UID=999 and GID=999 which is handled differently depending on your operating system. During startup the container is temporarily run as `root`, after modifying the permissions of `/algod/data` it drops to the `algorand` user. This can sometimes cause problems.
+The container executes in the context of the `algorand` user with UID=999 and GID=999 which is handled differently depending on your operating system or deployment platform. During startup the container temporarily runs as `root` in order to modify the permissions of `/algod/data`. It then changes to the `algorand` user. This can sometimes cause problems, for example if your deployment platform doesn't allow containers to run as the root user.
 
 #### Named Volume
 
@@ -91,6 +91,9 @@ docker volume create algod-data
 docker run -it --rm -d -v algod-data:/algod/data algorand/algod
 ```
 
+#### Use specific UID and GID
+
+On the host system, ensure the directory being mounted uses UID=999 and GID=999. If the directory already has these permissions you may override the default user with `-u 999:999`.
 
 ### Private Network
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -80,7 +80,7 @@ The data directory located at `/algod/data`. Mounting a volume at that location 
 
 ### Volume Permissions
 
-The container executes in the context of the `algorand` user with it's own UID and GID which is handled differently depending on your operating system. Here are a few options for how to work with this environment:
+The container executes in the context of the `algorand` user with UID=999 and GID=999 which is handled differently depending on your operating system. During startup the container is temporarily run as `root`, after modifying the permissions of `/algod/data` it drops to the `algorand` user. This can sometimes cause problems.
 
 #### Named Volume
 
@@ -91,23 +91,6 @@ docker volume create algod-data
 docker run -it --rm -d -v algod-data:/algod/data algorand/algod
 ```
 
-#### Local Directory without SELinux
-
-Explicitly set the UID and GID of the container:
-
-```bash
-docker run -it --rm -d -v /srv/data:/algod/data -u $UID:$GID algorand/algod
-```
-
-#### Local Directory with SELinux
-
-Set the UID and GID of the container while add the `Z` option to the volume definition:
-
-```bash
-docker run -it --rm -d -v /srv/data:/algod/data:Z -u $UID:$GID algorand/algod
-```
-
-> See the documentation on [configuring the selinux label](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label).
 
 ### Private Network
 

--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -6,9 +6,17 @@ if [ "$DEBUG" = "1" ]; then
   set -x
 fi
 
+# To allow mounting the data directory we need to change permissions
+# to our algorand user. The script is initially run as the root user
+# in order to change permissions, afterwards the script is re-launched
+# as the algorand user.
+if [ "$(id -u)" = '0' ]; then
+  chown -R algorand:algorand $ALGORAND_DATA
+  exec runuser -u algorand "$BASH_SOURCE"
+fi
+
 # Script to configure or resume a network. Based on environment settings the
 # node will be setup with a private network or connect to a public network.
-
 ####################
 # Helper functions #
 ####################


### PR DESCRIPTION

## Summary

Set UID and GID to 999 consistently.
Start as root user for init then drop to algorand user.

## Test Plan

Build the container locally
```
docker build \
    -t algod_test \
    --build-arg CHANNEL=stable \
    --build-arg TARGETARCH=amd64 --no-cache \
    .
```

Without these changes, mounting a directory fails with a permission denied error.
```
docker run --rm -it \
    -p 4190:4190 \
    --name algod-test-run \
    -e TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
    -v (pwd)/docker_data_dir:/algod/data \
    algod_test
```

Also had some help from Patrick testing in kubernetes.