### PR TITLE
node: fix monitoringRoutinesWaitGroup's Add/Wait concurrent access

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -418,8 +418,8 @@ func (node *AlgorandFullNode) ListeningAddress() (string, bool) {
 func (node *AlgorandFullNode) Stop() {
 	node.mu.Lock()
 	defer func() {
-		node.mu.Unlock()
 		node.waitMonitoringRoutines()
+		node.mu.Unlock()
 	}()
 
 	node.net.ClearHandlers()
@@ -1225,8 +1225,8 @@ func (node *AlgorandFullNode) SetCatchpointCatchupMode(catchpointCatchupMode boo
 		if catchpointCatchupMode {
 			// stop..
 			defer func() {
-				node.mu.Unlock()
 				node.waitMonitoringRoutines()
+				node.mu.Unlock()
 			}()
 			node.net.ClearHandlers()
 			node.stateProofWorker.Stop()


### PR DESCRIPTION
## Summary

One of the tests detected a data race (see below) that is indeed a concurrent access of monitoringRoutinesWaitGroup. Grats to @algoidan 

```
algod(5908) : WARNING: DATA RACE
algod(5908) : Read at 0x00c000266a68 by goroutine 185:
algod(5908) :   runtime.raceread()
algod(5908) :       <autogenerated>:1 +0x24
algod(5908) :   github.com/algorand/go-algorand/node.(*AlgorandFullNode).startMonitoringRoutines()
algod(5908) :       github.com/algorand/go-algorand/node/node.go:390 +0x5d
algod(5908) :   github.com/algorand/go-algorand/node.(*AlgorandFullNode).SetCatchpointCatchupMode.func1()
algod(5908) :       github.com/algorand/go-algorand/node/node.go:1244 +0xaa7
algod(5908) : Previous write at 0x00c000266a68 by goroutine 186:
algod(5908) :   runtime.racewrite()
algod(5908) :       <autogenerated>:1 +0x24
algod(5908) :   github.com/algorand/go-algorand/node.(*AlgorandFullNode).waitMonitoringRoutines()
algod(5908) :       github.com/algorand/go-algorand/node/node.go:404 +0x44
algod(5908) :   github.com/algorand/go-algorand/node.(*AlgorandFullNode).SetCatchpointCatchupMode.func1.1()
algod(5908) :       github.com/algorand/go-algorand/node/node.go:1197 +0x33
algod(5908) :   github.com/algorand/go-algorand/node.(*AlgorandFullNode).SetCatchpointCatchupMode.func1()
algod(5908) :       github.com/algorand/go-algorand/node/node.go:1215 +0x41f
algod(5908) : Goroutine 185 (running) created at:
algod(5908) :   github.com/algorand/go-algorand/node.(*AlgorandFullNode).SetCatchpointCatchupMode()
algod(5908) :       github.com/algorand/go-algorand/node/node.go:1184 +0xf8
algod(5908) :   github.com/algorand/go-algorand/catchup.(*CatchpointCatchupService).updateNodeCatchupMode()
algod(5908) :       github.com/algorand/go-algorand/catchup/catchpointService.go:741 +0x75
algod(5908) :   github.com/algorand/go-algorand/catchup.(*CatchpointCatchupService).processStageSwitch()
algod(5908) :       github.com/algorand/go-algorand/catchup/catchpointService.go:697 +0x28e
algod(5908) :   github.com/algorand/go-algorand/catchup.(*CatchpointCatchupService).run()
algod(5908) :       github.com/algorand/go-algorand/catchup/catchpointService.go:213 +0x1d6
algod(5908) :   github.com/algorand/go-algorand/catchup.(*CatchpointCatchupService).Start·dwrap·1()
algod(5908) :       github.com/algorand/go-algorand/catchup/catchpointService.go:163 +0x39
```

## Test Plan

Existing tests