### PR TITLE
tests: dump logs at the end of exit callback

### DIFF
--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -120,8 +120,10 @@ func (f *LibGoalFixture) nodeExitWithError(nc *nodecontrol.NodeController, err e
 		return
 	}
 
-	f.t.Logf("Node at %s has terminated with an error: %v. Dumping logs...", nc.GetDataDir(), err)
-	f.dumpLogs(filepath.Join(nc.GetDataDir(), "node.log"))
+	defer func() {
+		f.t.Logf("Node at %s has terminated with an error: %v. Dumping logs...", nc.GetDataDir(), err)
+		f.dumpLogs(filepath.Join(nc.GetDataDir(), "node.log"))
+	}()
 
 	exitError, ok := err.(*exec.ExitError)
 	if !ok {


### PR DESCRIPTION
## Summary

There are some random TestCatchupOverGossip failures like [this](https://circleci.com/api/v1.1/project/github/algorand/go-algorand/267035/output/114/3?file=true&allocation-id=65eb44dd6e155f4592d8f6a1-3-build%2FABCDEFGH) , and the panic itself is caused by the fact controller's `StartAlgod` inner goroutine calls asserts after the test itself is terminated. For some reason we do not get any log output in case of panic and my current suggestion it is because of STDOUT buffering and panic just flushes STDERR with its own message.
This PR does not prevent the race itself but makes it much less probable by deferring logs dumping to after asserting.

A proper fix is somewhat complicated because the controller object copying/modifying, and `StartAlgod` is called on a different object than `StopAlgod`. I suggest to apply this fast fix to see if it help gathering required info, and implement the controller lifetime refactoring if needed.

## Test Plan

This is a test fix.