### PR TITLE
add block hash to state proof

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -419,6 +419,11 @@ type ConsensusParams struct {
 	// their account balances.
 	StateProofExcludeTotalWeightWithRewards bool
 
+	// StateProofBlockHashInLightHeader specifies that the LightBlockHeader
+	// committed to by state proofs should contain the BlockHash of each
+	// block, instead of the seed.
+	StateProofBlockHashInLightHeader bool
+
 	// EnableAssetCloseAmount adds an extra field to the ApplyData. The field contains the amount of the remaining
 	// asset that were sent to the close-to address.
 	EnableAssetCloseAmount bool
@@ -1361,6 +1366,8 @@ func initConsensusProtocols() {
 
 	vFuture.LogicSigVersion = 10 // When moving this to a release, put a new higher LogicSigVersion here
 	vFuture.EnableLogicSigCostPooling = true
+
+	vFuture.StateProofBlockHashInLightHeader = true
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 

--- a/data/bookkeeping/lightBlockHeader.go
+++ b/data/bookkeeping/lightBlockHeader.go
@@ -17,6 +17,7 @@
 package bookkeeping
 
 import (
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/committee"
@@ -38,8 +39,15 @@ type LightBlockHeader struct {
 		In addition, we make sure that the Seed (The unpredictable value) would be the first field that gets
 		hashed (give it the lowest codec value in the LightBlockHeader struct) to mitigate a collision attack
 		on the merkle damgard construction.
+
+		The BlockHash serves a similar role, in that it also depends on the seed and introduces some
+		uncontrollable input.  It is slightly weaker, in the sense that an adversary can influence
+		the BlockHash to some degree (e.g., by including specific transactions in the payset), but
+		it comes with the added benefit of allowing to authenticate the entire blockchain based on
+		the BlockHash value.
 	*/
 	Seed                committee.Seed       `codec:"0"`
+	BlockHash           BlockHash            `codec:"1"`
 	Round               basics.Round         `codec:"r"`
 	GenesisHash         crypto.Digest        `codec:"gh"`
 	Sha256TxnCommitment crypto.GenericDigest `codec:"tc,allocbound=crypto.Sha256Size"`
@@ -47,12 +55,20 @@ type LightBlockHeader struct {
 
 // ToLightBlockHeader creates returns a LightBlockHeader from a given block header
 func (bh *BlockHeader) ToLightBlockHeader() LightBlockHeader {
-	return LightBlockHeader{
-		Seed:                bh.Seed,
+	res := LightBlockHeader{
 		GenesisHash:         bh.GenesisHash,
 		Round:               bh.Round,
 		Sha256TxnCommitment: bh.Sha256Commitment[:],
 	}
+
+	proto := config.Consensus[bh.CurrentProtocol]
+	if proto.StateProofBlockHashInLightHeader {
+		res.BlockHash = bh.Hash()
+	} else {
+		res.Seed = bh.Seed
+	}
+
+	return res
 }
 
 // ToBeHashed implements the crypto.Hashable interface

--- a/data/bookkeeping/msgp_gen.go
+++ b/data/bookkeeping/msgp_gen.go
@@ -2608,23 +2608,27 @@ func GenesisAllocationMaxSize() (s int) {
 func (z *LightBlockHeader) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0001Len := uint32(4)
-	var zb0001Mask uint8 /* 5 bits */
+	zb0001Len := uint32(5)
+	var zb0001Mask uint8 /* 6 bits */
 	if (*z).Seed.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x1
 	}
-	if (*z).GenesisHash.MsgIsZero() {
+	if (*z).BlockHash.MsgIsZero() {
 		zb0001Len--
-		zb0001Mask |= 0x4
+		zb0001Mask |= 0x2
 	}
-	if (*z).Round.MsgIsZero() {
+	if (*z).GenesisHash.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
-	if (*z).Sha256TxnCommitment.MsgIsZero() {
+	if (*z).Round.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x10
+	}
+	if (*z).Sha256TxnCommitment.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x20
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -2634,17 +2638,22 @@ func (z *LightBlockHeader) MarshalMsg(b []byte) (o []byte) {
 			o = append(o, 0xa1, 0x30)
 			o = (*z).Seed.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x4) == 0 { // if not empty
+		if (zb0001Mask & 0x2) == 0 { // if not empty
+			// string "1"
+			o = append(o, 0xa1, 0x31)
+			o = (*z).BlockHash.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "gh"
 			o = append(o, 0xa2, 0x67, 0x68)
 			o = (*z).GenesisHash.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x8) == 0 { // if not empty
+		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "r"
 			o = append(o, 0xa1, 0x72)
 			o = (*z).Round.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x10) == 0 { // if not empty
+		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "tc"
 			o = append(o, 0xa2, 0x74, 0x63)
 			o = (*z).Sha256TxnCommitment.MarshalMsg(o)
@@ -2676,6 +2685,14 @@ func (z *LightBlockHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			bts, err = (*z).Seed.UnmarshalMsg(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Seed")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).BlockHash.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "BlockHash")
 				return
 			}
 		}
@@ -2732,6 +2749,12 @@ func (z *LightBlockHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "Seed")
 					return
 				}
+			case "1":
+				bts, err = (*z).BlockHash.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "BlockHash")
+					return
+				}
 			case "r":
 				bts, err = (*z).Round.UnmarshalMsg(bts)
 				if err != nil {
@@ -2770,18 +2793,18 @@ func (_ *LightBlockHeader) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *LightBlockHeader) Msgsize() (s int) {
-	s = 1 + 2 + (*z).Seed.Msgsize() + 2 + (*z).Round.Msgsize() + 3 + (*z).GenesisHash.Msgsize() + 3 + (*z).Sha256TxnCommitment.Msgsize()
+	s = 1 + 2 + (*z).Seed.Msgsize() + 2 + (*z).BlockHash.Msgsize() + 2 + (*z).Round.Msgsize() + 3 + (*z).GenesisHash.Msgsize() + 3 + (*z).Sha256TxnCommitment.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *LightBlockHeader) MsgIsZero() bool {
-	return ((*z).Seed.MsgIsZero()) && ((*z).Round.MsgIsZero()) && ((*z).GenesisHash.MsgIsZero()) && ((*z).Sha256TxnCommitment.MsgIsZero())
+	return ((*z).Seed.MsgIsZero()) && ((*z).BlockHash.MsgIsZero()) && ((*z).Round.MsgIsZero()) && ((*z).GenesisHash.MsgIsZero()) && ((*z).Sha256TxnCommitment.MsgIsZero())
 }
 
 // MaxSize returns a maximum valid message size for this message type
 func LightBlockHeaderMaxSize() (s int) {
-	s = 1 + 2 + committee.SeedMaxSize() + 2 + basics.RoundMaxSize() + 3 + crypto.DigestMaxSize() + 3 + crypto.GenericDigestMaxSize()
+	s = 1 + 2 + committee.SeedMaxSize() + 2 + BlockHashMaxSize() + 2 + basics.RoundMaxSize() + 3 + crypto.DigestMaxSize() + 3 + crypto.GenericDigestMaxSize()
 	return
 }
 


### PR DESCRIPTION
Replace the `Seed` value in the state proof light header with `BlockHash`. It serves a similar purpose in terms of the second-order consideration of defending against potential future hash-collision attacks (albeit a little bit weaker), but has the benefit of allowing validating the entire blockchain, by committing to the block hash itself in the state proof.