### PR TITLE
AVM: Simplify conversion and fix a spurious complaint from static analysis

### DIFF
--- a/data/transactions/logic/debugger.go
+++ b/data/transactions/logic/debugger.go
@@ -253,15 +253,6 @@ func (sv stackValue) toEncodedTealValue() basics.TealValue {
 	return basics.TealValue{Type: basics.TealUintType, Uint: sv.Uint}
 }
 
-// valueDeltaToValueDelta converts delta's bytes to base64 in a new struct
-func valueDeltaToValueDelta(vd *basics.ValueDelta) basics.ValueDelta {
-	return basics.ValueDelta{
-		Action: vd.Action,
-		Bytes:  base64.StdEncoding.EncodeToString([]byte(vd.Bytes)),
-		Uint:   vd.Uint,
-	}
-}
-
 // parseCallStack initializes an array of CallFrame objects from the raw
 // callstack.
 func (d *DebugState) parseCallstack(callstack []frame) []CallFrame {

--- a/data/transactions/logic/debugger_test.go
+++ b/data/transactions/logic/debugger_test.go
@@ -17,10 +17,8 @@
 package logic
 
 import (
-	"encoding/base64"
 	"testing"
 
-	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/stretchr/testify/require"
 )
@@ -61,22 +59,6 @@ func TestLineToPC(t *testing.T) {
 	dState.PCOffset = []PCOffset{{PC: 1, Offset: 0}}
 	pc = dState.LineToPC(1)
 	require.Equal(t, 0, pc)
-}
-
-func TestValueDeltaToValueDelta(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-
-	vDelta := basics.ValueDelta{
-		Action: basics.SetUintAction,
-		Bytes:  "some string",
-		Uint:   uint64(0xffffffff),
-	}
-	ans := valueDeltaToValueDelta(&vDelta)
-	require.Equal(t, vDelta.Action, ans.Action)
-	require.NotEqual(t, vDelta.Bytes, ans.Bytes)
-	require.Equal(t, base64.StdEncoding.EncodeToString([]byte(vDelta.Bytes)), ans.Bytes)
-	require.Equal(t, vDelta.Uint, ans.Uint)
 }
 
 const testCallStackProgram string = `intcblock 1

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -160,7 +160,7 @@ func (sv stackValue) string(limit int) (string, error) {
 	return string(sv.Bytes), nil
 }
 
-func (sv stackValue) toTealValue() (tv basics.TealValue) {
+func (sv stackValue) toTealValue() basics.TealValue {
 	if sv.avmType() == avmBytes {
 		return basics.TealValue{Type: basics.TealBytesType, Bytes: string(sv.Bytes)}
 	}


### PR DESCRIPTION
Static analysis tools noted that:
```
for i, sv := range cx.stack {
    stack[i] = stackValueToTealValue(&sv)
}
```
was a potential problem because `sv` is always the same variable in a for loop, so this code was passing the same address on each call. That was fine, since stackValueToTealValue is single-threaded, and does not store the address. It's just a simple conversion.

But, noting that the conversion was more complicated than it needed to be, and probably allocated more than it needed to, this PR simplifies it and makes it work on stackValue values instead of pointers.

Also removes the unused function: valueDeltaToValueDelta and associated test.

## Test Plan

Existing tests