### PR TITLE
CICD: Macos dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ workflows:
           name: << matrix.platform >>_test
           matrix: &matrix-default
             parameters:
-              platform: ["mac_arm64"]
+              platform: ["amd64"]
           filters: &filters-default
             branches:
               ignore:
@@ -204,7 +204,7 @@ workflows:
           name: << matrix.platform >>_<< matrix.job_type >>_verification
           matrix:
             parameters:
-              platform: ["mac_arm64"]
+              platform: ["amd64"]
               job_type: ["test", "integration", "e2e_expect"]
           requires:
             - << matrix.platform >>_<< matrix.job_type >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ workflows:
           name: << matrix.platform >>_test
           matrix: &matrix-default
             parameters:
-              platform: ["amd64"]
+              platform: ["mac_amd64"]
           filters: &filters-default
             branches:
               ignore:
@@ -204,7 +204,7 @@ workflows:
           name: << matrix.platform >>_<< matrix.job_type >>_verification
           matrix:
             parameters:
-              platform: ["amd64"]
+              platform: ["mac_amd64"]
               job_type: ["test", "integration", "e2e_expect"]
           requires:
             - << matrix.platform >>_<< matrix.job_type >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ workflows:
           name: << matrix.platform >>_test
           matrix: &matrix-default
             parameters:
-              platform: ["mac_amd64"]
+              platform: ["mac_arm64"]
           filters: &filters-default
             branches:
               ignore:
@@ -204,7 +204,7 @@ workflows:
           name: << matrix.platform >>_<< matrix.job_type >>_verification
           matrix:
             parameters:
-              platform: ["mac_amd64"]
+              platform: ["mac_arm64"]
               job_type: ["test", "integration", "e2e_expect"]
           requires:
             - << matrix.platform >>_<< matrix.job_type >>

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -79,15 +79,13 @@ elif [ "${OS}" = "darwin" ]; then
     install_or_upgrade pkg-config
     install_or_upgrade libtool
     install_or_upgrade shellcheck
-    if [ "${CIRCLECI}" != "true" ]; then
-        install_or_upgrade jq
-        install_or_upgrade autoconf
-        install_or_upgrade automake
-        install_or_upgrade python3
-        install_or_upgrade lnav
-        install_or_upgrade diffutils
-        lnav -i "$SCRIPTPATH/algorand_node_log.json"
-    fi
+    install_or_upgrade jq
+    install_or_upgrade autoconf
+    install_or_upgrade automake
+    install_or_upgrade python3
+    install_or_upgrade lnav
+    install_or_upgrade diffutils
+    lnav -i "$SCRIPTPATH/algorand_node_log.json"
 elif [ "${OS}" = "windows" ]; then
     if ! $msys2 pacman -S --disable-download-timeout --noconfirm git automake autoconf m4 libtool make mingw-w64-x86_64-gcc mingw-w64-x86_64-python mingw-w64-x86_64-jq unzip procps; then
         echo "Error installing pacman dependencies"


### PR DESCRIPTION
## Summary

CircleCI's amd64 machine are missing certain packages when we upgraded to 14.2.0. This change removes the conditional and will install and upgrade when we run the jobs on mac os machines each time.

### Observed Behavior
During the mac_amd64 upgrade from xcode 13.2.1 to 14.2.0 (#5590 ), we had installed all of the packages by removing this conditional and running it once before reverting back the change. It seems to have cached the installed packages for a few days (7 days). However after a week we see this error `automake is required, but wasn't found on this system` again in our nightly builds.

The behavior seen in #2608 no longer seems to be true for CircleCI's xcode 14.2.0 machine.

## Test Plan

Test that mac_amd64 build succeeds:
https://app.circleci.com/pipelines/github/algorand/go-algorand/15737/workflows/ea33bcc1-7654-4505-b7a7-ff8c959e89ac

