### PR TITLE
docker: Additional private network options and container tweaks.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,9 @@ FROM debian:bullseye-slim as final
 ENV PATH="/node/bin:${PATH}" ALGOD_PORT="8080" KMD_PORT="7833" ALGORAND_DATA="/algod/data"
 
 # curl is needed to lookup the fast catchup url
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl gosu && \
+    update-ca-certificates && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p "$ALGORAND_DATA" && \
     groupadd --gid=999 --system algorand && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -36,17 +36,19 @@ The following environment variables can be supplied. Except when noted, it is po
 
 | Variable | Description |
 | -------- | ----------- |
-| NETWORK        | Leave blank for a private network, otherwise specify one of mainnet, betanet, testnet, or devnet. Only used during a data directory initialization. |
-| PROFILE        | If set, initializes the config.json file according to the given profile. |
-| DEV_MODE       | If set to 1 on a private network, enable dev mode. Only used during data directory initialization.                                                  |
-| START_KMD      | When set to 1, start kmd service with no timeout. THIS SHOULD NOT BE USED IN PRODUCTION.                                                            |
-| FAST_CATCHUP   | If set to 1 on a public network, attempt to start fast-catchup during initial config.                                                               |
-| TOKEN          | If set, overrides the REST API token.                                                                                                               |
-| ADMIN_TOKEN    | If set, overrides the REST API admin token.                                                                                                         |
-| KMD_TOKEN      | If set along with `START_KMD`, override the KMD REST API token.                                                                                     |
-| TELEMETRY_NAME | If set on a public network, telemetry is reported with this name.                                                                                   |
-| NUM_ROUNDS     | If set on a private network, override default of 30000 participation keys.                                                                          |
-| PEER_ADDRESS   | If set, override phonebook with peer ip:port (or semicolon separated list: ip:port;ip:port;ip:port...)                                              |
+| NETWORK         | Leave blank for a private network, otherwise specify one of mainnet, betanet, testnet, or devnet. Only used during a data directory initialization. |
+| PROFILE         | If set, initializes the config.json file according to the given profile. |
+| DEV_MODE        | If set to 1 on a private network, enable dev mode. Only used during data directory initialization.                                                  |
+| START_KMD       | When set to 1, start kmd service with no timeout. THIS SHOULD NOT BE USED IN PRODUCTION.                                                            |
+| FAST_CATCHUP    | If set to 1 on a public network, attempt to start fast-catchup during initial config.                                                               |
+| TOKEN           | If set, overrides the REST API token.                                                                                                               |
+| ADMIN_TOKEN     | If set, overrides the REST API admin token.                                                                                                         |
+| KMD_TOKEN       | If set along with `START_KMD`, override the KMD REST API token.                                                                                     |
+| TELEMETRY_NAME  | If set on a public network, telemetry is reported with this name.                                                                                   |
+| NUM_ROUNDS      | If set on a private network, override default of 30000 participation keys.                                                                          |
+| GENESIS_ADDRESS | If set, use this API address to initialize the genesis file. |
+| PEER_ADDRESS    | If set, override phonebook with peer ip:port (or semicolon separated list: ip:port;ip:port;ip:port...)                                              |
+| GOSSIP_PORT     | If set, configure the node to listen for external connections on this address. For example "4161" |
 
 ### Special Files
 
@@ -58,7 +60,7 @@ Configuration can be modified by specifying certain files. These can be changed 
 | /etc/algorand/algod.token | Override default randomized REST API token. |
 | /etc/algorand/algod.admin.token | Override default randomized REST API admin token. |
 | /etc/algorand/logging.config | Use a custom [logging.config](https://developer.algorand.org/docs/run-a-node/reference/telemetry-config/#configuration) file for configuring telemetry. |
- | /etc/algorand/template.json | Override default private network topology. One of the nodes in the template must be named "data".| 
+ | /etc/algorand/template.json | Override default private network topology. One of the nodes in the template must be named "data".|
 
 ## Example Configuration
 

--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -17,7 +17,7 @@ fi
 # as the algorand user.
 if [ "$(id -u)" = '0' ]; then
   chown -R algorand:algorand $ALGORAND_DATA
-  runuser -u algorand "$BASH_SOURCE"
+  exec gosu algorand "$0" "$@"
 fi
 
 # Script to configure or resume a network. Based on environment settings the

--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -148,24 +148,23 @@ function start_new_public_network() {
     exit 1
   fi
 
-
-  cp /node/run/config.json.example config.json
-
   configure_data_dir
 
-  local ID
-  case $NETWORK in
-  mainnet) ID="<network>.algorand.network" ;;
-  testnet) ID="<network>.algorand.network" ;;
-  betanet) ID="<network>.algodev.network" ;;
-  alphanet) ID="<network>.algodev.network" ;;
-  devnet) ID="<network>.algodev.network" ;;
-  *)
-    echo "Unknown network, not setting bootstrap ID"
-    ;;
-  esac
+  # if the peer address is set, it will be used instead of the DNS bootstrap ID
+  if [ "$PEER_ADDRESS" != "" ]; then
+    local ID
+    case $NETWORK in
+    mainnet) ID="<network>.algorand.network" ;;
+    testnet) ID="<network>.algorand.network" ;;
+    betanet) ID="<network>.algodev.network" ;;
+    alphanet) ID="<network>.algodev.network" ;;
+    devnet) ID="<network>.algodev.network" ;;
+    *)
+      echo "Unknown network."
+      exit 1
+      ;;
+    esac
 
