### PR TITLE
Revert "ledger: increase locks granularity in lookupWithoutRewards"

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1327,21 +1327,15 @@ func (au *accountUpdates) lookupWithoutRewards(rnd basics.Round, addr basics.Add
 			return
 		}
 
-		deltas := au.deltas[:offset]
 		rewardsVersion = au.versions[offset]
 		rewardsLevel = au.roundTotals[offset].RewardsLevel
 
 		// check if we've had this address modified in the past rounds. ( i.e. if it's in the deltas )
 		macct, indeltas := au.accounts[addr]
-		if synchronized {
-			au.accountsMu.RUnlock()
-			needUnlock = false
-		}
-
 		if indeltas {
 			// Check if this is the most recent round, in which case, we can
 			// use a cache of the most recent account state.
-			if offset == uint64(currentDeltaLen) {
+			if offset == uint64(len(au.deltas)) {
 				return macct.data, rnd, rewardsVersion, rewardsLevel, nil
 			}
 			// the account appears in the deltas, but we don't know if it appears in the
@@ -1349,7 +1343,7 @@ func (au *accountUpdates) lookupWithoutRewards(rnd basics.Round, addr basics.Add
 			// backwards to ensure that later updates take priority if present.
 			for offset > 0 {
 				offset--
-				d, ok := deltas[offset].Accts.GetData(addr)
+				d, ok := au.deltas[offset].Accts.GetData(addr)
 				if ok {
 					// the returned validThrough here is not optimal, but it still correct. We could get a more accurate value by scanning
 					// the deltas forward, but this would be time consuming loop, which might not pay off.
@@ -1364,10 +1358,6 @@ func (au *accountUpdates) lookupWithoutRewards(rnd basics.Round, addr basics.Add
 			rnd = currentDbRound + basics.Round(currentDeltaLen)
 		}
 
-		if synchronized {
-			au.accountsMu.RLock()
-			needUnlock = true
-		}
 		// check the baseAccounts -
 		if macct, has := au.baseAccounts.read(addr); has {
 			// we don't technically need this, since it's already in the baseAccounts, however, writing this over


### PR DESCRIPTION
Reverts algorand/go-algorand#5527 because it causes `TestAcctUpdatesUpdatesCorrectness` failures. Need to investigate.