### PR TITLE
tests: fix state proof e2e test failures

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -770,12 +770,14 @@ func LoadConfigurableConsensusProtocols(dataDirectory string) error {
 }
 
 // SetConfigurableConsensusProtocols sets the configurable protocols.
-func SetConfigurableConsensusProtocols(newConsensus ConsensusProtocols) {
+func SetConfigurableConsensusProtocols(newConsensus ConsensusProtocols) ConsensusProtocols {
+	oldConsensus := Consensus
 	Consensus = newConsensus
 	// Set allocation limits
 	for _, p := range Consensus {
 		checkSetAllocBounds(p)
 	}
+	return oldConsensus
 }
 
 // PreloadConfigurableConsensusProtocols loads the configurable protocols from the data directory

--- a/test/e2e-go/features/stateproofs/stateproofs_test.go
+++ b/test/e2e-go/features/stateproofs/stateproofs_test.go
@@ -323,7 +323,8 @@ func TestStateProofMessageCommitmentVerification(t *testing.T) {
 	consensusVersion := protocol.ConsensusVersion("test-fast-stateproofs")
 	consensusParams := getDefaultStateProofConsensusParams()
 	configurableConsensus[consensusVersion] = consensusParams
-	config.SetConfigurableConsensusProtocols(configurableConsensus)
+	oldConsensus := config.SetConfigurableConsensusProtocols(configurableConsensus)
+	defer config.SetConfigurableConsensusProtocols(oldConsensus)
 
 	var fixture fixtures.RestClientFixture
 	fixture.SetConsensus(configurableConsensus)


### PR DESCRIPTION
## Summary

Fix test [failures](https://app.circleci.com/pipelines/github/algorand/go-algorand/17268/workflows/6ba0e710-2391-43bc-97f2-c5fcc045a0a6/jobs/259789) after merging https://github.com/algorand/go-algorand/pull/5663
The `TestStateProofMessageCommitmentVerification` reset a global var `config.Consensus` and `TestStateProofRecovery` was not able to find its consensus there.

## Test Plan

Tests passed locally
```
% export NODEBINDIR=~/go/bin
% export TESTDATADIR=`pwd`/test/testdata
% export TESTDIR=/tmp
% make
% go test ./test/e2e-go/features/stateproofs -run '(TestStateProofMessageCommitmentVerification)|(TestStateProofRecovery)$'