### PR TITLE
cmd/updater: add install directory to logging

### DIFF
--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -537,7 +537,7 @@ function install_new_binaries() {
     if [ ! -d ${UPDATESRCDIR}/bin ]; then
         return 0
     else
-        echo "Installing new binary files into ${BINDIR}..."
+        echo "Installing new binary files into ${BINDIR}"
         ROLLBACKBIN=1
         rm -rf ${BINDIR}/new
         mkdir ${BINDIR}/new

--- a/cmd/updater/update.sh
+++ b/cmd/updater/update.sh
@@ -537,7 +537,7 @@ function install_new_binaries() {
     if [ ! -d ${UPDATESRCDIR}/bin ]; then
         return 0
     else
-        echo "Installing new binary files..."
+        echo "Installing new binary files into ${BINDIR}..."
         ROLLBACKBIN=1
         rm -rf ${BINDIR}/new
         mkdir ${BINDIR}/new


### PR DESCRIPTION
Unhelpfully silent on where exactly the binary has been installed after running `make install`.
