### PR TITLE
config: Add MaxBlockHistoryLookback option

### DIFF
--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -520,6 +520,10 @@ type Local struct {
 	// i.e. the ledger can answer account states questions for the range Latest-MaxAcctLookback...Latest
 	MaxAcctLookback uint64 `version[23]:"4"`
 
+	// BlockHistoryLookback sets the max lookback range for block information.
+	// i.e. the block DB can return transaction IDs for questions for the range Latest-MaxBlockHistoryLookback...Latest
+	MaxBlockHistoryLookback uint64 `version[32]:"0"`
+
 	// EnableUsageLog enables 10Hz log of CPU and RAM usage.
 	// Also adds 'algod_ram_usage` (number of bytes in use) to /metrics
 	EnableUsageLog bool `version[24]:"false"`

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -522,7 +522,7 @@ type Local struct {
 
 	// BlockHistoryLookback sets the max lookback range for block information.
 	// i.e. the block DB can return transaction IDs for questions for the range Latest-MaxBlockHistoryLookback...Latest
-	MaxBlockHistoryLookback uint64 `version[32]:"0"`
+	MaxBlockHistoryLookback uint64 `version[31]:"0"`
 
 	// EnableUsageLog enables 10Hz log of CPU and RAM usage.
 	// Also adds 'algod_ram_usage` (number of bytes in use) to /metrics

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -104,6 +104,7 @@ var defaultLocal = Local{
 	MaxAPIBoxPerApplication:                    100000,
 	MaxAPIResourcesPerAccount:                  100000,
 	MaxAcctLookback:                            4,
+	MaxBlockHistoryLookback:                    0,
 	MaxCatchpointDownloadDuration:              43200000000000,
 	MaxConnectionsPerIP:                        15,
 	MinCatchpointFileDownloadBytesPerSecond:    20480,

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -83,6 +83,7 @@
     "MaxAPIBoxPerApplication": 100000,
     "MaxAPIResourcesPerAccount": 100000,
     "MaxAcctLookback": 4,
+    "MaxBlockHistoryLookback": 0,
     "MaxCatchpointDownloadDuration": 43200000000000,
     "MaxConnectionsPerIP": 15,
     "MinCatchpointFileDownloadBytesPerSecond": 20480,

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -454,6 +454,11 @@ func (l *Ledger) notifyCommit(r basics.Round) basics.Round {
 	}()
 	minToSave := l.trackers.committedUpTo(r)
 
+	// Check if additional block history is configured, and adjust minToSave if so.
+	if configuredMinToSave := r.SubSaturate(basics.Round(l.cfg.MaxBlockHistoryLookback)); configuredMinToSave < minToSave {
+		minToSave = configuredMinToSave
+	}
+
 	if l.archival {
 		// Do not forget any blocks.
 		minToSave = 0

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -3279,6 +3279,7 @@ func TestLedgerMaxBlockHistoryLookback(t *testing.T) {
 		eval := nextBlock(t, l)
 		endBlock(t, l, eval)
 	}
+	require.Equal(t, basics.Round(1500), l.Latest())
 
 	// make sure we can get the last 1400 blocks
 	blk, err := l.Block(100)

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -3261,3 +3261,32 @@ func TestLedgerSPTrackerAfterReplay(t *testing.T) {
 	a.Equal(1, len(l.spVerification.pendingDeleteContexts))
 	verifyStateProofVerificationTracking(t, &l.spVerification, firstStateProofRound, 1, proto.StateProofInterval, true, spverDBLoc)
 }
+
+func TestLedgerMaxBlockHistoryLookback(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	genBalances, _, _ := ledgertesting.NewTestGenesis()
+	var genHash crypto.Digest
+	crypto.RandBytes(genHash[:])
+	cfg := config.GetDefaultLocal()
+	// set the max lookback to 1400
+	cfg.MaxBlockHistoryLookback = 1400
+	l := newSimpleLedgerFull(t, genBalances, protocol.ConsensusCurrentVersion, genHash, cfg, simpleLedgerNotArchival())
+	defer l.Close()
+
+	// make 1500 blocks
+	for i := 0; i < 1500; i++ {
+		eval := nextBlock(t, l)
+		endBlock(t, l, eval)
+	}
+
+	// make sure we can get the last 1400 blocks
+	blk, err := l.Block(100)
+	require.NoError(t, err)
+	require.NotEmpty(t, blk)
+
+	// make sure we can't get a block before the max lookback
+	blk, err = l.Block(90)
+	require.Error(t, err)
+	require.Empty(t, blk)
+}

--- a/test/testdata/configs/config-v31.json
+++ b/test/testdata/configs/config-v31.json
@@ -83,6 +83,7 @@
     "MaxAPIBoxPerApplication": 100000,
     "MaxAPIResourcesPerAccount": 100000,
     "MaxAcctLookback": 4,
+    "MaxBlockHistoryLookback": 0,
     "MaxCatchpointDownloadDuration": 43200000000000,
     "MaxConnectionsPerIP": 15,
     "MinCatchpointFileDownloadBytesPerSecond": 20480,


### PR DESCRIPTION
## Summary

There is no way to request a node to store more blocks if it is not archival. This adds a MaxBlockHistoryLookback similar to MaxAcctLookback config option.

## Test Plan

No tests yet