### PR TITLE
genesis: add GenesisAccountData type for use in GenesisAllocation

### DIFF
--- a/cmd/incorporate/incorporate.go
+++ b/cmd/incorporate/incorporate.go
@@ -175,7 +175,7 @@ func parseInput() (genesis bookkeeping.Genesis) {
 		alloc := bookkeeping.GenesisAllocation{
 			Address: record.Address,
 			Comment: record.Comment,
-			State: basics.AccountData{
+			State: bookkeeping.GenesisAccountData{
 				Status:          record.Status,
 				MicroAlgos:      basics.MicroAlgos{Raw: record.Algos * 1e6},
 				VoteID:          record.VoteID,

--- a/data/bookkeeping/genesis.go
+++ b/data/bookkeeping/genesis.go
@@ -190,6 +190,7 @@ type GenesisAccountData struct {
 	VoteKeyDilution uint64                          `codec:"voteKD"`
 }
 
+// AccountData returns a basics.AccountData type for this genesis account.
 func (ga *GenesisAccountData) AccountData() basics.AccountData {
 	return basics.AccountData{
 		Status:          ga.Status,

--- a/data/bookkeeping/genesis.go
+++ b/data/bookkeeping/genesis.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/crypto/merklesignature"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/committee"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -120,7 +121,7 @@ func (genesis Genesis) Balances() (GenesisBalances, error) {
 			return GenesisBalances{}, fmt.Errorf("repeated allocation to %s", entry.Address)
 		}
 
-		genalloc[addr] = entry.State
+		genalloc[addr] = entry.State.AccountData()
 	}
 
 	feeSink, err := basics.UnmarshalChecksumAddress(genesis.FeeSink)
@@ -159,7 +160,7 @@ type GenesisAllocation struct {
 
 	Address string             `codec:"addr"`
 	Comment string             `codec:"comment"`
-	State   basics.AccountData `codec:"state"`
+	State   GenesisAccountData `codec:"state"`
 }
 
 // ToBeHashed impements the crypto.Hashable interface.
@@ -173,6 +174,33 @@ type GenesisBalances struct {
 	FeeSink     basics.Address
 	RewardsPool basics.Address
 	Timestamp   int64
+}
+
+// GenesisAccountData contains a subset of account information that is present in the genesis file.
+type GenesisAccountData struct {
+	_struct struct{} `codec:",omitempty,omitemptyarray"`
+
+	Status          basics.Status                   `codec:"onl"`
+	MicroAlgos      basics.MicroAlgos               `codec:"algo"`
+	VoteID          crypto.OneTimeSignatureVerifier `codec:"vote"`
+	StateProofID    merklesignature.Commitment      `codec:"stprf"`
+	SelectionID     crypto.VRFVerifier              `codec:"sel"`
+	VoteFirstValid  basics.Round                    `codec:"voteFst"`
+	VoteLastValid   basics.Round                    `codec:"voteLst"`
+	VoteKeyDilution uint64                          `codec:"voteKD"`
+}
+
+func (ga *GenesisAccountData) AccountData() basics.AccountData {
+	return basics.AccountData{
+		Status:          ga.Status,
+		MicroAlgos:      ga.MicroAlgos,
+		VoteID:          ga.VoteID,
+		StateProofID:    ga.StateProofID,
+		SelectionID:     ga.SelectionID,
+		VoteFirstValid:  ga.VoteFirstValid,
+		VoteLastValid:   ga.VoteLastValid,
+		VoteKeyDilution: ga.VoteKeyDilution,
+	}
 }
 
 // MakeGenesisBalances returns the information needed to bootstrap the ledger based on the current time

--- a/data/bookkeeping/genesis_test.go
+++ b/data/bookkeeping/genesis_test.go
@@ -50,7 +50,7 @@ func TestGenesis_Balances(t *testing.T) {
 			_struct: struct{}{},
 			Address: addr,
 			Comment: "",
-			State: basics.AccountData{
+			State: GenesisAccountData{
 				MicroAlgos: basics.MicroAlgos{Raw: algos},
 			},
 		}
@@ -79,7 +79,7 @@ func TestGenesis_Balances(t *testing.T) {
 			},
 			want: GenesisBalances{
 				Balances: map[basics.Address]basics.AccountData{
-					mustAddr(allocation1.Address): allocation1.State,
+					mustAddr(allocation1.Address): allocation1.State.AccountData(),
 				},
 				FeeSink:     goodAddr,
 				RewardsPool: goodAddr,
@@ -96,8 +96,8 @@ func TestGenesis_Balances(t *testing.T) {
 			},
 			want: GenesisBalances{
 				Balances: map[basics.Address]basics.AccountData{
-					mustAddr(allocation1.Address): allocation1.State,
-					mustAddr(allocation2.Address): allocation2.State,
+					mustAddr(allocation1.Address): allocation1.State.AccountData(),
+					mustAddr(allocation2.Address): allocation2.State.AccountData(),
 				},
 				FeeSink:     goodAddr,
 				RewardsPool: goodAddr,

--- a/data/bookkeeping/msgp_gen.go
+++ b/data/bookkeeping/msgp_gen.go
@@ -46,6 +46,14 @@ import (
 //    |-----> (*) Msgsize
 //    |-----> (*) MsgIsZero
 //
+// GenesisAccountData
+//          |-----> (*) MarshalMsg
+//          |-----> (*) CanMarshalMsg
+//          |-----> (*) UnmarshalMsg
+//          |-----> (*) CanUnmarshalMsg
+//          |-----> (*) Msgsize
+//          |-----> (*) MsgIsZero
+//
 // GenesisAllocation
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
@@ -2074,6 +2082,273 @@ func (z *Genesis) Msgsize() (s int) {
 // MsgIsZero returns whether this is a zero value
 func (z *Genesis) MsgIsZero() bool {
 	return ((*z).SchemaID == "") && ((*z).Network.MsgIsZero()) && ((*z).Proto.MsgIsZero()) && (len((*z).Allocation) == 0) && ((*z).RewardsPool == "") && ((*z).FeeSink == "") && ((*z).Timestamp == 0) && ((*z).Comment == "") && ((*z).DevMode == false)
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *GenesisAccountData) MarshalMsg(b []byte) (o []byte) {
+	o = msgp.Require(b, z.Msgsize())
+	// omitempty: check for empty values
+	zb0001Len := uint32(8)
+	var zb0001Mask uint16 /* 9 bits */
+	if (*z).MicroAlgos.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if (*z).Status.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if (*z).SelectionID.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if (*z).StateProofID.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if (*z).VoteID.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if (*z).VoteFirstValid.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if (*z).VoteKeyDilution == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	if (*z).VoteLastValid.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x100
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x2) == 0 { // if not empty
+			// string "algo"
+			o = append(o, 0xa4, 0x61, 0x6c, 0x67, 0x6f)
+			o = (*z).MicroAlgos.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not empty
+			// string "onl"
+			o = append(o, 0xa3, 0x6f, 0x6e, 0x6c)
+			o = (*z).Status.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not empty
+			// string "sel"
+			o = append(o, 0xa3, 0x73, 0x65, 0x6c)
+			o = (*z).SelectionID.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not empty
+			// string "stprf"
+			o = append(o, 0xa5, 0x73, 0x74, 0x70, 0x72, 0x66)
+			o = (*z).StateProofID.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not empty
+			// string "vote"
+			o = append(o, 0xa4, 0x76, 0x6f, 0x74, 0x65)
+			o = (*z).VoteID.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not empty
+			// string "voteFst"
+			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x46, 0x73, 0x74)
+			o = (*z).VoteFirstValid.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not empty
+			// string "voteKD"
+			o = append(o, 0xa6, 0x76, 0x6f, 0x74, 0x65, 0x4b, 0x44)
+			o = msgp.AppendUint64(o, (*z).VoteKeyDilution)
+		}
+		if (zb0001Mask & 0x100) == 0 { // if not empty
+			// string "voteLst"
+			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x4c, 0x73, 0x74)
+			o = (*z).VoteLastValid.MarshalMsg(o)
+		}
+	}
+	return
+}
+
+func (_ *GenesisAccountData) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(*GenesisAccountData)
+	return ok
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *GenesisAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 int
+	var zb0002 bool
+	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if _, ok := err.(msgp.TypeError); ok {
+		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).Status.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Status")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).MicroAlgos.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "MicroAlgos")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).VoteID.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "VoteID")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).StateProofID.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "StateProofID")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).SelectionID.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "SelectionID")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).VoteFirstValid.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "VoteFirstValid")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).VoteLastValid.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "VoteLastValid")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			(*z).VoteKeyDilution, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "VoteKeyDilution")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			err = msgp.ErrTooManyArrayFields(zb0001)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array")
+				return
+			}
+		}
+	} else {
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0002 {
+			(*z) = GenesisAccountData{}
+		}
+		for zb0001 > 0 {
+			zb0001--
+			field, bts, err = msgp.ReadMapKeyZC(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+			switch string(field) {
+			case "onl":
+				bts, err = (*z).Status.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Status")
+					return
+				}
+			case "algo":
+				bts, err = (*z).MicroAlgos.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "MicroAlgos")
+					return
+				}
+			case "vote":
+				bts, err = (*z).VoteID.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "VoteID")
+					return
+				}
+			case "stprf":
+				bts, err = (*z).StateProofID.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "StateProofID")
+					return
+				}
+			case "sel":
+				bts, err = (*z).SelectionID.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "SelectionID")
+					return
+				}
+			case "voteFst":
+				bts, err = (*z).VoteFirstValid.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "VoteFirstValid")
+					return
+				}
+			case "voteLst":
+				bts, err = (*z).VoteLastValid.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "VoteLastValid")
+					return
+				}
+			case "voteKD":
+				(*z).VoteKeyDilution, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "VoteKeyDilution")
+					return
+				}
+			default:
+				err = msgp.ErrNoField(string(field))
+				if err != nil {
+					err = msgp.WrapError(err)
+					return
+				}
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (_ *GenesisAccountData) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*GenesisAccountData)
+	return ok
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *GenesisAccountData) Msgsize() (s int) {
+	s = 1 + 4 + (*z).Status.Msgsize() + 5 + (*z).MicroAlgos.Msgsize() + 5 + (*z).VoteID.Msgsize() + 6 + (*z).StateProofID.Msgsize() + 4 + (*z).SelectionID.Msgsize() + 8 + (*z).VoteFirstValid.Msgsize() + 8 + (*z).VoteLastValid.Msgsize() + 7 + msgp.Uint64Size
+	return
+}
+
+// MsgIsZero returns whether this is a zero value
+func (z *GenesisAccountData) MsgIsZero() bool {
+	return ((*z).Status.MsgIsZero()) && ((*z).MicroAlgos.MsgIsZero()) && ((*z).VoteID.MsgIsZero()) && ((*z).StateProofID.MsgIsZero()) && ((*z).SelectionID.MsgIsZero()) && ((*z).VoteFirstValid.MsgIsZero()) && ((*z).VoteLastValid.MsgIsZero()) && ((*z).VoteKeyDilution == 0)
 }
 
 // MarshalMsg implements msgp.Marshaler

