### PR TITLE
ci: fix scripts/create_and_deploy_recipe.sh build

### DIFF
--- a/docker/build/Dockerfile-deploy
+++ b/docker/build/Dockerfile-deploy
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 ubuntu:20.04
 ARG GOLANG_VERSION
 
-RUN apt-get update && apt-get install -y git wget autoconf jq bsdmainutils shellcheck
+RUN apt-get update && apt-get install -y git wget autoconf jq bsdmainutils shellcheck make python3 libtool g++
 WORKDIR /root
 RUN wget --quiet https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz && tar -xvf go${GOLANG_VERSION}.linux-amd64.tar.gz && mv go /usr/local
 ENV GOROOT=/usr/local/go \

--- a/scripts/upload_config.sh
+++ b/scripts/upload_config.sh
@@ -34,6 +34,9 @@ SRCPATH=${SCRIPTPATH}/..
 export CHANNEL=$2
 export FULLVERSION=$($SRCPATH/scripts/compute_build_number.sh -f)
 
+# prevent ._* files from being included in the tarball
+export COPYFILE_DISABLE=true
+
 TEMPDIR=$(mktemp -d -t "upload_config.tmp.XXXXXX")
 TARFILE=${TEMPDIR}/config_${CHANNEL}_${FULLVERSION}.tar.gz
 


### PR DESCRIPTION
## Summary

Fix binaries build for local cluster deployment with docker.
Some errors seen are:

```
 > [9/9] RUN scripts/configure_dev-deps.sh && make clean && find tmp && tmp/pavel-5rel-arch/deploy_linux_version_exec.sh:
0.255 /bin/sh: 1: make: not found
...

37.18 /usr/bin/env: 'python3': No such file or directory
37.52 + '[' 3.19. = '' ']'
37.54 + export BUILDNUMBER=
37.54 + BUILDNUMBER=
37.54 + '[' '' = '' ']'
37.54 FULLVERSION does not appear to be valid: 3.19.
37.54 + echo 'FULLVERSION does not appear to be valid: 3.19.'
37.54 + exit 1
```

Additionally, fix `._Wallet` hidden files in tar archive with `export COPYFILE_DISABLE=true` as per this [post](https://stackoverflow.com/questions/8766730/tar-command-in-mac-os-x-adding-hidden-files-why)
Otherwise algod is trying to load these metadata files and fails with

```json
{"file":"main.go","function":"main.run","level":"error","line":326,"msg":"couldn't initialize the node: AlgorandFullNode.loadParticipationKeys: cannot load db ._Wallet2.0.30000.partkey: file is not a database","time":"2023-09-28T19:40:02.936041Z"}
```
when starting with a dir containing
```
-rw-rw-r-- 1 ubuntu ubuntu    163 Sep 28 19:39 ._Wallet2.0.30000.partkey
-rw-rw-r-- 1 ubuntu ubuntu    163 Sep 28 19:39 ._Wallet2.rootkey
-rw-rw-r-- 1 ubuntu ubuntu 585728 Sep 28 19:39 Wallet2.0.30000.partkey
-rw-rw-r-- 1 ubuntu ubuntu   8192 Sep 28 19:39 Wallet2.rootkey
```


## Test Plan

Local build with `./scripts/create_and_deploy_recipe.sh -c $NETWORK_NAME --recipe test/testdata/deployednettemplates/recipes/custom/recipe.json -r ~/networks/$NETWORK_NAME -b $S3_RELEASE_BUCKET` succeeded.