### PR TITLE
eval: increase opcode budget with fee credit

### DIFF
--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1565,7 +1565,7 @@ func (cx *EvalContext) step() error {
 		if cx.runMode == ModeApp {
 			*cx.pooledAllowedInners -= int(requiredMinFees)
 			if *cx.pooledAllowedInners < 0 {
-				return fmt.Errorf("pc=%3d dynamic group cost budget exceeded, executing %s: local program cost was %d.",
+				return fmt.Errorf("pc=%3d dynamic group cost budget exceeded, executing %s: local program cost was %d",
 					cx.pc, spec.Name, cx.cost)
 			}
 

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1553,11 +1553,7 @@ func (cx *EvalContext) step() error {
 			budgetPerMinFee = uint64(cx.Proto.MaxAppProgramCost)
 		}
 
-		shortfall := cx.Proto.MinTxnFee * (requiredExtraBudget / budgetPerMinFee)
-
-		if requiredExtraBudget%budgetPerMinFee != 0 {
-			shortfall += cx.Proto.MinTxnFee
-		}
+		shortfall := cx.Proto.MinTxnFee * ((requiredExtraBudget + budgetPerMinFee - 1) / budgetPerMinFee)
 
 		if cx.FeeCredit == nil || *cx.FeeCredit < shortfall {
 			return fmt.Errorf("pc=%3d dynamic cost budget exceeded, executing %s: local program cost was %d",

--- a/data/transactions/logic/evalAppTxn_test.go
+++ b/data/transactions/logic/evalAppTxn_test.go
@@ -1500,6 +1500,52 @@ itxn_submit;
 	TestApp(t, buy+buy+strings.Repeat(waste, 12)+"int 1", ep)
 }
 
+func TestInnerBudgetIncrementFromFee(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	ep, tx, ledger := MakeSampleEnv()
+
+	waste := `global CurrentApplicationAddress; keccak256; pop;`
+
+	ledger.NewApp(tx.Receiver, 888, basics.AppParams{})
+	ledger.NewAccount(appAddr(888), 50_000)
+	tx.ForeignApps = []basics.AppIndex{basics.AppIndex(222)}
+
+	// For every variation ensure the following:
+	//
+	// 1. The opcode budget is increased, but not more than necessary
+	// 2. The fee credit is deducted
+
+	*ep.FeeCredit = 0
+	TestApp(t, strings.Repeat(waste, 5)+"int 1", ep)
+	require.IsIncreasing(t, []int{0, *ep.PooledApplicationBudget, ep.Proto.MaxAppProgramCost})
+	require.Equal(t, uint64(0), *ep.FeeCredit)
+	TestApp(t, strings.Repeat(waste, 6)+"int 1", ep, "dynamic cost budget exceeded")
+
+	*ep.FeeCredit = ep.Proto.MinTxnFee
+	TestApp(t, strings.Repeat(waste, 6)+"int 1", ep)
+	require.IsIncreasing(t, []int{0, *ep.PooledApplicationBudget, ep.Proto.MaxAppProgramCost})
+	require.Equal(t, uint64(0), *ep.FeeCredit)
+	TestApp(t, strings.Repeat(waste, 11)+"int 1", ep, "dynamic cost budget exceeded")
+
+	*ep.FeeCredit = ep.Proto.MinTxnFee * 2
+	TestApp(t, strings.Repeat(waste, 11)+"int 1", ep)
+	require.IsIncreasing(t, []int{0, *ep.PooledApplicationBudget, ep.Proto.MaxAppProgramCost})
+	require.Equal(t, uint64(0), *ep.FeeCredit)
+	TestApp(t, strings.Repeat(waste, 16)+"int 1", ep, "dynamic cost budget exceeded")
+
+	// Ensure that the fee credit isn't deducted more than necessary
+	*ep.FeeCredit = ep.Proto.MinTxnFee * 3
+	TestApp(t, strings.Repeat(waste, 11)+"int 1", ep)
+	require.IsIncreasing(t, []int{0, *ep.PooledApplicationBudget, ep.Proto.MaxAppProgramCost})
+	require.Equal(t, ep.Proto.MinTxnFee, *ep.FeeCredit)
+
+	// Ensure the group budget is still enforced
+	*ep.FeeCredit = ep.Proto.MinTxnFee * 257
+	TestApp(t, strings.Repeat(waste, 5*257)+"int 1", ep, "dynamic group cost budget exceeded")
+}
+
 func TestIncrementCheck(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()


### PR DESCRIPTION
## Summary

Right now using inner txns is a very common pattern to increase opcode budget within an app call. This works, but it can be quite a clunky experience as a developer trying to figure out where your opups (or opup checks) should be as you iterate. It also leads to some extra bytes in programs and extraneous inner transactions in blocks (and potentially created apps if not properly deleted).

This PR is a proposal to add a new feature that increases the opcode budget by deducting `MinTxnFee` from the fee credit when extra opcode budget is needed. `pooledAllowedInners` is used and deducted accordingly to ensure that a single group doesn't consume more budget than what has historically been possible. 

## Test Plan

`TestInnerBudgetIncrementFromFee` ensures that this works in applications and verifies budget increase and fee credit deduction works as expected. 

- [ ] Test with inner transactions to ensure `pooledAllowedInners` is working as expected (or maybe just make it public so it can be verified in tests)

## TODO

- [ ] Put behind new AVM version
- [ ] Figure out best way to reconcile with the fact that the semantics of transaction have changed. Perhaps increment txn counter?



