### PR TITLE
build: support SWAGGER_CONVERTER_API override

### DIFF
--- a/.github/workflows/codegen_verification.yml
+++ b/.github/workflows/codegen_verification.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   codegen_verification:
     runs-on: ubuntu-20.04
+    services:
+      converter:
+        image: swaggerapi/swagger-converter:v1.0.4
+        ports:
+          - 8080:8080
     steps:
       - name: Check out code
         uses: actions/checkout@v3.5.3
@@ -16,6 +21,8 @@ jobs:
       - name: Uninstall existing go installation
         run: sudo apt-get -y -q purge golang-go
       - name: Run codegen_verification.sh
+        env:
+          SWAGGER_CONVERTER_API: "http://localhost:8080"
         run: |
           export GOPATH="${GITHUB_WORKSPACE}/go"
           cd go-algorand

--- a/.github/workflows/codegen_verification.yml
+++ b/.github/workflows/codegen_verification.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     services:
       converter:
-        image: swaggerapi/swagger-converter:v1.0.4
+        image: swaggerapi/swagger-converter@sha256:dcfd1c2537f5f271cb4ec942d08aa59ca41b9a24078040061a772afca7e548ae # v1.0.4
         ports:
           - 8080:8080
     steps:

--- a/daemon/algod/api/Makefile
+++ b/daemon/algod/api/Makefile
@@ -1,6 +1,9 @@
 GOPATH	:= $(shell go env GOPATH)
 GOPATH1	:= $(firstword $(subst :, ,$(GOPATH)))
 
+# Allow overriding swagger-converter API, e.g. for use with local container
+SWAGGER_CONVERTER_API ?= https://converter.swagger.io
+
 # `make all` or just `make` should be appropriate for dev work
 all:	server/v2/generated/model/types.go server/v2/generated/nonparticipating/public/routes.go server/v2/generated/nonparticipating/private/routes.go server/v2/generated/participating/public/routes.go server/v2/generated/participating/private/routes.go server/v2/generated/data/routes.go server/v2/generated/experimental/routes.go
 
@@ -30,7 +33,7 @@ server/v2/generated/model/types.go:	algod.oas3.yml
 	$(GOPATH1)/bin/oapi-codegen -config ./server/v2/generated/model/model_types.yml algod.oas3.yml
 
 algod.oas3.yml:	algod.oas2.json
-	curl -s -X POST "https://converter.swagger.io/api/convert" -H "accept: application/json" -H "Content-Type: application/json" -d @./algod.oas2.json -o .3tmp.json
+	curl -s -X POST "$(SWAGGER_CONVERTER_API)/api/convert" -H "accept: application/json" -H "Content-Type: application/json" -d @./algod.oas2.json -o .3tmp.json
 	python3 jsoncanon.py < .3tmp.json > algod.oas3.yml
 	rm -f .3tmp.json
 

--- a/daemon/algod/api/README.md
+++ b/daemon/algod/api/README.md
@@ -49,4 +49,9 @@ Specifically, `uint64` types aren't strictly supported by OpenAPI. So we added a
 
 ## Why do we have algod.oas2.json and algod.oas3.yml?
 
-We chose to maintain V2 and V3 versions of the spec because OpenAPI v3 doesn't seem to be widely supported. Some tools worked better with V3 and others with V2, so having both available has been useful. To reduce developer burdon, the v2 specfile is automatically converted v3 using [converter.swagger.io](http://converter.swagger.io/).
+We chose to maintain V2 and V3 versions of the spec because OpenAPI v3 doesn't seem to be widely supported. Some tools worked better with V3 and others with V2, so having both available has been useful. To reduce developer burden, the v2 specfile is automatically converted v3 using [converter.swagger.io](http://converter.swagger.io/).
+
+If you want to run the converter locally, you can build the [swagger-converter](https://github.com/swagger-api/swagger-converter) project or run its [docker image](https://hub.docker.com/r/swaggerapi/swagger-converter) and specify the `SWAGGER_CONVERTER_API` environment variable when using this Makefile, for example by running:
+```
+SWAGGER_CONVERTER_API=http://localhost:8080 make
+```


### PR DESCRIPTION
## Summary

This updates the Makefile in daemon/algod/api to support setting a different SWAGGER_CONVERTER_API, and starts up a Github workflow service container for `swaggerapi/swagger-converter` when running the codegen_verification job.

## Test Plan

Check codegen_verification Github job to make sure it works.