### PR TITLE
Feature: Disable EnableBlockServiceFallbackToArchiver by default.

### DIFF
--- a/catchup/universalFetcher_test.go
+++ b/catchup/universalFetcher_test.go
@@ -94,7 +94,6 @@ func TestUGetBlockHTTP(t *testing.T) {
 
 	blockServiceConfig := config.GetDefaultLocal()
 	blockServiceConfig.EnableBlockService = true
-	blockServiceConfig.EnableBlockServiceFallbackToArchiver = false
 
 	net := &httpTestPeerSource{}
 	ls := rpcs.MakeBlockService(logging.Base(), blockServiceConfig, ledger, net, "test genesisID")

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -440,7 +440,7 @@ type Local struct {
 	// an archiver or return StatusNotFound (404) when in does not have the requested round, and
 	// BlockServiceCustomFallbackEndpoints is empty.
 	// The archiver is randomly selected, if none is available, will return StatusNotFound (404).
-	EnableBlockServiceFallbackToArchiver bool `version[16]:"true"`
+	EnableBlockServiceFallbackToArchiver bool `version[16]:"true" version[31]:"false"`
 
 	// CatchupBlockValidateMode is a development and testing configuration used by the catchup service.
 	// It can be used to omit certain validations to speed up the catchup process, or to apply extra validations which are redundant in normal operation.

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -64,7 +64,7 @@ var defaultLocal = Local{
 	EnableAgreementTimeMetrics:                 false,
 	EnableAssembleStats:                        false,
 	EnableBlockService:                         false,
-	EnableBlockServiceFallbackToArchiver:       true,
+	EnableBlockServiceFallbackToArchiver:       false,
 	EnableCatchupFromArchiveServers:            false,
 	EnableDeveloperAPI:                         false,
 	EnableExperimentalAPI:                      false,

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -43,7 +43,7 @@
     "EnableAgreementTimeMetrics": false,
     "EnableAssembleStats": false,
     "EnableBlockService": false,
-    "EnableBlockServiceFallbackToArchiver": true,
+    "EnableBlockServiceFallbackToArchiver": false,
     "EnableCatchupFromArchiveServers": false,
     "EnableDeveloperAPI": false,
     "EnableExperimentalAPI": false,

--- a/rpcs/blockService_test.go
+++ b/rpcs/blockService_test.go
@@ -143,6 +143,9 @@ func TestRedirectFallbackArchiver(t *testing.T) {
 	net2 := &httpTestPeerSource{}
 
 	config := config.GetDefaultLocal()
+	// Need to enable block service fallbacks
+	config.EnableBlockServiceFallbackToArchiver = true
+
 	bs1 := MakeBlockService(log, config, ledger1, net1, "test-genesis-ID")
 	bs2 := MakeBlockService(log, config, ledger2, net2, "test-genesis-ID")
 
@@ -311,6 +314,8 @@ func TestRedirectOnFullCapacity(t *testing.T) {
 	net2 := &httpTestPeerSource{}
 
 	config := config.GetDefaultLocal()
+	// Need to enable block service fallbacks
+	config.EnableBlockServiceFallbackToArchiver = true
 	bs1 := MakeBlockService(log1, config, ledger1, net1, "test-genesis-ID")
 	bs2 := MakeBlockService(log2, config, ledger2, net2, "test-genesis-ID")
 	// set the memory cap so that it can serve only 1 block at a time
@@ -487,6 +492,9 @@ func TestRedirectExceptions(t *testing.T) {
 	net1 := &httpTestPeerSource{}
 
 	config := config.GetDefaultLocal()
+	// Need to enable block service fallbacks
+	config.EnableBlockServiceFallbackToArchiver = true
+
 	bs1 := MakeBlockService(log, config, ledger1, net1, "{genesisID}")
 
 	nodeA := &basicRPCNode{}

--- a/test/testdata/configs/config-v31.json
+++ b/test/testdata/configs/config-v31.json
@@ -43,7 +43,7 @@
     "EnableAgreementTimeMetrics": false,
     "EnableAssembleStats": false,
     "EnableBlockService": false,
-    "EnableBlockServiceFallbackToArchiver": true,
+    "EnableBlockServiceFallbackToArchiver": false,
     "EnableCatchupFromArchiveServers": false,
     "EnableDeveloperAPI": false,
     "EnableExperimentalAPI": false,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Given there are no archival server records on mainnet/testnet, repeatedly doing queries for them (and adding warn messages to logs) makes little sense at the moment.
<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan
Existing tests pass.
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
