### PR TITLE
api: Add support for Private Network Access header preflight requests

### DIFF
--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -167,6 +167,9 @@ type Local struct {
 	// EndpointAddress configures the address the node listens to for REST API calls. Specify an IP and port or just port. For example, 127.0.0.1:0 will listen on a random port on the localhost (preferring 8080).
 	EndpointAddress string `version[0]:"127.0.0.1:0"`
 
+	// Respond to Private Network Access preflight requests sent to the node. Useful when a public website is trying to access a node that's hosted on a local network.
+	EnablePrivateNetworkAccessHeader bool `version[34]:"false"`
+
 	// RestReadTimeoutSeconds is passed to the API servers rest http.Server implementation.
 	RestReadTimeoutSeconds int `version[4]:"15"`
 

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -77,6 +77,7 @@ var defaultLocal = Local{
 	EnableP2P:                                  false,
 	EnableP2PHybridMode:                        false,
 	EnablePingHandler:                          true,
+	EnablePrivateNetworkAccessHeader:           false,
 	EnableProcessBlockStats:                    false,
 	EnableProfiler:                             false,
 	EnableRequestLogger:                        false,

--- a/daemon/algod/api/server/lib/middlewares/cors.go
+++ b/daemon/algod/api/server/lib/middlewares/cors.go
@@ -32,6 +32,7 @@ func MakeCORS(tokenHeader string) echo.MiddlewareFunc {
 	})
 }
 
+// MakePNA constructs the Private Network Access middleware function
 func MakePNA() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(ctx echo.Context) error {

--- a/daemon/algod/api/server/lib/middlewares/cors.go
+++ b/daemon/algod/api/server/lib/middlewares/cors.go
@@ -31,3 +31,15 @@ func MakeCORS(tokenHeader string) echo.MiddlewareFunc {
 		AllowMethods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions},
 	})
 }
+
+func MakePNA() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(ctx echo.Context) error {
+			req := ctx.Request()
+			if req.Method == http.MethodOptions && req.Header.Get("Access-Control-Request-Private-Network") == "true" {
+				ctx.Response().Header().Set("Access-Control-Allow-Private-Network", "true")
+			}
+			return next(ctx)
+		}
+	}
+}

