### PR TITLE
goal: `--all-trace-options` keeps track of everything in exec trace

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -74,7 +74,7 @@ var (
 	simulateAllowMoreOpcodeBudget bool
 	simulateExtraOpcodeBudget     uint64
 
-	simulateAllTraceOptions    bool
+	simulateFullTrace          bool
 	simulateEnableRequestTrace bool
 	simulateStackChange        bool
 	simulateScratchChange      bool
@@ -167,7 +167,7 @@ func init() {
 	simulateCmd.Flags().BoolVar(&simulateAllowMoreOpcodeBudget, "allow-more-opcode-budget", false, "Apply max extra opcode budget for apps per transaction group (default 320000) during simulation")
 	simulateCmd.Flags().Uint64Var(&simulateExtraOpcodeBudget, "extra-opcode-budget", 0, "Apply extra opcode budget for apps per transaction group during simulation")
 
-	simulateCmd.Flags().BoolVar(&simulateAllTraceOptions, "all-trace-options", false, "Enable all options for simulation execution trace")
+	simulateCmd.Flags().BoolVar(&simulateFullTrace, "full-trace", false, "Enable all options for simulation execution trace")
 	simulateCmd.Flags().BoolVar(&simulateEnableRequestTrace, "trace", false, "Enable simulation time execution trace of app calls")
 	simulateCmd.Flags().BoolVar(&simulateStackChange, "stack", false, "Report stack change during simulation time")
 	simulateCmd.Flags().BoolVar(&simulateScratchChange, "scratch", false, "Report scratch change during simulation time")
@@ -1373,7 +1373,7 @@ func decodeTxnsFromFile(file string) []transactions.SignedTxn {
 
 func traceCmdOptionToSimulateTraceConfigModel() simulation.ExecTraceConfig {
 	var traceConfig simulation.ExecTraceConfig
-	if simulateAllTraceOptions {
+	if simulateFullTrace {
 		traceConfig = simulation.ExecTraceConfig{
 			Enable:  true,
 			Stack:   true,

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -73,9 +73,11 @@ var (
 	simulateAllowMoreLogging      bool
 	simulateAllowMoreOpcodeBudget bool
 	simulateExtraOpcodeBudget     uint64
-	simulateEnableRequestTrace    bool
-	simulateStackChange           bool
-	simulateScratchChange         bool
+
+	simulateAllTraceOptions    bool
+	simulateEnableRequestTrace bool
+	simulateStackChange        bool
+	simulateScratchChange      bool
 )
 
 func init() {
@@ -164,6 +166,8 @@ func init() {
 	simulateCmd.Flags().BoolVar(&simulateAllowMoreLogging, "allow-more-logging", false, "Lift the limits on log opcode during simulation")
 	simulateCmd.Flags().BoolVar(&simulateAllowMoreOpcodeBudget, "allow-more-opcode-budget", false, "Apply max extra opcode budget for apps per transaction group (default 320000) during simulation")
 	simulateCmd.Flags().Uint64Var(&simulateExtraOpcodeBudget, "extra-opcode-budget", 0, "Apply extra opcode budget for apps per transaction group during simulation")
+
+	simulateCmd.Flags().BoolVar(&simulateAllTraceOptions, "all-trace-options", false, "Enable all options for simulation execution trace")
 	simulateCmd.Flags().BoolVar(&simulateEnableRequestTrace, "trace", false, "Enable simulation time execution trace of app calls")
 	simulateCmd.Flags().BoolVar(&simulateStackChange, "stack", false, "Report stack change during simulation time")
 	simulateCmd.Flags().BoolVar(&simulateScratchChange, "scratch", false, "Report scratch change during simulation time")
@@ -1368,9 +1372,17 @@ func decodeTxnsFromFile(file string) []transactions.SignedTxn {
 }
 
 func traceCmdOptionToSimulateTraceConfigModel() simulation.ExecTraceConfig {
-	return simulation.ExecTraceConfig{
-		Enable:  simulateEnableRequestTrace,
-		Stack:   simulateStackChange,
-		Scratch: simulateScratchChange,
+	var traceConfig simulation.ExecTraceConfig
+	if simulateAllTraceOptions {
+		traceConfig = simulation.ExecTraceConfig{
+			Enable:  true,
+			Stack:   true,
+			Scratch: true,
+		}
 	}
+	traceConfig.Enable = traceConfig.Enable || simulateEnableRequestTrace
+	traceConfig.Stack = traceConfig.Stack || simulateStackChange
+	traceConfig.Scratch = traceConfig.Scratch || simulateScratchChange
+
+	return traceConfig
 }

--- a/test/scripts/e2e_subs/e2e-app-simulate.sh
+++ b/test/scripts/e2e_subs/e2e-app-simulate.sh
@@ -401,7 +401,7 @@ APPID=$(echo "$RES" | grep Created | awk '{ print $6 }')
 
 ${gcmd} app call --app-id $APPID --app-arg "int:10" --from $ACCOUNT 2>&1 -o "${TEMPDIR}/stack-and-scratch.tx"
 ${gcmd} clerk sign -i "${TEMPDIR}/stack-and-scratch.tx" -o "${TEMPDIR}/stack-and-scratch.stx"
-RES=$(${gcmd} clerk simulate --all-trace-options -t "${TEMPDIR}/stack-and-scratch.stx")
+RES=$(${gcmd} clerk simulate --full-trace -t "${TEMPDIR}/stack-and-scratch.stx")
 
 if [[ $(echo "$RES" | jq '."txn-groups" | any(has("failure-message"))') != $CONST_FALSE ]]; then
     date '+app-simulate-test FAIL the app call for stack and scratch trace should pass %Y%m%d_%H%M%S'

--- a/test/scripts/e2e_subs/e2e-app-simulate.sh
+++ b/test/scripts/e2e_subs/e2e-app-simulate.sh
@@ -401,7 +401,7 @@ APPID=$(echo "$RES" | grep Created | awk '{ print $6 }')
 
 ${gcmd} app call --app-id $APPID --app-arg "int:10" --from $ACCOUNT 2>&1 -o "${TEMPDIR}/stack-and-scratch.tx"
 ${gcmd} clerk sign -i "${TEMPDIR}/stack-and-scratch.tx" -o "${TEMPDIR}/stack-and-scratch.stx"
-RES=$(${gcmd} clerk simulate --trace --stack --scratch -t "${TEMPDIR}/stack-and-scratch.stx")
+RES=$(${gcmd} clerk simulate --all-trace-options -t "${TEMPDIR}/stack-and-scratch.stx")
 
 if [[ $(echo "$RES" | jq '."txn-groups" | any(has("failure-message"))') != $CONST_FALSE ]]; then
     date '+app-simulate-test FAIL the app call for stack and scratch trace should pass %Y%m%d_%H%M%S'


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We 
appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

In a discussion, we found it helpful to define a handy "activate all" option for exec trace in `goal clerk simulate`, this PR provides a straight-forward implementation.

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

modified a line in e2e test with the new option, should go through with stack changes and scratch slot changes.
