### PR TITLE
test: TestAcctUpdatesLookupLatestCacheRetry Randomly fails

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1172,7 +1172,7 @@ func (au *accountUpdates) lookupLatest(addr basics.Address) (data basics.Account
 
 		if resourceDbRound < currentDbRound {
 			au.log.Errorf("accountUpdates.lookupLatest: resource database round %d is behind in-memory round %d", resourceDbRound, currentDbRound)
-			return basics.AccountData{}, basics.Round(0), basics.MicroAlgos{}, &StaleDatabaseRoundError{databaseRound: resourceDbRound, memoryRound: currentDbRound}
+			/*xxxxx*/ return basics.AccountData{}, basics.Round(0), basics.MicroAlgos{}, &StaleDatabaseRoundError{databaseRound: resourceDbRound, memoryRound: currentDbRound}
 		}
 
 	tryAgain:

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -2439,7 +2439,7 @@ func TestAcctUpdatesLookupLatestCacheRetry(t *testing.T) {
 	wg.Add(1)
 	done := make(chan struct{})
 	go func() {
-		ad, _, _, err = au.lookupLatest(addr1)
+		/*xxxxx*/ ad, _, _, err = au.lookupLatest(addr1)
 		close(done)
 		wg.Done()
 	}()


### PR DESCRIPTION
TestAcctUpdatesLookupLatestCacheRetry randomly fails.

Draft PR: indicating the cause of the failure with xxxx marker. to fix.  

repro:
`go test -run TestAcctUpdatesLookupLatestCacheRetry -count=20`
```
    acctupdates_test.go:2470:
        	Error Trace:	/Users/shantkarakashian/go/src/github.com/algorand/3/go-algorand/ledger/acctupdates_test.go:2470
        	Error:      	Received unexpected error:
        	            	database round 0 is behind in-memory round 2
        	Test:       	TestAcctUpdatesLookupLatestCacheRetry
```