### PR TITLE
config: update MaxCatchpointDownloadDuration to 12h

### DIFF
--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -361,7 +361,7 @@ type Local struct {
 	// MaxCatchpointDownloadDuration defines the maximum duration a client will be keeping the outgoing connection of a catchpoint download request open for processing before
 	// shutting it down. Networks that have large catchpoint files, slow connection or slow storage could be a good reason to increase this value. Note that this is a client-side only
 	// configuration value, and it's independent of the actual catchpoint file size.
-	MaxCatchpointDownloadDuration time.Duration `version[13]:"7200000000000"`
+	MaxCatchpointDownloadDuration time.Duration `version[13]:"7200000000000" version[28]:"43200000000000"`
 
 	// MinCatchpointFileDownloadBytesPerSecond defines the minimal download speed that would be considered to be "acceptable" by the catchpoint file fetcher, measured in bytes per seconds. If the
 	// provided stream speed drops below this threshold, the connection would be recycled. Note that this field is evaluated per catchpoint "chunk" and not on it's own. If this field is zero,

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -95,7 +95,7 @@ var defaultLocal = Local{
 	MaxAPIBoxPerApplication:                    100000,
 	MaxAPIResourcesPerAccount:                  100000,
 	MaxAcctLookback:                            4,
-	MaxCatchpointDownloadDuration:              7200000000000,
+	MaxCatchpointDownloadDuration:              43200000000000,
 	MaxConnectionsPerIP:                        15,
 	MinCatchpointFileDownloadBytesPerSecond:    20480,
 	NetAddress:                                 "",

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -74,7 +74,7 @@
     "MaxAPIBoxPerApplication": 100000,
     "MaxAPIResourcesPerAccount": 100000,
     "MaxAcctLookback": 4,
-    "MaxCatchpointDownloadDuration": 7200000000000,
+    "MaxCatchpointDownloadDuration": 43200000000000,
     "MaxConnectionsPerIP": 15,
     "MinCatchpointFileDownloadBytesPerSecond": 20480,
     "NetAddress": "",

--- a/test/testdata/configs/config-v28.json
+++ b/test/testdata/configs/config-v28.json
@@ -74,7 +74,7 @@
     "MaxAPIBoxPerApplication": 100000,
     "MaxAPIResourcesPerAccount": 100000,
     "MaxAcctLookback": 4,
-    "MaxCatchpointDownloadDuration": 7200000000000,
+    "MaxCatchpointDownloadDuration": 43200000000000,
     "MaxConnectionsPerIP": 15,
     "MinCatchpointFileDownloadBytesPerSecond": 20480,
     "NetAddress": "",


### PR DESCRIPTION
## Summary

Today the catchpoint restore system waits for a maximum of 2 hours to download a snapshot before giving up. Since this parameter was originally set, the size of a snapshot has increased by several times. This increases the default `MaxCatchpointDownloadDuration` configuration value to 12h.

## Test Plan

Configuration update only; existing tests should pass.