### PR TITLE
draft: test data race and postMessagesOfInterestThread

### DIFF
--- a/network/requestTracker_test.go
+++ b/network/requestTracker_test.go
@@ -78,8 +78,8 @@ func TestRateLimiting(t *testing.T) {
 	if defaultConfig.ConnectionsRateLimitingCount == 0 || defaultConfig.ConnectionsRateLimitingWindowSeconds == 0 {
 		t.Skip()
 	}
-	log := logging.TestingLog(t)
-	log.SetLevel(logging.Level(defaultConfig.BaseLoggerDebugLevel))
+	log := logging.Base()
+	log.SetLevel(logging.Error)
 	testConfig := defaultConfig
 	// This test is conducted locally, so we want to treat all hosts the same for counting incoming requests.
 	testConfig.DisableLocalhostConnectionRateLimit = false

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -456,7 +456,7 @@ func (wp *wsPeer) reportReadErr(err error) {
 	// only report error if we haven't already closed the peer
 	if atomic.LoadInt32(&wp.didInnerClose) == 0 {
 		_, _, line, _ := runtime.Caller(1)
-		wp.net.log.Warnf("peer[%s] line=%d read err: %s", wp.conn.RemoteAddr().String(), line, err)
+		wp.net.log.Warnf("peer[%s] line=%d read err: %s", wp.conn.RemoteAddr().String(), line, err) //xx
 		networkConnectionsDroppedTotal.Inc(map[string]string{"reason": "reader err"})
 	}
 }
@@ -732,7 +732,7 @@ func (wp *wsPeer) writeLoopSendMsg(msg sendMessage) disconnectReason {
 	err := wp.conn.WriteMessage(websocket.BinaryMessage, msg.data)
 	if err != nil {
 		if atomic.LoadInt32(&wp.didInnerClose) == 0 {
-			wp.net.log.Warn("peer write error ", err)
+			wp.net.log.Warn("peer write error ", err) //xx
 			networkConnectionsDroppedTotal.Inc(map[string]string{"reason": "write err"})
 		}
 		return disconnectWriteError
@@ -883,7 +883,7 @@ func (wp *wsPeer) Close(deadline time.Time) {
 		close(wp.closing)
 		err := wp.conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), deadline)
 		if err != nil {
-			wp.net.log.Infof("failed to write CloseMessage to connection for %s", wp.conn.RemoteAddr().String())
+			wp.net.log.Infof("failed to write CloseMessage to connection for %s", wp.conn.RemoteAddr().String()) //xx
 		}
 		err = wp.conn.CloseWithoutFlush()
 		if err != nil {


### PR DESCRIPTION
This PR is to address the following race condition below.

This fix is to replace`logging.TestingLog` with `logging.Base`.
When the network stops, there will be some associated services that will shut down asynchronously. Thus, they may still log something after the test ends, and that is not allowed. It will either panic or trigger the data race detector. 

In the process of fixing this, I noticed that the   `postMessagesOfInterestThread` is not terminated after stopping the network. A draft fix for it is also here. 

https://circleci.com/api/v1.1/project/github/algorand/go-algorand/234612/output/114/17?file=true&allocation-id=646b8c40d9ef8372d2bb808f-17-build%2FEUE0509X
```
WARNING: DATA RACE
Write at 0x00c000093be3 by goroutine 53:
  testing.tRunner.func1()
      /opt/cibuild/.gimme/versions/go1.17.13.linux.amd64/src/testing/testing.go:1246 +0x584
  testing.tRunner()
      /opt/cibuild/.gimme/versions/go1.17.13.linux.amd64/src/testing/testing.go:1265 +0x268
  testing.(*T).Run·dwrap·21()
      /opt/cibuild/.gimme/versions/go1.17.13.linux.amd64/src/testing/testing.go:1306 +0x47

Previous read at 0x00c000093be3 by goroutine 1787:
  testing.(*common).logDepth()
      /opt/cibuild/.gimme/versions/go1.17.13.linux.amd64/src/testing/testing.go:768 +0xc4
  testing.(*common).log()
      /opt/cibuild/.gimme/versions/go1.17.13.linux.amd64/src/testing/testing.go:761 +0x5a
  testing.(*common).Log()
      /opt/cibuild/.gimme/versions/go1.17.13.linux.amd64/src/testing/testing.go:800 +0x14
  testing.(*T).Log()
      <autogenerated>:1 +0x55
  github.com/algorand/go-algorand/logging.TestLogWriter.Write()
      /opt/cibuild/project/logging/testingLogger.go:38 +0x107
  github.com/algorand/go-algorand/logging.(*TestLogWriter).Write()
      <autogenerated>:1 +0x7a
  github.com/sirupsen/logrus.(*Entry).write()
      /opt/cibuild/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:286 +0x258
  github.com/sirupsen/logrus.(*Entry).log()
      /opt/cibuild/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:251 +0x453
  github.com/sirupsen/logrus.(*Entry).Log()
      /opt/cibuild/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:293 +0x8b
  github.com/sirupsen/logrus.(*Entry).Logf()
      /opt/cibuild/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:338 +0xc4
  github.com/sirupsen/logrus.(*Entry).Infof()
      /opt/cibuild/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:351 +0x8d
  github.com/algorand/go-algorand/logging.logger.Infof()
      /opt/cibuild/project/logging/log.go:205 +0x2c
  github.com/algorand/go-algorand/logging.(*logger).Infof()
      <autogenerated>:1 +0x93
  github.com/algorand/go-algorand/network.(*wsPeer).Close()
      /opt/cibuild/project/network/wsPeer.go:886 +0x2f8
  github.com/algorand/go-algorand/network.(*wsPeer).internalClose()
      /opt/cibuild/project/network/wsPeer.go:876 +0xd7
  github.com/algorand/go-algorand/network.(*wsPeer).readLoopCleanup()
      /opt/cibuild/project/network/wsPeer.go:659 +0x51
  github.com/algorand/go-algorand/network.(*wsPeer).readLoop.func1()
      /opt/cibuild/project/network/wsPeer.go:473 +0x64
  github.com/algorand/go-algorand/network.(*wsPeer).readLoop()
      /opt/cibuild/project/network/wsPeer.go:488 +0x1c2d
  github.com/algorand/go-algorand/network.(*wsPeer).init·dwrap·69()
      /opt/cibuild/project/network/wsPeer.go:446 +0x39

Goroutine 53 (running) created at:
  testing.(*T).Run()
      /opt/cibuild/.gimme/versions/go1.17.13.linux.amd64/src/testing/testing.go:1306 +0x726
  testing.runTests.func1()
      /opt/cibuild/.gimme/versions/go1.17.13.linux.amd64/src/testing/testing.go:1598 +0x99
  testing.tRunner()
      /opt/cibuild/.gimme/versions/go1.17.13.linux.amd64/src/testing/testing.go:1259 +0x22f
  testing.runTests()
      /opt/cibuild/.gimme/versions/go1.17.13.linux.amd64/src/testing/testing.go:1596 +0x7ca
  testing.(*M).Run()
      /opt/cibuild/.gimme/versions/go1.17.13.linux.amd64/src/testing/testing.go:1504 +0x9d1
  github.com/algorand/go-algorand/network.TestMain()
      /opt/cibuild/project/network/wsNetwork_test.go:68 +0x56
  main.main()
      _testmain.go:405 +0x364

Goroutine 1787 (finished) created at:
  github.com/algorand/go-algorand/network.(*wsPeer).init()
      /opt/cibuild/project/network/wsPeer.go:446 +0x704
  github.com/algorand/go-algorand/network.(*WebsocketNetwork).tryConnect()
      /opt/cibuild/project/network/wsNetwork.go:2315 +0x1c64
  github.com/algorand/go-algorand/network.(*WebsocketNetwork).checkNewConnectionsNeeded·dwrap·53()
      /opt/cibuild/project/network/wsNetwork.go:1776 +0x71

```