### PR TITLE
p2p: convert additional Multiplexer method to use generic implementation

### DIFF
--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -248,7 +248,7 @@ func (handler *TxHandler) Start() {
 		{
 			Tag: protocol.TxnTag,
 			// create anonymous struct to hold the two functions and satisfy the network.MessageProcessor interface
-			MessageProcessor: struct {
+			MessageHandler: struct {
 				network.ProcessorValidateFunc
 				network.ProcessorHandleFunc
 			}{

--- a/network/gossipNode.go
+++ b/network/gossipNode.go
@@ -239,18 +239,17 @@ func (f ProcessorHandleFunc) Handle(message ValidatedMessage) OutgoingMessage {
 	return f(message)
 }
 
-// TaggedMessageHandler receives one type of broadcast messages
-type TaggedMessageHandler struct {
+type taggedMessageDispatcher[T any] struct {
 	Tag
-	MessageHandler
+	Dispatcher T
 }
+
+// TaggedMessageHandler receives one type of broadcast messages
+type TaggedMessageHandler = taggedMessageDispatcher[MessageHandler]
 
 // TaggedMessageProcessor receives one type of broadcast messages
 // and performs two stage processing: validating and handling
-type TaggedMessageProcessor struct {
-	Tag
-	MessageProcessor
-}
+type TaggedMessageProcessor = taggedMessageDispatcher[MessageProcessor]
 
 // Propagate is a convenience function to save typing in the common case of a message handler telling us to propagate an incoming message
 // "return network.Propagate(msg)" instead of "return network.OutgoingMsg{network.Broadcast, msg.Tag, msg.Data}"

--- a/network/gossipNode.go
+++ b/network/gossipNode.go
@@ -241,7 +241,7 @@ func (f ProcessorHandleFunc) Handle(message ValidatedMessage) OutgoingMessage {
 
 type taggedMessageDispatcher[T any] struct {
 	Tag
-	Dispatcher T
+	MessageHandler T
 }
 
 // TaggedMessageHandler receives one type of broadcast messages

--- a/network/multiplexer.go
+++ b/network/multiplexer.go
@@ -45,16 +45,6 @@ func getMap[T any](source *atomic.Value) map[Tag]T {
 	return nil
 }
 
-// getHandlersMap retrieves the handlers map.
-func (m *Multiplexer) getHandlersMap() map[Tag]MessageHandler {
-	return getMap[MessageHandler](&m.msgHandlers)
-}
-
-// getProcessorsMap retrieves the processors map.
-func (m *Multiplexer) getProcessorsMap() map[Tag]MessageProcessor {
-	return getMap[MessageProcessor](&m.msgHandlers)
-}
-
 // Retrieves the handler for the given message Tag from the given value while.
 func getHandler[T any](source *atomic.Value, tag Tag) (T, bool) {
 	if handlers := getMap[T](source); handlers != nil {
@@ -77,38 +67,29 @@ func (m *Multiplexer) getProcessor(tag Tag) (MessageProcessor, bool) {
 
 // Handle is the "input" side of the multiplexer. It dispatches the message to the previously defined handler.
 func (m *Multiplexer) Handle(msg IncomingMessage) OutgoingMessage {
-	handler, ok := m.getHandler(msg.Tag)
-
-	if ok {
-		outmsg := handler.Handle(msg)
-		return outmsg
+	if handler, ok := m.getHandler(msg.Tag); ok {
+		return handler.Handle(msg)
 	}
 	return OutgoingMessage{}
 }
 
 // Validate is an alternative "input" side of the multiplexer. It dispatches the message to the previously defined validator.
 func (m *Multiplexer) Validate(msg IncomingMessage) ValidatedMessage {
-	handler, ok := m.getProcessor(msg.Tag)
-
-	if ok {
-		outmsg := handler.Validate(msg)
-		return outmsg
+	if handler, ok := m.getProcessor(msg.Tag); ok {
+		return handler.Validate(msg)
 	}
 	return ValidatedMessage{}
 }
 
 // Process is the second step of message handling after validation. It dispatches the message to the previously defined processor.
 func (m *Multiplexer) Process(msg ValidatedMessage) OutgoingMessage {
-	handler, ok := m.getProcessor(msg.Tag)
-
-	if ok {
-		outmsg := handler.Handle(msg)
-		return outmsg
+	if handler, ok := m.getProcessor(msg.Tag); ok {
+		return handler.Handle(msg)
 	}
 	return OutgoingMessage{}
 }
 
-func register[T any](target *atomic.Value, dispatch []taggedMessageDispatcher[T]) {
+func registerMultiplexer[T any](target *atomic.Value, dispatch []taggedMessageDispatcher[T]) {
 	mp := make(map[Tag]T)
 	if existingMap := getMap[T](target); existingMap != nil {
 		for k, v := range existingMap {
@@ -119,22 +100,22 @@ func register[T any](target *atomic.Value, dispatch []taggedMessageDispatcher[T]
 		if _, has := mp[v.Tag]; has {
 			panic(fmt.Sprintf("Already registered a handler for tag %v", v.Tag))
 		}
-		mp[v.Tag] = v.Dispatcher
+		mp[v.Tag] = v.MessageHandler
 	}
 	target.Store(mp)
 }
 
 // RegisterHandlers registers the set of given message handlers.
 func (m *Multiplexer) RegisterHandlers(dispatch []TaggedMessageHandler) {
-	register[MessageHandler](&m.msgHandlers, dispatch)
+	registerMultiplexer(&m.msgHandlers, dispatch)
 }
 
 // RegisterProcessors registers the set of given message handlers.
 func (m *Multiplexer) RegisterProcessors(dispatch []TaggedMessageProcessor) {
-	register[MessageProcessor](&m.msgProcessors, dispatch)
+	registerMultiplexer(&m.msgProcessors, dispatch)
 }
 
-func clear[T any](target *atomic.Value, excludeTags []Tag) {
+func clearMultiplexer[T any](target *atomic.Value, excludeTags []Tag) {
 	if len(excludeTags) == 0 {
 		target.Store(make(map[Tag]T))
 		return
@@ -159,10 +140,10 @@ func clear[T any](target *atomic.Value, excludeTags []Tag) {
 
 // ClearHandlers deregisters all the existing message handlers other than the one provided in the excludeTags list
 func (m *Multiplexer) ClearHandlers(excludeTags []Tag) {
-	clear[MessageHandler](&m.msgHandlers, excludeTags)
+	clearMultiplexer[MessageHandler](&m.msgHandlers, excludeTags)
 }
 
 // ClearProcessors deregisters all the existing message handlers other than the one provided in the excludeTags list
 func (m *Multiplexer) ClearProcessors(excludeTags []Tag) {
-	clear[MessageProcessor](&m.msgProcessors, excludeTags)
+	clearMultiplexer[MessageProcessor](&m.msgProcessors, excludeTags)
 }

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -103,7 +103,7 @@ func TestP2PSubmitTX(t *testing.T) {
 	passThroughHandler := []TaggedMessageProcessor{
 		{
 			Tag: protocol.TxnTag,
-			MessageProcessor: struct {
+			MessageHandler: struct {
 				ProcessorValidateFunc
 				ProcessorHandleFunc
 			}{
@@ -195,7 +195,7 @@ func TestP2PSubmitTXNoGossip(t *testing.T) {
 	passThroughHandler := []TaggedMessageProcessor{
 		{
 			Tag: protocol.TxnTag,
-			MessageProcessor: struct {
+			MessageHandler: struct {
 				ProcessorValidateFunc
 				ProcessorHandleFunc
 			}{
@@ -835,7 +835,7 @@ func TestP2PRelay(t *testing.T) {
 		counterHandler := []TaggedMessageProcessor{
 			{
 				Tag: protocol.TxnTag,
-				MessageProcessor: struct {
+				MessageHandler: struct {
 					ProcessorValidateFunc
 					ProcessorHandleFunc
 				}{

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -829,8 +829,8 @@ func TestP2PRelay(t *testing.T) {
 		return netA.hasPeers() && netB.hasPeers()
 	}, 2*time.Second, 50*time.Millisecond)
 
-	makeCounterHandler := func(numExpected int) ([]TaggedMessageProcessor, *int, chan struct{}) {
-		numActual := 0
+	makeCounterHandler := func(numExpected int) ([]TaggedMessageProcessor, *atomic.Uint32, chan struct{}) {
+		var numActual atomic.Uint32
 		counterDone := make(chan struct{})
 		counterHandler := []TaggedMessageProcessor{
 			{
@@ -843,8 +843,7 @@ func TestP2PRelay(t *testing.T) {
 						return ValidatedMessage{Action: Accept, Tag: msg.Tag, ValidatorData: nil}
 					}),
 					ProcessorHandleFunc(func(msg ValidatedMessage) OutgoingMessage {
-						numActual++
-						if numActual >= numExpected {
+						if count := numActual.Add(1); int(count) >= numExpected {
 							close(counterDone)
 						}
 						return OutgoingMessage{Action: Ignore}
@@ -916,10 +915,10 @@ func TestP2PRelay(t *testing.T) {
 	select {
 	case <-counterDone:
 	case <-time.After(2 * time.Second):
-		if *count < expectedMsgs {
-			require.Failf(t, "One or more messages failed to reach destination network", "%d > %d", expectedMsgs, *count)
-		} else if *count > expectedMsgs {
-			require.Failf(t, "One or more messages that were expected to be dropped, reached destination network", "%d < %d", expectedMsgs, *count)
+		if c := count.Load(); c < expectedMsgs {
+			require.Failf(t, "One or more messages failed to reach destination network", "%d > %d", expectedMsgs, c)
+		} else if c > expectedMsgs {
+			require.Failf(t, "One or more messages that were expected to be dropped, reached destination network", "%d < %d", expectedMsgs, c)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Based on review comment in https://github.com/algorand/go-algorand/pull/5939#discussion_r1643340427 a small tweak to multiplexer to deduplicate RegisterProcessors/RegisterHandlers with generic implementation, making everything generic in that file. Also changes name to avoid conflict with builtin `clear` function.

## Test Plan

Existing tests should pass.