### PR TITLE
Tests: Thread testing.T through so we panic less

### DIFF
--- a/agreement/service_test.go
+++ b/agreement/service_test.go
@@ -650,14 +650,10 @@ func createTestAccountsAndBalances(t *testing.T, numNodes int, rootSeed []byte) 
 		// add new account rootAddress to db
 		{
 			rootAccess, err := db.MakeAccessor(t.Name()+"root"+strconv.Itoa(i+off), false, true)
-			if err != nil {
-				panic(err)
-			}
+			require.NoError(t, err)
 			seed = sha256.Sum256(seed[:]) // rehash every node to get different root addresses
 			root, err := account.ImportRoot(rootAccess, seed)
-			if err != nil {
-				panic(err)
-			}
+			require.NoError(t, err)
 			rootAddress = root.Address()
 		}
 
@@ -742,9 +738,7 @@ func setupAgreementWithValidator(t *testing.T, numNodes int, traceLevel traceLev
 
 	for i := 0; i < numNodes; i++ {
 		accessor, err := db.MakeAccessor(t.Name()+"_"+strconv.Itoa(i)+"_crash.db", false, true)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 		dbAccessors[i] = accessor
 
 		m := baseNetwork.monitors[nodeID(i)]
@@ -826,23 +820,17 @@ func (m *coserviceMonitor) clearClock() {
 	}
 }
 
-func expectNewPeriod(clocks []timers.Clock[TimeoutType], zeroes uint) (newzeroes uint) {
+func expectNewPeriod(t *testing.T, clocks []timers.Clock[TimeoutType], zeroes uint) (newzeroes uint) {
 	zeroes++
 	for i := range clocks {
-		if clocks[i].(*testingClock).zeroes != zeroes {
-			errstr := fmt.Sprintf("unexpected number of zeroes: %v != %v", clocks[i].(*testingClock).zeroes, zeroes)
-			panic(errstr)
-		}
+		require.Equal(t, zeroes, clocks[i].(*testingClock).zeroes, "unexpected number of zeroes")
 	}
 	return zeroes
 }
 
-func expectNoNewPeriod(clocks []timers.Clock[TimeoutType], zeroes uint) (newzeroes uint) {
+func expectNoNewPeriod(t *testing.T, clocks []timers.Clock[TimeoutType], zeroes uint) (newzeroes uint) {
 	for i := range clocks {
-		if clocks[i].(*testingClock).zeroes != zeroes {
-			errstr := fmt.Sprintf("unexpected number of zeroes: %v != %v", clocks[i].(*testingClock).zeroes, zeroes)
-			panic(errstr)
-		}
+		require.Equal(t, zeroes, clocks[i].(*testingClock).zeroes, "unexpected number of zeroes")
 	}
 	return zeroes
 }
@@ -869,13 +857,13 @@ func triggerGlobalTimeoutType(timeoutType TimeoutType, clocks []timers.Clock[Tim
 	activityMonitor.waitForQuiet()
 }
 
-func runRound(clocks []timers.Clock[TimeoutType], activityMonitor *activityMonitor, zeroes uint, filterTimeout time.Duration) (newzeroes uint) {
+func runRound(t *testing.T, clocks []timers.Clock[TimeoutType], activityMonitor *activityMonitor, zeroes uint, filterTimeout time.Duration) (newzeroes uint) {
 	triggerGlobalTimeout(filterTimeout, TimeoutFilter, clocks, activityMonitor)
-	return expectNewPeriod(clocks, zeroes)
+	return expectNewPeriod(t, clocks, zeroes)
 }
-func runRoundTriggerFilter(clocks []timers.Clock[TimeoutType], activityMonitor *activityMonitor, zeroes uint) (newzeroes uint) {
+func runRoundTriggerFilter(t *testing.T, clocks []timers.Clock[TimeoutType], activityMonitor *activityMonitor, zeroes uint) (newzeroes uint) {
 	triggerGlobalTimeoutType(TimeoutFilter, clocks, activityMonitor)
-	return expectNewPeriod(clocks, zeroes)
+	return expectNewPeriod(t, clocks, zeroes)
 }
 
 func sanityCheck(startRound round, numRounds round, ledgers []Ledger) {
@@ -916,19 +904,19 @@ func simulateAgreementWithLedgerFactory(t *testing.T, numNodes int, numRounds in
 	}
 	activityMonitor.waitForActivity()
 	activityMonitor.waitForQuiet()
-	zeroes := expectNewPeriod(clocks, 0)
+	zeroes := expectNewPeriod(t, clocks, 0)
 
 	filterTimeouts := make([][]time.Duration, numNodes, numNodes)
 
 	// run round with round-specific consensus version first (since fix in #1896)
-	zeroes = runRoundTriggerFilter(clocks, activityMonitor, zeroes)
+	zeroes = runRoundTriggerFilter(t, clocks, activityMonitor, zeroes)
 	for j := 1; j < numRounds; j++ {
 		for srvIdx, clock := range clocks {
 			delta, err := clock.(*testingClock).when(TimeoutFilter)
 			require.NoError(t, err)
 			filterTimeouts[srvIdx] = append(filterTimeouts[srvIdx], delta)
 		}
-		zeroes = runRoundTriggerFilter(clocks, activityMonitor, zeroes)
+		zeroes = runRoundTriggerFilter(t, clocks, activityMonitor, zeroes)
 	}
 
 	for i := 0; i < numNodes; i++ {
@@ -1127,21 +1115,21 @@ func TestDynamicFilterTimeoutResets(t *testing.T) {
 	}
 	activityMonitor.waitForActivity()
 	activityMonitor.waitForQuiet()
-	zeroes := expectNewPeriod(clocks, 0)
+	zeroes := expectNewPeriod(t, clocks, 0)
 
 	filterTimeouts := make([][]time.Duration, numNodes, numNodes)
 
 	baseHistoryRounds := dynamicFilterCredentialArrivalHistory + int(credentialRoundLag)
 
 	// run round with round-specific consensus version first (since fix in #1896)
-	zeroes = runRoundTriggerFilter(clocks, activityMonitor, zeroes)
+	zeroes = runRoundTriggerFilter(t, clocks, activityMonitor, zeroes)
 	for j := 1; j < baseHistoryRounds+2; j++ {
 		for srvIdx, clock := range clocks {
 			delta, err := clock.(*testingClock).when(TimeoutFilter)
 			require.NoError(t, err)
 			filterTimeouts[srvIdx] = append(filterTimeouts[srvIdx], delta)
 		}
-		zeroes = runRoundTriggerFilter(clocks, activityMonitor, zeroes)
+		zeroes = runRoundTriggerFilter(t, clocks, activityMonitor, zeroes)
 	}
 
 	for i := range clocks {
@@ -1158,36 +1146,36 @@ func TestDynamicFilterTimeoutResets(t *testing.T) {
 		baseNetwork.dropAllSlowNextVotes()
 
 		triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeoutType(TimeoutDeadline, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(0, TimeoutFastRecovery, clocks, activityMonitor) // activates fast partition recovery timer
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(firstFPR, TimeoutFastRecovery, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// terminate on period 1
 	{
 		baseNetwork.repairAll()
 		triggerGlobalTimeout(FilterTimeout(1, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	filterTimeoutsPostRecovery := make([][]time.Duration, numNodes, numNodes)
 
 	// run round with round-specific consensus version first (since fix in #1896)
-	zeroes = runRoundTriggerFilter(clocks, activityMonitor, zeroes)
+	zeroes = runRoundTriggerFilter(t, clocks, activityMonitor, zeroes)
 	for j := 1; j < baseHistoryRounds+1; j++ {
 		for srvIdx, clock := range clocks {
 			delta, err := clock.(*testingClock).when(TimeoutFilter)
 			require.NoError(t, err)
 			filterTimeoutsPostRecovery[srvIdx] = append(filterTimeoutsPostRecovery[srvIdx], delta)
 		}
-		zeroes = runRoundTriggerFilter(clocks, activityMonitor, zeroes)
+		zeroes = runRoundTriggerFilter(t, clocks, activityMonitor, zeroes)
 	}
 
 	for i := range clocks {
@@ -1262,11 +1250,11 @@ func TestAgreementFastRecoveryDownEarly(t *testing.T) {
 	}
 	activityMonitor.waitForActivity()
 	activityMonitor.waitForQuiet()
-	zeroes := expectNewPeriod(clocks, 0)
+	zeroes := expectNewPeriod(t, clocks, 0)
 
 	// run two rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	// force fast partition recovery into bottom
@@ -1275,28 +1263,28 @@ func TestAgreementFastRecoveryDownEarly(t *testing.T) {
 		baseNetwork.dropAllSlowNextVotes()
 
 		triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeoutType(TimeoutDeadline, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(0, TimeoutFastRecovery, clocks, activityMonitor) // activates fast partition recovery timer
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(firstFPR, TimeoutFastRecovery, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// terminate on period 1
 	{
 		baseNetwork.repairAll()
 		triggerGlobalTimeout(FilterTimeout(1, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// run two more rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	for i := 0; i < numNodes; i++ {
@@ -1320,11 +1308,11 @@ func TestAgreementFastRecoveryDownMiss(t *testing.T) {
 	}
 	activityMonitor.waitForActivity()
 	activityMonitor.waitForQuiet()
-	zeroes := expectNewPeriod(clocks, 0)
+	zeroes := expectNewPeriod(t, clocks, 0)
 
 	// run two rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	// force fast partition recovery into bottom
@@ -1332,13 +1320,13 @@ func TestAgreementFastRecoveryDownMiss(t *testing.T) {
 		// fail all steps
 		baseNetwork.dropAllVotes()
 		triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(DeadlineTimeout(0, version), TimeoutDeadline, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(0, TimeoutFastRecovery, clocks, activityMonitor) // activates fast partition recovery timer
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		firstClocks := clocks[:4]
 		restClocks := clocks[4:]
@@ -1351,7 +1339,7 @@ func TestAgreementFastRecoveryDownMiss(t *testing.T) {
 		}
 		activityMonitor.waitForActivity()
 		activityMonitor.waitForQuiet()
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		baseNetwork.repairAll()
 		for i := range restClocks {
@@ -1362,22 +1350,22 @@ func TestAgreementFastRecoveryDownMiss(t *testing.T) {
 		}
 		activityMonitor.waitForActivity()
 		activityMonitor.waitForQuiet()
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(secondFPR, TimeoutFastRecovery, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// terminate on period 1
 	{
 		baseNetwork.repairAll()
 		triggerGlobalTimeout(FilterTimeout(1, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// run two more rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	for i := 0; i < numNodes; i++ {
@@ -1401,11 +1389,11 @@ func TestAgreementFastRecoveryLate(t *testing.T) {
 	}
 	activityMonitor.waitForActivity()
 	activityMonitor.waitForQuiet()
-	zeroes := expectNewPeriod(clocks, 0)
+	zeroes := expectNewPeriod(t, clocks, 0)
 
 	// run two rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	// force fast partition recovery into value
@@ -1415,31 +1403,26 @@ func TestAgreementFastRecoveryLate(t *testing.T) {
 		closeFn := baseNetwork.pocketAllCertVotes(pocket)
 		baseNetwork.dropAllSlowNextVotes()
 		triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 		closeFn()
 
 		for msg := range pocket {
 			var uv unauthenticatedVote
 			err := protocol.DecodeStream(bytes.NewBuffer(msg.data), &uv)
-			if err != nil {
-				panic(err)
-			}
+			require.NoError(t, err)
 
 			if expected == (proposalValue{}) {
 				expected = uv.R.Proposal
 			} else {
-				if uv.R.Proposal != expected {
-					errstr := fmt.Sprintf("got unexpected proposal: %v != %v", uv.R.Proposal, expected)
-					panic(errstr)
-				}
+				require.Equal(t, expected, uv.R.Proposal, "unexpected proposal")
 			}
 		}
 
 		triggerGlobalTimeout(DeadlineTimeout(0, version), TimeoutDeadline, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(0, TimeoutFastRecovery, clocks, activityMonitor) // activates fast partition recovery timer
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 		baseNetwork.dropAllVotes()
 
 		firstClocks := clocks[:4]
@@ -1453,7 +1436,7 @@ func TestAgreementFastRecoveryLate(t *testing.T) {
 		}
 		activityMonitor.waitForActivity()
 		activityMonitor.waitForQuiet()
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		baseNetwork.repairAll()
 		for i := range restClocks {
@@ -1464,33 +1447,28 @@ func TestAgreementFastRecoveryLate(t *testing.T) {
 		}
 		activityMonitor.waitForActivity()
 		activityMonitor.waitForQuiet()
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(secondFPR, TimeoutFastRecovery, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// terminate on period 1
 	{
 		baseNetwork.repairAll()
 		triggerGlobalTimeout(FilterTimeout(1, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	for _, l := range ledgers {
 		lastHash, err := l.LookupDigest(l.NextRound() - 1)
-		if err != nil {
-			panic(err)
-		}
-		if lastHash != expected.BlockDigest {
-			errstr := fmt.Sprintf("converged on wrong block: %v != %v", lastHash, expected.BlockDigest)
-			panic(errstr)
-		}
+		require.NoError(t, err)
+		require.Equal(t, expected.BlockDigest, lastHash, "converged on wrong block")
 	}
 
 	// run two more rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	for i := 0; i < numNodes; i++ {
@@ -1514,11 +1492,11 @@ func TestAgreementFastRecoveryRedo(t *testing.T) {
 	}
 	activityMonitor.waitForActivity()
 	activityMonitor.waitForQuiet()
-	zeroes := expectNewPeriod(clocks, 0)
+	zeroes := expectNewPeriod(t, clocks, 0)
 
 	// run two rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	// force fast partition recovery into value
@@ -1528,31 +1506,26 @@ func TestAgreementFastRecoveryRedo(t *testing.T) {
 		closeFn := baseNetwork.pocketAllCertVotes(pocket)
 		baseNetwork.dropAllSlowNextVotes()
 		triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 		closeFn()
 
 		for msg := range pocket {
 			var uv unauthenticatedVote
 			err := protocol.DecodeStream(bytes.NewBuffer(msg.data), &uv)
-			if err != nil {
-				panic(err)
-			}
+			require.NoError(t, err)
 
 			if expected == (proposalValue{}) {
 				expected = uv.R.Proposal
 			} else {
-				if uv.R.Proposal != expected {
-					errstr := fmt.Sprintf("got unexpected proposal: %v != %v", uv.R.Proposal, expected)
-					panic(errstr)
-				}
+				require.Equal(t, expected, uv.R.Proposal, "unexpected proposal")
 			}
 		}
 
 		triggerGlobalTimeout(DeadlineTimeout(0, version), TimeoutDeadline, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(0, TimeoutFastRecovery, clocks, activityMonitor) // activates fast partition recovery timer
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 		baseNetwork.dropAllVotes()
 
 		firstClocks := clocks[:4]
@@ -1566,7 +1539,7 @@ func TestAgreementFastRecoveryRedo(t *testing.T) {
 		}
 		activityMonitor.waitForActivity()
 		activityMonitor.waitForQuiet()
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		baseNetwork.repairAll()
 		for i := range restClocks {
@@ -1577,23 +1550,23 @@ func TestAgreementFastRecoveryRedo(t *testing.T) {
 		}
 		activityMonitor.waitForActivity()
 		activityMonitor.waitForQuiet()
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(secondFPR, TimeoutFastRecovery, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// fail period 1 with value again
 	{
 		baseNetwork.dropAllVotes()
 		triggerGlobalTimeout(FilterTimeout(1, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(DeadlineTimeout(1, version), TimeoutDeadline, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(0, TimeoutFastRecovery, clocks, activityMonitor) // activates fast partition recovery timer
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 		baseNetwork.dropAllVotes()
 
 		firstClocks := clocks[:4]
@@ -1607,7 +1580,7 @@ func TestAgreementFastRecoveryRedo(t *testing.T) {
 		}
 		activityMonitor.waitForActivity()
 		activityMonitor.waitForQuiet()
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		baseNetwork.repairAll()
 		for i := range restClocks {
@@ -1618,33 +1591,28 @@ func TestAgreementFastRecoveryRedo(t *testing.T) {
 		}
 		activityMonitor.waitForActivity()
 		activityMonitor.waitForQuiet()
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(secondFPR, TimeoutFastRecovery, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// terminate on period 2
 	{
 		baseNetwork.repairAll()
 		triggerGlobalTimeout(FilterTimeout(2, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	for _, l := range ledgers {
 		lastHash, err := l.LookupDigest(l.NextRound() - 1)
-		if err != nil {
-			panic(err)
-		}
-		if lastHash != expected.BlockDigest {
-			errstr := fmt.Sprintf("converged on wrong block: %v != %v", lastHash, expected.BlockDigest)
-			panic(errstr)
-		}
+		require.NoError(t, err)
+		require.Equal(t, expected.BlockDigest, lastHash, "converged on wrong block")
 	}
 
 	// run two more rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	for i := 0; i < numNodes; i++ {
@@ -1668,42 +1636,42 @@ func TestAgreementBlockReplayBug_b29ea57(t *testing.T) {
 	}
 	activityMonitor.waitForActivity()
 	activityMonitor.waitForQuiet()
-	zeroes := expectNewPeriod(clocks, 0)
+	zeroes := expectNewPeriod(t, clocks, 0)
 
 	// run two rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	// fail period 0
 	{
 		baseNetwork.dropAllSoftVotes()
 		triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(DeadlineTimeout(0, version), TimeoutDeadline, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// fail period 1 on bottom with block
 	{
 		triggerGlobalTimeout(FilterTimeout(1, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(DeadlineTimeout(1, version), TimeoutDeadline, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// terminate on period 2
 	{
 		baseNetwork.repairAll()
 		triggerGlobalTimeout(FilterTimeout(2, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// run two more rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	for i := 0; i < numNodes; i++ {
@@ -1727,11 +1695,11 @@ func TestAgreementLateCertBug(t *testing.T) {
 	}
 	activityMonitor.waitForActivity()
 	activityMonitor.waitForQuiet()
-	zeroes := expectNewPeriod(clocks, 0)
+	zeroes := expectNewPeriod(t, clocks, 0)
 
 	// run two rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	// delay minority cert votes to force period 1
@@ -1739,12 +1707,12 @@ func TestAgreementLateCertBug(t *testing.T) {
 	{
 		closeFn := baseNetwork.pocketAllCertVotes(pocket)
 		triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 		closeFn()
 		baseNetwork.repairAll()
 
 		triggerGlobalTimeout(DeadlineTimeout(0, version), TimeoutDeadline, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// terminate on period 0 in period 1
@@ -1756,12 +1724,12 @@ func TestAgreementLateCertBug(t *testing.T) {
 		baseNetwork.finishAllMulticast()
 		activityMonitor.waitForActivity()
 		activityMonitor.waitForQuiet()
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// run two more rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	for i := 0; i < numNodes; i++ {
@@ -1785,11 +1753,11 @@ func TestAgreementRecoverGlobalStartingValue(t *testing.T) {
 	}
 	activityMonitor.waitForActivity()
 	activityMonitor.waitForQuiet()
-	zeroes := expectNewPeriod(clocks, 0)
+	zeroes := expectNewPeriod(t, clocks, 0)
 
 	// run two rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	// force partition recovery into value
@@ -1799,28 +1767,23 @@ func TestAgreementRecoverGlobalStartingValue(t *testing.T) {
 		closeFn := baseNetwork.pocketAllCertVotes(pocket)
 
 		triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 		closeFn()
 
 		for msg := range pocket {
 			var uv unauthenticatedVote
 			err := protocol.DecodeStream(bytes.NewBuffer(msg.data), &uv)
-			if err != nil {
-				panic(err)
-			}
+			require.NoError(t, err)
 
 			if expected == (proposalValue{}) {
 				expected = uv.R.Proposal
 			} else {
-				if uv.R.Proposal != expected {
-					errstr := fmt.Sprintf("got unexpected proposal: %v != %v", uv.R.Proposal, expected)
-					panic(errstr)
-				}
+				require.Equal(t, expected, uv.R.Proposal, "unexpected proposal")
 			}
 		}
 
 		triggerGlobalTimeout(DeadlineTimeout(0, version), TimeoutDeadline, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 		require.Equal(t, 4, int(zeroes))
 	}
 
@@ -1830,24 +1793,18 @@ func TestAgreementRecoverGlobalStartingValue(t *testing.T) {
 		closeFn := baseNetwork.pocketAllCertVotes(pocket)
 
 		triggerGlobalTimeout(FilterTimeout(1, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 		closeFn()
 
 		for msg := range pocket {
 			var uv unauthenticatedVote
 			err := protocol.DecodeStream(bytes.NewBuffer(msg.data), &uv)
-			if err != nil {
-				panic(err)
-			}
-
-			if uv.R.Proposal != expected {
-				errstr := fmt.Sprintf("got unexpected proposal: %v != %v", uv.R.Proposal, expected)
-				panic(errstr)
-			}
+			require.NoError(t, err)
+			require.Equal(t, expected, uv.R.Proposal, "unexpected proposal")
 		}
 
 		triggerGlobalTimeout(DeadlineTimeout(1, version), TimeoutDeadline, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 		require.Equal(t, 5, int(zeroes))
 	}
 
@@ -1856,13 +1813,13 @@ func TestAgreementRecoverGlobalStartingValue(t *testing.T) {
 	{
 		baseNetwork.repairAll()
 		triggerGlobalTimeout(FilterTimeout(2, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 		require.Equal(t, 6, int(zeroes))
 	}
 
 	// run two more rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 	for i := 0; i < numNodes; i++ {
 		services[i].Shutdown()
@@ -1885,11 +1842,11 @@ func TestAgreementRecoverGlobalStartingValueBadProposal(t *testing.T) {
 	}
 	activityMonitor.waitForActivity()
 	activityMonitor.waitForQuiet()
-	zeroes := expectNewPeriod(clocks, 0)
+	zeroes := expectNewPeriod(t, clocks, 0)
 
 	// run two rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	// force partition recovery into value.
@@ -1898,23 +1855,18 @@ func TestAgreementRecoverGlobalStartingValueBadProposal(t *testing.T) {
 		pocket := make(chan multicastParams, 100)
 		closeFn := baseNetwork.pocketAllCertVotes(pocket)
 		triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 		closeFn()
 
 		for msg := range pocket {
 			var uv unauthenticatedVote
 			err := protocol.DecodeStream(bytes.NewBuffer(msg.data), &uv)
-			if err != nil {
-				panic(err)
-			}
+			require.NoError(t, err)
 
 			if expected == (proposalValue{}) {
 				expected = uv.R.Proposal
 			} else {
-				if uv.R.Proposal != expected {
-					errstr := fmt.Sprintf("got unexpected proposal: %v != %v", uv.R.Proposal, expected)
-					panic(errstr)
-				}
+				require.Equal(t, expected, uv.R.Proposal, "unexpected proposal")
 			}
 		}
 		// intercept all proposals for the next period; replace with unexpected
@@ -1925,7 +1877,7 @@ func TestAgreementRecoverGlobalStartingValueBadProposal(t *testing.T) {
 			return params
 		})
 		triggerGlobalTimeout(DeadlineTimeout(0, version), TimeoutDeadline, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 		require.Equal(t, 4, int(zeroes))
 	}
 
@@ -1935,23 +1887,17 @@ func TestAgreementRecoverGlobalStartingValueBadProposal(t *testing.T) {
 		pocket := make(chan multicastParams, 100)
 		closeFn := baseNetwork.pocketAllCertVotes(pocket)
 		triggerGlobalTimeout(FilterTimeout(1, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 		closeFn()
 
 		for msg := range pocket {
 			var uv unauthenticatedVote
 			err := protocol.DecodeStream(bytes.NewBuffer(msg.data), &uv)
-			if err != nil {
-				panic(err)
-			}
-
-			if uv.R.Proposal != expected {
-				errstr := fmt.Sprintf("got unexpected proposal: %v != %v", uv.R.Proposal, expected)
-				panic(errstr)
-			}
+			require.NoError(t, err)
+			require.Equal(t, expected, uv.R.Proposal, "unexpected proposal")
 		}
 		triggerGlobalTimeout(DeadlineTimeout(1, version), TimeoutDeadline, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 
 	}
 
@@ -1959,13 +1905,13 @@ func TestAgreementRecoverGlobalStartingValueBadProposal(t *testing.T) {
 	{
 		baseNetwork.repairAll()
 		triggerGlobalTimeout(FilterTimeout(2, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 		require.Equal(t, 6, int(zeroes))
 	}
 
 	// run two more rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 	for i := 0; i < numNodes; i++ {
 		services[i].Shutdown()
@@ -1988,11 +1934,11 @@ func TestAgreementRecoverBothVAndBotQuorums(t *testing.T) {
 	}
 	activityMonitor.waitForActivity()
 	activityMonitor.waitForQuiet()
-	zeroes := expectNewPeriod(clocks, 0)
+	zeroes := expectNewPeriod(t, clocks, 0)
 
 	// run two rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	// force partition recovery into both bottom and value. one node enters bottom, the rest enter value
@@ -2001,7 +1947,7 @@ func TestAgreementRecoverBothVAndBotQuorums(t *testing.T) {
 		pocket := make(chan multicastParams, 100)
 		closeFn := baseNetwork.pocketAllSoftVotes(pocket)
 		triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 		closeFn()
 		pocketedSoft := make([]multicastParams, len(pocket))
 		i := 0
@@ -2009,16 +1955,11 @@ func TestAgreementRecoverBothVAndBotQuorums(t *testing.T) {
 			r := bytes.NewBuffer(params.data)
 			var uv unauthenticatedVote
 			err := protocol.DecodeStream(r, &uv)
-			if err != nil {
-				panic(err)
-			}
+			require.NoError(t, err)
 			if expected == (proposalValue{}) {
 				expected = uv.R.Proposal
 			} else {
-				if uv.R.Proposal != expected {
-					errstr := fmt.Sprintf("got unexpected soft vote: %v != %v", uv.R.Proposal, expected)
-					panic(errstr)
-				}
+				require.Equal(t, expected, uv.R.Proposal, "unexpected soft vote")
 			}
 			pocketedSoft[i] = params
 			i++
@@ -2026,11 +1967,9 @@ func TestAgreementRecoverBothVAndBotQuorums(t *testing.T) {
 		// generate a bottom quorum; let only one node see it.
 		baseNetwork.crown(0)
 		triggerGlobalTimeout(DeadlineTimeout(0, version), TimeoutDeadline, clocks, activityMonitor)
-		if clocks[0].(*testingClock).zeroes != zeroes+1 {
-			errstr := fmt.Sprintf("node 0 did not enter new period from bot quorum")
-			panic(errstr)
-		}
-		zeroes = expectNoNewPeriod(clocks[1:], zeroes)
+		require.Equal(t, zeroes+1, clocks[0].(*testingClock).zeroes,
+			"node 0 did not enter new period from bot quorum")
+		zeroes = expectNoNewPeriod(t, clocks[1:], zeroes)
 
 		// enable creation of a value quorum; let everyone else see it
 		baseNetwork.repairAll()
@@ -2045,12 +1984,12 @@ func TestAgreementRecoverBothVAndBotQuorums(t *testing.T) {
 		// actually create the value quorum
 		_, upper := (next).nextVoteRanges(DeadlineTimeout(0, version))
 		triggerGlobalTimeout(upper, TimeoutDeadline, clocks[1:], activityMonitor) // activates next timers
-		zeroes = expectNoNewPeriod(clocks[1:], zeroes)
+		zeroes = expectNoNewPeriod(t, clocks[1:], zeroes)
 
 		lower, upper := (next + 1).nextVoteRanges(DeadlineTimeout(0, version))
 		delta := time.Duration(testingRand{}.Uint64() % uint64(upper-lower))
 		triggerGlobalTimeout(lower+delta, TimeoutDeadline, clocks[1:], activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 		require.Equal(t, 4, int(zeroes))
 	}
 
@@ -2060,37 +1999,31 @@ func TestAgreementRecoverBothVAndBotQuorums(t *testing.T) {
 		pocket := make(chan multicastParams, 100)
 		closeFn := baseNetwork.pocketAllCertVotes(pocket)
 		triggerGlobalTimeout(FilterTimeout(1, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 		closeFn()
 
 		for msg := range pocket {
 			var uv unauthenticatedVote
 			err := protocol.DecodeStream(bytes.NewBuffer(msg.data), &uv)
-			if err != nil {
-				panic(err)
-			}
-
-			if uv.R.Proposal != expected {
-				errstr := fmt.Sprintf("got unexpected proposal: %v != %v", uv.R.Proposal, expected)
-				panic(errstr)
-			}
+			require.NoError(t, err)
+			require.Equal(t, expected, uv.R.Proposal, "got unexpected proposal")
 		}
 
 		triggerGlobalTimeout(DeadlineTimeout(1, version), TimeoutDeadline, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// Finish in period 2
 	{
 		baseNetwork.repairAll()
 		triggerGlobalTimeout(FilterTimeout(2, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 		require.Equal(t, 6, int(zeroes))
 	}
 
 	// run two more rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 	for i := 0; i < numNodes; i++ {
 		services[i].Shutdown()
@@ -2113,11 +2046,11 @@ func TestAgreementSlowPayloadsPreDeadline(t *testing.T) {
 	}
 	activityMonitor.waitForActivity()
 	activityMonitor.waitForQuiet()
-	zeroes := expectNewPeriod(clocks, 0)
+	zeroes := expectNewPeriod(t, clocks, 0)
 
 	// run two rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	// run round and then start pocketing payloads
@@ -2125,13 +2058,13 @@ func TestAgreementSlowPayloadsPreDeadline(t *testing.T) {
 	closeFn := baseNetwork.pocketAllCompound(pocket) // (takes effect next round)
 	{
 		triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// run round with late payload
 	{
 		triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		// release payloads; expect new round
 		closeFn()
@@ -2143,12 +2076,12 @@ func TestAgreementSlowPayloadsPreDeadline(t *testing.T) {
 		baseNetwork.finishAllMulticast()
 		activityMonitor.waitForActivity()
 		activityMonitor.waitForQuiet()
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// run two more rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 	for i := 0; i < numNodes; i++ {
 		services[i].Shutdown()
@@ -2171,11 +2104,11 @@ func TestAgreementSlowPayloadsPostDeadline(t *testing.T) {
 	}
 	activityMonitor.waitForActivity()
 	activityMonitor.waitForQuiet()
-	zeroes := expectNewPeriod(clocks, 0)
+	zeroes := expectNewPeriod(t, clocks, 0)
 
 	// run two rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	// run round and then start pocketing payloads
@@ -2183,15 +2116,15 @@ func TestAgreementSlowPayloadsPostDeadline(t *testing.T) {
 	closeFn := baseNetwork.pocketAllCompound(pocket) // (takes effect next round)
 	{
 		triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// force network into period 1 by delaying proposals
 	{
 		triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 		triggerGlobalTimeout(DeadlineTimeout(0, version), TimeoutDeadline, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// recover in period 1
@@ -2205,15 +2138,15 @@ func TestAgreementSlowPayloadsPostDeadline(t *testing.T) {
 		baseNetwork.finishAllMulticast()
 		activityMonitor.waitForActivity()
 		activityMonitor.waitForQuiet()
-		zeroes = expectNoNewPeriod(clocks, zeroes)
+		zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 		triggerGlobalTimeout(FilterTimeout(1, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// run two more rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 	for i := 0; i < numNodes; i++ {
 		services[i].Shutdown()
@@ -2236,11 +2169,11 @@ func TestAgreementLargePeriods(t *testing.T) {
 
 	activityMonitor.waitForActivity()
 	activityMonitor.waitForQuiet()
-	zeroes := expectNewPeriod(clocks, 0)
+	zeroes := expectNewPeriod(t, clocks, 0)
 
 	// run two rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	// partition the network, run until period 60
@@ -2248,11 +2181,11 @@ func TestAgreementLargePeriods(t *testing.T) {
 		{
 			baseNetwork.partition(0, 1, 2)
 			triggerGlobalTimeout(FilterTimeout(period(p), version), TimeoutFilter, clocks, activityMonitor)
-			zeroes = expectNoNewPeriod(clocks, zeroes)
+			zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 			baseNetwork.repairAll()
 			triggerGlobalTimeout(DeadlineTimeout(period(p), version), TimeoutDeadline, clocks, activityMonitor)
-			zeroes = expectNewPeriod(clocks, zeroes)
+			zeroes = expectNewPeriod(t, clocks, zeroes)
 			require.Equal(t, 4+p, int(zeroes))
 		}
 	}
@@ -2260,12 +2193,12 @@ func TestAgreementLargePeriods(t *testing.T) {
 	// terminate
 	{
 		triggerGlobalTimeout(FilterTimeout(60, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// run two more rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 	for i := 0; i < numNodes; i++ {
 		services[i].Shutdown()
@@ -2273,9 +2206,8 @@ func TestAgreementLargePeriods(t *testing.T) {
 
 	const expectNumRounds = 5
 	for i := 0; i < numNodes; i++ {
-		if ledgers[i].NextRound() != startRound+round(expectNumRounds) {
-			panic("did not progress 5 rounds")
-		}
+		require.Equal(t, startRound+round(expectNumRounds), ledgers[i].NextRound(),
+			"did not progress 5 rounds")
 	}
 
 	for j := 0; j < expectNumRounds; j++ {
@@ -2283,9 +2215,7 @@ func TestAgreementLargePeriods(t *testing.T) {
 		reference := ledger.entries[startRound+round(j)].Digest()
 		for i := 0; i < numNodes; i++ {
 			ledger := ledgers[i].(*testLedger)
-			if ledger.entries[startRound+round(j)].Digest() != reference {
-				panic("wrong block confirmed")
-			}
+			require.Equal(t, reference, ledger.entries[startRound+round(j)].Digest(), "wrong block confirmed")
 		}
 	}
 }
@@ -2334,11 +2264,11 @@ func TestAgreementRegression_WrongPeriodPayloadVerificationCancellation_8ba23942
 	}
 	activityMonitor.waitForActivity()
 	activityMonitor.waitForQuiet()
-	zeroes := expectNewPeriod(clocks, 0)
+	zeroes := expectNewPeriod(t, clocks, 0)
 
 	// run two rounds
 	for j := 0; j < 2; j++ {
-		zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+		zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	}
 
 	// run round and then start pocketing payloads, suspending validation
@@ -2347,13 +2277,13 @@ func TestAgreementRegression_WrongPeriodPayloadVerificationCancellation_8ba23942
 	closeFn := baseNetwork.pocketAllCompound(pocket0) // (takes effect next round)
 	{
 		triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-		zeroes = expectNewPeriod(clocks, zeroes)
+		zeroes = expectNewPeriod(t, clocks, zeroes)
 	}
 
 	// force network into period 1 by failing period 0, entering with bottom and no soft threshold (to prevent proposal value pinning)
 	baseNetwork.dropAllSoftVotes()
 	triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-	zeroes = expectNoNewPeriod(clocks, zeroes)
+	zeroes = expectNoNewPeriod(t, clocks, zeroes)
 
 	// resume delivery of payloads in following period
 	baseNetwork.repairAll()
@@ -2440,15 +2370,15 @@ func TestAgreementRegression_WrongPeriodPayloadVerificationCancellation_8ba23942
 	}
 	baseNetwork.finishAllMulticast()
 
-	zeroes = expectNewPeriod(clocks, zeroes)
+	zeroes = expectNewPeriod(t, clocks, zeroes)
 	activityMonitor.waitForQuiet()
 
 	// run two more rounds
 	//for j := 0; j < 2; j++ {
-	//	zeroes = runRound(clocks, activityMonitor, zeroes, period(1-j))
+	//	zeroes = runRound(t, clocks, activityMonitor, zeroes, period(1-j))
 	//}
-	zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(1, version))
-	zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+	zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(1, version))
+	zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 
 	for i := 0; i < numNodes; i++ {
 		services[i].Shutdown()
@@ -2456,9 +2386,8 @@ func TestAgreementRegression_WrongPeriodPayloadVerificationCancellation_8ba23942
 
 	const expectNumRounds = 5
 	for i := 0; i < numNodes; i++ {
-		if ledgers[i].NextRound() != startRound+round(expectNumRounds) {
-			panic("did not progress 5 rounds")
-		}
+		require.Equal(t, startRound+round(expectNumRounds), ledgers[i].NextRound(),
+			"did not progress 5 rounds")
 	}
 
 	for j := 0; j < expectNumRounds; j++ {
@@ -2466,9 +2395,7 @@ func TestAgreementRegression_WrongPeriodPayloadVerificationCancellation_8ba23942
 		reference := ledger.entries[startRound+round(j)].Digest()
 		for i := 0; i < numNodes; i++ {
 			ledger := ledgers[i].(*testLedger)
-			if ledger.entries[startRound+round(j)].Digest() != reference {
-				panic("wrong block confirmed")
-			}
+			require.Equal(t, reference, ledger.entries[startRound+round(j)].Digest(), "wrong block confirmed")
 		}
 	}
 }
@@ -2491,17 +2418,15 @@ func TestAgreementCertificateDoesNotStallSingleRelay(t *testing.T) {
 	}
 	activityMonitor.waitForActivity()
 	activityMonitor.waitForQuiet()
-	zeroes := expectNewPeriod(clocks, 0)
+	zeroes := expectNewPeriod(t, clocks, 0)
 	// run two rounds
-	zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+	zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 	// make sure relay does not see block proposal for round 3
 	baseNetwork.intercept(func(params multicastParams) multicastParams {
 		if params.tag == protocol.ProposalPayloadTag {
 			var tp transmittedPayload
 			err := protocol.DecodeStream(bytes.NewBuffer(params.data), &tp)
-			if err != nil {
-				panic(err)
-			}
+			require.NoError(t, err)
 			if tp.Round() == basics.Round(startRound+2) {
 				params.exclude = relayID
 			}
@@ -2512,9 +2437,7 @@ func TestAgreementCertificateDoesNotStallSingleRelay(t *testing.T) {
 			if params.tag == protocol.AgreementVoteTag {
 				var uv unauthenticatedVote
 				err := protocol.DecodeStream(r, &uv)
-				if err != nil {
-					panic(err)
-				}
+				require.NoError(t, err)
 				if uv.R.Step != propose {
 					return params
 				}
@@ -2524,7 +2447,7 @@ func TestAgreementCertificateDoesNotStallSingleRelay(t *testing.T) {
 
 		return params
 	})
-	zeroes = runRound(clocks, activityMonitor, zeroes, FilterTimeout(0, version))
+	zeroes = runRound(t, clocks, activityMonitor, zeroes, FilterTimeout(0, version))
 
 	// Round 3:
 	// First partition the relay to prevent it from seeing certificate or block
@@ -2537,9 +2460,7 @@ func TestAgreementCertificateDoesNotStallSingleRelay(t *testing.T) {
 			r := bytes.NewBuffer(params.data)
 			var uv unauthenticatedVote
 			err := protocol.DecodeStream(r, &uv)
-			if err != nil {
-				panic(err)
-			}
+			require.NoError(t, err)
 			if uv.R.Step == cert {
 				pocketCert <- params
 			}
@@ -2548,7 +2469,7 @@ func TestAgreementCertificateDoesNotStallSingleRelay(t *testing.T) {
 	})
 	// And with some hypothetical second relay the network achieves consensus on a certificate and block.
 	triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks, activityMonitor)
-	zeroes = expectNewPeriod(clocks[1:], zeroes)
+	zeroes = expectNewPeriod(t, clocks[1:], zeroes)
 	require.Equal(t, uint(3), clocks[0].(*testingClock).zeroes)
 	close(pocketCert)
 
@@ -2567,7 +2488,7 @@ func TestAgreementCertificateDoesNotStallSingleRelay(t *testing.T) {
 	// this relay must still relay initial messages. Note that payloads were already relayed with
 	// the previous global timeout.
 	triggerGlobalTimeout(FilterTimeout(0, version), TimeoutFilter, clocks[1:], activityMonitor)
-	zeroes = expectNewPeriod(clocks[1:], zeroes)
+	zeroes = expectNewPeriod(t, clocks[1:], zeroes)
 	require.Equal(t, uint(3), clocks[0].(*testingClock).zeroes)
 
 	for i := 0; i < numNodes; i++ {
@@ -2575,18 +2496,15 @@ func TestAgreementCertificateDoesNotStallSingleRelay(t *testing.T) {
 	}
 	const expectNumRounds = 4
 	for i := 1; i < numNodes; i++ {
-		if ledgers[i].NextRound() != startRound+round(expectNumRounds) {
-			panic("did not progress 4 rounds")
-		}
+		require.Equal(t, startRound+round(expectNumRounds), ledgers[i].NextRound(),
+			"did not progress 4 rounds")
 	}
 	for j := 0; j < expectNumRounds; j++ {
 		ledger := ledgers[1].(*testLedger)
 		reference := ledger.entries[startRound+round(j)].Digest()
 		for i := 1; i < numNodes; i++ {
 			ledger := ledgers[i].(*testLedger)
-			if ledger.entries[startRound+round(j)].Digest() != reference {
-				panic("wrong block confirmed")
-			}
+			require.Equal(t, reference, ledger.entries[startRound+round(j)].Digest(), "wrong block confirmed")
 		}
 	}
 }


### PR DESCRIPTION
Same tests, nicer output, and we can see multiple failures, since we don't panic.

Ran into tests that were hard to understand because they panic'ed while doing incentive work.  This PR breaks out the very repetitive changes to use `require.