### PR TITLE
Incentives: Use agreement round when estimating a node's proposal interval

### DIFF
--- a/agreement/selector.go
+++ b/agreement/selector.go
@@ -51,7 +51,13 @@ func (sel selector) CommitteeSize(proto config.ConsensusParams) uint64 {
 // looking at online stake (and status and key material). It is exported so that
 // AVM can provide opcodes that return the same data.
 func BalanceRound(r basics.Round, cparams config.ConsensusParams) basics.Round {
-	return r.SubSaturate(basics.Round(2 * cparams.SeedRefreshInterval * cparams.SeedLookback))
+	return r.SubSaturate(BalanceLookback(cparams))
+}
+
+// BalanceLookback is how far back agreement looks when considering balances for
+// voting stake.
+func BalanceLookback(cparams config.ConsensusParams) basics.Round {
+	return basics.Round(2 * cparams.SeedRefreshInterval * cparams.SeedLookback)
 }
 
 func seedRound(r basics.Round, cparams config.ConsensusParams) basics.Round {

--- a/ledger/apply/keyreg.go
+++ b/ledger/apply/keyreg.go
@@ -80,7 +80,7 @@ func Keyreg(keyreg transactions.KeyregTxnFields, header transactions.Header, bal
 		}
 		record.Status = basics.Online
 		if params.Payouts.Enabled {
-			lookback := agreement.BalanceRound(round, balances.ConsensusParams())
+			lookback := agreement.BalanceLookback(balances.ConsensusParams())
 			record.LastHeartbeat = round + lookback
 		}
 		record.VoteFirstValid = keyreg.VoteFirst

--- a/ledger/apply/keyreg.go
+++ b/ledger/apply/keyreg.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 )
@@ -79,7 +80,8 @@ func Keyreg(keyreg transactions.KeyregTxnFields, header transactions.Header, bal
 		}
 		record.Status = basics.Online
 		if params.Payouts.Enabled {
-			record.LastHeartbeat = header.FirstValid
+			lookback := agreement.BalanceRound(round, balances.ConsensusParams())
+			record.LastHeartbeat = round + lookback
 		}
 		record.VoteFirstValid = keyreg.VoteFirst
 		record.VoteLastValid = keyreg.VoteLast

--- a/test/e2e-go/features/incentives/whalejoin_test.go
+++ b/test/e2e-go/features/incentives/whalejoin_test.go
@@ -1,0 +1,146 @@
+// Copyright (C) 2019-2024 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package suspension
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated/model"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/libgoal"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/test/framework/fixtures"
+	"github.com/algorand/go-algorand/test/partitiontest"
+)
+
+// TestWhaleJoin shows a "whale" with more stake than is currently online can go
+// online without immediate suspension.  This tests for a bug we had where we
+// calcululated expected proposal interval using the _old_ totals, rather than
+// the totals following the keyreg. So big joiner could be expected to propose
+// in the same block they joined.
+func TestWhaleJoin(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
+
+	t.Parallel()
+	a := require.New(fixtures.SynchronizedTest(t))
+
+	var fixture fixtures.RestClientFixture
+	// Make rounds shorter and seed lookback smaller, otherwise we need to wait
+	// 320 slow rounds for particpation effects to matter.
+	const lookback = 32
+	fixture.FasterConsensus(protocol.ConsensusFuture, time.Second, lookback)
+	fixture.Setup(t, filepath.Join("nettemplates", "Payouts.json"))
+	defer fixture.Shutdown()
+
+	// Overview of this test:
+	// 1. Take wallet15 offline (but retain keys so can back online later)
+	// 2. Have wallet01 spend almost all their algos
+	// 3. Wait for balances to flow through "lookback"
+	// 4. Rejoin wallet15 which will have way more stake that what is online.
+
+	clientAndAccount := func(name string) (libgoal.Client, model.Account) {
+		c := fixture.GetLibGoalClientForNamedNode(name)
+		accounts, err := fixture.GetNodeWalletsSortedByBalance(c)
+		a.NoError(err)
+		a.Len(accounts, 1)
+		fmt.Printf("Client %s is %v\n", name, accounts[0].Address)
+		return c, accounts[0]
+	}
+
+	c15, account15 := clientAndAccount("Node15")
+	c01, account01 := clientAndAccount("Node01")
+
+	// 1. take wallet15 offline
+	keys := offline(&fixture, a, c15, account15.Address)
+
+	// 2. c01 starts with 100M, so burn 99.9M to get total online stake down
+	burn, err := c01.SendPaymentFromUnencryptedWallet(account01.Address, basics.Address{}.String(),
+		1000, 99_900_000_000_000, nil)
+	a.NoError(err)
+	receipt, err := fixture.WaitForConfirmedTxn(uint64(burn.LastValid), burn.ID().String())
+	a.NoError(err)
+
+	// 3. Wait lookback rounds
+	_, err = c01.WaitForRound(*receipt.ConfirmedRound + lookback)
+	a.NoError(err)
+
+	// 4. rejoin, with 1.5B against the paltry 100k that's currently online
+	online(&fixture, a, c15, account15.Address, keys)
+}
+
+// Go offline, but return the key material so it's easy to go back online
+func offline(f *fixtures.RestClientFixture, a *require.Assertions, client libgoal.Client, address string) transactions.KeyregTxnFields {
+	offTx, err := client.MakeUnsignedGoOfflineTx(address, 0, 0, 100_000, [32]byte{})
+	a.NoError(err)
+
+	data, err := client.AccountData(address)
+	a.NoError(err)
+	keys := transactions.KeyregTxnFields{
+		VotePK:          data.VoteID,
+		SelectionPK:     data.SelectionID,
+		StateProofPK:    data.StateProofID,
+		VoteFirst:       data.VoteFirstValid,
+		VoteLast:        data.VoteLastValid,
+		VoteKeyDilution: data.VoteKeyDilution,
+	}
+
+	wh, err := client.GetUnencryptedWalletHandle()
+	a.NoError(err)
+	onlineTxID, err := client.SignAndBroadcastTransaction(wh, nil, offTx)
+	a.NoError(err)
+	txn, err := f.WaitForConfirmedTxn(uint64(offTx.LastValid), onlineTxID)
+	a.NoError(err)
+	// sync up with the network
+	_, err = client.WaitForRound(*txn.ConfirmedRound)
+	a.NoError(err)
+	data, err = client.AccountData(address)
+	a.NoError(err)
+	a.Equal(basics.Offline, data.Status)
+	return keys
+}
+
+// Go online with the supplied key material
+func online(f *fixtures.RestClientFixture, a *require.Assertions, client libgoal.Client, address string, keys transactions.KeyregTxnFields) {
+	// sanity check that we start offline
+	data, err := client.AccountData(address)
+	a.NoError(err)
+	a.Equal(basics.Offline, data.Status)
+
+	// make an empty keyreg, we'll copy in the keys
+	onTx, err := client.MakeUnsignedGoOfflineTx(address, 0, 0, 100_000, [32]byte{})
+	a.NoError(err)
+
+	onTx.KeyregTxnFields = keys
+	wh, err := client.GetUnencryptedWalletHandle()
+	a.NoError(err)
+	onlineTxID, err := client.SignAndBroadcastTransaction(wh, nil, onTx)
+	a.NoError(err)
+	_, err = f.WaitForConfirmedTxn(uint64(onTx.LastValid), onlineTxID)
+	a.NoError(err)
+	data, err = client.AccountData(address)
+	a.NoError(err)
+	// Before bug fix, the account would be suspended in the same round of the
+	// keyreg, so it would not be online.
+	a.Equal(basics.Online, data.Status)
+}

