### PR TITLE
node: Relaying nodes are not archival by default anymore

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -145,10 +145,7 @@ func mergeConfigFromFile(configpath string, source Local) (Local, error) {
 
 	err = loadConfig(f, &source)
 
-	// For now, all relays (listening for incoming connections) are also Archival
-	// We can change this logic in the future, but it's currently the sanest default.
-	if source.NetAddress != "" {
-		source.Archival = true
+	if source.Archival {
 		source.EnableLedgerService = true
 		source.EnableBlockService = true
 

--- a/config/config.go
+++ b/config/config.go
@@ -145,7 +145,7 @@ func mergeConfigFromFile(configpath string, source Local) (Local, error) {
 
 	err = loadConfig(f, &source)
 
-	if source.Archival {
+	if source.Archival || source.NetAddress != "" {
 		source.EnableLedgerService = true
 		source.EnableBlockService = true
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -112,7 +112,7 @@ func TestLocal_MergeConfig(t *testing.T) {
 	c2, err := mergeConfigFromDir(tempDir, defaultConfig)
 
 	require.NoError(t, err)
-	require.Equal(t, defaultConfig.Archival || c1.NetAddress != "", c2.Archival)
+	require.Equal(t, defaultConfig.Archival, c2.Archival)
 	require.Equal(t, defaultConfig.IncomingConnectionsLimit, c2.IncomingConnectionsLimit)
 	require.Equal(t, defaultConfig.BaseLoggerDebugLevel, c2.BaseLoggerDebugLevel)
 
@@ -165,29 +165,15 @@ func TestLoadPhonebookMissing(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 }
 
-func TestArchivalIfRelay(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-
-	testArchivalIfRelay(t, true)
-}
-
 func TestArchivalIfNotRelay(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	testArchivalIfRelay(t, false)
-}
-
-func testArchivalIfRelay(t *testing.T, relay bool) {
 	tempDir := t.TempDir()
 
 	c1 := struct {
 		NetAddress string
 	}{}
-	if relay {
-		c1.NetAddress = ":1234"
-	}
 
 	// write our reduced version of the Local struct
 	fileToMerge := filepath.Join(tempDir, ConfigFilename)
@@ -202,11 +188,7 @@ func testArchivalIfRelay(t *testing.T, relay bool) {
 
 	c2, err := mergeConfigFromDir(tempDir, defaultConfig)
 	require.NoError(t, err)
-	if relay {
-		require.True(t, c2.Archival, "Relay should be archival")
-	} else {
-		require.False(t, c2.Archival, "Non-relay should still be non-archival")
-	}
+	require.False(t, c2.Archival, "Non-relay should still be non-archival")
 }
 
 func TestLocal_ConfigExampleIsCorrect(t *testing.T) {

--- a/test/testdata/deployednettemplates/recipes/custom/configs/relay.json
+++ b/test/testdata/deployednettemplates/recipes/custom/configs/relay.json
@@ -8,5 +8,19 @@
     "TelemetryURI": "{{TelemetryURI}}",
     "EnableMetrics": true,
     "MetricsURI": "{{MetricsURI}}",
-    "ConfigJSONOverride": "{ \"TxPoolExponentialIncreaseFactor\": 1, \"DNSBootstrapID\": \"<network>.algodev.network\", \"DeadlockDetection\": -1, \"EnableRuntimeMetrics\": true, \"CadaverSizeTarget\": 0, \"PeerPingPeriodSeconds\": 30, \"EnableAgreementReporting\": true, \"EnableAgreementTimeMetrics\": true, \"EnableAssembleStats\": true, \"EnableProcessBlockStats\": true, \"BaseLoggerDebugLevel\": 4, \"EnableProfiler\": true }"
+    "ConfigJSONOverride": "{ \"TxPoolExponentialIncreaseFactor\": 1, \"DNSBootstrapID\": \"<network>.algodev.network\", \"DeadlockDetection\": -1, \"EnableRuntimeMetrics\": true, \"CadaverSizeTarget\": 0, \"PeerPingPeriodSeconds\": 30, \"EnableAgreementReporting\": true, \"EnableAgreementTimeMetrics\": true, \"EnableAssembleStats\": true, \"EnableProcessBlockStats\": true, \"BaseLoggerDebugLevel\": 4, \"EnableProfiler\": true }",
+    "AltConfigs": [
+        {
+            "NetAddress": "{{NetworkPort}}",
+            "APIEndpoint": "{{APIEndpoint}}",
+            "APIToken": "{{APIToken}}",
+            "EnableBlockStats": true,
+            "EnableTelemetry": true,
+            "TelemetryURI": "{{TelemetryURI}}",
+            "EnableMetrics": true,
+            "MetricsURI": "{{MetricsURI}}",
+            "ConfigJSONOverride": "{ \"Archival\": true, \"TxPoolExponentialIncreaseFactor\": 1, \"DNSBootstrapID\": \"<network>.algodev.network\", \"DeadlockDetection\": -1, \"EnableRuntimeMetrics\": true, \"CadaverSizeTarget\": 0, \"PeerPingPeriodSeconds\": 30, \"EnableAgreementReporting\": true, \"EnableAgreementTimeMetrics\": true, \"EnableAssembleStats\": true, \"EnableProcessBlockStats\": true, \"BaseLoggerDebugLevel\": 4, \"EnableProfiler\": true }",
+            "FractionApply": 0.20
+        }
+    ]
 }

--- a/test/testdata/nettemplates/CatchpointCatchupTestNetwork.json
+++ b/test/testdata/nettemplates/CatchpointCatchupTestNetwork.json
@@ -23,7 +23,8 @@
       "Wallets": [
         { "Name": "Wallet1",
           "ParticipationOnly": false }
-      ]
+      ],
+      "ConfigJSONOverride": "{\"Archival\": true}"
     },
     {
       "Name": "Node",


### PR DESCRIPTION
## Summary

Do not set `Archival=true` for nodes with non-empty `NetAddress` (these nodes accept incoming connections and act as relays).

IMPORTANT:
1. This should not be deployed to relays who want to remain archival nodes. They need to set `Archival=true` in their config files
2. non-archival nodes who wants to generate and store catchpoints need to set `CatchpointTracking=2`
3. Consider setting a new `MaxBlockHistoryLookback` to something like `3*CatchpointInterval` to have all the relays serving blocks after recent fast catchup?

## Test Plan

Manual 5 relays test on 2000+ rounds with a single archival relay.

1. New node with `GossipFanout=1` connected to non-archival relay:
```json
{"event":"ConnectedOut","file":"wsNetwork.go","function":"github.com/algorand/go-algorand/network.(*WebsocketNetwork).tryConnect","level":"info","line":2181,"local":"","msg":"Made outgoing connection to peer r4.pavel-5rel-arch.algodev.network:4560","name":"","remote":"r4.pavel-5rel-arch.algodev.network:4560","time":"2023-09-29T11:45:07.226655-04:00"}

{"details":{"Address":"52.53.125.234","HostName":"","Incoming":false,"InstanceName":"","Endpoint":"r4.pavel-5rel-arch.algodev.network:4560"},"file":"telemetry.go","function":"github.com/algorand/go-algorand/logging.(*telemetryState).logTelemetry","instanceName":"3+VKrJ2KvGSJxjbz","level":"info","line":255,"msg":"/Network/ConnectPeer","name":"","session":"","time":"2023-09-29T11:45:07.226740-04:00","v":"3.19.195314"}

{"file":"wsNetwork.go","function":"github.com/algorand/go-algorand/network.(*WebsocketNetwork).maybeSendMessagesOfInterest","level":"info","line":1120,"msg":"msgOfInterest Enc=nil, MOIGen=1","name":"","time":"2023-09-29T11:45:07.226785-04:00"}
```

2. Relay4 does not have first blocks
```bash
sqlite3 data/relay4/pavel-5rel-arch-v1/ledger.block.sqlite 'select min(rnd) from blocks'
855
```

3. Node keeps trying other known relays to find a block:
```json
{"Context":"sync","file":"universalFetcher.go","function":"github.com/algorand/go-algorand/catchup.(*HTTPFetcher).getBlockBytes","level":"debug","line":222,"msg":"block GET \"http://r4.pavel-5rel-arch.algodev.network:4560/v1/pavel-5rel-arch-v1/block/1\" peer \u0026network.wsPeerCore{net:(*network.WebsocketNetwork)(0x140009b2c00), netCtx:(*context.cancelCtx)(0x1400093a190), log:logging.logger{entry:(*logrus.Entry)(0x1400092ea10), loggerState:(*logging.loggerState)(0x14000010090)}, readBuffer:(chan\u003c- network.IncomingMessage)(0x1400093e5a0), rootURL:\"r4.pavel-5rel-arch.algodev.network:4560\", originAddress:\"\", client:http.Client{Transport:(*network.rateLimitingTransport)(0x140009b3c60), CheckRedirect:(func(*http.Request, []*http.Request) error)(nil), Jar:http.CookieJar(nil), Timeout:0}} *network.wsPeerCore","name":"","time":"2023-09-29T11:54:59.006826-04:00"}

{"Context":"sync","file":"universalFetcher.go","function":"github.com/algorand/go-algorand/catchup.(*HTTPFetcher).getBlockBytes","level":"debug","line":222,"msg":"block GET \"http://r1.pavel-5rel-arch.algodev.network:4560/v1/pavel-5rel-arch-v1/block/5\" peer \u0026network.wsPeerCore{net:(*network.WebsocketNetwork)(0x140009b2c00), netCtx:(*context.cancelCtx)(0x1400093a190), log:logging.logger{entry:(*logrus.Entry)(0x1400092ea10), loggerState:(*logging.loggerState)(0x14000010090)}, readBuffer:(chan\u003c- network.IncomingMessage)(0x1400093e5a0), rootURL:\"r1.pavel-5rel-arch.algodev.network:4560\", originAddress:\"\", client:http.Client{Transport:(*network.rateLimitingTransport)(0x140009b3c60), CheckRedirect:(func(*http.Request, []*http.Request) error)(nil), Jar:http.CookieJar(nil), Timeout:0}} *network.wsPeerCore","name":"","time":"2023-09-29T11:54:59.006903-04:00"}
```

4. Node caught up
```sh
sqlite3 mynode/pavel-5rel-arch-v1/ledger.block.sqlite 'select min(rnd), max(rnd) from blocks'
1023|2023
```