### PR TITLE
CICD: downgrade ubuntu to 20.04 and ensure ARM64 binaries are built static

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,14 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.3.0
+  win: circleci/windows@5.0.0
   go: circleci/go@1.7.3
-  slack: circleci/slack@4.10.1
+  slack: circleci/slack@4.12.5
 
 parameters:
   ubuntu_image:
     type: string
-    default: "ubuntu-2004:202104-01"
+    default: "ubuntu-2004:2023.04.2"
   build_dir:
     type: string
     default: "/opt/cibuild"

--- a/.github/workflows/pr-type-category.yml
+++ b/.github/workflows/pr-type-category.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check PR Category and Type
     steps:
       - name: Checking for correct number of required github pr labels
-        uses: mheap/github-action-required-labels@v2
+        uses: mheap/github-action-required-labels@v5
         with:
           mode: exactly
           count: 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as builder
+FROM ubuntu:20.04 as builder
 
 ARG GO_VERSION="1.20.5"
 

--- a/Makefile
+++ b/Makefile
@@ -49,23 +49,15 @@ export CPATH=/opt/homebrew/include
 export LIBRARY_PATH=/opt/homebrew/lib
 endif
 endif
+
 ifeq ($(UNAME), Linux)
 EXTLDFLAGS := -static-libstdc++ -static-libgcc
-ifeq ($(ARCH), amd64)
 # the following predicate is abit misleading; it tests if we're not in centos.
 ifeq (,$(wildcard /etc/centos-release))
 EXTLDFLAGS  += -static
 endif
 GOTAGSLIST  += osusergo netgo static_build
 GOBUILDMODE := -buildmode pie
-endif
-ifeq ($(ARCH), $(filter $(ARCH), arm arm64))
-ifeq (,$(wildcard /etc/alpine-release))
-EXTLDFLAGS  += -static
-GOTAGSLIST  += osusergo netgo static_build
-GOBUILDMODE := -buildmode pie
-endif
-endif
 endif
 
 ifneq (, $(findstring MINGW,$(UNAME)))

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ endif
 GOTAGSLIST  += osusergo netgo static_build
 GOBUILDMODE := -buildmode pie
 endif
-ifeq ($(ARCH), arm)
-ifneq ("$(wildcard /etc/alpine-release)","")
+ifeq ($(ARCH), $(filter $(ARCH), arm arm64))
+ifeq (,$(wildcard /etc/alpine-release))
 EXTLDFLAGS  += -static
 GOTAGSLIST  += osusergo netgo static_build
 GOBUILDMODE := -buildmode pie

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ the [official Go documentation website](https://golang.org/doc/).
 
 ### Linux / OSX
 
-We currently strive to support Debian-based distributions with Ubuntu 22.04
+We currently strive to support Debian-based distributions with Ubuntu 20.04
 being our official release target.
 Building on Arch Linux works as well.
 Our core engineering team uses Linux and OSX, so both environments are well

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 ARG GOLANG_VERSION
 
 RUN apt-get update && apt-get install -y git wget sqlite3 autoconf build-essential shellcheck

--- a/docker/build/Dockerfile-deploy
+++ b/docker/build/Dockerfile-deploy
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ubuntu:22.04
+FROM --platform=linux/amd64 ubuntu:20.04
 ARG GOLANG_VERSION
 
 RUN apt-get update && apt-get install -y git wget sqlite3 autoconf jq bsdmainutils shellcheck

--- a/docker/build/aptly.Dockerfile
+++ b/docker/build/aptly.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 ARG ARCH=amd64
 ARG GOLANG_VERSION

--- a/docker/build/cicd.ubuntu.Dockerfile
+++ b/docker/build/cicd.ubuntu.Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH="amd64"
 
-FROM ${ARCH}/ubuntu:22.04
+FROM ${ARCH}/ubuntu:20.04
 ARG GOLANG_VERSION
 ARG ARCH="amd64"
 ARG GOARCH="amd64"

--- a/docker/build/docker.ubuntu.Dockerfile
+++ b/docker/build/docker.ubuntu.Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH="amd64"
 
-FROM ${ARCH}/ubuntu:22.04
+FROM ${ARCH}/ubuntu:20.04
 ARG GOLANG_VERSION
 ARG ARCH="amd64"
 RUN apt-get update && apt-get install curl python python3.7 python3-pip build-essential apt-transport-https ca-certificates software-properties-common -y && \

--- a/docker/build/releases-page.Dockerfile
+++ b/docker/build/releases-page.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install git python3 python3-pip -y && \

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -52,7 +52,7 @@ This section briefly describes the expected outcomes of the current build pipeli
 
     1. Build (compile) the binaries in a Centos 7 & 8 docker container that will then be used by both `deb` and `rpm` packaging.
 
-    1. Docker containers will package `deb` and `rpm` artifacts inside of Ubuntu 22.04 and Centos 7 & 8, respectively.
+    1. Docker containers will package `deb` and `rpm` artifacts inside of Ubuntu 20.04 and Centos 7 & 8, respectively.
 
     1. Jenkins will then pause to wait for [the only manual part of the build/package/test phase], which is to forward the `gpg-agent` that establishes a direct between the local machine that contains the signing keys and the remote ec2 instance.
 

--- a/scripts/release/common/docker/setup.Dockerfile
+++ b/scripts/release/common/docker/setup.Dockerfile
@@ -9,7 +9,7 @@
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=869194
 # https://github.com/boto/s3transfer/pull/102
 
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y jq git python python-pip python3-boto3 ssh && \
     pip install awscli


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

With dynamic libraries, building on older OSes would be supported, but not vice versa. As we were updating OSes, ARM64 builds started failing due to dynamic builds on newer platforms. I.e., if you built a binary on ubuntu. 22.04, it would not run on 20.04, due to lack of static linking in ARM64.

This fix does three things:

- Expand static builds outside of CentOS
- Revert build environments to 20.04
- Cherry-pick in the orb/container upgrade for CI

Ubuntu 22.04 showed some downstream incompatibilities when building RPMs, so is rolled back for now.

An additional change is to bump the required labels github action version, but this is separate from the above fixes.

## Test Plan

Built command line, to verify it would build a static binary.
