### PR TITLE
tests: fix concurrent accout commits in TestLedgerVerifiesOldStateProofs

### DIFF
--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -1683,6 +1683,15 @@ func TestLedgerVerifiesOldStateProofs(t *testing.T) {
 	backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)
 	defer backlogPool.Shutdown()
 
+	// wait all pending commits to finish
+	l.trackers.accountsWriting.Wait()
+
+	// quit the commitSyncer goroutine: this test flushes manually with triggerTrackerFlush
+	l.trackers.ctxCancel()
+	l.trackers.ctxCancel = nil
+	<-l.trackers.commitSyncerClosed
+	l.trackers.commitSyncerClosed = nil
+
 	triggerTrackerFlush(t, l)
 	l.WaitForCommit(l.Latest())
 	blk := createBlkWithStateproof(t, maxBlocks, proto, genesisInitState, l, accounts)
@@ -1714,7 +1723,7 @@ func TestLedgerVerifiesOldStateProofs(t *testing.T) {
 	}
 	l.acctsOnline.voters.votersMu.Unlock()
 
-	// However, we are still able to very a state proof sicne we use the tracker
+	// However, we are still able to very a state proof since we use the tracker
 	blk = createBlkWithStateproof(t, maxBlocks, proto, genesisInitState, l, accounts)
 	_, err = l.Validate(context.Background(), blk, backlogPool)
 	require.ErrorContains(t, err, "state proof crypto error")
@@ -2934,7 +2943,7 @@ func testVotersReloadFromDiskAfterOneStateProofCommitted(t *testing.T, cfg confi
 	// wait all pending commits to finish
 	l.trackers.accountsWriting.Wait()
 
-	// quit the commitSyncer goroutine
+	// quit the commitSyncer goroutine: this test flushes manually with triggerTrackerFlush
 	l.trackers.ctxCancel()
 	l.trackers.ctxCancel = nil
 	<-l.trackers.commitSyncerClosed


### PR DESCRIPTION
## Summary

`TestLedgerVerifiesOldStateProofs` uses manual account commit scheduling with automatic one that rarely brings tracker into invalid state as seen in this [build](https://app.circleci.com/pipelines/github/algorand/go-algorand/18689/workflows/e9507a50-9f65-4850-91f1-ed72477d7514/jobs/275110):
```
produceCommittingTask: block 3328 too far in the future, lookback 4, dbRound 3277 (cached 3320), deltas 8

2024-07-09T01:35:21.030105 +0000 level=error msg=[Stack] goroutine 346823 [running]:
runtime/debug.Stack()
	/opt/cibuild/.gimme/versions/go1.21.10.linux.arm64/src/runtime/debug/stack.go:24 +0x6c
github.com/algorand/go-algorand/logging.logger.Panicf({0xc0000f42a0?, 0xc0008660a8?}, {0x2495c48, 0x65}, {0xc0041c29b0, 0x5, 0x5})
	/opt/cibuild/project/logging/log.go:282 +0xb0
github.com/algorand/go-algorand/ledger.(*accountUpdates).produceCommittingTask(0xc000f5e420, 0xd00, 0xccd, 0xc003fdc600)
	/opt/cibuild/project/ledger/acctupdates.go:640 +0x3b4
github.com/algorand/go-algorand/ledger.(*trackerRegistry).produceCommittingTask(0xc000f5ea80, 0xd00?, 0xc003fa5990?, 0xc003fdc600)
	/opt/cibuild/project/ledger/tracker.go:404 +0x158
github.com/algorand/go-algorand/ledger.triggerTrackerFlush(0x0?, 0xc000f5e000)
	/opt/cibuild/project/ledger/ledger_test.go:1496 +0x1e4
github.com/algorand/go-algorand/ledger.TestLedgerVerifiesOldStateProofs(0xc002ef11e0)
	/opt/cibuild/project/ledger/ledger_test.go:1686 +0xd84
testing.tRunner(0xc002ef11e0, 0x272e698)
	/opt/cibuild/.gimme/versions/go1.21.10.linux.arm64/src/testing/testing.go:1595 +0x1b4
created by testing.(*T).Run in goroutine 1
	/opt/cibuild/.gimme/versions/go1.21.10.linux.arm64/src/testing/testing.go:1648 +0x5ec
 file=acctupdates.go function=github.com/algorand/go-algorand/ledger.(*accountUpdates).produceCommittingTask
~
```

## Test Plan

This is a test fix.