### PR TITLE
p2p: Telemetry and metrics improvements

### DIFF
--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -445,6 +445,8 @@ var startupConfigCheckFields = []string{
 	"TxPoolExponentialIncreaseFactor",
 	"TxPoolSize",
 	"VerifiedTranscationsCacheSize",
+	"EnableP2P",
+	"EnableP2PHybridMode",
 }
 
 func resolveDataDir() string {

--- a/network/p2p/pubsubTracer.go
+++ b/network/p2p/pubsubTracer.go
@@ -93,7 +93,7 @@ func (t pubsubTracer) SendRPC(rpc *pubsub.RPC, p peer.ID) {
 		for i := range rpc.Publish {
 			if rpc.Publish[i] != nil && rpc.Publish[i].Topic != nil && *rpc.Publish[i].Topic == TXTopicName {
 				transactionMessagesP2PSentMessages.Inc(nil)
-				transactionMessagesP2PSentBytes.AddUint64(uint64(len(rpc.Publish[0].Data)), nil)
+				transactionMessagesP2PSentBytes.AddUint64(uint64(len(rpc.Publish[i].Data)), nil)
 			}
 		}
 	}

--- a/test/heapwatch/requirements.txt
+++ b/test/heapwatch/requirements.txt
@@ -6,5 +6,5 @@ plotly==5.16.0
 py-algorand-sdk==2.3.0
 kaleido==0.2.1
 networkx==3.3
-gravis=0.1.0
-termcolor=2.4.0
+gravis==0.1.0
+termcolor==2.4.0

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -139,6 +139,11 @@ var (
 	// TransactionMessagesP2PValidateMessage "Number of p2p pubsub transaction messages received for validation"
 	TransactionMessagesP2PValidateMessage = MetricName{Name: "algod_transaction_messages_p2p_validate", Description: "Number of p2p pubsub transaction messages received for validation"}
 
+	// TransactionMessagesP2PSentMessage "Number of p2p pubsub transaction messages received for validation"
+	TransactionMessagesP2PSentMessage = MetricName{Name: "algod_transaction_messages_p2p_sent", Description: "Number of p2p pubsub transaction messages sent"}
+	// TransactionMessagesP2PSentBytes "Number p2p pubsub transaction bytes sent"
+	TransactionMessagesP2PSentBytes = MetricName{Name: "algod_transaction_messages_p2p_bytes", Description: "Number p2p pubsub transaction bytes sent"}
+
 	// TransactionGroupTxSyncHandled "Number of transaction groups handled via txsync"
 	TransactionGroupTxSyncHandled = MetricName{Name: "algod_transaction_group_txsync_handled", Description: "Number of transaction groups handled via txsync"}
 	// TransactionGroupTxSyncRemember "Number of transaction groups remembered via txsync"


### PR DESCRIPTION
## Summary

1. Added `EnableP2P` and `EnableP2PHybridMode` to the telemetry `Startup` event. This will allow to see fractions of WS, P2P and Hybrid nodes.
2. Added `pubsubTracer.SendRPC` implementation to track TX messages being broadcasted over the network. These will be the same as `algod_network_sent_bytes_TX` and `algod_network_message_sent_TX`.

This is part 1 of a bigger change to separate metrics like `algod_network_sent_bytes_{TAG}` for ws and p2p networks. The newly added `algod_transaction_messages_p2p_sent` will be replaced by `algod_network_message_sent_TX` but this requires moving all of these into the `util/metrics` to be used in both `network` package and `network/p2p` sub-packages. This would also allow to write a simple unit test for gossipsub metric (having the counter available in the node or network package).

## Test Plan

Tested locally with `goal network` + `pingpong` + `test/heapwatch/heapWatch.py --period 10 --metrics`