### PR TITLE
scripts(configure_dev): conditional tap homebrew

### DIFF
--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -13,24 +13,30 @@ Options:
 
 FORCE=false
 while getopts ":sfh" opt; do
-  case ${opt} in
-    f ) FORCE=true
-      ;;
-    h ) echo "${HELP}"
+    case ${opt} in
+    f)
+        FORCE=true
+        ;;
+    h)
+        echo "${HELP}"
         exit 0
-      ;;
-    \? ) echo "${HELP}"
+        ;;
+    \?)
+        echo "${HELP}"
         exit 2
-      ;;
-  esac
+        ;;
+    esac
 done
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+SCRIPTPATH="$(
+    cd "$(dirname "$0")"
+    pwd -P
+)"
 
 OS=$("$SCRIPTPATH"/ostype.sh)
 
 function install_or_upgrade {
-    if ${FORCE} ; then
+    if ${FORCE}; then
         BREW_FORCE="-f"
     fi
     if brew ls --versions "$1" >/dev/null; then
@@ -43,30 +49,30 @@ function install_or_upgrade {
 function install_windows_shellcheck() {
     version="v0.7.1"
     if ! wget https://github.com/koalaman/shellcheck/releases/download/$version/shellcheck-$version.zip -O /tmp/shellcheck-$version.zip; then
-        rm /tmp/shellcheck-$version.zip &> /dev/null
+        rm /tmp/shellcheck-$version.zip &>/dev/null
         echo "Error downloading shellcheck $version"
         return 1
     fi
 
     if ! unzip -o /tmp/shellcheck-$version.zip shellcheck-$version.exe -d /tmp; then
-        rm /tmp/shellcheck-$version.zip &> /dev/null
+        rm /tmp/shellcheck-$version.zip &>/dev/null
         echo "Unable to decompress shellcheck $version"
         return 1
     fi
 
     if ! mv -f /tmp/shellcheck-$version.exe /usr/bin/shellcheck.exe; then
-        rm /tmp/shellcheck-$version.zip &> /dev/null
+        rm /tmp/shellcheck-$version.zip &>/dev/null
         echo "Unable to move shellcheck to /usr/bin"
         return 1
     fi
 
-    rm /tmp/shellcheck-$version.zip &> /dev/null
+    rm /tmp/shellcheck-$version.zip &>/dev/null
 
     return 0
 }
 
 if [ "${OS}" = "linux" ]; then
-    if ! which sudo > /dev/null; then
+    if ! which sudo >/dev/null; then
         "$SCRIPTPATH/install_linux_deps.sh"
     else
         sudo "$SCRIPTPATH/install_linux_deps.sh"
@@ -74,7 +80,9 @@ if [ "${OS}" = "linux" ]; then
 elif [ "${OS}" = "darwin" ]; then
     if [ "${CIRCLECI}" != "true" ]; then
         brew update
-        brew tap homebrew/cask
+        if [[ $(brew --version | cut -d' ' -f2) < "2.5.0" ]]; then
+            brew tap homebrew/cask
+        fi
     fi
     install_or_upgrade pkg-config
     install_or_upgrade libtool


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

In OSX, homebrew does not need to tap in versions above "2.5.0", so this PR adds a condition to check that before running `brew tap homebrew/cask` and does not proceed with tap for homebrew versions above "2.5.0"

## Test Plan
Tested on an old and new MacOS with homebrew versions above and below 2.5.0 and it does detect and work fine!
Dear reviewers, please inform me if there is a need to make a unit test using frameworks like bats or shunit2! But since it was just a small modification I humbly considered It would not be necessary!

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
