### PR TITLE
Feature: Catchup Eval Stake Exception Round Handling

### DIFF
--- a/ledger/eval/eval.go
+++ b/ledger/eval/eval.go
@@ -1713,7 +1713,7 @@ transactionGroupLoop:
 				break
 			}
 			if err1 != nil {
-				return ledgercore.StateDelta{}, err
+				return ledgercore.StateDelta{}, err1
 			}
 		}
 	}

--- a/ledger/eval/eval.go
+++ b/ledger/eval/eval.go
@@ -1318,28 +1318,18 @@ func (eval *BlockEvaluator) endOfBlock() error {
 		if !eval.block.StateProofTracking[protocol.StateProofBasic].StateProofVotersCommitment.IsEqual(expectedVoters) {
 			return fmt.Errorf("StateProofVotersCommitment wrong: %v != %v", eval.block.StateProofTracking[protocol.StateProofBasic].StateProofVotersCommitment, expectedVoters)
 		}
-		if eval.proto.ExcludeExpiredCirculation {
-			if eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight != expectedVotersWeight {
-				return fmt.Errorf("StateProofOnlineTotalWeight wrong: %v != %v", eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight, expectedVotersWeight)
-			}
-		} else {
-			if eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight != expectedVotersWeight {
-				actualVotersWeight := eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight
-				var highWeight, lowWeight basics.MicroAlgos
-				if expectedVotersWeight.LessThan(actualVotersWeight) {
-					highWeight = actualVotersWeight
-					lowWeight = expectedVotersWeight
-				} else {
-					highWeight = expectedVotersWeight
-					lowWeight = actualVotersWeight
-				}
-				const stakeDiffusionFactor = 5
-				allowedDelta, overflowed := basics.Muldiv(expectedVotersWeight.Raw, stakeDiffusionFactor, 100)
-				if overflowed {
-					return fmt.Errorf("StateProofOnlineTotalWeight overflow: %v != %v", actualVotersWeight, expectedVotersWeight)
-				}
-				if (highWeight.Raw - lowWeight.Raw) > allowedDelta {
-					return fmt.Errorf("StateProofOnlineTotalWeight wrong: %v != %v greater than %d", actualVotersWeight, expectedVotersWeight, allowedDelta)
+		if eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight != expectedVotersWeight {
+			mainnetGenesisHash, _ := crypto.DigestFromString("YBQ4JWH4DW655UWXMBF6IVUOH5WQIGMHVQ333ZFWEC22WOJERLPQ")
+			if eval.genesisHash == mainnetGenesisHash {
+				// Handful of historic rounds where the state proof online total weight is known to be slightly different
+				// than expected voters weight. A consensus release (V38) addressed this/prevented the corner case from
+				// occurring going forward.
+				switch eval.block.Round() {
+				case 24018688, 26982912, 27009024, 27713280, 27822080, 27822848, 27929344, 28032768,
+					28977920, 29822208, 30005248, 30033920:
+					// In Go, break is implicit at the end of each case
+				default:
+					return fmt.Errorf("StateProofOnlineTotalWeight wrong: %v != %v", eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight, expectedVotersWeight)
 				}
 			}
 		}

--- a/ledger/eval/eval.go
+++ b/ledger/eval/eval.go
@@ -1328,7 +1328,7 @@ func (eval *BlockEvaluator) endOfBlock() error {
 				switch eval.block.Round() {
 				case 24018688, 26982912, 27009024, 27713280, 27822080, 27822848, 27929344, 28032768,
 					28977920, 29822208, 30005248, 30033920:
-					// In Go, break is implicit at the end of each case
+					// Don't return an error for these blocks
 				default:
 					return fmt.Errorf("StateProofOnlineTotalWeight wrong: %v != %v", eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight, expectedVotersWeight)
 				}

--- a/ledger/eval/eval.go
+++ b/ledger/eval/eval.go
@@ -1325,8 +1325,6 @@ func (eval *BlockEvaluator) endOfBlock() error {
 		} else {
 			if eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight != expectedVotersWeight {
 				actualVotersWeight := eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight
-
-				logging.Base().With("WEIGHTMISMATCH", "true").Warnf("StateProofOnlineTotalWeight wrong: %v != %v for round %v", actualVotersWeight, expectedVotersWeight, eval.block.Round())
 				var highWeight, lowWeight basics.MicroAlgos
 				if expectedVotersWeight.LessThan(actualVotersWeight) {
 					highWeight = actualVotersWeight

--- a/ledger/eval/eval.go
+++ b/ledger/eval/eval.go
@@ -1325,6 +1325,8 @@ func (eval *BlockEvaluator) endOfBlock() error {
 		} else {
 			if eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight != expectedVotersWeight {
 				actualVotersWeight := eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight
+
+				logging.Base().With("WEIGHTMISMATCH", "true").Warnf("StateProofOnlineTotalWeight wrong: %v != %v for round %v", actualVotersWeight, expectedVotersWeight, eval.block.Round())
 				var highWeight, lowWeight basics.MicroAlgos
 				if expectedVotersWeight.LessThan(actualVotersWeight) {
 					highWeight = actualVotersWeight

--- a/ledger/eval/eval.go
+++ b/ledger/eval/eval.go
@@ -1318,6 +1318,7 @@ func (eval *BlockEvaluator) endOfBlock() error {
 		if !eval.block.StateProofTracking[protocol.StateProofBasic].StateProofVotersCommitment.IsEqual(expectedVoters) {
 			return fmt.Errorf("StateProofVotersCommitment wrong: %v != %v", eval.block.StateProofTracking[protocol.StateProofBasic].StateProofVotersCommitment, expectedVoters)
 		}
+
 		if eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight != expectedVotersWeight {
 			mainnetGenesisHash, _ := crypto.DigestFromString("YBQ4JWH4DW655UWXMBF6IVUOH5WQIGMHVQ333ZFWEC22WOJERLPQ")
 			if eval.genesisHash == mainnetGenesisHash {
@@ -1331,6 +1332,8 @@ func (eval *BlockEvaluator) endOfBlock() error {
 				default:
 					return fmt.Errorf("StateProofOnlineTotalWeight wrong: %v != %v", eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight, expectedVotersWeight)
 				}
+			} else {
+				return fmt.Errorf("StateProofOnlineTotalWeight wrong: %v != %v", eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight, expectedVotersWeight)
 			}
 		}
 		if eval.block.StateProofTracking[protocol.StateProofBasic].StateProofNextRound != eval.state.GetStateProofNextRound() {
@@ -1705,11 +1708,11 @@ transactionGroupLoop:
 		select {
 		case <-ctx.Done():
 			return ledgercore.StateDelta{}, ctx.Err()
-		case err, open := <-txvalidator.done:
+		case err1, open := <-txvalidator.done:
 			if !open {
 				break
 			}
-			if err != nil {
+			if err1 != nil {
 				return ledgercore.StateDelta{}, err
 			}
 		}

--- a/ledger/eval/eval_test.go
+++ b/ledger/eval/eval_test.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/algorand/go-algorand/crypto/merklearray"
+	"math"
 	"math/rand"
 	"testing"
 
@@ -671,56 +673,6 @@ func testnetFixupExecution(t *testing.T, headerRound basics.Round, poolBonus uin
 	require.NoError(t, err)
 }
 
-// newTestGenesis creates a bunch of accounts, splits up 10B algos
-// between them and the rewardspool and feesink, and gives out the
-// addresses and secrets it creates to enable tests.  For special
-// scenarios, manipulate these return values before using newTestLedger.
-func newTestGenesis() (bookkeeping.GenesisBalances, []basics.Address, []*crypto.SignatureSecrets) {
-	// irrelevant, but deterministic
-	sink, err := basics.UnmarshalChecksumAddress("YTPRLJ2KK2JRFSZZNAF57F3K5Y2KCG36FZ5OSYLW776JJGAUW5JXJBBD7Q")
-	if err != nil {
-		panic(err)
-	}
-	rewards, err := basics.UnmarshalChecksumAddress("242H5OXHUEBYCGGWB3CQ6AZAMQB5TMCWJGHCGQOZPEIVQJKOO7NZXUXDQA")
-	if err != nil {
-		panic(err)
-	}
-
-	const count = 10
-	addrs := make([]basics.Address, count)
-	secrets := make([]*crypto.SignatureSecrets, count)
-	accts := make(map[basics.Address]basics.AccountData)
-
-	// 10 billion microalgos, across N accounts and pool and sink
-	amount := 10 * 1000000000 * 1000000 / uint64(count+2)
-
-	for i := 0; i < count; i++ {
-		// Create deterministic addresses, so that output stays the same, run to run.
-		var seed crypto.Seed
-		seed[0] = byte(i)
-		secrets[i] = crypto.GenerateSignatureSecrets(seed)
-		addrs[i] = basics.Address(secrets[i].SignatureVerifier)
-
-		adata := basics.AccountData{
-			MicroAlgos: basics.MicroAlgos{Raw: amount},
-		}
-		accts[addrs[i]] = adata
-	}
-
-	accts[sink] = basics.AccountData{
-		MicroAlgos: basics.MicroAlgos{Raw: amount},
-		Status:     basics.NotParticipating,
-	}
-
-	accts[rewards] = basics.AccountData{
-		MicroAlgos: basics.MicroAlgos{Raw: amount},
-	}
-
-	genBalances := bookkeeping.MakeGenesisBalances(accts, sink, rewards)
-
-	return genBalances, addrs, secrets
-}
-
 type evalTestLedger struct {
 	blocks              map[basics.Round]bookkeeping.Block
 	roundBalances       map[basics.Round]map[basics.Address]basics.AccountData
@@ -732,6 +684,7 @@ type evalTestLedger struct {
 	latestTotals        ledgercore.AccountTotals
 	tracer              logic.EvalTracer
 	boxes               map[string][]byte
+	voters              map[basics.Round]*ledgercore.VotersForRound
 }
 
 // newTestLedger creates a in memory Ledger that is as realistic as
@@ -941,6 +894,9 @@ func (ledger *evalTestLedger) BlockHdr(rnd basics.Round) (bookkeeping.BlockHeade
 }
 
 func (ledger *evalTestLedger) VotersForStateProof(rnd basics.Round) (*ledgercore.VotersForRound, error) {
+	if v, ok := ledger.voters[rnd]; ok {
+		return v, nil
+	}
 	return nil, errors.New("untested code path")
 }
 
@@ -1444,4 +1400,180 @@ func TestExpiredAccountGeneration(t *testing.T) {
 	require.Equal(t, crypto.OneTimeSignatureVerifier{}, recvAcct.VoteID)
 	require.Equal(t, crypto.VRFVerifier{}, recvAcct.SelectionID)
 	require.Equal(t, merklesignature.Verifier{}.Commitment, recvAcct.StateProofID)
+}
+
+func TestEval_EndOfBlockStake(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	proto := protocol.ConsensusFuture
+	mainnetDigest, digestError := crypto.DigestFromString("YBQ4JWH4DW655UWXMBF6IVUOH5WQIGMHVQ333ZFWEC22WOJERLPQ")
+	require.NoError(t, digestError)
+
+	var tests = []struct {
+		actual      basics.MicroAlgos
+		expected    basics.MicroAlgos
+		round       basics.Round
+		genesisHash crypto.Digest
+		err         string
+	}{
+		// Normal round mainnet, matched stake => no error
+		{
+			actual:      basics.MicroAlgos{Raw: 100},
+			expected:    basics.MicroAlgos{Raw: 100},
+			round:       basics.Round(config.Consensus[proto].StateProofInterval),
+			genesisHash: mainnetDigest,
+			err:         "",
+		},
+		// Normal round mainnet, mismatched stake (actual<expected) => error
+		{
+			actual:      basics.MicroAlgos{Raw: 99},
+			expected:    basics.MicroAlgos{Raw: 100},
+			round:       basics.Round(config.Consensus[proto].StateProofInterval),
+			genesisHash: mainnetDigest,
+			err:         "StateProofOnlineTotalWeight wrong: {99} != {100}",
+		},
+		// Normal round mainnet, mismatched stake (actual>expected) => error
+		{
+			actual:      basics.MicroAlgos{Raw: 100},
+			expected:    basics.MicroAlgos{Raw: 99},
+			round:       basics.Round(config.Consensus[proto].StateProofInterval),
+			genesisHash: mainnetDigest,
+			err:         "StateProofOnlineTotalWeight wrong: {100} != {99}",
+		},
+		// Normal round mainnet, mismatched stake with max possible value for muldiv => error
+		{
+			actual:      basics.MicroAlgos{Raw: 100},
+			expected:    basics.MicroAlgos{Raw: math.MaxUint64},
+			round:       basics.Round(config.Consensus[proto].StateProofInterval),
+			genesisHash: mainnetDigest,
+			err:         "StateProofOnlineTotalWeight wrong: {100} != {18446744073709551615}",
+		},
+		// Normal round mainnet, matched stake with max possible value for muldiv => no error
+		{
+			actual:      basics.MicroAlgos{Raw: math.MaxUint64},
+			expected:    basics.MicroAlgos{Raw: math.MaxUint64},
+			round:       basics.Round(config.Consensus[proto].StateProofInterval),
+			genesisHash: mainnetDigest,
+			err:         "",
+		},
+		// Exception round mainnet, mismatched state (actual>expected) => no error
+		{
+			actual:      basics.MicroAlgos{Raw: 100},
+			expected:    basics.MicroAlgos{Raw: 99},
+			round:       basics.Round(27713280),
+			genesisHash: mainnetDigest,
+			err:         "",
+		},
+		// Exception round mainnet, mismatched state (actual<expected) => no error
+		{
+			actual:      basics.MicroAlgos{Raw: 99},
+			expected:    basics.MicroAlgos{Raw: 100},
+			round:       basics.Round(27713280),
+			genesisHash: mainnetDigest,
+			err:         "",
+		},
+		// Exception round mainnet, mismatched stake with max possible value for muldiv => no error
+		{
+			actual:      basics.MicroAlgos{Raw: math.MaxUint64 - 100},
+			expected:    basics.MicroAlgos{Raw: math.MaxUint64},
+			round:       basics.Round(27713280),
+			genesisHash: mainnetDigest,
+			err:         "",
+		},
+		// Normal round non-mainnet, matched stake => no error
+		{
+			actual:   basics.MicroAlgos{Raw: 100},
+			expected: basics.MicroAlgos{Raw: 100},
+			round:    basics.Round(config.Consensus[proto].StateProofInterval),
+			err:      "",
+		},
+		// Normal round non-mainnet, mismatched stake (actual<expected) => error
+		{
+			actual:   basics.MicroAlgos{Raw: 99},
+			expected: basics.MicroAlgos{Raw: 100},
+			round:    basics.Round(config.Consensus[proto].StateProofInterval),
+			err:      "StateProofOnlineTotalWeight wrong: {99} != {100}",
+		},
+		// Exception round non-mainnet, mismatched state (actual>expected) => no error
+		{
+			actual:   basics.MicroAlgos{Raw: 100},
+			expected: basics.MicroAlgos{Raw: 99},
+			round:    basics.Round(27713280),
+			err:      "StateProofOnlineTotalWeight wrong: {100} != {99}",
+		},
+		// Exception round non-mainnet, mismatched state (actual<expected) => no error
+		{
+			actual:   basics.MicroAlgos{Raw: 99},
+			expected: basics.MicroAlgos{Raw: 100},
+			round:    basics.Round(27713280),
+			err:      "StateProofOnlineTotalWeight wrong: {99} != {100}",
+		},
+		// Exception round non-mainnet, mismatched stake with max possible value for muldiv => no error
+		{
+			actual:   basics.MicroAlgos{Raw: math.MaxUint64 - 100},
+			expected: basics.MicroAlgos{Raw: math.MaxUint64},
+			round:    basics.Round(27713280),
+			err:      "StateProofOnlineTotalWeight wrong: {18446744073709551515} != {18446744073709551615}",
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			params := config.Consensus[proto]
+
+			genesisInitState, _, _ := ledgertesting.GenesisWithProto(2, proto)
+
+			l := newTestLedger(t, bookkeeping.GenesisBalances{
+				Balances:    genesisInitState.Accounts,
+				FeeSink:     testSinkAddr,
+				RewardsPool: testPoolAddr,
+				Timestamp:   0,
+			})
+			// If genesis hash is non-nil in test case, override the test hash here
+			if !test.genesisHash.IsZero() {
+				l.genesisHash = test.genesisHash
+			}
+			l.voters = map[basics.Round]*ledgercore.VotersForRound{
+				basics.Round(uint64(test.round) - params.StateProofVotersLookback): {
+					Tree:        &merklearray.Tree{},
+					TotalWeight: test.expected,
+				},
+			}
+
+			genesisBlockHeader, err := l.BlockHdr(0)
+			require.NoError(t, err)
+			newBlock := bookkeeping.MakeBlock(genesisBlockHeader)
+			newBlock.StateProofTracking = map[protocol.StateProofType]bookkeeping.StateProofTrackingData{
+				protocol.StateProofBasic: {
+					StateProofOnlineTotalWeight: test.actual,
+				},
+			}
+			newBlock.BlockHeader.Round = test.round
+
+			pcow := mockLedger{balanceMap: map[basics.Address]basics.AccountData{}}
+			mods := ledgercore.StateDelta{Hdr: &newBlock.BlockHeader}
+			cow := &roundCowState{
+				lookupParent: &pcow,
+				mods:         mods,
+			}
+			eval := BlockEvaluator{
+				state:       cow,
+				validate:    true,
+				prevHeader:  genesisBlockHeader,
+				proto:       params,
+				genesisHash: l.genesisHash,
+				block:       newBlock,
+				l:           l,
+			}
+
+			err = eval.endOfBlock()
+			if len(test.err) == 0 {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.err)
+			}
+		})
+	}
+
 }

--- a/ledger/eval/eval_test.go
+++ b/ledger/eval/eval_test.go
@@ -1570,8 +1570,7 @@ func TestEval_EndOfBlockStake(t *testing.T) {
 			if len(test.err) == 0 {
 				require.NoError(t, err)
 			} else {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), test.err)
+				require.ErrorContains(t, err, test.err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

We had a brief period where a handful of rounds had stake miniscully mismatching in some cases based on delta corruption in some nodes. This pull request ensures catchup cannot stall while removing the stake dilution factor (underlying cause/corrections were addressed in the last consensus upgrade).

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->



<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Added a new `TestEval_EndOfBlockStake` (thanks @algorandskiy ) to exercise various cases being handled as expected.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
