### PR TITLE
build: remove sqlite from release configurations

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 ARG GOLANG_VERSION
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt update && apt-get install -y git wget sqlite3 autoconf sudo tzdata bsdmainutils
+RUN apt update && apt-get install -y git wget autoconf sudo tzdata bsdmainutils
 
 WORKDIR /root
 RUN wget --quiet https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz && tar -xvf go${GOLANG_VERSION}.linux-amd64.tar.gz && mv go /usr/local

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 ARG GOLANG_VERSION
 
-RUN apt-get update && apt-get install -y git wget sqlite3 autoconf build-essential shellcheck
+RUN apt-get update && apt-get install -y git wget autoconf build-essential shellcheck
 WORKDIR /root
 RUN wget --quiet https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz && tar -xvf go${GOLANG_VERSION}.linux-amd64.tar.gz && mv go /usr/local
 ENV GOROOT=/usr/local/go \

--- a/docker/build/Dockerfile-deploy
+++ b/docker/build/Dockerfile-deploy
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 ubuntu:22.04
 ARG GOLANG_VERSION
 
-RUN apt-get update && apt-get install -y git wget sqlite3 autoconf jq bsdmainutils shellcheck
+RUN apt-get update && apt-get install -y git wget autoconf jq bsdmainutils shellcheck
 WORKDIR /root
 RUN wget --quiet https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz && tar -xvf go${GOLANG_VERSION}.linux-amd64.tar.gz && mv go /usr/local
 ENV GOROOT=/usr/local/go \

--- a/docker/build/cicd.alpine.Dockerfile
+++ b/docker/build/cicd.alpine.Dockerfile
@@ -13,8 +13,7 @@ RUN apk update && \
     apk add automake && \
     apk add fmt && \
     apk add build-base && \
-    apk add musl-dev && \
-    apk add sqlite
+    apk add musl-dev
 
 RUN apk add dpkg && \
     wget http://deb.debian.org/debian/pool/main/s/shellcheck/shellcheck_0.5.0-3_armhf.deb && \

--- a/docker/build/cicd.centos.Dockerfile
+++ b/docker/build/cicd.centos.Dockerfile
@@ -5,7 +5,7 @@ ARG GOLANG_VERSION
 ARG ARCH="amd64"
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     yum update -y && \
-    yum install -y autoconf wget awscli git gnupg2 nfs-utils python3-devel sqlite3 expect jq \
+    yum install -y autoconf wget awscli git gnupg2 nfs-utils python3-devel expect jq \
     libtool gcc-c++ libstdc++-devel libstdc++-static rpmdevtools createrepo rpm-sign bzip2 which ShellCheck \
     libffi-devel openssl-devel
 WORKDIR /root

--- a/docker/build/cicd.centos8.Dockerfile
+++ b/docker/build/cicd.centos8.Dockerfile
@@ -10,7 +10,6 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
     libffi-devel openssl-devel
 RUN dnf install -y epel-release && \
     dnf update && \
-    dnf -y install sqlite && \
     dnf -y --enablerepo=powertools install libstdc++-static && \
     dnf -y install make
 RUN echo "${BOLD}Downloading and installing binaries...${RESET}" && \

--- a/docker/build/cicd.ubuntu.Dockerfile
+++ b/docker/build/cicd.ubuntu.Dockerfile
@@ -5,7 +5,7 @@ ARG GOLANG_VERSION
 ARG ARCH="amd64"
 ARG GOARCH="amd64"
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y build-essential git wget sqlite3 autoconf jq bsdmainutils shellcheck awscli libtool
+RUN apt-get update && apt-get install -y build-essential git wget autoconf jq bsdmainutils shellcheck awscli libtool
 WORKDIR /root
 RUN wget https://dl.google.com/go/go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz \
     && tar -xvf go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz && \

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -73,12 +73,6 @@ check_deps() {
     then
         missing_dep shellcheck
     fi
-
-    # Don't print `sqlite3`s location.
-    if ! which sqlite3 > /dev/null
-    then
-        missing_dep sqlite3
-    fi
 }
 
 check_deps

--- a/scripts/release/common/docker/centos.Dockerfile
+++ b/scripts/release/common/docker/centos.Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 
 WORKDIR /root
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum install -y autoconf awscli curl git gnupg2 nfs-utils python36 sqlite3 expect jq libtool gcc-c++ libstdc++-devel libstdc++-static rpmdevtools createrepo rpm-sign bzip2 which ShellCheck
+RUN yum install -y autoconf awscli curl git gnupg2 nfs-utils python36 expect jq libtool gcc-c++ libstdc++-devel libstdc++-static rpmdevtools createrepo rpm-sign bzip2 which ShellCheck
 
 ENTRYPOINT ["/bin/bash"]
 

--- a/scripts/release/common/docker/centos8.Dockerfile
+++ b/scripts/release/common/docker/centos8.Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/centos/centos:stream8
 
 WORKDIR /root
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
-    dnf install -y autoconf awscli curl git gnupg2 nfs-utils python36 sqlite expect jq libtool gcc-c++ libstdc++-devel rpmdevtools createrepo rpm-sign bzip2 which && \
+    dnf install -y autoconf awscli curl git gnupg2 nfs-utils python36 expect jq libtool gcc-c++ libstdc++-devel rpmdevtools createrepo rpm-sign bzip2 which && \
     dnf -y --enablerepo=powertools install libstdc++-static
 
 RUN echo "${BOLD}Downloading and installing binaries...${RESET}" && \

--- a/scripts/release/common/setup.sh
+++ b/scripts/release/common/setup.sh
@@ -25,7 +25,7 @@ sudo apt-get upgrade -y
 # `apt-get` fails randomly when downloading package, this is a hack that "works" reasonably well.
 sudo apt-get update
 
-sudo apt-get install -y build-essential automake autoconf awscli docker.io git gpg nfs-common python python3 rpm sqlite3 python3-boto3 g++ libtool rng-tools
+sudo apt-get install -y build-essential automake autoconf awscli docker.io git gpg nfs-common python python3 rpm python3-boto3 g++ libtool rng-tools
 sudo rngd -r /dev/urandom
 
 #umask 0077


### PR DESCRIPTION
## Summary

I was just talking with @onetechnical about how our build containers install sqlite3 unnecessarily, since the go-sqlite3 package contains its own version-tracked distribution of sqlite's source code. The only reason we add it to scripts like configure_dev.sh is for usage in the CLI for development and debugging, but it is not a release or build-time dependency, so I am removing it in this PR.

## Test Plan

Existing tests and builds should succeed as before.