### PR TITLE
vrf: Add a pure Go VRF implementation

### DIFF
--- a/crypto/compare_verify_implementations.go
+++ b/crypto/compare_verify_implementations.go
@@ -1,0 +1,18 @@
+// +build compare_purego_implementation
+
+package crypto
+
+import "fmt"
+
+func init() {
+	fmt.Println("purego: Compiled with comparison enabled for Verify() implementation.")
+	validateGoVerify = func(pk VrfPubkey, p VrfProof, message Hashable, ok bool, out VrfOutput) {
+		goOk, goOut := pk.verifyBytesGo(p, hashRep(message))
+		if out != goOut {
+			panic(fmt.Sprintf("Go and C implementations differ: %x %x %x %x %x\n", pk, p, message, out, goOut))
+		}
+		if ok != goOk {
+			panic(fmt.Sprintf("Go and C implementations differ: %x %x %x\n", pk, p, message))
+		}
+	}
+}

--- a/crypto/compare_verify_implementations.go
+++ b/crypto/compare_verify_implementations.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 // +build compare_purego_implementation
 
 package crypto

--- a/crypto/vrf.go
+++ b/crypto/vrf.go
@@ -134,10 +134,18 @@ func (pk VrfPubkey) verifyBytes(proof VrfProof, msg []byte) (bool, VrfOutput) {
 	return ret == 0, out
 }
 
+// validateGoVerify is a temporary helper that allows testing both C and Go VRF implementations (this will be removed before this branch is merged).
+var validateGoVerify func(pk VrfPubkey, p VrfProof, message Hashable, ok bool, out VrfOutput)
+
 // Verify checks a VRF proof of a given Hashable. If the proof is valid the pseudorandom VrfOutput will be returned.
 // For a given public key and message, there are potentially multiple valid proofs.
 // However, given a public key and message, all valid proofs will yield the same output.
 // Moreover, the output is indistinguishable from random to anyone without the proof or the secret key.
 func (pk VrfPubkey) Verify(p VrfProof, message Hashable) (bool, VrfOutput) {
-	return pk.verifyBytes(p, HashRep(message))
+	ok, out := pk.verifyBytes(p, hashRep(message))
+	// Temporary addition to enable build tag based setting of an implementation to compare C and Go implementations.
+	if validateGoVerify != nil {
+		validateGoVerify(pk, p, message, ok, out)
+	}
+	return ok, out
 }

