### PR TITLE
testing: fix consensus version inconsistency in newTestLedger

### DIFF
--- a/ledger/eval/eval_test.go
+++ b/ledger/eval/eval_test.go
@@ -611,8 +611,11 @@ func newTestLedger(t testing.TB, balances bookkeeping.GenesisBalances) *evalTest
 		rewardsPool:   balances.RewardsPool,
 	}
 
+	protoVersion := protocol.ConsensusFuture
+	proto := config.Consensus[protoVersion]
+
 	crypto.RandBytes(l.genesisHash[:])
-	genBlock, err := bookkeeping.MakeGenesisBlock(protocol.ConsensusFuture,
+	genBlock, err := bookkeeping.MakeGenesisBlock(protoVersion,
 		balances, "test", l.genesisHash)
 	require.NoError(t, err)
 	l.roundBalances[0] = balances.Balances
@@ -620,12 +623,11 @@ func newTestLedger(t testing.TB, balances bookkeeping.GenesisBalances) *evalTest
 
 	// calculate the accounts totals.
 	var ot basics.OverflowTracker
-	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	for _, acctData := range balances.Balances {
 		l.latestTotals.AddAccount(proto, ledgercore.ToAccountData(acctData), &ot)
 	}
 	l.genesisProto = proto
-	l.genesisProtoVersion = protocol.ConsensusCurrentVersion
+	l.genesisProtoVersion = protoVersion
 
 	require.False(t, genBlock.FeeSink.IsZero())
 	require.False(t, genBlock.RewardsPool.IsZero())


### PR DESCRIPTION
## Summary

While updating a test that uses `newTestLedger` (formerly known as OpenLedger; a previous version returned a real `*Ledger` until https://github.com/algorand/go-algorand/pull/2983 changed it to return a mock type `*evalTestLedger`), I noticed some inconsistency in the consensus version used by `newTestLedger` where MakeGenesisBlock() is called to use vFuture but later sets evalTestLedger.genesisProto = vCurrent. So this means the evaluator and the blocks it generates after genesis will all use vFuture, but calls to Ledger.GenesisProto() will return vCurrent.

## Test Plan

Existing tests should pass; I didn't see any tests fail when I changed this, which is good because it means no tests were relying on this inconsistent mock ledger behavior.

## Future work

Future work might include support for passing a custom consensus version to `newTestLedger`, or replacing its usage everywhere with a real `*Ledger`-based replacement.