### PR TITLE
txngroup-deltas: Fix pointer bug copying deltas for txngroups

### DIFF
--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -2077,7 +2077,7 @@ func TestDeltasForTxnGroup(t *testing.T) {
 	blk1 := bookkeeping.BlockHeader{Round: 1}
 	blk2 := bookkeeping.BlockHeader{Round: 2}
 	delta1 := ledgercore.StateDelta{Hdr: &blk1}
-	delta2 := ledgercore.StateDelta{Hdr: &blk2}
+	delta2 := ledgercore.StateDelta{Hdr: &blk2, KvMods: map[string]ledgercore.KvValueDelta{"bx1": {Data: []byte("foobar")}}}
 	txn1 := transactions.SignedTxnWithAD{SignedTxn: transactions.SignedTxn{Txn: transactions.Transaction{Type: protocol.PaymentTx}}}
 	groupID1, err := crypto.DigestFromString(crypto.Hash([]byte("hello")).String())
 	require.NoError(t, err)
@@ -2160,6 +2160,7 @@ func TestDeltasForTxnGroup(t *testing.T) {
 	require.NoError(t, err)
 	err = json.Unmarshal(rec.Body.Bytes(), &groupResponse)
 	require.NoError(t, err)
+	require.NotNil(t, groupResponse["KvMods"])
 	groupHdr, ok = groupResponse["Hdr"].(map[string]interface{})
 	require.True(t, ok)
 	require.Equal(t, delta2.Hdr.Round, basics.Round(groupHdr["rnd"].(float64)))

--- a/ledger/eval/eval_test.go
+++ b/ledger/eval/eval_test.go
@@ -600,6 +600,7 @@ type evalTestLedger struct {
 	rewardsPool         basics.Address
 	latestTotals        ledgercore.AccountTotals
 	tracer              logic.EvalTracer
+	boxes               map[string][]byte
 }
 
 // newTestLedger creates a in memory Ledger that is as realistic as
@@ -611,6 +612,7 @@ func newTestLedger(t testing.TB, balances bookkeeping.GenesisBalances) *evalTest
 		feeSink:       balances.FeeSink,
 		rewardsPool:   balances.RewardsPool,
 		tracer:        nil,
+		boxes:         make(map[string][]byte),
 	}
 
 	protoVersion := protocol.ConsensusFuture
@@ -728,7 +730,9 @@ func (ledger *evalTestLedger) LookupAsset(rnd basics.Round, addr basics.Address,
 }
 
 func (ledger *evalTestLedger) LookupKv(rnd basics.Round, key string) ([]byte, error) {
-	panic("unimplemented")
+	// The test ledger only has one view of the value of a box--no rnd based retrieval is implemented currently
+	val, _ := ledger.boxes[key]
+	return val, nil
 }
 
 // GenesisHash returns the genesis hash for this ledger.

--- a/ledger/eval/txntracer.go
+++ b/ledger/eval/txntracer.go
@@ -51,19 +51,19 @@ func convertStateDelta(delta ledgercore.StateDelta) StateDeltaSubset {
 	// The StateDelta object returned through the EvalTracer has its values deleted between txn groups to avoid
 	// reallocation during evaluation.
 	// This means the map values need to be copied (to avoid deletion) since they are all passed by reference.
-	kvmods := make(map[string]ledgercore.KvValueDelta)
+	kvmods := make(map[string]ledgercore.KvValueDelta, len(delta.KvMods))
 	for k1, v1 := range delta.KvMods {
 		kvmods[k1] = v1
 	}
-	txids := make(map[transactions.Txid]ledgercore.IncludedTransactions)
+	txids := make(map[transactions.Txid]ledgercore.IncludedTransactions, len(delta.Txids))
 	for k2, v2 := range delta.Txids {
 		txids[k2] = v2
 	}
-	txleases := make(map[ledgercore.Txlease]basics.Round)
+	txleases := make(map[ledgercore.Txlease]basics.Round, len(delta.Txleases))
 	for k3, v3 := range delta.Txleases {
 		txleases[k3] = v3
 	}
-	creatables := make(map[basics.CreatableIndex]ledgercore.ModifiedCreatable)
+	creatables := make(map[basics.CreatableIndex]ledgercore.ModifiedCreatable, len(delta.Creatables))
 	for k4, v4 := range delta.Creatables {
 		creatables[k4] = v4
 	}

--- a/ledger/eval/txntracer.go
+++ b/ledger/eval/txntracer.go
@@ -67,8 +67,27 @@ func convertStateDelta(delta ledgercore.StateDelta) StateDeltaSubset {
 	for k4, v4 := range delta.Creatables {
 		creatables[k4] = v4
 	}
+	var accR []ledgercore.BalanceRecord
+	var appR []ledgercore.AppResourceRecord
+	var assetR []ledgercore.AssetResourceRecord
+	if len(delta.Accts.Accts) > 0 {
+		accR = make([]ledgercore.BalanceRecord, len(delta.Accts.Accts))
+		copy(accR, delta.Accts.Accts)
+	}
+	if len(delta.Accts.AppResources) > 0 {
+		appR = make([]ledgercore.AppResourceRecord, len(delta.Accts.AppResources))
+		copy(appR, delta.Accts.AppResources)
+	}
+	if len(delta.Accts.AssetResources) > 0 {
+		assetR = make([]ledgercore.AssetResourceRecord, len(delta.Accts.AssetResources))
+		copy(assetR, delta.Accts.AssetResources)
+	}
 	return StateDeltaSubset{
-		Accts:      delta.Accts,
+		Accts: ledgercore.AccountDeltas{
+			Accts:          accR,
+			AppResources:   appR,
+			AssetResources: assetR,
+		},
 		KvMods:     kvmods,
 		Txids:      txids,
 		Txleases:   txleases,

--- a/ledger/eval/txntracer.go
+++ b/ledger/eval/txntracer.go
@@ -48,12 +48,28 @@ type StateDeltaSubset struct {
 }
 
 func convertStateDelta(delta ledgercore.StateDelta) StateDeltaSubset {
+	kvmods := make(map[string]ledgercore.KvValueDelta)
+	for k1, v1 := range delta.KvMods {
+		kvmods[k1] = v1
+	}
+	txids := make(map[transactions.Txid]ledgercore.IncludedTransactions)
+	for k2, v2 := range delta.Txids {
+		txids[k2] = v2
+	}
+	txleases := make(map[ledgercore.Txlease]basics.Round)
+	for k3, v3 := range delta.Txleases {
+		txleases[k3] = v3
+	}
+	creatables := make(map[basics.CreatableIndex]ledgercore.ModifiedCreatable)
+	for k4, v4 := range delta.Creatables {
+		creatables[k4] = v4
+	}
 	return StateDeltaSubset{
 		Accts:      delta.Accts,
-		KvMods:     delta.KvMods,
-		Txids:      delta.Txids,
-		Txleases:   delta.Txleases,
-		Creatables: delta.Creatables,
+		KvMods:     kvmods,
+		Txids:      txids,
+		Txleases:   txleases,
+		Creatables: creatables,
 		Hdr:        delta.Hdr,
 	}
 }
@@ -66,7 +82,7 @@ type TxnGroupDeltaTracer struct {
 	// no-op methods we don't care about
 	logic.NullEvalTracer
 	// txnGroupDeltas stores the StateDelta objects for each round, indexed by all the IDs within the group
-	txnGroupDeltas map[basics.Round]map[crypto.Digest]*ledgercore.StateDelta
+	txnGroupDeltas map[basics.Round]map[crypto.Digest]*StateDeltaSubset
 	// latestRound is the most recent round seen via the BeforeBlock hdr
 	latestRound basics.Round
 }
@@ -75,7 +91,7 @@ type TxnGroupDeltaTracer struct {
 func MakeTxnGroupDeltaTracer(lookback uint64) *TxnGroupDeltaTracer {
 	return &TxnGroupDeltaTracer{
 		lookback:       lookback,
-		txnGroupDeltas: make(map[basics.Round]map[crypto.Digest]*ledgercore.StateDelta),
+		txnGroupDeltas: make(map[basics.Round]map[crypto.Digest]*StateDeltaSubset),
 	}
 }
 
@@ -87,7 +103,7 @@ func (tracer *TxnGroupDeltaTracer) BeforeBlock(hdr *bookkeeping.BlockHeader) {
 	delete(tracer.txnGroupDeltas, hdr.Round-basics.Round(tracer.lookback))
 	tracer.latestRound = hdr.Round
 	// Initialize the delta map for the round
-	tracer.txnGroupDeltas[tracer.latestRound] = make(map[crypto.Digest]*ledgercore.StateDelta)
+	tracer.txnGroupDeltas[tracer.latestRound] = make(map[crypto.Digest]*StateDeltaSubset)
 }
 
 // AfterTxnGroup implements the EvalTracer interface for txn group boundaries
@@ -95,16 +111,17 @@ func (tracer *TxnGroupDeltaTracer) AfterTxnGroup(ep *logic.EvalParams, deltas *l
 	if deltas == nil {
 		return
 	}
+	deltaSub := convertStateDelta(*deltas)
 	tracer.deltasLock.Lock()
 	defer tracer.deltasLock.Unlock()
 	txnDeltaMap := tracer.txnGroupDeltas[tracer.latestRound]
 	for _, txn := range ep.TxnGroup {
 		// Add Group ID
 		if !txn.Txn.Group.IsZero() {
-			txnDeltaMap[txn.Txn.Group] = deltas
+			txnDeltaMap[txn.Txn.Group] = &deltaSub
 		}
 		// Add Txn ID
-		txnDeltaMap[crypto.Digest(txn.ID())] = deltas
+		txnDeltaMap[crypto.Digest(txn.ID())] = &deltaSub
 	}
 }
 
@@ -117,7 +134,7 @@ func (tracer *TxnGroupDeltaTracer) GetDeltasForRound(rnd basics.Round) ([]TxnGro
 		return nil, fmt.Errorf("round %d not found in txnGroupDeltaTracer", rnd)
 	}
 	// Dedupe entries in our map and collect Ids
-	var deltas = map[*ledgercore.StateDelta][]string{}
+	var deltas = map[*StateDeltaSubset][]string{}
 	for id, delta := range rndEntries {
 		if _, present := deltas[delta]; !present {
 			deltas[delta] = append(deltas[delta], id.String())
@@ -127,7 +144,7 @@ func (tracer *TxnGroupDeltaTracer) GetDeltasForRound(rnd basics.Round) ([]TxnGro
 	for delta, ids := range deltas {
 		deltasForRound = append(deltasForRound, TxnGroupDeltaWithIds{
 			Ids:   ids,
-			Delta: convertStateDelta(*delta),
+			Delta: *delta,
 		})
 	}
 	return deltasForRound, nil
@@ -139,7 +156,7 @@ func (tracer *TxnGroupDeltaTracer) GetDeltaForID(id crypto.Digest) (StateDeltaSu
 	defer tracer.deltasLock.RUnlock()
 	for _, deltasForRound := range tracer.txnGroupDeltas {
 		if delta, exists := deltasForRound[id]; exists {
-			return convertStateDelta(*delta), nil
+			return *delta, nil
 		}
 	}
 	return StateDeltaSubset{}, fmt.Errorf("unable to find delta for id: %s", id)

--- a/ledger/eval/txntracer_test.go
+++ b/ledger/eval/txntracer_test.go
@@ -216,6 +216,22 @@ int 1`
 			require.NoError(t, err)
 			require.Len(t, eval.block.Payset, 4)
 
+			secondPayTxn := txntest.Txn{
+				Type:        protocol.PaymentTx,
+				Sender:      addrs[2],
+				Receiver:    addrs[1],
+				Amount:      100_000,
+				FirstValid:  newBlock.Round(),
+				LastValid:   newBlock.Round() + 1000,
+				Fee:         minFee,
+				GenesisHash: genHash,
+			}
+			secondTxGroup := transactions.WrapSignedTxnsWithAD([]transactions.SignedTxn{
+				secondPayTxn.Txn().Sign(keys[2]),
+			})
+			err = eval.TransactionGroup(secondTxGroup)
+			require.NoError(t, err)
+
 			expectedAccts := ledgercore.AccountDeltas{
 				Accts: []ledgercore.BalanceRecord{
 					{
@@ -344,7 +360,7 @@ int 1`
 			require.NoError(t, err)
 			allDeltas, err := tracer.GetDeltasForRound(basics.Round(1))
 			require.NoError(t, err)
-			require.Len(t, allDeltas, 1)
+			require.Len(t, allDeltas, 2)
 
 			require.Equal(t, expectedAccts.Accts, actualDelta.Accts.Accts)
 			require.Equal(t, expectedAccts.AppResources, actualDelta.Accts.AppResources)

--- a/ledger/eval/txntracer_test.go
+++ b/ledger/eval/txntracer_test.go
@@ -122,6 +122,8 @@ int 1`,
 			}
 
 			// a non-app call txn
+			var txnLease [32]byte
+			copy(txnLease[:], "txnLeaseTest")
 			payTxn := txntest.Txn{
 				Type:             protocol.PaymentTx,
 				Sender:           addrs[1],
@@ -133,6 +135,7 @@ int 1`,
 				Fee:              minFee,
 				GenesisHash:      genHash,
 				Note:             []byte("two"),
+				Lease:            txnLease,
 			}
 			// an app call with inner txn
 			innerAppCallTxn := txntest.Txn{
@@ -269,6 +272,9 @@ int 1`,
 					Data:    []uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 				},
 			}
+			expectedLeases := map[ledgercore.Txlease]basics.Round{
+				{Sender: payTxn.Sender, Lease: payTxn.Lease}: payTxn.LastValid,
+			}
 
 			actualDelta, err := tracer.GetDeltaForID(crypto.Digest(txgroup[0].ID()))
 			require.NoError(t, err)
@@ -284,6 +290,7 @@ int 1`,
 			require.Equal(t, expectedAccts.AppResources, actualDelta.Accts.AppResources)
 			require.Equal(t, expectedAccts.AssetResources, actualDelta.Accts.AssetResources)
 			require.Equal(t, expectedKvMods, actualDelta.KvMods)
+			require.Equal(t, expectedLeases, actualDelta.Txleases)
 		})
 	}
 }

--- a/ledger/eval/txntracer_test.go
+++ b/ledger/eval/txntracer_test.go
@@ -75,8 +75,8 @@ func TestTransactionGroupWithDeltaTracer(t *testing.T) {
 
 			innerAppID := basics.AppIndex(3) + offset
 			innerAppAddress := innerAppID.Address()
-			appId := basics.AppIndex(1) + offset
-			appAddress := appId.Address()
+			appID := basics.AppIndex(1) + offset
+			appAddress := appID.Address()
 			balances := genesisInitState.Accounts
 			balances[innerAppAddress] = basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1_000_000})
 			balances[appAddress] = basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1_000_000})
@@ -115,7 +115,7 @@ int 1`,
 				Fee:         minFee,
 				GenesisHash: genHash,
 				Note:        []byte("one"),
-				Boxes: []transactions.BoxRef{transactions.BoxRef{
+				Boxes: []transactions.BoxRef{{
 					Index: 0,
 					Name:  []byte("hellobox"),
 				}},


### PR DESCRIPTION
## Summary

The KvMods (and other fields in the StateDelta which are maps) have their values deleted when the roundCoW gets recycled. Because we're not copying this data out of the delta in the txn tracer, this affects the results returned by the tracer.

I've now copied all of the fields out of the maps in the StateDelta (for those that we care about returning).

## Test Plan

Adding full unit tests for kvmods--other data should function similarly. This required adding some functionality to the eval test ledger which was not initially implemented during the Boxes PR.
