### PR TITLE
Added boost dependency in MSYS2

### DIFF
--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -99,7 +99,7 @@ elif [ "${OS}" = "darwin" ]; then
     install_or_upgrade diffutils
     lnav -i "$SCRIPTPATH/algorand_node_log.json"
 elif [ "${OS}" = "windows" ]; then
-    if ! $msys2 pacman -S --disable-download-timeout --noconfirm git automake autoconf m4 libtool make mingw-w64-x86_64-gcc mingw-w64-x86_64-python mingw-w64-x86_64-jq unzip procps; then
+    if ! $msys2 pacman -S --disable-download-timeout --noconfirm git automake autoconf m4 libtool make mingw-w64-x86_64-gcc mingw-w64-x86_64-python mingw-w64-x86_64-boost mingw-w64-x86_64-jq unzip procps; then
         echo "Error installing pacman dependencies"
         exit 1
     fi


### PR DESCRIPTION
In conjuntion with https://github.com/algorand/sortition/pull/7 this minor patch adds a new dependency requirement to build the Algorand node in Windows.