### PR TITLE
tests: log algod-err and algod-out on e2e failure

### DIFF
--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -314,8 +314,12 @@ func (f *LibGoalFixture) ShutdownImpl(preserveData bool) {
 	if preserveData {
 		f.network.Stop(f.binDir)
 		f.dumpLogs(filepath.Join(f.PrimaryDataDir(), "node.log"))
+		f.dumpLogs(filepath.Join(f.PrimaryDataDir(), "algod-err.log"))
+		f.dumpLogs(filepath.Join(f.PrimaryDataDir(), "algod-out.log"))
 		for _, nodeDir := range f.NodeDataDirs() {
 			f.dumpLogs(filepath.Join(nodeDir, "node.log"))
+			f.dumpLogs(filepath.Join(nodeDir, "algod-err.log"))
+			f.dumpLogs(filepath.Join(nodeDir, "algod-out.log"))
 		}
 	} else {
 		f.network.Delete(f.binDir)


### PR DESCRIPTION
## Summary

Looking into these e2e tests failures ([one](https://app.circleci.com/pipelines/github/algorand/go-algorand/16209/workflows/a2f4b57c-3d92-4f01-978a-f974162fa554/jobs/250872), [two](https://app.circleci.com/pipelines/github/algorand/go-algorand/16209/workflows/a2f4b57c-3d92-4f01-978a-f974162fa554/jobs/250872), [three](https://app.circleci.com/pipelines/github/algorand/go-algorand/16209/workflows/a2f4b57c-3d92-4f01-978a-f974162fa554/jobs/250869/parallel-runs/1?filterBy=FAILED)) made me think we have some race condition on node termination caught by race detector. These changes allows to see panic stacktrace and fix. 

## Test Plan

This is a test harness fix.