### PR TITLE
goal: non-interactive wallet creation with "wallet new --unencrypted --no-display-seed" 

### DIFF
--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -174,6 +174,7 @@ const (
 	infoPasswordConfirmation     = "Please confirm the password: "
 	infoCreatingWallet           = "Creating wallet..."
 	infoCreatedWallet            = "Created wallet '%s'"
+	infoSkipPassword             = "Skipping password prompt"
 	infoBackupExplanation        = "Your new wallet has a backup phrase that can be used for recovery.\nKeeping this backup phrase safe is extremely important.\nWould you like to see it now? (Y/n): "
 	infoPrintedBackupPhrase      = "Your backup phrase is printed below.\nKeep this information safe -- never share it with anyone!"
 	infoBackupPhrase             = "\n%s"

--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -174,7 +174,7 @@ const (
 	infoPasswordConfirmation     = "Please confirm the password: "
 	infoCreatingWallet           = "Creating wallet..."
 	infoCreatedWallet            = "Created wallet '%s'"
-	infoSkipPassword             = "Skipping password prompt"
+	infoUnencrypted             = "Creating unencrypted wallet"
 	infoBackupExplanation        = "Your new wallet has a backup phrase that can be used for recovery.\nKeeping this backup phrase safe is extremely important.\nWould you like to see it now? (Y/n): "
 	infoPrintedBackupPhrase      = "Your backup phrase is printed below.\nKeep this information safe -- never share it with anyone!"
 	infoBackupPhrase             = "\n%s"

--- a/cmd/goal/messages.go
+++ b/cmd/goal/messages.go
@@ -174,7 +174,7 @@ const (
 	infoPasswordConfirmation     = "Please confirm the password: "
 	infoCreatingWallet           = "Creating wallet..."
 	infoCreatedWallet            = "Created wallet '%s'"
-	infoUnencrypted             = "Creating unencrypted wallet"
+	infoUnencrypted              = "Creating unencrypted wallet"
 	infoBackupExplanation        = "Your new wallet has a backup phrase that can be used for recovery.\nKeeping this backup phrase safe is extremely important.\nWould you like to see it now? (Y/n): "
 	infoPrintedBackupPhrase      = "Your backup phrase is printed below.\nKeep this information safe -- never share it with anyone!"
 	infoBackupPhrase             = "\n%s"

--- a/cmd/goal/wallet.go
+++ b/cmd/goal/wallet.go
@@ -47,7 +47,7 @@ func init() {
 
 	// Should we recover the wallet?
 	newWalletCmd.Flags().BoolVarP(&recoverWallet, "recover", "r", false, "Recover the wallet from the backup mnemonic provided at wallet creation (NOT the mnemonic provided by goal account export or by algokey). Regenerate accounts in the wallet with `goal account new`")
-	newWalletCmd.Flags().BoolVar(&createUnencryptedWallet, "unencrypted", false, "Create a new wallet without prompting for password.")
+	newWalletCmd.Flags().BoolVar(&createUnencryptedWallet, "unencrypted", false, "Create a new wallet without a password.")
 	newWalletCmd.Flags().BoolVar(&noDisplaySeed, "no-display-seed", false, "Create a new wallet without displaying the seed phrase.")
 }
 
@@ -120,7 +120,7 @@ var newWalletCmd = &cobra.Command{
 		walletPassword := []byte{}
 
 		if createUnencryptedWallet {
-			reportInfoln(infoSkipPassword)
+			reportInfoln(infoUnencrypted)
 		} else {
 			// Fetch a password for the wallet
 			fmt.Printf(infoChoosePasswordPrompt, walletName)

--- a/cmd/goal/wallet.go
+++ b/cmd/goal/wallet.go
@@ -47,8 +47,8 @@ func init() {
 
 	// Should we recover the wallet?
 	newWalletCmd.Flags().BoolVarP(&recoverWallet, "recover", "r", false, "Recover the wallet from the backup mnemonic provided at wallet creation (NOT the mnemonic provided by goal account export or by algokey). Regenerate accounts in the wallet with `goal account new`")
-	newWalletCmd.Flags().BoolVarP(&createUnencryptedWallet, "unencrypted", "n", false, "Create a new wallet without prompting for password.")
-	newWalletCmd.Flags().BoolVarP(&noDisplaySeed, "no-display-seed", "s", false, "Create a new wallet without displaying the seed phrase.")
+	newWalletCmd.Flags().BoolVar(&createUnencryptedWallet, "unencrypted", false, "Create a new wallet without prompting for password.")
+	newWalletCmd.Flags().BoolVar(&noDisplaySeed, "no-display-seed", false, "Create a new wallet without displaying the seed phrase.")
 }
 
 var walletCmd = &cobra.Command{

--- a/cmd/goal/wallet.go
+++ b/cmd/goal/wallet.go
@@ -33,6 +33,7 @@ import (
 
 var (
 	recoverWallet     bool
+	noPassword        bool
 	defaultWalletName string
 )
 
@@ -45,6 +46,7 @@ func init() {
 
 	// Should we recover the wallet?
 	newWalletCmd.Flags().BoolVarP(&recoverWallet, "recover", "r", false, "Recover the wallet from the backup mnemonic provided at wallet creation (NOT the mnemonic provided by goal account export or by algokey). Regenerate accounts in the wallet with `goal account new`")
+	newWalletCmd.Flags().BoolVarP(&noPassword, "non-interactive", "n", false, "Create the new wallet without prompting for password or displaying the seed phrase")
 }
 
 var walletCmd = &cobra.Command{
@@ -113,17 +115,23 @@ var newWalletCmd = &cobra.Command{
 			}
 		}
 
-		// Fetch a password for the wallet
-		fmt.Printf(infoChoosePasswordPrompt, walletName)
-		walletPassword := ensurePassword()
+		walletPassword := []byte{}
 
-		// Confirm the password
-		fmt.Printf(infoPasswordConfirmation)
-		passwordConfirmation := ensurePassword()
+		if noPassword {
+			reportInfoln(infoSkipPassword)
+		} else {
+			// Fetch a password for the wallet
+			fmt.Printf(infoChoosePasswordPrompt, walletName)
+			walletPassword = ensurePassword()
 
-		// Check the password confirmation
-		if !bytes.Equal(walletPassword, passwordConfirmation) {
-			reportErrorln(errorPasswordConfirmation)
+			// Confirm the password
+			fmt.Print(infoPasswordConfirmation)
+			passwordConfirmation := ensurePassword()
+
+			// Check the password confirmation
+			if !bytes.Equal(walletPassword, passwordConfirmation) {
+				reportErrorln(errorPasswordConfirmation)
+			}
 		}
 
 		// Create the wallet
@@ -134,7 +142,7 @@ var newWalletCmd = &cobra.Command{
 		}
 		reportInfof(infoCreatedWallet, walletName)
 
-		if !recoverWallet {
+		if !recoverWallet && !noPassword {
 			// Offer to print backup seed
 			fmt.Printf(infoBackupExplanation)
 			resp, err := reader.ReadString('\n')

--- a/cmd/goal/wallet.go
+++ b/cmd/goal/wallet.go
@@ -32,9 +32,10 @@ import (
 )
 
 var (
-	recoverWallet     bool
-	noPassword        bool
-	defaultWalletName string
+	recoverWallet           bool
+	createUnencryptedWallet bool
+	noDisplaySeed           bool
+	defaultWalletName       string
 )
 
 func init() {
@@ -46,7 +47,8 @@ func init() {
 
 	// Should we recover the wallet?
 	newWalletCmd.Flags().BoolVarP(&recoverWallet, "recover", "r", false, "Recover the wallet from the backup mnemonic provided at wallet creation (NOT the mnemonic provided by goal account export or by algokey). Regenerate accounts in the wallet with `goal account new`")
-	newWalletCmd.Flags().BoolVarP(&noPassword, "non-interactive", "n", false, "Create the new wallet without prompting for password or displaying the seed phrase")
+	newWalletCmd.Flags().BoolVarP(&createUnencryptedWallet, "unencrypted", "n", false, "Create a new wallet without prompting for password.")
+	newWalletCmd.Flags().BoolVarP(&noDisplaySeed, "no-display-seed", "s", false, "Create a new wallet without displaying the seed phrase.")
 }
 
 var walletCmd = &cobra.Command{
@@ -117,7 +119,7 @@ var newWalletCmd = &cobra.Command{
 
 		walletPassword := []byte{}
 
-		if noPassword {
+		if createUnencryptedWallet {
 			reportInfoln(infoSkipPassword)
 		} else {
 			// Fetch a password for the wallet
@@ -142,9 +144,9 @@ var newWalletCmd = &cobra.Command{
 		}
 		reportInfof(infoCreatedWallet, walletName)
 
-		if !recoverWallet && !noPassword {
+		if !recoverWallet && !noDisplaySeed {
 			// Offer to print backup seed
-			fmt.Printf(infoBackupExplanation)
+			fmt.Println(infoBackupExplanation)
 			resp, err := reader.ReadString('\n')
 			resp = strings.TrimSpace(resp)
 			if err != nil {


### PR DESCRIPTION
Adds this option to `goal wallet new`:

> -n, --non-interactive
> Create the new wallet without prompting for password or displaying the seed phrase

Skipping the password prompt is useful in scripted KMD creation.

The password prompt method for `goal wallet new`, which hides the input from the console, doesn't work with piping (unlike `goal account import`, which accepts `echo apple apple apple ... | goal account import`)