### PR TITLE
build: upgrade to go 1.20.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04 as builder
 
-ARG GO_VERSION="1.20.7"
+ARG GO_VERSION="1.20.14"
 
 ARG CHANNEL
 ARG URL

--- a/scripts/get_golang_version.sh
+++ b/scripts/get_golang_version.sh
@@ -11,7 +11,7 @@
 # Our build task-runner `mule` will refer to this script and will automatically
 # build a new image whenever the version number has been changed.
 
-BUILD=1.20.7
+BUILD=1.20.14
  MIN=1.20
  GO_MOD_SUPPORT=1.20
 


### PR DESCRIPTION
## Summary

This updates the builds to use the latest version of Go 1.20.

## Test Plan

No code changes, relying on existing tests.