### PR TITLE
encoding: eliminate unnecessary allocations

### DIFF
--- a/crypto/merklesignature/persistentMerkleSignatureScheme.go
+++ b/crypto/merklesignature/persistentMerkleSignatureScheme.go
@@ -98,7 +98,8 @@ func (s *Secrets) Persist(store db.Accessor) error {
 		return fmt.Errorf("Secrets.Persist: %w", ErrKeyLifetimeIsZero)
 	}
 	round := indexToRound(s.FirstValid, s.KeyLifetime, 0)
-	encodedKey := protocol.GetEncodingBuf()
+	encodedBuf := protocol.GetEncodingBuf()
+	encodedKey := encodedBuf.Bytes()
 	err := store.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 		err := InstallStateProofTable(tx) // assumes schema table already exists (created by partInstallDatabase)
 		if err != nil {
@@ -126,7 +127,7 @@ func (s *Secrets) Persist(store db.Accessor) error {
 
 		return nil
 	})
-	protocol.PutEncodingBuf(encodedKey)
+	protocol.PutEncodingBuf(encodedBuf.Update(encodedKey))
 	if err != nil {
 		return fmt.Errorf("Secrets.Persist: %w", err)
 	}

--- a/data/transactions/signedtxn.go
+++ b/data/transactions/signedtxn.go
@@ -71,15 +71,17 @@ func (s SignedTxnInBlock) ID() {
 
 // GetEncodedLength returns the length in bytes of the encoded transaction
 func (s SignedTxn) GetEncodedLength() int {
-	enc := s.MarshalMsg(protocol.GetEncodingBuf())
-	defer protocol.PutEncodingBuf(enc)
+	buf := protocol.GetEncodingBuf()
+	enc := s.MarshalMsg(buf.Bytes())
+	defer protocol.PutEncodingBuf(buf.Update(enc))
 	return len(enc)
 }
 
 // GetEncodedLength returns the length in bytes of the encoded transaction
 func (s SignedTxnInBlock) GetEncodedLength() int {
-	enc := s.MarshalMsg(protocol.GetEncodingBuf())
-	defer protocol.PutEncodingBuf(enc)
+	buf := protocol.GetEncodingBuf()
+	enc := s.MarshalMsg(buf.Bytes())
+	defer protocol.PutEncodingBuf(buf.Update(enc))
 	return len(enc)
 }
 
@@ -116,16 +118,17 @@ func (s *SignedTxnInBlock) ToBeHashed() (protocol.HashID, []byte) {
 
 // Hash implements an optimized version of crypto.HashObj(s).
 func (s *SignedTxnInBlock) Hash() crypto.Digest {
-	enc := s.MarshalMsg(append(protocol.GetEncodingBuf(), []byte(protocol.SignedTxnInBlock)...))
-	defer protocol.PutEncodingBuf(enc)
-
+	buf := protocol.GetEncodingBuf()
+	enc := s.MarshalMsg(append(buf.Bytes(), []byte(protocol.SignedTxnInBlock)...))
+	defer protocol.PutEncodingBuf(buf.Update(enc))
 	return crypto.Hash(enc)
 }
 
 // HashSHA256 implements an optimized version of crypto.HashObj(s) using SHA256 instead of the default SHA512_256.
 func (s *SignedTxnInBlock) HashSHA256() crypto.Digest {
-	enc := s.MarshalMsg(append(protocol.GetEncodingBuf(), []byte(protocol.SignedTxnInBlock)...))
-	defer protocol.PutEncodingBuf(enc)
+	buf := protocol.GetEncodingBuf()
+	enc := s.MarshalMsg(append(buf.Bytes(), []byte(protocol.SignedTxnInBlock)...))
+	defer protocol.PutEncodingBuf(buf.Update(enc))
 
 	return sha256.Sum256(enc)
 }

--- a/data/transactions/teal.go
+++ b/data/transactions/teal.go
@@ -89,9 +89,13 @@ func (ed EvalDelta) Equal(o EvalDelta) bool {
 // tedious) field comparisons. == is not defined on almost any of the
 // subfields because of slices.
 func (stx SignedTxn) equal(o SignedTxn) bool {
-	stxenc := stx.MarshalMsg(protocol.GetEncodingBuf())
-	defer protocol.PutEncodingBuf(stxenc)
-	oenc := o.MarshalMsg(protocol.GetEncodingBuf())
-	defer protocol.PutEncodingBuf(oenc)
+	buf1 := protocol.GetEncodingBuf()
+	stxenc := stx.MarshalMsg(buf1.Bytes())
+	defer protocol.PutEncodingBuf(buf1.Update(stxenc))
+
+	buf2 := protocol.GetEncodingBuf()
+	oenc := o.MarshalMsg(buf2.Bytes())
+	defer protocol.PutEncodingBuf(buf2.Update(oenc))
+
 	return bytes.Equal(stxenc, oenc)
 }

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
@@ -177,31 +178,81 @@ func (tx Transaction) ToBeHashed() (protocol.HashID, []byte) {
 	return protocol.Transaction, protocol.Encode(&tx)
 }
 
+// txAllocSize returns the max possible size of a transaction without state proof fields.
+// It is used to preallocate a buffer for encoding a transaction.
+func txAllocSize() int {
+	return TransactionMaxSize() - StateProofTxnFieldsMaxSize()
+}
+
+// txEncodingPool holds temporary byte slice buffers used for encoding transaction messages.
+// Note, it prepends protocol.Transaction tag to the buffer economizing on subsequent append ops.
+var txEncodingPool = sync.Pool{
+	New: func() interface{} {
+		size := txAllocSize() + len(protocol.Transaction)
+		buf := make([]byte, len(protocol.Transaction), size)
+		copy(buf, []byte(protocol.Transaction))
+		return &txEncodingBuf{b: buf}
+	},
+}
+
+// getTxEncodingBuf returns a wrapped byte slice that can be used for encoding a
+// temporary message.  The byte slice has zero length but potentially
+// non-zero capacity.  The caller gets full ownership of the byte slice,
+// but is encouraged to return it using putEncodingBuf().
+func getTxEncodingBuf() *txEncodingBuf {
+	buf := txEncodingPool.Get().(*txEncodingBuf)
+	return buf
+}
+
+// putTxEncodingBuf places a byte slice into the pool of temporary buffers
+// for encoding.  The caller gives up ownership of the byte slice when
+// passing it to putTxEncodingBuf().
+func putTxEncodingBuf(buf *txEncodingBuf) {
+	buf.b = buf.b[:len(protocol.Transaction)]
+	txEncodingPool.Put(buf)
+}
+
+type txEncodingBuf struct {
+	b []byte
+}
+
 // ID returns the Txid (i.e., hash) of the transaction.
 func (tx Transaction) ID() Txid {
-	enc := tx.MarshalMsg(append(protocol.GetEncodingBuf(), []byte(protocol.Transaction)...))
-	defer protocol.PutEncodingBuf(enc)
+	buf := getTxEncodingBuf()
+	enc := tx.MarshalMsg(buf.b)
+	if cap(enc) > cap(buf.b) {
+		// use a bigger buffer is New's estimate was too small
+		buf.b = enc
+	}
+	defer putTxEncodingBuf(buf)
 	return Txid(crypto.Hash(enc))
 }
 
 // IDSha256 returns the digest (i.e., hash) of the transaction.
 // This is different from the canonical ID computed with Sum512_256 hashing function.
 func (tx Transaction) IDSha256() crypto.Digest {
-	enc := tx.MarshalMsg(append(protocol.GetEncodingBuf(), []byte(protocol.Transaction)...))
-	defer protocol.PutEncodingBuf(enc)
+	buf := getTxEncodingBuf()
+	enc := tx.MarshalMsg(buf.b)
+	if cap(enc) > cap(buf.b) {
+		buf.b = enc
+	}
+	defer putTxEncodingBuf(buf)
 	return sha256.Sum256(enc)
 }
 
 // InnerID returns something akin to Txid, but folds in the parent Txid and the
 // index of the inner call.
 func (tx Transaction) InnerID(parent Txid, index int) Txid {
-	input := append(protocol.GetEncodingBuf(), []byte(protocol.Transaction)...)
-	input = append(input, parent[:]...)
-	buf := make([]byte, 8)
-	binary.BigEndian.PutUint64(buf, uint64(index))
-	input = append(input, buf...)
+	buf := getTxEncodingBuf()
+	input := append(buf.b, parent[:]...)
+	var indexBuf [8]byte
+	binary.BigEndian.PutUint64(indexBuf[:], uint64(index))
+	input = append(input, indexBuf[:]...)
 	enc := tx.MarshalMsg(input)
-	defer protocol.PutEncodingBuf(enc)
+	if cap(enc) > cap(buf.b) {
+		buf.b = enc
+	}
+	defer putTxEncodingBuf(buf)
 	return Txid(crypto.Hash(enc))
 }
 

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -196,8 +196,8 @@ var txEncodingPool = sync.Pool{
 }
 
 // getTxEncodingBuf returns a wrapped byte slice that can be used for encoding a
-// temporary message.  The byte slice has zero length but potentially
-// non-zero capacity.  The caller gets full ownership of the byte slice,
+// temporary message.  The byte slice length of encoded Transaction{} object.
+// The caller gets full ownership of the byte slice,
 // but is encouraged to return it using putEncodingBuf().
 func getTxEncodingBuf() *txEncodingBuf {
 	buf := txEncodingPool.Get().(*txEncodingBuf)
@@ -221,7 +221,7 @@ func (tx Transaction) ID() Txid {
 	buf := getTxEncodingBuf()
 	enc := tx.MarshalMsg(buf.b)
 	if cap(enc) > cap(buf.b) {
-		// use a bigger buffer is New's estimate was too small
+		// use a bigger buffer as New's estimate was too small
 		buf.b = enc
 	}
 	defer putTxEncodingBuf(buf)

--- a/protocol/codec.go
+++ b/protocol/codec.go
@@ -288,21 +288,38 @@ func (d *MsgpDecoderBytes) Remaining() int {
 // encodingPool holds temporary byte slice buffers used for encoding messages.
 var encodingPool = sync.Pool{
 	New: func() interface{} {
-		return []byte{}
+		return &EncodingBuf{b: make([]byte, 0, 1024)}
 	},
+}
+
+type EncodingBuf struct {
+	b []byte
+}
+
+func (eb *EncodingBuf) Bytes() []byte {
+	return eb.b
+}
+
+func (eb *EncodingBuf) Update(v []byte) *EncodingBuf {
+	if cap(eb.b) < cap(v) {
+		eb.b = v
+	}
+	return eb
 }
 
 // GetEncodingBuf returns a byte slice that can be used for encoding a
 // temporary message.  The byte slice has zero length but potentially
 // non-zero capacity.  The caller gets full ownership of the byte slice,
 // but is encouraged to return it using PutEncodingBuf().
-func GetEncodingBuf() []byte {
-	return encodingPool.Get().([]byte)[:0]
+func GetEncodingBuf() *EncodingBuf {
+	buf := encodingPool.Get().(*EncodingBuf)
+	buf.b = buf.b[:0]
+	return buf
 }
 
 // PutEncodingBuf places a byte slice into the pool of temporary buffers
 // for encoding.  The caller gives up ownership of the byte slice when
 // passing it to PutEncodingBuf().
-func PutEncodingBuf(s []byte) {
-	encodingPool.Put(s)
+func PutEncodingBuf(buf *EncodingBuf) {
+	encodingPool.Put(buf)
 }

--- a/protocol/codec.go
+++ b/protocol/codec.go
@@ -288,18 +288,21 @@ func (d *MsgpDecoderBytes) Remaining() int {
 // encodingPool holds temporary byte slice buffers used for encoding messages.
 var encodingPool = sync.Pool{
 	New: func() interface{} {
-		return &EncodingBuf{b: make([]byte, 0, 1024)}
+		return &EncodingBuf{b: make([]byte, 0)}
 	},
 }
 
+// EncodingBuf is a wrapper for a byte slice that can be used for encoding
 type EncodingBuf struct {
 	b []byte
 }
 
+// Bytes returns the underlying byte slice
 func (eb *EncodingBuf) Bytes() []byte {
 	return eb.b
 }
 
+// Update updates the underlying byte slice to the given one if its capacity exceeds the current one.
 func (eb *EncodingBuf) Update(v []byte) *EncodingBuf {
 	if cap(eb.b) < cap(v) {
 		eb.b = v


### PR DESCRIPTION
## Summary

While working on reducing memory requirements I found about 12% of allocations come from `protocol.PutEncodingBuf`( see the picture below). This happens when a slice object (pointer to data, len, cap) gets reallocated to the heap.

<img width="1418" alt="image" src="https://github.com/algorand/go-algorand/assets/65323360/d4f3918d-43d0-469a-aa60-e3e4c017b64e">

Fix is to wrap a byte slice in struct and make `pool.New()` to return a pointer to it. In this case the wrapping struct is allocated on heap, so returning pointer into a pool fixes the issue.

I also noticed that majority of the calls come from `Transaction.ID` and made a separate pool for it (commit 1).

As a result total number of allocations decreased by **10%** 673713259 (master) vs 609152614 (feature)

## Test Plan

Run bunch of local tests (2 nodes, target tps=3000) for master vs commit 1 (separate pool for transaction id) vs the entire PR (global `protocol.PutEncodingBuf` fix and transaction id pool).

### Number of allocations

**commit 1** `PutEncodingBuf` allocations (this is 20m run, so absolute numbers are different):
<img width="1418" alt="image" src="https://github.com/algorand/go-algorand/assets/65323360/53c8b86e-c1e9-4917-a292-b672e3479ad0">

**full PR (feature)**`PutEncodingBuf` allocations (all gone):
<img width="714" alt="image" src="https://github.com/algorand/go-algorand/assets/65323360/f9ddd589-c1f3-4571-9c44-d4c82a051bd2">

###  Memory charts for 20m run:

| master | commit 1 | feature |
|      :---:     |     :---:      |     :---:     |
| ![image](https://github.com/algorand/go-algorand/assets/65323360/de33c04b-c70f-4f3b-ac18-c03bf8efb3f3) | ![image](https://github.com/algorand/go-algorand/assets/65323360/fb5eda1a-7efb-41a9-aa4e-18cfc65fb793) | ![image](https://github.com/algorand/go-algorand/assets/65323360/9e1cb1f5-86e2-4afa-b3f9-56ac550ea66f) |

### Block sizes / TPS

| master | commit 1 | feature |
|      :---:     |     :---:      |     :---:     |
|![image](https://github.com/algorand/go-algorand/assets/65323360/0b6fca69-8f29-4a72-b6c3-ba7bfe117964) | ![image](https://github.com/algorand/go-algorand/assets/65323360/885e55e4-def7-4c2e-b88b-ad1433800620) | ![note the released amount is lower indicating less mem usage/less allocations (having the same load)](https://github.com/algorand/go-algorand/assets/65323360/33f0fc8d-4563-4d36-8675-6887ead58371)|

TODO: explain TPS bump at the beginning and drop after some rounds.