### PR TITLE
ledger: restore block listeners on reloadLedger

### DIFF
--- a/catchup/fetcher_test.go
+++ b/catchup/fetcher_test.go
@@ -66,8 +66,7 @@ func buildTestLedger(t *testing.T, blk bookkeeping.Block) (ledger *data.Ledger, 
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
 	ledger, err = data.LoadLedger(
-		log, t.Name(), inMem, protocol.ConsensusCurrentVersion, genBal, "", genHash,
-		nil, cfg,
+		log, t.Name(), inMem, protocol.ConsensusCurrentVersion, genBal, "", genHash, cfg,
 	)
 	if err != nil {
 		t.Fatal("couldn't build ledger", err)

--- a/catchup/pref_test.go
+++ b/catchup/pref_test.go
@@ -62,7 +62,7 @@ func BenchmarkServiceFetchBlocks(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		inMem := true
 		prefix := b.Name() + "empty" + strconv.Itoa(i)
-		local, err := data.LoadLedger(logging.TestingLog(b), prefix, inMem, protocol.ConsensusCurrentVersion, genesisBalances, "", crypto.Digest{}, nil, cfg)
+		local, err := data.LoadLedger(logging.TestingLog(b), prefix, inMem, protocol.ConsensusCurrentVersion, genesisBalances, "", crypto.Digest{}, cfg)
 		require.NoError(b, err)
 
 		// Make Service
@@ -150,7 +150,7 @@ func benchenv(t testing.TB, numAccounts, numBlocks int) (ledger, emptyLedger *da
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
 	prefix := t.Name() + "empty"
-	emptyLedger, err = data.LoadLedger(logging.TestingLog(t), prefix, inMem, protocol.ConsensusCurrentVersion, genesisBalances, "", crypto.Digest{}, nil, cfg)
+	emptyLedger, err = data.LoadLedger(logging.TestingLog(t), prefix, inMem, protocol.ConsensusCurrentVersion, genesisBalances, "", crypto.Digest{}, cfg)
 	require.NoError(t, err)
 
 	ledger, err = datatest.FabricateLedger(logging.TestingLog(t), t.Name(), parts, genesisBalances, emptyLedger.LastRound()+basics.Round(numBlocks))

--- a/daemon/algod/api/server/v2/test/helpers.go
+++ b/daemon/algod/api/server/v2/test/helpers.go
@@ -313,7 +313,7 @@ func testingenvWithBalances(t testing.TB, minMoneyAtStart, maxMoneyAtStart, numA
 	const inMem = true
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	ledger, err := data.LoadLedger(logging.Base(), t.Name(), inMem, protocol.ConsensusFuture, bootstrap, genesisID, genesisHash, nil, cfg)
+	ledger, err := data.LoadLedger(logging.Base(), t.Name(), inMem, protocol.ConsensusFuture, bootstrap, genesisID, genesisHash, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/data/common_test.go
+++ b/data/common_test.go
@@ -121,7 +121,7 @@ func testingenv(t testing.TB, numAccounts, numTxs int, offlineAccounts bool) (*L
 	const inMem = true
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	ledger, err := LoadLedger(logging.Base(), t.Name(), inMem, protocol.ConsensusCurrentVersion, bootstrap, genesisID, genesisHash, nil, cfg)
+	ledger, err := LoadLedger(logging.Base(), t.Name(), inMem, protocol.ConsensusCurrentVersion, bootstrap, genesisID, genesisHash, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/data/datatest/fabricateLedger.go
+++ b/data/datatest/fabricateLedger.go
@@ -38,7 +38,7 @@ func FabricateLedger(log logging.Logger, ledgerName string, accounts []account.P
 	const inMem = true
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	ledger, err := data.LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genesis, "", crypto.Digest{}, nil, cfg)
+	ledger, err := data.LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genesis, "", crypto.Digest{}, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/data/ledger.go
+++ b/data/ledger.go
@@ -81,7 +81,7 @@ type roundSeed struct {
 func LoadLedger[T string | ledger.DirsAndPrefix](
 	log logging.Logger, dir T, memory bool,
 	genesisProto protocol.ConsensusVersion, genesisBal bookkeeping.GenesisBalances, genesisID string, genesisHash crypto.Digest,
-	blockListeners []ledgercore.BlockListener, cfg config.Local,
+	cfg config.Local,
 ) (*Ledger, error) {
 	if genesisBal.Balances == nil {
 		genesisBal.Balances = make(map[basics.Address]basics.AccountData)
@@ -115,7 +115,6 @@ func LoadLedger[T string | ledger.DirsAndPrefix](
 	}
 
 	l.Ledger = ll
-	l.RegisterBlockListeners(blockListeners)
 	return l, nil
 }
 

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -109,7 +109,7 @@ func BenchmarkTxHandlerProcessing(b *testing.B) {
 	cfg.Archival = true
 	cfg.TxBacklogReservedCapacityPerPeer = 1
 	cfg.IncomingConnectionsLimit = 10
-	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, nil, cfg)
+	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, cfg)
 	require.NoError(b, err)
 	defer ledger.Close()
 
@@ -1027,7 +1027,7 @@ func TestTxHandlerProcessIncomingCacheTxPoolDrop(t *testing.T) {
 	cfg.Archival = true
 	cfg.EnableTxBacklogRateLimiting = false
 	cfg.TxIncomingFilteringFlags = 3 // txFilterRawMsg + txFilterCanonical
-	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, nil, cfg)
+	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, cfg)
 	require.NoError(t, err)
 	defer ledger.Close()
 
@@ -1196,7 +1196,7 @@ func incomingTxHandlerProcessing(maxGroupSize, numberOfTransactionGroups int, t 
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
 	cfg.EnableTxBacklogRateLimiting = false
-	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, nil, cfg)
+	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, cfg)
 	require.NoError(t, err)
 	defer ledger.Close()
 
@@ -1641,7 +1641,7 @@ func (g *txGenerator) makeLedger(tb testing.TB, cfg config.Local, log logging.Lo
 	ledgerName := fmt.Sprintf("%s-in_mem-w_inv=%d", namePrefix, ivrString)
 	ledgerName = strings.Replace(ledgerName, "#", "-", 1)
 	const inMem = true
-	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, nil, cfg)
+	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, cfg)
 	require.NoError(tb, err)
 	return ledger
 }
@@ -2183,7 +2183,7 @@ func TestTxHandlerRememberReportErrorsWithTxPool(t *testing.T) { //nolint:parall
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
 	cfg.TxPoolSize = config.MaxTxGroupSize + 1
-	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, nil, cfg)
+	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, cfg)
 	require.NoError(t, err)
 	defer ledger.Close()
 
@@ -2419,7 +2419,7 @@ func TestTxHandlerRestartWithBacklogAndTxPool(t *testing.T) { //nolint:parallelt
 	const inMem = true
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, nil, cfg)
+	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, cfg)
 	require.NoError(t, err)
 	defer ledger.Ledger.Close()
 
@@ -2524,7 +2524,7 @@ func TestTxHandlerAppRateLimiterERLEnabled(t *testing.T) {
 	cfg.TxBacklogServiceRateWindowSeconds = 1
 	cfg.TxBacklogAppTxPerSecondRate = 3
 	cfg.TxBacklogSize = 3
-	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, bookkeeping.GenesisBalances{}, genesisID, genesisHash, nil, cfg)
+	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, bookkeeping.GenesisBalances{}, genesisID, genesisHash, cfg)
 	require.NoError(t, err)
 	defer ledger.Close()
 
@@ -2636,7 +2636,7 @@ func TestTxHandlerAppRateLimiter(t *testing.T) {
 	cfg.TxBacklogAppTxRateLimiterMaxSize = 100
 	cfg.TxBacklogServiceRateWindowSeconds = 1
 	cfg.TxBacklogAppTxPerSecondRate = 3
-	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, nil, cfg)
+	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, cfg)
 	require.NoError(t, err)
 	defer ledger.Close()
 
@@ -2705,7 +2705,7 @@ func TestTxHandlerCapGuard(t *testing.T) {
 	cfg.IncomingConnectionsLimit = 1
 	cfg.TxBacklogSize = 3
 
-	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, nil, cfg)
+	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, cfg)
 	require.NoError(t, err)
 	defer ledger.Close()
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -261,7 +261,6 @@ func (l *Ledger) reloadLedger() error {
 	}
 
 	// restore block listeners since l.notifier might not survive a reload
