### PR TITLE
Config: Archival mode is no longer automatically enabled when netAddress is s…

### DIFF
--- a/cmd/algocfg/profileCommand.go
+++ b/cmd/algocfg/profileCommand.go
@@ -69,7 +69,9 @@ var (
 	relay = configUpdater{
 		description: "Relay consensus messages across the network and support catchup.",
 		updateFunc: func(cfg config.Local) config.Local {
-			cfg.Archival = true
+			cfg.MaxBlockHistoryLookback = 20000
+			cfg.CatchpointFileHistoryLength = 3
+			cfg.CatchpointTracking = 2
 			cfg.EnableLedgerService = true
 			cfg.EnableBlockService = true
 			cfg.NetAddress = ":4160"

--- a/config/config.go
+++ b/config/config.go
@@ -145,10 +145,7 @@ func mergeConfigFromFile(configpath string, source Local) (Local, error) {
 
 	err = loadConfig(f, &source)
 
-	// For now, all relays (listening for incoming connections) are also Archival
-	// We can change this logic in the future, but it's currently the sanest default.
 	if source.NetAddress != "" {
-		source.Archival = true
 		source.EnableLedgerService = true
 		source.EnableBlockService = true
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -112,7 +112,8 @@ func TestLocal_MergeConfig(t *testing.T) {
 	c2, err := mergeConfigFromDir(tempDir, defaultConfig)
 
 	require.NoError(t, err)
-	require.Equal(t, defaultConfig.Archival || c1.NetAddress != "", c2.Archival)
+	require.Equal(t, defaultConfig.EnableLedgerService || c1.NetAddress != "", c2.EnableLedgerService)
+	require.Equal(t, defaultConfig.EnableBlockService || c1.NetAddress != "", c2.EnableBlockService)
 	require.Equal(t, defaultConfig.IncomingConnectionsLimit, c2.IncomingConnectionsLimit)
 	require.Equal(t, defaultConfig.BaseLoggerDebugLevel, c2.BaseLoggerDebugLevel)
 
@@ -163,50 +164,6 @@ func TestLoadPhonebookMissing(t *testing.T) {
 	tempDir := t.TempDir()
 	_, err := LoadPhonebook(tempDir)
 	require.True(t, os.IsNotExist(err))
-}
-
-func TestArchivalIfRelay(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-
-	testArchivalIfRelay(t, true)
-}
-
-func TestArchivalIfNotRelay(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-
-	testArchivalIfRelay(t, false)
-}
-
-func testArchivalIfRelay(t *testing.T, relay bool) {
-	tempDir := t.TempDir()
-
-	c1 := struct {
-		NetAddress string
-	}{}
-	if relay {
-		c1.NetAddress = ":1234"
-	}
-
-	// write our reduced version of the Local struct
-	fileToMerge := filepath.Join(tempDir, ConfigFilename)
-	f, err := os.OpenFile(fileToMerge, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
-	if err == nil {
-		enc := json.NewEncoder(f)
-		err = enc.Encode(c1)
-		f.Close()
-	}
-	require.NoError(t, err)
-	require.False(t, defaultConfig.Archival, "Default should be non-archival")
-
-	c2, err := mergeConfigFromDir(tempDir, defaultConfig)
-	require.NoError(t, err)
-	if relay {
-		require.True(t, c2.Archival, "Relay should be archival")
-	} else {
-		require.False(t, c2.Archival, "Non-relay should still be non-archival")
-	}
 }
 
 func TestLocal_ConfigExampleIsCorrect(t *testing.T) {

--- a/test/e2e-go/cli/goal/expect/catchpointCatchupTest.exp
+++ b/test/e2e-go/cli/goal/expect/catchpointCatchupTest.exp
@@ -6,7 +6,7 @@ log_user 1
 #
 # The goal of the test is to demonstrate the catchpoint catchup functionality using the goal command line interface.
 # It does that by deploying a single relay, which advances until it generates a catchpoint.
-# Once it does, another node is started, and instructred to catchup using the catchpoint from the first relay.
+# Once it does, another node is started, and instructed to catchup using the catchpoint from the first relay.
 # To make sure that the second node won't be using the "regular" catchup, we tunnel all the communication between the two using a proxy.
 # The proxy is responsible to filter out block number 2. This would prevent the "regular" catchup from working,
 # and would be a good test ground for the catchpoint catchup.
@@ -64,7 +64,7 @@ if { [catch {
     ::AlgorandGoal::CreateNetwork $NETWORK_NAME $NETWORK_TEMPLATE $TEST_ALGO_DIR $TEST_ROOT_DIR
 
     # Update the Primary Node configuration
-    exec -- cat "$TEST_ROOT_DIR/Primary/config.json" | jq {. |= . + {"MaxAcctLookback": 2, "CatchpointInterval": 4,"EnableRequestLogger":true}} > $TEST_ROOT_DIR/Primary/config.json.new
+    exec -- cat "$TEST_ROOT_DIR/Primary/config.json" | jq {. |= . + {"MaxAcctLookback": 2, "CatchpointInterval": 4,"EnableRequestLogger":true,"Archival":true}} > $TEST_ROOT_DIR/Primary/config.json.new
     exec rm $TEST_ROOT_DIR/Primary/config.json
     exec mv $TEST_ROOT_DIR/Primary/config.json.new $TEST_ROOT_DIR/Primary/config.json
 


### PR DESCRIPTION


<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Archival mode is no longer automatically enabled when netAddress is set in configuration (allowing for non-archival relays). Updated relay profile to reflect more ideal non-archival relay properties (number of catchpoints retained, 20k block history lookback, etc.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Existing tests should pass.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
