### PR TITLE
perf tests: use metrics for memory usage charts

### DIFF
--- a/shared/pingpong/pingpong.go
+++ b/shared/pingpong/pingpong.go
@@ -295,17 +295,19 @@ func (pps *WorkerState) scheduleAction() bool {
 		}
 		pps.refreshPos = 0
 	}
-	addr := pps.refreshAddrs[pps.refreshPos]
-	ai, err := pps.client.AccountInformation(addr, true)
-	if err == nil {
-		ppa := pps.accounts[addr]
+	if pps.cfg.NumApp > 0 || pps.cfg.NumAsset > 0 {
+		addr := pps.refreshAddrs[pps.refreshPos]
+		ai, err := pps.client.AccountInformation(addr, true)
+		if err == nil {
+			ppa := pps.accounts[addr]
 
-		pps.integrateAccountInfo(addr, ppa, ai)
-	} else {
-		if !pps.cfg.Quiet {
-			fmt.Printf("background refresh err: %v\n", err)
+			pps.integrateAccountInfo(addr, ppa, ai)
+		} else {
+			if !pps.cfg.Quiet {
+				fmt.Printf("background refresh err: %v\n", err)
+			}
+			return false
 		}
-		return false
 	}
 	pps.refreshPos++
 	return true

--- a/test/heapwatch/plot_crr_csv.py
+++ b/test/heapwatch/plot_crr_csv.py
@@ -71,15 +71,16 @@ def main():
                 for k,v in rec.items():
                     if k in _meta_cols:
                         continue
-                    if k in _metrics_cols:
-                        v = float(v)
-                        metric = k
-                        add_metric(fvals, row_nick, metric, xround, v)
-                    else:
-                        v = float(v)
+                    v = float(v)
+                    parts = k.split('#')
+                    if len(parts) == 2:
+                        row_nick = parts[0]
+                        metric = parts[1]
+                    else :
+                        print(f"unknown column {k}")
                         row_nick = k
-                        metric = 'inuse_space'
-                        add_metric(fvals, row_nick, metric, xround, v)
+                        metric = k
+                    add_metric(fvals, row_nick, metric, xround, v)
 
                     minv = smin(minv, v)
                     maxv = smax(maxv, v)

--- a/test/heapwatch/plot_crr_csv.py
+++ b/test/heapwatch/plot_crr_csv.py
@@ -6,8 +6,18 @@ import csv
 import random
 
 from matplotlib import pyplot as plt
+from matplotlib.ticker import MaxNLocator
 
 _meta_cols = {'when', 'dt', 'round'}
+_metrics_cols = {'free', 'inuse', 'released', 'total'}
+
+# see https://matplotlib.org/stable/gallery/lines_bars_and_markers/linestyles.html
+plt_line_styles = [
+    'solid', 'dotted', 'dashed', 'dashdot',
+    (5, (10, 3)), # long dash with offset
+    (0, (3, 5, 1, 5)), # dashdotted
+    (0, (3, 10, 1, 10, 1, 10)), # loosely dashdotted
+]
 
 def smin(a,b):
     if a is None:
@@ -21,6 +31,18 @@ def smax(a,b):
     if b is None:
         return a
     return max(a,b)
+
+def add_metric(d, k, m, x, y):
+    """d: {k: {m: [(x,y)]}}"""
+    mt = d.get(k)
+    if mt is None:
+        d[k] = {m: [(x,y)]}
+    else:
+        klist = mt.get(m)
+        if klist is None:
+            mt[m] = [(x,y)]
+        else:
+            klist.append((x, y))
 
 def main():
     import argparse
@@ -36,29 +58,40 @@ def main():
             reader = csv.DictReader(fin)
             for rec in reader:
                 xround = int(rec['round'])
+                row_nick = None
                 for k,v in rec.items():
                     if k in _meta_cols:
                         continue
-                    klist = fvals.get(k)
-                    if klist is None:
-                        klist = []
-                        fvals[k] = klist
-                    v = float(v)
-                    klist.append((xround, v))
+                    if k in _metrics_cols:
+                        v = float(v)
+                        metric = k
+                        add_metric(fvals, row_nick, metric, xround, v)
+                    else:
+                        v = float(v)
+                        row_nick = k
+                        metric = 'inuse_space'
+                        add_metric(fvals, row_nick, metric, xround, v)
+
                     minv = smin(minv, v)
                     maxv = smax(maxv, v)
         if not fvals:
             print(f"{fname} empty")
             continue
-        print("{} found series {}".format(fname, sorted(fvals.keys())))
+        nodes = sorted(fvals.keys())
+        print("{} found series {}".format(fname, nodes))
         fig, ax = plt.subplots()
+        ax.xaxis.set_major_locator(MaxNLocator(integer=True))
         ax.set_ylabel('bytes')
         ax.set_xlabel('round')
         ax.set_ylim(minv,maxv)
-        for k in sorted(fvals.keys()):
-            xy = fvals[k]
-            #for k, xy in fvals.items():
-            lc = None
+
+        max_val_color = max(map(len, nodes)) * ord('z')
+        for k in nodes:
+            lc = None  # let matplotlib to pick a color if there is no standard nodes name pattern => probably because of a single local run
+            if len(nodes) > 1:
+            # if there are multiple nodes choose some color based on the node name
+                s = sum(map(ord, k))
+                lc = (s/max_val_color, s/max_val_color, s/max_val_color)
             if k.startswith('r'):
                 # blueish
                 lc = (0.3*random.random(), 0.3*random.random(), 0.7+(0.3*random.random()))
@@ -68,7 +101,12 @@ def main():
             elif k.startswith('n'):
                 # reddish
                 lc = (0.7+(0.3*random.random()), 0.3*random.random(), 0.3*random.random())
-            ax.plot([p[0] for p in xy], [p[1] for p in xy], label=k, color=lc)
+
+            metrics = fvals[k]
+            for i, metric in enumerate(metrics.keys()):
+                xy = metrics[metric]
+
+                ax.plot([p[0] for p in xy], [p[1] for p in xy], label=f'{k}/{metric}', color=lc, linestyle=plt_line_styles[i%len(plt_line_styles)])
         ax.legend(loc='upper left', ncol=2)
         plt.savefig(fname + '.svg', format='svg')
         plt.savefig(fname + '.png', format='png')

--- a/test/heapwatch/plot_crr_csv.py
+++ b/test/heapwatch/plot_crr_csv.py
@@ -6,7 +6,7 @@ import csv
 import random
 
 from matplotlib import pyplot as plt
-from matplotlib.ticker import MaxNLocator
+from matplotlib.ticker import MaxNLocator, FuncFormatter
 
 _meta_cols = {'when', 'dt', 'round'}
 _metrics_cols = {'free', 'inuse', 'released', 'total'}
@@ -43,6 +43,15 @@ def add_metric(d, k, m, x, y):
             mt[m] = [(x,y)]
         else:
             klist.append((x, y))
+
+
+def format_mem(x, _):
+    if x<0:
+        return ""
+    for unit in ['bytes', 'KB', 'MB', 'GB']:
+        if x < 1024:
+            return "%3.1f %s" % (x, unit)
+        x /= 1024
 
 def main():
     import argparse
@@ -81,6 +90,7 @@ def main():
         print("{} found series {}".format(fname, nodes))
         fig, ax = plt.subplots()
         ax.xaxis.set_major_locator(MaxNLocator(integer=True))
+        ax.yaxis.set_major_formatter(FuncFormatter(format_mem))
         ax.set_ylabel('bytes')
         ax.set_xlabel('round')
         ax.set_ylim(minv,maxv)


### PR DESCRIPTION
## Summary

Current heapwatch tooling uses only pprof heap profile for memory usage charts and reports although there are runtime metrics collected and available.
1. client_ram_report.py uses both heap and metrics
2. plot_crr_csv.py renders charts using all the data from (1)
3. additionally excluded account lookups in pinpong for pure payment tests

## Test Plan

Tested locally, chart sample attached. The solid line is the old pprof data, all non-solid lines are new from runtime metrics.
![Primary heap2 csv](https://github.com/algorand/go-algorand/assets/65323360/5f462934-8d02-44c7-80dd-3a0ca5e52d54)

