### PR TITLE
Tests: Fix flakey htlc test

### DIFF
--- a/test/scripts/e2e_subs/htlc-teal-test.sh
+++ b/test/scripts/e2e_subs/htlc-teal-test.sh
@@ -46,8 +46,9 @@ ${gcmd} clerk send --fee=1000 --from-program ${TEMPDIR}/atomic.teal -a=0 -t=${ZE
 
 # Check balance
 BALANCEB=$(${gcmd} account balance -a ${ACCOUNTB} | awk '{ print $1 }')
-if [ $BALANCEB -ne 9999000 ]; then
-    date "+htlc-teal-test FAIL wanted balance=9999000 but got ${BALANCEB} %Y%m%d_%H%M%S"
+# Use >= 9999000 to account for rewards which may have accumulated
+if [ $BALANCEB -lt 9999000 ]; then
+    date "+htlc-teal-test FAIL wanted balance>=9999000 but got ${BALANCEB} %Y%m%d_%H%M%S"
     false
 fi
 


### PR DESCRIPTION
## Summary

Fix for flakey htlc test, which is comparing exact account balance. I believe sometimes rewards are applied, so it's off by a small amount. Fixed this by comparing to the minimum expected amount of algos.

Example of a failure: https://app.circleci.com/pipelines/github/algorand/go-algorand/18425/workflows/259ccdba-c6c1-4093-abd9-e0c59e22a0d3/jobs/272733

## Test Plan

Existing tests should pass