### PR TITLE
TEAL: Add columns to assembly error messages.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,11 +31,6 @@ linters-settings:
     require-explanation: true
   errcheck:
     exclude-functions:
-      # data/transactions/logic/assembler.go uses ops.error, warn, to append log messages: OK to ignore for this case
-    - (*github.com/algorand/go-algorand/data/transactions/logic.OpStream).errorf
-    - (*github.com/algorand/go-algorand/data/transactions/logic.OpStream).error
-    - (*github.com/algorand/go-algorand/data/transactions/logic.OpStream).warnf
-    - (*github.com/algorand/go-algorand/data/transactions/logic.OpStream).warn
     # We do this 121 times and never check the error.
     - (*github.com/spf13/cobra.Command).MarkFlagRequired
   govet:
@@ -62,9 +57,6 @@ linters-settings:
           - (github.com/algorand/go-algorand/logging.Logger).Error
           - (github.com/algorand/go-algorand/logging.Logger).Fatal
           - (github.com/algorand/go-algorand/logging.Logger).Panic
-          - (github.com/algorand/go-algorand/data/transactions/logic.OpStream).warnf
-          - (github.com/algorand/go-algorand/data/transactions/logic.OpStream).errorf
-          - (github.com/algorand/go-algorand/data/transactions/logic.OpStream).lineErrorf
           - (github.com/algorand/go-algorand/cmd/goal/main).reportInfof
           - (github.com/algorand/go-algorand/cmd/goal/main).reportInfoln
           - (github.com/algorand/go-algorand/cmd/goal/main).reportWarnf

