### PR TITLE
testing: add config flag for ARL to count all messages

### DIFF
--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -255,7 +255,11 @@ type Local struct {
 	// EnableTxBacklogAppRateLimiting controls if an app rate limiter should be attached to the tx backlog enqueue process
 	EnableTxBacklogAppRateLimiting bool `version[32]:"true"`
 
-	TxBacklogAppRateLimitingCountERLDrops bool `version[34]:"false"`
+	// TxBacklogAppRateLimitingCountERLDrops feeds messages dropped by the ERL congestion manager & rate limiter (enabled by
+	// EnableTxBacklogRateLimiting) to the app rate limiter (enabled by EnableTxBacklogAppRateLimiting), so that all TX messages
+	// are counted. This provides more accurate rate limiting for the app rate limiter, at the potential expense of additional
+	// deserialization overhead.
+	TxBacklogAppRateLimitingCountERLDrops bool `version[35]:"false"`
 
 	// EnableTxBacklogRateLimiting controls if a rate limiter and congestion manager should be attached to the tx backlog enqueue process
 	// if enabled, the over-all TXBacklog Size will be larger by MAX_PEERS*TxBacklogReservedCapacityPerPeer

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -255,6 +255,8 @@ type Local struct {
 	// EnableTxBacklogAppRateLimiting controls if an app rate limiter should be attached to the tx backlog enqueue process
 	EnableTxBacklogAppRateLimiting bool `version[32]:"true"`
 
+	TxBacklogAppRateLimitingCountERLDrops bool `version[34]:"false"`
+
 	// EnableTxBacklogRateLimiting controls if a rate limiter and congestion manager should be attached to the tx backlog enqueue process
 	// if enabled, the over-all TXBacklog Size will be larger by MAX_PEERS*TxBacklogReservedCapacityPerPeer
 	EnableTxBacklogRateLimiting bool `version[27]:"false" version[30]:"true"`

--- a/config/local_defaults.go
+++ b/config/local_defaults.go
@@ -148,6 +148,7 @@ var defaultLocal = Local{
 	TrackerDBDir:                               "",
 	TransactionSyncDataExchangeRate:            0,
 	TransactionSyncSignificantMessageThreshold: 0,
+	TxBacklogAppRateLimitingCountERLDrops:      false,
 	TxBacklogAppTxPerSecondRate:                100,
 	TxBacklogAppTxRateLimiterMaxSize:           1048576,
 	TxBacklogRateLimitingCongestionPct:         50,

--- a/installer/config.json.example
+++ b/installer/config.json.example
@@ -127,6 +127,7 @@
     "TrackerDBDir": "",
     "TransactionSyncDataExchangeRate": 0,
     "TransactionSyncSignificantMessageThreshold": 0,
+    "TxBacklogAppRateLimitingCountERLDrops": false,
     "TxBacklogAppTxPerSecondRate": 100,
     "TxBacklogAppTxRateLimiterMaxSize": 1048576,
     "TxBacklogRateLimitingCongestionPct": 50,

--- a/test/testdata/configs/config-v35.json
+++ b/test/testdata/configs/config-v35.json
@@ -127,6 +127,7 @@
     "TrackerDBDir": "",
     "TransactionSyncDataExchangeRate": 0,
     "TransactionSyncSignificantMessageThreshold": 0,
+    "TxBacklogAppRateLimitingCountERLDrops": false,
     "TxBacklogAppTxPerSecondRate": 100,
     "TxBacklogAppTxRateLimiterMaxSize": 1048576,
     "TxBacklogRateLimitingCongestionPct": 50,


### PR DESCRIPTION
## Summary

Following on #6167 this provides a configuration option (default disabled) to feed messages dropped by ERL (EnableTxBacklogRateLimiting) into ARL (EnableTxBacklogAppRateLimiting), so that all TX messages are counted by ARL, not just the ones that made it past the first pass of ERL's rate limiter.

## Test Plan

Merging into a testing feature branch — existing tests should pass.