### PR TITLE
P2P: Add DisableRelayP2PTransport param to expose ability for certain node…

### DIFF
--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -610,6 +610,10 @@ type Local struct {
 	// EnableDHT will turn on the hash table for use with capabilities advertisement
 	EnableDHTProviders bool `version[34]:"false"`
 
+	// DisableP2PRelayTransport disables the relay transport for the P2P network. Relay transport is
+	// enabled by default when EnableP2P or EnableP2PHybridMode is set to true.
+	DisableP2PRelayTransport bool `version[34]:"false"`
+
 	// P2PPersistPeerID will write the private key used for the node's PeerID to the P2PPrivateKeyLocation.
 	// This is only used when P2PEnable is true. If P2PPrivateKey is not specified, it uses the default location.
 	P2PPersistPeerID bool `version[29]:"false"`

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -59,6 +59,7 @@ var defaultLocal = Local{
 	DisableLocalhostConnectionRateLimit:        true,
 	DisableNetworking:                          false,
 	DisableOutgoingConnectionThrottling:        false,
+	DisableP2PRelayTransport:                   false,
 	EnableAccountUpdatesStats:                  false,
 	EnableAgreementReporting:                   false,
 	EnableAgreementTimeMetrics:                 false,

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -38,6 +38,7 @@
     "DisableLocalhostConnectionRateLimit": true,
     "DisableNetworking": false,
     "DisableOutgoingConnectionThrottling": false,
+    "DisableP2PRelayTransport": false,
     "EnableAccountUpdatesStats": false,
     "EnableAgreementReporting": false,
     "EnableAgreementTimeMetrics": false,

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -115,9 +115,14 @@ func MakeHost(cfg config.Local, datadir string, pstore *pstore.PeerStore) (host.
 		listenAddr = "/ip4/0.0.0.0/tcp/0"
 	}
 
-	// the libp2p.NoListenAddrs builtin disables relays but this one does not
-	var noListenAddrs = func(cfg *libp2p.Config) error {
-		cfg.ListenAddrs = []multiaddr.Multiaddr{}
+	// the libp2p.NoListenAddrs builtin disables relays but this one only does if
+	// DisableP2PRelayTransport is set to true
+	var noListenAddrs = func(p2pCfg *libp2p.Config) error {
+		if cfg.DisableP2PRelayTransport {
+			return libp2p.NoListenAddrs(p2pCfg)
+		}
+
+		p2pCfg.ListenAddrs = []multiaddr.Multiaddr{}
 		return nil
 	}
 

--- a/test/testdata/configs/config-v34.json
+++ b/test/testdata/configs/config-v34.json
@@ -38,6 +38,7 @@
     "DisableLocalhostConnectionRateLimit": true,
     "DisableNetworking": false,
     "DisableOutgoingConnectionThrottling": false,
+    "DisableP2PRelayTransport": false,
     "EnableAccountUpdatesStats": false,
     "EnableAgreementReporting": false,
     "EnableAgreementTimeMetrics": false,


### PR DESCRIPTION


<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
Add DisableRelayP2PTransport param to expose ability for certain node classes to not gossip messages on the P2P network (while still connecting to it).
<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan
Existing tests should pass.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
