### PR TITLE
tests: Fix flaky TestAccountSelected test

### DIFF
--- a/data/committee/common_test.go
+++ b/data/committee/common_test.go
@@ -89,7 +89,7 @@ func testingenvMoreKeys(t testing.TB, numAccounts, numTxs int, keyBatchesForward
 	}
 
 	var seed Seed
-	rand.Read(seed[:])
+	gen.Read(seed[:])
 
 	tx := make([]transactions.SignedTxn, TXs)
 	for i := 0; i < TXs; i++ {
@@ -115,7 +115,7 @@ func testingenvMoreKeys(t testing.TB, numAccounts, numTxs int, keyBatchesForward
 				Amount:   amt,
 			},
 		}
-		rand.Read(t.Note)
+		gen.Read(t.Note)
 		tx[i] = t.Sign(secrets[send])
 	}
 

--- a/data/committee/common_test.go
+++ b/data/committee/common_test.go
@@ -57,6 +57,9 @@ func testingenv(t testing.TB, numAccounts, numTxs int, seedGen io.Reader) (selec
 }
 
 func testingenvMoreKeys(t testing.TB, numAccounts, numTxs int, keyBatchesForward uint, seedGen io.Reader) (selectionParameterFn, selectionParameterListFn, basics.Round, []basics.Address, []*crypto.SignatureSecrets, []*crypto.VrfPrivkey, []*crypto.OneTimeSignatureSecrets, []transactions.SignedTxn) {
+	if seedGen == nil {
+		seedGen = rand.New(rand.NewSource(1)) // same source as setting GODEBUG=randautoseed=0, same as pre-Go 1.20 default seed
+	}
 	P := numAccounts          // n accounts
 	TXs := numTxs             // n txns
 	maxMoneyAtStart := 100000 // max money start

--- a/data/committee/common_test.go
+++ b/data/committee/common_test.go
@@ -47,11 +47,11 @@ func signTx(s *crypto.SignatureSecrets, t transactions.Transaction) transactions
 	return t.Sign(s)
 }
 
