### PR TITLE
tracer: Default to ledger tracer when starting new evaluator

### DIFF
--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -760,7 +760,7 @@ func (client RestClient) GetLedgerStateDeltaForTransactionGroup(id string) (resp
 	return
 }
 
-// GetTransactionGroupLedgerStateDeltasForRound retrieves the ledger state deltas for the txn groups in the specified by round
+// GetTransactionGroupLedgerStateDeltasForRound retrieves the ledger state deltas for the txn groups in the specified round
 func (client RestClient) GetTransactionGroupLedgerStateDeltasForRound(round uint64) (response model.TransactionGroupLedgerStateDeltasForRoundResponse, err error) {
 	err = client.get(&response, fmt.Sprintf("/v2/deltas/%d/txn/group", round), nil)
 	return

--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -754,6 +754,18 @@ func (client RestClient) GetLedgerStateDelta(round uint64) (response model.Ledge
 	return
 }
 
+// GetLedgerStateDeltaForTransactionGroup retrieves the ledger state delta for the txn group specified by the id
+func (client RestClient) GetLedgerStateDeltaForTransactionGroup(id string) (response model.LedgerStateDeltaForTransactionGroupResponse, err error) {
+	err = client.get(&response, fmt.Sprintf("/v2/deltas/txn/group/%s", id), nil)
+	return
+}
+
+// GetTransactionGroupLedgerStateDeltasForRound retrieves the ledger state deltas for the txn groups in the specified by round
+func (client RestClient) GetTransactionGroupLedgerStateDeltasForRound(round uint64) (response model.TransactionGroupLedgerStateDeltasForRoundResponse, err error) {
+	err = client.get(&response, fmt.Sprintf("/v2/deltas/%d/txn/group", round), nil)
+	return
+}
+
 // SetBlockTimestampOffset sets the offset in seconds to add to the block timestamp when in devmode
 func (client RestClient) SetBlockTimestampOffset(offset uint64) (err error) {
 	err = client.post(nil, fmt.Sprintf("/v2/devmode/blocks/offset/%d", offset), nil, nil, true)

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -836,15 +836,19 @@ func (l *Ledger) VerifiedTransactionCache() verify.VerifiedTransactionCache {
 // If a value of zero or less is passed to maxTxnBytesPerBlock, the consensus MaxTxnBytesPerBlock would
 // be used instead.
 // The tracer argument is a logic.EvalTracer which will be attached to the evaluator and have its hooked invoked during
-// the eval process for each block. A nil tracer will skip tracer invocation entirely.
+// the eval process for each block. A nil tracer will default to the tracer attached to the ledger.
 func (l *Ledger) StartEvaluator(hdr bookkeeping.BlockHeader, paysetHint, maxTxnBytesPerBlock int, tracer logic.EvalTracer) (*eval.BlockEvaluator, error) {
+	tracerForEval := tracer
+	if tracerForEval == nil {
+		tracerForEval = l.tracer
+	}
 	return eval.StartEvaluator(l, hdr,
 		eval.EvaluatorOptions{
 			PaysetHint:          paysetHint,
 			Generate:            true,
 			Validate:            true,
 			MaxTxnBytesPerBlock: maxTxnBytesPerBlock,
-			Tracer:              tracer,
+			Tracer:              tracerForEval,
 		})
 }
 

--- a/test/e2e-go/features/devmode/devmode_test.go
+++ b/test/e2e-go/features/devmode/devmode_test.go
@@ -110,4 +110,7 @@ func TestTxnGroupDeltasDevMode(t *testing.T) {
 	groupDelta := roundResponse.Deltas[0]
 	require.Equal(t, 1, len(groupDelta.Ids))
 	require.Equal(t, groupDelta.Ids[0], txn.Txn.ID().String())
+
+	// Assert that the TxIDs field across both endpoint responses is the same
+	require.Equal(t, txngroupResponse["Txids"], groupDelta.Delta["Txids"])
 }

--- a/test/e2e-go/features/devmode/devmode_test.go
+++ b/test/e2e-go/features/devmode/devmode_test.go
@@ -75,3 +75,39 @@ func TestDevMode(t *testing.T) {
 		prevTime = currTime
 	}
 }
+
+// Starts up a devmode network, sends a txn, and fetches the txn group delta for that txn
+func TestTxnGroupDeltasDevMode(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	if testing.Short() {
+		t.Skip()
+	}
+
+	// Start devmode network, and send a transaction.
+	var fixture fixtures.RestClientFixture
+	fixture.SetupNoStart(t, filepath.Join("nettemplates", "DevModeTxnTracerNetwork.json"))
+	fixture.Start()
+	defer fixture.Shutdown()
+	sender, err := fixture.GetRichestAccount()
+	require.NoError(t, err)
+	key := crypto.GenerateSignatureSecrets(crypto.Seed{})
+	receiver := basics.Address(key.SignatureVerifier)
+	txn := fixture.SendMoneyAndWait(0, 100000, 1000, sender.Address, receiver.String(), "")
+	require.NotNil(t, txn.ConfirmedRound)
+	_, err = fixture.AlgodClient.Block(*txn.ConfirmedRound)
+	require.NoError(t, err)
+
+	// Test GetLedgerStateDeltaForTransactionGroup and verify the response contains a delta
+	txngroupResponse, err := fixture.AlgodClient.GetLedgerStateDeltaForTransactionGroup(txn.Txn.ID().String())
+	require.NoError(t, err)
+	require.True(t, len(txngroupResponse) > 0)
+
+	// Test GetTransactionGroupLedgerStateDeltasForRound and verify the response contains the delta for our txn
+	roundResponse, err := fixture.AlgodClient.GetTransactionGroupLedgerStateDeltasForRound(1)
+	require.NoError(t, err)
+	require.Equal(t, len(roundResponse.Deltas), 1)
+	groupDelta := roundResponse.Deltas[0]
+	require.Equal(t, 1, len(groupDelta.Ids))
+	require.Equal(t, groupDelta.Ids[0], txn.Txn.ID().String())
+}

--- a/test/testdata/nettemplates/DevModeTxnTracerNetwork.json
+++ b/test/testdata/nettemplates/DevModeTxnTracerNetwork.json
@@ -1,0 +1,36 @@
+{
+  "Genesis": {
+    "NetworkName": "devmodefollowernet",
+    "LastPartKeyRound": 3000,
+    "Wallets": [
+      {
+        "Name": "Wallet1",
+        "Stake": 40,
+        "Online": true
+      },
+      {
+        "Name": "Wallet2",
+        "Stake": 40,
+        "Online": true
+      },
+      {
+        "Name": "Wallet3",
+        "Stake": 20,
+        "Online": true
+      }
+    ],
+    "DevMode": true
+  },
+  "Nodes": [
+    {
+      "Name": "Node",
+      "IsRelay": false,
+      "ConfigJSONOverride": "{\"EnableTxnEvalTracer\":true}",
+      "Wallets": [
+        { "Name": "Wallet1", "ParticipationOnly": false },
+        { "Name": "Wallet2", "ParticipationOnly": false },
+        { "Name": "Wallet3", "ParticipationOnly": false }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION


## Summary

Addresses #5483 by assigning the Block Evaluator's tracer to be the tracer associated with the ledger on creation if there is no tracer passed in.

This lets devmode and private networks accumulate txn group deltas when the tracer is enabled on the ledger.

## Test Plan

Added e2e test which retrieves txn group deltas while in dev mode.
