### PR TITLE
Scripts: update buildnumber to use timezone-aware datetime

### DIFF
--- a/scripts/buildnumber.py
+++ b/scripts/buildnumber.py
@@ -7,9 +7,9 @@
 # e.g. if NOW is 5/28/2018 5:30am
 #   => 305
 
-from datetime import datetime
+from datetime import datetime, timezone
 
-epoch = datetime(2018, 5, 25, 0, 0, 0)
-d1 = datetime.utcnow()
+epoch = datetime(2018, 5, 25, 0, 0, 0, tzinfo=timezone.utc)
+d1 = datetime.now(timezone.utc)
 delta = d1 - epoch
 print("%d%02d" % (delta.days, d1.hour))


### PR DESCRIPTION
## Summary

Running `make` will get this deprecation warning for newer versions of python:

```
./scripts/buildnumber.py:13: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  d1 = datetime.utcnow()
```

This is because utcnow is timezone-aware, and the earlier datetime call is naive. To make this consistent, we just mark all to UTC, to make consistent with the comment for setting the epoch.

## Test Plan

Verified that `./scripts/buildnumber.py` returned output without deprecation warnings.

Verified on 3.12.2 and 3.8.10 (version shipped with Ubuntu 20.04).

