### PR TITLE
ledger: move MakeCatchpointReader back to the Reader interface

### DIFF
--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -1126,7 +1126,7 @@ func (ct *catchpointTracker) generateCatchpointData(ctx context.Context, account
 
 	start := time.Now()
 	ledgerGeneratecatchpointCount.Inc(nil)
-	err = ct.dbs.TransactionContext(ctx, func(dbCtx context.Context, tx trackerdb.TransactionScope) (err error) {
+	err = ct.dbs.SnapshotContext(ctx, func(dbCtx context.Context, tx trackerdb.SnapshotScope) (err error) {
 		catchpointWriter, err = makeCatchpointWriter(dbCtx, catchpointDataFilePath, tx, ResourcesPerCatchpointFileChunk)
 		if err != nil {
 			return

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -1316,7 +1316,7 @@ func (ct *catchpointTracker) GetCatchpointStream(round basics.Round) (ReadCloseS
 	ledgerGetcatchpointCount.Inc(nil)
 	// TODO: we need to generalize this, check @cce PoC PR, he has something
 	//       somewhat broken for some KVs..
-	err := ct.dbs.Transaction(func(ctx context.Context, tx trackerdb.TransactionScope) (err error) {
+	err := ct.dbs.Snapshot(func(ctx context.Context, tx trackerdb.SnapshotScope) (err error) {
 		cr, err := tx.MakeCatchpointReader()
 		if err != nil {
 			return err

--- a/ledger/catchpointwriter.go
+++ b/ledger/catchpointwriter.go
@@ -53,7 +53,7 @@ const (
 // has the option of throttling the CPU utilization in between the calls.
 type catchpointWriter struct {
 	ctx                  context.Context
-	tx                   trackerdb.TransactionScope
+	tx                   trackerdb.SnapshotScope
 	filePath             string
 	totalAccounts        uint64
 	totalKVs             uint64
@@ -107,7 +107,7 @@ func (data catchpointStateProofVerificationContext) ToBeHashed() (protocol.HashI
 	return protocol.StateProofVerCtx, protocol.Encode(&data)
 }
 
-func makeCatchpointWriter(ctx context.Context, filePath string, tx trackerdb.TransactionScope, maxResourcesPerChunk int) (*catchpointWriter, error) {
+func makeCatchpointWriter(ctx context.Context, filePath string, tx trackerdb.SnapshotScope, maxResourcesPerChunk int) (*catchpointWriter, error) {
 	aw, err := tx.MakeAccountsReader()
 	if err != nil {
 		return nil, err

--- a/ledger/store/trackerdb/sqlitedriver/catchpoint.go
+++ b/ledger/store/trackerdb/sqlitedriver/catchpoint.go
@@ -52,6 +52,10 @@ func NewCatchpointSQLReaderWriter(e db.Executable) *catchpointReaderWriter {
 	}
 }
 
+func makeCatchpointReader(e db.Queryable) trackerdb.CatchpointReader {
+	return &catchpointReader{q: e}
+}
+
 func (cr *catchpointReader) GetCatchpoint(ctx context.Context, round basics.Round) (fileName string, catchpoint string, fileSize int64, err error) {
 	err = cr.q.QueryRowContext(ctx, "SELECT filename, catchpoint, filesize FROM storedcatchpoints WHERE round=?", int64(round)).Scan(&fileName, &catchpoint, &fileSize)
 	return

--- a/ledger/store/trackerdb/sqlitedriver/sqlitedriver.go
+++ b/ledger/store/trackerdb/sqlitedriver/sqlitedriver.go
@@ -183,6 +183,11 @@ func (r *sqlReader) MakeCatchpointPendingHashesIterator(hashCount int) trackerdb
 	return MakeCatchpointPendingHashesIterator(hashCount, r.q)
 }
 
+// MakeCatchpointReader implements trackerdb.Reader
+func (r *sqlReader) MakeCatchpointReader() (trackerdb.CatchpointReader, error) {
+	return makeCatchpointReader(r.q), nil
+}
+
 type sqlWriter struct {
 	e db.Executable
 }
@@ -234,11 +239,6 @@ func (w *sqlWriter) ModifyAcctBaseTest() error {
 
 type sqlCatchpoint struct {
 	e db.Executable
-}
-
-// MakeCatchpointReader implements trackerdb.Catchpoint
-func (c *sqlCatchpoint) MakeCatchpointReader() (trackerdb.CatchpointReader, error) {
-	return NewCatchpointSQLReaderWriter(c.e), nil
 }
 
 // MakeCatchpointReaderWriter implements trackerdb.Catchpoint

--- a/ledger/store/trackerdb/store.go
+++ b/ledger/store/trackerdb/store.go
@@ -59,6 +59,8 @@ type Reader interface {
 	// catchpoint
 	// Note: BuildMerkleTrie() needs this on the reader handle in sqlite to not get locked by write txns
 	MakeCatchpointPendingHashesIterator(hashCount int) CatchpointPendingHashesIter
+	// Note: Catchpoint tracker needs this on the reader handle in sqlite to not get locked by write txns
+	MakeCatchpointReader() (CatchpointReader, error)
 }
 
 // Writer is the interface for the trackerdb write operations.
@@ -82,7 +84,6 @@ type Writer interface {
 //	we should split these two sets of methods into two separate interfaces
 type Catchpoint interface {
 	// reader
-	MakeCatchpointReader() (CatchpointReader, error)
 	MakeOrderedAccountsIter(accountCount int) OrderedAccountsIter
 	MakeKVsIter(ctx context.Context) (KVsIter, error)
 	MakeEncodedAccoutsBatchIter() EncodedAccountsBatchIter

--- a/ledger/store/trackerdb/store.go
+++ b/ledger/store/trackerdb/store.go
@@ -61,6 +61,8 @@ type Reader interface {
 	MakeCatchpointPendingHashesIterator(hashCount int) CatchpointPendingHashesIter
 	// Note: Catchpoint tracker needs this on the reader handle in sqlite to not get locked by write txns
 	MakeCatchpointReader() (CatchpointReader, error)
+	MakeEncodedAccoutsBatchIter() EncodedAccountsBatchIter
+	MakeKVsIter(ctx context.Context) (KVsIter, error)
 }
 
 // Writer is the interface for the trackerdb write operations.
@@ -85,8 +87,6 @@ type Writer interface {
 type Catchpoint interface {
 	// reader
 	MakeOrderedAccountsIter(accountCount int) OrderedAccountsIter
-	MakeKVsIter(ctx context.Context) (KVsIter, error)
-	MakeEncodedAccoutsBatchIter() EncodedAccountsBatchIter
 	// writer
 	MakeCatchpointWriter() (CatchpointWriter, error)
 	// reader/writer
@@ -123,6 +123,7 @@ type Batch interface {
 // SnapshotScope is an atomic read-only scope to the store.
 type SnapshotScope interface {
 	Reader
+	ResetTransactionWarnDeadline(ctx context.Context, deadline time.Time) (prevDeadline time.Time, err error)
 }
 
 // Snapshot is an atomic read-only accecssor to the store.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

#5451 introduced a bug, catchpoint reads need to be kept on a separate readonly connection for the node to make forward progress.

This PR adds the required method to the Reader interface for the store, so it becomes available via the Snapshot scope.
There is an implicit contract that the snapshot is going through a separate read-only handle to the sqlite db.
If this were ever to change, this will break again.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
