### PR TITLE
Remove one allocate per hash by using generics.

### DIFF
--- a/agreement/proposal.go
+++ b/agreement/proposal.go
@@ -189,6 +189,54 @@ func deriveNewSeed(address basics.Address, vrf *crypto.VRFSecrets, rnd round, pe
 	return
 }
 
+func deriveNewSeedFast(address basics.Address, vrf *crypto.VRFSecrets, rnd round, period period, ledger LedgerReader) (newSeed committee.Seed, seedProof crypto.VRFProof, reterr error) {
+	var ok bool
+	var vrfOut crypto.VrfOutput
+
+	cparams, err := ledger.ConsensusParams(ParamsRound(rnd))
+	if err != nil {
+		reterr = fmt.Errorf("failed to obtain consensus parameters in round %d: %v", ParamsRound(rnd), err)
+		return
+	}
+	var alpha crypto.Digest
+	prevSeed, err := ledger.Seed(seedRound(rnd, cparams))
+	if err != nil {
+		reterr = fmt.Errorf("failed read seed of round %d: %v", seedRound(rnd, cparams), err)
+		return
+	}
+
+	if period == 0 {
+		seedProof, ok = vrf.SK.Prove(prevSeed)
+		if !ok {
+			reterr = fmt.Errorf("could not make seed proof")
+			return
+		}
+		vrfOut, ok = seedProof.Hash()
+		if !ok {
+			// If proof2hash fails on a proof we produced with VRF Prove, this indicates our VRF code has a dangerous bug.
+			// Panicking is the only safe thing to do.
+			logging.Base().Panicf("VrfProof.Hash() failed on a proof we ourselves generated; this indicates a bug in the VRF code: %v", seedProof)
+		}
+		alpha = crypto.HashObjFast(proposerSeed{Addr: address, VRF: vrfOut})
+	} else {
+		alpha = crypto.HashObjFast(prevSeed)
+	}
+
+	input := seedInput{Alpha: alpha}
+	rerand := rnd % basics.Round(cparams.SeedLookback*cparams.SeedRefreshInterval)
+	if rerand < basics.Round(cparams.SeedLookback) {
+		digrnd := rnd.SubSaturate(basics.Round(cparams.SeedLookback * cparams.SeedRefreshInterval))
+		oldDigest, err := ledger.LookupDigest(digrnd)
+		if err != nil {
+			reterr = fmt.Errorf("could not lookup old entry digest (for seed) from round %d: %v", digrnd, err)
+			return
+		}
+		input.History = oldDigest
+	}
+	newSeed = committee.Seed(crypto.HashObjFast(input))
+	return
+}
+
 func verifyNewSeed(p unauthenticatedProposal, ledger LedgerReader) error {
 	value := p.value()
 	rnd := p.Round()
@@ -258,6 +306,24 @@ func proposalForBlock(address basics.Address, vrf *crypto.VRFSecrets, ve Validat
 		OriginalProposer: address,
 		BlockDigest:      proposal.Block.Digest(),
 		EncodingDigest:   crypto.HashObj(proposal),
+	}
+	return proposal, value, nil
+}
+
+func proposalForBlockFast(address basics.Address, vrf *crypto.VRFSecrets, ve ValidatedBlock, period period, ledger LedgerReader) (proposal, proposalValue, error) {
+	rnd := ve.Block().Round()
+	newSeed, seedProof, err := deriveNewSeedFast(address, vrf, rnd, period, ledger)
+	if err != nil {
+		return proposal{}, proposalValue{}, fmt.Errorf("proposalForBlock: could not derive new seed: %v", err)
+	}
+
+	ve = ve.WithSeed(newSeed)
+	proposal := makeProposal(ve, seedProof, period, address)
+	value := proposalValue{
+		OriginalPeriod:   period,
+		OriginalProposer: address,
+		BlockDigest:      proposal.Block.DigestFast(),
+		EncodingDigest:   crypto.HashObjFast(proposal),
 	}
 	return proposal, value, nil
 }

