### PR TITLE
assembler: Error if extra args are present in pragmas

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -2193,6 +2193,9 @@ func pragma(ops *OpStream, tokens []string) error {
 		if len(tokens) < 3 {
 			return ops.error("no version value")
 		}
+		if len(tokens) > 3 {
+			return ops.errorf("unexpected extra tokens: %s", strings.Join(tokens[3:], " "))
+		}
 		value := tokens[2]
 		var ver uint64
 		if ops.pending.Len() > 0 {
@@ -2221,6 +2224,9 @@ func pragma(ops *OpStream, tokens []string) error {
 	case "typetrack":
 		if len(tokens) < 3 {
 			return ops.error("no typetrack value")
+		}
+		if len(tokens) > 3 {
+			return ops.errorf("unexpected extra tokens: %s", strings.Join(tokens[3:], " "))
 		}
 		value := tokens[2]
 		on, err := strconv.ParseBool(value)

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2329,6 +2329,12 @@ func TestPragmas(t *testing.T) {
 	testProg(t, "#pragma version 5 blah", assemblerNoVersion,
 		Expect{1, "unexpected extra tokens: blah"})
 
+	testProg(t, "#pragma typetrack", assemblerNoVersion,
+		Expect{1, "no typetrack value"})
+
+	testProg(t, "#pragma typetrack blah", assemblerNoVersion,
+		Expect{1, `bad #pragma typetrack: "blah"`})
+
 	testProg(t, "#pragma typetrack false blah", assemblerNoVersion,
 		Expect{1, "unexpected extra tokens: blah"})
 

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2325,6 +2325,20 @@ func TestPragmas(t *testing.T) {
 
 	ops = testProg(t, "    #pragma version 5     ", assemblerNoVersion)
 	require.Equal(t, uint64(5), ops.Version)
+
+	testProg(t, "#pragma version 5 blah", assemblerNoVersion,
+		Expect{1, "unexpected extra tokens: blah"})
+
+	testProg(t, "#pragma typetrack false blah", assemblerNoVersion,
+		Expect{1, "unexpected extra tokens: blah"})
+
+	// Currently pragmas don't treat semicolons as newlines. It would probably
+	// be nice to fix this.
+	testProg(t, "#pragma version 5; int 1", assemblerNoVersion,
+		Expect{1, "unexpected extra tokens: ; int 1"})
+
+	testProg(t, "#pragma typetrack false; int 1", assemblerNoVersion,
+		Expect{1, "unexpected extra tokens: ; int 1"})
 }
 
 func TestAssemblePragmaVersion(t *testing.T) {

--- a/data/txntest/txn.go
+++ b/data/txntest/txn.go
@@ -182,8 +182,7 @@ func assemble(source interface{}) []byte {
 		}
 		ops, err := logic.AssembleString(program)
 		if err != nil {
-			fmt.Printf("Bad program %v", ops.Errors)
-			panic(ops.Errors)
+			panic(fmt.Sprintf("Bad program %v", ops.Errors))
 		}
 		return ops.Program
 	case []byte:

--- a/ledger/simulation/simulation_eval_test.go
+++ b/ledger/simulation/simulation_eval_test.go
@@ -867,7 +867,7 @@ func TestAppCallWithExtraBudget(t *testing.T) {
 			Sender:            sender.Addr,
 			ApplicationID:     0,
 			ApprovalProgram:   expensiveAppSource,
-			ClearStateProgram: `#pragma version 6; int 0`,
+			ClearStateProgram: "#pragma version 6\nint 0",
 		})
 		// Expensive 700 repetition of int 1 and pop total cost 1404
 		expensiveTxn := env.TxnInfo.NewTxn(txntest.Txn{
@@ -938,7 +938,7 @@ func TestAppCallWithExtraBudgetOverBudget(t *testing.T) {
 			Sender:            sender.Addr,
 			ApplicationID:     0,
 			ApprovalProgram:   expensiveAppSource,
-			ClearStateProgram: `#pragma version 6; int 0`,
+			ClearStateProgram: "#pragma version 6\nint 0",
 		})
 		// Expensive 700 repetition of int 1 and pop total cost 1404
 		expensiveTxn := env.TxnInfo.NewTxn(txntest.Txn{
@@ -1015,7 +1015,7 @@ func TestAppCallWithExtraBudgetExceedsInternalLimit(t *testing.T) {
 		Sender:            sender.Addr,
 		ApplicationID:     0,
 		ApprovalProgram:   expensiveAppSource,
-		ClearStateProgram: `#pragma version 6; int 0`,
+		ClearStateProgram: "#pragma version 6\nint 0",
 	})
 	// Expensive 700 repetition of int 1 and pop total cost 1404
 	expensiveTxn := env.TxnInfo.NewTxn(txntest.Txn{

--- a/netdeploy/remote/deployedNetwork.go
+++ b/netdeploy/remote/deployedNetwork.go
@@ -757,7 +757,7 @@ func createSignedTx(src basics.Address, round basics.Round, params config.Consen
 			return []transactions.SignedTxn{}, err
 		}
 		approval := ops.Program
-		ops, err = logic.AssembleString("#pragma version 2 int 1")
+		ops, err = logic.AssembleString("#pragma version 2\nint 1")
 		if err != nil {
 			panic(err)
 		}

--- a/test/e2e-go/restAPI/restClient_test.go
+++ b/test/e2e-go/restAPI/restClient_test.go
@@ -1907,7 +1907,7 @@ int 1`
 	ops, err := logic.AssembleString(prog)
 	a.NoError(err)
 	approval := ops.Program
-	ops, err = logic.AssembleString("#pragma version 8; int 1")
+	ops, err = logic.AssembleString("#pragma version 8\nint 1")
 	a.NoError(err)
 	clearState := ops.Program
 


### PR DESCRIPTION
## Summary

One might think these programs are equivalent:

```
#pragma version 5; int 1
```

```
#pragma version 5
int 1
```

However, they are not. Pragma lines are "greedy" in that they consume all tokens in a line, but only look at the first 3.

I've ran into this a few times, so I thought it would be a good idea to at least error if you try to assemble with extra stuff after a pragma.

A better solution would be to treat semicolons as newlines and make those example programs actually equal, but I've not gone that far in this PR. (And it deserves some extra thought, since it's currently illegal to start a directive unless it's the first thing in a line. Plus `#define` is greedy because it actually consumes the whole line.)

## Test Plan

Unit test added, existing tests fixed.
