### PR TITLE
tools: option to run test multiple times.

### DIFF
--- a/tools/block-generator/generator/generate.go
+++ b/tools/block-generator/generator/generate.go
@@ -288,7 +288,8 @@ func (g *generator) WriteBlock(output io.Writer, round uint64) error {
 
 	if round == cachedRound {
 		// one round behind, so write the cached block (if non-empty)
-		fmt.Printf("Received round request %d, but nextRound=%d. Not finishing round.\n", round, nextRound)
+		// Verbose logging
+		//fmt.Printf("Received round request %d, but nextRound=%d. Not finishing round.\n", round, nextRound)
 		if len(g.latestBlockMsgp) != 0 {
 			// write the msgpack bytes for a block
 			_, err := output.Write(g.latestBlockMsgp)
@@ -304,9 +305,10 @@ func (g *generator) WriteBlock(output io.Writer, round uint64) error {
 	if err != nil {
 		return err
 	}
-	if g.round == 0 {
-		fmt.Printf("starting txnCounter: %d\n", g.txnCounter)
-	}
+	//Verbose logging.
+	//if g.round == 0 {
+	//	fmt.Printf("starting txnCounter: %d\n", g.txnCounter)
+	//}
 	minTxnsForBlock := g.minTxnsForBlock(g.round)
 
 	var cert rpcs.EncodedBlockCert
@@ -335,8 +337,8 @@ func (g *generator) WriteBlock(output io.Writer, round uint64) error {
 		if err != nil {
 			return fmt.Errorf("failed to evaluate block: %w", err)
 		}
-		if ledgerTxnCount != g.txnCounter + intra {
-			return fmt.Errorf("evaluateBlock() txn count mismatches theoretical intra: %d != %d", ledgerTxnCount, g.txnCounter + intra)
+		if ledgerTxnCount != g.txnCounter+intra {
+			return fmt.Errorf("evaluateBlock() txn count mismatches theoretical intra: %d != %d", ledgerTxnCount, g.txnCounter+intra)
 		}
 
 		err = g.ledger.AddValidatedBlock(*vBlock, cert.Certificate)

--- a/tools/block-generator/generator/generate.go
+++ b/tools/block-generator/generator/generate.go
@@ -288,8 +288,9 @@ func (g *generator) WriteBlock(output io.Writer, round uint64) error {
 
 	if round == cachedRound {
 		// one round behind, so write the cached block (if non-empty)
-		// Verbose logging
-		//fmt.Printf("Received round request %d, but nextRound=%d. Not finishing round.\n", round, nextRound)
+		if g.verbose {
+			fmt.Printf("Received round request %d, but nextRound=%d. Not finishing round.\n", round, nextRound)
+		}
 		if len(g.latestBlockMsgp) != 0 {
 			// write the msgpack bytes for a block
 			_, err := output.Write(g.latestBlockMsgp)
@@ -305,10 +306,9 @@ func (g *generator) WriteBlock(output io.Writer, round uint64) error {
 	if err != nil {
 		return err
 	}
-	//Verbose logging.
-	//if g.round == 0 {
-	//	fmt.Printf("starting txnCounter: %d\n", g.txnCounter)
-	//}
+	if g.verbose && g.round == 0 {
+		fmt.Printf("starting txnCounter: %d\n", g.txnCounter)
+	}
 	minTxnsForBlock := g.minTxnsForBlock(g.round)
 
 	var cert rpcs.EncodedBlockCert

--- a/tools/block-generator/runner/runner.go
+++ b/tools/block-generator/runner/runner.go
@@ -48,7 +48,7 @@ func init() {
 	RunnerCmd.Flags().Uint64VarP(&runnerArgs.MetricsPort, "metrics-port", "p", 9999, "Port to start the metrics server at.")
 	RunnerCmd.Flags().StringVarP(&runnerArgs.PostgresConnectionString, "postgres-connection-string", "c", "", "Postgres connection string.")
 	RunnerCmd.Flags().DurationVarP(&runnerArgs.RunDuration, "test-duration", "d", 5*time.Minute, "Duration to use for each scenario.")
-	RunnerCmd.Flags().StringVarP(&runnerArgs.ReportDirectory, "report-directory", "r", "", "Location to place test reports.")
+	RunnerCmd.Flags().StringVarP(&runnerArgs.BaseReportDirectory, "report-directory", "r", "", "Location to place test reports. If --times is used, this is the prefix for multiple report directories.")
 	RunnerCmd.Flags().BoolVarP(&runnerArgs.RunnerVerbose, "verbose", "v", false, "If set the runner will print debugging information from the generator and ledger.")
 	RunnerCmd.Flags().StringVarP(&runnerArgs.ConduitLogLevel, "conduit-log-level", "l", "error", "LogLevel to use when starting Conduit. [panic, fatal, error, warn, info, debug, trace]")
 	RunnerCmd.Flags().StringVarP(&runnerArgs.CPUProfilePath, "cpuprofile", "", "", "Path where Conduit writes its CPU profile.")
@@ -57,6 +57,7 @@ func init() {
 	RunnerCmd.Flags().BoolVarP(&runnerArgs.KeepDataDir, "keep-data-dir", "k", false, "If set the validator will not delete the data directory after tests complete.")
 	RunnerCmd.Flags().StringVarP(&runnerArgs.GenesisFile, "genesis-file", "f", "", "file path to the genesis associated with the db snapshot")
 	RunnerCmd.Flags().BoolVarP(&runnerArgs.ResetDB, "reset-db", "", false, "If set database will be deleted before running tests.")
+	RunnerCmd.Flags().Uint64VarP(&runnerArgs.Times, "times", "t", 1, "Number of times to run the scenario(s).")
 
 	RunnerCmd.MarkFlagRequired("scenario")
 	RunnerCmd.MarkFlagRequired("conduit-binary")


### PR DESCRIPTION
## Summary

Optimizing for usage patterns. It is sometimes useful to run the same suite multiple times to account for transient DB behavior.

I'm using several scripts to run this tool. There may be other features from those scripts that should be migrated, but this seemed like a good start.

There are also some minor changes to logging to remove constant debug output and optimize for general usage.

## Test Plan

1) Start a postgres container.
2) Run the command:
```
./block-generator runner \
    --conduit-binary /home/will/algorand/conduit/cmd/conduit/conduit \
    --report-directory reports \
    --test-duration 5s \
    --conduit-log-level trace \
    --postgres-connection-string "host=localhost user=algorand password=algorand dbname=generator_db port=15432 sslmode=disable" \
    --scenario generator/test_scenario.yml \
    --reset-db --times 5 --reset-report-dir
```