### PR TITLE
docker: Update docker config with node_exporter path.

### DIFF
--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -87,6 +87,7 @@ function configure_data_dir() {
   fi
 
   algocfg -d . set -p EndpointAddress -v "0.0.0.0:${ALGOD_PORT}"
+  algocfg -d . set -p NodeExporterPath -v "$(which node_exporter)"
 
   # set token overrides
   for dir in ${ALGORAND_DATA}/../*/; do


### PR DESCRIPTION
## Summary

Fixes #5732 

The default node exporter path is `./node_exporter`. The docker container puts binaries on the path instead of using a fixed location, so this change simply fills in the absolute path.

## Test Plan

Using the following `config.json`:
```
{
  "EnableMetricReporting": true
}
```

1. Control test:
```
docker run --rm -it \
      -p 9100:9100 \
      -v (pwd)/config.json:/etc/algorand/config.json \
      -e NETWORK=betanet \
      algorand/algod:3.18.0-stable
```
2. The metric endpoint does not work:
```
curl localhost:9100/metrics
```

3. Build container with this branch:
```
docker build \
       -t wwinder/algod:metrics-fix \
       --build-arg CHANNEL=nightly \
       --build-arg TARGETARCH=amd64 --no-cache \
       .
```
4. Run the container like above:
```
docker run --rm -it \
      -p 9100:9100 \
      -v (pwd)/config.json:/etc/algorand/config.json \
      -e NETWORK=betanet \
      wwinder/algod:metrics-fix
```
5. The metric endpoint works:
```
curl localhost:9100/metrics
```
