### PR TITLE
algod: Capitalize API fields for state deltas

### DIFF
--- a/daemon/algod/api/algod.oas2.json
+++ b/daemon/algod/api/algod.oas2.json
@@ -2661,14 +2661,14 @@
       "description": "Contains a ledger delta for a single transaction group",
       "type": "object",
       "required": [
-        "delta",
-        "ids"
+        "Delta",
+        "Ids"
       ],
       "properties": {
-        "delta": {
+        "Delta": {
           "$ref": "#/definitions/LedgerStateDelta"
         },
-        "ids": {
+        "Ids": {
           "type": "array",
           "items": {
             "type": "string"
@@ -4045,10 +4045,10 @@
       "schema": {
         "type": "object",
         "required": [
-          "deltas"
+          "Deltas"
         ],
         "properties": {
-          "deltas": {
+          "Deltas": {
             "type": "array",
             "items": {
               "$ref": "#/definitions/LedgerStateDeltaForTransactionGroup"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

Replaces https://github.com/algorand/go-algorand/pull/5411. Non-specified encoding names produce capital letters e.g. Deltas, which is problematic for our code generation tool which expects all lowercase encoding names. We change the API spec to match the upper-cased fields in the handler. 

Changing this makes the code generation in the SDKs work properly without having to make custom alterations.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

Confirmed that generator generates the correctly cased fields in the go-sdk and matches expected output response in the tests: https://github.com/algorand/go-algorand-sdk/pull/538