### PR TITLE
Network: Class-based Peer Selector

### DIFF
--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -285,10 +285,10 @@ func (cs *CatchpointCatchupService) processStageLedgerDownload() error {
 	cs.statsMu.Lock()
 	label := cs.stats.CatchpointLabel
 	cs.statsMu.Unlock()
-	round, _, err0 := ledgercore.ParseCatchpointLabel(label)
+	round, _, err := ledgercore.ParseCatchpointLabel(label)
 
-	if err0 != nil {
-		return cs.abort(fmt.Errorf("processStageLedgerDownload failed to parse label : %v", err0))
+	if err != nil {
+		return cs.abort(fmt.Errorf("processStageLedgerDownload failed to parse label : %v", err))
 	}
 
 	// download balances file.
@@ -298,26 +298,26 @@ func (cs *CatchpointCatchupService) processStageLedgerDownload() error {
 	for {
 		attemptsCount++
 
-		err1 := cs.ledgerAccessor.ResetStagingBalances(cs.ctx, true)
-		if err1 != nil {
+		err0 := cs.ledgerAccessor.ResetStagingBalances(cs.ctx, true)
+		if err0 != nil {
 			if cs.ctx.Err() != nil {
 				return cs.stopOrAbort()
 			}
-			return cs.abort(fmt.Errorf("processStageLedgerDownload failed to reset staging balances : %v", err1))
+			return cs.abort(fmt.Errorf("processStageLedgerDownload failed to reset staging balances : %v", err0))
 		}
-		psp, err1 := cs.blocksDownloadPeerSelector.getNextPeer()
-		if err1 != nil {
-			err1 = fmt.Errorf("processStageLedgerDownload: catchpoint catchup was unable to obtain a list of peers to retrieve the catchpoint file from")
-			return cs.abort(err1)
+		psp, err0 := cs.blocksDownloadPeerSelector.getNextPeer()
+		if err0 != nil {
+			err0 = fmt.Errorf("processStageLedgerDownload: catchpoint catchup was unable to obtain a list of peers to retrieve the catchpoint file from")
+			return cs.abort(err0)
 		}
 		peer := psp.Peer
 		start := time.Now()
-		err1 = lf.downloadLedger(cs.ctx, peer, round)
-		if err1 == nil {
+		err0 = lf.downloadLedger(cs.ctx, peer, round)
+		if err0 == nil {
 			cs.log.Infof("ledger downloaded in %d seconds", time.Since(start)/time.Second)
 			start = time.Now()
-			err1 = cs.ledgerAccessor.BuildMerkleTrie(cs.ctx, cs.updateVerifiedCounts)
-			if err1 == nil {
+			err0 = cs.ledgerAccessor.BuildMerkleTrie(cs.ctx, cs.updateVerifiedCounts)
+			if err0 == nil {
 				cs.log.Infof("built merkle trie in %d seconds", time.Since(start)/time.Second)
 				break
 			}
@@ -335,15 +335,15 @@ func (cs *CatchpointCatchupService) processStageLedgerDownload() error {
 		}
 
 		if attemptsCount >= cs.config.CatchupLedgerDownloadRetryAttempts {
-			err1 = fmt.Errorf("processStageLedgerDownload: catchpoint catchup exceeded number of attempts to retrieve ledger")
-			return cs.abort(err1)
+			err0 = fmt.Errorf("processStageLedgerDownload: catchpoint catchup exceeded number of attempts to retrieve ledger")
+			return cs.abort(err0)
 		}
-		cs.log.Warnf("unable to download ledger : %v", err1)
+		cs.log.Warnf("unable to download ledger : %v", err0)
 	}
 
-	err0 = cs.updateStage(ledger.CatchpointCatchupStateLatestBlockDownload)
-	if err0 != nil {
-		return cs.abort(fmt.Errorf("processStageLedgerDownload failed to update stage to CatchpointCatchupStateLatestBlockDownload : %v", err0))
+	err = cs.updateStage(ledger.CatchpointCatchupStateLatestBlockDownload)
+	if err != nil {
+		return cs.abort(fmt.Errorf("processStageLedgerDownload failed to update stage to CatchpointCatchupStateLatestBlockDownload : %v", err))
 	}
 	return nil
 }

--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -803,30 +803,7 @@ func (cs *CatchpointCatchupService) updateBlockRetrievalStatistics(acquiredBlock
 }
 
 func (cs *CatchpointCatchupService) initDownloadPeerSelector() {
-	cs.blocksDownloadPeerSelector = cs.makeCatchpointPeerSelector()
-}
-
-func (cs *CatchpointCatchupService) makeCatchpointPeerSelector() peerSelector {
-	wrappedPeerSelectors := []*wrappedPeerSelector{
-		{
-			peerClass: network.PeersPhonebookRelays,
-			peerSelector: makeRankPooledPeerSelector(cs.net,
-				[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookRelays}}),
-			priority:        peerRankInitialFirstPriority,
-			toleranceFactor: 3,
-			lastCheckedTime: time.Now(),
-		},
-		{
-			peerClass: network.PeersPhonebookArchivalNodes,
-			peerSelector: makeRankPooledPeerSelector(cs.net,
-				[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivalNodes}}),
-			priority:        peerRankInitialSecondPriority,
-			toleranceFactor: 10,
-			lastCheckedTime: time.Now(),
-		},
-	}
-
-	return makeClassBasedPeerSelector(wrappedPeerSelectors)
+	cs.blocksDownloadPeerSelector = makeCatchpointPeerSelector(cs.net)
 }
 
 // checkLedgerDownload sends a HEAD request to the ledger endpoint of peers to validate the catchpoint's availability

--- a/catchup/classBasedPeerSelector.go
+++ b/catchup/classBasedPeerSelector.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2019-2024 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package catchup
+
+import (
+	"github.com/algorand/go-algorand/network"
+	"github.com/algorand/go-deadlock"
+	"time"
+)
+
+// classBasedPeerSelector is a peerSelector that tracks and ranks classes of peers based on their response behavior.
+// It is used to select the most appropriate peers to download blocks from - this is most useful when catching up
+// and needing to figure out whether the blocks can be retrieved from relay nodes or require archive nodes.
+type classBasedPeerSelector struct {
+	mu            deadlock.Mutex
+	peerSelectors []*wrappedPeerSelector
+}
+
+func (c *classBasedPeerSelector) rankPeer(psp *peerSelectorPeer, rank int) (int, int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	peerSelectorSortNeeded := false
+	poolIdx, peerIdx := -1, -1
+	for _, wp := range c.peerSelectors {
+		// See if the peer is in the class, ranking it appropriately if so
+		poolIdx, peerIdx = wp.peerSelector.rankPeer(psp, rank)
+		if poolIdx < 0 || peerIdx < 0 {
+			// Peer not found in this class
+			continue
+		}
+		// Peer was in this class, if there was any kind of download issue, we increment the failure count
+		if rank >= peerRankNoBlockForRound {
+			wp.downloadFailures++
+		}
+
+		// If we have failed more than the tolerance factor, we re-sort the slice of peerSelectors
+		if wp.downloadFailures > wp.toleranceFactor {
+			peerSelectorSortNeeded = true
+		}
+		break
+	}
+
+	if peerSelectorSortNeeded {
+		// TODO: Implement sorting of peerSelectors
+	}
+
+	return poolIdx, peerIdx
+}
+
+func (c *classBasedPeerSelector) peerDownloadDurationToRank(psp *peerSelectorPeer, blockDownloadDuration time.Duration) (rank int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, wp := range c.peerSelectors {
+		rank = wp.peerSelector.peerDownloadDurationToRank(psp, blockDownloadDuration)
+		// If rank is peerRankInvalidDownload, we check the next class's peerSelector
+		if rank >= peerRankInvalidDownload {
+			continue
+		}
+		// Should be a legit ranking, we return it
+		return
+	}
+	// If we reached here, we have exhausted all classes without finding the peer
+	return peerRankInvalidDownload
+}
+
+func (c *classBasedPeerSelector) getNextPeer() (psp *peerSelectorPeer, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, wp := range c.peerSelectors {
+		psp, err = wp.peerSelector.getNextPeer()
+		if err != nil {
+			// TODO: No peers available in this class, move to the end of our list???
+			continue
+		}
+		return
+	}
+	// If we reached here, we have exhausted all classes and still have no peers
+	return
+}
+
+type wrappedPeerSelector struct {
+	peerSelector     peerSelector
+	peerClass        network.PeerOption
+	toleranceFactor  int // The number of times we can net fail for any reason before we move to the next class's peerSelector
+	downloadFailures int
+	// TODO: Add a lastUsed time.Duration to this struct
+}
+
+// Logic: We try a class's peerSelector Y times, and if it fails, we move to the next class.
+// If we get to the last peerSelector and are still not getting blocks, we return an error.
+// NOTE: if a peerselector has no pools, we do not use it??

--- a/catchup/classBasedPeerSelector.go
+++ b/catchup/classBasedPeerSelector.go
@@ -52,11 +52,16 @@ func (c *classBasedPeerSelector) rankPeer(psp *peerSelectorPeer, rank int) (int,
 	oldRank, newRank := -1, -1
 	for _, wp := range c.peerSelectors {
 		// See if the peer is in the class, ranking it appropriately if so
-		oldRank, newRank = wp.peerSelector.rankPeer(psp, rank)
-		if oldRank < 0 || newRank < 0 {
-			// Peer not found in this class
+		if psp.peerClass != wp.peerClass {
 			continue
 		}
+
+		oldRank, newRank = wp.peerSelector.rankPeer(psp, rank)
+		if oldRank < 0 || newRank < 0 {
+			// Peer not found in this selector
+			continue
+		}
+
 		// Peer was in this class, if there was any kind of download issue, we increment the failure count
 		if rank >= peerRankNoBlockForRound {
 			wp.downloadFailures++

--- a/catchup/classBasedPeerSelector_test.go
+++ b/catchup/classBasedPeerSelector_test.go
@@ -47,27 +47,23 @@ func TestClassBasedPeerSelector_makeClassBasedPeerSelector(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	// Intentionally put the selectors in non-priority order
 	wrappedPeerSelectors := []*wrappedPeerSelector{
+		{
+			peerClass:       network.PeersPhonebookRelays,
+			peerSelector:    mockPeerSelector{},
+			toleranceFactor: 3,
+			lastCheckedTime: time.Now(),
+		},
 		{
 			peerClass:       network.PeersConnectedOut,
 			peerSelector:    mockPeerSelector{},
-			priority:        peerRankInitialSecondPriority,
 			toleranceFactor: 3,
 			lastCheckedTime: time.Now(),
 		},
 		{
 			peerClass:       network.PeersPhonebookArchivalNodes,
 			peerSelector:    mockPeerSelector{},
-			priority:        peerRankInitialThirdPriority,
 			toleranceFactor: 10,
-			lastCheckedTime: time.Now(),
-		},
-		{
-			peerClass:       network.PeersPhonebookRelays,
-			peerSelector:    mockPeerSelector{},
-			priority:        peerRankInitialFirstPriority,
-			toleranceFactor: 3,
 			lastCheckedTime: time.Now(),
 		},
 	}
@@ -99,7 +95,6 @@ func TestClassBasedPeerSelector_rankPeer(t *testing.T) {
 					return -1, -1
 				},
 			},
-			priority:        peerRankInitialFirstPriority,
 			toleranceFactor: 3,
 			lastCheckedTime: time.Now(),
 		},
@@ -113,7 +108,6 @@ func TestClassBasedPeerSelector_rankPeer(t *testing.T) {
 					return -1, -1
 				},
 			},
-			priority:        peerRankInitialSecondPriority,
 			toleranceFactor: 3,
 			lastCheckedTime: time.Now(),
 		},
@@ -124,7 +118,6 @@ func TestClassBasedPeerSelector_rankPeer(t *testing.T) {
 					return -1, -1
 				},
 			},
-			priority:        peerRankInitialThirdPriority,
 			toleranceFactor: 3,
 			lastCheckedTime: time.Now(),
 		},
@@ -198,7 +191,6 @@ func TestClassBasedPeerSelector_peerDownloadDurationToRank(t *testing.T) {
 					return peerRankInvalidDownload
 				},
 			},
-			priority:        peerRankInitialFirstPriority,
 			toleranceFactor: 3,
 			lastCheckedTime: time.Now(),
 		},
@@ -212,7 +204,6 @@ func TestClassBasedPeerSelector_peerDownloadDurationToRank(t *testing.T) {
 					return peerRankInvalidDownload
 				},
 			},
-			priority:        peerRankInitialSecondPriority,
 			toleranceFactor: 3,
 			lastCheckedTime: time.Now(),
 		},
@@ -223,7 +214,6 @@ func TestClassBasedPeerSelector_peerDownloadDurationToRank(t *testing.T) {
 					return peerRankInvalidDownload
 				},
 			},
