### PR TITLE
docker: Do not disable telemetry if logging.config is present.

### DIFF
--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -96,7 +96,7 @@ function configure_data_dir() {
   if [ "$TELEMETRY_NAME" != "" ]; then
     diagcfg telemetry name -n "$TELEMETRY_NAME" -d "$ALGORAND_DATA"
     diagcfg telemetry enable -d "$ALGORAND_DATA"
-  else
+  elif ! [ -f "/etc/algorand/logging.config" ]; then
     diagcfg telemetry disable
   fi
 


### PR DESCRIPTION
## Summary

The docker image proactively disables telemetry if `TELEMETRY_NAME` is not set. Presumably this was to allow turning telemetry on and off for an existing container. This has a side effect of disabling telemetry enabled by a `logging.config` override.

We have two options:
1) this is desirable behavior even when providing `logging.config`. No change is necessary.
2) (this PR) If `logging.config` is provided and no `TELEMETRY_NAME` is provided, skip disabling telemetry.

## Test Plan

Manually tested the bash script and ran it through shellcheck.
