### PR TITLE
follow mode: set sync round after fast catchup.

### DIFF
--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -1348,8 +1348,6 @@ func (v2 *Handlers) startCatchup(ctx echo.Context, catchpoint string) error {
 		code = http.StatusOK
 	case *node.CatchpointUnableToStartError:
 		return badRequest(ctx, err, err.Error(), v2.Log)
-	case *node.CatchpointSyncRoundFailure:
-		return badRequest(ctx, err, fmt.Sprintf(errFailedToStartCatchup, err), v2.Log)
 	default:
 		return internalError(ctx, err, fmt.Sprintf(errFailedToStartCatchup, err), v2.Log)
 	}

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -1222,10 +1222,6 @@ func TestStartCatchup(t *testing.T) {
 
 	badCatchPoint := "bad catchpoint"
 	startCatchupTest(t, badCatchPoint, nil, 400)
-
-	// Test that a catchup fails w/ 400 when the catchpoint round is > syncRound (while syncRound is set)
-	syncRoundError := node.MakeCatchpointSyncRoundFailure(goodCatchPoint, 1)
-	startCatchupTest(t, goodCatchPoint, syncRoundError, 400)
 }
 
 func abortCatchupTest(t *testing.T, catchpoint string, expectedCode int) {

--- a/node/error.go
+++ b/node/error.go
@@ -62,24 +62,3 @@ func (e *CatchpointUnableToStartError) Error() string {
 		e.catchpointRequested,
 		e.catchpointRunning)
 }
-
-// CatchpointSyncRoundFailure indicates that the requested catchpoint is beyond the currently set sync round
-type CatchpointSyncRoundFailure struct {
-	catchpoint string
-	syncRound  uint64
-}
-
-// MakeCatchpointSyncRoundFailure creates the error type
-func MakeCatchpointSyncRoundFailure(catchpoint string, syncRound uint64) *CatchpointSyncRoundFailure {
-	return &CatchpointSyncRoundFailure{
-		catchpoint: catchpoint,
-		syncRound:  syncRound,
-	}
-}
-
-// Error satisfies the builtin `error` interface
-func (e *CatchpointSyncRoundFailure) Error() string {
-	return fmt.Sprintf(
-		"unable to start catchpoint catchup for '%s' - resulting round is beyond current sync round '%v'",
-		e.catchpoint, e.syncRound)
-}

--- a/node/follower_node.go
+++ b/node/follower_node.go
@@ -412,7 +412,9 @@ func (node *AlgorandFollowerNode) SetCatchpointCatchupMode(catchpointCatchupMode
 		defer node.mu.Unlock()
 
 		// update sync round before starting services
-		node.SetSyncRound(uint64(node.ledger.LastRound()))
+		if err := node.SetSyncRound(uint64(node.ledger.LastRound())); err != nil {
+			node.log.Warnf("unable to set sync round while resuming fast catchup: %v", err)
+		}
 
 		// start
 		node.catchupService.Start()


### PR DESCRIPTION
## Summary

Automatically set the sync round after running fast catchup on a follower node.

## Test Plan

New unit test.
