### PR TITLE
tests: fix expect tests and add EOF linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,9 @@ fix: build
 lint: deps
 	$(GOPATH1)/bin/golangci-lint run -c .golangci.yml
 
+expectlint:
+	cd test/e2e-go/cli/goal/expect && python3 expect_linter.py *.exp
+
 check_go_version:
 	@if [ $(CURRENT_GO_VERSION_MAJOR) != $(GOLANG_VERSION_BUILD_MAJOR) ]; then \
 		echo "Wrong major version of Go installed ($(CURRENT_GO_VERSION_MAJOR)). Please use $(GOLANG_VERSION_BUILD_MAJOR)"; \

--- a/scripts/travis/codegen_verification.sh
+++ b/scripts/travis/codegen_verification.sh
@@ -40,6 +40,9 @@ echo "Running fixcheck"
 GOPATH=$(go env GOPATH)
 "$GOPATH"/bin/algofix -error */
 
+echo "Running expect linter"
+make expectlint
+
 echo "Updating TEAL Specs"
 touch data/transactions/logic/fields_string.go # ensure rebuild
 make -C data/transactions/logic

--- a/test/e2e-go/cli/goal/expect/basicExpectTest.exp
+++ b/test/e2e-go/cli/goal/expect/basicExpectTest.exp
@@ -16,12 +16,14 @@ if { [catch {
     spawn echo "hello"
     expect {
         timeout { abort "\n Failed to see expected input hello" }
+        eof { abort "Ended without hello" }
         "^hello*" {close}
     }
 
     spawn echo "goodbye"
     expect {
         timeout { abort "Failed to see expected input goodbye" }
+        eof { abort "Ended without goodbye" }
         "^goodbye*" {close}
     }
 

--- a/test/e2e-go/cli/goal/expect/corsTest.exp
+++ b/test/e2e-go/cli/goal/expect/corsTest.exp
@@ -32,6 +32,7 @@ if { [catch {
     ::AlgorandGoal::CheckNetworkAddressForCors $ALGOD_NET_ADDRESS
 
     # Start kmd, then do the same CORS check as algod
+    exec -- cat "$TEST_PRIMARY_NODE_DIR/kmd-v0.5/kmd_config.json.example" | jq {. |= . + {"allowed_origins": ["http://algorand.com"]}} > "$TEST_PRIMARY_NODE_DIR/kmd-v0.5/kmd_config.json"
     exec goal kmd start -t 180 -d $TEST_PRIMARY_NODE_DIR
     set KMD_NET_ADDRESS [::AlgorandGoal::GetKMDNetworkAddress $TEST_PRIMARY_NODE_DIR]
     ::AlgorandGoal::CheckNetworkAddressForCors $KMD_NET_ADDRESS

--- a/test/e2e-go/cli/goal/expect/expect_linter.py
+++ b/test/e2e-go/cli/goal/expect/expect_linter.py
@@ -2,6 +2,9 @@
 import sys
 import argparse
 
+found_issues = False
+
+
 def check_expect_blocks(filename, verbose=False):
     with open(filename, 'r') as f:
         lines = f.readlines()
@@ -39,7 +42,7 @@ def check_expect_blocks(filename, verbose=False):
                 print(f"{filename}:{block_start_line}: SKIP: 'nolint:eof' comment found, skipping")
             continue
 
-        if 'eof' not in block:
+        if 'eof ' not in block:
             # Check for only timeout condition
             actions = block.count('}')
             if block.count('timeout') == actions:
@@ -48,6 +51,8 @@ def check_expect_blocks(filename, verbose=False):
                 continue
 
             print(f"{filename}:{block_start_line}: Warning: missing 'eof' in expect block")
+            global found_issues
+            found_issues = True
         elif verbose:
             print(f"{filename}:{block_start_line}: OK: expect block contains 'eof'")
 
@@ -59,6 +64,9 @@ def main():
 
     for fname in args.files:
         check_expect_blocks(fname, args.verbose)
+
+    if found_issues:
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/test/e2e-go/cli/goal/expect/expect_linter.py
+++ b/test/e2e-go/cli/goal/expect/expect_linter.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+import sys
+import argparse
+
+def check_expect_blocks(filename, verbose=False):
+    with open(filename, 'r') as f:
+        lines = f.readlines()
+
+    in_expect_block = False
+    brace_count = 0
+    block_start_line = None
+    current_block = []
+    expect_blocks = []
+
+    # Process each line, considering possible strings or comments
+    for line_num, line in enumerate(lines, start=1):
+        stripped_line = line.strip()
+
+        if not in_expect_block:
+            if "expect " in stripped_line and '{' in stripped_line:
+                in_expect_block = True
+                block_start_line = line_num
+                brace_count = stripped_line.count('{') - stripped_line.count('}')
+                current_block = [stripped_line]
+            elif stripped_line.startswith("#") or stripped_line.startswith("//"):
+                continue  # Ignore comment lines outside of expect blocks
+        else:
+            current_block.append(stripped_line)
+            brace_count += stripped_line.count('{') - stripped_line.count('}')
+
+            if brace_count == 0:
+                in_expect_block = False
+                expect_blocks.append((block_start_line, "\n".join(current_block)))
+                current_block = []
+
+    for block_start_line, block in expect_blocks:
+        if '#nolint:eof' in block:
+            if verbose:
+                print(f"{filename}:{block_start_line}: SKIP: 'nolint:eof' comment found, skipping")
+            continue
+
+        if 'eof' not in block:
+            # Check for only timeout condition
+            actions = block.count('}')
+            if block.count('timeout') == actions:
+                if verbose:
+                    print(f"{filename}:{block_start_line}: OK: only timeout action present")
+                continue
+
+            print(f"{filename}:{block_start_line}: Warning: missing 'eof' in expect block")
+        elif verbose:
+            print(f"{filename}:{block_start_line}: OK: expect block contains 'eof'")
+
+def main():
+    parser = argparse.ArgumentParser(description="Check for 'eof' in expect blocks of scripts.")
+    parser.add_argument('files', metavar='FILE', type=str, nargs='+', help='Files to check')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose output')
+    args = parser.parse_args()
+
+    for fname in args.files:
+        check_expect_blocks(fname, args.verbose)
+
+if __name__ == "__main__":
+    main()

--- a/test/e2e-go/cli/goal/expect/goalCmdFlagsTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalCmdFlagsTest.exp
@@ -5,7 +5,8 @@ log_user 1
 proc TestGoalCommandLineFlags { CMD EXPECTED_RE } {
     set PASSED 0
     eval spawn $CMD
-    expect { #nolint:eof checking PASSED catches no match
+    expect {
+        #nolint:eof checking PASSED catches no match
         timeout { puts "goal asset create timed out"; exit 1 }
         -re $EXPECTED_RE {set PASSED 1; close }
     }

--- a/test/e2e-go/cli/goal/expect/goalCmdFlagsTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalCmdFlagsTest.exp
@@ -5,7 +5,7 @@ log_user 1
 proc TestGoalCommandLineFlags { CMD EXPECTED_RE } {
     set PASSED 0
     eval spawn $CMD
-    expect {
+    expect { #nolint:eof checking PASSED catches no match
         timeout { puts "goal asset create timed out"; exit 1 }
         -re $EXPECTED_RE {set PASSED 1; close }
     }

--- a/test/e2e-go/cli/goal/expect/goalDryrunRestTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalDryrunRestTest.exp
@@ -7,7 +7,7 @@ proc TestGoalDryrun { DRREQ_FILE TEST_PRIMARY_NODE_DIR } {
     set COST 0
     set PROGRAM_TYPE ""
     spawn goal clerk dryrun-remote -d $TEST_PRIMARY_NODE_DIR -D $DRREQ_FILE -v
-    expect {
+    expect { #nolint:eof checking PASSED catches no match
         timeout { ::AlgorandGoal::Abort "goal clerk dryrun-remote timeout" }
         "budget consumed:" {set COST 1; exp_continue}
         -re {(ApprovalProgram)} {set PROGRAM_TYPE $expect_out(1,string); exp_continue}

--- a/test/e2e-go/cli/goal/expect/goalDryrunRestTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalDryrunRestTest.exp
@@ -7,7 +7,8 @@ proc TestGoalDryrun { DRREQ_FILE TEST_PRIMARY_NODE_DIR } {
     set COST 0
     set PROGRAM_TYPE ""
     spawn goal clerk dryrun-remote -d $TEST_PRIMARY_NODE_DIR -D $DRREQ_FILE -v
-    expect { #nolint:eof checking PASSED catches no match
+    expect {
+        #nolint:eof checking PASSED catches no match
         timeout { ::AlgorandGoal::Abort "goal clerk dryrun-remote timeout" }
         "budget consumed:" {set COST 1; exp_continue}
         -re {(ApprovalProgram)} {set PROGRAM_TYPE $expect_out(1,string); exp_continue}

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -578,6 +578,7 @@ proc ::AlgorandGoal::AssetCreate { CREATOR WALLET_NAME WALLET_PASSWORD TOTAL_SUP
         expect {
             timeout { ::AlgorandGoal::Abort "Timed out create asset"  }
 	        "Please enter the password for wallet '$WALLET_NAME':" { send "$WALLET_PASSWORD\r"; exp_continue }
+            -re {Created asset with asset index (\d+)} { puts "Asset created"; close }
 	        eof { ::AlgorandGoal::Abort "EOF create asset"  }
         }
     } EXCEPTION ] } {
@@ -664,10 +665,11 @@ proc ::AlgorandGoal::AssembleGroup { INPUT_GROUP OUTPUT_GROUP } {
 proc ::AlgorandGoal::SplitGroup { INPUT_GROUP OUTPUT_GROUP } {
     if { [ catch {
         spawn goal clerk split -i $INPUT_GROUP -o $OUTPUT_GROUP
-	    expect { #nolint:eof just checking status
+	    expect {
+            #nolint:eof just checking status
             timeout { ::AlgorandGoal::Abort "Timed out splitting group transaction"  }
 	        eof
-            }
+        }
         set status [wait]
         if {$status != 0} { ::AlgorandGoal::Abort "Split group failed with exit code $status" }
     } EXCEPTION ] } {
@@ -740,9 +742,9 @@ proc ::AlgorandGoal::SignTransaction { WALLET_NAME WALLET_PASSWORD INPUT_TXN OUT
     if { [ catch {
         spawn goal clerk sign -d $TEST_PRIMARY_NODE_DIR -w $WALLET_NAME -i $INPUT_TXN -o $OUTPUT_TXN
         expect {
+            #nolint:eof just signing with outputting to file
             timeout { ::AlgorandGoal::Abort "Timed out signing transaction"  }
-	        "Please enter the password for wallet '$WALLET_NAME':" { send "$WALLET_PASSWORD\r" ; exp_continue}
-	        eof { ::AlgorandGoal::Abort "EOF signing transaction"  }
+	        "Please enter the password for wallet '$WALLET_NAME':" { send "$WALLET_PASSWORD\r" ;}
         }
     } EXCEPTION ] } {
        ::AlgorandGoal::Abort "ERROR in SignTransaction: $EXCEPTION"

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -234,12 +234,14 @@ proc ::AlgorandGoal::RestartNode { TEST_ALGO_DIR {SYSTEMD_MANAGED ""} } {
             expect {
                 timeout { close; ::AlgorandGoal::Abort "Did not receive appropriate message during node restart" }
                 "^The node was successfully stopped.*Algorand node successfully started!*" {puts "Node restarted successfully"; close}
+                eof { close; ::AlgorandGoal::Abort "Did not receive appropriate message before node restart eof" }
             }
         } else {
             spawn goal node restart -d $TEST_ALGO_DIR
             expect {
                 timeout { close; ::AlgorandGoal::Abort "Did not receive appropriate message during node restart" }
                 "^This node is using systemd and should be managed with systemctl*" { puts "Goal showed correct error message for systemd" ; close}
+                eof { close; ::AlgorandGoal::Abort "Did not receive appropriate message before node restart eof" }
             }
         }
     } EXCEPTION] } {
@@ -333,22 +335,27 @@ proc ::AlgorandGoal::CreateWallet { WALLET_NAME WALLET_PASSWORD TEST_PRIMARY_NOD
 
         expect {
             timeout {::AlgorandGoal::Abort "Timed out CreateWallet password"  }
+            eof {::AlgorandGoal::Abort "EOF CreateWallet password"  }
             "Please choose a password for wallet*" { send "$WALLET_PASSWORD\r" }
         }
         expect {
             timeout {::AlgorandGoal::Abort "Timed out CreateWallet confirmation"  }
+            eof {::AlgorandGoal::Abort "EOF CreateWallet confirmation"  }
             "Please confirm*" { send "$WALLET_PASSWORD\r"}
         }
         expect {
              timeout {::AlgorandGoal::Abort "Timed out CreateWallet see it now"  }
+             eof {::AlgorandGoal::Abort "EOF CreateWallet see it now"  }
              "Would you like to see it now? (Y/n):" { send "y\r" }
         }
         expect {
               timeout {::AlgorandGoal::Abort "Timed out CreateWallet keep info safe"  }
+              eof {::AlgorandGoal::Abort "EOF CreateWallet keep info safe"  }
               "Keep this information safe -- never share it with anyone!" {}
         }
         expect {
              timeout {::AlgorandGoal::Abort "Timed out CreateWallet pass phrase"  }
+             eof {::AlgorandGoal::Abort "EOF CreateWallet pass phrase"  }
              -re {([a-z ]+)} {set WALLET_PASS_PHRASE $expect_out(1,string); close;}
         }
     } EXCEPTION ] } {
@@ -364,6 +371,7 @@ proc ::AlgorandGoal::VerifyWallet { WALLET_NAME TEST_PRIMARY_NODE_DIR } {
         spawn goal wallet list -d $TEST_PRIMARY_NODE_DIR
         expect {
              timeout { ::AlgorandGoal::Abort "Timed out seeing expected input for spawn goal wallet list" }
+             eof { ::AlgorandGoal::Abort "EOF seeing expected input for spawn goal wallet list" }
              "*$WALLET_NAME*" {close}
         }
     } EXCEPTION ] } {
@@ -376,12 +384,14 @@ proc ::AlgorandGoal::RecoverWallet { NEW_WALLET_NAME WALLET_PASSPHRASE NEW_WALLE
     if { [catch {
         spawn goal wallet new -r $NEW_WALLET_NAME -d $TEST_PRIMARY_NODE_DIR
            expect {
-               timeout { puts "TIMEOUT"    }
+               timeout { ::AlgorandGoal::Abort "TIMEOUT"    }
+               eof { ::AlgorandGoal::Abort "EOF"    }
                {Please type your recovery mnemonic below, and hit return when you are done:*} { send "$WALLET_PASSPHRASE\r" }
             }
         for { set index 1}  {$index <= 5} {incr index} {
             expect {
-               timeout { puts "TIMEOUT"  }
+               timeout { ::AlgorandGoal::Abort "TIMEOUT"    }
+               eof { ::AlgorandGoal::Abort "EOF"    }
                {Please choose a password for wallet* } { send "$NEW_WALLET_PASSWORD\r"}
                {Please confirm the password:*} { send "$NEW_WALLET_PASSWORD\r"}
                {Creating wallet...*} {puts $expect_out(buffer) }
@@ -403,6 +413,7 @@ proc ::AlgorandGoal::CreateAccountForWallet { WALLET_NAME WALLET_PASSWORD TEST_P
         while 1 {
             expect {
                 timeout { break; ::AlgorandGoal::Abort "Timed out seeing new account created for wallet $WALLET_NAME" }
+                eof { break; ::AlgorandGoal::Abort "EOF seeing new account created for wallet $WALLET_NAME" }
                 "Please enter the password for wallet*" { send "$WALLET_PASSWORD\r" }
                  -re {Created new account with address ([a-zA-Z0-9]+)} {set ACCOUNT_ADDRESS $expect_out(1,string) ;close; break }
             }
@@ -422,6 +433,7 @@ proc ::AlgorandGoal::VerifyAccount { WALLET_NAME WALLET_PASSWORD ACCOUNT_ADDRESS
         while 1 {
             expect {
                 timeout {break; ::AlgorandGoal::Abort "Timed out seeing expected account: $ACCOUNT_ADDRESS"}
+                eof {break; ::AlgorandGoal::Abort "EOF seeing expected account: $ACCOUNT_ADDRESS"}
                 "Please enter the password for wallet*" { send "$WALLET_PASSWORD\r" }
                 -re {\t([A-Z0-9]+)\t([A-Z0-9]+)} {set RETURN_ACCOUNT_ADDRESS $expect_out(1,string); break  }
             }
@@ -487,6 +499,7 @@ proc ::AlgorandGoal::GetAccountRewards { WALLET_NAME ACCOUNT_ADDRESS TEST_PRIMAR
     spawn goal account rewards -w $WALLET_NAME -a $ACCOUNT_ADDRESS -d $TEST_PRIMARY_NODE_DIR
     expect {
         timeout { ::AlgorandGoal::Abort "Timed out retrieving account rewards for wallet $WALLET_NAME and account $ACCOUNT_ADDRESS"  }
+        eof { ::AlgorandGoal::Abort "EOF retrieving account rewards for wallet $WALLET_NAME and account $ACCOUNT_ADDRESS"  }
         -re {\d+} {set ACCOUNT_EARNINGS  $expect_out(0,string)}
     }
     puts "Wallet: $WALLET_NAME, Account: $ACCOUNT_ADDRESS, Rewards: $ACCOUNT_EARNINGS"
@@ -667,6 +680,7 @@ proc ::AlgorandGoal::LimitOrder {TEAL_DRIVER SWAP_N SWAP_D MIN_TRD OWNER FEE TIM
         spawn python $TEAL_DRIVER "limit-order" --swapn $SWAP_N --swapd $SWAP_D --mintrd $MIN_TRD --own $OWNER  --fee $FEE --timeout $TIME_OUT --asset $ASSET_ID
         expect {
             timeout { ::AlgorandGoal::Abort "Timed out limit order"  }
+            eof { ::AlgorandGoal::Abort "EOF limit order"  }
             -re {^.+$} { puts $limitf $expect_out(buffer); close $limitf; close }
         }
     } EXCEPTION ] } {
@@ -741,6 +755,7 @@ proc ::AlgorandGoal::RawSend { TXN_FILE TEST_PRIMARY_NODE_DIR } {
         spawn goal clerk rawsend -f $TXN_FILE -d $TEST_PRIMARY_NODE_DIR
         expect {
             timeout { close; ::AlgorandGoal::Abort "Timed out rawsend $TXN_FILE"  }
+            eof { close; ::AlgorandGoal::Abort "EOF rawsend $TXN_FILE"  }
             -re {Transaction ([A-Z0-9]{52}) committed} {set TRANSACTION_ID $expect_out(1,string); close }
 	        -re {Rejected transactions written to (.+rej)} {::AlgorandGoal::Abort "RawSend rejected."}
         }
@@ -809,6 +824,7 @@ proc ::AlgorandGoal::CheckNetworkAddressForCors { NET_ADDRESS } {
         spawn curl -X OPTIONS -H "Origin: http://algorand.com" --head $NET_ADDRESS
         expect {
             timeout { close; ::AlgorandGoal::Abort "Timeout failure in CheckNetworkAddressForCors" }
+            eof { close; ::AlgorandGoal::Abort "EOF in CheckNetworkAddressForCors" }
             "Access-Control-Allow-Origin" { puts "success" ; close  }
             eof {
                 return -code error "EOF without Access-Control-Allow-Origin in output"
@@ -826,6 +842,7 @@ proc ::AlgorandGoal::GetLedgerSupply { TEST_PRIMARY_NODE_DIR } {
         spawn goal ledger supply -d $TEST_PRIMARY_NODE_DIR
         expect {
             timeout { ::AlgorandGoal::Abort "Get Ledger Supply timed out"  }
+            eof { ::AlgorandGoal::Abort "Get Ledger Supply EOF"  }
             -re {Round: (\d+)} {set ROUND $expect_out(1,string); exp_continue }
             -re {Total Money: (\d+)} {set TOTAL_MONEY $expect_out(1,string); exp_continue }
             -re {Online Money: (\d+)} {set ONLINE_MONEY $expect_out(1,string) }
@@ -844,6 +861,7 @@ proc ::AlgorandGoal::CreateOneOfTwoMultisigForWallet { ADDRESS_1 ADDRESS_2 WALLE
         spawn goal account multisig new $ADDRESS_1 $ADDRESS_2 -T 1 -d $TEST_PRIMARY_NODE_DIR -w $WALLET_NAME
         expect {
             timeout { ::AlgorandGoal::Abort "Timed out creating a multisig account from $ADDRESS_1 and $ADDRESS_2"  }
+            eof { ::AlgorandGoal::Abort "EOF creating a multisig account from $ADDRESS_1 and $ADDRESS_2"  }
             "Please enter the password for wallet*" { send "$WALLET_PASSWORD\r" }
             -re {Created new account with address ([a-zA-Z0-9]+)} {
                     set MULTISIG_ADDRESS $expect_out(1,string);
@@ -862,6 +880,7 @@ proc ::AlgorandGoal::VerifyMultisigInfoForOneOfTwoMultisig { MULTISIG_ADDRESS AD
         spawn goal account multisig info --address $MULTISIG_ADDRESS -d $TEST_PRIMARY_NODE_DIR -w $WALLET_NAME
         expect {
             timeout { ::AlgorandGoal::Abort "Timed out querying info about multisig account $MULTISIG_ADDRESS"  }
+            eof { ::AlgorandGoal::Abort "EOF querying info about multisig account $MULTISIG_ADDRESS"  }
             -re {Version: (\d+)\s+Threshold: (\d+)\s+Public keys:\s+([a-zA-Z0-9]+)\s+([a-zA-Z0-9]+)\s+} {
                 set VERSION $expect_out(1,string);
                 set THRESHOLD $expect_out(2,string);
@@ -882,7 +901,11 @@ proc ::AlgorandGoal::VerifyMultisigInfoForOneOfTwoMultisig { MULTISIG_ADDRESS AD
 proc ::AlgorandGoal::DeleteMultisigAccount { MULTISIG_ADDRESS TEST_PRIMARY_NODE_DIR } {
     if { [ catch {
         spawn goal account multisig delete --address $MULTISIG_ADDRESS -d $TEST_PRIMARY_NODE_DIR
-        expect {*}
+        expect eof
+        set status [wait]
+        if {$status != 0} {
+            ::AlgorandGoal::Abort "DeleteMultisigAccount failed with exit code $status"
+        }
     } EXCEPTION ] } {
        ::AlgorandGoal::Abort "ERROR in DeleteMultisigAccount: $EXCEPTION"
     }
@@ -1049,6 +1072,7 @@ proc ::AlgorandGoal::Report { TEST_PRIMARY_NODE_DIR } {
         spawn goal report -d $TEST_PRIMARY_NODE_DIR
         expect {
             timeout { ::AlgorandGoal::Abort "goal report timed out"  }
+            eof { ::AlgorandGoal::Abort "goal report EOF"  }
             "source code available at https://github.com/algorand/go-algorand" {puts "goal -v ok"}
             -re {Genesis ID from genesis.json: *} {puts "genesis ID from genesis.json ok"}
             -re {Last committed block: (\d+)} {puts "status check ok"}

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -578,7 +578,7 @@ proc ::AlgorandGoal::AssetCreate { CREATOR WALLET_NAME WALLET_PASSWORD TOTAL_SUP
         expect {
             timeout { ::AlgorandGoal::Abort "Timed out create asset"  }
 	        "Please enter the password for wallet '$WALLET_NAME':" { send "$WALLET_PASSWORD\r"; exp_continue }
-	        eof
+	        eof { ::AlgorandGoal::Abort "EOF create asset"  }
         }
     } EXCEPTION ] } {
        ::AlgorandGoal::Abort "ERROR in AssetCreate: $EXCEPTION"
@@ -664,10 +664,12 @@ proc ::AlgorandGoal::AssembleGroup { INPUT_GROUP OUTPUT_GROUP } {
 proc ::AlgorandGoal::SplitGroup { INPUT_GROUP OUTPUT_GROUP } {
     if { [ catch {
         spawn goal clerk split -i $INPUT_GROUP -o $OUTPUT_GROUP
-	    expect {
+	    expect { #nolint:eof just checking status
             timeout { ::AlgorandGoal::Abort "Timed out splitting group transaction"  }
 	        eof
-        }
+            }
+        set status [wait]
+        if {$status != 0} { ::AlgorandGoal::Abort "Split group failed with exit code $status" }
     } EXCEPTION ] } {
        ::AlgorandGoal::Abort "ERROR in Split Group: $EXCEPTION"
     }
@@ -740,7 +742,7 @@ proc ::AlgorandGoal::SignTransaction { WALLET_NAME WALLET_PASSWORD INPUT_TXN OUT
         expect {
             timeout { ::AlgorandGoal::Abort "Timed out signing transaction"  }
 	        "Please enter the password for wallet '$WALLET_NAME':" { send "$WALLET_PASSWORD\r" ; exp_continue}
-	        eof
+	        eof { ::AlgorandGoal::Abort "EOF signing transaction"  }
         }
     } EXCEPTION ] } {
        ::AlgorandGoal::Abort "ERROR in SignTransaction: $EXCEPTION"
@@ -1344,8 +1346,10 @@ proc ::AlgorandGoal::CheckEOF { { ERROR_STRING "" } } {
 proc ::AlgorandGoal::InspectTransactionFile { TRX_FILE } {
     puts "\n Inspect $TRX_FILE"
     spawn goal clerk inspect $TRX_FILE
-    expect {
-        eof
+    expect eof
+    set status [wait]
+    if {$status != 0} {
+        ::AlgorandGoal::Abort "InspectTransactionFile failed with exit code $status"
     }
 }
 

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -810,6 +810,9 @@ proc ::AlgorandGoal::CheckNetworkAddressForCors { NET_ADDRESS } {
         expect {
             timeout { close; ::AlgorandGoal::Abort "Timeout failure in CheckNetworkAddressForCors" }
             "Access-Control-Allow-Origin" { puts "success" ; close  }
+            eof {
+                return -code error "EOF without Access-Control-Allow-Origin in output"
+            }
             close
         }
     } EXCEPTION ] } {
@@ -1348,4 +1351,3 @@ proc ::AlgorandGoal::RunPingpong {DURATION PINGPONG_OPTIONS TEST_PRIMARY_NODE_DI
        ::AlgorandGoal::Abort "ERROR in RunPingpong: $EXCEPTION"
     }
 }
-

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -383,20 +383,18 @@ proc ::AlgorandGoal::RecoverWallet { NEW_WALLET_NAME WALLET_PASSPHRASE NEW_WALLE
     set timeout 60
     if { [catch {
         spawn goal wallet new -r $NEW_WALLET_NAME -d $TEST_PRIMARY_NODE_DIR
-           expect {
-               timeout { ::AlgorandGoal::Abort "TIMEOUT"    }
-               eof { ::AlgorandGoal::Abort "EOF"    }
-               {Please type your recovery mnemonic below, and hit return when you are done:*} { send "$WALLET_PASSPHRASE\r" }
-            }
-        for { set index 1}  {$index <= 5} {incr index} {
-            expect {
-               timeout { ::AlgorandGoal::Abort "TIMEOUT"    }
-               eof { ::AlgorandGoal::Abort "EOF"    }
-               {Please choose a password for wallet* } { send "$NEW_WALLET_PASSWORD\r"}
-               {Please confirm the password:*} { send "$NEW_WALLET_PASSWORD\r"}
-               {Creating wallet...*} {puts $expect_out(buffer) }
-               -re {Created wallet '([-a-zA-Z0-9_]+)'} {set RECOVERED_WALLET_NAME $expect_out(1,string) }
-            }
+        expect {
+            timeout { ::AlgorandGoal::Abort "TIMEOUT"    }
+            eof { ::AlgorandGoal::Abort "EOF"    }
+            {Please type your recovery mnemonic below, and hit return when you are done:*} { send "$WALLET_PASSPHRASE\r" }
+        }
+        expect {
+            timeout { ::AlgorandGoal::Abort "TIMEOUT"    }
+            eof { ::AlgorandGoal::Abort "EOF"    }
+            {Please choose a password for wallet* } { send "$NEW_WALLET_PASSWORD\r"; exp_continue;}
+            {Please confirm the password:*} { send "$NEW_WALLET_PASSWORD\r"; exp_continue;}
+            {Creating wallet...*} {puts $expect_out(buffer); exp_continue; }
+            -re {Created wallet '([-a-zA-Z0-9_]+)'} {set RECOVERED_WALLET_NAME $expect_out(1,string) }
         }
         puts "Recovered wallet: $RECOVERED_WALLET_NAME"
     } EXCEPTION ] } {

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -670,8 +670,13 @@ proc ::AlgorandGoal::SplitGroup { INPUT_GROUP OUTPUT_GROUP } {
             timeout { ::AlgorandGoal::Abort "Timed out splitting group transaction"  }
 	        eof
         }
-        set status [wait]
-        if {$status != 0} { ::AlgorandGoal::Abort "Split group failed with exit code $status" }
+        lassign [wait] PID SPAWNID OS_CODE ERR_CODE
+        if {$OS_CODE == -1} {
+            ::AlgorandGoal::Abort "Split group failed: OS error code: $ERR_CODE"
+        }
+        if {$ERR_CODE != 0} {
+            ::AlgorandGoal::Abort "Split group failed with: exit code: $ERR_CODE"
+        }
     } EXCEPTION ] } {
        ::AlgorandGoal::Abort "ERROR in Split Group: $EXCEPTION"
     }
@@ -742,9 +747,16 @@ proc ::AlgorandGoal::SignTransaction { WALLET_NAME WALLET_PASSWORD INPUT_TXN OUT
     if { [ catch {
         spawn goal clerk sign -d $TEST_PRIMARY_NODE_DIR -w $WALLET_NAME -i $INPUT_TXN -o $OUTPUT_TXN
         expect {
-            #nolint:eof just signing with outputting to file
+            #nolint:eof just signing with outputting to file and checking status
             timeout { ::AlgorandGoal::Abort "Timed out signing transaction"  }
-	        "Please enter the password for wallet '$WALLET_NAME':" { send "$WALLET_PASSWORD\r" ;}
+	        "Please enter the password for wallet '$WALLET_NAME':" { send "$WALLET_PASSWORD\r" ; exp_continue;}
+        }
+        lassign [wait] PID SPAWNID OS_CODE ERR_CODE
+        if {$OS_CODE == -1} {
+            ::AlgorandGoal::Abort "SignTransaction failed: OS error code: $ERR_CODE"
+        }
+        if {$ERR_CODE != 0} {
+            ::AlgorandGoal::Abort "SignTransaction failed with: exit code: $ERR_CODE"
         }
     } EXCEPTION ] } {
        ::AlgorandGoal::Abort "ERROR in SignTransaction: $EXCEPTION"
@@ -905,9 +917,12 @@ proc ::AlgorandGoal::DeleteMultisigAccount { MULTISIG_ADDRESS TEST_PRIMARY_NODE_
     if { [ catch {
         spawn goal account multisig delete --address $MULTISIG_ADDRESS -d $TEST_PRIMARY_NODE_DIR
         expect eof
-        set status [wait]
-        if {$status != 0} {
-            ::AlgorandGoal::Abort "DeleteMultisigAccount failed with exit code $status"
+        lassign [wait] PID SPAWNID OS_CODE ERR_CODE
+        if {$OS_CODE == -1} {
+            ::AlgorandGoal::Abort "DeleteMultisigAccount failed: OS error code: $ERR_CODE"
+        }
+        if {$ERR_CODE != 0} {
+            ::AlgorandGoal::Abort "DeleteMultisigAccount failed with: exit code: $ERR_CODE"
         }
     } EXCEPTION ] } {
        ::AlgorandGoal::Abort "ERROR in DeleteMultisigAccount: $EXCEPTION"
@@ -1349,9 +1364,12 @@ proc ::AlgorandGoal::InspectTransactionFile { TRX_FILE } {
     puts "\n Inspect $TRX_FILE"
     spawn goal clerk inspect $TRX_FILE
     expect eof
-    set status [wait]
-    if {$status != 0} {
-        ::AlgorandGoal::Abort "InspectTransactionFile failed with exit code $status"
+    lassign [wait] PID SPAWNID OS_CODE ERR_CODE
+    if {$OS_CODE == -1} {
+        ::AlgorandGoal::Abort "InspectTransactionFile failed: OS error code: $ERR_CODE"
+    }
+    if {$ERR_CODE != 0} {
+        ::AlgorandGoal::Abort "InspectTransactionFile failed with: exit code: $ERR_CODE"
     }
 }
 

--- a/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
+++ b/test/e2e-go/cli/goal/expect/goalExpectCommon.exp
@@ -824,7 +824,6 @@ proc ::AlgorandGoal::CheckNetworkAddressForCors { NET_ADDRESS } {
         spawn curl -X OPTIONS -H "Origin: http://algorand.com" --head $NET_ADDRESS
         expect {
             timeout { close; ::AlgorandGoal::Abort "Timeout failure in CheckNetworkAddressForCors" }
-            eof { close; ::AlgorandGoal::Abort "EOF in CheckNetworkAddressForCors" }
             "Access-Control-Allow-Origin" { puts "success" ; close  }
             eof {
                 return -code error "EOF without Access-Control-Allow-Origin in output"

--- a/test/e2e-go/cli/goal/expect/goalTxValidityTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalTxValidityTest.exp
@@ -32,6 +32,7 @@ proc TestLastValidInTx { CMD TX_FILE EXPECTED_LAST_VALID } {
     spawn goal clerk inspect $TX_FILE
     expect {
         timeout { ::AlgorandGoal::Abort "'goal clerk inspect' timed out" }
+        eof { ::AlgorandGoal::Abort "'goal clerk inspect' eof" }
         -re {"lv": (\d+)} {set PASSED 1; set LAST_VALID $expect_out(1,string); close }
     }
 

--- a/test/e2e-go/cli/goal/expect/limitOrderTest.exp
+++ b/test/e2e-go/cli/goal/expect/limitOrderTest.exp
@@ -91,10 +91,7 @@ if { [catch {
     set UNIT_NAME "duckcoin"
     ::AlgorandGoal::AssetCreate $ACCOUNT_1_ADDRESS $WALLET_1_NAME $WALLET_1_PASSWORD $TOTAL_SUPPLY 0 "" $UNIT_NAME $TEST_PRIMARY_NODE_DIR
 
-    # wait about 4 rounds
-    set ASSET_CREATE_WAIT 20
-    puts "Wait $ASSET_CREATE_WAIT for asset creation"
-    exec sleep $ASSET_CREATE_WAIT
+    # no extra waiting here since AssetCreate waits for confirmation
 
     # get asset id
     set ASSET_ID [::AlgorandGoal::AssetLookup $ACCOUNT_1_ADDRESS $UNIT_NAME $TEST_PRIMARY_NODE_DIR]
@@ -123,8 +120,9 @@ if { [catch {
 
     puts "Generated Teal Source:"
     spawn cat $TEAL_SOURCE
-    expect { #nolint:eof not asserting expected output
-	    -re {^.+$} { close }
+    expect {
+        #nolint:eof not asserting expected output
+        -re {^.+$} { close }
     }
 
     # compile teal assembly to bytecode
@@ -146,10 +144,10 @@ if { [catch {
     # the second payment sends money (the asset) from the Bob to the Alice
     set ZERO_ADDRESS "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ"
     set LIMIT_TXN_1 "$TEST_ROOT_DIR/limit1.tx"
-    ::AlgorandGoal::TealTxnCreate $TEAL_SOURCE $ACCOUNT_1_ADDRESS $ZERO_ADDRESS 20000 $TEST_PRIMARY_NODE_DIR $LIMIT_TXN_1 
+    ::AlgorandGoal::TealTxnCreate $TEAL_SOURCE $ACCOUNT_1_ADDRESS $ZERO_ADDRESS 20000 $TEST_PRIMARY_NODE_DIR $LIMIT_TXN_1
 
     set LIMIT_TXN_2 "$TEST_ROOT_DIR/limit2.tx"
-    ::AlgorandGoal::CreateAssetTransfer $ACCOUNT_1_ADDRESS $ACCOUNT_2_ADDRESS $ASSET_ID 30000 $TEST_PRIMARY_NODE_DIR $LIMIT_TXN_2 
+    ::AlgorandGoal::CreateAssetTransfer $ACCOUNT_1_ADDRESS $ACCOUNT_2_ADDRESS $ASSET_ID 30000 $TEST_PRIMARY_NODE_DIR $LIMIT_TXN_2
 
     set LIMIT_CMB "$TEST_ROOT_DIR/limitcmb.tx"
     exec cat $LIMIT_TXN_1 $LIMIT_TXN_2 > $LIMIT_CMB

--- a/test/e2e-go/cli/goal/expect/limitOrderTest.exp
+++ b/test/e2e-go/cli/goal/expect/limitOrderTest.exp
@@ -123,7 +123,7 @@ if { [catch {
 
     puts "Generated Teal Source:"
     spawn cat $TEAL_SOURCE
-    expect {
+    expect { #nolint:eof not asserting expected output
 	    -re {^.+$} { close }
     }
 

--- a/test/e2e-go/cli/goal/expect/tealAndStatefulTealTest.exp
+++ b/test/e2e-go/cli/goal/expect/tealAndStatefulTealTest.exp
@@ -141,9 +141,7 @@ if { [catch {
     ::AlgorandGoal::SplitGroup groupedtransactions.tx split.tx
 
     puts "sign the split transaction"
-    set RAW_TX_1 split-0.tx
-    set RAW_STX_1 signout-0.tx
-    ::AlgorandGoal::SignTransaction $WALLET_1_NAME $WALLET_1_PASSWORD $RAW_TX_1 $RAW_STX_1 $TEST_PRIMARY_NODE_DIR
+    ::AlgorandGoal::SignTransaction $WALLET_1_NAME $WALLET_1_PASSWORD split-0.tx signout-0.tx $TEST_PRIMARY_NODE_DIR
 
     puts "\ncombine into the sign out transaction"
     exec cat signout-0.tx split-1.tx > signout.tx

--- a/test/e2e-go/cli/goal/expect/tealConsensusTest.exp
+++ b/test/e2e-go/cli/goal/expect/tealConsensusTest.exp
@@ -50,6 +50,7 @@ if { [catch {
     spawn goal clerk compile "$TEST_ROOT_DIR/small-sig.teal"
     expect {
         -re {[A-Z2-9]{58}} { set SMALL_SIG $expect_out(0,string) }
+        eof { ::AlgorandGoal::Abort $expect_out(buffer) }
         "\n" { ::AlgorandGoal::Abort $expect_out(buffer) }
     }
 
@@ -58,6 +59,7 @@ if { [catch {
     expect {
         -re {[A-Z2-9]{58}} { ::AlgorandGoal::Abort "hash" }
         -re {.*logicsig program size too large} { puts "bigsigcheck: pass" }
+        eof { ::AlgorandGoal::Abort $expect_out(buffer) }
         "\n" { ::AlgorandGoal::Abort $expect_out(buffer) }
     }
 
@@ -65,6 +67,7 @@ if { [catch {
     spawn goal clerk compile "$TEST_ROOT_DIR/barely-fits-app.teal"
     expect {
         -re {[A-Z2-9]{58}} { puts "hash $expect_out(0,string)" }
+        eof { ::AlgorandGoal::Abort $expect_out(buffer) }
         "\n" { ::AlgorandGoal::Abort $expect_out(buffer) }
     }
 
@@ -74,6 +77,7 @@ if { [catch {
     expect {
         -re {[A-Z2-9]{58}} { ::AlgorandGoal::Abort "hash" }
         -re {.*app program size too large} { puts "bigappcheck: pass" }
+        eof { ::AlgorandGoal::Abort $expect_out(buffer) }
         "\n" { ::AlgorandGoal::Abort $expect_out(buffer) }
     }
 
@@ -84,6 +88,7 @@ if { [catch {
         " - pass -" { puts "small-sig dryrun pass" }
         "REJECT" { ::AlgorandGoal::Abort $expect_out(buffer) }
         "static cost budget" { ::AlgorandGoal::Abort $expect_out(buffer) }
+        eof { ::AlgorandGoal::Abort $expect_out(buffer) }
     }
 
     teal "$TEST_ROOT_DIR/slow-sig.teal" 2 1 20001
@@ -94,6 +99,7 @@ if { [catch {
         "dynamic cost budget" { puts "slow-sig dryrun pass" }
         " - pass -" { ::AlgorandGoal::Abort $expect_out(buffer) }
         "REJECT" { ::AlgorandGoal::Abort $expect_out(buffer) }
+        eof { ::AlgorandGoal::Abort $expect_out(buffer) }
     }
 
     # Shutdown the network

--- a/test/e2e-go/cli/goal/expect/tealConsensusTest.exp
+++ b/test/e2e-go/cli/goal/expect/tealConsensusTest.exp
@@ -91,20 +91,16 @@ if { [catch {
         eof { ::AlgorandGoal::Abort $expect_out(buffer) }
     }
 
-    # TODO: FIXME: This test is failing with the following error:
-    # program failed Check: pc=164 static cost budget of 20000 exceeded
-    # Aborting with Error: program failed Check: pc=164 static cost budget of 20000 exceeded
-
-    # teal "$TEST_ROOT_DIR/slow-sig.teal" 2 1 20001
-    # exec goal clerk compile "$TEST_ROOT_DIR/slow-sig.teal"
-    # exec goal clerk send -F "$TEST_ROOT_DIR/slow-sig.teal" -t GXBNLU4AXQABPLHXJDMTG2YXSDT4EWUZACT7KTPFXDQW52XPTIUS5OZ5HQ -a 100 -d $TEST_PRIMARY_NODE_DIR -o $TEST_ROOT_DIR/slow-sig.tx
-    # spawn goal clerk dryrun -P future -t $TEST_ROOT_DIR/slow-sig.tx  # Should succeed Check, fail Eval
-    # expect {
-    #     "dynamic cost budget" { puts "slow-sig dryrun pass" }
-    #     " - pass -" { ::AlgorandGoal::Abort $expect_out(buffer) }
-    #     "REJECT" { ::AlgorandGoal::Abort $expect_out(buffer) }
-    #     eof { ::AlgorandGoal::Abort $expect_out(buffer) }
-    # }
+    teal "$TEST_ROOT_DIR/slow-sig.teal" 4 1 20001
+    exec goal clerk compile "$TEST_ROOT_DIR/slow-sig.teal"
+    exec goal clerk send -F "$TEST_ROOT_DIR/slow-sig.teal" -t GXBNLU4AXQABPLHXJDMTG2YXSDT4EWUZACT7KTPFXDQW52XPTIUS5OZ5HQ -a 100 -d $TEST_PRIMARY_NODE_DIR -o $TEST_ROOT_DIR/slow-sig.tx
+    spawn goal clerk dryrun -P future -t $TEST_ROOT_DIR/slow-sig.tx  # Should succeed Check, fail Eval
+    expect {
+        "dynamic cost budget" { puts "slow-sig dryrun pass" }
+        " - pass -" { ::AlgorandGoal::Abort $expect_out(buffer) }
+        "REJECT" { ::AlgorandGoal::Abort $expect_out(buffer) }
+        eof { ::AlgorandGoal::Abort $expect_out(buffer) }
+    }
 
     # Shutdown the network
     ::AlgorandGoal::StopNetwork $NETWORK_NAME $TEST_ROOT_DIR

--- a/test/e2e-go/cli/goal/expect/tealConsensusTest.exp
+++ b/test/e2e-go/cli/goal/expect/tealConsensusTest.exp
@@ -91,16 +91,20 @@ if { [catch {
         eof { ::AlgorandGoal::Abort $expect_out(buffer) }
     }
 
-    teal "$TEST_ROOT_DIR/slow-sig.teal" 2 1 20001
-    exec goal clerk compile "$TEST_ROOT_DIR/slow-sig.teal"
-    exec goal clerk send -F "$TEST_ROOT_DIR/slow-sig.teal" -t GXBNLU4AXQABPLHXJDMTG2YXSDT4EWUZACT7KTPFXDQW52XPTIUS5OZ5HQ -a 100 -d $TEST_PRIMARY_NODE_DIR -o $TEST_ROOT_DIR/slow-sig.tx
-    spawn goal clerk dryrun -P future -t $TEST_ROOT_DIR/slow-sig.tx  # Should succeed Check, fail Eval
-    expect {
-        "dynamic cost budget" { puts "slow-sig dryrun pass" }
-        " - pass -" { ::AlgorandGoal::Abort $expect_out(buffer) }
-        "REJECT" { ::AlgorandGoal::Abort $expect_out(buffer) }
-        eof { ::AlgorandGoal::Abort $expect_out(buffer) }
-    }
+    # TODO: FIXME: This test is failing with the following error:
+    # program failed Check: pc=164 static cost budget of 20000 exceeded
+    # Aborting with Error: program failed Check: pc=164 static cost budget of 20000 exceeded
+
+    # teal "$TEST_ROOT_DIR/slow-sig.teal" 2 1 20001
+    # exec goal clerk compile "$TEST_ROOT_DIR/slow-sig.teal"
+    # exec goal clerk send -F "$TEST_ROOT_DIR/slow-sig.teal" -t GXBNLU4AXQABPLHXJDMTG2YXSDT4EWUZACT7KTPFXDQW52XPTIUS5OZ5HQ -a 100 -d $TEST_PRIMARY_NODE_DIR -o $TEST_ROOT_DIR/slow-sig.tx
+    # spawn goal clerk dryrun -P future -t $TEST_ROOT_DIR/slow-sig.tx  # Should succeed Check, fail Eval
+    # expect {
+    #     "dynamic cost budget" { puts "slow-sig dryrun pass" }
+    #     " - pass -" { ::AlgorandGoal::Abort $expect_out(buffer) }
+    #     "REJECT" { ::AlgorandGoal::Abort $expect_out(buffer) }
+    #     eof { ::AlgorandGoal::Abort $expect_out(buffer) }
+    # }
 
     # Shutdown the network
     ::AlgorandGoal::StopNetwork $NETWORK_NAME $TEST_ROOT_DIR

--- a/test/e2e-go/cli/goal/expect/testInfraTest.exp
+++ b/test/e2e-go/cli/goal/expect/testInfraTest.exp
@@ -58,6 +58,7 @@ proc checkProcessReturnedCodeTest {} {
 	44 {
 	    close
 	}
+        eof { puts "expected output not 44"; exit 1 }
     }
     lassign [::AlgorandGoal::CheckProcessReturnedCode 0] response OS_CODE ERR_CODE KILLED KILL_SIGNAL EXP
     if {$response != 0} {
@@ -72,6 +73,7 @@ proc checkProcessReturnedCodeTest {} {
 	44 {
 	    puts "not closing"
 	}
+        eof { puts "expected output not 44"; exit 1 }
     }
     lassign [::AlgorandGoal::CheckProcessReturnedCode 0] response OS_CODE ERR_CODE KILLED KILL_SIGNAL EXP
     if {$KILLED != "CHILDKILLED" || $KILL_SIGNAL != "SIGSEGV" || $EXP != "segmentation violation"} {


### PR DESCRIPTION
## Summary

While looking why https://github.com/algorand/go-algorand/pull/6089 expect test did not work as expected, I found it copied the `expect` statement from the `CheckNetworkAddressForCors` function, and it does not perform check correctly ignoring the fact of missing expected output. 
I fixed that by added `eof` sub statement which is hit when no other statement executed previously and when there is no `exp_continue`. After that the test started failing since it was checking KMD headers without setting `allowed_origins` configuration option.

@cce also discovered the same issue in some other tests and added a linter.

## Test Plan

This is a test fix.