### PR TITLE
CI: fix mac universal rebuild for nightlies

### DIFF
--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -9,11 +9,17 @@
 # Examples: scripts/travis/build.sh
 
 MAKE_DEBUG_OPTION=""
+MAKE_UNIVERSAL_OPTION=""
+
 while [ "$1" != "" ]; do
     case "$1" in
         --make_debug)
             shift
             MAKE_DEBUG_OPTION="1"
+            ;;
+        --make_universal)
+            shift
+            MAKE_UNIVERSAL_OPTION="1"
             ;;
         *)
             echo "Unknown option" "$1"
@@ -75,13 +81,15 @@ set -e
 scripts/travis/before_build.sh
 duration "before_build.sh"
 
-if [ "${OS}-${ARCH}" = "linux-arm" ] || [ "${OS}-${ARCH}" = "windows-amd64" ]; then
-    # for arm, build just the basic distro
+if [ "${OS}-${ARCH}" = "windows-amd64" ]; then
     # for windows, we still have some issues with the enlistment checking, so we'll make it simple for now.
     MAKE_DEBUG_OPTION=""
 fi
 
-if [ "${MAKE_DEBUG_OPTION}" != "" ]; then
+if [ "${MAKE_UNIVERSAL_OPTION}" != "" ]; then
+    make universal
+    duration "make universal"
+elif [ "${MAKE_DEBUG_OPTION}" != "" ]; then
     make build build-race
     duration "make build build-race"
 else

--- a/scripts/travis/deploy_packages.sh
+++ b/scripts/travis/deploy_packages.sh
@@ -26,11 +26,11 @@ fi
 
 if [ "${NIGHTLY_BUILD}" == "true" ]; then
     # we want to rebuild universal binaries for nightly builds
-    NO_BUILD=true
     if [ "${OSARCH}" == "darwin/arm64" ]; then
-        make universal
+        ./scripts/travis/build.sh --make_universal
         OSARCH="darwin/universal"
     fi
+    NO_BUILD=true
 fi
 
 if [ -z "${NO_BUILD}" ] || [ "${NO_BUILD}" != "true" ]; then


### PR DESCRIPTION
## Summary

Introduced a bug in #6071 because build deps are not in that stage.

Because we rebuild for the universal target for nightlies on darwin, we need build dependencies. This modifies deploy packages to call the build script to install for this case.

(Also removed a small case for linux-arm, since that's deprecated.)

## Test Plan

Ran manually to ensure it triggered properly.

