### PR TITLE
tests: Fix flaky tealdbg unit test

### DIFF
--- a/cmd/tealdbg/server_test.go
+++ b/cmd/tealdbg/server_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"math/rand"
 	"strings"
 	"testing"
 	"time"
@@ -105,17 +104,9 @@ func tryStartingServerDebug(t *testing.T, ds *DebugServer) (ok bool) {
 }
 
 func serverTestImpl(t *testing.T, run func(t *testing.T, ds *DebugServer) bool, dp *DebugParams) {
-	maxPortNum := 65000
-	minPortNum := 40000
-	attempt := 0
-	started := false
-	var ds DebugServer
-	for attempt < 5 && !started {
-		port = rand.Intn(maxPortNum-minPortNum) + minPortNum
-		ds = makeDebugServer("127.0.0.1", port, &mockFactory{}, dp)
-		started = run(t, &ds)
-		attempt++
-	}
+	// Using 0 as port should select a random available port.
+	ds := makeDebugServer("127.0.0.1", 0, &mockFactory{}, dp)
+	started := run(t, &ds)
 
 	require.True(t, started)
 	require.NotEmpty(t, ds)


### PR DESCRIPTION
## Summary

Our arm64 nightly build shows a test failure of `TestServerLocal` and several others from the package `cmd/tealdbg`: https://app.circleci.com/pipelines/github/algorand/go-algorand/16882/workflows/78daf42e-bd47-4f33-8ac2-b210eaf0b2bb/jobs/256093/tests

I can't say why the others failed (in fact I'm suspicious this is a reporting error), but the failure from `TestServerLocal` indicates that it couldn't find a free port to use for its server. I've fixed this by using port 0, which should assign it any randomly-chosen available port.

## Test Plan

Test-only fix
