### PR TITLE
ledger: Implement JSON encoding and decoding for ledgercore.StateDelta

### DIFF
--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -299,10 +299,7 @@ func (sd StateDelta) ToSerializable() (StateDeltaSerializable, error) {
 	}
 	serializableTxids := map[string]IncludedTransactions{}
 	for k, v := range sd.Txids {
-		json, err := json.Marshal(k)
-		if err != nil {
-			return StateDeltaSerializable{}, err
-		}
+		json := k.String()
 		serializableTxids[string(json)] = v
 	}
 	return StateDeltaSerializable{
@@ -358,10 +355,10 @@ func (sd StateDeltaSerializable) ToNonSerializable() (StateDelta, error) {
 	nonSerializableTxids := map[transactions.Txid]IncludedTransactions{}
 	for k, v := range sd.Txids {
 		var txid transactions.Txid
-		err := json.Unmarshal([]byte(k), &txid)
-		if err != nil {
-			return StateDelta{}, err
-		}
+		err := txid.UnmarshalText([]byte(k))
+    if err != nil {
+      return StateDelta{}, err
+    }
 		nonSerializableTxids[txid] = v
 	}
 	return StateDelta{

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -17,8 +17,8 @@
 package ledgercore
 
 import (
+	"encoding/json"
 	"fmt"
-  "encoding/json"
 
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
@@ -127,7 +127,6 @@ type StateDelta struct {
 	Totals AccountTotals
 }
 
-
 // StateDeltaSerializable is nearly identical to StateDelta,
 // but is able to be serialized/deserialized to/from JSON without custom
 // MarshalJSON() and UnmarshalJSON() methods.
@@ -162,12 +161,11 @@ type StateDeltaSerializable struct {
 	PrevTimestamp int64
 
 	// initial hint for allocating data structures for StateDelta
-  initialHint int
+	initialHint int
 
 	// The account totals reflecting the changes in this StateDelta object.
 	Totals AccountTotals
 }
-
 
 // BalanceRecord is similar to basics.BalanceRecord but with decoupled base and voting data
 type BalanceRecord struct {
@@ -291,93 +289,93 @@ func (sd *StateDelta) Dehydrate() {
 
 // ToSerializable() converts a StateDeltaSerializable to a StateDelta
 func (sd StateDelta) ToSerializable() (StateDeltaSerializable, error) {
-  serializableTxleases := map[string]basics.Round{}
-  for k, v := range sd.Txleases {
-    json, err := json.Marshal(k);
-    if err != nil {
-      return StateDeltaSerializable{}, err
-    }
-    serializableTxleases[string(json)] = v;
-  }
-  serializableTxids := map[string]IncludedTransactions{}
-  for k, v := range sd.Txids {
-    json, err := json.Marshal(k);
-    if err != nil {
-      return StateDeltaSerializable{}, err
-    }
-    serializableTxids[string(json)] = v;
-  }
-	return StateDeltaSerializable {
-    Accts: sd.Accts,
-    KvMods: sd.KvMods,
-    Txids: serializableTxids,
-    Txleases: serializableTxleases,
-    Creatables: sd.Creatables,
-    Hdr: *sd.Hdr,
-    StateProofNext: sd.StateProofNext,
-    PrevTimestamp: sd.PrevTimestamp,
-    initialHint: sd.initialHint,
-    Totals: sd.Totals,
-  }, nil;
+	serializableTxleases := map[string]basics.Round{}
+	for k, v := range sd.Txleases {
+		json, err := json.Marshal(k)
+		if err != nil {
+			return StateDeltaSerializable{}, err
+		}
+		serializableTxleases[string(json)] = v
+	}
+	serializableTxids := map[string]IncludedTransactions{}
+	for k, v := range sd.Txids {
+		json, err := json.Marshal(k)
+		if err != nil {
+			return StateDeltaSerializable{}, err
+		}
+		serializableTxids[string(json)] = v
+	}
+	return StateDeltaSerializable{
+		Accts:          sd.Accts,
+		KvMods:         sd.KvMods,
+		Txids:          serializableTxids,
+		Txleases:       serializableTxleases,
+		Creatables:     sd.Creatables,
+		Hdr:            *sd.Hdr,
+		StateProofNext: sd.StateProofNext,
+		PrevTimestamp:  sd.PrevTimestamp,
+		initialHint:    sd.initialHint,
+		Totals:         sd.Totals,
+	}, nil
 }
 
 // MarshalJSON() encodes a StateDelta into JSON
 func (sd StateDelta) MarshalJSON() ([]byte, error) {
-  serializable, err := sd.ToSerializable();
-  if err != nil {
-    return nil, err
-  }
-  serialized, err := json.Marshal(serializable)
-  return serialized, err
+	serializable, err := sd.ToSerializable()
+	if err != nil {
+		return nil, err
+	}
+	serialized, err := json.Marshal(serializable)
+	return serialized, err
 }
 
 // UnmarshalJSON() converts JSON into a StateDelta
 func (sd *StateDelta) UnmarshalJSON(data []byte) error {
-  var serializable StateDeltaSerializable
-  err := json.Unmarshal(data, &serializable)
-  if err != nil {
-    return err
-  }
-  nonSerializable, err := serializable.ToNonSerializable()
-  if err != nil {
-    return err
-  }
-  *sd = nonSerializable
-  return nil
+	var serializable StateDeltaSerializable
+	err := json.Unmarshal(data, &serializable)
+	if err != nil {
+		return err
+	}
+	nonSerializable, err := serializable.ToNonSerializable()
+	if err != nil {
+		return err
+	}
+	*sd = nonSerializable
+	return nil
 }
 
 // ToNonSerializable() converts a StateDeltaSerializable to a StateDelta
 func (sd StateDeltaSerializable) ToNonSerializable() (StateDelta, error) {
-  nonSerializableTxleases := map[Txlease]basics.Round{}
-  for k, v := range sd.Txleases {
-    var txlease Txlease
-    err := json.Unmarshal([]byte(k), &txlease)
-    if err != nil {
-      return StateDelta{}, err
-    }
-    nonSerializableTxleases[txlease] = v
-  }
-  nonSerializableTxids := map[transactions.Txid]IncludedTransactions{}
-  for k, v := range sd.Txids {
-    var txid transactions.Txid
-    err := json.Unmarshal([]byte(k), &txid)
-    if err != nil {
-      return StateDelta{}, err
-    }
-    nonSerializableTxids[txid] = v
-  }
-	return StateDelta {
-    Accts: sd.Accts,
-    KvMods: sd.KvMods,
-    Txids: nonSerializableTxids,
-    Txleases: nonSerializableTxleases,
-    Creatables: sd.Creatables,
-    Hdr: &sd.Hdr,
-    StateProofNext: sd.StateProofNext,
-    PrevTimestamp: sd.PrevTimestamp,
-    initialHint: sd.initialHint,
-    Totals: sd.Totals,
-  }, nil;
+	nonSerializableTxleases := map[Txlease]basics.Round{}
+	for k, v := range sd.Txleases {
+		var txlease Txlease
+		err := json.Unmarshal([]byte(k), &txlease)
+		if err != nil {
+			return StateDelta{}, err
+		}
+		nonSerializableTxleases[txlease] = v
+	}
+	nonSerializableTxids := map[transactions.Txid]IncludedTransactions{}
+	for k, v := range sd.Txids {
+		var txid transactions.Txid
+		err := json.Unmarshal([]byte(k), &txid)
+		if err != nil {
+			return StateDelta{}, err
+		}
+		nonSerializableTxids[txid] = v
+	}
+	return StateDelta{
+		Accts:          sd.Accts,
+		KvMods:         sd.KvMods,
+		Txids:          nonSerializableTxids,
+		Txleases:       nonSerializableTxleases,
+		Creatables:     sd.Creatables,
+		Hdr:            &sd.Hdr,
+		StateProofNext: sd.StateProofNext,
+		PrevTimestamp:  sd.PrevTimestamp,
+		initialHint:    sd.initialHint,
+		Totals:         sd.Totals,
+	}, nil
 }
 
 // MakeAccountDeltas creates account delta

--- a/ledger/ledgercore/statedelta_test.go
+++ b/ledger/ledgercore/statedelta_test.go
@@ -543,13 +543,23 @@ func TestStateDeltaReflect(t *testing.T) {
 func TestStateDeltaJSON(t *testing.T) {
   partitiontest.PartitionTest(t)
   sd := StateDelta{
-    Accts: AccountDeltas{}, // TODO
+    Accts: AccountDeltas{
+      Accts: []BalanceRecord{},
+      AppResources: []AppResourceRecord{},
+      AssetResources: []AssetResourceRecord{},
+    },
     KvMods: map[string]KvValueDelta{
-      "123": KvValueDelta{}, // TODO
+      "123": KvValueDelta{
+        Data: []byte("abc"),
+        OldData: []byte("xyz"),
+      },
     },
     Txids: map[transactions.Txid]IncludedTransactions{},
     Txleases: map[Txlease]basics.Round{
-      Txlease{}: basics.Round(123), // TODO
+      Txlease{
+        Sender: basics.Address{},
+        Lease: [32]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31},
+      }: basics.Round(123), // TODO
     },
     Creatables: map[basics.CreatableIndex]ModifiedCreatable{
       basics.CreatableIndex(123): ModifiedCreatable{}, // TODO

--- a/ledger/ledgercore/statedelta_test.go
+++ b/ledger/ledgercore/statedelta_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+  "fmt"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -554,26 +555,28 @@ func TestStateDeltaJSON(t *testing.T) {
 				OldData: []byte("xyz"),
 			},
 		},
-		Txids: map[transactions.Txid]IncludedTransactions{},
+		Txids: map[transactions.Txid]IncludedTransactions{
+      transactions.Txid{}: IncludedTransactions {
+      },
+    },
 		Txleases: map[Txlease]basics.Round{
 			Txlease{
 				Sender: basics.Address{},
 				Lease:  [32]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31},
-			}: basics.Round(123), // TODO
+			}: basics.Round(123),
 		},
-		Creatables: map[basics.CreatableIndex]ModifiedCreatable{
-			basics.CreatableIndex(123): ModifiedCreatable{}, // TODO
-		},
-		Hdr:            &bookkeeping.BlockHeader{}, // TODO
-		StateProofNext: basics.Round(123),          // TODO
+		Creatables: map[basics.CreatableIndex]ModifiedCreatable{},
+		Hdr:            &bookkeeping.BlockHeader{},
+		StateProofNext: basics.Round(123),
 		PrevTimestamp:  123,
 		initialHint:    0,               // Ignore initialHint as it's not exported
-		Totals:         AccountTotals{}, // TODO
+		Totals:         AccountTotals{},
 	}
 	encoded, err := json.Marshal(sd)
 	if err != nil {
 		panic(err)
 	}
+  fmt.Println(string(encoded))
 	var decoded StateDelta
 	err = json.Unmarshal(encoded, &decoded)
 	if err != nil {

--- a/ledger/ledgercore/statedelta_test.go
+++ b/ledger/ledgercore/statedelta_test.go
@@ -19,6 +19,7 @@ package ledgercore
 import (
 	"reflect"
 	"testing"
+  "encoding/json"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -537,6 +538,38 @@ func TestStateDeltaReflect(t *testing.T) {
 		reflectedStateDeltaName := st.Field(i).Name
 		assert.Containsf(t, stateDeltaFieldNames, reflectedStateDeltaName, "new field:\"%v\" added to StateDelta, please update StateDelta.Reset() to handle it before fixing the test", reflectedStateDeltaName)
 	}
+}
+
+func TestStateDeltaJSON(t *testing.T) {
+  partitiontest.PartitionTest(t)
+  sd := StateDelta{
+    Accts: AccountDeltas{}, // TODO
+    KvMods: map[string]KvValueDelta{
+      "123": KvValueDelta{}, // TODO
+    },
+    Txids: map[transactions.Txid]IncludedTransactions{},
+    Txleases: map[Txlease]basics.Round{
+      Txlease{}: basics.Round(123), // TODO
+    },
+    Creatables: map[basics.CreatableIndex]ModifiedCreatable{
+      basics.CreatableIndex(123): ModifiedCreatable{}, // TODO
+    },
+    Hdr: &bookkeeping.BlockHeader{}, // TODO
+    StateProofNext: basics.Round(123), // TODO
+    PrevTimestamp: 123,
+    initialHint: 0, // Ignore initialHint as it's not exported
+    Totals: AccountTotals{}, // TODO
+  }
+  encoded, err := json.Marshal(sd)
+  if err != nil {
+    panic(err)
+  }
+  var decoded StateDelta
+  err = json.Unmarshal(encoded, &decoded)
+  if err != nil {
+    panic(err)
+  }
+  assert.Equal(t, sd, decoded)
 }
 
 func TestAccountDeltaReflect(t *testing.T) {

--- a/ledger/ledgercore/statedelta_test.go
+++ b/ledger/ledgercore/statedelta_test.go
@@ -17,9 +17,9 @@
 package ledgercore
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
-  "encoding/json"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -541,45 +541,45 @@ func TestStateDeltaReflect(t *testing.T) {
 }
 
 func TestStateDeltaJSON(t *testing.T) {
-  partitiontest.PartitionTest(t)
-  sd := StateDelta{
-    Accts: AccountDeltas{
-      Accts: []BalanceRecord{},
-      AppResources: []AppResourceRecord{},
-      AssetResources: []AssetResourceRecord{},
-    },
-    KvMods: map[string]KvValueDelta{
-      "123": KvValueDelta{
-        Data: []byte("abc"),
-        OldData: []byte("xyz"),
-      },
-    },
-    Txids: map[transactions.Txid]IncludedTransactions{},
-    Txleases: map[Txlease]basics.Round{
-      Txlease{
-        Sender: basics.Address{},
-        Lease: [32]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31},
-      }: basics.Round(123), // TODO
-    },
-    Creatables: map[basics.CreatableIndex]ModifiedCreatable{
-      basics.CreatableIndex(123): ModifiedCreatable{}, // TODO
-    },
-    Hdr: &bookkeeping.BlockHeader{}, // TODO
-    StateProofNext: basics.Round(123), // TODO
-    PrevTimestamp: 123,
-    initialHint: 0, // Ignore initialHint as it's not exported
-    Totals: AccountTotals{}, // TODO
-  }
-  encoded, err := json.Marshal(sd)
-  if err != nil {
-    panic(err)
-  }
-  var decoded StateDelta
-  err = json.Unmarshal(encoded, &decoded)
-  if err != nil {
-    panic(err)
-  }
-  assert.Equal(t, sd, decoded)
+	partitiontest.PartitionTest(t)
+	sd := StateDelta{
+		Accts: AccountDeltas{
+			Accts:          []BalanceRecord{},
+			AppResources:   []AppResourceRecord{},
+			AssetResources: []AssetResourceRecord{},
+		},
+		KvMods: map[string]KvValueDelta{
+			"123": KvValueDelta{
+				Data:    []byte("abc"),
+				OldData: []byte("xyz"),
+			},
+		},
+		Txids: map[transactions.Txid]IncludedTransactions{},
+		Txleases: map[Txlease]basics.Round{
+			Txlease{
+				Sender: basics.Address{},
+				Lease:  [32]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31},
+			}: basics.Round(123), // TODO
+		},
+		Creatables: map[basics.CreatableIndex]ModifiedCreatable{
+			basics.CreatableIndex(123): ModifiedCreatable{}, // TODO
+		},
+		Hdr:            &bookkeeping.BlockHeader{}, // TODO
+		StateProofNext: basics.Round(123),          // TODO
+		PrevTimestamp:  123,
+		initialHint:    0,               // Ignore initialHint as it's not exported
+		Totals:         AccountTotals{}, // TODO
+	}
+	encoded, err := json.Marshal(sd)
+	if err != nil {
+		panic(err)
+	}
+	var decoded StateDelta
+	err = json.Unmarshal(encoded, &decoded)
+	if err != nil {
+		panic(err)
+	}
+	assert.Equal(t, sd, decoded)
 }
 
 func TestAccountDeltaReflect(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Implements `MarshalJSON()` and `UnmarshalJSON()` methods on the `ledgercore.StateDelta` struct that can properly encode maps with objects as keys.

## Test Plan

To test JSON encoding/decoding on `ledgercore.StateDelta`, I've added a unit test that uses the `json.Marshal()` to encode the `StateDelta`, then `json.Unmarshal()` to decode it. If the initial `StateDelta` value matches the decoded value, the test passes. Otherwise, it fails. All tests are in `ledger/ledgercore/statedelta_test.go`.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
