### PR TITLE
tests: flaky tests fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ ALWAYS:
 # build our fork of libsodium, placing artifacts into crypto/lib/ and crypto/include/
 crypto/libs/$(OS_TYPE)/$(ARCH)/lib/libsodium.a:
 	mkdir -p crypto/copies/$(OS_TYPE)/$(ARCH)
-	cp -R crypto/libsodium-fork crypto/copies/$(OS_TYPE)/$(ARCH)/libsodium-fork
+	cp -R crypto/libsodium-fork/. crypto/copies/$(OS_TYPE)/$(ARCH)/libsodium-fork
 	cd crypto/copies/$(OS_TYPE)/$(ARCH)/libsodium-fork && \
 		./autogen.sh --prefix $(SRCPATH)/crypto/libs/$(OS_TYPE)/$(ARCH) && \
 		./configure --disable-shared --prefix="$(SRCPATH)/crypto/libs/$(OS_TYPE)/$(ARCH)" && \

--- a/tools/network/dnssec/sort_test.go
+++ b/tools/network/dnssec/sort_test.go
@@ -32,7 +32,7 @@ func TestSrvSort(t *testing.T) {
 	arr := make([]*net.SRV, 0, 7)
 	arr = append(arr, &net.SRV{Priority: 4, Weight: 1})
 	arr = append(arr, &net.SRV{Priority: 3, Weight: 1})
-	arr = append(arr, &net.SRV{Priority: 1, Weight: 200})
+	arr = append(arr, &net.SRV{Priority: 1, Weight: 0xFFFF}) // max possible value to increase the ordering probability
 	arr = append(arr, &net.SRV{Priority: 1, Weight: 1})
 	arr = append(arr, &net.SRV{Priority: 1, Weight: 1})
 	arr = append(arr, &net.SRV{Priority: 1, Weight: 1})
@@ -41,17 +41,17 @@ func TestSrvSort(t *testing.T) {
 	retryCounter := 0
 retry:
 	srvRecArray(arr).sortAndRand()
-	if (*arr[0] != net.SRV{Priority: 1, Weight: 200}) {
-		// there is a small change that random number from 0 to 204 would 0 or 1
-		// so the first element would be with weight of 1 and not 200
-		// if this happens, we will try again
-		if retryCounter > 3 {
-			a.Fail("randomization failed")
+	if (*arr[0] != net.SRV{Priority: 1, Weight: 0xFFFF}) {
+		// there is a small change that a random number from 0 to max uint15 would be 0 or 1
+		// in this case the first element of the resulting sequence would be with weight of 1 and not the highest possible.
+		// if this happens, we will try again since it is expected time to time.
+		if retryCounter > 1 {
+			a.Fail("The first element of the resulting sequence should be with the highest possible weight at least in one of 3 attempts")
 		}
 		retryCounter++
 		goto retry
 	}
-	a.Equal(net.SRV{Priority: 1, Weight: 200}, *arr[0])
+	a.Equal(net.SRV{Priority: 1, Weight: 0xFFFF}, *arr[0])
 	a.Equal(net.SRV{Priority: 1, Weight: 1}, *arr[1])
 	a.Equal(net.SRV{Priority: 1, Weight: 1}, *arr[2])
 	a.Equal(net.SRV{Priority: 1, Weight: 1}, *arr[3])

--- a/tools/network/dnssec/sort_test.go
+++ b/tools/network/dnssec/sort_test.go
@@ -38,7 +38,19 @@ func TestSrvSort(t *testing.T) {
 	arr = append(arr, &net.SRV{Priority: 1, Weight: 1})
 	arr = append(arr, &net.SRV{Priority: 1, Weight: 1})
 
+	retryCounter := 0
+retry:
 	srvRecArray(arr).sortAndRand()
+	if (*arr[0] != net.SRV{Priority: 1, Weight: 200}) {
+		// there is a small change that random number from 0 to 204 would 0 or 1
+		// so the first element would be with weight of 1 and not 200
+		// if this happens, we will try again
+		if retryCounter > 3 {
+			a.Fail("randomization failed")
+		}
+		retryCounter++
+		goto retry
+	}
 	a.Equal(net.SRV{Priority: 1, Weight: 200}, *arr[0])
 	a.Equal(net.SRV{Priority: 1, Weight: 1}, *arr[1])
 	a.Equal(net.SRV{Priority: 1, Weight: 1}, *arr[2])

--- a/tools/network/dnssec/sort_test.go
+++ b/tools/network/dnssec/sort_test.go
@@ -42,7 +42,7 @@ func TestSrvSort(t *testing.T) {
 retry:
 	srvRecArray(arr).sortAndRand()
 	if (*arr[0] != net.SRV{Priority: 1, Weight: 0xFFFF}) {
-		// there is a small change that a random number from 0 to max uint15 would be 0 or 1
+		// there is a small chance that a random number from 0 to max uint15 would be 0 or 1
 		// in this case the first element of the resulting sequence would be with weight of 1 and not the highest possible.
 		// if this happens, we will try again since it is expected time to time.
 		if retryCounter > 1 {


### PR DESCRIPTION
## Summary

1. Fix libsodium copying when re-running libsodium build. This caused `libsodium-fork/libsodium-fork` nested directory for example in this path: `./crypto/copies/darwin/amd64/libsodium-fork/libsodium-fork/src/libsodium/crypto_sign/ed25519/ref10`. This prevents from making changes in libsodium sources and compiling it with make like `make crypto/libs/darwin/amd64/lib/libsodium.a`.
2. Fix TestLedgerErrorValidate that fails when ledger flushes accounts between EnsureValidatedBlock and EnsureBlock for the same round. This causes very specific lookup error that comes from evaluator. Fix handles this specific error.
3. Fix TestSrvSort. Sometimes random generator draws values 0, 1 for uniform between [0, 204] and breaks test assumption. Retry up to 3 times in this case.

## Test Plan

1. Tested manually - no nested dup dirs anymore.
2. Cannot repro locally.
3. Reproducible with `go test ./tools/network/dnssec -run TestSrvSort -count 100` and gone after the fix.