### PR TITLE
AVM: Increase coverage by deleting a dead function and adding limit tests

### DIFF
--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -652,23 +652,6 @@ func (at avmType) String() string {
 	return "internal error, unknown type"
 }
 
-// stackType lifts the avmType to a StackType
-// it can do this because the base StackTypes
-// are a superset of avmType
-func (at avmType) stackType() StackType {
-	switch at {
-	case avmNone:
-		return StackNone
-	case avmAny:
-		return StackAny
-	case avmUint64:
-		return StackUint64
-	case avmBytes:
-		return StackBytes
-	}
-	return StackNone
-}
-
 var (
 	// StackUint64 is any valid uint64
 	StackUint64 = NewStackType(avmUint64, bound(0, math.MaxUint64))
@@ -5366,14 +5349,8 @@ func (cx *EvalContext) stackIntoTxnField(sv stackValue, fs *txnFieldSpec, txn *t
 		txn.AssetParams.Total, err = sv.uint()
 	case ConfigAssetDecimals:
 		var decimals uint64
-		decimals, err = sv.uint()
-		if err == nil {
-			if decimals > uint64(cx.Proto.MaxAssetDecimals) {
-				err = fmt.Errorf("too many decimals (%d)", decimals)
-			} else {
-				txn.AssetParams.Decimals = uint32(decimals)
-			}
-		}
+		decimals, err = sv.uintMaxed(uint64(cx.Proto.MaxAssetDecimals))
+		txn.AssetParams.Decimals = uint32(decimals)
 	case ConfigAssetDefaultFrozen:
 		txn.AssetParams.DefaultFrozen, err = sv.bool()
 	case ConfigAssetUnitName:

--- a/data/transactions/logic/evalAppTxn_test.go
+++ b/data/transactions/logic/evalAppTxn_test.go
@@ -128,6 +128,71 @@ func TestFieldTypes(t *testing.T) {
 	TestApp(t, NoTrack("itxn_begin; byte \"pay\"; itxn_field Nonparticipation;"), ep, "not a uint64")
 }
 
+func TestFieldLimits(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	ep, _, _ := MakeSampleEnv()
+
+	intProgram := "itxn_begin; int %d; itxn_field %s; int 1"
+	goodInt := func(field string, value interface{}) {
+		TestApp(t, fmt.Sprintf(intProgram, value, field), ep)
+	}
+	badInt := func(field string, value interface{}) {
+		// error messages are different for different fields, just use a space
+		// to indicate there should be an error, it will surely match any error.
+		TestApp(t, NoTrack(fmt.Sprintf(intProgram, value, field)), ep, " ")
+	}
+	testInt := func(field string, max int) {
+		goodInt(field, 1)
+		goodInt(field, max)
+		badInt(field, max+1)
+	}
+	testBool := func(field string) {
+		goodInt(field, 0)
+		goodInt(field, 1)
+		badInt(field, 2)
+	}
+	bytesProgram := "itxn_begin; byte %#v; itxn_field %s; int 1"
+	goodBytes := func(field string, value string) {
+		TestApp(t, fmt.Sprintf(bytesProgram, value, field), ep)
+	}
+	badBytes := func(field string, value string) {
+		// error messages are different for different fields, just use a space
+		// to indicate there should be an error, it will surely match any error.
+		TestApp(t, NoTrack(fmt.Sprintf(bytesProgram, value, field)), ep, " ")
+	}
+	testBytes := func(field string, maxLen int) {
+		goodBytes(field, "")
+		goodBytes(field, strings.Repeat("a", maxLen))
+		badBytes(field, strings.Repeat("a", maxLen+1))
+	}
+
+	// header
+	badInt("TypeEnum", 0)
+	testInt("TypeEnum", len(TxnTypeNames)-1)
+	//keyreg
+	testBool("Nonparticipation")
+	//acfg
+	goodInt("ConfigAssetTotal", 1)
+	goodInt("ConfigAssetTotal", uint64(1<<63))
+	goodInt("ConfigAssetDecimals", 0)
+	testInt("ConfigAssetDecimals", int(ep.Proto.MaxAssetDecimals))
+	testBool("ConfigAssetDefaultFrozen")
+	testBytes("ConfigAssetUnitName", ep.Proto.MaxAssetUnitNameBytes)
+	testBytes("ConfigAssetName", ep.Proto.MaxAssetNameBytes)
+	testBytes("ConfigAssetURL", ep.Proto.MaxAssetURLBytes)
+	//afrz
+	testBool("FreezeAssetFrozen")
+	// appl
+	testInt("OnCompletion", len(OnCompletionNames)-1)
+	testInt("LocalNumUint", int(ep.Proto.MaxLocalSchemaEntries))
+	testInt("LocalNumByteSlice", int(ep.Proto.MaxLocalSchemaEntries))
+	testInt("GlobalNumUint", int(ep.Proto.MaxGlobalSchemaEntries))
+	testInt("GlobalNumByteSlice", int(ep.Proto.MaxGlobalSchemaEntries))
+	testInt("ExtraProgramPages", int(ep.Proto.MaxExtraAppProgramPages))
+}
+
 func appAddr(id int) basics.Address {
 	return basics.AppIndex(id).Address()
 }

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -19,6 +19,7 @@ package logic
 import (
 	"encoding/hex"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -3261,5 +3262,25 @@ itxn_submit
 		maxAppCallDepth = 10_000_000
 
 		testApp(t, source, ep, "too many inner transactions 1 with 0 left")
+	})
+}
+
+func TestTxnaLimits(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+	// txna came in v2, but Apps and Assets in v3.
+	TestLogicRange(t, 3, 0, func(t *testing.T, ep *EvalParams, tx *transactions.Transaction, ledger *Ledger) {
+		testApp(t, "txna Accounts "+strconv.Itoa(len(tx.Accounts))+";len", ep)
+		testApp(t, "txna Accounts "+strconv.Itoa(len(tx.Accounts)+1)+";len", ep, "invalid Accounts index")
+
+		testApp(t, "txna Applications "+strconv.Itoa(len(tx.ForeignApps)), ep)
+		testApp(t, "txna Applications "+strconv.Itoa(len(tx.ForeignApps)+1), ep, "invalid Applications index")
+
+		// Assets and AppArgs have no implicit 0 index, so everything shifts
+		testApp(t, "txna Assets "+strconv.Itoa(len(tx.ForeignAssets)-1), ep)
+		testApp(t, "txna Assets "+strconv.Itoa(len(tx.ForeignAssets)), ep, "invalid Assets index")
+
+		testApp(t, "txna ApplicationArgs "+strconv.Itoa(len(tx.ApplicationArgs)-1)+";len", ep)
+		testApp(t, "txna ApplicationArgs "+strconv.Itoa(len(tx.ApplicationArgs))+";len", ep, "invalid ApplicationArgs index")
 	})
 }


### PR DESCRIPTION
Title says it all. Delete dead code. Add some tests for coverage.
