### PR TITLE
docker: add profile support and improved endpoint access.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -10,11 +10,11 @@ There are a number of special files and environment variables used to control ho
 
 ### Default Configuration
 
-By default the following config.json overrides are applied:
+The following config.json overrides are applied:
 
-| Setting | Value |
-| ------- | ----- |
-| EndpointAddress | 0.0.0.0:8080 |
+| Setting | Value | Description |
+| ------- | ----- | ----------- |
+| EndpointAddress | 0.0.0.0:8080 | Ensure the API is accessible from outside of the container. |
 
 ### Environment Variables
 
@@ -23,14 +23,15 @@ The following environment variables can be supplied. Except when noted, it is po
 | Variable | Description |
 | -------- | ----------- |
 | NETWORK        | Leave blank for a private network, otherwise specify one of mainnet, betanet, testnet, or devnet. Only used during a data directory initialization. |
-| FAST_CATCHUP   | If set to 1 on a public network, attempt to start fast-catchup during initial config.                                                               |
-| TELEMETRY_NAME | If set on a public network, telemetry is reported with this name.                                                                                   |
+| PROFILE        | If set, initializes the config.json file according to the given profile. |
 | DEV_MODE       | If set to 1 on a private network, enable dev mode. Only used during data directory initialization.                                                  |
-| NUM_ROUNDS     | If set on a private network, override default of 30000 participation keys.                                                                          |
+| START_KMD      | When set to 1, start kmd service with no timeout. THIS SHOULD NOT BE USED IN PRODUCTION.                                                            |
+| FAST_CATCHUP   | If set to 1 on a public network, attempt to start fast-catchup during initial config.                                                               |
 | TOKEN          | If set, overrides the REST API token.                                                                                                               |
 | ADMIN_TOKEN    | If set, overrides the REST API admin token.                                                                                                         |
 | KMD_TOKEN      | If set along with `START_KMD`, override the KMD REST API token.                                                                                     |
-| START_KMD      | When set to 1, start kmd service with no timeout. THIS SHOULD NOT BE USED IN PRODUCTION.                                                            |
+| TELEMETRY_NAME | If set on a public network, telemetry is reported with this name.                                                                                   |
+| NUM_ROUNDS     | If set on a private network, override default of 30000 participation keys.                                                                          |
 | PEER_ADDRESS   | If set, override phonebook with peer ip:port (or semicolon separated list: ip:port;ip:port;ip:port...)                                              |
 
 ### Special Files

--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -54,7 +54,6 @@ function start_public_network() {
 
 function configure_data_dir() {
   cd "$ALGORAND_DATA"
-  algocfg -d . set -p EndpointAddress -v "0.0.0.0:${ALGOD_PORT}"
 
   # check for config file overrides.
   if [ -f "/etc/algorand/config.json" ]; then
@@ -69,6 +68,14 @@ function configure_data_dir() {
   if [ -f "/etc/algorand/logging.config" ]; then
     cp /etc/algorand/logging.config logging.config
   fi
+
+  # initialize config with profile.
+  if [ "$PROFILE" != "" ]; then
+    algocfg profile set --yes -d "$ALGORAND_DATA" "$PROFILE" 
+  fi
+
+  # call after copying config.json to make sure the port is exposed.
+  algocfg -d . set -p EndpointAddress -v "0.0.0.0:${ALGOD_PORT}"
 
   # check for token overrides
   if [ "$TOKEN" != "" ]; then


### PR DESCRIPTION
## Summary

Final feature from #5197 

These changes make the docker container easier to use without providing a `config.json` file, and make the behavior more expected when a `config.json` file is provided.

1. Move the endpoint address setting down. This ensures that the API is available at port 8080. Users who override the `config.json` file via `/etc/algorand/config.json` or the `PROFILE` environment variable would be likely to miss this option and be unable to access the REST API.
2. New `PROFILE` environment variable. When set algocfg is used to initialize the `config.json` file.

## Test Plan

Manual testing. By mounting a data directory in different scenarios observe that the config.json file is set as expected.

### EndpointAddress Override

Mount a config.json file
```
~$ cat algod_config.json
{
	"CatchupParallelBlocks": 32,
	"MaxAcctLookback": 64,
	"EnableFollowMode": true
}
~$ docker run --rm -it \
    -p 4000:8080 \
    --name algod-test-run \
    -e TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
    -v (pwd)/algod_config.json:/etc/algorand/config.json \
    -v (pwd)/docker_data_dir:/algod/data \
    wwinder/algod:latest
```

Observe that the EndpointAddress is added to the other settings:
```
~$ cat docker_data_dir/config.json
{
	"EndpointAddress": "0.0.0.0:8080",
	"CatchupParallelBlocks": 32,
	"MaxAcctLookback": 64,
	"EnableFollowMode": true
}
```

### algocfg profile

Add a PROFILE environment variable
```
~$ docker run --rm -it \
    -p 4000:8080 \
    --name algod-test-run \
    -e TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
    -e PROFILE=relay \
    -v (pwd)/docker_data_dir:/algod/data \
    wwinder/algod:latest
```
Observe that the profile settings, and EndpointAddress setting are properly set:
```
~$ cat docker_data_dir/config.json
{
	"GossipFanout": 0,
	"IncomingConnectionsLimit": 0,
	"EndpointAddress": "0.0.0.0:8080",
	"DNSBootstrapID": "",
	"EnableProfiler": true,
	"EnableRuntimeMetrics": true,
	"DisableNetworking": true
}
```

