### PR TITLE
config: ensure both ws and p2p net running the same mode in hybrid

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -751,6 +751,42 @@ func TestLocal_RecalculateConnectionLimits(t *testing.T) {
 	}
 }
 
+func TestLocal_ValidateP2PHybridConfig(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	var tests = []struct {
+		enableP2PHybridMode bool
+		p2pHybridNetAddress string
+		netAddress          string
+		err                 bool
+	}{
+		{false, "", "", false},
+		{false, ":0", "", false},
+		{false, "", ":0", false},
+		{false, ":0", ":0", false},
+		{true, "", "", false},
+		{true, ":0", "", true},
+		{true, "", ":0", true},
+		{true, ":0", ":0", false},
+	}
+
+	for i, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("test=%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			c := Local{
+				EnableP2PHybridMode: test.enableP2PHybridMode,
+				P2PHybridNetAddress: test.p2pHybridNetAddress,
+				NetAddress:          test.netAddress,
+			}
+			err := c.ValidateP2PHybridConfig()
+			require.Equal(t, test.err, err != nil, "test=%d", i)
+		})
+	}
+}
+
 // Tests that ensureAbsGenesisDir resolves a path to an absolute path, appends the genesis directory, and creates any needed directories
 func TestEnsureAbsDir(t *testing.T) {
 	partitiontest.PartitionTest(t)

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -17,6 +17,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -762,6 +763,16 @@ func (cfg Local) IsP2PGossipServer() bool {
 // IsHybridServer returns true if a node configured to run a listening both ws and p2p networks
 func (cfg Local) IsHybridServer() bool {
 	return cfg.NetAddress != "" && cfg.P2PHybridNetAddress != "" && cfg.EnableP2PHybridMode
+}
+
+// ValidateP2PHybridConfig checks if both NetAddress and P2PHybridNetAddress are set or unset in hybrid mode.
+func (cfg Local) ValidateP2PHybridConfig() error {
+	if cfg.EnableP2PHybridMode {
+		if cfg.NetAddress == "" && cfg.P2PHybridNetAddress != "" || cfg.NetAddress != "" && cfg.P2PHybridNetAddress == "" {
+			return errors.New("both NetAddress and P2PHybridNetAddress must be set or unset")
+		}
+	}
+	return nil
 }
 
 // ensureAbsGenesisDir will convert a path to absolute, and will attempt to make a genesis directory there

--- a/network/hybridNetwork.go
+++ b/network/hybridNetwork.go
@@ -38,7 +38,11 @@ type HybridP2PNetwork struct {
 }
 
 // NewHybridP2PNetwork constructs a GossipNode that combines P2PNetwork and WebsocketNetwork
+// Hybrid mode requires both P2P and WS to be running in server (NetAddress set) or client (NetAddress empty) mode.
 func NewHybridP2PNetwork(log logging.Logger, cfg config.Local, datadir string, phonebookAddresses []string, genesisID string, networkID protocol.NetworkID, nodeInfo NodeInfo) (*HybridP2PNetwork, error) {
+	if err := cfg.ValidateP2PHybridConfig(); err != nil {
+		return nil, err
+	}
 	// supply alternate NetAddress for P2P network
 	p2pcfg := cfg
 	p2pcfg.NetAddress = cfg.P2PHybridNetAddress

--- a/network/hybridNetwork_test.go
+++ b/network/hybridNetwork_test.go
@@ -181,3 +181,21 @@ func TestHybridNetwork_DuplicateConn(t *testing.T) {
 		return len(netA.GetPeers(PeersConnectedIn)) == 2
 	}, 3*time.Second, 50*time.Millisecond)
 }
+
+func TestHybridNetwork_ValidateConfig(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	cfg := config.GetDefaultLocal()
+	cfg.EnableP2PHybridMode = true
+	cfg.NetAddress = ":0"
+	cfg.P2PHybridNetAddress = ""
+
+	_, err := NewHybridP2PNetwork(logging.TestingLog(t), cfg, "", nil, genesisID, "net", &nopeNodeInfo{})
+	require.ErrorContains(t, err, "both NetAddress and P2PHybridNetAddress")
+
+	cfg.NetAddress = ""
+	cfg.P2PHybridNetAddress = ":0"
+	_, err = NewHybridP2PNetwork(logging.TestingLog(t), cfg, "", nil, genesisID, "net", &nopeNodeInfo{})
+	require.ErrorContains(t, err, "both NetAddress and P2PHybridNetAddress")
+}


### PR DESCRIPTION
## Summary

Setting `NetAddress` and leaving `P2PHybridNetAddress` empty (and another way around) in hybrid mode might start a node with dual server-client mode that is not what operators expect.
Fixed by checking `NetAddress` and `P2PHybridNetAddress` for consistency if `EnableP2PHybridMode` is set.

## Test Plan

Added new unit tests.