### PR TITLE
Chore: Small cleanups for clarity

### DIFF
--- a/crypto/multisig.go
+++ b/crypto/multisig.go
@@ -75,6 +75,18 @@ func (msig MultisigSig) Preimage() (version, threshold uint8, pks []PublicKey) {
 	return msig.Version, msig.Threshold, pks
 }
 
+// Signatures returns the actually number of signatures included in the
+// multisig. That is, the number of subsigs that are not blank.
+func (msig MultisigSig) Signatures() int {
+	sigs := 0
+	for i := range msig.Subsigs {
+		if !msig.Subsigs[i].Sig.Blank() {
+			sigs++
+		}
+	}
+	return sigs
+}
+
 const multiSigString = "MultisigAddr"
 const maxMultisig = 255
 
@@ -207,7 +219,7 @@ func MultisigAssemble(unisig []MultisigSig) (msig MultisigSig, err error) {
 	}
 	for i := 0; i < len(unisig); i++ {
 		for j := 0; j < len(unisig[0].Subsigs); j++ {
-			if (unisig[i].Subsigs[j].Sig != Signature{}) {
+			if !unisig[i].Subsigs[j].Sig.Blank() {
 				msig.Subsigs[j].Sig = unisig[i].Subsigs[j].Sig
 			}
 		}
@@ -228,7 +240,7 @@ func MultisigVerify(msg Hashable, addr Digest, sig MultisigSig) (err error) {
 
 // MultisigBatchPrep performs checks on the assembled MultisigSig and adds to the batch.
 // The caller must call batchVerifier.verify() to verify it.
-func MultisigBatchPrep(msg Hashable, addr Digest, sig MultisigSig, batchVerifier *BatchVerifier) (err error) {
+func MultisigBatchPrep(msg Hashable, addr Digest, sig MultisigSig, batchVerifier *BatchVerifier) error {
 	// short circuit: if msig doesn't have subsigs or if Subsigs are empty
 	// then terminate (the upper layer should now verify the unisig)
 	if (len(sig.Subsigs) == 0 || sig.Subsigs[0] == MultisigSubsig{}) {
@@ -238,7 +250,7 @@ func MultisigBatchPrep(msg Hashable, addr Digest, sig MultisigSig, batchVerifier
 	// check the address is correct
 	addrnew, err := MultisigAddrGenWithSubsigs(sig.Version, sig.Threshold, sig.Subsigs)
 	if err != nil {
-		return
+		return err
 	}
 	if addr != addrnew {
 		return errInvalidAddress
@@ -249,37 +261,18 @@ func MultisigBatchPrep(msg Hashable, addr Digest, sig MultisigSig, batchVerifier
 		return errInvalidNumberOfSignature
 	}
 
-	// check that we don't have too few multisig subsigs
-	if len(sig.Subsigs) < int(sig.Threshold) {
-		return errInvalidNumberOfSignature
-	}
-
 	// checks the number of non-blank signatures is no less than threshold
-	var counter uint8
-	for _, subsigi := range sig.Subsigs {
-		if (subsigi.Sig != Signature{}) {
-			counter++
-		}
-	}
-	if counter < sig.Threshold {
+	if sig.Signatures() < int(sig.Threshold) {
 		return errInvalidNumberOfSignature
 	}
 
-	// checks individual signature verifies
-	var sigCount int
+	// queues individual signature verifies
 	for _, subsigi := range sig.Subsigs {
-		if (subsigi.Sig != Signature{}) {
+		if !subsigi.Sig.Blank() {
 			batchVerifier.EnqueueSignature(subsigi.Key, msg, subsigi.Sig)
-			sigCount++
 		}
 	}
-
-	// sanity check. if we get here then every non-blank subsig should have
-	// been verified successfully, and we should have had enough of them
-	if sigCount < int(sig.Threshold) {
-		return errInvalidNumberOfSignature
-	}
-	return
+	return nil
 }
 
 // MultisigAdd adds unisig to an existing msig
@@ -315,8 +308,8 @@ func MultisigAdd(unisig []MultisigSig, msig *MultisigSig) (err error) {
 	// update the msig
 	for i := 0; i < len(unisig); i++ {
 		for j := 0; j < len(msig.Subsigs); j++ {
-			if (unisig[i].Subsigs[j].Sig != Signature{}) {
-				if (msig.Subsigs[j].Sig == Signature{}) {
+			if !unisig[i].Subsigs[j].Sig.Blank() {
+				if msig.Subsigs[j].Sig.Blank() {
 					// add the signature
 					msig.Subsigs[j].Sig = unisig[i].Subsigs[j].Sig
 				} else if msig.Subsigs[j].Sig != unisig[i].Subsigs[j].Sig {
@@ -354,13 +347,13 @@ func MultisigMerge(msig1 MultisigSig, msig2 MultisigSig) (msigt MultisigSig, err
 	msigt.Subsigs = make([]MultisigSubsig, len(msig1.Subsigs))
 	for i := 0; i < len(msigt.Subsigs); i++ {
 		msigt.Subsigs[i].Key = msig1.Subsigs[i].Key
-		if (msig1.Subsigs[i].Sig == Signature{}) {
-			if (msig2.Subsigs[i].Sig != Signature{}) {
+		if msig1.Subsigs[i].Sig.Blank() {
+			if !msig2.Subsigs[i].Sig.Blank() {
 				// update signature with msig2's signature
 				msigt.Subsigs[i].Sig = msig2.Subsigs[i].Sig
 			}
-		} else if (msig2.Subsigs[i].Sig == Signature{} || // msig2's sig is empty
-			msig2.Subsigs[i].Sig == msig1.Subsigs[i].Sig) { // valid duplicates
+		} else if msig2.Subsigs[i].Sig.Blank() || // msig2's sig is empty
+			msig2.Subsigs[i].Sig == msig1.Subsigs[i].Sig { // valid duplicates
 			// update signature with msig1's signature
 			msigt.Subsigs[i].Sig = msig1.Subsigs[i].Sig
 		} else {

--- a/crypto/multisig.go
+++ b/crypto/multisig.go
@@ -75,7 +75,7 @@ func (msig MultisigSig) Preimage() (version, threshold uint8, pks []PublicKey) {
 	return msig.Version, msig.Threshold, pks
 }
 
-// Signatures returns the actually number of signatures included in the
+// Signatures returns the actual number of signatures included in the
 // multisig. That is, the number of subsigs that are not blank.
 func (msig MultisigSig) Signatures() int {
 	sigs := 0

--- a/data/transactions/logic/backwardCompat_test.go
+++ b/data/transactions/logic/backwardCompat_test.go
@@ -368,7 +368,6 @@ func TestBackwardCompatGlobalFields(t *testing.T) {
 		ops := testProg(t, text, AssemblerMaxVersion)
 
 		ep, _, _ := makeSampleEnvWithVersion(1)
-		ep.TxnGroup[0].Txn.RekeyTo = basics.Address{} // avoid min version issues
 		ep.TxnGroup[0].Lsig.Logic = ops.Program
 		_, err := EvalSignature(0, ep)
 		require.Error(t, err)
@@ -431,11 +430,7 @@ func TestBackwardCompatTxnFields(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			ep, tx, _ := makeSampleEnvWithVersion(1)
-			// We'll reject too early if we have a nonzero RekeyTo, because that
-			// field must be zero for every txn in the group if this is an old
-			// AVM version
-			tx.RekeyTo = basics.Address{}
+			ep, _, _ := makeSampleEnvWithVersion(1)
 			ep.TxnGroup[0].Lsig.Logic = ops.Program
 
 			// check failure with version check

--- a/data/transactions/logic/debugger.go
+++ b/data/transactions/logic/debugger.go
@@ -177,7 +177,7 @@ func makeDebugState(cx *EvalContext) *DebugState {
 	globals := make([]basics.TealValue, len(globalFieldSpecs))
 	for _, fs := range globalFieldSpecs {
 		// Don't try to grab app only fields when evaluating a signature
-		if (cx.runModeFlags&ModeSig) != 0 && fs.mode == ModeApp {
+		if cx.runMode == ModeSig && fs.mode == ModeApp {
 			continue
 		}
 		sv, err := cx.globalFieldToValue(fs)
@@ -188,7 +188,7 @@ func makeDebugState(cx *EvalContext) *DebugState {
 	}
 	ds.Globals = globals
 
-	if (cx.runModeFlags & ModeApp) != 0 {
+	if cx.runMode == ModeApp {
 		ds.EvalDelta = cx.txn.EvalDelta
 	}
 
@@ -300,7 +300,7 @@ func (a *debuggerEvalTracerAdaptor) refreshDebugState(cx *EvalContext, evalError
 	ds.OpcodeBudget = cx.remainingBudget()
 	ds.CallStack = ds.parseCallstack(cx.callstack)
 
-	if (cx.runModeFlags & ModeApp) != 0 {
+	if cx.runMode == ModeApp {
 		ds.EvalDelta = cx.txn.EvalDelta
 	}
 

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -57,6 +57,10 @@ func makeSampleEnvWithVersion(version uint64) (*EvalParams, *transactions.Transa
 	if version >= appsEnabledVersion {
 		firstTxn.Txn.Type = protocol.ApplicationCallTx
 	}
+	// avoid putting in a RekeyTo field if version < rekeyingEnabledVersion
+	if version < rekeyingEnabledVersion {
+		firstTxn.Txn.RekeyTo = basics.Address{}
+	}
 	ep := defaultEvalParamsWithVersion(version, makeSampleTxnGroup(firstTxn)...)
 	ledger := NewLedger(nil)
 	ep.SigLedger = ledger
@@ -2845,11 +2849,11 @@ func TestReturnTypes(t *testing.T) {
 				ep.ioBudget = 50
 
 				cx := EvalContext{
-					EvalParams:   ep,
-					runModeFlags: m,
-					groupIndex:   1,
-					txn:          &ep.TxnGroup[1],
-					appID:        300,
+					EvalParams: ep,
+					runMode:    m,
+					groupIndex: 1,
+					txn:        &ep.TxnGroup[1],
+					appID:      300,
 				}
 
 				// These set conditions for some ops that examine the group.

--- a/data/transactions/verify/txnBatch.go
+++ b/data/transactions/verify/txnBatch.go
@@ -212,14 +212,7 @@ func getNumberOfBatchableSigsInTxn(stx *transactions.SignedTxn, groupIndex int) 
 	case regularSig:
 		return 1, nil
 	case multiSig:
-		sig := stx.Msig
-		batchSigs := uint64(0)
-		for _, subsigi := range sig.Subsigs {
-			if (subsigi.Sig != crypto.Signature{}) {
-				batchSigs++
-			}
-		}
-		return batchSigs, nil
+		return uint64(stx.Msig.Signatures()), nil
 	case logicSig:
 		// Currently the sigs in here are not batched. Something to consider later.
 		return 0, nil


### PR DESCRIPTION
I'm doing a larger bit of work to enable logicsig cost pooling and I found myself making these changes along the way. It's easier to review by extracting them into their own PR.  This does four things.

1. Introduces and uses:
```
func (msig MultisigSig) Signatures() int
```
for the several places we need to examine a MultiSig to count the number of sub signatures present.

2. Uses the pre-existing `func (s *Signature) Blank() bool` in many places.

3. Renames `EvalContext.runModeFlags` to simply `EvalContext.runMode` because it takes on a single value, it can't be, for example: `ModeSig | ModeApp`, it must be one or the other.

4. Improves tests by making it so that sample transactions created for versions below `rekeyingEnabledVerion` don't have their `RekeyAddress` set.