### PR TITLE
refactor: replace experimental `maps` and `slices` with stdlib

### DIFF
--- a/agreement/agreementtest/simulate_test.go
+++ b/agreement/agreementtest/simulate_test.go
@@ -19,6 +19,7 @@ package agreementtest
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/rand"
 	"os"
 	"strconv"
@@ -27,7 +28,6 @@ import (
 
 	"github.com/algorand/go-deadlock"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/config"

--- a/agreement/autopsy.go
+++ b/agreement/autopsy.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
-	"golang.org/x/exp/slices"
 )
 
 // An Autopsy is a trace of the ordered input events and output

--- a/agreement/common_test.go
+++ b/agreement/common_test.go
@@ -19,12 +19,12 @@ package agreement
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/rand"
 	"testing"
 
 	"github.com/algorand/go-deadlock"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"

--- a/cmd/algokey/keyreg.go
+++ b/cmd/algokey/keyreg.go
@@ -20,11 +20,12 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/maps"
 
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/account"
@@ -95,7 +96,7 @@ func init() {
 		"betanet": mustConvertB64ToDigest("mFgazF+2uRS1tMiL9dsj01hJGySEmPN28B/TjjvpVW0="),
 		"devnet":  mustConvertB64ToDigest("sC3P7e2SdbqKJK0tbiCdK9tdSpbe6XeCGKdoNzmlj0E="),
 	}
