### PR TITLE
CICD: update OS support in test release script

### DIFF
--- a/test/packages/test_release.sh
+++ b/test/packages/test_release.sh
@@ -15,11 +15,12 @@ then
 fi
 
 OS_LIST=(
-    centos:7
-    quay.io/centos/centos:stream8
-    fedora:38
+    quay.io/centos/centos:stream9
+    fedora:39
+    fedora:40
     ubuntu:20.04
     ubuntu:22.04
+    ubuntu:24.04
 )
 
 BUCKET=algorand-builds
@@ -68,7 +69,7 @@ EOF
         then
             WITH_PACMAN=$(echo -e "${TOKENIZED//\{\{PACMAN\}\}/RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y curl}")
         else
-            WITH_PACMAN=$(echo -e "${TOKENIZED//\{\{PACMAN\}\}/RUN yum install -y curl}")
+            WITH_PACMAN=$(echo -e "${TOKENIZED//\{\{PACMAN\}\}/RUN dnf install -y curl}")
         fi
 
         echo -e "$BLUE_FG[$0]$END_FG_COLOR Testing $item..."

--- a/test/packages/test_release.sh
+++ b/test/packages/test_release.sh
@@ -69,7 +69,8 @@ EOF
         then
             WITH_PACMAN=$(echo -e "${TOKENIZED//\{\{PACMAN\}\}/RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y curl}")
         else
-            WITH_PACMAN=$(echo -e "${TOKENIZED//\{\{PACMAN\}\}/RUN dnf install -y curl}")
+            # fedora and centos already have curl installed.
+            WITH_PACMAN=$(echo -e "${TOKENIZED//\{\{PACMAN\}\}/}")
         fi
 
         echo -e "$BLUE_FG[$0]$END_FG_COLOR Testing $item..."


### PR DESCRIPTION
## Summary

The script to test releases was breaking due to the recent deprecation of CentOS Stream 8. In here, we update the list of supported OSes. We also do not try to install curl on Fedora and CentOS, because they are deprecated.

## Test Plan

Verify this fixes nightly uploads.
