### PR TITLE
tests: fix a rare data race in staling tracker tests

### DIFF
--- a/ledger/acctonline_test.go
+++ b/ledger/acctonline_test.go
@@ -1605,8 +1605,6 @@ func TestAcctOnlineTopBetweenCommitAndPostCommit(t *testing.T) {
 		postCommitUnlockedReleaseLock: make(chan struct{}),
 		postCommitEntryLock:           make(chan struct{}),
 		postCommitReleaseLock:         make(chan struct{}),
-		alwaysLock:                    false,
-		shouldLockPostCommit:          false,
 	}
 
 	conf := config.GetDefaultLocal()
@@ -1632,7 +1630,7 @@ func TestAcctOnlineTopBetweenCommitAndPostCommit(t *testing.T) {
 		newBlockWithUpdates(genesisAccts, updates, totals, t, ml, i, oa)
 	}
 
-	stallingTracker.shouldLockPostCommit = true
+	stallingTracker.shouldLockPostCommit.Store(true)
 
 	updateAccountsRoutine := func() {
 		var updates ledgercore.AccountDeltas
@@ -1698,8 +1696,6 @@ func TestAcctOnlineTopDBBehindMemRound(t *testing.T) {
 		postCommitUnlockedReleaseLock: make(chan struct{}),
 		postCommitEntryLock:           make(chan struct{}),
 		postCommitReleaseLock:         make(chan struct{}),
-		alwaysLock:                    false,
-		shouldLockPostCommit:          false,
 	}
 
 	conf := config.GetDefaultLocal()
@@ -1725,7 +1721,7 @@ func TestAcctOnlineTopDBBehindMemRound(t *testing.T) {
 		newBlockWithUpdates(genesisAccts, updates, totals, t, ml, i, oa)
 	}
 
-	stallingTracker.shouldLockPostCommit = true
+	stallingTracker.shouldLockPostCommit.Store(true)
 
 	updateAccountsRoutine := func() {
 		var updates ledgercore.AccountDeltas

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -2192,8 +2192,8 @@ func testAcctUpdatesLookupRetry(t *testing.T, assertFn func(au *accountUpdates, 
 		postCommitUnlockedReleaseLock: make(chan struct{}),
 		postCommitEntryLock:           make(chan struct{}),
 		postCommitReleaseLock:         make(chan struct{}),
-		alwaysLock:                    true,
 	}
+	stallingTracker.alwaysLock.Store(true)
 	ml.trackers.trackers = append([]ledgerTracker{stallingTracker}, ml.trackers.trackers...)
 
 	// kick off another round


### PR DESCRIPTION
## Summary

Fix data race seen in [this build](https://app.circleci.com/pipelines/github/algorand/go-algorand/16714/workflows/3b31ab65-73d5-4982-a2aa-48d458399bf3/jobs/254613)

## Test Plan

Existing ledger unit tests passed