### PR TITLE
p2p: handle txns in pubsub validator

### DIFF
--- a/components/mocks/mockNetwork.go
+++ b/components/mocks/mockNetwork.go
@@ -91,8 +91,8 @@ func (network *MockNetwork) RegisterHandlers(dispatch []network.TaggedMessageHan
 func (network *MockNetwork) ClearHandlers() {
 }
 
-// RegisterProcessors - empty implementation.
-func (network *MockNetwork) RegisterProcessors(dispatch []network.TaggedMessageProcessor) {
+// RegisterValidatorHandlers - empty implementation.
+func (network *MockNetwork) RegisterValidatorHandlers(dispatch []network.TaggedMessageValidatorHandler) {
 }
 
 // ClearProcessors - empty implementation

--- a/data/transactions/verify/txnBatch.go
+++ b/data/transactions/verify/txnBatch.go
@@ -17,7 +17,7 @@
 package verify
 
 import (
-	"errors"
+	"fmt"
 	"sync/atomic"
 
 	"github.com/algorand/go-algorand/crypto"
@@ -98,10 +98,16 @@ func (bl *batchLoad) addLoad(txngrp []transactions.SignedTxn, gctx *GroupContext
 
 }
 
+// TxnGroupBatchSigVerifier provides Verify method to synchronously verify a group of transactions
+// It starts a new block listener to receive latests block headers for the sig verification
+type TxnGroupBatchSigVerifier struct {
+	cache  VerifiedTransactionCache
+	nbw    *NewBlockWatcher
+	ledger logic.LedgerForSignature
+}
+
 type txnSigBatchProcessor struct {
-	cache       VerifiedTransactionCache
-	nbw         *NewBlockWatcher
-	ledger      logic.LedgerForSignature
+	TxnGroupBatchSigVerifier
 	resultChan  chan<- *VerificationResult
 	droppedChan chan<- *UnverifiedTxnSigJob
 }
@@ -142,25 +148,45 @@ func (tbp txnSigBatchProcessor) sendResult(veTxnGroup []transactions.SignedTxn, 
 	}
 }
 
-// MakeSigVerifyJobProcessor returns the object implementing the stream verifier Helper interface
-func MakeSigVerifyJobProcessor(ledger LedgerForStreamVerifier, cache VerifiedTransactionCache,
-	resultChan chan<- *VerificationResult, droppedChan chan<- *UnverifiedTxnSigJob) (svp execpool.BatchProcessor, err error) {
+func MakeSigVerifier(ledger LedgerForStreamVerifier, cache VerifiedTransactionCache) (TxnGroupBatchSigVerifier, error) {
 	latest := ledger.Latest()
 	latestHdr, err := ledger.BlockHdr(latest)
 	if err != nil {
-		return nil, errors.New("MakeStreamVerifier: Could not get header for previous block")
+		return TxnGroupBatchSigVerifier{}, fmt.Errorf("MakeSigVerifier: Could not get header for previous block: %w", err)
 	}
 
 	nbw := MakeNewBlockWatcher(latestHdr)
 	ledger.RegisterBlockListeners([]ledgercore.BlockListener{nbw})
 
+	verifier := TxnGroupBatchSigVerifier{
+		cache:  cache,
+		nbw:    nbw,
+		ledger: ledger,
+	}
+
+	return verifier, nil
+}
+
+// MakeSigVerifyJobProcessor returns the object implementing the stream verifier Helper interface
+func MakeSigVerifyJobProcessor(
+	ledger LedgerForStreamVerifier, cache VerifiedTransactionCache,
+	resultChan chan<- *VerificationResult, droppedChan chan<- *UnverifiedTxnSigJob,
+) (svp execpool.BatchProcessor, err error) {
+	sigVerifier, err := MakeSigVerifier(ledger, cache)
+	if err != nil {
+		return nil, err
+	}
 	return &txnSigBatchProcessor{
-		cache:       cache,
-		nbw:         nbw,
-		ledger:      ledger,
-		droppedChan: droppedChan,
-		resultChan:  resultChan,
+		TxnGroupBatchSigVerifier: sigVerifier,
+		droppedChan:              droppedChan,
+		resultChan:               resultChan,
 	}, nil
+}
+
+func (sv *TxnGroupBatchSigVerifier) Verify(stxs []transactions.SignedTxn) error {
+	blockHeader := sv.nbw.getBlockHeader()
+	_, err := txnGroup(stxs, blockHeader, sv.cache, sv.ledger, nil)
+	return err
 }
 
 func (tbp *txnSigBatchProcessor) ProcessBatch(txns []execpool.InputJob) {

--- a/data/transactions/verify/txnBatch.go
+++ b/data/transactions/verify/txnBatch.go
@@ -148,6 +148,7 @@ func (tbp txnSigBatchProcessor) sendResult(veTxnGroup []transactions.SignedTxn, 
 	}
 }
 
+// MakeSigVerifier creats a new TxnGroupBatchSigVerifier for synchronous verification of transactions
 func MakeSigVerifier(ledger LedgerForStreamVerifier, cache VerifiedTransactionCache) (TxnGroupBatchSigVerifier, error) {
 	latest := ledger.Latest()
 	latestHdr, err := ledger.BlockHdr(latest)
@@ -183,6 +184,7 @@ func MakeSigVerifyJobProcessor(
 	}, nil
 }
 
+// Verify synchronously verifies the signatures of the transactions in the group
 func (sv *TxnGroupBatchSigVerifier) Verify(stxs []transactions.SignedTxn) error {
 	blockHeader := sv.nbw.getBlockHeader()
 	_, err := txnGroup(stxs, blockHeader, sv.cache, sv.ledger, nil)

--- a/data/transactions/verify/txnBatch_test.go
+++ b/data/transactions/verify/txnBatch_test.go
@@ -139,9 +139,7 @@ func verifyResults(txnGroups [][]transactions.SignedTxn, badTxnGroups map[uint64
 	require.GreaterOrEqual(t, len(unverifiedGroups), badSigResultCounter)
 	for _, txn := range unverifiedGroups {
 		u, _ := binary.Uvarint(txn[0].Txn.Note)
-		if _, has := badTxnGroups[u]; has {
-			delete(badTxnGroups, u)
-		}
+		delete(badTxnGroups, u)
 	}
 	require.Empty(t, badTxnGroups, "unverifiedGroups should have all the transactions with invalid sigs")
 }
@@ -301,6 +299,7 @@ func TestGetNumberOfBatchableSigsInGroup(t *testing.T) {
 	txnGroups[mod][0].Sig = crypto.Signature{}
 	batchSigs, err := UnverifiedTxnSigJob{TxnGroup: txnGroups[mod]}.GetNumberOfBatchableItems()
 	require.ErrorIs(t, err, errTxnSigHasNoSig)
+	require.Equal(t, uint64(0), batchSigs)
 	mod++
 
 	_, signedTxns, secrets, addrs := generateTestObjects(numOfTxns, 20, 0, 50)
@@ -353,6 +352,7 @@ byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
 	txnGroups[mod][0].Msig = mSigTxn[0].Msig
 	batchSigs, err = UnverifiedTxnSigJob{TxnGroup: txnGroups[mod]}.GetNumberOfBatchableItems()
 	require.ErrorIs(t, err, errTxnSigNotWellFormed)
+	require.Equal(t, uint64(0), batchSigs)
 }
 
 // TestStreamToBatchPoolShutdown tests what happens when the exec pool shuts down
@@ -437,10 +437,11 @@ func TestStreamToBatchPoolShutdown(t *testing.T) { //nolint:paralleltest // Not 
 	// send txn groups to be verified
 	go func() {
 		defer wg.Done()
+	outer:
 		for _, tg := range txnGroups {
 			select {
 			case <-ctx.Done():
-				break
+				break outer
 			case inputChan <- &UnverifiedTxnSigJob{TxnGroup: tg, BacklogMessage: nil}:
 			}
 		}
@@ -493,6 +494,7 @@ func TestStreamToBatchRestart(t *testing.T) {
 	// send txn groups to be verified
 	go func() {
 		defer wg.Done()
+	outer:
 		for i, tg := range txnGroups {
 			if (i+1)%10 == 0 {
 				cancel()
@@ -502,7 +504,7 @@ func TestStreamToBatchRestart(t *testing.T) {
 			}
 			select {
 			case <-ctx2.Done():
-				break
+				break outer
 			case inputChan <- &UnverifiedTxnSigJob{TxnGroup: tg, BacklogMessage: nil}:
 			}
 		}
@@ -798,7 +800,10 @@ func TestStreamToBatchPostVBlocked(t *testing.T) {
 
 func TestStreamToBatchMakeStreamToBatchErr(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	_, err := MakeSigVerifyJobProcessor(&DummyLedgerForSignature{badHdr: true}, nil, nil, nil)
+	_, err := MakeSigVerifier(&DummyLedgerForSignature{badHdr: true}, nil)
+	require.Error(t, err)
+
+	_, err = MakeSigVerifyJobProcessor(&DummyLedgerForSignature{badHdr: true}, nil, nil, nil)
 	require.Error(t, err)
 }
 
@@ -863,11 +868,40 @@ func TestGetErredUnprocessed(t *testing.T) {
 
 	droppedChan := make(chan *UnverifiedTxnSigJob, 1)
 	svh := txnSigBatchProcessor{
-		resultChan:  make(chan<- *VerificationResult, 0),
+		resultChan:  make(chan<- *VerificationResult),
 		droppedChan: droppedChan,
 	}
 
 	svh.GetErredUnprocessed(&UnverifiedTxnSigJob{}, nil)
 	dropped := <-droppedChan
 	require.Equal(t, *dropped, UnverifiedTxnSigJob{})
+}
+
+func TestSigVerifier(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	numOfTxns := 16
+	txnGroups, badTxnGroups := getSignedTransactions(numOfTxns, numOfTxns, 0, 0)
+	require.GreaterOrEqual(t, len(txnGroups), 1)
+	require.Equal(t, len(badTxnGroups), 0)
+	txnGroup := txnGroups[0]
+
+	verificationPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, t)
+	defer verificationPool.Shutdown()
+
+	cache := MakeVerifiedTransactionCache(50000)
+
+	verifier, err := MakeSigVerifier(&DummyLedgerForSignature{}, cache)
+	require.NoError(t, err)
+
+	err = verifier.Verify(txnGroup)
+	require.NoError(t, err)
+
+	txnGroups, badTxnGroups = getSignedTransactions(numOfTxns, numOfTxns, 0, 1)
+	require.GreaterOrEqual(t, len(txnGroups), 1)
+	require.Greater(t, len(badTxnGroups), 0)
+	txnGroup = txnGroups[0]
+
+	err = verifier.Verify(txnGroup)
+	require.Error(t, err)
 }

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -178,8 +178,9 @@ func MakeTxHandler(opts TxHandlerOpts) (*TxHandler, error) {
 		streamVerifierChan:    make(chan execpool.InputJob),
 		streamVerifierDropped: make(chan *verify.UnverifiedTxnSigJob),
 
-		postVerificationQueue2: make(chan *verify.VerificationResult, 1),
-		streamVerifierDropped2: make(chan *verify.UnverifiedTxnSigJob, 1),
+		// match to the number of validator workers
+		postVerificationQueue2: make(chan *verify.VerificationResult, 20),
+		streamVerifierDropped2: make(chan *verify.UnverifiedTxnSigJob, 20),
 	}
 
 	if opts.Config.TxFilterRawMsgEnabled() {

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -698,7 +698,7 @@ func decodeMsg(data []byte) (unverifiedTxGroup []transactions.SignedTxn, consume
 	return unverifiedTxGroup, consumed, false
 }
 
-// incomingTxGroupDupRateLimit checks if the incoming transaction group has been seen before after reencoding to canonical representation.
+// incomingTxGroupCanonicalDedup checks if the incoming transaction group has been seen before after reencoding to canonical representation.
 // It also return canonical representation of the transaction group allowing the caller to compare it with the input.
 func (handler *TxHandler) incomingTxGroupCanonicalDedup(unverifiedTxGroup []transactions.SignedTxn, encodedExpectedSize int) (*crypto.Digest, []byte, bool) {
 	var canonicalKey *crypto.Digest

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -133,7 +133,7 @@ type TxHandler struct {
 	appLimiter                 *appRateLimiter
 	appLimiterBacklogThreshold int
 
-	// batchVerifier provides synchronous verification of transaction groups
+	// batchVerifier provides synchronous verification of transaction groups, used only by pubsub validation in validateIncomingTxMessage.
 	batchVerifier verify.TxnGroupBatchSigVerifier
 }
 

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -823,6 +823,8 @@ func (handler *TxHandler) validateIncomingTxMessage(rawmsg network.IncomingMessa
 		}
 	}
 
+	// TODO: implement a proper batching when more messages can be batched together
+	// and each validator waits on a channel for its result.
 	jobs := []execpool.InputJob{&verify.UnverifiedTxnSigJob{TxnGroup: wi.unverifiedTxGroup, BacklogMessage: wi}}
 	handler.batchProcessor.ProcessBatch(jobs)
 

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -2781,7 +2781,7 @@ func TestTxHandlerValidateIncomingTxMessage(t *testing.T) {
 	stxn := stxns[0]
 	blobNonCan := craftNonCanonical(t, &stxn, blob)
 	outmsg = handler.validateIncomingTxMessage(network.IncomingMessage{Data: blobNonCan})
-	require.Equal(t, outmsg.Action, network.Ignore)
+	require.Equal(t, outmsg.Action, network.Disconnect)
 
 	// invalid signature
 	stxns, _ = makeTxns(addresses, secrets, 1, 2, genesisHash)
@@ -2814,6 +2814,6 @@ func TestTxHandlerValidateIncomingTxMessage(t *testing.T) {
 		stxn := stxns[0]
 		blobNonCan := craftNonCanonical(t, &stxn, blob)
 		outmsg = handler.validateIncomingTxMessage(network.IncomingMessage{Data: blobNonCan})
-		require.Equal(t, outmsg.Action, network.Ignore)
+		require.Equal(t, outmsg.Action, network.Disconnect)
 	})
 }

--- a/network/gossipNode.go
+++ b/network/gossipNode.go
@@ -80,8 +80,10 @@ type GossipNode interface {
 	// ClearHandlers deregisters all the existing message handlers.
 	ClearHandlers()
 
-	// RegisterProcessors adds to the set of given message processors.
-	RegisterProcessors(dispatch []TaggedMessageProcessor)
+	// RegisterValidatorHandlers adds to the set of given message validation handlers.
+	// A difference with regular handlers is validation ones perform synchronous validation.
+	// Currently used as p2p pubsub topic validators.
+	RegisterValidatorHandlers(dispatch []TaggedMessageValidatorHandler)
 
 	// ClearProcessors deregisters all the existing message processors.
 	ClearProcessors()
@@ -156,14 +158,6 @@ type OutgoingMessage struct {
 	OnRelease func()
 }
 
-// ValidatedMessage is a message that has been validated and is ready to be processed.
-// Think as an intermediate one between IncomingMessage and OutgoingMessage
-type ValidatedMessage struct {
-	Action           ForwardingPolicy
-	Tag              Tag
-	ValidatedMessage interface{}
-}
-
 // ForwardingPolicy is an enum indicating to whom we should send a message
 //
 //msgp:ignore ForwardingPolicy
@@ -202,28 +196,19 @@ func (f HandlerFunc) Handle(message IncomingMessage) OutgoingMessage {
 	return f(message)
 }
 
-// MessageProcessor takes a IncomingMessage (e.g., vote, transaction), processes it, and returns what (if anything)
+// MessageValidatorHandler takes a IncomingMessage (e.g., vote, transaction), processes it, and returns what (if anything)
 // to send to the network in response.
-// This is an extension of the MessageHandler that works in two stages: validate ->[result]-> handle.
-type MessageProcessor interface {
-	Validate(message IncomingMessage) ValidatedMessage
-	Handle(message ValidatedMessage) OutgoingMessage
+// it supposed to perform synchronous validation and return the result of the validation
+// so that network knows immediately if the message should be be broadcasted or not.
+type MessageValidatorHandler interface {
+	ValidateHandle(message IncomingMessage) OutgoingMessage
 }
 
-// ProcessorValidateFunc represents an implementation of the MessageProcessor interface
-type ProcessorValidateFunc func(message IncomingMessage) ValidatedMessage
+// ValidateHandleFunc represents an implementation of the MessageProcessor interface
+type ValidateHandleFunc func(message IncomingMessage) OutgoingMessage
 
-// ProcessorHandleFunc represents an implementation of the MessageProcessor interface
-type ProcessorHandleFunc func(message ValidatedMessage) OutgoingMessage
-
-// Validate implements MessageProcessor.Validate, calling the validator with the IncomingMessage and returning the action
-// and validation extra data that can be use as the handler input.
-func (f ProcessorValidateFunc) Validate(message IncomingMessage) ValidatedMessage {
-	return f(message)
-}
-
-// Handle implements MessageProcessor.Handle calling the handler with the ValidatedMessage and returning the OutgoingMessage
-func (f ProcessorHandleFunc) Handle(message ValidatedMessage) OutgoingMessage {
+// ValidateHandle implements MessageValidatorHandler.ValidateHandle, calling the validator with the IncomingMessage and returning the action.
+func (f ValidateHandleFunc) ValidateHandle(message IncomingMessage) OutgoingMessage {
 	return f(message)
 }
 
@@ -235,9 +220,9 @@ type taggedMessageDispatcher[T any] struct {
 // TaggedMessageHandler receives one type of broadcast messages
 type TaggedMessageHandler = taggedMessageDispatcher[MessageHandler]
 
-// TaggedMessageProcessor receives one type of broadcast messages
+// TaggedMessageValidatorHandler receives one type of broadcast messages
 // and performs two stage processing: validating and handling
-type TaggedMessageProcessor = taggedMessageDispatcher[MessageProcessor]
+type TaggedMessageValidatorHandler = taggedMessageDispatcher[MessageValidatorHandler]
 
 // Propagate is a convenience function to save typing in the common case of a message handler telling us to propagate an incoming message
 // "return network.Propagate(msg)" instead of "return network.OutgoingMsg{network.Broadcast, msg.Tag, msg.Data}"

--- a/network/hybridNetwork.go
+++ b/network/hybridNetwork.go
@@ -180,10 +180,10 @@ func (n *HybridP2PNetwork) ClearHandlers() {
 	n.wsNetwork.ClearHandlers()
 }
 
-// RegisterProcessors adds to the set of given message processors.
-func (n *HybridP2PNetwork) RegisterProcessors(dispatch []TaggedMessageProcessor) {
-	n.p2pNetwork.RegisterProcessors(dispatch)
-	n.wsNetwork.RegisterProcessors(dispatch)
+// RegisterValidatorHandlers adds to the set of given message processors.
+func (n *HybridP2PNetwork) RegisterValidatorHandlers(dispatch []TaggedMessageValidatorHandler) {
+	n.p2pNetwork.RegisterValidatorHandlers(dispatch)
+	n.wsNetwork.RegisterValidatorHandlers(dispatch)
 }
 
 // ClearProcessors deregisters all the existing message processors.

--- a/network/multiplexer.go
+++ b/network/multiplexer.go
@@ -61,8 +61,8 @@ func (m *Multiplexer) getHandler(tag Tag) (MessageHandler, bool) {
 }
 
 // Retrieves the processor for the given message Tag from the processors array.
-func (m *Multiplexer) getProcessor(tag Tag) (MessageProcessor, bool) {
-	return getHandler[MessageProcessor](&m.msgProcessors, tag)
+func (m *Multiplexer) getProcessor(tag Tag) (MessageValidatorHandler, bool) {
+	return getHandler[MessageValidatorHandler](&m.msgProcessors, tag)
 }
 
 // Handle is the "input" side of the multiplexer. It dispatches the message to the previously defined handler.
@@ -74,17 +74,9 @@ func (m *Multiplexer) Handle(msg IncomingMessage) OutgoingMessage {
 }
 
 // Validate is an alternative "input" side of the multiplexer. It dispatches the message to the previously defined validator.
-func (m *Multiplexer) Validate(msg IncomingMessage) ValidatedMessage {
+func (m *Multiplexer) Validate(msg IncomingMessage) OutgoingMessage {
 	if handler, ok := m.getProcessor(msg.Tag); ok {
-		return handler.Validate(msg)
-	}
-	return ValidatedMessage{}
-}
-
-// Process is the second step of message handling after validation. It dispatches the message to the previously defined processor.
-func (m *Multiplexer) Process(msg ValidatedMessage) OutgoingMessage {
-	if handler, ok := m.getProcessor(msg.Tag); ok {
-		return handler.Handle(msg)
+		return handler.ValidateHandle(msg)
 	}
 	return OutgoingMessage{}
 }
@@ -110,8 +102,8 @@ func (m *Multiplexer) RegisterHandlers(dispatch []TaggedMessageHandler) {
 	registerMultiplexer(&m.msgHandlers, dispatch)
 }
 
-// RegisterProcessors registers the set of given message handlers.
-func (m *Multiplexer) RegisterProcessors(dispatch []TaggedMessageProcessor) {
+// RegisterValidatorHandlers registers the set of given message handlers.
+func (m *Multiplexer) RegisterValidatorHandlers(dispatch []TaggedMessageValidatorHandler) {
 	registerMultiplexer(&m.msgProcessors, dispatch)
 }
 
@@ -145,5 +137,5 @@ func (m *Multiplexer) ClearHandlers(excludeTags []Tag) {
 
 // ClearProcessors deregisters all the existing message handlers other than the one provided in the excludeTags list
 func (m *Multiplexer) ClearProcessors(excludeTags []Tag) {
-	clearMultiplexer[MessageProcessor](&m.msgProcessors, excludeTags)
+	clearMultiplexer[MessageValidatorHandler](&m.msgProcessors, excludeTags)
 }

--- a/network/p2p/pubsub.go
+++ b/network/p2p/pubsub.go
@@ -98,6 +98,7 @@ func makePubSub(ctx context.Context, cfg config.Local, host host.Host) (*pubsub.
 		pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign),
 		// pubsub.WithValidateThrottle(cfg.TxBacklogSize),
 		pubsub.WithValidateWorkers(incomingThreads),
+		pubsub.WithRawTracer(pubsubTracer{}),
 	}
 
 	return pubsub.NewGossipSub(ctx, host, options...)

--- a/network/p2p/pubsubTracer.go
+++ b/network/p2p/pubsubTracer.go
@@ -26,7 +26,7 @@ import (
 
 var _ = pubsub.RawTracer(pubsubTracer{})
 
-var transactionMessagesDroppedFromBacklog = metrics.MakeCounter(metrics.TransactionMessagesDroppedFromBacklog)
+var transactionMessagesDroppedFromBacklogP2P = metrics.MakeCounter(metrics.TransactionMessagesDroppedFromBacklogP2P)
 var transactionMessagesDupRawMsg = metrics.MakeCounter(metrics.TransactionMessagesDupRawMsg)
 
 // pubsubTracer is a tracer for pubsub events used to track metrics.
@@ -60,7 +60,7 @@ func (t pubsubTracer) DeliverMessage(msg *pubsub.Message) {}
 // The reason argument can be one of the named strings Reject*.
 func (t pubsubTracer) RejectMessage(msg *pubsub.Message, reason string) {
 	if reason == pubsub.RejectValidationThrottled || reason == pubsub.RejectValidationQueueFull {
-		transactionMessagesDroppedFromBacklog.Inc(nil)
+		transactionMessagesDroppedFromBacklogP2P.Inc(nil)
 	}
 }
 

--- a/network/p2p/pubsubTracer.go
+++ b/network/p2p/pubsubTracer.go
@@ -1,0 +1,86 @@
+// Copyright (C) 2019-2024 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package p2p
+
+import (
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+
+	"github.com/algorand/go-algorand/util/metrics"
+)
+
+var _ = pubsub.RawTracer(pubsubTracer{})
+
+var transactionMessagesDroppedFromBacklog = metrics.MakeCounter(metrics.TransactionMessagesDroppedFromBacklog)
+var transactionMessagesDupRawMsg = metrics.MakeCounter(metrics.TransactionMessagesDupRawMsg)
+
+// pubsubTracer is a tracer for pubsub events used to track metrics.
+type pubsubTracer struct{}
+
+// AddPeer is invoked when a new peer is added.
+func (t pubsubTracer) AddPeer(p peer.ID, proto protocol.ID) {}
+
+// RemovePeer is invoked when a peer is removed.
+func (t pubsubTracer) RemovePeer(p peer.ID) {}
+
+// Join is invoked when a new topic is joined
+func (t pubsubTracer) Join(topic string) {}
+
+// Leave is invoked when a topic is abandoned
+func (t pubsubTracer) Leave(topic string) {}
+
+// Graft is invoked when a new peer is grafted on the mesh (gossipsub)
+func (t pubsubTracer) Graft(p peer.ID, topic string) {}
+
+// Prune is invoked when a peer is pruned from the message (gossipsub)
+func (t pubsubTracer) Prune(p peer.ID, topic string) {}
+
+// ValidateMessage is invoked when a message first enters the validation pipeline.
+func (t pubsubTracer) ValidateMessage(msg *pubsub.Message) {}
+
+// DeliverMessage is invoked when a message is delivered
+func (t pubsubTracer) DeliverMessage(msg *pubsub.Message) {}
+
+// RejectMessage is invoked when a message is Rejected or Ignored.
+// The reason argument can be one of the named strings Reject*.
+func (t pubsubTracer) RejectMessage(msg *pubsub.Message, reason string) {
+	if reason == pubsub.RejectValidationThrottled || reason == pubsub.RejectValidationQueueFull {
+		transactionMessagesDroppedFromBacklog.Inc(nil)
+	}
+}
+
+// DuplicateMessage is invoked when a duplicate message is dropped.
+func (t pubsubTracer) DuplicateMessage(msg *pubsub.Message) {
+	transactionMessagesDupRawMsg.Inc(nil)
+}
+
+// ThrottlePeer is invoked when a peer is throttled by the peer gater.
+func (t pubsubTracer) ThrottlePeer(p peer.ID) {}
+
+// RecvRPC is invoked when an incoming RPC is received.
+func (t pubsubTracer) RecvRPC(rpc *pubsub.RPC) {}
+
+// SendRPC is invoked when a RPC is sent.
+func (t pubsubTracer) SendRPC(rpc *pubsub.RPC, p peer.ID) {}
+
+// DropRPC is invoked when an outbound RPC is dropped, typically because of a queue full.
+func (t pubsubTracer) DropRPC(rpc *pubsub.RPC, p peer.ID) {}
+
+// UndeliverableMessage is invoked when the consumer of Subscribe is not reading messages fast enough and
+// the pressure release mechanism trigger, dropping messages.
+func (t pubsubTracer) UndeliverableMessage(msg *pubsub.Message) {}

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -692,7 +692,7 @@ func (n *P2PNetwork) RegisterValidatorHandlers(dispatch []TaggedMessageValidator
 
 // ClearProcessors deregisters all the existing message handlers.
 func (n *P2PNetwork) ClearProcessors() {
-	n.handler.ClearProcessors([]Tag{})
+	n.handler.ClearValidatorHandlers([]Tag{})
 }
 
 // GetHTTPClient returns a http.Client with a suitable for the network Transport
@@ -933,7 +933,7 @@ func (n *P2PNetwork) txTopicValidator(ctx context.Context, peerID peer.ID, msg *
 	peerStats.txReceived.Add(1)
 	n.peerStatsMu.Unlock()
 
-	outmsg := n.handler.Validate(inmsg)
+	outmsg := n.handler.ValidateHandle(inmsg)
 	// there was a decision made in the handler about this message
 	switch outmsg.Action {
 	case Ignore:

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -685,9 +685,9 @@ func (n *P2PNetwork) ClearHandlers() {
 	n.handler.ClearHandlers([]Tag{})
 }
 
-// RegisterProcessors adds to the set of given message handlers.
-func (n *P2PNetwork) RegisterProcessors(dispatch []TaggedMessageProcessor) {
-	n.handler.RegisterProcessors(dispatch)
+// RegisterValidatorHandlers adds to the set of given message handlers.
+func (n *P2PNetwork) RegisterValidatorHandlers(dispatch []TaggedMessageValidatorHandler) {
+	n.handler.RegisterValidatorHandlers(dispatch)
 }
 
 // ClearProcessors deregisters all the existing message handlers.
@@ -880,7 +880,8 @@ func (n *P2PNetwork) txTopicHandleLoop() {
 	n.log.Debugf("Subscribed to topic %s", p2p.TXTopicName)
 
 	for {
-		msg, err := sub.Next(n.ctx)
+		// msg from sub.Next not used since all work done by txTopicValidator
+		_, err := sub.Next(n.ctx)
 		if err != nil {
 			if err != pubsub.ErrSubscriptionCancelled && err != context.Canceled {
 				n.log.Errorf("Error reading from subscription %v, peerId %s", err, n.service.ID())
@@ -889,13 +890,6 @@ func (n *P2PNetwork) txTopicHandleLoop() {
 			sub.Cancel()
 			return
 		}
-		// if there is a self-sent the message no need to process it.
-		if msg.ReceivedFrom == n.service.ID() {
-			continue
-		}
-
-		_ = n.handler.Process(msg.ValidatorData.(ValidatedMessage))
-
 		// participation or configuration change, cancel subscription and quit
 		if !n.wantTXGossip.Load() {
 			n.log.Debugf("Cancelling subscription to topic %s due participation change", p2p.TXTopicName)

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -124,6 +124,7 @@ var networkIncomingBufferMicros = metrics.MakeCounter(metrics.MetricName{Name: "
 var networkHandleMicros = metrics.MakeCounter(metrics.MetricName{Name: "algod_network_rx_handle_micros_total", Description: "microseconds spent by protocol handlers in the receive thread"})
 
 var networkBroadcasts = metrics.MakeCounter(metrics.MetricName{Name: "algod_network_broadcasts_total", Description: "number of broadcast operations"})
+var networkBroadcastQueueFull = metrics.MakeCounter(metrics.MetricName{Name: "algod_network_broadcast_queue_full_total", Description: "number of messages that were drops due to full broadcast queue"})
 var networkBroadcastQueueMicros = metrics.MakeCounter(metrics.MetricName{Name: "algod_network_broadcast_queue_micros_total", Description: "microseconds broadcast requests sit on queue"})
 var networkBroadcastSendMicros = metrics.MakeCounter(metrics.MetricName{Name: "algod_network_broadcast_send_micros_total", Description: "microseconds spent broadcasting"})
 var networkBroadcastsDropped = metrics.MakeCounter(metrics.MetricName{Name: "algod_broadcasts_dropped_total", Description: "number of broadcast messages not sent to any peer"})
@@ -135,7 +136,6 @@ var networkPeerAlreadyClosed = metrics.MakeCounter(metrics.MetricName{Name: "alg
 
 var networkSlowPeerDrops = metrics.MakeCounter(metrics.MetricName{Name: "algod_network_slow_drops_total", Description: "number of peers dropped for being slow to send to"})
 var networkIdlePeerDrops = metrics.MakeCounter(metrics.MetricName{Name: "algod_network_idle_drops_total", Description: "number of peers dropped due to idle connection"})
-var networkBroadcastQueueFull = metrics.MakeCounter(metrics.MetricName{Name: "algod_network_broadcast_queue_full_total", Description: "number of messages that were drops due to full broadcast queue"})
 
 var minPing = metrics.MakeGauge(metrics.MetricName{Name: "algod_network_peer_min_ping_seconds", Description: "Network round trip time to fastest peer in seconds."})
 var meanPing = metrics.MakeGauge(metrics.MetricName{Name: "algod_network_peer_mean_ping_seconds", Description: "Network round trip time to average peer in seconds."})

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -864,8 +864,8 @@ func (wn *WebsocketNetwork) ClearHandlers() {
 	wn.handler.ClearHandlers([]Tag{protocol.PingTag, protocol.PingReplyTag, protocol.NetPrioResponseTag})
 }
 
-// RegisterProcessors registers the set of given message handlers.
-func (wn *WebsocketNetwork) RegisterProcessors(dispatch []TaggedMessageProcessor) {
+// RegisterValidatorHandlers registers the set of given message handlers.
+func (wn *WebsocketNetwork) RegisterValidatorHandlers(dispatch []TaggedMessageValidatorHandler) {
 }
 
 // ClearProcessors deregisters all the existing message handlers.

--- a/test/e2e-go/features/p2p/p2p_basic_test.go
+++ b/test/e2e-go/features/p2p/p2p_basic_test.go
@@ -17,6 +17,7 @@
 package p2p
 
 import (
+	"crypto/rand"
 	"path/filepath"
 	"testing"
 	"time"
@@ -28,7 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testP2PWithConfig(t *testing.T, cfgname string) {
+func testP2PWithConfig(t *testing.T, templateName string) *fixtures.RestClientFixture {
 	r := require.New(fixtures.SynchronizedTest(t))
 
 	var fixture fixtures.RestClientFixture
@@ -42,22 +43,88 @@ func testP2PWithConfig(t *testing.T, cfgname string) {
 	consensus[protocol.ConsensusCurrentVersion] = fastProtocol
 	fixture.SetConsensus(consensus)
 
-	fixture.Setup(t, filepath.Join("nettemplates", cfgname))
-	defer fixture.ShutdownImpl(true) // preserve logs in testdir
-
+	fixture.Setup(t, filepath.Join("nettemplates", templateName))
 	_, err := fixture.NC.AlgodClient()
 	r.NoError(err)
 
 	err = fixture.WaitForRound(10, 30*time.Second)
 	r.NoError(err)
+
+	return &fixture
 }
 
 func TestP2PTwoNodes(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	testP2PWithConfig(t, "TwoNodes50EachP2P.json")
+	fixture := testP2PWithConfig(t, "TwoNodes50EachP2P.json")
+	defer fixture.Shutdown()
+
+	// ensure transaction propagation on both directions
+	pingClient := fixture.LibGoalClient
+	pingAccountList, err := fixture.GetWalletsSortedByBalance()
+	require.NoError(t, err)
+	pingAccount := pingAccountList[0].Address
+
+	pongClient := fixture.GetLibGoalClientForNamedNode("Node")
+	pongAccounts, err := fixture.GetNodeWalletsSortedByBalance(pongClient)
+	require.NoError(t, err)
+	pongAccount := pongAccounts[0].Address
+
+	pingBalance, err := pingClient.GetBalance(pingAccount)
+	require.NoError(t, err)
+	pongBalance, err := pingClient.GetBalance(pongAccount)
+	require.NoError(t, err)
+
+	require.Equal(t, pingBalance, pongBalance)
+
+	expectedPingBalance := pingBalance
+	expectedPongBalance := pongBalance
+
+	minTxnFee, minAcctBalance, err := fixture.CurrentMinFeeAndBalance()
+	require.NoError(t, err)
+
+	transactionFee := minTxnFee + 5
+	amountPongSendsPing := minAcctBalance
+	amountPingSendsPong := minAcctBalance * 3 / 2
+
+	pongTxidsToAddresses := make(map[string]string)
+	pingTxidsToAddresses := make(map[string]string)
+
+	randNote := func(tb testing.TB) []byte {
+		b := make([]byte, 8)
+		_, err := rand.Read(b)
+		require.NoError(tb, err)
+		return b
+	}
+
+	for i := 0; i < 5; i++ {
+		pongTx, err := pongClient.SendPaymentFromUnencryptedWallet(pongAccount, pingAccount, transactionFee, amountPongSendsPing, randNote(t))
+		pongTxidsToAddresses[pongTx.ID().String()] = pongAccount
+		require.NoError(t, err)
+		pingTx, err := pingClient.SendPaymentFromUnencryptedWallet(pingAccount, pongAccount, transactionFee, amountPingSendsPong, randNote(t))
+		pingTxidsToAddresses[pingTx.ID().String()] = pingAccount
+		require.NoError(t, err)
+		expectedPingBalance = expectedPingBalance - transactionFee - amountPingSendsPong + amountPongSendsPing
+		expectedPongBalance = expectedPongBalance - transactionFee - amountPongSendsPing + amountPingSendsPong
+	}
+	curStatus, _ := pongClient.Status()
+	curRound := curStatus.LastRound
+
+	fixture.AlgodClient = fixture.GetAlgodClientForController(fixture.GetNodeControllerForDataDir(pongClient.DataDir()))
+	confirmed := fixture.WaitForAllTxnsToConfirm(curRound+uint64(5), pingTxidsToAddresses)
+	require.True(t, confirmed, "failed to see confirmed ping transaction by round %v", curRound+uint64(5))
+	confirmed = fixture.WaitForAllTxnsToConfirm(curRound+uint64(5), pongTxidsToAddresses)
+	require.True(t, confirmed, "failed to see confirmed pong transaction by round %v", curRound+uint64(5))
+
+	pingBalance, err = pongClient.GetBalance(pingAccount)
+	require.NoError(t, err)
+	pongBalance, err = pongClient.GetBalance(pongAccount)
+	require.NoError(t, err)
+	require.True(t, expectedPingBalance <= pingBalance, "ping balance is different than expected.")
+	require.True(t, expectedPongBalance <= pongBalance, "pong balance is different than expected.")
 }
 
 func TestP2PFiveNodes(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	testP2PWithConfig(t, "FiveNodesP2P.json")
+	fixture := testP2PWithConfig(t, "FiveNodesP2P.json")
+	defer fixture.Shutdown()
 }

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -93,6 +93,8 @@ var (
 	TransactionMessagesHandled = MetricName{Name: "algod_transaction_messages_handled", Description: "Number of transaction messages handled"}
 	// TransactionMessagesDroppedFromBacklog "Number of transaction messages dropped from backlog"
 	TransactionMessagesDroppedFromBacklog = MetricName{Name: "algod_transaction_messages_dropped_backlog", Description: "Number of transaction messages dropped from backlog"}
+	// TransactionMessagesDroppedFromBacklogP2P "Number of transaction messages throttled with p2p pubsub"
+	TransactionMessagesDroppedFromBacklogP2P = MetricName{Name: "algod_transaction_messages_dropped_backlog_p2p", Description: "Number of transaction messages throttled with p2p pubsub"}
 	// TransactionMessagesDroppedFromPool "Number of transaction messages dropped from pool"
 	TransactionMessagesDroppedFromPool = MetricName{Name: "algod_transaction_messages_dropped_pool", Description: "Number of transaction messages dropped from pool"}
 	// TransactionMessagesAlreadyCommitted "Number of duplicate or error transaction messages before placing into a backlog"

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -93,8 +93,6 @@ var (
 	TransactionMessagesHandled = MetricName{Name: "algod_transaction_messages_handled", Description: "Number of transaction messages handled"}
 	// TransactionMessagesDroppedFromBacklog "Number of transaction messages dropped from backlog"
 	TransactionMessagesDroppedFromBacklog = MetricName{Name: "algod_transaction_messages_dropped_backlog", Description: "Number of transaction messages dropped from backlog"}
-	// TransactionMessagesDroppedFromBacklogP2P "Number of transaction messages throttled with p2p pubsub"
-	TransactionMessagesDroppedFromBacklogP2P = MetricName{Name: "algod_transaction_messages_dropped_backlog_p2p", Description: "Number of transaction messages throttled with p2p pubsub"}
 	// TransactionMessagesDroppedFromPool "Number of transaction messages dropped from pool"
 	TransactionMessagesDroppedFromPool = MetricName{Name: "algod_transaction_messages_dropped_pool", Description: "Number of transaction messages dropped from pool"}
 	// TransactionMessagesAlreadyCommitted "Number of duplicate or error transaction messages before placing into a backlog"
@@ -129,6 +127,17 @@ var (
 	TransactionMessagesAppLimiterDrop = MetricName{Name: "algod_transaction_messages_dropped_app_limiter", Description: "Number of transaction messages dropped after app limits check"}
 	// TransactionMessagesBacklogSize "Number of transaction messages in the TX handler backlog queue"
 	TransactionMessagesBacklogSize = MetricName{Name: "algod_transaction_messages_backlog_size", Description: "Number of transaction messages in the TX handler backlog queue"}
+
+	// TransactionMessagesP2PRejectMessage "Number of rejected p2p pubsub transaction messages"
+	TransactionMessagesP2PRejectMessage = MetricName{Name: "algod_transaction_messages_p2p_reject", Description: "Number of rejected p2p pubsub transaction messages"}
+	// TransactionMessagesP2PDuplicateMessage "Number of duplicate p2p pubsub transaction messages"}
+	TransactionMessagesP2PDuplicateMessage = MetricName{Name: "algod_transaction_messages_p2p_duplicate", Description: "Number of duplicate p2p pubsub transaction messages"}
+	// TransactionMessagesP2PDeliverMessage "Number of delivered p2p pubsub transaction messages"
+	TransactionMessagesP2PDeliverMessage = MetricName{Name: "algod_transaction_messages_p2p_delivered", Description: "Number of delivered p2p pubsub transaction messages"}
+	// TransactionMessagesP2PUndeliverableMessage "Number of undeliverable p2p pubsub transaction messages"
+	TransactionMessagesP2PUndeliverableMessage = MetricName{Name: "algod_transaction_messages_p2p_undeliverable", Description: "Number of undeliverable p2p pubsub transaction messages"}
+	// TransactionMessagesP2PValidateMessage "Number of p2p pubsub transaction messages received for validation"
+	TransactionMessagesP2PValidateMessage = MetricName{Name: "algod_transaction_messages_p2p_validate", Description: "Number of p2p pubsub transaction messages received for validation"}
 
 	// TransactionGroupTxSyncHandled "Number of transaction groups handled via txsync"
 	TransactionGroupTxSyncHandled = MetricName{Name: "algod_transaction_group_txsync_handled", Description: "Number of transaction groups handled via txsync"}


### PR DESCRIPTION
## Summary

This is a draft implementation on how txHandler logic would look like if fully implemented in pubsub validator.
It loses batch verification part so could be a large performance drawback.

Tried an alternative approach where pubsub validator always returns `Ignore` and then tx handler calls `Relay`. This does not work since pubsub discards the second submission as a duplicate.

## Test Plan

Extended e2e p2p test to send transactions

## Performance

Run scenario1s-p2p: 6781.17 TPS
![image](https://github.com/user-attachments/assets/30f94436-69ea-46cb-bc72-0b63cd01d006)

![image](https://github.com/user-attachments/assets/f5d74436-d6d7-4dfd-8a00-187aa8486879)


Resolves #6052 