### PR TITLE
dynamic lambda: current round awareness for AttachReceivedAt, AttachValidatedAt

### DIFF
--- a/agreement/demux.go
+++ b/agreement/demux.go
@@ -201,10 +201,10 @@ func (d *demux) next(s *Service, deadline Deadline, fastDeadline Deadline, curre
 		case payloadVerified:
 			e = e.(messageEvent).AttachValidatedAt(s.Clock.Since(), currentRound)
 		case payloadPresent, votePresent:
-			e = e.(messageEvent).AttachReceivedAt(s.Clock.Since())
+			e = e.(messageEvent).AttachReceivedAt(s.Clock.Since(), currentRound)
 		case voteVerified:
 			// if this is a proposal vote (step 0), record the validatedAt time on the vote
-			if e.(messageEvent).Input.UnauthenticatedVote.R.Step == 0 {
+			if e.(messageEvent).Input.Vote.R.Step == 0 {
 				e = e.(messageEvent).AttachValidatedAt(s.Clock.Since(), currentRound)
 			}
 		}

--- a/agreement/player_test.go
+++ b/agreement/player_test.go
@@ -3257,7 +3257,7 @@ func TestPlayerRetainsReceivedValidatedAtOneSample(t *testing.T) {
 	// send payloadPresent message
 	m := message{UnauthenticatedProposal: pP.u()}
 	inMsg = messageEvent{T: payloadPresent, Input: m}
-	inMsg = inMsg.AttachReceivedAt(time.Second)
+	inMsg = inMsg.AttachReceivedAt(time.Second, r-1)
 	err, panicErr = pM.transition(inMsg)
 	require.NoError(t, err)
 	require.NoError(t, panicErr)
@@ -3297,7 +3297,7 @@ func TestPlayerRetainsReceivedValidatedAtForHistoryWindow(t *testing.T) {
 		// send payloadPresent message
 		m := message{UnauthenticatedProposal: pP.u()}
 		inMsg = messageEvent{T: payloadPresent, Input: m}
-		inMsg = inMsg.AttachReceivedAt(time.Second)
+		inMsg = inMsg.AttachReceivedAt(time.Second, r+round(i)-1)
 		err, panicErr = pM.transition(inMsg)
 		require.NoError(t, err)
 		require.NoError(t, panicErr)
@@ -3331,7 +3331,7 @@ func TestPlayerRetainsReceivedValidatedAtPPOneSample(t *testing.T) {
 	proposalMsg := message{UnauthenticatedProposal: pP.u()}
 	compoundMsg := messageEvent{T: votePresent, Input: unverifiedVoteMsg,
 		Tail: &messageEvent{T: payloadPresent, Input: proposalMsg}}
-	inMsg := compoundMsg.AttachReceivedAt(time.Second) // call AttachReceivedAt like demux would
+	inMsg := compoundMsg.AttachReceivedAt(time.Second, r-1) // call AttachReceivedAt like demux would
 	err, panicErr := pM.transition(inMsg)
 	require.NoError(t, err)
 	require.NoError(t, panicErr)
@@ -3380,7 +3380,7 @@ func TestPlayerRetainsReceivedValidatedAtPPForHistoryWindow(t *testing.T) {
 		compoundMsg := messageEvent{T: votePresent, Input: unverifiedVoteMsg,
 			Tail: &messageEvent{T: payloadPresent, Input: proposalMsg}}
 
-		inMsg := compoundMsg.AttachReceivedAt(time.Second) // call AttachReceivedAt like demux would
+		inMsg := compoundMsg.AttachReceivedAt(time.Second, r+round(i)-1) // call AttachReceivedAt like demux would
 		err, panicErr := pM.transition(inMsg)
 		require.NoError(t, err)
 		require.NoError(t, panicErr)
@@ -3446,7 +3446,7 @@ func TestPlayerRetainsReceivedValidatedAtAVPPOneSample(t *testing.T) {
 	proposalMsg := message{UnauthenticatedProposal: pP.u()}
 	compoundMsg := messageEvent{T: votePresent, Input: unverifiedVoteMsg,
 		Tail: &messageEvent{T: payloadPresent, Input: proposalMsg}}
-	inMsg = compoundMsg.AttachReceivedAt(time.Second) // call AttachReceivedAt like demux would
+	inMsg = compoundMsg.AttachReceivedAt(time.Second, r-1) // call AttachReceivedAt like demux would
 	err, panicErr = pM.transition(inMsg)
 	require.NoError(t, err)
 	require.NoError(t, panicErr)
@@ -3500,7 +3500,7 @@ func TestPlayerRetainsReceivedValidatedAtAVPPHistoryWindow(t *testing.T) {
 		proposalMsg := message{UnauthenticatedProposal: pP.u()}
 		compoundMsg := messageEvent{T: votePresent, Input: unverifiedVoteMsg,
 			Tail: &messageEvent{T: payloadPresent, Input: proposalMsg}}
-		inMsg = compoundMsg.AttachReceivedAt(time.Second) // call AttachReceivedAt like demux would
+		inMsg = compoundMsg.AttachReceivedAt(time.Second, r+round(i)-1) // call AttachReceivedAt like demux would
 		err, panicErr = pM.transition(inMsg)
 		require.NoError(t, err)
 		require.NoError(t, panicErr)


### PR DESCRIPTION
## Summary

This lets AttachReceivedAt and AttachValidatedAt know what the player's current round is, so that they can handle setting timestamps for messages for R+1 better (these are called pipelined votes or proposals). Instead of using the clock for round R they set a timestamp of 1ns for these pipelined messages, since they have arrived before cert quorum was locally observed on R.

## Test Plan

Updated existing tests to provide currentRound.