### PR TITLE
build: Add automake to linux dependencies

### DIFF
--- a/scripts/install_linux_deps.sh
+++ b/scripts/install_linux_deps.sh
@@ -5,7 +5,7 @@ set -e
 DISTRIB=$ID
 
 ARCH_DEPS="expect jq autoconf shellcheck sqlite python-virtualenv"
-UBUNTU_DEPS="libtool expect jq autoconf shellcheck sqlite3 python3-venv build-essential"
+UBUNTU_DEPS="libtool expect jq autoconf automake shellcheck sqlite3 python3-venv build-essential"
 FEDORA_DEPS="expect jq autoconf ShellCheck sqlite python-virtualenv"
 
 case $DISTRIB in 


### PR DESCRIPTION
I just setup a brand new Linux machine (Debian 12) and ran through the usual install steps. But upon doing `make` I hit the following.

```
...
./scripts/check_golang_version.sh build
mkdir -p crypto/copies/linux/arm64
cp -R crypto/libsodium-fork/. crypto/copies/linux/arm64/libsodium-fork
cd crypto/copies/linux/arm64/libsodium-fork && \
	./autogen.sh --prefix /home/steve/go-algorand/crypto/libs/linux/arm64 && \
	./configure --disable-shared --prefix="/home/steve/go-algorand/crypto/libs/linux/arm64"  && \
	make && \
	make install
automake is required, but wasn't found on this system
make: *** [Makefile:169: crypto/libs/linux/arm64/lib/libsodium.a] Error 1
```

As for arch it seems as though `jq` has its own dependency on `automake` and would be installed, but I'm not sure about Fedora.