### PR TITLE
goal: account info with deleted asset suppress error and better output

### DIFF
--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -632,15 +632,15 @@ func printAccountInfo(client libgoal.Client, address string, onlyShowAssetIds bo
 		}
 		assetParams, err := client.AssetInformation(assetHolding.AssetID)
 		if err != nil {
-			hasError = true
-
 			var httpError apiClient.HTTPError
 			if errors.As(err, &httpError) && httpError.StatusCode == http.StatusNotFound {
 				fmt.Fprintf(report, "\tID %d, <deleted/unknown asset>\n", assetHolding.AssetID)
 			} else {
 				fmt.Fprintf(errorReport, "Error: Unable to retrieve asset information for asset %d referred to by account %s: %v\n", assetHolding.AssetID, address, err)
 				fmt.Fprintf(report, "\tID %d, error\n", assetHolding.AssetID)
+				hasError = true
 			}
+			continue
 		}
 
 		amount := assetDecimalsFmt(assetHolding.Amount, assetParams.Params.Decimals)

--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -19,7 +19,9 @@ package main
 import (
 	"bufio"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -33,6 +35,7 @@ import (
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/passphrase"
+	apiClient "github.com/algorand/go-algorand/daemon/algod/api/client"
 	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated/model"
 	algodAcct "github.com/algorand/go-algorand/data/account"
 	"github.com/algorand/go-algorand/data/basics"
@@ -630,8 +633,14 @@ func printAccountInfo(client libgoal.Client, address string, onlyShowAssetIds bo
 		assetParams, err := client.AssetInformation(assetHolding.AssetID)
 		if err != nil {
 			hasError = true
-			fmt.Fprintf(errorReport, "Error: Unable to retrieve asset information for asset %d referred to by account %s: %v\n", assetHolding.AssetID, address, err)
-			fmt.Fprintf(report, "\tID %d, error\n", assetHolding.AssetID)
+
+			var httpError apiClient.HTTPError
+			if errors.As(err, &httpError) && httpError.StatusCode == http.StatusNotFound {
+				fmt.Fprintf(report, "\tID %d, <deleted/unknown asset>\n", assetHolding.AssetID)
+			} else {
+				fmt.Fprintf(errorReport, "Error: Unable to retrieve asset information for asset %d referred to by account %s: %v\n", assetHolding.AssetID, address, err)
+				fmt.Fprintf(report, "\tID %d, error\n", assetHolding.AssetID)
+			}
 		}
 
 		amount := assetDecimalsFmt(assetHolding.Amount, assetParams.Params.Decimals)

--- a/test/scripts/e2e_subs/goal-account-asset.sh
+++ b/test/scripts/e2e_subs/goal-account-asset.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+date '+goal-account-asset-test start %Y%m%d_%H%M%S'
+
+set -e
+set -x
+set -o pipefail
+export SHELLOPTS
+
+WALLET=$1
+
+gcmd="goal -w ${WALLET}"
+
+ACCOUNTA=$(${gcmd} account list|awk '{ print $3 }')
+ACCOUNTB=$(${gcmd} account new|awk '{ print $6 }')
+
+ASSET_INDEX_PATTERN='Created asset with asset index [[:digit:]]+'
+
+# fund account B a bit
+${gcmd} clerk send -a 100000000 -f ${ACCOUNTA} -t ${ACCOUNTB}
+
+# create all assets
+RES=$(${gcmd} asset create --name "asset-a" --creator ${ACCOUNTA} --total 100 --no-clawback --no-freezer --manager ${ACCOUNTA} --no-reserve --signer ${ACCOUNTA})
+ASSET_A_ID=$(echo ${RES} | grep -Eo "${ASSET_INDEX_PATTERN}" | grep -Eo '[[:digit:]]+')
+
+RES=$(${gcmd} asset create --name "asset-b" --creator ${ACCOUNTA} --total 200 --no-clawback --no-freezer --manager ${ACCOUNTA} --no-reserve --signer ${ACCOUNTA})
+ASSET_B_ID=$(echo ${RES} | grep -Eo "${ASSET_INDEX_PATTERN}" | grep -Eo '[[:digit:]]+')
+
+RES=$(${gcmd} asset create --name "asset-c" --creator ${ACCOUNTA} --total 300 --no-clawback --no-freezer --manager ${ACCOUNTA} --no-reserve --signer ${ACCOUNTA})
+ASSET_C_ID=$(echo ${RES} | grep -Eo "${ASSET_INDEX_PATTERN}" | grep -Eo '[[:digit:]]+')
+
+RES=$(${gcmd} asset create --name "asset-d" --creator ${ACCOUNTA} --total 400 --no-clawback --no-freezer --manager ${ACCOUNTA} --no-reserve --signer ${ACCOUNTA})
+ASSET_D_ID=$(echo ${RES} | grep -Eo "${ASSET_INDEX_PATTERN}" | grep -Eo '[[:digit:]]+')
+
+# opt in all assets
+${gcmd} asset optin --account ${ACCOUNTB} --assetid ${ASSET_A_ID} --signer ${ACCOUNTB}
+${gcmd} asset optin --account ${ACCOUNTB} --assetid ${ASSET_B_ID} --signer ${ACCOUNTB}
+${gcmd} asset optin --account ${ACCOUNTB} --assetid ${ASSET_C_ID} --signer ${ACCOUNTB}
+${gcmd} asset optin --account ${ACCOUNTB} --assetid ${ASSET_D_ID} --signer ${ACCOUNTB}
+
+# displays held assets
+${gcmd} account info -a ${ACCOUNTB}
+
+# delete one of the asset
+${gcmd} asset destroy --assetid ${ASSET_B_ID} --creator ${ACCOUNTA} --signer ${ACCOUNTA}
+
+# check account info display
+RES=$(${gcmd} account info -a ${ACCOUNTB})
+
+# check result
+EXPECTED="ID ${ASSET_B_ID}, <deleted/unknown asset>"
+
+if [[ ${RES} != *"${EXPECTED}"* ]]; then
+    date '+goal-account-asset-test should list account info with deleted asset expected line %Y%m%d_%H%M%S'
+    false
+fi


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

Suppress the asset search error with a better output on deleted/unknown asset (404 resp on querying such asset from algod). An example output is shown as follows:
```
Created Assets:
	<none>
Held Assets:
	ID 1003, asset-a, balance 0 units
	ID 1004, <deleted/unknown asset>
	ID 1005, asset-c, balance 0 units
	ID 1006, asset-d, balance 0 units
Created Apps:
	<none>
Opted In Apps:
	<none>
Minimum Balance:	500000 microAlgos
```

Should resolve #5154.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

An e2e test for `goal account info` with deleted asset.
