### PR TITLE
p2p: fix wantTXGossip modifications

### DIFF
--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -197,6 +197,15 @@ type gossipSubPeer struct {
 
 func (p gossipSubPeer) GetNetwork() GossipNode { return p.net }
 
+func (p gossipSubPeer) OnClose(f func()) {
+	net := p.GetNetwork().(*P2PNetwork)
+	net.wsPeersLock.Lock()
+	defer net.wsPeersLock.Unlock()
+	if wsp, ok := net.wsPeers[p.peerID]; ok {
+		wsp.OnClose(f)
+	}
+}
+
 // NewP2PNetwork returns an instance of GossipNode that uses the p2p.Service
 func NewP2PNetwork(log logging.Logger, cfg config.Local, datadir string, phonebookAddresses []string, genesisID string, networkID protocol.NetworkID, node NodeInfo) (*P2PNetwork, error) {
 	const readBufferLen = 2048

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -677,7 +677,7 @@ func (n *P2PNetwork) GetHTTPClient(address string) (*http.Client, error) {
 func (n *P2PNetwork) OnNetworkAdvance() {
 	if n.nodeInfo != nil {
 		old := n.wantTXGossip.Load()
-		new := n.nodeInfo.IsParticipating()
+		new := n.relayMessages || n.config.ForceFetchTransactions || n.nodeInfo.IsParticipating()
 		if old != new {
 			n.wantTXGossip.Store(new)
 			if new {

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -40,7 +40,6 @@ import (
 	"time"
 
 	"github.com/algorand/go-algorand/internal/rapidgen"
-	"github.com/algorand/go-algorand/network/p2p"
 	"github.com/algorand/go-algorand/network/phonebook"
 	"pgregory.net/rapid"
 
@@ -3293,13 +3292,11 @@ func TestWebsocketNetworkTXMessageOfInterestNPN(t *testing.T) {
 }
 
 type participatingNodeInfo struct {
+	nopeNodeInfo
 }
 
 func (nnni *participatingNodeInfo) IsParticipating() bool {
 	return true
-}
-func (nnni *participatingNodeInfo) Capabilities() []p2p.Capability {
-	return nil
 }
 
 func TestWebsocketNetworkTXMessageOfInterestPN(t *testing.T) {


### PR DESCRIPTION
## Summary

There was a bug in wantTXGossip setting [here](https://github.com/algorand/go-algorand/pull/5935/files#diff-4e519aba1b9b7f153328113f57806378cef2b400953324e9de025130c2eaabd4R669), forcing relays to unsubscribe from TX traffic.

Additionally added a missing `gossipSubPeer.OnClose` needed in txHandler.

## Test Plan

Updated wantTXGossip unit test.