### PR TITLE
api: optimize /transactions/pending/{txid} endpoint

### DIFF
--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -657,8 +657,12 @@ func (l *Ledger) CheckDup(currentProto config.ConsensusParams, current basics.Ro
 	return l.txTail.checkDup(currentProto, current, firstValid, lastValid, txid, txl)
 }
 
-// CheckConfirmed return whether a transaction was confirmed in last up to MaxTxnLife rounds.
-func (l *Ledger) CheckConfirmed(txid transactions.Txid) (basics.Round, bool) {
+// CheckConfirmedTail checks if a transaction txid happens to have LastValid greater than the current round on time of calling and was committed to the ledger.
+// If both conditions are met it returns true.
+// This function could be used as filter to check if a transaction is committed to the ledger, and no extra checks needed if it says true.
+//
+// Note, this cannot be used to check if transaction happened or not in past MaxTxnLife rounds.
+func (l *Ledger) CheckConfirmedTail(txid transactions.Txid) (basics.Round, bool) {
 	return l.txTail.checkConfirmed(txid)
 }
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -657,7 +657,7 @@ func (l *Ledger) CheckDup(currentProto config.ConsensusParams, current basics.Ro
 	return l.txTail.checkDup(currentProto, current, firstValid, lastValid, txid, txl)
 }
 
-// CheckConfirmedTail checks if a transaction txid happens to have LastValid greater than the current round on time of calling and was committed to the ledger.
+// CheckConfirmedTail checks if a transaction txid happens to have LastValid greater than the current round at the time of calling and has been already committed to the ledger.
 // If both conditions are met it returns true.
 // This function could be used as filter to check if a transaction is committed to the ledger, and no extra checks needed if it says true.
 //

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -657,6 +657,11 @@ func (l *Ledger) CheckDup(currentProto config.ConsensusParams, current basics.Ro
 	return l.txTail.checkDup(currentProto, current, firstValid, lastValid, txid, txl)
 }
 
+// CheckConfirmed return whether a transaction was confirmed in last up to MaxTxnLife rounds.
+func (l *Ledger) CheckConfirmed(txid transactions.Txid) (basics.Round, bool) {
+	return l.txTail.checkConfirmed(txid)
+}
+
 // Latest returns the latest known block round added to the ledger.
 func (l *Ledger) Latest() basics.Round {
 	return l.blockQ.latest()

--- a/ledger/txtail.go
+++ b/ledger/txtail.go
@@ -184,7 +184,8 @@ func (t *txTail) loadFromDisk(l ledgerForTracker, dbRound basics.Round) error {
 			if lastValid < entry.rnd {
 				return fmt.Errorf("txTail: invalid lastValid %d / rnd %d for txid %s", lastValid, entry.rnd, entry.txid)
 			}
-			lastValueMap[entry.txid] = int16(lastValid - entry.rnd)
+			deltaR := int16(lastValid - entry.rnd)
+			lastValueMap[entry.txid] = deltaR
 		}
 		t.lastValid[lastValid] = lastValueMap
 	}
@@ -398,7 +399,7 @@ func (t *txTail) checkConfirmed(txid transactions.Txid) (basics.Round, bool) {
 
 	for lastValidRound, lastValid := range t.lastValid {
 		if deltaR, confirmed := lastValid[txid]; confirmed {
-			return lastValidRound + basics.Round(deltaR), true
+			return lastValidRound - basics.Round(deltaR), true
 		}
 	}
 	return 0, false

--- a/ledger/txtail_test.go
+++ b/ledger/txtail_test.go
@@ -112,13 +112,15 @@ func TestTxTailCheckdup(t *testing.T) {
 type txTailTestLedger struct {
 	Ledger
 	protoVersion protocol.ConsensusVersion
+	blocks       map[basics.Round]bookkeeping.Block
 }
 
 const testTxTailValidityRange = 200
 const testTxTailTxnPerRound = 150
+const testTxTailExtraRounds = 10
 
 func (t *txTailTestLedger) Latest() basics.Round {
-	return basics.Round(config.Consensus[t.protoVersion].MaxTxnLife + 10)
+	return basics.Round(config.Consensus[t.protoVersion].MaxTxnLife + testTxTailExtraRounds)
 }
 
 func (t *txTailTestLedger) BlockHdr(r basics.Round) (bookkeeping.BlockHeader, error) {
@@ -130,6 +132,10 @@ func (t *txTailTestLedger) BlockHdr(r basics.Round) (bookkeeping.BlockHeader, er
 }
 
 func (t *txTailTestLedger) Block(r basics.Round) (bookkeeping.Block, error) {
+	if bkl, found := t.blocks[r]; found {
+		return bkl, nil
+	}
+
 	blk := bookkeeping.Block{
 		BlockHeader: bookkeeping.BlockHeader{
 			UpgradeState: bookkeeping.UpgradeState{
@@ -142,6 +148,10 @@ func (t *txTailTestLedger) Block(r basics.Round) (bookkeeping.Block, error) {
 	for i := range blk.Payset {
 		blk.Payset[i] = makeTxTailTestTransaction(r, i)
 	}
+	if t.blocks == nil {
+		t.blocks = make(map[basics.Round]bookkeeping.Block)
+	}
+	t.blocks[r] = blk
 
 	return blk, nil
 }
@@ -328,6 +338,73 @@ func TestTxTailDeltaTracking(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTxTailCheckConfirmed(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	var ledger txTailTestLedger
+	txtail := txTail{}
+	protoVersion := protocol.ConsensusCurrentVersion
+	proto := config.Consensus[protoVersion]
+	require.NoError(t, ledger.initialize(t, protoVersion))
+	require.NoError(t, txtail.loadFromDisk(&ledger, ledger.Latest()))
+
+	// check all txids in blocks are in txTail as well
+	startRound := ledger.Latest() - basics.Round(proto.MaxTxnLife) + 1
+	// ensure block caching works
+	b1, err := ledger.Block(startRound)
+	require.NoError(t, err)
+	b2, err := ledger.Block(startRound)
+	require.NoError(t, err)
+	require.Equal(t, b1, b2)
+
+	for i := startRound; i <= ledger.Latest(); i++ {
+		blk, err := ledger.Block(i)
+		require.NoError(t, err)
+		for _, txn := range blk.Payset {
+			confirmedAt, found := txtail.checkConfirmed(txn.Txn.ID())
+			require.True(t, found, "failed to find txn at round %d (startRound=%d, latest=%d)", i, startRound, ledger.Latest())
+			require.Equal(t, basics.Round(i), confirmedAt)
+		}
+	}
+
+	rnd := ledger.Latest() + 1
+	lv := basics.Round(rnd + 50)
+	blk := bookkeeping.Block{
+		BlockHeader: bookkeeping.BlockHeader{
+			Round:     rnd,
+			TimeStamp: int64(rnd << 10),
+			UpgradeState: bookkeeping.UpgradeState{
+				CurrentProtocol: protoVersion,
+			},
+		},
+		Payset: make(transactions.Payset, 1),
+	}
+	sender := &basics.Address{}
+	sender[0] = byte(rnd)
+	sender[1] = byte(rnd >> 8)
+	sender[2] = byte(rnd >> 16)
+	blk.Payset[0].Txn.Sender = *sender
+	blk.Payset[0].Txn.FirstValid = rnd
+	blk.Payset[0].Txn.LastValid = lv
+	deltas := ledgercore.MakeStateDelta(&blk.BlockHeader, 0, 0, 0)
+	deltas.Txids[blk.Payset[0].Txn.ID()] = ledgercore.IncludedTransactions{
+		LastValid: lv,
+		Intra:     0,
+	}
+	deltas.AddTxLease(ledgercore.Txlease{Sender: blk.Payset[0].Txn.Sender, Lease: blk.Payset[0].Txn.Lease}, basics.Round(rnd+50))
+
+	txtail.newBlock(blk, deltas)
+	txtail.committedUpTo(basics.Round(rnd))
+
+	confirmedAt, found := txtail.checkConfirmed(blk.Payset[0].Txn.ID())
+	require.True(t, found)
+	require.Equal(t, basics.Round(rnd), confirmedAt)
+
+	confirmedAt, found = txtail.checkConfirmed(transactions.Txid{})
+	require.False(t, found)
+	require.Equal(t, basics.Round(0), confirmedAt)
 }
 
 // BenchmarkTxTailBlockHeaderCache adds 2M random blocks by calling

--- a/ledger/txtail_test.go
+++ b/ledger/txtail_test.go
@@ -350,16 +350,17 @@ func TestTxTailCheckConfirmed(t *testing.T) {
 	require.NoError(t, ledger.initialize(t, protoVersion))
 	require.NoError(t, txtail.loadFromDisk(&ledger, ledger.Latest()))
 
-	// check all txids in blocks are in txTail as well
+	// ensure block retrieval from txTailTestLedger works
 	startRound := ledger.Latest() - basics.Round(proto.MaxTxnLife) + 1
-	// ensure block caching works
 	b1, err := ledger.Block(startRound)
 	require.NoError(t, err)
 	b2, err := ledger.Block(startRound)
 	require.NoError(t, err)
 	require.Equal(t, b1, b2)
 
-	for i := startRound; i <= ledger.Latest(); i++ {
+	// check all txids in blocks are in txTail as well
+	// note, txtail does not store txids for transactions with lastValid < ledger.Latest()
+	for i := ledger.Latest() - testTxTailValidityRange + 1; i < ledger.Latest(); i++ {
 		blk, err := ledger.Block(i)
 		require.NoError(t, err)
 		for _, txn := range blk.Payset {


### PR DESCRIPTION
## Summary

* Use txtail data to find txid in memory (only txns with LastValid > current round) in addition to iterating blocks
* RPS: before: 10, after: 450
* Another optimization possible with caching blocks that would bump RPS to 30k
* It is possible to completely get rid of blocks iteration by one of the following:
   - Extend txtail to have MaxTxnLife old rounds. Requires lots of memory.
   - Make a new cache in AlgorandFullNode for txids: 26k txns/block * 1000 rounds => need 25 bits for all combos => 4 bytes (32bits) of txid instead of 32 bytes of a full txid would require 26M*4b = 100MB of RAM.
* Estimated extra memory footprint is 52MB = 26k txns/block * 1000 rounds * 2 bytes per round delta.

## Test Plan

Added unit test for new txtail logic