### PR TITLE
CICD: Update ubuntu circleci image and orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ orbs:
 parameters:
   ubuntu_image:
     type: string
-    default: "ubuntu-2204:2023.04.2"
+    default: "ubuntu-2004:2023.04.2"
   build_dir:
     type: string
     default: "/opt/cibuild"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,14 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.3.0
+  win: circleci/windows@5.0.0
   go: circleci/go@1.7.3
-  slack: circleci/slack@4.10.1
+  slack: circleci/slack@4.12.5
 
 parameters:
   ubuntu_image:
     type: string
-    default: "ubuntu-2004:202104-01"
+    default: "ubuntu-2204:2023.04.2"
   build_dir:
     type: string
     default: "/opt/cibuild"


### PR DESCRIPTION
## Summary

Update the build image and orbs in CircleCI. 

The update to the ubuntu image also will update the docker installation. This will fix the amd64_upload_binaries step in CircleCI's nightly_build_and_test workflow. We had observed failures in `apt-get update` in rel/beta and rel/nightly workflows recently (after #5529 ubuntu build upgrades) and we believe it is related to the docker version installed in the CircleCi ubuntu image.
- https://app.circleci.com/pipelines/github/algorand/go-algorand/15444/workflows/c38634af-054b-4a98-b938-3abdcd9022a2
- https://app.circleci.com/pipelines/github/algorand/go-algorand/15447/workflows/ea9fb152-1868-4e8a-bbf4-137bc1b529b5

## Test Plan

Tested on a separate workflow here (to run nightly): https://app.circleci.com/pipelines/github/algorand/go-algorand/15462/workflows/69d4fb53-eae2-428e-90ff-4d4d0b146299
