### PR TITLE
ledger: increase locks granularity in lookupWithoutRewards

### DIFF
--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1321,15 +1321,21 @@ func (au *accountUpdates) lookupWithoutRewards(rnd basics.Round, addr basics.Add
 			return
 		}
 
+		deltas := au.deltas[:offset]
 		rewardsVersion = au.versions[offset]
 		rewardsLevel = au.roundTotals[offset].RewardsLevel
 
 		// check if we've had this address modified in the past rounds. ( i.e. if it's in the deltas )
 		macct, indeltas := au.accounts[addr]
+		if synchronized {
+			au.accountsMu.RUnlock()
+			needUnlock = false
+		}
+
 		if indeltas {
 			// Check if this is the most recent round, in which case, we can
 			// use a cache of the most recent account state.
-			if offset == uint64(len(au.deltas)) {
+			if offset == uint64(currentDeltaLen) {
 				return macct.data, rnd, rewardsVersion, rewardsLevel, nil
 			}
 			// the account appears in the deltas, but we don't know if it appears in the
@@ -1337,7 +1343,7 @@ func (au *accountUpdates) lookupWithoutRewards(rnd basics.Round, addr basics.Add
 			// backwards to ensure that later updates take priority if present.
 			for offset > 0 {
 				offset--
-				d, ok := au.deltas[offset].Accts.GetData(addr)
+				d, ok := deltas[offset].Accts.GetData(addr)
 				if ok {
 					// the returned validThrough here is not optimal, but it still correct. We could get a more accurate value by scanning
 					// the deltas forward, but this would be time consuming loop, which might not pay off.
@@ -1352,17 +1358,27 @@ func (au *accountUpdates) lookupWithoutRewards(rnd basics.Round, addr basics.Add
 			rnd = currentDbRound + basics.Round(currentDeltaLen)
 		}
 
+		if synchronized {
+			au.accountsMu.RLock()
+			needUnlock = true
+		}
 		// check the baseAccounts -
 		if macct, has := au.baseAccounts.read(addr); has {
+			// there is a chance the db advanced between deltas check and the baseAccounts check
+			// ensure the round requested is still in the db
+			if macct.Round > rnd {
+				return ledgercore.AccountData{}, 0, "", 0, &RoundOffsetError{rnd, macct.Round}
+			}
+
 			// we don't technically need this, since it's already in the baseAccounts, however, writing this over
 			// would ensure that we promote this field.
 			au.baseAccounts.writePending(macct)
 			return macct.AccountData.GetLedgerCoreAccountData(), rnd, rewardsVersion, rewardsLevel, nil
 		}
 
-		// check baseAccoiunts again to see if it does not exist
+		// check baseAccounts again to see if it does not exist
 		if au.baseAccounts.readNotFound(addr) {
-			// it seems the account doesnt exist
+			// it seems the account does not exist
 			return ledgercore.AccountData{}, rnd, rewardsVersion, rewardsLevel, nil
 		}
 

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -830,7 +830,7 @@ func testAcctUpdatesUpdatesCorrectness(t *testing.T, cfg config.Local) {
 				fromAccountDataOld, validThrough, err := au.LookupWithoutRewards(i-1, fromAccount)
 				require.NoError(t, err)
 				require.Equal(t, i-1, validThrough)
-				require.Equalf(t, moneyAccountsExpectedAmounts[i-1][j], fromAccountDataOld.MicroAlgos.Raw, "Account index : %d\nRound number : %d", j, i)
+				require.Equalf(t, int(moneyAccountsExpectedAmounts[i-1][j]), int(fromAccountDataOld.MicroAlgos.Raw), "Account index : %d (%s)\nRound number : %d (%d)", j, moneyAccounts[j], i, i-1)
 
 				fromAccountDataNew := fromAccountDataOld
 
@@ -869,7 +869,7 @@ func testAcctUpdatesUpdatesCorrectness(t *testing.T, cfg config.Local) {
 					require.NoError(t, err)
 					require.GreaterOrEqual(t, int64(validThrough), int64(basics.Round(checkRound-uint64(testback))))
 					// if we received no error, we want to make sure the reported amount is correct.
-					require.Equalf(t, moneyAccountsExpectedAmounts[checkRound-uint64(testback)][j], acct.MicroAlgos.Raw, "Account index : %d\nRound number : %d", j, checkRound)
+					require.Equalf(t, int(moneyAccountsExpectedAmounts[checkRound-uint64(testback)][j]), int(acct.MicroAlgos.Raw), "Account index : %d (%s)\nRound number : %d (%d)", j, moneyAccounts[j], checkRound, checkRound-uint64(testback))
 					testback++
 					j--
 				}


### PR DESCRIPTION
## Summary

This PR is a rework of #5527 (later revered in #5620 because of test failure).

1. Take a state snapshot for a single iteration (the first part of the for {} loop in lookupWithoutRewards) - dbRound, deltas, offset, rewards, inDeltas check. 
2. Make the nested loop over deltas lock free.
3. If not found in deltas check baseAccounts and ensure the ledger did not advance while we were checking deltas.

#### Why does it work:

say au.deltas has 10 elements that is backed by some array underneath. e make local `deltas = au.deltas[0:len(au.deltas)]`, pointing to the same backing array. Then there are two options:
1. when receiving a new block => add element
   - if backing array has space, it is not reallocated, just appended, our `deltas` keeps pointing on it
   - if not enough space, then realloc for au.deltas but our `deltas` keeps pointing to the old backing array
2. when committing => remove elements
   - removal op is slicing, so `au.deltas` keeps pointing to the same backing array but to the right subset, our `deltas` is fine as well

The change would benefit from @icorderi work on making lru caches concurrency-safe and possible switch to a bound circular buffer of deltas.

#### Why is it safe

`lookupWithoutRewards` is used by block evaluator in txpool, ensureBlock, catchup to add a new block into the ledger, i.e. always has `rnd=latest`. Having the `MaxAcctLookback > 1` (deltas size, actual value is 4) guarantees the requested `rnd` is greater than the flushed rounds, and for `rnd=latest` the invariant "value is in deltas, or is in baseAccounts if flushed recently, or in DB" still holds.

## Test Plan

Existing tests should pass