-	l.notifier.clearListeners()
 	l.notifier.register(blockListeners)
 
 	// post-init actions
@@ -431,6 +430,8 @@ func (l *Ledger) Close() {
 // RegisterBlockListeners registers listeners that will be called when a
 // new block is added to the ledger.
 func (l *Ledger) RegisterBlockListeners(listeners []ledgercore.BlockListener) {
+	l.trackerMu.RLock()
+	defer l.trackerMu.RUnlock()
 	l.notifier.register(listeners)
 }
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -428,7 +428,7 @@ func (l *Ledger) RegisterBlockListeners(listeners []ledgercore.BlockListener) {
 
 // ClearBlockListeners removes all listeners block listeners.
 func (l *Ledger) ClearBlockListeners() {
-	l.notifier.clear()
+	l.notifier.clearListeners()
 }
 
 // RegisterVotersCommitListener registers a listener that will be called when a

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -426,6 +426,11 @@ func (l *Ledger) RegisterBlockListeners(listeners []ledgercore.BlockListener) {
 	l.notifier.register(listeners)
 }
 
+// ClearBlockListeners removes all listeners block listeners.
+func (l *Ledger) ClearBlockListeners() {
+	l.notifier.clear()
+}
+
 // RegisterVotersCommitListener registers a listener that will be called when a
 // commit is about to cover a round.
 func (l *Ledger) RegisterVotersCommitListener(listener ledgercore.VotersCommitListener) {

--- a/ledger/notifier.go
+++ b/ledger/notifier.go
@@ -100,7 +100,7 @@ func (bn *blockNotifier) register(listeners []ledgercore.BlockListener) {
 	bn.listeners = append(bn.listeners, listeners...)
 }
 
-func (bn *blockNotifier) clear() {
+func (bn *blockNotifier) clearListeners() {
 	bn.mu.Lock()
 	defer bn.mu.Unlock()
 	bn.listeners = nil

--- a/ledger/notifier.go
+++ b/ledger/notifier.go
@@ -100,6 +100,12 @@ func (bn *blockNotifier) register(listeners []ledgercore.BlockListener) {
 	bn.listeners = append(bn.listeners, listeners...)
 }
 
+func (bn *blockNotifier) clear() {
+	bn.mu.Lock()
+	defer bn.mu.Unlock()
+	bn.listeners = nil
+}
+
 func (bn *blockNotifier) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {
 	bn.mu.Lock()
 	defer bn.mu.Unlock()

--- a/ledger/notifier.go
+++ b/ledger/notifier.go
@@ -100,12 +100,6 @@ func (bn *blockNotifier) register(listeners []ledgercore.BlockListener) {
 	bn.listeners = append(bn.listeners, listeners...)
 }
 
-func (bn *blockNotifier) clearListeners() {
-	bn.mu.Lock()
-	defer bn.mu.Unlock()
-	bn.listeners = nil
-}
-
 func (bn *blockNotifier) newBlock(blk bookkeeping.Block, delta ledgercore.StateDelta) {
 	bn.mu.Lock()
 	defer bn.mu.Unlock()

--- a/node/assemble_test.go
+++ b/node/assemble_test.go
@@ -83,7 +83,7 @@ func BenchmarkAssembleBlock(b *testing.B) {
 	const inMem = true
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	ledger, err := data.LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, nil, cfg)
+	ledger, err := data.LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, cfg)
 	require.NoError(b, err)
 
 	l := ledger
@@ -212,7 +212,7 @@ func TestAssembleBlockTransactionPoolBehind(t *testing.T) {
 	const inMem = true
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	ledger, err := data.LoadLedger(log, "ledgerName", inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, nil, cfg)
+	ledger, err := data.LoadLedger(log, "ledgerName", inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, cfg)
 	require.NoError(t, err)
 
 	l := ledger

--- a/node/follower_node.go
+++ b/node/follower_node.go
@@ -122,11 +122,7 @@ func MakeFollower(log logging.Logger, rootDir string, cfg config.Local, phoneboo
 		return nil, err
 	}
 
-	blockListeners := []ledgercore.BlockListener{
-		node,
-	}
-
-	node.ledger.RegisterBlockListeners(blockListeners)
+	node.ledger.RegisterBlockListeners([]ledgercore.BlockListener{node})
 
 	if cfg.IsGossipServer() {
 		rpcs.MakeHealthService(node.net)
@@ -218,6 +214,7 @@ func (node *AlgorandFollowerNode) Stop() {
 		node.catchupService.Stop()
 		node.blockService.Stop()
 	}
+	node.ledger.ClearBlockListeners()
 	node.catchupBlockAuth.Quit()
 	node.lowPriorityCryptoVerificationPool.Shutdown()
 	node.cryptoPool.Shutdown()
@@ -407,6 +404,7 @@ func (node *AlgorandFollowerNode) SetCatchpointCatchupMode(catchpointCatchupMode
 			node.net.ClearHandlers()
 			node.catchupService.Stop()
 			node.blockService.Stop()
+			node.ledger.ClearBlockListeners()
 
 			prevNodeCancelFunc := node.cancelCtx
 
@@ -427,6 +425,7 @@ func (node *AlgorandFollowerNode) SetCatchpointCatchupMode(catchpointCatchupMode
 		}
 
 		// start
+		node.ledger.RegisterBlockListeners([]ledgercore.BlockListener{node})
 		node.catchupService.Start()
 		node.blockService.Start()
 

--- a/node/follower_node.go
+++ b/node/follower_node.go
@@ -116,7 +116,7 @@ func MakeFollower(log logging.Logger, rootDir string, cfg config.Local, phoneboo
 		DBFilePrefix:        config.LedgerFilenamePrefix,
 		ResolvedGenesisDirs: node.genesisDirs,
 	}
-	node.ledger, err = data.LoadLedger(node.log, ledgerPaths, false, genesis.Proto, genalloc, node.genesisID, node.genesisHash, []ledgercore.BlockListener{}, cfg)
+	node.ledger, err = data.LoadLedger(node.log, ledgerPaths, false, genesis.Proto, genalloc, node.genesisID, node.genesisHash, cfg)
 	if err != nil {
 		log.Errorf("Cannot initialize ledger (%v): %v", ledgerPaths, err)
 		return nil, err

--- a/node/follower_node.go
+++ b/node/follower_node.go
@@ -214,7 +214,6 @@ func (node *AlgorandFollowerNode) Stop() {
 		node.catchupService.Stop()
 		node.blockService.Stop()
 	}
-	node.ledger.ClearBlockListeners()
 	node.catchupBlockAuth.Quit()
 	node.lowPriorityCryptoVerificationPool.Shutdown()
 	node.cryptoPool.Shutdown()
@@ -404,7 +403,6 @@ func (node *AlgorandFollowerNode) SetCatchpointCatchupMode(catchpointCatchupMode
 			node.net.ClearHandlers()
 			node.catchupService.Stop()
 			node.blockService.Stop()
-			node.ledger.ClearBlockListeners()
 
 			prevNodeCancelFunc := node.cancelCtx
 
@@ -425,7 +423,6 @@ func (node *AlgorandFollowerNode) SetCatchpointCatchupMode(catchpointCatchupMode
 		}
 
 		// start
-		node.ledger.RegisterBlockListeners([]ledgercore.BlockListener{node})
 		node.catchupService.Start()
 		node.blockService.Start()
 

--- a/node/node.go
+++ b/node/node.go
@@ -438,7 +438,6 @@ func (node *AlgorandFullNode) Stop() {
 		node.blockService.Stop()
 		node.ledgerService.Stop()
 	}
-	node.ledger.ClearBlockListeners()
 	node.catchupBlockAuth.Quit()
 	node.log.Debug("crypto worker pools are stopping")
 	node.highPriorityCryptoVerificationPool.Shutdown()
@@ -1196,7 +1195,6 @@ func (node *AlgorandFullNode) SetCatchpointCatchupMode(catchpointCatchupMode boo
 			node.txPoolSyncerService.Stop()
 			node.blockService.Stop()
 			node.ledgerService.Stop()
-			node.ledger.ClearBlockListeners()
 
 			prevNodeCancelFunc := node.cancelCtx
 
@@ -1210,8 +1208,6 @@ func (node *AlgorandFullNode) SetCatchpointCatchupMode(catchpointCatchupMode boo
 		defer node.mu.Unlock()
 
 		// start
-		// catchpoint service reloads the ledger, need to re-register the listeners
-		node.ledger.RegisterBlockListeners([]ledgercore.BlockListener{node.transactionPool, node})
 		node.transactionPool.Reset()
 		node.catchupService.Start()
 		node.agreementService.Start()

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -168,7 +168,7 @@ func setupFullNodes(t *testing.T, proto protocol.ConsensusVersion, verificationP
 		cfg, err := config.LoadConfigFromDisk(rootDirectory)
 		require.NoError(t, err)
 		cfg.Archival = true
-		_, err = data.LoadLedger(logging.Base().With("name", nodeID), ledgerFilenamePrefix, inMem, g.Proto, bootstrap, g.ID(), g.Hash(), nil, cfg)
+		_, err = data.LoadLedger(logging.Base().With("name", nodeID), ledgerFilenamePrefix, inMem, g.Proto, bootstrap, g.ID(), g.Hash(), cfg)
 		require.NoError(t, err)
 	}
 

--- a/rpcs/blockService_test.go
+++ b/rpcs/blockService_test.go
@@ -520,7 +520,7 @@ func makeLedger(t *testing.T, namePostfix string) *data.Ledger {
 	prefix := t.Name() + namePostfix
 	ledger, err := data.LoadLedger(
 		log, prefix, inMem, protocol.ConsensusCurrentVersion, genBal, "", genHash,
-		nil, cfg,
+		cfg,
 	)
 	require.NoError(t, err)
 	return ledger


### PR DESCRIPTION
## Summary

* #6039 [discovered](https://circleci.com/api/v1.1/project/github/algorand/go-algorand/274376/output/114/2?file=true&allocation-id=667b6a1ffc7c6545c0d31136-2-build%2FABCDEFGH) blockNotifier preserves state between ledger reloads that breaks assumptions on how trackers work
* Made ledger to explicitly preserve block listeners in `reloadLedger`
* Also removed unused blockListeners argument from data.Ledger

## Test Plan

Existing tests including `TestNodeTxHandlerRestart` and `TestNodeTxSyncRestart` passed locally.