### PR TITLE
algons: expose error for dnsaddr command

### DIFF
--- a/cmd/algons/dnsaddrCmd.go
+++ b/cmd/algons/dnsaddrCmd.go
@@ -141,7 +141,7 @@ var dnsaddrTreeCreateCmd = &cobra.Command{
 		dnsaddrsFrom := []string{fmt.Sprintf("_dnsaddr.%s", dnsaddrDomain)}
 		entries, err := getEntries(dnsaddrsFrom[0], "TXT")
 		if err != nil {
-			fmt.Printf("failed fetching entries for %s\n", dnsaddrsFrom[0])
+			fmt.Printf("failed fetching entries for %s: %v\n", dnsaddrsFrom[0], err)
 			os.Exit(1)
 		}
 		if len(entries) > 0 {


### PR DESCRIPTION
## Summary

For troubleshooting it's helpful to print the error in this algons subcommand.

## Test Plan

Built and ran and found an error in invocation. :)

