### PR TITLE
AVM: Expose relevant incentive constants

### DIFF
--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -643,11 +643,12 @@ func lines(s string, num int) (bool, string) {
 }
 
 func summarize(trace *strings.Builder) string {
-	truncated, msg := lines(trace.String(), 50)
-	if !truncated {
-		return msg
+	all := trace.String()
+	if strings.Count(all, "\n") < 50 {
+		return all
 	}
-	return msg + "(trace truncated)\n"
+	lines := strings.Split(trace.String(), "\n")
+	return strings.Join(lines[:20], "\n") + "\n(some trace elided)\n" + strings.Join(lines[len(lines)-20:], "\n")
 }
 
 func testProg(t testing.TB, source string, ver uint64, expected ...expect) *OpStream {
@@ -1713,6 +1714,11 @@ pushint 1
 block BlkFeesCollected
 pushint 1
 block BlkBonus
+global PayoutsEnabled
+global PayoutsGoOnlineFee
+global PayoutsPercent
+global PayoutsMinBalance
+global PayoutsMaxBalance
 `, AssemblerMaxVersion)
 	for _, names := range [][]string{GlobalFieldNames[:], TxnFieldNames[:], blockFieldNames[:]} {
 		for _, f := range names {

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -626,28 +626,12 @@ func assembleWithTrace(text string, ver uint64) (*OpStream, error) {
 	return &ops, err
 }
 
-func lines(s string, num int) (bool, string) {
-	if num < 1 {
-		return true, ""
-	}
-	found := 0
-	for i := 0; i < len(s); i++ {
-		if s[i] == '\n' {
-			found++
-			if found == num {
-				return true, s[0 : i+1]
-			}
-		}
-	}
-	return false, s
-}
-
 func summarize(trace *strings.Builder) string {
 	all := trace.String()
 	if strings.Count(all, "\n") < 50 {
 		return all
 	}
-	lines := strings.Split(trace.String(), "\n")
+	lines := strings.Split(all, "\n")
 	return strings.Join(lines[:20], "\n") + "\n(some trace elided)\n" + strings.Join(lines[len(lines)-20:], "\n")
 }
 

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -3732,6 +3732,16 @@ func (cx *EvalContext) globalFieldToValue(fs globalFieldSpec) (sv stackValue, er
 	case GenesisHash:
 		gh := cx.SigLedger.GenesisHash()
 		sv.Bytes = gh[:]
+	case PayoutsEnabled:
+		sv.Uint = boolToUint(cx.Proto.Payouts.Enabled)
+	case PayoutsGoOnlineFee:
+		sv.Uint = cx.Proto.Payouts.GoOnlineFee
+	case PayoutsPercent:
+		sv.Uint = cx.Proto.Payouts.Percent
+	case PayoutsMinBalance:
+		sv.Uint = cx.Proto.Payouts.MinBalance
+	case PayoutsMaxBalance:
+		sv.Uint = cx.Proto.Payouts.MaxBalance
 	default:
 		return sv, fmt.Errorf("invalid global field %s", fs.field)
 	}

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -125,6 +125,14 @@ func makeTestProto(opts ...protoOpt) *config.ConsensusParams {
 
 		MaxBoxSize:           1000,
 		BytesPerBoxReference: 100,
+
+		Payouts: config.ProposerPayoutRules{
+			Enabled:     true,
+			GoOnlineFee: 3,
+			Percent:     4,
+			MinBalance:  5,
+			MaxBalance:  6,
+		},
 	}
 	for _, opt := range opts {
 		if opt != nil { // so some callsites can take one arg and pass it in
@@ -1236,7 +1244,11 @@ global GenesisHash; len; int 32; ==; &&
 `
 
 const globalV11TestProgram = globalV10TestProgram + `
-// No new globals in v11
+global PayoutsEnabled; assert
+global PayoutsGoOnlineFee; int 3; ==; assert
+global PayoutsPercent; int 4; ==; assert
+global PayoutsMinBalance; int 5; ==; assert
+global PayoutsMaxBalance; int 6; ==; assert
 `
 
 func TestGlobal(t *testing.T) {
@@ -1260,7 +1272,7 @@ func TestGlobal(t *testing.T) {
 		8:  {CallerApplicationAddress, globalV8TestProgram},
 		9:  {CallerApplicationAddress, globalV9TestProgram},
 		10: {GenesisHash, globalV10TestProgram},
-		11: {GenesisHash, globalV11TestProgram},
+		11: {PayoutsMaxBalance, globalV11TestProgram},
 	}
 	// tests keys are versions so they must be in a range 1..AssemblerMaxVersion plus zero version
 	require.LessOrEqual(t, len(tests), AssemblerMaxVersion+1)

--- a/data/transactions/logic/fields.go
+++ b/data/transactions/logic/fields.go
@@ -550,7 +550,7 @@ const (
 	// PayoutsMinBalance is the minimum algo balance an account must have to receive block payouts (in the agreement round).
 	PayoutsMinBalance
 
-	// PayoutsMaxBalance is the minimum algo balance an account must have to receive block payouts (in the agreement round).
+	// PayoutsMaxBalance is the maximum algo balance an account can have to receive block payouts (in the agreement round).
 	PayoutsMaxBalance
 
 	invalidGlobalField // compile-time constant for number of fields
@@ -628,7 +628,7 @@ var globalFieldSpecs = [...]globalFieldSpec{
 	{PayoutsMinBalance, StackUint64, modeAny, incentiveVersion,
 		"The minimum algo balance an account must have in the agreement round to receive block payouts in the proposal round."},
 	{PayoutsMaxBalance, StackUint64, modeAny, incentiveVersion,
-		"The minimum algo balance an account must have in the agreement round to receive block payouts in the proposal round."},
+		"The maximum algo balance an account can have in the agreement round to receive block payouts in the proposal round."},
 }
 
 func globalFieldSpecByField(f GlobalField) (globalFieldSpec, bool) {

--- a/data/transactions/logic/fields.go
+++ b/data/transactions/logic/fields.go
@@ -538,6 +538,21 @@ const (
 	// GenesisHash is the genesis hash for the network
 	GenesisHash
 
+	// PayoutsEnabled is whether block proposal payouts are enabled
+	PayoutsEnabled
+
+	// PayoutsGoOnlineFee is the fee required in a keyreg transaction to make an account incentive eligible
+	PayoutsGoOnlineFee
+
+	// PayoutsPercent is the percentage of transaction fees in a block that can be paid to the block proposer.
+	PayoutsPercent
+
+	// PayoutsMinBalance is the minimum algo balance an account must have to receive block payouts (in the agreement round).
+	PayoutsMinBalance
+
+	// PayoutsMaxBalance is the minimum algo balance an account must have to receive block payouts (in the agreement round).
+	PayoutsMaxBalance
+
 	invalidGlobalField // compile-time constant for number of fields
 )
 
@@ -603,6 +618,17 @@ var globalFieldSpecs = [...]globalFieldSpec{
 	{AssetOptInMinBalance, StackUint64, modeAny, 10,
 		"The additional minimum balance required to opt-in to an asset."},
 	{GenesisHash, StackBytes32, modeAny, 10, "The Genesis Hash for the network."},
+
+	{PayoutsEnabled, StackBoolean, modeAny, incentiveVersion,
+		"Whether block proposal payouts are enabled."},
+	{PayoutsGoOnlineFee, StackUint64, modeAny, incentiveVersion,
+		"The fee required in a keyreg transaction to make an account incentive eligible."},
+	{PayoutsPercent, StackUint64, modeAny, incentiveVersion,
+		"The percentage of transaction fees in a block that can be paid to the block proposer."},
+	{PayoutsMinBalance, StackUint64, modeAny, incentiveVersion,
+		"The minimum algo balance an account must have in the agreement round to receive block payouts in the proposal round."},
+	{PayoutsMaxBalance, StackUint64, modeAny, incentiveVersion,
+		"The minimum algo balance an account must have in the agreement round to receive block payouts in the proposal round."},
 }
 
 func globalFieldSpecByField(f GlobalField) (globalFieldSpec, bool) {

--- a/data/transactions/logic/fields_string.go
+++ b/data/transactions/logic/fields_string.go
@@ -111,12 +111,17 @@ func _() {
 	_ = x[AssetCreateMinBalance-15]
 	_ = x[AssetOptInMinBalance-16]
 	_ = x[GenesisHash-17]
-	_ = x[invalidGlobalField-18]
+	_ = x[PayoutsEnabled-18]
+	_ = x[PayoutsGoOnlineFee-19]
+	_ = x[PayoutsPercent-20]
+	_ = x[PayoutsMinBalance-21]
+	_ = x[PayoutsMaxBalance-22]
+	_ = x[invalidGlobalField-23]
 }
 
-const _GlobalField_name = "MinTxnFeeMinBalanceMaxTxnLifeZeroAddressGroupSizeLogicSigVersionRoundLatestTimestampCurrentApplicationIDCreatorAddressCurrentApplicationAddressGroupIDOpcodeBudgetCallerApplicationIDCallerApplicationAddressAssetCreateMinBalanceAssetOptInMinBalanceGenesisHashinvalidGlobalField"
+const _GlobalField_name = "MinTxnFeeMinBalanceMaxTxnLifeZeroAddressGroupSizeLogicSigVersionRoundLatestTimestampCurrentApplicationIDCreatorAddressCurrentApplicationAddressGroupIDOpcodeBudgetCallerApplicationIDCallerApplicationAddressAssetCreateMinBalanceAssetOptInMinBalanceGenesisHashPayoutsEnabledPayoutsGoOnlineFeePayoutsPercentPayoutsMinBalancePayoutsMaxBalanceinvalidGlobalField"
 
-var _GlobalField_index = [...]uint16{0, 9, 19, 29, 40, 49, 64, 69, 84, 104, 118, 143, 150, 162, 181, 205, 226, 246, 257, 275}
+var _GlobalField_index = [...]uint16{0, 9, 19, 29, 40, 49, 64, 69, 84, 104, 118, 143, 150, 162, 181, 205, 226, 246, 257, 271, 289, 303, 320, 337, 355}
 
 func (i GlobalField) String() string {
 	if i >= GlobalField(len(_GlobalField_index)-1) {


### PR DESCRIPTION
Create global constants for some of the protocol constants introduced with the block incentive mechanism.

Resolves https://github.com/algorand/go-algorand/issues/5998