### PR TITLE
chore: Remove faulty assertion

### DIFF
--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -4328,7 +4328,6 @@ func TestUpdatePhonebookAddressesPersistentPeers(t *testing.T) {
 
 		// Check that entries are in fact in phonebook less any duplicates
 		dedupedRelayDomains := removeDuplicateStr(relayDomains, false)
-		require.Equal(t, 0, len(relayDomains)-len(dedupedRelayDomains))
 
 		relayPeers := nw.GetPeers(PeersPhonebookRelays)
 		require.Equal(t, len(dedupedRelayDomains)+len(persistentPeers), len(relayPeers))


### PR DESCRIPTION

## Summary

This test is flaky (see failed nightly run in https://app.circleci.com/pipelines/github/algorand/go-algorand/16122/workflows/feaae371-cb4f-49a5-becc-f46f2ef422d5/jobs/250292). 

I've removed the assertion that the generated lists would have no duplicates--clearly the rapid test framework can and will generate some duplicates and it really doesn't matter to the logic of the test if it does.

## Test Plan

Tests pass--haven't seen other parts of the test be flaky as far as I know.
