### PR TITLE
Installer: add support for algoh to systemd installs

### DIFF
--- a/cmd/updater/systemd-setup-user.sh
+++ b/cmd/updater/systemd-setup-user.sh
@@ -21,9 +21,27 @@ setup_user() {
     sed -e s,@@BINDIR@@,"$bindir", "${SCRIPTPATH}/algorand@.service.template-user" \
         > "$homedir/.config/systemd/user/algorand@.service"
 
+    if [[ ${HOSTMODE} == true ]]; then
+	    echo "[INFO] Hosted mode - replacing algod with algoh"
+	    sed -i 's/algod/algoh/g' "$homedir/.config/systemd/user/algorand@.service"
+    fi
+
     systemctl --user daemon-reload
 }
 
+HOSTMODE=false
+while getopts H opt; do
+    case $opt in
+	H)
+	    HOSTMODE=true
+	    ;;
+	?)
+	    echo "Invalid option: -${OPTARG}"
+	    exit 1
+	    ;;
+    esac
+done
+shift $((OPTIND-1))
 
 if [ "$#" != 1 ]; then
     echo "Usage: $0 username"

--- a/cmd/updater/systemd-setup.sh
+++ b/cmd/updater/systemd-setup.sh
@@ -14,8 +14,27 @@ setup_root() {
     sed ${sedargs} "${SCRIPTPATH}/algorand@.service.template" \
         > /lib/systemd/system/algorand@.service
 
+    if [[ ${HOSTMODE} == true ]]; then
+	echo "[INFO] Hosted mode - replacing algod with algoh"
+	sed -i 's/algod/algoh/g' /lib/systemd/system/algorand@.service
+    fi
+
     systemctl daemon-reload
 }
+
+HOSTMODE=false
+while getopts H opt; do
+    case $opt in
+	H)
+	    HOSTMODE=true
+	    ;;
+	?)
+	    echo "Invalid option: -${OPTARG}"
+	    exit 1
+	    ;;
+    esac
+done
+shift $((OPTIND-1))
 
 if [ "$#" != 2 ] && [ "$#" != 3 ]; then
     echo "Usage: $0 username group [bindir]"


### PR DESCRIPTION
## Summary

The systemd setup right now does not support `algoh` installs, which can be useful for additional diagnostic information. This PR will replace launching algod with algoh.

Usage (e.g.):


```
./systemd-setup.sh -H ubuntu ubuntu
```

The `-H` option has to come first. This will replace occurences of algod with algoh in the systemd file.

Note that because of this, output from algod would no longer be recorded to syslog. This should be fine, because `algoh` usage is typically for servers that have enabled telemetry, and `node.log` remains in use.

## Test Plan

Verified installation works both with and without `-H`. Verified killing `algoh` or `algod` restores service.
