### PR TITLE
goal: Add initialize option to 'goal node catchup'.

### DIFF
--- a/cmd/goal/node.go
+++ b/cmd/goal/node.go
@@ -187,7 +187,7 @@ var catchupCmd = &cobra.Command{
 				}
 				genesis := strings.Split(vers.GenesisID, "-")[0]
 				URL := fmt.Sprintf(catchpointURL, genesis)
-				catchpoint, err := getMissingCatchpointLabel(URL)
+				catchpoint, err = getMissingCatchpointLabel(URL)
 				if err != nil {
 					reportErrorf(errorCatchpointLabelMissing, errorUnableToLookupCatchpointLabel, err.Error())
 				}

--- a/cmd/goal/node.go
+++ b/cmd/goal/node.go
@@ -208,7 +208,9 @@ var catchupCmd = &cobra.Command{
 			if err != nil {
 				reportErrorf(errorNodeStatus, err)
 			}
-			reportInfof("node response: %s", resp.CatchupMessage)
+			if resp.CatchupMessage != catchpoint {
+				reportInfof("node response: %s", resp.CatchupMessage)
+			}
 		})
 	},
 }

--- a/cmd/goal/node.go
+++ b/cmd/goal/node.go
@@ -194,7 +194,8 @@ var catchupCmd = &cobra.Command{
 				catchpoint = label
 			}
 
