### PR TITLE
p2p: get rid of interface{} from PeerStore methods

### DIFF
--- a/network/p2p/capabilities_test.go
+++ b/network/p2p/capabilities_test.go
@@ -83,7 +83,7 @@ func setupDHTHosts(t *testing.T, numHosts int) []*dht.IpfsDHT {
 		tmpdir := t.TempDir()
 		pk, err := GetPrivKey(cfg, tmpdir)
 		require.NoError(t, err)
-		ps, err := peerstore.NewPeerStore([]*peer.AddrInfo{}, "")
+		ps, err := peerstore.NewPeerStore(nil, "")
 		require.NoError(t, err)
 		h, err := libp2p.New(
 			libp2p.ListenAddrStrings("/dns4/localhost/tcp/0"),
@@ -134,7 +134,7 @@ func setupCapDiscovery(t *testing.T, numHosts int, numBootstrapPeers int) []*Cap
 		tmpdir := t.TempDir()
 		pk, err := GetPrivKey(cfg, tmpdir)
 		require.NoError(t, err)
-		ps, err := peerstore.NewPeerStore([]*peer.AddrInfo{}, "")
+		ps, err := peerstore.NewPeerStore(nil, "")
 		require.NoError(t, err)
 		h, err := libp2p.New(
 			libp2p.ListenAddrStrings("/dns4/localhost/tcp/0"),

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -177,7 +177,7 @@ func configureResourceManager(cfg config.Local) (network.ResourceManager, error)
 }
 
 // MakeService creates a P2P service instance
-func MakeService(ctx context.Context, log logging.Logger, cfg config.Local, h host.Host, listenAddr string, wsStreamHandler StreamHandler, bootstrapPeers []*peer.AddrInfo) (*serviceImpl, error) {
+func MakeService(ctx context.Context, log logging.Logger, cfg config.Local, h host.Host, listenAddr string, wsStreamHandler StreamHandler) (*serviceImpl, error) {
 
 	sm := makeStreamManager(ctx, log, h, wsStreamHandler, cfg.EnableGossipService)
 	h.Network().Notify(sm)
@@ -239,7 +239,7 @@ func (s *serviceImpl) IDSigner() *PeerIDChallengeSigner {
 // DialPeersUntilTargetCount attempts to establish connections to the provided phonebook addresses
 func (s *serviceImpl) DialPeersUntilTargetCount(targetConnCount int) {
 	ps := s.host.Peerstore().(*pstore.PeerStore)
-	peerIDs := ps.GetAddresses(targetConnCount, phonebook.PhoneBookEntryRelayRole)
+	addrInfos := ps.GetAddresses(targetConnCount, phonebook.PhoneBookEntryRelayRole)
 	conns := s.host.Network().Conns()
 	var numOutgoingConns int
 	for _, conn := range conns {
@@ -247,8 +247,7 @@ func (s *serviceImpl) DialPeersUntilTargetCount(targetConnCount int) {
 			numOutgoingConns++
 		}
 	}
-	for _, peerInfo := range peerIDs {
-		peerInfo := peerInfo.(*peer.AddrInfo)
+	for _, peerInfo := range addrInfos {
 		// if we are at our target count stop trying to connect
 		if numOutgoingConns >= targetConnCount {
 			return

--- a/network/p2p/peerstore/peerstore_test.go
+++ b/network/p2p/peerstore/peerstore_test.go
@@ -91,8 +91,7 @@ func TestPeerstore(t *testing.T) {
 
 func testPhonebookAll(t *testing.T, set []*peer.AddrInfo, ph *PeerStore) {
 	actual := ph.GetAddresses(len(set), PhoneBookEntryRelayRole)
-	for _, got := range actual {
-		info := got.(*peer.AddrInfo)
+	for _, info := range actual {
 		ok := false
 		for _, known := range set {
 			if info.ID == known.ID {
@@ -101,13 +100,12 @@ func testPhonebookAll(t *testing.T, set []*peer.AddrInfo, ph *PeerStore) {
 			}
 		}
 		if !ok {
-			t.Errorf("get returned junk %#v", got)
+			t.Errorf("get returned junk %#v", info)
 		}
 	}
 	for _, known := range set {
 		ok := false
-		for _, got := range actual {
-			info := got.(*peer.AddrInfo)
+		for _, info := range actual {
 			if info.ID == known.ID {
 				ok = true
 				break
@@ -128,8 +126,7 @@ func testPhonebookUniform(t *testing.T, set []*peer.AddrInfo, ph *PeerStore, get
 	}
 	for i := 0; i < uniformityTestLength; i++ {
 		actual := ph.GetAddresses(getsize, PhoneBookEntryRelayRole)
-		for _, xa := range actual {
-			info := xa.(*peer.AddrInfo)
+		for _, info := range actual {
 			if _, ok := counts[info.ID.String()]; ok {
 				counts[info.ID.String()]++
 			}
@@ -226,11 +223,11 @@ func TestMultiPhonebook(t *testing.T) {
 		require.NoError(t, err)
 		infoSet = append(infoSet, info)
 	}
-	pha := make([]interface{}, 0)
+	pha := make([]*peer.AddrInfo, 0)
 	for _, e := range infoSet[:5] {
 		pha = append(pha, e)
 	}
-	phb := make([]interface{}, 0)
+	phb := make([]*peer.AddrInfo, 0)
 	for _, e := range infoSet[5:] {
 		phb = append(phb, e)
 	}
@@ -252,7 +249,7 @@ func TestMultiPhonebookPersistentPeers(t *testing.T) {
 
 	info, err := peerInfoFromDomainPort("a:4041")
 	require.NoError(t, err)
-	persistentPeers := []interface{}{info}
+	persistentPeers := []*peer.AddrInfo{info}
 	set := []string{"b:4042", "c:4043", "d:4044", "e:4045", "f:4046", "g:4047", "h:4048", "i:4049", "j:4010"}
 	infoSet := make([]*peer.AddrInfo, 0)
 	for _, addr := range set {
@@ -261,11 +258,11 @@ func TestMultiPhonebookPersistentPeers(t *testing.T) {
 		infoSet = append(infoSet, info)
 	}
 
-	pha := make([]interface{}, 0)
+	pha := make([]*peer.AddrInfo, 0)
 	for _, e := range infoSet[:5] {
 		pha = append(pha, e)
 	}
-	phb := make([]interface{}, 0)
+	phb := make([]*peer.AddrInfo, 0)
 	for _, e := range infoSet[5:] {
 		phb = append(phb, e)
 	}
@@ -279,10 +276,8 @@ func TestMultiPhonebookPersistentPeers(t *testing.T) {
 	testPhonebookAll(t, append(infoSet, info), ph)
 	allAddresses := ph.GetAddresses(len(set)+len(persistentPeers), PhoneBookEntryRelayRole)
 	for _, pp := range persistentPeers {
-		pp := pp.(*peer.AddrInfo)
 		found := false
 		for _, addr := range allAddresses {
-			addr := addr.(*peer.AddrInfo)
 			if addr.ID == pp.ID {
 				found = true
 				break
@@ -303,11 +298,11 @@ func TestMultiPhonebookDuplicateFiltering(t *testing.T) {
 		infoSet = append(infoSet, info)
 	}
 
-	pha := make([]interface{}, 0)
+	pha := make([]*peer.AddrInfo, 0)
 	for _, e := range infoSet[:7] {
 		pha = append(pha, e)
 	}
-	phb := make([]interface{}, 0)
+	phb := make([]*peer.AddrInfo, 0)
 	for _, e := range infoSet[3:] {
 		phb = append(phb, e)
 	}
@@ -343,7 +338,7 @@ func TestWaitAndAddConnectionTimeLongtWindow(t *testing.T) {
 
 	// Test the addresses are populated in the phonebook and a
 	// time can be added to one of them
-	entries.ReplacePeerList([]interface{}{info1, info2}, "default", PhoneBookEntryRelayRole)
+	entries.ReplacePeerList([]*peer.AddrInfo{info1, info2}, "default", PhoneBookEntryRelayRole)
 	addrInPhonebook, waitTime, provisionalTime := entries.GetConnectionWaitTime(string(info1.ID))
 	require.Equal(t, true, addrInPhonebook)
 	require.Equal(t, time.Duration(0), waitTime)
@@ -458,14 +453,14 @@ func TestPhonebookRoles(t *testing.T) {
 	relaysSet := []string{"relay1:4040", "relay2:4041", "relay3:4042"}
 	archiverSet := []string{"archiver1:1111", "archiver2:1112", "archiver3:1113"}
 
-	infoRelaySet := make([]interface{}, 0)
+	infoRelaySet := make([]*peer.AddrInfo, 0)
 	for _, addr := range relaysSet {
 		info, err := peerInfoFromDomainPort(addr)
 		require.NoError(t, err)
 		infoRelaySet = append(infoRelaySet, info)
 	}
 
-	infoArchiverSet := make([]interface{}, 0)
+	infoArchiverSet := make([]*peer.AddrInfo, 0)
 	for _, addr := range archiverSet {
 		info, err := peerInfoFromDomainPort(addr)
 		require.NoError(t, err)
@@ -485,12 +480,10 @@ func TestPhonebookRoles(t *testing.T) {
 				entries := ph.GetAddresses(l, role)
 				if role == PhoneBookEntryRelayRole {
 					for _, entry := range entries {
-						entry := entry.(*peer.AddrInfo)
 						require.Contains(t, string(entry.ID), "relay")
 					}
 				} else if role == PhoneBookEntryArchiverRole {
 					for _, entry := range entries {
-						entry := entry.(*peer.AddrInfo)
 						require.Contains(t, string(entry.ID), "archiver")
 					}
 				}

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -261,15 +261,21 @@ func NewP2PNetwork(log logging.Logger, cfg config.Local, datadir string, phonebo
 	}
 	log.Infof("P2P host created: peer ID %s addrs %s", h.ID(), h.Addrs())
 
-	net.service, err = p2p.MakeService(net.ctx, log, cfg, h, la, net.wsStreamHandler, addrInfo)
+	net.service, err = p2p.MakeService(net.ctx, log, cfg, h, la, net.wsStreamHandler)
 	if err != nil {
 		return nil, err
 	}
 
+	peerIDs := pstore.Peers()
+	addrInfos := make([]*peer.AddrInfo, 0, len(peerIDs))
+	for _, peerID := range peerIDs {
+		addrInfo := pstore.PeerInfo(peerID)
+		addrInfos = append(addrInfos, &addrInfo)
+	}
 	bootstrapper := &bootstrapper{
 		cfg:               cfg,
 		networkID:         networkID,
-		phonebookPeers:    addrInfo,
+		phonebookPeers:    addrInfos,
 		resolveController: dnsaddr.NewMultiaddrDNSResolveController(cfg.DNSSecurityTXTEnforced(), ""),
 		log:               net.log,
 	}
@@ -426,7 +432,7 @@ func (n *P2PNetwork) meshThreadInner() int {
 	}
 
 	peers := mergeP2PAddrInfoResolvedAddresses(dnsPeers, dhtPeers)
-	replace := make([]interface{}, 0, len(peers))
+	replace := make([]*peer.AddrInfo, 0, len(peers))
 	for i := range peers {
 		replace = append(replace, &peers[i])
 	}
@@ -631,9 +637,8 @@ func (n *P2PNetwork) GetPeers(options ...PeerOption) []Peer {
 			n.wsPeersLock.RUnlock()
 		case PeersPhonebookRelays:
 			const maxNodes = 100
-			peerIDs := n.pstore.GetAddresses(maxNodes, phonebook.PhoneBookEntryRelayRole)
-			for _, peerInfo := range peerIDs {
-				peerInfo := peerInfo.(*peer.AddrInfo)
+			addrInfos := n.pstore.GetAddresses(maxNodes, phonebook.PhoneBookEntryRelayRole)
+			for _, peerInfo := range addrInfos {
 				if peerCore, ok := addrInfoToWsPeerCore(n, peerInfo); ok {
 					peers = append(peers, &peerCore)
 				}

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -787,7 +787,7 @@ func TestP2PHTTPHandler(t *testing.T) {
 	// zero clients allowed, rate limiting window (10s) is greater than queue deadline (1s)
 	pstore, err := peerstore.MakePhonebook(0, 10*time.Second)
 	require.NoError(t, err)
-	pstore.AddPersistentPeers([]interface{}{&peerInfoA}, "net", phonebook.PhoneBookEntryRelayRole)
+	pstore.AddPersistentPeers([]*peer.AddrInfo{&peerInfoA}, "net", phonebook.PhoneBookEntryRelayRole)
 	httpClient, err = p2p.MakeHTTPClientWithRateLimit(&peerInfoA, pstore, 1*time.Second, 1)
 	require.NoError(t, err)
 	_, err = httpClient.Get("/test")

--- a/network/phonebook/phonebook.go
+++ b/network/phonebook/phonebook.go
@@ -204,7 +204,7 @@ func (e *phonebookImpl) AddPersistentPeers(dnsAddresses []string, networkName st
 			// we already have this.
 			// Make sure the persistence field is set to true
 			pbData.persistent = true
-
+			e.data[addr] = pbData
 		} else {
 			// we don't have this item. add it.
 			e.data[addr] = makePhonebookEntryData(networkName, role, true)


### PR DESCRIPTION
## Summary

At some point `PeerStore` was though to implement `Phonebook` interface, and as part of this some methods had `interface{}` in signature to accommodate both `string` and `peer.AddrInfo`. It ended up exact interface match not needed so I'm reverting this `interface{}` workaround.

Actually it is possible to keep `addr []string` in `AddPersistentPeers` and `ReplacePeerList` since they operate on single-address `AddrInfo` so string to `AddrInfo` conversion is possible.
In the same time `GetAddresses` returns slice of either strings (`Phonebook`) or generic learned `peer.AddrInfo` from the underlying peerstore, and no multiple addr to string conversion possible.

## Test Plan

Existing tests to pass