### PR TITLE
VoteLastValid Counting Cache

### DIFF
--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -119,7 +119,7 @@ type onlineAccounts struct {
 	// disableCache (de)activates the LRU cache use in onlineAccounts
 	disableCache bool
 
-	// voteLastValidCache tracks which accounts
+	// voteLastValidCache tracks how many accounts are expiring per-round
 	voteLastValidCache roundCounterCache
 }
 

--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -120,7 +120,7 @@ type onlineAccounts struct {
 	disableCache bool
 
 	// voteLastValidCache tracks which accounts
-	voteLastValidCache voteLastValidCache
+	voteLastValidCache roundCounterCache
 }
 
 // initialize initializes the accountUpdates structure
@@ -178,6 +178,7 @@ func (ao *onlineAccounts) initializeFromDisk(l ledgerForTracker, lastBalancesRou
 		}
 		ao.onlineAccountsCache.init(onlineAccounts, onlineAccountsCacheMaxSize)
 
+		ao.voteLastValidCache = newVoteLastValidCache()
 		ao.voteLastValidCache.init(onlineAccounts)
 
 		return nil

--- a/ledger/acctonline_expired_test.go
+++ b/ledger/acctonline_expired_test.go
@@ -409,7 +409,7 @@ func (l *Ledger) OnlineTotalStake(rnd basics.Round) (basics.MicroAlgos, error) {
 func (l *Ledger) ExpiredOnlineCirculation(rnd, voteRnd basics.Round) (basics.MicroAlgos, error) {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()
-	return l.acctsOnline.StakeExpiringBy(rnd, voteRnd)
+	return l.acctsOnline.ExpiredOnlineCirculation(rnd, voteRnd)
 }
 
 // ExpiredOnlineCirculation returns the total expired stake at rnd this model produced, while

--- a/ledger/acctonline_expired_test.go
+++ b/ledger/acctonline_expired_test.go
@@ -409,7 +409,7 @@ func (l *Ledger) OnlineTotalStake(rnd basics.Round) (basics.MicroAlgos, error) {
 func (l *Ledger) ExpiredOnlineCirculation(rnd, voteRnd basics.Round) (basics.MicroAlgos, error) {
 	l.trackerMu.RLock()
 	defer l.trackerMu.RUnlock()
-	return l.acctsOnline.ExpiredOnlineCirculation(rnd, voteRnd)
+	return l.acctsOnline.StakeExpiringBy(rnd, voteRnd)
 }
 
 // ExpiredOnlineCirculation returns the total expired stake at rnd this model produced, while
@@ -640,7 +640,7 @@ func TestOnlineAcctModelScenario(t *testing.T) {
 
 func BenchmarkExpiredOnlineCirculation(b *testing.B) {
 	// set up totalAccounts online accounts in 10k batches
-	totalAccounts := 100_000
+	totalAccounts := 10_000
 	const maxKeyregPerBlock = 10_000
 	// if TOTAL_ACCOUNTS env var set, override totalAccounts
 	if n, err := strconv.Atoi(os.Getenv("TOTAL_ACCOUNTS")); err == nil {
@@ -687,4 +687,8 @@ func BenchmarkExpiredOnlineCirculation(b *testing.B) {
 		//total, err := m.dl.validator.OnlineTotalStake(startRnd + offset)
 		//b.Log("expired circulation", startRnd+offset, startRnd+offset+320, "returned", expiredStake, "total", total)
 	}
+}
+
+func BenchmarkExpiredStakeCache(b *testing.B) {
+
 }

--- a/ledger/store/trackerdb/data.go
+++ b/ledger/store/trackerdb/data.go
@@ -203,6 +203,7 @@ type PersistedResourcesData struct {
 }
 
 // PersistedOnlineAccountData is exported view of persistedOnlineAccountData
+// TODO: persistedOnlineAccountData is not a symbol in this repo, we should correct this comment.
 type PersistedOnlineAccountData struct {
 	Addr        basics.Address
 	AccountData BaseOnlineAccountData

--- a/ledger/votelastvalidcache.go
+++ b/ledger/votelastvalidcache.go
@@ -100,7 +100,7 @@ type onlineAccountAttributeCache[K, V any] interface {
 	init([]trackerdb.PersistedOnlineAccountData)
 	clear()
 	update(onlineAccountDelta)
-	getRange(K, K, config.ConsensusParams, uint64) (map[basics.Address]*ledgercore.OnlineAccountData, error)
+	getRange(K, K, config.ConsensusParams, uint64) map[basics.Address]*ledgercore.OnlineAccountData
 	trim(K)
 }
 
@@ -148,13 +148,12 @@ func (e expiringStakeCache) update(ad onlineAccountDelta) {
 	// f mt.Printrintf("after update: %v\n", e.microAlgos)
 }
 
-func (e expiringStakeCache) getRange(rStart, rEnd basics.Round, proto config.ConsensusParams, rewardsLevel uint64) (map[basics.Address]*ledgercore.OnlineAccountData, error) {
+func (e expiringStakeCache) getRange(rStart, rEnd basics.Round, proto config.ConsensusParams, rewardsLevel uint64) map[basics.Address]*ledgercore.OnlineAccountData {
 	var expiredAccounts map[basics.Address]*ledgercore.OnlineAccountData
 	expiredAccounts = make(map[basics.Address]*ledgercore.OnlineAccountData)
 	for i := rStart; i < rEnd; i++ {
 		acctsStake, ok := e.microAlgos.getPrimary(i)
 		if ok {
-			// f mt.Printrintln("stake:", acctsStake)
 			for addr, stake := range acctsStake {
 				data := trackerdb.BaseOnlineAccountData{
 					MicroAlgos: stake,
@@ -168,11 +167,7 @@ func (e expiringStakeCache) getRange(rStart, rEnd basics.Round, proto config.Con
 
 		}
 	}
-	// f mt.Printrintln("expiredAccounts:", expiredAccounts)
-	//for _, ex := range expiredAccounts {
-	//// f mt.Printrintln("ex:", ex)
-	//}
-	return expiredAccounts, nil
+	return expiredAccounts
 }
 
 func (e expiringStakeCache) clear() {

--- a/ledger/votelastvalidcache.go
+++ b/ledger/votelastvalidcache.go
@@ -46,6 +46,7 @@ func newVoteLastValidCache() roundCounterCache {
 	v.deltaFn = func(delta accountDelta) (basics.Round, basics.Round) {
 		return delta.oldAcct.AccountData.VoteLastValid, delta.newAcct.VoteLastValid
 	}
+	return v
 }
 
 // init initializes the cache for use.

--- a/ledger/votelastvalidcache.go
+++ b/ledger/votelastvalidcache.go
@@ -1,0 +1,101 @@
+// Copyright (C) 2019-2023 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package ledger
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/ledger/store/trackerdb"
+)
+
+type voteLastValidCache struct {
+	trimBehind basics.Round                    // the round that we have trimmed the cache to
+	m          map[basics.Round]*atomic.Uint64 // count of addresses whos voting expires on this round
+}
+
+// init initializes the voteLastValidCache for use.
+// thread locking semantics : write lock
+func (v *voteLastValidCache) init(accts []trackerdb.PersistedOnlineAccountData) {
+	v.trimBehind = 0
+	v.m = make(map[basics.Round]*atomic.Uint64)
+
+	for _, acct := range accts {
+		v.inc(acct.AccountData.VoteLastValid)
+	}
+}
+
+func (v *voteLastValidCache) inc(vLast basics.Round) {
+	if _, ok := v.m[vLast]; !ok {
+		v.m[vLast] = &atomic.Uint64{}
+	}
+	v.m[vLast].Add(1)
+}
+
+// TODO: include thread locking semantic comments once known
+func (v *voteLastValidCache) update(vLastOld, vLastNew basics.Round) {
+	// no actual update
+	if vLastNew == vLastOld {
+		return
+	}
+	// if the old round is still in the cache, decrement the address from it
+	if vLastOld >= v.trimBehind {
+		v.m[vLastOld].Add(^uint64(0))
+	}
+	v.inc(vLastNew)
+}
+
+// clear clears the cache to pre-init state
+func (v *voteLastValidCache) clear() {
+	v.m = nil
+	v.trimBehind = 0
+}
+
+// count returns the number of addresses whos voting expire on vLast
+func (v voteLastValidCache) count(vLast basics.Round) (*atomic.Uint64, bool) {
+	ret, ok := v.m[vLast]
+	return ret, ok
+}
+
+// updateFromAccountDeltas updates the cache from the account deltas
+func (v *voteLastValidCache) updateFromAccountDeltas(deltas compactAccountDeltas) {
+	for _, delta := range deltas.deltas {
+		new := delta.newAcct.GetAccountData().VoteLastValid
+		old := delta.oldAcct.AccountData.VoteLastValid
+		v.update(old, new)
+	}
+}
+
+// trim removes all entries from the cache that are older than vLast
+// and advances the trimBehind to vLast
+func (v *voteLastValidCache) trim(vLast basics.Round) {
+	// if we have already trimmed to this round, do nothing
+	if v.trimBehind >= vLast {
+		return
+	}
+	// otherwise, remove all entries older than vLast
+	for i := v.trimBehind; i < vLast; i++ {
+		delete(v.m, i)
+	}
+	v.trimBehind = vLast
+}
+
+// implements fmt.Stringer
+func (v voteLastValidCache) String() string {
+	return fmt.Sprintf("voteLastValidCache: trimBehind: %d, m: %v", v.trimBehind, v.m)
+}

--- a/ledger/votelastvalidcache.go
+++ b/ledger/votelastvalidcache.go
@@ -24,7 +24,7 @@ import (
 	"github.com/algorand/go-algorand/ledger/store/trackerdb"
 )
 
-// roundCounterCache is a cache that tracks counters by-round
+// roundCounterCache is a cache that tracks atomic ints used for counting, by-round
 // it is abstracted to allow for different types of counters,
 // but currently only used for the number of addresses whos voting expires on a given round via newVoteLastValidCache
 type roundCounterCache struct {


### PR DESCRIPTION
# WIP
Still WIP, large chunks and explanations may change.

# What

Establishes a new caching mechanism in the Online Accounts Tracker, named `ExpiringStakeCache`

# Why

Presently, the calls to `ExpiredOnlineCirculation` in the Online Account tracker will return a `basics.MicroAlgos` representing "how much stake is expiring on round `votingRnd`, from the perspective of the chain at round `rnd`". Under the hood, this call does a query which scans a large portion of the Online Accounts table.

We are interested in calling `ExpiredOnlineCirculation` more often, especially during ledger apply. From this, there is a concern about the performance of running to the database on every evaluation.

Therefore, a cache has been put in place to serve *some* of the calls which would otherwise hit the database. This should improve performance when getting expiring stake in these new scenarios

## How
Two new interface/structures are in `votelastvalidcache.go`:

### Double Index Map
A double index map is used to store `V` using a primary and secondary key (Ka and Kb).Data about the account's expiring stake is stored at [round][address]->V . An additional map stores [address]->round so that callers only need to know the address of the account, *or* the round they want to retrieve and they get an O(1) lookup.

### ExpiringStakeCache
Expiring Stake Cache uses a double index map and a `trimBehind` value in order to keep record of all the expiring stake per account per round. This map is updatable using AccountDeltas from the deferred commiit context in CommitRound. It intentionally *does not* use account deltas, as the Online Account Tracker handles the play-forward of that data.

In Online Account Tracker,
### At request time: onlineAcctsExpiredByRound
When getting the Online Accounts Expired By Round, a new parameter `noCache` is included. This is intended for testing purposes, to confirm that the behavior of this function is the same whether the cache is used or not.

When onlineAcctsExpiredByRound collects the DBRound via snapshot, if the DB Round is the requested `rnd` from the caller, then we know we can serve the the cache results. Otherwise, we use the existing SQL Query.

** Why not use the cache always?** : The OAER function takes `rnd` as a parameter representing the temporal perspective of the call. Take for example the following data:
```
round = 1, account X will expire on Round 400
round = 5, account X will expire on Round 399
round =10, account X will expire on Round 500
```

In this situation, the most up to date truth is that X will expire on Round 500. However, the existing utility of this call is to say "When will X expire from the perspective of round `rnd`?" From the perspective of round 8, X expired on Round 399.

To calculate this result, we need to look at all account updates which are *not newer than* the perspective round `rnd`. To achieve this today, we use a table scan which finds the most up-to-date update which is not newer than the perspective. In the *cache*, however, we would have to store all these updates in some journaled fashion in order to know which updates are applicable to which request. At that point we are storing essentially an entire database view in memory.

So instead, the cache only knows the expiring stake per round and account *from the perspective of the current database round*. This data is easy to keep, and since callers like `eval` will be looking for the most up to date information, this cache works for their calls.

### At commit time: `postCommit`
When the `dbTracker` commits a round to the database, once complete it updates its trackers via a call to `postCommit`, under a lock.
When post commit runs, all updates from the deferred commit context are fed to the cache. In this way, if the database has been updated, so has the cache :)


## Tests
Existing unit tests 

## Ongoing
* Unit tests - need tests for the new structures, and for the new tracking functionality of OnlineAccount Tracker
* Finish Wiring - need to expose the collected data to the ledger-apply functionality
* Limits in Consensus.Params - we need a maximum amount of stake to compare against, and also a maximum distance to the supplied VoteLastValid. Limiting the distance of VLV keeps this cache's memory usage bounded, where it otherwise would not be.