### PR TITLE
refactor: remove ledgercore.OnlineAccountData

### DIFF
--- a/ledger/acctdeltas_test.go
+++ b/ledger/acctdeltas_test.go
@@ -2233,7 +2233,7 @@ func TestAccountOnlineQueries(t *testing.T) {
 				MicroAlgos: basics.MicroAlgos{Raw: 100_000_000},
 				Status:     basics.Online,
 			},
-			VotingData: ledgercore.VotingData{
+			VotingData: basics.VotingData{
 				VoteID: voteIDA,
 			},
 		}
@@ -2243,7 +2243,7 @@ func TestAccountOnlineQueries(t *testing.T) {
 				MicroAlgos: basics.MicroAlgos{Raw: 200_000_000},
 				Status:     basics.Online,
 			},
-			VotingData: ledgercore.VotingData{
+			VotingData: basics.VotingData{
 				VoteID: voteIDB,
 			},
 		}
@@ -2253,7 +2253,7 @@ func TestAccountOnlineQueries(t *testing.T) {
 				MicroAlgos: basics.MicroAlgos{Raw: 300_000_000},
 				Status:     basics.Online,
 			},
-			VotingData: ledgercore.VotingData{
+			VotingData: basics.VotingData{
 				VoteID: voteIDC,
 			},
 		}

--- a/ledger/acctonline.go
+++ b/ledger/acctonline.go
@@ -618,21 +618,7 @@ func (ao *onlineAccounts) onlineTotals(rnd basics.Round) (basics.MicroAlgos, pro
 
 // LookupOnlineAccountData returns the online account data for a given address at a given round.
 func (ao *onlineAccounts) LookupOnlineAccountData(rnd basics.Round, addr basics.Address) (data basics.OnlineAccountData, err error) {
-	oad, err := ao.lookupOnlineAccountData(rnd, addr)
-	if err != nil {
-		return
-	}
-
-	data.MicroAlgosWithRewards = oad.MicroAlgosWithRewards
-	data.VotingData.VoteID = oad.VotingData.VoteID
-	data.VotingData.SelectionID = oad.VotingData.SelectionID
-	data.VotingData.StateProofID = oad.VotingData.StateProofID
-	data.VotingData.VoteFirstValid = oad.VotingData.VoteFirstValid
-	data.VotingData.VoteLastValid = oad.VotingData.VoteLastValid
-	data.VotingData.VoteKeyDilution = oad.VotingData.VoteKeyDilution
-	data.IncentiveEligible = oad.IncentiveEligible
-
-	return
+	return ao.lookupOnlineAccountData(rnd, addr)
 }
 
 // roundOffset calculates the offset of the given round compared to the current dbRound. Requires that the lock would be taken.

--- a/ledger/acctonline_test.go
+++ b/ledger/acctonline_test.go
@@ -207,7 +207,7 @@ func TestAcctOnline(t *testing.T) {
 		var updates ledgercore.AccountDeltas
 		acctIdx := int(i) - 1
 
-		updates.Upsert(allAccts[acctIdx].Addr, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: ledgercore.VotingData{}})
+		updates.Upsert(allAccts[acctIdx].Addr, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: basics.VotingData{}})
 
 		base := genesisAccts[i-1]
 		newAccts := applyPartialDeltas(base, updates)
@@ -489,13 +489,13 @@ func TestAcctOnlineCache(t *testing.T) {
 
 				// put all accts online, then all offline, one each round
 				if (int(i)-1)%(numAccts*2) >= numAccts {
-					updates.Upsert(allAccts[acctIdx].Addr, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: ledgercore.VotingData{}})
+					updates.Upsert(allAccts[acctIdx].Addr, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: basics.VotingData{}})
 				} else {
 					updates.Upsert(allAccts[acctIdx].Addr, ledgercore.ToAccountData(allAccts[acctIdx].AccountData))
 				}
 
 				// set acctA online for each round
-				updates.Upsert(addrA, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online}, VotingData: ledgercore.VotingData{VoteLastValid: basics.Round(100 * i)}})
+				updates.Upsert(addrA, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online}, VotingData: basics.VotingData{VoteLastValid: basics.Round(100 * i)}})
 
 				base := genesisAccts[i-1]
 				newAccts := applyPartialDeltas(base, updates)
