### PR TITLE
tests: fix TestVotersReloadFromDiskAfterOneStateProofCommitted

### DIFF
--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -547,6 +547,8 @@ func (tr *trackerRegistry) commitRound(dcc *deferredCommitContext) error {
 	offset := dcc.offset
 	dbRound := dcc.oldBase
 
+	tr.log.Debugf("commitRound called for (%d-%d)", dbRound, dbRound+basics.Round(offset))
+
 	// we can exit right away, as this is the result of mis-ordered call to committedUpTo.
 	if tr.dbRound < dbRound || offset < uint64(tr.dbRound-dbRound) {
 		tr.log.Warnf("out of order deferred commit: offset %d, dbRound %d but current tracker DB round is %d", offset, dbRound, tr.dbRound)
@@ -574,6 +576,7 @@ func (tr *trackerRegistry) commitRound(dcc *deferredCommitContext) error {
 	dcc.offset = offset
 	dcc.oldBase = dbRound
 	dcc.flushTime = time.Now()
+	tr.log.Debugf("commitRound advancing tracker db snapshot (%d-%d)", dbRound, dbRound+basics.Round(offset))
 
 	var err error
 	for _, lt := range tr.trackers {

--- a/ledger/tracker_test.go
+++ b/ledger/tracker_test.go
@@ -259,7 +259,7 @@ func (st *commitRoundStallingTracker) commitRound(context.Context, trackerdb.Tra
 // 3. Set a block in prepareCommit, and initiate the commit
 // 4. Set a block in produceCommittingTask, add a new block and resume the commit
 // 5. Resume produceCommittingTask
-// 6. The data race and panic happens in block queue syncher thread
+// 6. The data race and panic happens in block queue syncer thread
 func TestTrackers_DbRoundDataRace(t *testing.T) {
 	partitiontest.PartitionTest(t)
 


### PR DESCRIPTION
## Summary

`TestVotersReloadFromDiskAfterOneStateProofCommitted` had two issues:
1. Deadlock when assertion failed with lock taken, this prevented ledger to close. Fixed by scoping `Lock()` and `defer Unlock()`
2. Two parallel commit scheduling and handling (one is a normal via `newBlock` + `commitSyncer` and a manual one via `triggerDeleteVoters`) led to the `unable to advance tracker db snapshot (775-778): UNIQUE constraint failed: onlineroundparamstail.rnd` error when two `commitRound` are called concurrently. Usually `commitRound` tolerates such issues by adjusting the commit ranges on retries, but if there is no new blocks or manual sync it is never re-attempted so that committing machinery does not advance voters so the test expectation fail (that lead to the deadlock from (1)).

## Test Plan

To reproduce in 1-2m
```
until go test ./ledger -run TestVotersReloadFromDiskAfterOneStateProofCommitted/test_with_lru_cache -v -count=1 | tee tst.log | grep UNIQUE; do ; done
```

After the fix the issue was not reproduced in 10m
