### PR TITLE
fix: catchpoint pending hashes locking

### DIFF
--- a/ledger/catchupaccessor.go
+++ b/ledger/catchupaccessor.go
@@ -754,7 +754,8 @@ func (c *catchpointCatchupAccessorImpl) BuildMerkleTrie(ctx context.Context, pro
 		defer wg.Done()
 		defer close(writerQueue)
 
-		dbErr := dbs.Transaction(func(transactionCtx context.Context, tx trackerdb.TransactionScope) (err error) {
+		// Note: this needs to be accessed on a snapshot to guarantee a concurrent read-only access to the sqlite db
+		dbErr := dbs.Snapshot(func(transactionCtx context.Context, tx trackerdb.SnapshotScope) (err error) {
 			it := tx.MakeCatchpointPendingHashesIterator(trieRebuildAccountChunkSize)
 			var hashes [][]byte
 			for {

--- a/ledger/store/trackerdb/sqlitedriver/sqlitedriver.go
+++ b/ledger/store/trackerdb/sqlitedriver/sqlitedriver.go
@@ -178,6 +178,11 @@ func (r *sqlReader) MakeSpVerificationCtxReader() trackerdb.SpVerificationCtxRea
 	return makeStateProofVerificationReader(r.q)
 }
 
+// MakeCatchpointPendingHashesIterator implements trackerdb.Reader
+func (r *sqlReader) MakeCatchpointPendingHashesIterator(hashCount int) trackerdb.CatchpointPendingHashesIter {
+	return MakeCatchpointPendingHashesIterator(hashCount, r.q)
+}
+
 type sqlWriter struct {
 	e db.Executable
 }
@@ -229,11 +234,6 @@ func (w *sqlWriter) ModifyAcctBaseTest() error {
 
 type sqlCatchpoint struct {
 	e db.Executable
-}
-
-// MakeCatchpointPendingHashesIterator implements trackerdb.Catchpoint
-func (c *sqlCatchpoint) MakeCatchpointPendingHashesIterator(hashCount int) trackerdb.CatchpointPendingHashesIter {
-	return MakeCatchpointPendingHashesIterator(hashCount, c.e)
 }
 
 // MakeCatchpointReader implements trackerdb.Catchpoint

--- a/ledger/store/trackerdb/store.go
+++ b/ledger/store/trackerdb/store.go
@@ -56,6 +56,9 @@ type Reader interface {
 	MakeAccountsOptimizedReader() (AccountsReader, error)
 	MakeOnlineAccountsOptimizedReader() (OnlineAccountsReader, error)
 	MakeSpVerificationCtxReader() SpVerificationCtxReader
+	// catchpoint
+	// Note: BuildMerkleTrie() needs this on the reader handle in sqlite to not get locked by write txns
+	MakeCatchpointPendingHashesIterator(hashCount int) CatchpointPendingHashesIter
 }
 
 // Writer is the interface for the trackerdb write operations.
@@ -80,7 +83,6 @@ type Writer interface {
 type Catchpoint interface {
 	// reader
 	MakeCatchpointReader() (CatchpointReader, error)
-	MakeCatchpointPendingHashesIterator(hashCount int) CatchpointPendingHashesIter
 	MakeOrderedAccountsIter(accountCount int) OrderedAccountsIter
 	MakeKVsIter(ctx context.Context) (KVsIter, error)
 	MakeEncodedAccoutsBatchIter() EncodedAccountsBatchIter


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

#5451 introduced a bug, the catchpoint merkle tree generation needs to be kept on a separate readonly connection for it to make forward progress. 

This PR add the required method to the `Reader` interface for the store, so it becomes available via the `Snapshot` scope. 
There is an implicit contract that the snapshot is going through a separate read-only handle to the sqlite db. 
If this were ever to change, this will break again. 

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
