### PR TITLE
Algod: Use future consensus version to test with no low resources

### DIFF
--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -934,7 +934,7 @@ func TestSimulateTransaction(t *testing.T) {
 	for name, scenarioFn := range scenarios {
 		t.Run(name, func(t *testing.T) { //nolint:paralleltest // Uses shared testing env
 			sender := roots[0]
-			futureAppID := basics.AppIndex(2)
+			futureAppID := basics.AppIndex(1002)
 
 			payTxn := txnInfo.NewTxn(txntest.Txn{
 				Type:     protocol.PaymentTx,
@@ -1514,7 +1514,7 @@ func TestTealDryrun(t *testing.T) {
 	gdr.ProtocolVersion = ""
 
 	ddr := tealDryrunTest(t, &gdr, "json", 200, "PASS", true)
-	require.Equal(t, string(protocol.ConsensusCurrentVersion), ddr.ProtocolVersion)
+	require.Equal(t, string(protocol.ConsensusFuture), ddr.ProtocolVersion)
 	gdr.ProtocolVersion = string(protocol.ConsensusFuture)
 	ddr = tealDryrunTest(t, &gdr, "json", 200, "PASS", true)
 	require.Equal(t, string(protocol.ConsensusFuture), ddr.ProtocolVersion)

--- a/daemon/algod/api/server/v2/test/helpers.go
+++ b/daemon/algod/api/server/v2/test/helpers.go
@@ -266,7 +266,7 @@ var genesisHash = crypto.Digest{0xff, 0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 
 var genesisID = "testingid"
 var retOneProgram = []byte{2, 0x20, 1, 1, 0x22}
 
-var proto = config.Consensus[protocol.ConsensusCurrentVersion]
+var proto = config.Consensus[protocol.ConsensusFuture]
 
 func testingenv(t testing.TB, numAccounts, numTxs int, offlineAccounts bool) (*data.Ledger, []account.Root, []account.Participation, []transactions.SignedTxn, func()) {
 	minMoneyAtStart := 100000  // min money start
@@ -313,7 +313,7 @@ func testingenvWithBalances(t testing.TB, minMoneyAtStart, maxMoneyAtStart, numA
 		}
 		accessors = append(accessors, access)
 
-		part, err := account.FillDBWithParticipationKeys(access, root.Address(), 0, lastValid, config.Consensus[protocol.ConsensusCurrentVersion].DefaultKeyDilution)
+		part, err := account.FillDBWithParticipationKeys(access, root.Address(), 0, lastValid, proto.DefaultKeyDilution)
 		if err != nil {
 			panic(err)
 		}
@@ -351,7 +351,7 @@ func testingenvWithBalances(t testing.TB, minMoneyAtStart, maxMoneyAtStart, numA
 	const inMem = true
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	ledger, err := data.LoadLedger(logging.Base(), t.Name(), inMem, protocol.ConsensusCurrentVersion, bootstrap, genesisID, genesisHash, nil, cfg)
+	ledger, err := data.LoadLedger(logging.Base(), t.Name(), inMem, protocol.ConsensusFuture, bootstrap, genesisID, genesisHash, nil, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -1331,8 +1331,8 @@ return
 	a.Greater(len(ops.Program), 1)
 	program := ops.Program
 
-	proto := config.Consensus[protocol.ConsensusCurrentVersion]
-	genesisInitState, initKeys := ledgertesting.GenerateInitState(t, protocol.ConsensusCurrentVersion, 1000000)
+	proto := config.Consensus[protocol.ConsensusFuture]
+	genesisInitState, initKeys := ledgertesting.GenerateInitState(t, protocol.ConsensusFuture, 1000000)
 
 	creator, err := basics.UnmarshalChecksumAddress("3LN5DBFC2UTPD265LQDP3LMTLGZCQ5M3JV7XTVTGRH5CKSVNQVDFPN6FG4")
 	a.NoError(err)
@@ -1357,7 +1357,7 @@ return
 		GenesisHash: genesisInitState.GenesisHash,
 	}
 
-	appIdx := basics.AppIndex(2) // second tnx => idx = 2
+	appIdx := basics.AppIndex(1002) // second tnx => idx = 1002
 
 	// fund app account
 	fundingPayment := transactions.Transaction{
@@ -1386,7 +1386,7 @@ return
 		Header:                   txHeader,
 		ApplicationCallTxnFields: appCreateFields,
 	}
-	err = l1.appendUnvalidatedTx(t, genesisInitState.Accounts, initKeys, appCreate, transactions.ApplyData{ApplicationID: 2})
+	err = l1.appendUnvalidatedTx(t, genesisInitState.Accounts, initKeys, appCreate, transactions.ApplyData{ApplicationID: appIdx})
 	a.NoError(err)
 
 	// few empty blocks to reset deltas and flush

--- a/ledger/simulation/simulation_eval_test.go
+++ b/ledger/simulation/simulation_eval_test.go
@@ -535,7 +535,7 @@ int 1`,
 				var AppBudgetConsumed, AppBudgetAdded uint64
 				if expectedSuccess {
 					expectedAppCallAD = transactions.ApplyData{
-						ApplicationID: 2,
+						ApplicationID: 1002,
 						EvalDelta: transactions.EvalDelta{
 							Logs: []string{"hello"},
 						},
@@ -586,7 +586,7 @@ func TestSimpleAppCall(t *testing.T) {
 		sender := accounts[0]
 
 		// Create program and call it
-		futureAppID := basics.AppIndex(1)
+		futureAppID := basics.AppIndex(1001)
 		createTxn := txnInfo.NewTxn(txntest.Txn{
 			Type:          protocol.ApplicationCallTx,
 			Sender:        sender.Addr,
@@ -667,7 +667,7 @@ func TestRejectAppCall(t *testing.T) {
 	simulationTest(t, func(accounts []simulationtesting.Account, txnInfo simulationtesting.TxnInfo) simulationTestCase {
 		sender := accounts[0]
 
-		futureAppID := basics.AppIndex(1)
+		futureAppID := basics.AppIndex(1001)
 		createTxn := txnInfo.NewTxn(txntest.Txn{
 			Type:          protocol.ApplicationCallTx,
 			Sender:        sender.Addr,
@@ -722,7 +722,7 @@ func TestErrorAppCall(t *testing.T) {
 	simulationTest(t, func(accounts []simulationtesting.Account, txnInfo simulationtesting.TxnInfo) simulationTestCase {
 		sender := accounts[0]
 
-		futureAppID := basics.AppIndex(1)
+		futureAppID := basics.AppIndex(1001)
 		createTxn := txnInfo.NewTxn(txntest.Txn{
 			Type:          protocol.ApplicationCallTx,
 			Sender:        sender.Addr,
@@ -787,7 +787,7 @@ func TestAppCallOverBudget(t *testing.T) {
 	simulationTest(t, func(accounts []simulationtesting.Account, txnInfo simulationtesting.TxnInfo) simulationTestCase {
 		sender := accounts[0]
 
-		futureAppID := basics.AppIndex(1)
+		futureAppID := basics.AppIndex(1001)
 		// App create with cost 4
 		createTxn := txnInfo.NewTxn(txntest.Txn{
 			Type:            protocol.ApplicationCallTx,
@@ -860,7 +860,7 @@ func TestAppCallWithExtraBudget(t *testing.T) {
 	simulationTest(t, func(accounts []simulationtesting.Account, txnInfo simulationtesting.TxnInfo) simulationTestCase {
 		sender := accounts[0]
 
-		futureAppID := basics.AppIndex(1)
+		futureAppID := basics.AppIndex(1001)
 		// App create with cost 4
 		createTxn := txnInfo.NewTxn(txntest.Txn{
 			Type:              protocol.ApplicationCallTx,
@@ -931,7 +931,7 @@ func TestAppCallWithExtraBudgetOverBudget(t *testing.T) {
 	simulationTest(t, func(accounts []simulationtesting.Account, txnInfo simulationtesting.TxnInfo) simulationTestCase {
 		sender := accounts[0]
 
-		futureAppID := basics.AppIndex(1)
+		futureAppID := basics.AppIndex(1001)
 		// App create with cost 4
 		createTxn := txnInfo.NewTxn(txntest.Txn{
 			Type:              protocol.ApplicationCallTx,
@@ -1008,7 +1008,7 @@ func TestAppCallWithExtraBudgetExceedsInternalLimit(t *testing.T) {
 
 	sender := accounts[0]
 
-	futureAppID := basics.AppIndex(1)
+	futureAppID := basics.AppIndex(1001)
 	// App create with cost 4
 	createTxn := txnInfo.NewTxn(txntest.Txn{
 		Type:              protocol.ApplicationCallTx,
@@ -1143,7 +1143,7 @@ pop
 	simulationTest(t, func(accounts []simulationtesting.Account, txnInfo simulationtesting.TxnInfo) simulationTestCase {
 		sender := accounts[0]
 
-		futureAppID := basics.AppIndex(2)
+		futureAppID := basics.AppIndex(1002)
 		// fund outer app
 		fund := txnInfo.NewTxn(txntest.Txn{
 			Type:     protocol.PaymentTx,
@@ -1305,7 +1305,7 @@ int 1`
 		sender := accounts[0]
 		receiver := accounts[1]
 
-		futureAppID := basics.AppIndex(1)
+		futureAppID := basics.AppIndex(1001)
 
 		createTxn := txnInfo.NewTxn(txntest.Txn{
 			Type:              protocol.ApplicationCallTx,
@@ -1399,7 +1399,7 @@ int 1`
 		sender := accounts[0]
 		receiver := accounts[1]
 
-		futureAppID := basics.AppIndex(1)
+		futureAppID := basics.AppIndex(1001)
 
 		createTxn := txnInfo.NewTxn(txntest.Txn{
 			Type:              protocol.ApplicationCallTx,
@@ -1487,7 +1487,7 @@ func TestBalanceChangesWithApp(t *testing.T) {
 		receiver := accounts[1]
 		receiverBalance := receiver.AcctData.MicroAlgos.Raw
 
-		futureAppID := basics.AppIndex(1)
+		futureAppID := basics.AppIndex(1001)
 		createTxn := txnInfo.NewTxn(txntest.Txn{
 			Type:   protocol.ApplicationCallTx,
 			Sender: sender.Addr,
@@ -1702,13 +1702,13 @@ func TestPartialMissingSignatures(t *testing.T) {
 							{
 								Txn: transactions.SignedTxnWithAD{
 									ApplyData: transactions.ApplyData{
-										ConfigAsset: 1,
+										ConfigAsset: 1001,
 									},
 								},
 							}, {
 								Txn: transactions.SignedTxnWithAD{
 									ApplyData: transactions.ApplyData{
-										ConfigAsset: 2,
+										ConfigAsset: 1002,
 									},
 								},
 							},
@@ -1836,18 +1836,21 @@ func TestAppCallInnerTxnApplyDataOnFail(t *testing.T) {
 		singleInnerLogAndFail := makeProgramToCallInner(t, logAndFail)
 		nestedInnerLogAndFail := makeProgramToCallInner(t, singleInnerLogAndFail)
 
+		futureOuterAppID := basics.AppIndex(1003)
+		futureInnerAppID := futureOuterAppID + 1
+
 		// fund outer app
 		pay1 := txnInfo.NewTxn(txntest.Txn{
 			Type:     protocol.PaymentTx,
 			Sender:   sender.Addr,
-			Receiver: basics.AppIndex(3).Address(),
+			Receiver: futureOuterAppID.Address(),
 			Amount:   401_000, // 400_000 min balance plus 1_000 for 1 txn
 		})
 		// fund inner app
 		pay2 := txnInfo.NewTxn(txntest.Txn{
 			Type:     protocol.PaymentTx,
 			Sender:   sender.Addr,
-			Receiver: basics.AppIndex(4).Address(),
+			Receiver: futureInnerAppID.Address(),
 			Amount:   401_000, // 400_000 min balance plus 1_000 for 1 txn
 		})
 		// create app
@@ -1882,19 +1885,19 @@ int 1`,
 							{
 								Txn: transactions.SignedTxnWithAD{
 									ApplyData: transactions.ApplyData{
-										ApplicationID: 3,
+										ApplicationID: futureOuterAppID,
 										EvalDelta: transactions.EvalDelta{
 											Logs: []string{"starting inner txn"},
 											InnerTxns: []transactions.SignedTxnWithAD{
 												{
 													ApplyData: transactions.ApplyData{
-														ApplicationID: 4,
+														ApplicationID: futureInnerAppID,
 														EvalDelta: transactions.EvalDelta{
 															Logs: []string{"starting inner txn"},
 															InnerTxns: []transactions.SignedTxnWithAD{
 																{
 																	ApplyData: transactions.ApplyData{
-																		ApplicationID: 5,
+																		ApplicationID: futureInnerAppID + 1,
 																		EvalDelta: transactions.EvalDelta{
 																			Logs: []string{"message"},
 																		},
@@ -1943,11 +1946,13 @@ func TestNonAppCallInnerTxnApplyDataOnFail(t *testing.T) {
 		logAndFailItxnCode := makeItxnSubmitToCallInner(t, logAndFail)
 		approvalProgram := wrapCodeWithVersionAndReturn(createAssetCode + logAndFailItxnCode)
 
+		futureAppID := basics.AppIndex(1002)
+
 		// fund outer app
 		pay1 := txnInfo.NewTxn(txntest.Txn{
 			Type:     protocol.PaymentTx,
 			Sender:   sender.Addr,
-			Receiver: basics.AppIndex(2).Address(),
+			Receiver: futureAppID.Address(),
 			Amount:   401_000, // 400_000 min balance plus 1_000 for 1 txn
 		})
 		// create app
@@ -1981,18 +1986,18 @@ int 1`,
 							{
 								Txn: transactions.SignedTxnWithAD{
 									ApplyData: transactions.ApplyData{
-										ApplicationID: 2,
+										ApplicationID: futureAppID,
 										EvalDelta: transactions.EvalDelta{
 											Logs: []string{"starting asset create", "finished asset create", "starting inner txn"},
 											InnerTxns: []transactions.SignedTxnWithAD{
 												{
 													ApplyData: transactions.ApplyData{
-														ConfigAsset: 3,
+														ConfigAsset: basics.AssetIndex(futureAppID) + 1,
 													},
 												},
 												{
 													ApplyData: transactions.ApplyData{
-														ApplicationID: 4,
+														ApplicationID: futureAppID + 2,
 														EvalDelta: transactions.EvalDelta{
 															Logs: []string{"message"},
 														},
@@ -2035,14 +2040,17 @@ func TestInnerTxnNonAppCallFailure(t *testing.T) {
 	simulationTest(t, func(accounts []simulationtesting.Account, txnInfo simulationtesting.TxnInfo) simulationTestCase {
 		sender := accounts[0]
 
+		futureAppID := basics.AppIndex(1002)
+		futureAssetID := basics.AssetIndex(1003)
+
 		// configAssetCode should fail because createAssetCode does not set an asset manager
-		approvalProgram := wrapCodeWithVersionAndReturn(createAssetCode + fmt.Sprintf(configAssetCode, 3))
+		approvalProgram := wrapCodeWithVersionAndReturn(createAssetCode + fmt.Sprintf(configAssetCode, futureAssetID))
 
 		// fund outer app
 		pay1 := txnInfo.NewTxn(txntest.Txn{
 			Type:     protocol.PaymentTx,
 			Sender:   sender.Addr,
-			Receiver: basics.AppIndex(2).Address(),
+			Receiver: futureAppID.Address(),
 			Amount:   402_000, // 400_000 min balance plus 2_000 for 2 inners
 		})
 		// create app
@@ -2076,13 +2084,13 @@ int 1`,
 							{
 								Txn: transactions.SignedTxnWithAD{
 									ApplyData: transactions.ApplyData{
-										ApplicationID: 2,
+										ApplicationID: futureAppID,
 										EvalDelta: transactions.EvalDelta{
 											Logs: []string{"starting asset create", "finished asset create", "starting asset config"},
 											InnerTxns: []transactions.SignedTxnWithAD{
 												{
 													ApplyData: transactions.ApplyData{
-														ConfigAsset: 3,
+														ConfigAsset: futureAssetID,
 													},
 												},
 												{},
@@ -2116,7 +2124,7 @@ func TestMockTracerScenarios(t *testing.T) {
 			simulationTest(t, func(accounts []simulationtesting.Account, txnInfo simulationtesting.TxnInfo) simulationTestCase {
 				sender := accounts[0]
 
-				futureAppID := basics.AppIndex(2)
+				futureAppID := basics.AppIndex(1002)
 				payTxn := txnInfo.NewTxn(txntest.Txn{
 					Type:     protocol.PaymentTx,
 					Sender:   sender.Addr,

--- a/ledger/simulation/testing/utils.go
+++ b/ledger/simulation/testing/utils.go
@@ -78,7 +78,7 @@ func (info TxnInfo) InnerTxn(parent transactions.SignedTxn, inner txntest.Txn) t
 
 // PrepareSimulatorTest creates an environment to test transaction simulations
 func PrepareSimulatorTest(t *testing.T) (l *data.Ledger, accounts []Account, txnInfo TxnInfo) {
-	genesisInitState, keys := ledgertesting.GenerateInitState(t, protocol.ConsensusCurrentVersion, 100)
+	genesisInitState, keys := ledgertesting.GenerateInitState(t, protocol.ConsensusFuture, 100)
 
 	// Prepare ledger
 	const inMem = true
@@ -119,6 +119,7 @@ func PrepareSimulatorTest(t *testing.T) (l *data.Ledger, accounts []Account, txn
 	numBlocks := rand.Intn(4)
 	for i := 0; i < numBlocks; i++ {
 		nextBlock := bookkeeping.MakeBlock(latestHeader)
+		nextBlock.TxnCounter = latestHeader.TxnCounter
 		err = l.AddBlock(nextBlock, agreement.Certificate{})
 		require.NoError(t, err)
 

--- a/ledger/testing/initState.go
+++ b/ledger/testing/initState.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	basics_testing "github.com/algorand/go-algorand/data/basics/testing"
@@ -46,7 +45,6 @@ func init() {
 
 // GenerateInitState generates testing init state
 func GenerateInitState(tb testing.TB, proto protocol.ConsensusVersion, baseAlgoPerAccount int) (genesisInitState ledgercore.InitState, initKeys map[basics.Address]*crypto.SignatureSecrets) {
-	params := config.Consensus[proto]
 	poolAddr := testPoolAddr
 	sinkAddr := testSinkAddr
 
@@ -76,40 +74,19 @@ func GenerateInitState(tb testing.TB, proto protocol.ConsensusVersion, baseAlgoP
 	initKeys[sinkAddr] = sinkSecret
 	initAccounts[sinkAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 7654321})
 
-	incentivePoolBalanceAtGenesis := initAccounts[poolAddr].MicroAlgos
-	var initialRewardsPerRound uint64
-	if params.InitialRewardsRateCalculation {
-		initialRewardsPerRound = basics.SubSaturate(incentivePoolBalanceAtGenesis.Raw, params.MinBalance) / uint64(params.RewardsRateRefreshInterval)
-	} else {
-		initialRewardsPerRound = incentivePoolBalanceAtGenesis.Raw / uint64(params.RewardsRateRefreshInterval)
-	}
+	genesisBalances := bookkeeping.MakeTimestampedGenesisBalances(initAccounts, sinkAddr, poolAddr, 0)
+	genesisID := tb.Name()
+	genesisHash := crypto.Hash([]byte(genesisID))
 
-	initBlock := bookkeeping.Block{
-		BlockHeader: bookkeeping.BlockHeader{
-			GenesisID: tb.Name(),
-			Round:     0,
-			RewardsState: bookkeeping.RewardsState{
-				RewardsRate: initialRewardsPerRound,
-				RewardsPool: poolAddr,
-				FeeSink:     sinkAddr,
-			},
-			UpgradeState: bookkeeping.UpgradeState{
-				CurrentProtocol: proto,
-			},
-		},
-	}
+	initBlock, err := bookkeeping.MakeGenesisBlock(proto, genesisBalances, genesisID, genesisHash)
+	require.NoError(tb, err)
 
-	var err error
 	initBlock.TxnCommitments, err = initBlock.PaysetCommit()
 	require.NoError(tb, err)
 
-	if params.SupportGenesisHash {
-		initBlock.BlockHeader.GenesisHash = crypto.Hash([]byte(tb.Name()))
-	}
-
 	genesisInitState.Block = initBlock
 	genesisInitState.Accounts = initAccounts
-	genesisInitState.GenesisHash = crypto.Hash([]byte(tb.Name()))
+	genesisInitState.GenesisHash = genesisHash
 
 	return
 }


### PR DESCRIPTION
## Summary

#5328 changed the initial txn counter from 0 to 1000, and simulate tests relied on this starting at 0 to predict app and asset IDs. Since we were testing with the current consensus version, not future, we didn't see any problems.

Since it's best to fix tests at development time instead of release time, I changed the relevant testing infrastructure to use consensus future instead of current. I've also fixed the simulate tests to work with a higher initial txn counter.

Note: this PR is not exhaustive. There seem to be quite a lot of tests which use the current consensus version, so it's possible more issues like this are present.

## Test Plan

Tests modified.
