### PR TITLE
tools: test on CI regardless of modded file

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -9,9 +9,6 @@ on:
       - 'tools/block-generator/**'
       - 'tools/x-repo-types/**'
   pull_request:
-    paths:
-      - 'tools/block-generator/**'
-      - 'tools/x-repo-types/**'
 
 jobs:
   tools_test:

--- a/tools/block-generator/go.mod
+++ b/tools/block-generator/go.mod
@@ -6,7 +6,7 @@ go 1.20
 
 require (
 	github.com/algorand/avm-abi v0.2.0
-	github.com/algorand/go-algorand v0.0.0-00010101000000-000000000000
+	github.com/algorand/go-algorand v0.0.0
 	github.com/algorand/go-codec/codec v1.1.10
 	github.com/algorand/go-deadlock v0.2.2
 	github.com/lib/pq v1.10.9

--- a/tools/x-repo-types/Makefile
+++ b/tools/x-repo-types/Makefile
@@ -39,6 +39,13 @@ goal-v-sdk-stateproof:
 		--y-package "github.com/algorand/go-algorand-sdk/v2/types" \
 		--y-type "StateProof"
 
+goal-v-sdk-consensus:
+	x-repo-types --x-package "github.com/algorand/go-algorand/config" \
+		--x-type "ConsensusParams" \
+		--y-branch "develop" \
+		--y-package "github.com/algorand/go-algorand-sdk/v2/protocol/config" \
+		--y-type "ConsensusParams"
+
 # go-algorand vs go-stateproof-verification:
 
 goal-v-spv: goal-v-spv-stateproof

--- a/tools/x-repo-types/Makefile
+++ b/tools/x-repo-types/Makefile
@@ -1,50 +1,57 @@
-all: goal-v-sdk goal-v-spv
+all: clean goal-v-sdk goal-v-spv
+
+
+clean:
+	rm x-repo-types
+
+x-repo-types:
+	go build
 
 # go-algorand vs go-algorand-sdk:
 
 goal-v-sdk: goal-v-sdk-state-delta goal-v-sdk-genesis goal-v-sdk-block goal-v-sdk-blockheader goal-v-sdk-stateproof
 
-goal-v-sdk-state-delta:
+goal-v-sdk-state-delta: x-repo-types
 	x-repo-types --x-package "github.com/algorand/go-algorand/ledger/ledgercore" \
 		--x-type "StateDelta" \
 		--y-branch "develop" \
 		--y-package "github.com/algorand/go-algorand-sdk/v2/types" \
 		--y-type "LedgerStateDelta"
 
-goal-v-sdk-genesis:
+goal-v-sdk-genesis: x-repo-types
 	x-repo-types --x-package "github.com/algorand/go-algorand/data/bookkeeping" \
 		--x-type "Genesis" \
 		--y-branch "develop" \
 		--y-package "github.com/algorand/go-algorand-sdk/v2/types" \
 		--y-type "Genesis"
 
-goal-v-sdk-block:
+goal-v-sdk-block: x-repo-types
 	x-repo-types --x-package "github.com/algorand/go-algorand/data/bookkeeping" \
 		--x-type "Block" \
 		--y-branch "develop" \
 		--y-package "github.com/algorand/go-algorand-sdk/v2/types" \
 		--y-type "Block"
 
-goal-v-sdk-blockheader:
+goal-v-sdk-blockheader: x-repo-types
 	x-repo-types --x-package "github.com/algorand/go-algorand/data/bookkeeping" \
 		--x-type "BlockHeader" \
 		--y-branch "develop" \
 		--y-package "github.com/algorand/go-algorand-sdk/v2/types" \
 		--y-type "BlockHeader"
 
-goal-v-sdk-stateproof:
-	x-repo-types --x-package "github.com/algorand/go-algorand/crypto/stateproof" \
-		--x-type "StateProof" \
-		--y-branch "develop" \
-		--y-package "github.com/algorand/go-algorand-sdk/v2/types" \
-		--y-type "StateProof"
-
-goal-v-sdk-consensus:
+goal-v-sdk-consensus: x-repo-types
 	x-repo-types --x-package "github.com/algorand/go-algorand/config" \
 		--x-type "ConsensusParams" \
 		--y-branch "develop" \
 		--y-package "github.com/algorand/go-algorand-sdk/v2/protocol/config" \
 		--y-type "ConsensusParams"
+
+goal-v-sdk-stateproof: x-repo-types
+	x-repo-types --x-package "github.com/algorand/go-algorand/crypto/stateproof" \
+		--x-type "StateProof" \
+		--y-branch "develop" \
+		--y-package "github.com/algorand/go-algorand-sdk/v2/types" \
+		--y-type "StateProof"
 
 # go-algorand vs go-stateproof-verification:
 

--- a/tools/x-repo-types/Makefile
+++ b/tools/x-repo-types/Makefile
@@ -1,6 +1,5 @@
 all: clean goal-v-sdk goal-v-spv
 
-
 clean:
 	rm x-repo-types
 

--- a/tools/x-repo-types/go.mod
+++ b/tools/x-repo-types/go.mod
@@ -5,7 +5,7 @@ go 1.20
 replace github.com/algorand/go-algorand => ../..
 
 require (
-	github.com/algorand/go-algorand v0.0.0-20230502140608-e24a35add0bb
+	github.com/algorand/go-algorand v0.0.0-20230731133715-1bf7a214788a
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
 )

--- a/tools/x-repo-types/go.mod
+++ b/tools/x-repo-types/go.mod
@@ -5,7 +5,7 @@ go 1.20
 replace github.com/algorand/go-algorand => ../..
 
 require (
-	github.com/algorand/go-algorand v0.0.0-20230731133715-1bf7a214788a
+	github.com/algorand/go-algorand v0.0.0
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
 )

--- a/tools/x-repo-types/xrt.go
+++ b/tools/x-repo-types/xrt.go
@@ -231,6 +231,10 @@ func restoreFile(src, dst string) error {
 func goGet(repo string) error {
 	fmt.Println("Downloading repo:", repo)
 	cmd := exec.Command("go", "get", repo)
+
+	env := os.Environ()
+	cmd.Env = append(env, "GOPROXY=direct")
+
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/tools/x-repo-types/xrt.go
+++ b/tools/x-repo-types/xrt.go
@@ -231,10 +231,6 @@ func restoreFile(src, dst string) error {
 func goGet(repo string) error {
 	fmt.Println("Downloading repo:", repo)
 	cmd := exec.Command("go", "get", repo)
-
-	env := os.Environ()
-	cmd.Env = append(env, "GOPROXY=direct")
-
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()


### PR DESCRIPTION
The workflow file for the GA tools job was too narrow. It ought to run on every PR against `master`.

Now that it's running it can detect problems on changes to ConsensusParams [as here](https://github.com/algorand/go-algorand/actions/runs/5719301732/job/15496902979#step:8:332).

After the SDK's ConsensusParams were fixed the [test is passing](https://github.com/algorand/go-algorand/actions/runs/5720880973/job/15501567219?pr=5621) as well.