### PR TITLE
Network: Penalize peer/class rankings when peer does not have catchpoint

### DIFF
--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -824,6 +824,8 @@ func (cs *CatchpointCatchupService) checkLedgerDownload() error {
 		if err == nil {
 			return nil
 		}
+		// a non-nil error means that the catchpoint is not available, so we should rank it accordingly
+		cs.blocksDownloadPeerSelector.rankPeer(psp, peerRankNoCatchpointForRound)
 	}
 	return fmt.Errorf("checkLedgerDownload(): catchpoint '%s' unavailable from peers: %s", cs.stats.CatchpointLabel, err)
 }

--- a/catchup/peerSelector.go
+++ b/catchup/peerSelector.go
@@ -55,6 +55,10 @@ const (
 	// This indicates a peer is either behind or a block has not happened yet, or does not have a block that is old enough.
 	peerRankNoBlockForRound = 2000
 
+	// peerRankNoCatchpointForRound is used for responses failed because of no catchpoint for round
+	// This indicates a peer is either behind or a catchpoint has not been produced, or this node did not retain this catchpoint (aged out).
+	peerRankNoCatchpointForRound = 2000
+
 	// peerRankDownloadFailed is used for responses which could be temporary, such as missing files, or such that we don't
 	// have clear resolution
 	peerRankDownloadFailed = 10000


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Penalize peer/class rankings during catchpoint catchup initialization when they do not have a catchpoint. This is critical to ensure that the class based peer selector falls back to the next class of peers when too many peers in the first priority class do not have a catchpoint (in turn to prevent blocking the node from doing a fast catchup).

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Reproduced catchup against older catchpoints on Betanet getting failing locally, then working properly once the ranking was included. Existing automated tests should all pass.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