--- a/daemon/algod/api/server/lib/middlewares/cors_test.go
+++ b/daemon/algod/api/server/lib/middlewares/cors_test.go
@@ -21,11 +21,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMakeCORS(t *testing.T) {
+	partitiontest.PartitionTest(t)
 	e := echo.New()
 	tokenHeader := "X-Algo-API-Token"
 	corsMiddleware := MakeCORS(tokenHeader)
@@ -89,6 +91,7 @@ func TestMakeCORS(t *testing.T) {
 }
 
 func TestMakePNA(t *testing.T) {
+	partitiontest.PartitionTest(t)
 	e := echo.New()
 	pnaMiddleware := MakePNA()
 

--- a/daemon/algod/api/server/lib/middlewares/cors_test.go
+++ b/daemon/algod/api/server/lib/middlewares/cors_test.go
@@ -1,3 +1,19 @@
+// Copyright (C) 2019-2024 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
 package middlewares
 
 import (

--- a/daemon/algod/api/server/lib/middlewares/cors_test.go
+++ b/daemon/algod/api/server/lib/middlewares/cors_test.go
@@ -1,0 +1,129 @@
+package middlewares
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeCORS(t *testing.T) {
+	e := echo.New()
+	tokenHeader := "X-Algo-API-Token"
+	corsMiddleware := MakeCORS(tokenHeader)
+
+	testCases := []struct {
+		name            string
+		method          string
+		headers         map[string]string
+		expectedStatus  int
+		expectedHeaders map[string]string
+	}{
+		{
+			name:   "OPTIONS request",
+			method: http.MethodOptions,
+			headers: map[string]string{
+				"Origin":                         "http://algorand.com",
+				"Access-Control-Request-Headers": "Content-Type," + tokenHeader,
+			},
+			expectedStatus: http.StatusNoContent,
+			expectedHeaders: map[string]string{
+				"Access-Control-Allow-Origin":  "*",
+				"Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,OPTIONS",
+				"Access-Control-Allow-Headers": tokenHeader + ",Content-Type",
+			},
+		},
+		{
+			name:   "GET request",
+			method: http.MethodGet,
+			headers: map[string]string{
+				"Origin": "http://algorand.com",
+			},
+			expectedStatus: http.StatusOK,
+			expectedHeaders: map[string]string{
+				"Access-Control-Allow-Origin": "*",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "/health", nil)
+			for key, value := range tc.headers {
+				req.Header.Set(key, value)
+			}
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			handler := corsMiddleware(func(c echo.Context) error {
+				return c.NoContent(http.StatusOK)
+			})
+
+			err := handler(c)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedStatus, rec.Code)
+			for key, value := range tc.expectedHeaders {
+				assert.Equal(t, value, rec.Header().Get(key))
+			}
+		})
+	}
+}
+
+func TestMakePNA(t *testing.T) {
+	e := echo.New()
+	pnaMiddleware := MakePNA()
+
+	testCases := []struct {
+		name               string
+		method             string
+		headers            map[string]string
+		expectedStatusCode int
+		expectedHeader     string
+	}{
+		{
+			name:               "OPTIONS request with PNA header",
+			method:             http.MethodOptions,
+			headers:            map[string]string{"Access-Control-Request-Private-Network": "true"},
+			expectedStatusCode: http.StatusOK,
+			expectedHeader:     "true",
+		},
+		{
+			name:               "OPTIONS request without PNA header",
+			method:             http.MethodOptions,
+			headers:            map[string]string{},
+			expectedStatusCode: http.StatusOK,
+			expectedHeader:     "",
+		},
+		{
+			name:               "GET request",
+			method:             http.MethodGet,
+			headers:            map[string]string{},
+			expectedStatusCode: http.StatusOK,
+			expectedHeader:     "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "/", nil)
+			for key, value := range tc.headers {
+				req.Header.Set(key, value)
+			}
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			handler := pnaMiddleware(func(c echo.Context) error {
+				return c.NoContent(http.StatusOK)
+			})
+
+			err := handler(c)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedStatusCode, rec.Code)
+			assert.Equal(t, tc.expectedHeader, rec.Header().Get("Access-Control-Allow-Private-Network"))
+		})
+	}
+}

--- a/daemon/algod/api/server/router.go
+++ b/daemon/algod/api/server/router.go
@@ -107,7 +107,12 @@ func NewRouter(logger logging.Logger, node APINodeInterface, shutdown <-chan str
 		middleware.RemoveTrailingSlash())
 	e.Use(
 		middlewares.MakeLogger(logger),
-		middlewares.MakePNA(),
+	)
+	// Optional middleware for Private Network Access Header (PNA). Must come before CORS middleware.
+	if node.Config().EnablePrivateNetworkAccessHeader {
+		e.Use(middlewares.MakePNA())
+	}
+	e.Use(
 		middlewares.MakeCORS(TokenHeader),
 	)
 

--- a/daemon/algod/api/server/router.go
+++ b/daemon/algod/api/server/router.go
@@ -107,6 +107,7 @@ func NewRouter(logger logging.Logger, node APINodeInterface, shutdown <-chan str
 		middleware.RemoveTrailingSlash())
 	e.Use(
 		middlewares.MakeLogger(logger),
+		middlewares.MakePNA(),
 		middlewares.MakeCORS(TokenHeader),
 	)
 

