### PR TITLE
tests: custom recipe tweaks

### DIFF
--- a/test/testdata/deployednettemplates/generate-recipe/generate_network.py
+++ b/test/testdata/deployednettemplates/generate-recipe/generate_network.py
@@ -70,6 +70,7 @@ def build_net(template_path, netgoal_params):
 def build_genesis(template_path, netgoal_params, template_dict):
     args = [
         '-t', 'genesis',
+        '--last-part-key-round', str(100_000),
         '-o', f"{template_path}/generated/genesis.json"
     ]
     args.extend(netgoal_params)

--- a/test/testdata/deployednettemplates/recipes/custom/configs/node.json
+++ b/test/testdata/deployednettemplates/recipes/custom/configs/node.json
@@ -19,7 +19,7 @@
             "EnableMetrics": true,
             "MetricsURI": "{{MetricsURI}}",
             "ConfigJSONOverride": "{ \"TxPoolExponentialIncreaseFactor\": 1, \"DNSBootstrapID\": \"<network>.algodev.network\", \"DeadlockDetection\": -1, \"PeerPingPeriodSeconds\": 30, \"EnableAgreementReporting\": true, \"EnableAgreementTimeMetrics\": true, \"EnableAssembleStats\": true, \"EnableProcessBlockStats\": true, \"BaseLoggerDebugLevel\": 4, \"EnableProfiler\": true, \"EnableRuntimeMetrics\": true, \"CadaverSizeTarget\": 0 }",
-            "FractionApply": 0.01
+            "FractionApply": 0.1
         }
     ]
 }


### PR DESCRIPTION
## Summary

* Part nodes apply alt config at 10% rate (vs 1%) to let smaller networs reporting more telemetry
* Set LastPartKeyRound to 100k instead of 3M to speedup parts key generation

## Test Plan

Checked locally