### PR TITLE
Tests: Fix e2e kmd timeout

### DIFF
--- a/test/scripts/e2e_client_runner.py
+++ b/test/scripts/e2e_client_runner.py
@@ -106,7 +106,7 @@ def _script_thread_inner(runset, scriptname, timeout):
 
     # create a wallet for the test
     walletname = base64.b16encode(os.urandom(16)).decode()
-    winfo = kmd.create_wallet(walletname, '')
+    winfo = kmd.create_wallet(walletname, '', timeout=120) # 2 minute timeout
     handle = kmd.init_wallet_handle(winfo['id'], '')
     addr = kmd.generate_key(handle)
 


### PR DESCRIPTION
## Summary

Fix e2e KMD timeout in tests, introduced by the latest Python SDK release, 2.6.0, which included https://github.com/algorand/py-algorand-sdk/pull/527

## Test Plan

Tests should pass
