### PR TITLE
p2p: support block request redirects for p2p addresses

### DIFF
--- a/rpcs/blockService.go
+++ b/rpcs/blockService.go
@@ -378,7 +378,6 @@ func (bs *BlockService) handleCatchupReq(ctx context.Context, reqMsg network.Inc
 		return
 	}
 	respTopics, n = topicBlockBytes(bs.log, bs.ledger, basics.Round(round), string(requestType))
-	return
 }
 
 // redirectRequest redirects the request to the next round robin fallback endpoint if available
@@ -389,18 +388,24 @@ func (bs *BlockService) redirectRequest(round uint64, response http.ResponseWrit
 		return false
 	}
 
-	parsedURL, err := network.ParseHostOrURL(peerAddress)
-	if err != nil {
-		bs.log.Debugf("redirectRequest: %s", err.Error())
-		return false
+	var redirectURL string
+	if network.IsMultiaddr(peerAddress) {
+		redirectURL = strings.Replace(FormatBlockQuery(round, "", bs.net), "{genesisID}", bs.genesisID, 1)
+	} else {
+		parsedURL, err := network.ParseHostOrURL(peerAddress)
+		if err != nil {
+			bs.log.Debugf("redirectRequest: %s", err.Error())
+			return false
+		}
+		parsedURL.Path = strings.Replace(FormatBlockQuery(round, parsedURL.Path, bs.net), "{genesisID}", bs.genesisID, 1)
+		redirectURL = parsedURL.String()
 	}
-	parsedURL.Path = strings.Replace(FormatBlockQuery(round, parsedURL.Path, bs.net), "{genesisID}", bs.genesisID, 1)
-	http.Redirect(response, request, parsedURL.String(), http.StatusTemporaryRedirect)
-	bs.log.Debugf("redirectRequest: redirected block request to %s", parsedURL.String())
+	http.Redirect(response, request, redirectURL, http.StatusTemporaryRedirect)
+	bs.log.Debugf("redirectRequest: redirected block request to %s", redirectURL)
 	return true
 }
 
-// getNextCustomFallbackEndpoint returns the next custorm fallback endpoint in RR ordering
+// getNextCustomFallbackEndpoint returns the next custom fallback endpoint in RR ordering
 func (bs *BlockService) getNextCustomFallbackEndpoint() (endpointAddress string) {
 	if len(bs.fallbackEndpoints.endpoints) == 0 {
 		return
@@ -493,12 +498,16 @@ func makeFallbackEndpoints(log logging.Logger, customFallbackEndpoints string) (
 	}
 	endpoints := strings.Split(customFallbackEndpoints, ",")
 	for _, ep := range endpoints {
-		parsed, err := network.ParseHostOrURL(ep)
-		if err != nil {
-			log.Warnf("makeFallbackEndpoints: error parsing %s %s", ep, err.Error())
-			continue
+		if network.IsMultiaddr(ep) {
+			fe.endpoints = append(fe.endpoints, ep)
+		} else {
+			parsed, err := network.ParseHostOrURL(ep)
+			if err != nil {
+				log.Warnf("makeFallbackEndpoints: error parsing %s %s", ep, err.Error())
+				continue
+			}
+			fe.endpoints = append(fe.endpoints, parsed.String())
 		}
-		fe.endpoints = append(fe.endpoints, parsed.String())
 	}
 	return
 }


### PR DESCRIPTION
## Summary

Support p2p addresses (multiaddr) in block service redirect code.

## Test Plan

Added unit test.