--- a/test/e2e-go/features/incentives/whalejoin_test.go
+++ b/test/e2e-go/features/incentives/whalejoin_test.go
@@ -87,6 +87,117 @@ func TestWhaleJoin(t *testing.T) {
 
 	// 4. rejoin, with 1.5B against the paltry 100k that's currently online
 	online(&fixture, a, c15, account15.Address, keys)
+
+	// 5. wait for agreement balances to kick in (another lookback's worth, plus some slack)
+	_, err = c01.WaitForRound(*receipt.ConfirmedRound + 2*lookback + 5)
+	a.NoError(err)
+
+	data, err := c15.AccountData(account15.Address)
+	a.NoError(err)
+	a.Equal(basics.Online, data.Status)
+
+	// even after being in the block to "get noticed"
+	txn, err := c15.SendPaymentFromUnencryptedWallet(account15.Address, basics.Address{}.String(),
+		1000, 1, nil)
+	a.NoError(err)
+	_, err = fixture.WaitForConfirmedTxn(uint64(txn.LastValid), txn.ID().String())
+	a.NoError(err)
+	data, err = c15.AccountData(account15.Address)
+	a.NoError(err)
+	a.Equal(basics.Online, data.Status)
+}
+
+// TestBigJoin shows that even though an account can't vote during the first 320
+// rounds after joining, it is not marked absent because of that gap. This would
+// be a problem for "biggish" accounts, that might already be absent after 320
+// rounds of not voting.
+func TestBigJoin(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
+
+	t.Parallel()
+	a := require.New(fixtures.SynchronizedTest(t))
+
+	var fixture fixtures.RestClientFixture
+	// We need lookback to be fairly long, so that we can have a node join with
+	// 1/16 stake, and have lookback be long enough to risk absenteeism.
+	const lookback = 164 // > 160, which is 10x the 1/16th's interval
+	fixture.FasterConsensus(protocol.ConsensusFuture, time.Second/2, lookback)
+	fixture.Setup(t, filepath.Join("nettemplates", "Payouts.json"))
+	defer fixture.Shutdown()
+
+	// Overview of this test:
+	// 1. Take wallet01 offline (but retain keys so can back online later)
+	// 2. Wait `lookback` rounds so it can't propose.
+	// 3. Rejoin wallet01 which will now have 1/16 of the stake
+	// 4. Wait 160 rounds and ensure node01 does not get knocked offline for being absent
+	// 5. Wait the rest of lookback to ensure it _still_ does not get knock off.
+
+	clientAndAccount := func(name string) (libgoal.Client, model.Account) {
+		c := fixture.GetLibGoalClientForNamedNode(name)
+		accounts, err := fixture.GetNodeWalletsSortedByBalance(c)
+		a.NoError(err)
+		a.Len(accounts, 1)
+		fmt.Printf("Client %s is %v\n", name, accounts[0].Address)
+		return c, accounts[0]
+	}
+
+	c01, account01 := clientAndAccount("Node01")
+
+	// 1. take wallet01 offline
+	keys := offline(&fixture, a, c01, account01.Address)
+
+	// 2. Wait lookback rounds
+	wait(&fixture, a, lookback)
+
+	// 4. rejoin, with 1/16 of total stake
+	onRound := online(&fixture, a, c01, account01.Address, keys)
+
+	// 5. wait for enough rounds to pass, during which c01 can't vote, that is
+	// could get knocked off.
+	wait(&fixture, a, 161)
+	data, err := c01.AccountData(account01.Address)
+	a.NoError(err)
+	a.Equal(basics.Online, data.Status)
+
+	// 5a. just to be sure, do a zero pay to get it "noticed"
+	zeroPay(&fixture, a, c01, account01.Address)
+	data, err = c01.AccountData(account01.Address)
+	a.NoError(err)
+	a.Equal(basics.Online, data.Status)
+
+	// 6. Now wait until lookback after onRound (which should just be a couple
+	// more rounds). Check again, to ensure that once c01 is _really_
+	// online/voting, it is still safe for long enough to propose.
+	a.NoError(fixture.WaitForRoundWithTimeout(onRound + lookback))
+	data, err = c01.AccountData(account01.Address)
+	a.NoError(err)
+	a.Equal(basics.Online, data.Status)
+
+	zeroPay(&fixture, a, c01, account01.Address)
+	data, err = c01.AccountData(account01.Address)
+	a.NoError(err)
+	a.Equal(basics.Online, data.Status)
+
+	// The node _could_ have gotten lucky and propose in first couple rounds it
+	// is allowed to propose, so this test is expected to be "flaky" in a
+	// sense. It would pass about 1/8 of the time, even if we had the problem it
+	// is looking for.
+}
+
+func wait(f *fixtures.RestClientFixture, a *require.Assertions, count uint64) {
+	res, err := f.AlgodClient.Status()
+	a.NoError(err)
+	round := res.LastRound + count
+	a.NoError(f.WaitForRoundWithTimeout(round))
+}
+
+func zeroPay(f *fixtures.RestClientFixture, a *require.Assertions,
+	c libgoal.Client, address string) {
+	pay, err := c.SendPaymentFromUnencryptedWallet(address, address, 1000, 0, nil)
+	a.NoError(err)
+	_, err = f.WaitForConfirmedTxn(uint64(pay.LastValid), pay.ID().String())
+	a.NoError(err)
 }
 
 // Go offline, but return the key material so it's easy to go back online
