### PR TITLE
Test: Improve flaky test from non-deterministic order string

### DIFF
--- a/cmd/algocfg/profileCommand_test.go
+++ b/cmd/algocfg/profileCommand_test.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,11 +32,9 @@ func Test_getConfigForArg(t *testing.T) {
 		t.Parallel()
 		_, err := getConfigForArg("invalid")
 
-		var names []string
 		for name := range profileNames {
-			names = append(names, name)
+			require.ErrorContains(t, err, name)
 		}
-		require.ErrorContains(t, err, strings.Join(names, ", "))
 
 	})
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

Testing in `algocfg` gets flaky for non-deterministic string concatenation order from `profileNames`.

Improve testing by checking existence of each profile name in error string.