### PR TITLE
Goal: rename `--allow-extra-opcode-budget` to `--allow-more-opcode-budget`

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -69,10 +69,10 @@ var (
 	requestFilename    string
 	requestOutFilename string
 
-	simulateAllowEmptySignatures   bool
-	simulateAllowMoreLogging       bool
-	simulateAllowExtraOpcodeBudget bool
-	simulateExtraOpcodeBudget      uint64
+	simulateAllowEmptySignatures  bool
+	simulateAllowMoreLogging      bool
+	simulateAllowMoreOpcodeBudget bool
+	simulateExtraOpcodeBudget     uint64
 )
 
 func init() {
@@ -159,7 +159,7 @@ func init() {
 	simulateCmd.Flags().StringVarP(&outFilename, "result-out", "o", "", "Filename for writing simulation result")
 	simulateCmd.Flags().BoolVar(&simulateAllowEmptySignatures, "allow-empty-signatures", false, "Allow transactions without signatures to be simulated as if they had correct signatures")
 	simulateCmd.Flags().BoolVar(&simulateAllowMoreLogging, "allow-more-logging", false, "Lift the limits on log opcode during simulation")
-	simulateCmd.Flags().BoolVar(&simulateAllowExtraOpcodeBudget, "allow-extra-opcode-budget", false, "Apply max extra opcode budget for apps per transaction group (default 320000) during simulation")
+	simulateCmd.Flags().BoolVar(&simulateAllowMoreOpcodeBudget, "allow-more-opcode-budget", false, "Apply max extra opcode budget for apps per transaction group (default 320000) during simulation")
 	simulateCmd.Flags().Uint64Var(&simulateExtraOpcodeBudget, "extra-opcode-budget", 0, "Apply extra opcode budget for apps per transaction group during simulation")
 }
 
@@ -1246,12 +1246,11 @@ var simulateCmd = &cobra.Command{
 			reportErrorf("exactly one of --txfile or --request must be provided")
 		}
 
-		allowExtraBudgetProvided := cmd.Flags().Changed("allow-extra-opcode-budget")
 		extraBudgetProvided := cmd.Flags().Changed("extra-opcode-budget")
-		if allowExtraBudgetProvided && extraBudgetProvided {
+		if simulateAllowMoreOpcodeBudget && extraBudgetProvided {
 			reportErrorf("--allow-extra-opcode-budget and --extra-opcode-budget are mutually exclusive")
 		}
-		if allowExtraBudgetProvided {
+		if simulateAllowMoreOpcodeBudget {
 			simulateExtraOpcodeBudget = simulation.MaxExtraOpcodeBudget
 		}
 

--- a/test/scripts/e2e_subs/e2e-app-simulate.sh
+++ b/test/scripts/e2e_subs/e2e-app-simulate.sh
@@ -362,8 +362,8 @@ if [[ $(echo "$RES" | jq '."txn-groups"[0]."app-budget-consumed"') -ne 804 ]]; t
     false
 fi
 
-# SIMULATION! with --allow-extra-budget should pass direct call
-RES=$(${gcmd} clerk simulate --allow-extra-opcode-budget -t "${TEMPDIR}/no-extra-opcode-budget.stx")
+# SIMULATION! with --allow-more-opcode-budget should pass direct call
+RES=$(${gcmd} clerk simulate --allow-more-opcode-budget -t "${TEMPDIR}/no-extra-opcode-budget.stx")
 
 if [[ $(echo "$RES" | jq '."txn-groups" | any(has("failure-message"))') != $CONST_FALSE ]]; then
     date '+app-simulate-test FAIL the app call to generated large TEAL with extra budget should pass %Y%m%d_%H%M%S'


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

For the sake of uniformity, we rename `--allow-extra-opcode-budget` to `--allow-more-opcode-budget`, to align with `--allow-more-logging`.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
