### PR TITLE
goal: Make goal state schema optional

### DIFF
--- a/cmd/goal/README.md
+++ b/cmd/goal/README.md
@@ -68,7 +68,7 @@ TEALDIR=cmd/goal/examples
 echo $TEALDIR
 
 # create the app and TAKE NOTE of its "app index"
-goal app create --creator ${ACCOUNT} --approval-prog ${TEALDIR}/boxes.teal --clear-prog ${TEALDIR}/clear.teal --global-byteslices 0 --global-ints 0 --local-byteslices 0 --local-ints 0
+goal app create --creator ${ACCOUNT} --approval-prog ${TEALDIR}/boxes.teal --clear-prog ${TEALDIR}/clear.teal
 ```
 
 For the following questions, you'll need to use the app index. That will be shown in the last line printed. EG:

--- a/cmd/goal/application.go
+++ b/cmd/goal/application.go
@@ -163,10 +163,6 @@ func init() {
 	readStateAppCmd.Flags().BoolVar(&guessFormat, "guess-format", false, "Format application state using heuristics to guess data encoding.")
 
 	createAppCmd.MarkFlagRequired("creator")
-	createAppCmd.MarkFlagRequired("global-ints")
-	createAppCmd.MarkFlagRequired("global-byteslices")
-	createAppCmd.MarkFlagRequired("local-ints")
-	createAppCmd.MarkFlagRequired("local-byteslices")
 
 	optInAppCmd.MarkFlagRequired("app-id")
 	optInAppCmd.MarkFlagRequired("from")

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -498,6 +498,9 @@ type ConsensusParams struct {
 	// EnableCatchpointsWithSPContexts specifies when to re-enable version 7 catchpoints.
 	// Version 7 includes state proof verification contexts
 	EnableCatchpointsWithSPContexts bool
+
+	// EnableBoxRefNameError specifies that box ref names should be validated early
+	EnableBoxRefNameError bool
 }
 
 // PaysetCommitType enumerates possible ways for the block header to commit to
@@ -1266,6 +1269,7 @@ func initConsensusProtocols() {
 	vFuture.LogicSigVersion = 9 // When moving this to a release, put a new higher LogicSigVersion here
 	vFuture.EnablePrecheckECDSACurve = true
 	vFuture.EnableBareBudgetError = true
+	vFuture.EnableBoxRefNameError = true
 
 	vFuture.StateProofUseTrackerVerification = true
 	vFuture.EnableCatchpointsWithSPContexts = true

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -477,6 +477,9 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 			if br.Index > uint64(len(tx.ForeignApps)) {
 				return fmt.Errorf("tx.Boxes[%d].Index is %d. Exceeds len(tx.ForeignApps)", i, br.Index)
 			}
+			if proto.EnableBoxRefNameError && len(br.Name) > proto.MaxAppKeyLen {
+				return fmt.Errorf("tx.Boxes[%d].Name too long, max len %d bytes", i, proto.MaxAppKeyLen)
+			}
 		}
 
 		if tx.LocalStateSchema.NumEntries() > proto.MaxLocalSchemaEntries {

--- a/data/transactions/transaction_test.go
+++ b/data/transactions/transaction_test.go
@@ -274,6 +274,7 @@ func TestWellFormedErrors(t *testing.T) {
 	protoV27 := config.Consensus[protocol.ConsensusV27]
 	protoV28 := config.Consensus[protocol.ConsensusV28]
 	protoV32 := config.Consensus[protocol.ConsensusV32]
+	protoV36 := config.Consensus[protocol.ConsensusV36]
 	addr1, err := basics.UnmarshalChecksumAddress("NDQCJNNY5WWWFLP4GFZ7MEF2QJSMZYK6OWIV2AQ7OMAVLEFCGGRHFPKJJA")
 	require.NoError(t, err)
 	v5 := []byte{0x05}
@@ -565,6 +566,32 @@ func TestWellFormedErrors(t *testing.T) {
 			},
 			proto:         protoV32,
 			expectedError: fmt.Errorf("tx.Boxes too long, max number of box references is 0"),
+		},
+		{
+			tx: Transaction{
+				Type:   protocol.ApplicationCallTx,
+				Header: okHeader,
+				ApplicationCallTxnFields: ApplicationCallTxnFields{
+					ApplicationID: 1,
+					Boxes:         []BoxRef{{Index: 1, Name: make([]byte, 65)}},
+					ForeignApps:   []basics.AppIndex{1},
+				},
+			},
+			proto:         futureProto,
+			expectedError: fmt.Errorf("tx.Boxes[0].Name too long, max len 64 bytes"),
+		},
+		{
+			tx: Transaction{
+				Type:   protocol.ApplicationCallTx,
+				Header: okHeader,
+				ApplicationCallTxnFields: ApplicationCallTxnFields{
+					ApplicationID: 1,
+					Boxes:         []BoxRef{{Index: 1, Name: make([]byte, 65)}},
+					ForeignApps:   []basics.AppIndex{1},
+				},
+			},
+			proto:         protoV36,
+			expectedError: nil,
 		},
 	}
 	for _, usecase := range usecases {

--- a/test/scripts/e2e_subs/access-previous-scratch.sh
+++ b/test/scripts/e2e_subs/access-previous-scratch.sh
@@ -17,7 +17,7 @@ gcmd="goal -w ${WALLET}"
 
 ACCOUNT=$(${gcmd} account list|awk '{ print $3 }')
 
-APPID=$(${gcmd} app create --creator "${ACCOUNT}" --approval-prog=${TEAL}/scratch-rw.teal --global-byteslices 0 --global-ints 0 --local-byteslices 0 --local-ints 0  --clear-prog=${TEAL}/approve-all.teal | grep Created | awk '{ print $6 }')
+APPID=$(${gcmd} app create --creator "${ACCOUNT}" --approval-prog=${TEAL}/scratch-rw.teal --clear-prog=${TEAL}/approve-all.teal | grep Created | awk '{ print $6 }')
 
 # Create app calls
 function create_app_call {

--- a/test/scripts/e2e_subs/box-search.sh
+++ b/test/scripts/e2e_subs/box-search.sh
@@ -20,7 +20,7 @@ ACCOUNT=$(${gcmd} account list|awk '{ print $3 }')
 # Version 8 clear program
 printf '#pragma version 8\nint 1' > "${TEMPDIR}/clear.teal"
 
-APPID=$(${gcmd} app create --creator "$ACCOUNT" --approval-prog=${TEAL}/boxes.teal --clear-prog "$TEMPDIR/clear.teal" --global-byteslices 0 --global-ints 0 --local-byteslices 0 --local-ints 0 | grep Created | awk '{ print $6 }')
+APPID=$(${gcmd} app create --creator "$ACCOUNT" --approval-prog=${TEAL}/boxes.teal --clear-prog "$TEMPDIR/clear.teal" | grep Created | awk '{ print $6 }')
 
 # Fund the app account 10 algos
 APP_ACCOUNT=$(${gcmd} app info --app-id "$APPID" | grep "Application account" | awk '{print $3}')
@@ -38,9 +38,18 @@ EXPECTED="No box found for appid $APPID with name str:not_found"
 
 [ "$BOX_INFO" = "$EXPECTED" ]
 
+# Confirm that we error for an invalid box name
+BOX_NAME="str:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+RES=$(${gcmd} app call --from "$ACCOUNT" --app-id "$APPID" --box "$BOX_NAME" --app-arg "str:create" --app-arg "$BOX_NAME" 2>&1 || true)
+EXPECTED="invalid : tx.Boxes[0].Name too long, max len 64 bytes"
+
+if [[ "$RES" != *"$EXPECTED" ]]; then
+  date "+${scriptname} unexpected response from goal app call with invalid box name %Y%m%d_%H%M%S"
+  false
+fi
+
 # Create several boxes
 BOX_NAMES=("str:box1" "str:with spaces" "b64:YmFzZTY0" "b64:AQIDBA==") # b64:YmFzZTY0 == str:base64, b64:AQIDBA== is not unicode
-BOX_VALUE="box value"
 B64_BOX_VALUE="b64:Ym94IHZhbHVlAAAAAAAAAAAAAAAAAAAA"
 
 for BOX_NAME in "${BOX_NAMES[@]}"

--- a/test/scripts/e2e_subs/box-search.sh
+++ b/test/scripts/e2e_subs/box-search.sh
@@ -50,6 +50,7 @@ fi
 
 # Create several boxes
 BOX_NAMES=("str:box1" "str:with spaces" "b64:YmFzZTY0" "b64:AQIDBA==") # b64:YmFzZTY0 == str:base64, b64:AQIDBA== is not unicode
+BOX_VALUE="box value"
 B64_BOX_VALUE="b64:Ym94IHZhbHVlAAAAAAAAAAAAAAAAAAAA"
 
 for BOX_NAME in "${BOX_NAMES[@]}"

--- a/test/scripts/e2e_subs/e2e-app-abi-arg.sh
+++ b/test/scripts/e2e_subs/e2e-app-abi-arg.sh
@@ -19,7 +19,7 @@ ACCOUNT=$(${gcmd} account list|awk '{ print $3 }')
 
 printf '#pragma version 2\nint 1' > "${TEMPDIR}/simple.teal"
 PROGRAM=($(${gcmd} clerk compile "${TEMPDIR}/simple.teal"))
-APPID=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog ${DIR}/tealprogs/app-abi-arg.teal --clear-prog ${TEMPDIR}/simple.teal --global-byteslices 0 --global-ints ${GLOBAL_INTS} --local-byteslices 0 --local-ints 0 | grep Created | awk '{ print $6 }')
+APPID=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog ${DIR}/tealprogs/app-abi-arg.teal --clear-prog ${TEMPDIR}/simple.teal --global-ints ${GLOBAL_INTS} | grep Created | awk '{ print $6 }')
 
 # Should succeed to opt in with string "optin"
 ${gcmd} app optin --app-id $APPID --from $ACCOUNT --app-arg 'abi:string:"optin"'

--- a/test/scripts/e2e_subs/e2e-app-abi-method.sh
+++ b/test/scripts/e2e_subs/e2e-app-abi-method.sh
@@ -20,7 +20,7 @@ printf '#pragma version 2\nint 1' > "${TEMPDIR}/simple-v2.teal"
 printf '#pragma version 3\nint 1' > "${TEMPDIR}/simple-v3.teal"
 
 # Create
-RES=$(${gcmd} app method --method "create(uint64)uint64" --arg "1234" --create --approval-prog ${DIR}/tealprogs/app-abi-method-example.teal --clear-prog ${TEMPDIR}/simple-v2.teal --global-byteslices 0 --global-ints 0 --local-byteslices 1 --local-ints 0 --extra-pages 0 --from $ACCOUNT 2>&1 || true)
+RES=$(${gcmd} app method --method "create(uint64)uint64" --arg "1234" --create --approval-prog ${DIR}/tealprogs/app-abi-method-example.teal --clear-prog ${TEMPDIR}/simple-v2.teal --local-byteslices 1 --from $ACCOUNT 2>&1 || true)
 EXPECTED="method create(uint64)uint64 succeeded with output: 2468"
 if [[ $RES != *"${EXPECTED}"* ]]; then
     date '+app-abi-method-test FAIL the method call to create(uint64)uint64 should not fail %Y%m%d_%H%M%S'
@@ -112,7 +112,7 @@ if [[ $RES != *"${EXPECTED}"* ]]; then
 fi
 
 # Foreign reference test during creation
-RES=$(${gcmd} app method --create --approval-prog ${DIR}/tealprogs/app-abi-method-example.teal --clear-prog ${TEMPDIR}/simple-v2.teal --global-byteslices 0 --global-ints 0 --local-byteslices 1 --local-ints 0 --extra-pages 0 --on-completion deleteapplication --method "referenceTest(account,application,account,asset,account,asset,asset,application,application)uint8[9]" --arg KGTOR3F3Q74JP4LB5M3SOCSJ4BOPOKZ2GPSLMLLGCWYWRXZJNN4LYQJXXU --arg 0 --arg $ACCOUNT --arg 10 --arg KGTOR3F3Q74JP4LB5M3SOCSJ4BOPOKZ2GPSLMLLGCWYWRXZJNN4LYQJXXU --arg 11 --arg 10 --arg 20 --arg 21 --app-account 2R5LMPTYLVMWYEG4RPI26PJAM7ARTGUB7LZSONQPGLUWTPOP6LQCJTQZVE --foreign-app 21 --foreign-asset 10 --from $ACCOUNT 2>&1 || true)
+RES=$(${gcmd} app method --create --approval-prog ${DIR}/tealprogs/app-abi-method-example.teal --clear-prog ${TEMPDIR}/simple-v2.teal --local-byteslices 1 --on-completion deleteapplication --method "referenceTest(account,application,account,asset,account,asset,asset,application,application)uint8[9]" --arg KGTOR3F3Q74JP4LB5M3SOCSJ4BOPOKZ2GPSLMLLGCWYWRXZJNN4LYQJXXU --arg 0 --arg $ACCOUNT --arg 10 --arg KGTOR3F3Q74JP4LB5M3SOCSJ4BOPOKZ2GPSLMLLGCWYWRXZJNN4LYQJXXU --arg 11 --arg 10 --arg 20 --arg 21 --app-account 2R5LMPTYLVMWYEG4RPI26PJAM7ARTGUB7LZSONQPGLUWTPOP6LQCJTQZVE --foreign-app 21 --foreign-asset 10 --from $ACCOUNT 2>&1 || true)
 EXPECTED="method referenceTest(account,application,account,asset,account,asset,asset,application,application)uint8[9] succeeded with output: [2,0,2,0,2,1,0,1,0]"
 if [[ $RES != *"${EXPECTED}"* ]]; then
     date '+app-abi-method-test FAIL the creation method call to referenceTest(account,application,account,asset,account,asset,asset,application,application)uint8[9] should not fail %Y%m%d_%H%M%S'

--- a/test/scripts/e2e_subs/e2e-app-bootloader.sh
+++ b/test/scripts/e2e_subs/e2e-app-bootloader.sh
@@ -33,7 +33,7 @@ sed -i"" -e "s/TMPL_CLEARSTATE_HASH/${TARGET_HASH}/g" ${TEMPDIR}/bootloader.teal
 
 # Create an app using filled-in bootloader template
 printf '#pragma version 2\nint 1' > "${TEMPDIR}/int1.teal"
-APPID=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog ${TEMPDIR}/bootloader.teal --global-byteslices 1 --global-ints 0 --local-byteslices 0 --local-ints 0 --clear-prog "${TEMPDIR}/int1.teal" | grep Created | awk '{ print $6 }')
+APPID=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog ${TEMPDIR}/bootloader.teal --global-byteslices 1 --clear-prog "${TEMPDIR}/int1.teal" | grep Created | awk '{ print $6 }')
 
 # Calling app without args and wrong OnCompletion should fail
 EXPERROR='rejected by ApprovalProgram'

--- a/test/scripts/e2e_subs/e2e-app-delete-clear.sh
+++ b/test/scripts/e2e_subs/e2e-app-delete-clear.sh
@@ -20,7 +20,7 @@ PROGRAM_FILE="${TEMPDIR}/simple.teal"
 GLOBAL_INTS=2
 
 # Succeed in creating app with on-completion delete
-APPID=$(${gcmd} app create --creator ${ACCOUNT}  --on-completion "DeleteApplication" --approval-prog "${PROGRAM_FILE}" --clear-prog "${PROGRAM_FILE}" --global-byteslices 0 --global-ints ${GLOBAL_INTS} --local-byteslices 0 --local-ints 0 | grep Created | awk '{ print $6 }')
+APPID=$(${gcmd} app create --creator ${ACCOUNT}  --on-completion "DeleteApplication" --approval-prog "${PROGRAM_FILE}" --clear-prog "${PROGRAM_FILE}" --global-ints ${GLOBAL_INTS} | grep Created | awk '{ print $6 }')
 # Check that the app is not created
 APPID_CHECK=$(${gcmd} app info --app-id $APPID 2>&1 || true)
 EXPERROR="application does not exist"
@@ -30,7 +30,7 @@ if [[ $APPID_CHECK != *"${EXPERROR}"* ]]; then
 fi
 
 # Fail if creating app with on-completion clear
-RES=$(${gcmd} app create --creator ${ACCOUNT}  --on-completion "ClearState" --approval-prog "${PROGRAM_FILE}" --clear-prog "${PROGRAM_FILE}" --global-byteslices 0 --global-ints ${GLOBAL_INTS} --local-byteslices 0 --local-ints 0 2>&1 || true  ) 
+RES=$(${gcmd} app create --creator ${ACCOUNT}  --on-completion "ClearState" --approval-prog "${PROGRAM_FILE}" --clear-prog "${PROGRAM_FILE}" --global-ints ${GLOBAL_INTS} 2>&1 || true  ) 
 EXPERROR1='cannot clear state'
 EXPERROR2='is not currently opted in'
 if [[ $RES != *"${EXPERROR1}"*"${EXPERROR2}"* ]]; then

--- a/test/scripts/e2e_subs/e2e-app-extra-pages.sh
+++ b/test/scripts/e2e_subs/e2e-app-extra-pages.sh
@@ -52,7 +52,7 @@ generate_teal "$APPR_PROG" 4 3072 1 "int 0\nbalance\npop\n"
 generate_teal "$BIG_APPR_PROG" 4 4098 1 "int 0\nbalance\npop\n"
 
 # App create fails. Approval program too long
-RES=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog "${BIG_TEAL_FILE}" --clear-prog "${BIG_TEAL_FILE}" --global-byteslices 1 --global-ints 0 --local-byteslices 0 --local-ints 0 2>&1 || true)
+RES=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog "${BIG_TEAL_FILE}" --clear-prog "${BIG_TEAL_FILE}" --global-byteslices 1 2>&1 || true)
 EXPERROR="approval program too long. max len 2048 bytes"
 if [[ $RES != *"${EXPERROR}"* ]]; then
     date '+app-extra-pages-test FAIL the application creation should fail %Y%m%d_%H%M%S'
@@ -60,7 +60,7 @@ if [[ $RES != *"${EXPERROR}"* ]]; then
 fi
 
 # App create fails. Clear state program too long
-RES=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog "${SMALL_TEAL_FILE}" --clear-prog "${BIG_TEAL_FILE}" --global-byteslices 1 --global-ints 0 --local-byteslices 0 --local-ints 0 2>&1 || true)
+RES=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog "${SMALL_TEAL_FILE}" --clear-prog "${BIG_TEAL_FILE}" --global-byteslices 1 2>&1 || true)
 EXPERROR="clear state program too long. max len 2048 bytes"
 if [[ $RES != *"${EXPERROR}"* ]]; then
     date '+app-extra-pages-test FAIL the application creation should fail %Y%m%d_%H%M%S'
@@ -68,7 +68,7 @@ if [[ $RES != *"${EXPERROR}"* ]]; then
 fi
 
 # App create with extra pages, v3 teal
-RES=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog "${BIG_TEAL_FILE}" --clear-prog "${BIG_TEAL_FILE}" --extra-pages 3 --global-byteslices 1 --global-ints 0 --local-byteslices 0 --local-ints 0 2>&1 || true)
+RES=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog "${BIG_TEAL_FILE}" --clear-prog "${BIG_TEAL_FILE}" --extra-pages 3 --global-byteslices 1 2>&1 || true)
 EXPERROR="pc=705 static cost budget of 700 exceeded"
 if [[ $RES != *"${EXPERROR}"* ]]; then
     date '+app-extra-pages-test FAIL the application creation should fail %Y%m%d_%H%M%S'
@@ -76,7 +76,7 @@ if [[ $RES != *"${EXPERROR}"* ]]; then
 fi
 
 # App create with extra pages, v4 teal
-RES=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog "${BIG_TEAL_V4_FILE}" --clear-prog "${BIG_TEAL_V4_FILE}" --extra-pages 3 --global-byteslices 1 --global-ints 0 --local-byteslices 0 --local-ints 0 2>&1 || true)
+RES=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog "${BIG_TEAL_V4_FILE}" --clear-prog "${BIG_TEAL_V4_FILE}" --extra-pages 3 --global-byteslices 1 2>&1 || true)
 EXPERROR="pc=704 dynamic cost budget exceeded, executing intc_0: local program cost was 700"
 if [[ $RES != *"${EXPERROR}"* ]]; then
     date '+app-extra-pages-test FAIL the application creation should fail %Y%m%d_%H%M%S'
@@ -84,7 +84,7 @@ if [[ $RES != *"${EXPERROR}"* ]]; then
 fi
 
 # App create with extra pages, succeeded
-RES=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog "${SMALL_TEAL_FILE}" --clear-prog "${SMALL_TEAL_FILE}" --extra-pages 1 --global-byteslices 1 --global-ints 0 --local-byteslices 0 --local-ints 0 2>&1 || true)
+RES=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog "${SMALL_TEAL_FILE}" --clear-prog "${SMALL_TEAL_FILE}" --extra-pages 1 --global-byteslices 1 2>&1 || true)
 EXP="Created app"
 APPID=$(echo $RES | awk '{print $NF}')
 if [[ $RES != *"${EXP}"* ]]; then

--- a/test/scripts/e2e_subs/goal-app-create-state-defaults.sh
+++ b/test/scripts/e2e_subs/goal-app-create-state-defaults.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+scriptname="goal-app-create-state-defaults"
+date "+${scriptname} start %Y%m%d_%H%M%S"
+
+set -e
+set -x
+set -o pipefail
+export SHELLOPTS
+
+WALLET=$1
+
+# Directory of this bash program
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+gcmd="goal -w ${WALLET}"
+
+ACCOUNT=$(${gcmd} account list|awk '{ print $3 }')
+
+printf '#pragma version 2\nint 1' > "${TEMPDIR}/simple.teal"
+
+# Check goal flags --global-byteslices, --global-ints, --local-byteslices, --local-ints. We want to
+# ensure that omitting these flags has the same effect as setting them to 0.
+
+APP_CREATE_TXN_NO_STATE_FILE="${TEMPDIR}/create_no_state.txn"
+APP_CREATE_TXN_NO_FULLY_SPECIFIED_FILE="${TEMPDIR}/create_fully_specified.txn"
+
+# Checks for 'goal app create'
+
+# Passing a note is needed because goal will sometimes try to customize a note
+# to avoid duplicate txns
+
+${gcmd} app create --note "hello" --creator "${ACCOUNT}" --approval-prog "${TEMPDIR}/simple.teal" --clear-prog "${TEMPDIR}/simple.teal" --out "${APP_CREATE_TXN_NO_STATE_FILE}"
+APP_CREATE_TXN_NO_STATE=$(msgpacktool -d < "${APP_CREATE_TXN_NO_STATE_FILE}")
+
+FIRSTVALID=$(echo $APP_CREATE_TXN_NO_STATE | jq ".txn.fv")
+
+# Passing --firstvalid is used for subsequent transactions to ensure they have
+# the same valid range as the first txn
+
+${gcmd} app create --note "hello" --creator "${ACCOUNT}" --approval-prog "${TEMPDIR}/simple.teal" --clear-prog "${TEMPDIR}/simple.teal" --global-byteslices 0 --global-ints 0 --local-byteslices 0 --local-ints 0 --firstvalid $FIRSTVALID --out "${APP_CREATE_TXN_NO_FULLY_SPECIFIED_FILE}"
+APP_CREATE_TXN_NO_FULLY_SPECIFIED=$(msgpacktool -d < "${APP_CREATE_TXN_NO_FULLY_SPECIFIED_FILE}")
+
+if [ "$APP_CREATE_TXN_NO_FULLY_SPECIFIED" != "$APP_CREATE_TXN_NO_STATE" ]; then
+  date "+${scriptname} transactions made with 'goal app create' are not equal %Y%m%d_%H%M%S"
+  false
+fi
+
+# Checks for 'goal method --create'
+
+${gcmd} app method --create --note "hello" --from "${ACCOUNT}" --method "create(uint64)uint64" --arg "1234" --create --approval-prog "${TEMPDIR}/simple.teal" --clear-prog "${TEMPDIR}/simple.teal" --out "${APP_CREATE_TXN_NO_STATE_FILE}"
+APP_CREATE_TXN_NO_STATE=$(msgpacktool -d < "${APP_CREATE_TXN_NO_STATE_FILE}")
+
+FIRSTVALID=$(echo $APP_CREATE_TXN_NO_STATE | jq ".txn.fv")
+
+${gcmd} app method --create --note "hello" --from "${ACCOUNT}" --method "create(uint64)uint64" --arg "1234" --create --approval-prog "${TEMPDIR}/simple.teal" --clear-prog "${TEMPDIR}/simple.teal" --global-byteslices 0 --global-ints 0 --local-byteslices 0 --local-ints 0 --firstvalid $FIRSTVALID --out "${APP_CREATE_TXN_NO_FULLY_SPECIFIED_FILE}"
+APP_CREATE_TXN_NO_FULLY_SPECIFIED=$(msgpacktool -d < "${APP_CREATE_TXN_NO_FULLY_SPECIFIED_FILE}")
+
+if [ "$APP_CREATE_TXN_NO_FULLY_SPECIFIED" != "$APP_CREATE_TXN_NO_STATE" ]; then
+  date "+${scriptname} transactions made with 'goal method --create' are not equal %Y%m%d_%H%M%S"
+  false
+fi
+
+date "+${scriptname} OK %Y%m%d_%H%M%S"

--- a/test/scripts/e2e_subs/teal-creatable-id.sh
+++ b/test/scripts/e2e_subs/teal-creatable-id.sh
@@ -17,7 +17,7 @@ gcmd="goal -w ${WALLET}"
 
 ACCOUNT=$(${gcmd} account list|awk '{ print $3 }')
 
-APPID=$(${gcmd} app create --creator "${ACCOUNT}" --approval-prog=${TEAL}/check_creatable_id.teal --global-byteslices 0 --global-ints 0 --local-byteslices 0 --local-ints 0  --clear-prog=${TEAL}/approve-all.teal --app-arg=str:skipcreation | grep Created | awk '{ print $6 }')
+APPID=$(${gcmd} app create --creator "${ACCOUNT}" --approval-prog=${TEAL}/check_creatable_id.teal --clear-prog=${TEAL}/approve-all.teal --app-arg=str:skipcreation | grep Created | awk '{ print $6 }')
 
 # ==============================
 # > Asset and application test
@@ -30,7 +30,7 @@ ${gcmd} asset create --creator "${ACCOUNT}" --total 1000 --unitname "" --assetur
 ${gcmd} app call --app-id="$APPID" --from="$ACCOUNT" --app-arg=str:skipcreation --app-arg=int:0 --out "$TEMPDIR/unsigned_asset_check_app_call.txn"
 
 # Create app transaction
-${gcmd} app create --creator "${ACCOUNT}" --approval-prog=${TEAL}/approve-all.teal --global-byteslices 0 --global-ints 0 --local-byteslices 0 --local-ints 0  --clear-prog=${TEAL}/approve-all.teal --out "$TEMPDIR/unsigned_app_create.txn"
+${gcmd} app create --creator "${ACCOUNT}" --approval-prog=${TEAL}/approve-all.teal --clear-prog=${TEAL}/approve-all.teal --out "$TEMPDIR/unsigned_app_create.txn"
 
 # App call transaction to check app creatable ID
 ${gcmd} app call --app-id="$APPID" --from="$ACCOUNT" --app-arg=str:skipcreation --app-arg=int:2 --out "$TEMPDIR/unsigned_app_check_app_call.txn"


### PR DESCRIPTION
## Summary

Follow up from #4946, this PR makes the goal app flags `--global-byteslices`, `--global-ints`, `--local-byteslices`, and `--local-ints` optional. Also errors earlier for invalid box names.

## Test Plan

Added `test/scripts/e2e_subs/goal-app-create-state-defaults.sh` to ensure that omitting the flags has the same effect as setting them to 0.

Also modified existing tests to prefer omitting the state schema flags instead of setting them to 0.