--- a/agreement/proposalStore_test.go
+++ b/agreement/proposalStore_test.go
@@ -928,3 +928,39 @@ func TestProposalStoreRegressionWrongPipelinePeriodBug_39387501(t *testing.T) {
 		require.Equal(t, res.(payloadProcessedEvent).Period, period(1))
 	}
 }
+
+func BenchmarkProposalForBlock(b *testing.B) {
+	type fields struct {
+		Pipeline       unauthenticatedProposal
+		Filled         bool
+		Payload        proposal
+		Assembled      bool
+		Authenticators []vote
+	}
+	type args struct {
+		p unauthenticatedProposal
+	}
+
+	player, _, accounts, factory, ledger := testSetup(0)
+
+	round := player.Round
+	period := player.Period
+	testBlockFactory, err := factory.AssembleBlock(player.Round)
+	require.NoError(b, err, "Could not generate a proposal for round %d: %v", round, err)
+
+	accountIndex := 0
+	accountIndex++
+
+	b.Run("existing", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			proposalForBlock(accounts.addresses[accountIndex], accounts.vrfs[accountIndex], testBlockFactory, period, ledger)
+		}
+	})
+	b.Run("new", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			proposalForBlockFast(accounts.addresses[accountIndex], accounts.vrfs[accountIndex], testBlockFactory, period, ledger)
+		}
+	})
+}

--- a/cmd/goal/application.go
+++ b/cmd/goal/application.go
@@ -488,7 +488,7 @@ var createAppCmd = &cobra.Command{
 				reportErrorf(errorBroadcastingTX, err2)
 			}
 
-			reportInfof("Attempting to create app (approval size %d, hash %v; clear size %d, hash %v)", len(approvalProg), crypto.HashObj(logic.Program(approvalProg)), len(clearProg), crypto.HashObj(logic.Program(clearProg)))
+			reportInfof("Attempting to create app (approval size %d, hash %v; clear size %d, hash %v)", len(approvalProg), crypto.HashObj(logic.Program(approvalProg)), len(clearProg), logic.HashProgram(clearProg))
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
@@ -563,7 +563,7 @@ var updateAppCmd = &cobra.Command{
 				reportErrorf(errorBroadcastingTX, err2)
 			}
 
