### PR TITLE
go-algorand 3.16.0-beta Release PR

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -69,10 +69,10 @@ var (
 	requestFilename    string
 	requestOutFilename string
 
-	simulateAllowEmptySignatures   bool
-	simulateAllowMoreLogging       bool
-	simulateAllowExtraOpcodeBudget bool
-	simulateExtraOpcodeBudget      uint64
+	simulateAllowEmptySignatures  bool
+	simulateAllowMoreLogging      bool
+	simulateAllowMoreOpcodeBudget bool
+	simulateExtraOpcodeBudget     uint64
 )
 
 func init() {
@@ -159,7 +159,7 @@ func init() {
 	simulateCmd.Flags().StringVarP(&outFilename, "result-out", "o", "", "Filename for writing simulation result")
 	simulateCmd.Flags().BoolVar(&simulateAllowEmptySignatures, "allow-empty-signatures", false, "Allow transactions without signatures to be simulated as if they had correct signatures")
 	simulateCmd.Flags().BoolVar(&simulateAllowMoreLogging, "allow-more-logging", false, "Lift the limits on log opcode during simulation")
-	simulateCmd.Flags().BoolVar(&simulateAllowExtraOpcodeBudget, "allow-extra-opcode-budget", false, "Apply max extra opcode budget for apps per transaction group (default 320000) during simulation")
+	simulateCmd.Flags().BoolVar(&simulateAllowMoreOpcodeBudget, "allow-more-opcode-budget", false, "Apply max extra opcode budget for apps per transaction group (default 320000) during simulation")
 	simulateCmd.Flags().Uint64Var(&simulateExtraOpcodeBudget, "extra-opcode-budget", 0, "Apply extra opcode budget for apps per transaction group during simulation")
 }
 
@@ -1246,12 +1246,11 @@ var simulateCmd = &cobra.Command{
 			reportErrorf("exactly one of --txfile or --request must be provided")
 		}
 
-		allowExtraBudgetProvided := cmd.Flags().Changed("allow-extra-opcode-budget")
 		extraBudgetProvided := cmd.Flags().Changed("extra-opcode-budget")
-		if allowExtraBudgetProvided && extraBudgetProvided {
+		if simulateAllowMoreOpcodeBudget && extraBudgetProvided {
 			reportErrorf("--allow-extra-opcode-budget and --extra-opcode-budget are mutually exclusive")
 		}
-		if allowExtraBudgetProvided {
+		if simulateAllowMoreOpcodeBudget {
 			simulateExtraOpcodeBudget = simulation.MaxExtraOpcodeBudget
 		}
 

--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -78,14 +78,14 @@ function configure_data_dir() {
   algocfg -d . set -p EndpointAddress -v "0.0.0.0:${ALGOD_PORT}"
 
   # check for token overrides
-  if [ "$TOKEN" != "" ]; then
-    for dir in ${ALGORAND_DATA}/../*/; do
-      echo "$TOKEN" > "$dir/algod.token"
-    done
-  fi
-  if [ "$ADMIN_TOKEN" != "" ]; then
-    echo "$ADMIN_TOKEN" >algod.admin.token
-  fi
+  for dir in ${ALGORAND_DATA}/../*/; do
+    if [ "$TOKEN" != "" ]; then
+        echo "$TOKEN" > "$dir/algod.token"
+    fi
+    if [ "$ADMIN_TOKEN" != "" ]; then
+      echo "$ADMIN_TOKEN" > "$dir/algod.admin.token"
+    fi
+  done
 
   # configure telemetry
   if [ "$TELEMETRY_NAME" != "" ]; then
@@ -184,13 +184,17 @@ function start_new_private_network() {
 echo "Starting Algod Docker Container"
 echo "   ALGORAND_DATA:  $ALGORAND_DATA"
 echo "   NETWORK:        $NETWORK"
-echo "   ALGOD_PORT:     $ALGOD_PORT"
-echo "   FAST_CATCHUP:   $FAST_CATCHUP"
+echo "   PROFILE:        $PROFILE"
 echo "   DEV_MODE:       $DEV_MODE"
+echo "   START_KMD:      ${START_KMD:-"Not Set"}"
+echo "   FAST_CATCHUP:   $FAST_CATCHUP"
 echo "   TOKEN:          ${TOKEN:-"Not Set"}"
+echo "   ADMIN_TOKEN:    ${ADMIN_TOKEN:-"Not Set"}"
 echo "   KMD_TOKEN:      ${KMD_TOKEN:-"Not Set"}"
 echo "   TELEMETRY_NAME: $TELEMETRY_NAME"
-echo "   START_KMD:      ${START_KMD:-"Not Set"}"
+echo "   NUM_ROUNDS:     $NUM_ROUNDS"
+echo "   PEER_ADDRESS:   $PEER_ADDRESS"
+echo "   ALGOD_PORT:     $ALGOD_PORT"
 
 # If data directory is initialized, start existing environment.
 if [ -f "$ALGORAND_DATA/../network.json" ]; then

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/algorand/go-deadlock"
@@ -1602,7 +1601,7 @@ func (au *accountUpdates) roundOffset(rnd basics.Round) (offset uint64, err erro
 	return off, nil
 }
 
-func (au *accountUpdates) handleUnorderedCommit(dcc *deferredCommitContext) {
+func (au *accountUpdates) handleUnorderedCommitOrError(dcc *deferredCommitContext) {
 }
 
 // prepareCommit prepares data to write to the database a "chunk" of rounds, and update the cached dbRound accordingly.
@@ -1625,14 +1624,6 @@ func (au *accountUpdates) prepareCommit(dcc *deferredCommitContext) error {
 	// verify version correctness : all the entries in the au.versions[1:offset+1] should have the *same* version, and the committedUpTo should be enforcing that.
 	if au.versions[1] != au.versions[offset] {
 		au.accountsMu.RUnlock()
-
-		// in scheduleCommit, we expect that this function to update the catchpointWriting when
-		// it's on a catchpoint round and the node is configured to generate catchpoints. Doing this in a deferred function
-		// here would prevent us from "forgetting" to update this variable later on.
-		// The same is repeated in commitRound on errors.
-		if dcc.catchpointFirstStage && dcc.enableGeneratingCatchpointFiles {
-			atomic.StoreInt32(dcc.catchpointDataWriting, 0)
-		}
 		return fmt.Errorf("attempted to commit series of rounds with non-uniform consensus versions")
 	}
 
@@ -1663,14 +1654,6 @@ func (au *accountUpdates) prepareCommit(dcc *deferredCommitContext) error {
 func (au *accountUpdates) commitRound(ctx context.Context, tx trackerdb.TransactionScope, dcc *deferredCommitContext) (err error) {
 	offset := dcc.offset
 	dbRound := dcc.oldBase
-
-	defer func() {
-		if err != nil {
-			if dcc.catchpointFirstStage && dcc.enableGeneratingCatchpointFiles {
-				atomic.StoreInt32(dcc.catchpointDataWriting, 0)
-			}
-		}
-	}()
 
 	_, err = tx.ResetTransactionWarnDeadline(ctx, time.Now().Add(accountsUpdatePerRoundHighWatermark*time.Duration(offset)))
 	if err != nil {

--- a/ledger/bulletin.go
+++ b/ledger/bulletin.go
@@ -123,7 +123,7 @@ func (b *bulletin) postCommit(ctx context.Context, dcc *deferredCommitContext) {
 func (b *bulletin) postCommitUnlocked(ctx context.Context, dcc *deferredCommitContext) {
 }
 
-func (b *bulletin) handleUnorderedCommit(*deferredCommitContext) {
+func (b *bulletin) handleUnorderedCommitOrError(*deferredCommitContext) {
 }
 
 func (b *bulletin) produceCommittingTask(committedRound basics.Round, dbRound basics.Round, dcr *deferredCommitRange) *deferredCommitRange {

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -449,7 +449,7 @@ func (ct *catchpointTracker) produceCommittingTask(committedRound basics.Round, 
 			ct.catchpointInterval, dcr.catchpointLookback)
 
 	// if we're still writing the previous balances, we can't move forward yet.
-	if ct.IsWritingCatchpointDataFile() {
+	if ct.isWritingCatchpointDataFile() {
 		// if we hit this path, it means that we're still writing a catchpoint.
 		// see if the new delta range contains another catchpoint.
 		if hasIntermediateFirstStageRound {
@@ -469,8 +469,6 @@ func (ct *catchpointTracker) produceCommittingTask(committedRound basics.Round, 
 		dcr.catchpointFirstStage = true
 
 		if ct.enableGeneratingCatchpointFiles {
-			// store non-zero ( all ones ) into the catchpointWriting atomic variable to indicate that a catchpoint is being written ( or, queued to be written )
-			atomic.StoreInt32(&ct.catchpointDataWriting, int32(-1))
 			ct.catchpointDataSlowWriting = make(chan struct{}, 1)
 			if hasMultipleIntermediateFirstStageRounds {
 				close(ct.catchpointDataSlowWriting)
@@ -478,7 +476,6 @@ func (ct *catchpointTracker) produceCommittingTask(committedRound basics.Round, 
 		}
 	}
 
-	dcr.catchpointDataWriting = &ct.catchpointDataWriting
 	dcr.enableGeneratingCatchpointFiles = ct.enableGeneratingCatchpointFiles
 
 	rounds := ct.calculateCatchpointRounds(dcr)
@@ -492,6 +489,11 @@ func (ct *catchpointTracker) produceCommittingTask(committedRound basics.Round, 
 func (ct *catchpointTracker) prepareCommit(dcc *deferredCommitContext) error {
 	ct.catchpointsMu.RLock()
 	defer ct.catchpointsMu.RUnlock()
+
+	if ct.enableGeneratingCatchpointFiles && dcc.catchpointFirstStage {
+		// store non-zero ( all ones ) into the catchpointWriting atomic variable to indicate that a catchpoint is being written
+		atomic.StoreInt32(&ct.catchpointDataWriting, int32(-1))
+	}
 
 	dcc.committedRoundDigests = make([]crypto.Digest, dcc.offset)
 	copy(dcc.committedRoundDigests, ct.roundDigest[:dcc.offset])
@@ -926,10 +928,10 @@ func (ct *catchpointTracker) postCommitUnlocked(ctx context.Context, dcc *deferr
 	}
 }
 
-// handleUnorderedCommit is a special method for handling deferred commits that are out of order.
+// handleUnorderedCommitOrError is a special method for handling deferred commits that are out of order.
 // Tracker might update own state in this case. For example, account catchpoint tracker cancels
 // scheduled catchpoint writing that deferred commit.
-func (ct *catchpointTracker) handleUnorderedCommit(dcc *deferredCommitContext) {
+func (ct *catchpointTracker) handleUnorderedCommitOrError(dcc *deferredCommitContext) {
 	// if the node is configured to generate catchpoint files, we might need to update the catchpointWriting variable.
 	if ct.enableGeneratingCatchpointFiles {
 		// determine if this was a catchpoint round
@@ -1085,9 +1087,9 @@ func (ct *catchpointTracker) accountsUpdateBalances(accountsDeltas compactAccoun
 	return
 }
 
-// IsWritingCatchpointDataFile returns true iff a (first stage) catchpoint data file
+// isWritingCatchpointDataFile returns true iff a (first stage) catchpoint data file
 // is being generated.
-func (ct *catchpointTracker) IsWritingCatchpointDataFile() bool {
+func (ct *catchpointTracker) isWritingCatchpointDataFile() bool {
 	return atomic.LoadInt32(&ct.catchpointDataWriting) != 0
 }
 

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -54,11 +54,11 @@ func TestCatchpointIsWritingCatchpointFile(t *testing.T) {
 	ct := &catchpointTracker{}
 
 	ct.catchpointDataWriting = -1
-	ans := ct.IsWritingCatchpointDataFile()
+	ans := ct.isWritingCatchpointDataFile()
 	require.True(t, ans)
 
 	ct.catchpointDataWriting = 0
-	ans = ct.IsWritingCatchpointDataFile()
+	ans = ct.isWritingCatchpointDataFile()
 	require.False(t, ans)
 }
 
@@ -569,7 +569,7 @@ func TestCatchpointReproducibleLabels(t *testing.T) {
 			ml.trackers.waitAccountsWriting()
 
 			// Let catchpoint data generation finish so that nothing gets skipped.
-			for ct.IsWritingCatchpointDataFile() {
+			for ct.isWritingCatchpointDataFile() {
 				time.Sleep(time.Millisecond)
 			}
 		}
@@ -612,7 +612,7 @@ func TestCatchpointReproducibleLabels(t *testing.T) {
 				ml2.trackers.committedUpTo(i)
 				ml2.trackers.waitAccountsWriting()
 				// Let catchpoint data generation finish so that nothing gets skipped.
-				for ct.IsWritingCatchpointDataFile() {
+				for ct.isWritingCatchpointDataFile() {
 					time.Sleep(time.Millisecond)
 				}
 			}
@@ -694,8 +694,8 @@ func (bt *blockingTracker) postCommitUnlocked(ctx context.Context, dcc *deferred
 	}
 }
 
-// handleUnorderedCommit is not used by the blockingTracker
-func (bt *blockingTracker) handleUnorderedCommit(*deferredCommitContext) {
+// handleUnorderedCommitOrError is not used by the blockingTracker
+func (bt *blockingTracker) handleUnorderedCommitOrError(*deferredCommitContext) {
 }
 
 // close is not used by the blockingTracker
@@ -1089,7 +1089,7 @@ func TestCatchpointFirstStageInfoPruning(t *testing.T) {
 			ml.trackers.committedUpTo(i)
 			ml.trackers.waitAccountsWriting()
 			// Let catchpoint data generation finish so that nothing gets skipped.
-			for ct.IsWritingCatchpointDataFile() {
+			for ct.isWritingCatchpointDataFile() {
 				time.Sleep(time.Millisecond)
 			}
 		}
@@ -1304,7 +1304,7 @@ func TestCatchpointSecondStagePersistence(t *testing.T) {
 			ml.trackers.committedUpTo(i)
 			ml.trackers.waitAccountsWriting()
 			// Let catchpoint data generation finish so that nothing gets skipped.
-			for ct.IsWritingCatchpointDataFile() {
+			for ct.isWritingCatchpointDataFile() {
 				time.Sleep(time.Millisecond)
 			}
 		}
@@ -1509,7 +1509,7 @@ func TestCatchpointSecondStageDeletesUnfinishedCatchpointRecordAfterRestart(t *t
 		ml.addToBlockQueue(blockEntry{block: blk}, delta)
 
 		// Let catchpoint data generation finish so that nothing gets skipped.
-		for ct.IsWritingCatchpointDataFile() {
+		for ct.isWritingCatchpointDataFile() {
 			time.Sleep(time.Millisecond)
 		}
 	}

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -832,7 +832,7 @@ func (l *Ledger) trackerEvalVerified(blk bookkeeping.Block, accUpdatesLedger eva
 func (l *Ledger) IsWritingCatchpointDataFile() bool {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()
-	return l.catchpoint.IsWritingCatchpointDataFile()
+	return l.catchpoint.isWritingCatchpointDataFile()
 }
 
 // VerifiedTransactionCache returns the verify.VerifiedTransactionCache

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -80,7 +80,7 @@ func (mt *metricsTracker) postCommit(ctx context.Context, dcc *deferredCommitCon
 func (mt *metricsTracker) postCommitUnlocked(ctx context.Context, dcc *deferredCommitContext) {
 }
 
-func (mt *metricsTracker) handleUnorderedCommit(*deferredCommitContext) {
+func (mt *metricsTracker) handleUnorderedCommitOrError(*deferredCommitContext) {
 }
 
 func (mt *metricsTracker) produceCommittingTask(committedRound basics.Round, dbRound basics.Round, dcr *deferredCommitRange) *deferredCommitRange {

--- a/ledger/notifier.go
+++ b/ledger/notifier.go
@@ -123,7 +123,7 @@ func (bn *blockNotifier) postCommit(ctx context.Context, dcc *deferredCommitCont
 func (bn *blockNotifier) postCommitUnlocked(ctx context.Context, dcc *deferredCommitContext) {
 }
 
-func (bn *blockNotifier) handleUnorderedCommit(*deferredCommitContext) {
+func (bn *blockNotifier) handleUnorderedCommitOrError(*deferredCommitContext) {
 }
 
 func (bn *blockNotifier) produceCommittingTask(committedRound basics.Round, dbRound basics.Round, dcr *deferredCommitRange) *deferredCommitRange {

--- a/ledger/spverificationtracker.go
+++ b/ledger/spverificationtracker.go
@@ -160,7 +160,7 @@ func (spt *spVerificationTracker) postCommit(_ context.Context, dcc *deferredCom
 func (spt *spVerificationTracker) postCommitUnlocked(context.Context, *deferredCommitContext) {
 }
 
-func (spt *spVerificationTracker) handleUnorderedCommit(*deferredCommitContext) {
+func (spt *spVerificationTracker) handleUnorderedCommitOrError(*deferredCommitContext) {
 }
 
 func (spt *spVerificationTracker) close() {

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -118,10 +118,11 @@ type ledgerTracker interface {
 	// An optional context is provided for long-running operations.
 	postCommitUnlocked(context.Context, *deferredCommitContext)
 
-	// handleUnorderedCommit is a special method for handling deferred commits that are out of order.
+	// handleUnorderedCommitOrError is a special method for handling deferred commits that are out of order
+	// or to handle errors reported by other trackers while committing a batch.
 	// Tracker might update own state in this case. For example, account updates tracker cancels
-	// scheduled catchpoint writing that deferred commit.
-	handleUnorderedCommit(*deferredCommitContext)
+	// scheduled catchpoint writing flag for this batch.
+	handleUnorderedCommitOrError(*deferredCommitContext)
 
 	// close terminates the tracker, reclaiming any resources
 	// like open database connections or goroutines.  close may
@@ -213,12 +214,6 @@ type deferredCommitRange struct {
 	// True iff we are doing the first stage of catchpoint generation, possibly creating
 	// a catchpoint data file, in this commit cycle iteration.
 	catchpointFirstStage bool
-
-	// catchpointDataWriting is a pointer to a variable with the same name in the
-	// catchpointTracker. It's used in order to reset the catchpointDataWriting flag from
-	// the acctupdates's prepareCommit/commitRound (which is called before the
-	// corresponding catchpoint tracker method.
-	catchpointDataWriting *int32
 
 	// enableGeneratingCatchpointFiles controls whether the node produces catchpoint files or not.
 	enableGeneratingCatchpointFiles bool
@@ -514,7 +509,7 @@ func (tr *trackerRegistry) commitRound(dcc *deferredCommitContext) error {
 	if tr.dbRound < dbRound || offset < uint64(tr.dbRound-dbRound) {
 		tr.log.Warnf("out of order deferred commit: offset %d, dbRound %d but current tracker DB round is %d", offset, dbRound, tr.dbRound)
 		for _, lt := range tr.trackers {
-			lt.handleUnorderedCommit(dcc)
+			lt.handleUnorderedCommitOrError(dcc)
 		}
 		tr.mu.RUnlock()
 		return nil
@@ -538,19 +533,27 @@ func (tr *trackerRegistry) commitRound(dcc *deferredCommitContext) error {
 	dcc.oldBase = dbRound
 	dcc.flushTime = time.Now()
 
+	var err error
 	for _, lt := range tr.trackers {
-		err := lt.prepareCommit(dcc)
+		err = lt.prepareCommit(dcc)
 		if err != nil {
 			tr.log.Errorf(err.Error())
-			tr.mu.RUnlock()
-			return err
+			break
 		}
 	}
+	if err != nil {
+		for _, lt := range tr.trackers {
+			lt.handleUnorderedCommitOrError(dcc)
+		}
+		tr.mu.RUnlock()
+		return err
+	}
+
 	tr.mu.RUnlock()
 
 	start := time.Now()
 	ledgerCommitroundCount.Inc(nil)
-	err := tr.dbs.Transaction(func(ctx context.Context, tx trackerdb.TransactionScope) (err error) {
+	err = tr.dbs.Transaction(func(ctx context.Context, tx trackerdb.TransactionScope) (err error) {
 		arw, err := tx.MakeAccountsReaderWriter()
 		if err != nil {
 			return err
@@ -568,6 +571,9 @@ func (tr *trackerRegistry) commitRound(dcc *deferredCommitContext) error {
 	ledgerCommitroundMicros.AddMicrosecondsSince(start, nil)
 
 	if err != nil {
+		for _, lt := range tr.trackers {
+			lt.handleUnorderedCommitOrError(dcc)
+		}
 		tr.log.Warnf("unable to advance tracker db snapshot (%d-%d): %v", dbRound, dbRound+basics.Round(offset), err)
 		return err
 	}

--- a/ledger/tracker_test.go
+++ b/ledger/tracker_test.go
@@ -191,8 +191,8 @@ func (bt *producePrepareBlockingTracker) postCommit(ctx context.Context, dcc *de
 func (bt *producePrepareBlockingTracker) postCommitUnlocked(ctx context.Context, dcc *deferredCommitContext) {
 }
 
-// handleUnorderedCommit is not used by the blockingTracker
-func (bt *producePrepareBlockingTracker) handleUnorderedCommit(*deferredCommitContext) {
+// handleUnorderedCommitOrError is not used by the blockingTracker
+func (bt *producePrepareBlockingTracker) handleUnorderedCommitOrError(*deferredCommitContext) {
 }
 
 // close is not used by the blockingTracker

--- a/ledger/txtail.go
+++ b/ledger/txtail.go
@@ -313,7 +313,7 @@ func (t *txTail) postCommit(ctx context.Context, dcc *deferredCommitContext) {
 func (t *txTail) postCommitUnlocked(ctx context.Context, dcc *deferredCommitContext) {
 }
 
-func (t *txTail) handleUnorderedCommit(*deferredCommitContext) {
+func (t *txTail) handleUnorderedCommitOrError(*deferredCommitContext) {
 }
 
 func (t *txTail) produceCommittingTask(committedRound basics.Round, dbRound basics.Round, dcr *deferredCommitRange) *deferredCommitRange {

--- a/node/follower_node_test.go
+++ b/node/follower_node_test.go
@@ -19,7 +19,6 @@ package node
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -150,84 +149,6 @@ func TestDevModeWarning(t *testing.T) {
 	}
 	require.NotNil(t, foundEntry)
 	require.Contains(t, foundEntry.Message, "Follower running on a devMode network. Must submit txns to a different node.")
-}
-
-// TestSyncRoundWithRemake extends TestSyncRound to simulate starting and stopping the network
-func TestSyncRoundWithRemake(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-
-	maxAcctLookback := uint64(10)
-
-	followNode, tempDir := remakeableFollowNode(t, "", maxAcctLookback)
-	addBlock := func(round basics.Round) {
-		b := bookkeeping.Block{
-			BlockHeader: bookkeeping.BlockHeader{
-				GenesisHash: followNode.ledger.GenesisHash(),
-				Round:       round,
-				RewardsState: bookkeeping.RewardsState{
-					RewardsRate: 0,
-					RewardsPool: poolAddr,
-					FeeSink:     sinkAddr,
-				},
-			},
-		}
-		b.CurrentProtocol = protocol.ConsensusCurrentVersion
-		err := followNode.Ledger().AddBlock(b, agreement.Certificate{})
-		require.NoError(t, err)
-
-		status, err := followNode.Status()
-		require.NoError(t, err)
-		require.Equal(t, round, status.LastRound)
-	}
-
-	// Part I. redo TestSyncRound
-	// main differences are:
-	// * cfg.DisableNetworking = true
-	// * cfg.MaxAcctLookback = 10 (instead of 4)
-
-	addBlock(basics.Round(1))
-
-	dbRound := uint64(followNode.Ledger().LatestTrackerCommitted())
-	// Sync Round should be initialized to the ledger's dbRound + 1
-	require.Equal(t, dbRound+1, followNode.GetSyncRound())
-	// Set a new sync round
-	require.NoError(t, followNode.SetSyncRound(dbRound+11))
-	// Ensure it is persisted
-	require.Equal(t, dbRound+11, followNode.GetSyncRound())
-	// Unset the sync round and make sure get returns 0
-	followNode.UnsetSyncRound()
-	require.Equal(t, uint64(0), followNode.GetSyncRound())
-
-	// Part II. fast forward and then remake the node
-
-	newRound := basics.Round(2 * maxAcctLookback)
-	for i := basics.Round(2); i <= newRound; i++ {
-		addBlock(i)
-	}
-
-	followNode, _ = remakeableFollowNode(t, tempDir, maxAcctLookback)
-
-	// Wait for follower to catch up. This rarely is needed, but can happen
-	// and cause flakey test failures. Timing out can still occur, but is less
-	// likely than the being caught behind a few rounds.
-	var status *StatusReport
-	require.Eventually(t, func() bool {
-		st, err := followNode.Status()
-		require.NoError(t, err)
-		if st.LastRound >= newRound {
-			status = &st
-			return true
-		}
-		return false
-	}, 20*time.Second, 500*time.Millisecond, "failed to reach newRound within the allowed time")
-
-	require.Equal(t, newRound, status.LastRound)
-
-	// syncRound should be at
-	// newRound - maxAcctLookback + 1 = maxAcctLookback + 1
-	syncRound := followNode.GetSyncRound()
-	require.Equal(t, uint64(maxAcctLookback+1), syncRound)
 }
 
 func TestFastCatchupResume(t *testing.T) {

--- a/test/scripts/e2e_subs/e2e-app-simulate.sh
+++ b/test/scripts/e2e_subs/e2e-app-simulate.sh
@@ -362,8 +362,8 @@ if [[ $(echo "$RES" | jq '."txn-groups"[0]."app-budget-consumed"') -ne 804 ]]; t
     false
 fi
 
-# SIMULATION! with --allow-extra-budget should pass direct call
-RES=$(${gcmd} clerk simulate --allow-extra-opcode-budget -t "${TEMPDIR}/no-extra-opcode-budget.stx")
+# SIMULATION! with --allow-more-opcode-budget should pass direct call
+RES=$(${gcmd} clerk simulate --allow-more-opcode-budget -t "${TEMPDIR}/no-extra-opcode-budget.stx")
 
 if [[ $(echo "$RES" | jq '."txn-groups" | any(has("failure-message"))') != $CONST_FALSE ]]; then
     date '+app-simulate-test FAIL the app call to generated large TEAL with extra budget should pass %Y%m%d_%H%M%S'

--- a/tools/block-generator/generator/generate_test.go
+++ b/tools/block-generator/generator/generate_test.go
@@ -18,11 +18,13 @@ package generator
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/rpcs"
@@ -30,9 +32,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makePrivateGenerator(t *testing.T) *generator {
-	partitiontest.PartitionTest(t)
-	publicGenerator, err := MakeGenerator(GenerationConfig{
+func makePrivateGenerator(t *testing.T, round uint64, genesis bookkeeping.Genesis) *generator {
+	publicGenerator, err := MakeGenerator(round, genesis, GenerationConfig{
 		NumGenesisAccounts:           10,
 		GenesisAccountInitialBalance: 1000000000000,
 		PaymentTransactionFraction:   1.0,
@@ -45,21 +46,21 @@ func makePrivateGenerator(t *testing.T) *generator {
 
 func TestPaymentAcctCreate(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	g := makePrivateGenerator(t)
+	g := makePrivateGenerator(t, 0, bookkeeping.Genesis{})
 	g.generatePaymentTxnInternal(paymentAcctCreateTx, 0, 0)
 	require.Len(t, g.balances, int(g.config.NumGenesisAccounts+1))
 }
 
 func TestPaymentTransfer(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	g := makePrivateGenerator(t)
+	g := makePrivateGenerator(t, 0, bookkeeping.Genesis{})
 	g.generatePaymentTxnInternal(paymentTx, 0, 0)
 	require.Len(t, g.balances, int(g.config.NumGenesisAccounts))
 }
 
 func TestAssetXferNoAssetsOverride(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	g := makePrivateGenerator(t)
+	g := makePrivateGenerator(t, 0, bookkeeping.Genesis{})
 
 	// First asset transaction must create.
 	actual, txn := g.generateAssetTxnInternal(assetXfer, 1, 0)
@@ -73,7 +74,7 @@ func TestAssetXferNoAssetsOverride(t *testing.T) {
 
 func TestAssetXferOneHolderOverride(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	g := makePrivateGenerator(t)
+	g := makePrivateGenerator(t, 0, bookkeeping.Genesis{})
 	g.finishRound(0)
 	g.generateAssetTxnInternal(assetCreate, 1, 0)
 	g.finishRound(1)
@@ -90,7 +91,7 @@ func TestAssetXferOneHolderOverride(t *testing.T) {
 
 func TestAssetCloseCreatorOverride(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	g := makePrivateGenerator(t)
+	g := makePrivateGenerator(t, 0, bookkeeping.Genesis{})
 	g.finishRound(0)
 	g.generateAssetTxnInternal(assetCreate, 1, 0)
 	g.finishRound(1)
@@ -107,7 +108,7 @@ func TestAssetCloseCreatorOverride(t *testing.T) {
 
 func TestAssetOptinEveryAccountOverride(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	g := makePrivateGenerator(t)
+	g := makePrivateGenerator(t, 0, bookkeeping.Genesis{})
 	g.finishRound(0)
 	g.generateAssetTxnInternal(assetCreate, 1, 0)
 	g.finishRound(1)
@@ -140,7 +141,7 @@ func TestAssetOptinEveryAccountOverride(t *testing.T) {
 
 func TestAssetDestroyWithHoldingsOverride(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	g := makePrivateGenerator(t)
+	g := makePrivateGenerator(t, 0, bookkeeping.Genesis{})
 	g.finishRound(0)
 	g.generateAssetTxnInternal(assetCreate, 1, 0)
 	g.finishRound(1)
@@ -161,7 +162,7 @@ func TestAssetDestroyWithHoldingsOverride(t *testing.T) {
 
 func TestAssetTransfer(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	g := makePrivateGenerator(t)
+	g := makePrivateGenerator(t, 0, bookkeeping.Genesis{})
 	g.finishRound(0)
 
 	g.generateAssetTxnInternal(assetCreate, 1, 0)
@@ -175,7 +176,7 @@ func TestAssetTransfer(t *testing.T) {
 
 func TestAssetDestroy(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	g := makePrivateGenerator(t)
+	g := makePrivateGenerator(t, 0, bookkeeping.Genesis{})
 	g.finishRound(0)
 	g.generateAssetTxnInternal(assetCreate, 1, 0)
 	g.finishRound(1)
@@ -189,18 +190,45 @@ func TestAssetDestroy(t *testing.T) {
 
 func TestWriteRoundZero(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	g := makePrivateGenerator(t)
-	var data []byte
-	writer := bytes.NewBuffer(data)
-	g.WriteBlock(writer, 0)
-	var block rpcs.EncodedBlockCert
-	protocol.Decode(data, &block)
-	require.Len(t, block.Block.Payset, 0)
+	var testcases = []struct {
+		name    string
+		dbround uint64
+		round   uint64
+		genesis bookkeeping.Genesis
+	}{
+		{
+			name:    "empty database",
+			dbround: 0,
+			round:   0,
+			genesis: bookkeeping.Genesis{},
+		},
+		{
+			name:    "preloaded database",
+			dbround: 1,
+			round:   1,
+			genesis: bookkeeping.Genesis{Network: "TestWriteRoundZero"},
+		},
+	}
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(fmt.Sprintf("%s", tc.name), func(t *testing.T) {
+			t.Parallel()
+			g := makePrivateGenerator(t, tc.dbround, tc.genesis)
+			var data []byte
+			writer := bytes.NewBuffer(data)
+			g.WriteBlock(writer, tc.round)
+			var block rpcs.EncodedBlockCert
+			protocol.Decode(data, &block)
+			require.Len(t, block.Block.Payset, 0)
+			g.ledger.Close()
+		})
+	}
+
 }
 
 func TestWriteRound(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	g := makePrivateGenerator(t)
+	g := makePrivateGenerator(t, 0, bookkeeping.Genesis{})
 	var data []byte
 	writer := bytes.NewBuffer(data)
 	g.WriteBlock(writer, 0)
@@ -212,11 +240,95 @@ func TestWriteRound(t *testing.T) {
 	require.Equal(t, basics.Round(1), g.ledger.Latest())
 	_, err := g.ledger.GetStateDeltaForRound(1)
 	require.NoError(t, err)
+	// request a block that is several rounds ahead of the current round
+	err = g.WriteBlock(writer, 10)
+	require.NotNil(t, err)
+	require.Equal(t, err.Error(), "generator only supports sequential block access. Expected 2 but received request for 10")
+}
+
+func TestWriteRoundWithPreloadedDB(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	var testcases = []struct {
+		name    string
+		dbround uint64
+		round   uint64
+		genesis bookkeeping.Genesis
+		err     error
+	}{
+		{
+			name:    "preloaded database starting at round 1",
+			dbround: 1,
+			round:   1,
+			genesis: bookkeeping.Genesis{Network: "generator-test1"},
+			err:     nil,
+		},
+		{
+			name:    "invalid request",
+			dbround: 10,
+			round:   1,
+			genesis: bookkeeping.Genesis{Network: "generator-test2"},
+			err:     fmt.Errorf("cannot generate block for round 1, already in database"),
+		},
+		{
+			name:    "invalid request 2",
+			dbround: 1,
+			round:   10,
+			genesis: bookkeeping.Genesis{Network: "generator-test3"},
+			err:     fmt.Errorf("generator only supports sequential block access. Expected 2 but received request for 10"),
+		},
+		{
+			name:    "preloaded database starting at 10",
+			dbround: 10,
+			round:   11,
+			genesis: bookkeeping.Genesis{Network: "generator-test4"},
+			err:     nil,
+		},
+		{
+			name:    "preloaded database request round 20",
+			dbround: 10,
+			round:   20,
+			genesis: bookkeeping.Genesis{Network: "generator-test5"},
+			err:     nil,
+		},
+	}
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(fmt.Sprintf("%s", tc.name), func(t *testing.T) {
+			t.Parallel()
+			g := makePrivateGenerator(t, tc.dbround, tc.genesis)
+			defer g.ledger.Close()
+			var data []byte
+			writer := bytes.NewBuffer(data)
+			err := g.WriteBlock(writer, tc.dbround)
+			require.Nil(t, err)
+			// invalid block request
+			if tc.round != tc.dbround && tc.err != nil {
+				err = g.WriteBlock(writer, tc.round)
+				require.NotNil(t, err)
+				require.Equal(t, err.Error(), tc.err.Error())
+				return
+			}
+			// write the rest of the blocks
+			for i := tc.dbround + 1; i <= tc.round; i++ {
+				err = g.WriteBlock(writer, i)
+				require.Nil(t, err)
+			}
+			var block rpcs.EncodedBlockCert
+			protocol.Decode(data, &block)
+			require.Len(t, block.Block.Payset, int(g.config.TxnPerBlock))
+			require.NotNil(t, g.ledger)
+			require.Equal(t, basics.Round(tc.round-tc.dbround), g.ledger.Latest())
+			if tc.round > tc.dbround {
+				_, err = g.ledger.GetStateDeltaForRound(basics.Round(tc.round - tc.dbround))
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestHandlers(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	g := makePrivateGenerator(t)
+	g := makePrivateGenerator(t, 0, bookkeeping.Genesis{})
 	handler := getBlockHandler(g)
 	var testcases = []struct {
 		name string

--- a/tools/block-generator/generator/server.go
+++ b/tools/block-generator/generator/server.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/tools/block-generator/util"
 	"gopkg.in/yaml.v3"
 )
@@ -45,7 +46,7 @@ func MakeServer(configFile string, addr string) (*http.Server, Generator) {
 	noOp := func(next http.Handler) http.Handler {
 		return next
 	}
-	return MakeServerWithMiddleware(configFile, addr, noOp)
+	return MakeServerWithMiddleware(0, "", configFile, addr, noOp)
 }
 
 // BlocksMiddleware is a middleware for the blocks endpoint.
@@ -54,11 +55,15 @@ type BlocksMiddleware func(next http.Handler) http.Handler
 // MakeServerWithMiddleware allows injecting a middleware for the blocks handler.
 // This is needed to simplify tests by stopping block production while validation
 // is done on the data.
-func MakeServerWithMiddleware(configFile string, addr string, blocksMiddleware BlocksMiddleware) (*http.Server, Generator) {
+func MakeServerWithMiddleware(dbround uint64, genesisFile string, configFile string, addr string, blocksMiddleware BlocksMiddleware) (*http.Server, Generator) {
 	config, err := initializeConfigFile(configFile)
 	util.MaybeFail(err, "problem loading config file. Use '--config' or create a config file.")
-
-	gen, err := MakeGenerator(config)
+	var bkGenesis bookkeeping.Genesis
+	if genesisFile != "" {
+		bkGenesis, err = bookkeeping.LoadGenesisFromFile(genesisFile)
+		util.MaybeFail(err, "Failed to parse genesis file '%s'", genesisFile)
+	}
+	gen, err := MakeGenerator(dbround, bkGenesis, config)
 	util.MaybeFail(err, "Failed to make generator with config file '%s'", configFile)
 
 	mux := http.NewServeMux()

--- a/tools/block-generator/run_runner.sh
+++ b/tools/block-generator/run_runner.sh
@@ -13,7 +13,7 @@ fi
 POSTGRES_CONTAINER=generator-test-container
 POSTGRES_PORT=15432
 POSTGRES_DATABASE=generator_db
-CONFIG=${2:-"$(dirname $0)/test_config.yml"}
+CONFIG=${4:-"$(dirname $0)/test_config.yml"}
 echo "Using config file: $CONFIG"
 
 function start_postgres() {
@@ -54,4 +54,6 @@ $(dirname "$0")/block-generator runner \
 	--test-duration 30s \
 	--log-level trace \
 	--postgres-connection-string "host=localhost user=algorand password=algorand dbname=generator_db port=15432 sslmode=disable" \
-	--scenario ${CONFIG}
+	--scenario ${CONFIG} \
+	--db-round ${2:-0} \
+  --genesis-file ${3:-""} \

--- a/tools/block-generator/runner/runner.go
+++ b/tools/block-generator/runner/runner.go
@@ -53,6 +53,8 @@ func init() {
 	RunnerCmd.Flags().BoolVarP(&runnerArgs.ResetReportDir, "reset", "", false, "If set any existing report directory will be deleted before running tests.")
 	RunnerCmd.Flags().BoolVarP(&runnerArgs.RunValidation, "validate", "", false, "If set the validator will run after test-duration has elapsed to verify data is correct. An extra line in each report indicates validator success or failure.")
 	RunnerCmd.Flags().BoolVarP(&runnerArgs.KeepDataDir, "keep-data-dir", "k", false, "If set the validator will not delete the data directory after tests complete.")
+	RunnerCmd.Flags().Uint64VarP(&runnerArgs.NextDBRound, "next-db-round", "n", 0, "next round on db. It is the next_account_round from Indexer's metastate table.")
+	RunnerCmd.Flags().StringVarP(&runnerArgs.GenesisFile, "genesis-file", "f", "", "file path to the genesis associated with the db snapshot")
 
 	RunnerCmd.MarkFlagRequired("scenario")
 	RunnerCmd.MarkFlagRequired("conduit-binary")


### PR DESCRIPTION
![GitHub Logo](https://raw.githubusercontent.com/algorand/go-algorand/master/release/release-banner.jpg)

| **IMPORTANT**<br /> **This release requires a protocol upgrade.** <br /> This release contains a consensus protocol upgrade, which implements the following spec:  https://github.com/algorandfoundation/specs/tree/abd3d4823c6f77349fc04c3af7b1e99fe4df699f |
|---|

# Overview

This update includes a drop in round time of ~0.4 seconds, a robustness improvement to State Proofs, and several developer-oriented features in the AVM, simulate, and devmode.

⚠️ In order to avoid opcode ambiguity, access to assets or applications with an ID less than 256 within a contract will fail immediately. For new networks, asset and application IDs will now start at 1000 to avoid any potential issues due to this change.

# What&apos;s New

- 🚀 Round times are reduced by 400 milliseconds. See [here](placeholder) for details.
- 👥 Group resource sharing for app calls: access to resources (assets, apps, accounts, boxes) during smart contract evaluation is shared across the transaction group. See [here](placeholder) for details.
- 🕦 Devmode timestamp control: when running a network in devmode, the block timestamp can now be manipulated with a new API. See [here](placeholder) for details.
- 🔮 More logging and opcode budget in simulate: when calling the simulate endpoint, there are now options to let the algod evaluate the transaction group with much higher limits on logging and on opcode budget. See [here](placeholder) for details.
- 📒 Transaction group updates API: a new algod API that returns the ledger updates caused by individual transaction groups. See [here](placeholder) for details.
- ➕ Readiness Endpoint: algod has a new supplementary `/ready` endpoint to benefit any K8's deployment as a readiness probe. The endpoint will return a `200` response code once algod has caught up to the latest state.
- 📦 Algod Docker Container: algod container usage just got easier! The container now supports node profiles to simplify running common configurations in place of mounting a custom `config.json` file. There are also changes to make mounting a data directory more consistent. See [DockerHub](https://hub.docker.com/r/algorand/algod) for more details.

# Changelog
## Protocol Upgrade
This release contains a double protocol upgrade (Consensus v37 and v38). No action is needed from node runners but is called out for transparency. Consensus v37 is a technical upgrade released in unison with Consensus v38. v37 is needed to allow nodes to build up a necessary state to support State Proof related options in consensus v38.

## New Features
* AVM: Share resource arrays across transactions ([#5035](https://github.com/algorand/go-algorand/pull/5035))
* Algod: Allow timestamp offsets in dev mode ([#5296](https://github.com/algorand/go-algorand/pull/5296))
* Algod: Simulation run with extra budget per transaction group ([#5354](https://github.com/algorand/go-algorand/pull/5354))
* Algod: Simulation run with increased limits on logs ([#5247](https://github.com/algorand/go-algorand/pull/5247))
* API: Txn Group Delta Apis ([#5350](https://github.com/algorand/go-algorand/pull/5350))
* Evaltracer: Txn group deltas Tracer ([#5297](https://github.com/algorand/go-algorand/pull/5297))
* Algod: New health endpoint (k8s `/ready` endpoint) ([#4844](https://github.com/algorand/go-algorand/pull/4844))
* Docker: add profile support and improved endpoint access. ([#5323](https://github.com/algorand/go-algorand/pull/5323))
* Algod: support state proofs recoverability ([#4803](https://github.com/algorand/go-algorand/pull/4803))

## Enhancements
* API: Don&apos;t return a top level array from algod ([#5404](https://github.com/algorand/go-algorand/pull/5404))
* API: Limit request body size to 10MB ([#5246](https://github.com/algorand/go-algorand/pull/5246))
* AVM: Modify StackType to provide additional information ([#5130](https://github.com/algorand/go-algorand/pull/5130))
* AVM: No low resources ([#5328](https://github.com/algorand/go-algorand/pull/5328))
* AVM: Show opcode context for logicsigs (not just apps) ([#5336](https://github.com/algorand/go-algorand/pull/5336))
* Algocfg(profile): Add file name to config file conflict message. ([#5262](https://github.com/algorand/go-algorand/pull/5262))
* Algocfg(profile): improve invalid profile error message. ([#5324](https://github.com/algorand/go-algorand/pull/5324))
* Algod: Add EvalTracer tests for StateDeltas ([#5368](https://github.com/algorand/go-algorand/pull/5368))
* Algod: Better Box Reference Error Message ([#5325](https://github.com/algorand/go-algorand/pull/5325))
* Algod: Minor refactoring REST client `submitForm` from go-sdk PR #335 ([#5253](https://github.com/algorand/go-algorand/pull/5253))
* Algod: Modify simulate endpoint request type ([#5292](https://github.com/algorand/go-algorand/pull/5292))
* Algod: Move delta API tags ([#5396](https://github.com/algorand/go-algorand/pull/5396))
* Algod: Remove unused 404 resp in simulate endpoint ([#5211](https://github.com/algorand/go-algorand/pull/5211))
* Algod: Use future consensus version to test with no low resources ([#5362](https://github.com/algorand/go-algorand/pull/5362))
* Algod: search phonebook in data directory in addition to bindir ([#5235](https://github.com/algorand/go-algorand/pull/5235))
* Catchpoints: Small tweaks, mostly to comments ([#5195](https://github.com/algorand/go-algorand/pull/5195))
* Chore: Focus CONTRIBUTING.md on code contributions. ([#5294](https://github.com/algorand/go-algorand/pull/5294))
* Ci: set reviewdog golangci-lint go version ([#5196](https://github.com/algorand/go-algorand/pull/5196))
* Consensus: Introduce versions v37 and v38 ([#5397](https://github.com/algorand/go-algorand/pull/5397))
* Dev Tools: Integrate Logfile Navigator (lnav) ([#5000](https://github.com/algorand/go-algorand/pull/5000))
* Devops: Add CODEOWNERS to restrict workflow edits ([#5353](https://github.com/algorand/go-algorand/pull/5353))
* Devops: Update CODEOWNERS to only refer to the devops group ([#5389](https://github.com/algorand/go-algorand/pull/5389))
* Docker: Updated user and data dir handling. ([#5276](https://github.com/algorand/go-algorand/pull/5276))
* Docker: disable rewards in devmode template ([#5270](https://github.com/algorand/go-algorand/pull/5270))
* Docker: option to override topology file and peer address. ([#5209](https://github.com/algorand/go-algorand/pull/5209))
* Docs: Fix bug label ([#5322](https://github.com/algorand/go-algorand/pull/5322))
* Docs: add titles of subsystems, minor md fixes ([#5279](https://github.com/algorand/go-algorand/pull/5279))
* Docs: increase heading levels, thus only one h1 is used ([#5291](https://github.com/algorand/go-algorand/pull/5291))
* Enhancement: Only look back to FirstValid for pending transactions that were found in the pool ([#5295](https://github.com/algorand/go-algorand/pull/5295))
* Eval: Add block hooks to eval tracer ([#5303](https://github.com/algorand/go-algorand/pull/5303))
* Fix: Tech Debt (wsNetwork &quot;auto&quot; and OnlineAccountsDelete comment) ([#5207](https://github.com/algorand/go-algorand/pull/5207))
* Follow Mode: set sync round after fast catchup. ([#5349](https://github.com/algorand/go-algorand/pull/5349))
* Follower: add round information for missing deltas request ([#5277](https://github.com/algorand/go-algorand/pull/5277))
* Goal: Introduce new command for simulate ([#5213](https://github.com/algorand/go-algorand/pull/5213))
* Goal: Make goal state schema optional ([#5356](https://github.com/algorand/go-algorand/pull/5356))
* Goal: rename `--allow-extra-opcode-budget` to `--allow-more-opcode-budget` ([#5407](https://github.com/algorand/go-algorand/pull/5407))
* Goal: user defined scheme to connect to remote host ([#4922](https://github.com/algorand/go-algorand/pull/4922))
* Ledger: Check MaxAcctLookback in tracker. ([#5300](https://github.com/algorand/go-algorand/pull/5300))
* Ledger: Exclude stake at R-320 that is expired by R ([#5403](https://github.com/algorand/go-algorand/pull/5403))
* Ledger: convert FC unmarshalled nil value to empty byte slice on DB write KVs ([#5225](https://github.com/algorand/go-algorand/pull/5225))
* Ledger: rename &quot;internal&quot; to &quot;eval&quot; ([#5236](https://github.com/algorand/go-algorand/pull/5236))
* Lint: enable nilerr linter and fix errors ([#5361](https://github.com/algorand/go-algorand/pull/5361))
* Netdeploy: Copy ledger directory for kv tracker database ([#5392](https://github.com/algorand/go-algorand/pull/5392))
* Network: enforce maximum header size on outgoing ws conns ([#5268](https://github.com/algorand/go-algorand/pull/5268))
* REST: add the round number to algod box endpoint response ([#5340](https://github.com/algorand/go-algorand/pull/5340))
* Scripts: enhance upload_config.sh ([#5260](https://github.com/algorand/go-algorand/pull/5260))
* Simulate: Add opcode costs and budgets into response ([#5221](https://github.com/algorand/go-algorand/pull/5221))
* Simulate: Make optional signatures an opt-in feature ([#5335](https://github.com/algorand/go-algorand/pull/5335))
* Tools: Cross Repo Types Comparison Tool ([#5304](https://github.com/algorand/go-algorand/pull/5304))
* Tools: Don&apos;t use strings.Title in chopper ([#5239](https://github.com/algorand/go-algorand/pull/5239))
* Tools: Run the Cross Repo Type Checker in C.I. ([#5326](https://github.com/algorand/go-algorand/pull/5326))
* Tools: add block-generator into published build ([#5351](https://github.com/algorand/go-algorand/pull/5351))
* Tools: allow dumpblocks work with wal-enabled dbs ([#5380](https://github.com/algorand/go-algorand/pull/5380))
* Tools: block generator ([#5245](https://github.com/algorand/go-algorand/pull/5245))
* Tools: block generator data reporting ([#5339](https://github.com/algorand/go-algorand/pull/5339))
* Tools: new endpoints for block generator ([#5257](https://github.com/algorand/go-algorand/pull/5257))
* Tools: run block generator using a preloaded db ([#5384](https://github.com/algorand/go-algorand/pull/5384))
* Tools: search/replace indexer/conduit in block-generator ([#5321](https://github.com/algorand/go-algorand/pull/5321))
* Tools: update block-generator to use conduit binary ([#5306](https://github.com/algorand/go-algorand/pull/5306))
## Bugfixes
* API: Fix vote status computation. ([#5228](https://github.com/algorand/go-algorand/pull/5228))
* AVM: Avoid panics in disassembly when branch instructions are short ([#5252](https://github.com/algorand/go-algorand/pull/5252))
* AVM: Avoid panics while type checking bad immediates ([#5271](https://github.com/algorand/go-algorand/pull/5271))
* Assembler: Error if extra args are present in pragmas ([#5400](https://github.com/algorand/go-algorand/pull/5400))
* Bug Fix: block generator test ([#5410](https://github.com/algorand/go-algorand/pull/5410))
* Bugfix: reduce flakiness in follower node test ([#5355](https://github.com/algorand/go-algorand/pull/5355))
* Chore: Rename ModStateProofNextRound to StateProofNext. ([#5265](https://github.com/algorand/go-algorand/pull/5265))
* Dependency: Update codec version to 1.1.9 ([#5395](https://github.com/algorand/go-algorand/pull/5395))
* Devops: fix codecov uploading ([#5345](https://github.com/algorand/go-algorand/pull/5345))
* Docker: Fix ADMIN_TOKEN and add missing variables to echo statements. ([#5357](https://github.com/algorand/go-algorand/pull/5357))
* Erl: Support zero-size reservations ([#5192](https://github.com/algorand/go-algorand/pull/5192))
* Fix: Correct GeneratedAccountsMnemonics Check ([#5274](https://github.com/algorand/go-algorand/pull/5274))
* Follower: Set initial sync round to latest tracker committed round. ([#5251](https://github.com/algorand/go-algorand/pull/5251))
* Goal: Better formatting in `goal clerk simulate` ([#5259](https://github.com/algorand/go-algorand/pull/5259))
* Ledger: fix commit tasks enqueueing ([#5214](https://github.com/algorand/go-algorand/pull/5214))
* Ledger: fix error shadowing in accountsNewRound ([#5266](https://github.com/algorand/go-algorand/pull/5266))
* Ledger: report catchpoint writing only when it actually started ([#5413](https://github.com/algorand/go-algorand/pull/5413))
* Logging: fix logging to line. ([#5359](https://github.com/algorand/go-algorand/pull/5359))
* Tests: Change `dd` argument to use a bytes value ([#5263](https://github.com/algorand/go-algorand/pull/5263))
* Tests: Change truncate to dd for mac amd tests ([#5256](https://github.com/algorand/go-algorand/pull/5256))
* Tests: Fix State-Proofs ledger tests ([#5379](https://github.com/algorand/go-algorand/pull/5379))
* Tests: Fix devmode test ([#5334](https://github.com/algorand/go-algorand/pull/5334))
* Tests: Fix error messages in ledger tests ([#5363](https://github.com/algorand/go-algorand/pull/5363))
* Tests: Improve flaky test from non-deterministic order string ([#5333](https://github.com/algorand/go-algorand/pull/5333))
* Tests: fix consensus version inconsistency in newTestLedger ([#5342](https://github.com/algorand/go-algorand/pull/5342))
* Tests: remove follower node flaky TestSyncRoundWithRemake ([#5415](https://github.com/algorand/go-algorand/pull/5415))
* Txhandler: make dedup working set independent from ERL ([#5200](https://github.com/algorand/go-algorand/pull/5200))
* Txngroup-deltas: Fix pointer bug copying deltas for txngroups ([#5375](https://github.com/algorand/go-algorand/pull/5375))
## Additional Resources
* [Algorand Forum](https://forum.algorand.org)
* [Developer Documentation](https://developer.algorand.org)
