### PR TITLE
AVM: Show opcode context for logicsigs (not just apps)

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -488,6 +488,9 @@ type ConsensusParams struct {
 	// returning false, if pubkey is not on the curve.
 	EnablePrecheckECDSACurve bool
 
+	// EnableBareBudgetError specifies that I/O budget overruns should not be considered EvalError
+	EnableBareBudgetError bool
+
 	// StateProofUseTrackerVerification specifies whether the node will use data from state proof verification tracker
 	// in order to verify state proofs.
 	StateProofUseTrackerVerification bool
@@ -1262,6 +1265,7 @@ func initConsensusProtocols() {
 
 	vFuture.LogicSigVersion = 9 // When moving this to a release, put a new higher LogicSigVersion here
 	vFuture.EnablePrecheckECDSACurve = true
+	vFuture.EnableBareBudgetError = true
 
 	vFuture.StateProofUseTrackerVerification = true
 	vFuture.EnableCatchpointsWithSPContexts = true

--- a/data/transactions/logic/backwardCompat_test.go
+++ b/data/transactions/logic/backwardCompat_test.go
@@ -284,7 +284,7 @@ func TestBackwardCompatTEALv1(t *testing.T) {
 	ep.TxnGroup[0].Lsig.Logic = program
 	ep.TxnGroup[0].Lsig.Args = [][]byte{data[:], sig[:], pk[:], tx.Sender[:], tx.Note}
 
-	// ensure v1 program runs well on latest TEAL evaluator
+	// ensure v1 program runs well on latest evaluator
 	require.Equal(t, uint8(1), program[0])
 
 	// Cost should stay exactly 2140
@@ -315,7 +315,7 @@ func TestBackwardCompatTEALv1(t *testing.T) {
 	ep2.Proto.LogicSigMaxCost = 2308
 	testLogicBytes(t, opsV2.Program, ep2)
 
-	// ensure v0 program runs well on latest TEAL evaluator
+	// ensure v0 program runs well on latest evaluator
 	ep, tx, _ = makeSampleEnv()
 	program[0] = 0
 	sig = c.Sign(Msg{

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -691,7 +691,7 @@ func (pe panicError) Error() string {
 var errLogicSigNotSupported = errors.New("LogicSig not supported")
 var errTooManyArgs = errors.New("LogicSig has too many arguments")
 
-// EvalError indicates TEAL evaluation failure
+// EvalError indicates AVM evaluation failure
 type EvalError struct {
 	Err     error
 	Details string

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -5576,7 +5576,7 @@ func (cx *EvalContext) pcDetails() (pc int, dis string) {
 			break
 		}
 	}
-	return cx.pc, dis
+	return cx.pc, strings.ReplaceAll(strings.TrimSuffix(dis, "\n"), "\n", "; ")
 }
 
 func base64Decode(encoded []byte, encoding *base64.Encoding) ([]byte, error) {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -5138,9 +5138,9 @@ func TestPcDetails(t *testing.T) {
 		pc     int
 		det    string
 	}{
-		{"int 1; int 2; -", 5, "pushint 1\npushint 2\n-\n"},
-		{"int 1; err", 3, "pushint 1\nerr\n"},
-		{"int 1; dup; int 2; -; +", 6, "dup\npushint 2\n-\n"},
+		{"int 1; int 2; -", 5, "pushint 1; pushint 2; -"},
+		{"int 1; err", 3, "pushint 1; err"},
+		{"int 1; dup; int 2; -; +", 6, "dup; pushint 2; -"},
 		{"b end; end:", 4, ""},
 	}
 	for i, test := range tests {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -5158,7 +5158,7 @@ func TestPcDetails(t *testing.T) {
 
 			assert.Equal(t, test.pc, cx.pc, ep.Trace.String())
 
-			pc, det := cx.PcDetails()
+			pc, det := cx.pcDetails()
 			assert.Equal(t, test.pc, pc)
 			assert.Equal(t, test.det, det)
 		})

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -450,7 +450,7 @@ func logicSigVerify(txn *transactions.SignedTxn, groupIndex int, groupCtx *Group
 	pass, cx, err := logic.EvalSignatureFull(groupIndex, &ep)
 	if err != nil {
 		logicErrTotal.Inc(nil)
-		return LogicSigError{groupIndex, fmt.Errorf("transaction %v: rejected by logic err=%w", txn.ID(), err)}
+		return LogicSigError{groupIndex, fmt.Errorf("transaction %v: %w", txn.ID(), err)}
 	}
 	if !pass {
 		logicRejTotal.Inc(nil)

--- a/ledger/apply/application.go
+++ b/ledger/apply/application.go
@@ -413,8 +413,8 @@ func ApplicationCall(ac transactions.ApplicationCallTxnFields, header transactio
 		if exists {
 			pass, evalDelta, err := balances.StatefulEval(gi, evalParams, appIdx, params.ClearStateProgram)
 			if err != nil {
-				// Fail on non-logic eval errors and ignore LogicEvalError errors
-				if _, ok := err.(ledgercore.LogicEvalError); !ok {
+				// ClearStateProgram evaluation can't make the txn fail.
+				if _, ok := err.(logic.EvalError); !ok {
 					return err
 				}
 			}

--- a/ledger/apply/application_test.go
+++ b/ledger/apply/application_test.go
@@ -895,7 +895,7 @@ func TestAppCallClearState(t *testing.T) {
 	// one to opt out, one deallocate, no error from ApplicationCall
 	b.pass = true
 	b.delta = transactions.EvalDelta{GlobalDelta: nil}
-	b.err = ledgercore.LogicEvalError{Err: fmt.Errorf("test error")}
+	b.err = logic.EvalError{Err: fmt.Errorf("test error")}
 	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
 	a.NoError(err)
 	a.Equal(1, b.put)

--- a/ledger/boxtxn_test.go
+++ b/ledger/boxtxn_test.go
@@ -171,28 +171,28 @@ func TestBoxCreate(t *testing.T) {
 		}
 
 		dl.txn(adam.Args("check", "adam", "\x00\x00"))
-		dl.txgroup("box_create\nassert", adam.Noted("one"), adam.Noted("two"))
+		dl.txgroup("box_create; assert", adam.Noted("one"), adam.Noted("two"))
 
 		bobo := call.Args("create", "bobo")
 		dl.txn(bobo, fmt.Sprintf("invalid Box reference %#x", "bobo"))
 		bobo.Boxes = []transactions.BoxRef{{Index: 0, Name: []byte("bobo")}}
 		dl.txn(bobo)
-		dl.txgroup("box_create\nassert", bobo.Noted("one"), bobo.Noted("two"))
+		dl.txgroup("box_create; assert", bobo.Noted("one"), bobo.Noted("two"))
 
 		dl.beginBlock()
 		chaz := call.Args("create", "chaz")
 		chaz.Boxes = []transactions.BoxRef{{Index: 0, Name: []byte("chaz")}}
 		dl.txn(chaz)
-		dl.txn(chaz.Noted("again"), "box_create\nassert")
+		dl.txn(chaz.Noted("again"), "box_create; assert")
 		dl.endBlock()
 
 		// new block
-		dl.txn(chaz.Noted("again"), "box_create\nassert")
+		dl.txn(chaz.Noted("again"), "box_create; assert")
 		dogg := call.Args("create", "dogg")
 		dogg.Boxes = []transactions.BoxRef{{Index: 0, Name: []byte("dogg")}}
 		dl.txn(dogg, "below min")
 		dl.txn(chaz.Args("delete", "chaz"))
-		dl.txn(chaz.Args("delete", "chaz").Noted("again"), "box_del\nassert")
+		dl.txn(chaz.Args("delete", "chaz").Noted("again"), "box_del; assert")
 		dl.txn(dogg)
 		dl.txn(bobo.Args("delete", "bobo"))
 
@@ -231,7 +231,7 @@ func TestBoxRecreate(t *testing.T) {
 		create := call.Args("create", "adam", "\x04") // box value size is 4 bytes
 		recreate := call.Args("recreate", "adam", "\x04")
 
-		dl.txn(recreate, "box_create\n!\nassert")
+		dl.txn(recreate, "box_create; !; assert")
 		dl.txn(create)
 		dl.txn(recreate)
 		dl.txn(call.Args("set", "adam", "\x01\x02\x03\x04"))

--- a/ledger/eval/appcow.go
+++ b/ledger/eval/appcow.go
@@ -467,19 +467,9 @@ func (cb *roundCowState) StatefulEval(gi int, params *logic.EvalParams, aidx bas
 	params.Ledger = calf
 	params.SigLedger = calf
 
-	// Eval the program
-	pass, cx, err := logic.EvalContract(program, gi, aidx, params)
+	pass, err = logic.EvalApp(program, gi, aidx, params)
 	if err != nil {
-		var details string
-		if cx != nil {
-			pc, det := cx.PcDetails()
-			details = fmt.Sprintf("pc=%d, opcodes=%s", pc, det)
-		}
-		// Don't wrap ClearStateBudgetError, so it will be taken seriously
-		if _, ok := err.(logic.ClearStateBudgetError); ok {
-			return false, transactions.EvalDelta{}, err
-		}
-		return false, transactions.EvalDelta{}, ledgercore.LogicEvalError{Err: err, Details: details}
+		return false, transactions.EvalDelta{}, err
 	}
 
 	// If program passed, build our eval delta, and commit to state changes

--- a/ledger/eval/cow.go
+++ b/ledger/eval/cow.go
@@ -80,7 +80,7 @@ type roundCowState struct {
 
 	// storage deltas populated as side effects of AppCall transaction
 	// 1. Opt-in/Close actions (see Allocate/Deallocate)
-	// 2. Stateful TEAL evaluation (see setKey/delKey)
+	// 2. Application evaluation (see setKey/delKey)
 	// must be incorporated into mods.accts before passing deltas forward
 	sdeltas map[basics.Address]map[storagePtr]*storageDelta
 

--- a/ledger/ledgercore/error.go
+++ b/ledger/ledgercore/error.go
@@ -93,21 +93,6 @@ func (err ErrNoEntry) Error() string {
 	return fmt.Sprintf("ledger does not have entry %d (latest %d, committed %d)", err.Round, err.Latest, err.Committed)
 }
 
-// LogicEvalError indicates TEAL evaluation failure
-type LogicEvalError struct {
-	Err     error
-	Details string
-}
-
-// Error satisfies builtin interface `error`
-func (err LogicEvalError) Error() string {
-	msg := fmt.Sprintf("logic eval error: %v", err.Err)
-	if len(err.Details) > 0 {
-		msg = fmt.Sprintf("%s. Details: %s", msg, err.Details)
-	}
-	return msg
-}
-
 // ErrNonSequentialBlockEval provides feedback when the evaluator cannot be created for
 // stale/future rounds.
 type ErrNonSequentialBlockEval struct {


### PR DESCRIPTION
Users find the extra info about the previous opcodes to be a helpful addition when debugging an app failure.  This extends the support to LogicSigs.
