### PR TITLE
tests: fix a race in TestP2PwsStreamHandlerDedup

### DIFF
--- a/network/p2p/capabilities_test.go
+++ b/network/p2p/capabilities_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	golog "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/core/discovery"
@@ -37,42 +36,6 @@ import (
 	"github.com/algorand/go-algorand/network/p2p/peerstore"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
-
-func TestCapabilities_Discovery(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	golog.SetDebugLogging()
-	var caps []*CapabilitiesDiscovery
-	var addrs []peer.AddrInfo
-	testSize := 3
-	for i := 0; i < testSize; i++ {
-		tempdir := t.TempDir()
-		ps, err := peerstore.NewPeerStore(nil, "")
-		require.NoError(t, err)
-		h, _, err := MakeHost(config.GetDefaultLocal(), tempdir, ps)
-		require.NoError(t, err)
-		capD, err := MakeCapabilitiesDiscovery(context.Background(), config.GetDefaultLocal(), h, "devtestnet", logging.Base(), func() []peer.AddrInfo { return nil })
-		require.NoError(t, err)
-		caps = append(caps, capD)
-		addrs = append(addrs, peer.AddrInfo{
-			ID:    capD.Host().ID(),
-			Addrs: capD.Host().Addrs(),
-		})
-	}
-	for _, capD := range caps {
-		peersAdded := 0
-		for _, addr := range addrs {
-			added, err := capD.addPeer(addr)
-			require.NoError(t, err)
-			require.True(t, added)
-			peersAdded++
-		}
-		err := capD.dht.Bootstrap(context.Background())
-		require.NoError(t, err)
-		capD.dht.ForceRefresh()
-		require.Equal(t, peersAdded, capD.dht.RoutingTable().Size())
-	}
-}
 
 func setupDHTHosts(t *testing.T, numHosts int) []*dht.IpfsDHT {
 	var hosts []host.Host

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -1187,8 +1187,10 @@ func TestP2PwsStreamHandlerDedup(t *testing.T) {
 		return networkPeerIdentityDisconnect.GetUint64Value() == networkPeerIdentityDisconnectInitial+1
 	}, 2*time.Second, 50*time.Millisecond)
 
-	require.False(t, netA.hasPeers())
-	require.False(t, netB.hasPeers())
+	// now allow the peer made outgoing connection to handle conn closing initiated by the other side
+	require.Eventually(t, func() bool {
+		return !netA.hasPeers() && !netB.hasPeers()
+	}, 2*time.Second, 50*time.Millisecond)
 }
 
 // TestP2PEnableGossipService_NodeDisable ensures that a node with EnableGossipService=false


### PR DESCRIPTION
## Summary

There were [couple](https://app.circleci.com/pipelines/github/algorand/go-algorand/18996/workflows/11fa1b4b-d5d8-4447-b3c0-846d2e428be6/jobs/277884) [failures](https://app.circleci.com/pipelines/github/algorand/go-algorand/19002/workflows/45e8afeb-ca4a-4efd-b722-1ef8b5e5e32f/jobs/277925) in TestP2PwsStreamHandlerDedup caused by too early check on the second node - before it had a chance to handle connection closure and remove unsuccessful peer.

Additionally, there is also an attempt to fix `TestCapabilities_Discovery` that works on non-connected p2p hosts, manually adds peers to DHT routing table and then compares the table expected size.
Not sure what exactly it was testing (adding to routing table and checking its size looks unusual) but there is a race between `capD.dht.ForceRefresh()` and `capD.dht.RoutingTable().Size()` since as soon as it completes it prunes all non-reachable peers (and they all unreachable).
Having said that the test looks quite useless so I removed it.

## Test Plan

This is a test fix.