--- a/cmd/opdoc/opdoc.go
+++ b/cmd/opdoc/opdoc.go
@@ -91,7 +91,7 @@ func namedStackTypesMarkdown(out io.Writer, stackTypes []namedType) {
 	for _, st := range stackTypes {
 		fmt.Fprintf(out, "| %s | %s | %s |\n", st.Name, st.boundString(), st.AVMType)
 	}
-	out.Write([]byte("\n"))
+	fmt.Fprintf(out, "\n")
 }
 
 func integerConstantsTableMarkdown(out io.Writer) {

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1865,12 +1865,12 @@ var tokenSeparators = [256]bool{'\t': true, ' ': true, ';': true}
 
 // tokensFromLine splits a line into tokens, ignoring comments. tokens are
 // annotated with the provided lineno, and column where they are found.
-func tokensFromLine(line string, lineno int) []token {
+func tokensFromLine(sourceLine string, lineno int) []token {
 	var tokens []token
 
 	i := 0
-	for i < len(line) && tokenSeparators[line[i]] {
-		if line[i] == ';' {
+	for i < len(sourceLine) && tokenSeparators[sourceLine[i]] {
+		if sourceLine[i] == ';' {
 			tokens = append(tokens, token{";", i, lineno})
 		}
 		i++
@@ -1879,28 +1879,28 @@ func tokensFromLine(line string, lineno int) []token {
 	start := i
 	inString := false // tracked to allow spaces and comments inside
 	inBase64 := false // tracked to allow '//' inside
-	for i < len(line) {
-		if !tokenSeparators[line[i]] { // if not space
-			switch line[i] {
+	for i < len(sourceLine) {
+		if !tokenSeparators[sourceLine[i]] { // if not space
+			switch sourceLine[i] {
 			case '"': // is a string literal?
 				if !inString {
-					if i == 0 || i > 0 && tokenSeparators[line[i-1]] {
+					if i == 0 || i > 0 && tokenSeparators[sourceLine[i-1]] {
 						inString = true
 					}
 				} else {
-					if line[i-1] != '\\' { // if not escape symbol
+					if sourceLine[i-1] != '\\' { // if not escape symbol
 						inString = false
 					}
 				}
 			case '/': // is a comment?
-				if i < len(line)-1 && line[i+1] == '/' && !inBase64 && !inString {
+				if i < len(sourceLine)-1 && sourceLine[i+1] == '/' && !inBase64 && !inString {
 					if start != i { // if a comment without whitespace
-						tokens = append(tokens, token{line[start:i], start, lineno})
+						tokens = append(tokens, token{sourceLine[start:i], start, lineno})
 					}
 					return tokens
 				}
 			case '(': // is base64( seq?
-				prefix := line[start:i]
+				prefix := sourceLine[start:i]
 				if prefix == "base64" || prefix == "b64" {
 					inBase64 = true
 				}
@@ -1917,9 +1917,9 @@ func tokensFromLine(line string, lineno int) []token {
 		// we've hit a space, end last token unless inString
 
 		if !inString {
-			s := line[start:i]
+			s := sourceLine[start:i]
 			tokens = append(tokens, token{s, start, lineno})
-			if line[i] == ';' {
+			if sourceLine[i] == ';' {
 				tokens = append(tokens, token{";", i, lineno})
 			}
 			if inBase64 {
@@ -1932,8 +1932,8 @@ func tokensFromLine(line string, lineno int) []token {
 
 		// gobble up consecutive whitespace (but notice semis)
 		if !inString {
-			for i < len(line) && tokenSeparators[line[i]] {
-				if line[i] == ';' {
+			for i < len(sourceLine) && tokenSeparators[sourceLine[i]] {
+				if sourceLine[i] == ';' {
 					tokens = append(tokens, token{";", i, lineno})
 				}
 				i++
@@ -1943,8 +1943,8 @@ func tokensFromLine(line string, lineno int) []token {
 	}
 
 	// add rest of the string if any
-	if start < len(line) {
-		tokens = append(tokens, token{line[start:i], start, lineno})
+	if start < len(sourceLine) {
+		tokens = append(tokens, token{sourceLine[start:i], start, lineno})
 	}
 
 	return tokens

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -48,14 +48,13 @@ type Writer interface {
 }
 
 type labelReference struct {
-	sourceLine int
-
-	// position of the label reference
+	// position (PC) of the label reference
 	position int
 
-	label string
+	// token holding the label name (and line, column)
+	label token
 
-	// ending positions of the opcode containing the label reference.
+	// ending position of the opcode containing the label reference.
 	offsetPosition int
 }
 
@@ -219,9 +218,9 @@ func (ref byteReference) makeNewReference(ops *OpStream, singleton bool, newInde
 type OpStream struct {
 	Version  uint64
 	Trace    *strings.Builder
-	Warnings []error     // informational warnings, shouldn't stop assembly
-	Errors   []lineError // errors that should prevent final assembly
-	Program  []byte      // Final program bytes. Will stay nil if any errors
+	Warnings []error       // informational warnings, shouldn't stop assembly
+	Errors   []sourceError // errors that should prevent final assembly
+	Program  []byte        // Final program bytes. Will stay nil if any errors
 
 	// Running bytes as they are assembled. jumps must be resolved
 	// and cblocks added before these bytes become a legal program.
@@ -258,7 +257,7 @@ type OpStream struct {
 	// Need new copy for each opstream
 	versionedPseudoOps map[string]map[int]OpSpec
 
-	macros map[string][]string
+	macros map[string][]token
 }
 
 // newOpStream constructs OpStream instances ready to invoke assemble. A new
@@ -269,7 +268,7 @@ func newOpStream(version uint64) OpStream {
 		OffsetToLine: make(map[int]int),
 		typeTracking: true,
 		Version:      version,
-		macros:       make(map[string][]string),
+		macros:       make(map[string][]token),
 		known:        ProgramKnowledge{fp: -1},
 	}
 
@@ -357,9 +356,10 @@ func (pgm *ProgramKnowledge) reset() {
 
 // createLabel inserts a label to point to the next instruction, reporting an
 // error for a duplicate.
-func (ops *OpStream) createLabel(label string) {
+func (ops *OpStream) createLabel(withColon token) {
+	label := strings.TrimSuffix(withColon.str, ":")
 	if _, ok := ops.labels[label]; ok {
-		ops.errorf("duplicate label %#v", label)
+		ops.errorOnf(withColon, "duplicate label %#v", label)
 	}
 	ops.labels[label] = ops.pending.Len()
 	ops.known.label()
@@ -371,11 +371,11 @@ func (ops *OpStream) recordSourceLine() {
 }
 
 // referToLabel records an opcode label reference to resolve later
-func (ops *OpStream) referToLabel(pc int, label string, offsetPosition int) {
-	ops.labelReferences = append(ops.labelReferences, labelReference{ops.sourceLine, pc, label, offsetPosition})
+func (ops *OpStream) referToLabel(pc int, label token, offsetPosition int) {
+	ops.labelReferences = append(ops.labelReferences, labelReference{pc, label, offsetPosition})
 }
 
-type refineFunc func(pgm *ProgramKnowledge, immediates []string) (StackTypes, StackTypes, error)
+type refineFunc func(pgm *ProgramKnowledge, immediates []token) (StackTypes, StackTypes, error)
 
 // returns allows opcodes like `txn` to be specific about their return value
 // types, based on the field requested, rather than use Any as specified by
@@ -396,8 +396,8 @@ func (ops *OpStream) returns(spec *OpSpec, replacement StackType) {
 	panic(fmt.Sprintf("%+v", spec))
 }
 
-// Intc writes opcodes for loading a uint64 constant onto the stack.
-func (ops *OpStream) Intc(constIndex uint) {
+// writeIntc writes opcodes for loading a uint64 constant onto the stack.
+func (ops *OpStream) writeIntc(constIndex uint) error {
 	switch constIndex {
 	case 0:
 		ops.pending.WriteByte(OpsByName[ops.Version]["intc_0"].Opcode)
@@ -409,20 +409,20 @@ func (ops *OpStream) Intc(constIndex uint) {
 		ops.pending.WriteByte(OpsByName[ops.Version]["intc_3"].Opcode)
 	default:
 		if constIndex > 0xff {
-			ops.error("cannot have more than 256 int constants")
+			return errors.New("cannot have more than 256 int constants")
 		}
 		ops.pending.WriteByte(OpsByName[ops.Version]["intc"].Opcode)
 		ops.pending.WriteByte(uint8(constIndex))
 	}
 	if constIndex >= uint(len(ops.intc)) {
-		ops.errorf("intc %d is not defined", constIndex)
-	} else {
-		ops.trace("intc %d: %d", constIndex, ops.intc[constIndex])
+		return fmt.Errorf("intc %d is not defined", constIndex)
 	}
+	ops.trace("intc %d: %d", constIndex, ops.intc[constIndex])
+	return nil
 }
 
-// IntLiteral writes opcodes for loading a uint literal
-func (ops *OpStream) IntLiteral(val uint64) {
+// intLiteral writes opcodes for loading a uint literal
+func (ops *OpStream) intLiteral(val uint64) error {
 	ops.hasPseudoInt = true
 
 	found := false
@@ -437,7 +437,7 @@ func (ops *OpStream) IntLiteral(val uint64) {
 
 	if !found {
 		if ops.cntIntcBlock > 0 {
-			ops.errorf("int %d used without %d in intcblock", val, val)
+			return fmt.Errorf("value %d does not appear in existing intcblock", val)
 		}
 		constIndex = uint(len(ops.intc))
 		ops.intc = append(ops.intc, val)
@@ -446,11 +446,11 @@ func (ops *OpStream) IntLiteral(val uint64) {
 		value:    val,
 		position: ops.pending.Len(),
 	})
-	ops.Intc(constIndex)
+	return ops.writeIntc(constIndex)
 }
 
-// Bytec writes opcodes for loading a []byte constant onto the stack.
-func (ops *OpStream) Bytec(constIndex uint) {
+// writeBytec writes opcodes for loading a []byte constant onto the stack.
+func (ops *OpStream) writeBytec(constIndex uint) error {
 	switch constIndex {
 	case 0:
 		ops.pending.WriteByte(OpsByName[ops.Version]["bytec_0"].Opcode)
@@ -462,21 +462,21 @@ func (ops *OpStream) Bytec(constIndex uint) {
 		ops.pending.WriteByte(OpsByName[ops.Version]["bytec_3"].Opcode)
 	default:
 		if constIndex > 0xff {
-			ops.error("cannot have more than 256 byte constants")
+			return errors.New("cannot have more than 256 byte constants")
 		}
 		ops.pending.WriteByte(OpsByName[ops.Version]["bytec"].Opcode)
 		ops.pending.WriteByte(uint8(constIndex))
 	}
 	if constIndex >= uint(len(ops.bytec)) {
-		ops.errorf("bytec %d is not defined", constIndex)
-	} else {
-		ops.trace("bytec %d %s", constIndex, hex.EncodeToString(ops.bytec[constIndex]))
+		return fmt.Errorf("bytec %d is not defined", constIndex)
 	}
+	ops.trace("bytec %d %s", constIndex, hex.EncodeToString(ops.bytec[constIndex]))
+	return nil
 }
 
-// ByteLiteral writes opcodes and data for loading a []byte literal
+// byteLiteral writes opcodes and data for loading a []byte literal
 // Values are accumulated so that they can be put into a bytecblock
-func (ops *OpStream) ByteLiteral(val []byte) {
+func (ops *OpStream) byteLiteral(val []byte) error {
 	ops.hasPseudoByte = true
 
 	found := false
@@ -490,7 +490,7 @@ func (ops *OpStream) ByteLiteral(val []byte) {
 	}
 	if !found {
 		if ops.cntBytecBlock > 0 {
-			ops.errorf("byte/addr/method used without value in bytecblock")
+			return fmt.Errorf("value 0x%x does not appear in existing bytecblock", val)
 		}
 		constIndex = uint(len(ops.bytec))
 		ops.bytec = append(ops.bytec, val)
@@ -499,21 +499,21 @@ func (ops *OpStream) ByteLiteral(val []byte) {
 		value:    val,
 		position: ops.pending.Len(),
 	})
-	ops.Bytec(constIndex)
+	return ops.writeBytec(constIndex)
 }
 
-func asmInt(ops *OpStream, spec *OpSpec, args []string) error {
-	if len(args) != 1 {
-		return ops.errorf("%s needs one immediate argument, was given %d", spec.Name, len(args))
+func asmInt(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
+	if err := checkArgCount(spec.Name, mnemonic, args, 1); err != nil {
+		return ops.accumulate(err)
 	}
 
 	// After backBranchEnabledVersion, control flow is confusing, so if there's
 	// a manual cblock, use push instead of trying to use what's given.
 	if ops.cntIntcBlock > 0 && ops.Version >= backBranchEnabledVersion {
 		// We don't understand control-flow, so use pushint
-		ops.warnf("int %s used with explicit intcblock. must pushint", args[0])
+		ops.warnOnf(args[0], "int %s used with explicit intcblock. must pushint", args[0].str)
 		pushint := OpsByName[ops.Version]["pushint"]
-		return asmPushInt(ops, &pushint, args)
+		return asmPushInt(ops, &pushint, mnemonic, args)
 	}
 
 	// There are no backjumps, but there are multiple cblocks. Maybe one is
@@ -521,65 +521,71 @@ func asmInt(ops *OpStream, spec *OpSpec, args []string) error {
 	if ops.cntIntcBlock > 1 {
 		pushint, ok := OpsByName[ops.Version]["pushint"]
 		if ok {
-			return asmPushInt(ops, &pushint, args)
+			return asmPushInt(ops, &pushint, mnemonic, args)
 		}
-		return ops.errorf("int %s used with manual intcblocks. Use intc.", args[0])
+		return ops.errorOnf(mnemonic, "int %s used with manual intcblocks. Use intc.", args[0].str)
 	}
 
 	// In both of the above clauses, we _could_ track whether a particular
 	// intcblock dominates the current instruction. If so, we could use it.
 
 	// check txn type constants
-	i, ok := txnTypeMap[args[0]]
-	if ok {
-		ops.IntLiteral(i)
-		return nil
+	i, ok := txnTypeMap[args[0].str]
+	if !ok {
+		// check OnCompletion constants
+		i, ok = onCompletionMap[args[0].str]
 	}
-	// check OnCompletion constants
-	oc, isOCStr := onCompletionMap[args[0]]
-	if isOCStr {
-		ops.IntLiteral(oc)
-		return nil
+	if !ok {
+		val, err := strconv.ParseUint(args[0].str, 0, 64)
+		if err != nil {
+			return ops.errorOn(args[0], err)
+		}
+		i = val
 	}
-	val, err := strconv.ParseUint(args[0], 0, 64)
+	err := ops.intLiteral(i)
 	if err != nil {
-		return ops.error(err)
+		return ops.errorOn(args[0], err)
 	}
-	ops.IntLiteral(val)
 	return nil
 }
 
 // Explicit invocation of const lookup and push
-func asmIntC(ops *OpStream, spec *OpSpec, args []string) error {
-	if len(args) != 1 {
-		return ops.errorf("%s needs one immediate argument, was given %d", spec.Name, len(args))
+func asmIntC(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
+	if err := checkArgCount(spec.Name, mnemonic, args, 1); err != nil {
+		return ops.accumulate(err)
 	}
-	constIndex, err := byteImm(args[0], "constant")
+	constIndex, err := byteImm(args[0].str, "constant")
 	if err != nil {
-		return ops.error(err)
+		return ops.errorOn(args[0], err)
 	}
-	ops.Intc(uint(constIndex))
+	err = ops.writeIntc(uint(constIndex))
+	if err != nil {
+		return ops.errorOn(args[0], err)
+	}
 	return nil
 }
-func asmByteC(ops *OpStream, spec *OpSpec, args []string) error {
-	if len(args) != 1 {
-		return ops.errorf("%s needs one immediate argument, was given %d", spec.Name, len(args))
+func asmByteC(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
+	if err := checkArgCount(spec.Name, mnemonic, args, 1); err != nil {
+		return ops.accumulate(err)
 	}
-	constIndex, err := byteImm(args[0], "constant")
+	constIndex, err := byteImm(args[0].str, "constant")
 	if err != nil {
-		return ops.error(err)
+		return ops.errorOn(args[0], err)
 	}
-	ops.Bytec(uint(constIndex))
+	err = ops.writeBytec(uint(constIndex))
+	if err != nil {
+		return ops.errorOn(args[0], err)
+	}
 	return nil
 }
 
-func asmPushInt(ops *OpStream, spec *OpSpec, args []string) error {
-	if len(args) != 1 {
-		return ops.errorf("%s needs one immediate argument, was given %d", spec.Name, len(args))
+func asmPushInt(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
+	if err := checkArgCount(spec.Name, mnemonic, args, 1); err != nil {
+		return ops.accumulate(err)
 	}
-	val, err := strconv.ParseUint(args[0], 0, 64)
+	val, err := strconv.ParseUint(args[0].str, 0, 64)
 	if err != nil {
-		return ops.error(err)
+		return ops.errorOn(args[0], err)
 	}
 	ops.pending.WriteByte(spec.Opcode)
 	var scratch [binary.MaxVarintLen64]byte
@@ -588,22 +594,24 @@ func asmPushInt(ops *OpStream, spec *OpSpec, args []string) error {
 	return nil
 }
 
-func asmPushInts(ops *OpStream, spec *OpSpec, args []string) error {
+func asmPushInts(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
 	ops.pending.WriteByte(spec.Opcode)
 	_, err := asmIntImmArgs(ops, args)
 	return err
 }
 
-func asmPushBytes(ops *OpStream, spec *OpSpec, args []string) error {
+func asmPushBytes(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
+	// asmPushBytes is sometimes used to assemble the "byte" mnemonic, so use
+	// mnemonic.str instead of spec.Name when reporting errors.
 	if len(args) == 0 {
-		return ops.errorf("%s needs byte literal argument", spec.Name)
+		return ops.errorAfterf(mnemonic, "%s needs byte literal argument", mnemonic.str)
 	}
 	val, consumed, err := parseBinaryArgs(args)
 	if err != nil {
-		return ops.error(err)
+		return ops.errorOnf(args[consumed], "%s %w", mnemonic.str, err)
 	}
 	if len(args) != consumed {
-		return ops.errorf("%s with extraneous argument", spec.Name)
+		return ops.errorOnf(args[consumed], "%s with extraneous argument", mnemonic.str)
 	}
 	ops.pending.WriteByte(spec.Opcode)
 	var scratch [binary.MaxVarintLen64]byte
@@ -613,9 +621,9 @@ func asmPushBytes(ops *OpStream, spec *OpSpec, args []string) error {
 	return nil
 }
 
-func asmPushBytess(ops *OpStream, spec *OpSpec, args []string) error {
+func asmPushBytess(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
 	ops.pending.WriteByte(spec.Opcode)
-	_, err := asmByteImmArgs(ops, args)
+	_, err := asmByteImmArgs(ops, spec, args)
 	return err
 }
 
@@ -632,66 +640,70 @@ func base32DecodeAnyPadding(x string) (val []byte, err error) {
 	return
 }
 
-func parseBinaryArgs(args []string) (val []byte, consumed int, err error) {
-	arg := args[0]
+// parseBinaryArgs parses a byte literal argument. It returns the argument,
+// interpetted into raw bytes, and the number of tokens consumed.
+func parseBinaryArgs(args []token) ([]byte, int, error) {
+	arg := args[0].str
 	if strings.HasPrefix(arg, "base32(") || strings.HasPrefix(arg, "b32(") {
 		open := strings.IndexRune(arg, '(')
 		close := strings.IndexRune(arg, ')')
 		if close == -1 {
-			err = errors.New("byte base32 arg lacks close paren")
-			return
+			return nil, 0, fmt.Errorf("argument %s lacks closing parenthesis", arg)
 		}
-		val, err = base32DecodeAnyPadding(arg[open+1 : close])
+		if close != len(arg)-1 {
+			return nil, 0, fmt.Errorf("argument %s must end at first closing parenthesis", arg)
+		}
+		val, err := base32DecodeAnyPadding(arg[open+1 : close])
 		if err != nil {
-			return
+			return nil, 0, err
 		}
-		consumed = 1
+		return val, 1, nil
 	} else if strings.HasPrefix(arg, "base64(") || strings.HasPrefix(arg, "b64(") {
 		open := strings.IndexRune(arg, '(')
 		close := strings.IndexRune(arg, ')')
 		if close == -1 {
-			err = errors.New("byte base64 arg lacks close paren")
-			return
+			return nil, 0, fmt.Errorf("argument %s lacks closing parenthesis", arg)
 		}
-		val, err = base64.StdEncoding.DecodeString(arg[open+1 : close])
+		if close != len(arg)-1 {
+			return nil, 0, fmt.Errorf("argument %s must end at first closing parenthesis", arg)
+		}
+		val, err := base64.StdEncoding.DecodeString(arg[open+1 : close])
 		if err != nil {
-			return
+			return nil, 0, err
 		}
-		consumed = 1
+		return val, 1, nil
 	} else if strings.HasPrefix(arg, "0x") {
-		val, err = hex.DecodeString(arg[2:])
+		val, err := hex.DecodeString(arg[2:])
 		if err != nil {
-			return
+			return nil, 0, err
 		}
-		consumed = 1
+		return val, 1, nil
 	} else if arg == "base32" || arg == "b32" {
 		if len(args) < 2 {
-			err = fmt.Errorf("need literal after 'byte %s'", arg)
-			return
+			return nil, 0, fmt.Errorf("%s needs byte literal argument", arg)
 		}
-		val, err = base32DecodeAnyPadding(args[1])
+		val, err := base32DecodeAnyPadding(args[1].str)
 		if err != nil {
-			return
+			return nil, 1, err // return 1, so that the right token is blamed
 		}
-		consumed = 2
+		return val, 2, nil
 	} else if arg == "base64" || arg == "b64" {
 		if len(args) < 2 {
-			err = fmt.Errorf("need literal after 'byte %s'", arg)
-			return
+			return nil, 0, fmt.Errorf("%s needs byte literal argument", arg)
 		}
-		val, err = base64.StdEncoding.DecodeString(args[1])
+		val, err := base64.StdEncoding.DecodeString(args[1].str)
 		if err != nil {
-			return
+			return nil, 1, err
 		}
-		consumed = 2
+		return val, 2, nil
 	} else if len(arg) > 1 && arg[0] == '"' && arg[len(arg)-1] == '"' {
-		val, err = parseStringLiteral(arg)
-		consumed = 1
-	} else {
-		err = fmt.Errorf("byte arg did not parse: %v", arg)
-		return
+		val, err := parseStringLiteral(arg)
+		if err != nil {
+			return nil, 0, err
+		}
+		return val, 1, err
 	}
-	return
+	return nil, 0, fmt.Errorf("arg did not parse: %v", arg)
 }
 
 func parseStringLiteral(input string) (result []byte, err error) {
@@ -766,28 +778,29 @@ func parseStringLiteral(input string) (result []byte, err error) {
 // byte {base64,b64,base32,b32} ...
 // byte 0x....
 // byte "this is a string\n"
-func asmByte(ops *OpStream, spec *OpSpec, args []string) error {
+func asmByte(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
 	if len(args) == 0 {
-		return ops.errorf("%s needs byte literal argument", spec.Name)
+		return ops.errorAfterf(mnemonic, "%s needs byte literal argument", spec.Name)
 	}
 
 	// After backBranchEnabledVersion, control flow is confusing, so if there's
 	// a manual cblock, use push instead of trying to use what's given.
 	if ops.cntBytecBlock > 0 && ops.Version >= backBranchEnabledVersion {
 		// We don't understand control-flow, so use pushbytes
-		ops.warnf("byte %s used with explicit bytecblock. must pushbytes", args[0])
-		pushbytes := OpsByName[ops.Version]["pushbytes"]
-		return asmPushBytes(ops, &pushbytes, args)
+		ops.warnOnf(args[0], "byte %s used with explicit bytecblock. must pushbytes", args[0].str)
+		pushbytes := OpsByName[ops.Version]["pushbytes"] // make sure pushbytes opcode is written
+		return asmPushBytes(ops, &pushbytes, mnemonic, args)
 	}
 
 	// There are no backjumps, but there are multiple cblocks. Maybe one is
 	// conditional skipped. Too confusing.
 	if ops.cntBytecBlock > 1 {
+		// use pushbytes opcode if available
 		pushbytes, ok := OpsByName[ops.Version]["pushbytes"]
 		if ok {
-			return asmPushBytes(ops, &pushbytes, args)
+			return asmPushBytes(ops, &pushbytes, mnemonic, args)
 		}
-		return ops.errorf("byte %s used with manual bytecblocks. Use bytec.", args[0])
+		return ops.errorOnf(args[0], "byte %s used with manual bytecblocks. Use bytec.", args[0].str)
 	}
 
 	// In both of the above clauses, we _could_ track whether a particular
@@ -795,49 +808,55 @@ func asmByte(ops *OpStream, spec *OpSpec, args []string) error {
 
 	val, consumed, err := parseBinaryArgs(args)
 	if err != nil {
-		return ops.error(err)
+		return ops.errorOnf(args[consumed], "%s %w", spec.Name, err)
 	}
 	if len(args) != consumed {
-		return ops.errorf("%s with extraneous argument", spec.Name)
+		return ops.errorOnf(args[consumed], "%s with extraneous argument", spec.Name)
 	}
-	ops.ByteLiteral(val)
+	err = ops.byteLiteral(val)
+	if err != nil {
+		return ops.errorOn(args[0], err)
+	}
 	return nil
 }
 
 // method "add(uint64,uint64)uint64"
-func asmMethod(ops *OpStream, spec *OpSpec, args []string) error {
-	if len(args) == 0 {
-		return ops.error("method requires a literal argument")
+func asmMethod(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
+	if err := checkArgCount(spec.Name, mnemonic, args, 1); err != nil {
+		return ops.accumulate(err)
 	}
-	arg := args[0]
+	arg := args[0].str
 	if len(arg) > 1 && arg[0] == '"' && arg[len(arg)-1] == '"' {
 		methodSig, err := parseStringLiteral(arg)
 		if err != nil {
-			return ops.error(err)
+			return ops.errorOn(args[0], err)
 		}
 		methodSigStr := string(methodSig)
 		err = abi.VerifyMethodSignature(methodSigStr)
 		if err != nil {
 			// Warn if an invalid signature is used. Don't return an error, since the ABI is not
 			// governed by the core protocol, so there may be changes to it that we don't know about
-			ops.warnf("Invalid ARC-4 ABI method signature for method op: %s", err.Error())
+			ops.warnOnf(args[0], "invalid ARC-4 ABI method signature for method op: %w", err)
 		}
 		hash := sha512.Sum512_256(methodSig)
-		ops.ByteLiteral(hash[0:4])
+		err = ops.byteLiteral(hash[:4])
+		if err != nil {
+			return ops.errorOn(args[0], err)
+		}
 		return nil
 	}
-	return ops.error("Unable to parse method signature")
+	return ops.errorOn(args[0], "Unable to parse method signature")
 }
 
-func asmIntImmArgs(ops *OpStream, args []string) ([]uint64, error) {
+func asmIntImmArgs(ops *OpStream, args []token) ([]uint64, *sourceError) {
 	ivals := make([]uint64, len(args))
 	var scratch [binary.MaxVarintLen64]byte
 	l := binary.PutUvarint(scratch[:], uint64(len(args)))
 	ops.pending.Write(scratch[:l])
 	for i, xs := range args {
-		cu, err := strconv.ParseUint(xs, 0, 64)
+		cu, err := strconv.ParseUint(xs.str, 0, 64)
 		if err != nil {
-			ops.error(err)
+			ops.errorOn(xs, err)
 		}
 		l = binary.PutUvarint(scratch[:], cu)
 		ops.pending.Write(scratch[:l])
@@ -847,7 +866,7 @@ func asmIntImmArgs(ops *OpStream, args []string) ([]uint64, error) {
 	return ivals, nil
 }
 
-func asmIntCBlock(ops *OpStream, spec *OpSpec, args []string) error {
+func asmIntCBlock(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
 	ops.pending.WriteByte(spec.Opcode)
 	ivals, err := asmIntImmArgs(ops, args)
 	if err != nil {
@@ -857,7 +876,7 @@ func asmIntCBlock(ops *OpStream, spec *OpSpec, args []string) error {
 		// If we previously processed an `int`, we thought we could insert our
 		// own intcblock, but now we see a manual one.
 		if ops.hasPseudoInt {
-			ops.error("intcblock following int")
+			return ops.errorOn(mnemonic, "intcblock following int")
 		}
 		ops.intcRefs = nil
 		ops.intc = ivals
@@ -867,7 +886,7 @@ func asmIntCBlock(ops *OpStream, spec *OpSpec, args []string) error {
 	return nil
 }
 
-func asmByteImmArgs(ops *OpStream, args []string) ([][]byte, error) {
+func asmByteImmArgs(ops *OpStream, spec *OpSpec, args []token) ([][]byte, *sourceError) {
 	bvals := make([][]byte, 0, len(args))
 	rest := args
 	for len(rest) > 0 {
@@ -877,7 +896,7 @@ func asmByteImmArgs(ops *OpStream, args []string) ([][]byte, error) {
 			// intcblock, but parseBinaryArgs would have
 			// to return a useful consumed value even in
 			// the face of errors.  Hard.
-			return nil, ops.error(err)
+			return nil, ops.errorOnf(rest[0], "%s %w", spec.Name, err)
 		}
 		bvals = append(bvals, val)
 		rest = rest[consumed:]
@@ -894,9 +913,9 @@ func asmByteImmArgs(ops *OpStream, args []string) ([][]byte, error) {
 	return bvals, nil
 }
 
-func asmByteCBlock(ops *OpStream, spec *OpSpec, args []string) error {
+func asmByteCBlock(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
 	ops.pending.WriteByte(spec.Opcode)
-	bvals, err := asmByteImmArgs(ops, args)
+	bvals, err := asmByteImmArgs(ops, spec, args)
 	if err != nil {
 		return err
 	}
@@ -905,7 +924,7 @@ func asmByteCBlock(ops *OpStream, spec *OpSpec, args []string) error {
 		// If we previously processed a pseudo `byte`, we thought we could
 		// insert our own bytecblock, but now we see a manual one.
 		if ops.hasPseudoByte {
-			ops.error("bytecblock following byte/addr/method")
+			return ops.errorOn(mnemonic, "bytecblock following byte/addr/method")
 		}
 		ops.bytecRefs = nil
 		ops.bytec = bvals
@@ -916,25 +935,28 @@ func asmByteCBlock(ops *OpStream, spec *OpSpec, args []string) error {
 
 // addr A1EU...
 // parses base32-with-checksum account address strings into a byte literal
-func asmAddr(ops *OpStream, spec *OpSpec, args []string) error {
-	if len(args) != 1 {
-		return ops.errorf("%s needs one immediate argument, was given %d", spec.Name, len(args))
+func asmAddr(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
+	if err := checkArgCount(spec.Name, mnemonic, args, 1); err != nil {
+		return ops.accumulate(err)
 	}
-	addr, err := basics.UnmarshalChecksumAddress(args[0])
+	addr, err := basics.UnmarshalChecksumAddress(args[0].str)
 	if err != nil {
-		return ops.error(err)
+		return ops.errorOn(args[0], err)
 	}
-	ops.ByteLiteral(addr[:])
+	err = ops.byteLiteral(addr[:])
+	if err != nil {
+		return ops.errorOn(args[0], err)
+	}
 	return nil
 }
 
-func asmArg(ops *OpStream, spec *OpSpec, args []string) error {
-	if len(args) != 1 {
-		return ops.errorf("%s needs one immediate argument, was given %d", spec.Name, len(args))
+func asmArg(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
+	if err := checkArgCount(spec.Name, mnemonic, args, 1); err != nil {
+		return ops.accumulate(err)
 	}
-	val, err := byteImm(args[0], "argument")
+	val, err := byteImm(args[0].str, "argument")
 	if err != nil {
-		return ops.error(err)
+		return ops.errorOn(args[0], err)
 	}
 	altSpec := *spec
 	if val < 4 {
@@ -948,14 +970,14 @@ func asmArg(ops *OpStream, spec *OpSpec, args []string) error {
 		case 3:
 			altSpec = OpsByName[ops.Version]["arg_3"]
 		}
-		args = []string{}
+		args = []token{}
 	}
-	return asmDefault(ops, &altSpec, args)
+	return asmDefault(ops, &altSpec, mnemonic, args)
 }
 
-func asmBranch(ops *OpStream, spec *OpSpec, args []string) error {
-	if len(args) != 1 {
-		return ops.errorf("%s needs a single label argument", spec.Name)
+func asmBranch(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
+	if err := checkArgCount(spec.Name, mnemonic, args, 1); err != nil {
+		return ops.accumulate(err)
 	}
 
 	ops.referToLabel(ops.pending.Len()+1, args[0], ops.pending.Len()+spec.Size)
@@ -966,10 +988,10 @@ func asmBranch(ops *OpStream, spec *OpSpec, args []string) error {
 	return nil
 }
 
-func asmSwitch(ops *OpStream, spec *OpSpec, args []string) error {
+func asmSwitch(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
 	numOffsets := len(args)
 	if numOffsets > math.MaxUint8 {
-		return ops.errorf("%s cannot take more than 255 labels", spec.Name)
+		return ops.errorOnf(args[math.MaxUint8], "%s cannot take more than 255 labels", spec.Name)
 	}
 	ops.pending.WriteByte(spec.Opcode)
 	ops.pending.WriteByte(byte(numOffsets))
@@ -983,16 +1005,16 @@ func asmSwitch(ops *OpStream, spec *OpSpec, args []string) error {
 	return nil
 }
 
-func asmSubstring(ops *OpStream, spec *OpSpec, args []string) error {
-	err := asmDefault(ops, spec, args)
+func asmSubstring(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
+	err := asmDefault(ops, spec, mnemonic, args)
 	if err != nil {
 		return err
 	}
 	// Having run asmDefault, only need to check extra constraints.
-	start, _ := strconv.ParseUint(args[0], 0, 64)
-	end, _ := strconv.ParseUint(args[1], 0, 64)
+	start, _ := strconv.ParseUint(args[0].str, 0, 64)
+	end, _ := strconv.ParseUint(args[1].str, 0, 64)
 	if end < start {
-		return ops.error("substring end is before start")
+		return ops.errorOn(args[0], "substring end is before start")
 	}
 	return nil
 }
@@ -1016,58 +1038,74 @@ func int8Imm(value string, label string) (byte, error) {
 	return byte(res), err
 }
 
-func asmItxn(ops *OpStream, spec *OpSpec, args []string) error {
+func asmItxn(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
 	if len(args) == 1 {
-		return asmDefault(ops, spec, args)
+		return asmDefault(ops, spec, mnemonic, args)
 	}
 	if len(args) == 2 {
 		itxna := OpsByName[ops.Version]["itxna"]
-		return asmDefault(ops, &itxna, args)
+		return asmDefault(ops, &itxna, mnemonic, args)
 	}
-	return ops.errorf("%s expects 1 or 2 immediate arguments", spec.Name)
+	return ops.errorOnf(mnemonic, "%s expects 1 or 2 immediate arguments", spec.Name)
 }
 
 // asmGitxn substitutes gitna's spec if the are 3 args
-func asmGitxn(ops *OpStream, spec *OpSpec, args []string) error {
+func asmGitxn(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
 	if len(args) == 2 {
-		return asmDefault(ops, spec, args)
+		return asmDefault(ops, spec, mnemonic, args)
 	}
 	if len(args) == 3 {
 		itxna := OpsByName[ops.Version]["gitxna"]
-		return asmDefault(ops, &itxna, args)
+		return asmDefault(ops, &itxna, mnemonic, args)
 	}
-	return ops.errorf("%s expects 2 or 3 immediate arguments", spec.Name)
+	return ops.errorOnf(mnemonic, "%s expects 2 or 3 immediate arguments", spec.Name)
 }
 
-func asmItxnField(ops *OpStream, spec *OpSpec, args []string) error {
-	if len(args) != 1 {
-		return ops.errorf("%s expects one argument", spec.Name)
+func asmItxnField(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
+	if err := checkArgCount(spec.Name, mnemonic, args, 1); err != nil {
+		return ops.accumulate(err)
 	}
-	fs, ok := txnFieldSpecByName[args[0]]
+	fs, ok := txnFieldSpecByName[args[0].str]
 	if !ok {
-		return ops.errorf("%s unknown field: %#v", spec.Name, args[0])
+		return ops.errorOnf(args[0], "%s unknown field: %#v", spec.Name, args[0].str)
 	}
 	if fs.itxVersion == 0 {
-		return ops.errorf("%s %#v is not allowed.", spec.Name, args[0])
+		return ops.errorOnf(args[0], "%s %#v is not allowed.", spec.Name, args[0].str)
 	}
 	if fs.itxVersion > ops.Version {
-		return ops.errorf("%s %s field was introduced in v%d. Missed #pragma version?", spec.Name, args[0], fs.itxVersion)
+		return ops.errorOnf(args[0], "%s %s field was introduced in v%d. Missed #pragma version?", spec.Name, args[0].str, fs.itxVersion)
 	}
 	ops.pending.WriteByte(spec.Opcode)
 	ops.pending.WriteByte(fs.Field())
 	return nil
 }
 
-type asmFunc func(*OpStream, *OpSpec, []string) error
+type asmFunc func(*OpStream, *OpSpec, token, []token) *sourceError
+
+func checkArgCount(name string, mnemonic token, args []token, expected int) *sourceError {
+	offered := len(args)
+	if offered != expected {
+		all := make([]token, len(args)+1)
+		all[0] = mnemonic
+		copy(all[1:], args)
+		line := all[offered].line
+		col := all[offered].col + len(all[offered].str) // end of last arg (or mnemonic)
+		if offered > expected {
+			line = all[expected+1].line
+			col = all[expected+1].col // start of first extra arg
+		}
+		if expected == 1 {
+			return positionError(line, col, "%s expects 1 immediate argument", name)
+		}
+		return positionError(line, col, "%s expects %d immediate arguments", name, expected)
+	}
+	return nil
+}
 
 // Basic assembly. Any extra bytes of opcode are encoded as byte immediates.
-func asmDefault(ops *OpStream, spec *OpSpec, args []string) error {
-	expected := len(spec.OpDetails.Immediates)
-	if len(args) != expected {
-		if expected == 1 {
-			return ops.errorf("%s expects 1 immediate argument", spec.Name)
-		}
-		return ops.errorf("%s expects %d immediate arguments", spec.Name, expected)
+func asmDefault(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
+	if err := checkArgCount(spec.Name, mnemonic, args, len(spec.OpDetails.Immediates)); err != nil {
+		return ops.accumulate(err)
 	}
 	ops.pending.WriteByte(spec.Opcode)
 	for i, imm := range spec.OpDetails.Immediates {
@@ -1077,9 +1115,9 @@ func asmDefault(ops *OpStream, spec *OpSpec, args []string) error {
 		switch imm.kind {
 		case immByte:
 			if imm.Group != nil {
-				fs, ok := imm.Group.SpecByName(args[i])
+				fs, ok := imm.Group.SpecByName(args[i].str)
 				if !ok {
-					_, err := byteImm(args[i], "")
+					_, err := byteImm(args[i].str, "")
 					if err == nil {
 						// User supplied a uint, so we see if any of the other immediates take uints
 						for j, otherImm := range spec.OpDetails.Immediates {
@@ -1092,43 +1130,43 @@ func asmDefault(ops *OpStream, spec *OpSpec, args []string) error {
 							if isPseudoName {
 								errMsg += " with " + joinIntsOnOr("immediate", len(args))
 							}
-							return ops.errorf("%s can only use %#v as immediate %s", errMsg, args[i], strings.Join(correctImmediates, " or "))
+							return ops.errorOnf(args[i], "%s can only use %#v as immediate %s", errMsg, args[i].str, strings.Join(correctImmediates, " or "))
 						}
 					}
 					if isPseudoName {
 						for numImms, ps := range pseudos {
 							for _, psImm := range ps.OpDetails.Immediates {
 								if psImm.kind == immByte && psImm.Group != nil {
-									if _, ok := psImm.Group.SpecByName(args[i]); ok {
+									if _, ok := psImm.Group.SpecByName(args[i].str); ok {
 										numImmediatesWithField = append(numImmediatesWithField, numImms)
 									}
 								}
 							}
 						}
 						if len(numImmediatesWithField) > 0 {
-							return ops.errorf("%#v field of %s can only be used with %s", args[i], spec.Name, joinIntsOnOr("immediate", numImmediatesWithField...))
+							return ops.errorOnf(args[i], "%#v field of %s can only be used with %s", args[i].str, spec.Name, joinIntsOnOr("immediate", numImmediatesWithField...))
 						}
 					}
-					return ops.errorf("%s unknown field: %#v", spec.Name, args[i])
+					return ops.errorOnf(args[i], "%s unknown field: %#v", spec.Name, args[i].str)
 				}
 				// refine the typestack now, so it is maintained even if there's a version error
 				if fs.Type().Typed() {
 					ops.returns(spec, fs.Type())
 				}
 				if fs.Version() > ops.Version {
-					return ops.errorf("%s %s field was introduced in v%d. Missed #pragma version?",
-						spec.Name, args[i], fs.Version())
+					return ops.errorOnf(args[i], "%s %s field was introduced in v%d. Missed #pragma version?",
+						spec.Name, args[i].str, fs.Version())
 				}
 				ops.pending.WriteByte(fs.Field())
 			} else {
 				// simple immediate that must be a number from 0-255
-				val, err := byteImm(args[i], imm.Name)
+				val, err := byteImm(args[i].str, imm.Name)
 				if err != nil {
 					if strings.Contains(err.Error(), "unable to parse") {
 						// Perhaps the field works in a different order
 						for j, otherImm := range spec.OpDetails.Immediates {
 							if otherImm.kind == immByte && otherImm.Group != nil {
-								if _, match := otherImm.Group.SpecByName(args[i]); match {
+								if _, match := otherImm.Group.SpecByName(args[i].str); match {
 									correctImmediates = append(correctImmediates, strconv.Itoa(j+1))
 								}
 							}
@@ -1138,21 +1176,21 @@ func asmDefault(ops *OpStream, spec *OpSpec, args []string) error {
 							if isPseudoName {
 								errMsg += " with " + joinIntsOnOr("immediate", len(args))
 							}
-							return ops.errorf("%s can only use %#v as immediate %s", errMsg, args[i], strings.Join(correctImmediates, " or "))
+							return ops.errorOnf(args[i], "%s can only use %#v as immediate %s", errMsg, args[i].str, strings.Join(correctImmediates, " or "))
 						}
 					}
-					return ops.errorf("%s %w", spec.Name, err)
+					return ops.errorOnf(args[i], "%s %w", spec.Name, err)
 				}
 				ops.pending.WriteByte(val)
 			}
 		case immInt8:
-			val, err := int8Imm(args[i], imm.Name)
+			val, err := int8Imm(args[i].str, imm.Name)
 			if err != nil {
-				return ops.errorf("%s %w", spec.Name, err)
+				return ops.errorOnf(args[i], "%s %w", spec.Name, err)
 			}
 			ops.pending.WriteByte(val)
 		default:
-			return ops.errorf("unable to assemble immKind %d", imm.kind)
+			return ops.errorOnf(args[i], "unable to assemble immKind %d", imm.kind)
 		}
 	}
 	return nil
@@ -1160,13 +1198,13 @@ func asmDefault(ops *OpStream, spec *OpSpec, args []string) error {
 
 // getImm interprets the arg at index argIndex as an immediate that must be
 // between -128 and 127 (if signed=true) or between 0 and 255 (if signed=false)
-func getImm(args []string, argIndex int, signed bool) (int, bool) {
+func getImm(args []token, argIndex int, signed bool) (int, bool) {
 	if len(args) <= argIndex {
 		return 0, false
 	}
 	// We want to parse anything from -128 up to 255. So allow 9 bits.
 	// Normal assembly checking will catch signed as byte, vice versa
-	n, err := strconv.ParseInt(args[argIndex], 0, 9)
+	n, err := strconv.ParseInt(args[argIndex].str, 0, 9)
 	if err != nil {
 		return 0, false
 	}
@@ -1190,7 +1228,7 @@ func anyTypes(n int) StackTypes {
 	return as
 }
 
-func typeSwap(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeSwap(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	swapped := StackTypes{StackAny, StackAny}
 	top := len(pgm.stack) - 1
 	if top >= 0 {
@@ -1202,7 +1240,7 @@ func typeSwap(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, err
 	return nil, swapped, nil
 }
 
-func typeDig(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeDig(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	n, ok := getImm(args, 0, false)
 	if !ok {
 		return nil, nil, nil
@@ -1219,7 +1257,7 @@ func typeDig(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, erro
 	return anyTypes(depth), returns, nil
 }
 
-func typeBury(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeBury(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	n, ok := getImm(args, 0, false)
 	if !ok {
 		return nil, nil, nil
@@ -1251,7 +1289,7 @@ func typeBury(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, err
 	return pgm.stack[idx:], returns, nil
 }
 
-func typeFrameDig(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeFrameDig(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	n, ok := getImm(args, 0, true)
 	if !ok {
 		return nil, nil, nil
@@ -1272,7 +1310,7 @@ func typeFrameDig(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes,
 	return nil, StackTypes{pgm.stack[idx]}, nil
 }
 
-func typeFrameBury(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeFrameBury(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	n, ok := getImm(args, 0, true)
 	if !ok {
 		return nil, nil, nil
@@ -1313,7 +1351,7 @@ func typeFrameBury(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes
 	return pgm.stack[idx:], returns, nil
 }
 
-func typeEquals(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeEquals(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	top := len(pgm.stack) - 1
 	if top >= 0 {
 		// Require arg0 and arg1 to have same avm type
@@ -1324,7 +1362,7 @@ func typeEquals(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, e
 	return nil, nil, nil
 }
 
-func typeDup(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeDup(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	top := len(pgm.stack) - 1
 	if top >= 0 {
 		return nil, StackTypes{pgm.stack[top], pgm.stack[top]}, nil
@@ -1332,7 +1370,7 @@ func typeDup(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, erro
 	return nil, nil, nil
 }
 
-func typeDupTwo(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeDupTwo(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	topTwo := StackTypes{StackAny, StackAny}
 	top := len(pgm.stack) - 1
 	if top >= 0 {
@@ -1344,7 +1382,7 @@ func typeDupTwo(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, e
 	return nil, append(topTwo, topTwo...), nil
 }
 
-func typeSelect(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeSelect(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	top := len(pgm.stack) - 1
 	if top >= 2 {
 		return nil, StackTypes{pgm.stack[top-1].union(pgm.stack[top-2])}, nil
@@ -1352,7 +1390,7 @@ func typeSelect(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, e
 	return nil, nil, nil
 }
 
-func typeSetBit(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeSetBit(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	top := len(pgm.stack) - 1
 	if top >= 2 {
 		return nil, StackTypes{pgm.stack[top-2]}, nil
@@ -1360,7 +1398,7 @@ func typeSetBit(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, e
 	return nil, nil, nil
 }
 
-func typeCover(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeCover(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	n, ok := getImm(args, 0, false)
 	if !ok {
 		return nil, nil, nil
@@ -1382,7 +1420,7 @@ func typeCover(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, er
 	return anyTypes(depth), returns, nil
 }
 
-func typeUncover(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeUncover(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	n, ok := getImm(args, 0, false)
 	if !ok {
 		return nil, nil, nil
@@ -1401,23 +1439,23 @@ func typeUncover(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, 
 }
 
 func typeByteMath(resultSize uint64) refineFunc {
-	return func(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+	return func(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 		return nil, StackTypes{NewStackType(avmBytes, bound(0, resultSize))}, nil
 	}
 }
 
-func typeTxField(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeTxField(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	if len(args) != 1 {
 		return nil, nil, nil
 	}
-	fs, ok := txnFieldSpecByName[args[0]]
+	fs, ok := txnFieldSpecByName[args[0].str]
 	if !ok {
 		return nil, nil, nil
 	}
 	return StackTypes{fs.ftype}, nil, nil
 }
 
-func typeStore(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeStore(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	scratchIndex, ok := getImm(args, 0, false)
 	if !ok {
 		return nil, nil, nil
@@ -1429,7 +1467,7 @@ func typeStore(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, er
 	return nil, nil, nil
 }
 
-func typeStores(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeStores(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	top := len(pgm.stack) - 1
 	if top < 0 {
 		return nil, nil, nil
@@ -1452,7 +1490,7 @@ func typeStores(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, e
 	return nil, nil, nil
 }
 
-func typeLoad(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeLoad(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	scratchIndex, ok := getImm(args, 0, false)
 	if !ok {
 		return nil, nil, nil
@@ -1460,7 +1498,7 @@ func typeLoad(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, err
 	return nil, StackTypes{pgm.scratchSpace[scratchIndex]}, nil
 }
 
-func typeProto(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeProto(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	a, aok := getImm(args, 0, false)
 	_, rok := getImm(args, 1, false)
 	if !aok || !rok {
@@ -1475,8 +1513,7 @@ func typeProto(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, er
 	return nil, nil, nil
 }
 
-func typeLoads(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
-
+func typeLoads(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	top := len(pgm.stack) - 1
 	if top < 0 {
 		return nil, nil, nil
@@ -1496,7 +1533,7 @@ func typeLoads(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, er
 	return nil, StackTypes{scratchType}, nil
 }
 
-func typePopN(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typePopN(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	n, ok := getImm(args, 0, false)
 	if !ok {
 		return nil, nil, nil
@@ -1504,7 +1541,7 @@ func typePopN(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, err
 	return anyTypes(n), nil, nil
 }
 
-func typeDupN(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeDupN(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	n, ok := getImm(args, 0, false)
 	if !ok {
 		return nil, nil, nil
@@ -1523,7 +1560,7 @@ func typeDupN(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, err
 	return nil, copies, nil
 }
 
-func typePushBytess(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typePushBytess(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	types := make(StackTypes, len(args))
 	for i := range types {
 		types[i] = StackBytes
@@ -1532,7 +1569,7 @@ func typePushBytess(pgm *ProgramKnowledge, args []string) (StackTypes, StackType
 	return nil, types, nil
 }
 
-func typePushInts(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typePushInts(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	types := make(StackTypes, len(args))
 	for i := range types {
 		types[i] = StackUint64
@@ -1541,10 +1578,10 @@ func typePushInts(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes,
 	return nil, types, nil
 }
 
-func typePushInt(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typePushInt(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	types := make(StackTypes, len(args))
 	for i := range types {
-		val, err := strconv.ParseUint(args[i], 10, 64)
+		val, err := strconv.ParseUint(args[i].str, 10, 64)
 		if err != nil {
 			types[i] = StackUint64
 		} else {
@@ -1554,12 +1591,12 @@ func typePushInt(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, 
 	return nil, types, nil
 }
 
-func typeBzero(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeBzero(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	// Bzero should only allow its input int to be up to maxStringSize bytes
 	return StackTypes{StackUint64.narrowed(bound(0, maxStringSize))}, StackTypes{StackBytes}, nil
 }
 
-func typeByte(pgm *ProgramKnowledge, args []string) (StackTypes, StackTypes, error) {
+func typeByte(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
 	if len(args) == 0 {
 		return nil, StackTypes{StackBytes}, nil
 	}
@@ -1591,41 +1628,45 @@ func joinIntsOnOr(singularTerminator string, list ...int) string {
 	return errMsg + singularTerminator + "s"
 }
 
-func pseudoImmediatesError(ops *OpStream, name string, specs map[int]OpSpec) {
+func pseudoImmediatesError(ops *OpStream, mnemonic token, specs map[int]OpSpec) {
 	immediateCounts := make([]int, len(specs))
 	i := 0
 	for numImms := range specs {
 		immediateCounts[i] = numImms
 		i++
 	}
-	ops.error(name + " expects " + joinIntsOnOr("immediate argument", immediateCounts...))
+	ops.errorOn(mnemonic, mnemonic.str+" expects "+joinIntsOnOr("immediate argument", immediateCounts...))
 }
 
 // getSpec finds the OpSpec we need during assembly based on its name, our current version, and the immediates passed in
 // Note getSpec handles both normal OpSpecs and those supplied by versionedPseudoOps
 // The returned string is the spec's name, annotated if it was a pseudoOp with no immediates to help disambiguate typetracking errors
-func getSpec(ops *OpStream, name string, args []string) (OpSpec, string, bool) {
+func getSpec(ops *OpStream, mnemonic token, args int) (OpSpec, string, bool) {
+	name := mnemonic.str
 	pseudoSpecs, ok := ops.versionedPseudoOps[name]
 	if ok {
-		pseudo, ok := pseudoSpecs[len(args)]
+		pseudo, ok := pseudoSpecs[args]
 		if !ok {
 			// Could be that pseudoOp wants to handle immediates itself so check -1 key
 			pseudo, ok = pseudoSpecs[anyImmediates]
 			if !ok {
 				// Number of immediates supplied did not match any of the pseudoOps of the given name, so we try to construct a mock spec that can be used to track types
-				pseudoImmediatesError(ops, name, pseudoSpecs)
+				pseudoImmediatesError(ops, mnemonic, pseudoSpecs)
 				proto, version, ok := mergeProtos(pseudoSpecs)
 				if !ok {
 					return OpSpec{}, "", false
 				}
-				pseudo = OpSpec{Name: name, Proto: proto, Version: version, OpDetails: OpDetails{asm: func(*OpStream, *OpSpec, []string) error { return nil }}}
+				pseudo = OpSpec{Name: name, Proto: proto, Version: version, OpDetails: OpDetails{
+					asm: func(*OpStream, *OpSpec, token, []token) *sourceError { return nil },
+				}}
 			}
 		}
 		pseudo.Name = name
 		if pseudo.Version > ops.Version {
-			ops.errorf("%s opcode with %s was introduced in v%d", pseudo.Name, joinIntsOnOr("immediate", len(args)), pseudo.Version)
+			ops.errorOnf(mnemonic, "%s opcode with %s was introduced in v%d",
+				pseudo.Name, joinIntsOnOr("immediate", args), pseudo.Version)
 		}
-		if len(args) == 0 {
+		if args == 0 {
 			return pseudo, pseudo.Name + " without immediates", true
 		}
 		return pseudo, pseudo.Name, true
@@ -1635,7 +1676,7 @@ func getSpec(ops *OpStream, name string, args []string) (OpSpec, string, bool) {
 		var err error
 		spec, err = unknownOpcodeComplaint(name, ops.Version)
 		// unknownOpcodeComplaint's job is to return a nice error, so err != nil
-		ops.error(err)
+		ops.errorOn(mnemonic, err)
 	}
 	return spec, spec.Name, ok
 }
@@ -1764,29 +1805,61 @@ func prepareVersionedPseudoTable(version uint64) map[string]map[int]OpSpec {
 	return m
 }
 
-type lineError struct {
-	Line int
-	Err  error
+type sourceError struct {
+	Line   int
+	Column int
+	Err    error
 }
 
-func (le lineError) Error() string {
-	return fmt.Sprintf("%d: %s", le.Line, le.Err.Error())
+func (se sourceError) Error() string {
+	if se.Column != 0 {
+		return fmt.Sprintf("%d:%d: %s", se.Line, se.Column, se.Err.Error())
+	}
+	return fmt.Sprintf("%d: %s", se.Line, se.Err.Error())
 }
 
-func (le lineError) Unwrap() error {
-	return le.Err
+func (se sourceError) Unwrap() error {
+	return se.Err
+}
+
+func positionError(line, col int, format string, args ...interface{}) *sourceError {
+	return &sourceError{line, col, fmt.Errorf(format, args...)}
+}
+
+func tokenError(t token, format string, args ...interface{}) *sourceError {
+	return positionError(t.line, t.col, format, args...)
+}
+
+func typecheck(expected, got StackType) bool {
+	// Some ops push 'any' and we wait for run time to see what it is.
+	// Some of those 'any' are based on fields that we _could_ know now but haven't written a more detailed system of typecheck for (yet).
+	if expected == StackAny && got == StackNone { // Any is lenient, but stack can't be empty
+		return false
+	}
+	if (expected == StackAny) || (got == StackAny) {
+		return true
+	}
+	return expected == got
+}
+
+type token struct {
+	str  string
+	col  int
+	line int
 }
 
 // newline not included since handled in scanner
 var tokenSeparators = [256]bool{'\t': true, ' ': true, ';': true}
 
-func tokensFromLine(line string) []string {
-	var tokens []string
+// tokensFromLine splits a line into tokens, ignoring comments. tokens are
+// annotated with the correct column, but the caller should add the line number.
+func tokensFromLine(line string, lineno int) []token {
+	var tokens []token
 
 	i := 0
 	for i < len(line) && tokenSeparators[line[i]] {
 		if line[i] == ';' {
-			tokens = append(tokens, ";")
+			tokens = append(tokens, token{";", i, lineno})
 		}
 		i++
 	}
@@ -1810,7 +1883,7 @@ func tokensFromLine(line string) []string {
 			case '/': // is a comment?
 				if i < len(line)-1 && line[i+1] == '/' && !inBase64 && !inString {
 					if start != i { // if a comment without whitespace
-						tokens = append(tokens, line[start:i])
+						tokens = append(tokens, token{line[start:i], start, lineno})
 					}
 					return tokens
 				}
@@ -1832,14 +1905,14 @@ func tokensFromLine(line string) []string {
 		// we've hit a space, end last token unless inString
 
 		if !inString {
-			token := line[start:i]
-			tokens = append(tokens, token)
+			s := line[start:i]
+			tokens = append(tokens, token{s, start, lineno})
 			if line[i] == ';' {
-				tokens = append(tokens, ";")
+				tokens = append(tokens, token{";", i, lineno})
 			}
 			if inBase64 {
 				inBase64 = false
-			} else if token == "base64" || token == "b64" {
+			} else if s == "base64" || s == "b64" {
 				inBase64 = true
 			}
 		}
@@ -1849,7 +1922,7 @@ func tokensFromLine(line string) []string {
 		if !inString {
 			for i < len(line) && tokenSeparators[line[i]] {
 				if line[i] == ';' {
-					tokens = append(tokens, ";")
+					tokens = append(tokens, token{";", i, lineno})
 				}
 				i++
 			}
@@ -1859,7 +1932,7 @@ func tokensFromLine(line string) []string {
 
 	// add rest of the string if any
 	if start < len(line) {
-		tokens = append(tokens, line[start:i])
+		tokens = append(tokens, token{line[start:i], start, lineno})
 	}
 
 	return tokens
@@ -1872,22 +1945,32 @@ func (ops *OpStream) trace(format string, args ...interface{}) {
 	fmt.Fprintf(ops.Trace, format, args...)
 }
 
-func (ops *OpStream) typeErrorf(format string, args ...interface{}) {
+func (ops *OpStream) typeErrorf(opcode token, format string, args ...interface{}) {
 	if ops.typeTracking {
-		ops.errorf(format, args...)
+		ops.errorOnf(opcode, format, args...)
 	}
 }
 
+func reJoin(instruction string, args []token) string {
+	var buf bytes.Buffer
+	buf.WriteString(instruction)
+	for _, t := range args {
+		buf.WriteString(" ")
+		buf.WriteString(t.str)
+	}
+	return buf.String()
+}
+
 // trackStack checks that the typeStack has `args` on it, then pushes `returns` to it.
-func (ops *OpStream) trackStack(args StackTypes, returns StackTypes, instruction []string) {
+func (ops *OpStream) trackStack(args StackTypes, returns StackTypes, instruction string, tokens []token) {
 	// If in deadcode, allow anything. Maybe it's some sort of onchain data.
 	if ops.known.deadcode {
 		return
 	}
 	argcount := len(args)
 	if argcount > len(ops.known.stack) && ops.known.bottom.AVMType == avmNone {
-		ops.typeErrorf("%s expects %d stack arguments but stack height is %d",
-			strings.Join(instruction, " "), argcount, len(ops.known.stack))
+		ops.typeErrorf(tokens[0], "%s expects %d stack arguments but stack height is %d",
+			reJoin(instruction, tokens[1:]), argcount, len(ops.known.stack))
 	} else {
 		firstPop := true
 		for i := argcount - 1; i >= 0; i-- {
@@ -1900,8 +1983,8 @@ func (ops *OpStream) trackStack(args StackTypes, returns StackTypes, instruction
 				ops.trace(", %s", argType)
 			}
 			if !stype.overlaps(argType) {
-				ops.typeErrorf("%s arg %d wanted type %s got %s",
-					strings.Join(instruction, " "), i, argType, stype)
+				ops.typeErrorf(tokens[0], "%s arg %d wanted type %s got %s",
+					reJoin(instruction, tokens[1:]), i, argType, stype)
 			}
 		}
 		if !firstPop {
@@ -1922,49 +2005,49 @@ func (ops *OpStream) trackStack(args StackTypes, returns StackTypes, instruction
 }
 
 // nextStatement breaks tokens into two slices at the first semicolon and expands macros along the way.
-func nextStatement(ops *OpStream, tokens []string) (current, rest []string) {
+func nextStatement(ops *OpStream, tokens []token) (current, rest []token) {
 	for i := 0; i < len(tokens); i++ {
 		token := tokens[i]
-		replacement, ok := ops.macros[token]
+		replacement, ok := ops.macros[token.str]
 		if ok {
-			tokens = append(tokens[0:i], append(replacement, tokens[i+1:]...)...)
+			tokens = append(tokens[0:i], append(replacement[1:], tokens[i+1:]...)...)
 			// backup to handle potential re-expansion of the first token in the expansion
 			i--
 			continue
 		}
-		if token == ";" {
+		if token.str == ";" {
 			return tokens[:i], tokens[i+1:]
 		}
 	}
 	return tokens, nil
 }
 
-type directiveFunc func(*OpStream, []string) error
+type directiveFunc func(*OpStream, []token) error
 
 var directives = map[string]directiveFunc{"pragma": pragma, "define": define}
 
 // assemble reads text from an input and accumulates the program
 func (ops *OpStream) assemble(text string) error {
 	if ops.Version > LogicVersion && ops.Version != assemblerNoVersion {
-		return ops.errorf("Can not assemble version %d", ops.Version)
+		return ops.errorOnf(token{line: 1}, "Can not assemble version %d", ops.Version)
 	}
 	if strings.TrimSpace(text) == "" {
-		return ops.errorf("Cannot assemble empty program text")
+		return ops.errorOnf(token{line: 1}, "Cannot assemble empty program text")
 	}
 	fin := strings.NewReader(text)
 	scanner := bufio.NewScanner(fin)
 	for scanner.Scan() {
 		ops.sourceLine++
 		line := scanner.Text()
-		tokens := tokensFromLine(line)
+		tokens := tokensFromLine(line, ops.sourceLine)
 		if len(tokens) > 0 {
-			if first := tokens[0]; first[0] == '#' {
-				directive := first[1:]
+			if first := tokens[0]; first.str[0] == '#' {
+				directive := first.str[1:]
 				if dFunc, ok := directives[directive]; ok {
 					_ = dFunc(ops, tokens)
-					ops.trace("%3d: %s line\n", ops.sourceLine, first)
+					ops.trace("%3d: %s line\n", first.line, first.str)
 				} else {
-					ops.errorf("Unknown directive: %s", directive)
+					ops.errorOnf(first, "Unknown directive: %s", directive)
 				}
 				continue
 			}
@@ -1981,22 +2064,22 @@ func (ops *OpStream) assemble(text string) error {
 			if ops.versionedPseudoOps == nil {
 				ops.versionedPseudoOps = prepareVersionedPseudoTable(ops.Version)
 			}
-			opstring := current[0]
+			opstring := current[0].str
 			if opstring[len(opstring)-1] == ':' {
 				labelName := opstring[:len(opstring)-1]
 				if _, ok := ops.macros[labelName]; ok {
-					ops.errorf("Cannot create label with same name as macro: %s", labelName)
+					ops.errorOnf(current[0], "Cannot create label with same name as macro: %s", labelName)
 				} else {
-					ops.createLabel(opstring[:len(opstring)-1])
+					ops.createLabel(current[0])
 				}
 				current = current[1:]
 				if len(current) == 0 {
 					ops.trace("%3d: label only\n", ops.sourceLine)
 					continue
 				}
-				opstring = current[0]
+				opstring = current[0].str
 			}
-			spec, expandedName, ok := getSpec(ops, opstring, current[1:])
+			spec, expandedName, ok := getSpec(ops, current[0], len(current)-1)
 			if ok {
 				ops.trace("%3d: %s\t", ops.sourceLine, opstring)
 				ops.recordSourceLine()
@@ -2007,7 +2090,7 @@ func (ops *OpStream) assemble(text string) error {
 				if spec.refine != nil {
 					nargs, nreturns, err := spec.refine(&ops.known, current[1:])
 					if err != nil {
-						ops.typeErrorf("%w", err)
+						ops.typeErrorf(current[0], "%w", err)
 					}
 					if nargs != nil {
 						args = nargs
@@ -2016,10 +2099,9 @@ func (ops *OpStream) assemble(text string) error {
 						returns = nreturns
 					}
 				}
-				ops.trackStack(args, returns, append([]string{expandedName}, current[1:]...))
-				spec.asm(ops, &spec, current[1:]) //nolint:errcheck // ignore error and continue, to collect more errors
-
-				if spec.deadens() { // An unconditional branch deadens the following code
+				ops.trackStack(args, returns, expandedName, current)
+				spec.asm(ops, &spec, current[0], current[1:]) //nolint:errcheck // ignore error and continue, to collect more errors
+				if spec.deadens() {                           // An unconditional branch deadens the following code
 					ops.known.deaden()
 				}
 				if spec.Name == "callsub" {
@@ -2036,16 +2118,7 @@ func (ops *OpStream) assemble(text string) error {
 		if errors.Is(err, bufio.ErrTooLong) {
 			err = errors.New("line too long")
 		}
-		ops.error(err)
-	}
-
-	// backward compatibility: do not allow jumps past last instruction in v1
-	if ops.Version <= 1 {
-		for label, dest := range ops.labels {
-			if dest == ops.pending.Len() {
-				ops.errorf("label %#v is too far away", label)
-			}
-		}
+		ops.errorOn(token{line: ops.sourceLine}, err)
 	}
 
 	if ops.Version >= optimizeConstantsEnabledVersion {
@@ -2066,21 +2139,23 @@ func (ops *OpStream) assemble(text string) error {
 	return nil
 }
 
-func (ops *OpStream) cycle(macro string, previous ...string) bool {
-	replacement, ok := ops.macros[macro]
+// cycle return a slice of strings that constitute a cycle, if one is
+// found. That is, the first token expands to the second, and so on, with the
+// first and last string being the same.
+func (ops *OpStream) cycle(macro token, previous []string) []string {
+	replacement, ok := ops.macros[macro.str]
 	if !ok {
-		return false
+		return nil
 	}
-	if len(previous) > 0 && macro == previous[0] {
-		ops.errorf("Macro cycle discovered: %s", strings.Join(append(previous, macro), " -> "))
-		return true
+	if len(previous) > 0 && macro.str == previous[0] {
+		return append(previous, macro.str)
 	}
-	for _, token := range replacement {
-		if ops.cycle(token, append(previous, macro)...) {
-			return true
+	for _, repl := range replacement[1:] {
+		if found := ops.cycle(repl, append(previous, macro.str)); found != nil {
+			return found
 		}
 	}
-	return false
+	return nil
 }
 
 // recheckMacroNames goes through previously defined macros and ensures they
@@ -2091,8 +2166,8 @@ func (ops *OpStream) recheckMacroNames() error {
 	for macroName := range ops.macros {
 		err := checkMacroName(macroName, ops.Version, ops.labels)
 		if err != nil {
+			ops.errorOn(ops.macros[macroName][0], err)
 			delete(ops.macros, macroName)
-			ops.error(err)
 			errored = true
 		}
 	}
@@ -2156,57 +2231,58 @@ func checkMacroName(macroName string, version uint64, labels map[string]int) err
 	return nil
 }
 
-func define(ops *OpStream, tokens []string) error {
-	if tokens[0] != "#define" {
-		return ops.errorf("invalid syntax: %s", tokens[0])
+func define(ops *OpStream, tokens []token) error {
+	if tokens[0].str != "#define" {
+		return ops.errorOnf(tokens[0], "invalid syntax: %s", tokens[0].str)
 	}
 	if len(tokens) < 3 {
-		return ops.errorf("define directive requires a name and body")
+		return ops.errorOnf(tokens[len(tokens)-1], "define directive requires a name and body")
 	}
-	name := tokens[1]
+	name := tokens[1].str
 	err := checkMacroName(name, ops.Version, ops.labels)
 	if err != nil {
-		return ops.error(err)
+		return ops.errorOn(tokens[1], err)
 	}
 	saved, ok := ops.macros[name]
-	ops.macros[name] = tokens[2:len(tokens):len(tokens)]
-	if ops.cycle(tokens[1]) {
+	ops.macros[name] = tokens[1:len(tokens):len(tokens)] // include the name itself at the front
+	if found := ops.cycle(tokens[1], nil); found != nil {
 		if ok {
-			ops.macros[tokens[1]] = saved
+			ops.macros[name] = saved // restore previous macro
 		} else {
-			delete(ops.macros, tokens[1])
+			delete(ops.macros, name) // remove new macro that caused cycle
 		}
+		ops.errorOnf(tokens[1], "macro expansion cycle discovered: %s", strings.Join(found, " -> "))
 	}
 	return nil
 }
 
-func pragma(ops *OpStream, tokens []string) error {
-	if tokens[0] != "#pragma" {
-		return ops.errorf("invalid syntax: %s", tokens[0])
+func pragma(ops *OpStream, tokens []token) error {
+	if tokens[0].str != "#pragma" {
+		return ops.errorOnf(tokens[0], "invalid syntax: %s", tokens[0].str)
 	}
 	if len(tokens) < 2 {
-		return ops.error("empty pragma")
+		return ops.errorOn(tokens[0], "empty pragma")
 	}
-	key := tokens[1]
+	key := tokens[1].str
 	switch key {
 	case "version":
 		if len(tokens) < 3 {
-			return ops.error("no version value")
+			return ops.errorOn(tokens[1], "no version value")
 		}
 		if len(tokens) > 3 {
-			return ops.errorf("unexpected extra tokens: %s", strings.Join(tokens[3:], " "))
+			return ops.errorOnf(tokens[3], "unexpected extra tokens:%s", reJoin("", tokens[3:]))
 		}
-		value := tokens[2]
 		var ver uint64
 		if ops.pending.Len() > 0 {
-			return ops.error("#pragma version is only allowed before instructions")
+			return ops.errorOn(tokens[0], "#pragma version is only allowed before instructions")
 		}
+		value := tokens[2].str
 		ver, err := strconv.ParseUint(value, 0, 64)
 		if err != nil {
-			return ops.errorf("bad #pragma version: %#v", value)
+			return ops.errorOnf(tokens[2], "bad #pragma version: %#v", value)
 		}
 		if ver > AssemblerMaxVersion {
-			return ops.errorf("unsupported version: %d", ver)
+			return ops.errorOnf(tokens[2], "unsupported version: %d", ver)
 		}
 
 		// We initialize Version with assemblerNoVersion as a marker for
@@ -2217,21 +2293,21 @@ func pragma(ops *OpStream, tokens []string) error {
 			return ops.recheckMacroNames()
 		}
 		if ops.Version != ver {
-			return ops.errorf("version mismatch: assembling v%d with v%d assembler", ver, ops.Version)
+			return ops.errorOnf(tokens[2], "version mismatch: assembling v%d with v%d assembler", ver, ops.Version)
 		}
 		// ops.Version is already correct, or needed to be upped.
 		return nil
 	case "typetrack":
 		if len(tokens) < 3 {
-			return ops.error("no typetrack value")
+			return ops.errorOn(tokens[1], "no typetrack value")
 		}
 		if len(tokens) > 3 {
-			return ops.errorf("unexpected extra tokens: %s", strings.Join(tokens[3:], " "))
+			return ops.errorOnf(tokens[3], "unexpected extra tokens:%s", reJoin("", tokens[3:]))
 		}
-		value := tokens[2]
+		value := tokens[2].str
 		on, err := strconv.ParseBool(value)
 		if err != nil {
-			return ops.errorf("bad #pragma typetrack: %#v", value)
+			return ops.errorOnf(tokens[2], "bad #pragma typetrack: %#v", value)
 		}
 		prev := ops.typeTracking
 		if !prev && on {
@@ -2241,41 +2317,45 @@ func pragma(ops *OpStream, tokens []string) error {
 
 		return nil
 	default:
-		return ops.errorf("unsupported pragma directive: %#v", key)
+		return ops.errorOnf(tokens[0], "unsupported pragma directive: %#v", key)
 	}
 }
 
 func (ops *OpStream) resolveLabels() {
-	saved := ops.sourceLine
 	raw := ops.pending.Bytes()
 	reported := make(map[string]bool)
 	for _, lr := range ops.labelReferences {
-		ops.sourceLine = lr.sourceLine // so errors get reported where the label was used
-		dest, ok := ops.labels[lr.label]
+		dest, ok := ops.labels[lr.label.str]
 		if !ok {
-			if !reported[lr.label] {
-				ops.errorf("reference to undefined label %#v", lr.label)
+			if !reported[lr.label.str] {
+				ops.errorOnf(lr.label, "reference to undefined label %#v", lr.label.str)
 			}
-			reported[lr.label] = true
+			reported[lr.label.str] = true
 			continue
+		}
+
+		// backward compatibility: do not allow jumps past last instruction in v1
+		if ops.Version <= 1 {
+			if dest == ops.pending.Len() {
+				ops.errorOnf(lr.label, "label %#v is too far away", lr.label.str)
+			}
 		}
 
 		// All branch targets are encoded as 2 offset bytes. The destination is relative to the end of the
 		// instruction they appear in, which is available in lr.offsetPostion
 		if ops.Version < backBranchEnabledVersion && dest < lr.offsetPosition {
-			ops.errorf("label %#v is a back reference, back jump support was introduced in v4", lr.label)
+			ops.errorOnf(lr.label, "label %#v is a back reference, back jump support was introduced in v4", lr.label.str)
 			continue
 		}
 		jump := dest - lr.offsetPosition
 		if jump > 0x7fff {
-			ops.errorf("label %#v is too far away", lr.label)
+			ops.errorOnf(lr.label, "label %#v is too far away", lr.label.str)
 			continue
 		}
 		raw[lr.position] = uint8(jump >> 8)
 		raw[lr.position+1] = uint8(jump & 0x0ff)
 	}
 	ops.pending = *bytes.NewBuffer(raw)
-	ops.sourceLine = saved
 }
 
 // AssemblerDefaultVersion what version of code do we emit by default
@@ -2425,7 +2505,7 @@ func (ops *OpStream) optimizeConstants(refs []constReference, constBlock []inter
 			}
 		}
 		if !found {
-			err = ops.lineErrorf(ops.OffsetToLine[ref.getPosition()], "Value not found in constant block: %v", ref.getValue())
+			err = ops.lineErrorf(ops.OffsetToLine[ref.getPosition()], "value not found in constant block: %v", ref.getValue())
 			return
 		}
 	}
@@ -2463,7 +2543,7 @@ func (ops *OpStream) optimizeConstants(refs []constReference, constBlock []inter
 			}
 		}
 		if newIndex == -1 {
-			return nil, ops.lineErrorf(ops.OffsetToLine[ref.getPosition()], "Value not found in constant block: %v", ref.getValue())
+			return nil, ops.lineErrorf(ops.OffsetToLine[ref.getPosition()], "value not found in constant block: %v", ref.getValue())
 		}
 
 		newBytes := ref.makeNewReference(ops, singleton, newIndex)
@@ -2584,48 +2664,47 @@ func (ops *OpStream) prependCBlocks() []byte {
 	return out
 }
 
-func (ops *OpStream) error(problem interface{}) error {
-	return ops.lineError(ops.sourceLine, problem)
+func (ops *OpStream) errorOn(t token, problem interface{}) *sourceError {
+	return ops.sourceError(t.line, t.col, problem)
 }
 
-func (ops *OpStream) lineError(line int, problem interface{}) error {
-	var err lineError
+func (ops *OpStream) sourceError(line int, col int, problem interface{}) *sourceError {
+	var err *sourceError
 	switch p := problem.(type) {
 	case string:
-		err = lineError{Line: line, Err: errors.New(p)}
+		err = &sourceError{Line: line, Column: col, Err: errors.New(p)}
 	case error:
-		err = lineError{Line: line, Err: p}
+		err = &sourceError{Line: line, Column: col, Err: p}
 	default:
-		err = lineError{Line: line, Err: fmt.Errorf("%#v", p)}
+		err = &sourceError{Line: line, Column: col, Err: fmt.Errorf("%#v", p)}
 	}
-	ops.Errors = append(ops.Errors, err)
-	return err
+	return ops.accumulate(err)
 }
 
-func (ops *OpStream) errorf(format string, a ...interface{}) error {
-	return ops.error(fmt.Errorf(format, a...))
+func (ops *OpStream) accumulate(e *sourceError) *sourceError {
+	ops.Errors = append(ops.Errors, *e)
+	return e
+}
+
+func (ops *OpStream) errorf(format string, a ...interface{}) *sourceError {
+	return ops.sourceError(ops.sourceLine, 0, fmt.Errorf(format, a...))
+}
+
+func (ops *OpStream) errorOnf(t token, format string, a ...interface{}) *sourceError {
+	return ops.errorOn(t, fmt.Errorf(format, a...))
+}
+
+func (ops *OpStream) errorAfterf(t token, format string, a ...interface{}) *sourceError {
+	return ops.sourceError(t.line, t.col+len(t.str), fmt.Errorf(format, a...))
 }
 
 func (ops *OpStream) lineErrorf(line int, format string, a ...interface{}) error {
-	return ops.lineError(line, fmt.Errorf(format, a...))
+	return ops.sourceError(line, 0, fmt.Errorf(format, a...))
 }
 
-func (ops *OpStream) warn(problem interface{}) error {
-	var le *lineError
-	switch p := problem.(type) {
-	case string:
-		le = &lineError{Line: ops.sourceLine, Err: errors.New(p)}
-	case error:
-		le = &lineError{Line: ops.sourceLine, Err: p}
-	default:
-		le = &lineError{Line: ops.sourceLine, Err: fmt.Errorf("%#v", p)}
-	}
-	warning := fmt.Errorf("warning: %w", le)
+func (ops *OpStream) warnOnf(t token, format string, a ...interface{}) {
+	warning := &sourceError{Line: t.line, Column: t.col, Err: fmt.Errorf(format, a...)}
 	ops.Warnings = append(ops.Warnings, warning)
-	return warning
-}
-func (ops *OpStream) warnf(format string, a ...interface{}) error {
-	return ops.warn(fmt.Errorf(format, a...))
 }
 
 // ReportMultipleErrors issues accumulated warnings and outputs errors to an io.Writer.

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -3520,7 +3520,6 @@ func TestAssembleEmpty(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	emptyExpect := exp(0, "Cannot assemble empty program text")
 	emptyPrograms := []string{
 		"",
 		"     ",
@@ -3532,7 +3531,7 @@ func TestAssembleEmpty(t *testing.T) {
 
 	for version := uint64(1); version <= AssemblerMaxVersion; version++ {
 		for _, prog := range emptyPrograms {
-			testProg(t, prog, version, emptyExpect)
+			testProg(t, prog, version, exp(0, "Cannot assemble empty program text"))
 		}
 		testProg(t, nonEmpty, version)
 	}

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -812,11 +812,11 @@ func TestOpUint(t *testing.T) {
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			ops := newOpStream(v)
-			ops.intLiteral(0xcafebabe)
+			ops.intLiteral(0xcafef00d)
 			prog := ops.prependCBlocks()
 			require.NotNil(t, prog)
 			s := hex.EncodeToString(prog)
-			expected := mutateProgVersion(v, "012001bef5fad70c22")
+			expected := mutateProgVersion(v, "xx20018de0fbd70c22")
 			require.Equal(t, expected, s)
 		})
 	}
@@ -829,11 +829,11 @@ func TestOpUint64(t *testing.T) {
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			ops := newOpStream(v)
-			ops.intLiteral(0xcafebabecafebabe)
+			ops.intLiteral(0xcafef00dcafef00d)
 			prog := ops.prependCBlocks()
 			require.NotNil(t, prog)
 			s := hex.EncodeToString(prog)
-			require.Equal(t, mutateProgVersion(v, "012001bef5fad7ecd7aeffca0122"), s)
+			require.Equal(t, mutateProgVersion(v, "xx20018de0fbd7dc81bcffca0122"), s)
 		})
 	}
 }
@@ -859,8 +859,8 @@ func TestAssembleInt(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	expectedDefaultConsts := "012001bef5fad70c22"
-	expectedOptimizedConsts := "0181bef5fad70c"
+	expectedDefaultConsts := "xx20018de0fbd70c22"
+	expectedOptimizedConsts := "xx818de0fbd70c"
 
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
@@ -869,7 +869,7 @@ func TestAssembleInt(t *testing.T) {
 				expected = expectedOptimizedConsts
 			}
 
-			text := "int 0xcafebabe"
+			text := "int 0xcafef00d"
 			ops := testProg(t, text, v)
 			s := hex.EncodeToString(ops.Program)
 			require.Equal(t, mutateProgVersion(v, expected), s)

--- a/data/transactions/logic/backwardCompat_test.go
+++ b/data/transactions/logic/backwardCompat_test.go
@@ -464,22 +464,22 @@ func TestBackwardCompatAssemble(t *testing.T) {
 	// v1 does not allow branching to the last line
 	// v2 makes such programs legal
 	t.Parallel()
-	source := "int 1; int 1; bnz done; done:"
 
-	t.Run("v=default", func(t *testing.T) {
-		t.Parallel()
-		testProg(t, source, assemblerNoVersion, Expect{1, "label \"done\" is too far away"})
-	})
+	// Label is ok, it just can't be branched to
+	source := "int 1; done:"
+	testProg(t, source, assemblerNoVersion)
+	testProg(t, source, 0)
+	testProg(t, source, 1)
 
-	t.Run("v=default", func(t *testing.T) {
-		t.Parallel()
-		testProg(t, source, 0, Expect{1, "label \"done\" is too far away"})
-	})
-
-	t.Run("v=default", func(t *testing.T) {
-		t.Parallel()
-		testProg(t, source, 1, Expect{1, "label \"done\" is too far away"})
-	})
+	// use multiple lines, so that error report is checked better
+	source = `int 1;
+ int 1;
+ bnz done;
+ done:
+`
+	testProg(t, source, assemblerNoVersion, exp(3, "label \"done\" is too far away", 5))
+	testProg(t, source, 0, exp(3, "label \"done\" is too far away", 5))
+	testProg(t, source, 1, exp(3, "label \"done\" is too far away", 5))
 
 	for v := uint64(2); v <= AssemblerMaxVersion; v++ {
 		v := v

--- a/data/transactions/logic/box_test.go
+++ b/data/transactions/logic/box_test.go
@@ -242,7 +242,7 @@ func TestBoxAvailability(t *testing.T) {
 	TestApps(t, []string{
 		`byte "self"; int 64; box_create`,
 		`byte "B"; int 10; int 4; box_extract; byte 0x00000000; ==`,
-	}, nil, 8, ledger, NewExpect(1, fmt.Sprintf("invalid Box reference %#x", 'B')))
+	}, nil, 8, ledger, Exp(1, fmt.Sprintf("invalid Box reference %#x", 'B')))
 
 	// B is available if indexed by 0 in tx[1].Boxes
 	group := MakeSampleTxnGroup(MakeSampleTxn(), txntest.Txn{
@@ -254,7 +254,7 @@ func TestBoxAvailability(t *testing.T) {
 	TestApps(t, []string{
 		`byte "self"; int 64; box_create`,
 		`byte "B"; int 10; int 4; box_extract; byte 0x00000000; ==`,
-	}, group, 8, ledger, NewExpect(1, "no such box"))
+	}, group, 8, ledger, Exp(1, "no such box"))
 
 	// B is available if listed by appId in tx[1].Boxes
 	group = MakeSampleTxnGroup(MakeSampleTxn(), txntest.Txn{
@@ -267,7 +267,7 @@ func TestBoxAvailability(t *testing.T) {
 	TestApps(t, []string{
 		`byte "self"; int 64; box_create`,
 		`byte "B"; int 10; int 4; box_extract; byte 0x00000000; ==`,
-	}, group, 8, ledger, NewExpect(1, "no such box"))
+	}, group, 8, ledger, Exp(1, "no such box"))
 }
 
 func TestBoxReadBudget(t *testing.T) {

--- a/data/transactions/logic/evalAppTxn_test.go
+++ b/data/transactions/logic/evalAppTxn_test.go
@@ -584,12 +584,12 @@ func TestNumInnerPooled(t *testing.T) {
 	TestApps(t, []string{short, long}, grp, LogicVersion, ledger)
 	TestApps(t, []string{long, short}, grp, LogicVersion, ledger)
 	TestApps(t, []string{long, long}, grp, LogicVersion, ledger,
-		NewExpect(1, "too many inner transactions"))
+		Exp(1, "too many inner transactions"))
 	grp = append(grp, grp[0])
 	TestApps(t, []string{short, long, long}, grp, LogicVersion, ledger,
-		NewExpect(2, "too many inner transactions"))
+		Exp(2, "too many inner transactions"))
 	TestApps(t, []string{long, long, long}, grp, LogicVersion, ledger,
-		NewExpect(1, "too many inner transactions"))
+		Exp(1, "too many inner transactions"))
 }
 
 func TestAssetCreate(t *testing.T) {

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -383,7 +383,7 @@ func TestBalance(t *testing.T) {
 		// won't assemble in old version teal
 		if v < directRefEnabledVersion {
 			testProg(t, source, ep.Proto.LogicSigVersion,
-				Expect{1, "balance arg 0 wanted type uint64..."})
+				exp(1, "balance arg 0 wanted type uint64..."))
 			return
 		}
 
@@ -399,7 +399,7 @@ func TestBalance(t *testing.T) {
 }
 
 func testApps(t *testing.T, programs []string, txgroup []transactions.SignedTxn, version uint64, ledger *Ledger,
-	expected ...Expect) *EvalParams {
+	expected ...expect) *EvalParams {
 	t.Helper()
 	codes := make([][]byte, len(programs))
 	for i, program := range programs {
@@ -427,7 +427,7 @@ func testApps(t *testing.T, programs []string, txgroup []transactions.SignedTxn,
 	return ep
 }
 
-func testAppsBytes(t *testing.T, programs [][]byte, ep *EvalParams, expected ...Expect) {
+func testAppsBytes(t *testing.T, programs [][]byte, ep *EvalParams, expected ...expect) {
 	t.Helper()
 	require.LessOrEqual(t, len(programs), len(ep.TxnGroup))
 	for i := range ep.TxnGroup {
@@ -623,7 +623,7 @@ func TestAppCheckOptedIn(t *testing.T) {
 	testApp(t, "int 1; int 2; app_opted_in; int 0; ==", pre) // in pre, int 2 is an actual app id
 	testApp(t, "byte \"aoeuiaoeuiaoeuiaoeuiaoeuiaoeui01\"; int 2; app_opted_in; int 1; ==", now)
 	testProg(t, "byte \"aoeuiaoeuiaoeuiaoeuiaoeuiaoeui01\"; int 2; app_opted_in; int 1; ==", directRefEnabledVersion-1,
-		Expect{1, "app_opted_in arg 0 wanted type uint64..."})
+		exp(1, "app_opted_in arg 0 wanted type uint64..."))
 
 	// Receiver opts into 888, the current app in testApp
 	ledger.NewLocals(txn.Txn.Receiver, 888)
@@ -698,7 +698,7 @@ byte "ALGO"
 	testApp(t, text, now)
 	testApp(t, strings.Replace(text, "int 1  // account idx", "byte \"aoeuiaoeuiaoeuiaoeuiaoeuiaoeui01\"", -1), now)
 	testProg(t, strings.Replace(text, "int 1  // account idx", "byte \"aoeuiaoeuiaoeuiaoeuiaoeuiaoeui01\"", -1), directRefEnabledVersion-1,
-		Expect{4, "app_local_get_ex arg 0 wanted type uint64..."})
+		exp(4, "app_local_get_ex arg 0 wanted type uint64..."))
 	testApp(t, strings.Replace(text, "int 100 // app id", "int 2", -1), now)
 	// Next we're testing if the use of the current app's id works
 	// as a direct reference. The error is because the receiver
@@ -771,7 +771,7 @@ byte "ALGO"
 	testApp(t, text, now)
 	testApp(t, strings.Replace(text, "int 0  // account idx", "byte \"aoeuiaoeuiaoeuiaoeuiaoeuiaoeui00\"", -1), now)
 	testProg(t, strings.Replace(text, "int 0  // account idx", "byte \"aoeuiaoeuiaoeuiaoeuiaoeuiaoeui00\"", -1), directRefEnabledVersion-1,
-		Expect{3, "app_local_get arg 0 wanted type uint64..."})
+		exp(3, "app_local_get arg 0 wanted type uint64..."))
 	testApp(t, strings.Replace(text, "int 0  // account idx", "byte \"aoeuiaoeuiaoeuiaoeuiaoeuiaoeui01\"", -1), now)
 	testApp(t, strings.Replace(text, "int 0  // account idx", "byte \"aoeuiaoeuiaoeuiaoeuiaoeuiaoeui02\"", -1), now,
 		"invalid Account reference")
@@ -1033,7 +1033,7 @@ func testAssetsByVersion(t *testing.T, assetsTestProgram string, version uint64)
 
 	// it wasn't legal to use a direct ref for account
 	testProg(t, `byte "aoeuiaoeuiaoeuiaoeuiaoeuiaoeui00"; int 54; asset_holding_get AssetBalance`,
-		directRefEnabledVersion-1, Expect{1, "asset_holding_get AssetBalance arg 0 wanted type uint64..."})
+		directRefEnabledVersion-1, exp(1, "asset_holding_get AssetBalance arg 0 wanted type uint64..."))
 	// but it is now (empty asset yields 0,0 on stack)
 	testApp(t, `byte "aoeuiaoeuiaoeuiaoeuiaoeuiaoeui00"; int 55; asset_holding_get AssetBalance; ==`, now)
 	// This is receiver, who is in Assets array
@@ -1076,7 +1076,7 @@ func testAssetsByVersion(t *testing.T, assetsTestProgram string, version uint64)
 	testApp(t, strings.Replace(assetsTestProgram, "int 55", "int 0", -1), now)
 
 	// but old code cannot
-	testProg(t, strings.Replace(assetsTestProgram, "int 0//account", "byte \"aoeuiaoeuiaoeuiaoeuiaoeuiaoeui00\"", -1), directRefEnabledVersion-1, Expect{3, "asset_holding_get AssetBalance arg 0 wanted type uint64..."})
+	testProg(t, strings.Replace(assetsTestProgram, "int 0//account", "byte \"aoeuiaoeuiaoeuiaoeuiaoeuiaoeui00\"", -1), directRefEnabledVersion-1, exp(3, "asset_holding_get AssetBalance arg 0 wanted type uint64..."))
 
 	if version < 5 {
 		// Can't run these with AppCreator anyway
@@ -2391,7 +2391,7 @@ int 1
 			delta := testApp(t, withBytes, ep)
 			// But won't even compile in old teal
 			testProg(t, withBytes, directRefEnabledVersion-1,
-				Expect{4, "app_local_put arg 0 wanted..."}, Expect{11, "app_local_del arg 0 wanted..."})
+				exp(4, "app_local_put arg 0 wanted..."), exp(11, "app_local_del arg 0 wanted..."))
 			require.Equal(t, 0, len(delta.GlobalDelta))
 			require.Equal(t, 2, len(delta.LocalDeltas))
 			ledger.Reset()
@@ -2900,9 +2900,9 @@ func TestTxnEffects(t *testing.T) {
 
 	// Look past the logs of tx 0
 	testApps(t, []string{"byte 0x37; log; int 1", "gtxna 0 Logs 1; byte 0x37; =="}, nil, AssemblerMaxVersion, nil,
-		Expect{1, "invalid Logs index 1"})
+		exp(1, "invalid Logs index 1"))
 	testApps(t, []string{"byte 0x37; log; int 1", "int 6; gtxnas 0 Logs; byte 0x37; =="}, nil, AssemblerMaxVersion, nil,
-		Expect{1, "invalid Logs index 6"})
+		exp(1, "invalid Logs index 6"))
 }
 
 func TestRound(t *testing.T) {
@@ -3002,7 +3002,7 @@ func TestPooledAppCallsVerifyOp(t *testing.T) {
 	call := transactions.SignedTxn{Txn: transactions.Transaction{Type: protocol.ApplicationCallTx}}
 	// Simulate test with 2 grouped txn
 	testApps(t, []string{source, ""}, []transactions.SignedTxn{call, call}, LogicVersion, ledger,
-		Expect{0, "pc=107 dynamic cost budget exceeded, executing ed25519verify: local program cost was 5"})
+		exp(0, "pc=107 dynamic cost budget exceeded, executing ed25519verify: local program cost was 5"))
 
 	// Simulate test with 3 grouped txn
 	testApps(t, []string{source, "", ""}, []transactions.SignedTxn{call, call, call}, LogicVersion, ledger)

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -621,7 +621,7 @@ after:
 dup
 pop
 `
-	testProg(t, code, LogicVersion, Expect{12, "+ expects 2 stack arguments..."})
+	testProg(t, code, LogicVersion, exp(12, "+ expects 2 stack arguments..."))
 	testAccepts(t, notrack(code), 1)
 }
 
@@ -2463,17 +2463,17 @@ func TestSubstringFlop(t *testing.T) {
 	// fails in compiler
 	testProg(t, `byte 0xf000000000000000
 substring
-len`, 2, Expect{2, "substring expects 2 immediate arguments"})
+len`, 2, exp(2, "substring expects 2 immediate arguments"))
 
 	// fails in compiler
 	testProg(t, `byte 0xf000000000000000
 substring 1
-len`, 2, Expect{2, "substring expects 2 immediate arguments"})
+len`, 2, exp(2, "substring expects 2 immediate arguments"))
 
 	// fails in compiler
 	testProg(t, `byte 0xf000000000000000
 substring 4 2
-len`, 2, Expect{2, "substring end is before start"})
+len`, 2, exp(2, "substring end is before start"))
 
 	// fails at runtime
 	testPanics(t, `byte 0xf000000000000000
@@ -2528,17 +2528,17 @@ func TestExtractFlop(t *testing.T) {
 	// fails in compiler
 	testProg(t, `byte 0xf000000000000000
 	extract
-	len`, 5, Expect{2, "extract without immediates expects 3 stack arguments but stack height is 1"})
+	len`, 5, exp(2, "extract without immediates expects 3 stack arguments but stack height is 1"))
 
 	testProg(t, `byte 0xf000000000000000
 	extract 1
-	len`, 5, Expect{2, "extract expects 0 or 2 immediate arguments"})
+	len`, 5, exp(2, "extract expects 0 or 2 immediate arguments"))
 
 	testProg(t, `byte 0xf000000000000000
 	int 0
 	int 5
 	extract3 1 2
-	len`, 5, Expect{4, "extract3 expects 0 immediate arguments"})
+	len`, 5, exp(4, "extract3 expects 0 immediate arguments"))
 
 	// fails at runtime
 	err := testPanics(t, `byte 0xf000000000000000
@@ -2740,7 +2740,7 @@ func TestGload(t *testing.T) {
 			}
 
 			if testCase.errContains != "" {
-				testApps(t, sources, txgroup, LogicVersion, nil, Expect{testCase.errTxn, testCase.errContains})
+				testApps(t, sources, txgroup, LogicVersion, nil, exp(testCase.errTxn, testCase.errContains))
 			} else {
 				testApps(t, sources, txgroup, LogicVersion, nil)
 			}
@@ -4426,7 +4426,7 @@ func testEvaluation(t *testing.T, program string, introduced uint64, tester eval
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			t.Helper()
 			if v < introduced {
-				testProg(t, notrack(program), v, Expect{0, "...was introduced..."})
+				testProg(t, notrack(program), v, exp(0, "...was introduced..."))
 				return
 			}
 			ops := testProg(t, program, v)
@@ -4621,7 +4621,7 @@ func TestBury(t *testing.T) {
 
 	// bury 0 panics
 	source := "int 3; int 2; int 7; bury 0; int 1; return"
-	testProg(t, source, 8, Expect{1, "bury 0 always fails"})
+	testProg(t, source, 8, exp(1, "bury 0 always fails"))
 	testPanics(t, notrack("int 3; int 2; int 7; bury 0; int 1; return"), 8, "bury outside stack")
 
 	// bury 1 pops the ToS and replaces the thing "1 down", which becomes the new ToS
@@ -5271,13 +5271,13 @@ By Herman Melville`, "",
 		source := fmt.Sprintf(template, hex.EncodeToString([]byte(tc.decoded)), hex.EncodeToString([]byte(tc.encoded)), tc.alph)
 		if tc.error == "" {
 			if LogicVersion < fidoVersion {
-				testProg(t, source, AssemblerMaxVersion, Expect{0, "unknown opcode..."})
+				testProg(t, source, AssemblerMaxVersion, exp(0, "unknown opcode..."))
 			} else {
 				testAccepts(t, source, fidoVersion)
 			}
 		} else {
 			if LogicVersion < fidoVersion {
-				testProg(t, source, AssemblerMaxVersion, Expect{0, "unknown opcode..."})
+				testProg(t, source, AssemblerMaxVersion, exp(0, "unknown opcode..."))
 			} else {
 				err := testPanics(t, source, fidoVersion)
 				require.Error(t, err)
@@ -5394,7 +5394,7 @@ func TestOpJSONRef(t *testing.T) {
 	ep.SigLedger = ledger
 	testCases := []struct {
 		source             string
-		previousVersErrors []Expect
+		previousVersErrors []expect
 	}{
 		{
 			source: `byte  "{\"key0\": 0,\"key1\": \"algo\",\"key2\":{\"key3\": \"teal\", \"key4\":3}, \"key5\": 18446744073709551615 }";
@@ -5402,7 +5402,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONUint64;
 			int 0;
 			==`,
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "{\"key0\": 0,\"key1\": \"algo\",\"key2\":{\"key3\": \"teal\", \"key4\": 3}, \"key5\": 18446744073709551615 }";
@@ -5410,7 +5410,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONUint64;
 			int 18446744073709551615; //max uint64 value
 			==`,
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "{\"key0\": 0,\"key1\": \"algo\",\"key2\":{\"key3\": \"teal\", \"key4\": 3}, \"key5\": 18446744073709551615 }";
@@ -5418,7 +5418,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONString;
 			byte "algo";
 			==`,
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "{\"key0\": 0,\"key1\": \"\\u0061\\u006C\\u0067\\u006F\",\"key2\":{\"key3\": \"teal\", \"key4\": 3}, \"key5\": 18446744073709551615 }";
@@ -5426,7 +5426,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONString;
 			byte "algo";
 			==`,
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "{\"key0\": 0,\"key1\": \"algo\",\"key2\":{\"key3\": \"teal\", \"key4\": {\"key40\": 10}}, \"key5\": 18446744073709551615 }";
@@ -5438,7 +5438,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONUint64
 			int 10
 			==`,
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}, {5, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref"), exp(5, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "{\"key0\": 0,\"key1\": \"algo\",\"key2\":{\"key3\": \"teal\", \"key4\": {\"key40\": 10}}, \"key5\": 18446744073709551615 }";
@@ -5448,7 +5448,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONString;
 			byte "teal"
 			==`,
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}, {5, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref"), exp(5, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "{\"key0\": 0,\"key1\": \"algo\",\"key2\":{\"key3\": \"\\"teal\\"\", \"key4\": {\"key40\": 10}}, \"key5\": 18446744073709551615 }";
@@ -5458,7 +5458,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONString;
 			byte ""teal"" // quotes match
 			==`,
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}, {5, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref"), exp(5, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "{\"key0\": 0,\"key1\": \"algo\",\"key2\":{\"key3\": \" teal \", \"key4\": {\"key40\": 10}}, \"key5\": 18446744073709551615 }";
@@ -5468,7 +5468,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONString;
 			byte " teal " // spaces match
 			==`,
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}, {5, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref"), exp(5, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "{\"key0\": 0,\"key1\": \"algo\",\"key2\":{\"key3\": \"teal\", \"key4\": {\"key40\": 10, \"key40\": \"10\"}}, \"key5\": 18446744073709551615 }";
@@ -5479,7 +5479,7 @@ func TestOpJSONRef(t *testing.T) {
 			byte "{\"key40\": 10, \"key40\": \"10\"}"
 			==
 			`,
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "{\"rawId\": \"responseId\",\"id\": \"0\",\"response\": {\"attestationObject\": \"based64url_encoded_buffer\",\"clientDataJSON\":  \" based64url_encoded_client_data\"},\"getClientExtensionResults\": {},\"type\": \"public-key\"}";
@@ -5487,7 +5487,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONObject;
 			byte "{\"attestationObject\": \"based64url_encoded_buffer\",\"clientDataJSON\":  \" based64url_encoded_client_data\"}" // object as it appeared in input
 			==`,
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "{\"rawId\": \"responseId\",\"id\": \"0\",\"response\": {\"attestationObject\": \"based64url_encoded_buffer\",\"clientD\\u0061taJSON\":  \" based64url_encoded_client_data\"},\"getClientExtensionResults\": {},\"type\": \"public-key\"}";
@@ -5495,7 +5495,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONObject;
 			byte "{\"attestationObject\": \"based64url_encoded_buffer\",\"clientD\\u0061taJSON\":  \" based64url_encoded_client_data\"}" // object as it appeared in input
 			==`,
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "{\"rawId\": \"responseId\",\"id\": \"0\",\"response\": {\"attestationObject\": \"based64url_encoded_buffer\",\"clientDataJSON\":  \" based64url_encoded_client_data\"},\"getClientExtensionResults\": {},\"type\": \"public-key\"}";
@@ -5505,7 +5505,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONString;
 			byte " based64url_encoded_client_data";
 			==`,
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}, {5, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref"), exp(5, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "{\"\\u0072\\u0061\\u0077\\u0049\\u0044\": \"responseId\",\"id\": \"0\",\"response\": {\"attestationObject\": \"based64url_encoded_buffer\",\"clientDataJSON\":  \" based64url_encoded_client_data\"},\"getClientExtensionResults\": {},\"type\": \"public-key\"}";
@@ -5513,7 +5513,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONString;
 			byte "responseId"
 			==`,
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 		// JavaScript MAX_SAFE_INTEGER
 		{
@@ -5522,7 +5522,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONUint64;
 			int 9007199254740991;
 			==`,
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 		// maximum uint64
 		{
@@ -5531,7 +5531,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONUint64;
 			int 18446744073709551615;
 			==`,
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 		// larger-than-uint64s are allowed if not requested
 		{
@@ -5540,7 +5540,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONUint64;
 			int 0;
 			==`,
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 	}
 
@@ -5575,57 +5575,57 @@ func TestOpJSONRef(t *testing.T) {
 	failedCases := []struct {
 		source             string
 		error              string
-		previousVersErrors []Expect
+		previousVersErrors []expect
 	}{
 		{
 			source:             `byte  "{\"key0\": 1 }"; byte "key0"; json_ref JSONString;`,
 			error:              "json: cannot unmarshal number into Go value of type string",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": [1] }"; byte "key0"; json_ref JSONString;`,
 			error:              "json: cannot unmarshal array into Go value of type string",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": {\"key1\":1} }"; byte "key0"; json_ref JSONString;`,
 			error:              "json: cannot unmarshal object into Go value of type string",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": \"1\" }"; byte "key0"; json_ref JSONUint64;`,
 			error:              "json: cannot unmarshal string into Go value of type uint64",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": [\"1\"] }"; byte "key0"; json_ref JSONUint64;`,
 			error:              "json: cannot unmarshal array into Go value of type uint64",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": {\"key1\":1} }"; byte "key0"; json_ref JSONUint64;`,
 			error:              "json: cannot unmarshal object into Go value of type uint64",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": [1]}"; byte "key0"; json_ref JSONObject;`,
 			error:              "json: cannot unmarshal array into Go value of type map[string]json.RawMessage",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": 1}"; byte "key0"; json_ref JSONObject;`,
 			error:              "json: cannot unmarshal number into Go value of type map[string]json.RawMessage",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": \"1\"}"; byte "key0"; json_ref JSONObject;`,
 			error:              "json: cannot unmarshal string into Go value of type map[string]json.RawMessage",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": 1,\"key1\": \"algo\",\"key2\":{\"key3\": \"teal\", \"key4\": [1,2,3]} }"; byte "key3"; json_ref JSONString;`,
 			error:              "key key3 not found in JSON text",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "{\"key0\": 1,\"key1\": \"algo\",\"key2\":{\"key3\": \"teal\", \"key4\": [1,2,3]}}";
@@ -5635,52 +5635,52 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONString
 			`,
 			error:              "key key5 not found in JSON text",
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}, {5, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref"), exp(5, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": -0,\"key1\": 2.5,\"key2\": -3}"; byte "key0"; json_ref JSONUint64;`,
 			error:              "json: cannot unmarshal number -0 into Go value of type uint64",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": 1e10,\"key1\": 2.5,\"key2\": -3}"; byte "key0"; json_ref JSONUint64;`,
 			error:              "json: cannot unmarshal number 1e10 into Go value of type uint64",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": 0.2e-2,\"key1\": 2.5,\"key2\": -3}"; byte "key0"; json_ref JSONUint64;`,
 			error:              "json: cannot unmarshal number 0.2e-2 into Go value of type uint64",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": 1.0,\"key1\": 2.5,\"key2\": -3}"; byte "key0"; json_ref JSONUint64;`,
 			error:              "json: cannot unmarshal number 1.0 into Go value of type uint64",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": 1.0,\"key1\": 2.5,\"key2\": -3}"; byte "key1"; json_ref JSONUint64;`,
 			error:              "json: cannot unmarshal number 2.5 into Go value of type uint64",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": 1.0,\"key1\": 2.5,\"key2\": -3}"; byte "key2"; json_ref JSONUint64;`,
 			error:              "json: cannot unmarshal number -3 into Go value of type uint64",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": 18446744073709551616}"; byte "key0"; json_ref JSONUint64;`,
 			error:              "json: cannot unmarshal number 18446744073709551616 into Go value of type uint64",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": 1,}"; byte "key0"; json_ref JSONString;`,
 			error:              "error while parsing JSON text, invalid json text",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source:             `byte  "{\"key0\": 1, \"key0\": \"3\"}"; byte "key0"; json_ref JSONString;`,
 			error:              "error while parsing JSON text, invalid json text, duplicate keys not allowed",
-			previousVersErrors: []Expect{{1, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(1, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "{\"key0\": 0,\"key1\": \"algo\",\"key2\":{\"key3\": \"teal\", \"key4\": {\"key40\": 10, \"key40\": \"should fail!\"}}}";
@@ -5692,7 +5692,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONString
 			`,
 			error:              "error while parsing JSON text, invalid json text, duplicate keys not allowed",
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}, {5, "unknown opcode: json_ref"}, {7, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref"), exp(5, "unknown opcode: json_ref"), exp(7, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "[1,2,3]";
@@ -5700,7 +5700,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONUint64
 			`,
 			error:              "error while parsing JSON text, invalid json text, only json object is allowed",
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "2";
@@ -5708,7 +5708,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONUint64
 			`,
 			error:              "error while parsing JSON text, invalid json text, only json object is allowed",
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "null";
@@ -5716,7 +5716,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONUint64
 			`,
 			error:              "error while parsing JSON text, invalid json text, only json object is allowed",
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "true";
@@ -5724,7 +5724,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONUint64
 			`,
 			error:              "error while parsing JSON text, invalid json text, only json object is allowed",
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte  "\"sometext\"";
@@ -5732,7 +5732,7 @@ func TestOpJSONRef(t *testing.T) {
 			json_ref JSONUint64
 			`,
 			error:              "error while parsing JSON text, invalid json text, only json object is allowed",
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 		{
 			source: `byte "{noquotes: \"shouldn't work\"}";
@@ -5741,7 +5741,7 @@ func TestOpJSONRef(t *testing.T) {
 			byte "shouldn't work";
 			==`,
 			error:              "error while parsing JSON text, invalid json text",
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 		// max uint64 + 1 should fail
 		{
@@ -5751,7 +5751,7 @@ func TestOpJSONRef(t *testing.T) {
 			int 1;
 			return`,
 			error:              "json: cannot unmarshal number 18446744073709551616 into Go value of type uint64",
-			previousVersErrors: []Expect{{3, "unknown opcode: json_ref"}},
+			previousVersErrors: []expect{exp(3, "unknown opcode: json_ref")},
 		},
 	}
 

--- a/data/transactions/logic/export_test.go
+++ b/data/transactions/logic/export_test.go
@@ -24,10 +24,6 @@ import "github.com/algorand/go-algorand/data/basics"
 // we export some extra things to make testing easier there. But we do it in a
 // _test.go file, so they are only exported during testing.
 
-func NewExpect(l int, s string) Expect {
-	return Expect{l, s}
-}
-
 func (ep *EvalParams) Reset() {
 	ep.reset()
 }
@@ -45,6 +41,7 @@ func (l *Ledger) DelBoxes(app basics.AppIndex, names ...string) {
 }
 
 var DefaultEvalParams = defaultEvalParams
+var Exp = exp
 var MakeSampleEnv = makeSampleEnv
 var MakeSampleEnvWithVersion = makeSampleEnvWithVersion
 var MakeSampleTxn = makeSampleTxn

--- a/data/transactions/logic/fields_test.go
+++ b/data/transactions/logic/fields_test.go
@@ -232,7 +232,7 @@ func TestAssetParamsFieldsVersions(t *testing.T) {
 			ledger.NewAsset(txn.Sender, 55, basics.AssetParams{})
 			ep.Proto.LogicSigVersion = v
 			if field.version > v {
-				testProg(t, text, v, Expect{1, "...was introduced in..."})
+				testProg(t, text, v, exp(1, "...was introduced in..."))
 				ops := testProg(t, text, field.version) // assemble in the future
 				ops.Program[0] = byte(v)
 				testAppBytes(t, ops.Program, ep, "invalid asset_params_get field")
@@ -282,7 +282,7 @@ func TestAcctParamsFieldsVersions(t *testing.T) {
 			ledger.NewAccount(txn.Sender, 200_000)
 			if field.version > v {
 				// check assembler fails if version before introduction
-				testProg(t, text, v, Expect{1, "...was introduced in..."})
+				testProg(t, text, v, exp(1, "...was introduced in..."))
 				ops := testProg(t, text, field.version) // assemble in the future
 				ops.Program[0] = byte(v)                // but set version back to before intro
 				if v < 6 {

--- a/data/transactions/logic/frames_test.go
+++ b/data/transactions/logic/frames_test.go
@@ -50,7 +50,7 @@ func TestDupPopN(t *testing.T) {
 	testAccepts(t, "int 1; int 1; int 1; popn 2", fpVersion)
 	testAccepts(t, "int 1; int 0; popn 1", fpVersion)
 	testPanics(t, "int 1; int 0; popn 2", fpVersion)
-	testProg(t, "int 1; int 0; popn 3", LogicVersion, Expect{1, "popn 3 expects 3..."})
+	testProg(t, "int 1; int 0; popn 3", LogicVersion, exp(1, "popn 3 expects 3..."))
 	testPanics(t, notrack("int 1; int 0; popn 3"), fpVersion)
 
 	testAccepts(t, `int 7; dupn 250; dupn 250; dupn 250; dupn 249;
@@ -69,9 +69,9 @@ func TestDupPopNTyping(t *testing.T) {
 	t.Parallel()
 
 	testProg(t, "int 8; dupn 2; +; pop", LogicVersion)
-	testProg(t, "int 8; dupn 2; concat; pop", LogicVersion, Expect{1, "...wanted type []byte..."})
+	testProg(t, "int 8; dupn 2; concat; pop", LogicVersion, exp(1, "...wanted type []byte..."))
 
-	testProg(t, "popn 1", LogicVersion, Expect{1, "...expects 1 stack argument..."})
+	testProg(t, "popn 1", LogicVersion, exp(1, "...expects 1 stack argument..."))
 }
 
 func TestSimpleFrame(t *testing.T) {
@@ -342,7 +342,7 @@ func TestFrameAccess(t *testing.T) {
         int 1
         return
 `
-	testProg(t, source, fpVersion, Expect{4, "frame_dig above stack"})
+	testProg(t, source, fpVersion, exp(4, "frame_dig above stack"))
 	testPanics(t, notrack(source), fpVersion, "frame_dig above stack")
 
 	source = `
@@ -357,7 +357,7 @@ func TestFrameAccess(t *testing.T) {
         int 1
         return
 `
-	testProg(t, source, fpVersion, Expect{5, "frame_dig above stack"})
+	testProg(t, source, fpVersion, exp(5, "frame_dig above stack"))
 	testPanics(t, notrack(source), fpVersion, "frame_dig above stack")
 
 	// Note that at the moment of frame_bury, the stack IS big enough, because
@@ -376,7 +376,7 @@ func TestFrameAccess(t *testing.T) {
         int 1
         return
 `
-	testProg(t, source, fpVersion, Expect{6, "frame_bury above stack"})
+	testProg(t, source, fpVersion, exp(6, "frame_bury above stack"))
 	testPanics(t, notrack(source), fpVersion, "frame_bury above stack")
 }
 
@@ -400,7 +400,7 @@ main:
      pop						// argument popped
      frame_dig -1				// but then frame_dig used to get at it
 `
-	testProg(t, source, fpVersion, Expect{7, "frame_dig above stack"})
+	testProg(t, source, fpVersion, exp(7, "frame_dig above stack"))
 	testPanics(t, notrack(source), fpVersion, "frame_dig above stack")
 
 	testAccepts(t, `
@@ -427,7 +427,7 @@ main:
      frame_bury 1;
      retsub
 `
-	testProg(t, source, fpVersion, Expect{8, "frame_dig above stack"})
+	testProg(t, source, fpVersion, exp(8, "frame_dig above stack"))
 	testPanics(t, notrack(source), fpVersion)
 }
 
@@ -442,7 +442,7 @@ main:
      proto 1 1
      frame_dig -10				// digging down below arguments
 `
-	testProg(t, source, fpVersion, Expect{6, "frame_dig -10 in sub with 1 arg..."})
+	testProg(t, source, fpVersion, exp(6, "frame_dig -10 in sub with 1 arg..."))
 	testPanics(t, notrack(source), fpVersion, "frame_dig -10 in sub with 1 arg")
 
 	testPanics(t, `
@@ -459,7 +459,7 @@ main:
      proto 1 15
      frame_bury -10				// burying down below arguments
 `
-	testProg(t, source, fpVersion, Expect{6, "frame_bury -10 in sub with 1 arg..."})
+	testProg(t, source, fpVersion, exp(6, "frame_bury -10 in sub with 1 arg..."))
 	testPanics(t, notrack(source), fpVersion, "frame_bury -10 in sub with 1 arg")
 
 	// Without `proto`, frame_bury can't be checked by assembler, but still panics


### PR DESCRIPTION
This should let IDE integrations or lsp-like programs use the assembly output to direct the cursor the exact spot of many problems. It also allowed some error improvements and simplifications because tokens from the assembly process now know their line number.

The changes in terms of line count are big, but mostly boring. The signatures of the asm* and type* functions changed to take tokens instead of strings, which caused a lot of churn.  Also, in order to minimize the work to change existing tests, I converted `testProg` calls so that they called `exp` instead of constructing an `Expect`. That allowed me to make the column checking optional by making the column an optional final argument to `exp`. I extended a bunch of tests to check columns, but many of the tests were mechanically (emacs kbd macros!) converted to `exp`, checking only the line number that they always checked.

