### PR TITLE
p2p: Close all connections and wsPeers on P2P network shutdown

### DIFF
--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -63,7 +63,9 @@ func TestP2PSubmitTX(t *testing.T) {
 	require.Eventually(
 		t,
 		func() bool {
-			return len(netA.service.ListPeersForTopic(p2p.TXTopicName)) == 2 && len(netB.service.ListPeersForTopic(p2p.TXTopicName)) == 1 && len(netC.service.ListPeersForTopic(p2p.TXTopicName)) == 1
+			return len(netA.service.ListPeersForTopic(p2p.TXTopicName)) == 2 &&
+				len(netB.service.ListPeersForTopic(p2p.TXTopicName)) == 1 &&
+				len(netC.service.ListPeersForTopic(p2p.TXTopicName)) == 1
 		},
 		2*time.Second,
 		50*time.Millisecond,


### PR DESCRIPTION
## Summary

This PR defines an innerStop() method similar to the one in wsNetwork that loops through the wsPeers and shuts them down as part of the network Stop method. Additionally it prevents unnecessary logging on node shutdown by checking if the error is caused by context cancellation shutting down the whole node. 

## Test Plan
Existing tests should pass and data races on wsPeer logging should no-longer occur due to logging after test is over. 
