### PR TITLE
DevOps: fix releases page links

### DIFF
--- a/scripts/release/mule/deploy/releases_page/generate_releases_page.py
+++ b/scripts/release/mule/deploy/releases_page/generate_releases_page.py
@@ -213,12 +213,19 @@ def main():
         # 'releases/beta/f9fa9a084_2.5.2' => [file_obj1, file_obj2, ...]
         release_sets = get_stage_release_set(staging_response)
 
+        release_contents = []
         # List everything from the releases bucket s3://algorand-releases/
         releases_response = s3.list_objects_v2(Bucket=releases_bucket)
+        release_contents.extend(releases_response["Contents"])
+
+        # If response was truncated, keep looping and appending
+        while (releases_response["IsTruncated"] == True):
+            releases_response = s3.list_objects_v2(Bucket=releases_bucket, ContinuationToken=releases_response["NextContinuationToken"])
+            release_contents.extend(releases_response["Contents"])
 
         # Return dict keyed by filename of file_objs from
         # s3://algorand-releases/
-        release_files = objects_by_fname(releases_response["Contents"])
+        release_files = objects_by_fname(release_contents)
 
         table = []
 

--- a/scripts/release/mule/deploy/releases_page/generate_releases_page.py
+++ b/scripts/release/mule/deploy/releases_page/generate_releases_page.py
@@ -219,7 +219,7 @@ def main():
         release_contents.extend(releases_response["Contents"])
 
         # If response was truncated, keep looping and appending
-        while (releases_response["IsTruncated"] == True):
+        while releases_response["IsTruncated"] == True:
             releases_response = s3.list_objects_v2(Bucket=releases_bucket, ContinuationToken=releases_response["NextContinuationToken"])
             release_contents.extend(releases_response["Contents"])
 

--- a/scripts/release/mule/deploy/rpm/deploy.sh
+++ b/scripts/release/mule/deploy/rpm/deploy.sh
@@ -78,6 +78,8 @@ then
     cp -r /root/rpmrepo .
 else
     aws s3 sync rpmrepo "s3://algorand-releases/rpm/$CHANNEL/"
+    # sync signatures to releases so that the .sig files load from there
+    aws s3 sync s3://$S3_SOURCE/releases/$CHANNEL/ s3://algorand-releases/rpm/sigs/$CHANNEL/ --exclude='*' --include='*.rpm.sig'
 fi
 
 echo


### PR DESCRIPTION
## Summary

Links on the releases page are meant to pull from the main repository. However, due to pagination, files were not getting assigned.

This PR fixes this by adding pagination to the file listing from S3. It also syncs signatures for RPMs to the repository.

## Test Plan

Ran release page generator and verified it would update links properly.
