### PR TITLE
Blocks: Bump min to save based on catchpoint support

### DIFF
--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -462,8 +462,8 @@ func (l *Ledger) notifyCommit(r basics.Round) basics.Round {
 	if l.archival {
 		// Do not forget any blocks.
 		minToSave = 0
-	} else if minCatchpointsRoundsLookback := l.calcMinCatchpointRoundsLookback(); minCatchpointsRoundsLookback > 0 {
-		catchpointsMinToSave := r.SubSaturate(minCatchpointsRoundsLookback)
+	} else {
+		catchpointsMinToSave := r.SubSaturate(l.calcMinCatchpointRoundsLookback())
 		if catchpointsMinToSave < minToSave {
 			minToSave = catchpointsMinToSave
 		}

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -478,18 +478,7 @@ func (l *Ledger) calcMinCatchpointRoundsLookback() basics.Round {
 		return 0
 	}
 
-	// Nodes catching up from the _most recent_
-	// catchpoint will need to look back at least MaxTxnLife+DeeperBlockHeaderHistory+CatchpointLookback+
-	// buffer rounds before the catchpoint round in order to build up the necessary state.
-	// The max comparison is to mitigate against small catchpoint interval configurations.
-	catchpointIntervalLookback := 2 * l.cfg.CatchpointInterval
-	existingEstimatedLookback := l.cfg.CatchpointInterval + l.genesisProto.MaxTxnLife + l.genesisProto.DeeperBlockHeaderHistory +
-		l.genesisProto.CatchpointLookback + 100 // 100 rounds buffer
-	if catchpointIntervalLookback > existingEstimatedLookback {
-		return basics.Round(catchpointIntervalLookback)
-	}
-
-	return 0 // should be treated as a no-op
+	return basics.Round(2 * l.cfg.CatchpointInterval)
 }
 
 // GetLastCatchpointLabel returns the latest catchpoint label that was written to the


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Support minimum number of rounds saved that takes the being able to catchup from a recent catchpoint into account.

## Test Plan

Added a new unit test that exercises the impact of enabling/disabling catchpoint support on ledger's `minToSave` calculation.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
