### PR TITLE
TEAL: Report columns in TEAL source maps

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -1010,9 +1010,38 @@ func assembleFile(fname string, printWarnings bool) (program []byte) {
 	return ops.Program
 }
 
-func assembleFileWithMap(fname string, printWarnings bool) ([]byte, logic.SourceMap) {
-	ops := assembleFileImpl(fname, printWarnings)
-	return ops.Program, logic.GetSourceMap([]string{fname}, ops.OffsetToSource)
+func assembleFileWithMap(sourceFile string, outFile string, printWarnings bool) ([]byte, logic.SourceMap, error) {
+	ops := assembleFileImpl(sourceFile, printWarnings)
+	pathToSourceFromSourceMap, err := determinePathToSourceFromSourceMap(sourceFile, outFile)
+	if err != nil {
+		return nil, logic.SourceMap{}, err
+	}
+	return ops.Program, logic.GetSourceMap([]string{pathToSourceFromSourceMap}, ops.OffsetToSource), nil
+}
+
+func determinePathToSourceFromSourceMap(sourceFile string, outFile string) (string, error) {
+	var pathToSourceFromSourceMap string
+	if sourceFile == stdinFileNameValue {
+		pathToSourceFromSourceMap = "stdin"
+	} else {
+		sourceFileAbsolute, err := filepath.Abs(sourceFile)
+		if err != nil {
+			return "", fmt.Errorf("could not determine absolute path to source file '%s': %w", sourceFile, err)
+		}
+		if outFile == stdoutFilenameValue {
+			pathToSourceFromSourceMap = sourceFileAbsolute
+		} else {
+			outFileAbsolute, err := filepath.Abs(outFile)
+			if err != nil {
+				return "", fmt.Errorf("could not determine absolute path to output file '%s': %w", outFile, err)
+			}
+			pathToSourceFromSourceMap, err = filepath.Rel(filepath.Dir(outFileAbsolute), sourceFileAbsolute)
+			if err != nil {
+				return "", fmt.Errorf("could not determine path from source map to source: %w", err)
+			}
+		}
+	}
+	return pathToSourceFromSourceMap, nil
 }
 
 func disassembleFile(fname, outname string) {
@@ -1070,7 +1099,10 @@ var compileCmd = &cobra.Command{
 				}
 			}
 			shouldPrintAdditionalInfo := outname != stdoutFilenameValue
-			program, sourceMap := assembleFileWithMap(fname, true)
+			program, sourceMap, err := assembleFileWithMap(fname, outname, true)
+			if err != nil {
+				reportErrorf("Could not assemble: %s", err)
+			}
 			outblob := program
 			if signProgram {
 				dataDir := datadir.EnsureSingleDataDir()

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -1012,7 +1012,7 @@ func assembleFile(fname string, printWarnings bool) (program []byte) {
 
 func assembleFileWithMap(fname string, printWarnings bool) ([]byte, logic.SourceMap) {
 	ops := assembleFileImpl(fname, printWarnings)
-	return ops.Program, logic.GetSourceMap([]string{fname}, ops.OffsetToLine)
+	return ops.Program, logic.GetSourceMap([]string{fname}, ops.OffsetToSource)
 }
 
 func disassembleFile(fname, outname string) {

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -1020,26 +1020,23 @@ func assembleFileWithMap(sourceFile string, outFile string, printWarnings bool) 
 }
 
 func determinePathToSourceFromSourceMap(sourceFile string, outFile string) (string, error) {
-	var pathToSourceFromSourceMap string
 	if sourceFile == stdinFileNameValue {
-		pathToSourceFromSourceMap = "stdin"
-	} else {
-		sourceFileAbsolute, err := filepath.Abs(sourceFile)
-		if err != nil {
-			return "", fmt.Errorf("could not determine absolute path to source file '%s': %w", sourceFile, err)
-		}
-		if outFile == stdoutFilenameValue {
-			pathToSourceFromSourceMap = sourceFileAbsolute
-		} else {
-			outFileAbsolute, err := filepath.Abs(outFile)
-			if err != nil {
-				return "", fmt.Errorf("could not determine absolute path to output file '%s': %w", outFile, err)
-			}
-			pathToSourceFromSourceMap, err = filepath.Rel(filepath.Dir(outFileAbsolute), sourceFileAbsolute)
-			if err != nil {
-				return "", fmt.Errorf("could not determine path from source map to source: %w", err)
-			}
-		}
+		return "<stdin>", nil
+	}
+	sourceFileAbsolute, err := filepath.Abs(sourceFile)
+	if err != nil {
+		return "", fmt.Errorf("could not determine absolute path to source file '%s': %w", sourceFile, err)
+	}
+	if outFile == stdoutFilenameValue {
+		return sourceFileAbsolute, nil
+	}
+	outFileAbsolute, err := filepath.Abs(outFile)
+	if err != nil {
+		return "", fmt.Errorf("could not determine absolute path to output file '%s': %w", outFile, err)
+	}
+	pathToSourceFromSourceMap, err := filepath.Rel(filepath.Dir(outFileAbsolute), sourceFileAbsolute)
+	if err != nil {
+		return "", fmt.Errorf("could not determine path from source map to source: %w", err)
 	}
 	return pathToSourceFromSourceMap, nil
 }

--- a/cmd/goal/clerk_test.go
+++ b/cmd/goal/clerk_test.go
@@ -57,8 +57,20 @@ func TestDeterminePathToSourceFromSourceMap(t *testing.T) {
 		{
 			name:         "output one level down",
 			sourceFile:   filepath.FromSlash("data/program.teal"),
-			outFile:      filepath.FromSlash("program.teal.tok"),
+			outFile:      "program.teal.tok",
 			expectedPath: filepath.FromSlash("data/program.teal"),
+		},
+		{
+			name:         "input stdin",
+			sourceFile:   stdinFileNameValue,
+			outFile:      "program.teal.tok",
+			expectedPath: "stdin",
+		},
+		{
+			name:         "output stdout",
+			sourceFile:   filepath.FromSlash("data/program.teal"),
+			outFile:      stdoutFilenameValue,
+			expectedPath: abs(t, filepath.FromSlash("data/program.teal")),
 		},
 	}
 
@@ -66,8 +78,18 @@ func TestDeterminePathToSourceFromSourceMap(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			for sourceIndex, source := range []string{tc.sourceFile, abs(t, tc.sourceFile)} {
-				for outIndex, out := range []string{tc.outFile, abs(t, tc.outFile)} {
+
+			sources := []string{tc.sourceFile}
+			if tc.sourceFile != stdinFileNameValue {
+				sources = append(sources, abs(t, tc.sourceFile))
+			}
+			outs := []string{tc.outFile}
+			if tc.outFile != stdoutFilenameValue {
+				outs = append(outs, abs(t, tc.outFile))
+			}
+
+			for sourceIndex, source := range sources {
+				for outIndex, out := range outs {
 					actualPath, err := determinePathToSourceFromSourceMap(source, out)
 					require.NoError(t, err, "sourceIndex: %d, outIndex: %d", sourceIndex, outIndex)
 					require.Equal(t, tc.expectedPath, actualPath, "sourceIndex: %d, outIndex: %d", sourceIndex, outIndex)

--- a/cmd/goal/clerk_test.go
+++ b/cmd/goal/clerk_test.go
@@ -64,7 +64,7 @@ func TestDeterminePathToSourceFromSourceMap(t *testing.T) {
 			name:         "input stdin",
 			sourceFile:   stdinFileNameValue,
 			outFile:      "program.teal.tok",
-			expectedPath: "stdin",
+			expectedPath: "<stdin>",
 		},
 		{
 			name:         "output stdout",

--- a/cmd/goal/clerk_test.go
+++ b/cmd/goal/clerk_test.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2019-2023 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/stretchr/testify/require"
+)
+
+func abs(t *testing.T, path string) string {
+	t.Helper()
+	absPath, err := filepath.Abs(path)
+	require.NoError(t, err)
+	return absPath
+}
+
+func TestDeterminePathToSourceFromSourceMap(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		sourceFile string
+		outFile    string
+
+		expectedPath string
+	}{
+		{
+			name:         "same directory",
+			sourceFile:   filepath.FromSlash("data/program.teal"),
+			outFile:      filepath.FromSlash("data/program.teal.tok"),
+			expectedPath: "program.teal",
+		},
+		{
+			name:         "output one level up",
+			sourceFile:   filepath.FromSlash("data/program.teal"),
+			outFile:      filepath.FromSlash("data/output/program.teal.tok"),
+			expectedPath: filepath.FromSlash("../program.teal"),
+		},
+		{
+			name:         "output one level down",
+			sourceFile:   filepath.FromSlash("data/program.teal"),
+			outFile:      filepath.FromSlash("program.teal.tok"),
+			expectedPath: filepath.FromSlash("data/program.teal"),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			for sourceIndex, source := range []string{tc.sourceFile, abs(t, tc.sourceFile)} {
+				for outIndex, out := range []string{tc.outFile, abs(t, tc.outFile)} {
+					actualPath, err := determinePathToSourceFromSourceMap(source, out)
+					require.NoError(t, err, "sourceIndex: %d, outIndex: %d", sourceIndex, outIndex)
+					require.Equal(t, tc.expectedPath, actualPath, "sourceIndex: %d, outIndex: %d", sourceIndex, outIndex)
+				}
+			}
+		})
+	}
+}

--- a/cmd/tealdbg/debugger.go
+++ b/cmd/tealdbg/debugger.go
@@ -85,11 +85,11 @@ func MakeDebugger() *Debugger {
 }
 
 type programMeta struct {
-	name         string
-	program      []byte
-	source       string
-	offsetToLine map[int]int
-	states       AppState
+	name           string
+	program        []byte
+	source         string
+	offsetToSource map[int]logic.SourceLocation
+	states         AppState
 }
 
 // debugConfig contains information about control execution and breakpoints.
@@ -160,11 +160,11 @@ type session struct {
 	disassembly string
 	lines       []string
 
-	programName  string
-	program      []byte
-	source       string
-	offsetToLine map[int]int // pc to source line
-	pcOffset     map[int]int // disassembly line to pc
+	programName    string
+	program        []byte
+	source         string
+	offsetToSource map[int]logic.SourceLocation // pc to source line/col
+	pcOffset       map[int]int                  // disassembly line to pc
 
 	breakpoints []breakpoint
 	line        atomicInt
@@ -364,28 +364,27 @@ func (s *session) GetSourceMap() ([]byte, error) {
 	lines := make([]string, len(s.lines))
 	const targetCol int = 0
 	const sourceIdx int = 0
-	sourceLine := 0
-	const sourceCol int = 0
-	prevSourceLine := 0
+	prevLoc := logic.SourceLocation{Line: 0, Column: 0}
 
 	// the very first entry is needed by CDT
-	lines[0] = logic.MakeSourceMapLine(targetCol, sourceIdx, 0, sourceCol)
+	lines[0] = logic.MakeSourceMapLine(targetCol, sourceIdx, 0, 0)
 	for targetLine := 1; targetLine < len(s.lines); targetLine++ {
 		if pc, ok := s.pcOffset[targetLine]; ok && pc != 0 {
-			sourceLine, ok = s.offsetToLine[pc]
+			source, ok := s.offsetToSource[pc]
 			if !ok {
 				lines[targetLine] = ""
 			} else {
-				lines[targetLine] = logic.MakeSourceMapLine(targetCol, sourceIdx, sourceLine-prevSourceLine, sourceCol)
-				prevSourceLine = sourceLine
+				lines[targetLine] = logic.MakeSourceMapLine(targetCol, sourceIdx, source.Line-prevLoc.Line, source.Column-prevLoc.Column)
+				prevLoc = source
 			}
 		} else {
-			delta := 0
+			ldelta, cdelta := 0, 0
 			// the very last empty line, increment by number src number by 1
 			if targetLine == len(s.lines)-1 {
-				delta = 1
+				ldelta = 1
+				cdelta = -prevLoc.Column
 			}
-			lines[targetLine] = logic.MakeSourceMapLine(targetCol, sourceIdx, delta, sourceCol)
+			lines[targetLine] = logic.MakeSourceMapLine(targetCol, sourceIdx, ldelta, cdelta)
 		}
 	}
 
@@ -489,7 +488,7 @@ func (d *Debugger) createSession(sid string, disassembly string, line int, pcOff
 		s.programName = meta.name
 		s.program = meta.program
 		s.source = meta.source
-		s.offsetToLine = meta.offsetToLine
+		s.offsetToSource = meta.offsetToSource
 		s.pcOffset = pcOffset
 		s.states = meta.states
 	}
@@ -513,7 +512,7 @@ func (d *Debugger) AddAdapter(da DebugAdapter) {
 
 // SaveProgram stores program, source and offsetToLine for later use
 func (d *Debugger) SaveProgram(
-	name string, program []byte, source string, offsetToLine map[int]int,
+	name string, program []byte, source string, offsetToSource map[int]logic.SourceLocation,
 	states AppState,
 ) {
 	hash := logic.GetProgramID(program)
@@ -523,7 +522,7 @@ func (d *Debugger) SaveProgram(
 		name,
 		program,
 		source,
-		offsetToLine,
+		offsetToSource,
 		states,
 	}
 }

--- a/cmd/tealdbg/debugger_test.go
+++ b/cmd/tealdbg/debugger_test.go
@@ -130,15 +130,17 @@ func createSessionFromSource(t *testing.T, program string) *session {
 
 	// create a sample disassembly line to pc mapping
 	// this simple source is similar to disassembly except intcblock at the beginning
-	pcOffset := make(map[int]int, len(ops.OffsetToLine))
-	for pc, line := range ops.OffsetToLine {
-		pcOffset[line+1] = pc
+	offsetToLine := make(map[int]int, len(ops.OffsetToSource))
+	pcOffset := make(map[int]int, len(ops.OffsetToSource))
+	for pc, location := range ops.OffsetToSource {
+		offsetToLine[pc] = location.Line
+		pcOffset[location.Line+1] = pc
 	}
 
 	s := makeSession(disassembly, 0)
 	s.source = source
 	s.programName = "test"
-	s.offsetToLine = ops.OffsetToLine
+	s.offsetToLine = offsetToLine
 	s.pcOffset = pcOffset
 
 	return s

--- a/cmd/tealdbg/debugger_test.go
+++ b/cmd/tealdbg/debugger_test.go
@@ -130,17 +130,15 @@ func createSessionFromSource(t *testing.T, program string) *session {
 
 	// create a sample disassembly line to pc mapping
 	// this simple source is similar to disassembly except intcblock at the beginning
-	offsetToLine := make(map[int]int, len(ops.OffsetToSource))
 	pcOffset := make(map[int]int, len(ops.OffsetToSource))
 	for pc, location := range ops.OffsetToSource {
-		offsetToLine[pc] = location.Line
 		pcOffset[location.Line+1] = pc
 	}
 
 	s := makeSession(disassembly, 0)
 	s.source = source
 	s.programName = "test"
-	s.offsetToLine = offsetToLine
+	s.offsetToSource = ops.OffsetToSource
 	s.pcOffset = pcOffset
 
 	return s

--- a/cmd/tealdbg/local.go
+++ b/cmd/tealdbg/local.go
@@ -225,16 +225,16 @@ const (
 
 // evaluation is a description of a single debugger run
 type evaluation struct {
-	program      []byte
-	source       string
-	offsetToLine map[int]int
-	name         string
-	groupIndex   uint64
-	mode         modeType
-	aidx         basics.AppIndex
-	ba           apply.Balances
-	result       evalResult
-	states       AppState
+	program        []byte
+	source         string
+	offsetToSource map[int]logic.SourceLocation
+	name           string
+	groupIndex     uint64
+	mode           modeType
+	aidx           basics.AppIndex
+	ba             apply.Balances
+	result         evalResult
+	states         AppState
 }
 
 func (e *evaluation) eval(gi int, sep *logic.EvalParams, aep *logic.EvalParams) (pass bool, err error) {
@@ -395,11 +395,7 @@ func (r *LocalRunner) Setup(dp *DebugParams) (err error) {
 				}
 				r.runs[i].program = ops.Program
 				if !dp.DisableSourceMap {
-					offsetToLine := make(map[int]int, len(ops.OffsetToSource))
-					for pc, location := range ops.OffsetToSource {
-						offsetToLine[pc] = location.Line
-					}
-					r.runs[i].offsetToLine = offsetToLine
+					r.runs[i].offsetToSource = ops.OffsetToSource
 					r.runs[i].source = source
 				}
 			}
@@ -551,7 +547,7 @@ func (r *LocalRunner) RunAll() error {
 	for i := range r.runs {
 		run := &r.runs[i]
 		if r.debugger != nil {
-			r.debugger.SaveProgram(run.name, run.program, run.source, run.offsetToLine, run.states)
+			r.debugger.SaveProgram(run.name, run.program, run.source, run.offsetToSource, run.states)
 		}
 
 		run.result.pass, run.result.err = run.eval(int(run.groupIndex), sep, aep)

--- a/cmd/tealdbg/local.go
+++ b/cmd/tealdbg/local.go
@@ -395,7 +395,11 @@ func (r *LocalRunner) Setup(dp *DebugParams) (err error) {
 				}
 				r.runs[i].program = ops.Program
 				if !dp.DisableSourceMap {
-					r.runs[i].offsetToLine = ops.OffsetToLine
+					offsetToLine := make(map[int]int, len(ops.OffsetToSource))
+					for pc, location := range ops.OffsetToSource {
+						offsetToLine[pc] = location.Line
+					}
+					r.runs[i].offsetToLine = offsetToLine
 					r.runs[i].source = source
 				}
 			}

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -1660,7 +1660,7 @@ func (v2 *Handlers) TealCompile(ctx echo.Context, params model.TealCompileParams
 	// If source map flag is enabled, then return the map.
 	var sourcemap *logic.SourceMap
 	if *params.Sourcemap {
-		rawmap := logic.GetSourceMap([]string{"body.teal"}, ops.OffsetToSource)
+		rawmap := logic.GetSourceMap([]string{"<body>"}, ops.OffsetToSource)
 		sourcemap = &rawmap
 	}
 

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -1660,7 +1660,7 @@ func (v2 *Handlers) TealCompile(ctx echo.Context, params model.TealCompileParams
 	// If source map flag is enabled, then return the map.
 	var sourcemap *logic.SourceMap
 	if *params.Sourcemap {
-		rawmap := logic.GetSourceMap([]string{}, ops.OffsetToLine)
+		rawmap := logic.GetSourceMap([]string{}, ops.OffsetToSource)
 		sourcemap = &rawmap
 	}
 

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -1660,7 +1660,7 @@ func (v2 *Handlers) TealCompile(ctx echo.Context, params model.TealCompileParams
 	// If source map flag is enabled, then return the map.
 	var sourcemap *logic.SourceMap
 	if *params.Sourcemap {
-		rawmap := logic.GetSourceMap([]string{}, ops.OffsetToSource)
+		rawmap := logic.GetSourceMap([]string{"body.teal"}, ops.OffsetToSource)
 		sourcemap = &rawmap
 	}
 

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -1452,7 +1452,7 @@ int 1
 assert
 int 1`, logic.AssemblerMaxVersion)
 	ops, _ := logic.AssembleString(goodProgram)
-	expectedSourcemap := logic.GetSourceMap([]string{}, ops.OffsetToLine)
+	expectedSourcemap := logic.GetSourceMap([]string{}, ops.OffsetToSource)
 	goodProgramBytes := []byte(goodProgram)
 
 	// Test good program with params

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -1452,7 +1452,7 @@ int 1
 assert
 int 1`, logic.AssemblerMaxVersion)
 	ops, _ := logic.AssembleString(goodProgram)
-	expectedSourcemap := logic.GetSourceMap([]string{"body.teal"}, ops.OffsetToSource)
+	expectedSourcemap := logic.GetSourceMap([]string{"<body>"}, ops.OffsetToSource)
 	goodProgramBytes := []byte(goodProgram)
 
 	// Test good program with params

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -1452,7 +1452,7 @@ int 1
 assert
 int 1`, logic.AssemblerMaxVersion)
 	ops, _ := logic.AssembleString(goodProgram)
-	expectedSourcemap := logic.GetSourceMap([]string{}, ops.OffsetToSource)
+	expectedSourcemap := logic.GetSourceMap([]string{"body.teal"}, ops.OffsetToSource)
 	goodProgramBytes := []byte(goodProgram)
 
 	// Test good program with params

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2151,73 +2151,77 @@ func TestAssembleOffsets(t *testing.T) {
 	source := "err"
 	ops := testProg(t, source, AssemblerMaxVersion)
 	require.Equal(t, 2, len(ops.Program))
-	require.Equal(t, 1, len(ops.OffsetToLine))
+	require.Equal(t, 1, len(ops.OffsetToSource))
 	// vlen
-	line, ok := ops.OffsetToLine[0]
+	location, ok := ops.OffsetToSource[0]
 	require.False(t, ok)
-	require.Equal(t, 0, line)
+	require.Equal(t, SourceLocation{}, location)
 	// err
-	line, ok = ops.OffsetToLine[1]
+	location, ok = ops.OffsetToSource[1]
 	require.True(t, ok)
-	require.Equal(t, 0, line)
+	require.Equal(t, SourceLocation{}, location)
 
 	source = `err
 // comment
-err
+err; err
 `
 	ops = testProg(t, source, AssemblerMaxVersion)
-	require.Equal(t, 3, len(ops.Program))
-	require.Equal(t, 2, len(ops.OffsetToLine))
+	require.Equal(t, 4, len(ops.Program))
+	require.Equal(t, 3, len(ops.OffsetToSource))
 	// vlen
-	line, ok = ops.OffsetToLine[0]
+	location, ok = ops.OffsetToSource[0]
 	require.False(t, ok)
-	require.Equal(t, 0, line)
+	require.Equal(t, SourceLocation{}, location)
 	// err 1
-	line, ok = ops.OffsetToLine[1]
+	location, ok = ops.OffsetToSource[1]
 	require.True(t, ok)
-	require.Equal(t, 0, line)
+	require.Equal(t, SourceLocation{}, location)
 	// err 2
-	line, ok = ops.OffsetToLine[2]
+	location, ok = ops.OffsetToSource[2]
 	require.True(t, ok)
-	require.Equal(t, 2, line)
+	require.Equal(t, SourceLocation{Line: 2}, location)
+	// err 3
+	location, ok = ops.OffsetToSource[3]
+	require.True(t, ok)
+	require.Equal(t, SourceLocation{Line: 2, Column: 5}, location)
 
 	source = `err
 b label1
 err
 label1:
-err
+  err
 `
 	ops = testProg(t, source, AssemblerMaxVersion)
 	require.Equal(t, 7, len(ops.Program))
-	require.Equal(t, 4, len(ops.OffsetToLine))
+	require.Equal(t, 4, len(ops.OffsetToSource))
 	// vlen
-	line, ok = ops.OffsetToLine[0]
+	location, ok = ops.OffsetToSource[0]
 	require.False(t, ok)
-	require.Equal(t, 0, line)
+	require.Equal(t, SourceLocation{}, location)
 	// err 1
-	line, ok = ops.OffsetToLine[1]
+	location, ok = ops.OffsetToSource[1]
 	require.True(t, ok)
-	require.Equal(t, 0, line)
+	require.Equal(t, SourceLocation{}, location)
 	// b
-	line, ok = ops.OffsetToLine[2]
+	location, ok = ops.OffsetToSource[2]
 	require.True(t, ok)
-	require.Equal(t, 1, line)
+	require.Equal(t, SourceLocation{Line: 1}, location)
 	// b byte 1
-	line, ok = ops.OffsetToLine[3]
+	location, ok = ops.OffsetToSource[3]
 	require.False(t, ok)
-	require.Equal(t, 0, line)
+	require.Equal(t, SourceLocation{}, location)
 	// b byte 2
-	line, ok = ops.OffsetToLine[4]
+	location, ok = ops.OffsetToSource[4]
 	require.False(t, ok)
-	require.Equal(t, 0, line)
+	require.Equal(t, SourceLocation{}, location)
 	// err 2
-	line, ok = ops.OffsetToLine[5]
+	location, ok = ops.OffsetToSource[5]
 	require.True(t, ok)
-	require.Equal(t, 2, line)
+	require.Equal(t, SourceLocation{Line: 2}, location)
 	// err 3
-	line, ok = ops.OffsetToLine[6]
+	location, ok = ops.OffsetToSource[6]
 	require.True(t, ok)
-	require.Equal(t, 4, line)
+	require.Equal(t, SourceLocation{Line: 4, Column: 2}, location)
 
 	source = `pushint 0
 // comment
@@ -2225,23 +2229,23 @@ err
 `
 	ops = testProg(t, source, AssemblerMaxVersion)
 	require.Equal(t, 4, len(ops.Program))
-	require.Equal(t, 2, len(ops.OffsetToLine))
+	require.Equal(t, 2, len(ops.OffsetToSource))
 	// vlen
-	line, ok = ops.OffsetToLine[0]
+	location, ok = ops.OffsetToSource[0]
 	require.False(t, ok)
-	require.Equal(t, 0, line)
+	require.Equal(t, SourceLocation{}, location)
 	// pushint
-	line, ok = ops.OffsetToLine[1]
+	location, ok = ops.OffsetToSource[1]
 	require.True(t, ok)
-	require.Equal(t, 0, line)
+	require.Equal(t, SourceLocation{}, location)
 	// pushint byte 1
-	line, ok = ops.OffsetToLine[2]
+	location, ok = ops.OffsetToSource[2]
 	require.False(t, ok)
-	require.Equal(t, 0, line)
+	require.Equal(t, SourceLocation{}, location)
 	// !
-	line, ok = ops.OffsetToLine[3]
+	location, ok = ops.OffsetToSource[3]
 	require.True(t, ok)
-	require.Equal(t, 2, line)
+	require.Equal(t, SourceLocation{Line: 2}, location)
 }
 
 func TestHasStatefulOps(t *testing.T) {

--- a/data/transactions/logic/sourcemap.go
+++ b/data/transactions/logic/sourcemap.go
@@ -41,21 +41,21 @@ type SourceMap struct {
 
 // GetSourceMap returns a struct containing details about
 // the assembled file and encoded mappings to the source file.
-func GetSourceMap(sourceNames []string, offsetToLine map[int]int) SourceMap {
+func GetSourceMap(sourceNames []string, offsetToLocation map[int]SourceLocation) SourceMap {
 	maxPC := 0
-	for pc := range offsetToLine {
+	for pc := range offsetToLocation {
 		if pc > maxPC {
 			maxPC = pc
 		}
 	}
 
 	// Array where index is the PC and value is the line for `mappings` field.
-	prevSourceLine := 0
+	prevSourceLocation := SourceLocation{}
 	pcToLine := make([]string, maxPC+1)
 	for pc := range pcToLine {
-		if line, ok := offsetToLine[pc]; ok {
-			pcToLine[pc] = MakeSourceMapLine(0, 0, line-prevSourceLine, 0)
-			prevSourceLine = line
+		if location, ok := offsetToLocation[pc]; ok {
+			pcToLine[pc] = MakeSourceMapLine(0, 0, location.Line-prevSourceLocation.Line, location.Column-prevSourceLocation.Column)
+			prevSourceLocation = location
 		} else {
 			pcToLine[pc] = ""
 		}

--- a/data/transactions/logic/sourcemap_test.go
+++ b/data/transactions/logic/sourcemap_test.go
@@ -17,7 +17,6 @@
 package logic
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/algorand/go-algorand/test/partitiontest"
@@ -30,28 +29,22 @@ func TestGetSourceMap(t *testing.T) {
 	a := require.New(t)
 
 	sourceNames := []string{"test.teal"}
-	offsetToLine := map[int]int{
-		1: 1,
-		2: 2,
-		5: 3,
+	offsetToLocation := map[int]SourceLocation{
+		1:  {Line: 1},
+		2:  {Line: 2},
+		5:  {Line: 3},
+		6:  {Line: 3, Column: 1},
+		7:  {Line: 4},
+		8:  {Line: 5, Column: 5},
+		9:  {Line: 5, Column: 6},
+		10: {Line: 6},
 	}
-	actualSourceMap := GetSourceMap(sourceNames, offsetToLine)
+	actualSourceMap := GetSourceMap(sourceNames, offsetToLocation)
 
 	a.Equal(sourceMapVersion, actualSourceMap.Version)
 	a.Equal(sourceNames, actualSourceMap.Sources)
 	a.Equal([]string{}, actualSourceMap.Names)
-
-	// Check encoding for `mappings` field.
-	splitMappings := strings.Split(actualSourceMap.Mappings, ";")
-	prevLine := 0
-	for pc := range splitMappings {
-		if line, ok := offsetToLine[pc]; ok {
-			a.Equal(MakeSourceMapLine(0, 0, line-prevLine, 0), splitMappings[pc])
-			prevLine = line
-		} else {
-			a.Equal("", splitMappings[pc])
-		}
-	}
+	a.Equal(";AACA;AACA;;;AACA;AAAC;AACD;AACK;AAAC;AACN", actualSourceMap.Mappings)
 }
 
 func TestVLQ(t *testing.T) {

--- a/test/scripts/e2e_subs/e2e-teal.sh
+++ b/test/scripts/e2e_subs/e2e-teal.sh
@@ -157,7 +157,14 @@ printf '\x02' | dd of=${TEMPDIR}/true2.lsig bs=1 seek=0 count=1 conv=notrunc
 ${gcmd} clerk compile ${TEAL}/quine.teal -m
 trap 'rm ${TEAL}/quine.teal.*' EXIT
 if ! diff ${TEAL}/quine.map ${TEAL}/quine.teal.tok.map; then
-    echo "produced source maps do not match"
+    echo "produced source maps do not match: ${TEAL}/quine.map vs ${TEAL}/quine.teal.tok.map"
+    exit 1
+fi
+
+${gcmd} clerk compile ${TEAL}/sourcemap-test.teal -m
+trap 'rm ${TEAL}/sourcemap-test.teal.*' EXIT
+if ! diff ${TEAL}/sourcemap-test.map ${TEAL}/sourcemap-test.teal.tok.map; then
+    echo "produced source maps do not match: ${TEAL}/sourcemap-test.map vs ${TEAL}/sourcemap-test.teal.tok.map"
     exit 1
 fi
 

--- a/test/scripts/e2e_subs/tealprogs/quine.map
+++ b/test/scripts/e2e_subs/tealprogs/quine.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["test/scripts/e2e_subs/tealprogs/quine.teal"],"names":[],"mappings":";AAOA;;;;;;;;;;;;;;;;;;;;;;;;;;;;AACA;AACA;;;AACA;;;AACA;AACA;;AACA;AACA;;;AACA;AACA;AACA;;AACA;;AACA;AACA;AACA"}
+{"version":3,"sources":["quine.teal"],"names":[],"mappings":";AAOA;;;;;;;;;;;;;;;;;;;;;;;;;;;;AACA;AACA;;;AACA;;;AACA;AACA;;AACA;AACA;;;AACA;AACA;AACA;;AACA;;AACA;AACA;AACA"}

--- a/test/scripts/e2e_subs/tealprogs/sourcemap-test.map
+++ b/test/scripts/e2e_subs/tealprogs/sourcemap-test.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["test/scripts/e2e_subs/tealprogs/sourcemap-test.teal"],"names":[],"mappings":";;;;AAGA;;AAAmB;;AAAO;AAAI;;;AAE9B;;AAAO;;AAAO;AACd;;AAAO;AAAO;AALO;AAAI;AASrB;AACA"}

--- a/test/scripts/e2e_subs/tealprogs/sourcemap-test.map
+++ b/test/scripts/e2e_subs/tealprogs/sourcemap-test.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["test/scripts/e2e_subs/tealprogs/sourcemap-test.teal"],"names":[],"mappings":";;;;AAGA;;AAAmB;;AAAO;AAAI;;;AAE9B;;AAAO;;AAAO;AACd;;AAAO;AAAO;AALO;AAAI;AASrB;AACA"}
+{"version":3,"sources":["sourcemap-test.teal"],"names":[],"mappings":";;;;AAGA;;AAAmB;;AAAO;AAAI;;;AAE9B;;AAAO;;AAAO;AACd;;AAAO;AAAO;AALO;AAAI;AASrB;AACA"}

--- a/test/scripts/e2e_subs/tealprogs/sourcemap-test.teal
+++ b/test/scripts/e2e_subs/tealprogs/sourcemap-test.teal
@@ -1,0 +1,12 @@
+#pragma version 9
+#define assertEquals ==; assert
+
+txn ApplicationID; int 0; ==; bz create
+
+int 3; int 4; +;
+int 6; int 1; +;
+assertEquals
+
+create:
+    int 1
+    return


### PR DESCRIPTION
## Summary

Prior to this, TEAL source maps would only map PCs to line numbers, always assuming the column was 0. Since multiple opcodes can now be placed on a single line, separated by `;`, it makes sense to also report the source column as well.

Additionally, I also made the path to the source file relative to the source map file, which is what the specification requires (see [Resolving Sources](https://sourcemaps.info/spec.html#h.75yo6yoyk7x5)). Prior to this PR, we were just using whatever the user input as the source program path.

## Test Plan

Existing unit tests updated and added an additional e2e test to expand coverage of more complicated cases.
