### PR TITLE
algocfg: Add EnableTxnEvalTracer to algocfg development profile.

### DIFF
--- a/cmd/algocfg/profileCommand.go
+++ b/cmd/algocfg/profileCommand.go
@@ -42,6 +42,8 @@ var (
 		updateFunc: func(cfg config.Local) config.Local {
 			cfg.EnableExperimentalAPI = true
 			cfg.EnableDeveloperAPI = true
+			cfg.MaxAcctLookback = 256
+			cfg.EnableTxnEvalTracer = true
 			return cfg
 		},
 	}


### PR DESCRIPTION
## Summary

Update `algocfg` development profile to set:
```
MaxAcctLookback = 256
EnableTxnEvalTracer = true
```

## Test Plan

Run `algocfg profile set development -d .` and confirm the expected config file is created.