### PR TITLE
catchup: Provide more information to client when requested block not available

### DIFF
--- a/catchup/universalFetcher.go
+++ b/catchup/universalFetcher.go
@@ -248,7 +248,7 @@ func (hf *HTTPFetcher) getBlockBytes(ctx context.Context, r basics.Round) (data 
 		response.Body.Close()
 		noBlockErr := noBlockForRoundError{round: r}
 		if latestBytes := response.Header.Get("X-Latest-Round"); latestBytes != "" {
-			if latest, err := strconv.ParseUint(latestBytes, 10, 64); err == nil {
+			if latest, pErr := strconv.ParseUint(latestBytes, 10, 64); pErr == nil {
 				noBlockErr.latest = basics.Round(latest)
 			}
 		}

--- a/catchup/universalFetcher.go
+++ b/catchup/universalFetcher.go
@@ -247,7 +247,7 @@ func (hf *HTTPFetcher) getBlockBytes(ctx context.Context, r basics.Round) (data 
 	case http.StatusNotFound: // server could not find a block with that round numbers.
 		response.Body.Close()
 		noBlockErr := noBlockForRoundError{round: r}
-		if latestBytes := response.Header.Get("X-Latest-Round"); latestBytes != "" {
+		if latestBytes := response.Header.Get(rpcs.BlockResponseLatestRoundHeader); latestBytes != "" {
 			if latest, pErr := strconv.ParseUint(latestBytes, 10, 64); pErr == nil {
 				noBlockErr.latest = basics.Round(latest)
 			}

--- a/catchup/universalFetcher.go
+++ b/catchup/universalFetcher.go
@@ -202,7 +202,7 @@ type noBlockForRoundError struct {
 	latest, round basics.Round
 }
 
-func (noBlockForRoundError) Error() string { return "No block available for given round" }
+func (noBlockForRoundError) Error() string { return "no block available for given round" }
 
 // HTTPFetcher implements FetcherClient doing an HTTP GET of the block
 type HTTPFetcher struct {

--- a/catchup/universalFetcher_test.go
+++ b/catchup/universalFetcher_test.go
@@ -74,7 +74,9 @@ func TestUGetBlockWs(t *testing.T) {
 	block, cert, duration, err = fetcher.fetchBlock(context.Background(), next+1, up)
 
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "requested block is not available")
+	require.Error(t, noBlockForRoundError{}, err)
+	require.Equal(t, next+1, err.(noBlockForRoundError).round)
+	require.Equal(t, next, err.(noBlockForRoundError).latest)
 	require.Nil(t, block)
 	require.Nil(t, cert)
 	require.Equal(t, int64(duration), int64(0))
@@ -118,7 +120,9 @@ func TestUGetBlockHTTP(t *testing.T) {
 
 	block, cert, duration, err = fetcher.fetchBlock(context.Background(), next+1, net.GetPeers()[0])
 
-	require.Error(t, errNoBlockForRound, err)
+	require.Error(t, noBlockForRoundError{}, err)
+	require.Equal(t, next+1, err.(noBlockForRoundError).round)
+	require.Equal(t, next, err.(noBlockForRoundError).latest)
 	require.Contains(t, err.Error(), "No block available for given round")
 	require.Nil(t, block)
 	require.Nil(t, cert)

--- a/catchup/universalFetcher_test.go
+++ b/catchup/universalFetcher_test.go
@@ -123,7 +123,7 @@ func TestUGetBlockHTTP(t *testing.T) {
 	require.Error(t, noBlockForRoundError{}, err)
 	require.Equal(t, next+1, err.(noBlockForRoundError).round)
 	require.Equal(t, next, err.(noBlockForRoundError).latest)
-	require.Contains(t, err.Error(), "No block available for given round")
+	require.Contains(t, err.Error(), "no block available for given round")
 	require.Nil(t, block)
 	require.Nil(t, cert)
 	require.Equal(t, int64(duration), int64(0))

--- a/rpcs/blockService.go
+++ b/rpcs/blockService.go
@@ -54,6 +54,9 @@ const blockResponseRetryAfter = "3"                                             
 const blockServerMaxBodyLength = 512                                               // we don't really pass meaningful content here, so 512 bytes should be a safe limit
 const blockServerCatchupRequestBufferSize = 10
 
+// BlockResponseLatestRoundHeader is returned in the response header when the requested block is not available
+const BlockResponseLatestRoundHeader = "X-Latest-Round"
+
 // BlockServiceBlockPath is the path to register BlockService as a handler for when using gorilla/mux
 // e.g. .Handle(BlockServiceBlockPath, &ls)
 const BlockServiceBlockPath = "/v{version:[0-9.]+}/{genesisID}/block/{round:[0-9a-z]+}"
@@ -246,7 +249,7 @@ func (bs *BlockService) ServeHTTP(response http.ResponseWriter, request *http.Re
 			ok := bs.redirectRequest(round, response, request)
 			if !ok {
 				response.Header().Set("Cache-Control", blockResponseMissingBlockCacheControl)
-				response.Header().Set("X-Latest-Round", fmt.Sprintf("%d", lerr.Latest))
+				response.Header().Set(BlockResponseLatestRoundHeader, fmt.Sprintf("%d", lerr.Latest))
 				response.WriteHeader(http.StatusNotFound)
 			}
 			return

--- a/rpcs/blockService.go
+++ b/rpcs/blockService.go
@@ -240,12 +240,13 @@ func (bs *BlockService) ServeHTTP(response http.ResponseWriter, request *http.Re
 	}
 	encodedBlockCert, err := bs.rawBlockBytes(basics.Round(round))
 	if err != nil {
-		switch err.(type) {
+		switch lerr := err.(type) {
 		case ledgercore.ErrNoEntry:
 			// entry cound not be found.
 			ok := bs.redirectRequest(round, response, request)
 			if !ok {
 				response.Header().Set("Cache-Control", blockResponseMissingBlockCacheControl)
+				response.Header().Set("X-Latest-Round", fmt.Sprintf("%d", lerr.Latest))
 				response.WriteHeader(http.StatusNotFound)
 			}
 			return

--- a/rpcs/blockService.go
+++ b/rpcs/blockService.go
@@ -467,7 +467,8 @@ func topicBlockBytes(log logging.Logger, dataLedger LedgerForBlockService, round
 		default:
 			log.Infof("BlockService topicBlockBytes: %s", err)
 		}
-		return network.Topics{network.MakeTopic(network.ErrorKey, []byte(blockNotAvailableErrMsg))}, 0
+		return network.Topics{
+			network.MakeTopic(network.ErrorKey, []byte(blockNotAvailableErrMsg))}, 0
 	}
 	switch requestType {
 	case BlockAndCertValue:


### PR DESCRIPTION
## Summary

When a node requests a block that is outside the range that a node contains, it returns a 404 (for HTTP catchup) or an `{ErrorKey: blockNotAvailableErrMsg}` value (for websockets catchup). This provides more information to the client so it can more effectively request and poll for new blocks. 

## Test Plan

Updated TestUGetBlockWs and TestUGetBlockHTTP.