### PR TITLE
msgp: Add canonical validation to msgp unmarshalling

### DIFF
--- a/agreement/msgp_gen.go
+++ b/agreement/msgp_gen.go
@@ -20,6 +20,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -29,6 +30,7 @@ import (
 //           |-----> (*) MarshalMsg
 //           |-----> (*) CanMarshalMsg
 //           |-----> (*) UnmarshalMsg
+//           |-----> (*) UnmarshalValidateMsg
 //           |-----> (*) CanUnmarshalMsg
 //           |-----> (*) Msgsize
 //           |-----> (*) MsgIsZero
@@ -38,6 +40,7 @@ import (
 //      |-----> MarshalMsg
 //      |-----> CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> Msgsize
 //      |-----> MsgIsZero
@@ -47,6 +50,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -56,6 +60,7 @@ import (
 //    |-----> (*) MarshalMsg
 //    |-----> (*) CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> (*) Msgsize
 //    |-----> (*) MsgIsZero
@@ -65,6 +70,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -74,6 +80,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -83,6 +90,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -92,6 +100,7 @@ import (
 //               |-----> (*) MarshalMsg
 //               |-----> (*) CanMarshalMsg
 //               |-----> (*) UnmarshalMsg
+//               |-----> (*) UnmarshalValidateMsg
 //               |-----> (*) CanUnmarshalMsg
 //               |-----> (*) Msgsize
 //               |-----> (*) MsgIsZero
@@ -101,6 +110,7 @@ import (
 //     |-----> MarshalMsg
 //     |-----> CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> Msgsize
 //     |-----> MsgIsZero
@@ -110,6 +120,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -119,6 +130,7 @@ import (
 //    |-----> (*) MarshalMsg
 //    |-----> (*) CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> (*) Msgsize
 //    |-----> (*) MsgIsZero
@@ -128,6 +140,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -137,6 +150,7 @@ import (
 //             |-----> (*) MarshalMsg
 //             |-----> (*) CanMarshalMsg
 //             |-----> (*) UnmarshalMsg
+//             |-----> (*) UnmarshalValidateMsg
 //             |-----> (*) CanUnmarshalMsg
 //             |-----> (*) Msgsize
 //             |-----> (*) MsgIsZero
@@ -146,6 +160,7 @@ import (
 //    |-----> MarshalMsg
 //    |-----> CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> Msgsize
 //    |-----> MsgIsZero
@@ -155,6 +170,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -164,6 +180,7 @@ import (
 //    |-----> (*) MarshalMsg
 //    |-----> (*) CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> (*) Msgsize
 //    |-----> (*) MsgIsZero
@@ -173,6 +190,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -182,6 +200,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -191,6 +210,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -200,6 +220,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -209,6 +230,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -218,6 +240,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -227,6 +250,7 @@ import (
 //            |-----> (*) MarshalMsg
 //            |-----> (*) CanMarshalMsg
 //            |-----> (*) UnmarshalMsg
+//            |-----> (*) UnmarshalValidateMsg
 //            |-----> (*) CanUnmarshalMsg
 //            |-----> (*) Msgsize
 //            |-----> (*) MsgIsZero
@@ -236,6 +260,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -245,6 +270,7 @@ import (
 //          |-----> (*) MarshalMsg
 //          |-----> (*) CanMarshalMsg
 //          |-----> (*) UnmarshalMsg
+//          |-----> (*) UnmarshalValidateMsg
 //          |-----> (*) CanUnmarshalMsg
 //          |-----> (*) Msgsize
 //          |-----> (*) MsgIsZero
@@ -254,6 +280,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -263,6 +290,7 @@ import (
 //    |-----> (*) MarshalMsg
 //    |-----> (*) CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> (*) Msgsize
 //    |-----> (*) MsgIsZero
@@ -272,6 +300,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -281,6 +310,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -290,6 +320,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -299,6 +330,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -308,6 +340,7 @@ import (
 //         |-----> MarshalMsg
 //         |-----> CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> Msgsize
 //         |-----> MsgIsZero
@@ -317,6 +350,7 @@ import (
 //   |-----> MarshalMsg
 //   |-----> CanMarshalMsg
 //   |-----> (*) UnmarshalMsg
+//   |-----> (*) UnmarshalValidateMsg
 //   |-----> (*) CanUnmarshalMsg
 //   |-----> Msgsize
 //   |-----> MsgIsZero
@@ -326,6 +360,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -335,6 +370,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -344,6 +380,7 @@ import (
 //          |-----> (*) MarshalMsg
 //          |-----> (*) CanMarshalMsg
 //          |-----> (*) UnmarshalMsg
+//          |-----> (*) UnmarshalValidateMsg
 //          |-----> (*) CanUnmarshalMsg
 //          |-----> (*) Msgsize
 //          |-----> (*) MsgIsZero
@@ -353,6 +390,7 @@ import (
 //           |-----> (*) MarshalMsg
 //           |-----> (*) CanMarshalMsg
 //           |-----> (*) UnmarshalMsg
+//           |-----> (*) UnmarshalValidateMsg
 //           |-----> (*) CanUnmarshalMsg
 //           |-----> (*) Msgsize
 //           |-----> (*) MsgIsZero
@@ -362,6 +400,7 @@ import (
 //                |-----> (*) MarshalMsg
 //                |-----> (*) CanMarshalMsg
 //                |-----> (*) UnmarshalMsg
+//                |-----> (*) UnmarshalValidateMsg
 //                |-----> (*) CanUnmarshalMsg
 //                |-----> (*) Msgsize
 //                |-----> (*) MsgIsZero
@@ -371,6 +410,7 @@ import (
 //            |-----> (*) MarshalMsg
 //            |-----> (*) CanMarshalMsg
 //            |-----> (*) UnmarshalMsg
+//            |-----> (*) UnmarshalValidateMsg
 //            |-----> (*) CanUnmarshalMsg
 //            |-----> (*) Msgsize
 //            |-----> (*) MsgIsZero
@@ -380,6 +420,7 @@ import (
 //          |-----> (*) MarshalMsg
 //          |-----> (*) CanMarshalMsg
 //          |-----> (*) UnmarshalMsg
+//          |-----> (*) UnmarshalValidateMsg
 //          |-----> (*) CanUnmarshalMsg
 //          |-----> (*) Msgsize
 //          |-----> (*) MsgIsZero
@@ -389,6 +430,7 @@ import (
 //   |-----> (*) MarshalMsg
 //   |-----> (*) CanMarshalMsg
 //   |-----> (*) UnmarshalMsg
+//   |-----> (*) UnmarshalValidateMsg
 //   |-----> (*) CanUnmarshalMsg
 //   |-----> (*) Msgsize
 //   |-----> (*) MsgIsZero
@@ -398,6 +440,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -407,6 +450,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -416,6 +460,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -425,6 +470,7 @@ import (
 //          |-----> (*) MarshalMsg
 //          |-----> (*) CanMarshalMsg
 //          |-----> (*) UnmarshalMsg
+//          |-----> (*) UnmarshalValidateMsg
 //          |-----> (*) CanUnmarshalMsg
 //          |-----> (*) Msgsize
 //          |-----> (*) MsgIsZero
@@ -434,6 +480,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -443,6 +490,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -536,16 +584,24 @@ func (_ *Certificate) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Certificate) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Certificate) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -559,25 +615,25 @@ func (z *Certificate) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		if zb0003 > 0 {
 			zb0003--
 			{
-				var zb0005 uint64
-				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0007 uint64
+				zb0007, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Period")
 					return
 				}
-				(*z).Period = period(zb0005)
+				(*z).Period = period(zb0007)
 			}
 		}
 		if zb0003 > 0 {
 			zb0003--
 			{
-				var zb0006 uint64
-				zb0006, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0008 uint64
+				zb0008, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Step")
 					return
 				}
-				(*z).Step = step(zb0006)
+				(*z).Step = step(zb0008)
 			}
 		}
 		if zb0003 > 0 {
@@ -590,24 +646,24 @@ func (z *Certificate) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0007 int
-			var zb0008 bool
-			zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0009 int
+			var zb0010 bool
+			zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Votes")
 				return
 			}
-			if zb0007 > config.MaxVoteThreshold {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxVoteThreshold))
+			if zb0009 > config.MaxVoteThreshold {
+				err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxVoteThreshold))
 				err = msgp.WrapError(err, "struct-from-array", "Votes")
 				return
 			}
-			if zb0008 {
+			if zb0010 {
 				(*z).Votes = nil
-			} else if (*z).Votes != nil && cap((*z).Votes) >= zb0007 {
-				(*z).Votes = ((*z).Votes)[:zb0007]
+			} else if (*z).Votes != nil && cap((*z).Votes) >= zb0009 {
+				(*z).Votes = ((*z).Votes)[:zb0009]
 			} else {
-				(*z).Votes = make([]voteAuthenticator, zb0007)
+				(*z).Votes = make([]voteAuthenticator, zb0009)
 			}
 			for zb0001 := range (*z).Votes {
 				bts, err = (*z).Votes[zb0001].UnmarshalMsg(bts)
@@ -619,24 +675,24 @@ func (z *Certificate) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0009 int
-			var zb0010 bool
-			zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0011 int
+			var zb0012 bool
+			zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "EquivocationVotes")
 				return
 			}
-			if zb0009 > config.MaxVoteThreshold {
-				err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxVoteThreshold))
+			if zb0011 > config.MaxVoteThreshold {
+				err = msgp.ErrOverflow(uint64(zb0011), uint64(config.MaxVoteThreshold))
 				err = msgp.WrapError(err, "struct-from-array", "EquivocationVotes")
 				return
 			}
-			if zb0010 {
+			if zb0012 {
 				(*z).EquivocationVotes = nil
-			} else if (*z).EquivocationVotes != nil && cap((*z).EquivocationVotes) >= zb0009 {
-				(*z).EquivocationVotes = ((*z).EquivocationVotes)[:zb0009]
+			} else if (*z).EquivocationVotes != nil && cap((*z).EquivocationVotes) >= zb0011 {
+				(*z).EquivocationVotes = ((*z).EquivocationVotes)[:zb0011]
 			} else {
-				(*z).EquivocationVotes = make([]equivocationVoteAuthenticator, zb0009)
+				(*z).EquivocationVotes = make([]equivocationVoteAuthenticator, zb0011)
 			}
 			for zb0002 := range (*z).EquivocationVotes {
 				bts, err = (*z).EquivocationVotes[zb0002].UnmarshalMsg(bts)
@@ -670,56 +726,80 @@ func (z *Certificate) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "rnd":
+				if validate && zb0006 && "rnd" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Round.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0005 = "rnd"
 			case "per":
+				if validate && zb0006 && "per" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0011 uint64
-					zb0011, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0013 uint64
+					zb0013, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Period")
 						return
 					}
-					(*z).Period = period(zb0011)
+					(*z).Period = period(zb0013)
 				}
+				zb0005 = "per"
 			case "step":
+				if validate && zb0006 && "step" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0012 uint64
-					zb0012, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0014 uint64
+					zb0014, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Step")
 						return
 					}
-					(*z).Step = step(zb0012)
+					(*z).Step = step(zb0014)
 				}
+				zb0005 = "step"
 			case "prop":
+				if validate && zb0006 && "prop" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Proposal.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Proposal")
 					return
 				}
+				zb0005 = "prop"
 			case "vote":
-				var zb0013 int
-				var zb0014 bool
-				zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "vote" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0015 int
+				var zb0016 bool
+				zb0015, zb0016, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Votes")
 					return
 				}
-				if zb0013 > config.MaxVoteThreshold {
-					err = msgp.ErrOverflow(uint64(zb0013), uint64(config.MaxVoteThreshold))
+				if zb0015 > config.MaxVoteThreshold {
+					err = msgp.ErrOverflow(uint64(zb0015), uint64(config.MaxVoteThreshold))
 					err = msgp.WrapError(err, "Votes")
 					return
 				}
-				if zb0014 {
+				if zb0016 {
 					(*z).Votes = nil
-				} else if (*z).Votes != nil && cap((*z).Votes) >= zb0013 {
-					(*z).Votes = ((*z).Votes)[:zb0013]
+				} else if (*z).Votes != nil && cap((*z).Votes) >= zb0015 {
+					(*z).Votes = ((*z).Votes)[:zb0015]
 				} else {
-					(*z).Votes = make([]voteAuthenticator, zb0013)
+					(*z).Votes = make([]voteAuthenticator, zb0015)
 				}
 				for zb0001 := range (*z).Votes {
 					bts, err = (*z).Votes[zb0001].UnmarshalMsg(bts)
@@ -728,25 +808,30 @@ func (z *Certificate) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0005 = "vote"
 			case "eqv":
-				var zb0015 int
-				var zb0016 bool
-				zb0015, zb0016, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "eqv" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0017 int
+				var zb0018 bool
+				zb0017, zb0018, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "EquivocationVotes")
 					return
 				}
-				if zb0015 > config.MaxVoteThreshold {
-					err = msgp.ErrOverflow(uint64(zb0015), uint64(config.MaxVoteThreshold))
+				if zb0017 > config.MaxVoteThreshold {
+					err = msgp.ErrOverflow(uint64(zb0017), uint64(config.MaxVoteThreshold))
 					err = msgp.WrapError(err, "EquivocationVotes")
 					return
 				}
-				if zb0016 {
+				if zb0018 {
 					(*z).EquivocationVotes = nil
-				} else if (*z).EquivocationVotes != nil && cap((*z).EquivocationVotes) >= zb0015 {
-					(*z).EquivocationVotes = ((*z).EquivocationVotes)[:zb0015]
+				} else if (*z).EquivocationVotes != nil && cap((*z).EquivocationVotes) >= zb0017 {
+					(*z).EquivocationVotes = ((*z).EquivocationVotes)[:zb0017]
 				} else {
-					(*z).EquivocationVotes = make([]equivocationVoteAuthenticator, zb0015)
+					(*z).EquivocationVotes = make([]equivocationVoteAuthenticator, zb0017)
 				}
 				for zb0002 := range (*z).EquivocationVotes {
 					bts, err = (*z).EquivocationVotes[zb0002].UnmarshalMsg(bts)
@@ -755,6 +840,7 @@ func (z *Certificate) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0005 = "eqv"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -762,12 +848,19 @@ func (z *Certificate) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *Certificate) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Certificate) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Certificate) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Certificate)
 	return ok
@@ -825,16 +918,24 @@ func (_ *ConsensusVersionView) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *ConsensusVersionView) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *ConsensusVersionView) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -850,13 +951,13 @@ func (z *ConsensusVersionView) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					(*z).Err = new(serializableError)
 				}
 				{
-					var zb0003 string
-					zb0003, bts, err = msgp.ReadStringBytes(bts)
+					var zb0005 string
+					zb0005, bts, err = msgp.ReadStringBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Err")
 						return
 					}
-					*(*z).Err = serializableError(zb0003)
+					*(*z).Err = serializableError(zb0005)
 				}
 			}
 		}
@@ -892,6 +993,10 @@ func (z *ConsensusVersionView) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "Err":
+				if validate && zb0004 && "Err" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
@@ -903,21 +1008,27 @@ func (z *ConsensusVersionView) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						(*z).Err = new(serializableError)
 					}
 					{
-						var zb0004 string
-						zb0004, bts, err = msgp.ReadStringBytes(bts)
+						var zb0006 string
+						zb0006, bts, err = msgp.ReadStringBytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Err")
 							return
 						}
-						*(*z).Err = serializableError(zb0004)
+						*(*z).Err = serializableError(zb0006)
 					}
 				}
+				zb0003 = "Err"
 			case "Version":
+				if validate && zb0004 && "Version" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Version.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Version")
 					return
 				}
+				zb0003 = "Version"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -925,12 +1036,19 @@ func (z *ConsensusVersionView) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *ConsensusVersionView) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *ConsensusVersionView) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *ConsensusVersionView) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*ConsensusVersionView)
 	return ok
@@ -977,7 +1095,7 @@ func (_ actionType) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *actionType) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *actionType) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 uint8
 		zb0001, bts, err = msgp.ReadUint8Bytes(bts)
@@ -991,6 +1109,12 @@ func (z *actionType) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *actionType) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *actionType) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *actionType) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*actionType)
 	return ok
@@ -1048,16 +1172,24 @@ func (_ *blockAssembler) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *blockAssembler) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *blockAssembler) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0002 > 0 {
@@ -1094,19 +1226,19 @@ func (z *blockAssembler) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0004 int
-			var zb0005 bool
-			zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0006 int
+			var zb0007 bool
+			zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Authenticators")
 				return
 			}
-			if zb0005 {
+			if zb0007 {
 				(*z).Authenticators = nil
-			} else if (*z).Authenticators != nil && cap((*z).Authenticators) >= zb0004 {
-				(*z).Authenticators = ((*z).Authenticators)[:zb0004]
+			} else if (*z).Authenticators != nil && cap((*z).Authenticators) >= zb0006 {
+				(*z).Authenticators = ((*z).Authenticators)[:zb0006]
 			} else {
-				(*z).Authenticators = make([]vote, zb0004)
+				(*z).Authenticators = make([]vote, zb0006)
 			}
 			for zb0001 := range (*z).Authenticators {
 				bts, err = (*z).Authenticators[zb0001].UnmarshalMsg(bts)
@@ -1140,43 +1272,67 @@ func (z *blockAssembler) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "Pipeline":
+				if validate && zb0005 && "Pipeline" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Pipeline.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Pipeline")
 					return
 				}
+				zb0004 = "Pipeline"
 			case "Filled":
+				if validate && zb0005 && "Filled" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Filled, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Filled")
 					return
 				}
+				zb0004 = "Filled"
 			case "Payload":
+				if validate && zb0005 && "Payload" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Payload.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Payload")
 					return
 				}
+				zb0004 = "Payload"
 			case "Assembled":
+				if validate && zb0005 && "Assembled" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Assembled, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Assembled")
 					return
 				}
+				zb0004 = "Assembled"
 			case "Authenticators":
-				var zb0006 int
-				var zb0007 bool
-				zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0005 && "Authenticators" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0008 int
+				var zb0009 bool
+				zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Authenticators")
 					return
 				}
-				if zb0007 {
+				if zb0009 {
 					(*z).Authenticators = nil
-				} else if (*z).Authenticators != nil && cap((*z).Authenticators) >= zb0006 {
-					(*z).Authenticators = ((*z).Authenticators)[:zb0006]
+				} else if (*z).Authenticators != nil && cap((*z).Authenticators) >= zb0008 {
+					(*z).Authenticators = ((*z).Authenticators)[:zb0008]
 				} else {
-					(*z).Authenticators = make([]vote, zb0006)
+					(*z).Authenticators = make([]vote, zb0008)
 				}
 				for zb0001 := range (*z).Authenticators {
 					bts, err = (*z).Authenticators[zb0001].UnmarshalMsg(bts)
@@ -1185,6 +1341,7 @@ func (z *blockAssembler) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0004 = "Authenticators"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1192,12 +1349,19 @@ func (z *blockAssembler) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *blockAssembler) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *blockAssembler) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *blockAssembler) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*blockAssembler)
 	return ok
@@ -1285,16 +1449,24 @@ func (_ *bundle) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *bundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *bundle) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -1307,24 +1479,24 @@ func (z *bundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0007 int
+			var zb0008 bool
+			zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Votes")
 				return
 			}
-			if zb0005 > config.MaxVoteThreshold {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(config.MaxVoteThreshold))
+			if zb0007 > config.MaxVoteThreshold {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxVoteThreshold))
 				err = msgp.WrapError(err, "struct-from-array", "Votes")
 				return
 			}
-			if zb0006 {
+			if zb0008 {
 				(*z).Votes = nil
-			} else if (*z).Votes != nil && cap((*z).Votes) >= zb0005 {
-				(*z).Votes = ((*z).Votes)[:zb0005]
+			} else if (*z).Votes != nil && cap((*z).Votes) >= zb0007 {
+				(*z).Votes = ((*z).Votes)[:zb0007]
 			} else {
-				(*z).Votes = make([]vote, zb0005)
+				(*z).Votes = make([]vote, zb0007)
 			}
 			for zb0001 := range (*z).Votes {
 				bts, err = (*z).Votes[zb0001].UnmarshalMsg(bts)
@@ -1336,24 +1508,24 @@ func (z *bundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0007 int
-			var zb0008 bool
-			zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0009 int
+			var zb0010 bool
+			zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "EquivocationVotes")
 				return
 			}
-			if zb0007 > config.MaxVoteThreshold {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxVoteThreshold))
+			if zb0009 > config.MaxVoteThreshold {
+				err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxVoteThreshold))
 				err = msgp.WrapError(err, "struct-from-array", "EquivocationVotes")
 				return
 			}
-			if zb0008 {
+			if zb0010 {
 				(*z).EquivocationVotes = nil
-			} else if (*z).EquivocationVotes != nil && cap((*z).EquivocationVotes) >= zb0007 {
-				(*z).EquivocationVotes = ((*z).EquivocationVotes)[:zb0007]
+			} else if (*z).EquivocationVotes != nil && cap((*z).EquivocationVotes) >= zb0009 {
+				(*z).EquivocationVotes = ((*z).EquivocationVotes)[:zb0009]
 			} else {
-				(*z).EquivocationVotes = make([]equivocationVote, zb0007)
+				(*z).EquivocationVotes = make([]equivocationVote, zb0009)
 			}
 			for zb0002 := range (*z).EquivocationVotes {
 				bts, err = (*z).EquivocationVotes[zb0002].UnmarshalMsg(bts)
@@ -1387,30 +1559,39 @@ func (z *bundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "u":
+				if validate && zb0006 && "u" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).U.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "U")
 					return
 				}
+				zb0005 = "u"
 			case "vote":
-				var zb0009 int
-				var zb0010 bool
-				zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "vote" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0011 int
+				var zb0012 bool
+				zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Votes")
 					return
 				}
-				if zb0009 > config.MaxVoteThreshold {
-					err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxVoteThreshold))
+				if zb0011 > config.MaxVoteThreshold {
+					err = msgp.ErrOverflow(uint64(zb0011), uint64(config.MaxVoteThreshold))
 					err = msgp.WrapError(err, "Votes")
 					return
 				}
-				if zb0010 {
+				if zb0012 {
 					(*z).Votes = nil
-				} else if (*z).Votes != nil && cap((*z).Votes) >= zb0009 {
-					(*z).Votes = ((*z).Votes)[:zb0009]
+				} else if (*z).Votes != nil && cap((*z).Votes) >= zb0011 {
+					(*z).Votes = ((*z).Votes)[:zb0011]
 				} else {
-					(*z).Votes = make([]vote, zb0009)
+					(*z).Votes = make([]vote, zb0011)
 				}
 				for zb0001 := range (*z).Votes {
 					bts, err = (*z).Votes[zb0001].UnmarshalMsg(bts)
@@ -1419,25 +1600,30 @@ func (z *bundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0005 = "vote"
 			case "eqv":
-				var zb0011 int
-				var zb0012 bool
-				zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "eqv" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0013 int
+				var zb0014 bool
+				zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "EquivocationVotes")
 					return
 				}
-				if zb0011 > config.MaxVoteThreshold {
-					err = msgp.ErrOverflow(uint64(zb0011), uint64(config.MaxVoteThreshold))
+				if zb0013 > config.MaxVoteThreshold {
+					err = msgp.ErrOverflow(uint64(zb0013), uint64(config.MaxVoteThreshold))
 					err = msgp.WrapError(err, "EquivocationVotes")
 					return
 				}
-				if zb0012 {
+				if zb0014 {
 					(*z).EquivocationVotes = nil
-				} else if (*z).EquivocationVotes != nil && cap((*z).EquivocationVotes) >= zb0011 {
-					(*z).EquivocationVotes = ((*z).EquivocationVotes)[:zb0011]
+				} else if (*z).EquivocationVotes != nil && cap((*z).EquivocationVotes) >= zb0013 {
+					(*z).EquivocationVotes = ((*z).EquivocationVotes)[:zb0013]
 				} else {
-					(*z).EquivocationVotes = make([]equivocationVote, zb0011)
+					(*z).EquivocationVotes = make([]equivocationVote, zb0013)
 				}
 				for zb0002 := range (*z).EquivocationVotes {
 					bts, err = (*z).EquivocationVotes[zb0002].UnmarshalMsg(bts)
@@ -1446,6 +1632,7 @@ func (z *bundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0005 = "eqv"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1453,12 +1640,19 @@ func (z *bundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *bundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *bundle) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *bundle) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*bundle)
 	return ok
@@ -1512,16 +1706,24 @@ func (_ *compoundMessage) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *compoundMessage) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *compoundMessage) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -1564,17 +1766,27 @@ func (z *compoundMessage) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "Vote":
+				if validate && zb0004 && "Vote" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Vote.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Vote")
 					return
 				}
+				zb0003 = "Vote"
 			case "Proposal":
+				if validate && zb0004 && "Proposal" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Proposal.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Proposal")
 					return
 				}
+				zb0003 = "Proposal"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1582,12 +1794,19 @@ func (z *compoundMessage) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *compoundMessage) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *compoundMessage) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *compoundMessage) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*compoundMessage)
 	return ok
@@ -1652,16 +1871,24 @@ func (_ *diskState) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *diskState) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *diskState) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -1690,47 +1917,47 @@ func (z *diskState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0007 int
+			var zb0008 bool
+			zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ActionTypes")
 				return
 			}
-			if zb0006 {
+			if zb0008 {
 				(*z).ActionTypes = nil
-			} else if (*z).ActionTypes != nil && cap((*z).ActionTypes) >= zb0005 {
-				(*z).ActionTypes = ((*z).ActionTypes)[:zb0005]
+			} else if (*z).ActionTypes != nil && cap((*z).ActionTypes) >= zb0007 {
+				(*z).ActionTypes = ((*z).ActionTypes)[:zb0007]
 			} else {
-				(*z).ActionTypes = make([]actionType, zb0005)
+				(*z).ActionTypes = make([]actionType, zb0007)
 			}
 			for zb0001 := range (*z).ActionTypes {
 				{
-					var zb0007 uint8
-					zb0007, bts, err = msgp.ReadUint8Bytes(bts)
+					var zb0009 uint8
+					zb0009, bts, err = msgp.ReadUint8Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "ActionTypes", zb0001)
 						return
 					}
-					(*z).ActionTypes[zb0001] = actionType(zb0007)
+					(*z).ActionTypes[zb0001] = actionType(zb0009)
 				}
 			}
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0008 int
-			var zb0009 bool
-			zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0010 int
+			var zb0011 bool
+			zb0010, zb0011, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Actions")
 				return
 			}
-			if zb0009 {
+			if zb0011 {
 				(*z).Actions = nil
-			} else if (*z).Actions != nil && cap((*z).Actions) >= zb0008 {
-				(*z).Actions = ((*z).Actions)[:zb0008]
+			} else if (*z).Actions != nil && cap((*z).Actions) >= zb0010 {
+				(*z).Actions = ((*z).Actions)[:zb0010]
 			} else {
-				(*z).Actions = make([][]byte, zb0008)
+				(*z).Actions = make([][]byte, zb0010)
 			}
 			for zb0002 := range (*z).Actions {
 				(*z).Actions[zb0002], bts, err = msgp.ReadBytesBytes(bts, (*z).Actions[zb0002])
@@ -1764,63 +1991,87 @@ func (z *diskState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "Router":
+				if validate && zb0006 && "Router" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Router, bts, err = msgp.ReadBytesBytes(bts, (*z).Router)
 				if err != nil {
 					err = msgp.WrapError(err, "Router")
 					return
 				}
+				zb0005 = "Router"
 			case "Player":
+				if validate && zb0006 && "Player" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Player, bts, err = msgp.ReadBytesBytes(bts, (*z).Player)
 				if err != nil {
 					err = msgp.WrapError(err, "Player")
 					return
 				}
+				zb0005 = "Player"
 			case "Clock":
+				if validate && zb0006 && "Clock" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Clock, bts, err = msgp.ReadBytesBytes(bts, (*z).Clock)
 				if err != nil {
 					err = msgp.WrapError(err, "Clock")
 					return
 				}
+				zb0005 = "Clock"
 			case "ActionTypes":
-				var zb0010 int
-				var zb0011 bool
-				zb0010, zb0011, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "ActionTypes" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0012 int
+				var zb0013 bool
+				zb0012, zb0013, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ActionTypes")
 					return
 				}
-				if zb0011 {
+				if zb0013 {
 					(*z).ActionTypes = nil
-				} else if (*z).ActionTypes != nil && cap((*z).ActionTypes) >= zb0010 {
-					(*z).ActionTypes = ((*z).ActionTypes)[:zb0010]
+				} else if (*z).ActionTypes != nil && cap((*z).ActionTypes) >= zb0012 {
+					(*z).ActionTypes = ((*z).ActionTypes)[:zb0012]
 				} else {
-					(*z).ActionTypes = make([]actionType, zb0010)
+					(*z).ActionTypes = make([]actionType, zb0012)
 				}
 				for zb0001 := range (*z).ActionTypes {
 					{
-						var zb0012 uint8
-						zb0012, bts, err = msgp.ReadUint8Bytes(bts)
+						var zb0014 uint8
+						zb0014, bts, err = msgp.ReadUint8Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "ActionTypes", zb0001)
 							return
 						}
-						(*z).ActionTypes[zb0001] = actionType(zb0012)
+						(*z).ActionTypes[zb0001] = actionType(zb0014)
 					}
 				}
+				zb0005 = "ActionTypes"
 			case "Actions":
-				var zb0013 int
-				var zb0014 bool
-				zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "Actions" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0015 int
+				var zb0016 bool
+				zb0015, zb0016, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Actions")
 					return
 				}
-				if zb0014 {
+				if zb0016 {
 					(*z).Actions = nil
-				} else if (*z).Actions != nil && cap((*z).Actions) >= zb0013 {
-					(*z).Actions = ((*z).Actions)[:zb0013]
+				} else if (*z).Actions != nil && cap((*z).Actions) >= zb0015 {
+					(*z).Actions = ((*z).Actions)[:zb0015]
 				} else {
-					(*z).Actions = make([][]byte, zb0013)
+					(*z).Actions = make([][]byte, zb0015)
 				}
 				for zb0002 := range (*z).Actions {
 					(*z).Actions[zb0002], bts, err = msgp.ReadBytesBytes(bts, (*z).Actions[zb0002])
@@ -1829,6 +2080,7 @@ func (z *diskState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0005 = "Actions"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1836,12 +2088,19 @@ func (z *diskState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *diskState) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *diskState) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *diskState) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*diskState)
 	return ok
@@ -1966,16 +2225,24 @@ func (_ *equivocationVote) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *equivocationVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *equivocationVote) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -1997,25 +2264,25 @@ func (z *equivocationVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		if zb0003 > 0 {
 			zb0003--
 			{
-				var zb0005 uint64
-				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0007 uint64
+				zb0007, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Period")
 					return
 				}
-				(*z).Period = period(zb0005)
+				(*z).Period = period(zb0007)
 			}
 		}
 		if zb0003 > 0 {
 			zb0003--
 			{
-				var zb0006 uint64
-				zb0006, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0008 uint64
+				zb0008, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Step")
 					return
 				}
-				(*z).Step = step(zb0006)
+				(*z).Step = step(zb0008)
 			}
 		}
 		if zb0003 > 0 {
@@ -2028,17 +2295,17 @@ func (z *equivocationVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0007 int
-			zb0007, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0009 int
+			zb0009, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Proposals")
 				return
 			}
-			if zb0007 > 2 {
-				err = msgp.ArrayError{Wanted: 2, Got: zb0007}
+			if zb0009 > 2 {
+				err = msgp.ArrayError{Wanted: 2, Got: zb0009}
 				return
 			}
-			for zb0001 := 0; zb0001 < zb0007; zb0001++ {
+			for zb0001 := 0; zb0001 < zb0009; zb0001++ {
 				bts, err = (*z).Proposals[zb0001].UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Proposals", zb0001)
@@ -2048,17 +2315,17 @@ func (z *equivocationVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0008 int
-			zb0008, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0010 int
+			zb0010, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Sigs")
 				return
 			}
-			if zb0008 > 2 {
-				err = msgp.ArrayError{Wanted: 2, Got: zb0008}
+			if zb0010 > 2 {
+				err = msgp.ArrayError{Wanted: 2, Got: zb0010}
 				return
 			}
-			for zb0002 := 0; zb0002 < zb0008; zb0002++ {
+			for zb0002 := 0; zb0002 < zb0010; zb0002++ {
 				bts, err = (*z).Sigs[zb0002].UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Sigs", zb0002)
@@ -2090,79 +2357,114 @@ func (z *equivocationVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "snd":
+				if validate && zb0006 && "snd" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sender.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sender")
 					return
 				}
+				zb0005 = "snd"
 			case "rnd":
+				if validate && zb0006 && "rnd" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Round.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0005 = "rnd"
 			case "per":
+				if validate && zb0006 && "per" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0009 uint64
-					zb0009, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0011 uint64
+					zb0011, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Period")
 						return
 					}
-					(*z).Period = period(zb0009)
+					(*z).Period = period(zb0011)
 				}
+				zb0005 = "per"
 			case "step":
+				if validate && zb0006 && "step" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0010 uint64
-					zb0010, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0012 uint64
+					zb0012, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Step")
 						return
 					}
-					(*z).Step = step(zb0010)
+					(*z).Step = step(zb0012)
 				}
+				zb0005 = "step"
 			case "cred":
+				if validate && zb0006 && "cred" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Cred.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Cred")
 					return
 				}
+				zb0005 = "cred"
 			case "props":
-				var zb0011 int
-				zb0011, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "props" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0013 int
+				zb0013, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Proposals")
 					return
 				}
-				if zb0011 > 2 {
-					err = msgp.ArrayError{Wanted: 2, Got: zb0011}
+				if zb0013 > 2 {
+					err = msgp.ArrayError{Wanted: 2, Got: zb0013}
 					return
 				}
-				for zb0001 := 0; zb0001 < zb0011; zb0001++ {
+				for zb0001 := 0; zb0001 < zb0013; zb0001++ {
 					bts, err = (*z).Proposals[zb0001].UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Proposals", zb0001)
 						return
 					}
 				}
+				zb0005 = "props"
 			case "sigs":
-				var zb0012 int
-				zb0012, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "sigs" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0014 int
+				zb0014, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sigs")
 					return
 				}
-				if zb0012 > 2 {
-					err = msgp.ArrayError{Wanted: 2, Got: zb0012}
+				if zb0014 > 2 {
+					err = msgp.ArrayError{Wanted: 2, Got: zb0014}
 					return
 				}
-				for zb0002 := 0; zb0002 < zb0012; zb0002++ {
+				for zb0002 := 0; zb0002 < zb0014; zb0002++ {
 					bts, err = (*z).Sigs[zb0002].UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Sigs", zb0002)
 						return
 					}
 				}
+				zb0005 = "sigs"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2170,12 +2472,19 @@ func (z *equivocationVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *equivocationVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *equivocationVote) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *equivocationVote) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*equivocationVote)
 	return ok
@@ -2246,16 +2555,24 @@ func (_ *equivocationVoteAuthenticator) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *equivocationVoteAuthenticator) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *equivocationVoteAuthenticator) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -2276,17 +2593,17 @@ func (z *equivocationVoteAuthenticator) UnmarshalMsg(bts []byte) (o []byte, err 
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			zb0005, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0007 int
+			zb0007, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Sigs")
 				return
 			}
-			if zb0005 > 2 {
-				err = msgp.ArrayError{Wanted: 2, Got: zb0005}
+			if zb0007 > 2 {
+				err = msgp.ArrayError{Wanted: 2, Got: zb0007}
 				return
 			}
-			for zb0001 := 0; zb0001 < zb0005; zb0001++ {
+			for zb0001 := 0; zb0001 < zb0007; zb0001++ {
 				bts, err = (*z).Sigs[zb0001].UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Sigs", zb0001)
@@ -2296,17 +2613,17 @@ func (z *equivocationVoteAuthenticator) UnmarshalMsg(bts []byte) (o []byte, err 
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0006 int
-			zb0006, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0008 int
+			zb0008, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Proposals")
 				return
 			}
-			if zb0006 > 2 {
-				err = msgp.ArrayError{Wanted: 2, Got: zb0006}
+			if zb0008 > 2 {
+				err = msgp.ArrayError{Wanted: 2, Got: zb0008}
 				return
 			}
-			for zb0002 := 0; zb0002 < zb0006; zb0002++ {
+			for zb0002 := 0; zb0002 < zb0008; zb0002++ {
 				bts, err = (*z).Proposals[zb0002].UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Proposals", zb0002)
@@ -2338,53 +2655,73 @@ func (z *equivocationVoteAuthenticator) UnmarshalMsg(bts []byte) (o []byte, err 
 			}
 			switch string(field) {
 			case "snd":
+				if validate && zb0006 && "snd" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sender.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sender")
 					return
 				}
+				zb0005 = "snd"
 			case "cred":
+				if validate && zb0006 && "cred" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Cred.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Cred")
 					return
 				}
+				zb0005 = "cred"
 			case "sig":
-				var zb0007 int
-				zb0007, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "sig" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0009 int
+				zb0009, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sigs")
 					return
 				}
-				if zb0007 > 2 {
-					err = msgp.ArrayError{Wanted: 2, Got: zb0007}
+				if zb0009 > 2 {
+					err = msgp.ArrayError{Wanted: 2, Got: zb0009}
 					return
 				}
-				for zb0001 := 0; zb0001 < zb0007; zb0001++ {
+				for zb0001 := 0; zb0001 < zb0009; zb0001++ {
 					bts, err = (*z).Sigs[zb0001].UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Sigs", zb0001)
 						return
 					}
 				}
+				zb0005 = "sig"
 			case "props":
-				var zb0008 int
-				zb0008, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "props" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0010 int
+				zb0010, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Proposals")
 					return
 				}
-				if zb0008 > 2 {
-					err = msgp.ArrayError{Wanted: 2, Got: zb0008}
+				if zb0010 > 2 {
+					err = msgp.ArrayError{Wanted: 2, Got: zb0010}
 					return
 				}
-				for zb0002 := 0; zb0002 < zb0008; zb0002++ {
+				for zb0002 := 0; zb0002 < zb0010; zb0002++ {
 					bts, err = (*z).Proposals[zb0002].UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Proposals", zb0002)
 						return
 					}
 				}
+				zb0005 = "props"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2392,12 +2729,19 @@ func (z *equivocationVoteAuthenticator) UnmarshalMsg(bts []byte) (o []byte, err 
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *equivocationVoteAuthenticator) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *equivocationVoteAuthenticator) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *equivocationVoteAuthenticator) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*equivocationVoteAuthenticator)
 	return ok
@@ -2448,7 +2792,7 @@ func (_ eventType) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *eventType) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *eventType) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 uint8
 		zb0001, bts, err = msgp.ReadUint8Bytes(bts)
@@ -2462,6 +2806,12 @@ func (z *eventType) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *eventType) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *eventType) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *eventType) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*eventType)
 	return ok
@@ -2509,16 +2859,24 @@ func (_ *freshnessData) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *freshnessData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *freshnessData) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -2532,37 +2890,37 @@ func (z *freshnessData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0003 uint64
-				zb0003, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0005 uint64
+				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "PlayerPeriod")
 					return
 				}
-				(*z).PlayerPeriod = period(zb0003)
+				(*z).PlayerPeriod = period(zb0005)
 			}
 		}
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0004 uint64
-				zb0004, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0006 uint64
+				zb0006, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "PlayerStep")
 					return
 				}
-				(*z).PlayerStep = step(zb0004)
+				(*z).PlayerStep = step(zb0006)
 			}
 		}
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0005 uint64
-				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0007 uint64
+				zb0007, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "PlayerLastConcluding")
 					return
 				}
-				(*z).PlayerLastConcluding = step(zb0005)
+				(*z).PlayerLastConcluding = step(zb0007)
 			}
 		}
 		if zb0001 > 0 {
@@ -2589,41 +2947,61 @@ func (z *freshnessData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "PlayerRound":
+				if validate && zb0004 && "PlayerRound" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).PlayerRound.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "PlayerRound")
 					return
 				}
+				zb0003 = "PlayerRound"
 			case "PlayerPeriod":
-				{
-					var zb0006 uint64
-					zb0006, bts, err = msgp.ReadUint64Bytes(bts)
-					if err != nil {
-						err = msgp.WrapError(err, "PlayerPeriod")
-						return
-					}
-					(*z).PlayerPeriod = period(zb0006)
+				if validate && zb0004 && "PlayerPeriod" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
 				}
-			case "PlayerStep":
-				{
-					var zb0007 uint64
-					zb0007, bts, err = msgp.ReadUint64Bytes(bts)
-					if err != nil {
-						err = msgp.WrapError(err, "PlayerStep")
-						return
-					}
-					(*z).PlayerStep = step(zb0007)
-				}
-			case "PlayerLastConcluding":
 				{
 					var zb0008 uint64
 					zb0008, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
+						err = msgp.WrapError(err, "PlayerPeriod")
+						return
+					}
+					(*z).PlayerPeriod = period(zb0008)
+				}
+				zb0003 = "PlayerPeriod"
+			case "PlayerStep":
+				if validate && zb0004 && "PlayerStep" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				{
+					var zb0009 uint64
+					zb0009, bts, err = msgp.ReadUint64Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "PlayerStep")
+						return
+					}
+					(*z).PlayerStep = step(zb0009)
+				}
+				zb0003 = "PlayerStep"
+			case "PlayerLastConcluding":
+				if validate && zb0004 && "PlayerLastConcluding" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				{
+					var zb0010 uint64
+					zb0010, bts, err = msgp.ReadUint64Bytes(bts)
+					if err != nil {
 						err = msgp.WrapError(err, "PlayerLastConcluding")
 						return
 					}
-					(*z).PlayerLastConcluding = step(zb0008)
+					(*z).PlayerLastConcluding = step(zb0010)
 				}
+				zb0003 = "PlayerLastConcluding"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2631,12 +3009,19 @@ func (z *freshnessData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *freshnessData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *freshnessData) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *freshnessData) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*freshnessData)
 	return ok
@@ -2705,16 +3090,24 @@ func (_ *message) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *message) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *message) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -2783,33 +3176,41 @@ func (z *message) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0001 > 0 {
 			zb0001--
-			var zb0003 int
-			var zb0004 bool
-			zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0005 int
+			var zb0007 string
+			var zb0008 bool
+			var zb0006 bool
+			_ = zb0007
+			_ = zb0008
+			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "CompoundMessage")
 					return
 				}
-				if zb0003 > 0 {
-					zb0003--
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0005 > 0 {
+					zb0005--
 					bts, err = (*z).CompoundMessage.Vote.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "CompoundMessage", "struct-from-array", "Vote")
 						return
 					}
 				}
-				if zb0003 > 0 {
-					zb0003--
+				if zb0005 > 0 {
+					zb0005--
 					bts, err = (*z).CompoundMessage.Proposal.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "CompoundMessage", "struct-from-array", "Proposal")
 						return
 					}
 				}
-				if zb0003 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0003)
+				if zb0005 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0005)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "CompoundMessage", "struct-from-array")
 						return
@@ -2820,11 +3221,11 @@ func (z *message) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "CompoundMessage")
 					return
 				}
-				if zb0004 {
+				if zb0006 {
 					(*z).CompoundMessage = compoundMessage{}
 				}
-				for zb0003 > 0 {
-					zb0003--
+				for zb0005 > 0 {
+					zb0005--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "CompoundMessage")
@@ -2832,17 +3233,27 @@ func (z *message) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch string(field) {
 					case "Vote":
+						if validate && zb0008 && "Vote" < zb0007 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						bts, err = (*z).CompoundMessage.Vote.UnmarshalMsg(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "CompoundMessage", "Vote")
 							return
 						}
+						zb0007 = "Vote"
 					case "Proposal":
+						if validate && zb0008 && "Proposal" < zb0007 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						bts, err = (*z).CompoundMessage.Proposal.UnmarshalMsg(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "CompoundMessage", "Proposal")
 							return
 						}
+						zb0007 = "Proposal"
 					default:
 						err = msgp.ErrNoField(string(field))
 						if err != nil {
@@ -2850,6 +3261,7 @@ func (z *message) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0008 = true
 				}
 			}
 		}
@@ -2877,81 +3289,133 @@ func (z *message) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "MessageHandle":
+				if validate && zb0004 && "MessageHandle" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).MessageHandle.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "MessageHandle")
 					return
 				}
+				zb0003 = "MessageHandle"
 			case "Tag":
+				if validate && zb0004 && "Tag" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Tag.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Tag")
 					return
 				}
+				zb0003 = "Tag"
 			case "Vote":
+				if validate && zb0004 && "Vote" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Vote.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Vote")
 					return
 				}
+				zb0003 = "Vote"
 			case "Proposal":
+				if validate && zb0004 && "Proposal" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Proposal.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Proposal")
 					return
 				}
+				zb0003 = "Proposal"
 			case "Bundle":
+				if validate && zb0004 && "Bundle" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Bundle.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Bundle")
 					return
 				}
+				zb0003 = "Bundle"
 			case "UnauthenticatedVote":
+				if validate && zb0004 && "UnauthenticatedVote" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).UnauthenticatedVote.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UnauthenticatedVote")
 					return
 				}
+				zb0003 = "UnauthenticatedVote"
 			case "UnauthenticatedProposal":
+				if validate && zb0004 && "UnauthenticatedProposal" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).UnauthenticatedProposal.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UnauthenticatedProposal")
 					return
 				}
+				zb0003 = "UnauthenticatedProposal"
 			case "UnauthenticatedBundle":
+				if validate && zb0004 && "UnauthenticatedBundle" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).UnauthenticatedBundle.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UnauthenticatedBundle")
 					return
 				}
+				zb0003 = "UnauthenticatedBundle"
 			case "CompoundMessage":
-				var zb0005 int
-				var zb0006 bool
-				zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0004 && "CompoundMessage" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0009 int
+				var zb0011 string
+				var zb0012 bool
+				var zb0010 bool
+				_ = zb0011
+				_ = zb0012
+				zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "CompoundMessage")
 						return
 					}
-					if zb0005 > 0 {
-						zb0005--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0009 > 0 {
+						zb0009--
 						bts, err = (*z).CompoundMessage.Vote.UnmarshalMsg(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "CompoundMessage", "struct-from-array", "Vote")
 							return
 						}
 					}
-					if zb0005 > 0 {
-						zb0005--
+					if zb0009 > 0 {
+						zb0009--
 						bts, err = (*z).CompoundMessage.Proposal.UnmarshalMsg(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "CompoundMessage", "struct-from-array", "Proposal")
 							return
 						}
 					}
-					if zb0005 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0005)
+					if zb0009 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0009)
 						if err != nil {
 							err = msgp.WrapError(err, "CompoundMessage", "struct-from-array")
 							return
@@ -2962,11 +3426,11 @@ func (z *message) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "CompoundMessage")
 						return
 					}
-					if zb0006 {
+					if zb0010 {
 						(*z).CompoundMessage = compoundMessage{}
 					}
-					for zb0005 > 0 {
-						zb0005--
+					for zb0009 > 0 {
+						zb0009--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "CompoundMessage")
@@ -2974,17 +3438,27 @@ func (z *message) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "Vote":
+							if validate && zb0012 && "Vote" < zb0011 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							bts, err = (*z).CompoundMessage.Vote.UnmarshalMsg(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "CompoundMessage", "Vote")
 								return
 							}
+							zb0011 = "Vote"
 						case "Proposal":
+							if validate && zb0012 && "Proposal" < zb0011 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							bts, err = (*z).CompoundMessage.Proposal.UnmarshalMsg(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "CompoundMessage", "Proposal")
 								return
 							}
+							zb0011 = "Proposal"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -2992,8 +3466,10 @@ func (z *message) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0012 = true
 					}
 				}
+				zb0003 = "CompoundMessage"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3001,12 +3477,19 @@ func (z *message) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *message) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *message) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *message) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*message)
 	return ok
@@ -3073,11 +3556,15 @@ func (_ *messageEvent) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *messageEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *messageEvent) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -3085,16 +3572,20 @@ func (z *messageEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0003 uint8
-				zb0003, bts, err = msgp.ReadUint8Bytes(bts)
+				var zb0005 uint8
+				zb0005, bts, err = msgp.ReadUint8Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "T")
 					return
 				}
-				(*z).T = eventType(zb0003)
+				(*z).T = eventType(zb0005)
 			}
 		}
 		if zb0001 > 0 {
@@ -3118,13 +3609,13 @@ func (z *messageEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					(*z).Err = new(serializableError)
 				}
 				{
-					var zb0004 string
-					zb0004, bts, err = msgp.ReadStringBytes(bts)
+					var zb0006 string
+					zb0006, bts, err = msgp.ReadStringBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Err")
 						return
 					}
-					*(*z).Err = serializableError(zb0004)
+					*(*z).Err = serializableError(zb0006)
 				}
 			}
 		}
@@ -3195,22 +3686,36 @@ func (z *messageEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "T":
+				if validate && zb0004 && "T" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0005 uint8
-					zb0005, bts, err = msgp.ReadUint8Bytes(bts)
+					var zb0007 uint8
+					zb0007, bts, err = msgp.ReadUint8Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "T")
 						return
 					}
-					(*z).T = eventType(zb0005)
+					(*z).T = eventType(zb0007)
 				}
+				zb0003 = "T"
 			case "Input":
+				if validate && zb0004 && "Input" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Input.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Input")
 					return
 				}
+				zb0003 = "Input"
 			case "Err":
+				if validate && zb0004 && "Err" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
@@ -3222,22 +3727,32 @@ func (z *messageEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						(*z).Err = new(serializableError)
 					}
 					{
-						var zb0006 string
-						zb0006, bts, err = msgp.ReadStringBytes(bts)
+						var zb0008 string
+						zb0008, bts, err = msgp.ReadStringBytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Err")
 							return
 						}
-						*(*z).Err = serializableError(zb0006)
+						*(*z).Err = serializableError(zb0008)
 					}
 				}
+				zb0003 = "Err"
 			case "TaskIndex":
+				if validate && zb0004 && "TaskIndex" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TaskIndex, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TaskIndex")
 					return
 				}
+				zb0003 = "TaskIndex"
 			case "Tail":
+				if validate && zb0004 && "Tail" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
@@ -3254,18 +3769,29 @@ func (z *messageEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0003 = "Tail"
 			case "Cancelled":
+				if validate && zb0004 && "Cancelled" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Cancelled, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Cancelled")
 					return
 				}
+				zb0003 = "Cancelled"
 			case "Proto":
+				if validate && zb0004 && "Proto" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Proto.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Proto")
 					return
 				}
+				zb0003 = "Proto"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3273,12 +3799,19 @@ func (z *messageEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *messageEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *messageEvent) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *messageEvent) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*messageEvent)
 	return ok
@@ -3336,16 +3869,24 @@ func (_ *nextThresholdStatusEvent) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *nextThresholdStatusEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *nextThresholdStatusEvent) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -3388,17 +3929,27 @@ func (z *nextThresholdStatusEvent) UnmarshalMsg(bts []byte) (o []byte, err error
 			}
 			switch string(field) {
 			case "Bottom":
+				if validate && zb0004 && "Bottom" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Bottom, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Bottom")
 					return
 				}
+				zb0003 = "Bottom"
 			case "Proposal":
+				if validate && zb0004 && "Proposal" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Proposal.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Proposal")
 					return
 				}
+				zb0003 = "Proposal"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3406,12 +3957,19 @@ func (z *nextThresholdStatusEvent) UnmarshalMsg(bts []byte) (o []byte, err error
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *nextThresholdStatusEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *nextThresholdStatusEvent) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *nextThresholdStatusEvent) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*nextThresholdStatusEvent)
 	return ok
@@ -3450,7 +4008,7 @@ func (_ period) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *period) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *period) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 uint64
 		zb0001, bts, err = msgp.ReadUint64Bytes(bts)
@@ -3464,6 +4022,12 @@ func (z *period) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *period) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *period) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *period) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*period)
 	return ok
@@ -3530,16 +4094,24 @@ func (_ *periodRouter) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *periodRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *periodRouter) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -3568,27 +4140,37 @@ func (z *periodRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0007 int
+			var zb0008 bool
+			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Children")
 				return
 			}
-			if zb0006 {
+			if zb0008 {
 				(*z).Children = nil
 			} else if (*z).Children == nil {
-				(*z).Children = make(map[step]*stepRouter, zb0005)
+				(*z).Children = make(map[step]*stepRouter, zb0007)
 			}
-			for zb0005 > 0 {
+			var zb0009 step
+			_ = zb0009
+			var zb0010 bool
+			_ = zb0010
+			for zb0007 > 0 {
 				var zb0001 step
 				var zb0002 *stepRouter
-				zb0005--
+				zb0007--
 				bts, err = zb0001.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Children")
 					return
 				}
+				if validate && zb0010 && StepLess(zb0001, zb0009) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0009 = zb0001
+				zb0010 = true
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
@@ -3632,45 +4214,74 @@ func (z *periodRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "ProposalTracker":
+				if validate && zb0006 && "ProposalTracker" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ProposalTracker.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ProposalTracker")
 					return
 				}
+				zb0005 = "ProposalTracker"
 			case "VoteTrackerPeriod":
+				if validate && zb0006 && "VoteTrackerPeriod" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VoteTrackerPeriod.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteTrackerPeriod")
 					return
 				}
+				zb0005 = "VoteTrackerPeriod"
 			case "ProposalTrackerContract":
+				if validate && zb0006 && "ProposalTrackerContract" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ProposalTrackerContract.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ProposalTrackerContract")
 					return
 				}
+				zb0005 = "ProposalTrackerContract"
 			case "Children":
-				var zb0007 int
-				var zb0008 bool
-				zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0006 && "Children" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0011 int
+				var zb0012 bool
+				zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Children")
 					return
 				}
-				if zb0008 {
+				if zb0012 {
 					(*z).Children = nil
 				} else if (*z).Children == nil {
-					(*z).Children = make(map[step]*stepRouter, zb0007)
+					(*z).Children = make(map[step]*stepRouter, zb0011)
 				}
-				for zb0007 > 0 {
+				var zb0013 step
+				_ = zb0013
+				var zb0014 bool
+				_ = zb0014
+				for zb0011 > 0 {
 					var zb0001 step
 					var zb0002 *stepRouter
-					zb0007--
+					zb0011--
 					bts, err = zb0001.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Children")
 						return
 					}
+					if validate && zb0014 && StepLess(zb0001, zb0013) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0013 = zb0001
+					zb0014 = true
 					if msgp.IsNil(bts) {
 						bts, err = msgp.ReadNilBytes(bts)
 						if err != nil {
@@ -3689,6 +4300,7 @@ func (z *periodRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).Children[zb0001] = zb0002
 				}
+				zb0005 = "Children"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3696,12 +4308,19 @@ func (z *periodRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *periodRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *periodRouter) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *periodRouter) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*periodRouter)
 	return ok
@@ -3775,16 +4394,24 @@ func (_ *player) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *player) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *player) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -3798,37 +4425,37 @@ func (z *player) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0003 uint64
-				zb0003, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0005 uint64
+				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Period")
 					return
 				}
-				(*z).Period = period(zb0003)
+				(*z).Period = period(zb0005)
 			}
 		}
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0004 uint64
-				zb0004, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0006 uint64
+				zb0006, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Step")
 					return
 				}
-				(*z).Step = step(zb0004)
+				(*z).Step = step(zb0006)
 			}
 		}
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0005 uint64
-				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0007 uint64
+				zb0007, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "LastConcluding")
 					return
 				}
-				(*z).LastConcluding = step(zb0005)
+				(*z).LastConcluding = step(zb0007)
 			}
 		}
 		if zb0001 > 0 {
@@ -3887,65 +4514,105 @@ func (z *player) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "Round":
+				if validate && zb0004 && "Round" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Round.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0003 = "Round"
 			case "Period":
-				{
-					var zb0006 uint64
-					zb0006, bts, err = msgp.ReadUint64Bytes(bts)
-					if err != nil {
-						err = msgp.WrapError(err, "Period")
-						return
-					}
-					(*z).Period = period(zb0006)
+				if validate && zb0004 && "Period" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
 				}
-			case "Step":
-				{
-					var zb0007 uint64
-					zb0007, bts, err = msgp.ReadUint64Bytes(bts)
-					if err != nil {
-						err = msgp.WrapError(err, "Step")
-						return
-					}
-					(*z).Step = step(zb0007)
-				}
-			case "LastConcluding":
 				{
 					var zb0008 uint64
 					zb0008, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
+						err = msgp.WrapError(err, "Period")
+						return
+					}
+					(*z).Period = period(zb0008)
+				}
+				zb0003 = "Period"
+			case "Step":
+				if validate && zb0004 && "Step" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				{
+					var zb0009 uint64
+					zb0009, bts, err = msgp.ReadUint64Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Step")
+						return
+					}
+					(*z).Step = step(zb0009)
+				}
+				zb0003 = "Step"
+			case "LastConcluding":
+				if validate && zb0004 && "LastConcluding" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				{
+					var zb0010 uint64
+					zb0010, bts, err = msgp.ReadUint64Bytes(bts)
+					if err != nil {
 						err = msgp.WrapError(err, "LastConcluding")
 						return
 					}
-					(*z).LastConcluding = step(zb0008)
+					(*z).LastConcluding = step(zb0010)
 				}
+				zb0003 = "LastConcluding"
 			case "Deadline":
+				if validate && zb0004 && "Deadline" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Deadline, bts, err = msgp.ReadDurationBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Deadline")
 					return
 				}
+				zb0003 = "Deadline"
 			case "Napping":
+				if validate && zb0004 && "Napping" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Napping, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Napping")
 					return
 				}
+				zb0003 = "Napping"
 			case "FastRecoveryDeadline":
+				if validate && zb0004 && "FastRecoveryDeadline" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).FastRecoveryDeadline, bts, err = msgp.ReadDurationBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FastRecoveryDeadline")
 					return
 				}
+				zb0003 = "FastRecoveryDeadline"
 			case "Pending":
+				if validate && zb0004 && "Pending" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Pending.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Pending")
 					return
 				}
+				zb0003 = "Pending"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3953,12 +4620,19 @@ func (z *player) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *player) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *player) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *player) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*player)
 	return ok
@@ -4283,16 +4957,24 @@ func (_ *proposal) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *proposal) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *proposal) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0004 int
+	var zb0006 string
+	var zb0007 bool
 	var zb0005 bool
+	_ = zb0006
+	_ = zb0007
 	zb0004, zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0004 > 0 {
@@ -4345,14 +5027,14 @@ func (z *proposal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0006 int
-			zb0006, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0008 int
+			zb0008, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "GenesisID")
 				return
 			}
-			if zb0006 > config.MaxGenesisIDLen {
-				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxGenesisIDLen))
+			if zb0008 > config.MaxGenesisIDLen {
+				err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxGenesisIDLen))
 				return
 			}
 			(*z).unauthenticatedProposal.Block.BlockHeader.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -4491,32 +5173,42 @@ func (z *proposal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0007 int
-			var zb0008 bool
-			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0009 int
+			var zb0010 bool
+			zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "StateProofTracking")
 				return
 			}
-			if zb0007 > protocol.NumStateProofTypes {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(protocol.NumStateProofTypes))
+			if zb0009 > protocol.NumStateProofTypes {
+				err = msgp.ErrOverflow(uint64(zb0009), uint64(protocol.NumStateProofTypes))
 				err = msgp.WrapError(err, "struct-from-array", "StateProofTracking")
 				return
 			}
-			if zb0008 {
+			if zb0010 {
 				(*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking = nil
 			} else if (*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking == nil {
-				(*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking = make(map[protocol.StateProofType]bookkeeping.StateProofTrackingData, zb0007)
+				(*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking = make(map[protocol.StateProofType]bookkeeping.StateProofTrackingData, zb0009)
 			}
-			for zb0007 > 0 {
+			var zb0011 protocol.StateProofType
+			_ = zb0011
+			var zb0012 bool
+			_ = zb0012
+			for zb0009 > 0 {
 				var zb0001 protocol.StateProofType
 				var zb0002 bookkeeping.StateProofTrackingData
-				zb0007--
+				zb0009--
 				bts, err = zb0001.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "StateProofTracking")
 					return
 				}
+				if validate && zb0012 && protocol.StateProofTypeLess(zb0001, zb0011) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0011 = zb0001
+				zb0012 = true
 				bts, err = zb0002.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "StateProofTracking", zb0001)
@@ -4527,24 +5219,24 @@ func (z *proposal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0009 int
-			var zb0010 bool
-			zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0013 int
+			var zb0014 bool
+			zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0009 > config.MaxProposedExpiredOnlineAccounts {
-				err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxProposedExpiredOnlineAccounts))
+			if zb0013 > config.MaxProposedExpiredOnlineAccounts {
+				err = msgp.ErrOverflow(uint64(zb0013), uint64(config.MaxProposedExpiredOnlineAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0010 {
+			if zb0014 {
 				(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = nil
-			} else if (*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts) >= zb0009 {
-				(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = ((*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts)[:zb0009]
+			} else if (*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts) >= zb0013 {
+				(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = ((*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts)[:zb0013]
 			} else {
-				(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0009)
+				(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0013)
 			}
 			for zb0003 := range (*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts {
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts[zb0003].UnmarshalMsg(bts)
@@ -4573,13 +5265,13 @@ func (z *proposal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		if zb0004 > 0 {
 			zb0004--
 			{
-				var zb0011 uint64
-				zb0011, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0015 uint64
+				zb0015, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "OriginalPeriod")
 					return
 				}
-				(*z).unauthenticatedProposal.OriginalPeriod = period(zb0011)
+				(*z).unauthenticatedProposal.OriginalPeriod = period(zb0015)
 			}
 		}
 		if zb0004 > 0 {
@@ -4614,50 +5306,84 @@ func (z *proposal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "rnd":
+				if validate && zb0007 && "rnd" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.Round.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0006 = "rnd"
 			case "prev":
+				if validate && zb0007 && "prev" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.Branch.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Branch")
 					return
 				}
+				zb0006 = "prev"
 			case "seed":
+				if validate && zb0007 && "seed" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.Seed.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Seed")
 					return
 				}
+				zb0006 = "seed"
 			case "txn":
+				if validate && zb0007 && "txn" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.TxnCommitments.NativeSha512_256Commitment.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NativeSha512_256Commitment")
 					return
 				}
+				zb0006 = "txn"
 			case "txn256":
+				if validate && zb0007 && "txn256" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.TxnCommitments.Sha256Commitment.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sha256Commitment")
 					return
 				}
+				zb0006 = "txn256"
 			case "ts":
+				if validate && zb0007 && "ts" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.TimeStamp, bts, err = msgp.ReadInt64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TimeStamp")
 					return
 				}
+				zb0006 = "ts"
 			case "gen":
-				var zb0012 int
-				zb0012, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0007 && "gen" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0016 int
+				zb0016, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
-				if zb0012 > config.MaxGenesisIDLen {
-					err = msgp.ErrOverflow(uint64(zb0012), uint64(config.MaxGenesisIDLen))
+				if zb0016 > config.MaxGenesisIDLen {
+					err = msgp.ErrOverflow(uint64(zb0016), uint64(config.MaxGenesisIDLen))
 					return
 				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -4665,129 +5391,224 @@ func (z *proposal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
+				zb0006 = "gen"
 			case "gh":
+				if validate && zb0007 && "gh" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.GenesisHash.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GenesisHash")
 					return
 				}
+				zb0006 = "gh"
 			case "fees":
+				if validate && zb0007 && "fees" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.FeeSink.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FeeSink")
 					return
 				}
+				zb0006 = "fees"
 			case "rwd":
+				if validate && zb0007 && "rwd" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsPool.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsPool")
 					return
 				}
+				zb0006 = "rwd"
 			case "earn":
+				if validate && zb0007 && "earn" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsLevel, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsLevel")
 					return
 				}
+				zb0006 = "earn"
 			case "rate":
+				if validate && zb0007 && "rate" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRate, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsRate")
 					return
 				}
+				zb0006 = "rate"
 			case "frac":
+				if validate && zb0007 && "frac" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsResidue, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsResidue")
 					return
 				}
+				zb0006 = "frac"
 			case "rwcalr":
+				if validate && zb0007 && "rwcalr" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRecalculationRound.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsRecalculationRound")
 					return
 				}
+				zb0006 = "rwcalr"
 			case "proto":
+				if validate && zb0007 && "proto" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.CurrentProtocol.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "CurrentProtocol")
 					return
 				}
+				zb0006 = "proto"
 			case "nextproto":
+				if validate && zb0007 && "nextproto" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocol.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocol")
 					return
 				}
+				zb0006 = "nextproto"
 			case "nextyes":
+				if validate && zb0007 && "nextyes" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocolApprovals, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocolApprovals")
 					return
 				}
+				zb0006 = "nextyes"
 			case "nextbefore":
+				if validate && zb0007 && "nextbefore" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocolVoteBefore.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocolVoteBefore")
 					return
 				}
+				zb0006 = "nextbefore"
 			case "nextswitch":
+				if validate && zb0007 && "nextswitch" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocolSwitchOn.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocolSwitchOn")
 					return
 				}
+				zb0006 = "nextswitch"
 			case "upgradeprop":
+				if validate && zb0007 && "upgradeprop" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradePropose.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradePropose")
 					return
 				}
+				zb0006 = "upgradeprop"
 			case "upgradedelay":
+				if validate && zb0007 && "upgradedelay" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeDelay.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradeDelay")
 					return
 				}
+				zb0006 = "upgradedelay"
 			case "upgradeyes":
+				if validate && zb0007 && "upgradeyes" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeApprove, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradeApprove")
 					return
 				}
+				zb0006 = "upgradeyes"
 			case "tc":
+				if validate && zb0007 && "tc" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.TxnCounter, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TxnCounter")
 					return
 				}
+				zb0006 = "tc"
 			case "spt":
-				var zb0013 int
-				var zb0014 bool
-				zb0013, zb0014, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0007 && "spt" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0017 int
+				var zb0018 bool
+				zb0017, zb0018, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofTracking")
 					return
 				}
-				if zb0013 > protocol.NumStateProofTypes {
-					err = msgp.ErrOverflow(uint64(zb0013), uint64(protocol.NumStateProofTypes))
+				if zb0017 > protocol.NumStateProofTypes {
+					err = msgp.ErrOverflow(uint64(zb0017), uint64(protocol.NumStateProofTypes))
 					err = msgp.WrapError(err, "StateProofTracking")
 					return
 				}
-				if zb0014 {
+				if zb0018 {
 					(*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking = nil
 				} else if (*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking == nil {
-					(*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking = make(map[protocol.StateProofType]bookkeeping.StateProofTrackingData, zb0013)
+					(*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking = make(map[protocol.StateProofType]bookkeeping.StateProofTrackingData, zb0017)
 				}
-				for zb0013 > 0 {
+				var zb0019 protocol.StateProofType
+				_ = zb0019
+				var zb0020 bool
+				_ = zb0020
+				for zb0017 > 0 {
 					var zb0001 protocol.StateProofType
 					var zb0002 bookkeeping.StateProofTrackingData
-					zb0013--
+					zb0017--
 					bts, err = zb0001.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "StateProofTracking")
 						return
 					}
+					if validate && zb0020 && protocol.StateProofTypeLess(zb0001, zb0019) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0019 = zb0001
+					zb0020 = true
 					bts, err = zb0002.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "StateProofTracking", zb0001)
@@ -4795,25 +5616,30 @@ func (z *proposal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking[zb0001] = zb0002
 				}
+				zb0006 = "spt"
 			case "partupdrmv":
-				var zb0015 int
-				var zb0016 bool
-				zb0015, zb0016, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0007 && "partupdrmv" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0021 int
+				var zb0022 bool
+				zb0021, zb0022, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0015 > config.MaxProposedExpiredOnlineAccounts {
-					err = msgp.ErrOverflow(uint64(zb0015), uint64(config.MaxProposedExpiredOnlineAccounts))
+				if zb0021 > config.MaxProposedExpiredOnlineAccounts {
+					err = msgp.ErrOverflow(uint64(zb0021), uint64(config.MaxProposedExpiredOnlineAccounts))
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0016 {
+				if zb0022 {
 					(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = nil
-				} else if (*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts) >= zb0015 {
-					(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = ((*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts)[:zb0015]
+				} else if (*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts) >= zb0021 {
+					(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = ((*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts)[:zb0021]
 				} else {
-					(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0015)
+					(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0021)
 				}
 				for zb0003 := range (*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts {
 					bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts[zb0003].UnmarshalMsg(bts)
@@ -4822,34 +5648,55 @@ func (z *proposal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0006 = "partupdrmv"
 			case "txns":
+				if validate && zb0007 && "txns" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.Payset.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Payset")
 					return
 				}
+				zb0006 = "txns"
 			case "sdpf":
+				if validate && zb0007 && "sdpf" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.SeedProof.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SeedProof")
 					return
 				}
+				zb0006 = "sdpf"
 			case "oper":
+				if validate && zb0007 && "oper" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0017 uint64
-					zb0017, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0023 uint64
+					zb0023, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "OriginalPeriod")
 						return
 					}
-					(*z).unauthenticatedProposal.OriginalPeriod = period(zb0017)
+					(*z).unauthenticatedProposal.OriginalPeriod = period(zb0023)
 				}
+				zb0006 = "oper"
 			case "oprop":
+				if validate && zb0007 && "oprop" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.OriginalProposer.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "OriginalProposer")
 					return
 				}
+				zb0006 = "oprop"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -4857,12 +5704,19 @@ func (z *proposal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0007 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *proposal) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *proposal) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *proposal) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*proposal)
 	return ok
@@ -4923,16 +5777,24 @@ func (_ *proposalManager) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *proposalManager) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *proposalManager) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -4965,12 +5827,19 @@ func (z *proposalManager) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *proposalManager) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *proposalManager) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *proposalManager) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*proposalManager)
 	return ok
@@ -5015,16 +5884,24 @@ func (_ *proposalSeeker) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *proposalSeeker) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *proposalSeeker) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -5075,23 +5952,38 @@ func (z *proposalSeeker) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "Lowest":
+				if validate && zb0004 && "Lowest" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Lowest.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Lowest")
 					return
 				}
+				zb0003 = "Lowest"
 			case "Filled":
+				if validate && zb0004 && "Filled" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Filled, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Filled")
 					return
 				}
+				zb0003 = "Filled"
 			case "Frozen":
+				if validate && zb0004 && "Frozen" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Frozen, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Frozen")
 					return
 				}
+				zb0003 = "Frozen"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -5099,12 +5991,19 @@ func (z *proposalSeeker) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *proposalSeeker) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *proposalSeeker) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *proposalSeeker) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*proposalSeeker)
 	return ok
@@ -5179,11 +6078,15 @@ func (_ *proposalStore) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *proposalStore) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *proposalStore) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0005 int
+	var zb0007 string
+	var zb0008 bool
 	var zb0006 bool
+	_ = zb0007
+	_ = zb0008
 	zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -5191,29 +6094,43 @@ func (z *proposalStore) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0005 > 0 {
 			zb0005--
-			var zb0007 int
-			var zb0008 bool
-			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0009 int
+			var zb0010 bool
+			zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Relevant")
 				return
 			}
-			if zb0008 {
+			if zb0010 {
 				(*z).Relevant = nil
 			} else if (*z).Relevant == nil {
-				(*z).Relevant = make(map[period]proposalValue, zb0007)
+				(*z).Relevant = make(map[period]proposalValue, zb0009)
 			}
-			for zb0007 > 0 {
+			var zb0011 period
+			_ = zb0011
+			var zb0012 bool
+			_ = zb0012
+			for zb0009 > 0 {
 				var zb0001 period
 				var zb0002 proposalValue
-				zb0007--
+				zb0009--
 				bts, err = zb0001.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Relevant")
 					return
 				}
+				if validate && zb0012 && PeriodLess(zb0001, zb0011) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0011 = zb0001
+				zb0012 = true
 				bts, err = zb0002.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Relevant", zb0001)
@@ -5232,27 +6149,37 @@ func (z *proposalStore) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0005 > 0 {
 			zb0005--
-			var zb0009 int
-			var zb0010 bool
-			zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0013 int
+			var zb0014 bool
+			zb0013, zb0014, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Assemblers")
 				return
 			}
-			if zb0010 {
+			if zb0014 {
 				(*z).Assemblers = nil
 			} else if (*z).Assemblers == nil {
-				(*z).Assemblers = make(map[proposalValue]blockAssembler, zb0009)
+				(*z).Assemblers = make(map[proposalValue]blockAssembler, zb0013)
 			}
-			for zb0009 > 0 {
+			var zb0015 proposalValue
+			_ = zb0015
+			var zb0016 bool
+			_ = zb0016
+			for zb0013 > 0 {
 				var zb0003 proposalValue
 				var zb0004 blockAssembler
-				zb0009--
+				zb0013--
 				bts, err = zb0003.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Assemblers")
 					return
 				}
+				if validate && zb0016 && ProposalValueLess(zb0003, zb0015) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0015 = zb0003
+				zb0016 = true
 				bts, err = zb0004.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Assemblers", zb0003)
@@ -5285,27 +6212,41 @@ func (z *proposalStore) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "Relevant":
-				var zb0011 int
-				var zb0012 bool
-				zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0008 && "Relevant" < zb0007 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0017 int
+				var zb0018 bool
+				zb0017, zb0018, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Relevant")
 					return
 				}
-				if zb0012 {
+				if zb0018 {
 					(*z).Relevant = nil
 				} else if (*z).Relevant == nil {
-					(*z).Relevant = make(map[period]proposalValue, zb0011)
+					(*z).Relevant = make(map[period]proposalValue, zb0017)
 				}
-				for zb0011 > 0 {
+				var zb0019 period
+				_ = zb0019
+				var zb0020 bool
+				_ = zb0020
+				for zb0017 > 0 {
 					var zb0001 period
 					var zb0002 proposalValue
-					zb0011--
+					zb0017--
 					bts, err = zb0001.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Relevant")
 						return
 					}
+					if validate && zb0020 && PeriodLess(zb0001, zb0019) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0019 = zb0001
+					zb0020 = true
 					bts, err = zb0002.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Relevant", zb0001)
@@ -5313,34 +6254,54 @@ func (z *proposalStore) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).Relevant[zb0001] = zb0002
 				}
+				zb0007 = "Relevant"
 			case "Pinned":
+				if validate && zb0008 && "Pinned" < zb0007 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Pinned.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Pinned")
 					return
 				}
+				zb0007 = "Pinned"
 			case "Assemblers":
-				var zb0013 int
-				var zb0014 bool
-				zb0013, zb0014, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0008 && "Assemblers" < zb0007 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0021 int
+				var zb0022 bool
+				zb0021, zb0022, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Assemblers")
 					return
 				}
-				if zb0014 {
+				if zb0022 {
 					(*z).Assemblers = nil
 				} else if (*z).Assemblers == nil {
-					(*z).Assemblers = make(map[proposalValue]blockAssembler, zb0013)
+					(*z).Assemblers = make(map[proposalValue]blockAssembler, zb0021)
 				}
-				for zb0013 > 0 {
+				var zb0023 proposalValue
+				_ = zb0023
+				var zb0024 bool
+				_ = zb0024
+				for zb0021 > 0 {
 					var zb0003 proposalValue
 					var zb0004 blockAssembler
-					zb0013--
+					zb0021--
 					bts, err = zb0003.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Assemblers")
 						return
 					}
+					if validate && zb0024 && ProposalValueLess(zb0003, zb0023) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0023 = zb0003
+					zb0024 = true
 					bts, err = zb0004.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Assemblers", zb0003)
@@ -5348,6 +6309,7 @@ func (z *proposalStore) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).Assemblers[zb0003] = zb0004
 				}
+				zb0007 = "Assemblers"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -5355,12 +6317,19 @@ func (z *proposalStore) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0008 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *proposalStore) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *proposalStore) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *proposalStore) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*proposalStore)
 	return ok
@@ -5459,11 +6428,15 @@ func (_ *proposalTable) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *proposalTable) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *proposalTable) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -5471,29 +6444,43 @@ func (z *proposalTable) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0007 int
+			var zb0008 bool
+			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Pending")
 				return
 			}
-			if zb0006 {
+			if zb0008 {
 				(*z).Pending = nil
 			} else if (*z).Pending == nil {
-				(*z).Pending = make(map[uint64]*messageEvent, zb0005)
+				(*z).Pending = make(map[uint64]*messageEvent, zb0007)
 			}
-			for zb0005 > 0 {
+			var zb0009 uint64
+			_ = zb0009
+			var zb0010 bool
+			_ = zb0010
+			for zb0007 > 0 {
 				var zb0001 uint64
 				var zb0002 *messageEvent
-				zb0005--
+				zb0007--
 				zb0001, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Pending")
 					return
 				}
+				if validate && zb0010 && Uint64Less(zb0001, zb0009) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0009 = zb0001
+				zb0010 = true
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
@@ -5545,27 +6532,41 @@ func (z *proposalTable) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "Pending":
-				var zb0007 int
-				var zb0008 bool
-				zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0006 && "Pending" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0011 int
+				var zb0012 bool
+				zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Pending")
 					return
 				}
-				if zb0008 {
+				if zb0012 {
 					(*z).Pending = nil
 				} else if (*z).Pending == nil {
-					(*z).Pending = make(map[uint64]*messageEvent, zb0007)
+					(*z).Pending = make(map[uint64]*messageEvent, zb0011)
 				}
-				for zb0007 > 0 {
+				var zb0013 uint64
+				_ = zb0013
+				var zb0014 bool
+				_ = zb0014
+				for zb0011 > 0 {
 					var zb0001 uint64
 					var zb0002 *messageEvent
-					zb0007--
+					zb0011--
 					zb0001, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Pending")
 						return
 					}
+					if validate && zb0014 && Uint64Less(zb0001, zb0013) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0013 = zb0001
+					zb0014 = true
 					if msgp.IsNil(bts) {
 						bts, err = msgp.ReadNilBytes(bts)
 						if err != nil {
@@ -5584,12 +6585,18 @@ func (z *proposalTable) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).Pending[zb0001] = zb0002
 				}
+				zb0005 = "Pending"
 			case "PendingNext":
+				if validate && zb0006 && "PendingNext" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).PendingNext, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "PendingNext")
 					return
 				}
+				zb0005 = "PendingNext"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -5597,12 +6604,19 @@ func (z *proposalTable) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *proposalTable) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *proposalTable) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *proposalTable) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*proposalTable)
 	return ok
@@ -5678,11 +6692,15 @@ func (_ *proposalTracker) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *proposalTracker) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *proposalTracker) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -5690,29 +6708,43 @@ func (z *proposalTracker) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0007 int
+			var zb0008 bool
+			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Duplicate")
 				return
 			}
-			if zb0006 {
+			if zb0008 {
 				(*z).Duplicate = nil
 			} else if (*z).Duplicate == nil {
-				(*z).Duplicate = make(map[basics.Address]bool, zb0005)
+				(*z).Duplicate = make(map[basics.Address]bool, zb0007)
 			}
-			for zb0005 > 0 {
+			var zb0009 basics.Address
+			_ = zb0009
+			var zb0010 bool
+			_ = zb0010
+			for zb0007 > 0 {
 				var zb0001 basics.Address
 				var zb0002 bool
-				zb0005--
+				zb0007--
 				bts, err = zb0001.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Duplicate")
 					return
 				}
+				if validate && zb0010 && basics.AddressLess(zb0001, zb0009) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0009 = zb0001
+				zb0010 = true
 				zb0002, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Duplicate", zb0001)
@@ -5761,27 +6793,41 @@ func (z *proposalTracker) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "Duplicate":
-				var zb0007 int
-				var zb0008 bool
-				zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0006 && "Duplicate" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0011 int
+				var zb0012 bool
+				zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Duplicate")
 					return
 				}
-				if zb0008 {
+				if zb0012 {
 					(*z).Duplicate = nil
 				} else if (*z).Duplicate == nil {
-					(*z).Duplicate = make(map[basics.Address]bool, zb0007)
+					(*z).Duplicate = make(map[basics.Address]bool, zb0011)
 				}
-				for zb0007 > 0 {
+				var zb0013 basics.Address
+				_ = zb0013
+				var zb0014 bool
+				_ = zb0014
+				for zb0011 > 0 {
 					var zb0001 basics.Address
 					var zb0002 bool
-					zb0007--
+					zb0011--
 					bts, err = zb0001.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Duplicate")
 						return
 					}
+					if validate && zb0014 && basics.AddressLess(zb0001, zb0013) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0013 = zb0001
+					zb0014 = true
 					zb0002, bts, err = msgp.ReadBoolBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Duplicate", zb0001)
@@ -5789,18 +6835,29 @@ func (z *proposalTracker) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).Duplicate[zb0001] = zb0002
 				}
+				zb0005 = "Duplicate"
 			case "Freezer":
+				if validate && zb0006 && "Freezer" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Freezer.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Freezer")
 					return
 				}
+				zb0005 = "Freezer"
 			case "Staging":
+				if validate && zb0006 && "Staging" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Staging.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Staging")
 					return
 				}
+				zb0005 = "Staging"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -5808,12 +6865,19 @@ func (z *proposalTracker) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *proposalTracker) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *proposalTracker) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *proposalTracker) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*proposalTracker)
 	return ok
@@ -5872,16 +6936,24 @@ func (_ *proposalTrackerContract) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *proposalTrackerContract) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *proposalTrackerContract) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -5940,29 +7012,49 @@ func (z *proposalTrackerContract) UnmarshalMsg(bts []byte) (o []byte, err error)
 			}
 			switch string(field) {
 			case "SawOneVote":
+				if validate && zb0004 && "SawOneVote" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).SawOneVote, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SawOneVote")
 					return
 				}
+				zb0003 = "SawOneVote"
 			case "Froze":
+				if validate && zb0004 && "Froze" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Froze, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Froze")
 					return
 				}
+				zb0003 = "Froze"
 			case "SawSoftThreshold":
+				if validate && zb0004 && "SawSoftThreshold" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).SawSoftThreshold, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SawSoftThreshold")
 					return
 				}
+				zb0003 = "SawSoftThreshold"
 			case "SawCertThreshold":
+				if validate && zb0004 && "SawCertThreshold" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).SawCertThreshold, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SawCertThreshold")
 					return
 				}
+				zb0003 = "SawCertThreshold"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -5970,12 +7062,19 @@ func (z *proposalTrackerContract) UnmarshalMsg(bts []byte) (o []byte, err error)
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *proposalTrackerContract) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *proposalTrackerContract) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *proposalTrackerContract) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*proposalTrackerContract)
 	return ok
@@ -6053,11 +7152,15 @@ func (_ *proposalValue) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *proposalValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *proposalValue) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -6065,16 +7168,20 @@ func (z *proposalValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0003 uint64
-				zb0003, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0005 uint64
+				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "OriginalPeriod")
 					return
 				}
-				(*z).OriginalPeriod = period(zb0003)
+				(*z).OriginalPeriod = period(zb0005)
 			}
 		}
 		if zb0001 > 0 {
@@ -6125,33 +7232,53 @@ func (z *proposalValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "oper":
+				if validate && zb0004 && "oper" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0004 uint64
-					zb0004, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0006 uint64
+					zb0006, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "OriginalPeriod")
 						return
 					}
-					(*z).OriginalPeriod = period(zb0004)
+					(*z).OriginalPeriod = period(zb0006)
 				}
+				zb0003 = "oper"
 			case "oprop":
+				if validate && zb0004 && "oprop" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).OriginalProposer.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "OriginalProposer")
 					return
 				}
+				zb0003 = "oprop"
 			case "dig":
+				if validate && zb0004 && "dig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockDigest.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "BlockDigest")
 					return
 				}
+				zb0003 = "dig"
 			case "encdig":
+				if validate && zb0004 && "encdig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).EncodingDigest.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "EncodingDigest")
 					return
 				}
+				zb0003 = "encdig"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -6159,12 +7286,19 @@ func (z *proposalValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *proposalValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *proposalValue) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *proposalValue) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*proposalValue)
 	return ok
@@ -6221,16 +7355,24 @@ func (_ *proposalVoteCounter) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *proposalVoteCounter) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *proposalVoteCounter) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -6243,27 +7385,37 @@ func (z *proposalVoteCounter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0007 int
+			var zb0008 bool
+			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Votes")
 				return
 			}
-			if zb0006 {
+			if zb0008 {
 				(*z).Votes = nil
 			} else if (*z).Votes == nil {
-				(*z).Votes = make(map[basics.Address]vote, zb0005)
+				(*z).Votes = make(map[basics.Address]vote, zb0007)
 			}
-			for zb0005 > 0 {
+			var zb0009 basics.Address
+			_ = zb0009
+			var zb0010 bool
+			_ = zb0010
+			for zb0007 > 0 {
 				var zb0001 basics.Address
 				var zb0002 vote
-				zb0005--
+				zb0007--
 				bts, err = zb0001.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Votes")
 					return
 				}
+				if validate && zb0010 && basics.AddressLess(zb0001, zb0009) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0009 = zb0001
+				zb0010 = true
 				bts, err = zb0002.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Votes", zb0001)
@@ -6296,33 +7448,52 @@ func (z *proposalVoteCounter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "Count":
+				if validate && zb0006 && "Count" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Count, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Count")
 					return
 				}
+				zb0005 = "Count"
 			case "Votes":
-				var zb0007 int
-				var zb0008 bool
-				zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0006 && "Votes" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0011 int
+				var zb0012 bool
+				zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Votes")
 					return
 				}
-				if zb0008 {
+				if zb0012 {
 					(*z).Votes = nil
 				} else if (*z).Votes == nil {
-					(*z).Votes = make(map[basics.Address]vote, zb0007)
+					(*z).Votes = make(map[basics.Address]vote, zb0011)
 				}
-				for zb0007 > 0 {
+				var zb0013 basics.Address
+				_ = zb0013
+				var zb0014 bool
+				_ = zb0014
+				for zb0011 > 0 {
 					var zb0001 basics.Address
 					var zb0002 vote
-					zb0007--
+					zb0011--
 					bts, err = zb0001.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Votes")
 						return
 					}
+					if validate && zb0014 && basics.AddressLess(zb0001, zb0013) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0013 = zb0001
+					zb0014 = true
 					bts, err = zb0002.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Votes", zb0001)
@@ -6330,6 +7501,7 @@ func (z *proposalVoteCounter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).Votes[zb0001] = zb0002
 				}
+				zb0005 = "Votes"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -6337,12 +7509,19 @@ func (z *proposalVoteCounter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *proposalVoteCounter) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *proposalVoteCounter) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *proposalVoteCounter) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*proposalVoteCounter)
 	return ok
@@ -6393,16 +7572,24 @@ func (_ *proposerSeed) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *proposerSeed) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *proposerSeed) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -6445,17 +7632,27 @@ func (z *proposerSeed) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "addr":
+				if validate && zb0004 && "addr" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Addr.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Addr")
 					return
 				}
+				zb0003 = "addr"
 			case "vrf":
+				if validate && zb0004 && "vrf" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VRF.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VRF")
 					return
 				}
+				zb0003 = "vrf"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -6463,12 +7660,19 @@ func (z *proposerSeed) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *proposerSeed) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *proposerSeed) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *proposerSeed) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*proposerSeed)
 	return ok
@@ -6555,16 +7759,24 @@ func (_ *rawVote) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *rawVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *rawVote) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -6586,25 +7798,25 @@ func (z *rawVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0003 uint64
-				zb0003, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0005 uint64
+				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Period")
 					return
 				}
-				(*z).Period = period(zb0003)
+				(*z).Period = period(zb0005)
 			}
 		}
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0004 uint64
-				zb0004, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0006 uint64
+				zb0006, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Step")
 					return
 				}
-				(*z).Step = step(zb0004)
+				(*z).Step = step(zb0006)
 			}
 		}
 		if zb0001 > 0 {
@@ -6639,43 +7851,68 @@ func (z *rawVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "snd":
+				if validate && zb0004 && "snd" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sender.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sender")
 					return
 				}
+				zb0003 = "snd"
 			case "rnd":
+				if validate && zb0004 && "rnd" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Round.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0003 = "rnd"
 			case "per":
+				if validate && zb0004 && "per" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0005 uint64
-					zb0005, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0007 uint64
+					zb0007, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Period")
 						return
 					}
-					(*z).Period = period(zb0005)
+					(*z).Period = period(zb0007)
 				}
+				zb0003 = "per"
 			case "step":
+				if validate && zb0004 && "step" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0006 uint64
-					zb0006, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0008 uint64
+					zb0008, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Step")
 						return
 					}
-					(*z).Step = step(zb0006)
+					(*z).Step = step(zb0008)
 				}
+				zb0003 = "step"
 			case "prop":
+				if validate && zb0004 && "prop" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Proposal.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Proposal")
 					return
 				}
+				zb0003 = "prop"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -6683,12 +7920,19 @@ func (z *rawVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *rawVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *rawVote) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *rawVote) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*rawVote)
 	return ok
@@ -6754,11 +7998,15 @@ func (_ *rootRouter) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *rootRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *rootRouter) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -6766,19 +8014,31 @@ func (z *rootRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0007 int
+			var zb0009 string
+			var zb0010 bool
+			var zb0008 bool
+			_ = zb0009
+			_ = zb0010
+			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "ProposalManager")
 					return
 				}
-				if zb0005 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0005)
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0007 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0007)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "ProposalManager", "struct-from-array")
 						return
@@ -6789,11 +8049,11 @@ func (z *rootRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "ProposalManager")
 					return
 				}
-				if zb0006 {
+				if zb0008 {
 					(*z).ProposalManager = proposalManager{}
 				}
-				for zb0005 > 0 {
-					zb0005--
+				for zb0007 > 0 {
+					zb0007--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "ProposalManager")
@@ -6807,22 +8067,31 @@ func (z *rootRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0010 = true
 				}
 			}
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0007 int
-			var zb0008 bool
-			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0011 int
+			var zb0013 string
+			var zb0014 bool
+			var zb0012 bool
+			_ = zb0013
+			_ = zb0014
+			zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "VoteAggregator")
 					return
 				}
-				if zb0007 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0007)
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0011 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0011)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "VoteAggregator", "struct-from-array")
 						return
@@ -6833,11 +8102,11 @@ func (z *rootRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "VoteAggregator")
 					return
 				}
-				if zb0008 {
+				if zb0012 {
 					(*z).VoteAggregator = voteAggregator{}
 				}
-				for zb0007 > 0 {
-					zb0007--
+				for zb0011 > 0 {
+					zb0011--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "VoteAggregator")
@@ -6851,32 +8120,43 @@ func (z *rootRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0014 = true
 				}
 			}
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0009 int
-			var zb0010 bool
-			zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0015 int
+			var zb0016 bool
+			zb0015, zb0016, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Children")
 				return
 			}
-			if zb0010 {
+			if zb0016 {
 				(*z).Children = nil
 			} else if (*z).Children == nil {
-				(*z).Children = make(map[round]*roundRouter, zb0009)
+				(*z).Children = make(map[round]*roundRouter, zb0015)
 			}
-			for zb0009 > 0 {
+			var zb0017 basics.Round
+			_ = zb0017
+			var zb0018 bool
+			_ = zb0018
+			for zb0015 > 0 {
 				var zb0001 basics.Round
 				var zb0002 *roundRouter
-				zb0009--
+				zb0015--
 				bts, err = zb0001.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Children")
 					return
 				}
+				if validate && zb0018 && RoundLess(zb0001, zb0017) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0017 = zb0001
+				zb0018 = true
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
@@ -6920,17 +8200,29 @@ func (z *rootRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "ProposalManager":
-				var zb0011 int
-				var zb0012 bool
-				zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0006 && "ProposalManager" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0019 int
+				var zb0021 string
+				var zb0022 bool
+				var zb0020 bool
+				_ = zb0021
+				_ = zb0022
+				zb0019, zb0020, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0019, zb0020, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "ProposalManager")
 						return
 					}
-					if zb0011 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0011)
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0019 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0019)
 						if err != nil {
 							err = msgp.WrapError(err, "ProposalManager", "struct-from-array")
 							return
@@ -6941,11 +8233,11 @@ func (z *rootRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "ProposalManager")
 						return
 					}
-					if zb0012 {
+					if zb0020 {
 						(*z).ProposalManager = proposalManager{}
 					}
-					for zb0011 > 0 {
-						zb0011--
+					for zb0019 > 0 {
+						zb0019--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "ProposalManager")
@@ -6959,20 +8251,34 @@ func (z *rootRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0022 = true
 					}
 				}
+				zb0005 = "ProposalManager"
 			case "VoteAggregator":
-				var zb0013 int
-				var zb0014 bool
-				zb0013, zb0014, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0006 && "VoteAggregator" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0023 int
+				var zb0025 string
+				var zb0026 bool
+				var zb0024 bool
+				_ = zb0025
+				_ = zb0026
+				zb0023, zb0024, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0023, zb0024, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "VoteAggregator")
 						return
 					}
-					if zb0013 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0013)
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0023 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0023)
 						if err != nil {
 							err = msgp.WrapError(err, "VoteAggregator", "struct-from-array")
 							return
@@ -6983,11 +8289,11 @@ func (z *rootRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "VoteAggregator")
 						return
 					}
-					if zb0014 {
+					if zb0024 {
 						(*z).VoteAggregator = voteAggregator{}
 					}
-					for zb0013 > 0 {
-						zb0013--
+					for zb0023 > 0 {
+						zb0023--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "VoteAggregator")
@@ -7001,30 +8307,46 @@ func (z *rootRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0026 = true
 					}
 				}
+				zb0005 = "VoteAggregator"
 			case "Children":
-				var zb0015 int
-				var zb0016 bool
-				zb0015, zb0016, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0006 && "Children" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0027 int
+				var zb0028 bool
+				zb0027, zb0028, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Children")
 					return
 				}
-				if zb0016 {
+				if zb0028 {
 					(*z).Children = nil
 				} else if (*z).Children == nil {
-					(*z).Children = make(map[round]*roundRouter, zb0015)
+					(*z).Children = make(map[round]*roundRouter, zb0027)
 				}
-				for zb0015 > 0 {
+				var zb0029 basics.Round
+				_ = zb0029
+				var zb0030 bool
+				_ = zb0030
+				for zb0027 > 0 {
 					var zb0001 basics.Round
 					var zb0002 *roundRouter
-					zb0015--
+					zb0027--
 					bts, err = zb0001.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Children")
 						return
 					}
+					if validate && zb0030 && RoundLess(zb0001, zb0029) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0029 = zb0001
+					zb0030 = true
 					if msgp.IsNil(bts) {
 						bts, err = msgp.ReadNilBytes(bts)
 						if err != nil {
@@ -7043,6 +8365,7 @@ func (z *rootRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).Children[zb0001] = zb0002
 				}
+				zb0005 = "Children"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -7050,12 +8373,19 @@ func (z *rootRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *rootRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *rootRouter) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *rootRouter) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*rootRouter)
 	return ok
@@ -7139,16 +8469,24 @@ func (_ *roundRouter) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *roundRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *roundRouter) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -7161,33 +8499,41 @@ func (z *roundRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0007 int
+			var zb0009 string
+			var zb0010 bool
+			var zb0008 bool
+			_ = zb0009
+			_ = zb0010
+			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "VoteTrackerRound")
 					return
 				}
-				if zb0005 > 0 {
-					zb0005--
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0007 > 0 {
+					zb0007--
 					bts, err = (*z).VoteTrackerRound.Freshest.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "VoteTrackerRound", "struct-from-array", "Freshest")
 						return
 					}
 				}
-				if zb0005 > 0 {
-					zb0005--
+				if zb0007 > 0 {
+					zb0007--
 					(*z).VoteTrackerRound.Ok, bts, err = msgp.ReadBoolBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "VoteTrackerRound", "struct-from-array", "Ok")
 						return
 					}
 				}
-				if zb0005 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0005)
+				if zb0007 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0007)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "VoteTrackerRound", "struct-from-array")
 						return
@@ -7198,11 +8544,11 @@ func (z *roundRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "VoteTrackerRound")
 					return
 				}
-				if zb0006 {
+				if zb0008 {
 					(*z).VoteTrackerRound = voteTrackerRound{}
 				}
-				for zb0005 > 0 {
-					zb0005--
+				for zb0007 > 0 {
+					zb0007--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "VoteTrackerRound")
@@ -7210,17 +8556,27 @@ func (z *roundRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch string(field) {
 					case "Freshest":
+						if validate && zb0010 && "Freshest" < zb0009 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						bts, err = (*z).VoteTrackerRound.Freshest.UnmarshalMsg(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "VoteTrackerRound", "Freshest")
 							return
 						}
+						zb0009 = "Freshest"
 					case "Ok":
+						if validate && zb0010 && "Ok" < zb0009 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).VoteTrackerRound.Ok, bts, err = msgp.ReadBoolBytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "VoteTrackerRound", "Ok")
 							return
 						}
+						zb0009 = "Ok"
 					default:
 						err = msgp.ErrNoField(string(field))
 						if err != nil {
@@ -7228,32 +8584,43 @@ func (z *roundRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0010 = true
 				}
 			}
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0007 int
-			var zb0008 bool
-			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0011 int
+			var zb0012 bool
+			zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Children")
 				return
 			}
-			if zb0008 {
+			if zb0012 {
 				(*z).Children = nil
 			} else if (*z).Children == nil {
-				(*z).Children = make(map[period]*periodRouter, zb0007)
+				(*z).Children = make(map[period]*periodRouter, zb0011)
 			}
-			for zb0007 > 0 {
+			var zb0013 period
+			_ = zb0013
+			var zb0014 bool
+			_ = zb0014
+			for zb0011 > 0 {
 				var zb0001 period
 				var zb0002 *periodRouter
-				zb0007--
+				zb0011--
 				bts, err = zb0001.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Children")
 					return
 				}
+				if validate && zb0014 && PeriodLess(zb0001, zb0013) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0013 = zb0001
+				zb0014 = true
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
@@ -7297,39 +8664,56 @@ func (z *roundRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "ProposalStore":
+				if validate && zb0006 && "ProposalStore" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ProposalStore.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ProposalStore")
 					return
 				}
+				zb0005 = "ProposalStore"
 			case "VoteTrackerRound":
-				var zb0009 int
-				var zb0010 bool
-				zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0006 && "VoteTrackerRound" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0015 int
+				var zb0017 string
+				var zb0018 bool
+				var zb0016 bool
+				_ = zb0017
+				_ = zb0018
+				zb0015, zb0016, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0015, zb0016, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "VoteTrackerRound")
 						return
 					}
-					if zb0009 > 0 {
-						zb0009--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0015 > 0 {
+						zb0015--
 						bts, err = (*z).VoteTrackerRound.Freshest.UnmarshalMsg(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "VoteTrackerRound", "struct-from-array", "Freshest")
 							return
 						}
 					}
-					if zb0009 > 0 {
-						zb0009--
+					if zb0015 > 0 {
+						zb0015--
 						(*z).VoteTrackerRound.Ok, bts, err = msgp.ReadBoolBytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "VoteTrackerRound", "struct-from-array", "Ok")
 							return
 						}
 					}
-					if zb0009 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0009)
+					if zb0015 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0015)
 						if err != nil {
 							err = msgp.WrapError(err, "VoteTrackerRound", "struct-from-array")
 							return
@@ -7340,11 +8724,11 @@ func (z *roundRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "VoteTrackerRound")
 						return
 					}
-					if zb0010 {
+					if zb0016 {
 						(*z).VoteTrackerRound = voteTrackerRound{}
 					}
-					for zb0009 > 0 {
-						zb0009--
+					for zb0015 > 0 {
+						zb0015--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "VoteTrackerRound")
@@ -7352,17 +8736,27 @@ func (z *roundRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "Freshest":
+							if validate && zb0018 && "Freshest" < zb0017 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							bts, err = (*z).VoteTrackerRound.Freshest.UnmarshalMsg(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "VoteTrackerRound", "Freshest")
 								return
 							}
+							zb0017 = "Freshest"
 						case "Ok":
+							if validate && zb0018 && "Ok" < zb0017 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).VoteTrackerRound.Ok, bts, err = msgp.ReadBoolBytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "VoteTrackerRound", "Ok")
 								return
 							}
+							zb0017 = "Ok"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -7370,30 +8764,46 @@ func (z *roundRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0018 = true
 					}
 				}
+				zb0005 = "VoteTrackerRound"
 			case "Children":
-				var zb0011 int
-				var zb0012 bool
-				zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0006 && "Children" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0019 int
+				var zb0020 bool
+				zb0019, zb0020, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Children")
 					return
 				}
-				if zb0012 {
+				if zb0020 {
 					(*z).Children = nil
 				} else if (*z).Children == nil {
-					(*z).Children = make(map[period]*periodRouter, zb0011)
+					(*z).Children = make(map[period]*periodRouter, zb0019)
 				}
-				for zb0011 > 0 {
+				var zb0021 period
+				_ = zb0021
+				var zb0022 bool
+				_ = zb0022
+				for zb0019 > 0 {
 					var zb0001 period
 					var zb0002 *periodRouter
-					zb0011--
+					zb0019--
 					bts, err = zb0001.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Children")
 						return
 					}
+					if validate && zb0022 && PeriodLess(zb0001, zb0021) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0021 = zb0001
+					zb0022 = true
 					if msgp.IsNil(bts) {
 						bts, err = msgp.ReadNilBytes(bts)
 						if err != nil {
@@ -7412,6 +8822,7 @@ func (z *roundRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).Children[zb0001] = zb0002
 				}
+				zb0005 = "Children"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -7419,12 +8830,19 @@ func (z *roundRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *roundRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *roundRouter) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *roundRouter) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*roundRouter)
 	return ok
@@ -7480,16 +8898,24 @@ func (_ *seedInput) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *seedInput) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *seedInput) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -7532,17 +8958,27 @@ func (z *seedInput) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "alpha":
+				if validate && zb0004 && "alpha" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Alpha.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Alpha")
 					return
 				}
+				zb0003 = "alpha"
 			case "hist":
+				if validate && zb0004 && "hist" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).History.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "History")
 					return
 				}
+				zb0003 = "hist"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -7550,12 +8986,19 @@ func (z *seedInput) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *seedInput) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *seedInput) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *seedInput) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*seedInput)
 	return ok
@@ -7603,16 +9046,24 @@ func (_ *selector) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *selector) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *selector) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -7634,25 +9085,25 @@ func (z *selector) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0003 uint64
-				zb0003, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0005 uint64
+				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Period")
 					return
 				}
-				(*z).Period = period(zb0003)
+				(*z).Period = period(zb0005)
 			}
 		}
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0004 uint64
-				zb0004, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0006 uint64
+				zb0006, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Step")
 					return
 				}
-				(*z).Step = step(zb0004)
+				(*z).Step = step(zb0006)
 			}
 		}
 		if zb0001 > 0 {
@@ -7679,37 +9130,57 @@ func (z *selector) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "seed":
+				if validate && zb0004 && "seed" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Seed.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Seed")
 					return
 				}
+				zb0003 = "seed"
 			case "rnd":
+				if validate && zb0004 && "rnd" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Round.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0003 = "rnd"
 			case "per":
+				if validate && zb0004 && "per" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0005 uint64
-					zb0005, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0007 uint64
+					zb0007, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Period")
 						return
 					}
-					(*z).Period = period(zb0005)
+					(*z).Period = period(zb0007)
 				}
+				zb0003 = "per"
 			case "step":
+				if validate && zb0004 && "step" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0006 uint64
-					zb0006, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0008 uint64
+					zb0008, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Step")
 						return
 					}
-					(*z).Step = step(zb0006)
+					(*z).Step = step(zb0008)
 				}
+				zb0003 = "step"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -7717,12 +9188,19 @@ func (z *selector) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *selector) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *selector) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *selector) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*selector)
 	return ok
@@ -7761,7 +9239,7 @@ func (_ serializableError) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *serializableError) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *serializableError) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 string
 		zb0001, bts, err = msgp.ReadStringBytes(bts)
@@ -7775,6 +9253,12 @@ func (z *serializableError) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *serializableError) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *serializableError) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *serializableError) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*serializableError)
 	return ok
@@ -7813,7 +9297,7 @@ func (_ step) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *step) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *step) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 uint64
 		zb0001, bts, err = msgp.ReadUint64Bytes(bts)
@@ -7827,6 +9311,12 @@ func (z *step) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *step) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *step) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *step) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*step)
 	return ok
@@ -7868,16 +9358,24 @@ func (_ *stepRouter) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *stepRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *stepRouter) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -7920,17 +9418,27 @@ func (z *stepRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "VoteTracker":
+				if validate && zb0004 && "VoteTracker" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VoteTracker.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteTracker")
 					return
 				}
+				zb0003 = "VoteTracker"
 			case "VoteTrackerContract":
+				if validate && zb0004 && "VoteTrackerContract" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VoteTrackerContract.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteTrackerContract")
 					return
 				}
+				zb0003 = "VoteTrackerContract"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -7938,12 +9446,19 @@ func (z *stepRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *stepRouter) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *stepRouter) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *stepRouter) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*stepRouter)
 	return ok
@@ -8000,11 +9515,15 @@ func (_ *thresholdEvent) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *thresholdEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *thresholdEvent) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -8012,16 +9531,20 @@ func (z *thresholdEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0003 uint8
-				zb0003, bts, err = msgp.ReadUint8Bytes(bts)
+				var zb0005 uint8
+				zb0005, bts, err = msgp.ReadUint8Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "T")
 					return
 				}
-				(*z).T = eventType(zb0003)
+				(*z).T = eventType(zb0005)
 			}
 		}
 		if zb0001 > 0 {
@@ -8035,25 +9558,25 @@ func (z *thresholdEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0004 uint64
-				zb0004, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0006 uint64
+				zb0006, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Period")
 					return
 				}
-				(*z).Period = period(zb0004)
+				(*z).Period = period(zb0006)
 			}
 		}
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0005 uint64
-				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0007 uint64
+				zb0007, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Step")
 					return
 				}
-				(*z).Step = step(zb0005)
+				(*z).Step = step(zb0007)
 			}
 		}
 		if zb0001 > 0 {
@@ -8104,59 +9627,94 @@ func (z *thresholdEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "T":
+				if validate && zb0004 && "T" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0006 uint8
-					zb0006, bts, err = msgp.ReadUint8Bytes(bts)
+					var zb0008 uint8
+					zb0008, bts, err = msgp.ReadUint8Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "T")
 						return
 					}
-					(*z).T = eventType(zb0006)
+					(*z).T = eventType(zb0008)
 				}
+				zb0003 = "T"
 			case "Round":
+				if validate && zb0004 && "Round" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Round.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0003 = "Round"
 			case "Period":
+				if validate && zb0004 && "Period" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0007 uint64
-					zb0007, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0009 uint64
+					zb0009, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Period")
 						return
 					}
-					(*z).Period = period(zb0007)
+					(*z).Period = period(zb0009)
 				}
+				zb0003 = "Period"
 			case "Step":
+				if validate && zb0004 && "Step" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0008 uint64
-					zb0008, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0010 uint64
+					zb0010, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Step")
 						return
 					}
-					(*z).Step = step(zb0008)
+					(*z).Step = step(zb0010)
 				}
+				zb0003 = "Step"
 			case "Proposal":
+				if validate && zb0004 && "Proposal" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Proposal.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Proposal")
 					return
 				}
+				zb0003 = "Proposal"
 			case "Bundle":
+				if validate && zb0004 && "Bundle" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Bundle.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Bundle")
 					return
 				}
+				zb0003 = "Bundle"
 			case "Proto":
+				if validate && zb0004 && "Proto" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Proto.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Proto")
 					return
 				}
+				zb0003 = "Proto"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -8164,12 +9722,19 @@ func (z *thresholdEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *thresholdEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *thresholdEvent) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *thresholdEvent) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*thresholdEvent)
 	return ok
@@ -8503,16 +10068,24 @@ func (_ *transmittedPayload) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *transmittedPayload) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *transmittedPayload) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0004 int
+	var zb0006 string
+	var zb0007 bool
 	var zb0005 bool
+	_ = zb0006
+	_ = zb0007
 	zb0004, zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0004 > 0 {
@@ -8565,14 +10138,14 @@ func (z *transmittedPayload) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0006 int
-			zb0006, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0008 int
+			zb0008, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "GenesisID")
 				return
 			}
-			if zb0006 > config.MaxGenesisIDLen {
-				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxGenesisIDLen))
+			if zb0008 > config.MaxGenesisIDLen {
+				err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxGenesisIDLen))
 				return
 			}
 			(*z).unauthenticatedProposal.Block.BlockHeader.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -8711,32 +10284,42 @@ func (z *transmittedPayload) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0007 int
-			var zb0008 bool
-			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0009 int
+			var zb0010 bool
+			zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "StateProofTracking")
 				return
 			}
-			if zb0007 > protocol.NumStateProofTypes {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(protocol.NumStateProofTypes))
+			if zb0009 > protocol.NumStateProofTypes {
+				err = msgp.ErrOverflow(uint64(zb0009), uint64(protocol.NumStateProofTypes))
 				err = msgp.WrapError(err, "struct-from-array", "StateProofTracking")
 				return
 			}
-			if zb0008 {
+			if zb0010 {
 				(*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking = nil
 			} else if (*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking == nil {
-				(*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking = make(map[protocol.StateProofType]bookkeeping.StateProofTrackingData, zb0007)
+				(*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking = make(map[protocol.StateProofType]bookkeeping.StateProofTrackingData, zb0009)
 			}
-			for zb0007 > 0 {
+			var zb0011 protocol.StateProofType
+			_ = zb0011
+			var zb0012 bool
+			_ = zb0012
+			for zb0009 > 0 {
 				var zb0001 protocol.StateProofType
 				var zb0002 bookkeeping.StateProofTrackingData
-				zb0007--
+				zb0009--
 				bts, err = zb0001.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "StateProofTracking")
 					return
 				}
+				if validate && zb0012 && protocol.StateProofTypeLess(zb0001, zb0011) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0011 = zb0001
+				zb0012 = true
 				bts, err = zb0002.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "StateProofTracking", zb0001)
@@ -8747,24 +10330,24 @@ func (z *transmittedPayload) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0009 int
-			var zb0010 bool
-			zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0013 int
+			var zb0014 bool
+			zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0009 > config.MaxProposedExpiredOnlineAccounts {
-				err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxProposedExpiredOnlineAccounts))
+			if zb0013 > config.MaxProposedExpiredOnlineAccounts {
+				err = msgp.ErrOverflow(uint64(zb0013), uint64(config.MaxProposedExpiredOnlineAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0010 {
+			if zb0014 {
 				(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = nil
-			} else if (*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts) >= zb0009 {
-				(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = ((*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts)[:zb0009]
+			} else if (*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts) >= zb0013 {
+				(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = ((*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts)[:zb0013]
 			} else {
-				(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0009)
+				(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0013)
 			}
 			for zb0003 := range (*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts {
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts[zb0003].UnmarshalMsg(bts)
@@ -8793,13 +10376,13 @@ func (z *transmittedPayload) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		if zb0004 > 0 {
 			zb0004--
 			{
-				var zb0011 uint64
-				zb0011, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0015 uint64
+				zb0015, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "OriginalPeriod")
 					return
 				}
-				(*z).unauthenticatedProposal.OriginalPeriod = period(zb0011)
+				(*z).unauthenticatedProposal.OriginalPeriod = period(zb0015)
 			}
 		}
 		if zb0004 > 0 {
@@ -8842,50 +10425,84 @@ func (z *transmittedPayload) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "rnd":
+				if validate && zb0007 && "rnd" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.Round.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0006 = "rnd"
 			case "prev":
+				if validate && zb0007 && "prev" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.Branch.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Branch")
 					return
 				}
+				zb0006 = "prev"
 			case "seed":
+				if validate && zb0007 && "seed" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.Seed.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Seed")
 					return
 				}
+				zb0006 = "seed"
 			case "txn":
+				if validate && zb0007 && "txn" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.TxnCommitments.NativeSha512_256Commitment.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NativeSha512_256Commitment")
 					return
 				}
+				zb0006 = "txn"
 			case "txn256":
+				if validate && zb0007 && "txn256" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.TxnCommitments.Sha256Commitment.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sha256Commitment")
 					return
 				}
+				zb0006 = "txn256"
 			case "ts":
+				if validate && zb0007 && "ts" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.TimeStamp, bts, err = msgp.ReadInt64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TimeStamp")
 					return
 				}
+				zb0006 = "ts"
 			case "gen":
-				var zb0012 int
-				zb0012, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0007 && "gen" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0016 int
+				zb0016, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
-				if zb0012 > config.MaxGenesisIDLen {
-					err = msgp.ErrOverflow(uint64(zb0012), uint64(config.MaxGenesisIDLen))
+				if zb0016 > config.MaxGenesisIDLen {
+					err = msgp.ErrOverflow(uint64(zb0016), uint64(config.MaxGenesisIDLen))
 					return
 				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -8893,129 +10510,224 @@ func (z *transmittedPayload) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
+				zb0006 = "gen"
 			case "gh":
+				if validate && zb0007 && "gh" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.GenesisHash.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GenesisHash")
 					return
 				}
+				zb0006 = "gh"
 			case "fees":
+				if validate && zb0007 && "fees" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.FeeSink.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FeeSink")
 					return
 				}
+				zb0006 = "fees"
 			case "rwd":
+				if validate && zb0007 && "rwd" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsPool.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsPool")
 					return
 				}
+				zb0006 = "rwd"
 			case "earn":
+				if validate && zb0007 && "earn" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsLevel, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsLevel")
 					return
 				}
+				zb0006 = "earn"
 			case "rate":
+				if validate && zb0007 && "rate" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRate, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsRate")
 					return
 				}
+				zb0006 = "rate"
 			case "frac":
+				if validate && zb0007 && "frac" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsResidue, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsResidue")
 					return
 				}
+				zb0006 = "frac"
 			case "rwcalr":
+				if validate && zb0007 && "rwcalr" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.RewardsState.RewardsRecalculationRound.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsRecalculationRound")
 					return
 				}
+				zb0006 = "rwcalr"
 			case "proto":
+				if validate && zb0007 && "proto" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.CurrentProtocol.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "CurrentProtocol")
 					return
 				}
+				zb0006 = "proto"
 			case "nextproto":
+				if validate && zb0007 && "nextproto" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocol.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocol")
 					return
 				}
+				zb0006 = "nextproto"
 			case "nextyes":
+				if validate && zb0007 && "nextyes" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocolApprovals, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocolApprovals")
 					return
 				}
+				zb0006 = "nextyes"
 			case "nextbefore":
+				if validate && zb0007 && "nextbefore" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocolVoteBefore.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocolVoteBefore")
 					return
 				}
+				zb0006 = "nextbefore"
 			case "nextswitch":
+				if validate && zb0007 && "nextswitch" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeState.NextProtocolSwitchOn.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocolSwitchOn")
 					return
 				}
+				zb0006 = "nextswitch"
 			case "upgradeprop":
+				if validate && zb0007 && "upgradeprop" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradePropose.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradePropose")
 					return
 				}
+				zb0006 = "upgradeprop"
 			case "upgradedelay":
+				if validate && zb0007 && "upgradedelay" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeDelay.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradeDelay")
 					return
 				}
+				zb0006 = "upgradedelay"
 			case "upgradeyes":
+				if validate && zb0007 && "upgradeyes" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.UpgradeVote.UpgradeApprove, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradeApprove")
 					return
 				}
+				zb0006 = "upgradeyes"
 			case "tc":
+				if validate && zb0007 && "tc" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.TxnCounter, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TxnCounter")
 					return
 				}
+				zb0006 = "tc"
 			case "spt":
-				var zb0013 int
-				var zb0014 bool
-				zb0013, zb0014, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0007 && "spt" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0017 int
+				var zb0018 bool
+				zb0017, zb0018, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofTracking")
 					return
 				}
-				if zb0013 > protocol.NumStateProofTypes {
-					err = msgp.ErrOverflow(uint64(zb0013), uint64(protocol.NumStateProofTypes))
+				if zb0017 > protocol.NumStateProofTypes {
+					err = msgp.ErrOverflow(uint64(zb0017), uint64(protocol.NumStateProofTypes))
 					err = msgp.WrapError(err, "StateProofTracking")
 					return
 				}
-				if zb0014 {
+				if zb0018 {
 					(*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking = nil
 				} else if (*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking == nil {
-					(*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking = make(map[protocol.StateProofType]bookkeeping.StateProofTrackingData, zb0013)
+					(*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking = make(map[protocol.StateProofType]bookkeeping.StateProofTrackingData, zb0017)
 				}
-				for zb0013 > 0 {
+				var zb0019 protocol.StateProofType
+				_ = zb0019
+				var zb0020 bool
+				_ = zb0020
+				for zb0017 > 0 {
 					var zb0001 protocol.StateProofType
 					var zb0002 bookkeeping.StateProofTrackingData
-					zb0013--
+					zb0017--
 					bts, err = zb0001.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "StateProofTracking")
 						return
 					}
+					if validate && zb0020 && protocol.StateProofTypeLess(zb0001, zb0019) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0019 = zb0001
+					zb0020 = true
 					bts, err = zb0002.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "StateProofTracking", zb0001)
@@ -9023,25 +10735,30 @@ func (z *transmittedPayload) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).unauthenticatedProposal.Block.BlockHeader.StateProofTracking[zb0001] = zb0002
 				}
+				zb0006 = "spt"
 			case "partupdrmv":
-				var zb0015 int
-				var zb0016 bool
-				zb0015, zb0016, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0007 && "partupdrmv" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0021 int
+				var zb0022 bool
+				zb0021, zb0022, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0015 > config.MaxProposedExpiredOnlineAccounts {
-					err = msgp.ErrOverflow(uint64(zb0015), uint64(config.MaxProposedExpiredOnlineAccounts))
+				if zb0021 > config.MaxProposedExpiredOnlineAccounts {
+					err = msgp.ErrOverflow(uint64(zb0021), uint64(config.MaxProposedExpiredOnlineAccounts))
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0016 {
+				if zb0022 {
 					(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = nil
-				} else if (*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts) >= zb0015 {
-					(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = ((*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts)[:zb0015]
+				} else if (*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts) >= zb0021 {
+					(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = ((*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts)[:zb0021]
 				} else {
-					(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0015)
+					(*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0021)
 				}
 				for zb0003 := range (*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts {
 					bts, err = (*z).unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts[zb0003].UnmarshalMsg(bts)
@@ -9050,40 +10767,66 @@ func (z *transmittedPayload) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0006 = "partupdrmv"
 			case "txns":
+				if validate && zb0007 && "txns" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.Block.Payset.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Payset")
 					return
 				}
+				zb0006 = "txns"
 			case "sdpf":
+				if validate && zb0007 && "sdpf" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.SeedProof.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SeedProof")
 					return
 				}
+				zb0006 = "sdpf"
 			case "oper":
+				if validate && zb0007 && "oper" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0017 uint64
-					zb0017, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0023 uint64
+					zb0023, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "OriginalPeriod")
 						return
 					}
-					(*z).unauthenticatedProposal.OriginalPeriod = period(zb0017)
+					(*z).unauthenticatedProposal.OriginalPeriod = period(zb0023)
 				}
+				zb0006 = "oper"
 			case "oprop":
+				if validate && zb0007 && "oprop" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).unauthenticatedProposal.OriginalProposer.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "OriginalProposer")
 					return
 				}
+				zb0006 = "oprop"
 			case "pv":
+				if validate && zb0007 && "pv" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).PriorVote.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "PriorVote")
 					return
 				}
+				zb0006 = "pv"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -9091,12 +10834,19 @@ func (z *transmittedPayload) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0007 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *transmittedPayload) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *transmittedPayload) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *transmittedPayload) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*transmittedPayload)
 	return ok
@@ -9230,16 +10980,24 @@ func (_ *unauthenticatedBundle) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *unauthenticatedBundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *unauthenticatedBundle) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -9253,25 +11011,25 @@ func (z *unauthenticatedBundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		if zb0003 > 0 {
 			zb0003--
 			{
-				var zb0005 uint64
-				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0007 uint64
+				zb0007, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Period")
 					return
 				}
-				(*z).Period = period(zb0005)
+				(*z).Period = period(zb0007)
 			}
 		}
 		if zb0003 > 0 {
 			zb0003--
 			{
-				var zb0006 uint64
-				zb0006, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0008 uint64
+				zb0008, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Step")
 					return
 				}
-				(*z).Step = step(zb0006)
+				(*z).Step = step(zb0008)
 			}
 		}
 		if zb0003 > 0 {
@@ -9284,24 +11042,24 @@ func (z *unauthenticatedBundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0007 int
-			var zb0008 bool
-			zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0009 int
+			var zb0010 bool
+			zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Votes")
 				return
 			}
-			if zb0007 > config.MaxVoteThreshold {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxVoteThreshold))
+			if zb0009 > config.MaxVoteThreshold {
+				err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxVoteThreshold))
 				err = msgp.WrapError(err, "struct-from-array", "Votes")
 				return
 			}
-			if zb0008 {
+			if zb0010 {
 				(*z).Votes = nil
-			} else if (*z).Votes != nil && cap((*z).Votes) >= zb0007 {
-				(*z).Votes = ((*z).Votes)[:zb0007]
+			} else if (*z).Votes != nil && cap((*z).Votes) >= zb0009 {
+				(*z).Votes = ((*z).Votes)[:zb0009]
 			} else {
-				(*z).Votes = make([]voteAuthenticator, zb0007)
+				(*z).Votes = make([]voteAuthenticator, zb0009)
 			}
 			for zb0001 := range (*z).Votes {
 				bts, err = (*z).Votes[zb0001].UnmarshalMsg(bts)
@@ -9313,24 +11071,24 @@ func (z *unauthenticatedBundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0009 int
-			var zb0010 bool
-			zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0011 int
+			var zb0012 bool
+			zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "EquivocationVotes")
 				return
 			}
-			if zb0009 > config.MaxVoteThreshold {
-				err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxVoteThreshold))
+			if zb0011 > config.MaxVoteThreshold {
+				err = msgp.ErrOverflow(uint64(zb0011), uint64(config.MaxVoteThreshold))
 				err = msgp.WrapError(err, "struct-from-array", "EquivocationVotes")
 				return
 			}
-			if zb0010 {
+			if zb0012 {
 				(*z).EquivocationVotes = nil
-			} else if (*z).EquivocationVotes != nil && cap((*z).EquivocationVotes) >= zb0009 {
-				(*z).EquivocationVotes = ((*z).EquivocationVotes)[:zb0009]
+			} else if (*z).EquivocationVotes != nil && cap((*z).EquivocationVotes) >= zb0011 {
+				(*z).EquivocationVotes = ((*z).EquivocationVotes)[:zb0011]
 			} else {
-				(*z).EquivocationVotes = make([]equivocationVoteAuthenticator, zb0009)
+				(*z).EquivocationVotes = make([]equivocationVoteAuthenticator, zb0011)
 			}
 			for zb0002 := range (*z).EquivocationVotes {
 				bts, err = (*z).EquivocationVotes[zb0002].UnmarshalMsg(bts)
@@ -9364,56 +11122,80 @@ func (z *unauthenticatedBundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "rnd":
+				if validate && zb0006 && "rnd" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Round.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0005 = "rnd"
 			case "per":
+				if validate && zb0006 && "per" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0011 uint64
-					zb0011, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0013 uint64
+					zb0013, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Period")
 						return
 					}
-					(*z).Period = period(zb0011)
+					(*z).Period = period(zb0013)
 				}
+				zb0005 = "per"
 			case "step":
+				if validate && zb0006 && "step" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0012 uint64
-					zb0012, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0014 uint64
+					zb0014, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Step")
 						return
 					}
-					(*z).Step = step(zb0012)
+					(*z).Step = step(zb0014)
 				}
+				zb0005 = "step"
 			case "prop":
+				if validate && zb0006 && "prop" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Proposal.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Proposal")
 					return
 				}
+				zb0005 = "prop"
 			case "vote":
-				var zb0013 int
-				var zb0014 bool
-				zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "vote" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0015 int
+				var zb0016 bool
+				zb0015, zb0016, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Votes")
 					return
 				}
-				if zb0013 > config.MaxVoteThreshold {
-					err = msgp.ErrOverflow(uint64(zb0013), uint64(config.MaxVoteThreshold))
+				if zb0015 > config.MaxVoteThreshold {
+					err = msgp.ErrOverflow(uint64(zb0015), uint64(config.MaxVoteThreshold))
 					err = msgp.WrapError(err, "Votes")
 					return
 				}
-				if zb0014 {
+				if zb0016 {
 					(*z).Votes = nil
-				} else if (*z).Votes != nil && cap((*z).Votes) >= zb0013 {
-					(*z).Votes = ((*z).Votes)[:zb0013]
+				} else if (*z).Votes != nil && cap((*z).Votes) >= zb0015 {
+					(*z).Votes = ((*z).Votes)[:zb0015]
 				} else {
-					(*z).Votes = make([]voteAuthenticator, zb0013)
+					(*z).Votes = make([]voteAuthenticator, zb0015)
 				}
 				for zb0001 := range (*z).Votes {
 					bts, err = (*z).Votes[zb0001].UnmarshalMsg(bts)
@@ -9422,25 +11204,30 @@ func (z *unauthenticatedBundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0005 = "vote"
 			case "eqv":
-				var zb0015 int
-				var zb0016 bool
-				zb0015, zb0016, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "eqv" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0017 int
+				var zb0018 bool
+				zb0017, zb0018, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "EquivocationVotes")
 					return
 				}
-				if zb0015 > config.MaxVoteThreshold {
-					err = msgp.ErrOverflow(uint64(zb0015), uint64(config.MaxVoteThreshold))
+				if zb0017 > config.MaxVoteThreshold {
+					err = msgp.ErrOverflow(uint64(zb0017), uint64(config.MaxVoteThreshold))
 					err = msgp.WrapError(err, "EquivocationVotes")
 					return
 				}
-				if zb0016 {
+				if zb0018 {
 					(*z).EquivocationVotes = nil
-				} else if (*z).EquivocationVotes != nil && cap((*z).EquivocationVotes) >= zb0015 {
-					(*z).EquivocationVotes = ((*z).EquivocationVotes)[:zb0015]
+				} else if (*z).EquivocationVotes != nil && cap((*z).EquivocationVotes) >= zb0017 {
+					(*z).EquivocationVotes = ((*z).EquivocationVotes)[:zb0017]
 				} else {
-					(*z).EquivocationVotes = make([]equivocationVoteAuthenticator, zb0015)
+					(*z).EquivocationVotes = make([]equivocationVoteAuthenticator, zb0017)
 				}
 				for zb0002 := range (*z).EquivocationVotes {
 					bts, err = (*z).EquivocationVotes[zb0002].UnmarshalMsg(bts)
@@ -9449,6 +11236,7 @@ func (z *unauthenticatedBundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0005 = "eqv"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -9456,12 +11244,19 @@ func (z *unauthenticatedBundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *unauthenticatedBundle) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *unauthenticatedBundle) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *unauthenticatedBundle) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*unauthenticatedBundle)
 	return ok
@@ -9584,16 +11379,24 @@ func (_ *unauthenticatedEquivocationVote) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *unauthenticatedEquivocationVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *unauthenticatedEquivocationVote) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -9615,25 +11418,25 @@ func (z *unauthenticatedEquivocationVote) UnmarshalMsg(bts []byte) (o []byte, er
 		if zb0003 > 0 {
 			zb0003--
 			{
-				var zb0005 uint64
-				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0007 uint64
+				zb0007, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Period")
 					return
 				}
-				(*z).Period = period(zb0005)
+				(*z).Period = period(zb0007)
 			}
 		}
 		if zb0003 > 0 {
 			zb0003--
 			{
-				var zb0006 uint64
-				zb0006, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0008 uint64
+				zb0008, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Step")
 					return
 				}
-				(*z).Step = step(zb0006)
+				(*z).Step = step(zb0008)
 			}
 		}
 		if zb0003 > 0 {
@@ -9646,17 +11449,17 @@ func (z *unauthenticatedEquivocationVote) UnmarshalMsg(bts []byte) (o []byte, er
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0007 int
-			zb0007, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0009 int
+			zb0009, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Proposals")
 				return
 			}
-			if zb0007 > 2 {
-				err = msgp.ArrayError{Wanted: 2, Got: zb0007}
+			if zb0009 > 2 {
+				err = msgp.ArrayError{Wanted: 2, Got: zb0009}
 				return
 			}
-			for zb0001 := 0; zb0001 < zb0007; zb0001++ {
+			for zb0001 := 0; zb0001 < zb0009; zb0001++ {
 				bts, err = (*z).Proposals[zb0001].UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Proposals", zb0001)
@@ -9666,17 +11469,17 @@ func (z *unauthenticatedEquivocationVote) UnmarshalMsg(bts []byte) (o []byte, er
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0008 int
-			zb0008, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0010 int
+			zb0010, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Sigs")
 				return
 			}
-			if zb0008 > 2 {
-				err = msgp.ArrayError{Wanted: 2, Got: zb0008}
+			if zb0010 > 2 {
+				err = msgp.ArrayError{Wanted: 2, Got: zb0010}
 				return
 			}
-			for zb0002 := 0; zb0002 < zb0008; zb0002++ {
+			for zb0002 := 0; zb0002 < zb0010; zb0002++ {
 				bts, err = (*z).Sigs[zb0002].UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Sigs", zb0002)
@@ -9708,79 +11511,114 @@ func (z *unauthenticatedEquivocationVote) UnmarshalMsg(bts []byte) (o []byte, er
 			}
 			switch string(field) {
 			case "snd":
+				if validate && zb0006 && "snd" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sender.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sender")
 					return
 				}
+				zb0005 = "snd"
 			case "rnd":
+				if validate && zb0006 && "rnd" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Round.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0005 = "rnd"
 			case "per":
+				if validate && zb0006 && "per" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0009 uint64
-					zb0009, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0011 uint64
+					zb0011, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Period")
 						return
 					}
-					(*z).Period = period(zb0009)
+					(*z).Period = period(zb0011)
 				}
+				zb0005 = "per"
 			case "step":
+				if validate && zb0006 && "step" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0010 uint64
-					zb0010, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0012 uint64
+					zb0012, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Step")
 						return
 					}
-					(*z).Step = step(zb0010)
+					(*z).Step = step(zb0012)
 				}
+				zb0005 = "step"
 			case "cred":
+				if validate && zb0006 && "cred" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Cred.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Cred")
 					return
 				}
+				zb0005 = "cred"
 			case "props":
-				var zb0011 int
-				zb0011, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "props" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0013 int
+				zb0013, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Proposals")
 					return
 				}
-				if zb0011 > 2 {
-					err = msgp.ArrayError{Wanted: 2, Got: zb0011}
+				if zb0013 > 2 {
+					err = msgp.ArrayError{Wanted: 2, Got: zb0013}
 					return
 				}
-				for zb0001 := 0; zb0001 < zb0011; zb0001++ {
+				for zb0001 := 0; zb0001 < zb0013; zb0001++ {
 					bts, err = (*z).Proposals[zb0001].UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Proposals", zb0001)
 						return
 					}
 				}
+				zb0005 = "props"
 			case "sigs":
-				var zb0012 int
-				zb0012, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "sigs" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0014 int
+				zb0014, _, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sigs")
 					return
 				}
-				if zb0012 > 2 {
-					err = msgp.ArrayError{Wanted: 2, Got: zb0012}
+				if zb0014 > 2 {
+					err = msgp.ArrayError{Wanted: 2, Got: zb0014}
 					return
 				}
-				for zb0002 := 0; zb0002 < zb0012; zb0002++ {
+				for zb0002 := 0; zb0002 < zb0014; zb0002++ {
 					bts, err = (*z).Sigs[zb0002].UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Sigs", zb0002)
 						return
 					}
 				}
+				zb0005 = "sigs"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -9788,12 +11626,19 @@ func (z *unauthenticatedEquivocationVote) UnmarshalMsg(bts []byte) (o []byte, er
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *unauthenticatedEquivocationVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *unauthenticatedEquivocationVote) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *unauthenticatedEquivocationVote) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*unauthenticatedEquivocationVote)
 	return ok
@@ -10130,16 +11975,24 @@ func (_ *unauthenticatedProposal) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *unauthenticatedProposal) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *unauthenticatedProposal) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0004 int
+	var zb0006 string
+	var zb0007 bool
 	var zb0005 bool
+	_ = zb0006
+	_ = zb0007
 	zb0004, zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0004 > 0 {
@@ -10192,14 +12045,14 @@ func (z *unauthenticatedProposal) UnmarshalMsg(bts []byte) (o []byte, err error)
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0006 int
-			zb0006, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0008 int
+			zb0008, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "GenesisID")
 				return
 			}
-			if zb0006 > config.MaxGenesisIDLen {
-				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxGenesisIDLen))
+			if zb0008 > config.MaxGenesisIDLen {
+				err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxGenesisIDLen))
 				return
 			}
 			(*z).Block.BlockHeader.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -10338,32 +12191,42 @@ func (z *unauthenticatedProposal) UnmarshalMsg(bts []byte) (o []byte, err error)
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0007 int
-			var zb0008 bool
-			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0009 int
+			var zb0010 bool
+			zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "StateProofTracking")
 				return
 			}
-			if zb0007 > protocol.NumStateProofTypes {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(protocol.NumStateProofTypes))
+			if zb0009 > protocol.NumStateProofTypes {
+				err = msgp.ErrOverflow(uint64(zb0009), uint64(protocol.NumStateProofTypes))
 				err = msgp.WrapError(err, "struct-from-array", "StateProofTracking")
 				return
 			}
-			if zb0008 {
+			if zb0010 {
 				(*z).Block.BlockHeader.StateProofTracking = nil
 			} else if (*z).Block.BlockHeader.StateProofTracking == nil {
-				(*z).Block.BlockHeader.StateProofTracking = make(map[protocol.StateProofType]bookkeeping.StateProofTrackingData, zb0007)
+				(*z).Block.BlockHeader.StateProofTracking = make(map[protocol.StateProofType]bookkeeping.StateProofTrackingData, zb0009)
 			}
-			for zb0007 > 0 {
+			var zb0011 protocol.StateProofType
+			_ = zb0011
+			var zb0012 bool
+			_ = zb0012
+			for zb0009 > 0 {
 				var zb0001 protocol.StateProofType
 				var zb0002 bookkeeping.StateProofTrackingData
-				zb0007--
+				zb0009--
 				bts, err = zb0001.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "StateProofTracking")
 					return
 				}
+				if validate && zb0012 && protocol.StateProofTypeLess(zb0001, zb0011) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0011 = zb0001
+				zb0012 = true
 				bts, err = zb0002.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "StateProofTracking", zb0001)
@@ -10374,24 +12237,24 @@ func (z *unauthenticatedProposal) UnmarshalMsg(bts []byte) (o []byte, err error)
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0009 int
-			var zb0010 bool
-			zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0013 int
+			var zb0014 bool
+			zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0009 > config.MaxProposedExpiredOnlineAccounts {
-				err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxProposedExpiredOnlineAccounts))
+			if zb0013 > config.MaxProposedExpiredOnlineAccounts {
+				err = msgp.ErrOverflow(uint64(zb0013), uint64(config.MaxProposedExpiredOnlineAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0010 {
+			if zb0014 {
 				(*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = nil
-			} else if (*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts) >= zb0009 {
-				(*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = ((*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts)[:zb0009]
+			} else if (*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts) >= zb0013 {
+				(*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = ((*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts)[:zb0013]
 			} else {
-				(*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0009)
+				(*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0013)
 			}
 			for zb0003 := range (*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts {
 				bts, err = (*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts[zb0003].UnmarshalMsg(bts)
@@ -10420,13 +12283,13 @@ func (z *unauthenticatedProposal) UnmarshalMsg(bts []byte) (o []byte, err error)
 		if zb0004 > 0 {
 			zb0004--
 			{
-				var zb0011 uint64
-				zb0011, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0015 uint64
+				zb0015, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "OriginalPeriod")
 					return
 				}
-				(*z).OriginalPeriod = period(zb0011)
+				(*z).OriginalPeriod = period(zb0015)
 			}
 		}
 		if zb0004 > 0 {
@@ -10461,50 +12324,84 @@ func (z *unauthenticatedProposal) UnmarshalMsg(bts []byte) (o []byte, err error)
 			}
 			switch string(field) {
 			case "rnd":
+				if validate && zb0007 && "rnd" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.BlockHeader.Round.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0006 = "rnd"
 			case "prev":
+				if validate && zb0007 && "prev" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.BlockHeader.Branch.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Branch")
 					return
 				}
+				zb0006 = "prev"
 			case "seed":
+				if validate && zb0007 && "seed" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.BlockHeader.Seed.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Seed")
 					return
 				}
+				zb0006 = "seed"
 			case "txn":
+				if validate && zb0007 && "txn" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.BlockHeader.TxnCommitments.NativeSha512_256Commitment.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NativeSha512_256Commitment")
 					return
 				}
+				zb0006 = "txn"
 			case "txn256":
+				if validate && zb0007 && "txn256" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.BlockHeader.TxnCommitments.Sha256Commitment.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sha256Commitment")
 					return
 				}
+				zb0006 = "txn256"
 			case "ts":
+				if validate && zb0007 && "ts" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Block.BlockHeader.TimeStamp, bts, err = msgp.ReadInt64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TimeStamp")
 					return
 				}
+				zb0006 = "ts"
 			case "gen":
-				var zb0012 int
-				zb0012, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0007 && "gen" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0016 int
+				zb0016, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
-				if zb0012 > config.MaxGenesisIDLen {
-					err = msgp.ErrOverflow(uint64(zb0012), uint64(config.MaxGenesisIDLen))
+				if zb0016 > config.MaxGenesisIDLen {
+					err = msgp.ErrOverflow(uint64(zb0016), uint64(config.MaxGenesisIDLen))
 					return
 				}
 				(*z).Block.BlockHeader.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -10512,129 +12409,224 @@ func (z *unauthenticatedProposal) UnmarshalMsg(bts []byte) (o []byte, err error)
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
+				zb0006 = "gen"
 			case "gh":
+				if validate && zb0007 && "gh" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.BlockHeader.GenesisHash.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GenesisHash")
 					return
 				}
+				zb0006 = "gh"
 			case "fees":
+				if validate && zb0007 && "fees" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.BlockHeader.RewardsState.FeeSink.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FeeSink")
 					return
 				}
+				zb0006 = "fees"
 			case "rwd":
+				if validate && zb0007 && "rwd" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.BlockHeader.RewardsState.RewardsPool.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsPool")
 					return
 				}
+				zb0006 = "rwd"
 			case "earn":
+				if validate && zb0007 && "earn" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Block.BlockHeader.RewardsState.RewardsLevel, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsLevel")
 					return
 				}
+				zb0006 = "earn"
 			case "rate":
+				if validate && zb0007 && "rate" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Block.BlockHeader.RewardsState.RewardsRate, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsRate")
 					return
 				}
+				zb0006 = "rate"
 			case "frac":
+				if validate && zb0007 && "frac" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Block.BlockHeader.RewardsState.RewardsResidue, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsResidue")
 					return
 				}
+				zb0006 = "frac"
 			case "rwcalr":
+				if validate && zb0007 && "rwcalr" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.BlockHeader.RewardsState.RewardsRecalculationRound.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsRecalculationRound")
 					return
 				}
+				zb0006 = "rwcalr"
 			case "proto":
+				if validate && zb0007 && "proto" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.BlockHeader.UpgradeState.CurrentProtocol.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "CurrentProtocol")
 					return
 				}
+				zb0006 = "proto"
 			case "nextproto":
+				if validate && zb0007 && "nextproto" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.BlockHeader.UpgradeState.NextProtocol.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocol")
 					return
 				}
+				zb0006 = "nextproto"
 			case "nextyes":
+				if validate && zb0007 && "nextyes" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Block.BlockHeader.UpgradeState.NextProtocolApprovals, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocolApprovals")
 					return
 				}
+				zb0006 = "nextyes"
 			case "nextbefore":
+				if validate && zb0007 && "nextbefore" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.BlockHeader.UpgradeState.NextProtocolVoteBefore.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocolVoteBefore")
 					return
 				}
+				zb0006 = "nextbefore"
 			case "nextswitch":
+				if validate && zb0007 && "nextswitch" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.BlockHeader.UpgradeState.NextProtocolSwitchOn.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocolSwitchOn")
 					return
 				}
+				zb0006 = "nextswitch"
 			case "upgradeprop":
+				if validate && zb0007 && "upgradeprop" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.BlockHeader.UpgradeVote.UpgradePropose.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradePropose")
 					return
 				}
+				zb0006 = "upgradeprop"
 			case "upgradedelay":
+				if validate && zb0007 && "upgradedelay" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.BlockHeader.UpgradeVote.UpgradeDelay.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradeDelay")
 					return
 				}
+				zb0006 = "upgradedelay"
 			case "upgradeyes":
+				if validate && zb0007 && "upgradeyes" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Block.BlockHeader.UpgradeVote.UpgradeApprove, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradeApprove")
 					return
 				}
+				zb0006 = "upgradeyes"
 			case "tc":
+				if validate && zb0007 && "tc" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Block.BlockHeader.TxnCounter, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TxnCounter")
 					return
 				}
+				zb0006 = "tc"
 			case "spt":
-				var zb0013 int
-				var zb0014 bool
-				zb0013, zb0014, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0007 && "spt" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0017 int
+				var zb0018 bool
+				zb0017, zb0018, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofTracking")
 					return
 				}
-				if zb0013 > protocol.NumStateProofTypes {
-					err = msgp.ErrOverflow(uint64(zb0013), uint64(protocol.NumStateProofTypes))
+				if zb0017 > protocol.NumStateProofTypes {
+					err = msgp.ErrOverflow(uint64(zb0017), uint64(protocol.NumStateProofTypes))
 					err = msgp.WrapError(err, "StateProofTracking")
 					return
 				}
-				if zb0014 {
+				if zb0018 {
 					(*z).Block.BlockHeader.StateProofTracking = nil
 				} else if (*z).Block.BlockHeader.StateProofTracking == nil {
-					(*z).Block.BlockHeader.StateProofTracking = make(map[protocol.StateProofType]bookkeeping.StateProofTrackingData, zb0013)
+					(*z).Block.BlockHeader.StateProofTracking = make(map[protocol.StateProofType]bookkeeping.StateProofTrackingData, zb0017)
 				}
-				for zb0013 > 0 {
+				var zb0019 protocol.StateProofType
+				_ = zb0019
+				var zb0020 bool
+				_ = zb0020
+				for zb0017 > 0 {
 					var zb0001 protocol.StateProofType
 					var zb0002 bookkeeping.StateProofTrackingData
-					zb0013--
+					zb0017--
 					bts, err = zb0001.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "StateProofTracking")
 						return
 					}
+					if validate && zb0020 && protocol.StateProofTypeLess(zb0001, zb0019) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0019 = zb0001
+					zb0020 = true
 					bts, err = zb0002.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "StateProofTracking", zb0001)
@@ -10642,25 +12634,30 @@ func (z *unauthenticatedProposal) UnmarshalMsg(bts []byte) (o []byte, err error)
 					}
 					(*z).Block.BlockHeader.StateProofTracking[zb0001] = zb0002
 				}
+				zb0006 = "spt"
 			case "partupdrmv":
-				var zb0015 int
-				var zb0016 bool
-				zb0015, zb0016, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0007 && "partupdrmv" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0021 int
+				var zb0022 bool
+				zb0021, zb0022, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0015 > config.MaxProposedExpiredOnlineAccounts {
-					err = msgp.ErrOverflow(uint64(zb0015), uint64(config.MaxProposedExpiredOnlineAccounts))
+				if zb0021 > config.MaxProposedExpiredOnlineAccounts {
+					err = msgp.ErrOverflow(uint64(zb0021), uint64(config.MaxProposedExpiredOnlineAccounts))
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0016 {
+				if zb0022 {
 					(*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = nil
-				} else if (*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts) >= zb0015 {
-					(*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = ((*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts)[:zb0015]
+				} else if (*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts) >= zb0021 {
+					(*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = ((*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts)[:zb0021]
 				} else {
-					(*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0015)
+					(*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0021)
 				}
 				for zb0003 := range (*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts {
 					bts, err = (*z).Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts[zb0003].UnmarshalMsg(bts)
@@ -10669,34 +12666,55 @@ func (z *unauthenticatedProposal) UnmarshalMsg(bts []byte) (o []byte, err error)
 						return
 					}
 				}
+				zb0006 = "partupdrmv"
 			case "txns":
+				if validate && zb0007 && "txns" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.Payset.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Payset")
 					return
 				}
+				zb0006 = "txns"
 			case "sdpf":
+				if validate && zb0007 && "sdpf" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SeedProof.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SeedProof")
 					return
 				}
+				zb0006 = "sdpf"
 			case "oper":
+				if validate && zb0007 && "oper" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0017 uint64
-					zb0017, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0023 uint64
+					zb0023, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "OriginalPeriod")
 						return
 					}
-					(*z).OriginalPeriod = period(zb0017)
+					(*z).OriginalPeriod = period(zb0023)
 				}
+				zb0006 = "oper"
 			case "oprop":
+				if validate && zb0007 && "oprop" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).OriginalProposer.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "OriginalProposer")
 					return
 				}
+				zb0006 = "oprop"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -10704,12 +12722,19 @@ func (z *unauthenticatedProposal) UnmarshalMsg(bts []byte) (o []byte, err error)
 					return
 				}
 			}
+			zb0007 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *unauthenticatedProposal) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *unauthenticatedProposal) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *unauthenticatedProposal) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*unauthenticatedProposal)
 	return ok
@@ -10802,16 +12827,24 @@ func (_ *unauthenticatedVote) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *unauthenticatedVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *unauthenticatedVote) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -10862,23 +12895,38 @@ func (z *unauthenticatedVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "r":
+				if validate && zb0004 && "r" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).R.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "R")
 					return
 				}
+				zb0003 = "r"
 			case "cred":
+				if validate && zb0004 && "cred" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Cred.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Cred")
 					return
 				}
+				zb0003 = "cred"
 			case "sig":
+				if validate && zb0004 && "sig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sig")
 					return
 				}
+				zb0003 = "sig"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -10886,12 +12934,19 @@ func (z *unauthenticatedVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *unauthenticatedVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *unauthenticatedVote) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *unauthenticatedVote) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*unauthenticatedVote)
 	return ok
@@ -10960,16 +13015,24 @@ func (_ *vote) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *vote) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *vote) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -11020,23 +13083,38 @@ func (z *vote) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "r":
+				if validate && zb0004 && "r" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).R.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "R")
 					return
 				}
+				zb0003 = "r"
 			case "cred":
+				if validate && zb0004 && "cred" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Cred.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Cred")
 					return
 				}
+				zb0003 = "cred"
 			case "sig":
+				if validate && zb0004 && "sig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sig")
 					return
 				}
+				zb0003 = "sig"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -11044,12 +13122,19 @@ func (z *vote) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *vote) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *vote) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *vote) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*vote)
 	return ok
@@ -11086,16 +13171,24 @@ func (_ *voteAggregator) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *voteAggregator) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *voteAggregator) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -11128,12 +13221,19 @@ func (z *voteAggregator) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *voteAggregator) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *voteAggregator) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *voteAggregator) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*voteAggregator)
 	return ok
@@ -11190,16 +13290,24 @@ func (_ *voteAuthenticator) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *voteAuthenticator) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *voteAuthenticator) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -11250,23 +13358,38 @@ func (z *voteAuthenticator) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "snd":
+				if validate && zb0004 && "snd" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sender.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sender")
 					return
 				}
+				zb0003 = "snd"
 			case "cred":
+				if validate && zb0004 && "cred" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Cred.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Cred")
 					return
 				}
+				zb0003 = "cred"
 			case "sig":
+				if validate && zb0004 && "sig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sig")
 					return
 				}
+				zb0003 = "sig"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -11274,12 +13397,19 @@ func (z *voteAuthenticator) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *voteAuthenticator) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *voteAuthenticator) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *voteAuthenticator) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*voteAuthenticator)
 	return ok
@@ -11372,11 +13502,15 @@ func (_ *voteTracker) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *voteTracker) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *voteTracker) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0007 int
+	var zb0009 string
+	var zb0010 bool
 	var zb0008 bool
+	_ = zb0009
+	_ = zb0010
 	zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -11384,29 +13518,43 @@ func (z *voteTracker) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0007 > 0 {
 			zb0007--
-			var zb0009 int
-			var zb0010 bool
-			zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0011 int
+			var zb0012 bool
+			zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Voters")
 				return
 			}
-			if zb0010 {
+			if zb0012 {
 				(*z).Voters = nil
 			} else if (*z).Voters == nil {
-				(*z).Voters = make(map[basics.Address]vote, zb0009)
+				(*z).Voters = make(map[basics.Address]vote, zb0011)
 			}
-			for zb0009 > 0 {
+			var zb0013 basics.Address
+			_ = zb0013
+			var zb0014 bool
+			_ = zb0014
+			for zb0011 > 0 {
 				var zb0001 basics.Address
 				var zb0002 vote
-				zb0009--
+				zb0011--
 				bts, err = zb0001.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Voters")
 					return
 				}
+				if validate && zb0014 && basics.AddressLess(zb0001, zb0013) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0013 = zb0001
+				zb0014 = true
 				bts, err = zb0002.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Voters", zb0001)
@@ -11417,27 +13565,37 @@ func (z *voteTracker) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0007 > 0 {
 			zb0007--
-			var zb0011 int
-			var zb0012 bool
-			zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0015 int
+			var zb0016 bool
+			zb0015, zb0016, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Counts")
 				return
 			}
-			if zb0012 {
+			if zb0016 {
 				(*z).Counts = nil
 			} else if (*z).Counts == nil {
-				(*z).Counts = make(map[proposalValue]proposalVoteCounter, zb0011)
+				(*z).Counts = make(map[proposalValue]proposalVoteCounter, zb0015)
 			}
-			for zb0011 > 0 {
+			var zb0017 proposalValue
+			_ = zb0017
+			var zb0018 bool
+			_ = zb0018
+			for zb0015 > 0 {
 				var zb0003 proposalValue
 				var zb0004 proposalVoteCounter
-				zb0011--
+				zb0015--
 				bts, err = zb0003.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Counts")
 					return
 				}
+				if validate && zb0018 && ProposalValueLess(zb0003, zb0017) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0017 = zb0003
+				zb0018 = true
 				bts, err = zb0004.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Counts", zb0003)
@@ -11448,27 +13606,37 @@ func (z *voteTracker) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0007 > 0 {
 			zb0007--
-			var zb0013 int
-			var zb0014 bool
-			zb0013, zb0014, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0019 int
+			var zb0020 bool
+			zb0019, zb0020, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Equivocators")
 				return
 			}
-			if zb0014 {
+			if zb0020 {
 				(*z).Equivocators = nil
 			} else if (*z).Equivocators == nil {
-				(*z).Equivocators = make(map[basics.Address]equivocationVote, zb0013)
+				(*z).Equivocators = make(map[basics.Address]equivocationVote, zb0019)
 			}
-			for zb0013 > 0 {
+			var zb0021 basics.Address
+			_ = zb0021
+			var zb0022 bool
+			_ = zb0022
+			for zb0019 > 0 {
 				var zb0005 basics.Address
 				var zb0006 equivocationVote
-				zb0013--
+				zb0019--
 				bts, err = zb0005.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Equivocators")
 					return
 				}
+				if validate && zb0022 && basics.AddressLess(zb0005, zb0021) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0021 = zb0005
+				zb0022 = true
 				bts, err = zb0006.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Equivocators", zb0005)
@@ -11509,27 +13677,41 @@ func (z *voteTracker) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "Voters":
-				var zb0015 int
-				var zb0016 bool
-				zb0015, zb0016, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0010 && "Voters" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0023 int
+				var zb0024 bool
+				zb0023, zb0024, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Voters")
 					return
 				}
-				if zb0016 {
+				if zb0024 {
 					(*z).Voters = nil
 				} else if (*z).Voters == nil {
-					(*z).Voters = make(map[basics.Address]vote, zb0015)
+					(*z).Voters = make(map[basics.Address]vote, zb0023)
 				}
-				for zb0015 > 0 {
+				var zb0025 basics.Address
+				_ = zb0025
+				var zb0026 bool
+				_ = zb0026
+				for zb0023 > 0 {
 					var zb0001 basics.Address
 					var zb0002 vote
-					zb0015--
+					zb0023--
 					bts, err = zb0001.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Voters")
 						return
 					}
+					if validate && zb0026 && basics.AddressLess(zb0001, zb0025) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0025 = zb0001
+					zb0026 = true
 					bts, err = zb0002.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Voters", zb0001)
@@ -11537,28 +13719,43 @@ func (z *voteTracker) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).Voters[zb0001] = zb0002
 				}
+				zb0009 = "Voters"
 			case "Counts":
-				var zb0017 int
-				var zb0018 bool
-				zb0017, zb0018, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0010 && "Counts" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0027 int
+				var zb0028 bool
+				zb0027, zb0028, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Counts")
 					return
 				}
-				if zb0018 {
+				if zb0028 {
 					(*z).Counts = nil
 				} else if (*z).Counts == nil {
-					(*z).Counts = make(map[proposalValue]proposalVoteCounter, zb0017)
+					(*z).Counts = make(map[proposalValue]proposalVoteCounter, zb0027)
 				}
-				for zb0017 > 0 {
+				var zb0029 proposalValue
+				_ = zb0029
+				var zb0030 bool
+				_ = zb0030
+				for zb0027 > 0 {
 					var zb0003 proposalValue
 					var zb0004 proposalVoteCounter
-					zb0017--
+					zb0027--
 					bts, err = zb0003.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Counts")
 						return
 					}
+					if validate && zb0030 && ProposalValueLess(zb0003, zb0029) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0029 = zb0003
+					zb0030 = true
 					bts, err = zb0004.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Counts", zb0003)
@@ -11566,28 +13763,43 @@ func (z *voteTracker) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).Counts[zb0003] = zb0004
 				}
+				zb0009 = "Counts"
 			case "Equivocators":
-				var zb0019 int
-				var zb0020 bool
-				zb0019, zb0020, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0010 && "Equivocators" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0031 int
+				var zb0032 bool
+				zb0031, zb0032, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Equivocators")
 					return
 				}
-				if zb0020 {
+				if zb0032 {
 					(*z).Equivocators = nil
 				} else if (*z).Equivocators == nil {
-					(*z).Equivocators = make(map[basics.Address]equivocationVote, zb0019)
+					(*z).Equivocators = make(map[basics.Address]equivocationVote, zb0031)
 				}
-				for zb0019 > 0 {
+				var zb0033 basics.Address
+				_ = zb0033
+				var zb0034 bool
+				_ = zb0034
+				for zb0031 > 0 {
 					var zb0005 basics.Address
 					var zb0006 equivocationVote
-					zb0019--
+					zb0031--
 					bts, err = zb0005.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Equivocators")
 						return
 					}
+					if validate && zb0034 && basics.AddressLess(zb0005, zb0033) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0033 = zb0005
+					zb0034 = true
 					bts, err = zb0006.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Equivocators", zb0005)
@@ -11595,12 +13807,18 @@ func (z *voteTracker) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).Equivocators[zb0005] = zb0006
 				}
+				zb0009 = "Equivocators"
 			case "EquivocatorsCount":
+				if validate && zb0010 && "EquivocatorsCount" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).EquivocatorsCount, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "EquivocatorsCount")
 					return
 				}
+				zb0009 = "EquivocatorsCount"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -11608,12 +13826,19 @@ func (z *voteTracker) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0010 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *voteTracker) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *voteTracker) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *voteTracker) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*voteTracker)
 	return ok
@@ -11691,11 +13916,15 @@ func (_ *voteTrackerContract) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *voteTrackerContract) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *voteTrackerContract) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -11703,16 +13932,20 @@ func (z *voteTrackerContract) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0003 uint64
-				zb0003, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0005 uint64
+				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Step")
 					return
 				}
-				(*z).Step = step(zb0003)
+				(*z).Step = step(zb0005)
 			}
 		}
 		if zb0001 > 0 {
@@ -11755,27 +13988,42 @@ func (z *voteTrackerContract) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "Step":
+				if validate && zb0004 && "Step" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0004 uint64
-					zb0004, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0006 uint64
+					zb0006, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Step")
 						return
 					}
-					(*z).Step = step(zb0004)
+					(*z).Step = step(zb0006)
 				}
+				zb0003 = "Step"
 			case "StepOk":
+				if validate && zb0004 && "StepOk" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).StepOk, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StepOk")
 					return
 				}
+				zb0003 = "StepOk"
 			case "Emitted":
+				if validate && zb0004 && "Emitted" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Emitted, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Emitted")
 					return
 				}
+				zb0003 = "Emitted"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -11783,12 +14031,19 @@ func (z *voteTrackerContract) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *voteTrackerContract) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *voteTrackerContract) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *voteTrackerContract) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*voteTrackerContract)
 	return ok
@@ -11833,11 +14088,15 @@ func (_ *voteTrackerPeriod) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *voteTrackerPeriod) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *voteTrackerPeriod) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -11845,35 +14104,47 @@ func (z *voteTrackerPeriod) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0001 > 0 {
 			zb0001--
-			var zb0003 int
-			var zb0004 bool
-			zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0005 int
+			var zb0007 string
+			var zb0008 bool
+			var zb0006 bool
+			_ = zb0007
+			_ = zb0008
+			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Cached")
 					return
 				}
-				if zb0003 > 0 {
-					zb0003--
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0005 > 0 {
+					zb0005--
 					(*z).Cached.Bottom, bts, err = msgp.ReadBoolBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Cached", "struct-from-array", "Bottom")
 						return
 					}
 				}
-				if zb0003 > 0 {
-					zb0003--
+				if zb0005 > 0 {
+					zb0005--
 					bts, err = (*z).Cached.Proposal.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Cached", "struct-from-array", "Proposal")
 						return
 					}
 				}
-				if zb0003 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0003)
+				if zb0005 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0005)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Cached", "struct-from-array")
 						return
@@ -11884,11 +14155,11 @@ func (z *voteTrackerPeriod) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "Cached")
 					return
 				}
-				if zb0004 {
+				if zb0006 {
 					(*z).Cached = nextThresholdStatusEvent{}
 				}
-				for zb0003 > 0 {
-					zb0003--
+				for zb0005 > 0 {
+					zb0005--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Cached")
@@ -11896,17 +14167,27 @@ func (z *voteTrackerPeriod) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch string(field) {
 					case "Bottom":
+						if validate && zb0008 && "Bottom" < zb0007 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).Cached.Bottom, bts, err = msgp.ReadBoolBytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Cached", "Bottom")
 							return
 						}
+						zb0007 = "Bottom"
 					case "Proposal":
+						if validate && zb0008 && "Proposal" < zb0007 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						bts, err = (*z).Cached.Proposal.UnmarshalMsg(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Cached", "Proposal")
 							return
 						}
+						zb0007 = "Proposal"
 					default:
 						err = msgp.ErrNoField(string(field))
 						if err != nil {
@@ -11914,6 +14195,7 @@ func (z *voteTrackerPeriod) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0008 = true
 				}
 			}
 		}
@@ -11941,33 +14223,45 @@ func (z *voteTrackerPeriod) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "Cached":
-				var zb0005 int
-				var zb0006 bool
-				zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0004 && "Cached" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0009 int
+				var zb0011 string
+				var zb0012 bool
+				var zb0010 bool
+				_ = zb0011
+				_ = zb0012
+				zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Cached")
 						return
 					}
-					if zb0005 > 0 {
-						zb0005--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0009 > 0 {
+						zb0009--
 						(*z).Cached.Bottom, bts, err = msgp.ReadBoolBytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Cached", "struct-from-array", "Bottom")
 							return
 						}
 					}
-					if zb0005 > 0 {
-						zb0005--
+					if zb0009 > 0 {
+						zb0009--
 						bts, err = (*z).Cached.Proposal.UnmarshalMsg(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Cached", "struct-from-array", "Proposal")
 							return
 						}
 					}
-					if zb0005 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0005)
+					if zb0009 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0009)
 						if err != nil {
 							err = msgp.WrapError(err, "Cached", "struct-from-array")
 							return
@@ -11978,11 +14272,11 @@ func (z *voteTrackerPeriod) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "Cached")
 						return
 					}
-					if zb0006 {
+					if zb0010 {
 						(*z).Cached = nextThresholdStatusEvent{}
 					}
-					for zb0005 > 0 {
-						zb0005--
+					for zb0009 > 0 {
+						zb0009--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Cached")
@@ -11990,17 +14284,27 @@ func (z *voteTrackerPeriod) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "Bottom":
+							if validate && zb0012 && "Bottom" < zb0011 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).Cached.Bottom, bts, err = msgp.ReadBoolBytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Cached", "Bottom")
 								return
 							}
+							zb0011 = "Bottom"
 						case "Proposal":
+							if validate && zb0012 && "Proposal" < zb0011 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							bts, err = (*z).Cached.Proposal.UnmarshalMsg(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Cached", "Proposal")
 								return
 							}
+							zb0011 = "Proposal"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -12008,8 +14312,10 @@ func (z *voteTrackerPeriod) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0012 = true
 					}
 				}
+				zb0003 = "Cached"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -12017,12 +14323,19 @@ func (z *voteTrackerPeriod) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *voteTrackerPeriod) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *voteTrackerPeriod) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *voteTrackerPeriod) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*voteTrackerPeriod)
 	return ok
@@ -12064,16 +14377,24 @@ func (_ *voteTrackerRound) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *voteTrackerRound) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *voteTrackerRound) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -12116,17 +14437,27 @@ func (z *voteTrackerRound) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "Freshest":
+				if validate && zb0004 && "Freshest" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Freshest.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Freshest")
 					return
 				}
+				zb0003 = "Freshest"
 			case "Ok":
+				if validate && zb0004 && "Ok" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Ok, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Ok")
 					return
 				}
+				zb0003 = "Ok"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -12134,12 +14465,19 @@ func (z *voteTrackerRound) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *voteTrackerRound) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *voteTrackerRound) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *voteTrackerRound) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*voteTrackerRound)
 	return ok

--- a/agreement/sort.go
+++ b/agreement/sort.go
@@ -22,7 +22,10 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 )
 
-// These types are defined to satisfy SortInterface used by
+// Uint64Less is necessary for UnmarshalValidateMsg functionality
+func Uint64Less(a, b uint64) bool { return a < b }
+
+// These types are defined to satisfy SortInterface used by msgp
 
 // SortAddress is re-exported from basics.Address since the interface is already defined there
 //

--- a/agreement/sort.go
+++ b/agreement/sort.go
@@ -26,7 +26,7 @@ import (
 
 // SortAddress is re-exported from basics.Address since the interface is already defined there
 //
-//msgp:sort basics.Address SortAddress
+//msgp:sort basics.Address SortAddress basics.AddressLess
 type SortAddress = basics.SortAddress
 
 // SortUint64 is re-exported from basics since the interface is already defined there
@@ -36,38 +36,41 @@ type SortUint64 = basics.SortUint64
 // SortStep defines SortInterface used by msgp to consistently sort maps with this type as key.
 //
 //msgp:ignore SortStep
-//msgp:sort step SortStep
+//msgp:sort step SortStep StepLess
 type SortStep []step
 
 func (a SortStep) Len() int           { return len(a) }
 func (a SortStep) Less(i, j int) bool { return a[i] < a[j] }
 func (a SortStep) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func StepLess(a, b step) bool         { return a < b }
 
 // SortPeriod defines SortInterface used by msgp to consistently sort maps with this type as key.
 //
 //msgp:ignore SortPeriod
-//msgp:sort period SortPeriod
+//msgp:sort period SortPeriod PeriodLess
 type SortPeriod []period
 
 func (a SortPeriod) Len() int           { return len(a) }
 func (a SortPeriod) Less(i, j int) bool { return a[i] < a[j] }
 func (a SortPeriod) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func PeriodLess(a, b period) bool       { return a < b }
 
 // SortRound defines SortInterface used by msgp to consistently sort maps with this type as key.
 // note, for type aliases the base type is used for the interface
 //
 //msgp:ignore SortRound
-//msgp:sort basics.Round SortRound
+//msgp:sort basics.Round SortRound RoundLess
 type SortRound []basics.Round
 
 func (a SortRound) Len() int           { return len(a) }
 func (a SortRound) Less(i, j int) bool { return a[i] < a[j] }
 func (a SortRound) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func RoundLess(a, b round) bool        { return a < b }
 
 // SortProposalValue defines SortInterface used by msgp to consistently sort maps with this type as key.
 //
 //msgp:ignore SortProposalValue
-//msgp:sort proposalValue SortProposalValue
+//msgp:sort proposalValue SortProposalValue ProposalValueLess
 type SortProposalValue []proposalValue
 
 func (a SortProposalValue) Len() int { return len(a) }
@@ -88,3 +91,19 @@ func (a SortProposalValue) Less(i, j int) bool {
 }
 
 func (a SortProposalValue) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
+func ProposalValueLess(a, b proposalValue) bool {
+	if a.OriginalPeriod != b.OriginalPeriod {
+		return a.OriginalPeriod < b.OriginalPeriod
+	}
+	cmp := bytes.Compare(a.OriginalProposer[:], b.OriginalProposer[:])
+	if cmp != 0 {
+		return cmp < 0
+	}
+	cmp = bytes.Compare(a.BlockDigest[:], b.BlockDigest[:])
+	if cmp != 0 {
+		return cmp < 0
+	}
+	cmp = bytes.Compare(a.EncodingDigest[:], b.EncodingDigest[:])
+	return cmp < 0
+}

--- a/crypto/merklearray/msgp_gen.go
+++ b/crypto/merklearray/msgp_gen.go
@@ -13,6 +13,7 @@ import (
 //   |-----> MarshalMsg
 //   |-----> CanMarshalMsg
 //   |-----> (*) UnmarshalMsg
+//   |-----> (*) UnmarshalValidateMsg
 //   |-----> (*) CanUnmarshalMsg
 //   |-----> Msgsize
 //   |-----> MsgIsZero
@@ -22,6 +23,7 @@ import (
 //   |-----> (*) MarshalMsg
 //   |-----> (*) CanMarshalMsg
 //   |-----> (*) UnmarshalMsg
+//   |-----> (*) UnmarshalValidateMsg
 //   |-----> (*) CanUnmarshalMsg
 //   |-----> (*) Msgsize
 //   |-----> (*) MsgIsZero
@@ -31,6 +33,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -39,6 +42,7 @@ import (
 //   |-----> (*) MarshalMsg
 //   |-----> (*) CanMarshalMsg
 //   |-----> (*) UnmarshalMsg
+//   |-----> (*) UnmarshalValidateMsg
 //   |-----> (*) CanUnmarshalMsg
 //   |-----> (*) Msgsize
 //   |-----> (*) MsgIsZero
@@ -68,7 +72,7 @@ func (_ Layer) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Layer) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Layer) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var zb0002 int
 	var zb0003 bool
 	zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -99,6 +103,12 @@ func (z *Layer) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *Layer) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Layer) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Layer) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Layer)
 	return ok
@@ -178,11 +188,15 @@ func (_ *Proof) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Proof) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Proof) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -190,26 +204,30 @@ func (z *Proof) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0004 int
-			var zb0005 bool
-			zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0006 int
+			var zb0007 bool
+			zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Path")
 				return
 			}
-			if zb0004 > MaxNumLeavesOnEncodedTree/2 {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(MaxNumLeavesOnEncodedTree/2))
+			if zb0006 > MaxNumLeavesOnEncodedTree/2 {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(MaxNumLeavesOnEncodedTree/2))
 				err = msgp.WrapError(err, "struct-from-array", "Path")
 				return
 			}
-			if zb0005 {
+			if zb0007 {
 				(*z).Path = nil
-			} else if (*z).Path != nil && cap((*z).Path) >= zb0004 {
-				(*z).Path = ((*z).Path)[:zb0004]
+			} else if (*z).Path != nil && cap((*z).Path) >= zb0006 {
+				(*z).Path = ((*z).Path)[:zb0006]
 			} else {
-				(*z).Path = make([]crypto.GenericDigest, zb0004)
+				(*z).Path = make([]crypto.GenericDigest, zb0006)
 			}
 			for zb0001 := range (*z).Path {
 				bts, err = (*z).Path[zb0001].UnmarshalMsg(bts)
@@ -259,24 +277,28 @@ func (z *Proof) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "pth":
-				var zb0006 int
-				var zb0007 bool
-				zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0005 && "pth" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0008 int
+				var zb0009 bool
+				zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Path")
 					return
 				}
-				if zb0006 > MaxNumLeavesOnEncodedTree/2 {
-					err = msgp.ErrOverflow(uint64(zb0006), uint64(MaxNumLeavesOnEncodedTree/2))
+				if zb0008 > MaxNumLeavesOnEncodedTree/2 {
+					err = msgp.ErrOverflow(uint64(zb0008), uint64(MaxNumLeavesOnEncodedTree/2))
 					err = msgp.WrapError(err, "Path")
 					return
 				}
-				if zb0007 {
+				if zb0009 {
 					(*z).Path = nil
-				} else if (*z).Path != nil && cap((*z).Path) >= zb0006 {
-					(*z).Path = ((*z).Path)[:zb0006]
+				} else if (*z).Path != nil && cap((*z).Path) >= zb0008 {
+					(*z).Path = ((*z).Path)[:zb0008]
 				} else {
-					(*z).Path = make([]crypto.GenericDigest, zb0006)
+					(*z).Path = make([]crypto.GenericDigest, zb0008)
 				}
 				for zb0001 := range (*z).Path {
 					bts, err = (*z).Path[zb0001].UnmarshalMsg(bts)
@@ -285,18 +307,29 @@ func (z *Proof) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0004 = "pth"
 			case "hsh":
+				if validate && zb0005 && "hsh" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).HashFactory.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "HashFactory")
 					return
 				}
+				zb0004 = "hsh"
 			case "td":
+				if validate && zb0005 && "td" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TreeDepth, bts, err = msgp.ReadUint8Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TreeDepth")
 					return
 				}
+				zb0004 = "td"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -304,12 +337,19 @@ func (z *Proof) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *Proof) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Proof) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Proof) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Proof)
 	return ok
@@ -392,11 +432,15 @@ func (_ *SingleLeafProof) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *SingleLeafProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *SingleLeafProof) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -404,26 +448,30 @@ func (z *SingleLeafProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0004 int
-			var zb0005 bool
-			zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0006 int
+			var zb0007 bool
+			zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Path")
 				return
 			}
-			if zb0004 > MaxNumLeavesOnEncodedTree/2 {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(MaxNumLeavesOnEncodedTree/2))
+			if zb0006 > MaxNumLeavesOnEncodedTree/2 {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(MaxNumLeavesOnEncodedTree/2))
 				err = msgp.WrapError(err, "struct-from-array", "Path")
 				return
 			}
-			if zb0005 {
+			if zb0007 {
 				(*z).Proof.Path = nil
-			} else if (*z).Proof.Path != nil && cap((*z).Proof.Path) >= zb0004 {
-				(*z).Proof.Path = ((*z).Proof.Path)[:zb0004]
+			} else if (*z).Proof.Path != nil && cap((*z).Proof.Path) >= zb0006 {
+				(*z).Proof.Path = ((*z).Proof.Path)[:zb0006]
 			} else {
-				(*z).Proof.Path = make([]crypto.GenericDigest, zb0004)
+				(*z).Proof.Path = make([]crypto.GenericDigest, zb0006)
 			}
 			for zb0001 := range (*z).Proof.Path {
 				bts, err = (*z).Proof.Path[zb0001].UnmarshalMsg(bts)
@@ -473,24 +521,28 @@ func (z *SingleLeafProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "pth":
-				var zb0006 int
-				var zb0007 bool
-				zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0005 && "pth" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0008 int
+				var zb0009 bool
+				zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Path")
 					return
 				}
-				if zb0006 > MaxNumLeavesOnEncodedTree/2 {
-					err = msgp.ErrOverflow(uint64(zb0006), uint64(MaxNumLeavesOnEncodedTree/2))
+				if zb0008 > MaxNumLeavesOnEncodedTree/2 {
+					err = msgp.ErrOverflow(uint64(zb0008), uint64(MaxNumLeavesOnEncodedTree/2))
 					err = msgp.WrapError(err, "Path")
 					return
 				}
-				if zb0007 {
+				if zb0009 {
 					(*z).Proof.Path = nil
-				} else if (*z).Proof.Path != nil && cap((*z).Proof.Path) >= zb0006 {
-					(*z).Proof.Path = ((*z).Proof.Path)[:zb0006]
+				} else if (*z).Proof.Path != nil && cap((*z).Proof.Path) >= zb0008 {
+					(*z).Proof.Path = ((*z).Proof.Path)[:zb0008]
 				} else {
-					(*z).Proof.Path = make([]crypto.GenericDigest, zb0006)
+					(*z).Proof.Path = make([]crypto.GenericDigest, zb0008)
 				}
 				for zb0001 := range (*z).Proof.Path {
 					bts, err = (*z).Proof.Path[zb0001].UnmarshalMsg(bts)
@@ -499,18 +551,29 @@ func (z *SingleLeafProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0004 = "pth"
 			case "hsh":
+				if validate && zb0005 && "hsh" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Proof.HashFactory.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "HashFactory")
 					return
 				}
+				zb0004 = "hsh"
 			case "td":
+				if validate && zb0005 && "td" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Proof.TreeDepth, bts, err = msgp.ReadUint8Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TreeDepth")
 					return
 				}
+				zb0004 = "td"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -518,12 +581,19 @@ func (z *SingleLeafProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *SingleLeafProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *SingleLeafProof) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *SingleLeafProof) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*SingleLeafProof)
 	return ok
@@ -613,11 +683,15 @@ func (_ *Tree) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Tree) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Tree) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -625,46 +699,50 @@ func (z *Tree) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0007 int
+			var zb0008 bool
+			zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Levels")
 				return
 			}
-			if zb0005 > MaxEncodedTreeDepth+1 {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(MaxEncodedTreeDepth+1))
+			if zb0007 > MaxEncodedTreeDepth+1 {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(MaxEncodedTreeDepth+1))
 				err = msgp.WrapError(err, "struct-from-array", "Levels")
 				return
 			}
-			if zb0006 {
+			if zb0008 {
 				(*z).Levels = nil
-			} else if (*z).Levels != nil && cap((*z).Levels) >= zb0005 {
-				(*z).Levels = ((*z).Levels)[:zb0005]
+			} else if (*z).Levels != nil && cap((*z).Levels) >= zb0007 {
+				(*z).Levels = ((*z).Levels)[:zb0007]
 			} else {
-				(*z).Levels = make([]Layer, zb0005)
+				(*z).Levels = make([]Layer, zb0007)
 			}
 			for zb0001 := range (*z).Levels {
-				var zb0007 int
-				var zb0008 bool
-				zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				var zb0009 int
+				var zb0010 bool
+				zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Levels", zb0001)
 					return
 				}
-				if zb0007 > MaxNumLeavesOnEncodedTree {
-					err = msgp.ErrOverflow(uint64(zb0007), uint64(MaxNumLeavesOnEncodedTree))
+				if zb0009 > MaxNumLeavesOnEncodedTree {
+					err = msgp.ErrOverflow(uint64(zb0009), uint64(MaxNumLeavesOnEncodedTree))
 					err = msgp.WrapError(err, "struct-from-array", "Levels", zb0001)
 					return
 				}
-				if zb0008 {
+				if zb0010 {
 					(*z).Levels[zb0001] = nil
-				} else if (*z).Levels[zb0001] != nil && cap((*z).Levels[zb0001]) >= zb0007 {
-					(*z).Levels[zb0001] = ((*z).Levels[zb0001])[:zb0007]
+				} else if (*z).Levels[zb0001] != nil && cap((*z).Levels[zb0001]) >= zb0009 {
+					(*z).Levels[zb0001] = ((*z).Levels[zb0001])[:zb0009]
 				} else {
-					(*z).Levels[zb0001] = make(Layer, zb0007)
+					(*z).Levels[zb0001] = make(Layer, zb0009)
 				}
 				for zb0002 := range (*z).Levels[zb0001] {
 					bts, err = (*z).Levels[zb0001][zb0002].UnmarshalMsg(bts)
@@ -723,44 +801,48 @@ func (z *Tree) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "lvls":
-				var zb0009 int
-				var zb0010 bool
-				zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "lvls" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0011 int
+				var zb0012 bool
+				zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Levels")
 					return
 				}
-				if zb0009 > MaxEncodedTreeDepth+1 {
-					err = msgp.ErrOverflow(uint64(zb0009), uint64(MaxEncodedTreeDepth+1))
+				if zb0011 > MaxEncodedTreeDepth+1 {
+					err = msgp.ErrOverflow(uint64(zb0011), uint64(MaxEncodedTreeDepth+1))
 					err = msgp.WrapError(err, "Levels")
 					return
 				}
-				if zb0010 {
+				if zb0012 {
 					(*z).Levels = nil
-				} else if (*z).Levels != nil && cap((*z).Levels) >= zb0009 {
-					(*z).Levels = ((*z).Levels)[:zb0009]
+				} else if (*z).Levels != nil && cap((*z).Levels) >= zb0011 {
+					(*z).Levels = ((*z).Levels)[:zb0011]
 				} else {
-					(*z).Levels = make([]Layer, zb0009)
+					(*z).Levels = make([]Layer, zb0011)
 				}
 				for zb0001 := range (*z).Levels {
-					var zb0011 int
-					var zb0012 bool
-					zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					var zb0013 int
+					var zb0014 bool
+					zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Levels", zb0001)
 						return
 					}
-					if zb0011 > MaxNumLeavesOnEncodedTree {
-						err = msgp.ErrOverflow(uint64(zb0011), uint64(MaxNumLeavesOnEncodedTree))
+					if zb0013 > MaxNumLeavesOnEncodedTree {
+						err = msgp.ErrOverflow(uint64(zb0013), uint64(MaxNumLeavesOnEncodedTree))
 						err = msgp.WrapError(err, "Levels", zb0001)
 						return
 					}
-					if zb0012 {
+					if zb0014 {
 						(*z).Levels[zb0001] = nil
-					} else if (*z).Levels[zb0001] != nil && cap((*z).Levels[zb0001]) >= zb0011 {
-						(*z).Levels[zb0001] = ((*z).Levels[zb0001])[:zb0011]
+					} else if (*z).Levels[zb0001] != nil && cap((*z).Levels[zb0001]) >= zb0013 {
+						(*z).Levels[zb0001] = ((*z).Levels[zb0001])[:zb0013]
 					} else {
-						(*z).Levels[zb0001] = make(Layer, zb0011)
+						(*z).Levels[zb0001] = make(Layer, zb0013)
 					}
 					for zb0002 := range (*z).Levels[zb0001] {
 						bts, err = (*z).Levels[zb0001][zb0002].UnmarshalMsg(bts)
@@ -770,24 +852,40 @@ func (z *Tree) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 					}
 				}
+				zb0005 = "lvls"
 			case "nl":
+				if validate && zb0006 && "nl" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).NumOfElements, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NumOfElements")
 					return
 				}
+				zb0005 = "nl"
 			case "hsh":
+				if validate && zb0006 && "hsh" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Hash.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Hash")
 					return
 				}
+				zb0005 = "hsh"
 			case "vc":
+				if validate && zb0006 && "vc" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).IsVectorCommitment, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "IsVectorCommitment")
 					return
 				}
+				zb0005 = "vc"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -795,12 +893,19 @@ func (z *Tree) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *Tree) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Tree) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Tree) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Tree)
 	return ok

--- a/crypto/merklesignature/msgp_gen.go
+++ b/crypto/merklesignature/msgp_gen.go
@@ -14,6 +14,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -23,6 +24,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -32,6 +34,7 @@ import (
 //    |-----> (*) MarshalMsg
 //    |-----> (*) CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> (*) Msgsize
 //    |-----> (*) MsgIsZero
@@ -41,6 +44,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -50,6 +54,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -59,6 +64,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -78,7 +84,7 @@ func (_ *Commitment) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Commitment) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Commitment) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -88,6 +94,12 @@ func (z *Commitment) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *Commitment) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Commitment) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Commitment) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Commitment)
 	return ok
@@ -152,16 +164,24 @@ func (_ *KeyRoundPair) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *KeyRoundPair) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *KeyRoundPair) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -215,12 +235,21 @@ func (z *KeyRoundPair) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "rnd":
+				if validate && zb0004 && "rnd" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Round, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0003 = "rnd"
 			case "key":
+				if validate && zb0004 && "key" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
@@ -237,6 +266,7 @@ func (z *KeyRoundPair) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0003 = "key"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -244,12 +274,19 @@ func (z *KeyRoundPair) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *KeyRoundPair) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *KeyRoundPair) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *KeyRoundPair) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*KeyRoundPair)
 	return ok
@@ -324,16 +361,24 @@ func (_ *Secrets) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Secrets) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Secrets) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0002 > 0 {
@@ -384,23 +429,38 @@ func (z *Secrets) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "fv":
+				if validate && zb0005 && "fv" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).SignerContext.FirstValid, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FirstValid")
 					return
 				}
+				zb0004 = "fv"
 			case "iv":
+				if validate && zb0005 && "iv" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).SignerContext.KeyLifetime, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "KeyLifetime")
 					return
 				}
+				zb0004 = "iv"
 			case "tree":
+				if validate && zb0005 && "tree" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignerContext.Tree.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Tree")
 					return
 				}
+				zb0004 = "tree"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -408,12 +468,19 @@ func (z *Secrets) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *Secrets) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Secrets) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Secrets) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Secrets)
 	return ok
@@ -491,16 +558,24 @@ func (_ *Signature) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Signature) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Signature) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -559,29 +634,49 @@ func (z *Signature) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "sig":
+				if validate && zb0004 && "sig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Signature.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Signature")
 					return
 				}
+				zb0003 = "sig"
 			case "idx":
+				if validate && zb0004 && "idx" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).VectorCommitmentIndex, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VectorCommitmentIndex")
 					return
 				}
+				zb0003 = "idx"
 			case "prf":
+				if validate && zb0004 && "prf" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Proof.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Proof")
 					return
 				}
+				zb0003 = "prf"
 			case "vkey":
+				if validate && zb0004 && "vkey" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VerifyingKey.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VerifyingKey")
 					return
 				}
+				zb0003 = "vkey"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -589,12 +684,19 @@ func (z *Signature) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *Signature) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Signature) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Signature) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Signature)
 	return ok
@@ -663,16 +765,24 @@ func (_ *SignerContext) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *SignerContext) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *SignerContext) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -723,23 +833,38 @@ func (z *SignerContext) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "fv":
+				if validate && zb0004 && "fv" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).FirstValid, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FirstValid")
 					return
 				}
+				zb0003 = "fv"
 			case "iv":
+				if validate && zb0004 && "iv" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).KeyLifetime, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "KeyLifetime")
 					return
 				}
+				zb0003 = "iv"
 			case "tree":
+				if validate && zb0004 && "tree" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Tree.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Tree")
 					return
 				}
+				zb0003 = "tree"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -747,12 +872,19 @@ func (z *SignerContext) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *SignerContext) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *SignerContext) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *SignerContext) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*SignerContext)
 	return ok
@@ -812,16 +944,24 @@ func (_ *Verifier) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Verifier) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Verifier) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0002 > 0 {
@@ -864,17 +1004,27 @@ func (z *Verifier) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "cmt":
+				if validate && zb0005 && "cmt" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).Commitment)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "Commitment")
 					return
 				}
+				zb0004 = "cmt"
 			case "lf":
+				if validate && zb0005 && "lf" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).KeyLifetime, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "KeyLifetime")
 					return
 				}
+				zb0004 = "lf"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -882,12 +1032,19 @@ func (z *Verifier) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *Verifier) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Verifier) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Verifier) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Verifier)
 	return ok

--- a/crypto/msgp_gen.go
+++ b/crypto/msgp_gen.go
@@ -15,6 +15,7 @@ import (
 //    |-----> (*) MarshalMsg
 //    |-----> (*) CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> (*) Msgsize
 //    |-----> (*) MsgIsZero
@@ -24,6 +25,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -33,6 +35,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -42,6 +45,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -51,6 +55,7 @@ import (
 //        |-----> MarshalMsg
 //        |-----> CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> Msgsize
 //        |-----> MsgIsZero
@@ -60,6 +65,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -69,6 +75,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -78,6 +85,7 @@ import (
 //       |-----> MarshalMsg
 //       |-----> CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> Msgsize
 //       |-----> MsgIsZero
@@ -87,6 +95,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -96,6 +105,7 @@ import (
 //     |-----> MarshalMsg
 //     |-----> CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> Msgsize
 //     |-----> MsgIsZero
@@ -105,6 +115,7 @@ import (
 //          |-----> (*) MarshalMsg
 //          |-----> (*) CanMarshalMsg
 //          |-----> (*) UnmarshalMsg
+//          |-----> (*) UnmarshalValidateMsg
 //          |-----> (*) CanUnmarshalMsg
 //          |-----> (*) Msgsize
 //          |-----> (*) MsgIsZero
@@ -114,6 +125,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -123,6 +135,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -132,6 +145,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -141,6 +155,7 @@ import (
 //            |-----> (*) MarshalMsg
 //            |-----> (*) CanMarshalMsg
 //            |-----> (*) UnmarshalMsg
+//            |-----> (*) UnmarshalValidateMsg
 //            |-----> (*) CanUnmarshalMsg
 //            |-----> (*) Msgsize
 //            |-----> (*) MsgIsZero
@@ -150,6 +165,7 @@ import (
 //                 |-----> (*) MarshalMsg
 //                 |-----> (*) CanMarshalMsg
 //                 |-----> (*) UnmarshalMsg
+//                 |-----> (*) UnmarshalValidateMsg
 //                 |-----> (*) CanUnmarshalMsg
 //                 |-----> (*) Msgsize
 //                 |-----> (*) MsgIsZero
@@ -159,6 +175,7 @@ import (
 //               |-----> (*) MarshalMsg
 //               |-----> (*) CanMarshalMsg
 //               |-----> (*) UnmarshalMsg
+//               |-----> (*) UnmarshalValidateMsg
 //               |-----> (*) CanUnmarshalMsg
 //               |-----> (*) Msgsize
 //               |-----> (*) MsgIsZero
@@ -168,6 +185,7 @@ import (
 //                |-----> (*) MarshalMsg
 //                |-----> (*) CanMarshalMsg
 //                |-----> (*) UnmarshalMsg
+//                |-----> (*) UnmarshalValidateMsg
 //                |-----> (*) CanUnmarshalMsg
 //                |-----> (*) Msgsize
 //                |-----> (*) MsgIsZero
@@ -177,6 +195,7 @@ import (
 //             |-----> (*) MarshalMsg
 //             |-----> (*) CanMarshalMsg
 //             |-----> (*) UnmarshalMsg
+//             |-----> (*) UnmarshalValidateMsg
 //             |-----> (*) CanUnmarshalMsg
 //             |-----> (*) Msgsize
 //             |-----> (*) MsgIsZero
@@ -186,6 +205,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -195,6 +215,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -204,6 +225,7 @@ import (
 //   |-----> (*) MarshalMsg
 //   |-----> (*) CanMarshalMsg
 //   |-----> (*) UnmarshalMsg
+//   |-----> (*) UnmarshalValidateMsg
 //   |-----> (*) CanUnmarshalMsg
 //   |-----> (*) Msgsize
 //   |-----> (*) MsgIsZero
@@ -213,6 +235,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -222,6 +245,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -231,6 +255,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -240,6 +265,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -249,6 +275,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -258,6 +285,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -267,6 +295,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -276,6 +305,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -285,6 +315,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -294,6 +325,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -303,6 +335,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -312,6 +345,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -331,7 +365,7 @@ func (_ *Digest) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Digest) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Digest) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -341,6 +375,12 @@ func (z *Digest) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *Digest) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Digest) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Digest) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Digest)
 	return ok
@@ -377,7 +417,7 @@ func (_ *FalconPrivateKey) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *FalconPrivateKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *FalconPrivateKey) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -387,6 +427,12 @@ func (z *FalconPrivateKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *FalconPrivateKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *FalconPrivateKey) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *FalconPrivateKey) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*FalconPrivateKey)
 	return ok
@@ -423,7 +469,7 @@ func (_ *FalconPublicKey) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *FalconPublicKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *FalconPublicKey) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -433,6 +479,12 @@ func (z *FalconPublicKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *FalconPublicKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *FalconPublicKey) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *FalconPublicKey) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*FalconPublicKey)
 	return ok
@@ -469,7 +521,7 @@ func (_ *FalconSeed) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *FalconSeed) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *FalconSeed) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -479,6 +531,12 @@ func (z *FalconSeed) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *FalconSeed) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *FalconSeed) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *FalconSeed) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*FalconSeed)
 	return ok
@@ -518,7 +576,7 @@ func (_ FalconSignature) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *FalconSignature) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *FalconSignature) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 []byte
 		var zb0002 int
@@ -542,6 +600,12 @@ func (z *FalconSignature) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *FalconSignature) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *FalconSignature) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *FalconSignature) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*FalconSignature)
 	return ok
@@ -601,16 +665,24 @@ func (_ *FalconSigner) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *FalconSigner) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *FalconSigner) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -653,17 +725,27 @@ func (z *FalconSigner) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "pk":
+				if validate && zb0006 && "pk" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).PublicKey)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "PublicKey")
 					return
 				}
+				zb0005 = "pk"
 			case "sk":
+				if validate && zb0006 && "sk" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).PrivateKey)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "PrivateKey")
 					return
 				}
+				zb0005 = "sk"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -671,12 +753,19 @@ func (z *FalconSigner) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *FalconSigner) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *FalconSigner) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *FalconSigner) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*FalconSigner)
 	return ok
@@ -732,16 +821,24 @@ func (_ *FalconVerifier) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *FalconVerifier) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *FalconVerifier) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0002 > 0 {
@@ -776,11 +873,16 @@ func (z *FalconVerifier) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "k":
+				if validate && zb0005 && "k" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).PublicKey)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "PublicKey")
 					return
 				}
+				zb0004 = "k"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -788,12 +890,19 @@ func (z *FalconVerifier) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *FalconVerifier) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *FalconVerifier) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *FalconVerifier) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*FalconVerifier)
 	return ok
@@ -834,7 +943,7 @@ func (_ GenericDigest) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *GenericDigest) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *GenericDigest) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 []byte
 		var zb0002 int
@@ -858,6 +967,12 @@ func (z *GenericDigest) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *GenericDigest) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *GenericDigest) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *GenericDigest) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*GenericDigest)
 	return ok
@@ -908,11 +1023,15 @@ func (_ *HashFactory) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *HashFactory) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *HashFactory) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -920,16 +1039,20 @@ func (z *HashFactory) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0003 uint16
-				zb0003, bts, err = msgp.ReadUint16Bytes(bts)
+				var zb0005 uint16
+				zb0005, bts, err = msgp.ReadUint16Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "HashType")
 					return
 				}
-				(*z).HashType = HashType(zb0003)
+				(*z).HashType = HashType(zb0005)
 			}
 		}
 		if zb0001 > 0 {
@@ -956,15 +1079,20 @@ func (z *HashFactory) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "t":
+				if validate && zb0004 && "t" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0004 uint16
-					zb0004, bts, err = msgp.ReadUint16Bytes(bts)
+					var zb0006 uint16
+					zb0006, bts, err = msgp.ReadUint16Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "HashType")
 						return
 					}
-					(*z).HashType = HashType(zb0004)
+					(*z).HashType = HashType(zb0006)
 				}
+				zb0003 = "t"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -972,6 +1100,7 @@ func (z *HashFactory) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
@@ -981,6 +1110,12 @@ func (z *HashFactory) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *HashFactory) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *HashFactory) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *HashFactory) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*HashFactory)
 	return ok
@@ -1019,7 +1154,7 @@ func (_ HashType) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *HashType) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *HashType) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 uint16
 		zb0001, bts, err = msgp.ReadUint16Bytes(bts)
@@ -1033,6 +1168,12 @@ func (z *HashType) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *HashType) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *HashType) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *HashType) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*HashType)
 	return ok
@@ -1068,7 +1209,7 @@ func (_ *MasterDerivationKey) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *MasterDerivationKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *MasterDerivationKey) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -1078,6 +1219,12 @@ func (z *MasterDerivationKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *MasterDerivationKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *MasterDerivationKey) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *MasterDerivationKey) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*MasterDerivationKey)
 	return ok
@@ -1154,16 +1301,24 @@ func (_ *MultisigSig) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *MultisigSig) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *MultisigSig) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0002 > 0 {
@@ -1184,24 +1339,24 @@ func (z *MultisigSig) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0004 int
-			var zb0005 bool
-			zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0006 int
+			var zb0007 bool
+			zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Subsigs")
 				return
 			}
-			if zb0004 > maxMultisig {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(maxMultisig))
+			if zb0006 > maxMultisig {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(maxMultisig))
 				err = msgp.WrapError(err, "struct-from-array", "Subsigs")
 				return
 			}
-			if zb0005 {
+			if zb0007 {
 				(*z).Subsigs = nil
-			} else if (*z).Subsigs != nil && cap((*z).Subsigs) >= zb0004 {
-				(*z).Subsigs = ((*z).Subsigs)[:zb0004]
+			} else if (*z).Subsigs != nil && cap((*z).Subsigs) >= zb0006 {
+				(*z).Subsigs = ((*z).Subsigs)[:zb0006]
 			} else {
-				(*z).Subsigs = make([]MultisigSubsig, zb0004)
+				(*z).Subsigs = make([]MultisigSubsig, zb0006)
 			}
 			for zb0001 := range (*z).Subsigs {
 				bts, err = (*z).Subsigs[zb0001].UnmarshalMsg(bts)
@@ -1235,36 +1390,50 @@ func (z *MultisigSig) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "v":
+				if validate && zb0005 && "v" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Version, bts, err = msgp.ReadUint8Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Version")
 					return
 				}
+				zb0004 = "v"
 			case "thr":
+				if validate && zb0005 && "thr" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Threshold, bts, err = msgp.ReadUint8Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Threshold")
 					return
 				}
+				zb0004 = "thr"
 			case "subsig":
-				var zb0006 int
-				var zb0007 bool
-				zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0005 && "subsig" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0008 int
+				var zb0009 bool
+				zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Subsigs")
 					return
 				}
-				if zb0006 > maxMultisig {
-					err = msgp.ErrOverflow(uint64(zb0006), uint64(maxMultisig))
+				if zb0008 > maxMultisig {
+					err = msgp.ErrOverflow(uint64(zb0008), uint64(maxMultisig))
 					err = msgp.WrapError(err, "Subsigs")
 					return
 				}
-				if zb0007 {
+				if zb0009 {
 					(*z).Subsigs = nil
-				} else if (*z).Subsigs != nil && cap((*z).Subsigs) >= zb0006 {
-					(*z).Subsigs = ((*z).Subsigs)[:zb0006]
+				} else if (*z).Subsigs != nil && cap((*z).Subsigs) >= zb0008 {
+					(*z).Subsigs = ((*z).Subsigs)[:zb0008]
 				} else {
-					(*z).Subsigs = make([]MultisigSubsig, zb0006)
+					(*z).Subsigs = make([]MultisigSubsig, zb0008)
 				}
 				for zb0001 := range (*z).Subsigs {
 					bts, err = (*z).Subsigs[zb0001].UnmarshalMsg(bts)
@@ -1273,6 +1442,7 @@ func (z *MultisigSig) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0004 = "subsig"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1280,12 +1450,19 @@ func (z *MultisigSig) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *MultisigSig) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *MultisigSig) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *MultisigSig) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*MultisigSig)
 	return ok
@@ -1350,16 +1527,24 @@ func (_ *MultisigSubsig) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *MultisigSubsig) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *MultisigSubsig) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -1402,17 +1587,27 @@ func (z *MultisigSubsig) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "pk":
+				if validate && zb0006 && "pk" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).Key)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "Key")
 					return
 				}
+				zb0005 = "pk"
 			case "s":
+				if validate && zb0006 && "s" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).Sig)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "Sig")
 					return
 				}
+				zb0005 = "s"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1420,12 +1615,19 @@ func (z *MultisigSubsig) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *MultisigSubsig) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *MultisigSubsig) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *MultisigSubsig) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*MultisigSubsig)
 	return ok
@@ -1484,16 +1686,24 @@ func (_ *OneTimeSignature) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *OneTimeSignature) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *OneTimeSignature) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0007 int
+	var zb0009 string
+	var zb0010 bool
 	var zb0008 bool
+	_ = zb0009
+	_ = zb0010
 	zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0007 > 0 {
@@ -1568,41 +1778,71 @@ func (z *OneTimeSignature) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "s":
+				if validate && zb0010 && "s" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).Sig)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "Sig")
 					return
 				}
+				zb0009 = "s"
 			case "p":
+				if validate && zb0010 && "p" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).PK)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "PK")
 					return
 				}
+				zb0009 = "p"
 			case "ps":
+				if validate && zb0010 && "ps" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).PKSigOld)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "PKSigOld")
 					return
 				}
+				zb0009 = "ps"
 			case "p2":
+				if validate && zb0010 && "p2" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).PK2)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "PK2")
 					return
 				}
+				zb0009 = "p2"
 			case "p1s":
+				if validate && zb0010 && "p1s" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).PK1Sig)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "PK1Sig")
 					return
 				}
+				zb0009 = "p1s"
 			case "p2s":
+				if validate && zb0010 && "p2s" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).PK2Sig)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "PK2Sig")
 					return
 				}
+				zb0009 = "p2s"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1610,12 +1850,19 @@ func (z *OneTimeSignature) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0010 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *OneTimeSignature) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *OneTimeSignature) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *OneTimeSignature) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*OneTimeSignature)
 	return ok
@@ -1751,16 +1998,24 @@ func (_ *OneTimeSignatureSecrets) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *OneTimeSignatureSecrets) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *OneTimeSignatureSecrets) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0006 int
+	var zb0008 string
+	var zb0009 bool
 	var zb0007 bool
+	_ = zb0008
+	_ = zb0009
 	zb0006, zb0007, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0006 > 0 {
@@ -1781,19 +2036,19 @@ func (z *OneTimeSignatureSecrets) UnmarshalMsg(bts []byte) (o []byte, err error)
 		}
 		if zb0006 > 0 {
 			zb0006--
-			var zb0008 int
-			var zb0009 bool
-			zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0010 int
+			var zb0011 bool
+			zb0010, zb0011, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Batches")
 				return
 			}
-			if zb0009 {
+			if zb0011 {
 				(*z).OneTimeSignatureSecretsPersistent.Batches = nil
-			} else if (*z).OneTimeSignatureSecretsPersistent.Batches != nil && cap((*z).OneTimeSignatureSecretsPersistent.Batches) >= zb0008 {
-				(*z).OneTimeSignatureSecretsPersistent.Batches = ((*z).OneTimeSignatureSecretsPersistent.Batches)[:zb0008]
+			} else if (*z).OneTimeSignatureSecretsPersistent.Batches != nil && cap((*z).OneTimeSignatureSecretsPersistent.Batches) >= zb0010 {
+				(*z).OneTimeSignatureSecretsPersistent.Batches = ((*z).OneTimeSignatureSecretsPersistent.Batches)[:zb0010]
 			} else {
-				(*z).OneTimeSignatureSecretsPersistent.Batches = make([]ephemeralSubkey, zb0008)
+				(*z).OneTimeSignatureSecretsPersistent.Batches = make([]ephemeralSubkey, zb0010)
 			}
 			for zb0002 := range (*z).OneTimeSignatureSecretsPersistent.Batches {
 				bts, err = (*z).OneTimeSignatureSecretsPersistent.Batches[zb0002].UnmarshalMsg(bts)
@@ -1813,19 +2068,19 @@ func (z *OneTimeSignatureSecrets) UnmarshalMsg(bts []byte) (o []byte, err error)
 		}
 		if zb0006 > 0 {
 			zb0006--
-			var zb0010 int
-			var zb0011 bool
-			zb0010, zb0011, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0012 int
+			var zb0013 bool
+			zb0012, zb0013, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Offsets")
 				return
 			}
-			if zb0011 {
+			if zb0013 {
 				(*z).OneTimeSignatureSecretsPersistent.Offsets = nil
-			} else if (*z).OneTimeSignatureSecretsPersistent.Offsets != nil && cap((*z).OneTimeSignatureSecretsPersistent.Offsets) >= zb0010 {
-				(*z).OneTimeSignatureSecretsPersistent.Offsets = ((*z).OneTimeSignatureSecretsPersistent.Offsets)[:zb0010]
+			} else if (*z).OneTimeSignatureSecretsPersistent.Offsets != nil && cap((*z).OneTimeSignatureSecretsPersistent.Offsets) >= zb0012 {
+				(*z).OneTimeSignatureSecretsPersistent.Offsets = ((*z).OneTimeSignatureSecretsPersistent.Offsets)[:zb0012]
 			} else {
-				(*z).OneTimeSignatureSecretsPersistent.Offsets = make([]ephemeralSubkey, zb0010)
+				(*z).OneTimeSignatureSecretsPersistent.Offsets = make([]ephemeralSubkey, zb0012)
 			}
 			for zb0003 := range (*z).OneTimeSignatureSecretsPersistent.Offsets {
 				bts, err = (*z).OneTimeSignatureSecretsPersistent.Offsets[zb0003].UnmarshalMsg(bts)
@@ -1875,31 +2130,45 @@ func (z *OneTimeSignatureSecrets) UnmarshalMsg(bts []byte) (o []byte, err error)
 			}
 			switch string(field) {
 			case "OneTimeSignatureVerifier":
+				if validate && zb0009 && "OneTimeSignatureVerifier" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).OneTimeSignatureSecretsPersistent.OneTimeSignatureVerifier)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "OneTimeSignatureVerifier")
 					return
 				}
+				zb0008 = "OneTimeSignatureVerifier"
 			case "First":
+				if validate && zb0009 && "First" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).OneTimeSignatureSecretsPersistent.FirstBatch, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FirstBatch")
 					return
 				}
+				zb0008 = "First"
 			case "Sub":
-				var zb0012 int
-				var zb0013 bool
-				zb0012, zb0013, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0009 && "Sub" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0014 int
+				var zb0015 bool
+				zb0014, zb0015, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Batches")
 					return
 				}
-				if zb0013 {
+				if zb0015 {
 					(*z).OneTimeSignatureSecretsPersistent.Batches = nil
-				} else if (*z).OneTimeSignatureSecretsPersistent.Batches != nil && cap((*z).OneTimeSignatureSecretsPersistent.Batches) >= zb0012 {
-					(*z).OneTimeSignatureSecretsPersistent.Batches = ((*z).OneTimeSignatureSecretsPersistent.Batches)[:zb0012]
+				} else if (*z).OneTimeSignatureSecretsPersistent.Batches != nil && cap((*z).OneTimeSignatureSecretsPersistent.Batches) >= zb0014 {
+					(*z).OneTimeSignatureSecretsPersistent.Batches = ((*z).OneTimeSignatureSecretsPersistent.Batches)[:zb0014]
 				} else {
-					(*z).OneTimeSignatureSecretsPersistent.Batches = make([]ephemeralSubkey, zb0012)
+					(*z).OneTimeSignatureSecretsPersistent.Batches = make([]ephemeralSubkey, zb0014)
 				}
 				for zb0002 := range (*z).OneTimeSignatureSecretsPersistent.Batches {
 					bts, err = (*z).OneTimeSignatureSecretsPersistent.Batches[zb0002].UnmarshalMsg(bts)
@@ -1908,26 +2177,36 @@ func (z *OneTimeSignatureSecrets) UnmarshalMsg(bts []byte) (o []byte, err error)
 						return
 					}
 				}
+				zb0008 = "Sub"
 			case "firstoff":
+				if validate && zb0009 && "firstoff" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).OneTimeSignatureSecretsPersistent.FirstOffset, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FirstOffset")
 					return
 				}
+				zb0008 = "firstoff"
 			case "offkeys":
-				var zb0014 int
-				var zb0015 bool
-				zb0014, zb0015, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0009 && "offkeys" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0016 int
+				var zb0017 bool
+				zb0016, zb0017, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Offsets")
 					return
 				}
-				if zb0015 {
+				if zb0017 {
 					(*z).OneTimeSignatureSecretsPersistent.Offsets = nil
-				} else if (*z).OneTimeSignatureSecretsPersistent.Offsets != nil && cap((*z).OneTimeSignatureSecretsPersistent.Offsets) >= zb0014 {
-					(*z).OneTimeSignatureSecretsPersistent.Offsets = ((*z).OneTimeSignatureSecretsPersistent.Offsets)[:zb0014]
+				} else if (*z).OneTimeSignatureSecretsPersistent.Offsets != nil && cap((*z).OneTimeSignatureSecretsPersistent.Offsets) >= zb0016 {
+					(*z).OneTimeSignatureSecretsPersistent.Offsets = ((*z).OneTimeSignatureSecretsPersistent.Offsets)[:zb0016]
 				} else {
-					(*z).OneTimeSignatureSecretsPersistent.Offsets = make([]ephemeralSubkey, zb0014)
+					(*z).OneTimeSignatureSecretsPersistent.Offsets = make([]ephemeralSubkey, zb0016)
 				}
 				for zb0003 := range (*z).OneTimeSignatureSecretsPersistent.Offsets {
 					bts, err = (*z).OneTimeSignatureSecretsPersistent.Offsets[zb0003].UnmarshalMsg(bts)
@@ -1936,18 +2215,29 @@ func (z *OneTimeSignatureSecrets) UnmarshalMsg(bts []byte) (o []byte, err error)
 						return
 					}
 				}
+				zb0008 = "offkeys"
 			case "offpk2":
+				if validate && zb0009 && "offpk2" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).OneTimeSignatureSecretsPersistent.OffsetsPK2)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "OffsetsPK2")
 					return
 				}
+				zb0008 = "offpk2"
 			case "offpk2sig":
+				if validate && zb0009 && "offpk2sig" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).OneTimeSignatureSecretsPersistent.OffsetsPK2Sig)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "OffsetsPK2Sig")
 					return
 				}
+				zb0008 = "offpk2sig"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1955,12 +2245,19 @@ func (z *OneTimeSignatureSecrets) UnmarshalMsg(bts []byte) (o []byte, err error)
 					return
 				}
 			}
+			zb0009 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *OneTimeSignatureSecrets) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *OneTimeSignatureSecrets) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *OneTimeSignatureSecrets) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*OneTimeSignatureSecrets)
 	return ok
@@ -2101,16 +2398,24 @@ func (_ *OneTimeSignatureSecretsPersistent) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *OneTimeSignatureSecretsPersistent) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *OneTimeSignatureSecretsPersistent) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0006 int
+	var zb0008 string
+	var zb0009 bool
 	var zb0007 bool
+	_ = zb0008
+	_ = zb0009
 	zb0006, zb0007, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0006 > 0 {
@@ -2131,19 +2436,19 @@ func (z *OneTimeSignatureSecretsPersistent) UnmarshalMsg(bts []byte) (o []byte, 
 		}
 		if zb0006 > 0 {
 			zb0006--
-			var zb0008 int
-			var zb0009 bool
-			zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0010 int
+			var zb0011 bool
+			zb0010, zb0011, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Batches")
 				return
 			}
-			if zb0009 {
+			if zb0011 {
 				(*z).Batches = nil
-			} else if (*z).Batches != nil && cap((*z).Batches) >= zb0008 {
-				(*z).Batches = ((*z).Batches)[:zb0008]
+			} else if (*z).Batches != nil && cap((*z).Batches) >= zb0010 {
+				(*z).Batches = ((*z).Batches)[:zb0010]
 			} else {
-				(*z).Batches = make([]ephemeralSubkey, zb0008)
+				(*z).Batches = make([]ephemeralSubkey, zb0010)
 			}
 			for zb0002 := range (*z).Batches {
 				bts, err = (*z).Batches[zb0002].UnmarshalMsg(bts)
@@ -2163,19 +2468,19 @@ func (z *OneTimeSignatureSecretsPersistent) UnmarshalMsg(bts []byte) (o []byte, 
 		}
 		if zb0006 > 0 {
 			zb0006--
-			var zb0010 int
-			var zb0011 bool
-			zb0010, zb0011, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0012 int
+			var zb0013 bool
+			zb0012, zb0013, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Offsets")
 				return
 			}
-			if zb0011 {
+			if zb0013 {
 				(*z).Offsets = nil
-			} else if (*z).Offsets != nil && cap((*z).Offsets) >= zb0010 {
-				(*z).Offsets = ((*z).Offsets)[:zb0010]
+			} else if (*z).Offsets != nil && cap((*z).Offsets) >= zb0012 {
+				(*z).Offsets = ((*z).Offsets)[:zb0012]
 			} else {
-				(*z).Offsets = make([]ephemeralSubkey, zb0010)
+				(*z).Offsets = make([]ephemeralSubkey, zb0012)
 			}
 			for zb0003 := range (*z).Offsets {
 				bts, err = (*z).Offsets[zb0003].UnmarshalMsg(bts)
@@ -2225,31 +2530,45 @@ func (z *OneTimeSignatureSecretsPersistent) UnmarshalMsg(bts []byte) (o []byte, 
 			}
 			switch string(field) {
 			case "OneTimeSignatureVerifier":
+				if validate && zb0009 && "OneTimeSignatureVerifier" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).OneTimeSignatureVerifier)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "OneTimeSignatureVerifier")
 					return
 				}
+				zb0008 = "OneTimeSignatureVerifier"
 			case "First":
+				if validate && zb0009 && "First" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).FirstBatch, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FirstBatch")
 					return
 				}
+				zb0008 = "First"
 			case "Sub":
-				var zb0012 int
-				var zb0013 bool
-				zb0012, zb0013, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0009 && "Sub" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0014 int
+				var zb0015 bool
+				zb0014, zb0015, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Batches")
 					return
 				}
-				if zb0013 {
+				if zb0015 {
 					(*z).Batches = nil
-				} else if (*z).Batches != nil && cap((*z).Batches) >= zb0012 {
-					(*z).Batches = ((*z).Batches)[:zb0012]
+				} else if (*z).Batches != nil && cap((*z).Batches) >= zb0014 {
+					(*z).Batches = ((*z).Batches)[:zb0014]
 				} else {
-					(*z).Batches = make([]ephemeralSubkey, zb0012)
+					(*z).Batches = make([]ephemeralSubkey, zb0014)
 				}
 				for zb0002 := range (*z).Batches {
 					bts, err = (*z).Batches[zb0002].UnmarshalMsg(bts)
@@ -2258,26 +2577,36 @@ func (z *OneTimeSignatureSecretsPersistent) UnmarshalMsg(bts []byte) (o []byte, 
 						return
 					}
 				}
+				zb0008 = "Sub"
 			case "firstoff":
+				if validate && zb0009 && "firstoff" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).FirstOffset, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FirstOffset")
 					return
 				}
+				zb0008 = "firstoff"
 			case "offkeys":
-				var zb0014 int
-				var zb0015 bool
-				zb0014, zb0015, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0009 && "offkeys" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0016 int
+				var zb0017 bool
+				zb0016, zb0017, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Offsets")
 					return
 				}
-				if zb0015 {
+				if zb0017 {
 					(*z).Offsets = nil
-				} else if (*z).Offsets != nil && cap((*z).Offsets) >= zb0014 {
-					(*z).Offsets = ((*z).Offsets)[:zb0014]
+				} else if (*z).Offsets != nil && cap((*z).Offsets) >= zb0016 {
+					(*z).Offsets = ((*z).Offsets)[:zb0016]
 				} else {
-					(*z).Offsets = make([]ephemeralSubkey, zb0014)
+					(*z).Offsets = make([]ephemeralSubkey, zb0016)
 				}
 				for zb0003 := range (*z).Offsets {
 					bts, err = (*z).Offsets[zb0003].UnmarshalMsg(bts)
@@ -2286,18 +2615,29 @@ func (z *OneTimeSignatureSecretsPersistent) UnmarshalMsg(bts []byte) (o []byte, 
 						return
 					}
 				}
+				zb0008 = "offkeys"
 			case "offpk2":
+				if validate && zb0009 && "offpk2" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).OffsetsPK2)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "OffsetsPK2")
 					return
 				}
+				zb0008 = "offpk2"
 			case "offpk2sig":
+				if validate && zb0009 && "offpk2sig" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).OffsetsPK2Sig)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "OffsetsPK2Sig")
 					return
 				}
+				zb0008 = "offpk2sig"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2305,12 +2645,19 @@ func (z *OneTimeSignatureSecretsPersistent) UnmarshalMsg(bts []byte) (o []byte, 
 					return
 				}
 			}
+			zb0009 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *OneTimeSignatureSecretsPersistent) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *OneTimeSignatureSecretsPersistent) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *OneTimeSignatureSecretsPersistent) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*OneTimeSignatureSecretsPersistent)
 	return ok
@@ -2374,16 +2721,24 @@ func (_ *OneTimeSignatureSubkeyBatchID) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *OneTimeSignatureSubkeyBatchID) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *OneTimeSignatureSubkeyBatchID) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0002 > 0 {
@@ -2426,17 +2781,27 @@ func (z *OneTimeSignatureSubkeyBatchID) UnmarshalMsg(bts []byte) (o []byte, err 
 			}
 			switch string(field) {
 			case "pk":
+				if validate && zb0005 && "pk" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).SubKeyPK)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "SubKeyPK")
 					return
 				}
+				zb0004 = "pk"
 			case "batch":
+				if validate && zb0005 && "batch" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Batch, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Batch")
 					return
 				}
+				zb0004 = "batch"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2444,12 +2809,19 @@ func (z *OneTimeSignatureSubkeyBatchID) UnmarshalMsg(bts []byte) (o []byte, err 
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *OneTimeSignatureSubkeyBatchID) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *OneTimeSignatureSubkeyBatchID) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *OneTimeSignatureSubkeyBatchID) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*OneTimeSignatureSubkeyBatchID)
 	return ok
@@ -2497,16 +2869,24 @@ func (_ *OneTimeSignatureSubkeyOffsetID) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *OneTimeSignatureSubkeyOffsetID) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *OneTimeSignatureSubkeyOffsetID) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0002 > 0 {
@@ -2557,23 +2937,38 @@ func (z *OneTimeSignatureSubkeyOffsetID) UnmarshalMsg(bts []byte) (o []byte, err
 			}
 			switch string(field) {
 			case "pk":
+				if validate && zb0005 && "pk" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).SubKeyPK)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "SubKeyPK")
 					return
 				}
+				zb0004 = "pk"
 			case "batch":
+				if validate && zb0005 && "batch" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Batch, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Batch")
 					return
 				}
+				zb0004 = "batch"
 			case "off":
+				if validate && zb0005 && "off" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Offset, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Offset")
 					return
 				}
+				zb0004 = "off"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2581,12 +2976,19 @@ func (z *OneTimeSignatureSubkeyOffsetID) UnmarshalMsg(bts []byte) (o []byte, err
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *OneTimeSignatureSubkeyOffsetID) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *OneTimeSignatureSubkeyOffsetID) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *OneTimeSignatureSubkeyOffsetID) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*OneTimeSignatureSubkeyOffsetID)
 	return ok
@@ -2625,7 +3027,7 @@ func (_ *OneTimeSignatureVerifier) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *OneTimeSignatureVerifier) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *OneTimeSignatureVerifier) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -2635,6 +3037,12 @@ func (z *OneTimeSignatureVerifier) UnmarshalMsg(bts []byte) (o []byte, err error
 	return
 }
 
+func (z *OneTimeSignatureVerifier) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *OneTimeSignatureVerifier) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *OneTimeSignatureVerifier) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*OneTimeSignatureVerifier)
 	return ok
@@ -2671,7 +3079,7 @@ func (_ *PrivateKey) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *PrivateKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *PrivateKey) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -2681,6 +3089,12 @@ func (z *PrivateKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *PrivateKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *PrivateKey) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *PrivateKey) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*PrivateKey)
 	return ok
@@ -2717,7 +3131,7 @@ func (_ *PublicKey) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *PublicKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *PublicKey) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -2727,6 +3141,12 @@ func (z *PublicKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *PublicKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *PublicKey) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *PublicKey) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*PublicKey)
 	return ok
@@ -2763,7 +3183,7 @@ func (_ *Seed) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Seed) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Seed) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -2773,6 +3193,12 @@ func (z *Seed) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *Seed) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Seed) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Seed) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Seed)
 	return ok
@@ -2809,7 +3235,7 @@ func (_ *Signature) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Signature) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Signature) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -2819,6 +3245,12 @@ func (z *Signature) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *Signature) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Signature) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Signature) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Signature)
 	return ok
@@ -2861,16 +3293,24 @@ func (_ *SignatureSecrets) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *SignatureSecrets) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *SignatureSecrets) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -2913,17 +3353,27 @@ func (z *SignatureSecrets) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "SignatureVerifier":
+				if validate && zb0006 && "SignatureVerifier" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).SignatureVerifier)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "SignatureVerifier")
 					return
 				}
+				zb0005 = "SignatureVerifier"
 			case "SK":
+				if validate && zb0006 && "SK" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).SK)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "SK")
 					return
 				}
+				zb0005 = "SK"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2931,12 +3381,19 @@ func (z *SignatureSecrets) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *SignatureSecrets) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *SignatureSecrets) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *SignatureSecrets) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*SignatureSecrets)
 	return ok
@@ -2983,16 +3440,24 @@ func (_ *VRFSecrets) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *VRFSecrets) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *VRFSecrets) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -3035,17 +3500,27 @@ func (z *VRFSecrets) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "PK":
+				if validate && zb0006 && "PK" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).PK)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "PK")
 					return
 				}
+				zb0005 = "PK"
 			case "SK":
+				if validate && zb0006 && "SK" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).SK)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "SK")
 					return
 				}
+				zb0005 = "SK"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3053,12 +3528,19 @@ func (z *VRFSecrets) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *VRFSecrets) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *VRFSecrets) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *VRFSecrets) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*VRFSecrets)
 	return ok
@@ -3099,7 +3581,7 @@ func (_ *VrfOutput) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *VrfOutput) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *VrfOutput) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -3109,6 +3591,12 @@ func (z *VrfOutput) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *VrfOutput) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *VrfOutput) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *VrfOutput) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*VrfOutput)
 	return ok
@@ -3145,7 +3633,7 @@ func (_ *VrfPrivkey) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *VrfPrivkey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *VrfPrivkey) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -3155,6 +3643,12 @@ func (z *VrfPrivkey) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *VrfPrivkey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *VrfPrivkey) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *VrfPrivkey) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*VrfPrivkey)
 	return ok
@@ -3191,7 +3685,7 @@ func (_ *VrfProof) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *VrfProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *VrfProof) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -3201,6 +3695,12 @@ func (z *VrfProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *VrfProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *VrfProof) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *VrfProof) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*VrfProof)
 	return ok
@@ -3237,7 +3737,7 @@ func (_ *VrfPubkey) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *VrfPubkey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *VrfPubkey) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -3247,6 +3747,12 @@ func (z *VrfPubkey) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *VrfPubkey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *VrfPubkey) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *VrfPubkey) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*VrfPubkey)
 	return ok
@@ -3283,7 +3789,7 @@ func (_ *ed25519PrivateKey) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *ed25519PrivateKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *ed25519PrivateKey) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -3293,6 +3799,12 @@ func (z *ed25519PrivateKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *ed25519PrivateKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *ed25519PrivateKey) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *ed25519PrivateKey) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*ed25519PrivateKey)
 	return ok
@@ -3329,7 +3841,7 @@ func (_ *ed25519PublicKey) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *ed25519PublicKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *ed25519PublicKey) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -3339,6 +3851,12 @@ func (z *ed25519PublicKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *ed25519PublicKey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *ed25519PublicKey) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *ed25519PublicKey) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*ed25519PublicKey)
 	return ok
@@ -3375,7 +3893,7 @@ func (_ *ed25519Seed) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *ed25519Seed) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *ed25519Seed) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -3385,6 +3903,12 @@ func (z *ed25519Seed) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *ed25519Seed) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *ed25519Seed) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *ed25519Seed) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*ed25519Seed)
 	return ok
@@ -3421,7 +3945,7 @@ func (_ *ed25519Signature) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *ed25519Signature) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *ed25519Signature) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -3431,6 +3955,12 @@ func (z *ed25519Signature) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *ed25519Signature) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *ed25519Signature) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *ed25519Signature) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*ed25519Signature)
 	return ok
@@ -3479,16 +4009,24 @@ func (_ *ephemeralSubkey) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *ephemeralSubkey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *ephemeralSubkey) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0005 int
+	var zb0007 string
+	var zb0008 bool
 	var zb0006 bool
+	_ = zb0007
+	_ = zb0008
 	zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0005 > 0 {
@@ -3547,29 +4085,49 @@ func (z *ephemeralSubkey) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "PK":
+				if validate && zb0008 && "PK" < zb0007 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).PK)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "PK")
 					return
 				}
+				zb0007 = "PK"
 			case "SK":
+				if validate && zb0008 && "SK" < zb0007 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).SK)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "SK")
 					return
 				}
+				zb0007 = "SK"
 			case "PKSig":
+				if validate && zb0008 && "PKSig" < zb0007 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).PKSigOld)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "PKSigOld")
 					return
 				}
+				zb0007 = "PKSig"
 			case "sig2":
+				if validate && zb0008 && "sig2" < zb0007 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).PKSigNew)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "PKSigNew")
 					return
 				}
+				zb0007 = "sig2"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3577,12 +4135,19 @@ func (z *ephemeralSubkey) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0008 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *ephemeralSubkey) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *ephemeralSubkey) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *ephemeralSubkey) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*ephemeralSubkey)
 	return ok

--- a/crypto/stateproof/msgp_gen.go
+++ b/crypto/stateproof/msgp_gen.go
@@ -18,6 +18,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -27,6 +28,7 @@ import (
 //    |-----> (*) MarshalMsg
 //    |-----> (*) CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> (*) Msgsize
 //    |-----> (*) MsgIsZero
@@ -36,6 +38,7 @@ import (
 //           |-----> (*) MarshalMsg
 //           |-----> (*) CanMarshalMsg
 //           |-----> (*) UnmarshalMsg
+//           |-----> (*) UnmarshalValidateMsg
 //           |-----> (*) CanUnmarshalMsg
 //           |-----> (*) Msgsize
 //           |-----> (*) MsgIsZero
@@ -45,6 +48,7 @@ import (
 //    |-----> (*) MarshalMsg
 //    |-----> (*) CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> (*) Msgsize
 //    |-----> (*) MsgIsZero
@@ -54,6 +58,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -63,6 +68,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -82,7 +88,7 @@ func (_ *MessageHash) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *MessageHash) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *MessageHash) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -92,6 +98,12 @@ func (z *MessageHash) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *MessageHash) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *MessageHash) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *MessageHash) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*MessageHash)
 	return ok
@@ -208,16 +220,24 @@ func (_ *Prover) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Prover) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Prover) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0004 int
+	var zb0006 string
+	var zb0007 bool
 	var zb0005 bool
+	_ = zb0006
+	_ = zb0007
 	zb0004, zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0004 > 0 {
@@ -238,24 +258,24 @@ func (z *Prover) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0006 int
-			var zb0007 bool
-			zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0008 int
+			var zb0009 bool
+			zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Participants")
 				return
 			}
-			if zb0006 > VotersAllocBound {
-				err = msgp.ErrOverflow(uint64(zb0006), uint64(VotersAllocBound))
+			if zb0008 > VotersAllocBound {
+				err = msgp.ErrOverflow(uint64(zb0008), uint64(VotersAllocBound))
 				err = msgp.WrapError(err, "struct-from-array", "Participants")
 				return
 			}
-			if zb0007 {
+			if zb0009 {
 				(*z).ProverPersistedFields.Participants = nil
-			} else if (*z).ProverPersistedFields.Participants != nil && cap((*z).ProverPersistedFields.Participants) >= zb0006 {
-				(*z).ProverPersistedFields.Participants = ((*z).ProverPersistedFields.Participants)[:zb0006]
+			} else if (*z).ProverPersistedFields.Participants != nil && cap((*z).ProverPersistedFields.Participants) >= zb0008 {
+				(*z).ProverPersistedFields.Participants = ((*z).ProverPersistedFields.Participants)[:zb0008]
 			} else {
-				(*z).ProverPersistedFields.Participants = make([]basics.Participant, zb0006)
+				(*z).ProverPersistedFields.Participants = make([]basics.Participant, zb0008)
 			}
 			for zb0002 := range (*z).ProverPersistedFields.Participants {
 				bts, err = (*z).ProverPersistedFields.Participants[zb0002].UnmarshalMsg(bts)
@@ -332,36 +352,50 @@ func (z *Prover) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "data":
+				if validate && zb0007 && "data" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).ProverPersistedFields.Data)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "Data")
 					return
 				}
+				zb0006 = "data"
 			case "rnd":
+				if validate && zb0007 && "rnd" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).ProverPersistedFields.Round, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0006 = "rnd"
 			case "parts":
-				var zb0008 int
-				var zb0009 bool
-				zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0007 && "parts" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0010 int
+				var zb0011 bool
+				zb0010, zb0011, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Participants")
 					return
 				}
-				if zb0008 > VotersAllocBound {
-					err = msgp.ErrOverflow(uint64(zb0008), uint64(VotersAllocBound))
+				if zb0010 > VotersAllocBound {
+					err = msgp.ErrOverflow(uint64(zb0010), uint64(VotersAllocBound))
 					err = msgp.WrapError(err, "Participants")
 					return
 				}
-				if zb0009 {
+				if zb0011 {
 					(*z).ProverPersistedFields.Participants = nil
-				} else if (*z).ProverPersistedFields.Participants != nil && cap((*z).ProverPersistedFields.Participants) >= zb0008 {
-					(*z).ProverPersistedFields.Participants = ((*z).ProverPersistedFields.Participants)[:zb0008]
+				} else if (*z).ProverPersistedFields.Participants != nil && cap((*z).ProverPersistedFields.Participants) >= zb0010 {
+					(*z).ProverPersistedFields.Participants = ((*z).ProverPersistedFields.Participants)[:zb0010]
 				} else {
-					(*z).ProverPersistedFields.Participants = make([]basics.Participant, zb0008)
+					(*z).ProverPersistedFields.Participants = make([]basics.Participant, zb0010)
 				}
 				for zb0002 := range (*z).ProverPersistedFields.Participants {
 					bts, err = (*z).ProverPersistedFields.Participants[zb0002].UnmarshalMsg(bts)
@@ -370,7 +404,12 @@ func (z *Prover) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0006 = "parts"
 			case "parttree":
+				if validate && zb0007 && "parttree" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
@@ -387,24 +426,40 @@ func (z *Prover) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0006 = "parttree"
 			case "lnprv":
+				if validate && zb0007 && "lnprv" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).ProverPersistedFields.LnProvenWeight, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "LnProvenWeight")
 					return
 				}
+				zb0006 = "lnprv"
 			case "prv":
+				if validate && zb0007 && "prv" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).ProverPersistedFields.ProvenWeight, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ProvenWeight")
 					return
 				}
+				zb0006 = "prv"
 			case "str":
+				if validate && zb0007 && "str" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).ProverPersistedFields.StrengthTarget, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StrengthTarget")
 					return
 				}
+				zb0006 = "str"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -412,12 +467,19 @@ func (z *Prover) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0007 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *Prover) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Prover) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Prover) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Prover)
 	return ok
@@ -551,16 +613,24 @@ func (_ *ProverPersistedFields) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *ProverPersistedFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *ProverPersistedFields) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -581,24 +651,24 @@ func (z *ProverPersistedFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0007 int
+			var zb0008 bool
+			zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Participants")
 				return
 			}
-			if zb0005 > VotersAllocBound {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(VotersAllocBound))
+			if zb0007 > VotersAllocBound {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(VotersAllocBound))
 				err = msgp.WrapError(err, "struct-from-array", "Participants")
 				return
 			}
-			if zb0006 {
+			if zb0008 {
 				(*z).Participants = nil
-			} else if (*z).Participants != nil && cap((*z).Participants) >= zb0005 {
-				(*z).Participants = ((*z).Participants)[:zb0005]
+			} else if (*z).Participants != nil && cap((*z).Participants) >= zb0007 {
+				(*z).Participants = ((*z).Participants)[:zb0007]
 			} else {
-				(*z).Participants = make([]basics.Participant, zb0005)
+				(*z).Participants = make([]basics.Participant, zb0007)
 			}
 			for zb0002 := range (*z).Participants {
 				bts, err = (*z).Participants[zb0002].UnmarshalMsg(bts)
@@ -675,36 +745,50 @@ func (z *ProverPersistedFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "data":
+				if validate && zb0006 && "data" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).Data)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "Data")
 					return
 				}
+				zb0005 = "data"
 			case "rnd":
+				if validate && zb0006 && "rnd" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Round, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0005 = "rnd"
 			case "parts":
-				var zb0007 int
-				var zb0008 bool
-				zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "parts" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0009 int
+				var zb0010 bool
+				zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Participants")
 					return
 				}
-				if zb0007 > VotersAllocBound {
-					err = msgp.ErrOverflow(uint64(zb0007), uint64(VotersAllocBound))
+				if zb0009 > VotersAllocBound {
+					err = msgp.ErrOverflow(uint64(zb0009), uint64(VotersAllocBound))
 					err = msgp.WrapError(err, "Participants")
 					return
 				}
-				if zb0008 {
+				if zb0010 {
 					(*z).Participants = nil
-				} else if (*z).Participants != nil && cap((*z).Participants) >= zb0007 {
-					(*z).Participants = ((*z).Participants)[:zb0007]
+				} else if (*z).Participants != nil && cap((*z).Participants) >= zb0009 {
+					(*z).Participants = ((*z).Participants)[:zb0009]
 				} else {
-					(*z).Participants = make([]basics.Participant, zb0007)
+					(*z).Participants = make([]basics.Participant, zb0009)
 				}
 				for zb0002 := range (*z).Participants {
 					bts, err = (*z).Participants[zb0002].UnmarshalMsg(bts)
@@ -713,7 +797,12 @@ func (z *ProverPersistedFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0005 = "parts"
 			case "parttree":
+				if validate && zb0006 && "parttree" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
@@ -730,24 +819,40 @@ func (z *ProverPersistedFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0005 = "parttree"
 			case "lnprv":
+				if validate && zb0006 && "lnprv" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).LnProvenWeight, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "LnProvenWeight")
 					return
 				}
+				zb0005 = "lnprv"
 			case "prv":
+				if validate && zb0006 && "prv" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).ProvenWeight, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ProvenWeight")
 					return
 				}
+				zb0005 = "prv"
 			case "str":
+				if validate && zb0006 && "str" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).StrengthTarget, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StrengthTarget")
 					return
 				}
+				zb0005 = "str"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -755,12 +860,19 @@ func (z *ProverPersistedFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *ProverPersistedFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *ProverPersistedFields) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *ProverPersistedFields) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*ProverPersistedFields)
 	return ok
@@ -860,11 +972,15 @@ func (_ *Reveal) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Reveal) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Reveal) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -872,35 +988,47 @@ func (z *Reveal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0001 > 0 {
 			zb0001--
-			var zb0003 int
-			var zb0004 bool
-			zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0005 int
+			var zb0007 string
+			var zb0008 bool
+			var zb0006 bool
+			_ = zb0007
+			_ = zb0008
+			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "SigSlot")
 					return
 				}
-				if zb0003 > 0 {
-					zb0003--
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0005 > 0 {
+					zb0005--
 					bts, err = (*z).SigSlot.Sig.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "SigSlot", "struct-from-array", "Sig")
 						return
 					}
 				}
-				if zb0003 > 0 {
-					zb0003--
+				if zb0005 > 0 {
+					zb0005--
 					(*z).SigSlot.L, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "SigSlot", "struct-from-array", "L")
 						return
 					}
 				}
-				if zb0003 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0003)
+				if zb0005 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0005)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "SigSlot", "struct-from-array")
 						return
@@ -911,11 +1039,11 @@ func (z *Reveal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "SigSlot")
 					return
 				}
-				if zb0004 {
+				if zb0006 {
 					(*z).SigSlot = sigslotCommit{}
 				}
-				for zb0003 > 0 {
-					zb0003--
+				for zb0005 > 0 {
+					zb0005--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "SigSlot")
@@ -923,17 +1051,27 @@ func (z *Reveal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch string(field) {
 					case "s":
+						if validate && zb0008 && "s" < zb0007 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						bts, err = (*z).SigSlot.Sig.UnmarshalMsg(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "SigSlot", "Sig")
 							return
 						}
+						zb0007 = "s"
 					case "l":
+						if validate && zb0008 && "l" < zb0007 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).SigSlot.L, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "SigSlot", "L")
 							return
 						}
+						zb0007 = "l"
 					default:
 						err = msgp.ErrNoField(string(field))
 						if err != nil {
@@ -941,6 +1079,7 @@ func (z *Reveal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0008 = true
 				}
 			}
 		}
@@ -976,33 +1115,45 @@ func (z *Reveal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "s":
-				var zb0005 int
-				var zb0006 bool
-				zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0004 && "s" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0009 int
+				var zb0011 string
+				var zb0012 bool
+				var zb0010 bool
+				_ = zb0011
+				_ = zb0012
+				zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "SigSlot")
 						return
 					}
-					if zb0005 > 0 {
-						zb0005--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0009 > 0 {
+						zb0009--
 						bts, err = (*z).SigSlot.Sig.UnmarshalMsg(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "SigSlot", "struct-from-array", "Sig")
 							return
 						}
 					}
-					if zb0005 > 0 {
-						zb0005--
+					if zb0009 > 0 {
+						zb0009--
 						(*z).SigSlot.L, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "SigSlot", "struct-from-array", "L")
 							return
 						}
 					}
-					if zb0005 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0005)
+					if zb0009 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0009)
 						if err != nil {
 							err = msgp.WrapError(err, "SigSlot", "struct-from-array")
 							return
@@ -1013,11 +1164,11 @@ func (z *Reveal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "SigSlot")
 						return
 					}
-					if zb0006 {
+					if zb0010 {
 						(*z).SigSlot = sigslotCommit{}
 					}
-					for zb0005 > 0 {
-						zb0005--
+					for zb0009 > 0 {
+						zb0009--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "SigSlot")
@@ -1025,17 +1176,27 @@ func (z *Reveal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "s":
+							if validate && zb0012 && "s" < zb0011 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							bts, err = (*z).SigSlot.Sig.UnmarshalMsg(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "SigSlot", "Sig")
 								return
 							}
+							zb0011 = "s"
 						case "l":
+							if validate && zb0012 && "l" < zb0011 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).SigSlot.L, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "SigSlot", "L")
 								return
 							}
+							zb0011 = "l"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -1043,14 +1204,21 @@ func (z *Reveal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0012 = true
 					}
 				}
+				zb0003 = "s"
 			case "p":
+				if validate && zb0004 && "p" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Part.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Part")
 					return
 				}
+				zb0003 = "p"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1058,12 +1226,19 @@ func (z *Reveal) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *Reveal) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Reveal) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Reveal) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Reveal)
 	return ok
@@ -1190,16 +1365,24 @@ func (_ *StateProof) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *StateProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *StateProof) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0004 int
+	var zb0006 string
+	var zb0007 bool
 	var zb0005 bool
+	_ = zb0006
+	_ = zb0007
 	zb0004, zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0004 > 0 {
@@ -1244,32 +1427,42 @@ func (z *StateProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0006 int
-			var zb0007 bool
-			zb0006, zb0007, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0008 int
+			var zb0009 bool
+			zb0008, zb0009, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Reveals")
 				return
 			}
-			if zb0006 > MaxReveals {
-				err = msgp.ErrOverflow(uint64(zb0006), uint64(MaxReveals))
+			if zb0008 > MaxReveals {
+				err = msgp.ErrOverflow(uint64(zb0008), uint64(MaxReveals))
 				err = msgp.WrapError(err, "struct-from-array", "Reveals")
 				return
 			}
-			if zb0007 {
+			if zb0009 {
 				(*z).Reveals = nil
 			} else if (*z).Reveals == nil {
-				(*z).Reveals = make(map[uint64]Reveal, zb0006)
+				(*z).Reveals = make(map[uint64]Reveal, zb0008)
 			}
-			for zb0006 > 0 {
+			var zb0010 uint64
+			_ = zb0010
+			var zb0011 bool
+			_ = zb0011
+			for zb0008 > 0 {
 				var zb0001 uint64
 				var zb0002 Reveal
-				zb0006--
+				zb0008--
 				zb0001, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Reveals")
 					return
 				}
+				if validate && zb0011 && Uint64Less(zb0001, zb0010) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0010 = zb0001
+				zb0011 = true
 				bts, err = zb0002.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Reveals", zb0001)
@@ -1280,24 +1473,24 @@ func (z *StateProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0008 int
-			var zb0009 bool
-			zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0012 int
+			var zb0013 bool
+			zb0012, zb0013, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "PositionsToReveal")
 				return
 			}
-			if zb0008 > MaxReveals {
-				err = msgp.ErrOverflow(uint64(zb0008), uint64(MaxReveals))
+			if zb0012 > MaxReveals {
+				err = msgp.ErrOverflow(uint64(zb0012), uint64(MaxReveals))
 				err = msgp.WrapError(err, "struct-from-array", "PositionsToReveal")
 				return
 			}
-			if zb0009 {
+			if zb0013 {
 				(*z).PositionsToReveal = nil
-			} else if (*z).PositionsToReveal != nil && cap((*z).PositionsToReveal) >= zb0008 {
-				(*z).PositionsToReveal = ((*z).PositionsToReveal)[:zb0008]
+			} else if (*z).PositionsToReveal != nil && cap((*z).PositionsToReveal) >= zb0012 {
+				(*z).PositionsToReveal = ((*z).PositionsToReveal)[:zb0012]
 			} else {
-				(*z).PositionsToReveal = make([]uint64, zb0008)
+				(*z).PositionsToReveal = make([]uint64, zb0012)
 			}
 			for zb0003 := range (*z).PositionsToReveal {
 				(*z).PositionsToReveal[zb0003], bts, err = msgp.ReadUint64Bytes(bts)
@@ -1331,62 +1524,101 @@ func (z *StateProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "c":
+				if validate && zb0007 && "c" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SigCommit.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SigCommit")
 					return
 				}
+				zb0006 = "c"
 			case "w":
+				if validate && zb0007 && "w" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).SignedWeight, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SignedWeight")
 					return
 				}
+				zb0006 = "w"
 			case "S":
+				if validate && zb0007 && "S" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SigProofs.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SigProofs")
 					return
 				}
+				zb0006 = "S"
 			case "P":
+				if validate && zb0007 && "P" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).PartProofs.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "PartProofs")
 					return
 				}
+				zb0006 = "P"
 			case "v":
+				if validate && zb0007 && "v" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).MerkleSignatureSaltVersion, bts, err = msgp.ReadByteBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "MerkleSignatureSaltVersion")
 					return
 				}
+				zb0006 = "v"
 			case "r":
-				var zb0010 int
-				var zb0011 bool
-				zb0010, zb0011, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0007 && "r" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0014 int
+				var zb0015 bool
+				zb0014, zb0015, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Reveals")
 					return
 				}
-				if zb0010 > MaxReveals {
-					err = msgp.ErrOverflow(uint64(zb0010), uint64(MaxReveals))
+				if zb0014 > MaxReveals {
+					err = msgp.ErrOverflow(uint64(zb0014), uint64(MaxReveals))
 					err = msgp.WrapError(err, "Reveals")
 					return
 				}
-				if zb0011 {
+				if zb0015 {
 					(*z).Reveals = nil
 				} else if (*z).Reveals == nil {
-					(*z).Reveals = make(map[uint64]Reveal, zb0010)
+					(*z).Reveals = make(map[uint64]Reveal, zb0014)
 				}
-				for zb0010 > 0 {
+				var zb0016 uint64
+				_ = zb0016
+				var zb0017 bool
+				_ = zb0017
+				for zb0014 > 0 {
 					var zb0001 uint64
 					var zb0002 Reveal
-					zb0010--
+					zb0014--
 					zb0001, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Reveals")
 						return
 					}
+					if validate && zb0017 && Uint64Less(zb0001, zb0016) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0016 = zb0001
+					zb0017 = true
 					bts, err = zb0002.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Reveals", zb0001)
@@ -1394,25 +1626,30 @@ func (z *StateProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).Reveals[zb0001] = zb0002
 				}
+				zb0006 = "r"
 			case "pr":
-				var zb0012 int
-				var zb0013 bool
-				zb0012, zb0013, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0007 && "pr" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0018 int
+				var zb0019 bool
+				zb0018, zb0019, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "PositionsToReveal")
 					return
 				}
-				if zb0012 > MaxReveals {
-					err = msgp.ErrOverflow(uint64(zb0012), uint64(MaxReveals))
+				if zb0018 > MaxReveals {
+					err = msgp.ErrOverflow(uint64(zb0018), uint64(MaxReveals))
 					err = msgp.WrapError(err, "PositionsToReveal")
 					return
 				}
-				if zb0013 {
+				if zb0019 {
 					(*z).PositionsToReveal = nil
-				} else if (*z).PositionsToReveal != nil && cap((*z).PositionsToReveal) >= zb0012 {
-					(*z).PositionsToReveal = ((*z).PositionsToReveal)[:zb0012]
+				} else if (*z).PositionsToReveal != nil && cap((*z).PositionsToReveal) >= zb0018 {
+					(*z).PositionsToReveal = ((*z).PositionsToReveal)[:zb0018]
 				} else {
-					(*z).PositionsToReveal = make([]uint64, zb0012)
+					(*z).PositionsToReveal = make([]uint64, zb0018)
 				}
 				for zb0003 := range (*z).PositionsToReveal {
 					(*z).PositionsToReveal[zb0003], bts, err = msgp.ReadUint64Bytes(bts)
@@ -1421,6 +1658,7 @@ func (z *StateProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0006 = "pr"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1428,12 +1666,19 @@ func (z *StateProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0007 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *StateProof) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *StateProof) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *StateProof) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*StateProof)
 	return ok
@@ -1515,16 +1760,24 @@ func (_ *sigslotCommit) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *sigslotCommit) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *sigslotCommit) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -1567,17 +1820,27 @@ func (z *sigslotCommit) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "s":
+				if validate && zb0004 && "s" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sig")
 					return
 				}
+				zb0003 = "s"
 			case "l":
+				if validate && zb0004 && "l" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).L, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "L")
 					return
 				}
+				zb0003 = "l"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1585,12 +1848,19 @@ func (z *sigslotCommit) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *sigslotCommit) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *sigslotCommit) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *sigslotCommit) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*sigslotCommit)
 	return ok

--- a/crypto/stateproof/structs.go
+++ b/crypto/stateproof/structs.go
@@ -112,3 +112,6 @@ func (s StateProof) String() string {
 // SortUint64 implements sorting by uint64 keys for
 // canonical encoding of maps in msgpack format.
 type SortUint64 = basics.SortUint64
+
+// Uint64Less is necessary for UnmarshalValidateMsg functionality
+func Uint64Less(a, b uint64) bool { return a < b }

--- a/daemon/algod/api/spec/v2/msgp_gen.go
+++ b/daemon/algod/api/spec/v2/msgp_gen.go
@@ -13,6 +13,7 @@ import (
 //            |-----> (*) MarshalMsg
 //            |-----> (*) CanMarshalMsg
 //            |-----> (*) UnmarshalMsg
+//            |-----> (*) UnmarshalValidateMsg
 //            |-----> (*) CanUnmarshalMsg
 //            |-----> (*) Msgsize
 //            |-----> (*) MsgIsZero
@@ -22,6 +23,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -73,16 +75,24 @@ func (_ *AccountApplicationModel) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *AccountApplicationModel) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *AccountApplicationModel) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -147,6 +157,10 @@ func (z *AccountApplicationModel) UnmarshalMsg(bts []byte) (o []byte, err error)
 			}
 			switch string(field) {
 			case "app-local-state":
+				if validate && zb0004 && "app-local-state" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
@@ -163,7 +177,12 @@ func (z *AccountApplicationModel) UnmarshalMsg(bts []byte) (o []byte, err error)
 						return
 					}
 				}
+				zb0003 = "app-local-state"
 			case "app-params":
+				if validate && zb0004 && "app-params" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
@@ -180,6 +199,7 @@ func (z *AccountApplicationModel) UnmarshalMsg(bts []byte) (o []byte, err error)
 						return
 					}
 				}
+				zb0003 = "app-params"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -187,12 +207,19 @@ func (z *AccountApplicationModel) UnmarshalMsg(bts []byte) (o []byte, err error)
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *AccountApplicationModel) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *AccountApplicationModel) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *AccountApplicationModel) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*AccountApplicationModel)
 	return ok
@@ -274,16 +301,24 @@ func (_ *AccountAssetModel) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *AccountAssetModel) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *AccountAssetModel) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -348,6 +383,10 @@ func (z *AccountAssetModel) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "asset-params":
+				if validate && zb0004 && "asset-params" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
@@ -364,7 +403,12 @@ func (z *AccountAssetModel) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0003 = "asset-params"
 			case "asset-holding":
+				if validate && zb0004 && "asset-holding" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
@@ -381,6 +425,7 @@ func (z *AccountAssetModel) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0003 = "asset-holding"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -388,12 +433,19 @@ func (z *AccountAssetModel) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *AccountAssetModel) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *AccountAssetModel) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *AccountAssetModel) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*AccountAssetModel)
 	return ok

--- a/data/account/msgp_gen.go
+++ b/data/account/msgp_gen.go
@@ -15,6 +15,7 @@ import (
 //             |-----> (*) MarshalMsg
 //             |-----> (*) CanMarshalMsg
 //             |-----> (*) UnmarshalMsg
+//             |-----> (*) UnmarshalValidateMsg
 //             |-----> (*) CanUnmarshalMsg
 //             |-----> (*) Msgsize
 //             |-----> (*) MsgIsZero
@@ -24,6 +25,7 @@ import (
 //        |-----> MarshalMsg
 //        |-----> CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> Msgsize
 //        |-----> MsgIsZero
@@ -103,16 +105,24 @@ func (_ *ParticipationKeyIdentity) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *ParticipationKeyIdentity) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *ParticipationKeyIdentity) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -187,41 +197,71 @@ func (z *ParticipationKeyIdentity) UnmarshalMsg(bts []byte) (o []byte, err error
 			}
 			switch string(field) {
 			case "addr":
+				if validate && zb0004 && "addr" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Parent.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Parent")
 					return
 				}
+				zb0003 = "addr"
 			case "vrfsk":
+				if validate && zb0004 && "vrfsk" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VRFSK.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VRFSK")
 					return
 				}
+				zb0003 = "vrfsk"
 			case "vote-id":
+				if validate && zb0004 && "vote-id" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VoteID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteID")
 					return
 				}
+				zb0003 = "vote-id"
 			case "fv":
+				if validate && zb0004 && "fv" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).FirstValid.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FirstValid")
 					return
 				}
+				zb0003 = "fv"
 			case "lv":
+				if validate && zb0004 && "lv" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).LastValid.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "LastValid")
 					return
 				}
+				zb0003 = "lv"
 			case "kd":
+				if validate && zb0004 && "kd" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).KeyDilution, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "KeyDilution")
 					return
 				}
+				zb0003 = "kd"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -229,12 +269,19 @@ func (z *ParticipationKeyIdentity) UnmarshalMsg(bts []byte) (o []byte, err error
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *ParticipationKeyIdentity) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *ParticipationKeyIdentity) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *ParticipationKeyIdentity) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*ParticipationKeyIdentity)
 	return ok
@@ -280,7 +327,7 @@ func (_ StateProofKeys) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *StateProofKeys) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *StateProofKeys) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var zb0002 int
 	var zb0003 bool
 	zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -311,6 +358,12 @@ func (z *StateProofKeys) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *StateProofKeys) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *StateProofKeys) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *StateProofKeys) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*StateProofKeys)
 	return ok

--- a/data/basics/msgp_gen.go
+++ b/data/basics/msgp_gen.go
@@ -17,6 +17,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -26,6 +27,7 @@ import (
 //    |-----> (*) MarshalMsg
 //    |-----> (*) CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> (*) Msgsize
 //    |-----> (*) MsgIsZero
@@ -34,6 +36,7 @@ import (
 //     |-----> MarshalMsg
 //     |-----> CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> Msgsize
 //     |-----> MsgIsZero
@@ -43,6 +46,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -52,6 +56,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -61,6 +66,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -70,6 +76,7 @@ import (
 //      |-----> MarshalMsg
 //      |-----> CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> Msgsize
 //      |-----> MsgIsZero
@@ -79,6 +86,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -88,6 +96,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -97,6 +106,7 @@ import (
 //        |-----> MarshalMsg
 //        |-----> CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> Msgsize
 //        |-----> MsgIsZero
@@ -106,6 +116,7 @@ import (
 //       |-----> MarshalMsg
 //       |-----> CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> Msgsize
 //       |-----> MsgIsZero
@@ -115,6 +126,7 @@ import (
 //      |-----> MarshalMsg
 //      |-----> CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> Msgsize
 //      |-----> MsgIsZero
@@ -124,6 +136,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -133,6 +146,7 @@ import (
 //   |-----> MarshalMsg
 //   |-----> CanMarshalMsg
 //   |-----> (*) UnmarshalMsg
+//   |-----> (*) UnmarshalValidateMsg
 //   |-----> (*) CanUnmarshalMsg
 //   |-----> Msgsize
 //   |-----> MsgIsZero
@@ -142,6 +156,7 @@ import (
 //       |-----> MarshalMsg
 //       |-----> CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> Msgsize
 //       |-----> MsgIsZero
@@ -151,6 +166,7 @@ import (
 //      |-----> MarshalMsg
 //      |-----> CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> Msgsize
 //      |-----> MsgIsZero
@@ -160,6 +176,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -169,6 +186,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -178,6 +196,7 @@ import (
 //    |-----> MarshalMsg
 //    |-----> CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> Msgsize
 //    |-----> MsgIsZero
@@ -187,6 +206,7 @@ import (
 //       |-----> MarshalMsg
 //       |-----> CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> Msgsize
 //       |-----> MsgIsZero
@@ -196,6 +216,7 @@ import (
 //     |-----> MarshalMsg
 //     |-----> CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> Msgsize
 //     |-----> MsgIsZero
@@ -205,6 +226,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -214,6 +236,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -519,11 +542,15 @@ func (_ *AccountData) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *AccountData) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0009 int
+	var zb0011 string
+	var zb0012 bool
 	var zb0010 bool
+	_ = zb0011
+	_ = zb0012
 	zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -531,16 +558,20 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0009 > 0 {
 			zb0009--
 			{
-				var zb0011 byte
-				zb0011, bts, err = msgp.ReadByteBytes(bts)
+				var zb0013 byte
+				zb0013, bts, err = msgp.ReadByteBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Status")
 					return
 				}
-				(*z).Status = Status(zb0011)
+				(*z).Status = Status(zb0013)
 			}
 		}
 		if zb0009 > 0 {
@@ -594,25 +625,25 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		if zb0009 > 0 {
 			zb0009--
 			{
-				var zb0012 uint64
-				zb0012, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0014 uint64
+				zb0014, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "VoteFirstValid")
 					return
 				}
-				(*z).VoteFirstValid = Round(zb0012)
+				(*z).VoteFirstValid = Round(zb0014)
 			}
 		}
 		if zb0009 > 0 {
 			zb0009--
 			{
-				var zb0013 uint64
-				zb0013, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0015 uint64
+				zb0015, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "VoteLastValid")
 					return
 				}
-				(*z).VoteLastValid = Round(zb0013)
+				(*z).VoteLastValid = Round(zb0015)
 			}
 		}
 		if zb0009 > 0 {
@@ -625,32 +656,42 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0009 > 0 {
 			zb0009--
-			var zb0014 int
-			var zb0015 bool
-			zb0014, zb0015, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0016 int
+			var zb0017 bool
+			zb0016, zb0017, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "AssetParams")
 				return
 			}
-			if zb0014 > encodedMaxAssetsPerAccount {
-				err = msgp.ErrOverflow(uint64(zb0014), uint64(encodedMaxAssetsPerAccount))
+			if zb0016 > encodedMaxAssetsPerAccount {
+				err = msgp.ErrOverflow(uint64(zb0016), uint64(encodedMaxAssetsPerAccount))
 				err = msgp.WrapError(err, "struct-from-array", "AssetParams")
 				return
 			}
-			if zb0015 {
+			if zb0017 {
 				(*z).AssetParams = nil
 			} else if (*z).AssetParams == nil {
-				(*z).AssetParams = make(map[AssetIndex]AssetParams, zb0014)
+				(*z).AssetParams = make(map[AssetIndex]AssetParams, zb0016)
 			}
-			for zb0014 > 0 {
+			var zb0018 AssetIndex
+			_ = zb0018
+			var zb0019 bool
+			_ = zb0019
+			for zb0016 > 0 {
 				var zb0001 AssetIndex
 				var zb0002 AssetParams
-				zb0014--
+				zb0016--
 				bts, err = zb0001.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "AssetParams")
 					return
 				}
+				if validate && zb0019 && AssetIndexLess(zb0001, zb0018) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0018 = zb0001
+				zb0019 = true
 				bts, err = zb0002.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "AssetParams", zb0001)
@@ -661,59 +702,77 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0009 > 0 {
 			zb0009--
-			var zb0016 int
-			var zb0017 bool
-			zb0016, zb0017, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0020 int
+			var zb0021 bool
+			zb0020, zb0021, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Assets")
 				return
 			}
-			if zb0016 > encodedMaxAssetsPerAccount {
-				err = msgp.ErrOverflow(uint64(zb0016), uint64(encodedMaxAssetsPerAccount))
+			if zb0020 > encodedMaxAssetsPerAccount {
+				err = msgp.ErrOverflow(uint64(zb0020), uint64(encodedMaxAssetsPerAccount))
 				err = msgp.WrapError(err, "struct-from-array", "Assets")
 				return
 			}
-			if zb0017 {
+			if zb0021 {
 				(*z).Assets = nil
 			} else if (*z).Assets == nil {
-				(*z).Assets = make(map[AssetIndex]AssetHolding, zb0016)
+				(*z).Assets = make(map[AssetIndex]AssetHolding, zb0020)
 			}
-			for zb0016 > 0 {
+			var zb0022 AssetIndex
+			_ = zb0022
+			var zb0023 bool
+			_ = zb0023
+			for zb0020 > 0 {
 				var zb0003 AssetIndex
 				var zb0004 AssetHolding
-				zb0016--
+				zb0020--
 				bts, err = zb0003.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Assets")
 					return
 				}
-				var zb0018 int
-				var zb0019 bool
-				zb0018, zb0019, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0023 && AssetIndexLess(zb0003, zb0022) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0022 = zb0003
+				zb0023 = true
+				var zb0024 int
+				var zb0026 string
+				var zb0027 bool
+				var zb0025 bool
+				_ = zb0026
+				_ = zb0027
+				zb0024, zb0025, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0018, zb0019, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0024, zb0025, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Assets", zb0003)
 						return
 					}
-					if zb0018 > 0 {
-						zb0018--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0024 > 0 {
+						zb0024--
 						zb0004.Amount, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Assets", zb0003, "struct-from-array", "Amount")
 							return
 						}
 					}
-					if zb0018 > 0 {
-						zb0018--
+					if zb0024 > 0 {
+						zb0024--
 						zb0004.Frozen, bts, err = msgp.ReadBoolBytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Assets", zb0003, "struct-from-array", "Frozen")
 							return
 						}
 					}
-					if zb0018 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0018)
+					if zb0024 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0024)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Assets", zb0003, "struct-from-array")
 							return
@@ -724,11 +783,11 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "struct-from-array", "Assets", zb0003)
 						return
 					}
-					if zb0019 {
+					if zb0025 {
 						zb0004 = AssetHolding{}
 					}
-					for zb0018 > 0 {
-						zb0018--
+					for zb0024 > 0 {
+						zb0024--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Assets", zb0003)
@@ -736,17 +795,27 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "a":
+							if validate && zb0027 && "a" < zb0026 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							zb0004.Amount, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "struct-from-array", "Assets", zb0003, "Amount")
 								return
 							}
+							zb0026 = "a"
 						case "f":
+							if validate && zb0027 && "f" < zb0026 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							zb0004.Frozen, bts, err = msgp.ReadBoolBytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "struct-from-array", "Assets", zb0003, "Frozen")
 								return
 							}
+							zb0026 = "f"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -754,6 +823,7 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0027 = true
 					}
 				}
 				(*z).Assets[zb0003] = zb0004
@@ -769,32 +839,42 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0009 > 0 {
 			zb0009--
-			var zb0020 int
-			var zb0021 bool
-			zb0020, zb0021, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0028 int
+			var zb0029 bool
+			zb0028, zb0029, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "AppLocalStates")
 				return
 			}
-			if zb0020 > EncodedMaxAppLocalStates {
-				err = msgp.ErrOverflow(uint64(zb0020), uint64(EncodedMaxAppLocalStates))
+			if zb0028 > EncodedMaxAppLocalStates {
+				err = msgp.ErrOverflow(uint64(zb0028), uint64(EncodedMaxAppLocalStates))
 				err = msgp.WrapError(err, "struct-from-array", "AppLocalStates")
 				return
 			}
-			if zb0021 {
+			if zb0029 {
 				(*z).AppLocalStates = nil
 			} else if (*z).AppLocalStates == nil {
-				(*z).AppLocalStates = make(map[AppIndex]AppLocalState, zb0020)
+				(*z).AppLocalStates = make(map[AppIndex]AppLocalState, zb0028)
 			}
-			for zb0020 > 0 {
+			var zb0030 AppIndex
+			_ = zb0030
+			var zb0031 bool
+			_ = zb0031
+			for zb0028 > 0 {
 				var zb0005 AppIndex
 				var zb0006 AppLocalState
-				zb0020--
+				zb0028--
 				bts, err = zb0005.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "AppLocalStates")
 					return
 				}
+				if validate && zb0031 && AppIndexLess(zb0005, zb0030) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0030 = zb0005
+				zb0031 = true
 				bts, err = zb0006.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "AppLocalStates", zb0005)
@@ -805,32 +885,42 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0009 > 0 {
 			zb0009--
-			var zb0022 int
-			var zb0023 bool
-			zb0022, zb0023, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0032 int
+			var zb0033 bool
+			zb0032, zb0033, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "AppParams")
 				return
 			}
-			if zb0022 > EncodedMaxAppParams {
-				err = msgp.ErrOverflow(uint64(zb0022), uint64(EncodedMaxAppParams))
+			if zb0032 > EncodedMaxAppParams {
+				err = msgp.ErrOverflow(uint64(zb0032), uint64(EncodedMaxAppParams))
 				err = msgp.WrapError(err, "struct-from-array", "AppParams")
 				return
 			}
-			if zb0023 {
+			if zb0033 {
 				(*z).AppParams = nil
 			} else if (*z).AppParams == nil {
-				(*z).AppParams = make(map[AppIndex]AppParams, zb0022)
+				(*z).AppParams = make(map[AppIndex]AppParams, zb0032)
 			}
-			for zb0022 > 0 {
+			var zb0034 AppIndex
+			_ = zb0034
+			var zb0035 bool
+			_ = zb0035
+			for zb0032 > 0 {
 				var zb0007 AppIndex
 				var zb0008 AppParams
-				zb0022--
+				zb0032--
 				bts, err = zb0007.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "AppParams")
 					return
 				}
+				if validate && zb0035 && AppIndexLess(zb0007, zb0034) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0034 = zb0007
+				zb0035 = true
 				bts, err = zb0008.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "AppParams", zb0007)
@@ -841,33 +931,41 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0009 > 0 {
 			zb0009--
-			var zb0024 int
-			var zb0025 bool
-			zb0024, zb0025, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0036 int
+			var zb0038 string
+			var zb0039 bool
+			var zb0037 bool
+			_ = zb0038
+			_ = zb0039
+			zb0036, zb0037, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0024, zb0025, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0036, zb0037, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "TotalAppSchema")
 					return
 				}
-				if zb0024 > 0 {
-					zb0024--
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0036 > 0 {
+					zb0036--
 					(*z).TotalAppSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "TotalAppSchema", "struct-from-array", "NumUint")
 						return
 					}
 				}
-				if zb0024 > 0 {
-					zb0024--
+				if zb0036 > 0 {
+					zb0036--
 					(*z).TotalAppSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "TotalAppSchema", "struct-from-array", "NumByteSlice")
 						return
 					}
 				}
-				if zb0024 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0024)
+				if zb0036 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0036)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "TotalAppSchema", "struct-from-array")
 						return
@@ -878,11 +976,11 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "TotalAppSchema")
 					return
 				}
-				if zb0025 {
+				if zb0037 {
 					(*z).TotalAppSchema = StateSchema{}
 				}
-				for zb0024 > 0 {
-					zb0024--
+				for zb0036 > 0 {
+					zb0036--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "TotalAppSchema")
@@ -890,17 +988,27 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch string(field) {
 					case "nui":
+						if validate && zb0039 && "nui" < zb0038 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).TotalAppSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "TotalAppSchema", "NumUint")
 							return
 						}
+						zb0038 = "nui"
 					case "nbs":
+						if validate && zb0039 && "nbs" < zb0038 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).TotalAppSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "TotalAppSchema", "NumByteSlice")
 							return
 						}
+						zb0038 = "nbs"
 					default:
 						err = msgp.ErrNoField(string(field))
 						if err != nil {
@@ -908,6 +1016,7 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0039 = true
 				}
 			}
 		}
@@ -959,104 +1068,168 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "onl":
+				if validate && zb0012 && "onl" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0026 byte
-					zb0026, bts, err = msgp.ReadByteBytes(bts)
+					var zb0040 byte
+					zb0040, bts, err = msgp.ReadByteBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Status")
 						return
 					}
-					(*z).Status = Status(zb0026)
+					(*z).Status = Status(zb0040)
 				}
+				zb0011 = "onl"
 			case "algo":
+				if validate && zb0012 && "algo" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).MicroAlgos.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "MicroAlgos")
 					return
 				}
+				zb0011 = "algo"
 			case "ebase":
+				if validate && zb0012 && "ebase" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).RewardsBase, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsBase")
 					return
 				}
+				zb0011 = "ebase"
 			case "ern":
+				if validate && zb0012 && "ern" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).RewardedMicroAlgos.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardedMicroAlgos")
 					return
 				}
+				zb0011 = "ern"
 			case "vote":
+				if validate && zb0012 && "vote" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VoteID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteID")
 					return
 				}
+				zb0011 = "vote"
 			case "sel":
+				if validate && zb0012 && "sel" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SelectionID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SelectionID")
 					return
 				}
+				zb0011 = "sel"
 			case "stprf":
+				if validate && zb0012 && "stprf" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).StateProofID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofID")
 					return
 				}
+				zb0011 = "stprf"
 			case "voteFst":
+				if validate && zb0012 && "voteFst" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0027 uint64
-					zb0027, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0041 uint64
+					zb0041, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "VoteFirstValid")
 						return
 					}
-					(*z).VoteFirstValid = Round(zb0027)
+					(*z).VoteFirstValid = Round(zb0041)
 				}
+				zb0011 = "voteFst"
 			case "voteLst":
+				if validate && zb0012 && "voteLst" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0028 uint64
-					zb0028, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0042 uint64
+					zb0042, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "VoteLastValid")
 						return
 					}
-					(*z).VoteLastValid = Round(zb0028)
+					(*z).VoteLastValid = Round(zb0042)
 				}
+				zb0011 = "voteLst"
 			case "voteKD":
+				if validate && zb0012 && "voteKD" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).VoteKeyDilution, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteKeyDilution")
 					return
 				}
+				zb0011 = "voteKD"
 			case "apar":
-				var zb0029 int
-				var zb0030 bool
-				zb0029, zb0030, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0012 && "apar" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0043 int
+				var zb0044 bool
+				zb0043, zb0044, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetParams")
 					return
 				}
-				if zb0029 > encodedMaxAssetsPerAccount {
-					err = msgp.ErrOverflow(uint64(zb0029), uint64(encodedMaxAssetsPerAccount))
+				if zb0043 > encodedMaxAssetsPerAccount {
+					err = msgp.ErrOverflow(uint64(zb0043), uint64(encodedMaxAssetsPerAccount))
 					err = msgp.WrapError(err, "AssetParams")
 					return
 				}
-				if zb0030 {
+				if zb0044 {
 					(*z).AssetParams = nil
 				} else if (*z).AssetParams == nil {
-					(*z).AssetParams = make(map[AssetIndex]AssetParams, zb0029)
+					(*z).AssetParams = make(map[AssetIndex]AssetParams, zb0043)
 				}
-				for zb0029 > 0 {
+				var zb0045 AssetIndex
+				_ = zb0045
+				var zb0046 bool
+				_ = zb0046
+				for zb0043 > 0 {
 					var zb0001 AssetIndex
 					var zb0002 AssetParams
-					zb0029--
+					zb0043--
 					bts, err = zb0001.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "AssetParams")
 						return
 					}
+					if validate && zb0046 && AssetIndexLess(zb0001, zb0045) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0045 = zb0001
+					zb0046 = true
 					bts, err = zb0002.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "AssetParams", zb0001)
@@ -1064,60 +1237,83 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).AssetParams[zb0001] = zb0002
 				}
+				zb0011 = "apar"
 			case "asset":
-				var zb0031 int
-				var zb0032 bool
-				zb0031, zb0032, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0012 && "asset" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0047 int
+				var zb0048 bool
+				zb0047, zb0048, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Assets")
 					return
 				}
-				if zb0031 > encodedMaxAssetsPerAccount {
-					err = msgp.ErrOverflow(uint64(zb0031), uint64(encodedMaxAssetsPerAccount))
+				if zb0047 > encodedMaxAssetsPerAccount {
+					err = msgp.ErrOverflow(uint64(zb0047), uint64(encodedMaxAssetsPerAccount))
 					err = msgp.WrapError(err, "Assets")
 					return
 				}
-				if zb0032 {
+				if zb0048 {
 					(*z).Assets = nil
 				} else if (*z).Assets == nil {
-					(*z).Assets = make(map[AssetIndex]AssetHolding, zb0031)
+					(*z).Assets = make(map[AssetIndex]AssetHolding, zb0047)
 				}
-				for zb0031 > 0 {
+				var zb0049 AssetIndex
+				_ = zb0049
+				var zb0050 bool
+				_ = zb0050
+				for zb0047 > 0 {
 					var zb0003 AssetIndex
 					var zb0004 AssetHolding
-					zb0031--
+					zb0047--
 					bts, err = zb0003.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Assets")
 						return
 					}
-					var zb0033 int
-					var zb0034 bool
-					zb0033, zb0034, bts, err = msgp.ReadMapHeaderBytes(bts)
+					if validate && zb0050 && AssetIndexLess(zb0003, zb0049) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0049 = zb0003
+					zb0050 = true
+					var zb0051 int
+					var zb0053 string
+					var zb0054 bool
+					var zb0052 bool
+					_ = zb0053
+					_ = zb0054
+					zb0051, zb0052, bts, err = msgp.ReadMapHeaderBytes(bts)
 					if _, ok := err.(msgp.TypeError); ok {
-						zb0033, zb0034, bts, err = msgp.ReadArrayHeaderBytes(bts)
+						zb0051, zb0052, bts, err = msgp.ReadArrayHeaderBytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Assets", zb0003)
 							return
 						}
-						if zb0033 > 0 {
-							zb0033--
+						if validate {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
+						if zb0051 > 0 {
+							zb0051--
 							zb0004.Amount, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Assets", zb0003, "struct-from-array", "Amount")
 								return
 							}
 						}
-						if zb0033 > 0 {
-							zb0033--
+						if zb0051 > 0 {
+							zb0051--
 							zb0004.Frozen, bts, err = msgp.ReadBoolBytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Assets", zb0003, "struct-from-array", "Frozen")
 								return
 							}
 						}
-						if zb0033 > 0 {
-							err = msgp.ErrTooManyArrayFields(zb0033)
+						if zb0051 > 0 {
+							err = msgp.ErrTooManyArrayFields(zb0051)
 							if err != nil {
 								err = msgp.WrapError(err, "Assets", zb0003, "struct-from-array")
 								return
@@ -1128,11 +1324,11 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							err = msgp.WrapError(err, "Assets", zb0003)
 							return
 						}
-						if zb0034 {
+						if zb0052 {
 							zb0004 = AssetHolding{}
 						}
-						for zb0033 > 0 {
-							zb0033--
+						for zb0051 > 0 {
+							zb0051--
 							field, bts, err = msgp.ReadMapKeyZC(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Assets", zb0003)
@@ -1140,17 +1336,27 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							}
 							switch string(field) {
 							case "a":
+								if validate && zb0054 && "a" < zb0053 {
+									err = &msgp.ErrNonCanonical{}
+									return
+								}
 								zb0004.Amount, bts, err = msgp.ReadUint64Bytes(bts)
 								if err != nil {
 									err = msgp.WrapError(err, "Assets", zb0003, "Amount")
 									return
 								}
+								zb0053 = "a"
 							case "f":
+								if validate && zb0054 && "f" < zb0053 {
+									err = &msgp.ErrNonCanonical{}
+									return
+								}
 								zb0004.Frozen, bts, err = msgp.ReadBoolBytes(bts)
 								if err != nil {
 									err = msgp.WrapError(err, "Assets", zb0003, "Frozen")
 									return
 								}
+								zb0053 = "f"
 							default:
 								err = msgp.ErrNoField(string(field))
 								if err != nil {
@@ -1158,43 +1364,64 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 									return
 								}
 							}
+							zb0054 = true
 						}
 					}
 					(*z).Assets[zb0003] = zb0004
 				}
+				zb0011 = "asset"
 			case "spend":
+				if validate && zb0012 && "spend" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AuthAddr.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AuthAddr")
 					return
 				}
+				zb0011 = "spend"
 			case "appl":
-				var zb0035 int
-				var zb0036 bool
-				zb0035, zb0036, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0012 && "appl" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0055 int
+				var zb0056 bool
+				zb0055, zb0056, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AppLocalStates")
 					return
 				}
-				if zb0035 > EncodedMaxAppLocalStates {
-					err = msgp.ErrOverflow(uint64(zb0035), uint64(EncodedMaxAppLocalStates))
+				if zb0055 > EncodedMaxAppLocalStates {
+					err = msgp.ErrOverflow(uint64(zb0055), uint64(EncodedMaxAppLocalStates))
 					err = msgp.WrapError(err, "AppLocalStates")
 					return
 				}
-				if zb0036 {
+				if zb0056 {
 					(*z).AppLocalStates = nil
 				} else if (*z).AppLocalStates == nil {
-					(*z).AppLocalStates = make(map[AppIndex]AppLocalState, zb0035)
+					(*z).AppLocalStates = make(map[AppIndex]AppLocalState, zb0055)
 				}
-				for zb0035 > 0 {
+				var zb0057 AppIndex
+				_ = zb0057
+				var zb0058 bool
+				_ = zb0058
+				for zb0055 > 0 {
 					var zb0005 AppIndex
 					var zb0006 AppLocalState
-					zb0035--
+					zb0055--
 					bts, err = zb0005.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "AppLocalStates")
 						return
 					}
+					if validate && zb0058 && AppIndexLess(zb0005, zb0057) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0057 = zb0005
+					zb0058 = true
 					bts, err = zb0006.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "AppLocalStates", zb0005)
@@ -1202,33 +1429,48 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).AppLocalStates[zb0005] = zb0006
 				}
+				zb0011 = "appl"
 			case "appp":
-				var zb0037 int
-				var zb0038 bool
-				zb0037, zb0038, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0012 && "appp" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0059 int
+				var zb0060 bool
+				zb0059, zb0060, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AppParams")
 					return
 				}
-				if zb0037 > EncodedMaxAppParams {
-					err = msgp.ErrOverflow(uint64(zb0037), uint64(EncodedMaxAppParams))
+				if zb0059 > EncodedMaxAppParams {
+					err = msgp.ErrOverflow(uint64(zb0059), uint64(EncodedMaxAppParams))
 					err = msgp.WrapError(err, "AppParams")
 					return
 				}
-				if zb0038 {
+				if zb0060 {
 					(*z).AppParams = nil
 				} else if (*z).AppParams == nil {
-					(*z).AppParams = make(map[AppIndex]AppParams, zb0037)
+					(*z).AppParams = make(map[AppIndex]AppParams, zb0059)
 				}
-				for zb0037 > 0 {
+				var zb0061 AppIndex
+				_ = zb0061
+				var zb0062 bool
+				_ = zb0062
+				for zb0059 > 0 {
 					var zb0007 AppIndex
 					var zb0008 AppParams
-					zb0037--
+					zb0059--
 					bts, err = zb0007.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "AppParams")
 						return
 					}
+					if validate && zb0062 && AppIndexLess(zb0007, zb0061) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0061 = zb0007
+					zb0062 = true
 					bts, err = zb0008.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "AppParams", zb0007)
@@ -1236,34 +1478,47 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).AppParams[zb0007] = zb0008
 				}
+				zb0011 = "appp"
 			case "tsch":
-				var zb0039 int
-				var zb0040 bool
-				zb0039, zb0040, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0012 && "tsch" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0063 int
+				var zb0065 string
+				var zb0066 bool
+				var zb0064 bool
+				_ = zb0065
+				_ = zb0066
+				zb0063, zb0064, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0039, zb0040, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0063, zb0064, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "TotalAppSchema")
 						return
 					}
-					if zb0039 > 0 {
-						zb0039--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0063 > 0 {
+						zb0063--
 						(*z).TotalAppSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "TotalAppSchema", "struct-from-array", "NumUint")
 							return
 						}
 					}
-					if zb0039 > 0 {
-						zb0039--
+					if zb0063 > 0 {
+						zb0063--
 						(*z).TotalAppSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "TotalAppSchema", "struct-from-array", "NumByteSlice")
 							return
 						}
 					}
-					if zb0039 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0039)
+					if zb0063 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0063)
 						if err != nil {
 							err = msgp.WrapError(err, "TotalAppSchema", "struct-from-array")
 							return
@@ -1274,11 +1529,11 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "TotalAppSchema")
 						return
 					}
-					if zb0040 {
+					if zb0064 {
 						(*z).TotalAppSchema = StateSchema{}
 					}
-					for zb0039 > 0 {
-						zb0039--
+					for zb0063 > 0 {
+						zb0063--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "TotalAppSchema")
@@ -1286,17 +1541,27 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "nui":
+							if validate && zb0066 && "nui" < zb0065 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).TotalAppSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "TotalAppSchema", "NumUint")
 								return
 							}
+							zb0065 = "nui"
 						case "nbs":
+							if validate && zb0066 && "nbs" < zb0065 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).TotalAppSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "TotalAppSchema", "NumByteSlice")
 								return
 							}
+							zb0065 = "nbs"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -1304,26 +1569,43 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0066 = true
 					}
 				}
+				zb0011 = "tsch"
 			case "teap":
+				if validate && zb0012 && "teap" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalExtraAppPages, bts, err = msgp.ReadUint32Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalExtraAppPages")
 					return
 				}
+				zb0011 = "teap"
 			case "tbx":
+				if validate && zb0012 && "tbx" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalBoxes, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalBoxes")
 					return
 				}
+				zb0011 = "tbx"
 			case "tbxb":
+				if validate && zb0012 && "tbxb" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalBoxBytes, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalBoxBytes")
 					return
 				}
+				zb0011 = "tbxb"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1331,12 +1613,19 @@ func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0012 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *AccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *AccountData) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *AccountData) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*AccountData)
 	return ok
@@ -1429,6 +1718,9 @@ func (_ *Address) CanMarshalMsg(z interface{}) bool {
 func (z *Address) UnmarshalMsg(bts []byte) ([]byte, error) {
 	return ((*(crypto.Digest))(z)).UnmarshalMsg(bts)
 }
+func (z *Address) UnmarshalValidateMsg(bts []byte) ([]byte, error) {
+	return ((*(crypto.Digest))(z)).UnmarshalValidateMsg(bts)
+}
 func (_ *Address) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Address)
 	return ok
@@ -1465,7 +1757,7 @@ func (_ AppIndex) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *AppIndex) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *AppIndex) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 uint64
 		zb0001, bts, err = msgp.ReadUint64Bytes(bts)
@@ -1479,6 +1771,12 @@ func (z *AppIndex) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *AppIndex) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *AppIndex) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *AppIndex) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*AppIndex)
 	return ok
@@ -1575,11 +1873,15 @@ func (_ *AppLocalState) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *AppLocalState) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *AppLocalState) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -1587,35 +1889,47 @@ func (z *AppLocalState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0007 int
+			var zb0009 string
+			var zb0010 bool
+			var zb0008 bool
+			_ = zb0009
+			_ = zb0010
+			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Schema")
 					return
 				}
-				if zb0005 > 0 {
-					zb0005--
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0007 > 0 {
+					zb0007--
 					(*z).Schema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Schema", "struct-from-array", "NumUint")
 						return
 					}
 				}
-				if zb0005 > 0 {
-					zb0005--
+				if zb0007 > 0 {
+					zb0007--
 					(*z).Schema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Schema", "struct-from-array", "NumByteSlice")
 						return
 					}
 				}
-				if zb0005 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0005)
+				if zb0007 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0007)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Schema", "struct-from-array")
 						return
@@ -1626,11 +1940,11 @@ func (z *AppLocalState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "Schema")
 					return
 				}
-				if zb0006 {
+				if zb0008 {
 					(*z).Schema = StateSchema{}
 				}
-				for zb0005 > 0 {
-					zb0005--
+				for zb0007 > 0 {
+					zb0007--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Schema")
@@ -1638,17 +1952,27 @@ func (z *AppLocalState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch string(field) {
 					case "nui":
+						if validate && zb0010 && "nui" < zb0009 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).Schema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Schema", "NumUint")
 							return
 						}
+						zb0009 = "nui"
 					case "nbs":
+						if validate && zb0010 && "nbs" < zb0009 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).Schema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Schema", "NumByteSlice")
 							return
 						}
+						zb0009 = "nbs"
 					default:
 						err = msgp.ErrNoField(string(field))
 						if err != nil {
@@ -1656,37 +1980,48 @@ func (z *AppLocalState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0010 = true
 				}
 			}
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0007 int
-			var zb0008 bool
-			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0011 int
+			var zb0012 bool
+			zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "KeyValue")
 				return
 			}
-			if zb0007 > EncodedMaxKeyValueEntries {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(EncodedMaxKeyValueEntries))
+			if zb0011 > EncodedMaxKeyValueEntries {
+				err = msgp.ErrOverflow(uint64(zb0011), uint64(EncodedMaxKeyValueEntries))
 				err = msgp.WrapError(err, "struct-from-array", "KeyValue")
 				return
 			}
-			if zb0008 {
+			if zb0012 {
 				(*z).KeyValue = nil
 			} else if (*z).KeyValue == nil {
-				(*z).KeyValue = make(TealKeyValue, zb0007)
+				(*z).KeyValue = make(TealKeyValue, zb0011)
 			}
-			for zb0007 > 0 {
+			var zb0013 string
+			_ = zb0013
+			var zb0014 bool
+			_ = zb0014
+			for zb0011 > 0 {
 				var zb0001 string
 				var zb0002 TealValue
-				zb0007--
+				zb0011--
 				zb0001, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "KeyValue")
 					return
 				}
+				if validate && zb0014 && StringLess(zb0001, zb0013) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0013 = zb0001
+				zb0014 = true
 				bts, err = zb0002.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "KeyValue", zb0001)
@@ -1719,33 +2054,45 @@ func (z *AppLocalState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "hsch":
-				var zb0009 int
-				var zb0010 bool
-				zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0006 && "hsch" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0015 int
+				var zb0017 string
+				var zb0018 bool
+				var zb0016 bool
+				_ = zb0017
+				_ = zb0018
+				zb0015, zb0016, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0015, zb0016, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Schema")
 						return
 					}
-					if zb0009 > 0 {
-						zb0009--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0015 > 0 {
+						zb0015--
 						(*z).Schema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Schema", "struct-from-array", "NumUint")
 							return
 						}
 					}
-					if zb0009 > 0 {
-						zb0009--
+					if zb0015 > 0 {
+						zb0015--
 						(*z).Schema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Schema", "struct-from-array", "NumByteSlice")
 							return
 						}
 					}
-					if zb0009 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0009)
+					if zb0015 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0015)
 						if err != nil {
 							err = msgp.WrapError(err, "Schema", "struct-from-array")
 							return
@@ -1756,11 +2103,11 @@ func (z *AppLocalState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "Schema")
 						return
 					}
-					if zb0010 {
+					if zb0016 {
 						(*z).Schema = StateSchema{}
 					}
-					for zb0009 > 0 {
-						zb0009--
+					for zb0015 > 0 {
+						zb0015--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Schema")
@@ -1768,17 +2115,27 @@ func (z *AppLocalState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "nui":
+							if validate && zb0018 && "nui" < zb0017 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).Schema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Schema", "NumUint")
 								return
 							}
+							zb0017 = "nui"
 						case "nbs":
+							if validate && zb0018 && "nbs" < zb0017 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).Schema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Schema", "NumByteSlice")
 								return
 							}
+							zb0017 = "nbs"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -1786,35 +2143,51 @@ func (z *AppLocalState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0018 = true
 					}
 				}
+				zb0005 = "hsch"
 			case "tkv":
-				var zb0011 int
-				var zb0012 bool
-				zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0006 && "tkv" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0019 int
+				var zb0020 bool
+				zb0019, zb0020, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "KeyValue")
 					return
 				}
-				if zb0011 > EncodedMaxKeyValueEntries {
-					err = msgp.ErrOverflow(uint64(zb0011), uint64(EncodedMaxKeyValueEntries))
+				if zb0019 > EncodedMaxKeyValueEntries {
+					err = msgp.ErrOverflow(uint64(zb0019), uint64(EncodedMaxKeyValueEntries))
 					err = msgp.WrapError(err, "KeyValue")
 					return
 				}
-				if zb0012 {
+				if zb0020 {
 					(*z).KeyValue = nil
 				} else if (*z).KeyValue == nil {
-					(*z).KeyValue = make(TealKeyValue, zb0011)
+					(*z).KeyValue = make(TealKeyValue, zb0019)
 				}
-				for zb0011 > 0 {
+				var zb0021 string
+				_ = zb0021
+				var zb0022 bool
+				_ = zb0022
+				for zb0019 > 0 {
 					var zb0001 string
 					var zb0002 TealValue
-					zb0011--
+					zb0019--
 					zb0001, bts, err = msgp.ReadStringBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "KeyValue")
 						return
 					}
+					if validate && zb0022 && StringLess(zb0001, zb0021) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0021 = zb0001
+					zb0022 = true
 					bts, err = zb0002.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "KeyValue", zb0001)
@@ -1822,6 +2195,7 @@ func (z *AppLocalState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).KeyValue[zb0001] = zb0002
 				}
+				zb0005 = "tkv"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1829,12 +2203,19 @@ func (z *AppLocalState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *AppLocalState) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *AppLocalState) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *AppLocalState) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*AppLocalState)
 	return ok
@@ -2001,11 +2382,15 @@ func (_ *AppParams) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *AppParams) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -2013,16 +2398,20 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			zb0005, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0007 int
+			zb0007, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ApprovalProgram")
 				return
 			}
-			if zb0005 > config.MaxAvailableAppProgramLen {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(config.MaxAvailableAppProgramLen))
+			if zb0007 > config.MaxAvailableAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxAvailableAppProgramLen))
 				return
 			}
 			(*z).ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApprovalProgram)
@@ -2033,14 +2422,14 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0006 int
-			zb0006, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0008 int
+			zb0008, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ClearStateProgram")
 				return
 			}
-			if zb0006 > config.MaxAvailableAppProgramLen {
-				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxAvailableAppProgramLen))
+			if zb0008 > config.MaxAvailableAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxAvailableAppProgramLen))
 				return
 			}
 			(*z).ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ClearStateProgram)
@@ -2051,32 +2440,42 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0007 int
-			var zb0008 bool
-			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0009 int
+			var zb0010 bool
+			zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "GlobalState")
 				return
 			}
-			if zb0007 > EncodedMaxKeyValueEntries {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(EncodedMaxKeyValueEntries))
+			if zb0009 > EncodedMaxKeyValueEntries {
+				err = msgp.ErrOverflow(uint64(zb0009), uint64(EncodedMaxKeyValueEntries))
 				err = msgp.WrapError(err, "struct-from-array", "GlobalState")
 				return
 			}
-			if zb0008 {
+			if zb0010 {
 				(*z).GlobalState = nil
 			} else if (*z).GlobalState == nil {
-				(*z).GlobalState = make(TealKeyValue, zb0007)
+				(*z).GlobalState = make(TealKeyValue, zb0009)
 			}
-			for zb0007 > 0 {
+			var zb0011 string
+			_ = zb0011
+			var zb0012 bool
+			_ = zb0012
+			for zb0009 > 0 {
 				var zb0001 string
 				var zb0002 TealValue
-				zb0007--
+				zb0009--
 				zb0001, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "GlobalState")
 					return
 				}
+				if validate && zb0012 && StringLess(zb0001, zb0011) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0011 = zb0001
+				zb0012 = true
 				bts, err = zb0002.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "GlobalState", zb0001)
@@ -2087,33 +2486,41 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0009 int
-			var zb0010 bool
-			zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0013 int
+			var zb0015 string
+			var zb0016 bool
+			var zb0014 bool
+			_ = zb0015
+			_ = zb0016
+			zb0013, zb0014, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema")
 					return
 				}
-				if zb0009 > 0 {
-					zb0009--
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0013 > 0 {
+					zb0013--
 					(*z).StateSchemas.LocalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema", "struct-from-array", "NumUint")
 						return
 					}
 				}
-				if zb0009 > 0 {
-					zb0009--
+				if zb0013 > 0 {
+					zb0013--
 					(*z).StateSchemas.LocalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema", "struct-from-array", "NumByteSlice")
 						return
 					}
 				}
-				if zb0009 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0009)
+				if zb0013 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0013)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema", "struct-from-array")
 						return
@@ -2124,11 +2531,11 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema")
 					return
 				}
-				if zb0010 {
+				if zb0014 {
 					(*z).StateSchemas.LocalStateSchema = StateSchema{}
 				}
-				for zb0009 > 0 {
-					zb0009--
+				for zb0013 > 0 {
+					zb0013--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema")
@@ -2136,17 +2543,27 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch string(field) {
 					case "nui":
+						if validate && zb0016 && "nui" < zb0015 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).StateSchemas.LocalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema", "NumUint")
 							return
 						}
+						zb0015 = "nui"
 					case "nbs":
+						if validate && zb0016 && "nbs" < zb0015 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).StateSchemas.LocalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema", "NumByteSlice")
 							return
 						}
+						zb0015 = "nbs"
 					default:
 						err = msgp.ErrNoField(string(field))
 						if err != nil {
@@ -2154,38 +2571,47 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0016 = true
 				}
 			}
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0011 int
-			var zb0012 bool
-			zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0017 int
+			var zb0019 string
+			var zb0020 bool
+			var zb0018 bool
+			_ = zb0019
+			_ = zb0020
+			zb0017, zb0018, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0017, zb0018, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema")
 					return
 				}
-				if zb0011 > 0 {
-					zb0011--
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0017 > 0 {
+					zb0017--
 					(*z).StateSchemas.GlobalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema", "struct-from-array", "NumUint")
 						return
 					}
 				}
-				if zb0011 > 0 {
-					zb0011--
+				if zb0017 > 0 {
+					zb0017--
 					(*z).StateSchemas.GlobalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema", "struct-from-array", "NumByteSlice")
 						return
 					}
 				}
-				if zb0011 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0011)
+				if zb0017 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0017)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema", "struct-from-array")
 						return
@@ -2196,11 +2622,11 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema")
 					return
 				}
-				if zb0012 {
+				if zb0018 {
 					(*z).StateSchemas.GlobalStateSchema = StateSchema{}
 				}
-				for zb0011 > 0 {
-					zb0011--
+				for zb0017 > 0 {
+					zb0017--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema")
@@ -2208,17 +2634,27 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch string(field) {
 					case "nui":
+						if validate && zb0020 && "nui" < zb0019 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).StateSchemas.GlobalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema", "NumUint")
 							return
 						}
+						zb0019 = "nui"
 					case "nbs":
+						if validate && zb0020 && "nbs" < zb0019 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).StateSchemas.GlobalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema", "NumByteSlice")
 							return
 						}
+						zb0019 = "nbs"
 					default:
 						err = msgp.ErrNoField(string(field))
 						if err != nil {
@@ -2226,6 +2662,7 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0020 = true
 				}
 			}
 		}
@@ -2261,14 +2698,18 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "approv":
-				var zb0013 int
-				zb0013, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0006 && "approv" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0021 int
+				zb0021, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ApprovalProgram")
 					return
 				}
-				if zb0013 > config.MaxAvailableAppProgramLen {
-					err = msgp.ErrOverflow(uint64(zb0013), uint64(config.MaxAvailableAppProgramLen))
+				if zb0021 > config.MaxAvailableAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0021), uint64(config.MaxAvailableAppProgramLen))
 					return
 				}
 				(*z).ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApprovalProgram)
@@ -2276,15 +2717,20 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "ApprovalProgram")
 					return
 				}
+				zb0005 = "approv"
 			case "clearp":
-				var zb0014 int
-				zb0014, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0006 && "clearp" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0022 int
+				zb0022, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ClearStateProgram")
 					return
 				}
-				if zb0014 > config.MaxAvailableAppProgramLen {
-					err = msgp.ErrOverflow(uint64(zb0014), uint64(config.MaxAvailableAppProgramLen))
+				if zb0022 > config.MaxAvailableAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0022), uint64(config.MaxAvailableAppProgramLen))
 					return
 				}
 				(*z).ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ClearStateProgram)
@@ -2292,33 +2738,48 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "ClearStateProgram")
 					return
 				}
+				zb0005 = "clearp"
 			case "gs":
-				var zb0015 int
-				var zb0016 bool
-				zb0015, zb0016, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0006 && "gs" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0023 int
+				var zb0024 bool
+				zb0023, zb0024, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GlobalState")
 					return
 				}
-				if zb0015 > EncodedMaxKeyValueEntries {
-					err = msgp.ErrOverflow(uint64(zb0015), uint64(EncodedMaxKeyValueEntries))
+				if zb0023 > EncodedMaxKeyValueEntries {
+					err = msgp.ErrOverflow(uint64(zb0023), uint64(EncodedMaxKeyValueEntries))
 					err = msgp.WrapError(err, "GlobalState")
 					return
 				}
-				if zb0016 {
+				if zb0024 {
 					(*z).GlobalState = nil
 				} else if (*z).GlobalState == nil {
-					(*z).GlobalState = make(TealKeyValue, zb0015)
+					(*z).GlobalState = make(TealKeyValue, zb0023)
 				}
-				for zb0015 > 0 {
+				var zb0025 string
+				_ = zb0025
+				var zb0026 bool
+				_ = zb0026
+				for zb0023 > 0 {
 					var zb0001 string
 					var zb0002 TealValue
-					zb0015--
+					zb0023--
 					zb0001, bts, err = msgp.ReadStringBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "GlobalState")
 						return
 					}
+					if validate && zb0026 && StringLess(zb0001, zb0025) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0025 = zb0001
+					zb0026 = true
 					bts, err = zb0002.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "GlobalState", zb0001)
@@ -2326,34 +2787,47 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).GlobalState[zb0001] = zb0002
 				}
+				zb0005 = "gs"
 			case "lsch":
-				var zb0017 int
-				var zb0018 bool
-				zb0017, zb0018, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0006 && "lsch" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0027 int
+				var zb0029 string
+				var zb0030 bool
+				var zb0028 bool
+				_ = zb0029
+				_ = zb0030
+				zb0027, zb0028, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0017, zb0018, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0027, zb0028, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "LocalStateSchema")
 						return
 					}
-					if zb0017 > 0 {
-						zb0017--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0027 > 0 {
+						zb0027--
 						(*z).StateSchemas.LocalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "LocalStateSchema", "struct-from-array", "NumUint")
 							return
 						}
 					}
-					if zb0017 > 0 {
-						zb0017--
+					if zb0027 > 0 {
+						zb0027--
 						(*z).StateSchemas.LocalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "LocalStateSchema", "struct-from-array", "NumByteSlice")
 							return
 						}
 					}
-					if zb0017 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0017)
+					if zb0027 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0027)
 						if err != nil {
 							err = msgp.WrapError(err, "LocalStateSchema", "struct-from-array")
 							return
@@ -2364,11 +2838,11 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "LocalStateSchema")
 						return
 					}
-					if zb0018 {
+					if zb0028 {
 						(*z).StateSchemas.LocalStateSchema = StateSchema{}
 					}
-					for zb0017 > 0 {
-						zb0017--
+					for zb0027 > 0 {
+						zb0027--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "LocalStateSchema")
@@ -2376,17 +2850,27 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "nui":
+							if validate && zb0030 && "nui" < zb0029 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).StateSchemas.LocalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "LocalStateSchema", "NumUint")
 								return
 							}
+							zb0029 = "nui"
 						case "nbs":
+							if validate && zb0030 && "nbs" < zb0029 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).StateSchemas.LocalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "LocalStateSchema", "NumByteSlice")
 								return
 							}
+							zb0029 = "nbs"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -2394,36 +2878,50 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0030 = true
 					}
 				}
+				zb0005 = "lsch"
 			case "gsch":
-				var zb0019 int
-				var zb0020 bool
-				zb0019, zb0020, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0006 && "gsch" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0031 int
+				var zb0033 string
+				var zb0034 bool
+				var zb0032 bool
+				_ = zb0033
+				_ = zb0034
+				zb0031, zb0032, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0019, zb0020, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0031, zb0032, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "GlobalStateSchema")
 						return
 					}
-					if zb0019 > 0 {
-						zb0019--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0031 > 0 {
+						zb0031--
 						(*z).StateSchemas.GlobalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "GlobalStateSchema", "struct-from-array", "NumUint")
 							return
 						}
 					}
-					if zb0019 > 0 {
-						zb0019--
+					if zb0031 > 0 {
+						zb0031--
 						(*z).StateSchemas.GlobalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "GlobalStateSchema", "struct-from-array", "NumByteSlice")
 							return
 						}
 					}
-					if zb0019 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0019)
+					if zb0031 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0031)
 						if err != nil {
 							err = msgp.WrapError(err, "GlobalStateSchema", "struct-from-array")
 							return
@@ -2434,11 +2932,11 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "GlobalStateSchema")
 						return
 					}
-					if zb0020 {
+					if zb0032 {
 						(*z).StateSchemas.GlobalStateSchema = StateSchema{}
 					}
-					for zb0019 > 0 {
-						zb0019--
+					for zb0031 > 0 {
+						zb0031--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "GlobalStateSchema")
@@ -2446,17 +2944,27 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "nui":
+							if validate && zb0034 && "nui" < zb0033 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).StateSchemas.GlobalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "GlobalStateSchema", "NumUint")
 								return
 							}
+							zb0033 = "nui"
 						case "nbs":
+							if validate && zb0034 && "nbs" < zb0033 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).StateSchemas.GlobalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "GlobalStateSchema", "NumByteSlice")
 								return
 							}
+							zb0033 = "nbs"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -2464,14 +2972,21 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0034 = true
 					}
 				}
+				zb0005 = "gsch"
 			case "epp":
+				if validate && zb0006 && "epp" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).ExtraProgramPages, bts, err = msgp.ReadUint32Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ExtraProgramPages")
 					return
 				}
+				zb0005 = "epp"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2479,12 +2994,19 @@ func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *AppParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *AppParams) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *AppParams) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*AppParams)
 	return ok
@@ -2558,16 +3080,24 @@ func (_ *AssetHolding) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *AssetHolding) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *AssetHolding) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -2610,17 +3140,27 @@ func (z *AssetHolding) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "a":
+				if validate && zb0004 && "a" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Amount, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Amount")
 					return
 				}
+				zb0003 = "a"
 			case "f":
+				if validate && zb0004 && "f" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Frozen, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Frozen")
 					return
 				}
+				zb0003 = "f"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2628,12 +3168,19 @@ func (z *AssetHolding) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *AssetHolding) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *AssetHolding) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *AssetHolding) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*AssetHolding)
 	return ok
@@ -2672,7 +3219,7 @@ func (_ AssetIndex) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *AssetIndex) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *AssetIndex) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 uint64
 		zb0001, bts, err = msgp.ReadUint64Bytes(bts)
@@ -2686,6 +3233,12 @@ func (z *AssetIndex) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *AssetIndex) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *AssetIndex) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *AssetIndex) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*AssetIndex)
 	return ok
@@ -2826,16 +3379,24 @@ func (_ *AssetParams) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *AssetParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *AssetParams) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0002 > 0 {
@@ -2864,14 +3425,14 @@ func (z *AssetParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0004 int
-			zb0004, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0006 int
+			zb0006, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "UnitName")
 				return
 			}
-			if zb0004 > config.MaxAssetUnitNameBytes {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(config.MaxAssetUnitNameBytes))
+			if zb0006 > config.MaxAssetUnitNameBytes {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxAssetUnitNameBytes))
 				return
 			}
 			(*z).UnitName, bts, err = msgp.ReadStringBytes(bts)
@@ -2882,14 +3443,14 @@ func (z *AssetParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0005 int
-			zb0005, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0007 int
+			zb0007, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "AssetName")
 				return
 			}
-			if zb0005 > config.MaxAssetNameBytes {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(config.MaxAssetNameBytes))
+			if zb0007 > config.MaxAssetNameBytes {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxAssetNameBytes))
 				return
 			}
 			(*z).AssetName, bts, err = msgp.ReadStringBytes(bts)
@@ -2900,14 +3461,14 @@ func (z *AssetParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0006 int
-			zb0006, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0008 int
+			zb0008, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "URL")
 				return
 			}
-			if zb0006 > config.MaxAssetURLBytes {
-				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxAssetURLBytes))
+			if zb0008 > config.MaxAssetURLBytes {
+				err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxAssetURLBytes))
 				return
 			}
 			(*z).URL, bts, err = msgp.ReadStringBytes(bts)
@@ -2980,32 +3541,51 @@ func (z *AssetParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "t":
+				if validate && zb0005 && "t" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Total, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Total")
 					return
 				}
+				zb0004 = "t"
 			case "dc":
+				if validate && zb0005 && "dc" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Decimals, bts, err = msgp.ReadUint32Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Decimals")
 					return
 				}
+				zb0004 = "dc"
 			case "df":
+				if validate && zb0005 && "df" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).DefaultFrozen, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "DefaultFrozen")
 					return
 				}
+				zb0004 = "df"
 			case "un":
-				var zb0007 int
-				zb0007, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0005 && "un" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0009 int
+				zb0009, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UnitName")
 					return
 				}
-				if zb0007 > config.MaxAssetUnitNameBytes {
-					err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxAssetUnitNameBytes))
+				if zb0009 > config.MaxAssetUnitNameBytes {
+					err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxAssetUnitNameBytes))
 					return
 				}
 				(*z).UnitName, bts, err = msgp.ReadStringBytes(bts)
@@ -3013,15 +3593,20 @@ func (z *AssetParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "UnitName")
 					return
 				}
+				zb0004 = "un"
 			case "an":
-				var zb0008 int
-				zb0008, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0005 && "an" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0010 int
+				zb0010, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetName")
 					return
 				}
-				if zb0008 > config.MaxAssetNameBytes {
-					err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxAssetNameBytes))
+				if zb0010 > config.MaxAssetNameBytes {
+					err = msgp.ErrOverflow(uint64(zb0010), uint64(config.MaxAssetNameBytes))
 					return
 				}
 				(*z).AssetName, bts, err = msgp.ReadStringBytes(bts)
@@ -3029,15 +3614,20 @@ func (z *AssetParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "AssetName")
 					return
 				}
+				zb0004 = "an"
 			case "au":
-				var zb0009 int
-				zb0009, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0005 && "au" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0011 int
+				zb0011, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "URL")
 					return
 				}
-				if zb0009 > config.MaxAssetURLBytes {
-					err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxAssetURLBytes))
+				if zb0011 > config.MaxAssetURLBytes {
+					err = msgp.ErrOverflow(uint64(zb0011), uint64(config.MaxAssetURLBytes))
 					return
 				}
 				(*z).URL, bts, err = msgp.ReadStringBytes(bts)
@@ -3045,36 +3635,62 @@ func (z *AssetParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "URL")
 					return
 				}
+				zb0004 = "au"
 			case "am":
+				if validate && zb0005 && "am" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).MetadataHash)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "MetadataHash")
 					return
 				}
+				zb0004 = "am"
 			case "m":
+				if validate && zb0005 && "m" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Manager.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Manager")
 					return
 				}
+				zb0004 = "m"
 			case "r":
+				if validate && zb0005 && "r" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Reserve.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Reserve")
 					return
 				}
+				zb0004 = "r"
 			case "f":
+				if validate && zb0005 && "f" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Freeze.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Freeze")
 					return
 				}
+				zb0004 = "f"
 			case "c":
+				if validate && zb0005 && "c" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Clawback.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Clawback")
 					return
 				}
+				zb0004 = "c"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3082,12 +3698,19 @@ func (z *AssetParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *AssetParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *AssetParams) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *AssetParams) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*AssetParams)
 	return ok
@@ -3418,16 +4041,24 @@ func (_ *BalanceRecord) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *BalanceRecord) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0009 int
+	var zb0011 string
+	var zb0012 bool
 	var zb0010 bool
+	_ = zb0011
+	_ = zb0012
 	zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0009 > 0 {
@@ -3441,13 +4072,13 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		if zb0009 > 0 {
 			zb0009--
 			{
-				var zb0011 byte
-				zb0011, bts, err = msgp.ReadByteBytes(bts)
+				var zb0013 byte
+				zb0013, bts, err = msgp.ReadByteBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Status")
 					return
 				}
-				(*z).AccountData.Status = Status(zb0011)
+				(*z).AccountData.Status = Status(zb0013)
 			}
 		}
 		if zb0009 > 0 {
@@ -3501,25 +4132,25 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		if zb0009 > 0 {
 			zb0009--
 			{
-				var zb0012 uint64
-				zb0012, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0014 uint64
+				zb0014, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "VoteFirstValid")
 					return
 				}
-				(*z).AccountData.VoteFirstValid = Round(zb0012)
+				(*z).AccountData.VoteFirstValid = Round(zb0014)
 			}
 		}
 		if zb0009 > 0 {
 			zb0009--
 			{
-				var zb0013 uint64
-				zb0013, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0015 uint64
+				zb0015, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "VoteLastValid")
 					return
 				}
-				(*z).AccountData.VoteLastValid = Round(zb0013)
+				(*z).AccountData.VoteLastValid = Round(zb0015)
 			}
 		}
 		if zb0009 > 0 {
@@ -3532,32 +4163,42 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0009 > 0 {
 			zb0009--
-			var zb0014 int
-			var zb0015 bool
-			zb0014, zb0015, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0016 int
+			var zb0017 bool
+			zb0016, zb0017, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "AssetParams")
 				return
 			}
-			if zb0014 > encodedMaxAssetsPerAccount {
-				err = msgp.ErrOverflow(uint64(zb0014), uint64(encodedMaxAssetsPerAccount))
+			if zb0016 > encodedMaxAssetsPerAccount {
+				err = msgp.ErrOverflow(uint64(zb0016), uint64(encodedMaxAssetsPerAccount))
 				err = msgp.WrapError(err, "struct-from-array", "AssetParams")
 				return
 			}
-			if zb0015 {
+			if zb0017 {
 				(*z).AccountData.AssetParams = nil
 			} else if (*z).AccountData.AssetParams == nil {
-				(*z).AccountData.AssetParams = make(map[AssetIndex]AssetParams, zb0014)
+				(*z).AccountData.AssetParams = make(map[AssetIndex]AssetParams, zb0016)
 			}
-			for zb0014 > 0 {
+			var zb0018 AssetIndex
+			_ = zb0018
+			var zb0019 bool
+			_ = zb0019
+			for zb0016 > 0 {
 				var zb0001 AssetIndex
 				var zb0002 AssetParams
-				zb0014--
+				zb0016--
 				bts, err = zb0001.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "AssetParams")
 					return
 				}
+				if validate && zb0019 && AssetIndexLess(zb0001, zb0018) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0018 = zb0001
+				zb0019 = true
 				bts, err = zb0002.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "AssetParams", zb0001)
@@ -3568,59 +4209,77 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0009 > 0 {
 			zb0009--
-			var zb0016 int
-			var zb0017 bool
-			zb0016, zb0017, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0020 int
+			var zb0021 bool
+			zb0020, zb0021, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Assets")
 				return
 			}
-			if zb0016 > encodedMaxAssetsPerAccount {
-				err = msgp.ErrOverflow(uint64(zb0016), uint64(encodedMaxAssetsPerAccount))
+			if zb0020 > encodedMaxAssetsPerAccount {
+				err = msgp.ErrOverflow(uint64(zb0020), uint64(encodedMaxAssetsPerAccount))
 				err = msgp.WrapError(err, "struct-from-array", "Assets")
 				return
 			}
-			if zb0017 {
+			if zb0021 {
 				(*z).AccountData.Assets = nil
 			} else if (*z).AccountData.Assets == nil {
-				(*z).AccountData.Assets = make(map[AssetIndex]AssetHolding, zb0016)
+				(*z).AccountData.Assets = make(map[AssetIndex]AssetHolding, zb0020)
 			}
-			for zb0016 > 0 {
+			var zb0022 AssetIndex
+			_ = zb0022
+			var zb0023 bool
+			_ = zb0023
+			for zb0020 > 0 {
 				var zb0003 AssetIndex
 				var zb0004 AssetHolding
-				zb0016--
+				zb0020--
 				bts, err = zb0003.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Assets")
 					return
 				}
-				var zb0018 int
-				var zb0019 bool
-				zb0018, zb0019, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0023 && AssetIndexLess(zb0003, zb0022) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0022 = zb0003
+				zb0023 = true
+				var zb0024 int
+				var zb0026 string
+				var zb0027 bool
+				var zb0025 bool
+				_ = zb0026
+				_ = zb0027
+				zb0024, zb0025, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0018, zb0019, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0024, zb0025, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Assets", zb0003)
 						return
 					}
-					if zb0018 > 0 {
-						zb0018--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0024 > 0 {
+						zb0024--
 						zb0004.Amount, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Assets", zb0003, "struct-from-array", "Amount")
 							return
 						}
 					}
-					if zb0018 > 0 {
-						zb0018--
+					if zb0024 > 0 {
+						zb0024--
 						zb0004.Frozen, bts, err = msgp.ReadBoolBytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Assets", zb0003, "struct-from-array", "Frozen")
 							return
 						}
 					}
-					if zb0018 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0018)
+					if zb0024 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0024)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Assets", zb0003, "struct-from-array")
 							return
@@ -3631,11 +4290,11 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "struct-from-array", "Assets", zb0003)
 						return
 					}
-					if zb0019 {
+					if zb0025 {
 						zb0004 = AssetHolding{}
 					}
-					for zb0018 > 0 {
-						zb0018--
+					for zb0024 > 0 {
+						zb0024--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Assets", zb0003)
@@ -3643,17 +4302,27 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "a":
+							if validate && zb0027 && "a" < zb0026 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							zb0004.Amount, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "struct-from-array", "Assets", zb0003, "Amount")
 								return
 							}
+							zb0026 = "a"
 						case "f":
+							if validate && zb0027 && "f" < zb0026 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							zb0004.Frozen, bts, err = msgp.ReadBoolBytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "struct-from-array", "Assets", zb0003, "Frozen")
 								return
 							}
+							zb0026 = "f"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -3661,6 +4330,7 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0027 = true
 					}
 				}
 				(*z).AccountData.Assets[zb0003] = zb0004
@@ -3676,32 +4346,42 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0009 > 0 {
 			zb0009--
-			var zb0020 int
-			var zb0021 bool
-			zb0020, zb0021, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0028 int
+			var zb0029 bool
+			zb0028, zb0029, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "AppLocalStates")
 				return
 			}
-			if zb0020 > EncodedMaxAppLocalStates {
-				err = msgp.ErrOverflow(uint64(zb0020), uint64(EncodedMaxAppLocalStates))
+			if zb0028 > EncodedMaxAppLocalStates {
+				err = msgp.ErrOverflow(uint64(zb0028), uint64(EncodedMaxAppLocalStates))
 				err = msgp.WrapError(err, "struct-from-array", "AppLocalStates")
 				return
 			}
-			if zb0021 {
+			if zb0029 {
 				(*z).AccountData.AppLocalStates = nil
 			} else if (*z).AccountData.AppLocalStates == nil {
-				(*z).AccountData.AppLocalStates = make(map[AppIndex]AppLocalState, zb0020)
+				(*z).AccountData.AppLocalStates = make(map[AppIndex]AppLocalState, zb0028)
 			}
-			for zb0020 > 0 {
+			var zb0030 AppIndex
+			_ = zb0030
+			var zb0031 bool
+			_ = zb0031
+			for zb0028 > 0 {
 				var zb0005 AppIndex
 				var zb0006 AppLocalState
-				zb0020--
+				zb0028--
 				bts, err = zb0005.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "AppLocalStates")
 					return
 				}
+				if validate && zb0031 && AppIndexLess(zb0005, zb0030) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0030 = zb0005
+				zb0031 = true
 				bts, err = zb0006.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "AppLocalStates", zb0005)
@@ -3712,32 +4392,42 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0009 > 0 {
 			zb0009--
-			var zb0022 int
-			var zb0023 bool
-			zb0022, zb0023, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0032 int
+			var zb0033 bool
+			zb0032, zb0033, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "AppParams")
 				return
 			}
-			if zb0022 > EncodedMaxAppParams {
-				err = msgp.ErrOverflow(uint64(zb0022), uint64(EncodedMaxAppParams))
+			if zb0032 > EncodedMaxAppParams {
+				err = msgp.ErrOverflow(uint64(zb0032), uint64(EncodedMaxAppParams))
 				err = msgp.WrapError(err, "struct-from-array", "AppParams")
 				return
 			}
-			if zb0023 {
+			if zb0033 {
 				(*z).AccountData.AppParams = nil
 			} else if (*z).AccountData.AppParams == nil {
-				(*z).AccountData.AppParams = make(map[AppIndex]AppParams, zb0022)
+				(*z).AccountData.AppParams = make(map[AppIndex]AppParams, zb0032)
 			}
-			for zb0022 > 0 {
+			var zb0034 AppIndex
+			_ = zb0034
+			var zb0035 bool
+			_ = zb0035
+			for zb0032 > 0 {
 				var zb0007 AppIndex
 				var zb0008 AppParams
-				zb0022--
+				zb0032--
 				bts, err = zb0007.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "AppParams")
 					return
 				}
+				if validate && zb0035 && AppIndexLess(zb0007, zb0034) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0034 = zb0007
+				zb0035 = true
 				bts, err = zb0008.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "AppParams", zb0007)
@@ -3748,33 +4438,41 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0009 > 0 {
 			zb0009--
-			var zb0024 int
-			var zb0025 bool
-			zb0024, zb0025, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0036 int
+			var zb0038 string
+			var zb0039 bool
+			var zb0037 bool
+			_ = zb0038
+			_ = zb0039
+			zb0036, zb0037, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0024, zb0025, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0036, zb0037, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "TotalAppSchema")
 					return
 				}
-				if zb0024 > 0 {
-					zb0024--
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0036 > 0 {
+					zb0036--
 					(*z).AccountData.TotalAppSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "TotalAppSchema", "struct-from-array", "NumUint")
 						return
 					}
 				}
-				if zb0024 > 0 {
-					zb0024--
+				if zb0036 > 0 {
+					zb0036--
 					(*z).AccountData.TotalAppSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "TotalAppSchema", "struct-from-array", "NumByteSlice")
 						return
 					}
 				}
-				if zb0024 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0024)
+				if zb0036 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0036)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "TotalAppSchema", "struct-from-array")
 						return
@@ -3785,11 +4483,11 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "TotalAppSchema")
 					return
 				}
-				if zb0025 {
+				if zb0037 {
 					(*z).AccountData.TotalAppSchema = StateSchema{}
 				}
-				for zb0024 > 0 {
-					zb0024--
+				for zb0036 > 0 {
+					zb0036--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "TotalAppSchema")
@@ -3797,17 +4495,27 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch string(field) {
 					case "nui":
+						if validate && zb0039 && "nui" < zb0038 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).AccountData.TotalAppSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "TotalAppSchema", "NumUint")
 							return
 						}
+						zb0038 = "nui"
 					case "nbs":
+						if validate && zb0039 && "nbs" < zb0038 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).AccountData.TotalAppSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "TotalAppSchema", "NumByteSlice")
 							return
 						}
+						zb0038 = "nbs"
 					default:
 						err = msgp.ErrNoField(string(field))
 						if err != nil {
@@ -3815,6 +4523,7 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0039 = true
 				}
 			}
 		}
@@ -3866,110 +4575,179 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "addr":
+				if validate && zb0012 && "addr" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Addr.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Addr")
 					return
 				}
+				zb0011 = "addr"
 			case "onl":
+				if validate && zb0012 && "onl" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0026 byte
-					zb0026, bts, err = msgp.ReadByteBytes(bts)
+					var zb0040 byte
+					zb0040, bts, err = msgp.ReadByteBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Status")
 						return
 					}
-					(*z).AccountData.Status = Status(zb0026)
+					(*z).AccountData.Status = Status(zb0040)
 				}
+				zb0011 = "onl"
 			case "algo":
+				if validate && zb0012 && "algo" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AccountData.MicroAlgos.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "MicroAlgos")
 					return
 				}
+				zb0011 = "algo"
 			case "ebase":
+				if validate && zb0012 && "ebase" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).AccountData.RewardsBase, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsBase")
 					return
 				}
+				zb0011 = "ebase"
 			case "ern":
+				if validate && zb0012 && "ern" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AccountData.RewardedMicroAlgos.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardedMicroAlgos")
 					return
 				}
+				zb0011 = "ern"
 			case "vote":
+				if validate && zb0012 && "vote" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AccountData.VoteID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteID")
 					return
 				}
+				zb0011 = "vote"
 			case "sel":
+				if validate && zb0012 && "sel" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AccountData.SelectionID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SelectionID")
 					return
 				}
+				zb0011 = "sel"
 			case "stprf":
+				if validate && zb0012 && "stprf" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AccountData.StateProofID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofID")
 					return
 				}
+				zb0011 = "stprf"
 			case "voteFst":
+				if validate && zb0012 && "voteFst" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0027 uint64
-					zb0027, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0041 uint64
+					zb0041, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "VoteFirstValid")
 						return
 					}
-					(*z).AccountData.VoteFirstValid = Round(zb0027)
+					(*z).AccountData.VoteFirstValid = Round(zb0041)
 				}
+				zb0011 = "voteFst"
 			case "voteLst":
+				if validate && zb0012 && "voteLst" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0028 uint64
-					zb0028, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0042 uint64
+					zb0042, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "VoteLastValid")
 						return
 					}
-					(*z).AccountData.VoteLastValid = Round(zb0028)
+					(*z).AccountData.VoteLastValid = Round(zb0042)
 				}
+				zb0011 = "voteLst"
 			case "voteKD":
+				if validate && zb0012 && "voteKD" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).AccountData.VoteKeyDilution, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteKeyDilution")
 					return
 				}
+				zb0011 = "voteKD"
 			case "apar":
-				var zb0029 int
-				var zb0030 bool
-				zb0029, zb0030, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0012 && "apar" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0043 int
+				var zb0044 bool
+				zb0043, zb0044, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetParams")
 					return
 				}
-				if zb0029 > encodedMaxAssetsPerAccount {
-					err = msgp.ErrOverflow(uint64(zb0029), uint64(encodedMaxAssetsPerAccount))
+				if zb0043 > encodedMaxAssetsPerAccount {
+					err = msgp.ErrOverflow(uint64(zb0043), uint64(encodedMaxAssetsPerAccount))
 					err = msgp.WrapError(err, "AssetParams")
 					return
 				}
-				if zb0030 {
+				if zb0044 {
 					(*z).AccountData.AssetParams = nil
 				} else if (*z).AccountData.AssetParams == nil {
-					(*z).AccountData.AssetParams = make(map[AssetIndex]AssetParams, zb0029)
+					(*z).AccountData.AssetParams = make(map[AssetIndex]AssetParams, zb0043)
 				}
-				for zb0029 > 0 {
+				var zb0045 AssetIndex
+				_ = zb0045
+				var zb0046 bool
+				_ = zb0046
+				for zb0043 > 0 {
 					var zb0001 AssetIndex
 					var zb0002 AssetParams
-					zb0029--
+					zb0043--
 					bts, err = zb0001.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "AssetParams")
 						return
 					}
+					if validate && zb0046 && AssetIndexLess(zb0001, zb0045) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0045 = zb0001
+					zb0046 = true
 					bts, err = zb0002.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "AssetParams", zb0001)
@@ -3977,60 +4755,83 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).AccountData.AssetParams[zb0001] = zb0002
 				}
+				zb0011 = "apar"
 			case "asset":
-				var zb0031 int
-				var zb0032 bool
-				zb0031, zb0032, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0012 && "asset" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0047 int
+				var zb0048 bool
+				zb0047, zb0048, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Assets")
 					return
 				}
-				if zb0031 > encodedMaxAssetsPerAccount {
-					err = msgp.ErrOverflow(uint64(zb0031), uint64(encodedMaxAssetsPerAccount))
+				if zb0047 > encodedMaxAssetsPerAccount {
+					err = msgp.ErrOverflow(uint64(zb0047), uint64(encodedMaxAssetsPerAccount))
 					err = msgp.WrapError(err, "Assets")
 					return
 				}
-				if zb0032 {
+				if zb0048 {
 					(*z).AccountData.Assets = nil
 				} else if (*z).AccountData.Assets == nil {
-					(*z).AccountData.Assets = make(map[AssetIndex]AssetHolding, zb0031)
+					(*z).AccountData.Assets = make(map[AssetIndex]AssetHolding, zb0047)
 				}
-				for zb0031 > 0 {
+				var zb0049 AssetIndex
+				_ = zb0049
+				var zb0050 bool
+				_ = zb0050
+				for zb0047 > 0 {
 					var zb0003 AssetIndex
 					var zb0004 AssetHolding
-					zb0031--
+					zb0047--
 					bts, err = zb0003.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Assets")
 						return
 					}
-					var zb0033 int
-					var zb0034 bool
-					zb0033, zb0034, bts, err = msgp.ReadMapHeaderBytes(bts)
+					if validate && zb0050 && AssetIndexLess(zb0003, zb0049) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0049 = zb0003
+					zb0050 = true
+					var zb0051 int
+					var zb0053 string
+					var zb0054 bool
+					var zb0052 bool
+					_ = zb0053
+					_ = zb0054
+					zb0051, zb0052, bts, err = msgp.ReadMapHeaderBytes(bts)
 					if _, ok := err.(msgp.TypeError); ok {
-						zb0033, zb0034, bts, err = msgp.ReadArrayHeaderBytes(bts)
+						zb0051, zb0052, bts, err = msgp.ReadArrayHeaderBytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Assets", zb0003)
 							return
 						}
-						if zb0033 > 0 {
-							zb0033--
+						if validate {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
+						if zb0051 > 0 {
+							zb0051--
 							zb0004.Amount, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Assets", zb0003, "struct-from-array", "Amount")
 								return
 							}
 						}
-						if zb0033 > 0 {
-							zb0033--
+						if zb0051 > 0 {
+							zb0051--
 							zb0004.Frozen, bts, err = msgp.ReadBoolBytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Assets", zb0003, "struct-from-array", "Frozen")
 								return
 							}
 						}
-						if zb0033 > 0 {
-							err = msgp.ErrTooManyArrayFields(zb0033)
+						if zb0051 > 0 {
+							err = msgp.ErrTooManyArrayFields(zb0051)
 							if err != nil {
 								err = msgp.WrapError(err, "Assets", zb0003, "struct-from-array")
 								return
@@ -4041,11 +4842,11 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							err = msgp.WrapError(err, "Assets", zb0003)
 							return
 						}
-						if zb0034 {
+						if zb0052 {
 							zb0004 = AssetHolding{}
 						}
-						for zb0033 > 0 {
-							zb0033--
+						for zb0051 > 0 {
+							zb0051--
 							field, bts, err = msgp.ReadMapKeyZC(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Assets", zb0003)
@@ -4053,17 +4854,27 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							}
 							switch string(field) {
 							case "a":
+								if validate && zb0054 && "a" < zb0053 {
+									err = &msgp.ErrNonCanonical{}
+									return
+								}
 								zb0004.Amount, bts, err = msgp.ReadUint64Bytes(bts)
 								if err != nil {
 									err = msgp.WrapError(err, "Assets", zb0003, "Amount")
 									return
 								}
+								zb0053 = "a"
 							case "f":
+								if validate && zb0054 && "f" < zb0053 {
+									err = &msgp.ErrNonCanonical{}
+									return
+								}
 								zb0004.Frozen, bts, err = msgp.ReadBoolBytes(bts)
 								if err != nil {
 									err = msgp.WrapError(err, "Assets", zb0003, "Frozen")
 									return
 								}
+								zb0053 = "f"
 							default:
 								err = msgp.ErrNoField(string(field))
 								if err != nil {
@@ -4071,43 +4882,64 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 									return
 								}
 							}
+							zb0054 = true
 						}
 					}
 					(*z).AccountData.Assets[zb0003] = zb0004
 				}
+				zb0011 = "asset"
 			case "spend":
+				if validate && zb0012 && "spend" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AccountData.AuthAddr.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AuthAddr")
 					return
 				}
+				zb0011 = "spend"
 			case "appl":
-				var zb0035 int
-				var zb0036 bool
-				zb0035, zb0036, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0012 && "appl" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0055 int
+				var zb0056 bool
+				zb0055, zb0056, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AppLocalStates")
 					return
 				}
-				if zb0035 > EncodedMaxAppLocalStates {
-					err = msgp.ErrOverflow(uint64(zb0035), uint64(EncodedMaxAppLocalStates))
+				if zb0055 > EncodedMaxAppLocalStates {
+					err = msgp.ErrOverflow(uint64(zb0055), uint64(EncodedMaxAppLocalStates))
 					err = msgp.WrapError(err, "AppLocalStates")
 					return
 				}
-				if zb0036 {
+				if zb0056 {
 					(*z).AccountData.AppLocalStates = nil
 				} else if (*z).AccountData.AppLocalStates == nil {
-					(*z).AccountData.AppLocalStates = make(map[AppIndex]AppLocalState, zb0035)
+					(*z).AccountData.AppLocalStates = make(map[AppIndex]AppLocalState, zb0055)
 				}
-				for zb0035 > 0 {
+				var zb0057 AppIndex
+				_ = zb0057
+				var zb0058 bool
+				_ = zb0058
+				for zb0055 > 0 {
 					var zb0005 AppIndex
 					var zb0006 AppLocalState
-					zb0035--
+					zb0055--
 					bts, err = zb0005.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "AppLocalStates")
 						return
 					}
+					if validate && zb0058 && AppIndexLess(zb0005, zb0057) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0057 = zb0005
+					zb0058 = true
 					bts, err = zb0006.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "AppLocalStates", zb0005)
@@ -4115,33 +4947,48 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).AccountData.AppLocalStates[zb0005] = zb0006
 				}
+				zb0011 = "appl"
 			case "appp":
-				var zb0037 int
-				var zb0038 bool
-				zb0037, zb0038, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0012 && "appp" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0059 int
+				var zb0060 bool
+				zb0059, zb0060, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AppParams")
 					return
 				}
-				if zb0037 > EncodedMaxAppParams {
-					err = msgp.ErrOverflow(uint64(zb0037), uint64(EncodedMaxAppParams))
+				if zb0059 > EncodedMaxAppParams {
+					err = msgp.ErrOverflow(uint64(zb0059), uint64(EncodedMaxAppParams))
 					err = msgp.WrapError(err, "AppParams")
 					return
 				}
-				if zb0038 {
+				if zb0060 {
 					(*z).AccountData.AppParams = nil
 				} else if (*z).AccountData.AppParams == nil {
-					(*z).AccountData.AppParams = make(map[AppIndex]AppParams, zb0037)
+					(*z).AccountData.AppParams = make(map[AppIndex]AppParams, zb0059)
 				}
-				for zb0037 > 0 {
+				var zb0061 AppIndex
+				_ = zb0061
+				var zb0062 bool
+				_ = zb0062
+				for zb0059 > 0 {
 					var zb0007 AppIndex
 					var zb0008 AppParams
-					zb0037--
+					zb0059--
 					bts, err = zb0007.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "AppParams")
 						return
 					}
+					if validate && zb0062 && AppIndexLess(zb0007, zb0061) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0061 = zb0007
+					zb0062 = true
 					bts, err = zb0008.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "AppParams", zb0007)
@@ -4149,34 +4996,47 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).AccountData.AppParams[zb0007] = zb0008
 				}
+				zb0011 = "appp"
 			case "tsch":
-				var zb0039 int
-				var zb0040 bool
-				zb0039, zb0040, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0012 && "tsch" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0063 int
+				var zb0065 string
+				var zb0066 bool
+				var zb0064 bool
+				_ = zb0065
+				_ = zb0066
+				zb0063, zb0064, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0039, zb0040, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0063, zb0064, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "TotalAppSchema")
 						return
 					}
-					if zb0039 > 0 {
-						zb0039--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0063 > 0 {
+						zb0063--
 						(*z).AccountData.TotalAppSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "TotalAppSchema", "struct-from-array", "NumUint")
 							return
 						}
 					}
-					if zb0039 > 0 {
-						zb0039--
+					if zb0063 > 0 {
+						zb0063--
 						(*z).AccountData.TotalAppSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "TotalAppSchema", "struct-from-array", "NumByteSlice")
 							return
 						}
 					}
-					if zb0039 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0039)
+					if zb0063 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0063)
 						if err != nil {
 							err = msgp.WrapError(err, "TotalAppSchema", "struct-from-array")
 							return
@@ -4187,11 +5047,11 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "TotalAppSchema")
 						return
 					}
-					if zb0040 {
+					if zb0064 {
 						(*z).AccountData.TotalAppSchema = StateSchema{}
 					}
-					for zb0039 > 0 {
-						zb0039--
+					for zb0063 > 0 {
+						zb0063--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "TotalAppSchema")
@@ -4199,17 +5059,27 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "nui":
+							if validate && zb0066 && "nui" < zb0065 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).AccountData.TotalAppSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "TotalAppSchema", "NumUint")
 								return
 							}
+							zb0065 = "nui"
 						case "nbs":
+							if validate && zb0066 && "nbs" < zb0065 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).AccountData.TotalAppSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "TotalAppSchema", "NumByteSlice")
 								return
 							}
+							zb0065 = "nbs"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -4217,26 +5087,43 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0066 = true
 					}
 				}
+				zb0011 = "tsch"
 			case "teap":
+				if validate && zb0012 && "teap" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).AccountData.TotalExtraAppPages, bts, err = msgp.ReadUint32Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalExtraAppPages")
 					return
 				}
+				zb0011 = "teap"
 			case "tbx":
+				if validate && zb0012 && "tbx" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).AccountData.TotalBoxes, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalBoxes")
 					return
 				}
+				zb0011 = "tbx"
 			case "tbxb":
+				if validate && zb0012 && "tbxb" < zb0011 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).AccountData.TotalBoxBytes, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalBoxBytes")
 					return
 				}
+				zb0011 = "tbxb"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -4244,12 +5131,19 @@ func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0012 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *BalanceRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *BalanceRecord) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *BalanceRecord) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*BalanceRecord)
 	return ok
@@ -4345,7 +5239,7 @@ func (_ CreatableIndex) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *CreatableIndex) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *CreatableIndex) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 uint64
 		zb0001, bts, err = msgp.ReadUint64Bytes(bts)
@@ -4359,6 +5253,12 @@ func (z *CreatableIndex) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *CreatableIndex) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *CreatableIndex) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *CreatableIndex) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*CreatableIndex)
 	return ok
@@ -4397,7 +5297,7 @@ func (_ CreatableType) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *CreatableType) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *CreatableType) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 uint64
 		zb0001, bts, err = msgp.ReadUint64Bytes(bts)
@@ -4411,6 +5311,12 @@ func (z *CreatableType) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *CreatableType) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *CreatableType) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *CreatableType) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*CreatableType)
 	return ok
@@ -4449,7 +5355,7 @@ func (_ DeltaAction) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *DeltaAction) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *DeltaAction) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 uint64
 		zb0001, bts, err = msgp.ReadUint64Bytes(bts)
@@ -4463,6 +5369,12 @@ func (z *DeltaAction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *DeltaAction) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *DeltaAction) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *DeltaAction) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*DeltaAction)
 	return ok
@@ -4522,16 +5434,24 @@ func (_ *Participant) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Participant) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Participant) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -4574,17 +5494,27 @@ func (z *Participant) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "p":
+				if validate && zb0004 && "p" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).PK.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "PK")
 					return
 				}
+				zb0003 = "p"
 			case "w":
+				if validate && zb0004 && "w" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Weight, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Weight")
 					return
 				}
+				zb0003 = "w"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -4592,12 +5522,19 @@ func (z *Participant) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *Participant) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Participant) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Participant) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Participant)
 	return ok
@@ -4636,7 +5573,7 @@ func (_ Round) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Round) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Round) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 uint64
 		zb0001, bts, err = msgp.ReadUint64Bytes(bts)
@@ -4650,6 +5587,12 @@ func (z *Round) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *Round) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Round) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Round) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Round)
 	return ok
@@ -4688,7 +5631,7 @@ func (_ RoundInterval) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *RoundInterval) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *RoundInterval) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 uint64
 		zb0001, bts, err = msgp.ReadUint64Bytes(bts)
@@ -4702,6 +5645,12 @@ func (z *RoundInterval) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *RoundInterval) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *RoundInterval) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *RoundInterval) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*RoundInterval)
 	return ok
@@ -4755,7 +5704,7 @@ func (_ StateDelta) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *StateDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *StateDelta) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var zb0003 int
 	var zb0004 bool
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
@@ -4773,6 +5722,10 @@ func (z *StateDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	} else if (*z) == nil {
 		(*z) = make(StateDelta, zb0003)
 	}
+	var zb0005 string
+	_ = zb0005
+	var zb0006 bool
+	_ = zb0006
 	for zb0003 > 0 {
 		var zb0001 string
 		var zb0002 ValueDelta
@@ -4782,6 +5735,12 @@ func (z *StateDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate && zb0006 && StringLess(zb0001, zb0005) {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
+		zb0005 = zb0001
+		zb0006 = true
 		bts, err = zb0002.UnmarshalMsg(bts)
 		if err != nil {
 			err = msgp.WrapError(err, zb0001)
@@ -4793,6 +5752,12 @@ func (z *StateDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *StateDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *StateDelta) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *StateDelta) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*StateDelta)
 	return ok
@@ -4863,16 +5828,24 @@ func (_ *StateSchema) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *StateSchema) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *StateSchema) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -4915,17 +5888,27 @@ func (z *StateSchema) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "nui":
+				if validate && zb0004 && "nui" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NumUint")
 					return
 				}
+				zb0003 = "nui"
 			case "nbs":
+				if validate && zb0004 && "nbs" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NumByteSlice")
 					return
 				}
+				zb0003 = "nbs"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -4933,12 +5916,19 @@ func (z *StateSchema) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *StateSchema) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *StateSchema) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *StateSchema) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*StateSchema)
 	return ok
@@ -5042,11 +6032,15 @@ func (_ *StateSchemas) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *StateSchemas) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -5054,35 +6048,47 @@ func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0001 > 0 {
 			zb0001--
-			var zb0003 int
-			var zb0004 bool
-			zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0005 int
+			var zb0007 string
+			var zb0008 bool
+			var zb0006 bool
+			_ = zb0007
+			_ = zb0008
+			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema")
 					return
 				}
-				if zb0003 > 0 {
-					zb0003--
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0005 > 0 {
+					zb0005--
 					(*z).LocalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema", "struct-from-array", "NumUint")
 						return
 					}
 				}
-				if zb0003 > 0 {
-					zb0003--
+				if zb0005 > 0 {
+					zb0005--
 					(*z).LocalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema", "struct-from-array", "NumByteSlice")
 						return
 					}
 				}
-				if zb0003 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0003)
+				if zb0005 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0005)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema", "struct-from-array")
 						return
@@ -5093,11 +6099,11 @@ func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema")
 					return
 				}
-				if zb0004 {
+				if zb0006 {
 					(*z).LocalStateSchema = StateSchema{}
 				}
-				for zb0003 > 0 {
-					zb0003--
+				for zb0005 > 0 {
+					zb0005--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema")
@@ -5105,17 +6111,27 @@ func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch string(field) {
 					case "nui":
+						if validate && zb0008 && "nui" < zb0007 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).LocalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema", "NumUint")
 							return
 						}
+						zb0007 = "nui"
 					case "nbs":
+						if validate && zb0008 && "nbs" < zb0007 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).LocalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "LocalStateSchema", "NumByteSlice")
 							return
 						}
+						zb0007 = "nbs"
 					default:
 						err = msgp.ErrNoField(string(field))
 						if err != nil {
@@ -5123,38 +6139,47 @@ func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0008 = true
 				}
 			}
 		}
 		if zb0001 > 0 {
 			zb0001--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0009 int
+			var zb0011 string
+			var zb0012 bool
+			var zb0010 bool
+			_ = zb0011
+			_ = zb0012
+			zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema")
 					return
 				}
-				if zb0005 > 0 {
-					zb0005--
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0009 > 0 {
+					zb0009--
 					(*z).GlobalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema", "struct-from-array", "NumUint")
 						return
 					}
 				}
-				if zb0005 > 0 {
-					zb0005--
+				if zb0009 > 0 {
+					zb0009--
 					(*z).GlobalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema", "struct-from-array", "NumByteSlice")
 						return
 					}
 				}
-				if zb0005 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0005)
+				if zb0009 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0009)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema", "struct-from-array")
 						return
@@ -5165,11 +6190,11 @@ func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema")
 					return
 				}
-				if zb0006 {
+				if zb0010 {
 					(*z).GlobalStateSchema = StateSchema{}
 				}
-				for zb0005 > 0 {
-					zb0005--
+				for zb0009 > 0 {
+					zb0009--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema")
@@ -5177,17 +6202,27 @@ func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch string(field) {
 					case "nui":
+						if validate && zb0012 && "nui" < zb0011 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).GlobalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema", "NumUint")
 							return
 						}
+						zb0011 = "nui"
 					case "nbs":
+						if validate && zb0012 && "nbs" < zb0011 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).GlobalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "GlobalStateSchema", "NumByteSlice")
 							return
 						}
+						zb0011 = "nbs"
 					default:
 						err = msgp.ErrNoField(string(field))
 						if err != nil {
@@ -5195,6 +6230,7 @@ func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0012 = true
 				}
 			}
 		}
@@ -5222,33 +6258,45 @@ func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "lsch":
-				var zb0007 int
-				var zb0008 bool
-				zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0004 && "lsch" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0013 int
+				var zb0015 string
+				var zb0016 bool
+				var zb0014 bool
+				_ = zb0015
+				_ = zb0016
+				zb0013, zb0014, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "LocalStateSchema")
 						return
 					}
-					if zb0007 > 0 {
-						zb0007--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0013 > 0 {
+						zb0013--
 						(*z).LocalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "LocalStateSchema", "struct-from-array", "NumUint")
 							return
 						}
 					}
-					if zb0007 > 0 {
-						zb0007--
+					if zb0013 > 0 {
+						zb0013--
 						(*z).LocalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "LocalStateSchema", "struct-from-array", "NumByteSlice")
 							return
 						}
 					}
-					if zb0007 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0007)
+					if zb0013 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0013)
 						if err != nil {
 							err = msgp.WrapError(err, "LocalStateSchema", "struct-from-array")
 							return
@@ -5259,11 +6307,11 @@ func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "LocalStateSchema")
 						return
 					}
-					if zb0008 {
+					if zb0014 {
 						(*z).LocalStateSchema = StateSchema{}
 					}
-					for zb0007 > 0 {
-						zb0007--
+					for zb0013 > 0 {
+						zb0013--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "LocalStateSchema")
@@ -5271,17 +6319,27 @@ func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "nui":
+							if validate && zb0016 && "nui" < zb0015 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).LocalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "LocalStateSchema", "NumUint")
 								return
 							}
+							zb0015 = "nui"
 						case "nbs":
+							if validate && zb0016 && "nbs" < zb0015 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).LocalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "LocalStateSchema", "NumByteSlice")
 								return
 							}
+							zb0015 = "nbs"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -5289,36 +6347,50 @@ func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0016 = true
 					}
 				}
+				zb0003 = "lsch"
 			case "gsch":
-				var zb0009 int
-				var zb0010 bool
-				zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0004 && "gsch" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0017 int
+				var zb0019 string
+				var zb0020 bool
+				var zb0018 bool
+				_ = zb0019
+				_ = zb0020
+				zb0017, zb0018, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0017, zb0018, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "GlobalStateSchema")
 						return
 					}
-					if zb0009 > 0 {
-						zb0009--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0017 > 0 {
+						zb0017--
 						(*z).GlobalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "GlobalStateSchema", "struct-from-array", "NumUint")
 							return
 						}
 					}
-					if zb0009 > 0 {
-						zb0009--
+					if zb0017 > 0 {
+						zb0017--
 						(*z).GlobalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "GlobalStateSchema", "struct-from-array", "NumByteSlice")
 							return
 						}
 					}
-					if zb0009 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0009)
+					if zb0017 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0017)
 						if err != nil {
 							err = msgp.WrapError(err, "GlobalStateSchema", "struct-from-array")
 							return
@@ -5329,11 +6401,11 @@ func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "GlobalStateSchema")
 						return
 					}
-					if zb0010 {
+					if zb0018 {
 						(*z).GlobalStateSchema = StateSchema{}
 					}
-					for zb0009 > 0 {
-						zb0009--
+					for zb0017 > 0 {
+						zb0017--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "GlobalStateSchema")
@@ -5341,17 +6413,27 @@ func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "nui":
+							if validate && zb0020 && "nui" < zb0019 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).GlobalStateSchema.NumUint, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "GlobalStateSchema", "NumUint")
 								return
 							}
+							zb0019 = "nui"
 						case "nbs":
+							if validate && zb0020 && "nbs" < zb0019 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).GlobalStateSchema.NumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "GlobalStateSchema", "NumByteSlice")
 								return
 							}
+							zb0019 = "nbs"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -5359,8 +6441,10 @@ func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0020 = true
 					}
 				}
+				zb0003 = "gsch"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -5368,12 +6452,19 @@ func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *StateSchemas) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *StateSchemas) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *StateSchemas) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*StateSchemas)
 	return ok
@@ -5412,7 +6503,7 @@ func (_ Status) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Status) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Status) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 byte
 		zb0001, bts, err = msgp.ReadByteBytes(bts)
@@ -5426,6 +6517,12 @@ func (z *Status) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *Status) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Status) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Status) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Status)
 	return ok
@@ -5479,7 +6576,7 @@ func (_ TealKeyValue) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *TealKeyValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *TealKeyValue) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var zb0003 int
 	var zb0004 bool
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
@@ -5497,6 +6594,10 @@ func (z *TealKeyValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	} else if (*z) == nil {
 		(*z) = make(TealKeyValue, zb0003)
 	}
+	var zb0005 string
+	_ = zb0005
+	var zb0006 bool
+	_ = zb0006
 	for zb0003 > 0 {
 		var zb0001 string
 		var zb0002 TealValue
@@ -5506,6 +6607,12 @@ func (z *TealKeyValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate && zb0006 && StringLess(zb0001, zb0005) {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
+		zb0005 = zb0001
+		zb0006 = true
 		bts, err = zb0002.UnmarshalMsg(bts)
 		if err != nil {
 			err = msgp.WrapError(err, zb0001)
@@ -5517,6 +6624,12 @@ func (z *TealKeyValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *TealKeyValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *TealKeyValue) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *TealKeyValue) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*TealKeyValue)
 	return ok
@@ -5566,7 +6679,7 @@ func (_ TealType) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *TealType) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *TealType) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 uint64
 		zb0001, bts, err = msgp.ReadUint64Bytes(bts)
@@ -5580,6 +6693,12 @@ func (z *TealType) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *TealType) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *TealType) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *TealType) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*TealType)
 	return ok
@@ -5648,11 +6767,15 @@ func (_ *TealValue) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *TealValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *TealValue) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -5660,16 +6783,20 @@ func (z *TealValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0003 uint64
-				zb0003, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0005 uint64
+				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Type")
 					return
 				}
-				(*z).Type = TealType(zb0003)
+				(*z).Type = TealType(zb0005)
 			}
 		}
 		if zb0001 > 0 {
@@ -5712,27 +6839,42 @@ func (z *TealValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "tt":
+				if validate && zb0004 && "tt" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0004 uint64
-					zb0004, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0006 uint64
+					zb0006, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Type")
 						return
 					}
-					(*z).Type = TealType(zb0004)
+					(*z).Type = TealType(zb0006)
 				}
+				zb0003 = "tt"
 			case "tb":
+				if validate && zb0004 && "tb" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Bytes, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Bytes")
 					return
 				}
+				zb0003 = "tb"
 			case "ui":
+				if validate && zb0004 && "ui" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Uint, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Uint")
 					return
 				}
+				zb0003 = "ui"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -5740,12 +6882,19 @@ func (z *TealValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *TealValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *TealValue) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *TealValue) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*TealValue)
 	return ok
@@ -5816,11 +6965,15 @@ func (_ *ValueDelta) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *ValueDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *ValueDelta) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -5828,28 +6981,32 @@ func (z *ValueDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0001 > 0 {
 			zb0001--
 			{
-				var zb0003 uint64
-				zb0003, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0005 uint64
+				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Action")
 					return
 				}
-				(*z).Action = DeltaAction(zb0003)
+				(*z).Action = DeltaAction(zb0005)
 			}
 		}
 		if zb0001 > 0 {
 			zb0001--
-			var zb0004 int
-			zb0004, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0006 int
+			zb0006, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Bytes")
 				return
 			}
-			if zb0004 > config.MaxAppBytesValueLen {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(config.MaxAppBytesValueLen))
+			if zb0006 > config.MaxAppBytesValueLen {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxAppBytesValueLen))
 				return
 			}
 			(*z).Bytes, bts, err = msgp.ReadStringBytes(bts)
@@ -5890,24 +7047,33 @@ func (z *ValueDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "at":
+				if validate && zb0004 && "at" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0005 uint64
-					zb0005, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0007 uint64
+					zb0007, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Action")
 						return
 					}
-					(*z).Action = DeltaAction(zb0005)
+					(*z).Action = DeltaAction(zb0007)
 				}
+				zb0003 = "at"
 			case "bs":
-				var zb0006 int
-				zb0006, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0004 && "bs" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0008 int
+				zb0008, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Bytes")
 					return
 				}
-				if zb0006 > config.MaxAppBytesValueLen {
-					err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxAppBytesValueLen))
+				if zb0008 > config.MaxAppBytesValueLen {
+					err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxAppBytesValueLen))
 					return
 				}
 				(*z).Bytes, bts, err = msgp.ReadStringBytes(bts)
@@ -5915,12 +7081,18 @@ func (z *ValueDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "Bytes")
 					return
 				}
+				zb0003 = "bs"
 			case "ui":
+				if validate && zb0004 && "ui" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Uint, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Uint")
 					return
 				}
+				zb0003 = "ui"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -5928,12 +7100,19 @@ func (z *ValueDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *ValueDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *ValueDelta) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *ValueDelta) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*ValueDelta)
 	return ok

--- a/data/basics/sort.go
+++ b/data/basics/sort.go
@@ -24,53 +24,58 @@ import (
 // canonical encoding of maps in msgpack format.
 //
 //msgp:ignore SortUint64
-//msgp:sort uint64 SortUint64
+//msgp:sort uint64 SortUint64 Uint64Less
 type SortUint64 []uint64
 
 func (a SortUint64) Len() int           { return len(a) }
 func (a SortUint64) Less(i, j int) bool { return a[i] < a[j] }
 func (a SortUint64) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func Uint64Less(a, b uint64) bool       { return a < b }
 
 // SortAssetIndex implements sorting by AssetIndex keys for
 // canonical encoding of maps in msgpack format.
 //
 //msgp:ignore SortAssetIndex
-//msgp:sort AssetIndex SortAssetIndex
+//msgp:sort AssetIndex SortAssetIndex AssetIndexLess
 type SortAssetIndex []AssetIndex
 
 func (a SortAssetIndex) Len() int           { return len(a) }
 func (a SortAssetIndex) Less(i, j int) bool { return a[i] < a[j] }
 func (a SortAssetIndex) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func AssetIndexLess(a, b AssetIndex) bool   { return a < b }
 
 // SortAppIndex implements sorting by AppIndex keys for
 // canonical encoding of maps in msgpack format.
 //
 //msgp:ignore SortAppIndex
-//msgp:sort AppIndex SortAppIndex
+//msgp:sort AppIndex SortAppIndex AppIndexLess
 type SortAppIndex []AppIndex
 
 func (a SortAppIndex) Len() int           { return len(a) }
 func (a SortAppIndex) Less(i, j int) bool { return a[i] < a[j] }
 func (a SortAppIndex) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func AppIndexLess(a, b AppIndex) bool     { return a < b }
 
 // SortString implements sorting by string keys for
 // canonical encoding of maps in msgpack format.
 //
 //msgp:ignore SortString
-//msgp:sort string SortString
+//msgp:sort string SortString StringLess
 type SortString []string
 
 func (a SortString) Len() int           { return len(a) }
 func (a SortString) Less(i, j int) bool { return a[i] < a[j] }
 func (a SortString) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func StringLess(a, b string) bool       { return a < b }
 
 // SortAddress implements sorting by Address keys for
 // canonical encoding of maps in msgpack format.
 //
 //msgp:ignore SortAddress
-//msgp:sort Address SortAddress
+//msgp:sort Address SortAddress AddressLess
 type SortAddress []Address
 
 func (a SortAddress) Len() int           { return len(a) }
 func (a SortAddress) Less(i, j int) bool { return bytes.Compare(a[i][:], a[j][:]) < 0 }
 func (a SortAddress) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func AddressLess(a, b Address) bool      { return bytes.Compare(a[:], b[:]) < 0 }

--- a/data/bookkeeping/block.go
+++ b/data/bookkeeping/block.go
@@ -116,7 +116,7 @@ type (
 
 		// StateProofTracking tracks the status of the state proofs, potentially
 		// for multiple types of ASPs (Algorand's State Proofs).
-		//msgp:sort protocol.StateProofType protocol.SortStateProofType
+		//msgp:sort protocol.StateProofType protocol.SortStateProofType protocol.StateProofTypeLess
 		StateProofTracking map[protocol.StateProofType]StateProofTrackingData `codec:"spt,allocbound=protocol.NumStateProofTypes"`
 
 		// ParticipationUpdates contains the information needed to mark

--- a/data/bookkeeping/msgp_gen.go
+++ b/data/bookkeeping/msgp_gen.go
@@ -20,6 +20,7 @@ import (
 //   |-----> (*) MarshalMsg
 //   |-----> (*) CanMarshalMsg
 //   |-----> (*) UnmarshalMsg
+//   |-----> (*) UnmarshalValidateMsg
 //   |-----> (*) CanUnmarshalMsg
 //   |-----> (*) Msgsize
 //   |-----> (*) MsgIsZero
@@ -29,6 +30,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -37,6 +39,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -46,6 +49,7 @@ import (
 //    |-----> (*) MarshalMsg
 //    |-----> (*) CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> (*) Msgsize
 //    |-----> (*) MsgIsZero
@@ -55,6 +59,7 @@ import (
 //          |-----> (*) MarshalMsg
 //          |-----> (*) CanMarshalMsg
 //          |-----> (*) UnmarshalMsg
+//          |-----> (*) UnmarshalValidateMsg
 //          |-----> (*) CanUnmarshalMsg
 //          |-----> (*) Msgsize
 //          |-----> (*) MsgIsZero
@@ -64,6 +69,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -73,6 +79,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -82,6 +89,7 @@ import (
 //           |-----> (*) MarshalMsg
 //           |-----> (*) CanMarshalMsg
 //           |-----> (*) UnmarshalMsg
+//           |-----> (*) UnmarshalValidateMsg
 //           |-----> (*) CanUnmarshalMsg
 //           |-----> (*) Msgsize
 //           |-----> (*) MsgIsZero
@@ -91,6 +99,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -100,6 +109,7 @@ import (
 //            |-----> (*) MarshalMsg
 //            |-----> (*) CanMarshalMsg
 //            |-----> (*) UnmarshalMsg
+//            |-----> (*) UnmarshalValidateMsg
 //            |-----> (*) CanUnmarshalMsg
 //            |-----> (*) Msgsize
 //            |-----> (*) MsgIsZero
@@ -109,6 +119,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -118,6 +129,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -402,16 +414,24 @@ func (_ *Block) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Block) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Block) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0004 int
+	var zb0006 string
+	var zb0007 bool
 	var zb0005 bool
+	_ = zb0006
+	_ = zb0007
 	zb0004, zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0004 > 0 {
@@ -464,14 +484,14 @@ func (z *Block) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0006 int
-			zb0006, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0008 int
+			zb0008, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "GenesisID")
 				return
 			}
-			if zb0006 > config.MaxGenesisIDLen {
-				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxGenesisIDLen))
+			if zb0008 > config.MaxGenesisIDLen {
+				err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxGenesisIDLen))
 				return
 			}
 			(*z).BlockHeader.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -610,32 +630,42 @@ func (z *Block) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0007 int
-			var zb0008 bool
-			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0009 int
+			var zb0010 bool
+			zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "StateProofTracking")
 				return
 			}
-			if zb0007 > protocol.NumStateProofTypes {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(protocol.NumStateProofTypes))
+			if zb0009 > protocol.NumStateProofTypes {
+				err = msgp.ErrOverflow(uint64(zb0009), uint64(protocol.NumStateProofTypes))
 				err = msgp.WrapError(err, "struct-from-array", "StateProofTracking")
 				return
 			}
-			if zb0008 {
+			if zb0010 {
 				(*z).BlockHeader.StateProofTracking = nil
 			} else if (*z).BlockHeader.StateProofTracking == nil {
-				(*z).BlockHeader.StateProofTracking = make(map[protocol.StateProofType]StateProofTrackingData, zb0007)
+				(*z).BlockHeader.StateProofTracking = make(map[protocol.StateProofType]StateProofTrackingData, zb0009)
 			}
-			for zb0007 > 0 {
+			var zb0011 protocol.StateProofType
+			_ = zb0011
+			var zb0012 bool
+			_ = zb0012
+			for zb0009 > 0 {
 				var zb0001 protocol.StateProofType
 				var zb0002 StateProofTrackingData
-				zb0007--
+				zb0009--
 				bts, err = zb0001.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "StateProofTracking")
 					return
 				}
+				if validate && zb0012 && protocol.StateProofTypeLess(zb0001, zb0011) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0011 = zb0001
+				zb0012 = true
 				bts, err = zb0002.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "StateProofTracking", zb0001)
@@ -646,24 +676,24 @@ func (z *Block) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0009 int
-			var zb0010 bool
-			zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0013 int
+			var zb0014 bool
+			zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0009 > config.MaxProposedExpiredOnlineAccounts {
-				err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxProposedExpiredOnlineAccounts))
+			if zb0013 > config.MaxProposedExpiredOnlineAccounts {
+				err = msgp.ErrOverflow(uint64(zb0013), uint64(config.MaxProposedExpiredOnlineAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0010 {
+			if zb0014 {
 				(*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = nil
-			} else if (*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts) >= zb0009 {
-				(*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = ((*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts)[:zb0009]
+			} else if (*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts) >= zb0013 {
+				(*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = ((*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts)[:zb0013]
 			} else {
-				(*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0009)
+				(*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0013)
 			}
 			for zb0003 := range (*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts {
 				bts, err = (*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts[zb0003].UnmarshalMsg(bts)
@@ -705,50 +735,84 @@ func (z *Block) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "rnd":
+				if validate && zb0007 && "rnd" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockHeader.Round.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0006 = "rnd"
 			case "prev":
+				if validate && zb0007 && "prev" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockHeader.Branch.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Branch")
 					return
 				}
+				zb0006 = "prev"
 			case "seed":
+				if validate && zb0007 && "seed" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockHeader.Seed.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Seed")
 					return
 				}
+				zb0006 = "seed"
 			case "txn":
+				if validate && zb0007 && "txn" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockHeader.TxnCommitments.NativeSha512_256Commitment.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NativeSha512_256Commitment")
 					return
 				}
+				zb0006 = "txn"
 			case "txn256":
+				if validate && zb0007 && "txn256" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockHeader.TxnCommitments.Sha256Commitment.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sha256Commitment")
 					return
 				}
+				zb0006 = "txn256"
 			case "ts":
+				if validate && zb0007 && "ts" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).BlockHeader.TimeStamp, bts, err = msgp.ReadInt64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TimeStamp")
 					return
 				}
+				zb0006 = "ts"
 			case "gen":
-				var zb0011 int
-				zb0011, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0007 && "gen" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0015 int
+				zb0015, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
-				if zb0011 > config.MaxGenesisIDLen {
-					err = msgp.ErrOverflow(uint64(zb0011), uint64(config.MaxGenesisIDLen))
+				if zb0015 > config.MaxGenesisIDLen {
+					err = msgp.ErrOverflow(uint64(zb0015), uint64(config.MaxGenesisIDLen))
 					return
 				}
 				(*z).BlockHeader.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -756,129 +820,224 @@ func (z *Block) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
+				zb0006 = "gen"
 			case "gh":
+				if validate && zb0007 && "gh" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockHeader.GenesisHash.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GenesisHash")
 					return
 				}
+				zb0006 = "gh"
 			case "fees":
+				if validate && zb0007 && "fees" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockHeader.RewardsState.FeeSink.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FeeSink")
 					return
 				}
+				zb0006 = "fees"
 			case "rwd":
+				if validate && zb0007 && "rwd" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockHeader.RewardsState.RewardsPool.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsPool")
 					return
 				}
+				zb0006 = "rwd"
 			case "earn":
+				if validate && zb0007 && "earn" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).BlockHeader.RewardsState.RewardsLevel, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsLevel")
 					return
 				}
+				zb0006 = "earn"
 			case "rate":
+				if validate && zb0007 && "rate" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).BlockHeader.RewardsState.RewardsRate, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsRate")
 					return
 				}
+				zb0006 = "rate"
 			case "frac":
+				if validate && zb0007 && "frac" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).BlockHeader.RewardsState.RewardsResidue, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsResidue")
 					return
 				}
+				zb0006 = "frac"
 			case "rwcalr":
+				if validate && zb0007 && "rwcalr" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockHeader.RewardsState.RewardsRecalculationRound.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsRecalculationRound")
 					return
 				}
+				zb0006 = "rwcalr"
 			case "proto":
+				if validate && zb0007 && "proto" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockHeader.UpgradeState.CurrentProtocol.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "CurrentProtocol")
 					return
 				}
+				zb0006 = "proto"
 			case "nextproto":
+				if validate && zb0007 && "nextproto" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockHeader.UpgradeState.NextProtocol.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocol")
 					return
 				}
+				zb0006 = "nextproto"
 			case "nextyes":
+				if validate && zb0007 && "nextyes" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).BlockHeader.UpgradeState.NextProtocolApprovals, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocolApprovals")
 					return
 				}
+				zb0006 = "nextyes"
 			case "nextbefore":
+				if validate && zb0007 && "nextbefore" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockHeader.UpgradeState.NextProtocolVoteBefore.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocolVoteBefore")
 					return
 				}
+				zb0006 = "nextbefore"
 			case "nextswitch":
+				if validate && zb0007 && "nextswitch" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockHeader.UpgradeState.NextProtocolSwitchOn.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocolSwitchOn")
 					return
 				}
+				zb0006 = "nextswitch"
 			case "upgradeprop":
+				if validate && zb0007 && "upgradeprop" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockHeader.UpgradeVote.UpgradePropose.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradePropose")
 					return
 				}
+				zb0006 = "upgradeprop"
 			case "upgradedelay":
+				if validate && zb0007 && "upgradedelay" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockHeader.UpgradeVote.UpgradeDelay.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradeDelay")
 					return
 				}
+				zb0006 = "upgradedelay"
 			case "upgradeyes":
+				if validate && zb0007 && "upgradeyes" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).BlockHeader.UpgradeVote.UpgradeApprove, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradeApprove")
 					return
 				}
+				zb0006 = "upgradeyes"
 			case "tc":
+				if validate && zb0007 && "tc" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).BlockHeader.TxnCounter, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TxnCounter")
 					return
 				}
+				zb0006 = "tc"
 			case "spt":
-				var zb0012 int
-				var zb0013 bool
-				zb0012, zb0013, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0007 && "spt" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0016 int
+				var zb0017 bool
+				zb0016, zb0017, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofTracking")
 					return
 				}
-				if zb0012 > protocol.NumStateProofTypes {
-					err = msgp.ErrOverflow(uint64(zb0012), uint64(protocol.NumStateProofTypes))
+				if zb0016 > protocol.NumStateProofTypes {
+					err = msgp.ErrOverflow(uint64(zb0016), uint64(protocol.NumStateProofTypes))
 					err = msgp.WrapError(err, "StateProofTracking")
 					return
 				}
-				if zb0013 {
+				if zb0017 {
 					(*z).BlockHeader.StateProofTracking = nil
 				} else if (*z).BlockHeader.StateProofTracking == nil {
-					(*z).BlockHeader.StateProofTracking = make(map[protocol.StateProofType]StateProofTrackingData, zb0012)
+					(*z).BlockHeader.StateProofTracking = make(map[protocol.StateProofType]StateProofTrackingData, zb0016)
 				}
-				for zb0012 > 0 {
+				var zb0018 protocol.StateProofType
+				_ = zb0018
+				var zb0019 bool
+				_ = zb0019
+				for zb0016 > 0 {
 					var zb0001 protocol.StateProofType
 					var zb0002 StateProofTrackingData
-					zb0012--
+					zb0016--
 					bts, err = zb0001.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "StateProofTracking")
 						return
 					}
+					if validate && zb0019 && protocol.StateProofTypeLess(zb0001, zb0018) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0018 = zb0001
+					zb0019 = true
 					bts, err = zb0002.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "StateProofTracking", zb0001)
@@ -886,25 +1045,30 @@ func (z *Block) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).BlockHeader.StateProofTracking[zb0001] = zb0002
 				}
+				zb0006 = "spt"
 			case "partupdrmv":
-				var zb0014 int
-				var zb0015 bool
-				zb0014, zb0015, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0007 && "partupdrmv" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0020 int
+				var zb0021 bool
+				zb0020, zb0021, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0014 > config.MaxProposedExpiredOnlineAccounts {
-					err = msgp.ErrOverflow(uint64(zb0014), uint64(config.MaxProposedExpiredOnlineAccounts))
+				if zb0020 > config.MaxProposedExpiredOnlineAccounts {
+					err = msgp.ErrOverflow(uint64(zb0020), uint64(config.MaxProposedExpiredOnlineAccounts))
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0015 {
+				if zb0021 {
 					(*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = nil
-				} else if (*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts) >= zb0014 {
-					(*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = ((*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts)[:zb0014]
+				} else if (*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts) >= zb0020 {
+					(*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = ((*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts)[:zb0020]
 				} else {
-					(*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0014)
+					(*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0020)
 				}
 				for zb0003 := range (*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts {
 					bts, err = (*z).BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts[zb0003].UnmarshalMsg(bts)
@@ -913,12 +1077,18 @@ func (z *Block) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0006 = "partupdrmv"
 			case "txns":
+				if validate && zb0007 && "txns" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Payset.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Payset")
 					return
 				}
+				zb0006 = "txns"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -926,12 +1096,19 @@ func (z *Block) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0007 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *Block) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Block) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Block) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Block)
 	return ok
@@ -989,6 +1166,9 @@ func (_ *BlockHash) CanMarshalMsg(z interface{}) bool {
 // UnmarshalMsg implements msgp.Unmarshaler
 func (z *BlockHash) UnmarshalMsg(bts []byte) ([]byte, error) {
 	return ((*(crypto.Digest))(z)).UnmarshalMsg(bts)
+}
+func (z *BlockHash) UnmarshalValidateMsg(bts []byte) ([]byte, error) {
+	return ((*(crypto.Digest))(z)).UnmarshalValidateMsg(bts)
 }
 func (_ *BlockHash) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*BlockHash)
@@ -1276,16 +1456,24 @@ func (_ *BlockHeader) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *BlockHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *BlockHeader) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0004 int
+	var zb0006 string
+	var zb0007 bool
 	var zb0005 bool
+	_ = zb0006
+	_ = zb0007
 	zb0004, zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0004 > 0 {
@@ -1338,14 +1526,14 @@ func (z *BlockHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0006 int
-			zb0006, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0008 int
+			zb0008, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "GenesisID")
 				return
 			}
-			if zb0006 > config.MaxGenesisIDLen {
-				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxGenesisIDLen))
+			if zb0008 > config.MaxGenesisIDLen {
+				err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxGenesisIDLen))
 				return
 			}
 			(*z).GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -1484,32 +1672,42 @@ func (z *BlockHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0007 int
-			var zb0008 bool
-			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0009 int
+			var zb0010 bool
+			zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "StateProofTracking")
 				return
 			}
-			if zb0007 > protocol.NumStateProofTypes {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(protocol.NumStateProofTypes))
+			if zb0009 > protocol.NumStateProofTypes {
+				err = msgp.ErrOverflow(uint64(zb0009), uint64(protocol.NumStateProofTypes))
 				err = msgp.WrapError(err, "struct-from-array", "StateProofTracking")
 				return
 			}
-			if zb0008 {
+			if zb0010 {
 				(*z).StateProofTracking = nil
 			} else if (*z).StateProofTracking == nil {
-				(*z).StateProofTracking = make(map[protocol.StateProofType]StateProofTrackingData, zb0007)
+				(*z).StateProofTracking = make(map[protocol.StateProofType]StateProofTrackingData, zb0009)
 			}
-			for zb0007 > 0 {
+			var zb0011 protocol.StateProofType
+			_ = zb0011
+			var zb0012 bool
+			_ = zb0012
+			for zb0009 > 0 {
 				var zb0001 protocol.StateProofType
 				var zb0002 StateProofTrackingData
-				zb0007--
+				zb0009--
 				bts, err = zb0001.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "StateProofTracking")
 					return
 				}
+				if validate && zb0012 && protocol.StateProofTypeLess(zb0001, zb0011) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0011 = zb0001
+				zb0012 = true
 				bts, err = zb0002.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "StateProofTracking", zb0001)
@@ -1520,24 +1718,24 @@ func (z *BlockHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0009 int
-			var zb0010 bool
-			zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0013 int
+			var zb0014 bool
+			zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0009 > config.MaxProposedExpiredOnlineAccounts {
-				err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxProposedExpiredOnlineAccounts))
+			if zb0013 > config.MaxProposedExpiredOnlineAccounts {
+				err = msgp.ErrOverflow(uint64(zb0013), uint64(config.MaxProposedExpiredOnlineAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0010 {
+			if zb0014 {
 				(*z).ParticipationUpdates.ExpiredParticipationAccounts = nil
-			} else if (*z).ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).ParticipationUpdates.ExpiredParticipationAccounts) >= zb0009 {
-				(*z).ParticipationUpdates.ExpiredParticipationAccounts = ((*z).ParticipationUpdates.ExpiredParticipationAccounts)[:zb0009]
+			} else if (*z).ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).ParticipationUpdates.ExpiredParticipationAccounts) >= zb0013 {
+				(*z).ParticipationUpdates.ExpiredParticipationAccounts = ((*z).ParticipationUpdates.ExpiredParticipationAccounts)[:zb0013]
 			} else {
-				(*z).ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0009)
+				(*z).ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0013)
 			}
 			for zb0003 := range (*z).ParticipationUpdates.ExpiredParticipationAccounts {
 				bts, err = (*z).ParticipationUpdates.ExpiredParticipationAccounts[zb0003].UnmarshalMsg(bts)
@@ -1571,50 +1769,84 @@ func (z *BlockHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "rnd":
+				if validate && zb0007 && "rnd" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Round.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0006 = "rnd"
 			case "prev":
+				if validate && zb0007 && "prev" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Branch.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Branch")
 					return
 				}
+				zb0006 = "prev"
 			case "seed":
+				if validate && zb0007 && "seed" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Seed.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Seed")
 					return
 				}
+				zb0006 = "seed"
 			case "txn":
+				if validate && zb0007 && "txn" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).TxnCommitments.NativeSha512_256Commitment.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NativeSha512_256Commitment")
 					return
 				}
+				zb0006 = "txn"
 			case "txn256":
+				if validate && zb0007 && "txn256" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).TxnCommitments.Sha256Commitment.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sha256Commitment")
 					return
 				}
+				zb0006 = "txn256"
 			case "ts":
+				if validate && zb0007 && "ts" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TimeStamp, bts, err = msgp.ReadInt64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TimeStamp")
 					return
 				}
+				zb0006 = "ts"
 			case "gen":
-				var zb0011 int
-				zb0011, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0007 && "gen" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0015 int
+				zb0015, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
-				if zb0011 > config.MaxGenesisIDLen {
-					err = msgp.ErrOverflow(uint64(zb0011), uint64(config.MaxGenesisIDLen))
+				if zb0015 > config.MaxGenesisIDLen {
+					err = msgp.ErrOverflow(uint64(zb0015), uint64(config.MaxGenesisIDLen))
 					return
 				}
 				(*z).GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -1622,129 +1854,224 @@ func (z *BlockHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
+				zb0006 = "gen"
 			case "gh":
+				if validate && zb0007 && "gh" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).GenesisHash.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GenesisHash")
 					return
 				}
+				zb0006 = "gh"
 			case "fees":
+				if validate && zb0007 && "fees" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).RewardsState.FeeSink.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FeeSink")
 					return
 				}
+				zb0006 = "fees"
 			case "rwd":
+				if validate && zb0007 && "rwd" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).RewardsState.RewardsPool.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsPool")
 					return
 				}
+				zb0006 = "rwd"
 			case "earn":
+				if validate && zb0007 && "earn" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).RewardsState.RewardsLevel, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsLevel")
 					return
 				}
+				zb0006 = "earn"
 			case "rate":
+				if validate && zb0007 && "rate" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).RewardsState.RewardsRate, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsRate")
 					return
 				}
+				zb0006 = "rate"
 			case "frac":
+				if validate && zb0007 && "frac" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).RewardsState.RewardsResidue, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsResidue")
 					return
 				}
+				zb0006 = "frac"
 			case "rwcalr":
+				if validate && zb0007 && "rwcalr" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).RewardsState.RewardsRecalculationRound.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsRecalculationRound")
 					return
 				}
+				zb0006 = "rwcalr"
 			case "proto":
+				if validate && zb0007 && "proto" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).UpgradeState.CurrentProtocol.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "CurrentProtocol")
 					return
 				}
+				zb0006 = "proto"
 			case "nextproto":
+				if validate && zb0007 && "nextproto" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).UpgradeState.NextProtocol.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocol")
 					return
 				}
+				zb0006 = "nextproto"
 			case "nextyes":
+				if validate && zb0007 && "nextyes" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).UpgradeState.NextProtocolApprovals, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocolApprovals")
 					return
 				}
+				zb0006 = "nextyes"
 			case "nextbefore":
+				if validate && zb0007 && "nextbefore" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).UpgradeState.NextProtocolVoteBefore.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocolVoteBefore")
 					return
 				}
+				zb0006 = "nextbefore"
 			case "nextswitch":
+				if validate && zb0007 && "nextswitch" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).UpgradeState.NextProtocolSwitchOn.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NextProtocolSwitchOn")
 					return
 				}
+				zb0006 = "nextswitch"
 			case "upgradeprop":
+				if validate && zb0007 && "upgradeprop" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).UpgradeVote.UpgradePropose.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradePropose")
 					return
 				}
+				zb0006 = "upgradeprop"
 			case "upgradedelay":
+				if validate && zb0007 && "upgradedelay" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).UpgradeVote.UpgradeDelay.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradeDelay")
 					return
 				}
+				zb0006 = "upgradedelay"
 			case "upgradeyes":
+				if validate && zb0007 && "upgradeyes" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).UpgradeVote.UpgradeApprove, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradeApprove")
 					return
 				}
+				zb0006 = "upgradeyes"
 			case "tc":
+				if validate && zb0007 && "tc" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TxnCounter, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TxnCounter")
 					return
 				}
+				zb0006 = "tc"
 			case "spt":
-				var zb0012 int
-				var zb0013 bool
-				zb0012, zb0013, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0007 && "spt" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0016 int
+				var zb0017 bool
+				zb0016, zb0017, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofTracking")
 					return
 				}
-				if zb0012 > protocol.NumStateProofTypes {
-					err = msgp.ErrOverflow(uint64(zb0012), uint64(protocol.NumStateProofTypes))
+				if zb0016 > protocol.NumStateProofTypes {
+					err = msgp.ErrOverflow(uint64(zb0016), uint64(protocol.NumStateProofTypes))
 					err = msgp.WrapError(err, "StateProofTracking")
 					return
 				}
-				if zb0013 {
+				if zb0017 {
 					(*z).StateProofTracking = nil
 				} else if (*z).StateProofTracking == nil {
-					(*z).StateProofTracking = make(map[protocol.StateProofType]StateProofTrackingData, zb0012)
+					(*z).StateProofTracking = make(map[protocol.StateProofType]StateProofTrackingData, zb0016)
 				}
-				for zb0012 > 0 {
+				var zb0018 protocol.StateProofType
+				_ = zb0018
+				var zb0019 bool
+				_ = zb0019
+				for zb0016 > 0 {
 					var zb0001 protocol.StateProofType
 					var zb0002 StateProofTrackingData
-					zb0012--
+					zb0016--
 					bts, err = zb0001.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "StateProofTracking")
 						return
 					}
+					if validate && zb0019 && protocol.StateProofTypeLess(zb0001, zb0018) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0018 = zb0001
+					zb0019 = true
 					bts, err = zb0002.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "StateProofTracking", zb0001)
@@ -1752,25 +2079,30 @@ func (z *BlockHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).StateProofTracking[zb0001] = zb0002
 				}
+				zb0006 = "spt"
 			case "partupdrmv":
-				var zb0014 int
-				var zb0015 bool
-				zb0014, zb0015, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0007 && "partupdrmv" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0020 int
+				var zb0021 bool
+				zb0020, zb0021, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0014 > config.MaxProposedExpiredOnlineAccounts {
-					err = msgp.ErrOverflow(uint64(zb0014), uint64(config.MaxProposedExpiredOnlineAccounts))
+				if zb0020 > config.MaxProposedExpiredOnlineAccounts {
+					err = msgp.ErrOverflow(uint64(zb0020), uint64(config.MaxProposedExpiredOnlineAccounts))
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0015 {
+				if zb0021 {
 					(*z).ParticipationUpdates.ExpiredParticipationAccounts = nil
-				} else if (*z).ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).ParticipationUpdates.ExpiredParticipationAccounts) >= zb0014 {
-					(*z).ParticipationUpdates.ExpiredParticipationAccounts = ((*z).ParticipationUpdates.ExpiredParticipationAccounts)[:zb0014]
+				} else if (*z).ParticipationUpdates.ExpiredParticipationAccounts != nil && cap((*z).ParticipationUpdates.ExpiredParticipationAccounts) >= zb0020 {
+					(*z).ParticipationUpdates.ExpiredParticipationAccounts = ((*z).ParticipationUpdates.ExpiredParticipationAccounts)[:zb0020]
 				} else {
-					(*z).ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0014)
+					(*z).ParticipationUpdates.ExpiredParticipationAccounts = make([]basics.Address, zb0020)
 				}
 				for zb0003 := range (*z).ParticipationUpdates.ExpiredParticipationAccounts {
 					bts, err = (*z).ParticipationUpdates.ExpiredParticipationAccounts[zb0003].UnmarshalMsg(bts)
@@ -1779,6 +2111,7 @@ func (z *BlockHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0006 = "partupdrmv"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1786,12 +2119,19 @@ func (z *BlockHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0007 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *BlockHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *BlockHeader) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *BlockHeader) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*BlockHeader)
 	return ok
@@ -1940,16 +2280,24 @@ func (_ *Genesis) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Genesis) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Genesis) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0002 > 0 {
@@ -1978,24 +2326,24 @@ func (z *Genesis) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0004 int
-			var zb0005 bool
-			zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0006 int
+			var zb0007 bool
+			zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Allocation")
 				return
 			}
-			if zb0004 > MaxInitialGenesisAllocationSize {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(MaxInitialGenesisAllocationSize))
+			if zb0006 > MaxInitialGenesisAllocationSize {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(MaxInitialGenesisAllocationSize))
 				err = msgp.WrapError(err, "struct-from-array", "Allocation")
 				return
 			}
-			if zb0005 {
+			if zb0007 {
 				(*z).Allocation = nil
-			} else if (*z).Allocation != nil && cap((*z).Allocation) >= zb0004 {
-				(*z).Allocation = ((*z).Allocation)[:zb0004]
+			} else if (*z).Allocation != nil && cap((*z).Allocation) >= zb0006 {
+				(*z).Allocation = ((*z).Allocation)[:zb0006]
 			} else {
-				(*z).Allocation = make([]GenesisAllocation, zb0004)
+				(*z).Allocation = make([]GenesisAllocation, zb0006)
 			}
 			for zb0001 := range (*z).Allocation {
 				bts, err = (*z).Allocation[zb0001].UnmarshalMsg(bts)
@@ -2069,42 +2417,61 @@ func (z *Genesis) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "id":
+				if validate && zb0005 && "id" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).SchemaID, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SchemaID")
 					return
 				}
+				zb0004 = "id"
 			case "network":
+				if validate && zb0005 && "network" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Network.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Network")
 					return
 				}
+				zb0004 = "network"
 			case "proto":
+				if validate && zb0005 && "proto" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Proto.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Proto")
 					return
 				}
+				zb0004 = "proto"
 			case "alloc":
-				var zb0006 int
-				var zb0007 bool
-				zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0005 && "alloc" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0008 int
+				var zb0009 bool
+				zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Allocation")
 					return
 				}
-				if zb0006 > MaxInitialGenesisAllocationSize {
-					err = msgp.ErrOverflow(uint64(zb0006), uint64(MaxInitialGenesisAllocationSize))
+				if zb0008 > MaxInitialGenesisAllocationSize {
+					err = msgp.ErrOverflow(uint64(zb0008), uint64(MaxInitialGenesisAllocationSize))
 					err = msgp.WrapError(err, "Allocation")
 					return
 				}
-				if zb0007 {
+				if zb0009 {
 					(*z).Allocation = nil
-				} else if (*z).Allocation != nil && cap((*z).Allocation) >= zb0006 {
-					(*z).Allocation = ((*z).Allocation)[:zb0006]
+				} else if (*z).Allocation != nil && cap((*z).Allocation) >= zb0008 {
+					(*z).Allocation = ((*z).Allocation)[:zb0008]
 				} else {
-					(*z).Allocation = make([]GenesisAllocation, zb0006)
+					(*z).Allocation = make([]GenesisAllocation, zb0008)
 				}
 				for zb0001 := range (*z).Allocation {
 					bts, err = (*z).Allocation[zb0001].UnmarshalMsg(bts)
@@ -2113,36 +2480,62 @@ func (z *Genesis) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0004 = "alloc"
 			case "rwd":
+				if validate && zb0005 && "rwd" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).RewardsPool, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsPool")
 					return
 				}
+				zb0004 = "rwd"
 			case "fees":
+				if validate && zb0005 && "fees" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).FeeSink, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FeeSink")
 					return
 				}
+				zb0004 = "fees"
 			case "timestamp":
+				if validate && zb0005 && "timestamp" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Timestamp, bts, err = msgp.ReadInt64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Timestamp")
 					return
 				}
+				zb0004 = "timestamp"
 			case "comment":
+				if validate && zb0005 && "comment" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Comment, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Comment")
 					return
 				}
+				zb0004 = "comment"
 			case "devmode":
+				if validate && zb0005 && "devmode" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).DevMode, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "DevMode")
 					return
 				}
+				zb0004 = "devmode"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2150,12 +2543,19 @@ func (z *Genesis) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *Genesis) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Genesis) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Genesis) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Genesis)
 	return ok
@@ -2284,16 +2684,24 @@ func (_ *GenesisAccountData) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *GenesisAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *GenesisAccountData) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -2384,53 +2792,93 @@ func (z *GenesisAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "onl":
+				if validate && zb0004 && "onl" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Status.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Status")
 					return
 				}
+				zb0003 = "onl"
 			case "algo":
+				if validate && zb0004 && "algo" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).MicroAlgos.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "MicroAlgos")
 					return
 				}
+				zb0003 = "algo"
 			case "vote":
+				if validate && zb0004 && "vote" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VoteID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteID")
 					return
 				}
+				zb0003 = "vote"
 			case "stprf":
+				if validate && zb0004 && "stprf" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).StateProofID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofID")
 					return
 				}
+				zb0003 = "stprf"
 			case "sel":
+				if validate && zb0004 && "sel" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SelectionID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SelectionID")
 					return
 				}
+				zb0003 = "sel"
 			case "voteFst":
+				if validate && zb0004 && "voteFst" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VoteFirstValid.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteFirstValid")
 					return
 				}
+				zb0003 = "voteFst"
 			case "voteLst":
+				if validate && zb0004 && "voteLst" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VoteLastValid.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteLastValid")
 					return
 				}
+				zb0003 = "voteLst"
 			case "voteKD":
+				if validate && zb0004 && "voteKD" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).VoteKeyDilution, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteKeyDilution")
 					return
 				}
+				zb0003 = "voteKD"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2438,12 +2886,19 @@ func (z *GenesisAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *GenesisAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *GenesisAccountData) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *GenesisAccountData) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*GenesisAccountData)
 	return ok
@@ -2488,16 +2943,24 @@ func (_ *GenesisAllocation) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *GenesisAllocation) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *GenesisAllocation) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -2548,23 +3011,38 @@ func (z *GenesisAllocation) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "addr":
+				if validate && zb0004 && "addr" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Address, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Address")
 					return
 				}
+				zb0003 = "addr"
 			case "comment":
+				if validate && zb0004 && "comment" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Comment, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Comment")
 					return
 				}
+				zb0003 = "comment"
 			case "state":
+				if validate && zb0004 && "state" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).State.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "State")
 					return
 				}
+				zb0003 = "state"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2572,12 +3050,19 @@ func (z *GenesisAllocation) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *GenesisAllocation) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *GenesisAllocation) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *GenesisAllocation) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*GenesisAllocation)
 	return ok
@@ -2659,16 +3144,24 @@ func (_ *LightBlockHeader) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *LightBlockHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *LightBlockHeader) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -2727,29 +3220,49 @@ func (z *LightBlockHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "0":
+				if validate && zb0004 && "0" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Seed.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Seed")
 					return
 				}
+				zb0003 = "0"
 			case "r":
+				if validate && zb0004 && "r" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Round.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0003 = "r"
 			case "gh":
+				if validate && zb0004 && "gh" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).GenesisHash.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GenesisHash")
 					return
 				}
+				zb0003 = "gh"
 			case "tc":
+				if validate && zb0004 && "tc" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sha256TxnCommitment.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sha256TxnCommitment")
 					return
 				}
+				zb0003 = "tc"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2757,12 +3270,19 @@ func (z *LightBlockHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *LightBlockHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *LightBlockHeader) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *LightBlockHeader) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*LightBlockHeader)
 	return ok
@@ -2820,11 +3340,15 @@ func (_ *ParticipationUpdates) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *ParticipationUpdates) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *ParticipationUpdates) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -2832,26 +3356,30 @@ func (z *ParticipationUpdates) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0004 int
-			var zb0005 bool
-			zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0006 int
+			var zb0007 bool
+			zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0004 > config.MaxProposedExpiredOnlineAccounts {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(config.MaxProposedExpiredOnlineAccounts))
+			if zb0006 > config.MaxProposedExpiredOnlineAccounts {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxProposedExpiredOnlineAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0005 {
+			if zb0007 {
 				(*z).ExpiredParticipationAccounts = nil
-			} else if (*z).ExpiredParticipationAccounts != nil && cap((*z).ExpiredParticipationAccounts) >= zb0004 {
-				(*z).ExpiredParticipationAccounts = ((*z).ExpiredParticipationAccounts)[:zb0004]
+			} else if (*z).ExpiredParticipationAccounts != nil && cap((*z).ExpiredParticipationAccounts) >= zb0006 {
+				(*z).ExpiredParticipationAccounts = ((*z).ExpiredParticipationAccounts)[:zb0006]
 			} else {
-				(*z).ExpiredParticipationAccounts = make([]basics.Address, zb0004)
+				(*z).ExpiredParticipationAccounts = make([]basics.Address, zb0006)
 			}
 			for zb0001 := range (*z).ExpiredParticipationAccounts {
 				bts, err = (*z).ExpiredParticipationAccounts[zb0001].UnmarshalMsg(bts)
@@ -2885,24 +3413,28 @@ func (z *ParticipationUpdates) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "partupdrmv":
-				var zb0006 int
-				var zb0007 bool
-				zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0005 && "partupdrmv" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0008 int
+				var zb0009 bool
+				zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0006 > config.MaxProposedExpiredOnlineAccounts {
-					err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxProposedExpiredOnlineAccounts))
+				if zb0008 > config.MaxProposedExpiredOnlineAccounts {
+					err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxProposedExpiredOnlineAccounts))
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0007 {
+				if zb0009 {
 					(*z).ExpiredParticipationAccounts = nil
-				} else if (*z).ExpiredParticipationAccounts != nil && cap((*z).ExpiredParticipationAccounts) >= zb0006 {
-					(*z).ExpiredParticipationAccounts = ((*z).ExpiredParticipationAccounts)[:zb0006]
+				} else if (*z).ExpiredParticipationAccounts != nil && cap((*z).ExpiredParticipationAccounts) >= zb0008 {
+					(*z).ExpiredParticipationAccounts = ((*z).ExpiredParticipationAccounts)[:zb0008]
 				} else {
-					(*z).ExpiredParticipationAccounts = make([]basics.Address, zb0006)
+					(*z).ExpiredParticipationAccounts = make([]basics.Address, zb0008)
 				}
 				for zb0001 := range (*z).ExpiredParticipationAccounts {
 					bts, err = (*z).ExpiredParticipationAccounts[zb0001].UnmarshalMsg(bts)
@@ -2911,6 +3443,7 @@ func (z *ParticipationUpdates) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0004 = "partupdrmv"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2918,12 +3451,19 @@ func (z *ParticipationUpdates) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *ParticipationUpdates) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *ParticipationUpdates) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *ParticipationUpdates) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*ParticipationUpdates)
 	return ok
@@ -3024,16 +3564,24 @@ func (_ *RewardsState) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *RewardsState) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *RewardsState) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -3108,41 +3656,71 @@ func (z *RewardsState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "fees":
+				if validate && zb0004 && "fees" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).FeeSink.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FeeSink")
 					return
 				}
+				zb0003 = "fees"
 			case "rwd":
+				if validate && zb0004 && "rwd" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).RewardsPool.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsPool")
 					return
 				}
+				zb0003 = "rwd"
 			case "earn":
+				if validate && zb0004 && "earn" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).RewardsLevel, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsLevel")
 					return
 				}
+				zb0003 = "earn"
 			case "rate":
+				if validate && zb0004 && "rate" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).RewardsRate, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsRate")
 					return
 				}
+				zb0003 = "rate"
 			case "frac":
+				if validate && zb0004 && "frac" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).RewardsResidue, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsResidue")
 					return
 				}
+				zb0003 = "frac"
 			case "rwcalr":
+				if validate && zb0004 && "rwcalr" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).RewardsRecalculationRound.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsRecalculationRound")
 					return
 				}
+				zb0003 = "rwcalr"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3150,12 +3728,19 @@ func (z *RewardsState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *RewardsState) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *RewardsState) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *RewardsState) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*RewardsState)
 	return ok
@@ -3224,16 +3809,24 @@ func (_ *StateProofTrackingData) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *StateProofTrackingData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *StateProofTrackingData) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -3284,23 +3877,38 @@ func (z *StateProofTrackingData) UnmarshalMsg(bts []byte) (o []byte, err error) 
 			}
 			switch string(field) {
 			case "v":
+				if validate && zb0004 && "v" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).StateProofVotersCommitment.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofVotersCommitment")
 					return
 				}
+				zb0003 = "v"
 			case "t":
+				if validate && zb0004 && "t" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).StateProofOnlineTotalWeight.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofOnlineTotalWeight")
 					return
 				}
+				zb0003 = "t"
 			case "n":
+				if validate && zb0004 && "n" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).StateProofNextRound.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofNextRound")
 					return
 				}
+				zb0003 = "n"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3308,12 +3916,19 @@ func (z *StateProofTrackingData) UnmarshalMsg(bts []byte) (o []byte, err error) 
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *StateProofTrackingData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *StateProofTrackingData) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *StateProofTrackingData) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*StateProofTrackingData)
 	return ok
@@ -3373,16 +3988,24 @@ func (_ *TxnCommitments) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *TxnCommitments) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *TxnCommitments) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -3425,17 +4048,27 @@ func (z *TxnCommitments) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "txn":
+				if validate && zb0004 && "txn" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).NativeSha512_256Commitment.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "NativeSha512_256Commitment")
 					return
 				}
+				zb0003 = "txn"
 			case "txn256":
+				if validate && zb0004 && "txn256" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sha256Commitment.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sha256Commitment")
 					return
 				}
+				zb0003 = "txn256"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3443,12 +4076,19 @@ func (z *TxnCommitments) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *TxnCommitments) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *TxnCommitments) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *TxnCommitments) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*TxnCommitments)
 	return ok
@@ -3517,16 +4157,24 @@ func (_ *UpgradeVote) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *UpgradeVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *UpgradeVote) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -3577,23 +4225,38 @@ func (z *UpgradeVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "upgradeprop":
+				if validate && zb0004 && "upgradeprop" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).UpgradePropose.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradePropose")
 					return
 				}
+				zb0003 = "upgradeprop"
 			case "upgradedelay":
+				if validate && zb0004 && "upgradedelay" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).UpgradeDelay.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradeDelay")
 					return
 				}
+				zb0003 = "upgradedelay"
 			case "upgradeyes":
+				if validate && zb0004 && "upgradeyes" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).UpgradeApprove, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpgradeApprove")
 					return
 				}
+				zb0003 = "upgradeyes"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3601,12 +4264,19 @@ func (z *UpgradeVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *UpgradeVote) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *UpgradeVote) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *UpgradeVote) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*UpgradeVote)
 	return ok

--- a/data/committee/msgp_gen.go
+++ b/data/committee/msgp_gen.go
@@ -14,6 +14,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -23,6 +24,7 @@ import (
 //   |-----> (*) MarshalMsg
 //   |-----> (*) CanMarshalMsg
 //   |-----> (*) UnmarshalMsg
+//   |-----> (*) UnmarshalValidateMsg
 //   |-----> (*) CanUnmarshalMsg
 //   |-----> (*) Msgsize
 //   |-----> (*) MsgIsZero
@@ -32,6 +34,7 @@ import (
 //             |-----> (*) MarshalMsg
 //             |-----> (*) CanMarshalMsg
 //             |-----> (*) UnmarshalMsg
+//             |-----> (*) UnmarshalValidateMsg
 //             |-----> (*) CanUnmarshalMsg
 //             |-----> (*) Msgsize
 //             |-----> (*) MsgIsZero
@@ -41,6 +44,7 @@ import (
 //          |-----> (*) MarshalMsg
 //          |-----> (*) CanMarshalMsg
 //          |-----> (*) UnmarshalMsg
+//          |-----> (*) UnmarshalValidateMsg
 //          |-----> (*) CanUnmarshalMsg
 //          |-----> (*) Msgsize
 //          |-----> (*) MsgIsZero
@@ -111,16 +115,24 @@ func (_ *Credential) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Credential) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Credential) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -187,35 +199,60 @@ func (z *Credential) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "wt":
+				if validate && zb0004 && "wt" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Weight, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Weight")
 					return
 				}
+				zb0003 = "wt"
 			case "h":
+				if validate && zb0004 && "h" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VrfOut.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VrfOut")
 					return
 				}
+				zb0003 = "h"
 			case "ds":
+				if validate && zb0004 && "ds" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).DomainSeparationEnabled, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "DomainSeparationEnabled")
 					return
 				}
+				zb0003 = "ds"
 			case "hc":
+				if validate && zb0004 && "hc" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Hashable.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Hashable")
 					return
 				}
+				zb0003 = "hc"
 			case "pf":
+				if validate && zb0004 && "pf" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).UnauthenticatedCredential.Proof.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Proof")
 					return
 				}
+				zb0003 = "pf"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -223,12 +260,19 @@ func (z *Credential) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *Credential) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Credential) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Credential) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Credential)
 	return ok
@@ -264,7 +308,7 @@ func (_ *Seed) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Seed) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Seed) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -274,6 +318,12 @@ func (z *Seed) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *Seed) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Seed) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Seed) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Seed)
 	return ok
@@ -325,16 +375,24 @@ func (_ *UnauthenticatedCredential) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *UnauthenticatedCredential) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *UnauthenticatedCredential) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -369,11 +427,16 @@ func (z *UnauthenticatedCredential) UnmarshalMsg(bts []byte) (o []byte, err erro
 			}
 			switch string(field) {
 			case "pf":
+				if validate && zb0004 && "pf" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Proof.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Proof")
 					return
 				}
+				zb0003 = "pf"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -381,12 +444,19 @@ func (z *UnauthenticatedCredential) UnmarshalMsg(bts []byte) (o []byte, err erro
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *UnauthenticatedCredential) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *UnauthenticatedCredential) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *UnauthenticatedCredential) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*UnauthenticatedCredential)
 	return ok
@@ -455,16 +525,24 @@ func (_ *hashableCredential) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *hashableCredential) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *hashableCredential) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -515,23 +593,38 @@ func (z *hashableCredential) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "v":
+				if validate && zb0004 && "v" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).RawOut.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RawOut")
 					return
 				}
+				zb0003 = "v"
 			case "m":
+				if validate && zb0004 && "m" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Member.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Member")
 					return
 				}
+				zb0003 = "m"
 			case "i":
+				if validate && zb0004 && "i" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Iter, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Iter")
 					return
 				}
+				zb0003 = "i"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -539,12 +632,19 @@ func (z *hashableCredential) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *hashableCredential) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *hashableCredential) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *hashableCredential) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*hashableCredential)
 	return ok

--- a/data/stateproofmsg/msgp_gen.go
+++ b/data/stateproofmsg/msgp_gen.go
@@ -13,6 +13,7 @@ import (
 //    |-----> (*) MarshalMsg
 //    |-----> (*) CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> (*) Msgsize
 //    |-----> (*) MsgIsZero
@@ -83,11 +84,15 @@ func (_ *Message) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Message) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Message) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -95,16 +100,20 @@ func (z *Message) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0001 > 0 {
 			zb0001--
-			var zb0003 int
-			zb0003, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0005 int
+			zb0005, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "BlockHeadersCommitment")
 				return
 			}
-			if zb0003 > crypto.Sha256Size {
-				err = msgp.ErrOverflow(uint64(zb0003), uint64(crypto.Sha256Size))
+			if zb0005 > crypto.Sha256Size {
+				err = msgp.ErrOverflow(uint64(zb0005), uint64(crypto.Sha256Size))
 				return
 			}
 			(*z).BlockHeadersCommitment, bts, err = msgp.ReadBytesBytes(bts, (*z).BlockHeadersCommitment)
@@ -115,14 +124,14 @@ func (z *Message) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0001 > 0 {
 			zb0001--
-			var zb0004 int
-			zb0004, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0006 int
+			zb0006, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "VotersCommitment")
 				return
 			}
-			if zb0004 > crypto.SumhashDigestSize {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(crypto.SumhashDigestSize))
+			if zb0006 > crypto.SumhashDigestSize {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(crypto.SumhashDigestSize))
 				return
 			}
 			(*z).VotersCommitment, bts, err = msgp.ReadBytesBytes(bts, (*z).VotersCommitment)
@@ -179,14 +188,18 @@ func (z *Message) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "b":
-				var zb0005 int
-				zb0005, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0004 && "b" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0007 int
+				zb0007, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "BlockHeadersCommitment")
 					return
 				}
-				if zb0005 > crypto.Sha256Size {
-					err = msgp.ErrOverflow(uint64(zb0005), uint64(crypto.Sha256Size))
+				if zb0007 > crypto.Sha256Size {
+					err = msgp.ErrOverflow(uint64(zb0007), uint64(crypto.Sha256Size))
 					return
 				}
 				(*z).BlockHeadersCommitment, bts, err = msgp.ReadBytesBytes(bts, (*z).BlockHeadersCommitment)
@@ -194,15 +207,20 @@ func (z *Message) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "BlockHeadersCommitment")
 					return
 				}
+				zb0003 = "b"
 			case "v":
-				var zb0006 int
-				zb0006, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0004 && "v" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0008 int
+				zb0008, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VotersCommitment")
 					return
 				}
-				if zb0006 > crypto.SumhashDigestSize {
-					err = msgp.ErrOverflow(uint64(zb0006), uint64(crypto.SumhashDigestSize))
+				if zb0008 > crypto.SumhashDigestSize {
+					err = msgp.ErrOverflow(uint64(zb0008), uint64(crypto.SumhashDigestSize))
 					return
 				}
 				(*z).VotersCommitment, bts, err = msgp.ReadBytesBytes(bts, (*z).VotersCommitment)
@@ -210,24 +228,40 @@ func (z *Message) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "VotersCommitment")
 					return
 				}
+				zb0003 = "v"
 			case "P":
+				if validate && zb0004 && "P" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).LnProvenWeight, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "LnProvenWeight")
 					return
 				}
+				zb0003 = "P"
 			case "f":
+				if validate && zb0004 && "f" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).FirstAttestedRound, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FirstAttestedRound")
 					return
 				}
+				zb0003 = "f"
 			case "l":
+				if validate && zb0004 && "l" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).LastAttestedRound, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "LastAttestedRound")
 					return
 				}
+				zb0003 = "l"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -235,12 +269,19 @@ func (z *Message) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *Message) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Message) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Message) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Message)
 	return ok

--- a/data/transactions/msgp_gen.go
+++ b/data/transactions/msgp_gen.go
@@ -21,6 +21,7 @@ import (
 //             |-----> (*) MarshalMsg
 //             |-----> (*) CanMarshalMsg
 //             |-----> (*) UnmarshalMsg
+//             |-----> (*) UnmarshalValidateMsg
 //             |-----> (*) CanUnmarshalMsg
 //             |-----> (*) Msgsize
 //             |-----> (*) MsgIsZero
@@ -30,6 +31,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -39,6 +41,7 @@ import (
 //           |-----> (*) MarshalMsg
 //           |-----> (*) CanMarshalMsg
 //           |-----> (*) UnmarshalMsg
+//           |-----> (*) UnmarshalValidateMsg
 //           |-----> (*) CanUnmarshalMsg
 //           |-----> (*) Msgsize
 //           |-----> (*) MsgIsZero
@@ -48,6 +51,7 @@ import (
 //           |-----> (*) MarshalMsg
 //           |-----> (*) CanMarshalMsg
 //           |-----> (*) UnmarshalMsg
+//           |-----> (*) UnmarshalValidateMsg
 //           |-----> (*) CanUnmarshalMsg
 //           |-----> (*) Msgsize
 //           |-----> (*) MsgIsZero
@@ -57,6 +61,7 @@ import (
 //            |-----> (*) MarshalMsg
 //            |-----> (*) CanMarshalMsg
 //            |-----> (*) UnmarshalMsg
+//            |-----> (*) UnmarshalValidateMsg
 //            |-----> (*) CanUnmarshalMsg
 //            |-----> (*) Msgsize
 //            |-----> (*) MsgIsZero
@@ -66,6 +71,7 @@ import (
 //    |-----> (*) MarshalMsg
 //    |-----> (*) CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> (*) Msgsize
 //    |-----> (*) MsgIsZero
@@ -75,6 +81,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -84,6 +91,7 @@ import (
 //    |-----> (*) MarshalMsg
 //    |-----> (*) CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> (*) Msgsize
 //    |-----> (*) MsgIsZero
@@ -93,6 +101,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -102,6 +111,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -111,6 +121,7 @@ import (
 //       |-----> MarshalMsg
 //       |-----> CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> Msgsize
 //       |-----> MsgIsZero
@@ -120,6 +131,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -129,6 +141,7 @@ import (
 //    |-----> MarshalMsg
 //    |-----> CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> Msgsize
 //    |-----> MsgIsZero
@@ -138,6 +151,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -147,6 +161,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -156,6 +171,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -165,6 +181,7 @@ import (
 //          |-----> (*) MarshalMsg
 //          |-----> (*) CanMarshalMsg
 //          |-----> (*) UnmarshalMsg
+//          |-----> (*) UnmarshalValidateMsg
 //          |-----> (*) CanUnmarshalMsg
 //          |-----> (*) Msgsize
 //          |-----> (*) MsgIsZero
@@ -174,6 +191,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -183,6 +201,7 @@ import (
 //    |-----> (*) MarshalMsg
 //    |-----> (*) CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> (*) Msgsize
 //    |-----> (*) MsgIsZero
@@ -192,6 +211,7 @@ import (
 //   |-----> (*) MarshalMsg
 //   |-----> (*) CanMarshalMsg
 //   |-----> (*) UnmarshalMsg
+//   |-----> (*) UnmarshalValidateMsg
 //   |-----> (*) CanUnmarshalMsg
 //   |-----> (*) Msgsize
 //   |-----> (*) MsgIsZero
@@ -384,16 +404,24 @@ func (_ *ApplicationCallTxnFields) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *ApplicationCallTxnFields) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0006 int
+	var zb0008 string
+	var zb0009 bool
 	var zb0007 bool
+	_ = zb0008
+	_ = zb0009
 	zb0006, zb0007, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0006 > 0 {
@@ -407,35 +435,35 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 		if zb0006 > 0 {
 			zb0006--
 			{
-				var zb0008 uint64
-				zb0008, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0010 uint64
+				zb0010, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "OnCompletion")
 					return
 				}
-				(*z).OnCompletion = OnCompletion(zb0008)
+				(*z).OnCompletion = OnCompletion(zb0010)
 			}
 		}
 		if zb0006 > 0 {
 			zb0006--
-			var zb0009 int
-			var zb0010 bool
-			zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0011 int
+			var zb0012 bool
+			zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ApplicationArgs")
 				return
 			}
-			if zb0009 > encodedMaxApplicationArgs {
-				err = msgp.ErrOverflow(uint64(zb0009), uint64(encodedMaxApplicationArgs))
+			if zb0011 > encodedMaxApplicationArgs {
+				err = msgp.ErrOverflow(uint64(zb0011), uint64(encodedMaxApplicationArgs))
 				err = msgp.WrapError(err, "struct-from-array", "ApplicationArgs")
 				return
 			}
-			if zb0010 {
+			if zb0012 {
 				(*z).ApplicationArgs = nil
-			} else if (*z).ApplicationArgs != nil && cap((*z).ApplicationArgs) >= zb0009 {
-				(*z).ApplicationArgs = ((*z).ApplicationArgs)[:zb0009]
+			} else if (*z).ApplicationArgs != nil && cap((*z).ApplicationArgs) >= zb0011 {
+				(*z).ApplicationArgs = ((*z).ApplicationArgs)[:zb0011]
 			} else {
-				(*z).ApplicationArgs = make([][]byte, zb0009)
+				(*z).ApplicationArgs = make([][]byte, zb0011)
 			}
 			for zb0001 := range (*z).ApplicationArgs {
 				(*z).ApplicationArgs[zb0001], bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationArgs[zb0001])
@@ -447,24 +475,24 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 		}
 		if zb0006 > 0 {
 			zb0006--
-			var zb0011 int
-			var zb0012 bool
-			zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0013 int
+			var zb0014 bool
+			zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Accounts")
 				return
 			}
-			if zb0011 > encodedMaxAccounts {
-				err = msgp.ErrOverflow(uint64(zb0011), uint64(encodedMaxAccounts))
+			if zb0013 > encodedMaxAccounts {
+				err = msgp.ErrOverflow(uint64(zb0013), uint64(encodedMaxAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "Accounts")
 				return
 			}
-			if zb0012 {
+			if zb0014 {
 				(*z).Accounts = nil
-			} else if (*z).Accounts != nil && cap((*z).Accounts) >= zb0011 {
-				(*z).Accounts = ((*z).Accounts)[:zb0011]
+			} else if (*z).Accounts != nil && cap((*z).Accounts) >= zb0013 {
+				(*z).Accounts = ((*z).Accounts)[:zb0013]
 			} else {
-				(*z).Accounts = make([]basics.Address, zb0011)
+				(*z).Accounts = make([]basics.Address, zb0013)
 			}
 			for zb0002 := range (*z).Accounts {
 				bts, err = (*z).Accounts[zb0002].UnmarshalMsg(bts)
@@ -476,24 +504,24 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 		}
 		if zb0006 > 0 {
 			zb0006--
-			var zb0013 int
-			var zb0014 bool
-			zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0015 int
+			var zb0016 bool
+			zb0015, zb0016, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ForeignApps")
 				return
 			}
-			if zb0013 > encodedMaxForeignApps {
-				err = msgp.ErrOverflow(uint64(zb0013), uint64(encodedMaxForeignApps))
+			if zb0015 > encodedMaxForeignApps {
+				err = msgp.ErrOverflow(uint64(zb0015), uint64(encodedMaxForeignApps))
 				err = msgp.WrapError(err, "struct-from-array", "ForeignApps")
 				return
 			}
-			if zb0014 {
+			if zb0016 {
 				(*z).ForeignApps = nil
-			} else if (*z).ForeignApps != nil && cap((*z).ForeignApps) >= zb0013 {
-				(*z).ForeignApps = ((*z).ForeignApps)[:zb0013]
+			} else if (*z).ForeignApps != nil && cap((*z).ForeignApps) >= zb0015 {
+				(*z).ForeignApps = ((*z).ForeignApps)[:zb0015]
 			} else {
-				(*z).ForeignApps = make([]basics.AppIndex, zb0013)
+				(*z).ForeignApps = make([]basics.AppIndex, zb0015)
 			}
 			for zb0003 := range (*z).ForeignApps {
 				bts, err = (*z).ForeignApps[zb0003].UnmarshalMsg(bts)
@@ -505,53 +533,61 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 		}
 		if zb0006 > 0 {
 			zb0006--
-			var zb0015 int
-			var zb0016 bool
-			zb0015, zb0016, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0017 int
+			var zb0018 bool
+			zb0017, zb0018, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Boxes")
 				return
 			}
-			if zb0015 > encodedMaxBoxes {
-				err = msgp.ErrOverflow(uint64(zb0015), uint64(encodedMaxBoxes))
+			if zb0017 > encodedMaxBoxes {
+				err = msgp.ErrOverflow(uint64(zb0017), uint64(encodedMaxBoxes))
 				err = msgp.WrapError(err, "struct-from-array", "Boxes")
 				return
 			}
-			if zb0016 {
+			if zb0018 {
 				(*z).Boxes = nil
-			} else if (*z).Boxes != nil && cap((*z).Boxes) >= zb0015 {
-				(*z).Boxes = ((*z).Boxes)[:zb0015]
+			} else if (*z).Boxes != nil && cap((*z).Boxes) >= zb0017 {
+				(*z).Boxes = ((*z).Boxes)[:zb0017]
 			} else {
-				(*z).Boxes = make([]BoxRef, zb0015)
+				(*z).Boxes = make([]BoxRef, zb0017)
 			}
 			for zb0004 := range (*z).Boxes {
-				var zb0017 int
-				var zb0018 bool
-				zb0017, zb0018, bts, err = msgp.ReadMapHeaderBytes(bts)
+				var zb0019 int
+				var zb0021 string
+				var zb0022 bool
+				var zb0020 bool
+				_ = zb0021
+				_ = zb0022
+				zb0019, zb0020, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0017, zb0018, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0019, zb0020, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0004)
 						return
 					}
-					if zb0017 > 0 {
-						zb0017--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0019 > 0 {
+						zb0019--
 						(*z).Boxes[zb0004].Index, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0004, "struct-from-array", "Index")
 							return
 						}
 					}
-					if zb0017 > 0 {
-						zb0017--
-						var zb0019 int
-						zb0019, err = msgp.ReadBytesBytesHeader(bts)
+					if zb0019 > 0 {
+						zb0019--
+						var zb0023 int
+						zb0023, err = msgp.ReadBytesBytesHeader(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0004, "struct-from-array", "Name")
 							return
 						}
-						if zb0019 > config.MaxBytesKeyValueLen {
-							err = msgp.ErrOverflow(uint64(zb0019), uint64(config.MaxBytesKeyValueLen))
+						if zb0023 > config.MaxBytesKeyValueLen {
+							err = msgp.ErrOverflow(uint64(zb0023), uint64(config.MaxBytesKeyValueLen))
 							return
 						}
 						(*z).Boxes[zb0004].Name, bts, err = msgp.ReadBytesBytes(bts, (*z).Boxes[zb0004].Name)
@@ -560,8 +596,8 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 							return
 						}
 					}
-					if zb0017 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0017)
+					if zb0019 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0019)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0004, "struct-from-array")
 							return
@@ -572,11 +608,11 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 						err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0004)
 						return
 					}
-					if zb0018 {
+					if zb0020 {
 						(*z).Boxes[zb0004] = BoxRef{}
 					}
-					for zb0017 > 0 {
-						zb0017--
+					for zb0019 > 0 {
+						zb0019--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0004)
@@ -584,20 +620,29 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 						}
 						switch string(field) {
 						case "i":
+							if validate && zb0022 && "i" < zb0021 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).Boxes[zb0004].Index, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0004, "Index")
 								return
 							}
+							zb0021 = "i"
 						case "n":
-							var zb0020 int
-							zb0020, err = msgp.ReadBytesBytesHeader(bts)
+							if validate && zb0022 && "n" < zb0021 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
+							var zb0024 int
+							zb0024, err = msgp.ReadBytesBytesHeader(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0004, "Name")
 								return
 							}
-							if zb0020 > config.MaxBytesKeyValueLen {
-								err = msgp.ErrOverflow(uint64(zb0020), uint64(config.MaxBytesKeyValueLen))
+							if zb0024 > config.MaxBytesKeyValueLen {
+								err = msgp.ErrOverflow(uint64(zb0024), uint64(config.MaxBytesKeyValueLen))
 								return
 							}
 							(*z).Boxes[zb0004].Name, bts, err = msgp.ReadBytesBytes(bts, (*z).Boxes[zb0004].Name)
@@ -605,6 +650,7 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 								err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0004, "Name")
 								return
 							}
+							zb0021 = "n"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -612,30 +658,31 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 								return
 							}
 						}
+						zb0022 = true
 					}
 				}
 			}
 		}
 		if zb0006 > 0 {
 			zb0006--
-			var zb0021 int
-			var zb0022 bool
-			zb0021, zb0022, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0025 int
+			var zb0026 bool
+			zb0025, zb0026, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ForeignAssets")
 				return
 			}
-			if zb0021 > encodedMaxForeignAssets {
-				err = msgp.ErrOverflow(uint64(zb0021), uint64(encodedMaxForeignAssets))
+			if zb0025 > encodedMaxForeignAssets {
+				err = msgp.ErrOverflow(uint64(zb0025), uint64(encodedMaxForeignAssets))
 				err = msgp.WrapError(err, "struct-from-array", "ForeignAssets")
 				return
 			}
-			if zb0022 {
+			if zb0026 {
 				(*z).ForeignAssets = nil
-			} else if (*z).ForeignAssets != nil && cap((*z).ForeignAssets) >= zb0021 {
-				(*z).ForeignAssets = ((*z).ForeignAssets)[:zb0021]
+			} else if (*z).ForeignAssets != nil && cap((*z).ForeignAssets) >= zb0025 {
+				(*z).ForeignAssets = ((*z).ForeignAssets)[:zb0025]
 			} else {
-				(*z).ForeignAssets = make([]basics.AssetIndex, zb0021)
+				(*z).ForeignAssets = make([]basics.AssetIndex, zb0025)
 			}
 			for zb0005 := range (*z).ForeignAssets {
 				bts, err = (*z).ForeignAssets[zb0005].UnmarshalMsg(bts)
@@ -663,14 +710,14 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 		}
 		if zb0006 > 0 {
 			zb0006--
-			var zb0023 int
-			zb0023, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0027 int
+			zb0027, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ApprovalProgram")
 				return
 			}
-			if zb0023 > config.MaxAvailableAppProgramLen {
-				err = msgp.ErrOverflow(uint64(zb0023), uint64(config.MaxAvailableAppProgramLen))
+			if zb0027 > config.MaxAvailableAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0027), uint64(config.MaxAvailableAppProgramLen))
 				return
 			}
 			(*z).ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApprovalProgram)
@@ -681,14 +728,14 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 		}
 		if zb0006 > 0 {
 			zb0006--
-			var zb0024 int
-			zb0024, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0028 int
+			zb0028, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ClearStateProgram")
 				return
 			}
-			if zb0024 > config.MaxAvailableAppProgramLen {
-				err = msgp.ErrOverflow(uint64(zb0024), uint64(config.MaxAvailableAppProgramLen))
+			if zb0028 > config.MaxAvailableAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0028), uint64(config.MaxAvailableAppProgramLen))
 				return
 			}
 			(*z).ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ClearStateProgram)
@@ -729,40 +776,54 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 			}
 			switch string(field) {
 			case "apid":
+				if validate && zb0009 && "apid" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ApplicationID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ApplicationID")
 					return
 				}
+				zb0008 = "apid"
 			case "apan":
+				if validate && zb0009 && "apan" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0025 uint64
-					zb0025, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0029 uint64
+					zb0029, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "OnCompletion")
 						return
 					}
-					(*z).OnCompletion = OnCompletion(zb0025)
+					(*z).OnCompletion = OnCompletion(zb0029)
 				}
+				zb0008 = "apan"
 			case "apaa":
-				var zb0026 int
-				var zb0027 bool
-				zb0026, zb0027, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0009 && "apaa" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0030 int
+				var zb0031 bool
+				zb0030, zb0031, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ApplicationArgs")
 					return
 				}
-				if zb0026 > encodedMaxApplicationArgs {
-					err = msgp.ErrOverflow(uint64(zb0026), uint64(encodedMaxApplicationArgs))
+				if zb0030 > encodedMaxApplicationArgs {
+					err = msgp.ErrOverflow(uint64(zb0030), uint64(encodedMaxApplicationArgs))
 					err = msgp.WrapError(err, "ApplicationArgs")
 					return
 				}
-				if zb0027 {
+				if zb0031 {
 					(*z).ApplicationArgs = nil
-				} else if (*z).ApplicationArgs != nil && cap((*z).ApplicationArgs) >= zb0026 {
-					(*z).ApplicationArgs = ((*z).ApplicationArgs)[:zb0026]
+				} else if (*z).ApplicationArgs != nil && cap((*z).ApplicationArgs) >= zb0030 {
+					(*z).ApplicationArgs = ((*z).ApplicationArgs)[:zb0030]
 				} else {
-					(*z).ApplicationArgs = make([][]byte, zb0026)
+					(*z).ApplicationArgs = make([][]byte, zb0030)
 				}
 				for zb0001 := range (*z).ApplicationArgs {
 					(*z).ApplicationArgs[zb0001], bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationArgs[zb0001])
@@ -771,25 +832,30 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 						return
 					}
 				}
+				zb0008 = "apaa"
 			case "apat":
-				var zb0028 int
-				var zb0029 bool
-				zb0028, zb0029, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0009 && "apat" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0032 int
+				var zb0033 bool
+				zb0032, zb0033, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Accounts")
 					return
 				}
-				if zb0028 > encodedMaxAccounts {
-					err = msgp.ErrOverflow(uint64(zb0028), uint64(encodedMaxAccounts))
+				if zb0032 > encodedMaxAccounts {
+					err = msgp.ErrOverflow(uint64(zb0032), uint64(encodedMaxAccounts))
 					err = msgp.WrapError(err, "Accounts")
 					return
 				}
-				if zb0029 {
+				if zb0033 {
 					(*z).Accounts = nil
-				} else if (*z).Accounts != nil && cap((*z).Accounts) >= zb0028 {
-					(*z).Accounts = ((*z).Accounts)[:zb0028]
+				} else if (*z).Accounts != nil && cap((*z).Accounts) >= zb0032 {
+					(*z).Accounts = ((*z).Accounts)[:zb0032]
 				} else {
-					(*z).Accounts = make([]basics.Address, zb0028)
+					(*z).Accounts = make([]basics.Address, zb0032)
 				}
 				for zb0002 := range (*z).Accounts {
 					bts, err = (*z).Accounts[zb0002].UnmarshalMsg(bts)
@@ -798,25 +864,30 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 						return
 					}
 				}
+				zb0008 = "apat"
 			case "apfa":
-				var zb0030 int
-				var zb0031 bool
-				zb0030, zb0031, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0009 && "apfa" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0034 int
+				var zb0035 bool
+				zb0034, zb0035, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ForeignApps")
 					return
 				}
-				if zb0030 > encodedMaxForeignApps {
-					err = msgp.ErrOverflow(uint64(zb0030), uint64(encodedMaxForeignApps))
+				if zb0034 > encodedMaxForeignApps {
+					err = msgp.ErrOverflow(uint64(zb0034), uint64(encodedMaxForeignApps))
 					err = msgp.WrapError(err, "ForeignApps")
 					return
 				}
-				if zb0031 {
+				if zb0035 {
 					(*z).ForeignApps = nil
-				} else if (*z).ForeignApps != nil && cap((*z).ForeignApps) >= zb0030 {
-					(*z).ForeignApps = ((*z).ForeignApps)[:zb0030]
+				} else if (*z).ForeignApps != nil && cap((*z).ForeignApps) >= zb0034 {
+					(*z).ForeignApps = ((*z).ForeignApps)[:zb0034]
 				} else {
-					(*z).ForeignApps = make([]basics.AppIndex, zb0030)
+					(*z).ForeignApps = make([]basics.AppIndex, zb0034)
 				}
 				for zb0003 := range (*z).ForeignApps {
 					bts, err = (*z).ForeignApps[zb0003].UnmarshalMsg(bts)
@@ -825,54 +896,67 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 						return
 					}
 				}
+				zb0008 = "apfa"
 			case "apbx":
-				var zb0032 int
-				var zb0033 bool
-				zb0032, zb0033, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0009 && "apbx" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0036 int
+				var zb0037 bool
+				zb0036, zb0037, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Boxes")
 					return
 				}
-				if zb0032 > encodedMaxBoxes {
-					err = msgp.ErrOverflow(uint64(zb0032), uint64(encodedMaxBoxes))
+				if zb0036 > encodedMaxBoxes {
+					err = msgp.ErrOverflow(uint64(zb0036), uint64(encodedMaxBoxes))
 					err = msgp.WrapError(err, "Boxes")
 					return
 				}
-				if zb0033 {
+				if zb0037 {
 					(*z).Boxes = nil
-				} else if (*z).Boxes != nil && cap((*z).Boxes) >= zb0032 {
-					(*z).Boxes = ((*z).Boxes)[:zb0032]
+				} else if (*z).Boxes != nil && cap((*z).Boxes) >= zb0036 {
+					(*z).Boxes = ((*z).Boxes)[:zb0036]
 				} else {
-					(*z).Boxes = make([]BoxRef, zb0032)
+					(*z).Boxes = make([]BoxRef, zb0036)
 				}
 				for zb0004 := range (*z).Boxes {
-					var zb0034 int
-					var zb0035 bool
-					zb0034, zb0035, bts, err = msgp.ReadMapHeaderBytes(bts)
+					var zb0038 int
+					var zb0040 string
+					var zb0041 bool
+					var zb0039 bool
+					_ = zb0040
+					_ = zb0041
+					zb0038, zb0039, bts, err = msgp.ReadMapHeaderBytes(bts)
 					if _, ok := err.(msgp.TypeError); ok {
-						zb0034, zb0035, bts, err = msgp.ReadArrayHeaderBytes(bts)
+						zb0038, zb0039, bts, err = msgp.ReadArrayHeaderBytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Boxes", zb0004)
 							return
 						}
-						if zb0034 > 0 {
-							zb0034--
+						if validate {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
+						if zb0038 > 0 {
+							zb0038--
 							(*z).Boxes[zb0004].Index, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Boxes", zb0004, "struct-from-array", "Index")
 								return
 							}
 						}
-						if zb0034 > 0 {
-							zb0034--
-							var zb0036 int
-							zb0036, err = msgp.ReadBytesBytesHeader(bts)
+						if zb0038 > 0 {
+							zb0038--
+							var zb0042 int
+							zb0042, err = msgp.ReadBytesBytesHeader(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Boxes", zb0004, "struct-from-array", "Name")
 								return
 							}
-							if zb0036 > config.MaxBytesKeyValueLen {
-								err = msgp.ErrOverflow(uint64(zb0036), uint64(config.MaxBytesKeyValueLen))
+							if zb0042 > config.MaxBytesKeyValueLen {
+								err = msgp.ErrOverflow(uint64(zb0042), uint64(config.MaxBytesKeyValueLen))
 								return
 							}
 							(*z).Boxes[zb0004].Name, bts, err = msgp.ReadBytesBytes(bts, (*z).Boxes[zb0004].Name)
@@ -881,8 +965,8 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 								return
 							}
 						}
-						if zb0034 > 0 {
-							err = msgp.ErrTooManyArrayFields(zb0034)
+						if zb0038 > 0 {
+							err = msgp.ErrTooManyArrayFields(zb0038)
 							if err != nil {
 								err = msgp.WrapError(err, "Boxes", zb0004, "struct-from-array")
 								return
@@ -893,11 +977,11 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 							err = msgp.WrapError(err, "Boxes", zb0004)
 							return
 						}
-						if zb0035 {
+						if zb0039 {
 							(*z).Boxes[zb0004] = BoxRef{}
 						}
-						for zb0034 > 0 {
-							zb0034--
+						for zb0038 > 0 {
+							zb0038--
 							field, bts, err = msgp.ReadMapKeyZC(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Boxes", zb0004)
@@ -905,20 +989,29 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 							}
 							switch string(field) {
 							case "i":
+								if validate && zb0041 && "i" < zb0040 {
+									err = &msgp.ErrNonCanonical{}
+									return
+								}
 								(*z).Boxes[zb0004].Index, bts, err = msgp.ReadUint64Bytes(bts)
 								if err != nil {
 									err = msgp.WrapError(err, "Boxes", zb0004, "Index")
 									return
 								}
+								zb0040 = "i"
 							case "n":
-								var zb0037 int
-								zb0037, err = msgp.ReadBytesBytesHeader(bts)
+								if validate && zb0041 && "n" < zb0040 {
+									err = &msgp.ErrNonCanonical{}
+									return
+								}
+								var zb0043 int
+								zb0043, err = msgp.ReadBytesBytesHeader(bts)
 								if err != nil {
 									err = msgp.WrapError(err, "Boxes", zb0004, "Name")
 									return
 								}
-								if zb0037 > config.MaxBytesKeyValueLen {
-									err = msgp.ErrOverflow(uint64(zb0037), uint64(config.MaxBytesKeyValueLen))
+								if zb0043 > config.MaxBytesKeyValueLen {
+									err = msgp.ErrOverflow(uint64(zb0043), uint64(config.MaxBytesKeyValueLen))
 									return
 								}
 								(*z).Boxes[zb0004].Name, bts, err = msgp.ReadBytesBytes(bts, (*z).Boxes[zb0004].Name)
@@ -926,6 +1019,7 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 									err = msgp.WrapError(err, "Boxes", zb0004, "Name")
 									return
 								}
+								zb0040 = "n"
 							default:
 								err = msgp.ErrNoField(string(field))
 								if err != nil {
@@ -933,28 +1027,34 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 									return
 								}
 							}
+							zb0041 = true
 						}
 					}
 				}
+				zb0008 = "apbx"
 			case "apas":
-				var zb0038 int
-				var zb0039 bool
-				zb0038, zb0039, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0009 && "apas" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0044 int
+				var zb0045 bool
+				zb0044, zb0045, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ForeignAssets")
 					return
 				}
-				if zb0038 > encodedMaxForeignAssets {
-					err = msgp.ErrOverflow(uint64(zb0038), uint64(encodedMaxForeignAssets))
+				if zb0044 > encodedMaxForeignAssets {
+					err = msgp.ErrOverflow(uint64(zb0044), uint64(encodedMaxForeignAssets))
 					err = msgp.WrapError(err, "ForeignAssets")
 					return
 				}
-				if zb0039 {
+				if zb0045 {
 					(*z).ForeignAssets = nil
-				} else if (*z).ForeignAssets != nil && cap((*z).ForeignAssets) >= zb0038 {
-					(*z).ForeignAssets = ((*z).ForeignAssets)[:zb0038]
+				} else if (*z).ForeignAssets != nil && cap((*z).ForeignAssets) >= zb0044 {
+					(*z).ForeignAssets = ((*z).ForeignAssets)[:zb0044]
 				} else {
-					(*z).ForeignAssets = make([]basics.AssetIndex, zb0038)
+					(*z).ForeignAssets = make([]basics.AssetIndex, zb0044)
 				}
 				for zb0005 := range (*z).ForeignAssets {
 					bts, err = (*z).ForeignAssets[zb0005].UnmarshalMsg(bts)
@@ -963,27 +1063,42 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 						return
 					}
 				}
+				zb0008 = "apas"
 			case "apls":
+				if validate && zb0009 && "apls" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).LocalStateSchema.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "LocalStateSchema")
 					return
 				}
+				zb0008 = "apls"
 			case "apgs":
+				if validate && zb0009 && "apgs" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).GlobalStateSchema.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GlobalStateSchema")
 					return
 				}
+				zb0008 = "apgs"
 			case "apap":
-				var zb0040 int
-				zb0040, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0009 && "apap" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0046 int
+				zb0046, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ApprovalProgram")
 					return
 				}
-				if zb0040 > config.MaxAvailableAppProgramLen {
-					err = msgp.ErrOverflow(uint64(zb0040), uint64(config.MaxAvailableAppProgramLen))
+				if zb0046 > config.MaxAvailableAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0046), uint64(config.MaxAvailableAppProgramLen))
 					return
 				}
 				(*z).ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApprovalProgram)
@@ -991,15 +1106,20 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 					err = msgp.WrapError(err, "ApprovalProgram")
 					return
 				}
+				zb0008 = "apap"
 			case "apsu":
-				var zb0041 int
-				zb0041, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0009 && "apsu" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0047 int
+				zb0047, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ClearStateProgram")
 					return
 				}
-				if zb0041 > config.MaxAvailableAppProgramLen {
-					err = msgp.ErrOverflow(uint64(zb0041), uint64(config.MaxAvailableAppProgramLen))
+				if zb0047 > config.MaxAvailableAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0047), uint64(config.MaxAvailableAppProgramLen))
 					return
 				}
 				(*z).ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ClearStateProgram)
@@ -1007,12 +1127,18 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 					err = msgp.WrapError(err, "ClearStateProgram")
 					return
 				}
+				zb0008 = "apsu"
 			case "apep":
+				if validate && zb0009 && "apep" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).ExtraProgramPages, bts, err = msgp.ReadUint32Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ExtraProgramPages")
 					return
 				}
+				zb0008 = "apep"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1020,12 +1146,19 @@ func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error
 					return
 				}
 			}
+			zb0009 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *ApplicationCallTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *ApplicationCallTxnFields) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *ApplicationCallTxnFields) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*ApplicationCallTxnFields)
 	return ok
@@ -1173,16 +1306,24 @@ func (_ *ApplyData) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *ApplyData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *ApplyData) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -1273,53 +1414,93 @@ func (z *ApplyData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "ca":
+				if validate && zb0004 && "ca" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ClosingAmount.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ClosingAmount")
 					return
 				}
+				zb0003 = "ca"
 			case "aca":
+				if validate && zb0004 && "aca" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).AssetClosingAmount, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetClosingAmount")
 					return
 				}
+				zb0003 = "aca"
 			case "rs":
+				if validate && zb0004 && "rs" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SenderRewards.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SenderRewards")
 					return
 				}
+				zb0003 = "rs"
 			case "rr":
+				if validate && zb0004 && "rr" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ReceiverRewards.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ReceiverRewards")
 					return
 				}
+				zb0003 = "rr"
 			case "rc":
+				if validate && zb0004 && "rc" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).CloseRewards.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "CloseRewards")
 					return
 				}
+				zb0003 = "rc"
 			case "dt":
+				if validate && zb0004 && "dt" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).EvalDelta.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "EvalDelta")
 					return
 				}
+				zb0003 = "dt"
 			case "caid":
+				if validate && zb0004 && "caid" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ConfigAsset.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ConfigAsset")
 					return
 				}
+				zb0003 = "caid"
 			case "apid":
+				if validate && zb0004 && "apid" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ApplicationID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ApplicationID")
 					return
 				}
+				zb0003 = "apid"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1327,12 +1508,19 @@ func (z *ApplyData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *ApplyData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *ApplyData) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *ApplyData) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*ApplyData)
 	return ok
@@ -1392,16 +1580,24 @@ func (_ *AssetConfigTxnFields) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *AssetConfigTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *AssetConfigTxnFields) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -1444,17 +1640,27 @@ func (z *AssetConfigTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "caid":
+				if validate && zb0004 && "caid" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ConfigAsset.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ConfigAsset")
 					return
 				}
+				zb0003 = "caid"
 			case "apar":
+				if validate && zb0004 && "apar" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AssetParams.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetParams")
 					return
 				}
+				zb0003 = "apar"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1462,12 +1668,19 @@ func (z *AssetConfigTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *AssetConfigTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *AssetConfigTxnFields) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *AssetConfigTxnFields) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*AssetConfigTxnFields)
 	return ok
@@ -1536,16 +1749,24 @@ func (_ *AssetFreezeTxnFields) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *AssetFreezeTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *AssetFreezeTxnFields) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -1596,23 +1817,38 @@ func (z *AssetFreezeTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "fadd":
+				if validate && zb0004 && "fadd" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).FreezeAccount.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FreezeAccount")
 					return
 				}
+				zb0003 = "fadd"
 			case "faid":
+				if validate && zb0004 && "faid" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).FreezeAsset.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FreezeAsset")
 					return
 				}
+				zb0003 = "faid"
 			case "afrz":
+				if validate && zb0004 && "afrz" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).AssetFrozen, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetFrozen")
 					return
 				}
+				zb0003 = "afrz"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1620,12 +1856,19 @@ func (z *AssetFreezeTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *AssetFreezeTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *AssetFreezeTxnFields) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *AssetFreezeTxnFields) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*AssetFreezeTxnFields)
 	return ok
@@ -1712,16 +1955,24 @@ func (_ *AssetTransferTxnFields) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *AssetTransferTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *AssetTransferTxnFields) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -1788,35 +2039,60 @@ func (z *AssetTransferTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) 
 			}
 			switch string(field) {
 			case "xaid":
+				if validate && zb0004 && "xaid" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).XferAsset.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "XferAsset")
 					return
 				}
+				zb0003 = "xaid"
 			case "aamt":
+				if validate && zb0004 && "aamt" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).AssetAmount, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetAmount")
 					return
 				}
+				zb0003 = "aamt"
 			case "asnd":
+				if validate && zb0004 && "asnd" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AssetSender.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetSender")
 					return
 				}
+				zb0003 = "asnd"
 			case "arcv":
+				if validate && zb0004 && "arcv" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AssetReceiver.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetReceiver")
 					return
 				}
+				zb0003 = "arcv"
 			case "aclose":
+				if validate && zb0004 && "aclose" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AssetCloseTo.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetCloseTo")
 					return
 				}
+				zb0003 = "aclose"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1824,12 +2100,19 @@ func (z *AssetTransferTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) 
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *AssetTransferTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *AssetTransferTxnFields) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *AssetTransferTxnFields) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*AssetTransferTxnFields)
 	return ok
@@ -1889,16 +2172,24 @@ func (_ *BoxRef) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *BoxRef) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *BoxRef) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -1911,14 +2202,14 @@ func (z *BoxRef) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0001 > 0 {
 			zb0001--
-			var zb0003 int
-			zb0003, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0005 int
+			zb0005, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Name")
 				return
 			}
-			if zb0003 > config.MaxBytesKeyValueLen {
-				err = msgp.ErrOverflow(uint64(zb0003), uint64(config.MaxBytesKeyValueLen))
+			if zb0005 > config.MaxBytesKeyValueLen {
+				err = msgp.ErrOverflow(uint64(zb0005), uint64(config.MaxBytesKeyValueLen))
 				return
 			}
 			(*z).Name, bts, err = msgp.ReadBytesBytes(bts, (*z).Name)
@@ -1951,20 +2242,29 @@ func (z *BoxRef) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "i":
+				if validate && zb0004 && "i" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Index, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Index")
 					return
 				}
+				zb0003 = "i"
 			case "n":
-				var zb0004 int
-				zb0004, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0004 && "n" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0006 int
+				zb0006, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Name")
 					return
 				}
-				if zb0004 > config.MaxBytesKeyValueLen {
-					err = msgp.ErrOverflow(uint64(zb0004), uint64(config.MaxBytesKeyValueLen))
+				if zb0006 > config.MaxBytesKeyValueLen {
+					err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxBytesKeyValueLen))
 					return
 				}
 				(*z).Name, bts, err = msgp.ReadBytesBytes(bts, (*z).Name)
@@ -1972,6 +2272,7 @@ func (z *BoxRef) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "Name")
 					return
 				}
+				zb0003 = "n"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1979,12 +2280,19 @@ func (z *BoxRef) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *BoxRef) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *BoxRef) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *BoxRef) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*BoxRef)
 	return ok
@@ -2107,16 +2415,24 @@ func (_ *EvalDelta) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *EvalDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *EvalDelta) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0006 int
+	var zb0008 string
+	var zb0009 bool
 	var zb0007 bool
+	_ = zb0008
+	_ = zb0009
 	zb0006, zb0007, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0006 > 0 {
@@ -2129,64 +2445,70 @@ func (z *EvalDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0006 > 0 {
 			zb0006--
-			var zb0008 int
-			var zb0009 bool
-			zb0008, zb0009, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0010 int
+			var zb0011 bool
+			zb0010, zb0011, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "LocalDeltas")
 				return
 			}
-			if zb0008 > config.MaxEvalDeltaAccounts {
-				err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxEvalDeltaAccounts))
+			if zb0010 > config.MaxEvalDeltaAccounts {
+				err = msgp.ErrOverflow(uint64(zb0010), uint64(config.MaxEvalDeltaAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "LocalDeltas")
 				return
 			}
-			if zb0009 {
+			if zb0011 {
 				(*z).LocalDeltas = nil
 			} else if (*z).LocalDeltas == nil {
-				(*z).LocalDeltas = make(map[uint64]basics.StateDelta, zb0008)
+				(*z).LocalDeltas = make(map[uint64]basics.StateDelta, zb0010)
 			}
-			for zb0008 > 0 {
+			var zb0012 uint64
+			_ = zb0012
+			var zb0013 bool
+			_ = zb0013
+			for zb0010 > 0 {
 				var zb0001 uint64
 				var zb0002 basics.StateDelta
-				zb0008--
+				zb0010--
 				zb0001, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "LocalDeltas")
 					return
 				}
+				if validate && zb0013 && Uint64Less(zb0001, zb0012) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0012 = zb0001
+				zb0013 = true
 				bts, err = zb0002.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "LocalDeltas", zb0001)
 					return
 				}
-				if SortUint64([]uint64{prev,zb0001}).Less(0,1) {
-					notCanonical = true // !!! uh oh!!
-				}
 				(*z).LocalDeltas[zb0001] = zb0002
-				prev = zb0001
 			}
 		}
 		if zb0006 > 0 {
 			zb0006--
-			var zb0010 int
-			var zb0011 bool
-			zb0010, zb0011, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0014 int
+			var zb0015 bool
+			zb0014, zb0015, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "SharedAccts")
 				return
 			}
-			if zb0010 > config.MaxEvalDeltaAccounts {
-				err = msgp.ErrOverflow(uint64(zb0010), uint64(config.MaxEvalDeltaAccounts))
+			if zb0014 > config.MaxEvalDeltaAccounts {
+				err = msgp.ErrOverflow(uint64(zb0014), uint64(config.MaxEvalDeltaAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "SharedAccts")
 				return
 			}
-			if zb0011 {
+			if zb0015 {
 				(*z).SharedAccts = nil
-			} else if (*z).SharedAccts != nil && cap((*z).SharedAccts) >= zb0010 {
-				(*z).SharedAccts = ((*z).SharedAccts)[:zb0010]
+			} else if (*z).SharedAccts != nil && cap((*z).SharedAccts) >= zb0014 {
+				(*z).SharedAccts = ((*z).SharedAccts)[:zb0014]
 			} else {
-				(*z).SharedAccts = make([]basics.Address, zb0010)
+				(*z).SharedAccts = make([]basics.Address, zb0014)
 			}
 			for zb0003 := range (*z).SharedAccts {
 				bts, err = (*z).SharedAccts[zb0003].UnmarshalMsg(bts)
@@ -2198,24 +2520,24 @@ func (z *EvalDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0006 > 0 {
 			zb0006--
-			var zb0012 int
-			var zb0013 bool
-			zb0012, zb0013, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0016 int
+			var zb0017 bool
+			zb0016, zb0017, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Logs")
 				return
 			}
-			if zb0012 > config.MaxLogCalls {
-				err = msgp.ErrOverflow(uint64(zb0012), uint64(config.MaxLogCalls))
+			if zb0016 > config.MaxLogCalls {
+				err = msgp.ErrOverflow(uint64(zb0016), uint64(config.MaxLogCalls))
 				err = msgp.WrapError(err, "struct-from-array", "Logs")
 				return
 			}
-			if zb0013 {
+			if zb0017 {
 				(*z).Logs = nil
-			} else if (*z).Logs != nil && cap((*z).Logs) >= zb0012 {
-				(*z).Logs = ((*z).Logs)[:zb0012]
+			} else if (*z).Logs != nil && cap((*z).Logs) >= zb0016 {
+				(*z).Logs = ((*z).Logs)[:zb0016]
 			} else {
-				(*z).Logs = make([]string, zb0012)
+				(*z).Logs = make([]string, zb0016)
 			}
 			for zb0004 := range (*z).Logs {
 				(*z).Logs[zb0004], bts, err = msgp.ReadStringBytes(bts)
@@ -2227,24 +2549,24 @@ func (z *EvalDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0006 > 0 {
 			zb0006--
-			var zb0014 int
-			var zb0015 bool
-			zb0014, zb0015, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0018 int
+			var zb0019 bool
+			zb0018, zb0019, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "InnerTxns")
 				return
 			}
-			if zb0014 > config.MaxInnerTransactionsPerDelta {
-				err = msgp.ErrOverflow(uint64(zb0014), uint64(config.MaxInnerTransactionsPerDelta))
+			if zb0018 > config.MaxInnerTransactionsPerDelta {
+				err = msgp.ErrOverflow(uint64(zb0018), uint64(config.MaxInnerTransactionsPerDelta))
 				err = msgp.WrapError(err, "struct-from-array", "InnerTxns")
 				return
 			}
-			if zb0015 {
+			if zb0019 {
 				(*z).InnerTxns = nil
-			} else if (*z).InnerTxns != nil && cap((*z).InnerTxns) >= zb0014 {
-				(*z).InnerTxns = ((*z).InnerTxns)[:zb0014]
+			} else if (*z).InnerTxns != nil && cap((*z).InnerTxns) >= zb0018 {
+				(*z).InnerTxns = ((*z).InnerTxns)[:zb0018]
 			} else {
-				(*z).InnerTxns = make([]SignedTxnWithAD, zb0014)
+				(*z).InnerTxns = make([]SignedTxnWithAD, zb0018)
 			}
 			for zb0005 := range (*z).InnerTxns {
 				bts, err = (*z).InnerTxns[zb0005].UnmarshalMsg(bts)
@@ -2278,38 +2600,57 @@ func (z *EvalDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "gd":
+				if validate && zb0009 && "gd" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).GlobalDelta.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GlobalDelta")
 					return
 				}
+				zb0008 = "gd"
 			case "ld":
-				var zb0016 int
-				var zb0017 bool
-				zb0016, zb0017, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0009 && "ld" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0020 int
+				var zb0021 bool
+				zb0020, zb0021, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "LocalDeltas")
 					return
 				}
-				if zb0016 > config.MaxEvalDeltaAccounts {
-					err = msgp.ErrOverflow(uint64(zb0016), uint64(config.MaxEvalDeltaAccounts))
+				if zb0020 > config.MaxEvalDeltaAccounts {
+					err = msgp.ErrOverflow(uint64(zb0020), uint64(config.MaxEvalDeltaAccounts))
 					err = msgp.WrapError(err, "LocalDeltas")
 					return
 				}
-				if zb0017 {
+				if zb0021 {
 					(*z).LocalDeltas = nil
 				} else if (*z).LocalDeltas == nil {
-					(*z).LocalDeltas = make(map[uint64]basics.StateDelta, zb0016)
+					(*z).LocalDeltas = make(map[uint64]basics.StateDelta, zb0020)
 				}
-				for zb0016 > 0 {
+				var zb0022 uint64
+				_ = zb0022
+				var zb0023 bool
+				_ = zb0023
+				for zb0020 > 0 {
 					var zb0001 uint64
 					var zb0002 basics.StateDelta
-					zb0016--
+					zb0020--
 					zb0001, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "LocalDeltas")
 						return
 					}
+					if validate && zb0023 && Uint64Less(zb0001, zb0022) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0022 = zb0001
+					zb0023 = true
 					bts, err = zb0002.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "LocalDeltas", zb0001)
@@ -2317,25 +2658,30 @@ func (z *EvalDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).LocalDeltas[zb0001] = zb0002
 				}
+				zb0008 = "ld"
 			case "sa":
-				var zb0018 int
-				var zb0019 bool
-				zb0018, zb0019, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0009 && "sa" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0024 int
+				var zb0025 bool
+				zb0024, zb0025, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SharedAccts")
 					return
 				}
-				if zb0018 > config.MaxEvalDeltaAccounts {
-					err = msgp.ErrOverflow(uint64(zb0018), uint64(config.MaxEvalDeltaAccounts))
+				if zb0024 > config.MaxEvalDeltaAccounts {
+					err = msgp.ErrOverflow(uint64(zb0024), uint64(config.MaxEvalDeltaAccounts))
 					err = msgp.WrapError(err, "SharedAccts")
 					return
 				}
-				if zb0019 {
+				if zb0025 {
 					(*z).SharedAccts = nil
-				} else if (*z).SharedAccts != nil && cap((*z).SharedAccts) >= zb0018 {
-					(*z).SharedAccts = ((*z).SharedAccts)[:zb0018]
+				} else if (*z).SharedAccts != nil && cap((*z).SharedAccts) >= zb0024 {
+					(*z).SharedAccts = ((*z).SharedAccts)[:zb0024]
 				} else {
-					(*z).SharedAccts = make([]basics.Address, zb0018)
+					(*z).SharedAccts = make([]basics.Address, zb0024)
 				}
 				for zb0003 := range (*z).SharedAccts {
 					bts, err = (*z).SharedAccts[zb0003].UnmarshalMsg(bts)
@@ -2344,25 +2690,30 @@ func (z *EvalDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0008 = "sa"
 			case "lg":
-				var zb0020 int
-				var zb0021 bool
-				zb0020, zb0021, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0009 && "lg" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0026 int
+				var zb0027 bool
+				zb0026, zb0027, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Logs")
 					return
 				}
-				if zb0020 > config.MaxLogCalls {
-					err = msgp.ErrOverflow(uint64(zb0020), uint64(config.MaxLogCalls))
+				if zb0026 > config.MaxLogCalls {
+					err = msgp.ErrOverflow(uint64(zb0026), uint64(config.MaxLogCalls))
 					err = msgp.WrapError(err, "Logs")
 					return
 				}
-				if zb0021 {
+				if zb0027 {
 					(*z).Logs = nil
-				} else if (*z).Logs != nil && cap((*z).Logs) >= zb0020 {
-					(*z).Logs = ((*z).Logs)[:zb0020]
+				} else if (*z).Logs != nil && cap((*z).Logs) >= zb0026 {
+					(*z).Logs = ((*z).Logs)[:zb0026]
 				} else {
-					(*z).Logs = make([]string, zb0020)
+					(*z).Logs = make([]string, zb0026)
 				}
 				for zb0004 := range (*z).Logs {
 					(*z).Logs[zb0004], bts, err = msgp.ReadStringBytes(bts)
@@ -2371,25 +2722,30 @@ func (z *EvalDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0008 = "lg"
 			case "itx":
-				var zb0022 int
-				var zb0023 bool
-				zb0022, zb0023, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0009 && "itx" < zb0008 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0028 int
+				var zb0029 bool
+				zb0028, zb0029, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "InnerTxns")
 					return
 				}
-				if zb0022 > config.MaxInnerTransactionsPerDelta {
-					err = msgp.ErrOverflow(uint64(zb0022), uint64(config.MaxInnerTransactionsPerDelta))
+				if zb0028 > config.MaxInnerTransactionsPerDelta {
+					err = msgp.ErrOverflow(uint64(zb0028), uint64(config.MaxInnerTransactionsPerDelta))
 					err = msgp.WrapError(err, "InnerTxns")
 					return
 				}
-				if zb0023 {
+				if zb0029 {
 					(*z).InnerTxns = nil
-				} else if (*z).InnerTxns != nil && cap((*z).InnerTxns) >= zb0022 {
-					(*z).InnerTxns = ((*z).InnerTxns)[:zb0022]
+				} else if (*z).InnerTxns != nil && cap((*z).InnerTxns) >= zb0028 {
+					(*z).InnerTxns = ((*z).InnerTxns)[:zb0028]
 				} else {
-					(*z).InnerTxns = make([]SignedTxnWithAD, zb0022)
+					(*z).InnerTxns = make([]SignedTxnWithAD, zb0028)
 				}
 				for zb0005 := range (*z).InnerTxns {
 					bts, err = (*z).InnerTxns[zb0005].UnmarshalMsg(bts)
@@ -2398,6 +2754,7 @@ func (z *EvalDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0008 = "itx"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2405,12 +2762,19 @@ func (z *EvalDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0009 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *EvalDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *EvalDelta) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *EvalDelta) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*EvalDelta)
 	return ok
@@ -2574,16 +2938,24 @@ func (_ *Header) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Header) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Header) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0002 > 0 {
@@ -2620,14 +2992,14 @@ func (z *Header) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0004 int
-			zb0004, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0006 int
+			zb0006, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Note")
 				return
 			}
-			if zb0004 > config.MaxTxnNoteBytes {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(config.MaxTxnNoteBytes))
+			if zb0006 > config.MaxTxnNoteBytes {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxTxnNoteBytes))
 				return
 			}
 			(*z).Note, bts, err = msgp.ReadBytesBytes(bts, (*z).Note)
@@ -2638,14 +3010,14 @@ func (z *Header) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0005 int
-			zb0005, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0007 int
+			zb0007, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "GenesisID")
 				return
 			}
-			if zb0005 > config.MaxGenesisIDLen {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(config.MaxGenesisIDLen))
+			if zb0007 > config.MaxGenesisIDLen {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxGenesisIDLen))
 				return
 			}
 			(*z).GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -2710,38 +3082,62 @@ func (z *Header) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "snd":
+				if validate && zb0005 && "snd" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sender.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sender")
 					return
 				}
+				zb0004 = "snd"
 			case "fee":
+				if validate && zb0005 && "fee" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Fee.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Fee")
 					return
 				}
+				zb0004 = "fee"
 			case "fv":
+				if validate && zb0005 && "fv" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).FirstValid.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FirstValid")
 					return
 				}
+				zb0004 = "fv"
 			case "lv":
+				if validate && zb0005 && "lv" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).LastValid.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "LastValid")
 					return
 				}
+				zb0004 = "lv"
 			case "note":
-				var zb0006 int
-				zb0006, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0005 && "note" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0008 int
+				zb0008, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Note")
 					return
 				}
-				if zb0006 > config.MaxTxnNoteBytes {
-					err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxTxnNoteBytes))
+				if zb0008 > config.MaxTxnNoteBytes {
+					err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxTxnNoteBytes))
 					return
 				}
 				(*z).Note, bts, err = msgp.ReadBytesBytes(bts, (*z).Note)
@@ -2749,15 +3145,20 @@ func (z *Header) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "Note")
 					return
 				}
+				zb0004 = "note"
 			case "gen":
-				var zb0007 int
-				zb0007, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0005 && "gen" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0009 int
+				zb0009, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
-				if zb0007 > config.MaxGenesisIDLen {
-					err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxGenesisIDLen))
+				if zb0009 > config.MaxGenesisIDLen {
+					err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxGenesisIDLen))
 					return
 				}
 				(*z).GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -2765,30 +3166,51 @@ func (z *Header) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
+				zb0004 = "gen"
 			case "gh":
+				if validate && zb0005 && "gh" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).GenesisHash.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GenesisHash")
 					return
 				}
+				zb0004 = "gh"
 			case "grp":
+				if validate && zb0005 && "grp" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Group.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Group")
 					return
 				}
+				zb0004 = "grp"
 			case "lx":
+				if validate && zb0005 && "lx" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).Lease)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "Lease")
 					return
 				}
+				zb0004 = "lx"
 			case "rekey":
+				if validate && zb0005 && "rekey" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).RekeyTo.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RekeyTo")
 					return
 				}
+				zb0004 = "rekey"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2796,12 +3218,19 @@ func (z *Header) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *Header) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Header) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Header) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Header)
 	return ok
@@ -2909,16 +3338,24 @@ func (_ *KeyregTxnFields) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *KeyregTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *KeyregTxnFields) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -3001,47 +3438,82 @@ func (z *KeyregTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "votekey":
+				if validate && zb0004 && "votekey" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VotePK.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VotePK")
 					return
 				}
+				zb0003 = "votekey"
 			case "selkey":
+				if validate && zb0004 && "selkey" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SelectionPK.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SelectionPK")
 					return
 				}
+				zb0003 = "selkey"
 			case "sprfkey":
+				if validate && zb0004 && "sprfkey" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).StateProofPK.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofPK")
 					return
 				}
+				zb0003 = "sprfkey"
 			case "votefst":
+				if validate && zb0004 && "votefst" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VoteFirst.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteFirst")
 					return
 				}
+				zb0003 = "votefst"
 			case "votelst":
+				if validate && zb0004 && "votelst" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VoteLast.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteLast")
 					return
 				}
+				zb0003 = "votelst"
 			case "votekd":
+				if validate && zb0004 && "votekd" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).VoteKeyDilution, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteKeyDilution")
 					return
 				}
+				zb0003 = "votekd"
 			case "nonpart":
+				if validate && zb0004 && "nonpart" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Nonparticipation, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Nonparticipation")
 					return
 				}
+				zb0003 = "nonpart"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3049,12 +3521,19 @@ func (z *KeyregTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *KeyregTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *KeyregTxnFields) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *KeyregTxnFields) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*KeyregTxnFields)
 	return ok
@@ -3139,11 +3618,15 @@ func (_ *LogicSig) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *LogicSig) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *LogicSig) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -3151,16 +3634,20 @@ func (z *LogicSig) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0004 int
-			zb0004, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0006 int
+			zb0006, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Logic")
 				return
 			}
-			if zb0004 > config.MaxLogicSigMaxSize {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(config.MaxLogicSigMaxSize))
+			if zb0006 > config.MaxLogicSigMaxSize {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxLogicSigMaxSize))
 				return
 			}
 			(*z).Logic, bts, err = msgp.ReadBytesBytes(bts, (*z).Logic)
@@ -3187,34 +3674,34 @@ func (z *LogicSig) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0007 int
+			var zb0008 bool
+			zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Args")
 				return
 			}
-			if zb0005 > EvalMaxArgs {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(EvalMaxArgs))
+			if zb0007 > EvalMaxArgs {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(EvalMaxArgs))
 				err = msgp.WrapError(err, "struct-from-array", "Args")
 				return
 			}
-			if zb0006 {
+			if zb0008 {
 				(*z).Args = nil
-			} else if (*z).Args != nil && cap((*z).Args) >= zb0005 {
-				(*z).Args = ((*z).Args)[:zb0005]
+			} else if (*z).Args != nil && cap((*z).Args) >= zb0007 {
+				(*z).Args = ((*z).Args)[:zb0007]
 			} else {
-				(*z).Args = make([][]byte, zb0005)
+				(*z).Args = make([][]byte, zb0007)
 			}
 			for zb0001 := range (*z).Args {
-				var zb0007 int
-				zb0007, err = msgp.ReadBytesBytesHeader(bts)
+				var zb0009 int
+				zb0009, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Args", zb0001)
 					return
 				}
-				if zb0007 > config.MaxLogicSigMaxSize {
-					err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxLogicSigMaxSize))
+				if zb0009 > config.MaxLogicSigMaxSize {
+					err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxLogicSigMaxSize))
 					return
 				}
 				(*z).Args[zb0001], bts, err = msgp.ReadBytesBytes(bts, (*z).Args[zb0001])
@@ -3248,14 +3735,18 @@ func (z *LogicSig) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "l":
-				var zb0008 int
-				zb0008, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0005 && "l" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0010 int
+				zb0010, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Logic")
 					return
 				}
-				if zb0008 > config.MaxLogicSigMaxSize {
-					err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxLogicSigMaxSize))
+				if zb0010 > config.MaxLogicSigMaxSize {
+					err = msgp.ErrOverflow(uint64(zb0010), uint64(config.MaxLogicSigMaxSize))
 					return
 				}
 				(*z).Logic, bts, err = msgp.ReadBytesBytes(bts, (*z).Logic)
@@ -3263,47 +3754,62 @@ func (z *LogicSig) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "Logic")
 					return
 				}
+				zb0004 = "l"
 			case "sig":
+				if validate && zb0005 && "sig" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sig")
 					return
 				}
+				zb0004 = "sig"
 			case "msig":
+				if validate && zb0005 && "msig" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Msig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Msig")
 					return
 				}
+				zb0004 = "msig"
 			case "arg":
-				var zb0009 int
-				var zb0010 bool
-				zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0005 && "arg" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0011 int
+				var zb0012 bool
+				zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Args")
 					return
 				}
-				if zb0009 > EvalMaxArgs {
-					err = msgp.ErrOverflow(uint64(zb0009), uint64(EvalMaxArgs))
+				if zb0011 > EvalMaxArgs {
+					err = msgp.ErrOverflow(uint64(zb0011), uint64(EvalMaxArgs))
 					err = msgp.WrapError(err, "Args")
 					return
 				}
-				if zb0010 {
+				if zb0012 {
 					(*z).Args = nil
-				} else if (*z).Args != nil && cap((*z).Args) >= zb0009 {
-					(*z).Args = ((*z).Args)[:zb0009]
+				} else if (*z).Args != nil && cap((*z).Args) >= zb0011 {
+					(*z).Args = ((*z).Args)[:zb0011]
 				} else {
-					(*z).Args = make([][]byte, zb0009)
+					(*z).Args = make([][]byte, zb0011)
 				}
 				for zb0001 := range (*z).Args {
-					var zb0011 int
-					zb0011, err = msgp.ReadBytesBytesHeader(bts)
+					var zb0013 int
+					zb0013, err = msgp.ReadBytesBytesHeader(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Args", zb0001)
 						return
 					}
-					if zb0011 > config.MaxLogicSigMaxSize {
-						err = msgp.ErrOverflow(uint64(zb0011), uint64(config.MaxLogicSigMaxSize))
+					if zb0013 > config.MaxLogicSigMaxSize {
+						err = msgp.ErrOverflow(uint64(zb0013), uint64(config.MaxLogicSigMaxSize))
 						return
 					}
 					(*z).Args[zb0001], bts, err = msgp.ReadBytesBytes(bts, (*z).Args[zb0001])
@@ -3312,6 +3818,7 @@ func (z *LogicSig) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0004 = "arg"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3319,12 +3826,19 @@ func (z *LogicSig) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *LogicSig) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *LogicSig) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *LogicSig) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*LogicSig)
 	return ok
@@ -3368,7 +3882,7 @@ func (_ OnCompletion) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *OnCompletion) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *OnCompletion) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 uint64
 		zb0001, bts, err = msgp.ReadUint64Bytes(bts)
@@ -3382,6 +3896,12 @@ func (z *OnCompletion) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *OnCompletion) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *OnCompletion) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *OnCompletion) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*OnCompletion)
 	return ok
@@ -3450,16 +3970,24 @@ func (_ *PaymentTxnFields) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *PaymentTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *PaymentTxnFields) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -3510,23 +4038,38 @@ func (z *PaymentTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "rcv":
+				if validate && zb0004 && "rcv" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Receiver.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Receiver")
 					return
 				}
+				zb0003 = "rcv"
 			case "amt":
+				if validate && zb0004 && "amt" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Amount.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Amount")
 					return
 				}
+				zb0003 = "amt"
 			case "close":
+				if validate && zb0004 && "close" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).CloseRemainderTo.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "CloseRemainderTo")
 					return
 				}
+				zb0003 = "close"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3534,12 +4077,19 @@ func (z *PaymentTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *PaymentTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *PaymentTxnFields) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *PaymentTxnFields) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*PaymentTxnFields)
 	return ok
@@ -3585,7 +4135,7 @@ func (_ Payset) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Payset) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Payset) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var zb0002 int
 	var zb0003 bool
 	zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -3616,6 +4166,12 @@ func (z *Payset) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *Payset) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Payset) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Payset) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Payset)
 	return ok
@@ -3706,16 +4262,24 @@ func (_ *SignedTxn) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *SignedTxn) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *SignedTxn) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -3782,35 +4346,60 @@ func (z *SignedTxn) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "sig":
+				if validate && zb0004 && "sig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sig")
 					return
 				}
+				zb0003 = "sig"
 			case "msig":
+				if validate && zb0004 && "msig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Msig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Msig")
 					return
 				}
+				zb0003 = "msig"
 			case "lsig":
+				if validate && zb0004 && "lsig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Lsig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Lsig")
 					return
 				}
+				zb0003 = "lsig"
 			case "txn":
+				if validate && zb0004 && "txn" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Txn.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Txn")
 					return
 				}
+				zb0003 = "txn"
 			case "sgnr":
+				if validate && zb0004 && "sgnr" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AuthAddr.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AuthAddr")
 					return
 				}
+				zb0003 = "sgnr"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3818,12 +4407,19 @@ func (z *SignedTxn) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *SignedTxn) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *SignedTxn) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *SignedTxn) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*SignedTxn)
 	return ok
@@ -4000,16 +4596,24 @@ func (_ *SignedTxnInBlock) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *SignedTxnInBlock) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *SignedTxnInBlock) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -4156,95 +4760,170 @@ func (z *SignedTxnInBlock) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "sig":
+				if validate && zb0004 && "sig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxnWithAD.SignedTxn.Sig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sig")
 					return
 				}
+				zb0003 = "sig"
 			case "msig":
+				if validate && zb0004 && "msig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxnWithAD.SignedTxn.Msig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Msig")
 					return
 				}
+				zb0003 = "msig"
 			case "lsig":
+				if validate && zb0004 && "lsig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxnWithAD.SignedTxn.Lsig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Lsig")
 					return
 				}
+				zb0003 = "lsig"
 			case "txn":
+				if validate && zb0004 && "txn" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxnWithAD.SignedTxn.Txn.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Txn")
 					return
 				}
+				zb0003 = "txn"
 			case "sgnr":
+				if validate && zb0004 && "sgnr" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxnWithAD.SignedTxn.AuthAddr.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AuthAddr")
 					return
 				}
+				zb0003 = "sgnr"
 			case "ca":
+				if validate && zb0004 && "ca" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxnWithAD.ApplyData.ClosingAmount.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ClosingAmount")
 					return
 				}
+				zb0003 = "ca"
 			case "aca":
+				if validate && zb0004 && "aca" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).SignedTxnWithAD.ApplyData.AssetClosingAmount, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetClosingAmount")
 					return
 				}
+				zb0003 = "aca"
 			case "rs":
+				if validate && zb0004 && "rs" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxnWithAD.ApplyData.SenderRewards.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SenderRewards")
 					return
 				}
+				zb0003 = "rs"
 			case "rr":
+				if validate && zb0004 && "rr" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxnWithAD.ApplyData.ReceiverRewards.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ReceiverRewards")
 					return
 				}
+				zb0003 = "rr"
 			case "rc":
+				if validate && zb0004 && "rc" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxnWithAD.ApplyData.CloseRewards.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "CloseRewards")
 					return
 				}
+				zb0003 = "rc"
 			case "dt":
+				if validate && zb0004 && "dt" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxnWithAD.ApplyData.EvalDelta.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "EvalDelta")
 					return
 				}
+				zb0003 = "dt"
 			case "caid":
+				if validate && zb0004 && "caid" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxnWithAD.ApplyData.ConfigAsset.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ConfigAsset")
 					return
 				}
+				zb0003 = "caid"
 			case "apid":
+				if validate && zb0004 && "apid" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxnWithAD.ApplyData.ApplicationID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ApplicationID")
 					return
 				}
+				zb0003 = "apid"
 			case "hgi":
+				if validate && zb0004 && "hgi" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).HasGenesisID, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "HasGenesisID")
 					return
 				}
+				zb0003 = "hgi"
 			case "hgh":
+				if validate && zb0004 && "hgh" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).HasGenesisHash, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "HasGenesisHash")
 					return
 				}
+				zb0003 = "hgh"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -4252,12 +4931,19 @@ func (z *SignedTxnInBlock) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *SignedTxnInBlock) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *SignedTxnInBlock) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *SignedTxnInBlock) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*SignedTxnInBlock)
 	return ok
@@ -4416,16 +5102,24 @@ func (_ *SignedTxnWithAD) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *SignedTxnWithAD) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *SignedTxnWithAD) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -4556,83 +5250,148 @@ func (z *SignedTxnWithAD) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "sig":
+				if validate && zb0004 && "sig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxn.Sig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sig")
 					return
 				}
+				zb0003 = "sig"
 			case "msig":
+				if validate && zb0004 && "msig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxn.Msig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Msig")
 					return
 				}
+				zb0003 = "msig"
 			case "lsig":
+				if validate && zb0004 && "lsig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxn.Lsig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Lsig")
 					return
 				}
+				zb0003 = "lsig"
 			case "txn":
+				if validate && zb0004 && "txn" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxn.Txn.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Txn")
 					return
 				}
+				zb0003 = "txn"
 			case "sgnr":
+				if validate && zb0004 && "sgnr" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignedTxn.AuthAddr.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AuthAddr")
 					return
 				}
+				zb0003 = "sgnr"
 			case "ca":
+				if validate && zb0004 && "ca" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ApplyData.ClosingAmount.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ClosingAmount")
 					return
 				}
+				zb0003 = "ca"
 			case "aca":
+				if validate && zb0004 && "aca" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).ApplyData.AssetClosingAmount, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetClosingAmount")
 					return
 				}
+				zb0003 = "aca"
 			case "rs":
+				if validate && zb0004 && "rs" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ApplyData.SenderRewards.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SenderRewards")
 					return
 				}
+				zb0003 = "rs"
 			case "rr":
+				if validate && zb0004 && "rr" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ApplyData.ReceiverRewards.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ReceiverRewards")
 					return
 				}
+				zb0003 = "rr"
 			case "rc":
+				if validate && zb0004 && "rc" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ApplyData.CloseRewards.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "CloseRewards")
 					return
 				}
+				zb0003 = "rc"
 			case "dt":
+				if validate && zb0004 && "dt" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ApplyData.EvalDelta.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "EvalDelta")
 					return
 				}
+				zb0003 = "dt"
 			case "caid":
+				if validate && zb0004 && "caid" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ApplyData.ConfigAsset.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ConfigAsset")
 					return
 				}
+				zb0003 = "caid"
 			case "apid":
+				if validate && zb0004 && "apid" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ApplyData.ApplicationID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ApplicationID")
 					return
 				}
+				zb0003 = "apid"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -4640,12 +5399,19 @@ func (z *SignedTxnWithAD) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *SignedTxnWithAD) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *SignedTxnWithAD) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *SignedTxnWithAD) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*SignedTxnWithAD)
 	return ok
@@ -4714,16 +5480,24 @@ func (_ *StateProofTxnFields) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *StateProofTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *StateProofTxnFields) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -4774,23 +5548,38 @@ func (z *StateProofTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "sptype":
+				if validate && zb0004 && "sptype" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).StateProofType.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofType")
 					return
 				}
+				zb0003 = "sptype"
 			case "sp":
+				if validate && zb0004 && "sp" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).StateProof.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProof")
 					return
 				}
+				zb0003 = "sp"
 			case "spmsg":
+				if validate && zb0004 && "spmsg" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Message.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Message")
 					return
 				}
+				zb0003 = "spmsg"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -4798,12 +5587,19 @@ func (z *StateProofTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *StateProofTxnFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *StateProofTxnFields) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *StateProofTxnFields) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*StateProofTxnFields)
 	return ok
@@ -5316,16 +6112,24 @@ func (_ *Transaction) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Transaction) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0007 int
+	var zb0009 string
+	var zb0010 bool
 	var zb0008 bool
+	_ = zb0009
+	_ = zb0010
 	zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0007 > 0 {
@@ -5370,14 +6174,14 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0007 > 0 {
 			zb0007--
-			var zb0009 int
-			zb0009, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0011 int
+			zb0011, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Note")
 				return
 			}
-			if zb0009 > config.MaxTxnNoteBytes {
-				err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxTxnNoteBytes))
+			if zb0011 > config.MaxTxnNoteBytes {
+				err = msgp.ErrOverflow(uint64(zb0011), uint64(config.MaxTxnNoteBytes))
 				return
 			}
 			(*z).Header.Note, bts, err = msgp.ReadBytesBytes(bts, (*z).Header.Note)
@@ -5388,14 +6192,14 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0007 > 0 {
 			zb0007--
-			var zb0010 int
-			zb0010, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0012 int
+			zb0012, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "GenesisID")
 				return
 			}
-			if zb0010 > config.MaxGenesisIDLen {
-				err = msgp.ErrOverflow(uint64(zb0010), uint64(config.MaxGenesisIDLen))
+			if zb0012 > config.MaxGenesisIDLen {
+				err = msgp.ErrOverflow(uint64(zb0012), uint64(config.MaxGenesisIDLen))
 				return
 			}
 			(*z).Header.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -5607,35 +6411,35 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		if zb0007 > 0 {
 			zb0007--
 			{
-				var zb0011 uint64
-				zb0011, bts, err = msgp.ReadUint64Bytes(bts)
+				var zb0013 uint64
+				zb0013, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "OnCompletion")
 					return
 				}
-				(*z).ApplicationCallTxnFields.OnCompletion = OnCompletion(zb0011)
+				(*z).ApplicationCallTxnFields.OnCompletion = OnCompletion(zb0013)
 			}
 		}
 		if zb0007 > 0 {
 			zb0007--
-			var zb0012 int
-			var zb0013 bool
-			zb0012, zb0013, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0014 int
+			var zb0015 bool
+			zb0014, zb0015, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ApplicationArgs")
 				return
 			}
-			if zb0012 > encodedMaxApplicationArgs {
-				err = msgp.ErrOverflow(uint64(zb0012), uint64(encodedMaxApplicationArgs))
+			if zb0014 > encodedMaxApplicationArgs {
+				err = msgp.ErrOverflow(uint64(zb0014), uint64(encodedMaxApplicationArgs))
 				err = msgp.WrapError(err, "struct-from-array", "ApplicationArgs")
 				return
 			}
-			if zb0013 {
+			if zb0015 {
 				(*z).ApplicationCallTxnFields.ApplicationArgs = nil
-			} else if (*z).ApplicationCallTxnFields.ApplicationArgs != nil && cap((*z).ApplicationCallTxnFields.ApplicationArgs) >= zb0012 {
-				(*z).ApplicationCallTxnFields.ApplicationArgs = ((*z).ApplicationCallTxnFields.ApplicationArgs)[:zb0012]
+			} else if (*z).ApplicationCallTxnFields.ApplicationArgs != nil && cap((*z).ApplicationCallTxnFields.ApplicationArgs) >= zb0014 {
+				(*z).ApplicationCallTxnFields.ApplicationArgs = ((*z).ApplicationCallTxnFields.ApplicationArgs)[:zb0014]
 			} else {
-				(*z).ApplicationCallTxnFields.ApplicationArgs = make([][]byte, zb0012)
+				(*z).ApplicationCallTxnFields.ApplicationArgs = make([][]byte, zb0014)
 			}
 			for zb0002 := range (*z).ApplicationCallTxnFields.ApplicationArgs {
 				(*z).ApplicationCallTxnFields.ApplicationArgs[zb0002], bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.ApplicationArgs[zb0002])
@@ -5647,24 +6451,24 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0007 > 0 {
 			zb0007--
-			var zb0014 int
-			var zb0015 bool
-			zb0014, zb0015, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0016 int
+			var zb0017 bool
+			zb0016, zb0017, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Accounts")
 				return
 			}
-			if zb0014 > encodedMaxAccounts {
-				err = msgp.ErrOverflow(uint64(zb0014), uint64(encodedMaxAccounts))
+			if zb0016 > encodedMaxAccounts {
+				err = msgp.ErrOverflow(uint64(zb0016), uint64(encodedMaxAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "Accounts")
 				return
 			}
-			if zb0015 {
+			if zb0017 {
 				(*z).ApplicationCallTxnFields.Accounts = nil
-			} else if (*z).ApplicationCallTxnFields.Accounts != nil && cap((*z).ApplicationCallTxnFields.Accounts) >= zb0014 {
-				(*z).ApplicationCallTxnFields.Accounts = ((*z).ApplicationCallTxnFields.Accounts)[:zb0014]
+			} else if (*z).ApplicationCallTxnFields.Accounts != nil && cap((*z).ApplicationCallTxnFields.Accounts) >= zb0016 {
+				(*z).ApplicationCallTxnFields.Accounts = ((*z).ApplicationCallTxnFields.Accounts)[:zb0016]
 			} else {
-				(*z).ApplicationCallTxnFields.Accounts = make([]basics.Address, zb0014)
+				(*z).ApplicationCallTxnFields.Accounts = make([]basics.Address, zb0016)
 			}
 			for zb0003 := range (*z).ApplicationCallTxnFields.Accounts {
 				bts, err = (*z).ApplicationCallTxnFields.Accounts[zb0003].UnmarshalMsg(bts)
@@ -5676,24 +6480,24 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0007 > 0 {
 			zb0007--
-			var zb0016 int
-			var zb0017 bool
-			zb0016, zb0017, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0018 int
+			var zb0019 bool
+			zb0018, zb0019, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ForeignApps")
 				return
 			}
-			if zb0016 > encodedMaxForeignApps {
-				err = msgp.ErrOverflow(uint64(zb0016), uint64(encodedMaxForeignApps))
+			if zb0018 > encodedMaxForeignApps {
+				err = msgp.ErrOverflow(uint64(zb0018), uint64(encodedMaxForeignApps))
 				err = msgp.WrapError(err, "struct-from-array", "ForeignApps")
 				return
 			}
-			if zb0017 {
+			if zb0019 {
 				(*z).ApplicationCallTxnFields.ForeignApps = nil
-			} else if (*z).ApplicationCallTxnFields.ForeignApps != nil && cap((*z).ApplicationCallTxnFields.ForeignApps) >= zb0016 {
-				(*z).ApplicationCallTxnFields.ForeignApps = ((*z).ApplicationCallTxnFields.ForeignApps)[:zb0016]
+			} else if (*z).ApplicationCallTxnFields.ForeignApps != nil && cap((*z).ApplicationCallTxnFields.ForeignApps) >= zb0018 {
+				(*z).ApplicationCallTxnFields.ForeignApps = ((*z).ApplicationCallTxnFields.ForeignApps)[:zb0018]
 			} else {
-				(*z).ApplicationCallTxnFields.ForeignApps = make([]basics.AppIndex, zb0016)
+				(*z).ApplicationCallTxnFields.ForeignApps = make([]basics.AppIndex, zb0018)
 			}
 			for zb0004 := range (*z).ApplicationCallTxnFields.ForeignApps {
 				bts, err = (*z).ApplicationCallTxnFields.ForeignApps[zb0004].UnmarshalMsg(bts)
@@ -5705,53 +6509,61 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0007 > 0 {
 			zb0007--
-			var zb0018 int
-			var zb0019 bool
-			zb0018, zb0019, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0020 int
+			var zb0021 bool
+			zb0020, zb0021, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Boxes")
 				return
 			}
-			if zb0018 > encodedMaxBoxes {
-				err = msgp.ErrOverflow(uint64(zb0018), uint64(encodedMaxBoxes))
+			if zb0020 > encodedMaxBoxes {
+				err = msgp.ErrOverflow(uint64(zb0020), uint64(encodedMaxBoxes))
 				err = msgp.WrapError(err, "struct-from-array", "Boxes")
 				return
 			}
-			if zb0019 {
+			if zb0021 {
 				(*z).ApplicationCallTxnFields.Boxes = nil
-			} else if (*z).ApplicationCallTxnFields.Boxes != nil && cap((*z).ApplicationCallTxnFields.Boxes) >= zb0018 {
-				(*z).ApplicationCallTxnFields.Boxes = ((*z).ApplicationCallTxnFields.Boxes)[:zb0018]
+			} else if (*z).ApplicationCallTxnFields.Boxes != nil && cap((*z).ApplicationCallTxnFields.Boxes) >= zb0020 {
+				(*z).ApplicationCallTxnFields.Boxes = ((*z).ApplicationCallTxnFields.Boxes)[:zb0020]
 			} else {
-				(*z).ApplicationCallTxnFields.Boxes = make([]BoxRef, zb0018)
+				(*z).ApplicationCallTxnFields.Boxes = make([]BoxRef, zb0020)
 			}
 			for zb0005 := range (*z).ApplicationCallTxnFields.Boxes {
-				var zb0020 int
-				var zb0021 bool
-				zb0020, zb0021, bts, err = msgp.ReadMapHeaderBytes(bts)
+				var zb0022 int
+				var zb0024 string
+				var zb0025 bool
+				var zb0023 bool
+				_ = zb0024
+				_ = zb0025
+				zb0022, zb0023, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0020, zb0021, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0022, zb0023, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0005)
 						return
 					}
-					if zb0020 > 0 {
-						zb0020--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0022 > 0 {
+						zb0022--
 						(*z).ApplicationCallTxnFields.Boxes[zb0005].Index, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0005, "struct-from-array", "Index")
 							return
 						}
 					}
-					if zb0020 > 0 {
-						zb0020--
-						var zb0022 int
-						zb0022, err = msgp.ReadBytesBytesHeader(bts)
+					if zb0022 > 0 {
+						zb0022--
+						var zb0026 int
+						zb0026, err = msgp.ReadBytesBytesHeader(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0005, "struct-from-array", "Name")
 							return
 						}
-						if zb0022 > config.MaxBytesKeyValueLen {
-							err = msgp.ErrOverflow(uint64(zb0022), uint64(config.MaxBytesKeyValueLen))
+						if zb0026 > config.MaxBytesKeyValueLen {
+							err = msgp.ErrOverflow(uint64(zb0026), uint64(config.MaxBytesKeyValueLen))
 							return
 						}
 						(*z).ApplicationCallTxnFields.Boxes[zb0005].Name, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.Boxes[zb0005].Name)
@@ -5760,8 +6572,8 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
-					if zb0020 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0020)
+					if zb0022 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0022)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0005, "struct-from-array")
 							return
@@ -5772,11 +6584,11 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0005)
 						return
 					}
-					if zb0021 {
+					if zb0023 {
 						(*z).ApplicationCallTxnFields.Boxes[zb0005] = BoxRef{}
 					}
-					for zb0020 > 0 {
-						zb0020--
+					for zb0022 > 0 {
+						zb0022--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0005)
@@ -5784,20 +6596,29 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "i":
+							if validate && zb0025 && "i" < zb0024 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).ApplicationCallTxnFields.Boxes[zb0005].Index, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0005, "Index")
 								return
 							}
+							zb0024 = "i"
 						case "n":
-							var zb0023 int
-							zb0023, err = msgp.ReadBytesBytesHeader(bts)
+							if validate && zb0025 && "n" < zb0024 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
+							var zb0027 int
+							zb0027, err = msgp.ReadBytesBytesHeader(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0005, "Name")
 								return
 							}
-							if zb0023 > config.MaxBytesKeyValueLen {
-								err = msgp.ErrOverflow(uint64(zb0023), uint64(config.MaxBytesKeyValueLen))
+							if zb0027 > config.MaxBytesKeyValueLen {
+								err = msgp.ErrOverflow(uint64(zb0027), uint64(config.MaxBytesKeyValueLen))
 								return
 							}
 							(*z).ApplicationCallTxnFields.Boxes[zb0005].Name, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.Boxes[zb0005].Name)
@@ -5805,6 +6626,7 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0005, "Name")
 								return
 							}
+							zb0024 = "n"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -5812,30 +6634,31 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0025 = true
 					}
 				}
 			}
 		}
 		if zb0007 > 0 {
 			zb0007--
-			var zb0024 int
-			var zb0025 bool
-			zb0024, zb0025, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0028 int
+			var zb0029 bool
+			zb0028, zb0029, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ForeignAssets")
 				return
 			}
-			if zb0024 > encodedMaxForeignAssets {
-				err = msgp.ErrOverflow(uint64(zb0024), uint64(encodedMaxForeignAssets))
+			if zb0028 > encodedMaxForeignAssets {
+				err = msgp.ErrOverflow(uint64(zb0028), uint64(encodedMaxForeignAssets))
 				err = msgp.WrapError(err, "struct-from-array", "ForeignAssets")
 				return
 			}
-			if zb0025 {
+			if zb0029 {
 				(*z).ApplicationCallTxnFields.ForeignAssets = nil
-			} else if (*z).ApplicationCallTxnFields.ForeignAssets != nil && cap((*z).ApplicationCallTxnFields.ForeignAssets) >= zb0024 {
-				(*z).ApplicationCallTxnFields.ForeignAssets = ((*z).ApplicationCallTxnFields.ForeignAssets)[:zb0024]
+			} else if (*z).ApplicationCallTxnFields.ForeignAssets != nil && cap((*z).ApplicationCallTxnFields.ForeignAssets) >= zb0028 {
+				(*z).ApplicationCallTxnFields.ForeignAssets = ((*z).ApplicationCallTxnFields.ForeignAssets)[:zb0028]
 			} else {
-				(*z).ApplicationCallTxnFields.ForeignAssets = make([]basics.AssetIndex, zb0024)
+				(*z).ApplicationCallTxnFields.ForeignAssets = make([]basics.AssetIndex, zb0028)
 			}
 			for zb0006 := range (*z).ApplicationCallTxnFields.ForeignAssets {
 				bts, err = (*z).ApplicationCallTxnFields.ForeignAssets[zb0006].UnmarshalMsg(bts)
@@ -5863,14 +6686,14 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0007 > 0 {
 			zb0007--
-			var zb0026 int
-			zb0026, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0030 int
+			zb0030, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ApprovalProgram")
 				return
 			}
-			if zb0026 > config.MaxAvailableAppProgramLen {
-				err = msgp.ErrOverflow(uint64(zb0026), uint64(config.MaxAvailableAppProgramLen))
+			if zb0030 > config.MaxAvailableAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0030), uint64(config.MaxAvailableAppProgramLen))
 				return
 			}
 			(*z).ApplicationCallTxnFields.ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.ApprovalProgram)
@@ -5881,14 +6704,14 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0007 > 0 {
 			zb0007--
-			var zb0027 int
-			zb0027, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0031 int
+			zb0031, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ClearStateProgram")
 				return
 			}
-			if zb0027 > config.MaxAvailableAppProgramLen {
-				err = msgp.ErrOverflow(uint64(zb0027), uint64(config.MaxAvailableAppProgramLen))
+			if zb0031 > config.MaxAvailableAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0031), uint64(config.MaxAvailableAppProgramLen))
 				return
 			}
 			(*z).ApplicationCallTxnFields.ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.ClearStateProgram)
@@ -5953,44 +6776,73 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "type":
+				if validate && zb0010 && "type" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Type.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Type")
 					return
 				}
+				zb0009 = "type"
 			case "snd":
+				if validate && zb0010 && "snd" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Header.Sender.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sender")
 					return
 				}
+				zb0009 = "snd"
 			case "fee":
+				if validate && zb0010 && "fee" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Header.Fee.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Fee")
 					return
 				}
+				zb0009 = "fee"
 			case "fv":
+				if validate && zb0010 && "fv" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Header.FirstValid.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FirstValid")
 					return
 				}
+				zb0009 = "fv"
 			case "lv":
+				if validate && zb0010 && "lv" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Header.LastValid.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "LastValid")
 					return
 				}
+				zb0009 = "lv"
 			case "note":
-				var zb0028 int
-				zb0028, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0010 && "note" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0032 int
+				zb0032, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Note")
 					return
 				}
-				if zb0028 > config.MaxTxnNoteBytes {
-					err = msgp.ErrOverflow(uint64(zb0028), uint64(config.MaxTxnNoteBytes))
+				if zb0032 > config.MaxTxnNoteBytes {
+					err = msgp.ErrOverflow(uint64(zb0032), uint64(config.MaxTxnNoteBytes))
 					return
 				}
 				(*z).Header.Note, bts, err = msgp.ReadBytesBytes(bts, (*z).Header.Note)
@@ -5998,15 +6850,20 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "Note")
 					return
 				}
+				zb0009 = "note"
 			case "gen":
-				var zb0029 int
-				zb0029, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0010 && "gen" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0033 int
+				zb0033, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
-				if zb0029 > config.MaxGenesisIDLen {
-					err = msgp.ErrOverflow(uint64(zb0029), uint64(config.MaxGenesisIDLen))
+				if zb0033 > config.MaxGenesisIDLen {
+					err = msgp.ErrOverflow(uint64(zb0033), uint64(config.MaxGenesisIDLen))
 					return
 				}
 				(*z).Header.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -6014,185 +6871,320 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
+				zb0009 = "gen"
 			case "gh":
+				if validate && zb0010 && "gh" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Header.GenesisHash.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GenesisHash")
 					return
 				}
+				zb0009 = "gh"
 			case "grp":
+				if validate && zb0010 && "grp" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Header.Group.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Group")
 					return
 				}
+				zb0009 = "grp"
 			case "lx":
+				if validate && zb0010 && "lx" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).Header.Lease)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "Lease")
 					return
 				}
+				zb0009 = "lx"
 			case "rekey":
+				if validate && zb0010 && "rekey" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Header.RekeyTo.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RekeyTo")
 					return
 				}
+				zb0009 = "rekey"
 			case "votekey":
+				if validate && zb0010 && "votekey" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).KeyregTxnFields.VotePK.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VotePK")
 					return
 				}
+				zb0009 = "votekey"
 			case "selkey":
+				if validate && zb0010 && "selkey" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).KeyregTxnFields.SelectionPK.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SelectionPK")
 					return
 				}
+				zb0009 = "selkey"
 			case "sprfkey":
+				if validate && zb0010 && "sprfkey" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).KeyregTxnFields.StateProofPK.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofPK")
 					return
 				}
+				zb0009 = "sprfkey"
 			case "votefst":
+				if validate && zb0010 && "votefst" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).KeyregTxnFields.VoteFirst.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteFirst")
 					return
 				}
+				zb0009 = "votefst"
 			case "votelst":
+				if validate && zb0010 && "votelst" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).KeyregTxnFields.VoteLast.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteLast")
 					return
 				}
+				zb0009 = "votelst"
 			case "votekd":
+				if validate && zb0010 && "votekd" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).KeyregTxnFields.VoteKeyDilution, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteKeyDilution")
 					return
 				}
+				zb0009 = "votekd"
 			case "nonpart":
+				if validate && zb0010 && "nonpart" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).KeyregTxnFields.Nonparticipation, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Nonparticipation")
 					return
 				}
+				zb0009 = "nonpart"
 			case "rcv":
+				if validate && zb0010 && "rcv" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).PaymentTxnFields.Receiver.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Receiver")
 					return
 				}
+				zb0009 = "rcv"
 			case "amt":
+				if validate && zb0010 && "amt" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).PaymentTxnFields.Amount.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Amount")
 					return
 				}
+				zb0009 = "amt"
 			case "close":
+				if validate && zb0010 && "close" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).PaymentTxnFields.CloseRemainderTo.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "CloseRemainderTo")
 					return
 				}
+				zb0009 = "close"
 			case "caid":
+				if validate && zb0010 && "caid" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AssetConfigTxnFields.ConfigAsset.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ConfigAsset")
 					return
 				}
+				zb0009 = "caid"
 			case "apar":
+				if validate && zb0010 && "apar" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AssetConfigTxnFields.AssetParams.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetParams")
 					return
 				}
+				zb0009 = "apar"
 			case "xaid":
+				if validate && zb0010 && "xaid" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AssetTransferTxnFields.XferAsset.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "XferAsset")
 					return
 				}
+				zb0009 = "xaid"
 			case "aamt":
+				if validate && zb0010 && "aamt" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).AssetTransferTxnFields.AssetAmount, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetAmount")
 					return
 				}
+				zb0009 = "aamt"
 			case "asnd":
+				if validate && zb0010 && "asnd" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AssetTransferTxnFields.AssetSender.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetSender")
 					return
 				}
+				zb0009 = "asnd"
 			case "arcv":
+				if validate && zb0010 && "arcv" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AssetTransferTxnFields.AssetReceiver.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetReceiver")
 					return
 				}
+				zb0009 = "arcv"
 			case "aclose":
+				if validate && zb0010 && "aclose" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AssetTransferTxnFields.AssetCloseTo.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetCloseTo")
 					return
 				}
+				zb0009 = "aclose"
 			case "fadd":
+				if validate && zb0010 && "fadd" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AssetFreezeTxnFields.FreezeAccount.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FreezeAccount")
 					return
 				}
+				zb0009 = "fadd"
 			case "faid":
+				if validate && zb0010 && "faid" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AssetFreezeTxnFields.FreezeAsset.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "FreezeAsset")
 					return
 				}
+				zb0009 = "faid"
 			case "afrz":
+				if validate && zb0010 && "afrz" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).AssetFreezeTxnFields.AssetFrozen, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetFrozen")
 					return
 				}
+				zb0009 = "afrz"
 			case "apid":
+				if validate && zb0010 && "apid" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ApplicationCallTxnFields.ApplicationID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ApplicationID")
 					return
 				}
+				zb0009 = "apid"
 			case "apan":
+				if validate && zb0010 && "apan" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0030 uint64
-					zb0030, bts, err = msgp.ReadUint64Bytes(bts)
+					var zb0034 uint64
+					zb0034, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "OnCompletion")
 						return
 					}
-					(*z).ApplicationCallTxnFields.OnCompletion = OnCompletion(zb0030)
+					(*z).ApplicationCallTxnFields.OnCompletion = OnCompletion(zb0034)
 				}
+				zb0009 = "apan"
 			case "apaa":
-				var zb0031 int
-				var zb0032 bool
-				zb0031, zb0032, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0010 && "apaa" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0035 int
+				var zb0036 bool
+				zb0035, zb0036, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ApplicationArgs")
 					return
 				}
-				if zb0031 > encodedMaxApplicationArgs {
-					err = msgp.ErrOverflow(uint64(zb0031), uint64(encodedMaxApplicationArgs))
+				if zb0035 > encodedMaxApplicationArgs {
+					err = msgp.ErrOverflow(uint64(zb0035), uint64(encodedMaxApplicationArgs))
 					err = msgp.WrapError(err, "ApplicationArgs")
 					return
 				}
-				if zb0032 {
+				if zb0036 {
 					(*z).ApplicationCallTxnFields.ApplicationArgs = nil
-				} else if (*z).ApplicationCallTxnFields.ApplicationArgs != nil && cap((*z).ApplicationCallTxnFields.ApplicationArgs) >= zb0031 {
-					(*z).ApplicationCallTxnFields.ApplicationArgs = ((*z).ApplicationCallTxnFields.ApplicationArgs)[:zb0031]
+				} else if (*z).ApplicationCallTxnFields.ApplicationArgs != nil && cap((*z).ApplicationCallTxnFields.ApplicationArgs) >= zb0035 {
+					(*z).ApplicationCallTxnFields.ApplicationArgs = ((*z).ApplicationCallTxnFields.ApplicationArgs)[:zb0035]
 				} else {
-					(*z).ApplicationCallTxnFields.ApplicationArgs = make([][]byte, zb0031)
+					(*z).ApplicationCallTxnFields.ApplicationArgs = make([][]byte, zb0035)
 				}
 				for zb0002 := range (*z).ApplicationCallTxnFields.ApplicationArgs {
 					(*z).ApplicationCallTxnFields.ApplicationArgs[zb0002], bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.ApplicationArgs[zb0002])
@@ -6201,25 +7193,30 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0009 = "apaa"
 			case "apat":
-				var zb0033 int
-				var zb0034 bool
-				zb0033, zb0034, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0010 && "apat" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0037 int
+				var zb0038 bool
+				zb0037, zb0038, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Accounts")
 					return
 				}
-				if zb0033 > encodedMaxAccounts {
-					err = msgp.ErrOverflow(uint64(zb0033), uint64(encodedMaxAccounts))
+				if zb0037 > encodedMaxAccounts {
+					err = msgp.ErrOverflow(uint64(zb0037), uint64(encodedMaxAccounts))
 					err = msgp.WrapError(err, "Accounts")
 					return
 				}
-				if zb0034 {
+				if zb0038 {
 					(*z).ApplicationCallTxnFields.Accounts = nil
-				} else if (*z).ApplicationCallTxnFields.Accounts != nil && cap((*z).ApplicationCallTxnFields.Accounts) >= zb0033 {
-					(*z).ApplicationCallTxnFields.Accounts = ((*z).ApplicationCallTxnFields.Accounts)[:zb0033]
+				} else if (*z).ApplicationCallTxnFields.Accounts != nil && cap((*z).ApplicationCallTxnFields.Accounts) >= zb0037 {
+					(*z).ApplicationCallTxnFields.Accounts = ((*z).ApplicationCallTxnFields.Accounts)[:zb0037]
 				} else {
-					(*z).ApplicationCallTxnFields.Accounts = make([]basics.Address, zb0033)
+					(*z).ApplicationCallTxnFields.Accounts = make([]basics.Address, zb0037)
 				}
 				for zb0003 := range (*z).ApplicationCallTxnFields.Accounts {
 					bts, err = (*z).ApplicationCallTxnFields.Accounts[zb0003].UnmarshalMsg(bts)
@@ -6228,25 +7225,30 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0009 = "apat"
 			case "apfa":
-				var zb0035 int
-				var zb0036 bool
-				zb0035, zb0036, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0010 && "apfa" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0039 int
+				var zb0040 bool
+				zb0039, zb0040, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ForeignApps")
 					return
 				}
-				if zb0035 > encodedMaxForeignApps {
-					err = msgp.ErrOverflow(uint64(zb0035), uint64(encodedMaxForeignApps))
+				if zb0039 > encodedMaxForeignApps {
+					err = msgp.ErrOverflow(uint64(zb0039), uint64(encodedMaxForeignApps))
 					err = msgp.WrapError(err, "ForeignApps")
 					return
 				}
-				if zb0036 {
+				if zb0040 {
 					(*z).ApplicationCallTxnFields.ForeignApps = nil
-				} else if (*z).ApplicationCallTxnFields.ForeignApps != nil && cap((*z).ApplicationCallTxnFields.ForeignApps) >= zb0035 {
-					(*z).ApplicationCallTxnFields.ForeignApps = ((*z).ApplicationCallTxnFields.ForeignApps)[:zb0035]
+				} else if (*z).ApplicationCallTxnFields.ForeignApps != nil && cap((*z).ApplicationCallTxnFields.ForeignApps) >= zb0039 {
+					(*z).ApplicationCallTxnFields.ForeignApps = ((*z).ApplicationCallTxnFields.ForeignApps)[:zb0039]
 				} else {
-					(*z).ApplicationCallTxnFields.ForeignApps = make([]basics.AppIndex, zb0035)
+					(*z).ApplicationCallTxnFields.ForeignApps = make([]basics.AppIndex, zb0039)
 				}
 				for zb0004 := range (*z).ApplicationCallTxnFields.ForeignApps {
 					bts, err = (*z).ApplicationCallTxnFields.ForeignApps[zb0004].UnmarshalMsg(bts)
@@ -6255,54 +7257,67 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0009 = "apfa"
 			case "apbx":
-				var zb0037 int
-				var zb0038 bool
-				zb0037, zb0038, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0010 && "apbx" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0041 int
+				var zb0042 bool
+				zb0041, zb0042, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Boxes")
 					return
 				}
-				if zb0037 > encodedMaxBoxes {
-					err = msgp.ErrOverflow(uint64(zb0037), uint64(encodedMaxBoxes))
+				if zb0041 > encodedMaxBoxes {
+					err = msgp.ErrOverflow(uint64(zb0041), uint64(encodedMaxBoxes))
 					err = msgp.WrapError(err, "Boxes")
 					return
 				}
-				if zb0038 {
+				if zb0042 {
 					(*z).ApplicationCallTxnFields.Boxes = nil
-				} else if (*z).ApplicationCallTxnFields.Boxes != nil && cap((*z).ApplicationCallTxnFields.Boxes) >= zb0037 {
-					(*z).ApplicationCallTxnFields.Boxes = ((*z).ApplicationCallTxnFields.Boxes)[:zb0037]
+				} else if (*z).ApplicationCallTxnFields.Boxes != nil && cap((*z).ApplicationCallTxnFields.Boxes) >= zb0041 {
+					(*z).ApplicationCallTxnFields.Boxes = ((*z).ApplicationCallTxnFields.Boxes)[:zb0041]
 				} else {
-					(*z).ApplicationCallTxnFields.Boxes = make([]BoxRef, zb0037)
+					(*z).ApplicationCallTxnFields.Boxes = make([]BoxRef, zb0041)
 				}
 				for zb0005 := range (*z).ApplicationCallTxnFields.Boxes {
-					var zb0039 int
-					var zb0040 bool
-					zb0039, zb0040, bts, err = msgp.ReadMapHeaderBytes(bts)
+					var zb0043 int
+					var zb0045 string
+					var zb0046 bool
+					var zb0044 bool
+					_ = zb0045
+					_ = zb0046
+					zb0043, zb0044, bts, err = msgp.ReadMapHeaderBytes(bts)
 					if _, ok := err.(msgp.TypeError); ok {
-						zb0039, zb0040, bts, err = msgp.ReadArrayHeaderBytes(bts)
+						zb0043, zb0044, bts, err = msgp.ReadArrayHeaderBytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Boxes", zb0005)
 							return
 						}
-						if zb0039 > 0 {
-							zb0039--
+						if validate {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
+						if zb0043 > 0 {
+							zb0043--
 							(*z).ApplicationCallTxnFields.Boxes[zb0005].Index, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Boxes", zb0005, "struct-from-array", "Index")
 								return
 							}
 						}
-						if zb0039 > 0 {
-							zb0039--
-							var zb0041 int
-							zb0041, err = msgp.ReadBytesBytesHeader(bts)
+						if zb0043 > 0 {
+							zb0043--
+							var zb0047 int
+							zb0047, err = msgp.ReadBytesBytesHeader(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Boxes", zb0005, "struct-from-array", "Name")
 								return
 							}
-							if zb0041 > config.MaxBytesKeyValueLen {
-								err = msgp.ErrOverflow(uint64(zb0041), uint64(config.MaxBytesKeyValueLen))
+							if zb0047 > config.MaxBytesKeyValueLen {
+								err = msgp.ErrOverflow(uint64(zb0047), uint64(config.MaxBytesKeyValueLen))
 								return
 							}
 							(*z).ApplicationCallTxnFields.Boxes[zb0005].Name, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.Boxes[zb0005].Name)
@@ -6311,8 +7326,8 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
-						if zb0039 > 0 {
-							err = msgp.ErrTooManyArrayFields(zb0039)
+						if zb0043 > 0 {
+							err = msgp.ErrTooManyArrayFields(zb0043)
 							if err != nil {
 								err = msgp.WrapError(err, "Boxes", zb0005, "struct-from-array")
 								return
@@ -6323,11 +7338,11 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							err = msgp.WrapError(err, "Boxes", zb0005)
 							return
 						}
-						if zb0040 {
+						if zb0044 {
 							(*z).ApplicationCallTxnFields.Boxes[zb0005] = BoxRef{}
 						}
-						for zb0039 > 0 {
-							zb0039--
+						for zb0043 > 0 {
+							zb0043--
 							field, bts, err = msgp.ReadMapKeyZC(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Boxes", zb0005)
@@ -6335,20 +7350,29 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							}
 							switch string(field) {
 							case "i":
+								if validate && zb0046 && "i" < zb0045 {
+									err = &msgp.ErrNonCanonical{}
+									return
+								}
 								(*z).ApplicationCallTxnFields.Boxes[zb0005].Index, bts, err = msgp.ReadUint64Bytes(bts)
 								if err != nil {
 									err = msgp.WrapError(err, "Boxes", zb0005, "Index")
 									return
 								}
+								zb0045 = "i"
 							case "n":
-								var zb0042 int
-								zb0042, err = msgp.ReadBytesBytesHeader(bts)
+								if validate && zb0046 && "n" < zb0045 {
+									err = &msgp.ErrNonCanonical{}
+									return
+								}
+								var zb0048 int
+								zb0048, err = msgp.ReadBytesBytesHeader(bts)
 								if err != nil {
 									err = msgp.WrapError(err, "Boxes", zb0005, "Name")
 									return
 								}
-								if zb0042 > config.MaxBytesKeyValueLen {
-									err = msgp.ErrOverflow(uint64(zb0042), uint64(config.MaxBytesKeyValueLen))
+								if zb0048 > config.MaxBytesKeyValueLen {
+									err = msgp.ErrOverflow(uint64(zb0048), uint64(config.MaxBytesKeyValueLen))
 									return
 								}
 								(*z).ApplicationCallTxnFields.Boxes[zb0005].Name, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.Boxes[zb0005].Name)
@@ -6356,6 +7380,7 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 									err = msgp.WrapError(err, "Boxes", zb0005, "Name")
 									return
 								}
+								zb0045 = "n"
 							default:
 								err = msgp.ErrNoField(string(field))
 								if err != nil {
@@ -6363,28 +7388,34 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 									return
 								}
 							}
+							zb0046 = true
 						}
 					}
 				}
+				zb0009 = "apbx"
 			case "apas":
-				var zb0043 int
-				var zb0044 bool
-				zb0043, zb0044, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0010 && "apas" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0049 int
+				var zb0050 bool
+				zb0049, zb0050, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ForeignAssets")
 					return
 				}
-				if zb0043 > encodedMaxForeignAssets {
-					err = msgp.ErrOverflow(uint64(zb0043), uint64(encodedMaxForeignAssets))
+				if zb0049 > encodedMaxForeignAssets {
+					err = msgp.ErrOverflow(uint64(zb0049), uint64(encodedMaxForeignAssets))
 					err = msgp.WrapError(err, "ForeignAssets")
 					return
 				}
-				if zb0044 {
+				if zb0050 {
 					(*z).ApplicationCallTxnFields.ForeignAssets = nil
-				} else if (*z).ApplicationCallTxnFields.ForeignAssets != nil && cap((*z).ApplicationCallTxnFields.ForeignAssets) >= zb0043 {
-					(*z).ApplicationCallTxnFields.ForeignAssets = ((*z).ApplicationCallTxnFields.ForeignAssets)[:zb0043]
+				} else if (*z).ApplicationCallTxnFields.ForeignAssets != nil && cap((*z).ApplicationCallTxnFields.ForeignAssets) >= zb0049 {
+					(*z).ApplicationCallTxnFields.ForeignAssets = ((*z).ApplicationCallTxnFields.ForeignAssets)[:zb0049]
 				} else {
-					(*z).ApplicationCallTxnFields.ForeignAssets = make([]basics.AssetIndex, zb0043)
+					(*z).ApplicationCallTxnFields.ForeignAssets = make([]basics.AssetIndex, zb0049)
 				}
 				for zb0006 := range (*z).ApplicationCallTxnFields.ForeignAssets {
 					bts, err = (*z).ApplicationCallTxnFields.ForeignAssets[zb0006].UnmarshalMsg(bts)
@@ -6393,27 +7424,42 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0009 = "apas"
 			case "apls":
+				if validate && zb0010 && "apls" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ApplicationCallTxnFields.LocalStateSchema.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "LocalStateSchema")
 					return
 				}
+				zb0009 = "apls"
 			case "apgs":
+				if validate && zb0010 && "apgs" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).ApplicationCallTxnFields.GlobalStateSchema.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GlobalStateSchema")
 					return
 				}
+				zb0009 = "apgs"
 			case "apap":
-				var zb0045 int
-				zb0045, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0010 && "apap" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0051 int
+				zb0051, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ApprovalProgram")
 					return
 				}
-				if zb0045 > config.MaxAvailableAppProgramLen {
-					err = msgp.ErrOverflow(uint64(zb0045), uint64(config.MaxAvailableAppProgramLen))
+				if zb0051 > config.MaxAvailableAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0051), uint64(config.MaxAvailableAppProgramLen))
 					return
 				}
 				(*z).ApplicationCallTxnFields.ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.ApprovalProgram)
@@ -6421,15 +7467,20 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "ApprovalProgram")
 					return
 				}
+				zb0009 = "apap"
 			case "apsu":
-				var zb0046 int
-				zb0046, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0010 && "apsu" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0052 int
+				zb0052, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ClearStateProgram")
 					return
 				}
-				if zb0046 > config.MaxAvailableAppProgramLen {
-					err = msgp.ErrOverflow(uint64(zb0046), uint64(config.MaxAvailableAppProgramLen))
+				if zb0052 > config.MaxAvailableAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0052), uint64(config.MaxAvailableAppProgramLen))
 					return
 				}
 				(*z).ApplicationCallTxnFields.ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.ClearStateProgram)
@@ -6437,30 +7488,51 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "ClearStateProgram")
 					return
 				}
+				zb0009 = "apsu"
 			case "apep":
+				if validate && zb0010 && "apep" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).ApplicationCallTxnFields.ExtraProgramPages, bts, err = msgp.ReadUint32Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ExtraProgramPages")
 					return
 				}
+				zb0009 = "apep"
 			case "sptype":
+				if validate && zb0010 && "sptype" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).StateProofTxnFields.StateProofType.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofType")
 					return
 				}
+				zb0009 = "sptype"
 			case "sp":
+				if validate && zb0010 && "sp" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).StateProofTxnFields.StateProof.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProof")
 					return
 				}
+				zb0009 = "sp"
 			case "spmsg":
+				if validate && zb0010 && "spmsg" < zb0009 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).StateProofTxnFields.Message.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Message")
 					return
 				}
+				zb0009 = "spmsg"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -6468,12 +7540,19 @@ func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0010 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *Transaction) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Transaction) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Transaction) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Transaction)
 	return ok
@@ -6568,11 +7647,15 @@ func (_ *TxGroup) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *TxGroup) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *TxGroup) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -6580,26 +7663,30 @@ func (z *TxGroup) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0004 int
-			var zb0005 bool
-			zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0006 int
+			var zb0007 bool
+			zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "TxGroupHashes")
 				return
 			}
-			if zb0004 > config.MaxTxGroupSize {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(config.MaxTxGroupSize))
+			if zb0006 > config.MaxTxGroupSize {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxTxGroupSize))
 				err = msgp.WrapError(err, "struct-from-array", "TxGroupHashes")
 				return
 			}
-			if zb0005 {
+			if zb0007 {
 				(*z).TxGroupHashes = nil
-			} else if (*z).TxGroupHashes != nil && cap((*z).TxGroupHashes) >= zb0004 {
-				(*z).TxGroupHashes = ((*z).TxGroupHashes)[:zb0004]
+			} else if (*z).TxGroupHashes != nil && cap((*z).TxGroupHashes) >= zb0006 {
+				(*z).TxGroupHashes = ((*z).TxGroupHashes)[:zb0006]
 			} else {
-				(*z).TxGroupHashes = make([]crypto.Digest, zb0004)
+				(*z).TxGroupHashes = make([]crypto.Digest, zb0006)
 			}
 			for zb0001 := range (*z).TxGroupHashes {
 				bts, err = (*z).TxGroupHashes[zb0001].UnmarshalMsg(bts)
@@ -6633,24 +7720,28 @@ func (z *TxGroup) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "txlist":
-				var zb0006 int
-				var zb0007 bool
-				zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0005 && "txlist" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0008 int
+				var zb0009 bool
+				zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TxGroupHashes")
 					return
 				}
-				if zb0006 > config.MaxTxGroupSize {
-					err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxTxGroupSize))
+				if zb0008 > config.MaxTxGroupSize {
+					err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxTxGroupSize))
 					err = msgp.WrapError(err, "TxGroupHashes")
 					return
 				}
-				if zb0007 {
+				if zb0009 {
 					(*z).TxGroupHashes = nil
-				} else if (*z).TxGroupHashes != nil && cap((*z).TxGroupHashes) >= zb0006 {
-					(*z).TxGroupHashes = ((*z).TxGroupHashes)[:zb0006]
+				} else if (*z).TxGroupHashes != nil && cap((*z).TxGroupHashes) >= zb0008 {
+					(*z).TxGroupHashes = ((*z).TxGroupHashes)[:zb0008]
 				} else {
-					(*z).TxGroupHashes = make([]crypto.Digest, zb0006)
+					(*z).TxGroupHashes = make([]crypto.Digest, zb0008)
 				}
 				for zb0001 := range (*z).TxGroupHashes {
 					bts, err = (*z).TxGroupHashes[zb0001].UnmarshalMsg(bts)
@@ -6659,6 +7750,7 @@ func (z *TxGroup) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0004 = "txlist"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -6666,12 +7758,19 @@ func (z *TxGroup) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *TxGroup) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *TxGroup) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *TxGroup) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*TxGroup)
 	return ok
@@ -6711,6 +7810,9 @@ func (_ *Txid) CanMarshalMsg(z interface{}) bool {
 // UnmarshalMsg implements msgp.Unmarshaler
 func (z *Txid) UnmarshalMsg(bts []byte) ([]byte, error) {
 	return ((*(crypto.Digest))(z)).UnmarshalMsg(bts)
+}
+func (z *Txid) UnmarshalValidateMsg(bts []byte) ([]byte, error) {
+	return ((*(crypto.Digest))(z)).UnmarshalValidateMsg(bts)
 }
 func (_ *Txid) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Txid)

--- a/data/transactions/msgp_gen.go
+++ b/data/transactions/msgp_gen.go
@@ -2160,7 +2160,11 @@ func (z *EvalDelta) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "LocalDeltas", zb0001)
 					return
 				}
+				if SortUint64([]uint64{prev,zb0001}).Less(0,1) {
+					notCanonical = true // !!! uh oh!!
+				}
 				(*z).LocalDeltas[zb0001] = zb0002
+				prev = zb0001
 			}
 		}
 		if zb0006 > 0 {

--- a/data/transactions/sort.go
+++ b/data/transactions/sort.go
@@ -20,20 +20,22 @@ package transactions
 // canonical encoding of maps in msgpack format.
 //
 //msgp:ignore SortUint64
-//msgp:sort uint64 SortUint64
+//msgp:sort uint64 SortUint64 Uint64Less
 type SortUint64 []uint64
 
 func (a SortUint64) Len() int           { return len(a) }
 func (a SortUint64) Less(i, j int) bool { return a[i] < a[j] }
 func (a SortUint64) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func Uint64Less(a, b uint64) bool       { return a < b }
 
 // SortString implements sorting by string keys for
 // canonical encoding of maps in msgpack format.
 //
 //msgp:ignore SortString
-//msgp:sort string SortString
+//msgp:sort string SortString StringLess
 type SortString []string
 
 func (a SortString) Len() int           { return len(a) }
 func (a SortString) Less(i, j int) bool { return a[i] < a[j] }
 func (a SortString) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func StringLess(a, b string) bool       { return a < b }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/algorand/go-deadlock v0.2.2
 	github.com/algorand/go-sumhash v0.1.0
 	github.com/algorand/graphtrace v0.1.0
-	github.com/algorand/msgp v1.1.55
+	github.com/algorand/msgp v1.1.56-0.20230721170557-eeedb47bc66f
 	github.com/algorand/oapi-codegen v1.12.0-algorand.0
 	github.com/algorand/sortition v1.0.0
 	github.com/algorand/websocket v1.4.6

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/algorand/go-sumhash v0.1.0 h1:b/QRhyLuF//vOcicBIxBXYW8bERNoeLxieht/dU
 github.com/algorand/go-sumhash v0.1.0/go.mod h1:OOe7jdDWUhLkuP1XytkK5gnLu9entAviN5DfDZh6XAc=
 github.com/algorand/graphtrace v0.1.0 h1:QemP1iT0W56SExD0NfiU6rsG34/v0Je6bg5UZnptEUM=
 github.com/algorand/graphtrace v0.1.0/go.mod h1:HscLQrzBdH1BH+5oehs3ICd8SYcXvnSL9BjfTu8WHCc=
-github.com/algorand/msgp v1.1.55 h1:kWc9Xc08xtxCTWUiq1cRW5XGF+DFcfSGihYf0IZ/ivs=
-github.com/algorand/msgp v1.1.55/go.mod h1:RqZQBzAFDWpwh5TlabzZkWy+6kwL9cvXfLbU0gD99EA=
+github.com/algorand/msgp v1.1.56-0.20230721170557-eeedb47bc66f h1:2RbW0uKBy3+r0ngvV58PUeAmo1VE6sE7gqzmpUUqm2M=
+github.com/algorand/msgp v1.1.56-0.20230721170557-eeedb47bc66f/go.mod h1:RqZQBzAFDWpwh5TlabzZkWy+6kwL9cvXfLbU0gD99EA=
 github.com/algorand/oapi-codegen v1.12.0-algorand.0 h1:W9PvED+wAJc+9EeXPONnA+0zE9UhynEqoDs4OgAxKhk=
 github.com/algorand/oapi-codegen v1.12.0-algorand.0/go.mod h1:tIWJ9K/qrLDVDt5A1p82UmxZIEGxv2X+uoujdhEAL48=
 github.com/algorand/sortition v1.0.0 h1:PJiZtdSTBm4nArQrZXBnhlljHXhuyAXRJBqVWowQu3E=

--- a/ledger/encoded/msgp_gen.go
+++ b/ledger/encoded/msgp_gen.go
@@ -15,6 +15,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -24,6 +25,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -33,6 +35,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -76,16 +79,24 @@ func (_ *BalanceRecordV5) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *BalanceRecordV5) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *BalanceRecordV5) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -128,17 +139,27 @@ func (z *BalanceRecordV5) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "pk":
+				if validate && zb0004 && "pk" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Address.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Address")
 					return
 				}
+				zb0003 = "pk"
 			case "ad":
+				if validate && zb0004 && "ad" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AccountData.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AccountData")
 					return
 				}
+				zb0003 = "ad"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -146,12 +167,19 @@ func (z *BalanceRecordV5) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *BalanceRecordV5) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *BalanceRecordV5) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *BalanceRecordV5) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*BalanceRecordV5)
 	return ok
@@ -245,16 +273,24 @@ func (_ *BalanceRecordV6) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *BalanceRecordV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *BalanceRecordV6) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -275,32 +311,42 @@ func (z *BalanceRecordV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0007 int
+			var zb0008 bool
+			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Resources")
 				return
 			}
-			if zb0005 > resourcesPerCatchpointFileChunkBackwardCompatible {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(resourcesPerCatchpointFileChunkBackwardCompatible))
+			if zb0007 > resourcesPerCatchpointFileChunkBackwardCompatible {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(resourcesPerCatchpointFileChunkBackwardCompatible))
 				err = msgp.WrapError(err, "struct-from-array", "Resources")
 				return
 			}
-			if zb0006 {
+			if zb0008 {
 				(*z).Resources = nil
 			} else if (*z).Resources == nil {
-				(*z).Resources = make(map[uint64]msgp.Raw, zb0005)
+				(*z).Resources = make(map[uint64]msgp.Raw, zb0007)
 			}
-			for zb0005 > 0 {
+			var zb0009 uint64
+			_ = zb0009
+			var zb0010 bool
+			_ = zb0010
+			for zb0007 > 0 {
 				var zb0001 uint64
 				var zb0002 msgp.Raw
-				zb0005--
+				zb0007--
 				zb0001, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Resources")
 					return
 				}
+				if validate && zb0010 && Uint64Less(zb0001, zb0009) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				zb0009 = zb0001
+				zb0010 = true
 				bts, err = zb0002.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Resources", zb0001)
@@ -341,44 +387,68 @@ func (z *BalanceRecordV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "a":
+				if validate && zb0006 && "a" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Address.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Address")
 					return
 				}
+				zb0005 = "a"
 			case "b":
+				if validate && zb0006 && "b" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AccountData.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AccountData")
 					return
 				}
+				zb0005 = "b"
 			case "c":
-				var zb0007 int
-				var zb0008 bool
-				zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0006 && "c" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0011 int
+				var zb0012 bool
+				zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Resources")
 					return
 				}
-				if zb0007 > resourcesPerCatchpointFileChunkBackwardCompatible {
-					err = msgp.ErrOverflow(uint64(zb0007), uint64(resourcesPerCatchpointFileChunkBackwardCompatible))
+				if zb0011 > resourcesPerCatchpointFileChunkBackwardCompatible {
+					err = msgp.ErrOverflow(uint64(zb0011), uint64(resourcesPerCatchpointFileChunkBackwardCompatible))
 					err = msgp.WrapError(err, "Resources")
 					return
 				}
-				if zb0008 {
+				if zb0012 {
 					(*z).Resources = nil
 				} else if (*z).Resources == nil {
-					(*z).Resources = make(map[uint64]msgp.Raw, zb0007)
+					(*z).Resources = make(map[uint64]msgp.Raw, zb0011)
 				}
-				for zb0007 > 0 {
+				var zb0013 uint64
+				_ = zb0013
+				var zb0014 bool
+				_ = zb0014
+				for zb0011 > 0 {
 					var zb0001 uint64
 					var zb0002 msgp.Raw
-					zb0007--
+					zb0011--
 					zb0001, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Resources")
 						return
 					}
+					if validate && zb0014 && Uint64Less(zb0001, zb0013) {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					zb0013 = zb0001
+					zb0014 = true
 					bts, err = zb0002.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Resources", zb0001)
@@ -386,12 +456,18 @@ func (z *BalanceRecordV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).Resources[zb0001] = zb0002
 				}
+				zb0005 = "c"
 			case "e":
+				if validate && zb0006 && "e" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).ExpectingMoreEntries, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ExpectingMoreEntries")
 					return
 				}
+				zb0005 = "e"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -399,12 +475,19 @@ func (z *BalanceRecordV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *BalanceRecordV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *BalanceRecordV6) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *BalanceRecordV6) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*BalanceRecordV6)
 	return ok
@@ -481,11 +564,15 @@ func (_ *KVRecordV6) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *KVRecordV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *KVRecordV6) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -493,16 +580,20 @@ func (z *KVRecordV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0001 > 0 {
 			zb0001--
-			var zb0003 int
-			zb0003, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0005 int
+			zb0005, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Key")
 				return
 			}
-			if zb0003 > KVRecordV6MaxKeyLength {
-				err = msgp.ErrOverflow(uint64(zb0003), uint64(KVRecordV6MaxKeyLength))
+			if zb0005 > KVRecordV6MaxKeyLength {
+				err = msgp.ErrOverflow(uint64(zb0005), uint64(KVRecordV6MaxKeyLength))
 				return
 			}
 			(*z).Key, bts, err = msgp.ReadBytesBytes(bts, (*z).Key)
@@ -513,14 +604,14 @@ func (z *KVRecordV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0001 > 0 {
 			zb0001--
-			var zb0004 int
-			zb0004, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0006 int
+			zb0006, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Value")
 				return
 			}
-			if zb0004 > KVRecordV6MaxValueLength {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(KVRecordV6MaxValueLength))
+			if zb0006 > KVRecordV6MaxValueLength {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(KVRecordV6MaxValueLength))
 				return
 			}
 			(*z).Value, bts, err = msgp.ReadBytesBytes(bts, (*z).Value)
@@ -553,14 +644,18 @@ func (z *KVRecordV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "k":
-				var zb0005 int
-				zb0005, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0004 && "k" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0007 int
+				zb0007, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Key")
 					return
 				}
-				if zb0005 > KVRecordV6MaxKeyLength {
-					err = msgp.ErrOverflow(uint64(zb0005), uint64(KVRecordV6MaxKeyLength))
+				if zb0007 > KVRecordV6MaxKeyLength {
+					err = msgp.ErrOverflow(uint64(zb0007), uint64(KVRecordV6MaxKeyLength))
 					return
 				}
 				(*z).Key, bts, err = msgp.ReadBytesBytes(bts, (*z).Key)
@@ -568,15 +663,20 @@ func (z *KVRecordV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "Key")
 					return
 				}
+				zb0003 = "k"
 			case "v":
-				var zb0006 int
-				zb0006, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0004 && "v" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0008 int
+				zb0008, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Value")
 					return
 				}
-				if zb0006 > KVRecordV6MaxValueLength {
-					err = msgp.ErrOverflow(uint64(zb0006), uint64(KVRecordV6MaxValueLength))
+				if zb0008 > KVRecordV6MaxValueLength {
+					err = msgp.ErrOverflow(uint64(zb0008), uint64(KVRecordV6MaxValueLength))
 					return
 				}
 				(*z).Value, bts, err = msgp.ReadBytesBytes(bts, (*z).Value)
@@ -584,6 +684,7 @@ func (z *KVRecordV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "Value")
 					return
 				}
+				zb0003 = "v"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -591,12 +692,19 @@ func (z *KVRecordV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *KVRecordV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *KVRecordV6) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *KVRecordV6) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*KVRecordV6)
 	return ok

--- a/ledger/encoded/recordsV6.go
+++ b/ledger/encoded/recordsV6.go
@@ -43,6 +43,9 @@ const (
 // encoding the resources map below.
 type SortUint64 = basics.SortUint64
 
+// Uint64Less is necessary for UnmarshalValidateMsg functionality
+func Uint64Less(a, b uint64) bool { return a < b }
+
 // BalanceRecordV6 is the encoded account balance record.
 type BalanceRecordV6 struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`

--- a/ledger/ledgercore/msgp_gen.go
+++ b/ledger/ledgercore/msgp_gen.go
@@ -15,6 +15,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -24,6 +25,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -33,6 +35,7 @@ import (
 //           |-----> (*) MarshalMsg
 //           |-----> (*) CanMarshalMsg
 //           |-----> (*) UnmarshalMsg
+//           |-----> (*) UnmarshalValidateMsg
 //           |-----> (*) CanUnmarshalMsg
 //           |-----> (*) Msgsize
 //           |-----> (*) MsgIsZero
@@ -42,6 +45,7 @@ import (
 //               |-----> (*) MarshalMsg
 //               |-----> (*) CanMarshalMsg
 //               |-----> (*) UnmarshalMsg
+//               |-----> (*) UnmarshalValidateMsg
 //               |-----> (*) CanUnmarshalMsg
 //               |-----> (*) Msgsize
 //               |-----> (*) MsgIsZero
@@ -169,11 +173,15 @@ func (_ *AccountTotals) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *AccountTotals) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -181,35 +189,47 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0001 > 0 {
 			zb0001--
-			var zb0003 int
-			var zb0004 bool
-			zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0005 int
+			var zb0007 string
+			var zb0008 bool
+			var zb0006 bool
+			_ = zb0007
+			_ = zb0008
+			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Online")
 					return
 				}
-				if zb0003 > 0 {
-					zb0003--
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0005 > 0 {
+					zb0005--
 					bts, err = (*z).Online.Money.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Online", "struct-from-array", "Money")
 						return
 					}
 				}
-				if zb0003 > 0 {
-					zb0003--
+				if zb0005 > 0 {
+					zb0005--
 					(*z).Online.RewardUnits, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Online", "struct-from-array", "RewardUnits")
 						return
 					}
 				}
-				if zb0003 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0003)
+				if zb0005 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0005)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Online", "struct-from-array")
 						return
@@ -220,11 +240,11 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "Online")
 					return
 				}
-				if zb0004 {
+				if zb0006 {
 					(*z).Online = AlgoCount{}
 				}
-				for zb0003 > 0 {
-					zb0003--
+				for zb0005 > 0 {
+					zb0005--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Online")
@@ -232,17 +252,27 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch string(field) {
 					case "mon":
+						if validate && zb0008 && "mon" < zb0007 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						bts, err = (*z).Online.Money.UnmarshalMsg(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Online", "Money")
 							return
 						}
+						zb0007 = "mon"
 					case "rwd":
+						if validate && zb0008 && "rwd" < zb0007 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).Online.RewardUnits, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Online", "RewardUnits")
 							return
 						}
+						zb0007 = "rwd"
 					default:
 						err = msgp.ErrNoField(string(field))
 						if err != nil {
@@ -250,38 +280,47 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0008 = true
 				}
 			}
 		}
 		if zb0001 > 0 {
 			zb0001--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0009 int
+			var zb0011 string
+			var zb0012 bool
+			var zb0010 bool
+			_ = zb0011
+			_ = zb0012
+			zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Offline")
 					return
 				}
-				if zb0005 > 0 {
-					zb0005--
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0009 > 0 {
+					zb0009--
 					bts, err = (*z).Offline.Money.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Offline", "struct-from-array", "Money")
 						return
 					}
 				}
-				if zb0005 > 0 {
-					zb0005--
+				if zb0009 > 0 {
+					zb0009--
 					(*z).Offline.RewardUnits, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Offline", "struct-from-array", "RewardUnits")
 						return
 					}
 				}
-				if zb0005 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0005)
+				if zb0009 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0009)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Offline", "struct-from-array")
 						return
@@ -292,11 +331,11 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "Offline")
 					return
 				}
-				if zb0006 {
+				if zb0010 {
 					(*z).Offline = AlgoCount{}
 				}
-				for zb0005 > 0 {
-					zb0005--
+				for zb0009 > 0 {
+					zb0009--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Offline")
@@ -304,17 +343,27 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch string(field) {
 					case "mon":
+						if validate && zb0012 && "mon" < zb0011 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						bts, err = (*z).Offline.Money.UnmarshalMsg(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Offline", "Money")
 							return
 						}
+						zb0011 = "mon"
 					case "rwd":
+						if validate && zb0012 && "rwd" < zb0011 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).Offline.RewardUnits, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Offline", "RewardUnits")
 							return
 						}
+						zb0011 = "rwd"
 					default:
 						err = msgp.ErrNoField(string(field))
 						if err != nil {
@@ -322,38 +371,47 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0012 = true
 				}
 			}
 		}
 		if zb0001 > 0 {
 			zb0001--
-			var zb0007 int
-			var zb0008 bool
-			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0013 int
+			var zb0015 string
+			var zb0016 bool
+			var zb0014 bool
+			_ = zb0015
+			_ = zb0016
+			zb0013, zb0014, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "NotParticipating")
 					return
 				}
-				if zb0007 > 0 {
-					zb0007--
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0013 > 0 {
+					zb0013--
 					bts, err = (*z).NotParticipating.Money.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "NotParticipating", "struct-from-array", "Money")
 						return
 					}
 				}
-				if zb0007 > 0 {
-					zb0007--
+				if zb0013 > 0 {
+					zb0013--
 					(*z).NotParticipating.RewardUnits, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "NotParticipating", "struct-from-array", "RewardUnits")
 						return
 					}
 				}
-				if zb0007 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0007)
+				if zb0013 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0013)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "NotParticipating", "struct-from-array")
 						return
@@ -364,11 +422,11 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "NotParticipating")
 					return
 				}
-				if zb0008 {
+				if zb0014 {
 					(*z).NotParticipating = AlgoCount{}
 				}
-				for zb0007 > 0 {
-					zb0007--
+				for zb0013 > 0 {
+					zb0013--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "NotParticipating")
@@ -376,17 +434,27 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch string(field) {
 					case "mon":
+						if validate && zb0016 && "mon" < zb0015 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						bts, err = (*z).NotParticipating.Money.UnmarshalMsg(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "NotParticipating", "Money")
 							return
 						}
+						zb0015 = "mon"
 					case "rwd":
+						if validate && zb0016 && "rwd" < zb0015 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						(*z).NotParticipating.RewardUnits, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "NotParticipating", "RewardUnits")
 							return
 						}
+						zb0015 = "rwd"
 					default:
 						err = msgp.ErrNoField(string(field))
 						if err != nil {
@@ -394,6 +462,7 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0016 = true
 				}
 			}
 		}
@@ -429,33 +498,45 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "online":
-				var zb0009 int
-				var zb0010 bool
-				zb0009, zb0010, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0004 && "online" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0017 int
+				var zb0019 string
+				var zb0020 bool
+				var zb0018 bool
+				_ = zb0019
+				_ = zb0020
+				zb0017, zb0018, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0017, zb0018, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Online")
 						return
 					}
-					if zb0009 > 0 {
-						zb0009--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0017 > 0 {
+						zb0017--
 						bts, err = (*z).Online.Money.UnmarshalMsg(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Online", "struct-from-array", "Money")
 							return
 						}
 					}
-					if zb0009 > 0 {
-						zb0009--
+					if zb0017 > 0 {
+						zb0017--
 						(*z).Online.RewardUnits, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Online", "struct-from-array", "RewardUnits")
 							return
 						}
 					}
-					if zb0009 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0009)
+					if zb0017 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0017)
 						if err != nil {
 							err = msgp.WrapError(err, "Online", "struct-from-array")
 							return
@@ -466,11 +547,11 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "Online")
 						return
 					}
-					if zb0010 {
+					if zb0018 {
 						(*z).Online = AlgoCount{}
 					}
-					for zb0009 > 0 {
-						zb0009--
+					for zb0017 > 0 {
+						zb0017--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Online")
@@ -478,17 +559,27 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "mon":
+							if validate && zb0020 && "mon" < zb0019 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							bts, err = (*z).Online.Money.UnmarshalMsg(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Online", "Money")
 								return
 							}
+							zb0019 = "mon"
 						case "rwd":
+							if validate && zb0020 && "rwd" < zb0019 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).Online.RewardUnits, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Online", "RewardUnits")
 								return
 							}
+							zb0019 = "rwd"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -496,36 +587,50 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0020 = true
 					}
 				}
+				zb0003 = "online"
 			case "offline":
-				var zb0011 int
-				var zb0012 bool
-				zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0004 && "offline" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0021 int
+				var zb0023 string
+				var zb0024 bool
+				var zb0022 bool
+				_ = zb0023
+				_ = zb0024
+				zb0021, zb0022, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0021, zb0022, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Offline")
 						return
 					}
-					if zb0011 > 0 {
-						zb0011--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0021 > 0 {
+						zb0021--
 						bts, err = (*z).Offline.Money.UnmarshalMsg(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Offline", "struct-from-array", "Money")
 							return
 						}
 					}
-					if zb0011 > 0 {
-						zb0011--
+					if zb0021 > 0 {
+						zb0021--
 						(*z).Offline.RewardUnits, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Offline", "struct-from-array", "RewardUnits")
 							return
 						}
 					}
-					if zb0011 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0011)
+					if zb0021 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0021)
 						if err != nil {
 							err = msgp.WrapError(err, "Offline", "struct-from-array")
 							return
@@ -536,11 +641,11 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "Offline")
 						return
 					}
-					if zb0012 {
+					if zb0022 {
 						(*z).Offline = AlgoCount{}
 					}
-					for zb0011 > 0 {
-						zb0011--
+					for zb0021 > 0 {
+						zb0021--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Offline")
@@ -548,17 +653,27 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "mon":
+							if validate && zb0024 && "mon" < zb0023 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							bts, err = (*z).Offline.Money.UnmarshalMsg(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Offline", "Money")
 								return
 							}
+							zb0023 = "mon"
 						case "rwd":
+							if validate && zb0024 && "rwd" < zb0023 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).Offline.RewardUnits, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Offline", "RewardUnits")
 								return
 							}
+							zb0023 = "rwd"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -566,36 +681,50 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0024 = true
 					}
 				}
+				zb0003 = "offline"
 			case "notpart":
-				var zb0013 int
-				var zb0014 bool
-				zb0013, zb0014, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0004 && "notpart" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0025 int
+				var zb0027 string
+				var zb0028 bool
+				var zb0026 bool
+				_ = zb0027
+				_ = zb0028
+				zb0025, zb0026, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0025, zb0026, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "NotParticipating")
 						return
 					}
-					if zb0013 > 0 {
-						zb0013--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0025 > 0 {
+						zb0025--
 						bts, err = (*z).NotParticipating.Money.UnmarshalMsg(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "NotParticipating", "struct-from-array", "Money")
 							return
 						}
 					}
-					if zb0013 > 0 {
-						zb0013--
+					if zb0025 > 0 {
+						zb0025--
 						(*z).NotParticipating.RewardUnits, bts, err = msgp.ReadUint64Bytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "NotParticipating", "struct-from-array", "RewardUnits")
 							return
 						}
 					}
-					if zb0013 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0013)
+					if zb0025 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0025)
 						if err != nil {
 							err = msgp.WrapError(err, "NotParticipating", "struct-from-array")
 							return
@@ -606,11 +735,11 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "NotParticipating")
 						return
 					}
-					if zb0014 {
+					if zb0026 {
 						(*z).NotParticipating = AlgoCount{}
 					}
-					for zb0013 > 0 {
-						zb0013--
+					for zb0025 > 0 {
+						zb0025--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "NotParticipating")
@@ -618,17 +747,27 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "mon":
+							if validate && zb0028 && "mon" < zb0027 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							bts, err = (*z).NotParticipating.Money.UnmarshalMsg(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "NotParticipating", "Money")
 								return
 							}
+							zb0027 = "mon"
 						case "rwd":
+							if validate && zb0028 && "rwd" < zb0027 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							(*z).NotParticipating.RewardUnits, bts, err = msgp.ReadUint64Bytes(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "NotParticipating", "RewardUnits")
 								return
 							}
+							zb0027 = "rwd"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -636,14 +775,21 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0028 = true
 					}
 				}
+				zb0003 = "notpart"
 			case "rwdlvl":
+				if validate && zb0004 && "rwdlvl" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).RewardsLevel, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsLevel")
 					return
 				}
+				zb0003 = "rwdlvl"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -651,12 +797,19 @@ func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *AccountTotals) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *AccountTotals) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *AccountTotals) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*AccountTotals)
 	return ok
@@ -716,16 +869,24 @@ func (_ *AlgoCount) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *AlgoCount) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *AlgoCount) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -768,17 +929,27 @@ func (z *AlgoCount) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "mon":
+				if validate && zb0004 && "mon" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Money.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Money")
 					return
 				}
+				zb0003 = "mon"
 			case "rwd":
+				if validate && zb0004 && "rwd" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).RewardUnits, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardUnits")
 					return
 				}
+				zb0003 = "rwd"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -786,12 +957,19 @@ func (z *AlgoCount) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *AlgoCount) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *AlgoCount) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *AlgoCount) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*AlgoCount)
 	return ok
@@ -860,16 +1038,24 @@ func (_ *OnlineRoundParamsData) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *OnlineRoundParamsData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *OnlineRoundParamsData) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -920,23 +1106,38 @@ func (z *OnlineRoundParamsData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "online":
+				if validate && zb0004 && "online" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).OnlineSupply, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "OnlineSupply")
 					return
 				}
+				zb0003 = "online"
 			case "rwdlvl":
+				if validate && zb0004 && "rwdlvl" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).RewardsLevel, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsLevel")
 					return
 				}
+				zb0003 = "rwdlvl"
 			case "proto":
+				if validate && zb0004 && "proto" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).CurrentProtocol.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "CurrentProtocol")
 					return
 				}
+				zb0003 = "proto"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -944,12 +1145,19 @@ func (z *OnlineRoundParamsData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *OnlineRoundParamsData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *OnlineRoundParamsData) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *OnlineRoundParamsData) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*OnlineRoundParamsData)
 	return ok
@@ -1027,16 +1235,24 @@ func (_ *StateProofVerificationContext) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *StateProofVerificationContext) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *StateProofVerificationContext) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -1095,29 +1311,49 @@ func (z *StateProofVerificationContext) UnmarshalMsg(bts []byte) (o []byte, err 
 			}
 			switch string(field) {
 			case "spround":
+				if validate && zb0004 && "spround" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).LastAttestedRound.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "LastAttestedRound")
 					return
 				}
+				zb0003 = "spround"
 			case "vc":
+				if validate && zb0004 && "vc" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VotersCommitment.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VotersCommitment")
 					return
 				}
+				zb0003 = "vc"
 			case "pw":
+				if validate && zb0004 && "pw" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).OnlineTotalWeight.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "OnlineTotalWeight")
 					return
 				}
+				zb0003 = "pw"
 			case "v":
+				if validate && zb0004 && "v" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Version.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Version")
 					return
 				}
+				zb0003 = "v"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1125,12 +1361,19 @@ func (z *StateProofVerificationContext) UnmarshalMsg(bts []byte) (o []byte, err 
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *StateProofVerificationContext) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *StateProofVerificationContext) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *StateProofVerificationContext) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*StateProofVerificationContext)
 	return ok

--- a/ledger/msgp_gen.go
+++ b/ledger/msgp_gen.go
@@ -16,6 +16,7 @@ import (
 //            |-----> MarshalMsg
 //            |-----> CanMarshalMsg
 //            |-----> (*) UnmarshalMsg
+//            |-----> (*) UnmarshalValidateMsg
 //            |-----> (*) CanUnmarshalMsg
 //            |-----> Msgsize
 //            |-----> MsgIsZero
@@ -25,6 +26,7 @@ import (
 //           |-----> (*) MarshalMsg
 //           |-----> (*) CanMarshalMsg
 //           |-----> (*) UnmarshalMsg
+//           |-----> (*) UnmarshalValidateMsg
 //           |-----> (*) CanUnmarshalMsg
 //           |-----> (*) Msgsize
 //           |-----> (*) MsgIsZero
@@ -34,6 +36,7 @@ import (
 //               |-----> (*) MarshalMsg
 //               |-----> (*) CanMarshalMsg
 //               |-----> (*) UnmarshalMsg
+//               |-----> (*) UnmarshalValidateMsg
 //               |-----> (*) CanUnmarshalMsg
 //               |-----> (*) Msgsize
 //               |-----> (*) MsgIsZero
@@ -43,6 +46,7 @@ import (
 //           |-----> (*) MarshalMsg
 //           |-----> (*) CanMarshalMsg
 //           |-----> (*) UnmarshalMsg
+//           |-----> (*) UnmarshalValidateMsg
 //           |-----> (*) CanUnmarshalMsg
 //           |-----> (*) Msgsize
 //           |-----> (*) MsgIsZero
@@ -52,6 +56,7 @@ import (
 //                    |-----> (*) MarshalMsg
 //                    |-----> (*) CanMarshalMsg
 //                    |-----> (*) UnmarshalMsg
+//                    |-----> (*) UnmarshalValidateMsg
 //                    |-----> (*) CanUnmarshalMsg
 //                    |-----> (*) Msgsize
 //                    |-----> (*) MsgIsZero
@@ -74,7 +79,7 @@ func (_ CatchpointCatchupState) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *CatchpointCatchupState) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *CatchpointCatchupState) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 int32
 		zb0001, bts, err = msgp.ReadInt32Bytes(bts)
@@ -88,6 +93,12 @@ func (z *CatchpointCatchupState) UnmarshalMsg(bts []byte) (o []byte, err error) 
 	return
 }
 
+func (z *CatchpointCatchupState) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *CatchpointCatchupState) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *CatchpointCatchupState) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*CatchpointCatchupState)
 	return ok
@@ -210,16 +221,24 @@ func (_ *CatchpointFileHeader) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *CatchpointFileHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *CatchpointFileHeader) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -318,59 +337,104 @@ func (z *CatchpointFileHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "version":
+				if validate && zb0004 && "version" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Version, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Version")
 					return
 				}
+				zb0003 = "version"
 			case "balancesRound":
+				if validate && zb0004 && "balancesRound" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BalancesRound.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "BalancesRound")
 					return
 				}
+				zb0003 = "balancesRound"
 			case "blocksRound":
+				if validate && zb0004 && "blocksRound" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlocksRound.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "BlocksRound")
 					return
 				}
+				zb0003 = "blocksRound"
 			case "accountTotals":
+				if validate && zb0004 && "accountTotals" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Totals.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Totals")
 					return
 				}
+				zb0003 = "accountTotals"
 			case "accountsCount":
+				if validate && zb0004 && "accountsCount" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalAccounts, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalAccounts")
 					return
 				}
+				zb0003 = "accountsCount"
 			case "chunksCount":
+				if validate && zb0004 && "chunksCount" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalChunks, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalChunks")
 					return
 				}
+				zb0003 = "chunksCount"
 			case "kvsCount":
+				if validate && zb0004 && "kvsCount" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalKVs, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalKVs")
 					return
 				}
+				zb0003 = "kvsCount"
 			case "catchpoint":
+				if validate && zb0004 && "catchpoint" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Catchpoint, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Catchpoint")
 					return
 				}
+				zb0003 = "catchpoint"
 			case "blockHeaderDigest":
+				if validate && zb0004 && "blockHeaderDigest" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BlockHeaderDigest.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "BlockHeaderDigest")
 					return
 				}
+				zb0003 = "blockHeaderDigest"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -378,12 +442,19 @@ func (z *CatchpointFileHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *CatchpointFileHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *CatchpointFileHeader) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *CatchpointFileHeader) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*CatchpointFileHeader)
 	return ok
@@ -443,11 +514,15 @@ func (_ *catchpointFileBalancesChunkV5) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *catchpointFileBalancesChunkV5) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *catchpointFileBalancesChunkV5) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -455,26 +530,30 @@ func (z *catchpointFileBalancesChunkV5) UnmarshalMsg(bts []byte) (o []byte, err 
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0004 int
-			var zb0005 bool
-			zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0006 int
+			var zb0007 bool
+			zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Balances")
 				return
 			}
-			if zb0004 > BalancesPerCatchpointFileChunk {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(BalancesPerCatchpointFileChunk))
+			if zb0006 > BalancesPerCatchpointFileChunk {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(BalancesPerCatchpointFileChunk))
 				err = msgp.WrapError(err, "struct-from-array", "Balances")
 				return
 			}
-			if zb0005 {
+			if zb0007 {
 				(*z).Balances = nil
-			} else if (*z).Balances != nil && cap((*z).Balances) >= zb0004 {
-				(*z).Balances = ((*z).Balances)[:zb0004]
+			} else if (*z).Balances != nil && cap((*z).Balances) >= zb0006 {
+				(*z).Balances = ((*z).Balances)[:zb0006]
 			} else {
-				(*z).Balances = make([]encoded.BalanceRecordV5, zb0004)
+				(*z).Balances = make([]encoded.BalanceRecordV5, zb0006)
 			}
 			for zb0001 := range (*z).Balances {
 				bts, err = (*z).Balances[zb0001].UnmarshalMsg(bts)
@@ -508,24 +587,28 @@ func (z *catchpointFileBalancesChunkV5) UnmarshalMsg(bts []byte) (o []byte, err 
 			}
 			switch string(field) {
 			case "bl":
-				var zb0006 int
-				var zb0007 bool
-				zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0005 && "bl" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0008 int
+				var zb0009 bool
+				zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Balances")
 					return
 				}
-				if zb0006 > BalancesPerCatchpointFileChunk {
-					err = msgp.ErrOverflow(uint64(zb0006), uint64(BalancesPerCatchpointFileChunk))
+				if zb0008 > BalancesPerCatchpointFileChunk {
+					err = msgp.ErrOverflow(uint64(zb0008), uint64(BalancesPerCatchpointFileChunk))
 					err = msgp.WrapError(err, "Balances")
 					return
 				}
-				if zb0007 {
+				if zb0009 {
 					(*z).Balances = nil
-				} else if (*z).Balances != nil && cap((*z).Balances) >= zb0006 {
-					(*z).Balances = ((*z).Balances)[:zb0006]
+				} else if (*z).Balances != nil && cap((*z).Balances) >= zb0008 {
+					(*z).Balances = ((*z).Balances)[:zb0008]
 				} else {
-					(*z).Balances = make([]encoded.BalanceRecordV5, zb0006)
+					(*z).Balances = make([]encoded.BalanceRecordV5, zb0008)
 				}
 				for zb0001 := range (*z).Balances {
 					bts, err = (*z).Balances[zb0001].UnmarshalMsg(bts)
@@ -534,6 +617,7 @@ func (z *catchpointFileBalancesChunkV5) UnmarshalMsg(bts []byte) (o []byte, err 
 						return
 					}
 				}
+				zb0004 = "bl"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -541,12 +625,19 @@ func (z *catchpointFileBalancesChunkV5) UnmarshalMsg(bts []byte) (o []byte, err 
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *catchpointFileBalancesChunkV5) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *catchpointFileBalancesChunkV5) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *catchpointFileBalancesChunkV5) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*catchpointFileBalancesChunkV5)
 	return ok
@@ -625,11 +716,15 @@ func (_ *catchpointFileChunkV6) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *catchpointFileChunkV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *catchpointFileChunkV6) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -637,26 +732,30 @@ func (z *catchpointFileChunkV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0007 int
+			var zb0008 bool
+			zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Balances")
 				return
 			}
-			if zb0005 > BalancesPerCatchpointFileChunk {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(BalancesPerCatchpointFileChunk))
+			if zb0007 > BalancesPerCatchpointFileChunk {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(BalancesPerCatchpointFileChunk))
 				err = msgp.WrapError(err, "struct-from-array", "Balances")
 				return
 			}
-			if zb0006 {
+			if zb0008 {
 				(*z).Balances = nil
-			} else if (*z).Balances != nil && cap((*z).Balances) >= zb0005 {
-				(*z).Balances = ((*z).Balances)[:zb0005]
+			} else if (*z).Balances != nil && cap((*z).Balances) >= zb0007 {
+				(*z).Balances = ((*z).Balances)[:zb0007]
 			} else {
-				(*z).Balances = make([]encoded.BalanceRecordV6, zb0005)
+				(*z).Balances = make([]encoded.BalanceRecordV6, zb0007)
 			}
 			for zb0001 := range (*z).Balances {
 				bts, err = (*z).Balances[zb0001].UnmarshalMsg(bts)
@@ -668,24 +767,24 @@ func (z *catchpointFileChunkV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0007 int
-			var zb0008 bool
-			zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0009 int
+			var zb0010 bool
+			zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "KVs")
 				return
 			}
-			if zb0007 > BalancesPerCatchpointFileChunk {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(BalancesPerCatchpointFileChunk))
+			if zb0009 > BalancesPerCatchpointFileChunk {
+				err = msgp.ErrOverflow(uint64(zb0009), uint64(BalancesPerCatchpointFileChunk))
 				err = msgp.WrapError(err, "struct-from-array", "KVs")
 				return
 			}
-			if zb0008 {
+			if zb0010 {
 				(*z).KVs = nil
-			} else if (*z).KVs != nil && cap((*z).KVs) >= zb0007 {
-				(*z).KVs = ((*z).KVs)[:zb0007]
+			} else if (*z).KVs != nil && cap((*z).KVs) >= zb0009 {
+				(*z).KVs = ((*z).KVs)[:zb0009]
 			} else {
-				(*z).KVs = make([]encoded.KVRecordV6, zb0007)
+				(*z).KVs = make([]encoded.KVRecordV6, zb0009)
 			}
 			for zb0002 := range (*z).KVs {
 				bts, err = (*z).KVs[zb0002].UnmarshalMsg(bts)
@@ -719,24 +818,28 @@ func (z *catchpointFileChunkV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "bl":
-				var zb0009 int
-				var zb0010 bool
-				zb0009, zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "bl" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0011 int
+				var zb0012 bool
+				zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Balances")
 					return
 				}
-				if zb0009 > BalancesPerCatchpointFileChunk {
-					err = msgp.ErrOverflow(uint64(zb0009), uint64(BalancesPerCatchpointFileChunk))
+				if zb0011 > BalancesPerCatchpointFileChunk {
+					err = msgp.ErrOverflow(uint64(zb0011), uint64(BalancesPerCatchpointFileChunk))
 					err = msgp.WrapError(err, "Balances")
 					return
 				}
-				if zb0010 {
+				if zb0012 {
 					(*z).Balances = nil
-				} else if (*z).Balances != nil && cap((*z).Balances) >= zb0009 {
-					(*z).Balances = ((*z).Balances)[:zb0009]
+				} else if (*z).Balances != nil && cap((*z).Balances) >= zb0011 {
+					(*z).Balances = ((*z).Balances)[:zb0011]
 				} else {
-					(*z).Balances = make([]encoded.BalanceRecordV6, zb0009)
+					(*z).Balances = make([]encoded.BalanceRecordV6, zb0011)
 				}
 				for zb0001 := range (*z).Balances {
 					bts, err = (*z).Balances[zb0001].UnmarshalMsg(bts)
@@ -745,25 +848,30 @@ func (z *catchpointFileChunkV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0005 = "bl"
 			case "kv":
-				var zb0011 int
-				var zb0012 bool
-				zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0006 && "kv" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0013 int
+				var zb0014 bool
+				zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "KVs")
 					return
 				}
-				if zb0011 > BalancesPerCatchpointFileChunk {
-					err = msgp.ErrOverflow(uint64(zb0011), uint64(BalancesPerCatchpointFileChunk))
+				if zb0013 > BalancesPerCatchpointFileChunk {
+					err = msgp.ErrOverflow(uint64(zb0013), uint64(BalancesPerCatchpointFileChunk))
 					err = msgp.WrapError(err, "KVs")
 					return
 				}
-				if zb0012 {
+				if zb0014 {
 					(*z).KVs = nil
-				} else if (*z).KVs != nil && cap((*z).KVs) >= zb0011 {
-					(*z).KVs = ((*z).KVs)[:zb0011]
+				} else if (*z).KVs != nil && cap((*z).KVs) >= zb0013 {
+					(*z).KVs = ((*z).KVs)[:zb0013]
 				} else {
-					(*z).KVs = make([]encoded.KVRecordV6, zb0011)
+					(*z).KVs = make([]encoded.KVRecordV6, zb0013)
 				}
 				for zb0002 := range (*z).KVs {
 					bts, err = (*z).KVs[zb0002].UnmarshalMsg(bts)
@@ -772,6 +880,7 @@ func (z *catchpointFileChunkV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0005 = "kv"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -779,12 +888,19 @@ func (z *catchpointFileChunkV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *catchpointFileChunkV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *catchpointFileChunkV6) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *catchpointFileChunkV6) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*catchpointFileChunkV6)
 	return ok
@@ -854,11 +970,15 @@ func (_ *catchpointStateProofVerificationContext) CanMarshalMsg(z interface{}) b
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *catchpointStateProofVerificationContext) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *catchpointStateProofVerificationContext) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -866,26 +986,30 @@ func (z *catchpointStateProofVerificationContext) UnmarshalMsg(bts []byte) (o []
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0004 int
-			var zb0005 bool
-			zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0006 int
+			var zb0007 bool
+			zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Data")
 				return
 			}
-			if zb0004 > SPContextPerCatchpointFile {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(SPContextPerCatchpointFile))
+			if zb0006 > SPContextPerCatchpointFile {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(SPContextPerCatchpointFile))
 				err = msgp.WrapError(err, "struct-from-array", "Data")
 				return
 			}
-			if zb0005 {
+			if zb0007 {
 				(*z).Data = nil
-			} else if (*z).Data != nil && cap((*z).Data) >= zb0004 {
-				(*z).Data = ((*z).Data)[:zb0004]
+			} else if (*z).Data != nil && cap((*z).Data) >= zb0006 {
+				(*z).Data = ((*z).Data)[:zb0006]
 			} else {
-				(*z).Data = make([]ledgercore.StateProofVerificationContext, zb0004)
+				(*z).Data = make([]ledgercore.StateProofVerificationContext, zb0006)
 			}
 			for zb0001 := range (*z).Data {
 				bts, err = (*z).Data[zb0001].UnmarshalMsg(bts)
@@ -919,24 +1043,28 @@ func (z *catchpointStateProofVerificationContext) UnmarshalMsg(bts []byte) (o []
 			}
 			switch string(field) {
 			case "spd":
-				var zb0006 int
-				var zb0007 bool
-				zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0005 && "spd" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0008 int
+				var zb0009 bool
+				zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Data")
 					return
 				}
-				if zb0006 > SPContextPerCatchpointFile {
-					err = msgp.ErrOverflow(uint64(zb0006), uint64(SPContextPerCatchpointFile))
+				if zb0008 > SPContextPerCatchpointFile {
+					err = msgp.ErrOverflow(uint64(zb0008), uint64(SPContextPerCatchpointFile))
 					err = msgp.WrapError(err, "Data")
 					return
 				}
-				if zb0007 {
+				if zb0009 {
 					(*z).Data = nil
-				} else if (*z).Data != nil && cap((*z).Data) >= zb0006 {
-					(*z).Data = ((*z).Data)[:zb0006]
+				} else if (*z).Data != nil && cap((*z).Data) >= zb0008 {
+					(*z).Data = ((*z).Data)[:zb0008]
 				} else {
-					(*z).Data = make([]ledgercore.StateProofVerificationContext, zb0006)
+					(*z).Data = make([]ledgercore.StateProofVerificationContext, zb0008)
 				}
 				for zb0001 := range (*z).Data {
 					bts, err = (*z).Data[zb0001].UnmarshalMsg(bts)
@@ -945,6 +1073,7 @@ func (z *catchpointStateProofVerificationContext) UnmarshalMsg(bts []byte) (o []
 						return
 					}
 				}
+				zb0004 = "spd"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -952,12 +1081,19 @@ func (z *catchpointStateProofVerificationContext) UnmarshalMsg(bts []byte) (o []
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *catchpointStateProofVerificationContext) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *catchpointStateProofVerificationContext) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *catchpointStateProofVerificationContext) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*catchpointStateProofVerificationContext)
 	return ok

--- a/ledger/store/trackerdb/msgp_gen.go
+++ b/ledger/store/trackerdb/msgp_gen.go
@@ -19,6 +19,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -28,6 +29,7 @@ import (
 //           |-----> (*) MarshalMsg
 //           |-----> (*) CanMarshalMsg
 //           |-----> (*) UnmarshalMsg
+//           |-----> (*) UnmarshalValidateMsg
 //           |-----> (*) CanUnmarshalMsg
 //           |-----> (*) Msgsize
 //           |-----> (*) MsgIsZero
@@ -37,6 +39,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -46,6 +49,7 @@ import (
 //             |-----> (*) MarshalMsg
 //             |-----> (*) CanMarshalMsg
 //             |-----> (*) UnmarshalMsg
+//             |-----> (*) UnmarshalValidateMsg
 //             |-----> (*) CanUnmarshalMsg
 //             |-----> (*) Msgsize
 //             |-----> (*) MsgIsZero
@@ -55,6 +59,7 @@ import (
 //       |-----> MarshalMsg
 //       |-----> CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> Msgsize
 //       |-----> MsgIsZero
@@ -64,6 +69,7 @@ import (
 //       |-----> (*) MarshalMsg
 //       |-----> (*) CanMarshalMsg
 //       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalValidateMsg
 //       |-----> (*) CanUnmarshalMsg
 //       |-----> (*) Msgsize
 //       |-----> (*) MsgIsZero
@@ -73,6 +79,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -82,6 +89,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -296,16 +304,24 @@ func (_ *BaseAccountData) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *BaseAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *BaseAccountData) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -500,131 +516,236 @@ func (z *BaseAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "a":
+				if validate && zb0004 && "a" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Status.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Status")
 					return
 				}
+				zb0003 = "a"
 			case "b":
+				if validate && zb0004 && "b" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).MicroAlgos.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "MicroAlgos")
 					return
 				}
+				zb0003 = "b"
 			case "c":
+				if validate && zb0004 && "c" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).RewardsBase, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsBase")
 					return
 				}
+				zb0003 = "c"
 			case "d":
+				if validate && zb0004 && "d" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).RewardedMicroAlgos.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardedMicroAlgos")
 					return
 				}
+				zb0003 = "d"
 			case "e":
+				if validate && zb0004 && "e" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).AuthAddr.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AuthAddr")
 					return
 				}
+				zb0003 = "e"
 			case "f":
+				if validate && zb0004 && "f" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalAppSchemaNumUint, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalAppSchemaNumUint")
 					return
 				}
+				zb0003 = "f"
 			case "g":
+				if validate && zb0004 && "g" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalAppSchemaNumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalAppSchemaNumByteSlice")
 					return
 				}
+				zb0003 = "g"
 			case "h":
+				if validate && zb0004 && "h" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalExtraAppPages, bts, err = msgp.ReadUint32Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalExtraAppPages")
 					return
 				}
+				zb0003 = "h"
 			case "i":
+				if validate && zb0004 && "i" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalAssetParams, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalAssetParams")
 					return
 				}
+				zb0003 = "i"
 			case "j":
+				if validate && zb0004 && "j" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalAssets, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalAssets")
 					return
 				}
+				zb0003 = "j"
 			case "k":
+				if validate && zb0004 && "k" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalAppParams, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalAppParams")
 					return
 				}
+				zb0003 = "k"
 			case "l":
+				if validate && zb0004 && "l" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalAppLocalStates, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalAppLocalStates")
 					return
 				}
+				zb0003 = "l"
 			case "m":
+				if validate && zb0004 && "m" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalBoxes, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalBoxes")
 					return
 				}
+				zb0003 = "m"
 			case "n":
+				if validate && zb0004 && "n" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalBoxBytes, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalBoxBytes")
 					return
 				}
+				zb0003 = "n"
 			case "A":
+				if validate && zb0004 && "A" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BaseVotingData.VoteID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteID")
 					return
 				}
+				zb0003 = "A"
 			case "B":
+				if validate && zb0004 && "B" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BaseVotingData.SelectionID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SelectionID")
 					return
 				}
+				zb0003 = "B"
 			case "C":
+				if validate && zb0004 && "C" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BaseVotingData.VoteFirstValid.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteFirstValid")
 					return
 				}
+				zb0003 = "C"
 			case "D":
+				if validate && zb0004 && "D" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BaseVotingData.VoteLastValid.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteLastValid")
 					return
 				}
+				zb0003 = "D"
 			case "E":
+				if validate && zb0004 && "E" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).BaseVotingData.VoteKeyDilution, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteKeyDilution")
 					return
 				}
+				zb0003 = "E"
 			case "F":
+				if validate && zb0004 && "F" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BaseVotingData.StateProofID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofID")
 					return
 				}
+				zb0003 = "F"
 			case "z":
+				if validate && zb0004 && "z" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).UpdateRound, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpdateRound")
 					return
 				}
+				zb0003 = "z"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -632,12 +753,19 @@ func (z *BaseAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *BaseAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *BaseAccountData) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *BaseAccountData) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*BaseAccountData)
 	return ok
@@ -751,16 +879,24 @@ func (_ *BaseOnlineAccountData) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *BaseOnlineAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *BaseOnlineAccountData) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -851,53 +987,93 @@ func (z *BaseOnlineAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "A":
+				if validate && zb0004 && "A" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BaseVotingData.VoteID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteID")
 					return
 				}
+				zb0003 = "A"
 			case "B":
+				if validate && zb0004 && "B" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BaseVotingData.SelectionID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SelectionID")
 					return
 				}
+				zb0003 = "B"
 			case "C":
+				if validate && zb0004 && "C" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BaseVotingData.VoteFirstValid.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteFirstValid")
 					return
 				}
+				zb0003 = "C"
 			case "D":
+				if validate && zb0004 && "D" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BaseVotingData.VoteLastValid.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteLastValid")
 					return
 				}
+				zb0003 = "D"
 			case "E":
+				if validate && zb0004 && "E" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).BaseVotingData.VoteKeyDilution, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteKeyDilution")
 					return
 				}
+				zb0003 = "E"
 			case "F":
+				if validate && zb0004 && "F" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).BaseVotingData.StateProofID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofID")
 					return
 				}
+				zb0003 = "F"
 			case "Y":
+				if validate && zb0004 && "Y" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).MicroAlgos.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "MicroAlgos")
 					return
 				}
+				zb0003 = "Y"
 			case "Z":
+				if validate && zb0004 && "Z" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).RewardsBase, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "RewardsBase")
 					return
 				}
+				zb0003 = "Z"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -905,12 +1081,19 @@ func (z *BaseOnlineAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *BaseOnlineAccountData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *BaseOnlineAccountData) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *BaseOnlineAccountData) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*BaseOnlineAccountData)
 	return ok
@@ -1006,16 +1189,24 @@ func (_ *BaseVotingData) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *BaseVotingData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *BaseVotingData) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -1090,41 +1281,71 @@ func (z *BaseVotingData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "A":
+				if validate && zb0004 && "A" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VoteID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteID")
 					return
 				}
+				zb0003 = "A"
 			case "B":
+				if validate && zb0004 && "B" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SelectionID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SelectionID")
 					return
 				}
+				zb0003 = "B"
 			case "C":
+				if validate && zb0004 && "C" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VoteFirstValid.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteFirstValid")
 					return
 				}
+				zb0003 = "C"
 			case "D":
+				if validate && zb0004 && "D" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VoteLastValid.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteLastValid")
 					return
 				}
+				zb0003 = "D"
 			case "E":
+				if validate && zb0004 && "E" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).VoteKeyDilution, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VoteKeyDilution")
 					return
 				}
+				zb0003 = "E"
 			case "F":
+				if validate && zb0004 && "F" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).StateProofID.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofID")
 					return
 				}
+				zb0003 = "F"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1132,12 +1353,19 @@ func (z *BaseVotingData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *BaseVotingData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *BaseVotingData) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *BaseVotingData) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*BaseVotingData)
 	return ok
@@ -1242,16 +1470,24 @@ func (_ *CatchpointFirstStageInfo) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *CatchpointFirstStageInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *CatchpointFirstStageInfo) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -1334,47 +1570,82 @@ func (z *CatchpointFirstStageInfo) UnmarshalMsg(bts []byte) (o []byte, err error
 			}
 			switch string(field) {
 			case "accountTotals":
+				if validate && zb0004 && "accountTotals" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Totals.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Totals")
 					return
 				}
+				zb0003 = "accountTotals"
 			case "trieBalancesHash":
+				if validate && zb0004 && "trieBalancesHash" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).TrieBalancesHash.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TrieBalancesHash")
 					return
 				}
+				zb0003 = "trieBalancesHash"
 			case "accountsCount":
+				if validate && zb0004 && "accountsCount" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalAccounts, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalAccounts")
 					return
 				}
+				zb0003 = "accountsCount"
 			case "kvsCount":
+				if validate && zb0004 && "kvsCount" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalKVs, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalKVs")
 					return
 				}
+				zb0003 = "kvsCount"
 			case "chunksCount":
+				if validate && zb0004 && "chunksCount" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TotalChunks, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TotalChunks")
 					return
 				}
+				zb0003 = "chunksCount"
 			case "biggestChunk":
+				if validate && zb0004 && "biggestChunk" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).BiggestChunkLen, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "BiggestChunkLen")
 					return
 				}
+				zb0003 = "biggestChunk"
 			case "spVerificationHash":
+				if validate && zb0004 && "spVerificationHash" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).StateProofVerificationHash.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "StateProofVerificationHash")
 					return
 				}
+				zb0003 = "spVerificationHash"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1382,12 +1653,19 @@ func (z *CatchpointFirstStageInfo) UnmarshalMsg(bts []byte) (o []byte, err error
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *CatchpointFirstStageInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *CatchpointFirstStageInfo) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *CatchpointFirstStageInfo) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*CatchpointFirstStageInfo)
 	return ok
@@ -1426,7 +1704,7 @@ func (_ ResourceFlags) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *ResourceFlags) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *ResourceFlags) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 uint8
 		zb0001, bts, err = msgp.ReadUint8Bytes(bts)
@@ -1440,6 +1718,12 @@ func (z *ResourceFlags) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *ResourceFlags) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *ResourceFlags) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *ResourceFlags) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*ResourceFlags)
 	return ok
@@ -1715,16 +1999,24 @@ func (_ *ResourcesData) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *ResourcesData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *ResourcesData) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0002 > 0 {
@@ -1857,14 +2149,14 @@ func (z *ResourcesData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0004 int
-			zb0004, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0006 int
+			zb0006, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ApprovalProgram")
 				return
 			}
-			if zb0004 > config.MaxAvailableAppProgramLen {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(config.MaxAvailableAppProgramLen))
+			if zb0006 > config.MaxAvailableAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxAvailableAppProgramLen))
 				return
 			}
 			(*z).ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApprovalProgram)
@@ -1875,14 +2167,14 @@ func (z *ResourcesData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0005 int
-			zb0005, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0007 int
+			zb0007, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "ClearStateProgram")
 				return
 			}
-			if zb0005 > config.MaxAvailableAppProgramLen {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(config.MaxAvailableAppProgramLen))
+			if zb0007 > config.MaxAvailableAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxAvailableAppProgramLen))
 				return
 			}
 			(*z).ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ClearStateProgram)
@@ -1942,13 +2234,13 @@ func (z *ResourcesData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		if zb0002 > 0 {
 			zb0002--
 			{
-				var zb0006 uint8
-				zb0006, bts, err = msgp.ReadUint8Bytes(bts)
+				var zb0008 uint8
+				zb0008, bts, err = msgp.ReadUint8Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "ResourceFlags")
 					return
 				}
-				(*z).ResourceFlags = ResourceFlags(zb0006)
+				(*z).ResourceFlags = ResourceFlags(zb0008)
 			}
 		}
 		if zb0002 > 0 {
@@ -1983,110 +2275,194 @@ func (z *ResourcesData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "a":
+				if validate && zb0005 && "a" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Total, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Total")
 					return
 				}
+				zb0004 = "a"
 			case "b":
+				if validate && zb0005 && "b" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Decimals, bts, err = msgp.ReadUint32Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Decimals")
 					return
 				}
+				zb0004 = "b"
 			case "c":
+				if validate && zb0005 && "c" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).DefaultFrozen, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "DefaultFrozen")
 					return
 				}
+				zb0004 = "c"
 			case "d":
+				if validate && zb0005 && "d" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).UnitName, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UnitName")
 					return
 				}
+				zb0004 = "d"
 			case "e":
+				if validate && zb0005 && "e" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).AssetName, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AssetName")
 					return
 				}
+				zb0004 = "e"
 			case "f":
+				if validate && zb0005 && "f" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).URL, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "URL")
 					return
 				}
+				zb0004 = "f"
 			case "g":
+				if validate && zb0005 && "g" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).MetadataHash)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "MetadataHash")
 					return
 				}
+				zb0004 = "g"
 			case "h":
+				if validate && zb0005 && "h" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Manager.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Manager")
 					return
 				}
+				zb0004 = "h"
 			case "i":
+				if validate && zb0005 && "i" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Reserve.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Reserve")
 					return
 				}
+				zb0004 = "i"
 			case "j":
+				if validate && zb0005 && "j" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Freeze.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Freeze")
 					return
 				}
+				zb0004 = "j"
 			case "k":
+				if validate && zb0005 && "k" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Clawback.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Clawback")
 					return
 				}
+				zb0004 = "k"
 			case "l":
+				if validate && zb0005 && "l" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Amount, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Amount")
 					return
 				}
+				zb0004 = "l"
 			case "m":
+				if validate && zb0005 && "m" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).Frozen, bts, err = msgp.ReadBoolBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Frozen")
 					return
 				}
+				zb0004 = "m"
 			case "n":
+				if validate && zb0005 && "n" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).SchemaNumUint, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SchemaNumUint")
 					return
 				}
+				zb0004 = "n"
 			case "o":
+				if validate && zb0005 && "o" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).SchemaNumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SchemaNumByteSlice")
 					return
 				}
+				zb0004 = "o"
 			case "p":
+				if validate && zb0005 && "p" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).KeyValue.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "KeyValue")
 					return
 				}
+				zb0004 = "p"
 			case "q":
-				var zb0007 int
-				zb0007, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0005 && "q" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0009 int
+				zb0009, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ApprovalProgram")
 					return
 				}
-				if zb0007 > config.MaxAvailableAppProgramLen {
-					err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxAvailableAppProgramLen))
+				if zb0009 > config.MaxAvailableAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxAvailableAppProgramLen))
 					return
 				}
 				(*z).ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApprovalProgram)
@@ -2094,15 +2470,20 @@ func (z *ResourcesData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "ApprovalProgram")
 					return
 				}
+				zb0004 = "q"
 			case "r":
-				var zb0008 int
-				zb0008, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0005 && "r" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0010 int
+				zb0010, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ClearStateProgram")
 					return
 				}
-				if zb0008 > config.MaxAvailableAppProgramLen {
-					err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxAvailableAppProgramLen))
+				if zb0010 > config.MaxAvailableAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0010), uint64(config.MaxAvailableAppProgramLen))
 					return
 				}
 				(*z).ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ClearStateProgram)
@@ -2110,58 +2491,99 @@ func (z *ResourcesData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "ClearStateProgram")
 					return
 				}
+				zb0004 = "r"
 			case "s":
+				if validate && zb0005 && "s" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).GlobalState.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GlobalState")
 					return
 				}
+				zb0004 = "s"
 			case "t":
+				if validate && zb0005 && "t" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).LocalStateSchemaNumUint, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "LocalStateSchemaNumUint")
 					return
 				}
+				zb0004 = "t"
 			case "u":
+				if validate && zb0005 && "u" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).LocalStateSchemaNumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "LocalStateSchemaNumByteSlice")
 					return
 				}
+				zb0004 = "u"
 			case "v":
+				if validate && zb0005 && "v" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).GlobalStateSchemaNumUint, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GlobalStateSchemaNumUint")
 					return
 				}
+				zb0004 = "v"
 			case "w":
+				if validate && zb0005 && "w" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).GlobalStateSchemaNumByteSlice, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "GlobalStateSchemaNumByteSlice")
 					return
 				}
+				zb0004 = "w"
 			case "x":
+				if validate && zb0005 && "x" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).ExtraProgramPages, bts, err = msgp.ReadUint32Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ExtraProgramPages")
 					return
 				}
+				zb0004 = "x"
 			case "y":
+				if validate && zb0005 && "y" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				{
-					var zb0009 uint8
-					zb0009, bts, err = msgp.ReadUint8Bytes(bts)
+					var zb0011 uint8
+					zb0011, bts, err = msgp.ReadUint8Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "ResourceFlags")
 						return
 					}
-					(*z).ResourceFlags = ResourceFlags(zb0009)
+					(*z).ResourceFlags = ResourceFlags(zb0011)
 				}
+				zb0004 = "y"
 			case "z":
+				if validate && zb0005 && "z" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).UpdateRound, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "UpdateRound")
 					return
 				}
+				zb0004 = "z"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2169,12 +2591,19 @@ func (z *ResourcesData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *ResourcesData) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *ResourcesData) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *ResourcesData) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*ResourcesData)
 	return ok
@@ -2282,11 +2711,15 @@ func (_ *TxTailRound) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *TxTailRound) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *TxTailRound) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0004 int
+	var zb0006 string
+	var zb0007 bool
 	var zb0005 bool
+	_ = zb0006
+	_ = zb0007
 	zb0004, zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -2294,21 +2727,25 @@ func (z *TxTailRound) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0006 int
-			var zb0007 bool
-			zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0008 int
+			var zb0009 bool
+			zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "TxnIDs")
 				return
 			}
-			if zb0007 {
+			if zb0009 {
 				(*z).TxnIDs = nil
-			} else if (*z).TxnIDs != nil && cap((*z).TxnIDs) >= zb0006 {
-				(*z).TxnIDs = ((*z).TxnIDs)[:zb0006]
+			} else if (*z).TxnIDs != nil && cap((*z).TxnIDs) >= zb0008 {
+				(*z).TxnIDs = ((*z).TxnIDs)[:zb0008]
 			} else {
-				(*z).TxnIDs = make([]transactions.Txid, zb0006)
+				(*z).TxnIDs = make([]transactions.Txid, zb0008)
 			}
 			for zb0001 := range (*z).TxnIDs {
 				bts, err = (*z).TxnIDs[zb0001].UnmarshalMsg(bts)
@@ -2320,19 +2757,19 @@ func (z *TxTailRound) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0008 int
-			var zb0009 bool
-			zb0008, zb0009, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0010 int
+			var zb0011 bool
+			zb0010, zb0011, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "LastValid")
 				return
 			}
-			if zb0009 {
+			if zb0011 {
 				(*z).LastValid = nil
-			} else if (*z).LastValid != nil && cap((*z).LastValid) >= zb0008 {
-				(*z).LastValid = ((*z).LastValid)[:zb0008]
+			} else if (*z).LastValid != nil && cap((*z).LastValid) >= zb0010 {
+				(*z).LastValid = ((*z).LastValid)[:zb0010]
 			} else {
-				(*z).LastValid = make([]basics.Round, zb0008)
+				(*z).LastValid = make([]basics.Round, zb0010)
 			}
 			for zb0002 := range (*z).LastValid {
 				bts, err = (*z).LastValid[zb0002].UnmarshalMsg(bts)
@@ -2344,19 +2781,19 @@ func (z *TxTailRound) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0004 > 0 {
 			zb0004--
-			var zb0010 int
-			var zb0011 bool
-			zb0010, zb0011, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0012 int
+			var zb0013 bool
+			zb0012, zb0013, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Leases")
 				return
 			}
-			if zb0011 {
+			if zb0013 {
 				(*z).Leases = nil
-			} else if (*z).Leases != nil && cap((*z).Leases) >= zb0010 {
-				(*z).Leases = ((*z).Leases)[:zb0010]
+			} else if (*z).Leases != nil && cap((*z).Leases) >= zb0012 {
+				(*z).Leases = ((*z).Leases)[:zb0012]
 			} else {
-				(*z).Leases = make([]TxTailRoundLease, zb0010)
+				(*z).Leases = make([]TxTailRoundLease, zb0012)
 			}
 			for zb0003 := range (*z).Leases {
 				bts, err = (*z).Leases[zb0003].UnmarshalMsg(bts)
@@ -2398,19 +2835,23 @@ func (z *TxTailRound) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "i":
-				var zb0012 int
-				var zb0013 bool
-				zb0012, zb0013, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0007 && "i" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0014 int
+				var zb0015 bool
+				zb0014, zb0015, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TxnIDs")
 					return
 				}
-				if zb0013 {
+				if zb0015 {
 					(*z).TxnIDs = nil
-				} else if (*z).TxnIDs != nil && cap((*z).TxnIDs) >= zb0012 {
-					(*z).TxnIDs = ((*z).TxnIDs)[:zb0012]
+				} else if (*z).TxnIDs != nil && cap((*z).TxnIDs) >= zb0014 {
+					(*z).TxnIDs = ((*z).TxnIDs)[:zb0014]
 				} else {
-					(*z).TxnIDs = make([]transactions.Txid, zb0012)
+					(*z).TxnIDs = make([]transactions.Txid, zb0014)
 				}
 				for zb0001 := range (*z).TxnIDs {
 					bts, err = (*z).TxnIDs[zb0001].UnmarshalMsg(bts)
@@ -2419,20 +2860,25 @@ func (z *TxTailRound) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0006 = "i"
 			case "v":
-				var zb0014 int
-				var zb0015 bool
-				zb0014, zb0015, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0007 && "v" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0016 int
+				var zb0017 bool
+				zb0016, zb0017, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "LastValid")
 					return
 				}
-				if zb0015 {
+				if zb0017 {
 					(*z).LastValid = nil
-				} else if (*z).LastValid != nil && cap((*z).LastValid) >= zb0014 {
-					(*z).LastValid = ((*z).LastValid)[:zb0014]
+				} else if (*z).LastValid != nil && cap((*z).LastValid) >= zb0016 {
+					(*z).LastValid = ((*z).LastValid)[:zb0016]
 				} else {
-					(*z).LastValid = make([]basics.Round, zb0014)
+					(*z).LastValid = make([]basics.Round, zb0016)
 				}
 				for zb0002 := range (*z).LastValid {
 					bts, err = (*z).LastValid[zb0002].UnmarshalMsg(bts)
@@ -2441,20 +2887,25 @@ func (z *TxTailRound) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0006 = "v"
 			case "l":
-				var zb0016 int
-				var zb0017 bool
-				zb0016, zb0017, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if validate && zb0007 && "l" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0018 int
+				var zb0019 bool
+				zb0018, zb0019, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Leases")
 					return
 				}
-				if zb0017 {
+				if zb0019 {
 					(*z).Leases = nil
-				} else if (*z).Leases != nil && cap((*z).Leases) >= zb0016 {
-					(*z).Leases = ((*z).Leases)[:zb0016]
+				} else if (*z).Leases != nil && cap((*z).Leases) >= zb0018 {
+					(*z).Leases = ((*z).Leases)[:zb0018]
 				} else {
-					(*z).Leases = make([]TxTailRoundLease, zb0016)
+					(*z).Leases = make([]TxTailRoundLease, zb0018)
 				}
 				for zb0003 := range (*z).Leases {
 					bts, err = (*z).Leases[zb0003].UnmarshalMsg(bts)
@@ -2463,12 +2914,18 @@ func (z *TxTailRound) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0006 = "l"
 			case "h":
+				if validate && zb0007 && "h" < zb0006 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Hdr.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Hdr")
 					return
 				}
+				zb0006 = "h"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2476,12 +2933,19 @@ func (z *TxTailRound) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0007 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *TxTailRound) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *TxTailRound) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *TxTailRound) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*TxTailRound)
 	return ok
@@ -2571,16 +3035,24 @@ func (_ *TxTailRoundLease) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *TxTailRoundLease) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *TxTailRoundLease) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0002 > 0 {
@@ -2631,23 +3103,38 @@ func (z *TxTailRoundLease) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "s":
+				if validate && zb0005 && "s" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sender.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sender")
 					return
 				}
+				zb0004 = "s"
 			case "l":
+				if validate && zb0005 && "l" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).Lease)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "Lease")
 					return
 				}
+				zb0004 = "l"
 			case "TxnIdx":
+				if validate && zb0005 && "TxnIdx" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				(*z).TxnIdx, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "TxnIdx")
 					return
 				}
+				zb0004 = "TxnIdx"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -2655,12 +3142,19 @@ func (z *TxTailRoundLease) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *TxTailRoundLease) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *TxTailRoundLease) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *TxTailRoundLease) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*TxTailRoundLease)
 	return ok

--- a/network/msgp_gen.go
+++ b/network/msgp_gen.go
@@ -13,6 +13,7 @@ import (
 //         |-----> MarshalMsg
 //         |-----> CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> Msgsize
 //         |-----> MsgIsZero
@@ -22,6 +23,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -31,6 +33,7 @@ import (
 //             |-----> (*) MarshalMsg
 //             |-----> (*) CanMarshalMsg
 //             |-----> (*) UnmarshalMsg
+//             |-----> (*) UnmarshalValidateMsg
 //             |-----> (*) CanUnmarshalMsg
 //             |-----> (*) Msgsize
 //             |-----> (*) MsgIsZero
@@ -40,6 +43,7 @@ import (
 //                |-----> (*) MarshalMsg
 //                |-----> (*) CanMarshalMsg
 //                |-----> (*) UnmarshalMsg
+//                |-----> (*) UnmarshalValidateMsg
 //                |-----> (*) CanUnmarshalMsg
 //                |-----> (*) Msgsize
 //                |-----> (*) MsgIsZero
@@ -49,6 +53,7 @@ import (
 //            |-----> (*) MarshalMsg
 //            |-----> (*) CanMarshalMsg
 //            |-----> (*) UnmarshalMsg
+//            |-----> (*) UnmarshalValidateMsg
 //            |-----> (*) CanUnmarshalMsg
 //            |-----> (*) Msgsize
 //            |-----> (*) MsgIsZero
@@ -58,6 +63,7 @@ import (
 //            |-----> (*) MarshalMsg
 //            |-----> (*) CanMarshalMsg
 //            |-----> (*) UnmarshalMsg
+//            |-----> (*) UnmarshalValidateMsg
 //            |-----> (*) CanUnmarshalMsg
 //            |-----> (*) Msgsize
 //            |-----> (*) MsgIsZero
@@ -67,6 +73,7 @@ import (
 //              |-----> (*) MarshalMsg
 //              |-----> (*) CanMarshalMsg
 //              |-----> (*) UnmarshalMsg
+//              |-----> (*) UnmarshalValidateMsg
 //              |-----> (*) CanUnmarshalMsg
 //              |-----> (*) Msgsize
 //              |-----> (*) MsgIsZero
@@ -76,6 +83,7 @@ import (
 //                 |-----> (*) MarshalMsg
 //                 |-----> (*) CanMarshalMsg
 //                 |-----> (*) UnmarshalMsg
+//                 |-----> (*) UnmarshalValidateMsg
 //                 |-----> (*) CanUnmarshalMsg
 //                 |-----> (*) Msgsize
 //                 |-----> (*) MsgIsZero
@@ -98,7 +106,7 @@ func (_ disconnectReason) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *disconnectReason) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *disconnectReason) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 string
 		zb0001, bts, err = msgp.ReadStringBytes(bts)
@@ -112,6 +120,12 @@ func (z *disconnectReason) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *disconnectReason) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *disconnectReason) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *disconnectReason) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*disconnectReason)
 	return ok
@@ -180,16 +194,24 @@ func (_ *identityChallenge) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *identityChallenge) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *identityChallenge) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0002 > 0 {
@@ -210,14 +232,14 @@ func (z *identityChallenge) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0004 int
-			zb0004, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0006 int
+			zb0006, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "PublicAddress")
 				return
 			}
-			if zb0004 > maxAddressLen {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(maxAddressLen))
+			if zb0006 > maxAddressLen {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(maxAddressLen))
 				return
 			}
 			(*z).PublicAddress, bts, err = msgp.ReadBytesBytes(bts, (*z).PublicAddress)
@@ -250,26 +272,40 @@ func (z *identityChallenge) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "pk":
+				if validate && zb0005 && "pk" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Key.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Key")
 					return
 				}
+				zb0004 = "pk"
 			case "c":
+				if validate && zb0005 && "c" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).Challenge)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "Challenge")
 					return
 				}
+				zb0004 = "c"
 			case "a":
-				var zb0005 int
-				zb0005, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0005 && "a" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0007 int
+				zb0007, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "PublicAddress")
 					return
 				}
-				if zb0005 > maxAddressLen {
-					err = msgp.ErrOverflow(uint64(zb0005), uint64(maxAddressLen))
+				if zb0007 > maxAddressLen {
+					err = msgp.ErrOverflow(uint64(zb0007), uint64(maxAddressLen))
 					return
 				}
 				(*z).PublicAddress, bts, err = msgp.ReadBytesBytes(bts, (*z).PublicAddress)
@@ -277,6 +313,7 @@ func (z *identityChallenge) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "PublicAddress")
 					return
 				}
+				zb0004 = "a"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -284,12 +321,19 @@ func (z *identityChallenge) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *identityChallenge) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *identityChallenge) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *identityChallenge) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*identityChallenge)
 	return ok
@@ -361,16 +405,24 @@ func (_ *identityChallengeResponse) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *identityChallengeResponse) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *identityChallengeResponse) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -421,23 +473,38 @@ func (z *identityChallengeResponse) UnmarshalMsg(bts []byte) (o []byte, err erro
 			}
 			switch string(field) {
 			case "pk":
+				if validate && zb0006 && "pk" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Key.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Key")
 					return
 				}
+				zb0005 = "pk"
 			case "c":
+				if validate && zb0006 && "c" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).Challenge)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "Challenge")
 					return
 				}
+				zb0005 = "c"
 			case "rc":
+				if validate && zb0006 && "rc" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).ResponseChallenge)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "ResponseChallenge")
 					return
 				}
+				zb0005 = "rc"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -445,12 +512,19 @@ func (z *identityChallengeResponse) UnmarshalMsg(bts []byte) (o []byte, err erro
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *identityChallengeResponse) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *identityChallengeResponse) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *identityChallengeResponse) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*identityChallengeResponse)
 	return ok
@@ -515,16 +589,24 @@ func (_ *identityChallengeResponseSigned) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *identityChallengeResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *identityChallengeResponseSigned) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -567,17 +649,27 @@ func (z *identityChallengeResponseSigned) UnmarshalMsg(bts []byte) (o []byte, er
 			}
 			switch string(field) {
 			case "icr":
+				if validate && zb0004 && "icr" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Msg.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Msg")
 					return
 				}
+				zb0003 = "icr"
 			case "sig":
+				if validate && zb0004 && "sig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Signature.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Signature")
 					return
 				}
+				zb0003 = "sig"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -585,12 +677,19 @@ func (z *identityChallengeResponseSigned) UnmarshalMsg(bts []byte) (o []byte, er
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *identityChallengeResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *identityChallengeResponseSigned) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *identityChallengeResponseSigned) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*identityChallengeResponseSigned)
 	return ok
@@ -650,16 +749,24 @@ func (_ *identityChallengeSigned) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *identityChallengeSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *identityChallengeSigned) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -702,17 +809,27 @@ func (z *identityChallengeSigned) UnmarshalMsg(bts []byte) (o []byte, err error)
 			}
 			switch string(field) {
 			case "ic":
+				if validate && zb0004 && "ic" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Msg.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Msg")
 					return
 				}
+				zb0003 = "ic"
 			case "sig":
+				if validate && zb0004 && "sig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Signature.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Signature")
 					return
 				}
+				zb0003 = "sig"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -720,12 +837,19 @@ func (z *identityChallengeSigned) UnmarshalMsg(bts []byte) (o []byte, err error)
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *identityChallengeSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *identityChallengeSigned) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *identityChallengeSigned) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*identityChallengeSigned)
 	return ok
@@ -761,7 +885,7 @@ func (_ *identityChallengeValue) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *identityChallengeValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *identityChallengeValue) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	bts, err = msgp.ReadExactBytes(bts, (*z)[:])
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -771,6 +895,12 @@ func (z *identityChallengeValue) UnmarshalMsg(bts []byte) (o []byte, err error) 
 	return
 }
 
+func (z *identityChallengeValue) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *identityChallengeValue) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *identityChallengeValue) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*identityChallengeValue)
 	return ok
@@ -822,16 +952,24 @@ func (_ *identityVerificationMessage) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *identityVerificationMessage) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *identityVerificationMessage) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0002 > 0 {
@@ -866,11 +1004,16 @@ func (z *identityVerificationMessage) UnmarshalMsg(bts []byte) (o []byte, err er
 			}
 			switch string(field) {
 			case "rc":
+				if validate && zb0005 && "rc" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = msgp.ReadExactBytes(bts, ((*z).ResponseChallenge)[:])
 				if err != nil {
 					err = msgp.WrapError(err, "ResponseChallenge")
 					return
 				}
+				zb0004 = "rc"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -878,12 +1021,19 @@ func (z *identityVerificationMessage) UnmarshalMsg(bts []byte) (o []byte, err er
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *identityVerificationMessage) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *identityVerificationMessage) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *identityVerificationMessage) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*identityVerificationMessage)
 	return ok
@@ -958,11 +1108,15 @@ func (_ *identityVerificationMessageSigned) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *identityVerificationMessageSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *identityVerificationMessageSigned) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0002 int
+	var zb0004 string
+	var zb0005 bool
 	var zb0003 bool
+	_ = zb0004
+	_ = zb0005
 	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -970,27 +1124,39 @@ func (z *identityVerificationMessageSigned) UnmarshalMsg(bts []byte) (o []byte, 
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0002 > 0 {
 			zb0002--
-			var zb0004 int
-			var zb0005 bool
-			zb0004, zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0006 int
+			var zb0008 string
+			var zb0009 bool
+			var zb0007 bool
+			_ = zb0008
+			_ = zb0009
+			zb0006, zb0007, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0004, zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Msg")
 					return
 				}
-				if zb0004 > 0 {
-					zb0004--
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0006 > 0 {
+					zb0006--
 					bts, err = msgp.ReadExactBytes(bts, ((*z).Msg.ResponseChallenge)[:])
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Msg", "struct-from-array", "ResponseChallenge")
 						return
 					}
 				}
-				if zb0004 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0004)
+				if zb0006 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0006)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Msg", "struct-from-array")
 						return
@@ -1001,11 +1167,11 @@ func (z *identityVerificationMessageSigned) UnmarshalMsg(bts []byte) (o []byte, 
 					err = msgp.WrapError(err, "struct-from-array", "Msg")
 					return
 				}
-				if zb0005 {
+				if zb0007 {
 					(*z).Msg = identityVerificationMessage{}
 				}
-				for zb0004 > 0 {
-					zb0004--
+				for zb0006 > 0 {
+					zb0006--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Msg")
@@ -1013,11 +1179,16 @@ func (z *identityVerificationMessageSigned) UnmarshalMsg(bts []byte) (o []byte, 
 					}
 					switch string(field) {
 					case "rc":
+						if validate && zb0009 && "rc" < zb0008 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
 						bts, err = msgp.ReadExactBytes(bts, ((*z).Msg.ResponseChallenge)[:])
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Msg", "ResponseChallenge")
 							return
 						}
+						zb0008 = "rc"
 					default:
 						err = msgp.ErrNoField(string(field))
 						if err != nil {
@@ -1025,6 +1196,7 @@ func (z *identityVerificationMessageSigned) UnmarshalMsg(bts []byte) (o []byte, 
 							return
 						}
 					}
+					zb0009 = true
 				}
 			}
 		}
@@ -1060,25 +1232,37 @@ func (z *identityVerificationMessageSigned) UnmarshalMsg(bts []byte) (o []byte, 
 			}
 			switch string(field) {
 			case "ivm":
-				var zb0006 int
-				var zb0007 bool
-				zb0006, zb0007, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0005 && "ivm" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0010 int
+				var zb0012 string
+				var zb0013 bool
+				var zb0011 bool
+				_ = zb0012
+				_ = zb0013
+				zb0010, zb0011, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0006, zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0010, zb0011, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Msg")
 						return
 					}
-					if zb0006 > 0 {
-						zb0006--
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0010 > 0 {
+						zb0010--
 						bts, err = msgp.ReadExactBytes(bts, ((*z).Msg.ResponseChallenge)[:])
 						if err != nil {
 							err = msgp.WrapError(err, "Msg", "struct-from-array", "ResponseChallenge")
 							return
 						}
 					}
-					if zb0006 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0006)
+					if zb0010 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0010)
 						if err != nil {
 							err = msgp.WrapError(err, "Msg", "struct-from-array")
 							return
@@ -1089,11 +1273,11 @@ func (z *identityVerificationMessageSigned) UnmarshalMsg(bts []byte) (o []byte, 
 						err = msgp.WrapError(err, "Msg")
 						return
 					}
-					if zb0007 {
+					if zb0011 {
 						(*z).Msg = identityVerificationMessage{}
 					}
-					for zb0006 > 0 {
-						zb0006--
+					for zb0010 > 0 {
+						zb0010--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Msg")
@@ -1101,11 +1285,16 @@ func (z *identityVerificationMessageSigned) UnmarshalMsg(bts []byte) (o []byte, 
 						}
 						switch string(field) {
 						case "rc":
+							if validate && zb0013 && "rc" < zb0012 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
 							bts, err = msgp.ReadExactBytes(bts, ((*z).Msg.ResponseChallenge)[:])
 							if err != nil {
 								err = msgp.WrapError(err, "Msg", "ResponseChallenge")
 								return
 							}
+							zb0012 = "rc"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -1113,14 +1302,21 @@ func (z *identityVerificationMessageSigned) UnmarshalMsg(bts []byte) (o []byte, 
 								return
 							}
 						}
+						zb0013 = true
 					}
 				}
+				zb0004 = "ivm"
 			case "sig":
+				if validate && zb0005 && "sig" < zb0004 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Signature.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Signature")
 					return
 				}
+				zb0004 = "sig"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -1128,12 +1324,19 @@ func (z *identityVerificationMessageSigned) UnmarshalMsg(bts []byte) (o []byte, 
 					return
 				}
 			}
+			zb0005 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *identityVerificationMessageSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *identityVerificationMessageSigned) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *identityVerificationMessageSigned) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*identityVerificationMessageSigned)
 	return ok

--- a/node/msgp_gen.go
+++ b/node/msgp_gen.go
@@ -14,6 +14,7 @@ import (
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> (*) Msgsize
 //        |-----> (*) MsgIsZero
@@ -23,6 +24,7 @@ import (
 //           |-----> (*) MarshalMsg
 //           |-----> (*) CanMarshalMsg
 //           |-----> (*) UnmarshalMsg
+//           |-----> (*) UnmarshalValidateMsg
 //           |-----> (*) CanUnmarshalMsg
 //           |-----> (*) Msgsize
 //           |-----> (*) MsgIsZero
@@ -57,11 +59,15 @@ func (_ *netPrioResponse) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *netPrioResponse) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *netPrioResponse) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -69,16 +75,20 @@ func (z *netPrioResponse) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0001 > 0 {
 			zb0001--
-			var zb0003 int
-			zb0003, err = msgp.ReadBytesBytesHeader(bts)
+			var zb0005 int
+			zb0005, err = msgp.ReadBytesBytesHeader(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Nonce")
 				return
 			}
-			if zb0003 > netPrioChallengeSize {
-				err = msgp.ErrOverflow(uint64(zb0003), uint64(netPrioChallengeSize))
+			if zb0005 > netPrioChallengeSize {
+				err = msgp.ErrOverflow(uint64(zb0005), uint64(netPrioChallengeSize))
 				return
 			}
 			(*z).Nonce, bts, err = msgp.ReadStringBytes(bts)
@@ -111,14 +121,18 @@ func (z *netPrioResponse) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "Nonce":
-				var zb0004 int
-				zb0004, err = msgp.ReadBytesBytesHeader(bts)
+				if validate && zb0004 && "Nonce" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0006 int
+				zb0006, err = msgp.ReadBytesBytesHeader(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Nonce")
 					return
 				}
-				if zb0004 > netPrioChallengeSize {
-					err = msgp.ErrOverflow(uint64(zb0004), uint64(netPrioChallengeSize))
+				if zb0006 > netPrioChallengeSize {
+					err = msgp.ErrOverflow(uint64(zb0006), uint64(netPrioChallengeSize))
 					return
 				}
 				(*z).Nonce, bts, err = msgp.ReadStringBytes(bts)
@@ -126,6 +140,7 @@ func (z *netPrioResponse) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "Nonce")
 					return
 				}
+				zb0003 = "Nonce"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -133,12 +148,19 @@ func (z *netPrioResponse) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *netPrioResponse) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *netPrioResponse) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *netPrioResponse) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*netPrioResponse)
 	return ok
@@ -229,11 +251,15 @@ func (_ *netPrioResponseSigned) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *netPrioResponseSigned) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -241,27 +267,39 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			err = msgp.WrapError(err)
 			return
 		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
+			return
+		}
 		if zb0001 > 0 {
 			zb0001--
-			var zb0003 int
-			var zb0004 bool
-			zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0005 int
+			var zb0007 string
+			var zb0008 bool
+			var zb0006 bool
+			_ = zb0007
+			_ = zb0008
+			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if _, ok := err.(msgp.TypeError); ok {
-				zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "Response")
 					return
 				}
-				if zb0003 > 0 {
-					zb0003--
-					var zb0005 int
-					zb0005, err = msgp.ReadBytesBytesHeader(bts)
+				if validate {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				if zb0005 > 0 {
+					zb0005--
+					var zb0009 int
+					zb0009, err = msgp.ReadBytesBytesHeader(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Response", "struct-from-array", "Nonce")
 						return
 					}
-					if zb0005 > netPrioChallengeSize {
-						err = msgp.ErrOverflow(uint64(zb0005), uint64(netPrioChallengeSize))
+					if zb0009 > netPrioChallengeSize {
+						err = msgp.ErrOverflow(uint64(zb0009), uint64(netPrioChallengeSize))
 						return
 					}
 					(*z).Response.Nonce, bts, err = msgp.ReadStringBytes(bts)
@@ -270,8 +308,8 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
-				if zb0003 > 0 {
-					err = msgp.ErrTooManyArrayFields(zb0003)
+				if zb0005 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0005)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Response", "struct-from-array")
 						return
@@ -282,11 +320,11 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "struct-from-array", "Response")
 					return
 				}
-				if zb0004 {
+				if zb0006 {
 					(*z).Response = netPrioResponse{}
 				}
-				for zb0003 > 0 {
-					zb0003--
+				for zb0005 > 0 {
+					zb0005--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "struct-from-array", "Response")
@@ -294,14 +332,18 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch string(field) {
 					case "Nonce":
-						var zb0006 int
-						zb0006, err = msgp.ReadBytesBytesHeader(bts)
+						if validate && zb0008 && "Nonce" < zb0007 {
+							err = &msgp.ErrNonCanonical{}
+							return
+						}
+						var zb0010 int
+						zb0010, err = msgp.ReadBytesBytesHeader(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "struct-from-array", "Response", "Nonce")
 							return
 						}
-						if zb0006 > netPrioChallengeSize {
-							err = msgp.ErrOverflow(uint64(zb0006), uint64(netPrioChallengeSize))
+						if zb0010 > netPrioChallengeSize {
+							err = msgp.ErrOverflow(uint64(zb0010), uint64(netPrioChallengeSize))
 							return
 						}
 						(*z).Response.Nonce, bts, err = msgp.ReadStringBytes(bts)
@@ -309,6 +351,7 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							err = msgp.WrapError(err, "struct-from-array", "Response", "Nonce")
 							return
 						}
+						zb0007 = "Nonce"
 					default:
 						err = msgp.ErrNoField(string(field))
 						if err != nil {
@@ -316,6 +359,7 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
+					zb0008 = true
 				}
 			}
 		}
@@ -367,25 +411,37 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "Response":
-				var zb0007 int
-				var zb0008 bool
-				zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0004 && "Response" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0011 int
+				var zb0013 string
+				var zb0014 bool
+				var zb0012 bool
+				_ = zb0013
+				_ = zb0014
+				zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if _, ok := err.(msgp.TypeError); ok {
-					zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "Response")
 						return
 					}
-					if zb0007 > 0 {
-						zb0007--
-						var zb0009 int
-						zb0009, err = msgp.ReadBytesBytesHeader(bts)
+					if validate {
+						err = &msgp.ErrNonCanonical{}
+						return
+					}
+					if zb0011 > 0 {
+						zb0011--
+						var zb0015 int
+						zb0015, err = msgp.ReadBytesBytesHeader(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Response", "struct-from-array", "Nonce")
 							return
 						}
-						if zb0009 > netPrioChallengeSize {
-							err = msgp.ErrOverflow(uint64(zb0009), uint64(netPrioChallengeSize))
+						if zb0015 > netPrioChallengeSize {
+							err = msgp.ErrOverflow(uint64(zb0015), uint64(netPrioChallengeSize))
 							return
 						}
 						(*z).Response.Nonce, bts, err = msgp.ReadStringBytes(bts)
@@ -394,8 +450,8 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					}
-					if zb0007 > 0 {
-						err = msgp.ErrTooManyArrayFields(zb0007)
+					if zb0011 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0011)
 						if err != nil {
 							err = msgp.WrapError(err, "Response", "struct-from-array")
 							return
@@ -406,11 +462,11 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "Response")
 						return
 					}
-					if zb0008 {
+					if zb0012 {
 						(*z).Response = netPrioResponse{}
 					}
-					for zb0007 > 0 {
-						zb0007--
+					for zb0011 > 0 {
+						zb0011--
 						field, bts, err = msgp.ReadMapKeyZC(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Response")
@@ -418,14 +474,18 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						}
 						switch string(field) {
 						case "Nonce":
-							var zb0010 int
-							zb0010, err = msgp.ReadBytesBytesHeader(bts)
+							if validate && zb0014 && "Nonce" < zb0013 {
+								err = &msgp.ErrNonCanonical{}
+								return
+							}
+							var zb0016 int
+							zb0016, err = msgp.ReadBytesBytesHeader(bts)
 							if err != nil {
 								err = msgp.WrapError(err, "Response", "Nonce")
 								return
 							}
-							if zb0010 > netPrioChallengeSize {
-								err = msgp.ErrOverflow(uint64(zb0010), uint64(netPrioChallengeSize))
+							if zb0016 > netPrioChallengeSize {
+								err = msgp.ErrOverflow(uint64(zb0016), uint64(netPrioChallengeSize))
 								return
 							}
 							(*z).Response.Nonce, bts, err = msgp.ReadStringBytes(bts)
@@ -433,6 +493,7 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								err = msgp.WrapError(err, "Response", "Nonce")
 								return
 							}
+							zb0013 = "Nonce"
 						default:
 							err = msgp.ErrNoField(string(field))
 							if err != nil {
@@ -440,26 +501,43 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								return
 							}
 						}
+						zb0014 = true
 					}
 				}
+				zb0003 = "Response"
 			case "Round":
+				if validate && zb0004 && "Round" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Round.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0003 = "Round"
 			case "Sender":
+				if validate && zb0004 && "Sender" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sender.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sender")
 					return
 				}
+				zb0003 = "Sender"
 			case "Sig":
+				if validate && zb0004 && "Sig" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sig")
 					return
 				}
+				zb0003 = "Sig"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -467,12 +545,19 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *netPrioResponseSigned) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *netPrioResponseSigned) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*netPrioResponseSigned)
 	return ok

--- a/protocol/msgp_gen.go
+++ b/protocol/msgp_gen.go
@@ -11,6 +11,7 @@ import (
 //         |-----> MarshalMsg
 //         |-----> CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> Msgsize
 //         |-----> MsgIsZero
@@ -20,6 +21,7 @@ import (
 //   |-----> MarshalMsg
 //   |-----> CanMarshalMsg
 //   |-----> (*) UnmarshalMsg
+//   |-----> (*) UnmarshalValidateMsg
 //   |-----> (*) CanUnmarshalMsg
 //   |-----> Msgsize
 //   |-----> MsgIsZero
@@ -29,6 +31,7 @@ import (
 //    |-----> MarshalMsg
 //    |-----> CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> Msgsize
 //    |-----> MsgIsZero
@@ -38,6 +41,7 @@ import (
 //     |-----> MarshalMsg
 //     |-----> CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> Msgsize
 //     |-----> MsgIsZero
@@ -47,6 +51,7 @@ import (
 //        |-----> MarshalMsg
 //        |-----> CanMarshalMsg
 //        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalValidateMsg
 //        |-----> (*) CanUnmarshalMsg
 //        |-----> Msgsize
 //        |-----> MsgIsZero
@@ -56,6 +61,7 @@ import (
 //  |-----> MarshalMsg
 //  |-----> CanMarshalMsg
 //  |-----> (*) UnmarshalMsg
+//  |-----> (*) UnmarshalValidateMsg
 //  |-----> (*) CanUnmarshalMsg
 //  |-----> Msgsize
 //  |-----> MsgIsZero
@@ -65,6 +71,7 @@ import (
 //    |-----> MarshalMsg
 //    |-----> CanMarshalMsg
 //    |-----> (*) UnmarshalMsg
+//    |-----> (*) UnmarshalValidateMsg
 //    |-----> (*) CanUnmarshalMsg
 //    |-----> Msgsize
 //    |-----> MsgIsZero
@@ -87,7 +94,7 @@ func (_ ConsensusVersion) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *ConsensusVersion) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *ConsensusVersion) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 string
 		var zb0002 int
@@ -111,6 +118,12 @@ func (z *ConsensusVersion) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *ConsensusVersion) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *ConsensusVersion) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *ConsensusVersion) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*ConsensusVersion)
 	return ok
@@ -149,7 +162,7 @@ func (_ Error) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Error) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Error) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 string
 		zb0001, bts, err = msgp.ReadStringBytes(bts)
@@ -163,6 +176,12 @@ func (z *Error) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *Error) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Error) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Error) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Error)
 	return ok
@@ -201,7 +220,7 @@ func (_ HashID) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *HashID) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *HashID) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 string
 		zb0001, bts, err = msgp.ReadStringBytes(bts)
@@ -215,6 +234,12 @@ func (z *HashID) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *HashID) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *HashID) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *HashID) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*HashID)
 	return ok
@@ -253,7 +278,7 @@ func (_ NetworkID) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *NetworkID) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *NetworkID) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 string
 		zb0001, bts, err = msgp.ReadStringBytes(bts)
@@ -267,6 +292,12 @@ func (z *NetworkID) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *NetworkID) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *NetworkID) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *NetworkID) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*NetworkID)
 	return ok
@@ -305,7 +336,7 @@ func (_ StateProofType) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *StateProofType) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *StateProofType) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 uint64
 		zb0001, bts, err = msgp.ReadUint64Bytes(bts)
@@ -319,6 +350,12 @@ func (z *StateProofType) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *StateProofType) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *StateProofType) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *StateProofType) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*StateProofType)
 	return ok
@@ -357,7 +394,7 @@ func (_ Tag) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Tag) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *Tag) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 string
 		zb0001, bts, err = msgp.ReadStringBytes(bts)
@@ -371,6 +408,12 @@ func (z *Tag) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *Tag) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *Tag) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *Tag) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*Tag)
 	return ok
@@ -409,7 +452,7 @@ func (_ TxType) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *TxType) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *TxType) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	{
 		var zb0001 string
 		var zb0002 int
@@ -433,6 +476,12 @@ func (z *TxType) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *TxType) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *TxType) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *TxType) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*TxType)
 	return ok

--- a/protocol/stateproof.go
+++ b/protocol/stateproof.go
@@ -37,9 +37,10 @@ const (
 // canonical encoding of maps in msgpack format.
 //
 //msgp:ignore SortStateProofType
-//msgp:sort StateProofType SortStateProofType
+//msgp:sort StateProofType SortStateProofType StateProofTypeLess
 type SortStateProofType []StateProofType
 
-func (a SortStateProofType) Len() int           { return len(a) }
-func (a SortStateProofType) Less(i, j int) bool { return a[i] < a[j] }
-func (a SortStateProofType) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a SortStateProofType) Len() int             { return len(a) }
+func (a SortStateProofType) Less(i, j int) bool   { return a[i] < a[j] }
+func (a SortStateProofType) Swap(i, j int)        { a[i], a[j] = a[j], a[i] }
+func StateProofTypeLess(a, b StateProofType) bool { return a < b }

--- a/protocol/test/msgp_gen.go
+++ b/protocol/test/msgp_gen.go
@@ -11,6 +11,7 @@ import (
 //     |-----> MarshalMsg
 //     |-----> CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> Msgsize
 //     |-----> MsgIsZero
@@ -40,7 +41,7 @@ func (_ testSlice) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *testSlice) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *testSlice) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var zb0002 int
 	var zb0003 bool
 	zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -71,6 +72,12 @@ func (z *testSlice) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+func (z *testSlice) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *testSlice) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *testSlice) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*testSlice)
 	return ok

--- a/rpcs/msgp_gen.go
+++ b/rpcs/msgp_gen.go
@@ -14,6 +14,7 @@ import (
 //         |-----> (*) MarshalMsg
 //         |-----> (*) CanMarshalMsg
 //         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalValidateMsg
 //         |-----> (*) CanUnmarshalMsg
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
@@ -39,16 +40,24 @@ func (_ *EncodedBlockCert) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *EncodedBlockCert) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *EncodedBlockCert) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -91,17 +100,27 @@ func (z *EncodedBlockCert) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "block":
+				if validate && zb0004 && "block" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Block.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Block")
 					return
 				}
+				zb0003 = "block"
 			case "cert":
+				if validate && zb0004 && "cert" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Certificate.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Certificate")
 					return
 				}
+				zb0003 = "cert"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -109,12 +128,19 @@ func (z *EncodedBlockCert) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *EncodedBlockCert) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *EncodedBlockCert) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *EncodedBlockCert) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*EncodedBlockCert)
 	return ok

--- a/stateproof/msgp_gen.go
+++ b/stateproof/msgp_gen.go
@@ -261,7 +261,7 @@ func (z *spProver) MarshalMsg(b []byte) (o []byte) {
 			for zb0001 := range (*z).AddrToPos {
 				zb0001_keys = append(zb0001_keys, zb0001)
 			}
-			sort.Sort((zb0001_keys))
+			sort.Sort(SortAddress(zb0001_keys))
 			for _, zb0001 := range zb0001_keys {
 				zb0002 := (*z).AddrToPos[zb0001]
 				_ = zb0002
@@ -369,6 +369,10 @@ func (z *spProver) unmarshalMsg(bts []byte, validate bool) (o []byte, err error)
 					err = msgp.WrapError(err, "struct-from-array", "AddrToPos")
 					return
 				}
+				if validate && zb0010 && basics.AddressLess(zb0001, zb0009) {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				zb0009 = zb0001
 				zb0010 = true
 				zb0002, bts, err = msgp.ReadUint64Bytes(bts)
@@ -473,6 +477,10 @@ func (z *spProver) unmarshalMsg(bts []byte, validate bool) (o []byte, err error)
 					bts, err = zb0001.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "AddrToPos")
+						return
+					}
+					if validate && zb0014 && basics.AddressLess(zb0001, zb0013) {
+						err = &msgp.ErrNonCanonical{}
 						return
 					}
 					zb0013 = zb0001

--- a/stateproof/msgp_gen.go
+++ b/stateproof/msgp_gen.go
@@ -19,6 +19,7 @@ import (
 //      |-----> (*) MarshalMsg
 //      |-----> (*) CanMarshalMsg
 //      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalValidateMsg
 //      |-----> (*) CanUnmarshalMsg
 //      |-----> (*) Msgsize
 //      |-----> (*) MsgIsZero
@@ -28,6 +29,7 @@ import (
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
 //     |-----> (*) UnmarshalMsg
+//     |-----> (*) UnmarshalValidateMsg
 //     |-----> (*) CanUnmarshalMsg
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
@@ -80,16 +82,24 @@ func (_ *sigFromAddr) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *sigFromAddr) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *sigFromAddr) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0001 int
+	var zb0003 string
+	var zb0004 bool
 	var zb0002 bool
+	_ = zb0003
+	_ = zb0004
 	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0001 > 0 {
@@ -140,23 +150,38 @@ func (z *sigFromAddr) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "a":
+				if validate && zb0004 && "a" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).SignerAddress.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "SignerAddress")
 					return
 				}
+				zb0003 = "a"
 			case "r":
+				if validate && zb0004 && "r" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Round.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Round")
 					return
 				}
+				zb0003 = "r"
 			case "s":
+				if validate && zb0004 && "s" < zb0003 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Sig.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Sig")
 					return
 				}
+				zb0003 = "s"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -164,12 +189,19 @@ func (z *sigFromAddr) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0004 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *sigFromAddr) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *sigFromAddr) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *sigFromAddr) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*sigFromAddr)
 	return ok
@@ -229,7 +261,7 @@ func (z *spProver) MarshalMsg(b []byte) (o []byte) {
 			for zb0001 := range (*z).AddrToPos {
 				zb0001_keys = append(zb0001_keys, zb0001)
 			}
-			sort.Sort(SortAddress(zb0001_keys))
+			sort.Sort((zb0001_keys))
 			for _, zb0001 := range zb0001_keys {
 				zb0002 := (*z).AddrToPos[zb0001]
 				_ = zb0002
@@ -266,16 +298,24 @@ func (_ *spProver) CanMarshalMsg(z interface{}) bool {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *spProver) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *spProver) unmarshalMsg(bts []byte, validate bool) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var zb0003 int
+	var zb0005 string
+	var zb0006 bool
 	var zb0004 bool
+	_ = zb0005
+	_ = zb0006
 	zb0003, zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if _, ok := err.(msgp.TypeError); ok {
 		zb0003, zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
+			return
+		}
+		if validate {
+			err = &msgp.ErrNonCanonical{}
 			return
 		}
 		if zb0003 > 0 {
@@ -299,32 +339,38 @@ func (z *spProver) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if zb0003 > 0 {
 			zb0003--
-			var zb0005 int
-			var zb0006 bool
-			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0007 int
+			var zb0008 bool
+			zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "AddrToPos")
 				return
 			}
-			if zb0005 > stateproof.VotersAllocBound {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(stateproof.VotersAllocBound))
+			if zb0007 > stateproof.VotersAllocBound {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(stateproof.VotersAllocBound))
 				err = msgp.WrapError(err, "struct-from-array", "AddrToPos")
 				return
 			}
-			if zb0006 {
+			if zb0008 {
 				(*z).AddrToPos = nil
 			} else if (*z).AddrToPos == nil {
-				(*z).AddrToPos = make(map[Address]uint64, zb0005)
+				(*z).AddrToPos = make(map[Address]uint64, zb0007)
 			}
-			for zb0005 > 0 {
+			var zb0009 basics.Address
+			_ = zb0009
+			var zb0010 bool
+			_ = zb0010
+			for zb0007 > 0 {
 				var zb0001 basics.Address
 				var zb0002 uint64
-				zb0005--
+				zb0007--
 				bts, err = zb0001.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "AddrToPos")
 					return
 				}
+				zb0009 = zb0001
+				zb0010 = true
 				zb0002, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "struct-from-array", "AddrToPos", zb0001)
@@ -373,6 +419,10 @@ func (z *spProver) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			switch string(field) {
 			case "prv":
+				if validate && zb0006 && "prv" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
@@ -389,33 +439,44 @@ func (z *spProver) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						return
 					}
 				}
+				zb0005 = "prv"
 			case "addr":
-				var zb0007 int
-				var zb0008 bool
-				zb0007, zb0008, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if validate && zb0006 && "addr" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
+				var zb0011 int
+				var zb0012 bool
+				zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "AddrToPos")
 					return
 				}
-				if zb0007 > stateproof.VotersAllocBound {
-					err = msgp.ErrOverflow(uint64(zb0007), uint64(stateproof.VotersAllocBound))
+				if zb0011 > stateproof.VotersAllocBound {
+					err = msgp.ErrOverflow(uint64(zb0011), uint64(stateproof.VotersAllocBound))
 					err = msgp.WrapError(err, "AddrToPos")
 					return
 				}
-				if zb0008 {
+				if zb0012 {
 					(*z).AddrToPos = nil
 				} else if (*z).AddrToPos == nil {
-					(*z).AddrToPos = make(map[Address]uint64, zb0007)
+					(*z).AddrToPos = make(map[Address]uint64, zb0011)
 				}
-				for zb0007 > 0 {
+				var zb0013 basics.Address
+				_ = zb0013
+				var zb0014 bool
+				_ = zb0014
+				for zb0011 > 0 {
 					var zb0001 basics.Address
 					var zb0002 uint64
-					zb0007--
+					zb0011--
 					bts, err = zb0001.UnmarshalMsg(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "AddrToPos")
 						return
 					}
+					zb0013 = zb0001
+					zb0014 = true
 					zb0002, bts, err = msgp.ReadUint64Bytes(bts)
 					if err != nil {
 						err = msgp.WrapError(err, "AddrToPos", zb0001)
@@ -423,18 +484,29 @@ func (z *spProver) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					(*z).AddrToPos[zb0001] = zb0002
 				}
+				zb0005 = "addr"
 			case "hdr":
+				if validate && zb0006 && "hdr" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).VotersHdr.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "VotersHdr")
 					return
 				}
+				zb0005 = "hdr"
 			case "msg":
+				if validate && zb0006 && "msg" < zb0005 {
+					err = &msgp.ErrNonCanonical{}
+					return
+				}
 				bts, err = (*z).Message.UnmarshalMsg(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Message")
 					return
 				}
+				zb0005 = "msg"
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -442,12 +514,19 @@ func (z *spProver) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+			zb0006 = true
 		}
 	}
 	o = bts
 	return
 }
 
+func (z *spProver) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, false)
+}
+func (z *spProver) UnmarshalValidateMsg(bts []byte) (o []byte, err error) {
+	return z.unmarshalMsg(bts, true)
+}
 func (_ *spProver) CanUnmarshalMsg(z interface{}) bool {
 	_, ok := (z).(*spProver)
 	return ok

--- a/stateproof/worker.go
+++ b/stateproof/worker.go
@@ -162,7 +162,7 @@ func (spw *Worker) Stop() {
 // SortAddress implements sorting by Address keys for
 // canonical encoding of maps in msgpack format.
 //
-//msgp:sort basics.Address SortAddress
+//msgp:sort basics.Address SortAddress basics.AddressLess
 type SortAddress = basics.SortAddress
 
 // Address is required for the msgpack sort binding, since it looks for Address and not basics.Address

--- a/tools/block-generator/go.mod
+++ b/tools/block-generator/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/algorand/falcon v0.1.0 // indirect
 	github.com/algorand/go-sumhash v0.1.0 // indirect
-	github.com/algorand/msgp v1.1.55 // indirect
+	github.com/algorand/msgp v1.1.56-0.20230721170557-eeedb47bc66f // indirect
 	github.com/algorand/oapi-codegen v1.12.0-algorand.0 // indirect
 	github.com/algorand/sortition v1.0.0 // indirect
 	github.com/algorand/websocket v1.4.6 // indirect

--- a/tools/block-generator/go.sum
+++ b/tools/block-generator/go.sum
@@ -10,8 +10,8 @@ github.com/algorand/go-deadlock v0.2.2 h1:L7AKATSUCzoeVuOgpTipfCEjdUu5ECmlje8R7l
 github.com/algorand/go-deadlock v0.2.2/go.mod h1:Hat1OXKqKNUcN/iv74FjGhF4hsOE2l7gOgQ9ZVIq6Fk=
 github.com/algorand/go-sumhash v0.1.0 h1:b/QRhyLuF//vOcicBIxBXYW8bERNoeLxieht/dUYpVg=
 github.com/algorand/go-sumhash v0.1.0/go.mod h1:OOe7jdDWUhLkuP1XytkK5gnLu9entAviN5DfDZh6XAc=
-github.com/algorand/msgp v1.1.55 h1:kWc9Xc08xtxCTWUiq1cRW5XGF+DFcfSGihYf0IZ/ivs=
-github.com/algorand/msgp v1.1.55/go.mod h1:RqZQBzAFDWpwh5TlabzZkWy+6kwL9cvXfLbU0gD99EA=
+github.com/algorand/msgp v1.1.56-0.20230721170557-eeedb47bc66f h1:2RbW0uKBy3+r0ngvV58PUeAmo1VE6sE7gqzmpUUqm2M=
+github.com/algorand/msgp v1.1.56-0.20230721170557-eeedb47bc66f/go.mod h1:RqZQBzAFDWpwh5TlabzZkWy+6kwL9cvXfLbU0gD99EA=
 github.com/algorand/oapi-codegen v1.12.0-algorand.0 h1:W9PvED+wAJc+9EeXPONnA+0zE9UhynEqoDs4OgAxKhk=
 github.com/algorand/oapi-codegen v1.12.0-algorand.0/go.mod h1:tIWJ9K/qrLDVDt5A1p82UmxZIEGxv2X+uoujdhEAL48=
 github.com/algorand/sortition v1.0.0 h1:PJiZtdSTBm4nArQrZXBnhlljHXhuyAXRJBqVWowQu3E=


### PR DESCRIPTION
## Summary

Adds UnmarshalValidateMsg() functions to the set of generated methods. This function will error out if non-canonical encoding of a message is detected. This should only be used in places where we care about canonicity, specifically any messages that end up going on-chain such as transactions and certs. 

Adds code generated by https://github.com/algorand/msgp/pull/25 as well as supporting functions -- various LessFns passed into `msgp:sort` directives. 

- [ ] Add the new method to `/protocol/codec.go` to call UnmarshallValidate and handle the response. 

## Test Plan

Existing tests should pass, other than codegen test because it's running off of a specific commit in the msgp repo. 

Still need explicit tests making sure that canonical checks catch:
- map keys out of order
- struct fields out of order
- array instead of map headers for structs (go-codec encoding)