### PR TITLE
Round Times: Set minimum dynamic filter timeout to 2500ms. 

### DIFF
--- a/agreement/dynamicFilterTimeoutParams.go
+++ b/agreement/dynamicFilterTimeoutParams.go
@@ -31,7 +31,7 @@ const dynamicFilterCredentialArrivalHistory int = 40
 
 // DynamicFilterTimeoutLowerBound specifies a minimal duration that the
 // filter timeout must meet.
-const dynamicFilterTimeoutLowerBound time.Duration = 500 * time.Millisecond
+const dynamicFilterTimeoutLowerBound time.Duration = 2500 * time.Millisecond
 
 // DynamicFilterTimeoutCredentialArrivalHistoryIdx specified which sample to use
 // out of a sorted DynamicFilterCredentialArrivalHistory-sized array of time

--- a/agreement/router.go
+++ b/agreement/router.go
@@ -59,7 +59,16 @@ var credentialRoundLag round
 
 func init() {
 	// credential arrival time should be at most 2*config.Protocol.SmallLambda after it was sent
+	// Note that the credentialRoundLag is inversely proportional to the dynamicFilterTimeoutLowerBound
+	// in the default formula. Since we are adjusting this lower bound over time,
+	// for consistency in analytics we are setting the minimum to be 8 rounds
+	// (equivalent to a dynamicFilterTimeoutLowerBound of 500 ms).
+	minCredentialRoundLag := round(8) // round 2*2000ms / 500ms
 	credentialRoundLag = round(2 * config.Protocol.SmallLambda / dynamicFilterTimeoutLowerBound)
+
+	if credentialRoundLag < minCredentialRoundLag {
+		credentialRoundLag = minCredentialRoundLag
+	}
 	if credentialRoundLag*round(dynamicFilterTimeoutLowerBound) < round(2*config.Protocol.SmallLambda) {
 		credentialRoundLag++
 	}


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Set minimum dynamic filter timeout to 2500ms. Additionally, set minimum credential round lag to 8 (helping stabilize for voteValidatedAt lookups in telemetry).


<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Existing tests pass.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
