### PR TITLE
CI: Don't run tests during benchmark

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,7 +29,7 @@ jobs:
       # degradation, (2) `eval` degradation.  (2) suggests a broader performance
       # issue. 
       - name: Run benchmark
-        run: go test ./data/transactions/logic -bench 'BenchmarkUintMath' | tee benchmark_output.txt
+        run: go test ./data/transactions/logic -bench 'BenchmarkUintMath' -run=^$ | tee benchmark_output.txt
       - name: Push benchmark result to gh-pages branch
         if: github.event_name == 'push'
         uses: benchmark-action/github-action-benchmark@v1


### PR DESCRIPTION
## Summary

I noticed that our benchmark job also runs all unit tests in the logic package.

Not only is this unnecessary, it also causes the benchmark job to fail if there are unrelated test failures in that package, which I found confusing during development. See here for an example: https://github.com/algorand/go-algorand/actions/runs/5340633710/jobs/9680667023

The solution is pretty simple, we just need to filter out all tests, which I've done by adding the `-run=^$` flag.

## Test Plan

n/a
