### PR TITLE
logging: fix logging to line.

### DIFF
--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -83,7 +83,6 @@ func (s *Server) Initialize(cfg config.Local, phonebookAddresses []string, genes
 
 	liveLog := filepath.Join(s.RootPath, "node.log")
 	archive := filepath.Join(s.RootPath, cfg.LogArchiveName)
-	fmt.Println("Logging to: ", liveLog)
 	var maxLogAge time.Duration
 	var err error
 	if cfg.LogArchiveMaxAge != "" {
@@ -96,8 +95,10 @@ func (s *Server) Initialize(cfg config.Local, phonebookAddresses []string, genes
 
 	var logWriter io.Writer
 	if cfg.LogSizeLimit > 0 {
+		fmt.Println("Logging to: ", liveLog)
 		logWriter = logging.MakeCyclicFileWriter(liveLog, archive, cfg.LogSizeLimit, maxLogAge)
 	} else {
+		fmt.Println("Logging to: stdout")
 		logWriter = os.Stdout
 	}
 	s.log.SetOutput(logWriter)


### PR DESCRIPTION
## Summary

Fixes the `Logging to` print statement to indicate stdout if a file is not being used.

## Test Plan

Manually ran `algod` and `algod -o` to see the different log statements.