### PR TITLE
tests: log all relay logs on e2e failure

### DIFF
--- a/netdeploy/network.go
+++ b/netdeploy/network.go
@@ -169,6 +169,16 @@ func (n Network) PrimaryDataDir() string {
 	panic(fmt.Errorf("neither relay directories nor node directories are defined for the network"))
 }
 
+// RelayDataDirs returns an array of relay data directories (not the nodes)
+func (n Network) RelayDataDirs() []string {
+	var directories []string
+	for _, dir := range n.cfg.RelayDirs {
+		directories = append(directories, n.getNodeFullPath(dir))
+	}
+	sort.Strings(directories)
+	return directories
+}
+
 // NodeDataDirs returns an array of node data directories (not the relays)
 func (n Network) NodeDataDirs() []string {
 	var directories []string

--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -317,7 +317,9 @@ func (f *LibGoalFixture) ShutdownImpl(preserveData bool) {
 	f.NC.StopKMD()
 	if preserveData {
 		f.network.Stop(f.binDir)
-		f.dumpLogs(filepath.Join(f.PrimaryDataDir(), "node.log"))
+		for _, relayDir := range f.RelayDataDirs() {
+			f.dumpLogs(filepath.Join(relayDir, "node.log"))
+		}
 		for _, nodeDir := range f.NodeDataDirs() {
 			f.dumpLogs(filepath.Join(nodeDir, "node.log"))
 		}
@@ -363,6 +365,11 @@ func (f *LibGoalFixture) failOnError(err error, message string) {
 // PrimaryDataDir returns the data directory for the PrimaryNode for the network
 func (f *LibGoalFixture) PrimaryDataDir() string {
 	return f.network.PrimaryDataDir()
+}
+
+// RelayDataDirs returns the relays data directories for the network (including the primary relay)
+func (f *LibGoalFixture) RelayDataDirs() []string {
+	return f.network.RelayDataDirs()
 }
 
 // NodeDataDirs returns the (non-Primary) data directories for the network


### PR DESCRIPTION
## Summary

Expose new `RelayDataDirs` method to save relays logs on e2e test failure.

## Test Plan

This is tests-related change.