### PR TITLE
wip: feature: singleton path provider

### DIFF
--- a/config/datapaths.go
+++ b/config/datapaths.go
@@ -36,17 +36,23 @@ var dataDirDelegation = map[string]string{
 }
 
 type fileResources struct {
+	genesisDirPath  string
 	dataDirPath     string
 	dataDirHotPath  string
 	dataDirColdPath string
 	trackerdbPath   string
-	genesisPath     string
-	genesisText     string
+	catchpointPath  string
 }
 
 var fr fileResources
 
-func InitializeDataDirs(dataDirectory *string, genesisFile *string) (cfg Local, retErr error) {
+// genesis directory is the dataDir + genesisID
+// can only be set once the genesisID is known (genesis file is loaded)
+func SetGenesisDir(genesisID string) {
+	fr.genesisDirPath = filepath.Join(fr.dataDirPath, genesisID)
+}
+
+func InitializeDataDirs(dataDirectory *string, dataDirsMap map[string]string, genesisFile *string) (cfg Local, retErr error) {
 	// first, ensure data directory is defined and valid
 	dataDir := ResolveDataDir(dataDirectory)
 	if len(dataDir) == 0 {
@@ -70,7 +76,40 @@ func InitializeDataDirs(dataDirectory *string, genesisFile *string) (cfg Local, 
 		retErr = err
 		return
 	}
+
+	// resolve data directory paths for each resource
+	// TODO: should this be iterable so it can be a range loop?
+	// the root data directory can't be specified in cfg, nor does it have a fallback
+	fr.dataDirPath = resolve(dataDir, "ALGORAND_DATA", "", "")
+
+	// hot and cold data directories fallback to the root directory
+	fr.dataDirHotPath = resolve(dataDirsMap["ALGORAND_DATA_HOT"], "ALGORAND_DATA_HOT", cfg.HotDataDir, fr.dataDirPath)
+	fr.dataDirColdPath = resolve(dataDirsMap["ALGORAND_DATA_COLD"], "ALGORAND_DATA_COLD", cfg.ColdDataDir, fr.dataDirPath)
+
+	// these resources fallback to hot data directory
+	fr.trackerdbPath = resolve(dataDirsMap["ALGORAND_DATA_LEDGER_TRACKERDB"], "ALGORAND_DATA_LEDGER_TRACKERDB", cfg.TrackerDbDir, fr.dataDirHotPath)
+
+	// these resources fallback to cold data directory
+	fr.catchpointPath = resolve(dataDirsMap["ALGORAND_DATA_LEDGER_CATCHPOINT"], "ALGORAND_DATA_LEDGER_CATCHPOINT", cfg.CatchpointDir, fr.dataDirColdPath)
+
 	return
+}
+
+// TODO: func (fr *fileResources) Validate() error{
+// this way we can check that all necessary paths are defined and valid
+
+func resolve(cli string, env string, cfg string, fallback string) string {
+	if cli != "" {
+		return cli
+	}
+	envValue := os.Getenv(env)
+	if envValue != "" {
+		return envValue
+	}
+	if cfg != "" {
+		return cfg
+	}
+	return fallback
 }
 
 // GetFileResource returns the path to a file resource, given a resource name.
@@ -79,8 +118,10 @@ func GetFileResource(resource string) string {
 	switch resource {
 	case "absolutePath", "root", "dataDir":
 		return fr.dataDirPath
-	case "genesisText":
-		return fr.genesisText
+	case "trackerdb":
+		return fr.trackerdbPath
+	case "genesisDir":
+		return fr.genesisDirPath
 	}
 	return ""
 }

--- a/config/datapaths.go
+++ b/config/datapaths.go
@@ -1,0 +1,98 @@
+// Copyright (C) 2019-2023 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var baseDataDirKey = "ALGORAND_DATA"
+
+// dataDirDelegation maps a config key to a less specific key
+// this way the chain of responsibility can be followed up to the most specific defined key
+var dataDirDelegation = map[string]string{
+	//TODO: these names are not correctly formatted
+	"ALGORAND_DATA_HOT":               "ALGORAND_DATA",
+	"ALGORAND_DATA_COLD":              "ALGORAND_DATA",
+	"ALGORAND_DATA_LEDGER_TRACKERDB":  "ALGORAND_DATA_HOT",
+	"ALGORAND_DATA_LEDGER_CATCHPOINT": "ALGORAND_DATA_COLD",
+	"ALGORAND_DATA_AGREEMENT":         "ALGORAND_DATA_COLD",
+}
+
+type fileResources struct {
+	dataDirPath     string
+	dataDirHotPath  string
+	dataDirColdPath string
+	trackerdbPath   string
+	genesisPath     string
+	genesisText     string
+}
+
+var fr fileResources
+
+func InitializeDataDirs(dataDirectory *string, genesisFile *string) (cfg Local, retErr error) {
+	// first, ensure data directory is defined and valid
+	dataDir := ResolveDataDir(dataDirectory)
+	if len(dataDir) == 0 {
+		retErr = fmt.Errorf("data directory not specified")
+		return
+	}
+	// ensure path can be made absolute
+	absolutePath, absPathErr := filepath.Abs(dataDir)
+	if absPathErr != nil {
+		retErr = fmt.Errorf("can't convert data directory's path to absolute, %v", dataDir)
+		return
+	}
+	// If data directory doesn't exist, we can't run
+	if _, err := os.Stat(absolutePath); err != nil {
+		retErr = err
+		return
+	}
+	// load the config
+	cfg, err := LoadConfigFromDisk(absolutePath)
+	if err != nil && !os.IsNotExist(err) {
+		retErr = err
+		return
+	}
+	return
+}
+
+// GetFileResource returns the path to a file resource, given a resource name.
+// these names are collected from existing code
+func GetFileResource(resource string) string {
+	switch resource {
+	case "absolutePath", "root", "dataDir":
+		return fr.dataDirPath
+	case "genesisText":
+		return fr.genesisText
+	}
+	return ""
+}
+
+func ResolveDataDir(dataDirectory *string) string {
+	// Figure out what data directory to tell algod to use.
+	// If not specified on cmdline with '-d', look for default in environment.
+	var dir string
+	if dataDirectory == nil || *dataDirectory == "" {
+		dir = os.Getenv("ALGORAND_DATA")
+	} else {
+		dir = *dataDirectory
+	}
+	return dir
+}

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -78,6 +78,12 @@ type Local struct {
 	CadaverSizeTarget uint64 `version[0]:"1073741824" version[24]:"0"`
 	CadaverDirectory  string `version[27]:""`
 
+	// Data directories
+	HotDataDir    string `version[0]:""`
+	ColdDataDir   string `version[0]:""`
+	TrackerDbDir  string `version[0]:""`
+	CatchpointDir string `version[0]:""`
+
 	// IncomingConnectionsLimit specifies the max number of long-lived incoming
 	// connections. 0 means no connections allowed. Must be non-negative.
 	// Estimating 1.5MB per incoming connection, 1.5MB*2400 = 3.6GB

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -304,7 +304,10 @@ func openLedgerDB(dbPathPrefix string, dbMem bool, cfg config.Local, log logging
 			fallthrough
 		// anything else will initialize a sqlite engine.
 		default:
-			file := dbPathPrefix + ".tracker.sqlite"
+			file := config.GetFileResource("trackerdb") + "tracker.sqlite"
+			file2 := dbPathPrefix + ".tracker.sqlite"
+			log.Warn("AXELAXEL file: ", file)
+			log.Warn("AXELAXEL file2: ", file2)
 			trackerDBs, lerr = sqlitedriver.Open(file, dbMem, log)
 		}
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/datadir"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
@@ -304,7 +305,7 @@ func openLedgerDB(dbPathPrefix string, dbMem bool, cfg config.Local, log logging
 			fallthrough
 		// anything else will initialize a sqlite engine.
 		default:
-			file := config.GetFileResource("trackerdb") + "tracker.sqlite"
+			file := datadir.Get("trackerdb") + "tracker.sqlite"
 			file2 := dbPathPrefix + ".tracker.sqlite"
 			log.Warn("AXELAXEL file: ", file)
 			log.Warn("AXELAXEL file2: ", file2)

--- a/ledger/store/trackerdb/sqlitedriver/sqlitedriver.go
+++ b/ledger/store/trackerdb/sqlitedriver/sqlitedriver.go
@@ -40,6 +40,7 @@ type trackerSQLStore struct {
 // Open opens the sqlite database store
 func Open(dbFilename string, dbMem bool, log logging.Logger) (store trackerdb.Store, err error) {
 	pair, err := db.OpenPair(dbFilename, dbMem)
+	log.Warn("AXELAXEL, dbFilename: ", dbFilename)
 	if err != nil {
 		return
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -32,6 +32,7 @@ import (
 	"github.com/algorand/go-algorand/agreement/gossip"
 	"github.com/algorand/go-algorand/catchup"
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/datadir"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data"
 	"github.com/algorand/go-algorand/data/account"
@@ -193,7 +194,7 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 	node.net = p2pNode
 
 	// load stored data
-	genesisDir := config.GetFileResource("genesisDir")
+	genesisDir := datadir.Get("genesisDir")
 	ledgerPathnamePrefix := filepath.Join(genesisDir, config.LedgerFilenamePrefix)
 	log.Warn("AXELAXEL ledgerPathnamePrefix: ", ledgerPathnamePrefix)
 

--- a/node/node.go
+++ b/node/node.go
@@ -179,7 +179,6 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 	node := new(AlgorandFullNode)
 	node.rootDir = rootDir
 	node.log = log.With("name", cfg.NetAddress)
-	node.genesisID = genesis.ID()
 	node.genesisHash = genesis.Hash()
 	node.devMode = genesis.DevMode
 	node.config = cfg
@@ -194,8 +193,9 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 	node.net = p2pNode
 
 	// load stored data
-	genesisDir := filepath.Join(rootDir, genesis.ID())
+	genesisDir := config.GetFileResource("genesisDir")
 	ledgerPathnamePrefix := filepath.Join(genesisDir, config.LedgerFilenamePrefix)
+	log.Warn("AXELAXEL ledgerPathnamePrefix: ", ledgerPathnamePrefix)
 
 	// create initial ledger, if it doesn't exist
 	err = os.Mkdir(genesisDir, 0700)


### PR DESCRIPTION
## WIP
This is a work in progress. I will specify what is/isn't done in the sections below

Code still includes debug print, unneeded functions and other rough edges.

# What
This PR adds `datadir` package inside of `config`, with the purpose of being a one-stop-shop for paths and related data.

<Description Being Written>

# Actually...

Some changes to the spec have allowed me to simplify this quite a bit and integrate it more directly to our existing code. This review will be replaced by a largely new one.