-			priority:        peerRankInitialThirdPriority,
 			toleranceFactor: 3,
 			lastCheckedTime: time.Now(),
 		},
@@ -259,7 +249,6 @@ func TestClassBasedPeerSelector_getNextPeer(t *testing.T) {
 					return nil, errPeerSelectorNoPeerPoolsAvailable
 				},
 			},
-			priority:        peerRankInitialFirstPriority,
 			toleranceFactor: 3,
 			lastCheckedTime: time.Now(),
 		},
@@ -270,7 +259,6 @@ func TestClassBasedPeerSelector_getNextPeer(t *testing.T) {
 					return mockPeer, nil
 				},
 			},
-			priority:        peerRankInitialSecondPriority,
 			toleranceFactor: 3,
 			lastCheckedTime: time.Now(),
 		},
@@ -281,7 +269,6 @@ func TestClassBasedPeerSelector_getNextPeer(t *testing.T) {
 					return nil, errPeerSelectorNoPeerPoolsAvailable
 				},
 			},
-			priority:        peerRankInitialThirdPriority,
 			toleranceFactor: 3,
 			lastCheckedTime: time.Now(),
 		},
@@ -330,7 +317,6 @@ func TestClassBasedPeerSelector_getNextPeer(t *testing.T) {
 					return -1, -1
 				},
 			},
-			priority:        peerRankInitialFirstPriority,
 			toleranceFactor: 3,
 			lastCheckedTime: time.Now(),
 		},
@@ -347,7 +333,6 @@ func TestClassBasedPeerSelector_getNextPeer(t *testing.T) {
 					return -1, -1
 				},
 			},
-			priority:        peerRankInitialSecondPriority,
 			toleranceFactor: 10,
 			lastCheckedTime: time.Now(),
 		},
@@ -364,7 +349,6 @@ func TestClassBasedPeerSelector_getNextPeer(t *testing.T) {
 					return -1, -1
 				},
 			},
-			priority:        peerRankInitialThirdPriority,
 			toleranceFactor: 3,
 			lastCheckedTime: time.Now(),
 		},

