### PR TITLE
logger: fix data race in tests

### DIFF
--- a/logging/log.go
+++ b/logging/log.go
@@ -308,7 +308,7 @@ func (l logger) SetOutput(w io.Writer) {
 }
 
 func (l logger) setOutput(w io.Writer) {
-	l.entry.Logger.Out = w
+	l.entry.Logger.SetOutput(w)
 }
 
 func (l logger) getOutput() io.Writer {


### PR DESCRIPTION
## Summary

Fix for the following data race seen in [tests](https://app.circleci.com/pipelines/github/algorand/go-algorand/18323/workflows/b4bc8ccb-dc50-4c08-9a3d-50ba0e7f32cb/jobs/271397/tests):
```
=== RUN   TestVoteAggregatorFiltersBundlePresent
==================
WARNING: DATA RACE
Read at 0x00c0005e3260 by goroutine 483304:
  github.com/sirupsen/logrus.(*Entry).write()
      /opt/cibuild/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:286 +0x23e
  github.com/sirupsen/logrus.(*Entry).log()
      /opt/cibuild/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:251 +0x964
  github.com/sirupsen/logrus.(*Entry).Log()
      /opt/cibuild/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:293 +0x8b
  github.com/sirupsen/logrus.(*Entry).Logf()
      /opt/cibuild/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:338 +0xd8
  github.com/sirupsen/logrus.(*Entry).Infof()
      /opt/cibuild/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:351 +0x86
  github.com/algorand/go-algorand/logging.logger.Infof()
      /opt/cibuild/project/logging/log.go:205 +0x4f
  github.com/algorand/go-algorand/logging.(*logger).Infof()
      <autogenerated>:1 +0x84
  github.com/algorand/go-algorand/agreement.pseudonodeVotesTask.execute()

Previous write at 0x00c0005e3260 by goroutine 493961:
  github.com/algorand/go-algorand/logging.logger.setOutput()
      /opt/cibuild/project/logging/log.go:311 +0x1bb
  github.com/algorand/go-algorand/logging.logger.SetOutput()
      /opt/cibuild/project/logging/log.go:306 +0x1a2
  github.com/algorand/go-algorand/logging.(*logger).SetOutput()
      <autogenerated>:1 +0x24
  github.com/algorand/go-algorand/agreement.(*determisticTraceTestCase).ValidateAsExtension.func1()
      /opt/cibuild/project/agreement/state_machine_test.go:417 +0x6f
  runtime.deferreturn()
      /opt/cibuild/.gimme/versions/go1.21.10.linux.amd64/src/runtime/panic.go:477 +0x30
  github.com/algorand/go-algorand/agreement.(*directMatchIoSafetyProp).containsTrace()
      /opt/cibuild/project/agreement/state_machine_test.go:255 +0xc1
```

`Logger.SetOutput` takes lock before assigning `Logger.Out` that is a correct thing to do.

## Test Plan

Existing tests should pass.