### PR TITLE
DevOps: update releases page GPG key mentions

### DIFF
--- a/scripts/release/mule/deploy/releases_page/html.tpl
+++ b/scripts/release/mule/deploy/releases_page/html.tpl
@@ -11,7 +11,7 @@
 <p>See <a href="https://developer.algorand.org/">Algorand Developer Resources</a> for instructions on installation and getting started</a></p>
 <p>The Algorand public key to verify these files (except RPM<sup><b>**</b></sup>) is at <a href="https://releases.algorand.com/key.pub">https://releases.algorand.com/key.pub</a></p>
 <p>The public key for verifying RPMs is <a href="https://releases.algorand.com/rpm/rpm_algorand.pub">https://releases.algorand.com/rpm/rpm_algorand.pub</a></p>
-<p><sup><b>**</b></sup> The RPM package for the 2.0.3 release was signed with the <a href="https://releases.algorand.com/key.pub">https://releases.algorand.com/key.pub</a>. All other releases will have been signed with the RPM key as noted.</p>
+<p>The public key for verifying binaries out of our CI builds is <a href="https://releases.algorand.com/dev_ci_build.pub">https://releases.algorand.com/dev_ci_build.pub</a></p>
 
 <hr>
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

We've added a new GPG key for CI build binaries, so adding mention of this. Also removed message about old binary.

## Test Plan

Executed and updated releases page.

