### PR TITLE
tools: add block-generator into published build

### DIFF
--- a/scripts/build_package.sh
+++ b/scripts/build_package.sh
@@ -106,7 +106,7 @@ TOOLS_ROOT=${PKG_ROOT}/tools
 
 echo "Staging tools package files"
 
-bin_files=("algons" "coroner" "dispenser" "netgoal" "nodecfg" "pingpong" "cc_service" "cc_agent" "cc_client" "loadgenerator" "COPYING" "dsign" "catchpointdump")
+bin_files=("algons" "coroner" "dispenser" "netgoal" "nodecfg" "pingpong" "cc_service" "cc_agent" "cc_client" "loadgenerator" "COPYING" "dsign" "catchpointdump" "block-generator")
 mkdir -p ${TOOLS_ROOT}
 for bin in "${bin_files[@]}"; do
     cp ${GOPATHBIN}/${bin} ${TOOLS_ROOT}


### PR DESCRIPTION
## Summary

Adding the block-generator into tools bundle.

## Test Plan

Accepting suggestions regarding how to test. Once it's on `master` and the nightly channel has finished building, we can verify that this worked with the following commands:

```sh
❯ LATEST_TOOLS_TAR_BALL=$(aws s3 ls algorand-releases/channel/nightly/ | sort | tail -n 1 | awk '{print $NF}')
❯ echo $LATEST_TOOLS_TAR_BALL
tools_nightly_linux-arm64_3.16.1601.tar.gz

❯ aws s3 cp s3://algorand-releases/channel/nightly/$LATEST_TOOLS_TAR_BALL .
download: s3://algorand-releases/channel/nightly/tools_nightly_linux-arm64_3.16.1601.tar.gz to ./tools_nightly_linux-arm64_3.16.1601.tar.gz

# Inspect that block-generator is in the below list (not here yet...)
❯ tar -tzf $LATEST_TOOLS_TAR_BALL
algons
catchpointdump
cc_agent
cc_client
cc_service
COPYING
coroner
dispenser
dsign
loadgenerator
netgoal
nodecfg
pingpong
sysctl-all.sh
sysctl.sh
```