### PR TITLE
go-algorand 3.20.0-beta Release PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Please refer to our [CONTRIBUTING](CONTRIBUTING.md) document.
 
 ## Project Layout
 
-`go-algorand` is split into various subsystems containing varius packages.
+`go-algorand` is split into various subsystems containing various packages.
 
 ### Core
 

--- a/cmd/algocfg/profileCommand.go
+++ b/cmd/algocfg/profileCommand.go
@@ -92,6 +92,7 @@ func init() {
 	rootCmd.AddCommand(profileCmd)
 	profileCmd.AddCommand(setProfileCmd)
 	setProfileCmd.Flags().BoolVarP(&forceUpdate, "yes", "y", false, "Force updates to be written")
+	profileCmd.AddCommand(printProfileCmd)
 	profileCmd.AddCommand(listProfileCmd)
 }
 
@@ -133,6 +134,23 @@ var listProfileCmd = &cobra.Command{
 	},
 }
 
+var printProfileCmd = &cobra.Command{
+	Use:   "print",
+	Short: "Print config.json to stdout.",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg, err := getConfigForArg(args[0])
+		if err != nil {
+			reportErrorf("%v", err)
+		}
+		err = codecs.WriteNonDefaultValues(os.Stdout, cfg, config.GetDefaultLocal(), nil)
+		if err != nil {
+			reportErrorf("Error writing config file to stdout: %s", err)
+		}
+		fmt.Fprintf(os.Stdout, "\n")
+	},
+}
+
 var setProfileCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set config.json file from a profile.",
@@ -157,7 +175,7 @@ var setProfileCmd = &cobra.Command{
 					return
 				}
 			}
-			err = codecs.SaveNonDefaultValuesToFile(file, cfg, config.GetDefaultLocal(), nil, true)
+			err = codecs.SaveNonDefaultValuesToFile(file, cfg, config.GetDefaultLocal(), nil)
 			if err != nil {
 				reportErrorf("Error saving updated config file '%s' - %s", file, err)
 			}

--- a/cmd/algocfg/resetCommand.go
+++ b/cmd/algocfg/resetCommand.go
@@ -63,7 +63,7 @@ var resetCmd = &cobra.Command{
 			}
 
 			file := filepath.Join(dataDir, config.ConfigFilename)