@@ -887,7 +887,7 @@ func TestAcctOnlineCacheDBSync(t *testing.T) {
 		require.NoError(t, err)
 
 		var updates ledgercore.AccountDeltas
-		updates.Upsert(addrA, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: ledgercore.VotingData{}})
+		updates.Upsert(addrA, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: basics.VotingData{}})
 
 		// copy genesisAccts for the test
 		accounts := copyGenesisAccts()
@@ -967,7 +967,7 @@ func TestAcctOnlineCacheDBSync(t *testing.T) {
 		require.NoError(t, err)
 
 		var updates ledgercore.AccountDeltas
-		updates.Upsert(addrA, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: ledgercore.VotingData{}})
+		updates.Upsert(addrA, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: basics.VotingData{}})
 
 		// copy genesisAccts for the test
 		accounts := copyGenesisAccts()
@@ -1016,8 +1016,8 @@ func TestAcctOnlineCacheDBSync(t *testing.T) {
 
 		addrB := ledgertesting.RandomAddress()
 		var updates ledgercore.AccountDeltas
-		updates.Upsert(addrA, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: ledgercore.VotingData{}})
-		updates.Upsert(addrB, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online}, VotingData: ledgercore.VotingData{VoteLastValid: 10000}})
+		updates.Upsert(addrA, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: basics.VotingData{}})
+		updates.Upsert(addrB, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online}, VotingData: basics.VotingData{VoteLastValid: 10000}})
 
 		// copy genesisAccts for the test
 		accounts := copyGenesisAccts()
@@ -1174,9 +1174,9 @@ func TestAcctOnlineBaseAccountCache(t *testing.T) {
 	accounts := genesisAccts
 
 	acctDatas := [3]ledgercore.AccountData{
-		{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online}, VotingData: ledgercore.VotingData{VoteLastValid: basics.Round(1000 + maxBalLookback)}},
-		{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: ledgercore.VotingData{}},
-		{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online}, VotingData: ledgercore.VotingData{VoteLastValid: basics.Round(1000 + maxBalLookback)}},
+		{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online}, VotingData: basics.VotingData{VoteLastValid: basics.Round(1000 + maxBalLookback)}},
+		{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: basics.VotingData{}},
+		{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online}, VotingData: basics.VotingData{VoteLastValid: basics.Round(1000 + maxBalLookback)}},
 	}
 	// set online, offline, online
 	for i := 1; i <= 3; i++ {
@@ -1276,7 +1276,7 @@ func TestAcctOnlineVotersLongerHistory(t *testing.T) {
 	maxBlocks := maxBalLookback * 5
 	for i := 1; i <= maxBlocks; i++ {
 		var updates ledgercore.AccountDeltas
-		updates.Upsert(addrA, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online}, VotingData: ledgercore.VotingData{VoteLastValid: basics.Round(100 * i)}})
+		updates.Upsert(addrA, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online}, VotingData: basics.VotingData{VoteLastValid: basics.Round(100 * i)}})
 		base := genesisAccts[i-1]
 		newAccts := applyPartialDeltas(base, updates)
 		totals = newBlock(t, ml, testProtocolVersion, protoParams, basics.Round(i), base, updates, totals)
@@ -1438,7 +1438,7 @@ func TestAcctOnlineTop(t *testing.T) {
 	var updates ledgercore.AccountDeltas
 	ac := allAccts[numAccts-3]
 	updates.Upsert(ac.Addr, ledgercore.AccountData{
-		AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline, MicroAlgos: ac.MicroAlgos}, VotingData: ledgercore.VotingData{}})
+		AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline, MicroAlgos: ac.MicroAlgos}, VotingData: basics.VotingData{}})
 	totals = newBlockWithUpdates(genesisAccts, updates, totals, t, ml, 1, oa)
 	accountToBeUpdated := ac
 	accountToBeUpdated.Status = basics.Offline
