### PR TITLE
metrics: Add LedgerDBRound gauge

### DIFF
--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -30,12 +30,14 @@ type metricsTracker struct {
 	ledgerTransactionsTotal *metrics.Counter
 	ledgerRewardClaimsTotal *metrics.Counter
 	ledgerRound             *metrics.Gauge
+	ledgerDBRound           *metrics.Gauge
 }
 
 func (mt *metricsTracker) loadFromDisk(l ledgerForTracker, _ basics.Round) error {
 	mt.ledgerTransactionsTotal = metrics.MakeCounter(metrics.LedgerTransactionsTotal)
 	mt.ledgerRewardClaimsTotal = metrics.MakeCounter(metrics.LedgerRewardClaimsTotal)
 	mt.ledgerRound = metrics.MakeGauge(metrics.LedgerRound)
+	mt.ledgerDBRound = metrics.MakeGauge(metrics.LedgerDBRound)
 	return nil
 }
 
@@ -51,6 +53,10 @@ func (mt *metricsTracker) close() {
 	if mt.ledgerRound != nil {
 		mt.ledgerRound.Deregister(nil)
 		mt.ledgerRound = nil
+	}
+	if mt.ledgerDBRound != nil {
+		mt.ledgerDBRound.Deregister(nil)
+		mt.ledgerDBRound = nil
 	}
 }
 
@@ -75,6 +81,7 @@ func (mt *metricsTracker) commitRound(context.Context, trackerdb.TransactionScop
 }
 
 func (mt *metricsTracker) postCommit(ctx context.Context, dcc *deferredCommitContext) {
+	mt.ledgerDBRound.Set(uint64(dcc.newBase()))
 }
 
 func (mt *metricsTracker) postCommitUnlocked(ctx context.Context, dcc *deferredCommitContext) {

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -81,6 +81,8 @@ var (
 	LedgerRewardClaimsTotal = MetricName{Name: "algod_ledger_reward_claims_total", Description: "Total number of reward claims written to the ledger"}
 	// LedgerRound Last round written to ledger
 	LedgerRound = MetricName{Name: "algod_ledger_round", Description: "Last round written to ledger"}
+	// LedgerDBRound Last round written to ledger
+	LedgerDBRound = MetricName{Name: "algod_ledger_dbround", Description: "Last round written to the ledger DB"}
 
 	// AgreementMessagesHandled "Number of agreement messages handled"
 	AgreementMessagesHandled = MetricName{Name: "algod_agreement_handled", Description: "Number of agreement messages handled"}


### PR DESCRIPTION
## Summary

Small change to add an additional gauge to the metricsTracker to track the latest flushed round.

## Test Plan

Existing tests should pass; manually tested to check gauge is set.