### PR TITLE
docker: Support pregenerated keys in docker private networks

### DIFF
--- a/cmd/goal/network.go
+++ b/cmd/goal/network.go
@@ -282,7 +282,8 @@ var networkDeleteCmd = &cobra.Command{
 
 var networkPregenCmd = &cobra.Command{
 	Use:   "pregen",
-	Short: "Pregenerates the genesis.json, root and participation keys for a wallet",
+	Short: "Pregenerate private network",
+	Long:  "Pregenerates the root and participation keys for a private network. The pregen directory can then be passed to the 'goal network create' to start the network more quickly.",
 	Args:  validateNoPosArgsFn,
 	Run: func(cmd *cobra.Command, _ []string) {
 		var err error

--- a/docker/README.md
+++ b/docker/README.md
@@ -60,7 +60,8 @@ Configuration can be modified by specifying certain files. These can be changed 
 | /etc/algorand/algod.token | Override default randomized REST API token. |
 | /etc/algorand/algod.admin.token | Override default randomized REST API admin token. |
 | /etc/algorand/logging.config | Use a custom [logging.config](https://developer.algorand.org/docs/run-a-node/reference/telemetry-config/#configuration) file for configuring telemetry. |
- | /etc/algorand/template.json | Override default private network topology. One of the nodes in the template must be named "data".|
+| /etc/algorand/template.json | Override default private network topology. One of the nodes in the template must be named "data". |
+| /etc/algorand/keys/ | Override this directory to provide pregenerated private network data. |
 
 ## Example Configuration
 
@@ -117,3 +118,28 @@ On the host system, ensure the directory being mounted uses UID=999 and GID=999.
 Private networks work a little bit differently. They are configured with, potentially, several data directories. The default topology supplied with this container is installed to `/algod/`, and has a single node named `data`. This means the private network has a data directory at `/algod/data`, matching the production configuration.
 
 Because the root directory contains some metadata, if persistence of the private network is required, you should mount the volume `/algod/` instead of `/algod/data`. This will ensure the extra metadata is included when changing images.
+
+## Faster Private Network Startup
+
+Generating participation keys may take several minutes. By creating them ahead of time a new private network can be started more quickly. These keys can be reused for multiple networks.
+
+Note that you must provide a template.json file for this operation. [You can find a template here](https://github.com/algorand/go-algorand/blob/master/docker/files/run/devmode_template.json), be sure to replace `NUM_ROUNDS` with your desired number of rounds, such as 3000000.
+
+Use the `goal network pregen` command to generate the files in a mounted directory:
+```bash
+docker run --rm -it \
+    --name pregen \
+    -v /path/to/your/template.json:/etc/algorand/template.json \
+    -v $(pwd)/pregen:/algod/pregen \
+    --entrypoint "/node/bin/goal" \
+    algorand/algod:stable network pregen -t /etc/algorand/template.json -p /algod/pregen
+```
+
+You will now have a local directory named `pregen` which can be mounted the next time you want to start a network with this template:
+```bash
+docker run --rm -it --name algod-pregen-run \
+    -p 4190:8080 \
+    -v /tmp/big_keys.json:/etc/algorand/template.json \
+    -v $(pwd)/pregen:/etc/algorand/keys \
+    algorand/algod:stable
+```

--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -190,7 +190,16 @@ function start_new_private_network() {
       fi
   fi
   sed -i "s/NUM_ROUNDS/${NUM_ROUNDS:-30000}/" "/node/run/$TEMPLATE"
-  goal network create --noclean -n dockernet -r "${ALGORAND_DATA}/.." -t "/node/run/$TEMPLATE"
+
+  # Check if keys are mounted, and if so, copy them over
+  # Use pregen keys in network create command
+  if [ -d "/etc/algorand/keys" ]; then
+      cp -r /etc/algorand/keys /node/run/keys
+      goal network create --noclean -n dockernet -r "${ALGORAND_DATA}/.." -t "/node/run/$TEMPLATE" -p "/node/run/keys"
+  else
+      goal network create --noclean -n dockernet -r "${ALGORAND_DATA}/.." -t "/node/run/$TEMPLATE"
+  fi
+
   configure_data_dir
   start_private_network
 }


### PR DESCRIPTION
## Summary

Docker changes:
* Detect participation keys at the /etc/algorand/keys directory.
* If a private network is going to be started, use that directory if there are keys.
* README updates describing how the feature is used.

https://github.com/algorand/go-algorand/issues/5699

## Test Plan

Pregenerate keys with `goal`:
`goal network pregen -t some_template.json -p pregen`

Pregenerate keys with `docker`:
```bash
docker run --rm -it \
    -v /path/to/your/template.json:/etc/algorand/template.json \
    -v $(pwd)/pregen:/algod/pregen \
    --entrypoint "/node/bin/goal" \
    algorand/algod:nightly network pregen -t /etc/algorand/template.json -p /algod/pregen
```
Build the image (from root dir):

```bash
docker build \
    -t wwinder/algod:pregen-test  \
    --build-arg CHANNEL=nightly \
    --build-arg TARGETARCH=amd64 --no-cache \
    . 
```

Run (mounting the template and pregen directory):
```bash
docker run --rm -it --name algod-pregen-run \
    -v /path/to/your/template.json:/etc/algorand/template.json \
    -v $(pwd)/pregen:/etc/algorand/keys \
    wwinder/algod:pregen-test
```

On my machine, I used a `template.json` with 10 million keys. Pregen took nearly 20 minutes. The network start was almost instantaneous.