### PR TITLE
tests: fix coder tester for TxType bound

### DIFF
--- a/protocol/codec_tester.go
+++ b/protocol/codec_tester.go
@@ -249,6 +249,9 @@ func randomizeValue(v reflect.Value, datapath string, tag string, remainingChang
 			// Don't generate empty strings for serializableError since nil values of *string type
 			// will serialize differently by msgp and go-codec
 			len = rand.Int()%63 + 1
+		} else if strings.HasSuffix(v.Type().PkgPath(), "go-algorand/protocol") && v.Type().Name() == "TxType" {
+			// protocol.TxType has allocbound defined as a custom msgp:allocbound directive so not supported by reflect
+			len = rand.Int()%6 + 1
 		} else if hasAllocBound {
 			len = 1
 		} else {


### PR DESCRIPTION
## Summary

Fix for codec tester that disregard TxType allocbound declaration in `protocol/txntype.go` when called on `data/transactions`'s `Transaction` type.
```
--- FAIL: TestRandomizedEncodingTransaction (0.09s)
    codec_tester.go:480: 
        	Error Trace:	/go-algorand/data/transactions/codec_tester.go:480
        	            				/go-algorand/data/transactions/msgp_gen_test.go:999
        	Error:      	Received unexpected error:
        	            	msgp: length overflow: 60 > 7 at Type
        	Test:       	TestRandomizedEncodingTransaction
FAIL
FAIL	github.com/algorand/go-algorand/data/transactions	0.318s
```

## Test Plan

Existing tests passing now