### PR TITLE
Revert "Ledger: Close the ledger at node shutdown"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ parameters:
     default: "/tmp/build_test_results_<< pipeline.id >>"
   valid_nightly_branch:
     type: string
-    default: revert-5668-shant/close_ledger
+    default: /hotfix\/.*/
   # The following is intentional - hardcoding a token for public repos
   # is recommended here to allow fork access
   codecov:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ parameters:
     default: "/tmp/build_test_results_<< pipeline.id >>"
   valid_nightly_branch:
     type: string
-    default: /revert-5668-shant/close_ledger
+    default: revert-5668-shant/close_ledger
   # The following is intentional - hardcoding a token for public repos
   # is recommended here to allow fork access
   codecov:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ parameters:
     default: "/tmp/build_test_results_<< pipeline.id >>"
   valid_nightly_branch:
     type: string
-    default: /hotfix\/.*/
+    default: /revert-5668-shant/close_ledger
   # The following is intentional - hardcoding a token for public repos
   # is recommended here to allow fork access
   codecov:

--- a/node/node.go
+++ b/node/node.go
@@ -418,7 +418,6 @@ func (node *AlgorandFullNode) Stop() {
 	node.lowPriorityCryptoVerificationPool.Shutdown()
 	node.cryptoPool.Shutdown()
 	node.cancelCtx()
-	node.ledger.Close()
 }
 
 // note: unlike the other two functions, this accepts a whole filename


### PR DESCRIPTION
# Summary

Reverts algorand/go-algorand#5668

Tests are occasionally failing, and we theorize that the test succeeds, but the shutdown is timing out. Via Pavel:

"It could the following based on the termination sequence in server.go

```
	s.node.Stop()

	err := server.Shutdown(context.Background())
```

node.Stop stops all services first but there could be some active network connections that handled later by server.Shutdown so I suspect some network requests do not allow ledger to be closed or, another way around, server.Shutdown waits longer than 30s after ledger shutdown."

# Tests

Ran nightly tests to verify.

https://app.circleci.com/pipelines/github/algorand/go-algorand/16377/workflows/0e0fceb7-111a-492d-9fa0-b0df27285afe
