### PR TITLE
agreement: log current player state for VoteBroadcast and ProposalBroadcast events

### DIFF
--- a/agreement/pseudonode.go
+++ b/agreement/pseudonode.go
@@ -422,6 +422,9 @@ func (t pseudonodeVotesTask) execute(verifier *AsyncVoteVerifier, quit chan stru
 				Type:         logspec.VoteBroadcast,
 				Sender:       vote.R.Sender.String(),
 				Hash:         vote.R.Proposal.BlockDigest.String(),
+				Round:        uint64(t.round),
+				Period:       uint64(t.period),
+				Step:         uint64(t.step),
 				ObjectRound:  uint64(vote.R.Round),
 				ObjectPeriod: uint64(vote.R.Period),
 				ObjectStep:   uint64(vote.R.Step),
@@ -549,6 +552,8 @@ func (t pseudonodeProposalsTask) execute(verifier *AsyncVoteVerifier, quit chan 
 		logEvent := logspec.AgreementEvent{
 			Type:         logspec.ProposalBroadcast,
 			Hash:         vote.R.Proposal.BlockDigest.String(),
+			Round:        uint64(t.round),
+			Period:       uint64(t.period),
 			ObjectRound:  uint64(vote.R.Round),
 			ObjectPeriod: uint64(vote.R.Period),
 		}


### PR DESCRIPTION
## Summary

While debugging some delayed consensus on network startup I noticed `VoteBroadcast` and `ProposalBroadcast` do not log player state like other events ({Vote|Proposal}Accepted, VoteAttest, ProposalAccepted etc do).
This PR adds player's Round, Period, Step logging for these events.

## Test Plan

Local run