-	validNetworkList = maps.Keys(validNetworks)
+	validNetworkList = slices.Collect(maps.Keys(validNetworks))
 }
 
 func mustConvertB64ToDigest(b64 string) (digest crypto.Digest) {

--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -24,12 +24,12 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 
 	"github.com/algorand/go-algorand/cmd/util/datadir"
 	"github.com/algorand/go-algorand/config"

--- a/cmd/tealdbg/local.go
+++ b/cmd/tealdbg/local.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"slices"
 	"time"
 
 	"github.com/algorand/go-algorand/config"
@@ -28,7 +29,6 @@ import (
 	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/ledger/apply"
 	"github.com/algorand/go-algorand/protocol"
-	"golang.org/x/exp/slices"
 )
 
 func protoFromString(protoString string) (name string, proto config.ConsensusParams, err error) {

--- a/crypto/merklearray/merkle.go
+++ b/crypto/merklearray/merkle.go
@@ -21,10 +21,10 @@ import (
 	"errors"
 	"fmt"
 	"hash"
+	"slices"
 	"sort"
 
 	"github.com/algorand/go-algorand/crypto"
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/crypto/merkletrie/cache.go
+++ b/crypto/merkletrie/cache.go
@@ -21,9 +21,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
+	"maps"
+	"slices"
 )
 
 // storedNodeIdentifier is the "equivalent" of a node-ptr, but oriented around persisting the
@@ -448,8 +447,7 @@ func (mtc *merkleTrieCache) reallocatePendingPages(stats *CommitStats) (pagesToC
 	}
 
 	// create a sorted list of created pages
-	sortedCreatedPages := maps.Keys(createdPages)
-	slices.Sort(sortedCreatedPages)
+	sortedCreatedPages := slices.Sorted(maps.Keys(createdPages))
 
 	mtc.reallocatedPages = make(map[uint64]map[storedNodeIdentifier]*node)
 

--- a/crypto/merkletrie/committer.go
+++ b/crypto/merkletrie/committer.go
@@ -16,7 +16,7 @@
 
 package merkletrie
 
-import "golang.org/x/exp/slices"
+import "slices"
 
 // Committer is the interface supporting serializing tries into persistent storage.
 type Committer interface {

--- a/crypto/merkletrie/committer_test.go
+++ b/crypto/merkletrie/committer_test.go
@@ -18,10 +18,10 @@ package merkletrie
 
 import (
 	"encoding/binary"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/test/partitiontest"

--- a/crypto/merkletrie/node.go
+++ b/crypto/merkletrie/node.go
@@ -19,11 +19,11 @@ package merkletrie
 import (
 	"bytes"
 	"encoding/binary"
+	"slices"
 	"sort"
 	"unsafe"
 
 	"github.com/algorand/go-algorand/crypto"
-	"golang.org/x/exp/slices"
 )
 
 type childEntry struct {

--- a/daemon/algod/api/server/v2/account.go
+++ b/daemon/algod/api/server/v2/account.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"math"
+	"slices"
 	"sort"
 
 	"github.com/algorand/go-algorand/config"
@@ -27,7 +28,6 @@ import (
 	"github.com/algorand/go-algorand/crypto/merklesignature"
 	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated/model"
 	"github.com/algorand/go-algorand/data/basics"
-	"golang.org/x/exp/slices"
 )
 
 // AssetHolding converts between basics.AssetHolding and model.AssetHolding

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -37,7 +38,6 @@ import (
 	"github.com/algorand/go-algorand/daemon/algod/api/server"
 	"github.com/algorand/go-algorand/ledger/eval"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
-	"golang.org/x/exp/slices"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"

--- a/daemon/algod/api/server/v2/utils.go
+++ b/daemon/algod/api/server/v2/utils.go
@@ -20,15 +20,15 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
+	"slices"
 	"strings"
 	"unicode"
 	"unicode/utf8"
 
 	"github.com/algorand/go-codec/codec"
 	"github.com/labstack/echo/v4"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated/model"
@@ -494,23 +494,23 @@ func convertUnnamedResourcesAccessed(resources *simulation.ResourceTracker) *mod
 		return nil
 	}
 	return &model.SimulateUnnamedResourcesAccessed{
-		Accounts: sliceOrNil(stringSlice(maps.Keys(resources.Accounts))),
-		Assets:   sliceOrNil(uint64Slice(maps.Keys(resources.Assets))),
-		Apps:     sliceOrNil(uint64Slice(maps.Keys(resources.Apps))),
-		Boxes: sliceOrNil(convertSlice(maps.Keys(resources.Boxes), func(box logic.BoxRef) model.BoxReference {
+		Accounts: sliceOrNil(stringSlice(slices.Collect(maps.Keys(resources.Accounts)))),
+		Assets:   sliceOrNil(uint64Slice(slices.Collect(maps.Keys(resources.Assets)))),
+		Apps:     sliceOrNil(uint64Slice(slices.Collect(maps.Keys(resources.Apps)))),
+		Boxes: sliceOrNil(convertSlice(slices.Collect(maps.Keys(resources.Boxes)), func(box logic.BoxRef) model.BoxReference {
 			return model.BoxReference{
 				App:  uint64(box.App),
 				Name: []byte(box.Name),
 			}
 		})),
 		ExtraBoxRefs: omitEmpty(uint64(resources.NumEmptyBoxRefs)),
-		AssetHoldings: sliceOrNil(convertSlice(maps.Keys(resources.AssetHoldings), func(holding ledgercore.AccountAsset) model.AssetHoldingReference {
+		AssetHoldings: sliceOrNil(convertSlice(slices.Collect(maps.Keys(resources.AssetHoldings)), func(holding ledgercore.AccountAsset) model.AssetHoldingReference {
 			return model.AssetHoldingReference{
 				Account: holding.Address.String(),
 				Asset:   uint64(holding.Asset),
 			}
 		})),
-		AppLocals: sliceOrNil(convertSlice(maps.Keys(resources.AppLocals), func(local ledgercore.AccountApp) model.ApplicationLocalReference {
+		AppLocals: sliceOrNil(convertSlice(slices.Collect(maps.Keys(resources.AppLocals)), func(local ledgercore.AccountApp) model.ApplicationLocalReference {
 			return model.ApplicationLocalReference{
 				Account: local.Address.String(),
 				App:     uint64(local.App),

--- a/data/basics/teal.go
+++ b/data/basics/teal.go
@@ -19,9 +19,9 @@ package basics
 import (
 	"encoding/hex"
 	"fmt"
+	"maps"
 
 	"github.com/algorand/go-algorand/config"
-	"golang.org/x/exp/maps"
 )
 
 // DeltaAction is an enum of actions that may be performed when applying a

--- a/data/basics/userBalance.go
+++ b/data/basics/userBalance.go
@@ -20,13 +20,13 @@ import (
 	"encoding/binary"
 	"fmt"
 	"reflect"
+	"slices"
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/merklesignature"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
-	"golang.org/x/exp/slices"
 )
 
 // Status is the delegation status of an account's MicroAlgos

--- a/data/transactions/application.go
+++ b/data/transactions/application.go
@@ -18,9 +18,9 @@ package transactions
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/algorand/go-algorand/data/basics"
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/data/transactions/logic/crypto_test.go
+++ b/data/transactions/logic/crypto_test.go
@@ -25,11 +25,11 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"slices"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/secp256k1"

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -28,10 +28,9 @@ import (
 	"math/big"
 	"math/bits"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -838,8 +838,8 @@ func OpcodesByVersion(version uint64) []OpSpec {
 			}
 		}
 	}
-	result := maps.Values(subv)
-	return slices.SortedFunc(result, func(a, b OpSpec) int {
+	values := maps.Values(subv)
+	return slices.SortedFunc(values, func(a, b OpSpec) int {
 		return cmp.Compare(a.Opcode, b.Opcode)
 	})
 }

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -19,12 +19,12 @@ package logic
 import (
 	"cmp"
 	"fmt"
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/algorand/go-algorand/data/basics"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 // LogicVersion defines default assembler and max eval versions
@@ -839,10 +839,9 @@ func OpcodesByVersion(version uint64) []OpSpec {
 		}
 	}
 	result := maps.Values(subv)
-	slices.SortFunc(result, func(a, b OpSpec) int {
+	return slices.SortedFunc(result, func(a, b OpSpec) int {
 		return cmp.Compare(a.Opcode, b.Opcode)
 	})
-	return result
 }
 
 // direct opcode bytes

--- a/data/transactions/logic/opcodes_test.go
+++ b/data/transactions/logic/opcodes_test.go
@@ -19,11 +19,11 @@ package logic
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func TestOpSpecs(t *testing.T) {

--- a/data/transactions/teal.go
+++ b/data/transactions/teal.go
@@ -18,11 +18,11 @@ package transactions
 
 import (
 	"bytes"
+	"maps"
+	"slices"
 
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/protocol"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 // EvalDelta stores StateDeltas for an application's global key/value store, as

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -21,13 +21,13 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/protocol"
-	"golang.org/x/exp/slices"
 )
 
 // Txid is a hash used to uniquely identify individual transactions

--- a/ledger/apply/application_test.go
+++ b/ledger/apply/application_test.go
@@ -18,11 +18,11 @@ package apply
 
 import (
 	"fmt"
+	"maps"
 	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"

--- a/ledger/apply/mockBalances_test.go
+++ b/ledger/apply/mockBalances_test.go
@@ -17,13 +17,14 @@
 package apply
 
 import (
+	"maps"
+
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/protocol"
-	"golang.org/x/exp/maps"
 )
 
 type mockBalances struct {

--- a/ledger/eval/cow.go
+++ b/ledger/eval/cow.go
@@ -28,7 +28,6 @@ import (
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/protocol"
-	"golang.org/x/exp/maps"
 )
 
 //   ___________________
@@ -352,9 +351,9 @@ func (cb *roundCowState) reset() {
 	cb.proto = config.ConsensusParams{}
 	cb.mods.Reset()
 	cb.txnCount = 0
-	maps.Clear(cb.sdeltas)
+	clear(cb.sdeltas)
 	cb.compatibilityMode = false
-	maps.Clear(cb.compatibilityGetKeyCache)
+	clear(cb.compatibilityGetKeyCache)
 	cb.prevTotals = ledgercore.AccountTotals{}
 	cb.feesCollected = basics.MicroAlgos{}
 }

--- a/ledger/eval/txntracer.go
+++ b/ledger/eval/txntracer.go
@@ -18,10 +18,10 @@ package eval
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/algorand/go-deadlock"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -25,11 +25,11 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/config"

--- a/ledger/ledgercore/statedelta.go
+++ b/ledger/ledgercore/statedelta.go
@@ -18,11 +18,11 @@ package ledgercore
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
-	"golang.org/x/exp/maps"
 )
 
 const (
@@ -294,24 +294,24 @@ func (ad *AccountDeltas) Dehydrate() {
 	if ad.acctsCache == nil {
 		ad.acctsCache = make(map[basics.Address]int)
 	}
-	maps.Clear(ad.acctsCache)
+	clear(ad.acctsCache)
 	if ad.appResourcesCache == nil {
 		ad.appResourcesCache = make(map[AccountApp]int)
 	}
-	maps.Clear(ad.appResourcesCache)
+	clear(ad.appResourcesCache)
 	if ad.assetResourcesCache == nil {
 		ad.assetResourcesCache = make(map[AccountAsset]int)
 	}
-	maps.Clear(ad.assetResourcesCache)
+	clear(ad.assetResourcesCache)
 }
 
 // Reset resets the StateDelta for re-use with sync.Pool
 func (sd *StateDelta) Reset() {
 	sd.Accts.reset()
-	maps.Clear(sd.Txids)
-	maps.Clear(sd.Txleases)
-	maps.Clear(sd.Creatables)
-	maps.Clear(sd.KvMods)
+	clear(sd.Txids)
+	clear(sd.Txleases)
+	clear(sd.Creatables)
+	clear(sd.KvMods)
 	sd.Totals = AccountTotals{}
 
 	// these fields are going to be populated on next use but resetting them anyway for safety.
@@ -329,9 +329,9 @@ func (ad *AccountDeltas) reset() {
 	ad.AssetResources = ad.AssetResources[:0]
 
 	// reset the maps
-	maps.Clear(ad.acctsCache)
-	maps.Clear(ad.appResourcesCache)
-	maps.Clear(ad.assetResourcesCache)
+	clear(ad.acctsCache)
+	clear(ad.appResourcesCache)
+	clear(ad.assetResourcesCache)
 }
 
 // notAllocated returns true if any of the fields allocated by MakeAccountDeltas is nil

--- a/ledger/simulation/simulation_eval_test.go
+++ b/ledger/simulation/simulation_eval_test.go
@@ -21,10 +21,9 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 	"testing"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"

--- a/netdeploy/network.go
+++ b/netdeploy/network.go
@@ -20,8 +20,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -34,7 +36,6 @@ import (
 	"github.com/algorand/go-algorand/nodecontrol"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/util"
-	"golang.org/x/exp/maps"
 )
 
 const configFileName = "network.json"
@@ -365,7 +366,7 @@ func (n Network) GetPeerAddresses(binDir string) []string {
 }
 
 func (n Network) startNodes(binDir string, relayNameToAddress map[string]string, redirectOutput bool) error {
-	allRelaysAddresses := strings.Join(maps.Values(relayNameToAddress), ";")
+	allRelaysAddresses := strings.Join(slices.Collect(maps.Values(relayNameToAddress)), ";")
 
 	nodeConfigToEntry := make(map[string]remote.NodeConfigGoal, len(n.cfg.Template.Nodes))
 	for _, n := range n.cfg.Template.Nodes {

--- a/network/p2p/peerstore/peerstore.go
+++ b/network/p2p/peerstore/peerstore.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"slices"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	libp2p "github.com/libp2p/go-libp2p/core/peerstore"
 	mempstore "github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
-	"golang.org/x/exp/slices"
 
 	"github.com/algorand/go-algorand/network/phonebook"
 	"github.com/algorand/go-deadlock"

--- a/network/phonebook/phonebook.go
+++ b/network/phonebook/phonebook.go
@@ -19,10 +19,10 @@ package phonebook
 import (
 	"math"
 	"math/rand"
+	"slices"
 	"time"
 
 	"github.com/algorand/go-deadlock"
-	"golang.org/x/exp/slices"
 )
 
 // getAllAddresses when using GetAddresses with getAllAddresses, all the addresses will be retrieved, regardless

--- a/stateproof/builder.go
+++ b/stateproof/builder.go
@@ -22,6 +22,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto/stateproof"
@@ -34,8 +36,6 @@ import (
 	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/stateproof/verify"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 var errVotersNotTracked = errors.New("voters not tracked for the given lookback round")
@@ -642,8 +642,7 @@ func (spw *Worker) tryBroadcast() {
 	spw.mu.Lock()
 	defer spw.mu.Unlock()
 
-	sortedRounds := maps.Keys(spw.provers)
-	slices.Sort(sortedRounds)
+	sortedRounds := slices.Sorted(maps.Keys(spw.provers))
 
 	for _, rnd := range sortedRounds {
 		// Iterate over the provers in a sequential manner. If the earlist state proof is not ready/rejected

--- a/test/reflectionhelpers/helpers.go
+++ b/test/reflectionhelpers/helpers.go
@@ -19,9 +19,8 @@ package reflectionhelpers
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 )
 
 // TypeSegmentKind is a enum for the types of TypeSegment

--- a/util/metrics/opencensus.go
+++ b/util/metrics/opencensus.go
@@ -21,11 +21,11 @@ package metrics
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"go.opencensus.io/metric/metricdata"
 	"go.opencensus.io/metric/metricexport"
-	"golang.org/x/exp/slices"
 )
 
 type defaultOpencensusGatherer struct {

--- a/util/metrics/tagcounter.go
+++ b/util/metrics/tagcounter.go
@@ -17,12 +17,12 @@
 package metrics
 
 import (
+	"maps"
 	"strconv"
 	"strings"
 	"sync/atomic"
 
 	"github.com/algorand/go-deadlock"
-	"golang.org/x/exp/maps"
 )
 
 // NewTagCounterFiltered makes a set of metrics under rootName for tagged counting.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

Follow-up of https://github.com/algorand/go-algorand/pull/6169#issuecomment-2477267623.

The experimental functions are now part of the standard library as of Go 1.21 and Go 1.23.

The key difference is that `maps.Keys` and `maps.Values` in the `golang.org/x/exp` package return a slice, whereas `maps.Keys` and `maps.Values` in the standard library return an iterator. To work with slices, we need to use `slices.Collect` to convert the iterator into a slice.

Reference: https://go.dev/doc/go1.21#slices
Reference: https://go.dev/doc/go1.23#new-unique-package

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->

Go compiler