### PR TITLE
catchpoint: store certs with blocks during catchpoint restore

### DIFF
--- a/components/mocks/mockCatchpointCatchupAccessor.go
+++ b/components/mocks/mockCatchpointCatchupAccessor.go
@@ -19,6 +19,7 @@ package mocks
 import (
 	"context"
 
+	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
@@ -86,12 +87,12 @@ func (m *MockCatchpointCatchupAccessor) StoreBalancesRound(ctx context.Context, 
 }
 
 // StoreFirstBlock stores a single block to the blocks database.
-func (m *MockCatchpointCatchupAccessor) StoreFirstBlock(ctx context.Context, blk *bookkeeping.Block) (err error) {
+func (m *MockCatchpointCatchupAccessor) StoreFirstBlock(ctx context.Context, blk *bookkeeping.Block, cert *agreement.Certificate) (err error) {
 	return nil
 }
 
 // StoreBlock stores a single block to the blocks database.
-func (m *MockCatchpointCatchupAccessor) StoreBlock(ctx context.Context, blk *bookkeeping.Block) (err error) {
+func (m *MockCatchpointCatchupAccessor) StoreBlock(ctx context.Context, blk *bookkeeping.Block, cert *agreement.Certificate) (err error) {
 	return nil
 }
 

--- a/ledger/catchupaccessor_test.go
+++ b/ledger/catchupaccessor_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
@@ -162,7 +163,7 @@ func initializeTestCatchupAccessor(t *testing.T, l *Ledger, accountsCount uint64
 	require.NoError(t, err)
 
 	// We do this to initialize the catchpointblocks table. Needed to be able to use CompleteCatchup.
-	err = catchpointAccessor.StoreFirstBlock(ctx, &bookkeeping.Block{})
+	err = catchpointAccessor.StoreFirstBlock(ctx, &bookkeeping.Block{}, &agreement.Certificate{})
 	require.NoError(t, err)
 
 	// We do this to initialize the accounttotals table. Needed to be able to use CompleteCatchup.
@@ -441,6 +442,7 @@ func TestVerifyCatchpoint(t *testing.T) {
 
 	// actual testing...
 	var blk bookkeeping.Block
+	var cert agreement.Certificate
 	err = catchpointAccessor.VerifyCatchpoint(ctx, &blk)
 	require.Error(t, err)
 
@@ -455,14 +457,14 @@ func TestVerifyCatchpoint(t *testing.T) {
 	err = catchpointAccessor.StoreBalancesRound(ctx, &blk)
 	require.NoError(t, err)
 	// StoreFirstBlock is a dumb wrapper on some db logic
-	err = catchpointAccessor.StoreFirstBlock(ctx, &blk)
+	err = catchpointAccessor.StoreFirstBlock(ctx, &blk, &cert)
 	require.NoError(t, err)
 
 	_, err = catchpointAccessor.EnsureFirstBlock(ctx)
 	require.NoError(t, err)
 
 	blk.BlockHeader.Round++
-	err = catchpointAccessor.StoreBlock(ctx, &blk)
+	err = catchpointAccessor.StoreBlock(ctx, &blk, &cert)
 	require.NoError(t, err)
 
 	// TODO: write a case with working no-err

--- a/ledger/store/blockdb/blockdb.go
+++ b/ledger/store/blockdb/blockdb.go
@@ -262,7 +262,7 @@ func BlockStartCatchupStaging(tx *sql.Tx, blk bookkeeping.Block, cert agreement.
 	}
 
 	// insert the top entry to the blocks table.
-	_, err := tx.Exec("INSERT INTO catchpointblocks (rnd, proto, hdrdata, blkdata, certdata) VALUES (?, ?, ?, ?)",
+	_, err := tx.Exec("INSERT INTO catchpointblocks (rnd, proto, hdrdata, blkdata, certdata) VALUES (?, ?, ?, ?, ?)",
 		blk.Round(),
 		blk.CurrentProtocol,
 		protocol.Encode(&blk.BlockHeader),
@@ -308,7 +308,7 @@ func BlockAbortCatchup(tx *sql.Tx) error {
 // BlockPutStaging store a block into catchpoint staging table
 func BlockPutStaging(tx *sql.Tx, blk bookkeeping.Block, cert agreement.Certificate) (err error) {
 	// insert the new entry
-	_, err = tx.Exec("INSERT INTO catchpointblocks (rnd, proto, hdrdata, blkdata, certdata) VALUES (?, ?, ?, ?)",
+	_, err = tx.Exec("INSERT INTO catchpointblocks (rnd, proto, hdrdata, blkdata, certdata) VALUES (?, ?, ?, ?, ?)",
 		blk.Round(),
 		blk.CurrentProtocol,
 		protocol.Encode(&blk.BlockHeader),

--- a/ledger/store/blockdb/blockdb.go
+++ b/ledger/store/blockdb/blockdb.go
@@ -242,7 +242,7 @@ func BlockForgetBefore(tx *sql.Tx, rnd basics.Round) error {
 }
 
 // BlockStartCatchupStaging initializes catchup for catchpoint
-func BlockStartCatchupStaging(tx *sql.Tx, blk bookkeeping.Block) error {
+func BlockStartCatchupStaging(tx *sql.Tx, blk bookkeeping.Block, cert agreement.Certificate) error {
 	// delete the old catchpointblocks table, if there is such.
 	for _, stmt := range blockResetExprs {
 		stmt = strings.Replace(stmt, "blocks", "catchpointblocks", 1)
@@ -262,11 +262,12 @@ func BlockStartCatchupStaging(tx *sql.Tx, blk bookkeeping.Block) error {
 	}
 
 	// insert the top entry to the blocks table.
-	_, err := tx.Exec("INSERT INTO catchpointblocks (rnd, proto, hdrdata, blkdata) VALUES (?, ?, ?, ?)",
+	_, err := tx.Exec("INSERT INTO catchpointblocks (rnd, proto, hdrdata, blkdata, certdata) VALUES (?, ?, ?, ?)",
 		blk.Round(),
 		blk.CurrentProtocol,
 		protocol.Encode(&blk.BlockHeader),
 		protocol.Encode(&blk),
+		protocol.Encode(&cert),
 	)
 	if err != nil {
 		return err
@@ -305,13 +306,14 @@ func BlockAbortCatchup(tx *sql.Tx) error {
 }
 
 // BlockPutStaging store a block into catchpoint staging table
-func BlockPutStaging(tx *sql.Tx, blk bookkeeping.Block) (err error) {
+func BlockPutStaging(tx *sql.Tx, blk bookkeeping.Block, cert agreement.Certificate) (err error) {
 	// insert the new entry
-	_, err = tx.Exec("INSERT INTO catchpointblocks (rnd, proto, hdrdata, blkdata) VALUES (?, ?, ?, ?)",
+	_, err = tx.Exec("INSERT INTO catchpointblocks (rnd, proto, hdrdata, blkdata, certdata) VALUES (?, ?, ?, ?)",
 		blk.Round(),
 		blk.CurrentProtocol,
 		protocol.Encode(&blk.BlockHeader),
 		protocol.Encode(&blk),
+		protocol.Encode(&cert),
 	)
 	if err != nil {
 		return err

--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -363,6 +363,10 @@ func TestBasicCatchpointCatchup(t *testing.T) {
 
 	err = fixture.ClientWaitForRoundWithTimeout(usingNodeRestClient, uint64(targetCatchpointRound+1))
 	a.NoError(err)
+
+	// ensure the raw block can be downloaded (including cert)
+	_, err = usingNodeRestClient.RawBlock(uint64(targetCatchpointRound))
+	a.NoError(err)
 }
 
 func TestCatchpointLabelGeneration(t *testing.T) {


### PR DESCRIPTION
## Summary

Each block certificate is downloaded but thrown away during catchpoint restore, leading to errors like #5352 when trying to retrieve blocks with their certificates later. Since we always store blocks and certs together this keeps the certificates from being thrown away so `certdata` ends up in the block db with the `blkdata`

Closes #5352.

## Test Plan

Updated TestBasicCatchpointCatchup to request a msgpack block at the end.