### PR TITLE
CI: update reviewdog warning linter job

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -95,7 +95,7 @@ jobs:
           -f=golangci-lint \
           -name="Lint Warnings" \
           -reporter=github-pr-check \
-          -filter-mode=nofilter \
+          -filter-mode=added \
           -fail-on-error=true \
           -level=warning
       - name: Slack Notification

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -92,8 +92,8 @@ jobs:
           cat temp_golangci-lint-cgo.txt | reviewdog \
           -f=golangci-lint \
           -name="Lint Warnings" \
-          -reporter=github-check \
-          -filter-mode=added \
+          -reporter=github-pr-check \
+          -filter-mode=nofilter \
           -fail-on-error=true \
           -level=warning
       - name: Slack Notification

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,4 +1,6 @@
 name: "ReviewDog workflow"
+env:
+  GOLANGCI_LINT_VERSION: "v1.62.0"
 on:
   push:
     branches:
@@ -20,7 +22,7 @@ jobs:
         uses: reviewdog/action-golangci-lint@v2.6.2
         with:
           go_version_file: go.mod
-          golangci_lint_version: "v1.62.0"
+          golangci_lint_version: ${{ env.GOLANGCI_LINT_VERSION }}
           golangci_lint_flags: "-c .golangci.yml --allow-parallel-runners"
           reporter: "github-pr-check"
           tool_name: "Lint Errors"
@@ -56,14 +58,14 @@ jobs:
         uses: actions/cache@v3.3.1
         with:
           path: cicdtmp/golangci-lint/golangci-lint-cgo
-          key: cicd-golangci-lint-cgo-v0.0.2-${{ env.GO_VERSION }}
+          key: cicd-golangci-lint-cgo-v0.0.3-${{ env.GO_VERSION }}-${{ env.GOLANGCI_LINT_VERSION }}
 
       - name: Build custom golangci-lint with CGO_ENABLED
         if: steps.cache-golangci-lint.outputs.cache-hit != 'true'
         run: |
           cd cicdtmp/golangci-lint
           git clone https://github.com/golangci/golangci-lint.git .
-          git checkout tags/v1.62.0
+          git checkout tags/${GOLANGCI_LINT_VERSION}
           CGO_ENABLED=true go build -trimpath -o golangci-lint-cgo ./cmd/golangci-lint
           ./golangci-lint-cgo --version
           cd ../../
@@ -71,12 +73,12 @@ jobs:
         run: |
           curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/v0.20.2/install.sh | sh -s -- v0.20.2
           reviewdog --version
-      # - name: Build custom linters
-      #   run: |
-      #     cd cmd/partitiontest_linter/
-      #     CGO_ENABLED=true go build -buildmode=plugin -trimpath plugin/plugin.go
-      #     cd ../../
-      #     ls -la cmd/partitiontest_linter/
+      - name: Build custom linters
+        run: |
+          cd cmd/partitiontest_linter/
+          CGO_ENABLED=true go build -buildmode=plugin -trimpath plugin/plugin.go
+          cd ../../
+          ls -la cmd/partitiontest_linter/
       - name: Run golangci-lint with reviewdog
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -71,12 +71,12 @@ jobs:
         run: |
           curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/v0.20.2/install.sh | sh -s -- v0.20.2
           reviewdog --version
-      - name: Build custom linters
-        run: |
-          cd cmd/partitiontest_linter/
-          CGO_ENABLED=true go build -buildmode=plugin -trimpath plugin/plugin.go
-          cd ../../
-          ls -la cmd/partitiontest_linter/
+      # - name: Build custom linters
+      #   run: |
+      #     cd cmd/partitiontest_linter/
+      #     CGO_ENABLED=true go build -buildmode=plugin -trimpath plugin/plugin.go
+      #     cd ../../
+      #     ls -la cmd/partitiontest_linter/
       - name: Run golangci-lint with reviewdog
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.golangci-warnings.yml
+++ b/.golangci-warnings.yml
@@ -6,16 +6,16 @@ linters:
   disable-all: true
   enable:
     - gosec