-			reportInfof("Attempting to update app (approval size %d, hash %v; clear size %d, hash %v)", len(approvalProg), crypto.HashObj(logic.Program(approvalProg)), len(clearProg), crypto.HashObj(logic.Program(clearProg)))
+			reportInfof("Attempting to update app (approval size %d, hash %v; clear size %d, hash %v)", len(approvalProg), crypto.HashObj(logic.Program(approvalProg)), len(clearProg), logic.HashProgram(clearProg))
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 
 			if !noWaitAfterSend {
@@ -1455,9 +1455,9 @@ var methodAppCmd = &cobra.Command{
 
 		// Report tx details to user
 		if methodCreatesApp {
-			reportInfof("Attempting to create app (approval size %d, hash %v; clear size %d, hash %v)", len(approvalProg), crypto.HashObj(logic.Program(approvalProg)), len(clearProg), crypto.HashObj(logic.Program(clearProg)))
+			reportInfof("Attempting to create app (approval size %d, hash %v; clear size %d, hash %v)", len(approvalProg), crypto.HashObj(logic.Program(approvalProg)), len(clearProg), logic.HashProgram(clearProg))
 		} else if onCompletionEnum == transactions.UpdateApplicationOC {
-			reportInfof("Attempting to update app (approval size %d, hash %v; clear size %d, hash %v)", len(approvalProg), crypto.HashObj(logic.Program(approvalProg)), len(clearProg), crypto.HashObj(logic.Program(clearProg)))
+			reportInfof("Attempting to update app (approval size %d, hash %v; clear size %d, hash %v)", len(approvalProg), crypto.HashObj(logic.Program(approvalProg)), len(clearProg), logic.HashProgram(clearProg))
 		}
 
 		reportInfof("Issued %d transaction(s):", len(signedTxnGroup))

--- a/cmd/goal/interact.go
+++ b/cmd/goal/interact.go
@@ -625,9 +625,9 @@ var appExecuteCmd = &cobra.Command{
 			}
 
 			if appIdx == 0 {
-				reportInfof("Attempting to create app (global ints %d, global blobs %d, local ints %d, local blobs %d, approval size %d, hash %v; clear size %d, hash %v)", globalSchema.NumUint, globalSchema.NumByteSlice, localSchema.NumUint, localSchema.NumByteSlice, len(approvalProg), crypto.HashObj(logic.Program(approvalProg)), len(clearProg), crypto.HashObj(logic.Program(clearProg)))
+				reportInfof("Attempting to create app (global ints %d, global blobs %d, local ints %d, local blobs %d, approval size %d, hash %v; clear size %d, hash %v)", globalSchema.NumUint, globalSchema.NumByteSlice, localSchema.NumUint, localSchema.NumByteSlice, len(approvalProg), logic.HashProgram(approvalProg), len(clearProg), crypto.HashObj(logic.Program(clearProg)))
 			} else if onCompletion == transactions.UpdateApplicationOC {
-				reportInfof("Attempting to update app (approval size %d, hash %v; clear size %d, hash %v)", len(approvalProg), crypto.HashObj(logic.Program(approvalProg)), len(clearProg), crypto.HashObj(logic.Program(clearProg)))
+				reportInfof("Attempting to update app (approval size %d, hash %v; clear size %d, hash %v)", len(approvalProg), crypto.HashObj(logic.Program(approvalProg)), len(clearProg), logic.HashProgram(clearProg))
 			}
 			reportInfof("Issued transaction from account %s, txid %s (fee %d)", tx.Sender, txid, tx.Fee.Raw)
 

--- a/cmd/goal/tealsign.go
+++ b/cmd/goal/tealsign.go
@@ -139,7 +139,7 @@ The base64 encoding of the signature will always be printed to stdout. Optionall
 				reportErrorf(tealsignEmptyLogic)
 			}
 
-			progHash = crypto.HashObj(logic.Program(stxn.Lsig.Logic))
+			progHash = logic.HashProgram(stxn.Lsig.Logic)
 		} else {
 			// Otherwise, the contract address is the logic hash
 			parsedAddr, err := basics.UnmarshalChecksumAddress(contractAddr)

--- a/crypto/hashes_test.go
+++ b/crypto/hashes_test.go
@@ -53,7 +53,6 @@ func TestHashSum(t *testing.T) {
 
 	dgst := HashObj(TestingHashable{})
 	a.Equal(GenericHashObj(h, TestingHashable{}), dgst[:])
-
 }
 
 func TestEmptyHash(t *testing.T) {

--- a/crypto/util.go
+++ b/crypto/util.go
@@ -40,6 +40,12 @@ func HashRep(h Hashable) []byte {
 	return append([]byte(hashid), data...)
 }
 
+// HashRepFast appends the correct hashid before the message to be hashed.
+func HashRepFast[H Hashable](h H) []byte {
+	hashid, data := h.ToBeHashed()
+	return append([]byte(hashid), data...)
+}
+
 // DigestSize is the number of bytes in the preferred hash Digest used here.
 const DigestSize = sha512.Size256
 
@@ -88,6 +94,11 @@ func Hash(data []byte) Digest {
 // HashObj computes a hash of a Hashable object and its type
 func HashObj(h Hashable) Digest {
 	return Hash(HashRep(h))
+}
+
+// HashObjFast computes a hash of a Hashable object and its type
+func HashObjFast[H Hashable](h H) Digest {
+	return Hash(HashRepFast(h))
 }
 
 // NewHash returns a sha512-256 object to do the same operation as Hash()

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"golang.org/x/sync/semaphore"
 	"io"
 	"math"
 	"net"
@@ -32,6 +31,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/sync/semaphore"
 
 	"github.com/algorand/go-algorand/daemon/algod/api/server"
 	"github.com/algorand/go-algorand/ledger/eval"
@@ -272,8 +273,7 @@ func addBlockHelper(t *testing.T) (v2.Handlers, echo.Context, *httptest.Response
 
 	// make an app call txn with eval delta
 	lsig := transactions.LogicSig{Logic: retOneProgram} // int 1
-	program := logic.Program(lsig.Logic)
-	lhash := crypto.HashObj(&program)
+	lhash := logic.HashProgram(lsig.Logic)
 	var sender basics.Address
 	copy(sender[:], lhash[:])
 	stx := transactions.SignedTxn{

--- a/daemon/algod/api/server/v2/test/helpers.go
+++ b/daemon/algod/api/server/v2/test/helpers.go
@@ -342,8 +342,7 @@ func testingenvWithBalances(t testing.TB, minMoneyAtStart, maxMoneyAtStart, numA
 
 	genesis[poolAddr] = basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 100000 * uint64(proto.RewardsRateRefreshInterval)})
 
-	program := logic.Program(retOneProgram)
-	lhash := crypto.HashObj(&program)
+	lhash := logic.HashProgram(retOneProgram)
 	var addr basics.Address
 	copy(addr[:], lhash[:])
 	ad := basics_testing.MakeAccountData(basics.NotParticipating, basics.MicroAlgos{Raw: 100000 * uint64(proto.RewardsRateRefreshInterval)})

--- a/data/account/participation.go
+++ b/data/account/participation.go
@@ -84,6 +84,11 @@ func (id ParticipationKeyIdentity) ID() ParticipationID {
 	return ParticipationID(crypto.HashObj(&id))
 }
 
+// ID creates a ParticipationID hash from the identity file.
+func (id *ParticipationKeyIdentity) IDFast() ParticipationID {
+	return ParticipationID(crypto.HashObjFast(id))
+}
+
 // ID computes a ParticipationID.
 func (part Participation) ID() ParticipationID {
 	idData := ParticipationKeyIdentity{

--- a/data/account/participation_test.go
+++ b/data/account/participation_test.go
@@ -606,3 +606,19 @@ func BenchmarkParticipationSign(b *testing.B) {
 		_ = part.Voting.Sign(ephID, msg)
 	}
 }
+
+func BenchmarkID(b *testing.B) {
+	pki := ParticipationKeyIdentity{}
+	b.Run("existing", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			pki.ID()
+		}
+	})
+	b.Run("new", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			pki.IDFast()
+		}
+	})
+}

--- a/data/basics/userBalance.go
+++ b/data/basics/userBalance.go
@@ -414,6 +414,11 @@ func (app AppIndex) Address() Address {
 	return Address(crypto.HashObj(app))
 }
 
+// AddressFast yields the "app address" of the app
+func (app AppIndex) AddressFast() Address {
+	return Address(crypto.HashObjFast(app))
+}
+
 // Money returns the amount of MicroAlgos associated with the user's account
 func (u AccountData) Money(proto config.ConsensusParams, rewardsLevel uint64) (money MicroAlgos, rewards MicroAlgos) {
 	e := u.WithUpdatedRewards(proto, rewardsLevel)

--- a/data/basics/userBalance_test.go
+++ b/data/basics/userBalance_test.go
@@ -175,6 +175,23 @@ func TestAppIndexHashing(t *testing.T) {
 	require.Equal(t, "PCYUFPA2ZTOYWTP43MX2MOX2OWAIAXUDNC2WFCXAGMRUZ3DYD6BWFDL5YM", i.Address().String())
 }
 
+func BenchmarkAddress(b *testing.B) {
+	b.ReportAllocs()
+	ai := AppIndex(12)
+	b.Run("existing", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			ai.Address()
+		}
+	})
+	b.Run("new", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			ai.AddressFast()
+		}
+	})
+}
+
 func TestOnlineAccountData(t *testing.T) {
 	partitiontest.PartitionTest(t)
 

--- a/data/bookkeeping/block.go
+++ b/data/bookkeeping/block.go
@@ -244,6 +244,10 @@ func (bh BlockHeader) Hash() BlockHash {
 	return BlockHash(crypto.HashObj(bh))
 }
 
+func (bh BlockHeader) HashFast() BlockHash {
+	return BlockHash(crypto.HashObjFast(bh))
+}
+
 // ToBeHashed implements the crypto.Hashable interface
 func (bh BlockHeader) ToBeHashed() (protocol.HashID, []byte) {
 	return protocol.BlockHeader, protocol.Encode(&bh)
@@ -252,6 +256,11 @@ func (bh BlockHeader) ToBeHashed() (protocol.HashID, []byte) {
 // Digest returns a cryptographic digest summarizing the Block.
 func (block Block) Digest() crypto.Digest {
 	return crypto.Digest(block.BlockHeader.Hash())
+}
+
+// Digest returns a cryptographic digest summarizing the Block.
+func (block Block) DigestFast() crypto.Digest {
+	return crypto.Digest(block.BlockHeader.HashFast())
 }
 
 // Round returns the Round for which the Block is relevant

--- a/data/bookkeeping/genesis.go
+++ b/data/bookkeeping/genesis.go
@@ -107,6 +107,11 @@ func (genesis Genesis) Hash() crypto.Digest {
 	return crypto.HashObj(genesis)
 }
 
+// HashFast is the genesis hash.
+func (genesis Genesis) HashFast() crypto.Digest {
+	return crypto.HashObjFast(genesis)
+}
+
 // Balances returns the genesis account balances.
 func (genesis Genesis) Balances() (GenesisBalances, error) {
 	genalloc := make(map[basics.Address]basics.AccountData)

--- a/data/bookkeeping/genesis_test.go
+++ b/data/bookkeeping/genesis_test.go
@@ -155,3 +155,20 @@ func TestGenesis_Balances(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkGenesisHash(b *testing.B) {
+	b.ReportAllocs()
+	g := Genesis{}
+	b.Run("existing", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			g.Hash()
+		}
+	})
+	b.Run("new", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			g.HashFast()
+		}
+	})
+}

--- a/data/transactions/logic/program.go
+++ b/data/transactions/logic/program.go
@@ -35,3 +35,10 @@ func HashProgram(program []byte) crypto.Digest {
 	pb := Program(program)
 	return crypto.HashObj(&pb)
 }
+
+// HashProgram takes program bytes and returns the Digest
+// This Digest can be used as an Address for a logic controlled account.
+func HashProgramFast(program []byte) crypto.Digest {
+	pb := Program(program)
+	return crypto.HashObjFast(pb)
+}

--- a/data/transactions/logic/program_test.go
+++ b/data/transactions/logic/program_test.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2019-2023 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package logic
+
+import (
+	"testing"
+)
+
+func BenchmarkProgramHash(b *testing.B) {
+	bytecode := make([]byte, 100)
+	b.Run("existing", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			HashProgram(bytecode)
+		}
+	})
+	b.Run("new", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			HashProgramFast(bytecode)
+		}
+	})
+}


### PR DESCRIPTION
The way we currently hash various objects is with:

```
// HashRep appends the correct hashid before the message to be hashed.
func HashRep(h Hashable) []byte {
	hashid, data := h.ToBeHashed()
	return append([]byte(hashid), data...)
}
```

This means that every callers generally have to allocate in order to convert their argument, which might be a `BlockHeader`, for example, into a Hashable. (This happens transparently, of course.)

However, by writing HashRep as:

```
func HashRep[H Hashable](h H) []byte {
	hashid, data := h.ToBeHashed()
	return append([]byte(hashid), data...)
}
```

We use generics to make a HashRep for each Hashable type. So a `Hashable` need not be created to call it. Thus we we get one fewer allocations most of the time.

For this PR, I did this by writing `HashRepFast` instead, so that I could commit some benchmarks.  They show one for allocation.

I had to create several copies of existsing functions to make the Benchmarks work.  In the real PR, I'll remove all that extra stuff.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