--- a/crypto/vrf.go
+++ b/crypto/vrf.go
@@ -142,7 +142,7 @@ var validateGoVerify func(pk VrfPubkey, p VrfProof, message Hashable, ok bool, o
 // However, given a public key and message, all valid proofs will yield the same output.
 // Moreover, the output is indistinguishable from random to anyone without the proof or the secret key.
 func (pk VrfPubkey) Verify(p VrfProof, message Hashable) (bool, VrfOutput) {
-	ok, out := pk.verifyBytes(p, hashRep(message))
+	ok, out := pk.verifyBytes(p, HashRep(message))
 	// Temporary addition to enable build tag based setting of an implementation to compare C and Go implementations.
 	if validateGoVerify != nil {
 		validateGoVerify(pk, p, message, ok, out)

--- a/crypto/vrf_go.go
+++ b/crypto/vrf_go.go
@@ -186,6 +186,7 @@ func ge25519FromUniform(r []byte) ([]byte, error) {
 	var eIsMinus1 int
 	var xSign byte
 
+	one := new(field.Element).One()
 	copy(s, r)
 	xSign = s[31] & 0x80
 	s[31] &= 0x7f
@@ -196,15 +197,12 @@ func ge25519FromUniform(r []byte) ([]byte, error) {
 	// elligator
 	rr2.Square(rr2) // fe25519_sq2(rr2, rr2);
 	rr2.Add(rr2, rr2)
-	rr2Bytes := rr2.Bytes()
-	rr2Bytes[0]++
-	rr2.SetBytes(rr2Bytes) // rr2[0]++;
-	rr2.Invert(rr2)        // fe25519_invert(rr2, rr2);
+	rr2.Add(rr2, one)
+	rr2.Invert(rr2) // fe25519_invert(rr2, rr2);
 
 	x = &field.Element{}
 
 	const curve25519A = 486662
-	one := new(field.Element).One()
 	curve25519AElement := new(field.Element).Mult32(one, curve25519A)
 
 	x.Mult32(rr2, curve25519A) // fe25519_mul(x, curve25519_A, rr2);

--- a/crypto/vrf_go.go
+++ b/crypto/vrf_go.go
@@ -78,7 +78,7 @@ func vrfVerifyAndHash(pk []byte, proof []byte, msg []byte) ([]byte, error) {
 	}
 	isSmallOrder := (&edwards25519.Point{}).MultByCofactor(Y).Equal(edwards25519.NewIdentityPoint()) == 1
 	if isSmallOrder {
-		return nil, fmt.Errorf("expected key to have small order")
+		return nil, fmt.Errorf("public key is a small order point")
 	}
 	// vrf_verify
 	ok, err := vrfVerify(Y, proof, msg)
@@ -213,7 +213,8 @@ func ge25519FromUniform(r []byte) ([]byte, error) {
 	x = &field.Element{}
 
 	const curve25519A = 486662
-	curve25519AElement := (&field.Element{}).One().Mult32((&field.Element{}).One(), curve25519A)
+	one := new(field.Element).One()
+	curve25519AElement := new(field.Element).Mult32(one, curve25519A)
 
 	x.Mult32(rr2, curve25519A) // fe25519_mul(x, curve25519_A, rr2);
 	x.Negate(x)                // fe25519_neg(x, x);
@@ -234,7 +235,7 @@ func ge25519FromUniform(r []byte) ([]byte, error) {
 	eIsMinus1 = int(s[1] & 1) // e_is_minus_1 = s[1] & 1;
 	eIsNotMinus1 := eIsMinus1 ^ 1
 	negx = (&field.Element{}).Set(x)
-	negx.Negate(negx)                               // fe25519_neg(negx, x);
+	negx := new(field.Element).Negate(x)                               // fe25519_neg(negx, x);
 	x.Select(x, negx, eIsNotMinus1)                 // fe25519_cmov(x, negx, e_is_minus_1);
 	x2.Zero()                                       // fe25519_0(x2);
 	x2.Select(x2, curve25519AElement, eIsNotMinus1) // fe25519_cmov(x2, curve25519_A, e_is_minus_1);
@@ -299,7 +300,7 @@ func vrfHashPoints(P1, P2, P3, P4 *edwards25519.Point) *edwards25519.Scalar {
 
 	copy(result[:], sum[:16])
 	r := edwards25519.NewScalar()
-	r.SetCanonicalBytes(result)
+	if _, err := r.SetCanonicalBytes(result); err != nil { panic(err) }
 	return r
 
 }

--- a/crypto/vrf_go.go
+++ b/crypto/vrf_go.go
@@ -1,0 +1,577 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package crypto
+
+import (
+	"crypto/sha512"
+	"crypto/subtle"
+	"fmt"
+
+	"filippo.io/edwards25519"
+	"filippo.io/edwards25519/field"
+)
+
+const (
+	vrfSuite = 0x04 // ECVRF-ED25519-SHA512-Elligator2
+)
+
+// VrfKeygenFromSeed deterministically generates a VRF keypair from 32 bytes of (secret) entropy.
+func VrfKeygenFromSeedGo(seed [32]byte) (VrfPubkey, VrfPrivkey) {
+	var pk VrfPubkey
+	var sk VrfPrivkey
+	h := sha512.New()
+	h.Write(seed[:])
+	hSum := h.Sum(nil)
+	copy(sk[:], hSum[:32])
+	sk[0] &= 248
+	sk[31] &= 127
+	sk[31] |= 64
+	p := edwards25519.NewScalar()
+	skBytes := make([]byte, 64)
+	copy(skBytes, sk[:32])
+	p.SetUniformBytes(skBytes)
+	A := edwards25519.NewIdentityPoint().ScalarBaseMult(p)
+	copy(pk[:], A.Bytes())
+	copy(sk[:], seed[:])
+	copy(sk[32:], pk[:])
+	return pk, sk
+}
+
+func (pk VrfPubkey) verifyBytesGo(proof VrfProof, msg []byte) (bool, VrfOutput) {
+	var out VrfOutput
+	h, err := crypto_vrf_verify(pk[:], proof[:], msg)
+	if err != nil {
+		// TODO: this method should return an error.
+		// fmt.Println("issue verifying:", err)
+		return false, out
+	}
+	copy(out[:], h)
+	return true, out
+}
+
+func crypto_vrf_verify(pk []byte, proof []byte, msg []byte) ([]byte, error) {
+	return crypto_vrf_ietfdraft03_verify(pk, proof, msg)
+}
+
+/* Verify a VRF proof (for a given a public key and message) and validate the
+ * public key. If verification succeeds, store the VRF output hash in output[].
+ * Specified in draft spec section 5.3.
+ *
+ * For a given public key and message, there are many possible proofs but only
+ * one possible output hash.
+ */
+func crypto_vrf_ietfdraft03_verify(pk []byte, proof []byte, msg []byte) ([]byte, error) {
+	// var Y ge25519_p3
+	Y := &edwards25519.Point{}
+	// validate key
+	if _, err := Y.SetBytes(pk); err != nil {
+		return nil, err
+	}
+	isSmallOrder := (&edwards25519.Point{}).MultByCofactor(Y).Equal(edwards25519.NewIdentityPoint()) == 1
+	if isSmallOrder {
+		return nil, fmt.Errorf("expected key to have small order")
+	}
+	// vrf_verify
+	ok, err := vrf_verify(Y, proof, msg)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("issue verifying proof")
+	}
+	// proof to hash
+	return crypto_vrf_ietfdraft03_proof_to_hash(proof)
+}
+
+/* Utility function to convert a "secret key" (32-byte seed || 32-byte PK)
+ * into the public point Y, the private saclar x, and truncated hash of the
+ * seed to be used later in nonce generation.
+ * Return 0 on success, -1 on failure decoding the public point Y.
+ */
+func (sk VrfPrivkey) expand() (*edwards25519.Point, *edwards25519.Scalar, []byte, error) {
+	var tmp [64]byte
+	h := sha512.New()
+	h.Write(sk[:32])
+	hSum := h.Sum(nil)
+	copy(tmp[:], hSum[:64])
+	xScaler := edwards25519.NewScalar()
+	tmpBytes := make([]byte, 64)
+	copy(tmpBytes, tmp[:32])
+	xScaler.SetBytesWithClamping(tmp[:32])
+
+	truncatedHashedSKString := tmp[32:]
+	Y := edwards25519.NewIdentityPoint()
+	Y.SetBytes(sk[32:])
+	return Y, xScaler, truncatedHashedSKString, nil
+}
+
+func (sk VrfPrivkey) proveBytesGo(msg []byte) (proof VrfProof, ok bool) {
+
+	// inlined vrf_expand_sk
+	Y_point, x_scalar, truncated_hashed_sk_string, err := sk.expand()
+	if err != nil {
+		// TODO: this method should return an error.
+		// fmt.Println("issue expanding:", err)
+		return proof, false
+	}
+
+	proof, err = vrf_prove(Y_point, x_scalar, truncated_hashed_sk_string, msg)
+	if err != nil {
+		// TODO: this method should return an error.
+		// fmt.Println("issue proving:", err)
+		return proof, false
+	}
+
+	return proof, err == nil
+}
+
+/* Construct a proof for a message alpha per draft spec section 5.1.
+ * Takes in a secret scalar x, a public point Y, and a secret string
+ * truncated_hashed_sk that is used in nonce generation.
+ * These are computed from the secret key using the expand_sk function.
+ * Constant time in everything except alphalen (the length of the message)
+ */
+func vrf_prove(Y_point *edwards25519.Point, x_scalar *edwards25519.Scalar, trunc_hashed_sk []byte, alpha []byte) (VrfProof, error) {
+	var pi VrfProof
+	//var h_string, k_scalar, c_scalar []byte
+	//	var H_point, Gamma_point, kB_point, kH_point *edwards25519.Point
+
+	h_string, err := _vrf_ietfdraft03_hash_to_curve_elligator2_25519(Y_point, alpha)
+	if err != nil {
+		return VrfProof{}, err
+	}
+	//spew.Dump("x_scalar", x_scalar.Bytes())
+	H_point := edwards25519.NewIdentityPoint()
+	H_point.SetBytes(h_string)
+	// fmt.Printf("h string: %x\n", h_string)
+	// fmt.Printf("h poitn: %x\n", H_point.Bytes())
+	Gamma_point := edwards25519.NewIdentityPoint()
+	Gamma_point.ScalarMult(x_scalar, H_point)
+	//fmt.Println(h_string)
+
+	/*
+		vrf_nonce_generation(k_scalar, truncated_hashed_sk_string, h_string)
+		ge25519_scalarmult_base(&kB_point, k_scalar)      // compute k*B
+		ge25519_scalarmult(&kH_point, k_scalar, &H_point) // compute k*H
+	*/
+	k_scalar := vrf_nonce_generation(trunc_hashed_sk, H_point)
+	// fmt.Printf("g k_scalar: %x\n", k_scalar.Bytes())
+	// fmt.Printf("g h_point: %x\n", H_point.Bytes())
+	// fmt.Printf("g trunc_hash: %x\n", trunc_hashed_sk)
+	kB_point := edwards25519.NewIdentityPoint()
+	kB_point.ScalarBaseMult(k_scalar)
+	kH_point := edwards25519.NewIdentityPoint()
+	kH_point.ScalarMult(k_scalar, H_point)
+	// fmt.Printf("g kB_point: %x\n", kB_point.Bytes())
+	// fmt.Printf("g kH_point: %x\n", kH_point.Bytes())
+
+	c_scalar := _vrf_ietfdraft03_hash_points(H_point, Gamma_point, kB_point, kH_point)
+	// fmt.Printf("g c_scalar: %x\n", c_scalar)
+	s := edwards25519.NewScalar()
+	s.MultiplyAdd(c_scalar, x_scalar, k_scalar)
+
+	// output pi
+	copy(pi[:], Gamma_point.Bytes())
+	copy(pi[32:], c_scalar.Bytes()[:16])
+	copy(pi[48:], s.Bytes())
+	/*
+		// c = ECVRF_hash_points(h, gamma, k*B, k*H)
+		_vrf_ietfdraft03_hash_points(c_scalar, &H_point, &Gamma_point, &kB_point, &kH_point)
+		memset(c_scalar+16, 0, 16) // zero the remaining 16 bytes of c_scalar
+
+		// output pi
+		_vrf_ietfdraft03_point_to_string(pi, &Gamma_point)  // pi[0:32] = point_to_string(Gamma)
+		memmove(pi+32, c_scalar, 16)                        // pi[32:48] = c (16 bytes)
+		sc25519_muladd(pi+48, c_scalar, x_scalar, k_scalar) // pi[48:80] = s = c*x + k (mod q)
+	*/
+	return pi, nil
+}
+
+/* Hash a message to a curve point using Elligator2.
+ * Specified in VRF draft spec section 5.4.1.2.
+ * The actual elligator2 implementation is ge25519_from_uniform.
+ * Runtime depends only on alphalen (the message length)
+ */
+func _vrf_ietfdraft03_hash_to_curve_elligator2_25519(Y_point *edwards25519.Point, alpha []byte) ([]byte, error) {
+	hs := sha512.New()
+
+	hs.Write([]byte{vrfSuite})
+	hs.Write([]byte{1})
+	hs.Write(Y_point.Bytes())
+	hs.Write(alpha)
+	r_string := hs.Sum(nil)
+	r_string[31] &= 0x7f // clear sign bit
+
+	/*
+	   crypto_hash_sha512_state hs;
+	   unsigned char            Y_string[32], r_string[64];
+
+	   _vrf_ietfdraft03_point_to_string(Y_string, Y_point);
+
+	   // r = first 32 bytes of SHA512(suite || 0x01 || Y || alpha)
+	   crypto_hash_sha512_init(&hs);
+	   crypto_hash_sha512_update(&hs, &SUITE, 1);
+	   crypto_hash_sha512_update(&hs, &ONE, 1);
+	   crypto_hash_sha512_update(&hs, Y_string, 32);
+	   crypto_hash_sha512_update(&hs, alpha, alphalen);
+	   crypto_hash_sha512_final(&hs, r_string);
+
+	   r_string[31] &= 0x7f; // clear sign bit
+	   ge25519_from_uniform(H_string, r_string); // elligator2
+	*/
+	h, err := ge25519_from_uniform(r_string)
+	return h, err
+}
+
+// elligator2
+func ge25519_from_uniform(r []byte) ([]byte, error) {
+	s := make([]byte, 32)
+	var e, negx, rr2, x, x2, x3 *field.Element
+	var p3 *edwards25519.Point
+	var e_is_minus_1 int
+	var x_sign byte
+
+	copy(s, r)
+	x_sign = s[31] & 0x80
+	s[31] &= 0x7f
+	// fmt.Println("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+
+	rr2 = &field.Element{}
+	rr2.SetBytes(s) // fe25519_frombytes(rr2, s);
+
+	//rr2a := &field.Element{}.One().Mult32
+	// elligator
+	rr2.Square(rr2) // fe25519_sq2(rr2, rr2);
+	rr2.Add(rr2, rr2)
+	rr2Bytes := rr2.Bytes()
+	rr2Bytes[0]++
+	rr2.SetBytes(rr2Bytes) // rr2[0]++;
+	rr2.Invert(rr2)        // fe25519_invert(rr2, rr2);
+
+	x = &field.Element{}
+
+	const curve25519A = 486662
+	curve25519AElement := (&field.Element{}).One().Mult32((&field.Element{}).One(), curve25519A)
+
+	x.Mult32(rr2, curve25519A) // fe25519_mul(x, curve25519_A, rr2);
+	x.Negate(x)                // fe25519_neg(x, x);
+	// fmt.Printf("g rr2: %x\n", rr2.Bytes())
+
+	x2 = &field.Element{}
+	x2.Multiply(x, x) // fe25519_sq(x2, x);
+	x3 = &field.Element{}
+	x3.Multiply(x, x2) // fe25519_mul(x3, x, x2);
+
+	e = &field.Element{}
+	e.Add(x3, x)               // fe25519_add(e, x3, x);
+	x2.Mult32(x2, curve25519A) // fe25519_mul(x2, x2, curve25519_A);
+	e.Add(x2, e)               // fe25519_add(e, x2, e);
+
+	e = chi25519(e) // chi25519(e, e);
+	// fmt.Printf("g  e1: %x\n", e.Bytes())
+	s = e.Bytes() // fe25519_tobytes(s, e);
+
+	e_is_minus_1 = int(s[1] & 1) // e_is_minus_1 = s[1] & 1;
+	e_is_not_minus_1 := e_is_minus_1 ^ 1
+	negx = (&field.Element{}).Set(x)
+	negx.Negate(negx)                   // fe25519_neg(negx, x);
+	x.Select(x, negx, e_is_not_minus_1) // fe25519_cmov(x, negx, e_is_minus_1);
+	// fmt.Printf("x: %x\n", x.Bytes())
+	// fmt.Printf("negx: %x\n", x.Bytes())
+	x2.Zero() // fe25519_0(x2);
+	// fmt.Printf("curve: %x\n", curve25519AElement.Bytes())
+	// fmt.Printf("x2: %x\n", x2.Bytes())
+	// fmt.Printf("e_is_minus_1: %+v\n", e_is_minus_1)
+	x2.Select(x2, curve25519AElement, e_is_not_minus_1) // fe25519_cmov(x2, curve25519_A, e_is_minus_1);
+	x.Subtract(x, x2)                                   // fe25519_sub(x, x, x2);
+	// yed = (x-1)/(x+1)
+	{
+		var one, x_plus_one, x_plus_one_inv, x_minus_one, yed *field.Element
+		// fe25519 one;
+		// fe25519 x_plus_one;
+		// fe25519 x_plus_one_inv;
+		// fe25519 x_minus_one;
+		// fe25519 yed;
+
+		one = (&field.Element{}).One()                                 // fe25519_1(one);
+		x_plus_one = (&field.Element{}).Add(x, one)                    // fe25519_add(x_plus_one, x, one);
+		x_minus_one = (&field.Element{}).Subtract(x, one)              // fe25519_sub(x_minus_one, x, one);
+		x_plus_one_inv = (&field.Element{}).Invert(x_plus_one)         // fe25519_invert(x_plus_one_inv, x_plus_one);
+		yed = (&field.Element{}).Multiply(x_minus_one, x_plus_one_inv) // fe25519_mul(yed, x_minus_one, x_plus_one_inv);
+		s = yed.Bytes()                                                // fe25519_tobytes(s, yed);
+	}
+
+	// recover x
+	s[31] |= x_sign
+
+	p3 = &edwards25519.Point{}
+	_, err := p3.SetBytes(s) // ge25519_frombytes(&p3, s) != 0
+	if err != nil {
+		// fmt.Printf("issue setting bytes: %x - %v\n", s, err)
+		return nil, err
+	}
+
+	// // multiply by the cofactor
+	p3.MultByCofactor(p3)
+	// ge25519_p3_dbl(&p1, &p3);
+	// ge25519_p1p1_to_p2(&p2, &p1);
+	// ge25519_p2_dbl(&p1, &p2);
+	// ge25519_p1p1_to_p2(&p2, &p1);
+	// ge25519_p2_dbl(&p1, &p2);
+	// ge25519_p1p1_to_p3(&p3, &p1);
+
+	s = p3.Bytes() // ge25519_p3_tobytes(s, &p3);
+	// fmt.Printf("g elligator 2: %x\n", s)
+	return s, nil
+}
+
+func vrf_nonce_generation(trunc_hashed_sk []byte, H_point *edwards25519.Point) *edwards25519.Scalar {
+	result := edwards25519.NewScalar()
+
+	hs := sha512.New()
+	hs.Write(trunc_hashed_sk)
+	hs.Write(H_point.Bytes())
+	k_string := hs.Sum(nil)[:64]
+	result.SetUniformBytes(k_string)
+	// fmt.Printf("g k_string: %x\n", k_string)
+	// fmt.Printf("g k_string2: %x\n", result.Bytes())
+
+	return result
+}
+
+/* Subroutine specified in draft spec section 5.4.3.
+ * Hashes four points to a 16-byte string.
+ * Constant time. */
+func _vrf_ietfdraft03_hash_points(P1, P2, P3, P4 *edwards25519.Point) *edwards25519.Scalar {
+	result := make([]byte, 32)
+	var str [2 + (32 * 4)]byte
+
+	str[0] = vrfSuite
+	str[1] = 0x02
+	copy(str[2+(32*0):], P1.Bytes())
+	copy(str[2+(32*1):], P2.Bytes())
+	copy(str[2+(32*2):], P3.Bytes())
+	copy(str[2+(32*3):], P4.Bytes())
+	h := sha512.New()
+	//var c1 [32]byte
+	// fmt.Printf("gPN %x\n", P4.Bytes())
+	h.Write(str[:])
+	sum := h.Sum(nil)
+	// fmt.Printf("g sum %x\n", sum)
+
+	copy(result[:], sum[:16])
+	// sum := h.Sum(str[:])
+	// fmt.Println("sum:", sum)
+	// result.SetBytes(c1[:])
+	// result.SetBytes(c1[:])
+	/*
+	   unsigned char str[2r32*4], c1[64];
+
+	   str[0] = SUITE;
+	   str[1] = TWO;
+	   _vrf_ietfdraft03_point_to_string(str+2+32*0, P1);
+	   _vrf_ietfdraft03_point_to_string(str+2+32*1, P2);
+	   _vrf_ietfdraft03_point_to_string(str+2+32*2, P3);
+	   _vrf_ietfdraft03_point_to_string(str+2+32*3, P4);
+	   crypto_hash_sha512(c1, str, sizeof str);
+	   memmove(c, c1, 16);
+	   sodium_memzero(c1, 64);
+	*/
+	r := edwards25519.NewScalar()
+	r.SetCanonicalBytes(result)
+	return r
+
+}
+
+func chi25519(z *field.Element) *field.Element {
+	out := &field.Element{}
+	out.Set(z)
+
+	var t0, t1, t2, t3 *field.Element // fe25519 t0, t1, t2, t3;
+	var i int                         // int     i;
+
+	t0 = &field.Element{}
+	t1 = &field.Element{}
+	t2 = &field.Element{}
+	t3 = &field.Element{}
+
+	t0.Square(z)        // fe25519_sq(t0, z);
+	t1.Multiply(t0, z)  // fe25519_mul(t1, t0, z);
+	t0.Square(t1)       // fe25519_sq(t0, t1);
+	t2.Square(t0)       // fe25519_sq(t2, t0);
+	t2.Square(t2)       // fe25519_sq(t2, t2);
+	t2.Multiply(t2, t0) // fe25519_mul(t2, t2, t0);
+	t1.Multiply(t2, z)  // fe25519_mul(t1, t2, z);
+	t2.Square(t1)       // fe25519_sq(t2, t1);
+
+	for i = 1; i < 5; i++ {
+		t2.Square(t2) // fe25519_sq(t2, t2);
+	}
+	t1.Multiply(t2, t1) // fe25519_mul(t1, t2, t1);
+	t2.Square(t1)       // fe25519_sq(t2, t1);
+	for i = 1; i < 10; i++ {
+		t2.Square(t2) //     fe25519_sq(t2, t2);
+	}
+	t2.Multiply(t2, t1) // fe25519_mul(t2, t2, t1);
+	t3.Square(t2)       // fe25519_sq(t3, t2);
+	// fmt.Printf("g t2b: %x\n", t2.Bytes())
+	// fmt.Printf("g t3b: %x\n", t3.Bytes())
+	for i = 1; i < 20; i++ {
+		t3.Square(t3) //     fe25519_sq(t3, t3);
+	}
+	t2.Multiply(t3, t2) // fe25519_mul(t2, t3, t2);
+	t2.Square(t2)       // fe25519_sq(t2, t2);
+	for i = 1; i < 10; i++ {
+		t2.Square(t2) //     fe25519_sq(t2, t2);
+	}
+	t1.Multiply(t2, t1) // fe25519_mul(t1, t2, t1);
+	t2.Square(t1)       // fe25519_sq(t2, t1);
+	// fmt.Printf("g t2c: %x\n", t2.Bytes())
+	// fmt.Printf("g t3c: %x\n", t3.Bytes())
+	// fmt.Printf("g t1 50: %x\n", t1.Bytes())
+	// fmt.Printf("g t2 50: %x\n", t2.Bytes())
+	// fmt.Printf("g t3 50: %x\n", t3.Bytes())
+
+	for i = 1; i < 50; i++ {
+		t2.Square(t2) //     fe25519_sq(t2, t2);
+	}
+	t2.Multiply(t2, t1) // fe25519_mul(t2, t2, t1);
+	t3.Square(t2)       // fe25519_sq(t3, t2);
+	for i = 1; i < 100; i++ {
+		t3.Square(t3) //     fe25519_sq(t3, t3);
+	}
+	t2.Multiply(t3, t2) // fe25519_mul(t2, t3, t2);
+	t2.Square(t2)       // fe25519_sq(t2, t2);
+	for i = 1; i < 50; i++ {
+		t2.Square(t2) //     fe25519_sq(t2, t2);
+	}
+	t1.Multiply(t2, t1) // fe25519_mul(t1, t2, t1);
+	t1.Square(t1)       // fe25519_sq(t1, t1);
+	for i = 1; i < 4; i++ {
+		t1.Square(t1) //     fe25519_sq(t1, t1);
+	}
+	out.Multiply(t1, t0) // fe25519_mul(out, t1, t0);
+
+	return out
+}
+
+/* Verify a proof per draft section 5.3.
+ * We assume Y_point has passed public key validation already.
+ * Assuming verification succeeds, runtime does not depend on the message alpha
+ * (but does depend on its length alphalen)
+ */
+func vrf_verify(Y *edwards25519.Point, pi []byte, alpha []byte) (bool, error) {
+	// // Note: c fits in 16 bytes, but ge25519_scalarmult expects a 32-byte scalar.
+	//  // Similarly, s_scalar fits in 32 bytes but sc25519_reduce takes in 64 bytes.
+	// unsigned char h_string[32], c_scalar[32], s_scalar[64], cprime[16];
+
+	var H_point, U_point, V_point *edwards25519.Point // ge25519_p3     H_point, Gamma_point, U_point, V_point, tmp_p3_point;
+	var tmp1, tmp2 *edwards25519.Point
+	// ge25519_p1p1   tmp_p1p1_point;
+	// ge25519_cached tmp_cached_point;
+
+	Gamma_point, c_scalar, s_scalar, err := _vrf_ietfdraft03_decode_proof(pi) // _vrf_ietfdraft03_decode_proof(&Gamma_point, c_scalar, s_scalar, pi) != 0
+
+	// // vrf_decode_proof writes to the first 16 bytes of c_scalar; we zero the
+	// // second 16 bytes ourselves, as ge25519_scalarmult expects a 32-byte scalar.
+	// memset(c_scalar+16, 0, 16);
+
+	// // vrf_decode_proof sets only the first 32 bytes of s_scalar; we zero the
+	// // second 32 bytes ourselves, as sc25519_reduce expects a 64-byte scalar.
+	// // Reducing the scalar s mod q ensures the high order bit of s is 0, which
+	// // ref10's scalarmult functions require.
+	// memset(s_scalar+32, 0, 32);
+	// sc25519_reduce(s_scalar);
+
+	_ = s_scalar // TODO
+
+	h_string, err := _vrf_ietfdraft03_hash_to_curve_elligator2_25519(Y, alpha)
+	if err != nil {
+		return false, err
+	}
+	H_point = &edwards25519.Point{}
+	H_point.SetBytes(h_string[:]) // ge25519_frombytes(&H_point, h_string);
+
+	// // calculate U = s*B - c*Y
+	tmp1 = &edwards25519.Point{}
+	// SetBytes needs 32 bytes while c_scalar is only 16 bytes long.
+	c_scalar_bytes := make([]byte, 64)
+	copy(c_scalar_bytes, c_scalar)
+	c := edwards25519.NewScalar()
+	c.SetUniformBytes(c_scalar_bytes)
+	tmp1.ScalarMult(c, Y)
+	tmp2 = (&edwards25519.Point{}).Set(tmp1)
+	s := edwards25519.NewScalar()
+	s_scalar_bytes := make([]byte, 64)
+	copy(s_scalar_bytes, s_scalar)
+	s.SetUniformBytes(s_scalar_bytes)
+	tmp1.ScalarBaseMult(s)
+	U_point = &edwards25519.Point{}
+	U_point.Subtract(tmp1, tmp2)
+
+	// // calculate V = s*H -  c*Gamma
+	tmp1 = &edwards25519.Point{}
+	tmp1.ScalarMult(s, H_point)
+	tmp2 = &edwards25519.Point{}
+	tmp2.ScalarMult(c, Gamma_point)
+	V_point = &edwards25519.Point{}
+	V_point.Subtract(tmp1, tmp2)
+
+	cprime := _vrf_ietfdraft03_hash_points(H_point, Gamma_point, U_point, V_point) // _vrf_ietfdraft03_hash_points(cprime, &H_point, &Gamma_point, &U_point, &V_point);
+
+	cmp := subtle.ConstantTimeCompare(c_scalar[:], cprime.Bytes()) // return crypto_verify_16(c_scalar, cprime);
+	return cmp == 1, nil
+}
+
+/* Convert a VRF proof pi into a VRF output hash beta per draft spec section 5.2.
+ * This function does not verify the proof! For an untrusted proof, instead call
+ * crypto_vrf_ietfdraft03_verify, which will output the hash if verification
+ * succeeds.
+ */
+func crypto_vrf_ietfdraft03_proof_to_hash(pi []byte) ([]byte, error) {
+	var hash_input [34]byte // unsigned char hash_input[2+32];
+	Gamma_point, _, _, err := _vrf_ietfdraft03_decode_proof(pi)
+	if err != nil {
+		return nil, err
+	}
+	// beta_string = Hash(suite_string || three_string || point_to_string(cofactor * Gamma))
+	hash_input[0] = vrfSuite
+	hash_input[1] = 0x03
+	Gamma_point.MultByCofactor(Gamma_point)
+	copy(hash_input[2:], Gamma_point.Bytes())
+	h := sha512.New()
+	h.Write(hash_input[:])
+	return h.Sum(nil), nil
+}
+
+/* Decode an 80-byte proof pi into a point gamma, a 16-byte scalar c, and a
+ * 32-byte scalar s, as specified in IETF draft section 5.4.4.
+ * Returns 0 on success, nonzero on failure.
+ */
+func _vrf_ietfdraft03_decode_proof(pi []byte) (gamma *edwards25519.Point, c []byte, s []byte, err error) {
+	if len(pi) != 80 {
+		return nil, nil, nil, fmt.Errorf("unexpected length of pi (must be 80)")
+	}
+	/* gamma = decode_point(pi[0:32]) */
+	gamma = &edwards25519.Point{}
+	gamma.SetBytes(pi[:32])
+	c = make([]byte, 32)
+	s = make([]byte, 32)
+	copy(c[:], pi[32:48]) // c = pi[32:48]
+	copy(s[:], pi[48:80]) // s = pi[48:80]
+	return gamma, c, s, nil
+}

--- a/crypto/vrf_go.go
+++ b/crypto/vrf_go.go
@@ -372,7 +372,7 @@ func chi25519(z *field.Element) *field.Element {
 /* Verify a proof per draft section 5.3.
  * We assume Y_point has passed public key validation already.
  * Assuming verification succeeds, runtime does not depend on the message alpha
- * (but does depend on its length alphalen)
+ * (but does depend on its length)
  */
 func vrfVerify(Y *edwards25519.Point, pi []byte, alpha []byte) (bool, error) {
 	var U, V *edwards25519.Point // ge25519_p3     H_point, Gamma_point, U_point, V_point, tmp_p3_point;
@@ -420,8 +420,7 @@ func vrfVerify(Y *edwards25519.Point, pi []byte, alpha []byte) (bool, error) {
 
 /* Convert a VRF proof pi into a VRF output hash beta per draft spec section 5.2.
  * This function does not verify the proof! For an untrusted proof, instead call
- * crypto_vrf_ietfdraft03_verify, which will output the hash if verification
- * succeeds.
+ * vrfVerifyAndHash, which will output the hash if verification succeeds.
  */
 func cryptoVrfIetfdraft03ProofToHash(pi []byte) ([]byte, error) {
 	var hashInput [34]byte // unsigned char hash_input[2+32];
@@ -441,7 +440,6 @@ func cryptoVrfIetfdraft03ProofToHash(pi []byte) ([]byte, error) {
 
 /* Decode an 80-byte proof pi into a point gamma, a 16-byte scalar c, and a
  * 32-byte scalar s, as specified in IETF draft section 5.4.4.
- * Returns 0 on success, nonzero on failure.
  */
 func vrfIetfdraft03DecodeProof(pi []byte) (gamma *edwards25519.Point, c []byte, s []byte, err error) {
 	if len(pi) != 80 {

--- a/crypto/vrf_go_comparisons_test.go
+++ b/crypto/vrf_go_comparisons_test.go
@@ -1,0 +1,60 @@
+package crypto
+
+import (
+	"bytes"
+	"flag"
+	mathrand "math/rand"
+	"testing"
+)
+
+var (
+	flagRunPureGoComparisonsTests  = flag.Bool("purego-compare", false, "If enabled, run comparison tests between C and pure Go VRF implementations.")
+	flagRunPureGoComparisonsTestsN = flag.Int("purego-compare-iterations", 10000, "Specifies the number of iterations to perform.")
+	flagRunPureGoComparisonsSeed   = flag.Int("purego-compare-seed", 42, "Specifies the random number generator seed for the comparison tests.")
+)
+
+func TestPureGoImplementationComparison(t *testing.T) {
+	if !*flagRunPureGoComparisonsTests {
+		t.Skip("skipping pure go comparison tests since -purego-compare flag is not supplied")
+	}
+	N := *flagRunPureGoComparisonsTestsN
+	t.Log("running with", N, "iterations with seed of", *flagRunPureGoComparisonsSeed)
+	pks := make([]VrfPubkey, N)
+	sks := make([]VrfPrivkey, N)
+	strs := make([][]byte, N)
+	proofs := make([]VrfProof, N)
+	randSource := mathrand.New(mathrand.NewSource(int64(*flagRunPureGoComparisonsSeed)))
+
+	for i := 0; i < N; i++ {
+		pks[i], sks[i] = VrfKeygen()
+		strs[i] = make([]byte, 100)
+		_, err := randSource.Read(strs[i])
+		if err != nil {
+			panic(err)
+		}
+	}
+	t.Log("done generating keys")
+
+	for i := 0; i < N; i++ {
+		var ok bool
+		proofs[i], ok = sks[i].proveBytes(strs[i])
+		goProof, goOk := sks[i].proveBytesGo(strs[i])
+
+		if i > 0 && i%(N/10) == 0 {
+			t.Logf("%v/%v", i, N)
+		}
+
+		if ok != goOk {
+			t.Errorf("non-matching results: %d sk:%x pk:%x str:%x %v %v\n", i, sks[i][:32], pks[i], strs[i], ok, goOk)
+		}
+		if bytes.Compare(proofs[i][:], goProof[:]) != 0 {
+			t.Errorf("non-matching results: %x %x %x\n", strs[i], proofs[i], goProof)
+		}
+		// compare verify outputs
+		_, cVerify := pks[i].verifyBytes(proofs[i], strs[i])
+		_, goVerify := pks[i].verifyBytes(proofs[i], strs[i])
+		if cVerify != goVerify {
+			t.Errorf("non-matching verify results.")
+		}
+	}
+}

--- a/crypto/vrf_go_comparisons_test.go
+++ b/crypto/vrf_go_comparisons_test.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package crypto
 
 import (

--- a/crypto/vrf_go_test.go
+++ b/crypto/vrf_go_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // ECVRF-ED25519-SHA512-Elligator2 test vectors from: https://www.ietf.org/id/draft-irtf-cfrg-vrf-03.txt appendix A.4
-func TestVRFTestVectorsGo(t *testing.T) {
+func TestPureGoVRFTestVectors(t *testing.T) {
 	testVectorGo(t,
 		"9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60", //sk
 		"d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a", //pk
@@ -241,4 +241,22 @@ func TestPureGoVrfVerify(t *testing.T) {
 		fmt.Printf("pgo: %x\n", out)
 		t.Error("go and cgo implementations differ:", ok, cgoOk)
 	}
+}
+
+// Test additional vectors to ensure the c and go implementations match.
+func TestPureGoAdditionalVectors(t *testing.T) {
+	testVector(t,
+		"879a0117c5a21784c1842b94c2ebfe24396ec1dae09374a8eacc5971ed8dba2d", //sk
+		"600d940760d4688c135d2e9137c8f2300f6497d9c3db527cbe4bcc1d49097fef", //pk
+		"1673af80c55179bc43dc5547a2f61d6f4081164c65ded70e0ff0749088d487976e3a815c40211cd1a764140396b8edae30698a57b301e04d6756d1a1665a3d1445641e33eb5b3985aa047ef8bdec648c2acb9f4413ddea17dc86d923e472259e3f3f797d", // alpha
+		"c70ab42559dc6bfc66c14c07fd2c075d9049968845521b4211ff33cdfb2617e29c32f265750bd76c5f625d5202d11375778c6ec43c4af86924c63b367f637bf4df2df39db504e053faffc09ac773f20d",                                         // pi
+		"4dff4bc2a74f34073e963c7e266fc6532780834a41a17200d476f80aa3829fa796f8be0ef1dc2f9a02884e4f10a08a717e2859f4f8e57d7ab9cd9a7c1366cf2b",                                                                         // beta
+	)
+	testVectorGo(t,
+		"879a0117c5a21784c1842b94c2ebfe24396ec1dae09374a8eacc5971ed8dba2d", //sk
+		"600d940760d4688c135d2e9137c8f2300f6497d9c3db527cbe4bcc1d49097fef", //pk
+		"1673af80c55179bc43dc5547a2f61d6f4081164c65ded70e0ff0749088d487976e3a815c40211cd1a764140396b8edae30698a57b301e04d6756d1a1665a3d1445641e33eb5b3985aa047ef8bdec648c2acb9f4413ddea17dc86d923e472259e3f3f797d", // alpha
+		"c70ab42559dc6bfc66c14c07fd2c075d9049968845521b4211ff33cdfb2617e29c32f265750bd76c5f625d5202d11375778c6ec43c4af86924c63b367f637bf4df2df39db504e053faffc09ac773f20d",                                         // pi
+		"4dff4bc2a74f34073e963c7e266fc6532780834a41a17200d476f80aa3829fa796f8be0ef1dc2f9a02884e4f10a08a717e2859f4f8e57d7ab9cd9a7c1366cf2b",                                                                         // beta
+	)
 }

--- a/crypto/vrf_go_test.go
+++ b/crypto/vrf_go_test.go
@@ -91,18 +91,11 @@ func BenchmarkVrfVerifyGo(b *testing.B) {
 	strs := make([][]byte, b.N)
 	proofs := make([]VrfProof, b.N)
 	for i := 0; i < b.N; i++ {
-		validPoint := false
-		var sk VrfPrivkey
-		for !validPoint {
-			pks[i], sk = VrfKeygen()
-			strs[i] = make([]byte, 100)
-			_, err := rand.Read(strs[i])
-			if err != nil {
-				panic(err)
-			}
-			var ok bool
-			proofs[i], ok = sk.proveBytesGo(strs[i])
-			validPoint = ok == true
+		pks[i], _ = VrfKeygen()
+		strs[i] = make([]byte, 100)
+		_, err := rand.Read(strs[i])
+		if err != nil {
+			panic(err)
 		}
 	}
 

--- a/crypto/vrf_go_test.go
+++ b/crypto/vrf_go_test.go
@@ -1,0 +1,251 @@
+// Copyright (C) 2019-2021 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package crypto
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	mathrand "math/rand"
+	"testing"
+)
+
+// ECVRF-ED25519-SHA512-Elligator2 test vectors from: https://www.ietf.org/id/draft-irtf-cfrg-vrf-03.txt appendix A.4
+func TestVRFTestVectorsGo(t *testing.T) {
+	testVectorGo(t,
+		"9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60", //sk
+		"d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a", //pk
+		"", // alpha
+		"b6b4699f87d56126c9117a7da55bd0085246f4c56dbc95d20172612e9d38e8d7ca65e573a126ed88d4e30a46f80a666854d675cf3ba81de0de043c3774f061560f55edc256a787afe701677c0f602900", // pi
+		"5b49b554d05c0cd5a5325376b3387de59d924fd1e13ded44648ab33c21349a603f25b84ec5ed887995b33da5e3bfcb87cd2f64521c4c62cf825cffabbe5d31cc",                                 // beta
+	)
+
+	testVectorGo(t,
+		"4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb", //sk
+		"3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c", //pk
+		"72", // alpha
+		"ae5b66bdf04b4c010bfe32b2fc126ead2107b697634f6f7337b9bff8785ee111200095ece87dde4dbe87343f6df3b107d91798c8a7eb1245d3bb9c5aafb093358c13e6ae1111a55717e895fd15f99f07", // pi
+		"94f4487e1b2fec954309ef1289ecb2e15043a2461ecc7b2ae7d4470607ef82eb1cfa97d84991fe4a7bfdfd715606bc27e2967a6c557cfb5875879b671740b7d8",                                 // beta
+	)
+}
+
+func testVectorGo(t *testing.T, skHex, pkHex, alphaHex, piHex, betaHex string) {
+	t.Helper()
+	var seed [32]byte
+	// our "secret keys" are 64 bytes: the spec's 32-byte "secret keys" (which we call the "seed") followed by the 32-byte precomputed public key
+	// so the 32-byte "SK" in the test vectors is not directly decoded into a VrfPrivkey, it instead has to go through VrfKeypairFromSeed()
+
+	var pk VrfPubkey
+	var alpha []byte
+	var pi VrfProof
+	var beta VrfOutput
+
+	// Decode hex
+	mustDecode(t, seed[:], skHex)
+	mustDecode(t, pk[:], pkHex)
+	mustDecode(t, pi[:], piHex)
+	mustDecode(t, beta[:], betaHex)
+	// alpha is variable-length
+	alpha = make([]byte, hex.DecodedLen(len(alphaHex)))
+	mustDecode(t, alpha, alphaHex)
+
+	pkTest, sk := VrfKeygenFromSeedGo(seed)
+	if pkTest != pk {
+		t.Errorf("Computed public key does not match the test vector")
+	}
+
+	piTest, ok := sk.proveBytesGo(alpha)
+	if !ok {
+		t.Errorf("Failed to produce a proof")
+	}
+	if piTest != pi {
+		t.Errorf("Proof produced by Prove() does not match the test vector")
+	}
+
+	ok, betaTest := pk.verifyBytesGo(pi, alpha)
+	if !ok {
+		t.Errorf("Verify() fails on proof from the test vector")
+	}
+	if betaTest != beta {
+		t.Errorf("VRF output does not match test vector:\n%x\n%x\n", beta, betaTest)
+	}
+}
+
+func BenchmarkVrfVerifyGo(b *testing.B) {
+	pks := make([]VrfPubkey, b.N)
+	strs := make([][]byte, b.N)
+	proofs := make([]VrfProof, b.N)
+	for i := 0; i < b.N; i++ {
+		validPoint := false
+		var sk VrfPrivkey
+		for !validPoint {
+			pks[i], sk = VrfKeygen()
+			strs[i] = make([]byte, 100)
+			_, err := rand.Read(strs[i])
+			if err != nil {
+				panic(err)
+			}
+			var ok bool
+			proofs[i], ok = sk.proveBytesGo(strs[i])
+			validPoint = ok == true
+		}
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = pks[i].verifyBytesGo(proofs[i], strs[i])
+	}
+}
+
+func BenchmarkProveBytes(b *testing.B) {
+	var keySeed [32]byte
+	sks := make([]VrfPrivkey, b.N)
+	strs := make([][]byte, b.N)
+	for i := 0; i < b.N; i++ {
+		_, err := rand.Read(keySeed[:])
+		if err != nil {
+			panic(err)
+		}
+		_, sks[i] = VrfKeygenFromSeed(keySeed)
+		strs[i] = make([]byte, 100)
+		_, err = rand.Read(strs[i])
+		if err != nil {
+			panic(err)
+		}
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sks[i].proveBytes(strs[i])
+	}
+}
+
+func BenchmarkProveBytesGo(b *testing.B) {
+	var keySeed [32]byte
+	sks := make([]VrfPrivkey, b.N)
+	strs := make([][]byte, b.N)
+	for i := 0; i < b.N; i++ {
+		_, err := rand.Read(keySeed[:])
+		if err != nil {
+			panic(err)
+		}
+		_, sks[i] = VrfKeygenFromSeed(keySeed)
+		strs[i] = make([]byte, 100)
+		_, err = rand.Read(strs[i])
+		if err != nil {
+			panic(err)
+		}
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sks[i].proveBytesGo(strs[i])
+	}
+}
+
+func TestPureGoVrfKeygenFromSeed(t *testing.T) {
+	var keySeed [32]byte
+	rand.Read(keySeed[:])
+	pk1, sk1 := VrfKeygenFromSeed(keySeed)
+	pk2, sk2 := VrfKeygenFromSeedGo(keySeed)
+
+	if fmt.Sprint(sk1) != fmt.Sprint(sk2) {
+		t.Logf("sk1 %x\n", sk1)
+		t.Logf("sk2 %x\n", sk2)
+		t.Errorf("sks did not match:%v\n%v", sk1, sk2)
+	}
+	if fmt.Sprint(pk1) != fmt.Sprint(pk2) {
+		t.Logf("pk1 %x\n", pk1)
+		t.Logf("pk2 %x\n", pk2)
+		t.Errorf("pks did not match:%v\n%v", pk1, pk2)
+	}
+}
+
+func TestPureGoProveBytes(t *testing.T) {
+	var sk VrfPrivkey
+	var str []byte
+
+	randSource := mathrand.New(mathrand.NewSource(42))
+
+	var keySeed [32]byte
+	copy(keySeed[:], []byte("abcdefghijklmnopqrstuvwxyzfoobars"))
+	_, sk = VrfKeygenFromSeed(keySeed)
+	str = make([]byte, 100)
+	_, err := randSource.Read(str)
+	if err != nil {
+		panic(err)
+	}
+
+	proof1, ok1 := sk.proveBytes(str)
+	if !ok1 {
+		panic("Failed to construct VRF proof")
+	}
+	proof2, ok2 := sk.proveBytesGo(str)
+	if !ok2 {
+		panic("Failed to construct VRF proof")
+	}
+	if fmt.Sprint(proof1) != fmt.Sprint(proof2) {
+		t.Logf("proof1 %x\n", proof1)
+		t.Logf("proof2 %x\n", proof2)
+		t.Errorf("proofs did not match:%v\n%v", proof1, proof2)
+	}
+}
+
+func TestPureGoVrfVerify(t *testing.T) {
+	var pk VrfPubkey
+	var sk VrfPrivkey
+	var keySeed [32]byte
+	var alpha []byte
+
+	// randSource := mathrand.New(mathrand.NewSource(42))
+	// copy(keySeed[:], []byte("abcdefghijklmnopqrstuvwxyzfoobars"))
+	skHex := "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60"
+	pkHex := "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+	alphaHex := ""
+
+	mustDecode(t, keySeed[:], skHex)
+	mustDecode(t, pk[:], pkHex)
+	// alpha is variable-length
+	alpha = make([]byte, hex.DecodedLen(len(alphaHex)))
+	mustDecode(t, alpha, alphaHex)
+
+	pk, sk = VrfKeygenFromSeedGo(keySeed)
+	cgoProof, ok := sk.proveBytes(alpha)
+	if !ok {
+		panic("Failed to construct VRF proof")
+	}
+	cgoOk, cgoOut := pk.verifyBytes(cgoProof, alpha)
+
+	proof, ok := sk.proveBytesGo(alpha)
+	if !ok {
+		panic("Failed to construct VRF proof")
+	}
+	ok, out := pk.verifyBytesGo(proof, alpha)
+	if cgoOk != ok {
+		fmt.Println(cgoOk, ok)
+		fmt.Printf("cgo: %x\n", cgoOut)
+		fmt.Printf("pgo: %x\n", out)
+		t.Error("go and cgo implementations differ:", ok, cgoOk)
+	}
+	if bytes.Compare(cgoOut[:], out[:]) != 0 {
+		fmt.Printf("cgo: %x\n", cgoOut)
+		fmt.Printf("pgo: %x\n", out)
+		t.Error("go and cgo implementations differ:", ok, cgoOk)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/algorand/go-algorand
 go 1.20
 
 require (
+	filippo.io/edwards25519 v1.0.0
 	github.com/DataDog/zstd v1.5.2
 	github.com/algorand/avm-abi v0.2.0
 	github.com/algorand/falcon v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBrvjyP0v+ecvNYvCpyZgu5/xkfAUhi6wJj28eUfSU=
 dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1:a1inKt/atXimZ4Mv927x+r7UpyzRUf4emIoiiSC2TN4=
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
+filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
+filippo.io/edwards25519 v1.0.0/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=


### PR DESCRIPTION
## Summary

This proposes a pure Go implementation of the VRF (Verifiable Random Functions) primitives used in Algorand.

The goal of this change is to demonstrate the viability of a pure Go implementation of the VRF primitives in Algorand.

It goes without saying that any change to the cryptographic primitives in a project must undergo significant scrutiny. I intend this changeset to be a kicking off point for further discussion.

To most closely match the existing libsodium implementation there are a few design decisions that may differ in a final implementation (better error value propagation in particular). 

## Test Plan

Included in this PR are a number of unit tests and benchmarks that compare the output of the two implementations.

This additional [test case](https://github.com/tmc/go-algorand/blob/purego-vrf-additional-tests/crypto/vrf_go_comparisons_test.go#L11) provides wide value coverage in terms of inputs to build confidence in the accuracy of the Go implementation.

## Initial Performance Testing Results

```shell
$ benchstat results
name            time/op
ProveBytes-2    283µs ± 3%
ProveBytesGo-2  257µs ± 0%
VrfVerify-2     345µs ± 1%
VrfVerifyGo-2   333µs ± 1%
```

These results were compiled from many runs on a GCE e2-medium (2 vCPUs, 4 GB memory) which reports as: `cpu: Intel(R) Xeon(R) CPU @ 2.30GHz`

Raw benchmark results are available [here](https://gist.github.com/tmc/f1364bcee04d1192278dd2f297cf116f).

My initial interpretation of these results is that it is viable from a performance perspective to implement the core VRF algorithms in pure Go. Having this implemented directly in Go carries a number of benefits, some of which are highlighted in #2131 

I'd like feedback from the core team on this proposed change and we can map out what a reasonable pathway regarding further testing and eventual inclusion might be.

I want to thank and acknowledge @FiloSottile for guidance in using the edwards25519 package.