@@ -121,7 +232,7 @@ func offline(f *fixtures.RestClientFixture, a *require.Assertions, client libgoa
 }
 
 // Go online with the supplied key material
-func online(f *fixtures.RestClientFixture, a *require.Assertions, client libgoal.Client, address string, keys transactions.KeyregTxnFields) {
+func online(f *fixtures.RestClientFixture, a *require.Assertions, client libgoal.Client, address string, keys transactions.KeyregTxnFields) uint64 {
 	// sanity check that we start offline
 	data, err := client.AccountData(address)
 	a.NoError(err)
@@ -136,11 +247,12 @@ func online(f *fixtures.RestClientFixture, a *require.Assertions, client libgoal
 	a.NoError(err)
 	onlineTxID, err := client.SignAndBroadcastTransaction(wh, nil, onTx)
 	a.NoError(err)
-	_, err = f.WaitForConfirmedTxn(uint64(onTx.LastValid), onlineTxID)
+	receipt, err := f.WaitForConfirmedTxn(uint64(onTx.LastValid), onlineTxID)
 	a.NoError(err)
 	data, err = client.AccountData(address)
 	a.NoError(err)
 	// Before bug fix, the account would be suspended in the same round of the
 	// keyreg, so it would not be online.
 	a.Equal(basics.Online, data.Status)
+	return *receipt.ConfirmedRound
 }


### PR DESCRIPTION
This PR is intended to fix some bugs in the block incentive scheme related to detecting when an account is absent.

1) If a node goes online with much more stake than the current total online stake, it could be immediately suspended because it appears to be "absent" in the very round in which it joins.

2) Because keyreg sets LastHeartbeat to fv, if a txn takes a while to get onto the chain, the account may already be absent.