-			if !fastCatchupForce {
+			// Prompt user to confirm implicit catchpoint.
+			if !fastCatchupForce && len(args) == 0 {
 				fmt.Printf(nodeConfirmImplicitCatchpoint, catchpoint)
 				reader := bufio.NewReader(os.Stdin)
 				text, _ := reader.ReadString('\n')

--- a/cmd/goal/node.go
+++ b/cmd/goal/node.go
@@ -187,21 +187,20 @@ var catchupCmd = &cobra.Command{
 				}
 				genesis := strings.Split(vers.GenesisID, "-")[0]
 				URL := fmt.Sprintf(catchpointURL, genesis)
-				label, err := getMissingCatchpointLabel(URL)
+				catchpoint, err := getMissingCatchpointLabel(URL)
 				if err != nil {
 					reportErrorf(errorCatchpointLabelMissing, errorUnableToLookupCatchpointLabel, err.Error())
 				}
-				catchpoint = label
-			}
 
-			// Prompt user to confirm implicit catchpoint.
-			if !fastCatchupForce && len(args) == 0 {
-				fmt.Printf(nodeConfirmImplicitCatchpoint, catchpoint)
-				reader := bufio.NewReader(os.Stdin)
-				text, _ := reader.ReadString('\n')
-				text = strings.Replace(text, "\n", "", -1)
-				if text != "yes" {
-					reportErrorf(errorAbortedPerUserRequest)
+				// Prompt user to confirm using an implicit catchpoint.
+				if !fastCatchupForce {
+					fmt.Printf(nodeConfirmImplicitCatchpoint, catchpoint)
+					reader := bufio.NewReader(os.Stdin)
+					text, _ := reader.ReadString('\n')
+					text = strings.Replace(text, "\n", "", -1)
+					if text != "yes" {
+						reportErrorf(errorAbortedPerUserRequest)
+					}
 				}
 			}
 

--- a/daemon/algod/api/client/restClient.go
+++ b/daemon/algod/api/client/restClient.go
@@ -389,6 +389,10 @@ type accountInformationParams struct {
 	Exclude string `url:"exclude"`
 }
 
+type catchupParams struct {
+	Initialize uint64 `url:"initialize"`
+}
+
 // PendingTransactionsByAddr returns all the pending transactions for an addr.
 func (client RestClient) PendingTransactionsByAddr(addr string, max uint64) (response model.PendingTransactionsResponse, err error) {
 	err = client.get(&response, fmt.Sprintf("/v2/accounts/%s/transactions/pending", addr), pendingTransactionsByAddrParams{max})
@@ -575,8 +579,8 @@ func (client RestClient) AbortCatchup(catchpointLabel string) (response model.Ca
 }
 
 // Catchup start catching up to the give catchpoint label
-func (client RestClient) Catchup(catchpointLabel string) (response model.CatchpointStartResponse, err error) {
-	err = client.submitForm(&response, fmt.Sprintf("/v2/catchup/%s", catchpointLabel), nil, nil, "POST", false, true, false)
+func (client RestClient) Catchup(catchpointLabel string, initializeRounds uint64) (response model.CatchpointStartResponse, err error) {
+	err = client.submitForm(&response, fmt.Sprintf("/v2/catchup/%s", catchpointLabel), catchupParams{Initialize: initializeRounds}, nil, "POST", false, true, false)
 	return
 }
 

--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -1131,16 +1131,12 @@ func (c *Client) AbortCatchup() error {
 }
 
 // Catchup start catching up to the give catchpoint label.
-func (c *Client) Catchup(catchpointLabel string) error {
+func (c *Client) Catchup(catchpointLabel string, initialize uint64) (model.CatchpointStartResponse, error) {
 	algod, err := c.ensureAlgodClient()
 	if err != nil {
-		return err
+		return model.CatchpointStartResponse{}, err
 	}
-	_, err = algod.Catchup(catchpointLabel)
-	if err != nil {
-		return err
-	}
-	return nil
+	return algod.Catchup(catchpointLabel, initialize)
 }
 
 const defaultAppIdx = 1380011588

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -936,6 +936,7 @@ proc ::AlgorandGoal::StartCatchup { NODE_DATA_DIR CATCHPOINT } {
         spawn goal node catchup $CATCHPOINT -d $NODE_DATA_DIR
         expect {
             timeout { ::AlgorandGoal::Abort "goal node catchup timed out" }
+            -re {Fast catchup response: ([0-9]*#[A-Z2-7]*)} {regexp -- {[0-9]*#[A-Z2-7]*} $expect_out(0,string) CATCHPOINT; exp_continue }
             eof { catch wait result; if { [lindex $result 3] != 0 } { ::AlgorandGoal::Abort "failed to start catching up : error code [lindex $result 3]"} }
         }
     } EXCEPTION ] } {

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -933,7 +933,7 @@ proc ::AlgorandGoal::StartCatchup { NODE_DATA_DIR CATCHPOINT } {
     if { [catch {
         # start catchup
         puts "[clock format [clock seconds] -format %H:%M:%S]: spawn node catchup $CATCHPOINT"
-        spawn goal node catchup --force $CATCHPOINT -d $NODE_DATA_DIR
+        spawn goal node catchup $CATCHPOINT -d $NODE_DATA_DIR
         expect {
             timeout { ::AlgorandGoal::Abort "goal node catchup timed out" }
             eof { catch wait result; if { [lindex $result 3] != 0 } { ::AlgorandGoal::Abort "failed to start catching up : error code [lindex $result 3]"} }

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -936,7 +936,6 @@ proc ::AlgorandGoal::StartCatchup { NODE_DATA_DIR CATCHPOINT } {
         spawn goal node catchup $CATCHPOINT -d $NODE_DATA_DIR
         expect {
             timeout { ::AlgorandGoal::Abort "goal node catchup timed out" }
-            -re {Fast catchup response: ([0-9]*#[A-Z2-7]*)} {regexp -- {[0-9]*#[A-Z2-7]*} $expect_out(0,string) CATCHPOINT; exp_continue }
             eof { catch wait result; if { [lindex $result 3] != 0 } { ::AlgorandGoal::Abort "failed to start catching up : error code [lindex $result 3]"} }
         }
     } EXCEPTION ] } {

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -933,7 +933,7 @@ proc ::AlgorandGoal::StartCatchup { NODE_DATA_DIR CATCHPOINT } {
     if { [catch {
         # start catchup
         puts "[clock format [clock seconds] -format %H:%M:%S]: spawn node catchup $CATCHPOINT"
-        spawn goal node catchup $CATCHPOINT -d $NODE_DATA_DIR
+        spawn goal node catchup --force $CATCHPOINT -d $NODE_DATA_DIR
         expect {
             timeout { ::AlgorandGoal::Abort "goal node catchup timed out" }
             eof { catch wait result; if { [lindex $result 3] != 0 } { ::AlgorandGoal::Abort "failed to start catching up : error code [lindex $result 3]"} }

--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -316,7 +316,7 @@ func TestCatchpointCatchupFailure(t *testing.T) {
 	err = primaryNode.StopAlgod()
 	a.NoError(err)
 
-	_, err = usingNodeRestClient.Catchup(catchpointLabel)
+	_, err = usingNodeRestClient.Catchup(catchpointLabel, 0)
 	a.ErrorContains(err, node.MakeStartCatchpointError(catchpointLabel, fmt.Errorf("")).Error())
 }
 
@@ -358,7 +358,7 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 
 	catchpointLabel := waitForCatchpointGeneration(t, fixture, primaryNodeRestClient, targetCatchpointRound)
 
-	_, err = usingNodeRestClient.Catchup(catchpointLabel)
+	_, err = usingNodeRestClient.Catchup(catchpointLabel, 0)
 	a.NoError(err)
 
 	err = fixture.ClientWaitForRoundWithTimeout(usingNodeRestClient, uint64(targetCatchpointRound+1))
@@ -534,7 +534,7 @@ func TestNodeTxHandlerRestart(t *testing.T) {
 	lastCatchpoint := waitForCatchpointGeneration(t, &fixture, relayClient, basics.Round(targetCatchpointRound))
 
 	// let the primary node catchup
-	err = client1.Catchup(lastCatchpoint)
+	_, err = client1.Catchup(lastCatchpoint, 0)
 	a.NoError(err)
 
 	status1, err := client1.Status()
@@ -647,7 +647,7 @@ func TestReadyEndpoint(t *testing.T) {
 	// Then when the primary node is at target round, it should satisfy ready 200 condition
 
 	// let the primary node catchup
-	err = client1.Catchup(lastCatchpoint)
+	_, err = client1.Catchup(lastCatchpoint, 0)
 	a.NoError(err)
 
 	// The primary node is catching up with its previous catchpoint
@@ -789,7 +789,7 @@ func TestNodeTxSyncRestart(t *testing.T) {
 	_, err = fixture.StartNode(primaryNode.GetDataDir())
 	a.NoError(err)
 	// let the primary node catchup
-	err = client1.Catchup(lastCatchpoint)
+	_, err = client1.Catchup(lastCatchpoint, 0)
 	a.NoError(err)
 
 	// the transaction should not be confirmed yet

--- a/test/e2e-go/features/catchup/stateproofsCatchup_test.go
+++ b/test/e2e-go/features/catchup/stateproofsCatchup_test.go
@@ -93,7 +93,7 @@ func TestStateProofInReplayCatchpoint(t *testing.T) {
 
 	catchpointLabel := waitForCatchpointGeneration(t, fixture, primaryNodeRestClient, targetCatchpointRound)
 
-	_, err = usingNodeRestClient.Catchup(catchpointLabel)
+	_, err = usingNodeRestClient.Catchup(catchpointLabel, 0)
 	a.NoError(err)
 
 	// waiting for fastcatchup to start
@@ -169,7 +169,7 @@ func TestStateProofAfterCatchpoint(t *testing.T) {
 
 	catchpointLabel := waitForCatchpointGeneration(t, fixture, primaryNodeRestClient, targetCatchpointRound)
 
-	_, err = usingNodeRestClient.Catchup(catchpointLabel)
+	_, err = usingNodeRestClient.Catchup(catchpointLabel, 0)
 	a.NoError(err)
 
 	roundAfterSPGeneration := targetCatchpointRound.RoundUpToMultipleOf(basics.Round(consensusParams.StateProofInterval)) +
@@ -258,7 +258,7 @@ func TestSendSigsAfterCatchpointCatchup(t *testing.T) {
 	targetCatchpointRound := getFirstCatchpointRound(&consensusParams)
 
 	catchpointLabel := waitForCatchpointGeneration(t, &fixture, primaryNodeRestClient, targetCatchpointRound)
-	_, err = usingNodeRestClient.Catchup(catchpointLabel)
+	_, err = usingNodeRestClient.Catchup(catchpointLabel, 0)
 	a.NoError(err)
 
 	err = fixture.ClientWaitForRoundWithTimeout(usingNodeRestClient, uint64(targetCatchpointRound)+1)


### PR DESCRIPTION
## Summary

Add new parameter from #5752 to `goal node catchup`.

Minor refactoring to command to try and simplify the operations. In particular things I didn't like:
* referencing `args[0]` without saying anywhere that it was an optional positional argument.
* the `catchup` function references global abort flag, which is also referenced in the cobra function.
* multiple client objects created.

## Test Plan

Manually tested a bunch of permutations:
```
goal node catchup
goal node catchup -x
goal node catchup --force
goal node catchup --force -i 100000000
goal node catchup -i 100000000
goal node catchup -i 1000
goal node catchup -i 1000 --force
goal node catchup --force 
goal node catchup 29900000#K35DLY2QEMR6LPL6GOM5XR4ZVDYBNQ34TOWZVOPPL6PHSQGJJXHA
goal node catchup -i 100000000 29900000#K35DLY2QEMR6LPL6GOM5XR4ZVDYBNQ34TOWZVOPPL6PHSQGJJXHA
goal node catchup -i 100000000 --force 29900000#K35DLY2QEMR6LPL6GOM5XR4ZVDYBNQ34TOWZVOPPL6PHSQGJJXHA
goal node catchup -i 10000 29900000#K35DLY2QEMR6LPL6GOM5XR4ZVDYBNQ34TOWZVOPPL6PHSQGJJXHA --force
goal node catchup -i 10000 --force 29900000#K35DLY2QEMR6LPL6GOM5XR4ZVDYBNQ34TOWZVOPPL6PHSQGJJXHA --force
```