### PR TITLE
API: Allow DELETE calls

### DIFF
--- a/daemon/algod/api/server/lib/middlewares/cors.go
+++ b/daemon/algod/api/server/lib/middlewares/cors.go
@@ -28,6 +28,6 @@ func MakeCORS(tokenHeader string) echo.MiddlewareFunc {
 	return middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins: []string{"*"},
 		AllowHeaders: []string{tokenHeader, "Content-Type"},
-		AllowMethods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodOptions},
+		AllowMethods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions},
 	})
 }


### PR DESCRIPTION
## Summary

The algod REST API has some methods that require DELETE calls. In particular, I want to [delete a participation key](https://developer.algorand.org/docs/rest-apis/algod/#delete-v2participationparticipation-id). Making a DELETE call currently gives the following error:
```
Access to fetch at 'http://localhost:8080/v2/participation/{participation-id}' from origin 'http://localhost:3000' has been blocked by CORS policy: Method DELETE is not allowed by Access-Control-Allow-Methods in preflight response.
```

This PR adds the DELETE method to the the Access-Control-Allow-Methods so the DELETE endpoints will work.

## Test Plan

I started the node, generated a key, and then deleted the key via the API to make sure it worked.
