### PR TITLE
p2p: enable p2p http txsync

### DIFF
--- a/components/mocks/mockNetwork.go
+++ b/components/mocks/mockNetwork.go
@@ -18,6 +18,7 @@ package mocks
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 
@@ -76,11 +77,6 @@ func (network *MockNetwork) GetPeers(options ...network.PeerOption) []network.Pe
 	return nil
 }
 
-// GetRoundTripper -- returns the network round tripper
-func (network *MockNetwork) GetRoundTripper(peer network.Peer) http.RoundTripper {
-	return http.DefaultTransport
-}
-
 // Ready - always ready
 func (network *MockNetwork) Ready() chan struct{} {
 	c := make(chan struct{})
@@ -114,4 +110,9 @@ func (network *MockNetwork) GetGenesisID() string {
 		return "mocknet"
 	}
 	return network.GenesisID
+}
+
+// GetHTTPClient returns a http.Client with a suitable for the network
+func (network *MockNetwork) GetHTTPClient(p network.HTTPPeer) (*http.Client, error) {
+	return nil, errors.New("not implemented")
 }

--- a/network/addr_test.go
+++ b/network/addr_test.go
@@ -89,10 +89,12 @@ func TestParseHostOrURL(t *testing.T) {
 		t.Run(addr, func(t *testing.T) {
 			_, err := ParseHostOrURL(addr)
 			require.Error(t, err, "url should fail", addr)
+			require.False(t, IsMultiaddr(addr))
 		})
 		t.Run(addr+"-multiaddr", func(t *testing.T) {
 			_, err := ParseHostOrURLOrMultiaddr(addr)
 			require.Error(t, err, "url should fail", addr)
+			require.False(t, IsMultiaddr(addr))
 		})
 	}
 

