### PR TITLE
Build: Remove n-algorand from wsnetwork partial overlap test.

### DIFF
--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -4410,30 +4410,6 @@ type MergeTestDNSInputs struct {
 
 func mergePrimarySecondaryRelayAddressListsPartialOverlapTestInputsGen() *rapid.Generator[*MergeTestDNSInputs] {
 
-	algorand0Base := rapid.Custom(func(t *rapid.T) *MergeTestDNSInputs {
-		//unused/satisfying rapid expectation
-		rapid.String().Draw(t, "algorand0Base")
-		// <network>.algorand.network?backup=<network>.algorand0.network&
-		//		dedup=<name>.(algorand-<network>|n-<network>.algorand0).network
-		return &MergeTestDNSInputs{
-			dedupExpStr:           "((algorand-<network>|n-<network>.algorand0).network)",
-			primaryDomainSuffix:   "algorand-<network>.network",
-			secondaryDomainSuffix: "n-<network>.algorand0.network",
-		}
-	})
-
-	algorand0Inverse := rapid.Custom(func(t *rapid.T) *MergeTestDNSInputs {
-		//unused/satisfying rapid expectation
-		rapid.String().Draw(t, "algorand0Inverse")
-		// <network>.algorand0.network?backup=<network>.algorand.network&
-		//		dedup=<name>.(algorand-<network>|n-<network>.algorand0).network
-		return &MergeTestDNSInputs{
-			dedupExpStr:           "((algorand-<network>|n-<network>.algorand0).network)",
-			primaryDomainSuffix:   "n-<network>.algorand0.network",
-			secondaryDomainSuffix: "algorand-<network>.network",
-		}
-	})
-
 	algorandNetBase := rapid.Custom(func(t *rapid.T) *MergeTestDNSInputs {
 		//unused/satisfying rapid expectation
 		rapid.String().Draw(t, "algorandNetBase")
@@ -4458,7 +4434,7 @@ func mergePrimarySecondaryRelayAddressListsPartialOverlapTestInputsGen() *rapid.
 		}
 	})
 
-	return rapid.OneOf(algorand0Base, algorand0Inverse, algorandNetBase, algorandNetInverse)
+	return rapid.OneOf(algorandNetBase, algorandNetInverse)
 }
 
 func TestMergePrimarySecondaryRelayAddressListsPartialOverlap(t *testing.T) {
@@ -4516,7 +4492,7 @@ func TestMergePrimarySecondaryRelayAddressListsNoDedupExp(t *testing.T) {
 
 		network := supportedNetworkGen().Draw(t1, "network")
 		primaryDomainSuffix := strings.Replace(
-			`n-<network>.algorand0.network`, "<network>", network, -1)
+			`algorand-<network>.net`, "<network>", network, -1)
 
 		// Generate hosts for a primary network domain
 		primaryNetworkDomainGen := rapidgen.DomainWithSuffixAndPort(primaryDomainSuffix, nil)


### PR DESCRIPTION


## Summary
Potential quick fix for instability on MergePrimarySecondaryDNS PartialOverlap test.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Ran test several times.
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
