### PR TITLE
tests: flaky tests fixes

### DIFF
--- a/network/p2p/p2p_test.go
+++ b/network/p2p/p2p_test.go
@@ -290,7 +290,13 @@ func TestP2PMakeHostAddressFilter(t *testing.T) {
 		mala, err := multiaddr.NewMultiaddr(la)
 		require.NoError(t, err)
 		host.Network().Listen(mala)
-		require.Empty(t, host.Addrs())
+		addrs := host.Addrs()
+		if len(addrs) > 0 {
+			// CI servers might have a single public IP interface, validate if this is a case
+			for _, a := range addrs {
+				require.True(t, manet.IsPublicAddr(a))
+			}
+		}
 		host.Close()
 	}
 


### PR DESCRIPTION
## Summary

1. `TestP2PMakeHostAddressFilter` listening on "0.0.0.0:0" was not ready for a builder having only a single interface with a public IPv4 so its actual listen address became this interface address. Fixed by ensuring if `Addrs()` return non-empty, all elements are public ([failure](https://app.circleci.com/pipelines/github/algorand/go-algorand/18895/workflows/1b030ad6-7699-42a7-9525-6c921b888b08/jobs/276851)).
2. Rewrote `TestVotersReloadFromDiskAfterOneStateProofCommitted` to use synchronous commits. Handled extra element in deferred commits queue by draining it before `reloadLedger` - a very first commit gets scheduled there because AddBlock -> AddValidatedBlock -> notifyCommit -> scheduleCommit is still being called, and `reloadLedger` does not reset  the accountWriting wait group ([failure](https://app.circleci.com/pipelines/github/algorand/go-algorand/18893/workflows/aecb8c5c-0ad1-4e26-b499-6cd61be2a23a/jobs/276838)).
3. `goal-partkey-commands.sh` [fails](https://app.circleci.com/pipelines/github/algorand/go-algorand/18895/workflows/1b030ad6-7699-42a7-9525-6c921b888b08/jobs/276854) for no good reason - output has all required strings but `if echo "$OUTPIT" | grep -q "$STRING"` fails to handle it as expected. I fixed possible whitespaces and fixed shellcheck. Not sure what else.
