### PR TITLE
CICD: Update to switch e2e_expect to large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,7 +303,7 @@ jobs:
     parameters:
       platform:
         type: string
-    executor: << parameters.platform >>_medium
+    executor: << parameters.platform >>_large
     working_directory: << pipeline.parameters.build_dir >>/project
     parallelism: 10
     environment:
@@ -319,7 +319,7 @@ jobs:
     parameters:
       platform:
         type: string
-    executor: << parameters.platform >>_medium
+    executor: << parameters.platform >>_large
     working_directory: << pipeline.parameters.build_dir >>/project
     parallelism: 2
     environment:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-.github/ @algorand/devops
-.circleci/ @algorand/devops


### PR DESCRIPTION
## Summary

We occasionally see memory issues with e2e tests, so let's switch from medium (2 CPU, 7.5 GB) to large (4 CPU, 15 GB). This is at the cost of more credits usage, obviously. This is for e2e_expect and e2e_expect_nightly.

Unrelated: also remove CODEOWNERS file, which is deprecated.

## Test Plan

See if nightlies succeed.
