### PR TITLE
netgoal: Use --last-part-key-round when generating a goalnet template

### DIFF
--- a/cmd/netgoal/generate.go
+++ b/cmd/netgoal/generate.go
@@ -475,6 +475,9 @@ func saveTemplateToDisk(template remote.DeployedNetworkConfig, filename string) 
 }
 
 func saveGoalTemplateToDisk(template netdeploy.NetworkTemplate, filename string) error {
+	if lastPartKeyRound != 0 {
+		template.Genesis.LastPartKeyRound = lastPartKeyRound
+	}
 	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err == nil {
 		defer f.Close()


### PR DESCRIPTION
Whenever I've generated a goalnet template using `netgoal` I have to manually modify the `LastPartKeyRound` value from 3000000 to something like 10000, depsite using the `--last-part-key-round` argument in the command.
Example:
```sh
netgoal generate -n 1 -R 0 -w 4 --last-part-key-round 10000 -t goalnet -r tmpnet -o tmpnet.json
goal network create -t tmpnet.json -n tmpnet --start -r tmpnet
```
This fix works in the same way generating a genesis template works. I've no idea how many people use this, but it's a nice quick QOL update for me.