### PR TITLE
node: close ledger and part keys on node shutdown

### DIFF
--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -95,6 +95,11 @@ type TransactionPool struct {
 	// stateproofOverflowed indicates that a stateproof transaction was allowed to
 	// exceed the txPoolMaxSize. This flag is reset to false OnNewBlock
 	stateproofOverflowed bool
+
+	// shutdown is set to true when the pool is being shut down. It is checked in exported methods
+	// to prevent pool operations like remember and recomputing the block evaluator
+	// from using down stream resources like ledger that may be shutting down.
+	shutdown bool
 }
 
 // BlockEvaluator defines the block evaluator interface exposed by the ledger package.
@@ -112,6 +117,8 @@ type BlockEvaluator interface {
 type VotingAccountSupplier interface {
 	VotingAccountsForRound(basics.Round) []basics.Address
 }
+
+var errPoolShutdown = errors.New("transaction pool is shutting down")
 
 // MakeTransactionPool makes a transaction pool.
 func MakeTransactionPool(ledger *ledger.Ledger, cfg config.Local, log logging.Logger, vac VotingAccountSupplier) *TransactionPool {
@@ -430,6 +437,10 @@ func (pool *TransactionPool) ingest(txgroup []transactions.SignedTxn, params poo
 		return ErrNoPendingBlockEvaluator
 	}
 
+	if pool.shutdown {
+		return errPoolShutdown
+	}
+
 	if !params.recomputing {
 		// Make sure that the latest block has been processed by OnNewBlock().
 		// If not, we might be in a race, so wait a little bit for OnNewBlock()
@@ -529,6 +540,10 @@ func (pool *TransactionPool) OnNewBlock(block bookkeeping.Block, delta ledgercor
 
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
+	if pool.shutdown {
+		return
+	}
+
 	defer pool.cond.Broadcast()
 	if pool.pendingBlockEvaluator == nil || block.Round() >= pool.pendingBlockEvaluator.Round() {
 		// Adjust the pool fee threshold.  The rules are:
@@ -1009,4 +1024,14 @@ func (pool *TransactionPool) AssembleDevModeBlock() (assembled *ledgercore.Unfin
 	// so there won't be any waiting on this call.
 	assembled, err = pool.AssembleBlock(pool.pendingBlockEvaluator.Round(), time.Now().Add(pool.proposalAssemblyTime))
 	return
+}
+
+// Shutdown stops the transaction pool from accepting new transactions and blocks.
+// It takes the pool.mu lock in order to ensure there is no pending remember or block operations in flight
+// and sets the shutdown flag to true.
+func (pool *TransactionPool) Shutdown() {
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+
+	pool.shutdown = true
 }

--- a/data/pools/transactionPool.go
+++ b/data/pools/transactionPool.go
@@ -452,6 +452,10 @@ func (pool *TransactionPool) ingest(txgroup []transactions.SignedTxn, params poo
 			if pool.pendingBlockEvaluator == nil {
 				return ErrNoPendingBlockEvaluator
 			}
+			// recheck if the pool is shutting down since TimedWait above releases the lock
+			if pool.shutdown {
+				return errPoolShutdown
+			}
 		}
 
 		err := pool.checkSufficientFee(txgroup)

--- a/ledger/notifier.go
+++ b/ledger/notifier.go
@@ -74,6 +74,8 @@ func (bn *blockNotifier) worker() {
 
 func (bn *blockNotifier) close() {
 	bn.mu.Lock()
+	bn.pendingBlocks = nil
+	bn.listeners = nil
 	if bn.running {
 		bn.running = false
 		bn.cond.Broadcast()

--- a/node/node.go
+++ b/node/node.go
@@ -441,7 +441,9 @@ func (node *AlgorandFullNode) Stop() {
 	node.lowPriorityCryptoVerificationPool.Shutdown()
 	node.cryptoPool.Shutdown()
 	node.log.Debug("crypto worker pools have stopped")
+	node.transactionPool.Shutdown()
 	node.cancelCtx()
+	node.ledger.Close()
 }
 
 // note: unlike the other two functions, this accepts a whole filename

--- a/node/node.go
+++ b/node/node.go
@@ -152,6 +152,7 @@ type AlgorandFullNode struct {
 	tracer messagetracer.MessageTracer
 
 	stateProofWorker *stateproof.Worker
+	partHandles      []db.Accessor
 }
 
 // TxnWithStatus represents information about a single transaction,
@@ -418,6 +419,12 @@ func (node *AlgorandFullNode) Stop() {
 	defer func() {
 		node.mu.Unlock()
 		node.waitMonitoringRoutines()
+
+		// oldKeyDeletionThread uses accountManager registry so must be stopped before accountManager is closed
+		node.accountManager.Registry().Close()
+		for h := range node.partHandles {
+			node.partHandles[h].Close()
+		}
 	}()
 
 	node.net.ClearHandlers()
@@ -430,6 +437,7 @@ func (node *AlgorandFullNode) Stop() {
 		node.stateProofWorker.Stop()
 		node.txHandler.Stop()
 		node.agreementService.Shutdown()
+		node.agreementService.Accessor.Close()
 		node.catchupService.Stop()
 		node.txPoolSyncerService.Stop()
 		node.blockService.Stop()
@@ -989,12 +997,12 @@ func (node *AlgorandFullNode) loadParticipationKeys() error {
 			// These files are not ephemeral and must be deleted eventually since
 			// this function is called to load files located in the node on startup
 			added := node.accountManager.AddParticipation(part, false)
-			if added {
-				node.log.Infof("Loaded participation keys from storage: %s %s", part.Address(), info.Name())
-			} else {
+			if !added {
 				part.Close()
 				continue
 			}
+			node.log.Infof("Loaded participation keys from storage: %s %s", part.Address(), info.Name())
+			node.partHandles = append(node.partHandles, handle)
 			err = insertStateProofToRegistry(part, node)
 			if err != nil {
 				return err
@@ -1026,7 +1034,7 @@ func (node *AlgorandFullNode) txPoolGaugeThread(done <-chan struct{}) {
 	defer node.monitoringRoutinesWaitGroup.Done()
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
-	for true {
+	for {
 		select {
 		case <-ticker.C:
 			txPoolGauge.Set(uint64(node.transactionPool.PendingCount()))


### PR DESCRIPTION
## Summary

* node_test runs multiple nodes in a single process that leads to file descriptors leak (see #5057 for more details).
* just closing ledger is not enough because of concurrent operations evaluation operations done by transaction pool.
* made transaction pool shutdown-able and stop it before ledger termination.

<details><summary>Deadlock example as seen in <a href="https://app.circleci.com/pipelines/github/algorand/go-algorand/18590/workflows/351f0ff3-6c92-42bb-8b66-afe7072d3435/jobs/274266">this p2p build</a></summary>
<pre>
POTENTIAL DEADLOCK:
Previous place where the lock was grabbed
goroutine 412 lock 0xc0006fe300
node.go:446 node.(*AlgorandFullNode).Stop { node.mu.Lock() } <<<<<
node_test.go:938 node.TestNodeHybridTopology { } }

Have been trying to lock it again for more than 30s
goroutine 17114 lock 0xc0006fe300
node.go:1125 node.(*AlgorandFullNode).oldKeyDeletionThread { node.mu.Lock() } <<<<<

Here is what goroutine 412 doing now
goroutine 412 [semacquire]:
sync.runtime_Semacquire(0xc0094269b0?)
	/opt/cibuild/.gimme/versions/go1.21.10.linux.amd64/src/runtime/sema.go:62 +0x25
sync.(*WaitGroup).Wait(0xc0094269a8)
	/opt/cibuild/.gimme/versions/go1.21.10.linux.amd64/src/sync/waitgroup.go:116 +0xa5
github.com/algorand/go-algorand/ledger.(*blockNotifier).close(0xc009426958)
	/opt/cibuild/project/ledger/notifier.go:82 +0x97
github.com/algorand/go-algorand/ledger.(*trackerRegistry).close(0xc009426a80)
	/opt/cibuild/project/ledger/tracker.go:506 +0x104
github.com/algorand/go-algorand/ledger.(*Ledger).Close(0xc009426000)
	/opt/cibuild/project/ledger/ledger.go:416 +0x111
github.com/algorand/go-algorand/node.(*AlgorandFullNode).Stop(0xc0006fe300)
	/opt/cibuild/project/node/node.go:473 +0x717
github.com/algorand/go-algorand/node.TestNodeHybridTopology(0xc006d53860)
	/opt/cibuild/project/node/node_test.go:938 +0xe2a
testing.tRunner(0xc006d53860, 0x30e34c8)
	/opt/cibuild/.gimme/versions/go1.21.10.linux.amd64/src/testing/testing.go:1595 +0x262
created by testing.(*T).Run in goroutine 1
	/opt/cibuild/.gimme/versions/go1.21.10.linux.amd64/src/testing/testing.go:1648 +0x846
Other goroutines holding locks:
goroutine 617 lock 5a4
../data/pools/transactionPool.go:530 pools.(*TransactionPool).OnNewBlock { pool.mu.Lock() } <<<<<
../ledger/notifier.go:67 ledger.(*blockNotifier).worker { listener.OnNewBlock(blk.block, blk.delta) }

goroutine 617 lock 3f
../data/pools/transactionPool.go:781 pools.(*TransactionPool).recomputeBlockEvaluator { pool.assemblyMu.Lock() } <<<<<
../data/pools/transactionPool.go:560 pools.(*TransactionPool).OnNewBlock { stats = pool.recomputeBlockEvaluator(committedTxids, knownCommitted) }
../ledger/notifier.go:67 ledger.(*blockNotifier).worker { listener.OnNewBlock(blk.block, blk.delta) }

goroutine 412 lock 32
../ledger/ledger.go:412 ledger.(*Ledger).Close { l.trackerMu.Lock() } <<<<<
node.go:473 node.(*AlgorandFullNode).Stop { node.ledger.Close() }
node_test.go:938 node.TestNodeHybridTopology { } }

POTENTIAL DEADLOCK:
Previous place where the lock was grabbed
goroutine 412 lock 0xc009426fe8
../ledger/ledger.go:412 ledger.(*Ledger).Close { l.trackerMu.Lock() } <<<<<
node.go:473 node.(*AlgorandFullNode).Stop { node.ledger.Close() }
node_test.go:938 node.TestNodeHybridTopology { } }

Have been trying to lock it again for more than 30s
goroutine 617 lock 0xc009426fe8
../ledger/ledger.go:636 ledger.(*Ledger).LookupWithoutRewards { l.trackerMu.RLock() } <<<<<
../ledger/eval/eval.go:200 eval.(*roundCowBase).lookup { ad, _, err := x.l.LookupWithoutRewards(x.rnd, addr) }
../ledger/eval/cow.go:186 eval.(*roundCowState).lookup { return cb.lookupParent.lookup(addr) }
../ledger/eval/eval.go:1910 eval.(*BlockEvaluator).GenerateBlock { acct, err := eval.state.lookup(addrs[i]) }
../data/pools/transactionPool.go:794 pools.(*TransactionPool).recomputeBlockEvaluator { lvb, err := pool.pendingBlockEvaluator.GenerateBlock(pool.getVotingAccountsForRound(evalRnd)) }
../data/pools/transactionPool.go:560 pools.(*TransactionPool).OnNewBlock { stats = pool.recomputeBlockEvaluator(committedTxids, knownCommitted) }
../ledger/notifier.go:67 ledger.(*blockNotifier).worker { listener.OnNewBlock(blk.block, blk.delta) }

</pre>
</details> 

Additionally added part keys closing.

Monitored with `while pgrep node.test > /dev/null; do lsof -p $(pgrep node.test) | wc -l; sleep 1; done` on p2p branch:

| description | peak fd | avg fd | last 3 avg fd |
| -- | -- | -- | -- |
|  no closing | 1158 | 1060 | 1130 |
| ledger close | 888 | 770 | 653 |
| all closed | 589 | 498 | 157 |

## Test Plan

Existing tests should pass