### PR TITLE
CICD: Fix debian package error

### DIFF
--- a/installer/debian/algorand-devtools/conffiles
+++ b/installer/debian/algorand-devtools/conffiles
@@ -1,2 +1,1 @@
 /etc/apt/apt.conf.d/53algorand-devtools-upgrades
-


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

We updated the Ubuntu image we use to build the debian package, and it has tighter tolerances. As a result, debian packaging now fails because of an extraneous newline in the algorand-devtools conffile.

## Test Plan

Successfully ran packaging with the newline removed.
