### PR TITLE
txHandler: fix ARL triggering without ERL

### DIFF
--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -597,8 +597,10 @@ func (handler *TxHandler) processIncomingTxn(rawmsg network.IncomingMessage) net
 	var err error
 	var capguard *util.ErlCapacityGuard
 	var congested bool
-	if handler.erl != nil {
+	if handler.erl != nil || handler.appLimiter != nil {
 		congested = float64(cap(handler.backlogQueue))*handler.backlogCongestionThreshold < float64(len(handler.backlogQueue))
+	}
+	if handler.erl != nil {
 		// consume a capacity unit
 		// if the elastic rate limiter cannot vend a capacity, the error it returns
 		// is sufficient to indicate that we should enable Congestion Control, because


### PR DESCRIPTION
## Summary

While evaluating ARL after deployment I noticed the combo ERL=off ARL=on actually disables ARL as well. This fixes the configuration.

## Test Plan

Manually tested