### PR TITLE
rest api: Fix to Disable API authentication

### DIFF
--- a/daemon/algod/api/server/router.go
+++ b/daemon/algod/api/server/router.go
@@ -19,9 +19,10 @@ package server
 
 import (
 	"fmt"
-	"golang.org/x/sync/semaphore"
 	"net"
 	"net/http"
+
+	"golang.org/x/sync/semaphore"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -74,18 +75,26 @@ func registerHandlers(router *echo.Echo, prefix string, routes lib.Routes, ctx l
 
 // NewRouter builds and returns a new router with our REST handlers registered.
 func NewRouter(logger logging.Logger, node APINodeInterface, shutdown <-chan struct{}, apiToken string, adminAPIToken string, listener net.Listener, numConnectionsLimit uint64) *echo.Echo {
-	if err := tokens.ValidateAPIToken(apiToken); err != nil {
-		logger.Errorf("Invalid apiToken was passed to NewRouter ('%s'): %v", apiToken, err)
-	}
+	// check admin token and init admin middleware
 	if err := tokens.ValidateAPIToken(adminAPIToken); err != nil {
 		logger.Errorf("Invalid adminAPIToken was passed to NewRouter ('%s'): %v", adminAPIToken, err)
 	}
 	adminMiddleware := []echo.MiddlewareFunc{
 		middlewares.MakeAuth(TokenHeader, []string{adminAPIToken}),
 	}
+
+	// check public api tokens and init public middleware
 	publicMiddleware := []echo.MiddlewareFunc{
 		middleware.BodyLimit(MaxRequestBodyBytes),
-		middlewares.MakeAuth(TokenHeader, []string{adminAPIToken, apiToken}),
+	}
+	if apiToken == "" {
+		logger.Warn("Running with empty apiToken")
+	} else {
+		if err := tokens.ValidateAPIToken(apiToken); err != nil {
+			logger.Errorf("Invalid apiToken was passed to NewRouter ('%s'): %v", apiToken, err)
+		}
+		publicMiddleware = append(publicMiddleware, middlewares.MakeAuth(TokenHeader, []string{adminAPIToken, apiToken}))
+
 	}
 
 	e := echo.New()

--- a/daemon/algod/api/server/router.go
+++ b/daemon/algod/api/server/router.go
@@ -88,7 +88,7 @@ func NewRouter(logger logging.Logger, node APINodeInterface, shutdown <-chan str
 		middleware.BodyLimit(MaxRequestBodyBytes),
 	}
 	if apiToken == "" {
-		logger.Warn("Running with with public API authentication disabled")
+		logger.Warn("Running with public API authentication disabled")
 	} else {
 		if err := tokens.ValidateAPIToken(apiToken); err != nil {
 			logger.Errorf("Invalid apiToken was passed to NewRouter ('%s'): %v", apiToken, err)

--- a/daemon/algod/api/server/router.go
+++ b/daemon/algod/api/server/router.go
@@ -88,7 +88,7 @@ func NewRouter(logger logging.Logger, node APINodeInterface, shutdown <-chan str
 		middleware.BodyLimit(MaxRequestBodyBytes),
 	}
 	if apiToken == "" {
-		logger.Warn("Running with empty apiToken")
+		logger.Warn("Running with with public API authentication disabled")
 	} else {
 		if err := tokens.ValidateAPIToken(apiToken); err != nil {
 			logger.Errorf("Invalid apiToken was passed to NewRouter ('%s'): %v", apiToken, err)

--- a/test/e2e-go/restAPI/other/misc_test.go
+++ b/test/e2e-go/restAPI/other/misc_test.go
@@ -70,8 +70,7 @@ func TestDisabledAPIConfig(t *testing.T) {
 	a.NoError(err)
 
 	// check admin api works with the generated token
-	adminClient := localFixture.LibGoalClient
-	_, err = adminClient.GetParticipationKeys()
+	_, err = libgoalClient.GetParticipationKeys()
 	assert.NoError(t, err)
 
 	// check admin api doesn't work with an invalid token

--- a/test/e2e-go/restAPI/other/misc_test.go
+++ b/test/e2e-go/restAPI/other/misc_test.go
@@ -39,12 +39,12 @@ func TestDisabledAPIConfig(t *testing.T) {
 	localFixture.Setup(t, filepath.Join("nettemplates", "DisableAPIAuth.json"))
 	defer localFixture.Shutdown()
 
-	testClient := localFixture.LibGoalClient
+	libgoalClient := localFixture.LibGoalClient
 
-	statusResponse, err := testClient.Status()
+	statusResponse, err := libgoalClient.Status()
 	a.NoError(err)
 	a.NotEmpty(statusResponse)
-	statusResponse2, err := testClient.Status()
+	statusResponse2, err := libgoalClient.Status()
 	a.NoError(err)
 	a.NotEmpty(statusResponse2)
 	a.True(statusResponse2.LastRound >= statusResponse.LastRound)
@@ -58,12 +58,22 @@ func TestDisabledAPIConfig(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 
 	// check public api works without a token
-	testClient.WaitForRound(1)
+	url, err := localFixture.NC.ServerURL()
+	a.NoError(err)
+	testClient := client.MakeRestClient(url, "") // empty token
+
+	_, err = testClient.WaitForBlock(1)
+	assert.NoError(t, err)
 	_, err = testClient.Block(1)
 	assert.NoError(t, err)
+	_, err = testClient.Status()
+	a.NoError(err)
+
 	// check admin api works with the generated token
-	_, err = testClient.GetParticipationKeys()
+	adminClient := localFixture.LibGoalClient
+	_, err = adminClient.GetParticipationKeys()
 	assert.NoError(t, err)
+
 	// check admin api doesn't work with an invalid token
 	algodURL, err := nc.ServerURL()
 	assert.NoError(t, err)

--- a/test/framework/fixtures/libgoalFixture.go
+++ b/test/framework/fixtures/libgoalFixture.go
@@ -390,7 +390,7 @@ func (f *LibGoalFixture) dumpLogs(filePath string) {
 	fmt.Fprintf(os.Stderr, "%s/%s:\n", parts[len(parts)-2], parts[len(parts)-1]) // Primary/node.log
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		fmt.Fprint(os.Stderr, scanner.Text())
+		fmt.Fprintln(os.Stderr, scanner.Text())
 	}
 	fmt.Fprintln(os.Stderr)
 }


### PR DESCRIPTION
## Summary

Fix to #5625 where incorrect test with a client always using an adminToken lead to incorrect actual implementation.

## Test Plan

Fixed an existing e2e test