### PR TITLE
catchup: do not loop forever if there is no peers

### DIFF
--- a/catchup/service.go
+++ b/catchup/service.go
@@ -760,6 +760,13 @@ func (s *Service) fetchRound(cert agreement.Certificate, verifier *agreement.Asy
 		psp, getPeerErr := ps.getNextPeer()
 		if getPeerErr != nil {
 			s.log.Debugf("fetchRound: was unable to obtain a peer to retrieve the block from")
+			select {
+			case <-s.ctx.Done():
+				logging.Base().Debugf("fetchRound was asked to quit while collecting peers")
+				return
+			default:
+			}
+
 			s.net.RequestConnectOutgoing(true, s.ctx.Done())
 			continue
 		}

--- a/test/e2e-go/features/catchup/basicCatchup_test.go
+++ b/test/e2e-go/features/catchup/basicCatchup_test.go
@@ -128,15 +128,6 @@ func runCatchupOverGossip(t fixtures.TestingTB,
 		a.NoError(err)
 		a.Empty(cfg.NetworkProtocolVersion)
 		cfg.NetworkProtocolVersion = ledgerNodeDowngradeTo
-		cfg.BaseLoggerDebugLevel = 5 // debug logging while debugging this test
-		cfg.SaveToDisk(dir)
-	} else {
-		// TODO: remove when TestCatchupOverGossip is fixed
-		dir, err := fixture.GetNodeDir("Node")
-		a.NoError(err)
-		cfg, err := config.LoadConfigFromDisk(dir)
-		a.NoError(err)
-		cfg.BaseLoggerDebugLevel = 5 // debug logging while debugging this test
 		cfg.SaveToDisk(dir)
 	}
 
@@ -147,14 +138,6 @@ func runCatchupOverGossip(t fixtures.TestingTB,
 		a.NoError(err)
 		a.Empty(cfg.NetworkProtocolVersion)
 		cfg.NetworkProtocolVersion = fetcherNodeDowngradeTo
-		cfg.BaseLoggerDebugLevel = 5 // debug logging while debugging this test
-		cfg.SaveToDisk(dir)
-	} else {
-		// TODO: remove when TestCatchupOverGossip is fixed
-		dir := fixture.PrimaryDataDir()
-		cfg, err := config.LoadConfigFromDisk(dir)
-		a.NoError(err)
-		cfg.BaseLoggerDebugLevel = 5 // debug logging while debugging this test
 		cfg.SaveToDisk(dir)
 	}
 


### PR DESCRIPTION
## Summary

* Add context cancellation check to fetchRound peers retrieval loop
* This prevented some e2e tests to finish when a other nodes quit but the last node fell into catchup mode
* Revert debug logging in `TestCatchupOverGossip` from https://github.com/algorand/go-algorand/pull/6030

Diagnosed with debug logging in `TestCatchupOverGossip`: catchup service attempted to stop but never finished while keep logging entries below until it got killed.
```json
{
  "Context": "sync",
  "file": "service.go",
  "function": "github.com/algorand/go-algorand/catchup.(*Service).fetchRound",
  "level": "debug",
  "line": 762,
  "msg": "fetchRound: was unable to obtain a peer to retrieve the block from",
  "name": "127.0.0.1:0",
  "time": "2024-06-20T01:23:49.586961Z"
}
```

## Test Plan

Existing tests