### PR TITLE
API: Make maps the right size from the start

### DIFF
--- a/data/pools/statusCache.go
+++ b/data/pools/statusCache.go
@@ -52,7 +52,7 @@ func (sc *statusCache) check(txid transactions.Txid) (tx transactions.SignedTxn,
 func (sc *statusCache) put(tx transactions.SignedTxn, txErr string) {
 	if len(sc.cur) >= sc.sz {
 		sc.prev = sc.cur
-		sc.cur = map[transactions.Txid]statusCacheEntry{}
+		sc.cur = make(map[transactions.Txid]statusCacheEntry, sc.sz)
 	}
 
 	sc.cur[tx.ID()] = statusCacheEntry{
@@ -62,6 +62,6 @@ func (sc *statusCache) put(tx transactions.SignedTxn, txErr string) {
 }
 
 func (sc *statusCache) reset() {
-	sc.cur = map[transactions.Txid]statusCacheEntry{}
-	sc.prev = map[transactions.Txid]statusCacheEntry{}
+	sc.cur = make(map[transactions.Txid]statusCacheEntry, sc.sz)
+	sc.prev = make(map[transactions.Txid]statusCacheEntry, sc.sz)
 }

--- a/data/pools/statusCache.go
+++ b/data/pools/statusCache.go
@@ -63,5 +63,5 @@ func (sc *statusCache) put(tx transactions.SignedTxn, txErr string) {
 
 func (sc *statusCache) reset() {
 	sc.cur = make(map[transactions.Txid]statusCacheEntry, sc.sz)
-	sc.prev = make(map[transactions.Txid]statusCacheEntry, sc.sz)
+	sc.prev = nil
 }


### PR DESCRIPTION
Should be a tiny gain. It bothered me that we knew the size and didn't use it.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
