### PR TITLE
p2p: refactor gossipsub to validation and handling

### DIFF
--- a/components/mocks/mockNetwork.go
+++ b/components/mocks/mockNetwork.go
@@ -91,9 +91,11 @@ func (network *MockNetwork) RegisterHandlers(dispatch []network.TaggedMessageHan
 func (network *MockNetwork) ClearHandlers() {
 }
 
+// RegisterProcessors - empty implementation.
 func (network *MockNetwork) RegisterProcessors(dispatch []network.TaggedMessageProcessor) {
 }
 
+// ClearProcessors - empty implementation
 func (network *MockNetwork) ClearProcessors() {
 }
 

--- a/components/mocks/mockNetwork.go
+++ b/components/mocks/mockNetwork.go
@@ -91,6 +91,12 @@ func (network *MockNetwork) RegisterHandlers(dispatch []network.TaggedMessageHan
 func (network *MockNetwork) ClearHandlers() {
 }
 
+func (network *MockNetwork) RegisterProcessors(dispatch []network.TaggedMessageProcessor) {
+}
+
+func (network *MockNetwork) ClearProcessors() {
+}
+
 // RegisterHTTPHandler - empty implementation
 func (network *MockNetwork) RegisterHTTPHandler(path string, handler http.Handler) {
 }

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -530,7 +530,7 @@ func (handler *TxHandler) deleteFromCaches(msgKey *crypto.Digest, canonicalKey *
 
 // dedupCanonical checks if the transaction group has been seen before after reencoding to canonical representation.
 // returns a key used for insertion if the group was not found.
-func (handler *TxHandler) dedupCanonical(ntx int, unverifiedTxGroup []transactions.SignedTxn, consumed int) (key *crypto.Digest, isDup bool) {
+func (handler *TxHandler) dedupCanonical(unverifiedTxGroup []transactions.SignedTxn, consumed int) (key *crypto.Digest, isDup bool) {
 	// consider situations where someone want to censor transactions A
 	// 1. Txn A is not part of a group => txn A with a valid signature is OK
 	// Censorship attempts are:
@@ -547,6 +547,7 @@ func (handler *TxHandler) dedupCanonical(ntx int, unverifiedTxGroup []transactio
 	// - using individual txn from a group: {A, Z} could be poisoned by {A, B}, where B is invalid
 
 	var d crypto.Digest
+	ntx := len(unverifiedTxGroup)
 	if ntx == 1 {
 		// a single transaction => cache/dedup canonical txn with its signature
 		enc := unverifiedTxGroup[0].MarshalMsg(nil)
@@ -574,49 +575,46 @@ func (handler *TxHandler) dedupCanonical(ntx int, unverifiedTxGroup []transactio
 	return &d, false
 }
 
-// processIncomingTxn decodes a transaction group from incoming message and enqueues into the back log for processing.
-// The function also performs some input data pre-validation;
-//  - txn groups are cut to MaxTxGroupSize size
-//  - message are checked for duplicates
-//  - transactions are checked for duplicates
-
-func (handler *TxHandler) processIncomingTxn(rawmsg network.IncomingMessage) network.OutgoingMessage {
+func (handler *TxHandler) incomingMsgDupErlCheck(data []byte, sender network.DisconnectablePeer) (*crypto.Digest, *util.ErlCapacityGuard, bool) {
 	var msgKey *crypto.Digest
+	var capguard *util.ErlCapacityGuard
 	var isDup bool
 	if handler.msgCache != nil {
 		// check for duplicate messages
 		// this helps against relaying duplicates
-		if msgKey, isDup = handler.msgCache.CheckAndPut(rawmsg.Data); isDup {
+		if msgKey, isDup = handler.msgCache.CheckAndPut(data); isDup {
 			transactionMessagesDupRawMsg.Inc(nil)
-			return network.OutgoingMessage{Action: network.Ignore}
+			return msgKey, capguard, true
 		}
 	}
 
-	unverifiedTxGroup := make([]transactions.SignedTxn, 1)
-	dec := protocol.NewMsgpDecoderBytes(rawmsg.Data)
-	ntx := 0
-	consumed := 0
-
 	var err error
-	var capguard *util.ErlCapacityGuard
 	if handler.erl != nil {
 		congestedERL := float64(cap(handler.backlogQueue))*handler.backlogCongestionThreshold < float64(len(handler.backlogQueue))
 		// consume a capacity unit
 		// if the elastic rate limiter cannot vend a capacity, the error it returns
 		// is sufficient to indicate that we should enable Congestion Control, because
 		// an issue in vending capacity indicates the underlying resource (TXBacklog) is full
-		capguard, err = handler.erl.ConsumeCapacity(rawmsg.Sender.(util.ErlClient))
+		capguard, err = handler.erl.ConsumeCapacity(sender.(util.ErlClient))
 		if err != nil {
 			handler.erl.EnableCongestionControl()
 			// if there is no capacity, it is the same as if we failed to put the item onto the backlog, so report such
 			transactionMessagesDroppedFromBacklog.Inc(nil)
-			return network.OutgoingMessage{Action: network.Ignore}
+			return msgKey, capguard, true
 		}
 		// if the backlog Queue has 50% of its buffer back, turn congestion control off
 		if !congestedERL {
 			handler.erl.DisableCongestionControl()
 		}
 	}
+	return msgKey, capguard, false
+}
+
+func decodeMsg(data []byte) ([]transactions.SignedTxn, int, bool) {
+	unverifiedTxGroup := make([]transactions.SignedTxn, 1)
+	dec := protocol.NewMsgpDecoderBytes(data)
+	ntx := 0
+	consumed := 0
 
 	for {
 		if len(unverifiedTxGroup) == ntx {
@@ -630,7 +628,7 @@ func (handler *TxHandler) processIncomingTxn(rawmsg network.IncomingMessage) net
 				break
 			}
 			logging.Base().Warnf("Received a non-decodable txn: %v", err)
-			return network.OutgoingMessage{Action: network.Disconnect}
+			return nil, 0, true
 		}
 		consumed = dec.Consumed()
 		ntx++
@@ -639,13 +637,13 @@ func (handler *TxHandler) processIncomingTxn(rawmsg network.IncomingMessage) net
 			if dec.Remaining() > 0 {
 				// if something else left in the buffer - this is an error, drop
 				transactionMessageTxGroupExcessive.Inc(nil)
-				return network.OutgoingMessage{Action: network.Disconnect}
+				return nil, 0, true
 			}
 		}
 	}
 	if ntx == 0 {
 		logging.Base().Warnf("Received empty tx group")
-		return network.OutgoingMessage{Action: network.Disconnect}
+		return nil, 0, true
 	}
 
 	unverifiedTxGroup = unverifiedTxGroup[:ntx]
@@ -654,21 +652,49 @@ func (handler *TxHandler) processIncomingTxn(rawmsg network.IncomingMessage) net
 		transactionMessageTxGroupFull.Inc(nil)
 	}
 
+	return unverifiedTxGroup, consumed, false
+}
+
+func (handler *TxHandler) incomingTxGroupDupRateLimit(unverifiedTxGroup []transactions.SignedTxn, encodedExpectedSize int, sender network.DisconnectablePeer) (*crypto.Digest, bool) {
 	var canonicalKey *crypto.Digest
 	if handler.txCanonicalCache != nil {
-		if canonicalKey, isDup = handler.dedupCanonical(ntx, unverifiedTxGroup, consumed); isDup {
+		var isDup bool
+		if canonicalKey, isDup = handler.dedupCanonical(unverifiedTxGroup, encodedExpectedSize); isDup {
 			transactionMessagesDupCanonical.Inc(nil)
-			return network.OutgoingMessage{Action: network.Ignore}
+			return canonicalKey, true
 		}
 	}
 
 	// rate limit per application in a group. Limiting any app in a group drops the entire message.
 	if handler.appLimiter != nil {
 		congestedARL := len(handler.backlogQueue) > handler.appLimiterBacklogThreshold
-		if congestedARL && handler.appLimiter.shouldDrop(unverifiedTxGroup, rawmsg.Sender.(network.IPAddressable).RoutingAddr()) {
+		if congestedARL && handler.appLimiter.shouldDrop(unverifiedTxGroup, sender.(network.IPAddressable).RoutingAddr()) {
 			transactionMessagesAppLimiterDrop.Inc(nil)
-			return network.OutgoingMessage{Action: network.Ignore}
+			return canonicalKey, true
 		}
+	}
+	return canonicalKey, false
+}
+
+// processIncomingTxn decodes a transaction group from incoming message and enqueues into the back log for processing.
+// The function also performs some input data pre-validation;
+//   - txn groups are cut to MaxTxGroupSize size
+//   - message are checked for duplicates
+//   - transactions are checked for duplicates
+func (handler *TxHandler) processIncomingTxn(rawmsg network.IncomingMessage) network.OutgoingMessage {
+	msgKey, capguard, isDup := handler.incomingMsgDupErlCheck(rawmsg.Data, rawmsg.Sender)
+	if isDup {
+		return network.OutgoingMessage{Action: network.Ignore}
+	}
+
+	unverifiedTxGroup, consumed, drop := decodeMsg(rawmsg.Data)
+	if drop {
+		return network.OutgoingMessage{Action: network.Disconnect}
+	}
+
+	canonicalKey, drop := handler.incomingTxGroupDupRateLimit(unverifiedTxGroup, consumed, rawmsg.Sender)
+	if drop {
+		return network.OutgoingMessage{Action: network.Ignore}
 	}
 
 	select {

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -762,7 +762,7 @@ func (handler *TxHandler) validateIncomingTxMessage(rawmsg network.IncomingMessa
 	}
 
 	return network.ValidatedMessage{
-		Action: network.Ignore,
+		Action: network.Accept,
 		Tag:    rawmsg.Tag,
 		ValidatorData: &validatedIncomingTxMessage{
 			rawmsg:            rawmsg,

--- a/network/gossipNode.go
+++ b/network/gossipNode.go
@@ -193,6 +193,9 @@ const (
 
 	// Respond - reply to the sender
 	Respond
+
+	// Accept - accept for further processing after successful validation
+	Accept
 )
 
 // MessageHandler takes a IncomingMessage (e.g., vote, transaction), processes it, and returns what (if anything)

--- a/network/gossipNode.go
+++ b/network/gossipNode.go
@@ -88,6 +88,12 @@ type GossipNode interface {
 	// ClearHandlers deregisters all the existing message handlers.
 	ClearHandlers()
 
+	// RegisterProcessors adds to the set of given message processors.
+	RegisterProcessors(dispatch []TaggedMessageProcessor)
+
+	// ClearProcessors deregisters all the existing message processors.
+	ClearProcessors()
+
 	// GetHTTPClient returns a http.Client with a suitable for the network Transport
 	// that would also limit the number of outgoing connections.
 	GetHTTPClient(address string) (*http.Client, error)
@@ -162,6 +168,14 @@ type OutgoingMessage struct {
 	OnRelease func()
 }
 
+// ValidatedMessage is a message that has been validated and is ready to be processed.
+// Think as an intermediate one between IncomingMessage and OutgoingMessage
+type ValidatedMessage struct {
+	Action        ForwardingPolicy
+	Tag           Tag
+	ValidatorData interface{}
+}
+
 // ForwardingPolicy is an enum indicating to whom we should send a message
 //
 //msgp:ignore ForwardingPolicy
@@ -189,11 +203,36 @@ type MessageHandler interface {
 	Handle(message IncomingMessage) OutgoingMessage
 }
 
-// HandlerFunc represents an implemenation of the MessageHandler interface
+// HandlerFunc represents an implementation of the MessageHandler interface
 type HandlerFunc func(message IncomingMessage) OutgoingMessage
 
-// Handle implements MessageHandler.Handle, calling the handler with the IncomingKessage and returning the OutgoingMessage
+// Handle implements MessageHandler.Handle, calling the handler with the IncomingMessage and returning the OutgoingMessage
 func (f HandlerFunc) Handle(message IncomingMessage) OutgoingMessage {
+	return f(message)
+}
+
+// MessageProcessor takes a IncomingMessage (e.g., vote, transaction), processes it, and returns what (if anything)
+// to send to the network in response.
+// This is an extension of the MessageHandler that works in two stages: validate ->[result]-> handle.
+type MessageProcessor interface {
+	Validate(message IncomingMessage) ValidatedMessage
+	Handle(message ValidatedMessage) OutgoingMessage
+}
+
+// ProcessorValidateFunc represents an implementation of the MessageProcessor interface
+type ProcessorValidateFunc func(message IncomingMessage) ValidatedMessage
+
+// ProcessorHandleFunc represents an implementation of the MessageProcessor interface
+type ProcessorHandleFunc func(message ValidatedMessage) OutgoingMessage
+
+// Validate implements MessageProcessor.Validate, calling the validator with the IncomingMessage and returning the action
+// and validation extra data that can be use as the handler input.
+func (f ProcessorValidateFunc) Validate(message IncomingMessage) ValidatedMessage {
+	return f(message)
+}
+
+// Handle implements MessageProcessor.Handle calling the handler with the ValidatedMessage and returning the OutgoingMessage
+func (f ProcessorHandleFunc) Handle(message ValidatedMessage) OutgoingMessage {
 	return f(message)
 }
 
@@ -201,6 +240,13 @@ func (f HandlerFunc) Handle(message IncomingMessage) OutgoingMessage {
 type TaggedMessageHandler struct {
 	Tag
 	MessageHandler
+}
+
+// TaggedMessageProcessor receives one type of broadcast messages
+// and performs two stage processing: validating and handling
+type TaggedMessageProcessor struct {
+	Tag
+	MessageProcessor
 }
 
 // Propagate is a convenience function to save typing in the common case of a message handler telling us to propagate an incoming message

--- a/network/hybridNetwork.go
+++ b/network/hybridNetwork.go
@@ -180,6 +180,18 @@ func (n *HybridP2PNetwork) ClearHandlers() {
 	n.wsNetwork.ClearHandlers()
 }
 
+// RegisterHandlers adds to the set of given message handlers.
+func (n *HybridP2PNetwork) RegisterProcessors(dispatch []TaggedMessageProcessor) {
+	n.p2pNetwork.RegisterProcessors(dispatch)
+	n.wsNetwork.RegisterProcessors(dispatch)
+}
+
+// ClearHandlers deregisters all the existing message handlers.
+func (n *HybridP2PNetwork) ClearProcessors() {
+	n.p2pNetwork.ClearProcessors()
+	n.wsNetwork.ClearProcessors()
+}
+
 // GetHTTPClient returns a http.Client with a suitable for the network Transport
 // that would also limit the number of outgoing connections.
 func (n *HybridP2PNetwork) GetHTTPClient(address string) (*http.Client, error) {

--- a/network/hybridNetwork.go
+++ b/network/hybridNetwork.go
@@ -180,13 +180,13 @@ func (n *HybridP2PNetwork) ClearHandlers() {
 	n.wsNetwork.ClearHandlers()
 }
 
-// RegisterHandlers adds to the set of given message handlers.
+// RegisterProcessors adds to the set of given message handlers.
 func (n *HybridP2PNetwork) RegisterProcessors(dispatch []TaggedMessageProcessor) {
 	n.p2pNetwork.RegisterProcessors(dispatch)
 	n.wsNetwork.RegisterProcessors(dispatch)
 }
 
-// ClearHandlers deregisters all the existing message handlers.
+// ClearProcessors deregisters all the existing message handlers.
 func (n *HybridP2PNetwork) ClearProcessors() {
 	n.p2pNetwork.ClearProcessors()
 	n.wsNetwork.ClearProcessors()

--- a/network/multiplexer.go
+++ b/network/multiplexer.go
@@ -82,7 +82,7 @@ func (m *Multiplexer) Handle(msg IncomingMessage) OutgoingMessage {
 	return OutgoingMessage{}
 }
 
-// Validate is the "input" side of the multiplexer. It dispatches the message to the previously defined handler.
+// Validate is an alternative "input" side of the multiplexer. It dispatches the message to the previously defined validator.
 func (m *Multiplexer) Validate(msg IncomingMessage) ValidatedMessage {
 	handler, ok := m.getProcessor(msg.Tag)
 
@@ -93,7 +93,7 @@ func (m *Multiplexer) Validate(msg IncomingMessage) ValidatedMessage {
 	return ValidatedMessage{}
 }
 
-// Handle is the "input" side of the multiplexer. It dispatches the message to the previously defined handler.
+// Process is the second step of message handling after validation. It dispatches the message to the previously defined processor.
 func (m *Multiplexer) Process(msg ValidatedMessage) OutgoingMessage {
 	handler, ok := m.getProcessor(msg.Tag)
 
@@ -145,7 +145,7 @@ func (m *Multiplexer) ClearHandlers(excludeTags []Tag) {
 	m.msgHandlers.Store(newMap)
 }
 
-// RegisterHandlers registers the set of given message handlers.
+// RegisterProcessors registers the set of given message handlers.
 func (m *Multiplexer) RegisterProcessors(dispatch []TaggedMessageProcessor) {
 	mp := make(map[Tag]MessageProcessor)
 	if existingMap := m.getProcessorsMap(); existingMap != nil {
@@ -162,7 +162,7 @@ func (m *Multiplexer) RegisterProcessors(dispatch []TaggedMessageProcessor) {
 	m.msgProcessors.Store(mp)
 }
 
-// ClearHandlers deregisters all the existing message handlers other than the one provided in the excludeTags list
+// ClearProcessors deregisters all the existing message handlers other than the one provided in the excludeTags list
 func (m *Multiplexer) ClearProcessors(excludeTags []Tag) {
 	if len(excludeTags) == 0 {
 		m.msgProcessors.Store(make(map[Tag]MessageProcessor))

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -894,9 +894,9 @@ func (n *P2PNetwork) txTopicHandleLoop() {
 			sub.Cancel()
 			return
 		}
-		// if we sent the message no need to process it.
+		// if there is a self-sent the message no need to process it.
 		if msg.ReceivedFrom == n.service.ID() {
-			return
+			continue
 		}
 
 		_ = n.handler.Process(msg.ValidatorData.(ValidatedMessage))

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -938,15 +938,11 @@ func (n *P2PNetwork) txTopicValidator(ctx context.Context, peerID peer.ID, msg *
 	// there was a decision made in the handler about this message
 	switch outmsg.Action {
 	case Ignore:
-		// TODO: add a new ForwardingPolicy action?
-		if outmsg.ValidatorData != nil {
-			msg.ValidatorData = outmsg.ValidatorData
-			return pubsub.ValidationAccept
-		}
 		return pubsub.ValidationIgnore
 	case Disconnect:
 		return pubsub.ValidationReject
-	case Broadcast: // TxHandler.processIncomingTxn does not currently return this Action
+	case Accept:
+		msg.ValidatorData = outmsg
 		return pubsub.ValidationAccept
 	default:
 		n.log.Warnf("handler returned invalid action %d", outmsg.Action)

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -659,12 +659,12 @@ func (n *P2PNetwork) ClearHandlers() {
 	n.handler.ClearHandlers([]Tag{})
 }
 
-// RegisterHandlers adds to the set of given message handlers.
+// RegisterProcessors adds to the set of given message handlers.
 func (n *P2PNetwork) RegisterProcessors(dispatch []TaggedMessageProcessor) {
 	n.handler.RegisterProcessors(dispatch)
 }
 
-// ClearHandlers deregisters all the existing message handlers.
+// ClearProcessors deregisters all the existing message handlers.
 func (n *P2PNetwork) ClearProcessors() {
 	n.handler.ClearProcessors([]Tag{})
 }

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -884,29 +884,37 @@ func (n *P2PNetwork) txTopicHandleLoop() {
 	}
 	n.log.Debugf("Subscribed to topic %s", p2p.TXTopicName)
 
-	for {
-		msg, err := sub.Next(n.ctx)
-		if err != nil {
-			if err != pubsub.ErrSubscriptionCancelled && err != context.Canceled {
-				n.log.Errorf("Error reading from subscription %v, peerId %s", err, n.service.ID())
+	var wg sync.WaitGroup
+	wg.Add(incomingThreads)
+	defer wg.Wait()
+	for i := 0; i < incomingThreads; i++ {
+		go func() {
+			defer wg.Done()
+			for {
+				msg, err := sub.Next(n.ctx)
+				if err != nil {
+					if err != pubsub.ErrSubscriptionCancelled && err != context.Canceled {
+						n.log.Errorf("Error reading from subscription %v, peerId %s", err, n.service.ID())
+					}
+					n.log.Debugf("Cancelling subscription to topic %s due Subscription.Next error: %v", p2p.TXTopicName, err)
+					sub.Cancel()
+					return
+				}
+				// if we sent the message no need to process it.
+				if msg.ReceivedFrom == n.service.ID() {
+					return
+				}
+
+				_ = n.handler.Process(msg.ValidatorData.(ValidatedMessage))
+
+				// participation or configuration change, cancel subscription and quit
+				if !n.wantTXGossip.Load() {
+					n.log.Debugf("Cancelling subscription to topic %s due participation change", p2p.TXTopicName)
+					sub.Cancel()
+					return
+				}
 			}
-			n.log.Debugf("Cancelling subscription to topic %s due Subscription.Next error: %v", p2p.TXTopicName, err)
-			sub.Cancel()
-			return
-		}
-		// if we sent the message no need to process it.
-		if msg.ReceivedFrom == n.service.ID() {
-			return
-		}
-
-		_ = n.handler.Process(msg.ValidatorData.(ValidatedMessage))
-
-		// participation or configuration change, cancel subscription and quit
-		if !n.wantTXGossip.Load() {
-			n.log.Debugf("Cancelling subscription to topic %s due participation change", p2p.TXTopicName)
-			sub.Cancel()
-			return
-		}
+		}()
 	}
 }
 

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -853,6 +853,14 @@ func (wn *WebsocketNetwork) ClearHandlers() {
 	wn.handler.ClearHandlers([]Tag{protocol.PingTag, protocol.PingReplyTag, protocol.NetPrioResponseTag})
 }
 
+// RegisterHandlers registers the set of given message handlers.
+func (wn *WebsocketNetwork) RegisterProcessors(dispatch []TaggedMessageProcessor) {
+}
+
+// ClearHandlers deregisters all the existing message handlers.
+func (wn *WebsocketNetwork) ClearProcessors() {
+}
+
 func (wn *WebsocketNetwork) setHeaders(header http.Header) {
 	localTelemetryGUID := wn.log.GetTelemetryGUID()
 	localInstanceName := wn.log.GetInstanceName()

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -853,11 +853,11 @@ func (wn *WebsocketNetwork) ClearHandlers() {
 	wn.handler.ClearHandlers([]Tag{protocol.PingTag, protocol.PingReplyTag, protocol.NetPrioResponseTag})
 }
 
-// RegisterHandlers registers the set of given message handlers.
+// RegisterProcessors registers the set of given message handlers.
 func (wn *WebsocketNetwork) RegisterProcessors(dispatch []TaggedMessageProcessor) {
 }
 
-// ClearHandlers deregisters all the existing message handlers.
+// ClearProcessors deregisters all the existing message handlers.
 func (wn *WebsocketNetwork) ClearProcessors() {
 }
 


### PR DESCRIPTION
## Summary

* Added `MessageProcessor` similar to `MessageHandler` but working in two stages: validate and handle
* Split `processIncomingTxn` txhandler method into two validate + handle
* This allowed to use gossipsub's validate and handing framework as intended.

## Test Plan

* Existing tests should work
