### PR TITLE
draft: Refactor GenesisAccountData from AccountData

### DIFF
--- a/agreement/agreementtest/simulate_test.go
+++ b/agreement/agreementtest/simulate_test.go
@@ -320,10 +320,12 @@ func TestSimulate(t *testing.T) {
 	for _, account := range accs {
 		amount := basics.MicroAlgos{Raw: uint64(minMoneyAtStart + (gen.Int() % (maxMoneyAtStart - minMoneyAtStart)))}
 		genesis[account.Address()] = basics.AccountData{
-			Status:      basics.Online,
-			MicroAlgos:  amount,
-			SelectionID: account.VRFSecrets().PK,
-			VoteID:      account.VotingSecrets().OneTimeSignatureVerifier,
+			GenesisAccountData: basics.GenesisAccountData{
+				Status:      basics.Online,
+				MicroAlgos:  amount,
+				SelectionID: account.VRFSecrets().PK,
+				VoteID:      account.VotingSecrets().OneTimeSignatureVerifier,
+			},
 		}
 	}
 

--- a/agreement/common_test.go
+++ b/agreement/common_test.go
@@ -107,10 +107,12 @@ func generateEnvironment(numAccounts int) (map[basics.Address]basics.AccountData
 
 		startamt := uint64(minMoneyAtStart + (gen.Int() % (maxMoneyAtStart - minMoneyAtStart)))
 		genesis[addr] = basics.AccountData{
-			Status:      basics.Online,
-			MicroAlgos:  basics.MicroAlgos{Raw: startamt},
-			SelectionID: vrfSec.PK,
-			VoteID:      otSec.OneTimeSignatureVerifier,
+			GenesisAccountData: basics.GenesisAccountData{
+				Status:      basics.Online,
+				MicroAlgos:  basics.MicroAlgos{Raw: startamt},
+				SelectionID: vrfSec.PK,
+				VoteID:      otSec.OneTimeSignatureVerifier,
+			},
 		}
 		total.Raw += startamt
 	}

--- a/agreement/fuzzer/fuzzer_test.go
+++ b/agreement/fuzzer/fuzzer_test.go
@@ -218,10 +218,12 @@ func (n *Fuzzer) initAccountsAndBalances(rootSeed []byte, onlineNodes []bool) er
 		}
 
 		acctData := basics.AccountData{
-			Status:      basics.Online,
-			MicroAlgos:  stake,
-			VoteID:      n.accounts[i].VotingSecrets().OneTimeSignatureVerifier,
-			SelectionID: n.accounts[i].VRFSecrets().PK,
+			GenesisAccountData: basics.GenesisAccountData{
+				Status:      basics.Online,
+				MicroAlgos:  stake,
+				VoteID:      n.accounts[i].VotingSecrets().OneTimeSignatureVerifier,
+				SelectionID: n.accounts[i].VRFSecrets().PK,
+			},
 		}
 		if len(onlineNodes) > i {
 			if onlineNodes[i] == false {

--- a/agreement/service_test.go
+++ b/agreement/service_test.go
@@ -672,10 +672,12 @@ func createTestAccountsAndBalances(t *testing.T, numNodes int, rootSeed []byte) 
 
 		// expose balances for future ledger creation
 		acctData := basics.AccountData{
-			Status:      basics.Online,
-			MicroAlgos:  basics.MicroAlgos{Raw: 1000000},
-			VoteID:      accounts[i].VotingSecrets().OneTimeSignatureVerifier,
-			SelectionID: accounts[i].VRFSecrets().PK,
+			GenesisAccountData: basics.GenesisAccountData{
+				Status:      basics.Online,
+				MicroAlgos:  basics.MicroAlgos{Raw: 1000000},
+				VoteID:      accounts[i].VotingSecrets().OneTimeSignatureVerifier,
+				SelectionID: accounts[i].VRFSecrets().PK,
+			},
 		}
 		balances[rootAddress] = acctData
 	}

--- a/catchup/fetcher_test.go
+++ b/catchup/fetcher_test.go
@@ -45,16 +45,16 @@ func buildTestLedger(t *testing.T, blk bookkeeping.Block) (ledger *data.Ledger, 
 	user[0] = 123
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
-	genesis := make(map[basics.Address]basics.AccountData)
-	genesis[user] = basics.AccountData{
+	genesis := make(map[basics.Address]basics.GenesisAccountData)
+	genesis[user] = basics.GenesisAccountData{
 		Status:     basics.Online,
 		MicroAlgos: basics.MicroAlgos{Raw: proto.MinBalance * 2000000},
 	}
-	genesis[sinkAddr] = basics.AccountData{
+	genesis[sinkAddr] = basics.GenesisAccountData{
 		Status:     basics.Online,
 		MicroAlgos: basics.MicroAlgos{Raw: proto.MinBalance * 2000000},
 	}
-	genesis[poolAddr] = basics.AccountData{
+	genesis[poolAddr] = basics.GenesisAccountData{
 		Status:     basics.Online,
 		MicroAlgos: basics.MicroAlgos{Raw: proto.MinBalance * 2000000},
 	}

--- a/catchup/pref_test.go
+++ b/catchup/pref_test.go
@@ -96,7 +96,7 @@ func benchenv(t testing.TB, numAccounts, numBlocks int) (ledger, emptyLedger *da
 		}
 	}
 	// generate accounts
-	genesis := make(map[basics.Address]basics.AccountData)
+	genesis := make(map[basics.Address]basics.GenesisAccountData)
 	gen := rand.New(rand.NewSource(2))
 	parts := make([]account.Participation, P)
 	for i := 0; i < P; i++ {
@@ -121,7 +121,7 @@ func benchenv(t testing.TB, numAccounts, numBlocks int) (ledger, emptyLedger *da
 			panic(err)
 		}
 
-		startamt := basics.AccountData{
+		startamt := basics.GenesisAccountData{
 			Status:      basics.Online,
 			MicroAlgos:  basics.MicroAlgos{Raw: uint64(minMoneyAtStart + (gen.Uint64() % (maxMoneyAtStart - minMoneyAtStart)))},
 			SelectionID: part.VRFSecrets().PK,
@@ -134,11 +134,11 @@ func benchenv(t testing.TB, numAccounts, numBlocks int) (ledger, emptyLedger *da
 		part.Close()
 	}
 
-	genesis[basics.Address(sinkAddr)] = basics.AccountData{
+	genesis[basics.Address(sinkAddr)] = basics.GenesisAccountData{
 		Status:     basics.NotParticipating,
 		MicroAlgos: basics.MicroAlgos{Raw: uint64(1e3 * minMoneyAtStart)},
 	}
-	genesis[basics.Address(poolAddr)] = basics.AccountData{
+	genesis[basics.Address(poolAddr)] = basics.GenesisAccountData{
 		Status:     basics.NotParticipating,
 		MicroAlgos: basics.MicroAlgos{Raw: uint64(1e3 * minMoneyAtStart)},
 	}

--- a/cmd/incorporate/incorporate.go
+++ b/cmd/incorporate/incorporate.go
@@ -175,7 +175,7 @@ func parseInput() (genesis bookkeeping.Genesis) {
 		alloc := bookkeeping.GenesisAllocation{
 			Address: record.Address,
 			Comment: record.Comment,
-			State: basics.AccountData{
+			State: basics.GenesisAccountData{
 				Status:          record.Status,
 				MicroAlgos:      basics.MicroAlgos{Raw: record.Algos * 1e6},
 				VoteID:          record.VoteID,

--- a/cmd/tealdbg/local_test.go
+++ b/cmd/tealdbg/local_test.go
@@ -1237,7 +1237,9 @@ int 1`
 	br := basics.BalanceRecord{
 		Addr: sender,
 		AccountData: basics.AccountData{
-			MicroAlgos: basics.MicroAlgos{Raw: 5000000},
+			GenesisAccountData: basics.GenesisAccountData{
+				MicroAlgos: basics.MicroAlgos{Raw: 5000000},
+			},
 			AppParams: map[basics.AppIndex]basics.AppParams{
 				appIdx: {
 					ApprovalProgram:   prog,
@@ -1361,7 +1363,9 @@ byte 0x5ce9454909639d2d17a3f753ce7d93fa0b9ab12e // addr
 	br := basics.BalanceRecord{
 		Addr: sender,
 		AccountData: basics.AccountData{
-			MicroAlgos: basics.MicroAlgos{Raw: 5000000},
+			GenesisAccountData: basics.GenesisAccountData{
+				MicroAlgos: basics.MicroAlgos{Raw: 5000000},
+			},
 			AppParams: map[basics.AppIndex]basics.AppParams{
 				appIdx: {
 					ApprovalProgram:   prog,

--- a/daemon/algod/api/server/v2/account.go
+++ b/daemon/algod/api/server/v2/account.go
@@ -345,15 +345,17 @@ func AccountToAccountData(a *model.Account) (basics.AccountData, error) {
 	}
 
 	ad := basics.AccountData{
-		Status:             status,
-		MicroAlgos:         basics.MicroAlgos{Raw: a.Amount},
+		GenesisAccountData: basics.GenesisAccountData{
+			Status:          status,
+			MicroAlgos:      basics.MicroAlgos{Raw: a.Amount},
+			VoteID:          voteID,
+			SelectionID:     selID,
+			VoteFirstValid:  voteFirstValid,
+			VoteLastValid:   voteLastValid,
+			VoteKeyDilution: voteKeyDilution,
+		},
 		RewardsBase:        rewardsBase,
 		RewardedMicroAlgos: basics.MicroAlgos{Raw: a.Rewards},
-		VoteID:             voteID,
-		SelectionID:        selID,
-		VoteFirstValid:     voteFirstValid,
-		VoteLastValid:      voteLastValid,
-		VoteKeyDilution:    voteKeyDilution,
 		Assets:             assets,
 		AppLocalStates:     appLocalStates,
 		AppParams:          appParams,

--- a/daemon/algod/api/server/v2/account_test.go
+++ b/daemon/algod/api/server/v2/account_test.go
@@ -74,8 +74,10 @@ func TestAccount(t *testing.T) {
 	}
 	copy(assetParams2.MetadataHash[:], []byte("test2"))
 	a := basics.AccountData{
-		Status:             basics.Online,
-		MicroAlgos:         basics.MicroAlgos{Raw: 80000000},
+		GenesisAccountData: basics.GenesisAccountData{
+			Status:     basics.Online,
+			MicroAlgos: basics.MicroAlgos{Raw: 80000000},
+		},
 		RewardedMicroAlgos: basics.MicroAlgos{Raw: ^uint64(0)},
 		RewardsBase:        0,
 		AppParams:          map[basics.AppIndex]basics.AppParams{appIdx1: appParams1, appIdx2: appParams2},

--- a/daemon/algod/api/server/v2/test/helpers.go
+++ b/daemon/algod/api/server/v2/test/helpers.go
@@ -291,7 +291,7 @@ func testingenvWithBalances(t testing.TB, minMoneyAtStart, maxMoneyAtStart, numA
 	}
 
 	// generate accounts
-	genesis := make(map[basics.Address]basics.AccountData)
+	genesis := make(map[basics.Address]basics.GenesisAccountData)
 	gen := rand.New(rand.NewSource(2))
 	roots := make([]account.Root, P)
 	parts := make([]account.Participation, P)
@@ -325,9 +325,9 @@ func testingenvWithBalances(t testing.TB, minMoneyAtStart, maxMoneyAtStart, numA
 		short := root.Address()
 
 		if offlineAccounts && i > P/2 {
-			genesis[short] = basics_testing.MakeAccountData(basics.Offline, startamt)
+			genesis[short] = basics_testing.MakeAccountData(basics.Offline, startamt).GenesisAccountData
 		} else {
-			data := basics_testing.MakeAccountData(basics.Online, startamt)
+			data := basics_testing.MakeAccountData(basics.Online, startamt).GenesisAccountData
 			data.SelectionID = parts[i].VRFSecrets().PK
 			data.VoteID = parts[i].VotingSecrets().OneTimeSignatureVerifier
 			genesis[short] = data
@@ -335,7 +335,7 @@ func testingenvWithBalances(t testing.TB, minMoneyAtStart, maxMoneyAtStart, numA
 		part.Close()
 	}
 
-	genesis[poolAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 100000 * uint64(proto.RewardsRateRefreshInterval)})
+	genesis[poolAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 100000 * uint64(proto.RewardsRateRefreshInterval)}).GenesisAccountData
 
 	program := logic.Program(retOneProgram)
 	lhash := crypto.HashObj(&program)
@@ -343,7 +343,7 @@ func testingenvWithBalances(t testing.TB, minMoneyAtStart, maxMoneyAtStart, numA
 	copy(addr[:], lhash[:])
 	ad := basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 100000 * uint64(proto.RewardsRateRefreshInterval)})
 	ad.AppLocalStates = map[basics.AppIndex]basics.AppLocalState{1: {}}
-	genesis[addr] = ad
+	genesis[addr] = ad.GenesisAccountData
 
 	bootstrap := bookkeeping.MakeGenesisBalances(genesis, sinkAddr, poolAddr)
 

--- a/data/basics/testing/userBalance.go
+++ b/data/basics/testing/userBalance.go
@@ -22,7 +22,11 @@ import (
 
 // MakeAccountData returns a AccountData with non-empty voting fields for online accounts
 func MakeAccountData(status basics.Status, algos basics.MicroAlgos) basics.AccountData {
-	ad := basics.AccountData{Status: status, MicroAlgos: algos}
+	ad := basics.AccountData{
+		GenesisAccountData: basics.GenesisAccountData{
+			Status: status, MicroAlgos: algos,
+		},
+	}
 	if status == basics.Online {
 		ad.VoteFirstValid = 1
 		ad.VoteLastValid = 100_000

--- a/data/basics/userBalance.go
+++ b/data/basics/userBalance.go
@@ -111,6 +111,23 @@ type OnlineAccountData struct {
 	VotingData
 }
 
+// GenesisAccountData contains a subset of account information that is
+// present in the genesis file.
+type GenesisAccountData struct {
+	_struct struct{} `codec:",omitempty,omitemptyarray"`
+
+	Status     Status     `codec:"onl"`
+	MicroAlgos MicroAlgos `codec:"algo"`
+
+	VoteID       crypto.OneTimeSignatureVerifier `codec:"vote"`
+	SelectionID  crypto.VRFVerifier              `codec:"sel"`
+	StateProofID merklesignature.Commitment      `codec:"stprf"`
+
+	VoteFirstValid  Round  `codec:"voteFst"`
+	VoteLastValid   Round  `codec:"voteLst"`
+	VoteKeyDilution uint64 `codec:"voteKD"`
+}
+
 // AccountData contains the data associated with a given address.
 //
 // This includes the account balance, cryptographic public keys,
@@ -118,8 +135,9 @@ type OnlineAccountData struct {
 type AccountData struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	Status     Status     `codec:"onl"`
-	MicroAlgos MicroAlgos `codec:"algo"`
+	// GenesisAccountData contains a subset of account information that is
+	// relevant in the genesis file.
+	GenesisAccountData
 
 	// RewardsBase is used to implement rewards.
 	// This is not meaningful for accounts with Status=NotParticipating.
@@ -161,14 +179,6 @@ type AccountData struct {
 	// it won't answer the question "how many algos did I make in
 	// the past week".
 	RewardedMicroAlgos MicroAlgos `codec:"ern"`
-
-	VoteID       crypto.OneTimeSignatureVerifier `codec:"vote"`
-	SelectionID  crypto.VRFVerifier              `codec:"sel"`
-	StateProofID merklesignature.Commitment      `codec:"stprf"`
-
-	VoteFirstValid  Round  `codec:"voteFst"`
-	VoteLastValid   Round  `codec:"voteLst"`
-	VoteKeyDilution uint64 `codec:"voteKD"`
 
 	// If this account created an asset, AssetParams stores
 	// the parameters defining that asset.  The params are indexed

--- a/data/basics/userBalance_test.go
+++ b/data/basics/userBalance_test.go
@@ -44,8 +44,10 @@ func TestRewards(t *testing.T) {
 	accountAlgos := []MicroAlgos{{Raw: 0}, {Raw: 8000}, {Raw: 13000}, {Raw: 83000}}
 	for _, accountAlgo := range accountAlgos {
 		ad := AccountData{
-			Status:             Online,
-			MicroAlgos:         accountAlgo,
+			GenesisAccountData: GenesisAccountData{
+				Status:     Online,
+				MicroAlgos: accountAlgo,
+			},
 			RewardsBase:        100,
 			RewardedMicroAlgos: MicroAlgos{Raw: 25},
 		}
@@ -76,8 +78,10 @@ func TestWithUpdatedRewardsPanics(t *testing.T) {
 				}
 			}()
 			a := AccountData{
-				Status:             Online,
-				MicroAlgos:         MicroAlgos{Raw: ^uint64(0)},
+				GenesisAccountData: GenesisAccountData{
+					Status:     Online,
+					MicroAlgos: MicroAlgos{Raw: ^uint64(0)},
+				},
 				RewardedMicroAlgos: MicroAlgos{Raw: 0},
 				RewardsBase:        0,
 			}
@@ -88,8 +92,10 @@ func TestWithUpdatedRewardsPanics(t *testing.T) {
 
 	t.Run("RewardsOverflow", func(t *testing.T) {
 		a := AccountData{
-			Status:             Online,
-			MicroAlgos:         MicroAlgos{Raw: 80000000},
+			GenesisAccountData: GenesisAccountData{
+				Status:     Online,
+				MicroAlgos: MicroAlgos{Raw: 80000000},
+			},
 			RewardedMicroAlgos: MicroAlgos{Raw: ^uint64(0)},
 			RewardsBase:        0,
 		}
@@ -113,16 +119,18 @@ func getSampleAccountData() AccountData {
 	crypto.RandBytes(stateProofID[:])
 
 	return AccountData{
-		Status:             NotParticipating,
-		MicroAlgos:         MicroAlgos{},
+		GenesisAccountData: GenesisAccountData{
+			Status:          NotParticipating,
+			MicroAlgos:      MicroAlgos{},
+			VoteID:          oneTimeSecrets.OneTimeSignatureVerifier,
+			SelectionID:     vrfSecrets.PK,
+			StateProofID:    stateProofID,
+			VoteFirstValid:  Round(0x1234123412341234),
+			VoteLastValid:   Round(0x1234123412341234),
+			VoteKeyDilution: 0x1234123412341234,
+		},
 		RewardsBase:        0x1234123412341234,
 		RewardedMicroAlgos: MicroAlgos{},
-		VoteID:             oneTimeSecrets.OneTimeSignatureVerifier,
-		SelectionID:        vrfSecrets.PK,
-		StateProofID:       stateProofID,
-		VoteFirstValid:     Round(0x1234123412341234),
-		VoteLastValid:      Round(0x1234123412341234),
-		VoteKeyDilution:    0x1234123412341234,
 		AssetParams:        make(map[AssetIndex]AssetParams),
 		Assets:             make(map[AssetIndex]AssetHolding),
 		AppLocalStates:     make(map[AppIndex]AppLocalState),

--- a/data/bookkeeping/genesis.go
+++ b/data/bookkeeping/genesis.go
@@ -108,7 +108,7 @@ func (genesis Genesis) Hash() crypto.Digest {
 
 // Balances returns the genesis account balances.
 func (genesis Genesis) Balances() (GenesisBalances, error) {
-	genalloc := make(map[basics.Address]basics.AccountData)
+	genalloc := make(map[basics.Address]basics.GenesisAccountData)
 	for _, entry := range genesis.Allocation {
 		addr, err := basics.UnmarshalChecksumAddress(entry.Address)
 		if err != nil {
@@ -157,9 +157,9 @@ type GenesisAllocation struct {
 	// Address, Comment, and State fields..
 	_struct struct{} `codec:""`
 
-	Address string             `codec:"addr"`
-	Comment string             `codec:"comment"`
-	State   basics.AccountData `codec:"state"`
+	Address string                    `codec:"addr"`
+	Comment string                    `codec:"comment"`
+	State   basics.GenesisAccountData `codec:"state"`
 }
 
 // ToBeHashed impements the crypto.Hashable interface.
@@ -169,19 +169,19 @@ func (genesis Genesis) ToBeHashed() (protocol.HashID, []byte) {
 
 // GenesisBalances contains the information needed to generate a new ledger
 type GenesisBalances struct {
-	Balances    map[basics.Address]basics.AccountData
+	Balances    map[basics.Address]basics.GenesisAccountData
 	FeeSink     basics.Address
 	RewardsPool basics.Address
 	Timestamp   int64
 }
 
 // MakeGenesisBalances returns the information needed to bootstrap the ledger based on the current time
-func MakeGenesisBalances(balances map[basics.Address]basics.AccountData, feeSink, rewardsPool basics.Address) GenesisBalances {
+func MakeGenesisBalances(balances map[basics.Address]basics.GenesisAccountData, feeSink, rewardsPool basics.Address) GenesisBalances {
 	return MakeTimestampedGenesisBalances(balances, feeSink, rewardsPool, time.Now().Unix())
 }
 
 // MakeTimestampedGenesisBalances returns the information needed to bootstrap the ledger based on a given time
-func MakeTimestampedGenesisBalances(balances map[basics.Address]basics.AccountData, feeSink, rewardsPool basics.Address, timestamp int64) GenesisBalances {
+func MakeTimestampedGenesisBalances(balances map[basics.Address]basics.GenesisAccountData, feeSink, rewardsPool basics.Address, timestamp int64) GenesisBalances {
 	return GenesisBalances{Balances: balances, FeeSink: feeSink, RewardsPool: rewardsPool, Timestamp: timestamp}
 }
 

--- a/data/bookkeeping/genesis_test.go
+++ b/data/bookkeeping/genesis_test.go
@@ -50,7 +50,7 @@ func TestGenesis_Balances(t *testing.T) {
 			_struct: struct{}{},
 			Address: addr,
 			Comment: "",
-			State: basics.AccountData{
+			State: basics.GenesisAccountData{
 				MicroAlgos: basics.MicroAlgos{Raw: algos},
 			},
 		}
@@ -78,7 +78,7 @@ func TestGenesis_Balances(t *testing.T) {
 				RewardsPool: goodAddr.String(),
 			},
 			want: GenesisBalances{
-				Balances: map[basics.Address]basics.AccountData{
+				Balances: map[basics.Address]basics.GenesisAccountData{
 					mustAddr(allocation1.Address): allocation1.State,
 				},
 				FeeSink:     goodAddr,
@@ -95,7 +95,7 @@ func TestGenesis_Balances(t *testing.T) {
 				RewardsPool: goodAddr.String(),
 			},
 			want: GenesisBalances{
-				Balances: map[basics.Address]basics.AccountData{
+				Balances: map[basics.Address]basics.GenesisAccountData{
 					mustAddr(allocation1.Address): allocation1.State,
 					mustAddr(allocation2.Address): allocation2.State,
 				},

--- a/data/committee/common_test.go
+++ b/data/committee/common_test.go
@@ -79,11 +79,15 @@ func testingenvMoreKeys(t testing.TB, numAccounts, numTxs int, keyBatchesForward
 
 		startamt := uint64(minMoneyAtStart + (gen.Int() % (maxMoneyAtStart - minMoneyAtStart)))
 		short := addr
+		// Use AccountData here so it satisfies the interface that implements
+		// OnlineAccountData()
 		genesis[short] = basics.AccountData{
-			Status:      basics.Online,
-			MicroAlgos:  basics.MicroAlgos{Raw: startamt},
-			SelectionID: vrfSec.Pubkey(),
-			VoteID:      otSec.OneTimeSignatureVerifier,
+			GenesisAccountData: basics.GenesisAccountData{
+				Status:      basics.Online,
+				MicroAlgos:  basics.MicroAlgos{Raw: startamt},
+				SelectionID: vrfSec.Pubkey(),
+				VoteID:      otSec.OneTimeSignatureVerifier,
+			},
 		}
 		total.Raw += startamt
 	}

--- a/data/common_test.go
+++ b/data/common_test.go
@@ -70,7 +70,7 @@ func testingenv(t testing.TB, numAccounts, numTxs int, offlineAccounts bool) (*L
 	}
 
 	// generate accounts
-	genesis := make(map[basics.Address]basics.AccountData)
+	genesis := make(map[basics.Address]basics.GenesisAccountData)
 	gen := rand.New(rand.NewSource(2))
 	roots := make([]account.Root, P)
 	parts := make([]account.PersistedParticipation, P)
@@ -104,16 +104,16 @@ func testingenv(t testing.TB, numAccounts, numTxs int, offlineAccounts bool) (*L
 		short := root.Address()
 
 		if offlineAccounts && i > P/2 {
-			genesis[short] = basics_testing.MakeAccountData(basics.Offline, startamt)
+			genesis[short] = basics_testing.MakeAccountData(basics.Offline, startamt).GenesisAccountData
 		} else {
-			data := basics_testing.MakeAccountData(basics.Online, startamt)
+			data := basics_testing.MakeAccountData(basics.Online, startamt).GenesisAccountData
 			data.SelectionID = parts[i].VRFSecrets().PK
 			data.VoteID = parts[i].VotingSecrets().OneTimeSignatureVerifier
 			genesis[short] = data
 		}
 	}
 
-	genesis[poolAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 100000 * uint64(proto.RewardsRateRefreshInterval)})
+	genesis[poolAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 100000 * uint64(proto.RewardsRateRefreshInterval)}).GenesisAccountData
 
 	bootstrap := bookkeeping.MakeGenesisBalances(genesis, poolAddr, sinkAddr)
 

--- a/data/ledger.go
+++ b/data/ledger.go
@@ -84,7 +84,7 @@ func LoadLedger(
 	blockListeners []ledgercore.BlockListener, cfg config.Local,
 ) (*Ledger, error) {
 	if genesisBal.Balances == nil {
-		genesisBal.Balances = make(map[basics.Address]basics.AccountData)
+		genesisBal.Balances = make(map[basics.Address]basics.GenesisAccountData)
 	}
 	genBlock, err := bookkeeping.MakeGenesisBlock(genesisProto, genesisBal, genesisID, genesisHash)
 	if err != nil {

--- a/data/ledger_test.go
+++ b/data/ledger_test.go
@@ -71,7 +71,7 @@ func testGenerateInitState(tb testing.TB, proto protocol.ConsensusVersion) (gene
 	}
 
 	initKeys = make(map[basics.Address]*crypto.SignatureSecrets)
-	initAccounts := make(map[basics.Address]basics.AccountData)
+	initAccounts := make(map[basics.Address]basics.GenesisAccountData)
 	for i := range genaddrs {
 		initKeys[genaddrs[i]] = gensecrets[i]
 		// Give each account quite a bit more balance than MinFee or MinBalance
@@ -79,12 +79,12 @@ func testGenerateInitState(tb testing.TB, proto protocol.ConsensusVersion) (gene
 		if i%2 == 0 {
 			accountStatus = basics.NotParticipating
 		}
-		initAccounts[genaddrs[i]] = basics_testing.MakeAccountData(accountStatus, basics.MicroAlgos{Raw: uint64((i + 100) * 100000)})
+		initAccounts[genaddrs[i]] = basics_testing.MakeAccountData(accountStatus, basics.MicroAlgos{Raw: uint64((i + 100) * 100000)}).GenesisAccountData
 	}
 	initKeys[poolAddr] = poolSecret
-	initAccounts[poolAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 1234567})
+	initAccounts[poolAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 1234567}).GenesisAccountData
 	initKeys[sinkAddr] = sinkSecret
-	initAccounts[sinkAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 7654321})
+	initAccounts[sinkAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 7654321}).GenesisAccountData
 
 	incentivePoolBalanceAtGenesis := initAccounts[poolAddr].MicroAlgos
 	initialRewardsPerRound := incentivePoolBalanceAtGenesis.Raw / uint64(params.RewardsRateRefreshInterval)
@@ -500,9 +500,9 @@ func TestLedgerErrorValidate(t *testing.T) {
 	blk.FeeSink = testSinkAddr
 	blk.BlockHeader.GenesisHash = crypto.Hash([]byte(t.Name()))
 
-	accts := make(map[basics.Address]basics.AccountData)
-	accts[testPoolAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 0})
-	accts[testSinkAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 0})
+	accts := make(map[basics.Address]basics.GenesisAccountData)
+	accts[testPoolAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 0}).GenesisAccountData
+	accts[testSinkAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 0}).GenesisAccountData
 
 	genesisInitState := ledgercore.InitState{
 		Accounts:    accts,
@@ -615,7 +615,7 @@ func TestLedgerErrorValidate(t *testing.T) {
 	}
 
 	for rnd := basics.Round(1); rnd <= basics.Round(2000); rnd++ {
-		blk, err := getEmptyBlock(rnd-1, l.Ledger, t.Name(), genesisInitState.Accounts)
+		blk, err := getEmptyBlock(rnd-1, l.Ledger, t.Name())
 		require.NoError(t, err)
 		blkChan3 <- blk
 		blkChan2 <- blk
@@ -644,7 +644,7 @@ func validatedBlock(l *ledger.Ledger, blk bookkeeping.Block) (vb *ledgercore.Val
 	return
 }
 
-func getEmptyBlock(afterRound basics.Round, l *ledger.Ledger, genesisID string, initAccounts map[basics.Address]basics.AccountData) (blk bookkeeping.Block, err error) {
+func getEmptyBlock(afterRound basics.Round, l *ledger.Ledger, genesisID string) (blk bookkeeping.Block, err error) {
 	l.WaitForCommit(afterRound)
 
 	lastBlock, err := l.Block(l.Latest())

--- a/data/transactions/logic/ledger_test.go
+++ b/data/transactions/logic/ledger_test.go
@@ -908,7 +908,9 @@ func (l *Ledger) Get(addr basics.Address, withPendingRewards bool) (basics.Accou
 		return basics.AccountData{}, fmt.Errorf("no account %s", addr)
 	}
 	return basics.AccountData{
-		MicroAlgos:     basics.MicroAlgos{Raw: br.balance},
+		GenesisAccountData: basics.GenesisAccountData{
+			MicroAlgos: basics.MicroAlgos{Raw: br.balance},
+		},
 		AssetParams:    map[basics.AssetIndex]basics.AssetParams{},
 		Assets:         map[basics.AssetIndex]basics.AssetHolding{},
 		AppLocalStates: map[basics.AppIndex]basics.AppLocalState{},

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -68,22 +68,22 @@ type txHandlerConfig struct {
 	enableFilteringCanonical bool
 }
 
-func makeTestGenesisAccounts(tb testing.TB, numUsers int) ([]basics.Address, []*crypto.SignatureSecrets, map[basics.Address]basics.AccountData) {
+func makeTestGenesisAccounts(tb testing.TB, numUsers int) ([]basics.Address, []*crypto.SignatureSecrets, map[basics.Address]basics.GenesisAccountData) {
 	addresses := make([]basics.Address, numUsers)
 	secrets := make([]*crypto.SignatureSecrets, numUsers)
-	genesis := make(map[basics.Address]basics.AccountData)
+	genesis := make(map[basics.Address]basics.GenesisAccountData)
 	for i := 0; i < numUsers; i++ {
 		secret := keypair()
 		addr := basics.Address(secret.SignatureVerifier)
 		secrets[i] = secret
 		addresses[i] = addr
-		genesis[addr] = basics.AccountData{
+		genesis[addr] = basics.GenesisAccountData{
 			Status:     basics.Online,
 			MicroAlgos: basics.MicroAlgos{Raw: 10000000000000},
 		}
 	}
 
-	genesis[poolAddr] = basics.AccountData{
+	genesis[poolAddr] = basics.GenesisAccountData{
 		Status:     basics.NotParticipating,
 		MicroAlgos: basics.MicroAlgos{Raw: config.Consensus[protocol.ConsensusCurrentVersion].MinBalance},
 	}
@@ -1603,7 +1603,7 @@ type txGenerator struct {
 
 	addresses []basics.Address
 	secrets   []*crypto.SignatureSecrets
-	genesis   map[basics.Address]basics.AccountData
+	genesis   map[basics.Address]basics.GenesisAccountData
 }
 
 type sigGenerator struct {
@@ -2153,7 +2153,7 @@ func TestTxHandlerRememberReportErrorsWithTxPool(t *testing.T) { //nolint:parall
 	log.SetLevel(logging.Warn)
 
 	const numAccts = 2
-	genesis := make(map[basics.Address]basics.AccountData, numAccts+1)
+	genesis := make(map[basics.Address]basics.GenesisAccountData, numAccts+1)
 	addresses := make([]basics.Address, numAccts)
 	secrets := make([]*crypto.SignatureSecrets, numAccts)
 
@@ -2162,12 +2162,12 @@ func TestTxHandlerRememberReportErrorsWithTxPool(t *testing.T) { //nolint:parall
 		addr := basics.Address(secret.SignatureVerifier)
 		secrets[i] = secret
 		addresses[i] = addr
-		genesis[addr] = basics.AccountData{
+		genesis[addr] = basics.GenesisAccountData{
 			Status:     basics.Online,
 			MicroAlgos: basics.MicroAlgos{Raw: 10000000000000},
 		}
 	}
-	genesis[poolAddr] = basics.AccountData{
+	genesis[poolAddr] = basics.GenesisAccountData{
 		Status:     basics.NotParticipating,
 		MicroAlgos: basics.MicroAlgos{Raw: config.Consensus[protocol.ConsensusCurrentVersion].MinBalance},
 	}
@@ -2392,18 +2392,18 @@ func TestTxHandlerRestartWithBacklogAndTxPool(t *testing.T) { //nolint:parallelt
 	logging.Base().SetLevel(logging.Error)
 
 	// prepare the accounts
-	genesis := make(map[basics.Address]basics.AccountData)
+	genesis := make(map[basics.Address]basics.GenesisAccountData)
 	for i := 0; i < numUsers; i++ {
 		secret := keypair()
 		addr := basics.Address(secret.SignatureVerifier)
 		secrets[i] = secret
 		addresses[i] = addr
-		genesis[addr] = basics.AccountData{
+		genesis[addr] = basics.GenesisAccountData{
 			Status:     basics.Online,
 			MicroAlgos: basics.MicroAlgos{Raw: 10000000000000},
 		}
 	}
-	genesis[poolAddr] = basics.AccountData{
+	genesis[poolAddr] = basics.GenesisAccountData{
 		Status:     basics.NotParticipating,
 		MicroAlgos: basics.MicroAlgos{Raw: config.Consensus[protocol.ConsensusCurrentVersion].MinBalance},
 	}

--- a/gen/generate.go
+++ b/gen/generate.go
@@ -346,13 +346,17 @@ func generateGenesisFiles(protoVersion protocol.ConsensusVersion, protoParams co
 	}
 
 	records["FeeSink"] = basics.AccountData{
-		Status:     basics.NotParticipating,
-		MicroAlgos: basics.MicroAlgos{Raw: protoParams.MinBalance},
+		GenesisAccountData: basics.GenesisAccountData{
+			Status:     basics.NotParticipating,
+			MicroAlgos: basics.MicroAlgos{Raw: protoParams.MinBalance},
+		},
 	}
 
 	records["RewardsPool"] = basics.AccountData{
-		Status:     basics.NotParticipating,
-		MicroAlgos: basics.MicroAlgos{Raw: rewardsBalance},
+		GenesisAccountData: basics.GenesisAccountData{
+			Status:     basics.NotParticipating,
+			MicroAlgos: basics.MicroAlgos{Raw: rewardsBalance},
+		},
 	}
 
 	// Add FeeSink and RewardsPool to allocation slice to be handled with other allocations.
@@ -385,7 +389,7 @@ func generateGenesisFiles(protoVersion protocol.ConsensusVersion, protoParams co
 		g.Allocation = append(g.Allocation, bookkeeping.GenesisAllocation{
 			Address: genesisAddrs[wallet.Name].String(),
 			Comment: wallet.Name,
-			State:   walletData,
+			State:   walletData.GenesisAccountData,
 		})
 	}
 

--- a/ledger/acctdeltas_test.go
+++ b/ledger/acctdeltas_test.go
@@ -562,16 +562,18 @@ func generateRandomTestingAccountBalances(numAccounts int) (updates map[basics.A
 	for i := 0; i < numAccounts; i++ {
 		addr := ledgertesting.RandomAddress()
 		updates[addr] = basics.AccountData{
-			MicroAlgos:         basics.MicroAlgos{Raw: 0x000ffffffffffffff / uint64(numAccounts)},
-			Status:             basics.NotParticipating,
+			GenesisAccountData: basics.GenesisAccountData{
+				MicroAlgos:      basics.MicroAlgos{Raw: 0x000ffffffffffffff / uint64(numAccounts)},
+				Status:          basics.NotParticipating,
+				VoteID:          secrets.OneTimeSignatureVerifier,
+				SelectionID:     pubVrfKey,
+				StateProofID:    stateProofID.Commitment,
+				VoteFirstValid:  basics.Round(0x000ffffffffffffff),
+				VoteLastValid:   basics.Round(0x000ffffffffffffff),
+				VoteKeyDilution: 0x000ffffffffffffff,
+			},
 			RewardsBase:        uint64(i),
 			RewardedMicroAlgos: basics.MicroAlgos{Raw: 0x000ffffffffffffff / uint64(numAccounts)},
-			VoteID:             secrets.OneTimeSignatureVerifier,
-			SelectionID:        pubVrfKey,
-			StateProofID:       stateProofID.Commitment,
-			VoteFirstValid:     basics.Round(0x000ffffffffffffff),
-			VoteLastValid:      basics.Round(0x000ffffffffffffff),
-			VoteKeyDilution:    0x000ffffffffffffff,
 			AssetParams: map[basics.AssetIndex]basics.AssetParams{
 				0x000ffffffffffffff: {
 					Total:         0x000ffffffffffffff,

--- a/ledger/acctonline_test.go
+++ b/ledger/acctonline_test.go
@@ -1389,8 +1389,10 @@ func TestAcctOnlineTop(t *testing.T) {
 		allAccts[i] = basics.BalanceRecord{
 			Addr: ledgertesting.RandomAddress(),
 			AccountData: basics.AccountData{
-				MicroAlgos:  basics.MicroAlgos{Raw: uint64(i + 1)},
-				Status:      basics.Offline,
+				GenesisAccountData: basics.GenesisAccountData{
+					MicroAlgos: basics.MicroAlgos{Raw: uint64(i + 1)},
+					Status:     basics.Offline,
+				},
 				RewardsBase: 0},
 		}
 		genesisAccts[0][allAccts[i].Addr] = allAccts[i].AccountData
@@ -1399,11 +1401,13 @@ func TestAcctOnlineTop(t *testing.T) {
 		allAccts[i] = basics.BalanceRecord{
 			Addr: ledgertesting.RandomAddress(),
 			AccountData: basics.AccountData{
-				MicroAlgos:     basics.MicroAlgos{Raw: uint64(i + 1)},
-				Status:         basics.Online,
-				VoteLastValid:  1000,
-				VoteFirstValid: 0,
-				RewardsBase:    0},
+				GenesisAccountData: basics.GenesisAccountData{
+					MicroAlgos:     basics.MicroAlgos{Raw: uint64(i + 1)},
+					Status:         basics.Online,
+					VoteLastValid:  1000,
+					VoteFirstValid: 0,
+				},
+				RewardsBase: 0},
 		}
 		genesisAccts[0][allAccts[i].Addr] = allAccts[i].AccountData
 	}
@@ -1411,8 +1415,10 @@ func TestAcctOnlineTop(t *testing.T) {
 	allAccts[i] = basics.BalanceRecord{
 		Addr: ledgertesting.RandomAddress(),
 		AccountData: basics.AccountData{
-			MicroAlgos:  basics.MicroAlgos{Raw: uint64(100000)},
-			Status:      basics.Offline,
+			GenesisAccountData: basics.GenesisAccountData{
+				MicroAlgos: basics.MicroAlgos{Raw: uint64(100000)},
+				Status:     basics.Offline,
+			},
 			RewardsBase: 0},
 	}
 	genesisAccts[0][allAccts[i].Addr] = allAccts[i].AccountData
@@ -1512,11 +1518,13 @@ func TestAcctOnlineTopInBatches(t *testing.T) {
 		allAccts[i] = basics.BalanceRecord{
 			Addr: intToAddress(i + 1),
 			AccountData: basics.AccountData{
-				MicroAlgos:     basics.MicroAlgos{Raw: uint64(i + 1)},
-				Status:         basics.Online,
-				VoteLastValid:  basics.Round(i + 1),
-				VoteFirstValid: 0,
-				RewardsBase:    0},
+				GenesisAccountData: basics.GenesisAccountData{
+					MicroAlgos:     basics.MicroAlgos{Raw: uint64(i + 1)},
+					Status:         basics.Online,
+					VoteLastValid:  basics.Round(i + 1),
+					VoteFirstValid: 0,
+				},
+				RewardsBase: 0},
 		}
 		genesisAccts[0][allAccts[i].Addr] = allAccts[i].AccountData
 	}
@@ -1586,11 +1594,13 @@ func TestAcctOnlineTopBetweenCommitAndPostCommit(t *testing.T) {
 		allAccts[i] = basics.BalanceRecord{
 			Addr: ledgertesting.RandomAddress(),
 			AccountData: basics.AccountData{
-				MicroAlgos:     basics.MicroAlgos{Raw: uint64(i + 1)},
-				Status:         basics.Online,
-				VoteLastValid:  1000,
-				VoteFirstValid: 0,
-				RewardsBase:    0},
+				GenesisAccountData: basics.GenesisAccountData{
+					MicroAlgos:     basics.MicroAlgos{Raw: uint64(i + 1)},
+					Status:         basics.Online,
+					VoteLastValid:  1000,
+					VoteFirstValid: 0,
+				},
+				RewardsBase: 0},
 		}
 		genesisAccts[0][allAccts[i].Addr] = allAccts[i].AccountData
 	}
@@ -1679,11 +1689,13 @@ func TestAcctOnlineTopDBBehindMemRound(t *testing.T) {
 		allAccts[i] = basics.BalanceRecord{
 			Addr: ledgertesting.RandomAddress(),
 			AccountData: basics.AccountData{
-				MicroAlgos:     basics.MicroAlgos{Raw: uint64(i + 1)},
-				Status:         basics.Online,
-				VoteLastValid:  1000,
-				VoteFirstValid: 0,
-				RewardsBase:    0},
+				GenesisAccountData: basics.GenesisAccountData{
+					MicroAlgos:     basics.MicroAlgos{Raw: uint64(i + 1)},
+					Status:         basics.Online,
+					VoteLastValid:  1000,
+					VoteFirstValid: 0,
+				},
+				RewardsBase: 0},
 		}
 		genesisAccts[0][allAccts[i].Addr] = allAccts[i].AccountData
 	}
@@ -1772,11 +1784,13 @@ func TestAcctOnlineTop_ChangeOnlineStake(t *testing.T) {
 		allAccts[i] = basics.BalanceRecord{
 			Addr: ledgertesting.RandomAddress(),
 			AccountData: basics.AccountData{
-				MicroAlgos:     basics.MicroAlgos{Raw: uint64(i + 1)},
-				Status:         basics.Online,
-				VoteLastValid:  1000,
-				VoteFirstValid: 0,
-				RewardsBase:    0},
+				GenesisAccountData: basics.GenesisAccountData{
+					MicroAlgos:     basics.MicroAlgos{Raw: uint64(i + 1)},
+					Status:         basics.Online,
+					VoteLastValid:  1000,
+					VoteFirstValid: 0,
+				},
+				RewardsBase: 0},
 		}
 		genesisAccts[0][allAccts[i].Addr] = allAccts[i].AccountData
 	}
@@ -1784,11 +1798,13 @@ func TestAcctOnlineTop_ChangeOnlineStake(t *testing.T) {
 	allAccts[numAccts-1] = basics.BalanceRecord{
 		Addr: ledgertesting.RandomAddress(),
 		AccountData: basics.AccountData{
-			MicroAlgos:     basics.MicroAlgos{Raw: uint64(numAccts)},
-			Status:         basics.Online,
-			VoteLastValid:  1,
-			VoteFirstValid: 0,
-			RewardsBase:    0},
+			GenesisAccountData: basics.GenesisAccountData{
+				MicroAlgos:     basics.MicroAlgos{Raw: uint64(numAccts)},
+				Status:         basics.Online,
+				VoteLastValid:  1,
+				VoteFirstValid: 0,
+			},
+			RewardsBase: 0},
 	}
 	genesisAccts[0][allAccts[numAccts-1].Addr] = allAccts[numAccts-1].AccountData
 	acctInvalidFromRnd2 := allAccts[numAccts-1]
@@ -1906,11 +1922,13 @@ func TestAcctOnline_ExpiredOnlineCirculation(t *testing.T) {
 		allAccts[i] = basics.BalanceRecord{
 			Addr: ledgertesting.RandomAddress(),
 			AccountData: basics.AccountData{
-				MicroAlgos:     basics.MicroAlgos{Raw: uint64(stake)},
-				Status:         basics.Online,
-				VoteLastValid:  10000,
-				VoteFirstValid: 0,
-				RewardsBase:    0},
+				GenesisAccountData: basics.GenesisAccountData{
+					MicroAlgos:     basics.MicroAlgos{Raw: uint64(stake)},
+					Status:         basics.Online,
+					VoteLastValid:  10000,
+					VoteFirstValid: 0,
+				},
+				RewardsBase: 0},
 		}
 		genesisAccts[0][allAccts[i].Addr] = allAccts[i].AccountData
 		totalStake = algops.Add(totalStake, allAccts[i].MicroAlgos)

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -280,7 +280,7 @@ func (ml *mockLedgerForTracker) GenesisProtoVersion() protocol.ConsensusVersion 
 	return ml.consensusVersion
 }
 
-func (ml *mockLedgerForTracker) GenesisAccounts() map[basics.Address]basics.AccountData {
+func (ml *mockLedgerForTracker) GenesisAccounts() map[basics.Address]basics.GenesisAccountData {
 	return ml.accts
 }
 

--- a/ledger/apply/asset_test.go
+++ b/ledger/apply/asset_test.go
@@ -66,7 +66,9 @@ func TestAssetTransfer(t *testing.T) {
 	// prepare data
 	var addrs = map[basics.Address]basics.AccountData{
 		src: {
-			MicroAlgos: basics.MicroAlgos{Raw: 10000000},
+			GenesisAccountData: basics.GenesisAccountData{
+				MicroAlgos: basics.MicroAlgos{Raw: 10000000},
+			},
 			AssetParams: map[basics.AssetIndex]basics.AssetParams{
 				1: {Total: total},
 			},
@@ -75,13 +77,17 @@ func TestAssetTransfer(t *testing.T) {
 			},
 		},
 		dst: {
-			MicroAlgos: basics.MicroAlgos{Raw: 10000000},
+			GenesisAccountData: basics.GenesisAccountData{
+				MicroAlgos: basics.MicroAlgos{Raw: 10000000},
+			},
 			Assets: map[basics.AssetIndex]basics.AssetHolding{
 				1: {Amount: dstAmount},
 			},
 		},
 		cls: {
-			MicroAlgos: basics.MicroAlgos{Raw: 10000000},
+			GenesisAccountData: basics.GenesisAccountData{
+				MicroAlgos: basics.MicroAlgos{Raw: 10000000},
+			},
 			Assets: map[basics.AssetIndex]basics.AssetHolding{
 				1: {Amount: 0},
 			},

--- a/ledger/apply/keyreg_test.go
+++ b/ledger/apply/keyreg_test.go
@@ -135,7 +135,9 @@ func TestKeyregApply(t *testing.T) {
 	mockBal := newKeyregTestBalances()
 
 	// Going from offline to online should be okay
-	mockBal.addrs[src] = basics.AccountData{Status: basics.Offline}
+	mockBal.addrs[src] = basics.AccountData{
+		GenesisAccountData: basics.GenesisAccountData{Status: basics.Offline},
+	}
 	err = Keyreg(tx.KeyregTxnFields, tx.Header, mockBal, transactions.SpecialAddresses{FeeSink: feeSink}, nil, basics.Round(0))
 	require.NoError(t, err)
 
@@ -147,7 +149,9 @@ func TestKeyregApply(t *testing.T) {
 		require.NoError(t, err)
 
 		// Nonparticipatory accounts should not be able to change status
-		mockBal.addrs[src] = basics.AccountData{Status: basics.NotParticipating}
+		mockBal.addrs[src] = basics.AccountData{
+			GenesisAccountData: basics.GenesisAccountData{Status: basics.NotParticipating},
+		}
 		err = Keyreg(tx.KeyregTxnFields, tx.Header, mockBal, transactions.SpecialAddresses{FeeSink: feeSink}, nil, basics.Round(0))
 		require.Error(t, err)
 	}
@@ -170,7 +174,9 @@ func TestKeyregApply(t *testing.T) {
 				VoteLast:        1000,
 			},
 		}
-		mockBal.addrs[src] = basics.AccountData{Status: basics.Offline}
+		mockBal.addrs[src] = basics.AccountData{
+			GenesisAccountData: basics.GenesisAccountData{Status: basics.Offline},
+		}
 		err = Keyreg(tx.KeyregTxnFields, tx.Header, mockBal, transactions.SpecialAddresses{FeeSink: feeSink}, nil, basics.Round(999))
 		require.NoError(t, err)
 

--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -100,7 +100,7 @@ func (wl *wrappedLedger) GenesisProtoVersion() protocol.ConsensusVersion {
 	return wl.l.GenesisProtoVersion()
 }
 
-func (wl *wrappedLedger) GenesisAccounts() map[basics.Address]basics.AccountData {
+func (wl *wrappedLedger) GenesisAccounts() map[basics.Address]basics.GenesisAccountData {
 	return wl.l.GenesisAccounts()
 }
 
@@ -110,9 +110,9 @@ func getInitState() (genesisInitState ledgercore.InitState) {
 	blk.RewardsPool = testPoolAddr
 	blk.FeeSink = testSinkAddr
 
-	accts := make(map[basics.Address]basics.AccountData)
-	accts[testPoolAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 1234567890})
-	accts[testSinkAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 1234567890})
+	accts := make(map[basics.Address]basics.GenesisAccountData)
+	accts[testPoolAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 1234567890}).GenesisAccountData
+	accts[testSinkAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 1234567890}).GenesisAccountData
 
 	genesisInitState.Accounts = accts
 	genesisInitState.Block = blk
@@ -355,7 +355,7 @@ func TestArchivalCreatables(t *testing.T) {
 		_, err := rand.Read(creator[:])
 		require.NoError(t, err)
 		creators = append(creators, creator)
-		genesisInitState.Accounts[creator] = basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1234567890})
+		genesisInitState.Accounts[creator] = basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1234567890}).GenesisAccountData
 	}
 
 	// open ledger
@@ -686,7 +686,7 @@ func TestArchivalFromNonArchival(t *testing.T) {
 		_, err := rand.Read(addr[:])
 		require.NoError(t, err)
 		br := basics.BalanceRecord{AccountData: basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1234567890}), Addr: addr}
-		genesisInitState.Accounts[addr] = br.AccountData
+		genesisInitState.Accounts[addr] = br.AccountData.GenesisAccountData
 		balanceRecords = append(balanceRecords, br)
 	}
 

--- a/ledger/eval/appcow_test.go
+++ b/ledger/eval/appcow_test.go
@@ -1089,7 +1089,11 @@ func TestCowGet(t *testing.T) {
 	c := getCow([]modsData{{addr, basics.CreatableIndex(aidx), basics.AppCreatable}})
 
 	addr1 := ledgertesting.RandomAddress()
-	bre := basics.AccountData{MicroAlgos: basics.MicroAlgos{Raw: 100}}
+	bre := basics.AccountData{
+		GenesisAccountData: basics.GenesisAccountData{
+			MicroAlgos: basics.MicroAlgos{Raw: 100},
+		},
+	}
 	c.mods.Accts.Upsert(addr1, ledgercore.ToAccountData(bre))
 
 	bra, err := c.Get(addr1, true)

--- a/ledger/eval/eval_test.go
+++ b/ledger/eval/eval_test.go
@@ -279,7 +279,7 @@ func TestTransactionGroupWithTracer(t *testing.T) {
 			innerAppID := basics.AppIndex(1003)
 			innerAppAddress := innerAppID.Address()
 			balances := genesisInitState.Accounts
-			balances[innerAppAddress] = basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1_000_000})
+			balances[innerAppAddress] = basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1_000_000}).GenesisAccountData
 
 			genesisBalances := bookkeeping.GenesisBalances{
 				Balances:    balances,
@@ -354,7 +354,7 @@ int 1`,
 				GenesisHash: genHash,
 			}
 
-			expectedFeeSinkDataForScenario := ledgercore.ToAccountData(balances[testSinkAddr])
+			expectedFeeSinkDataForScenario := ledgercore.ToAccountDataFromGenesisAccountData(balances[testSinkAddr])
 			expectedFeeSinkDataForScenario.MicroAlgos.Raw += basicAppCallTxn.Txn().Fee.Raw
 			if testCase.firstTxnBehavior == "approve" {
 				expectedFeeSinkDataForScenario.MicroAlgos.Raw += payTxn.Txn().Fee.Raw
@@ -362,8 +362,8 @@ int 1`,
 
 			scenario := testCase.innerAppCallScenario(mocktracer.TestScenarioInfo{
 				CallingTxn:     innerAppCallTxn.Txn(),
-				SenderData:     ledgercore.ToAccountData(balances[addrs[4]]),
-				AppAccountData: ledgercore.ToAccountData(balances[innerAppAddress]),
+				SenderData:     ledgercore.ToAccountDataFromGenesisAccountData(balances[addrs[4]]),
+				AppAccountData: ledgercore.ToAccountDataFromGenesisAccountData(balances[innerAppAddress]),
 				FeeSinkData:    expectedFeeSinkDataForScenario,
 				FeeSinkAddr:    testSinkAddr,
 				MinFee:         minFee,
@@ -434,9 +434,9 @@ int 1`,
 					},
 				}
 
-			expectedFeeSinkData := ledgercore.ToAccountData(balances[testSinkAddr])
+			expectedFeeSinkData := ledgercore.ToAccountDataFromGenesisAccountData(balances[testSinkAddr])
 			expectedFeeSinkData.MicroAlgos.Raw += txgroup[0].Txn.Fee.Raw
-			expectedAcct0Data := ledgercore.ToAccountData(balances[addrs[0]])
+			expectedAcct0Data := ledgercore.ToAccountDataFromGenesisAccountData(balances[addrs[0]])
 			expectedAcct0Data.MicroAlgos.Raw -= txgroup[0].Txn.Fee.Raw
 			expectedAcct0Data.TotalAppParams = 1
 
@@ -490,9 +490,9 @@ int 1`,
 				require.NoError(t, err)
 
 				expectedAcct1Data := ledgercore.AccountData{}
-				expectedAcct2Data := ledgercore.ToAccountData(balances[addrs[2]])
+				expectedAcct2Data := ledgercore.ToAccountDataFromGenesisAccountData(balances[addrs[2]])
 				expectedAcct2Data.MicroAlgos.Raw += payTxn.Amount
-				expectedAcct3Data := ledgercore.ToAccountData(balances[addrs[3]])
+				expectedAcct3Data := ledgercore.ToAccountDataFromGenesisAccountData(balances[addrs[3]])
 				expectedAcct3Data.MicroAlgos.Raw += expectedPayTxnAD.ClosingAmount.Raw
 				expectedFeeSinkData.MicroAlgos.Raw += txgroup[1].Txn.Fee.Raw
 
@@ -624,7 +624,7 @@ func testnetFixupExecution(t *testing.T, headerRound basics.Round, poolBonus uin
 	genesisInitState.Block.BlockHeader.GenesisID = "testnet"
 	genesisInitState.GenesisHash = testnetGenesisHash
 
-	rewardPoolBalance := ledgercore.ToAccountData(genesisInitState.Accounts[testPoolAddr])
+	rewardPoolBalance := ledgercore.ToAccountDataFromGenesisAccountData(genesisInitState.Accounts[testPoolAddr])
 	nextPoolBalance := rewardPoolBalance.MicroAlgos.Raw + poolBonus
 
 	l := newTestLedger(t, bookkeeping.GenesisBalances{
@@ -689,7 +689,7 @@ func newTestGenesis() (bookkeeping.GenesisBalances, []basics.Address, []*crypto.
 	const count = 10
 	addrs := make([]basics.Address, count)
 	secrets := make([]*crypto.SignatureSecrets, count)
-	accts := make(map[basics.Address]basics.AccountData)
+	accts := make(map[basics.Address]basics.GenesisAccountData)
 
 	// 10 billion microalgos, across N accounts and pool and sink
 	amount := 10 * 1000000000 * 1000000 / uint64(count+2)
@@ -701,18 +701,18 @@ func newTestGenesis() (bookkeeping.GenesisBalances, []basics.Address, []*crypto.
 		secrets[i] = crypto.GenerateSignatureSecrets(seed)
 		addrs[i] = basics.Address(secrets[i].SignatureVerifier)
 
-		adata := basics.AccountData{
+		adata := basics.GenesisAccountData{
 			MicroAlgos: basics.MicroAlgos{Raw: amount},
 		}
 		accts[addrs[i]] = adata
 	}
 
-	accts[sink] = basics.AccountData{
+	accts[sink] = basics.GenesisAccountData{
 		MicroAlgos: basics.MicroAlgos{Raw: amount},
 		Status:     basics.NotParticipating,
 	}
 
-	accts[rewards] = basics.AccountData{
+	accts[rewards] = basics.GenesisAccountData{
 		MicroAlgos: basics.MicroAlgos{Raw: amount},
 	}
 
@@ -734,6 +734,21 @@ type evalTestLedger struct {
 	boxes               map[string][]byte
 }
 
+// convertGenesisAccountDataMapToAccountDataMap converts a map of
+// GenesisAccountData to AccountData
+func convertGenesisAccountDataMapToAccountDataMap(mgad map[basics.Address]basics.GenesisAccountData) map[basics.Address]basics.AccountData {
+	mad := make(map[basics.Address]basics.AccountData)
+	for addr, data := range mgad {
+		mad[addr] = basics.AccountData{
+			GenesisAccountData: basics.GenesisAccountData{
+				MicroAlgos: data.MicroAlgos,
+				Status:     data.Status,
+			},
+		}
+	}
+	return mad
+}
+
 // newTestLedger creates a in memory Ledger that is as realistic as
 // possible.  It has Rewards and FeeSink properly configured.
 func newTestLedger(t testing.TB, balances bookkeeping.GenesisBalances) *evalTestLedger {
@@ -753,13 +768,13 @@ func newTestLedger(t testing.TB, balances bookkeeping.GenesisBalances) *evalTest
 	genBlock, err := bookkeeping.MakeGenesisBlock(protoVersion,
 		balances, "test", l.genesisHash)
 	require.NoError(t, err)
-	l.roundBalances[0] = balances.Balances
+	l.roundBalances[0] = convertGenesisAccountDataMapToAccountDataMap(balances.Balances)
 	l.blocks[0] = genBlock
 
 	// calculate the accounts totals.
 	var ot basics.OverflowTracker
 	for _, acctData := range balances.Balances {
-		l.latestTotals.AddAccount(proto, ledgercore.ToAccountData(acctData), &ot)
+		l.latestTotals.AddAccount(proto, ledgercore.ToAccountDataFromGenesisAccountData(acctData), &ot)
 	}
 	l.genesisProto = proto
 	l.genesisProtoVersion = protoVersion

--- a/ledger/eval/txntracer_test.go
+++ b/ledger/eval/txntracer_test.go
@@ -81,8 +81,8 @@ func TestTransactionGroupWithDeltaTracer(t *testing.T) {
 			innerBoxAppID := basics.AppIndex(7) + offset
 			innerBoxAppAddress := innerBoxAppID.Address()
 			balances := genesisInitState.Accounts
-			balances[innerAppAddress] = basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1_000_000})
-			balances[appAddress] = basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1_000_000})
+			balances[innerAppAddress] = basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1_000_000}).GenesisAccountData
+			balances[appAddress] = basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1_000_000}).GenesisAccountData
 
 			genesisBalances := bookkeeping.GenesisBalances{
 				Balances:    genesisInitState.Accounts,

--- a/ledger/fullblock_perf_test.go
+++ b/ledger/fullblock_perf_test.go
@@ -82,7 +82,7 @@ func setupEnv(b *testing.B, numAccts int) (bc *benchConfig) {
 	creator := basics.Address{}
 	_, err := rand.Read(creator[:])
 	require.NoError(b, err)
-	genesisInitState.Accounts[creator] = basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1234567890000000000})
+	genesisInitState.Accounts[creator] = basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1234567890000000000}).GenesisAccountData
 
 	logger := logging.TestingLog(b)
 	logger.SetLevel(logging.Warn)

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -125,7 +125,7 @@ func OpenLedger(
 		log:                            log,
 		archival:                       cfg.Archival,
 		genesisHash:                    genesisInitState.GenesisHash,
-		genesisAccounts:                genesisInitState.Accounts,
+		genesisAccounts:                genesisInitState.GenesisAccountData,
 		genesisProto:                   config.Consensus[genesisInitState.Block.CurrentProtocol],
 		genesisProtoVersion:            genesisInitState.Block.CurrentProtocol,
 		synchronousMode:                db.SynchronousMode(cfg.LedgerSynchronousMode),

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -73,7 +73,7 @@ type Ledger struct {
 	// genesisHash stores the genesis hash for this ledger.
 	genesisHash crypto.Digest
 
-	genesisAccounts map[basics.Address]basics.AccountData
+	genesisAccounts map[basics.Address]basics.GenesisAccountData
 
 	genesisProto        config.ConsensusParams
 	genesisProtoVersion protocol.ConsensusVersion
@@ -125,7 +125,7 @@ func OpenLedger(
 		log:                            log,
 		archival:                       cfg.Archival,
 		genesisHash:                    genesisInitState.GenesisHash,
-		genesisAccounts:                genesisInitState.GenesisAccountData,
+		genesisAccounts:                genesisInitState.Accounts,
 		genesisProto:                   config.Consensus[genesisInitState.Block.CurrentProtocol],
 		genesisProtoVersion:            genesisInitState.Block.CurrentProtocol,
 		synchronousMode:                db.SynchronousMode(cfg.LedgerSynchronousMode),
@@ -167,7 +167,7 @@ func OpenLedger(
 	}
 
 	if l.genesisAccounts == nil {
-		l.genesisAccounts = make(map[basics.Address]basics.AccountData)
+		l.genesisAccounts = make(map[basics.Address]basics.GenesisAccountData)
 	}
 
 	l.blockQ, err = newBlockQueue(l)
@@ -763,7 +763,7 @@ func (l *Ledger) GenesisProtoVersion() protocol.ConsensusVersion {
 }
 
 // GenesisAccounts returns initial accounts for this ledger.
-func (l *Ledger) GenesisAccounts() map[basics.Address]basics.AccountData {
+func (l *Ledger) GenesisAccounts() map[basics.Address]basics.GenesisAccountData {
 	return l.genesisAccounts
 }
 

--- a/ledger/ledger_perf_test.go
+++ b/ledger/ledger_perf_test.go
@@ -152,7 +152,7 @@ func benchmarkFullBlocks(params testParams, b *testing.B) {
 	creator := basics.Address{}
 	_, err := rand.Read(creator[:])
 	require.NoError(b, err)
-	genesisInitState.Accounts[creator] = basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1234567890})
+	genesisInitState.Accounts[creator] = basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1234567890}).GenesisAccountData
 
 	// Make some accounts to opt into ASA
 	var accts []basics.Address
@@ -161,7 +161,7 @@ func benchmarkFullBlocks(params testParams, b *testing.B) {
 			acct := basics.Address{}
 			_, err = rand.Read(acct[:])
 			require.NoError(b, err)
-			genesisInitState.Accounts[acct] = basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1234567890})
+			genesisInitState.Accounts[acct] = basics_testing.MakeAccountData(basics.Offline, basics.MicroAlgos{Raw: 1234567890}).GenesisAccountData
 			accts = append(accts, acct)
 		}
 	}

--- a/ledger/ledgercore/accountdata.go
+++ b/ledger/ledgercore/accountdata.go
@@ -67,6 +67,24 @@ type OnlineAccountData struct {
 	VotingData
 }
 
+// ToAccountDataFromGenesisAccountData returns ledgercore.AccountData from basics.GenesisAccountData
+func ToAccountDataFromGenesisAccountData(gad basics.GenesisAccountData) AccountData {
+	return AccountData{
+		AccountBaseData: AccountBaseData{
+			Status:     gad.Status,
+			MicroAlgos: gad.MicroAlgos,
+		},
+		VotingData: VotingData{
+			VoteID:          gad.VoteID,
+			SelectionID:     gad.SelectionID,
+			StateProofID:    gad.StateProofID,
+			VoteFirstValid:  gad.VoteFirstValid,
+			VoteLastValid:   gad.VoteLastValid,
+			VoteKeyDilution: gad.VoteKeyDilution,
+		},
+	}
+}
+
 // ToAccountData returns ledgercore.AccountData from basics.AccountData
 func ToAccountData(acct basics.AccountData) AccountData {
 	return AccountData{

--- a/ledger/ledgercore/misc.go
+++ b/ledger/ledgercore/misc.go
@@ -25,7 +25,7 @@ import (
 // InitState structure defines blockchain init params
 type InitState struct {
 	Block       bookkeeping.Block
-	Accounts    map[basics.Address]basics.AccountData
+	Accounts    map[basics.Address]basics.GenesisAccountData
 	GenesisHash crypto.Digest
 }
 

--- a/ledger/simulation/testing/utils.go
+++ b/ledger/simulation/testing/utils.go
@@ -115,7 +115,7 @@ func PrepareSimulatorTest(t *testing.T) Environment {
 		account := Account{
 			Addr:     addr,
 			Sk:       key,
-			AcctData: genesisInitState.Accounts[addr],
+			AcctData: basics.AccountData{GenesisAccountData: genesisInitState.Accounts[addr]},
 		}
 
 		if addr == ledgertesting.SinkAddr() {

--- a/ledger/store/trackerdb/data.go
+++ b/ledger/store/trackerdb/data.go
@@ -360,8 +360,16 @@ func (ba *BaseAccountData) GetLedgerCoreVotingData() ledgercore.VotingData {
 // GetAccountData getter for account data.
 func (ba *BaseAccountData) GetAccountData() basics.AccountData {
 	return basics.AccountData{
-		Status:             ba.Status,
-		MicroAlgos:         ba.MicroAlgos,
+		GenesisAccountData: basics.GenesisAccountData{
+			Status:          ba.Status,
+			MicroAlgos:      ba.MicroAlgos,
+			VoteID:          ba.VoteID,
+			SelectionID:     ba.SelectionID,
+			StateProofID:    ba.StateProofID,
+			VoteFirstValid:  ba.VoteFirstValid,
+			VoteLastValid:   ba.VoteLastValid,
+			VoteKeyDilution: ba.VoteKeyDilution,
+		},
 		RewardsBase:        ba.RewardsBase,
 		RewardedMicroAlgos: ba.RewardedMicroAlgos,
 		AuthAddr:           ba.AuthAddr,
@@ -372,13 +380,6 @@ func (ba *BaseAccountData) GetAccountData() basics.AccountData {
 		TotalExtraAppPages: ba.TotalExtraAppPages,
 		TotalBoxes:         ba.TotalBoxes,
 		TotalBoxBytes:      ba.TotalBoxBytes,
-
-		VoteID:          ba.VoteID,
-		SelectionID:     ba.SelectionID,
-		StateProofID:    ba.StateProofID,
-		VoteFirstValid:  ba.VoteFirstValid,
-		VoteLastValid:   ba.VoteLastValid,
-		VoteKeyDilution: ba.VoteKeyDilution,
 	}
 }
 

--- a/ledger/store/trackerdb/sqlitedriver/schema_test.go
+++ b/ledger/store/trackerdb/sqlitedriver/schema_test.go
@@ -69,16 +69,18 @@ func TestAccountsReencoding(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			addr := ledgertesting.RandomAddress()
 			accData := basics.AccountData{
-				MicroAlgos:         basics.MicroAlgos{Raw: 0x000ffffffffffffff},
-				Status:             basics.NotParticipating,
+				GenesisAccountData: basics.GenesisAccountData{
+					MicroAlgos:      basics.MicroAlgos{Raw: 0x000ffffffffffffff},
+					Status:          basics.NotParticipating,
+					VoteID:          secrets.OneTimeSignatureVerifier,
+					SelectionID:     pubVrfKey,
+					StateProofID:    stateProofID.Commitment,
+					VoteFirstValid:  basics.Round(0x000ffffffffffffff),
+					VoteLastValid:   basics.Round(0x000ffffffffffffff),
+					VoteKeyDilution: 0x000ffffffffffffff,
+				},
 				RewardsBase:        uint64(i),
 				RewardedMicroAlgos: basics.MicroAlgos{Raw: 0x000ffffffffffffff},
-				VoteID:             secrets.OneTimeSignatureVerifier,
-				SelectionID:        pubVrfKey,
-				StateProofID:       stateProofID.Commitment,
-				VoteFirstValid:     basics.Round(0x000ffffffffffffff),
-				VoteLastValid:      basics.Round(0x000ffffffffffffff),
-				VoteKeyDilution:    0x000ffffffffffffff,
 				AssetParams: map[basics.AssetIndex]basics.AssetParams{
 					0x000ffffffffffffff: {
 						Total:         0x000ffffffffffffff,

--- a/ledger/testing/testGenesis.go
+++ b/ledger/testing/testGenesis.go
@@ -61,7 +61,7 @@ func NewTestGenesis(opts ...TestGenesisOption) (bookkeeping.GenesisBalances, []b
 	const count = 10
 	addrs := make([]basics.Address, count)
 	secrets := make([]*crypto.SignatureSecrets, count)
-	accts := make(map[basics.Address]basics.AccountData)
+	accts := make(map[basics.Address]basics.GenesisAccountData)
 
 	// 10 billion microalgos, across N accounts and pool and sink
 	amount := 10 * 1000000000 * 1000000 / uint64(count+2)
@@ -73,13 +73,13 @@ func NewTestGenesis(opts ...TestGenesisOption) (bookkeeping.GenesisBalances, []b
 		secrets[i] = crypto.GenerateSignatureSecrets(seed)
 		addrs[i] = basics.Address(secrets[i].SignatureVerifier)
 
-		adata := basics.AccountData{
+		adata := basics.GenesisAccountData{
 			MicroAlgos: basics.MicroAlgos{Raw: amount},
 		}
 		accts[addrs[i]] = adata
 	}
 
-	accts[sink] = basics.AccountData{
+	accts[sink] = basics.GenesisAccountData{
 		MicroAlgos: basics.MicroAlgos{Raw: amount},
 		Status:     basics.NotParticipating,
 	}
@@ -88,7 +88,7 @@ func NewTestGenesis(opts ...TestGenesisOption) (bookkeeping.GenesisBalances, []b
 	if cfg.rewardsPoolAmount.Raw > 0 {
 		poolBal = cfg.rewardsPoolAmount
 	}
-	accts[rewards] = basics.AccountData{
+	accts[rewards] = basics.GenesisAccountData{
 		MicroAlgos: poolBal,
 	}
 
@@ -113,7 +113,7 @@ func GenesisWithProto(naccts int, proto protocol.ConsensusVersion) (ledgercore.I
 
 	addrs := make([]basics.Address, 0, naccts)
 	keys := make([]*crypto.SignatureSecrets, 0, naccts)
-	accts := make(map[basics.Address]basics.AccountData)
+	accts := make(map[basics.Address]basics.GenesisAccountData)
 
 	// 10 billion microalgos, across N accounts and pool and sink
 	amount := 10 * 1000000000 * 1000000 / uint64(naccts+2)
@@ -132,17 +132,17 @@ func GenesisWithProto(naccts int, proto protocol.ConsensusVersion) (ledgercore.I
 		keys = append(keys, key)
 		addrs = append(addrs, addr)
 
-		adata := basics.AccountData{}
+		adata := basics.GenesisAccountData{}
 		adata.MicroAlgos.Raw = amount //1000 * 1000 * 1000 * 1000 / uint64(naccts)
 		accts[addr] = adata
 	}
 
-	pooldata := basics.AccountData{}
+	pooldata := basics.GenesisAccountData{}
 	pooldata.MicroAlgos.Raw = amount //1000 * 1000 * 1000 * 1000
 	pooldata.Status = basics.NotParticipating
 	accts[testPoolAddr] = pooldata
 
-	sinkdata := basics.AccountData{}
+	sinkdata := basics.GenesisAccountData{}
 	sinkdata.MicroAlgos.Raw = amount //1000 * 1000 * 1000 * 1000
 	sinkdata.Status = basics.NotParticipating
 	accts[testSinkAddr] = sinkdata

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -145,7 +145,7 @@ type ledgerForTracker interface {
 	GenesisHash() crypto.Digest
 	GenesisProto() config.ConsensusParams
 	GenesisProtoVersion() protocol.ConsensusVersion
-	GenesisAccounts() map[basics.Address]basics.AccountData
+	GenesisAccounts() map[basics.Address]basics.GenesisAccountData
 }
 
 type trackerRegistry struct {

--- a/netdeploy/remote/deployedNetwork.go
+++ b/netdeploy/remote/deployedNetwork.go
@@ -354,7 +354,7 @@ func (cfg DeployedNetwork) BuildNetworkFromTemplate(buildCfg BuildConfig, rootDi
 //GenerateDatabaseFiles generates database files according to the configurations
 func (cfg DeployedNetwork) GenerateDatabaseFiles(fileCfgs BootstrappedNetwork, genesisFolder string) error {
 
-	accounts := make(map[basics.Address]basics.AccountData)
+	accounts := make(map[basics.Address]basics.GenesisAccountData)
 
 	genesis, err := bookkeeping.LoadGenesisFromFile(filepath.Join(genesisFolder, "genesis.json"))
 	if err != nil {
@@ -493,7 +493,7 @@ func keypair() *crypto.SignatureSecrets {
 	return s
 }
 
-func generateInitState(accounts map[basics.Address]basics.AccountData, bootstrappedNet *netState) (ledgercore.InitState, error) {
+func generateInitState(accounts map[basics.Address]basics.GenesisAccountData, bootstrappedNet *netState) (ledgercore.InitState, error) {
 
 	var initState ledgercore.InitState
 

--- a/node/assemble_test.go
+++ b/node/assemble_test.go
@@ -60,19 +60,19 @@ func BenchmarkAssembleBlock(b *testing.B) {
 	secrets := make([]*crypto.SignatureSecrets, numUsers)
 	addresses := make([]basics.Address, numUsers)
 
-	genesis := make(map[basics.Address]basics.AccountData)
+	genesis := make(map[basics.Address]basics.GenesisAccountData)
 	for i := 0; i < numUsers; i++ {
 		secret := keypair()
 		addr := basics.Address(secret.SignatureVerifier)
 		secrets[i] = secret
 		addresses[i] = addr
-		genesis[addr] = basics.AccountData{
+		genesis[addr] = basics.GenesisAccountData{
 			Status:     basics.Online,
 			MicroAlgos: basics.MicroAlgos{Raw: 10000000000000},
 		}
 	}
 
-	genesis[poolAddr] = basics.AccountData{
+	genesis[poolAddr] = basics.GenesisAccountData{
 		Status:     basics.NotParticipating,
 		MicroAlgos: basics.MicroAlgos{Raw: config.Consensus[protocol.ConsensusCurrentVersion].MinBalance},
 	}
@@ -190,19 +190,19 @@ func TestAssembleBlockTransactionPoolBehind(t *testing.T) {
 	secrets := make([]*crypto.SignatureSecrets, numUsers)
 	addresses := make([]basics.Address, numUsers)
 
-	genesis := make(map[basics.Address]basics.AccountData)
+	genesis := make(map[basics.Address]basics.GenesisAccountData)
 	for i := 0; i < numUsers; i++ {
 		secret := keypair()
 		addr := basics.Address(secret.SignatureVerifier)
 		secrets[i] = secret
 		addresses[i] = addr
-		genesis[addr] = basics.AccountData{
+		genesis[addr] = basics.GenesisAccountData{
 			Status:     basics.Online,
 			MicroAlgos: basics.MicroAlgos{Raw: 10000000000000},
 		}
 	}
 
-	genesis[poolAddr] = basics.AccountData{
+	genesis[poolAddr] = basics.GenesisAccountData{
 		Status:     basics.NotParticipating,
 		MicroAlgos: basics.MicroAlgos{Raw: config.Consensus[protocol.ConsensusCurrentVersion].MinBalance},
 	}

--- a/node/follower_node_test.go
+++ b/node/follower_node_test.go
@@ -47,13 +47,13 @@ func followNodeDefaultGenesis() bookkeeping.Genesis {
 		Allocation: []bookkeeping.GenesisAllocation{
 			{
 				Address: poolAddr.String(),
-				State: basics.AccountData{
+				State: basics.GenesisAccountData{
 					MicroAlgos: basics.MicroAlgos{Raw: 1000000000},
 				},
 			},
 			{
 				Address: sinkAddr.String(),
-				State: basics.AccountData{
+				State: basics.GenesisAccountData{
 					MicroAlgos: basics.MicroAlgos{Raw: 1000000},
 				},
 			},

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -70,7 +70,7 @@ func setupFullNodes(t *testing.T, proto protocol.ConsensusVersion, verificationP
 	firstRound := basics.Round(0)
 	lastRound := basics.Round(200)
 
-	genesis := make(map[basics.Address]basics.AccountData)
+	genesis := make(map[basics.Address]basics.GenesisAccountData)
 	gen := rand.New(rand.NewSource(2))
 	neighbors := make([]string, numAccounts)
 	for i := range neighbors {
@@ -133,7 +133,7 @@ func setupFullNodes(t *testing.T, proto protocol.ConsensusVersion, verificationP
 		}
 		access.Close()
 
-		data := basics.AccountData{
+		data := basics.GenesisAccountData{
 			Status:      basics.Online,
 			MicroAlgos:  basics.MicroAlgos{Raw: uint64(minMoneyAtStart + (gen.Int() % (maxMoneyAtStart - minMoneyAtStart)))},
 			SelectionID: part.VRFSecrets().PK,
@@ -142,7 +142,7 @@ func setupFullNodes(t *testing.T, proto protocol.ConsensusVersion, verificationP
 		short := root.Address()
 		genesis[short] = data
 	}
-	genesis[poolAddr] = basics.AccountData{
+	genesis[poolAddr] = basics.GenesisAccountData{
 		Status:     basics.Online,
 		MicroAlgos: basics.MicroAlgos{Raw: uint64(100000)},
 	}

--- a/rpcs/blockService_test.go
+++ b/rpcs/blockService_test.go
@@ -334,12 +334,12 @@ var sinkAddr = basics.Address{0x7, 0xda, 0xcb, 0x4b, 0x6d, 0x9e, 0xd1, 0x41, 0xb
 
 func makeLedger(t *testing.T, namePostfix string) *data.Ledger {
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
-	genesis := make(map[basics.Address]basics.AccountData)
-	genesis[sinkAddr] = basics.AccountData{
+	genesis := make(map[basics.Address]basics.GenesisAccountData)
+	genesis[sinkAddr] = basics.GenesisAccountData{
 		Status:     basics.Online,
 		MicroAlgos: basics.MicroAlgos{Raw: proto.MinBalance * 2000000},
 	}
-	genesis[poolAddr] = basics.AccountData{
+	genesis[poolAddr] = basics.GenesisAccountData{
 		Status:     basics.Online,
 		MicroAlgos: basics.MicroAlgos{Raw: proto.MinBalance * 2000000},
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

This PR refactors `AccountData` so relevant fields for Genesis are separated out into another struct. This makes the code more idiomatic regarding Genesis-related functionality and makes it easier to understand and maintain AccountData-related state.

Closes https://github.com/algorand/go-algorand/issues/5316

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

Existing tests.
