### PR TITLE
catchpoint: fix data files deletion in hot/cold dirs scenario

### DIFF
--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -818,7 +818,6 @@ func (ct *catchpointTracker) createCatchpoint(ctx context.Context, accountsRound
 	}
 
 	relCatchpointFilePath := filepath.Join(trackerdb.CatchpointDirName, trackerdb.MakeCatchpointFilePath(round))
-
 	absCatchpointFilePath := filepath.Join(ct.dbDirectory, relCatchpointFilePath)
 
 	err = os.MkdirAll(filepath.Dir(absCatchpointFilePath), 0700)
@@ -929,7 +928,7 @@ func (ct *catchpointTracker) pruneFirstStageRecordsData(ctx context.Context, max
 	for _, round := range rounds {
 		relCatchpointDataFilePath :=
 			filepath.Join(trackerdb.CatchpointDirName, makeCatchpointDataFilePath(round))
-		err = trackerdb.RemoveSingleCatchpointFileFromDisk(ct.dbDirectory, relCatchpointDataFilePath)
+		err = trackerdb.RemoveSingleCatchpointFileFromDisk(ct.tmpDir, relCatchpointDataFilePath)
 		if err != nil {
 			return err
 		}

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -1213,20 +1213,12 @@ func TestCatchpointFirstStageInfoPruning(t *testing.T) {
 				if errors.Is(err, os.ErrNotExist) {
 					err := os.MkdirAll(path, 0777)
 					require.NoError(t, err)
-					cwd, err := os.Getwd()
-					require.NoError(t, err)
-					t.Logf("created directory %s/%s", cwd, path)
-					// defer os.RemoveAll(path)
 				}
 			}
 
-			// temporaryDirectory := t.TempDir()
 			dataFileDirectory := filepath.Join(test.hotPath, trackerdb.CatchpointDirName)
 			err := os.Mkdir(dataFileDirectory, 0777)
 			require.NoError(t, err)
-
-			// ct.dbDirectory = temporaryDirectory
-			// ct.tmpDir = temporaryDirectory
 
 			// create new protocol version, which has lower lookback
 			testProtocolVersion :=

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -1184,8 +1184,11 @@ func TestCalculateCatchpointRounds(t *testing.T) {
 	}
 }
 
-// Test that pruning first stage catchpoint database records and catchpoint data files
-// works.
+// TestCatchpointFirstStageInfoPruning checks pruning first stage catchpoint database records and catchpoint data files.
+// The test makes a catchpoint tracker and adds blocks into a mock ledger
+// until it reaches expected number of catchpoint. Then checks if database records match to data files existence.
+// Additional effect is that there are much more data files written during the process than catchpoints at the very end of the test
+// because of automatic pruning so check that most data files are removed confirms pruning works.
 func TestCatchpointFirstStageInfoPruning(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
@@ -1254,6 +1257,7 @@ func TestCatchpointFirstStageInfoPruning(t *testing.T) {
 			}
 
 			numCatchpointsCreated := uint64(0)
+			numDataFilesWritten := uint64(0)
 			i := basics.Round(0)
 			lastCatchpointLabel := ""
 
@@ -1279,6 +1283,7 @@ func TestCatchpointFirstStageInfoPruning(t *testing.T) {
 					for ct.isWritingCatchpointDataFile() {
 						time.Sleep(time.Millisecond)
 					}
+					numDataFilesWritten++
 				}
 
 				if isCatchpointRound(i) {
@@ -1309,6 +1314,7 @@ func TestCatchpointFirstStageInfoPruning(t *testing.T) {
 			}
 
 			require.Equal(t, expectedNumEntries, numEntries)
+			require.Greater(t, numDataFilesWritten, numEntries)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixed bug with data files deletion when catchpoint tracker configured with hot / cold directories.

## Test Plan

1. Extended `TestCatchpointFirstStageInfoPruning` to repro and fix
2. Checked all `MakeCatchpointFilePath` and `makeCatchpointDataFilePath` to ensure they are used with `ct.dbDirectory` and `ct.tmpDir` correspondingly.