### PR TITLE
p2p: do not advertise private and non-routable addresses

### DIFF
--- a/network/hybridNetwork_test.go
+++ b/network/hybridNetwork_test.go
@@ -64,7 +64,7 @@ func TestHybridNetwork_DuplicateConn(t *testing.T) {
 	// make it net address and restart the node
 	relayCfg.NetAddress = addr
 	relayCfg.PublicAddress = addr
-	relayCfg.P2PNetAddress = ":0"
+	relayCfg.P2PNetAddress = "127.0.0.1:0"
 	netA, err = NewHybridP2PNetwork(log.With("node", "netA"), relayCfg, p2pKeyDir, nil, genesisID, "net", &nopeNodeInfo{})
 	require.NoError(t, err)
 

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -133,8 +133,6 @@ func MakeHost(cfg config.Local, datadir string, pstore *pstore.PeerStore) (host.
 	var enableMetrics = func(cfg *libp2p.Config) error { cfg.DisableMetrics = false; return nil }
 	metrics.DefaultRegistry().Register(&metrics.PrometheusDefaultMetrics)
 
-	// if we are listening on a loopback address, most likely we are running tests or a goal network,
-	// so don't filter out any addresses
 	var addrFactory func(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr
 	if needAddressFilter {
 		logging.Base().Debug("private addresses filter is enabled")
@@ -369,7 +367,7 @@ func parseCIDR(cidrs []string) []*net.IPNet {
 func addressFilter(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
 	res := make([]multiaddr.Multiaddr, 0, len(addrs))
 	for _, addr := range addrs {
-		if manet.IsPublicAddr(addr) && !manet.IsPrivateAddr(addr) {
+		if manet.IsPublicAddr(addr) {
 			if _, err := addr.ValueForProtocol(multiaddr.P_IP4); err == nil {
 				// no rules for IPv4 at the moment, accept
 				res = append(res, addr)

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -128,6 +128,7 @@ func MakeHost(cfg config.Local, datadir string, pstore *pstore.PeerStore) (host.
 	// so don't filter out any addresses
 	var addrFactory func(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr
 	if !isLoopback {
+		logging.Base().Debug("Private addresses filter is set")
 		addrFactory = addrFilter
 	}
 

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -394,6 +394,7 @@ func addressFilter(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
 			for _, ipnet := range private6 {
 				if ipnet.Contains(addrIP) {
 					isPrivate = true
+					break
 				}
 			}
 			if !isPrivate {

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -365,6 +365,16 @@ func parseCIDR(cidrs []string) []*net.IPNet {
 
 // addressFilter filters out private and unroutable addresses
 func addressFilter(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
+	if logging.Base().IsLevelEnabled(logging.Debug) {
+		var b strings.Builder
+		for _, addr := range addrs {
+			b.WriteRune(' ')
+			b.WriteString(addr.String())
+			b.WriteRune(' ')
+		}
+		logging.Base().Debugf("addressFilter input: %s", b.String())
+	}
+
 	res := make([]multiaddr.Multiaddr, 0, len(addrs))
 	for _, addr := range addrs {
 		if manet.IsPublicAddr(addr) {
@@ -390,6 +400,15 @@ func addressFilter(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
 				res = append(res, addr)
 			}
 		}
+	}
+	if logging.Base().IsLevelEnabled(logging.Debug) {
+		var b strings.Builder
+		for _, addr := range res {
+			b.WriteRune(' ')
+			b.WriteString(addr.String())
+			b.WriteRune(' ')
+		}
+		logging.Base().Debugf("addressFilter output: %s", b.String())
 	}
 	return res
 }

--- a/network/p2p/p2p_test.go
+++ b/network/p2p/p2p_test.go
@@ -208,7 +208,7 @@ func TestP2PPrivateAddresses(t *testing.T) {
 
 	for _, addr := range privAddrList {
 		ma := multiaddr.StringCast(addr)
-		require.True(t, !manet.IsPublicAddr(ma) || manet.IsPrivateAddr(ma), "public/private check failed on %s", addr)
+		require.False(t, manet.IsPublicAddr(ma), "public check failed on %s", addr)
 		require.Empty(t, addressFilter([]multiaddr.Multiaddr{ma}), "addrFilter failed on %s", addr)
 	}
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -870,9 +870,6 @@ func TestNodeHybridTopology(t *testing.T) {
 			cfg.GossipFanout = 0
 		}
 
-		// TODO: REMOVE
-		cfg.BaseLoggerDebugLevel = 5
-
 		cfg.NetAddress = ni.wsNetAddr()
 		cfg.EnableP2PHybridMode = true
 		cfg.PublicAddress = ni.wsNetAddr()

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -870,6 +870,9 @@ func TestNodeHybridTopology(t *testing.T) {
 			cfg.GossipFanout = 0
 		}
 
+		// TODO: REMOVE
+		cfg.BaseLoggerDebugLevel = 5
+
 		cfg.NetAddress = ni.wsNetAddr()
 		cfg.EnableP2PHybridMode = true
 		cfg.PublicAddress = ni.wsNetAddr()


### PR DESCRIPTION
## Summary

When p2p net listens on all interfaces ("0.0.0.0:0", ":0", ":N"), it advertises everything including loopback and private interface addresses. The solution is to handle this specification and apply libp2p's AddressFactory filter.

Note, when some specific address is set like loopback or a private interface, it recognized as intentional action and no filters applied. This allows to all unit tests starting network on "127.0.0.1:0" to continue to operate, as well allows private nets to run if `NetAddress` is set appropriate (say to "10.1.0.101:0").

During algonet testing I found EC2 instances only have loopback and a private 172.31.x.x addresses so that filtered.
libp2p has address observation facility (part of netidentity) that reports addresses seen at least [4 times](https://github.com/libp2p/go-libp2p/blob/v0.33.2/p2p/protocol/identify/obsaddr.go#L203) (`activated()` piece) in last 30 minutes (TTL piece).
This means we need at least 4 p2p bootstrap nodes to allow other nodes to advertise their observed addresses over DHT.

## Test Plan

1. Added unit tests for `addressFilter' function and for `MakeHost` with different `NetAddress` specifications.
2. Successfully tested with algonet the following subset of s1-p2p (8 relays, 5 part, 5 non-part nodes):
```
PARAMS=-w 5 -R 8 -N 5 -n 5 --npn-algod-nodes 5 --node-template node.json --relay-template relay.json --non-participating-node-template nonPartNode.json
```
with 4 of 8 relays being p2p bootstrap nodes (via DNS TXT) and with all nodes `"EnableDHTProviders": true`. I was able to add an extra node with `"GossipFanout": 8` to this network and have it connected to all 8 relays despite the fact only 8 are registered in DNS.
