### PR TITLE
ci: pin reviewdog version to v0.18.1

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -69,7 +69,7 @@ jobs:
           cd ../../
       - name: Install reviewdog
         run: |
-          curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/v0.17.4/install.sh | sh -s
+          curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/v0.18.1/install.sh | sh -s -- v0.18.1
           reviewdog --version
       - name: Build custom linters
         run: |


### PR DESCRIPTION
## Summary

Reviewdog v.19+ started checking files not modified in PR and failing PR builds. This pins its version to the last known working.

## Test Plan

Build should pass