### PR TITLE
Fix: goal clerk rawsend print pending round rather than ptr to round

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -630,7 +630,7 @@ var rawsendCmd = &cobra.Command{
 				}
 
 				if txn.ConfirmedRound != nil && *txn.ConfirmedRound > 0 {
-					reportInfof(infoTxCommitted, txidStr, txn.ConfirmedRound)
+					reportInfof(infoTxCommitted, txidStr, *txn.ConfirmedRound)
 					break
 				}
 

--- a/test/scripts/e2e_subs/rawsend.sh
+++ b/test/scripts/e2e_subs/rawsend.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+date '+rawsend-test start %Y%m%d_%H%M%S'
+
+set -e
+set -x
+set -o pipefail
+export SHELLOPTS
+
+WALLET=$1
+
+gcmd="goal -w ${WALLET}"
+
+ACCOUNTA=$(${gcmd} account list|awk '{ print $3 }')
+ACCOUNTB=$(${gcmd} account new|awk '{ print $6 }')
+
+# prepare the signed txn for rawsend
+${gcmd} clerk send -a 100000000 -f ${ACCOUNTA} -t ${ACCOUNTB} -o ${TEMPDIR}/send-from-a-to-b.txn
+${gcmd} clerk sign -i ${TEMPDIR}/send-from-a-to-b.txn -o ${TEMPDIR}/send-from-a-to-b.stxn
+
+# rawsend should go through
+RES=$(${gcmd} clerk rawsend -f ${TEMPDIR}/send-from-a-to-b.stxn 2>&1 || true)
+EXPERROR='rejected'
+if [[ $RES == *"${EXPERROR}"* ]]; then
+    date '+rawsend-test sending raw signed payment txn should not be rejected %Y%m%d_%H%M%S'
+    false
+fi
+
+# pending round info matching from log, should always be ascending order
+STILL_PENDING_PATTERN='still pending as of round [[:digit:]]+'
+
+PENDING_ROUNDS=$(echo ${RES} | grep -Eo "${STILL_PENDING_PATTERN}" | grep -Eo '[[:digit:]]+')
+ASCENDING_PENDING_ROUNDS=$(echo ${PENDING_ROUNDS} | sort -n)
+
+if [[ ${PENDING_ROUNDS} != ${ASCENDING_PENDING_ROUNDS} ]]; then
+    date '+rawsend-test pending rounds should be in ascending order %Y%m%d_%H%M%S'
+    false
+fi
+
+LAST_PENDING_ROUND=$(echo ${PENDING_ROUNDS} | tail -1)
+
+# prepare commmited round, and committed round should always > any of the pending rounds
+COMMITTED_PATTERN='committed in round [[:digit:]]+'
+COMMITTED_ROUND=$(echo ${RES} | grep -Eo "${COMMITTED_PATTERN}" | grep -Eo '[[:digit:]]+')
+
+if [[ ! ${COMMITTED_ROUND} -gt ${LAST_PENDING_ROUND} ]]; then
+    date '+rawsend-test pending rounds should always be smaller than committed round %Y%m%d_%H%M%S'
+    false
+fi


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

This PR should fix #4963, where `goal clerk rawsend` prints ptr to pending round rather than actual pending round.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

An e2e-sh test for rawsend testing pending rounds + committed round should always be in ascending order.