### PR TITLE
build: upgrade to go1.20.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -456,7 +456,7 @@ commands:
           shell: bash.exe
           command: |
             choco install -y msys2 pacman make wget --force
-            choco install -y golang --version=1.20.5 --force
+            choco install -y golang --version=1.20.6 --force
             choco install -y python3 --version=3.7.3 --force
             export msys2='cmd //C RefreshEnv.cmd '
             export msys2+='& set MSYS=winsymlinks:nativestrict '

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,7 +601,6 @@ commands:
             export PACKAGE_NAMES=$(echo $PACKAGES | tr -d '\n')
             export PARTITION_TOTAL=${CIRCLE_NODE_TOTAL}
             export PARTITION_ID=${CIRCLE_NODE_INDEX}
-            export GOEXPERIMENT="none"
             gotestsum --format standard-verbose --junitfile << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/results.xml --jsonfile << parameters.result_path >>/<< parameters.result_subdir >>/${CIRCLE_NODE_INDEX}/testresults.json -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" << parameters.short_test_flag >> -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 1 $PACKAGE_NAMES
       - store_artifacts:
           path: << parameters.result_path >>

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/cache@v3.3.1
         with:
           path: cicdtmp/golangci-lint/golangci-lint-cgo
-          key: cicd-golangci-lint-cgo-v0.0.2
+          key: cicd-golangci-lint-cgo-v0.0.2-${{ env.GO_VERSION }}
 
       - name: Build custom golangci-lint with CGO_ENABLED
         if: steps.cache-golangci-lint.outputs.cache-hit != 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04 as builder
 
-ARG GO_VERSION="1.20.5"
+ARG GO_VERSION="1.20.6"
 
 ARG CHANNEL
 ARG URL

--- a/Makefile
+++ b/Makefile
@@ -77,11 +77,6 @@ ifeq ($(SHORT_PART_PERIOD), 1)
 export SHORT_PART_PERIOD_FLAG := -s
 endif
 
-# Disable go experiments during build as of go 1.20.5 due to
-# https://github.com/golang/go/issues/60825
-# Likely fix: https://go-review.googlesource.com/c/go/+/503937/6/src/runtime/race_arm64.s
-export GOEXPERIMENT=none
-
 GOTAGS      := --tags "$(GOTAGSLIST)"
 GOTRIMPATH	:= $(shell GOPATH=$(GOPATH) && go help build | grep -q .-trimpath && echo -trimpath)
 

--- a/scripts/get_golang_version.sh
+++ b/scripts/get_golang_version.sh
@@ -11,7 +11,7 @@
 # Our build task-runner `mule` will refer to this script and will automatically
 # build a new image whenever the version number has been changed.
 
-BUILD=1.20.5
+BUILD=1.20.6
  MIN=1.20
  GO_MOD_SUPPORT=1.20
 


### PR DESCRIPTION
## Summary

1. use go1.20.6
2. revert go-expermiments disabling

## Test Plan

Local runs showed no perf difference.