### PR TITLE
p2p: start p2p networking and DHT ops when starting services, not when instantiating them

### DIFF
--- a/agreement/fuzzer/networkFacade_test.go
+++ b/agreement/fuzzer/networkFacade_test.go
@@ -247,7 +247,7 @@ func (n *NetworkFacade) PushDownstreamMessage(newMsg context.CancelFunc) bool {
 func (n *NetworkFacade) Address() (string, bool) { return "mock network", true }
 
 // Start - unused function
-func (n *NetworkFacade) Start() {}
+func (n *NetworkFacade) Start() error { return nil }
 
 // Stop - unused function
 func (n *NetworkFacade) Stop() {}

--- a/agreement/gossip/network_test.go
+++ b/agreement/gossip/network_test.go
@@ -160,7 +160,7 @@ func (w *whiteholeNetwork) GetHTTPRequestConnection(request *http.Request) (conn
 	return nil
 }
 
-func (w *whiteholeNetwork) Start() {
+func (w *whiteholeNetwork) Start() error {
 	w.quit = make(chan struct{})
 	go func(w *whiteholeNetwork) {
 		w.domain.messagesMu.Lock()
@@ -216,7 +216,7 @@ func (w *whiteholeNetwork) Start() {
 			atomic.AddUint32(&w.lastMsgRead, 1)
 		}
 	}(w)
-	return
+	return nil
 }
 func (w *whiteholeNetwork) getMux() *network.Multiplexer {
 	return w.mux

--- a/components/mocks/mockNetwork.go
+++ b/components/mocks/mockNetwork.go
@@ -47,7 +47,8 @@ func (network *MockNetwork) Address() (string, bool) {
 }
 
 // Start - unused function
-func (network *MockNetwork) Start() {
+func (network *MockNetwork) Start() error {
+	return nil
 }
 
 // Stop - unused function

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -56,7 +56,7 @@ const maxHeaderBytes = 4096
 type ServerNode interface {
 	apiServer.APINodeInterface
 	ListeningAddress() (string, bool)
-	Start()
+	Start() error
 	Stop()
 }
 
@@ -272,7 +272,13 @@ func makeListener(addr string) (net.Listener, error) {
 func (s *Server) Start() {
 	s.log.Info("Trying to start an Algorand node")
 	fmt.Print("Initializing the Algorand node... ")
-	s.node.Start()
+	err := s.node.Start()
+	if err != nil {
+		msg := fmt.Sprintf(("Failed to start alg Algorand node: %v"), err)
+		s.log.Error(msg)
+		fmt.Println(msg)
+		os.Exit(1)
+	}
 	s.log.Info("Successfully started an Algorand node.")
 	fmt.Println("Success!")
 
@@ -291,7 +297,6 @@ func (s *Server) Start() {
 	}
 
 	var apiToken string
-	var err error
 	fmt.Printf("API authentication disabled: %v\n", cfg.DisableAPIAuth)
 	if !cfg.DisableAPIAuth {
 		apiToken, err = tokens.GetAndValidateAPIToken(s.RootPath, tokens.AlgodTokenFilename)

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -274,7 +274,7 @@ func (s *Server) Start() {
 	fmt.Print("Initializing the Algorand node... ")
 	err := s.node.Start()
 	if err != nil {
-		msg := fmt.Sprintf(("Failed to start alg Algorand node: %v"), err)
+		msg := fmt.Sprintf("Failed to start alg Algorand node: %v", err)
 		s.log.Error(msg)
 		fmt.Println(msg)
 		os.Exit(1)

--- a/network/gossipNode.go
+++ b/network/gossipNode.go
@@ -72,7 +72,7 @@ type GossipNode interface {
 	GetPeers(options ...PeerOption) []Peer
 
 	// Start threads, listen on sockets.
-	Start()
+	Start() error
 
 	// Close sockets. Stop threads.
 	Stop()

--- a/network/hybridNetwork.go
+++ b/network/hybridNetwork.go
@@ -163,7 +163,8 @@ func (n *HybridP2PNetwork) Start() error {
 // Stop implements GossipNode
 func (n *HybridP2PNetwork) Stop() {
 	_ = n.runParallel(func(net GossipNode) error {
-		return net.Start()
+		net.Stop()
+		return nil
 	})
 }
 

--- a/network/hybridNetwork.go
+++ b/network/hybridNetwork.go
@@ -153,11 +153,12 @@ func (n *HybridP2PNetwork) GetPeers(options ...PeerOption) []Peer {
 }
 
 // Start implements GossipNode
-func (n *HybridP2PNetwork) Start() {
-	_ = n.runParallel(func(net GossipNode) error {
-		net.Start()
-		return nil
+func (n *HybridP2PNetwork) Start() error {
+	err := n.runParallel(func(net GossipNode) error {
+		err0 := net.Start()
+		return err0
 	})
+	return err
 }
 
 // Stop implements GossipNode

--- a/network/hybridNetwork.go
+++ b/network/hybridNetwork.go
@@ -42,7 +42,7 @@ func NewHybridP2PNetwork(log logging.Logger, cfg config.Local, datadir string, p
 	// supply alternate NetAddress for P2P network
 	p2pcfg := cfg
 	p2pcfg.NetAddress = cfg.P2PListenAddress
-	p2pnet, err := NewP2PNetwork(log, p2pcfg, datadir, phonebookAddresses, genesisID, networkID)
+	p2pnet, err := NewP2PNetwork(log, p2pcfg, datadir, phonebookAddresses, genesisID, networkID, nodeInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -155,8 +155,7 @@ func (n *HybridP2PNetwork) GetPeers(options ...PeerOption) []Peer {
 // Start implements GossipNode
 func (n *HybridP2PNetwork) Start() error {
 	err := n.runParallel(func(net GossipNode) error {
-		err0 := net.Start()
-		return err0
+		return net.Start()
 	})
 	return err
 }
@@ -164,8 +163,7 @@ func (n *HybridP2PNetwork) Start() error {
 // Stop implements GossipNode
 func (n *HybridP2PNetwork) Stop() {
 	_ = n.runParallel(func(net GossipNode) error {
-		net.Start()
-		return nil
+		return net.Start()
 	})
 }
 

--- a/network/p2p/capabilities.go
+++ b/network/p2p/capabilities.go
@@ -147,7 +147,15 @@ func (c *CapabilitiesDiscovery) AdvertiseCapabilities(capabilities ...Capability
 }
 
 // MakeCapabilitiesDiscovery creates a new CapabilitiesDiscovery object which exposes peer discovery and capabilities advertisement
-func MakeCapabilitiesDiscovery(ctx context.Context, cfg config.Local, datadir string, network string, log logging.Logger, bootstrapPeers []*peer.AddrInfo) (*CapabilitiesDiscovery, error) {
+func MakeCapabilitiesDiscovery(ctx context.Context, cfg config.Local, datadir string, network string, log logging.Logger, phonebookAddresses []string) (*CapabilitiesDiscovery, error) {
+	var bootstrapPeers []*peer.AddrInfo
+	if len(phonebookAddresses) > 0 {
+		var malformedAddrs map[string]string
+		bootstrapPeers, malformedAddrs = peerstore.PeerInfoFromAddrs(phonebookAddresses)
+		for malAddr, malErr := range malformedAddrs {
+			log.Infof("Ignoring malformed phonebook address %s: %s", malAddr, malErr)
+		}
+	}
 	pstore, err := peerstore.NewPeerStore(bootstrapPeers)
 	if err != nil {
 		return nil, err

--- a/network/p2p/capabilities_test.go
+++ b/network/p2p/capabilities_test.go
@@ -310,7 +310,7 @@ func TestCapabilities_ExcludesSelf(t *testing.T) {
 	disc := setupCapDiscovery(t, 2, 2)
 
 	testPeersFound := func(disc *CapabilitiesDiscovery, n int, cap Capability) bool {
-		peers, err := disc.PeersForCapability(cap, n+1)
+		peers, err := disc.PeersForCapability(cap, n)
 		if err == nil && len(peers) == n {
 			return true
 		}

--- a/network/p2p/capabilities_test.go
+++ b/network/p2p/capabilities_test.go
@@ -141,6 +141,8 @@ func setupCapDiscovery(t *testing.T, numHosts int, numBootstrapPeers int) []*Cap
 	for _, h := range hosts {
 		bp := bootstrapPeers
 		if numBootstrapPeers != 0 && numBootstrapPeers != numHosts {
+			bp = make([]peer.AddrInfo, len(bootstrapPeers))
+			copy(bp, bootstrapPeers)
 			rand.Shuffle(len(bootstrapPeers), func(i, j int) {
 				bp[i], bp[j] = bp[j], bp[i]
 			})

--- a/network/p2p/dht/dht_test.go
+++ b/network/p2p/dht/dht_test.go
@@ -39,7 +39,7 @@ func TestDHTBasic(t *testing.T) {
 		h,
 		"devtestnet",
 		config.GetDefaultLocal(),
-		[]*peer.AddrInfo{{}})
+		func() []peer.AddrInfo { return nil })
 	require.NoError(t, err)
 	_, err = MakeDiscovery(dht)
 	require.NoError(t, err)
@@ -55,52 +55,10 @@ func TestDHTBasicAlgodev(t *testing.T) {
 	require.NoError(t, err)
 	cfg := config.GetDefaultLocal()
 	cfg.DNSBootstrapID = "<network>.algodev.network"
-	dht, err := MakeDHT(context.Background(), h, "betanet", cfg, []*peer.AddrInfo{})
+	dht, err := MakeDHT(context.Background(), h, "betanet", cfg, func() []peer.AddrInfo { return nil })
 	require.NoError(t, err)
 	_, err = MakeDiscovery(dht)
 	require.NoError(t, err)
 	err = dht.Bootstrap(context.Background())
 	require.NoError(t, err)
-}
-
-func TestGetBootstrapPeers(t *testing.T) {
-	t.Parallel()
-	partitiontest.PartitionTest(t)
-
-	cfg := config.GetDefaultLocal()
-	cfg.DNSBootstrapID = "<network>.algodev.network"
-	cfg.DNSSecurityFlags = 0
-
-	addrs := getBootstrapPeersFunc(cfg, "test")()
-
-	require.GreaterOrEqual(t, len(addrs), 1)
-	addr := addrs[0]
-	require.Equal(t, len(addr.Addrs), 1)
-	require.GreaterOrEqual(t, len(addr.Addrs), 1)
-}
-
-func TestGetBootstrapPeersFailure(t *testing.T) {
-	t.Parallel()
-	partitiontest.PartitionTest(t)
-
-	cfg := config.GetDefaultLocal()
-	cfg.DNSSecurityFlags = 0
-	cfg.DNSBootstrapID = "non-existent.algodev.network"
-
-	addrs := getBootstrapPeersFunc(cfg, "test")()
-
-	require.Equal(t, 0, len(addrs))
-}
-
-func TestGetBootstrapPeersInvalidAddr(t *testing.T) {
-	t.Parallel()
-	partitiontest.PartitionTest(t)
-
-	cfg := config.GetDefaultLocal()
-	cfg.DNSSecurityFlags = 0
-	cfg.DNSBootstrapID = "<network>.algodev.network"
-
-	addrs := getBootstrapPeersFunc(cfg, "testInvalidAddr")()
-
-	require.Equal(t, 0, len(addrs))
 }

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -197,12 +197,12 @@ func NewP2PNetwork(log logging.Logger, cfg config.Local, datadir string, phonebo
 	}
 
 	if cfg.EnableDHTProviders {
-		caps, err0 := p2p.MakeCapabilitiesDiscovery(net.ctx, cfg, h, networkID, net.log, bootstrapper.BootstrapFunc)
+		disc, err0 := p2p.MakeCapabilitiesDiscovery(net.ctx, cfg, h, networkID, net.log, bootstrapper.BootstrapFunc)
 		if err0 != nil {
 			log.Errorf("Failed to create dht node capabilities discovery: %v", err)
 			return nil, err
 		}
-		net.capabilitiesDiscovery = caps
+		net.capabilitiesDiscovery = disc
 	}
 
 	err = net.setup()

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -146,7 +146,7 @@ func (n *P2PNetwork) PeerIDSigner() identityChallengeSigner {
 }
 
 // Start threads, listen on sockets.
-func (n *P2PNetwork) Start() {
+func (n *P2PNetwork) Start() error {
 	n.wg.Add(1)
 	go n.txTopicHandleLoop()
 
@@ -166,6 +166,8 @@ func (n *P2PNetwork) Start() {
 
 	n.wg.Add(1)
 	go n.meshThread()
+
+	return nil
 }
 
 // Stop closes sockets and stop threads.

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -42,7 +42,7 @@ func TestP2PSubmitTX(t *testing.T) {
 
 	cfg := config.GetDefaultLocal()
 	log := logging.TestingLog(t)
-	netA, err := NewP2PNetwork(log, cfg, "", nil, genesisID, config.Devtestnet)
+	netA, err := NewP2PNetwork(log, cfg, "", nil, genesisID, config.Devtestnet, &nopeNodeInfo{})
 	require.NoError(t, err)
 	netA.Start()
 	defer netA.Stop()
@@ -54,12 +54,12 @@ func TestP2PSubmitTX(t *testing.T) {
 
 	multiAddrStr := addrsA[0].String()
 	phoneBookAddresses := []string{multiAddrStr}
-	netB, err := NewP2PNetwork(log, cfg, "", phoneBookAddresses, genesisID, config.Devtestnet)
+	netB, err := NewP2PNetwork(log, cfg, "", phoneBookAddresses, genesisID, config.Devtestnet, &nopeNodeInfo{})
 	require.NoError(t, err)
 	netB.Start()
 	defer netB.Stop()
 
-	netC, err := NewP2PNetwork(log, cfg, "", phoneBookAddresses, genesisID, config.Devtestnet)
+	netC, err := NewP2PNetwork(log, cfg, "", phoneBookAddresses, genesisID, config.Devtestnet, &nopeNodeInfo{})
 
 	require.NoError(t, err)
 	netC.Start()
@@ -116,7 +116,7 @@ func TestP2PSubmitWS(t *testing.T) {
 
 	cfg := config.GetDefaultLocal()
 	log := logging.TestingLog(t)
-	netA, err := NewP2PNetwork(log, cfg, "", nil, genesisID, config.Devtestnet)
+	netA, err := NewP2PNetwork(log, cfg, "", nil, genesisID, config.Devtestnet, &nopeNodeInfo{})
 	require.NoError(t, err)
 
 	err = netA.Start()
@@ -130,13 +130,13 @@ func TestP2PSubmitWS(t *testing.T) {
 
 	multiAddrStr := addrsA[0].String()
 	phoneBookAddresses := []string{multiAddrStr}
-	netB, err := NewP2PNetwork(log, cfg, "", phoneBookAddresses, genesisID, config.Devtestnet)
+	netB, err := NewP2PNetwork(log, cfg, "", phoneBookAddresses, genesisID, config.Devtestnet, &nopeNodeInfo{})
 	require.NoError(t, err)
 	err = netB.Start()
 	require.NoError(t, err)
 	defer netB.Stop()
 
-	netC, err := NewP2PNetwork(log, cfg, "", phoneBookAddresses, genesisID, config.Devtestnet)
+	netC, err := NewP2PNetwork(log, cfg, "", phoneBookAddresses, genesisID, config.Devtestnet, &nopeNodeInfo{})
 	require.NoError(t, err)
 	err = netC.Start()
 	require.NoError(t, err)
@@ -261,7 +261,7 @@ func TestP2PNetworkAddress(t *testing.T) {
 
 	cfg := config.GetDefaultLocal()
 	log := logging.TestingLog(t)
-	netA, err := NewP2PNetwork(log, cfg, "", nil, genesisID, config.Devtestnet)
+	netA, err := NewP2PNetwork(log, cfg, "", nil, genesisID, config.Devtestnet, &nopeNodeInfo{})
 	defer netA.Stop()
 	require.NoError(t, err)
 	addrInfo := netA.service.AddrInfo()

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -680,7 +680,7 @@ func (wn *WebsocketNetwork) setup() {
 }
 
 // Start makes network connections and threads
-func (wn *WebsocketNetwork) Start() {
+func (wn *WebsocketNetwork) Start() error {
 	wn.messagesOfInterestMu.Lock()
 	defer wn.messagesOfInterestMu.Unlock()
 	wn.messagesOfInterestEncoded = true
@@ -692,7 +692,7 @@ func (wn *WebsocketNetwork) Start() {
 		listener, err := net.Listen("tcp", wn.config.NetAddress)
 		if err != nil {
 			wn.log.Errorf("network could not listen %v: %s", wn.config.NetAddress, err)
-			return
+			return err
 		}
 		// wrap the original listener with a limited connection listener
 		listener = limitlistener.RejectingLimitListener(
@@ -768,6 +768,8 @@ func (wn *WebsocketNetwork) Start() {
 	go wn.postMessagesOfInterestThread()
 
 	wn.log.Infof("serving genesisID=%s on %#v with RandomID=%s", wn.GenesisID, wn.PublicAddress(), wn.RandomID)
+
+	return nil
 }
 
 func (wn *WebsocketNetwork) httpdThread() {

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -156,6 +156,8 @@ const GossipNetworkPath = "/v1/{genesisID}/gossip"
 type NodeInfo interface {
 	// IsParticipating returns true if this node has stake and may vote on blocks or propose blocks.
 	IsParticipating() bool
+	// Capabilities returns a list of capabilities this node has.
+	Capabilities() []p2p.Capability
 }
 
 type nopeNodeInfo struct {
@@ -163,6 +165,10 @@ type nopeNodeInfo struct {
 
 func (nnni *nopeNodeInfo) IsParticipating() bool {
 	return false
+}
+
+func (nnni *nopeNodeInfo) Capabilities() []p2p.Capability {
+	return nil
 }
 
 // WebsocketNetwork implements GossipNode

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -40,6 +40,7 @@ import (
 	"time"
 
 	"github.com/algorand/go-algorand/internal/rapidgen"
+	"github.com/algorand/go-algorand/network/p2p"
 	"pgregory.net/rapid"
 
 	"github.com/stretchr/testify/assert"
@@ -3288,6 +3289,9 @@ type participatingNodeInfo struct {
 
 func (nnni *participatingNodeInfo) IsParticipating() bool {
 	return true
+}
+func (nnni *participatingNodeInfo) Capabilities() []p2p.Capability {
+	return nil
 }
 
 func TestWebsocketNetworkTXMessageOfInterestPN(t *testing.T) {

--- a/node/follower_node.go
+++ b/node/follower_node.go
@@ -162,7 +162,7 @@ func (node *AlgorandFollowerNode) Config() config.Local {
 }
 
 // Start the node: connect to peers while obtaining a lock. Doesn't wait for initial sync.
-func (node *AlgorandFollowerNode) Start() {
+func (node *AlgorandFollowerNode) Start() error {
 	node.mu.Lock()
 	defer node.mu.Unlock()
 
@@ -172,22 +172,30 @@ func (node *AlgorandFollowerNode) Start() {
 	// The start network is being called only after the various services start up.
 	// We want to do so in order to let the services register their callbacks with the
 	// network package before any connections are being made.
-	startNetwork := func() {
+	startNetwork := func() error {
 		if !node.config.DisableNetworking {
 			// start accepting connections
-			node.net.Start()
+			err := node.net.Start()
+			if err != nil {
+				return err
+			}
 			node.config.NetAddress, _ = node.net.Address()
 		}
+		return nil
 	}
 
+	var err error
 	if node.catchpointCatchupService != nil {
-		startNetwork()
-		_ = node.catchpointCatchupService.Start(node.ctx)
+		err := startNetwork()
+		if err == nil {
+			err = node.catchpointCatchupService.Start(node.ctx)
+		}
 	} else {
 		node.catchupService.Start()
 		node.blockService.Start()
-		startNetwork()
+		err = startNetwork()
 	}
+	return err
 }
 
 // ListeningAddress retrieves the node's current listening address, if any.

--- a/node/follower_node.go
+++ b/node/follower_node.go
@@ -186,7 +186,7 @@ func (node *AlgorandFollowerNode) Start() error {
 
 	var err error
 	if node.catchpointCatchupService != nil {
-		err := startNetwork()
+		err = startNetwork()
 		if err == nil {
 			err = node.catchpointCatchupService.Start(node.ctx)
 		}

--- a/node/node.go
+++ b/node/node.go
@@ -390,6 +390,7 @@ func (node *AlgorandFullNode) Start() error {
 	return nil
 }
 
+// Capabilities returns the node's capabilities for advertising to other nodes.
 func (node *AlgorandFullNode) Capabilities() []p2p.Capability {
 	var caps []p2p.Capability
 	if node.IsArchival() {

--- a/node/node.go
+++ b/node/node.go
@@ -196,15 +196,6 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 		return nil, err
 	}
 
-	// if cfg.EnableDHTProviders {
-	// 	caps, err0 := p2p.MakeCapabilitiesDiscovery(node.ctx, node.config, node.genesisDirs.RootGenesisDir, string(genesis.Network), node.log, phonebookAddresses)
-	// 	if err0 != nil {
-	// 		log.Errorf("Failed to create dht node capabilities discovery: %v", err)
-	// 		return nil, err
-	// 	}
-	// 	node.capabilitiesDiscovery = caps
-	// }
-
 	// tie network, block fetcher, and agreement services together
 	var p2pNode network.GossipNode
 	if cfg.EnableP2PHybridMode {
@@ -215,7 +206,7 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 		}
 	} else if cfg.EnableP2P {
 		// TODO: pass more appropriate genesisDir (hot/cold). Presently this is just used to store a peerID key.
-		p2pNode, err = network.NewP2PNetwork(node.log, node.config, node.genesisDirs.RootGenesisDir, phonebookAddresses, genesis.ID(), genesis.Network)
+		p2pNode, err = network.NewP2PNetwork(node.log, node.config, node.genesisDirs.RootGenesisDir, phonebookAddresses, genesis.ID(), genesis.Network, node)
 		if err != nil {
 			log.Errorf("could not create p2p node: %v", err)
 			return nil, err
@@ -396,13 +387,10 @@ func (node *AlgorandFullNode) Start() error {
 
 		node.startMonitoringRoutines()
 	}
-	// if node.capabilitiesDiscovery != nil {
-	// 	node.capabilitiesDiscovery.AdvertiseCapabilities(node.capabilities()...)
-	// }
 	return nil
 }
 
-func (node *AlgorandFullNode) capabilities() []p2p.Capability {
+func (node *AlgorandFullNode) Capabilities() []p2p.Capability {
 	var caps []p2p.Capability
 	if node.IsArchival() {
 		caps = append(caps, p2p.Archival)
@@ -468,9 +456,6 @@ func (node *AlgorandFullNode) Stop() {
 	node.lowPriorityCryptoVerificationPool.Shutdown()
 	node.cryptoPool.Shutdown()
 	node.cancelCtx()
-	// if node.capabilitiesDiscovery != nil {
-	// 	node.capabilitiesDiscovery.Close()
-	// }
 }
 
 // note: unlike the other two functions, this accepts a whole filename

--- a/node/node.go
+++ b/node/node.go
@@ -28,8 +28,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/libp2p/go-libp2p/core/peer"
-
 	"github.com/algorand/go-deadlock"
 
 	"github.com/algorand/go-algorand/agreement"
@@ -201,7 +199,7 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 	}
 
 	if cfg.EnableDHTProviders {
-		caps, err0 := p2p.MakeCapabilitiesDiscovery(node.ctx, node.config, node.genesisDirs.RootGenesisDir, string(genesis.Network), node.log, []*peer.AddrInfo{})
+		caps, err0 := p2p.MakeCapabilitiesDiscovery(node.ctx, node.config, node.genesisDirs.RootGenesisDir, string(genesis.Network), node.log, phonebookAddresses)
 		if err0 != nil {
 			log.Errorf("Failed to create dht node capabilities discovery: %v", err)
 			return nil, err

--- a/node/node.go
+++ b/node/node.go
@@ -154,8 +154,6 @@ type AlgorandFullNode struct {
 	tracer messagetracer.MessageTracer
 
 	stateProofWorker *stateproof.Worker
-
-	capabilitiesDiscovery *p2p.CapabilitiesDiscovery
 }
 
 // TxnWithStatus represents information about a single transaction,
@@ -198,14 +196,14 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 		return nil, err
 	}
 
-	if cfg.EnableDHTProviders {
-		caps, err0 := p2p.MakeCapabilitiesDiscovery(node.ctx, node.config, node.genesisDirs.RootGenesisDir, string(genesis.Network), node.log, phonebookAddresses)
-		if err0 != nil {
-			log.Errorf("Failed to create dht node capabilities discovery: %v", err)
-			return nil, err
-		}
-		node.capabilitiesDiscovery = caps
-	}
+	// if cfg.EnableDHTProviders {
+	// 	caps, err0 := p2p.MakeCapabilitiesDiscovery(node.ctx, node.config, node.genesisDirs.RootGenesisDir, string(genesis.Network), node.log, phonebookAddresses)
+	// 	if err0 != nil {
+	// 		log.Errorf("Failed to create dht node capabilities discovery: %v", err)
+	// 		return nil, err
+	// 	}
+	// 	node.capabilitiesDiscovery = caps
+	// }
 
 	// tie network, block fetcher, and agreement services together
 	var p2pNode network.GossipNode
@@ -398,10 +396,10 @@ func (node *AlgorandFullNode) Start() error {
 
 		node.startMonitoringRoutines()
 	}
-	if node.capabilitiesDiscovery != nil {
-		node.capabilitiesDiscovery.AdvertiseCapabilities(node.capabilities()...)
-	}
-
+	// if node.capabilitiesDiscovery != nil {
+	// 	node.capabilitiesDiscovery.AdvertiseCapabilities(node.capabilities()...)
+	// }
+	return nil
 }
 
 func (node *AlgorandFullNode) capabilities() []p2p.Capability {
@@ -470,9 +468,9 @@ func (node *AlgorandFullNode) Stop() {
 	node.lowPriorityCryptoVerificationPool.Shutdown()
 	node.cryptoPool.Shutdown()
 	node.cancelCtx()
-	if node.capabilitiesDiscovery != nil {
-		node.capabilitiesDiscovery.Close()
-	}
+	// if node.capabilitiesDiscovery != nil {
+	// 	node.capabilitiesDiscovery.Close()
+	// }
 }
 
 // note: unlike the other two functions, this accepts a whole filename

--- a/tools/debug/algodump/main.go
+++ b/tools/debug/algodump/main.go
@@ -179,7 +179,11 @@ func main() {
 		*genesisID,
 		protocol.NetworkID(*networkID))
 	setDumpHandlers(n)
-	n.Start()
+	err := n.Start()
+	if err != nil {
+		log.Errorf("Failed to start network: %v", err)
+		return
+	}
 
 	for {
 		time.Sleep(time.Second)

--- a/tools/debug/transplanter/main.go
+++ b/tools/debug/transplanter/main.go
@@ -393,7 +393,11 @@ func main() {
 			os.Exit(1)
 		}
 
-		followerNode.Start()
+		err = followerNode.Start()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Cannot start follower node: %v", err)
+			os.Exit(1)
+		}
 
 		for followerNode.Ledger().Latest() < basics.Round(*roundStart) {
 			fmt.Printf("At round %d, waiting for %d\n", followerNode.Ledger().Latest(), *roundStart)


### PR DESCRIPTION
## Summary

1. Made code changes required to follow the algod's Services architecture: make + start as separate stages.
This is done by using `NoListenAddr` for p2p.Host and by providing an empty bootstrap callback to DHT.
When `net.Start()` is being called, manually calling `Listen` on p2p host, and unblock the `bootstrap callback` to return phonebook or DNS addresses for peering.
2. Also moved DHT init to netowork/p2p from node.
3. Changed `GossipNode.Start()` signature to return an error (and possibly explicitly abort node startup).

## Test Plan

1. Existing tests passed
2. Added DHT tests as part of p2p network