### PR TITLE
p2p: make sure p2p http server runs on all interfaces

### DIFF
--- a/network/p2p/http.go
+++ b/network/p2p/http.go
@@ -28,6 +28,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	libp2phttp "github.com/libp2p/go-libp2p/p2p/http"
+	"github.com/multiformats/go-multiaddr"
 )
 
 // algorandP2pHTTPProtocol defines a libp2p protocol name for algorand's http over p2p messages
@@ -45,6 +46,15 @@ func MakeHTTPServer(streamHost host.Host) *HTTPServer {
 	httpServer := HTTPServer{
 		Host:       libp2phttp.Host{StreamHost: streamHost},
 		p2phttpMux: mux.NewRouter(),
+	}
+	// libp2phttp server requires either explicit ListenAddrs or streamHost.Addrs() to be non-empty.
+	// If streamHost.Addrs() is empty, we will listen on all interfaces
+	if len(streamHost.Addrs()) == 0 {
+		logging.Base().Debugf("MakeHTTPServer: no addresses for %s, asking to listen all interfaces", streamHost.ID())
+		httpServer.ListenAddrs = []multiaddr.Multiaddr{
+			multiaddr.StringCast("/ip4/0.0.0.0/tcp/0/http"),
+		}
+		httpServer.InsecureAllowHTTP = true
 	}
 	return &httpServer
 }

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -39,6 +39,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
+	basichost "github.com/libp2p/go-libp2p/p2p/host/basic"
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	"github.com/libp2p/go-libp2p/p2p/muxer/yamux"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
@@ -277,7 +278,7 @@ func (s *serviceImpl) dialNode(ctx context.Context, peer *peer.AddrInfo) error {
 func (s *serviceImpl) AddrInfo() peer.AddrInfo {
 	return peer.AddrInfo{
 		ID:    s.host.ID(),
-		Addrs: s.host.Addrs(),
+		Addrs: s.host.(*basichost.BasicHost).AllAddrs(), // fetch all addresses, including private ones
 	}
 }
 

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -513,7 +513,6 @@ func (n *P2PNetwork) Address() (string, bool) {
 	for _, addr := range addrs {
 		if !manet.IsIPLoopback(addr) && !manet.IsIPUnspecified(addr) {
 			return addr.String(), true
-
 		}
 	}
 	// We don't have a non loopback address, so just return the first one if it contains an ip4 address or port


### PR DESCRIPTION
## Summary

libp2phttp server rejects to run when no listen addresses can be determined and no `ListenAddrs` provided. After filtering out all non-routable and private addresses via address factory in `host.Addrs()`, our http server failed to start since `host.Addrs()` returned empty.
Fixed by handling this situation explicitly in `MakeHTTPServer` and providing `0.0.0.0` via `ListenAddrs`.

Note, if `NetAddress` is set to some specific address, all this new logic is not executed - http server will start on the `NetAddress` interface as before this change.

## Test Plan

Added an explicit unit test for this `NetAddress = ":0"` case