### PR TITLE
phonebook: Persist initial phonebook peers; remove unused ExtendPeerList

### DIFF
--- a/network/phonebook_test.go
+++ b/network/phonebook_test.go
@@ -17,14 +17,10 @@
 package network
 
 import (
-	"fmt"
-	"math/rand"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/algorand/go-algorand/test/partitiontest"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -92,7 +88,7 @@ func TestArrayPhonebookAll(t *testing.T) {
 	set := []string{"a", "b", "c", "d", "e"}
 	ph := MakePhonebook(1, 1).(*phonebookImpl)
 	for _, e := range set {
-		ph.data[e] = makePhonebookEntryData("", PhoneBookEntryRelayRole)
+		ph.data[e] = makePhonebookEntryData("", PhoneBookEntryRelayRole, false)
 	}
 	testPhonebookAll(t, set, ph)
 }
@@ -103,7 +99,7 @@ func TestArrayPhonebookUniform1(t *testing.T) {
 	set := []string{"a", "b", "c", "d", "e"}
 	ph := MakePhonebook(1, 1).(*phonebookImpl)
 	for _, e := range set {
-		ph.data[e] = makePhonebookEntryData("", PhoneBookEntryRelayRole)
+		ph.data[e] = makePhonebookEntryData("", PhoneBookEntryRelayRole, false)
 	}
 	testPhonebookUniform(t, set, ph, 1)
 }
