### PR TITLE
tests: Fix simulate start round flaky test

### DIFF
--- a/test/e2e-go/restAPI/simulate/simulateRestAPI_test.go
+++ b/test/e2e-go/restAPI/simulate/simulateRestAPI_test.go
@@ -338,15 +338,16 @@ int 1`
 		a.LessOrEqual(followerSyncRound+i+1, binary.BigEndian.Uint64((*result.TxnGroups[0].Txns[0].Txn.Logs)[0]))
 	}
 
-	// There should be a failure when the round is too far back
+	// If the round is too far back, we should get an error saying so.
 	simulateRequest.Round = basics.Round(followerSyncRound - 3)
-	require.Eventually(t, func() bool {
-		// use Eventually to workaround the ledger delays with committing accounts
-		result, err = simulateTransactions(simulateRequest)
-		return err != nil
-	}, 6*time.Second, 500*time.Millisecond)
-
-	a.Error(err)
+	result, err = simulateTransactions(simulateRequest)
+	if err == nil {
+		// NOTE: The ledger can have variability in when it commits rounds to the database. It's
+		// possible that older rounds are still available because of this. If so, let's bail on the
+		// test.
+		t.Logf("Still producing a result for round %d", simulateRequest.Round)
+		return
+	}
 	var httpErr client.HTTPError
 	a.ErrorAs(err, &httpErr)
 	a.Equal(http.StatusInternalServerError, httpErr.StatusCode)


### PR DESCRIPTION
## Summary

The test `TestSimulateStartRound` can be flaky because it relies on the ledger quickly purging prior rounds from memory. I'm not convinced that adding a longer timeout will completely solve the flakiness, so I made the error case optional in this test. I'm ok with this solution because we really want to test the positive case (e.g. the result is valid for the last `MaxAcctLookback` rounds) -- if more rounds are available before this period, that's ok.

## Test Plan

Test modified.
