### PR TITLE
CI: fix rpmbuild call for cross-platform execution

### DIFF
--- a/installer/rpm/algorand-devtools/algorand-devtools.spec
+++ b/installer/rpm/algorand-devtools/algorand-devtools.spec
@@ -8,6 +8,7 @@ Requires:      @REQUIRED_ALGORAND_PKG@ >= @VER@
 
 %define SRCDIR go-algorand-rpmbuild
 %define _buildshell /bin/bash
+%define __os_install_post %{nil}
 
 %description
 This package provides development tools for the Algorand blockchain.

--- a/installer/rpm/algorand-devtools/algorand-devtools.spec
+++ b/installer/rpm/algorand-devtools/algorand-devtools.spec
@@ -8,7 +8,7 @@ Requires:      @REQUIRED_ALGORAND_PKG@ >= @VER@
 
 %define SRCDIR go-algorand-rpmbuild
 %define _buildshell /bin/bash
-%define __os_install_post %{nil}
+%define __os_install_post %{?__brp-compress}
 
 %description
 This package provides development tools for the Algorand blockchain.

--- a/installer/rpm/algorand/algorand.spec
+++ b/installer/rpm/algorand/algorand.spec
@@ -11,7 +11,7 @@ Requires(pre): shadow-utils
 
 %define SRCDIR go-algorand-rpmbuild
 %define _buildshell /bin/bash
-%define __os_install_post %{nil}
+%define __os_install_post %{?__brp-compress}
 
 %description
 This package provides an implementation of the Algorand protocol.

--- a/installer/rpm/algorand/algorand.spec
+++ b/installer/rpm/algorand/algorand.spec
@@ -11,6 +11,7 @@ Requires(pre): shadow-utils
 
 %define SRCDIR go-algorand-rpmbuild
 %define _buildshell /bin/bash
+%define __os_install_post %{nil}
 
 %description
 This package provides an implementation of the Algorand protocol.


### PR DESCRIPTION
## Summary

For ARM64, the agent will not run rpmbuild unless you remove the strip option.

## Test Plan

Ran manually and verified it worked.
