### PR TITLE
CICD: fix package signing issues

### DIFF
--- a/package-deploy.yaml
+++ b/package-deploy.yaml
@@ -56,7 +56,6 @@ agents:
       - NETWORK=$NETWORK
       - NO_DEPLOY=$NO_DEPLOY
       - PACKAGES_DIR=$PACKAGES_DIR
-      - S3_SOURCE=$S3_SOURCE
       - STAGING=$STAGING
       - VERSION=$VERSION
     volumes:

--- a/scripts/release/mule/common/ensure_centos8_image.sh
+++ b/scripts/release/mule/common/ensure_centos8_image.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+# Ensure the centos8 docker image is built and available
+
+DOCKER_IMAGE="algorand/go-algorand-ci-linux-centos8:amd64-$(sha1sum scripts/configure_dev-deps.sh | cut -f1 -d' ')"
+MATCH=${DOCKER_IMAGE/:*/}
+
+echo "Checking for RPM image"
+if docker images $DOCKER_IMAGE | grep -qs $MATCH > /dev/null 2>&1; then
+  echo "Image exists"
+else
+  echo "RPM image doesn't exist, building"
+  docker build --platform=linux/amd64 --build-arg ARCH=amd64 \
+    --build-arg GOLANG_VERSION=$(./scripts/get_golang_version.sh) -t $DOCKER_IMAGE -f docker/build/cicd.centos8.Dockerfile .
+fi

--- a/scripts/release/mule/deploy/deb/deploy.sh
+++ b/scripts/release/mule/deploy/deb/deploy.sh
@@ -8,6 +8,7 @@ PACKAGES_DIR=${PACKAGES_DIR:-~/packages}
 SNAPSHOT=${SNAPSHOT:-"${CHANNEL}-${VERSION}"}
 
 mkdir -p $PACKAGES_DIR
