### PR TITLE
avm: preserve line/column for assembler warnings

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -226,7 +226,7 @@ type SourceLocation struct {
 type OpStream struct {
 	Version  uint64
 	Trace    *strings.Builder
-	Warnings []error       // informational warnings, shouldn't stop assembly
+	Warnings []sourceError // informational warnings, shouldn't stop assembly
 	Errors   []sourceError // errors that should prevent final assembly
 	Program  []byte        // Final program bytes. Will stay nil if any errors
 
@@ -2694,7 +2694,7 @@ func (ops *OpStream) record(se *sourceError) {
 }
 
 func (ops *OpStream) warn(t token, format string, a ...interface{}) {
-	warning := &sourceError{t.line, t.col, fmt.Errorf(format, a...)}
+	warning := sourceError{t.line, t.col, fmt.Errorf(format, a...)}
 	ops.Warnings = append(ops.Warnings, warning)
 }
 

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -3604,10 +3604,13 @@ func TestReportMultipleErrors(t *testing.T) {
 			{Line: 1, Err: errors.New("error 1")},
 			{Err: errors.New("error 2")},
 			{Line: 3, Err: errors.New("error 3")},
+			{Line: 4, Column: 1, Err: errors.New("error 4")},
 		},
-		Warnings: []error{
-			errors.New("warning 1"),
-			errors.New("warning 2"),
+		Warnings: []sourceError{
+			{Line: 5, Err: errors.New("warning 1")},
+			{Err: errors.New("warning 2")},
+			{Line: 7, Err: errors.New("warning 3")},
+			{Line: 8, Column: 1, Err: errors.New("warning 4")},
 		},
 	}
 
@@ -3616,9 +3619,12 @@ func TestReportMultipleErrors(t *testing.T) {
 	ops.ReportMultipleErrors("test.txt", &b)
 	expected := `test.txt: 1: error 1
 test.txt: 0: error 2
-test.txt: 3: error 3
-test.txt: warning 1
-test.txt: warning 2
+test.txt: 3: error 4
+test.txt: 4:1: error 3
+test.txt: 5: warning 1
+test.txt: 0: warning 2
+test.txt: 7: warning 3
+test.txt: 8:1: warning 4
 `
 	require.Equal(t, expected, b.String())
 
@@ -3628,8 +3634,11 @@ test.txt: warning 2
 	expected = `1: error 1
 0: error 2
 3: error 3
-warning 1
-warning 2
+4:1: error 4
+5: warning 1
+0: warning 2
+7: warning 3
+8:1: warning 4
 `
 	require.Equal(t, expected, b.String())
 

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -3619,8 +3619,8 @@ func TestReportMultipleErrors(t *testing.T) {
 	ops.ReportMultipleErrors("test.txt", &b)
 	expected := `test.txt: 1: error 1
 test.txt: 0: error 2
-test.txt: 3: error 4
-test.txt: 4:1: error 3
+test.txt: 3: error 3
+test.txt: 4:1: error 4
 test.txt: 5: warning 1
 test.txt: 0: warning 2
 test.txt: 7: warning 3


### PR DESCRIPTION
## Summary

Modified OpStream Warnings from []error to []sourceError to preserve line and column information so it can be used by TEAL language servers to display a location of warnings.

## Test Plan

Added unit tests for warnings with zero and non-zero lines/columns