### PR TITLE
AVM: uint256 opcodes

### DIFF
--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -800,12 +800,12 @@ var OpSpecs = []OpSpec{
 			BLS12_381g1: 1_950, BLS12_381g2: 8_150})},
 
 	// uint256 math
-	{0xf0, "add256", opAdd256, proto("bb:b{32}"), 11, detDefault()},
-	{0xf1, "sub256", opSub256, proto("bb:b{32}"), 11, detDefault()},
-	{0xf2, "mul256", opMul256, proto("bb:b{32}"), 11, detDefault()},
-	{0xf3, "div256", opDiv256, proto("bb:b{32}"), 11, detDefault()},
-	{0xf4, "mod256", opMod256, proto("bb:b{32}"), 11, detDefault()},
-	{0xf5, "sqrt256", opSqrt256, proto("b:b{32}"), 11, detDefault()},
+	{0xf0, "add256", opAdd256, proto("bb:b{32}"), 11, costly(2)},
+	{0xf1, "sub256", opSub256, proto("bb:b{32}"), 11, costly(2)},
+	{0xf2, "mul256", opMul256, proto("bb:b{32}"), 11, costly(2)},
+	{0xf3, "div256", opDiv256, proto("bb:b{32}"), 11, costly(2)},
+	{0xf4, "mod256", opMod256, proto("bb:b{32}"), 11, costly(2)},
+	{0xf5, "sqrt256", opSqrt256, proto("b:b{32}"), 11, costly(2)},
 }
 
 // OpcodesByVersion returns list of opcodes available in a specific version of TEAL

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -798,6 +798,14 @@ var OpSpecs = []OpSpec{
 		costByField("g", &EcGroups, []int{
 			BN254g1: 630, BN254g2: 3_300,
 			BLS12_381g1: 1_950, BLS12_381g2: 8_150})},
+
+	// uint256 math
+	{0xf0, "add256", opAdd256, proto("bb:b{32}"), 11, detDefault()},
+	{0xf1, "sub256", opSub256, proto("bb:b{32}"), 11, detDefault()},
+	{0xf2, "mul256", opMul256, proto("bb:b{32}"), 11, detDefault()},
+	{0xf3, "div256", opDiv256, proto("bb:b{32}"), 11, detDefault()},
+	{0xf4, "mod256", opMod256, proto("bb:b{32}"), 11, detDefault()},
+	{0xf5, "sqrt256", opSqrt256, proto("b:b{32}"), 11, detDefault()},
 }
 
 // OpcodesByVersion returns list of opcodes available in a specific version of TEAL

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-querystring v1.0.0
 	github.com/gorilla/mux v1.8.0
+	github.com/holiman/uint256 v1.3.0
 	github.com/ipfs/go-log v1.0.5
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/jmoiron/sqlx v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -260,6 +260,8 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/golang-lru/v2 v2.0.5 h1:wW7h1TG88eUIJ2i69gaE3uNVtEPIagzhGvHgwfx2Vm4=
 github.com/hashicorp/golang-lru/v2 v2.0.5/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/holiman/uint256 v1.3.0 h1:4wdcm/tnd0xXdu7iS3ruNvxkWwrb4aeBQv19ayYn8F4=
+github.com/holiman/uint256 v1.3.0/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=


### PR DESCRIPTION
## Summary

This PR adds uint256 opcodes. The current draft contains basic arithmetic ops, but comparison and bitwise opcodes could also be added. 

* Leverages https://github.com/holiman/uint256 which is used by [go-ethereum](https://github.com/ethereum/go-ethereum) and [erigon](https://github.com/ledgerwatch/erigon)
* Each opcode takes in `[]byte` and returns `[32]byte`
* An error is returned if one of the arguments is > 32 bytes
* An error is returned on underflow/overflow where applicable

The benchmarks:

```
=== RUN   BenchmarkUint256Math
BenchmarkUint256Math
=== RUN   BenchmarkUint256Math/add256
BenchmarkUint256Math/add256
BenchmarkUint256Math/add256-10          16894750                72.34 ns/op              3.000 extra/op       38 B/op          1 allocs/op
=== RUN   BenchmarkUint256Math/sub256
BenchmarkUint256Math/sub256
BenchmarkUint256Math/sub256-10          17190334                68.53 ns/op              3.000 extra/op       38 B/op          1 allocs/op
=== RUN   BenchmarkUint256Math/mul256
BenchmarkUint256Math/mul256
BenchmarkUint256Math/mul256-10          15211278                79.63 ns/op              3.000 extra/op       38 B/op          1 allocs/op
=== RUN   BenchmarkUint256Math/div256
BenchmarkUint256Math/div256
BenchmarkUint256Math/div256-10          17130069                70.08 ns/op              3.000 extra/op       38 B/op          1 allocs/op
=== RUN   BenchmarkUint256Math/mod256
BenchmarkUint256Math/mod256
BenchmarkUint256Math/mod256-10          17231794                69.92 ns/op              3.000 extra/op       38 B/op          1 allocs/op
=== RUN   BenchmarkUint256Math/sqrt256
BenchmarkUint256Math/sqrt256
BenchmarkUint256Math/sqrt256-10         21905337                55.86 ns/op              2.000 extra/op       38 B/op 
```

Due to these results, I believe that a opcode cost of 2 is reasonable for all of the added opcodes. 

## Rationale

The byte math operators are rather expensive to use and if you are using them within the context of an ARC4 method even more opcodes need to be spent to pad values for encoding. This PR solves both of these problems by making uint256 more efficient and always returning `[32]byte`.

## Test Plan

All opcodes are tested to ensure they work as expected and return errors when expected.

## TODO

- [ ] Test error when arguments are > 32 bytes
- [ ] Add bitwise operators
- [ ] Add comparison operators (`<`, `>`, etc.)