### PR TITLE
tools: add block-generator initial round to report.

### DIFF
--- a/tools/block-generator/generator/generate.go
+++ b/tools/block-generator/generator/generate.go
@@ -77,6 +77,7 @@ func MakeGenerator(log logging.Logger, dbround uint64, bkGenesis bookkeeping.Gen
 		latestData:                make(map[TxTypeID]uint64),
 		roundOffset:               dbround,
 	}
+	gen.reportData.InitialRound = gen.roundOffset
 	gen.reportData.Transactions = make(map[TxTypeID]TxData)
 	gen.reportData.Counters = make(map[string]uint64)
 

--- a/tools/block-generator/generator/generator_types.go
+++ b/tools/block-generator/generator/generator_types.go
@@ -150,6 +150,7 @@ type assetHolding struct {
 
 // Report is the generation report.
 type Report struct {
+	InitialRound uint64              `json:"initial_round"`
 	Counters     map[string]uint64   `json:"counters"`
 	Transactions map[TxTypeID]TxData `json:"transactions"`
 }

--- a/tools/block-generator/runner/run.go
+++ b/tools/block-generator/runner/run.go
@@ -393,6 +393,10 @@ func writeReport(w io.Writer, scenario string, start time.Time, runDuration time
 		return err
 	}
 
+	if err := write("initial_round:%d\n", generatorReport.InitialRound); err != nil {
+		return err
+	}
+
 	for metric, value := range generatorReport.Counters {
 		if err := write("%s:%d\n", metric, value); err != nil {
 			return err


### PR DESCRIPTION
 ## Summary

Adding the initial round to the block generator so that the conduit benchmark can take that into consideration when loading data from a snapshot.

## Test Plan

Update unit test.
