### PR TITLE
build: disable pebbledb on arm32

### DIFF
--- a/ledger/store/trackerdb/pebbledbdriver/pebbledriver.go
+++ b/ledger/store/trackerdb/pebbledbdriver/pebbledriver.go
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
 
+//go:build !arm
+
 package pebbledbdriver
 
 import (

--- a/ledger/store/trackerdb/pebbledbdriver/pebbledriver_arm.go
+++ b/ledger/store/trackerdb/pebbledbdriver/pebbledriver_arm.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2019-2023 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+// go:build arm
+package pebbledbdriver
+
+import (
+	"errors"
+
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/ledger/store/trackerdb"
+	"github.com/algorand/go-algorand/logging"
+)
+
+func Open(dbdir string, inMem bool, proto config.ConsensusParams, log logging.Logger) (trackerdb.Store, error) {
+	return nil, errors.New("pebbledb storage backend not supported on arm32")
+}


### PR DESCRIPTION
## Summary

pebble is known not compiling on 32-bit systems - see https://github.com/cockroachdb/pebble/pull/2120
This PR disables pebble driver on arm32

## Test Plan

Build at arm32 docker, the algod compilation errors gone.