### PR TITLE
goal: support simulate scratch in exec trace

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -75,6 +75,7 @@ var (
 	simulateExtraOpcodeBudget     uint64
 	simulateEnableRequestTrace    bool
 	simulateStackChange           bool
+	simulateScratchChange         bool
 )
 
 func init() {
@@ -165,6 +166,7 @@ func init() {
 	simulateCmd.Flags().Uint64Var(&simulateExtraOpcodeBudget, "extra-opcode-budget", 0, "Apply extra opcode budget for apps per transaction group during simulation")
 	simulateCmd.Flags().BoolVar(&simulateEnableRequestTrace, "trace", false, "Enable simulation time execution trace of app calls")
 	simulateCmd.Flags().BoolVar(&simulateStackChange, "stack", false, "Report stack change during simulation time")
+	simulateCmd.Flags().BoolVar(&simulateScratchChange, "scratch", false, "Report scratch change during simulation time")
 }
 
 var clerkCmd = &cobra.Command{
@@ -1367,7 +1369,8 @@ func decodeTxnsFromFile(file string) []transactions.SignedTxn {
 
 func traceCmdOptionToSimulateTraceConfigModel() simulation.ExecTraceConfig {
 	return simulation.ExecTraceConfig{
-		Enable: simulateEnableRequestTrace,
-		Stack:  simulateStackChange,
+		Enable:  simulateEnableRequestTrace,
+		Stack:   simulateStackChange,
+		Scratch: simulateScratchChange,
 	}
 }

--- a/test/scripts/e2e_client_runner.py
+++ b/test/scripts/e2e_client_runner.py
@@ -449,7 +449,7 @@ def main():
     nodeDataDir = os.path.join(netdir, 'Node')
     primaryDataDir = os.path.join(netdir, 'Primary')
 
-    # Set EnableSimulationUnlimitedResourceAccess to true for both nodes
+    # Set EnableDeveloperAPI to true for both nodes
     for dataDir in (nodeDataDir, primaryDataDir):
         configFile = os.path.join(dataDir, 'config.json')
         with open(configFile, 'r') as f:

--- a/test/scripts/e2e_client_runner.py
+++ b/test/scripts/e2e_client_runner.py
@@ -446,11 +446,25 @@ def main():
     retcode = 0
     capv = args.version.capitalize()
     xrun(['goal', 'network', 'create', '-r', netdir, '-n', 'tbd', '-t', os.path.join(repodir, f'test/testdata/nettemplates/TwoNodes50Each{capv}.json')], timeout=90)
+    nodeDataDir = os.path.join(netdir, 'Node')
+    primaryDataDir = os.path.join(netdir, 'Primary')
+
+    # Set EnableSimulationUnlimitedResourceAccess to true for both nodes
+    for dataDir in (nodeDataDir, primaryDataDir):
+        configFile = os.path.join(dataDir, 'config.json')
+        with open(configFile, 'r') as f:
+            configOptions = json.load(f)
+
+        configOptions['EnableDeveloperAPI'] = True
+
+        with open(configFile, 'w') as f:
+            json.dump(configOptions, f)
+
     xrun(['goal', 'network', 'start', '-r', netdir], timeout=90)
     atexit.register(goal_network_stop, netdir, env)
 
-    env['ALGORAND_DATA'] = os.path.join(netdir, 'Node')
-    env['ALGORAND_DATA2'] = os.path.join(netdir, 'Primary')
+    env['ALGORAND_DATA'] = nodeDataDir
+    env['ALGORAND_DATA2'] = primaryDataDir
 
     if args.unsafe_scrypt:
         create_kmd_config_with_unsafe_scrypt(env['ALGORAND_DATA'])

--- a/test/scripts/e2e_subs/tealprogs/stack-scratch.teal
+++ b/test/scripts/e2e_subs/tealprogs/stack-scratch.teal
@@ -1,0 +1,45 @@
+#pragma version 8
+txn ApplicationID      // on creation, always approve
+bz end
+
+txn NumAppArgs
+int 1
+==
+assert
+
+txn ApplicationArgs 0
+btoi
+callsub subroutine_manipulating_stack
+itob
+log
+b end
+
+subroutine_manipulating_stack:
+  proto 1 1
+  int 0                                   // [0]
+  dup                                     // [0, 0]
+  dupn 4                                  // [0, 0, 0, 0, 0, 0]
+  frame_dig -1                            // [0, 0, 0, 0, 0, 0, arg_0]
+  frame_bury 0                            // [arg_0, 0, 0, 0, 0, 0]
+  dig 5                                   // [arg_0, 0, 0, 0, 0, 0, arg_0]
+  cover 5                                 // [arg_0, arg_0, 0, 0, 0, 0, 0]
+  frame_dig 0                             // [arg_0, arg_0, 0, 0, 0, 0, 0, arg_0]
+  frame_dig 1                             // [arg_0, arg_0, 0, 0, 0, 0, 0, arg_0, arg_0]
+  +                                       // [arg_0, arg_0, 0, 0, 0, 0, 0, arg_0 * 2]
+  bury 7                                  // [arg_0 * 2, arg_0, 0, 0, 0, 0, 0]
+  popn 5                                  // [arg_0 * 2, arg_0]
+  uncover 1                               // [arg_0, arg_0 * 2]
+  swap                                    // [arg_0 * 2, arg_0]
+  +                                       // [arg_0 * 3]
+  pushbytess "1!" "5!"                    // [arg_0 * 3, "1!", "5!"]
+  pushints 0 2 1 1 5 18446744073709551615 // [arg_0 * 3, "1!", "5!", 0, 2, 1, 1, 5, 18446744073709551615]
+  store 1                                 // [arg_0 * 3, "1!", "5!", 0, 2, 1, 1, 5]
+  load 1                                  // [arg_0 * 3, "1!", "5!", 0, 2, 1, 1, 5, 18446744073709551615]
+  stores                                  // [arg_0 * 3, "1!", "5!", 0, 2, 1, 1]
+  load 1                                  // [arg_0 * 3, "1!", "5!", 0, 2, 1, 1, 18446744073709551615]
+  store 1                                 // [arg_0 * 3, "1!", "5!", 0, 2, 1, 1]
+  retsub
+
+end:
+  int 1
+  return


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

#5563 forgot to add support for goal to return scratch slot changes in exec trace, this is an enhancement.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

e2e script test for goal to return stack and scratch changes in exec trace.
