### PR TITLE
Tools: Fix Cloudflare SRV update utility after API change

### DIFF
--- a/tools/network/cloudflare/createRecord.go
+++ b/tools/network/cloudflare/createRecord.go
@@ -38,11 +38,9 @@ type createDNSRecord struct {
 // https://community.cloudflare.com/t/cloudflare-api-v4-srv-dns-creation-failure-in-php/25677/7
 type createSRVRecord struct {
 	Type string `json:"type"`
+	Name string `json:"name"`
 	Data struct {
-		Name     string `json:"name"`
 		TTL      uint   `json:"ttl"`
-		Service  string `json:"service"`
-		Proto    string `json:"proto"`
 		Weight   uint   `json:"weight"`
 		Port     uint   `json:"port"`
 		Priority uint   `json:"priority"`
@@ -90,10 +88,8 @@ func createSRVRecordRequest(zoneID string, authToken string, name string, servic
 	requestJSON := createSRVRecord{
 		Type: "SRV",
 	}
-	requestJSON.Data.Name = name
+	requestJSON.Name = service + "." + protocol + "." + name
 	requestJSON.Data.TTL = ttl
-	requestJSON.Data.Service = service
-	requestJSON.Data.Proto = protocol
 	requestJSON.Data.Weight = weight
 	requestJSON.Data.Port = port
 	requestJSON.Data.Priority = priority

--- a/tools/network/cloudflare/updateRecord.go
+++ b/tools/network/cloudflare/updateRecord.go
@@ -63,11 +63,9 @@ func updateSRVRecordRequest(zoneID string, authToken string, recordID string, na
 
 	requestJSON := createSRVRecord{
 		Type: "SRV",
+		Name: fmt.Sprintf("%s.%s.%s", service, protocol, name),
 	}
-	requestJSON.Data.Name = name
 	requestJSON.Data.TTL = ttl
-	requestJSON.Data.Service = service
-	requestJSON.Data.Proto = protocol
 	requestJSON.Data.Weight = weight
 	requestJSON.Data.Port = port
 	requestJSON.Data.Priority = priority


### PR DESCRIPTION
## Summary

Cloudflare deprecated a few data fields on SRV records, relying on a name field incorporating them. This PR updates the Cloudflare library utility to remove the deprecated data fields and add a Name field. See also:

https://developers.cloudflare.com/fundamentals/api/reference/deprecations/#name-related-data-fields-on-srv-dns-records

## Test Plan

Tested using internal tooling to verify functionality.

