### PR TITLE
CI: remove homebrew autoupdate deactivation from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,14 +49,10 @@ executors:
     macos:
       xcode: 14.2.0
     resource_class: macos.m1.medium.gen1
-    environment:
-      HOMEBREW_NO_AUTO_UPDATE: "true"
   mac_arm64_large:
     macos:
       xcode: 14.2.0
     resource_class: macos.m1.large.gen1
-    environment:
-      HOMEBREW_NO_AUTO_UPDATE: "true"
 
 slack-fail-stop-step: &slack-fail-post-step
   post-steps:

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -78,15 +78,13 @@ if [ "${OS}" = "linux" ]; then
         sudo "$SCRIPTPATH/install_linux_deps.sh"
     fi
 elif [ "${OS}" = "darwin" ]; then
-    if [ "${CIRCLECI}" != "true" ]; then
-        brew update
-        brew_version=$(brew --version | head -1 | cut -d' ' -f2)
-        major_version=$(echo $brew_version | cut -d. -f1)
-        minor_version=$(echo $brew_version | cut -d. -f2)
-        version_decimal="$major_version.$minor_version"
-        if (($(echo "$version_decimal < 2.5" | bc -l))); then
-            brew tap homebrew/cask
-        fi
+    brew update
+    brew_version=$(brew --version | head -1 | cut -d' ' -f2)
+    major_version=$(echo $brew_version | cut -d. -f1)
+    minor_version=$(echo $brew_version | cut -d. -f2)
+    version_decimal="$major_version.$minor_version"
+    if (($(echo "$version_decimal < 2.5" | bc -l))); then
+        brew tap homebrew/cask
     fi
     install_or_upgrade pkg-config
     install_or_upgrade libtool

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -40,9 +40,9 @@ function install_or_upgrade {
         BREW_FORCE="-f"
     fi
     if brew ls --versions "$1" >/dev/null; then
-        brew upgrade ${BREW_FORCE} "$1" || true
+        HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade ${BREW_FORCE} "$1" || true
     else
-        brew install ${BREW_FORCE} "$1"
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install ${BREW_FORCE} "$1"
     fi
 }
 

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -40,9 +40,9 @@ function install_or_upgrade {
         BREW_FORCE="-f"
     fi
     if brew ls --versions "$1" >/dev/null; then
-        HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade ${BREW_FORCE} "$1" || true
+        brew upgrade ${BREW_FORCE} "$1" || true
     else
-        HOMEBREW_NO_AUTO_UPDATE=1 brew install ${BREW_FORCE} "$1"
+        brew install ${BREW_FORCE} "$1"
     fi
 }
 


### PR DESCRIPTION
## Summary

Nightly tests have been failing due to homebrew installation. We're attempting to fix this by not disabling homebrew upgrades.

The error we were getting was this:

```
Error: Failure while executing; `/usr/bin/env /opt/homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/4.0.3\ \(Macintosh\;\ arm64\ Mac\ OS\ X\ 12.6.3\)\ curl/7.79.1 --header Accept-Language:\ en --fail --progress-bar --retry 3 --location --remote-time --output /Users/distiller/Library/Caches/Homebrew/Formula/libarchive.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/da26dd20d93fea974312a0177989178f0a28d211/Formula/libarchive.rb` exited with 22. Here's the output:
curl: (22) The requested URL returned error: 404
```

The raw github URL here has a typo - it is missing `lib/` in the path. Homebrew itself needs to be updated to fix this problem.

We specifically avoided updating homebrew in #2608 as a build optimization, but as the default is no longer working and we aren't pinning the dependencies here, we should restore the update.

## Test Plan

Try to run nightly tests on this branch.