-func testingenv(t testing.TB, numAccounts, numTxs int) (selectionParameterFn, selectionParameterListFn, basics.Round, []basics.Address, []*crypto.SignatureSecrets, []*crypto.VrfPrivkey, []*crypto.OneTimeSignatureSecrets, []transactions.SignedTxn) {
-	return testingenvMoreKeys(t, numAccounts, numTxs, uint(5))
+func testingenv(t testing.TB, numAccounts, numTxs int, seedGen io.Reader) (selectionParameterFn, selectionParameterListFn, basics.Round, []basics.Address, []*crypto.SignatureSecrets, []*crypto.VrfPrivkey, []*crypto.OneTimeSignatureSecrets, []transactions.SignedTxn) {
+	return testingenvMoreKeys(t, numAccounts, numTxs, uint(5), seedGen)
 }
 
-func testingenvMoreKeys(t testing.TB, numAccounts, numTxs int, keyBatchesForward uint) (selectionParameterFn, selectionParameterListFn, basics.Round, []basics.Address, []*crypto.SignatureSecrets, []*crypto.VrfPrivkey, []*crypto.OneTimeSignatureSecrets, []transactions.SignedTxn) {
+func testingenvMoreKeys(t testing.TB, numAccounts, numTxs int, keyBatchesForward uint, seedGen io.Reader) (selectionParameterFn, selectionParameterListFn, basics.Round, []basics.Address, []*crypto.SignatureSecrets, []*crypto.VrfPrivkey, []*crypto.OneTimeSignatureSecrets, []transactions.SignedTxn) {
 	P := numAccounts          // n accounts
 	TXs := numTxs             // n txns
 	maxMoneyAtStart := 100000 // max money start
@@ -89,7 +89,7 @@ func testingenvMoreKeys(t testing.TB, numAccounts, numTxs int, keyBatchesForward
 	}
 
 	var seed Seed
-	gen.Read(seed[:])
+	seedGen.Read(seed[:])
 
 	tx := make([]transactions.SignedTxn, TXs)
 	for i := 0; i < TXs; i++ {
@@ -115,7 +115,7 @@ func testingenvMoreKeys(t testing.TB, numAccounts, numTxs int, keyBatchesForward
 				Amount:   amt,
 			},
 		}
-		gen.Read(t.Note)
+		seedGen.Read(t.Note) // to match output from previous versions, which shared global RNG for seed & note
 		tx[i] = t.Sign(secrets[send])
 	}
 

--- a/data/committee/common_test.go
+++ b/data/committee/common_test.go
@@ -47,6 +47,11 @@ func signTx(s *crypto.SignatureSecrets, t transactions.Transaction) transactions
 	return t.Sign(s)
 }
 
+// testingenv creates a random set of participating accounts and random transactions between them, and
+// the associated selection parameters for use testing committee membership and credential validation.
+// seedGen is provided as an external source of randomness for the selection seed and transaction notes;
+// if the caller persists seedGen between calls to testingenv, each iteration that calls testingenv will
+// exercise a new selection seed.
 func testingenv(t testing.TB, numAccounts, numTxs int, seedGen io.Reader) (selectionParameterFn, selectionParameterListFn, basics.Round, []basics.Address, []*crypto.SignatureSecrets, []*crypto.VrfPrivkey, []*crypto.OneTimeSignatureSecrets, []transactions.SignedTxn) {
 	return testingenvMoreKeys(t, numAccounts, numTxs, uint(5), seedGen)
 }

--- a/data/committee/credential_test.go
+++ b/data/committee/credential_test.go
@@ -98,7 +98,7 @@ func TestAccountSelected(t *testing.T) {
 func TestRichAccountSelected(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 10, 2000, rand.New(rand.NewSource(1)))
+	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 10, 2000, nil)
 
 	period := Period(0)
 	ok, record, selectionSeed, _ := selParams(addresses[0])
@@ -281,7 +281,7 @@ func TestNoMoneyAccountNotSelected(t *testing.T) {
 func TestLeadersSelected(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000, rand.New(rand.NewSource(1)))
+	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000, nil)
 
 	period := Period(0)
 	step := Propose
@@ -313,7 +313,7 @@ func TestLeadersSelected(t *testing.T) {
 func TestCommitteeSelected(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000, rand.New(rand.NewSource(1)))
+	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000, nil)
 
 	period := Period(0)
 	step := Soft
@@ -345,7 +345,7 @@ func TestCommitteeSelected(t *testing.T) {
 func TestAccountNotSelected(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000, rand.New(rand.NewSource(1)))
+	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000, nil)
 	period := Period(0)
 	leaders := uint64(0)
 	for i := range addresses {
@@ -375,7 +375,7 @@ func TestAccountNotSelected(t *testing.T) {
 
 // TODO update to remove VRF verification overhead
 func BenchmarkSortition(b *testing.B) {
-	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(b, 100, 2000, rand.New(rand.NewSource(1)))
+	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(b, 100, 2000, nil)
 
 	period := Period(0)
 	step := Soft

--- a/data/committee/credential_test.go
+++ b/data/committee/credential_test.go
@@ -20,6 +20,7 @@ import (
 	"math/rand" // used for replicability of sortition benchmark
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/data/basics"
@@ -31,9 +32,10 @@ import (
 func TestAccountSelected(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
+	seedGen := rand.New(rand.NewSource(1))
 	N := 1
 	for i := 0; i < N; i++ {
-		selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000)
+		selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000, seedGen)
 		period := Period(0)
 
 		leaders := uint64(0)
@@ -85,13 +87,18 @@ func TestAccountSelected(t *testing.T) {
 		if (committee < uint64(0.8*float64(step.CommitteeSize(proto)))) || (committee > uint64(1.2*float64(step.CommitteeSize(proto)))) {
 			t.Errorf("bad number of committee members %v expected %v", committee, step.CommitteeSize(proto))
 		}
+		if i == 0 {
+			// pin down deterministic outputs for first iteration
+			assert.EqualValues(t, 17, leaders)
+			assert.EqualValues(t, 2918, committee)
+		}
 	}
 }
 
 func TestRichAccountSelected(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 10, 2000)
+	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 10, 2000, rand.New(rand.NewSource(1)))
 
 	period := Period(0)
 	ok, record, selectionSeed, _ := selParams(addresses[0])
@@ -139,16 +146,20 @@ func TestRichAccountSelected(t *testing.T) {
 	if (ccred.Weight < uint64(0.4*float64(step.CommitteeSize(proto)))) || (ccred.Weight > uint64(.6*float64(step.CommitteeSize(proto)))) {
 		t.Errorf("bad number of committee members %v expected %v", ccred.Weight, step.CommitteeSize(proto))
 	}
+	// pin down deterministic outputs, given initial seed values
+	assert.EqualValues(t, 6, lcred.Weight)
+	assert.EqualValues(t, 735, ccred.Weight)
 }
 
 func TestPoorAccountSelectedLeaders(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
+	seedGen := rand.New(rand.NewSource(1))
 	N := 2
 	failsLeaders := 0
 	leaders := make([]uint64, N)
 	for i := 0; i < N; i++ {
-		selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000)
+		selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000, seedGen)
 		period := Period(0)
 		for j := range addresses {
 			ok, record, selectionSeed, _ := selParams(addresses[j])
@@ -184,15 +195,19 @@ func TestPoorAccountSelectedLeaders(t *testing.T) {
 	if failsLeaders == 2 {
 		t.Errorf("bad number of leaders %v expected %v", leaders, proto.NumProposers)
 	}
+	// pin down deterministic outputs, given initial seed values
+	assert.EqualValues(t, 18, leaders[0])
+	assert.EqualValues(t, 20, leaders[1])
 }
 
 func TestPoorAccountSelectedCommittee(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
+	seedGen := rand.New(rand.NewSource(1))
 	N := 1
 	committee := uint64(0)
 	for i := 0; i < N; i++ {
-		selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000)
+		selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000, seedGen)
 		period := Period(0)
 
 		step := Cert
@@ -223,15 +238,19 @@ func TestPoorAccountSelectedCommittee(t *testing.T) {
 		if (committee < uint64(0.8*float64(step.CommitteeSize(proto)))) || (committee > uint64(1.2*float64(step.CommitteeSize(proto)))) {
 			t.Errorf("bad number of committee members %v expected %v", committee, step.CommitteeSize(proto))
 		}
+		if i == 0 { // pin down deterministic committee size, given initial seed value
+			assert.EqualValues(t, 1513, committee)
+		}
 	}
 }
 
 func TestNoMoneyAccountNotSelected(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
+	seedGen := rand.New(rand.NewSource(1))
 	N := 1
 	for i := 0; i < N; i++ {
-		selParams, _, round, addresses, _, _, _, _ := testingenv(t, 10, 2000)
+		selParams, _, round, addresses, _, _, _, _ := testingenv(t, 10, 2000, seedGen)
 		lookback := basics.Round(2*proto.SeedRefreshInterval + proto.SeedLookback + 1)
 		gen := rand.New(rand.NewSource(2))
 		_, _, zeroVRFSecret, _ := newAccount(t, gen, lookback, 5)
@@ -262,7 +281,7 @@ func TestNoMoneyAccountNotSelected(t *testing.T) {
 func TestLeadersSelected(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000)
+	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000, rand.New(rand.NewSource(1)))
 
 	period := Period(0)
 	step := Propose
@@ -294,7 +313,7 @@ func TestLeadersSelected(t *testing.T) {
 func TestCommitteeSelected(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000)
+	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000, rand.New(rand.NewSource(1)))
 
 	period := Period(0)
 	step := Soft
@@ -326,7 +345,7 @@ func TestCommitteeSelected(t *testing.T) {
 func TestAccountNotSelected(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000)
+	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(t, 100, 2000, rand.New(rand.NewSource(1)))
 	period := Period(0)
 	leaders := uint64(0)
 	for i := range addresses {
@@ -356,7 +375,7 @@ func TestAccountNotSelected(t *testing.T) {
 
 // TODO update to remove VRF verification overhead
 func BenchmarkSortition(b *testing.B) {
-	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(b, 100, 2000)
+	selParams, _, round, addresses, _, vrfSecrets, _, _ := testingenv(b, 100, 2000, rand.New(rand.NewSource(1)))
 
 	period := Period(0)
 	step := Soft


### PR DESCRIPTION
## Summary

Go 1.20 [introduced a change](https://go.dev/doc/go1.20#math/rand) to math/rand that seeds the global RNG with a random value. This test `TestAccountSelected` was previously relying on the fixed-seed global RNG for deterministic behavior. There was already a non-global random generator [used for this test in testingEnvMoreKeys](https://github.com/algorand/go-algorand/blob/6c482ab1286bfc2b1b09b80cb55f8c52817fcc96/data/committee/common_test.go#L65), but it was not used for two usages of the global RNG to so different values would be produced for multiple iterations calling `testingEnv`.

Running with `GODEBUG=randautoseed=0` and extra logging revealed the difference between the old and new behavior.

## Test Plan

Existing tests should pass, and the number of leaders chosen in this test is unchanged, the same as when `GODEBUG=randautoseed=0` is set.

Hardened these tests further by asserting the leader & committee sizes checked by these tests match the deterministic values used since #716 and #1094 (the last consensus-gated change to this package). The values being asserted came from extra logging added to checkouts of ec4d9b5fc7f9303528b4ddf9041cdad217852b92 and 566855e77d3d5600eeeb6016fa30c607e6e02864 on Ubuntu 18.04 with Go 1.12.17, and boost 1.65.1. These values were reproduced in this PR after adding a `rand.New(rand.NewSource(1))` to generate the sequence of seeds, matching the previous behavior before Go 1.20.