### PR TITLE
CI: updates to fix publishing universal darwin binaries

### DIFF
--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -97,10 +97,14 @@ for var in "${VARIATION_ARRAY[@]}"; do
 
         pushd ${PLATFORM_ROOT}
         tar --exclude=tools -zcf ${PKG_ROOT}/node_${CHANNEL}_${PKG_NAME}_${FULLVERSION}.tar.gz * >/dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            echo "Error creating node tar file for package ${PLATFORM}.  Aborting..."
+            exit 1
+        fi
         cd bin
         tar -zcf ${PKG_ROOT}/install_${CHANNEL}_${PKG_NAME}_${FULLVERSION}.tar.gz updater update.sh >/dev/null 2>&1
         if [ $? -ne 0 ]; then
-            echo "Error creating tar file for package ${PLATFORM}.  Aborting..."
+            echo "Error creating install tar file for package ${PLATFORM}.  Aborting..."
             exit 1
         fi
 

--- a/scripts/release/mule/sign/sign.sh
+++ b/scripts/release/mule/sign/sign.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck disable=2035,2129
 
-# TODO: This needs to be reworked a bit to support Darwin.
-
 set -exo pipefail
 shopt -s nullglob
 
@@ -71,7 +69,6 @@ cd "$PKG_DIR"
 # Grab the directories directly underneath (max-depth 1) ./tmp/node_pkgs/ into a space-delimited string.
 # This will help us target `linux`, `darwin` and (possibly) `windows` build assets.
 # Note the surrounding parens turns the string created by `find` into an array.
-OS_TYPES=($(find . -mindepth 1 -maxdepth 1 -type d -printf '%f\n'))
 for os in "${OS_TYPES[@]}"; do
     for arch in "${ARCHS[@]}"; do
         if [ -d "$os/$arch" ]

--- a/scripts/release/mule/sign/sign.sh
+++ b/scripts/release/mule/sign/sign.sh
@@ -15,7 +15,7 @@ VERSION=${VERSION:-$(./scripts/compute_build_number.sh -f)}
 PKG_DIR="./tmp/node_pkgs"
 SIGNING_KEY_ADDR=dev@algorand.com
 OS_TYPE=$(./scripts/release/mule/common/ostype.sh)
-ARCHS=(amd64 arm64)
+ARCHS=(amd64 arm64 universal)
 ARCH_BITS=(x86_64 aarch64)
 # Note that we don't want to use $GNUPGHOME here because that is a documented env var for the gnupg
 # project and if it's set in the environment mule will automatically pick it up, which could have


### PR DESCRIPTION
## Summary

Some parts of the release pipeline do not account for the change in naming for the universal darwin binary. This PR addresses this.

Note that we also copy the universal binary to arch-specific named files. This is for backwards compatibility with the update.sh script.

The signing script in particular should run across all installs, as it handles it from a single platform. This means the host identifier is incorrect in this invocation.

## Test Plan

Tested by manually running parts of this; should verify with the next stable release if merged before then.
