### PR TITLE
Docs: Eliminate a unicode character that causes trouble in doc generation

### DIFF
--- a/cmd/opdoc/opdoc.go
+++ b/cmd/opdoc/opdoc.go
@@ -47,7 +47,7 @@ func opImmediateNoteSyntaxMarkdown(name string, oids []logic.OpImmediateDetails)
 		argDocs[idx] = fmt.Sprintf("%s: %s", oid.Name, argNote)
 	}
 
-	return fmt.Sprintf("`%s %s` ∋ %s", name, strings.Join(argNames, " "), strings.Join(argDocs, ", "))
+	return fmt.Sprintf("`%s %s` where %s", name, strings.Join(argNames, " "), strings.Join(argDocs, ", "))
 }
 
 func opImmediateNoteEncoding(opcode byte, oids []logic.OpImmediateDetails) string {

--- a/data/transactions/logic/TEAL_opcodes_v1.md
+++ b/data/transactions/logic/TEAL_opcodes_v1.md
@@ -182,7 +182,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## intcblock
 
-- Syntax: `intcblock UINT ...` ∋ UINT ...: a block of int constant values
+- Syntax: `intcblock UINT ...` where UINT ...: a block of int constant values
 - Bytecode: 0x20 {varuint count, [varuint ...]}
 - Stack: ... &rarr; ...
 - prepare block of uint64 constants for use by intc
@@ -191,7 +191,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## intc
 
-- Syntax: `intc I` ∋ I: an index in the intcblock
+- Syntax: `intc I` where I: an index in the intcblock
 - Bytecode: 0x21 {uint8}
 - Stack: ... &rarr; ..., uint64
 - Ith constant from intcblock
@@ -222,7 +222,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## bytecblock
 
-- Syntax: `bytecblock BYTES ...` ∋ BYTES ...: a block of byte constant values
+- Syntax: `bytecblock BYTES ...` where BYTES ...: a block of byte constant values
 - Bytecode: 0x26 {varuint count, [varuint length, bytes ...]}
 - Stack: ... &rarr; ...
 - prepare block of byte-array constants for use by bytec
@@ -231,7 +231,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## bytec
 
-- Syntax: `bytec I` ∋ I: an index in the bytecblock
+- Syntax: `bytec I` where I: an index in the bytecblock
 - Bytecode: 0x27 {uint8}
 - Stack: ... &rarr; ..., []byte
 - Ith constant from bytecblock
@@ -262,7 +262,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## arg
 
-- Syntax: `arg N` ∋ N: an arg index
+- Syntax: `arg N` where N: an arg index
 - Bytecode: 0x2c {uint8}
 - Stack: ... &rarr; ..., []byte
 - Nth LogicSig argument
@@ -298,7 +298,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## txn
 
-- Syntax: `txn F` ∋ F: [txn](#field-group-txn)
+- Syntax: `txn F` where F: [txn](#field-group-txn)
 - Bytecode: 0x31 {uint8}
 - Stack: ... &rarr; ..., any
 - field F of current transaction
@@ -336,7 +336,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## global
 
-- Syntax: `global F` ∋ F: [global](#field-group-global)
+- Syntax: `global F` where F: [global](#field-group-global)
 - Bytecode: 0x32 {uint8}
 - Stack: ... &rarr; ..., any
 - global field F
@@ -356,7 +356,7 @@ Fields
 
 ## gtxn
 
-- Syntax: `gtxn T F` ∋ T: transaction group index, F: [txn](#field-group-txn)
+- Syntax: `gtxn T F` where T: transaction group index, F: [txn](#field-group-txn)
 - Bytecode: 0x33 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the Tth transaction in the current group
@@ -365,21 +365,21 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 
 ## load
 
-- Syntax: `load I` ∋ I: position in scratch space to load from
+- Syntax: `load I` where I: position in scratch space to load from
 - Bytecode: 0x34 {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value. All scratch spaces are 0 at program start.
 
 ## store
 
-- Syntax: `store I` ∋ I: position in scratch space to store to
+- Syntax: `store I` where I: position in scratch space to store to
 - Bytecode: 0x35 {uint8}
 - Stack: ..., A &rarr; ...
 - store A to the Ith scratch space
 
 ## bnz
 
-- Syntax: `bnz TARGET` ∋ TARGET: branch offset
+- Syntax: `bnz TARGET` where TARGET: branch offset
 - Bytecode: 0x40 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is not zero

--- a/data/transactions/logic/TEAL_opcodes_v10.md
+++ b/data/transactions/logic/TEAL_opcodes_v10.md
@@ -41,7 +41,7 @@ The 32 byte public key is the last element on the stack, preceded by the 64 byte
 
 ## ecdsa_verify
 
-- Syntax: `ecdsa_verify V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_verify V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x05 {uint8}
 - Stack: ..., A: [32]byte, B: []byte, C: []byte, D: []byte, E: []byte &rarr; ..., bool
 - for (data A, signature B, C and pubkey D, E) verify the signature of the data against the pubkey => {0 or 1}
@@ -62,7 +62,7 @@ The 32 byte Y-component of a public key is the last element on the stack, preced
 
 ## ecdsa_pk_decompress
 
-- Syntax: `ecdsa_pk_decompress V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_pk_decompress V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x06 {uint8}
 - Stack: ..., A: []byte &rarr; ..., X: []byte, Y: []byte
 - decompress pubkey A into components X, Y
@@ -73,7 +73,7 @@ The 33 byte public key in a compressed form to be decompressed into X and Y (top
 
 ## ecdsa_pk_recover
 
-- Syntax: `ecdsa_pk_recover V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_pk_recover V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x07 {uint8}
 - Stack: ..., A: [32]byte, B: uint64, C: [32]byte, D: [32]byte &rarr; ..., X: []byte, Y: []byte
 - for (data A, recovery id B, signature C, D) recover a public key
@@ -241,7 +241,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## intcblock
 
-- Syntax: `intcblock UINT ...` ∋ UINT ...: a block of int constant values
+- Syntax: `intcblock UINT ...` where UINT ...: a block of int constant values
 - Bytecode: 0x20 {varuint count, [varuint ...]}
 - Stack: ... &rarr; ...
 - prepare block of uint64 constants for use by intc
@@ -250,7 +250,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## intc
 
-- Syntax: `intc I` ∋ I: an index in the intcblock
+- Syntax: `intc I` where I: an index in the intcblock
 - Bytecode: 0x21 {uint8}
 - Stack: ... &rarr; ..., uint64
 - Ith constant from intcblock
@@ -281,7 +281,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## bytecblock
 
-- Syntax: `bytecblock BYTES ...` ∋ BYTES ...: a block of byte constant values
+- Syntax: `bytecblock BYTES ...` where BYTES ...: a block of byte constant values
 - Bytecode: 0x26 {varuint count, [varuint length, bytes ...]}
 - Stack: ... &rarr; ...
 - prepare block of byte-array constants for use by bytec
@@ -290,7 +290,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## bytec
 
-- Syntax: `bytec I` ∋ I: an index in the bytecblock
+- Syntax: `bytec I` where I: an index in the bytecblock
 - Bytecode: 0x27 {uint8}
 - Stack: ... &rarr; ..., []byte
 - Ith constant from bytecblock
@@ -321,7 +321,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## arg
 
-- Syntax: `arg N` ∋ N: an arg index
+- Syntax: `arg N` where N: an arg index
 - Bytecode: 0x2c {uint8}
 - Stack: ... &rarr; ..., []byte
 - Nth LogicSig argument
@@ -357,7 +357,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## txn
 
-- Syntax: `txn F` ∋ F: [txn](#field-group-txn)
+- Syntax: `txn F` where F: [txn](#field-group-txn)
 - Bytecode: 0x31 {uint8}
 - Stack: ... &rarr; ..., any
 - field F of current transaction
@@ -433,7 +433,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## global
 
-- Syntax: `global F` ∋ F: [global](#field-group-global)
+- Syntax: `global F` where F: [global](#field-group-global)
 - Bytecode: 0x32 {uint8}
 - Stack: ... &rarr; ..., any
 - global field F
@@ -466,7 +466,7 @@ Fields
 
 ## gtxn
 
-- Syntax: `gtxn T F` ∋ T: transaction group index, F: [txn](#field-group-txn)
+- Syntax: `gtxn T F` where T: transaction group index, F: [txn](#field-group-txn)
 - Bytecode: 0x33 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the Tth transaction in the current group
@@ -475,21 +475,21 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 
 ## load
 
-- Syntax: `load I` ∋ I: position in scratch space to load from
+- Syntax: `load I` where I: position in scratch space to load from
 - Bytecode: 0x34 {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value. All scratch spaces are 0 at program start.
 
 ## store
 
-- Syntax: `store I` ∋ I: position in scratch space to store to
+- Syntax: `store I` where I: position in scratch space to store to
 - Bytecode: 0x35 {uint8}
 - Stack: ..., A &rarr; ...
 - store A to the Ith scratch space
 
 ## txna
 
-- Syntax: `txna F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `txna F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x36 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F of the current transaction<br />`txna` can be called using `txn` with 2 immediates.
@@ -512,7 +512,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxna
 
-- Syntax: `gtxna T F I` ∋ T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxna T F I` where T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x37 {uint8}, {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F from the Tth transaction in the current group<br />`gtxna` can be called using `gtxn` with 3 immediates.
@@ -520,7 +520,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxns
 
-- Syntax: `gtxns F` ∋ F: [txn](#field-group-txn)
+- Syntax: `gtxns F` where F: [txn](#field-group-txn)
 - Bytecode: 0x38 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - field F of the Ath transaction in the current group
@@ -530,7 +530,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gtxnsa
 
-- Syntax: `gtxnsa F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxnsa F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x39 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ith value of the array field F from the Ath transaction in the current group<br />`gtxnsa` can be called using `gtxns` with 2 immediates.
@@ -538,7 +538,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gload
 
-- Syntax: `gload T I` ∋ T: transaction group index, I: position in scratch space to load from
+- Syntax: `gload T I` where T: transaction group index, I: position in scratch space to load from
 - Bytecode: 0x3a {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value of the Tth transaction in the current group
@@ -549,7 +549,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gloads
 
-- Syntax: `gloads I` ∋ I: position in scratch space to load from
+- Syntax: `gloads I` where I: position in scratch space to load from
 - Bytecode: 0x3b {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ith scratch space value of the Ath transaction in the current group
@@ -560,7 +560,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gaid
 
-- Syntax: `gaid T` ∋ T: transaction group index
+- Syntax: `gaid T` where T: transaction group index
 - Bytecode: 0x3c {uint8}
 - Stack: ... &rarr; ..., uint64
 - ID of the asset or application created in the Tth transaction of the current group
@@ -595,7 +595,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## bnz
 
-- Syntax: `bnz TARGET` ∋ TARGET: branch offset
+- Syntax: `bnz TARGET` where TARGET: branch offset
 - Bytecode: 0x40 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is not zero
@@ -606,7 +606,7 @@ At v2 it became allowed to branch to the end of the program exactly after the la
 
 ## bz
 
-- Syntax: `bz TARGET` ∋ TARGET: branch offset
+- Syntax: `bz TARGET` where TARGET: branch offset
 - Bytecode: 0x41 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is zero
@@ -616,7 +616,7 @@ See `bnz` for details on how branches work. `bz` inverts the behavior of `bnz`.
 
 ## b
 
-- Syntax: `b TARGET` ∋ TARGET: branch offset
+- Syntax: `b TARGET` where TARGET: branch offset
 - Bytecode: 0x42 {int16 (big-endian)}
 - Stack: ... &rarr; ...
 - branch unconditionally to TARGET
@@ -640,7 +640,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## bury
 
-- Syntax: `bury N` ∋ N: depth
+- Syntax: `bury N` where N: depth
 - Bytecode: 0x45 {uint8}
 - Stack: ..., A &rarr; ...
 - replace the Nth value from the top of the stack with A. bury 0 fails.
@@ -648,7 +648,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## popn
 
-- Syntax: `popn N` ∋ N: stack depth
+- Syntax: `popn N` where N: stack depth
 - Bytecode: 0x46 {uint8}
 - Stack: ..., [N items] &rarr; ...
 - remove N values from the top of the stack
@@ -656,7 +656,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## dupn
 
-- Syntax: `dupn N` ∋ N: copy count
+- Syntax: `dupn N` where N: copy count
 - Bytecode: 0x47 {uint8}
 - Stack: ..., A &rarr; ..., A, [N copies of A]
 - duplicate A, N times
@@ -683,7 +683,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## dig
 
-- Syntax: `dig N` ∋ N: depth
+- Syntax: `dig N` where N: depth
 - Bytecode: 0x4b {uint8}
 - Stack: ..., A, [N items] &rarr; ..., A, [N items], A
 - Nth value from the top of the stack. dig 0 is equivalent to dup
@@ -705,7 +705,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## cover
 
-- Syntax: `cover N` ∋ N: depth
+- Syntax: `cover N` where N: depth
 - Bytecode: 0x4e {uint8}
 - Stack: ..., [N items], A &rarr; ..., A, [N items]
 - remove top of stack, and place it deeper in the stack such that N elements are above it. Fails if stack depth <= N.
@@ -713,7 +713,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## uncover
 
-- Syntax: `uncover N` ∋ N: depth
+- Syntax: `uncover N` where N: depth
 - Bytecode: 0x4f {uint8}
 - Stack: ..., A, [N items] &rarr; ..., [N items], A
 - remove the value at depth N in the stack and shift above items down so the Nth deep value is on top of the stack. Fails if stack depth <= N.
@@ -730,7 +730,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## substring
 
-- Syntax: `substring S E` ∋ S: start position, E: end position
+- Syntax: `substring S E` where S: start position, E: end position
 - Bytecode: 0x51 {uint8}, {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - A range of bytes from A starting at S up to but not including E. If E < S, or either is larger than the array length, the program fails
@@ -777,7 +777,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 
 ## extract
 
-- Syntax: `extract S L` ∋ S: start position, L: length
+- Syntax: `extract S L` where S: start position, L: length
 - Bytecode: 0x57 {uint8}, {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - A range of bytes from A starting at S up to but not including S+L. If L is 0, then extract to the end of the string. If S or S+L is larger than the array length, the program fails
@@ -813,7 +813,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 
 ## replace2
 
-- Syntax: `replace2 S` ∋ S: start position
+- Syntax: `replace2 S` where S: start position
 - Bytecode: 0x5c {uint8}
 - Stack: ..., A: []byte, B: []byte &rarr; ..., []byte
 - Copy of A with the bytes starting at S replaced by the bytes of B. Fails if S+len(B) exceeds len(A)<br />`replace2` can be called using `replace` with 1 immediate.
@@ -828,7 +828,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 
 ## base64_decode
 
-- Syntax: `base64_decode E` ∋ E: [base64](#field-group-base64)
+- Syntax: `base64_decode E` where E: [base64](#field-group-base64)
 - Bytecode: 0x5e {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - decode A which was base64-encoded using _encoding_ E. Fail if A is not base64 encoded with encoding E
@@ -851,7 +851,7 @@ Encodings
 
 ## json_ref
 
-- Syntax: `json_ref R` ∋ R: [json_ref](#field-group-json_ref)
+- Syntax: `json_ref R` where R: [json_ref](#field-group-json_ref)
 - Bytecode: 0x5f {uint8}
 - Stack: ..., A: []byte, B: []byte &rarr; ..., any
 - key B's value, of type R, from a [valid](jsonspec.md) utf-8 encoded json object A
@@ -977,7 +977,7 @@ Deleting a key which is already absent has no effect on the application global s
 
 ## asset_holding_get
 
-- Syntax: `asset_holding_get F` ∋ F: [asset_holding](#field-group-asset_holding)
+- Syntax: `asset_holding_get F` where F: [asset_holding](#field-group-asset_holding)
 - Bytecode: 0x70 {uint8}
 - Stack: ..., A, B: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from account A's holding of asset B. Y is 1 if A is opted into B, else 0
@@ -998,7 +998,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ address), asset id (or
 
 ## asset_params_get
 
-- Syntax: `asset_params_get F` ∋ F: [asset_params](#field-group-asset_params)
+- Syntax: `asset_params_get F` where F: [asset_params](#field-group-asset_params)
 - Bytecode: 0x71 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from asset A. Y is 1 if A exists, else 0
@@ -1029,7 +1029,7 @@ params: Txn.ForeignAssets offset (or, since v4, an _available_ asset id. Return:
 
 ## app_params_get
 
-- Syntax: `app_params_get F` ∋ F: [app_params](#field-group-app_params)
+- Syntax: `app_params_get F` where F: [app_params](#field-group-app_params)
 - Bytecode: 0x72 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from app A. Y is 1 if A exists, else 0
@@ -1057,7 +1057,7 @@ params: Txn.ForeignApps offset or an _available_ app id. Return: did_exist flag 
 
 ## acct_params_get
 
-- Syntax: `acct_params_get F` ∋ F: [acct_params](#field-group-acct_params)
+- Syntax: `acct_params_get F` where F: [acct_params](#field-group-acct_params)
 - Bytecode: 0x73 {uint8}
 - Stack: ..., A &rarr; ..., X: any, Y: bool
 - X is field F from account A. Y is 1 if A owns positive algos, else 0
@@ -1096,7 +1096,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ account address), _ava
 
 ## pushbytes
 
-- Syntax: `pushbytes BYTES` ∋ BYTES: a byte constant
+- Syntax: `pushbytes BYTES` where BYTES: a byte constant
 - Bytecode: 0x80 {varuint length, bytes}
 - Stack: ... &rarr; ..., []byte
 - immediate BYTES
@@ -1106,7 +1106,7 @@ pushbytes args are not added to the bytecblock during assembly processes
 
 ## pushint
 
-- Syntax: `pushint UINT` ∋ UINT: an int constant
+- Syntax: `pushint UINT` where UINT: an int constant
 - Bytecode: 0x81 {varuint}
 - Stack: ... &rarr; ..., uint64
 - immediate UINT
@@ -1116,7 +1116,7 @@ pushint args are not added to the intcblock during assembly processes
 
 ## pushbytess
 
-- Syntax: `pushbytess BYTES ...` ∋ BYTES ...: a list of byte constants
+- Syntax: `pushbytess BYTES ...` where BYTES ...: a list of byte constants
 - Bytecode: 0x82 {varuint count, [varuint length, bytes ...]}
 - Stack: ... &rarr; ..., [N items]
 - push sequences of immediate byte arrays to stack (first byte array being deepest)
@@ -1126,7 +1126,7 @@ pushbytess args are not added to the bytecblock during assembly processes
 
 ## pushints
 
-- Syntax: `pushints UINT ...` ∋ UINT ...: a list of int constants
+- Syntax: `pushints UINT ...` where UINT ...: a list of int constants
 - Bytecode: 0x83 {varuint count, [varuint ...]}
 - Stack: ... &rarr; ..., [N items]
 - push sequence of immediate uints to stack in the order they appear (first uint being deepest)
@@ -1144,7 +1144,7 @@ pushints args are not added to the intcblock during assembly processes
 
 ## callsub
 
-- Syntax: `callsub TARGET` ∋ TARGET: branch offset
+- Syntax: `callsub TARGET` where TARGET: branch offset
 - Bytecode: 0x88 {int16 (big-endian)}
 - Stack: ... &rarr; ...
 - branch unconditionally to TARGET, saving the next instruction on the call stack
@@ -1163,7 +1163,7 @@ If the current frame was prepared by `proto A R`, `retsub` will remove the 'A' a
 
 ## proto
 
-- Syntax: `proto A R` ∋ A: number of arguments, R: number of return values
+- Syntax: `proto A R` where A: number of arguments, R: number of return values
 - Bytecode: 0x8a {uint8}, {uint8}
 - Stack: ... &rarr; ...
 - Prepare top call frame for a retsub that will assume A args and R return values.
@@ -1173,7 +1173,7 @@ Fails unless the last instruction executed was a `callsub`.
 
 ## frame_dig
 
-- Syntax: `frame_dig I` ∋ I: frame slot
+- Syntax: `frame_dig I` where I: frame slot
 - Bytecode: 0x8b {int8}
 - Stack: ... &rarr; ..., any
 - Nth (signed) value from the frame pointer.
@@ -1181,7 +1181,7 @@ Fails unless the last instruction executed was a `callsub`.
 
 ## frame_bury
 
-- Syntax: `frame_bury I` ∋ I: frame slot
+- Syntax: `frame_bury I` where I: frame slot
 - Bytecode: 0x8c {int8}
 - Stack: ..., A &rarr; ...
 - replace the Nth (signed) value from the frame pointer in the stack with A
@@ -1189,7 +1189,7 @@ Fails unless the last instruction executed was a `callsub`.
 
 ## switch
 
-- Syntax: `switch TARGET ...` ∋ TARGET ...: list of labels
+- Syntax: `switch TARGET ...` where TARGET ...: list of labels
 - Bytecode: 0x8d {varuint count, [int16 (big-endian) ...]}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to the Ath label. Continue at following instruction if index A exceeds the number of labels.
@@ -1197,7 +1197,7 @@ Fails unless the last instruction executed was a `callsub`.
 
 ## match
 
-- Syntax: `match TARGET ...` ∋ TARGET ...: list of labels
+- Syntax: `match TARGET ...` where TARGET ...: list of labels
 - Bytecode: 0x8e {varuint count, [int16 (big-endian) ...]}
 - Stack: ..., [A1, A2, ..., AN], B &rarr; ...
 - given match cases from A[1] to A[N], branch to the Ith label where A[I] = B. Continue to the following instruction if no matches are found.
@@ -1419,7 +1419,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxn_field
 
-- Syntax: `itxn_field F` ∋ F: [txn](#field-group-txn)
+- Syntax: `itxn_field F` where F: [txn](#field-group-txn)
 - Bytecode: 0xb2 {uint8}
 - Stack: ..., A &rarr; ...
 - set field F of the current inner transaction to A
@@ -1440,7 +1440,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxn
 
-- Syntax: `itxn F` ∋ F: [txn](#field-group-txn)
+- Syntax: `itxn F` where F: [txn](#field-group-txn)
 - Bytecode: 0xb4 {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the last inner transaction
@@ -1449,7 +1449,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxna
 
-- Syntax: `itxna F I` ∋ F: [txna](#field-group-txna), I: a transaction field array index
+- Syntax: `itxna F I` where F: [txna](#field-group-txna), I: a transaction field array index
 - Bytecode: 0xb5 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F of the last inner transaction
@@ -1468,7 +1468,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## gitxn
 
-- Syntax: `gitxn T F` ∋ T: transaction group index, F: [txn](#field-group-txn)
+- Syntax: `gitxn T F` where T: transaction group index, F: [txn](#field-group-txn)
 - Bytecode: 0xb7 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the Tth transaction in the last inner group submitted
@@ -1477,7 +1477,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## gitxna
 
-- Syntax: `gitxna T F I` ∋ T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gitxna T F I` where T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0xb8 {uint8}, {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F from the Tth transaction in the last inner group submitted
@@ -1548,7 +1548,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## txnas
 
-- Syntax: `txnas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `txnas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc0 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F of the current transaction
@@ -1556,7 +1556,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## gtxnas
 
-- Syntax: `gtxnas T F` ∋ T: transaction group index, F: [txna](#field-group-txna)
+- Syntax: `gtxnas T F` where T: transaction group index, F: [txna](#field-group-txna)
 - Bytecode: 0xc1 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F from the Tth transaction in the current group
@@ -1564,7 +1564,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## gtxnsas
 
-- Syntax: `gtxnsas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `gtxnsas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc2 {uint8}
 - Stack: ..., A: uint64, B: uint64 &rarr; ..., any
 - Bth value of the array field F from the Ath transaction in the current group
@@ -1588,7 +1588,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## itxnas
 
-- Syntax: `itxnas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `itxnas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc5 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F of the last inner transaction
@@ -1597,7 +1597,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## gitxnas
 
-- Syntax: `gitxnas T F` ∋ T: transaction group index, F: [txna](#field-group-txna)
+- Syntax: `gitxnas T F` where T: transaction group index, F: [txna](#field-group-txna)
 - Bytecode: 0xc6 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F from the Tth transaction in the last inner group submitted
@@ -1606,7 +1606,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## vrf_verify
 
-- Syntax: `vrf_verify S` ∋ S: [vrf_verify](#field-group-vrf_verify)
+- Syntax: `vrf_verify S` where S: [vrf_verify](#field-group-vrf_verify)
 - Bytecode: 0xd0 {uint8}
 - Stack: ..., A: []byte, B: [80]byte, C: [32]byte &rarr; ..., X: []byte, Y: bool
 - Verify the proof B of message A against pubkey C. Returns vrf output and verification flag.
@@ -1626,7 +1626,7 @@ Standards
 
 ## block
 
-- Syntax: `block F` ∋ F: [block](#field-group-block)
+- Syntax: `block F` where F: [block](#field-group-block)
 - Bytecode: 0xd1 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - field F of block A. Fail unless A falls between txn.LastValid-1002 and txn.FirstValid (exclusive)
@@ -1662,7 +1662,7 @@ Boxes are of constant length. If C < len(D), then len(D)-C bytes will be removed
 
 ## ec_add
 
-- Syntax: `ec_add G` ∋ G: [EC](#field-group-ec)
+- Syntax: `ec_add G` where G: [EC](#field-group-ec)
 - Bytecode: 0xe0 {uint8}
 - Stack: ..., A: []byte, B: []byte &rarr; ..., []byte
 - for curve points A and B, return the curve point A + B
@@ -1694,7 +1694,7 @@ Does _not_ check if A and B are in the main prime-order subgroup.
 
 ## ec_scalar_mul
 
-- Syntax: `ec_scalar_mul G` ∋ G: [EC](#field-group-ec)
+- Syntax: `ec_scalar_mul G` where G: [EC](#field-group-ec)
 - Bytecode: 0xe1 {uint8}
 - Stack: ..., A: []byte, B: []byte &rarr; ..., []byte
 - for curve point A and scalar B, return the curve point BA, the point A multiplied by the scalar B.
@@ -1705,7 +1705,7 @@ A is a curve point encoded and checked as described in `ec_add`. Scalar B is int
 
 ## ec_pairing_check
 
-- Syntax: `ec_pairing_check G` ∋ G: [EC](#field-group-ec)
+- Syntax: `ec_pairing_check G` where G: [EC](#field-group-ec)
 - Bytecode: 0xe2 {uint8}
 - Stack: ..., A: []byte, B: []byte &rarr; ..., bool
 - 1 if the product of the pairing of each point in A with its respective point in B is equal to the identity element of the target group Gt, else 0
@@ -1716,7 +1716,7 @@ A and B are concatenated points, encoded and checked as described in `ec_add`. A
 
 ## ec_multi_scalar_mul
 
-- Syntax: `ec_multi_scalar_mul G` ∋ G: [EC](#field-group-ec)
+- Syntax: `ec_multi_scalar_mul G` where G: [EC](#field-group-ec)
 - Bytecode: 0xe3 {uint8}
 - Stack: ..., A: []byte, B: []byte &rarr; ..., []byte
 - for curve points A and scalars B, return curve point B0A0 + B1A1 + B2A2 + ... + BnAn
@@ -1728,7 +1728,7 @@ The name `ec_multi_scalar_mul` was chosen to reflect common usage, but a more co
 
 ## ec_subgroup_check
 
-- Syntax: `ec_subgroup_check G` ∋ G: [EC](#field-group-ec)
+- Syntax: `ec_subgroup_check G` where G: [EC](#field-group-ec)
 - Bytecode: 0xe4 {uint8}
 - Stack: ..., A: []byte &rarr; ..., bool
 - 1 if A is in the main prime-order subgroup of G (including the point at infinity) else 0. Program fails if A is not in G at all.
@@ -1737,7 +1737,7 @@ The name `ec_multi_scalar_mul` was chosen to reflect common usage, but a more co
 
 ## ec_map_to
 
-- Syntax: `ec_map_to G` ∋ G: [EC](#field-group-ec)
+- Syntax: `ec_map_to G` where G: [EC](#field-group-ec)
 - Bytecode: 0xe5 {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - maps field element A to group G

--- a/data/transactions/logic/TEAL_opcodes_v2.md
+++ b/data/transactions/logic/TEAL_opcodes_v2.md
@@ -189,7 +189,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## intcblock
 
-- Syntax: `intcblock UINT ...` ∋ UINT ...: a block of int constant values
+- Syntax: `intcblock UINT ...` where UINT ...: a block of int constant values
 - Bytecode: 0x20 {varuint count, [varuint ...]}
 - Stack: ... &rarr; ...
 - prepare block of uint64 constants for use by intc
@@ -198,7 +198,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## intc
 
-- Syntax: `intc I` ∋ I: an index in the intcblock
+- Syntax: `intc I` where I: an index in the intcblock
 - Bytecode: 0x21 {uint8}
 - Stack: ... &rarr; ..., uint64
 - Ith constant from intcblock
@@ -229,7 +229,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## bytecblock
 
-- Syntax: `bytecblock BYTES ...` ∋ BYTES ...: a block of byte constant values
+- Syntax: `bytecblock BYTES ...` where BYTES ...: a block of byte constant values
 - Bytecode: 0x26 {varuint count, [varuint length, bytes ...]}
 - Stack: ... &rarr; ...
 - prepare block of byte-array constants for use by bytec
@@ -238,7 +238,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## bytec
 
-- Syntax: `bytec I` ∋ I: an index in the bytecblock
+- Syntax: `bytec I` where I: an index in the bytecblock
 - Bytecode: 0x27 {uint8}
 - Stack: ... &rarr; ..., []byte
 - Ith constant from bytecblock
@@ -269,7 +269,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## arg
 
-- Syntax: `arg N` ∋ N: an arg index
+- Syntax: `arg N` where N: an arg index
 - Bytecode: 0x2c {uint8}
 - Stack: ... &rarr; ..., []byte
 - Nth LogicSig argument
@@ -305,7 +305,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## txn
 
-- Syntax: `txn F` ∋ F: [txn](#field-group-txn)
+- Syntax: `txn F` where F: [txn](#field-group-txn)
 - Bytecode: 0x31 {uint8}
 - Stack: ... &rarr; ..., any
 - field F of current transaction
@@ -365,7 +365,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## global
 
-- Syntax: `global F` ∋ F: [global](#field-group-global)
+- Syntax: `global F` where F: [global](#field-group-global)
 - Bytecode: 0x32 {uint8}
 - Stack: ... &rarr; ..., any
 - global field F
@@ -389,7 +389,7 @@ Fields
 
 ## gtxn
 
-- Syntax: `gtxn T F` ∋ T: transaction group index, F: [txn](#field-group-txn)
+- Syntax: `gtxn T F` where T: transaction group index, F: [txn](#field-group-txn)
 - Bytecode: 0x33 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the Tth transaction in the current group
@@ -398,21 +398,21 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 
 ## load
 
-- Syntax: `load I` ∋ I: position in scratch space to load from
+- Syntax: `load I` where I: position in scratch space to load from
 - Bytecode: 0x34 {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value. All scratch spaces are 0 at program start.
 
 ## store
 
-- Syntax: `store I` ∋ I: position in scratch space to store to
+- Syntax: `store I` where I: position in scratch space to store to
 - Bytecode: 0x35 {uint8}
 - Stack: ..., A &rarr; ...
 - store A to the Ith scratch space
 
 ## txna
 
-- Syntax: `txna F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `txna F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x36 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F of the current transaction<br />`txna` can be called using `txn` with 2 immediates.
@@ -430,7 +430,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxna
 
-- Syntax: `gtxna T F I` ∋ T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxna T F I` where T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x37 {uint8}, {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F from the Tth transaction in the current group<br />`gtxna` can be called using `gtxn` with 3 immediates.
@@ -438,7 +438,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## bnz
 
-- Syntax: `bnz TARGET` ∋ TARGET: branch offset
+- Syntax: `bnz TARGET` where TARGET: branch offset
 - Bytecode: 0x40 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is not zero
@@ -449,7 +449,7 @@ At v2 it became allowed to branch to the end of the program exactly after the la
 
 ## bz
 
-- Syntax: `bz TARGET` ∋ TARGET: branch offset
+- Syntax: `bz TARGET` where TARGET: branch offset
 - Bytecode: 0x41 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is zero
@@ -459,7 +459,7 @@ See `bnz` for details on how branches work. `bz` inverts the behavior of `bnz`.
 
 ## b
 
-- Syntax: `b TARGET` ∋ TARGET: branch offset
+- Syntax: `b TARGET` where TARGET: branch offset
 - Bytecode: 0x42 {int16 (big-endian)}
 - Stack: ... &rarr; ...
 - branch unconditionally to TARGET
@@ -504,7 +504,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## substring
 
-- Syntax: `substring S E` ∋ S: start position, E: end position
+- Syntax: `substring S E` where S: start position, E: end position
 - Bytecode: 0x51 {uint8}, {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - A range of bytes from A starting at S up to but not including E. If E < S, or either is larger than the array length, the program fails
@@ -621,7 +621,7 @@ Deleting a key which is already absent has no effect on the application global s
 
 ## asset_holding_get
 
-- Syntax: `asset_holding_get F` ∋ F: [asset_holding](#field-group-asset_holding)
+- Syntax: `asset_holding_get F` where F: [asset_holding](#field-group-asset_holding)
 - Bytecode: 0x70 {uint8}
 - Stack: ..., A: uint64, B: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from account A's holding of asset B. Y is 1 if A is opted into B, else 0
@@ -642,7 +642,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ address), asset id (or
 
 ## asset_params_get
 
-- Syntax: `asset_params_get F` ∋ F: [asset_params](#field-group-asset_params)
+- Syntax: `asset_params_get F` where F: [asset_params](#field-group-asset_params)
 - Bytecode: 0x71 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from asset A. Y is 1 if A exists, else 0

--- a/data/transactions/logic/TEAL_opcodes_v3.md
+++ b/data/transactions/logic/TEAL_opcodes_v3.md
@@ -189,7 +189,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## intcblock
 
-- Syntax: `intcblock UINT ...` ∋ UINT ...: a block of int constant values
+- Syntax: `intcblock UINT ...` where UINT ...: a block of int constant values
 - Bytecode: 0x20 {varuint count, [varuint ...]}
 - Stack: ... &rarr; ...
 - prepare block of uint64 constants for use by intc
@@ -198,7 +198,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## intc
 
-- Syntax: `intc I` ∋ I: an index in the intcblock
+- Syntax: `intc I` where I: an index in the intcblock
 - Bytecode: 0x21 {uint8}
 - Stack: ... &rarr; ..., uint64
 - Ith constant from intcblock
@@ -229,7 +229,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## bytecblock
 
-- Syntax: `bytecblock BYTES ...` ∋ BYTES ...: a block of byte constant values
+- Syntax: `bytecblock BYTES ...` where BYTES ...: a block of byte constant values
 - Bytecode: 0x26 {varuint count, [varuint length, bytes ...]}
 - Stack: ... &rarr; ...
 - prepare block of byte-array constants for use by bytec
@@ -238,7 +238,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## bytec
 
-- Syntax: `bytec I` ∋ I: an index in the bytecblock
+- Syntax: `bytec I` where I: an index in the bytecblock
 - Bytecode: 0x27 {uint8}
 - Stack: ... &rarr; ..., []byte
 - Ith constant from bytecblock
@@ -269,7 +269,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## arg
 
-- Syntax: `arg N` ∋ N: an arg index
+- Syntax: `arg N` where N: an arg index
 - Bytecode: 0x2c {uint8}
 - Stack: ... &rarr; ..., []byte
 - Nth LogicSig argument
@@ -305,7 +305,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## txn
 
-- Syntax: `txn F` ∋ F: [txn](#field-group-txn)
+- Syntax: `txn F` where F: [txn](#field-group-txn)
 - Bytecode: 0x31 {uint8}
 - Stack: ... &rarr; ..., any
 - field F of current transaction
@@ -371,7 +371,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## global
 
-- Syntax: `global F` ∋ F: [global](#field-group-global)
+- Syntax: `global F` where F: [global](#field-group-global)
 - Bytecode: 0x32 {uint8}
 - Stack: ... &rarr; ..., any
 - global field F
@@ -396,7 +396,7 @@ Fields
 
 ## gtxn
 
-- Syntax: `gtxn T F` ∋ T: transaction group index, F: [txn](#field-group-txn)
+- Syntax: `gtxn T F` where T: transaction group index, F: [txn](#field-group-txn)
 - Bytecode: 0x33 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the Tth transaction in the current group
@@ -405,21 +405,21 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 
 ## load
 
-- Syntax: `load I` ∋ I: position in scratch space to load from
+- Syntax: `load I` where I: position in scratch space to load from
 - Bytecode: 0x34 {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value. All scratch spaces are 0 at program start.
 
 ## store
 
-- Syntax: `store I` ∋ I: position in scratch space to store to
+- Syntax: `store I` where I: position in scratch space to store to
 - Bytecode: 0x35 {uint8}
 - Stack: ..., A &rarr; ...
 - store A to the Ith scratch space
 
 ## txna
 
-- Syntax: `txna F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `txna F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x36 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F of the current transaction<br />`txna` can be called using `txn` with 2 immediates.
@@ -439,7 +439,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxna
 
-- Syntax: `gtxna T F I` ∋ T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxna T F I` where T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x37 {uint8}, {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F from the Tth transaction in the current group<br />`gtxna` can be called using `gtxn` with 3 immediates.
@@ -447,7 +447,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxns
 
-- Syntax: `gtxns F` ∋ F: [txn](#field-group-txn)
+- Syntax: `gtxns F` where F: [txn](#field-group-txn)
 - Bytecode: 0x38 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - field F of the Ath transaction in the current group
@@ -457,7 +457,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gtxnsa
 
-- Syntax: `gtxnsa F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxnsa F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x39 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ith value of the array field F from the Ath transaction in the current group<br />`gtxnsa` can be called using `gtxns` with 2 immediates.
@@ -465,7 +465,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## bnz
 
-- Syntax: `bnz TARGET` ∋ TARGET: branch offset
+- Syntax: `bnz TARGET` where TARGET: branch offset
 - Bytecode: 0x40 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is not zero
@@ -476,7 +476,7 @@ At v2 it became allowed to branch to the end of the program exactly after the la
 
 ## bz
 
-- Syntax: `bz TARGET` ∋ TARGET: branch offset
+- Syntax: `bz TARGET` where TARGET: branch offset
 - Bytecode: 0x41 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is zero
@@ -486,7 +486,7 @@ See `bnz` for details on how branches work. `bz` inverts the behavior of `bnz`.
 
 ## b
 
-- Syntax: `b TARGET` ∋ TARGET: branch offset
+- Syntax: `b TARGET` where TARGET: branch offset
 - Bytecode: 0x42 {int16 (big-endian)}
 - Stack: ... &rarr; ...
 - branch unconditionally to TARGET
@@ -529,7 +529,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## dig
 
-- Syntax: `dig N` ∋ N: depth
+- Syntax: `dig N` where N: depth
 - Bytecode: 0x4b {uint8}
 - Stack: ..., A, [N items] &rarr; ..., A, [N items], A
 - Nth value from the top of the stack. dig 0 is equivalent to dup
@@ -560,7 +560,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## substring
 
-- Syntax: `substring S E` ∋ S: start position, E: end position
+- Syntax: `substring S E` where S: start position, E: end position
 - Bytecode: 0x51 {uint8}, {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - A range of bytes from A starting at S up to but not including E. If E < S, or either is larger than the array length, the program fails
@@ -709,7 +709,7 @@ Deleting a key which is already absent has no effect on the application global s
 
 ## asset_holding_get
 
-- Syntax: `asset_holding_get F` ∋ F: [asset_holding](#field-group-asset_holding)
+- Syntax: `asset_holding_get F` where F: [asset_holding](#field-group-asset_holding)
 - Bytecode: 0x70 {uint8}
 - Stack: ..., A: uint64, B: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from account A's holding of asset B. Y is 1 if A is opted into B, else 0
@@ -730,7 +730,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ address), asset id (or
 
 ## asset_params_get
 
-- Syntax: `asset_params_get F` ∋ F: [asset_params](#field-group-asset_params)
+- Syntax: `asset_params_get F` where F: [asset_params](#field-group-asset_params)
 - Bytecode: 0x71 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from asset A. Y is 1 if A exists, else 0
@@ -770,7 +770,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ account address), _ava
 
 ## pushbytes
 
-- Syntax: `pushbytes BYTES` ∋ BYTES: a byte constant
+- Syntax: `pushbytes BYTES` where BYTES: a byte constant
 - Bytecode: 0x80 {varuint length, bytes}
 - Stack: ... &rarr; ..., []byte
 - immediate BYTES
@@ -780,7 +780,7 @@ pushbytes args are not added to the bytecblock during assembly processes
 
 ## pushint
 
-- Syntax: `pushint UINT` ∋ UINT: an int constant
+- Syntax: `pushint UINT` where UINT: an int constant
 - Bytecode: 0x81 {varuint}
 - Stack: ... &rarr; ..., uint64
 - immediate UINT

--- a/data/transactions/logic/TEAL_opcodes_v4.md
+++ b/data/transactions/logic/TEAL_opcodes_v4.md
@@ -199,7 +199,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## intcblock
 
-- Syntax: `intcblock UINT ...` ∋ UINT ...: a block of int constant values
+- Syntax: `intcblock UINT ...` where UINT ...: a block of int constant values
 - Bytecode: 0x20 {varuint count, [varuint ...]}
 - Stack: ... &rarr; ...
 - prepare block of uint64 constants for use by intc
@@ -208,7 +208,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## intc
 
-- Syntax: `intc I` ∋ I: an index in the intcblock
+- Syntax: `intc I` where I: an index in the intcblock
 - Bytecode: 0x21 {uint8}
 - Stack: ... &rarr; ..., uint64
 - Ith constant from intcblock
@@ -239,7 +239,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## bytecblock
 
-- Syntax: `bytecblock BYTES ...` ∋ BYTES ...: a block of byte constant values
+- Syntax: `bytecblock BYTES ...` where BYTES ...: a block of byte constant values
 - Bytecode: 0x26 {varuint count, [varuint length, bytes ...]}
 - Stack: ... &rarr; ...
 - prepare block of byte-array constants for use by bytec
@@ -248,7 +248,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## bytec
 
-- Syntax: `bytec I` ∋ I: an index in the bytecblock
+- Syntax: `bytec I` where I: an index in the bytecblock
 - Bytecode: 0x27 {uint8}
 - Stack: ... &rarr; ..., []byte
 - Ith constant from bytecblock
@@ -279,7 +279,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## arg
 
-- Syntax: `arg N` ∋ N: an arg index
+- Syntax: `arg N` where N: an arg index
 - Bytecode: 0x2c {uint8}
 - Stack: ... &rarr; ..., []byte
 - Nth LogicSig argument
@@ -315,7 +315,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## txn
 
-- Syntax: `txn F` ∋ F: [txn](#field-group-txn)
+- Syntax: `txn F` where F: [txn](#field-group-txn)
 - Bytecode: 0x31 {uint8}
 - Stack: ... &rarr; ..., any
 - field F of current transaction
@@ -382,7 +382,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## global
 
-- Syntax: `global F` ∋ F: [global](#field-group-global)
+- Syntax: `global F` where F: [global](#field-group-global)
 - Bytecode: 0x32 {uint8}
 - Stack: ... &rarr; ..., any
 - global field F
@@ -407,7 +407,7 @@ Fields
 
 ## gtxn
 
-- Syntax: `gtxn T F` ∋ T: transaction group index, F: [txn](#field-group-txn)
+- Syntax: `gtxn T F` where T: transaction group index, F: [txn](#field-group-txn)
 - Bytecode: 0x33 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the Tth transaction in the current group
@@ -416,21 +416,21 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 
 ## load
 
-- Syntax: `load I` ∋ I: position in scratch space to load from
+- Syntax: `load I` where I: position in scratch space to load from
 - Bytecode: 0x34 {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value. All scratch spaces are 0 at program start.
 
 ## store
 
-- Syntax: `store I` ∋ I: position in scratch space to store to
+- Syntax: `store I` where I: position in scratch space to store to
 - Bytecode: 0x35 {uint8}
 - Stack: ..., A &rarr; ...
 - store A to the Ith scratch space
 
 ## txna
 
-- Syntax: `txna F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `txna F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x36 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F of the current transaction<br />`txna` can be called using `txn` with 2 immediates.
@@ -450,7 +450,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxna
 
-- Syntax: `gtxna T F I` ∋ T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxna T F I` where T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x37 {uint8}, {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F from the Tth transaction in the current group<br />`gtxna` can be called using `gtxn` with 3 immediates.
@@ -458,7 +458,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxns
 
-- Syntax: `gtxns F` ∋ F: [txn](#field-group-txn)
+- Syntax: `gtxns F` where F: [txn](#field-group-txn)
 - Bytecode: 0x38 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - field F of the Ath transaction in the current group
@@ -468,7 +468,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gtxnsa
 
-- Syntax: `gtxnsa F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxnsa F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x39 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ith value of the array field F from the Ath transaction in the current group<br />`gtxnsa` can be called using `gtxns` with 2 immediates.
@@ -476,7 +476,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gload
 
-- Syntax: `gload T I` ∋ T: transaction group index, I: position in scratch space to load from
+- Syntax: `gload T I` where T: transaction group index, I: position in scratch space to load from
 - Bytecode: 0x3a {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value of the Tth transaction in the current group
@@ -487,7 +487,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gloads
 
-- Syntax: `gloads I` ∋ I: position in scratch space to load from
+- Syntax: `gloads I` where I: position in scratch space to load from
 - Bytecode: 0x3b {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ith scratch space value of the Ath transaction in the current group
@@ -498,7 +498,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gaid
 
-- Syntax: `gaid T` ∋ T: transaction group index
+- Syntax: `gaid T` where T: transaction group index
 - Bytecode: 0x3c {uint8}
 - Stack: ... &rarr; ..., uint64
 - ID of the asset or application created in the Tth transaction of the current group
@@ -519,7 +519,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## bnz
 
-- Syntax: `bnz TARGET` ∋ TARGET: branch offset
+- Syntax: `bnz TARGET` where TARGET: branch offset
 - Bytecode: 0x40 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is not zero
@@ -530,7 +530,7 @@ At v2 it became allowed to branch to the end of the program exactly after the la
 
 ## bz
 
-- Syntax: `bz TARGET` ∋ TARGET: branch offset
+- Syntax: `bz TARGET` where TARGET: branch offset
 - Bytecode: 0x41 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is zero
@@ -540,7 +540,7 @@ See `bnz` for details on how branches work. `bz` inverts the behavior of `bnz`.
 
 ## b
 
-- Syntax: `b TARGET` ∋ TARGET: branch offset
+- Syntax: `b TARGET` where TARGET: branch offset
 - Bytecode: 0x42 {int16 (big-endian)}
 - Stack: ... &rarr; ...
 - branch unconditionally to TARGET
@@ -583,7 +583,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## dig
 
-- Syntax: `dig N` ∋ N: depth
+- Syntax: `dig N` where N: depth
 - Bytecode: 0x4b {uint8}
 - Stack: ..., A, [N items] &rarr; ..., A, [N items], A
 - Nth value from the top of the stack. dig 0 is equivalent to dup
@@ -614,7 +614,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## substring
 
-- Syntax: `substring S E` ∋ S: start position, E: end position
+- Syntax: `substring S E` where S: start position, E: end position
 - Bytecode: 0x51 {uint8}, {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - A range of bytes from A starting at S up to but not including E. If E < S, or either is larger than the array length, the program fails
@@ -763,7 +763,7 @@ Deleting a key which is already absent has no effect on the application global s
 
 ## asset_holding_get
 
-- Syntax: `asset_holding_get F` ∋ F: [asset_holding](#field-group-asset_holding)
+- Syntax: `asset_holding_get F` where F: [asset_holding](#field-group-asset_holding)
 - Bytecode: 0x70 {uint8}
 - Stack: ..., A, B: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from account A's holding of asset B. Y is 1 if A is opted into B, else 0
@@ -784,7 +784,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ address), asset id (or
 
 ## asset_params_get
 
-- Syntax: `asset_params_get F` ∋ F: [asset_params](#field-group-asset_params)
+- Syntax: `asset_params_get F` where F: [asset_params](#field-group-asset_params)
 - Bytecode: 0x71 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from asset A. Y is 1 if A exists, else 0
@@ -824,7 +824,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ account address), _ava
 
 ## pushbytes
 
-- Syntax: `pushbytes BYTES` ∋ BYTES: a byte constant
+- Syntax: `pushbytes BYTES` where BYTES: a byte constant
 - Bytecode: 0x80 {varuint length, bytes}
 - Stack: ... &rarr; ..., []byte
 - immediate BYTES
@@ -834,7 +834,7 @@ pushbytes args are not added to the bytecblock during assembly processes
 
 ## pushint
 
-- Syntax: `pushint UINT` ∋ UINT: an int constant
+- Syntax: `pushint UINT` where UINT: an int constant
 - Bytecode: 0x81 {varuint}
 - Stack: ... &rarr; ..., uint64
 - immediate UINT
@@ -844,7 +844,7 @@ pushint args are not added to the intcblock during assembly processes
 
 ## callsub
 
-- Syntax: `callsub TARGET` ∋ TARGET: branch offset
+- Syntax: `callsub TARGET` where TARGET: branch offset
 - Bytecode: 0x88 {int16 (big-endian)}
 - Stack: ... &rarr; ...
 - branch unconditionally to TARGET, saving the next instruction on the call stack

--- a/data/transactions/logic/TEAL_opcodes_v5.md
+++ b/data/transactions/logic/TEAL_opcodes_v5.md
@@ -41,7 +41,7 @@ The 32 byte public key is the last element on the stack, preceded by the 64 byte
 
 ## ecdsa_verify
 
-- Syntax: `ecdsa_verify V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_verify V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x05 {uint8}
 - Stack: ..., A: [32]byte, B: []byte, C: []byte, D: []byte, E: []byte &rarr; ..., bool
 - for (data A, signature B, C and pubkey D, E) verify the signature of the data against the pubkey => {0 or 1}
@@ -61,7 +61,7 @@ The 32 byte Y-component of a public key is the last element on the stack, preced
 
 ## ecdsa_pk_decompress
 
-- Syntax: `ecdsa_pk_decompress V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_pk_decompress V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x06 {uint8}
 - Stack: ..., A: []byte &rarr; ..., X: []byte, Y: []byte
 - decompress pubkey A into components X, Y
@@ -72,7 +72,7 @@ The 33 byte public key in a compressed form to be decompressed into X and Y (top
 
 ## ecdsa_pk_recover
 
-- Syntax: `ecdsa_pk_recover V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_pk_recover V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x07 {uint8}
 - Stack: ..., A: [32]byte, B: uint64, C: [32]byte, D: [32]byte &rarr; ..., X: []byte, Y: []byte
 - for (data A, recovery id B, signature C, D) recover a public key
@@ -240,7 +240,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## intcblock
 
-- Syntax: `intcblock UINT ...` ∋ UINT ...: a block of int constant values
+- Syntax: `intcblock UINT ...` where UINT ...: a block of int constant values
 - Bytecode: 0x20 {varuint count, [varuint ...]}
 - Stack: ... &rarr; ...
 - prepare block of uint64 constants for use by intc
@@ -249,7 +249,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## intc
 
-- Syntax: `intc I` ∋ I: an index in the intcblock
+- Syntax: `intc I` where I: an index in the intcblock
 - Bytecode: 0x21 {uint8}
 - Stack: ... &rarr; ..., uint64
 - Ith constant from intcblock
@@ -280,7 +280,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## bytecblock
 
-- Syntax: `bytecblock BYTES ...` ∋ BYTES ...: a block of byte constant values
+- Syntax: `bytecblock BYTES ...` where BYTES ...: a block of byte constant values
 - Bytecode: 0x26 {varuint count, [varuint length, bytes ...]}
 - Stack: ... &rarr; ...
 - prepare block of byte-array constants for use by bytec
@@ -289,7 +289,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## bytec
 
-- Syntax: `bytec I` ∋ I: an index in the bytecblock
+- Syntax: `bytec I` where I: an index in the bytecblock
 - Bytecode: 0x27 {uint8}
 - Stack: ... &rarr; ..., []byte
 - Ith constant from bytecblock
@@ -320,7 +320,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## arg
 
-- Syntax: `arg N` ∋ N: an arg index
+- Syntax: `arg N` where N: an arg index
 - Bytecode: 0x2c {uint8}
 - Stack: ... &rarr; ..., []byte
 - Nth LogicSig argument
@@ -356,7 +356,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## txn
 
-- Syntax: `txn F` ∋ F: [txn](#field-group-txn)
+- Syntax: `txn F` where F: [txn](#field-group-txn)
 - Bytecode: 0x31 {uint8}
 - Stack: ... &rarr; ..., any
 - field F of current transaction
@@ -427,7 +427,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## global
 
-- Syntax: `global F` ∋ F: [global](#field-group-global)
+- Syntax: `global F` where F: [global](#field-group-global)
 - Bytecode: 0x32 {uint8}
 - Stack: ... &rarr; ..., any
 - global field F
@@ -454,7 +454,7 @@ Fields
 
 ## gtxn
 
-- Syntax: `gtxn T F` ∋ T: transaction group index, F: [txn](#field-group-txn)
+- Syntax: `gtxn T F` where T: transaction group index, F: [txn](#field-group-txn)
 - Bytecode: 0x33 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the Tth transaction in the current group
@@ -463,21 +463,21 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 
 ## load
 
-- Syntax: `load I` ∋ I: position in scratch space to load from
+- Syntax: `load I` where I: position in scratch space to load from
 - Bytecode: 0x34 {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value. All scratch spaces are 0 at program start.
 
 ## store
 
-- Syntax: `store I` ∋ I: position in scratch space to store to
+- Syntax: `store I` where I: position in scratch space to store to
 - Bytecode: 0x35 {uint8}
 - Stack: ..., A &rarr; ...
 - store A to the Ith scratch space
 
 ## txna
 
-- Syntax: `txna F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `txna F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x36 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F of the current transaction<br />`txna` can be called using `txn` with 2 immediates.
@@ -498,7 +498,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxna
 
-- Syntax: `gtxna T F I` ∋ T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxna T F I` where T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x37 {uint8}, {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F from the Tth transaction in the current group<br />`gtxna` can be called using `gtxn` with 3 immediates.
@@ -506,7 +506,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxns
 
-- Syntax: `gtxns F` ∋ F: [txn](#field-group-txn)
+- Syntax: `gtxns F` where F: [txn](#field-group-txn)
 - Bytecode: 0x38 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - field F of the Ath transaction in the current group
@@ -516,7 +516,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gtxnsa
 
-- Syntax: `gtxnsa F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxnsa F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x39 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ith value of the array field F from the Ath transaction in the current group<br />`gtxnsa` can be called using `gtxns` with 2 immediates.
@@ -524,7 +524,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gload
 
-- Syntax: `gload T I` ∋ T: transaction group index, I: position in scratch space to load from
+- Syntax: `gload T I` where T: transaction group index, I: position in scratch space to load from
 - Bytecode: 0x3a {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value of the Tth transaction in the current group
@@ -535,7 +535,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gloads
 
-- Syntax: `gloads I` ∋ I: position in scratch space to load from
+- Syntax: `gloads I` where I: position in scratch space to load from
 - Bytecode: 0x3b {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ith scratch space value of the Ath transaction in the current group
@@ -546,7 +546,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gaid
 
-- Syntax: `gaid T` ∋ T: transaction group index
+- Syntax: `gaid T` where T: transaction group index
 - Bytecode: 0x3c {uint8}
 - Stack: ... &rarr; ..., uint64
 - ID of the asset or application created in the Tth transaction of the current group
@@ -581,7 +581,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## bnz
 
-- Syntax: `bnz TARGET` ∋ TARGET: branch offset
+- Syntax: `bnz TARGET` where TARGET: branch offset
 - Bytecode: 0x40 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is not zero
@@ -592,7 +592,7 @@ At v2 it became allowed to branch to the end of the program exactly after the la
 
 ## bz
 
-- Syntax: `bz TARGET` ∋ TARGET: branch offset
+- Syntax: `bz TARGET` where TARGET: branch offset
 - Bytecode: 0x41 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is zero
@@ -602,7 +602,7 @@ See `bnz` for details on how branches work. `bz` inverts the behavior of `bnz`.
 
 ## b
 
-- Syntax: `b TARGET` ∋ TARGET: branch offset
+- Syntax: `b TARGET` where TARGET: branch offset
 - Bytecode: 0x42 {int16 (big-endian)}
 - Stack: ... &rarr; ...
 - branch unconditionally to TARGET
@@ -645,7 +645,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## dig
 
-- Syntax: `dig N` ∋ N: depth
+- Syntax: `dig N` where N: depth
 - Bytecode: 0x4b {uint8}
 - Stack: ..., A, [N items] &rarr; ..., A, [N items], A
 - Nth value from the top of the stack. dig 0 is equivalent to dup
@@ -667,7 +667,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## cover
 
-- Syntax: `cover N` ∋ N: depth
+- Syntax: `cover N` where N: depth
 - Bytecode: 0x4e {uint8}
 - Stack: ..., [N items], A &rarr; ..., A, [N items]
 - remove top of stack, and place it deeper in the stack such that N elements are above it. Fails if stack depth <= N.
@@ -675,7 +675,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## uncover
 
-- Syntax: `uncover N` ∋ N: depth
+- Syntax: `uncover N` where N: depth
 - Bytecode: 0x4f {uint8}
 - Stack: ..., A, [N items] &rarr; ..., [N items], A
 - remove the value at depth N in the stack and shift above items down so the Nth deep value is on top of the stack. Fails if stack depth <= N.
@@ -692,7 +692,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## substring
 
-- Syntax: `substring S E` ∋ S: start position, E: end position
+- Syntax: `substring S E` where S: start position, E: end position
 - Bytecode: 0x51 {uint8}, {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - A range of bytes from A starting at S up to but not including E. If E < S, or either is larger than the array length, the program fails
@@ -739,7 +739,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 
 ## extract
 
-- Syntax: `extract S L` ∋ S: start position, L: length
+- Syntax: `extract S L` where S: start position, L: length
 - Bytecode: 0x57 {uint8}, {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - A range of bytes from A starting at S up to but not including S+L. If L is 0, then extract to the end of the string. If S or S+L is larger than the array length, the program fails
@@ -877,7 +877,7 @@ Deleting a key which is already absent has no effect on the application global s
 
 ## asset_holding_get
 
-- Syntax: `asset_holding_get F` ∋ F: [asset_holding](#field-group-asset_holding)
+- Syntax: `asset_holding_get F` where F: [asset_holding](#field-group-asset_holding)
 - Bytecode: 0x70 {uint8}
 - Stack: ..., A, B: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from account A's holding of asset B. Y is 1 if A is opted into B, else 0
@@ -898,7 +898,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ address), asset id (or
 
 ## asset_params_get
 
-- Syntax: `asset_params_get F` ∋ F: [asset_params](#field-group-asset_params)
+- Syntax: `asset_params_get F` where F: [asset_params](#field-group-asset_params)
 - Bytecode: 0x71 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from asset A. Y is 1 if A exists, else 0
@@ -929,7 +929,7 @@ params: Txn.ForeignAssets offset (or, since v4, an _available_ asset id. Return:
 
 ## app_params_get
 
-- Syntax: `app_params_get F` ∋ F: [app_params](#field-group-app_params)
+- Syntax: `app_params_get F` where F: [app_params](#field-group-app_params)
 - Bytecode: 0x72 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from app A. Y is 1 if A exists, else 0
@@ -967,7 +967,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ account address), _ava
 
 ## pushbytes
 
-- Syntax: `pushbytes BYTES` ∋ BYTES: a byte constant
+- Syntax: `pushbytes BYTES` where BYTES: a byte constant
 - Bytecode: 0x80 {varuint length, bytes}
 - Stack: ... &rarr; ..., []byte
 - immediate BYTES
@@ -977,7 +977,7 @@ pushbytes args are not added to the bytecblock during assembly processes
 
 ## pushint
 
-- Syntax: `pushint UINT` ∋ UINT: an int constant
+- Syntax: `pushint UINT` where UINT: an int constant
 - Bytecode: 0x81 {varuint}
 - Stack: ... &rarr; ..., uint64
 - immediate UINT
@@ -987,7 +987,7 @@ pushint args are not added to the intcblock during assembly processes
 
 ## callsub
 
-- Syntax: `callsub TARGET` ∋ TARGET: branch offset
+- Syntax: `callsub TARGET` where TARGET: branch offset
 - Bytecode: 0x88 {int16 (big-endian)}
 - Stack: ... &rarr; ...
 - branch unconditionally to TARGET, saving the next instruction on the call stack
@@ -1193,7 +1193,7 @@ bitlen interprets arrays as big-endian integers, unlike setbit/getbit
 
 ## itxn_field
 
-- Syntax: `itxn_field F` ∋ F: [txn](#field-group-txn)
+- Syntax: `itxn_field F` where F: [txn](#field-group-txn)
 - Bytecode: 0xb2 {uint8}
 - Stack: ..., A &rarr; ...
 - set field F of the current inner transaction to A
@@ -1214,7 +1214,7 @@ bitlen interprets arrays as big-endian integers, unlike setbit/getbit
 
 ## itxn
 
-- Syntax: `itxn F` ∋ F: [txn](#field-group-txn)
+- Syntax: `itxn F` where F: [txn](#field-group-txn)
 - Bytecode: 0xb4 {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the last inner transaction
@@ -1223,7 +1223,7 @@ bitlen interprets arrays as big-endian integers, unlike setbit/getbit
 
 ## itxna
 
-- Syntax: `itxna F I` ∋ F: [txna](#field-group-txna), I: a transaction field array index
+- Syntax: `itxna F I` where F: [txna](#field-group-txna), I: a transaction field array index
 - Bytecode: 0xb5 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F of the last inner transaction
@@ -1232,7 +1232,7 @@ bitlen interprets arrays as big-endian integers, unlike setbit/getbit
 
 ## txnas
 
-- Syntax: `txnas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `txnas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc0 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F of the current transaction
@@ -1240,7 +1240,7 @@ bitlen interprets arrays as big-endian integers, unlike setbit/getbit
 
 ## gtxnas
 
-- Syntax: `gtxnas T F` ∋ T: transaction group index, F: [txna](#field-group-txna)
+- Syntax: `gtxnas T F` where T: transaction group index, F: [txna](#field-group-txna)
 - Bytecode: 0xc1 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F from the Tth transaction in the current group
@@ -1248,7 +1248,7 @@ bitlen interprets arrays as big-endian integers, unlike setbit/getbit
 
 ## gtxnsas
 
-- Syntax: `gtxnsas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `gtxnsas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc2 {uint8}
 - Stack: ..., A: uint64, B: uint64 &rarr; ..., any
 - Bth value of the array field F from the Ath transaction in the current group

--- a/data/transactions/logic/TEAL_opcodes_v6.md
+++ b/data/transactions/logic/TEAL_opcodes_v6.md
@@ -41,7 +41,7 @@ The 32 byte public key is the last element on the stack, preceded by the 64 byte
 
 ## ecdsa_verify
 
-- Syntax: `ecdsa_verify V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_verify V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x05 {uint8}
 - Stack: ..., A: [32]byte, B: []byte, C: []byte, D: []byte, E: []byte &rarr; ..., bool
 - for (data A, signature B, C and pubkey D, E) verify the signature of the data against the pubkey => {0 or 1}
@@ -61,7 +61,7 @@ The 32 byte Y-component of a public key is the last element on the stack, preced
 
 ## ecdsa_pk_decompress
 
-- Syntax: `ecdsa_pk_decompress V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_pk_decompress V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x06 {uint8}
 - Stack: ..., A: []byte &rarr; ..., X: []byte, Y: []byte
 - decompress pubkey A into components X, Y
@@ -72,7 +72,7 @@ The 33 byte public key in a compressed form to be decompressed into X and Y (top
 
 ## ecdsa_pk_recover
 
-- Syntax: `ecdsa_pk_recover V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_pk_recover V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x07 {uint8}
 - Stack: ..., A: [32]byte, B: uint64, C: [32]byte, D: [32]byte &rarr; ..., X: []byte, Y: []byte
 - for (data A, recovery id B, signature C, D) recover a public key
@@ -240,7 +240,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## intcblock
 
-- Syntax: `intcblock UINT ...` ∋ UINT ...: a block of int constant values
+- Syntax: `intcblock UINT ...` where UINT ...: a block of int constant values
 - Bytecode: 0x20 {varuint count, [varuint ...]}
 - Stack: ... &rarr; ...
 - prepare block of uint64 constants for use by intc
@@ -249,7 +249,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## intc
 
-- Syntax: `intc I` ∋ I: an index in the intcblock
+- Syntax: `intc I` where I: an index in the intcblock
 - Bytecode: 0x21 {uint8}
 - Stack: ... &rarr; ..., uint64
 - Ith constant from intcblock
@@ -280,7 +280,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## bytecblock
 
-- Syntax: `bytecblock BYTES ...` ∋ BYTES ...: a block of byte constant values
+- Syntax: `bytecblock BYTES ...` where BYTES ...: a block of byte constant values
 - Bytecode: 0x26 {varuint count, [varuint length, bytes ...]}
 - Stack: ... &rarr; ...
 - prepare block of byte-array constants for use by bytec
@@ -289,7 +289,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## bytec
 
-- Syntax: `bytec I` ∋ I: an index in the bytecblock
+- Syntax: `bytec I` where I: an index in the bytecblock
 - Bytecode: 0x27 {uint8}
 - Stack: ... &rarr; ..., []byte
 - Ith constant from bytecblock
@@ -320,7 +320,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## arg
 
-- Syntax: `arg N` ∋ N: an arg index
+- Syntax: `arg N` where N: an arg index
 - Bytecode: 0x2c {uint8}
 - Stack: ... &rarr; ..., []byte
 - Nth LogicSig argument
@@ -356,7 +356,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## txn
 
-- Syntax: `txn F` ∋ F: [txn](#field-group-txn)
+- Syntax: `txn F` where F: [txn](#field-group-txn)
 - Bytecode: 0x31 {uint8}
 - Stack: ... &rarr; ..., any
 - field F of current transaction
@@ -429,7 +429,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## global
 
-- Syntax: `global F` ∋ F: [global](#field-group-global)
+- Syntax: `global F` where F: [global](#field-group-global)
 - Bytecode: 0x32 {uint8}
 - Stack: ... &rarr; ..., any
 - global field F
@@ -459,7 +459,7 @@ Fields
 
 ## gtxn
 
-- Syntax: `gtxn T F` ∋ T: transaction group index, F: [txn](#field-group-txn)
+- Syntax: `gtxn T F` where T: transaction group index, F: [txn](#field-group-txn)
 - Bytecode: 0x33 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the Tth transaction in the current group
@@ -468,21 +468,21 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 
 ## load
 
-- Syntax: `load I` ∋ I: position in scratch space to load from
+- Syntax: `load I` where I: position in scratch space to load from
 - Bytecode: 0x34 {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value. All scratch spaces are 0 at program start.
 
 ## store
 
-- Syntax: `store I` ∋ I: position in scratch space to store to
+- Syntax: `store I` where I: position in scratch space to store to
 - Bytecode: 0x35 {uint8}
 - Stack: ..., A &rarr; ...
 - store A to the Ith scratch space
 
 ## txna
 
-- Syntax: `txna F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `txna F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x36 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F of the current transaction<br />`txna` can be called using `txn` with 2 immediates.
@@ -503,7 +503,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxna
 
-- Syntax: `gtxna T F I` ∋ T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxna T F I` where T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x37 {uint8}, {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F from the Tth transaction in the current group<br />`gtxna` can be called using `gtxn` with 3 immediates.
@@ -511,7 +511,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxns
 
-- Syntax: `gtxns F` ∋ F: [txn](#field-group-txn)
+- Syntax: `gtxns F` where F: [txn](#field-group-txn)
 - Bytecode: 0x38 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - field F of the Ath transaction in the current group
@@ -521,7 +521,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gtxnsa
 
-- Syntax: `gtxnsa F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxnsa F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x39 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ith value of the array field F from the Ath transaction in the current group<br />`gtxnsa` can be called using `gtxns` with 2 immediates.
@@ -529,7 +529,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gload
 
-- Syntax: `gload T I` ∋ T: transaction group index, I: position in scratch space to load from
+- Syntax: `gload T I` where T: transaction group index, I: position in scratch space to load from
 - Bytecode: 0x3a {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value of the Tth transaction in the current group
@@ -540,7 +540,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gloads
 
-- Syntax: `gloads I` ∋ I: position in scratch space to load from
+- Syntax: `gloads I` where I: position in scratch space to load from
 - Bytecode: 0x3b {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ith scratch space value of the Ath transaction in the current group
@@ -551,7 +551,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gaid
 
-- Syntax: `gaid T` ∋ T: transaction group index
+- Syntax: `gaid T` where T: transaction group index
 - Bytecode: 0x3c {uint8}
 - Stack: ... &rarr; ..., uint64
 - ID of the asset or application created in the Tth transaction of the current group
@@ -586,7 +586,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## bnz
 
-- Syntax: `bnz TARGET` ∋ TARGET: branch offset
+- Syntax: `bnz TARGET` where TARGET: branch offset
 - Bytecode: 0x40 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is not zero
@@ -597,7 +597,7 @@ At v2 it became allowed to branch to the end of the program exactly after the la
 
 ## bz
 
-- Syntax: `bz TARGET` ∋ TARGET: branch offset
+- Syntax: `bz TARGET` where TARGET: branch offset
 - Bytecode: 0x41 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is zero
@@ -607,7 +607,7 @@ See `bnz` for details on how branches work. `bz` inverts the behavior of `bnz`.
 
 ## b
 
-- Syntax: `b TARGET` ∋ TARGET: branch offset
+- Syntax: `b TARGET` where TARGET: branch offset
 - Bytecode: 0x42 {int16 (big-endian)}
 - Stack: ... &rarr; ...
 - branch unconditionally to TARGET
@@ -650,7 +650,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## dig
 
-- Syntax: `dig N` ∋ N: depth
+- Syntax: `dig N` where N: depth
 - Bytecode: 0x4b {uint8}
 - Stack: ..., A, [N items] &rarr; ..., A, [N items], A
 - Nth value from the top of the stack. dig 0 is equivalent to dup
@@ -672,7 +672,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## cover
 
-- Syntax: `cover N` ∋ N: depth
+- Syntax: `cover N` where N: depth
 - Bytecode: 0x4e {uint8}
 - Stack: ..., [N items], A &rarr; ..., A, [N items]
 - remove top of stack, and place it deeper in the stack such that N elements are above it. Fails if stack depth <= N.
@@ -680,7 +680,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## uncover
 
-- Syntax: `uncover N` ∋ N: depth
+- Syntax: `uncover N` where N: depth
 - Bytecode: 0x4f {uint8}
 - Stack: ..., A, [N items] &rarr; ..., [N items], A
 - remove the value at depth N in the stack and shift above items down so the Nth deep value is on top of the stack. Fails if stack depth <= N.
@@ -697,7 +697,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## substring
 
-- Syntax: `substring S E` ∋ S: start position, E: end position
+- Syntax: `substring S E` where S: start position, E: end position
 - Bytecode: 0x51 {uint8}, {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - A range of bytes from A starting at S up to but not including E. If E < S, or either is larger than the array length, the program fails
@@ -744,7 +744,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 
 ## extract
 
-- Syntax: `extract S L` ∋ S: start position, L: length
+- Syntax: `extract S L` where S: start position, L: length
 - Bytecode: 0x57 {uint8}, {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - A range of bytes from A starting at S up to but not including S+L. If L is 0, then extract to the end of the string. If S or S+L is larger than the array length, the program fails
@@ -882,7 +882,7 @@ Deleting a key which is already absent has no effect on the application global s
 
 ## asset_holding_get
 
-- Syntax: `asset_holding_get F` ∋ F: [asset_holding](#field-group-asset_holding)
+- Syntax: `asset_holding_get F` where F: [asset_holding](#field-group-asset_holding)
 - Bytecode: 0x70 {uint8}
 - Stack: ..., A, B: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from account A's holding of asset B. Y is 1 if A is opted into B, else 0
@@ -903,7 +903,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ address), asset id (or
 
 ## asset_params_get
 
-- Syntax: `asset_params_get F` ∋ F: [asset_params](#field-group-asset_params)
+- Syntax: `asset_params_get F` where F: [asset_params](#field-group-asset_params)
 - Bytecode: 0x71 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from asset A. Y is 1 if A exists, else 0
@@ -934,7 +934,7 @@ params: Txn.ForeignAssets offset (or, since v4, an _available_ asset id. Return:
 
 ## app_params_get
 
-- Syntax: `app_params_get F` ∋ F: [app_params](#field-group-app_params)
+- Syntax: `app_params_get F` where F: [app_params](#field-group-app_params)
 - Bytecode: 0x72 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from app A. Y is 1 if A exists, else 0
@@ -962,7 +962,7 @@ params: Txn.ForeignApps offset or an _available_ app id. Return: did_exist flag 
 
 ## acct_params_get
 
-- Syntax: `acct_params_get F` ∋ F: [acct_params](#field-group-acct_params)
+- Syntax: `acct_params_get F` where F: [acct_params](#field-group-acct_params)
 - Bytecode: 0x73 {uint8}
 - Stack: ..., A &rarr; ..., X: any, Y: bool
 - X is field F from account A. Y is 1 if A owns positive algos, else 0
@@ -992,7 +992,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ account address), _ava
 
 ## pushbytes
 
-- Syntax: `pushbytes BYTES` ∋ BYTES: a byte constant
+- Syntax: `pushbytes BYTES` where BYTES: a byte constant
 - Bytecode: 0x80 {varuint length, bytes}
 - Stack: ... &rarr; ..., []byte
 - immediate BYTES
@@ -1002,7 +1002,7 @@ pushbytes args are not added to the bytecblock during assembly processes
 
 ## pushint
 
-- Syntax: `pushint UINT` ∋ UINT: an int constant
+- Syntax: `pushint UINT` where UINT: an int constant
 - Bytecode: 0x81 {varuint}
 - Stack: ... &rarr; ..., uint64
 - immediate UINT
@@ -1012,7 +1012,7 @@ pushint args are not added to the intcblock during assembly processes
 
 ## callsub
 
-- Syntax: `callsub TARGET` ∋ TARGET: branch offset
+- Syntax: `callsub TARGET` where TARGET: branch offset
 - Bytecode: 0x88 {int16 (big-endian)}
 - Stack: ... &rarr; ...
 - branch unconditionally to TARGET, saving the next instruction on the call stack
@@ -1235,7 +1235,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxn_field
 
-- Syntax: `itxn_field F` ∋ F: [txn](#field-group-txn)
+- Syntax: `itxn_field F` where F: [txn](#field-group-txn)
 - Bytecode: 0xb2 {uint8}
 - Stack: ..., A &rarr; ...
 - set field F of the current inner transaction to A
@@ -1256,7 +1256,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxn
 
-- Syntax: `itxn F` ∋ F: [txn](#field-group-txn)
+- Syntax: `itxn F` where F: [txn](#field-group-txn)
 - Bytecode: 0xb4 {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the last inner transaction
@@ -1265,7 +1265,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxna
 
-- Syntax: `itxna F I` ∋ F: [txna](#field-group-txna), I: a transaction field array index
+- Syntax: `itxna F I` where F: [txna](#field-group-txna), I: a transaction field array index
 - Bytecode: 0xb5 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F of the last inner transaction
@@ -1284,7 +1284,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## gitxn
 
-- Syntax: `gitxn T F` ∋ T: transaction group index, F: [txn](#field-group-txn)
+- Syntax: `gitxn T F` where T: transaction group index, F: [txn](#field-group-txn)
 - Bytecode: 0xb7 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the Tth transaction in the last inner group submitted
@@ -1293,7 +1293,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## gitxna
 
-- Syntax: `gitxna T F I` ∋ T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gitxna T F I` where T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0xb8 {uint8}, {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F from the Tth transaction in the last inner group submitted
@@ -1302,7 +1302,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## txnas
 
-- Syntax: `txnas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `txnas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc0 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F of the current transaction
@@ -1310,7 +1310,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## gtxnas
 
-- Syntax: `gtxnas T F` ∋ T: transaction group index, F: [txna](#field-group-txna)
+- Syntax: `gtxnas T F` where T: transaction group index, F: [txna](#field-group-txna)
 - Bytecode: 0xc1 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F from the Tth transaction in the current group
@@ -1318,7 +1318,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## gtxnsas
 
-- Syntax: `gtxnsas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `gtxnsas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc2 {uint8}
 - Stack: ..., A: uint64, B: uint64 &rarr; ..., any
 - Bth value of the array field F from the Ath transaction in the current group
@@ -1342,7 +1342,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxnas
 
-- Syntax: `itxnas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `itxnas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc5 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F of the last inner transaction
@@ -1351,7 +1351,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## gitxnas
 
-- Syntax: `gitxnas T F` ∋ T: transaction group index, F: [txna](#field-group-txna)
+- Syntax: `gitxnas T F` where T: transaction group index, F: [txna](#field-group-txna)
 - Bytecode: 0xc6 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F from the Tth transaction in the last inner group submitted

--- a/data/transactions/logic/TEAL_opcodes_v7.md
+++ b/data/transactions/logic/TEAL_opcodes_v7.md
@@ -41,7 +41,7 @@ The 32 byte public key is the last element on the stack, preceded by the 64 byte
 
 ## ecdsa_verify
 
-- Syntax: `ecdsa_verify V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_verify V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x05 {uint8}
 - Stack: ..., A: [32]byte, B: []byte, C: []byte, D: []byte, E: []byte &rarr; ..., bool
 - for (data A, signature B, C and pubkey D, E) verify the signature of the data against the pubkey => {0 or 1}
@@ -62,7 +62,7 @@ The 32 byte Y-component of a public key is the last element on the stack, preced
 
 ## ecdsa_pk_decompress
 
-- Syntax: `ecdsa_pk_decompress V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_pk_decompress V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x06 {uint8}
 - Stack: ..., A: []byte &rarr; ..., X: []byte, Y: []byte
 - decompress pubkey A into components X, Y
@@ -73,7 +73,7 @@ The 33 byte public key in a compressed form to be decompressed into X and Y (top
 
 ## ecdsa_pk_recover
 
-- Syntax: `ecdsa_pk_recover V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_pk_recover V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x07 {uint8}
 - Stack: ..., A: [32]byte, B: uint64, C: [32]byte, D: [32]byte &rarr; ..., X: []byte, Y: []byte
 - for (data A, recovery id B, signature C, D) recover a public key
@@ -241,7 +241,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## intcblock
 
-- Syntax: `intcblock UINT ...` ∋ UINT ...: a block of int constant values
+- Syntax: `intcblock UINT ...` where UINT ...: a block of int constant values
 - Bytecode: 0x20 {varuint count, [varuint ...]}
 - Stack: ... &rarr; ...
 - prepare block of uint64 constants for use by intc
@@ -250,7 +250,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## intc
 
-- Syntax: `intc I` ∋ I: an index in the intcblock
+- Syntax: `intc I` where I: an index in the intcblock
 - Bytecode: 0x21 {uint8}
 - Stack: ... &rarr; ..., uint64
 - Ith constant from intcblock
@@ -281,7 +281,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## bytecblock
 
-- Syntax: `bytecblock BYTES ...` ∋ BYTES ...: a block of byte constant values
+- Syntax: `bytecblock BYTES ...` where BYTES ...: a block of byte constant values
 - Bytecode: 0x26 {varuint count, [varuint length, bytes ...]}
 - Stack: ... &rarr; ...
 - prepare block of byte-array constants for use by bytec
@@ -290,7 +290,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## bytec
 
-- Syntax: `bytec I` ∋ I: an index in the bytecblock
+- Syntax: `bytec I` where I: an index in the bytecblock
 - Bytecode: 0x27 {uint8}
 - Stack: ... &rarr; ..., []byte
 - Ith constant from bytecblock
@@ -321,7 +321,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## arg
 
-- Syntax: `arg N` ∋ N: an arg index
+- Syntax: `arg N` where N: an arg index
 - Bytecode: 0x2c {uint8}
 - Stack: ... &rarr; ..., []byte
 - Nth LogicSig argument
@@ -357,7 +357,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## txn
 
-- Syntax: `txn F` ∋ F: [txn](#field-group-txn)
+- Syntax: `txn F` where F: [txn](#field-group-txn)
 - Bytecode: 0x31 {uint8}
 - Stack: ... &rarr; ..., any
 - field F of current transaction
@@ -433,7 +433,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## global
 
-- Syntax: `global F` ∋ F: [global](#field-group-global)
+- Syntax: `global F` where F: [global](#field-group-global)
 - Bytecode: 0x32 {uint8}
 - Stack: ... &rarr; ..., any
 - global field F
@@ -463,7 +463,7 @@ Fields
 
 ## gtxn
 
-- Syntax: `gtxn T F` ∋ T: transaction group index, F: [txn](#field-group-txn)
+- Syntax: `gtxn T F` where T: transaction group index, F: [txn](#field-group-txn)
 - Bytecode: 0x33 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the Tth transaction in the current group
@@ -472,21 +472,21 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 
 ## load
 
-- Syntax: `load I` ∋ I: position in scratch space to load from
+- Syntax: `load I` where I: position in scratch space to load from
 - Bytecode: 0x34 {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value. All scratch spaces are 0 at program start.
 
 ## store
 
-- Syntax: `store I` ∋ I: position in scratch space to store to
+- Syntax: `store I` where I: position in scratch space to store to
 - Bytecode: 0x35 {uint8}
 - Stack: ..., A &rarr; ...
 - store A to the Ith scratch space
 
 ## txna
 
-- Syntax: `txna F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `txna F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x36 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F of the current transaction<br />`txna` can be called using `txn` with 2 immediates.
@@ -509,7 +509,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxna
 
-- Syntax: `gtxna T F I` ∋ T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxna T F I` where T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x37 {uint8}, {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F from the Tth transaction in the current group<br />`gtxna` can be called using `gtxn` with 3 immediates.
@@ -517,7 +517,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxns
 
-- Syntax: `gtxns F` ∋ F: [txn](#field-group-txn)
+- Syntax: `gtxns F` where F: [txn](#field-group-txn)
 - Bytecode: 0x38 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - field F of the Ath transaction in the current group
@@ -527,7 +527,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gtxnsa
 
-- Syntax: `gtxnsa F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxnsa F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x39 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ith value of the array field F from the Ath transaction in the current group<br />`gtxnsa` can be called using `gtxns` with 2 immediates.
@@ -535,7 +535,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gload
 
-- Syntax: `gload T I` ∋ T: transaction group index, I: position in scratch space to load from
+- Syntax: `gload T I` where T: transaction group index, I: position in scratch space to load from
 - Bytecode: 0x3a {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value of the Tth transaction in the current group
@@ -546,7 +546,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gloads
 
-- Syntax: `gloads I` ∋ I: position in scratch space to load from
+- Syntax: `gloads I` where I: position in scratch space to load from
 - Bytecode: 0x3b {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ith scratch space value of the Ath transaction in the current group
@@ -557,7 +557,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gaid
 
-- Syntax: `gaid T` ∋ T: transaction group index
+- Syntax: `gaid T` where T: transaction group index
 - Bytecode: 0x3c {uint8}
 - Stack: ... &rarr; ..., uint64
 - ID of the asset or application created in the Tth transaction of the current group
@@ -592,7 +592,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## bnz
 
-- Syntax: `bnz TARGET` ∋ TARGET: branch offset
+- Syntax: `bnz TARGET` where TARGET: branch offset
 - Bytecode: 0x40 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is not zero
@@ -603,7 +603,7 @@ At v2 it became allowed to branch to the end of the program exactly after the la
 
 ## bz
 
-- Syntax: `bz TARGET` ∋ TARGET: branch offset
+- Syntax: `bz TARGET` where TARGET: branch offset
 - Bytecode: 0x41 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is zero
@@ -613,7 +613,7 @@ See `bnz` for details on how branches work. `bz` inverts the behavior of `bnz`.
 
 ## b
 
-- Syntax: `b TARGET` ∋ TARGET: branch offset
+- Syntax: `b TARGET` where TARGET: branch offset
 - Bytecode: 0x42 {int16 (big-endian)}
 - Stack: ... &rarr; ...
 - branch unconditionally to TARGET
@@ -656,7 +656,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## dig
 
-- Syntax: `dig N` ∋ N: depth
+- Syntax: `dig N` where N: depth
 - Bytecode: 0x4b {uint8}
 - Stack: ..., A, [N items] &rarr; ..., A, [N items], A
 - Nth value from the top of the stack. dig 0 is equivalent to dup
@@ -678,7 +678,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## cover
 
-- Syntax: `cover N` ∋ N: depth
+- Syntax: `cover N` where N: depth
 - Bytecode: 0x4e {uint8}
 - Stack: ..., [N items], A &rarr; ..., A, [N items]
 - remove top of stack, and place it deeper in the stack such that N elements are above it. Fails if stack depth <= N.
@@ -686,7 +686,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## uncover
 
-- Syntax: `uncover N` ∋ N: depth
+- Syntax: `uncover N` where N: depth
 - Bytecode: 0x4f {uint8}
 - Stack: ..., A, [N items] &rarr; ..., [N items], A
 - remove the value at depth N in the stack and shift above items down so the Nth deep value is on top of the stack. Fails if stack depth <= N.
@@ -703,7 +703,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## substring
 
-- Syntax: `substring S E` ∋ S: start position, E: end position
+- Syntax: `substring S E` where S: start position, E: end position
 - Bytecode: 0x51 {uint8}, {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - A range of bytes from A starting at S up to but not including E. If E < S, or either is larger than the array length, the program fails
@@ -750,7 +750,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 
 ## extract
 
-- Syntax: `extract S L` ∋ S: start position, L: length
+- Syntax: `extract S L` where S: start position, L: length
 - Bytecode: 0x57 {uint8}, {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - A range of bytes from A starting at S up to but not including S+L. If L is 0, then extract to the end of the string. If S or S+L is larger than the array length, the program fails
@@ -786,7 +786,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 
 ## replace2
 
-- Syntax: `replace2 S` ∋ S: start position
+- Syntax: `replace2 S` where S: start position
 - Bytecode: 0x5c {uint8}
 - Stack: ..., A: []byte, B: []byte &rarr; ..., []byte
 - Copy of A with the bytes starting at S replaced by the bytes of B. Fails if S+len(B) exceeds len(A)<br />`replace2` can be called using `replace` with 1 immediate.
@@ -801,7 +801,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 
 ## base64_decode
 
-- Syntax: `base64_decode E` ∋ E: [base64](#field-group-base64)
+- Syntax: `base64_decode E` where E: [base64](#field-group-base64)
 - Bytecode: 0x5e {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - decode A which was base64-encoded using _encoding_ E. Fail if A is not base64 encoded with encoding E
@@ -824,7 +824,7 @@ Encodings
 
 ## json_ref
 
-- Syntax: `json_ref R` ∋ R: [json_ref](#field-group-json_ref)
+- Syntax: `json_ref R` where R: [json_ref](#field-group-json_ref)
 - Bytecode: 0x5f {uint8}
 - Stack: ..., A: []byte, B: []byte &rarr; ..., any
 - key B's value, of type R, from a [valid](jsonspec.md) utf-8 encoded json object A
@@ -950,7 +950,7 @@ Deleting a key which is already absent has no effect on the application global s
 
 ## asset_holding_get
 
-- Syntax: `asset_holding_get F` ∋ F: [asset_holding](#field-group-asset_holding)
+- Syntax: `asset_holding_get F` where F: [asset_holding](#field-group-asset_holding)
 - Bytecode: 0x70 {uint8}
 - Stack: ..., A, B: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from account A's holding of asset B. Y is 1 if A is opted into B, else 0
@@ -971,7 +971,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ address), asset id (or
 
 ## asset_params_get
 
-- Syntax: `asset_params_get F` ∋ F: [asset_params](#field-group-asset_params)
+- Syntax: `asset_params_get F` where F: [asset_params](#field-group-asset_params)
 - Bytecode: 0x71 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from asset A. Y is 1 if A exists, else 0
@@ -1002,7 +1002,7 @@ params: Txn.ForeignAssets offset (or, since v4, an _available_ asset id. Return:
 
 ## app_params_get
 
-- Syntax: `app_params_get F` ∋ F: [app_params](#field-group-app_params)
+- Syntax: `app_params_get F` where F: [app_params](#field-group-app_params)
 - Bytecode: 0x72 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from app A. Y is 1 if A exists, else 0
@@ -1030,7 +1030,7 @@ params: Txn.ForeignApps offset or an _available_ app id. Return: did_exist flag 
 
 ## acct_params_get
 
-- Syntax: `acct_params_get F` ∋ F: [acct_params](#field-group-acct_params)
+- Syntax: `acct_params_get F` where F: [acct_params](#field-group-acct_params)
 - Bytecode: 0x73 {uint8}
 - Stack: ..., A &rarr; ..., X: any, Y: bool
 - X is field F from account A. Y is 1 if A owns positive algos, else 0
@@ -1060,7 +1060,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ account address), _ava
 
 ## pushbytes
 
-- Syntax: `pushbytes BYTES` ∋ BYTES: a byte constant
+- Syntax: `pushbytes BYTES` where BYTES: a byte constant
 - Bytecode: 0x80 {varuint length, bytes}
 - Stack: ... &rarr; ..., []byte
 - immediate BYTES
@@ -1070,7 +1070,7 @@ pushbytes args are not added to the bytecblock during assembly processes
 
 ## pushint
 
-- Syntax: `pushint UINT` ∋ UINT: an int constant
+- Syntax: `pushint UINT` where UINT: an int constant
 - Bytecode: 0x81 {varuint}
 - Stack: ... &rarr; ..., uint64
 - immediate UINT
@@ -1088,7 +1088,7 @@ pushint args are not added to the intcblock during assembly processes
 
 ## callsub
 
-- Syntax: `callsub TARGET` ∋ TARGET: branch offset
+- Syntax: `callsub TARGET` where TARGET: branch offset
 - Bytecode: 0x88 {int16 (big-endian)}
 - Stack: ... &rarr; ...
 - branch unconditionally to TARGET, saving the next instruction on the call stack
@@ -1319,7 +1319,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxn_field
 
-- Syntax: `itxn_field F` ∋ F: [txn](#field-group-txn)
+- Syntax: `itxn_field F` where F: [txn](#field-group-txn)
 - Bytecode: 0xb2 {uint8}
 - Stack: ..., A &rarr; ...
 - set field F of the current inner transaction to A
@@ -1340,7 +1340,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxn
 
-- Syntax: `itxn F` ∋ F: [txn](#field-group-txn)
+- Syntax: `itxn F` where F: [txn](#field-group-txn)
 - Bytecode: 0xb4 {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the last inner transaction
@@ -1349,7 +1349,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxna
 
-- Syntax: `itxna F I` ∋ F: [txna](#field-group-txna), I: a transaction field array index
+- Syntax: `itxna F I` where F: [txna](#field-group-txna), I: a transaction field array index
 - Bytecode: 0xb5 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F of the last inner transaction
@@ -1368,7 +1368,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## gitxn
 
-- Syntax: `gitxn T F` ∋ T: transaction group index, F: [txn](#field-group-txn)
+- Syntax: `gitxn T F` where T: transaction group index, F: [txn](#field-group-txn)
 - Bytecode: 0xb7 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the Tth transaction in the last inner group submitted
@@ -1377,7 +1377,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## gitxna
 
-- Syntax: `gitxna T F I` ∋ T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gitxna T F I` where T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0xb8 {uint8}, {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F from the Tth transaction in the last inner group submitted
@@ -1386,7 +1386,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## txnas
 
-- Syntax: `txnas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `txnas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc0 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F of the current transaction
@@ -1394,7 +1394,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## gtxnas
 
-- Syntax: `gtxnas T F` ∋ T: transaction group index, F: [txna](#field-group-txna)
+- Syntax: `gtxnas T F` where T: transaction group index, F: [txna](#field-group-txna)
 - Bytecode: 0xc1 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F from the Tth transaction in the current group
@@ -1402,7 +1402,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## gtxnsas
 
-- Syntax: `gtxnsas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `gtxnsas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc2 {uint8}
 - Stack: ..., A: uint64, B: uint64 &rarr; ..., any
 - Bth value of the array field F from the Ath transaction in the current group
@@ -1426,7 +1426,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxnas
 
-- Syntax: `itxnas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `itxnas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc5 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F of the last inner transaction
@@ -1435,7 +1435,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## gitxnas
 
-- Syntax: `gitxnas T F` ∋ T: transaction group index, F: [txna](#field-group-txna)
+- Syntax: `gitxnas T F` where T: transaction group index, F: [txna](#field-group-txna)
 - Bytecode: 0xc6 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F from the Tth transaction in the last inner group submitted
@@ -1444,7 +1444,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## vrf_verify
 
-- Syntax: `vrf_verify S` ∋ S: [vrf_verify](#field-group-vrf_verify)
+- Syntax: `vrf_verify S` where S: [vrf_verify](#field-group-vrf_verify)
 - Bytecode: 0xd0 {uint8}
 - Stack: ..., A: []byte, B: [80]byte, C: [32]byte &rarr; ..., X: []byte, Y: bool
 - Verify the proof B of message A against pubkey C. Returns vrf output and verification flag.
@@ -1464,7 +1464,7 @@ Standards
 
 ## block
 
-- Syntax: `block F` ∋ F: [block](#field-group-block)
+- Syntax: `block F` where F: [block](#field-group-block)
 - Bytecode: 0xd1 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - field F of block A. Fail unless A falls between txn.LastValid-1002 and txn.FirstValid (exclusive)

--- a/data/transactions/logic/TEAL_opcodes_v8.md
+++ b/data/transactions/logic/TEAL_opcodes_v8.md
@@ -41,7 +41,7 @@ The 32 byte public key is the last element on the stack, preceded by the 64 byte
 
 ## ecdsa_verify
 
-- Syntax: `ecdsa_verify V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_verify V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x05 {uint8}
 - Stack: ..., A: [32]byte, B: []byte, C: []byte, D: []byte, E: []byte &rarr; ..., bool
 - for (data A, signature B, C and pubkey D, E) verify the signature of the data against the pubkey => {0 or 1}
@@ -62,7 +62,7 @@ The 32 byte Y-component of a public key is the last element on the stack, preced
 
 ## ecdsa_pk_decompress
 
-- Syntax: `ecdsa_pk_decompress V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_pk_decompress V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x06 {uint8}
 - Stack: ..., A: []byte &rarr; ..., X: []byte, Y: []byte
 - decompress pubkey A into components X, Y
@@ -73,7 +73,7 @@ The 33 byte public key in a compressed form to be decompressed into X and Y (top
 
 ## ecdsa_pk_recover
 
-- Syntax: `ecdsa_pk_recover V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_pk_recover V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x07 {uint8}
 - Stack: ..., A: [32]byte, B: uint64, C: [32]byte, D: [32]byte &rarr; ..., X: []byte, Y: []byte
 - for (data A, recovery id B, signature C, D) recover a public key
@@ -241,7 +241,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## intcblock
 
-- Syntax: `intcblock UINT ...` ∋ UINT ...: a block of int constant values
+- Syntax: `intcblock UINT ...` where UINT ...: a block of int constant values
 - Bytecode: 0x20 {varuint count, [varuint ...]}
 - Stack: ... &rarr; ...
 - prepare block of uint64 constants for use by intc
@@ -250,7 +250,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## intc
 
-- Syntax: `intc I` ∋ I: an index in the intcblock
+- Syntax: `intc I` where I: an index in the intcblock
 - Bytecode: 0x21 {uint8}
 - Stack: ... &rarr; ..., uint64
 - Ith constant from intcblock
@@ -281,7 +281,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## bytecblock
 
-- Syntax: `bytecblock BYTES ...` ∋ BYTES ...: a block of byte constant values
+- Syntax: `bytecblock BYTES ...` where BYTES ...: a block of byte constant values
 - Bytecode: 0x26 {varuint count, [varuint length, bytes ...]}
 - Stack: ... &rarr; ...
 - prepare block of byte-array constants for use by bytec
@@ -290,7 +290,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## bytec
 
-- Syntax: `bytec I` ∋ I: an index in the bytecblock
+- Syntax: `bytec I` where I: an index in the bytecblock
 - Bytecode: 0x27 {uint8}
 - Stack: ... &rarr; ..., []byte
 - Ith constant from bytecblock
@@ -321,7 +321,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## arg
 
-- Syntax: `arg N` ∋ N: an arg index
+- Syntax: `arg N` where N: an arg index
 - Bytecode: 0x2c {uint8}
 - Stack: ... &rarr; ..., []byte
 - Nth LogicSig argument
@@ -357,7 +357,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## txn
 
-- Syntax: `txn F` ∋ F: [txn](#field-group-txn)
+- Syntax: `txn F` where F: [txn](#field-group-txn)
 - Bytecode: 0x31 {uint8}
 - Stack: ... &rarr; ..., any
 - field F of current transaction
@@ -433,7 +433,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## global
 
-- Syntax: `global F` ∋ F: [global](#field-group-global)
+- Syntax: `global F` where F: [global](#field-group-global)
 - Bytecode: 0x32 {uint8}
 - Stack: ... &rarr; ..., any
 - global field F
@@ -463,7 +463,7 @@ Fields
 
 ## gtxn
 
-- Syntax: `gtxn T F` ∋ T: transaction group index, F: [txn](#field-group-txn)
+- Syntax: `gtxn T F` where T: transaction group index, F: [txn](#field-group-txn)
 - Bytecode: 0x33 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the Tth transaction in the current group
@@ -472,21 +472,21 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 
 ## load
 
-- Syntax: `load I` ∋ I: position in scratch space to load from
+- Syntax: `load I` where I: position in scratch space to load from
 - Bytecode: 0x34 {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value. All scratch spaces are 0 at program start.
 
 ## store
 
-- Syntax: `store I` ∋ I: position in scratch space to store to
+- Syntax: `store I` where I: position in scratch space to store to
 - Bytecode: 0x35 {uint8}
 - Stack: ..., A &rarr; ...
 - store A to the Ith scratch space
 
 ## txna
 
-- Syntax: `txna F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `txna F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x36 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F of the current transaction<br />`txna` can be called using `txn` with 2 immediates.
@@ -509,7 +509,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxna
 
-- Syntax: `gtxna T F I` ∋ T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxna T F I` where T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x37 {uint8}, {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F from the Tth transaction in the current group<br />`gtxna` can be called using `gtxn` with 3 immediates.
@@ -517,7 +517,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxns
 
-- Syntax: `gtxns F` ∋ F: [txn](#field-group-txn)
+- Syntax: `gtxns F` where F: [txn](#field-group-txn)
 - Bytecode: 0x38 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - field F of the Ath transaction in the current group
@@ -527,7 +527,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gtxnsa
 
-- Syntax: `gtxnsa F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxnsa F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x39 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ith value of the array field F from the Ath transaction in the current group<br />`gtxnsa` can be called using `gtxns` with 2 immediates.
@@ -535,7 +535,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gload
 
-- Syntax: `gload T I` ∋ T: transaction group index, I: position in scratch space to load from
+- Syntax: `gload T I` where T: transaction group index, I: position in scratch space to load from
 - Bytecode: 0x3a {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value of the Tth transaction in the current group
@@ -546,7 +546,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gloads
 
-- Syntax: `gloads I` ∋ I: position in scratch space to load from
+- Syntax: `gloads I` where I: position in scratch space to load from
 - Bytecode: 0x3b {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ith scratch space value of the Ath transaction in the current group
@@ -557,7 +557,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gaid
 
-- Syntax: `gaid T` ∋ T: transaction group index
+- Syntax: `gaid T` where T: transaction group index
 - Bytecode: 0x3c {uint8}
 - Stack: ... &rarr; ..., uint64
 - ID of the asset or application created in the Tth transaction of the current group
@@ -592,7 +592,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## bnz
 
-- Syntax: `bnz TARGET` ∋ TARGET: branch offset
+- Syntax: `bnz TARGET` where TARGET: branch offset
 - Bytecode: 0x40 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is not zero
@@ -603,7 +603,7 @@ At v2 it became allowed to branch to the end of the program exactly after the la
 
 ## bz
 
-- Syntax: `bz TARGET` ∋ TARGET: branch offset
+- Syntax: `bz TARGET` where TARGET: branch offset
 - Bytecode: 0x41 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is zero
@@ -613,7 +613,7 @@ See `bnz` for details on how branches work. `bz` inverts the behavior of `bnz`.
 
 ## b
 
-- Syntax: `b TARGET` ∋ TARGET: branch offset
+- Syntax: `b TARGET` where TARGET: branch offset
 - Bytecode: 0x42 {int16 (big-endian)}
 - Stack: ... &rarr; ...
 - branch unconditionally to TARGET
@@ -637,7 +637,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## bury
 
-- Syntax: `bury N` ∋ N: depth
+- Syntax: `bury N` where N: depth
 - Bytecode: 0x45 {uint8}
 - Stack: ..., A &rarr; ...
 - replace the Nth value from the top of the stack with A. bury 0 fails.
@@ -645,7 +645,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## popn
 
-- Syntax: `popn N` ∋ N: stack depth
+- Syntax: `popn N` where N: stack depth
 - Bytecode: 0x46 {uint8}
 - Stack: ..., [N items] &rarr; ...
 - remove N values from the top of the stack
@@ -653,7 +653,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## dupn
 
-- Syntax: `dupn N` ∋ N: copy count
+- Syntax: `dupn N` where N: copy count
 - Bytecode: 0x47 {uint8}
 - Stack: ..., A &rarr; ..., A, [N copies of A]
 - duplicate A, N times
@@ -680,7 +680,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## dig
 
-- Syntax: `dig N` ∋ N: depth
+- Syntax: `dig N` where N: depth
 - Bytecode: 0x4b {uint8}
 - Stack: ..., A, [N items] &rarr; ..., A, [N items], A
 - Nth value from the top of the stack. dig 0 is equivalent to dup
@@ -702,7 +702,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## cover
 
-- Syntax: `cover N` ∋ N: depth
+- Syntax: `cover N` where N: depth
 - Bytecode: 0x4e {uint8}
 - Stack: ..., [N items], A &rarr; ..., A, [N items]
 - remove top of stack, and place it deeper in the stack such that N elements are above it. Fails if stack depth <= N.
@@ -710,7 +710,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## uncover
 
-- Syntax: `uncover N` ∋ N: depth
+- Syntax: `uncover N` where N: depth
 - Bytecode: 0x4f {uint8}
 - Stack: ..., A, [N items] &rarr; ..., [N items], A
 - remove the value at depth N in the stack and shift above items down so the Nth deep value is on top of the stack. Fails if stack depth <= N.
@@ -727,7 +727,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## substring
 
-- Syntax: `substring S E` ∋ S: start position, E: end position
+- Syntax: `substring S E` where S: start position, E: end position
 - Bytecode: 0x51 {uint8}, {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - A range of bytes from A starting at S up to but not including E. If E < S, or either is larger than the array length, the program fails
@@ -774,7 +774,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 
 ## extract
 
-- Syntax: `extract S L` ∋ S: start position, L: length
+- Syntax: `extract S L` where S: start position, L: length
 - Bytecode: 0x57 {uint8}, {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - A range of bytes from A starting at S up to but not including S+L. If L is 0, then extract to the end of the string. If S or S+L is larger than the array length, the program fails
@@ -810,7 +810,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 
 ## replace2
 
-- Syntax: `replace2 S` ∋ S: start position
+- Syntax: `replace2 S` where S: start position
 - Bytecode: 0x5c {uint8}
 - Stack: ..., A: []byte, B: []byte &rarr; ..., []byte
 - Copy of A with the bytes starting at S replaced by the bytes of B. Fails if S+len(B) exceeds len(A)<br />`replace2` can be called using `replace` with 1 immediate.
@@ -825,7 +825,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 
 ## base64_decode
 
-- Syntax: `base64_decode E` ∋ E: [base64](#field-group-base64)
+- Syntax: `base64_decode E` where E: [base64](#field-group-base64)
 - Bytecode: 0x5e {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - decode A which was base64-encoded using _encoding_ E. Fail if A is not base64 encoded with encoding E
@@ -848,7 +848,7 @@ Encodings
 
 ## json_ref
 
-- Syntax: `json_ref R` ∋ R: [json_ref](#field-group-json_ref)
+- Syntax: `json_ref R` where R: [json_ref](#field-group-json_ref)
 - Bytecode: 0x5f {uint8}
 - Stack: ..., A: []byte, B: []byte &rarr; ..., any
 - key B's value, of type R, from a [valid](jsonspec.md) utf-8 encoded json object A
@@ -974,7 +974,7 @@ Deleting a key which is already absent has no effect on the application global s
 
 ## asset_holding_get
 
-- Syntax: `asset_holding_get F` ∋ F: [asset_holding](#field-group-asset_holding)
+- Syntax: `asset_holding_get F` where F: [asset_holding](#field-group-asset_holding)
 - Bytecode: 0x70 {uint8}
 - Stack: ..., A, B: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from account A's holding of asset B. Y is 1 if A is opted into B, else 0
@@ -995,7 +995,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ address), asset id (or
 
 ## asset_params_get
 
-- Syntax: `asset_params_get F` ∋ F: [asset_params](#field-group-asset_params)
+- Syntax: `asset_params_get F` where F: [asset_params](#field-group-asset_params)
 - Bytecode: 0x71 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from asset A. Y is 1 if A exists, else 0
@@ -1026,7 +1026,7 @@ params: Txn.ForeignAssets offset (or, since v4, an _available_ asset id. Return:
 
 ## app_params_get
 
-- Syntax: `app_params_get F` ∋ F: [app_params](#field-group-app_params)
+- Syntax: `app_params_get F` where F: [app_params](#field-group-app_params)
 - Bytecode: 0x72 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from app A. Y is 1 if A exists, else 0
@@ -1054,7 +1054,7 @@ params: Txn.ForeignApps offset or an _available_ app id. Return: did_exist flag 
 
 ## acct_params_get
 
-- Syntax: `acct_params_get F` ∋ F: [acct_params](#field-group-acct_params)
+- Syntax: `acct_params_get F` where F: [acct_params](#field-group-acct_params)
 - Bytecode: 0x73 {uint8}
 - Stack: ..., A &rarr; ..., X: any, Y: bool
 - X is field F from account A. Y is 1 if A owns positive algos, else 0
@@ -1093,7 +1093,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ account address), _ava
 
 ## pushbytes
 
-- Syntax: `pushbytes BYTES` ∋ BYTES: a byte constant
+- Syntax: `pushbytes BYTES` where BYTES: a byte constant
 - Bytecode: 0x80 {varuint length, bytes}
 - Stack: ... &rarr; ..., []byte
 - immediate BYTES
@@ -1103,7 +1103,7 @@ pushbytes args are not added to the bytecblock during assembly processes
 
 ## pushint
 
-- Syntax: `pushint UINT` ∋ UINT: an int constant
+- Syntax: `pushint UINT` where UINT: an int constant
 - Bytecode: 0x81 {varuint}
 - Stack: ... &rarr; ..., uint64
 - immediate UINT
@@ -1113,7 +1113,7 @@ pushint args are not added to the intcblock during assembly processes
 
 ## pushbytess
 
-- Syntax: `pushbytess BYTES ...` ∋ BYTES ...: a list of byte constants
+- Syntax: `pushbytess BYTES ...` where BYTES ...: a list of byte constants
 - Bytecode: 0x82 {varuint count, [varuint length, bytes ...]}
 - Stack: ... &rarr; ..., [N items]
 - push sequences of immediate byte arrays to stack (first byte array being deepest)
@@ -1123,7 +1123,7 @@ pushbytess args are not added to the bytecblock during assembly processes
 
 ## pushints
 
-- Syntax: `pushints UINT ...` ∋ UINT ...: a list of int constants
+- Syntax: `pushints UINT ...` where UINT ...: a list of int constants
 - Bytecode: 0x83 {varuint count, [varuint ...]}
 - Stack: ... &rarr; ..., [N items]
 - push sequence of immediate uints to stack in the order they appear (first uint being deepest)
@@ -1141,7 +1141,7 @@ pushints args are not added to the intcblock during assembly processes
 
 ## callsub
 
-- Syntax: `callsub TARGET` ∋ TARGET: branch offset
+- Syntax: `callsub TARGET` where TARGET: branch offset
 - Bytecode: 0x88 {int16 (big-endian)}
 - Stack: ... &rarr; ...
 - branch unconditionally to TARGET, saving the next instruction on the call stack
@@ -1160,7 +1160,7 @@ If the current frame was prepared by `proto A R`, `retsub` will remove the 'A' a
 
 ## proto
 
-- Syntax: `proto A R` ∋ A: number of arguments, R: number of return values
+- Syntax: `proto A R` where A: number of arguments, R: number of return values
 - Bytecode: 0x8a {uint8}, {uint8}
 - Stack: ... &rarr; ...
 - Prepare top call frame for a retsub that will assume A args and R return values.
@@ -1170,7 +1170,7 @@ Fails unless the last instruction executed was a `callsub`.
 
 ## frame_dig
 
-- Syntax: `frame_dig I` ∋ I: frame slot
+- Syntax: `frame_dig I` where I: frame slot
 - Bytecode: 0x8b {int8}
 - Stack: ... &rarr; ..., any
 - Nth (signed) value from the frame pointer.
@@ -1178,7 +1178,7 @@ Fails unless the last instruction executed was a `callsub`.
 
 ## frame_bury
 
-- Syntax: `frame_bury I` ∋ I: frame slot
+- Syntax: `frame_bury I` where I: frame slot
 - Bytecode: 0x8c {int8}
 - Stack: ..., A &rarr; ...
 - replace the Nth (signed) value from the frame pointer in the stack with A
@@ -1186,7 +1186,7 @@ Fails unless the last instruction executed was a `callsub`.
 
 ## switch
 
-- Syntax: `switch TARGET ...` ∋ TARGET ...: list of labels
+- Syntax: `switch TARGET ...` where TARGET ...: list of labels
 - Bytecode: 0x8d {varuint count, [int16 (big-endian) ...]}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to the Ath label. Continue at following instruction if index A exceeds the number of labels.
@@ -1194,7 +1194,7 @@ Fails unless the last instruction executed was a `callsub`.
 
 ## match
 
-- Syntax: `match TARGET ...` ∋ TARGET ...: list of labels
+- Syntax: `match TARGET ...` where TARGET ...: list of labels
 - Bytecode: 0x8e {varuint count, [int16 (big-endian) ...]}
 - Stack: ..., [A1, A2, ..., AN], B &rarr; ...
 - given match cases from A[1] to A[N], branch to the Ith label where A[I] = B. Continue to the following instruction if no matches are found.
@@ -1416,7 +1416,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxn_field
 
-- Syntax: `itxn_field F` ∋ F: [txn](#field-group-txn)
+- Syntax: `itxn_field F` where F: [txn](#field-group-txn)
 - Bytecode: 0xb2 {uint8}
 - Stack: ..., A &rarr; ...
 - set field F of the current inner transaction to A
@@ -1437,7 +1437,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxn
 
-- Syntax: `itxn F` ∋ F: [txn](#field-group-txn)
+- Syntax: `itxn F` where F: [txn](#field-group-txn)
 - Bytecode: 0xb4 {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the last inner transaction
@@ -1446,7 +1446,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxna
 
-- Syntax: `itxna F I` ∋ F: [txna](#field-group-txna), I: a transaction field array index
+- Syntax: `itxna F I` where F: [txna](#field-group-txna), I: a transaction field array index
 - Bytecode: 0xb5 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F of the last inner transaction
@@ -1465,7 +1465,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## gitxn
 
-- Syntax: `gitxn T F` ∋ T: transaction group index, F: [txn](#field-group-txn)
+- Syntax: `gitxn T F` where T: transaction group index, F: [txn](#field-group-txn)
 - Bytecode: 0xb7 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the Tth transaction in the last inner group submitted
@@ -1474,7 +1474,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## gitxna
 
-- Syntax: `gitxna T F I` ∋ T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gitxna T F I` where T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0xb8 {uint8}, {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F from the Tth transaction in the last inner group submitted
@@ -1545,7 +1545,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## txnas
 
-- Syntax: `txnas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `txnas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc0 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F of the current transaction
@@ -1553,7 +1553,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## gtxnas
 
-- Syntax: `gtxnas T F` ∋ T: transaction group index, F: [txna](#field-group-txna)
+- Syntax: `gtxnas T F` where T: transaction group index, F: [txna](#field-group-txna)
 - Bytecode: 0xc1 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F from the Tth transaction in the current group
@@ -1561,7 +1561,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## gtxnsas
 
-- Syntax: `gtxnsas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `gtxnsas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc2 {uint8}
 - Stack: ..., A: uint64, B: uint64 &rarr; ..., any
 - Bth value of the array field F from the Ath transaction in the current group
@@ -1585,7 +1585,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## itxnas
 
-- Syntax: `itxnas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `itxnas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc5 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F of the last inner transaction
@@ -1594,7 +1594,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## gitxnas
 
-- Syntax: `gitxnas T F` ∋ T: transaction group index, F: [txna](#field-group-txna)
+- Syntax: `gitxnas T F` where T: transaction group index, F: [txna](#field-group-txna)
 - Bytecode: 0xc6 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F from the Tth transaction in the last inner group submitted
@@ -1603,7 +1603,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## vrf_verify
 
-- Syntax: `vrf_verify S` ∋ S: [vrf_verify](#field-group-vrf_verify)
+- Syntax: `vrf_verify S` where S: [vrf_verify](#field-group-vrf_verify)
 - Bytecode: 0xd0 {uint8}
 - Stack: ..., A: []byte, B: [80]byte, C: [32]byte &rarr; ..., X: []byte, Y: bool
 - Verify the proof B of message A against pubkey C. Returns vrf output and verification flag.
@@ -1623,7 +1623,7 @@ Standards
 
 ## block
 
-- Syntax: `block F` ∋ F: [block](#field-group-block)
+- Syntax: `block F` where F: [block](#field-group-block)
 - Bytecode: 0xd1 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - field F of block A. Fail unless A falls between txn.LastValid-1002 and txn.FirstValid (exclusive)

--- a/data/transactions/logic/TEAL_opcodes_v9.md
+++ b/data/transactions/logic/TEAL_opcodes_v9.md
@@ -41,7 +41,7 @@ The 32 byte public key is the last element on the stack, preceded by the 64 byte
 
 ## ecdsa_verify
 
-- Syntax: `ecdsa_verify V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_verify V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x05 {uint8}
 - Stack: ..., A: [32]byte, B: []byte, C: []byte, D: []byte, E: []byte &rarr; ..., bool
 - for (data A, signature B, C and pubkey D, E) verify the signature of the data against the pubkey => {0 or 1}
@@ -62,7 +62,7 @@ The 32 byte Y-component of a public key is the last element on the stack, preced
 
 ## ecdsa_pk_decompress
 
-- Syntax: `ecdsa_pk_decompress V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_pk_decompress V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x06 {uint8}
 - Stack: ..., A: []byte &rarr; ..., X: []byte, Y: []byte
 - decompress pubkey A into components X, Y
@@ -73,7 +73,7 @@ The 33 byte public key in a compressed form to be decompressed into X and Y (top
 
 ## ecdsa_pk_recover
 
-- Syntax: `ecdsa_pk_recover V` ∋ V: [ECDSA](#field-group-ecdsa)
+- Syntax: `ecdsa_pk_recover V` where V: [ECDSA](#field-group-ecdsa)
 - Bytecode: 0x07 {uint8}
 - Stack: ..., A: [32]byte, B: uint64, C: [32]byte, D: [32]byte &rarr; ..., X: []byte, Y: []byte
 - for (data A, recovery id B, signature C, D) recover a public key
@@ -241,7 +241,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## intcblock
 
-- Syntax: `intcblock UINT ...` ∋ UINT ...: a block of int constant values
+- Syntax: `intcblock UINT ...` where UINT ...: a block of int constant values
 - Bytecode: 0x20 {varuint count, [varuint ...]}
 - Stack: ... &rarr; ...
 - prepare block of uint64 constants for use by intc
@@ -250,7 +250,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## intc
 
-- Syntax: `intc I` ∋ I: an index in the intcblock
+- Syntax: `intc I` where I: an index in the intcblock
 - Bytecode: 0x21 {uint8}
 - Stack: ... &rarr; ..., uint64
 - Ith constant from intcblock
@@ -281,7 +281,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## bytecblock
 
-- Syntax: `bytecblock BYTES ...` ∋ BYTES ...: a block of byte constant values
+- Syntax: `bytecblock BYTES ...` where BYTES ...: a block of byte constant values
 - Bytecode: 0x26 {varuint count, [varuint length, bytes ...]}
 - Stack: ... &rarr; ...
 - prepare block of byte-array constants for use by bytec
@@ -290,7 +290,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## bytec
 
-- Syntax: `bytec I` ∋ I: an index in the bytecblock
+- Syntax: `bytec I` where I: an index in the bytecblock
 - Bytecode: 0x27 {uint8}
 - Stack: ... &rarr; ..., []byte
 - Ith constant from bytecblock
@@ -321,7 +321,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## arg
 
-- Syntax: `arg N` ∋ N: an arg index
+- Syntax: `arg N` where N: an arg index
 - Bytecode: 0x2c {uint8}
 - Stack: ... &rarr; ..., []byte
 - Nth LogicSig argument
@@ -357,7 +357,7 @@ The notation J,K indicates that two uint64 values J and K are interpreted as a u
 
 ## txn
 
-- Syntax: `txn F` ∋ F: [txn](#field-group-txn)
+- Syntax: `txn F` where F: [txn](#field-group-txn)
 - Bytecode: 0x31 {uint8}
 - Stack: ... &rarr; ..., any
 - field F of current transaction
@@ -433,7 +433,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## global
 
-- Syntax: `global F` ∋ F: [global](#field-group-global)
+- Syntax: `global F` where F: [global](#field-group-global)
 - Bytecode: 0x32 {uint8}
 - Stack: ... &rarr; ..., any
 - global field F
@@ -463,7 +463,7 @@ Fields
 
 ## gtxn
 
-- Syntax: `gtxn T F` ∋ T: transaction group index, F: [txn](#field-group-txn)
+- Syntax: `gtxn T F` where T: transaction group index, F: [txn](#field-group-txn)
 - Bytecode: 0x33 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the Tth transaction in the current group
@@ -472,21 +472,21 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 
 ## load
 
-- Syntax: `load I` ∋ I: position in scratch space to load from
+- Syntax: `load I` where I: position in scratch space to load from
 - Bytecode: 0x34 {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value. All scratch spaces are 0 at program start.
 
 ## store
 
-- Syntax: `store I` ∋ I: position in scratch space to store to
+- Syntax: `store I` where I: position in scratch space to store to
 - Bytecode: 0x35 {uint8}
 - Stack: ..., A &rarr; ...
 - store A to the Ith scratch space
 
 ## txna
 
-- Syntax: `txna F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `txna F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x36 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F of the current transaction<br />`txna` can be called using `txn` with 2 immediates.
@@ -509,7 +509,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxna
 
-- Syntax: `gtxna T F I` ∋ T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxna T F I` where T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x37 {uint8}, {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F from the Tth transaction in the current group<br />`gtxna` can be called using `gtxn` with 3 immediates.
@@ -517,7 +517,7 @@ Fields (see [transaction reference](https://developer.algorand.org/docs/referenc
 
 ## gtxns
 
-- Syntax: `gtxns F` ∋ F: [txn](#field-group-txn)
+- Syntax: `gtxns F` where F: [txn](#field-group-txn)
 - Bytecode: 0x38 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - field F of the Ath transaction in the current group
@@ -527,7 +527,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gtxnsa
 
-- Syntax: `gtxnsa F I` ∋ F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gtxnsa F I` where F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0x39 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ith value of the array field F from the Ath transaction in the current group<br />`gtxnsa` can be called using `gtxns` with 2 immediates.
@@ -535,7 +535,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gload
 
-- Syntax: `gload T I` ∋ T: transaction group index, I: position in scratch space to load from
+- Syntax: `gload T I` where T: transaction group index, I: position in scratch space to load from
 - Bytecode: 0x3a {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith scratch space value of the Tth transaction in the current group
@@ -546,7 +546,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gloads
 
-- Syntax: `gloads I` ∋ I: position in scratch space to load from
+- Syntax: `gloads I` where I: position in scratch space to load from
 - Bytecode: 0x3b {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ith scratch space value of the Ath transaction in the current group
@@ -557,7 +557,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## gaid
 
-- Syntax: `gaid T` ∋ T: transaction group index
+- Syntax: `gaid T` where T: transaction group index
 - Bytecode: 0x3c {uint8}
 - Stack: ... &rarr; ..., uint64
 - ID of the asset or application created in the Tth transaction of the current group
@@ -592,7 +592,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## bnz
 
-- Syntax: `bnz TARGET` ∋ TARGET: branch offset
+- Syntax: `bnz TARGET` where TARGET: branch offset
 - Bytecode: 0x40 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is not zero
@@ -603,7 +603,7 @@ At v2 it became allowed to branch to the end of the program exactly after the la
 
 ## bz
 
-- Syntax: `bz TARGET` ∋ TARGET: branch offset
+- Syntax: `bz TARGET` where TARGET: branch offset
 - Bytecode: 0x41 {int16 (big-endian)}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to TARGET if value A is zero
@@ -613,7 +613,7 @@ See `bnz` for details on how branches work. `bz` inverts the behavior of `bnz`.
 
 ## b
 
-- Syntax: `b TARGET` ∋ TARGET: branch offset
+- Syntax: `b TARGET` where TARGET: branch offset
 - Bytecode: 0x42 {int16 (big-endian)}
 - Stack: ... &rarr; ...
 - branch unconditionally to TARGET
@@ -637,7 +637,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## bury
 
-- Syntax: `bury N` ∋ N: depth
+- Syntax: `bury N` where N: depth
 - Bytecode: 0x45 {uint8}
 - Stack: ..., A &rarr; ...
 - replace the Nth value from the top of the stack with A. bury 0 fails.
@@ -645,7 +645,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## popn
 
-- Syntax: `popn N` ∋ N: stack depth
+- Syntax: `popn N` where N: stack depth
 - Bytecode: 0x46 {uint8}
 - Stack: ..., [N items] &rarr; ...
 - remove N values from the top of the stack
@@ -653,7 +653,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## dupn
 
-- Syntax: `dupn N` ∋ N: copy count
+- Syntax: `dupn N` where N: copy count
 - Bytecode: 0x47 {uint8}
 - Stack: ..., A &rarr; ..., A, [N copies of A]
 - duplicate A, N times
@@ -680,7 +680,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## dig
 
-- Syntax: `dig N` ∋ N: depth
+- Syntax: `dig N` where N: depth
 - Bytecode: 0x4b {uint8}
 - Stack: ..., A, [N items] &rarr; ..., A, [N items], A
 - Nth value from the top of the stack. dig 0 is equivalent to dup
@@ -702,7 +702,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## cover
 
-- Syntax: `cover N` ∋ N: depth
+- Syntax: `cover N` where N: depth
 - Bytecode: 0x4e {uint8}
 - Stack: ..., [N items], A &rarr; ..., A, [N items]
 - remove top of stack, and place it deeper in the stack such that N elements are above it. Fails if stack depth <= N.
@@ -710,7 +710,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## uncover
 
-- Syntax: `uncover N` ∋ N: depth
+- Syntax: `uncover N` where N: depth
 - Bytecode: 0x4f {uint8}
 - Stack: ..., A, [N items] &rarr; ..., [N items], A
 - remove the value at depth N in the stack and shift above items down so the Nth deep value is on top of the stack. Fails if stack depth <= N.
@@ -727,7 +727,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 
 ## substring
 
-- Syntax: `substring S E` ∋ S: start position, E: end position
+- Syntax: `substring S E` where S: start position, E: end position
 - Bytecode: 0x51 {uint8}, {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - A range of bytes from A starting at S up to but not including E. If E < S, or either is larger than the array length, the program fails
@@ -774,7 +774,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 
 ## extract
 
-- Syntax: `extract S L` ∋ S: start position, L: length
+- Syntax: `extract S L` where S: start position, L: length
 - Bytecode: 0x57 {uint8}, {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - A range of bytes from A starting at S up to but not including S+L. If L is 0, then extract to the end of the string. If S or S+L is larger than the array length, the program fails
@@ -810,7 +810,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 
 ## replace2
 
-- Syntax: `replace2 S` ∋ S: start position
+- Syntax: `replace2 S` where S: start position
 - Bytecode: 0x5c {uint8}
 - Stack: ..., A: []byte, B: []byte &rarr; ..., []byte
 - Copy of A with the bytes starting at S replaced by the bytes of B. Fails if S+len(B) exceeds len(A)<br />`replace2` can be called using `replace` with 1 immediate.
@@ -825,7 +825,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 
 ## base64_decode
 
-- Syntax: `base64_decode E` ∋ E: [base64](#field-group-base64)
+- Syntax: `base64_decode E` where E: [base64](#field-group-base64)
 - Bytecode: 0x5e {uint8}
 - Stack: ..., A: []byte &rarr; ..., []byte
 - decode A which was base64-encoded using _encoding_ E. Fail if A is not base64 encoded with encoding E
@@ -848,7 +848,7 @@ Encodings
 
 ## json_ref
 
-- Syntax: `json_ref R` ∋ R: [json_ref](#field-group-json_ref)
+- Syntax: `json_ref R` where R: [json_ref](#field-group-json_ref)
 - Bytecode: 0x5f {uint8}
 - Stack: ..., A: []byte, B: []byte &rarr; ..., any
 - key B's value, of type R, from a [valid](jsonspec.md) utf-8 encoded json object A
@@ -974,7 +974,7 @@ Deleting a key which is already absent has no effect on the application global s
 
 ## asset_holding_get
 
-- Syntax: `asset_holding_get F` ∋ F: [asset_holding](#field-group-asset_holding)
+- Syntax: `asset_holding_get F` where F: [asset_holding](#field-group-asset_holding)
 - Bytecode: 0x70 {uint8}
 - Stack: ..., A, B: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from account A's holding of asset B. Y is 1 if A is opted into B, else 0
@@ -995,7 +995,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ address), asset id (or
 
 ## asset_params_get
 
-- Syntax: `asset_params_get F` ∋ F: [asset_params](#field-group-asset_params)
+- Syntax: `asset_params_get F` where F: [asset_params](#field-group-asset_params)
 - Bytecode: 0x71 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from asset A. Y is 1 if A exists, else 0
@@ -1026,7 +1026,7 @@ params: Txn.ForeignAssets offset (or, since v4, an _available_ asset id. Return:
 
 ## app_params_get
 
-- Syntax: `app_params_get F` ∋ F: [app_params](#field-group-app_params)
+- Syntax: `app_params_get F` where F: [app_params](#field-group-app_params)
 - Bytecode: 0x72 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., X: any, Y: bool
 - X is field F from app A. Y is 1 if A exists, else 0
@@ -1054,7 +1054,7 @@ params: Txn.ForeignApps offset or an _available_ app id. Return: did_exist flag 
 
 ## acct_params_get
 
-- Syntax: `acct_params_get F` ∋ F: [acct_params](#field-group-acct_params)
+- Syntax: `acct_params_get F` where F: [acct_params](#field-group-acct_params)
 - Bytecode: 0x73 {uint8}
 - Stack: ..., A &rarr; ..., X: any, Y: bool
 - X is field F from account A. Y is 1 if A owns positive algos, else 0
@@ -1093,7 +1093,7 @@ params: Txn.Accounts offset (or, since v4, an _available_ account address), _ava
 
 ## pushbytes
 
-- Syntax: `pushbytes BYTES` ∋ BYTES: a byte constant
+- Syntax: `pushbytes BYTES` where BYTES: a byte constant
 - Bytecode: 0x80 {varuint length, bytes}
 - Stack: ... &rarr; ..., []byte
 - immediate BYTES
@@ -1103,7 +1103,7 @@ pushbytes args are not added to the bytecblock during assembly processes
 
 ## pushint
 
-- Syntax: `pushint UINT` ∋ UINT: an int constant
+- Syntax: `pushint UINT` where UINT: an int constant
 - Bytecode: 0x81 {varuint}
 - Stack: ... &rarr; ..., uint64
 - immediate UINT
@@ -1113,7 +1113,7 @@ pushint args are not added to the intcblock during assembly processes
 
 ## pushbytess
 
-- Syntax: `pushbytess BYTES ...` ∋ BYTES ...: a list of byte constants
+- Syntax: `pushbytess BYTES ...` where BYTES ...: a list of byte constants
 - Bytecode: 0x82 {varuint count, [varuint length, bytes ...]}
 - Stack: ... &rarr; ..., [N items]
 - push sequences of immediate byte arrays to stack (first byte array being deepest)
@@ -1123,7 +1123,7 @@ pushbytess args are not added to the bytecblock during assembly processes
 
 ## pushints
 
-- Syntax: `pushints UINT ...` ∋ UINT ...: a list of int constants
+- Syntax: `pushints UINT ...` where UINT ...: a list of int constants
 - Bytecode: 0x83 {varuint count, [varuint ...]}
 - Stack: ... &rarr; ..., [N items]
 - push sequence of immediate uints to stack in the order they appear (first uint being deepest)
@@ -1141,7 +1141,7 @@ pushints args are not added to the intcblock during assembly processes
 
 ## callsub
 
-- Syntax: `callsub TARGET` ∋ TARGET: branch offset
+- Syntax: `callsub TARGET` where TARGET: branch offset
 - Bytecode: 0x88 {int16 (big-endian)}
 - Stack: ... &rarr; ...
 - branch unconditionally to TARGET, saving the next instruction on the call stack
@@ -1160,7 +1160,7 @@ If the current frame was prepared by `proto A R`, `retsub` will remove the 'A' a
 
 ## proto
 
-- Syntax: `proto A R` ∋ A: number of arguments, R: number of return values
+- Syntax: `proto A R` where A: number of arguments, R: number of return values
 - Bytecode: 0x8a {uint8}, {uint8}
 - Stack: ... &rarr; ...
 - Prepare top call frame for a retsub that will assume A args and R return values.
@@ -1170,7 +1170,7 @@ Fails unless the last instruction executed was a `callsub`.
 
 ## frame_dig
 
-- Syntax: `frame_dig I` ∋ I: frame slot
+- Syntax: `frame_dig I` where I: frame slot
 - Bytecode: 0x8b {int8}
 - Stack: ... &rarr; ..., any
 - Nth (signed) value from the frame pointer.
@@ -1178,7 +1178,7 @@ Fails unless the last instruction executed was a `callsub`.
 
 ## frame_bury
 
-- Syntax: `frame_bury I` ∋ I: frame slot
+- Syntax: `frame_bury I` where I: frame slot
 - Bytecode: 0x8c {int8}
 - Stack: ..., A &rarr; ...
 - replace the Nth (signed) value from the frame pointer in the stack with A
@@ -1186,7 +1186,7 @@ Fails unless the last instruction executed was a `callsub`.
 
 ## switch
 
-- Syntax: `switch TARGET ...` ∋ TARGET ...: list of labels
+- Syntax: `switch TARGET ...` where TARGET ...: list of labels
 - Bytecode: 0x8d {varuint count, [int16 (big-endian) ...]}
 - Stack: ..., A: uint64 &rarr; ...
 - branch to the Ath label. Continue at following instruction if index A exceeds the number of labels.
@@ -1194,7 +1194,7 @@ Fails unless the last instruction executed was a `callsub`.
 
 ## match
 
-- Syntax: `match TARGET ...` ∋ TARGET ...: list of labels
+- Syntax: `match TARGET ...` where TARGET ...: list of labels
 - Bytecode: 0x8e {varuint count, [int16 (big-endian) ...]}
 - Stack: ..., [A1, A2, ..., AN], B &rarr; ...
 - given match cases from A[1] to A[N], branch to the Ith label where A[I] = B. Continue to the following instruction if no matches are found.
@@ -1416,7 +1416,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxn_field
 
-- Syntax: `itxn_field F` ∋ F: [txn](#field-group-txn)
+- Syntax: `itxn_field F` where F: [txn](#field-group-txn)
 - Bytecode: 0xb2 {uint8}
 - Stack: ..., A &rarr; ...
 - set field F of the current inner transaction to A
@@ -1437,7 +1437,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxn
 
-- Syntax: `itxn F` ∋ F: [txn](#field-group-txn)
+- Syntax: `itxn F` where F: [txn](#field-group-txn)
 - Bytecode: 0xb4 {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the last inner transaction
@@ -1446,7 +1446,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## itxna
 
-- Syntax: `itxna F I` ∋ F: [txna](#field-group-txna), I: a transaction field array index
+- Syntax: `itxna F I` where F: [txna](#field-group-txna), I: a transaction field array index
 - Bytecode: 0xb5 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F of the last inner transaction
@@ -1465,7 +1465,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## gitxn
 
-- Syntax: `gitxn T F` ∋ T: transaction group index, F: [txn](#field-group-txn)
+- Syntax: `gitxn T F` where T: transaction group index, F: [txn](#field-group-txn)
 - Bytecode: 0xb7 {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - field F of the Tth transaction in the last inner group submitted
@@ -1474,7 +1474,7 @@ The notation A,B indicates that A and B are interpreted as a uint128 value, with
 
 ## gitxna
 
-- Syntax: `gitxna T F I` ∋ T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
+- Syntax: `gitxna T F I` where T: transaction group index, F: [txna](#field-group-txna), I: transaction field array index
 - Bytecode: 0xb8 {uint8}, {uint8}, {uint8}
 - Stack: ... &rarr; ..., any
 - Ith value of the array field F from the Tth transaction in the last inner group submitted
@@ -1545,7 +1545,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## txnas
 
-- Syntax: `txnas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `txnas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc0 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F of the current transaction
@@ -1553,7 +1553,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## gtxnas
 
-- Syntax: `gtxnas T F` ∋ T: transaction group index, F: [txna](#field-group-txna)
+- Syntax: `gtxnas T F` where T: transaction group index, F: [txna](#field-group-txna)
 - Bytecode: 0xc1 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F from the Tth transaction in the current group
@@ -1561,7 +1561,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## gtxnsas
 
-- Syntax: `gtxnsas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `gtxnsas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc2 {uint8}
 - Stack: ..., A: uint64, B: uint64 &rarr; ..., any
 - Bth value of the array field F from the Ath transaction in the current group
@@ -1585,7 +1585,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## itxnas
 
-- Syntax: `itxnas F` ∋ F: [txna](#field-group-txna)
+- Syntax: `itxnas F` where F: [txna](#field-group-txna)
 - Bytecode: 0xc5 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F of the last inner transaction
@@ -1594,7 +1594,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## gitxnas
 
-- Syntax: `gitxnas T F` ∋ T: transaction group index, F: [txna](#field-group-txna)
+- Syntax: `gitxnas T F` where T: transaction group index, F: [txna](#field-group-txna)
 - Bytecode: 0xc6 {uint8}, {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - Ath value of the array field F from the Tth transaction in the last inner group submitted
@@ -1603,7 +1603,7 @@ For boxes that exceed 4,096 bytes, consider `box_create`, `box_extract`, and `bo
 
 ## vrf_verify
 
-- Syntax: `vrf_verify S` ∋ S: [vrf_verify](#field-group-vrf_verify)
+- Syntax: `vrf_verify S` where S: [vrf_verify](#field-group-vrf_verify)
 - Bytecode: 0xd0 {uint8}
 - Stack: ..., A: []byte, B: [80]byte, C: [32]byte &rarr; ..., X: []byte, Y: bool
 - Verify the proof B of message A against pubkey C. Returns vrf output and verification flag.
@@ -1623,7 +1623,7 @@ Standards
 
 ## block
 
-- Syntax: `block F` ∋ F: [block](#field-group-block)
+- Syntax: `block F` where F: [block](#field-group-block)
 - Bytecode: 0xd1 {uint8}
 - Stack: ..., A: uint64 &rarr; ..., any
 - field F of block A. Fail unless A falls between txn.LastValid-1002 and txn.FirstValid (exclusive)


### PR DESCRIPTION
In the specs repo we generate pdf from md, and it can't handle the unicode character we were using to mean "where".