### PR TITLE
tests: wait longer in TestTotalWeightChanges for larger nightly test network

### DIFF
--- a/test/e2e-go/features/stateproofs/stateproofs_test.go
+++ b/test/e2e-go/features/stateproofs/stateproofs_test.go
@@ -841,7 +841,11 @@ func TestTotalWeightChanges(t *testing.T) {
 			richNode.goOffline(a, &fixture, rnd)
 		}
 
-		a.NoError(fixture.WaitForRound(rnd, 30*time.Second))
+		if testing.Short() {
+			a.NoError(fixture.WaitForRound(rnd, 30*time.Second))
+		} else {
+			a.NoError(fixture.WaitForRound(rnd, 60*time.Second))
+		}
 		blk, err := libgoal.BookkeepingBlock(rnd)
 		a.NoErrorf(err, "failed to retrieve block from algod on round %d", rnd)
 


### PR DESCRIPTION
## Summary

During nightly / non-short runs, `TestTotalWeightChanges` uses a 7-node test network (compared to 3 nodes for PR commit short tests) and sometimes hits this 30s timeout when running in CI, this happens while nodes are first starting up and not yet finished coming to agreement on round 1. Provides a little more time for nodes to start up in a resource constrained nightly CI runner machine

## Test Plan

Tests are unchanged except for length of timeout.