### PR TITLE
Tests: Fix flakey ECDSA testing

### DIFF
--- a/data/transactions/logic/crypto_test.go
+++ b/data/transactions/logic/crypto_test.go
@@ -606,8 +606,8 @@ ecdsa_verify Secp256r1
 
 	ri, si, err := ecdsa.Sign(rand.Reader, key, msg[:])
 	require.NoError(t, err)
-	r := ri.Bytes()
-	s := si.Bytes()
+	r := ri.FillBytes(make([]byte, 32))
+	s := si.FillBytes(make([]byte, 32))
 
 	rTampered := slices.Clone(r)
 	rTampered[0] += byte(1) // intentional overflow
@@ -826,8 +826,8 @@ func benchmarkEcdsaGenData(b *testing.B, curve EcdsaCurve) (data []benchmarkEcds
 		} else if curve == Secp256r1 {
 			r, s, err := ecdsa.Sign(rand.Reader, key, data[i].msg[:])
 			require.NoError(b, err)
-			data[i].r = r.Bytes()
-			data[i].s = s.Bytes()
+			data[i].r = r.FillBytes(make([]byte, 32))
+			data[i].s = s.FillBytes(make([]byte, 32))
 		}
 	}
 	return data


### PR DESCRIPTION
## Summary

Fix flakey ECDSA testing, where a signature component had a leading zero byte, so `big.Int.Bytes()` produced a 31 byte slice.

The failing job: https://app.circleci.com/pipelines/github/algorand/go-algorand/18380/workflows/1d84e0b5-2ad9-4ac7-94cf-5c6315ac7138/jobs/272246

## Test Plan

Test only fix
