### PR TITLE
tests: Fix MaxConnectionsPerIP setting in agreement/gossip tests

### DIFF
--- a/agreement/gossip/networkFull_test.go
+++ b/agreement/gossip/networkFull_test.go
@@ -362,6 +362,7 @@ func testNetworkImplFull(t *testing.T, nodesCount int) {
 	// which is a different test of logic that agremeent needs to
 	// deal with.
 	cfg := config.GetDefaultLocal()
+	cfg.MaxConnectionsPerIP = nodesCount
 	cfg.AgreementIncomingVotesQueueLength = 100
 	cfg.AgreementIncomingProposalsQueueLength = 100
 	cfg.AgreementIncomingBundlesQueueLength = 100


### PR DESCRIPTION
## Summary

#6171 decreased MaxConnectionsPerIP default value and it is not enough for agreement/gossip tests.
Here is a failure [example](https://app.circleci.com/pipelines/github/algorand/go-algorand/19397/workflows/1e7afa79-249c-414e-827e-68187e778241/jobs/282014) for reference.

## Test Plan

agreement/gossip tests pass