### PR TITLE
incentives: handle round 0 "top voters" lookups for easier testing

### DIFF
--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -653,8 +653,8 @@ func (l *Ledger) GetKnockOfflineCandidates(rnd basics.Round, proto config.Consen
 		return nil, nil
 	}
 
-	// special handling for round 0: return participating genesis accounts
-	if rnd == 0 {
+	// special handling for rounds 0-240: return participating genesis accounts
+	if rnd < basics.Round(proto.StateProofInterval).SubSaturate(basics.Round(proto.StateProofVotersLookback)) {
 		ret := make(map[basics.Address]basics.OnlineAccountData)
 		for addr, data := range l.genesisAccounts {
 			if data.Status == basics.Online {


### PR DESCRIPTION
## Summary

Addresses feedback for PR #6085 to make E2E and unit tests easier to use when testing incentives & heartbeats — don't wait until the first time the state proof voters tracker starts calculating & caching the "Top N voters" information (at 256-16=240 rounds). This adds special case handling for round 0 when calling GetKnockOfflineCandidates to fetch that data from the genesis accounts.

## Test Plan

Will untangle a couple of tests for this change from other, bigger WIP test changes I described in https://github.com/algorand/go-algorand/pull/6085#issuecomment-2448016022