### PR TITLE
netgoal: allow unknown template tokens

### DIFF
--- a/cmd/netgoal/network.go
+++ b/cmd/netgoal/network.go
@@ -35,6 +35,7 @@ var networkRecipeFile string
 var networkName string
 var networkGenesisVersionModifier string
 var miscStringStringTokens []string
+var ignoreUnknownTokens bool
 
 var cpuprofilePath string
 
@@ -56,7 +57,8 @@ func init() {
 	networkBuildCmd.Flags().BoolVarP(&networkUseGenesisFiles, "use-existing-files", "e", false, "Use existing genesis files.")
 	networkBuildCmd.Flags().BoolVarP(&bootstrapLoadingFile, "gen-db-files", "b", false, "Generate database files.")
 	networkBuildCmd.Flags().BoolVarP(&networkIgnoreExistingDir, "force", "f", false, "Force generation into existing directory.")
-	networkBuildCmd.Flags().StringSliceVarP(&miscStringStringTokens, "val", "v", nil, "name=value, may be reapeated")
+	networkBuildCmd.Flags().StringSliceVarP(&miscStringStringTokens, "val", "v", nil, "name=value, may be repeated")
+	networkBuildCmd.Flags().BoolVarP(&ignoreUnknownTokens, "ignore", "i", false, "Ignore unknown tokens in network template file")
 	networkBuildCmd.Flags().StringVar(&cpuprofilePath, "cpuprofile", "", "write cpu profile to path")
 
 	rootCmd.PersistentFlags().StringVarP(&networkGenesisVersionModifier, "modifier", "m", "", "Override Genesis Version Modifier (eg 'v1')")
@@ -136,7 +138,7 @@ func runBuildNetwork() error {
 		return fmt.Errorf("error resolving network template file '%s' to full path: %v", networkTemplateFile, err)
 	}
 
-	netCfg, err := remote.InitDeployedNetworkConfig(networkTemplateFile, buildConfig)
+	netCfg, err := remote.InitDeployedNetworkConfig(networkTemplateFile, buildConfig, ignoreUnknownTokens)
 	if err != nil {
 		return fmt.Errorf("error loading Network Config file '%s': %v", networkTemplateFile, err)
 	}

--- a/netdeploy/remote/deployedNetwork.go
+++ b/netdeploy/remote/deployedNetwork.go
@@ -19,6 +19,7 @@ package remote
 import (
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"math/rand"
@@ -58,14 +59,14 @@ var ErrDeployedNetworkInsufficientHosts = fmt.Errorf("target network requires mo
 // ErrDeployedNetworkNameCantIncludeWildcard is returned by Validate if network name contains '*'
 var ErrDeployedNetworkNameCantIncludeWildcard = fmt.Errorf("network name cannont include wild-cards")
 
-// ErrDeployedNetworkTemplate A template file contained {{Field}} sections that were not handled by a corresponding Field value in configuration.
-type ErrDeployedNetworkTemplate struct {
-	UnhandledTemplate string
+// deployedNetworkTemplateError A template file contained {{Field}} sections that were not handled by a corresponding Field value in configuration.
+type deployedNetworkTemplateError struct {
+	unhandledTemplate string
 }
 
 // Error satisfies error interface
-func (ednt ErrDeployedNetworkTemplate) Error() string {
-	return fmt.Sprintf("config file contains unrecognized token: %s", ednt.UnhandledTemplate)
+func (dnte deployedNetworkTemplateError) Error() string {
+	return fmt.Sprintf("config file contains unrecognized token: %s", dnte.unhandledTemplate)
 }
 
 // DeployedNetworkConfig represents the complete configuration specification for a deployed network
@@ -123,10 +124,13 @@ int 1
 `
 
 // InitDeployedNetworkConfig loads the DeployedNetworkConfig from a file
-func InitDeployedNetworkConfig(file string, buildConfig BuildConfig) (cfg DeployedNetworkConfig, err error) {
+func InitDeployedNetworkConfig(file string, buildConfig BuildConfig, ignoreUnkTokens bool) (cfg DeployedNetworkConfig, err error) {
 	processedFile, err := loadAndProcessConfig(file, buildConfig)
 	if err != nil {
-		return
+		var dnte deployedNetworkTemplateError
+		if !errors.As(err, &dnte) || !ignoreUnkTokens {
+			return
+		}
 	}
 
 	err = json.Unmarshal([]byte(processedFile), &cfg)
@@ -178,7 +182,7 @@ func replaceTokens(original string, buildConfig BuildConfig) (expanded string, e
 		if closeIndex < 0 {
 			closeIndex = len(expanded) - 2
 		}
-		return "", ErrDeployedNetworkTemplate{expanded[openIndex : closeIndex+2]}
+		return expanded, deployedNetworkTemplateError{expanded[openIndex : closeIndex+2]}
 	}
 
 	return


### PR DESCRIPTION
## Summary

Add a new option `-i/--ignore` to `netgoal build` to suppress errors like `error building network files: error loading Network Config file 'net.json': config file contains unrecognized token: {{.Year}}` when using `LogArchiveName` templating in `ConfigJSONOverride`

Also renamed `ErrDeployedNetworkTemplate` error type to `deployedNetworkTemplateError` to match err val vs err type convention used in other parts of the code base (err- prefix for values, -Error suffix for types).

## Test Plan

Tested locally