### PR TITLE
follower: update follower node error messages.

### DIFF
--- a/node/follower_node.go
+++ b/node/follower_node.go
@@ -226,17 +226,17 @@ func (node *AlgorandFollowerNode) Ledger() *data.Ledger {
 
 // BroadcastSignedTxGroup errors in follower mode
 func (node *AlgorandFollowerNode) BroadcastSignedTxGroup(_ []transactions.SignedTxn) (err error) {
-	return fmt.Errorf("cannot broadcast txns in sync mode")
+	return fmt.Errorf("cannot broadcast txns in follower mode")
 }
 
 // AsyncBroadcastSignedTxGroup errors in follower mode
 func (node *AlgorandFollowerNode) AsyncBroadcastSignedTxGroup(_ []transactions.SignedTxn) (err error) {
-	return fmt.Errorf("cannot broadcast txns in sync mode")
+	return fmt.Errorf("cannot broadcast txns in follower mode")
 }
 
 // BroadcastInternalSignedTxGroup errors in follower mode
 func (node *AlgorandFollowerNode) BroadcastInternalSignedTxGroup(_ []transactions.SignedTxn) (err error) {
-	return fmt.Errorf("cannot broadcast internal signed txn group in sync mode")
+	return fmt.Errorf("cannot broadcast internal signed txn group in follower mode")
 }
 
 // Simulate speculatively runs a transaction group against the current


### PR DESCRIPTION
## Summary

The feature was renamed from `sync` to `follower` and this error message was not updated along with it.

There is a possibility that user code could be checking for this message, so this could be considered a breaking change. This error message also indicates a configuration issue, so error handling would be unable to resolve it.

My recommendation is to make the breaking change.

## Test Plan


