### PR TITLE
Releases Page: remove indexer and point to github

### DIFF
--- a/scripts/release/mule/deploy/releases_page/generate_releases_page.py
+++ b/scripts/release/mule/deploy/releases_page/generate_releases_page.py
@@ -24,7 +24,7 @@ html_tpl = "html.tpl"
 # Nit: should be styles_file
 styles_url = "releases_page.css"
 # May want to call these channels instead
-tokens = ["stable", "beta", "indexer"]
+tokens = ["stable", "beta"]
 
 
 def get_stage_release_set(response):
@@ -201,7 +201,7 @@ def main():
     channels = {}
 
     # Should use tokens array instead
-    for channel in ["stable", "beta", "indexer"]:
+    for channel in ["stable", "beta"]:
         # Fetch contents of e.g. s3://algorand-dev-deb-repo/releases/beta/
         # Note: MaxKeys will limit to last 100 releases, which is more than
         # enough. Consider dropping this to 2.

--- a/scripts/release/mule/deploy/releases_page/html.tpl
+++ b/scripts/release/mule/deploy/releases_page/html.tpl
@@ -13,6 +13,15 @@
 <p>The public key for verifying RPMs is <a href="https://releases.algorand.com/rpm/rpm_algorand.pub">https://releases.algorand.com/rpm/rpm_algorand.pub</a></p>
 <p>The public key for verifying binaries out of our CI builds is <a href="https://releases.algorand.com/dev_ci_build.pub">https://releases.algorand.com/dev_ci_build.pub</a></p>
 
+<h2>Indexer/Conduit</h2>
+
+Use the CI Build key above to verify these binaries.
+
+<ul>
+<li><a href="https://github.com/algorand/conduit/releases/latest">Latest Conduit Release</a></li>
+<li><a href="https://github.com/algorand/indexer/releases/latest">Latest Indexer Release</a></li>
+</ul>
+
 <hr>
 
 <section id="algod">
@@ -29,13 +38,6 @@
 </section>
 
 <hr>
-
-<section id="indexer">
-<h1>Indexer releases</h1>
-<table><tr><th>File</th><th>Bytes</th><th>GPG Signature</th></tr>
-{indexer}
-</table>
-</section>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary

The old calculation for this was deprecated, and was showing outdated indexer entries. Removed these and am pointing direct to Github Releases.

## Test Plan

Ran `generate_releases_page.py` locally to verify it built a new page.

