### PR TITLE
tools: better heap data rendering

### DIFF
--- a/test/heapwatch/client_ram_report.py
+++ b/test/heapwatch/client_ram_report.py
@@ -181,8 +181,9 @@ def hostports_to_nicks(args, hostports, metrics=None):
         if not hit:
             hit = hp
         out.append(hit)
+    out.sort()
     if metrics:
-        return ['{}#{}'.format(hp, m) for hp in hostports for m in metrics]
+        return ['{}#{}'.format(hp, m) for hp in out for m in metrics]
     return out
 
 

--- a/test/heapwatch/plot_crr_csv.py
+++ b/test/heapwatch/plot_crr_csv.py
@@ -118,7 +118,7 @@ def main():
                 xy = metrics[metric]
 
                 ax.plot([p[0] for p in xy], [p[1] for p in xy], label=f'{k}/{metric}', color=lc, linestyle=plt_line_styles[i%len(plt_line_styles)])
-        ax.legend(loc='upper left', ncol=2)
+        fig.legend(loc='outside upper left', ncol=4)
         plt.savefig(fname + '.svg', format='svg')
         plt.savefig(fname + '.png', format='png')
         #plt.show()


### PR DESCRIPTION
## Summary

heapWatch's metric renderer does not work well for multiple nodes. This slightly improves heap chart rendering.
Also fixed IP to nicknames resolution.
Not super great but better.

## Test Plan

| Before | After |
| ------  | ----- |
| ![image](https://github.com/algorand/go-algorand/assets/65323360/49072c6f-bf64-45a0-b967-44e9deb82453) | ![image](https://github.com/algorand/go-algorand/assets/65323360/3fe4bb54-a6b6-4e9d-a694-1a02f7566870) |