### PR TITLE
p2p: remove TestP2PThreeNodesEvenDist

### DIFF
--- a/test/e2e-go/features/p2p/p2p_basic_test.go
+++ b/test/e2e-go/features/p2p/p2p_basic_test.go
@@ -57,11 +57,6 @@ func TestP2PTwoNodes(t *testing.T) {
 	testP2PWithConfig(t, "TwoNodes50EachP2P.json")
 }
 
-func TestP2PThreeNodesEvenDist(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	testP2PWithConfig(t, "ThreeNodesEvenDistP2P.json")
-}
-
 func TestP2PFiveNodes(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	testP2PWithConfig(t, "FiveNodesP2P.json")


### PR DESCRIPTION
## Summary

~~Currently the `TestP2PThreeNodesEvenDist` fails pretty regularly. The theory here is that part of the problem is that P2P stream connections take longer to setup than the wsNetwork and that because of that nodes get into a bad state with consensus trying to move too quickly. The errors on the CI runs for these tests indicate that nodes are trying to catchup via gossip protocol but these attempts fail on timeouts.~~

After further investigation it looks like this behavior is not specific to P2P but happens on the websocket network as well. 50~60% of the time the test takes significantly longer locally but still succeeds. The failure on the CircleCI side is likely just different resourcing leading to slower execution and slower recovery from the bad state that nodes get into. Removing the test for now. 

FWIW P2P does pass the PartitionRecovery tests where this network template is used on the websocket network side. 

## Test Plan

~~This is a test only change. We want to see whether this change stops the existing test from being so flaky while discussing options to make it more stable and support the faster lambda.~~

This only removes a flaky test, it should hopefully bring nightly builds back into a stable state.