### PR TITLE
netdeploy: allow simple local net topologies

### DIFF
--- a/netdeploy/network.go
+++ b/netdeploy/network.go
@@ -341,7 +341,7 @@ func (n Network) GetPeerAddresses(binDir string) []string {
 }
 
 func (n Network) startNodes(binDir string, relayNameToAddress map[string]string, redirectOutput bool) error {
-	allRelaysAddresses := strings.Join(maps.Keys(relayNameToAddress), ";")
+	allRelaysAddresses := strings.Join(maps.Values(relayNameToAddress), ";")
 
 	nodeConfigToEntry := make(map[string]remote.NodeConfigGoal, len(n.cfg.Template.Nodes))
 	for _, n := range n.cfg.Template.Nodes {

--- a/netdeploy/network.go
+++ b/netdeploy/network.go
@@ -30,8 +30,10 @@ import (
 	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated/model"
 	"github.com/algorand/go-algorand/gen"
 	"github.com/algorand/go-algorand/libgoal"
+	"github.com/algorand/go-algorand/netdeploy/remote"
 	"github.com/algorand/go-algorand/nodecontrol"
 	"github.com/algorand/go-algorand/util"
+	"golang.org/x/exp/maps"
 )
 
 const configFileName = "network.json"
@@ -43,8 +45,8 @@ type NetworkCfg struct {
 	Name string `json:"Name,omitempty"`
 	// RelayDirs are directories where relays live (where we check for connection IP:Port)
 	// They are stored relative to root dir (e.g. "Primary")
-	RelayDirs    []string `json:"RelayDirs,omitempty"`
-	TemplateFile string   `json:"TemplateFile,omitempty"` // Template file used to create the network
+	RelayDirs []string        `json:"RelayDirs,omitempty"`
+	Template  NetworkTemplate `json:"Template,omitempty"` // Template file used to create the network
 }
 
 // Network represents an instance of a deployed network
@@ -108,6 +110,7 @@ func CreateNetworkFromTemplate(name, rootDir string, templateReader io.Reader, b
 		return n, err
 	}
 	n.gen = template.Genesis
+	n.cfg.Template = template
 
 	err = n.Save(rootDir)
 	n.SetConsensus(binDir, consensus)
@@ -278,9 +281,9 @@ func (n Network) Start(binDir string, redirectOutput bool) error {
 
 	// Start Prime Relay and get its listening address
 
-	var peerAddressListBuilder strings.Builder
 	var relayAddress string
 	var err error
+	relayNameToAddress := map[string]string{}
 	for _, relayDir := range n.cfg.RelayDirs {
 		nodeFullPath := n.getNodeFullPath(relayDir)
 		nc := nodecontrol.MakeNodeController(binDir, nodeFullPath)
@@ -299,15 +302,10 @@ func (n Network) Start(binDir string, redirectOutput bool) error {
 		if err != nil {
 			return err
 		}
-
-		if peerAddressListBuilder.Len() != 0 {
-			peerAddressListBuilder.WriteString(";")
-		}
-		peerAddressListBuilder.WriteString(relayAddress)
+		relayNameToAddress[relayDir] = relayAddress
 	}
 
-	peerAddressList := peerAddressListBuilder.String()
-	err = n.startNodes(binDir, peerAddressList, redirectOutput)
+	err = n.startNodes(binDir, relayNameToAddress, redirectOutput)
 	return err
 }
 
@@ -337,21 +335,38 @@ func (n Network) GetPeerAddresses(binDir string) []string {
 		if err != nil {
 			continue
 		}
-		if strings.HasPrefix(relayAddress, "http://") {
-			relayAddress = relayAddress[7:]
-		}
-		peerAddresses = append(peerAddresses, relayAddress)
+		peerAddresses = append(peerAddresses, strings.TrimPrefix(relayAddress, "http://"))
 	}
 	return peerAddresses
 }
 
-func (n Network) startNodes(binDir, relayAddress string, redirectOutput bool) error {
-	args := nodecontrol.AlgodStartArgs{
-		PeerAddress:       relayAddress,
-		RedirectOutput:    redirectOutput,
-		ExitErrorCallback: n.nodeExitCallback,
+func (n Network) startNodes(binDir string, relayNameToAddress map[string]string, redirectOutput bool) error {
+	allRelaysAddresses := strings.Join(maps.Keys(relayNameToAddress), ";")
+
+	nodeConfigToEntry := make(map[string]remote.NodeConfigGoal, len(n.cfg.Template.Nodes))
+	for _, n := range n.cfg.Template.Nodes {
+		nodeConfigToEntry[n.Name] = n
 	}
+
 	for _, nodeDir := range n.nodeDirs {
+		args := nodecontrol.AlgodStartArgs{
+			PeerAddress:       allRelaysAddresses,
+			RedirectOutput:    redirectOutput,
+			ExitErrorCallback: n.nodeExitCallback,
+		}
+		if n, ok := nodeConfigToEntry[nodeDir]; ok && len(n.PeerList) > 0 {
+			relayNames := strings.Split(n.PeerList, ";")
+			var peerAddresses []string
+			for _, relayName := range relayNames {
+				relayAddress, ok := relayNameToAddress[relayName]
+				if !ok {
+					return fmt.Errorf("relay %s is not defined in the network", relayName)
+				}
+				peerAddresses = append(peerAddresses, relayAddress)
+			}
+			args.PeerAddress = strings.Join(peerAddresses, ";")
+		}
+
 		nc := nodecontrol.MakeNodeController(binDir, n.getNodeFullPath(nodeDir))
 		_, err := nc.StartAlgod(args)
 		if err != nil {

--- a/netdeploy/networkTemplate.go
+++ b/netdeploy/networkTemplate.go
@@ -235,9 +235,13 @@ func (t NetworkTemplate) Validate() error {
 	}
 
 	// Follow nodes cannot be relays
+	// Relays cannot have peer list
 	for _, cfg := range t.Nodes {
 		if cfg.IsRelay && isEnableFollowMode(cfg.ConfigJSONOverride) {
 			return fmt.Errorf("invalid template: follower nodes may not be relays")
+		}
+		if cfg.IsRelay && len(cfg.PeerList) > 0 {
+			return fmt.Errorf("invalid template: relays may not have a peer list")
 		}
 	}
 

--- a/netdeploy/networkTemplates_test.go
+++ b/netdeploy/networkTemplates_test.go
@@ -52,7 +52,7 @@ func TestLoadMissingConfig(t *testing.T) {
 	a := require.New(t)
 
 	templateDir, err := filepath.Abs("../test/testdata/nettemplates")
-	a.Error(err)
+	a.NoError(err)
 	template, err := loadTemplate(filepath.Join(templateDir, "<invalidname>.json"))
 	a.Error(err)
 	a.Equal(template.Genesis.NetworkName, "")

--- a/netdeploy/networkTemplates_test.go
+++ b/netdeploy/networkTemplates_test.go
@@ -52,6 +52,7 @@ func TestLoadMissingConfig(t *testing.T) {
 	a := require.New(t)
 
 	templateDir, err := filepath.Abs("../test/testdata/nettemplates")
+	a.Error(err)
 	template, err := loadTemplate(filepath.Join(templateDir, "<invalidname>.json"))
 	a.Error(err)
 	a.Equal(template.Genesis.NetworkName, "")
@@ -102,6 +103,68 @@ func TestValidate(t *testing.T) {
 	template, _ = loadTemplate(filepath.Join(templateDir, "TwoNodesOneRelay1000Accounts.json"))
 	err = template.Validate()
 	a.NoError(err)
+
+	templateDir, _ = filepath.Abs("../test/testdata/nettemplates")
+	template, _ = loadTemplate(filepath.Join(templateDir, "FiveNodesTwoRelays.json"))
+	err = template.Validate()
+	a.NoError(err)
+}
+
+func TestPeerListValidate(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	devmodeGenesis := gen.GenesisData{
+		Wallets: []gen.WalletData{
+			{
+				Stake: 100,
+			},
+		},
+	}
+
+	t.Run("PeerList is optional", func(t *testing.T) {
+		t.Parallel()
+		tmpl := NetworkTemplate{
+			Genesis: devmodeGenesis,
+			Nodes: []remote.NodeConfigGoal{
+				{
+					IsRelay: true,
+				},
+				{
+					IsRelay: false,
+				},
+			},
+		}
+		require.NoError(t, tmpl.Validate())
+	})
+
+	t.Run("Relays cannot have PeerList", func(t *testing.T) {
+		t.Parallel()
+		tmpl := NetworkTemplate{
+			Genesis: devmodeGenesis,
+			Nodes: []remote.NodeConfigGoal{
+				{
+					IsRelay:  true,
+					PeerList: "R2",
+				},
+			},
+		}
+		require.ErrorContains(t, tmpl.Validate(), "relays may not have a peer list")
+	})
+
+	t.Run("Non-relays might have PeerList", func(t *testing.T) {
+		t.Parallel()
+		tmpl := NetworkTemplate{
+			Genesis: devmodeGenesis,
+			Nodes: []remote.NodeConfigGoal{
+				{
+					IsRelay:  false,
+					PeerList: "R2",
+				},
+			},
+		}
+		require.NoError(t, tmpl.Validate())
+	})
 }
 
 func TestDevModeValidate(t *testing.T) {

--- a/netdeploy/network_test.go
+++ b/netdeploy/network_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/gen"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
@@ -34,9 +35,11 @@ func TestSaveNetworkCfg(t *testing.T) {
 	a := require.New(t)
 
 	cfg := NetworkCfg{
-		Name:         "testName",
-		RelayDirs:    []string{"testPND"},
-		TemplateFile: "testTemplate",
+		Name:      "testName",
+		RelayDirs: []string{"testPND"},
+		Template: NetworkTemplate{
+			Genesis: gen.DefaultGenesis,
+		},
 	}
 
 	tmpFolder := t.TempDir()
@@ -44,6 +47,7 @@ func TestSaveNetworkCfg(t *testing.T) {
 	err := saveNetworkCfg(cfg, cfgFile)
 	a.Nil(err)
 	cfg1, err := loadNetworkCfg(cfgFile)
+	a.NoError(err)
 	a.Equal(cfg, cfg1)
 }
 
@@ -63,9 +67,11 @@ func TestSaveConsensus(t *testing.T) {
 
 	net := Network{
 		cfg: NetworkCfg{
-			Name:         "testName",
-			RelayDirs:    []string{relayDir},
-			TemplateFile: "testTemplate",
+			Name:      "testName",
+			RelayDirs: []string{relayDir},
+			Template: NetworkTemplate{
+				Genesis: gen.DefaultGenesis,
+			},
 		},
 		nodeDirs: map[string]string{
 			"node1": nodeDir,

--- a/netdeploy/remote/nodeConfig.go
+++ b/netdeploy/remote/nodeConfig.go
@@ -59,4 +59,5 @@ type NodeConfigGoal struct {
 	Wallets            []NodeWalletData
 	DeadlockDetection  int    `json:"-"`
 	ConfigJSONOverride string `json:",omitempty"` // Raw json to merge into config.json after other modifications are complete
+	PeerList           string `json:",omitempty"` // Semicolon separated list of peers to connect to. Only applicable for non-relays
 }

--- a/test/testdata/nettemplates/FiveNodesTwoRelays.json
+++ b/test/testdata/nettemplates/FiveNodesTwoRelays.json
@@ -1,0 +1,48 @@
+{
+    "Genesis": {
+        "NetworkName": "tbd",
+        "LastPartKeyRound": 5000,
+        "Wallets": [
+            {
+                "Name": "LargeWallet",
+                "Stake": 85,
+                "Online": true
+            },
+            {
+                "Name": "SmallWallet",
+                "Stake": 15,
+                "Online": true
+            }
+        ]
+    },
+    "Nodes": [
+        {
+            "Name": "Relay1",
+            "IsRelay": true
+        },
+        {
+            "Name": "Relay2",
+            "IsRelay": true
+        },
+        {
+            "Name": "PartNode1",
+            "Wallets": [{
+                "Name": "LargeWallet",
+                "ParticipationOnly": true
+            }],
+            "PeerList": "Relay1;Relay2"
+        },
+        {
+            "Name": "PartNode2",
+            "Wallets": [{
+                "Name": "SmallWallet",
+                "ParticipationOnly": true
+            }],
+            "PeerList": "Relay2"
+        },
+        {
+            "Name": "NonPartNode",
+            "PeerList": "Relay1"
+        }
+    ]
+}

--- a/test/testdata/nettemplates/FiveNodesTwoRelays.json
+++ b/test/testdata/nettemplates/FiveNodesTwoRelays.json
@@ -10,7 +10,12 @@
             },
             {
                 "Name": "SmallWallet",
-                "Stake": 15,
+                "Stake": 10,
+                "Online": true
+            },
+            {
+                "Name": "NonPartWallet",
+                "Stake": 5,
                 "Online": true
             }
         ]
@@ -42,6 +47,9 @@
         },
         {
             "Name": "NonPartNode",
+            "Wallets": [{
+                "Name": "NonPartWallet"
+            }],
             "PeerList": "Relay1"
         }
     ]


### PR DESCRIPTION
## Summary

Changes to netdeploy to control local net topologies. Motivation is allow some networking tests on a local machine without spinning up a cluster.

Implementation Notes:
1. Added `PeerList` property into local net templates
2. Replaced `TemplateFile` with actual `Template` in deployed template `network.json` since the former was not used.
3. Supported `PeerList` in network template start (`goal network -r xxx start`)

## Test Plan

Added some unit test. Tested manually with `FiveNodesTwoRelays.json` templates that forces NPN to connect a single relay, and one of part nodes to connect to another single relay.

```sh
$ ps | grep algod
30090 ttys001    0:02.75 ~/go/bin/algod -d ~/networks/five-test/Relay1
30091 ttys001    0:02.91 ~/go/bin/algod -d ~/networks/five-test/Relay2 -p http://127.0.0.1:63606
30092 ttys001    0:02.90 ~/go/bin/algod -d ~/networks/five-test/NonPartNode -p http://127.0.0.1:63606
30093 ttys001    0:04.83 ~/go/bin/algod -d ~/networks/five-test/PartNode1 -p http://127.0.0.1:63606;http://127.0.0.1:63608
30094 ttys001    0:04.91 ~/go/bin/algod -d ~/networks/five-test/PartNode2 -p http://127.0.0.1:63608
```
NonPartNode connects only R1, PartNode1 connects to both, and PartNode2 connects only to R2 as the templates specifies:
```json
        {
            "Name": "PartNode1",
            "Wallets": [{
                "Name": "LargeWallet",
                "ParticipationOnly": true
            }],
            "PeerList": "Relay1;Relay2"
        },
        {
            "Name": "PartNode2",
            "Wallets": [{
                "Name": "SmallWallet",
                "ParticipationOnly": true
            }],
            "PeerList": "Relay2"
        },
        {
            "Name": "NonPartNode",
            "PeerList": "Relay1"
        }
