### PR TITLE
bugfix: ensure blockservice callbacks are not nil

### DIFF
--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -416,11 +416,15 @@ func (wp *wsPeer) Respond(ctx context.Context, reqMsg IncomingMessage, outMsg Ou
 	select {
 	case wp.sendBufferBulk <- sendMessages{msgs: msg, onRelease: outMsg.OnRelease}:
 	case <-wp.closing:
-		outMsg.OnRelease()
+		if outMsg.OnRelease != nil {
+			outMsg.OnRelease()
+		}
 		wp.net.log.Debugf("peer closing %s", wp.conn.RemoteAddr().String())
 		return
 	case <-ctx.Done():
-		outMsg.OnRelease()
+		if outMsg.OnRelease != nil {
+			outMsg.OnRelease()
+		}
 		return ctx.Err()
 	}
 	return nil


### PR DESCRIPTION
## Summary

@cce caught an issue with a #5472 after it was merged. Here is the fix to ensure clean shutdown of the server since before we weren't checking that `OnRelease` callback isn't nil. 

## Test Plan

 Existing tests