### PR TITLE
blockserver: Memory counter for http block requests

### DIFF
--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -510,6 +510,10 @@ type Local struct {
 	// EnableTxnEvalTracer turns on features in the BlockEvaluator which collect data on transactions, exposing them via algod APIs.
 	// It will store txn deltas created during block evaluation, potentially consuming much larger amounts of memory,
 	EnableTxnEvalTracer bool `version[27]:"false"`
+
+	// BlockServiceHTTPMemCap is the memory capacity in bytes which is allowed for the block service to use for HTTP block requests.
+	// When it exceeds this capacity, it redirects the block requests to a different node
+	BlockServiceHTTPMemCap uint64 `version[27]:"500000000"`
 }
 
 // DNSBootstrapArray returns an array of one or more DNS Bootstrap identifiers

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -30,6 +30,7 @@ var defaultLocal = Local{
 	Archival:                                   false,
 	BaseLoggerDebugLevel:                       4,
 	BlockServiceCustomFallbackEndpoints:        "",
+	BlockServiceHTTPMemCap:                     500000000,
 	BroadcastConnectionsLimit:                  -1,
 	CadaverDirectory:                           "",
 	CadaverSizeTarget:                          0,

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -9,6 +9,7 @@
     "Archival": false,
     "BaseLoggerDebugLevel": 4,
     "BlockServiceCustomFallbackEndpoints": "",
+    "BlockServiceHTTPMemCap": 500000000,
     "BroadcastConnectionsLimit": -1,
     "CadaverDirectory": "",
     "CadaverSizeTarget": 0,

--- a/rpcs/blockService.go
+++ b/rpcs/blockService.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"net/http"
 	"path"
 	"strconv"
@@ -47,6 +48,7 @@ import (
 const BlockResponseContentType = "application/x-algorand-block-v1"
 const blockResponseHasBlockCacheControl = "public, max-age=31536000, immutable"    // 31536000 seconds are one year.
 const blockResponseMissingBlockCacheControl = "public, max-age=1, must-revalidate" // cache for 1 second, and force revalidation afterward
+const blockResponseRetryAfter = "3"                                                // retry after 3 seconds
 const blockServerMaxBodyLength = 512                                               // we don't really pass meaningful content here, so 512 bytes should be a safe limit
 const blockServerCatchupRequestBufferSize = 10
 
@@ -64,6 +66,12 @@ const (
 )
 
 var errBlockServiceClosed = errors.New("block service is shutting down")
+
+type errMemoryAtCapacity struct{ capacity, used uint64 }
+
+func (err errMemoryAtCapacity) Error() string {
+	return fmt.Sprintf("block service memory over capacity: %d / %d", err.capacity, err.used)
+}
 
 // LedgerForBlockService describes the Ledger methods used by BlockService.
 type LedgerForBlockService interface {
@@ -84,6 +92,8 @@ type BlockService struct {
 	log                     logging.Logger
 	closeWaitGroup          sync.WaitGroup
 	mu                      deadlock.Mutex
+	memoryUsed              uint64
+	memoryCap               uint64
 }
 
 // EncodedBlockCert defines how GetBlockBytes encodes a block and its certificate
@@ -96,6 +106,7 @@ type EncodedBlockCert struct {
 
 // PreEncodedBlockCert defines how GetBlockBytes encodes a block and its certificate,
 // using a pre-encoded Block and Certificate in msgpack format.
+//
 //msgp:ignore PreEncodedBlockCert
 type PreEncodedBlockCert struct {
 	Block       codec.Raw `codec:"block"`
@@ -119,6 +130,7 @@ func MakeBlockService(log logging.Logger, config config.Local, ledger LedgerForB
 		fallbackEndpoints:       makeFallbackEndpoints(log, config.BlockServiceCustomFallbackEndpoints),
 		enableArchiverFallback:  config.EnableBlockServiceFallbackToArchiver,
 		log:                     log,
+		memoryCap:               config.BlockServiceHTTPMemCap,
 	}
 	if service.enableService {
 		net.RegisterHTTPHandler(BlockServiceBlockPath, service)
@@ -224,6 +236,14 @@ func (bs *BlockService) ServeHTTP(response http.ResponseWriter, request *http.Re
 				response.WriteHeader(http.StatusNotFound)
 			}
 			return
+		case errMemoryAtCapacity:
+			// memory used by HTTP block requests is over the cap
+			ok := bs.redirectRequest(round, response, request)
+			if !ok {
+				response.Header().Set("Retry-After", blockResponseRetryAfter)
+				response.WriteHeader(http.StatusServiceUnavailable)
+			}
+			return
 		default:
 			// unexpected error.
 			bs.log.Warnf("ServeHTTP : failed to retrieve block %d %v", round, err)
@@ -240,6 +260,9 @@ func (bs *BlockService) ServeHTTP(response http.ResponseWriter, request *http.Re
 	if err != nil {
 		bs.log.Warn("http block write failed ", err)
 	}
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	bs.memoryUsed = bs.memoryUsed - uint64(len(encodedBlockCert))
 }
 
 func (bs *BlockService) processIncomingMessage(msg network.IncomingMessage) (n network.OutgoingMessage) {
@@ -382,7 +405,14 @@ func (bs *BlockService) rawBlockBytes(round basics.Round) ([]byte, error) {
 		}
 	default:
 	}
-	return RawBlockBytes(bs.ledger, round)
+	if bs.memoryUsed > bs.memoryCap {
+		return nil, errMemoryAtCapacity{used: bs.memoryUsed, capacity: bs.memoryCap}
+	}
+	data, err := RawBlockBytes(bs.ledger, round)
+	if err == nil {
+		bs.memoryUsed = bs.memoryUsed + uint64(len(data))
+	}
+	return data, err
 }
 
 func topicBlockBytes(log logging.Logger, dataLedger LedgerForBlockService, round basics.Round, requestType string) network.Topics {

--- a/rpcs/blockService_test.go
+++ b/rpcs/blockService_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -279,6 +280,121 @@ func TestRedirectFallbackEndpoints(t *testing.T) {
 	require.Equal(t, http.StatusOK, response.StatusCode)
 }
 
+// TestRedirectFallbackArchiver tests the case when the block service
+// fallback to another because its memory use it at capacity
+func TestRedirectOnFullCapacity(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	log := logging.TestingLog(t)
+	log.SetLevel(logging.Error)
+
+	ledger1 := makeLedger(t, "l1")
+	defer ledger1.Close()
+	ledger2 := makeLedger(t, "l2")
+	defer ledger2.Close()
+	addBlock(t, ledger1)
+	l1Block2Ts := addBlock(t, ledger1)
+	addBlock(t, ledger2)
+	l2Block2Ts := addBlock(t, ledger2)
+	require.NotEqual(t, l1Block2Ts, l2Block2Ts)
+
+	net1 := &httpTestPeerSource{}
+	net2 := &httpTestPeerSource{}
+
+	config := config.GetDefaultLocal()
+	bs1 := MakeBlockService(log, config, ledger1, net1, "test-genesis-ID")
+	bs2 := MakeBlockService(log, config, ledger2, net2, "test-genesis-ID")
+	// set the meory cap so that it can serve only 1 block at a time
+	bs1.memoryCap = 250
+	bs2.memoryCap = 250
+
+	nodeA := &basicRPCNode{}
+	nodeB := &basicRPCNode{}
+
+	nodeA.RegisterHTTPHandler(BlockServiceBlockPath, bs1)
+	nodeA.start()
+	defer nodeA.stop()
+
+	nodeB.RegisterHTTPHandler(BlockServiceBlockPath, bs2)
+	nodeB.start()
+	defer nodeB.stop()
+
+	net1.addPeer(nodeB.rootURL())
+
+	parsedURL, err := network.ParseHostOrURL(nodeA.rootURL())
+	require.NoError(t, err)
+
+	client := http.Client{}
+
+	parsedURL.Path = FormatBlockQuery(uint64(2), parsedURL.Path, net1)
+	parsedURL.Path = strings.Replace(parsedURL.Path, "{genesisID}", "test-genesis-ID", 1)
+	blockURL := parsedURL.String()
+	request, err := http.NewRequest("GET", blockURL, nil)
+	require.NoError(t, err)
+	network.SetUserAgentHeader(request.Header)
+
+	var responses1, responses2, responses3, responses4 *http.Response
+	var blk bookkeeping.Block
+	var l2Failed bool
+	xDone := 1000
+	// Keep on sending 4 simultanious requests to the first node, to force it to redirect to node 2
+	// then check the timestamp from the block header to confirm the redirection took place
+	var x int
+forloop:
+	for ; x < xDone; x++ {
+		wg := sync.WaitGroup{}
+		wg.Add(4)
+		go func() {
+			defer wg.Done()
+			responses1, _ = client.Do(request)
+		}()
+		go func() {
+			defer wg.Done()
+			responses2, _ = client.Do(request)
+		}()
+		go func() {
+			defer wg.Done()
+			responses3, _ = client.Do(request)
+		}()
+		go func() {
+			defer wg.Done()
+			responses4, _ = client.Do(request)
+		}()
+
+		wg.Wait()
+		responses := [4]*http.Response{responses1, responses2, responses3, responses4}
+		for p := 0; p < 4; p++ {
+			if responses[p] == nil {
+				continue
+			}
+			if responses[p].StatusCode == http.StatusServiceUnavailable {
+				l2Failed = true
+				require.Equal(t, "3", responses[p].Header["Retry-After"][0])
+				continue
+			}
+			// parse the block to get the header timestamp
+			// timestamp is needed to know which node served the block
+			require.Equal(t, http.StatusOK, responses[p].StatusCode)
+			bodyData, err := io.ReadAll(responses[p].Body)
+			require.NoError(t, err)
+			require.NotEqual(t, 0, len(bodyData))
+			var blkCert PreEncodedBlockCert
+			err = protocol.DecodeReflect(bodyData, &blkCert)
+			require.NoError(t, err)
+			err = protocol.Decode(blkCert.Block, &blk)
+			require.NoError(t, err)
+			if blk.TimeStamp == l2Block2Ts && l2Failed {
+				break forloop
+			}
+		}
+	}
+	require.Less(t, x, xDone)
+	// check if redirection happened
+	require.Equal(t, blk.TimeStamp, l2Block2Ts)
+	// check if node 2 was also overwhelmed and responded with retry-after, since it cannod redirect
+	require.True(t, l2Failed)
+}
+
 // TestRedirectExceptions tests exception cases:
 // - the case when the peer is not a valid http peer
 // - the case when the block service keeps redirecting and cannot get a block
@@ -358,7 +474,7 @@ func makeLedger(t *testing.T, namePostfix string) *data.Ledger {
 	return ledger
 }
 
-func addBlock(t *testing.T, ledger *data.Ledger) {
+func addBlock(t *testing.T, ledger *data.Ledger) (timestamp int64) {
 	blk, err := ledger.Block(ledger.LastRound())
 	require.NoError(t, err)
 	blk.BlockHeader.Round++
@@ -375,4 +491,5 @@ func addBlock(t *testing.T, ledger *data.Ledger) {
 	hdr, err := ledger.BlockHdr(blk.BlockHeader.Round)
 	require.NoError(t, err)
 	require.Equal(t, blk.BlockHeader, hdr)
+	return blk.BlockHeader.TimeStamp
 }


### PR DESCRIPTION
This PR addresses the vulnerability of a node when too many requests are made to the HTTP block server.
The server will have to load the blocks from the disk to the main memory, then serve the block. When too many requests arrive, it may consume way too much memory.

This change calculates the amount of memory consumed by the service, and when it is above a constant (500MB), it redirects the next request, or, in case redirection is not possible, returns a retry response after 3 seconds. 


Doc:
https://docs.google.com/document/d/1ptqknyuGAWFEGp4LwBqwpVvvQZv-MENtXKtlUd4jSsg/edit#heading=h.cfl2099c5rvj

Fixes:
https://github.com/algorand/go-algorand-internal/issues/2738