### PR TITLE
Runtime: Add delete-if-exists check for the no longer used indexer.sqlite file…

### DIFF
--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/algorand/go-algorand/util"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -158,10 +159,10 @@ func run() int {
 	}
 	defer fileLock.Unlock()
 
-	// Delete legaxy indexer.sqlite file if it happens to exist
+	// Delete legacy indexer.sqlite file if it happens to exist
 	indexerDBPath := filepath.Join(absolutePath, genesis.ID(), "indexer.sqlite")
 
-	if _, idxFilePathErr := os.Stat(indexerDBPath); idxFilePathErr == nil {
+	if util.FileExists(indexerDBPath) {
 		if idxFileRemoveErr := os.Remove(indexerDBPath); idxFileRemoveErr != nil {
 			fmt.Fprintln(os.Stderr, "Error removing indexer.sqlite file from Data directory", idxFileRemoveErr)
 		} else {

--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -158,6 +158,17 @@ func run() int {
 	}
 	defer fileLock.Unlock()
 
+	// Delete legaxy indexer.sqlite file if it happens to exist
+	indexerDBPath := filepath.Join(absolutePath, genesis.ID(), "indexer.sqlite")
+
+	if _, idxFilePathErr := os.Stat(indexerDBPath); idxFilePathErr == nil {
+		if idxFileRemoveErr := os.Remove(indexerDBPath); idxFileRemoveErr != nil {
+			fmt.Fprintln(os.Stderr, "Error removing indexer.sqlite file from Data directory", idxFileRemoveErr)
+		} else {
+			fmt.Fprintln(os.Stdout, "Removed legacy indexer.sqlite file from data directory")
+		}
+	}
+
 	cfg, err := config.LoadConfigFromDisk(absolutePath)
 	if err != nil && !os.IsNotExist(err) {
 		// log is not setup yet, this will log to stderr

--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -159,16 +159,22 @@ func run() int {
 	}
 	defer fileLock.Unlock()
 
-	// Delete legacy indexer.sqlite file if it happens to exist
-	indexerDBPath := filepath.Join(absolutePath, genesis.ID(), "indexer.sqlite")
+	// Delete legacy indexer.sqlite files if they happen to exist
+	checkAndDeleteIndexerFile := func(fileName string) {
+		indexerDBFilePath := filepath.Join(absolutePath, genesis.ID(), fileName)
 
-	if util.FileExists(indexerDBPath) {
-		if idxFileRemoveErr := os.Remove(indexerDBPath); idxFileRemoveErr != nil {
-			fmt.Fprintln(os.Stderr, "Error removing indexer.sqlite file from Data directory", idxFileRemoveErr)
-		} else {
-			fmt.Fprintln(os.Stdout, "Removed legacy indexer.sqlite file from data directory")
+		if util.FileExists(indexerDBFilePath) {
+			if idxFileRemoveErr := os.Remove(indexerDBFilePath); idxFileRemoveErr != nil {
+				fmt.Fprintf(os.Stderr, "Error removing %s file from data directory: %v\n", fileName, idxFileRemoveErr)
+			} else {
+				fmt.Fprintf(os.Stdout, "Removed legacy %s file from data directory\n", fileName)
+			}
 		}
 	}
+
+	checkAndDeleteIndexerFile("indexer.sqlite")
+	checkAndDeleteIndexerFile("indexer.sqlite-shm")
+	checkAndDeleteIndexerFile("indexer.sqlite-wal")
 
 	cfg, err := config.LoadConfigFromDisk(absolutePath)
 	if err != nil && !os.IsNotExist(err) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
Add delete-if-exists check for the no longer used indexer.sqlite file in genesis data directory.
<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Ran node locally with indexer.sqlite file present, not present, and initial condition with data directory not created yet.
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
