### PR TITLE
fix typo in simulate.go

### DIFF
--- a/agreement/agreementtest/simulate.go
+++ b/agreement/agreementtest/simulate.go
@@ -129,7 +129,7 @@ func (b *blackhole) Address() (string, bool) {
 // CryptoRandomSource is a random source that is based off our crypto library.
 type CryptoRandomSource struct{}
 
-// Uint64 implements the randomness by calling hte crypto library.
+// Uint64 implements the randomness by calling the crypto library.
 func (c *CryptoRandomSource) Uint64() uint64 {
 	return crypto.RandUint64()
 }


### PR DESCRIPTION


<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
hte -> the