### PR TITLE
ledger: increase locks granularity in lookupWithoutRewards

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1327,15 +1327,21 @@ func (au *accountUpdates) lookupWithoutRewards(rnd basics.Round, addr basics.Add
 			return
 		}
 
+		deltas := au.deltas[:offset]
 		rewardsVersion = au.versions[offset]
 		rewardsLevel = au.roundTotals[offset].RewardsLevel
 
 		// check if we've had this address modified in the past rounds. ( i.e. if it's in the deltas )
 		macct, indeltas := au.accounts[addr]
+		if synchronized {
+			au.accountsMu.RUnlock()
+			needUnlock = false
+		}
+
 		if indeltas {
 			// Check if this is the most recent round, in which case, we can
 			// use a cache of the most recent account state.
-			if offset == uint64(len(au.deltas)) {
+			if offset == uint64(currentDeltaLen) {
 				return macct.data, rnd, rewardsVersion, rewardsLevel, nil
 			}
 			// the account appears in the deltas, but we don't know if it appears in the
@@ -1343,7 +1349,7 @@ func (au *accountUpdates) lookupWithoutRewards(rnd basics.Round, addr basics.Add
 			// backwards to ensure that later updates take priority if present.
 			for offset > 0 {
 				offset--
-				d, ok := au.deltas[offset].Accts.GetData(addr)
+				d, ok := deltas[offset].Accts.GetData(addr)
 				if ok {
 					// the returned validThrough here is not optimal, but it still correct. We could get a more accurate value by scanning
 					// the deltas forward, but this would be time consuming loop, which might not pay off.
@@ -1358,6 +1364,10 @@ func (au *accountUpdates) lookupWithoutRewards(rnd basics.Round, addr basics.Add
 			rnd = currentDbRound + basics.Round(currentDeltaLen)
 		}
 
+		if synchronized {
+			au.accountsMu.RLock()
+			needUnlock = true
+		}
 		// check the baseAccounts -
 		if macct, has := au.baseAccounts.read(addr); has {
 			// we don't technically need this, since it's already in the baseAccounts, however, writing this over


### PR DESCRIPTION
## Summary

#### Proposal for exclusion deltas iteration loop from trackers own lock.

1. Take a state snapshot for a single iteration (the first part of the for {} loop in lookupWithoutRewards) - dbRound, deltas, offset, rewards, inDeltas check. 
2. make the nested loop over deltas lock free.

#### Why does it work:
say au.deltas has 10 elements that is backed by some array underneath. e make local `deltas = au.deltas[0:len(au.deltas)]`, pointing to the same backing array. Then there are two options:
1. when receiving a new block => add element
   - if backing array has space, it is not reallocated, just appended, our `deltas` keeps pointing on it
   - if not enough space, then realloc for au.deltas but our `deltas` keeps pointing to the old backing array
2. when committing => remove elements
   - removal op is slicing, so `au.deltas` keeps pointing to the same backing array but to the right subset, our `deltas` is fine as well

The change would benefit from @icorderi work on making lru caches concurrency-safe.

## Test Plan

Existing tests