### PR TITLE
tools: block-generator option to delay before running scenario.

### DIFF
--- a/tools/block-generator/runner/run.go
+++ b/tools/block-generator/runner/run.go
@@ -65,6 +65,7 @@ type Args struct {
 	KeepDataDir              bool
 	GenesisFile              string
 	ResetDB                  bool
+	StartDelay               time.Duration
 	Times                    uint64
 }
 
@@ -125,6 +126,7 @@ func Run(args Args) error {
 }
 
 func (r *Args) run(reportDirectory string) error {
+
 	baseName := filepath.Base(r.Path)
 	baseNameNoExt := strings.TrimSuffix(baseName, filepath.Ext(baseName))
 	reportfile := path.Join(reportDirectory, fmt.Sprintf("%s.report", baseNameNoExt))
@@ -166,6 +168,12 @@ func (r *Args) run(reportDirectory string) error {
 		}
 		fmt.Printf("%sPostgreSQL next round: %d\n", pad, nextRound)
 	}
+
+	if r.StartDelay > 0 {
+		fmt.Printf("%sSleeping for start delay: %s\n", pad, r.StartDelay)
+		time.Sleep(r.StartDelay)
+	}
+
 	// Start services
 	algodNet := fmt.Sprintf("localhost:%d", 11112)
 	metricsNet := fmt.Sprintf("localhost:%d", r.MetricsPort)

--- a/tools/block-generator/runner/runner.go
+++ b/tools/block-generator/runner/runner.go
@@ -58,6 +58,7 @@ func init() {
 	RunnerCmd.Flags().StringVarP(&runnerArgs.GenesisFile, "genesis-file", "f", "", "file path to the genesis associated with the db snapshot")
 	RunnerCmd.Flags().BoolVarP(&runnerArgs.ResetDB, "reset-db", "", false, "If set database will be deleted before running tests.")
 	RunnerCmd.Flags().Uint64VarP(&runnerArgs.Times, "times", "t", 1, "Number of times to run the scenario(s).")
+	RunnerCmd.Flags().DurationVarP(&runnerArgs.StartDelay, "start-delay", "", 0, "Duration to wait before starting a test scenario. This may be useful for snapshot tests where DB maintenance occurs after loading data.")
 
 	RunnerCmd.MarkFlagRequired("scenario")
 	RunnerCmd.MarkFlagRequired("conduit-binary")


### PR DESCRIPTION
## Summary

New block generator option to delay the start of a test. After noticing large variation in snapshot test performance results, we wonder if there could be some postgres processes from earlier tests effecting latter tests. This option gives us a simple way to test that by putting a delay between runs.
