### PR TITLE
p2p: p2p http catchpoints support

### DIFF
--- a/agreement/gossip/network_test.go
+++ b/agreement/gossip/network_test.go
@@ -18,7 +18,6 @@ package gossip
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -156,7 +155,7 @@ func (w *whiteholeNetwork) GetPeers(options ...network.PeerOption) []network.Pee
 }
 func (w *whiteholeNetwork) RegisterHTTPHandler(path string, handler http.Handler) {
 }
-func (w *whiteholeNetwork) GetHTTPRequestConnection(request *http.Request) (conn net.Conn) {
+func (w *whiteholeNetwork) GetHTTPRequestConnection(request *http.Request) (conn network.DeadlineSettable) {
 	return nil
 }
 

--- a/catchup/ledgerFetcher.go
+++ b/catchup/ledgerFetcher.go
@@ -74,13 +74,18 @@ func makeLedgerFetcher(net network.GossipNode, accessor ledger.CatchpointCatchup
 }
 
 func (lf *ledgerFetcher) requestLedger(ctx context.Context, peer network.HTTPPeer, round basics.Round, method string) (*http.Response, error) {
-	parsedURL, err := network.ParseHostOrURL(peer.GetAddress())
-	if err != nil {
-		return nil, err
-	}
+	var ledgerURL string
+	if network.IsMultiaddr(peer.GetAddress()) {
+		ledgerURL = network.SubstituteGenesisID(lf.net, "/v1/{genesisID}/ledger/"+strconv.FormatUint(uint64(round), 36))
+	} else {
 
-	parsedURL.Path = network.SubstituteGenesisID(lf.net, path.Join(parsedURL.Path, "/v1/{genesisID}/ledger/"+strconv.FormatUint(uint64(round), 36)))
-	ledgerURL := parsedURL.String()
+		parsedURL, err := network.ParseHostOrURL(peer.GetAddress())
+		if err != nil {
+			return nil, err
+		}
+		parsedURL.Path = network.SubstituteGenesisID(lf.net, path.Join(parsedURL.Path, "/v1/{genesisID}/ledger/"+strconv.FormatUint(uint64(round), 36)))
+		ledgerURL = parsedURL.String()
+	}
 	lf.log.Debugf("ledger %s %#v peer %#v %T", method, ledgerURL, peer, peer)
 	request, err := http.NewRequestWithContext(ctx, method, ledgerURL, nil)
 	if err != nil {

--- a/components/mocks/mockNetwork.go
+++ b/components/mocks/mockNetwork.go
@@ -19,7 +19,6 @@ package mocks
 import (
 	"context"
 	"errors"
-	"net"
 	"net/http"
 
 	"github.com/algorand/go-algorand/network"
@@ -100,7 +99,7 @@ func (network *MockNetwork) RegisterHTTPHandler(path string, handler http.Handle
 func (network *MockNetwork) OnNetworkAdvance() {}
 
 // GetHTTPRequestConnection - empty implementation
-func (network *MockNetwork) GetHTTPRequestConnection(request *http.Request) (conn net.Conn) {
+func (network *MockNetwork) GetHTTPRequestConnection(request *http.Request) (conn network.DeadlineSettable) {
 	return nil
 }
 

--- a/network/gossipNode.go
+++ b/network/gossipNode.go
@@ -18,9 +18,9 @@ package network
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/protocol"
@@ -51,6 +51,13 @@ const (
 	// PeersPhonebookArchivers specifies all archivers in the phonebook
 	PeersPhonebookArchivers PeerOption = iota
 )
+
+// DeadlineSettable abstracts net.Conn and related types as deadline-settable
+type DeadlineSettable interface {
+	SetDeadline(time.Time) error
+	SetReadDeadline(time.Time) error
+	SetWriteDeadline(time.Time) error
+}
 
 // GossipNode represents a node in the gossip network
 type GossipNode interface {
@@ -95,7 +102,7 @@ type GossipNode interface {
 
 	// GetHTTPRequestConnection returns the underlying connection for the given request. Note that the request must be the same
 	// request that was provided to the http handler ( or provide a fallback Context() to that )
-	GetHTTPRequestConnection(request *http.Request) (conn net.Conn)
+	GetHTTPRequestConnection(request *http.Request) (conn DeadlineSettable)
 
 	// GetGenesisID returns the network-specific genesisID.
 	GetGenesisID() string

--- a/network/hybridNetwork.go
+++ b/network/hybridNetwork.go
@@ -19,7 +19,6 @@ package network
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"sync"
 
@@ -206,8 +205,12 @@ func (n *HybridP2PNetwork) OnNetworkAdvance() {
 
 // GetHTTPRequestConnection returns the underlying connection for the given request. Note that the request must be the same
 // request that was provided to the http handler ( or provide a fallback Context() to that )
-func (n *HybridP2PNetwork) GetHTTPRequestConnection(request *http.Request) (conn net.Conn) {
-	return nil
+func (n *HybridP2PNetwork) GetHTTPRequestConnection(request *http.Request) (conn DeadlineSettable) {
+	conn = n.wsNetwork.GetHTTPRequestConnection(request)
+	if conn != nil {
+		return conn
+	}
+	return n.p2pNetwork.GetHTTPRequestConnection(request)
 }
 
 // GetGenesisID returns the network-specific genesisID.

--- a/network/p2p/p2p_test.go
+++ b/network/p2p/p2p_test.go
@@ -17,11 +17,20 @@
 package p2p
 
 import (
+	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
-	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/network/p2p/peerstore"
+	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
 // Tests the helper function netAddressToListenAddress which converts
@@ -73,4 +82,65 @@ func TestNetAddressToListenAddress(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestP2PStreamingHost(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	cfg := config.GetDefaultLocal()
+	dir := t.TempDir()
+	pstore, err := peerstore.NewPeerStore(nil)
+	require.NoError(t, err)
+	h, la, err := MakeHost(cfg, dir, pstore)
+	require.NoError(t, err)
+
+	var h1calls atomic.Int64
+	h1 := func(network.Stream) {
+		h1calls.Add(1)
+	}
+	var h2calls atomic.Int64
+	h2 := func(network.Stream) {
+		h2calls.Add(1)
+	}
+
+	ma, err := multiaddr.NewMultiaddr(la)
+	require.NoError(t, err)
+	h.Network().Listen(ma)
+	defer h.Close()
+
+	h.SetStreamHandler(AlgorandWsProtocol, h1)
+	h.SetStreamHandler(AlgorandWsProtocol, h2)
+
+	addrInfo := peer.AddrInfo{
+		ID:    h.ID(),
+		Addrs: h.Addrs(),
+	}
+	cpstore, err := peerstore.NewPeerStore([]*peer.AddrInfo{&addrInfo})
+	require.NoError(t, err)
+	c, _, err := MakeHost(cfg, dir, cpstore)
+	require.NoError(t, err)
+	defer c.Close()
+
+	s1, err := c.NewStream(context.Background(), h.ID(), AlgorandWsProtocol)
+	require.NoError(t, err)
+	s1.Write([]byte("hello"))
+	defer s1.Close()
+
+	require.Eventually(t, func() bool {
+		return h1calls.Load() == 1 && h2calls.Load() == 1
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// ensure a single handler also works as expected
+	h1calls.Store(0)
+	h.SetStreamHandler(algorandP2pHTTPProtocol, h1)
+
+	s2, err := c.NewStream(context.Background(), h.ID(), algorandP2pHTTPProtocol)
+	require.NoError(t, err)
+	s2.Write([]byte("hello"))
+	defer s2.Close()
+
+	require.Eventually(t, func() bool {
+		return h1calls.Load() == 1
+	}, 5*time.Second, 100*time.Millisecond)
+
 }

--- a/network/p2p/testing/httpNode.go
+++ b/network/p2p/testing/httpNode.go
@@ -77,6 +77,12 @@ func (p *HTTPNode) Stop() {
 	p.Host.Close()
 }
 
+// GetHTTPPeer returns the http peer for connecting to this node
+func (p *HTTPNode) GetHTTPPeer() network.Peer {
+	addrInfo := peer.AddrInfo{ID: p.ID(), Addrs: p.Addrs()}
+	return httpPeer{addrInfo, p.tb}
+}
+
 // GetGenesisID returns genesisID
 func (p *HTTPNode) GetGenesisID() string { return p.genesisID }
 

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -246,6 +246,10 @@ func (s *mockService) Publish(ctx context.Context, topic string, data []byte) er
 	return nil
 }
 
+func (s *mockService) GetStream(peer.ID) (network.Stream, bool) {
+	return nil, false
+}
+
 func makeMockService(id peer.ID, addrs []ma.Multiaddr) *mockService {
 	return &mockService{
 		id:    id,
@@ -568,11 +572,17 @@ func TestMultiaddrConversionToFrom(t *testing.T) {
 }
 
 type p2phttpHandler struct {
+	tb      testing.TB
 	retData string
+	net     GossipNode
 }
 
 func (h *p2phttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(h.retData))
+	if r.URL.Path == "/check-conn" {
+		c := h.net.GetHTTPRequestConnection(r)
+		require.NotEmpty(h.tb, c)
+	}
 }
 
 func TestP2PHTTPHandler(t *testing.T) {
@@ -587,11 +597,11 @@ func TestP2PHTTPHandler(t *testing.T) {
 	netA, err := NewP2PNetwork(log, cfg, "", nil, genesisID, config.Devtestnet, &nopeNodeInfo{})
 	require.NoError(t, err)
 
-	h := &p2phttpHandler{"hello"}
+	h := &p2phttpHandler{t, "hello", nil}
 	netA.RegisterHTTPHandler("/test", h)
 
-	h2 := &p2phttpHandler{"world"}
-	netA.RegisterHTTPHandler("/bar", h2)
+	h2 := &p2phttpHandler{t, "world", netA}
+	netA.RegisterHTTPHandler("/check-conn", h2)
 
 	netA.Start()
 	defer netA.Stop()
@@ -613,7 +623,7 @@ func TestP2PHTTPHandler(t *testing.T) {
 
 	httpClient, err = p2p.MakeHTTPClient(&peerInfoA)
 	require.NoError(t, err)
-	resp, err = httpClient.Get("/bar")
+	resp, err = httpClient.Get("/check-conn")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1019,7 +1019,7 @@ func (wn *WebsocketNetwork) checkIncomingConnectionVariables(response http.Respo
 // request that was provided to the http handler ( or provide a fallback Context() to that )
 // if the provided request has no associated connection, it returns nil. ( this should not happen for any http request that was registered
 // by WebsocketNetwork )
-func (wn *WebsocketNetwork) GetHTTPRequestConnection(request *http.Request) (conn net.Conn) {
+func (wn *WebsocketNetwork) GetHTTPRequestConnection(request *http.Request) (conn DeadlineSettable) {
 	if wn.requestsTracker != nil {
 		conn = wn.requestsTracker.GetRequestConnection(request)
 	}

--- a/rpcs/ledgerService.go
+++ b/rpcs/ledgerService.go
@@ -60,19 +60,25 @@ type LedgerForService interface {
 	GetCatchpointStream(round basics.Round) (ledger.ReadCloseSizer, error)
 }
 
+// httpGossipNode is a reduced interface for the gossipNode that only includes the methods needed by the LedgerService
+type httpGossipNode interface {
+	RegisterHTTPHandler(path string, handler http.Handler)
+	GetHTTPRequestConnection(request *http.Request) (conn network.DeadlineSettable)
+}
+
 // LedgerService represents the Ledger RPC API
 type LedgerService struct {
 	// running is non-zero once the service is running, and zero when it's not running. it needs to be at a 32-bit aligned address for RasPI support.
 	running       atomic.Int32
 	ledger        LedgerForService
 	genesisID     string
-	net           network.GossipNode
+	net           httpGossipNode
 	enableService bool
 	stopping      sync.WaitGroup
 }
 
 // MakeLedgerService creates a LedgerService around the provider Ledger and registers it with the HTTP router
-func MakeLedgerService(config config.Local, ledger LedgerForService, net network.GossipNode, genesisID string) *LedgerService {
+func MakeLedgerService(config config.Local, ledger LedgerForService, net httpGossipNode, genesisID string) *LedgerService {
 	service := &LedgerService{
 		ledger:        ledger,
 		genesisID:     genesisID,


### PR DESCRIPTION
## Summary

P2P HTTP support for ledger service:
1. Ledger fetcher understands p2p URL now
2. P2pNetwork implements `GetHTTPRequestConnection`:
   - A new `StreamChainingHost` wrapper for `libp2p.host.Host` allows multiple stream handlers for the same protocol.ID
   - Main use is to have an extra handler for "/http/1.1" in order to track streams with HTTP protocol inside.
3.  Ledger Service worked out of the box

## Test Plan

Added unit test for fetcher, service and new p2p stream wrapper.