### PR TITLE
CICD: Fix RPM repository updating

### DIFF
--- a/docker/build/cicd.centos8.Dockerfile
+++ b/docker/build/cicd.centos8.Dockerfile
@@ -3,7 +3,8 @@ ARG ARCH="amd64"
 FROM quay.io/centos/centos:stream8
 ARG GOLANG_VERSION
 ARG ARCH="amd64"
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+RUN dnf update rpm -y && \
+    dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     dnf update -y && \
     dnf install -y autoconf wget awscli git gnupg2 nfs-utils python3-devel expect jq \
     libtool gcc-c++ libstdc++-devel rpmdevtools createrepo rpm-sign bzip2 which \

--- a/package-deploy.yaml
+++ b/package-deploy.yaml
@@ -45,8 +45,8 @@ agents:
     workDir: $HOME/projects/go-algorand
 
   - name: rpm
-    dockerFilePath: docker/build/cicd.centos.Dockerfile
-    image: algorand/go-algorand-ci-linux-centos
+    dockerFilePath: docker/build/cicd.centos8.Dockerfile
+    image: algorand/go-algorand-ci-linux-centos8
     version: scripts/configure_dev-deps.sh
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
@@ -54,9 +54,10 @@ agents:
       - AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
       - NETWORK=$NETWORK
-      - PACKAGES_DIR=$PACKAGES_DIR
       - NO_DEPLOY=$NO_DEPLOY
+      - PACKAGES_DIR=$PACKAGES_DIR
       - S3_SOURCE=$S3_SOURCE
+      - STAGING=$STAGING
       - VERSION=$VERSION
     volumes:
       - $XDG_RUNTIME_DIR/gnupg/S.gpg-agent:/root/.gnupg/S.gpg-agent

--- a/scripts/release/mule/deploy/rpm/deploy.sh
+++ b/scripts/release/mule/deploy/rpm/deploy.sh
@@ -51,20 +51,14 @@ echo "wat" | gpg -u rpm@algorand.com --clearsign
 
 cat << EOF > .rpmmacros
 %_gpg_name Algorand RPM <rpm@algorand.com>
-%__gpg /root/gnupg2/bin/gpg
+%__gpg /usr/bin/gpg2
 %__gpg_check_password_cmd true
-EOF
-
-cat << EOF > rpmsign.py
-import rpm
-import sys
-rpm.addSign(sys.argv[1], '')
 EOF
 
 mkdir rpmrepo
 for rpm in $(ls *"$VERSION"*.rpm)
 do
-    python3 rpmsign.py "$rpm"
+    rpmsign --addsign "$rpm"
     cp -p "$rpm" rpmrepo
 done
 

--- a/scripts/release/mule/deploy/rpm/deploy.sh
+++ b/scripts/release/mule/deploy/rpm/deploy.sh
@@ -17,24 +17,24 @@ VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
 NO_DEPLOY=${NO_DEPLOY:-false}
 OS_TYPE=$(./scripts/release/mule/common/ostype.sh)
 PACKAGES_DIR=${PACKAGES_DIR:-"./tmp/node_pkgs/$OS_TYPE/$ARCH_TYPE"}
+STAGING=${STAGING:-"algorand-staging/releases"}
 
 if [ -n "$S3_SOURCE" ]
 then
     PREFIX="$S3_SOURCE/$CHANNEL/$VERSION"
-
-    aws s3 cp "s3://$PREFIX/algorand-$VERSION-1.x86_64.rpm" /root
-    aws s3 cp "s3://$PREFIX/algorand-devtools-$VERSION-1.x86_64.rpm" /root
+    if [ "$CHANNEL" == "beta" ]
+    then
+        aws s3 cp "s3://$PREFIX/algorand-beta-$VERSION-1.x86_64.rpm" /root
+        aws s3 cp "s3://$PREFIX/algorand-devtools-beta-$VERSION-1.x86_64.rpm" /root
+    else
+        aws s3 cp "s3://$PREFIX/algorand-$VERSION-1.x86_64.rpm" /root
+        aws s3 cp "s3://$PREFIX/algorand-devtools-$VERSION-1.x86_64.rpm" /root
+    fi
 else
     cp "$PACKAGES_DIR"/*"$VERSION"*.rpm /root
 fi
 
 pushd /root
-
-aws s3 cp s3://algorand-devops-misc/tools/gnupg2.2.9_centos7_amd64.tar.bz2 .
-tar jxf gnupg*.tar.bz2
-
-export PATH="/root/gnupg2/bin:$PATH"
-export LD_LIBRARY_PATH=/root/gnupg2/lib
 
 mkdir -p .gnupg
 chmod 400 .gnupg
@@ -64,7 +64,7 @@ EOF
 mkdir rpmrepo
 for rpm in $(ls *"$VERSION"*.rpm)
 do
-    python2 rpmsign.py "$rpm"
+    python3 rpmsign.py "$rpm"
     cp -p "$rpm" rpmrepo
 done
 
@@ -79,7 +79,7 @@ then
 else
     aws s3 sync rpmrepo "s3://algorand-releases/rpm/$CHANNEL/"
     # sync signatures to releases so that the .sig files load from there
-    aws s3 sync s3://$S3_SOURCE/releases/$CHANNEL/ s3://algorand-releases/rpm/sigs/$CHANNEL/ --exclude='*' --include='*.rpm.sig'
+    aws s3 sync s3://$STAGING/releases/$CHANNEL/ s3://algorand-releases/rpm/sigs/$CHANNEL/ --exclude='*' --include='*.rpm.sig'
 fi
 
 echo


### PR DESCRIPTION
## Summary

This was broken because of adding an S3 sync of signatures, but there were other issues uncovered.

- Fixed centos 8 base image, which needed to update RPM
- Updated repository updater to use centos 8 base image
- Updated RPM signing and removed python script dependency

Note that the beta channel RPM repository has been non-functional to date, due to lack of a repo definition file, which was fixed as part of this testing.

The purpose of this was to narrowly fix the repository issue, However a closer look at simplifying this process is recommended in the future.

## Test Plan

Re-ran the update for the beta release. Verified signatures validated with RPM key.

These changes should be cherry-picked into the next stable release as well.
