### PR TITLE
p2p: more CR fixes: ERL and DHT err logging

### DIFF
--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -613,7 +613,7 @@ func (handler *TxHandler) incomingMsgDupCheck(data []byte) (*crypto.Digest, bool
 	return msgKey, false
 }
 
-// incomingMsgErlCheck runs the rate limiting check on a raw incoming message.
+// incomingMsgErlCheck runs the rate limiting check on a sender.
 // Returns:
 // - the capacity guard returned by the elastic rate limiter
 // - a boolean indicating if the sender is rate limited

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -766,7 +766,7 @@ func (handler *TxHandler) processIncomingTxn(rawmsg network.IncomingMessage) net
 		transactionMessagesDroppedFromBacklog.Inc(nil)
 
 		// additionally, remove the txn from duplicate caches to ensure it can be re-submitted
-		handler.deleteFromCaches(canonicalKey, msgKey)
+		handler.deleteFromCaches(msgKey, canonicalKey)
 	}
 
 	return network.OutgoingMessage{Action: network.Ignore}

--- a/network/p2p/capabilities.go
+++ b/network/p2p/capabilities.go
@@ -67,9 +67,10 @@ func (c *CapabilitiesDiscovery) FindPeers(ctx context.Context, ns string, opts .
 }
 
 // Close should be called when fully shutting down the node
-func (c *CapabilitiesDiscovery) Close() {
-	_ = c.dht.Close()
+func (c *CapabilitiesDiscovery) Close() error {
+	err := c.dht.Close()
 	c.wg.Wait()
+	return err
 }
 
 // Host exposes the underlying libp2p host.Host object

--- a/network/p2p/capabilities_test.go
+++ b/network/p2p/capabilities_test.go
@@ -309,7 +309,8 @@ func TestCapabilities_Varying(t *testing.T) {
 			wg.Wait()
 
 			for _, disc := range capsDisc[3:] {
-				disc.Close()
+				err := disc.Close()
+				require.NoError(t, err)
 				// Make sure it actually closes
 				disc.wg.Wait()
 			}
@@ -347,6 +348,7 @@ func TestCapabilities_ExcludesSelf(t *testing.T) {
 		"Found self when searching for capability",
 	)
 
-	disc[0].Close()
+	err := disc[0].Close()
+	require.NoError(t, err)
 	disc[0].wg.Wait()
 }

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -365,7 +365,10 @@ func (n *P2PNetwork) Start() error {
 // Stop closes sockets and stop threads.
 func (n *P2PNetwork) Stop() {
 	if n.capabilitiesDiscovery != nil {
-		n.capabilitiesDiscovery.Close()
+		err := n.capabilitiesDiscovery.Close()
+		if err != nil {
+			n.log.Warnf("Error closing capabilities discovery: %v", err)
+		}
 	}
 
 	n.handler.ClearHandlers([]Tag{})


### PR DESCRIPTION
## Summary

1. Do not run ERL in p2pNet tx handler - libp2p has own congestion control mechanism, plus we are using pubsub.
2. Log `dht.Close()` errors if any.

## Test Plan

Existing tests