### PR TITLE
p2p: introduce Gossip peer capability

### DIFF
--- a/network/p2p/capabilities.go
+++ b/network/p2p/capabilities.go
@@ -41,6 +41,8 @@ const (
 	Archival Capability = "archival"
 	// Catchpoints storing nodes
 	Catchpoints = "catchpointStoring"
+	// Gossip nodes are non permissioned relays
+	Gossip = "gossip"
 )
 
 const operationTimeout = time.Second * 5

--- a/network/p2p/capabilities_test.go
+++ b/network/p2p/capabilities_test.go
@@ -47,7 +47,7 @@ func TestCapabilities_Discovery(t *testing.T) {
 	testSize := 3
 	for i := 0; i < testSize; i++ {
 		tempdir := t.TempDir()
-		ps, err := peerstore.NewPeerStore(nil)
+		ps, err := peerstore.NewPeerStore(nil, "")
 		require.NoError(t, err)
 		h, _, err := MakeHost(config.GetDefaultLocal(), tempdir, ps)
 		require.NoError(t, err)
@@ -83,7 +83,7 @@ func setupDHTHosts(t *testing.T, numHosts int) []*dht.IpfsDHT {
 		tmpdir := t.TempDir()
 		pk, err := GetPrivKey(cfg, tmpdir)
 		require.NoError(t, err)
-		ps, err := peerstore.NewPeerStore([]*peer.AddrInfo{})
+		ps, err := peerstore.NewPeerStore([]*peer.AddrInfo{}, "")
 		require.NoError(t, err)
 		h, err := libp2p.New(
 			libp2p.ListenAddrStrings("/dns4/localhost/tcp/0"),
@@ -134,7 +134,7 @@ func setupCapDiscovery(t *testing.T, numHosts int, numBootstrapPeers int) []*Cap
 		tmpdir := t.TempDir()
 		pk, err := GetPrivKey(cfg, tmpdir)
 		require.NoError(t, err)
-		ps, err := peerstore.NewPeerStore([]*peer.AddrInfo{})
+		ps, err := peerstore.NewPeerStore([]*peer.AddrInfo{}, "")
 		require.NoError(t, err)
 		h, err := libp2p.New(
 			libp2p.ListenAddrStrings("/dns4/localhost/tcp/0"),

--- a/network/p2p/dnsaddr/resolve_test.go
+++ b/network/p2p/dnsaddr/resolve_test.go
@@ -37,22 +37,22 @@ func TestIsDnsaddr(t *testing.T) {
 	t.Parallel()
 
 	testcases := []struct {
-		name     string
-		addr     string
-		expected bool
+		name      string
+		addr      string
+		isDnsaddr bool
 	}{
-		{name: "DnsAddr", addr: "/dnsaddr/foobar.com", expected: true},
-		{name: "DnsAddrWithPeerId", addr: "/dnsaddr/foobar.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN", expected: true},
-		{name: "DnsAddrWithIPPeerId", addr: "/dnsaddr/foobar.com/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN", expected: true},
-		{name: "Dns4Addr", addr: "/dns4/foobar.com/", expected: false},
-		{name: "Dns6Addr", addr: "/dns6/foobar.com/", expected: false},
-		{name: "Dns4AddrWithPeerId", addr: "/dns4/foobar.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN", expected: false},
+		{name: "DnsAddr", addr: "/dnsaddr/foobar.com", isDnsaddr: true},
+		{name: "DnsAddrWithPeerId", addr: "/dnsaddr/foobar.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN", isDnsaddr: true},
+		{name: "DnsAddrWithIPPeerId", addr: "/dnsaddr/foobar.com/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN", isDnsaddr: true},
+		{name: "Dns4Addr", addr: "/dns4/foobar.com/", isDnsaddr: false},
+		{name: "Dns6Addr", addr: "/dns6/foobar.com/", isDnsaddr: false},
+		{name: "Dns4AddrWithPeerId", addr: "/dns4/foobar.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN", isDnsaddr: false},
 	}
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
 			maddr, err := multiaddr.NewMultiaddr(testcase.addr)
 			require.NoError(t, err)
-			require.Equal(t, testcase.expected, isDnsaddr(maddr))
+			require.Equal(t, testcase.isDnsaddr, isDnsaddr(maddr))
 		})
 	}
 }

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -43,6 +43,7 @@ import (
 	"github.com/multiformats/go-multiaddr"
 )
 
+// SubNextCancellable is an abstraction for pubsub.Subscription
 type SubNextCancellable interface {
 	Next(ctx context.Context) (*pubsub.Message, error)
 	Cancel()

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -43,6 +43,11 @@ import (
 	"github.com/multiformats/go-multiaddr"
 )
 
+type SubNextCancellable interface {
+	Next(ctx context.Context) (*pubsub.Message, error)
+	Cancel()
+}
+
 // Service defines the interface used by the network integrating with underlying p2p implementation
 type Service interface {
 	Start() error
@@ -57,7 +62,7 @@ type Service interface {
 
 	Conns() []network.Conn
 	ListPeersForTopic(topic string) []peer.ID
-	Subscribe(topic string, val pubsub.ValidatorEx) (*pubsub.Subscription, error)
+	Subscribe(topic string, val pubsub.ValidatorEx) (SubNextCancellable, error)
 	Publish(ctx context.Context, topic string, data []byte) error
 
 	GetStream(peer.ID) (network.Stream, bool)

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -226,6 +226,8 @@ func (s *serviceImpl) DialPeersUntilTargetCount(targetConnCount int) {
 		if len(s.host.Network().ConnsToPeer(peerID)) > 0 {
 			continue
 		}
+		// TODO: prefer relays nodes?
+		// switch to phonebook instead of peerstore
 		peerInfo := s.host.Peerstore().PeerInfo(peerID)
 		err := s.DialNode(context.Background(), &peerInfo) // leaving the calls as blocking for now, to not over-connect beyond fanout
 		if err != nil {

--- a/network/p2p/p2p_test.go
+++ b/network/p2p/p2p_test.go
@@ -89,7 +89,7 @@ func TestP2PStreamingHost(t *testing.T) {
 
 	cfg := config.GetDefaultLocal()
 	dir := t.TempDir()
-	pstore, err := peerstore.NewPeerStore(nil)
+	pstore, err := peerstore.NewPeerStore(nil, "")
 	require.NoError(t, err)
 	h, la, err := MakeHost(cfg, dir, pstore)
 	require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestP2PStreamingHost(t *testing.T) {
 		ID:    h.ID(),
 		Addrs: h.Addrs(),
 	}
-	cpstore, err := peerstore.NewPeerStore([]*peer.AddrInfo{&addrInfo})
+	cpstore, err := peerstore.NewPeerStore([]*peer.AddrInfo{&addrInfo}, "")
 	require.NoError(t, err)
 	c, _, err := MakeHost(cfg, dir, cpstore)
 	require.NoError(t, err)

--- a/network/p2p/peerstore/peerstore.go
+++ b/network/p2p/peerstore/peerstore.go
@@ -68,18 +68,21 @@ type peerStoreCAB interface {
 }
 
 // NewPeerStore creates a new peerstore backed by a datastore.
-func NewPeerStore(addrInfo []*peer.AddrInfo) (*PeerStore, error) {
+func NewPeerStore(addrInfo []*peer.AddrInfo, network string) (*PeerStore, error) {
 	ps, err := mempstore.NewPeerstore()
 	if err != nil {
 		return nil, fmt.Errorf("cannot initialize a peerstore: %w", err)
 	}
 
 	// initialize peerstore with addresses
+	peers := make([]interface{}, len(addrInfo))
 	for i := 0; i < len(addrInfo); i++ {
-		info := addrInfo[i]
-		ps.AddAddrs(info.ID, info.Addrs, libp2p.AddressTTL)
+		peers[i] = addrInfo[i]
+		// ps.AddAddrs(addrInfo[i].ID, addrInfo[i].Addrs, libp2p.AddressTTL)
 	}
+
 	pstore := &PeerStore{peerStoreCAB: ps}
+	pstore.AddPersistentPeers(peers, network, phonebook.PhoneBookEntryRelayRole)
 	return pstore, nil
 }
 
@@ -98,7 +101,7 @@ func MakePhonebook(connectionsRateLimitingCount uint,
 }
 
 // GetAddresses returns up to N addresses, but may return fewer
-func (ps *PeerStore) GetAddresses(n int, role phonebook.PhoneBookEntryRoles) []string {
+func (ps *PeerStore) GetAddresses(n int, role phonebook.PhoneBookEntryRoles) []interface{} {
 	return shuffleSelect(ps.filterRetryTime(time.Now(), role), n)
 }
 
@@ -206,7 +209,7 @@ func (ps *PeerStore) UpdateConnectionTime(addr interface{}, provisionalTime time
 }
 
 // ReplacePeerList replaces the peer list for the given networkName and role.
-func (ps *PeerStore) ReplacePeerList(addressesThey []string, networkName string, role phonebook.PhoneBookEntryRoles) {
+func (ps *PeerStore) ReplacePeerList(addressesThey []interface{}, networkName string, role phonebook.PhoneBookEntryRoles) {
 	// prepare a map of items we'd like to remove.
 	removeItems := make(map[peer.ID]bool, 0)
 	peerIDs := ps.Peers()
@@ -221,10 +224,7 @@ func (ps *PeerStore) ReplacePeerList(addressesThey []string, networkName string,
 
 	}
 	for _, addr := range addressesThey {
-		info, err := peerInfoFromDomainPort(addr)
-		if err != nil {
-			return
-		}
+		info := addr.(*peer.AddrInfo)
 		data, _ := ps.Get(info.ID, addressDataKey)
 		if data != nil {
 			// we already have this.
@@ -294,7 +294,7 @@ func (ps *PeerStore) deletePhonebookEntry(peerID peer.ID, networkName string) {
 	}
 	ad := data.(addressData)
 	delete(ad.networkNames, networkName)
-	if 0 == len(ad.networkNames) {
+	if len(ad.networkNames) == 0 {
 		ps.ClearAddrs(peerID)
 		_ = ps.Put(peerID, addressDataKey, nil)
 	}
@@ -319,21 +319,23 @@ func (ps *PeerStore) popNElements(n int, peerID peer.ID) {
 	_ = ps.Put(peerID, addressDataKey, ad)
 }
 
-func (ps *PeerStore) filterRetryTime(t time.Time, role phonebook.PhoneBookEntryRoles) []string {
-	o := make([]string, 0, len(ps.Peers()))
+func (ps *PeerStore) filterRetryTime(t time.Time, role phonebook.PhoneBookEntryRoles) []interface{} {
+	o := make([]interface{}, 0, len(ps.Peers()))
 	for _, peerID := range ps.Peers() {
 		data, _ := ps.Get(peerID, addressDataKey)
 		if data != nil {
 			ad := data.(addressData)
 			if t.After(ad.retryAfter) && role == ad.role {
-				o = append(o, string(peerID))
+				mas := ps.Addrs(peerID)
+				info := peer.AddrInfo{ID: peerID, Addrs: mas}
+				o = append(o, &info)
 			}
 		}
 	}
 	return o
 }
 
-func shuffleSelect(set []string, n int) []string {
+func shuffleSelect(set []interface{}, n int) []interface{} {
 	if n >= len(set) || n == getAllAddresses {
 		// return shuffled copy of everything
 		out := slices.Clone(set)
@@ -350,13 +352,13 @@ func shuffleSelect(set []string, n int) []string {
 			}
 		}
 	}
-	out := make([]string, n)
+	out := make([]interface{}, n)
 	for i, index := range indexSample {
 		out[i] = set[index]
 	}
 	return out
 }
 
-func shuffleStrings(set []string) {
+func shuffleStrings(set []interface{}) {
 	rand.Shuffle(len(set), func(i, j int) { set[i], set[j] = set[j], set[i] })
 }

--- a/network/p2p/peerstore/peerstore.go
+++ b/network/p2p/peerstore/peerstore.go
@@ -78,7 +78,6 @@ func NewPeerStore(addrInfo []*peer.AddrInfo, network string) (*PeerStore, error)
 	peers := make([]interface{}, len(addrInfo))
 	for i := 0; i < len(addrInfo); i++ {
 		peers[i] = addrInfo[i]
-		// ps.AddAddrs(addrInfo[i].ID, addrInfo[i].Addrs, libp2p.AddressTTL)
 	}
 
 	pstore := &PeerStore{peerStoreCAB: ps}

--- a/network/p2p/pubsub.go
+++ b/network/p2p/pubsub.go
@@ -133,7 +133,7 @@ func (s *serviceImpl) getOrCreateTopic(topicName string) (*pubsub.Topic, error) 
 }
 
 // Subscribe returns a subscription to the given topic
-func (s *serviceImpl) Subscribe(topic string, val pubsub.ValidatorEx) (*pubsub.Subscription, error) {
+func (s *serviceImpl) Subscribe(topic string, val pubsub.ValidatorEx) (SubNextCancellable, error) {
 	if err := s.pubsub.RegisterTopicValidator(topic, val); err != nil {
 		return nil, err
 	}

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -544,8 +544,9 @@ func (n *P2PNetwork) GetPeers(options ...PeerOption) []Peer {
 				}
 				n.log.Debugf("Got %d archival node(s) from DHT", len(infos))
 				for _, addrInfo := range infos {
-					info := &addrInfo
-					if peerCore, ok := addrInfoToWsPeerCore(n, info); ok {
+					// TODO: remove after go1.22
+					info := addrInfo
+					if peerCore, ok := addrInfoToWsPeerCore(n, &info); ok {
 						peers = append(peers, &peerCore)
 					}
 				}

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -175,7 +175,6 @@ func NewP2PNetwork(log logging.Logger, cfg config.Local, datadir string, phonebo
 		pstore:        pstore,
 		relayMessages: relayMessages,
 	}
-	net.wantTXGossip.Store(relayMessages || cfg.ForceFetchTransactions || node.IsParticipating())
 
 	net.ctx, net.ctxCancel = context.WithCancel(context.Background())
 	net.handler = msgHandler{
@@ -253,7 +252,10 @@ func (n *P2PNetwork) Start() error {
 	if err != nil {
 		return err
 	}
-	if n.wantTXGossip.Load() {
+
+	wantTXGossip := n.relayMessages || n.config.ForceFetchTransactions || n.nodeInfo.IsParticipating()
+	if wantTXGossip {
+		n.wantTXGossip.Store(true)
 		n.wg.Add(1)
 		go n.txTopicHandleLoop()
 	}

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -167,7 +167,7 @@ func NewP2PNetwork(log logging.Logger, cfg config.Local, datadir string, phonebo
 		config:        cfg,
 		genesisID:     genesisID,
 		networkID:     networkID,
-		topicTags:     map[protocol.Tag]string{"TX": p2p.TXTopicName},
+		topicTags:     map[protocol.Tag]string{protocol.TxnTag: p2p.TXTopicName},
 		wsPeers:       make(map[peer.ID]*wsPeer),
 		wsPeersToIDs:  make(map[*wsPeer]peer.ID),
 		peerStats:     make(map[peer.ID]*p2pPeerStats),
@@ -767,6 +767,7 @@ func (n *P2PNetwork) txTopicHandleLoop() {
 		n.log.Errorf("Failed to subscribe to topic %s: %v", p2p.TXTopicName, err)
 		return
 	}
+	n.log.Debugf("Subscribed to topic %s", p2p.TXTopicName)
 
 	for {
 		msg, err := sub.Next(n.ctx)
@@ -774,6 +775,7 @@ func (n *P2PNetwork) txTopicHandleLoop() {
 			if err != pubsub.ErrSubscriptionCancelled && err != context.Canceled {
 				n.log.Errorf("Error reading from subscription %v, peerId %s", err, n.service.ID())
 			}
+			n.log.Debugf("Canceling subscription to topic %s due Next error", p2p.TXTopicName)
 			sub.Cancel()
 			return
 		}
@@ -785,7 +787,7 @@ func (n *P2PNetwork) txTopicHandleLoop() {
 
 		// participation or configuration change, cancel subscription and quit
 		if !n.wantTXGossip.Load() {
-			n.log.Debugf("Canceling subscription to topic %s", p2p.TXTopicName)
+			n.log.Debugf("Canceling subscription to topic %s due participation change", p2p.TXTopicName)
 			sub.Cancel()
 			return
 		}

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -115,10 +115,14 @@ func TestP2PSubmitTX(t *testing.T) {
 		func() bool {
 			netC.peerStatsMu.Lock()
 			netCpeerStatsA, ok := netC.peerStats[netA.service.ID()]
+			for pid, stat := range netC.peerStats {
+				fmt.Printf("peer %s: %v\n", pid, stat)
+			}
 			netC.peerStatsMu.Unlock()
 			if !ok {
 				return false
 			}
+			// fmt.Printf("netCpeerStatsA.txReceived.Load() %d", netCpeerStatsA.txReceived.Load())
 			return netCpeerStatsA.txReceived.Load() == 10
 		},
 		5*time.Second,
@@ -867,9 +871,10 @@ func TestP2PWantTXGossip(t *testing.T) {
 	cancel()
 	mockService := &mockSubPService{}
 	net := &P2PNetwork{
+		service:  mockService,
+		log:      logging.TestingLog(t),
 		ctx:      ctx,
 		nodeInfo: &nopeNodeInfo{},
-		service:  mockService,
 	}
 	net.wantTXGossip.Store(false)
 

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -427,8 +427,8 @@ func waitForRouting(t *testing.T, disc *p2p.CapabilitiesDiscovery) {
 	}
 }
 
-// TestP2PNetworkDHTCapabilities runs nodes with capabilites and ensures that connected nodes
-// can discover themself. The other nodes receive the first node in bootstrap list before starting.
+// TestP2PNetworkDHTCapabilities runs nodes with capabilities and ensures that connected nodes
+// can discover itself. The other nodes receive the first node in bootstrap list before starting.
 // There is two variations of the test: only netA advertises capabilities, and all nodes advertise.
 func TestP2PNetworkDHTCapabilities(t *testing.T) {
 	partitiontest.PartitionTest(t)
@@ -506,9 +506,13 @@ func TestP2PNetworkDHTCapabilities(t *testing.T) {
 
 			t.Logf("DHT is ready")
 
-			// ensure all peers are connected
+			// ensure all peers are connected - wait for connectivity as needed
 			for _, disc := range discs {
-				require.Equal(t, 2, len(disc.Host().Network().Peers()))
+				go func(disc *p2p.CapabilitiesDiscovery) {
+					require.Eventuallyf(t, func() bool {
+						return len(disc.Host().Network().Peers()) == 2
+					}, time.Minute, time.Second, "Not all peers were found")
+				}(disc)
 			}
 
 			wg.Add(len(discs))

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -248,6 +248,8 @@ func TestP2PSubmitWS(t *testing.T) {
 		return netA.hasPeers() && netB.hasPeers() && netC.hasPeers()
 	}, 2*time.Second, 50*time.Millisecond)
 
+	time.Sleep(time.Second) // give time for peers to connect.
+
 	// now we should be connected in a line: B <-> A <-> C where both B and C are connected to A but not each other
 
 	testTag := protocol.AgreementVoteTag

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -121,7 +121,7 @@ func TestP2PSubmitTX(t *testing.T) {
 			}
 			return netCpeerStatsA.txReceived.Load() == 10
 		},
-		1*time.Second,
+		5*time.Second,
 		50*time.Millisecond,
 	)
 }
@@ -197,7 +197,7 @@ func TestP2PSubmitTXNoGossip(t *testing.T) {
 			}
 			return netBpeerStatsA.txReceived.Load() == 10
 		},
-		1*time.Second,
+		5*time.Second,
 		50*time.Millisecond,
 	)
 

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -453,7 +453,7 @@ func TestP2PBootstrapFunc(t *testing.T) {
 	b := bootstrapper{}
 	require.Nil(t, b.BootstrapFunc())
 
-	b.started = true
+	b.started.Store(true)
 	p := peer.AddrInfo{ID: "test"}
 	b.phonebookPeers = []*peer.AddrInfo{&p}
 	require.Equal(t, []peer.AddrInfo{p}, b.BootstrapFunc())

--- a/node/node.go
+++ b/node/node.go
@@ -399,7 +399,6 @@ func (node *AlgorandFullNode) Capabilities() []p2p.Capability {
 	if node.config.StoresCatchpoints() {
 		caps = append(caps, p2p.Catchpoints)
 	}
-	// TODO: change to a separate
 	if node.config.EnableGossipService && node.config.IsGossipServer() {
 		caps = append(caps, p2p.Gossip)
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -399,6 +399,10 @@ func (node *AlgorandFullNode) Capabilities() []p2p.Capability {
 	if node.config.StoresCatchpoints() {
 		caps = append(caps, p2p.Catchpoints)
 	}
+	// TODO: change to a separate
+	if node.config.EnableGossipService && node.config.IsGossipServer() {
+		caps = append(caps, p2p.Gossip)
+	}
 	return caps
 }
 


### PR DESCRIPTION
## Summary

This PR enables p2p relays by introducing a new gossip capability and preferring such peers for connection.
- [x] Add DHT capability
- [x] Update peerstore methods (and tests) to support AddInfo/multiaddrs
- [x] Query `Gossip` peer from DHT
- [x] Prefer `Gossip` peers when dialing. Ensure DHT subsystem maintains own peers and can connect to such DHT peers.
- [x] Added `relayMessages` condition 
- [x] Do not send TX traffic to NPN nodes 

## Test Plan

* Unit tests for `relayMessages`
* Unit tests for `wantTXGossip` and gossip sub.
* Unit test for gossip capability