### PR TITLE
feat: add support to display mnemonic discreetly for `algokey import` and `algokey export`

### DIFF
--- a/cmd/algokey/export.go
+++ b/cmd/algokey/export.go
@@ -27,10 +27,12 @@ import (
 
 var exportKeyfile string
 var exportPubkeyfile string
+var exportDiscreet bool
 
 func init() {
 	exportCmd.Flags().StringVarP(&exportKeyfile, "keyfile", "f", "", "Private key filename")
 	exportCmd.Flags().StringVarP(&exportPubkeyfile, "pubkeyfile", "p", "", "Public key filename")
+	exportCmd.Flags().BoolVar(&exportDiscreet, "discreet", false, "Print mnemonic discreetly to an alternate screen")
 	exportCmd.MarkFlagRequired("keyfile")
 }
 
@@ -45,7 +47,14 @@ var exportCmd = &cobra.Command{
 		key := crypto.GenerateSignatureSecrets(seed)
 		publicKeyChecksummed := basics.Address(key.SignatureVerifier).String()
 
-		fmt.Printf("Private key mnemonic: %s\n", mnemonic)
+		if exportDiscreet {
+			if err := printDiscreetly(os.Stderr, "**Important** write this private key mnemonic phrase in a safe place. Do not share it to anyone", fmt.Sprintf("Private key mnemonic: %s", mnemonic)); err != nil {
+				fmt.Fprintf(os.Stderr, "Fail to print mnemonic: %v", err)
+				os.Exit(1)
+			}
+		} else {
+			fmt.Printf("Private key mnemonic: %s\n", mnemonic)
+		}
 		fmt.Printf("Public key: %s\n", publicKeyChecksummed)
 
 		if exportPubkeyfile != "" {

--- a/cmd/algokey/export.go
+++ b/cmd/algokey/export.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 

--- a/cmd/algokey/import.go
+++ b/cmd/algokey/import.go
@@ -27,10 +27,12 @@ import (
 
 var mnemonic string
 var importKeyfile string
+var importDiscreet bool
 
 func init() {
 	importCmd.Flags().StringVarP(&mnemonic, "mnemonic", "m", "", "Private key mnemonic")
 	importCmd.Flags().StringVarP(&importKeyfile, "keyfile", "f", "", "Private key filename")
+	importCmd.Flags().BoolVar(&importDiscreet, "discreet", false, "Print mnemonic discreetly to an alternate screen")
 	importCmd.MarkFlagRequired("mnemonic")
 }
 
@@ -44,7 +46,14 @@ var importCmd = &cobra.Command{
 		key := crypto.GenerateSignatureSecrets(seed)
 		publicKeyChecksummed := basics.Address(key.SignatureVerifier).String()
 
-		fmt.Printf("Private key mnemonic: %s\n", mnemonic)
+		if importDiscreet {
+			if err := printDiscreetly(os.Stderr, "**Important** write this private key mnemonic phrase in a safe place. Do not share it to anyone", fmt.Sprintf("Private key mnemonic: %s", mnemonic)); err != nil {
+				fmt.Fprintf(os.Stderr, "Fail to print mnemonic: %v", err)
+				os.Exit(1)
+			}
+		} else {
+			fmt.Printf("Private key mnemonic: %s\n", mnemonic)
+		}
 		fmt.Printf("Public key: %s\n", publicKeyChecksummed)
 
 		if importKeyfile != "" {

--- a/cmd/algokey/import.go
+++ b/cmd/algokey/import.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Similar to #5886

Refer to [comment](https://github.com/algorand/go-algorand/pull/5886#issuecomment-1869202954), this pr is for `algokey import` and `algokey export`