-  if [ "$ID" != "" ]; then
     set -p DNSBootstrapID -v "$ID"
   fi
 
@@ -227,7 +226,7 @@ elif [ -f "$ALGORAND_DATA/genesis.json" ]; then
 fi
 
 # Initialize and start network.
-if [ "$NETWORK" == "" ]; then
+if [ "$NETWORK" == "" ] && [ "$PEER_ADDRESS" == "" ]; then
   start_new_private_network
 else
   start_new_public_network

--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -76,7 +76,7 @@ function configure_data_dir() {
 
   # initialize config with profile.
   if [ "$PROFILE" != "" ]; then
-    algocfg profile set --yes -d "$ALGORAND_DATA" "$PROFILE" 
+    algocfg profile set --yes -d "$ALGORAND_DATA" "$PROFILE"
   fi
 
   # set profile overrides
@@ -201,19 +201,21 @@ function start_new_private_network() {
 ##############
 
 echo "Starting Algod Docker Container"
-echo "   ALGORAND_DATA:  $ALGORAND_DATA"
-echo "   NETWORK:        $NETWORK"
-echo "   PROFILE:        $PROFILE"
-echo "   DEV_MODE:       $DEV_MODE"
-echo "   START_KMD:      ${START_KMD:-"Not Set"}"
-echo "   FAST_CATCHUP:   $FAST_CATCHUP"
-echo "   TOKEN:          ${TOKEN:-"Not Set"}"
-echo "   ADMIN_TOKEN:    ${ADMIN_TOKEN:-"Not Set"}"
-echo "   KMD_TOKEN:      ${KMD_TOKEN:-"Not Set"}"
-echo "   TELEMETRY_NAME: $TELEMETRY_NAME"
-echo "   NUM_ROUNDS:     $NUM_ROUNDS"
-echo "   PEER_ADDRESS:   $PEER_ADDRESS"
-echo "   ALGOD_PORT:     $ALGOD_PORT"
+echo "   ALGORAND_DATA:   $ALGORAND_DATA"
+echo "   NETWORK:         $NETWORK"
+echo "   PROFILE:         $PROFILE"
+echo "   DEV_MODE:        $DEV_MODE"
+echo "   START_KMD:       ${START_KMD:-"Not Set"}"
+echo "   FAST_CATCHUP:    $FAST_CATCHUP"
+echo "   TOKEN:           ${TOKEN:-"Not Set"}"
+echo "   ADMIN_TOKEN:     ${ADMIN_TOKEN:-"Not Set"}"
+echo "   KMD_TOKEN:       ${KMD_TOKEN:-"Not Set"}"
+echo "   TELEMETRY_NAME:  $TELEMETRY_NAME"
+echo "   NUM_ROUNDS:      $NUM_ROUNDS"
+echo "   GENESIS_ADDRESS: $GENESIS_ADDRESS"
+echo "   PEER_ADDRESS:    $PEER_ADDRESS"
+echo "   GOSSIP_PORT:     $GOSSIP_PORT"
+echo "   ALGOD_PORT:      $ALGOD_PORT"
 
 # If data directory is initialized, start existing environment.
 if [ -f "$ALGORAND_DATA/../network.json" ]; then


### PR DESCRIPTION
## Summary

Add support for configuring a private network with networking enabled, and for adding peers to a non-standard relay.

This is done by adding the following options:

* `GENESIS_ADDRESS` - allows a peer node to resolve `genesis.json` through the REST API.
* `GOSSIP_PORT` - sets the `NetAddress`, ensures `DisableNetworking` is false, and sets `IncomingConnectionsLimit` to 1000.

Additional tweaks:
* Add `ALGORAND_DATA` value sanity check. It should not be overridden.
* Switch from `runuser` to `gosu` to more closely follow conventions in other high quality docker images.

## Test Plan

Manual testing:

1. Same tests used previously for kmd startup delay #5514.
2. The following docker-compose:
```
version: '3'

services:
  algod-private:
    #image: "algorand/algod:stable"
    image: "wwinder/algod:peertest"
    ports:
      - 4190:8080
      - 4191:7833
    environment:
      TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
      ADMIN_TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
      GOSSIP_PORT: 10000

  algod-follower:
    #image: "algorand/algod:stable"
    image: "wwinder/algod:peertest"
    # the genesis file must be downloaded from algod-private
    # if this image starts first, keep restarting until algod-private
    # is available.
    restart: unless-stopped
    # follower node is internal
    ports:
      - 5190:8080 # exposed for testing.
    environment:
      NETWORK: private
      TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
      ADMIN_TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
      PROFILE: conduit
      GENESIS_ADDRESS: algod-private:8080
      PEER_ADDRESS: algod-private:10000
    depends_on:
      - algod-private
```