### PR TITLE
algod: fix telemetry lookup if phonebook is used

### DIFF
--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -362,7 +362,7 @@ func run() int {
 
 		// If the telemetry URI is not set, periodically check SRV records for new telemetry URI
 		if remoteTelemetryEnabled && log.GetTelemetryURI() == "" {
-			toolsnet.StartTelemetryURIUpdateService(time.Minute, cfg, s.Genesis.Network, log, done)
+			toolsnet.StartTelemetryURIUpdateService(time.Minute, cfgCopy, s.Genesis.Network, log, done)
 		}
 
 		currentVersion := config.GetCurrentVersion()


### PR DESCRIPTION
## Summary

In rare case of using phonebook only addresses AND enabling telemetry, telemetry DNS lookup would be skipped due to empty DNSBootstrapID.

## Test Plan

Existing tests