### PR TITLE
catchup: pause catchup if ledger lagging behind

### DIFF
--- a/catchup/service.go
+++ b/catchup/service.go
@@ -36,7 +36,6 @@ import (
 	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/util/execpool"
-	"github.com/algorand/go-algorand/util/metrics"
 )
 
 const catchupPeersForSync = 10
@@ -295,7 +294,6 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 
 		// Try to fetch, timing out after retryInterval
 		block, cert, blockDownloadDuration, err := s.innerFetch(ctx, r, peer)
-		totalBlocksFetched.Inc(nil)
 
 		if err != nil {
 			if err == errLedgerAlreadyHasBlock {
@@ -857,5 +855,3 @@ func createPeerSelector(net network.GossipNode, cfg config.Local, pipelineFetch 
 	}
 	return makePeerSelector(net, peerClasses)
 }
-
-var totalBlocksFetched = metrics.MakeCounter(metrics.MetricName{Name: "algod_catchup_blocks_fetched", Description: "Total number of blocks fetched with catchup"})

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -88,7 +88,7 @@ type Service struct {
 	blockValidationPool execpool.BacklogPool
 
 	// suspendForLedgerOps defines whether we've run into a state where the ledger is currently busy writing the
-	// catchpoint file. If so, we want to suspend the catchup process until the catchpoint file writing is complete,
+	// catchpoint file or flushing accounts. If so, we want to suspend the catchup process until the catchpoint file writing is complete,
 	// and resume from there without stopping the catchup timer.
 	suspendForLedgerOps bool
 

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -501,7 +501,7 @@ func (s *Service) pipelinedFetch(seedLookback uint64) {
 				time.Sleep(100 * time.Millisecond)
 			}
 
-			// if ledger is still busy after s.deadlineTimeout timeout then about the current pipelinedFetch invocation.
+			// if ledger is still busy after s.deadlineTimeout timeout then abort the current pipelinedFetch invocation.
 
 			// if we're writing a catchpoint file, stop catching up to reduce the memory pressure. Once we finish writing the file we
 			// could resume with the catchup.

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -830,16 +830,16 @@ func (m *mockedLedger) IsWritingCatchpointDataFile() bool {
 	return false
 }
 
-func (m *mockedLedger) Available() bool {
-	return true
+func (m *mockedLedger) IsBehindCommittingDeltas() bool {
+	return false
 }
 
-type mockedUnavalLedger struct {
+type mockedBehindDeltasLedger struct {
 	mockedLedger
 }
 
-func (m *mockedUnavalLedger) Available() bool {
-	return false
+func (m *mockedBehindDeltasLedger) IsBehindCommittingDeltas() bool {
+	return true
 }
 
 func testingenvWithUpgrade(
@@ -1145,7 +1145,7 @@ func TestServiceLedgerUnavailable(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	// Make Ledger
-	local := new(mockedUnavalLedger)
+	local := new(mockedBehindDeltasLedger)
 	local.blocks = append(local.blocks, bookkeeping.Block{})
 
 	remote, _, blk, err := buildTestLedger(t, bookkeeping.Block{})

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -830,6 +830,10 @@ func (m *mockedLedger) IsWritingCatchpointDataFile() bool {
 	return false
 }
 
+func (m *mockedLedger) Available() bool {
+	return true
+}
+
 func testingenvWithUpgrade(
 	t testing.TB,
 	numBlocks,

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -1173,7 +1173,9 @@ func TestServiceLedgerUnavailable(t *testing.T) {
 
 	// Make Service
 	auth := &mockedAuthenticator{fail: false}
-	s := MakeService(logging.Base(), defaultConfig, net, local, auth, nil, nil)
+	cfg := config.GetDefaultLocal()
+	cfg.CatchupParallelBlocks = 2
+	s := MakeService(logging.Base(), cfg, net, local, auth, nil, nil)
 	s.log = &periodicSyncLogger{Logger: logging.Base()}
 	s.deadlineTimeout = 2 * time.Second
 

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -738,13 +738,6 @@ func (au *accountUpdates) totalsImpl(rnd basics.Round) (ledgercore.AccountTotals
 	return au.roundTotals[offset], nil
 }
 
-func (au *accountUpdates) numDeltas() uint64 {
-	au.accountsMu.RLock()
-	numDeltas := uint64(len(au.deltas))
-	au.accountsMu.RUnlock()
-	return numDeltas
-}
-
 // initializeFromDisk performs the atomic operation of loading the accounts data information from disk
 // and preparing the accountUpdates for operation.
 func (au *accountUpdates) initializeFromDisk(l ledgerForTracker, lastBalancesRound basics.Round) error {

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -738,6 +738,13 @@ func (au *accountUpdates) totalsImpl(rnd basics.Round) (ledgercore.AccountTotals
 	return au.roundTotals[offset], nil
 }
 
+func (au *accountUpdates) numDeltas() uint64 {
+	au.accountsMu.RLock()
+	numDeltas := uint64(len(au.deltas))
+	au.accountsMu.RUnlock()
+	return numDeltas
+}
+
 // initializeFromDisk performs the atomic operation of loading the accounts data information from disk
 // and preparing the accountUpdates for operation.
 func (au *accountUpdates) initializeFromDisk(l ledgerForTracker, lastBalancesRound basics.Round) error {

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -773,6 +773,7 @@ func TestCatchpointReproducibleLabels(t *testing.T) {
 
 // blockingTracker is a testing tracker used to test "what if" a tracker would get blocked.
 type blockingTracker struct {
+	emptyTracker
 	postCommitUnlockedEntryLock   chan struct{}
 	postCommitUnlockedReleaseLock chan struct{}
 	postCommitEntryLock           chan struct{}
@@ -783,34 +784,10 @@ type blockingTracker struct {
 	shouldLockPostCommitUnlocked  atomic.Bool
 }
 
-// loadFromDisk is not implemented in the blockingTracker.
-func (bt *blockingTracker) loadFromDisk(ledgerForTracker, basics.Round) error {
-	return nil
-}
-
-// newBlock is not implemented in the blockingTracker.
-func (bt *blockingTracker) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {
-}
-
 // committedUpTo in the blockingTracker just stores the committed round.
 func (bt *blockingTracker) committedUpTo(committedRnd basics.Round) (minRound, lookback basics.Round) {
 	atomic.StoreInt64(&bt.committedUpToRound, int64(committedRnd))
 	return committedRnd, basics.Round(0)
-}
-
-// produceCommittingTask is not used by the blockingTracker
-func (bt *blockingTracker) produceCommittingTask(committedRound basics.Round, dbRound basics.Round, dcr *deferredCommitRange) *deferredCommitRange {
-	return dcr
-}
-
-// prepareCommit, is not used by the blockingTracker
-func (bt *blockingTracker) prepareCommit(*deferredCommitContext) error {
-	return nil
-}
-
-// commitRound is not used by the blockingTracker
-func (bt *blockingTracker) commitRound(context.Context, trackerdb.TransactionScope, *deferredCommitContext) error {
-	return nil
 }
 
 // postCommit implements entry/exit blockers, designed for testing.
@@ -827,18 +804,6 @@ func (bt *blockingTracker) postCommitUnlocked(ctx context.Context, dcc *deferred
 		bt.postCommitUnlockedEntryLock <- struct{}{}
 		<-bt.postCommitUnlockedReleaseLock
 	}
-}
-
-// control functions are not used by the blockingTracker
-func (bt *blockingTracker) handleUnorderedCommit(dcc *deferredCommitContext) {
-}
-func (bt *blockingTracker) handlePrepareCommitError(dcc *deferredCommitContext) {
-}
-func (bt *blockingTracker) handleCommitError(dcc *deferredCommitContext) {
-}
-
-// close is not used by the blockingTracker
-func (bt *blockingTracker) close() {
 }
 
 func TestCatchpointTrackerNonblockingCatchpointWriting(t *testing.T) {

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -898,10 +898,10 @@ func (l *Ledger) LatestTrackerCommitted() basics.Round {
 	return l.trackers.getDbRound()
 }
 
-// Available returns indicates if the ledger is can safely accept more blocks.
-// It is intended use with catchup to slowdown when deltas overgrow some limit.
-func (l *Ledger) Available() bool {
-	return l.trackers.available()
+// IsBehindCommittingDeltas indicates if the ledger is behind expected number of in-memory deltas.
+// It intended to slow down the catchup service when deltas overgrow some limit.
+func (l *Ledger) IsBehindCommittingDeltas() bool {
+	return l.trackers.isBehindCommittingDeltas()
 }
 
 // DebuggerLedger defines the minimal set of method required for creating a debug balances.

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -901,7 +901,7 @@ func (l *Ledger) LatestTrackerCommitted() basics.Round {
 // IsBehindCommittingDeltas indicates if the ledger is behind expected number of in-memory deltas.
 // It intended to slow down the catchup service when deltas overgrow some limit.
 func (l *Ledger) IsBehindCommittingDeltas() bool {
-	return l.trackers.isBehindCommittingDeltas()
+	return l.trackers.isBehindCommittingDeltas(l.Latest())
 }
 
 // DebuggerLedger defines the minimal set of method required for creating a debug balances.

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -898,20 +898,10 @@ func (l *Ledger) LatestTrackerCommitted() basics.Round {
 	return l.trackers.getDbRound()
 }
 
-// maxNonFlushedAccountRounds is a maximum number of not flushed yet account rounds (in-memory deltas)
-// that we allow to have before we stop the catchup process.
-// To many in-memory deltas can cause the node to run out of memory.
-const maxAccountDeltas = 256
-
 // Available returns indicates if the ledger is can safely accept more blocks.
 // It is intended use with catchup to slowdown when deltas overgrow some limit.
 func (l *Ledger) Available() bool {
-	deltas := l.Latest().SubSaturate(l.trackers.getDbRound())
-	if deltas < maxAccountDeltas {
-		return true
-	}
-
-	return !l.trackers.busy()
+	return l.trackers.available()
 }
 
 // DebuggerLedger defines the minimal set of method required for creating a debug balances.

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -898,6 +898,22 @@ func (l *Ledger) LatestTrackerCommitted() basics.Round {
 	return l.trackers.getDbRound()
 }
 
+// maxNonFlushedAccountRounds is a maximum number of not flushed yet account rounds (in-memory deltas)
+// that we allow to have before we stop the catchup process.
+// To many in-memory deltas can cause the node to run out of memory.
+const maxAccountDeltas = 256
+
+// Available returns indicates if the ledger is can safely accept more blocks.
+// It is intended use with catchup to slowdown when deltas overgrow some limit.
+func (l *Ledger) Available() bool {
+	deltas := l.Latest().SubSaturate(l.trackers.getDbRound())
+	if deltas < maxAccountDeltas {
+		return true
+	}
+
+	return !l.trackers.busy()
+}
+
 // DebuggerLedger defines the minimal set of method required for creating a debug balances.
 type DebuggerLedger = eval.LedgerForCowBase
 

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -307,7 +307,7 @@ func (tr *trackerRegistry) initialize(l ledgerForTracker, trackers []ledgerTrack
 	tr.maxAccountDeltas = defaultMaxAccountDeltas
 	if cfg.MaxAcctLookback > tr.maxAccountDeltas {
 		tr.maxAccountDeltas = cfg.MaxAcctLookback + 1
-		tr.log.Infof("maxAccountDeltas as overridden to %d because of MaxAcctLookback=%d: this combination might use lots of RAM. To preserve some blocks in blockdb consider using MaxBlockHistoryLookback config option instead of MaxAcctLookback", tr.maxAccountDeltas, cfg.MaxAcctLookback)
+		tr.log.Infof("maxAccountDeltas was overridden to %d because of MaxAcctLookback=%d: this combination might use lots of RAM. To preserve some blocks in blockdb consider using MaxBlockHistoryLookback config option instead of MaxAcctLookback", tr.maxAccountDeltas, cfg.MaxAcctLookback)
 	}
 
 	tr.ctx, tr.ctxCancel = context.WithCancel(context.Background())

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -473,8 +473,13 @@ func (tr *trackerRegistry) waitAccountsWriting() {
 	tr.accountsWriting.Wait()
 }
 
-func (tr *trackerRegistry) isBehindCommittingDeltas() bool {
-	if tr.accts.numDeltas() < tr.maxAccountDeltas {
+func (tr *trackerRegistry) isBehindCommittingDeltas(latest basics.Round) bool {
+	tr.mu.RLock()
+	dbRound := tr.dbRound
+	tr.mu.RUnlock()
+
+	numDeltas := uint64(latest.SubSaturate(dbRound))
+	if numDeltas < tr.maxAccountDeltas {
 		return false
 	}
 

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -307,7 +307,7 @@ func (tr *trackerRegistry) initialize(l ledgerForTracker, trackers []ledgerTrack
 	tr.maxAccountDeltas = defaultMaxAccountDeltas
 	if cfg.MaxAcctLookback > tr.maxAccountDeltas {
 		tr.maxAccountDeltas = cfg.MaxAcctLookback + 1
-		tr.log.Infof("Reset maxAccountDeltas to %d because of config.MaxAcctLookback=%d. Be advised it could cause OOM.", tr.maxAccountDeltas, cfg.MaxAcctLookback)
+		tr.log.Infof("maxAccountDeltas as overridden to %d because of MaxAcctLookback=%d: this combination might use lots of RAM. To preserve some blocks in blockdb consider using MaxBlockHistoryLookback config option instead of MaxAcctLookback", tr.maxAccountDeltas, cfg.MaxAcctLookback)
 	}
 
 	tr.ctx, tr.ctxCancel = context.WithCancel(context.Background())

--- a/ledger/tracker_test.go
+++ b/ledger/tracker_test.go
@@ -153,16 +153,16 @@ func TestTrackerScheduleCommit(t *testing.T) {
 type emptyTracker struct {
 }
 
-// loadFromDisk is not implemented in the blockingTracker.
+// loadFromDisk is not implemented in the emptyTracker.
 func (t *emptyTracker) loadFromDisk(ledgerForTracker, basics.Round) error {
 	return nil
 }
 
-// newBlock is not implemented in the blockingTracker.
+// newBlock is not implemented in the emptyTracker.
 func (t *emptyTracker) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {
 }
 
-// committedUpTo in the blockingTracker just stores the committed round.
+// committedUpTo in the emptyTracker just stores the committed round.
 func (t *emptyTracker) committedUpTo(committedRnd basics.Round) (minRound, lookback basics.Round) {
 	return 0, basics.Round(0)
 }
@@ -171,12 +171,12 @@ func (t *emptyTracker) produceCommittingTask(committedRound basics.Round, dbRoun
 	return dcr
 }
 
-// prepareCommit, is not used by the blockingTracker
+// prepareCommit, is not used by the emptyTracker
 func (t *emptyTracker) prepareCommit(*deferredCommitContext) error {
 	return nil
 }
 
-// commitRound is not used by the blockingTracker
+// commitRound is not used by the emptyTracker
 func (t *emptyTracker) commitRound(context.Context, trackerdb.TransactionScope, *deferredCommitContext) error {
 	return nil
 }
@@ -188,7 +188,7 @@ func (t *emptyTracker) postCommit(ctx context.Context, dcc *deferredCommitContex
 func (t *emptyTracker) postCommitUnlocked(ctx context.Context, dcc *deferredCommitContext) {
 }
 
-// control functions are not used by the blockingTracker
+// control functions are not used by the emptyTracker
 func (t *emptyTracker) handleUnorderedCommit(dcc *deferredCommitContext) {
 }
 func (t *emptyTracker) handlePrepareCommitError(dcc *deferredCommitContext) {
@@ -196,7 +196,7 @@ func (t *emptyTracker) handlePrepareCommitError(dcc *deferredCommitContext) {
 func (t *emptyTracker) handleCommitError(dcc *deferredCommitContext) {
 }
 
-// close is not used by the blockingTracker
+// close is not used by the emptyTracker
 func (t *emptyTracker) close() {
 }
 
@@ -204,7 +204,7 @@ type ioErrorTracker struct {
 	emptyTracker
 }
 
-// commitRound is not used by the blockingTracker
+// commitRound is not used by the ioErrorTracker
 func (io *ioErrorTracker) commitRound(context.Context, trackerdb.TransactionScope, *deferredCommitContext) error {
 	return sqlite3.Error{Code: sqlite3.ErrIoErr}
 }

--- a/ledger/tracker_test.go
+++ b/ledger/tracker_test.go
@@ -150,30 +150,58 @@ func TestTrackerScheduleCommit(t *testing.T) {
 	a.Equal(expectedOffset, dc.offset)
 }
 
-type ioErrorTracker struct {
+type emptyTracker struct {
 }
 
 // loadFromDisk is not implemented in the blockingTracker.
-func (io *ioErrorTracker) loadFromDisk(ledgerForTracker, basics.Round) error {
+func (t *emptyTracker) loadFromDisk(ledgerForTracker, basics.Round) error {
 	return nil
 }
 
 // newBlock is not implemented in the blockingTracker.
-func (io *ioErrorTracker) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {
+func (t *emptyTracker) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {
 }
 
 // committedUpTo in the blockingTracker just stores the committed round.
-func (io *ioErrorTracker) committedUpTo(committedRnd basics.Round) (minRound, lookback basics.Round) {
+func (io *emptyTracker) committedUpTo(committedRnd basics.Round) (minRound, lookback basics.Round) {
 	return 0, basics.Round(0)
 }
 
-func (io *ioErrorTracker) produceCommittingTask(committedRound basics.Round, dbRound basics.Round, dcr *deferredCommitRange) *deferredCommitRange {
+func (t *emptyTracker) produceCommittingTask(committedRound basics.Round, dbRound basics.Round, dcr *deferredCommitRange) *deferredCommitRange {
 	return dcr
 }
 
 // prepareCommit, is not used by the blockingTracker
-func (io *ioErrorTracker) prepareCommit(*deferredCommitContext) error {
+func (t *emptyTracker) prepareCommit(*deferredCommitContext) error {
 	return nil
+}
+
+// commitRound is not used by the blockingTracker
+func (t *emptyTracker) commitRound(context.Context, trackerdb.TransactionScope, *deferredCommitContext) error {
+	return nil
+}
+
+func (t *emptyTracker) postCommit(ctx context.Context, dcc *deferredCommitContext) {
+}
+
+// postCommitUnlocked implements entry/exit blockers, designed for testing.
+func (t *emptyTracker) postCommitUnlocked(ctx context.Context, dcc *deferredCommitContext) {
+}
+
+// control functions are not used by the blockingTracker
+func (t *emptyTracker) handleUnorderedCommit(dcc *deferredCommitContext) {
+}
+func (t *emptyTracker) handlePrepareCommitError(dcc *deferredCommitContext) {
+}
+func (t *emptyTracker) handleCommitError(dcc *deferredCommitContext) {
+}
+
+// close is not used by the blockingTracker
+func (t *emptyTracker) close() {
+}
+
+type ioErrorTracker struct {
+	emptyTracker
 }
 
 // commitRound is not used by the blockingTracker
@@ -181,47 +209,12 @@ func (io *ioErrorTracker) commitRound(context.Context, trackerdb.TransactionScop
 	return sqlite3.Error{Code: sqlite3.ErrIoErr}
 }
 
-func (io *ioErrorTracker) postCommit(ctx context.Context, dcc *deferredCommitContext) {
-}
-
-// postCommitUnlocked implements entry/exit blockers, designed for testing.
-func (io *ioErrorTracker) postCommitUnlocked(ctx context.Context, dcc *deferredCommitContext) {
-}
-
-// control functions are not used by the blockingTracker
-func (io *ioErrorTracker) handleUnorderedCommit(dcc *deferredCommitContext) {
-}
-func (io *ioErrorTracker) handlePrepareCommitError(dcc *deferredCommitContext) {
-}
-func (io *ioErrorTracker) handleCommitError(dcc *deferredCommitContext) {
-}
-
-// close is not used by the blockingTracker
-func (io *ioErrorTracker) close() {
-}
-
-func (io *ioErrorTracker) reset() {
-}
-
 type producePrepareBlockingTracker struct {
+	emptyTracker
 	produceReleaseLock       chan struct{}
 	prepareCommitEntryLock   chan struct{}
 	prepareCommitReleaseLock chan struct{}
 	cancelTasks              bool
-}
-
-// loadFromDisk is not implemented in the blockingTracker.
-func (bt *producePrepareBlockingTracker) loadFromDisk(ledgerForTracker, basics.Round) error {
-	return nil
-}
-
-// newBlock is not implemented in the blockingTracker.
-func (bt *producePrepareBlockingTracker) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {
-}
-
-// committedUpTo in the blockingTracker just stores the committed round.
-func (bt *producePrepareBlockingTracker) committedUpTo(committedRnd basics.Round) (minRound, lookback basics.Round) {
-	return 0, basics.Round(0)
 }
 
 func (bt *producePrepareBlockingTracker) produceCommittingTask(committedRound basics.Round, dbRound basics.Round, dcr *deferredCommitRange) *deferredCommitRange {
@@ -240,30 +233,6 @@ func (bt *producePrepareBlockingTracker) prepareCommit(*deferredCommitContext) e
 	return nil
 }
 
-// commitRound is not used by the blockingTracker
-func (bt *producePrepareBlockingTracker) commitRound(context.Context, trackerdb.TransactionScope, *deferredCommitContext) error {
-	return nil
-}
-
-func (bt *producePrepareBlockingTracker) postCommit(ctx context.Context, dcc *deferredCommitContext) {
-}
-
-// postCommitUnlocked implements entry/exit blockers, designed for testing.
-func (bt *producePrepareBlockingTracker) postCommitUnlocked(ctx context.Context, dcc *deferredCommitContext) {
-}
-
-// control functions are not used by the blockingTracker
-func (bt *producePrepareBlockingTracker) handleUnorderedCommit(dcc *deferredCommitContext) {
-}
-func (bt *producePrepareBlockingTracker) handlePrepareCommitError(dcc *deferredCommitContext) {
-}
-func (bt *producePrepareBlockingTracker) handleCommitError(dcc *deferredCommitContext) {
-}
-
-// close is not used by the blockingTracker
-func (bt *producePrepareBlockingTracker) close() {
-}
-
 func (bt *producePrepareBlockingTracker) reset() {
 	bt.prepareCommitEntryLock = make(chan struct{})
 	bt.prepareCommitReleaseLock = make(chan struct{})
@@ -271,7 +240,7 @@ func (bt *producePrepareBlockingTracker) reset() {
 	bt.cancelTasks = false
 }
 
-// TestTrackerDbRoundDataRace checks for dbRound data race
+// TestTrackers_DbRoundDataRace checks for dbRound data race
 // when commit scheduling relies on dbRound from the tracker registry but tracker's deltas
 // are used in calculations
 // 1. Add say 128 + MaxAcctLookback (MaxLookback) blocks and commit
@@ -280,7 +249,7 @@ func (bt *producePrepareBlockingTracker) reset() {
 // 4. Set a block in produceCommittingTask, add a new block and resume the commit
 // 5. Resume produceCommittingTask
 // 6. The data race and panic happens in block queue syncher thread
-func TestTrackerDbRoundDataRace(t *testing.T) {
+func TestTrackers_DbRoundDataRace(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	t.Skip("For manual run when touching ledger locking")
@@ -367,7 +336,7 @@ func TestTrackerDbRoundDataRace(t *testing.T) {
 	close(stallingTracker.produceReleaseLock)
 }
 
-func TestCommitRoundIOError(t *testing.T) {
+func TestTrackers_CommitRoundIOError(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	a := require.New(t)

--- a/ledger/tracker_test.go
+++ b/ledger/tracker_test.go
@@ -488,20 +488,22 @@ func TestTrackers_IsBehindCommittingDeltas(t *testing.T) {
 		maxAccountDeltas: defaultMaxAccountDeltas,
 	}
 
-	a.False(tr.isBehindCommittingDeltas())
+	latest := basics.Round(0)
+	a.False(tr.isBehindCommittingDeltas(latest))
 
 	// no deltas but busy committing => not behind
 	tr.accountsCommitting.Store(true)
-	a.False(tr.isBehindCommittingDeltas())
+	a.False(tr.isBehindCommittingDeltas(latest))
 	tr.accountsCommitting.Store(false)
 
 	// lots of deltas but not committing => not behind
-	tr.accts.deltas = make([]ledgercore.StateDelta, defaultMaxAccountDeltas+10)
-	a.False(tr.isBehindCommittingDeltas())
+	latest = basics.Round(defaultMaxAccountDeltas + 10)
+	tr.dbRound = 0
+	a.False(tr.isBehindCommittingDeltas(latest))
 
 	// lots of deltas and committing => behind
 	tr.accountsCommitting.Store(true)
-	a.True(tr.isBehindCommittingDeltas())
+	a.True(tr.isBehindCommittingDeltas(latest))
 }
 
 func TestTrackers_AccountUpdatesLedgerEvaluatorNoBlockHdr(t *testing.T) {


### PR DESCRIPTION
## Summary

It is possible catchup downloads blocks faster than ledger commits it slow disks. This could cause OOM because of too many pending deltas.

### Implementation overview
1. Defined max deltas number = 256 used to slow down catchup via a new `Ledger.Available()` method.
2. If `MaxAcctLookback` is manually set greater than 256, use `MaxAcctLookback+1` as a new max.
3. Added a new boolean flag for checking if the ledger is committing right now. If both deltas exceeded and committing then ledger is unavailable.
4. When unavailable, catchup service stops blocks fetching similarly to what happens with catchpoint file writing.

Additionally moved `trackerRegistry.dbRound` initialization from `initialize` to `loadFromDisk` to 1) simplify testing 2) it seems naturally belongs to `loadFromDisk`.

### Considered improvement(s) [not implemented]
1. It is possible to use max deltas value to force flushing in addition on max accounts and time delay.

## Test Plan

Added unit tests to catchup and ledger packages.
Run a manual mainnet catchup test.

| Memory usage  | algod_ledger_round - algod_ledger_dbround | node.log `.details.NewBase - .details.OldBase` |
| ------------- | ------------- | ------------- |
|  ![mm heap](https://github.com/algorand/go-algorand/assets/65323360/08337e64-8c81-4220-80d8-a4bd7051bcde) | ![metrics_viz](https://github.com/algorand/go-algorand/assets/65323360/67e1ee58-3aca-4f97-b83d-1ec4d5635845) | ![deltas](https://github.com/algorand/go-algorand/assets/65323360/17354cdd-b1d2-4637-a550-2db24c3362de) |

