### PR TITLE
AVM: Only update the bytec disassembleState for bytecblock opcodes

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -2887,7 +2887,9 @@ func disassemble(dis *disassembleState, spec *OpSpec) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			dis.bytec = bytec
+			if spec.Name == "bytecblock" {
+				dis.bytec = bytec
+			}
 			for i, bv := range bytec {
 				if i != 0 {
 					out += " "

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -2873,8 +2873,9 @@ func disassemble(dis *disassembleState, spec *OpSpec) (string, error) {
 			if err != nil {
 				return "", err
 			}
-
-			dis.intc = intc
+			if spec.Name == "intcblock" {
+				dis.intc = intc
+			}
 			for i, iv := range intc {
 				if i != 0 {
 					out += " "

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2182,6 +2182,52 @@ label1:
 	}
 }
 
+// TestDisassembleBytecblock asserts correctly disassembly for
+// uses of bytecblock and intcblock, from examples in #6154
+func TestDisassembleBytecblock(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	ver := uint64(AssemblerMaxVersion)
+	for _, prog := range []string{
+		`#pragma version %d
+intcblock 0 1 2 3 4 5
+intc_0 // 0
+intc_1 // 1
+intc_2 // 2
+intc_3 // 3
+intc 4 // 4
+pushints 6
+intc_0 // 0
+intc_1 // 1
+intc_2 // 2
+intc_3 // 3
+intc 4 // 4
+`,
+		`#pragma version %d
+bytecblock 0x6869 0x414243 0x74657374 0x666f7572 0x6c617374
+bytec_0 // "hi"
+bytec_1 // "ABC"
+bytec_2 // "test"
+bytec_3 // "four"
+bytec 4 // "last"
+pushbytess 0x6576696c
+bytec_0 // "hi"
+bytec_1 // "ABC"
+bytec_2 // "test"
+bytec_3 // "four"
+bytec 4 // "last"
+`,
+	} {
+		source := fmt.Sprintf(prog, ver)
+		ops, err := AssembleStringWithVersion(source, ver)
+		require.NoError(t, err)
+		dis, err := Disassemble(ops.Program)
+		require.NoError(t, err, dis)
+		require.Equal(t, source, dis)
+	}
+}
+
 func TestAssembleOffsets(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2182,7 +2182,7 @@ label1:
 	}
 }
 
-// TestDisassembleBytecblock asserts correctly disassembly for
+// TestDisassembleBytecblock asserts correct disassembly for
 // uses of bytecblock and intcblock, from examples in #6154
 func TestDisassembleBytecblock(t *testing.T) {
 	partitiontest.PartitionTest(t)


### PR DESCRIPTION
During disassembly, if a contract includes a `pushbytess` opcode after the `bytecblock`, it will no longer overwrite the bytec disassembleState. This resulted in incorrect or missing comments for disassembled `bytec` opcodes.

Of course, there is still the issue of someone using `bytecblock` multiple times, however that's easier to identify. This threw me for a while.

Test program:
```
cat test.teal                                                  
#pragma version 10
bytecblock 0x6869 0x414243 0x74657374 0x666f7572 0x6c617374
bytec_0
bytec_1
bytec_2
bytec_3
bytec 4
pushbytess 0x6576696c
bytec_0
bytec_1
bytec_2
bytec_3
bytec 4
```
Before:
```
goal clerk compile test.teal -o - | goal clerk compile -D - 
#pragma version 10
bytecblock 0x6869 0x414243 0x74657374 0x666f7572 0x6c617374
bytec_0 // "hi"
bytec_1 // "ABC"
bytec_2 // "test"
bytec_3 // "four"
bytec 4 // "last"
pushbytess 0x6576696c
bytec_0 // "evil"
bytec_1
bytec_2
bytec_3
bytec 4
```
After:
```
goal clerk compile test.teal -o - | goal clerk compile -D - 
#pragma version 10
bytecblock 0x6869 0x414243 0x74657374 0x666f7572 0x6c617374
bytec_0 // "hi"
bytec_1 // "ABC"
bytec_2 // "test"
bytec_3 // "four"
bytec 4 // "last"
pushbytess 0x6576696c
bytec_0 // "hi"
bytec_1 // "ABC"
bytec_2 // "test"
bytec_3 // "four"
bytec 4 // "last"
```