3) After going online, a node _can't_ vote for 320 rounds. So, if it joins with, say, 5% of stake, then after 200 rounds it is already absent.

This is a draft for now as it does not address everything yet.

1) Was caused because we were calculating the expected interval using the node's _new_ online balance, as a fraction of the _old_ total balance. Since we don't know the _new_ total balance yet (because we are processing absentee and challenge kickoffs), the fix was to move to comparing balances in the agreement round rather than current round.  This makes more sense anyway, since the interval in effect at round n is really based on the stake ratio at n-320 anyway.

2) Can be fixed by using the current round instead of FirstValid for the account's LastHeartbeat during keyreg, but see next point...

3) Is _partially_ fixed because of change 1.  All during the 320 rounds after keyreg, the account's online balance is 0, so it _won't_ be absent after 200 rounds. But it _would_ be considered absent as soon as it becomes truly eligible to vote (320 rounds after keyreg). The online balance would be high, it should have voted at least once in the last 200 rounds (but couldn't) so it would be marked absent then. Is _completely_ fixed by adding the agreement round lookback to the LastHeartbeat that is put in place during keyreg.  That is, if an account registers in round 1500, we write 1820 to the account's LastHeartbeat, thus making it immune from the 10x interval check until after it actually has a chance to start proposing. Furthermore, once it is truly ready to vote in round 1820, it needs to "last seen" in the last 200 rounds, and the heartbeat will count.
