### PR TITLE
DevOps: Update CODEOWNERS to only refer to the devops group

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-.github/ @algorand/dev
-.circleci/ @algorand/dev
+.github/ @algorand/devops
+.circleci/ @algorand/devops


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

The auto-reviewer assignment was hitting too large a net, so cutting this back to the devops group.

## Test Plan

N/A