--- a/catchup/classBasedPeerSelector_test.go
+++ b/catchup/classBasedPeerSelector_test.go
@@ -1,0 +1,322 @@
+package catchup
+
+import (
+	"github.com/algorand/go-algorand/network"
+	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+// Use to mock the wrapped peer selectors where warranted
+type mockPeerSelector struct {
+	mockRankPeer                   func(psp *peerSelectorPeer, rank int) (int, int)
+	mockPeerDownloadDurationToRank func(psp *peerSelectorPeer, blockDownloadDuration time.Duration) (rank int)
+	mockGetNextPeer                func() (psp *peerSelectorPeer, err error)
+}
+
+func (m mockPeerSelector) rankPeer(psp *peerSelectorPeer, rank int) (int, int) {
+	return m.mockRankPeer(psp, rank)
+}
+
+func (m mockPeerSelector) peerDownloadDurationToRank(psp *peerSelectorPeer, blockDownloadDuration time.Duration) (rank int) {
+	return m.mockPeerDownloadDurationToRank(psp, blockDownloadDuration)
+}
+
+func (m mockPeerSelector) getNextPeer() (psp *peerSelectorPeer, err error) {
+	return m.mockGetNextPeer()
+}
+
+func TestClassBasedPeerSelector_makeClassBasedPeerSelector(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	// Intentionally put the selectors in non-priority order
+	wrappedPeerSelectors := []*wrappedPeerSelector{
+		{
+			peerClass:       network.PeersConnectedOut,
+			peerSelector:    mockPeerSelector{},
+			priority:        peerRankInitialSecondPriority,
+			toleranceFactor: 3,
+			lastCheckedTime: time.Now(),
+		},
+		{
+			peerClass:       network.PeersPhonebookArchivalNodes,
+			peerSelector:    mockPeerSelector{},
+			priority:        peerRankInitialThirdPriority,
+			toleranceFactor: 10,
+			lastCheckedTime: time.Now(),
+		},
+		{
+			peerClass:       network.PeersPhonebookRelays,
+			peerSelector:    mockPeerSelector{},
+			priority:        peerRankInitialFirstPriority,
+			toleranceFactor: 3,
+			lastCheckedTime: time.Now(),
+		},
+	}
+
+	cps := makeClassBasedPeerSelector(wrappedPeerSelectors)
+
+	// The selectors should be sorted by priority
+	require.Equal(t, 3, len(cps.peerSelectors))
+	require.Equal(t, network.PeersPhonebookRelays, cps.peerSelectors[0].peerClass)
+	require.Equal(t, network.PeersConnectedOut, cps.peerSelectors[1].peerClass)
+	require.Equal(t, network.PeersPhonebookArchivalNodes, cps.peerSelectors[2].peerClass)
+}
+
+func TestClassBasedPeerSelector_rankPeer(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	mockPeer := &peerSelectorPeer{}
+
+	// Create a class based peer selector initially with the first wrapped peer selector not having the peer,
+	// second one having it, and a third one not having it
+	wrappedPeerSelectors := []*wrappedPeerSelector{
+		{
+			peerClass: network.PeersConnectedOut,
+			peerSelector: mockPeerSelector{
+				mockRankPeer: func(psp *peerSelectorPeer, rank int) (int, int) {
+					return -1, -1
+				},
+			},
+			priority:        peerRankInitialFirstPriority,
+			toleranceFactor: 3,
+			lastCheckedTime: time.Now(),
+		},
+		{
+			peerClass: network.PeersPhonebookRelays,
+			peerSelector: mockPeerSelector{
+				mockRankPeer: func(psp *peerSelectorPeer, rank int) (int, int) {
+					if psp == mockPeer {
+						return 10, rank
+					}
+					return -1, -1
+				},
+			},
+			priority:        peerRankInitialSecondPriority,
+			toleranceFactor: 3,
+			lastCheckedTime: time.Now(),
+		},
+		{
+			peerClass: network.PeersPhonebookArchivalNodes,
+			peerSelector: mockPeerSelector{
+				mockRankPeer: func(psp *peerSelectorPeer, rank int) (int, int) {
+					return -1, -1
+				},
+			},
+			priority:        peerRankInitialThirdPriority,
+			toleranceFactor: 3,
+			lastCheckedTime: time.Now(),
+		},
+	}
+	cps := makeClassBasedPeerSelector(wrappedPeerSelectors)
+
+	// Peer is found in second selector, rank is within range for a block found
+	oldRank, newRank := cps.rankPeer(mockPeer, 50)
+
+	require.Equal(t, 10, oldRank)
+	require.Equal(t, 50, newRank)
+	require.Equal(t, 0, cps.peerSelectors[1].downloadFailures)
+
+	// Peer is found in second selector, rank is >= peerRankNoBlockForRound
+	oldRank, newRank = cps.rankPeer(mockPeer, peerRankNoBlockForRound)
+
+	require.Equal(t, 10, oldRank)
+	require.Equal(t, peerRankNoBlockForRound, newRank)
+	require.Equal(t, 1, cps.peerSelectors[1].downloadFailures)
+
+	// We fail to find a block for round 3 more times, so the peer selector should be re-sorted
+	cps.rankPeer(mockPeer, peerRankNoBlockForRound)
+	oldRank, newRank = cps.rankPeer(mockPeer, peerRankNoBlockForRound)
+
+	require.Equal(t, 10, oldRank)
+	require.Equal(t, peerRankNoBlockForRound, newRank)
+	require.Equal(t, 3, cps.peerSelectors[1].downloadFailures)
+
+	oldRank, newRank = cps.rankPeer(mockPeer, peerRankNoBlockForRound)
+	require.Equal(t, 10, oldRank)
+	require.Equal(t, peerRankNoBlockForRound, newRank)
+	// Note that the download failures should be 0 in this position, as the peer selector should have been re-sorted to last
+	require.Equal(t, 0, cps.peerSelectors[1].downloadFailures)
+	require.Equal(t, 4, cps.peerSelectors[2].downloadFailures)
+
+	// Now, feed a peer that is not in any of the selectors - it should return -1, -1
+	mockPeer2 := &peerSelectorPeer{}
+	oldRank, newRank = cps.rankPeer(mockPeer2, 50)
+	require.Equal(t, -1, oldRank)
+	require.Equal(t, -1, newRank)
+}
+
+func TestClassBasedPeerSelector_peerDownloadDurationToRank(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	mockPeer := &peerSelectorPeer{}
+	testDuration := 50 * time.Millisecond
+
+	// Create a class based peer selector initially with the first wrapped peer selector not having the peer,
+	// second one having it, and a third one not having it
+	wrappedPeerSelectors := []*wrappedPeerSelector{
+		{
+			peerClass: network.PeersConnectedOut,
+			peerSelector: mockPeerSelector{
+				mockPeerDownloadDurationToRank: func(psp *peerSelectorPeer, blockDownloadDuration time.Duration) (rank int) {
+					return peerRankInvalidDownload
+				},
+			},
+			priority:        peerRankInitialFirstPriority,
+			toleranceFactor: 3,
+			lastCheckedTime: time.Now(),
+		},
+		{
+			peerClass: network.PeersPhonebookRelays,
+			peerSelector: mockPeerSelector{
+				mockPeerDownloadDurationToRank: func(psp *peerSelectorPeer, blockDownloadDuration time.Duration) (rank int) {
+					if psp == mockPeer && blockDownloadDuration == testDuration {
+						return peerRank0HighBlockTime
+					}
+					return peerRankInvalidDownload
+				},
+			},
+			priority:        peerRankInitialSecondPriority,
+			toleranceFactor: 3,
+			lastCheckedTime: time.Now(),
+		},
+		{
+			peerClass: network.PeersPhonebookArchivalNodes,
+			peerSelector: mockPeerSelector{
+				mockPeerDownloadDurationToRank: func(psp *peerSelectorPeer, blockDownloadDuration time.Duration) (rank int) {
+					return peerRankInvalidDownload
+				},
+			},
+			priority:        peerRankInitialThirdPriority,
+			toleranceFactor: 3,
+			lastCheckedTime: time.Now(),
+		},
+	}
+	cps := makeClassBasedPeerSelector(wrappedPeerSelectors)
+
+	// The peer is found in the second selector, so the rank should be peerRank0HighBlockTime
+	rank := cps.peerDownloadDurationToRank(mockPeer, testDuration)
+	require.Equal(t, peerRank0HighBlockTime, rank)
+
+	// The peer is not found in any of the selectors, so the rank should be peerRankInvalidDownload
+	mockPeer2 := &peerSelectorPeer{}
+
+	rank = cps.peerDownloadDurationToRank(mockPeer2, testDuration)
+	require.Equal(t, peerRankInvalidDownload, rank)
+}
+
+func TestClassBasedPeerSelector_getNextPeer(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	mockPeer := &peerSelectorPeer{}
+
+	// Create a class based peer selector initially with the first wrapped peer selector not having any peers,
+	// second one having a peer, and a third one not having any peers
+	wrappedPeerSelectors := []*wrappedPeerSelector{
+		{
+			peerClass: network.PeersConnectedOut,
+			peerSelector: mockPeerSelector{
+				mockGetNextPeer: func() (psp *peerSelectorPeer, err error) {
+					return nil, errPeerSelectorNoPeerPoolsAvailable
+				},
+			},
+			priority:        peerRankInitialFirstPriority,
+			toleranceFactor: 3,
+			lastCheckedTime: time.Now(),
+		},
+		{
+			peerClass: network.PeersPhonebookRelays,
+			peerSelector: mockPeerSelector{
+				mockGetNextPeer: func() (psp *peerSelectorPeer, err error) {
+					return mockPeer, nil
+				},
+			},
+			priority:        peerRankInitialSecondPriority,
+			toleranceFactor: 3,
+			lastCheckedTime: time.Now(),
+		},
+		{
+			peerClass: network.PeersPhonebookArchivalNodes,
+			peerSelector: mockPeerSelector{
+				mockGetNextPeer: func() (psp *peerSelectorPeer, err error) {
+					return nil, errPeerSelectorNoPeerPoolsAvailable
+				},
+			},
+			priority:        peerRankInitialThirdPriority,
+			toleranceFactor: 3,
+			lastCheckedTime: time.Now(),
+		},
+	}
+
+	cps := makeClassBasedPeerSelector(wrappedPeerSelectors)
+
+	peerResult, err := cps.getNextPeer()
+	require.Nil(t, err)
+	require.Equal(t, peerResult, mockPeer)
+
+	// Update selector to not return any peers
+	wrappedPeerSelectors[1].peerSelector = mockPeerSelector{
+		mockGetNextPeer: func() (psp *peerSelectorPeer, err error) {
+			return nil, errPeerSelectorNoPeerPoolsAvailable
+		},
+	}
+
+	peerResult, err = cps.getNextPeer()
+	require.Nil(t, peerResult)
+	require.Equal(t, errPeerSelectorNoPeerPoolsAvailable, err)
+
+	// Create a class based peer selector initially with all wrapped peer selectors having peers.
+	// The peers should always come from the first one repeatedly since rankings are not changed.
+	mockPeer2 := &peerSelectorPeer{}
+	mockPeer3 := &peerSelectorPeer{}
+
+	wrappedPeerSelectors = []*wrappedPeerSelector{
+		{
+			peerClass: network.PeersConnectedOut,
+			peerSelector: mockPeerSelector{
+				mockGetNextPeer: func() (psp *peerSelectorPeer, err error) {
+					return mockPeer, nil
+				},
+			},
+			priority:        peerRankInitialFirstPriority,
+			toleranceFactor: 3,
+			lastCheckedTime: time.Now(),
+		},
+		{
+			peerClass: network.PeersPhonebookRelays,
+			peerSelector: mockPeerSelector{
+				mockGetNextPeer: func() (psp *peerSelectorPeer, err error) {
+					return mockPeer2, nil
+				},
+			},
+			priority:        peerRankInitialSecondPriority,
+			toleranceFactor: 3,
+			lastCheckedTime: time.Now(),
+		},
+		{
+			peerClass: network.PeersPhonebookArchivalNodes,
+			peerSelector: mockPeerSelector{
+				mockGetNextPeer: func() (psp *peerSelectorPeer, err error) {
+					return mockPeer3, nil
+				},
+			},
+			priority:        peerRankInitialThirdPriority,
+			toleranceFactor: 3,
+			lastCheckedTime: time.Now(),
+		},
+	}
+
+	cps = makeClassBasedPeerSelector(wrappedPeerSelectors)
+
+	// We should always get the peer from the top priority selector since rankings are not updated/list is not re-sorted.
+	for i := 0; i < 10; i++ {
+		peerResult, err = cps.getNextPeer()
+		require.Nil(t, err)
+		require.Equal(t, peerResult, mockPeer)
+	}
+}

--- a/catchup/classBasedPeerSelector_test.go
+++ b/catchup/classBasedPeerSelector_test.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2024 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package catchup
 
 import (

--- a/catchup/peerSelector.go
+++ b/catchup/peerSelector.go
@@ -88,7 +88,7 @@ type peerClass struct {
 	peerClass   network.PeerOption
 }
 
-// the peersRetriever is a subset of the network.GossipNode used to ensure that we can create an instance of the peerSelector
+// the peersRetriever is a subset of the network.GossipNode used to ensure that we can create an instance of the rankPooledPeerSelector
 // for testing purposes, providing just the above function.
 type peersRetriever interface {
 	// Get a list of Peers we could potentially send a direct message to.
@@ -109,20 +109,20 @@ type peerPool struct {
 	peers []peerPoolEntry
 }
 
-type peerSelectorI interface {
+type peerSelector interface {
 	rankPeer(psp *peerSelectorPeer, rank int) (int, int)
 	peerDownloadDurationToRank(psp *peerSelectorPeer, blockDownloadDuration time.Duration) (rank int)
 	getNextPeer() (psp *peerSelectorPeer, err error)
 }
 
-// peerSelector is a helper struct used to select the next peer to try and connect to
+// rankPooledPeerSelector is a helper struct used to select the next peer to try and connect to
 // for various catchup purposes. Unlike the underlying network GetPeers(), it allows the
 // client to provide feedback regarding the peer's performance, and to have the subsequent
 // query(s) take advantage of that intel.
-type peerSelector struct {
+type rankPooledPeerSelector struct {
 	mu  deadlock.Mutex
 	net peersRetriever
-	// peerClasses is the list of peer classes we want to have in the peerSelector.
+	// peerClasses is the list of peer classes we want to have in the rankPooledPeerSelector.
 	peerClasses []peerClass
 	// pools is the list of peer pools, each pool contains a list of peers with the same rank.
 	pools   []peerPool
@@ -290,9 +290,9 @@ func (hs *historicStats) push(value int, counter uint64, class peerClass) (avera
 	return bounded
 }
 
-// makePeerSelector creates a peerSelector, given a peersRetriever and peerClass array.
-func makePeerSelector(net peersRetriever, initialPeersClasses []peerClass) *peerSelector {
-	selector := &peerSelector{
+// makeRankPooledPeerSelector creates a rankPooledPeerSelector, given a peersRetriever and peerClass array.
+func makeRankPooledPeerSelector(net peersRetriever, initialPeersClasses []peerClass) *rankPooledPeerSelector {
+	selector := &rankPooledPeerSelector{
 		net:         net,
 		peerClasses: initialPeersClasses,
 	}
@@ -302,7 +302,7 @@ func makePeerSelector(net peersRetriever, initialPeersClasses []peerClass) *peer
 // getNextPeer returns the next peer. It randomally selects a peer from a pool that has
 // the lowest rank value. Given that the peers are grouped by their ranks, allow us to
 // prioritize peers based on their class and/or performance.
-func (ps *peerSelector) getNextPeer() (psp *peerSelectorPeer, err error) {
+func (ps *rankPooledPeerSelector) getNextPeer() (psp *peerSelectorPeer, err error) {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 	ps.refreshAvailablePeers()
@@ -323,7 +323,7 @@ func (ps *peerSelector) getNextPeer() (psp *peerSelectorPeer, err error) {
 // rankPeer ranks a given peer.
 // return the old value and the new updated value.
 // updated value could be different from the input rank.
-func (ps *peerSelector) rankPeer(psp *peerSelectorPeer, rank int) (int, int) {
+func (ps *rankPooledPeerSelector) rankPeer(psp *peerSelectorPeer, rank int) (int, int) {
 	if psp == nil {
 		return -1, -1
 	}
@@ -390,7 +390,7 @@ func (ps *peerSelector) rankPeer(psp *peerSelectorPeer, rank int) (int, int) {
 }
 
 // peerDownloadDurationToRank calculates the rank for a peer given a peer and the block download time.
-func (ps *peerSelector) peerDownloadDurationToRank(psp *peerSelectorPeer, blockDownloadDuration time.Duration) (rank int) {
+func (ps *rankPooledPeerSelector) peerDownloadDurationToRank(psp *peerSelectorPeer, blockDownloadDuration time.Duration) (rank int) {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 	poolIdx, peerIdx := ps.findPeer(psp)
@@ -415,7 +415,7 @@ func (ps *peerSelector) peerDownloadDurationToRank(psp *peerSelectorPeer, blockD
 // addToPool adds a given peer to the correct group. If no group exists for that peer's rank,
 // a new group is created.
 // The method return true if a new group was created ( suggesting that the pools list would need to be re-ordered ), or false otherwise.
-func (ps *peerSelector) addToPool(peer network.Peer, rank int, class peerClass, peerHistory *historicStats) bool {
+func (ps *rankPooledPeerSelector) addToPool(peer network.Peer, rank int, class peerClass, peerHistory *historicStats) bool {
 	// see if we already have a list with that rank:
 	for i, pool := range ps.pools {
 		if pool.rank == rank {
@@ -429,7 +429,7 @@ func (ps *peerSelector) addToPool(peer network.Peer, rank int, class peerClass, 
 }
 
 // sort the pools array in an ascending order according to the rank of each pool.
-func (ps *peerSelector) sort() {
+func (ps *rankPooledPeerSelector) sort() {
 	sort.SliceStable(ps.pools, func(i, j int) bool {
 		return ps.pools[i].rank < ps.pools[j].rank
 	})
@@ -449,7 +449,7 @@ func peerAddress(peer network.Peer) string {
 
 // refreshAvailablePeers reload the available peers from the network package, add new peers along with their
 // corresponding initial rank, and deletes peers that have been dropped by the network package.
-func (ps *peerSelector) refreshAvailablePeers() {
+func (ps *rankPooledPeerSelector) refreshAvailablePeers() {
 	existingPeers := make(map[network.PeerOption]map[string]bool)
 	for _, pool := range ps.pools {
 		for _, localPeer := range pool.peers {
@@ -507,7 +507,7 @@ func (ps *peerSelector) refreshAvailablePeers() {
 
 // findPeer look into the peer pool and find the given peer.
 // The method returns the pool and peer indices if a peer was found, or (-1, -1) otherwise.
-func (ps *peerSelector) findPeer(psp *peerSelectorPeer) (poolIdx, peerIdx int) {
+func (ps *rankPooledPeerSelector) findPeer(psp *peerSelectorPeer) (poolIdx, peerIdx int) {
 	peerAddr := peerAddress(psp.Peer)
 	if peerAddr == "" {
 		return -1, -1

--- a/catchup/peerSelector.go
+++ b/catchup/peerSelector.go
@@ -109,6 +109,12 @@ type peerPool struct {
 	peers []peerPoolEntry
 }
 
+type peerSelectorI interface {
+	rankPeer(psp *peerSelectorPeer, rank int) (int, int)
+	peerDownloadDurationToRank(psp *peerSelectorPeer, blockDownloadDuration time.Duration) (rank int)
+	getNextPeer() (psp *peerSelectorPeer, err error)
+}
+
 // peerSelector is a helper struct used to select the next peer to try and connect to
 // for various catchup purposes. Unlike the underlying network GetPeers(), it allows the
 // client to provide feedback regarding the peer's performance, and to have the subsequent

--- a/catchup/peerSelector_test.go
+++ b/catchup/peerSelector_test.go
@@ -131,7 +131,7 @@ func TestPeerSelector_RankPeer(t *testing.T) {
 
 	peers := []network.Peer{&mockHTTPPeer{address: "12345"}}
 
-	peerSelector := makePeerSelector(
+	peerSelector := makeRankPooledPeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) []network.Peer {
 			return peers
 		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivalNodes}},
@@ -191,7 +191,7 @@ func TestPeerSelector_PeerDownloadRanking(t *testing.T) {
 	peers1 := []network.Peer{&mockHTTPPeer{address: "1234"}, &mockHTTPPeer{address: "5678"}}
 	peers2 := []network.Peer{&mockHTTPPeer{address: "abcd"}, &mockHTTPPeer{address: "efgh"}}
 
-	peerSelector := makePeerSelector(
+	peerSelector := makeRankPooledPeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivalNodes {
@@ -240,7 +240,7 @@ func TestPeerSelector_FindMissingPeer(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	peerSelector := makePeerSelector(
+	peerSelector := makeRankPooledPeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) []network.Peer {
 			return []network.Peer{}
 		}), []peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivalNodes}},
@@ -258,7 +258,7 @@ func TestPeerSelector_HistoricData(t *testing.T) {
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}, &mockHTTPPeer{address: "a3"}}
 	peers2 := []network.Peer{&mockHTTPPeer{address: "b1"}, &mockHTTPPeer{address: "b2"}}
 
-	peerSelector := makePeerSelector(
+	peerSelector := makeRankPooledPeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivalNodes {
@@ -332,7 +332,7 @@ func TestPeerSelector_PeersDownloadFailed(t *testing.T) {
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}, &mockHTTPPeer{address: "a3"}}
 	peers2 := []network.Peer{&mockHTTPPeer{address: "b1"}, &mockHTTPPeer{address: "b2"}}
 
-	peerSelector := makePeerSelector(
+	peerSelector := makeRankPooledPeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivalNodes {
@@ -408,7 +408,7 @@ func TestPeerSelector_Penalty(t *testing.T) {
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}, &mockHTTPPeer{address: "a3"}}
 	peers2 := []network.Peer{&mockHTTPPeer{address: "b1"}, &mockHTTPPeer{address: "b2"}}
 
-	peerSelector := makePeerSelector(
+	peerSelector := makeRankPooledPeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivalNodes {
@@ -469,7 +469,7 @@ func TestPeerSelector_PeerDownloadDurationToRank(t *testing.T) {
 	peers3 := []network.Peer{&mockHTTPPeer{address: "c1"}, &mockHTTPPeer{address: "c2"}}
 	peers4 := []network.Peer{&mockHTTPPeer{address: "d1"}, &mockHTTPPeer{address: "b2"}}
 
-	peerSelector := makePeerSelector(
+	peerSelector := makeRankPooledPeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookRelays {
@@ -574,7 +574,7 @@ func TestPeerSelector_ClassUpperBound(t *testing.T) {
 
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}}
 	pClass := peerClass{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookArchivalNodes}
-	peerSelector := makePeerSelector(
+	peerSelector := makeRankPooledPeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivalNodes {
@@ -609,7 +609,7 @@ func TestPeerSelector_ClassLowerBound(t *testing.T) {
 
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}, &mockHTTPPeer{address: "a2"}}
 	pClass := peerClass{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookArchivalNodes}
-	peerSelector := makePeerSelector(
+	peerSelector := makeRankPooledPeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivalNodes {
@@ -639,7 +639,7 @@ func TestPeerSelector_EvictionAndUpgrade(t *testing.T) {
 	peers1 := []network.Peer{&mockHTTPPeer{address: "a1"}}
 	peers2 := []network.Peer{&mockHTTPPeer{address: "a1"}}
 
-	peerSelector := makePeerSelector(
+	peerSelector := makeRankPooledPeerSelector(
 		makePeersRetrieverStub(func(options ...network.PeerOption) (peers []network.Peer) {
 			for _, opt := range options {
 				if opt == network.PeersPhonebookArchivalNodes {
@@ -677,7 +677,7 @@ func TestPeerSelector_RefreshAvailablePeers(t *testing.T) {
 	// check new peers added to the pool
 	p1 := mockHTTPPeer{address: "p1"}
 	p2 := mockHTTPPeer{address: "p2"}
-	ps := peerSelector{
+	ps := rankPooledPeerSelector{
 		peerClasses: []peerClass{
 			{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
 			{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookArchivalNodes},

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -38,9 +38,6 @@ import (
 	"github.com/algorand/go-algorand/util/execpool"
 )
 
-const catchupPeersForSync = 10
-const blockQueryPeerLimit = 10
-
 // uncapParallelDownloadRate is a simple threshold to detect whether or not the node is caught up.
 // If a block is downloaded in less than this duration, it's assumed that the node is not caught up
 // and allow the block downloader to start N=parallelBlocks concurrent fetches.
@@ -266,7 +263,7 @@ const errNoBlockForRoundThreshold = 5
 //   - If we couldn't fetch the block (e.g. if there are no peers available, or we've reached the catchupRetryLimit)
 //   - If the block is already in the ledger (e.g. if agreement service has already written it)
 //   - If the retrieval of the previous block was unsuccessful
-func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCompleteChan chan struct{}, lookbackComplete chan struct{}, peerSelector *peerSelector) bool {
+func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCompleteChan chan struct{}, lookbackComplete chan struct{}, peerSelector peerSelectorI) bool {
 	// If sync-ing this round is not intended, don't fetch it
 	if dontSyncRound := s.GetDisableSyncRound(); dontSyncRound != 0 && r >= basics.Round(dontSyncRound) {
 		return false
@@ -751,9 +748,9 @@ func (s *Service) fetchRound(cert agreement.Certificate, verifier *agreement.Asy
 	peerErrors := map[network.Peer]int{}
 
 	blockHash := bookkeeping.BlockHash(cert.Proposal.BlockDigest) // semantic digest (i.e., hash of the block header), not byte-for-byte digest
-	peerSelector := createPeerSelector(s.net, s.cfg, false)
+	ps := createPeerSelector(s.net, s.cfg, false)
 	for s.ledger.LastRound() < cert.Round {
-		psp, getPeerErr := peerSelector.getNextPeer()
+		psp, getPeerErr := ps.getNextPeer()
 		if getPeerErr != nil {
 			s.log.Debugf("fetchRound: was unable to obtain a peer to retrieve the block from")
 			s.net.RequestConnectOutgoing(true, s.ctx.Done())
@@ -788,14 +785,14 @@ func (s *Service) fetchRound(cert agreement.Certificate, verifier *agreement.Asy
 						// - peer selector punishes one of the peers more than the other
 						// - the punoshed peer gets the block, and the less punished peer stucks.
 						// It this case reset the peer selector to let it re-learn priorities.
-						peerSelector = createPeerSelector(s.net, s.cfg, false)
+						ps = createPeerSelector(s.net, s.cfg, false)
 					}
 				}
 				peerErrors[peer]++
 			}
 			// remote peer doesn't have the block, try another peer
 			logging.Base().Warnf("fetchRound could not acquire block, fetcher errored out: %v", err)
-			peerSelector.rankPeer(psp, failureRank)
+			ps.rankPeer(psp, failureRank)
 			continue
 		}
 
@@ -805,7 +802,7 @@ func (s *Service) fetchRound(cert agreement.Certificate, verifier *agreement.Asy
 		}
 		// Otherwise, fetcher gave us the wrong block
 		logging.Base().Warnf("fetcher gave us bad/wrong block (for round %d): fetched hash %v; want hash %v", cert.Round, block.Hash(), blockHash)
-		peerSelector.rankPeer(psp, peerRankInvalidDownload)
+		ps.rankPeer(psp, peerRankInvalidDownload)
 
 		// As a failsafe, if the cert we fetched is valid but for the wrong block, panic as loudly as possible
 		if cert.Round == fetchedCert.Round &&
@@ -866,38 +863,138 @@ func (s *Service) roundIsNotSupported(nextRound basics.Round) bool {
 	return true
 }
 
-func createPeerSelector(net network.GossipNode, cfg config.Local, pipelineFetch bool) *peerSelector {
-	var peerClasses []peerClass
+func createPeerSelector(net network.GossipNode, cfg config.Local, pipelineFetch bool) peerSelectorI {
+	var wrappedPeerSelectors []*wrappedPeerSelector
+	//TODO: Revisit this ordering
 	if pipelineFetch {
 		if cfg.NetAddress != "" && cfg.EnableGossipService { // Relay node
-			peerClasses = []peerClass{
-				{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
-				{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookArchivalNodes},
-				{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookRelays},
-				{initialRank: peerRankInitialFourthPriority, peerClass: network.PeersConnectedIn},
+			wrappedPeerSelectors = []*wrappedPeerSelector{
+				{
+					peerClass: network.PeersConnectedOut,
+					peerSelectorIRenameMeLater: makePeerSelector(net,
+						[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut}}),
+					priority:        peerRankInitialFirstPriority,
+					toleranceFactor: 3,
+					lastCheckedTime: time.Now(),
+				},
+				{
+					peerClass: network.PeersPhonebookRelays,
+					peerSelectorIRenameMeLater: makePeerSelector(net,
+						[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookRelays}}),
+					priority:        peerRankInitialSecondPriority,
+					toleranceFactor: 3,
+					lastCheckedTime: time.Now(),
+				},
+				{
+					peerClass: network.PeersPhonebookArchivalNodes,
+					peerSelectorIRenameMeLater: makePeerSelector(net,
+						[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivalNodes}}),
+					priority:        peerRankInitialThirdPriority,
+					toleranceFactor: 10,
+					lastCheckedTime: time.Now(),
+				},
+				{
+					peerClass: network.PeersConnectedIn,
+					peerSelectorIRenameMeLater: makePeerSelector(net,
+						[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedIn}}),
+					priority:        peerRankInitialFourthPriority,
+					toleranceFactor: 3,
+					lastCheckedTime: time.Now(),
+				},
 			}
 		} else {
-			peerClasses = []peerClass{
-				{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivalNodes},
-				{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersConnectedOut},
-				{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookRelays},
+			wrappedPeerSelectors = []*wrappedPeerSelector{
+				{
+					peerClass: network.PeersConnectedOut,
+					peerSelectorIRenameMeLater: makePeerSelector(net,
+						[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut}}),
+					priority:        peerRankInitialFirstPriority,
+					toleranceFactor: 3,
+					lastCheckedTime: time.Now(),
+				},
+				{
+					peerClass: network.PeersPhonebookRelays,
+					peerSelectorIRenameMeLater: makePeerSelector(net,
+						[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookRelays}}),
+					priority:        peerRankInitialSecondPriority,
+					toleranceFactor: 3,
+					lastCheckedTime: time.Now(),
+				},
+				{
+					peerClass: network.PeersPhonebookArchivalNodes,
+					peerSelectorIRenameMeLater: makePeerSelector(net,
+						[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivalNodes}}),
+					priority:        peerRankInitialThirdPriority,
+					toleranceFactor: 10,
+					lastCheckedTime: time.Now(),
+				},
 			}
 		}
 	} else {
 		if cfg.NetAddress != "" && cfg.EnableGossipService { // Relay node
-			peerClasses = []peerClass{
-				{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
-				{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersConnectedIn},
-				{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookArchivalNodes},
-				{initialRank: peerRankInitialFourthPriority, peerClass: network.PeersPhonebookRelays},
+			wrappedPeerSelectors = []*wrappedPeerSelector{
+				{
+					peerClass: network.PeersConnectedOut,
+					peerSelectorIRenameMeLater: makePeerSelector(net,
+						[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut}}),
+					priority:        peerRankInitialFirstPriority,
+					toleranceFactor: 3,
+					lastCheckedTime: time.Now(),
+				},
+				{
+					peerClass: network.PeersConnectedIn,
+					peerSelectorIRenameMeLater: makePeerSelector(net,
+						[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedIn}}),
+					priority:        peerRankInitialSecondPriority,
+					toleranceFactor: 3,
+					lastCheckedTime: time.Now(),
+				},
+				{
+					peerClass: network.PeersPhonebookArchivalNodes,
+					peerSelectorIRenameMeLater: makePeerSelector(net,
+						[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivalNodes}}),
+					priority:        peerRankInitialThirdPriority,
+					toleranceFactor: 10,
+					lastCheckedTime: time.Now(),
+				},
+				{
+					peerClass: network.PeersPhonebookRelays,
+					peerSelectorIRenameMeLater: makePeerSelector(net,
+						[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookRelays}}),
+					priority:        peerRankInitialFourthPriority,
+					toleranceFactor: 3,
+					lastCheckedTime: time.Now(),
+				},
 			}
 		} else {
-			peerClasses = []peerClass{
-				{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
-				{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookArchivalNodes},
-				{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookRelays},
+			wrappedPeerSelectors = []*wrappedPeerSelector{
+				{
+					peerClass: network.PeersConnectedOut,
+					peerSelectorIRenameMeLater: makePeerSelector(net,
+						[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut}}),
+					priority:        peerRankInitialFirstPriority,
+					toleranceFactor: 3,
+					lastCheckedTime: time.Now(),
+				},
+				{
+					peerClass: network.PeersPhonebookArchivalNodes,
+					peerSelectorIRenameMeLater: makePeerSelector(net,
+						[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivalNodes}}),
+					priority:        peerRankInitialSecondPriority,
+					toleranceFactor: 10,
+					lastCheckedTime: time.Now(),
+				},
+				{
+					peerClass: network.PeersPhonebookRelays,
+					peerSelectorIRenameMeLater: makePeerSelector(net,
+						[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookRelays}}),
+					priority:        peerRankInitialThirdPriority,
+					toleranceFactor: 3,
+					lastCheckedTime: time.Now(),
+				},
 			}
 		}
 	}
-	return makePeerSelector(net, peerClasses)
+
+	return makeClassBasedPeerSelector(wrappedPeerSelectors)
 }

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -874,28 +874,24 @@ func createPeerSelector(net network.GossipNode) peerSelector {
 			peerSelector: makeRankPooledPeerSelector(net,
 				[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut}}),
 			toleranceFactor: 3,
-			lastCheckedTime: time.Now(),
 		},
 		{
 			peerClass: network.PeersPhonebookRelays,
 			peerSelector: makeRankPooledPeerSelector(net,
 				[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookRelays}}),
 			toleranceFactor: 3,
-			lastCheckedTime: time.Now(),
 		},
 		{
 			peerClass: network.PeersPhonebookArchivalNodes,
 			peerSelector: makeRankPooledPeerSelector(net,
 				[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivalNodes}}),
 			toleranceFactor: 10,
-			lastCheckedTime: time.Now(),
 		},
 		{
 			peerClass: network.PeersConnectedIn,
 			peerSelector: makeRankPooledPeerSelector(net,
 				[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedIn}}),
 			toleranceFactor: 3,
-			lastCheckedTime: time.Now(),
 		},
 	}
 

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -442,7 +442,7 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 			if err != nil {
 				var errNonSequentialBlockEval ledgercore.ErrNonSequentialBlockEval
 				var blockInLedgerError ledgercore.BlockInLedgerError
-				var err1 protocol.Error
+				var protocolErr protocol.Error
 				switch {
 				case errors.As(err, &errNonSequentialBlockEval):
 					s.log.Infof("fetchAndWrite(%d): no need to re-evaluate historical block", r)
@@ -452,7 +452,7 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 					// only the agreement could have added this block into the ledger, catchup is complete
 					s.log.Infof("fetchAndWrite(%d): after fetching the block, it is already in the ledger. The catchup is complete", r)
 					return false
-				case errors.As(err, &err1):
+				case errors.As(err, &protocolErr):
 					if !s.protocolErrorLogged {
 						logging.Base().Errorf("fetchAndWrite(%v): unrecoverable protocol error detected: %v", r, err)
 						s.protocolErrorLogged = true
@@ -873,7 +873,6 @@ func createPeerSelector(net network.GossipNode) peerSelector {
 			peerClass: network.PeersConnectedOut,
 			peerSelector: makeRankPooledPeerSelector(net,
 				[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut}}),
-			priority:        peerRankInitialFirstPriority,
 			toleranceFactor: 3,
 			lastCheckedTime: time.Now(),
 		},
@@ -881,7 +880,6 @@ func createPeerSelector(net network.GossipNode) peerSelector {
 			peerClass: network.PeersPhonebookRelays,
 			peerSelector: makeRankPooledPeerSelector(net,
 				[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookRelays}}),
-			priority:        peerRankInitialSecondPriority,
 			toleranceFactor: 3,
 			lastCheckedTime: time.Now(),
 		},
@@ -889,7 +887,6 @@ func createPeerSelector(net network.GossipNode) peerSelector {
 			peerClass: network.PeersPhonebookArchivalNodes,
 			peerSelector: makeRankPooledPeerSelector(net,
 				[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivalNodes}}),
-			priority:        peerRankInitialThirdPriority,
 			toleranceFactor: 10,
 			lastCheckedTime: time.Now(),
 		},
@@ -897,7 +894,6 @@ func createPeerSelector(net network.GossipNode) peerSelector {
 			peerClass: network.PeersConnectedIn,
 			peerSelector: makeRankPooledPeerSelector(net,
 				[]peerClass{{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedIn}}),
-			priority:        peerRankInitialFourthPriority,
 			toleranceFactor: 3,
 			lastCheckedTime: time.Now(),
 		},

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -454,7 +454,7 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 					return false
 				case errors.As(err, &err1):
 					if !s.protocolErrorLogged {
-						logging.Base().Errorf("fetchAndWrite(%v): unrecoverable protocol err1 detected: %v", r, err)
+						logging.Base().Errorf("fetchAndWrite(%v): unrecoverable protocol error detected: %v", r, err)
 						s.protocolErrorLogged = true
 					}
 				default:
@@ -493,7 +493,7 @@ func (s *Service) pipelinedFetch(seedLookback uint64) {
 	}()
 
 	ps := createPeerSelector(s.net)
-	if _, err := ps.getNextPeer(); errors.Is(err, errPeerSelectorNoPeerPoolsAvailable) {
+	if _, err := ps.getNextPeer(); err != nil {
 		s.log.Debugf("pipelinedFetch: was unable to obtain a peer to retrieve the block from")
 		return
 	}

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -975,11 +975,6 @@ func TestCreatePeerSelector(t *testing.T) {
 	require.Equal(t, 3, cps.peerSelectors[1].toleranceFactor)
 	require.Equal(t, 10, cps.peerSelectors[2].toleranceFactor)
 	require.Equal(t, 3, cps.peerSelectors[3].toleranceFactor)
-
-	require.False(t, cps.peerSelectors[0].lastCheckedTime.IsZero())
-	require.False(t, cps.peerSelectors[1].lastCheckedTime.IsZero())
-	require.False(t, cps.peerSelectors[2].lastCheckedTime.IsZero())
-	require.False(t, cps.peerSelectors[3].lastCheckedTime.IsZero())
 }
 
 func TestServiceStartStop(t *testing.T) {

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -958,14 +958,8 @@ func TestCatchupUnmatchedCertificate(t *testing.T) {
 func TestCreatePeerSelector(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	// Make Service
-	cfg := defaultConfig
-
-	// cfg.NetAddress != ""; cfg.EnableGossipService = true; pipelineFetch = true
-	cfg.NetAddress = "someAddress"
-	cfg.EnableGossipService = true
-	s := MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
-	ps := createPeerSelector(s.net, s.cfg, true)
+	s := MakeService(logging.Base(), defaultConfig, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
+	ps := createPeerSelector(s.net)
 
 	cps, ok := ps.(*classBasedPeerSelector)
 	require.True(t, ok)
@@ -990,130 +984,6 @@ func TestCreatePeerSelector(t *testing.T) {
 	require.False(t, cps.peerSelectors[1].lastCheckedTime.IsZero())
 	require.False(t, cps.peerSelectors[2].lastCheckedTime.IsZero())
 	require.False(t, cps.peerSelectors[3].lastCheckedTime.IsZero())
-
-	// cfg.NetAddress == ""; cfg.EnableGossipService = true; pipelineFetch = true
-	cfg.NetAddress = ""
-	cfg.EnableGossipService = true
-	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
-	ps = createPeerSelector(s.net, s.cfg, true)
-
-	cps, ok = ps.(*classBasedPeerSelector)
-	require.True(t, ok)
-
-	require.Equal(t, 3, len(cps.peerSelectors))
-	require.Equal(t, peerRankInitialFirstPriority, cps.peerSelectors[0].priority)
-	require.Equal(t, peerRankInitialSecondPriority, cps.peerSelectors[1].priority)
-	require.Equal(t, peerRankInitialThirdPriority, cps.peerSelectors[2].priority)
-
-	require.Equal(t, network.PeersConnectedOut, cps.peerSelectors[0].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, cps.peerSelectors[1].peerClass)
-	require.Equal(t, network.PeersPhonebookArchivalNodes, cps.peerSelectors[2].peerClass)
-
-	require.Equal(t, 3, cps.peerSelectors[0].toleranceFactor)
-	require.Equal(t, 3, cps.peerSelectors[1].toleranceFactor)
-	require.Equal(t, 10, cps.peerSelectors[2].toleranceFactor)
-
-	require.False(t, cps.peerSelectors[0].lastCheckedTime.IsZero())
-	require.False(t, cps.peerSelectors[1].lastCheckedTime.IsZero())
-	require.False(t, cps.peerSelectors[2].lastCheckedTime.IsZero())
-
-	// cfg.NetAddress != ""; cfg.EnableGossipService = false; pipelineFetch = true
-	cfg.NetAddress = "someAddress"
-	cfg.EnableGossipService = false
-	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
-	ps = createPeerSelector(s.net, s.cfg, true)
-
-	cps, ok = ps.(*classBasedPeerSelector)
-	require.True(t, ok)
-
-	require.Equal(t, 3, len(cps.peerSelectors))
-	require.Equal(t, peerRankInitialFirstPriority, cps.peerSelectors[0].priority)
-	require.Equal(t, peerRankInitialSecondPriority, cps.peerSelectors[1].priority)
-	require.Equal(t, peerRankInitialThirdPriority, cps.peerSelectors[2].priority)
-
-	require.Equal(t, network.PeersConnectedOut, cps.peerSelectors[0].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, cps.peerSelectors[1].peerClass)
-	require.Equal(t, network.PeersPhonebookArchivalNodes, cps.peerSelectors[2].peerClass)
-
-	require.Equal(t, 3, cps.peerSelectors[0].toleranceFactor)
-	require.Equal(t, 3, cps.peerSelectors[1].toleranceFactor)
-	require.Equal(t, 10, cps.peerSelectors[2].toleranceFactor)
-
-	require.False(t, cps.peerSelectors[0].lastCheckedTime.IsZero())
-	require.False(t, cps.peerSelectors[1].lastCheckedTime.IsZero())
-	require.False(t, cps.peerSelectors[2].lastCheckedTime.IsZero())
-
-	// cfg.NetAddress != ""; cfg.EnableGossipService = true; pipelineFetch = false
-	cfg.NetAddress = "someAddress"
-	cfg.EnableGossipService = true
-	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
-	ps = createPeerSelector(s.net, s.cfg, false)
-
-	cps, ok = ps.(*classBasedPeerSelector)
-	require.True(t, ok)
-
-	require.Equal(t, 4, len(cps.peerSelectors))
-	require.Equal(t, peerRankInitialFirstPriority, cps.peerSelectors[0].priority)
-	require.Equal(t, peerRankInitialSecondPriority, cps.peerSelectors[1].priority)
-	require.Equal(t, peerRankInitialThirdPriority, cps.peerSelectors[2].priority)
-	require.Equal(t, peerRankInitialFourthPriority, cps.peerSelectors[3].priority)
-
-	require.Equal(t, network.PeersConnectedOut, cps.peerSelectors[0].peerClass)
-	require.Equal(t, network.PeersConnectedIn, cps.peerSelectors[1].peerClass)
-	require.Equal(t, network.PeersPhonebookArchivalNodes, cps.peerSelectors[2].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, cps.peerSelectors[3].peerClass)
-
-	// cfg.NetAddress == ""; cfg.EnableGossipService = true; pipelineFetch = false
-	cfg.NetAddress = ""
-	cfg.EnableGossipService = true
-	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
-	ps = createPeerSelector(s.net, s.cfg, false)
-
-	cps, ok = ps.(*classBasedPeerSelector)
-	require.True(t, ok)
-
-	require.Equal(t, 3, len(cps.peerSelectors))
-	require.Equal(t, peerRankInitialFirstPriority, cps.peerSelectors[0].priority)
-	require.Equal(t, peerRankInitialSecondPriority, cps.peerSelectors[1].priority)
-	require.Equal(t, peerRankInitialThirdPriority, cps.peerSelectors[2].priority)
-
-	require.Equal(t, network.PeersConnectedOut, cps.peerSelectors[0].peerClass)
-	require.Equal(t, network.PeersPhonebookArchivalNodes, cps.peerSelectors[1].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, cps.peerSelectors[2].peerClass)
-
-	require.Equal(t, 3, cps.peerSelectors[0].toleranceFactor)
-	require.Equal(t, 10, cps.peerSelectors[1].toleranceFactor)
-	require.Equal(t, 3, cps.peerSelectors[2].toleranceFactor)
-
-	require.False(t, cps.peerSelectors[0].lastCheckedTime.IsZero())
-	require.False(t, cps.peerSelectors[1].lastCheckedTime.IsZero())
-	require.False(t, cps.peerSelectors[2].lastCheckedTime.IsZero())
-
-	// cfg.NetAddress != ""; cfg.EnableGossipService = false; pipelineFetch = false
-	cfg.NetAddress = "someAddress"
-	cfg.EnableGossipService = false
-	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
-	ps = createPeerSelector(s.net, s.cfg, false)
-
-	cps, ok = ps.(*classBasedPeerSelector)
-	require.True(t, ok)
-
-	require.Equal(t, 3, len(cps.peerSelectors))
-	require.Equal(t, peerRankInitialFirstPriority, cps.peerSelectors[0].priority)
-	require.Equal(t, peerRankInitialSecondPriority, cps.peerSelectors[1].priority)
-	require.Equal(t, peerRankInitialThirdPriority, cps.peerSelectors[2].priority)
-
-	require.Equal(t, network.PeersConnectedOut, cps.peerSelectors[0].peerClass)
-	require.Equal(t, network.PeersPhonebookArchivalNodes, cps.peerSelectors[1].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, cps.peerSelectors[2].peerClass)
-
-	require.Equal(t, 3, cps.peerSelectors[0].toleranceFactor)
-	require.Equal(t, 10, cps.peerSelectors[1].toleranceFactor)
-	require.Equal(t, 3, cps.peerSelectors[2].toleranceFactor)
-
-	require.False(t, cps.peerSelectors[0].lastCheckedTime.IsZero())
-	require.False(t, cps.peerSelectors[1].lastCheckedTime.IsZero())
-	require.False(t, cps.peerSelectors[2].lastCheckedTime.IsZero())
 }
 
 func TestServiceStartStop(t *testing.T) {

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -967,16 +967,29 @@ func TestCreatePeerSelector(t *testing.T) {
 	s := MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
 	ps := createPeerSelector(s.net, s.cfg, true)
 
-	require.Equal(t, 4, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
-	require.Equal(t, peerRankInitialFourthPriority, ps.peerClasses[3].initialRank)
+	cps, ok := ps.(*classBasedPeerSelector)
+	require.True(t, ok)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
-	require.Equal(t, network.PeersPhonebookArchivalNodes, ps.peerClasses[1].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].peerClass)
-	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[3].peerClass)
+	require.Equal(t, 4, len(cps.peerSelectors))
+	require.Equal(t, peerRankInitialFirstPriority, cps.peerSelectors[0].priority)
+	require.Equal(t, peerRankInitialSecondPriority, cps.peerSelectors[1].priority)
+	require.Equal(t, peerRankInitialThirdPriority, cps.peerSelectors[2].priority)
+	require.Equal(t, peerRankInitialFourthPriority, cps.peerSelectors[3].priority)
+
+	require.Equal(t, network.PeersConnectedOut, cps.peerSelectors[0].peerClass)
+	require.Equal(t, network.PeersPhonebookRelays, cps.peerSelectors[1].peerClass)
+	require.Equal(t, network.PeersPhonebookArchivalNodes, cps.peerSelectors[2].peerClass)
+	require.Equal(t, network.PeersConnectedIn, cps.peerSelectors[3].peerClass)
+
+	require.Equal(t, 3, cps.peerSelectors[0].toleranceFactor)
+	require.Equal(t, 3, cps.peerSelectors[1].toleranceFactor)
+	require.Equal(t, 10, cps.peerSelectors[2].toleranceFactor)
+	require.Equal(t, 3, cps.peerSelectors[3].toleranceFactor)
+
+	require.False(t, cps.peerSelectors[0].lastCheckedTime.IsZero())
+	require.False(t, cps.peerSelectors[1].lastCheckedTime.IsZero())
+	require.False(t, cps.peerSelectors[2].lastCheckedTime.IsZero())
+	require.False(t, cps.peerSelectors[3].lastCheckedTime.IsZero())
 
 	// cfg.NetAddress == ""; cfg.EnableGossipService = true; pipelineFetch = true
 	cfg.NetAddress = ""
@@ -984,14 +997,25 @@ func TestCreatePeerSelector(t *testing.T) {
 	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
 	ps = createPeerSelector(s.net, s.cfg, true)
 
-	require.Equal(t, 3, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
+	cps, ok = ps.(*classBasedPeerSelector)
+	require.True(t, ok)
 
-	require.Equal(t, network.PeersPhonebookArchivalNodes, ps.peerClasses[0].peerClass)
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[1].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].peerClass)
+	require.Equal(t, 3, len(cps.peerSelectors))
+	require.Equal(t, peerRankInitialFirstPriority, cps.peerSelectors[0].priority)
+	require.Equal(t, peerRankInitialSecondPriority, cps.peerSelectors[1].priority)
+	require.Equal(t, peerRankInitialThirdPriority, cps.peerSelectors[2].priority)
+
+	require.Equal(t, network.PeersConnectedOut, cps.peerSelectors[0].peerClass)
+	require.Equal(t, network.PeersPhonebookRelays, cps.peerSelectors[1].peerClass)
+	require.Equal(t, network.PeersPhonebookArchivalNodes, cps.peerSelectors[2].peerClass)
+
+	require.Equal(t, 3, cps.peerSelectors[0].toleranceFactor)
+	require.Equal(t, 3, cps.peerSelectors[1].toleranceFactor)
+	require.Equal(t, 10, cps.peerSelectors[2].toleranceFactor)
+
+	require.False(t, cps.peerSelectors[0].lastCheckedTime.IsZero())
+	require.False(t, cps.peerSelectors[1].lastCheckedTime.IsZero())
+	require.False(t, cps.peerSelectors[2].lastCheckedTime.IsZero())
 
 	// cfg.NetAddress != ""; cfg.EnableGossipService = false; pipelineFetch = true
 	cfg.NetAddress = "someAddress"
@@ -999,14 +1023,25 @@ func TestCreatePeerSelector(t *testing.T) {
 	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
 	ps = createPeerSelector(s.net, s.cfg, true)
 
-	require.Equal(t, 3, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
+	cps, ok = ps.(*classBasedPeerSelector)
+	require.True(t, ok)
 
-	require.Equal(t, network.PeersPhonebookArchivalNodes, ps.peerClasses[0].peerClass)
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[1].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].peerClass)
+	require.Equal(t, 3, len(cps.peerSelectors))
+	require.Equal(t, peerRankInitialFirstPriority, cps.peerSelectors[0].priority)
+	require.Equal(t, peerRankInitialSecondPriority, cps.peerSelectors[1].priority)
+	require.Equal(t, peerRankInitialThirdPriority, cps.peerSelectors[2].priority)
+
+	require.Equal(t, network.PeersConnectedOut, cps.peerSelectors[0].peerClass)
+	require.Equal(t, network.PeersPhonebookRelays, cps.peerSelectors[1].peerClass)
+	require.Equal(t, network.PeersPhonebookArchivalNodes, cps.peerSelectors[2].peerClass)
+
+	require.Equal(t, 3, cps.peerSelectors[0].toleranceFactor)
+	require.Equal(t, 3, cps.peerSelectors[1].toleranceFactor)
+	require.Equal(t, 10, cps.peerSelectors[2].toleranceFactor)
+
+	require.False(t, cps.peerSelectors[0].lastCheckedTime.IsZero())
+	require.False(t, cps.peerSelectors[1].lastCheckedTime.IsZero())
+	require.False(t, cps.peerSelectors[2].lastCheckedTime.IsZero())
 
 	// cfg.NetAddress != ""; cfg.EnableGossipService = true; pipelineFetch = false
 	cfg.NetAddress = "someAddress"
@@ -1014,16 +1049,19 @@ func TestCreatePeerSelector(t *testing.T) {
 	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
 	ps = createPeerSelector(s.net, s.cfg, false)
 
-	require.Equal(t, 4, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
-	require.Equal(t, peerRankInitialFourthPriority, ps.peerClasses[3].initialRank)
+	cps, ok = ps.(*classBasedPeerSelector)
+	require.True(t, ok)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
-	require.Equal(t, network.PeersConnectedIn, ps.peerClasses[1].peerClass)
-	require.Equal(t, network.PeersPhonebookArchivalNodes, ps.peerClasses[2].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[3].peerClass)
+	require.Equal(t, 4, len(cps.peerSelectors))
+	require.Equal(t, peerRankInitialFirstPriority, cps.peerSelectors[0].priority)
+	require.Equal(t, peerRankInitialSecondPriority, cps.peerSelectors[1].priority)
+	require.Equal(t, peerRankInitialThirdPriority, cps.peerSelectors[2].priority)
+	require.Equal(t, peerRankInitialFourthPriority, cps.peerSelectors[3].priority)
+
+	require.Equal(t, network.PeersConnectedOut, cps.peerSelectors[0].peerClass)
+	require.Equal(t, network.PeersConnectedIn, cps.peerSelectors[1].peerClass)
+	require.Equal(t, network.PeersPhonebookArchivalNodes, cps.peerSelectors[2].peerClass)
+	require.Equal(t, network.PeersPhonebookRelays, cps.peerSelectors[3].peerClass)
 
 	// cfg.NetAddress == ""; cfg.EnableGossipService = true; pipelineFetch = false
 	cfg.NetAddress = ""
@@ -1031,14 +1069,25 @@ func TestCreatePeerSelector(t *testing.T) {
 	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
 	ps = createPeerSelector(s.net, s.cfg, false)
 
-	require.Equal(t, 3, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
+	cps, ok = ps.(*classBasedPeerSelector)
+	require.True(t, ok)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
-	require.Equal(t, network.PeersPhonebookArchivalNodes, ps.peerClasses[1].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].peerClass)
+	require.Equal(t, 3, len(cps.peerSelectors))
+	require.Equal(t, peerRankInitialFirstPriority, cps.peerSelectors[0].priority)
+	require.Equal(t, peerRankInitialSecondPriority, cps.peerSelectors[1].priority)
+	require.Equal(t, peerRankInitialThirdPriority, cps.peerSelectors[2].priority)
+
+	require.Equal(t, network.PeersConnectedOut, cps.peerSelectors[0].peerClass)
+	require.Equal(t, network.PeersPhonebookArchivalNodes, cps.peerSelectors[1].peerClass)
+	require.Equal(t, network.PeersPhonebookRelays, cps.peerSelectors[2].peerClass)
+
+	require.Equal(t, 3, cps.peerSelectors[0].toleranceFactor)
+	require.Equal(t, 10, cps.peerSelectors[1].toleranceFactor)
+	require.Equal(t, 3, cps.peerSelectors[2].toleranceFactor)
+
+	require.False(t, cps.peerSelectors[0].lastCheckedTime.IsZero())
+	require.False(t, cps.peerSelectors[1].lastCheckedTime.IsZero())
+	require.False(t, cps.peerSelectors[2].lastCheckedTime.IsZero())
 
 	// cfg.NetAddress != ""; cfg.EnableGossipService = false; pipelineFetch = false
 	cfg.NetAddress = "someAddress"
@@ -1046,14 +1095,25 @@ func TestCreatePeerSelector(t *testing.T) {
 	s = MakeService(logging.Base(), cfg, &httpTestPeerSource{}, new(mockedLedger), &mockedAuthenticator{errorRound: int(0 + 1)}, nil, nil)
 	ps = createPeerSelector(s.net, s.cfg, false)
 
-	require.Equal(t, 3, len(ps.peerClasses))
-	require.Equal(t, peerRankInitialFirstPriority, ps.peerClasses[0].initialRank)
-	require.Equal(t, peerRankInitialSecondPriority, ps.peerClasses[1].initialRank)
-	require.Equal(t, peerRankInitialThirdPriority, ps.peerClasses[2].initialRank)
+	cps, ok = ps.(*classBasedPeerSelector)
+	require.True(t, ok)
 
-	require.Equal(t, network.PeersConnectedOut, ps.peerClasses[0].peerClass)
-	require.Equal(t, network.PeersPhonebookArchivalNodes, ps.peerClasses[1].peerClass)
-	require.Equal(t, network.PeersPhonebookRelays, ps.peerClasses[2].peerClass)
+	require.Equal(t, 3, len(cps.peerSelectors))
+	require.Equal(t, peerRankInitialFirstPriority, cps.peerSelectors[0].priority)
+	require.Equal(t, peerRankInitialSecondPriority, cps.peerSelectors[1].priority)
+	require.Equal(t, peerRankInitialThirdPriority, cps.peerSelectors[2].priority)
+
+	require.Equal(t, network.PeersConnectedOut, cps.peerSelectors[0].peerClass)
+	require.Equal(t, network.PeersPhonebookArchivalNodes, cps.peerSelectors[1].peerClass)
+	require.Equal(t, network.PeersPhonebookRelays, cps.peerSelectors[2].peerClass)
+
+	require.Equal(t, 3, cps.peerSelectors[0].toleranceFactor)
+	require.Equal(t, 10, cps.peerSelectors[1].toleranceFactor)
+	require.Equal(t, 3, cps.peerSelectors[2].toleranceFactor)
+
+	require.False(t, cps.peerSelectors[0].lastCheckedTime.IsZero())
+	require.False(t, cps.peerSelectors[1].lastCheckedTime.IsZero())
+	require.False(t, cps.peerSelectors[2].lastCheckedTime.IsZero())
 }
 
 func TestServiceStartStop(t *testing.T) {

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -965,10 +965,6 @@ func TestCreatePeerSelector(t *testing.T) {
 	require.True(t, ok)
 
 	require.Equal(t, 4, len(cps.peerSelectors))
-	require.Equal(t, peerRankInitialFirstPriority, cps.peerSelectors[0].priority)
-	require.Equal(t, peerRankInitialSecondPriority, cps.peerSelectors[1].priority)
-	require.Equal(t, peerRankInitialThirdPriority, cps.peerSelectors[2].priority)
-	require.Equal(t, peerRankInitialFourthPriority, cps.peerSelectors[3].priority)
 
 	require.Equal(t, network.PeersConnectedOut, cps.peerSelectors[0].peerClass)
 	require.Equal(t, network.PeersPhonebookRelays, cps.peerSelectors[1].peerClass)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Introduce a class-based peer selector for explicitly ranking peer groups based on type and download performance. The intent is to be able to quickly move from one class of peers to the next in cases such as where a client needs older blocks that may only be present on archival nodes.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Introduce new unit tests for class-based peer selector, existing tests should be updated/pass. 

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