@@ -1452,7 +1452,7 @@ func TestAcctOnlineTop(t *testing.T) {
 	updates = ledgercore.AccountDeltas{}
 	updates.Upsert(allAccts[numAccts-2].Addr, ledgercore.AccountData{
 		AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online, MicroAlgos: allAccts[numAccts-2].MicroAlgos},
-		VotingData: ledgercore.VotingData{
+		VotingData: basics.VotingData{
 			VoteFirstValid: 0,
 			VoteLastValid:  1,
 		}})
@@ -1471,7 +1471,7 @@ func TestAcctOnlineTop(t *testing.T) {
 	// mark an account with high stake as online - it should be pushed to the top of the list
 	updates.Upsert(allAccts[numAccts-1].Addr, ledgercore.AccountData{
 		AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online, MicroAlgos: allAccts[numAccts-1].MicroAlgos},
-		VotingData:      ledgercore.VotingData{VoteLastValid: basics.Round(1000)}})
+		VotingData:      basics.VotingData{VoteLastValid: basics.Round(1000)}})
 	totals = newBlockWithUpdates(genesisAccts, updates, totals, t, ml, 3, oa)
 	accountToBeUpdated = allAccts[numAccts-1]
 	accountToBeUpdated.Status = basics.Online
@@ -1549,7 +1549,7 @@ func TestAcctOnlineTopInBatches(t *testing.T) {
 				if i == 300 {
 					updates.Upsert(acct299.Addr, ledgercore.AccountData{
 						AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline, MicroAlgos: acct299.MicroAlgos},
-						VotingData:      ledgercore.VotingData{},
+						VotingData:      basics.VotingData{},
 					})
 				}
 				newBlockWithUpdates(genesisAccts, updates, totals, t, ml, i, oa)
@@ -1626,7 +1626,7 @@ func TestAcctOnlineTopBetweenCommitAndPostCommit(t *testing.T) {
 	for ; i < 10; i++ {
 		var updates ledgercore.AccountDeltas
 		updates.Upsert(allAccts[numAccts-1].Addr, ledgercore.AccountData{
-			AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: ledgercore.VotingData{}})
+			AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: basics.VotingData{}})
 		newBlockWithUpdates(genesisAccts, updates, totals, t, ml, i, oa)
 	}
 
@@ -1635,7 +1635,7 @@ func TestAcctOnlineTopBetweenCommitAndPostCommit(t *testing.T) {
 	updateAccountsRoutine := func() {
 		var updates ledgercore.AccountDeltas
 		updates.Upsert(allAccts[numAccts-1].Addr, ledgercore.AccountData{
-			AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: ledgercore.VotingData{}})
+			AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: basics.VotingData{}})
 		newBlockWithUpdates(genesisAccts, updates, totals, t, ml, i, oa)
 	}
 
@@ -1717,7 +1717,7 @@ func TestAcctOnlineTopDBBehindMemRound(t *testing.T) {
 	for ; i < 10; i++ {
 		var updates ledgercore.AccountDeltas
 		updates.Upsert(allAccts[numAccts-1].Addr, ledgercore.AccountData{
-			AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: ledgercore.VotingData{}})
+			AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: basics.VotingData{}})
 		newBlockWithUpdates(genesisAccts, updates, totals, t, ml, i, oa)
 	}
 
@@ -1726,7 +1726,7 @@ func TestAcctOnlineTopDBBehindMemRound(t *testing.T) {
 	updateAccountsRoutine := func() {
 		var updates ledgercore.AccountDeltas
 		updates.Upsert(allAccts[numAccts-1].Addr, ledgercore.AccountData{
-			AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: ledgercore.VotingData{}})
+			AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline}, VotingData: basics.VotingData{}})
 		newBlockWithUpdates(genesisAccts, updates, totals, t, ml, i, oa)
 	}
 
@@ -1807,10 +1807,10 @@ func TestAcctOnlineTop_ChangeOnlineStake(t *testing.T) {
 		var updates ledgercore.AccountDeltas
 		if i == 15 { // round 15 should be in deltas (memory)
 			// turn account `i` offline
-			updates.Upsert(allAccts[i].Addr, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline, MicroAlgos: allAccts[i].MicroAlgos}, VotingData: ledgercore.VotingData{}})
+			updates.Upsert(allAccts[i].Addr, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline, MicroAlgos: allAccts[i].MicroAlgos}, VotingData: basics.VotingData{}})
 		}
 		if i == 18 {
-			updates.Upsert(allAccts[i].Addr, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online, MicroAlgos: allAccts[i].MicroAlgos}, VotingData: ledgercore.VotingData{VoteLastValid: basics.Round(18)}})
+			updates.Upsert(allAccts[i].Addr, ledgercore.AccountData{AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online, MicroAlgos: allAccts[i].MicroAlgos}, VotingData: basics.VotingData{VoteLastValid: basics.Round(18)}})
 		} // else: insert empty block
 		totals = newBlockWithUpdates(genesisAccts, updates, totals, t, ml, i, oa)
 	}
