### PR TITLE
network: remove ws net proto 2.1

### DIFF
--- a/network/msgCompressor.go
+++ b/network/msgCompressor.go
@@ -31,18 +31,6 @@ var zstdCompressionMagic = [4]byte{0x28, 0xb5, 0x2f, 0xfd}
 
 const zstdCompressionLevel = zstd.BestSpeed
 
-// checkCompressible checks if there is an proposal payload message
-func checkCompressible(request broadcastRequest) bool {
-	hasPP := false
-	for _, tag := range request.tags {
-		if tag == protocol.ProposalPayloadTag {
-			hasPP = true
-			break
-		}
-	}
-	return hasPP
-}
-
 // zstdCompressMsg returns a concatenation of a tag and compressed data
 func zstdCompressMsg(tbytes []byte, d []byte) ([]byte, string) {
 	bound := zstd.CompressBound(len(d))

--- a/network/msgCompressor.go
+++ b/network/msgCompressor.go
@@ -31,9 +31,8 @@ var zstdCompressionMagic = [4]byte{0x28, 0xb5, 0x2f, 0xfd}
 
 const zstdCompressionLevel = zstd.BestSpeed
 
-// checkCanCompress checks if there is an proposal payload message and peers supporting compression
-func checkCanCompress(request broadcastRequest, peers []*wsPeer) bool {
-	canCompress := false
+// checkCompressible checks if there is an proposal payload message
+func checkCompressible(request broadcastRequest) bool {
 	hasPP := false
 	for _, tag := range request.tags {
 		if tag == protocol.ProposalPayloadTag {
@@ -41,16 +40,7 @@ func checkCanCompress(request broadcastRequest, peers []*wsPeer) bool {
 			break
 		}
 	}
-	// if have proposal payload check if there are any peers supporting compression
-	if hasPP {
-		for _, peer := range peers {
-			if peer.pfProposalCompressionSupported() {
-				canCompress = true
-				break
-			}
-		}
-	}
-	return canCompress
+	return hasPP
 }
 
 // zstdCompressMsg returns a concatenation of a tag and compressed data
@@ -89,13 +79,7 @@ type wsPeerMsgDataConverter struct {
 	ppdec zstdProposalDecompressor
 }
 
-type zstdProposalDecompressor struct {
-	active bool
-}
-
-func (dec zstdProposalDecompressor) enabled() bool {
-	return dec.active
-}
+type zstdProposalDecompressor struct{}
 
 func (dec zstdProposalDecompressor) accept(data []byte) bool {
 	return len(data) > 4 && bytes.Equal(data[:4], zstdCompressionMagic[:])
@@ -126,18 +110,16 @@ func (dec zstdProposalDecompressor) convert(data []byte) ([]byte, error) {
 
 func (c *wsPeerMsgDataConverter) convert(tag protocol.Tag, data []byte) ([]byte, error) {
 	if tag == protocol.ProposalPayloadTag {
-		if c.ppdec.enabled() {
-			// sender might support compressed payload but fail to compress for whatever reason,
-			// in this case it sends non-compressed payload - the receiver decompress only if it is compressed.
-			if c.ppdec.accept(data) {
-				res, err := c.ppdec.convert(data)
-				if err != nil {
-					return nil, fmt.Errorf("peer %s: %w", c.origin, err)
-				}
-				return res, nil
+		// sender might support compressed payload but fail to compress for whatever reason,
+		// in this case it sends non-compressed payload - the receiver decompress only if it is compressed.
+		if c.ppdec.accept(data) {
+			res, err := c.ppdec.convert(data)
+			if err != nil {
+				return nil, fmt.Errorf("peer %s: %w", c.origin, err)
 			}
-			c.log.Warnf("peer %s supported zstd but sent non-compressed data", c.origin)
+			return res, nil
 		}
+		c.log.Warnf("peer %s supported zstd but sent non-compressed data", c.origin)
 	}
 	return data, nil
 }
@@ -148,11 +130,6 @@ func makeWsPeerMsgDataConverter(wp *wsPeer) *wsPeerMsgDataConverter {
 		origin: wp.originAddress,
 	}
 
-	if wp.pfProposalCompressionSupported() {
-		c.ppdec = zstdProposalDecompressor{
-			active: true,
-		}
-	}
-
+	c.ppdec = zstdProposalDecompressor{}
 	return &c
 }

--- a/network/msgCompressor_test.go
+++ b/network/msgCompressor_test.go
@@ -52,30 +52,15 @@ func TestCheckCanCompress(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	req := broadcastRequest{}
-	peers := []*wsPeer{}
-	r := checkCanCompress(req, peers)
+	r := checkCompressible(req)
 	require.False(t, r)
 
 	req.tags = []protocol.Tag{protocol.AgreementVoteTag}
-	r = checkCanCompress(req, peers)
+	r = checkCompressible(req)
 	require.False(t, r)
 
 	req.tags = []protocol.Tag{protocol.AgreementVoteTag, protocol.ProposalPayloadTag}
-	r = checkCanCompress(req, peers)
-	require.False(t, r)
-
-	peer1 := wsPeer{
-		features: 0,
-	}
-	peers = []*wsPeer{&peer1}
-	r = checkCanCompress(req, peers)
-	require.False(t, r)
-
-	peer2 := wsPeer{
-		features: pfCompressedProposal,
-	}
-	peers = []*wsPeer{&peer1, &peer2}
-	r = checkCanCompress(req, peers)
+	r = checkCompressible(req)
 	require.True(t, r)
 }
 
@@ -108,7 +93,7 @@ func TestWsPeerMsgDataConverterConvert(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	c := wsPeerMsgDataConverter{}
-	c.ppdec = zstdProposalDecompressor{active: false}
+	c.ppdec = zstdProposalDecompressor{}
 	tag := protocol.AgreementVoteTag
 	data := []byte("data")
 
@@ -117,13 +102,9 @@ func TestWsPeerMsgDataConverterConvert(t *testing.T) {
 	require.Equal(t, data, r)
 
 	tag = protocol.ProposalPayloadTag
-	r, err = c.convert(tag, data)
-	require.NoError(t, err)
-	require.Equal(t, data, r)
-
 	l := converterTestLogger{}
 	c.log = &l
-	c.ppdec = zstdProposalDecompressor{active: true}
+	c.ppdec = zstdProposalDecompressor{}
 	r, err = c.convert(tag, data)
 	require.NoError(t, err)
 	require.Equal(t, data, r)

--- a/network/msgCompressor_test.go
+++ b/network/msgCompressor_test.go
@@ -48,7 +48,7 @@ func TestZstdDecompress(t *testing.T) {
 	require.Nil(t, decompressed)
 }
 
-func TestCheckCanCompress(t *testing.T) {
+func TestCheckCompressible(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	req := broadcastRequest{}

--- a/network/msgCompressor_test.go
+++ b/network/msgCompressor_test.go
@@ -48,22 +48,6 @@ func TestZstdDecompress(t *testing.T) {
 	require.Nil(t, decompressed)
 }
 
-func TestCheckCompressible(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	req := broadcastRequest{}
-	r := checkCompressible(req)
-	require.False(t, r)
-
-	req.tags = []protocol.Tag{protocol.AgreementVoteTag}
-	r = checkCompressible(req)
-	require.False(t, r)
-
-	req.tags = []protocol.Tag{protocol.AgreementVoteTag, protocol.ProposalPayloadTag}
-	r = checkCompressible(req)
-	require.True(t, r)
-}
-
 func TestZstdCompressMsg(t *testing.T) {
 	partitiontest.PartitionTest(t)
 

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1058,7 +1058,7 @@ func (wn *WebsocketNetwork) ServeHTTP(response http.ResponseWriter, request *htt
 	responseHeader.Set(ProtocolVersionHeader, matchingVersion)
 	responseHeader.Set(GenesisHeader, wn.GenesisID)
 	// set the features we support, for example
-	// responseHeader.Set(PeerFeaturesHeader, "ppzstd")
+	responseHeader.Set(PeerFeaturesHeader, PeerFeatureProposalCompression)
 	var challenge string
 	if wn.prioScheme != nil {
 		challenge = wn.prioScheme.NewPrioChallenge()
@@ -1387,7 +1387,7 @@ func (wn *WebsocketNetwork) getPeersChangeCounter() int32 {
 }
 
 // preparePeerData prepares batches of data for sending.
-// It performs optional zstd compression for proposal massages
+// It performs zstd compression for proposal massages if they this is a prio request and has proposal.
 func (wn *msgBroadcaster) preparePeerData(request broadcastRequest, prio bool) ([][]byte, []crypto.Digest) {
 	// determine if there is a payload proposal and peers supporting compressed payloads
 	shouldCompress := false
@@ -1954,6 +1954,10 @@ const UserAgentHeader = "User-Agent"
 // PeerFeaturesHeader is the HTTP header listing features
 const PeerFeaturesHeader = "X-Algorand-Peer-Features"
 
+// PeerFeatureProposalCompression is a value for PeerFeaturesHeader indicating peer
+// supports proposal payload compression with zstd
+const PeerFeatureProposalCompression = "ppzstd"
+
 var websocketsScheme = map[string]string{"http": "ws", "https": "wss"}
 
 var errBadAddr = errors.New("bad address")
@@ -2075,8 +2079,8 @@ func (wn *WebsocketNetwork) tryConnect(netAddr, gossipAddr string) {
 
 	// for backward compatibility, include the ProtocolVersion header as well.
 	requestHeader.Set(ProtocolVersionHeader, wn.protocolVersion)
-	// set the features header (comma-separated list), for example
-	requestHeader.Set(PeerFeaturesHeader, "ppzstd")
+	// set the features header (comma-separated list)
+	requestHeader.Set(PeerFeaturesHeader, PeerFeatureProposalCompression)
 	SetUserAgentHeader(requestHeader)
 	myInstanceName := wn.log.GetInstanceName()
 	requestHeader.Set(InstanceNameHeader, myInstanceName)

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1389,7 +1389,7 @@ func (wn *WebsocketNetwork) getPeersChangeCounter() int32 {
 // preparePeerData prepares batches of data for sending.
 // It performs zstd compression for proposal massages if they this is a prio request and has proposal.
 func (wn *msgBroadcaster) preparePeerData(request broadcastRequest, prio bool) ([][]byte, []crypto.Digest) {
-	// determine if there is a payload proposal and peers supporting compressed payloads
+	// determine if there is a payload proposal and if so compress proposal portion of the request
 	shouldCompress := false
 	if prio {
 		shouldCompress = checkCompressible(request)

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1057,7 +1057,7 @@ func (wn *WebsocketNetwork) ServeHTTP(response http.ResponseWriter, request *htt
 	wn.setHeaders(responseHeader)
 	responseHeader.Set(ProtocolVersionHeader, matchingVersion)
 	responseHeader.Set(GenesisHeader, wn.GenesisID)
-	// set the features we support, for example
+	// set the features we support
 	responseHeader.Set(PeerFeaturesHeader, PeerFeatureProposalCompression)
 	var challenge string
 	if wn.prioScheme != nil {

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -434,6 +434,7 @@ func TestWebsocketProposalPayloadCompression(t *testing.T) {
 
 		// old node + new node
 		{[]string{"2.1"}, "2.1", []string{"2.2", "2.1"}, "2.2"},
+		{[]string{"2.2", "2.1"}, "2.1", []string{"2.2"}, "2.2"},
 
 		// combinations
 		{[]string{"2.2", "2.1"}, "2.1", []string{"2.2", "2.1"}, "2.1"},

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -429,15 +429,11 @@ func TestWebsocketProposalPayloadCompression(t *testing.T) {
 	}
 
 	var tests []testDef = []testDef{
-		// two old nodes
-		{[]string{"2.1"}, "2.1", []string{"2.1"}, "2.1"},
-
 		// two new nodes with overwritten config
 		{[]string{"2.2"}, "2.2", []string{"2.2"}, "2.2"},
 
 		// old node + new node
 		{[]string{"2.1"}, "2.1", []string{"2.2", "2.1"}, "2.2"},
-		{[]string{"2.2", "2.1"}, "2.2", []string{"2.1"}, "2.1"},
 
 		// combinations
 		{[]string{"2.2", "2.1"}, "2.1", []string{"2.2", "2.1"}, "2.1"},
@@ -1101,7 +1097,7 @@ func TestDupFilter(t *testing.T) {
 	defer netC.Stop()
 
 	makeMsg := func(n int) []byte {
-		// We cannot harcode the msgSize to messageFilterSize + 1 because max allowed AV message is smaller  than that.
+		// We cannot hardcode the msgSize to messageFilterSize + 1 because max allowed AV message is smaller  than that.
 		// We also cannot use maxSize for PP since it's a compressible tag but trying to compress random data will expand it.
 		if messageFilterSize+1 < n {
 			n = messageFilterSize + 1
@@ -1387,7 +1383,7 @@ func TestPeeringWithIdentityChallenge(t *testing.T) {
 	assert.Equal(t, 0, len(netB.GetPeers(PeersConnectedOut)))
 	// netA never attempts to set identity as it never sees a verified identity
 	assert.Equal(t, 1, netA.identityTracker.(*mockIdentityTracker).getSetCount())
-	// no connecton => netB does attepmt to add the identity to the tracker
+	// no connection => netB does attempt to add the identity to the tracker
 	// and it would not end up being added
 	assert.Equal(t, 1, netB.identityTracker.(*mockIdentityTracker).getSetCount())
 	assert.Equal(t, 1, netB.identityTracker.(*mockIdentityTracker).getInsertCount())
@@ -1608,7 +1604,7 @@ func TestPeeringReceiverIdentityChallengeOnly(t *testing.T) {
 	assert.Equal(t, 0, netB.identityTracker.(*mockIdentityTracker).getSetCount())
 }
 
-// TestPeeringIncorrectDeduplicationName confirm that if the reciever can't match
+// TestPeeringIncorrectDeduplicationName confirm that if the receiver can't match
 // the Address in the challenge to its PublicAddress, identities aren't exchanged, but peering continues
 func TestPeeringIncorrectDeduplicationName(t *testing.T) {
 	partitiontest.PartitionTest(t)
@@ -1665,7 +1661,7 @@ func TestPeeringIncorrectDeduplicationName(t *testing.T) {
 
 	// bi-directional connection would now work since netB detects to be connected to netA in tryConnectReserveAddr,
 	// so force it.
-	// this second connection should set identities, because the reciever address matches now
+	// this second connection should set identities, because the receiver address matches now
 	_, ok = netB.tryConnectReserveAddr(addrA)
 	assert.False(t, ok)
 	netB.wg.Add(1)
@@ -2504,9 +2500,9 @@ func TestWebsocketNetwork_checkServerResponseVariables(t *testing.T) {
 }
 
 func (wn *WebsocketNetwork) broadcastWithTimestamp(tag protocol.Tag, data []byte, when time.Time) error {
-	msgArr := make([][]byte, 1, 1)
+	msgArr := make([][]byte, 1)
 	msgArr[0] = data
-	tagArr := make([]protocol.Tag, 1, 1)
+	tagArr := make([]protocol.Tag, 1)
 	tagArr[0] = tag
 	request := broadcastRequest{tags: tagArr, data: msgArr, enqueueTime: when, ctx: context.Background()}
 
@@ -3711,48 +3707,29 @@ func TestPreparePeerData(t *testing.T) {
 		data: [][]byte{[]byte("test"), []byte("data")},
 	}
 
-	peers := []*wsPeer{}
 	wn := WebsocketNetwork{}
-	data, comp, digests, seenPrioPPTag := wn.broadcaster.preparePeerData(req, false, peers)
+	data, digests := wn.broadcaster.preparePeerData(req, false)
 	require.NotEmpty(t, data)
-	require.Empty(t, comp)
 	require.NotEmpty(t, digests)
 	require.Equal(t, len(req.data), len(digests))
 	require.Equal(t, len(data), len(digests))
-	require.False(t, seenPrioPPTag)
 
 	for i := range data {
 		require.Equal(t, append([]byte(req.tags[i]), req.data[i]...), data[i])
 	}
 
-	// compression
-	peer1 := wsPeer{
-		features: 0,
-	}
-	peer2 := wsPeer{
-		features: pfCompressedProposal,
-	}
-	peers = []*wsPeer{&peer1, &peer2}
-	data, comp, digests, seenPrioPPTag = wn.broadcaster.preparePeerData(req, true, peers)
+	data, digests = wn.broadcaster.preparePeerData(req, true)
 	require.NotEmpty(t, data)
-	require.NotEmpty(t, comp)
 	require.NotEmpty(t, digests)
 	require.Equal(t, len(req.data), len(digests))
 	require.Equal(t, len(data), len(digests))
-	require.Equal(t, len(comp), len(digests))
-	require.True(t, seenPrioPPTag)
 
 	for i := range data {
-		require.Equal(t, append([]byte(req.tags[i]), req.data[i]...), data[i])
-	}
-
-	for i := range comp {
 		if req.tags[i] != protocol.ProposalPayloadTag {
-			require.Equal(t, append([]byte(req.tags[i]), req.data[i]...), comp[i])
-			require.Equal(t, data[i], comp[i])
+			require.Equal(t, append([]byte(req.tags[i]), req.data[i]...), data[i])
+			require.Equal(t, data[i], data[i])
 		} else {
-			require.NotEqual(t, data[i], comp[i])
-			require.Equal(t, append([]byte(req.tags[i]), zstdCompressionMagic[:]...), comp[i][:len(req.tags[i])+len(zstdCompressionMagic)])
+			require.Equal(t, append([]byte(req.tags[i]), zstdCompressionMagic[:]...), data[i][:len(req.tags[i])+len(zstdCompressionMagic)])
 		}
 	}
 }

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -746,7 +746,7 @@ func (wp *wsPeer) handleMessageOfInterest(msg IncomingMessage) (close bool, reas
 		wp.log.Warnf("wsPeer handleMessageOfInterest: could not unmarshall message from: %s %v", wp.conn.RemoteAddrString(), err)
 		return true, disconnectBadData
 	}
-	msgs := make([]sendMessage, 1, 1)
+	msgs := make([]sendMessage, 1)
 	msgs[0] = sendMessage{
 		data:         nil,
 		enqueued:     time.Now(),
@@ -911,8 +911,8 @@ func (wp *wsPeer) writeLoopCleanup(reason disconnectReason) {
 }
 
 func (wp *wsPeer) writeNonBlock(ctx context.Context, data []byte, highPrio bool, digest crypto.Digest, msgEnqueueTime time.Time) bool {
-	msgs := make([][]byte, 1, 1)
-	digests := make([]crypto.Digest, 1, 1)
+	msgs := make([][]byte, 1)
+	digests := make([]crypto.Digest, 1)
 	msgs[0] = data
 	digests[0] = digest
 	return wp.writeNonBlockMsgs(ctx, msgs, highPrio, digests, msgEnqueueTime)
@@ -1090,7 +1090,7 @@ func (wp *wsPeer) Request(ctx context.Context, tag Tag, topics Topics) (resp *Re
 	defer wp.getAndRemoveResponseChannel(hash)
 
 	// Send serializedMsg
-	msg := make([]sendMessage, 1, 1)
+	msg := make([]sendMessage, 1)
 	msg[0] = sendMessage{
 		data:         append([]byte(tag), serializedMsg...),
 		enqueued:     time.Now(),
@@ -1166,10 +1166,6 @@ func (wp *wsPeer) sendMessagesOfInterest(messagesOfInterestGeneration uint32, me
 	}
 }
 
-func (wp *wsPeer) pfProposalCompressionSupported() bool {
-	return wp.features&pfCompressedProposal != 0
-}
-
 func (wp *wsPeer) OnClose(f func()) {
 	if wp.closers == nil {
 		wp.closers = []func(){}
@@ -1179,8 +1175,6 @@ func (wp *wsPeer) OnClose(f func()) {
 
 //msgp:ignore peerFeatureFlag
 type peerFeatureFlag int
-
-const pfCompressedProposal peerFeatureFlag = 1
 
 // versionPeerFeatures defines protocol version when peer features were introduced
 const versionPeerFeatures = "2.2"
@@ -1220,10 +1214,11 @@ func decodePeerFeatures(version string, announcedFeatures string) peerFeatureFla
 	var features peerFeatureFlag
 	parts := strings.Split(announcedFeatures, ",")
 	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part == PeerFeatureProposalCompression {
-			features |= pfCompressedProposal
-		}
+		// check features here, for example
+		_ = strings.TrimSpace(part)
+		// if part == "ppzstd" {
+		// 	features |= pfCompressedProposal
+		// }
 	}
 	return features
 }

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -1176,6 +1176,10 @@ func (wp *wsPeer) OnClose(f func()) {
 //msgp:ignore peerFeatureFlag
 type peerFeatureFlag int
 
+const (
+	pfCompressedProposal peerFeatureFlag = 1 << iota
+)
+
 // versionPeerFeatures defines protocol version when peer features were introduced
 const versionPeerFeatures = "2.2"
 
@@ -1214,11 +1218,10 @@ func decodePeerFeatures(version string, announcedFeatures string) peerFeatureFla
 	var features peerFeatureFlag
 	parts := strings.Split(announcedFeatures, ",")
 	for _, part := range parts {
-		// check features here, for example
-		_ = strings.TrimSpace(part)
-		// if part == "ppzstd" {
-		// 	features |= pfCompressedProposal
-		// }
+		part = strings.TrimSpace(part)
+		if part == PeerFeatureProposalCompression {
+			features |= pfCompressedProposal
+		}
 	}
 	return features
 }

--- a/network/wsPeer_test.go
+++ b/network/wsPeer_test.go
@@ -159,14 +159,10 @@ func TestVersionToFeature(t *testing.T) {
 		{"1.2.3", "", peerFeatureFlag(0)},
 		{"a.b", "", peerFeatureFlag(0)},
 		{"2.1", "", peerFeatureFlag(0)},
-		{"2.1", PeerFeatureProposalCompression, peerFeatureFlag(0)},
+		{"2.1", "", peerFeatureFlag(0)},
 		{"2.2", "", peerFeatureFlag(0)},
 		{"2.2", "test", peerFeatureFlag(0)},
 		{"2.2", strings.Join([]string{"a", "b"}, ","), peerFeatureFlag(0)},
-		{"2.2", PeerFeatureProposalCompression, pfCompressedProposal},
-		{"2.2", strings.Join([]string{PeerFeatureProposalCompression, "test"}, ","), pfCompressedProposal},
-		{"2.2", strings.Join([]string{PeerFeatureProposalCompression, "test"}, ", "), pfCompressedProposal},
-		{"2.3", PeerFeatureProposalCompression, pfCompressedProposal},
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {

--- a/network/wsPeer_test.go
+++ b/network/wsPeer_test.go
@@ -159,10 +159,14 @@ func TestVersionToFeature(t *testing.T) {
 		{"1.2.3", "", peerFeatureFlag(0)},
 		{"a.b", "", peerFeatureFlag(0)},
 		{"2.1", "", peerFeatureFlag(0)},
-		{"2.1", "", peerFeatureFlag(0)},
+		{"2.1", PeerFeatureProposalCompression, peerFeatureFlag(0)},
 		{"2.2", "", peerFeatureFlag(0)},
 		{"2.2", "test", peerFeatureFlag(0)},
 		{"2.2", strings.Join([]string{"a", "b"}, ","), peerFeatureFlag(0)},
+		{"2.2", PeerFeatureProposalCompression, pfCompressedProposal},
+		{"2.2", strings.Join([]string{PeerFeatureProposalCompression, "test"}, ","), pfCompressedProposal},
+		{"2.2", strings.Join([]string{PeerFeatureProposalCompression, "test"}, ", "), pfCompressedProposal},
+		{"2.3", PeerFeatureProposalCompression, pfCompressedProposal},
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {


### PR DESCRIPTION
## Summary

Remove wsnet proto=2.1 and optional compression since the entire network supports 2.2 and compressed PP messages.
I left couple commented out lines showing how to set and check features.

## Test Plan

Existing tests