### PR TITLE
Tests: Adjust catchup e2e tests for non-archival relays

### DIFF
--- a/netdeploy/networkTemplate.go
+++ b/netdeploy/networkTemplate.go
@@ -321,6 +321,8 @@ func createConfigFile(node remote.NodeConfigGoal, configFile string, numNodes in
 	if node.IsRelay {
 		// Have relays listen on any localhost port
 		cfg.NetAddress = "127.0.0.1:0"
+		// For test purposes, having relays keep all blocks (archival mode)
+		cfg.Archival = true
 	} else {
 		// Non-relays should not open incoming connections
 		cfg.IncomingConnectionsLimit = 0

--- a/netdeploy/networkTemplate.go
+++ b/netdeploy/networkTemplate.go
@@ -321,8 +321,9 @@ func createConfigFile(node remote.NodeConfigGoal, configFile string, numNodes in
 	if node.IsRelay {
 		// Have relays listen on any localhost port
 		cfg.NetAddress = "127.0.0.1:0"
-		// For test purposes, having relays keep all blocks (archival mode)
-		cfg.Archival = true
+
+		cfg.Archival = false                // make it explicit non-archival
+		cfg.MaxBlockHistoryLookback = 20000 // to save blocks beyond MaxTxnLife=13
 	} else {
 		// Non-relays should not open incoming connections
 		cfg.IncomingConnectionsLimit = 0

--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -126,6 +126,10 @@ func configureCatchpointGeneration(a *require.Assertions, nodeController *nodeco
 	a.NoError(err)
 
 	cfg.CatchpointInterval = basicTestCatchpointInterval
+	cfg.Archival = false                 // make it explicit non-archival
+	cfg.MaxBlockHistoryLookback = 20000  // to save blocks beyond MaxTxnLife=13
+	cfg.CatchpointTracking = 2           // to enable catchpoints on non-archival nodes
+	cfg.CatchpointFileHistoryLength = 30 // to store more than 2 default catchpoints
 	cfg.MaxAcctLookback = 2
 	err = cfg.SaveToDisk(nodeController.GetDataDir())
 	a.NoError(err)
@@ -383,7 +387,6 @@ func TestCatchpointLabelGeneration(t *testing.T) {
 		expectLabels       bool
 	}{
 		{4, true, true},
-		{4, false, true},
 		{0, true, false},
 	}
 
@@ -495,7 +498,10 @@ func TestNodeTxHandlerRestart(t *testing.T) {
 	cfg, err := config.LoadConfigFromDisk(primaryNode.GetDataDir())
 	a.NoError(err)
 	cfg.MaxAcctLookback = 2
-	cfg.Archival = false
+	cfg.Archival = false                 // make it explicit non-archival
+	cfg.MaxBlockHistoryLookback = 20000  // to save blocks beyond MaxTxnLife=13
+	cfg.CatchpointTracking = 2           // to enable catchpoints on non-archival nodes
+	cfg.CatchpointFileHistoryLength = 30 // to store more than 2 default catchpoints
 
 	cfg.TxSyncIntervalSeconds = 200000 // disable txSync
 
@@ -506,8 +512,11 @@ func TestNodeTxHandlerRestart(t *testing.T) {
 	a.NoError(err)
 	const catchpointInterval = 16
 	cfg.CatchpointInterval = catchpointInterval
-	cfg.CatchpointTracking = 2
-	cfg.TxSyncIntervalSeconds = 200000 // disable txSync
+	cfg.Archival = false                 // make it explicit non-archival
+	cfg.MaxBlockHistoryLookback = 20000  // to save blocks beyond MaxTxnLife=13
+	cfg.CatchpointTracking = 2           // to enable catchpoints on non-archival nodes
+	cfg.CatchpointFileHistoryLength = 30 // to store more than 2 default catchpoints
+	cfg.TxSyncIntervalSeconds = 200000   // disable txSync
 	cfg.SaveToDisk(relayNode.GetDataDir())
 
 	fixture.Start()
@@ -612,8 +621,11 @@ func TestReadyEndpoint(t *testing.T) {
 	a.NoError(err)
 	const catchpointInterval = 16
 	cfg.CatchpointInterval = catchpointInterval
-	cfg.CatchpointTracking = 2
-	cfg.TxSyncIntervalSeconds = 200000 // disable txSync
+	cfg.Archival = false                 // make it explicit non-archival
+	cfg.MaxBlockHistoryLookback = 20000  // to save blocks beyond MaxTxnLife=13
+	cfg.CatchpointTracking = 2           // to enable catchpoints on non-archival nodes
+	cfg.CatchpointFileHistoryLength = 30 // to store more than 2 default catchpoints
+	cfg.TxSyncIntervalSeconds = 200000   // disable txSync
 	cfg.SaveToDisk(relayNode.GetDataDir())
 
 	fixture.Start()

--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -498,10 +498,7 @@ func TestNodeTxHandlerRestart(t *testing.T) {
 	cfg, err := config.LoadConfigFromDisk(primaryNode.GetDataDir())
 	a.NoError(err)
 	cfg.MaxAcctLookback = 2
-	cfg.Archival = false                 // make it explicit non-archival
-	cfg.MaxBlockHistoryLookback = 20000  // to save blocks beyond MaxTxnLife=13
-	cfg.CatchpointTracking = 2           // to enable catchpoints on non-archival nodes
-	cfg.CatchpointFileHistoryLength = 30 // to store more than 2 default catchpoints
+	cfg.Archival = false
 
 	cfg.TxSyncIntervalSeconds = 200000 // disable txSync
 


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
Adjust catchup e2e tests for no longer default enabling archival with netAddress.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan
Existing tests should pass.
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