--- a/daemon/kmd/api/api.go
+++ b/daemon/kmd/api/api.go
@@ -137,11 +137,13 @@ func SwaggerHandler(w http.ResponseWriter, r *http.Request) {
 
 // Handler returns the root mux router for the kmd API. It sets up handlers on
 // subrouters specific to each API version.
-func Handler(sm *session.Manager, log logging.Logger, allowedOrigins []string, apiToken string, reqCB func()) *mux.Router {
+func Handler(sm *session.Manager, log logging.Logger, allowedOrigins []string, apiToken string, pnaHeader bool, reqCB func()) *mux.Router {
 	rootRouter := mux.NewRouter()
 
 	// Send the appropriate CORS headers
-	rootRouter.Use(AllowPNA())
+	if pnaHeader {
+		rootRouter.Use(AllowPNA())
+	}
 	rootRouter.Use(corsMiddleware(allowedOrigins))
 
 	// Handle OPTIONS requests

--- a/daemon/kmd/api/api.go
+++ b/daemon/kmd/api/api.go
@@ -141,6 +141,7 @@ func Handler(sm *session.Manager, log logging.Logger, allowedOrigins []string, a
 	rootRouter := mux.NewRouter()
 
 	// Send the appropriate CORS headers
+	rootRouter.Use(AllowPNA())
 	rootRouter.Use(corsMiddleware(allowedOrigins))
 
 	// Handle OPTIONS requests

--- a/daemon/kmd/api/cors.go
+++ b/daemon/kmd/api/cors.go
@@ -57,6 +57,7 @@ func corsMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
 	}
 }
 
+// AllowPNA constructs the Private Network Access middleware function
 func AllowPNA() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -65,6 +66,6 @@ func AllowPNA() func(http.Handler) http.Handler {
 			}
 
 			next.ServeHTTP(w, r)
-        })
-    }
+		})
+	}
 }

--- a/daemon/kmd/api/cors.go
+++ b/daemon/kmd/api/cors.go
@@ -56,3 +56,15 @@ func corsMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
 		})
 	}
 }
+
+func AllowPNA() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Private-Network") == "true" {
+				w.Header().Set("Access-Control-Allow-Private-Network", "true")
+			}
+
+			next.ServeHTTP(w, r)
+        })
+    }
+}

