### PR TITLE
Bookkeeping:  improve block documentation since no-low-resources

### DIFF
--- a/data/bookkeeping/block.go
+++ b/data/bookkeeping/block.go
@@ -109,14 +109,9 @@ type (
 		UpgradeState
 		UpgradeVote
 
-		// TxnCounter counts the number of transactions committed in the
-		// ledger, from the time at which support for this feature was
-		// introduced.
-		//
-		// Specifically, TxnCounter is the number of the next transaction
-		// that will be committed after this block.  It is 0 when no
-		// transactions have ever been committed (since TxnCounter
-		// started being supported).
+		// TxnCounter is the number of the next transaction that will be
+		// committed after this block.  Genesis blocks can start at either
+		// 0 or 1000, depending on a consensus parameter (AppForbidLowResources).
 		TxnCounter uint64 `codec:"tc"`
 
 		// StateProofTracking tracks the status of the state proofs, potentially


### PR DESCRIPTION
Updates commentary in the `BlockHeader` to support `TxCounter`s starting at nonzero numbers in genesis blocks (in support of banning low asset/app resources)
