### PR TITLE
Consensus: For Devnet and Betanet, support custom network upgrade delay

### DIFF
--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -196,7 +196,7 @@ func run() int {
 
 	// Apply network-specific consensus overrides, noting the configurable consensus protocols file
 	// takes precedence over network-specific overrides.
-	config.OverrideConsensusSettingsForNetwork(genesis.Network)
+	config.ApplyShorterUpgradeRoundsForDevNetworks(genesis.Network)
 
 	err = config.LoadConfigurableConsensusProtocols(absolutePath)
 	if err != nil {

--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -194,6 +194,10 @@ func run() int {
 		log.Fatalf("Error validating DNSBootstrap input: %v", err)
 	}
 
+	// Apply network-specific consensus overrides, noting the configurable consensus protocols file
+	// takes precedence over network-specific overrides.
+	config.OverrideConsensusSettingsForNetwork(genesis.Network)
+
 	err = config.LoadConfigurableConsensusProtocols(absolutePath)
 	if err != nil {
 		// log is not setup yet, this will log to stderr

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1560,9 +1560,9 @@ func initConsensusProtocols() {
 	vAlpha4.ApprovedUpgrades[protocol.ConsensusVAlpha5] = 10000
 }
 
-// OverrideConsensusSettingsForNetwork is a function that allows for network-specific overrides to the consensus parameters.
+// ApplyShorterUpgradeRoundsForDevNetworks applies a shorter upgrade round time for the Devnet and Betanet networks.
 // This function should not take precedence over settings loaded via `PreloadConfigurableConsensusProtocols`.
-func OverrideConsensusSettingsForNetwork(id protocol.NetworkID) {
+func ApplyShorterUpgradeRoundsForDevNetworks(id protocol.NetworkID) {
 	if id == Betanet || id == Devnet {
 		// Go through all approved upgrades and set to the MinUpgradeWaitRounds valid where MinUpgradeWaitRounds is set
 		for _, p := range Consensus {

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1560,6 +1560,23 @@ func initConsensusProtocols() {
 	vAlpha4.ApprovedUpgrades[protocol.ConsensusVAlpha5] = 10000
 }
 
+// OverrideConsensusSettingsForNetwork is a function that allows for network-specific overrides to the consensus parameters.
+// This function should not take precedence over settings loaded via `PreloadConfigurableConsensusProtocols`.
+func OverrideConsensusSettingsForNetwork(id protocol.NetworkID) {
+	if id == Betanet || id == Devnet {
+		// Go through all approved upgrades and set to the MinUpgradeWaitRounds valid where MinUpgradeWaitRounds is set
+		for _, p := range Consensus {
+			if p.ApprovedUpgrades != nil {
+				for v := range p.ApprovedUpgrades {
+					if p.MinUpgradeWaitRounds > 0 {
+						p.ApprovedUpgrades[v] = p.MinUpgradeWaitRounds
+					}
+				}
+			}
+		}
+	}
+}
+
 // Global defines global Algorand protocol parameters which should not be overridden.
 type Global struct {
 	SmallLambda time.Duration // min amount of time to wait for leader's credential (i.e., time to propagate one credential)

--- a/config/consensus_test.go
+++ b/config/consensus_test.go
@@ -62,7 +62,7 @@ func TestConsensusUpgradeWindow(t *testing.T) {
 func TestConsensusUpgradeWindow_NetworkOverrides(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	OverrideConsensusSettingsForNetwork(Devnet)
+	ApplyShorterUpgradeRoundsForDevNetworks(Devnet)
 	for _, params := range Consensus {
 		for toVersion, delay := range params.ApprovedUpgrades {
 			if params.MinUpgradeWaitRounds != 0 || params.MaxUpgradeWaitRounds != 0 {
@@ -81,7 +81,9 @@ func TestConsensusUpgradeWindow_NetworkOverrides(t *testing.T) {
 	Consensus = make(ConsensusProtocols)
 	initConsensusProtocols()
 
-	OverrideConsensusSettingsForNetwork(Mainnet)
+	origConsensus := Consensus.DeepCopy()
+	ApplyShorterUpgradeRoundsForDevNetworks(Mainnet)
+	require.EqualValues(t, origConsensus, Consensus)
 	for _, params := range Consensus {
 		for toVersion, delay := range params.ApprovedUpgrades {
 			if params.MinUpgradeWaitRounds != 0 || params.MaxUpgradeWaitRounds != 0 {
@@ -99,7 +101,7 @@ func TestConsensusUpgradeWindow_NetworkOverrides(t *testing.T) {
 	Consensus = make(ConsensusProtocols)
 	initConsensusProtocols()
 
-	OverrideConsensusSettingsForNetwork(Betanet)
+	ApplyShorterUpgradeRoundsForDevNetworks(Betanet)
 	for _, params := range Consensus {
 		for toVersion, delay := range params.ApprovedUpgrades {
 			if params.MinUpgradeWaitRounds != 0 || params.MaxUpgradeWaitRounds != 0 {
@@ -118,7 +120,8 @@ func TestConsensusUpgradeWindow_NetworkOverrides(t *testing.T) {
 	Consensus = make(ConsensusProtocols)
 	initConsensusProtocols()
 
-	OverrideConsensusSettingsForNetwork(Testnet)
+	ApplyShorterUpgradeRoundsForDevNetworks(Testnet)
+	require.EqualValues(t, origConsensus, Consensus)
 	for _, params := range Consensus {
 		for toVersion, delay := range params.ApprovedUpgrades {
 			if params.MinUpgradeWaitRounds != 0 || params.MaxUpgradeWaitRounds != 0 {

--- a/config/consensus_test.go
+++ b/config/consensus_test.go
@@ -59,6 +59,80 @@ func TestConsensusUpgradeWindow(t *testing.T) {
 	}
 }
 
+func TestConsensusUpgradeWindow_NetworkOverrides(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	OverrideConsensusSettingsForNetwork(Devnet)
+	for _, params := range Consensus {
+		for toVersion, delay := range params.ApprovedUpgrades {
+			if params.MinUpgradeWaitRounds != 0 || params.MaxUpgradeWaitRounds != 0 {
+				require.NotZerof(t, delay, "From :%v\nTo :%v", params, toVersion)
+				require.Equalf(t, delay, params.MinUpgradeWaitRounds, "From :%v\nTo :%v", params, toVersion)
+				// This check is not really needed, but leaving for sanity
+				require.LessOrEqualf(t, delay, params.MaxUpgradeWaitRounds, "From :%v\nTo :%v", params, toVersion)
+			} else {
+				// If no MinUpgradeWaitRounds is set, leaving everything as zero value is expected
+				require.Zerof(t, delay, "From :%v\nTo :%v", params, toVersion)
+			}
+		}
+	}
+
+	// Should be no-ops for Mainnet
+	Consensus = make(ConsensusProtocols)
+	initConsensusProtocols()
+
+	OverrideConsensusSettingsForNetwork(Mainnet)
+	for _, params := range Consensus {
+		for toVersion, delay := range params.ApprovedUpgrades {
+			if params.MinUpgradeWaitRounds != 0 || params.MaxUpgradeWaitRounds != 0 {
+				require.NotZerof(t, delay, "From :%v\nTo :%v", params, toVersion)
+				require.GreaterOrEqualf(t, delay, params.MinUpgradeWaitRounds, "From :%v\nTo :%v", params, toVersion)
+				require.LessOrEqualf(t, delay, params.MaxUpgradeWaitRounds, "From :%v\nTo :%v", params, toVersion)
+			} else {
+				require.Zerof(t, delay, "From :%v\nTo :%v", params, toVersion)
+
+			}
+		}
+	}
+
+	// reset consensus settings
+	Consensus = make(ConsensusProtocols)
+	initConsensusProtocols()
+
+	OverrideConsensusSettingsForNetwork(Betanet)
+	for _, params := range Consensus {
+		for toVersion, delay := range params.ApprovedUpgrades {
+			if params.MinUpgradeWaitRounds != 0 || params.MaxUpgradeWaitRounds != 0 {
+				require.NotZerof(t, delay, "From :%v\nTo :%v", params, toVersion)
+				require.Equalf(t, delay, params.MinUpgradeWaitRounds, "From :%v\nTo :%v", params, toVersion)
+				// This check is not really needed, but leaving for sanity
+				require.LessOrEqualf(t, delay, params.MaxUpgradeWaitRounds, "From :%v\nTo :%v", params, toVersion)
+			} else {
+				// If no MinUpgradeWaitRounds is set, leaving everything as zero value is expected
+				require.Zerof(t, delay, "From :%v\nTo :%v", params, toVersion)
+			}
+		}
+	}
+
+	// should be no-ops for Testnet
+	Consensus = make(ConsensusProtocols)
+	initConsensusProtocols()
+
+	OverrideConsensusSettingsForNetwork(Testnet)
+	for _, params := range Consensus {
+		for toVersion, delay := range params.ApprovedUpgrades {
+			if params.MinUpgradeWaitRounds != 0 || params.MaxUpgradeWaitRounds != 0 {
+				require.NotZerof(t, delay, "From :%v\nTo :%v", params, toVersion)
+				require.GreaterOrEqualf(t, delay, params.MinUpgradeWaitRounds, "From :%v\nTo :%v", params, toVersion)
+				require.LessOrEqualf(t, delay, params.MaxUpgradeWaitRounds, "From :%v\nTo :%v", params, toVersion)
+			} else {
+				require.Zerof(t, delay, "From :%v\nTo :%v", params, toVersion)
+
+			}
+		}
+	}
+}
+
 func TestConsensusStateProofParams(t *testing.T) {
 	partitiontest.PartitionTest(t)
 


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

For Devnet and Betanet explicitly, support overriding the ApprovedUpgrades delay in consensus parameters during startup. When merged, this shortens the wait time in pre-release testing processes.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

Added new test in consensus.go exercising initializing consensus params across 4 of our supported networks. All existing tests need to pass as well.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
