### PR TITLE
Bugfix: rawsend.sh nightly test failure fix

### DIFF
--- a/test/scripts/e2e_subs/rawsend.sh
+++ b/test/scripts/e2e_subs/rawsend.sh
@@ -30,14 +30,16 @@ fi
 STILL_PENDING_PATTERN='still pending as of round [[:digit:]]+'
 
 PENDING_ROUNDS=$(echo ${RES} | grep -Eo "${STILL_PENDING_PATTERN}" | grep -Eo '[[:digit:]]+')
-ASCENDING_PENDING_ROUNDS=$(echo ${PENDING_ROUNDS} | sort -n)
 
-if [[ ${PENDING_ROUNDS} != ${ASCENDING_PENDING_ROUNDS} ]]; then
+echo "$PENDING_ROUNDS" | sort -nuC
+SORT_CHECK=$?
+
+if [[ ${SORT_CHECK} -ne 0 ]]; then
     date '+rawsend-test pending rounds should be in ascending order %Y%m%d_%H%M%S'
     false
 fi
 
-LAST_PENDING_ROUND=$(echo ${PENDING_ROUNDS} | tail -1)
+LAST_PENDING_ROUND=$(echo "$PENDING_ROUNDS" | tail -1)
 
 # prepare commmited round, and committed round should always > any of the pending rounds
 COMMITTED_PATTERN='committed in round [[:digit:]]+'


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

Sorry, screwed up the e2e test for `rawsend.sh`:
- use `sort -nuC` then `$?` to check pending rounds in ascending order
- `echo "$PENDING_ROUNDS"` to keep breaklines, such that we can `tail -1` for last pending round