-			err = codecs.SaveNonDefaultValuesToFile(file, cfg, defaults, nil, true)
+			err = codecs.SaveNonDefaultValuesToFile(file, cfg, defaults, nil)
 			if err != nil {
 				reportWarnf("Error saving updated config file '%s' - %s", file, err)
 				anyError = true

--- a/cmd/algocfg/setCommand.go
+++ b/cmd/algocfg/setCommand.go
@@ -66,7 +66,7 @@ var setCmd = &cobra.Command{
 			}
 
 			file := filepath.Join(dataDir, config.ConfigFilename)
-			err = codecs.SaveNonDefaultValuesToFile(file, cfg, config.GetDefaultLocal(), nil, true)
+			err = codecs.SaveNonDefaultValuesToFile(file, cfg, config.GetDefaultLocal(), nil)
 			if err != nil {
 				reportWarnf("Error saving updated config file '%s' - %s", file, err)
 				anyError = true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -675,6 +675,12 @@ func TestEnsureAbsDir(t *testing.T) {
 	require.Equal(t, testDirectory+"/myGenesisID", t2Abs)
 }
 
+type tLogger struct{ t *testing.T }
+
+func (l tLogger) Infof(fmts string, args ...interface{}) {
+	l.t.Logf(fmts, args...)
+}
+
 // TestEnsureAndResolveGenesisDirs confirms that paths provided in the config are resolved to absolute paths and are created if relevant
 func TestEnsureAndResolveGenesisDirs(t *testing.T) {
 	partitiontest.PartitionTest(t)
@@ -689,7 +695,7 @@ func TestEnsureAndResolveGenesisDirs(t *testing.T) {
 	cfg.StateproofDir = filepath.Join(testDirectory, "/RELATIVEPATHS/../RELATIVE/../custom_stateproof")
 	cfg.CatchpointDir = filepath.Join(testDirectory, "custom_catchpoint")
 
-	paths, err := cfg.EnsureAndResolveGenesisDirs(testDirectory, "myGenesisID")
+	paths, err := cfg.EnsureAndResolveGenesisDirs(testDirectory, "myGenesisID", tLogger{t: t})
 	require.NoError(t, err)
 
 	// confirm that the paths are absolute, and contain the genesisID
@@ -711,7 +717,7 @@ func TestEnsureAndResolveGenesisDirs_hierarchy(t *testing.T) {
 
 	cfg := GetDefaultLocal()
 	testDirectory := t.TempDir()
-	paths, err := cfg.EnsureAndResolveGenesisDirs(testDirectory, "myGenesisID")
+	paths, err := cfg.EnsureAndResolveGenesisDirs(testDirectory, "myGenesisID", tLogger{t: t})
 	require.NoError(t, err)
 	// confirm that if only the root is specified, it is used for all directories
 	require.Equal(t, testDirectory+"/myGenesisID", paths.TrackerGenesisDir)
@@ -731,19 +737,123 @@ func TestEnsureAndResolveGenesisDirs_hierarchy(t *testing.T) {
 	cold := filepath.Join(testDirectory, "cold")
 	cfg.HotDataDir = hot
 	cfg.ColdDataDir = cold
-	paths, err = cfg.EnsureAndResolveGenesisDirs(testDirectory, "myGenesisID")
+	paths, err = cfg.EnsureAndResolveGenesisDirs(testDirectory, "myGenesisID", tLogger{t: t})
 	require.NoError(t, err)
 	// confirm that if hot/cold are specified, hot/cold are used for appropriate directories
 	require.Equal(t, hot+"/myGenesisID", paths.TrackerGenesisDir)
 	require.DirExists(t, paths.TrackerGenesisDir)
 	require.Equal(t, cold+"/myGenesisID", paths.BlockGenesisDir)
 	require.DirExists(t, paths.BlockGenesisDir)
-	require.Equal(t, cold+"/myGenesisID", paths.CrashGenesisDir)
+	require.Equal(t, hot+"/myGenesisID", paths.CrashGenesisDir)
 	require.DirExists(t, paths.CrashGenesisDir)
-	require.Equal(t, cold+"/myGenesisID", paths.StateproofGenesisDir)
+	require.Equal(t, hot+"/myGenesisID", paths.StateproofGenesisDir)
 	require.DirExists(t, paths.StateproofGenesisDir)
 	require.Equal(t, cold+"/myGenesisID", paths.CatchpointGenesisDir)
 	require.DirExists(t, paths.CatchpointGenesisDir)
+}
+
+func TestEnsureAndResolveGenesisDirs_migrate(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	cfg := GetDefaultLocal()
+	testDirectory := t.TempDir()
+	cfg.HotDataDir = filepath.Join(testDirectory, "hot")
+	cfg.ColdDataDir = filepath.Join(testDirectory, "cold")
+	coldDir := filepath.Join(cfg.ColdDataDir, "myGenesisID")
+	hotDir := filepath.Join(cfg.HotDataDir, "myGenesisID")
+	err := os.MkdirAll(coldDir, 0755)
+	require.NoError(t, err)
+	// put a crash.sqlite file in the ColdDataDir
+	err = os.WriteFile(filepath.Join(coldDir, "crash.sqlite"), []byte("test"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(coldDir, "crash.sqlite-shm"), []byte("test"), 0644)
+	require.NoError(t, err)
+	// put a stateproof.sqlite file in the ColdDataDir
+	err = os.WriteFile(filepath.Join(coldDir, "stateproof.sqlite"), []byte("test"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(coldDir, "stateproof.sqlite-wal"), []byte("test"), 0644)
+	require.NoError(t, err)
+	// Resolve
+	paths, err := cfg.EnsureAndResolveGenesisDirs(testDirectory, "myGenesisID", tLogger{t: t})
+	require.NoError(t, err)
+	// Confirm that crash.sqlite was moved to HotDataDir
+	require.DirExists(t, paths.CrashGenesisDir)
+	require.Equal(t, hotDir, paths.CrashGenesisDir)
+	require.NoFileExists(t, filepath.Join(coldDir, "crash.sqlite"))
+	require.NoFileExists(t, filepath.Join(coldDir, "crash.sqlite-shm"))
+	require.FileExists(t, filepath.Join(hotDir, "crash.sqlite"))
+	require.FileExists(t, filepath.Join(hotDir, "crash.sqlite-shm"))
+	// Confirm that stateproof.sqlite was moved to HotDataDir
+	require.DirExists(t, paths.StateproofGenesisDir)
+	require.Equal(t, hotDir, paths.StateproofGenesisDir)
+	require.NoFileExists(t, filepath.Join(coldDir, "stateproof.sqlite"))
+	require.NoFileExists(t, filepath.Join(coldDir, "stateproof.sqlite-wal"))
+	require.FileExists(t, filepath.Join(hotDir, "stateproof.sqlite"))
+	require.FileExists(t, filepath.Join(hotDir, "stateproof.sqlite-wal"))
+}
+
+func TestEnsureAndResolveGenesisDirs_migrateCrashFail(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	cfg := GetDefaultLocal()
+	testDirectory := t.TempDir()
+	cfg.HotDataDir = filepath.Join(testDirectory, "hot")
+	cfg.ColdDataDir = filepath.Join(testDirectory, "cold")
+	coldDir := filepath.Join(cfg.ColdDataDir, "myGenesisID")
+	hotDir := filepath.Join(cfg.HotDataDir, "myGenesisID")
+	err := os.MkdirAll(coldDir, 0755)
+	require.NoError(t, err)
+	err = os.MkdirAll(hotDir, 0755)
+	require.NoError(t, err)
+	// put a crash.sqlite file in the ColdDataDir
+	err = os.WriteFile(filepath.Join(coldDir, "crash.sqlite"), []byte("test"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(coldDir, "crash.sqlite-shm"), []byte("test"), 0644)
+	require.NoError(t, err)
+	// also put a crash.sqlite file in the HotDataDir
+	err = os.WriteFile(filepath.Join(hotDir, "crash.sqlite"), []byte("test"), 0644)
+	require.NoError(t, err)
+	// Resolve
+	paths, err := cfg.EnsureAndResolveGenesisDirs(testDirectory, "myGenesisID", tLogger{t: t})
+	require.Error(t, err)
+	require.Empty(t, paths)
+	// Confirm that crash.sqlite was not moved to HotDataDir
+	require.FileExists(t, filepath.Join(coldDir, "crash.sqlite"))
+	require.FileExists(t, filepath.Join(coldDir, "crash.sqlite-shm"))
+	require.FileExists(t, filepath.Join(hotDir, "crash.sqlite"))
+	require.NoFileExists(t, filepath.Join(hotDir, "crash.sqlite-shm"))
+}
+
+func TestEnsureAndResolveGenesisDirs_migrateSPFail(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	cfg := GetDefaultLocal()
+	testDirectory := t.TempDir()
+	cfg.HotDataDir = filepath.Join(testDirectory, "hot")
+	cfg.ColdDataDir = filepath.Join(testDirectory, "cold")
+	coldDir := filepath.Join(cfg.ColdDataDir, "myGenesisID")
+	hotDir := filepath.Join(cfg.HotDataDir, "myGenesisID")
+	err := os.MkdirAll(coldDir, 0755)
+	require.NoError(t, err)
+	err = os.MkdirAll(hotDir, 0755)
+	require.NoError(t, err)
+	// put a stateproof.sqlite file in the ColdDataDir
+	err = os.WriteFile(filepath.Join(coldDir, "stateproof.sqlite"), []byte("test"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(coldDir, "stateproof.sqlite-wal"), []byte("test"), 0644)
+	require.NoError(t, err)
+	// also put a stateproof.sqlite-wal file in the HotDataDir
+	err = os.WriteFile(filepath.Join(hotDir, "stateproof.sqlite-wal"), []byte("test"), 0644)
+	require.NoError(t, err)
+	// Resolve
+	paths, err := cfg.EnsureAndResolveGenesisDirs(testDirectory, "myGenesisID", tLogger{t: t})
+	require.Error(t, err)
+	require.Empty(t, paths)
+	// Confirm that stateproof.sqlite was not moved to HotDataDir
+	require.FileExists(t, filepath.Join(coldDir, "stateproof.sqlite"))
+	require.FileExists(t, filepath.Join(coldDir, "stateproof.sqlite-wal"))
+	require.NoFileExists(t, filepath.Join(hotDir, "stateproof.sqlite"))
+	require.FileExists(t, filepath.Join(hotDir, "stateproof.sqlite-wal"))
 }
 
 // TestEnsureAndResolveGenesisDirsError confirms that if a path can't be created, an error is returned
@@ -761,7 +871,7 @@ func TestEnsureAndResolveGenesisDirsError(t *testing.T) {
 	cfg.CatchpointDir = filepath.Join(testDirectory, "custom_catchpoint")
 
 	// first try an error with an empty root dir
-	paths, err := cfg.EnsureAndResolveGenesisDirs("", "myGenesisID")
+	paths, err := cfg.EnsureAndResolveGenesisDirs("", "myGenesisID", tLogger{t: t})
 	require.Empty(t, paths)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "rootDir is required")
@@ -769,7 +879,7 @@ func TestEnsureAndResolveGenesisDirsError(t *testing.T) {
 	require.NoError(t, os.Chmod(testDirectory, 0200))
 
 	// now try an error with a root dir that can't be written to
-	paths, err = cfg.EnsureAndResolveGenesisDirs(testDirectory, "myGenesisID")
+	paths, err = cfg.EnsureAndResolveGenesisDirs(testDirectory, "myGenesisID", tLogger{t: t})
 	require.Empty(t, paths)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "permission denied")

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -111,13 +111,13 @@ type Local struct {
 	// For isolation, the node will create a subdirectory in this location, named by the genesis-id of the network.
 	// If not specified, the node will use the ColdDataDir.
 	CatchpointDir string `version[31]:""`
-	// StateproofDir is an optional directory to store stateproof data.
+	// StateproofDir is an optional directory to persist state about observed and issued state proof messages.
 	// For isolation, the node will create a subdirectory in this location, named by the genesis-id of the network.
-	// If not specified, the node will use the ColdDataDir.
+	// If not specified, the node will use the HotDataDir.
 	StateproofDir string `version[31]:""`
-	// CrashDBDir is an optional directory to store the crash database.
+	// CrashDBDir is an optional directory to persist agreement's consensus participation state.
 	// For isolation, the node will create a subdirectory in this location, named by the genesis-id of the network.
-	// If not specified, the node will use the ColdDataDir.
+	// If not specified, the node will use the HotDataDir
 	CrashDBDir string `version[31]:""`
 
 	// LogFileDir is an optional directory to store the log, node.log
@@ -666,7 +666,7 @@ func (cfg Local) SaveAllToDisk(root string) error {
 func (cfg Local) SaveToFile(filename string) error {
 	var alwaysInclude []string
 	alwaysInclude = append(alwaysInclude, "Version")
-	return codecs.SaveNonDefaultValuesToFile(filename, cfg, defaultLocal, alwaysInclude, true)
+	return codecs.SaveNonDefaultValuesToFile(filename, cfg, defaultLocal, alwaysInclude)
 }
 
 // DNSSecuritySRVEnforced returns true if SRV response verification enforced
@@ -785,9 +785,13 @@ func (cfg *Local) ResolveLogPaths(rootDir string) (liveLog, archive string) {
 	return liveLog, archive
 }
 
+type logger interface {
+	Infof(format string, args ...interface{})
+}
+
 // EnsureAndResolveGenesisDirs will resolve the supplied config paths to absolute paths, and will create the genesis directories of each
 // returns a ResolvedGenesisDirs struct with the resolved paths for use during runtime
-func (cfg *Local) EnsureAndResolveGenesisDirs(rootDir, genesisID string) (ResolvedGenesisDirs, error) {
+func (cfg *Local) EnsureAndResolveGenesisDirs(rootDir, genesisID string, logger logger) (ResolvedGenesisDirs, error) {
 	var resolved ResolvedGenesisDirs
 	var err error
 	if rootDir != "" {
@@ -843,25 +847,60 @@ func (cfg *Local) EnsureAndResolveGenesisDirs(rootDir, genesisID string) (Resolv
 	} else {
 		resolved.CatchpointGenesisDir = resolved.ColdGenesisDir
 	}
-	// if StateproofDir is not set, use ColdDataDir
+	// if StateproofDir is not set, use HotDataDir
 	if cfg.StateproofDir != "" {
 		resolved.StateproofGenesisDir, err = ensureAbsGenesisDir(cfg.StateproofDir, genesisID)
 		if err != nil {
 			return ResolvedGenesisDirs{}, err
 		}
 	} else {
-		resolved.StateproofGenesisDir = resolved.ColdGenesisDir
+		resolved.StateproofGenesisDir = resolved.HotGenesisDir
+		// if separate HotDataDir and ColdDataDir was configured, but StateproofDir was not configured
+		if resolved.ColdGenesisDir != resolved.HotGenesisDir {
+			// move existing stateproof DB files from ColdDataDir to HotDataDir
+			moveErr := moveDirIfExists(logger, resolved.ColdGenesisDir, resolved.HotGenesisDir, StateProofFileName, StateProofFileName+"-shm", StateProofFileName+"-wal")
+			if moveErr != nil {
+				return ResolvedGenesisDirs{}, fmt.Errorf("error moving stateproof DB files from ColdDataDir %s to HotDataDir %s: %v", resolved.ColdGenesisDir, resolved.HotGenesisDir, moveErr)
+			}
+		}
 	}
-	// if CrashDBDir is not set, use ColdDataDir
+	// if CrashDBDir is not set, use HotDataDir
 	if cfg.CrashDBDir != "" {
 		resolved.CrashGenesisDir, err = ensureAbsGenesisDir(cfg.CrashDBDir, genesisID)
 		if err != nil {
 			return ResolvedGenesisDirs{}, err
 		}
 	} else {
-		resolved.CrashGenesisDir = resolved.ColdGenesisDir
+		resolved.CrashGenesisDir = resolved.HotGenesisDir
+		// if separate HotDataDir and ColdDataDir was configured, but CrashDBDir was not configured
+		if resolved.ColdGenesisDir != resolved.HotGenesisDir {
+			// move existing crash DB files from ColdDataDir to HotDataDir
+			moveErr := moveDirIfExists(logger, resolved.ColdGenesisDir, resolved.HotGenesisDir, CrashFilename, CrashFilename+"-shm", CrashFilename+"-wal")
+			if moveErr != nil {
+				return ResolvedGenesisDirs{}, fmt.Errorf("error moving crash DB files from ColdDataDir %s to HotDataDir %s: %v", resolved.ColdGenesisDir, resolved.HotGenesisDir, moveErr)
+			}
+		}
 	}
 	return resolved, nil
+}
+
+func moveDirIfExists(logger logger, srcdir, dstdir string, files ...string) error {
+	// first, check if any files already exist in dstdir, and quit if so
+	for _, file := range files {
+		if _, err := os.Stat(filepath.Join(dstdir, file)); err == nil {
+			return fmt.Errorf("destination file %s already exists, not overwriting", filepath.Join(dstdir, file))
+		}
+	}
+	// then, check if any files exist in srcdir, and move them to dstdir
+	for _, file := range files {
+		if _, err := os.Stat(filepath.Join(srcdir, file)); err == nil {
+			if err := os.Rename(filepath.Join(srcdir, file), filepath.Join(dstdir, file)); err != nil {
+				return fmt.Errorf("failed to move file %s from %s to %s: %v", file, srcdir, dstdir, err)
+			}
+			logger.Infof("Moved DB file %s from ColdDataDir %s to HotDataDir %s", file, srcdir, dstdir)
+		}
+	}
+	return nil
 }
 
 // AdjustConnectionLimits updates RestConnectionsSoftLimit, RestConnectionsHardLimit, IncomingConnectionsLimit

--- a/data/transactions/logic/README.md
+++ b/data/transactions/logic/README.md
@@ -341,7 +341,7 @@ An application transaction must indicate the action to be taken following the ex
 
 Most operations work with only one type of argument, uint64 or bytes, and fail if the wrong type value is on the stack.
 
-Many instructions accept values to designate Accounts, Assets, or Applications. Beginning with v4, these values may be given as an _offset_ in the corresponding Txn fields (Txn.Accounts, Txn.ForeignAssets, Txn.ForeignApps) _or_ as the value itself (a byte-array address for Accounts, or a uint64 ID). The values, however, must still be present in the Txn fields. Before v4, most opcodes required the use of an offset, except for reading account local values of assets or applications, which accepted the IDs directly and did not require the ID to be present in they corresponding _Foreign_ array. (Note that beginning with v4, those IDs _are_ required to be present in their corresponding _Foreign_ array.) See individual opcodes for details. In the case of account offsets or application offsets, 0 is specially defined to Txn.Sender or the ID of the current application, respectively.
+Many instructions accept values to designate Accounts, Assets, or Applications. Beginning with v4, these values may be given as an _offset_ in the corresponding Txn fields (Txn.Accounts, Txn.ForeignAssets, Txn.ForeignApps) _or_ as the value itself (a byte-array address for Accounts, or a uint64 ID). The values, however, must still be present in the Txn fields. Before v4, most opcodes required the use of an offset, except for reading account local values of assets or applications, which accepted the IDs directly and did not require the ID to be present in the corresponding _Foreign_ array. (Note that beginning with v4, those IDs _are_ required to be present in their corresponding _Foreign_ array.) See individual opcodes for details. In the case of account offsets or application offsets, 0 is specially defined to Txn.Sender or the ID of the current application, respectively.
 
 This summary is supplemented by more detail in the [opcodes document](TEAL_opcodes.md).
 
@@ -775,7 +775,7 @@ are sure to be _available_.
 
 The following opcodes allow for "inner transactions". Inner
 transactions allow stateful applications to have many of the effects
-of a true top-level transaction, programatically.  However, they are
+of a true top-level transaction, programmatically.  However, they are
 different in significant ways.  The most important differences are
 that they are not signed, duplicates are not rejected, and they do not
 appear in the block in the usual away. Instead, their effects are
@@ -786,7 +786,7 @@ account that has been rekeyed to that hash.
 
 In v5, inner transactions may perform `pay`, `axfer`, `acfg`, and
 `afrz` effects.  After executing an inner transaction with
-`itxn_submit`, the effects of the transaction are visible begining
+`itxn_submit`, the effects of the transaction are visible beginning
 with the next instruction with, for example, `balance` and
 `min_balance` checks. In v6, inner transactions may also perform
 `keyreg` and `appl` effects. Inner `appl` calls fail if they attempt
@@ -806,7 +806,7 @@ setting is used when `itxn_submit` executes. For this purpose `Type`
 and `TypeEnum` are considered to be the same field. When using
 `itxn_field` to set an array field (`ApplicationArgs` `Accounts`,
 `Assets`, or `Applications`) each use adds an element to the end of
-the the array, rather than setting the entire array at once.
+the array, rather than setting the entire array at once.
 
 `itxn_field` fails immediately for unsupported fields, unsupported
 transaction types, or improperly typed values for a particular

--- a/data/transactions/logic/README_in.md
+++ b/data/transactions/logic/README_in.md
@@ -300,7 +300,7 @@ of (varuint, bytes) length prefixed byte strings.
 
 Most operations work with only one type of argument, uint64 or bytes, and fail if the wrong type value is on the stack.
 
-Many instructions accept values to designate Accounts, Assets, or Applications. Beginning with v4, these values may be given as an _offset_ in the corresponding Txn fields (Txn.Accounts, Txn.ForeignAssets, Txn.ForeignApps) _or_ as the value itself (a byte-array address for Accounts, or a uint64 ID). The values, however, must still be present in the Txn fields. Before v4, most opcodes required the use of an offset, except for reading account local values of assets or applications, which accepted the IDs directly and did not require the ID to be present in they corresponding _Foreign_ array. (Note that beginning with v4, those IDs _are_ required to be present in their corresponding _Foreign_ array.) See individual opcodes for details. In the case of account offsets or application offsets, 0 is specially defined to Txn.Sender or the ID of the current application, respectively.
+Many instructions accept values to designate Accounts, Assets, or Applications. Beginning with v4, these values may be given as an _offset_ in the corresponding Txn fields (Txn.Accounts, Txn.ForeignAssets, Txn.ForeignApps) _or_ as the value itself (a byte-array address for Accounts, or a uint64 ID). The values, however, must still be present in the Txn fields. Before v4, most opcodes required the use of an offset, except for reading account local values of assets or applications, which accepted the IDs directly and did not require the ID to be present in the corresponding _Foreign_ array. (Note that beginning with v4, those IDs _are_ required to be present in their corresponding _Foreign_ array.) See individual opcodes for details. In the case of account offsets or application offsets, 0 is specially defined to Txn.Sender or the ID of the current application, respectively.
 
 This summary is supplemented by more detail in the [opcodes document](TEAL_opcodes.md).
 
@@ -422,7 +422,7 @@ are sure to be _available_.
 
 The following opcodes allow for "inner transactions". Inner
 transactions allow stateful applications to have many of the effects
-of a true top-level transaction, programatically.  However, they are
+of a true top-level transaction, programmatically.  However, they are
 different in significant ways.  The most important differences are
 that they are not signed, duplicates are not rejected, and they do not
 appear in the block in the usual away. Instead, their effects are
@@ -433,7 +433,7 @@ account that has been rekeyed to that hash.
 
 In v5, inner transactions may perform `pay`, `axfer`, `acfg`, and
 `afrz` effects.  After executing an inner transaction with
-`itxn_submit`, the effects of the transaction are visible begining
+`itxn_submit`, the effects of the transaction are visible beginning
 with the next instruction with, for example, `balance` and
 `min_balance` checks. In v6, inner transactions may also perform
 `keyreg` and `appl` effects. Inner `appl` calls fail if they attempt
@@ -453,7 +453,7 @@ setting is used when `itxn_submit` executes. For this purpose `Type`
 and `TypeEnum` are considered to be the same field. When using
 `itxn_field` to set an array field (`ApplicationArgs` `Accounts`,
 `Assets`, or `Applications`) each use adds an element to the end of
-the the array, rather than setting the entire array at once.
+the array, rather than setting the entire array at once.
 
 `itxn_field` fails immediately for unsupported fields, unsupported
 transaction types, or improperly typed values for a particular

--- a/data/transactions/logic/jsonspec.md
+++ b/data/transactions/logic/jsonspec.md
@@ -50,7 +50,7 @@ Duplicate keys at the top level result in an error; however, duplicate keys nest
 #### Special Values
 
 - `null`, `true`, `false` are the only accepted special values.
-- other spcial values such as `NaN`,`+Inf`,`-Inf` are not accepted
+- other special values such as `NaN`,`+Inf`,`-Inf` are not accepted
 
 #### Exponential Notation
 

--- a/docs/follower_node.md
+++ b/docs/follower_node.md
@@ -34,7 +34,7 @@ Behavior is controlled with the `config.json` file:
 
 On startup, a follower node will be paused (synchronized) with its ledger's
 current round. For a new deployment configured as a follower node, the
-initial sync round is 0. When a sync round is set, the node advance
+initial sync round is 0. When a sync round is set, the node advances
 `MaxAcctLookback-1` rounds. The node is synchronized for the availability
 of `Ledger State Delta` data. This means the minimum sync round is provided
 and the node advances to cache future rounds.
@@ -56,7 +56,7 @@ The follower node was stripped of all functionality not directly related to
 assisting with data-gathering capabilities. Since it is designed to run
 alongside another application, it was made as lightweight as possible.
 Other restrictions relate to the fact that this node is designed to be
-paused. So there are no guarantees that it's internal state matches the
+paused. So there are no guarantees that its internal state matches the
 current round of consensus.
 
 In particular, the follower node cannot participate in consensus or send

--- a/ledger/eval/eval.go
+++ b/ledger/eval/eval.go
@@ -1318,22 +1318,29 @@ func (eval *BlockEvaluator) endOfBlock() error {
 		if !eval.block.StateProofTracking[protocol.StateProofBasic].StateProofVotersCommitment.IsEqual(expectedVoters) {
 			return fmt.Errorf("StateProofVotersCommitment wrong: %v != %v", eval.block.StateProofTracking[protocol.StateProofBasic].StateProofVotersCommitment, expectedVoters)
 		}
-
-		if eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight != expectedVotersWeight {
-			mainnetGenesisHash, _ := crypto.DigestFromString("YBQ4JWH4DW655UWXMBF6IVUOH5WQIGMHVQ333ZFWEC22WOJERLPQ")
-			if eval.genesisHash == mainnetGenesisHash {
-				// Handful of historic rounds where the state proof online total weight is known to be slightly different
-				// than expected voters weight. A consensus release (V38) addressed this/prevented the corner case from
-				// occurring going forward.
-				switch eval.block.Round() {
-				case 24018688, 26982912, 27009024, 27713280, 27822080, 27822848, 27929344, 28032768,
-					28977920, 29822208, 30005248, 30033920:
-					// Don't return an error for these blocks
-				default:
-					return fmt.Errorf("StateProofOnlineTotalWeight wrong: %v != %v", eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight, expectedVotersWeight)
-				}
-			} else {
+		if eval.proto.ExcludeExpiredCirculation {
+			if eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight != expectedVotersWeight {
 				return fmt.Errorf("StateProofOnlineTotalWeight wrong: %v != %v", eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight, expectedVotersWeight)
+			}
+		} else {
+			if eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight != expectedVotersWeight {
+				actualVotersWeight := eval.block.StateProofTracking[protocol.StateProofBasic].StateProofOnlineTotalWeight
+				var highWeight, lowWeight basics.MicroAlgos
+				if expectedVotersWeight.LessThan(actualVotersWeight) {
+					highWeight = actualVotersWeight
+					lowWeight = expectedVotersWeight
+				} else {
+					highWeight = expectedVotersWeight
+					lowWeight = actualVotersWeight
+				}
+				const stakeDiffusionFactor = 1
+				allowedDelta, overflowed := basics.Muldiv(expectedVotersWeight.Raw, stakeDiffusionFactor, 100)
+				if overflowed {
+					return fmt.Errorf("StateProofOnlineTotalWeight overflow: %v != %v", actualVotersWeight, expectedVotersWeight)
+				}
+				if (highWeight.Raw - lowWeight.Raw) > allowedDelta {
+					return fmt.Errorf("StateProofOnlineTotalWeight wrong: %v != %v greater than %d", actualVotersWeight, expectedVotersWeight, allowedDelta)
+				}
 			}
 		}
 		if eval.block.StateProofTracking[protocol.StateProofBasic].StateProofNextRound != eval.state.GetStateProofNextRound() {
@@ -1708,12 +1715,12 @@ transactionGroupLoop:
 		select {
 		case <-ctx.Done():
 			return ledgercore.StateDelta{}, ctx.Err()
-		case err1, open := <-txvalidator.done:
+		case err, open := <-txvalidator.done:
 			if !open {
 				break
 			}
-			if err1 != nil {
-				return ledgercore.StateDelta{}, err1
+			if err != nil {
+				return ledgercore.StateDelta{}, err
 			}
 		}
 	}

--- a/ledger/eval/eval_test.go
+++ b/ledger/eval/eval_test.go
@@ -21,8 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/algorand/go-algorand/crypto/merklearray"
-	"math"
 	"math/rand"
 	"testing"
 
@@ -673,6 +671,56 @@ func testnetFixupExecution(t *testing.T, headerRound basics.Round, poolBonus uin
 	require.NoError(t, err)
 }
 
+// newTestGenesis creates a bunch of accounts, splits up 10B algos
+// between them and the rewardspool and feesink, and gives out the
+// addresses and secrets it creates to enable tests.  For special
+// scenarios, manipulate these return values before using newTestLedger.
+func newTestGenesis() (bookkeeping.GenesisBalances, []basics.Address, []*crypto.SignatureSecrets) {
+	// irrelevant, but deterministic
+	sink, err := basics.UnmarshalChecksumAddress("YTPRLJ2KK2JRFSZZNAF57F3K5Y2KCG36FZ5OSYLW776JJGAUW5JXJBBD7Q")
+	if err != nil {
+		panic(err)
+	}
+	rewards, err := basics.UnmarshalChecksumAddress("242H5OXHUEBYCGGWB3CQ6AZAMQB5TMCWJGHCGQOZPEIVQJKOO7NZXUXDQA")
+	if err != nil {
+		panic(err)
+	}
+
+	const count = 10
+	addrs := make([]basics.Address, count)
+	secrets := make([]*crypto.SignatureSecrets, count)
+	accts := make(map[basics.Address]basics.AccountData)
+
+	// 10 billion microalgos, across N accounts and pool and sink
+	amount := 10 * 1000000000 * 1000000 / uint64(count+2)
+
+	for i := 0; i < count; i++ {
+		// Create deterministic addresses, so that output stays the same, run to run.
+		var seed crypto.Seed
+		seed[0] = byte(i)
+		secrets[i] = crypto.GenerateSignatureSecrets(seed)
+		addrs[i] = basics.Address(secrets[i].SignatureVerifier)
+
+		adata := basics.AccountData{
+			MicroAlgos: basics.MicroAlgos{Raw: amount},
+		}
+		accts[addrs[i]] = adata
+	}
+
+	accts[sink] = basics.AccountData{
+		MicroAlgos: basics.MicroAlgos{Raw: amount},
+		Status:     basics.NotParticipating,
+	}
+
+	accts[rewards] = basics.AccountData{
+		MicroAlgos: basics.MicroAlgos{Raw: amount},
+	}
+
+	genBalances := bookkeeping.MakeGenesisBalances(accts, sink, rewards)
+
+	return genBalances, addrs, secrets
+}
+
 type evalTestLedger struct {
 	blocks              map[basics.Round]bookkeeping.Block
 	roundBalances       map[basics.Round]map[basics.Address]basics.AccountData
@@ -684,7 +732,6 @@ type evalTestLedger struct {
 	latestTotals        ledgercore.AccountTotals
 	tracer              logic.EvalTracer
 	boxes               map[string][]byte
-	voters              map[basics.Round]*ledgercore.VotersForRound
 }
 
 // newTestLedger creates a in memory Ledger that is as realistic as
@@ -894,9 +941,6 @@ func (ledger *evalTestLedger) BlockHdr(rnd basics.Round) (bookkeeping.BlockHeade
 }
 
 func (ledger *evalTestLedger) VotersForStateProof(rnd basics.Round) (*ledgercore.VotersForRound, error) {
-	if v, ok := ledger.voters[rnd]; ok {
-		return v, nil
-	}
 	return nil, errors.New("untested code path")
 }
 
@@ -1400,179 +1444,4 @@ func TestExpiredAccountGeneration(t *testing.T) {
 	require.Equal(t, crypto.OneTimeSignatureVerifier{}, recvAcct.VoteID)
 	require.Equal(t, crypto.VRFVerifier{}, recvAcct.SelectionID)
 	require.Equal(t, merklesignature.Verifier{}.Commitment, recvAcct.StateProofID)
-}
-
-func TestEval_EndOfBlockStake(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	proto := protocol.ConsensusFuture
-	mainnetDigest, digestError := crypto.DigestFromString("YBQ4JWH4DW655UWXMBF6IVUOH5WQIGMHVQ333ZFWEC22WOJERLPQ")
-	require.NoError(t, digestError)
-
-	var tests = []struct {
-		actual      basics.MicroAlgos
-		expected    basics.MicroAlgos
-		round       basics.Round
-		genesisHash crypto.Digest
-		err         string
-	}{
-		// Normal round mainnet, matched stake => no error
-		{
-			actual:      basics.MicroAlgos{Raw: 100},
-			expected:    basics.MicroAlgos{Raw: 100},
-			round:       basics.Round(config.Consensus[proto].StateProofInterval),
-			genesisHash: mainnetDigest,
-			err:         "",
-		},
-		// Normal round mainnet, mismatched stake (actual<expected) => error
-		{
-			actual:      basics.MicroAlgos{Raw: 99},
-			expected:    basics.MicroAlgos{Raw: 100},
-			round:       basics.Round(config.Consensus[proto].StateProofInterval),
-			genesisHash: mainnetDigest,
-			err:         "StateProofOnlineTotalWeight wrong: {99} != {100}",
-		},
-		// Normal round mainnet, mismatched stake (actual>expected) => error
-		{
-			actual:      basics.MicroAlgos{Raw: 100},
-			expected:    basics.MicroAlgos{Raw: 99},
-			round:       basics.Round(config.Consensus[proto].StateProofInterval),
-			genesisHash: mainnetDigest,
-			err:         "StateProofOnlineTotalWeight wrong: {100} != {99}",
-		},
-		// Normal round mainnet, mismatched stake with max possible value for muldiv => error
-		{
-			actual:      basics.MicroAlgos{Raw: 100},
-			expected:    basics.MicroAlgos{Raw: math.MaxUint64},
-			round:       basics.Round(config.Consensus[proto].StateProofInterval),
-			genesisHash: mainnetDigest,
-			err:         "StateProofOnlineTotalWeight wrong: {100} != {18446744073709551615}",
-		},
-		// Normal round mainnet, matched stake with max possible value for muldiv => no error
-		{
-			actual:      basics.MicroAlgos{Raw: math.MaxUint64},
-			expected:    basics.MicroAlgos{Raw: math.MaxUint64},
-			round:       basics.Round(config.Consensus[proto].StateProofInterval),
-			genesisHash: mainnetDigest,
-			err:         "",
-		},
-		// Exception round mainnet, mismatched state (actual>expected) => no error
-		{
-			actual:      basics.MicroAlgos{Raw: 100},
-			expected:    basics.MicroAlgos{Raw: 99},
-			round:       basics.Round(27713280),
-			genesisHash: mainnetDigest,
-			err:         "",
-		},
-		// Exception round mainnet, mismatched state (actual<expected) => no error
-		{
-			actual:      basics.MicroAlgos{Raw: 99},
-			expected:    basics.MicroAlgos{Raw: 100},
-			round:       basics.Round(27713280),
-			genesisHash: mainnetDigest,
-			err:         "",
-		},
-		// Exception round mainnet, mismatched stake with max possible value for muldiv => no error
-		{
-			actual:      basics.MicroAlgos{Raw: math.MaxUint64 - 100},
-			expected:    basics.MicroAlgos{Raw: math.MaxUint64},
-			round:       basics.Round(27713280),
-			genesisHash: mainnetDigest,
-			err:         "",
-		},
-		// Normal round non-mainnet, matched stake => no error
-		{
-			actual:   basics.MicroAlgos{Raw: 100},
-			expected: basics.MicroAlgos{Raw: 100},
-			round:    basics.Round(config.Consensus[proto].StateProofInterval),
-			err:      "",
-		},
-		// Normal round non-mainnet, mismatched stake (actual<expected) => error
-		{
-			actual:   basics.MicroAlgos{Raw: 99},
-			expected: basics.MicroAlgos{Raw: 100},
-			round:    basics.Round(config.Consensus[proto].StateProofInterval),
-			err:      "StateProofOnlineTotalWeight wrong: {99} != {100}",
-		},
-		// Exception round non-mainnet, mismatched state (actual>expected) => no error
-		{
-			actual:   basics.MicroAlgos{Raw: 100},
-			expected: basics.MicroAlgos{Raw: 99},
-			round:    basics.Round(27713280),
-			err:      "StateProofOnlineTotalWeight wrong: {100} != {99}",
-		},
-		// Exception round non-mainnet, mismatched state (actual<expected) => no error
-		{
-			actual:   basics.MicroAlgos{Raw: 99},
-			expected: basics.MicroAlgos{Raw: 100},
-			round:    basics.Round(27713280),
-			err:      "StateProofOnlineTotalWeight wrong: {99} != {100}",
-		},
-		// Exception round non-mainnet, mismatched stake with max possible value for muldiv => no error
-		{
-			actual:   basics.MicroAlgos{Raw: math.MaxUint64 - 100},
-			expected: basics.MicroAlgos{Raw: math.MaxUint64},
-			round:    basics.Round(27713280),
-			err:      "StateProofOnlineTotalWeight wrong: {18446744073709551515} != {18446744073709551615}",
-		},
-	}
-
-	for i, test := range tests {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			params := config.Consensus[proto]
-
-			genesisInitState, _, _ := ledgertesting.GenesisWithProto(2, proto)
-
-			l := newTestLedger(t, bookkeeping.GenesisBalances{
-				Balances:    genesisInitState.Accounts,
-				FeeSink:     testSinkAddr,
-				RewardsPool: testPoolAddr,
-				Timestamp:   0,
-			})
-			// If genesis hash is non-nil in test case, override the test hash here
-			if !test.genesisHash.IsZero() {
-				l.genesisHash = test.genesisHash
-			}
-			l.voters = map[basics.Round]*ledgercore.VotersForRound{
-				basics.Round(uint64(test.round) - params.StateProofVotersLookback): {
-					Tree:        &merklearray.Tree{},
-					TotalWeight: test.expected,
-				},
-			}
-
-			genesisBlockHeader, err := l.BlockHdr(0)
-			require.NoError(t, err)
-			newBlock := bookkeeping.MakeBlock(genesisBlockHeader)
-			newBlock.StateProofTracking = map[protocol.StateProofType]bookkeeping.StateProofTrackingData{
-				protocol.StateProofBasic: {
-					StateProofOnlineTotalWeight: test.actual,
-				},
-			}
-			newBlock.BlockHeader.Round = test.round
-
-			pcow := mockLedger{balanceMap: map[basics.Address]basics.AccountData{}}
-			mods := ledgercore.StateDelta{Hdr: &newBlock.BlockHeader}
-			cow := &roundCowState{
-				lookupParent: &pcow,
-				mods:         mods,
-			}
-			eval := BlockEvaluator{
-				state:       cow,
-				validate:    true,
-				prevHeader:  genesisBlockHeader,
-				proto:       params,
-				genesisHash: l.genesisHash,
-				block:       newBlock,
-				l:           l,
-			}
-
-			err = eval.endOfBlock()
-			if len(test.err) == 0 {
-				require.NoError(t, err)
-			} else {
-				require.ErrorContains(t, err, test.err)
-			}
-		})
-	}
-
 }

--- a/node/follower_node.go
+++ b/node/follower_node.go
@@ -83,7 +83,7 @@ func MakeFollower(log logging.Logger, rootDir string, cfg config.Local, phoneboo
 	node.genesisHash = genesis.Hash()
 	node.devMode = genesis.DevMode
 	var err error
-	node.genesisDirs, err = cfg.EnsureAndResolveGenesisDirs(rootDir, genesis.ID())
+	node.genesisDirs, err = cfg.EnsureAndResolveGenesisDirs(rootDir, genesis.ID(), log)
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -183,7 +183,7 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 	node.devMode = genesis.DevMode
 	node.config = cfg
 	var err error
-	node.genesisDirs, err = cfg.EnsureAndResolveGenesisDirs(rootDir, genesis.ID())
+	node.genesisDirs, err = cfg.EnsureAndResolveGenesisDirs(rootDir, genesis.ID(), log)
 	if err != nil {
 		return nil, err
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -598,7 +598,7 @@ func TestConfiguredDataDirs(t *testing.T) {
 	require.FileExists(t, filepath.Join(testDirHot, genesis.ID(), "ledger.tracker.sqlite"))
 
 	// confirm the stateproof db in the genesis dir of hot data dir
-	require.FileExists(t, filepath.Join(testDirCold, genesis.ID(), "stateproof.sqlite"))
+	require.FileExists(t, filepath.Join(testDirHot, genesis.ID(), "stateproof.sqlite"))
 
 	// confirm cold data dir exists and contains a genesis dir
 	require.DirExists(t, filepath.Join(testDirCold, genesis.ID()))
@@ -609,8 +609,8 @@ func TestConfiguredDataDirs(t *testing.T) {
 	// confirm the partregistry is in the genesis dir of cold data dir
 	require.FileExists(t, filepath.Join(testDirCold, genesis.ID(), "partregistry.sqlite"))
 
-	// confirm the partregistry is in the genesis dir of cold data dir
-	require.FileExists(t, filepath.Join(testDirCold, genesis.ID(), "crash.sqlite"))
+	// confirm the agreement crash DB is in the genesis dir of hot data dir
+	require.FileExists(t, filepath.Join(testDirHot, genesis.ID(), "crash.sqlite"))
 }
 
 // TestConfiguredResourcePaths tests to see that when TrackerDbFilePath, BlockDbFilePath, StateproofDir, and CrashFilePath are set, underlying resources are created in the correct locations

--- a/scripts/windows/instructions.md
+++ b/scripts/windows/instructions.md
@@ -8,7 +8,7 @@
 	pacman -Syu --disable-download-timeout
 	```
 
-	NOTE: It is very likely MSYS2 will ask to close the window and repeat the command for furter updates. Check `MSYS2` web page for additional support.
+	NOTE: It is very likely MSYS2 will ask to close the window and repeat the command for further updates. Check `MSYS2` web page for additional support.
 
 4. Install GIT on MSYS2 by executing the following command:
 

--- a/util/codecs/json.go
+++ b/util/codecs/json.go
@@ -18,6 +18,7 @@ package codecs
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -48,6 +49,16 @@ func LoadObjectFromFile(filename string, object interface{}) (err error) {
 	return
 }
 
+func writeBytes(writer io.Writer, object interface{}, prettyFormat bool) error {
+	var enc *json.Encoder
+	if prettyFormat {
+		enc = NewFormattedJSONEncoder(writer)
+	} else {
+		enc = json.NewEncoder(writer)
+	}
+	return enc.Encode(object)
+}
+
 // SaveObjectToFile implements the common pattern for saving an object to a file as json
 func SaveObjectToFile(filename string, object interface{}, prettyFormat bool) error {
 	f, err := os.Create(filename)
@@ -55,22 +66,13 @@ func SaveObjectToFile(filename string, object interface{}, prettyFormat bool) er
 		return err
 	}
 	defer f.Close()
-	var enc *json.Encoder
-	if prettyFormat {
-		enc = NewFormattedJSONEncoder(f)
-	} else {
-		enc = json.NewEncoder(f)
-	}
-	err = enc.Encode(object)
-	return err
+	return writeBytes(f, object, prettyFormat)
 }
 
-// SaveNonDefaultValuesToFile saves an object to a file as json, but only fields that are not
+// WriteNonDefaultValues writes object to a writer as json, but only fields that are not
 // currently set to be the default value.
 // Optionally, you can specify an array of field names to always include.
-func SaveNonDefaultValuesToFile(filename string, object, defaultObject interface{}, ignore []string, prettyFormat bool) error {
-	// Serialize object to temporary file.
-	// Read file into string array
+func WriteNonDefaultValues(writer io.Writer, object, defaultObject interface{}, ignore []string) error {
 	// Iterate one line at a time, parse Name
 	// If ignore contains Name, don't delete
 	// Use reflection to compare object[Name].value == defaultObject[Name].value
@@ -78,25 +80,13 @@ func SaveNonDefaultValuesToFile(filename string, object, defaultObject interface
 	// When done, ensure last value line doesn't include comma
 	// Write string array to file.
 
-	file, err := os.CreateTemp("", "encsndv")
+	var buf bytes.Buffer
+	err := writeBytes(&buf, object, true)
 	if err != nil {
 		return err
 	}
-	name := file.Name()
-	file.Close()
+	content := buf.Bytes()
 
-	defer os.Remove(name)
-	// Save object to file pretty-formatted so we can read one value-per-line
-	err = SaveObjectToFile(name, object, true)
-	if err != nil {
-		return err
-	}
-
-	// Read lines from encoded file into string array
-	content, err := os.ReadFile(name)
-	if err != nil {
-		return err
-	}
 	valueLines := strings.Split(string(content), "\n")
 
 	// Create maps of the name->value pairs for the object and the defaults
@@ -155,19 +145,30 @@ func SaveNonDefaultValuesToFile(filename string, object, defaultObject interface
 		}
 	}
 
+	combined := strings.Join(newFile, "\n")
+	combined = strings.TrimRight(combined, "\r\n ")
+	_, err = writer.Write([]byte(combined))
+	return err
+}
+
+// SaveNonDefaultValuesToFile saves an object to a file as json, but only fields that are not
+// currently set to be the default value.
+// Optionally, you can specify an array of field names to always include.
+func SaveNonDefaultValuesToFile(filename string, object, defaultObject interface{}, ignore []string) error {
 	outFile, err := os.Create(filename)
 	if err != nil {
 		return err
 	}
 	defer outFile.Close()
 	writer := bufio.NewWriter(outFile)
-	combined := strings.Join(newFile, "\n")
-	combined = strings.TrimRight(combined, "\r\n ")
-	_, err = writer.WriteString(combined)
-	if err == nil {
-		writer.Flush()
+
+	err = WriteNonDefaultValues(writer, object, defaultObject, ignore)
+	if err != nil {
+		return err
 	}
-	return err
+
+	writer.Flush()
+	return nil
 }
 
 func extractValueName(line string) (name string) {

--- a/util/codecs/json_test.go
+++ b/util/codecs/json_test.go
@@ -17,9 +17,15 @@
 package codecs
 
 import (
-	"github.com/algorand/go-algorand/test/partitiontest"
-	"github.com/stretchr/testify/require"
+	"bytes"
+	"os"
+	"path"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
 type testValue struct {
@@ -30,6 +36,7 @@ type testValue struct {
 
 func TestIsDefaultValue(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	a := require.New(t)
 
@@ -51,4 +58,114 @@ func TestIsDefaultValue(t *testing.T) {
 	a.True(isDefaultValue("String", objectValues, defaultValues))
 	a.False(isDefaultValue("Int", objectValues, defaultValues))
 	a.True(isDefaultValue("Missing", objectValues, defaultValues))
+}
+
+func TestSaveObjectToFile(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	type TestType struct {
+		A uint64
+		B string
+	}
+
+	obj := TestType{1024, "test"}
+
+	// prettyFormat = false
+	{
+		filename := path.Join(t.TempDir(), "test.json")
+		SaveObjectToFile(filename, obj, false)
+		data, err := os.ReadFile(filename)
+		require.NoError(t, err)
+		expected := `{"A":1024,"B":"test"}
+`
+		require.Equal(t, expected, string(data))
+	}
+
+	// prettyFormat = true
+	{
+		filename := path.Join(t.TempDir(), "test.json")
+		SaveObjectToFile(filename, obj, true)
+		data, err := os.ReadFile(filename)
+		require.NoError(t, err)
+		expected := `{
+	"A": 1024,
+	"B": "test"
+}
+`
+		require.Equal(t, expected, string(data))
+	}
+
+}
+
+func TestWriteNonDefaultValue(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	type TestType struct {
+		Version       uint32
+		Archival      bool
+		GossipFanout  int
+		NetAddress    string
+		ReconnectTime time.Duration
+	}
+
+	defaultObject := TestType{
+		Version:       1,
+		Archival:      true,
+		GossipFanout:  50,
+		NetAddress:    "Denver",
+		ReconnectTime: 60 * time.Second,
+	}
+
+	testcases := []struct {
+		name   string
+		in     TestType
+		out    string
+		ignore []string
+	}{
+		{
+			name: "all defaults",
+			in:   defaultObject,
+			out: `{
+}`,
+		}, {
+			name: "some defaults",
+			in: TestType{
+				Version:       1,
+				Archival:      false,
+				GossipFanout:  25,
+				NetAddress:    "Denver",
+				ReconnectTime: 60 * time.Nanosecond,
+			},
+			out: `{
+	"Archival": false,
+	"GossipFanout": 25,
+	"ReconnectTime": 60
+}`,
+		}, {
+			name:   "ignore",
+			in:     defaultObject,
+			ignore: []string{"Version", "Archival", "GossipFanout", "NetAddress", "ReconnectTime"},
+			out: `{
+	"Version": 1,
+	"Archival": true,
+	"GossipFanout": 50,
+	"NetAddress": "Denver",
+	"ReconnectTime": 60000000000
+}`,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a := require.New(t)
+			var writer bytes.Buffer
+			err := WriteNonDefaultValues(&writer, tc.in, defaultObject, tc.ignore)
+			a.NoError(err)
+			a.Equal(tc.out, writer.String())
+		})
+	}
 }


### PR DESCRIPTION
![GitHub Logo](https://raw.githubusercontent.com/algorand/go-algorand/master/release/release-banner.jpg)

# Overview

An endpoint to generate participation keys, network optimization, and other enhancements around catchpoints and catchup are included in this release.

Both the crash and state proof databases now default to the 'hot' data directory.

# What&apos;s New
* Participation key generation endpoint: a requested feature to allow the ability to generate API keys from the REST endpoint, provided you have the admin token.

# Changelog
## New Features
* API: Add participation key generation endpoint to algod API ([#5781](https://github.com/algorand/go-algorand/pull/5781))
* Txhandler: applications rate limiter ([#5734](https://github.com/algorand/go-algorand/pull/5734))
## Enhancements
* Algocfg: Add print option to algocfg. ([#5824](https://github.com/algorand/go-algorand/pull/5824))
* API: minor style improvements in keygen code. ([#5786](https://github.com/algorand/go-algorand/pull/5786))
* AVM: preserve line/column for assembler warnings ([#5796](https://github.com/algorand/go-algorand/pull/5796))
* AVM: Reorganize the crypto opcodes a bit to simplify incentive work ([#5787](https://github.com/algorand/go-algorand/pull/5787))
* Build: bump github.com/consensys/gnark-crypto from 0.12.0 to 0.12.1 ([#5822](https://github.com/algorand/go-algorand/pull/5822))
* Catchpoint: store certs with blocks during catchpoint restore ([#5798](https://github.com/algorand/go-algorand/pull/5798))
* Catchup: Dynamic parallel catchup ([#5802](https://github.com/algorand/go-algorand/pull/5802))
* Catchup: fetchAndWrite/fetchRound quit early on errNoBlockForRound ([#5809](https://github.com/algorand/go-algorand/pull/5809))
* Catchup: Provide more information to client when requested block not available ([#5819](https://github.com/algorand/go-algorand/pull/5819))
* Cleanup: Use Go 1.19 atomic types ([#5792](https://github.com/algorand/go-algorand/pull/5792))
* Config: move crash and stateproof DB defaults to hot dir ([#5817](https://github.com/algorand/go-algorand/pull/5817))
* Config: Update description for IncomingConnectionsLimit ([#5789](https://github.com/algorand/go-algorand/pull/5789))
* Docs: Add comment to initConsensusProtocols. ([#5791](https://github.com/algorand/go-algorand/pull/5791))
* Feature: Catchup Eval Stake Exception Round Handling ([#5795](https://github.com/algorand/go-algorand/pull/5795))
* Follower: update follower node error messages. ([#5797](https://github.com/algorand/go-algorand/pull/5797))
* Ledger: support WaitWithCancel for unsuccessful WaitForBlock API calls ([#5814](https://github.com/algorand/go-algorand/pull/5814))
* Tools: improve heapwatch chart drawing scripts ([#5801](https://github.com/algorand/go-algorand/pull/5801))
## Bugfixes
* Catchup: pause catchup if ledger lagging behind ([#5794](https://github.com/algorand/go-algorand/pull/5794))
* Cicd: Fix RPM repository updating ([#5790](https://github.com/algorand/go-algorand/pull/5790))
* Ledger: make catchpoint generation backward compatible ([#5598](https://github.com/algorand/go-algorand/pull/5598))
* Ledger: rollback vetting historical stateproof blocks ([#5830](https://github.com/algorand/go-algorand/pull/5830))
* Tests: Fix flaky TestAccountSelected test ([#5788](https://github.com/algorand/go-algorand/pull/5788))
## Protocol Upgrade
This release does not contain a protocol upgrade.

## Additional Resources
* [Algorand Forum](https://forum.algorand.org)
* [Developer Documentation](https://developer.algorand.org)
