### PR TITLE
tests: fix e2e subs goal-partkey-commands

### DIFF
--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -181,7 +181,16 @@ if [ -z "$E2E_TEST_FILTER" ] || [ "$E2E_TEST_FILTER" == "SCRIPTS" ]; then
 
     clientrunner="${TEMPDIR}/ve/bin/python3 e2e_client_runner.py ${RUN_KMD_WITH_UNSAFE_SCRYPT}"
 
-    $clientrunner ${KEEP_TEMPS_CMD_STR} "$SRCROOT"/test/scripts/e2e_subs/*.{sh,py}
+    if [ -n "$TESTFILTER" ]; then
+        echo "Running test: $TESTFILTER"
+        $clientrunner ${KEEP_TEMPS_CMD_STR} "$SRCROOT"/test/scripts/e2e_subs/${TESTFILTER}
+        echo -n "deactivating..."
+        deactivate
+        echo "done"
+        exit
+    else
+        $clientrunner ${KEEP_TEMPS_CMD_STR} "$SRCROOT"/test/scripts/e2e_subs/*.{sh,py}
+    fi
 
     # If the temporary artifact directory exists, then the test artifact needs to be created
     if [ -d "${TEMPDIR}/net" ]; then

--- a/test/scripts/e2e_subs/goal-partkey-commands.sh
+++ b/test/scripts/e2e_subs/goal-partkey-commands.sh
@@ -6,9 +6,14 @@ set -x
 
 date "+$0 start %Y%m%d_%H%M%S"
 
+WALLET=$1
+
+gcmd="goal -w ${WALLET}"
+INITIAL_ACCOUNT=$(${gcmd} account list|awk '{ print $3 }')
+
 # Registered  Account      ParticipationID   Last Used  First round  Last round
 # yes         LFMT...RHJQ  4UPT6AQC...               4            0     3000000
-OUTPUT=$(goal account listpartkeys)
+OUTPUT=$(${gcmd} account listpartkeys)
 # In case there are multiple keys, make sure we are checking the correct one.
 OUTPUT=$(echo "$OUTPUT"|grep "yes.*3000"|tr -s ' ')
 if [[ "$OUTPUT"                          != yes*    ]]; then echo "Registered should be 'yes' but wasn't."; exit 1; fi
@@ -29,7 +34,7 @@ if [[ $(echo "$OUTPUT" | cut -d' ' -f 6) != 3000 ]];    then echo "Last round sh
 #Key dilution:              10000
 #Selection key:             esIsBJB86P+sLeqO3gVoLBGfpuwYlWN4lNzz2AYslTo=
 #Voting key:                W1OcXLZsaATyOd5FbhRgXHmcywvn++xEVUAQ0NejmW4=
-OUTPUT=$(goal account partkeyinfo)
+OUTPUT=$(${gcmd} account partkeyinfo)
 if ! echo "$OUTPUT" | grep -q 'First round:[[:space:]]* 0';                  then echo "First round should have been 0.";             exit 1; fi
 if ! echo "$OUTPUT" | grep -q 'Last round:[[:space:]]* 3000';                then echo "Last round should have been 3000.";           exit 1; fi
 if ! echo "$OUTPUT" | grep -q 'Effective last round:[[:space:]]* 3000';      then echo "Effective last round should have been 3000."; exit 1; fi
@@ -39,18 +44,31 @@ if ! echo "$OUTPUT" | grep -q 'Participation ID:[[:space:]]*[[:alnum:]]\{52\}'; 
 
 # Test multiple data directory supported
 NUM_OUTPUT_1=$(echo "$OUTPUT"|grep -c 'Participation ID')
-OUTPUT=$(goal account partkeyinfo -d "$ALGORAND_DATA" -d "$ALGORAND_DATA2")
+OUTPUT=$(${gcmd} account partkeyinfo -d "$ALGORAND_DATA" -d "$ALGORAND_DATA2")
 NUM_OUTPUT_2=$(echo "$OUTPUT"|grep -c 'Participation ID')
 if (( "$NUM_OUTPUT_2" <= "$NUM_OUTPUT_1" )); then echo "Should have found more participation keys when checking both data directories."; exit 1; fi
 
 # get stderr from this one
-OUTPUT=$(goal account listpartkeys -d "$ALGORAND_DATA" -d "$ALGORAND_DATA2" 2>&1)
+OUTPUT=$(${gcmd} account listpartkeys -d "$ALGORAND_DATA" -d "$ALGORAND_DATA2" 2>&1)
 EXPECTED_ERR="Only one data directory can be specified for this command."
 if [[ "$OUTPUT" != "$EXPECTED_ERR" ]]; then echo -e "Unexpected output from multiple data directories with 'listpartkeys': \n$OUTPUT"; exit 1; fi
 
+# done with manual error checking
+set -exo pipefail
+
+fail_test () {
+  echo "test_fail: $1"
+  exit 1
+}
+
 create_and_fund_account () {
+  set +x  # disable command echoing to hide the account funding output
   local TEMP_ACCT=$(${gcmd} account new|awk '{ print $6 }')
-  ${gcmd} clerk send -f "$INITIAL_ACCOUNT" -t "$TEMP_ACCT" -a 1000000 > /dev/null
+  SEND_OUTOUT=$(${gcmd} clerk send -f "$INITIAL_ACCOUNT" -t "$TEMP_ACCT" -a 1000000 2>&1)
+  if [[ $SEND_OUTOUT == *"Couldn't broadcast tx"* ]]; then
+    fail_test "Failed to fund account: $SEND_OUTOUT"
+  fi
+  set -x
   echo "$TEMP_ACCT"
 }
 
@@ -60,14 +78,16 @@ create_and_fund_account () {
 # $3 - error message
 verify_registered_state () {
   # look for participation ID anywhere in the partkeyinfo output
-  if ! goal account partkeyinfo | grep -q "$2"; then
-    fail_test "Key was not installed properly: $3"
+  PARTKEY_OUTPUT=$(${gcmd} account partkeyinfo)
+  if ! echo "$PARTKEY_OUTPUT" | grep -q "$2"; then
+    fail_test "Key $2 was not installed properly for cmd '$3':\n$PARTKEY_OUTPUT"
   fi
 
   # looking for yes/no, and the 8 character head of participation id in this line:
   # yes         LFMT...RHJQ  4UPT6AQC...               4            0     3000
-  if ! goal account listpartkeys | grep -q "$1.*$(echo "$2" | cut -c1-8)\.\.\."; then
-    fail_test "Unexpected key state: $3"
+  LISTKEY_OUTPUT=$(${gcmd} account listpartkeys)
+  if ! echo "$LISTKEY_OUTPUT" | grep -q "$1.*$(echo "$2" | cut -c1-8)"; then
+    fail_test "Unexpected key $2 state ($1) for cmd '$3':\n$LISTKEY_OUTPUT"
   fi
 }
 
@@ -75,19 +95,31 @@ verify_registered_state () {
 # install manually generated participation keys (do not register)
 NEW_ACCOUNT_1=$(create_and_fund_account)
 algokey part generate --keyfile test_partkey --first 0 --last 3000 --parent "$NEW_ACCOUNT_1"
-PARTICIPATION_ID_1=$(goal account installpartkey --delete-input --partkey test_partkey|awk '{ print $7 }')
+OUTPUT=$(${gcmd} account installpartkey --delete-input --partkey test_partkey)
+PARTICIPATION_ID_1=$(echo "$OUTPUT" |awk '{ print $7 }')
 verify_registered_state "no" "$PARTICIPATION_ID_1" "goal account installpartkey"
 
 # goal account addpartkey
 # generate and install participation keys (do not register)
+# ============= Example output =============
+# Please stand by while generating keys. This might take a few minutes...
+# Participation key generation successful
+# Transaction id for status change transaction: U3SWNVPUODOUHHUM3W3QP3DTQPO6GLYVOB2A6UYBKAWKJP5T4GEQ
+# Transaction U3SWNVPUODOUHHUM3W3QP3DTQPO6GLYVOB2A6UYBKAWKJP5T4GEQ still pending as of round 11
+# Transaction U3SWNVPUODOUHHUM3W3QP3DTQPO6GLYVOB2A6UYBKAWKJP5T4GEQ still pending as of round 12
+# Transaction U3SWNVPUODOUHHUM3W3QP3DTQPO6GLYVOB2A6UYBKAWKJP5T4GEQ committed in round 13
+# Participation key installed successfully, Participation ID: NTJG7MGXZ5SCLIJXW7T2VZGLTVY47QBFTQSOC7JMIF7LWXVMQOPQ
+# Generated with goal v3.26.226519
 NEW_ACCOUNT_2=$(create_and_fund_account)
-PARTICIPATION_ID_2=$(goal account addpartkey -a "$NEW_ACCOUNT_2" --roundFirstValid 0 --roundLastValid 3000|awk '{ print $7 }')
+OUTPUT=$(${gcmd} account addpartkey -a "$NEW_ACCOUNT_2" --roundFirstValid 0 --roundLastValid 3000)
+PARTICIPATION_ID_2=$(echo "$OUTPUT" | grep "Participation ID" | awk '{ print $7 }')
 verify_registered_state "no" "$PARTICIPATION_ID_2" "goal account addpartkey"
 
 # goal account renewpartkeys
 # generate, install, and register
 NEW_ACCOUNT_3=$(create_and_fund_account)
-PARTICIPATION_ID_3=$(${gcmd} account renewpartkey --roundLastValid 3000 -a "$NEW_ACCOUNT_3"|tail -n 1|awk '{ print $7 }')
+OUTPUT=$(${gcmd} account renewpartkey --roundLastValid 3000 -a "$NEW_ACCOUNT_3")
+PARTICIPATION_ID_3=$(echo "$OUTPUT" | grep "Participation ID" | awk '{ print $7 }')
 verify_registered_state "yes" "$PARTICIPATION_ID_3" "goal account renewpartkey"
 
 # goal account changeonlinstatus (--account)


### PR DESCRIPTION
## Summary

goal-partkey-commands was extremely buggy:
1. Uses non-initialized gcmd and INITIAL_ACCOUNT
2. Does not check if cmd fails (no `set -e`)
3. Part key command output parsing was invalid.
4. Sometimes it raced with some other test and failed to correctly compare part keys. This was fixed by binding goal cmd to a wallet (the runner creates unique wallets for each test).

Also added `TESTFILTER` handling to e2e-subs so it can run a single test now (similarly to expect tests).

## Test Plan

This is a test fix, passed locally