### PR TITLE
p2p: fix connection deduplication in hybrid mode

### DIFF
--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -797,6 +797,7 @@ func (n *P2PNetwork) wsStreamHandler(ctx context.Context, p2pPeer peer.ID, strea
 		networkPeerIdentityDisconnect.Inc(nil)
 		n.log.With("remote", addr).With("local", localAddr).Warn("peer deduplicated before adding because the identity is already known")
 		stream.Close()
+		return
 	}
 
 	wsp.init(n.config, outgoingMessagesBufferSize)


### PR DESCRIPTION
## Summary

Some [TestHybridNetwork_DuplicateConn](https://app.circleci.com/pipelines/github/algorand/go-algorand/18782/workflows/9534087f-79ee-483a-aa3d-448bb2517267/jobs/275920) failures indicate deduplication does not work when a node first connects via wsnet and then via p2p. In this case p2p correctly determines duplicate but does not exit the handler as it should.

## Test Plan

Added a unit test checking the stream handler processes duplication correctly.