### PR TITLE
tests: use temp file for capturing e2e goal-partkey-commands output

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -102,3 +102,15 @@ jobs:
         run: |
           curl -X POST --data-urlencode "payload={\"text\": \"Reviewdog failed. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \"}" $SLACK_WEBHOOK
         if: ${{ failure() && (contains(github.ref_name, 'rel/nightly') || contains(github.ref_name, 'rel/beta') || contains(github.ref_name, 'rel/stable') || contains(github.ref_name, 'master')) }}
+  reviewdog-shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: "github-pr-check"
+          shellcheck_flags: "-e SC2154,SC2034,SC2046,SC2053,SC2207,SC2145 -S warning"
+          path: |
+            test/scripts/e2e_subs

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -111,6 +111,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: "github-pr-check"
-          shellcheck_flags: "-e SC2154,SC2034,SC2046,SC2053,SC2207,SC2145 -S warning"
+          shellcheck_flags: "-e SC2034,SC2046,SC2053,SC2207,SC2145 -S warning"
           path: |
             test/scripts/e2e_subs

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -112,5 +112,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: "github-pr-check"
           shellcheck_flags: "-e SC2034,SC2046,SC2053,SC2207,SC2145 -S warning"
+          fail_on_error: true
           path: |
             test/scripts/e2e_subs

--- a/scripts/travis/codegen_verification.sh
+++ b/scripts/travis/codegen_verification.sh
@@ -74,7 +74,7 @@ fi
 
 echo "Run shellcheck in e2e_subs"
 pushd test/scripts/e2e_subs
-shellcheck -e SC2154,SC2034,SC2046,SC2053,SC2207,SC2145 -S warning *.sh
+shellcheck -e SC2154,SC2034,SC2046,SC2053,SC2207,SC2145 -P . -S warning *.sh
 popd
 
 # test binary compatibility

--- a/scripts/travis/codegen_verification.sh
+++ b/scripts/travis/codegen_verification.sh
@@ -72,5 +72,10 @@ else
    echo All tidy
 fi
 
+echo "Run shellcheck in e2e_subs"
+pushd test/scripts/e2e_subs
+shellcheck -e SC2154,SC2034,SC2046,SC2053,SC2207,SC2145 -S warning *.sh
+popd
+
 # test binary compatibility
 "${SCRIPTPATH}/../../test/platform/test_linux_amd64_compatibility.sh"

--- a/scripts/travis/codegen_verification.sh
+++ b/scripts/travis/codegen_verification.sh
@@ -72,10 +72,5 @@ else
    echo All tidy
 fi
 
-echo "Run shellcheck in e2e_subs"
-pushd test/scripts/e2e_subs
-shellcheck -e SC2154,SC2034,SC2046,SC2053,SC2207,SC2145 -P . -S warning *.sh
-popd
-
 # test binary compatibility
 "${SCRIPTPATH}/../../test/platform/test_linux_amd64_compatibility.sh"

--- a/test/scripts/e2e_subs/goal-partkey-commands.sh
+++ b/test/scripts/e2e_subs/goal-partkey-commands.sh
@@ -83,16 +83,22 @@ verify_registered_state () {
   SEARCH_INVOKE_CONTEXT=$(echo "$3" | xargs)
 
   # look for participation ID anywhere in the partkeyinfo output
-  PARTKEY_OUTPUT=$(${gcmd} account partkeyinfo)
-  if ! echo "$PARTKEY_OUTPUT" | grep -q -F "$SEARCH_KEY"; then
-    fail_test "Key $SEARCH_KEY was not installed properly for cmd '$SEARCH_INVOKE_CONTEXT':\n$PARTKEY_OUTPUT"
+  info_temp_file=$(mktemp)
+  ${gcmd} account partkeyinfo > "${info_temp_file}"
+  if ! grep -q -F "$SEARCH_KEY" "${info_temp_file}"; then
+      echo "info_temp_file contents:"
+      cat "${info_temp_file}"
+      fail_test "Key $SEARCH_KEY was not installed properly for cmd '$SEARCH_INVOKE_CONTEXT'"
   fi
 
   # looking for yes/no, and the 8 character head of participation id in this line:
   # yes         LFMT...RHJQ  4UPT6AQC...               4            0     3000
-  LISTKEY_OUTPUT=$(${gcmd} account listpartkeys)
-  if ! echo "$LISTKEY_OUTPUT" | grep -q "$SEARCH_STATE.*$(echo "$SEARCH_KEY" | cut -c1-8)"; then
-    fail_test "Unexpected key $SEARCH_KEY state (looked for $SEARCH_STATE ) for cmd '$SEARCH_INVOKE_CONTEXT':\n$LISTKEY_OUTPUT"
+  list_temp_file=$(mktemp)
+  ${gcmd} account listpartkeys > "${list_temp_file}"
+  if ! grep -q "$SEARCH_STATE.*$(echo "$SEARCH_KEY" | cut -c1-8)" "${list_temp_file}"; then
+      echo "list_temp_file contents:"
+      cat "${list_temp_file}"
+      fail_test "Unexpected key $SEARCH_KEY state (looked for $SEARCH_STATE ) for cmd '$SEARCH_INVOKE_CONTEXT'"
   fi
 }
 

--- a/test/scripts/e2e_subs/goal-partkey-commands.sh
+++ b/test/scripts/e2e_subs/goal-partkey-commands.sh
@@ -8,6 +8,7 @@ date "+$0 start %Y%m%d_%H%M%S"
 
 WALLET=$1
 
+gcmd="goal -w ${WALLET}"
 INITIAL_ACCOUNT=$(${gcmd} account list|awk '{ print $3 }')
 
 # Registered  Account      ParticipationID   Last Used  First round  Last round

--- a/test/scripts/e2e_subs/goal-partkey-commands.sh
+++ b/test/scripts/e2e_subs/goal-partkey-commands.sh
@@ -8,7 +8,6 @@ date "+$0 start %Y%m%d_%H%M%S"
 
 WALLET=$1
 
-gcmd="goal -w ${WALLET}"
 INITIAL_ACCOUNT=$(${gcmd} account list|awk '{ print $3 }')
 
 # Registered  Account      ParticipationID   Last Used  First round  Last round


### PR DESCRIPTION
## Summary

Since #6095 fixed issues with this test, it seems to fail occasionally with long goal outputs. This attempts to fix the issue like seen in https://app.circleci.com/pipelines/github/algorand/go-algorand/18982/workflows/7b9dc41e-1521-436c-afe2-6d365c07fb57/jobs/277753

## Test Plan

Hopes to reduce occasional E2E test failures.

Adds a shellcheck in e2e_subs to CI that would have caught the bug found in #6095 where `${gcmd}` was being called without being defined.