### PR TITLE
tests: move TestCheckSpender to transactions package

### DIFF
--- a/data/transactions/payment.go
+++ b/data/transactions/payment.go
@@ -37,8 +37,8 @@ type PaymentTxnFields struct {
 	CloseRemainderTo basics.Address `codec:"close"`
 }
 
-// CheckSpender performs some stateless checks on the Sender of a pay transaction
-func (payment PaymentTxnFields) CheckSpender(header Header, spec SpecialAddresses, proto config.ConsensusParams) error {
+// checkSpender performs some stateless checks on the Sender of a pay transaction
+func (payment PaymentTxnFields) checkSpender(header Header, spec SpecialAddresses, proto config.ConsensusParams) error {
 	if header.Sender == payment.CloseRemainderTo {
 		return fmt.Errorf("transaction cannot close account to its sender %v", header.Sender)
 	}

--- a/data/transactions/payment_test.go
+++ b/data/transactions/payment_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/protocol"
@@ -67,4 +68,67 @@ func TestAlgosEncoding(t *testing.T) {
 	if err == nil {
 		panic("decode of bool into MicroAlgos succeeded")
 	}
+}
+
+func TestCheckSpender(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	v7 := config.Consensus[protocol.ConsensusV7]
+	v39 := config.Consensus[protocol.ConsensusV39]
+	vFuture := config.Consensus[protocol.ConsensusFuture]
+
+	secretSrc := keypair()
+	src := basics.Address(secretSrc.SignatureVerifier)
+
+	secretDst := keypair()
+	dst := basics.Address(secretDst.SignatureVerifier)
+
+	tx := Transaction{
+		Type: protocol.PaymentTx,
+		Header: Header{
+			Sender:     src,
+			Fee:        basics.MicroAlgos{Raw: 1},
+			FirstValid: basics.Round(100),
+			LastValid:  basics.Round(1000),
+		},
+		PaymentTxnFields: PaymentTxnFields{
+			Receiver: dst,
+			Amount:   basics.MicroAlgos{Raw: uint64(50)},
+		},
+	}
+
+	feeSink := basics.Address{0x01}
+	poolAddr := basics.Address{0x02}
+	var spec = SpecialAddresses{
+		FeeSink:     feeSink,
+		RewardsPool: poolAddr,
+	}
+
+	tx.Sender = feeSink
+	require.ErrorContains(t, tx.PaymentTxnFields.checkSpender(tx.Header, spec, v7),
+		"to non incentive pool address")
+	require.ErrorContains(t, tx.PaymentTxnFields.checkSpender(tx.Header, spec, v39),
+		"to non incentive pool address")
+	require.ErrorContains(t, tx.PaymentTxnFields.checkSpender(tx.Header, spec, vFuture),
+		"cannot spend from fee sink")
+
+	tx.Receiver = poolAddr
+	require.NoError(t, tx.PaymentTxnFields.checkSpender(tx.Header, spec, v7))
+	require.NoError(t, tx.PaymentTxnFields.checkSpender(tx.Header, spec, v39))
+	require.ErrorContains(t, tx.PaymentTxnFields.checkSpender(tx.Header, spec, vFuture),
+		"cannot spend from fee sink")
+
+	tx.CloseRemainderTo = poolAddr
+	require.ErrorContains(t, tx.PaymentTxnFields.checkSpender(tx.Header, spec, v7),
+		"cannot close fee sink")
+	require.ErrorContains(t, tx.PaymentTxnFields.checkSpender(tx.Header, spec, v39),
+		"cannot close fee sink")
+	require.ErrorContains(t, tx.PaymentTxnFields.checkSpender(tx.Header, spec, vFuture),
+		"cannot spend from fee sink")
+
+	// When not sending from fee sink, everything's fine
+	tx.Sender = src
+	require.NoError(t, tx.PaymentTxnFields.checkSpender(tx.Header, spec, v7))
+	require.NoError(t, tx.PaymentTxnFields.checkSpender(tx.Header, spec, v39))
+	require.NoError(t, tx.PaymentTxnFields.checkSpender(tx.Header, spec, vFuture))
 }

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -352,7 +352,7 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 	switch tx.Type {
 	case protocol.PaymentTx:
 		// in case that the fee sink is spending, check that this spend is to a valid address
-		err := tx.CheckSpender(tx.Header, spec, proto)
+		err := tx.checkSpender(tx.Header, spec, proto)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

While discussing https://github.com/algorand/go-algorand/pull/5757 we found there is a duplicate `checkSpender` in `ledger/apply` and `data/transactions`. The duplicate was fixed in #5757 and this PR moved `TestCheckSpender` to `data/transactions` to where `checkSpender` is defined.

## Test Plan

Existing tests.
