### PR TITLE
P2P: Introduce profiles for hybridRelay, hybridArchival, and hybridClient.

### DIFF
--- a/cmd/algocfg/profileCommand.go
+++ b/cmd/algocfg/profileCommand.go
@@ -138,7 +138,6 @@ var (
 			// P2P config defaults
 			cfg.EnableP2PHybridMode = true
 			cfg.EnableDHTProviders = true
-
 			return cfg
 		},
 	}

--- a/cmd/algocfg/profileCommand.go
+++ b/cmd/algocfg/profileCommand.go
@@ -120,8 +120,8 @@ var (
 			cfg.EnableBlockService = true
 			cfg.NetAddress = ":4160"
 			cfg.EnableGossipService = false
-			// This should be set to the public address of the node if public access is desired
-			cfg.PublicAddress = "PLEASE_SET_ME"
+			// This should be set to the public address of the node
+			cfg.PublicAddress = config.PlaceholderPublicAddress
 
 			// P2P config defaults
 			cfg.EnableP2PHybridMode = true
@@ -137,7 +137,6 @@ var (
 
 			// P2P config defaults
 			cfg.EnableP2PHybridMode = true
-			cfg.P2PNetAddress = ":4190"
 			cfg.EnableDHTProviders = true
 
 			return cfg

--- a/cmd/algocfg/profileCommand.go
+++ b/cmd/algocfg/profileCommand.go
@@ -102,7 +102,7 @@ var (
 			cfg.EnableBlockService = true
 			cfg.NetAddress = ":4160"
 			// This should be set to the public address of the node if public access is desired
-			cfg.PublicAddress = "PLEASE_SET_ME"
+			cfg.PublicAddress = config.PlaceholderPublicAddress
 
 			// P2P config defaults
 			cfg.EnableP2PHybridMode = true

--- a/cmd/algocfg/profileCommand.go
+++ b/cmd/algocfg/profileCommand.go
@@ -66,8 +66,8 @@ var (
 		},
 	}
 
-	relay = configUpdater{
-		description: "Relay consensus messages across the network and support catchup.",
+	wsRelay = configUpdater{
+		description: "Relay consensus messages across the ws network and support recent catchup.",
 		updateFunc: func(cfg config.Local) config.Local {
 			cfg.MaxBlockHistoryLookback = 22000 // Enough to support 2 catchpoints with some wiggle room for nodes to catch up from the older one
 			cfg.CatchpointFileHistoryLength = 3
@@ -80,7 +80,7 @@ var (
 	}
 
 	archival = configUpdater{
-		description: "Store the full chain history and support catchup.",
+		description: "Store the full chain history and support full catchup.",
 		updateFunc: func(cfg config.Local) config.Local {
 			cfg.Archival = true
 			cfg.EnableLedgerService = true
@@ -91,13 +91,69 @@ var (
 		},
 	}
 
+	hybridRelay = configUpdater{
+		description: "Relay consensus messages across both ws and p2p networks, also support recent catchup.",
+		updateFunc: func(cfg config.Local) config.Local {
+			// WS relay config defaults
+			cfg.MaxBlockHistoryLookback = 22000 // Enough to support 2 catchpoints with some wiggle room for nodes to catch up from the older one
+			cfg.CatchpointFileHistoryLength = 3
+			cfg.CatchpointTracking = 2
+			cfg.EnableLedgerService = true
+			cfg.EnableBlockService = true
+			cfg.NetAddress = ":4160"
+			// This should be set to the public address of the node if public access is desired
+			cfg.PublicAddress = "PLEASE_SET_ME"
+
+			// P2P config defaults
+			cfg.EnableP2PHybridMode = true
+			cfg.P2PNetAddress = ":4190"
+			cfg.EnableDHTProviders = true
+			return cfg
+		},
+	}
+
+	hybridArchival = configUpdater{
+		description: "Store the full chain history, support full catchup, P2P enabled, discoverable via DHT.",
+		updateFunc: func(cfg config.Local) config.Local {
+			cfg.Archival = true
+			cfg.EnableLedgerService = true
+			cfg.EnableBlockService = true
+			cfg.NetAddress = ":4160"
+			cfg.EnableGossipService = false
+			// This should be set to the public address of the node if public access is desired
+			cfg.PublicAddress = "PLEASE_SET_ME"
+
+			// P2P config defaults
+			cfg.EnableP2PHybridMode = true
+			cfg.P2PNetAddress = ":4190"
+			cfg.EnableDHTProviders = true
+			return cfg
+		},
+	}
+
+	hybridClient = configUpdater{
+		description: "Participate in consensus or simply ensure chain health by validating blocks and supporting P2P traffic propagation.",
+		updateFunc: func(cfg config.Local) config.Local {
+
+			// P2P config defaults
+			cfg.EnableP2PHybridMode = true
+			cfg.P2PNetAddress = ":4190"
+			cfg.EnableDHTProviders = true
+
+			return cfg
+		},
+	}
+
 	// profileNames are the supported pre-configurations of config values
 	profileNames = map[string]configUpdater{
-		"participation": participation,
-		"conduit":       conduit,
-		"relay":         relay,
-		"archival":      archival,
-		"development":   development,
+		"participation":  participation,
+		"conduit":        conduit,
+		"wsRelay":        wsRelay,
+		"archival":       archival,
+		"development":    development,
+		"hybridRelay":    hybridRelay,
+		"hybridArchival": hybridArchival,
+		"hybridClient":   hybridClient,
 	}
 
 	forceUpdate bool

--- a/cmd/algocfg/profileCommand_test.go
+++ b/cmd/algocfg/profileCommand_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"github.com/algorand/go-algorand/config"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -76,7 +77,7 @@ func Test_getConfigForArg(t *testing.T) {
 		require.True(t, cfg.EnableBlockService)
 		require.Equal(t, ":4160", cfg.NetAddress)
 		require.True(t, cfg.EnableGossipService)
-		require.Equal(t, "PLEASE_SET_ME", cfg.PublicAddress)
+		require.Equal(t, config.PlaceholderPublicAddress, cfg.PublicAddress)
 
 		require.True(t, cfg.EnableP2PHybridMode)
 		require.Equal(t, ":4190", cfg.P2PNetAddress)
@@ -96,7 +97,7 @@ func Test_getConfigForArg(t *testing.T) {
 		require.True(t, cfg.EnableBlockService)
 		require.Equal(t, ":4160", cfg.NetAddress)
 		require.False(t, cfg.EnableGossipService)
-		require.Equal(t, "PLEASE_SET_ME", cfg.PublicAddress)
+		require.Equal(t, config.PlaceholderPublicAddress, cfg.PublicAddress)
 
 		require.True(t, cfg.EnableP2PHybridMode)
 		require.Equal(t, ":4190", cfg.P2PNetAddress)
@@ -120,7 +121,7 @@ func Test_getConfigForArg(t *testing.T) {
 		require.Equal(t, "", cfg.PublicAddress)
 
 		require.True(t, cfg.EnableP2PHybridMode)
-		require.Equal(t, ":4190", cfg.P2PNetAddress)
+		require.Equal(t, "", cfg.P2PNetAddress)
 		require.True(t, cfg.EnableDHTProviders)
 	})
 }

--- a/cmd/algocfg/profileCommand_test.go
+++ b/cmd/algocfg/profileCommand_test.go
@@ -62,4 +62,65 @@ func Test_getConfigForArg(t *testing.T) {
 		require.Equal(t, ":4160", cfg.NetAddress)
 		require.False(t, cfg.EnableGossipService)
 	})
+
+	t.Run("valid config test hybrid relay", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := getConfigForArg("hybridRelay")
+		require.NoError(t, err)
+
+		require.False(t, cfg.Archival)
+		require.Equal(t, uint64(22000), cfg.MaxBlockHistoryLookback)
+		require.Equal(t, 3, cfg.CatchpointFileHistoryLength)
+		require.Equal(t, int64(2), cfg.CatchpointTracking)
+		require.True(t, cfg.EnableLedgerService)
+		require.True(t, cfg.EnableBlockService)
+		require.Equal(t, ":4160", cfg.NetAddress)
+		require.True(t, cfg.EnableGossipService)
+		require.Equal(t, "PLEASE_SET_ME", cfg.PublicAddress)
+
+		require.True(t, cfg.EnableP2PHybridMode)
+		require.Equal(t, ":4190", cfg.P2PNetAddress)
+		require.True(t, cfg.EnableDHTProviders)
+	})
+
+	t.Run("valid config test hybrid archival", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := getConfigForArg("hybridArchival")
+		require.NoError(t, err)
+
+		require.True(t, cfg.Archival)
+		require.Equal(t, uint64(0), cfg.MaxBlockHistoryLookback)
+		require.Equal(t, 365, cfg.CatchpointFileHistoryLength)
+		require.Equal(t, int64(0), cfg.CatchpointTracking)
+		require.True(t, cfg.EnableLedgerService)
+		require.True(t, cfg.EnableBlockService)
+		require.Equal(t, ":4160", cfg.NetAddress)
+		require.False(t, cfg.EnableGossipService)
+		require.Equal(t, "PLEASE_SET_ME", cfg.PublicAddress)
+
+		require.True(t, cfg.EnableP2PHybridMode)
+		require.Equal(t, ":4190", cfg.P2PNetAddress)
+		require.True(t, cfg.EnableDHTProviders)
+	})
+
+	t.Run("valid config test hybrid client", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := getConfigForArg("hybridClient")
+		require.NoError(t, err)
+
+		require.False(t, cfg.Archival)
+		require.Equal(t, uint64(0), cfg.MaxBlockHistoryLookback)
+		require.Equal(t, 365, cfg.CatchpointFileHistoryLength)
+		require.Equal(t, int64(0), cfg.CatchpointTracking)
+		require.False(t, cfg.EnableLedgerService)
+		require.False(t, cfg.EnableBlockService)
+		require.Empty(t, cfg.NetAddress)
+		// True because it is the default value, net address is blank so has no effect in practice
+		require.True(t, cfg.EnableGossipService)
+		require.Equal(t, "", cfg.PublicAddress)
+
+		require.True(t, cfg.EnableP2PHybridMode)
+		require.Equal(t, ":4190", cfg.P2PNetAddress)
+		require.True(t, cfg.EnableDHTProviders)
+	})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -148,6 +148,11 @@ func mergeConfigFromFile(configpath string, source Local) (Local, error) {
 
 	err = loadConfig(f, &source)
 
+	// If the PublicAddress in config file has the PlaceholderPublicAddress, treat it as if it were empty
+	if source.PublicAddress == PlaceholderPublicAddress {
+		source.PublicAddress = ""
+	}
+
 	if source.NetAddress != "" {
 		source.EnableLedgerService = true
 		source.EnableBlockService = true

--- a/config/config.go
+++ b/config/config.go
@@ -104,6 +104,9 @@ const CatchpointTrackingModeTracked = 1
 // as long as CatchpointInterval > 0
 const CatchpointTrackingModeStored = 2
 
+// PlaceholderPublicAddress is a placeholder for the public address generated in certain profiles
+const PlaceholderPublicAddress = "PLEASE_SET_ME"
+
 // LoadConfigFromDisk returns a Local config structure based on merging the defaults
 // with settings loaded from the config file from the custom dir.  If the custom file
 // cannot be loaded, the default config is returned (with the error from loading the

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -112,7 +112,8 @@ func MakeHost(cfg config.Local, datadir string, pstore *pstore.PeerStore) (host.
 			listenAddr = parsedListenAddr
 		}
 	} else {
-		listenAddr = "/ip4/0.0.0.0/tcp/0"
+		// don't listen if NetAddress is not set.
+		listenAddr = ""
 	}
 
 	var disableMetrics = func(cfg *libp2p.Config) error { return nil }
@@ -163,6 +164,11 @@ func MakeService(ctx context.Context, log logging.Logger, cfg config.Local, h ho
 
 // Start starts the P2P service
 func (s *serviceImpl) Start() error {
+	if s.listenAddr == "" {
+		// don't listen if no listen address configured
+		return nil
+	}
+
 	listenAddr, err := multiaddr.NewMultiaddr(s.listenAddr)
 	if err != nil {
 		s.log.Errorf("failed to create multiaddress: %s", err)

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -346,8 +346,11 @@ func (n *P2PNetwork) Start() error {
 		go n.handler.messageHandlerThread(&n.wg, n.wsPeersConnectivityCheckTicker.C, n, "network", "P2PNetwork")
 	}
 
-	n.wg.Add(1)
-	go n.httpdThread()
+	// start the HTTP server if configured to listen
+	if n.config.NetAddress != "" {
+		n.wg.Add(1)
+		go n.httpdThread()
+	}
 
 	n.wg.Add(1)
 	go n.broadcaster.broadcastThread(&n.wg, n, "network", "P2PNetwork")
@@ -471,10 +474,7 @@ func (n *P2PNetwork) meshThread() {
 
 func (n *P2PNetwork) httpdThread() {
 	defer n.wg.Done()
-	if n.config.NetAddress == "" {
-		// don't start HTTP server if not configured to listen
-		return
-	}
+
 	err := n.httpServer.Serve()
 	if err != nil {
 		n.log.Errorf("Error serving libp2phttp: %v", err)

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -471,6 +471,10 @@ func (n *P2PNetwork) meshThread() {
 
 func (n *P2PNetwork) httpdThread() {
 	defer n.wg.Done()
+	if n.config.NetAddress == "" {
+		// don't start HTTP server if not configured to listen
+		return
+	}
 	err := n.httpServer.Serve()
 	if err != nil {
 		n.log.Errorf("Error serving libp2phttp: %v", err)

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -1051,7 +1051,6 @@ func TestP2PWantTXGossip(t *testing.T) {
 	net.wantTXGossip.Store(false)
 	net.nodeInfo = &nopeNodeInfo{}
 	net.config.ForceFetchTransactions = true
-	net.config.NetAddress = "127.0.0.1:0"
 	net.relayMessages = false
 	net.OnNetworkAdvance()
 	require.Eventually(t, func() bool { return mockService.count.Load() == 2 }, 1*time.Second, 50*time.Millisecond)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Introduce configuration profiles for hybrid (WS+P2P support) relays, archival nodes, and part/non-participating role nodes. 
<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Unit tests were added in `profileCommand_test.go` for each new profile. All 3 configurations were tested being generated via algocfg CLI, with each also used on a running local node.
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
