### PR TITLE
AVM: Cleanly handle broken switch/match programs

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -998,6 +998,7 @@ func asmBranch(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourc
 	return nil
 }
 
+// asmSwitch assembles switch and match opcodes
 func asmSwitch(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceError {
 	numOffsets := len(args)
 	if numOffsets > math.MaxUint8 {


### PR DESCRIPTION
Previously, AVM panic'd while checking a malformed switch/match that was missing the byte encoding the number of cases. This meant the check failed, which is correct, but we endeavor to avoid panics.
