### PR TITLE
draft: adding handler to return all assets of an account

### DIFF
--- a/daemon/algod/api/algod.oas2.json
+++ b/daemon/algod/api/algod.oas2.json
@@ -293,7 +293,7 @@
             "description": "An asset identifier",
             "name": "asset-id",
             "in": "path",
-            "required": true
+            "required": false 
           },
           {
             "$ref": "#/parameters/format"


### PR DESCRIPTION
## Summary

A half attempt at an endpoint to support 

https://github.com/algorand/go-algorand/issues/5250 

Mostly because I was curious about what it _would_ take and to serve as a subject for discussion

## Test Plan

copied the bin into my sandbox and ran a curl
```sh
curl localhost:4001/v2/accounts/AZRSDXCKQIUKIEEFF7FMF43ZNTFWCYONKAI3SXX5GRVPURLMTXI2OVSKUY/assets/0  -H "X-Algo-API-Token: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
```
returns
```json
[
  {
    "asset-holding": {
      "amount": 9990,
      "asset-id": 220,
      "is-frozen": false
    },
    "created-asset": {
      "clawback": "R2MEJY67MKV6JDO7L6HXXONDGQPQJLXL6PSWZONO67ZAC76QTHSIZ54NHI",
      "creator": "AZRSDXCKQIUKIEEFF7FMF43ZNTFWCYONKAI3SXX5GRVPURLMTXI2OVSKUY",
      "decimals": 0,
      "default-frozen": false,
      "freeze": "R2MEJY67MKV6JDO7L6HXXONDGQPQJLXL6PSWZONO67ZAC76QTHSIZ54NHI",
      "manager": "R2MEJY67MKV6JDO7L6HXXONDGQPQJLXL6PSWZONO67ZAC76QTHSIZ54NHI",
      "name": "lol",
      "name-b64": "bG9s",
      "reserve": "R2MEJY67MKV6JDO7L6HXXONDGQPQJLXL6PSWZONO67ZAC76QTHSIZ54NHI",
      "total": 10000
    },
    "round": 0
  }
]```
