### PR TITLE
eval: takeFee and checkMinBalance after full group evaluation

### DIFF
--- a/data/pools/transactionPool_test.go
+++ b/data/pools/transactionPool_test.go
@@ -297,10 +297,10 @@ func TestSenderGoesBelowMinBalanceDueToAssets(t *testing.T) {
 	signedTx := tx.Sign(secrets[0])
 	err := transactionPool.RememberOne(signedTx)
 	require.Error(t, err)
-	var returnedTxid, returnedAcct string
+	var returnedAcct string
 	var returnedBal, returnedMin, numAssets uint64
-	_, err = fmt.Sscanf(err.Error(), "TransactionPool.Remember: transaction %s account %s balance %d below min %d (%d assets)",
-		&returnedTxid, &returnedAcct, &returnedBal, &returnedMin, &numAssets)
+	_, err = fmt.Sscanf(err.Error(), "TransactionPool.Remember: account %s balance %d below min %d (%d assets)",
+		&returnedAcct, &returnedBal, &returnedMin, &numAssets)
 	require.NoError(t, err)
 	require.Equal(t, (1+numAssets)*proto.MinBalance, returnedMin)
 }

--- a/ledger/eval/eval.go
+++ b/ledger/eval/eval.go
@@ -1045,7 +1045,7 @@ func (eval *BlockEvaluator) TransactionGroup(txgroup []transactions.SignedTxnWit
 			eval.Tracer.BeforeTxn(evalParams, gi)
 		}
 
-		err := eval.transaction(txad.SignedTxn, evalParams, gi, txad.ApplyData, cow, &txib)
+		err = eval.transaction(txad.SignedTxn, evalParams, gi, txad.ApplyData, cow, &txib)
 
 		if eval.Tracer != nil {
 			eval.Tracer.AfterTxn(evalParams, gi, txib.ApplyData, err)
@@ -1103,7 +1103,7 @@ func (eval *BlockEvaluator) TransactionGroup(txgroup []transactions.SignedTxnWit
 	// if we cannot provide account data that contains enough information to
 	// compute the correct minimum balance (the case with indexer which does not store it).
 	if eval.validate || eval.generate {
-		err := eval.checkMinBalance(cow)
+		err = eval.checkMinBalance(cow)
 		if err != nil {
 			return err
 		}

--- a/ledger/eval/eval.go
+++ b/ledger/eval/eval.go
@@ -1110,7 +1110,8 @@ func (eval *BlockEvaluator) TransactionGroup(txgroup []transactions.SignedTxnWit
 	}
 
 	// Take the fees from each txn except for closed accounts, which already had the fee taken
-	for _, txad := range txgroup {
+	for i := range txgroup {
+		txad := txgroup[i]
 		if txad.Txn.CloseRemainderTo.IsZero() {
 			err = cow.takeFee(&txad.Txn, &txad.SenderRewards, evalParams)
 			if err != nil {


### PR DESCRIPTION
## Summary

This is a draft PR to propose the idea of taking tx fees and calculating min balances *after* group evaluation, rather than during the evaluation of each individual transaction. The exception is close payments, which require the fee to be taken before the account is closed. 

This is particularly useful for two scenarios

1. A 0-ALGO account can call an app and that app can "cover" the fees + MBR via an inner payment back to the caller in one outer txn.
2. Creating boxes during app creation (outers only and there might be more details that I'm missing here that would still block this)

In actual implementation this should be put behind a new consensus version.

## Test Plan

As a draft, just make sure existing tests don't break. Then will test the two scenarios above.