--- a/network/gossipNode.go
+++ b/network/gossipNode.go
@@ -83,8 +83,9 @@ type GossipNode interface {
 	// ClearHandlers deregisters all the existing message handlers.
 	ClearHandlers()
 
-	// GetRoundTripper returns a Transport that would limit the number of outgoing connections.
-	GetRoundTripper(peer Peer) http.RoundTripper
+	// GetHTTPClient returns a http.Client with a suitable for the network Transport
+	// that would also limit the number of outgoing connections.
+	GetHTTPClient(peer HTTPPeer) (*http.Client, error)
 
 	// OnNetworkAdvance notifies the network library that the agreement protocol was able to make a notable progress.
 	// this is the only indication that we have that we haven't formed a clique, where all incoming messages

--- a/network/hybridNetwork.go
+++ b/network/hybridNetwork.go
@@ -180,14 +180,14 @@ func (n *HybridP2PNetwork) ClearHandlers() {
 	n.wsNetwork.ClearHandlers()
 }
 
-// GetRoundTripper returns a Transport that would limit the number of outgoing connections.
-func (n *HybridP2PNetwork) GetRoundTripper(peer Peer) http.RoundTripper {
-	// TODO today this is used by HTTPTxSync.Sync after calling GetPeers(network.PeersPhonebookRelays)
-	switch p := peer.(type) {
+// GetHTTPClient returns a http.Client with a suitable for the network Transport
+// that would also limit the number of outgoing connections.
+func (n *HybridP2PNetwork) GetHTTPClient(peer HTTPPeer) (*http.Client, error) {
+	switch peer.(type) {
 	case *wsPeer:
-		return p.net.GetRoundTripper(peer)
-	case gossipSubPeer:
-		return p.net.GetRoundTripper(peer)
+		return n.wsNetwork.GetHTTPClient(peer)
+	case *wsPeerCore:
+		return n.p2pNetwork.GetHTTPClient(peer)
 	default:
 		panic("unrecognized peer type")
 	}

--- a/network/p2p/capabilities_test.go
+++ b/network/p2p/capabilities_test.go
@@ -98,7 +98,7 @@ func setupDHTHosts(t *testing.T, numHosts int) []*dht.IpfsDHT {
 		require.NoError(t, err)
 		// this is a workaround for the following issue
 		// "failed to negotiate security protocol: error reading handshake message: noise: message is too short"
-		// it appears simultenous connectino attempts (dht.New() attempts to connect) causes this handshake error.
+		// it appears simultaneous connection attempts (dht.New() attempts to connect) causes this handshake error.
 		// https://github.com/libp2p/go-libp2p-noise/issues/70
 		time.Sleep(200 * time.Millisecond)
 
@@ -158,7 +158,7 @@ func setupCapDiscovery(t *testing.T, numHosts int, numBootstrapPeers int) []*Cap
 		require.NoError(t, err)
 		// this is a workaround for the following issue
 		// "failed to negotiate security protocol: error reading handshake message: noise: message is too short"
-		// it appears simultenous connectino attempts (dht.New() attempts to connect) causes this handshake error.
+		// it appears simultaneous connection attempts (dht.New() attempts to connect) causes this handshake error.
 		// https://github.com/libp2p/go-libp2p-noise/issues/70
 		time.Sleep(200 * time.Millisecond)
 

--- a/network/p2p/http.go
+++ b/network/p2p/http.go
@@ -30,12 +30,14 @@ import (
 // algorandP2pHTTPProtocol defines a libp2p protocol name for algorand's http over p2p messages
 const algorandP2pHTTPProtocol = "/algorand-http/1.0.0"
 
+// HTTPServer is a wrapper around libp2phttp.Host that allows registering http handlers with path parameters.
 type HTTPServer struct {
 	libp2phttp.Host
 	p2phttpMux              *mux.Router
 	p2phttpMuxRegistrarOnce sync.Once
 }
 
+// MakeHTTPServer creates a new HTTPServer
 func MakeHTTPServer(streamHost host.Host) *HTTPServer {
 	httpServer := HTTPServer{
 		Host:       libp2phttp.Host{StreamHost: streamHost},
@@ -44,6 +46,7 @@ func MakeHTTPServer(streamHost host.Host) *HTTPServer {
 	return &httpServer
 }
 
+// RegisterHTTPHandler registers a http handler with a given path.
 func (s *HTTPServer) RegisterHTTPHandler(path string, handler http.Handler) {
 	s.p2phttpMux.Handle(path, handler)
 	s.p2phttpMuxRegistrarOnce.Do(func() {

--- a/network/p2p/http.go
+++ b/network/p2p/http.go
@@ -32,8 +32,8 @@ const algorandP2pHTTPProtocol = "/algorand-http/1.0.0"
 
 type HTTPServer struct {
 	libp2phttp.Host
-	p2phttpMux             *mux.Router
-	p2phttpMuxRegistarOnce sync.Once
+	p2phttpMux              *mux.Router
+	p2phttpMuxRegistrarOnce sync.Once
 }
 
 func MakeHTTPServer(streamHost host.Host) *HTTPServer {
@@ -46,12 +46,12 @@ func MakeHTTPServer(streamHost host.Host) *HTTPServer {
 
 func (s *HTTPServer) RegisterHTTPHandler(path string, handler http.Handler) {
 	s.p2phttpMux.Handle(path, handler)
-	s.p2phttpMuxRegistarOnce.Do(func() {
+	s.p2phttpMuxRegistrarOnce.Do(func() {
 		s.Host.SetHTTPHandlerAtPath(algorandP2pHTTPProtocol, "/", s.p2phttpMux)
 	})
 }
 
-// MakeHTTPClient creates a http.Client that uses libp2p transport for a goven protocol and peer address.
+// MakeHTTPClient creates a http.Client that uses libp2p transport for a given protocol and peer address.
 func MakeHTTPClient(addrInfo *peer.AddrInfo) (*http.Client, error) {
 	clientStreamHost, err := libp2p.New(libp2p.NoListenAddrs)
 	if err != nil {

--- a/network/p2p/http.go
+++ b/network/p2p/http.go
@@ -25,10 +25,10 @@ import (
 )
 
 // MakeHTTPClient creates a http.Client that uses libp2p transport for a goven protocol and peer address.
-func MakeHTTPClient(protocolID string, addrInfo peer.AddrInfo) (http.Client, error) {
+func MakeHTTPClient(protocolID string, addrInfo *peer.AddrInfo) (*http.Client, error) {
 	clientStreamHost, err := libp2p.New(libp2p.NoListenAddrs)
 	if err != nil {
-		return http.Client{}, err
+		return nil, err
 	}
 
 	client := libp2phttp.Host{StreamHost: clientStreamHost}
@@ -37,10 +37,10 @@ func MakeHTTPClient(protocolID string, addrInfo peer.AddrInfo) (http.Client, err
 	// to make a NamespaceRoundTripper that limits to specific URL paths.
 	// First, we do not want make requests when listing peers (the main MakeHTTPClient invoker).
 	// Secondly, this makes unit testing easier - no need to register fake handlers.
-	rt, err := client.NewConstrainedRoundTripper(addrInfo)
+	rt, err := client.NewConstrainedRoundTripper(*addrInfo)
 	if err != nil {
-		return http.Client{}, err
+		return nil, err
 	}
 
-	return http.Client{Transport: rt}, nil
+	return &http.Client{Transport: rt}, nil
 }

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -75,9 +75,6 @@ type serviceImpl struct {
 // AlgorandWsProtocol defines a libp2p protocol name for algorand's websockets messages
 const AlgorandWsProtocol = "/algorand-ws/1.0.0"
 
-// AlgorandP2pHTTPProtocol defines a libp2p protocol name for algorand's http over p2p messages
-const AlgorandP2pHTTPProtocol = "/algorand-http/1.0.0"
-
 const dialTimeout = 30 * time.Second
 
 // MakeHost creates a libp2p host but does not start listening.

--- a/network/p2p/streams.go
+++ b/network/p2p/streams.go
@@ -80,7 +80,7 @@ func (n *streamManager) streamHandler(stream network.Stream) {
 				if stream.Stat().Direction == network.DirUnknown {
 					n.log.Warnf("Unknown direction for a steam %s to/from %s", stream.ID(), remotePeer)
 				} else {
-					n.log.Warnf("Unexpected outgoing sream in streamHandler for connection %s (%s): %s vs %s stream", stream.Conn().ID(), remotePeer, stream.Conn().Stat().Direction, stream.Stat().Direction.String())
+					n.log.Warnf("Unexpected outgoing stream in streamHandler for connection %s (%s): %s vs %s stream", stream.Conn().ID(), remotePeer, stream.Conn().Stat().Direction, stream.Stat().Direction.String())
 				}
 			}
 			n.handler(n.ctx, remotePeer, stream, incoming)
@@ -98,7 +98,7 @@ func (n *streamManager) streamHandler(stream network.Stream) {
 		if stream.Stat().Direction == network.DirUnknown {
 			n.log.Warnf("streamHandler: unknown direction for a steam %s to/from %s", stream.ID(), remotePeer)
 		} else {
-			n.log.Warnf("Unexpected outgoing sream in streamHandler for connection %s (%s): %s vs %s stream", stream.Conn().ID(), remotePeer, stream.Conn().Stat().Direction, stream.Stat().Direction.String())
+			n.log.Warnf("Unexpected outgoing stream in streamHandler for connection %s (%s): %s vs %s stream", stream.Conn().ID(), remotePeer, stream.Conn().Stat().Direction, stream.Stat().Direction.String())
 		}
 	}
 	n.handler(n.ctx, remotePeer, stream, incoming)
@@ -141,7 +141,7 @@ func (n *streamManager) Connected(net network.Network, conn network.Conn) {
 	// a new stream created above, expected direction is outbound
 	incoming := stream.Stat().Direction == network.DirInbound
 	if incoming {
-		n.log.Warnf("Unexpected incoming sream in streamHandler for connection %s (%s): %s vs %s stream", stream.Conn().ID(), remotePeer, stream.Conn().Stat().Direction, stream.Stat().Direction.String())
+		n.log.Warnf("Unexpected incoming stream in streamHandler for connection %s (%s): %s vs %s stream", stream.Conn().ID(), remotePeer, stream.Conn().Stat().Direction, stream.Stat().Direction.String())
 	} else {
 		if stream.Stat().Direction == network.DirUnknown {
 			n.log.Warnf("Connected: unknown direction for a steam %s to/from %s", stream.ID(), remotePeer)

--- a/network/p2p/testing/httpNode.go
+++ b/network/p2p/testing/httpNode.go
@@ -1,0 +1,101 @@
+// Copyright (C) 2019-2024 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+// This package wraps and re-exports the libp2p functions on order to keep
+// all go-libp2p imports in one place.
+
+package p2p
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/algorand/go-algorand/components/mocks"
+	"github.com/algorand/go-algorand/network"
+	"github.com/algorand/go-algorand/network/p2p"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+)
+
+type P2PHTTPNode struct {
+	mocks.MockNetwork
+	host.Host
+	httpServer *p2p.HTTPServer
+	peers      []network.Peer
+	tb         testing.TB
+	genesisID  string
+}
+
+// MakeP2PHost returns a new libp2p host.
+func MakeP2PHTTPNode(tb testing.TB) *P2PHTTPNode {
+	p2pHost, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(tb, err)
+
+	return &P2PHTTPNode{
+		Host:       p2pHost,
+		httpServer: p2p.MakeHTTPServer(p2pHost),
+		tb:         tb,
+	}
+}
+
+func (p *P2PHTTPNode) RegisterHTTPHandler(path string, handler http.Handler) {
+	p.httpServer.RegisterHTTPHandler(path, handler)
+}
+
+func (p *P2PHTTPNode) RegisterHandlers(dispatch []network.TaggedMessageHandler) {}
+
+func (p *P2PHTTPNode) Start() error {
+	go p.httpServer.Serve()
+	return nil
+}
+
+func (p *P2PHTTPNode) Stop() {
+	p.httpServer.Close()
+	p.Host.Close()
+}
+
+func (p *P2PHTTPNode) GetGenesisID() string          { return p.genesisID }
+func (p *P2PHTTPNode) SetGenesisID(genesisID string) { p.genesisID = genesisID }
+
+type httpPeer struct {
+	addrInfo peer.AddrInfo
+	tb       testing.TB
+}
+
+func (p httpPeer) GetAddress() string {
+	mas, err := peer.AddrInfoToP2pAddrs(&p.addrInfo)
+	require.NoError(p.tb, err)
+	require.Len(p.tb, mas, 1)
+	return mas[0].String()
+}
+
+func (p httpPeer) GetHTTPClient() *http.Client {
+	c, err := p2p.MakeHTTPClient(&p.addrInfo)
+	require.NoError(p.tb, err)
+	return c
+}
+
+func (p *P2PHTTPNode) SetPeers(other *P2PHTTPNode) {
+	addrInfo := peer.AddrInfo{ID: other.ID(), Addrs: other.Addrs()}
+	httpPeer := httpPeer{addrInfo, p.tb}
+	p.peers = append(p.peers, httpPeer)
+}
+
+func (p *P2PHTTPNode) GetPeers(options ...network.PeerOption) []network.Peer {
+	return p.peers
+}

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -469,7 +469,7 @@ func (n *P2PNetwork) GetPeers(options ...PeerOption) []Peer {
 			n.wsPeersLock.RUnlock()
 
 		case PeersPhonebookArchivalNodes:
-			// query known archvial nodes from DHT if enabled
+			// query known archival nodes from DHT if enabled
 			if n.config.EnableDHTProviders {
 				const nodesToFind = 5
 				info, err := n.capabilitiesDiscovery.PeersForCapability(p2p.Archival, nodesToFind)

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -38,6 +38,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	libp2phttp "github.com/libp2p/go-libp2p/p2p/http"
+	"github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
 )
 
@@ -500,7 +501,7 @@ func (n *P2PNetwork) GetPeers(options ...PeerOption) []Peer {
 						continue
 					}
 					addr := mas[0].String()
-					client, err := p2p.MakeHTTPClient(p2p.AlgorandP2pHTTPProtocol, addrInfo)
+					client, err := p2p.MakeHTTPClient(p2p.AlgorandP2pHTTPProtocol, &info)
 					if err != nil {
 						n.log.Warnf("MakeHTTPClient failed: %v", err)
 						continue
@@ -552,9 +553,14 @@ func (n *P2PNetwork) ClearHandlers() {
 	n.handler.ClearHandlers([]Tag{})
 }
 
-// GetRoundTripper returns a Transport that would limit the number of outgoing connections.
-func (n *P2PNetwork) GetRoundTripper(peer Peer) http.RoundTripper {
-	return http.DefaultTransport
+// GetHTTPClient returns a http.Client with a suitable for the network Transport
+// that would also limit the number of outgoing connections.
+func (n *P2PNetwork) GetHTTPClient(p HTTPPeer) (*http.Client, error) {
+	addrInfo, err := peer.AddrInfoFromString(p.GetAddress())
+	if err != nil {
+		return nil, err
+	}
+	return p2p.MakeHTTPClient(p2p.AlgorandP2pHTTPProtocol, addrInfo)
 }
 
 // OnNetworkAdvance notifies the network library that the agreement protocol was able to make a notable progress.
@@ -569,7 +575,7 @@ func (n *P2PNetwork) GetHTTPRequestConnection(request *http.Request) (conn net.C
 
 // wsStreamHandler is a callback that the p2p package calls when a new peer connects and establishes a
 // stream for the websocket protocol.
-func (n *P2PNetwork) wsStreamHandler(ctx context.Context, peer peer.ID, stream network.Stream, incoming bool) {
+func (n *P2PNetwork) wsStreamHandler(ctx context.Context, p2ppeer peer.ID, stream network.Stream, incoming bool) {
 	if stream.Protocol() != p2p.AlgorandWsProtocol {
 		n.log.Warnf("unknown protocol %s", stream.Protocol())
 		return
@@ -595,7 +601,7 @@ func (n *P2PNetwork) wsStreamHandler(ctx context.Context, peer peer.ID, stream n
 		if numOutgoingPeers >= n.config.GossipFanout {
 			// this appears to be some auxiliary connection made by libp2p itself like DHT connection.
 			// skip this connection since there are already enough peers
-			n.log.Debugf("skipping outgoing connection to peer %s: num outgoing %d > fanout %d ", peer, numOutgoingPeers, n.config.GossipFanout)
+			n.log.Debugf("skipping outgoing connection to peer %s: num outgoing %d > fanout %d ", p2ppeer, numOutgoingPeers, n.config.GossipFanout)
 			stream.Close()
 			return
 		}
@@ -611,18 +617,23 @@ func (n *P2PNetwork) wsStreamHandler(ctx context.Context, peer peer.ID, stream n
 	ma := stream.Conn().RemoteMultiaddr()
 	addr := ma.String()
 	if addr == "" {
-		n.log.Warnf("Could not get address for peer %s", peer)
+		n.log.Warnf("Could not get address for peer %s", p2ppeer)
 	}
 	// create a wsPeer for this stream and added it to the peers map.
+	client, err := p2p.MakeHTTPClient(p2p.AlgorandP2pHTTPProtocol, &peer.AddrInfo{ID: p2ppeer, Addrs: []multiaddr.Multiaddr{ma}})
+	if err != nil {
+		client = nil
+	}
+	peerCore := makePeerCoreWithClient(ctx, n, n.log, n.handler.readBuffer, addr, client, addr)
 	wsp := &wsPeer{
-		wsPeerCore: makePeerCore(ctx, n, n.log, n.handler.readBuffer, addr, n.GetRoundTripper(nil), addr),
+		wsPeerCore: peerCore,
 		conn:       &wsPeerConnP2PImpl{stream: stream},
 		outgoing:   !incoming,
 	}
 	wsp.init(n.config, outgoingMessagesBufferSize)
 	n.wsPeersLock.Lock()
-	n.wsPeers[peer] = wsp
-	n.wsPeersToIDs[wsp] = peer
+	n.wsPeers[p2ppeer] = wsp
+	n.wsPeersToIDs[wsp] = p2ppeer
 	n.wsPeersLock.Unlock()
 	n.wsPeersChangeCounter.Add(1)
 
@@ -633,7 +644,7 @@ func (n *P2PNetwork) wsStreamHandler(ctx context.Context, peer peer.ID, stream n
 		msg = "Accepted incoming connection from peer %s"
 	}
 	localAddr, _ := n.Address()
-	n.log.With("event", event).With("remote", addr).With("local", localAddr).Infof(msg, peer.String())
+	n.log.With("event", event).With("remote", addr).With("local", localAddr).Infof(msg, p2ppeer.String())
 
 	if n.log.GetLevel() >= logging.Debug {
 		n.log.Debugf("streams for %s conn %s ", stream.Conn().Stat().Direction.String(), stream.Conn().ID())

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -605,7 +605,7 @@ func TestP2PHTTPHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.NotZero(t, addrsA[0])
 
-	httpClient, err := p2p.MakeHTTPClient(p2p.AlgorandP2pHTTPProtocol, netA.service.AddrInfo())
+	httpClient, err := p2p.MakeHTTPClient(p2p.AlgorandP2pHTTPProtocol, &peerInfoA)
 	require.NoError(t, err)
 	resp, err := httpClient.Get("/test")
 	require.NoError(t, err)
@@ -615,7 +615,7 @@ func TestP2PHTTPHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "hello", string(body))
 
-	httpClient, err = p2p.MakeHTTPClient(p2p.AlgorandP2pHTTPProtocol, netA.service.AddrInfo())
+	httpClient, err = p2p.MakeHTTPClient(p2p.AlgorandP2pHTTPProtocol, &peerInfoA)
 	require.NoError(t, err)
 	resp, err = httpClient.Get("/bar")
 	require.NoError(t, err)

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -605,7 +605,7 @@ func TestP2PHTTPHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.NotZero(t, addrsA[0])
 
-	httpClient, err := p2p.MakeHTTPClient(p2p.AlgorandP2pHTTPProtocol, &peerInfoA)
+	httpClient, err := p2p.MakeHTTPClient(&peerInfoA)
 	require.NoError(t, err)
 	resp, err := httpClient.Get("/test")
 	require.NoError(t, err)
@@ -615,7 +615,7 @@ func TestP2PHTTPHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "hello", string(body))
 
-	httpClient, err = p2p.MakeHTTPClient(p2p.AlgorandP2pHTTPProtocol, &peerInfoA)
+	httpClient, err = p2p.MakeHTTPClient(&peerInfoA)
 	require.NoError(t, err)
 	resp, err = httpClient.Get("/bar")
 	require.NoError(t, err)

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -36,8 +36,6 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	peerstore "github.com/libp2p/go-libp2p/core/peer"
-	"github.com/multiformats/go-multiaddr"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 )
@@ -53,9 +51,7 @@ func TestP2PSubmitTX(t *testing.T) {
 	defer netA.Stop()
 
 	peerInfoA := netA.service.AddrInfo()
-	fmt.Print("peerInfoA is ", peerInfoA)
-	addrsA, err := peerstore.AddrInfoToP2pAddrs(&peerInfoA)
-	fmt.Printf("addrsA is %v\n", addrsA)
+	addrsA, err := peer.AddrInfoToP2pAddrs(&peerInfoA)
 	require.NoError(t, err)
 	require.NotZero(t, addrsA[0])
 
@@ -131,7 +127,7 @@ func TestP2PSubmitWS(t *testing.T) {
 	defer netA.Stop()
 
 	peerInfoA := netA.service.AddrInfo()
-	addrsA, err := peerstore.AddrInfoToP2pAddrs(&peerInfoA)
+	addrsA, err := peer.AddrInfoToP2pAddrs(&peerInfoA)
 	require.NoError(t, err)
 	require.NotZero(t, addrsA[0])
 
@@ -337,9 +333,9 @@ func (c *mockResolveController) Resolver() dnsaddr.Resolver {
 
 type mockResolver struct{}
 
-func (r *mockResolver) Resolve(ctx context.Context, maddr multiaddr.Multiaddr) ([]multiaddr.Multiaddr, error) {
-	ma, err := multiaddr.NewMultiaddr("/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
-	return []multiaddr.Multiaddr{ma}, err
+func (r *mockResolver) Resolve(ctx context.Context, _ ma.Multiaddr) ([]ma.Multiaddr, error) {
+	maddr, err := ma.NewMultiaddr("/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
+	return []ma.Multiaddr{maddr}, err
 }
 
 func TestBootstrapFunc(t *testing.T) {
@@ -454,7 +450,7 @@ func TestP2PNetworkDHTCapabilities(t *testing.T) {
 			defer netA.Stop()
 
 			peerInfoA := netA.service.AddrInfo()
-			addrsA, err := peerstore.AddrInfoToP2pAddrs(&peerInfoA)
+			addrsA, err := peer.AddrInfoToP2pAddrs(&peerInfoA)
 			require.NoError(t, err)
 			require.NotZero(t, addrsA[0])
 
@@ -535,9 +531,9 @@ func TestP2PNetworkDHTCapabilities(t *testing.T) {
 					net := nets[idx]
 					peers := net.GetPeers(PeersPhonebookArchivalNodes)
 					uniquePeerIDs := make(map[peer.ID]struct{})
-					for _, peer := range peers {
-						wsPeer := peer.(*wsPeerCore)
-						pi, err := peerstore.AddrInfoFromString(wsPeer.rootURL)
+					for _, p := range peers {
+						wsPeer := p.(*wsPeerCore)
+						pi, err := peer.AddrInfoFromString(wsPeer.rootURL)
 						require.NoError(t, err)
 						uniquePeerIDs[pi.ID] = struct{}{}
 					}
@@ -555,7 +551,7 @@ func TestMultiaddrConversionToFrom(t *testing.T) {
 	t.Parallel()
 
 	a := "/ip4/192.168.1.1/tcp/8180/p2p/Qmewz5ZHN1AAGTarRbMupNPbZRfg3p5jUGoJ3JYEatJVVk"
-	ma, err := multiaddr.NewMultiaddr(a)
+	ma, err := ma.NewMultiaddr(a)
 	require.NoError(t, err)
 	require.Equal(t, a, ma.String())
 
@@ -601,7 +597,7 @@ func TestP2PHTTPHandler(t *testing.T) {
 	defer netA.Stop()
 
 	peerInfoA := netA.service.AddrInfo()
-	addrsA, err := peerstore.AddrInfoToP2pAddrs(&peerInfoA)
+	addrsA, err := peer.AddrInfoToP2pAddrs(&peerInfoA)
 	require.NoError(t, err)
 	require.NotZero(t, addrsA[0])
 

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -167,7 +167,7 @@ type wsPeerCore struct {
 	readBuffer    chan<- IncomingMessage
 	rootURL       string
 	originAddress string // incoming connection remote host
-	client        http.Client
+	client        *http.Client
 }
 
 type disconnectReason string
@@ -348,11 +348,11 @@ type TCPInfoUnicastPeer interface {
 
 // Create a wsPeerCore object
 func makePeerCore(ctx context.Context, net GossipNode, log logging.Logger, readBuffer chan<- IncomingMessage, rootURL string, roundTripper http.RoundTripper, originAddress string) wsPeerCore {
-	return makePeerCoreWithClient(ctx, net, log, readBuffer, rootURL, http.Client{Transport: roundTripper}, originAddress)
+	return makePeerCoreWithClient(ctx, net, log, readBuffer, rootURL, &http.Client{Transport: roundTripper}, originAddress)
 }
 
 // Create a wsPeerCore object
-func makePeerCoreWithClient(ctx context.Context, net GossipNode, log logging.Logger, readBuffer chan<- IncomingMessage, rootURL string, client http.Client, originAddress string) wsPeerCore {
+func makePeerCoreWithClient(ctx context.Context, net GossipNode, log logging.Logger, readBuffer chan<- IncomingMessage, rootURL string, client *http.Client, originAddress string) wsPeerCore {
 	return wsPeerCore{
 		net:           net,
 		netCtx:        ctx,
@@ -374,7 +374,7 @@ func (wp *wsPeerCore) GetAddress() string {
 // GetHTTPClient returns a client for this peer.
 // http.Client will maintain a cache of connections with some keepalive.
 func (wp *wsPeerCore) GetHTTPClient() *http.Client {
-	return &wp.client
+	return wp.client
 }
 
 func (wp *wsPeerCore) GetNetwork() GossipNode {

--- a/rpcs/txService_test.go
+++ b/rpcs/txService_test.go
@@ -130,12 +130,12 @@ func nodePair() (*basicRPCNode, *basicRPCNode) {
 	return nodeA, nodeB
 }
 
-func nodePairP2p(tb testing.TB) (*p2ptesting.P2PHTTPNode, *p2ptesting.P2PHTTPNode) {
-	nodeA := p2ptesting.MakeP2PHTTPNode(tb)
+func nodePairP2p(tb testing.TB) (*p2ptesting.HTTPNode, *p2ptesting.HTTPNode) {
+	nodeA := p2ptesting.MakeHTTPNode(tb)
 	addrsA := nodeA.Addrs()
 	require.Greater(tb, len(addrsA), 0)
 
-	nodeB := p2ptesting.MakeP2PHTTPNode(tb)
+	nodeB := p2ptesting.MakeHTTPNode(tb)
 	addrsB := nodeA.Addrs()
 	require.Greater(tb, len(addrsB), 0)
 

--- a/rpcs/txSyncer_test.go
+++ b/rpcs/txSyncer_test.go
@@ -170,6 +170,10 @@ func (mca *mockClientAggregator) GetPeers(options ...network.PeerOption) []netwo
 	return mca.peers
 }
 
+func (mca *mockClientAggregator) GetHTTPClient(peer network.HTTPPeer) (*http.Client, error) {
+	return &http.Client{Transport: http.DefaultTransport}, nil
+}
+
 const numberOfPeers = 10
 
 func makeMockClientAggregator(t *testing.T, failWithNil bool, failWithError bool) *mockClientAggregator {

--- a/rpcs/txSyncer_test.go
+++ b/rpcs/txSyncer_test.go
@@ -174,18 +174,6 @@ func (mca *mockClientAggregator) GetHTTPClient(peer network.HTTPPeer) (*http.Cli
 	return &http.Client{Transport: http.DefaultTransport}, nil
 }
 
-const numberOfPeers = 10
-
-func makeMockClientAggregator(t *testing.T, failWithNil bool, failWithError bool) *mockClientAggregator {
-	clients := make([]network.Peer, 0)
-	for i := 0; i < numberOfPeers; i++ {
-		runner := mockRunner{failWithNil: failWithNil, failWithError: failWithError, done: make(chan *rpc.Call)}
-		clients = append(clients, &mockRPCClient{client: &runner, log: logging.TestingLog(t)})
-	}
-	t.Logf("len(mca.clients) = %d", len(clients))
-	return &mockClientAggregator{peers: clients}
-}
-
 func TestSyncFromClient(t *testing.T) {
 	partitiontest.PartitionTest(t)
 


### PR DESCRIPTION
## Summary

* Add multiaddr support to txsync
* Replace `GossipNode.GetRoundTripper` with `GossipNode.GetHTTPClient` as higher level alternative. (only txsync used GetRoundTripper outside of the `network` package.

## Test Plan

Added a new unit test to txSync to test p2p flow.