### PR TITLE
Metrics: Add algod version to metrics

### DIFF
--- a/config/version.go
+++ b/config/version.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"fmt"
-	"runtime"
 	"strconv"
 )
 
@@ -134,11 +133,6 @@ func UpdateVersionDataDir(dataDir string) {
 // GetAlgorandVersion retrieves the current version formatted as a simple version string (Major.Minor.BuildNumber)
 func GetAlgorandVersion() string {
 	return currentVersion.String()
-}
-
-// GetAlgorandVersionAndBuild retrieves the current version and build
-func GetAlgorandVersionAndBuild() string {
-	return fmt.Sprintf("algod/%d.%d.%d (%s; commit=%s) %s(%s)", currentVersion.Major, currentVersion.Minor, currentVersion.BuildNumber, currentVersion.Channel, currentVersion.CommitHash, runtime.GOOS, runtime.GOARCH)
 }
 
 // GetLicenseInfo retrieves the current license information

--- a/config/version.go
+++ b/config/version.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"runtime"
 	"strconv"
 )
 
@@ -133,6 +134,11 @@ func UpdateVersionDataDir(dataDir string) {
 // GetAlgorandVersion retrieves the current version formatted as a simple version string (Major.Minor.BuildNumber)
 func GetAlgorandVersion() string {
 	return currentVersion.String()
+}
+
+// GetAlgorandVersionAndBuild retrieves the current version and build
+func GetAlgorandVersionAndBuild() string {
+	return fmt.Sprintf("algod/%d.%d.%d (%s; commit=%s) %s(%s)", currentVersion.Major, currentVersion.Minor, currentVersion.BuildNumber, currentVersion.Channel, currentVersion.CommitHash, runtime.GOOS, runtime.GOARCH)
 }
 
 // GetLicenseInfo retrieves the current license information

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -234,7 +234,7 @@ func (s *Server) Initialize(cfg config.Local, phonebookAddresses []string, genes
 	var currentVersion = config.GetCurrentVersion()
 	var algodEnvironmentAlgodVersionGauge = metrics.MakeGauge(metrics.MetricName{Name: "algod_environment_algod_version", Description: "Version of the Algod binary"})
 	algodEnvironmentAlgodVersionGauge.SetLabels(1, map[string]string{
-		"version": fmt.Sprintf("%d.%d.%d", currentVersion.Major, currentVersion.Minor, currentVersion.BuildNumber),
+		"version": currentVersion.String(),
 		"goarch":  runtime.GOARCH,
 		"goos":    runtime.GOOS,
 		"commit":  currentVersion.CommitHash,

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -230,6 +230,9 @@ func (s *Server) Initialize(cfg config.Local, phonebookAddresses []string, genes
 			NodeExporterPath:          cfg.NodeExporterPath,
 		})
 
+	var algodEnvironmentAlgodVersionCounter = metrics.MakeCounter(metrics.MetricName{Name: "algod_environment_algod_version", Description: "Version of the Algod binary"})
+	algodEnvironmentAlgodVersionCounter.Inc(map[string]string{"version": config.GetAlgorandVersionAndBuild()})
+
 	var serverNode ServerNode
 	if cfg.EnableFollowMode {
 		var followerNode *node.AlgorandFollowerNode

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -232,8 +232,8 @@ func (s *Server) Initialize(cfg config.Local, phonebookAddresses []string, genes
 		})
 
 	var currentVersion = config.GetCurrentVersion()
-	var algodEnvironmentAlgodVersionGauge = metrics.MakeGauge(metrics.MetricName{Name: "algod_environment_algod_version", Description: "Version of the Algod binary"})
-	algodEnvironmentAlgodVersionGauge.SetLabels(1, map[string]string{
+	var algodBuildInfoGauge = metrics.MakeGauge(metrics.MetricName{Name: "algod_build_info", Description: "Algod build info"})
+	algodBuildInfoGauge.SetLabels(1, map[string]string{
 		"version": currentVersion.String(),
 		"goarch":  runtime.GOARCH,
 		"goos":    runtime.GOOS,

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -230,8 +231,15 @@ func (s *Server) Initialize(cfg config.Local, phonebookAddresses []string, genes
 			NodeExporterPath:          cfg.NodeExporterPath,
 		})
 
-	var algodEnvironmentAlgodVersionCounter = metrics.MakeCounter(metrics.MetricName{Name: "algod_environment_algod_version", Description: "Version of the Algod binary"})
-	algodEnvironmentAlgodVersionCounter.Inc(map[string]string{"version": config.GetAlgorandVersionAndBuild()})
+	var currentVersion = config.GetCurrentVersion()
+	var algodEnvironmentAlgodVersionGauge = metrics.MakeGauge(metrics.MetricName{Name: "algod_environment_algod_version", Description: "Version of the Algod binary"})
+	algodEnvironmentAlgodVersionGauge.SetLabels(1, map[string]string{
+		"version": fmt.Sprintf("%d.%d.%d", currentVersion.Major, currentVersion.Minor, currentVersion.BuildNumber),
+		"goarch":  runtime.GOARCH,
+		"goos":    runtime.GOOS,
+		"commit":  currentVersion.CommitHash,
+		"channel": currentVersion.Channel,
+	})
 
 	var serverNode ServerNode
 	if cfg.EnableFollowMode {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

This PR adds algod version information to metrics exported. This will allow querying relay servers to see if they have updated to required / requested versions, and potentially be used to enforce SLA's around patching.

This PR does introduce a new namespace 'environment' for metrics, with reasoning being that this namespace is for exposing app-level runtime environment information, which currently is not exposed (outside of what Prometheus's node_exporter may provide at an OS level).

One label is used (version). I was thinking of splitting this up into labels with version (major.minor.patch), build, OS, arch, etc - however without having a clear use-case as to why this would be required I opted for simplicity. Happy to adjust as designated labels would be a more stable interface for anyone needing these data, if that is expected.

Also note that the string is *VERY* similar to a duplicated user-agent header strings in wsNetwork.go and p2p.go (e.g. https://github.com/algorand/go-algorand/blob/master/network/p2p/p2p.go#L85), however the existing format makes it more difficult to parse the string in an observability platform, if goal is to map back to release versions published (e.g., 3.24.0) vs parsing in the format contained in this PR. I opted not to change user-agent strings as that could be seen as a breaking change, in case anyone parses these.

## Test Plan

- I ran a local algod version, and confirmed that the data was in there.
- Ran `make test` with no failures
