### PR TITLE
CICD: remove mac AMD64 support from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,19 +45,6 @@ executors:
     machine:
       image: << pipeline.parameters.ubuntu_image >>
     resource_class: arm.large
-  mac_amd64_medium:
-    macos:
-      xcode: 14.2.0
-    resource_class: macos.x86.medium.gen2
-    environment:
-      HOMEBREW_NO_AUTO_UPDATE: "true"
-  mac_amd64_large:
-    macos:
-      xcode: 14.2.0
-    # Since they removed the large class for amd64, we will use medium here too.
-    resource_class: macos.x86.medium.gen2
-    environment:
-      HOMEBREW_NO_AUTO_UPDATE: "true"
   mac_arm64: &executor-mac-arm64
     machine: true
     resource_class: algorand/macstadium-m1
@@ -86,7 +73,7 @@ workflows:
           name: << matrix.platform >>_build_nightly
           matrix: &matrix-nightly
             parameters:
-              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
+              platform: ["amd64", "arm64", "mac_arm64"]
           filters: &filters-nightly
             branches:
               only:
@@ -137,7 +124,7 @@ workflows:
           name: << matrix.platform >>_<< matrix.job_type >>_verification
           matrix:
             parameters:
-              platform: ["amd64", "arm64", "mac_amd64", "mac_arm64"]
+              platform: ["amd64", "arm64", "mac_arm64"]
               job_type: ["test_nightly", "integration_nightly", "e2e_expect_nightly"]
           requires:
             - << matrix.platform >>_<< matrix.job_type >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,17 +45,18 @@ executors:
     machine:
       image: << pipeline.parameters.ubuntu_image >>
     resource_class: arm.large
-  mac_arm64: &executor-mac-arm64
-    machine: true
-    resource_class: algorand/macstadium-m1
+  mac_arm64_medium:
+    macos:
+      xcode: 14.2.0
+    resource_class: macos.m1.medium.gen1
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "true"
-  # these are required b/c jobs explicitly assign sizes to the executors
-  # for `mac_arm64` there is only one size
-  mac_arm64_medium:
-    <<: *executor-mac-arm64
   mac_arm64_large:
-    <<: *executor-mac-arm64
+    macos:
+      xcode: 14.2.0
+    resource_class: macos.m1.large.gen1
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: "true"
 
 slack-fail-stop-step: &slack-fail-post-step
   post-steps:


### PR DESCRIPTION
## Summary

As per [CircleCI's announced deprecation](https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718) the Mac AMD64 resource class is being deprecated. As a result we should disable these tests.

This PR also switches to using CircleCI's mac resources, instead of a self-hosted runner.

There is a larger question of how much support we should provide to Intel architecture in general. The last Intel mac was discontinued a year ago. A universal build like in #6023 would obviate the need for AMD64 build platforms and dealing with XCode deprecations, but would lead to insecurity about validity of tests.

## Test Plan

Force nightly tests to execute against this branch.

*Note:* the test failure is from running the nightly execution, and the failure is unrelated to this change. It can be ignored.
