### PR TITLE
tests: fix TestExactAccountChunk

### DIFF
--- a/ledger/catchpointfilewriter_test.go
+++ b/ledger/catchpointfilewriter_test.go
@@ -824,6 +824,19 @@ func TestExactAccountChunk(t *testing.T) {
 	// ensure both committed all pending changes before taking a catchpoint
 	// another approach is to modify the test and craft round numbers,
 	// and make the ledger to generate catchpoint itself when it is time
+	flushRound := func(l *Ledger) {
+		// Clear the timer to ensure a flush
+		l.trackers.mu.Lock()
+		l.trackers.lastFlushTime = time.Time{}
+		l.trackers.mu.Unlock()
+
+		r, _ := l.LatestCommitted()
+		l.trackers.committedUpTo(r)
+		l.trackers.waitAccountsWriting()
+	}
+	flushRound(dl.generator)
+	flushRound(dl.validator)
+
 	require.Eventually(t, func() bool {
 		dl.generator.accts.accountsMu.RLock()
 		dlg := len(dl.generator.accts.deltas)
@@ -832,7 +845,6 @@ func TestExactAccountChunk(t *testing.T) {
 		dl.validator.accts.accountsMu.RLock()
 		dlv := len(dl.validator.accts.deltas)
 		dl.validator.accts.accountsMu.RUnlock()
-
 		return dlg == dlv && dl.generator.Latest() == dl.validator.Latest()
 	}, 10*time.Second, 100*time.Millisecond)
 


### PR DESCRIPTION
## Summary

`TestExactAccountChunk` compares MT stats on different components of a `DoubleLeger`. Sometimes these two might flush different number of rounds to disk causing different MTs (and catchpoint).
Force flushing and waiting should after should minimize such discrepancy.

## Testing

This is a fix to unstable `TestExactAccountChunk` that should pass.
Run multiple times locally and on CI.