### PR TITLE
algocfg: Remove block validation override from participation profile.

### DIFF
--- a/cmd/algocfg/profileCommand.go
+++ b/cmd/algocfg/profileCommand.go
@@ -61,7 +61,6 @@ var (
 	participation = configUpdater{
 		description: "Participate in consensus or simply ensure chain health by validating blocks.",
 		updateFunc: func(cfg config.Local) config.Local {
-			cfg.CatchupBlockValidateMode = 0b1100
 			return cfg
 		},
 	}


### PR DESCRIPTION
## Summary

The default `CatchupBlockValidationMode` value is sufficient for participation.