### PR TITLE
catchpoint: use read connection for data retrieval for spver hash calculation

### DIFF
--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -202,7 +202,7 @@ func (ct *catchpointTracker) GetLastCatchpointLabel() string {
 }
 
 func (ct *catchpointTracker) getSPVerificationData() (encodedData []byte, spVerificationHash crypto.Digest, err error) {
-	err = ct.dbs.Transaction(func(ctx context.Context, tx trackerdb.TransactionScope) error {
+	err = ct.dbs.Snapshot(func(ctx context.Context, tx trackerdb.SnapshotScope) error {
 		rawData, dbErr := tx.MakeSpVerificationCtxReader().GetAllSPContexts(ctx)
 		if dbErr != nil {
 			return dbErr


### PR DESCRIPTION
## Summary

#5579 was merged a few minutes before I had a chance to push this commit to address @AlgoAxel's PR feedback in https://github.com/algorand/go-algorand/pull/5579#discussion_r1269790619 about using read vs write scopes for getting the SP verification context. This is that change

## Test Plan

Existing tests should pass.