### PR TITLE
flakiness: remove follower node TestSyncRoundWithRemake

### DIFF
--- a/node/follower_node_test.go
+++ b/node/follower_node_test.go
@@ -19,7 +19,6 @@ package node
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -150,84 +149,6 @@ func TestDevModeWarning(t *testing.T) {
 	}
 	require.NotNil(t, foundEntry)
 	require.Contains(t, foundEntry.Message, "Follower running on a devMode network. Must submit txns to a different node.")
-}
-
-// TestSyncRoundWithRemake extends TestSyncRound to simulate starting and stopping the network
-func TestSyncRoundWithRemake(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-
-	maxAcctLookback := uint64(10)
-
-	followNode, tempDir := remakeableFollowNode(t, "", maxAcctLookback)
-	addBlock := func(round basics.Round) {
-		b := bookkeeping.Block{
-			BlockHeader: bookkeeping.BlockHeader{
-				GenesisHash: followNode.ledger.GenesisHash(),
-				Round:       round,
-				RewardsState: bookkeeping.RewardsState{
-					RewardsRate: 0,
-					RewardsPool: poolAddr,
-					FeeSink:     sinkAddr,
-				},
-			},
-		}
-		b.CurrentProtocol = protocol.ConsensusCurrentVersion
-		err := followNode.Ledger().AddBlock(b, agreement.Certificate{})
-		require.NoError(t, err)
-
-		status, err := followNode.Status()
-		require.NoError(t, err)
-		require.Equal(t, round, status.LastRound)
-	}
-
-	// Part I. redo TestSyncRound
-	// main differences are:
-	// * cfg.DisableNetworking = true
-	// * cfg.MaxAcctLookback = 10 (instead of 4)
-
-	addBlock(basics.Round(1))
-
-	dbRound := uint64(followNode.Ledger().LatestTrackerCommitted())
-	// Sync Round should be initialized to the ledger's dbRound + 1
-	require.Equal(t, dbRound+1, followNode.GetSyncRound())
-	// Set a new sync round
-	require.NoError(t, followNode.SetSyncRound(dbRound+11))
-	// Ensure it is persisted
-	require.Equal(t, dbRound+11, followNode.GetSyncRound())
-	// Unset the sync round and make sure get returns 0
-	followNode.UnsetSyncRound()
-	require.Equal(t, uint64(0), followNode.GetSyncRound())
-
-	// Part II. fast forward and then remake the node
-
-	newRound := basics.Round(2 * maxAcctLookback)
-	for i := basics.Round(2); i <= newRound; i++ {
-		addBlock(i)
-	}
-
-	followNode, _ = remakeableFollowNode(t, tempDir, maxAcctLookback)
-
-	// Wait for follower to catch up. This rarely is needed, but can happen
-	// and cause flakey test failures. Timing out can still occur, but is less
-	// likely than the being caught behind a few rounds.
-	var status *StatusReport
-	require.Eventually(t, func() bool {
-		st, err := followNode.Status()
-		require.NoError(t, err)
-		if st.LastRound >= newRound {
-			status = &st
-			return true
-		}
-		return false
-	}, 20*time.Second, 500*time.Millisecond, "failed to reach newRound within the allowed time")
-
-	require.Equal(t, newRound, status.LastRound)
-
-	// syncRound should be at
-	// newRound - maxAcctLookback + 1 = maxAcctLookback + 1
-	syncRound := followNode.GetSyncRound()
-	require.Equal(t, uint64(maxAcctLookback+1), syncRound)
 }
 
 func TestFastCatchupResume(t *testing.T) {


### PR DESCRIPTION
## Summary

Remove a flaky unit test which after repeated adjustments is still failing unpredictably: https://app.circleci.com/pipelines/github/algorand/go-algorand/14526/workflows/a474572e-62d9-49a2-8f05-e012f74926dc/jobs/235063?invite=true#step-114-6862

### Related PR's
* #5251 
* #5355 
* #5367 

## Test Plan

The same feature has test coverage in a more reliable end-to-end test: https://github.com/algorand/go-algorand/blob/5f2d5ede86af95246e0cba00f8103f6fc1692bd2/test/e2e-go/features/followerNode/syncRestart_test.go#L31