### PR TITLE
incentives: update GetKnockOfflineCandidates to return current OnlineAccountData when rnd < 240

### DIFF
--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -653,27 +653,31 @@ func (l *Ledger) GetKnockOfflineCandidates(rnd basics.Round, proto config.Consen
 		return nil, nil
 	}
 
+	var addrs []basics.Address
+
 	// special handling for rounds 0-240: return participating genesis accounts
 	if rnd < basics.Round(proto.StateProofInterval).SubSaturate(basics.Round(proto.StateProofVotersLookback)) {
-		ret := make(map[basics.Address]basics.OnlineAccountData)
 		for addr, data := range l.genesisAccounts {
 			if data.Status == basics.Online {
-				ret[addr] = data.OnlineAccountData()
+				addrs = append(addrs, addr)
 			}
 		}
-		return ret, nil
-	}
-
-	// get latest state proof voters information, up to rnd, without calling cond.Wait()
-	_, voters := l.acctsOnline.voters.LatestCompletedVotersUpTo(rnd)
-	if voters == nil { // no cached voters found < rnd
-		return nil, nil
+	} else {
+		// get latest state proof voters information, up to rnd, without calling cond.Wait()
+		_, voters := l.acctsOnline.voters.LatestCompletedVotersUpTo(rnd)
+		if voters == nil { // no cached voters found < rnd
+			return nil, nil
+		}
+		addrs = make([]basics.Address, 0, len(voters.AddrToPos))
+		for addr := range voters.AddrToPos {
+			addrs = append(addrs, addr)
+		}
 	}
 
 	// fetch fresh data up to this round from online account cache. These accounts should all
 	// be in cache, as long as proto.StateProofTopVoters < onlineAccountsCacheMaxSize.
 	ret := make(map[basics.Address]basics.OnlineAccountData)
-	for addr := range voters.AddrToPos {
+	for _, addr := range addrs {
 		data, err := l.acctsOnline.lookupOnlineAccountData(rnd, addr)
 		if err != nil {
 			continue // skip missing / not online accounts


### PR DESCRIPTION
## Summary

@jannotti noticed that in #6159 the GetKnockOfflineCandidates function was not retrieving the current round's OnlineAccountData when `0 < rnd < 240` because it was still returning the genesis balances — this fixes that.

## Test Plan

Updated TestDoubleLedgerGetKnockoffCandidates to change two balances in round 1 and assert it is returned afterwards for rounds < 240.