### PR TITLE
CICD: fix ci-build target for buildsrc-special support

### DIFF
--- a/scripts/release/mule/Makefile.mule
+++ b/scripts/release/mule/Makefile.mule
@@ -28,7 +28,7 @@ ci-integration:
 	SRCROOT=$(SRCPATH) \
 	test/scripts/e2e.sh -c $(CHANNEL) -n
 
-ci-build: ci-clean buildsrc ci-setup
+ci-build: ci-clean buildsrc buildsrc-special ci-setup
 	CHANNEL=$(CHANNEL) PKG_ROOT=$(PKG_DIR) NO_BUILD=True VARIATIONS=$(OS_TYPE)-$(ARCH) \
 	scripts/build_packages.sh $(OS_TYPE)/$(ARCH) && \
 	mkdir -p $(PKG_DIR)/data && \

--- a/scripts/release/mule/Makefile.mule
+++ b/scripts/release/mule/Makefile.mule
@@ -28,7 +28,7 @@ ci-integration:
 	SRCROOT=$(SRCPATH) \
 	test/scripts/e2e.sh -c $(CHANNEL) -n
 
-ci-build: ci-clean buildsrc buildsrc-special ci-setup
+ci-build: ci-clean build ci-setup
 	CHANNEL=$(CHANNEL) PKG_ROOT=$(PKG_DIR) NO_BUILD=True VARIATIONS=$(OS_TYPE)-$(ARCH) \
 	scripts/build_packages.sh $(OS_TYPE)/$(ARCH) && \
 	mkdir -p $(PKG_DIR)/data && \


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

A build target was added that is missing from the ci-build dependencies.

## Test Plan

N/A

