### PR TITLE
tests: fix e2e TestAssetValidRounds after libgoal adjustment

### DIFF
--- a/test/e2e-go/features/transactions/asset_test.go
+++ b/test/e2e-go/features/transactions/asset_test.go
@@ -163,7 +163,7 @@ func TestAssetValidRounds(t *testing.T) {
 	// ledger may advance between SuggestedParams and FillUnsignedTxTemplate calls
 	// expect validity sequence
 	var firstValidRange, lastValidRange []uint64
-	for i := lastRoundBefore + 1; i <= lastRoundAfter+1; i++ {
+	for i := lastRoundBefore; i <= lastRoundAfter+1; i++ {
 		firstValidRange = append(firstValidRange, i)
 		lastValidRange = append(lastValidRange, i+cparams.MaxTxnLife)
 	}


### PR DESCRIPTION
## Summary

[Nightly build](https://app.circleci.com/pipelines/github/algorand/go-algorand/15852/workflows/d6ac20a3-051a-4b9b-9c70-74c4597b5c70/jobs/248321?invite=true#step-114-1184) discovered one missing condition after libgoal  fixes in https://github.com/algorand/go-algorand/pull/5622

## Test Plan

This is a test fix after libgoal's FirstValid calculation adjustment.