### PR TITLE
Tests: Fix error messages in ledger tests

### DIFF
--- a/ledger/acctonline_test.go
+++ b/ledger/acctonline_test.go
@@ -129,9 +129,7 @@ func newBlock(t *testing.T, ml *mockLedgerForTracker, testProtocolVersion protoc
 	delta.Accts.MergeAccounts(updates)
 	delta.Totals = newTotals
 
-	err := ml.addMockBlock(blockEntry{block: blk}, delta)
-	require.NoError(t, err)
-	ml.trackers.newBlock(blk, delta)
+	ml.addBlock(blockEntry{block: blk}, delta)
 
 	return newTotals
 }
@@ -779,7 +777,7 @@ func TestAcctOnlineRoundParamsCache(t *testing.T) {
 
 		delta.Totals = accumulateTotals(t, consensusVersion, []map[basics.Address]ledgercore.AccountData{totals}, rewardLevel)
 		allTotals[i] = delta.Totals
-		ml.trackers.newBlock(blk, delta)
+		ml.addBlock(blockEntry{block: blk}, delta)
 		accts = append(accts, newAccts)
 
 		if i > basics.Round(maxBalLookback) && i%10 == 0 {

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -558,8 +558,7 @@ func TestCatchpointReproducibleLabels(t *testing.T) {
 		delta.Creatables = creatablesFromUpdates(base, updates, knownCreatables)
 		delta.Totals = newTotals
 
-		ml.trackers.newBlock(blk, delta)
-		ml.addMockBlock(blockEntry{block: blk}, delta)
+		ml.addBlock(blockEntry{block: blk}, delta)
 		accts = append(accts, newAccts)
 		rewardsLevels = append(rewardsLevels, rewardLevel)
 		roundDeltas[i] = delta
@@ -607,7 +606,7 @@ func TestCatchpointReproducibleLabels(t *testing.T) {
 			blk.CurrentProtocol = testProtocolVersion
 			delta := roundDeltas[i]
 
-			ml2.trackers.newBlock(blk, delta)
+			ml2.addBlock(blockEntry{block: blk}, delta)
 
 			if isDataFileRound(i) || isCatchpointRound(i) {
 				ml2.trackers.committedUpTo(i)
@@ -1084,8 +1083,7 @@ func TestCatchpointFirstStageInfoPruning(t *testing.T) {
 		}
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, 0, 0)
 
-		ml.trackers.newBlock(blk, delta)
-		ml.addMockBlock(blockEntry{block: blk}, delta)
+		ml.addBlock(blockEntry{block: blk}, delta)
 
 		if isDataFileRound(i) || isCatchpointRound(i) {
 			ml.trackers.committedUpTo(i)
@@ -1172,8 +1170,7 @@ func TestCatchpointFirstStagePersistence(t *testing.T) {
 		}
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, 0, 0)
 
-		ml.trackers.newBlock(blk, delta)
-		ml.addMockBlock(blockEntry{block: blk}, delta)
+		ml.addBlock(blockEntry{block: blk}, delta)
 	}
 	ml.trackers.committedUpTo(firstStageRound)
 	ml.trackers.waitAccountsWriting()
@@ -1301,8 +1298,7 @@ func TestCatchpointSecondStagePersistence(t *testing.T) {
 		}
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, 0, 0)
 
-		ml.trackers.newBlock(blk, delta)
-		ml.addMockBlock(blockEntry{block: blk}, delta)
+		ml.addBlock(blockEntry{block: blk}, delta)
 
 		if isDataFileRound(i) || isCatchpointRound(i) {
 			ml.trackers.committedUpTo(i)
@@ -1423,7 +1419,7 @@ func TestCatchpointSecondStageDeletesUnfinishedCatchpointRecord(t *testing.T) {
 
 		ml.trackers.newBlock(blk, delta)
 		ml.trackers.committedUpTo(i)
-		ml.addMockBlock(blockEntry{block: blk}, delta)
+		ml.addToBlockQueue(blockEntry{block: blk}, delta)
 	}
 	ml.trackers.waitAccountsWriting()
 
@@ -1454,7 +1450,7 @@ func TestCatchpointSecondStageDeletesUnfinishedCatchpointRecord(t *testing.T) {
 
 		ml2.trackers.newBlock(blk, delta)
 		ml2.trackers.committedUpTo(secondStageRound)
-		ml2.addMockBlock(blockEntry{block: blk}, delta)
+		ml2.addToBlockQueue(blockEntry{block: blk}, delta)
 	}
 	ml2.trackers.waitAccountsWriting()
 
@@ -1510,7 +1506,7 @@ func TestCatchpointSecondStageDeletesUnfinishedCatchpointRecordAfterRestart(t *t
 
 		ml.trackers.newBlock(blk, delta)
 		ml.trackers.committedUpTo(i)
-		ml.addMockBlock(blockEntry{block: blk}, delta)
+		ml.addToBlockQueue(blockEntry{block: blk}, delta)
 
 		// Let catchpoint data generation finish so that nothing gets skipped.
 		for ct.IsWritingCatchpointDataFile() {
@@ -1760,7 +1756,7 @@ func TestCatchpointFastUpdates(t *testing.T) {
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
-		ml.trackers.newBlock(blk, delta)
+		ml.addBlock(blockEntry{block: blk}, delta)
 		accts = append(accts, newAccts)
 		rewardsLevels = append(rewardsLevels, rewardLevel)
 
@@ -1861,7 +1857,7 @@ func TestCatchpointLargeAccountCountCatchpointGeneration(t *testing.T) {
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
-		ml.trackers.newBlock(blk, delta)
+		ml.addBlock(blockEntry{block: blk}, delta)
 		accts = append(accts, newAccts)
 		rewardsLevels = append(rewardsLevels, rewardLevel)
 

--- a/ledger/voters_test.go
+++ b/ledger/voters_test.go
@@ -38,9 +38,7 @@ func addBlockToAccountsUpdate(t *testing.T, blk bookkeeping.Block, ml *mockLedge
 	_, totals, err := ml.trackers.accts.LatestTotals()
 	require.NoError(t, err)
 	delta.Totals = totals
-	err = ml.addMockBlock(blockEntry{block: blk}, delta)
-	require.NoError(t, err)
-	ml.trackers.newBlock(blk, delta)
+	ml.addBlock(blockEntry{block: blk}, delta)
 }
 
 func addRandomBlock(t *testing.T, ml *mockLedgerForTracker) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Some of the ledger unit test does not add the block to the mock block queue and only invokes `newBlock` on all trackers. This causes the voters tracker to fail since it relays on data from the block queue.
In order to fix it, just need to make sure that blocks are added to the mock block queue   

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
