### PR TITLE
tools: add mutex profile to heapWatch

### DIFF
--- a/test/heapwatch/heapWatch.py
+++ b/test/heapwatch/heapWatch.py
@@ -165,6 +165,9 @@ class algodDir:
     def get_goroutine_snapshot(self, snapshot_name=None, outdir=None):
         return self.get_pprof_snapshot('goroutine', snapshot_name, outdir)
 
+    def get_mutex_snapshot(self, snapshot_name=None, outdir=None):
+        return self.get_pprof_snapshot('mutex', snapshot_name, outdir)
+
     def get_cpu_profile(self, snapshot_name=None, outdir=None, seconds=90):
         seconds = int(seconds)
         return self.get_pprof_snapshot('profile?seconds={}'.format(seconds), snapshot_name, outdir, timeout=seconds+20)
@@ -352,6 +355,9 @@ class watcher:
         if self.args.goroutine:
             for ad in self.they:
                 ad.get_goroutine_snapshot(snapshot_name, outdir=self.args.out)
+        if self.args.mutex:
+            for ad in self.they:
+                ad.get_mutex_snapshot(snapshot_name, outdir=self.args.out)
         if self.args.metrics:
             threads = []
             for ad in self.they:
@@ -428,6 +434,7 @@ def main():
     ap.add_argument('data_dirs', nargs='*', help='list paths to algorand datadirs to grab heap profile from')
     ap.add_argument('--no-heap', dest='heaps', default=True, action='store_false', help='disable heap snapshot capture')
     ap.add_argument('--goroutine', default=False, action='store_true', help='also capture goroutine profile')
+    ap.add_argument('--mutex', default=False, action='store_true', help='also capture mutex profile')
     ap.add_argument('--metrics', default=False, action='store_true', help='also capture /metrics counts')
     ap.add_argument('--blockinfo', default=False, action='store_true', help='also capture block header info')
     ap.add_argument('--period', default=None, help='seconds between automatically capturing')
@@ -451,6 +458,9 @@ def main():
         logging.basicConfig(level=logging.DEBUG)
     else:
         logging.basicConfig(level=logging.INFO)
+
+    if args.mutex:
+        print('Ensure algod is compiled with `runtime.SetMutexProfileFraction()` set')
 
     for nre in args.tf_name_re:
         try:


### PR DESCRIPTION
## Summary

Add ability to capture `mutex` profile to `heapWatch.py` tool.
Usage example:
```
python3 ~/projects/go-algorand/test/heapwatch/heapWatch.py --period 10 --metrics --mutex --blockinfo --runtime 3m -o nodedata ~/networks/two-fut/Primary
```

## Test Plan

Tested manually, example profile attached.
![image](https://github.com/algorand/go-algorand/assets/65323360/313b6a18-59a8-4b0a-b13c-635558b3109d)
