### PR TITLE
CI: increase artifact upload timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -721,6 +721,7 @@ commands:
               export GOPATH="<< parameters.build_dir >>/go"
               export TRAVIS_BRANCH=${CIRCLE_BRANCH}
               scripts/travis/deploy_packages.sh
+            no_output_timeout: 20m
         - when:
             condition:
               equal: [ "amd64", << parameters.platform >> ]


### PR DESCRIPTION
## Summary

While uploads usually take on the order of minutes, for Mac ARM64 for some reason it's taking longer than 10 minutes. It's not clear if it's stalled or just needs more time.

This PR increases the default from 10m to 20m.

## Test Plan

Should merge and see if it resolves nightly issues, as well as length of time for successful uploads.


