### PR TITLE
tests: increase ListPeersForTopic wait time in TestP2PRelay

### DIFF
--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -880,7 +880,7 @@ func TestP2PRelay(t *testing.T) {
 	// add a netC with listening address set and enable relaying on netB
 	// ensure all messages from netB and netC are received by netA
 	cfg.NetAddress = "127.0.0.1:0"
-	log.Debugf("Starting netB with phonebook addresses %v", phoneBookAddresses)
+	log.Debugf("Starting netC with phonebook addresses %v", phoneBookAddresses)
 	netC, err := NewP2PNetwork(log.With("net", "netC"), cfg, "", phoneBookAddresses, genesisID, config.Devtestnet, &nopeNodeInfo{})
 	require.NoError(t, err)
 	err = netC.Start()
@@ -892,11 +892,11 @@ func TestP2PRelay(t *testing.T) {
 	require.Eventually(
 		t,
 		func() bool {
-			return len(netA.service.ListPeersForTopic(p2p.TXTopicName)) > 0 &&
+			return len(netA.service.ListPeersForTopic(p2p.TXTopicName)) >= 2 &&
 				len(netB.service.ListPeersForTopic(p2p.TXTopicName)) > 0 &&
 				len(netC.service.ListPeersForTopic(p2p.TXTopicName)) > 0
 		},
-		2*time.Second,
+		10*time.Second, // wait until netC node gets actually connected to netA after starting
 		50*time.Millisecond,
 	)
 


### PR DESCRIPTION
## Summary

`TestP2PRelay` failures ([one](https://app.circleci.com/pipelines/github/algorand/go-algorand/18671/workflows/c4558f67-3c74-431b-a7ca-12ea7e5b6503/jobs/274943), [two](https://app.circleci.com/pipelines/github/algorand/go-algorand/18675/workflows/870a58dc-aa1c-4abc-833e-a1980672c95b/jobs/275029)) indicate netC messages get lost. Most likely it is not enough time for pubsub to establish its mesh so increased wait time to stabilize the test.

## Test Plan

This is a test fix