@@ -1969,19 +1969,19 @@ func TestAcctOnline_ExpiredOnlineCirculation(t *testing.T) {
 	addrA := allAccts[0].Addr
 	stakeA := allAccts[0].MicroAlgos
 	statesA := map[acctState]ledgercore.AccountData{
-		acctStateOffline: {AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline, MicroAlgos: stakeA}, VotingData: ledgercore.VotingData{}},
-		acctStateOnline:  {AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online, MicroAlgos: stakeA}, VotingData: ledgercore.VotingData(allAccts[0].OnlineAccountData().VotingData)},
+		acctStateOffline: {AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline, MicroAlgos: stakeA}, VotingData: basics.VotingData{}},
+		acctStateOnline:  {AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online, MicroAlgos: stakeA}, VotingData: basics.VotingData(allAccts[0].OnlineAccountData().VotingData)},
 	}
 
 	addrB := allAccts[1].Addr
 	stakeB := allAccts[1].MicroAlgos
 	votingDataB := allAccts[1].OnlineAccountData().VotingData
 	statesB := map[acctState]ledgercore.AccountData{
-		acctStateOffline: {AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline, MicroAlgos: stakeB}, VotingData: ledgercore.VotingData{}},
-		acctStateOnline:  {AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online, MicroAlgos: stakeB}, VotingData: ledgercore.VotingData(votingDataB)},
+		acctStateOffline: {AccountBaseData: ledgercore.AccountBaseData{Status: basics.Offline, MicroAlgos: stakeB}, VotingData: basics.VotingData{}},
+		acctStateOnline:  {AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online, MicroAlgos: stakeB}, VotingData: basics.VotingData(votingDataB)},
 	}
 	expStatesB := func(state acctState, voteRnd basics.Round) ledgercore.AccountData {
-		vd := ledgercore.VotingData(votingDataB)
+		vd := basics.VotingData(votingDataB)
 		switch state {
 		case acctStateExpired:
 			vd.VoteLastValid = voteRnd - 1
@@ -2100,7 +2100,7 @@ func TestAcctOnline_ExpiredOnlineCirculation(t *testing.T) {
 			commitSync(t, oa, ml, basics.Round(rnd-1))
 			a.Equal(int(conf.MaxAcctLookback), len(oa.deltas)) // ensure the only expected deltas are not flushed
 
-			var expiredAccts map[basics.Address]*ledgercore.OnlineAccountData
+			var expiredAccts map[basics.Address]*basics.OnlineAccountData
 			err = ml.trackers.dbs.Snapshot(func(ctx context.Context, tx trackerdb.SnapshotScope) error {
 				reader, err := tx.MakeAccountsReader()
 				if err != nil {
@@ -2158,7 +2158,7 @@ func TestAcctOnline_ExpiredOnlineCirculation(t *testing.T) {
 			base := accounts[rnd-1]
 			updates.Upsert(addrA, statesA[acctStateOnline])
 			updates.Upsert(addrB, ledgercore.AccountData{
-				AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online, MicroAlgos: stakeB}, VotingData: ledgercore.VotingData(votingDataB),
+				AccountBaseData: ledgercore.AccountBaseData{Status: basics.Online, MicroAlgos: stakeB}, VotingData: basics.VotingData(votingDataB),
 			})
 			accounts = append(accounts, applyPartialDeltas(base, updates))
 			totals = newBlock(t, ml, proto, params, rnd, base, updates, totals)

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -429,7 +429,7 @@ func checkAcctUpdates(t *testing.T, au *accountUpdates, ao *onlineAccounts, base
 			require.Equal(t, d, ledgercore.AccountData{})
 			od, err := ao.lookupOnlineAccountData(rnd, ledgertesting.RandomAddress())
 			require.NoError(t, err)
-			require.Equal(t, od, ledgercore.OnlineAccountData{})
+			require.Equal(t, od, basics.OnlineAccountData{})
 		}
 	}
 	checkAcctUpdatesConsistency(t, au, latestRnd)

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -621,11 +621,7 @@ func (l *Ledger) LookupAgreement(rnd basics.Round, addr basics.Address) (basics.
 
 	// Intentionally apply (pending) rewards up to rnd.
 	data, err := l.acctsOnline.LookupOnlineAccountData(rnd, addr)
-	if err != nil {
-		return basics.OnlineAccountData{}, err
-	}
-
-	return data, nil
+	return data, err
 }
 
 // LookupWithoutRewards is like Lookup but does not apply pending rewards up

--- a/ledger/ledgercore/accountdata.go
+++ b/ledger/ledgercore/accountdata.go
@@ -185,15 +185,8 @@ func (u AccountData) OnlineAccountData(proto config.ConsensusParams, rewardsLeve
 	)
 	return basics.OnlineAccountData{
 		MicroAlgosWithRewards: microAlgos,
-		VotingData: basics.VotingData{
-			VoteID:          u.VoteID,
-			SelectionID:     u.SelectionID,
-			StateProofID:    u.StateProofID,
-			VoteFirstValid:  u.VoteFirstValid,
-			VoteLastValid:   u.VoteLastValid,
-			VoteKeyDilution: u.VoteKeyDilution,
-		},
-		IncentiveEligible: u.IncentiveEligible,
+		VotingData:            u.VotingData,
+		IncentiveEligible:     u.IncentiveEligible,
 	}
 }
 

--- a/ledger/ledgercore/accountdata.go
+++ b/ledger/ledgercore/accountdata.go
@@ -18,8 +18,6 @@ package ledgercore
 
 import (
 	"github.com/algorand/go-algorand/config"
-	"github.com/algorand/go-algorand/crypto"
-	"github.com/algorand/go-algorand/crypto/merklesignature"
 	"github.com/algorand/go-algorand/data/basics"
 )
 
@@ -29,7 +27,7 @@ import (
 // separately, to better support on-disk and in-memory schemas that do not store them together.
 type AccountData struct {
 	AccountBaseData
-	VotingData
+	basics.VotingData
 }
 
 // AccountBaseData contains base account info like balance, status and total number of resources
@@ -52,24 +50,6 @@ type AccountBaseData struct {
 
 	LastProposed  basics.Round // The last round that this account proposed the winning block.
 	LastHeartbeat basics.Round // The last round that this account sent a heartbeat to show it was online.
-}
-
-// VotingData holds participation information
-type VotingData struct {
-	VoteID       crypto.OneTimeSignatureVerifier
-	SelectionID  crypto.VRFVerifier
-	StateProofID merklesignature.Commitment
-
-	VoteFirstValid  basics.Round
-	VoteLastValid   basics.Round
-	VoteKeyDilution uint64
-}
-
-// OnlineAccountData holds MicroAlgosWithRewards and VotingData as needed for agreement
-type OnlineAccountData struct {
-	MicroAlgosWithRewards basics.MicroAlgos
-	VotingData
-	IncentiveEligible bool
 }
 
 // ToAccountData returns ledgercore.AccountData from basics.AccountData
@@ -95,7 +75,7 @@ func ToAccountData(acct basics.AccountData) AccountData {
 			LastProposed:  acct.LastProposed,
 			LastHeartbeat: acct.LastHeartbeat,
 		},
-		VotingData: VotingData{
+		VotingData: basics.VotingData{
 			VoteID:          acct.VoteID,
 			SelectionID:     acct.SelectionID,
 			StateProofID:    acct.StateProofID,
@@ -143,7 +123,7 @@ func (u AccountData) WithUpdatedRewards(proto config.ConsensusParams, rewardsLev
 // ClearOnlineState resets the account's fields to indicate that the account is an offline account
 func (u *AccountData) ClearOnlineState() {
 	u.Status = basics.Offline
-	u.VotingData = VotingData{}
+	u.VotingData = basics.VotingData{}
 }
 
 // Suspend sets the status to Offline, but does _not_ clear voting keys, so
@@ -194,18 +174,18 @@ func (u AccountData) Money(proto config.ConsensusParams, rewardsLevel uint64) (m
 }
 
 // OnlineAccountData calculates the online account data given an AccountData, by adding the rewards.
-func (u AccountData) OnlineAccountData(proto config.ConsensusParams, rewardsLevel uint64) OnlineAccountData {
+func (u AccountData) OnlineAccountData(proto config.ConsensusParams, rewardsLevel uint64) basics.OnlineAccountData {
 	if u.Status != basics.Online {
 		// if the account is not Online and agreement requests it for some reason, clear it out
-		return OnlineAccountData{}
+		return basics.OnlineAccountData{}
 	}
 
 	microAlgos, _, _ := basics.WithUpdatedRewards(
 		proto, u.Status, u.MicroAlgos, u.RewardedMicroAlgos, u.RewardsBase, rewardsLevel,
 	)
-	return OnlineAccountData{
+	return basics.OnlineAccountData{
 		MicroAlgosWithRewards: microAlgos,
-		VotingData: VotingData{
+		VotingData: basics.VotingData{
 			VoteID:          u.VoteID,
 			SelectionID:     u.SelectionID,
 			StateProofID:    u.StateProofID,

--- a/ledger/store/trackerdb/data.go
+++ b/ledger/store/trackerdb/data.go
@@ -362,8 +362,8 @@ func (ba *BaseAccountData) GetLedgerCoreAccountBaseData() ledgercore.AccountBase
 }
 
 // GetLedgerCoreVotingData getter for voting data.
-func (ba *BaseAccountData) GetLedgerCoreVotingData() ledgercore.VotingData {
-	return ledgercore.VotingData{
+func (ba *BaseAccountData) GetLedgerCoreVotingData() basics.VotingData {
+	return basics.VotingData{
 		VoteID:          ba.VoteID,
 		SelectionID:     ba.SelectionID,
 		StateProofID:    ba.StateProofID,
@@ -467,14 +467,14 @@ func (bo *BaseOnlineAccountData) GetOnlineAccount(addr basics.Address, normBalan
 
 // GetOnlineAccountData returns basics.OnlineAccountData for lookup agreement
 // TODO: unify with GetOnlineAccount/ledgercore.OnlineAccount
-func (bo *BaseOnlineAccountData) GetOnlineAccountData(proto config.ConsensusParams, rewardsLevel uint64) ledgercore.OnlineAccountData {
+func (bo *BaseOnlineAccountData) GetOnlineAccountData(proto config.ConsensusParams, rewardsLevel uint64) basics.OnlineAccountData {
 	microAlgos, _, _ := basics.WithUpdatedRewards(
 		proto, basics.Online, bo.MicroAlgos, basics.MicroAlgos{}, bo.RewardsBase, rewardsLevel,
 	)
 
-	return ledgercore.OnlineAccountData{
+	return basics.OnlineAccountData{
 		MicroAlgosWithRewards: microAlgos,
-		VotingData: ledgercore.VotingData{
+		VotingData: basics.VotingData{
 			VoteID:          bo.VoteID,
 			SelectionID:     bo.SelectionID,
 			StateProofID:    bo.StateProofID,

--- a/ledger/store/trackerdb/dualdriver/accounts_reader_ext.go
+++ b/ledger/store/trackerdb/dualdriver/accounts_reader_ext.go
@@ -284,7 +284,7 @@ func (ar *accountsReaderExt) OnlineAccountsAll(maxAccounts uint64) (accounts []t
 }
 
 // ExpiredOnlineAccountsForRound implements trackerdb.AccountsReaderExt
-func (ar *accountsReaderExt) ExpiredOnlineAccountsForRound(rnd basics.Round, voteRnd basics.Round, proto config.ConsensusParams, rewardsLevel uint64) (expAccounts map[basics.Address]*ledgercore.OnlineAccountData, err error) {
+func (ar *accountsReaderExt) ExpiredOnlineAccountsForRound(rnd basics.Round, voteRnd basics.Round, proto config.ConsensusParams, rewardsLevel uint64) (expAccounts map[basics.Address]*basics.OnlineAccountData, err error) {
 	expAccountsP, errP := ar.primary.ExpiredOnlineAccountsForRound(rnd, voteRnd, proto, rewardsLevel)
 	expAccountsS, errS := ar.secondary.ExpiredOnlineAccountsForRound(rnd, voteRnd, proto, rewardsLevel)
 	// coalesce errors

--- a/ledger/store/trackerdb/generickv/accounts_ext_reader.go
+++ b/ledger/store/trackerdb/generickv/accounts_ext_reader.go
@@ -353,7 +353,7 @@ func (r *accountsReader) OnlineAccountsAll(maxAccounts uint64) ([]trackerdb.Pers
 }
 
 // ExpiredOnlineAccountsForRound implements trackerdb.AccountsReaderExt
-func (r *accountsReader) ExpiredOnlineAccountsForRound(rnd basics.Round, voteRnd basics.Round, proto config.ConsensusParams, rewardsLevel uint64) (data map[basics.Address]*ledgercore.OnlineAccountData, err error) {
+func (r *accountsReader) ExpiredOnlineAccountsForRound(rnd basics.Round, voteRnd basics.Round, proto config.ConsensusParams, rewardsLevel uint64) (data map[basics.Address]*basics.OnlineAccountData, err error) {
 	// The SQL at the time of writing:
 	//
 	// SELECT address, data, max(updround)
@@ -364,7 +364,7 @@ func (r *accountsReader) ExpiredOnlineAccountsForRound(rnd basics.Round, voteRnd
 	// ORDER BY address
 
 	// initialize return map
-	data = make(map[basics.Address]*ledgercore.OnlineAccountData)
+	data = make(map[basics.Address]*basics.OnlineAccountData)
 	expired := make(map[basics.Address]struct{})
 
 	// prepare iter over online accounts (by balance)

--- a/ledger/store/trackerdb/interface.go
+++ b/ledger/store/trackerdb/interface.go
@@ -129,7 +129,7 @@ type AccountsReaderExt interface {
 	LookupOnlineAccountDataByAddress(addr basics.Address) (ref OnlineAccountRef, data []byte, err error)
 	AccountsOnlineTop(rnd basics.Round, offset uint64, n uint64, proto config.ConsensusParams) (map[basics.Address]*ledgercore.OnlineAccount, error)
 	AccountsOnlineRoundParams() (onlineRoundParamsData []ledgercore.OnlineRoundParamsData, endRound basics.Round, err error)
-	ExpiredOnlineAccountsForRound(rnd, voteRnd basics.Round, proto config.ConsensusParams, rewardsLevel uint64) (map[basics.Address]*ledgercore.OnlineAccountData, error)
+	ExpiredOnlineAccountsForRound(rnd, voteRnd basics.Round, proto config.ConsensusParams, rewardsLevel uint64) (map[basics.Address]*basics.OnlineAccountData, error)
 	OnlineAccountsAll(maxAccounts uint64) ([]PersistedOnlineAccountData, error)
 	LoadTxTail(ctx context.Context, dbRound basics.Round) (roundData []*TxTailRound, roundHash []crypto.Digest, baseRound basics.Round, err error)
 	LoadAllFullAccounts(ctx context.Context, balancesTable string, resourcesTable string, acctCb func(basics.Address, basics.AccountData)) (count int, err error)

--- a/ledger/store/trackerdb/sqlitedriver/accountsV2.go
+++ b/ledger/store/trackerdb/sqlitedriver/accountsV2.go
@@ -303,7 +303,7 @@ func (r *accountsV2Reader) OnlineAccountsAll(maxAccounts uint64) ([]trackerdb.Pe
 }
 
 // ExpiredOnlineAccountsForRound returns all online accounts known at `rnd` that will be expired by `voteRnd`.
-func (r *accountsV2Reader) ExpiredOnlineAccountsForRound(rnd, voteRnd basics.Round, proto config.ConsensusParams, rewardsLevel uint64) (map[basics.Address]*ledgercore.OnlineAccountData, error) {
+func (r *accountsV2Reader) ExpiredOnlineAccountsForRound(rnd, voteRnd basics.Round, proto config.ConsensusParams, rewardsLevel uint64) (map[basics.Address]*basics.OnlineAccountData, error) {
 	// This relies on SQLite's handling of max(updround) and bare columns not in the GROUP BY.
 	// The values of votelastvalid, votefirstvalid, and data will all be from the same row as max(updround)
 	rows, err := r.q.Query(`SELECT address, data, max(updround)
@@ -317,7 +317,7 @@ ORDER BY address`, rnd, voteRnd)
 	}
 	defer rows.Close()
 
-	ret := make(map[basics.Address]*ledgercore.OnlineAccountData)
+	ret := make(map[basics.Address]*basics.OnlineAccountData)
 	for rows.Next() {
 		var addrbuf []byte
 		var buf []byte


### PR DESCRIPTION
## Summary

Use `basics.OnlineAccountData` instead since they are exact duplicates.

## Test Plan

Existing tests.

## Notes
Merge after https://github.com/algorand/go-algorand/pull/5757 due to conflicts 