### PR TITLE
tests: dump logs if e2e test node exited with an error

### DIFF
--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -119,6 +119,10 @@ func (f *LibGoalFixture) nodeExitWithError(nc *nodecontrol.NodeController, err e
 	if f.t == nil {
 		return
 	}
+
+	f.t.Logf("Node at %s has terminated with an error: %v. Dumping logs...", nc.GetDataDir(), err)
+	f.dumpLogs(filepath.Join(nc.GetDataDir(), "node.log"))
+
 	exitError, ok := err.(*exec.ExitError)
 	if !ok {
 		require.NoError(f.t, err, "Node at %s has terminated with an error", nc.GetDataDir())


### PR DESCRIPTION
## Summary

Time to time some catchup nightly e2e tests [fail](https://app.circleci.com/pipelines/github/algorand/go-algorand/17357/workflows/1871bddc-e37e-457c-aca7-f5dc3866b56b/jobs/260944) with a node non-zero exit status after the test completion. No luck reproducing it locally/branches/etc so adding extra logging to master.

## Test Plan

This is test fixture modification.