### PR TITLE
dnssec: Add new IANA trust anchor

### DIFF
--- a/tools/network/dnssec/anchor.go
+++ b/tools/network/dnssec/anchor.go
@@ -38,6 +38,12 @@ const rootAnchorXML = `<?xml version="1.0" encoding="UTF-8"?>
 <DigestType>2</DigestType>
 <Digest>E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D</Digest>
 </KeyDigest>
+<KeyDigest id="Kmyv6jo" validFrom="2024-07-18T00:00:00+00:00">
+<KeyTag>38696</KeyTag>
+<Algorithm>8</Algorithm>
+<DigestType>2</DigestType>
+<Digest>683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16</Digest>
+</KeyDigest>
 </TrustAnchor>`
 
 // KeyDigest represents a digest entry in the root anchor XML

--- a/tools/network/dnssec/anchor_test.go
+++ b/tools/network/dnssec/anchor_test.go
@@ -34,10 +34,10 @@ func TestParseRootTrustAnchor(t *testing.T) {
 	a.Equal(an1, an2)
 
 	dss := an2.ToDS()
-	a.Equal(2, len(dss))
-	currentDS := dss[1]
-	a.Equal("E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D", currentDS.Digest)
-	a.Equal(uint16(20326), currentDS.KeyTag)
+	a.Equal(3, len(dss))
+	currentDS := dss[2]
+	a.Equal("683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16", currentDS.Digest)
+	a.Equal(uint16(38696), currentDS.KeyTag)
 	a.Equal(uint8(8), currentDS.Algorithm)
 	a.Equal(uint8(2), currentDS.DigestType)
 

--- a/tools/network/dnssec/trustedchain_test.go
+++ b/tools/network/dnssec/trustedchain_test.go
@@ -394,10 +394,10 @@ func TestQueryWrapper(t *testing.T) {
 
 	dss, err := qr.GetRootAnchorDS()
 	a.NoError(err)
-	a.Equal(2, len(dss))
-	currentDS := dss[1]
-	a.Equal("E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D", currentDS.Digest)
-	a.Equal(uint16(20326), currentDS.KeyTag)
+	a.Equal(3, len(dss))
+	currentDS := dss[2]
+	a.Equal("683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16", currentDS.Digest)
+	a.Equal(uint16(38696), currentDS.KeyTag)
 	a.Equal(uint8(8), currentDS.Algorithm)
 	a.Equal(uint8(2), currentDS.DigestType)
 


### PR DESCRIPTION
## Summary
This PR updates the DNSSEC trust anchor information by incorporating a new Trust Anchor (TA) from the IANA root anchor data. The new TA is scheduled to start signing DNS data in 2026. This update ensures the DNSSEC implementation remains current and accurate with future trust anchor data. The specific changes include:
* Addition of New TA: Integrated into rootAnchorXML in anchor.go.
* Test Adjustments: Updated tests in anchor_test.go and trustedchain_test.go to validate the new TA's handling.
The new TA details are available at: https://data.iana.org/root-anchors/root-anchors.xml.
## Test Plan
* Tested Locally