### PR TITLE
scripts: allow metrics filtering by labels in metrics_viz.py

### DIFF
--- a/test/heapwatch/metrics_aggs.py
+++ b/test/heapwatch/metrics_aggs.py
@@ -33,7 +33,7 @@ import plotly.graph_objs as go
 from plotly.subplots import make_subplots
 
 
-from metrics_lib import Metric, MetricType, parse_metrics, gather_metrics_files_by_nick
+from metrics_lib import Metric, MetricType, parse_metrics, gather_metrics_files_by_nick, parse_tags
 
 logger = logging.getLogger(__name__)
 
@@ -62,14 +62,7 @@ def main():
     else:
         logging.basicConfig(level=logging.INFO)
 
-    tags = {}
-    if args.tags:
-        for tag in args.tags:
-            if '=' not in tag:
-                raise (f'Invalid tag: {tag}')
-            k, v = tag.split('=', 1)
-            tags[k] = v
-    tag_keys = set(tags.keys())
+    tags, tag_keys = parse_tags(args.tags)
 
     metrics_files = sorted(glob.glob(os.path.join(args.dir, '*.metrics')))
     metrics_files.extend(glob.glob(os.path.join(args.dir, 'terraform-inventory.host')))
@@ -119,7 +112,7 @@ def main():
                     for metric in metrics_seq:
                         if metric.type != MetricType.COUNTER:
                             raise RuntimeError('Only COUNT metrics are supported')
-                        if tags is None or tags is not None and metric.has_tags(tag_keys, tags):
+                        if tags is None or tags is not None and metric.has_tags(tags, tag_keys):
                             raw_value += metric.value
                             full_name = metric.string(set(tag_keys).union({'n'}))
 


### PR DESCRIPTION
## Summary

Updates to heapwatch tooling for metrics analysis:
1. Allow tags filters in `metrics_viz.py`
2. Support repeated tag values

## Test Plan

This allows to run aggs/viz scripts against high-freq scrapped metrics by heapwatch tooling like this
```
python3 ./test/heapwatch/metrics_viz.py -d /data/networks/p2p-200-1/metrics/500x15 libp2p_rcmgr_streams --nick-re 'name_n\d+' -s html -t protocol=/meshsub/1.1.0 -t protocol=/algorand-ws/1.0.0
```
and get subset of `libp2p_rcmgr_streams` values to look at:
<img width="1466" alt="image" src="https://github.com/user-attachments/assets/f5a4224a-3995-484b-a140-8702bc751747">

