### PR TITLE
docs: update agreement README with committableEvent

### DIFF
--- a/agreement/README.md
+++ b/agreement/README.md
@@ -356,5 +356,5 @@ a given period.
 The staging slot for a given period is important because its state is
 the precursor to cert and next votes. Once both a soft threshold for a
 value and the `Block` corresponding to this value has been observed by
-the node, a `proposalCommittableEvent` is emitted, which indicates
+the node, a proposal `committableEvent` is emitted, which indicates
 that the node may cert or next-vote for the proposal.


### PR DESCRIPTION
the mentioned `proposalCommittableEvent` does not exist in this form within the source code.

The correct event is `committableEvent`

https://github.com/algorand/go-algorand/blob/30acd707819fc9bc2b59036902d8b453ffbd4e10/agreement/events.go#L494-L500

