### PR TITLE
p2p: in-memory peerstore

### DIFF
--- a/network/p2p/peerstore/peerstore.go
+++ b/network/p2p/peerstore/peerstore.go
@@ -17,14 +17,11 @@
 package peerstore
 
 import (
-	"context"
 	"fmt"
 
-	ds "github.com/ipfs/go-datastore"
-	pebbledb "github.com/ipfs/go-ds-pebble"
 	"github.com/libp2p/go-libp2p/core/peer"
 	libp2p "github.com/libp2p/go-libp2p/core/peerstore"
-	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoreds"
+	pstore "github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
 )
 
 // PeerStore implements libp2p.Peerstore
@@ -32,18 +29,9 @@ type PeerStore struct {
 	libp2p.Peerstore
 }
 
-func initDBStore(path string) (ds.Batching, error) {
-	store, err := pebbledb.NewDatastore(path, nil)
-	return store, err
-}
-
 // NewPeerStore creates a new peerstore backed by a datastore.
-func NewPeerStore(ctx context.Context, path string, addrInfo []*peer.AddrInfo) (*PeerStore, error) {
-	datastore, err := initDBStore(path)
-	if err != nil {
-		return nil, fmt.Errorf("cannot initialize a peerstore, invalid path for datastore: %w", err)
-	}
-	ps, err := pstoreds.NewPeerstore(ctx, datastore, pstoreds.DefaultOpts())
+func NewPeerStore(addrInfo []*peer.AddrInfo) (*PeerStore, error) {
+	ps, err := pstore.NewPeerstore()
 	if err != nil {
 		return nil, fmt.Errorf("cannot initialize a peerstore: %w", err)
 	}

--- a/network/p2p/peerstore/peerstore.go
+++ b/network/p2p/peerstore/peerstore.go
@@ -21,17 +21,18 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	libp2p "github.com/libp2p/go-libp2p/core/peerstore"
-	pstore "github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
+	mempstore "github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
 )
 
-// PeerStore implements libp2p.Peerstore
-type PeerStore struct {
+// PeerStore implements the libp2p Peerstore and CertifiedAddrBook interfaces.
+type PeerStore interface {
 	libp2p.Peerstore
+	libp2p.CertifiedAddrBook
 }
 
 // NewPeerStore creates a new peerstore backed by a datastore.
-func NewPeerStore(addrInfo []*peer.AddrInfo) (*PeerStore, error) {
-	ps, err := pstore.NewPeerstore()
+func NewPeerStore(addrInfo []*peer.AddrInfo) (PeerStore, error) {
+	ps, err := mempstore.NewPeerstore()
 	if err != nil {
 		return nil, fmt.Errorf("cannot initialize a peerstore: %w", err)
 	}
@@ -41,6 +42,5 @@ func NewPeerStore(addrInfo []*peer.AddrInfo) (*PeerStore, error) {
 		info := addrInfo[i]
 		ps.AddAddrs(info.ID, info.Addrs, libp2p.AddressTTL)
 	}
-	pstore := &PeerStore{ps}
-	return pstore, nil
+	return ps, nil
 }

--- a/network/p2p/peerstore/peerstore_test.go
+++ b/network/p2p/peerstore/peerstore_test.go
@@ -72,7 +72,7 @@ func TestPeerstore(t *testing.T) {
 	require.Equal(t, 8, len(peers))
 
 	// remove a peer addr
-	ps.Peerstore.ClearAddrs(peerIDS[0])
+	ps.ClearAddrs(peerIDS[0])
 	peers = ps.PeersWithAddrs()
 	require.Equal(t, 7, len(peers))
 

--- a/network/p2p/peerstore/peerstore_test.go
+++ b/network/p2p/peerstore/peerstore_test.go
@@ -17,7 +17,6 @@
 package peerstore
 
 import (
-	"context"
 	"crypto/rand"
 	"fmt"
 	"testing"
@@ -41,8 +40,7 @@ func TestPeerstore(t *testing.T) {
 	}
 
 	addrInfo, _ := PeerInfoFromAddrs(peerAddrs)
-	dir := t.TempDir()
-	ps, err := NewPeerStore(context.Background(), dir, addrInfo)
+	ps, err := NewPeerStore(addrInfo)
 	require.NoError(t, err)
 	defer ps.Close()
 
@@ -77,14 +75,5 @@ func TestPeerstore(t *testing.T) {
 	ps.Peerstore.ClearAddrs(peerIDS[0])
 	peers = ps.PeersWithAddrs()
 	require.Equal(t, 7, len(peers))
-
-}
-
-func TestPeerStoreInitErrors(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-	// bad datastore path
-	_, err := NewPeerStore(context.Background(), "//", []*peer.AddrInfo{})
-	require.Contains(t, err.Error(), "invalid path for datastore")
 
 }


### PR DESCRIPTION
This PR changes the peerstore to use the in-memory version. #5650.  
