### PR TITLE
tests: make e2e TestBasicSuspension less flaky

### DIFF
--- a/test/e2e-go/features/incentives/suspension_test.go
+++ b/test/e2e-go/features/incentives/suspension_test.go
@@ -116,13 +116,11 @@ func TestBasicSuspension(t *testing.T) {
 	fixture.SendMoneyAndWait(afterStop.LastRound+suspend20, 5, 1000, richAccount.Address, account10.Address, "")
 	fixture.SendMoneyAndWait(afterStop.LastRound+suspend20, 5, 1000, richAccount.Address, account20.Address, "")
 
-	// all nodes are in sync
+	// make sure c10 node is in-sync with the network
 	status, err := fixture.LibGoalClient.Status()
 	a.NoError(err)
-	for _, c := range []libgoal.Client{c10, c20} {
-		_, err := c.WaitForRound(status.LastRound)
-		a.NoError(err)
-	}
+	_, err = c10.WaitForRound(status.LastRound)
+	a.NoError(err)
 
 	// n20's account is now offline, but has voting key material (suspended)
 	account, err = c10.AccountData(account20.Address)

--- a/test/e2e-go/features/incentives/suspension_test.go
+++ b/test/e2e-go/features/incentives/suspension_test.go
@@ -116,6 +116,14 @@ func TestBasicSuspension(t *testing.T) {
 	fixture.SendMoneyAndWait(afterStop.LastRound+suspend20, 5, 1000, richAccount.Address, account10.Address, "")
 	fixture.SendMoneyAndWait(afterStop.LastRound+suspend20, 5, 1000, richAccount.Address, account20.Address, "")
 
+	// all nodes are in sync
+	status, err := fixture.LibGoalClient.Status()
+	a.NoError(err)
+	for _, c := range []libgoal.Client{c10, c20} {
+		_, err := c.WaitForRound(status.LastRound)
+		a.NoError(err)
+	}
+
 	// n20's account is now offline, but has voting key material (suspended)
 	account, err = c10.AccountData(account20.Address)
 	a.NoError(err)


### PR DESCRIPTION
## Summary

Failure:
```
    fixture.go:120: 
        	Error Trace:	/opt/cibuild/project/test/e2e-go/features/incentives/suspension_test.go:122
        	Error:      	Not equal: 
        	            	expected: 0x0
        	            	actual  : 0x1
        	Test:       	TestBasicSuspension
```
Fix is to sync all test clients before proceeding, the same idea as #5986

## Test Plan

This is a test fix