### PR TITLE
AVM: Some error cleanup, and added coverage

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -596,8 +596,8 @@ func asmPushInt(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sour
 
 func asmPushInts(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
 	ops.pending.WriteByte(spec.Opcode)
-	_, err := asmIntImmArgs(ops, args)
-	return err
+	asmIntImmArgs(ops, args)
+	return nil
 }
 
 func asmPushBytes(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
@@ -672,6 +672,9 @@ func parseBinaryArgs(args []token) ([]byte, int, error) {
 		}
 		val, err := base64.StdEncoding.DecodeString(arg[open+1 : close])
 		if err != nil {
+			if cie, ok := err.(base64.CorruptInputError); ok {
+				return nil, 0, base64.CorruptInputError(int64(cie) + int64(open) + 1)
+			}
 			return nil, 0, err
 		}
 		return val, 1, nil
@@ -727,7 +730,7 @@ func parseStringLiteral(input string) (result []byte, err error) {
 		char := input[pos]
 		if char == '\\' && !escapeSeq {
 			if hexSeq {
-				return nil, fmt.Errorf("escape seq inside hex number")
+				return nil, fmt.Errorf("escape sequence inside hex number")
 			}
 			escapeSeq = true
 			pos++
@@ -757,7 +760,7 @@ func parseStringLiteral(input string) (result []byte, err error) {
 		if hexSeq {
 			hexSeq = false
 			if pos >= len(input)-2 { // count a closing quote
-				return nil, fmt.Errorf("non-terminated hex seq")
+				return nil, fmt.Errorf("non-terminated hex sequence")
 			}
 			num, err := strconv.ParseUint(input[pos:pos+2], 16, 8)
 			if err != nil {
@@ -771,7 +774,7 @@ func parseStringLiteral(input string) (result []byte, err error) {
 		pos++
 	}
 	if escapeSeq || hexSeq {
-		return nil, fmt.Errorf("non-terminated escape seq")
+		return nil, fmt.Errorf("non-terminated escape sequence")
 	}
 
 	return
@@ -851,7 +854,7 @@ func asmMethod(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourc
 	return args[0].errorf("unable to parse method signature")
 }
 
-func asmIntImmArgs(ops *OpStream, args []token) ([]uint64, *sourceError) {
+func asmIntImmArgs(ops *OpStream, args []token) []uint64 {
 	ivals := make([]uint64, len(args))
 	var scratch [binary.MaxVarintLen64]byte
 	l := binary.PutUvarint(scratch[:], uint64(len(args)))
@@ -866,15 +869,12 @@ func asmIntImmArgs(ops *OpStream, args []token) ([]uint64, *sourceError) {
 		ivals[i] = cu
 	}
 
-	return ivals, nil
+	return ivals
 }
 
 func asmIntCBlock(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
 	ops.pending.WriteByte(spec.Opcode)
-	ivals, err := asmIntImmArgs(ops, args)
-	if err != nil {
-		return err
-	}
+	ivals := asmIntImmArgs(ops, args)
 	if !ops.known.deadcode {
 		// If we previously processed an `int`, we thought we could insert our
 		// own intcblock, but now we see a manual one.
@@ -895,10 +895,9 @@ func asmByteImmArgs(ops *OpStream, spec *OpSpec, args []token) ([][]byte, *sourc
 	for len(rest) > 0 {
 		val, consumed, err := parseBinaryArgs(rest)
 		if err != nil {
-			// Would be nice to keep going, as in
-			// intcblock, but parseBinaryArgs would have
-			// to return a useful consumed value even in
-			// the face of errors.  Hard.
+			// Would be nice to keep going, as in asmIntImmArgs, but
+			// parseBinaryArgs would have to return a useful consumed value even
+			// in the face of errors.  Hard.
 			return nil, rest[0].errorf("%s %w", spec.Name, err)
 		}
 		bvals = append(bvals, val)
@@ -1271,11 +1270,6 @@ func typeBury(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, erro
 	}
 
 	top := len(pgm.stack) - 1
-	typ, ok := pgm.top()
-	if !ok {
-		return nil, nil, nil // Will error because bury demands a stack arg
-	}
-
 	idx := top - n
 	if idx < 0 {
 		if pgm.bottom.AVMType == avmNone {
@@ -1286,6 +1280,7 @@ func typeBury(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, erro
 		// nothing to update.
 		return nil, nil, nil
 	}
+	typ, _ := pgm.top()
 
 	returns := make(StackTypes, n)
 	copy(returns, pgm.stack[idx:]) // Won't have room to copy the top type
@@ -1320,11 +1315,7 @@ func typeFrameBury(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes,
 		return nil, nil, nil
 	}
 
-	top := len(pgm.stack) - 1
-	typ, ok := pgm.top()
-	if !ok {
-		return nil, nil, nil // Will error because fbury demands a stack arg
-	}
+	typ, _ := pgm.top() // !ok is a degenerate case anyway
 
 	// If we have no frame pointer, we have to wipe out any belief that the
 	// stack contains anything but the supplied type.
@@ -1344,6 +1335,7 @@ func typeFrameBury(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes,
 	if idx < 0 {
 		return nil, nil, fmt.Errorf("frame_bury %d in sub with %d args", n, pgm.fp)
 	}
+	top := len(pgm.stack) - 1
 	if idx >= top {
 		return nil, nil, fmt.Errorf("frame_bury above stack")
 	}
@@ -1828,18 +1820,6 @@ func (se sourceError) Unwrap() error {
 
 func errorLinef(line int, format string, a ...interface{}) *sourceError {
 	return &sourceError{line, 0, fmt.Errorf(format, a...)}
-}
-
-func typecheck(expected, got StackType) bool {
-	// Some ops push 'any' and we wait for run time to see what it is.
-	// Some of those 'any' are based on fields that we _could_ know now but haven't written a more detailed system of typecheck for (yet).
-	if expected == StackAny && got == StackNone { // Any is lenient, but stack can't be empty
-		return false
-	}
-	if (expected == StackAny) || (got == StackAny) {
-		return true
-	}
-	return expected == got
 }
 
 type token struct {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -979,16 +979,16 @@ func TestIntcTooFar(t *testing.T) {
 
 	t.Parallel()
 	// Want to be super clear that intc_1 fails, whether an intcblock exists (but small) or not
-	testPanics(t, "intc_1", 1)
-	testPanics(t, "int 1; intc_1; pop", 1)
+	testPanics(t, "intc_1", 1, "intc 1 beyond 0 constants")
+	testPanics(t, "intcblock 7; intc_1; pop", 1, "intc 1 beyond 1 constants")
 }
 
 func TestBytecTooFar(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	t.Parallel()
-	testPanics(t, "bytec_1; btoi", 1)
-	testPanics(t, "byte 0x23; bytec_1; btoi", 1)
+	testPanics(t, "bytec_1; btoi", 1, "bytec 1 beyond 0 constants")
+	testPanics(t, "bytecblock 0x23 0x45; bytec_2; btoi", 1, "bytec 2 beyond 2 constants")
 }
 
 func TestManualCBlockEval(t *testing.T) {
@@ -996,7 +996,7 @@ func TestManualCBlockEval(t *testing.T) {
 	t.Parallel()
 
 	// TestManualCBlock in assembler_test.go demonstrates that these will use
-	// an inserted constant block.
+	// an inserted constant block because the blocks given are in dead code.
 	testAccepts(t, "int 4; int 4; +; int 8; ==; return; intcblock 10", 2)
 	testAccepts(t, "b skip; intcblock 10; skip: int 4; int 4; +; int 8; ==;", 2)
 	testAccepts(t, "byte 0x2222; byte 0x2222; concat; len; int 4; ==; return; bytecblock 0x11", 2)

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -631,7 +631,7 @@ var OpSpecs = []OpSpec{
 
 	// AVM "effects"
 	{0xb0, "log", opLog, proto("b:"), 5, only(ModeApp)},
-	{0xb1, "itxn_begin", opTxBegin, proto(":"), 5, only(ModeApp)},
+	{0xb1, "itxn_begin", opItxnBegin, proto(":"), 5, only(ModeApp)},
 	{0xb2, "itxn_field", opItxnField, proto("a:"), 5, immediates("f").typed(typeTxField).field("f", &TxnFields).only(ModeApp).assembler(asmItxnField)},
 	{0xb3, "itxn_submit", opItxnSubmit, proto(":"), 5, only(ModeApp)},
 	{0xb4, "itxn", opItxn, proto(":a"), 5, field("f", &TxnScalarFields).only(ModeApp).assembler(asmItxn)},

--- a/data/transactions/logic/resources_test.go
+++ b/data/transactions/logic/resources_test.go
@@ -311,7 +311,7 @@ int 1`
 		ledger.NewAccount(appAddr(888), 50_000)
 		// First show that we're not just letting anything get passed in
 		logic.TestApp(t, fmt.Sprintf(callWithAccount, "int 32; bzero; byte 0x07; b|"), ep,
-			"invalid Account reference AAAAA")
+			"unavailable Account AAAAA")
 		// Now show we can pass our own address
 		logic.TestApp(t, fmt.Sprintf(callWithAccount, "global CurrentApplicationAddress"), ep)
 		// Or the address of one of our ForeignApps
@@ -550,12 +550,12 @@ int 1
 		appl.ApplicationArgs = [][]byte{senderAcct[:]}
 		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&keyreg, &appl), 9, ledger)
 		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&keyreg, &appl), 8, ledger,
-			logic.Exp(1, "invalid Account reference "+senderAcct.String()))
+			logic.Exp(1, "unavailable Account "+senderAcct.String()))
 
 		// confirm you can't just pay _anybody_. receiverAcct is not in use at all.
 		appl.ApplicationArgs = [][]byte{receiverAcct[:]}
 		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&keyreg, &appl), 9, ledger,
-			logic.Exp(1, "invalid Account reference "+receiverAcct.String()))
+			logic.Exp(1, "unavailable Account "+receiverAcct.String()))
 	})
 
 	t.Run("pay", func(t *testing.T) {
@@ -569,17 +569,17 @@ int 1
 		appl.ApplicationArgs = [][]byte{senderAcct[:]}
 		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 9, ledger)
 		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 8, ledger,
-			logic.Exp(1, "invalid Account reference "+senderAcct.String()))
+			logic.Exp(1, "unavailable Account "+senderAcct.String()))
 
 		appl.ApplicationArgs = [][]byte{receiverAcct[:]}
 		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 9, ledger)
 		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 8, ledger,
-			logic.Exp(1, "invalid Account reference "+receiverAcct.String()))
+			logic.Exp(1, "unavailable Account "+receiverAcct.String()))
 
 		// confirm you can't just pay _anybody_. otherAcct is not in use at all.
 		appl.ApplicationArgs = [][]byte{otherAcct[:]}
 		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 9, ledger,
-			logic.Exp(1, "invalid Account reference "+otherAcct.String()))
+			logic.Exp(1, "unavailable Account "+otherAcct.String()))
 	})
 
 	t.Run("axfer", func(t *testing.T) {
@@ -595,7 +595,7 @@ int 1
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {asa1}}
 		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&axfer, &appl), 9, ledger)
 		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&axfer, &appl), 8, ledger,
-			logic.Exp(1, "invalid Account reference "+senderAcct.String()))
+			logic.Exp(1, "unavailable Account "+senderAcct.String()))
 		// but can't axfer to sender, because appAcct doesn't have holding access for the asa
 		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
 			logic.Exp(1, "unavailable Holding"))
@@ -626,7 +626,7 @@ int 1
 		// or correct asset to an unknown address
 		appl.ApplicationArgs = [][]byte{unusedAcct[:], {asa1}}
 		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
-			logic.Exp(1, "invalid Account reference"))
+			logic.Exp(1, "unavailable Account"))
 
 		// appl can acfg the asset from tx0 (which requires asset available, not holding)
 		appl.ApplicationArgs = [][]byte{{asa1}}
@@ -686,9 +686,9 @@ int 1
 		// and not to the receiver which isn't in afrz
 		appl.ApplicationArgs = [][]byte{receiverAcct[:], {asa1}}
 		logic.TestApps(t, []string{payToArg}, txntest.Group(&appl, &afrz), 9, ledger,
-			logic.Exp(0, "invalid Account reference "+receiverAcct.String()))
+			logic.Exp(0, "unavailable Account "+receiverAcct.String()))
 		logic.TestApps(t, []string{axferToArgs}, txntest.Group(&appl, &afrz), 9, ledger,
-			logic.Exp(0, "invalid Account reference "+receiverAcct.String()))
+			logic.Exp(0, "unavailable Account "+receiverAcct.String()))
 
 		// otherAcct is the afrz target, it's holding and account are available
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {asa1}}
@@ -728,7 +728,7 @@ int 1
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {asa1}}
 		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&appl0, &appl), 9, ledger)
 		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&appl0, &appl), 8, ledger, // version 8 does not get sharing
-			logic.Exp(1, "invalid Account reference "+otherAcct.String()))
+			logic.Exp(1, "unavailable Account "+otherAcct.String()))
 		// appl can (almost) axfer asa1 to the otherAcct because both are in tx0
 		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger,
 			logic.Exp(1, "axfer Sender: unavailable Holding"))
@@ -781,7 +781,7 @@ int 1
 		// when the inner program is v8, it can't perform the pay
 		appl.ApplicationArgs = [][]byte{{88}, otherAcct[:], {asa1}}
 		logic.TestApps(t, []string{"", innerCall}, txntest.Group(&appl0, &appl), 9, ledger,
-			logic.Exp(1, "invalid Account reference "+otherAcct.String()))
+			logic.Exp(1, "unavailable Account "+otherAcct.String()))
 		// unless the caller passes in the account, but it can't pass the
 		// account because that also would give the called app access to the
 		// passed account's local state (which isn't available to the caller)

--- a/data/transactions/logic/resources_test.go
+++ b/data/transactions/logic/resources_test.go
@@ -398,7 +398,7 @@ func TestOtherTxSharing(t *testing.T) {
 	pop; pop; int 1
 `
 
-	t.Run("keyreg", func(t *testing.T) {
+	t.Run("keyreg", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {200}}
 		logic.TestApps(t, []string{"", holdingAccess}, txntest.Group(&keyreg, &appl), 9, ledger,
 			logic.Exp(1, "unavailable Asset 200"))
@@ -407,7 +407,7 @@ func TestOtherTxSharing(t *testing.T) {
 		logic.TestApps(t, []string{"", holdingAccess}, txntest.Group(&keyreg, &withRef), 9, ledger,
 			logic.Exp(1, "unavailable Holding "+senderAcct.String()))
 	})
-	t.Run("pay", func(t *testing.T) {
+	t.Run("pay", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		// The receiver is available for algo balance reading
 		appl.ApplicationArgs = [][]byte{receiverAcct[:]}
 		logic.TestApps(t, []string{"", receiverBalance}, txntest.Group(&pay, &appl), 9, ledger)
@@ -423,14 +423,14 @@ func TestOtherTxSharing(t *testing.T) {
 		logic.TestApps(t, []string{"", otherBalance}, txntest.Group(&withClose, &appl), 9, ledger)
 	})
 
-	t.Run("acfg", func(t *testing.T) {
+	t.Run("acfg", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		// The other account is not available even though it's all the extra addresses
 		appl.ApplicationArgs = [][]byte{otherAcct[:]}
 		logic.TestApps(t, []string{"", otherBalance}, txntest.Group(&acfg, &appl), 9, ledger,
 			logic.Exp(1, "invalid Account reference "+otherAcct.String()))
 	})
 
-	t.Run("axfer", func(t *testing.T) {
+	t.Run("axfer", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		// The receiver is also available for algo balance reading
 		appl.ApplicationArgs = [][]byte{receiverAcct[:]}
 		logic.TestApps(t, []string{"", receiverBalance}, txntest.Group(&axfer, &appl), 9, ledger)
@@ -465,7 +465,7 @@ func TestOtherTxSharing(t *testing.T) {
 		logic.TestApps(t, []string{"", holdingAccess}, txntest.Group(&withClose, &appl), 9, ledger)
 	})
 
-	t.Run("afrz", func(t *testing.T) {
+	t.Run("afrz", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		// The other account is available (for algo and asset)
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {byte(afrz.FreezeAsset)}}
 		logic.TestApps(t, []string{"", otherBalance}, txntest.Group(&afrz, &appl), 9, ledger)
@@ -540,7 +540,7 @@ int 1
 	// And needs some ASAs for inner axfer testing
 	ledger.NewHolding(appAcct, asa1, 1_000_000, false)
 
-	t.Run("keyreg", func(t *testing.T) {
+	t.Run("keyreg", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		keyreg := txntest.Txn{
 			Type:   protocol.KeyRegistrationTx,
 			Sender: senderAcct,
@@ -558,7 +558,7 @@ int 1
 			logic.Exp(1, "unavailable Account "+receiverAcct.String()))
 	})
 
-	t.Run("pay", func(t *testing.T) {
+	t.Run("pay", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		pay := txntest.Txn{
 			Type:     protocol.PaymentTx,
 			Sender:   senderAcct,
@@ -582,7 +582,7 @@ int 1
 			logic.Exp(1, "unavailable Account "+otherAcct.String()))
 	})
 
-	t.Run("axfer", func(t *testing.T) {
+	t.Run("axfer", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		axfer := txntest.Txn{
 			Type:          protocol.AssetTransferTx,
 			XferAsset:     asa1,
@@ -658,7 +658,7 @@ int 1
 			logic.Exp(2, "unavailable Holding "+payAcct.String()))
 	})
 
-	t.Run("afrz", func(t *testing.T) {
+	t.Run("afrz", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		appl.ForeignAssets = []basics.AssetIndex{} // reset after previous tests
 		afrz := txntest.Txn{
 			Type:          protocol.AssetFreezeTx,
@@ -714,7 +714,7 @@ int 1
 
 	})
 
-	t.Run("appl", func(t *testing.T) {
+	t.Run("appl", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		appl.ForeignAssets = []basics.AssetIndex{} // reset after previous test
 		appl.Accounts = []basics.Address{}         // reset after previous tests
 		appl0 := txntest.Txn{

--- a/ledger/apptxn_test.go
+++ b/ledger/apptxn_test.go
@@ -3101,7 +3101,7 @@ itxn_submit
 		}
 
 		if ver <= 33 {
-			dl.txgroup("invalid Account reference", &fund0, &fund1, &callTx)
+			dl.txgroup("unavailable Account", &fund0, &fund1, &callTx)
 			return
 		}
 		payset = dl.txgroup("", &fund0, &fund1, &callTx)


### PR DESCRIPTION
Added some tests to get more coverage, deleted some dead code for the same reason.

Also regularized an error message about "Unavailable account"

## Test Plan

Ran coverage locally. Better.