### PR TITLE
AVM: Enable pooling of logicsig execution across a group

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -445,7 +445,7 @@ var sendCmd = &cobra.Command{
 					CurrentProtocol: proto,
 				},
 			}
-			groupCtx, err := verify.PrepareGroupContext([]transactions.SignedTxn{uncheckedTxn}, &blockHeader, nil)
+			groupCtx, err := verify.PrepareGroupContext([]transactions.SignedTxn{uncheckedTxn}, &blockHeader, nil, nil)
 			if err == nil {
 				err = verify.LogicSigSanityCheck(0, groupCtx)
 			}
@@ -846,7 +846,7 @@ var signCmd = &cobra.Command{
 			}
 			var groupCtx *verify.GroupContext
 			if lsig.Logic != nil {
-				groupCtx, err = verify.PrepareGroupContext(txnGroup, &contextHdr, nil)
+				groupCtx, err = verify.PrepareGroupContext(txnGroup, &contextHdr, nil, nil)
 				if err != nil {
 					// this error has to be unsupported protocol
 					reportErrorf("%s: %v", txFilename, err)

--- a/cmd/tealdbg/debugger_test.go
+++ b/cmd/tealdbg/debugger_test.go
@@ -103,17 +103,13 @@ func TestDebuggerSimple(t *testing.T) {
 	da := makeTestDbgAdapter(t)
 	debugger.AddAdapter(da)
 
-	ep := logic.NewAppEvalParams(make([]transactions.SignedTxnWithAD, 1), &proto, nil)
-	ep.Tracer = logic.MakeEvalTracerDebuggerAdaptor(debugger)
-	ep.SigLedger = logic.NoHeaderLedger{}
-
-	source := `int 0
-int 1
-+
-`
-	ops, err := logic.AssembleStringWithVersion(source, 1)
+	ops, err := logic.AssembleStringWithVersion("int 0; int 1; +", 1)
 	require.NoError(t, err)
-	ep.TxnGroup[0].Lsig.Logic = ops.Program
+	txn := transactions.SignedTxn{}
+	txn.Lsig.Logic = ops.Program
+
+	ep := logic.NewSigEvalParams([]transactions.SignedTxn{txn}, &proto, logic.NoHeaderLedger{})
+	ep.Tracer = logic.MakeEvalTracerDebuggerAdaptor(debugger)
 
 	_, err = logic.EvalSignature(0, ep)
 	require.NoError(t, err)

--- a/cmd/tealdbg/debugger_test.go
+++ b/cmd/tealdbg/debugger_test.go
@@ -103,7 +103,7 @@ func TestDebuggerSimple(t *testing.T) {
 	da := makeTestDbgAdapter(t)
 	debugger.AddAdapter(da)
 
-	ep := logic.NewEvalParams(make([]transactions.SignedTxnWithAD, 1), &proto, nil)
+	ep := logic.NewAppEvalParams(make([]transactions.SignedTxnWithAD, 1), &proto, nil)
 	ep.Tracer = logic.MakeEvalTracerDebuggerAdaptor(debugger)
 	ep.SigLedger = logic.NoHeaderLedger{}
 

--- a/cmd/tealdbg/local.go
+++ b/cmd/tealdbg/local.go
@@ -237,13 +237,13 @@ type evaluation struct {
 	states       AppState
 }
 
-func (e *evaluation) eval(gi int, ep *logic.EvalParams) (pass bool, err error) {
+func (e *evaluation) eval(gi int, sep *logic.EvalParams, aep *logic.EvalParams) (pass bool, err error) {
 	if e.mode == modeStateful {
-		pass, _, err = e.ba.StatefulEval(gi, ep, e.aidx, e.program)
+		pass, _, err = e.ba.StatefulEval(gi, aep, e.aidx, e.program)
 		return
 	}
-	ep.TxnGroup[gi].Lsig.Logic = e.program
-	return logic.EvalSignature(gi, ep)
+	sep.TxnGroup[gi].Lsig.Logic = e.program
+	return logic.EvalSignature(gi, sep)
 }
 
 // LocalRunner runs local eval
@@ -531,23 +531,17 @@ func (r *LocalRunner) RunAll() error {
 		return fmt.Errorf("no program to debug")
 	}
 
-	configureDebugger := func(ep *logic.EvalParams) {
-		// Workaround for Go's nil/empty interfaces nil check after nil assignment, i.e.
-		// r.debugger = nil
-		// ep.Debugger = r.debugger
-		// if ep.Debugger != nil // FALSE
-		if r.debugger != nil {
-			ep.Tracer = logic.MakeEvalTracerDebuggerAdaptor(r.debugger)
-		}
-	}
-
 	txngroup := transactions.WrapSignedTxnsWithAD(r.txnGroup)
 	failed := 0
 	start := time.Now()
 
-	ep := logic.NewAppEvalParams(txngroup, &r.proto, &transactions.SpecialAddresses{})
-	ep.SigLedger = logic.NoHeaderLedger{}
-	configureDebugger(ep)
+	sep := logic.NewSigEvalParams(r.txnGroup, &r.proto, &logic.NoHeaderLedger{})
+	aep := logic.NewAppEvalParams(txngroup, &r.proto, &transactions.SpecialAddresses{})
+	if r.debugger != nil {
+		t := logic.MakeEvalTracerDebuggerAdaptor(r.debugger)
+		sep.Tracer = t
+		aep.Tracer = t
+	}
 
 	var last error
 	for i := range r.runs {
@@ -556,7 +550,7 @@ func (r *LocalRunner) RunAll() error {
 			r.debugger.SaveProgram(run.name, run.program, run.source, run.offsetToLine, run.states)
 		}
 
-		run.result.pass, run.result.err = run.eval(int(run.groupIndex), ep)
+		run.result.pass, run.result.err = run.eval(int(run.groupIndex), sep, aep)
 		if run.result.err != nil {
 			failed++
 			last = run.result.err

--- a/cmd/tealdbg/local.go
+++ b/cmd/tealdbg/local.go
@@ -545,7 +545,7 @@ func (r *LocalRunner) RunAll() error {
 	failed := 0
 	start := time.Now()
 
-	ep := logic.NewEvalParams(txngroup, &r.proto, &transactions.SpecialAddresses{})
+	ep := logic.NewAppEvalParams(txngroup, &r.proto, &transactions.SpecialAddresses{})
 	ep.SigLedger = logic.NoHeaderLedger{}
 	configureDebugger(ep)
 

--- a/cmd/tealdbg/localLedger_test.go
+++ b/cmd/tealdbg/localLedger_test.go
@@ -112,7 +112,7 @@ int 2
 	a.NoError(err)
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
-	ep := logic.NewEvalParams([]transactions.SignedTxnWithAD{{SignedTxn: txn}}, &proto, &transactions.SpecialAddresses{})
+	ep := logic.NewAppEvalParams([]transactions.SignedTxnWithAD{{SignedTxn: txn}}, &proto, &transactions.SpecialAddresses{})
 	pass, delta, err := ba.StatefulEval(0, ep, appIdx, program)
 	a.NoError(err)
 	a.True(pass)

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1363,6 +1363,7 @@ func initConsensusProtocols() {
 	vFuture.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 
 	vFuture.LogicSigVersion = 10 // When moving this to a release, put a new higher LogicSigVersion here
+	vFuture.EnableLogicSigCostPooling = true
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -112,6 +112,14 @@ type ConsensusParams struct {
 	// rather than check each individual app call is within the budget.
 	EnableAppCostPooling bool
 
+	// EnableLogicSigCostPooling specifies LogicSig budgets are pooled across a
+	// group, but unlike app budgets, such pooling must be explicit. The total
+	// available is len(group) * LogicSigMaxCost. The amount requested for a txn
+	// is LogicSigMaxCost by default, but can be changed with the `budget`
+	// opcode. A group is allowed if the total amount requested is less than
+	// what's available.
+	EnableLogicSigCostPooling bool
+
 	// RewardUnit specifies the number of MicroAlgos corresponding to one reward
 	// unit.
 	//

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -113,10 +113,7 @@ type ConsensusParams struct {
 	EnableAppCostPooling bool
 
 	// EnableLogicSigCostPooling specifies LogicSig budgets are pooled across a
-	// group. The total available is (len(group) * LogicSigMaxCost) - a penalty
-	// for verifies that must be performed in signatures (normal, or in
-	// delegated logicsigs). In any event, the budget is always at least
-	// #lsigsInGroup * LogicSigMaxCost.
+	// group. The total available is len(group) * LogicSigMaxCost)
 	EnableLogicSigCostPooling bool
 
 	// RewardUnit specifies the number of MicroAlgos corresponding to one reward

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -113,11 +113,10 @@ type ConsensusParams struct {
 	EnableAppCostPooling bool
 
 	// EnableLogicSigCostPooling specifies LogicSig budgets are pooled across a
-	// group, but unlike app budgets, such pooling must be explicit. The total
-	// available is len(group) * LogicSigMaxCost. The amount requested for a txn
-	// is LogicSigMaxCost by default, but can be changed with the `budget`
-	// opcode. A group is allowed if the total amount requested is less than
-	// what's available.
+	// group. The total available is (len(group) * LogicSigMaxCost) - a penalty
+	// for verifies that must be performed in signatures (normal, or in
+	// delegated logicsigs). In any event, the budget is always at least
+	// #lsigsInGroup * LogicSigMaxCost.
 	EnableLogicSigCostPooling bool
 
 	// RewardUnit specifies the number of MicroAlgos corresponding to one reward

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -400,6 +400,7 @@ func doDryrunRequest(dr *DryrunRequest, response *model.DryrunResponse) {
 	txgroup := transactions.WrapSignedTxnsWithAD(dr.Txns)
 	specials := transactions.SpecialAddresses{}
 	ep := logic.NewAppEvalParams(txgroup, &proto, &specials)
+	sep := logic.NewSigEvalParams(dr.Txns, &proto, &dl)
 
 	origEnableAppCostPooling := proto.EnableAppCostPooling
 	// Enable EnableAppCostPooling so that dryrun
@@ -421,11 +422,10 @@ func doDryrunRequest(dr *DryrunRequest, response *model.DryrunResponse) {
 	response.Txns = make([]model.DryrunTxnResult, len(dr.Txns))
 	for ti, stxn := range dr.Txns {
 		var result model.DryrunTxnResult
-		if len(stxn.Lsig.Logic) > 0 {
+		if !stxn.Lsig.Blank() {
 			var debug dryrunDebugReceiver
-			ep.Tracer = logic.MakeEvalTracerDebuggerAdaptor(&debug)
-			ep.SigLedger = &dl
-			pass, err := logic.EvalSignature(ti, ep)
+			sep.Tracer = logic.MakeEvalTracerDebuggerAdaptor(&debug)
+			pass, err := logic.EvalSignature(ti, sep)
 			var messages []string
 			result.Disassembly = debug.lines          // Keep backwards compat
 			result.LogicSigDisassembly = &debug.lines // Also add to Lsig specific

--- a/daemon/algod/api/server/v2/dryrun.go
+++ b/daemon/algod/api/server/v2/dryrun.go
@@ -399,7 +399,7 @@ func doDryrunRequest(dr *DryrunRequest, response *model.DryrunResponse) {
 	proto := config.Consensus[protocol.ConsensusVersion(dr.ProtocolVersion)]
 	txgroup := transactions.WrapSignedTxnsWithAD(dr.Txns)
 	specials := transactions.SpecialAddresses{}
-	ep := logic.NewEvalParams(txgroup, &proto, &specials)
+	ep := logic.NewAppEvalParams(txgroup, &proto, &specials)
 
 	origEnableAppCostPooling := proto.EnableAppCostPooling
 	// Enable EnableAppCostPooling so that dryrun

--- a/daemon/algod/api/server/v2/dryrun_test.go
+++ b/daemon/algod/api/server/v2/dryrun_test.go
@@ -363,6 +363,7 @@ func init() {
 }
 
 func checkLogicSigPass(t *testing.T, response *model.DryrunResponse) {
+	t.Helper()
 	if len(response.Txns) < 1 {
 		t.Error("no response txns")
 	} else if len(response.Txns) == 0 {

--- a/data/transactions/logic/README.md
+++ b/data/transactions/logic/README.md
@@ -122,21 +122,21 @@ A program can either authorize some delegated action on a normal
 signature-based or multisignature-based account or be wholly in charge
 of a contract account.
 
-* *Delegated Smart Signatures* --- If the account has signed the
-  program (by providing a valid ed25519 signature or valid
-  multisignature for the authorizer address on the string "Program"
-  concatenated with the program bytecode) then: if the program returns
-  true the transaction is authorized as if the account had signed
-  it. This allows an account to hand out a signed program so that
-  other users can carry out delegated actions which are approved by
-  the program. Note that Smart Signature Args are _not_ signed.
+* If the account has signed the program (by providing a valid ed25519
+  signature or valid multisignature for the authorizer address on the
+  string "Program" concatenated with the program bytecode) then: if the
+  program returns true the transaction is authorized as if the account
+  had signed it. This allows an account to hand out a signed program
+  so that other users can carry out delegated actions which are
+  approved by the program. Note that Smart Signature Args are _not_
+  signed.
 
-* *Contract Smart Signatures* -- If the SHA512_256 hash of the program
-  (prefixed by "Program") is equal to authorizer address of the
-  transaction sender then this is a contract account wholly controlled
-  by the program. No other signature is necessary or possible. The
-  only way to execute a transaction against the contract account is
-  for the program to approve it.
+* If the SHA512_256 hash of the program (prefixed by "Program") is
+  equal to authorizer address of the transaction sender then this is a
+  contract account wholly controlled by the program. No other
+  signature is necessary or possible. The only way to execute a
+  transaction against the contract account is for the program to
+  approve it.
 
 The bytecode plus the length of all Args must add up to no more than
 1000 bytes (consensus parameter LogicSigMaxSize). Each opcode has an
@@ -147,18 +147,9 @@ executed or not). Beginning with v4, the program's cost is tracked
 dynamically, while being evaluated. If the program exceeds its budget,
 it fails.
 
-The total program cost of a _delegated_ Smart Signature program must
-no exceed 20,000 (consensus parameter LogicSigMaxCost).
-
-The total program cost of all _contract_ signatures in a group must
-not exceed 20,000 (consensus parameter LogicSigMaxCost) times the
-number of transactions in the group that are not signed by delegated
-Smart Signatures.
-
-More intuitively --- Delegated Smart Signatures receive 20,000 opcode
-units, which they are free to use, but are not shared. All other
-transactions receive 20,000 opcode units each, which are shared among
-the Contract Smart Signatures.
+The total program cost of all Smart Signatures in a group must not
+exceed 20,000 (consensus parameter LogicSigMaxCost) times the number
+of transactions in the group.
 
 
 ## Execution Environment for Smart Contracts (Applications)

--- a/data/transactions/logic/README.md
+++ b/data/transactions/logic/README.md
@@ -122,31 +122,44 @@ A program can either authorize some delegated action on a normal
 signature-based or multisignature-based account or be wholly in charge
 of a contract account.
 
-* If the account has signed the program (by providing a valid ed25519
-  signature or valid multisignature for the authorizer address on the
-  string "Program" concatenated with the program bytecode) then: if the
-  program returns true the transaction is authorized as if the account
-  had signed it. This allows an account to hand out a signed program
-  so that other users can carry out delegated actions which are
-  approved by the program. Note that Smart Signature Args are _not_
-  signed.
+* *Delegated Smart Signatures* --- If the account has signed the
+  program (by providing a valid ed25519 signature or valid
+  multisignature for the authorizer address on the string "Program"
+  concatenated with the program bytecode) then: if the program returns
+  true the transaction is authorized as if the account had signed
+  it. This allows an account to hand out a signed program so that
+  other users can carry out delegated actions which are approved by
+  the program. Note that Smart Signature Args are _not_ signed.
 
-* If the SHA512_256 hash of the program (prefixed by "Program") is
-  equal to authorizer address of the transaction sender then this is a
-  contract account wholly controlled by the program. No other
-  signature is necessary or possible. The only way to execute a
-  transaction against the contract account is for the program to
-  approve it.
+* *Contract Smart Signatures* -- If the SHA512_256 hash of the program
+  (prefixed by "Program") is equal to authorizer address of the
+  transaction sender then this is a contract account wholly controlled
+  by the program. No other signature is necessary or possible. The
+  only way to execute a transaction against the contract account is
+  for the program to approve it.
 
 The bytecode plus the length of all Args must add up to no more than
 1000 bytes (consensus parameter LogicSigMaxSize). Each opcode has an
-associated cost and the program cost must total no more than 20,000
-(consensus parameter LogicSigMaxCost). Most opcodes have a cost of 1,
-but a few slow cryptographic operations have a much higher cost. Prior
-to v4, the program's cost was estimated as the static sum of all the
-opcode costs in the program (whether they were actually executed or
-not). Beginning with v4, the program's cost is tracked dynamically,
-while being evaluated. If the program exceeds its budget, it fails.
+associated cost, usually 1, but a few slow operations have higher
+costs. Prior to v4, the program's cost was estimated as the static sum
+of all the opcode costs in the program (whether they were actually
+executed or not). Beginning with v4, the program's cost is tracked
+dynamically, while being evaluated. If the program exceeds its budget,
+it fails.
+
+The total program cost of a _delegated_ Smart Signature program must
+no exceed 20,000 (consensus parameter LogicSigMaxCost).
+
+The total program cost of all _contract_ signatures in a group must
+not exceed 20,000 (consensus parameter LogicSigMaxCost) times the
+number of transactions in the group that are not signed by delegated
+Smart Signatures.
+
+More intuitively --- Delegated Smart Signatures receive 20,000 opcode
+units, which they are free to use, but are not shared. All other
+transactions receive 20,000 opcode units each, which are shared among
+the Contract Smart Signatures.
+
 
 ## Execution Environment for Smart Contracts (Applications)
 

--- a/data/transactions/logic/README_in.md
+++ b/data/transactions/logic/README_in.md
@@ -125,13 +125,17 @@ of a contract account.
 
 The bytecode plus the length of all Args must add up to no more than
 1000 bytes (consensus parameter LogicSigMaxSize). Each opcode has an
-associated cost and the program cost must total no more than 20,000
-(consensus parameter LogicSigMaxCost). Most opcodes have a cost of 1,
-but a few slow cryptographic operations have a much higher cost. Prior
-to v4, the program's cost was estimated as the static sum of all the
-opcode costs in the program (whether they were actually executed or
-not). Beginning with v4, the program's cost is tracked dynamically,
-while being evaluated. If the program exceeds its budget, it fails.
+associated cost, usually 1, but a few slow operations have higher
+costs. Prior to v4, the program's cost was estimated as the static sum
+of all the opcode costs in the program (whether they were actually
+executed or not). Beginning with v4, the program's cost is tracked
+dynamically, while being evaluated. If the program exceeds its budget,
+it fails.
+
+The total program cost of all Smart Signatures in a group must not
+exceed 20,000 (consensus parameter LogicSigMaxCost) times the number
+of transactions in the group.
+
 
 ## Execution Environment for Smart Contracts (Applications)
 

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -2370,7 +2370,7 @@ func (ops *OpStream) resolveLabels() {
 }
 
 // AssemblerDefaultVersion what version of code do we emit by default
-// AssemblerDefaultVersion is set to 1 on puprose
+// AssemblerDefaultVersion is set to 1 on purpose
 // to prevent accidental building of v1 official templates with version 2
 // because these templates are not aware of rekeying.
 const AssemblerDefaultVersion = 1

--- a/data/transactions/logic/backwardCompat_test.go
+++ b/data/transactions/logic/backwardCompat_test.go
@@ -327,7 +327,7 @@ func TestBackwardCompatTEALv1(t *testing.T) {
 
 	// Cost remains the same, because v0 does not get dynamic treatment
 	ep.Proto.LogicSigMaxCost = 2139
-	ep.MinAvmVersion = new(uint64) // Was higher because sample txn has a rekey
+	ep.minAvmVersion = 0 // Was higher because sample txn has a rekey
 	testLogicBytes(t, program, ep, "static cost", "")
 
 	ep.Proto.LogicSigMaxCost = 2140

--- a/data/transactions/logic/backwardCompat_test.go
+++ b/data/transactions/logic/backwardCompat_test.go
@@ -293,7 +293,7 @@ func TestBackwardCompatTEALv1(t *testing.T) {
 		}
 	}
 
-	// Cost should stay be exactly 2140 for v1
+	// Cost should stay exactly 2140 for v1, even as future changes are made
 	err = CheckSignature(0, optSigParams(maxCost(2139), stxn))
 	require.ErrorContains(t, err, "static cost")
 	ep := optSigParams(maxCost(2140), stxn)

--- a/data/transactions/logic/blackbox_test.go
+++ b/data/transactions/logic/blackbox_test.go
@@ -84,7 +84,7 @@ func TestNewAppEvalParams(t *testing.T) {
 			i, j, param, testCase := i, j, param, testCase
 			t.Run(fmt.Sprintf("i=%d,j=%d", i, j), func(t *testing.T) {
 				t.Parallel()
-				ep := logic.NewEvalParams(testCase.group, &param, nil)
+				ep := logic.NewAppEvalParams(testCase.group, &param, nil)
 				require.NotNil(t, ep)
 				require.Equal(t, ep.TxnGroup, testCase.group)
 				require.Equal(t, *ep.Proto, param)

--- a/data/transactions/logic/blackbox_test.go
+++ b/data/transactions/logic/blackbox_test.go
@@ -84,14 +84,10 @@ func TestNewAppEvalParams(t *testing.T) {
 			t.Run(fmt.Sprintf("i=%d,j=%d", i, j), func(t *testing.T) {
 				t.Parallel()
 				ep := logic.NewAppEvalParams(testCase.group, &param, nil)
-				if testCase.numAppCalls == 0 {
-					require.Nil(t, ep)
-					return
-				}
 				require.NotNil(t, ep)
 				require.Equal(t, ep.TxnGroup, testCase.group)
 				require.Equal(t, *ep.Proto, param)
-				if reflect.DeepEqual(param, config.Consensus[protocol.ConsensusV29]) {
+				if reflect.DeepEqual(param, config.Consensus[protocol.ConsensusV29]) || testCase.numAppCalls == 0 {
 					require.Nil(t, ep.PooledApplicationBudget)
 				} else if reflect.DeepEqual(param, config.Consensus[protocol.ConsensusFuture]) {
 					require.Equal(t, *ep.PooledApplicationBudget, param.MaxAppProgramCost*testCase.numAppCalls)

--- a/data/transactions/logic/box_test.go
+++ b/data/transactions/logic/box_test.go
@@ -148,12 +148,12 @@ func TestBoxAcrossTxns(t *testing.T) {
 	ledger := NewLedger(nil)
 	ledger.NewApp(basics.Address{}, 888, basics.AppParams{})
 	// After creation in first txn, second one can read it (though it's empty)
-	TestApps(t, []string{
+	TryApps(t, []string{
 		`byte "self"; int 64; box_create`,
 		`byte "self"; int 10; int 4; box_extract; byte 0x00000000; ==`,
 	}, nil, 8, ledger)
 	// after creation, modification, the third can read it
-	TestApps(t, []string{
+	TryApps(t, []string{
 		`byte "self"; int 64; box_create`,
 		`byte "self"; int 2; byte "hi"; box_replace; int 1`,
 		`byte "self"; int 1; int 4; box_extract; byte 0x00686900; ==`, // "\0hi\0"
@@ -238,8 +238,8 @@ func TestBoxAvailability(t *testing.T) {
 	ledger := NewLedger(nil)
 	ledger.NewApp(basics.Address{}, 888, basics.AppParams{})
 
-	// B is not available (recall that "self" is set up by MakeSampleEnv, in TestApps)
-	TestApps(t, []string{
+	// B is not available (recall that "self" is set up by MakeSampleEnv, in TryApps)
+	TryApps(t, []string{
 		`byte "self"; int 64; box_create`,
 		`byte "B"; int 10; int 4; box_extract; byte 0x00000000; ==`,
 	}, nil, 8, ledger, Exp(1, fmt.Sprintf("invalid Box reference %#x", 'B')))
@@ -251,7 +251,7 @@ func TestBoxAvailability(t *testing.T) {
 		Boxes:         []transactions.BoxRef{{Index: 0, Name: []byte("B")}},
 	}.SignedTxn())
 	group[0].Txn.Type = protocol.ApplicationCallTx
-	TestApps(t, []string{
+	TryApps(t, []string{
 		`byte "self"; int 64; box_create`,
 		`byte "B"; int 10; int 4; box_extract; byte 0x00000000; ==`,
 	}, group, 8, ledger, Exp(1, "no such box"))
@@ -264,7 +264,7 @@ func TestBoxAvailability(t *testing.T) {
 		Boxes:         []transactions.BoxRef{{Index: 1, Name: []byte("B")}},
 	}.SignedTxn())
 	group[0].Txn.Type = protocol.ApplicationCallTx
-	TestApps(t, []string{
+	TryApps(t, []string{
 		`byte "self"; int 64; box_create`,
 		`byte "B"; int 10; int 4; box_extract; byte 0x00000000; ==`,
 	}, group, 8, ledger, Exp(1, "no such box"))

--- a/data/transactions/logic/box_test.go
+++ b/data/transactions/logic/box_test.go
@@ -148,12 +148,12 @@ func TestBoxAcrossTxns(t *testing.T) {
 	ledger := NewLedger(nil)
 	ledger.NewApp(basics.Address{}, 888, basics.AppParams{})
 	// After creation in first txn, second one can read it (though it's empty)
-	TryApps(t, []string{
+	TestApps(t, []string{
 		`byte "self"; int 64; box_create`,
 		`byte "self"; int 10; int 4; box_extract; byte 0x00000000; ==`,
 	}, nil, 8, ledger)
 	// after creation, modification, the third can read it
-	TryApps(t, []string{
+	TestApps(t, []string{
 		`byte "self"; int 64; box_create`,
 		`byte "self"; int 2; byte "hi"; box_replace; int 1`,
 		`byte "self"; int 1; int 4; box_extract; byte 0x00686900; ==`, // "\0hi\0"
@@ -238,8 +238,8 @@ func TestBoxAvailability(t *testing.T) {
 	ledger := NewLedger(nil)
 	ledger.NewApp(basics.Address{}, 888, basics.AppParams{})
 
-	// B is not available (recall that "self" is set up by MakeSampleEnv, in TryApps)
-	TryApps(t, []string{
+	// B is not available (recall that "self" is set up by MakeSampleEnv, in TestApps)
+	TestApps(t, []string{
 		`byte "self"; int 64; box_create`,
 		`byte "B"; int 10; int 4; box_extract; byte 0x00000000; ==`,
 	}, nil, 8, ledger, Exp(1, fmt.Sprintf("invalid Box reference %#x", 'B')))
@@ -251,7 +251,7 @@ func TestBoxAvailability(t *testing.T) {
 		Boxes:         []transactions.BoxRef{{Index: 0, Name: []byte("B")}},
 	}.SignedTxn())
 	group[0].Txn.Type = protocol.ApplicationCallTx
-	TryApps(t, []string{
+	TestApps(t, []string{
 		`byte "self"; int 64; box_create`,
 		`byte "B"; int 10; int 4; box_extract; byte 0x00000000; ==`,
 	}, group, 8, ledger, Exp(1, "no such box"))
@@ -264,7 +264,7 @@ func TestBoxAvailability(t *testing.T) {
 		Boxes:         []transactions.BoxRef{{Index: 1, Name: []byte("B")}},
 	}.SignedTxn())
 	group[0].Txn.Type = protocol.ApplicationCallTx
-	TryApps(t, []string{
+	TestApps(t, []string{
 		`byte "self"; int 64; box_create`,
 		`byte "B"; int 10; int 4; box_extract; byte 0x00000000; ==`,
 	}, group, 8, ledger, Exp(1, "no such box"))

--- a/data/transactions/logic/debugger_eval_test.go
+++ b/data/transactions/logic/debugger_eval_test.go
@@ -171,7 +171,7 @@ func TestDebuggerLogicSigEval(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			testDbg := testDebugger{}
-			ep := DefaultEvalParams()
+			ep := DefaultSigParams()
 			ep.Tracer = MakeEvalTracerDebuggerAdaptor(&testDbg)
 			TestLogic(t, testCase.program, AssemblerMaxVersion, ep, testCase.evalProblems...)
 
@@ -191,7 +191,7 @@ func TestDebuggerTopLeveLAppEval(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			testDbg := testDebugger{}
-			ep := DefaultEvalParams()
+			ep := DefaultAppParams()
 			ep.Tracer = MakeEvalTracerDebuggerAdaptor(&testDbg)
 			TestApp(t, testCase.program, ep, testCase.evalProblems...)
 
@@ -291,7 +291,7 @@ func TestCallStackUpdate(t *testing.T) {
 	}
 
 	testDbg := testDebugger{}
-	ep := DefaultEvalParams()
+	ep := DefaultSigParams()
 	ep.Tracer = MakeEvalTracerDebuggerAdaptor(&testDbg)
 	TestLogic(t, TestCallStackProgram, AssemblerMaxVersion, ep)
 

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1404,14 +1404,15 @@ func (cx *EvalContext) step() error {
 	}
 
 	cx.cost += opcost
-	// Only one of these pooled budgets will be non-nil, perhaps we could collapse to one variable.
-	if cx.PooledLogicSigBudget != nil {
+	// At most one of these pooled budgets will be non-nil, perhaps we could
+	// collapse to one variable, but there are some complex callers trying to
+	// set up big budgets for debugging runs that would have to be looked at.
+	switch {
+	case cx.PooledApplicationBudget != nil:
+		*cx.PooledApplicationBudget -= opcost
+	case cx.PooledLogicSigBudget != nil:
 		*cx.PooledLogicSigBudget -= opcost
 	}
-	if cx.PooledApplicationBudget != nil {
-		*cx.PooledApplicationBudget -= opcost
-	}
-
 	preheight := len(cx.Stack)
 	err := spec.op(cx)
 

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -436,11 +436,6 @@ func NewAppEvalParams(txgroup []transactions.SignedTxnWithAD, proto *config.Cons
 		appAddrCache:            make(map[basics.AppIndex]basics.Address),
 		EvalConstants:           RuntimeEvalConstants(),
 	}
-	// resources are computed after ep is constructed because app addresses are
-	// calculated there, and we'd like to use the caching mechanism built into
-	// the EvalParams. Perhaps we can make the computation even lazier, so it is
-	// only computed if needed.
-	ep.available = ep.computeAvailability()
 	return ep
 }
 
@@ -984,6 +979,10 @@ func EvalContract(program []byte, gi int, aid basics.AppIndex, params *EvalParam
 		if cx.PooledApplicationBudget != nil && *cx.PooledApplicationBudget < cx.Proto.MaxAppProgramCost {
 			return false, nil, fmt.Errorf("Attempted ClearState execution with low OpcodeBudget %d", *cx.PooledApplicationBudget)
 		}
+	}
+
+	if cx.EvalParams.available == nil {
+		cx.EvalParams.available = cx.EvalParams.computeAvailability()
 	}
 
 	// If this is a creation...

--- a/data/transactions/logic/evalAppTxn_test.go
+++ b/data/transactions/logic/evalAppTxn_test.go
@@ -592,7 +592,6 @@ func TestNumInnerShallow(t *testing.T) {
 
 	ep, tx, ledger := MakeSampleEnv()
 	ep.Proto.EnableInnerTransactionPooling = false
-	ep.Reset()
 	ledger.NewApp(tx.Receiver, 888, basics.AppParams{})
 	ledger.NewAccount(appAddr(888), 1000000)
 	TestApp(t, pay+";int 1", ep)

--- a/data/transactions/logic/evalAppTxn_test.go
+++ b/data/transactions/logic/evalAppTxn_test.go
@@ -2753,20 +2753,17 @@ func TestNumInnerDeep(t *testing.T) {
   itxn_submit
 `
 
-	tx := txntest.Txn{
-		Type:          protocol.ApplicationCallTx,
-		ApplicationID: 888,
-		ForeignApps:   []basics.AppIndex{basics.AppIndex(222)},
-	}.SignedTxnWithAD()
-	require.Equal(t, 888, int(tx.Txn.ApplicationID))
-	ledger := NewLedger(nil)
+	ep, tx, ledger := MakeSampleEnv()
 
-	pay3 := TestProg(t, pay+pay+pay+"int 1;", AssemblerMaxVersion).Program
-	ledger.NewApp(tx.Txn.Receiver, 222, basics.AppParams{
-		ApprovalProgram: pay3,
+	tx.Type = protocol.ApplicationCallTx
+	tx.ApplicationID = 888
+	tx.ForeignApps = []basics.AppIndex{basics.AppIndex(222)}
+
+	ledger.NewApp(tx.Receiver, 222, basics.AppParams{
+		ApprovalProgram: TestProg(t, pay+pay+pay+"int 1;", AssemblerMaxVersion).Program,
 	})
 
-	ledger.NewApp(tx.Txn.Receiver, 888, basics.AppParams{})
+	ledger.NewApp(tx.Receiver, 888, basics.AppParams{})
 	ledger.NewAccount(appAddr(888), 1_000_000)
 
 	callpay3 := `itxn_begin
@@ -2774,10 +2771,6 @@ int appl;    itxn_field TypeEnum
 int 222;     itxn_field ApplicationID
 itxn_submit
 `
-	txg := []transactions.SignedTxnWithAD{tx}
-	ep := NewAppEvalParams(txg, MakeTestProto(), &transactions.SpecialAddresses{})
-	ep.Ledger = ledger
-	ep.SigLedger = ledger
 	TestApp(t, callpay3+"int 1", ep, "insufficient balance") // inner contract needs money
 
 	ledger.NewAccount(appAddr(222), 1_000_000)

--- a/data/transactions/logic/evalAppTxn_test.go
+++ b/data/transactions/logic/evalAppTxn_test.go
@@ -2776,7 +2776,7 @@ int 222;     itxn_field ApplicationID
 itxn_submit
 `
 	txg := []transactions.SignedTxnWithAD{tx}
-	ep := NewEvalParams(txg, MakeTestProto(), &transactions.SpecialAddresses{})
+	ep := NewAppEvalParams(txg, MakeTestProto(), &transactions.SpecialAddresses{})
 	ep.Ledger = ledger
 	ep.SigLedger = ledger
 	TestApp(t, callpay3+"int 1", ep, "insufficient balance") // inner contract needs money

--- a/data/transactions/logic/evalAppTxn_test.go
+++ b/data/transactions/logic/evalAppTxn_test.go
@@ -642,17 +642,17 @@ func TestNumInnerPooled(t *testing.T) {
 	long := strings.Repeat(pay, 17) + ";int 1" // More than half allowed
 
 	grp := MakeSampleTxnGroup(tx)
-	TestApps(t, []string{short, ""}, grp, LogicVersion, ledger)
-	TestApps(t, []string{short, short}, grp, LogicVersion, ledger)
-	TestApps(t, []string{long, ""}, grp, LogicVersion, ledger)
-	TestApps(t, []string{short, long}, grp, LogicVersion, ledger)
-	TestApps(t, []string{long, short}, grp, LogicVersion, ledger)
-	TestApps(t, []string{long, long}, grp, LogicVersion, ledger,
+	TryApps(t, []string{short, ""}, grp, LogicVersion, ledger)
+	TryApps(t, []string{short, short}, grp, LogicVersion, ledger)
+	TryApps(t, []string{long, ""}, grp, LogicVersion, ledger)
+	TryApps(t, []string{short, long}, grp, LogicVersion, ledger)
+	TryApps(t, []string{long, short}, grp, LogicVersion, ledger)
+	TryApps(t, []string{long, long}, grp, LogicVersion, ledger,
 		Exp(1, "too many inner transactions"))
 	grp = append(grp, grp[0])
-	TestApps(t, []string{short, long, long}, grp, LogicVersion, ledger,
+	TryApps(t, []string{short, long, long}, grp, LogicVersion, ledger,
 		Exp(2, "too many inner transactions"))
-	TestApps(t, []string{long, long, long}, grp, LogicVersion, ledger,
+	TryApps(t, []string{long, long, long}, grp, LogicVersion, ledger,
 		Exp(1, "too many inner transactions"))
 }
 

--- a/data/transactions/logic/evalAppTxn_test.go
+++ b/data/transactions/logic/evalAppTxn_test.go
@@ -642,17 +642,17 @@ func TestNumInnerPooled(t *testing.T) {
 	long := strings.Repeat(pay, 17) + ";int 1" // More than half allowed
 
 	grp := MakeSampleTxnGroup(tx)
-	TryApps(t, []string{short, ""}, grp, LogicVersion, ledger)
-	TryApps(t, []string{short, short}, grp, LogicVersion, ledger)
-	TryApps(t, []string{long, ""}, grp, LogicVersion, ledger)
-	TryApps(t, []string{short, long}, grp, LogicVersion, ledger)
-	TryApps(t, []string{long, short}, grp, LogicVersion, ledger)
-	TryApps(t, []string{long, long}, grp, LogicVersion, ledger,
+	TestApps(t, []string{short, ""}, grp, LogicVersion, ledger)
+	TestApps(t, []string{short, short}, grp, LogicVersion, ledger)
+	TestApps(t, []string{long, ""}, grp, LogicVersion, ledger)
+	TestApps(t, []string{short, long}, grp, LogicVersion, ledger)
+	TestApps(t, []string{long, short}, grp, LogicVersion, ledger)
+	TestApps(t, []string{long, long}, grp, LogicVersion, ledger,
 		Exp(1, "too many inner transactions"))
 	grp = append(grp, grp[0])
-	TryApps(t, []string{short, long, long}, grp, LogicVersion, ledger,
+	TestApps(t, []string{short, long, long}, grp, LogicVersion, ledger,
 		Exp(2, "too many inner transactions"))
-	TryApps(t, []string{long, long, long}, grp, LogicVersion, ledger,
+	TestApps(t, []string{long, long, long}, grp, LogicVersion, ledger,
 		Exp(1, "too many inner transactions"))
 }
 

--- a/data/transactions/logic/evalBench_test.go
+++ b/data/transactions/logic/evalBench_test.go
@@ -33,16 +33,11 @@ func BenchmarkCheckSignature(b *testing.B) {
 	ops, err := logic.AssembleString(txntest.TmLsig)
 	require.NoError(b, err)
 	stxns := []transactions.SignedTxn{{Txn: txns[3].Txn(), Lsig: transactions.LogicSig{Logic: ops.Program}}}
-	txgroup := transactions.WrapSignedTxnsWithAD(stxns)
-	ep := logic.EvalParams{
-		Proto:     &proto,
-		TxnGroup:  txgroup,
-		SigLedger: &logic.NoHeaderLedger{},
-	}
+	ep := logic.NewSigEvalParams(stxns, &proto, &logic.NoHeaderLedger{})
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		err = logic.CheckSignature(0, &ep)
+		err = logic.CheckSignature(0, ep)
 		require.NoError(b, err)
 	}
 }

--- a/data/transactions/logic/evalCrypto_test.go
+++ b/data/transactions/logic/evalCrypto_test.go
@@ -113,10 +113,12 @@ func TestVrfVerify(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	ep, _, _ := makeSampleEnv()
+	ep := defaultAppParams()
 	testApp(t, notrack("int 1; int 2; int 3; vrf_verify VrfAlgorand"), ep, "arg 0 wanted")
 	testApp(t, notrack("byte 0x1122; int 2; int 3; vrf_verify VrfAlgorand"), ep, "arg 1 wanted")
 	testApp(t, notrack("byte 0x1122; byte 0x2233; int 3; vrf_verify VrfAlgorand"), ep, "arg 2 wanted")
+
+	ep = defaultSigParams()
 	testLogic(t, "byte 0x1122; byte 0x2233; byte 0x3344; vrf_verify VrfAlgorand", LogicVersion, ep, "vrf proof wrong size")
 	// 80 byte proof
 	testLogic(t, "byte 0x1122; int 80; bzero; byte 0x3344; vrf_verify VrfAlgorand", LogicVersion, ep, "vrf pubkey wrong size")
@@ -210,18 +212,18 @@ ed25519verify`, pkStr), v)
 			var txn transactions.SignedTxn
 			txn.Lsig.Logic = ops.Program
 			txn.Lsig.Args = [][]byte{data[:], sig[:]}
-			testLogicBytes(t, ops.Program, defaultEvalParams(txn))
+			testLogicBytes(t, ops.Program, defaultSigParams(txn))
 
 			// short sig will fail
 			txn.Lsig.Args[1] = sig[1:]
-			testLogicBytes(t, ops.Program, defaultEvalParams(txn), "invalid signature")
+			testLogicBytes(t, ops.Program, defaultSigParams(txn), "invalid signature")
 
 			// flip a bit and it should not pass
 			msg1 := "52fdfc072182654f163f5f0f9a621d729566c74d0aa413bf009c9800418c19cd"
 			data1, err := hex.DecodeString(msg1)
 			require.NoError(t, err)
 			txn.Lsig.Args = [][]byte{data1, sig[:]}
-			testLogicBytes(t, ops.Program, defaultEvalParams(txn), "REJECT")
+			testLogicBytes(t, ops.Program, defaultSigParams(txn), "REJECT")
 		})
 	}
 }
@@ -250,18 +252,18 @@ ed25519verify_bare`, pkStr), v)
 			var txn transactions.SignedTxn
 			txn.Lsig.Logic = ops.Program
 			txn.Lsig.Args = [][]byte{data[:], sig[:]}
-			testLogicBytes(t, ops.Program, defaultEvalParams(txn))
+			testLogicBytes(t, ops.Program, defaultSigParams(txn))
 
 			// short sig will fail
 			txn.Lsig.Args[1] = sig[1:]
-			testLogicBytes(t, ops.Program, defaultEvalParams(txn), "invalid signature")
+			testLogicBytes(t, ops.Program, defaultSigParams(txn), "invalid signature")
 
 			// flip a bit and it should not pass
 			msg1 := "52fdfc072182654f163f5f0f9a621d729566c74d0aa413bf009c9800418c19cd"
 			data1, err := hex.DecodeString(msg1)
 			require.NoError(t, err)
 			txn.Lsig.Args = [][]byte{data1, sig[:]}
-			testLogicBytes(t, ops.Program, defaultEvalParams(txn), "REJECT")
+			testLogicBytes(t, ops.Program, defaultSigParams(txn), "REJECT")
 		})
 	}
 }
@@ -460,7 +462,7 @@ ecdsa_verify Secp256k1`, hex.EncodeToString(r), hex.EncodeToString(s), hex.Encod
 	ops := testProg(t, source, 5)
 	var txn transactions.SignedTxn
 	txn.Lsig.Logic = ops.Program
-	pass, err := EvalSignature(0, defaultEvalParamsWithVersion(5, txn))
+	pass, err := EvalSignature(0, defaultSigParamsWithVersion(5, txn))
 	require.NoError(t, err)
 	require.True(t, pass)
 }
@@ -568,7 +570,7 @@ ecdsa_verify Secp256r1`, hex.EncodeToString(r), hex.EncodeToString(s), hex.Encod
 	ops := testProg(t, source, fidoVersion)
 	var txn transactions.SignedTxn
 	txn.Lsig.Logic = ops.Program
-	pass, err := EvalSignature(0, defaultEvalParamsWithVersion(fidoVersion, txn))
+	pass, err := EvalSignature(0, defaultSigParamsWithVersion(fidoVersion, txn))
 	require.NoError(t, err)
 	require.True(t, pass)
 }
@@ -707,7 +709,7 @@ ed25519verify`, pkStr), AssemblerMaxVersion)
 		var txn transactions.SignedTxn
 		txn.Lsig.Logic = programs[i]
 		txn.Lsig.Args = [][]byte{data[i][:], signatures[i][:]}
-		ep := defaultEvalParams(txn)
+		ep := defaultSigParams(txn)
 		pass, err := EvalSignature(0, ep)
 		if !pass {
 			b.Log(hex.EncodeToString(programs[i]))
@@ -792,7 +794,7 @@ func benchmarkEcdsa(b *testing.B, source string, curve EcdsaCurve) {
 		var txn transactions.SignedTxn
 		txn.Lsig.Logic = data[i].programs
 		txn.Lsig.Args = [][]byte{data[i].msg[:], data[i].r, data[i].s, data[i].x, data[i].y, data[i].pk, {uint8(data[i].v)}}
-		ep := defaultEvalParams(txn)
+		ep := defaultSigParams(txn)
 		pass, err := EvalSignature(0, ep)
 		if !pass {
 			b.Log(hex.EncodeToString(data[i].programs))
@@ -915,7 +917,7 @@ func benchmarkBn256(b *testing.B, source string) {
 		var txn transactions.SignedTxn
 		txn.Lsig.Logic = data[i].programs
 		txn.Lsig.Args = [][]byte{data[i].a, data[i].k, data[i].g1, data[i].g2}
-		ep := defaultEvalParams(txn)
+		ep := defaultSigParams(txn)
 		pass, err := EvalSignature(0, ep)
 		if !pass {
 			b.Log(hex.EncodeToString(data[i].programs))

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -421,7 +421,7 @@ func testApps(t *testing.T, programs []string, txgroup []transactions.SignedTxn,
 			txgroup = append(txgroup, sample)
 		}
 	}
-	ep := NewEvalParams(transactions.WrapSignedTxnsWithAD(txgroup), makeTestProtoV(version), &transactions.SpecialAddresses{})
+	ep := NewAppEvalParams(transactions.WrapSignedTxnsWithAD(txgroup), makeTestProtoV(version), &transactions.SpecialAddresses{})
 	if ledger == nil {
 		ledger = NewLedger(nil)
 	}

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -22,7 +22,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"strconv"
 	"strings"
@@ -3198,7 +3198,7 @@ func TestPanic(t *testing.T) { //nolint:paralleltest // Uses withPanicOpcode
 	// tests fail. So it's pretty annoying to run `go test` on the whole
 	// package.  `logSink` swallows log messages.
 	logSink := logging.NewLogger()
-	logSink.SetOutput(ioutil.Discard)
+	logSink.SetOutput(io.Discard)
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		v := v
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) { //nolint:paralleltest // Uses withPanicOpcode

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -143,7 +143,8 @@ func defaultEvalParamsWithVersion(version uint64, txns ...transactions.SignedTxn
 	if empty {
 		// We made an app type in order to get a full ep, but that sets MinTealVersion=2
 		ep.TxnGroup[0].Txn.Type = "" // set it back
-		ep.MinAvmVersion = nil       // will recalculate in eval()
+		zero := uint64(0)
+		ep.MinAvmVersion = &zero
 	}
 	return ep
 }
@@ -3270,7 +3271,7 @@ func TestProgramTooNew(t *testing.T) {
 
 	t.Parallel()
 	var program [12]byte
-	vlen := binary.PutUvarint(program[:], evalMaxVersion+1)
+	vlen := binary.PutUvarint(program[:], LogicVersion+1)
 	testLogicBytes(t, program[:vlen], defaultEvalParams(),
 		"greater than max supported", "greater than max supported")
 }
@@ -3289,10 +3290,10 @@ func TestProgramProtoForbidden(t *testing.T) {
 
 	t.Parallel()
 	var program [12]byte
-	vlen := binary.PutUvarint(program[:], evalMaxVersion)
+	vlen := binary.PutUvarint(program[:], LogicVersion)
 	ep := defaultEvalParams()
 	ep.Proto = &config.ConsensusParams{
-		LogicSigVersion: evalMaxVersion - 1,
+		LogicSigVersion: LogicVersion - 1,
 	}
 	testLogicBytes(t, program[:vlen], ep, "greater than protocol", "greater than protocol")
 }

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -132,12 +132,10 @@ func makeTestProto(opts ...protoOpt) *config.ConsensusParams {
 }
 
 func benchmarkSigParams(txns ...transactions.SignedTxn) *EvalParams {
-	ep := defaultSigParams(txns...)
+	ep := optSigParams(func(p *config.ConsensusParams) {
+		p.LogicSigMaxCost = 1_000_000_000
+	}, txns...)
 	ep.Trace = nil // Tracing would slow down benchmarks
-	clone := *ep.Proto
-	bigBudget := 1000 * 1000 * 1000 // Allow long run times
-	clone.LogicSigMaxCost = uint64(bigBudget)
-	ep.Proto = &clone
 	return ep
 }
 

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -142,7 +142,7 @@ func defaultEvalParamsWithVersion(version uint64, txns ...transactions.SignedTxn
 	ep.SigLedger = NewLedger(nil)
 	if empty {
 		// We made an app type in order to get a full ep, but that sets MinTealVersion=2
-		ep.TxnGroup[0].Txn.Type = "" // set it back
+		ep.TxnGroup[0].Txn.Type = protocol.PaymentTx // set it to something boring
 		ep.minAvmVersion = 0
 	}
 	return ep
@@ -165,17 +165,11 @@ func (ep *EvalParams) reset() {
 		inners := ep.Proto.MaxTxGroupSize * ep.Proto.MaxInnerTransactions
 		ep.pooledAllowedInners = &inners
 	}
-	ep.pastScratch = make([]*scratchSpace, ep.Proto.MaxTxGroupSize)
+	ep.pastScratch = make([]*scratchSpace, len(ep.TxnGroup))
 	for i := range ep.TxnGroup {
 		ep.TxnGroup[i].ApplyData = transactions.ApplyData{}
 	}
-	if ep.available != nil {
-		available := NewAppEvalParams(ep.TxnGroup, ep.Proto, ep.Specials).available
-		if available != nil {
-			ep.available = available
-		}
-		ep.available.dirtyBytes = 0
-	}
+	ep.available = nil
 	ep.readBudgetChecked = false
 	ep.appAddrCache = make(map[basics.AppIndex]basics.Address)
 	if ep.Trace != nil {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"strconv"
 	"strings"
@@ -35,6 +36,7 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
 
@@ -115,42 +117,67 @@ func makeTestProtoV(version uint64) *config.ConsensusParams {
 	}
 }
 
-func defaultEvalParams(txns ...transactions.SignedTxn) *EvalParams {
-	return defaultEvalParamsWithVersion(LogicVersion, txns...)
-}
-
-func benchmarkEvalParams(txn transactions.SignedTxn) *EvalParams {
-	ep := defaultEvalParams(txn)
+func benchmarkSigParams(txns ...transactions.SignedTxn) *EvalParams {
+	ep := defaultSigParams(txns...)
 	ep.Trace = nil // Tracing would slow down benchmarks
 	clone := *ep.Proto
 	bigBudget := 1000 * 1000 * 1000 // Allow long run times
 	clone.LogicSigMaxCost = uint64(bigBudget)
-	clone.MaxAppProgramCost = bigBudget
 	ep.Proto = &clone
-	ep.PooledApplicationBudget = &bigBudget
 	return ep
 }
 
-func defaultEvalParamsWithVersion(version uint64, txns ...transactions.SignedTxn) *EvalParams {
-	empty := false
+func defaultSigParams(txns ...transactions.SignedTxn) *EvalParams {
+	return defaultSigParamsWithVersion(LogicVersion, txns...)
+}
+func defaultSigParamsWithVersion(version uint64, txns ...transactions.SignedTxn) *EvalParams {
 	if len(txns) == 0 {
-		empty = true
-		txns = []transactions.SignedTxn{{Txn: transactions.Transaction{Type: protocol.ApplicationCallTx}}}
+		// We need a transaction to exist, because we'll be stuffing the
+		// logicsig into it in order to test them, and we need the next clause
+		// to have a chance to convince NewSigEval to return non-nil.
+		txns = make([]transactions.SignedTxn, 1)
+	}
+	// Make it non-Blank so NewSigEval does not short-circuit (but try to avoid
+	// manipulating txns if they were actually supplied with other sigs.)
+	if txns[0].Sig.Blank() && txns[0].Msig.Blank() && txns[0].Lsig.Blank() {
+		txns[0].Lsig.Logic = []byte{LogicVersion + 1} // make sure it fails if used
+	}
+
+	ep := NewSigEvalParams(txns, makeTestProtoV(version), &NoHeaderLedger{})
+	ep.Trace = &strings.Builder{}
+	return ep
+}
+
+func defaultAppParams(txns ...transactions.SignedTxn) *EvalParams {
+	return defaultAppParamsWithVersion(LogicVersion, txns...)
+}
+func defaultAppParamsWithVersion(version uint64, txns ...transactions.SignedTxn) *EvalParams {
+	if len(txns) == 0 {
+		// Convince NewAppEvalParams not to return nil
+		txns = []transactions.SignedTxn{{
+			Txn: transactions.Transaction{Type: protocol.ApplicationCallTx},
+		}}
 	}
 	ep := NewAppEvalParams(transactions.WrapSignedTxnsWithAD(txns), makeTestProtoV(version), &transactions.SpecialAddresses{})
-	ep.Trace = &strings.Builder{}
-	ep.SigLedger = NewLedger(nil)
-	if empty {
-		// We made an app type in order to get a full ep, but that sets MinTealVersion=2
-		ep.TxnGroup[0].Txn.Type = protocol.PaymentTx // set it to something boring
-		ep.minAvmVersion = 0
+	if ep != nil { // If supplied no apps, ep is nil.
+		ep.Trace = &strings.Builder{}
+		ep.Ledger = NewLedger(nil)
+		ep.SigLedger = ep.Ledger
 	}
 	return ep
 }
 
-// `supportsAppEval` is test helper method for disambiguating whe `EvalParams` is suitable for logicsig vs app evaluations.
-func (ep *EvalParams) supportsAppEval() bool {
-	return ep.available != nil
+func defaultEvalParams(txns ...transactions.SignedTxn) (sig *EvalParams, app *EvalParams) {
+	return defaultEvalParamsWithVersion(LogicVersion, txns...)
+}
+func defaultEvalParamsWithVersion(version uint64, txns ...transactions.SignedTxn) (sig *EvalParams, app *EvalParams) {
+	sig = defaultSigParamsWithVersion(version, txns...)
+	app = defaultAppParamsWithVersion(version, txns...)
+	// Let's share ledgers for easier testing and let sigs use it for block access
+	if app != nil {
+		sig.SigLedger = app.SigLedger
+	}
+	return sig, app
 }
 
 // reset puts an ep back into its original state.  This is in *_test.go because
@@ -190,7 +217,7 @@ func TestTooManyArgs(t *testing.T) {
 			txn.Lsig.Logic = ops.Program
 			args := [transactions.EvalMaxArgs + 1][]byte{}
 			txn.Lsig.Args = args[:]
-			pass, err := EvalSignature(0, defaultEvalParams(txn))
+			pass, err := EvalSignature(0, defaultSigParams(txn))
 			require.Error(t, err)
 			require.False(t, pass)
 		})
@@ -201,7 +228,7 @@ func TestEmptyProgram(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	t.Parallel()
-	testLogicBytes(t, nil, defaultEvalParams(), "invalid", "invalid program (empty)")
+	testLogicBytes(t, nil, nil, "invalid", "invalid program (empty)")
 }
 
 // TestMinAvmVersionParamEval tests eval/check reading the minAvmVersion from the param
@@ -209,14 +236,14 @@ func TestMinAvmVersionParamEvalCheckSignature(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	t.Parallel()
-	params := defaultEvalParams()
+	params := defaultSigParams()
 	params.minAvmVersion = uint64(rekeyingEnabledVersion)
 	program := make([]byte, binary.MaxVarintLen64)
 	// set the program version to 1
 	binary.PutUvarint(program, 1)
 
 	verErr := fmt.Sprintf("program version must be >= %d", appsEnabledVersion)
-	testAppBytes(t, program, params, verErr, verErr)
+	testLogicBytes(t, program, params, verErr, verErr)
 }
 
 func TestTxnFieldToTealValue(t *testing.T) {
@@ -272,6 +299,10 @@ func TestTxnFirstValidTime(t *testing.T) {
 	t.Parallel()
 
 	ep, tx, ledger := makeSampleEnv()
+	// This is an unusual test that needs a ledger
+	// even though it's testing signatures. So it's convenient to use
+	// makeSampleEnv and then change the mode on the ep.
+	ep.runMode = ModeSig
 
 	// By default, test ledger uses an oddball round, ask it what round it's
 	// going to use and prep fv, lv accordingly.
@@ -332,8 +363,8 @@ func TestWrongProtoVersion(t *testing.T) {
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			ops := testProg(t, "int 1", v)
-			ep := defaultEvalParamsWithVersion(0)
-			testAppBytes(t, ops.Program, ep, "LogicSig not supported", "LogicSig not supported")
+			ep := defaultSigParamsWithVersion(0)
+			testLogicBytes(t, ops.Program, ep, "LogicSig not supported", "LogicSig not supported")
 		})
 	}
 }
@@ -406,7 +437,7 @@ byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
 			var txn transactions.SignedTxn
 			txn.Lsig.Logic = ops.Program
 			txn.Lsig.Args = [][]byte{[]byte("=0\x97S\x85H\xe9\x91B\xfd\xdb;1\xf5Z\xaec?\xae\xf2I\x93\x08\x12\x94\xaa~\x06\x08\x849b")}
-			ep := defaultEvalParams(txn)
+			ep := defaultSigParams(txn)
 			err := CheckSignature(0, ep)
 			require.NoError(t, err)
 			pass, cx, err := EvalSignatureFull(0, ep)
@@ -429,8 +460,7 @@ end:
 `, v)
 			var txn transactions.SignedTxn
 			txn.Lsig.Logic = ops.Program
-			ep := defaultEvalParams(txn)
-			err := CheckSignature(0, ep)
+			err := CheckSignature(0, defaultSigParams(txn))
 			require.NoError(t, err)
 		})
 	}
@@ -441,7 +471,7 @@ return
 `, v)
 			var txn transactions.SignedTxn
 			txn.Lsig.Logic = ops.Program
-			ep := defaultEvalParams(txn)
+			ep := defaultSigParams(txn)
 			err := CheckSignature(0, ep)
 			require.NoError(t, err)
 		})
@@ -452,8 +482,7 @@ return
 	pushint := OpsByName[LogicVersion]["pushint"]
 	var txn transactions.SignedTxn
 	txn.Lsig.Logic = []byte{LogicVersion, pushint.Opcode, 0x01}
-	ep := defaultEvalParams(txn)
-	err := CheckSignature(0, ep)
+	err := CheckSignature(0, defaultSigParams(txn))
 	require.NoError(t, err)
 }
 
@@ -508,7 +537,7 @@ func TestTLHC(t *testing.T) {
 			txn.Lsig.Args = [][]byte{secret}
 			txn.Txn.FirstValid = 999999
 			block := bookkeeping.Block{}
-			ep := defaultEvalParams(txn)
+			ep := defaultSigParams(txn)
 			err := CheckSignature(0, ep)
 			if err != nil {
 				t.Log(hex.EncodeToString(ops.Program))
@@ -527,7 +556,7 @@ func TestTLHC(t *testing.T) {
 
 			txn.Txn.Receiver = a2
 			txn.Txn.CloseRemainderTo = a2
-			ep = defaultEvalParams(txn)
+			ep = defaultSigParams(txn)
 			pass, err = EvalSignature(0, ep)
 			if !pass {
 				t.Log(hex.EncodeToString(ops.Program))
@@ -539,7 +568,7 @@ func TestTLHC(t *testing.T) {
 			txn.Txn.Receiver = a2
 			txn.Txn.CloseRemainderTo = a2
 			txn.Txn.FirstValid = 1
-			ep = defaultEvalParams(txn)
+			ep = defaultSigParams(txn)
 			pass, err = EvalSignature(0, ep)
 			if pass {
 				t.Log(hex.EncodeToString(ops.Program))
@@ -551,7 +580,7 @@ func TestTLHC(t *testing.T) {
 			txn.Txn.Receiver = a1
 			txn.Txn.CloseRemainderTo = a1
 			txn.Txn.FirstValid = 999999
-			ep = defaultEvalParams(txn)
+			ep = defaultSigParams(txn)
 			pass, err = EvalSignature(0, ep)
 			if !pass {
 				t.Log(hex.EncodeToString(ops.Program))
@@ -563,7 +592,7 @@ func TestTLHC(t *testing.T) {
 			// wrong answer
 			txn.Lsig.Args = [][]byte{[]byte("=0\x97S\x85H\xe9\x91B\xfd\xdb;1\xf5Z\xaec?\xae\xf2I\x93\x08\x12\x94\xaa~\x06\x08\x849a")}
 			block.BlockHeader.Round = 1
-			ep = defaultEvalParams(txn)
+			ep = defaultSigParams(txn)
 			pass, err = EvalSignature(0, ep)
 			if pass {
 				t.Log(hex.EncodeToString(ops.Program))
@@ -1001,7 +1030,7 @@ func TestTxnBadField(t *testing.T) {
 
 	t.Parallel()
 	program := []byte{0x01, 0x31, 0x7f}
-	testLogicBytes(t, program, defaultEvalParams(), "invalid txn field")
+	testLogicBytes(t, program, nil, "invalid txn field")
 	// TODO: Check should know the type stack was wrong
 
 	// test txn does not accept ApplicationArgs and Accounts
@@ -1014,7 +1043,7 @@ func TestTxnBadField(t *testing.T) {
 		ops := testProg(t, source, AssemblerMaxVersion)
 		require.Equal(t, txnaOpcode, ops.Program[1])
 		ops.Program[1] = txnOpcode
-		testLogicBytes(t, ops.Program, defaultEvalParams(), fmt.Sprintf("invalid txn field %s", field))
+		testLogicBytes(t, ops.Program, nil, fmt.Sprintf("invalid txn field %s", field))
 	}
 }
 
@@ -1023,7 +1052,7 @@ func TestGtxnBadIndex(t *testing.T) {
 
 	t.Parallel()
 	program := []byte{0x01, 0x33, 0x1, 0x01}
-	testLogicBytes(t, program, defaultEvalParams(), "txn index 1")
+	testLogicBytes(t, program, nil, "txn index 1")
 }
 
 func TestGtxnBadField(t *testing.T) {
@@ -1032,7 +1061,7 @@ func TestGtxnBadField(t *testing.T) {
 	t.Parallel()
 	program := []byte{0x01, 0x33, 0x0, 127}
 	// TODO: Check should know the type stack was wrong
-	testLogicBytes(t, program, defaultEvalParams(), "invalid txn field TxnField(127)")
+	testLogicBytes(t, program, nil, "invalid txn field TxnField(127)")
 
 	// test gtxn does not accept ApplicationArgs and Accounts
 	txnOpcode := OpsByName[LogicVersion]["txn"].Opcode
@@ -1044,7 +1073,7 @@ func TestGtxnBadField(t *testing.T) {
 		ops := testProg(t, source, AssemblerMaxVersion)
 		require.Equal(t, txnaOpcode, ops.Program[1])
 		ops.Program[1] = txnOpcode
-		testLogicBytes(t, ops.Program, defaultEvalParams(), fmt.Sprintf("invalid txn field %s", field))
+		testLogicBytes(t, ops.Program, nil, fmt.Sprintf("invalid txn field %s", field))
 	}
 }
 
@@ -1053,7 +1082,7 @@ func TestGlobalBadField(t *testing.T) {
 
 	t.Parallel()
 	program := []byte{0x01, 0x32, 127}
-	testLogicBytes(t, program, defaultEvalParams(), "invalid global field")
+	testLogicBytes(t, program, nil, "invalid global field")
 }
 
 func TestArg(t *testing.T) {
@@ -1076,7 +1105,7 @@ func TestArg(t *testing.T) {
 				[]byte("aoeu4"),
 			}
 			ops := testProg(t, source, v)
-			testLogicBytes(t, ops.Program, defaultEvalParams(txn))
+			testLogicBytes(t, ops.Program, defaultSigParams(txn))
 		})
 	}
 }
@@ -1225,7 +1254,7 @@ func TestGlobal(t *testing.T) {
 			}
 			appcall.Txn.Group = crypto.Digest{0x07, 0x06}
 
-			ep := defaultEvalParams(appcall)
+			ep := defaultAppParams(appcall)
 			ep.Ledger = ledger
 			testApp(t, tests[v].program, ep)
 		})
@@ -1270,11 +1299,11 @@ int %s
 					txn := transactions.SignedTxn{}
 					txn.Txn.Type = tt
 					if v < appsEnabledVersion && tt == protocol.ApplicationCallTx {
-						testLogicBytes(t, ops.Program, defaultEvalParams(txn),
+						testLogicBytes(t, ops.Program, defaultSigParams(txn),
 							"program version must be", "program version must be")
 						return
 					}
-					testLogicBytes(t, ops.Program, defaultEvalParams(txn))
+					testLogicBytes(t, ops.Program, defaultSigParams(txn))
 				})
 			}
 		})
@@ -1873,25 +1902,27 @@ func TestTxn(t *testing.T) {
 				clearProgramHash[:],
 			}
 			// Since we test GroupIndex ==3, we need a larger group
-			ep := defaultEvalParams(txn, txn, txn, txn)
-			ep.TxnGroup[2].EvalDelta.Logs = []string{"x", "prefilled"}
+			sep, aep := defaultEvalParams(txn, txn, txn, txn)
 			if v < txnEffectsVersion {
-				testLogicFull(t, ops.Program, 3, ep)
+				testLogicFull(t, ops.Program, 3, sep)
 			} else {
 				// Starting in txnEffectsVersion, there are fields we can't access in Logic mode
-				testLogicFull(t, ops.Program, 3, ep, "not allowed in current mode")
+				testLogicFull(t, ops.Program, 3, sep, "not allowed in current mode")
 				// And the early tests use "arg" a lot - not allowed in stateful. So remove those tests.
 				lastArg := strings.Index(source, "arg 10\n==\n&&")
 				require.NotEqual(t, -1, lastArg)
 
-				appSafe := "int 1" + strings.Replace(source[lastArg+12:], `txn Sender
+				if v >= appsEnabledVersion {
+					aep.TxnGroup[2].EvalDelta.Logs = []string{"x", "prefilled"}
+					appSafe := "int 1" + strings.Replace(source[lastArg+12:], `txn Sender
 int 0
 args
 ==
 assert`, "", 1)
 
-				ops := testProg(t, appSafe, v)
-				testAppFull(t, ops.Program, 3, basics.AppIndex(888), ep)
+					ops := testProg(t, appSafe, v)
+					testAppFull(t, ops.Program, 3, basics.AppIndex(888), aep)
+				}
 			}
 		})
 	}
@@ -1942,7 +1973,7 @@ return
 `
 	ops := testProg(t, cachedTxnProg, 2)
 
-	ep, _, _ := makeSampleEnv()
+	ep := defaultSigParams(makeSampleTxnGroup()...)
 	txid0 := ep.TxnGroup[0].ID()
 	txid1 := ep.TxnGroup[1].ID()
 	ep.TxnGroup[0].Lsig.Args = [][]byte{
@@ -1950,50 +1981,6 @@ return
 		txid1[:],
 	}
 	testLogicBytes(t, ops.Program, ep)
-}
-
-func TestGaid(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	t.Parallel()
-	check0 := testProg(t, "gaid 0; int 100; ==", 4)
-	appTxn := makeSampleTxn()
-	appTxn.Txn.Type = protocol.ApplicationCallTx
-	targetTxn := makeSampleTxn()
-	targetTxn.Txn.Type = protocol.AssetConfigTx
-	ep := defaultEvalParams(targetTxn, appTxn, makeSampleTxn())
-	ep.Ledger = NewLedger(nil)
-
-	// should fail when no creatable was created
-	_, err := EvalApp(check0.Program, 1, 888, ep)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "did not create anything")
-
-	ep.TxnGroup[0].ApplyData.ConfigAsset = 100
-	pass, err := EvalApp(check0.Program, 1, 888, ep)
-	if !pass || err != nil {
-		t.Log(ep.Trace.String())
-	}
-	require.NoError(t, err)
-	require.True(t, pass)
-
-	// should fail when accessing future transaction in group
-	check2 := testProg(t, "gaid 2; int 0; >", 4)
-	_, err = EvalApp(check2.Program, 1, 888, ep)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "gaid can't get creatable ID of txn ahead of the current one")
-
-	// should fail when accessing self
-	_, err = EvalApp(check0.Program, 0, 888, ep)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "gaid is only for accessing creatable IDs of previous txns")
-
-	// should fail on non-creatable
-	ep.TxnGroup[0].Txn.Type = protocol.PaymentTx
-	_, err = EvalApp(check0.Program, 1, 888, ep)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "can't use gaid on txn that is not an app call nor an asset config txn")
-	ep.TxnGroup[0].Txn.Type = protocol.AssetConfigTx
 }
 
 func TestGtxn(t *testing.T) {
@@ -2121,7 +2108,7 @@ gtxn 0 Sender
 				txn.Txn.SelectionPK[:],
 				txn.Txn.Note,
 			}
-			ep := defaultEvalParams(makeSampleTxnGroup(txn)...)
+			ep := defaultSigParams(makeSampleTxnGroup(txn)...)
 			testLogic(t, source, v, ep)
 			if v >= 3 {
 				gtxnsProg := strings.ReplaceAll(source, "gtxn 0", "int 0; gtxns")
@@ -2150,6 +2137,10 @@ func testLogicBytes(t *testing.T, program []byte, ep *EvalParams, problems ...st
 func testLogicFull(t *testing.T, program []byte, gi int, ep *EvalParams, problems ...string) {
 	t.Helper()
 
+	if ep == nil {
+		ep = defaultSigParams()
+	}
+
 	var checkProblem string
 	var evalProblem string
 	switch len(problems) {
@@ -2169,10 +2160,9 @@ func testLogicFull(t *testing.T, program []byte, gi int, ep *EvalParams, problem
 	ep.TxnGroup[0].Lsig.Logic = program
 	err := CheckSignature(gi, ep)
 	if checkProblem == "" {
-		require.NoError(t, err, sb.String())
+		require.NoError(t, err, "Error in CheckSignature %v", sb)
 	} else {
-		require.Error(t, err, "Check\n%s\nExpected: %v", sb, checkProblem)
-		require.Contains(t, err.Error(), checkProblem)
+		require.ErrorContains(t, err, checkProblem, "Wrong error in CheckSignature %v", sb)
 	}
 
 	// We continue on to check Eval() of things that failed Check() because it's
@@ -2192,8 +2182,7 @@ func testLogicFull(t *testing.T, program []byte, gi int, ep *EvalParams, problem
 	if evalProblem == "REJECT" {
 		require.True(t, err != nil || !pass, "Eval%s\nExpected: REJECT", sb)
 	} else {
-		require.Error(t, err, "Eval%s\nExpected: %v", sb, evalProblem)
-		require.Contains(t, err.Error(), evalProblem)
+		require.ErrorContains(t, err, evalProblem, sb)
 	}
 }
 
@@ -2210,7 +2199,7 @@ txna ApplicationArgs 0
 	txn.Txn.Accounts = make([]basics.Address, 1)
 	txn.Txn.Accounts[0] = txn.Txn.Sender
 	txn.Txn.ApplicationArgs = [][]byte{txn.Txn.Sender[:]}
-	ep := defaultEvalParams(txn)
+	ep := defaultSigParams(txn)
 	testLogicBytes(t, ops.Program, ep)
 
 	// modify txn field
@@ -2244,8 +2233,7 @@ txn Sender
 	ops2 := testProg(t, source, AssemblerMaxVersion)
 	var txn2 transactions.SignedTxn
 	copy(txn2.Txn.Sender[:], []byte("aoeuiaoeuiaoeuiaoeuiaoeuiaoeui00"))
-	ep2 := defaultEvalParams(txn2)
-	testLogicBytes(t, ops2.Program, ep2)
+	testLogicBytes(t, ops2.Program, defaultSigParams(txn2))
 
 	// check gtxna
 	source = `gtxna 0 Accounts 1
@@ -2285,8 +2273,7 @@ txn Sender
 	ops3 := testProg(t, source, AssemblerMaxVersion)
 	var txn3 transactions.SignedTxn
 	copy(txn2.Txn.Sender[:], []byte("aoeuiaoeuiaoeuiaoeuiaoeuiaoeui00"))
-	ep3 := defaultEvalParams(txn3)
-	testLogicBytes(t, ops3.Program, ep3)
+	testLogicBytes(t, ops3.Program, defaultSigParams(txn3))
 }
 
 // check empty values in ApplicationArgs and Account
@@ -2304,10 +2291,10 @@ int 0
 	var txn transactions.SignedTxn
 	txn.Txn.ApplicationArgs = make([][]byte, 1)
 	txn.Txn.ApplicationArgs[0] = []byte("")
-	testLogicBytes(t, ops.Program, defaultEvalParams(txn))
+	testLogicBytes(t, ops.Program, defaultSigParams(txn))
 
 	txn.Txn.ApplicationArgs[0] = nil
-	testLogicBytes(t, ops.Program, defaultEvalParams(txn))
+	testLogicBytes(t, ops.Program, defaultSigParams(txn))
 
 	source2 := `txna Accounts 1
 global ZeroAddress
@@ -2318,10 +2305,10 @@ global ZeroAddress
 	var txn2 transactions.SignedTxn
 	txn2.Txn.Accounts = make([]basics.Address, 1)
 	txn2.Txn.Accounts[0] = basics.Address{}
-	testLogicBytes(t, ops.Program, defaultEvalParams(txn2))
+	testLogicBytes(t, ops.Program, defaultSigParams(txn2))
 
 	txn2.Txn.Accounts = make([]basics.Address, 1)
-	testLogicBytes(t, ops.Program, defaultEvalParams(txn2))
+	testLogicBytes(t, ops.Program, defaultSigParams(txn2))
 }
 
 func TestTxnBigPrograms(t *testing.T) {
@@ -2347,14 +2334,14 @@ int 1
 	for i := range txn.Txn.ApprovalProgram {
 		txn.Txn.ApprovalProgram[i] = byte(i % 7)
 	}
-	testLogic(t, source, AssemblerMaxVersion, defaultEvalParams(txn))
+	testLogic(t, source, AssemblerMaxVersion, defaultSigParams(txn))
 
-	testLogic(t, `txna ApprovalProgramPages 2`, AssemblerMaxVersion, defaultEvalParams(txn),
+	testLogic(t, `txna ApprovalProgramPages 2`, AssemblerMaxVersion, defaultSigParams(txn),
 		"invalid ApprovalProgramPages index")
 
 	// ClearStateProgram is not in the txn at all
-	testLogic(t, `txn NumClearStateProgramPages; !`, AssemblerMaxVersion, defaultEvalParams(txn))
-	testLogic(t, `txna ClearStateProgramPages 0`, AssemblerMaxVersion, defaultEvalParams(txn),
+	testLogic(t, `txn NumClearStateProgramPages; !`, AssemblerMaxVersion, defaultSigParams(txn))
+	testLogic(t, `txna ClearStateProgramPages 0`, AssemblerMaxVersion, defaultSigParams(txn),
 		"invalid ClearStateProgramPages index")
 }
 
@@ -2374,7 +2361,7 @@ txnas ApplicationArgs
 	txn.Txn.Accounts = make([]basics.Address, 1)
 	txn.Txn.Accounts[0] = txn.Txn.Sender
 	txn.Txn.ApplicationArgs = [][]byte{txn.Txn.Sender[:]}
-	ep := defaultEvalParams(txn)
+	ep := defaultSigParams(txn)
 	testLogicBytes(t, ops.Program, ep)
 
 	// check special case: Account 0 == Sender
@@ -2387,7 +2374,7 @@ txn Sender
 	ops = testProg(t, source, AssemblerMaxVersion)
 	var txn2 transactions.SignedTxn
 	copy(txn2.Txn.Sender[:], []byte("aoeuiaoeuiaoeuiaoeuiaoeuiaoeui00"))
-	testLogicBytes(t, ops.Program, defaultEvalParams(txn2))
+	testLogicBytes(t, ops.Program, defaultSigParams(txn2))
 
 	// check gtxnas
 	source = `int 1
@@ -2407,7 +2394,7 @@ txn Sender
 	ops = testProg(t, source, AssemblerMaxVersion)
 	var txn3 transactions.SignedTxn
 	copy(txn3.Txn.Sender[:], []byte("aoeuiaoeuiaoeuiaoeuiaoeuiaoeui00"))
-	testLogicBytes(t, ops.Program, defaultEvalParams(txn3))
+	testLogicBytes(t, ops.Program, defaultSigParams(txn3))
 
 	// check gtxnsas
 	source = `int 0
@@ -2819,15 +2806,12 @@ func TestGload(t *testing.T) {
 				},
 			}
 
-			ep := defaultEvalParams(failCase.firstTxn, appcall)
-			ep.SigLedger = NewLedger(nil)
-
 			program := testProg(t, "gload 0 0", AssemblerMaxVersion).Program
 			switch failCase.runMode {
 			case ModeApp:
-				testAppBytes(t, program, ep, failCase.errContains)
+				testAppBytes(t, program, defaultAppParams(failCase.firstTxn, appcall), failCase.errContains)
 			default:
-				testLogicBytes(t, program, ep, failCase.errContains, failCase.errContains)
+				testLogicBytes(t, program, defaultSigParams(failCase.firstTxn, appcall), failCase.errContains, failCase.errContains)
 			}
 		})
 	}
@@ -2970,19 +2954,19 @@ func TestSlowLogic(t *testing.T) {
 	// v1overspend fails (on v1)
 	ops := testProg(t, v1overspend, 1)
 	// We should never Eval this after it fails Check(), but nice to see it also fails.
-	testLogicBytes(t, ops.Program, defaultEvalParamsWithVersion(1),
+	testLogicBytes(t, ops.Program, defaultSigParamsWithVersion(1),
 		"static cost", "dynamic cost")
 	// v2overspend passes Check, even on v2 proto, because the old low cost is "grandfathered"
 	ops = testProg(t, v2overspend, 1)
-	testLogicBytes(t, ops.Program, defaultEvalParamsWithVersion(2))
+	testLogicBytes(t, ops.Program, defaultSigParamsWithVersion(2))
 
 	// even the shorter, v2overspend, fails when compiled as v2 code
 	ops = testProg(t, v2overspend, 2)
-	testLogicBytes(t, ops.Program, defaultEvalParamsWithVersion(2),
+	testLogicBytes(t, ops.Program, defaultSigParamsWithVersion(2),
 		"static cost", "dynamic cost")
 
 	// in v4 cost is still 134, but only matters in Eval, not Check, so both fail there
-	ep4 := defaultEvalParamsWithVersion(4)
+	ep4 := defaultSigParamsWithVersion(4)
 	ops = testProg(t, v1overspend, 4)
 	testLogicBytes(t, ops.Program, ep4, "dynamic cost")
 
@@ -3007,7 +2991,7 @@ func TestStackUnderflow(t *testing.T) {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			ops := testProg(t, `int 1`, v)
 			ops.Program = append(ops.Program, 0x08) // +
-			testLogicBytes(t, ops.Program, defaultEvalParams(), "stack underflow")
+			testLogicBytes(t, ops.Program, nil, "stack underflow")
 		})
 	}
 }
@@ -3020,7 +3004,7 @@ func TestWrongStackTypeRuntime(t *testing.T) {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			ops := testProg(t, `int 1`, v)
 			ops.Program = append(ops.Program, 0x01, 0x15) // sha256, len
-			testLogicBytes(t, ops.Program, defaultEvalParams(), "sha256 arg 0 wanted")
+			testLogicBytes(t, ops.Program, nil, "sha256 arg 0 wanted")
 		})
 	}
 }
@@ -3033,7 +3017,7 @@ func TestEqMismatch(t *testing.T) {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			ops := testProg(t, `byte 0x1234; int 1`, v)
 			ops.Program = append(ops.Program, 0x12) // ==
-			testLogicBytes(t, ops.Program, defaultEvalParams(), "cannot compare")
+			testLogicBytes(t, ops.Program, nil, "cannot compare")
 			// TODO: Check should know the type stack was wrong
 		})
 	}
@@ -3047,7 +3031,7 @@ func TestNeqMismatch(t *testing.T) {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			ops := testProg(t, `byte 0x1234; int 1`, v)
 			ops.Program = append(ops.Program, 0x13) // !=
-			testLogicBytes(t, ops.Program, defaultEvalParams(), "cannot compare")
+			testLogicBytes(t, ops.Program, nil, "cannot compare")
 		})
 	}
 }
@@ -3060,7 +3044,7 @@ func TestWrongStackTypeRuntime2(t *testing.T) {
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) {
 			ops := testProg(t, `byte 0x1234; int 1`, v)
 			ops.Program = append(ops.Program, 0x08) // +
-			testLogicBytes(t, ops.Program, defaultEvalParams(), "+ arg 0 wanted")
+			testLogicBytes(t, ops.Program, nil, "+ arg 0 wanted")
 		})
 	}
 }
@@ -3078,7 +3062,7 @@ func TestIllegalOp(t *testing.T) {
 					break
 				}
 			}
-			testLogicBytes(t, ops.Program, defaultEvalParams(), "illegal opcode", "illegal opcode")
+			testLogicBytes(t, ops.Program, nil, "illegal opcode", "illegal opcode")
 		})
 	}
 }
@@ -3096,7 +3080,7 @@ int 1
 `, v)
 			// cut two last bytes - intc_1 and last byte of bnz
 			ops.Program = ops.Program[:len(ops.Program)-2]
-			testLogicBytes(t, ops.Program, defaultEvalParams(),
+			testLogicBytes(t, ops.Program, nil,
 				"bnz program ends short", "bnz program ends short")
 		})
 	}
@@ -3111,7 +3095,7 @@ intc 0
 intc 0
 bnz done
 done:`, 2)
-	testLogicBytes(t, ops.Program, defaultEvalParams())
+	testLogicBytes(t, ops.Program, nil)
 }
 
 func TestShortBytecblock(t *testing.T) {
@@ -3126,8 +3110,7 @@ func TestShortBytecblock(t *testing.T) {
 			for i := 2; i < len(fullops.Program); i++ {
 				program := fullops.Program[:i]
 				t.Run(hex.EncodeToString(program), func(t *testing.T) {
-					testLogicBytes(t, program, defaultEvalParams(),
-						"bytes list", "bytes list")
+					testLogicBytes(t, program, nil, "bytes list", "bytes list")
 				})
 			}
 		})
@@ -3150,7 +3133,7 @@ func TestShortBytecblock2(t *testing.T) {
 			t.Parallel()
 			program, err := hex.DecodeString(src)
 			require.NoError(t, err)
-			testLogicBytes(t, program, defaultEvalParams(), "const bytes list", "const bytes list")
+			testLogicBytes(t, program, nil, "const bytes list", "const bytes list")
 		})
 	}
 }
@@ -3211,6 +3194,11 @@ func withPanicOpcode(t *testing.T, version uint64, panicDuringCheck bool, f func
 func TestPanic(t *testing.T) { //nolint:paralleltest // Uses withPanicOpcode
 	partitiontest.PartitionTest(t)
 
+	// These tests would generate a lot of log noise which shows up if *other*
+	// tests fail. So it's pretty annoying to run `go test` on the whole
+	// package.  `logSink` swallows log messages.
+	logSink := logging.NewLogger()
+	logSink.SetOutput(ioutil.Discard)
 	for v := uint64(1); v <= AssemblerMaxVersion; v++ {
 		v := v
 		t.Run(fmt.Sprintf("v=%d", v), func(t *testing.T) { //nolint:paralleltest // Uses withPanicOpcode
@@ -3218,9 +3206,10 @@ func TestPanic(t *testing.T) { //nolint:paralleltest // Uses withPanicOpcode
 				ops := testProg(t, `int 1`, v)
 				ops.Program = append(ops.Program, opcode)
 
-				params := defaultEvalParams()
-				params.TxnGroup[0].Lsig.Logic = ops.Program
-				err := CheckSignature(0, params)
+				ep := defaultSigParams()
+				ep.logger = logSink
+				ep.TxnGroup[0].Lsig.Logic = ops.Program
+				err := CheckSignature(0, ep)
 				var pe panicError
 				require.ErrorAs(t, err, &pe)
 				require.Equal(t, panicString, pe.PanicValue)
@@ -3228,11 +3217,12 @@ func TestPanic(t *testing.T) { //nolint:paralleltest // Uses withPanicOpcode
 
 				var txn transactions.SignedTxn
 				txn.Lsig.Logic = ops.Program
-				params = defaultEvalParams(txn)
-				pass, err := EvalSignature(0, params)
+				ep = defaultSigParams(txn)
+				ep.logger = logSink
+				pass, err := EvalSignature(0, ep)
 				if pass {
 					t.Log(hex.EncodeToString(ops.Program))
-					t.Log(params.Trace.String())
+					t.Log(ep.Trace.String())
 				}
 				require.False(t, pass)
 				require.ErrorAs(t, err, &pe)
@@ -3245,9 +3235,9 @@ func TestPanic(t *testing.T) { //nolint:paralleltest // Uses withPanicOpcode
 							Type: protocol.ApplicationCallTx,
 						},
 					}
-					params = defaultEvalParams(txn)
-					params.Ledger = NewLedger(nil)
-					pass, err = EvalApp(ops.Program, 0, 1, params)
+					ep := defaultAppParams(txn)
+					ep.logger = logSink
+					pass, err = EvalApp(ops.Program, 0, 1, ep)
 					require.False(t, pass)
 					require.ErrorAs(t, err, &pe)
 					require.Equal(t, panicString, pe.PanicValue)
@@ -3264,7 +3254,7 @@ func TestProgramTooNew(t *testing.T) {
 	t.Parallel()
 	var program [12]byte
 	vlen := binary.PutUvarint(program[:], LogicVersion+1)
-	testLogicBytes(t, program[:vlen], defaultEvalParams(),
+	testLogicBytes(t, program[:vlen], nil,
 		"greater than max supported", "greater than max supported")
 }
 
@@ -3274,7 +3264,7 @@ func TestInvalidVersion(t *testing.T) {
 	t.Parallel()
 	program, err := hex.DecodeString("ffffffffffffffffffffffff")
 	require.NoError(t, err)
-	testLogicBytes(t, program, defaultEvalParams(), "invalid version", "invalid version")
+	testLogicBytes(t, program, nil, "invalid version", "invalid version")
 }
 
 func TestProgramProtoForbidden(t *testing.T) {
@@ -3283,10 +3273,7 @@ func TestProgramProtoForbidden(t *testing.T) {
 	t.Parallel()
 	var program [12]byte
 	vlen := binary.PutUvarint(program[:], LogicVersion)
-	ep := defaultEvalParams()
-	ep.Proto = &config.ConsensusParams{
-		LogicSigVersion: LogicVersion - 1,
-	}
+	ep := defaultSigParamsWithVersion(LogicVersion - 1)
 	testLogicBytes(t, program[:vlen], ep, "greater than protocol", "greater than protocol")
 }
 
@@ -3308,16 +3295,16 @@ int 1`, v)
 			require.Equal(t, ops.Program, canonicalProgramBytes)
 			ops.Program[7] = 3 // clobber the branch offset to be in the middle of the bytecblock
 			// Since Eval() doesn't know the jump is bad, we reject "by luck"
-			testLogicBytes(t, ops.Program, defaultEvalParams(), "aligned", "REJECT")
+			testLogicBytes(t, ops.Program, nil, "aligned", "REJECT")
 
 			// back branches are checked differently, so test misaligned back branch
 			ops.Program[6] = 0xff // Clobber the two bytes of offset with 0xff 0xff = -1
 			ops.Program[7] = 0xff // That jumps into the offset itself (pc + 3 -1)
 			if v < backBranchEnabledVersion {
-				testLogicBytes(t, ops.Program, defaultEvalParams(), "negative branch", "negative branch")
+				testLogicBytes(t, ops.Program, nil, "negative branch", "negative branch")
 			} else {
 				// Again, if we were ever to Eval(), we would not know it's wrong. But we reject here "by luck"
-				testLogicBytes(t, ops.Program, defaultEvalParams(), "back branch target", "REJECT")
+				testLogicBytes(t, ops.Program, nil, "back branch target", "REJECT")
 			}
 		})
 	}
@@ -3340,8 +3327,7 @@ int 1`, v)
 			require.NoError(t, err)
 			require.Equal(t, ops.Program, canonicalProgramBytes)
 			ops.Program[7] = 200 // clobber the branch offset to be beyond the end of the program
-			testLogicBytes(t, ops.Program, defaultEvalParams(),
-				"outside of program", "outside of program")
+			testLogicBytes(t, ops.Program, nil, "outside of program", "outside of program")
 		})
 	}
 }
@@ -3364,7 +3350,7 @@ int 1`, v)
 			require.NoError(t, err)
 			require.Equal(t, ops.Program, canonicalProgramBytes)
 			ops.Program[6] = 0x70 // clobber hi byte of branch offset
-			testLogicBytes(t, ops.Program, defaultEvalParams(), "outside", "outside")
+			testLogicBytes(t, ops.Program, nil, "outside", "outside")
 		})
 	}
 	branches := []string{
@@ -3386,8 +3372,7 @@ intc_1
 			require.NoError(t, err)
 			ops.Program[7] = 0xf0 // clobber the branch offset - highly negative
 			ops.Program[8] = 0xff // clobber the branch offset
-			testLogicBytes(t, ops.Program, defaultEvalParams(),
-				"outside of program", "outside of program")
+			testLogicBytes(t, ops.Program, nil, "outside of program", "outside of program")
 		})
 	}
 }
@@ -3676,10 +3661,10 @@ func evalLoop(b *testing.B, runs int, program []byte) {
 	for i := 0; i < runs; i++ {
 		var txn transactions.SignedTxn
 		txn.Lsig.Logic = program
-		pass, err := EvalSignature(0, benchmarkEvalParams(txn))
+		pass, err := EvalSignature(0, benchmarkSigParams(txn))
 		if !pass {
 			// rerun to trace it.  tracing messes up timing too much
-			ep := benchmarkEvalParams(txn)
+			ep := benchmarkSigParams(txn)
 			ep.Trace = &strings.Builder{}
 			pass, err = EvalSignature(0, ep)
 			b.Log(ep.Trace.String())
@@ -3991,7 +3976,7 @@ func BenchmarkCheckx5(b *testing.B) {
 		for _, program := range programs {
 			var txn transactions.SignedTxn
 			txn.Lsig.Logic = program
-			err := CheckSignature(0, defaultEvalParams(txn))
+			err := CheckSignature(0, defaultSigParams(txn))
 			if err != nil {
 				require.NoError(b, err)
 			}
@@ -4095,17 +4080,15 @@ pop
 	txn.Lsig.Logic = ops.Program
 	txn.Txn.ApplicationArgs = [][]byte{[]byte("test")}
 
-	ep := defaultEvalParams(txn)
-	testLogicBytes(t, ops.Program, ep)
+	testLogicBytes(t, ops.Program, defaultSigParams(txn))
 
-	ep = defaultEvalParamsWithVersion(1, txn)
-	testLogicBytes(t, ops.Program, ep,
+	testLogicBytes(t, ops.Program, defaultSigParamsWithVersion(1, txn),
 		"greater than protocol supported version 1", "greater than protocol supported version 1")
 
 	// hack the version and fail on illegal opcode
 	ops.Program[0] = 0x1
-	ep = defaultEvalParamsWithVersion(1, txn)
-	testLogicBytes(t, ops.Program, ep, "illegal opcode 0x36", "illegal opcode 0x36") // txna
+	testLogicBytes(t, ops.Program, defaultSigParamsWithVersion(1, txn),
+		"illegal opcode 0x36", "illegal opcode 0x36") // txna
 }
 
 func TestStackOverflow(t *testing.T) {
@@ -4201,26 +4184,6 @@ func TestArgType(t *testing.T) {
 	require.Equal(t, avmUint64, sv.avmType())
 }
 
-func TestApplicationsDisallowOldTeal(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-
-	const source = "int 1"
-
-	txn := makeSampleTxn()
-	txn.Txn.Type = protocol.ApplicationCallTx
-	txn.Txn.RekeyTo = basics.Address{}
-	ep := defaultEvalParams(txn)
-
-	for v := uint64(0); v < appsEnabledVersion; v++ {
-		ops := testProg(t, source, v)
-		e := fmt.Sprintf("program version must be >= %d", appsEnabledVersion)
-		testAppBytes(t, ops.Program, ep, e, e)
-	}
-
-	testApp(t, source, ep)
-}
-
 func TestAnyRekeyToOrApplicationRaisesMinAvmVersion(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
@@ -4265,29 +4228,36 @@ func TestAnyRekeyToOrApplicationRaisesMinAvmVersion(t *testing.T) {
 		ci, cse := ci, cse
 		t.Run(fmt.Sprintf("ci=%d", ci), func(t *testing.T) {
 			t.Parallel()
-			ep := defaultEvalParams(cse.group...)
+			sep, aep := defaultEvalParams(cse.group...)
 
 			// Computed MinAvmVersion should be == validFromVersion
-			calc := computeMinAvmVersion(ep.TxnGroup)
+			calc := computeMinAvmVersion(sep.TxnGroup)
 			require.Equal(t, calc, cse.validFromVersion)
+
+			if aep != nil {
+				// A nil aep happens when no apps present. No need to check
+				// minversion if NewAppEvalParams won't even give an ep!
+				calc = computeMinAvmVersion(aep.TxnGroup)
+				require.Equal(t, calc, cse.validFromVersion)
+			}
 
 			// Should fail for all versions < validFromVersion
 			expected := fmt.Sprintf("program version must be >= %d", cse.validFromVersion)
 			for v := uint64(0); v < cse.validFromVersion; v++ {
 				ops := testProg(t, source, v)
-				if ep.supportsAppEval() {
-					testAppBytes(t, ops.Program, ep, expected, expected)
+				if aep != nil {
+					testAppBytes(t, ops.Program, aep, expected, expected)
 				}
-				testLogicBytes(t, ops.Program, ep, expected, expected)
+				testLogicBytes(t, ops.Program, sep, expected, expected)
 			}
 
 			// Should succeed for all versions >= validFromVersion
 			for v := cse.validFromVersion; v <= AssemblerMaxVersion; v++ {
 				ops := testProg(t, source, v)
-				if ep.supportsAppEval() {
-					testAppBytes(t, ops.Program, ep)
+				if aep != nil {
+					testAppBytes(t, ops.Program, aep)
 				}
-				testLogicBytes(t, ops.Program, ep)
+				testLogicBytes(t, ops.Program, sep)
 			}
 		})
 	}
@@ -4332,7 +4302,7 @@ func TestAllowedOpcodesV2(t *testing.T) {
 		"gtxn":       true,
 	}
 
-	ep := defaultEvalParamsWithVersion(2)
+	sep, aep := defaultEvalParamsWithVersion(2)
 
 	cnt := 0
 	for _, spec := range OpSpecs {
@@ -4342,9 +4312,9 @@ func TestAllowedOpcodesV2(t *testing.T) {
 			require.Contains(t, source, spec.Name)
 			ops := testProg(t, source, 2)
 			// all opcodes allowed in stateful mode so use CheckStateful/EvalContract
-			err := CheckContract(ops.Program, ep)
+			err := CheckContract(ops.Program, aep)
 			require.NoError(t, err, source)
-			_, err = EvalApp(ops.Program, 0, 0, ep)
+			_, err = EvalApp(ops.Program, 0, 0, aep)
 			if spec.Name != "return" {
 				// "return" opcode always succeeds so ignore it
 				require.Error(t, err, source)
@@ -4353,8 +4323,11 @@ func TestAllowedOpcodesV2(t *testing.T) {
 
 			for v := byte(0); v <= 1; v++ {
 				ops.Program[0] = v
-				testLogicBytes(t, ops.Program, ep, "illegal opcode", "illegal opcode")
-				testAppBytes(t, ops.Program, ep, "illegal opcode", "illegal opcode")
+				testLogicBytes(t, ops.Program, sep, "illegal opcode", "illegal opcode")
+				// let the program run even though minAvmVersion would ban it,
+				// so we can have this sanity check
+				aep.minAvmVersion = uint64(v)
+				testAppBytes(t, ops.Program, aep, "illegal opcode", "illegal opcode")
 			}
 			cnt++
 		}
@@ -4365,7 +4338,6 @@ func TestAllowedOpcodesV2(t *testing.T) {
 // check all v3 opcodes: allowed in v3 and not allowed before
 func TestAllowedOpcodesV3(t *testing.T) {
 	partitiontest.PartitionTest(t)
-
 	t.Parallel()
 
 	// all tests are expected to fail in evaluation
@@ -4385,7 +4357,7 @@ func TestAllowedOpcodesV3(t *testing.T) {
 		"pushbytes":   `pushbytes "stringsfail?"`,
 	}
 
-	ep := defaultEvalParamsWithVersion(3)
+	sep, aep := defaultEvalParamsWithVersion(3)
 
 	cnt := 0
 	for _, spec := range OpSpecs {
@@ -4395,12 +4367,15 @@ func TestAllowedOpcodesV3(t *testing.T) {
 			require.Contains(t, source, spec.Name)
 			ops := testProg(t, source, 3)
 			// all opcodes allowed in stateful mode so use CheckStateful/EvalContract
-			testAppBytes(t, ops.Program, ep, "REJECT")
+			testAppBytes(t, ops.Program, aep, "REJECT")
 
-			for v := byte(0); v <= 1; v++ {
+			for v := byte(0); v <= 2; v++ {
 				ops.Program[0] = v
-				testLogicBytes(t, ops.Program, ep, "illegal opcode", "illegal opcode")
-				testAppBytes(t, ops.Program, ep, "illegal opcode", "illegal opcode")
+				testLogicBytes(t, ops.Program, sep, "illegal opcode", "illegal opcode")
+				// let the program run even though minAvmVersion would ban it,
+				// so we can have this sanity check
+				aep.minAvmVersion = uint64(v)
+				testAppBytes(t, ops.Program, aep, "illegal opcode", "illegal opcode")
 			}
 			cnt++
 		}
@@ -4430,9 +4405,8 @@ func TestRekeyFailsOnOldVersion(t *testing.T) {
 			ops := testProg(t, "int 1", v)
 			var txn transactions.SignedTxn
 			txn.Txn.RekeyTo = basics.Address{1, 2, 3, 4}
-			ep := defaultEvalParams(txn)
 			e := fmt.Sprintf("program version must be >= %d", rekeyingEnabledVersion)
-			testLogicBytes(t, ops.Program, ep, e, e)
+			testLogicBytes(t, ops.Program, defaultSigParams(txn), e, e)
 		})
 	}
 }
@@ -4471,13 +4445,13 @@ func testEvaluation(t *testing.T, program string, introduced uint64, tester eval
 					t.Helper()
 					var txn transactions.SignedTxn
 					txn.Lsig.Logic = ops.Program
-					ep := defaultEvalParamsWithVersion(lv, txn)
+					ep := defaultSigParamsWithVersion(lv, txn)
 					err := CheckSignature(0, ep)
 					if err != nil {
 						t.Log(ep.Trace.String())
 					}
 					require.NoError(t, err)
-					ep = defaultEvalParamsWithVersion(lv, txn)
+					ep = defaultSigParamsWithVersion(lv, txn)
 					pass, err := EvalSignature(0, ep)
 					ok := tester(t, pass, err)
 					if !ok {
@@ -5054,116 +5028,6 @@ func TestBytesConversions(t *testing.T) {
 	testAccepts(t, "byte 0x0011; byte 0x10; b+; btoi; int 0x21; ==", 4)
 }
 
-func TestLog(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	t.Parallel()
-	var txn transactions.SignedTxn
-	txn.Txn.Type = protocol.ApplicationCallTx
-	ledger := NewLedger(nil)
-	ledger.NewApp(txn.Txn.Receiver, 0, basics.AppParams{})
-	ep := defaultEvalParams(txn)
-	ep.Proto = makeTestProtoV(LogicVersion)
-	ep.Ledger = ledger
-	testCases := []struct {
-		source string
-		loglen int
-	}{
-		{
-			source: `byte  "a logging message"; log; int 1`,
-			loglen: 1,
-		},
-		{
-			source: `byte  "a logging message"; log; byte  "a logging message"; log; int 1`,
-			loglen: 2,
-		},
-		{
-			source: fmt.Sprintf(`%s int 1`, strings.Repeat(`byte "a logging message"; log; `, maxLogCalls)),
-			loglen: maxLogCalls,
-		},
-		{
-			source: `int 1; loop: byte "a logging message"; log; int 1; +; dup; int 30; <=; bnz loop;`,
-			loglen: 30,
-		},
-		{
-			source: fmt.Sprintf(`byte "%s"; log; int 1`, strings.Repeat("a", maxLogSize)),
-			loglen: 1,
-		},
-	}
-
-	//track expected number of logs in cx.EvalDelta.Logs
-	for i, s := range testCases {
-		delta := testApp(t, s.source, ep)
-		require.Len(t, delta.Logs, s.loglen)
-		if i == len(testCases)-1 {
-			require.Equal(t, strings.Repeat("a", maxLogSize), delta.Logs[0])
-		} else {
-			for _, l := range delta.Logs {
-				require.Equal(t, "a logging message", l)
-			}
-		}
-	}
-
-	msg := strings.Repeat("a", 400)
-	failCases := []struct {
-		source      string
-		runMode     RunMode
-		errContains string
-		// For cases where assembly errors, we manually put in the bytes
-		assembledBytes []byte
-	}{
-		{
-			source:      fmt.Sprintf(`byte  "%s"; log; int 1`, strings.Repeat("a", maxLogSize+1)),
-			errContains: fmt.Sprintf(">  %d bytes limit", maxLogSize),
-			runMode:     ModeApp,
-		},
-		{
-			source:      fmt.Sprintf(`byte  "%s"; log; byte  "%s"; log; byte  "%s"; log; int 1`, msg, msg, msg),
-			errContains: fmt.Sprintf(">  %d bytes limit", maxLogSize),
-			runMode:     ModeApp,
-		},
-		{
-			source:      fmt.Sprintf(`%s; int 1`, strings.Repeat(`byte "a"; log; `, maxLogCalls+1)),
-			errContains: "too many log calls",
-			runMode:     ModeApp,
-		},
-		{
-			source:      `int 1; loop: byte "a"; log; int 1; +; dup; int 35; <; bnz loop;`,
-			errContains: "too many log calls",
-			runMode:     ModeApp,
-		},
-		{
-			source:      fmt.Sprintf(`int 1; loop: byte "%s"; log; int 1; +; dup; int 6; <; bnz loop;`, strings.Repeat(`a`, 400)),
-			errContains: fmt.Sprintf(">  %d bytes limit", maxLogSize),
-			runMode:     ModeApp,
-		},
-		{
-			source:         `load 0; log`,
-			errContains:    "log arg 0 wanted []byte but got uint64",
-			runMode:        ModeApp,
-			assembledBytes: []byte{byte(ep.Proto.LogicSigVersion), 0x34, 0x00, 0xb0},
-		},
-		{
-			source:      `byte  "a logging message"; log; int 1`,
-			errContains: "log not allowed in current mode",
-			runMode:     ModeSig,
-		},
-	}
-
-	for _, c := range failCases {
-		switch c.runMode {
-		case ModeApp:
-			if c.assembledBytes == nil {
-				testApp(t, c.source, ep, c.errContains)
-			} else {
-				testAppBytes(t, c.assembledBytes, ep, c.errContains)
-			}
-		default:
-			testLogic(t, c.source, AssemblerMaxVersion, ep, c.errContains, c.errContains)
-		}
-	}
-}
-
 func TestPcDetails(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
@@ -5418,13 +5282,6 @@ func TestOpJSONRef(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	var txn transactions.SignedTxn
-	txn.Txn.Type = protocol.ApplicationCallTx
-	ledger := NewLedger(nil)
-	ledger.NewApp(txn.Txn.Receiver, 0, basics.AppParams{})
-	ep := defaultEvalParams(txn)
-	ep.Ledger = ledger
-	ep.SigLedger = ledger
 	testCases := []struct {
 		source             string
 		previousVersErrors []expect
@@ -5594,15 +5451,7 @@ func TestOpJSONRef(t *testing.T) {
 		}
 		ops := testProg(t, s.source, AssemblerMaxVersion)
 
-		err := CheckContract(ops.Program, ep)
-		require.NoError(t, err, s)
-
-		pass, _, err := EvalContract(ops.Program, 0, 888, ep)
-		require.NoError(t, err)
-		require.True(t, pass)
-
-		// reset pooled budget for new "app call"
-		*ep.PooledApplicationBudget = ep.Proto.MaxAppProgramCost
+		testLogicBytes(t, ops.Program, defaultSigParams())
 	}
 
 	failedCases := []struct {
@@ -5806,16 +5655,7 @@ func TestOpJSONRef(t *testing.T) {
 		}
 
 		ops := testProg(t, s.source, AssemblerMaxVersion)
-
-		err := CheckContract(ops.Program, ep)
-		require.NoError(t, err, s)
-
-		pass, _, err := EvalContract(ops.Program, 0, 888, ep)
-		require.False(t, pass)
-		require.ErrorContains(t, err, s.error)
-
-		// reset pooled budget for new "app call"
-		*ep.PooledApplicationBudget = ep.Proto.MaxAppProgramCost
+		testLogicBytes(t, ops.Program, defaultSigParams(), s.error)
 	}
 
 }

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -1932,18 +1932,17 @@ func TestTxn(t *testing.T) {
 				// And the early tests use "arg" a lot - not allowed in stateful. So remove those tests.
 				lastArg := strings.Index(source, "arg 10\n==\n&&")
 				require.NotEqual(t, -1, lastArg)
+				source = source[lastArg+12:]
 
-				if v >= appsEnabledVersion {
-					aep.TxnGroup[2].EvalDelta.Logs = []string{"x", "prefilled"}
-					appSafe := "int 1" + strings.Replace(source[lastArg+12:], `txn Sender
+				aep.TxnGroup[2].EvalDelta.Logs = []string{"x", "prefilled"} // allows gtxn 2 NumLogs
+				appSafe := "int 1" + strings.Replace(source, `txn Sender
 int 0
 args
 ==
 assert`, "", 1)
 
-					ops := testProg(t, appSafe, v)
-					testAppFull(t, ops.Program, 3, basics.AppIndex(888), aep)
-				}
+				ops := testProg(t, appSafe, v)
+				testAppFull(t, ops.Program, 3, basics.AppIndex(888), aep)
 			}
 		})
 	}

--- a/data/transactions/logic/export_test.go
+++ b/data/transactions/logic/export_test.go
@@ -36,14 +36,14 @@ func (l *Ledger) DelBoxes(app basics.AppIndex, names ...string) {
 	}
 }
 
-var DefaultEvalParams = defaultEvalParams
+var DefaultSigParams = defaultSigParams
+var DefaultAppParams = defaultAppParams
 var Exp = exp
 var MakeSampleEnv = makeSampleEnv
 var MakeSampleEnvWithVersion = makeSampleEnvWithVersion
 var MakeSampleTxn = makeSampleTxn
 var MakeSampleTxnGroup = makeSampleTxnGroup
 var MakeTestProto = makeTestProto
-var MakeTestProtoV = makeTestProtoV
 var NoTrack = notrack
 var TestLogic = testLogic
 var TestApp = testApp

--- a/data/transactions/logic/export_test.go
+++ b/data/transactions/logic/export_test.go
@@ -24,10 +24,6 @@ import "github.com/algorand/go-algorand/data/basics"
 // we export some extra things to make testing easier there. But we do it in a
 // _test.go file, so they are only exported during testing.
 
-func (ep *EvalParams) Reset() {
-	ep.reset()
-}
-
 // Inefficient (hashing), just a testing convenience
 func (l *Ledger) CreateBox(app basics.AppIndex, name string, size uint64) {
 	l.NewBox(app, name, make([]byte, size), app.Address())

--- a/data/transactions/logic/export_test.go
+++ b/data/transactions/logic/export_test.go
@@ -58,11 +58,13 @@ var TestProg = testProg
 var WithPanicOpcode = withPanicOpcode
 
 // TryApps exports "testApps" while accepting a simple uint64. Annoying, we
-// can't export this as "TestApps" because it looks like a Test function with
-// the wrong signature.
+// can't export call this "TestApps" because it looks like a Test function with
+// the wrong signature. But we can get that effect with the alias below.
 func TryApps(t *testing.T, programs []string, txgroup []transactions.SignedTxn, ver uint64, ledger *Ledger, expected ...expect) *EvalParams {
 	return testApps(t, programs, txgroup, protoVer(ver), ledger, expected...)
 }
+
+var TestApps = TryApps
 
 const CreatedResourcesVersion = createdResourcesVersion
 const AssemblerNoVersion = assemblerNoVersion

--- a/data/transactions/logic/export_test.go
+++ b/data/transactions/logic/export_test.go
@@ -16,7 +16,12 @@
 
 package logic
 
-import "github.com/algorand/go-algorand/data/basics"
+import (
+	"testing"
+
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/transactions"
+)
 
 // Export for testing only.  See
 // https://medium.com/@robiplus/golang-trick-export-for-test-aa16cbd7b8cd for a
@@ -48,10 +53,16 @@ var NoTrack = notrack
 var TestLogic = testLogic
 var TestApp = testApp
 var TestAppBytes = testAppBytes
-var TestApps = testApps
 var TestLogicRange = testLogicRange
 var TestProg = testProg
 var WithPanicOpcode = withPanicOpcode
+
+// TryApps exports "testApps" while accepting a simple uint64. Annoying, we
+// can't export this as "TestApps" because it looks like a Test function with
+// the wrong signature.
+func TryApps(t *testing.T, programs []string, txgroup []transactions.SignedTxn, ver uint64, ledger *Ledger, expected ...expect) *EvalParams {
+	return testApps(t, programs, txgroup, protoVer(ver), ledger, expected...)
+}
 
 const CreatedResourcesVersion = createdResourcesVersion
 const AssemblerNoVersion = assemblerNoVersion

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -890,7 +890,7 @@ func init() {
 	}
 	// Start from v2 and higher,
 	// copy lower version opcodes and overwrite matching version
-	for v := uint64(2); v <= evalMaxVersion; v++ {
+	for v := uint64(2); v <= LogicVersion; v++ {
 		// Copy opcodes from lower version
 		OpsByName[v] = maps.Clone(OpsByName[v-1])
 		for op, oi := range opsByOpcode[v-1] {

--- a/data/transactions/logic/resources_test.go
+++ b/data/transactions/logic/resources_test.go
@@ -67,10 +67,10 @@ func TestAppSharing(t *testing.T) {
 	getSchema := "int 500; app_params_get AppGlobalNumByteSlice; !; assert; pop; int 1"
 	// In v8, the first tx can read app params of 500, because it's in its
 	// foreign array, but the second can't
-	TryApps(t, []string{getSchema, getSchema}, txntest.Group(&appl0, &appl1), 8, nil,
+	TestApps(t, []string{getSchema, getSchema}, txntest.Group(&appl0, &appl1), 8, nil,
 		Exp(1, "unavailable App 500"))
 	// In v9, the second can, because the first can.
-	TryApps(t, []string{getSchema, getSchema}, txntest.Group(&appl0, &appl1), 9, nil)
+	TestApps(t, []string{getSchema, getSchema}, txntest.Group(&appl0, &appl1), 9, nil)
 
 	getLocalEx := `txn Sender; int 500; byte "some-key"; app_local_get_ex; pop; pop; int 1`
 
@@ -78,7 +78,7 @@ func TestAppSharing(t *testing.T) {
 	// reading the locals for a different account.
 
 	// app_local_get* requires the address and the app exist, else the program fails
-	TryApps(t, []string{getLocalEx, getLocalEx}, txntest.Group(&appl0, &appl1), 8, nil,
+	TestApps(t, []string{getLocalEx, getLocalEx}, txntest.Group(&appl0, &appl1), 8, nil,
 		Exp(0, "no account"))
 
 	_, _, ledger := MakeSampleEnv()
@@ -87,42 +87,42 @@ func TestAppSharing(t *testing.T) {
 	ledger.NewApp(appl0.Sender, 500, basics.AppParams{})
 	ledger.NewLocals(appl0.Sender, 500) // opt in
 	// Now txn0 passes, but txn1 has an error because it can't see app 500
-	TryApps(t, []string{getLocalEx, getLocalEx}, txntest.Group(&appl0, &appl1), 9, ledger,
+	TestApps(t, []string{getLocalEx, getLocalEx}, txntest.Group(&appl0, &appl1), 9, ledger,
 		Exp(1, "unavailable Local State"))
 
 	// But it's ok in appl2, because appl2 uses the same Sender, even though the
 	// foreign-app is not repeated in appl2 because the holding being accessed
 	// is the one from tx0.
-	TryApps(t, []string{getLocalEx, getLocalEx}, txntest.Group(&appl0, &appl2), 9, ledger)
-	TryApps(t, []string{getLocalEx, getLocalEx}, txntest.Group(&appl0, &appl2), 8, ledger, // version 8 does not get sharing
+	TestApps(t, []string{getLocalEx, getLocalEx}, txntest.Group(&appl0, &appl2), 9, ledger)
+	TestApps(t, []string{getLocalEx, getLocalEx}, txntest.Group(&appl0, &appl2), 8, ledger, // version 8 does not get sharing
 		Exp(1, "unavailable App 500"))
 
 	// Checking if an account is opted in has pretty much the same rules
 	optInCheck500 := "txn Sender; int 500; app_opted_in"
 
 	// app_opted_in requires the address and the app exist, else the program fails
-	TryApps(t, []string{optInCheck500, optInCheck500}, txntest.Group(&appl0, &appl1), 9, nil, // nil ledger, no account
+	TestApps(t, []string{optInCheck500, optInCheck500}, txntest.Group(&appl0, &appl1), 9, nil, // nil ledger, no account
 		Exp(0, "no account: "+appl0.Sender.String()))
 
 	// Now txn0 passes, but txn1 has an error because it can't see app 500 locals for appl1.Sender
-	TryApps(t, []string{optInCheck500, optInCheck500}, txntest.Group(&appl0, &appl1), 9, ledger,
+	TestApps(t, []string{optInCheck500, optInCheck500}, txntest.Group(&appl0, &appl1), 9, ledger,
 		Exp(1, "unavailable Local State "+appl1.Sender.String()))
 
 	// But it's ok in appl2, because appl2 uses the same Sender, even though the
 	// foreign-app is not repeated in appl2 because the holding being accessed
 	// is the one from tx0.
-	TryApps(t, []string{optInCheck500, optInCheck500}, txntest.Group(&appl0, &appl2), 9, ledger)
-	TryApps(t, []string{optInCheck500, optInCheck500}, txntest.Group(&appl0, &appl2), 8, ledger, // version 8 does not get sharing
+	TestApps(t, []string{optInCheck500, optInCheck500}, txntest.Group(&appl0, &appl2), 9, ledger)
+	TestApps(t, []string{optInCheck500, optInCheck500}, txntest.Group(&appl0, &appl2), 8, ledger, // version 8 does not get sharing
 		Exp(1, "unavailable App 500"))
 
 	// Confirm sharing applies to the app id called in tx0, not just foreign app array
 	optInCheck900 := "txn Sender; int 900; app_opted_in; !" // we did not opt any senders into 900
 
 	// as above, appl1 can't see the local state, but appl2 can b/c sender is same as appl0
-	TryApps(t, []string{optInCheck900, optInCheck900}, txntest.Group(&appl0, &appl1), 9, ledger,
+	TestApps(t, []string{optInCheck900, optInCheck900}, txntest.Group(&appl0, &appl1), 9, ledger,
 		Exp(1, "unavailable Local State "+appl1.Sender.String()))
-	TryApps(t, []string{optInCheck900, optInCheck900}, txntest.Group(&appl0, &appl2), 9, ledger)
-	TryApps(t, []string{optInCheck900, optInCheck900}, txntest.Group(&appl0, &appl2), 8, ledger, // v8=no sharing
+	TestApps(t, []string{optInCheck900, optInCheck900}, txntest.Group(&appl0, &appl2), 9, ledger)
+	TestApps(t, []string{optInCheck900, optInCheck900}, txntest.Group(&appl0, &appl2), 8, ledger, // v8=no sharing
 		Exp(1, "unavailable App 900"))
 
 	// Now, confirm that *setting* a local state in tx1 that was made available
@@ -134,14 +134,14 @@ func TestAppSharing(t *testing.T) {
 	sources := []string{noop, putLocal}
 	appl1.ApplicationArgs = [][]byte{appl0.Sender[:]} // tx1 will try to modify local state exposed in tx0
 	// appl0.Sender is available, but 901's local state for it isn't (only 900 is, since 900 was called in tx0)
-	TryApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger,
+	TestApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger,
 		Exp(1, "unavailable Local State "+appl0.Sender.String()))
 	// Add 901 to tx0's ForeignApps, and it works
 	appl0.ForeignApps = append(appl0.ForeignApps, 901) // well, it will after we opt in
-	TryApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger,
+	TestApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger,
 		Exp(1, "account "+appl0.Sender.String()+" is not opted into 901"))
 	ledger.NewLocals(appl0.Sender, 901) // opt in
-	ep := TryApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger)
+	ep := TestApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger)
 	require.Len(t, ep.TxnGroup, 2)
 	ed := ep.TxnGroup[1].ApplyData.EvalDelta
 	require.Equal(t, map[uint64]basics.StateDelta{
@@ -157,37 +157,37 @@ func TestAppSharing(t *testing.T) {
 
 	// when running all three, appl2 can't read the locals of app in tx0 and addr in tx1
 	sources = []string{"", "", "gtxn 1 Sender; gtxn 0 Applications 0; byte 0xAA; app_local_get_ex"}
-	TryApps(t, sources, txntest.Group(&appl0, &appl1, &appl2), 9, nil,
+	TestApps(t, sources, txntest.Group(&appl0, &appl1, &appl2), 9, nil,
 		Exp(2, "unavailable Local State")) // note that the error message is for Locals, not specialized
 	// same test of account in array of tx1 rather than Sender
 	appl1.Accounts = []basics.Address{{7, 7}}
 	sources = []string{"", "", "gtxn 1 Accounts 1; gtxn 0 Applications 0; byte 0xAA; app_local_get_ex"}
-	TryApps(t, sources, txntest.Group(&appl0, &appl1, &appl2), 9, nil,
+	TestApps(t, sources, txntest.Group(&appl0, &appl1, &appl2), 9, nil,
 		Exp(2, "unavailable Local State")) // note that the error message is for Locals, not specialized
 
 	// try to do a put on local state of the account in tx1, but tx0 ought not have access to that local state
 	ledger.NewAccount(pay1.Receiver, 200_000)
 	ledger.NewLocals(pay1.Receiver, 900) // opt in
 	sources = []string{`gtxn 1 Receiver; byte "key"; byte "val"; app_local_put; int 1`}
-	TryApps(t, sources, txntest.Group(&appl0, &pay1), 9, ledger,
+	TestApps(t, sources, txntest.Group(&appl0, &pay1), 9, ledger,
 		Exp(0, "unavailable Local State "+pay1.Receiver.String()))
 
 	// same for app_local_del
 	sources = []string{`gtxn 1 Receiver; byte "key"; app_local_del; int 1`}
-	TryApps(t, sources, txntest.Group(&appl0, &pay1), 9, ledger,
+	TestApps(t, sources, txntest.Group(&appl0, &pay1), 9, ledger,
 		Exp(0, "unavailable Local State "+pay1.Receiver.String()))
 
 	// now, use an app call in tx1, with 900 in the foreign apps, so the local state is available
 	appl1.ForeignApps = append(appl1.ForeignApps, 900)
 	ledger.NewLocals(appl1.Sender, 900) // opt in
 	sources = []string{`gtxn 1 Sender; byte "key"; byte "val"; app_local_put; int 1`}
-	TryApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger)
-	TryApps(t, sources, txntest.Group(&appl0, &appl1), 8, ledger, // 8 doesn't share the account
+	TestApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger)
+	TestApps(t, sources, txntest.Group(&appl0, &appl1), 8, ledger, // 8 doesn't share the account
 		Exp(0, "invalid Account reference "+appl1.Sender.String()))
 	// same for app_local_del
 	sources = []string{`gtxn 1 Sender; byte "key"; app_local_del; int 1`}
-	TryApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger)
-	TryApps(t, sources, txntest.Group(&appl0, &appl1), 8, ledger, // 8 doesn't share the account
+	TestApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger)
+	TestApps(t, sources, txntest.Group(&appl0, &appl1), 8, ledger, // 8 doesn't share the account
 		Exp(0, "invalid Account reference "+appl1.Sender.String()))
 }
 
@@ -258,31 +258,31 @@ func TestAssetSharing(t *testing.T) {
 
 	// In v8, the first tx can read asset 400, because it's in its foreign array,
 	// but the second can't
-	TryApps(t, []string{getTotal, getTotal}, txntest.Group(&appl0, &appl1), 8, nil,
+	TestApps(t, []string{getTotal, getTotal}, txntest.Group(&appl0, &appl1), 8, nil,
 		Exp(1, "unavailable Asset 400"))
 	// In v9, the second can, because the first can.
-	TryApps(t, []string{getTotal, getTotal}, txntest.Group(&appl0, &appl1), 9, nil)
+	TestApps(t, []string{getTotal, getTotal}, txntest.Group(&appl0, &appl1), 9, nil)
 
 	getBalance := "txn Sender; int 400; asset_holding_get AssetBalance; pop; pop; int 1"
 
 	// In contrast, here there's no help from v9, because the second tx is
 	// reading a holding for a different account.
-	TryApps(t, []string{getBalance, getBalance}, txntest.Group(&appl0, &appl1), 8, nil,
+	TestApps(t, []string{getBalance, getBalance}, txntest.Group(&appl0, &appl1), 8, nil,
 		Exp(1, "unavailable Asset 400"))
-	TryApps(t, []string{getBalance, getBalance}, txntest.Group(&appl0, &appl1), 9, nil,
+	TestApps(t, []string{getBalance, getBalance}, txntest.Group(&appl0, &appl1), 9, nil,
 		Exp(1, "unavailable Holding"))
 	// But it's ok in appl2, because the same account is used, even though the
 	// foreign-asset is not repeated in appl2.
-	TryApps(t, []string{getBalance, getBalance}, txntest.Group(&appl0, &appl2), 9, nil)
+	TestApps(t, []string{getBalance, getBalance}, txntest.Group(&appl0, &appl2), 9, nil)
 
 	// when running all three, appl2 can't read the holding of asset in tx0 and addr in tx1
 	sources := []string{"", "", "gtxn 1 Sender; gtxn 0 Assets 0; asset_holding_get AssetBalance"}
-	TryApps(t, sources, txntest.Group(&appl0, &appl1, &appl2), 9, nil,
+	TestApps(t, sources, txntest.Group(&appl0, &appl1, &appl2), 9, nil,
 		Exp(2, "unavailable Holding")) // note that the error message is for Holding, not specialized
 	// same test of account in array of tx1 rather than Sender
 	appl1.Accounts = []basics.Address{{7, 7}}
 	sources = []string{"", "", "gtxn 1 Accounts 1; gtxn 0 Assets 0; asset_holding_get AssetBalance"}
-	TryApps(t, sources, txntest.Group(&appl0, &appl1, &appl2), 9, nil,
+	TestApps(t, sources, txntest.Group(&appl0, &appl1, &appl2), 9, nil,
 		Exp(2, "unavailable Holding")) // note that the error message is for Holding, not specialized
 }
 
@@ -418,12 +418,12 @@ func TestOtherTxSharing(t *testing.T) {
 	}
 
 	for _, send := range []txntest.Txn{keyreg, pay, acfg, axfer, afrz} {
-		TryApps(t, []string{"", senderBalance}, txntest.Group(&send, &appl), 9, ledger)
-		TryApps(t, []string{senderBalance, ""}, txntest.Group(&appl, &send), 9, ledger)
+		TestApps(t, []string{"", senderBalance}, txntest.Group(&send, &appl), 9, ledger)
+		TestApps(t, []string{senderBalance, ""}, txntest.Group(&appl, &send), 9, ledger)
 
-		TryApps(t, []string{"", senderBalance}, txntest.Group(&send, &appl), 8, ledger,
+		TestApps(t, []string{"", senderBalance}, txntest.Group(&send, &appl), 8, ledger,
 			Exp(1, "invalid Account reference"))
-		TryApps(t, []string{senderBalance, ""}, txntest.Group(&appl, &send), 8, ledger,
+		TestApps(t, []string{senderBalance, ""}, txntest.Group(&appl, &send), 8, ledger,
 			Exp(0, "invalid Account reference"))
 	}
 
@@ -436,81 +436,81 @@ func TestOtherTxSharing(t *testing.T) {
 
 	t.Run("keyreg", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {200}}
-		TryApps(t, []string{"", holdingAccess}, txntest.Group(&keyreg, &appl), 9, ledger,
+		TestApps(t, []string{"", holdingAccess}, txntest.Group(&keyreg, &appl), 9, ledger,
 			Exp(1, "unavailable Asset 200"))
 		withRef := appl
 		withRef.ForeignAssets = []basics.AssetIndex{200}
-		TryApps(t, []string{"", holdingAccess}, txntest.Group(&keyreg, &withRef), 9, ledger,
+		TestApps(t, []string{"", holdingAccess}, txntest.Group(&keyreg, &withRef), 9, ledger,
 			Exp(1, "unavailable Holding "+senderAcct.String()))
 	})
 	t.Run("pay", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		// The receiver is available for algo balance reading
 		appl.ApplicationArgs = [][]byte{receiverAcct[:]}
-		TryApps(t, []string{"", receiverBalance}, txntest.Group(&pay, &appl), 9, ledger)
+		TestApps(t, []string{"", receiverBalance}, txntest.Group(&pay, &appl), 9, ledger)
 
 		// The other account is not (it's not even in the pay txn)
 		appl.ApplicationArgs = [][]byte{otherAcct[:]}
-		TryApps(t, []string{"", otherBalance}, txntest.Group(&pay, &appl), 9, ledger,
+		TestApps(t, []string{"", otherBalance}, txntest.Group(&pay, &appl), 9, ledger,
 			Exp(1, "invalid Account reference "+otherAcct.String()))
 
 		// The other account becomes accessible because used in CloseRemainderTo
 		withClose := pay
 		withClose.CloseRemainderTo = otherAcct
-		TryApps(t, []string{"", otherBalance}, txntest.Group(&withClose, &appl), 9, ledger)
+		TestApps(t, []string{"", otherBalance}, txntest.Group(&withClose, &appl), 9, ledger)
 	})
 
 	t.Run("acfg", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		// The other account is not available even though it's all the extra addresses
 		appl.ApplicationArgs = [][]byte{otherAcct[:]}
-		TryApps(t, []string{"", otherBalance}, txntest.Group(&acfg, &appl), 9, ledger,
+		TestApps(t, []string{"", otherBalance}, txntest.Group(&acfg, &appl), 9, ledger,
 			Exp(1, "invalid Account reference "+otherAcct.String()))
 	})
 
 	t.Run("axfer", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		// The receiver is also available for algo balance reading
 		appl.ApplicationArgs = [][]byte{receiverAcct[:]}
-		TryApps(t, []string{"", receiverBalance}, txntest.Group(&axfer, &appl), 9, ledger)
+		TestApps(t, []string{"", receiverBalance}, txntest.Group(&axfer, &appl), 9, ledger)
 
 		// as is the "other" (AssetSender)
 		appl.ApplicationArgs = [][]byte{otherAcct[:]}
-		TryApps(t, []string{"", otherBalance}, txntest.Group(&axfer, &appl), 9, ledger)
+		TestApps(t, []string{"", otherBalance}, txntest.Group(&axfer, &appl), 9, ledger)
 
 		// sender holding is available
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {byte(axfer.XferAsset)}}
-		TryApps(t, []string{"", holdingAccess}, txntest.Group(&axfer, &appl), 9, ledger)
+		TestApps(t, []string{"", holdingAccess}, txntest.Group(&axfer, &appl), 9, ledger)
 
 		// receiver holding is available
 		appl.ApplicationArgs = [][]byte{receiverAcct[:], {byte(axfer.XferAsset)}}
-		TryApps(t, []string{"", holdingAccess}, txntest.Group(&axfer, &appl), 9, ledger)
+		TestApps(t, []string{"", holdingAccess}, txntest.Group(&axfer, &appl), 9, ledger)
 
 		// asset sender (other) account is available
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {byte(axfer.XferAsset)}}
-		TryApps(t, []string{"", holdingAccess}, txntest.Group(&axfer, &appl), 9, ledger)
+		TestApps(t, []string{"", holdingAccess}, txntest.Group(&axfer, &appl), 9, ledger)
 
 		// AssetCloseTo holding becomes available when set
 		appl.ApplicationArgs = [][]byte{other2Acct[:], {byte(axfer.XferAsset)}}
-		TryApps(t, []string{"", other2Balance}, txntest.Group(&axfer, &appl), 9, ledger,
+		TestApps(t, []string{"", other2Balance}, txntest.Group(&axfer, &appl), 9, ledger,
 			Exp(1, "invalid Account reference "+other2Acct.String()))
-		TryApps(t, []string{"", holdingAccess}, txntest.Group(&axfer, &appl), 9, ledger,
+		TestApps(t, []string{"", holdingAccess}, txntest.Group(&axfer, &appl), 9, ledger,
 			Exp(1, "unavailable Account "+other2Acct.String()))
 
 		withClose := axfer
 		withClose.AssetCloseTo = other2Acct
 		appl.ApplicationArgs = [][]byte{other2Acct[:], {byte(axfer.XferAsset)}}
-		TryApps(t, []string{"", other2Balance}, txntest.Group(&withClose, &appl), 9, ledger)
-		TryApps(t, []string{"", holdingAccess}, txntest.Group(&withClose, &appl), 9, ledger)
+		TestApps(t, []string{"", other2Balance}, txntest.Group(&withClose, &appl), 9, ledger)
+		TestApps(t, []string{"", holdingAccess}, txntest.Group(&withClose, &appl), 9, ledger)
 	})
 
 	t.Run("afrz", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		// The other account is available (for algo and asset)
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {byte(afrz.FreezeAsset)}}
-		TryApps(t, []string{"", otherBalance}, txntest.Group(&afrz, &appl), 9, ledger)
-		TryApps(t, []string{"", holdingAccess}, txntest.Group(&afrz, &appl), 9, ledger)
+		TestApps(t, []string{"", otherBalance}, txntest.Group(&afrz, &appl), 9, ledger)
+		TestApps(t, []string{"", holdingAccess}, txntest.Group(&afrz, &appl), 9, ledger)
 
 		// The sender holding is _not_ (because the freezeaccount's holding is irrelevant to afrz)
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {byte(afrz.FreezeAsset)}}
-		TryApps(t, []string{"", senderBalance}, txntest.Group(&afrz, &appl), 9, ledger)
-		TryApps(t, []string{"", holdingAccess}, txntest.Group(&afrz, &appl), 9, ledger,
+		TestApps(t, []string{"", senderBalance}, txntest.Group(&afrz, &appl), 9, ledger)
+		TestApps(t, []string{"", holdingAccess}, txntest.Group(&afrz, &appl), 9, ledger,
 			Exp(1, "unavailable Holding "+senderAcct.String()))
 	})
 }
@@ -584,13 +584,13 @@ int 1
 
 		// appl has no foreign ref to senderAcct, but can still inner pay it
 		appl.ApplicationArgs = [][]byte{senderAcct[:]}
-		TryApps(t, []string{"", payToArg}, txntest.Group(&keyreg, &appl), 9, ledger)
-		TryApps(t, []string{"", payToArg}, txntest.Group(&keyreg, &appl), 8, ledger,
+		TestApps(t, []string{"", payToArg}, txntest.Group(&keyreg, &appl), 9, ledger)
+		TestApps(t, []string{"", payToArg}, txntest.Group(&keyreg, &appl), 8, ledger,
 			Exp(1, "unavailable Account "+senderAcct.String()))
 
 		// confirm you can't just pay _anybody_. receiverAcct is not in use at all.
 		appl.ApplicationArgs = [][]byte{receiverAcct[:]}
-		TryApps(t, []string{"", payToArg}, txntest.Group(&keyreg, &appl), 9, ledger,
+		TestApps(t, []string{"", payToArg}, txntest.Group(&keyreg, &appl), 9, ledger,
 			Exp(1, "unavailable Account "+receiverAcct.String()))
 	})
 
@@ -603,18 +603,18 @@ int 1
 
 		// appl has no foreign ref to senderAcct or receiverAcct, but can still inner pay them
 		appl.ApplicationArgs = [][]byte{senderAcct[:]}
-		TryApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 9, ledger)
-		TryApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 8, ledger,
+		TestApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 9, ledger)
+		TestApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 8, ledger,
 			Exp(1, "unavailable Account "+senderAcct.String()))
 
 		appl.ApplicationArgs = [][]byte{receiverAcct[:]}
-		TryApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 9, ledger)
-		TryApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 8, ledger,
+		TestApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 9, ledger)
+		TestApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 8, ledger,
 			Exp(1, "unavailable Account "+receiverAcct.String()))
 
 		// confirm you can't just pay _anybody_. otherAcct is not in use at all.
 		appl.ApplicationArgs = [][]byte{otherAcct[:]}
-		TryApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 9, ledger,
+		TestApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 9, ledger,
 			Exp(1, "unavailable Account "+otherAcct.String()))
 	})
 
@@ -629,46 +629,46 @@ int 1
 
 		// appl can pay the axfer sender
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {asa1}}
-		TryApps(t, []string{"", payToArg}, txntest.Group(&axfer, &appl), 9, ledger)
-		TryApps(t, []string{"", payToArg}, txntest.Group(&axfer, &appl), 8, ledger,
+		TestApps(t, []string{"", payToArg}, txntest.Group(&axfer, &appl), 9, ledger)
+		TestApps(t, []string{"", payToArg}, txntest.Group(&axfer, &appl), 8, ledger,
 			Exp(1, "unavailable Account "+senderAcct.String()))
 		// but can't axfer to sender, because appAcct doesn't have holding access for the asa
-		TryApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
+		TestApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
 			Exp(1, "unavailable Holding"))
 		// and to the receiver
 		appl.ApplicationArgs = [][]byte{receiverAcct[:], {asa1}}
-		TryApps(t, []string{payToArg}, txntest.Group(&appl, &axfer), 9, ledger)
-		TryApps(t, []string{axferToArgs}, txntest.Group(&appl, &axfer), 9, ledger,
+		TestApps(t, []string{payToArg}, txntest.Group(&appl, &axfer), 9, ledger)
+		TestApps(t, []string{axferToArgs}, txntest.Group(&appl, &axfer), 9, ledger,
 			Exp(0, "unavailable Holding"))
 		// and to the clawback
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {asa1}}
-		TryApps(t, []string{"", payToArg}, txntest.Group(&axfer, &appl), 9, ledger)
-		TryApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
+		TestApps(t, []string{"", payToArg}, txntest.Group(&axfer, &appl), 9, ledger)
+		TestApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
 			Exp(1, "unavailable Holding"))
 
 		// Those axfers become possible by adding the asa to the appl's ForeignAssets
 		appl.ForeignAssets = []basics.AssetIndex{asa1}
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {asa1}}
-		TryApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger)
+		TestApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger)
 		appl.ApplicationArgs = [][]byte{receiverAcct[:], {asa1}}
-		TryApps(t, []string{axferToArgs}, txntest.Group(&appl, &axfer), 9, ledger)
+		TestApps(t, []string{axferToArgs}, txntest.Group(&appl, &axfer), 9, ledger)
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {asa1}}
-		TryApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger)
+		TestApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger)
 
 		// but can't axfer a different asset
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {asa2}}
-		TryApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
+		TestApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
 			Exp(1, fmt.Sprintf("unavailable Asset %d", asa2)))
 		// or correct asset to an unknown address
 		appl.ApplicationArgs = [][]byte{unusedAcct[:], {asa1}}
-		TryApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
+		TestApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
 			Exp(1, "unavailable Account"))
 
 		// appl can acfg the asset from tx0 (which requires asset available, not holding)
 		appl.ApplicationArgs = [][]byte{{asa1}}
-		TryApps(t, []string{"", acfgArg}, txntest.Group(&axfer, &appl), 9, ledger)
+		TestApps(t, []string{"", acfgArg}, txntest.Group(&axfer, &appl), 9, ledger)
 		appl.ApplicationArgs = [][]byte{{asa2}} // but not asa2
-		TryApps(t, []string{"", acfgArg}, txntest.Group(&axfer, &appl), 9, ledger,
+		TestApps(t, []string{"", acfgArg}, txntest.Group(&axfer, &appl), 9, ledger,
 			Exp(1, fmt.Sprintf("unavailable Asset %d", asa2)))
 
 		// Now, confirm that access to account from a pay in one tx, and asa
@@ -682,15 +682,15 @@ int 1
 		}
 		// the asset is acfg-able
 		appl.ApplicationArgs = [][]byte{{asa1}}
-		TryApps(t, []string{"", "", acfgArg}, txntest.Group(&pay, &axfer, &appl), 9, ledger)
-		TryApps(t, []string{"", "", acfgArg}, txntest.Group(&axfer, &pay, &appl), 9, ledger)
+		TestApps(t, []string{"", "", acfgArg}, txntest.Group(&pay, &axfer, &appl), 9, ledger)
+		TestApps(t, []string{"", "", acfgArg}, txntest.Group(&axfer, &pay, &appl), 9, ledger)
 		// payAcct (the pay sender) is payable
 		appl.ApplicationArgs = [][]byte{payAcct[:]}
-		TryApps(t, []string{"", "", payToArg}, txntest.Group(&axfer, &pay, &appl), 9, ledger)
+		TestApps(t, []string{"", "", payToArg}, txntest.Group(&axfer, &pay, &appl), 9, ledger)
 		// but the cross-product is not available, so no axfer (opting in first, to prevent that error)
 		ledger.NewHolding(payAcct, asa1, 1, false)
 		appl.ApplicationArgs = [][]byte{payAcct[:], {asa1}}
-		TryApps(t, []string{"", "", axferToArgs}, txntest.Group(&axfer, &pay, &appl), 9, ledger,
+		TestApps(t, []string{"", "", axferToArgs}, txntest.Group(&axfer, &pay, &appl), 9, ledger,
 			Exp(2, "unavailable Holding "+payAcct.String()))
 	})
 
@@ -705,47 +705,47 @@ int 1
 
 		// appl can pay to the sender & freeze account
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {asa1}}
-		TryApps(t, []string{"", payToArg}, txntest.Group(&afrz, &appl), 9, ledger)
+		TestApps(t, []string{"", payToArg}, txntest.Group(&afrz, &appl), 9, ledger)
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {asa1}}
-		TryApps(t, []string{"", payToArg}, txntest.Group(&afrz, &appl), 9, ledger)
+		TestApps(t, []string{"", payToArg}, txntest.Group(&afrz, &appl), 9, ledger)
 
 		// can't axfer to the afrz sender because appAcct holding is not available from afrz
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {asa1}}
-		TryApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger,
+		TestApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger,
 			Exp(1, "unavailable Holding "+appAcct.String()))
 		appl.ForeignAssets = []basics.AssetIndex{asa1}
 		// _still_ can't axfer to sender because afrz sender's holding does NOT
 		// become available (not note that complaint is now about that account)
-		TryApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger,
+		TestApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger,
 			Exp(1, "unavailable Holding "+senderAcct.String()))
 
 		// and not to the receiver which isn't in afrz
 		appl.ApplicationArgs = [][]byte{receiverAcct[:], {asa1}}
-		TryApps(t, []string{payToArg}, txntest.Group(&appl, &afrz), 9, ledger,
+		TestApps(t, []string{payToArg}, txntest.Group(&appl, &afrz), 9, ledger,
 			Exp(0, "unavailable Account "+receiverAcct.String()))
-		TryApps(t, []string{axferToArgs}, txntest.Group(&appl, &afrz), 9, ledger,
+		TestApps(t, []string{axferToArgs}, txntest.Group(&appl, &afrz), 9, ledger,
 			Exp(0, "unavailable Account "+receiverAcct.String()))
 
 		// otherAcct is the afrz target, it's holding and account are available
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {asa1}}
-		TryApps(t, []string{"", payToArg}, txntest.Group(&afrz, &appl), 9, ledger)
-		TryApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger)
+		TestApps(t, []string{"", payToArg}, txntest.Group(&afrz, &appl), 9, ledger)
+		TestApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger)
 
 		// but still can't axfer a different asset
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {asa2}}
-		TryApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger,
+		TestApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger,
 			Exp(1, fmt.Sprintf("unavailable Asset %d", asa2)))
 		appl.ForeignAssets = []basics.AssetIndex{asa2}
 		// once added to appl's foreign array, the appl still lacks access to other's holding
-		TryApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger,
+		TestApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger,
 			Exp(1, "unavailable Holding "+otherAcct.String()))
 
 		// appl can acfg the asset from tx0 (which requires asset available, not holding)
 		appl.ForeignAssets = []basics.AssetIndex{}
 		appl.ApplicationArgs = [][]byte{{asa1}}
-		TryApps(t, []string{"", acfgArg}, txntest.Group(&afrz, &appl), 9, ledger)
+		TestApps(t, []string{"", acfgArg}, txntest.Group(&afrz, &appl), 9, ledger)
 		appl.ApplicationArgs = [][]byte{{asa2}} // but not asa2
-		TryApps(t, []string{"", acfgArg}, txntest.Group(&afrz, &appl), 9, ledger,
+		TestApps(t, []string{"", acfgArg}, txntest.Group(&afrz, &appl), 9, ledger,
 			Exp(1, fmt.Sprintf("unavailable Asset %d", asa2)))
 
 	})
@@ -762,25 +762,25 @@ int 1
 
 		// appl can pay to the otherAcct because it was in tx0
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {asa1}}
-		TryApps(t, []string{"", payToArg}, txntest.Group(&appl0, &appl), 9, ledger)
-		TryApps(t, []string{"", payToArg}, txntest.Group(&appl0, &appl), 8, ledger, // version 8 does not get sharing
+		TestApps(t, []string{"", payToArg}, txntest.Group(&appl0, &appl), 9, ledger)
+		TestApps(t, []string{"", payToArg}, txntest.Group(&appl0, &appl), 8, ledger, // version 8 does not get sharing
 			Exp(1, "unavailable Account "+otherAcct.String()))
 		// appl can (almost) axfer asa1 to the otherAcct because both are in tx0
-		TryApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger,
+		TestApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger,
 			Exp(1, "axfer Sender: unavailable Holding"))
 		// but it can't take access it's OWN asa1, unless added to ForeignAssets
 		appl.ForeignAssets = []basics.AssetIndex{asa1}
-		TryApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger)
+		TestApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger)
 
 		// but it can't use 202 at all. notice the error is more direct that
 		// above, as the problem is not the axfer Sender, only, it's that 202
 		// can't be used at all.
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {asa2}}
-		TryApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger,
+		TestApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger,
 			Exp(1, "unavailable Asset 202"))
 		// And adding asa2 does not fix this problem, because the other x 202 holding is unavailable
 		appl.ForeignAssets = []basics.AssetIndex{asa2}
-		TryApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger,
+		TestApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger,
 			Exp(1, "axfer AssetReceiver: unavailable Holding "+otherAcct.String()+" x 202"))
 
 		// Now, conduct similar tests, but with the apps performing the
@@ -813,28 +813,28 @@ int 1
 		appl.ForeignApps = []basics.AppIndex{11, 88, 99}
 
 		appl.ApplicationArgs = [][]byte{{99}, otherAcct[:], {asa1}}
-		TryApps(t, []string{"", innerCall}, txntest.Group(&appl0, &appl), 9, ledger)
+		TestApps(t, []string{"", innerCall}, txntest.Group(&appl0, &appl), 9, ledger)
 		// when the inner program is v8, it can't perform the pay
 		appl.ApplicationArgs = [][]byte{{88}, otherAcct[:], {asa1}}
-		TryApps(t, []string{"", innerCall}, txntest.Group(&appl0, &appl), 9, ledger,
+		TestApps(t, []string{"", innerCall}, txntest.Group(&appl0, &appl), 9, ledger,
 			Exp(1, "unavailable Account "+otherAcct.String()))
 		// unless the caller passes in the account, but it can't pass the
 		// account because that also would give the called app access to the
 		// passed account's local state (which isn't available to the caller)
 		innerCallWithAccount := fmt.Sprintf(innerCallTemplate, "addr "+otherAcct.String()+"; itxn_field Accounts")
-		TryApps(t, []string{"", innerCallWithAccount}, txntest.Group(&appl0, &appl), 9, ledger,
+		TestApps(t, []string{"", innerCallWithAccount}, txntest.Group(&appl0, &appl), 9, ledger,
 			Exp(1, "appl ApplicationID: unavailable Local State "+otherAcct.String()))
 		// the caller can't fix by passing 88 as a foreign app, because doing so
 		// is not much different than the current situation: 88 is being called,
 		// it's already available.
 		innerCallWithBoth := fmt.Sprintf(innerCallTemplate,
 			"addr "+otherAcct.String()+"; itxn_field Accounts; int 88; itxn_field Applications")
-		TryApps(t, []string{"", innerCallWithBoth}, txntest.Group(&appl0, &appl), 9, ledger,
+		TestApps(t, []string{"", innerCallWithBoth}, txntest.Group(&appl0, &appl), 9, ledger,
 			Exp(1, "appl ApplicationID: unavailable Local State "+otherAcct.String()))
 
 		// the caller *can* do it if it originally had access to that 88 holding.
 		appl0.ForeignApps = []basics.AppIndex{88}
-		TryApps(t, []string{"", innerCallWithAccount}, txntest.Group(&appl0, &appl), 9, ledger)
+		TestApps(t, []string{"", innerCallWithAccount}, txntest.Group(&appl0, &appl), 9, ledger)
 
 		// here we confirm that even if we try calling another app, we still
 		// can't pass in `other` and 88, because that would give the app access
@@ -842,7 +842,7 @@ int 1
 		// of the foreign arrays, not just the accounts against called app id)
 		appl.ApplicationArgs = [][]byte{{11}, otherAcct[:], {asa1}}
 		appl0.ForeignApps = []basics.AppIndex{11}
-		TryApps(t, []string{"", innerCallWithBoth}, txntest.Group(&appl0, &appl), 9, ledger,
+		TestApps(t, []string{"", innerCallWithBoth}, txntest.Group(&appl0, &appl), 9, ledger,
 			Exp(1, "appl ForeignApps: unavailable Local State "+otherAcct.String()))
 
 	})

--- a/data/transactions/logic/resources_test.go
+++ b/data/transactions/logic/resources_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
-	"github.com/algorand/go-algorand/data/transactions/logic"
+	. "github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/data/txntest"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
@@ -67,10 +67,10 @@ func TestAppSharing(t *testing.T) {
 	getSchema := "int 500; app_params_get AppGlobalNumByteSlice; !; assert; pop; int 1"
 	// In v8, the first tx can read app params of 500, because it's in its
 	// foreign array, but the second can't
-	logic.TestApps(t, []string{getSchema, getSchema}, txntest.Group(&appl0, &appl1), 8, nil,
-		logic.Exp(1, "unavailable App 500"))
+	TryApps(t, []string{getSchema, getSchema}, txntest.Group(&appl0, &appl1), 8, nil,
+		Exp(1, "unavailable App 500"))
 	// In v9, the second can, because the first can.
-	logic.TestApps(t, []string{getSchema, getSchema}, txntest.Group(&appl0, &appl1), 9, nil)
+	TryApps(t, []string{getSchema, getSchema}, txntest.Group(&appl0, &appl1), 9, nil)
 
 	getLocalEx := `txn Sender; int 500; byte "some-key"; app_local_get_ex; pop; pop; int 1`
 
@@ -78,52 +78,52 @@ func TestAppSharing(t *testing.T) {
 	// reading the locals for a different account.
 
 	// app_local_get* requires the address and the app exist, else the program fails
-	logic.TestApps(t, []string{getLocalEx, getLocalEx}, txntest.Group(&appl0, &appl1), 8, nil,
-		logic.Exp(0, "no account"))
+	TryApps(t, []string{getLocalEx, getLocalEx}, txntest.Group(&appl0, &appl1), 8, nil,
+		Exp(0, "no account"))
 
-	_, _, ledger := logic.MakeSampleEnv()
+	_, _, ledger := MakeSampleEnv()
 	ledger.NewAccount(appl0.Sender, 100_000)
 	ledger.NewAccount(appl1.Sender, 100_000)
 	ledger.NewApp(appl0.Sender, 500, basics.AppParams{})
 	ledger.NewLocals(appl0.Sender, 500) // opt in
 	// Now txn0 passes, but txn1 has an error because it can't see app 500
-	logic.TestApps(t, []string{getLocalEx, getLocalEx}, txntest.Group(&appl0, &appl1), 9, ledger,
-		logic.Exp(1, "unavailable Local State"))
+	TryApps(t, []string{getLocalEx, getLocalEx}, txntest.Group(&appl0, &appl1), 9, ledger,
+		Exp(1, "unavailable Local State"))
 
 	// But it's ok in appl2, because appl2 uses the same Sender, even though the
 	// foreign-app is not repeated in appl2 because the holding being accessed
 	// is the one from tx0.
-	logic.TestApps(t, []string{getLocalEx, getLocalEx}, txntest.Group(&appl0, &appl2), 9, ledger)
-	logic.TestApps(t, []string{getLocalEx, getLocalEx}, txntest.Group(&appl0, &appl2), 8, ledger, // version 8 does not get sharing
-		logic.Exp(1, "unavailable App 500"))
+	TryApps(t, []string{getLocalEx, getLocalEx}, txntest.Group(&appl0, &appl2), 9, ledger)
+	TryApps(t, []string{getLocalEx, getLocalEx}, txntest.Group(&appl0, &appl2), 8, ledger, // version 8 does not get sharing
+		Exp(1, "unavailable App 500"))
 
 	// Checking if an account is opted in has pretty much the same rules
 	optInCheck500 := "txn Sender; int 500; app_opted_in"
 
 	// app_opted_in requires the address and the app exist, else the program fails
-	logic.TestApps(t, []string{optInCheck500, optInCheck500}, txntest.Group(&appl0, &appl1), 9, nil, // nil ledger, no account
-		logic.Exp(0, "no account: "+appl0.Sender.String()))
+	TryApps(t, []string{optInCheck500, optInCheck500}, txntest.Group(&appl0, &appl1), 9, nil, // nil ledger, no account
+		Exp(0, "no account: "+appl0.Sender.String()))
 
 	// Now txn0 passes, but txn1 has an error because it can't see app 500 locals for appl1.Sender
-	logic.TestApps(t, []string{optInCheck500, optInCheck500}, txntest.Group(&appl0, &appl1), 9, ledger,
-		logic.Exp(1, "unavailable Local State "+appl1.Sender.String()))
+	TryApps(t, []string{optInCheck500, optInCheck500}, txntest.Group(&appl0, &appl1), 9, ledger,
+		Exp(1, "unavailable Local State "+appl1.Sender.String()))
 
 	// But it's ok in appl2, because appl2 uses the same Sender, even though the
 	// foreign-app is not repeated in appl2 because the holding being accessed
 	// is the one from tx0.
-	logic.TestApps(t, []string{optInCheck500, optInCheck500}, txntest.Group(&appl0, &appl2), 9, ledger)
-	logic.TestApps(t, []string{optInCheck500, optInCheck500}, txntest.Group(&appl0, &appl2), 8, ledger, // version 8 does not get sharing
-		logic.Exp(1, "unavailable App 500"))
+	TryApps(t, []string{optInCheck500, optInCheck500}, txntest.Group(&appl0, &appl2), 9, ledger)
+	TryApps(t, []string{optInCheck500, optInCheck500}, txntest.Group(&appl0, &appl2), 8, ledger, // version 8 does not get sharing
+		Exp(1, "unavailable App 500"))
 
 	// Confirm sharing applies to the app id called in tx0, not just foreign app array
 	optInCheck900 := "txn Sender; int 900; app_opted_in; !" // we did not opt any senders into 900
 
 	// as above, appl1 can't see the local state, but appl2 can b/c sender is same as appl0
-	logic.TestApps(t, []string{optInCheck900, optInCheck900}, txntest.Group(&appl0, &appl1), 9, ledger,
-		logic.Exp(1, "unavailable Local State "+appl1.Sender.String()))
-	logic.TestApps(t, []string{optInCheck900, optInCheck900}, txntest.Group(&appl0, &appl2), 9, ledger)
-	logic.TestApps(t, []string{optInCheck900, optInCheck900}, txntest.Group(&appl0, &appl2), 8, ledger, // v8=no sharing
-		logic.Exp(1, "unavailable App 900"))
+	TryApps(t, []string{optInCheck900, optInCheck900}, txntest.Group(&appl0, &appl1), 9, ledger,
+		Exp(1, "unavailable Local State "+appl1.Sender.String()))
+	TryApps(t, []string{optInCheck900, optInCheck900}, txntest.Group(&appl0, &appl2), 9, ledger)
+	TryApps(t, []string{optInCheck900, optInCheck900}, txntest.Group(&appl0, &appl2), 8, ledger, // v8=no sharing
+		Exp(1, "unavailable App 900"))
 
 	// Now, confirm that *setting* a local state in tx1 that was made available
 	// in tx0 works.  The extra check here is that the change is recorded
@@ -134,14 +134,14 @@ func TestAppSharing(t *testing.T) {
 	sources := []string{noop, putLocal}
 	appl1.ApplicationArgs = [][]byte{appl0.Sender[:]} // tx1 will try to modify local state exposed in tx0
 	// appl0.Sender is available, but 901's local state for it isn't (only 900 is, since 900 was called in tx0)
-	logic.TestApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger,
-		logic.Exp(1, "unavailable Local State "+appl0.Sender.String()))
+	TryApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger,
+		Exp(1, "unavailable Local State "+appl0.Sender.String()))
 	// Add 901 to tx0's ForeignApps, and it works
 	appl0.ForeignApps = append(appl0.ForeignApps, 901) // well, it will after we opt in
-	logic.TestApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger,
-		logic.Exp(1, "account "+appl0.Sender.String()+" is not opted into 901"))
+	TryApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger,
+		Exp(1, "account "+appl0.Sender.String()+" is not opted into 901"))
 	ledger.NewLocals(appl0.Sender, 901) // opt in
-	ep := logic.TestApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger)
+	ep := TryApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger)
 	require.Len(t, ep.TxnGroup, 2)
 	ed := ep.TxnGroup[1].ApplyData.EvalDelta
 	require.Equal(t, map[uint64]basics.StateDelta{
@@ -157,38 +157,38 @@ func TestAppSharing(t *testing.T) {
 
 	// when running all three, appl2 can't read the locals of app in tx0 and addr in tx1
 	sources = []string{"", "", "gtxn 1 Sender; gtxn 0 Applications 0; byte 0xAA; app_local_get_ex"}
-	logic.TestApps(t, sources, txntest.Group(&appl0, &appl1, &appl2), 9, nil,
-		logic.Exp(2, "unavailable Local State")) // note that the error message is for Locals, not specialized
+	TryApps(t, sources, txntest.Group(&appl0, &appl1, &appl2), 9, nil,
+		Exp(2, "unavailable Local State")) // note that the error message is for Locals, not specialized
 	// same test of account in array of tx1 rather than Sender
 	appl1.Accounts = []basics.Address{{7, 7}}
 	sources = []string{"", "", "gtxn 1 Accounts 1; gtxn 0 Applications 0; byte 0xAA; app_local_get_ex"}
-	logic.TestApps(t, sources, txntest.Group(&appl0, &appl1, &appl2), 9, nil,
-		logic.Exp(2, "unavailable Local State")) // note that the error message is for Locals, not specialized
+	TryApps(t, sources, txntest.Group(&appl0, &appl1, &appl2), 9, nil,
+		Exp(2, "unavailable Local State")) // note that the error message is for Locals, not specialized
 
 	// try to do a put on local state of the account in tx1, but tx0 ought not have access to that local state
 	ledger.NewAccount(pay1.Receiver, 200_000)
 	ledger.NewLocals(pay1.Receiver, 900) // opt in
 	sources = []string{`gtxn 1 Receiver; byte "key"; byte "val"; app_local_put; int 1`}
-	logic.TestApps(t, sources, txntest.Group(&appl0, &pay1), 9, ledger,
-		logic.Exp(0, "unavailable Local State "+pay1.Receiver.String()))
+	TryApps(t, sources, txntest.Group(&appl0, &pay1), 9, ledger,
+		Exp(0, "unavailable Local State "+pay1.Receiver.String()))
 
 	// same for app_local_del
 	sources = []string{`gtxn 1 Receiver; byte "key"; app_local_del; int 1`}
-	logic.TestApps(t, sources, txntest.Group(&appl0, &pay1), 9, ledger,
-		logic.Exp(0, "unavailable Local State "+pay1.Receiver.String()))
+	TryApps(t, sources, txntest.Group(&appl0, &pay1), 9, ledger,
+		Exp(0, "unavailable Local State "+pay1.Receiver.String()))
 
 	// now, use an app call in tx1, with 900 in the foreign apps, so the local state is available
 	appl1.ForeignApps = append(appl1.ForeignApps, 900)
 	ledger.NewLocals(appl1.Sender, 900) // opt in
 	sources = []string{`gtxn 1 Sender; byte "key"; byte "val"; app_local_put; int 1`}
-	logic.TestApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger)
-	logic.TestApps(t, sources, txntest.Group(&appl0, &appl1), 8, ledger, // 8 doesn't share the account
-		logic.Exp(0, "invalid Account reference "+appl1.Sender.String()))
+	TryApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger)
+	TryApps(t, sources, txntest.Group(&appl0, &appl1), 8, ledger, // 8 doesn't share the account
+		Exp(0, "invalid Account reference "+appl1.Sender.String()))
 	// same for app_local_del
 	sources = []string{`gtxn 1 Sender; byte "key"; app_local_del; int 1`}
-	logic.TestApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger)
-	logic.TestApps(t, sources, txntest.Group(&appl0, &appl1), 8, ledger, // 8 doesn't share the account
-		logic.Exp(0, "invalid Account reference "+appl1.Sender.String()))
+	TryApps(t, sources, txntest.Group(&appl0, &appl1), 9, ledger)
+	TryApps(t, sources, txntest.Group(&appl0, &appl1), 8, ledger, // 8 doesn't share the account
+		Exp(0, "invalid Account reference "+appl1.Sender.String()))
 }
 
 // TestBetterLocalErrors confirms that we get specific errors about the missing
@@ -199,7 +199,7 @@ func TestBetterLocalErrors(t *testing.T) {
 
 	joe := basics.Address{9, 9, 9}
 
-	ep, tx, ledger := logic.MakeSampleEnv()
+	ep, tx, ledger := MakeSampleEnv()
 	ledger.NewAccount(joe, 5000000)
 	ledger.NewApp(joe, 500, basics.AppParams{})
 	ledger.NewLocals(joe, 500)
@@ -215,19 +215,19 @@ pop; pop; int 1
 	binary.BigEndian.PutUint64(app, 500)
 
 	tx.ApplicationArgs = [][]byte{joe[:], app}
-	logic.TestApp(t, getLocalEx, ep, "unavailable Account "+joe.String()+", unavailable App 500")
+	TestApp(t, getLocalEx, ep, "unavailable Account "+joe.String()+", unavailable App 500")
 	tx.Accounts = []basics.Address{joe}
-	logic.TestApp(t, getLocalEx, ep, "unavailable App 500")
+	TestApp(t, getLocalEx, ep, "unavailable App 500")
 	tx.ForeignApps = []basics.AppIndex{500}
-	logic.TestApp(t, getLocalEx, ep)
+	TestApp(t, getLocalEx, ep)
 	binary.BigEndian.PutUint64(tx.ApplicationArgs[1], 500)
-	logic.TestApp(t, getLocalEx, ep)
+	TestApp(t, getLocalEx, ep)
 	binary.BigEndian.PutUint64(tx.ApplicationArgs[1], 501)
-	logic.TestApp(t, getLocalEx, ep, "unavailable App 501")
+	TestApp(t, getLocalEx, ep, "unavailable App 501")
 
 	binary.BigEndian.PutUint64(tx.ApplicationArgs[1], 500)
 	tx.Accounts = []basics.Address{}
-	logic.TestApp(t, getLocalEx, ep, "unavailable Account "+joe.String())
+	TestApp(t, getLocalEx, ep, "unavailable Account "+joe.String())
 }
 
 // TestAssetSharing confirms that as of v9, assets can be accessed across
@@ -258,32 +258,32 @@ func TestAssetSharing(t *testing.T) {
 
 	// In v8, the first tx can read asset 400, because it's in its foreign array,
 	// but the second can't
-	logic.TestApps(t, []string{getTotal, getTotal}, txntest.Group(&appl0, &appl1), 8, nil,
-		logic.Exp(1, "unavailable Asset 400"))
+	TryApps(t, []string{getTotal, getTotal}, txntest.Group(&appl0, &appl1), 8, nil,
+		Exp(1, "unavailable Asset 400"))
 	// In v9, the second can, because the first can.
-	logic.TestApps(t, []string{getTotal, getTotal}, txntest.Group(&appl0, &appl1), 9, nil)
+	TryApps(t, []string{getTotal, getTotal}, txntest.Group(&appl0, &appl1), 9, nil)
 
 	getBalance := "txn Sender; int 400; asset_holding_get AssetBalance; pop; pop; int 1"
 
 	// In contrast, here there's no help from v9, because the second tx is
 	// reading a holding for a different account.
-	logic.TestApps(t, []string{getBalance, getBalance}, txntest.Group(&appl0, &appl1), 8, nil,
-		logic.Exp(1, "unavailable Asset 400"))
-	logic.TestApps(t, []string{getBalance, getBalance}, txntest.Group(&appl0, &appl1), 9, nil,
-		logic.Exp(1, "unavailable Holding"))
+	TryApps(t, []string{getBalance, getBalance}, txntest.Group(&appl0, &appl1), 8, nil,
+		Exp(1, "unavailable Asset 400"))
+	TryApps(t, []string{getBalance, getBalance}, txntest.Group(&appl0, &appl1), 9, nil,
+		Exp(1, "unavailable Holding"))
 	// But it's ok in appl2, because the same account is used, even though the
 	// foreign-asset is not repeated in appl2.
-	logic.TestApps(t, []string{getBalance, getBalance}, txntest.Group(&appl0, &appl2), 9, nil)
+	TryApps(t, []string{getBalance, getBalance}, txntest.Group(&appl0, &appl2), 9, nil)
 
 	// when running all three, appl2 can't read the holding of asset in tx0 and addr in tx1
 	sources := []string{"", "", "gtxn 1 Sender; gtxn 0 Assets 0; asset_holding_get AssetBalance"}
-	logic.TestApps(t, sources, txntest.Group(&appl0, &appl1, &appl2), 9, nil,
-		logic.Exp(2, "unavailable Holding")) // note that the error message is for Holding, not specialized
+	TryApps(t, sources, txntest.Group(&appl0, &appl1, &appl2), 9, nil,
+		Exp(2, "unavailable Holding")) // note that the error message is for Holding, not specialized
 	// same test of account in array of tx1 rather than Sender
 	appl1.Accounts = []basics.Address{{7, 7}}
 	sources = []string{"", "", "gtxn 1 Accounts 1; gtxn 0 Assets 0; asset_holding_get AssetBalance"}
-	logic.TestApps(t, sources, txntest.Group(&appl0, &appl1, &appl2), 9, nil,
-		logic.Exp(2, "unavailable Holding")) // note that the error message is for Holding, not specialized
+	TryApps(t, sources, txntest.Group(&appl0, &appl1, &appl2), 9, nil,
+		Exp(2, "unavailable Holding")) // note that the error message is for Holding, not specialized
 }
 
 // TestBetterHoldingErrors confirms that we get specific errors about the missing
@@ -294,7 +294,7 @@ func TestBetterHoldingErrors(t *testing.T) {
 
 	joe := basics.Address{9, 9, 9}
 
-	ep, tx, ledger := logic.MakeSampleEnv()
+	ep, tx, ledger := MakeSampleEnv()
 	ledger.NewAccount(joe, 5000000)
 	ledger.NewAsset(joe, 200, basics.AssetParams{})
 	// as creator, joe will also be opted in
@@ -309,17 +309,17 @@ pop; pop; int 1
 	binary.BigEndian.PutUint64(asa, 200)
 
 	tx.ApplicationArgs = [][]byte{joe[:], asa}
-	logic.TestApp(t, getHoldingBalance, ep, "unavailable Account "+joe.String()+", unavailable Asset 200")
+	TestApp(t, getHoldingBalance, ep, "unavailable Account "+joe.String()+", unavailable Asset 200")
 	tx.Accounts = []basics.Address{joe}
-	logic.TestApp(t, getHoldingBalance, ep, "unavailable Asset 200")
+	TestApp(t, getHoldingBalance, ep, "unavailable Asset 200")
 	tx.ForeignAssets = []basics.AssetIndex{200}
-	logic.TestApp(t, getHoldingBalance, ep)
+	TestApp(t, getHoldingBalance, ep)
 	binary.BigEndian.PutUint64(tx.ApplicationArgs[1], 0) // slot=0 is same (200)
-	logic.TestApp(t, getHoldingBalance, ep)
+	TestApp(t, getHoldingBalance, ep)
 
 	binary.BigEndian.PutUint64(tx.ApplicationArgs[1], 200)
 	tx.Accounts = []basics.Address{}
-	logic.TestApp(t, getHoldingBalance, ep, "unavailable Account "+joe.String())
+	TestApp(t, getHoldingBalance, ep, "unavailable Account "+joe.String())
 }
 
 // TestAccountPassing checks that the current app account and foreign app's
@@ -329,9 +329,9 @@ func TestAccountPassing(t *testing.T) {
 	t.Parallel()
 
 	// appAddressVersion=7
-	logic.TestLogicRange(t, 7, 0, func(t *testing.T, ep *logic.EvalParams, tx *transactions.Transaction, ledger *logic.Ledger) {
+	TestLogicRange(t, 7, 0, func(t *testing.T, ep *EvalParams, tx *transactions.Transaction, ledger *Ledger) {
 		t.Parallel()
-		accept := logic.TestProg(t, "int 1", 6)
+		accept := TestProg(t, "int 1", 6)
 		alice := basics.Address{1, 1, 1, 1, 1}
 		ledger.NewApp(alice, 4, basics.AppParams{
 			ApprovalProgram: accept.Program,
@@ -346,12 +346,12 @@ int 1`
 		tx.ForeignApps = []basics.AppIndex{4}
 		ledger.NewAccount(appAddr(888), 50_000)
 		// First show that we're not just letting anything get passed in
-		logic.TestApp(t, fmt.Sprintf(callWithAccount, "int 32; bzero; byte 0x07; b|"), ep,
+		TestApp(t, fmt.Sprintf(callWithAccount, "int 32; bzero; byte 0x07; b|"), ep,
 			"unavailable Account AAAAA")
 		// Now show we can pass our own address
-		logic.TestApp(t, fmt.Sprintf(callWithAccount, "global CurrentApplicationAddress"), ep)
+		TestApp(t, fmt.Sprintf(callWithAccount, "global CurrentApplicationAddress"), ep)
 		// Or the address of one of our ForeignApps
-		logic.TestApp(t, fmt.Sprintf(callWithAccount, "addr "+basics.AppIndex(4).Address().String()), ep)
+		TestApp(t, fmt.Sprintf(callWithAccount, "addr "+basics.AppIndex(4).Address().String()), ep)
 	})
 }
 
@@ -360,7 +360,7 @@ func TestOtherTxSharing(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	_, _, ledger := logic.MakeSampleEnv()
+	_, _, ledger := MakeSampleEnv()
 
 	senderAcct := basics.Address{1, 2, 3, 4, 5, 6, 1}
 	ledger.NewAccount(senderAcct, 2001)
@@ -418,13 +418,13 @@ func TestOtherTxSharing(t *testing.T) {
 	}
 
 	for _, send := range []txntest.Txn{keyreg, pay, acfg, axfer, afrz} {
-		logic.TestApps(t, []string{"", senderBalance}, txntest.Group(&send, &appl), 9, ledger)
-		logic.TestApps(t, []string{senderBalance, ""}, txntest.Group(&appl, &send), 9, ledger)
+		TryApps(t, []string{"", senderBalance}, txntest.Group(&send, &appl), 9, ledger)
+		TryApps(t, []string{senderBalance, ""}, txntest.Group(&appl, &send), 9, ledger)
 
-		logic.TestApps(t, []string{"", senderBalance}, txntest.Group(&send, &appl), 8, ledger,
-			logic.Exp(1, "invalid Account reference"))
-		logic.TestApps(t, []string{senderBalance, ""}, txntest.Group(&appl, &send), 8, ledger,
-			logic.Exp(0, "invalid Account reference"))
+		TryApps(t, []string{"", senderBalance}, txntest.Group(&send, &appl), 8, ledger,
+			Exp(1, "invalid Account reference"))
+		TryApps(t, []string{senderBalance, ""}, txntest.Group(&appl, &send), 8, ledger,
+			Exp(0, "invalid Account reference"))
 	}
 
 	holdingAccess := `
@@ -436,82 +436,82 @@ func TestOtherTxSharing(t *testing.T) {
 
 	t.Run("keyreg", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {200}}
-		logic.TestApps(t, []string{"", holdingAccess}, txntest.Group(&keyreg, &appl), 9, ledger,
-			logic.Exp(1, "unavailable Asset 200"))
+		TryApps(t, []string{"", holdingAccess}, txntest.Group(&keyreg, &appl), 9, ledger,
+			Exp(1, "unavailable Asset 200"))
 		withRef := appl
 		withRef.ForeignAssets = []basics.AssetIndex{200}
-		logic.TestApps(t, []string{"", holdingAccess}, txntest.Group(&keyreg, &withRef), 9, ledger,
-			logic.Exp(1, "unavailable Holding "+senderAcct.String()))
+		TryApps(t, []string{"", holdingAccess}, txntest.Group(&keyreg, &withRef), 9, ledger,
+			Exp(1, "unavailable Holding "+senderAcct.String()))
 	})
 	t.Run("pay", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		// The receiver is available for algo balance reading
 		appl.ApplicationArgs = [][]byte{receiverAcct[:]}
-		logic.TestApps(t, []string{"", receiverBalance}, txntest.Group(&pay, &appl), 9, ledger)
+		TryApps(t, []string{"", receiverBalance}, txntest.Group(&pay, &appl), 9, ledger)
 
 		// The other account is not (it's not even in the pay txn)
 		appl.ApplicationArgs = [][]byte{otherAcct[:]}
-		logic.TestApps(t, []string{"", otherBalance}, txntest.Group(&pay, &appl), 9, ledger,
-			logic.Exp(1, "invalid Account reference "+otherAcct.String()))
+		TryApps(t, []string{"", otherBalance}, txntest.Group(&pay, &appl), 9, ledger,
+			Exp(1, "invalid Account reference "+otherAcct.String()))
 
 		// The other account becomes accessible because used in CloseRemainderTo
 		withClose := pay
 		withClose.CloseRemainderTo = otherAcct
-		logic.TestApps(t, []string{"", otherBalance}, txntest.Group(&withClose, &appl), 9, ledger)
+		TryApps(t, []string{"", otherBalance}, txntest.Group(&withClose, &appl), 9, ledger)
 	})
 
 	t.Run("acfg", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		// The other account is not available even though it's all the extra addresses
 		appl.ApplicationArgs = [][]byte{otherAcct[:]}
-		logic.TestApps(t, []string{"", otherBalance}, txntest.Group(&acfg, &appl), 9, ledger,
-			logic.Exp(1, "invalid Account reference "+otherAcct.String()))
+		TryApps(t, []string{"", otherBalance}, txntest.Group(&acfg, &appl), 9, ledger,
+			Exp(1, "invalid Account reference "+otherAcct.String()))
 	})
 
 	t.Run("axfer", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		// The receiver is also available for algo balance reading
 		appl.ApplicationArgs = [][]byte{receiverAcct[:]}
-		logic.TestApps(t, []string{"", receiverBalance}, txntest.Group(&axfer, &appl), 9, ledger)
+		TryApps(t, []string{"", receiverBalance}, txntest.Group(&axfer, &appl), 9, ledger)
 
 		// as is the "other" (AssetSender)
 		appl.ApplicationArgs = [][]byte{otherAcct[:]}
-		logic.TestApps(t, []string{"", otherBalance}, txntest.Group(&axfer, &appl), 9, ledger)
+		TryApps(t, []string{"", otherBalance}, txntest.Group(&axfer, &appl), 9, ledger)
 
 		// sender holding is available
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {byte(axfer.XferAsset)}}
-		logic.TestApps(t, []string{"", holdingAccess}, txntest.Group(&axfer, &appl), 9, ledger)
+		TryApps(t, []string{"", holdingAccess}, txntest.Group(&axfer, &appl), 9, ledger)
 
 		// receiver holding is available
 		appl.ApplicationArgs = [][]byte{receiverAcct[:], {byte(axfer.XferAsset)}}
-		logic.TestApps(t, []string{"", holdingAccess}, txntest.Group(&axfer, &appl), 9, ledger)
+		TryApps(t, []string{"", holdingAccess}, txntest.Group(&axfer, &appl), 9, ledger)
 
 		// asset sender (other) account is available
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {byte(axfer.XferAsset)}}
-		logic.TestApps(t, []string{"", holdingAccess}, txntest.Group(&axfer, &appl), 9, ledger)
+		TryApps(t, []string{"", holdingAccess}, txntest.Group(&axfer, &appl), 9, ledger)
 
 		// AssetCloseTo holding becomes available when set
 		appl.ApplicationArgs = [][]byte{other2Acct[:], {byte(axfer.XferAsset)}}
-		logic.TestApps(t, []string{"", other2Balance}, txntest.Group(&axfer, &appl), 9, ledger,
-			logic.Exp(1, "invalid Account reference "+other2Acct.String()))
-		logic.TestApps(t, []string{"", holdingAccess}, txntest.Group(&axfer, &appl), 9, ledger,
-			logic.Exp(1, "unavailable Account "+other2Acct.String()))
+		TryApps(t, []string{"", other2Balance}, txntest.Group(&axfer, &appl), 9, ledger,
+			Exp(1, "invalid Account reference "+other2Acct.String()))
+		TryApps(t, []string{"", holdingAccess}, txntest.Group(&axfer, &appl), 9, ledger,
+			Exp(1, "unavailable Account "+other2Acct.String()))
 
 		withClose := axfer
 		withClose.AssetCloseTo = other2Acct
 		appl.ApplicationArgs = [][]byte{other2Acct[:], {byte(axfer.XferAsset)}}
-		logic.TestApps(t, []string{"", other2Balance}, txntest.Group(&withClose, &appl), 9, ledger)
-		logic.TestApps(t, []string{"", holdingAccess}, txntest.Group(&withClose, &appl), 9, ledger)
+		TryApps(t, []string{"", other2Balance}, txntest.Group(&withClose, &appl), 9, ledger)
+		TryApps(t, []string{"", holdingAccess}, txntest.Group(&withClose, &appl), 9, ledger)
 	})
 
 	t.Run("afrz", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
 		// The other account is available (for algo and asset)
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {byte(afrz.FreezeAsset)}}
-		logic.TestApps(t, []string{"", otherBalance}, txntest.Group(&afrz, &appl), 9, ledger)
-		logic.TestApps(t, []string{"", holdingAccess}, txntest.Group(&afrz, &appl), 9, ledger)
+		TryApps(t, []string{"", otherBalance}, txntest.Group(&afrz, &appl), 9, ledger)
+		TryApps(t, []string{"", holdingAccess}, txntest.Group(&afrz, &appl), 9, ledger)
 
 		// The sender holding is _not_ (because the freezeaccount's holding is irrelevant to afrz)
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {byte(afrz.FreezeAsset)}}
-		logic.TestApps(t, []string{"", senderBalance}, txntest.Group(&afrz, &appl), 9, ledger)
-		logic.TestApps(t, []string{"", holdingAccess}, txntest.Group(&afrz, &appl), 9, ledger,
-			logic.Exp(1, "unavailable Holding "+senderAcct.String()))
+		TryApps(t, []string{"", senderBalance}, txntest.Group(&afrz, &appl), 9, ledger)
+		TryApps(t, []string{"", holdingAccess}, txntest.Group(&afrz, &appl), 9, ledger,
+			Exp(1, "unavailable Holding "+senderAcct.String()))
 	})
 }
 
@@ -520,7 +520,7 @@ func TestSharedInnerTxns(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	_, _, ledger := logic.MakeSampleEnv()
+	_, _, ledger := MakeSampleEnv()
 
 	const asa1 = 201
 	const asa2 = 202
@@ -584,14 +584,14 @@ int 1
 
 		// appl has no foreign ref to senderAcct, but can still inner pay it
 		appl.ApplicationArgs = [][]byte{senderAcct[:]}
-		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&keyreg, &appl), 9, ledger)
-		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&keyreg, &appl), 8, ledger,
-			logic.Exp(1, "unavailable Account "+senderAcct.String()))
+		TryApps(t, []string{"", payToArg}, txntest.Group(&keyreg, &appl), 9, ledger)
+		TryApps(t, []string{"", payToArg}, txntest.Group(&keyreg, &appl), 8, ledger,
+			Exp(1, "unavailable Account "+senderAcct.String()))
 
 		// confirm you can't just pay _anybody_. receiverAcct is not in use at all.
 		appl.ApplicationArgs = [][]byte{receiverAcct[:]}
-		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&keyreg, &appl), 9, ledger,
-			logic.Exp(1, "unavailable Account "+receiverAcct.String()))
+		TryApps(t, []string{"", payToArg}, txntest.Group(&keyreg, &appl), 9, ledger,
+			Exp(1, "unavailable Account "+receiverAcct.String()))
 	})
 
 	t.Run("pay", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
@@ -603,19 +603,19 @@ int 1
 
 		// appl has no foreign ref to senderAcct or receiverAcct, but can still inner pay them
 		appl.ApplicationArgs = [][]byte{senderAcct[:]}
-		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 9, ledger)
-		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 8, ledger,
-			logic.Exp(1, "unavailable Account "+senderAcct.String()))
+		TryApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 9, ledger)
+		TryApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 8, ledger,
+			Exp(1, "unavailable Account "+senderAcct.String()))
 
 		appl.ApplicationArgs = [][]byte{receiverAcct[:]}
-		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 9, ledger)
-		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 8, ledger,
-			logic.Exp(1, "unavailable Account "+receiverAcct.String()))
+		TryApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 9, ledger)
+		TryApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 8, ledger,
+			Exp(1, "unavailable Account "+receiverAcct.String()))
 
 		// confirm you can't just pay _anybody_. otherAcct is not in use at all.
 		appl.ApplicationArgs = [][]byte{otherAcct[:]}
-		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 9, ledger,
-			logic.Exp(1, "unavailable Account "+otherAcct.String()))
+		TryApps(t, []string{"", payToArg}, txntest.Group(&pay, &appl), 9, ledger,
+			Exp(1, "unavailable Account "+otherAcct.String()))
 	})
 
 	t.Run("axfer", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
@@ -629,47 +629,47 @@ int 1
 
 		// appl can pay the axfer sender
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {asa1}}
-		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&axfer, &appl), 9, ledger)
-		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&axfer, &appl), 8, ledger,
-			logic.Exp(1, "unavailable Account "+senderAcct.String()))
+		TryApps(t, []string{"", payToArg}, txntest.Group(&axfer, &appl), 9, ledger)
+		TryApps(t, []string{"", payToArg}, txntest.Group(&axfer, &appl), 8, ledger,
+			Exp(1, "unavailable Account "+senderAcct.String()))
 		// but can't axfer to sender, because appAcct doesn't have holding access for the asa
-		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
-			logic.Exp(1, "unavailable Holding"))
+		TryApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
+			Exp(1, "unavailable Holding"))
 		// and to the receiver
 		appl.ApplicationArgs = [][]byte{receiverAcct[:], {asa1}}
-		logic.TestApps(t, []string{payToArg}, txntest.Group(&appl, &axfer), 9, ledger)
-		logic.TestApps(t, []string{axferToArgs}, txntest.Group(&appl, &axfer), 9, ledger,
-			logic.Exp(0, "unavailable Holding"))
+		TryApps(t, []string{payToArg}, txntest.Group(&appl, &axfer), 9, ledger)
+		TryApps(t, []string{axferToArgs}, txntest.Group(&appl, &axfer), 9, ledger,
+			Exp(0, "unavailable Holding"))
 		// and to the clawback
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {asa1}}
-		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&axfer, &appl), 9, ledger)
-		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
-			logic.Exp(1, "unavailable Holding"))
+		TryApps(t, []string{"", payToArg}, txntest.Group(&axfer, &appl), 9, ledger)
+		TryApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
+			Exp(1, "unavailable Holding"))
 
 		// Those axfers become possible by adding the asa to the appl's ForeignAssets
 		appl.ForeignAssets = []basics.AssetIndex{asa1}
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {asa1}}
-		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger)
+		TryApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger)
 		appl.ApplicationArgs = [][]byte{receiverAcct[:], {asa1}}
-		logic.TestApps(t, []string{axferToArgs}, txntest.Group(&appl, &axfer), 9, ledger)
+		TryApps(t, []string{axferToArgs}, txntest.Group(&appl, &axfer), 9, ledger)
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {asa1}}
-		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger)
+		TryApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger)
 
 		// but can't axfer a different asset
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {asa2}}
-		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
-			logic.Exp(1, fmt.Sprintf("unavailable Asset %d", asa2)))
+		TryApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
+			Exp(1, fmt.Sprintf("unavailable Asset %d", asa2)))
 		// or correct asset to an unknown address
 		appl.ApplicationArgs = [][]byte{unusedAcct[:], {asa1}}
-		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
-			logic.Exp(1, "unavailable Account"))
+		TryApps(t, []string{"", axferToArgs}, txntest.Group(&axfer, &appl), 9, ledger,
+			Exp(1, "unavailable Account"))
 
 		// appl can acfg the asset from tx0 (which requires asset available, not holding)
 		appl.ApplicationArgs = [][]byte{{asa1}}
-		logic.TestApps(t, []string{"", acfgArg}, txntest.Group(&axfer, &appl), 9, ledger)
+		TryApps(t, []string{"", acfgArg}, txntest.Group(&axfer, &appl), 9, ledger)
 		appl.ApplicationArgs = [][]byte{{asa2}} // but not asa2
-		logic.TestApps(t, []string{"", acfgArg}, txntest.Group(&axfer, &appl), 9, ledger,
-			logic.Exp(1, fmt.Sprintf("unavailable Asset %d", asa2)))
+		TryApps(t, []string{"", acfgArg}, txntest.Group(&axfer, &appl), 9, ledger,
+			Exp(1, fmt.Sprintf("unavailable Asset %d", asa2)))
 
 		// Now, confirm that access to account from a pay in one tx, and asa
 		// from another don't allow inner axfer in the third (because there's no
@@ -682,16 +682,16 @@ int 1
 		}
 		// the asset is acfg-able
 		appl.ApplicationArgs = [][]byte{{asa1}}
-		logic.TestApps(t, []string{"", "", acfgArg}, txntest.Group(&pay, &axfer, &appl), 9, ledger)
-		logic.TestApps(t, []string{"", "", acfgArg}, txntest.Group(&axfer, &pay, &appl), 9, ledger)
+		TryApps(t, []string{"", "", acfgArg}, txntest.Group(&pay, &axfer, &appl), 9, ledger)
+		TryApps(t, []string{"", "", acfgArg}, txntest.Group(&axfer, &pay, &appl), 9, ledger)
 		// payAcct (the pay sender) is payable
 		appl.ApplicationArgs = [][]byte{payAcct[:]}
-		logic.TestApps(t, []string{"", "", payToArg}, txntest.Group(&axfer, &pay, &appl), 9, ledger)
+		TryApps(t, []string{"", "", payToArg}, txntest.Group(&axfer, &pay, &appl), 9, ledger)
 		// but the cross-product is not available, so no axfer (opting in first, to prevent that error)
 		ledger.NewHolding(payAcct, asa1, 1, false)
 		appl.ApplicationArgs = [][]byte{payAcct[:], {asa1}}
-		logic.TestApps(t, []string{"", "", axferToArgs}, txntest.Group(&axfer, &pay, &appl), 9, ledger,
-			logic.Exp(2, "unavailable Holding "+payAcct.String()))
+		TryApps(t, []string{"", "", axferToArgs}, txntest.Group(&axfer, &pay, &appl), 9, ledger,
+			Exp(2, "unavailable Holding "+payAcct.String()))
 	})
 
 	t.Run("afrz", func(t *testing.T) { // nolint:paralleltest // shares `ledger`
@@ -705,48 +705,48 @@ int 1
 
 		// appl can pay to the sender & freeze account
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {asa1}}
-		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&afrz, &appl), 9, ledger)
+		TryApps(t, []string{"", payToArg}, txntest.Group(&afrz, &appl), 9, ledger)
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {asa1}}
-		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&afrz, &appl), 9, ledger)
+		TryApps(t, []string{"", payToArg}, txntest.Group(&afrz, &appl), 9, ledger)
 
 		// can't axfer to the afrz sender because appAcct holding is not available from afrz
 		appl.ApplicationArgs = [][]byte{senderAcct[:], {asa1}}
-		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger,
-			logic.Exp(1, "unavailable Holding "+appAcct.String()))
+		TryApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger,
+			Exp(1, "unavailable Holding "+appAcct.String()))
 		appl.ForeignAssets = []basics.AssetIndex{asa1}
 		// _still_ can't axfer to sender because afrz sender's holding does NOT
 		// become available (not note that complaint is now about that account)
-		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger,
-			logic.Exp(1, "unavailable Holding "+senderAcct.String()))
+		TryApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger,
+			Exp(1, "unavailable Holding "+senderAcct.String()))
 
 		// and not to the receiver which isn't in afrz
 		appl.ApplicationArgs = [][]byte{receiverAcct[:], {asa1}}
-		logic.TestApps(t, []string{payToArg}, txntest.Group(&appl, &afrz), 9, ledger,
-			logic.Exp(0, "unavailable Account "+receiverAcct.String()))
-		logic.TestApps(t, []string{axferToArgs}, txntest.Group(&appl, &afrz), 9, ledger,
-			logic.Exp(0, "unavailable Account "+receiverAcct.String()))
+		TryApps(t, []string{payToArg}, txntest.Group(&appl, &afrz), 9, ledger,
+			Exp(0, "unavailable Account "+receiverAcct.String()))
+		TryApps(t, []string{axferToArgs}, txntest.Group(&appl, &afrz), 9, ledger,
+			Exp(0, "unavailable Account "+receiverAcct.String()))
 
 		// otherAcct is the afrz target, it's holding and account are available
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {asa1}}
-		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&afrz, &appl), 9, ledger)
-		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger)
+		TryApps(t, []string{"", payToArg}, txntest.Group(&afrz, &appl), 9, ledger)
+		TryApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger)
 
 		// but still can't axfer a different asset
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {asa2}}
-		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger,
-			logic.Exp(1, fmt.Sprintf("unavailable Asset %d", asa2)))
+		TryApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger,
+			Exp(1, fmt.Sprintf("unavailable Asset %d", asa2)))
 		appl.ForeignAssets = []basics.AssetIndex{asa2}
 		// once added to appl's foreign array, the appl still lacks access to other's holding
-		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger,
-			logic.Exp(1, "unavailable Holding "+otherAcct.String()))
+		TryApps(t, []string{"", axferToArgs}, txntest.Group(&afrz, &appl), 9, ledger,
+			Exp(1, "unavailable Holding "+otherAcct.String()))
 
 		// appl can acfg the asset from tx0 (which requires asset available, not holding)
 		appl.ForeignAssets = []basics.AssetIndex{}
 		appl.ApplicationArgs = [][]byte{{asa1}}
-		logic.TestApps(t, []string{"", acfgArg}, txntest.Group(&afrz, &appl), 9, ledger)
+		TryApps(t, []string{"", acfgArg}, txntest.Group(&afrz, &appl), 9, ledger)
 		appl.ApplicationArgs = [][]byte{{asa2}} // but not asa2
-		logic.TestApps(t, []string{"", acfgArg}, txntest.Group(&afrz, &appl), 9, ledger,
-			logic.Exp(1, fmt.Sprintf("unavailable Asset %d", asa2)))
+		TryApps(t, []string{"", acfgArg}, txntest.Group(&afrz, &appl), 9, ledger,
+			Exp(1, fmt.Sprintf("unavailable Asset %d", asa2)))
 
 	})
 
@@ -762,40 +762,40 @@ int 1
 
 		// appl can pay to the otherAcct because it was in tx0
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {asa1}}
-		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&appl0, &appl), 9, ledger)
-		logic.TestApps(t, []string{"", payToArg}, txntest.Group(&appl0, &appl), 8, ledger, // version 8 does not get sharing
-			logic.Exp(1, "unavailable Account "+otherAcct.String()))
+		TryApps(t, []string{"", payToArg}, txntest.Group(&appl0, &appl), 9, ledger)
+		TryApps(t, []string{"", payToArg}, txntest.Group(&appl0, &appl), 8, ledger, // version 8 does not get sharing
+			Exp(1, "unavailable Account "+otherAcct.String()))
 		// appl can (almost) axfer asa1 to the otherAcct because both are in tx0
-		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger,
-			logic.Exp(1, "axfer Sender: unavailable Holding"))
+		TryApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger,
+			Exp(1, "axfer Sender: unavailable Holding"))
 		// but it can't take access it's OWN asa1, unless added to ForeignAssets
 		appl.ForeignAssets = []basics.AssetIndex{asa1}
-		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger)
+		TryApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger)
 
 		// but it can't use 202 at all. notice the error is more direct that
 		// above, as the problem is not the axfer Sender, only, it's that 202
 		// can't be used at all.
 		appl.ApplicationArgs = [][]byte{otherAcct[:], {asa2}}
-		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger,
-			logic.Exp(1, "unavailable Asset 202"))
+		TryApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger,
+			Exp(1, "unavailable Asset 202"))
 		// And adding asa2 does not fix this problem, because the other x 202 holding is unavailable
 		appl.ForeignAssets = []basics.AssetIndex{asa2}
-		logic.TestApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger,
-			logic.Exp(1, "axfer AssetReceiver: unavailable Holding "+otherAcct.String()+" x 202"))
+		TryApps(t, []string{"", axferToArgs}, txntest.Group(&appl0, &appl), 9, ledger,
+			Exp(1, "axfer AssetReceiver: unavailable Holding "+otherAcct.String()+" x 202"))
 
 		// Now, conduct similar tests, but with the apps performing the
 		// pays/axfers invoked from an outer app. Use various versions to check
 		// cross version sharing.
 
 		// add v8 and v9 versions of the pay app to the ledger for inner calling
-		payToArgV8 := logic.TestProg(t, payToArg, 8)
+		payToArgV8 := TestProg(t, payToArg, 8)
 		ledger.NewApp(senderAcct, 88, basics.AppParams{ApprovalProgram: payToArgV8.Program})
 		ledger.NewAccount(appAddr(88), 1_000_000)
-		payToArgV9 := logic.TestProg(t, payToArg, 9)
+		payToArgV9 := TestProg(t, payToArg, 9)
 		ledger.NewApp(senderAcct, 99, basics.AppParams{ApprovalProgram: payToArgV9.Program})
 		ledger.NewAccount(appAddr(99), 1_000_000)
 
-		approvalV8 := logic.TestProg(t, "int 1", 8)
+		approvalV8 := TestProg(t, "int 1", 8)
 		ledger.NewApp(senderAcct, 11, basics.AppParams{ApprovalProgram: approvalV8.Program})
 
 		innerCallTemplate := `
@@ -813,28 +813,28 @@ int 1
 		appl.ForeignApps = []basics.AppIndex{11, 88, 99}
 
 		appl.ApplicationArgs = [][]byte{{99}, otherAcct[:], {asa1}}
-		logic.TestApps(t, []string{"", innerCall}, txntest.Group(&appl0, &appl), 9, ledger)
+		TryApps(t, []string{"", innerCall}, txntest.Group(&appl0, &appl), 9, ledger)
 		// when the inner program is v8, it can't perform the pay
 		appl.ApplicationArgs = [][]byte{{88}, otherAcct[:], {asa1}}
-		logic.TestApps(t, []string{"", innerCall}, txntest.Group(&appl0, &appl), 9, ledger,
-			logic.Exp(1, "unavailable Account "+otherAcct.String()))
+		TryApps(t, []string{"", innerCall}, txntest.Group(&appl0, &appl), 9, ledger,
+			Exp(1, "unavailable Account "+otherAcct.String()))
 		// unless the caller passes in the account, but it can't pass the
 		// account because that also would give the called app access to the
 		// passed account's local state (which isn't available to the caller)
 		innerCallWithAccount := fmt.Sprintf(innerCallTemplate, "addr "+otherAcct.String()+"; itxn_field Accounts")
-		logic.TestApps(t, []string{"", innerCallWithAccount}, txntest.Group(&appl0, &appl), 9, ledger,
-			logic.Exp(1, "appl ApplicationID: unavailable Local State "+otherAcct.String()))
+		TryApps(t, []string{"", innerCallWithAccount}, txntest.Group(&appl0, &appl), 9, ledger,
+			Exp(1, "appl ApplicationID: unavailable Local State "+otherAcct.String()))
 		// the caller can't fix by passing 88 as a foreign app, because doing so
 		// is not much different than the current situation: 88 is being called,
 		// it's already available.
 		innerCallWithBoth := fmt.Sprintf(innerCallTemplate,
 			"addr "+otherAcct.String()+"; itxn_field Accounts; int 88; itxn_field Applications")
-		logic.TestApps(t, []string{"", innerCallWithBoth}, txntest.Group(&appl0, &appl), 9, ledger,
-			logic.Exp(1, "appl ApplicationID: unavailable Local State "+otherAcct.String()))
+		TryApps(t, []string{"", innerCallWithBoth}, txntest.Group(&appl0, &appl), 9, ledger,
+			Exp(1, "appl ApplicationID: unavailable Local State "+otherAcct.String()))
 
 		// the caller *can* do it if it originally had access to that 88 holding.
 		appl0.ForeignApps = []basics.AppIndex{88}
-		logic.TestApps(t, []string{"", innerCallWithAccount}, txntest.Group(&appl0, &appl), 9, ledger)
+		TryApps(t, []string{"", innerCallWithAccount}, txntest.Group(&appl0, &appl), 9, ledger)
 
 		// here we confirm that even if we try calling another app, we still
 		// can't pass in `other` and 88, because that would give the app access
@@ -842,8 +842,8 @@ int 1
 		// of the foreign arrays, not just the accounts against called app id)
 		appl.ApplicationArgs = [][]byte{{11}, otherAcct[:], {asa1}}
 		appl0.ForeignApps = []basics.AppIndex{11}
-		logic.TestApps(t, []string{"", innerCallWithBoth}, txntest.Group(&appl0, &appl), 9, ledger,
-			logic.Exp(1, "appl ForeignApps: unavailable Local State "+otherAcct.String()))
+		TryApps(t, []string{"", innerCallWithBoth}, txntest.Group(&appl0, &appl), 9, ledger,
+			Exp(1, "appl ForeignApps: unavailable Local State "+otherAcct.String()))
 
 	})
 
@@ -856,7 +856,7 @@ func TestAccessMyLocals(t *testing.T) {
 	t.Parallel()
 
 	// start at 3, needs assert
-	logic.TestLogicRange(t, 3, 0, func(t *testing.T, ep *logic.EvalParams, tx *transactions.Transaction, ledger *logic.Ledger) {
+	TestLogicRange(t, 3, 0, func(t *testing.T, ep *EvalParams, tx *transactions.Transaction, ledger *Ledger) {
 		sender := basics.Address{1, 2, 3, 4}
 		ledger.NewAccount(sender, 1_000_000)
 		// we don't really process transactions in these tests, so despite the
@@ -894,13 +894,13 @@ func TestAccessMyLocals(t *testing.T) {
   app_local_del
   int 1
 `
-		logic.TestApp(t, source, ep)
+		TestApp(t, source, ep)
 		if ep.Proto.LogicSigVersion >= 4 {
 			// confirm "txn Sender" also works
 			source = strings.ReplaceAll(source, "int 0\n", "txn Sender\n")
-			logic.TestApp(t, source, ep)
+			TestApp(t, source, ep)
 		}
 
-		logic.TestApp(t, "int 0; int 0; app_opted_in", ep)
+		TestApp(t, "int 0; int 0; app_opted_in", ep)
 	})
 }

--- a/data/transactions/logic/tracer_test.go
+++ b/data/transactions/logic/tracer_test.go
@@ -105,7 +105,7 @@ func TestLogicSigEvalWithTracer(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			mock := mocktracer.Tracer{}
-			ep := DefaultEvalParams()
+			ep := DefaultSigParams()
 			ep.Tracer = &mock
 			TestLogic(t, testCase.program, AssemblerMaxVersion, ep, testCase.evalProblems...)
 
@@ -123,7 +123,7 @@ func TestTopLevelAppEvalWithTracer(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			mock := mocktracer.Tracer{}
-			ep := DefaultEvalParams()
+			ep := DefaultAppParams()
 			ep.Tracer = &mock
 			TestApp(t, testCase.program, ep, testCase.evalProblems...)
 
@@ -190,12 +190,14 @@ func TestEvalPanicWithTracer(t *testing.T) { //nolint:paralleltest // Uses WithP
 			t.Run(mode.String(), func(t *testing.T) { //nolint:paralleltest // Uses WithPanicOpcode
 				testCase := getPanicTracerTestCase(mode)
 				mock := mocktracer.Tracer{}
-				ep := DefaultEvalParams()
-				ep.Tracer = &mock
 				switch mode {
 				case ModeSig:
+					ep := DefaultSigParams()
+					ep.Tracer = &mock
 					TestLogic(t, testCase.program, AssemblerMaxVersion, ep, testCase.evalProblems...)
 				case ModeApp:
+					ep := DefaultAppParams()
+					ep.Tracer = &mock
 					TestApp(t, testCase.program, ep, testCase.evalProblems...)
 				default:
 					require.Fail(t, "unknown mode")
@@ -225,7 +227,7 @@ func TestEvalWithTracerPanic(t *testing.T) {
 		t.Run(mode.String(), func(t *testing.T) {
 			t.Parallel()
 			tracer := panicTracer{}
-			ep := DefaultEvalParams()
+			ep := DefaultSigParams()
 			ep.Tracer = &tracer
 			TestLogic(t, debuggerTestProgramApprove, AssemblerMaxVersion, ep, "panicTracer panics")
 		})

--- a/data/transactions/verify/artifact_test.go
+++ b/data/transactions/verify/artifact_test.go
@@ -43,20 +43,15 @@ func BenchmarkTinyMan(b *testing.B) {
 		require.NotEmpty(b, stxns[1].Lsig.Logic)
 		require.NotEmpty(b, stxns[2].Sig)
 		require.NotEmpty(b, stxns[3].Lsig.Logic)
-		txgroup := transactions.WrapSignedTxnsWithAD(stxns)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			proto := config.Consensus[protocol.ConsensusCurrentVersion]
-			ep := logic.EvalParams{
-				Proto:     &proto,
-				TxnGroup:  txgroup,
-				SigLedger: &logic.NoHeaderLedger{},
-			}
-			pass, err := logic.EvalSignature(1, &ep)
+			ep := logic.NewSigEvalParams(stxns, &proto, &logic.NoHeaderLedger{})
+			pass, err := logic.EvalSignature(1, ep)
 			require.NoError(b, err)
 			require.True(b, pass)
-			pass, err = logic.EvalSignature(3, &ep)
+			pass, err = logic.EvalSignature(3, ep)
 			require.NoError(b, err)
 			require.True(b, pass)
 		}

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -130,27 +130,6 @@ func (e *TxGroupError) Unwrap() error {
 	return e.err
 }
 
-// verifyCount gives the number of signature verifications
-func verifyCount(txn *transactions.SignedTxn) int {
-	if !txn.Sig.Blank() {
-		return 1
-	}
-	if !txn.Msig.Blank() {
-		return txn.Msig.Signatures()
-	}
-	if !txn.Lsig.Blank() {
-		if !txn.Lsig.Sig.Blank() {
-			return 1
-		}
-		if !txn.Lsig.Msig.Blank() {
-			return txn.Lsig.Msig.Signatures()
-		}
-		return 0
-	}
-	return 0
-	// stateproof txns have no sigs at all
-}
-
 // PrepareGroupContext prepares a GroupCtx for a given transaction group.
 func PrepareGroupContext(group []transactions.SignedTxn, contextHdr *bookkeeping.BlockHeader, ledger logic.LedgerForSignature, evalTracer logic.EvalTracer) (*GroupContext, error) {
 	if len(group) == 0 {

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -62,7 +62,7 @@ var spec = transactions.SpecialAddresses{
 func verifyTxn(gi int, groupCtx *GroupContext) error {
 	batchVerifier := crypto.MakeBatchVerifier()
 
-	if err := txnBatchPrep(gi, groupCtx, batchVerifier, nil); err != nil {
+	if err := txnBatchPrep(gi, groupCtx, batchVerifier); err != nil {
 		return err
 	}
 	return batchVerifier.Verify()
@@ -208,7 +208,7 @@ func TestSignedPayment(t *testing.T) {
 	payments, stxns, secrets, addrs := generateTestObjects(1, 1, 0, 0)
 	payment, stxn, secret, addr := payments[0], stxns[0], secrets[0], addrs[0]
 
-	groupCtx, err := PrepareGroupContext(stxns, blockHeader, nil)
+	groupCtx, err := PrepareGroupContext(stxns, blockHeader, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, payment.WellFormed(spec, proto), "generateTestObjects generated an invalid payment")
 	require.NoError(t, verifyTxn(0, groupCtx), "generateTestObjects generated a bad signedtxn")
@@ -230,7 +230,7 @@ func TestTxnValidationEncodeDecode(t *testing.T) {
 	_, signed, _, _ := generateTestObjects(100, 50, 0, 0)
 
 	for _, txn := range signed {
-		groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{txn}, blockHeader, nil)
+		groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{txn}, blockHeader, nil, nil)
 		require.NoError(t, err)
 		if verifyTxn(0, groupCtx) != nil {
 			t.Errorf("signed transaction %#v did not verify", txn)
@@ -250,7 +250,7 @@ func TestTxnValidationEmptySig(t *testing.T) {
 	_, signed, _, _ := generateTestObjects(100, 50, 0, 0)
 
 	for _, txn := range signed {
-		groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{txn}, blockHeader, nil)
+		groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{txn}, blockHeader, nil, nil)
 		require.NoError(t, err)
 		if verifyTxn(0, groupCtx) != nil {
 			t.Errorf("signed transaction %#v did not verify", txn)
@@ -292,7 +292,7 @@ func TestTxnValidationStateProof(t *testing.T) {
 		},
 	}
 
-	groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{stxn}, blockHeader, nil)
+	groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{stxn}, blockHeader, nil, nil)
 	require.NoError(t, err)
 
 	err = verifyTxn(0, groupCtx)
@@ -352,7 +352,7 @@ func TestDecodeNil(t *testing.T) {
 	err := protocol.Decode(nilEncoding, &st)
 	if err == nil {
 		// This used to panic when run on a zero value of SignedTxn.
-		groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{st}, blockHeader, nil)
+		groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{st}, blockHeader, nil, nil)
 		require.NoError(t, err)
 		verifyTxn(0, groupCtx)
 	}
@@ -1069,7 +1069,7 @@ func BenchmarkTxn(b *testing.B) {
 
 	b.ResetTimer()
 	for _, txnGroup := range txnGroups {
-		groupCtx, err := PrepareGroupContext(txnGroup, &blk.BlockHeader, nil)
+		groupCtx, err := PrepareGroupContext(txnGroup, &blk.BlockHeader, nil, nil)
 		require.NoError(b, err)
 		for i := range txnGroup {
 			err := verifyTxn(i, groupCtx)

--- a/data/transactions/verify/verifiedTxnCache.go
+++ b/data/transactions/verify/verifiedTxnCache.go
@@ -73,7 +73,7 @@ type VerifiedTransactionCache interface {
 type verifiedTransactionCache struct {
 	// Number of entries in each map (bucket).
 	entriesPerBucket int
-	// bucketsLock is the lock for syncornizing the access to the cache
+	// bucketsLock is the lock for synchronizing access to the cache
 	bucketsLock deadlock.Mutex
 	// buckets is the circular cache buckets buffer
 	buckets []map[transactions.Txid]*GroupContext

--- a/data/transactions/verify/verifiedTxnCache.go
+++ b/data/transactions/verify/verifiedTxnCache.go
@@ -22,7 +22,6 @@ import (
 	"github.com/algorand/go-deadlock"
 
 	"github.com/algorand/go-algorand/data/transactions"
-	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -127,7 +126,6 @@ func (v *verifiedTransactionCache) GetUnverifiedTransactionGroups(txnGroups [][]
 	for txnGroupIndex := 0; txnGroupIndex < len(txnGroups); txnGroupIndex++ {
 		signedTxnGroup := txnGroups[txnGroupIndex]
 		verifiedTxn := 0
-		groupCtx.minAvmVersion = logic.ComputeMinAvmVersion(transactions.WrapSignedTxnsWithAD(signedTxnGroup))
 
 		baseBucket := v.base
 		for txnIdx := 0; txnIdx < len(signedTxnGroup); txnIdx++ {

--- a/data/transactions/verify/verifiedTxnCache_test.go
+++ b/data/transactions/verify/verifiedTxnCache_test.go
@@ -34,7 +34,7 @@ func TestAddingToCache(t *testing.T) {
 	impl := icache.(*verifiedTransactionCache)
 	_, signedTxn, secrets, addrs := generateTestObjects(10, 5, 0, 50)
 	txnGroups := generateTransactionGroups(protoMaxGroupSize, signedTxn, secrets, addrs)
-	groupCtx, err := PrepareGroupContext(txnGroups[0], blockHeader, nil)
+	groupCtx, err := PrepareGroupContext(txnGroups[0], blockHeader, nil, nil)
 	require.NoError(t, err)
 	impl.Add(txnGroups[0], groupCtx)
 	// make it was added.
@@ -55,7 +55,7 @@ func TestBucketCycling(t *testing.T) {
 	_, signedTxn, _, _ := generateTestObjects(entriesPerBucket*bucketCount*2, bucketCount, 0, 0)
 
 	require.Equal(t, entriesPerBucket*bucketCount*2, len(signedTxn))
-	groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{signedTxn[0]}, blockHeader, nil)
+	groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{signedTxn[0]}, blockHeader, nil, nil)
 	require.NoError(t, err)
 
 	// fill up the cache with entries.
@@ -92,7 +92,7 @@ func TestGetUnverifiedTransactionGroups50(t *testing.T) {
 		if i%2 == 0 {
 			expectedUnverifiedGroups = append(expectedUnverifiedGroups, txnGroups[i])
 		} else {
-			groupCtx, _ := PrepareGroupContext(txnGroups[i], blockHeader, nil)
+			groupCtx, _ := PrepareGroupContext(txnGroups[i], blockHeader, nil, nil)
 			impl.Add(txnGroups[i], groupCtx)
 		}
 	}
@@ -116,7 +116,7 @@ func BenchmarkGetUnverifiedTransactionGroups50(b *testing.B) {
 		if i%2 == 1 {
 			queryTxnGroups = append(queryTxnGroups, txnGroups[i])
 		} else {
-			groupCtx, _ := PrepareGroupContext(txnGroups[i], blockHeader, nil)
+			groupCtx, _ := PrepareGroupContext(txnGroups[i], blockHeader, nil, nil)
 			impl.Add(txnGroups[i], groupCtx)
 		}
 	}
@@ -145,7 +145,7 @@ func TestUpdatePinned(t *testing.T) {
 
 	// insert some entries.
 	for i := 0; i < len(txnGroups); i++ {
-		groupCtx, _ := PrepareGroupContext(txnGroups[i], blockHeader, nil)
+		groupCtx, _ := PrepareGroupContext(txnGroups[i], blockHeader, nil, nil)
 		impl.Add(txnGroups[i], groupCtx)
 	}
 
@@ -174,7 +174,7 @@ func TestPinningTransactions(t *testing.T) {
 
 	// insert half of the entries.
 	for i := 0; i < len(txnGroups)/2; i++ {
-		groupCtx, _ := PrepareGroupContext(txnGroups[i], blockHeader, nil)
+		groupCtx, _ := PrepareGroupContext(txnGroups[i], blockHeader, nil, nil)
 		impl.Add(txnGroups[i], groupCtx)
 	}
 

--- a/ledger/apply/application_test.go
+++ b/ledger/apply/application_test.go
@@ -380,8 +380,7 @@ func TestAppCallAddressByIndex(t *testing.T) {
 	a.Equal(sender, addr)
 
 	addr, err = ac.AddressByIndex(1, sender)
-	a.Error(err)
-	a.Contains(err.Error(), "invalid Account reference 1")
+	a.ErrorContains(err, "invalid Account reference 1")
 	a.Zero(len(ac.Accounts))
 
 	acc0 := getRandomAddress(a)
@@ -391,8 +390,7 @@ func TestAppCallAddressByIndex(t *testing.T) {
 	a.Equal(acc0, addr)
 
 	addr, err = ac.AddressByIndex(2, sender)
-	a.Error(err)
-	a.Contains(err.Error(), "invalid Account reference 2")
+	a.ErrorContains(err, "invalid Account reference 2")
 }
 
 func TestAppCallCheckPrograms(t *testing.T) {
@@ -401,37 +399,33 @@ func TestAppCallCheckPrograms(t *testing.T) {
 	a := require.New(t)
 
 	var ac transactions.ApplicationCallTxnFields
-	var ep logic.EvalParams
 	// This check is for static costs. v26 is last with static cost checking
 	proto := config.Consensus[protocol.ConsensusV26]
-	ep.Proto = &proto
+	ep := logic.NewEvalParams(nil, &proto, nil)
 
 	proto.MaxAppProgramCost = 1
-	err := checkPrograms(&ac, &ep)
-	a.Error(err)
-	a.Contains(err.Error(), "check failed on ApprovalProgram")
+	err := checkPrograms(&ac, ep)
+	a.ErrorContains(err, "check failed on ApprovalProgram")
 
 	program := []byte{2, 0x20, 1, 1, 0x22} // version, intcb, int 1
 	ac.ApprovalProgram = program
 	ac.ClearStateProgram = program
 
-	err = checkPrograms(&ac, &ep)
-	a.Error(err)
-	a.Contains(err.Error(), "check failed on ApprovalProgram")
+	err = checkPrograms(&ac, ep)
+	a.ErrorContains(err, "check failed on ApprovalProgram")
 
 	proto.MaxAppProgramCost = 10
-	err = checkPrograms(&ac, &ep)
+	err = checkPrograms(&ac, ep)
 	a.NoError(err)
 
 	ac.ClearStateProgram = append(ac.ClearStateProgram, program...)
 	ac.ClearStateProgram = append(ac.ClearStateProgram, program...)
 	ac.ClearStateProgram = append(ac.ClearStateProgram, program...)
-	err = checkPrograms(&ac, &ep)
-	a.Error(err)
-	a.Contains(err.Error(), "check failed on ClearStateProgram")
+	err = checkPrograms(&ac, ep)
+	a.ErrorContains(err, "check failed on ClearStateProgram")
 
 	ac.ClearStateProgram = program
-	err = checkPrograms(&ac, &ep)
+	err = checkPrograms(&ac, ep)
 	a.NoError(err)
 }
 
@@ -488,13 +482,15 @@ func TestAppCallApplyCreate(t *testing.T) {
 	h := transactions.Header{
 		Sender: sender,
 	}
-	var ep logic.EvalParams
-	var txnCounter uint64 = 1
 	b := newTestBalances()
+	b.SetProto(protocol.ConsensusFuture)
+	proto := b.ConsensusParams()
+	ep := logic.NewEvalParams(nil, &proto, nil)
 
-	err := ApplicationCall(ac, h, b, nil, 0, &ep, txnCounter)
-	a.Error(err)
-	a.Contains(err.Error(), "ApplicationCall cannot have nil ApplyData")
+	var txnCounter uint64 = 1
+
+	err := ApplicationCall(ac, h, b, nil, 0, ep, txnCounter)
+	a.ErrorContains(err, "ApplicationCall cannot have nil ApplyData")
 	a.Zero(b.put)
 	a.Zero(b.putAppParams)
 
@@ -502,16 +498,11 @@ func TestAppCallApplyCreate(t *testing.T) {
 	b.balances[creator] = basics.AccountData{}
 	var ad *transactions.ApplyData = &transactions.ApplyData{}
 
-	b.SetProto(protocol.ConsensusFuture)
-	proto := b.ConsensusParams()
-	ep.Proto = &proto
-
 	// this test will succeed in creating the app, but then fail
 	// because the mock balances doesn't update the creators table
 	// so it will think the app doesn't exist
-	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
-	a.Error(err)
-	a.Contains(err.Error(), "only ClearState is supported")
+	err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
+	a.ErrorContains(err, "only ClearState is supported")
 	a.Equal(1, b.put)
 	a.Equal(1, b.putAppParams)
 
@@ -528,9 +519,8 @@ func TestAppCallApplyCreate(t *testing.T) {
 	cp.AppParams = maps.Clone(saved.AppParams)
 	cp.AppLocalStates = maps.Clone(saved.AppLocalStates)
 	b.balances[creator] = cp
-	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
-	a.Error(err)
-	a.Contains(err.Error(), "already found app with index")
+	err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
+	a.ErrorContains(err, "already found app with index")
 	a.Equal(uint64(0), uint64(b.allocatedAppIdx))
 	a.Zero(b.put)
 	a.Zero(b.putAppParams)
@@ -547,7 +537,7 @@ func TestAppCallApplyCreate(t *testing.T) {
 	b.balances[creator] = cp
 
 	ac.GlobalStateSchema = basics.StateSchema{NumUint: 1}
-	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
+	err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
 	a.NoError(err)
 	a.Equal(appIdx, b.allocatedAppIdx)
 	a.Equal(1, b.put)
@@ -566,7 +556,7 @@ func TestAppCallApplyCreate(t *testing.T) {
 	txnCounter++
 	appIdx = basics.AppIndex(txnCounter + 1)
 	b.appCreators[appIdx] = creator
-	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
+	err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
 	a.NoError(err)
 	br = b.putBalances[creator]
 	a.Equal(uint32(1), br.AppParams[appIdx].ExtraProgramPages)
@@ -592,23 +582,22 @@ func TestAppCallApplyCreateOptIn(t *testing.T) {
 	h := transactions.Header{
 		Sender: sender,
 	}
-	var ep logic.EvalParams
+	b := newTestBalancesPass()
+	b.SetProto(protocol.ConsensusFuture)
+	proto := b.ConsensusParams()
+	ep := logic.NewEvalParams(nil, &proto, nil)
 	var txnCounter uint64 = 1
 	appIdx := basics.AppIndex(txnCounter + 1)
 	var ad *transactions.ApplyData = &transactions.ApplyData{}
-	b := newTestBalancesPass()
 
 	b.balances = make(map[basics.Address]basics.AccountData)
 	b.balances[creator] = basics.AccountData{}
-	b.SetProto(protocol.ConsensusFuture)
-	proto := b.ConsensusParams()
-	ep.Proto = &proto
 	b.appCreators = map[basics.AppIndex]basics.Address{appIdx: creator}
 
 	gd := map[string]basics.ValueDelta{"uint": {Action: basics.SetUintAction, Uint: 1}}
 	b.delta = transactions.EvalDelta{GlobalDelta: gd}
 
-	err := ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
+	err := ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
 	a.NoError(err)
 	a.Equal(appIdx, b.allocatedAppIdx)
 	br := b.balances[creator]
@@ -650,8 +639,7 @@ func TestAppCallOptIn(t *testing.T) {
 	ad.AppLocalStates[appIdx] = basics.AppLocalState{}
 	b.balances = map[basics.Address]basics.AccountData{sender: ad}
 	err = optInApplication(b, sender, appIdx, params)
-	a.Error(err)
-	a.Contains(err.Error(), "has already opted in to app")
+	a.ErrorContains(err, "has already opted in to app")
 	a.Zero(b.put)
 	a.Zero(b.putAppLocalState)
 
@@ -749,14 +737,13 @@ func TestAppCallClearState(t *testing.T) {
 	var txnCounter uint64 = 1
 	appIdx := basics.AppIndex(txnCounter + 1)
 	b := newTestBalances()
-	var ep logic.EvalParams
+	b.SetProto(protocol.ConsensusFuture)
+	proto := b.ConsensusParams()
+	ep := logic.NewEvalParams(nil, &proto, nil)
 
 	ad := &transactions.ApplyData{}
 	b.appCreators = make(map[basics.AppIndex]basics.Address)
 	b.balances = make(map[basics.Address]basics.AccountData, 2)
-	b.SetProto(protocol.ConsensusFuture)
-	proto := b.ConsensusParams()
-	ep.Proto = &proto
 
 	ac := transactions.ApplicationCallTxnFields{
 		ApplicationID: appIdx,
@@ -782,9 +769,8 @@ func TestAppCallClearState(t *testing.T) {
 	b.pass = true
 	// check app not exist and not opted in
 	b.balances[sender] = basics.AccountData{}
-	err := ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
-	a.Error(err)
-	a.Contains(err.Error(), "is not currently opted in to app")
+	err := ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
+	a.ErrorContains(err, "is not currently opted in to app")
 	a.Zero(b.put)
 	a.Zero(b.putAppLocalState)
 	a.Zero(b.deleteAppLocalState)
@@ -793,7 +779,7 @@ func TestAppCallClearState(t *testing.T) {
 	b.balances[sender] = basics.AccountData{
 		AppLocalStates: map[basics.AppIndex]basics.AppLocalState{appIdx: {}},
 	}
-	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
+	err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
 	a.NoError(err)
 	a.Equal(1, b.put)
 	a.Zero(b.putAppLocalState)
@@ -813,7 +799,7 @@ func TestAppCallClearState(t *testing.T) {
 			appIdx: {Schema: basics.StateSchema{NumUint: 10}},
 		},
 	}
-	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
+	err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
 	a.NoError(err)
 	a.Equal(1, b.put)
 	a.Zero(b.putAppLocalState)
@@ -841,7 +827,7 @@ func TestAppCallClearState(t *testing.T) {
 	// one put: to opt out
 	b.pass = false
 	b.delta = transactions.EvalDelta{GlobalDelta: nil}
-	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
+	err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
 	a.NoError(err)
 	a.Equal(1, b.put)
 	a.Zero(b.putAppLocalState)
@@ -858,7 +844,7 @@ func TestAppCallClearState(t *testing.T) {
 	b.pass = true
 	b.delta = transactions.EvalDelta{GlobalDelta: nil}
 	b.err = logic.EvalError{Err: fmt.Errorf("test error")}
-	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
+	err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
 	a.NoError(err)
 	a.Equal(1, b.put)
 	a.Zero(b.putAppLocalState)
@@ -875,7 +861,7 @@ func TestAppCallClearState(t *testing.T) {
 	b.pass = true
 	b.delta = transactions.EvalDelta{GlobalDelta: nil}
 	b.err = fmt.Errorf("test error")
-	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
+	err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
 	a.Error(err)
 	br = b.putBalances[sender]
 	a.Zero(len(br.AppLocalStates))
@@ -890,7 +876,7 @@ func TestAppCallClearState(t *testing.T) {
 	b.err = nil
 	gd := basics.StateDelta{"uint": {Action: basics.SetUintAction, Uint: 1}}
 	b.delta = transactions.EvalDelta{GlobalDelta: gd}
-	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
+	err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
 	a.NoError(err)
 	a.Equal(1, b.put)
 	a.Zero(b.putAppLocalState)
@@ -905,7 +891,7 @@ func TestAppCallClearState(t *testing.T) {
 	b.err = nil
 	logs := []string{"a"}
 	b.delta = transactions.EvalDelta{Logs: []string{"a"}}
-	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
+	err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
 	a.NoError(err)
 	a.Equal(transactions.EvalDelta{Logs: logs}, ad.EvalDelta)
 }
@@ -953,8 +939,7 @@ func TestAppCallApplyCloseOut(t *testing.T) {
 
 	b.pass = false
 	err := ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
-	a.Error(err)
-	a.Contains(err.Error(), "transaction rejected by ApprovalProgram")
+	a.ErrorContains(err, "transaction rejected by ApprovalProgram")
 	a.Zero(b.put)
 	a.Zero(b.putAppLocalState)
 	a.Zero(b.deleteAppLocalState)
@@ -966,8 +951,7 @@ func TestAppCallApplyCloseOut(t *testing.T) {
 	b.pass = true
 	b.balances[sender] = basics.AccountData{}
 	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
-	a.Error(err)
-	a.Contains(err.Error(), "is not opted in to any app")
+	a.ErrorContains(err, "is not opted in to any app")
 	a.Zero(b.put)
 	a.Zero(b.putAppLocalState)
 	a.Zero(b.deleteAppLocalState)
@@ -1032,9 +1016,11 @@ func TestAppCallApplyUpdate(t *testing.T) {
 	h := transactions.Header{
 		Sender: sender,
 	}
-	var ep logic.EvalParams
 	var ad *transactions.ApplyData = &transactions.ApplyData{}
 	b := newTestBalances()
+	b.SetProto(protocol.ConsensusV28)
+	proto := b.ConsensusParams()
+	ep := logic.NewEvalParams(nil, &proto, nil)
 
 	b.balances = make(map[basics.Address]basics.AccountData)
 	cbr := basics.AccountData{
@@ -1046,14 +1032,9 @@ func TestAppCallApplyUpdate(t *testing.T) {
 	b.balances[creator] = cp
 	b.appCreators = map[basics.AppIndex]basics.Address{appIdx: creator}
 
-	b.SetProto(protocol.ConsensusV28)
-	proto := b.ConsensusParams()
-	ep.Proto = &proto
-
 	b.pass = false
-	err := ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
-	a.Error(err)
-	a.Contains(err.Error(), "transaction rejected by ApprovalProgram")
+	err := ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
+	a.ErrorContains(err, "transaction rejected by ApprovalProgram")
 	a.Zero(b.put)
 	a.Zero(b.putAppParams)
 	br := b.balances[creator]
@@ -1063,7 +1044,7 @@ func TestAppCallApplyUpdate(t *testing.T) {
 	// check updating on empty sender's balance record - happy case
 	b.pass = true
 	b.balances[sender] = basics.AccountData{}
-	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
+	err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
 	a.NoError(err)
 	a.Zero(b.put)
 	a.Equal(1, b.putAppParams)
@@ -1103,7 +1084,7 @@ func TestAppCallApplyUpdate(t *testing.T) {
 
 	logs := []string{"a"}
 	b.delta = transactions.EvalDelta{Logs: []string{"a"}}
-	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
+	err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
 	a.NoError(err)
 	a.Equal(transactions.EvalDelta{Logs: logs}, ad.EvalDelta)
 
@@ -1128,7 +1109,7 @@ func TestAppCallApplyUpdate(t *testing.T) {
 		}
 
 		b.pass = true
-		err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
+		err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
 		a.Error(err)
 		a.Contains(err.Error(), fmt.Sprintf("updateApplication %s program too long", test.name))
 	}
@@ -1144,7 +1125,7 @@ func TestAppCallApplyUpdate(t *testing.T) {
 		ClearStateProgram: []byte{2},
 	}
 	b.pass = true
-	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
+	err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
 	a.NoError(err)
 
 	// check extraProgramPages is used and long sum rejected
@@ -1155,9 +1136,8 @@ func TestAppCallApplyUpdate(t *testing.T) {
 		ClearStateProgram: appr,
 	}
 	b.pass = true
-	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
-	a.Error(err)
-	a.Contains(err.Error(), "updateApplication app programs too long")
+	err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
+	a.ErrorContains(err, "updateApplication app programs too long")
 
 }
 
@@ -1209,8 +1189,7 @@ func TestAppCallApplyDelete(t *testing.T) {
 
 	b.pass = false
 	err := ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
-	a.Error(err)
-	a.Contains(err.Error(), "transaction rejected by ApprovalProgram")
+	a.ErrorContains(err, "transaction rejected by ApprovalProgram")
 	a.Zero(b.put)
 	a.Zero(b.putAppParams)
 	a.Zero(b.deleteAppParams)
@@ -1300,17 +1279,17 @@ func TestAppCallApplyCreateClearState(t *testing.T) {
 	h := transactions.Header{
 		Sender: sender,
 	}
-	var ep logic.EvalParams
 	var txnCounter uint64 = 1
 	appIdx := basics.AppIndex(txnCounter + 1)
 	var ad *transactions.ApplyData = &transactions.ApplyData{}
 	b := newTestBalancesPass()
+	b.SetProto(protocol.ConsensusFuture)
+	proto := b.ConsensusParams()
+	ep := logic.NewEvalParams(nil, &proto, nil)
 
 	b.balances = make(map[basics.Address]basics.AccountData)
 	b.balances[creator] = basics.AccountData{}
 	b.SetProto(protocol.ConsensusFuture)
-	proto := b.ConsensusParams()
-	ep.Proto = &proto
 
 	b.appCreators = map[basics.AppIndex]basics.Address{appIdx: creator}
 
@@ -1319,9 +1298,8 @@ func TestAppCallApplyCreateClearState(t *testing.T) {
 	b.delta = transactions.EvalDelta{GlobalDelta: gd}
 
 	// check creation on empty balance record
-	err := ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
-	a.Error(err)
-	a.Contains(err.Error(), "not currently opted in")
+	err := ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
+	a.ErrorContains(err, "not currently opted in")
 	a.Equal(appIdx, b.allocatedAppIdx)
 	a.Equal(transactions.EvalDelta{}, ad.EvalDelta)
 	br := b.balances[creator]
@@ -1350,17 +1328,17 @@ func TestAppCallApplyCreateDelete(t *testing.T) {
 	h := transactions.Header{
 		Sender: sender,
 	}
-	var ep logic.EvalParams
 	var txnCounter uint64 = 1
 	appIdx := basics.AppIndex(txnCounter + 1)
 	var ad *transactions.ApplyData = &transactions.ApplyData{}
 	b := newTestBalancesPass()
+	b.SetProto(protocol.ConsensusFuture)
+	proto := b.ConsensusParams()
+	ep := logic.NewEvalParams(nil, &proto, nil)
 
 	b.balances = make(map[basics.Address]basics.AccountData)
 	b.balances[creator] = basics.AccountData{}
 	b.SetProto(protocol.ConsensusFuture)
-	proto := b.ConsensusParams()
-	ep.Proto = &proto
 
 	b.appCreators = map[basics.AppIndex]basics.Address{appIdx: creator}
 
@@ -1369,7 +1347,7 @@ func TestAppCallApplyCreateDelete(t *testing.T) {
 	b.delta = transactions.EvalDelta{GlobalDelta: gd}
 
 	// check creation on empty balance record
-	err := ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
+	err := ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
 	a.NoError(err)
 	a.Equal(appIdx, b.allocatedAppIdx)
 	a.Equal(transactions.EvalDelta{GlobalDelta: gd}, ad.EvalDelta)
@@ -1378,7 +1356,7 @@ func TestAppCallApplyCreateDelete(t *testing.T) {
 
 	logs := []string{"a"}
 	b.delta = transactions.EvalDelta{Logs: []string{"a"}}
-	err = ApplicationCall(ac, h, b, ad, 0, &ep, txnCounter)
+	err = ApplicationCall(ac, h, b, ad, 0, ep, txnCounter)
 	a.NoError(err)
 	a.Equal(transactions.EvalDelta{Logs: logs}, ad.EvalDelta)
 

--- a/ledger/apply/application_test.go
+++ b/ledger/apply/application_test.go
@@ -401,7 +401,7 @@ func TestAppCallCheckPrograms(t *testing.T) {
 	var ac transactions.ApplicationCallTxnFields
 	// This check is for static costs. v26 is last with static cost checking
 	proto := config.Consensus[protocol.ConsensusV26]
-	ep := logic.NewEvalParams(nil, &proto, nil)
+	ep := logic.NewAppEvalParams(nil, &proto, nil)
 
 	proto.MaxAppProgramCost = 1
 	err := checkPrograms(&ac, ep)
@@ -485,7 +485,7 @@ func TestAppCallApplyCreate(t *testing.T) {
 	b := newTestBalances()
 	b.SetProto(protocol.ConsensusFuture)
 	proto := b.ConsensusParams()
-	ep := logic.NewEvalParams(nil, &proto, nil)
+	ep := logic.NewAppEvalParams(nil, &proto, nil)
 
 	var txnCounter uint64 = 1
 
@@ -585,7 +585,7 @@ func TestAppCallApplyCreateOptIn(t *testing.T) {
 	b := newTestBalancesPass()
 	b.SetProto(protocol.ConsensusFuture)
 	proto := b.ConsensusParams()
-	ep := logic.NewEvalParams(nil, &proto, nil)
+	ep := logic.NewAppEvalParams(nil, &proto, nil)
 	var txnCounter uint64 = 1
 	appIdx := basics.AppIndex(txnCounter + 1)
 	var ad *transactions.ApplyData = &transactions.ApplyData{}
@@ -739,7 +739,7 @@ func TestAppCallClearState(t *testing.T) {
 	b := newTestBalances()
 	b.SetProto(protocol.ConsensusFuture)
 	proto := b.ConsensusParams()
-	ep := logic.NewEvalParams(nil, &proto, nil)
+	ep := logic.NewAppEvalParams(nil, &proto, nil)
 
 	ad := &transactions.ApplyData{}
 	b.appCreators = make(map[basics.AppIndex]basics.Address)
@@ -1020,7 +1020,7 @@ func TestAppCallApplyUpdate(t *testing.T) {
 	b := newTestBalances()
 	b.SetProto(protocol.ConsensusV28)
 	proto := b.ConsensusParams()
-	ep := logic.NewEvalParams(nil, &proto, nil)
+	ep := logic.NewAppEvalParams(nil, &proto, nil)
 
 	b.balances = make(map[basics.Address]basics.AccountData)
 	cbr := basics.AccountData{
@@ -1285,7 +1285,7 @@ func TestAppCallApplyCreateClearState(t *testing.T) {
 	b := newTestBalancesPass()
 	b.SetProto(protocol.ConsensusFuture)
 	proto := b.ConsensusParams()
-	ep := logic.NewEvalParams(nil, &proto, nil)
+	ep := logic.NewAppEvalParams(nil, &proto, nil)
 
 	b.balances = make(map[basics.Address]basics.AccountData)
 	b.balances[creator] = basics.AccountData{}
@@ -1334,7 +1334,7 @@ func TestAppCallApplyCreateDelete(t *testing.T) {
 	b := newTestBalancesPass()
 	b.SetProto(protocol.ConsensusFuture)
 	proto := b.ConsensusParams()
-	ep := logic.NewEvalParams(nil, &proto, nil)
+	ep := logic.NewAppEvalParams(nil, &proto, nil)
 
 	b.balances = make(map[basics.Address]basics.AccountData)
 	b.balances[creator] = basics.AccountData{}

--- a/ledger/eval/eval.go
+++ b/ledger/eval/eval.go
@@ -958,7 +958,7 @@ func (eval *BlockEvaluator) TransactionGroup(txgroup []transactions.SignedTxnWit
 	cow := eval.state.child(len(txgroup))
 	defer cow.recycle()
 
-	evalParams := logic.NewEvalParams(txgroup, &eval.proto, &eval.specials)
+	evalParams := logic.NewAppEvalParams(txgroup, &eval.proto, &eval.specials)
 	evalParams.Tracer = eval.Tracer
 
 	if eval.Tracer != nil {

--- a/ledger/simulation/simulation_eval_test.go
+++ b/ledger/simulation/simulation_eval_test.go
@@ -1205,7 +1205,7 @@ func TestLogicSigOverBudget(t *testing.T) {
 ` + strings.Repeat(`byte "a"
 keccak256
 pop
-`, 200) + `int 1`)
+`, 310) + `int 1`)
 	require.NoError(t, err)
 	program := logic.Program(op.Program)
 	lsigAddr := basics.Address(crypto.HashObj(&program))
@@ -1261,7 +1261,7 @@ int 1`,
 									ApplyData: expectedAppCallAD,
 								},
 								AppBudgetConsumed:      0,
-								LogicSigBudgetConsumed: 19934,
+								LogicSigBudgetConsumed: 39998,
 							},
 						},
 						FailedAt:          expectedFailedAt,

--- a/test/scripts/e2e_subs/app-group.py
+++ b/test/scripts/e2e_subs/app-group.py
@@ -74,4 +74,5 @@ assert not err, err
 txinfo, err = goal.app_call(joe, app_id, accounts=[goal.account])
 assert not err, err
 
+stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 print(f"{os.path.basename(sys.argv[0])} OK {stamp}")

--- a/test/scripts/e2e_subs/app-inner-calls-csp.py
+++ b/test/scripts/e2e_subs/app-inner-calls-csp.py
@@ -154,4 +154,5 @@ assert not err, err
 _, err = goal.app_call(joe, app1ID, app_args=[0x01], foreign_apps=[int(app2ID), int(app3ID)])
 assert not err, err
 
+stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 print(f"{os.path.basename(sys.argv[0])} OK {stamp}")

--- a/test/scripts/e2e_subs/app-inner-calls.py
+++ b/test/scripts/e2e_subs/app-inner-calls.py
@@ -145,4 +145,5 @@ assert not err, err
 assert 10 == goal.balance(app_account, asa_id)
 
 
+stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 print(f"{os.path.basename(sys.argv[0])} OK {stamp}")

--- a/test/scripts/e2e_subs/app-rekey.py
+++ b/test/scripts/e2e_subs/app-rekey.py
@@ -78,4 +78,5 @@ txinfo, err = goal.pay(flo, joe, amt=1)
 assert not err, err
 assert goal.balance(joe) == joeb+7, goal.balance(joe)
 
+stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 print(f"{os.path.basename(sys.argv[0])} OK {stamp}")

--- a/test/scripts/e2e_subs/example.py
+++ b/test/scripts/e2e_subs/example.py
@@ -19,7 +19,7 @@ flo = goal.new_account()
 
 pay = goal.pay(goal.account, receiver=joe, amt=10000)  # under min balance
 txid, err = goal.send(pay, confirm=False)              # errors early
-assert err
+assert "balance 10000 below min 100000" in str(err), err
 
 pay = goal.pay(goal.account, receiver=joe, amt=500_000)
 txinfo, err = goal.send(pay)

--- a/test/scripts/e2e_subs/goal/goal.py
+++ b/test/scripts/e2e_subs/goal/goal.py
@@ -144,10 +144,10 @@ class Goal:
             self.open_wallet(self.wallet_name)
             return self.kmd.sign_transaction(self.handle, "", tx)
 
-    def sign_with_program(self, tx, program, delegator=None):
+    def sign_with_program(self, tx, program, args=None, delegator=None):
         if delegator:
             raise Exception("haven't implemented delgated logicsig yet")
-        return txn.LogicSigTransaction(tx, txn.LogicSig(program))
+        return txn.LogicSigTransaction(tx, txn.LogicSig(program, args))
 
     def send(self, tx, confirm=True):
         try:

--- a/test/scripts/e2e_subs/hdr-access.py
+++ b/test/scripts/e2e_subs/hdr-access.py
@@ -91,4 +91,5 @@ txinfo, err = goal.send(tx)
 assert "round 0 is not available" in str(err), err
 assert "outside [1-" in str(err), err  # confirms that we can look back to 1
 
+stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 print(f"{os.path.basename(sys.argv[0])} OK {stamp}")

--- a/test/scripts/e2e_subs/lsig-budget.py
+++ b/test/scripts/e2e_subs/lsig-budget.py
@@ -83,5 +83,5 @@ stx1 = goal.sign_with_program(tx1, code, [(92).to_bytes(8, "big")])
 txinfo, err = goal.send_group([stx0, stx1])
 assert err, txinfo
 
-
+stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 print(f"{os.path.basename(sys.argv[0])} OK {stamp}")

--- a/test/scripts/e2e_subs/lsig-budget.py
+++ b/test/scripts/e2e_subs/lsig-budget.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+import os
+import sys
+from goal import Goal
+import algosdk.logic as logic
+
+from datetime import datetime
+
+stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+print(f"{os.path.basename(sys.argv[0])} start {stamp}")
+
+goal = Goal(sys.argv[1], autosend=True)
+
+# This lsig runs keccak256 (cost=130) the number of times in its first
+# logicsig arg, then accepts.  In effect, it accepts if it has enough
+# budget to run the number of hashes requested. The program consumes 6
+# opcodes in the base case (args[0] == 0), and 137 for each loop.
+run_hashes = """
+#pragma version 6
+ arg 0
+ btoi
+loop:
+ dup
+ bz end
+ byte 0x0102030405060708
+ keccak256
+ pop
+ int 1
+ -
+ b loop
+end:
+ pop                            // the 0 loop variable
+ int 1
+"""
+
+code = goal.assemble(run_hashes)
+escrow = goal.logic_address(code)
+
+# Fund the lsig's escrow account
+_, err = goal.pay(goal.account, escrow, amt=1_000_000)
+assert not err, err
+
+# Construct a transaction that uses the lsig. Can't send, because we
+# have to fill in the lsig (and args)
+tx = goal.pay(escrow, escrow, amt=0, note=b'5', send=False)
+# 5 loops is fine (20k budget)
+stx = goal.sign_with_program(tx, code, [(5).to_bytes(8, "big")])
+txinfo, err = goal.send(stx)
+assert not err, err
+
+# 145 loops is fine 6+145*137 < 20k budget
+tx = goal.pay(escrow, escrow, amt=0, note=b'145', send=False)
+stx = goal.sign_with_program(tx, code, [(145).to_bytes(8, "big")])
+txinfo, err = goal.send(stx)
+assert not err, err
+
+# 146 is not 6+146*137 = 20,008 (20k budget)
+tx = goal.pay(escrow, escrow, amt=0, note=b'146', send=False)
+stx = goal.sign_with_program(tx, code, [(146).to_bytes(8, "big")])
+txinfo, err = goal.send(stx)
+assert err, txinfo
+
+# Now, try pooling across multiple logicsigs 39988/137 = 291.xxx
+tx0 = goal.pay(escrow, escrow, amt=0, note=b'200', send=False)
+tx1 = goal.pay(escrow, escrow, amt=0, note=b'91', send=False)
+stx0 = goal.sign_with_program(tx0, code, [(200).to_bytes(8, "big")])
+stx1 = goal.sign_with_program(tx1, code, [(91).to_bytes(8, "big")])
+txinfo, err = goal.send_group([stx0, stx1])
+assert not err, err
+
+# order doesn't matter
+tx0.group = None
+tx1.group = None
+txinfo, err = goal.send_group([stx1, stx0])  # rearrange
+assert not err, err
+
+# 292 is too much
+tx0 = goal.pay(escrow, escrow, amt=0, note=b'200', send=False)
+tx1 = goal.pay(escrow, escrow, amt=0, note=b'92', send=False)
+stx0 = goal.sign_with_program(tx0, code, [(200).to_bytes(8, "big")])
+stx1 = goal.sign_with_program(tx1, code, [(92).to_bytes(8, "big")])
+txinfo, err = goal.send_group([stx0, stx1])
+assert err, txinfo
+
+
+print(f"{os.path.basename(sys.argv[0])} OK {stamp}")

--- a/test/scripts/e2e_subs/lsig-budget.py
+++ b/test/scripts/e2e_subs/lsig-budget.py
@@ -59,7 +59,7 @@ assert not err, err
 tx = goal.pay(escrow, escrow, amt=0, note=b'146', send=False)
 stx = goal.sign_with_program(tx, code, [(146).to_bytes(8, "big")])
 txinfo, err = goal.send(stx)
-assert err, txinfo
+assert "dynamic cost budget exceeded, executing keccak256" in str(err)
 
 # Now, try pooling across multiple logicsigs 39988/137 = 291.xxx
 tx0 = goal.pay(escrow, escrow, amt=0, note=b'200', send=False)
@@ -81,7 +81,7 @@ tx1 = goal.pay(escrow, escrow, amt=0, note=b'92', send=False)
 stx0 = goal.sign_with_program(tx0, code, [(200).to_bytes(8, "big")])
 stx1 = goal.sign_with_program(tx1, code, [(92).to_bytes(8, "big")])
 txinfo, err = goal.send_group([stx0, stx1])
-assert err, txinfo
+assert "dynamic cost budget exceeded, executing keccak256" in str(err)
 
 stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 print(f"{os.path.basename(sys.argv[0])} OK {stamp}")

--- a/test/scripts/e2e_subs/shared-resources.py
+++ b/test/scripts/e2e_subs/shared-resources.py
@@ -94,4 +94,5 @@ assert len(grp2_info["local-state-delta"]) == 1
 assert grp2_info["local-state-delta"][0]["address"] == goal.account
 assert grp2_info["local-state-delta"][0]["delta"][0]["value"]["uint"] == 70
 
+stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 print(f"{os.path.basename(sys.argv[0])} OK {stamp}")


### PR DESCRIPTION
A total of 20k opcode ticks per transaction will be available across all logicsigs in a group.

Something to spend reviewing cycles on - we now use a single EvalParams to execute all LogicSIgs in a group. Previously, we kept creating new ones.  This pretty much enshrines serial execution of LogicSigs (within group) but I don't mind that because: 1) Individual groups still seem small enough (and rarely have multiple lsigs anyway) so I don't think much optimization opportunity is lost, and 2) We already had several things that pushed in that direction - shared pointers, Tracer execution - so I don't think we'd ever try to squeeze out that parallelism anyway.

## Test Plan

One of the tricky things about this change is that MinAvmVersion is now a uint64 rather than *uint64, and it is now required to be set before calling `eval`. In order to shake out bugs in which callers did not set it, the PR was first tested by removing the check that sets the the min version inside eval, while still using a pointer, thus nil pointer errors would be triggered.

Only after all tests passed was it changed to `uint64`.

Further, EvalParams now have a `runMode` and can only be used to run apps OR sigs, not both. Since callers can't set the unexported value, they must use the exported constructors, ensure minAvmVersion and similar things are initialized.