### PR TITLE
P2P: Disable circuit relaying via libp2p.NoListenAddrs

### DIFF
--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -115,12 +115,6 @@ func MakeHost(cfg config.Local, datadir string, pstore *pstore.PeerStore) (host.
 		listenAddr = "/ip4/0.0.0.0/tcp/0"
 	}
 
-	// the libp2p.NoListenAddrs builtin disables relays but this one does not
-	var noListenAddrs = func(cfg *libp2p.Config) error {
-		cfg.ListenAddrs = []multiaddr.Multiaddr{}
-		return nil
-	}
-
 	var disableMetrics = func(cfg *libp2p.Config) error { return nil }
 	metrics.DefaultRegistry().Register(&metrics.PrometheusDefaultMetrics)
 
@@ -130,7 +124,7 @@ func MakeHost(cfg config.Local, datadir string, pstore *pstore.PeerStore) (host.
 		libp2p.Transport(tcp.NewTCPTransport),
 		libp2p.Muxer("/yamux/1.0.0", &ymx),
 		libp2p.Peerstore(pstore),
-		noListenAddrs,
+		libp2p.NoListenAddrs,
 		libp2p.Security(noise.ID, noise.New),
 		disableMetrics,
 	)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

This PR simply disables circuit relaying via libp2p.NoListenAddrs in either p2p or hybrid operating modes. More information on circuit relaying can be found at [https://docs.libp2p.io/concepts/nat/circuit-relay/](https://docs.libp2p.io/concepts/nat/circuit-relay/).

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Existing tests should pass.
<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
