### PR TITLE
Config: Set relay profile's MaxBalanceHistoryLookback to 22000

### DIFF
--- a/cmd/algocfg/profileCommand.go
+++ b/cmd/algocfg/profileCommand.go
@@ -69,7 +69,7 @@ var (
 	relay = configUpdater{
 		description: "Relay consensus messages across the network and support catchup.",
 		updateFunc: func(cfg config.Local) config.Local {
-			cfg.MaxBlockHistoryLookback = 20000
+			cfg.MaxBlockHistoryLookback = 22000 // Enough to support 2 catchpoints with some wiggle room for nodes to catch up from the older one
 			cfg.CatchpointFileHistoryLength = 3
 			cfg.CatchpointTracking = 2
 			cfg.EnableLedgerService = true


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Set relay profile's MaxBalanceHistoryLookback to 22000 to better support catchup from the two latest catchpoints.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Existing tests pass.
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
