### PR TITLE
docker: Start kmd in the background.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
     useradd --uid=999 --no-log-init --create-home --system --gid algorand algorand && \
     chown -R algorand:algorand /algod
 
-USER algorand
-
 COPY --chown=algorand:algorand --from=builder "/dist/bin/" "/node/bin/"
 COPY --chown=algorand:algorand --from=builder "/dist/files/run/" "/node/run/"
 

--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -12,7 +12,7 @@ fi
 # as the algorand user.
 if [ "$(id -u)" = '0' ]; then
   chown -R algorand:algorand $ALGORAND_DATA
-  exec runuser -u algorand "$BASH_SOURCE"
+  runuser -u algorand "$BASH_SOURCE"
 fi
 
 # Script to configure or resume a network. Based on environment settings the

--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -155,7 +155,7 @@ function start_new_public_network() {
 
 function start_private_network() {
   configure_data_dir
-  start_kmd
+  start_kmd &
 
   # TODO: Is there a way to properly exec a private network?
   goal network start -r "${ALGORAND_DATA}/.."


### PR DESCRIPTION
## Summary

The user is left out intentionally, see #5464 

This doesn't fix the root issue where it takes 30 seconds for kmd to start, but should allow it to startup without delay.

## Test Plan

Test against rel/stable and this PR branch:

```
docker build \
             -t wwinder/algod:exec \
             --build-arg CHANNEL=stable \
             --build-arg TARGETARCH=amd64 --no-cache \
             .
```

```
docker run --rm -it \
             -e START_KMD=1 \
             --name algod-test-run \
             -v (pwd)/docker_data_dir:/algod/data \
             wwinder/algod:exec
```

on rel/stable it takes 30 seconds to startup due to kmd locking the pidfile, which is due to the user being managed incorrectly with exec and runuser.

With this branch it starts in less than 5 seconds.