### PR TITLE
config: Add warning if EndpointAddress and NetAddress ports are equal

### DIFF
--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -376,12 +376,12 @@ func (s *Server) Start() {
 
 		addrPort, err := getPortFromAddress(addr)
 		if err != nil {
-			s.log.Errorf("Error getting port from EndpointAddress: %v", err)
+			s.log.Warnf("Error getting port from EndpointAddress: %v", err)
 		}
 
 		listenAddrPort, err := getPortFromAddress(listenAddr)
 		if err != nil {
-			s.log.Errorf("Error getting port from NetAddress: %v", err)
+			s.log.Warnf("Error getting port from NetAddress: %v", err)
 		}
 
 		if addrPort == listenAddrPort {

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -378,7 +378,7 @@ func (s *Server) Start() {
 		listenAddrPort := getPortFromAddress(listenAddr, s.log)
 
 		if addrPort == listenAddrPort {
-			s.log.Warnf("Warning: EndpointAddress port %v matches NetAddress port %v. This may lead to unexpected results when accessing endpoints.", addrPort, listenAddrPort)
+			s.log.Warnf("EndpointAddress port %v matches NetAddress port %v. This may lead to unexpected results when accessing endpoints.", addrPort, listenAddrPort)
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Log warning if EndpointAddress and NetAddress has identical ports.

This can happen in a scenario where NetAddress is set to listen to port 0.0.0.0:8080, and where no EndpointAddress is defined. In that case NetAddress is set to listen to 127.0.0.1:0 (port 0 being random OS assigned port in a specific range), however the `makeListener` func in `daemon/algod/server.go` has logic that sets the port to be port 8080 in case port 0 is provided (https://github.com/algorand/go-algorand/blob/master/daemon/algod/server.go#L256).


This will result in the following:
* REST API will be accepting incoming connections on 127.0.0.1:8080
* Gossip protocol will be accepting incoming connections on 0.0.0.0:8080, which will result in it binding to port 8080 for all IP's but 127.0.0.0.1

If you are like me this can cause a lot of confusion as paths and service responses now will default to standard 404 messages and payloads.

The proposed change will add a log warning if the two ports matches up.

Reasoning for a warning is that changing existing logic where port 0 implicitly means port 8080 may be a breaking change for anyone depending on the existing behavior, and where in some cases it could be assumed that people find this desirable (even if not following convention of using port 0).

Note that this PR does not change behavior regarding which address to bind to, meaning that a configuration such as the one below will continue to be a fatal error.

```
  "EndpointAddress": "127.0.0.1:8080",
  "NetAddress": "127.0.0.1:8080",
``` 

## Test Plan

- Remove any presence of EndpointAddress/NetAddress from config.json. No warning should be logged, as not in listening mode.
- Add `"NetAddress": "0.0.0.0:8080",` to config.json. Warning should be logged.
- Add ```"EndpointAddress": "0.0.0.0:8080",
  "NetAddress": "0.0.0.0:8081",```. No warning should be logged.
- Add ```"EndpointAddress": "127.0.0.1:8080",
  "NetAddress": "[::1]:8080",```. Warning should be logged.