-    - partitiontest
+    # - partitiontest
 
 linters-settings:
   gosec: # we are mostly only interested in G601
     excludes: [G101, G103, G104, G107, G202, G301, G302, G303, G304, G306, G307, G404]
-  custom:
-    partitiontest:
-      path: cmd/partitiontest_linter/plugin.so
-      description: This custom linter checks files that end in '_test.go', specifically functions that start with 'Test' and have testing argument, for a line 'partitiontest.ParitionTest(<testing arg>)'
-      original-url: github.com/algorand/go-algorand/cmd/partitiontest_linter
+  # custom:
+  #   partitiontest:
+  #     path: cmd/partitiontest_linter/plugin.so
+  #     description: This custom linter checks files that end in '_test.go', specifically functions that start with 'Test' and have testing argument, for a line 'partitiontest.ParitionTest(<testing arg>)'
+  #     original-url: github.com/algorand/go-algorand/cmd/partitiontest_linter
 
 severity:
   default-severity: warning
@@ -61,6 +61,6 @@ issues:
         - structcheck
         - varcheck
         - unused
-    - path: crypto/secp256k1/secp256_test\.go
-      linters:
-        - partitiontest
+    # - path: crypto/secp256k1/secp256_test\.go
+    #   linters:
+    #     - partitiontest

--- a/.golangci-warnings.yml
+++ b/.golangci-warnings.yml
@@ -9,8 +9,8 @@ linters:
     # - partitiontest
 
 linters-settings:
-  gosec: # we are mostly only interested in G601
-    excludes: [G101, G103, G104, G107, G202, G301, G302, G303, G304, G306, G307, G404]
+  gosec: # Go 1.22 makes G601 irrelevant
+    excludes: [G101, G103, G104, G107, G202, G301, G302, G303, G304, G306, G307, G404, G601]
   # custom:
   #   partitiontest:
   #     path: cmd/partitiontest_linter/plugin.so

--- a/.golangci-warnings.yml
+++ b/.golangci-warnings.yml
@@ -6,16 +6,16 @@ linters:
   disable-all: true
   enable:
     - gosec
-    # - partitiontest
+    - partitiontest
 
 linters-settings:
   gosec: # Go 1.22 makes G601 irrelevant
-    excludes: [G101, G103, G104, G107, G202, G301, G302, G303, G304, G306, G307, G404, G601]
-  # custom:
-  #   partitiontest:
-  #     path: cmd/partitiontest_linter/plugin.so
-  #     description: This custom linter checks files that end in '_test.go', specifically functions that start with 'Test' and have testing argument, for a line 'partitiontest.ParitionTest(<testing arg>)'
-  #     original-url: github.com/algorand/go-algorand/cmd/partitiontest_linter
+    excludes: [G101, G103, G104, G107, G115, G202, G301, G302, G303, G304, G306, G307, G404, G601]
+  custom:
+    partitiontest:
+      path: cmd/partitiontest_linter/plugin.so
+      description: This custom linter checks files that end in '_test.go', specifically functions that start with 'Test' and have testing argument, for a line 'partitiontest.ParitionTest(<testing arg>)'
+      original-url: github.com/algorand/go-algorand/cmd/partitiontest_linter
 
 severity:
   default-severity: warning
@@ -61,6 +61,6 @@ issues:
         - structcheck
         - varcheck
         - unused
-    # - path: crypto/secp256k1/secp256_test\.go
-    #   linters:
-    #     - partitiontest
+    - path: crypto/secp256k1/secp256_test\.go
+      linters:
+        - partitiontest

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -2269,7 +2269,7 @@ func define(ops *OpStream, tokens []token) *sourceError {
 		} else {
 			delete(ops.macros, name) // remove new macro that caused cycle
 		}
-		return tokens[1].errorf("macro expansion cycle discovered: %s", strings.Join(found, " -> "))
+		return tokens[1].errorf("macro expansion cycle discovered: %s", strings.Join(found, " -> ")) //nolint:gosec // false positive, len(tokens) >= 3
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Changes how the reviewdog warning linter is configured (to match flags used by the reviewdog errors linter); changes cache key for loading previous builds of golangci-lint; and updates the gosec exclude list.

## Test Plan

Should reliably make reviewdog warnings report on all builds.