### PR TITLE
tests: fix TestLedgerReloadStateProofVerificationTracker

### DIFF
--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -205,12 +205,14 @@ func (ao *onlineAccounts) latest() basics.Round {
 
 // close closes the accountUpdates, waiting for all the child go-routine to complete
 func (ao *onlineAccounts) close() {
+	// ao.voters' loadTree might use ao.accountsq if looking up DB
+	// so it must be closed before ao.accountsq
+	ao.voters.close()
+
 	if ao.accountsq != nil {
 		ao.accountsq.Close()
 		ao.accountsq = nil
 	}
-
-	ao.voters.close()
 
 	ao.baseOnlineAccounts.prune(0)
 }

--- a/ledger/spverificationtracker.go
+++ b/ledger/spverificationtracker.go
@@ -226,8 +226,8 @@ func (spt *spVerificationTracker) lookupContextInTrackedMemory(stateProofLastAtt
 		}
 	}
 
-	return &ledgercore.StateProofVerificationContext{}, fmt.Errorf("%w for round %d: memory lookup failed",
-		errSPVerificationContextNotFound, stateProofLastAttestedRound)
+	return &ledgercore.StateProofVerificationContext{}, fmt.Errorf("%w for round %d: memory lookup failed (pending len %d)",
+		errSPVerificationContextNotFound, stateProofLastAttestedRound, len(spt.pendingCommitContexts))
 }
 
 func (spt *spVerificationTracker) lookupContextInDB(stateProofLastAttestedRound basics.Round) (*ledgercore.StateProofVerificationContext, error) {


### PR DESCRIPTION
## Summary

The test failure caused by at least one additional block added into the ledger by `triggerTrackerFlush` that the test does not expect. Replaced `triggerTrackerFlush` by a version that triggers tracker flush without adding new blocks.

Failure [sample](https://app.circleci.com/pipelines/github/algorand/go-algorand/15299/workflows/d14dc96b-6a2c-4919-8b7b-f7ad2f6f8d4f/jobs/243989/parallel-runs/1?filterBy=FAILED):
```
spverificationtracker_test.go:169: 
        	Error Trace:	/opt/cibuild/project/ledger/spverificationtracker_test.go:169
        	            				/opt/cibuild/project/ledger/ledger_test.go:3152
        	Error:      	Received unexpected error:
        	            	requested state proof verification context not found for round 1024: memory lookup failed
        	Test:       	TestLedgerReloadStateProofVerificationTracker
```

Additionally fixed a data race between voters' `loadTree` and test termination:
```
WARNING: DATA RACE
Read at 0x00c002de45a0 by goroutine 705967:
  github.com/algorand/go-algorand/ledger.(*onlineAccounts).onlineTotalsEx()
      /go-algorand/ledger/acctonline.go:592 +0x184
  github.com/algorand/go-algorand/ledger.(*onlineAccounts).TopOnlineAccounts()
      /go-algorand/ledger/acctonline.go:968 +0xe66
  github.com/algorand/go-algorand/ledger/ledgercore.(*VotersForRound).LoadTree()
      /go-algorand/ledger/ledgercore/votersForRound.go:129 +0x11c
  github.com/algorand/go-algorand/ledger.(*votersTracker).loadTree.func1()
      /go-algorand/ledger/voters.go:181 +0x154

Previous write at 0x00c002de45a0 by goroutine 656506:
  github.com/algorand/go-algorand/ledger.(*onlineAccounts).close()
      /go-algorand/ledger/acctonline.go:210 +0x71
  github.com/algorand/go-algorand/ledger.(*trackerRegistry).close()
      /go-algorand/ledger/tracker.go:464 +0x104
  github.com/algorand/go-algorand/ledger.(*Ledger).Close()
      go-algorand/ledger/ledger.go:407 +0x104
  github.com/algorand/go-algorand/ledger.TestLedgerReloadStateProofVerificationTracker.func1()
      /go-algorand/ledger/ledger_test.go:3116 +0x39
```
and 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x100f7d475]

goroutine 706026 [running]:
github.com/algorand/go-algorand/ledger.(*onlineAccounts).onlineTotalsEx(0xc002de4590, 0xc000bb5920?)
	/go-algorand/ledger/acctonline.go:592 +0x195
github.com/algorand/go-algorand/ledger.(*onlineAccounts).TopOnlineAccounts(0xc002de4590, 0xf0, 0x200, 0x400, 0xc005d943a8, 0x4?)
```

## Test Plan

Repro:
```
go test -c ./ledger -race  -run TestLedgerReloadStateProofVerificationTracker  -o tt

./tt -test.run TestLedgerReloadStateProofVerificationTracker -test.count=30 & ./tt -test.run TestLedgerReloadStateProofVerificationTracker -test.count=30 & ./tt -test.run TestLedgerReloadStateProofVerificationTracker -test.count=30 & ./tt -test.run TestLedgerReloadStateProofVerificationTracker -test.count=30 & ./tt -test.run TestLedgerReloadStateProofVerificationTracker -test.count=30 &
```