### PR TITLE
ledger: allow trackers to fail on newBlock

### DIFF
--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -220,7 +220,7 @@ func (ao *onlineAccounts) checkBlock(blk bookkeeping.Block, delta ledgercore.Sta
 	rnd := blk.Round()
 	ao.accountsMu.Lock()
 	defer ao.accountsMu.Unlock()
-	if rnd != ao.latest()+1 {
+	if rnd > ao.latest() && rnd != ao.latest()+1 {
 		return fmt.Errorf("onlineAccounts: checkBlock %d too far in the future, dbRound %d, deltas %d", rnd, ao.cachedDBRoundOnline, len(ao.deltas))
 	}
 	return nil

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -767,7 +767,7 @@ func (au *accountUpdates) consecutiveVersion(offset uint64) uint64 {
 	return offset
 }
 
-// checkBlock is the onlineAccounts implementation of the ledgerTracker interface.
+// checkBlock is the accountUpdates implementation of the ledgerTracker interface.
 func (au *accountUpdates) checkBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) error {
 	rnd := blk.Round()
 	au.accountsMu.Lock()

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -772,7 +772,7 @@ func (au *accountUpdates) checkBlock(blk bookkeeping.Block, delta ledgercore.Sta
 	rnd := blk.Round()
 	au.accountsMu.Lock()
 	defer au.accountsMu.Unlock()
-	if rnd != au.latest()+1 {
+	if rnd > au.latest() && rnd != au.latest()+1 {
 		return fmt.Errorf("accountUpdates: checkBlock %d too far in the future, dbRound %d, deltas %d", rnd, au.cachedDBRound, len(au.deltas))
 	}
 	return nil

--- a/ledger/bulletin.go
+++ b/ledger/bulletin.go
@@ -89,6 +89,10 @@ func (b *bulletin) loadFromDisk(l ledgerForTracker, _ basics.Round) error {
 func (b *bulletin) close() {
 }
 
+func (b *bulletin) checkBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) error {
+	return nil
+}
+
 func (b *bulletin) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {
 }
 

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -365,6 +365,11 @@ func (ct *catchpointTracker) loadFromDisk(l ledgerForTracker, dbRound basics.Rou
 	return ct.recoverFromCrash(dbRound)
 }
 
+// checkBlock is the onlineAccounts implementation of the ledgerTracker interface.
+func (ct *catchpointTracker) checkBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) error {
+	return nil
+}
+
 // newBlock informs the tracker of a new block from round
 // rnd and a given ledgercore.StateDelta as produced by BlockEvaluator.
 func (ct *catchpointTracker) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -365,7 +365,7 @@ func (ct *catchpointTracker) loadFromDisk(l ledgerForTracker, dbRound basics.Rou
 	return ct.recoverFromCrash(dbRound)
 }
 
-// checkBlock is the onlineAccounts implementation of the ledgerTracker interface.
+// checkBlock is the catchpointTracker implementation of the ledgerTracker interface.
 func (ct *catchpointTracker) checkBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) error {
 	return nil
 }

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -654,6 +654,11 @@ func (bt *blockingTracker) loadFromDisk(ledgerForTracker, basics.Round) error {
 	return nil
 }
 
+// checkBlock is not implemented in the blockingTracker.
+func (bt *blockingTracker) checkBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) error {
+	return nil
+}
+
 // newBlock is not implemented in the blockingTracker.
 func (bt *blockingTracker) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {
 }

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -719,7 +719,10 @@ func (l *Ledger) AddValidatedBlock(vb ledgercore.ValidatedBlock, cert agreement.
 		return err
 	}
 	l.headerCache.put(blk.BlockHeader)
-	l.trackers.newBlock(blk, vb.Delta())
+	err = l.trackers.newBlock(blk, vb.Delta())
+	if err != nil {
+		return err
+	}
 	l.log.Debugf("ledger.AddValidatedBlock: added blk %d", blk.Round())
 	return nil
 }

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -54,6 +54,10 @@ func (mt *metricsTracker) close() {
 	}
 }
 
