### PR TITLE
Network: Support simple liveness check via http on gossip server port.

### DIFF
--- a/node/follower_node.go
+++ b/node/follower_node.go
@@ -128,8 +128,9 @@ func MakeFollower(log logging.Logger, rootDir string, cfg config.Local, phoneboo
 
 	node.ledger.RegisterBlockListeners(blockListeners)
 
-	// The health service registers itself with the network
-	rpcs.MakeHealthService(node.net, cfg.IsGossipServer())
+	if cfg.IsGossipServer() {
+		rpcs.MakeHealthService(node.net)
+	}
 
 	node.blockService = rpcs.MakeBlockService(node.log, cfg, node.ledger, p2pNode, node.genesisID)
 	node.catchupBlockAuth = blockAuthenticatorImpl{Ledger: node.ledger, AsyncVoteVerifier: agreement.MakeAsyncVoteVerifier(node.lowPriorityCryptoVerificationPool)}

--- a/node/follower_node.go
+++ b/node/follower_node.go
@@ -127,6 +127,10 @@ func MakeFollower(log logging.Logger, rootDir string, cfg config.Local, phoneboo
 	}
 
 	node.ledger.RegisterBlockListeners(blockListeners)
+
+	// The health service registers itself with the network
+	rpcs.MakeHealthService(node.net, cfg.IsGossipServer())
+
 	node.blockService = rpcs.MakeBlockService(node.log, cfg, node.ledger, p2pNode, node.genesisID)
 	node.catchupBlockAuth = blockAuthenticatorImpl{Ledger: node.ledger, AsyncVoteVerifier: agreement.MakeAsyncVoteVerifier(node.lowPriorityCryptoVerificationPool)}
 	node.catchupService = catchup.MakeService(node.log, node.config, p2pNode, node.ledger, node.catchupBlockAuth, make(chan catchup.PendingUnmatchedCertificate), node.lowPriorityCryptoVerificationPool)

--- a/node/node.go
+++ b/node/node.go
@@ -252,7 +252,9 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 	}
 
 	// The health service registers itself with the network
-	rpcs.MakeHealthService(node.net, cfg.IsGossipServer())
+	if cfg.IsGossipServer() {
+		rpcs.MakeHealthService(node.net)
+	}
 
 	node.blockService = rpcs.MakeBlockService(node.log, cfg, node.ledger, p2pNode, node.genesisID)
 	node.ledgerService = rpcs.MakeLedgerService(cfg, node.ledger, p2pNode, node.genesisID)

--- a/node/node.go
+++ b/node/node.go
@@ -251,6 +251,9 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 		return nil, err
 	}
 
+	// The health service registers itself with the network
+	rpcs.MakeHealthService(node.net, cfg.IsGossipServer())
+
 	node.blockService = rpcs.MakeBlockService(node.log, cfg, node.ledger, p2pNode, node.genesisID)
 	node.ledgerService = rpcs.MakeLedgerService(cfg, node.ledger, p2pNode, node.genesisID)
 	rpcs.RegisterTxService(node.transactionPool, p2pNode, node.genesisID, cfg.TxPoolSize, cfg.TxSyncServeResponseSize)

