### PR TITLE
AVM: Don't treat `any` as constant int in `loads`, `stores`

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1481,7 +1481,7 @@ func typeStores(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, er
 	// If the index of the scratch slot is a const
 	// we can modify only that scratch slots type
 	if top >= 1 {
-		if idx, isConst := pgm.stack[top-1].constant(); isConst {
+		if idx, isConst := pgm.stack[top-1].constInt(); isConst {
 			pgm.scratchSpace[idx] = pgm.stack[top]
 			return nil, nil, nil
 		}
@@ -1524,7 +1524,7 @@ func typeLoads(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, err
 		return nil, nil, nil
 	}
 
-	if val, isConst := pgm.stack[top].constant(); isConst {
+	if val, isConst := pgm.stack[top].constInt(); isConst {
 		return nil, StackTypes{pgm.scratchSpace[val]}, nil
 	}
 

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2950,6 +2950,22 @@ done:
 `, LogicVersion, exp(5, "concat arg 1 wanted type []byte..."))
 }
 
+func TestTypeTrackingRegression(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+	testProg(t, `
+callsub end	// wipes out initial program knowledge, makes scratch "any"
+label1:
+ load 1
+ byte 0x01
+ stores		// we had a bug in which the "any" seemed constant
+ load 0
+ load 0
+ +
+end:
+`, LogicVersion)
+}
+
 func TestMergeProtos(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -879,11 +879,11 @@ func (st StackType) widened() StackType {
 	}
 }
 
-func (st StackType) constant() (uint64, bool) {
-	if st.Bound[0] == st.Bound[1] {
-		return st.Bound[0], true
+func (st StackType) constInt() (uint64, bool) {
+	if st.AVMType != avmUint64 || st.Bound[0] != st.Bound[1] {
+		return 0, false
 	}
-	return 0, false
+	return st.Bound[0], true
 }
 
 // overlaps checks if there is enough overlap


### PR DESCRIPTION
When deciding how to propagate type into in `loads` and `stores` we sometimes thought we had a constant index to work with even when we didn't.

Regression unit test added.
