### PR TITLE
network: fix TestSlowPeerDisconnection regression after #5634

### DIFF
--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -2567,8 +2567,8 @@ func TestSlowPeerDisconnection(t *testing.T) {
 		GenesisID: genesisID,
 		NetworkID: config.Devtestnet,
 	}
-	wn.broadcaster.slowWritingPeerMonitorInterval = time.Millisecond * 50
 	wn.setup()
+	wn.broadcaster.slowWritingPeerMonitorInterval = time.Millisecond * 50
 	wn.eventualReadyDelay = time.Second
 	wn.messagesOfInterest = nil // clear this before starting the network so that we won't be sending a MOI upon connection.
 


### PR DESCRIPTION
## Summary

[wsNetwork refactoring](https://github.com/algorand/go-algorand/pull/5634/files#diff-c19b4d9a8a60432019fd844b78b1cf5c332cd63f7841736907b7badc04f18a50R809) changed the `slowWritingPeerMonitorInterval` value in `TestSlowPeerDisconnection`: it got overwritten in `wn.setup` by 5s default value that caused test fail time to time when the wait time as a bit greater than 5s.

Failure examples: [one](https://app.circleci.com/pipelines/github/algorand/go-algorand/17413/workflows/2592bfee-5164-4b9e-8e96-4f69d89cb464/jobs/261408), [two](https://app.circleci.com/pipelines/github/algorand/go-algorand/17447/workflows/53dbd82a-e9df-438e-8650-8d4739bb9fa9/jobs/261732)

## Test Plan

This is a test fix.