### PR TITLE
eval: do not disassemble failed app transaction

### DIFF
--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1027,8 +1027,8 @@ func (err EvalError) Unwrap() error {
 }
 
 func (cx *EvalContext) evalError(err error) error {
-	pc, det := cx.pcDetails()
-	details := fmt.Sprintf("pc=%d, opcodes=%s", pc, det)
+	pc := cx.pc
+	details := fmt.Sprintf("pc=%d", pc)
 
 	err = basics.Annotate(err,
 		"pc", pc,

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -929,7 +929,7 @@ itxn_submit
 				Stack: []any{uint64(777)},
 			},
 		},
-		"inner-msg": "logic eval error: cannot compare (uint64 to []byte). Details: app=5000, pc=26, opcodes=pushint 100; pushbytes 0x0201 // 0x0201; ==",
+		"inner-msg": "logic eval error: cannot compare (uint64 to []byte). Details: app=5000, pc=26",
 		"inner-attrs": map[string]any{
 			"pc":          26,
 			"group-index": 0,

--- a/ledger/apptxn_test.go
+++ b/ledger/apptxn_test.go
@@ -566,7 +566,7 @@ func TestRekeyActionCloseAccount(t *testing.T) {
 		// do it again, to ensure the lack of authorization is in the right
 		// place, by matching on the opcode that comes before the itxn_submit we
 		// want to know failed (it'll be in the error).
-		dl.txn(&useacct, "itxn_field Receiver")
+		dl.txn(&useacct, "logic eval error")
 	})
 }
 

--- a/ledger/boxtxn_test.go
+++ b/ledger/boxtxn_test.go
@@ -169,28 +169,28 @@ func TestBoxCreate(t *testing.T) {
 		}
 
 		dl.txn(adam.Args("check", "adam", "\x00\x00"))
-		dl.txgroup("box_create; assert", adam.Noted("one"), adam.Noted("two"))
+		dl.txgroup("logic eval error: assert failed", adam.Noted("one"), adam.Noted("two"))
 
 		bobo := call.Args("create", "bobo")
 		dl.txn(bobo, fmt.Sprintf("invalid Box reference %#x", "bobo"))
 		bobo.Boxes = []transactions.BoxRef{{Index: 0, Name: []byte("bobo")}}
 		dl.txn(bobo)
-		dl.txgroup("box_create; assert", bobo.Noted("one"), bobo.Noted("two"))
+		dl.txgroup("logic eval error: assert failed", bobo.Noted("one"), bobo.Noted("two"))
 
 		dl.beginBlock()
 		chaz := call.Args("create", "chaz")
 		chaz.Boxes = []transactions.BoxRef{{Index: 0, Name: []byte("chaz")}}
 		dl.txn(chaz)
-		dl.txn(chaz.Noted("again"), "box_create; assert")
+		dl.txn(chaz.Noted("again"), "logic eval error: assert failed")
 		dl.endBlock()
 
 		// new block
-		dl.txn(chaz.Noted("again"), "box_create; assert")
+		dl.txn(chaz.Noted("again"), "logic eval error: assert failed")
 		dogg := call.Args("create", "dogg")
 		dogg.Boxes = []transactions.BoxRef{{Index: 0, Name: []byte("dogg")}}
 		dl.txn(dogg, "below min")
 		dl.txn(chaz.Args("delete", "chaz"))
-		dl.txn(chaz.Args("delete", "chaz").Noted("again"), "box_del; assert")
+		dl.txn(chaz.Args("delete", "chaz").Noted("again"), "logic eval error: assert failed")
 		dl.txn(dogg)
 		dl.txn(bobo.Args("delete", "bobo"))
 
@@ -229,7 +229,7 @@ func TestBoxRecreate(t *testing.T) {
 		create := call.Args("create", "adam", "\x04") // box value size is 4 bytes
 		recreate := call.Args("recreate", "adam", "\x04")
 
-		dl.txn(recreate, "box_create; !; assert")
+		dl.txn(recreate, "logic eval error: assert failed")
 		dl.txn(create)
 		dl.txn(recreate)
 		dl.txn(call.Args("set", "adam", "\x01\x02\x03\x04"))


### PR DESCRIPTION
## Summary

Disassembling failed app transactions looks too expensive. Disabled for now.