--- a/rpcs/healthService.go
+++ b/rpcs/healthService.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2019-2024 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package rpcs
+
+import (
+	"fmt"
+	"github.com/algorand/go-algorand/network"
+	"net/http"
+)
+
+// HealthServiceStatusPath is the path to register HealthService as a handler for when using gorilla/mux
+const HealthServiceStatusPath = "/status"
+
+// HealthService is a service that provides health information endpoints for the node
+type HealthService struct {
+	net           network.GossipNode
+	enableService bool
+}
+
+// MakeHealthService creates a new HealthService and registers it with the provided network if enabled
+func MakeHealthService(net network.GossipNode, enableService bool) HealthService {
+	service := HealthService{net: net, enableService: enableService}
+
+	if enableService {
+		net.RegisterHTTPHandler(HealthServiceStatusPath, service)
+	}
+
+	return service
+}
+
+func (h HealthService) ServeHTTP(writer http.ResponseWriter, _ *http.Request) {
+	writer.WriteHeader(http.StatusOK)
+	_, err := fmt.Fprintf(writer, "Port is Open!")
+	if err != nil {
+		http.Error(writer, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/rpcs/healthService.go
+++ b/rpcs/healthService.go
@@ -44,8 +44,5 @@ func MakeHealthService(net network.GossipNode, enableService bool) HealthService
 
 func (h HealthService) ServeHTTP(writer http.ResponseWriter, _ *http.Request) {
 	writer.WriteHeader(http.StatusOK)
-	_, err := fmt.Fprintf(writer, "Port is Open!")
-	if err != nil {
-		http.Error(writer, err.Error(), http.StatusInternalServerError)
-	}
+	_, _ = fmt.Fprintf(writer, "Port is Open!")
 }

--- a/rpcs/healthService.go
+++ b/rpcs/healthService.go
@@ -17,7 +17,6 @@
 package rpcs
 
 import (
-	"fmt"
 	"github.com/algorand/go-algorand/network"
 	"net/http"
 )
@@ -26,23 +25,17 @@ import (
 const HealthServiceStatusPath = "/status"
 
 // HealthService is a service that provides health information endpoints for the node
-type HealthService struct {
-	net           network.GossipNode
-	enableService bool
-}
+type HealthService struct{}
 
 // MakeHealthService creates a new HealthService and registers it with the provided network if enabled
-func MakeHealthService(net network.GossipNode, enableService bool) HealthService {
-	service := HealthService{net: net, enableService: enableService}
+func MakeHealthService(net network.GossipNode) HealthService {
+	service := HealthService{}
 
-	if enableService {
-		net.RegisterHTTPHandler(HealthServiceStatusPath, service)
-	}
+	net.RegisterHTTPHandler(HealthServiceStatusPath, service)
 
 	return service
 }
 
 func (h HealthService) ServeHTTP(writer http.ResponseWriter, _ *http.Request) {
 	writer.WriteHeader(http.StatusOK)
-	_, _ = fmt.Fprintf(writer, "Port is Open!")
 }

--- a/rpcs/healthService_test.go
+++ b/rpcs/healthService_test.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2019-2024 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package rpcs
+
+import (
+	"github.com/algorand/go-algorand/network"
+	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/stretchr/testify/require"
+	"io"
+	"net/http"
+	"path"
+	"testing"
+)
+
+func TestHealthService_ServeHTTP(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	nodeA := &basicRPCNode{}
+	nodeA.start()
+	defer nodeA.stop()
+
+	_ = MakeHealthService(nodeA, true)
+
+	parsedURL, err := network.ParseHostOrURL(nodeA.rootURL())
+	require.NoError(t, err)
+
+	client := http.Client{}
+
+	parsedURL.Path = path.Join(parsedURL.Path, HealthServiceStatusPath)
+
+	response, err := client.Get(parsedURL.String())
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	bodyData, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.NotEqual(t, 0, len(bodyData))
+
+	// Test with status endpoint disabled
+	nodeA.stop()
+	nodeA = &basicRPCNode{}
+	nodeA.start()
+	defer nodeA.stop()
+
+	// Status endpoint should not register, connection will be refused
+	_ = MakeHealthService(nodeA, false)
+	response, err = client.Get(parsedURL.String())
+	require.Error(t, err)
+	require.Nil(t, response)
+}

--- a/rpcs/healthService_test.go
+++ b/rpcs/healthService_test.go
@@ -33,7 +33,7 @@ func TestHealthService_ServeHTTP(t *testing.T) {
 	nodeA.start()
 	defer nodeA.stop()
 
-	_ = MakeHealthService(nodeA, true)
+	_ = MakeHealthService(nodeA)
 
 	parsedURL, err := network.ParseHostOrURL(nodeA.rootURL())
 	require.NoError(t, err)
@@ -48,17 +48,5 @@ func TestHealthService_ServeHTTP(t *testing.T) {
 	require.Equal(t, http.StatusOK, response.StatusCode)
 	bodyData, err := io.ReadAll(response.Body)
 	require.NoError(t, err)
-	require.NotEqual(t, 0, len(bodyData))
-
-	// Test with status endpoint disabled
-	nodeA.stop()
-	nodeA = &basicRPCNode{}
-	nodeA.start()
-	defer nodeA.stop()
-
-	// Status endpoint should not register, connection will be refused
-	_ = MakeHealthService(nodeA, false)
-	response, err = client.Get(parsedURL.String())
-	require.Error(t, err)
-	require.Nil(t, response)
+	require.Empty(t, bodyData)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

This PR adds a simple /status http endpoint on the gossip server port, enough to ensure it is open. Continue to use the /ready endpoint on the API port for readiness checks (i.e. is the node caught up?).

closes #5208 

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Added new health check tests, existing tests should pass without issue. In addition, started node up locally with NetAddress set, confirmed can reach `/status` on the specified port.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
