### PR TITLE
ci: upgrade checkout action to v4

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,7 +17,7 @@ jobs:
     name: Performance regression check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4.0.1
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
           update: true
           path-type: inherit
       - name: Check out code
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Determine Go version

--- a/.github/workflows/codegen_verification.yml
+++ b/.github/workflows/codegen_verification.yml
@@ -14,7 +14,7 @@ jobs:
           - 8080:8080
     steps:
       - name: Check out code
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: go-algorand

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4
 
       - name: Generate Container Metadata
         id: meta
@@ -59,7 +59,7 @@ jobs:
   #   if: github.ref == format('refs/heads/{0}', 'master')
   #   steps:
   #     - name: Checkout Code
-  #       uses: actions/checkout@v3.5.3
+  #       uses: actions/checkout@v4
 
   #     - name: Update DockerHub Repository Description
   #       uses: peter-evans/dockerhub-description@v3

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # required for new-from-rev option in .golangci.yml
         # move go out of the way temporarily to avoid "go list ./..." from installing modules
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # required for new-from-rev option in .golangci.yml
       # move go out of the way temporarily to avoid "go list ./..." from installing modules

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4
       # move go out of the way temporarily to avoid "go list ./..." from installing modules
       - name: Make libsodium.a
         run: sudo mv /usr/bin/go /usr/bin/go.bak && make crypto/libs/linux/amd64/lib/libsodium.a && sudo mv /usr/bin/go.bak /usr/bin/go


### PR DESCRIPTION
## Summary

- Upgrade checkout action to `v4` (`v3` is deprecated and throwing warnings)
- Need someone with access to add appropriate label so PR tests will pass

## Test Plan

 - Check `Node.js 16` warning messages go away after next CI codegen run
