### PR TITLE
chore: Cut out some useless allocations when computing payset commitments

### DIFF
--- a/crypto/hashes.go
+++ b/crypto/hashes.go
@@ -118,7 +118,7 @@ func (z *HashFactory) Validate() error {
 }
 
 // GenericHashObj Makes it easier to sum using hash interface and Hashable interface
-func GenericHashObj(hsh hash.Hash, h Hashable) []byte {
+func GenericHashObj[H Hashable](hsh hash.Hash, h H) []byte {
 	rep := HashRep(h)
 	return hashBytes(hsh, rep)
 }

--- a/crypto/merklearray/layer.go
+++ b/crypto/merklearray/layer.go
@@ -37,14 +37,14 @@ type pair struct {
 	hashDigestSize int
 }
 
-func (p *pair) ToBeHashed() (protocol.HashID, []byte) {
+func (p pair) ToBeHashed() (protocol.HashID, []byte) {
 	// hashing of internal node will always be fixed length.
 	// If one of the children is missing we use [0...0].
 	// The size of the slice is based on the relevant hash function output size
 	buf := make([]byte, 2*p.hashDigestSize)
 	copy(buf[:], p.l[:])
 	copy(buf[len(p.l):], p.r[:])
-	return protocol.MerkleArrayNode, buf[:]
+	return protocol.MerkleArrayNode, buf
 }
 
 func upWorker(ws *workerState, in Layer, out Layer, h hash.Hash) {
@@ -69,7 +69,7 @@ func upWorker(ws *workerState, in Layer, out Layer, h hash.Hash) {
 				p.r = in[i+1]
 			}
 
-			out[i/2] = crypto.GenericHashObj(h, &p)
+			out[i/2] = crypto.GenericHashObj(h, p)
 		}
 
 		batchSize += 2

--- a/crypto/merklearray/merkle_test.go
+++ b/crypto/merklearray/merkle_test.go
@@ -1172,12 +1172,13 @@ func merkleCommitBench(b *testing.B, hashType crypto.HashType) {
 		msg := make(TestBuf, sz)
 		crypto.RandBytes(msg[:])
 
-		for cnt := 10; cnt <= 10000000; cnt *= 10 {
+		for cnt := 10; cnt <= 100000; cnt *= 10 {
 			var a TestRepeatingArray
 			a.item = msg
 			a.count = uint64(cnt)
 
 			b.Run(fmt.Sprintf("Item%d/Count%d", sz, cnt), func(b *testing.B) {
+				b.ReportAllocs()
 				for i := 0; i < b.N; i++ {
 					tree, err := Build(a, crypto.HashFactory{HashType: hashType})
 					require.NoError(b, err)
@@ -1205,6 +1206,7 @@ func benchmarkMerkleProve1M(b *testing.B, hashType crypto.HashType) {
 	require.NoError(b, err)
 
 	b.ResetTimer()
+	b.ReportAllocs()
 
 	for i := uint64(0); i < uint64(b.N); i++ {
 		_, err := tree.Prove([]uint64{i % a.count})
@@ -1238,6 +1240,7 @@ func benchmarkMerkleVerify1M(b *testing.B, hashType crypto.HashType) {
 	}
 
 	b.ResetTimer()
+	b.ReportAllocs()
 
 	for i := uint64(0); i < uint64(b.N); i++ {
 		err := Verify(root, map[uint64]crypto.Hashable{i % a.count: msg}, proofs[i])

--- a/crypto/merklearray/partial.go
+++ b/crypto/merklearray/partial.go
@@ -118,7 +118,7 @@ func (pl partialLayer) up(s *siblings, l uint64, doHash bool, hsh hash.Hash) (pa
 				p.l = siblingHash
 				p.r = posHash
 			}
-			nextLayerHash = crypto.GenericHashObj(hsh, &p)
+			nextLayerHash = crypto.GenericHashObj(hsh, p)
 		}
 
 		res = append(res, layerItem{


### PR DESCRIPTION
Decrease around 10% in allocations for construction and verifying.

Less in absolute speedup.

```
> benchstat bench-old.txt bench-new.txt
goos: darwin
goarch: arm64
pkg: github.com/algorand/go-algorand/crypto/merklearray
                                                  │ bench-old.txt │            bench-new.txt            │
                                                  │    sec/op     │    sec/op     vs base               │
MerkleCommit/sha512_256/Item10/Count10-10            13.45µ ± ∞ ¹   12.80µ ± ∞ ¹   -4.82% (p=0.008 n=5)
MerkleCommit/sha512_256/Item10/Count100-10           51.97µ ± ∞ ¹   49.54µ ± ∞ ¹        ~ (p=0.095 n=5)
MerkleCommit/sha512_256/Item10/Count1000-10          277.8µ ± ∞ ¹   257.0µ ± ∞ ¹   -7.50% (p=0.008 n=5)
MerkleCommit/sha512_256/Item10/Count10000-10         1.563m ± ∞ ¹   1.439m ± ∞ ¹   -7.90% (p=0.008 n=5)
MerkleCommit/sha512_256/Item10/Count100000-10       10.129m ± ∞ ¹   8.615m ± ∞ ¹  -14.95% (p=0.008 n=5)
MerkleCommit/sha512_256/Item1000/Count10-10          21.55µ ± ∞ ¹   20.22µ ± ∞ ¹   -6.17% (p=0.008 n=5)
MerkleCommit/sha512_256/Item1000/Count100-10         98.35µ ± ∞ ¹   92.30µ ± ∞ ¹   -6.14% (p=0.008 n=5)
MerkleCommit/sha512_256/Item1000/Count1000-10        546.1µ ± ∞ ¹   535.2µ ± ∞ ¹   -2.00% (p=0.032 n=5)
MerkleCommit/sha512_256/Item1000/Count10000-10       3.860m ± ∞ ¹   3.787m ± ∞ ¹   -1.91% (p=0.008 n=5)
MerkleCommit/sha512_256/Item1000/Count100000-10      32.26m ± ∞ ¹   31.51m ± ∞ ¹        ~ (p=0.690 n=5)
MerkleCommit/sha512_256/Item100000/Count10-10        356.4µ ± ∞ ¹   351.7µ ± ∞ ¹   -1.31% (p=0.008 n=5)
MerkleCommit/sha512_256/Item100000/Count100-10       2.198m ± ∞ ¹   2.186m ± ∞ ¹        ~ (p=0.548 n=5)
MerkleCommit/sha512_256/Item100000/Count1000-10      19.21m ± ∞ ¹   18.92m ± ∞ ¹        ~ (p=0.222 n=5)
MerkleCommit/sha512_256/Item100000/Count10000-10     167.1m ± ∞ ¹   167.5m ± ∞ ¹        ~ (p=0.841 n=5)
MerkleCommit/sha512_256/Item100000/Count100000-10     1.405 ± ∞ ¹    1.379 ± ∞ ¹        ~ (p=0.310 n=5)
MerkleCommit/sumhash/Item10/Count10-10               45.17µ ± ∞ ¹   45.46µ ± ∞ ¹        ~ (p=0.310 n=5)
MerkleCommit/sumhash/Item10/Count100-10              245.4µ ± ∞ ¹   244.3µ ± ∞ ¹        ~ (p=0.690 n=5)
MerkleCommit/sumhash/Item10/Count1000-10             1.230m ± ∞ ¹   1.221m ± ∞ ¹   -0.68% (p=0.032 n=5)
MerkleCommit/sumhash/Item10/Count10000-10            7.529m ± ∞ ¹   7.433m ± ∞ ¹   -1.27% (p=0.008 n=5)
MerkleCommit/sumhash/Item10/Count100000-10           62.26m ± ∞ ¹   60.17m ± ∞ ¹   -3.36% (p=0.016 n=5)
MerkleCommit/sumhash/Item1000/Count10-10             101.2µ ± ∞ ¹   102.1µ ± ∞ ¹   +0.92% (p=0.008 n=5)
MerkleCommit/sumhash/Item1000/Count100-10            502.8µ ± ∞ ¹   498.0µ ± ∞ ¹        ~ (p=0.151 n=5)
MerkleCommit/sumhash/Item1000/Count1000-10           2.800m ± ∞ ¹   2.786m ± ∞ ¹   -0.50% (p=0.008 n=5)
MerkleCommit/sumhash/Item1000/Count10000-10          22.29m ± ∞ ¹   22.31m ± ∞ ¹        ~ (p=1.000 n=5)
MerkleCommit/sumhash/Item1000/Count100000-10         202.7m ± ∞ ¹   205.1m ± ∞ ¹        ~ (p=0.421 n=5)
MerkleCommit/sumhash/Item100000/Count10-10           2.340m ± ∞ ¹   2.408m ± ∞ ¹   +2.89% (p=0.008 n=5)
MerkleCommit/sumhash/Item100000/Count100-10          17.64m ± ∞ ¹   17.77m ± ∞ ¹        ~ (p=0.095 n=5)
MerkleCommit/sumhash/Item100000/Count1000-10         155.4m ± ∞ ¹   156.7m ± ∞ ¹        ~ (p=0.095 n=5)
MerkleCommit/sumhash/Item100000/Count10000-10         1.524 ± ∞ ¹    1.537 ± ∞ ¹        ~ (p=0.095 n=5)
MerkleCommit/sumhash/Item100000/Count100000-10        14.98 ± ∞ ¹    14.77 ± ∞ ¹        ~ (p=0.690 n=5)
MerkleCommit/sha256/Item10/Count10-10                7.532µ ± ∞ ¹   7.845µ ± ∞ ¹   +4.16% (p=0.008 n=5)
MerkleCommit/sha256/Item10/Count100-10               35.30µ ± ∞ ¹   36.90µ ± ∞ ¹   +4.53% (p=0.008 n=5)
MerkleCommit/sha256/Item10/Count1000-10              213.1µ ± ∞ ¹   203.3µ ± ∞ ¹   -4.61% (p=0.008 n=5)
MerkleCommit/sha256/Item10/Count10000-10             1.304m ± ∞ ¹   1.164m ± ∞ ¹  -10.73% (p=0.008 n=5)
MerkleCommit/sha256/Item10/Count100000-10            8.824m ± ∞ ¹   7.633m ± ∞ ¹  -13.50% (p=0.008 n=5)
MerkleCommit/sha256/Item1000/Count10-10              12.32µ ± ∞ ¹   12.81µ ± ∞ ¹        ~ (p=0.095 n=5)
MerkleCommit/sha256/Item1000/Count100-10             70.40µ ± ∞ ¹   71.30µ ± ∞ ¹        ~ (p=0.151 n=5)
MerkleCommit/sha256/Item1000/Count1000-10            454.2µ ± ∞ ¹   444.3µ ± ∞ ¹   -2.17% (p=0.008 n=5)
MerkleCommit/sha256/Item1000/Count10000-10           3.440m ± ∞ ¹   3.226m ± ∞ ¹   -6.25% (p=0.008 n=5)
MerkleCommit/sha256/Item1000/Count100000-10          29.18m ± ∞ ¹   28.02m ± ∞ ¹        ~ (p=0.095 n=5)
MerkleCommit/sha256/Item100000/Count10-10            263.5µ ± ∞ ¹   253.1µ ± ∞ ¹        ~ (p=0.310 n=5)
MerkleCommit/sha256/Item100000/Count100-10           1.637m ± ∞ ¹   1.647m ± ∞ ¹        ~ (p=0.548 n=5)
MerkleCommit/sha256/Item100000/Count1000-10          15.44m ± ∞ ¹   15.07m ± ∞ ¹   -2.41% (p=0.032 n=5)
MerkleCommit/sha256/Item100000/Count10000-10         143.6m ± ∞ ¹   138.6m ± ∞ ¹        ~ (p=0.095 n=5)
MerkleCommit/sha256/Item100000/Count100000-10         1.142 ± ∞ ¹    1.143 ± ∞ ¹        ~ (p=0.690 n=5)
MerkleProve1M/sha512_256-10                          1.081µ ± ∞ ¹   1.054µ ± ∞ ¹        ~ (p=0.056 n=5)
MerkleProve1M/sumhash-10                             1.182µ ± ∞ ¹   1.147µ ± ∞ ¹        ~ (p=0.690 n=5)
MerkleProve1M/sha256-10                              1.057µ ± ∞ ¹   1.056µ ± ∞ ¹        ~ (p=0.690 n=5)
MerkleVerify1M/sha512_256-10                         6.179µ ± ∞ ¹   5.796µ ± ∞ ¹   -6.20% (p=0.008 n=5)
MerkleVerify1M/sumhash-10                            51.39µ ± ∞ ¹   49.85µ ± ∞ ¹        ~ (p=0.095 n=5)
MerkleVerify1M/sha256-10                             5.100µ ± ∞ ¹   4.812µ ± ∞ ¹   -5.65% (p=0.008 n=5)
geomean                                              1.240m         1.210m         -2.44%
¹ need >= 6 samples for confidence interval at level 0.95

                                                  │ bench-old.txt  │              bench-new.txt              │
                                                  │      B/op      │      B/op       vs base                 │
MerkleCommit/sha512_256/Item10/Count10-10            6.555Ki ± ∞ ¹    5.851Ki ± ∞ ¹  -10.74% (p=0.008 n=5)
MerkleCommit/sha512_256/Item10/Count100-10           40.17Ki ± ∞ ¹    33.76Ki ± ∞ ¹  -15.96% (p=0.008 n=5)
MerkleCommit/sha512_256/Item10/Count1000-10          353.8Ki ± ∞ ¹    291.1Ki ± ∞ ¹  -17.73% (p=0.008 n=5)
MerkleCommit/sha512_256/Item10/Count10000-10         3.394Mi ± ∞ ¹    2.783Mi ± ∞ ¹  -18.01% (p=0.008 n=5)
MerkleCommit/sha512_256/Item10/Count100000-10        33.63Mi ± ∞ ¹    27.52Mi ± ∞ ¹  -18.15% (p=0.008 n=5)
MerkleCommit/sha512_256/Item1000/Count10-10          16.44Ki ± ∞ ¹    15.73Ki ± ∞ ¹   -4.31% (p=0.008 n=5)
MerkleCommit/sha512_256/Item1000/Count100-10         138.8Ki ± ∞ ¹    132.4Ki ± ∞ ¹   -4.62% (p=0.008 n=5)
MerkleCommit/sha512_256/Item1000/Count1000-10        1.308Mi ± ∞ ¹    1.247Mi ± ∞ ¹   -4.68% (p=0.008 n=5)
MerkleCommit/sha512_256/Item1000/Count10000-10       13.01Mi ± ∞ ¹    12.40Mi ± ∞ ¹   -4.70% (p=0.008 n=5)
MerkleCommit/sha512_256/Item1000/Count100000-10      129.8Mi ± ∞ ¹    123.7Mi ± ∞ ¹   -4.70% (p=0.008 n=5)
MerkleCommit/sha512_256/Item100000/Count10-10        1.023Mi ± ∞ ¹    1.022Mi ± ∞ ¹   -0.07% (p=0.008 n=5)
MerkleCommit/sha512_256/Item100000/Count100-10       10.20Mi ± ∞ ¹    10.19Mi ± ∞ ¹   -0.06% (p=0.008 n=5)
MerkleCommit/sha512_256/Item100000/Count1000-10      101.9Mi ± ∞ ¹    101.8Mi ± ∞ ¹   -0.06% (p=0.008 n=5)
MerkleCommit/sha512_256/Item100000/Count10000-10    1018.9Mi ± ∞ ¹   1018.3Mi ± ∞ ¹   -0.06% (p=0.008 n=5)
MerkleCommit/sha512_256/Item100000/Count100000-10    9.950Gi ± ∞ ¹    9.944Gi ± ∞ ¹   -0.06% (p=0.008 n=5)
MerkleCommit/sumhash/Item10/Count10-10               17.04Ki ± ∞ ¹    16.34Ki ± ∞ ¹   -4.08% (p=0.008 n=5)
MerkleCommit/sumhash/Item10/Count100-10              137.0Ki ± ∞ ¹    130.6Ki ± ∞ ¹   -4.65% (p=0.008 n=5)
MerkleCommit/sumhash/Item10/Count1000-10             1.269Mi ± ∞ ¹    1.208Mi ± ∞ ¹   -4.83% (p=0.008 n=5)
MerkleCommit/sumhash/Item10/Count10000-10            12.56Mi ± ∞ ¹    11.95Mi ± ∞ ¹   -4.86% (p=0.008 n=5)
MerkleCommit/sumhash/Item10/Count100000-10           125.2Mi ± ∞ ¹    119.1Mi ± ∞ ¹   -4.88% (p=0.008 n=5)
MerkleCommit/sumhash/Item1000/Count10-10             28.54Ki ± ∞ ¹    27.84Ki ± ∞ ¹   -2.48% (p=0.008 n=5)
MerkleCommit/sumhash/Item1000/Count100-10            249.6Ki ± ∞ ¹    243.1Ki ± ∞ ¹   -2.58% (p=0.008 n=5)
MerkleCommit/sumhash/Item1000/Count1000-10           2.354Mi ± ∞ ¹    2.292Mi ± ∞ ¹   -2.61% (p=0.008 n=5)
MerkleCommit/sumhash/Item1000/Count10000-10          23.40Mi ± ∞ ¹    22.79Mi ± ∞ ¹   -2.61% (p=0.008 n=5)
MerkleCommit/sumhash/Item1000/Count100000-10         233.5Mi ± ∞ ¹    227.4Mi ± ∞ ¹   -2.61% (p=0.008 n=5)
MerkleCommit/sumhash/Item100000/Count10-10           1.036Mi ± ∞ ¹    1.035Mi ± ∞ ¹   -0.07% (p=0.008 n=5)
MerkleCommit/sumhash/Item100000/Count100-10          10.30Mi ± ∞ ¹    10.30Mi ± ∞ ¹   -0.06% (p=0.008 n=5)
MerkleCommit/sumhash/Item100000/Count1000-10         102.9Mi ± ∞ ¹    102.9Mi ± ∞ ¹   -0.06% (p=0.008 n=5)
MerkleCommit/sumhash/Item100000/Count10000-10        1.005Gi ± ∞ ¹    1.005Gi ± ∞ ¹   -0.06% (p=0.008 n=5)
MerkleCommit/sumhash/Item100000/Count100000-10       10.05Gi ± ∞ ¹    10.04Gi ± ∞ ¹   -0.06% (p=0.008 n=5)
MerkleCommit/sha256/Item10/Count10-10                5.976Ki ± ∞ ¹    5.291Ki ± ∞ ¹  -11.46% (p=0.008 n=5)
MerkleCommit/sha256/Item10/Count100-10               39.06Ki ± ∞ ¹    32.67Ki ± ∞ ¹  -16.37% (p=0.008 n=5)
MerkleCommit/sha256/Item10/Count1000-10              351.4Ki ± ∞ ¹    288.9Ki ± ∞ ¹  -17.77% (p=0.008 n=5)
MerkleCommit/sha256/Item10/Count10000-10             3.389Mi ± ∞ ¹    2.779Mi ± ∞ ¹  -18.02% (p=0.008 n=5)
MerkleCommit/sha256/Item10/Count100000-10            33.62Mi ± ∞ ¹    27.52Mi ± ∞ ¹  -18.16% (p=0.008 n=5)
MerkleCommit/sha256/Item1000/Count10-10              15.92Ki ± ∞ ¹    15.23Ki ± ∞ ¹   -4.38% (p=0.008 n=5)
MerkleCommit/sha256/Item1000/Count100-10             137.5Ki ± ∞ ¹    131.2Ki ± ∞ ¹   -4.63% (p=0.008 n=5)
MerkleCommit/sha256/Item1000/Count1000-10            1.305Mi ± ∞ ¹    1.244Mi ± ∞ ¹   -4.68% (p=0.008 n=5)
MerkleCommit/sha256/Item1000/Count10000-10           13.00Mi ± ∞ ¹    12.39Mi ± ∞ ¹   -4.70% (p=0.008 n=5)
MerkleCommit/sha256/Item1000/Count100000-10          129.8Mi ± ∞ ¹    123.6Mi ± ∞ ¹   -4.70% (p=0.008 n=5)
MerkleCommit/sha256/Item100000/Count10-10            1.022Mi ± ∞ ¹    1.021Mi ± ∞ ¹   -0.06% (p=0.008 n=5)
MerkleCommit/sha256/Item100000/Count100-10           10.19Mi ± ∞ ¹    10.19Mi ± ∞ ¹   -0.06% (p=0.008 n=5)
MerkleCommit/sha256/Item100000/Count1000-10          101.9Mi ± ∞ ¹    101.8Mi ± ∞ ¹   -0.06% (p=0.008 n=5)
MerkleCommit/sha256/Item100000/Count10000-10        1018.9Mi ± ∞ ¹   1018.3Mi ± ∞ ¹   -0.06% (p=0.008 n=5)
MerkleCommit/sha256/Item100000/Count100000-10        9.950Gi ± ∞ ¹    9.944Gi ± ∞ ¹   -0.06% (p=0.008 n=5)
MerkleProve1M/sha512_256-10                          2.383Ki ± ∞ ¹    2.383Ki ± ∞ ¹        ~ (p=1.000 n=5) ²
MerkleProve1M/sumhash-10                             2.414Ki ± ∞ ¹    2.414Ki ± ∞ ¹        ~ (p=1.000 n=5) ²
MerkleProve1M/sha256-10                              2.289Ki ± ∞ ¹    2.289Ki ± ∞ ¹        ~ (p=1.000 n=5) ²
MerkleVerify1M/sha512_256-10                         6.375Ki ± ∞ ¹    5.125Ki ± ∞ ¹  -19.61% (p=0.008 n=5)
MerkleVerify1M/sumhash-10                            18.66Ki ± ∞ ¹    17.41Ki ± ∞ ¹   -6.70% (p=0.008 n=5)
MerkleVerify1M/sha256-10                             6.188Ki ± ∞ ¹    4.938Ki ± ∞ ¹  -20.20% (p=0.008 n=5)
geomean                                              2.054Mi          1.931Mi         -5.97%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

                                                  │ bench-old.txt │             bench-new.txt             │
                                                  │   allocs/op   │  allocs/op    vs base                 │
MerkleCommit/sha512_256/Item10/Count10-10             118.0 ± ∞ ¹    107.0 ± ∞ ¹   -9.32% (p=0.008 n=5)
MerkleCommit/sha512_256/Item10/Count100-10            863.0 ± ∞ ¹    761.0 ± ∞ ¹  -11.82% (p=0.008 n=5)
MerkleCommit/sha512_256/Item10/Count1000-10          8.089k ± ∞ ¹   7.087k ± ∞ ¹  -12.39% (p=0.008 n=5)
MerkleCommit/sha512_256/Item10/Count10000-10         80.18k ± ∞ ¹   70.17k ± ∞ ¹  -12.48% (p=0.008 n=5)
MerkleCommit/sha512_256/Item10/Count100000-10        800.3k ± ∞ ¹   700.3k ± ∞ ¹  -12.50% (p=0.008 n=5)
MerkleCommit/sha512_256/Item1000/Count10-10           119.0 ± ∞ ¹    107.0 ± ∞ ¹  -10.08% (p=0.008 n=5)
MerkleCommit/sha512_256/Item1000/Count100-10          864.0 ± ∞ ¹    762.0 ± ∞ ¹  -11.81% (p=0.008 n=5)
MerkleCommit/sha512_256/Item1000/Count1000-10        8.097k ± ∞ ¹   7.095k ± ∞ ¹  -12.37% (p=0.008 n=5)
MerkleCommit/sha512_256/Item1000/Count10000-10       80.18k ± ∞ ¹   70.18k ± ∞ ¹  -12.48% (p=0.008 n=5)
MerkleCommit/sha512_256/Item1000/Count100000-10      800.3k ± ∞ ¹   700.3k ± ∞ ¹  -12.50% (p=0.008 n=5)
MerkleCommit/sha512_256/Item100000/Count10-10         126.0 ± ∞ ¹    114.0 ± ∞ ¹   -9.52% (p=0.008 n=5)
MerkleCommit/sha512_256/Item100000/Count100-10        879.0 ± ∞ ¹    776.0 ± ∞ ¹  -11.72% (p=0.008 n=5)
MerkleCommit/sha512_256/Item100000/Count1000-10      8.107k ± ∞ ¹   7.104k ± ∞ ¹  -12.37% (p=0.008 n=5)
MerkleCommit/sha512_256/Item100000/Count10000-10     80.21k ± ∞ ¹   70.21k ± ∞ ¹  -12.47% (p=0.008 n=5)
MerkleCommit/sha512_256/Item100000/Count100000-10    800.5k ± ∞ ¹   700.5k ± ∞ ¹  -12.50% (p=0.008 n=5)
MerkleCommit/sumhash/Item10/Count10-10                228.0 ± ∞ ¹    217.0 ± ∞ ¹   -4.82% (p=0.008 n=5)
MerkleCommit/sumhash/Item10/Count100-10              1.813k ± ∞ ¹   1.711k ± ∞ ¹   -5.63% (p=0.008 n=5)
MerkleCommit/sumhash/Item10/Count1000-10             17.22k ± ∞ ¹   16.22k ± ∞ ¹   -5.82% (p=0.008 n=5)
MerkleCommit/sumhash/Item10/Count10000-10            170.4k ± ∞ ¹   160.4k ± ∞ ¹   -5.87% (p=0.008 n=5)
MerkleCommit/sumhash/Item10/Count100000-10           1.701M ± ∞ ¹   1.601M ± ∞ ¹   -5.88% (p=0.008 n=5)
MerkleCommit/sumhash/Item1000/Count10-10              243.0 ± ∞ ¹    232.0 ± ∞ ¹   -4.53% (p=0.008 n=5)
MerkleCommit/sumhash/Item1000/Count100-10            1.933k ± ∞ ¹   1.831k ± ∞ ¹   -5.28% (p=0.008 n=5)
MerkleCommit/sumhash/Item1000/Count1000-10           18.23k ± ∞ ¹   17.23k ± ∞ ¹   -5.51% (p=0.008 n=5)
MerkleCommit/sumhash/Item1000/Count10000-10          180.4k ± ∞ ¹   170.4k ± ∞ ¹   -5.55% (p=0.008 n=5)
MerkleCommit/sumhash/Item1000/Count100000-10         1.801M ± ∞ ¹   1.701M ± ∞ ¹   -5.55% (p=0.008 n=5)
MerkleCommit/sumhash/Item100000/Count10-10            270.0 ± ∞ ¹    258.0 ± ∞ ¹   -4.44% (p=0.008 n=5)
MerkleCommit/sumhash/Item100000/Count100-10          1.942k ± ∞ ¹   1.839k ± ∞ ¹   -5.30% (p=0.008 n=5)
MerkleCommit/sumhash/Item100000/Count1000-10         18.24k ± ∞ ¹   17.24k ± ∞ ¹   -5.48% (p=0.008 n=5)
MerkleCommit/sumhash/Item100000/Count10000-10        180.5k ± ∞ ¹   170.4k ± ∞ ¹   -5.55% (p=0.008 n=5)
MerkleCommit/sumhash/Item100000/Count100000-10       1.801M ± ∞ ¹   1.701M ± ∞ ¹   -5.55% (p=0.008 n=5)
MerkleCommit/sha256/Item10/Count10-10                 118.0 ± ∞ ¹    107.0 ± ∞ ¹   -9.32% (p=0.008 n=5)
MerkleCommit/sha256/Item10/Count100-10                862.0 ± ∞ ¹    760.0 ± ∞ ¹  -11.83% (p=0.008 n=5)
MerkleCommit/sha256/Item10/Count1000-10              8.084k ± ∞ ¹   7.084k ± ∞ ¹  -12.37% (p=0.008 n=5)
MerkleCommit/sha256/Item10/Count10000-10             80.17k ± ∞ ¹   70.17k ± ∞ ¹  -12.48% (p=0.008 n=5)
MerkleCommit/sha256/Item10/Count100000-10            800.3k ± ∞ ¹   700.2k ± ∞ ¹  -12.50% (p=0.008 n=5)
MerkleCommit/sha256/Item1000/Count10-10               119.0 ± ∞ ¹    107.0 ± ∞ ¹  -10.08% (p=0.008 n=5)
MerkleCommit/sha256/Item1000/Count100-10              862.0 ± ∞ ¹    760.0 ± ∞ ¹  -11.83% (p=0.008 n=5)
MerkleCommit/sha256/Item1000/Count1000-10            8.094k ± ∞ ¹   7.092k ± ∞ ¹  -12.38% (p=0.008 n=5)
MerkleCommit/sha256/Item1000/Count10000-10           80.18k ± ∞ ¹   70.17k ± ∞ ¹  -12.48% (p=0.008 n=5)
MerkleCommit/sha256/Item1000/Count100000-10          800.3k ± ∞ ¹   700.2k ± ∞ ¹  -12.50% (p=0.008 n=5)
MerkleCommit/sha256/Item100000/Count10-10             125.0 ± ∞ ¹    114.0 ± ∞ ¹   -8.80% (p=0.008 n=5)
MerkleCommit/sha256/Item100000/Count100-10            878.0 ± ∞ ¹    775.0 ± ∞ ¹  -11.73% (p=0.008 n=5)
MerkleCommit/sha256/Item100000/Count1000-10          8.109k ± ∞ ¹   7.105k ± ∞ ¹  -12.38% (p=0.008 n=5)
MerkleCommit/sha256/Item100000/Count10000-10         80.24k ± ∞ ¹   70.23k ± ∞ ¹  -12.48% (p=0.008 n=5)
MerkleCommit/sha256/Item100000/Count100000-10        800.7k ± ∞ ¹   700.6k ± ∞ ¹  -12.50% (p=0.008 n=5)
MerkleProve1M/sha512_256-10                           29.00 ± ∞ ¹    29.00 ± ∞ ¹        ~ (p=1.000 n=5) ²
MerkleProve1M/sumhash-10                              31.00 ± ∞ ¹    31.00 ± ∞ ¹        ~ (p=1.000 n=5) ²
MerkleProve1M/sha256-10                               29.00 ± ∞ ¹    29.00 ± ∞ ¹        ~ (p=1.000 n=5) ²
MerkleVerify1M/sha512_256-10                          131.0 ± ∞ ¹    111.0 ± ∞ ¹  -15.27% (p=0.008 n=5)
MerkleVerify1M/sumhash-10                             239.0 ± ∞ ¹    219.0 ± ∞ ¹   -8.37% (p=0.008 n=5)
MerkleVerify1M/sha256-10                              131.0 ± ∞ ¹    111.0 ± ∞ ¹  -15.27% (p=0.008 n=5)
geomean                                              6.281k         5.695k         -9.33%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
```

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
