### PR TITLE
Docker: Remove usage of `gosu` and replace with `su`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ FROM debian:bookworm-20230703-slim as final
 ENV PATH="/node/bin:${PATH}" ALGOD_PORT="8080" KMD_PORT="7833" ALGORAND_DATA="/algod/data"
 
 # curl is needed to lookup the fast catchup url
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl gosu && \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && \
     update-ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -17,7 +17,7 @@ fi
 # as the algorand user.
 if [ "$(id -u)" = '0' ]; then
   chown -R algorand:algorand $ALGORAND_DATA
-  exec gosu algorand "$0" "$@"
+  exec su -p -c "$(readlink -f $0) $@" algorand
 fi
 
 # Script to configure or resume a network. Based on environment settings the


### PR DESCRIPTION
## Summary

Replace usage of upstream `gosu` command in Docker containers. 

`su` is available in the environment, and using `su` should reduce security exposure vs using upstream (Ubuntu) managed `gosu` dependency.

At the time of writing security scanning tools such as grype/Snyk/Docker Scout are all finding issues in the `gosu` linked stdlib (from go1.19.8), which this will remediate.

## Test Plan

Changed were tested by:
1) Search across repo for `gosu` to identify usages
2) By 
- Executing into a docker container by using `docker run -it algorand/algod:latest bash`
- Update `/node/run/run.sh` to use `su` command
- Execute `/node/run/run.sh`

Permutations tested:
- Executing using a relative path
- File ownership in files copied to `ALGORAND_DATA` has been inspected (`algorand:algorand` owner expected)
- Environment variables passed correctly to restarted process. If variables are not passed correctly the initial check for ALGORAND_DATA will cause script to abort

Notes:
- Local build were not tested as unit tests fails on my M2 Mac as part of the `make` script.
- Build of `/Dockerfile` was not done as I'm uncertain about build target to use for creating the necessary files req. in the copy step. To workaround this issue current Docker image was pulled fror Docker Hub, and where `run.sh` changes were injected.