### PR TITLE
windows: Fix GC

### DIFF
--- a/tools/network/dnssec/config_windows.go
+++ b/tools/network/dnssec/config_windows.go
@@ -98,6 +98,7 @@ func SystemConfig() (servers []ResolverAddress, timeout time.Duration, err error
 	buf, err := windows.LocalAlloc(windows.LMEM_FIXED | windows.LMEM_ZEROINIT, ulSize)
 	if err != nil {
 		err = fmt.Errorf("GetNetworkParams failed to allocate %d bytes of memory for fixedInfoWithOverlay", ulSize)
+		return
 	}
 
 	defer windows.LocalFree(windows.Handle(buf))

--- a/tools/network/dnssec/config_windows.go
+++ b/tools/network/dnssec/config_windows.go
@@ -95,7 +95,7 @@ type fixedInfoWithOverlay struct {
 func SystemConfig() (servers []ResolverAddress, timeout time.Duration, err error) {
 	ulSize := uint32(unsafe.Sizeof(fixedInfoWithOverlay{}))
 
-	buf, err := windows.LocalAlloc(windows.LMEM_FIXED, ulSize)
+	buf, err := windows.LocalAlloc(windows.LMEM_FIXED | windows.LMEM_ZEROINIT, ulSize)
 	if err != nil {
 		err = fmt.Errorf("GetNetworkParams failed to allocate %d bytes of memory for fixedInfoWithOverlay", ulSize)
 	}

--- a/tools/network/dnssec/config_windows.go
+++ b/tools/network/dnssec/config_windows.go
@@ -21,7 +21,6 @@ package dnssec
 
 import (
 	"fmt"
-	"runtime/debug"
 	"time"
 	"unsafe"
 
@@ -94,24 +93,29 @@ type fixedInfoWithOverlay struct {
 // See GetNetworkParams for details:
 // https://docs.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getnetworkparams
 func SystemConfig() (servers []ResolverAddress, timeout time.Duration, err error) {
-	// disable GC to prevent fi collection earlier than lookups in fi completed
-	pct := debug.SetGCPercent(-1)
-	defer debug.SetGCPercent(pct)
+	ulSize := uint32(unsafe.Sizeof(fixedInfoWithOverlay{}))
 
-	var fi fixedInfoWithOverlay
-	var ulSize uint32 = uint32(unsafe.Sizeof(fi))
+	buf, err := windows.LocalAlloc(windows.LMEM_FIXED, ulSize)
+	if err != nil {
+		err = fmt.Errorf("GetNetworkParams failed to allocate %d bytes of memory for fixedInfoWithOverlay", ulSize)
+	}
+
+	defer windows.LocalFree(windows.Handle(buf))
+
 	ret, _, _ := networkParamsProc.Call(
-		uintptr(unsafe.Pointer(&fi)),
+		buf,
 		uintptr(unsafe.Pointer(&ulSize)),
 	)
 	if ret != 0 {
 		if windows.Errno(ret) == windows.ERROR_BUFFER_OVERFLOW {
-			err = fmt.Errorf("GetNetworkParams requested %d bytes of memory, max supported is %d. Error code is %x", ulSize, unsafe.Sizeof(fi), ret)
+			err = fmt.Errorf("GetNetworkParams requested %d bytes of memory, max supported is %d. Error code is %x", ulSize, unsafe.Sizeof(fixedInfoWithOverlay{}), ret)
 			return
 		}
 		err = fmt.Errorf("GetNetworkParams failed with code is %x", ret)
 		return
 	}
+
+	fi := (*fixedInfoWithOverlay)(unsafe.Pointer(buf))
 
 	var p *ipAddrString = &fi.DnsServerList
 	for {


### PR DESCRIPTION
Fixes garbage collection on Windows by removing calls to SetGCPercent and replacing the GC stop with a native buffer allocation (LocalAlloc / LocalFree) for fixedInfoWithOverlay.

The previously used code didn't work well on Windows, causing the GC to stop from collecting. The SetGCPercent(pct) didn't restore the GC.

A minimal program that can be used to reproduce the issue with SetGCPercent on Windows:
```go
package main

import "runtime/debug"

func test() {
	pct := debug.SetGCPercent(-1)
	defer debug.SetGCPercent(pct)

	var r [][]byte
	for i := 0; i < 10; i++ {
		r = append(r, make([]byte, 1024))
	}
}

func main() {
	for {
		test()
	}
}
```