### PR TITLE
Algod: Better Box Reference Error Message

### DIFF
--- a/data/transactions/logic/box.go
+++ b/data/transactions/logic/box.go
@@ -37,7 +37,7 @@ func (cx *EvalContext) availableBox(name string, operation int, createSize uint6
 
 	dirty, ok := cx.available.boxes[boxRef{cx.appID, name}]
 	if !ok {
-		return nil, false, fmt.Errorf("invalid Box reference %v", name)
+		return nil, false, fmt.Errorf("invalid Box reference %#x", name)
 	}
 
 	// Since the box is in cx.available, we know this GetBox call is cheap. It
@@ -150,7 +150,7 @@ func opBoxExtract(cx *EvalContext) error {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("no such box %#v", name)
+		return fmt.Errorf("no such box %#x", name)
 	}
 
 	bytes, err := extractCarefully(contents, start, length)
@@ -178,7 +178,7 @@ func opBoxReplace(cx *EvalContext) error {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("no such box %#v", name)
+		return fmt.Errorf("no such box %#x", name)
 	}
 
 	bytes, err := replaceCarefully(contents, replacement, start)

--- a/data/transactions/logic/box_test.go
+++ b/data/transactions/logic/box_test.go
@@ -242,7 +242,7 @@ func TestBoxAvailability(t *testing.T) {
 	logic.TestApps(t, []string{
 		`byte "self"; int 64; box_create`,
 		`byte "B"; int 10; int 4; box_extract; byte 0x00000000; ==`,
-	}, nil, 8, ledger, logic.NewExpect(1, "invalid Box reference B"))
+	}, nil, 8, ledger, logic.NewExpect(1, "invalid Box reference 0x42"))
 
 	// B is available if indexed by 0 in tx[1].Boxes
 	group := logic.MakeSampleTxnGroup(logic.MakeSampleTxn(), txntest.Txn{

--- a/data/transactions/logic/box_test.go
+++ b/data/transactions/logic/box_test.go
@@ -242,7 +242,7 @@ func TestBoxAvailability(t *testing.T) {
 	logic.TestApps(t, []string{
 		`byte "self"; int 64; box_create`,
 		`byte "B"; int 10; int 4; box_extract; byte 0x00000000; ==`,
-	}, nil, 8, ledger, logic.NewExpect(1, "invalid Box reference 0x42"))
+	}, nil, 8, ledger, logic.NewExpect(1, fmt.Sprintf("invalid Box reference %#x", 'B')))
 
 	// B is available if indexed by 0 in tx[1].Boxes
 	group := logic.MakeSampleTxnGroup(logic.MakeSampleTxn(), txntest.Txn{

--- a/data/transactions/logic/ledger_test.go
+++ b/data/transactions/logic/ledger_test.go
@@ -412,10 +412,10 @@ func (l *Ledger) NewBox(appIdx basics.AppIndex, key string, value []byte, appAdd
 	}
 	if current, ok := params.boxMods[key]; ok {
 		if current != nil {
-			return fmt.Errorf("attempt to recreate %s", key)
+			return fmt.Errorf("attempt to recreate %#v", key)
 		}
 	} else if _, ok := params.boxes[key]; ok {
-		return fmt.Errorf("attempt to recreate %s", key)
+		return fmt.Errorf("attempt to recreate %#x", key)
 	}
 	params.boxMods[key] = value
 	l.applications[appIdx] = params

--- a/data/transactions/logic/ledger_test.go
+++ b/data/transactions/logic/ledger_test.go
@@ -412,10 +412,10 @@ func (l *Ledger) NewBox(appIdx basics.AppIndex, key string, value []byte, appAdd
 	}
 	if current, ok := params.boxMods[key]; ok {
 		if current != nil {
-			return fmt.Errorf("attempt to recreate %#v", key)
+			return fmt.Errorf("attempt to recreate box %#v", key)
 		}
 	} else if _, ok := params.boxes[key]; ok {
-		return fmt.Errorf("attempt to recreate %#x", key)
+		return fmt.Errorf("attempt to recreate box %#x", key)
 	}
 	params.boxMods[key] = value
 	l.applications[appIdx] = params

--- a/ledger/boxtxn_test.go
+++ b/ledger/boxtxn_test.go
@@ -19,6 +19,7 @@ package ledger
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -155,7 +156,7 @@ func TestBoxCreate(t *testing.T) {
 		}
 
 		adam := call.Args("create", "adam")
-		dl.txn(adam, "invalid Box reference adam")
+		dl.txn(adam, fmt.Sprintf("invalid Box reference %#x", "adam"))
 		adam.Boxes = []transactions.BoxRef{{Index: 0, Name: []byte("adam")}}
 
 		dl.beginBlock()
@@ -173,7 +174,7 @@ func TestBoxCreate(t *testing.T) {
 		dl.txgroup("box_create\nassert", adam.Noted("one"), adam.Noted("two"))
 
 		bobo := call.Args("create", "bobo")
-		dl.txn(bobo, "invalid Box reference bobo")
+		dl.txn(bobo, fmt.Sprintf("invalid Box reference %#x", "bobo"))
 		bobo.Boxes = []transactions.BoxRef{{Index: 0, Name: []byte("bobo")}}
 		dl.txn(bobo)
 		dl.txgroup("box_create\nassert", bobo.Noted("one"), bobo.Noted("two"))
@@ -421,7 +422,7 @@ func TestBoxRW(t *testing.T) {
 		time.Sleep(100 * time.Millisecond) // give commit time to run, and prune au caches
 		dl.fullBlock(call.Args("check", "x", "ABCDEFGH"))
 
-		dl.txn(call.Args("create", "yy"), "invalid Box reference yy")
+		dl.txn(call.Args("create", "yy"), fmt.Sprintf("invalid Box reference %#x", "yy"))
 		withBr := call.Args("create", "yy")
 		withBr.Boxes = append(withBr.Boxes, transactions.BoxRef{Index: 1, Name: []byte("yy")})
 		require.Error(dl.t, withBr.Txn().WellFormed(transactions.SpecialAddresses{}, dl.generator.GenesisProto()))
@@ -616,7 +617,7 @@ func TestBoxInners(t *testing.T) {
 		}
 		// The current Boxes gives top-level access to "x", not the inner app
 		dl.txn(call.Args("create", "x", "\x10"), // 8
-			"invalid Box reference x")
+			fmt.Sprintf("invalid Box reference %#x", 'x'))
 
 		// This isn't right: Index should be index into ForeignApps
 		call.Boxes = []transactions.BoxRef{{Index: uint64(boxIndex), Name: []byte("x")}}
@@ -658,7 +659,7 @@ func TestBoxInners(t *testing.T) {
 		dl.txgroup("", checkX, checkY)
 
 		require.Len(t, setY.Boxes, 2) // recall that setY has ("y", "nope") right now. no "x"
-		dl.txgroup("invalid Box reference x", checkX, setY)
+		dl.txgroup(fmt.Sprintf("invalid Box reference %#x", 'x'), checkX, setY)
 
 		setY.Boxes = append(setY.Boxes, transactions.BoxRef{Index: 1, Name: []byte("x")})
 		dl.txgroup("", checkX, setY)

--- a/ledger/eval/applications.go
+++ b/ledger/eval/applications.go
@@ -229,7 +229,7 @@ func (cs *roundCowState) NewBox(appIdx basics.AppIndex, key string, value []byte
 		return err
 	}
 	if exists {
-		return fmt.Errorf("attempt to recreate %s", key)
+		return fmt.Errorf("attempt to recreate %#x", key)
 	}
 
 	record, err := cs.Get(appAddr, false)
@@ -258,10 +258,10 @@ func (cs *roundCowState) SetBox(appIdx basics.AppIndex, key string, value []byte
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("box %s does not exist for %d", key, appIdx)
+		return fmt.Errorf("box %#x does not exist for %d", key, appIdx)
 	}
 	if len(old) != len(value) {
-		return fmt.Errorf("box %s is wrong size old:%d != new:%d",
+		return fmt.Errorf("box %#x is wrong size old:%d != new:%d",
 			key, len(old), len(value))
 	}
 	return cs.kvPut(fullKey, value)

--- a/ledger/eval/applications.go
+++ b/ledger/eval/applications.go
@@ -229,7 +229,7 @@ func (cs *roundCowState) NewBox(appIdx basics.AppIndex, key string, value []byte
 		return err
 	}
 	if exists {
-		return fmt.Errorf("attempt to recreate %#x", key)
+		return fmt.Errorf("attempt to recreate box %#x", key)
 	}
 
 	record, err := cs.Get(appAddr, false)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

See issue #5229, the box key representation is essentially a byte slice wrapped under `string`. This representation does not necessarily fall under ASCII symbol set, and printing with `%v` or `%#v` will be hard to decode and debug.

We decide to print with hex, i.e., `%#x` format.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
