### PR TITLE
Tests: Address flakiness with TestMergePrimarySecondaryRelayAddressListsPartialOverlap 

### DIFF
--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -4374,24 +4374,24 @@ func TestMergePrimarySecondaryRelayAddressListsPartialOverlap(t *testing.T) {
 		secondaryRelayAddresses := make([]string, 0)
 		extraSecondaryRelayAddresses := make([]string, 0)
 		for i := 0; i < 100; i++ {
-			relayId := alphaNumStr(2)
+			relayID := alphaNumStr(2)
 			primaryRelayAddresses = append(primaryRelayAddresses, fmt.Sprintf("r-%s.algorand-%s.network",
-				relayId, network))
+				relayID, network))
 			secondaryRelayAddresses = append(secondaryRelayAddresses, fmt.Sprintf("r-%s.algorand-%s.net",
-				relayId, network))
+				relayID, network))
 		}
 		for i := 0; i < 20; i++ {
-			relayId := alphaNumStr(2) + "-" + alphaNumStr(1)
+			relayID := alphaNumStr(2) + "-" + alphaNumStr(1)
 			primaryRelayAddresses = append(primaryRelayAddresses, fmt.Sprintf("relay-%s.algorand-%s.network",
-				relayId, network))
+				relayID, network))
 			secondaryRelayAddresses = append(secondaryRelayAddresses, fmt.Sprintf("relay-%s.algorand-%s.net",
-				relayId, network))
+				relayID, network))
 		}
 		// Add additional secondary ones that intentionally do not duplicate primary ones
 		for i := 0; i < 10; i++ {
-			relayId := alphaNumStr(2) + "-" + alphaNumStr(1)
+			relayID := alphaNumStr(2) + "-" + alphaNumStr(1)
 			extraSecondaryRelayAddresses = append(extraSecondaryRelayAddresses, fmt.Sprintf("noduprelay-%s.algorand-%s.net",
-				relayId, network))
+				relayID, network))
 		}
 		secondaryRelayAddresses = append(secondaryRelayAddresses, extraSecondaryRelayAddresses...)
 

--- a/tools/network/dnssec/config_windows.go
+++ b/tools/network/dnssec/config_windows.go
@@ -95,7 +95,7 @@ type fixedInfoWithOverlay struct {
 func SystemConfig() (servers []ResolverAddress, timeout time.Duration, err error) {
 	ulSize := uint32(unsafe.Sizeof(fixedInfoWithOverlay{}))
 
-	buf, err := windows.LocalAlloc(windows.LMEM_FIXED | windows.LMEM_ZEROINIT, ulSize)
+	buf, err := windows.LocalAlloc(windows.LMEM_FIXED|windows.LMEM_ZEROINIT, ulSize)
 	if err != nil {
 		err = fmt.Errorf("GetNetworkParams failed to allocate %d bytes of memory for fixedInfoWithOverlay", ulSize)
 		return


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
TestMergePrimarySecondaryRelayAddressListsPartialOverlap inconsistently passes on the build server - it seems there are some random DNS combos that are not compatible with our filtering. Given we have control over the SRV record naming convention, rather than debug these corner cases the test has been modified to better reflect patterns we actively support.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan
Ran TestMergePrimarySecondaryRelayAddressListsPartialOverlap several consecutive times locally - Rapid has been removed for this test so it also runs much faster.
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
