### PR TITLE
telemetry: add dynamicFilterTimeout to BlockAcceptedEvent

### DIFF
--- a/agreement/actions.go
+++ b/agreement/actions.go
@@ -213,6 +213,8 @@ type ensureAction struct {
 
 	// The time that the winning proposal-vote was validated, relative to the beginning of the round
 	voteValidatedAt time.Duration
+	// The dynamic filter timeout calculated for this round, even if not enabled, for reporting to telemetry.
+	dynamicFilterTimeout time.Duration
 }
 
 func (a ensureAction) t() actionType {
@@ -235,15 +237,16 @@ func (a ensureAction) do(ctx context.Context, s *Service) {
 		logEvent.Type = logspec.RoundConcluded
 		s.log.with(logEvent).Infof("committed round %d with pre-validated block %v", a.Certificate.Round, a.Certificate.Proposal)
 		s.log.EventWithDetails(telemetryspec.Agreement, telemetryspec.BlockAcceptedEvent, telemetryspec.BlockAcceptedEventDetails{
-			Address:         a.Certificate.Proposal.OriginalProposer.String(),
-			Hash:            a.Certificate.Proposal.BlockDigest.String(),
-			Round:           uint64(a.Certificate.Round),
-			ValidatedAt:     a.Payload.validatedAt,
-			ReceivedAt:      a.Payload.receivedAt,
-			VoteValidatedAt: a.voteValidatedAt,
-			PreValidated:    true,
-			PropBufLen:      uint64(len(s.demux.rawProposals)),
-			VoteBufLen:      uint64(len(s.demux.rawVotes)),
+			Address:              a.Certificate.Proposal.OriginalProposer.String(),
+			Hash:                 a.Certificate.Proposal.BlockDigest.String(),
+			Round:                uint64(a.Certificate.Round),
+			ValidatedAt:          a.Payload.validatedAt,
+			ReceivedAt:           a.Payload.receivedAt,
+			VoteValidatedAt:      a.voteValidatedAt,
+			DynamicFilterTimeout: a.dynamicFilterTimeout,
+			PreValidated:         true,
+			PropBufLen:           uint64(len(s.demux.rawProposals)),
+			VoteBufLen:           uint64(len(s.demux.rawVotes)),
 		})
 		s.Ledger.EnsureValidatedBlock(a.Payload.ve, a.Certificate)
 	} else {
@@ -251,14 +254,16 @@ func (a ensureAction) do(ctx context.Context, s *Service) {
 		logEvent.Type = logspec.RoundConcluded
 		s.log.with(logEvent).Infof("committed round %d with block %v", a.Certificate.Round, a.Certificate.Proposal)
 		s.log.EventWithDetails(telemetryspec.Agreement, telemetryspec.BlockAcceptedEvent, telemetryspec.BlockAcceptedEventDetails{
-			Address:      a.Certificate.Proposal.OriginalProposer.String(),
-			Hash:         a.Certificate.Proposal.BlockDigest.String(),
-			Round:        uint64(a.Certificate.Round),
-			ValidatedAt:  a.Payload.validatedAt,
-			ReceivedAt:   a.Payload.receivedAt,
-			PreValidated: false,
-			PropBufLen:   uint64(len(s.demux.rawProposals)),
-			VoteBufLen:   uint64(len(s.demux.rawVotes)),
+			Address:              a.Certificate.Proposal.OriginalProposer.String(),
+			Hash:                 a.Certificate.Proposal.BlockDigest.String(),
+			Round:                uint64(a.Certificate.Round),
+			ValidatedAt:          a.Payload.validatedAt,
+			ReceivedAt:           a.Payload.receivedAt,
+			VoteValidatedAt:      a.voteValidatedAt,
+			DynamicFilterTimeout: a.dynamicFilterTimeout,
+			PreValidated:         false,
+			PropBufLen:           uint64(len(s.demux.rawProposals)),
+			VoteBufLen:           uint64(len(s.demux.rawVotes)),
 		})
 		s.Ledger.EnsureBlock(block, a.Certificate)
 	}

--- a/agreement/msgp_gen.go
+++ b/agreement/msgp_gen.go
@@ -3950,7 +3950,7 @@ func (z *player) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0002Len := uint32(9)
-	var zb0002Mask uint16 /* 11 bits */
+	var zb0002Mask uint16 /* 12 bits */
 	if (*z).OldDeadline == 0 {
 		zb0002Len--
 		zb0002Mask |= 0x1


### PR DESCRIPTION
Following on #5691, this adds the dynamicFilterTimeout value for the round to the BlockAcceptedEvent.