### PR TITLE
logic: allocate EvalContext from a mem pool

### DIFF
--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -868,7 +868,7 @@ byte "ALGO"
 	// check that actual app id ok instead of indirect reference
 	text = `int 100; txn ApplicationArgs 0; app_global_get_ex; int 1; ==; assert; byte "ALGO"; ==`
 	testApp(t, text, now)
-	testApp(t, text, pre, "App index 100 beyond") // but not in old teal
+	testApp(t, text, pre, "app index 100 beyond") // but not in old teal
 
 	// check app_global_get default value
 	text = "byte 0x414c474f55; app_global_get; int 0; =="
@@ -1074,7 +1074,7 @@ func testAssetsByVersion(t *testing.T, assetsTestProgram string, version uint64)
 	testApp(t, `byte "aoeuiaoeuiaoeuiaoeuiaoeuiaoeui02"; int 55; asset_holding_get AssetBalance; ==`, now, "invalid")
 
 	// for params get, presence in ForeignAssets has always be required
-	testApp(t, "int 5; asset_params_get AssetTotal", pre, "Asset index 5 beyond")
+	testApp(t, "int 5; asset_params_get AssetTotal", pre, "asset index 5 beyond")
 	testApp(t, "int 5; asset_params_get AssetTotal", now, "unavailable Asset 5")
 
 	params := basics.AssetParams{
@@ -1112,7 +1112,7 @@ func testAssetsByVersion(t *testing.T, assetsTestProgram string, version uint64)
 
 	if version < 5 {
 		// Can't run these with AppCreator anyway
-		testApp(t, strings.Replace(assetsTestProgram, "int 0//params", "int 55", -1), pre, "Asset index 55 beyond")
+		testApp(t, strings.Replace(assetsTestProgram, "int 0//params", "int 55", -1), pre, "asset index 55 beyond")
 		testApp(t, strings.Replace(assetsTestProgram, "int 55", "int 0", -1), pre, "err opcode")
 	}
 
@@ -3235,7 +3235,15 @@ func TestReturnTypes(t *testing.T) {
 
 				var cx *EvalContext
 				if m == ModeApp {
-					_, cx, err = EvalContract(ops.Program, 1, 300, aep)
+					cx = &EvalContext{
+						EvalParams: aep,
+						runMode:    ModeApp,
+						groupIndex: 1,
+						txn:        &aep.TxnGroup[1],
+						appID:      300,
+						Scratch:    &scratchSpace{},
+					}
+					_, cx, err = EvalContract(ops.Program, 1, 300, cx)
 				} else {
 					_, cx, err = EvalSignatureFull(1, sep)
 				}

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -5152,7 +5152,16 @@ func TestPcDetails(t *testing.T) {
 			ep, _, _ := makeSampleEnv()
 			ep.Trace = &strings.Builder{}
 
-			pass, cx, err := EvalContract(ops.Program, 0, 888, ep)
+			cx := &EvalContext{
+				EvalParams: ep,
+				runMode:    ModeApp,
+				groupIndex: 0,
+				txn:        &ep.TxnGroup[0],
+				appID:      888,
+				Scratch:    &scratchSpace{},
+			}
+
+			pass, cx, err := EvalContract(ops.Program, 0, 888, cx)
 			require.Error(t, err)
 			require.False(t, pass)
 			require.NotNil(t, cx) // cx comes back nil if we couldn't even run

--- a/data/transactions/logic/ledger_test.go
+++ b/data/transactions/logic/ledger_test.go
@@ -832,7 +832,15 @@ func (l *Ledger) appl(from basics.Address, appl transactions.ApplicationCallTxnF
 	if !ok {
 		return errors.New("No application")
 	}
-	pass, cx, err := EvalContract(params.ApprovalProgram, gi, aid, ep)
+	cx := &EvalContext{
+		EvalParams: ep,
+		runMode:    ModeApp,
+		groupIndex: gi,
+		txn:        &ep.TxnGroup[gi],
+		appID:      aid,
+		Scratch:    &scratchSpace{},
+	}
+	pass, cx, err := EvalContract(params.ApprovalProgram, gi, aid, cx)
 	if err != nil {
 		ad.EvalDelta = transactions.EvalDelta{}
 		return err

--- a/ledger/simple_test.go
+++ b/ledger/simple_test.go
@@ -61,7 +61,7 @@ func newSimpleLedgerFull(t testing.TB, balances bookkeeping.GenesisBalances, cv 
 	for _, opt := range opts {
 		opt(&slCfg)
 	}
-	genBlock, err := bookkeeping.MakeGenesisBlock(cv, balances, "test", genHash)
+	genBlock, err := bookkeeping.MakeGenesisBlock(cv, balances, t.Name(), genHash)
 	require.NoError(t, err)
 	require.False(t, genBlock.FeeSink.IsZero())
 	require.False(t, genBlock.RewardsPool.IsZero())

--- a/test/scripts/e2e_subs/e2e-app-x-app-reads.sh
+++ b/test/scripts/e2e_subs/e2e-app-x-app-reads.sh
@@ -21,7 +21,7 @@ APPID=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog ${DIR}/tealprogs
 
 # Creating an app that attempts to read APPID's global state without setting
 # foreignapps should fail
-EXPERR="App index 1 beyond txn.ForeignApps"
+EXPERR="app index 1 beyond txn.ForeignApps"
 RES=$(${gcmd} app create --creator ${ACCOUNT} --approval-prog ${DIR}/tealprogs/xappreads.teal --global-byteslices 0 --global-ints 0 --local-byteslices 0 --local-ints 0 --clear-prog <(printf '#pragma version 2\nint 1') 2>&1 || true)
 if [[ $RES != *"$EXPERR"* ]]; then
     date '+x-app-reads FAIL expected disallowed foreign global read to fail %Y%m%d_%H%M%S'


### PR DESCRIPTION
## Summary

* Apps (unlike logic signatures) are executed sequentially
* Every app txn execution requires EvalContext allocation
* Using sync.Pool shaves this overhead

Benchmark showed one less allocation per txn. Total `EvalContext` allocation was 22-28 per 10,000 txns evaluated/committed.

### Drawbacks

*  A little more complicated `EvalContext` creation and `scratchSpace` management. Not sure if one alloc is enough to justify it.
* A similar approach required for `EvalParams` since it alone is another a big source of allocations (and memory consumption).

## Test Plan

Existing tests should pass