--- a/daemon/kmd/config/config.go
+++ b/daemon/kmd/config/config.go
@@ -35,12 +35,12 @@ const (
 
 // KMDConfig contains global configuration information for kmd
 type KMDConfig struct {
-	DataDir                          string       `json:"-"`
-	DriverConfig                     DriverConfig `json:"drivers"`
-	SessionLifetimeSecs              uint64       `json:"session_lifetime_secs"`
-	Address                          string       `json:"address"`
-	AllowedOrigins                   []string     `json:"allowed_origins"`
-	EnablePrivateNetworkAccessHeader bool         `json:"enable_private_network_access_header"`
+	DataDir             string       `json:"-"`
+	DriverConfig        DriverConfig `json:"drivers"`
+	SessionLifetimeSecs uint64       `json:"session_lifetime_secs"`
+	Address             string       `json:"address"`
+	AllowedOrigins      []string     `json:"allowed_origins"`
+	AllowHeaderPNA      bool         `json:"allow_header_pna"`
 }
 
 // DriverConfig contains config info specific to each wallet driver

--- a/daemon/kmd/config/config.go
+++ b/daemon/kmd/config/config.go
@@ -35,11 +35,12 @@ const (
 
 // KMDConfig contains global configuration information for kmd
 type KMDConfig struct {
-	DataDir             string       `json:"-"`
-	DriverConfig        DriverConfig `json:"drivers"`
-	SessionLifetimeSecs uint64       `json:"session_lifetime_secs"`
-	Address             string       `json:"address"`
-	AllowedOrigins      []string     `json:"allowed_origins"`
+	DataDir                          string       `json:"-"`
+	DriverConfig                     DriverConfig `json:"drivers"`
+	SessionLifetimeSecs              uint64       `json:"session_lifetime_secs"`
+	Address                          string       `json:"address"`
+	AllowedOrigins                   []string     `json:"allowed_origins"`
+	EnablePrivateNetworkAccessHeader bool         `json:"enable_private_network_access_header"`
 }
 
 // DriverConfig contains config info specific to each wallet driver

--- a/daemon/kmd/kmd.go
+++ b/daemon/kmd/kmd.go
@@ -65,13 +65,14 @@ func Start(startConfig StartConfig) (died chan error, sock string, err error) {
 
 	// Configure the wallet API server
 	serverCfg := server.WalletServerConfig{
-		APIToken:       apiToken,
-		DataDir:        startConfig.DataDir,
-		Address:        kmdCfg.Address,
-		AllowedOrigins: kmdCfg.AllowedOrigins,
-		SessionManager: session.MakeManager(kmdCfg),
-		Log:            startConfig.Log,
-		Timeout:        startConfig.Timeout,
+		APIToken:                         apiToken,
+		DataDir:                          startConfig.DataDir,
+		Address:                          kmdCfg.Address,
+		AllowedOrigins:                   kmdCfg.AllowedOrigins,
+		EnablePrivateNetworkAccessHeader: kmdCfg.EnablePrivateNetworkAccessHeader,
+		SessionManager:                   session.MakeManager(kmdCfg),
+		Log:                              startConfig.Log,
+		Timeout:                          startConfig.Timeout,
 	}
 
 	// Instantiate the wallet API server

--- a/daemon/kmd/kmd.go
+++ b/daemon/kmd/kmd.go
@@ -65,14 +65,14 @@ func Start(startConfig StartConfig) (died chan error, sock string, err error) {
 
 	// Configure the wallet API server
 	serverCfg := server.WalletServerConfig{
-		APIToken:                         apiToken,
-		DataDir:                          startConfig.DataDir,
-		Address:                          kmdCfg.Address,
-		AllowedOrigins:                   kmdCfg.AllowedOrigins,
-		EnablePrivateNetworkAccessHeader: kmdCfg.EnablePrivateNetworkAccessHeader,
-		SessionManager:                   session.MakeManager(kmdCfg),
-		Log:                              startConfig.Log,
-		Timeout:                          startConfig.Timeout,
+		APIToken:       apiToken,
+		DataDir:        startConfig.DataDir,
+		Address:        kmdCfg.Address,
+		AllowedOrigins: kmdCfg.AllowedOrigins,
+		AllowHeaderPNA: kmdCfg.AllowHeaderPNA,
+		SessionManager: session.MakeManager(kmdCfg),
+		Log:            startConfig.Log,
+		Timeout:        startConfig.Timeout,
 	}
 
 	// Instantiate the wallet API server

--- a/daemon/kmd/server/server.go
+++ b/daemon/kmd/server/server.go
@@ -50,13 +50,14 @@ const (
 
 // WalletServerConfig is the configuration passed to MakeWalletServer
 type WalletServerConfig struct {
-	APIToken       string
-	DataDir        string
-	Address        string
-	AllowedOrigins []string
-	SessionManager *session.Manager
-	Log            logging.Logger
-	Timeout        *time.Duration
+	APIToken                         string
+	DataDir                          string
+	Address                          string
+	AllowedOrigins                   []string
+	EnablePrivateNetworkAccessHeader bool
+	SessionManager                   *session.Manager
+	Log                              logging.Logger
+	Timeout                          *time.Duration
 }
 
 // WalletServer deals with serving API requests
@@ -211,7 +212,7 @@ func (ws *WalletServer) start(kill chan os.Signal) (died chan error, sock string
 	// Initialize HTTP server
 	watchdogCB := ws.makeWatchdogCallback(kill)
 	srv := http.Server{
-		Handler: api.Handler(ws.SessionManager, ws.Log, ws.AllowedOrigins, ws.APIToken, watchdogCB),
+		Handler: api.Handler(ws.SessionManager, ws.Log, ws.AllowedOrigins, ws.APIToken, ws.EnablePrivateNetworkAccessHeader, watchdogCB),
 	}
 
 	// Read the kill channel and shut down the server gracefully

--- a/daemon/kmd/server/server.go
+++ b/daemon/kmd/server/server.go
@@ -50,14 +50,14 @@ const (
 
 // WalletServerConfig is the configuration passed to MakeWalletServer
 type WalletServerConfig struct {
-	APIToken                         string
-	DataDir                          string
-	Address                          string
-	AllowedOrigins                   []string
-	EnablePrivateNetworkAccessHeader bool
-	SessionManager                   *session.Manager
-	Log                              logging.Logger
-	Timeout                          *time.Duration
+	APIToken       string
+	DataDir        string
+	Address        string
+	AllowedOrigins []string
+	AllowHeaderPNA bool
+	SessionManager *session.Manager
+	Log            logging.Logger
+	Timeout        *time.Duration
 }
 
 // WalletServer deals with serving API requests
@@ -212,7 +212,7 @@ func (ws *WalletServer) start(kill chan os.Signal) (died chan error, sock string
 	// Initialize HTTP server
 	watchdogCB := ws.makeWatchdogCallback(kill)
 	srv := http.Server{
-		Handler: api.Handler(ws.SessionManager, ws.Log, ws.AllowedOrigins, ws.APIToken, ws.EnablePrivateNetworkAccessHeader, watchdogCB),
+		Handler: api.Handler(ws.SessionManager, ws.Log, ws.AllowedOrigins, ws.APIToken, ws.AllowHeaderPNA, watchdogCB),
 	}
 
 	// Read the kill channel and shut down the server gracefully

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -56,6 +56,7 @@
     "EnableP2P": false,
     "EnableP2PHybridMode": false,
     "EnablePingHandler": true,
+    "EnablePrivateNetworkAccessHeader": false,
     "EnableProcessBlockStats": false,
     "EnableProfiler": false,
     "EnableRequestLogger": false,

--- a/test/e2e-go/cli/goal/expect/corsTest.exp
+++ b/test/e2e-go/cli/goal/expect/corsTest.exp
@@ -15,7 +15,7 @@ if { [catch {
     set TEST_ROOT_DIR $TEST_ALGO_DIR/root
     set TEST_PRIMARY_NODE_DIR $TEST_ROOT_DIR/Primary/
     set NETWORK_NAME test_net_expect_$TIME_STAMP
-    set NETWORK_TEMPLATE "$TEST_DATA_DIR/nettemplates/TwoNodes50Each.json"
+    set NETWORK_TEMPLATE "$TEST_DATA_DIR/nettemplates/TwoNodes50EachPNA.json"
 
     # Create network
     ::AlgorandGoal::CreateNetwork $NETWORK_NAME $NETWORK_TEMPLATE $TEST_ALGO_DIR $TEST_ROOT_DIR

--- a/test/e2e-go/cli/goal/expect/corsTest.exp
+++ b/test/e2e-go/cli/goal/expect/corsTest.exp
@@ -31,6 +31,10 @@ if { [catch {
     set ALGOD_NET_ADDRESS [::AlgorandGoal::GetAlgodNetworkAddress $TEST_PRIMARY_NODE_DIR]
     ::AlgorandGoal::CheckNetworkAddressForCors $ALGOD_NET_ADDRESS
 
+    # Hit algod with a private network access preflight request and look for 200 OK
+    set ALGOD_NET_ADDRESS [::AlgorandGoal::GetAlgodNetworkAddress $TEST_PRIMARY_NODE_DIR]
+    ::AlgorandGoal::CheckNetworkAddressForPNA $ALGOD_NET_ADDRESS
+
     # Start kmd, then do the same CORS check as algod
     exec goal kmd start -t 180 -d $TEST_PRIMARY_NODE_DIR
     set KMD_NET_ADDRESS [::AlgorandGoal::GetKMDNetworkAddress $TEST_PRIMARY_NODE_DIR]

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -824,6 +824,9 @@ proc ::AlgorandGoal::CheckNetworkAddressForPNA { NET_ADDRESS } {
         expect {
             timeout { close; ::AlgorandGoal::Abort "Timeout failure in CheckNetworkAddressForPNA" }
             "Access-Control-Allow-Private-Network" { puts "success" ; close  }
+            eof {
+                return -code error "EOF without Access-Control-Allow-Private-Network"
+            }
             close
         }
     } EXCEPTION ] } {

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -817,6 +817,20 @@ proc ::AlgorandGoal::CheckNetworkAddressForCors { NET_ADDRESS } {
     }
 }
 
+# Use curl to check if a network address supports private network access
+proc ::AlgorandGoal::CheckNetworkAddressForPNA { NET_ADDRESS } {
+    if { [ catch {
+        spawn curl -X OPTIONS -H "Access-Control-Request-Private-Network: true" --head $NET_ADDRESS
+        expect {
+            timeout { close; ::AlgorandGoal::Abort "Timeout failure in CheckNetworkAddressForPNA" }
+            "Access-Control-Allow-Private-Network" { puts "success" ; close  }
+            close
+        }
+    } EXCEPTION ] } {
+       ::AlgorandGoal::Abort "ERROR in CheckNetworkAddressForPNA: $EXCEPTION"
+    }
+}
+
 # Show the Ledger Supply
 proc ::AlgorandGoal::GetLedgerSupply { TEST_PRIMARY_NODE_DIR } {
     if { [ catch {

--- a/test/testdata/configs/config-v34.json
+++ b/test/testdata/configs/config-v34.json
@@ -56,6 +56,7 @@
     "EnableP2P": false,
     "EnableP2PHybridMode": false,
     "EnablePingHandler": true,
+    "EnablePrivateNetworkAccessHeader": false,
     "EnableProcessBlockStats": false,
     "EnableProfiler": false,
     "EnableRequestLogger": false,

--- a/test/testdata/nettemplates/TwoNodes50EachPNA.json
+++ b/test/testdata/nettemplates/TwoNodes50EachPNA.json
@@ -1,0 +1,37 @@
+{
+    "Genesis": {
+        "NetworkName": "tbd",
+        "LastPartKeyRound": 3000,
+        "Wallets": [
+            {
+                "Name": "Wallet1",
+                "Stake": 50,
+                "Online": true
+            },
+            {
+                "Name": "Wallet2",
+                "Stake": 50,
+                "Online": true
+            }
+        ]
+    },
+    "Nodes": [
+        {
+            "Name": "Primary",
+            "IsRelay": true,
+            "ConfigJSONOverride": "{\"EnablePrivateNetworkAccessHeader\":true}",
+            "Wallets": [
+                { "Name": "Wallet1",
+                  "ParticipationOnly": false }
+            ]
+        },
+        {
+            "Name": "Node",
+            "ConfigJSONOverride": "{\"EnablePrivateNetworkAccessHeader\":true}",
+            "Wallets": [
+                { "Name": "Wallet2",
+                  "ParticipationOnly": false }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

During development of Algorand smart contracts and platforms users will often run local environments consisting of algod, kmd, and indexer via sandbox or more recently algokit. By default all of these services are running on local/private network addresses (e.g. 127.0.0.1), however popular tools such as [DappFlow](https://app.dappflow.org/explorer) and [Lora](https://lora.algokit.io/localnet) are hosted on public network addresses and require the user to specify their local endpoints. Additionally some dapps allow their users to provide their own endpoints for a _more_ decentralised experience.

Schedule for [Google Chrome 130](https://developer.chrome.com/blog/private-network-access-update-2024-03) (although many users are already experiencing it), PNA protections will be enabled by default, disallowing public websites from making requests to local/private resources without a specific header response during a preflight request. This PR introduces a new configuration option for both **algod** and **kmd** that will add middleware to each of their API handlers to support responding to the Private Network Access request header.

## Test Plan

I simply copied the only CORS related test I could find and adjusted it to check for the PNA header. I'd be happy to add something more thorough if a suggestion can be offered.