### PR TITLE
chore: Focus CONTRIBUTING.md on code contributions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,58 +2,49 @@
 
 If you are interested in contributing to the project, we welcome and thank you. We want to make the best decentralized and effective blockchain platform available and we appreciate your willingness to help us.
 
-The [Algorand GitHub Organization](https://github.com/algorand) has all of our open source projects, and dependencies which we fork and use in those projects. This contribution guide applies to all of these.
-
-Some of our most active projects include:
-* [go-algorand](https://github.com/algorand/go-algorand) - Algorand node software (this repository)
-* [go-algorand-sdk](https://github.com/algorand/go-algorand-sdk) - Golang SDK
-* [java-algorand-sdk](https://github.com/algorand/java-algorand-sdk) - Java SDK
-* [js-algorand-sdk](https://github.com/algorand/js-algorand-sdk) - JavaScript SDK
-* [indexer](https://github.com/algorand/indexer) - Blockchain analytics database
-* [ledger-app-algorand](https://github.com/algorand/ledger-app-algorand) - Ledger hardware wallet application
-* [mule](https://github.com/algorand/mule) - Continuous Integration automation tool
-* [py-algorand-sdk](https://github.com/algorand/py-algorand-sdk) - Python SDK
-* [sandbox](https://github.com/algorand/sandbox) - Algorand node quickstart tool
-
-## Filing Issues
-
-Did you discover a bug? Do you have a feature request? Filing issues is an easy way anyone can contribute and helps us improve Algorand. We use GitHub Issues to track all known bugs and feature requests.
-
-Before logging an issue be sure to check current issues, verify that your [node is synced](https://developer.algorand.org/docs/introduction-installing-node#sync-node), check the [Developer Frequently Asked Questions](https://developer.algorand.org/docs/developer-faq) and [GitHub issues][issues_url] to see if your issue is described there.
-
-If you’d like to contribute to any of the repositories, please file a [GitHub issue][issues_url] using the issues menu item. Make sure to specify whether you are describing a bug or a new enhancement using the **Bug report** or **Feature request** button.
-
-See the GitHub help guide for more information on [filing an issue](https://help.github.com/en/articles/creating-an-issue).
-
-## Security / Vulnerabilities
-
-Please refer to our [SECURITY](SECURITY.md) document.
-
-If you have any questions, don't hesitate to contact us at security@algorand.com.
+The [Algorand GitHub Organization](https://github.com/algorand) has all of our open source projects, and dependencies which we fork and use in those projects. While technical details in this document is specific to `go-algorand`, the general ideas are applicable to all of our projects.
 
 ## Contribution Model
 
-For each of our repositories we use the same model for contributing code. Developers wanting to contribute must create pull requests. This process is described in the GitHub [Creating a pull request from a fork](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork) documentation. Each pull request should be initiated against the `master` branch in the Algorand repository.  After a pull request is submitted the core development team will review the submission and communicate with the developer using the comments sections of the PR. After the submission is reviewed and approved, it will be merged into the `master` branch of the source. These changes will be merged to our release branch on the next viable release date. For the SDKs, this may be immediate. Changes to the node software may take more time as we must ensure and verify the security, as well as apply protocol upgrades in an orderly way.
-
-Note: some of our projects are using gitflow, for these you will open pull requests against the `develop` branch.
-
-Again, if you have a patch for a critical security vulnerability, please use our [vulnerability disclosure form][vuln_url] instead of creating a PR.  We'll follow up with you on distributing the patch before we merge it.
-
-## Code Guidelines
-
-For Go code we use the [Golang guidelines defined here](https://golang.org/doc/effective_go.html).
-* Code must adhere to the official Go formatting guidelines (i.e. uses gofmt).
-* We use **gofmt** and **golangci-lint**. Also make sure to run `make sanity` and `make generate` before opening a pull request.
-* Code must be documented adhering to the official Go commentary guidelines.
-
-For JavaScript code we use the [MDN formatting rules](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Guidelines/Code_guidelines/JavaScript).
-
-For Java code we use [Oracle’s standard formatting rules for Java](https://www.oracle.com/technetwork/java/codeconventions-150003.pdf).
+All changes to `go-algorand` are made throught he same process: a pull request targeting the `master` branch. This goes for internal and external contributions. To familiarize yourself with the process we recommend that you review the current open pull requests, and the GitHub documentation for [creating a pull request from a fork](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). Note: some of our projects are using gitflow, for these the process is the same but you will target pull requests against the `develop` branch.
 
 ## Communication Channels
 
-The core development team monitors the Algorand community forums and regularly responds to questions and suggestions. Issues and Pull Requests are handled on GitHub.
+The core development team monitors the Algorand [discord community](https://discord.gg/algorand) and regularly responds to questions and suggestions. For very technical questions and implementation discussions GitHub Issues and Pull Requests are a good way to reach maintainers.
 
-[issues_url]: https://github.com/algorand/go-algorand/issues
-[vuln_url]: https://www.algorand.com/resources/blog/security
-[bug_bounty_url]: https://bugcrowd.com/algorand
+## Pull Requests
+
+All changes are are made via pull requests.
+
+Small changes are easier to review and merge than large ones, so the more focused a PR the better. If a feature requires refactoring, the refactoring should be a separate PR. If refactoring uncovers a bug, the bugfix should be a separate PR. These are not strict rules, but generally speaking, they make things easier to review which speeds up the PR process.
+
+
+### General Guidelines
+
+* Have a clear well-formatted description in the pull request. This helps reviewers and later serves as documentation in the release notes.
+* Code must adhere to the [Go formatting guidelines.](https://golang.org/doc/effective_go.html).
+* All tests must be passing.
+* New unit and integration tests should be added to ensure correctness and prevent regressions where appropriate.
+* Run the linter and code formatting tools, see [the README](README.md) for details.
+* All CI checks should pass.
+* Use draft mode for PRs that are still in progress.
+
+### Peer Review
+
+This is the single most important part of introducing new code to `go-algorand`.
+
+#### Concept Review
+
+Because code reviews are a considerable time committment, the first step for peer review is convincing reviewers that it is worth their time. Typically this is done by keeping changes small, writing a thorough description to clearly explain the need for a given improvement, or discussing larger changes ahead of time through one of the communication channels.
+
+If reviewers are not convinced about the merits of a change, they may reject a PR instead of reviewing it. All rejections should include the rational for how that decision was reached. It is not uncommon for this to occur. Some users opt to maintain long running forks to add features which are not suitable for the upstream repo at this time.
+
+#### Code Review
+
+Reviewers will leave feedback directly on the pull request, typically inline with the code. This is an opportunity to discuss the changes, if a PR is left open with unresolved feedback it may eventually be closed for this reason.
+
+The project maintainers are responsible for the code in `go-algorand`, so ultimately whether or not a pull request is merged depends on their involvement.
+
+#### Merge
+
+All changes are subject to a minimum of two reviews from subject matter experts prior. Once this approval is reached a small number of committers are responsible for merging the changes. The list of committers is limited for practical and security reasons.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 If you are interested in contributing to the project, we welcome and thank you. We want to make the best decentralized and effective blockchain platform available and we appreciate your willingness to help us.
 
-The [Algorand GitHub Organization](https://github.com/algorand) has all of our open source projects, and dependencies which we fork and use in those projects. While technical details in this document is specific to `go-algorand`, the general ideas are applicable to all of our projects.
+The [Algorand GitHub Organization](https://github.com/algorand) has all of our open source projects, and dependencies which we fork and use in those projects. While technical details in this document are specific to `go-algorand`, the general ideas are applicable to all of our projects.
 
 ## Non-code Contributions
 
@@ -15,7 +15,7 @@ While contributions come in many forms, this document is focused on code. For ot
 
 All changes to `go-algorand` are made through the same process: a pull request targeting the `master` branch. This goes for internal and external contributions. To familiarize yourself with the process we recommend that you review the current open pull requests, and the GitHub documentation for [creating a pull request from a fork](gh-pr-process).
 
-Note: some of our projects are using gitflow, for these the process is the same but you will target pull requests against the `develop` branch.
+Note: some of our other projects are using gitflow, for these the process is the same but you will target pull requests against the `develop` branch.
 
 ## Communication Channels
 
@@ -30,7 +30,7 @@ Small changes are easier to review and merge than large ones, so the more focuse
 ### General Guidelines
 
 * Have a clear well-formatted description in the pull request. This helps reviewers and later serves as documentation in the release notes.
-* Code must adhere to the [Go formatting guidelines.](https://golang.org/doc/effective_go.html).
+* Code must adhere to the [Go formatting guidelines](https://golang.org/doc/effective_go.html).
 * All tests must be passing.
 * New unit and integration tests should be added to ensure correctness and prevent regressions where appropriate.
 * Run linting and code formatting tools, see [the README](README.md) for details.
@@ -45,17 +45,17 @@ This is the single most important part of introducing new code to `go-algorand`.
 
 Because code reviews are a considerable time commitment, the first step for peer review is convincing reviewers that it is worth their time. Typically this is done by keeping changes small, writing a thorough description to clearly explain the need for a given improvement, or discussing larger changes ahead of time through one of the communication channels.
 
-If reviewers are not convinced about the merits of a change, they may reject a PR instead of reviewing it. All rejections should include the rational for how that decision was reached. It is not uncommon for this to occur. Some users opt to maintain long running forks to add features which are not suitable for the upstream repo at this time.
+If reviewers are not convinced about the merits of a change, they may reject a PR instead of reviewing it. All rejections should include the rationale for how that decision was reached. It is not uncommon for this to occur. Some users opt to maintain long running forks to add features which are not suitable for the upstream repo at this time.
 
 #### Code Review
 
-Reviewers will leave feedback directly on the pull request, typically inline with the code. This is an opportunity to discuss the changes, if a PR is left open with unresolved feedback it may eventually be closed for this reason.
+Reviewers will leave feedback directly on the pull request, typically inline with the code. This is an opportunity to discuss the changes. If a PR is left open with unresolved feedback it may eventually be closed.
 
 The project maintainers are responsible for the code in `go-algorand`, so ultimately whether or not a pull request is merged depends on their involvement.
 
 #### Merge
 
-All changes are subject to a minimum of two reviews from subject matter experts prior. Once this approval is reached a small number of committers are responsible for merging the changes. The list of committers is limited for practical and security reasons.
+All changes are subject to a minimum of two reviews from subject matter experts prior to merge. Once this approval is reached a small number of committers are responsible for merging the changes. The list of committers is limited for practical and security reasons.
 
 [gh-pr-process]: https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
 [go-algorand-issues]: https://github.com/algorand/go-algorand/issues/new/choose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,18 @@ If you are interested in contributing to the project, we welcome and thank you. 
 
 The [Algorand GitHub Organization](https://github.com/algorand) has all of our open source projects, and dependencies which we fork and use in those projects. While technical details in this document is specific to `go-algorand`, the general ideas are applicable to all of our projects.
 
+## Non-code Contributions
+
+While contributions come in many forms, this document is focused on code. For other types of involvement, see the following:
+* [Reporting issues and features requests.](go-algorand-issues)
+* [Security vulnerability disclosures.](security-disclosure)
+* [Documentation improvements.](algorand-docs)
+
 ## Contribution Model
 
-All changes to `go-algorand` are made through the same process: a pull request targeting the `master` branch. This goes for internal and external contributions. To familiarize yourself with the process we recommend that you review the current open pull requests, and the GitHub documentation for [creating a pull request from a fork](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). Note: some of our projects are using gitflow, for these the process is the same but you will target pull requests against the `develop` branch.
+All changes to `go-algorand` are made through the same process: a pull request targeting the `master` branch. This goes for internal and external contributions. To familiarize yourself with the process we recommend that you review the current open pull requests, and the GitHub documentation for [creating a pull request from a fork](gh-pr-process).
+
+Note: some of our projects are using gitflow, for these the process is the same but you will target pull requests against the `develop` branch.
 
 ## Communication Channels
 
@@ -17,7 +26,6 @@ The core development team monitors the Algorand [discord community](https://disc
 All changes are are made via pull requests.
 
 Small changes are easier to review and merge than large ones, so the more focused a PR the better. If a feature requires refactoring, the refactoring should be a separate PR. If refactoring uncovers a bug, the fix should be a separate PR. These are not strict rules, but generally speaking, they make things easier to review which speeds up the PR process.
-
 
 ### General Guidelines
 
@@ -48,3 +56,8 @@ The project maintainers are responsible for the code in `go-algorand`, so ultima
 #### Merge
 
 All changes are subject to a minimum of two reviews from subject matter experts prior. Once this approval is reached a small number of committers are responsible for merging the changes. The list of committers is limited for practical and security reasons.
+
+[gh-pr-process]: https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
+[go-algorand-issues]: https://github.com/algorand/go-algorand/issues/new/choose
+[security-disclosure]: https://github.com/algorand/go-algorand/security/policy
+[algorand-docs]: https://github.com/algorand/docs/blob/staging/CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ The [Algorand GitHub Organization](https://github.com/algorand) has all of our o
 
 ## Contribution Model
 
-All changes to `go-algorand` are made throught he same process: a pull request targeting the `master` branch. This goes for internal and external contributions. To familiarize yourself with the process we recommend that you review the current open pull requests, and the GitHub documentation for [creating a pull request from a fork](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). Note: some of our projects are using gitflow, for these the process is the same but you will target pull requests against the `develop` branch.
+All changes to `go-algorand` are made through the same process: a pull request targeting the `master` branch. This goes for internal and external contributions. To familiarize yourself with the process we recommend that you review the current open pull requests, and the GitHub documentation for [creating a pull request from a fork](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). Note: some of our projects are using gitflow, for these the process is the same but you will target pull requests against the `develop` branch.
 
 ## Communication Channels
 
@@ -16,7 +16,7 @@ The core development team monitors the Algorand [discord community](https://disc
 
 All changes are are made via pull requests.
 
-Small changes are easier to review and merge than large ones, so the more focused a PR the better. If a feature requires refactoring, the refactoring should be a separate PR. If refactoring uncovers a bug, the bugfix should be a separate PR. These are not strict rules, but generally speaking, they make things easier to review which speeds up the PR process.
+Small changes are easier to review and merge than large ones, so the more focused a PR the better. If a feature requires refactoring, the refactoring should be a separate PR. If refactoring uncovers a bug, the fix should be a separate PR. These are not strict rules, but generally speaking, they make things easier to review which speeds up the PR process.
 
 
 ### General Guidelines
@@ -25,7 +25,7 @@ Small changes are easier to review and merge than large ones, so the more focuse
 * Code must adhere to the [Go formatting guidelines.](https://golang.org/doc/effective_go.html).
 * All tests must be passing.
 * New unit and integration tests should be added to ensure correctness and prevent regressions where appropriate.
-* Run the linter and code formatting tools, see [the README](README.md) for details.
+* Run linting and code formatting tools, see [the README](README.md) for details.
 * All CI checks should pass.
 * Use draft mode for PRs that are still in progress.
 
@@ -35,7 +35,7 @@ This is the single most important part of introducing new code to `go-algorand`.
 
 #### Concept Review
 
-Because code reviews are a considerable time committment, the first step for peer review is convincing reviewers that it is worth their time. Typically this is done by keeping changes small, writing a thorough description to clearly explain the need for a given improvement, or discussing larger changes ahead of time through one of the communication channels.
+Because code reviews are a considerable time commitment, the first step for peer review is convincing reviewers that it is worth their time. Typically this is done by keeping changes small, writing a thorough description to clearly explain the need for a given improvement, or discussing larger changes ahead of time through one of the communication channels.
 
 If reviewers are not convinced about the merits of a change, they may reject a PR instead of reviewing it. All rejections should include the rational for how that decision was reached. It is not uncommon for this to occur. Some users opt to maintain long running forks to add features which are not suitable for the upstream repo at this time.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ ${GOPATH}/bin/goal node start -d ~/testnet_data
 Genesis files for mainnet, testnet, and betanet can be found in
 `installer/genesis/`.
 
-## Contributing (Code, Documentation, Bugs, Etc) ##
+## Contributing
 
 Please refer to our [CONTRIBUTING](CONTRIBUTING.md) document.
 


### PR DESCRIPTION
## Summary

Update `CONTRIBUTING.md` to be more focused on code contributions to `go-algorand`. The catch-all nature of the previous version was useful for cross-documentation, but made it less useful for it's main purpose of guiding potential core contributors.

Some specific themes to this PR:
* Remove content about other repositories. It was out of date and a distraction for `go-algorand` contributors.
* More information about what should be done when preparing a PR.
* More information about what to expect during peer review, and an attempt to set expectations.

## Test Plan

Not applicable.