--- a/data/bookkeeping/msgp_gen_test.go
+++ b/data/bookkeeping/msgp_gen_test.go
@@ -194,6 +194,66 @@ func BenchmarkUnmarshalGenesis(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalGenesisAccountData(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	v := GenesisAccountData{}
+	bts := v.MarshalMsg(nil)
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func TestRandomizedEncodingGenesisAccountData(t *testing.T) {
+	protocol.RunEncodingTest(t, &GenesisAccountData{})
+}
+
+func BenchmarkMarshalMsgGenesisAccountData(b *testing.B) {
+	v := GenesisAccountData{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgGenesisAccountData(b *testing.B) {
+	v := GenesisAccountData{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalGenesisAccountData(b *testing.B) {
+	v := GenesisAccountData{}
+	bts := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalGenesisAllocation(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	v := GenesisAllocation{}

--- a/gen/generate.go
+++ b/gen/generate.go
@@ -169,7 +169,7 @@ func generateGenesisFiles(protoVersion protocol.ConsensusVersion, protoParams co
 		comment               = genData.Comment
 
 		genesisAddrs = make(map[string]basics.Address)
-		records      = make(map[string]basics.AccountData)
+		records      = make(map[string]bookkeeping.GenesisAccountData)
 	)
 
 	if partKeyDilution == 0 {
@@ -275,7 +275,7 @@ func generateGenesisFiles(protoVersion protocol.ConsensusVersion, protoParams co
 				}
 			}
 
-			var data basics.AccountData
+			var data bookkeeping.GenesisAccountData
 			data.Status = wallet.Online
 			data.MicroAlgos.Raw = wallet.Stake
 			if wallet.Online == basics.Online {
@@ -345,12 +345,12 @@ func generateGenesisFiles(protoVersion protocol.ConsensusVersion, protoParams co
 		rewardsBalance = protoParams.MinBalance
 	}
 
-	records["FeeSink"] = basics.AccountData{
+	records["FeeSink"] = bookkeeping.GenesisAccountData{
 		Status:     basics.NotParticipating,
 		MicroAlgos: basics.MicroAlgos{Raw: protoParams.MinBalance},
 	}
 
-	records["RewardsPool"] = basics.AccountData{
+	records["RewardsPool"] = bookkeeping.GenesisAccountData{
 		Status:     basics.NotParticipating,
 		MicroAlgos: basics.MicroAlgos{Raw: rewardsBalance},
 	}

--- a/netdeploy/remote/deployedNetwork.go
+++ b/netdeploy/remote/deployedNetwork.go
@@ -387,7 +387,7 @@ func (cfg DeployedNetwork) GenerateDatabaseFiles(fileCfgs BootstrappedNetwork, g
 		default:
 		}
 
-		accounts[addr] = alloc.State
+		accounts[addr] = alloc.State.AccountData()
 	}
 
 	//initial state

--- a/node/follower_node_test.go
+++ b/node/follower_node_test.go
@@ -47,13 +47,13 @@ func followNodeDefaultGenesis() bookkeeping.Genesis {
 		Allocation: []bookkeeping.GenesisAllocation{
 			{
 				Address: poolAddr.String(),
-				State: basics.AccountData{
+				State: bookkeeping.GenesisAccountData{
 					MicroAlgos: basics.MicroAlgos{Raw: 1000000000},
 				},
 			},
 			{
 				Address: sinkAddr.String(),
-				State: basics.AccountData{
+				State: bookkeeping.GenesisAccountData{
 					MicroAlgos: basics.MicroAlgos{Raw: 1000000},
 				},
 			},

--- a/tools/block-generator/generator/generate.go
+++ b/tools/block-generator/generator/generate.go
@@ -309,7 +309,7 @@ func (g *generator) WriteGenesis(output io.Writer) error {
 		addr := indexToAccount(i)
 		allocations = append(allocations, bookkeeping.GenesisAllocation{
 			Address: addr.String(),
-			State: basics.AccountData{
+			State: bookkeeping.GenesisAccountData{
 				MicroAlgos: basics.MicroAlgos{Raw: g.config.GenesisAccountInitialBalance},
 			},
 		})
@@ -319,7 +319,7 @@ func (g *generator) WriteGenesis(output io.Writer) error {
 	allocations = append(allocations, bookkeeping.GenesisAllocation{
 		Address: g.rewardsPool.String(),
 		Comment: "RewardsPool",
-		State: basics.AccountData{
+		State: bookkeeping.GenesisAccountData{
 			MicroAlgos: basics.MicroAlgos{Raw: g.params.MinBalance},
 			Status:     basics.NotParticipating,
 		},


### PR DESCRIPTION
## Summary

Alternate for #5447 that specifies the narrow set of fields allowed in the GenesisAllocation (the `"alloc"` part of the genesis.json file).

## Test Plan

Existing tests updated, should pass