### PR TITLE
tests: debug output on LibGoalFixture failure

### DIFF
--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -144,20 +144,23 @@ func (f *LibGoalFixture) nodeExitWithError(nc *nodecontrol.NodeController, err e
 		return
 	}
 
-	defer func() {
+	debugLog := func() {
 		f.t.Logf("Node at %s has terminated with an error: %v. Dumping logs...", nc.GetDataDir(), err)
 		f.dumpLogs(filepath.Join(nc.GetDataDir(), "node.log"))
-	}()
+	}
 
 	exitError, ok := err.(*exec.ExitError)
 	if !ok {
-		require.NoError(f.t, err, "Node at %s has terminated with an error", nc.GetDataDir())
+		debugLog()
+		require.NoError(f.t, err)
 		return
 	}
 	ws := exitError.Sys().(syscall.WaitStatus)
 	exitCode := ws.ExitStatus()
 
-	require.NoError(f.t, err, "Node at %s has terminated with error code %d", nc.GetDataDir(), exitCode)
+	f.t.Logf("Node at %s has terminated with error code %d (%v)", nc.GetDataDir(), exitCode, *exitError)
+	debugLog()
+	require.NoError(f.t, err)
 }
 
 func (f *LibGoalFixture) importRootKeys(lg *libgoal.Client, dataDir string) {


### PR DESCRIPTION
## Summary

LibGoalFixture sometimes [detects](https://circleci.com/api/v1.1/project/github/algorand/go-algorand/273140/output/114/3?file=true&allocation-id=6667a362d7abf560ca960194-3-build%2FABCDEFGH) node termination error but it panics since test assert is called after test's main goroutine termination:

```
panic: Fail in goroutine after TestCatchupOverGossip/ledger=,fetcher=2.1 has completed
```

So that we observe this panic message instead an actual debug output with error code and node.log content. This PR changes the sequence - log all available info first and only then assert and fail.

## Test Plan

This is a test harness change.