### PR TITLE
eval: Add block hooks to eval tracer

### DIFF
--- a/data/transactions/logic/mocktracer/tracer.go
+++ b/data/transactions/logic/mocktracer/tracer.go
@@ -17,6 +17,7 @@
 package mocktracer
 
 import (
+	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/protocol"
@@ -26,6 +27,8 @@ import (
 type EventType string
 
 const (
+	// BeforeBlockEvent represents the logic.EvalTracer.BeforeBlock event
+	BeforeBlockEvent EventType = "BeforeBlock"
 	// BeforeTxnGroupEvent represents the logic.EvalTracer.BeforeTxnGroup event
 	BeforeTxnGroupEvent EventType = "BeforeTxnGroup"
 	// AfterTxnGroupEvent represents the logic.EvalTracer.AfterTxnGroup event
@@ -42,6 +45,8 @@ const (
 	BeforeOpcodeEvent EventType = "BeforeOpcode"
 	// AfterOpcodeEvent represents the logic.EvalTracer.AfterOpcode event
 	AfterOpcodeEvent EventType = "AfterOpcode"
+	// AfterBlockEvent represents the logic.EvalTracer.AfterBlock event
+	AfterBlockEvent EventType = "AfterBlock"
 )
 
 // Event represents a logic.EvalTracer event
@@ -62,6 +67,14 @@ type Event struct {
 
 	// only for AfterOpcode, AfterProgram, AfterTxn, and AfterTxnGroup
 	HasError bool
+
+	// only for BeforeBlock, AfterBlock
+	BlockHash bookkeeping.BlockHash
+}
+
+// BeforeBlock creates a new Event with the type BeforeBlockEvent
+func BeforeBlock(blockHash bookkeeping.BlockHash) Event {
+	return Event{Type: BeforeBlockEvent, BlockHash: blockHash}
 }
 
 // BeforeTxnGroup creates a new Event with the type BeforeTxnGroupEvent
@@ -104,6 +117,11 @@ func AfterOpcode(hasError bool) Event {
 	return Event{Type: AfterOpcodeEvent, HasError: hasError}
 }
 
+// AfterBlock creates a new Event with the type AfterBlockEvent
+func AfterBlock(blockHash bookkeeping.BlockHash) Event {
+	return Event{Type: AfterBlockEvent, BlockHash: blockHash}
+}
+
 // OpcodeEvents returns a slice of events that represent calling `count` opcodes
 func OpcodeEvents(count int, endsWithError bool) []Event {
 	events := make([]Event, 0, count*2)
@@ -129,6 +147,11 @@ func FlattenEvents(rows [][]Event) []Event {
 // Tracer is a mock tracer that implements logic.EvalTracer
 type Tracer struct {
 	Events []Event
+}
+
+// BeforeBlock mocks the logic.EvalTracer.BeforeBlock method
+func (d *Tracer) BeforeBlock(hdr *bookkeeping.BlockHeader) {
+	d.Events = append(d.Events, BeforeBlock(hdr.Hash()))
 }
 
 // BeforeTxnGroup mocks the logic.EvalTracer.BeforeTxnGroup method
@@ -169,4 +192,9 @@ func (d *Tracer) BeforeOpcode(cx *logic.EvalContext) {
 // AfterOpcode mocks the logic.EvalTracer.AfterOpcode method
 func (d *Tracer) AfterOpcode(cx *logic.EvalContext, evalError error) {
 	d.Events = append(d.Events, AfterOpcode(evalError != nil))
+}
+
+// AfterBlock mocks the logic.EvalTracer.BeforeBlock method
+func (d *Tracer) AfterBlock(hdr *bookkeeping.BlockHeader) {
+	d.Events = append(d.Events, AfterBlock(hdr.Hash()))
 }

--- a/data/transactions/logic/tracer.go
+++ b/data/transactions/logic/tracer.go
@@ -16,7 +16,10 @@
 
 package logic
 
-import "github.com/algorand/go-algorand/data/transactions"
+import (
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/data/transactions"
+)
 
 // EvalTracer functions are called by eval function during AVM program execution, if a tracer
 // is provided.
@@ -94,6 +97,9 @@ import "github.com/algorand/go-algorand/data/transactions"
 //   │ > AfterTxnGroup                                      │
 //   └──────────────────────────────────────────────────────┘
 type EvalTracer interface {
+	// BeforeBlock is called once at the beginning of block evaluation. It is passed the block header.
+	BeforeBlock(hdr *bookkeeping.BlockHeader)
+
 	// BeforeTxnGroup is called before a transaction group is executed. This includes both top-level
 	// and inner transaction groups. The argument ep is the EvalParams object for the group; if the
 	// group is an inner group, this is the EvalParams object for the inner group.
@@ -130,10 +136,17 @@ type EvalTracer interface {
 
 	// AfterOpcode is called after the op has been evaluated
 	AfterOpcode(cx *EvalContext, evalError error)
+
+	// AfterBlock is called after the block has finished evaluation. It will not be called in the event that an evalError
+	// stops evaluation of the block.
+	AfterBlock(hdr *bookkeeping.BlockHeader)
 }
 
 // NullEvalTracer implements EvalTracer, but all of its hook methods do nothing
 type NullEvalTracer struct{}
+
+// BeforeBlock does nothing
+func (n NullEvalTracer) BeforeBlock(hdr *bookkeeping.BlockHeader) {}
 
 // BeforeTxnGroup does nothing
 func (n NullEvalTracer) BeforeTxnGroup(ep *EvalParams) {}
@@ -159,3 +172,6 @@ func (n NullEvalTracer) BeforeOpcode(cx *EvalContext) {}
 
 // AfterOpcode does nothing
 func (n NullEvalTracer) AfterOpcode(cx *EvalContext, evalError error) {}
+
+// AfterBlock does nothing
+func (n NullEvalTracer) AfterBlock(hdr *bookkeeping.BlockHeader) {}

--- a/ledger/eval/eval.go
+++ b/ledger/eval/eval.go
@@ -620,6 +620,7 @@ type EvaluatorOptions struct {
 	Generate            bool
 	MaxTxnBytesPerBlock int
 	ProtoParams         *config.ConsensusParams
+	Tracer              logic.EvalTracer
 }
 
 // StartEvaluator creates a BlockEvaluator, given a ledger and a block header
@@ -678,6 +679,7 @@ func StartEvaluator(l LedgerForEvaluator, hdr bookkeeping.BlockHeader, evalOpts 
 		genesisHash:         l.GenesisHash(),
 		l:                   l,
 		maxTxnBytesPerBlock: evalOpts.MaxTxnBytesPerBlock,
+		Tracer:              evalOpts.Tracer,
 	}
 
 	// Preallocate space for the payset so that we don't have to
@@ -784,6 +786,10 @@ func StartEvaluator(l LedgerForEvaluator, hdr bookkeeping.BlockHeader, evalOpts 
 	if ot.Overflowed {
 		// TODO this should never happen; should we panic here?
 		return nil, fmt.Errorf("overflowed subtracting rewards for block %v", hdr.Round)
+	}
+
+	if eval.Tracer != nil {
+		eval.Tracer.BeforeBlock(&eval.block.BlockHeader)
 	}
 
 	return eval, nil
@@ -1332,6 +1338,10 @@ func (eval *BlockEvaluator) endOfBlock() error {
 	err = eval.state.CalculateTotals()
 	if err != nil {
 		return err
+	}
+
+	if eval.Tracer != nil {
+		eval.Tracer.AfterBlock(&eval.block.BlockHeader)
 	}
 
 	return nil

--- a/ledger/eval/eval_test.go
+++ b/ledger/eval/eval_test.go
@@ -71,7 +71,7 @@ func TestBlockEvaluatorFeeSink(t *testing.T) {
 	genesisBlockHeader, err := l.BlockHdr(basics.Round(0))
 	require.NoError(t, err)
 	newBlock := bookkeeping.MakeBlock(genesisBlockHeader)
-	eval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0)
+	eval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0, nil)
 	require.NoError(t, err)
 	require.Equal(t, eval.specials.FeeSink, testSinkAddr)
 }
@@ -90,7 +90,7 @@ func testEvalAppGroup(t *testing.T, schema basics.StateSchema) (*BlockEvaluator,
 	blkHeader, err := l.BlockHdr(basics.Round(0))
 	require.NoError(t, err)
 	newBlock := bookkeeping.MakeBlock(blkHeader)
-	eval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0)
+	eval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0, nil)
 	require.NoError(t, err)
 	eval.validate = true
 	eval.generate = false
@@ -291,7 +291,8 @@ func TestTransactionGroupWithTracer(t *testing.T) {
 			blkHeader, err := l.BlockHdr(basics.Round(0))
 			require.NoError(t, err)
 			newBlock := bookkeeping.MakeBlock(blkHeader)
-			eval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0)
+			tracer := &mocktracer.Tracer{}
+			eval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0, tracer)
 			require.NoError(t, err)
 			eval.validate = true
 			eval.generate = true
@@ -368,8 +369,6 @@ int 1`,
 
 			require.Len(t, eval.block.Payset, 0)
 
-			tracer := &mocktracer.Tracer{}
-			eval.Tracer = tracer
 			err = eval.TransactionGroup(txgroup)
 			switch testCase.firstTxnBehavior {
 			case "approve":
@@ -403,9 +402,11 @@ int 1`,
 					},
 				}
 
-			var expectedEvents []mocktracer.Event
+			var expectedEvents = []mocktracer.Event{mocktracer.BeforeBlock(eval.block.Hash())}
 			if testCase.firstTxnBehavior == "approve" {
-				expectedEvents = mocktracer.FlattenEvents([][]mocktracer.Event{
+				err = eval.endOfBlock()
+				require.NoError(t, err)
+				expectedEvents = append(expectedEvents, mocktracer.FlattenEvents([][]mocktracer.Event{
 					{
 						mocktracer.BeforeTxnGroup(3),
 						mocktracer.BeforeTxn(protocol.ApplicationCallTx), // start basicAppCallTxn
@@ -422,12 +423,15 @@ int 1`,
 					{
 						mocktracer.AfterTxnGroup(3, scenario.Outcome != mocktracer.ApprovalOutcome),
 					},
-				})
+					{
+						mocktracer.AfterBlock(eval.block.Hash()),
+					},
+				})...)
 			} else {
 				hasError := testCase.firstTxnBehavior == "error"
 				// EvalDeltas are removed from failed app call transactions
 				expectedBasicAppCallAD.EvalDelta = transactions.EvalDelta{}
-				expectedEvents = mocktracer.FlattenEvents([][]mocktracer.Event{
+				expectedEvents = append(expectedEvents, mocktracer.FlattenEvents([][]mocktracer.Event{
 					{
 						mocktracer.BeforeTxnGroup(3),
 						mocktracer.BeforeTxn(protocol.ApplicationCallTx), // start basicAppCallTxn
@@ -439,7 +443,7 @@ int 1`,
 						mocktracer.AfterTxn(protocol.ApplicationCallTx, expectedBasicAppCallAD, true), // end basicAppCallTxn
 						mocktracer.AfterTxnGroup(3, true),
 					},
-				})
+				})...)
 			}
 			require.Equal(t, expectedEvents, mocktracer.StripInnerTxnGroupIDsFromEvents(tracer.Events))
 		})
@@ -501,7 +505,7 @@ func testnetFixupExecution(t *testing.T, headerRound basics.Round, poolBonus uin
 	l.genesisHash = genesisInitState.GenesisHash
 
 	newBlock := bookkeeping.MakeBlock(genesisInitState.Block.BlockHeader)
-	eval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0)
+	eval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0, nil)
 	require.NoError(t, err)
 
 	// won't work before funding bank
