### PR TITLE
lint: Fix lint errors in `config/`

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -679,7 +679,7 @@ func (cp ConsensusProtocols) Merge(configurableConsensus ConsensusProtocols) Con
 			for cVer, cParam := range staticConsensus {
 				if cVer == consensusVersion {
 					delete(staticConsensus, cVer)
-				} else if _, has := cParam.ApprovedUpgrades[consensusVersion]; has {
+				} else {
 					// delete upgrade to deleted version
 					delete(cParam.ApprovedUpgrades, consensusVersion)
 				}

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -683,7 +683,6 @@ func (cp ConsensusProtocols) Merge(configurableConsensus ConsensusProtocols) Con
 					// delete upgrade to deleted version
 					delete(cParam.ApprovedUpgrades, consensusVersion)
 				}
-
 			}
 		} else {
 			// need to add/update entry

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -679,10 +679,9 @@ func (cp ConsensusProtocols) Merge(configurableConsensus ConsensusProtocols) Con
 			for cVer, cParam := range staticConsensus {
 				if cVer == consensusVersion {
 					delete(staticConsensus, cVer)
-				} else {
-					// delete upgrade to deleted version
-					delete(cParam.ApprovedUpgrades, consensusVersion)
 				}
+				// delete upgrade to deleted version
+				delete(cParam.ApprovedUpgrades, consensusVersion)
 			}
 		} else {
 			// need to add/update entry

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -679,9 +679,11 @@ func (cp ConsensusProtocols) Merge(configurableConsensus ConsensusProtocols) Con
 			for cVer, cParam := range staticConsensus {
 				if cVer == consensusVersion {
 					delete(staticConsensus, cVer)
+				} else {
+					// delete upgrade to deleted version
+					delete(cParam.ApprovedUpgrades, consensusVersion)
 				}
-				// delete upgrade to deleted version
-				delete(cParam.ApprovedUpgrades, consensusVersion)
+
 			}
 		} else {
 			// need to add/update entry

--- a/config/migrate.go
+++ b/config/migrate.go
@@ -128,9 +128,6 @@ func getLatestConfigVersion() uint32 {
 }
 
 func getVersionedDefaultLocalConfig(version uint32) (local Local) {
-	if version < 0 {
-		return
-	}
 	if version > 0 {
 		local = getVersionedDefaultLocalConfig(version - 1)
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

Running `golangci-lint run config/` (removing the commit hash gate in golangci.yml) generates the following lint error:

```
config/consensus.go:682:12: S1033: unnecessary guard around call to delete (gosimple)
                                } else if _, has := cParam.ApprovedUpgrades[consensusVersion]; has {
config/migrate.go:131:5: SA4003: no value of type uint32 is less than 0 (staticcheck)
        if version < 0 {
```

This PR fixes this lint error by removing the guard around the delete call (the code is functionally the same, since deleting nil map key/value is a no op) and removing the negative check for `uint` values. 

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
