### PR TITLE
build: resume/fix ci expect tests

### DIFF
--- a/test/scripts/e2e_go_tests.sh
+++ b/test/scripts/e2e_go_tests.sh
@@ -47,7 +47,7 @@ if [[ -n $TESTPATTERNS && -n $RUN_EXPECT ]]; then
     exit 1
 fi
 
-if [ -n $RUN_EXPECT ]; then
+if [[ -z $RUN_EXPECT ]]; then
     RUN_EXPECT="FALSE"
 fi
 


### PR DESCRIPTION
## Summary

It appears this [PR](https://github.com/algorand/go-algorand/pull/5625/files#diff-e0af12871616aaca898813b50e2521dc9dac6938c150fbd9f371c971f893f203R50) incidentally disabled `expect` tests.
Fixed bash condition to restore.

[Bash ref](https://www.gnu.org/software/bash/manual/html_node/Bash-Conditional-Expressions.html):
```
-n string
string
True if the length of string is non-zero.

-z string
True if the length of string is zero.
```

## Test Plan

Checked condition in a shell. `RUN_EXPECT` is set to `FALSE` when empty, and not modified when `TRUE`.