### PR TITLE
network: make GossipNode more independent from wsNetwork implementation

### DIFF
--- a/agreement/fuzzer/networkFacade_test.go
+++ b/agreement/fuzzer/networkFacade_test.go
@@ -77,7 +77,7 @@ func MakeNetworkFacade(fuzzer *Fuzzer, nodeID int) *NetworkFacade {
 	n := &NetworkFacade{
 		fuzzer:         fuzzer,
 		nodeID:         nodeID,
-		mux:            network.MakeMultiplexer(fuzzer.log),
+		mux:            network.MakeMultiplexer(),
 		clocks:         make(map[int]chan time.Time),
 		eventsQueues:   make(map[string]int),
 		eventsQueuesCh: make(chan int, 1000),

--- a/agreement/gossip/network_test.go
+++ b/agreement/gossip/network_test.go
@@ -323,7 +323,7 @@ func makewhiteholeNetwork(domain *whiteholeDomain) *whiteholeNetwork {
 	w := &whiteholeNetwork{
 		peer:         atomic.AddUint32(&domain.peerIdx, 1),
 		lastMsgRead:  uint32(len(domain.messages)),
-		mux:          network.MakeMultiplexer(domain.log),
+		mux:          network.MakeMultiplexer(),
 		domain:       domain,
 		disconnected: make(map[uint32]bool),
 	}

--- a/network/msgCompressor.go
+++ b/network/msgCompressor.go
@@ -144,7 +144,7 @@ func (c *wsPeerMsgDataConverter) convert(tag protocol.Tag, data []byte) ([]byte,
 
 func makeWsPeerMsgDataConverter(wp *wsPeer) *wsPeerMsgDataConverter {
 	c := wsPeerMsgDataConverter{
-		log:    wp.net.log,
+		log:    wp.log,
 		origin: wp.originAddress,
 	}
 

--- a/network/multiplexer.go
+++ b/network/multiplexer.go
@@ -17,24 +17,19 @@
 package network
 
 import (
+	"fmt"
 	"sync/atomic"
-
-	"github.com/algorand/go-algorand/logging"
 )
 
 // Multiplexer is a message handler that sorts incoming messages by Tag and passes
 // them along to the relevant message handler for that type of message.
 type Multiplexer struct {
 	msgHandlers atomic.Value // stores map[Tag]MessageHandler, an immutable map.
-
-	log logging.Logger
 }
 
 // MakeMultiplexer creates an empty Multiplexer
-func MakeMultiplexer(log logging.Logger) *Multiplexer {
-	m := &Multiplexer{
-		log: log,
-	}
+func MakeMultiplexer() *Multiplexer {
+	m := &Multiplexer{}
 	m.ClearHandlers([]Tag{}) // allocate the map
 	return m
 }
@@ -78,7 +73,7 @@ func (m *Multiplexer) RegisterHandlers(dispatch []TaggedMessageHandler) {
 	}
 	for _, v := range dispatch {
 		if _, has := mp[v.Tag]; has {
-			m.log.Panicf("Already registered a handler for tag %v", v.Tag)
+			panic(fmt.Sprintf("Already registered a handler for tag %v", v.Tag))
 		}
 		mp[v.Tag] = v.MessageHandler
 	}

--- a/network/multiplexer_test.go
+++ b/network/multiplexer_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
@@ -57,7 +56,7 @@ func (th *testHandler) SawMsg(msg IncomingMessage) bool {
 func TestMultiplexer(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	m := MakeMultiplexer(logging.TestingLog(t))
+	m := MakeMultiplexer()
 	handler := &testHandler{}
 
 	// Handler shouldn't be called before it is registered
@@ -78,7 +77,7 @@ func TestMultiplexer(t *testing.T) {
 				panicked = true
 			}
 		}()
-		m := MakeMultiplexer(logging.TestingLog(t))
+		m := MakeMultiplexer()
 		m.RegisterHandlers([]TaggedMessageHandler{{protocol.TxnTag, handler}, {protocol.TxnTag, handler}})
 
 	}()
@@ -90,7 +89,7 @@ func TestMultiplexer(t *testing.T) {
 				panicked = true
 			}
 		}()
-		m := MakeMultiplexer(logging.TestingLog(t))
+		m := MakeMultiplexer()
 		m.RegisterHandlers([]TaggedMessageHandler{{protocol.TxnTag, handler}})
 		m.RegisterHandlers([]TaggedMessageHandler{{protocol.TxnTag, handler}})
 

--- a/network/netidentity.go
+++ b/network/netidentity.go
@@ -325,6 +325,12 @@ func (i identityVerificationMessageSigned) Verify(key crypto.PublicKey) bool {
 // sender's claimed identity and the challenge that was assigned to it. If the identity is available,
 // the peer is loaded into the identity tracker. Otherwise, we ask the network to disconnect the peer.
 func identityVerificationHandler(message IncomingMessage) OutgoingMessage {
+	wsNet, ok := message.Net.(*WebsocketNetwork)
+	if !ok {
+		// this is only a feature for the wsNetwork
+		return OutgoingMessage{}
+	}
+
 	peer := message.Sender.(*wsPeer)
 	// avoid doing work (crypto and potentially taking a lock) if the peer is already verified
 	if atomic.LoadUint32(&peer.identityVerified) == 1 {
@@ -335,27 +341,27 @@ func identityVerificationHandler(message IncomingMessage) OutgoingMessage {
 	err := protocol.Decode(message.Data, &msg)
 	if err != nil {
 		networkPeerIdentityError.Inc(nil)
-		peer.net.log.With("err", err).With("remote", peer.OriginAddress()).With("local", localAddr).Warn("peer identity verification could not be decoded, disconnecting")
+		peer.log.With("err", err).With("remote", peer.OriginAddress()).With("local", localAddr).Warn("peer identity verification could not be decoded, disconnecting")
 		return OutgoingMessage{Action: Disconnect, reason: disconnectBadIdentityData}
 	}
 	if peer.identityChallenge != msg.Msg.ResponseChallenge {
 		networkPeerIdentityError.Inc(nil)
-		peer.net.log.With("remote", peer.OriginAddress()).With("local", localAddr).Warn("peer identity verification challenge does not match, disconnecting")
+		peer.log.With("remote", peer.OriginAddress()).With("local", localAddr).Warn("peer identity verification challenge does not match, disconnecting")
 		return OutgoingMessage{Action: Disconnect, reason: disconnectBadIdentityData}
 	}
 	if !msg.Verify(peer.identity) {
 		networkPeerIdentityError.Inc(nil)
-		peer.net.log.With("remote", peer.OriginAddress()).With("local", localAddr).Warn("peer identity verification is incorrectly signed, disconnecting")
+		peer.log.With("remote", peer.OriginAddress()).With("local", localAddr).Warn("peer identity verification is incorrectly signed, disconnecting")
 		return OutgoingMessage{Action: Disconnect, reason: disconnectBadIdentityData}
 	}
 	atomic.StoreUint32(&peer.identityVerified, 1)
 	// if the identity could not be claimed by this peer, it means the identity is in use
-	peer.net.peersLock.Lock()
-	ok := peer.net.identityTracker.setIdentity(peer)
-	peer.net.peersLock.Unlock()
+	wsNet.peersLock.Lock()
+	ok = wsNet.identityTracker.setIdentity(peer)
+	wsNet.peersLock.Unlock()
 	if !ok {
 		networkPeerIdentityDisconnect.Inc(nil)
-		peer.net.log.With("remote", peer.OriginAddress()).With("local", localAddr).Warn("peer identity already in use, disconnecting")
+		peer.log.With("remote", peer.OriginAddress()).With("local", localAddr).Warn("peer identity already in use, disconnecting")
 		return OutgoingMessage{Action: Disconnect, reason: disconnectDuplicateConnection}
 	}
 	return OutgoingMessage{}

--- a/network/netidentity.go
+++ b/network/netidentity.go
@@ -325,7 +325,7 @@ func (i identityVerificationMessageSigned) Verify(key crypto.PublicKey) bool {
 // sender's claimed identity and the challenge that was assigned to it. If the identity is available,
 // the peer is loaded into the identity tracker. Otherwise, we ask the network to disconnect the peer.
 func identityVerificationHandler(message IncomingMessage) OutgoingMessage {
-	wsNet, ok := message.Net.(*WebsocketNetwork)
+	wn, ok := message.Net.(*WebsocketNetwork)
 	if !ok {
 		// this is only a feature for the wsNetwork
 		return OutgoingMessage{}
@@ -356,9 +356,9 @@ func identityVerificationHandler(message IncomingMessage) OutgoingMessage {
 	}
 	atomic.StoreUint32(&peer.identityVerified, 1)
 	// if the identity could not be claimed by this peer, it means the identity is in use
-	wsNet.peersLock.Lock()
-	ok = wsNet.identityTracker.setIdentity(peer)
-	wsNet.peersLock.Unlock()
+	wn.peersLock.Lock()
+	ok = wn.identityTracker.setIdentity(peer)
+	wn.peersLock.Unlock()
 	if !ok {
 		networkPeerIdentityDisconnect.Inc(nil)
 		peer.log.With("remote", peer.OriginAddress()).With("local", localAddr).Warn("peer identity already in use, disconnecting")

--- a/network/netidentity.go
+++ b/network/netidentity.go
@@ -325,11 +325,7 @@ func (i identityVerificationMessageSigned) Verify(key crypto.PublicKey) bool {
 // sender's claimed identity and the challenge that was assigned to it. If the identity is available,
 // the peer is loaded into the identity tracker. Otherwise, we ask the network to disconnect the peer.
 func identityVerificationHandler(message IncomingMessage) OutgoingMessage {
-	wn, ok := message.Net.(*WebsocketNetwork)
-	if !ok {
-		// this is only a feature for the wsNetwork
-		return OutgoingMessage{}
-	}
+	wn := message.Net.(*WebsocketNetwork)
 
 	peer := message.Sender.(*wsPeer)
 	// avoid doing work (crypto and potentially taking a lock) if the peer is already verified
@@ -357,7 +353,7 @@ func identityVerificationHandler(message IncomingMessage) OutgoingMessage {
 	atomic.StoreUint32(&peer.identityVerified, 1)
 	// if the identity could not be claimed by this peer, it means the identity is in use
 	wn.peersLock.Lock()
-	ok = wn.identityTracker.setIdentity(peer)
+	ok := wn.identityTracker.setIdentity(peer)
 	wn.peersLock.Unlock()
 	if !ok {
 		networkPeerIdentityDisconnect.Inc(nil)

--- a/network/netidentity_test.go
+++ b/network/netidentity_test.go
@@ -356,11 +356,12 @@ func TestIdentityTrackerSetIdentity(t *testing.T) {
 }
 
 // Just tests that if a peer is already verified, it just returns OutgoingMessage{}
-func TestHandlerGuard(t *testing.T) {
+func TestIdentityTrackerHandlerGuard(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	p := wsPeer{identityVerified: uint32(1)}
 	msg := IncomingMessage{
 		Sender: &p,
+		Net:    &WebsocketNetwork{},
 	}
 	require.Equal(t, OutgoingMessage{}, identityVerificationHandler(msg))
 }

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -813,14 +813,14 @@ func (wn *WebsocketNetwork) setup() {
 		broadcastQueueHighPrio: make(chan broadcastRequest, wn.outgoingMessagesBufferSize),
 		broadcastQueueBulk:     make(chan broadcastRequest, 100),
 	}
+	if wn.broadcaster.slowWritingPeerMonitorInterval == 0 {
+		wn.broadcaster.slowWritingPeerMonitorInterval = slowWritingPeerMonitorInterval
+	}
 	wn.meshUpdateRequests = make(chan meshRequest, 5)
 	wn.readyChan = make(chan struct{})
 	wn.tryConnectAddrs = make(map[string]int64)
 	wn.eventualReadyDelay = time.Minute
 	wn.prioTracker = newPrioTracker(wn)
-	if wn.broadcaster.slowWritingPeerMonitorInterval == 0 {
-		wn.broadcaster.slowWritingPeerMonitorInterval = slowWritingPeerMonitorInterval
-	}
 
 	readBufferLen := wn.config.IncomingConnectionsLimit + wn.config.GossipFanout
 	if readBufferLen < 100 {

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -173,12 +173,9 @@ const (
 type GossipNode interface {
 	Address() (string, bool)
 	Broadcast(ctx context.Context, tag protocol.Tag, data []byte, wait bool, except Peer) error
-	BroadcastArray(ctx context.Context, tag []protocol.Tag, data [][]byte, wait bool, except Peer) error
 	Relay(ctx context.Context, tag protocol.Tag, data []byte, wait bool, except Peer) error
-	RelayArray(ctx context.Context, tag []protocol.Tag, data [][]byte, wait bool, except Peer) error
 	Disconnect(badnode Peer)
-	DisconnectPeers()
-	Ready() chan struct{}
+	DisconnectPeers() // only used by testing
 
 	// RegisterHTTPHandler path accepts gorilla/mux path annotations
 	RegisterHTTPHandler(path string, handler http.Handler)
@@ -226,12 +223,8 @@ type GossipNode interface {
 	// SubstituteGenesisID substitutes the "{genesisID}" with their network-specific genesisID.
 	SubstituteGenesisID(rawURL string) string
 
-	// GetPeerData returns a value stored by SetPeerData
-	GetPeerData(peer Peer, key string) interface{}
-
-	// SetPeerData attaches a piece of data to a peer.
-	// Other services inside go-algorand may attach data to a peer that gets garbage collected when the peer is closed.
-	SetPeerData(peer Peer, key string, value interface{})
+	// called from wsPeer to report that it has closed
+	peerRemoteClose(peer *wsPeer, reason disconnectReason)
 }
 
 // IncomingMessage represents a message arriving from some peer in our p2p network
@@ -354,11 +347,7 @@ type WebsocketNetwork struct {
 
 	log logging.Logger
 
-	readBuffer chan IncomingMessage
-
 	wg sync.WaitGroup
-
-	handlers Multiplexer
 
 	ctx       context.Context
 	ctxCancel context.CancelFunc
@@ -367,8 +356,8 @@ type WebsocketNetwork struct {
 	peers              []*wsPeer
 	peersChangeCounter int32 // peersChangeCounter is an atomic variable that increases on each change to the peers. It helps avoiding taking the peersLock when checking if the peers list was modified.
 
-	broadcastQueueHighPrio chan broadcastRequest
-	broadcastQueueBulk     chan broadcastRequest
+	broadcaster msgBroadcaster
+	handler     msgHandler
 
 	phonebook Phonebook
 
@@ -407,9 +396,6 @@ type WebsocketNetwork struct {
 
 	// wsMaxHeaderBytes is the maximum accepted size of the header prior to upgrading to websocket connection.
 	wsMaxHeaderBytes int64
-
-	// slowWritingPeerMonitorInterval defines the interval between two consecutive tests for slow peer writing
-	slowWritingPeerMonitorInterval time.Duration
 
 	requestsTracker *RequestTracker
 	requestsLogger  *RequestLogger
@@ -491,6 +477,43 @@ type broadcastRequest struct {
 	ctx         context.Context
 }
 
+// msgBroadcaster contains the logic for preparing data for broadcast, managing broadcast priorities
+// and queues. It provides a goroutine (broadcastThread) for reading from those queues and scheduling
+// broadcasts to peers managed by networkPeerManager.
+type msgBroadcaster struct {
+	ctx                    context.Context
+	log                    logging.Logger
+	config                 config.Local
+	broadcastQueueHighPrio chan broadcastRequest
+	broadcastQueueBulk     chan broadcastRequest
+	// slowWritingPeerMonitorInterval defines the interval between two consecutive tests for slow peer writing
+	slowWritingPeerMonitorInterval time.Duration
+}
+
+// msgHandler contains the logic for handling incoming messages and managing a readBuffer. It provides
+// a goroutine (messageHandlerThread) for reading incoming messages and calling handlers.
+type msgHandler struct {
+	ctx        context.Context
+	log        logging.Logger
+	config     config.Local
+	readBuffer chan IncomingMessage
+	Multiplexer
+}
+
+// networkPeerManager provides the network functionality needed by msgBroadcaster and msgHandler for managing
+// peer connectivity, and also sending messages.
+type networkPeerManager interface {
+	// used by msgBroadcaster
+	peerSnapshot(dest []*wsPeer) ([]*wsPeer, int32)
+	checkSlowWritingPeers()
+	getPeersChangeCounter() *int32
+
+	// used by msgHandler
+	Broadcast(ctx context.Context, tag protocol.Tag, data []byte, wait bool, except Peer) error
+	disconnectThread(badnode Peer, reason disconnectReason)
+	checkPeersConnectivity()
+}
+
 // Address returns a string and whether that is a 'final' address or guessed.
 // Part of GossipNode interface
 func (wn *WebsocketNetwork) Address() (string, bool) {
@@ -528,18 +551,17 @@ func (wn *WebsocketNetwork) Broadcast(ctx context.Context, tag protocol.Tag, dat
 	dataArray[0] = data
 	tagArray := make([]protocol.Tag, 1, 1)
 	tagArray[0] = tag
-	return wn.BroadcastArray(ctx, tagArray, dataArray, wait, except)
+	return wn.broadcaster.BroadcastArray(ctx, tagArray, dataArray, wait, except)
 }
 
 // BroadcastArray sends an array of messages.
 // If except is not nil then we will not send it to that neighboring Peer.
 // if wait is true then the call blocks until the packet has actually been sent to all neighbors.
 // TODO: add `priority` argument so that we don't have to guess it based on tag
-func (wn *WebsocketNetwork) BroadcastArray(ctx context.Context, tags []protocol.Tag, data [][]byte, wait bool, except Peer) error {
+func (wn *msgBroadcaster) BroadcastArray(ctx context.Context, tags []protocol.Tag, data [][]byte, wait bool, except Peer) error {
 	if wn.config.DisableNetworking {
 		return nil
 	}
-
 	if len(tags) != len(data) {
 		return errBcastInvalidArray
 	}
@@ -598,7 +620,7 @@ func (wn *WebsocketNetwork) Relay(ctx context.Context, tag protocol.Tag, data []
 // RelayArray relays array of messages
 func (wn *WebsocketNetwork) RelayArray(ctx context.Context, tags []protocol.Tag, data [][]byte, wait bool, except Peer) error {
 	if wn.relayMessages {
-		return wn.BroadcastArray(ctx, tags, data, wait, except)
+		return wn.broadcaster.BroadcastArray(ctx, tags, data, wait, except)
 	}
 	return nil
 }
@@ -691,14 +713,14 @@ func (wn *WebsocketNetwork) GetPeers(options ...PeerOption) []Peer {
 			var addrs []string
 			addrs = wn.phonebook.GetAddresses(1000, PhoneBookEntryRelayRole)
 			for _, addr := range addrs {
-				peerCore := makePeerCore(wn, addr, wn.GetRoundTripper(), "" /*origin address*/)
+				peerCore := makePeerCore(wn.ctx, wn, wn.log, wn.handler.readBuffer, addr, wn.GetRoundTripper(), "" /*origin address*/)
 				outPeers = append(outPeers, &peerCore)
 			}
 		case PeersPhonebookArchivalNodes:
 			var addrs []string
 			addrs = wn.phonebook.GetAddresses(1000, PhoneBookEntryRelayRole)
 			for _, addr := range addrs {
-				peerCore := makePeerCore(wn, addr, wn.GetRoundTripper(), "" /*origin address*/)
+				peerCore := makePeerCore(wn.ctx, wn, wn.log, wn.handler.readBuffer, addr, wn.GetRoundTripper(), "" /*origin address*/)
 				outPeers = append(outPeers, &peerCore)
 			}
 		case PeersPhonebookArchivers:
@@ -706,7 +728,7 @@ func (wn *WebsocketNetwork) GetPeers(options ...PeerOption) []Peer {
 			var addrs []string
 			addrs = wn.phonebook.GetAddresses(1000, PhoneBookEntryArchiverRole)
 			for _, addr := range addrs {
-				peerCore := makePeerCore(wn, addr, wn.GetRoundTripper(), "" /*origin address*/)
+				peerCore := makePeerCore(wn.ctx, wn, wn.log, wn.handler.readBuffer, addr, wn.GetRoundTripper(), "" /*origin address*/)
 				outPeers = append(outPeers, &peerCore)
 			}
 		case PeersConnectedIn:
@@ -784,15 +806,20 @@ func (wn *WebsocketNetwork) setup() {
 
 	wn.identityTracker = NewIdentityTracker()
 
-	wn.broadcastQueueHighPrio = make(chan broadcastRequest, wn.outgoingMessagesBufferSize)
-	wn.broadcastQueueBulk = make(chan broadcastRequest, 100)
+	wn.broadcaster = msgBroadcaster{
+		ctx:                    wn.ctx,
+		log:                    wn.log,
+		config:                 wn.config,
+		broadcastQueueHighPrio: make(chan broadcastRequest, wn.outgoingMessagesBufferSize),
+		broadcastQueueBulk:     make(chan broadcastRequest, 100),
+	}
 	wn.meshUpdateRequests = make(chan meshRequest, 5)
 	wn.readyChan = make(chan struct{})
 	wn.tryConnectAddrs = make(map[string]int64)
 	wn.eventualReadyDelay = time.Minute
 	wn.prioTracker = newPrioTracker(wn)
-	if wn.slowWritingPeerMonitorInterval == 0 {
-		wn.slowWritingPeerMonitorInterval = slowWritingPeerMonitorInterval
+	if wn.broadcaster.slowWritingPeerMonitorInterval == 0 {
+		wn.broadcaster.slowWritingPeerMonitorInterval = slowWritingPeerMonitorInterval
 	}
 
 	readBufferLen := wn.config.IncomingConnectionsLimit + wn.config.GossipFanout
@@ -802,7 +829,12 @@ func (wn *WebsocketNetwork) setup() {
 	if readBufferLen > 10000 {
 		readBufferLen = 10000
 	}
-	wn.readBuffer = make(chan IncomingMessage, readBufferLen)
+	wn.handler = msgHandler{
+		ctx:        wn.ctx,
+		log:        wn.log,
+		config:     wn.config,
+		readBuffer: make(chan IncomingMessage, readBufferLen),
+	}
 
 	var rbytes [10]byte
 	crypto.RandBytes(rbytes[:])
@@ -813,7 +845,6 @@ func (wn *WebsocketNetwork) setup() {
 	}
 	wn.connPerfMonitor = makeConnectionPerformanceMonitor([]Tag{protocol.AgreementVoteTag, protocol.TxnTag})
 	wn.lastNetworkAdvance = time.Now().UTC()
-	wn.handlers.log = wn.log
 
 	// set our supported versions
 	if wn.config.NetworkProtocolVersion != "" {
@@ -904,10 +935,10 @@ func (wn *WebsocketNetwork) Start() {
 	for i := 0; i < incomingThreads; i++ {
 		wn.wg.Add(1)
 		// We pass the peersConnectivityCheckTicker.C here so that we don't need to syncronize the access to the ticker's data structure.
-		go wn.messageHandlerThread(wn.peersConnectivityCheckTicker.C)
+		go wn.handler.messageHandlerThread(&wn.wg, wn.peersConnectivityCheckTicker.C, wn)
 	}
 	wn.wg.Add(1)
-	go wn.broadcastThread()
+	go wn.broadcaster.broadcastThread(wn.wg.Done, wn)
 	if wn.prioScheme != nil {
 		wn.wg.Add(1)
 		go wn.prioWeightRefresh()
@@ -950,7 +981,7 @@ func (wn *WebsocketNetwork) innerStop() {
 // Stop closes network connections and stops threads.
 // Stop blocks until all activity on this node is done.
 func (wn *WebsocketNetwork) Stop() {
-	wn.handlers.ClearHandlers([]Tag{})
+	wn.handler.ClearHandlers([]Tag{})
 
 	// if we have a working ticker, just stop it and clear it out. The access to this variable is safe since the Start()/Stop() are synced by the
 	// caller, and the WebsocketNetwork doesn't access wn.peersConnectivityCheckTicker directly.
@@ -987,13 +1018,13 @@ func (wn *WebsocketNetwork) Stop() {
 
 // RegisterHandlers registers the set of given message handlers.
 func (wn *WebsocketNetwork) RegisterHandlers(dispatch []TaggedMessageHandler) {
-	wn.handlers.RegisterHandlers(dispatch)
+	wn.handler.RegisterHandlers(dispatch)
 }
 
 // ClearHandlers deregisters all the existing message handlers.
 func (wn *WebsocketNetwork) ClearHandlers() {
 	// exclude the internal handlers. These would get cleared out when Stop is called.
-	wn.handlers.ClearHandlers([]Tag{protocol.PingTag, protocol.PingReplyTag, protocol.NetPrioResponseTag})
+	wn.handler.ClearHandlers([]Tag{protocol.PingTag, protocol.PingReplyTag, protocol.NetPrioResponseTag})
 }
 
 func (wn *WebsocketNetwork) setHeaders(header http.Header) {
@@ -1233,8 +1264,8 @@ func (wn *WebsocketNetwork) ServeHTTP(response http.ResponseWriter, request *htt
 	}
 
 	peer := &wsPeer{
-		wsPeerCore:        makePeerCore(wn, trackedRequest.otherPublicAddr, wn.GetRoundTripper(), trackedRequest.remoteHost),
-		conn:              conn,
+		wsPeerCore:        makePeerCore(wn.ctx, wn, wn.log, wn.handler.readBuffer, trackedRequest.otherPublicAddr, wn.GetRoundTripper(), trackedRequest.remoteHost),
+		conn:              wsPeerWebsocketConnImpl{conn},
 		outgoing:          false,
 		InstanceName:      trackedRequest.otherInstanceName,
 		incomingMsgFilter: wn.incomingMsgFilter,
@@ -1281,8 +1312,8 @@ func (wn *WebsocketNetwork) maybeSendMessagesOfInterest(peer *wsPeer, messagesOf
 	}
 }
 
-func (wn *WebsocketNetwork) messageHandlerThread(peersConnectivityCheckCh <-chan time.Time) {
-	defer wn.wg.Done()
+func (wn *msgHandler) messageHandlerThread(wg *sync.WaitGroup, peersConnectivityCheckCh <-chan time.Time, pm networkPeerManager) {
+	defer wg.Done()
 
 	for {
 		select {
@@ -1298,13 +1329,13 @@ func (wn *WebsocketNetwork) messageHandlerThread(peersConnectivityCheckCh <-chan
 				}
 			}
 			if wn.config.EnableOutgoingNetworkMessageFiltering && len(msg.Data) >= messageFilterSize {
-				wn.sendFilterMessage(msg)
+				wn.sendFilterMessage(msg, pm)
 			}
 			//wn.log.Debugf("msg handling %#v [%d]byte", msg.Tag, len(msg.Data))
 			start := time.Now()
 
 			// now, send to global handlers
-			outmsg := wn.handlers.Handle(msg)
+			outmsg := wn.Handle(msg)
 			handled := time.Now()
 			bufferNanos := start.UnixNano() - msg.Received
 			networkIncomingBufferMicros.AddUint64(uint64(bufferNanos/1000), nil)
@@ -1312,14 +1343,14 @@ func (wn *WebsocketNetwork) messageHandlerThread(peersConnectivityCheckCh <-chan
 			networkHandleMicros.AddUint64(uint64(handleTime.Nanoseconds()/1000), nil)
 			switch outmsg.Action {
 			case Disconnect:
-				wn.wg.Add(1)
+				wg.Add(1)
 				reason := disconnectBadData
 				if outmsg.reason != disconnectReasonNone {
 					reason = outmsg.reason
 				}
-				go wn.disconnectThread(msg.Sender, reason)
+				go pm.disconnectThread(msg.Sender, reason)
 			case Broadcast:
-				err := wn.Broadcast(wn.ctx, msg.Tag, msg.Data, false, msg.Sender)
+				err := pm.Broadcast(wn.ctx, msg.Tag, msg.Data, false, msg.Sender)
 				if err != nil && err != errBcastQFull {
 					wn.log.Warnf("WebsocketNetwork.messageHandlerThread: WebsocketNetwork.Broadcast returned unexpected error %v", err)
 				}
@@ -1332,7 +1363,7 @@ func (wn *WebsocketNetwork) messageHandlerThread(peersConnectivityCheckCh <-chan
 			}
 		case <-peersConnectivityCheckCh:
 			// go over the peers and ensure we have some type of communication going on.
-			wn.checkPeersConnectivity()
+			pm.checkPeersConnectivity()
 		}
 	}
 }
@@ -1372,25 +1403,29 @@ func (wn *WebsocketNetwork) checkSlowWritingPeers() {
 	}
 }
 
-func (wn *WebsocketNetwork) sendFilterMessage(msg IncomingMessage) {
+func (wn *WebsocketNetwork) getPeersChangeCounter() *int32 {
+	return &wn.peersChangeCounter
+}
+
+func (wn *msgHandler) sendFilterMessage(msg IncomingMessage, pm networkPeerManager) {
 	digest := generateMessageDigest(msg.Tag, msg.Data)
 	//wn.log.Debugf("send filter %s(%d) %v", msg.Tag, len(msg.Data), digest)
-	err := wn.Broadcast(context.Background(), protocol.MsgDigestSkipTag, digest[:], false, msg.Sender)
+	err := pm.Broadcast(context.Background(), protocol.MsgDigestSkipTag, digest[:], false, msg.Sender)
 	if err != nil && err != errBcastQFull {
 		wn.log.Warnf("WebsocketNetwork.sendFilterMessage: WebsocketNetwork.Broadcast returned unexpected error %v", err)
 	}
 }
 
-func (wn *WebsocketNetwork) broadcastThread() {
-	defer wn.wg.Done()
+func (wn *msgBroadcaster) broadcastThread(wgDone func(), pm networkPeerManager) {
+	defer wgDone()
 
 	slowWritingPeerCheckTicker := time.NewTicker(wn.slowWritingPeerMonitorInterval)
 	defer slowWritingPeerCheckTicker.Stop()
-	peers, lastPeersChangeCounter := wn.peerSnapshot([]*wsPeer{})
+	peers, lastPeersChangeCounter := pm.peerSnapshot([]*wsPeer{})
 	// updatePeers update the peers list if their peer change counter has changed.
 	updatePeers := func() {
-		if curPeersChangeCounter := atomic.LoadInt32(&wn.peersChangeCounter); curPeersChangeCounter != lastPeersChangeCounter {
-			peers, lastPeersChangeCounter = wn.peerSnapshot(peers)
+		if curPeersChangeCounter := atomic.LoadInt32(pm.getPeersChangeCounter()); curPeersChangeCounter != lastPeersChangeCounter {
+			peers, lastPeersChangeCounter = pm.peerSnapshot(peers)
 		}
 	}
 
@@ -1481,7 +1516,7 @@ func (wn *WebsocketNetwork) broadcastThread() {
 			}
 			wn.innerBroadcast(request, true, peers)
 		case <-slowWritingPeerCheckTicker.C:
-			wn.checkSlowWritingPeers()
+			pm.checkSlowWritingPeers()
 			continue
 		case request := <-wn.broadcastQueueBulk:
 			// check if peers need to be updated, since we've been waiting a while.
@@ -1522,7 +1557,7 @@ func (wn *WebsocketNetwork) peerSnapshot(dest []*wsPeer) ([]*wsPeer, int32) {
 
 // preparePeerData prepares batches of data for sending.
 // It performs optional zstd compression for proposal massages
-func (wn *WebsocketNetwork) preparePeerData(request broadcastRequest, prio bool, peers []*wsPeer) ([][]byte, [][]byte, []crypto.Digest, bool) {
+func (wn *msgBroadcaster) preparePeerData(request broadcastRequest, prio bool, peers []*wsPeer) ([][]byte, [][]byte, []crypto.Digest, bool) {
 	// determine if there is a payload proposal and peers supporting compressed payloads
 	wantCompression := false
 	containsPrioPPTag := false
@@ -1572,7 +1607,7 @@ func (wn *WebsocketNetwork) preparePeerData(request broadcastRequest, prio bool,
 }
 
 // prio is set if the broadcast is a high-priority broadcast.
-func (wn *WebsocketNetwork) innerBroadcast(request broadcastRequest, prio bool, peers []*wsPeer) {
+func (wn *msgBroadcaster) innerBroadcast(request broadcastRequest, prio bool, peers []*wsPeer) {
 	if request.done != nil {
 		defer close(request.done)
 	}
@@ -1946,7 +1981,7 @@ func (wn *WebsocketNetwork) getPeerConnectionTelemetryDetails(now time.Time, pee
 			connDetail.TCP = *tcpInfo
 		}
 		if peer.outgoing {
-			connDetail.Address = justHost(peer.conn.RemoteAddr().String())
+			connDetail.Address = justHost(peer.conn.RemoteAddrString())
 			connDetail.Endpoint = peer.GetAddress()
 			connDetail.MessageDelay = peer.peerMessageDelay
 			connectionDetails.OutgoingPeers = append(connectionDetails.OutgoingPeers, connDetail)
@@ -2357,8 +2392,8 @@ func (wn *WebsocketNetwork) tryConnect(addr, gossipAddr string) {
 	}
 
 	peer := &wsPeer{
-		wsPeerCore:                  makePeerCore(wn, addr, wn.GetRoundTripper(), "" /* origin */),
-		conn:                        conn,
+		wsPeerCore:                  makePeerCore(wn.ctx, wn, wn.log, wn.handler.readBuffer, addr, wn.GetRoundTripper(), "" /* origin */),
+		conn:                        wsPeerWebsocketConnImpl{conn},
 		outgoing:                    true,
 		incomingMsgFilter:           wn.incomingMsgFilter,
 		createTime:                  time.Now(),
@@ -2491,9 +2526,9 @@ func (wn *WebsocketNetwork) removePeer(peer *wsPeer, reason disconnectReason) {
 	peerAddr := peer.OriginAddress()
 	// we might be able to get addr out of conn, or it might be closed
 	if peerAddr == "" && peer.conn != nil {
-		paddr := peer.conn.RemoteAddr()
-		if paddr != nil {
-			peerAddr = justHost(paddr.String())
+		paddr := peer.conn.RemoteAddrString()
+		if paddr != "" {
+			peerAddr = justHost(paddr)
 		}
 	}
 	if peerAddr == "" {
@@ -2550,7 +2585,7 @@ func (wn *WebsocketNetwork) addPeer(peer *wsPeer) {
 	// guard against peers which are closed or closing
 	if atomic.LoadInt32(&peer.didSignalClose) == 1 {
 		networkPeerAlreadyClosed.Inc(nil)
-		wn.log.Debugf("peer closing %s", peer.conn.RemoteAddr().String())
+		wn.log.Debugf("peer closing %s", peer.conn.RemoteAddrString())
 		return
 	}
 	// simple duplicate *pointer* check. should never trigger given the callers to addPeer

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -543,7 +543,7 @@ func TestWebsocketNetworkArray(t *testing.T) {
 
 	tags := []protocol.Tag{protocol.TxnTag, protocol.TxnTag, protocol.TxnTag}
 	data := [][]byte{[]byte("foo"), []byte("bar"), []byte("algo")}
-	netA.BroadcastArray(context.Background(), tags, data, false, nil)
+	netA.broadcaster.BroadcastArray(context.Background(), tags, data, false, nil)
 
 	select {
 	case <-counterDone:
@@ -571,7 +571,7 @@ func TestWebsocketNetworkCancel(t *testing.T) {
 	cancel()
 
 	// try calling BroadcastArray
-	netA.BroadcastArray(ctx, tags, data, true, nil)
+	netA.broadcaster.BroadcastArray(ctx, tags, data, true, nil)
 
 	select {
 	case <-counterDone:
@@ -583,7 +583,7 @@ func TestWebsocketNetworkCancel(t *testing.T) {
 	// try calling innerBroadcast
 	request := broadcastRequest{tags: tags, data: data, enqueueTime: time.Now(), ctx: ctx}
 	peers, _ := netA.peerSnapshot([]*wsPeer{})
-	netA.innerBroadcast(request, true, peers)
+	netA.broadcaster.innerBroadcast(request, true, peers)
 
 	select {
 	case <-counterDone:
@@ -760,9 +760,11 @@ func TestAddrToGossipAddr(t *testing.T) {
 type nopConn struct{}
 
 func (nc *nopConn) RemoteAddr() net.Addr                        { return nil }
+func (nc *nopConn) RemoteAddrString() string                    { return "" }
 func (nc *nopConn) NextReader() (int, io.Reader, error)         { return 0, nil, nil }
 func (nc *nopConn) WriteMessage(int, []byte) error              { return nil }
 func (nc *nopConn) WriteControl(int, []byte, time.Time) error   { return nil }
+func (nc *nopConn) CloseWithMessage([]byte, time.Time) error    { return nil }
 func (nc *nopConn) SetReadLimit(limit int64)                    {}
 func (nc *nopConn) CloseWithoutFlush() error                    { return nil }
 func (nc *nopConn) SetPingHandler(h func(appData string) error) {}
@@ -799,7 +801,7 @@ func TestSlowHandlers(t *testing.T) {
 	// start slow handler calls that will block all handler threads
 	for i := 0; i < incomingThreads; i++ {
 		data := []byte{byte(i)}
-		node.readBuffer <- IncomingMessage{Sender: &injectionPeers[ipi], Tag: slowTag, Data: data, Net: node}
+		node.handler.readBuffer <- IncomingMessage{Sender: &injectionPeers[ipi], Tag: slowTag, Data: data, Net: node}
 		ipi++
 	}
 	defer slowCounter.Broadcast()
@@ -807,7 +809,7 @@ func TestSlowHandlers(t *testing.T) {
 	// start fast handler calls that won't get to run
 	for i := 0; i < incomingThreads; i++ {
 		data := []byte{byte(i)}
-		node.readBuffer <- IncomingMessage{Sender: &injectionPeers[ipi], Tag: fastTag, Data: data, Net: node}
+		node.handler.readBuffer <- IncomingMessage{Sender: &injectionPeers[ipi], Tag: fastTag, Data: data, Net: node}
 		ipi++
 	}
 	ok := false
@@ -890,7 +892,7 @@ func TestFloodingPeer(t *testing.T) {
 				}
 
 				select {
-				case node.readBuffer <- IncomingMessage{Sender: &injectionPeers[myIpi], Tag: slowTag, Data: data, Net: node, processing: processed}:
+				case node.handler.readBuffer <- IncomingMessage{Sender: &injectionPeers[myIpi], Tag: slowTag, Data: data, Net: node, processing: processed}:
 				case <-ctx.Done():
 					return
 				}
@@ -912,7 +914,7 @@ func TestFloodingPeer(t *testing.T) {
 	fastCounterDone := fastCounter.done
 	for ipi < len(injectionPeers) {
 		data := []byte{byte(ipi)}
-		node.readBuffer <- IncomingMessage{Sender: &injectionPeers[ipi], Tag: fastTag, Data: data, Net: node}
+		node.handler.readBuffer <- IncomingMessage{Sender: &injectionPeers[ipi], Tag: fastTag, Data: data, Net: node}
 		numFast++
 		ipi++
 	}
@@ -2176,7 +2178,7 @@ func BenchmarkWebsocketNetworkBasic(t *testing.B) {
 			networkBroadcastsDropped.WriteMetric(&buf, "")
 			t.Errorf(
 				"a out queue=%d, metric: %s",
-				len(netA.broadcastQueueBulk),
+				len(netA.broadcaster.broadcastQueueBulk),
 				buf.String(),
 			)
 			return
@@ -2450,9 +2452,9 @@ func (wn *WebsocketNetwork) broadcastWithTimestamp(tag protocol.Tag, data []byte
 	tagArr[0] = tag
 	request := broadcastRequest{tags: tagArr, data: msgArr, enqueueTime: when, ctx: context.Background()}
 
-	broadcastQueue := wn.broadcastQueueBulk
+	broadcastQueue := wn.broadcaster.broadcastQueueBulk
 	if highPriorityTag(tagArr) {
-		broadcastQueue = wn.broadcastQueueHighPrio
+		broadcastQueue = wn.broadcaster.broadcastQueueHighPrio
 	}
 	// no wait
 	select {
@@ -2508,13 +2510,13 @@ func TestSlowPeerDisconnection(t *testing.T) {
 	log := logging.TestingLog(t)
 	log.SetLevel(logging.Info)
 	wn := &WebsocketNetwork{
-		log:                            log,
-		config:                         defaultConfig,
-		phonebook:                      MakePhonebook(1, 1*time.Millisecond),
-		GenesisID:                      genesisID,
-		NetworkID:                      config.Devtestnet,
-		slowWritingPeerMonitorInterval: time.Millisecond * 50,
+		log:       log,
+		config:    defaultConfig,
+		phonebook: MakePhonebook(1, 1*time.Millisecond),
+		GenesisID: genesisID,
+		NetworkID: config.Devtestnet,
 	}
+	wn.broadcaster.slowWritingPeerMonitorInterval = time.Millisecond * 50
 	wn.setup()
 	wn.eventualReadyDelay = time.Second
 	wn.messagesOfInterest = nil // clear this before starting the network so that we won't be sending a MOI upon connection.
@@ -3705,7 +3707,7 @@ func TestPreparePeerData(t *testing.T) {
 
 	peers := []*wsPeer{}
 	wn := WebsocketNetwork{}
-	data, comp, digests, seenPrioPPTag := wn.preparePeerData(req, false, peers)
+	data, comp, digests, seenPrioPPTag := wn.broadcaster.preparePeerData(req, false, peers)
 	require.NotEmpty(t, data)
 	require.Empty(t, comp)
 	require.NotEmpty(t, digests)
@@ -3725,7 +3727,7 @@ func TestPreparePeerData(t *testing.T) {
 		features: pfCompressedProposal,
 	}
 	peers = []*wsPeer{&peer1, &peer2}
-	data, comp, digests, seenPrioPPTag = wn.preparePeerData(req, true, peers)
+	data, comp, digests, seenPrioPPTag = wn.broadcaster.preparePeerData(req, true, peers)
 	require.NotEmpty(t, data)
 	require.NotEmpty(t, comp)
 	require.NotEmpty(t, digests)


### PR DESCRIPTION
## Summary

This removes some unused interface methods on GossipNode, and extracts some functionality from WebsocketNetwork into two new types (msgHandler, msgBroadcaster) to make them more available for re-use.

## Test Plan

Existing tests should pass.