### PR TITLE
p2p: reuse existing libp2p.Host for http clients

### DIFF
--- a/network/p2p/testing/httpNode.go
+++ b/network/p2p/testing/httpNode.go
@@ -104,7 +104,7 @@ func (p httpPeer) GetAddress() string {
 
 // GetAddress implements HTTPPeer interface and returns the http client for a peer
 func (p httpPeer) GetHTTPClient() *http.Client {
-	c, err := p2p.MakeHTTPClient(&p.addrInfo)
+	c, err := p2p.MakeTestHTTPClient(&p.addrInfo)
 	require.NoError(p.tb, err)
 	return c
 }

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -612,7 +612,7 @@ func addrInfoToWsPeerCore(n *P2PNetwork, addrInfo *peer.AddrInfo) (wsPeerCore, b
 	}
 	addr := mas[0].String()
 
-	client, err := p2p.MakeHTTPClientWithRateLimit(addrInfo, n.service, n.pstore, limitcaller.DefaultQueueingTimeout)
+	client, err := n.service.GetHTTPClient(addrInfo, n.pstore, limitcaller.DefaultQueueingTimeout)
 	if err != nil {
 		n.log.Warnf("MakeHTTPClient failed: %v", err)
 		return wsPeerCore{}, false
@@ -718,7 +718,7 @@ func (n *P2PNetwork) GetHTTPClient(address string) (*http.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return p2p.MakeHTTPClientWithRateLimit(addrInfo, n.service, n.pstore, limitcaller.DefaultQueueingTimeout)
+	return n.service.GetHTTPClient(addrInfo, n.pstore, limitcaller.DefaultQueueingTimeout)
 }
 
 // OnNetworkAdvance notifies the network library that the agreement protocol was able to make a notable progress.
@@ -771,7 +771,7 @@ func (n *P2PNetwork) wsStreamHandler(ctx context.Context, p2pPeer peer.ID, strea
 
 	// create a wsPeer for this stream and added it to the peers map.
 	addrInfo := &peer.AddrInfo{ID: p2pPeer, Addrs: []multiaddr.Multiaddr{ma}}
-	client, err := p2p.MakeHTTPClientWithRateLimit(addrInfo, n.service, n.pstore, limitcaller.DefaultQueueingTimeout)
+	client, err := n.service.GetHTTPClient(addrInfo, n.pstore, limitcaller.DefaultQueueingTimeout)
 	if err != nil {
 		n.log.Warnf("Cannot construct HTTP Client for %s: %v", p2pPeer, err)
 		client = nil

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -612,7 +612,7 @@ func addrInfoToWsPeerCore(n *P2PNetwork, addrInfo *peer.AddrInfo) (wsPeerCore, b
 	}
 	addr := mas[0].String()
 
-	client, err := p2p.MakeHTTPClientWithRateLimit(addrInfo, n.pstore, limitcaller.DefaultQueueingTimeout)
+	client, err := p2p.MakeHTTPClientWithRateLimit(addrInfo, n.service, n.pstore, limitcaller.DefaultQueueingTimeout)
 	if err != nil {
 		n.log.Warnf("MakeHTTPClient failed: %v", err)
 		return wsPeerCore{}, false
@@ -718,7 +718,7 @@ func (n *P2PNetwork) GetHTTPClient(address string) (*http.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return p2p.MakeHTTPClientWithRateLimit(addrInfo, n.pstore, limitcaller.DefaultQueueingTimeout)
+	return p2p.MakeHTTPClientWithRateLimit(addrInfo, n.service, n.pstore, limitcaller.DefaultQueueingTimeout)
 }
 
 // OnNetworkAdvance notifies the network library that the agreement protocol was able to make a notable progress.
@@ -771,7 +771,7 @@ func (n *P2PNetwork) wsStreamHandler(ctx context.Context, p2pPeer peer.ID, strea
 
 	// create a wsPeer for this stream and added it to the peers map.
 	addrInfo := &peer.AddrInfo{ID: p2pPeer, Addrs: []multiaddr.Multiaddr{ma}}
-	client, err := p2p.MakeHTTPClientWithRateLimit(addrInfo, n.pstore, limitcaller.DefaultQueueingTimeout)
+	client, err := p2p.MakeHTTPClientWithRateLimit(addrInfo, n.service, n.pstore, limitcaller.DefaultQueueingTimeout)
 	if err != nil {
 		n.log.Warnf("Cannot construct HTTP Client for %s: %v", p2pPeer, err)
 		client = nil

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -780,10 +780,12 @@ func TestP2PHTTPHandler(t *testing.T) {
 
 	// check rate limiting client:
 	// zero clients allowed, rate limiting window (10s) is greater than queue deadline (1s)
+	netB, err := NewP2PNetwork(log, cfg, "", nil, genesisID, config.Devtestnet, &nopeNodeInfo{}, nil)
+	require.NoError(t, err)
 	pstore, err := peerstore.MakePhonebook(0, 10*time.Second)
 	require.NoError(t, err)
 	pstore.AddPersistentPeers([]*peer.AddrInfo{&peerInfoA}, "net", phonebook.PhoneBookEntryRelayRole)
-	httpClient, err = p2p.MakeHTTPClientWithRateLimit(&peerInfoA, pstore, 1*time.Second)
+	httpClient, err = p2p.MakeHTTPClientWithRateLimit(&peerInfoA, netB.service, pstore, 1*time.Second)
 	require.NoError(t, err)
 	_, err = httpClient.Get("/test")
 	require.ErrorIs(t, err, limitcaller.ErrConnectionQueueingTimeout)

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -368,6 +368,10 @@ func (s *mockService) Publish(ctx context.Context, topic string, data []byte) er
 	return nil
 }
 
+func (s *mockService) GetHTTPClient(addrInfo *peer.AddrInfo, connTimeStore limitcaller.ConnectionTimeStore, queueingTimeout time.Duration) (*http.Client, error) {
+	return nil, nil
+}
+
 func makeMockService(id peer.ID, addrs []ma.Multiaddr) *mockService {
 	return &mockService{
 		id:    id,
@@ -757,7 +761,7 @@ func TestP2PHTTPHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.NotZero(t, addrsA[0])
 
-	httpClient, err := p2p.MakeHTTPClient(&peerInfoA)
+	httpClient, err := p2p.MakeTestHTTPClient(&peerInfoA)
 	require.NoError(t, err)
 	resp, err := httpClient.Get("/test")
 	require.NoError(t, err)
@@ -768,7 +772,7 @@ func TestP2PHTTPHandler(t *testing.T) {
 	require.Equal(t, "hello", string(body))
 
 	// check another endpoint that also access the underlying connection/stream
-	httpClient, err = p2p.MakeHTTPClient(&peerInfoA)
+	httpClient, err = p2p.MakeTestHTTPClient(&peerInfoA)
 	require.NoError(t, err)
 	resp, err = httpClient.Get("/check-conn")
 	require.NoError(t, err)
@@ -785,7 +789,7 @@ func TestP2PHTTPHandler(t *testing.T) {
 	pstore, err := peerstore.MakePhonebook(0, 10*time.Second)
 	require.NoError(t, err)
 	pstore.AddPersistentPeers([]*peer.AddrInfo{&peerInfoA}, "net", phonebook.PhoneBookEntryRelayRole)
-	httpClient, err = p2p.MakeHTTPClientWithRateLimit(&peerInfoA, netB.service, pstore, 1*time.Second)
+	httpClient, err = netB.service.GetHTTPClient(&peerInfoA, pstore, 1*time.Second)
 	require.NoError(t, err)
 	_, err = httpClient.Get("/test")
 	require.ErrorIs(t, err, limitcaller.ErrConnectionQueueingTimeout)
@@ -817,7 +821,7 @@ func TestP2PHTTPHandlerAllInterfaces(t *testing.T) {
 	require.NotZero(t, addrsB[0])
 
 	t.Logf("peerInfoB: %s", peerInfoA)
-	httpClient, err := p2p.MakeHTTPClient(&peerInfoA)
+	httpClient, err := p2p.MakeTestHTTPClient(&peerInfoA)
 	require.NoError(t, err)
 	resp, err := httpClient.Get("/test")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

In some scenarios `GetPeers` for archival role gets called too often, and each time new libp2p.Host gets created that causes high memory usage.

Although this fix is good as is, the underlying issue with high `GetPeers` invocation rate is under investigation.

## Test Plan

Tested manually against devnet.