### PR TITLE
ledger: Exclude stake at R-320 that is expired by R

### DIFF
--- a/agreement/abstractions.go
+++ b/agreement/abstractions.go
@@ -133,14 +133,14 @@ type LedgerReader interface {
 	// protocol may lose liveness.
 	LookupAgreement(basics.Round, basics.Address) (basics.OnlineAccountData, error)
 
-	// Circulation returns the total amount of money in circulation at the
-	// conclusion of a given round.
+	// Circulation returns the total amount of online money in circulation at the
+	// conclusion of a given round rnd that is eligible for voting at voteRnd.
 	//
 	// This method returns an error if the given Round has not yet been
 	// confirmed. It may also return an error if the given Round is
 	// unavailable by the storage device. In that case, the agreement
 	// protocol may lose liveness.
-	Circulation(basics.Round) (basics.MicroAlgos, error)
+	Circulation(rnd basics.Round, voteRnd basics.Round) (basics.MicroAlgos, error)
 
 	// LookupDigest returns the Digest of the entry that was agreed on in a
 	// given round.

--- a/agreement/agreementtest/simulate_test.go
+++ b/agreement/agreementtest/simulate_test.go
@@ -215,7 +215,7 @@ func (l *testLedger) LookupAgreement(r basics.Round, a basics.Address) (basics.O
 	return l.state[a].OnlineAccountData(), nil
 }
 
-func (l *testLedger) Circulation(r basics.Round) (basics.MicroAlgos, error) {
+func (l *testLedger) Circulation(r basics.Round, voteRnd basics.Round) (basics.MicroAlgos, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 

--- a/agreement/common_test.go
+++ b/agreement/common_test.go
@@ -335,7 +335,7 @@ func (l *testLedger) LookupAgreement(r basics.Round, a basics.Address) (basics.O
 	return l.state[a].OnlineAccountData(), nil
 }
 
-func (l *testLedger) Circulation(r basics.Round) (basics.MicroAlgos, error) {
+func (l *testLedger) Circulation(r basics.Round, voteRnd basics.Round) (basics.MicroAlgos, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 

--- a/agreement/demux_test.go
+++ b/agreement/demux_test.go
@@ -495,7 +495,7 @@ func (t *demuxTester) LookupAgreement(basics.Round, basics.Address) (basics.Onli
 }
 
 // implement Ledger
-func (t *demuxTester) Circulation(basics.Round) (basics.MicroAlgos, error) {
+func (t *demuxTester) Circulation(basics.Round, basics.Round) (basics.MicroAlgos, error) {
 	// we don't care about this function in this test.
 	return basics.MicroAlgos{}, nil
 }

--- a/agreement/fuzzer/ledger_test.go
+++ b/agreement/fuzzer/ledger_test.go
@@ -236,7 +236,7 @@ func (l *testLedger) LookupAgreement(r basics.Round, a basics.Address) (basics.O
 	return l.state[a].OnlineAccountData(), nil
 }
 
-func (l *testLedger) Circulation(r basics.Round) (basics.MicroAlgos, error) {
+func (l *testLedger) Circulation(r basics.Round, voteRnd basics.Round) (basics.MicroAlgos, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 

--- a/agreement/selector.go
+++ b/agreement/selector.go
@@ -70,7 +70,7 @@ func membership(l LedgerReader, addr basics.Address, r basics.Round, p period, s
 		return
 	}
 
-	total, err := l.Circulation(balanceRound)
+	total, err := l.Circulation(balanceRound, r)
 	if err != nil {
 		err = fmt.Errorf("Service.initializeVote (r=%d): Failed to obtain total circulation in round %d: %v", r, balanceRound, err)
 		return

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -796,7 +796,7 @@ func (m *mockedLedger) Block(r basics.Round) (bookkeeping.Block, error) {
 func (m *mockedLedger) Lookup(basics.Round, basics.Address) (basics.AccountData, error) {
 	return basics.AccountData{}, errors.New("not needed for mockedLedger")
 }
-func (m *mockedLedger) Circulation(basics.Round) (basics.MicroAlgos, error) {
+func (m *mockedLedger) Circulation(basics.Round, basics.Round) (basics.MicroAlgos, error) {
 	return basics.MicroAlgos{}, errors.New("not needed for mockedLedger")
 }
 func (m *mockedLedger) ConsensusVersion(basics.Round) (protocol.ConsensusVersion, error) {

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -507,6 +507,11 @@ type ConsensusParams struct {
 
 	// EnableBoxRefNameError specifies that box ref names should be validated early
 	EnableBoxRefNameError bool
+
+	// ExcludeExpiredCirculation excludes expired stake from the total online stake
+	// used by agreement for Circulation, and updates the calculation of StateProofOnlineTotalWeight used
+	// by state proofs to use the same method (rather than excluding stake from the top N stakeholders as before).
+	ExcludeExpiredCirculation bool
 }
 
 // PaysetCommitType enumerates possible ways for the block header to commit to
@@ -1280,6 +1285,8 @@ func initConsensusProtocols() {
 
 	vFuture.StateProofUseTrackerVerification = true
 	vFuture.EnableCatchpointsWithSPContexts = true
+
+	vFuture.ExcludeExpiredCirculation = true
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 

--- a/data/datatest/impls.go
+++ b/data/datatest/impls.go
@@ -107,8 +107,8 @@ func (i ledgerImpl) LookupAgreement(r basics.Round, addr basics.Address) (basics
 }
 
 // Circulation implements Ledger.Circulation.
-func (i ledgerImpl) Circulation(r basics.Round) (basics.MicroAlgos, error) {
-	return i.l.Circulation(r)
+func (i ledgerImpl) Circulation(r basics.Round, voteRnd basics.Round) (basics.MicroAlgos, error) {
+	return i.l.Circulation(r, voteRnd)
 }
 
 // Wait implements Ledger.Wait.

--- a/data/ledger.go
+++ b/data/ledger.go
@@ -51,16 +51,17 @@ type Ledger struct {
 	lastRoundSeed atomic.Value
 }
 
-// roundCirculationPair used to hold a pair of matching round number and the amount of online money
-type roundCirculationPair struct {
+// roundCirculationItem used to hold matching round number, vote round and the amount of online money
+type roundCirculationItem struct {
 	round       basics.Round
+	voteRound   basics.Round
 	onlineMoney basics.MicroAlgos
 }
 
 // roundCirculation is the cache for the circulating coins
 type roundCirculation struct {
 	// elements holds several round-onlineMoney pairs
-	elements [2]roundCirculationPair
+	elements [2]roundCirculationItem
 }
 
 // roundSeedPair is the cache for a single seed at a given round
@@ -174,28 +175,29 @@ func (l *Ledger) NextRound() basics.Round {
 }
 
 // Circulation implements agreement.Ledger.Circulation.
-func (l *Ledger) Circulation(r basics.Round) (basics.MicroAlgos, error) {
+func (l *Ledger) Circulation(r basics.Round, voteRnd basics.Round) (basics.MicroAlgos, error) {
 	circulation, cached := l.lastRoundCirculation.Load().(roundCirculation)
 	if cached && r != basics.Round(0) {
 		for _, element := range circulation.elements {
-			if element.round == r {
+			if element.round == r && element.voteRound == voteRnd {
 				return element.onlineMoney, nil
 			}
 		}
 	}
 
-	totals, err := l.OnlineTotals(r)
+	totals, err := l.OnlineCirculation(r, voteRnd)
 	if err != nil {
 		return basics.MicroAlgos{}, err
 	}
 
-	if !cached || r > circulation.elements[1].round {
+	if !cached || r > circulation.elements[1].round || voteRnd > circulation.elements[1].voteRound {
 		l.lastRoundCirculation.Store(
 			roundCirculation{
-				elements: [2]roundCirculationPair{
+				elements: [2]roundCirculationItem{
 					circulation.elements[1],
 					{
 						round:       r,
+						voteRound:   voteRnd,
 						onlineMoney: totals},
 				},
 			})

--- a/ledger/acctonline_expired_test.go
+++ b/ledger/acctonline_expired_test.go
@@ -1,0 +1,689 @@
+// Copyright (C) 2019-2023 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package ledger
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/data/txntest"
+	ledgertesting "github.com/algorand/go-algorand/ledger/testing"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/stretchr/testify/require"
+)
+
+// onlineAcctModel provides a simple interface for tracking accounts
+// as they come online, go offline, and change their amount of stake.
+// It is implemented by a real ledger (doubleLedgerAcctModel) for testing
+// against a reference implementation (mapOnlineAcctModel).
+type onlineAcctModel interface {
+	currentRound() basics.Round
+	nextRound()
+	advanceToRound(rnd basics.Round)
+	goOnline(addr basics.Address, firstvalid, lastvalid basics.Round)
+	goOffline(addr basics.Address)
+	updateStake(addr basics.Address, stake basics.MicroAlgos)
+	teardown()
+
+	LookupAgreement(rnd basics.Round, addr basics.Address) onlineAcctModelAcct
+	OnlineCirculation(rnd basics.Round, voteRnd basics.Round) basics.MicroAlgos
+	ExpiredOnlineCirculation(rnd, voteRnd basics.Round) basics.MicroAlgos
+}
+
+// mapOnlineAcctModel provides a reference implementation for tracking online accounts used
+// for testing TopOnlineAccounts, ExpiredOnlineCirculation, and onlineAcctsExpiredByRound.
+// It is an oracle that the doubleLedgerAcctModel is compared against.
+type mapOnlineAcctModel struct {
+	t        *testing.T
+	cur      basics.Round
+	accts    map[basics.Address]map[basics.Round]onlineAcctModelAcct
+	expiring map[basics.Round]map[basics.Address]struct{}
+}
+
+type onlineAcctModelAcct struct {
+	Status                        basics.Status
+	VoteFirstValid, VoteLastValid basics.Round
+	Stake                         basics.MicroAlgos
+}
+
+func newMapOnlineAcctModel(t *testing.T) *mapOnlineAcctModel {
+	return &mapOnlineAcctModel{
+		t:        t,
+		accts:    make(map[basics.Address]map[basics.Round]onlineAcctModelAcct),
+		expiring: make(map[basics.Round]map[basics.Address]struct{}),
+	}
+}
+
+func (m *mapOnlineAcctModel) teardown()                  {}
+func (m *mapOnlineAcctModel) currentRound() basics.Round { return m.cur }
+func (m *mapOnlineAcctModel) nextRound()                 { m.cur++ }
+func (m *mapOnlineAcctModel) advanceToRound(rnd basics.Round) {
+	if rnd == m.cur {
+		return
+	}
+	require.Greater(m.t, rnd, m.cur, "cannot advance to previous round")
+	m.cur = rnd
+}
+
+func (m *mapOnlineAcctModel) lookupAcctAsOf(rnd basics.Round, addr basics.Address) onlineAcctModelAcct {
+	require.LessOrEqual(m.t, rnd, m.cur, "cannot lookup acct for future round")
+	acctRounds, ok := m.accts[addr]
+	if !ok {
+		return onlineAcctModelAcct{}
+	}
+	// find the acct record for the most recent round <= rnd
+	for r := rnd; r >= 0; r-- {
+		if acct, ok := acctRounds[r]; ok {
+			return acct
+		}
+	}
+	// not found
+	return onlineAcctModelAcct{}
+}
+
+func (m *mapOnlineAcctModel) LookupAgreement(rnd basics.Round, addr basics.Address) onlineAcctModelAcct {
+	return m.lookupAcctAsOf(rnd, addr)
+}
+
+// look up all online accounts as of the given round
+func (m *mapOnlineAcctModel) allOnlineAsOf(rnd basics.Round) map[basics.Address]onlineAcctModelAcct {
+	require.LessOrEqual(m.t, rnd, m.cur, "cannot lookup acct for future round")
+	accts := make(map[basics.Address]onlineAcctModelAcct)
+	for addr, acctRounds := range m.accts {
+		// find the acct record for the most recent round <= rnd
+		for r := rnd; r >= 0; r-- {
+			if acct, ok := acctRounds[r]; ok {
+				if acct.Status == basics.Online {
+					accts[addr] = acct
+				}
+				// found the most recent round <= rnd, so stop looking
+				// we will break even if the acct is offline
+				break
+			}
+		}
+	}
+	return accts
+}
+
+func (m *mapOnlineAcctModel) OnlineCirculation(rnd basics.Round, voteRnd basics.Round) basics.MicroAlgos {
+	accts := m.allOnlineAsOf(rnd)
+	return m.sumAcctStake(accts)
+}
+
+func (m *mapOnlineAcctModel) ExpiredOnlineCirculation(rnd, voteRnd basics.Round) basics.MicroAlgos {
+	accts := m.onlineAcctsExpiredByRound(rnd, voteRnd)
+	return m.sumAcctStake(accts)
+}
+
+func (m *mapOnlineAcctModel) sumAcctStake(accts map[basics.Address]onlineAcctModelAcct) basics.MicroAlgos {
+	algops := MicroAlgoOperations{a: require.New(m.t)}
+	var ret basics.MicroAlgos
+	for _, acct := range accts {
+		ret = algops.Add(ret, acct.Stake)
+	}
+	return ret
+}
+
+func (m *mapOnlineAcctModel) setAcct(rnd basics.Round, addr basics.Address, acct onlineAcctModelAcct) {
+	require.Equal(m.t, rnd, m.cur, "cannot set acct for round other than current round")
+
+	acctRounds, ok := m.accts[addr]
+	if !ok {
+		acctRounds = make(map[basics.Round]onlineAcctModelAcct)
+	}
+	acctRounds[rnd] = acct
+	m.accts[addr] = acctRounds
+}
+
+func (m *mapOnlineAcctModel) goOnline(addr basics.Address, firstvalid, lastvalid basics.Round) {
+	rnd := m.cur
+	oldAcct := m.lookupAcctAsOf(rnd, addr)
+
+	// if is already online, remove old lastvalid round from expiring map
+	if oldAcct.Status == basics.Online {
+		require.Contains(m.t, m.expiring, oldAcct.VoteLastValid, "round should be in expiring map")
+		require.Contains(m.t, m.expiring[oldAcct.VoteLastValid], addr, "address should be in expiring map")
+		delete(m.expiring[oldAcct.VoteLastValid], addr)
+	}
+
+	// create new acct record
+	newAcct := onlineAcctModelAcct{
+		Status:         basics.Online,
+		VoteFirstValid: firstvalid,
+		VoteLastValid:  lastvalid,
+		Stake:          oldAcct.Stake,
+	}
+	m.setAcct(rnd, addr, newAcct)
+
+	// remember when this account will expire
+	expiring, ok := m.expiring[lastvalid]
+	if !ok {
+		expiring = make(map[basics.Address]struct{})
+	}
+	expiring[addr] = struct{}{}
+	m.expiring[lastvalid] = expiring
+
+}
+
+func (m *mapOnlineAcctModel) goOffline(addr basics.Address) {
+	rnd := m.cur
+	oldAcct := m.lookupAcctAsOf(rnd, addr)
+
+	// must already be online: remove old lastvalid round from expiring map
+	require.Equal(m.t, basics.Online, oldAcct.Status, "cannot go offline if not online")
+	require.Contains(m.t, m.expiring, oldAcct.VoteLastValid, "round should be in expiring map")
+	require.Contains(m.t, m.expiring[oldAcct.VoteLastValid], addr, "address should be in expiring map")
+	delete(m.expiring[oldAcct.VoteLastValid], addr)
+
+	newAcct := onlineAcctModelAcct{
+		Status:         basics.Offline,
+		VoteFirstValid: 0,
+		VoteLastValid:  0,
+		Stake:          oldAcct.Stake,
+	}
+	m.setAcct(rnd, addr, newAcct)
+}
+
+func (m *mapOnlineAcctModel) updateStake(addr basics.Address, stake basics.MicroAlgos) {
+	rnd := m.cur
+	acct := m.lookupAcctAsOf(rnd, addr)
+	acct.Stake = stake
+	m.setAcct(rnd, addr, acct)
+}
+
+func (m *mapOnlineAcctModel) onlineAcctsExpiredByRound(rnd, voteRnd basics.Round) map[basics.Address]onlineAcctModelAcct {
+	require.LessOrEqual(m.t, rnd, m.cur, "cannot lookup expired accts for future round")
+
+	// get all online addresses as of rnd
+	ret := make(map[basics.Address]onlineAcctModelAcct)
+	for addr, acct := range m.allOnlineAsOf(rnd) {
+		require.NotZero(m.t, acct.VoteLastValid, "offline acct returned by allOnlineAsOf")
+		// will this acct be expired by voteRnd?
+		if voteRnd > acct.VoteLastValid {
+			ret[addr] = acct
+		}
+	}
+	return ret
+}
+
+// doubleLedgerAcctModel implements an onlineAcctModel using DoubleLedger, which starts up two
+// Ledger instances, a generator and a validator.
+type doubleLedgerAcctModel struct {
+	t           testing.TB
+	params      *config.ConsensusParams
+	dl          *DoubleLedger
+	ops         *MicroAlgoOperations
+	genAddrs    []basics.Address
+	genBalances bookkeeping.GenesisBalances
+	genSecrets  []*crypto.SignatureSecrets
+	// new accounts made by goOnline, balance value tracks uncommitted balance changes before dl.endBlock()
+	accts map[basics.Address]basics.MicroAlgos
+}
+
+func newDoubleLedgerAcctModel(t testing.TB, proto protocol.ConsensusVersion, inMem bool) *doubleLedgerAcctModel {
+	// set 1 Algo for rewards pool size -- rewards math not supported by newMapOnlineAcctModel
+	genesisOpt := ledgertesting.TestGenesisRewardsPoolSize(basics.MicroAlgos{Raw: 1_000_000})
+	genBalances, genAddrs, genSecrets := ledgertesting.NewTestGenesis(genesisOpt)
+	cfg := config.GetDefaultLocal()
+	opts := []simpleLedgerOption{simpleLedgerNotArchival()}
+	if !inMem {
+		opts = append(opts, simpleLedgerOnDisk())
+	}
+	dl := NewDoubleLedger(t, genBalances, proto, cfg, opts...)
+	dl.beginBlock()
+	params := config.Consensus[proto]
+	return &doubleLedgerAcctModel{
+		t:           t,
+		params:      &params,
+		ops:         &MicroAlgoOperations{a: require.New(t)},
+		dl:          &dl,
+		genAddrs:    genAddrs,
+		genBalances: genBalances,
+		genSecrets:  genSecrets,
+		accts:       make(map[basics.Address]basics.MicroAlgos),
+	}
+}
+
+func (m *doubleLedgerAcctModel) teardown() { m.dl.Close() }
+
+func (m *doubleLedgerAcctModel) nextRound() {
+	m.dl.endBlock()
+	m.dl.beginBlock()
+}
+
+func (m *doubleLedgerAcctModel) currentRound() basics.Round {
+	genRound := m.dl.generator.Latest()
+	valRound := m.dl.validator.Latest()
+	require.Equal(m.t, genRound, valRound)
+	return genRound + 1
+}
+
+func (m *doubleLedgerAcctModel) advanceToRound(rnd basics.Round) {
+	if rnd == m.currentRound() {
+		return
+	}
+	require.Greater(m.t, rnd, m.currentRound(), "cannot advance to previous round")
+	for m.currentRound() < rnd {
+		m.nextRound()
+	}
+	require.Equal(m.t, rnd, m.currentRound())
+}
+
+const doubleLedgerAcctModelAcctInitialBalance = 1_234_567
+
+func (m *doubleLedgerAcctModel) goOnline(addr basics.Address, firstvalid, lastvalid basics.Round) {
+	if _, ok := m.accts[addr]; !ok {
+		// not yet in the ledger: send 1 algo from a genesis account
+		m.dl.txn(&txntest.Txn{
+			Type:     protocol.PaymentTx,
+			Sender:   m.genAddrs[0],
+			Receiver: addr,
+			Amount:   doubleLedgerAcctModelAcctInitialBalance,
+		})
+		m.accts[addr] = basics.MicroAlgos{Raw: doubleLedgerAcctModelAcctInitialBalance}
+	}
+
+	require.NotZero(m.t, addr, "cannot go online with zero address")
+
+	minFee := m.params.MinTxnFee // subtract minFee from account balance
+	m.dl.txn(&txntest.Txn{
+		Type:      protocol.KeyRegistrationTx,
+		Sender:    addr,
+		VoteFirst: firstvalid,
+		VoteLast:  lastvalid,
+		Fee:       minFee,
+
+		Nonparticipation: false, // XXX test nonparticipating accounts
+
+		// meaningless non-zero voting data
+		VotePK:          crypto.OneTimeSignatureVerifier(addr),
+		SelectionPK:     crypto.VRFVerifier(addr),
+		VoteKeyDilution: 1024,
+	})
+	m.accts[addr] = m.ops.Sub(m.accts[addr], basics.MicroAlgos{Raw: minFee})
+}
+
+func (m *doubleLedgerAcctModel) goOffline(addr basics.Address) {
+	require.Contains(m.t, m.accts, addr, "cannot go offline with unknown address")
+
+	minFee := m.params.MinTxnFee // subtract minFee from account balance
+	m.dl.txn(&txntest.Txn{
+		Type:   protocol.KeyRegistrationTx,
+		Sender: addr,
+		Fee:    minFee,
+
+		// not necessary to specify
+		VoteFirst:       0,
+		VoteLast:        0,
+		VotePK:          crypto.OneTimeSignatureVerifier{},
+		SelectionPK:     crypto.VRFVerifier{},
+		VoteKeyDilution: 0,
+	})
+	m.accts[addr] = m.ops.Sub(m.accts[addr], basics.MicroAlgos{Raw: minFee})
+}
+
+func (m *doubleLedgerAcctModel) updateStake(addr basics.Address, amount basics.MicroAlgos) {
+	curStake := m.accts[addr]
+	require.GreaterOrEqual(m.t, amount.Raw, curStake.Raw, "currently cannot decrease stake")
+	if amount == curStake {
+		return
+	}
+	if amount.Raw > curStake.Raw {
+		sendAmt := m.ops.Sub(amount, curStake)
+		// send more algo from a genesis account
+		m.dl.txn(&txntest.Txn{
+			Type:     protocol.PaymentTx,
+			Sender:   m.genAddrs[0],
+			Receiver: addr,
+			Amount:   sendAmt.Raw,
+			Fee:      m.params.MinTxnFee,
+		})
+		m.accts[addr] = amount
+		m.t.Logf("updateStake addr %s sent %d, bal %d", addr, sendAmt, amount)
+	}
+}
+
+// OnlineCirculation returns the total online stake at rnd this model produced, while
+// also asserting that the validator and generator Ledgers both agree, and that different
+// Ledger/tracker methods used to retrieve and calculate the stake internally agree.
+func (m *doubleLedgerAcctModel) OnlineCirculation(rnd basics.Round, voteRnd basics.Round) basics.MicroAlgos {
+	valTotal, err := m.dl.validator.OnlineTotalStake(rnd)
+	require.NoError(m.t, err)
+	genTotal, err := m.dl.generator.OnlineTotalStake(rnd)
+	require.NoError(m.t, err)
+	require.Equal(m.t, valTotal, genTotal)
+
+	valStake, err := m.dl.validator.OnlineCirculation(rnd, voteRnd)
+	require.NoError(m.t, err)
+	genStake, err := m.dl.generator.OnlineCirculation(rnd, voteRnd)
+	require.NoError(m.t, err)
+	require.Equal(m.t, valStake, genStake)
+
+	// If ExcludeExpiredCirculation is set, this means OnlineCirculation
+	// has already subtracted the expired stake. So to get the total, add
+	// it back in by querying ExpiredOnlineCirculation.
+	if m.params.ExcludeExpiredCirculation {
+		expiredStake := m.ExpiredOnlineCirculation(rnd, rnd+320)
+		valStake = m.ops.Add(valStake, expiredStake)
+	}
+
+	// This should equal the value of onlineTotalsImpl(rnd) which provides
+	// the total online stake without subtracting expired stake.
+	require.Equal(m.t, valTotal, valStake)
+
+	return valStake
+}
+
+// OnlineTotalStake is a wrapper to access onlineAccounts.onlineTotalsImpl safely.
+func (l *Ledger) OnlineTotalStake(rnd basics.Round) (basics.MicroAlgos, error) {
+	l.trackerMu.RLock()
+	defer l.trackerMu.RUnlock()
+	totalStake, _, err := l.acctsOnline.onlineTotals(rnd)
+	return totalStake, err
+}
+
+// ExpiredOnlineCirculation is a wrapper to call onlineAccounts.ExpiredOnlineCirculation safely.
+func (l *Ledger) ExpiredOnlineCirculation(rnd, voteRnd basics.Round) (basics.MicroAlgos, error) {
+	l.trackerMu.RLock()
+	defer l.trackerMu.RUnlock()
+	return l.acctsOnline.ExpiredOnlineCirculation(rnd, voteRnd)
+}
+
+// ExpiredOnlineCirculation returns the total expired stake at rnd this model produced, while
+// also asserting that the validator and generator Ledgers both agree.
+func (m *doubleLedgerAcctModel) ExpiredOnlineCirculation(rnd, voteRnd basics.Round) basics.MicroAlgos {
+	valStake, err := m.dl.validator.ExpiredOnlineCirculation(rnd, voteRnd)
+	require.NoError(m.t, err)
+	genStake, err := m.dl.generator.ExpiredOnlineCirculation(rnd, voteRnd)
+	require.NoError(m.t, err)
+	require.Equal(m.t, valStake, genStake)
+	return valStake
+}
+
+func (m *doubleLedgerAcctModel) LookupAgreement(rnd basics.Round, addr basics.Address) onlineAcctModelAcct {
+	valAcct, err := m.dl.validator.LookupAgreement(rnd, addr)
+	require.NoError(m.t, err)
+	genAcct, err := m.dl.generator.LookupAgreement(rnd, addr)
+	require.NoError(m.t, err)
+	require.Equal(m.t, valAcct, genAcct)
+
+	status := basics.Offline
+	if valAcct.VoteLastValid > 0 || valAcct.VoteFirstValid > 0 {
+		status = basics.Online
+	}
+	return onlineAcctModelAcct{
+		VoteFirstValid: valAcct.VoteFirstValid,
+		VoteLastValid:  valAcct.VoteLastValid,
+		Status:         status,
+		Stake:          valAcct.MicroAlgosWithRewards,
+	}
+}
+
+//nolint:paralleltest // don't want to parallelize this test
+func TestOnlineAcctModelSimple(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	// first test using the in-memory model
+	t.Run("Map", func(t *testing.T) {
+		m := newMapOnlineAcctModel(t)
+		testOnlineAcctModelSimple(t, m)
+	})
+	// test same scenario on double ledger
+	t.Run("DoubleLedger", func(t *testing.T) {
+		m := newDoubleLedgerAcctModel(t, protocol.ConsensusFuture, true)
+		defer m.teardown()
+		testOnlineAcctModelSimple(t, m)
+	})
+}
+
+func testOnlineAcctModelSimple(t *testing.T, m onlineAcctModel) {
+	// acct 1 has 10 algos expiring at round 2000
+	m.goOnline(basics.Address{1}, 1, 2000)
+	m.updateStake(basics.Address{1}, basics.MicroAlgos{Raw: 10_000_000})
+	// acct 2 has 11 algos expiring at round 999
+	m.goOnline(basics.Address{2}, 1, 999)
+	m.updateStake(basics.Address{2}, basics.MicroAlgos{Raw: 11_000_000})
+
+	m.advanceToRound(500)
+	// acct 3 has 11.1 algos expiring at round 2500
+	m.goOnline(basics.Address{3}, 500, 2500)
+	m.updateStake(basics.Address{3}, basics.MicroAlgos{Raw: 11_100_000})
+
+	m.advanceToRound(600)
+	// acct 4 has 11.11 algos expiring at round 900
+	m.goOnline(basics.Address{4}, 600, 900)
+	m.updateStake(basics.Address{4}, basics.MicroAlgos{Raw: 11_110_000})
+
+	m.advanceToRound(1000)
+	// total stake is all 4 accounts
+	a := require.New(t)
+	onlineStake := m.OnlineCirculation(680, 1000)
+	a.Equal(basics.MicroAlgos{Raw: 43_210_000}, onlineStake)
+
+	// expired stake is acct 2 + acct 4
+	expiredStake := m.ExpiredOnlineCirculation(680, 1000)
+	a.Equal(basics.MicroAlgos{Raw: 22_110_000}, expiredStake)
+}
+
+// An onlineScenario is a list of actions to take at each round, which are
+// applied to the onlineAcctModel implementations (real and oracle) being tested.
+type onlineScenario struct {
+	// roundActions is a list of actions to take in each round, must be in rnd order
+	roundActions []onlineScenarioRound
+}
+
+type onlineScenarioRound struct {
+	rnd     basics.Round
+	actions []onlineScenarioRoundAction
+}
+
+// An onlineScenarioRoundAction is an action to take on an onlineAcctModel in a given round.
+type onlineScenarioRoundAction interface {
+	apply(t *testing.T, m onlineAcctModel)
+}
+
+type goOnlineWithStakeAction struct {
+	addr   basics.Address
+	fv, lv basics.Round
+	stake  uint64
+}
+
+func (a goOnlineWithStakeAction) apply(t *testing.T, m onlineAcctModel) {
+	m.goOnline(a.addr, a.fv, a.lv)
+	m.updateStake(a.addr, basics.MicroAlgos{Raw: a.stake})
+}
+
+type goOfflineAction struct{ addr basics.Address }
+
+func (a goOfflineAction) apply(t *testing.T, m onlineAcctModel) { m.goOffline(a.addr) }
+
+type updateStakeAction struct {
+	addr  basics.Address
+	stake uint64
+}
+
+func (a updateStakeAction) apply(t *testing.T, m onlineAcctModel) {
+	m.updateStake(a.addr, basics.MicroAlgos{Raw: a.stake})
+}
+
+type checkOnlineStakeAction struct {
+	rnd, voteRnd    basics.Round
+	online, expired uint64
+}
+
+func (a checkOnlineStakeAction) apply(t *testing.T, m onlineAcctModel) {
+	onlineStake := m.OnlineCirculation(a.rnd, a.voteRnd)
+	expiredStake := m.ExpiredOnlineCirculation(a.rnd, a.voteRnd)
+	require.Equal(t, basics.MicroAlgos{Raw: a.online}, onlineStake, "round %d, cur %d", a.rnd, m.currentRound())
+	require.Equal(t, basics.MicroAlgos{Raw: a.expired}, expiredStake, "rnd %d voteRnd %d, cur %d", a.rnd, a.voteRnd, m.currentRound())
+}
+
+// simpleOnlineScenario is the same as the TestOnlineAcctModelSimple test
+// but expressed as an onlineScenario
+var simpleOnlineScenario = onlineScenario{
+	roundActions: []onlineScenarioRound{
+		{1, []onlineScenarioRoundAction{
+			// acct 1 has 10 algos expiring at round 2000
+			goOnlineWithStakeAction{basics.Address{1}, 1, 2000, 10_000_000},
+			// acct 2 has 11 algos expiring at round 999
+			goOnlineWithStakeAction{basics.Address{2}, 1, 999, 11_000_000},
+		}},
+		{500, []onlineScenarioRoundAction{
+			// acct 3 has 11.1 algos expiring at round 2500
+			goOnlineWithStakeAction{basics.Address{3}, 500, 2500, 11_100_000},
+		}},
+		{600, []onlineScenarioRoundAction{
+			// acct 4 has 11.11 algos expiring at round 900
+			goOnlineWithStakeAction{basics.Address{4}, 600, 900, 11_110_000},
+		}},
+		{681, []onlineScenarioRoundAction{
+			// total stake is all 4 accounts
+			// expired stake is acct 2 + acct 4
+			checkOnlineStakeAction{680, 1000, 43_210_000, 22_110_000},
+		}},
+		{1000, []onlineScenarioRoundAction{
+			// check total & expired stake again at round 1000, should be the same
+			checkOnlineStakeAction{680, 1000, 43_210_000, 22_110_000},
+		}},
+	},
+}
+
+// a quick helper function for making it easier to identify whose balances are missing
+func shift1AlgoBy(n uint64) uint64 { return 1_000_000 << n }
+
+// simpleOfflineOnlineScenario is like simpleOnlineScenario but with acct 2
+// going from online+expired to offline at round 999.
+var simpleOfflineOnlineScenario = onlineScenario{
+	roundActions: []onlineScenarioRound{
+		{1, []onlineScenarioRoundAction{
+			goOnlineWithStakeAction{basics.Address{1}, 1, 2000, shift1AlgoBy(1)},
+			goOnlineWithStakeAction{basics.Address{2}, 1, 999, shift1AlgoBy(2)},
+		}},
+		{500, []onlineScenarioRoundAction{
+			goOnlineWithStakeAction{basics.Address{3}, 500, 2500, shift1AlgoBy(3)},
+		}},
+		{600, []onlineScenarioRoundAction{
+			goOnlineWithStakeAction{basics.Address{4}, 600, 900, shift1AlgoBy(4)}, // expired by 1000
+		}},
+		{679, []onlineScenarioRoundAction{
+			goOnlineWithStakeAction{basics.Address{5}, 679, 999, shift1AlgoBy(5)}, // expired by 1000
+			goOfflineAction{basics.Address{2}},                                    // was going to expire at 999 but now is offline
+		}},
+		{680, []onlineScenarioRoundAction{
+			goOnlineWithStakeAction{basics.Address{6}, 680, 999, shift1AlgoBy(6)}, // expired by 1000
+			goOnlineWithStakeAction{basics.Address{7}, 680, 1000, shift1AlgoBy(7)},
+		}},
+		{1000, []onlineScenarioRoundAction{
+			checkOnlineStakeAction{680, 1000, 250_000_000, 112_000_000},
+		}},
+	},
+}
+
+//nolint:paralleltest // don't want to parallelize this test
+func TestOnlineAcctModelScenario(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	runScenario := func(t *testing.T, m onlineAcctModel, s onlineScenario) {
+		for _, ra := range s.roundActions {
+			m.advanceToRound(ra.rnd)
+			for _, action := range ra.actions {
+				action.apply(t, m)
+			}
+		}
+	}
+
+	for _, tc := range []struct {
+		name     string
+		scenario onlineScenario
+	}{
+		{"Simple", simpleOnlineScenario},
+		{"SimpleOffline", simpleOfflineOnlineScenario},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// first test using the in-memory model
+			t.Run("Map", func(t *testing.T) {
+				m := newMapOnlineAcctModel(t)
+				runScenario(t, m, tc.scenario)
+			})
+			// test same scenario on double ledger
+			t.Run("DoubleLedger", func(t *testing.T) {
+				m := newDoubleLedgerAcctModel(t, protocol.ConsensusFuture, true)
+				defer m.teardown()
+				runScenario(t, m, tc.scenario)
+			})
+		})
+	}
+}
+
+func BenchmarkExpiredOnlineCirculation(b *testing.B) {
+	// set up totalAccounts online accounts in 10k batches
+	totalAccounts := 100_000
+	const maxKeyregPerBlock = 10_000
+	// if TOTAL_ACCOUNTS env var set, override totalAccounts
+	if n, err := strconv.Atoi(os.Getenv("TOTAL_ACCOUNTS")); err == nil {
+		b.Logf("using %d accounts", n)
+		if n%maxKeyregPerBlock != 0 {
+			b.Fatalf("TOTAL_ACCOUNTS %d must be a multiple of %d", n, maxKeyregPerBlock)
+		}
+		totalAccounts = n
+	}
+
+	proto := protocol.ConsensusFuture
+	m := newDoubleLedgerAcctModel(b, proto, false)
+	defer m.teardown()
+
+	addrFromUint64 := func(n uint64) basics.Address {
+		var addr basics.Address
+		binary.BigEndian.PutUint64(addr[:], n)
+		return addr
+	}
+
+	var blockCounter, acctCounter uint64
+	for i := 0; i < totalAccounts/maxKeyregPerBlock; i++ {
+		blockCounter++
+		for j := 0; j < maxKeyregPerBlock; j++ {
+			acctCounter++
+			// go online for a random number of rounds, from 400 to 1600
+			validFor := 400 + uint64(rand.Intn(1200))
+			m.goOnline(addrFromUint64(acctCounter), basics.Round(blockCounter), basics.Round(blockCounter+validFor))
+		}
+		b.Log("built block", blockCounter, "accts", acctCounter)
+		m.nextRound()
+	}
+	// then advance ~1K rounds to exercise the exercise accounts going offline
+	m.advanceToRound(basics.Round(blockCounter + 1000))
+	b.Log("advanced to round", m.currentRound())
+
+	b.ResetTimer()
+	for i := uint64(0); i < uint64(b.N); i++ {
+		// query expired circulation across the available range (last 320 rounds, from ~680 to ~1000)
+		startRnd := m.currentRound() - 320
+		offset := basics.Round(i % 320)
+		_, err := m.dl.validator.ExpiredOnlineCirculation(startRnd+offset, startRnd+offset+320)
+		require.NoError(b, err)
+		//total, err := m.dl.validator.OnlineTotalStake(startRnd + offset)
+		//b.Log("expired circulation", startRnd+offset, startRnd+offset+320, "returned", expiredStake, "total", total)
+	}
+}

--- a/ledger/acctonline_test.go
+++ b/ledger/acctonline_test.go
@@ -21,6 +21,7 @@ import (
 	"database/sql"
 	"fmt"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -781,7 +782,7 @@ func TestAcctOnlineRoundParamsCache(t *testing.T) {
 		accts = append(accts, newAccts)
 
 		if i > basics.Round(maxBalLookback) && i%10 == 0 {
-			onlineTotal, err := ao.onlineTotals(i - basics.Round(maxBalLookback))
+			onlineTotal, err := ao.onlineCirculation(i-basics.Round(maxBalLookback), i)
 			require.NoError(t, err)
 			require.Equal(t, allTotals[i-basics.Round(maxBalLookback)].Online.Money, onlineTotal)
 			expectedConsensusVersion := testProtocolVersion1
@@ -822,7 +823,7 @@ func TestAcctOnlineRoundParamsCache(t *testing.T) {
 	require.Equal(t, ao.onlineRoundParamsData[:basics.Round(maxBalLookback)], dbOnlineRoundParams)
 
 	for i := ml.Latest() - basics.Round(maxBalLookback); i < ml.Latest(); i++ {
-		onlineTotal, err := ao.onlineTotals(i)
+		onlineTotal, err := ao.onlineCirculation(i, i+basics.Round(maxBalLookback))
 		require.NoError(t, err)
 		require.Equal(t, allTotals[i].Online.Money, onlineTotal)
 	}
@@ -1421,7 +1422,7 @@ func TestAcctOnlineTop(t *testing.T) {
 	conf := config.GetDefaultLocal()
 	au, oa := newAcctUpdates(t, ml, conf)
 	defer oa.close()
-	initialOnlineTotals, err := oa.onlineTotals(0)
+	initialOnlineTotals, err := oa.onlineCirculation(0, basics.Round(oa.maxBalLookback()))
 	a.NoError(err)
 	top := compareOnlineTotals(a, oa, 0, 0, 5, initialOnlineTotals, initialOnlineTotals)
 	compareTopAccounts(a, top, allAccts)
@@ -1484,7 +1485,20 @@ func TestAcctOnlineTop(t *testing.T) {
 
 func TestAcctOnlineTopInBatches(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	a := require.New(t)
+
+	intToAddress := func(n int) basics.Address {
+		var addr basics.Address
+		pos := 0
+		for {
+			addr[pos] = byte(n % 10)
+			n /= 10
+			if n == 0 {
+				break
+			}
+			pos++
+		}
+		return addr
+	}
 
 	const numAccts = 2048
 	allAccts := make([]basics.BalanceRecord, numAccts)
@@ -1493,11 +1507,11 @@ func TestAcctOnlineTopInBatches(t *testing.T) {
 
 	for i := 0; i < numAccts; i++ {
 		allAccts[i] = basics.BalanceRecord{
-			Addr: ledgertesting.RandomAddress(),
+			Addr: intToAddress(i + 1),
 			AccountData: basics.AccountData{
 				MicroAlgos:     basics.MicroAlgos{Raw: uint64(i + 1)},
 				Status:         basics.Online,
-				VoteLastValid:  1000,
+				VoteLastValid:  basics.Round(i + 1),
 				VoteFirstValid: 0,
 				RewardsBase:    0},
 		}
@@ -1505,17 +1519,55 @@ func TestAcctOnlineTopInBatches(t *testing.T) {
 	}
 	addSinkAndPoolAccounts(genesisAccts)
 
-	ml := makeMockLedgerForTracker(t, true, 1, protocol.ConsensusCurrentVersion, genesisAccts)
-	defer ml.Close()
+	for _, proto := range []protocol.ConsensusVersion{protocol.ConsensusV36, protocol.ConsensusFuture} {
+		t.Run(string(proto), func(t *testing.T) {
+			a := require.New(t)
+			params := config.Consensus[proto]
+			ml := makeMockLedgerForTracker(t, true, 1, proto, genesisAccts)
+			defer ml.Close()
 
-	conf := config.GetDefaultLocal()
-	_, oa := newAcctUpdates(t, ml, conf)
-	defer oa.close()
+			conf := config.GetDefaultLocal()
+			au, oa := newAcctUpdates(t, ml, conf)
+			defer oa.close()
 
-	proto := config.Consensus[protocol.ConsensusCurrentVersion]
-	top, _, err := oa.TopOnlineAccounts(0, 0, 2048, &proto, 0)
-	a.NoError(err)
-	compareTopAccounts(a, top, allAccts)
+			top, totalOnlineStake, err := oa.TopOnlineAccounts(0, 0, numAccts, &params, 0)
+			a.NoError(err)
+			compareTopAccounts(a, top, allAccts)
+			a.Equal(basics.MicroAlgos{Raw: 2048 * 2049 / 2}, totalOnlineStake)
+
+			// add 300 blocks so the first 300 accounts expire
+			// at the last block put the 299th account offline to trigger TopOnlineAccounts behavior difference
+			_, totals, err := au.LatestTotals()
+			a.NoError(err)
+			acct299 := allAccts[298]
+			for i := 1; i <= 300; i++ {
+				var updates ledgercore.AccountDeltas
+				if i == 300 {
+					updates.Upsert(acct299.Addr, ledgercore.AccountData{
+						AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline, MicroAlgos: acct299.MicroAlgos},
+						VotingData:      ledgercore.VotingData{},
+					})
+				}
+				newBlockWithUpdates(genesisAccts, updates, totals, t, ml, i, oa)
+			}
+			a.Equal(basics.Round(300), oa.latest())
+
+			// 299 accts expired at voteRnd = 300
+			top, totalOnlineStake, err = oa.TopOnlineAccounts(0, 300, numAccts, &params, 0)
+			a.NoError(err)
+			compareTopAccounts(a, top, allAccts)
+			a.Equal(basics.MicroAlgos{Raw: 2048*2049/2 - 299*300/2}, totalOnlineStake)
+
+			// check the behavior difference between ConsensusV36 and ConsensusFuture
+			var correction uint64
+			if proto == protocol.ConsensusV36 {
+				correction = acct299.MicroAlgos.Raw
+			}
+			_, totalOnlineStake, err = oa.TopOnlineAccounts(300, 300, numAccts, &params, 0)
+			a.NoError(err)
+			a.Equal(basics.MicroAlgos{Raw: 2048*2049/2 - 299*300/2 - correction}, totalOnlineStake)
+		})
+	}
 }
 
 func TestAcctOnlineTopBetweenCommitAndPostCommit(t *testing.T) {
@@ -1763,7 +1815,8 @@ func TestAcctOnlineTop_ChangeOnlineStake(t *testing.T) {
 		totals = newBlockWithUpdates(genesisAccts, updates, totals, t, ml, i, oa)
 	}
 
-	initialOnlineStake, err := oa.onlineTotals(0)
+	params := config.Consensus[protocol.ConsensusCurrentVersion]
+	initialOnlineStake, err := oa.onlineCirculation(0, basics.Round(params.MaxBalLookback))
 	a.NoError(err)
 	rnd15TotalOnlineStake := algops.Sub(initialOnlineStake, allAccts[15].MicroAlgos) // 15 is offline
 
@@ -1808,9 +1861,318 @@ func compareOnlineTotals(a *require.Assertions, oa *onlineAccounts, rnd, voteRnd
 	top, onlineTotalVoteRnd, err := oa.TopOnlineAccounts(rnd, voteRnd, n, &proto, 0)
 	a.NoError(err)
 	a.Equal(expectedForVoteRnd, onlineTotalVoteRnd)
-	onlineTotalsRnd, err := oa.onlineTotals(rnd)
+	onlineTotalsRnd, err := oa.onlineCirculation(rnd, voteRnd)
 	a.NoError(err)
 	a.Equal(expectedForRnd, onlineTotalsRnd)
 	a.LessOrEqual(onlineTotalVoteRnd.Raw, onlineTotalsRnd.Raw)
 	return top
+}
+
+// TestAcctOnline_ExpiredOnlineCirculation mutates online state in deltas and DB
+// to ensure ExpiredOnlineCirculation returns expected online stake value
+// The test exercises all possible combinations for offline, online and expired values for two accounts.
+func TestAcctOnline_ExpiredOnlineCirculation(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+	algops := MicroAlgoOperations{a: a}
+
+	// powInt is a helper function to calculate powers of uint64
+	powInt := func(x, y uint64) uint64 {
+		ret := uint64(1)
+		if x == 0 {
+			return ret
+		}
+		for i := uint64(0); i < y; i++ {
+			ret *= x
+		}
+		return ret
+	}
+
+	// add some genesis online accounts with stake 1, 10, 20, 30... in order to see which account stake
+	// not included into results while debugging
+	const numAccts = 20
+	allAccts := make([]basics.BalanceRecord, numAccts)
+	genesisAccts := []map[basics.Address]basics.AccountData{{}}
+	genesisAccts[0] = make(map[basics.Address]basics.AccountData, numAccts)
+	totalStake := basics.MicroAlgos{Raw: 0}
+	for i := 0; i < numAccts-1; i++ {
+		stake := i * 10
+		if stake == 0 {
+			stake = 1
+		}
+		allAccts[i] = basics.BalanceRecord{
+			Addr: ledgertesting.RandomAddress(),
+			AccountData: basics.AccountData{
+				MicroAlgos:     basics.MicroAlgos{Raw: uint64(stake)},
+				Status:         basics.Online,
+				VoteLastValid:  10000,
+				VoteFirstValid: 0,
+				RewardsBase:    0},
+		}
+		genesisAccts[0][allAccts[i].Addr] = allAccts[i].AccountData
+		totalStake = algops.Add(totalStake, allAccts[i].MicroAlgos)
+	}
+
+	addSinkAndPoolAccounts(genesisAccts)
+
+	proto := protocol.ConsensusFuture
+	params := config.Consensus[proto]
+	ml := makeMockLedgerForTracker(t, true, 1, proto, genesisAccts)
+	defer ml.Close()
+
+	conf := config.GetDefaultLocal()
+	conf.MaxAcctLookback = 4 // technically the test work for any value of MaxAcctLookback but takes too long
+	// t.Logf("Running MaxAcctLookback=%d", conf.MaxAcctLookback)
+	au, oa := newAcctUpdates(t, ml, conf)
+	defer oa.close()
+
+	// close commitSyncer goroutine to prevent possible race between commitSyncer and commitSync
+	ml.trackers.ctxCancel()
+	ml.trackers.ctxCancel = nil
+	<-ml.trackers.commitSyncerClosed
+	ml.trackers.commitSyncerClosed = nil
+
+	// initial precondition checks on online stake
+	_, totals, err := au.LatestTotals()
+	a.NoError(err)
+	a.Equal(totalStake, totals.Online.Money)
+	initialOnlineStake, err := oa.onlineCirculation(0, basics.Round(oa.maxBalLookback()))
+	a.NoError(err)
+	a.Equal(totalStake, initialOnlineStake)
+	initialExpired, err := oa.ExpiredOnlineCirculation(0, 1000)
+	a.NoError(err)
+	a.Equal(basics.MicroAlgos{Raw: 0}, initialExpired)
+
+	type dbState uint64
+	const (
+		dbOffline dbState = iota
+		dbOnline
+		dbOnlineExpired
+	)
+
+	type deltaState uint64
+	const (
+		deltaNoChange deltaState = iota
+		deltaOffpired            // offline (addrA) or expired (addrB)
+		deltaOnline
+	)
+
+	type acctState uint64
+	const (
+		acctStateUnknown acctState = iota
+		acctStateOffline
+		acctStateOnline
+		acctStateExpired
+	)
+
+	// take two first accounts for the test - 0 and 1 - with stake 1 and 10 correspondingly
+	addrA := allAccts[0].Addr
+	stakeA := allAccts[0].MicroAlgos
+	statesA := map[acctState]ledgercore.AccountData{
+		acctStateOffline: {AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline, MicroAlgos: stakeA}, VotingData: ledgercore.VotingData{}},
+		acctStateOnline:  {AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online, MicroAlgos: stakeA}, VotingData: ledgercore.VotingData(allAccts[0].OnlineAccountData().VotingData)},
+	}
+
+	addrB := allAccts[1].Addr
+	stakeB := allAccts[1].MicroAlgos
+	votingDataB := allAccts[1].OnlineAccountData().VotingData
+	statesB := map[acctState]ledgercore.AccountData{
+		acctStateOffline: {AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline, MicroAlgos: stakeB}, VotingData: ledgercore.VotingData{}},
+		acctStateOnline:  {AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online, MicroAlgos: stakeB}, VotingData: ledgercore.VotingData(votingDataB)},
+	}
+	expStatesB := func(state acctState, voteRnd basics.Round) ledgercore.AccountData {
+		vd := ledgercore.VotingData(votingDataB)
+		switch state {
+		case acctStateExpired:
+			vd.VoteLastValid = voteRnd - 1
+		case acctStateOnline:
+			vd.VoteLastValid = voteRnd + 1
+		default:
+			a.Fail("invalid acct state")
+		}
+		return ledgercore.AccountData{
+			AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online, MicroAlgos: stakeB},
+			VotingData:      vd,
+		}
+	}
+
+	// try all possible online/offline delta states for account A
+	// try all possible valid/expired VoteLastValid for account B
+	// - generate {offline, online, online-expired} db states (two rounds committed) for account A and B
+	// - generate all combinations of deltaState {not changed, offline/expired, online} of size conf.MaxAcctLookback arrays
+	// - test all combinations in 3^2 * 3^conf.MaxAcctLookback tests
+	rnd := basics.Round(1)
+	accounts := []map[basics.Address]basics.AccountData{genesisAccts[0]} // base state
+	dbStates := []dbState{dbOffline, dbOnline, dbOnlineExpired}
+	deltaStates := []deltaState{deltaNoChange, deltaOffpired, deltaOnline}
+	const dbRoundsToCommit = 2
+	for dbCombo := uint64(0); dbCombo < powInt(uint64(len(dbStates)), dbRoundsToCommit); dbCombo++ {
+		for deltaCombo := uint64(0); deltaCombo < powInt(uint64(len(deltaStates)), conf.MaxAcctLookback); deltaCombo++ {
+			var stateA acctState
+			var stateB acctState
+
+			ternDb := strconv.FormatUint(dbCombo, 3)
+			ternDb = fmt.Sprintf("%0*s", dbRoundsToCommit, ternDb)
+
+			ternDelta := strconv.FormatUint(deltaCombo, 3)
+			ternDelta = fmt.Sprintf("%0*s", conf.MaxAcctLookback, ternDelta)
+			// uncomment for debugging
+			// t.Logf("db=%d|delta=%d <==> older->%s<-db top | first->%s<-last", dbCombo, deltaCombo, ternDb, ternDelta)
+
+			targetVoteRnd := rnd +
+				basics.Round(conf.MaxAcctLookback) /* all deltas */ +
+				2 /* db state committed */ +
+				basics.Round(params.MaxBalLookback)
+
+			// mutate the committed state
+			// addrA, addrB: offline, online not expired, online expired
+			dbSeed := dbState(9999) // not initialized
+			for i := uint64(0); i < dbRoundsToCommit; i++ {
+				combo := ternDb[i]
+				d, err := strconv.Atoi(string(combo))
+				a.NoError(err)
+				if i == dbRoundsToCommit-1 {
+					dbSeed = dbState(d)
+				}
+
+				var updates ledgercore.AccountDeltas
+				switch dbState(d) {
+				case dbOffline:
+					updates.Upsert(addrA, statesA[acctStateOffline])
+					updates.Upsert(addrB, statesB[acctStateOffline])
+				case dbOnline:
+					updates.Upsert(addrA, statesA[acctStateOnline])
+					updates.Upsert(addrB, statesB[acctStateOnline])
+				case dbOnlineExpired:
+					state := statesA[acctStateOnline]
+					state.VoteLastValid = targetVoteRnd - 1
+					updates.Upsert(addrA, state)
+					state = statesB[acctStateOnline]
+					state.VoteLastValid = targetVoteRnd - 1
+					updates.Upsert(addrB, state)
+				default:
+					a.Fail("unknown db state")
+				}
+				base := accounts[rnd-1]
+				accounts = append(accounts, applyPartialDeltas(base, updates))
+				totals = newBlock(t, ml, proto, params, rnd, base, updates, totals)
+				rnd++
+			}
+
+			// assert on expected online totals
+			switch dbSeed {
+			case dbOffline:
+				// both accounts are offline, decrease the original stake
+				a.Equal(initialOnlineStake.Raw-(stakeA.Raw+stakeB.Raw), totals.Online.Money.Raw)
+			case dbOnline, dbOnlineExpired: // being expired does not decrease the stake
+				a.Equal(initialOnlineStake, totals.Online.Money)
+			}
+
+			// mutate in-memory state
+			for i := uint64(0); i < conf.MaxAcctLookback; i++ {
+				combo := ternDelta[i]
+				d, err := strconv.Atoi(string(combo))
+				a.NoError(err)
+
+				var updates ledgercore.AccountDeltas
+				switch deltaState(d) {
+				case deltaNoChange:
+				case deltaOffpired:
+					updates.Upsert(addrA, statesA[acctStateOffline])
+					updates.Upsert(addrB, expStatesB(acctStateExpired, targetVoteRnd))
+					stateA = acctStateOffline
+					stateB = acctStateExpired
+				case deltaOnline:
+					updates.Upsert(addrA, statesA[acctStateOnline])
+					updates.Upsert(addrB, expStatesB(acctStateOnline, targetVoteRnd))
+					stateA = acctStateOnline
+					stateB = acctStateOnline
+
+				default:
+					a.Fail("unknown delta seed")
+				}
+				base := accounts[rnd-1]
+				accounts = append(accounts, applyPartialDeltas(base, updates))
+				totals = newBlock(t, ml, proto, params, rnd, base, updates, totals)
+				rnd++
+			}
+
+			commitSync(t, oa, ml, basics.Round(rnd-1))
+			a.Equal(int(conf.MaxAcctLookback), len(oa.deltas)) // ensure the only expected deltas are not flushed
+
+			var expiredAccts map[basics.Address]*ledgercore.OnlineAccountData
+			err = ml.trackers.dbs.Snapshot(func(ctx context.Context, tx trackerdb.SnapshotScope) error {
+				reader, err := tx.MakeAccountsReader()
+				if err != nil {
+					return err
+				}
+				expiredAccts, err = reader.ExpiredOnlineAccountsForRound(rnd-1, targetVoteRnd, params, 0)
+				if err != nil {
+					return err
+				}
+				return nil
+			})
+			a.NoError(err)
+
+			if dbSeed == dbOffline || dbSeed == dbOnline {
+				a.Empty(expiredAccts)
+			} else {
+				a.Len(expiredAccts, 2)
+				for _, acct := range expiredAccts {
+					a.NotZero(acct.VoteLastValid)
+				}
+			}
+
+			expectedExpiredStake := basics.MicroAlgos{}
+			// if both A and B were offline or online in DB then the expired stake is changed only if account is expired in deltas
+			// => check if B expired
+			// if both A and B were expired in DB then the expired stake is changed when any of them goes offline or online
+			// => check if A or B are offline or online
+			switch dbSeed {
+			case dbOffline, dbOnline:
+				if stateB == acctStateExpired {
+					expectedExpiredStake.Raw += stakeB.Raw
+				}
+			case dbOnlineExpired:
+				expectedExpiredStake.Raw += stakeA.Raw
+				expectedExpiredStake.Raw += stakeB.Raw
+				if stateA == acctStateOnline || stateA == acctStateOffline {
+					expectedExpiredStake.Raw -= stakeA.Raw
+				}
+				if stateB == acctStateOnline || stateB == acctStateOffline {
+					expectedExpiredStake.Raw -= stakeB.Raw
+				}
+			default:
+				a.Fail("unknown db seed")
+			}
+			a.Equal(targetVoteRnd, rnd+basics.Round(params.MaxBalLookback))
+			_, err := oa.ExpiredOnlineCirculation(rnd, targetVoteRnd)
+			a.Error(err)
+			a.Contains(err.Error(), fmt.Sprintf("round %d too high", rnd))
+			expiredStake, err := oa.ExpiredOnlineCirculation(rnd-1, targetVoteRnd)
+			a.NoError(err)
+			a.Equal(expectedExpiredStake, expiredStake)
+
+			// restore the original state of accounts A and B
+			updates := ledgercore.AccountDeltas{}
+			base := accounts[rnd-1]
+			updates.Upsert(addrA, statesA[acctStateOnline])
+			updates.Upsert(addrB, ledgercore.AccountData{
+				AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online, MicroAlgos: stakeB}, VotingData: ledgercore.VotingData(votingDataB),
+			})
+			accounts = append(accounts, applyPartialDeltas(base, updates))
+			totals = newBlock(t, ml, proto, params, rnd, base, updates, totals)
+			rnd++
+			// add conf.MaxAcctLookback empty blocks to flush/restore the original state
+			for i := uint64(0); i < conf.MaxAcctLookback; i++ {
+				var updates ledgercore.AccountDeltas
+				base = accounts[rnd-1]
+				accounts = append(accounts, base)
+				totals = newBlock(t, ml, proto, params, rnd, base, updates, totals)
+				rnd++
+			}
+			commitSync(t, oa, ml, basics.Round(rnd-1))
+			a.Equal(int(conf.MaxAcctLookback), len(oa.deltas))
+		}
+	}
 }

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -906,20 +906,6 @@ func (aul *accountUpdatesLedgerEvaluator) GetCreatorForRound(rnd basics.Round, c
 	return aul.au.getCreatorForRound(rnd, cidx, ctype, false /* don't sync */)
 }
 
-// onlineTotals returns the online totals of all accounts at the end of round rnd.
-// used in tests only
-func (au *accountUpdates) onlineTotals(rnd basics.Round) (basics.MicroAlgos, error) {
-	au.accountsMu.RLock()
-	defer au.accountsMu.RUnlock()
-	offset, err := au.roundOffset(rnd)
-	if err != nil {
-		return basics.MicroAlgos{}, err
-	}
-
-	totals := au.roundTotals[offset]
-	return totals.Online.Money, nil
-}
-
 // latestTotalsImpl returns the totals of all accounts for the most recent round, as well as the round number
 func (au *accountUpdates) latestTotalsImpl() (basics.Round, ledgercore.AccountTotals, error) {
 	offset := len(au.deltas)

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -1756,6 +1756,7 @@ func TestCatchpointFastUpdates(t *testing.T) {
 
 		delta := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, updates.Len(), 0)
 		delta.Accts.MergeAccounts(updates)
+		delta.Totals = accumulateTotals(t, protocol.ConsensusCurrentVersion, []map[basics.Address]ledgercore.AccountData{totals}, rewardLevel)
 		ml.addBlock(blockEntry{block: blk}, delta)
 		accts = append(accts, newAccts)
 		rewardsLevels = append(rewardsLevels, rewardLevel)

--- a/ledger/double_test.go
+++ b/ledger/double_test.go
@@ -42,7 +42,7 @@ import (
 // then temporarily placed in `generate` mode so that the entire block can be
 // generated in the copy second ledger, and compared.
 type DoubleLedger struct {
-	t *testing.T
+	t testing.TB
 
 	generator *Ledger
 	validator *Ledger
@@ -56,9 +56,9 @@ func (dl DoubleLedger) Close() {
 }
 
 // NewDoubleLedger creates a new DoubleLedger with the supplied balances and consensus version.
-func NewDoubleLedger(t *testing.T, balances bookkeeping.GenesisBalances, cv protocol.ConsensusVersion, cfg config.Local) DoubleLedger {
-	g := newSimpleLedgerWithConsensusVersion(t, balances, cv, cfg)
-	v := newSimpleLedgerFull(t, balances, cv, g.GenesisHash(), cfg)
+func NewDoubleLedger(t testing.TB, balances bookkeeping.GenesisBalances, cv protocol.ConsensusVersion, cfg config.Local, opts ...simpleLedgerOption) DoubleLedger {
+	g := newSimpleLedgerWithConsensusVersion(t, balances, cv, cfg, opts...)
+	v := newSimpleLedgerFull(t, balances, cv, g.GenesisHash(), cfg, opts...)
 	return DoubleLedger{t, g, v, nil}
 }
 
@@ -165,7 +165,7 @@ func (dl *DoubleLedger) reloadLedgers() {
 	require.NoError(dl.t, dl.validator.reloadLedger())
 }
 
-func checkBlock(t *testing.T, checkLedger *Ledger, vb *ledgercore.ValidatedBlock) {
+func checkBlock(t testing.TB, checkLedger *Ledger, vb *ledgercore.ValidatedBlock) {
 	bl := vb.Block()
 	msg := bl.MarshalMsg(nil)
 	var reconstituted bookkeeping.Block

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -630,11 +630,12 @@ func (l *Ledger) LatestTotals() (basics.Round, ledgercore.AccountTotals, error) 
 	return l.accts.LatestTotals()
 }
 
-// OnlineTotals returns the online totals of all accounts at the end of round rnd.
-func (l *Ledger) OnlineTotals(rnd basics.Round) (basics.MicroAlgos, error) {
+// OnlineCirculation returns the online totals of all accounts at the end of round rnd.
+// It implements agreement's calls for Circulation(rnd)
+func (l *Ledger) OnlineCirculation(rnd basics.Round, voteRnd basics.Round) (basics.MicroAlgos, error) {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()
-	return l.acctsOnline.onlineTotals(rnd)
+	return l.acctsOnline.onlineCirculation(rnd, voteRnd)
 }
 
 // CheckDup return whether a transaction is a duplicate one.

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/algorand/go-algorand/ledger/eval"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -42,6 +41,7 @@ import (
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/data/transactions/verify"
+	"github.com/algorand/go-algorand/ledger/eval"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/ledger/store/trackerdb"
 	ledgertesting "github.com/algorand/go-algorand/ledger/testing"
@@ -2205,10 +2205,11 @@ func TestLedgerReloadShrinkDeltas(t *testing.T) {
 	l.cfg = cfg
 	l.reloadLedger()
 
-	_, err = l.OnlineTotals(basics.Round(proto.MaxBalLookback - shorterLookback))
+	rnd := basics.Round(proto.MaxBalLookback - shorterLookback)
+	_, err = l.OnlineCirculation(rnd, rnd+basics.Round(proto.MaxBalLookback))
 	require.Error(t, err)
 	for i := basics.Round(proto.MaxBalLookback - shorterLookback + 1); i <= l.Latest(); i++ {
-		online, err := l.OnlineTotals(i)
+		online, err := l.OnlineCirculation(i, i+basics.Round(proto.MaxBalLookback))
 		require.NoError(t, err)
 		require.Equal(t, onlineTotals[i], online)
 	}
@@ -2631,10 +2632,11 @@ func TestLedgerMigrateV6ShrinkDeltas(t *testing.T) {
 		l2.Close()
 	}()
 
-	_, err = l2.OnlineTotals(basics.Round(proto.MaxBalLookback - shorterLookback))
+	rnd := basics.Round(proto.MaxBalLookback - shorterLookback)
+	_, err = l2.OnlineCirculation(rnd, rnd+basics.Round(proto.MaxBalLookback))
 	require.Error(t, err)
 	for i := l2.Latest() - basics.Round(proto.MaxBalLookback-1); i <= l2.Latest(); i++ {
-		online, err := l2.OnlineTotals(i)
+		online, err := l2.OnlineCirculation(i, i+basics.Round(proto.MaxBalLookback))
 		require.NoError(t, err)
 		require.Equal(t, onlineTotals[i], online)
 	}

--- a/ledger/store/trackerdb/interface.go
+++ b/ledger/store/trackerdb/interface.go
@@ -113,6 +113,7 @@ type AccountsReaderExt interface {
 	LookupOnlineAccountDataByAddress(addr basics.Address) (ref OnlineAccountRef, data []byte, err error)
 	AccountsOnlineTop(rnd basics.Round, offset uint64, n uint64, proto config.ConsensusParams) (map[basics.Address]*ledgercore.OnlineAccount, error)
 	AccountsOnlineRoundParams() (onlineRoundParamsData []ledgercore.OnlineRoundParamsData, endRound basics.Round, err error)
+	ExpiredOnlineAccountsForRound(rnd, voteRnd basics.Round, proto config.ConsensusParams, rewardsLevel uint64) (map[basics.Address]*ledgercore.OnlineAccountData, error)
 	OnlineAccountsAll(maxAccounts uint64) ([]PersistedOnlineAccountData, error)
 	LoadTxTail(ctx context.Context, dbRound basics.Round) (roundData []*TxTailRound, roundHash []crypto.Digest, baseRound basics.Round, err error)
 	LoadAllFullAccounts(ctx context.Context, balancesTable string, resourcesTable string, acctCb func(basics.Address, basics.AccountData)) (count int, err error)

--- a/ledger/store/trackerdb/sqlitedriver/schema.go
+++ b/ledger/store/trackerdb/sqlitedriver/schema.go
@@ -154,6 +154,10 @@ const createStateProofVerificationTableQuery = `
 	lastattestedround integer primary key NOT NULL,
 	verificationcontext blob NOT NULL)`
 
+const createVoteLastValidIndex = `
+	CREATE INDEX IF NOT EXISTS onlineaccounts_votelastvalid_idx
+	ON onlineaccounts ( votelastvalid )`
+
 var accountsResetExprs = []string{
 	`DROP TABLE IF EXISTS acctrounds`,
 	`DROP TABLE IF EXISTS accounttotals`,
@@ -926,4 +930,10 @@ func reencodeAccounts(ctx context.Context, tx *sql.Tx) (modifiedAccounts uint, e
 	err = rows.Err()
 	updateStmt.Close()
 	return
+}
+
+func convertOnlineRoundParamsTail(ctx context.Context, tx *sql.Tx) error {
+	// create vote last index
+	_, err := tx.ExecContext(ctx, createVoteLastValidIndex)
+	return err
 }

--- a/ledger/store/trackerdb/sqlitedriver/trackerdbV2.go
+++ b/ledger/store/trackerdb/sqlitedriver/trackerdbV2.go
@@ -499,6 +499,11 @@ func (tu *trackerDBSchemaInitializer) upgradeDatabaseSchema9(ctx context.Context
 		return fmt.Errorf("upgradeDatabaseSchema9 unable to replace kvstore nil entries with empty byte slices : %v", err)
 	}
 
+	err = convertOnlineRoundParamsTail(ctx, tx)
+	if err != nil {
+		return fmt.Errorf("upgradeDatabaseSchema10 unable to convert onlineroundparamstail: %v", err)
+	}
+
 	// update version
 	return tu.setVersion(ctx, tx, 10)
 }

--- a/ledger/testing/testGenesis.go
+++ b/ledger/testing/testGenesis.go
@@ -25,11 +25,29 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 )
 
+// testGenesisCfg provides a configuration object for NewTestGenesis.
+type testGenesisCfg struct {
+	rewardsPoolAmount basics.MicroAlgos
+}
+
+// TestGenesisOption provides functional options for testGenesisCfg.
+type TestGenesisOption func(*testGenesisCfg)
+
+// TestGenesisRewardsPoolSize configures the rewards pool size in the genesis block.
+func TestGenesisRewardsPoolSize(amount basics.MicroAlgos) TestGenesisOption {
+	return func(cfg *testGenesisCfg) { cfg.rewardsPoolAmount = amount }
+}
+
 // NewTestGenesis creates a bunch of accounts, splits up 10B algos
 // between them and the rewardspool and feesink, and gives out the
 // addresses and secrets it creates to enable tests.  For special
 // scenarios, manipulate these return values before using newTestLedger.
-func NewTestGenesis() (bookkeeping.GenesisBalances, []basics.Address, []*crypto.SignatureSecrets) {
+func NewTestGenesis(opts ...TestGenesisOption) (bookkeeping.GenesisBalances, []basics.Address, []*crypto.SignatureSecrets) {
+	var cfg testGenesisCfg
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	// irrelevant, but deterministic
 	sink, err := basics.UnmarshalChecksumAddress("YTPRLJ2KK2JRFSZZNAF57F3K5Y2KCG36FZ5OSYLW776JJGAUW5JXJBBD7Q")
 	if err != nil {
@@ -66,8 +84,12 @@ func NewTestGenesis() (bookkeeping.GenesisBalances, []basics.Address, []*crypto.
 		Status:     basics.NotParticipating,
 	}
 
+	poolBal := basics.MicroAlgos{Raw: amount}
+	if cfg.rewardsPoolAmount.Raw > 0 {
+		poolBal = cfg.rewardsPoolAmount
+	}
 	accts[rewards] = basics.AccountData{
-		MicroAlgos: basics.MicroAlgos{Raw: amount},
+		MicroAlgos: poolBal,
 	}
 
 	genBalances := bookkeeping.MakeGenesisBalances(accts, sink, rewards)


### PR DESCRIPTION
## Summary

This adds a DB method to calculate the total expired stake registered at rnd that is expired by voteRnd.

It adds a consensus check to the ledger implementation of the Circulation(rnd) call that agreement makes, which in turn calls onlineAccounts.onlineTotals. If ExcludeExpiredCirculation is set, it subtracts expired stake at rnd+320 from the total online stake at rnd.

Details:
* when the next round is going to be round R, a proposal/vote will come in for round R (or some other trigger we could add)
* query the DB's onlineaccounts table looking for accounts online at R that are expired in any round before R+320 (this using the "updated as of rnd" and "expired by rnd" indexes)
* sum up the expired online stake for these accounts
* subtract expired stake from total online stake and put in cache to use for all votes seen for R

## Test Plan

New unit tests added