### PR TITLE
tests: debug logging for TestVotersReloadFromDiskAfterOneStateProofCommitted

### DIFF
--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -130,7 +130,18 @@ func makeMockLedgerForTrackerWithLogger(t testing.TB, inMemory bool, initialBloc
 			Totals: totals,
 		}
 	}
-	return &mockLedgerForTracker{dbs: dbs, log: l, filename: fileName, inMemory: inMemory, blocks: blocks, deltas: deltas, consensusParams: config.Consensus[consensusVersion], consensusVersion: consensusVersion, accts: accts[0]}
+	ml := &mockLedgerForTracker{
+		dbs:      dbs,
+		log:      l,
+		filename: fileName,
+		inMemory: inMemory,
+		blocks:   blocks,
+		deltas:   deltas, consensusParams: config.Consensus[consensusVersion],
+		consensusVersion: consensusVersion,
+		accts:            accts[0],
+		trackers:         trackerRegistry{log: l},
+	}
+	return ml
 
 }
 
@@ -160,6 +171,7 @@ func (ml *mockLedgerForTracker) fork(t testing.TB) *mockLedgerForTracker {
 		filename:         fn,
 		consensusParams:  ml.consensusParams,
 		consensusVersion: ml.consensusVersion,
+		trackers:         trackerRegistry{log: dblogger},
 	}
 	for k, v := range ml.accts {
 		newLedgerTracker.accts[k] = v

--- a/ledger/blockqueue_test.go
+++ b/ledger/blockqueue_test.go
@@ -207,6 +207,7 @@ func TestBlockQueueSyncerDeletion(t *testing.T) {
 			l := &Ledger{
 				log:      log,
 				blockDBs: blockDBs,
+				trackers: trackerRegistry{log: log},
 			}
 			if test.tracker != nil {
 				l.trackers.trackers = append(l.trackers.trackers, test.tracker)

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -214,9 +214,11 @@ func (l *Ledger) reloadLedger() error {
 	blockListeners := make([]ledgercore.BlockListener, 0, len(l.notifier.listeners))
 	blockListeners = append(blockListeners, l.notifier.listeners...)
 
-	// close the trackers.
-	l.trackers.log = l.trackerLog()
-	l.trackers.close()
+	// close the trackers if the registry was already initialized: opening a new ledger calls reloadLedger
+	// and there is nothing to close. Registry's logger is not initialized yet so close cannot log.
+	if l.trackers.trackers != nil {
+		l.trackers.close()
+	}
 
 	// init block queue
 	var err error

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -215,6 +215,7 @@ func (l *Ledger) reloadLedger() error {
 	blockListeners = append(blockListeners, l.notifier.listeners...)
 
 	// close the trackers.
+	l.trackers.log = l.trackerLog()
 	l.trackers.close()
 
 	// init block queue

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -3415,6 +3415,7 @@ func TestLedgerRetainMinOffCatchpointInterval(t *testing.T) {
 			l := &Ledger{}
 			l.cfg = cfg
 			l.archival = cfg.Archival
+			l.trackers.log = logging.TestingLog(t)
 
 			for i := 1; i <= blocksToMake; i++ {
 				minBlockToKeep := l.notifyCommit(basics.Round(i))

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -492,7 +492,6 @@ func (tr *trackerRegistry) isBehindCommittingDeltas(latest basics.Round) bool {
 }
 
 func (tr *trackerRegistry) close() {
-	fmt.Printf("trackerRegistry: %v\n", tr.log)
 	tr.log.Debugf("trackerRegistry is closing")
 	if tr.ctxCancel != nil {
 		tr.ctxCancel()
@@ -500,13 +499,14 @@ func (tr *trackerRegistry) close() {
 
 	// close() is called from reloadLedger() when and trackerRegistry is not initialized yet
 	if tr.commitSyncerClosed != nil {
-		tr.log.Debugf("waiting for accounts writing to complete")
+		tr.log.Debugf("trackerRegistry is waiting for accounts writing to complete")
 		tr.waitAccountsWriting()
 		// this would block until the commitSyncerClosed channel get closed.
 		<-tr.commitSyncerClosed
-		tr.log.Debugf("accounts writing completed")
+		tr.log.Debugf("trackerRegistry done waiting for accounts writing")
 	}
 
+	tr.log.Debugf("trackerRegistry is closing trackers")
 	for _, lt := range tr.trackers {
 		lt.close()
 	}

--- a/ledger/tracker.go
+++ b/ledger/tracker.go
@@ -492,6 +492,7 @@ func (tr *trackerRegistry) isBehindCommittingDeltas(latest basics.Round) bool {
 }
 
 func (tr *trackerRegistry) close() {
+	fmt.Printf("trackerRegistry: %v\n", tr.log)
 	tr.log.Debugf("trackerRegistry is closing")
 	if tr.ctxCancel != nil {
 		tr.ctxCancel()


### PR DESCRIPTION
## Summary

Recent test failures ([one](https://app.circleci.com/pipelines/github/algorand/go-algorand/18713/workflows/3f6cd5f8-2ec2-4a8b-b6f5-0f9185f4eef6/jobs/275334/parallel-runs/29), [two](https://app.circleci.com/pipelines/github/algorand/go-algorand/18841/workflows/0a07a814-5acc-489a-9a5f-7e6f5645c37f/jobs/276383)) indicates `TestVotersReloadFromDiskAfterOneStateProofCommitted` it can hang on waiting tracker registry to close. Added debug logging to confirm or rule out this.

## Test Plan

This is an extra debug log statements for `TestVotersReloadFromDiskAfterOneStateProofCommitted` investigation.

This is the same as https://github.com/algorand/go-algorand/pull/6066 that for some reason cannot be reopened.