+func (mt *metricsTracker) checkBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) error {
+	return nil
+}
+
 func (mt *metricsTracker) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {
 	rnd := blk.Round()
 	mt.ledgerRound.Set(uint64(rnd))

--- a/ledger/notifier.go
+++ b/ledger/notifier.go
@@ -98,6 +98,10 @@ func (bn *blockNotifier) register(listeners []ledgercore.BlockListener) {
 	bn.listeners = append(bn.listeners, listeners...)
 }
 
+func (bn *blockNotifier) checkBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) error {
+	return nil
+}
+
 func (bn *blockNotifier) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {
 	bn.mu.Lock()
 	defer bn.mu.Unlock()

--- a/ledger/spverificationtracker_test.go
+++ b/ledger/spverificationtracker_test.go
@@ -463,7 +463,8 @@ func TestStateProofVerificationTracker_PanicInvalidBlockInsertion(t *testing.T) 
 		defaultStateProofInterval, true)
 
 	pastBlock := randomBlock(0)
-	a.Panics(func() { spt.appendCommitContext(&pastBlock.block) })
+	pastBlock.block.CurrentProtocol = protocol.ConsensusFuture
+	a.Error(spt.checkBlock(pastBlock.block, ledgercore.StateDelta{}))
 }
 
 func TestStateProofVerificationTracker_lastLookupContextUpdatedAfterLookup(t *testing.T) {

--- a/ledger/spverificationtracker_test.go
+++ b/ledger/spverificationtracker_test.go
@@ -450,7 +450,7 @@ func TestStateProofVerificationTracker_LookupVerificationContext(t *testing.T) {
 	a.ErrorContains(err, "memory lookup failed")
 }
 
-func TestStateProofVerificationTracker_PanicInvalidBlockInsertion(t *testing.T) {
+func TestStateProofVerificationTracker_ErrorInvalidBlockInsertion(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	a := require.New(t)
 

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -68,9 +68,10 @@ type ledgerTracker interface {
 	// current accounts storage round number.
 	loadFromDisk(ledgerForTracker, basics.Round) error
 
-	// checkBlock checks if the tracker can accept a new block and return an error if it can't.
-	// A purpose of this method is to operations that can potentially fail in newBlock flow
-	// but do not require to rollback all the trackers if say 5th fail. So check first and apply after.
+	// checkBlock checks if the tracker can accept a new block and returns an error if it can't.
+	// The purpose of checkBlock is to ask all the trackers if they already know they are going to fail newBlock
+	// based on the provided deltas and block.  This allows us to entirely skip the newBlock call to all of the trackers
+	// and thus not have to worry about rolling back any of the earlier tracker state.
 	// This method must be called under the same lock as newBlock.
 	checkBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) error
 

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -705,7 +705,10 @@ func (tr *trackerRegistry) replay(l ledgerForTracker) (err error) {
 			err = fmt.Errorf("trackerRegistry.replay: trackerEvalVerified failed : %w", err)
 			return
 		}
-		tr.newBlock(blk, delta)
+		err = tr.newBlock(blk, delta)
+		if err != nil {
+			return
+		}
 
 		// flush to disk if any of the following applies:
 		// 1. if we have loaded up more than initializeCachesRoundFlushInterval rounds since the last time we flushed the data to disk

--- a/ledger/tracker_test.go
+++ b/ledger/tracker_test.go
@@ -154,6 +154,11 @@ func (bt *producePrepareBlockingTracker) loadFromDisk(ledgerForTracker, basics.R
 	return nil
 }
 
+// checkBlock is not implemented in the blockingTracker.
+func (bt *producePrepareBlockingTracker) checkBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) error {
+	return nil
+}
+
 // newBlock is not implemented in the blockingTracker.
 func (bt *producePrepareBlockingTracker) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {
 }

--- a/ledger/txtail.go
+++ b/ledger/txtail.go
@@ -188,6 +188,10 @@ func (t *txTail) loadFromDisk(l ledgerForTracker, dbRound basics.Round) error {
 func (t *txTail) close() {
 }
 
+func (t *txTail) checkBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) error {
+	return nil
+}
+
 func (t *txTail) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {
 	rnd := blk.Round()
 


### PR DESCRIPTION
## Summary

Introduce new `checkBlock` function in ledgerTracker interface in order to allow failures from `newBlock` to be propagated to the caller. A problem here is `newBlock` modifies state and any of trackers might fail to apply that block, so either state revert or pre-check is needed so pre-check approach is implemented.

## Test Plan

Added `checkBlock` unit test.
