### PR TITLE
tests: debug logging for TestVotersReloadFromDiskAfterOneStateProofCommitted

### DIFF
--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -215,6 +215,7 @@ func (l *Ledger) reloadLedger() error {
 	blockListeners = append(blockListeners, l.notifier.listeners...)
 
 	// close the trackers.
+	l.trackers.log = l.trackerLog()
 	l.trackers.close()
 
 	// init block queue

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -492,6 +492,7 @@ func (tr *trackerRegistry) isBehindCommittingDeltas(latest basics.Round) bool {
 }
 
 func (tr *trackerRegistry) close() {
+	fmt.Printf("trackerRegistry: %v\n", tr.log)
 	tr.log.Debugf("trackerRegistry is closing")
 	if tr.ctxCancel != nil {
 		tr.ctxCancel()


### PR DESCRIPTION
## Summary

Recent test [failure](https://app.circleci.com/pipelines/github/algorand/go-algorand/18713/workflows/3f6cd5f8-2ec2-4a8b-b6f5-0f9185f4eef6/jobs/275334/parallel-runs/29) indicates `TestVotersReloadFromDiskAfterOneStateProofCommitted` it can hang on waiting tracker registry to close. Added debug logging to confirm or rule out this.

## Test Plan

This is an extra debug log statements for `TestVotersReloadFromDiskAfterOneStateProofCommitted` investigation.