+rm -f $PACKAGES_DIR/*.deb
 
 aptly mirror update stable
 aptly mirror update beta
@@ -18,18 +19,18 @@ aptly repo import beta beta algorand-beta algorand-devtools-beta
 
 cp -f tmp/{algorand,algorand-devtools}_${CHANNEL}_linux-{amd64,arm64}_${VERSION}.deb $PACKAGES_DIR
 
-if ls -A $PACKAGES_DIR
-then
-    aptly repo add "$CHANNEL" "$PACKAGES_DIR"/*.deb
-    aptly repo show -with-packages "$CHANNEL"
-    aptly snapshot create "$SNAPSHOT" from repo "$CHANNEL"
-    if ! aptly publish show "$CHANNEL" s3:algorand-releases: &> /dev/null
-    then
-        aptly publish -batch snapshot -gpg-key=dev@algorand.com -origin=Algorand -label=Algorand "$SNAPSHOT" s3:algorand-releases:
-    else
-        aptly publish switch "$CHANNEL" s3:algorand-releases: "$SNAPSHOT"
-    fi
-else
-    echo "[$0] The packages directory is empty, so there is nothing to add the \`$CHANNEL\` repo."
-    exit 1
-fi
+# if ls -A $PACKAGES_DIR
+# then
+#     aptly repo add "$CHANNEL" "$PACKAGES_DIR"/*.deb
+#     aptly repo show -with-packages "$CHANNEL"
+#     aptly snapshot create "$SNAPSHOT" from repo "$CHANNEL"
+#     if ! aptly publish show "$CHANNEL" s3:algorand-releases: &> /dev/null
+#     then
+#         aptly publish -batch snapshot -gpg-key=dev@algorand.com -origin=Algorand -label=Algorand "$SNAPSHOT" s3:algorand-releases:
+#     else
+#         aptly publish switch "$CHANNEL" s3:algorand-releases: "$SNAPSHOT"
+#     fi
+# else
+#     echo "[$0] The packages directory is empty, so there is nothing to add the \`$CHANNEL\` repo."
+#     exit 1
+# fi

--- a/scripts/release/mule/deploy/deb/deploy.sh
+++ b/scripts/release/mule/deploy/deb/deploy.sh
@@ -8,22 +8,16 @@ then
     exit 1
 fi
 
-if [ -z "$STAGING" ]
-then
-    echo "[$0] Staging is a required parameter."
-    exit 1
-fi
-
 CHANNEL=$("./scripts/release/mule/common/get_channel.sh" "$NETWORK")
 VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
+PACKAGES_DIR=${PACKAGES_DIR:-~/packages}
 
 if [ -z "$SNAPSHOT" ]
 then
     SNAPSHOT="$CHANNEL-$VERSION"
 fi
 
-PACKAGES_DIR=/root/packages
-mkdir -p /root/packages
+mkdir -p $PACKAGES_DIR
 
 aptly mirror update stable
 aptly mirror update beta

--- a/scripts/release/mule/deploy/deb/deploy.sh
+++ b/scripts/release/mule/deploy/deb/deploy.sh
@@ -2,20 +2,10 @@
 
 set -ex
 
-if [ -z "$NETWORK" ]
-then
-    echo "[$0] Network is a required parameter."
-    exit 1
-fi
-
-CHANNEL=$("./scripts/release/mule/common/get_channel.sh" "$NETWORK")
+CHANNEL=${CHANNEL:-$("./scripts/release/mule/common/get_channel.sh" "$NETWORK")}
 VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
 PACKAGES_DIR=${PACKAGES_DIR:-~/packages}
-
-if [ -z "$SNAPSHOT" ]
-then
-    SNAPSHOT="$CHANNEL-$VERSION"
-fi
+SNAPSHOT=${SNAPSHOT:-"${CHANNEL}-${VERSION}"}
 
 mkdir -p $PACKAGES_DIR
 

--- a/scripts/release/mule/deploy/deb/deploy.sh
+++ b/scripts/release/mule/deploy/deb/deploy.sh
@@ -19,18 +19,18 @@ aptly repo import beta beta algorand-beta algorand-devtools-beta
 
 cp -f tmp/{algorand,algorand-devtools}_${CHANNEL}_linux-{amd64,arm64}_${VERSION}.deb $PACKAGES_DIR
 
-# if ls -A $PACKAGES_DIR
-# then
-#     aptly repo add "$CHANNEL" "$PACKAGES_DIR"/*.deb
-#     aptly repo show -with-packages "$CHANNEL"
-#     aptly snapshot create "$SNAPSHOT" from repo "$CHANNEL"
-#     if ! aptly publish show "$CHANNEL" s3:algorand-releases: &> /dev/null
-#     then
-#         aptly publish -batch snapshot -gpg-key=dev@algorand.com -origin=Algorand -label=Algorand "$SNAPSHOT" s3:algorand-releases:
-#     else
-#         aptly publish switch "$CHANNEL" s3:algorand-releases: "$SNAPSHOT"
-#     fi
-# else
-#     echo "[$0] The packages directory is empty, so there is nothing to add the \`$CHANNEL\` repo."
-#     exit 1
-# fi
+if ls -A $PACKAGES_DIR
+then
+    aptly repo add "$CHANNEL" "$PACKAGES_DIR"/*.deb
+    aptly repo show -with-packages "$CHANNEL"
+    aptly snapshot create "$SNAPSHOT" from repo "$CHANNEL"
+    if ! aptly publish show "$CHANNEL" s3:algorand-releases: &> /dev/null
+    then
+        aptly publish -batch snapshot -gpg-key=dev@algorand.com -origin=Algorand -label=Algorand "$SNAPSHOT" s3:algorand-releases:
+    else
+        aptly publish switch "$CHANNEL" s3:algorand-releases: "$SNAPSHOT"
+    fi
+else
+    echo "[$0] The packages directory is empty, so there is nothing to add the \`$CHANNEL\` repo."
+    exit 1
+fi

--- a/scripts/release/mule/deploy/docker/docker.sh
+++ b/scripts/release/mule/deploy/docker/docker.sh
@@ -13,9 +13,9 @@ if [ -z "$NETWORK" ] || [ -z "$VERSION" ]; then
     exit 1
 fi
 
-if [[ ! "$NETWORK" =~ ^mainnet$|^testnet$|^betanet$|^alphanet$ ]]
+if [[ ! "$NETWORK" =~ ^mainnet$|^testnet$|^betanet$ ]]
 then
-    echo "[$0] Network values must be either \`mainnet\`, \`testnet\`, \`betanet\`, or \`alphanet\`."
+    echo "[$0] Network values must be either \`mainnet\`, \`testnet\`, or \`betanet\`."
     exit 1
 fi
 
@@ -28,7 +28,7 @@ then
 
   # Build and push testnet.
   ./build_releases.sh --tagname "$VERSION" --network testnet --cached
-elif [ "$NETWORK" = betanet ] || [ "$NETWORK" = alphanet ]
+elif [ "$NETWORK" = betanet ]
 then
   ./build_releases.sh --tagname "$VERSION" --network "$NETWORK"
 fi

--- a/scripts/release/mule/deploy/releases_page/generate_releases_page.sh
+++ b/scripts/release/mule/deploy/releases_page/generate_releases_page.sh
@@ -13,11 +13,9 @@ VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
 
 cd scripts/release/mule/deploy/releases_page
 
-echo $(./reverse_hex_timestamp)
-# aws s3 sync --acl public-read "s3://algorand-staging/releases/$CHANNEL/$VERSION" "s3://algorand-dev-deb-repo/releases/$CHANNEL/$(./reverse_hex_timestamp)_$VERSION"
+aws s3 sync --acl public-read "s3://algorand-staging/releases/$CHANNEL/$VERSION" "s3://algorand-dev-deb-repo/releases/$CHANNEL/$(./reverse_hex_timestamp)_$VERSION"
 ./generate_releases_page.py > index.html
-# aws s3 cp s3://algorand-releases/index.html s3://algorand-staging/releases-page/index.html-previous
-# aws s3 cp index.html s3://algorand-staging/releases-page/
-aws s3 cp index.html s3://algorand-staging/releases-page-test/ --acl public-read
-# aws s3 cp index.html s3://algorand-releases/
+aws s3 cp s3://algorand-releases/index.html s3://algorand-staging/releases-page/index.html-previous
+aws s3 cp index.html s3://algorand-staging/releases-page/
+aws s3 cp index.html s3://algorand-releases/
 

--- a/scripts/release/mule/deploy/releases_page/generate_releases_page.sh
+++ b/scripts/release/mule/deploy/releases_page/generate_releases_page.sh
@@ -13,9 +13,11 @@ VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
 
 cd scripts/release/mule/deploy/releases_page
 
-aws s3 sync --acl public-read "s3://algorand-staging/releases/$CHANNEL/$VERSION" "s3://algorand-dev-deb-repo/releases/$CHANNEL/$(./reverse_hex_timestamp)_$VERSION"
+echo $(./reverse_hex_timestamp)
+# aws s3 sync --acl public-read "s3://algorand-staging/releases/$CHANNEL/$VERSION" "s3://algorand-dev-deb-repo/releases/$CHANNEL/$(./reverse_hex_timestamp)_$VERSION"
 ./generate_releases_page.py > index.html
-aws s3 cp s3://algorand-releases/index.html s3://algorand-staging/releases-page/index.html-previous
-aws s3 cp index.html s3://algorand-staging/releases-page/
-aws s3 cp index.html s3://algorand-releases/
+# aws s3 cp s3://algorand-releases/index.html s3://algorand-staging/releases-page/index.html-previous
+# aws s3 cp index.html s3://algorand-staging/releases-page/
+aws s3 cp index.html s3://algorand-staging/releases-page-test/ --acl public-read
+# aws s3 cp index.html s3://algorand-releases/
 

--- a/scripts/release/mule/deploy/releases_page/generate_releases_page.sh
+++ b/scripts/release/mule/deploy/releases_page/generate_releases_page.sh
@@ -8,13 +8,8 @@
 
 set -ex
 
-if [ -z "$NETWORK" ] || [ -z "$VERSION" ]
-then
-    echo "[$0] Network and version are required parameters."
-    exit 1
-fi
-
 CHANNEL=${CHANNEL:-$(./scripts/release/mule/common/get_channel.sh "$NETWORK")}
+VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
 
 cd scripts/release/mule/deploy/releases_page
 

--- a/scripts/release/mule/deploy/releases_page/generate_releases_page.sh
+++ b/scripts/release/mule/deploy/releases_page/generate_releases_page.sh
@@ -14,7 +14,7 @@ then
     exit 1
 fi
 
-CHANNEL=$(./scripts/release/mule/common/get_channel.sh "$NETWORK")
+CHANNEL=${CHANNEL:-$(./scripts/release/mule/common/get_channel.sh "$NETWORK")}
 
 cd scripts/release/mule/deploy/releases_page
 

--- a/scripts/release/mule/deploy/rpm/deploy.sh
+++ b/scripts/release/mule/deploy/rpm/deploy.sh
@@ -9,8 +9,7 @@ echo
 
 CHANNEL=${CHANNEL:-$(./scripts/release/mule/common/get_channel.sh "$NETWORK")}
 VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
-# NO_DEPLOY=${NO_DEPLOY:-false}
-NO_DEPLOY=true
+NO_DEPLOY=${NO_DEPLOY:-false}
 PACKAGES_DIR=${PACKAGES_DIR:-"tmp"}
 
 if [ -n "$S3_SOURCE" ]

--- a/scripts/release/mule/deploy/rpm/deploy.sh
+++ b/scripts/release/mule/deploy/rpm/deploy.sh
@@ -71,7 +71,18 @@ then
 else
     # aws s3 sync rpmrepo "s3://algorand-releases/rpm/$CHANNEL/"
     # sync signatures to releases so that the .sig files load from there
-    # aws s3 sync s3://algorand-staging/releases/$CHANNEL/ s3://algorand-releases/rpm/sigs/$CHANNEL/ --exclude='*' --include='*.rpm.sig'
+
+    if [ -n "$S3_SOURCE" ]; then
+        # if S3_SOURCE exists, we copied files from s3
+        echo "Copy signatures from s3 staging to s3 releases"
+        # aws s3 sync s3://algorand-staging/releases/$CHANNEL/ s3://algorand-releases/rpm/sigs/$CHANNEL/ --exclude='*' --include='*.rpm.sig'
+
+    else
+        # We are working with files locally
+        popd
+        echo "Copy local signatures to s3 releases"
+        # aws s3 cp tmp/*.sig "s3://algorand-releases/rpm/sigs/$CHANNEL/"
+    fi
 fi
 
 echo

--- a/scripts/release/mule/deploy/rpm/deploy.sh
+++ b/scripts/release/mule/deploy/rpm/deploy.sh
@@ -57,7 +57,7 @@ mkdir rpmrepo
 for rpm in $(ls *"$VERSION"*.rpm)
 do
     rpmsign --addsign "$rpm"
-    mv -p "$rpm" rpmrepo
+    mv -f "$rpm" rpmrepo
 done
 
 createrepo --database rpmrepo

--- a/scripts/release/mule/sign/sign.sh
+++ b/scripts/release/mule/sign/sign.sh
@@ -94,8 +94,8 @@ for os in "${OS_TYPES[@]}"; do
 
                 HASHFILE="hashes_${CHANNEL}_${os}_${arch}_${VERSION}"
                 md5sum *.tar.gz *.deb *.rpm >> "$HASHFILE"
-                sha1sum -a 256 *.tar.gz *.deb *.rpm >> "$HASHFILE"
-                sha1sum -a 512 *.tar.gz *.deb *.rpm >> "$HASHFILE"
+                sha256sum *.tar.gz *.deb *.rpm >> "$HASHFILE"
+                sha512sum *.tar.gz *.deb *.rpm >> "$HASHFILE"
 
                 gpg -u "$SIGNING_KEY_ADDR" --detach-sign "$HASHFILE"
                 gpg -u "$SIGNING_KEY_ADDR" --clearsign "$HASHFILE"

--- a/scripts/release/mule/sign/sign.sh
+++ b/scripts/release/mule/sign/sign.sh
@@ -35,6 +35,14 @@ then
     find "$GPG_DIR" -type f -exec chmod 600 {} \;
 fi
 
+pushd /root
+cat << EOF > .rpmmacros
+%_gpg_name Algorand RPM <rpm@algorand.com>
+%__gpg /usr/bin/gpg2
+%__gpg_check_password_cmd true
+EOF
+popd
+
 # Note that when downloading from the cloud that we'll get all packages for all architectures.
 if [ -n "$S3_SOURCE" ]
 then
@@ -79,12 +87,6 @@ for os in "${OS_TYPES[@]}"; do
                 do
                     gpg -u "$SIGNING_KEY_ADDR" --detach-sign "$file"
                 done
-
-                cat << EOF > .rpmmacros
-%_gpg_name Algorand RPM <rpm@algorand.com>
-%__gpg /usr/bin/gpg2
-%__gpg_check_password_cmd true
-EOF
 
                 for file in *.rpm
                 do

--- a/scripts/release/mule/sign/sign.sh
+++ b/scripts/release/mule/sign/sign.sh
@@ -94,8 +94,8 @@ for os in "${OS_TYPES[@]}"; do
 
                 HASHFILE="hashes_${CHANNEL}_${os}_${arch}_${VERSION}"
                 md5sum *.tar.gz *.deb *.rpm >> "$HASHFILE"
-                shasum -a 256 *.tar.gz *.deb *.rpm >> "$HASHFILE"
-                shasum -a 512 *.tar.gz *.deb *.rpm >> "$HASHFILE"
+                sha1sum -a 256 *.tar.gz *.deb *.rpm >> "$HASHFILE"
+                sha1sum -a 512 *.tar.gz *.deb *.rpm >> "$HASHFILE"
 
                 gpg -u "$SIGNING_KEY_ADDR" --detach-sign "$HASHFILE"
                 gpg -u "$SIGNING_KEY_ADDR" --clearsign "$HASHFILE"

--- a/scripts/release/mule/sign/sign.sh
+++ b/scripts/release/mule/sign/sign.sh
@@ -53,12 +53,6 @@ then
     done
 fi
 
-cat << EOF > .rpmmacros
-%_gpg_name Algorand RPM <rpm@algorand.com>
-%__gpg /usr/bin/gpg2
-%__gpg_check_password_cmd true
-EOF
-
 cd "$PKG_DIR"
 
 # TODO: "$PKG_TYPE" == "source"
@@ -85,6 +79,12 @@ for os in "${OS_TYPES[@]}"; do
                 do
                     gpg -u "$SIGNING_KEY_ADDR" --detach-sign "$file"
                 done
+
+                cat << EOF > .rpmmacros
+%_gpg_name Algorand RPM <rpm@algorand.com>
+%__gpg /usr/bin/gpg2
+%__gpg_check_password_cmd true
+EOF
 
                 for file in *.rpm
                 do

--- a/test/muleCI/Jenkinsfile
+++ b/test/muleCI/Jenkinsfile
@@ -1,3 +1,3 @@
-@Library('go-algorand-ci@onetechnical/go-algorand-build-cleanup') _
+@Library('go-algorand-ci) _
 
 muleCI('test/muleCI/mule.yaml', '0.0.23')

--- a/test/muleCI/Jenkinsfile
+++ b/test/muleCI/Jenkinsfile
@@ -1,3 +1,3 @@
-@Library('go-algorand-ci) _
+@Library('go-algorand-ci') _
 
 muleCI('test/muleCI/mule.yaml', '0.0.23')

--- a/test/muleCI/Jenkinsfile
+++ b/test/muleCI/Jenkinsfile
@@ -1,3 +1,3 @@
-@Library('go-algorand-ci') _
+@Library('go-algorand-ci@onetechnical/go-algorand-build-cleanup') _
 
 muleCI('test/muleCI/mule.yaml', '0.0.23')

--- a/test/muleCI/mule.yaml
+++ b/test/muleCI/mule.yaml
@@ -61,22 +61,6 @@ agents:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
       - ARCH=arm64v8
       - GOARCH=arm64
-  - name: cicd.ubuntu.arm
-    dockerFilePath: docker/build/cicd.ubuntu.Dockerfile
-    image: algorand/go-algorand-ci-linux
-    version: scripts/configure_dev-deps.sh
-    arch: arm32v7
-    env:
-      - TRAVIS_BRANCH=${GIT_BRANCH}
-      - NETWORK=$NETWORK
-      - VERSION=$VERSION
-      - BUILD_NUMBER=$BUILD_NUMBER
-      - GOHOSTARCH=arm
-      - FULLVERSION=${FULLVERSION}
-    buildArgs:
-      - GOLANG_VERSION=`./scripts/get_golang_version.sh`
-      - ARCH=arm32v7
-      - GOARCH=armv6l
   - name: docker-ubuntu
     dockerFilePath: docker/build/docker.ubuntu.Dockerfile
     image: algorand/go-algorand-docker-linux-ubuntu
@@ -122,10 +106,6 @@ tasks:
     name: build.arm64
     agent: cicd.ubuntu.arm64
     target: ci-build
-  - task: docker.Make
-    name: build.arm
-    agent: cicd.ubuntu.arm
-    target: ci-build
 
   - task: docker.Make
     name: archive
@@ -168,12 +148,6 @@ tasks:
     globSpecs:
       - tmp/node_pkgs/**/*
   - task: stash.Stash
