### PR TITLE
agreement: log payloadVerified in tracer

### DIFF
--- a/agreement/trace.go
+++ b/agreement/trace.go
@@ -391,6 +391,22 @@ func (t *tracer) logProposalManagerResult(p player, input messageEvent, output e
 			logEvent.Type = logspec.BlockCommittable
 			t.log.with(logEvent).Infof("block committable for %v at (%v, %v)", logEvent.Hash, p.Round, p.Period)
 		}
+	case payloadVerified:
+		if !t.log.IsLevelEnabled(logging.Info) {
+			return
+		}
+		up := input.Input.UnauthenticatedProposal
+		logEvent := logspec.AgreementEvent{
+			Type:         logspec.ProposalVerified,
+			Round:        uint64(p.Round),
+			Period:       uint64(p.Period),
+			Step:         uint64(p.Step),
+			Sender:       up.OriginalProposer.String(),
+			Hash:         up.Digest().String(),
+			ObjectRound:  uint64(pipelinedRound),
+			ObjectPeriod: uint64(pipelinedPeriod),
+		}
+		t.log.with(logEvent).Infof("payload verified (%v, %v): %v", pipelinedRound, pipelinedPeriod, output.(payloadProcessedEvent).Err)
 	}
 }
 

--- a/logging/logspec/agreement.go
+++ b/logging/logspec/agreement.go
@@ -79,6 +79,8 @@ const (
 	ProposalAccepted
 	// ProposalRejected is emitted when the source rejects a leader proposal.
 	ProposalRejected
+	// ProposalVerified is emitted when the source verifies a proposal.
+	ProposalVerified
 
 	// BlockRejected is emitted when a block is rejected.
 	// (Since fragmentation is not implemented currently,

--- a/logging/logspec/agreementtype_string.go
+++ b/logging/logspec/agreementtype_string.go
@@ -22,24 +22,25 @@ func _() {
 	_ = x[ProposalFrozen-11]
 	_ = x[ProposalAccepted-12]
 	_ = x[ProposalRejected-13]
-	_ = x[BlockRejected-14]
-	_ = x[BlockResent-15]
-	_ = x[BlockPipelined-16]
-	_ = x[VoteAttest-17]
-	_ = x[VoteBroadcast-18]
-	_ = x[VoteAccepted-19]
-	_ = x[VoteRejected-20]
-	_ = x[BundleBroadcast-21]
-	_ = x[BundleAccepted-22]
-	_ = x[BundleRejected-23]
-	_ = x[Restored-24]
-	_ = x[Persisted-25]
-	_ = x[numAgreementTypes-26]
+	_ = x[ProposalVerified-14]
+	_ = x[BlockRejected-15]
+	_ = x[BlockResent-16]
+	_ = x[BlockPipelined-17]
+	_ = x[VoteAttest-18]
+	_ = x[VoteBroadcast-19]
+	_ = x[VoteAccepted-20]
+	_ = x[VoteRejected-21]
+	_ = x[BundleBroadcast-22]
+	_ = x[BundleAccepted-23]
+	_ = x[BundleRejected-24]
+	_ = x[Restored-25]
+	_ = x[Persisted-26]
+	_ = x[numAgreementTypes-27]
 }
 
-const _AgreementType_name = "RoundConcludedPeriodConcludedStepTimeoutRoundStartRoundInterruptedRoundWaitingThresholdReachedBlockAssembledBlockCommittableProposalAssembledProposalBroadcastProposalFrozenProposalAcceptedProposalRejectedBlockRejectedBlockResentBlockPipelinedVoteAttestVoteBroadcastVoteAcceptedVoteRejectedBundleBroadcastBundleAcceptedBundleRejectedRestoredPersistednumAgreementTypes"
+const _AgreementType_name = "RoundConcludedPeriodConcludedStepTimeoutRoundStartRoundInterruptedRoundWaitingThresholdReachedBlockAssembledBlockCommittableProposalAssembledProposalBroadcastProposalFrozenProposalAcceptedProposalRejectedProposalVerifiedBlockRejectedBlockResentBlockPipelinedVoteAttestVoteBroadcastVoteAcceptedVoteRejectedBundleBroadcastBundleAcceptedBundleRejectedRestoredPersistednumAgreementTypes"
 
-var _AgreementType_index = [...]uint16{0, 14, 29, 40, 50, 66, 78, 94, 108, 124, 141, 158, 172, 188, 204, 217, 228, 242, 252, 265, 277, 289, 304, 318, 332, 340, 349, 366}
+var _AgreementType_index = [...]uint16{0, 14, 29, 40, 50, 66, 78, 94, 108, 124, 141, 158, 172, 188, 204, 220, 233, 244, 258, 268, 281, 293, 305, 320, 334, 348, 356, 365, 382}
 
 func (i AgreementType) String() string {
 	if i < 0 || i >= AgreementType(len(_AgreementType_index)-1) {


### PR DESCRIPTION
## Summary

In order to debug a test failures where 7 nodes network fails to conclude round 1 ([one](https://circleci.com/api/v1.1/project/github/algorand/go-algorand/276592/output/114/1?file=true&allocation-id=66ac318d9631ca240dd7088b-1-build%2FABCDEFGH), [two](https://circleci.com/api/v1.1/project/github/algorand/go-algorand/276747/output/114/1?file=true&allocation-id=66b1780e3a96ed650df3fbd2-1-build%2FABCDEFGH))  adding `payloadVerified` agreement trace message.

## Test Plan

Existing tests should pass.