### PR TITLE
tests: fix TestNodeHybridTopology

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -841,16 +841,13 @@ func TestNodeHybridTopology(t *testing.T) {
 	testParams0.AgreementFilterTimeoutPeriod0 = 500 * time.Millisecond
 	configurableConsensus[consensusTest0] = testParams0
 
-	minMoneyAtStart := 1_000_000
-	maxMoneyAtStart := 100_000_000_000
-	gen := rand.New(rand.NewSource(2))
-
+	// configure the stake to have R and A producing and confirming blocks
+	const totalStake = 100_000_000_000
 	const numAccounts = 3
 	acctStake := make([]basics.MicroAlgos, numAccounts)
-	for i := range acctStake {
-		acctStake[i] = basics.MicroAlgos{Raw: uint64(minMoneyAtStart + (gen.Int() % (maxMoneyAtStart - minMoneyAtStart)))}
-	}
 	acctStake[0] = basics.MicroAlgos{} // no stake at node 0
+	acctStake[1] = basics.MicroAlgos{Raw: uint64(totalStake / 2)}
+	acctStake[2] = basics.MicroAlgos{Raw: uint64(totalStake / 2)}
 
 	configHook := func(ni nodeInfo, cfg config.Local) (nodeInfo, config.Local) {
 		cfg = config.GetDefaultLocal()
@@ -937,7 +934,7 @@ func TestNodeHybridTopology(t *testing.T) {
 		e1, err := nodes[1].ledger.Block(targetRound)
 		require.NoError(t, err)
 		require.Equal(t, e1.Hash(), e0.Hash())
-	case <-time.After(4 * time.Minute): // set it to 2x of the dht.periodicBootstrapInterval
+	case <-time.After(3 * time.Minute): // set it to 1.5x of the dht.periodicBootstrapInterval to give DHT code to rebuild routing table one more time
 		require.Fail(t, fmt.Sprintf("no block notification for wallet: %v.", wallets[0]))
 	}
 }


### PR DESCRIPTION
## Summary

It appeared the test struggled from two problems:
1. Node 0 has not discovered node 2 in time.
2. Node 1 was falling [behind](https://app.circleci.com/pipelines/github/algorand/go-algorand/18795/workflows/d34ef684-18a9-4092-9a5d-0c6dc63aa736/jobs/276036)

To fix (1) increased by test timeout. libp2p-kad-dht has non-configurable timeout of 2m for peers refresh in runFixLowPeersLoop. It looks like sometimes because of topology DHT does not have right peers in its routing table and max test wait time is not enough to update the routing table. My theory node0 discovers node2 very late and only have chance to download couple blocks. 1.5x wait time should allow DHT to rebuild routing second time (first is on a node startup) and give enough time node0 to catchup.

To fix (2) made node 1 and nod 2 to have equal stake so that network advances only if both nodes in sync.

## Test Plan

This is a test fix