### PR TITLE
algod: Remove cap in deltas

### DIFF
--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -1746,7 +1746,7 @@ func (v2 *Handlers) GetTransactionGroupLedgerStateDeltasForRound(ctx echo.Contex
 		return notFound(ctx, err, errFailedRetrievingStateDelta, v2.Log)
 	}
 	response := struct {
-		Deltas []eval.TxnGroupDeltaWithIds
+		Deltas []eval.TxnGroupDeltaWithIds `codec:"deltas"`
 	}{
 		Deltas: deltas,
 	}


### PR DESCRIPTION


## Summary

Non-specified encoding names produce capital letters e.g. `Deltas`, which is problematic for our code generation tool which expects all lowercase encoding names.

Changing this makes the code generation in the SDKs work properly without having to make custom alterations.
