### PR TITLE
tools: allow dumpblocks work with wal-enabled dbs

### DIFF
--- a/tools/debug/dumpblocks/main.go
+++ b/tools/debug/dumpblocks/main.go
@@ -54,7 +54,7 @@ func main() {
 		fmt.Println("-blockdb=file required")
 		usage()
 	}
-	uri := fmt.Sprintf("file:%s?mode=ro", *blockDBfile)
+	uri := fmt.Sprintf("file:%s?_journal_mode=wal", *blockDBfile)
 	fmt.Println("Opening", uri)
 	db, err := sql.Open("sqlite3", uri)
 	if err != nil {


### PR DESCRIPTION
## Summary

Without this opening blockdb.sqlite fails errors.

## Test Plan

Manual test