### PR TITLE
enhancement: fix slow docker container start up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
     useradd --uid=999 --no-log-init --create-home --system --gid algorand algorand && \
     chown -R algorand:algorand /algod
 
+USER algorand
+
 COPY --chown=algorand:algorand --from=builder "/dist/bin/" "/node/bin/"
 COPY --chown=algorand:algorand --from=builder "/dist/files/run/" "/node/run/"
 


### PR DESCRIPTION
Algod container v3.16.2-stable is taking 30s longer to start up than v3.15.1. This issue occurs when running the container as a root user. This PR sets the container to use a non-root user as in v3.15.1. 

A test has been ran from a forked branch with this change. 
`docker build -t algod-local --no-cache --build-arg BRANCH=v3.16.2 --build-arg URL=https://github.com/shiqizng/go-algorand.git .`

and the warm up time is down to 7s after the change. 
```
Starting algod-local:latest
Waiting for /v2/status ......
Took 7s
```

```
#!/bin/bash
export TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

wait_for_status() {
   echo -n "Waiting for /v2/status "
   for i in {1..60}; do
      curl --fail http://localhost:8080/v2/status --header "X-Algo-API-Token: $TOKEN" &>/dev/null
      if [ $? -eq 0 ]; then
         echo 
         echo "Took ${i}s"
         return
      fi
      echo -n .
      sleep 1
   done
}

get_warmup_local() {
   version=$1
   echo "Starting algod-local:$version"
   docker run \
      --name algod_warm_local \
      -d \
      --env START_KMD=1 \
      --env TOKEN=$TOKEN \
      -p 8080:8080 \
      algod-local:$version >/dev/null
   
   wait_for_status
#    echo "Cleaning up ..."   
      docker stop algod_warm_local >/dev/null
      docker rm algod_warm >/dev/null
   echo
}
get_warmup_local latest
```

