### PR TITLE
Tests: Stabilize nightly tests.

### DIFF
--- a/test/e2e-go/features/incentives/payouts_test.go
+++ b/test/e2e-go/features/incentives/payouts_test.go
@@ -48,7 +48,7 @@ func TestBasicPayouts(t *testing.T) {
 	var fixture fixtures.RestClientFixture
 	// Make the seed lookback shorter, otherwise we need to wait 320 rounds to become IncentiveEligible.
 	const lookback = 32
-	fixture.FasterConsensus(protocol.ConsensusFuture, time.Second/2, 32)
+	fixture.FasterConsensus(protocol.ConsensusFuture, time.Second, 32)
 	fmt.Printf("lookback is %d\n", lookback)
 	fixture.Setup(t, filepath.Join("nettemplates", "Payouts.json"))
 	defer fixture.Shutdown()

--- a/test/e2e-go/features/incentives/suspension_test.go
+++ b/test/e2e-go/features/incentives/suspension_test.go
@@ -53,7 +53,7 @@ func TestBasicSuspension(t *testing.T) {
 	var fixture fixtures.RestClientFixture
 	// Speed up rounds, but keep long lookback, so 20% node has a chance to get
 	// back online after being suspended.
-	fixture.FasterConsensus(protocol.ConsensusFuture, time.Second/2, 320)
+	fixture.FasterConsensus(protocol.ConsensusFuture, time.Second, 320)
 	fixture.Setup(t, filepath.Join("nettemplates", "Suspension.json"))
 	defer fixture.Shutdown()
 


### PR DESCRIPTION
Don't try to use such a fast consensus in nightly tests
