### PR TITLE
node: use correct allocbound on netprioResponse Nonce field

### DIFF
--- a/node/msgp_gen.go
+++ b/node/msgp_gen.go
@@ -77,8 +77,8 @@ func (z *netPrioResponse) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "struct-from-array", "Nonce")
 				return
 			}
-			if zb0003 > netPrioChallengeSize {
-				err = msgp.ErrOverflow(uint64(zb0003), uint64(netPrioChallengeSize))
+			if zb0003 > netPrioChallengeSizeBase64Encoded {
+				err = msgp.ErrOverflow(uint64(zb0003), uint64(netPrioChallengeSizeBase64Encoded))
 				return
 			}
 			(*z).Nonce, bts, err = msgp.ReadStringBytes(bts)
@@ -117,8 +117,8 @@ func (z *netPrioResponse) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "Nonce")
 					return
 				}
-				if zb0004 > netPrioChallengeSize {
-					err = msgp.ErrOverflow(uint64(zb0004), uint64(netPrioChallengeSize))
+				if zb0004 > netPrioChallengeSizeBase64Encoded {
+					err = msgp.ErrOverflow(uint64(zb0004), uint64(netPrioChallengeSizeBase64Encoded))
 					return
 				}
 				(*z).Nonce, bts, err = msgp.ReadStringBytes(bts)
@@ -157,7 +157,7 @@ func (z *netPrioResponse) MsgIsZero() bool {
 
 // MaxSize returns a maximum valid message size for this message type
 func NetPrioResponseMaxSize() (s int) {
-	s = 1 + 6 + msgp.StringPrefixSize + netPrioChallengeSize
+	s = 1 + 6 + msgp.StringPrefixSize + netPrioChallengeSizeBase64Encoded
 	return
 }
 
@@ -260,8 +260,8 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 						err = msgp.WrapError(err, "struct-from-array", "Response", "struct-from-array", "Nonce")
 						return
 					}
-					if zb0005 > netPrioChallengeSize {
-						err = msgp.ErrOverflow(uint64(zb0005), uint64(netPrioChallengeSize))
+					if zb0005 > netPrioChallengeSizeBase64Encoded {
+						err = msgp.ErrOverflow(uint64(zb0005), uint64(netPrioChallengeSizeBase64Encoded))
 						return
 					}
 					(*z).Response.Nonce, bts, err = msgp.ReadStringBytes(bts)
@@ -300,8 +300,8 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							err = msgp.WrapError(err, "struct-from-array", "Response", "Nonce")
 							return
 						}
-						if zb0006 > netPrioChallengeSize {
-							err = msgp.ErrOverflow(uint64(zb0006), uint64(netPrioChallengeSize))
+						if zb0006 > netPrioChallengeSizeBase64Encoded {
+							err = msgp.ErrOverflow(uint64(zb0006), uint64(netPrioChallengeSizeBase64Encoded))
 							return
 						}
 						(*z).Response.Nonce, bts, err = msgp.ReadStringBytes(bts)
@@ -384,8 +384,8 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							err = msgp.WrapError(err, "Response", "struct-from-array", "Nonce")
 							return
 						}
-						if zb0009 > netPrioChallengeSize {
-							err = msgp.ErrOverflow(uint64(zb0009), uint64(netPrioChallengeSize))
+						if zb0009 > netPrioChallengeSizeBase64Encoded {
+							err = msgp.ErrOverflow(uint64(zb0009), uint64(netPrioChallengeSizeBase64Encoded))
 							return
 						}
 						(*z).Response.Nonce, bts, err = msgp.ReadStringBytes(bts)
@@ -424,8 +424,8 @@ func (z *netPrioResponseSigned) UnmarshalMsg(bts []byte) (o []byte, err error) {
 								err = msgp.WrapError(err, "Response", "Nonce")
 								return
 							}
-							if zb0010 > netPrioChallengeSize {
-								err = msgp.ErrOverflow(uint64(zb0010), uint64(netPrioChallengeSize))
+							if zb0010 > netPrioChallengeSizeBase64Encoded {
+								err = msgp.ErrOverflow(uint64(zb0010), uint64(netPrioChallengeSizeBase64Encoded))
 								return
 							}
 							(*z).Response.Nonce, bts, err = msgp.ReadStringBytes(bts)
@@ -491,6 +491,6 @@ func (z *netPrioResponseSigned) MsgIsZero() bool {
 
 // MaxSize returns a maximum valid message size for this message type
 func NetPrioResponseSignedMaxSize() (s int) {
-	s = 1 + 9 + 1 + 6 + msgp.StringPrefixSize + netPrioChallengeSize + 6 + basics.RoundMaxSize() + 7 + basics.AddressMaxSize() + 4 + crypto.OneTimeSignatureMaxSize()
+	s = 1 + 9 + 1 + 6 + msgp.StringPrefixSize + netPrioChallengeSizeBase64Encoded + 6 + basics.RoundMaxSize() + 7 + basics.AddressMaxSize() + 4 + crypto.OneTimeSignatureMaxSize()
 	return
 }

--- a/node/netprio.go
+++ b/node/netprio.go
@@ -28,10 +28,12 @@ import (
 
 const netPrioChallengeSize = 32
 
+const netPrioChallengeSizeBase64Encoded = 44 // 32 * (4/3) rounded up to nearest multiple of 4 -> 44
+
 type netPrioResponse struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	Nonce string `codec:"Nonce,allocbound=netPrioChallengeSize"`
+	Nonce string `codec:"Nonce,allocbound=netPrioChallengeSizeBase64Encoded"`
 }
 
 type netPrioResponseSigned struct {

--- a/node/netprio_test.go
+++ b/node/netprio_test.go
@@ -19,6 +19,7 @@ package node
 import (
 	"testing"
 
+	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/stretchr/testify/require"
 )
@@ -30,6 +31,15 @@ func TestBase64AllocboundSize(t *testing.T) {
 	t.Parallel()
 
 	node := AlgorandFullNode{}
-	require.Len(t, node.NewPrioChallenge(), netPrioChallengeSizeBase64Encoded)
+	nonce := node.NewPrioChallenge()
+	require.Len(t, nonce, netPrioChallengeSizeBase64Encoded)
+
+	npr := netPrioResponse{Nonce: nonce}
+	e := protocol.Encode(&npr)
+
+	npr2 := netPrioResponse{}
+	err := protocol.Decode(e, &npr2)
+	require.NoError(t, err)
+	require.Equal(t, nonce, npr2.Nonce)
 
 }

--- a/node/netprio_test.go
+++ b/node/netprio_test.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2019-2023 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package node
+
+import (
+	"testing"
+
+	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBase64AllocboundSize tests that the base64 encoded size of the Nonce is the same as the allocbound
+// used on the Nonce field in the struct for netprio response messages.
+func TestBase64AllocboundSize(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	node := AlgorandFullNode{}
+	require.Len(t, node.NewPrioChallenge(), netPrioChallengeSizeBase64Encoded)
+
+}

--- a/node/netprio_test.go
+++ b/node/netprio_test.go
@@ -17,6 +17,7 @@
 package node
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/algorand/go-algorand/protocol"
@@ -30,6 +31,7 @@ func TestBase64AllocboundSize(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
+	require.Equal(t, netPrioChallengeSizeBase64Encoded, base64.StdEncoding.EncodedLen(netPrioChallengeSize))
 	node := AlgorandFullNode{}
 	nonce := node.NewPrioChallenge()
 	require.Len(t, nonce, netPrioChallengeSizeBase64Encoded)

--- a/protocol/tags.go
+++ b/protocol/tags.go
@@ -60,7 +60,7 @@ const MsgOfInterestTagMaxSize = 45
 const MsgDigestSkipTagMaxSize = 69
 
 // NetPrioResponseTagMaxSize is the maximum size of a NetPrioResponseTag message
-const NetPrioResponseTagMaxSize = 838
+const NetPrioResponseTagMaxSize = 850
 
 // NetIDVerificationTagMaxSize is the maximum size of a NetIDVerificationTag message
 const NetIDVerificationTagMaxSize = 215


### PR DESCRIPTION
## Summary

The `netprioResponse.Nonce` field is a base64 encoded string instead of a byte array/slice and therefore we have to use the correct base64 encoded max size of 44. 

## Test Plan

Existing tests should pass