### PR TITLE
tests: fix flaky simulate test

### DIFF
--- a/test/e2e-go/restAPI/simulate/simulateRestAPI_test.go
+++ b/test/e2e-go/restAPI/simulate/simulateRestAPI_test.go
@@ -340,7 +340,12 @@ int 1`
 
 	// There should be a failure when the round is too far back
 	simulateRequest.Round = basics.Round(followerSyncRound - 3)
-	result, err = simulateTransactions(simulateRequest)
+	require.Eventually(t, func() bool {
+		// use Eventually to workaround the ledger delays with committing accounts
+		result, err = simulateTransactions(simulateRequest)
+		return err != nil
+	}, 6*time.Second, 500*time.Millisecond)
+
 	a.Error(err)
 	var httpErr client.HTTPError
 	a.ErrorAs(err, &httpErr)


### PR DESCRIPTION
## Summary

TestSimulateStartRound [flaked](https://circleci.com/api/v1.1/project/github/algorand/go-algorand/254584/output/114/3?file=true&allocation-id=64fe692aeac3ce51df71bf1a-3-build%2FABCDEFGH) because it expects txn simulated execution failed at round 1 after catching up to round 7 but time to time ledger is delayed flushing most recent deltas and it has all the state at round 1 needed for simulated execution so the simulate succeeds.
Use `Eventually` to retry few times and give the ledger change to flush.

## Test Plan

This is a test fix.