### PR TITLE
Chore: Update testing to use current python SDK.

### DIFF
--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -128,7 +128,7 @@ if [ -z "$E2E_TEST_FILTER" ] || [ "$E2E_TEST_FILTER" == "SCRIPTS" ]; then
     # Pin major version of our python SDK's so that breaking changes
     # don't spuriously break our tests.  If a minor version breaks our
     # tests, we ought to find out.
-    "${TEMPDIR}/ve/bin/pip3" install py-algorand-sdk==2
+    "${TEMPDIR}/ve/bin/pip3" install 'py-algorand-sdk==2.*'
 
     # Enable remote debugging:
     "${TEMPDIR}/ve/bin/pip3" install --upgrade debugpy

--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -125,9 +125,10 @@ if [ -z "$E2E_TEST_FILTER" ] || [ "$E2E_TEST_FILTER" == "SCRIPTS" ]; then
     . "${TEMPDIR}/ve/bin/activate"
     "${TEMPDIR}/ve/bin/pip3" install --upgrade pip
 
-    # Pin a version of our python SDK's so that breaking changes don't spuriously break our tests.
-    # Please update as necessary.
-    "${TEMPDIR}/ve/bin/pip3" install py-algorand-sdk==1.17.0
+    # Pin major version of our python SDK's so that breaking changes
+    # don't spuriously break our tests.  If a minor version breaks our
+    # tests, we ought to find out.
+    "${TEMPDIR}/ve/bin/pip3" install py-algorand-sdk==2
 
     # Enable remote debugging:
     "${TEMPDIR}/ve/bin/pip3" install --upgrade debugpy

--- a/test/scripts/e2e_client_runner.py
+++ b/test/scripts/e2e_client_runner.py
@@ -114,11 +114,12 @@ def _script_thread_inner(runset, scriptname, timeout):
     params = algod.suggested_params()
     round = params.first
     max_init_wait_rounds = 5
-    txn = algosdk.transaction.PaymentTxn(sender=maxpubaddr, fee=params.min_fee, first=round, last=round+max_init_wait_rounds, gh=params.gh, receiver=addr, amt=1000000000000, flat_fee=True)
+    params.last = params.first + max_init_wait_rounds
+    txn = algosdk.transaction.PaymentTxn(maxpubaddr, params, addr, 1_000_000_000_000)
     stxn = kmd.sign_transaction(pubw, '', txn)
     txid = algod.send_transaction(stxn)
     ptxinfo = None
-    for i in range(max_init_wait_rounds):
+    for _ in range(max_init_wait_rounds):
         txinfo = algod.pending_transaction_info(txid)
         if txinfo.get('round'):
             break

--- a/test/scripts/e2e_subs/example.py
+++ b/test/scripts/e2e_subs/example.py
@@ -4,7 +4,7 @@ import os
 import sys
 from goal import Goal
 
-import algosdk.future.transaction as txn
+import algosdk.transaction as txn
 from datetime import datetime
 
 stamp = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/test/scripts/e2e_subs/goal/goal.py
+++ b/test/scripts/e2e_subs/goal/goal.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 
 import algosdk
-import algosdk.future.transaction as txn
+import algosdk.transaction as txn
 import algosdk.encoding as enc
 
 

--- a/test/scripts/e2e_subs/min_balance.py
+++ b/test/scripts/e2e_subs/min_balance.py
@@ -5,8 +5,6 @@ from datetime import datetime
 from pathlib import PurePath
 import sys
 
-import algosdk.future.transaction as txn
-
 from goal import Goal
 
 # Set INTERACTIVE True if you want to run a remote debugger interactively on the given PORT

--- a/test/scripts/e2e_subs/shared-resources.py
+++ b/test/scripts/e2e_subs/shared-resources.py
@@ -3,7 +3,7 @@
 import os
 import sys
 import algosdk.encoding as enc
-import algosdk.future.transaction as txn
+import algosdk.transaction as txn
 from goal import Goal
 
 from datetime import datetime


### PR DESCRIPTION
Changed our pinning strategy to only care about major versions, as minor versions aren't supposed to break things, and updates can be useful. Don't want a PR here every time we go from 2.4.11 to 2.4.12.

Existing e2e sub tests are the only thing this affects.
