### PR TITLE
p2p feature PR: CR fixes

### DIFF
--- a/agreement/fuzzer/networkFacade_test.go
+++ b/agreement/fuzzer/networkFacade_test.go
@@ -348,7 +348,7 @@ func (n *NetworkFacade) ReceiveMessage(sourceNode int, tag protocol.Tag, data []
 	n.pushPendingReceivedMessage()
 }
 
-func (n *NetworkFacade) Disconnect(sender network.DisconnectablePeer) {
+func (n *NetworkFacade) Disconnect(sender network.DeadlineSettableConn) {
 	sourceNode := n.peerToNode[sender.(*facadePeer)]
 	n.fuzzer.Disconnect(n.nodeID, sourceNode)
 }

--- a/agreement/gossip/network_test.go
+++ b/agreement/gossip/network_test.go
@@ -135,7 +135,7 @@ func (w *whiteholeNetwork) Relay(ctx context.Context, tag protocol.Tag, data []b
 func (w *whiteholeNetwork) BroadcastSimple(tag protocol.Tag, data []byte) error {
 	return w.Broadcast(context.Background(), tag, data, true, nil)
 }
-func (w *whiteholeNetwork) Disconnect(badnode network.DisconnectablePeer) {
+func (w *whiteholeNetwork) Disconnect(badnode network.DeadlineSettableConn) {
 	return
 }
 func (w *whiteholeNetwork) DisconnectPeers() {

--- a/components/mocks/mockNetwork.go
+++ b/components/mocks/mockNetwork.go
@@ -60,7 +60,7 @@ func (network *MockNetwork) RequestConnectOutgoing(replace bool, quit <-chan str
 }
 
 // Disconnect - unused function
-func (network *MockNetwork) Disconnect(badpeer network.DisconnectablePeer) {
+func (network *MockNetwork) Disconnect(badpeer network.DeadlineSettableConn) {
 }
 
 // DisconnectPeers - unused function

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -603,8 +603,8 @@ type Local struct {
 	// EnableP2PHybridMode turns on both websockets and P2P networking.
 	EnableP2PHybridMode bool `version[34]:"false"`
 
-	// P2PListenAddress sets the listen address used for P2P networking, if hybrid mode is set.
-	P2PListenAddress string `version[34]:""`
+	// P2PNetAddress sets the listen address used for P2P networking, if hybrid mode is set.
+	P2PNetAddress string `version[34]:""`
 
 	// EnableDHT will turn on the hash table for use with capabilities advertisement
 	EnableDHTProviders bool `version[34]:"false"`

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -119,7 +119,7 @@ var defaultLocal = Local{
 	OptimizeAccountsDatabaseOnStartup:          false,
 	OutgoingMessageFilterBucketCount:           3,
 	OutgoingMessageFilterBucketSize:            128,
-	P2PListenAddress:                           "",
+	P2PNetAddress:                              "",
 	P2PPersistPeerID:                           false,
 	P2PPrivateKeyLocation:                      "",
 	ParticipationKeysRefreshInterval:           60000000000,

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -289,7 +289,7 @@ func (s *Server) Start() {
 	fmt.Print("Initializing the Algorand node... ")
 	err := s.node.Start()
 	if err != nil {
-		msg := fmt.Sprintf("Failed to start alg Algorand node: %v", err)
+		msg := fmt.Sprintf("Failed to start an Algorand node: %v", err)
 		s.log.Error(msg)
 		fmt.Println(msg)
 		os.Exit(1)

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -786,27 +786,27 @@ func (handler *TxHandler) validateIncomingTxMessage(rawmsg network.IncomingMessa
 
 	if shouldDrop {
 		// this TX message was found in the duplicate cache, or ERL rate-limited it
-		return network.ValidatedMessage{Action: network.Ignore, ValidatorData: nil}
+		return network.ValidatedMessage{Action: network.Ignore, ValidatedMessage: nil}
 	}
 
 	unverifiedTxGroup, consumed, invalid := decodeMsg(rawmsg.Data)
 	if invalid {
 		// invalid encoding or exceeding txgroup, disconnect from this peer
-		return network.ValidatedMessage{Action: network.Disconnect, ValidatorData: nil}
+		return network.ValidatedMessage{Action: network.Disconnect, ValidatedMessage: nil}
 	}
 
 	canonicalKey, drop := handler.incomingTxGroupDupRateLimit(unverifiedTxGroup, consumed, rawmsg.Sender)
 	if drop {
 		// this re-serialized txgroup was detected as a duplicate by the canonical message cache,
 		// or it was rate-limited by the per-app rate limiter
-		return network.ValidatedMessage{Action: network.Ignore, ValidatorData: nil}
+		return network.ValidatedMessage{Action: network.Ignore, ValidatedMessage: nil}
 	}
 
 	accepted = true
 	return network.ValidatedMessage{
 		Action: network.Accept,
 		Tag:    rawmsg.Tag,
-		ValidatorData: &validatedIncomingTxMessage{
+		ValidatedMessage: &validatedIncomingTxMessage{
 			rawmsg:            rawmsg,
 			unverifiedTxGroup: unverifiedTxGroup,
 			msgKey:            msgKey,
@@ -818,7 +818,7 @@ func (handler *TxHandler) validateIncomingTxMessage(rawmsg network.IncomingMessa
 
 // processIncomingTxMessage is the handler for the MessageProcessor implementation used by P2PNetwork.
 func (handler *TxHandler) processIncomingTxMessage(validatedMessage network.ValidatedMessage) network.OutgoingMessage {
-	msg := validatedMessage.ValidatorData.(*validatedIncomingTxMessage)
+	msg := validatedMessage.ValidatedMessage.(*validatedIncomingTxMessage)
 	select {
 	case handler.backlogQueue <- &txBacklogMsg{
 		rawmsg:                &msg.rawmsg,

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -240,10 +240,12 @@ func (handler *TxHandler) Start() {
 	if handler.msgCache != nil {
 		handler.msgCache.Start(handler.ctx, 60*time.Second)
 	}
+	// wsNetwork handler
 	handler.net.RegisterHandlers([]network.TaggedMessageHandler{
 		{Tag: protocol.TxnTag, MessageHandler: network.HandlerFunc(handler.processIncomingTxn)},
 	})
 
+	// libp2p pubsub validator and handler abstracted as TaggedMessageProcessor
 	handler.net.RegisterProcessors([]network.TaggedMessageProcessor{
 		{
 			Tag: protocol.TxnTag,

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -711,11 +711,9 @@ func (handler *TxHandler) processIncomingTxn(rawmsg network.IncomingMessage) net
 	accepted := false
 	defer func() {
 		// if we failed to put the item onto the backlog, we should release the capacity if any
-		if !accepted {
-			if capguard != nil {
-				if capErr := capguard.Release(); capErr != nil {
-					logging.Base().Warnf("processIncomingTxn: failed to release capacity to ElasticRateLimiter: %v", capErr)
-				}
+		if !accepted && capguard != nil {
+			if capErr := capguard.Release(); capErr != nil {
+				logging.Base().Warnf("processIncomingTxn: failed to release capacity to ElasticRateLimiter: %v", capErr)
 			}
 		}
 	}()
@@ -779,11 +777,9 @@ func (handler *TxHandler) validateIncomingTxMessage(rawmsg network.IncomingMessa
 	accepted := false
 	defer func() {
 		// if we failed to put the item onto the backlog, we should release the capacity if any
-		if !accepted {
-			if capguard != nil {
-				if capErr := capguard.Release(); capErr != nil {
-					logging.Base().Warnf("validateIncomingTxMessage: failed to release capacity to ElasticRateLimiter: %v", capErr)
-				}
+		if !accepted && capguard != nil {
+			if capErr := capguard.Release(); capErr != nil {
+				logging.Base().Warnf("validateIncomingTxMessage: failed to release capacity to ElasticRateLimiter: %v", capErr)
 			}
 		}
 	}()

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -597,7 +597,7 @@ func (handler *TxHandler) dedupCanonical(unverifiedTxGroup []transactions.Signed
 // - the key used for insertion if the message was not found in the cache
 // - the capacity guard returned by the elastic rate limiter
 // - a boolean indicating if the message was a duplicate or the sender is rate limited
-func (handler *TxHandler) incomingMsgDupErlCheck(data []byte, sender network.DisconnectablePeer) (*crypto.Digest, *util.ErlCapacityGuard, bool) {
+func (handler *TxHandler) incomingMsgDupErlCheck(data []byte, sender network.DeadlineSettableConn) (*crypto.Digest, *util.ErlCapacityGuard, bool) {
 	var msgKey *crypto.Digest
 	var capguard *util.ErlCapacityGuard
 	var isDup bool
@@ -681,7 +681,7 @@ func decodeMsg(data []byte) (unverifiedTxGroup []transactions.SignedTxn, consume
 // incomingTxGroupDupRateLimit checks
 // - if the incoming transaction group has been seen before after reencoding to canonical representation, and
 // - if the sender is rate limited by the per-application rate limiter.
-func (handler *TxHandler) incomingTxGroupDupRateLimit(unverifiedTxGroup []transactions.SignedTxn, encodedExpectedSize int, sender network.DisconnectablePeer) (*crypto.Digest, bool) {
+func (handler *TxHandler) incomingTxGroupDupRateLimit(unverifiedTxGroup []transactions.SignedTxn, encodedExpectedSize int, sender network.DeadlineSettableConn) (*crypto.Digest, bool) {
 	var canonicalKey *crypto.Digest
 	if handler.txCanonicalCache != nil {
 		var isDup bool

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -98,7 +98,7 @@
     "OptimizeAccountsDatabaseOnStartup": false,
     "OutgoingMessageFilterBucketCount": 3,
     "OutgoingMessageFilterBucketSize": 128,
-    "P2PListenAddress": "",
+    "P2PNetAddress": "",
     "P2PPersistPeerID": false,
     "P2PPrivateKeyLocation": "",
     "ParticipationKeysRefreshInterval": 60000000000,

--- a/logging/log.go
+++ b/logging/log.go
@@ -319,7 +319,7 @@ func (l logger) getOutput() io.Writer {
 }
 
 func (l logger) SetJSONFormatter() {
-	l.entry.Logger.Formatter = &logrus.JSONFormatter{TimestampFormat: "2006-01-02T15:04:05.000000Z07:00"}
+	l.entry.Logger.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02T15:04:05.000000Z07:00"})
 }
 
 func (l logger) Entry() *logrus.Entry {

--- a/netdeploy/remote/nodecfg/nodeDir.go
+++ b/netdeploy/remote/nodecfg/nodeDir.go
@@ -174,21 +174,21 @@ func (nd *nodeDir) configureP2PDNSBootstrap(p2pBootstrap bool) error {
 	}
 	// ensure p2p config params set are what is expected:
 	// - EnableP2P or EnableP2PHybridMode
-	// - NetAddress or P2PListenAddress is set
+	// - NetAddress or P2PNetAddress is set
 	// - EnableGossipService
 	if !nd.config.EnableP2P && !nd.config.EnableP2PHybridMode {
 		return errors.New("p2p bootstrap requires EnableP2P or EnableP2PHybridMode to be set")
 	}
-	if nd.NetAddress == "" && nd.config.P2PListenAddress == "" {
-		return errors.New("p2p bootstrap requires NetAddress or P2PListenAddress to be set")
+	if nd.NetAddress == "" && nd.config.P2PNetAddress == "" {
+		return errors.New("p2p bootstrap requires NetAddress or P2PNetAddress to be set")
 	}
 	if !nd.config.EnableGossipService {
 		return errors.New("p2p bootstrap requires EnableGossipService to be set")
 	}
 
 	netAddress := nd.NetAddress
-	if nd.config.P2PListenAddress != "" {
-		netAddress = nd.config.P2PListenAddress
+	if nd.config.P2PNetAddress != "" {
+		netAddress = nd.config.P2PNetAddress
 	}
 
 	key, err := p2p.GetPrivKey(config.Local{P2PPersistPeerID: true}, nd.dataDir)

--- a/network/connPerfMon_test.go
+++ b/network/connPerfMon_test.go
@@ -48,7 +48,7 @@ func makeMsgPool(N int, peers []Peer) (out []IncomingMessage) {
 
 		addMsg := func(msgCount int) {
 			for i := 0; i < msgCount; i++ {
-				msg.Sender = peers[(int(msgIndex)+i)%len(peers)].(DisconnectablePeer)
+				msg.Sender = peers[(int(msgIndex)+i)%len(peers)].(DeadlineSettableConn)
 				timer += int64(7 * time.Nanosecond)
 				msg.Received = timer
 				out = append(out, msg)

--- a/network/gossipNode.go
+++ b/network/gossipNode.go
@@ -171,9 +171,9 @@ type OutgoingMessage struct {
 // ValidatedMessage is a message that has been validated and is ready to be processed.
 // Think as an intermediate one between IncomingMessage and OutgoingMessage
 type ValidatedMessage struct {
-	Action        ForwardingPolicy
-	Tag           Tag
-	ValidatorData interface{}
+	Action           ForwardingPolicy
+	Tag              Tag
+	ValidatedMessage interface{}
 }
 
 // ForwardingPolicy is an enum indicating to whom we should send a message

--- a/network/gossipNode.go
+++ b/network/gossipNode.go
@@ -29,8 +29,8 @@ import (
 // Peer opaque interface for referring to a neighbor in the network
 type Peer interface{}
 
-// DisconnectablePeer is a Peer with a long-living connection to a network that can be disconnected
-type DisconnectablePeer interface {
+// DeadlineSettableConn is a Peer with a long-living connection to a network that can be disconnected
+type DeadlineSettableConn interface {
 	GetNetwork() GossipNode
 }
 
@@ -62,7 +62,7 @@ type GossipNode interface {
 	Address() (string, bool)
 	Broadcast(ctx context.Context, tag protocol.Tag, data []byte, wait bool, except Peer) error
 	Relay(ctx context.Context, tag protocol.Tag, data []byte, wait bool, except Peer) error
-	Disconnect(badnode DisconnectablePeer)
+	Disconnect(badnode DeadlineSettableConn)
 	DisconnectPeers() // only used by testing
 
 	// RegisterHTTPHandler path accepts gorilla/mux path annotations
@@ -127,7 +127,7 @@ var outgoingMessagesBufferSize = int(
 
 // IncomingMessage represents a message arriving from some peer in our p2p network
 type IncomingMessage struct {
-	Sender DisconnectablePeer
+	Sender DeadlineSettableConn
 	Tag    Tag
 	Data   []byte
 	Err    error

--- a/network/hybridNetwork.go
+++ b/network/hybridNetwork.go
@@ -115,7 +115,7 @@ func (n *HybridP2PNetwork) Relay(ctx context.Context, tag protocol.Tag, data []b
 }
 
 // Disconnect implements GossipNode
-func (n *HybridP2PNetwork) Disconnect(badnode DisconnectablePeer) {
+func (n *HybridP2PNetwork) Disconnect(badnode DeadlineSettableConn) {
 	net := badnode.GetNetwork()
 	if net == n.p2pNetwork {
 		n.p2pNetwork.Disconnect(badnode)
@@ -180,13 +180,13 @@ func (n *HybridP2PNetwork) ClearHandlers() {
 	n.wsNetwork.ClearHandlers()
 }
 
-// RegisterProcessors adds to the set of given message handlers.
+// RegisterProcessors adds to the set of given message processors.
 func (n *HybridP2PNetwork) RegisterProcessors(dispatch []TaggedMessageProcessor) {
 	n.p2pNetwork.RegisterProcessors(dispatch)
 	n.wsNetwork.RegisterProcessors(dispatch)
 }
 
-// ClearProcessors deregisters all the existing message handlers.
+// ClearProcessors deregisters all the existing message processors.
 func (n *HybridP2PNetwork) ClearProcessors() {
 	n.p2pNetwork.ClearProcessors()
 	n.wsNetwork.ClearProcessors()

--- a/network/hybridNetwork.go
+++ b/network/hybridNetwork.go
@@ -41,7 +41,7 @@ type HybridP2PNetwork struct {
 func NewHybridP2PNetwork(log logging.Logger, cfg config.Local, datadir string, phonebookAddresses []string, genesisID string, networkID protocol.NetworkID, nodeInfo NodeInfo) (*HybridP2PNetwork, error) {
 	// supply alternate NetAddress for P2P network
 	p2pcfg := cfg
-	p2pcfg.NetAddress = cfg.P2PListenAddress
+	p2pcfg.NetAddress = cfg.P2PNetAddress
 	p2pnet, err := NewP2PNetwork(log, p2pcfg, datadir, phonebookAddresses, genesisID, networkID, nodeInfo)
 	if err != nil {
 		return nil, err

--- a/network/limitcaller/rateLimitingTransport.go
+++ b/network/limitcaller/rateLimitingTransport.go
@@ -85,7 +85,11 @@ func (r *RateLimitingTransport) RoundTrip(req *http.Request) (res *http.Response
 	addrOrPeerID := req.Host
 	// p2p/http clients have per-connection transport and address info so use that
 	if len(req.Host) == 0 && req.URL != nil && len(req.URL.Host) == 0 {
-		addrOrPeerID = string(r.targetAddr.(*peer.AddrInfo).ID)
+		addrInfo, ok := r.targetAddr.(*peer.AddrInfo)
+		if !ok {
+			return nil, errors.New("rateLimitingTransport: request without Host/URL and targetAddr is not a peer.AddrInfo")
+		}
+		addrOrPeerID = string(addrInfo.ID)
 	}
 	for {
 		_, waitTime, provisionalTime = r.phonebook.GetConnectionWaitTime(addrOrPeerID)

--- a/network/limitcaller/rateLimitingTransport.go
+++ b/network/limitcaller/rateLimitingTransport.go
@@ -64,9 +64,9 @@ func MakeRateLimitingTransport(phonebook ConnectionTimeStore, queueingTimeout ti
 	}
 }
 
-// MakeRateLimitingTransportWithTransport creates a rate limiting http transport that would limit the requests rate
+// MakeRateLimitingTransportWithRoundTripper creates a rate limiting http transport that would limit the requests rate
 // according to the entries in the phonebook.
-func MakeRateLimitingTransportWithTransport(phonebook ConnectionTimeStore, queueingTimeout time.Duration, rt http.RoundTripper, target interface{}, maxIdleConnsPerHost int) RateLimitingTransport {
+func MakeRateLimitingTransportWithRoundTripper(phonebook ConnectionTimeStore, queueingTimeout time.Duration, rt http.RoundTripper, target interface{}, maxIdleConnsPerHost int) RateLimitingTransport {
 	return RateLimitingTransport{
 		phonebook:       phonebook,
 		innerTransport:  rt,
@@ -82,8 +82,8 @@ func (r *RateLimitingTransport) RoundTrip(req *http.Request) (res *http.Response
 	var provisionalTime time.Time
 	queueingDeadline := time.Now().Add(r.queueingTimeout)
 	var host interface{} = req.Host
+	// p2p/http clients have per-connection transport and address info so use that
 	if len(req.Host) == 0 && req.URL != nil && len(req.URL.Host) == 0 {
-		// p2p/http clients have per-connection transport and address info so use that
 		host = r.targetAddr
 	}
 	for {

--- a/network/limitcaller/rateLimitingTransport.go
+++ b/network/limitcaller/rateLimitingTransport.go
@@ -22,12 +22,13 @@ import (
 	"time"
 
 	"github.com/algorand/go-algorand/util"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 // ConnectionTimeStore is a subset of the phonebook that is used to store the connection times.
 type ConnectionTimeStore interface {
-	GetConnectionWaitTime(addrOrInfo interface{}) (bool, time.Duration, time.Time)
-	UpdateConnectionTime(addrOrInfo interface{}, provisionalTime time.Time) bool
+	GetConnectionWaitTime(addrOrPeerID string) (bool, time.Duration, time.Time)
+	UpdateConnectionTime(addrOrPeerID string, provisionalTime time.Time) bool
 }
 
 // RateLimitingTransport is the transport for execute a single HTTP transaction, obtaining the Response for a given Request.
@@ -81,13 +82,13 @@ func (r *RateLimitingTransport) RoundTrip(req *http.Request) (res *http.Response
 	var waitTime time.Duration
 	var provisionalTime time.Time
 	queueingDeadline := time.Now().Add(r.queueingTimeout)
-	var host interface{} = req.Host
+	addrOrPeerID := req.Host
 	// p2p/http clients have per-connection transport and address info so use that
 	if len(req.Host) == 0 && req.URL != nil && len(req.URL.Host) == 0 {
-		host = r.targetAddr
+		addrOrPeerID = string(r.targetAddr.(*peer.AddrInfo).ID)
 	}
 	for {
-		_, waitTime, provisionalTime = r.phonebook.GetConnectionWaitTime(host)
+		_, waitTime, provisionalTime = r.phonebook.GetConnectionWaitTime(addrOrPeerID)
 		if waitTime == 0 {
 			break // break out of the loop and proceed to the connection
 		}
@@ -99,6 +100,6 @@ func (r *RateLimitingTransport) RoundTrip(req *http.Request) (res *http.Response
 		return nil, ErrConnectionQueueingTimeout
 	}
 	res, err = r.innerTransport.RoundTrip(req)
-	r.phonebook.UpdateConnectionTime(host, provisionalTime)
+	r.phonebook.UpdateConnectionTime(addrOrPeerID, provisionalTime)
 	return
 }

--- a/network/p2p/dnsaddr/resolve.go
+++ b/network/p2p/dnsaddr/resolve.go
@@ -35,7 +35,7 @@ func Iterate(initial multiaddr.Multiaddr, controller ResolveController, f func(d
 	if resolver == nil {
 		return errors.New("passed controller has no resolvers Iterate")
 	}
-	const maxHops = 100
+	const maxHops = 25 // any reasonable number to prevent infinite loop in case of circular dnsaddr
 	hops := 0
 	var toResolve = []multiaddr.Multiaddr{initial}
 	for resolver != nil && len(toResolve) > 0 {

--- a/network/p2p/http.go
+++ b/network/p2p/http.go
@@ -85,7 +85,7 @@ func MakeHTTPClientWithRateLimit(addrInfo *peer.AddrInfo, pstore limitcaller.Con
 	if err != nil {
 		return nil, err
 	}
-	rlrt := limitcaller.MakeRateLimitingTransportWithTransport(pstore, queueingTimeout, cl.Transport, addrInfo, maxIdleConnsPerHost)
+	rlrt := limitcaller.MakeRateLimitingTransportWithRoundTripper(pstore, queueingTimeout, cl.Transport, addrInfo, maxIdleConnsPerHost)
 	cl.Transport = &rlrt
 	return cl, nil
 

--- a/network/p2p/logger.go
+++ b/network/p2p/logger.go
@@ -70,7 +70,8 @@ func EnableP2PLogging(log logging.Logger, l logging.Level) {
 }
 
 func (c *loggingCore) Enabled(l zapcore.Level) bool {
-	return c.log.IsLevelEnabled(c.level)
+	level := levelsMap[l]
+	return c.log.IsLevelEnabled(level)
 }
 
 func (c *loggingCore) With(fields []zapcore.Field) zapcore.Core {

--- a/network/p2p/peerstore/peerstore_test.go
+++ b/network/p2p/peerstore/peerstore_test.go
@@ -337,17 +337,17 @@ func TestWaitAndAddConnectionTimeLongtWindow(t *testing.T) {
 	info2, _ := peerInfoFromDomainPort(addr2)
 
 	// Address not in. Should return false
-	addrInPhonebook, _, provisionalTime := entries.GetConnectionWaitTime(info1)
+	addrInPhonebook, _, provisionalTime := entries.GetConnectionWaitTime(string(info1.ID))
 	require.Equal(t, false, addrInPhonebook)
-	require.Equal(t, false, entries.UpdateConnectionTime(info1, provisionalTime))
+	require.Equal(t, false, entries.UpdateConnectionTime(string(info1.ID), provisionalTime))
 
 	// Test the addresses are populated in the phonebook and a
 	// time can be added to one of them
 	entries.ReplacePeerList([]interface{}{info1, info2}, "default", PhoneBookEntryRelayRole)
-	addrInPhonebook, waitTime, provisionalTime := entries.GetConnectionWaitTime(info1)
+	addrInPhonebook, waitTime, provisionalTime := entries.GetConnectionWaitTime(string(info1.ID))
 	require.Equal(t, true, addrInPhonebook)
 	require.Equal(t, time.Duration(0), waitTime)
-	require.Equal(t, true, entries.UpdateConnectionTime(info1, provisionalTime))
+	require.Equal(t, true, entries.UpdateConnectionTime(string(info1.ID), provisionalTime))
 	data, _ := entries.Get(info1.ID, addressDataKey)
 	require.NotNil(t, data)
 	ad := data.(addressData)
@@ -360,9 +360,9 @@ func TestWaitAndAddConnectionTimeLongtWindow(t *testing.T) {
 	}
 
 	// add another value to addr
-	addrInPhonebook, waitTime, provisionalTime = entries.GetConnectionWaitTime(info1)
+	addrInPhonebook, waitTime, provisionalTime = entries.GetConnectionWaitTime(string(info1.ID))
 	require.Equal(t, time.Duration(0), waitTime)
-	require.Equal(t, true, entries.UpdateConnectionTime(info1, provisionalTime))
+	require.Equal(t, true, entries.UpdateConnectionTime(string(info1.ID), provisionalTime))
 	data, _ = entries.Get(info1.ID, addressDataKey)
 	ad = data.(addressData)
 	phBookData = ad.recentConnectionTimes
@@ -375,9 +375,9 @@ func TestWaitAndAddConnectionTimeLongtWindow(t *testing.T) {
 
 	// the first time should be removed and a new one added
 	// there should not be any wait
-	addrInPhonebook, waitTime, provisionalTime = entries.GetConnectionWaitTime(info1)
+	addrInPhonebook, waitTime, provisionalTime = entries.GetConnectionWaitTime(string(info1.ID))
 	require.Equal(t, time.Duration(0), waitTime)
-	require.Equal(t, true, entries.UpdateConnectionTime(info1, provisionalTime))
+	require.Equal(t, true, entries.UpdateConnectionTime(string(info1.ID), provisionalTime))
 	data, _ = entries.Get(info1.ID, addressDataKey)
 	ad = data.(addressData)
 	phBookData2 := ad.recentConnectionTimes
@@ -392,9 +392,9 @@ func TestWaitAndAddConnectionTimeLongtWindow(t *testing.T) {
 
 	// add 3 values to another address. should not wait
 	// value 1
-	_, waitTime, provisionalTime = entries.GetConnectionWaitTime(info2)
+	_, waitTime, provisionalTime = entries.GetConnectionWaitTime(string(info2.ID))
 	require.Equal(t, time.Duration(0), waitTime)
-	require.Equal(t, true, entries.UpdateConnectionTime(info2, provisionalTime))
+	require.Equal(t, true, entries.UpdateConnectionTime(string(info2.ID), provisionalTime))
 
 	// introduce a gap between the two requests so that only the first will be removed later when waited
 	// simulate passing a unit of time
@@ -406,13 +406,13 @@ func TestWaitAndAddConnectionTimeLongtWindow(t *testing.T) {
 	}
 
 	// value 2
-	_, waitTime, provisionalTime = entries.GetConnectionWaitTime(info2)
+	_, waitTime, provisionalTime = entries.GetConnectionWaitTime(string(info2.ID))
 	require.Equal(t, time.Duration(0), waitTime)
-	require.Equal(t, true, entries.UpdateConnectionTime(info2, provisionalTime))
+	require.Equal(t, true, entries.UpdateConnectionTime(string(info2.ID), provisionalTime))
 	// value 3
-	_, waitTime, provisionalTime = entries.GetConnectionWaitTime(info2)
+	_, waitTime, provisionalTime = entries.GetConnectionWaitTime(string(info2.ID))
 	require.Equal(t, time.Duration(0), waitTime)
-	require.Equal(t, true, entries.UpdateConnectionTime(info2, provisionalTime))
+	require.Equal(t, true, entries.UpdateConnectionTime(string(info2.ID), provisionalTime))
 
 	data2, _ = entries.Get(info2.ID, addressDataKey)
 	ad2 = data2.(addressData)
@@ -421,7 +421,7 @@ func TestWaitAndAddConnectionTimeLongtWindow(t *testing.T) {
 	require.Equal(t, 3, len(phBookData))
 
 	// add another element to trigger wait
-	_, waitTime, provisionalTime = entries.GetConnectionWaitTime(info2)
+	_, waitTime, provisionalTime = entries.GetConnectionWaitTime(string(info2.ID))
 	require.Greater(t, int64(waitTime), int64(0))
 	// no element should be removed
 	data2, _ = entries.Get(info2.ID, addressDataKey)
@@ -436,9 +436,9 @@ func TestWaitAndAddConnectionTimeLongtWindow(t *testing.T) {
 	}
 
 	// The wait should be sufficient
-	_, waitTime, provisionalTime = entries.GetConnectionWaitTime(info2)
+	_, waitTime, provisionalTime = entries.GetConnectionWaitTime(string(info2.ID))
 	require.Equal(t, time.Duration(0), waitTime)
-	require.Equal(t, true, entries.UpdateConnectionTime(info2, provisionalTime))
+	require.Equal(t, true, entries.UpdateConnectionTime(string(info2.ID), provisionalTime))
 	// only one element should be removed, and one added
 	data2, _ = entries.Get(info2.ID, addressDataKey)
 	ad2 = data2.(addressData)

--- a/network/p2p/pubsub.go
+++ b/network/p2p/pubsub.go
@@ -53,6 +53,8 @@ const (
 // TXTopicName defines a pubsub topic for TX messages
 const TXTopicName = "/algo/tx/0.1.0"
 
+const incomingThreads = 20 // matches to number wsNetwork workers
+
 func makePubSub(ctx context.Context, cfg config.Local, host host.Host) (*pubsub.PubSub, error) {
 	//defaultParams := pubsub.DefaultGossipSubParams()
 
@@ -95,7 +97,7 @@ func makePubSub(ctx context.Context, cfg config.Local, host host.Host) (*pubsub.
 		pubsub.WithValidateQueueSize(256),
 		pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign),
 		// pubsub.WithValidateThrottle(cfg.TxBacklogSize),
-		pubsub.WithValidateWorkers(20), // match to number wsNetwork workers
+		pubsub.WithValidateWorkers(incomingThreads),
 	}
 
 	return pubsub.NewGossipSub(ctx, host, options...)

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -527,7 +527,7 @@ func (n *P2PNetwork) Relay(ctx context.Context, tag protocol.Tag, data []byte, w
 }
 
 // Disconnect from a peer, probably due to protocol errors.
-func (n *P2PNetwork) Disconnect(badpeer DisconnectablePeer) {
+func (n *P2PNetwork) Disconnect(badpeer DeadlineSettableConn) {
 	var peerID peer.ID
 	var wsp *wsPeer
 
@@ -555,7 +555,7 @@ func (n *P2PNetwork) Disconnect(badpeer DisconnectablePeer) {
 	}
 }
 
-func (n *P2PNetwork) disconnectThread(badnode DisconnectablePeer, reason disconnectReason) {
+func (n *P2PNetwork) disconnectThread(badnode DeadlineSettableConn, reason disconnectReason) {
 	defer n.wg.Done()
 	n.Disconnect(badnode) // ignores reason
 }

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -108,7 +108,7 @@ func TestP2PSubmitTX(t *testing.T) {
 				ProcessorHandleFunc
 			}{
 				ProcessorValidateFunc(func(msg IncomingMessage) ValidatedMessage {
-					return ValidatedMessage{Action: Accept, Tag: msg.Tag, ValidatorData: nil}
+					return ValidatedMessage{Action: Accept, Tag: msg.Tag, ValidatedMessage: nil}
 				}),
 				ProcessorHandleFunc(func(msg ValidatedMessage) OutgoingMessage {
 					return OutgoingMessage{Action: Ignore}
@@ -200,7 +200,7 @@ func TestP2PSubmitTXNoGossip(t *testing.T) {
 				ProcessorHandleFunc
 			}{
 				ProcessorValidateFunc(func(msg IncomingMessage) ValidatedMessage {
-					return ValidatedMessage{Action: Accept, Tag: msg.Tag, ValidatorData: nil}
+					return ValidatedMessage{Action: Accept, Tag: msg.Tag, ValidatedMessage: nil}
 				}),
 				ProcessorHandleFunc(func(msg ValidatedMessage) OutgoingMessage {
 					return OutgoingMessage{Action: Ignore}
@@ -840,7 +840,7 @@ func TestP2PRelay(t *testing.T) {
 					ProcessorHandleFunc
 				}{
 					ProcessorValidateFunc(func(msg IncomingMessage) ValidatedMessage {
-						return ValidatedMessage{Action: Accept, Tag: msg.Tag, ValidatorData: nil}
+						return ValidatedMessage{Action: Accept, Tag: msg.Tag, ValidatedMessage: nil}
 					}),
 					ProcessorHandleFunc(func(msg ValidatedMessage) OutgoingMessage {
 						if count := numActual.Add(1); int(count) >= numExpected {

--- a/network/phonebook/phonebook.go
+++ b/network/phonebook/phonebook.go
@@ -55,12 +55,12 @@ type Phonebook interface {
 	// The connection should be established when the waitTime is 0.
 	// It will register a provisional next connection time when the waitTime is 0.
 	// The provisional time should be updated after the connection with UpdateConnectionTime
-	GetConnectionWaitTime(addr interface{}) (addrInPhonebook bool,
+	GetConnectionWaitTime(addrOrPeerID string) (addrInPhonebook bool,
 		waitTime time.Duration, provisionalTime time.Time)
 
 	// UpdateConnectionTime will update the provisional connection time.
 	// Returns true of the addr was in the phonebook
-	UpdateConnectionTime(addr interface{}, provisionalTime time.Time) bool
+	UpdateConnectionTime(addrOrPeerID string, provisionalTime time.Time) bool
 
 	// ReplacePeerList merges a set of addresses with that passed in for networkName
 	// new entries in dnsAddresses are being added
@@ -231,10 +231,10 @@ func (e *phonebookImpl) UpdateRetryAfter(addr string, retryAfter time.Time) {
 // The connection should be established when the waitTime is 0.
 // It will register a provisional next connection time when the waitTime is 0.
 // The provisional time should be updated after the connection with UpdateConnectionTime
-func (e *phonebookImpl) GetConnectionWaitTime(a interface{}) (addrInPhonebook bool,
+func (e *phonebookImpl) GetConnectionWaitTime(addrOrPeerID string) (addrInPhonebook bool,
 	waitTime time.Duration, provisionalTime time.Time) {
 
-	addr := a.(string)
+	addr := addrOrPeerID
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
@@ -278,8 +278,8 @@ func (e *phonebookImpl) GetConnectionWaitTime(a interface{}) (addrInPhonebook bo
 
 // UpdateConnectionTime will update the provisional connection time.
 // Returns true of the addr was in the phonebook
-func (e *phonebookImpl) UpdateConnectionTime(a interface{}, provisionalTime time.Time) bool {
-	addr := a.(string)
+func (e *phonebookImpl) UpdateConnectionTime(addrOrPeerID string, provisionalTime time.Time) bool {
+	addr := addrOrPeerID
 	e.lock.Lock()
 	defer e.lock.Unlock()
 

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -362,7 +362,7 @@ type networkPeerManager interface {
 
 	// used by msgHandler
 	Broadcast(ctx context.Context, tag protocol.Tag, data []byte, wait bool, except Peer) error
-	disconnectThread(badnode DisconnectablePeer, reason disconnectReason)
+	disconnectThread(badnode DeadlineSettableConn, reason disconnectReason)
 	checkPeersConnectivity()
 }
 
@@ -477,13 +477,13 @@ func (wn *WebsocketNetwork) RelayArray(ctx context.Context, tags []protocol.Tag,
 	return nil
 }
 
-func (wn *WebsocketNetwork) disconnectThread(badnode DisconnectablePeer, reason disconnectReason) {
+func (wn *WebsocketNetwork) disconnectThread(badnode DeadlineSettableConn, reason disconnectReason) {
 	defer wn.wg.Done()
 	wn.disconnect(badnode, reason)
 }
 
 // Disconnect from a peer, probably due to protocol errors.
-func (wn *WebsocketNetwork) Disconnect(node DisconnectablePeer) {
+func (wn *WebsocketNetwork) Disconnect(node DeadlineSettableConn) {
 	wn.disconnect(node, disconnectBadData)
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -463,6 +463,7 @@ func (node *AlgorandFullNode) Stop() {
 	node.highPriorityCryptoVerificationPool.Shutdown()
 	node.lowPriorityCryptoVerificationPool.Shutdown()
 	node.cryptoPool.Shutdown()
+	node.ledger.Close()
 	node.cancelCtx()
 }
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -896,7 +896,7 @@ func TestNodeHybridTopology(t *testing.T) {
 		ni.p2pID, err = p2p.PeerIDFromPublicKey(privKey.GetPublic())
 		require.NoError(t, err)
 
-		cfg.P2PListenAddress = ni.p2pNetAddr()
+		cfg.P2PNetAddress = ni.p2pNetAddr()
 		return ni, cfg
 	}
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -903,9 +903,7 @@ func TestNodeHybridTopology(t *testing.T) {
 	phonebookHook := func(ni []nodeInfo, i int) []string {
 		switch i {
 		case 0:
-			// node 0 (N) only accept connections to work around the peer selector
-			// ConnectedOut priority. TODO: merge switching to archival peers from master
-			// when ready.
+			// node 0 (N) only accept connections at the beginning to learn about archival node from DHT
 			t.Logf("Node%d phonebook: empty", i)
 			return []string{}
 		case 1:

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -45,7 +45,6 @@ import (
 	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/algorand/go-algorand/util"
 	"github.com/algorand/go-algorand/util/db"
-	"github.com/algorand/go-algorand/util/execpool"
 )
 
 var expectedAgreementTime = 2*config.Protocol.BigLambda + config.Protocol.SmallLambda + config.Consensus[protocol.ConsensusCurrentVersion].AgreementFilterTimeout + 2*time.Second
@@ -86,7 +85,7 @@ func (ni nodeInfo) p2pMultiAddr() string {
 type configHook func(ni nodeInfo, cfg config.Local) (nodeInfo, config.Local)
 type phonebookHook func([]nodeInfo, int) []string
 
-func setupFullNodes(t *testing.T, proto protocol.ConsensusVersion, verificationPool execpool.BacklogPool, customConsensus config.ConsensusProtocols) ([]*AlgorandFullNode, []string) {
+func setupFullNodes(t *testing.T, proto protocol.ConsensusVersion, customConsensus config.ConsensusProtocols) ([]*AlgorandFullNode, []string) {
 	minMoneyAtStart := 10000
 	maxMoneyAtStart := 100000
 	gen := rand.New(rand.NewSource(2))
@@ -111,14 +110,14 @@ func setupFullNodes(t *testing.T, proto protocol.ConsensusVersion, verificationP
 		}
 		return phonebook
 	}
-	nodes, wallets := setupFullNodesEx(t, proto, verificationPool, customConsensus, acctStake, configHook, phonebookHook)
+	nodes, wallets := setupFullNodesEx(t, proto, customConsensus, acctStake, configHook, phonebookHook)
 	require.Len(t, nodes, numAccounts)
 	require.Len(t, wallets, numAccounts)
 	return nodes, wallets
 }
 
 func setupFullNodesEx(
-	t *testing.T, proto protocol.ConsensusVersion, verificationPool execpool.BacklogPool, customConsensus config.ConsensusProtocols,
+	t *testing.T, proto protocol.ConsensusVersion, customConsensus config.ConsensusProtocols,
 	acctStake []basics.MicroAlgos, configHook configHook, phonebookHook phonebookHook,
 ) ([]*AlgorandFullNode, []string) {
 
@@ -264,10 +263,7 @@ func TestSyncingFullNode(t *testing.T) {
 		t.Skip("Test is too heavy for amd64 builder running in parallel with other packages")
 	}
 
-	backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)
-	defer backlogPool.Shutdown()
-
-	nodes, wallets := setupFullNodes(t, protocol.ConsensusCurrentVersion, backlogPool, nil)
+	nodes, wallets := setupFullNodes(t, protocol.ConsensusCurrentVersion, nil)
 	for i := 0; i < len(nodes); i++ {
 		defer os.Remove(wallets[i])
 		defer nodes[i].Stop()
@@ -329,10 +325,7 @@ func TestInitialSync(t *testing.T) {
 		t.Skip("Test is too heavy for amd64 builder running in parallel with other packages")
 	}
 
-	backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)
-	defer backlogPool.Shutdown()
-
-	nodes, wallets := setupFullNodes(t, protocol.ConsensusCurrentVersion, backlogPool, nil)
+	nodes, wallets := setupFullNodes(t, protocol.ConsensusCurrentVersion, nil)
 	for i := 0; i < len(nodes); i++ {
 		defer os.Remove(wallets[i])
 		defer nodes[i].Stop()
@@ -370,9 +363,6 @@ func TestSimpleUpgrade(t *testing.T) {
 		t.Skip("Test is too heavy for amd64 builder running in parallel with other packages")
 	}
 
-	backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)
-	defer backlogPool.Shutdown()
-
 	// ConsensusTest0 is a version of ConsensusV0 used for testing
 	// (it has different approved upgrade paths).
 	const consensusTest0 = protocol.ConsensusVersion("test0")
@@ -409,7 +399,7 @@ func TestSimpleUpgrade(t *testing.T) {
 	testParams1.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 	configurableConsensus[consensusTest1] = testParams1
 
-	nodes, wallets := setupFullNodes(t, consensusTest0, backlogPool, configurableConsensus)
+	nodes, wallets := setupFullNodes(t, consensusTest0, configurableConsensus)
 	for i := 0; i < len(nodes); i++ {
 		defer os.Remove(wallets[i])
 		defer nodes[i].Stop()
@@ -921,10 +911,7 @@ func TestNodeHybridTopology(t *testing.T) {
 		return nil
 	}
 
-	backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)
-	defer backlogPool.Shutdown()
-
-	nodes, wallets := setupFullNodesEx(t, consensusTest0, backlogPool, configurableConsensus, acctStake, configHook, phonebookHook)
+	nodes, wallets := setupFullNodesEx(t, consensusTest0, configurableConsensus, acctStake, configHook, phonebookHook)
 	require.Len(t, nodes, 3)
 	require.Len(t, wallets, 3)
 	for i := 0; i < len(nodes); i++ {
@@ -1015,10 +1002,7 @@ func TestNodeP2PRelays(t *testing.T) {
 		return nil
 	}
 
-	backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)
-	defer backlogPool.Shutdown()
-
-	nodes, wallets := setupFullNodesEx(t, consensusTest0, backlogPool, configurableConsensus, acctStake, configHook, phonebookHook)
+	nodes, wallets := setupFullNodesEx(t, consensusTest0, configurableConsensus, acctStake, configHook, phonebookHook)
 	require.Len(t, nodes, 3)
 	require.Len(t, wallets, 3)
 	for i := 0; i < len(nodes); i++ {

--- a/test/testdata/configs/config-v34.json
+++ b/test/testdata/configs/config-v34.json
@@ -98,7 +98,7 @@
     "OptimizeAccountsDatabaseOnStartup": false,
     "OutgoingMessageFilterBucketCount": 3,
     "OutgoingMessageFilterBucketSize": 128,
-    "P2PListenAddress": "",
+    "P2PNetAddress": "",
     "P2PPersistPeerID": false,
     "P2PPrivateKeyLocation": "",
     "ParticipationKeysRefreshInterval": 60000000000,

--- a/util/metrics/opencensus_test.go
+++ b/util/metrics/opencensus_test.go
@@ -37,9 +37,9 @@ func TestDHTOpenCensusMetrics(t *testing.T) {
 
 	defaultBytesDistribution := view.Distribution(1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296)
 
-	keyMessageType, _ := tag.NewKey("message_type")
-	keyPeerID, _ := tag.NewKey("peer_id")
-	keyInstanceID, _ := tag.NewKey("instance_id")
+	keyMessageType := tag.MustNewKey("message_type")
+	keyPeerID := tag.MustNewKey("peer_id")
+	keyInstanceID := tag.MustNewKey("instance_id")
 
 	sentMessages := stats.Int64("my_sent_messages", "Total number of messages sent per RPC", stats.UnitDimensionless)
 	receivedBytes := stats.Int64("my_received_bytes", "Total received bytes per RPC", stats.UnitBytes)


### PR DESCRIPTION
## Summary

Addressed most code review items from https://github.com/algorand/go-algorand/pull/5939

Additionally fixed two data races: 
1. peerstore data race seen in [this build](https://app.circleci.com/pipelines/github/algorand/go-algorand/18574/workflows/aacb840e-dceb-4455-ad89-f2530ac35df7/jobs/274104)
2. logrus.Formatter concurrent access seen locally

Also fixed node.ledger descriptors leak that prevented `./nodetest -race` to pass due to extra connection opened by libp2p

Remaining items:
- [ ] [document](https://github.com/algorand/go-algorand/pull/5939#discussion_r1639955735) `EnableP2PHybridMode` vs `EnableP2P` after merging https://github.com/algorand/go-algorand/pull/6035 (otherwise a merge conflict)
