### PR TITLE
tests: fix close - commit data race in tracker tests

### DIFF
--- a/ledger/acctonline_test.go
+++ b/ledger/acctonline_test.go
@@ -730,8 +730,7 @@ func TestAcctOnlineRoundParamsCache(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, ao := newAcctUpdates(t, ml, conf)
-	defer au.close()
-	defer ao.close()
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	// cover 10 genesis blocks
 	rewardLevel := uint64(0)

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -532,8 +532,7 @@ func testAcctUpdates(t *testing.T, conf config.Local) {
 			defer ml.Close()
 
 			au, ao := newAcctUpdates(t, ml, conf)
-			defer au.close()
-			defer ao.close()
+			// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 			// cover 10 genesis blocks
 			rewardLevel := uint64(0)
@@ -662,9 +661,8 @@ func BenchmarkBalancesChanges(b *testing.B) {
 
 	conf := config.GetDefaultLocal()
 	maxAcctLookback := conf.MaxAcctLookback
-	au, ao := newAcctUpdates(b, ml, conf)
-	defer au.close()
-	defer ao.close()
+	au, _ := newAcctUpdates(b, ml, conf)
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	// cover initialRounds genesis blocks
 	rewardLevel := uint64(0)
@@ -798,7 +796,7 @@ func testAcctUpdatesUpdatesCorrectness(t *testing.T, cfg config.Local) {
 		}
 
 		au, _ := newAcctUpdates(t, ml, cfg)
-		defer au.close()
+		// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 		// cover 10 genesis blocks
 		rewardLevel := uint64(0)
@@ -929,7 +927,7 @@ func TestBoxNamesByAppIDs(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	defer au.close()
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	knownCreatables := make(map[basics.CreatableIndex]bool)
 	opts := auNewBlockOpts{ledgercore.AccountDeltas{}, protocol.ConsensusCurrentVersion, protoParams, knownCreatables}
@@ -1050,7 +1048,7 @@ func TestKVCache(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	defer au.close()
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	knownCreatables := make(map[basics.CreatableIndex]bool)
 	opts := auNewBlockOpts{ledgercore.AccountDeltas{}, protocol.ConsensusCurrentVersion, protoParams, knownCreatables}
@@ -1224,7 +1222,7 @@ func BenchmarkLargeMerkleTrieRebuild(b *testing.B) {
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
 	au, _ := newAcctUpdates(b, ml, cfg)
-	defer au.close()
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	// at this point, the database was created. We want to fill the accounts data
 	accountsNumber := 6000000 * b.N
@@ -1613,7 +1611,7 @@ func TestAcctUpdatesCachesInitialization(t *testing.T) {
 
 	conf = config.GetDefaultLocal()
 	au, _ = newAcctUpdates(t, ml2, conf)
-	defer au.close()
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	// make sure the deltas array end up containing only the most recent 320 rounds.
 	require.Equal(t, int(conf.MaxAcctLookback), len(au.deltas))
@@ -1641,7 +1639,7 @@ func TestAcctUpdatesSplittingConsensusVersionCommits(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	defer au.close()
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	// cover initialRounds genesis blocks
 	rewardLevel := uint64(0)
@@ -1746,7 +1744,7 @@ func TestAcctUpdatesSplittingConsensusVersionCommitsBoundary(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	defer au.close()
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	// cover initialRounds genesis blocks
 	rewardLevel := uint64(0)
@@ -1881,7 +1879,7 @@ func TestAcctUpdatesResources(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	defer au.close()
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	var addr1 basics.Address
 	var addr2 basics.Address
@@ -2088,7 +2086,7 @@ func TestAcctUpdatesLookupLatest(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	defer au.close()
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 	for addr, acct := range accts {
 		acctData, validThrough, withoutRewards, err := au.lookupLatest(addr)
 		require.NoError(t, err)
@@ -2124,8 +2122,7 @@ func testAcctUpdatesLookupRetry(t *testing.T, assertFn func(au *accountUpdates, 
 	defer ml.Close()
 
 	au, ao := newAcctUpdates(t, ml, conf)
-	defer au.close()
-	defer ao.close()
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	// cover 10 genesis blocks
 	rewardLevel := uint64(0)
@@ -2367,7 +2364,7 @@ func TestAcctUpdatesLookupLatestCacheRetry(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	defer au.close()
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	var addr1 basics.Address
 	for addr := range accts[0] {
@@ -2496,7 +2493,7 @@ func TestAcctUpdatesLookupResources(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	defer au.close()
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	var addr1 basics.Address
 	for addr := range accts[0] {
@@ -2576,7 +2573,7 @@ func TestAcctUpdatesLookupStateDelta(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	defer au.close()
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	knownCreatables := make(map[basics.CreatableIndex]bool)
 

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -662,7 +662,7 @@ func BenchmarkBalancesChanges(b *testing.B) {
 	conf := config.GetDefaultLocal()
 	maxAcctLookback := conf.MaxAcctLookback
 	au, _ := newAcctUpdates(b, ml, conf)
-	// au and ao are closed via ml.Close() -> ml.trackers.close()
+	// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
 
 	// cover initialRounds genesis blocks
 	rewardLevel := uint64(0)
@@ -796,7 +796,7 @@ func testAcctUpdatesUpdatesCorrectness(t *testing.T, cfg config.Local) {
 		}
 
 		au, _ := newAcctUpdates(t, ml, cfg)
-		// au and ao are closed via ml.Close() -> ml.trackers.close()
+		// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
 
 		// cover 10 genesis blocks
 		rewardLevel := uint64(0)
@@ -927,7 +927,7 @@ func TestBoxNamesByAppIDs(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	// au and ao are closed via ml.Close() -> ml.trackers.close()
+	// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
 
 	knownCreatables := make(map[basics.CreatableIndex]bool)
 	opts := auNewBlockOpts{ledgercore.AccountDeltas{}, protocol.ConsensusCurrentVersion, protoParams, knownCreatables}
@@ -1048,7 +1048,7 @@ func TestKVCache(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	// au and ao are closed via ml.Close() -> ml.trackers.close()
+	// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
 
 	knownCreatables := make(map[basics.CreatableIndex]bool)
 	opts := auNewBlockOpts{ledgercore.AccountDeltas{}, protocol.ConsensusCurrentVersion, protoParams, knownCreatables}
@@ -1222,7 +1222,7 @@ func BenchmarkLargeMerkleTrieRebuild(b *testing.B) {
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
 	au, _ := newAcctUpdates(b, ml, cfg)
-	// au and ao are closed via ml.Close() -> ml.trackers.close()
+	// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
 
 	// at this point, the database was created. We want to fill the accounts data
 	accountsNumber := 6000000 * b.N
@@ -1611,7 +1611,7 @@ func TestAcctUpdatesCachesInitialization(t *testing.T) {
 
 	conf = config.GetDefaultLocal()
 	au, _ = newAcctUpdates(t, ml2, conf)
-	// au and ao are closed via ml.Close() -> ml.trackers.close()
+	// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
 
 	// make sure the deltas array end up containing only the most recent 320 rounds.
 	require.Equal(t, int(conf.MaxAcctLookback), len(au.deltas))
@@ -1639,7 +1639,7 @@ func TestAcctUpdatesSplittingConsensusVersionCommits(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	// au and ao are closed via ml.Close() -> ml.trackers.close()
+	// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
 
 	// cover initialRounds genesis blocks
 	rewardLevel := uint64(0)
@@ -1744,7 +1744,7 @@ func TestAcctUpdatesSplittingConsensusVersionCommitsBoundary(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	// au and ao are closed via ml.Close() -> ml.trackers.close()
+	// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
 
 	// cover initialRounds genesis blocks
 	rewardLevel := uint64(0)
@@ -1879,7 +1879,7 @@ func TestAcctUpdatesResources(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	// au and ao are closed via ml.Close() -> ml.trackers.close()
+	// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
 
 	var addr1 basics.Address
 	var addr2 basics.Address
@@ -2086,7 +2086,7 @@ func TestAcctUpdatesLookupLatest(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	// au and ao are closed via ml.Close() -> ml.trackers.close()
+	// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
 	for addr, acct := range accts {
 		acctData, validThrough, withoutRewards, err := au.lookupLatest(addr)
 		require.NoError(t, err)
@@ -2364,7 +2364,7 @@ func TestAcctUpdatesLookupLatestCacheRetry(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	// au and ao are closed via ml.Close() -> ml.trackers.close()
+	// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
 
 	var addr1 basics.Address
 	for addr := range accts[0] {
@@ -2493,7 +2493,7 @@ func TestAcctUpdatesLookupResources(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	// au and ao are closed via ml.Close() -> ml.trackers.close()
+	// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
 
 	var addr1 basics.Address
 	for addr := range accts[0] {
@@ -2573,7 +2573,7 @@ func TestAcctUpdatesLookupStateDelta(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	au, _ := newAcctUpdates(t, ml, conf)
-	// au and ao are closed via ml.Close() -> ml.trackers.close()
+	// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
 
 	knownCreatables := make(map[basics.CreatableIndex]bool)
 

--- a/ledger/catchpointfilewriter_test.go
+++ b/ledger/catchpointfilewriter_test.go
@@ -132,7 +132,7 @@ func verifyStateProofVerificationContextWrite(t *testing.T, data []ledgercore.St
 	au, _ := newAcctUpdates(t, ml, conf)
 	err := au.loadFromDisk(ml, 0)
 	require.NoError(t, err)
-	au.close()
+	au.close() // it is OK to close it here - no data race since commitSyncer is not active
 	fileName := filepath.Join(temporaryDirectory, "15.data")
 
 	mockCommitData := make([]verificationCommitContext, 0)
@@ -258,7 +258,7 @@ func TestBasicCatchpointWriter(t *testing.T) {
 	au, _ := newAcctUpdates(t, ml, conf)
 	err := au.loadFromDisk(ml, 0)
 	require.NoError(t, err)
-	au.close()
+	au.close() // it is OK to close it here - no data race since commitSyncer is not active
 	fileName := filepath.Join(temporaryDirectory, "15.data")
 
 	err = ml.trackerDB().Transaction(func(ctx context.Context, tx trackerdb.TransactionScope) (err error) {
@@ -425,7 +425,7 @@ func TestCatchpointReadDatabaseOverflowSingleAccount(t *testing.T) {
 	au, _ := newAcctUpdates(t, ml, conf)
 	err := au.loadFromDisk(ml, 0)
 	require.NoError(t, err)
-	au.close()
+	au.close() // it is OK to close it here - no data race since commitSyncer is not active
 	catchpointDataFilePath := filepath.Join(temporaryDirectory, "15.data")
 
 	err = ml.trackerDB().Transaction(func(ctx context.Context, tx trackerdb.TransactionScope) (err error) {

--- a/ledger/voters_test.go
+++ b/ledger/voters_test.go
@@ -176,8 +176,8 @@ func TestLimitVoterTracker(t *testing.T) {
 	conf := config.GetDefaultLocal()
 	// To cause all blocks to be committed, for easier processing by the voters tracker.
 	conf.MaxAcctLookback = 0
+	_, ao := newAcctUpdates(t, ml, conf)
 	// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
-	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	i := uint64(1)
 

--- a/ledger/voters_test.go
+++ b/ledger/voters_test.go
@@ -122,9 +122,8 @@ func TestVoterTrackerDeleteVotersAfterStateproofConfirmed(t *testing.T) {
 	conf := config.GetDefaultLocal()
 	// To cause all blocks to be committed, for easier processing by the voters tracker.
 	conf.MaxAcctLookback = 0
-	au, ao := newAcctUpdates(t, ml, conf)
-	defer au.close()
-	defer ao.close()
+	_, ao := newAcctUpdates(t, ml, conf)
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	i := uint64(1)
 	// adding blocks to the voterstracker (in order to pass the numOfIntervals*stateproofInterval we add 1)
@@ -177,9 +176,8 @@ func TestLimitVoterTracker(t *testing.T) {
 	conf := config.GetDefaultLocal()
 	// To cause all blocks to be committed, for easier processing by the voters tracker.
 	conf.MaxAcctLookback = 0
-	au, ao := newAcctUpdates(t, ml, conf)
-	defer au.close()
-	defer ao.close()
+	_, ao := newAcctUpdates(t, ml, conf)
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	i := uint64(1)
 
@@ -261,9 +259,8 @@ func TestTopNAccountsThatHaveNoMssKeys(t *testing.T) {
 	defer ml.Close()
 
 	conf := config.GetDefaultLocal()
-	au, ao := newAcctUpdates(t, ml, conf)
-	defer au.close()
-	defer ao.close()
+	_, ao := newAcctUpdates(t, ml, conf)
+	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	i := uint64(1)
 	for ; i < (intervalForTest)+1; i++ {

--- a/ledger/voters_test.go
+++ b/ledger/voters_test.go
@@ -123,7 +123,7 @@ func TestVoterTrackerDeleteVotersAfterStateproofConfirmed(t *testing.T) {
 	// To cause all blocks to be committed, for easier processing by the voters tracker.
 	conf.MaxAcctLookback = 0
 	_, ao := newAcctUpdates(t, ml, conf)
-	// au and ao are closed via ml.Close() -> ml.trackers.close()
+	// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
 
 	i := uint64(1)
 	// adding blocks to the voterstracker (in order to pass the numOfIntervals*stateproofInterval we add 1)
@@ -176,7 +176,7 @@ func TestLimitVoterTracker(t *testing.T) {
 	conf := config.GetDefaultLocal()
 	// To cause all blocks to be committed, for easier processing by the voters tracker.
 	conf.MaxAcctLookback = 0
-	_, ao := newAcctUpdates(t, ml, conf)
+	// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
 	// au and ao are closed via ml.Close() -> ml.trackers.close()
 
 	i := uint64(1)
@@ -260,7 +260,7 @@ func TestTopNAccountsThatHaveNoMssKeys(t *testing.T) {
 
 	conf := config.GetDefaultLocal()
 	_, ao := newAcctUpdates(t, ml, conf)
-	// au and ao are closed via ml.Close() -> ml.trackers.close()
+	// accountUpdates and onlineAccounts are closed via: ml.Close() -> ml.trackers.close()
 
 	i := uint64(1)
 	for ; i < (intervalForTest)+1; i++ {


### PR DESCRIPTION
## Summary

Fixed data race from [this build](https://app.circleci.com/pipelines/github/algorand/go-algorand/15760/workflows/0e2eb8cb-cee7-4c76-9bc9-2ff3a244d6ec/jobs/247635?invite=true#step-114-6326):

```
WARNING: DATA RACE
Read at 0x00c000144900 by goroutine 3010:
  runtime.mapaccess1()
      /opt/cibuild/.gimme/versions/go1.20.5.linux.amd64/src/runtime/map.go:395 +0x0
  github.com/algorand/go-algorand/ledger.(*lruAccounts).read()
      /opt/cibuild/project/ledger/lruaccts.go:66 +0x97
  github.com/algorand/go-algorand/ledger.makeCompactAccountDeltas()
      /opt/cibuild/project/ledger/acctdeltas.go:453 +0x878
  github.com/algorand/go-algorand/ledger.(*accountUpdates).prepareCommit()
      /opt/cibuild/project/ledger/acctupdates.go:1555 +0x688
  github.com/algorand/go-algorand/ledger.(*trackerRegistry).commitRound()
      /opt/cibuild/project/ledger/tracker.go:538 +0x641
  github.com/algorand/go-algorand/ledger.(*trackerRegistry).commitSyncer()
      /opt/cibuild/project/ledger/tracker.go:480 +0x20d
  github.com/algorand/go-algorand/ledger.(*trackerRegistry).initialize.func2()
      /opt/cibuild/project/ledger/tracker.go:308 +0x47

Previous write at 0x00c000144900 by goroutine 2978:
  runtime.mapdelete()
      /opt/cibuild/.gimme/versions/go1.20.5.linux.amd64/src/runtime/map.go:695 +0x0
  github.com/algorand/go-algorand/ledger.(*lruAccounts).prune()
      /opt/cibuild/project/ledger/lruaccts.go:163 +0x113
  github.com/algorand/go-algorand/ledger.(*accountUpdates).close()
      /opt/cibuild/project/ledger/acctupdates.go:323 +0xee
  github.com/algorand/go-algorand/ledger.testAcctUpdatesUpdatesCorrectness.func1.2()
      /opt/cibuild/project/ledger/acctupdates_test.go:801 +0x39
  runtime.deferCallSave()
      /opt/cibuild/.gimme/versions/go1.20.5.linux.amd64/src/runtime/panic.go:796 +0x87
  testing.(*T).FailNow()
      <autogenerated>:1 +0x37
  github.com/stretchr/testify/require.Equalf()
      /opt/cibuild/go/pkg/mod/github.com/stretchr/testify@v1.8.4/require/require.go:280 +0x12d
  github.com/algorand/go-algorand/ledger.testAcctUpdatesUpdatesCorrectness.func1()
      /opt/cibuild/project/ledger/acctupdates_test.go:872 +0x2524
```

## Test Plan

Existing tests