### PR TITLE
ledger: support WaitWithCancel for unsuccessful WaitForBlock API calls

### DIFF
--- a/daemon/algod/api/server/v2/test/handlers_resources_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_resources_test.go
@@ -19,10 +19,11 @@ package test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/algorand/go-algorand/data/transactions/logic"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/algorand/go-algorand/data/transactions/logic"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -133,6 +134,9 @@ func (l *mockLedger) BlockHdr(rnd basics.Round) (bookkeeping.BlockHeader, error)
 	return blk.BlockHeader, nil
 }
 func (l *mockLedger) Wait(r basics.Round) chan struct{} {
+	panic("not implemented")
+}
+func (l *mockLedger) WaitWithCancel(r basics.Round) (chan struct{}, func()) {
 	panic("not implemented")
 }
 func (l *mockLedger) GetCreator(cidx basics.CreatableIndex, ctype basics.CreatableType) (c basics.Address, ok bool, err error) {

--- a/ledger/bulletin_test.go
+++ b/ledger/bulletin_test.go
@@ -104,6 +104,8 @@ func TestBulletin(t *testing.T) {
 }
 
 func TestCancelWait(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
 	bul := makeBulletin()
 
 	// Calling Wait before CancelWait

--- a/ledger/bulletin_test.go
+++ b/ledger/bulletin_test.go
@@ -136,7 +136,7 @@ func TestCancelWait(t *testing.T) {
 	// Two Waits, one cancelled
 	waitCh1 := bul.Wait(7)
 	waitCh2 := bul.Wait(7)
-	require.EqualValues(t, waitCh1, waitCh2)
+	require.Equal(t, waitCh1, waitCh2)
 	bul.CancelWait(7)
 	select {
 	case <-waitCh1:
@@ -197,4 +197,14 @@ func TestCancelWait(t *testing.T) {
 		t.Errorf("<-Wait(9) should have been notified")
 	}
 	require.NotContains(t, bul.pendingNotificationRequests, basics.Round(9))
+
+	// Two waits, both cancelled
+	waitCh1 = bul.Wait(10)
+	waitCh2 = bul.Wait(10)
+	require.Equal(t, waitCh1, waitCh2)
+	bul.CancelWait(10)
+	require.Contains(t, bul.pendingNotificationRequests, basics.Round(10))
+	require.Equal(t, bul.pendingNotificationRequests[basics.Round(10)].count, 1)
+	bul.CancelWait(10)
+	require.NotContains(t, bul.pendingNotificationRequests, basics.Round(10))
 }

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -769,6 +769,16 @@ func (l *Ledger) Wait(r basics.Round) chan struct{} {
 	return l.bulletinDisk.Wait(r)
 }
 
+// WaitWithCancel returns a channel that closes once a given round is
+// stored durably in the ledger. The returned function can be used to
+// cancel the wait, which cleans up resources if no other Wait call is
+// active for the same round.
+func (l *Ledger) WaitWithCancel(r basics.Round) (chan struct{}, func()) {
+	l.trackerMu.RLock()
+	defer l.trackerMu.RUnlock()
+	return l.bulletinDisk.Wait(r), func() { l.bulletinDisk.CancelWait(r) }
+}
+
 // WaitMem returns a channel that closes once a given round is
 // available in memory in the ledger, but might not be stored
 // durably on disk yet.


### PR DESCRIPTION
## Summary

The REST API WaitForBlockAfter call creates a notifier for each unique round requested, which remains present even if the HTTP request times out. This adds the ability to cancel and delete notifiers if no one wants them.

## Test Plan

Needs new tests