@@ -648,13 +652,14 @@ func (ledger *evalTestLedger) Validate(ctx context.Context, blk bookkeeping.Bloc
 // of the block that the caller is planning to evaluate. If the length of the
 // payset being evaluated is known in advance, a paysetHint >= 0 can be
 // passed, avoiding unnecessary payset slice growth.
-func (ledger *evalTestLedger) StartEvaluator(hdr bookkeeping.BlockHeader, paysetHint, maxTxnBytesPerBlock int) (*BlockEvaluator, error) {
+func (ledger *evalTestLedger) StartEvaluator(hdr bookkeeping.BlockHeader, paysetHint, maxTxnBytesPerBlock int, tracer logic.EvalTracer) (*BlockEvaluator, error) {
 	return StartEvaluator(ledger, hdr,
 		EvaluatorOptions{
 			PaysetHint:          paysetHint,
 			Validate:            true,
 			Generate:            true,
 			MaxTxnBytesPerBlock: maxTxnBytesPerBlock,
+			Tracer:              tracer,
 		})
 }
 
@@ -834,7 +839,7 @@ func (ledger *evalTestLedger) nextBlock(t testing.TB) *BlockEvaluator {
 	require.NoError(t, err)
 
 	nextHdr := bookkeeping.MakeBlock(hdr).BlockHeader
-	eval, err := ledger.StartEvaluator(nextHdr, 0, 0)
+	eval, err := ledger.StartEvaluator(nextHdr, 0, 0, nil)
 	require.NoError(t, err)
 	return eval
 }
@@ -1017,7 +1022,7 @@ func TestEvalFunctionForExpiredAccounts(t *testing.T) {
 
 	newBlock := bookkeeping.MakeBlock(l.blocks[0].BlockHeader)
 
-	blkEval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0)
+	blkEval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0, nil)
 	require.NoError(t, err)
 
 	// Advance the evaluator a couple rounds...
@@ -1158,7 +1163,7 @@ func TestExpiredAccountGenerationWithDiskFailure(t *testing.T) {
 
 	newBlock := bookkeeping.MakeBlock(l.blocks[0].BlockHeader)
 
-	eval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0)
+	eval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0, nil)
 	require.NoError(t, err)
 
 	// Advance the evaluator a couple rounds...
@@ -1256,7 +1261,7 @@ func TestExpiredAccountGeneration(t *testing.T) {
 
 	newBlock := bookkeeping.MakeBlock(l.blocks[0].BlockHeader)
 
-	eval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0)
+	eval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0, nil)
 	require.NoError(t, err)
 
 	// Advance the evaluator a couple rounds...


### PR DESCRIPTION

## Summary

Adds `BeforeBlock` and `AfterBlock` hooks to the `EvalTracer` interface. 

This should be a no-op for most of the things which Simulate is trying to do, but gives the Tracer a sense of which Block a given set invocations covers. That's important since the `EvalContext` and `EvalParams` from what I can tell don't have a deterministic way of looking at which round they're evaluating for without direct access to the `BlockEvaluator` itself.

## Test Plan

Updated existing test to ensure calls are properly made during eval lifecycle.