-    name: linux-arm
-    bucketName: go-algorand-ci-cache
-    stashId: ${JENKINS_JOB_CACHE_ID}/linux-arm
-    globSpecs:
-      - tmp/node_pkgs/**/*
-  - task: stash.Stash
     name: packages
     bucketName: go-algorand-ci-cache
     stashId: ${JENKINS_JOB_CACHE_ID}/packages
@@ -193,10 +167,6 @@ tasks:
     name: darwin-amd64
     bucketName: go-algorand-ci-cache
     stashId: ${JENKINS_JOB_CACHE_ID}/darwin-amd64
-  - task: stash.Unstash
-    name: linux-arm
-    bucketName: go-algorand-ci-cache
-    stashId: ${JENKINS_JOB_CACHE_ID}/linux-arm
   - task: stash.Unstash
     name: darwin-arm64
     bucketName: go-algorand-ci-cache
@@ -233,15 +203,10 @@ jobs:
     tasks:
       - docker.Make.build.arm64
       - stash.Stash.linux-arm64
-  build-linux-arm32:
-    tasks:
-      - docker.Make.build.arm
-      - stash.Stash.linux-arm
   package-all:
     tasks:
       - stash.Unstash.linux-amd64
       - stash.Unstash.linux-arm64
-      - stash.Unstash.linux-arm
       - stash.Unstash.darwin-arm64
       - stash.Unstash.darwin-amd64
       - docker.Make.deb.amd64


### PR DESCRIPTION
## Summary

Issues in some of the pipelines was preventing a clean end to end build. This PR makes the following changes:

- Fix issues in debian and rpm package building pipelines
- Shift rpm signing to build instead of rpm repository update step
- Explicitly enable ARM64 and disable ARM32
- Cleanup of some parameters passed to build stages
- Removed alphanet from some build processes

## Test Plan

Manual testing around building and signing
