### PR TITLE
build: add universal Mac make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,11 +168,11 @@ universal:
 ifeq ($(OS_TYPE),darwin)
 	# build amd64 Mac binaries
 	mkdir -p $(GOPATH1)/bin-darwin-amd64
-	CROSS_COMPILE_ARCH=amd64 GOBIN=$(GOPATH1)/bin-darwin-amd64 EXTRA_CONFIGURE_FLAGS='CFLAGS="-arch x86_64" --host=x86_64-apple-darwin' $(MAKE)
+	CROSS_COMPILE_ARCH=amd64 GOBIN=$(GOPATH1)/bin-darwin-amd64 MACOSX_DEPLOYMENT_TARGET=12.0 EXTRA_CONFIGURE_FLAGS='CFLAGS="-arch x86_64 -mmacos-version-min=12.0" --host=x86_64-apple-darwin' $(MAKE)
 
 	# build arm64 Mac binaries
 	mkdir -p $(GOPATH1)/bin-darwin-arm64
-	CROSS_COMPILE_ARCH=arm64 GOBIN=$(GOPATH1)/bin-darwin-arm64 EXTRA_CONFIGURE_FLAGS='CFLAGS="-arch arm64" --host=aarch64-apple-darwin' $(MAKE)
+	CROSS_COMPILE_ARCH=arm64 GOBIN=$(GOPATH1)/bin-darwin-arm64 MACOSX_DEPLOYMENT_TARGET=12.0 EXTRA_CONFIGURE_FLAGS='CFLAGS="-arch arm64 -mmacos-version-min=12.0" --host=aarch64-apple-darwin' $(MAKE)
 
 	# lipo together
 	mkdir -p $(GOPATH1)/bin-darwin-universal


### PR DESCRIPTION
## Summary

This adds a new `universal` build target that builds two libsodium libraries, runs the `make build` target for two architectures, and then uses lipo to merge the binaries for amd64 and arm64 together.

## Test Plan

Not sure what is next, or how this would integrate into the release process. The universal binaries are roughly twice the size, but if that's a problem, the build target produces 3 bin directories (bin-darwin-amd64, bin-darwin-arm64, bin-darwin-universal) allowing for different release options.