### PR TITLE
chore: use ++ instead of +=

### DIFF
--- a/tools/block-generator/generator/generate.go
+++ b/tools/block-generator/generator/generate.go
@@ -793,7 +793,7 @@ func track(id TxTypeID) (TxTypeID, time.Time) {
 func (g *generator) recordData(id TxTypeID, start time.Time) {
 	g.latestData[id]++
 	data := g.reportData[id]
-	data.GenerationCount += 1
+	data.GenerationCount++
 	data.GenerationTime += time.Since(start)
 	g.reportData[id] = data
 }

--- a/tools/block-generator/generator/generate_test.go
+++ b/tools/block-generator/generator/generate_test.go
@@ -359,7 +359,7 @@ func TestAppBoxesOptin(t *testing.T) {
 	g.finishRound()
 	// 2nd attempt to optin (with new sender) doesn't get replaced
 	g.startRound()
-	intra += 1
+	intra++
 	hint.sender = 8
 
 	actual, sgnTxns, appID, err = g.generateAppCallInternal(appBoxesOptin, round, intra, &hint)


### PR DESCRIPTION
## Summary
I used `++` instead of `=+` 
they do the same thing but the `++` is more readable and more properly