@@ -114,85 +110,9 @@ func TestArrayPhonebookUniform3(t *testing.T) {
 	set := []string{"a", "b", "c", "d", "e"}
 	ph := MakePhonebook(1, 1).(*phonebookImpl)
 	for _, e := range set {
-		ph.data[e] = makePhonebookEntryData("", PhoneBookEntryRelayRole)
+		ph.data[e] = makePhonebookEntryData("", PhoneBookEntryRelayRole, false)
 	}
 	testPhonebookUniform(t, set, ph, 3)
-}
-
-// TestPhonebookExtension tests for extending different phonebooks with
-// addresses.
-func TestPhonebookExtension(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	setA := []string{"a"}
-	moreB := []string{"b"}
-	ph := MakePhonebook(1, 1).(*phonebookImpl)
-	ph.ReplacePeerList(setA, "default", PhoneBookEntryRelayRole)
-	ph.ExtendPeerList(moreB, "default", PhoneBookEntryRelayRole)
-	ph.ExtendPeerList(setA, "other", PhoneBookEntryRelayRole)
-	assert.Equal(t, 2, ph.Length())
-	assert.Equal(t, true, ph.data["a"].networkNames["default"])
-	assert.Equal(t, true, ph.data["a"].networkNames["other"])
-	assert.Equal(t, true, ph.data["b"].networkNames["default"])
-	assert.Equal(t, false, ph.data["b"].networkNames["other"])
-}
-
-func extenderThread(th *phonebookImpl, more []string, wg *sync.WaitGroup, repetitions int) {
-	defer wg.Done()
-	for i := 0; i <= repetitions; i++ {
-		start := rand.Intn(len(more))
-		end := rand.Intn(len(more)-start) + start
-		th.ExtendPeerList(more[start:end], "default", PhoneBookEntryRelayRole)
-	}
-	th.ExtendPeerList(more, "default", PhoneBookEntryRelayRole)
-}
-
-func TestThreadsafePhonebookExtension(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	set := []string{"a", "b", "c", "d", "e"}
-	more := []string{"f", "g", "h", "i", "j"}
-	ph := MakePhonebook(1, 1).(*phonebookImpl)
-	ph.ReplacePeerList(set, "default", PhoneBookEntryRelayRole)
-	wg := sync.WaitGroup{}
-	wg.Add(5)
-	for ti := 0; ti < 5; ti++ {
-		go extenderThread(ph, more, &wg, 1000)
-	}
-	wg.Wait()
-
-	assert.Equal(t, 10, ph.Length())
-}
-
-func threadTestThreadsafePhonebookExtensionLong(wg *sync.WaitGroup, ph *phonebookImpl, setSize, repetitions int) {
-	set := make([]string, setSize)
-	for i := range set {
-		set[i] = fmt.Sprintf("%06d", i)
-	}
-	rand.Shuffle(len(set), func(i, j int) { t := set[i]; set[i] = set[j]; set[j] = t })
-	extenderThread(ph, set, wg, repetitions)
-}
-
-func TestThreadsafePhonebookExtensionLong(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	if testing.Short() {
-		t.SkipNow()
-		return
-	}
-	ph := MakePhonebook(1, 1).(*phonebookImpl)
-	wg := sync.WaitGroup{}
-	const threads = 5
-	const setSize = 1000
-	const repetitions = 100
-	wg.Add(threads)
-	for i := 0; i < threads; i++ {
-		go threadTestThreadsafePhonebookExtensionLong(&wg, ph, setSize, repetitions)
-	}
-
-	wg.Wait()
-
-	assert.Equal(t, setSize, ph.Length())
 }
 
 func TestMultiPhonebook(t *testing.T) {
@@ -214,6 +134,34 @@ func TestMultiPhonebook(t *testing.T) {
 	testPhonebookAll(t, set, mp)
 	testPhonebookUniform(t, set, mp, 1)
 	testPhonebookUniform(t, set, mp, 3)
+}
+
+// TestMultiPhonebookPersistentPeers validates that the peers added via Phonebook.AddPersistentPeers
+// are not replaced when Phonebook.ReplacePeerList is called
+func TestMultiPhonebookPersistentPeers(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	persistentPeers := []string{"a"}
+	set := []string{"b", "c", "d", "e", "f", "g", "h", "i", "j", "k"}
+	pha := make([]string, 0)
+	for _, e := range set[:5] {
+		pha = append(pha, e)
+	}
+	phb := make([]string, 0)
+	for _, e := range set[5:] {
+		phb = append(phb, e)
+	}
+	mp := MakePhonebook(1, 1*time.Millisecond)
+	mp.AddPersistentPeers(persistentPeers, "pha", PhoneBookEntryRelayRole)
+	mp.AddPersistentPeers(persistentPeers, "phb", PhoneBookEntryRelayRole)
+	mp.ReplacePeerList(pha, "pha", PhoneBookEntryRelayRole)
+	mp.ReplacePeerList(phb, "phb", PhoneBookEntryRelayRole)
+
+	testPhonebookAll(t, append(set, persistentPeers...), mp)
+	allAddresses := mp.GetAddresses(len(set)+len(persistentPeers), PhoneBookEntryRelayRole)
+	for _, pp := range persistentPeers {
+		require.Contains(t, allAddresses, pp)
+	}
 }
 
 func TestMultiPhonebookDuplicateFiltering(t *testing.T) {
@@ -386,21 +334,6 @@ func TestWaitAndAddConnectionTimeShortWindow(t *testing.T) {
 	// only one time should be left (the newly added)
 	phBookData := entries.data[addr1].recentConnectionTimes
 	require.Equal(t, 1, len(phBookData))
-}
-
-func BenchmarkThreadsafePhonebook(b *testing.B) {
-	ph := MakePhonebook(1, 1).(*phonebookImpl)
-	threads := 5
-	if b.N < threads {
-		threads = b.N
-	}
-	wg := sync.WaitGroup{}
-	wg.Add(threads)
-	repetitions := b.N / threads
-	for t := 0; t < threads; t++ {
-		go threadTestThreadsafePhonebookExtensionLong(&wg, ph, 1000, repetitions)
-	}
-	wg.Wait()
 }
 
 // TestPhonebookRoles tests that the filtering by roles for different

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1775,12 +1775,12 @@ func (wn *WebsocketNetwork) refreshRelayArchivePhonebookAddresses() {
 func (wn *WebsocketNetwork) updatePhonebookAddresses(relayAddrs []string, archiveAddrs []string) {
 	if len(relayAddrs) > 0 {
 		wn.log.Debugf("got %d relay dns addrs, %#v", len(relayAddrs), relayAddrs[:imin(5, len(relayAddrs))])
-		wn.phonebook.ExtendPeerList(relayAddrs, string(wn.NetworkID), PhoneBookEntryRelayRole)
+		wn.phonebook.ReplacePeerList(relayAddrs, string(wn.NetworkID), PhoneBookEntryRelayRole)
 	} else {
 		wn.log.Infof("got no relay DNS addrs for network %s", wn.NetworkID)
 	}
 	if len(archiveAddrs) > 0 {
-		wn.phonebook.ExtendPeerList(archiveAddrs, string(wn.NetworkID), PhoneBookEntryArchiverRole)
+		wn.phonebook.ReplacePeerList(archiveAddrs, string(wn.NetworkID), PhoneBookEntryArchiverRole)
 	}
 }
 
@@ -2449,7 +2449,7 @@ func (wn *WebsocketNetwork) SetPeerData(peer Peer, key string, value interface{}
 func NewWebsocketNetwork(log logging.Logger, config config.Local, phonebookAddresses []string, genesisID string, networkID protocol.NetworkID, nodeInfo NodeInfo) (wn *WebsocketNetwork, err error) {
 	phonebook := MakePhonebook(config.ConnectionsRateLimitingCount,
 		time.Duration(config.ConnectionsRateLimitingWindowSeconds)*time.Second)
-	phonebook.ReplacePeerList(phonebookAddresses, string(networkID), PhoneBookEntryRelayRole)
+	phonebook.AddPersistentPeers(phonebookAddresses, string(networkID), PhoneBookEntryRelayRole)
 	wn = &WebsocketNetwork{
 		log:               log,
 		config:            config,

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1775,12 +1775,12 @@ func (wn *WebsocketNetwork) refreshRelayArchivePhonebookAddresses() {
 func (wn *WebsocketNetwork) updatePhonebookAddresses(relayAddrs []string, archiveAddrs []string) {
 	if len(relayAddrs) > 0 {
 		wn.log.Debugf("got %d relay dns addrs, %#v", len(relayAddrs), relayAddrs[:imin(5, len(relayAddrs))])
-		wn.phonebook.ReplacePeerList(relayAddrs, string(wn.NetworkID), PhoneBookEntryRelayRole)
+		wn.phonebook.ExtendPeerList(relayAddrs, string(wn.NetworkID), PhoneBookEntryRelayRole)
 	} else {
 		wn.log.Infof("got no relay DNS addrs for network %s", wn.NetworkID)
 	}
 	if len(archiveAddrs) > 0 {
-		wn.phonebook.ReplacePeerList(archiveAddrs, string(wn.NetworkID), PhoneBookEntryArchiverRole)
+		wn.phonebook.ExtendPeerList(archiveAddrs, string(wn.NetworkID), PhoneBookEntryArchiverRole)
 	}
 }
 

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -4265,8 +4265,8 @@ func TestUpdatePhonebookAddresses(t *testing.T) {
 		assert.ElementsMatch(t, dedupedArchiveDomains, archiveAddrs)
 
 		// Generate fresh set of addresses with a duplicate from original batch if warranted,
-		// assert phonebook reflects fresh list / prior peers other than selected duplicate
-		// are not present
+		// assert phonebook reflects fresh list / prior peers without duplicates
+		// will be present since `updatePhonebookAddresses` calls ExtendPeerList
 		var priorRelayDomains = relayDomains
 
 		// Dont overlap with archive nodes previously specified, duplicates between them not stored in phonebook as of this writing
@@ -4282,7 +4282,8 @@ func TestUpdatePhonebookAddresses(t *testing.T) {
 		netA.updatePhonebookAddresses(relayDomains, nil)
 
 		// Check that entries are in fact in phonebook less any duplicates
-		dedupedRelayDomains = removeDuplicateStr(relayDomains, false)
+		// Since we extend, new entries are added instead of replacing existing entries
+		dedupedRelayDomains = removeDuplicateStr(append(relayDomains, priorRelayDomains...), false)
 
 		relayPeers = netA.GetPeers(PeersPhonebookRelays)
 		assert.Equal(t, len(dedupedRelayDomains), len(relayPeers))


### PR DESCRIPTION

## Summary
We never actually call ExtendPeerList anywhere. When we refresh the SRV list periodically it just fully replaces the peer list.


## Test Plan

grep'ing ExtendPeerList shows nothing. Also existing tests should pass.
