### PR TITLE
goal: Improve logicsig with signer support for clerk send

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -477,6 +477,13 @@ var sendCmd = &cobra.Command{
 					Args:  programArgs,
 				},
 			}
+			if signerAddress != "" {
+				var authAddr, err = basics.UnmarshalChecksumAddress(signerAddress)
+				if err != nil {
+					reportErrorf("Signer invalid (%s): %v", signerAddress, err)
+				}
+				stx.AuthAddr = basics.Address(authAddr)
+			}
 		} else {
 			signTx := sign || (outFilename == "")
 			var authAddr basics.Address

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -477,8 +477,9 @@ var sendCmd = &cobra.Command{
 					Args:  programArgs,
 				},
 			}
+			var authAddr basics.Address
 			if signerAddress != "" {
-				var authAddr, err = basics.UnmarshalChecksumAddress(signerAddress)
+				authAddr, err = basics.UnmarshalChecksumAddress(signerAddress)
 				if err != nil {
 					reportErrorf("Signer invalid (%s): %v", signerAddress, err)
 				}

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -383,7 +383,11 @@ var sendCmd = &cobra.Command{
 		if program != nil {
 			ph := logic.HashProgram(program)
 			pha := basics.Address(ph)
-			fromAddressResolved = pha.String()
+			if account == "" {
+				fromAddressResolved = pha.String()
+			} else {
+				fromAddressResolved = accountList.getAddressByName(account)
+			}
 			programArgs = getProgramArgs()
 		} else {
 			// Check if from was specified, else use default

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -359,7 +359,6 @@ var sendCmd = &cobra.Command{
 		dataDir := datadir.EnsureSingleDataDir()
 		accountList := makeAccountsList(dataDir)
 
-		var fromAddressResolved string
 		var program []byte = nil
 		var programArgs [][]byte = nil
 		var lsig transactions.LogicSig
@@ -381,12 +380,10 @@ var sendCmd = &cobra.Command{
 			lsigFromArgs(&lsig)
 		}
 		if program != nil {
-			ph := logic.HashProgram(program)
-			pha := basics.Address(ph)
 			if account == "" {
-				fromAddressResolved = pha.String()
-			} else {
-				fromAddressResolved = accountList.getAddressByName(account)
+				ph := logic.HashProgram(program)
+				pha := basics.Address(ph)
+				account = pha.String()
 			}
 			programArgs = getProgramArgs()
 		} else {
@@ -394,10 +391,8 @@ var sendCmd = &cobra.Command{
 			if account == "" {
 				account = accountList.getDefaultAccount()
 			}
-
-			// Resolving friendly names
-			fromAddressResolved = accountList.getAddressByName(account)
 		}
+		fromAddressResolved := accountList.getAddressByName(account)
 		toAddressResolved := accountList.getAddressByName(toAddress)
 
 		// Parse notes and lease fields
@@ -444,6 +439,14 @@ var sendCmd = &cobra.Command{
 			payment.Fee = basics.MicroAlgos{Raw: fee}
 		}
 
+		var authAddr basics.Address
+		if signerAddress != "" {
+			authAddr, err = basics.UnmarshalChecksumAddress(signerAddress)
+			if err != nil {
+				reportErrorf("Signer invalid (%s): %v", signerAddress, err)
+			}
+		}
+
 		var stx transactions.SignedTxn
 		if lsig.Logic != nil {
 
@@ -476,25 +479,13 @@ var sendCmd = &cobra.Command{
 					Logic: program,
 					Args:  programArgs,
 				},
-			}
-			var authAddr basics.Address
-			if signerAddress != "" {
-				authAddr, err = basics.UnmarshalChecksumAddress(signerAddress)
-				if err != nil {
-					reportErrorf("Signer invalid (%s): %v", signerAddress, err)
-				}
-				stx.AuthAddr = basics.Address(authAddr)
+				AuthAddr: authAddr,
 			}
 		} else {
 			signTx := sign || (outFilename == "")
-			var authAddr basics.Address
 			if signerAddress != "" {
 				if !signTx {
 					reportErrorf("Signer specified when txn won't be signed")
-				}
-				authAddr, err = basics.UnmarshalChecksumAddress(signerAddress)
-				if err != nil {
-					reportErrorf("Signer invalid (%s): %v", signerAddress, err)
 				}
 			}
 			stx, err = createSignedTransaction(client, signTx, dataDir, walletName, payment, authAddr)

--- a/test/e2e-go/cli/goal/expect/goalLogicSigTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalLogicSigTest.exp
@@ -1,0 +1,77 @@
+#!/usr/bin/expect -f
+set err 0
+log_user 1
+
+if { [catch {
+    source  goalExpectCommon.exp
+    set TEST_ALGO_DIR [lindex $argv 0]
+    set TEST_DATA_DIR [lindex $argv 1]
+
+    puts "TEST_ALGO_DIR: $TEST_ALGO_DIR"
+    puts "TEST_DATA_DIR: $TEST_DATA_DIR"
+
+    set TIME_STAMP [clock seconds]
+
+    set TEST_ROOT_DIR $TEST_ALGO_DIR/root
+    set TEST_PRIMARY_NODE_DIR $TEST_ROOT_DIR/Primary/
+    set NETWORK_NAME test_net_expect_$TIME_STAMP
+    set NETWORK_TEMPLATE "$TEST_DATA_DIR/nettemplates/TwoNodes50Each.json"
+
+    # Create network
+    ::AlgorandGoal::CreateNetwork $NETWORK_NAME $NETWORK_TEMPLATE $TEST_ALGO_DIR $TEST_ROOT_DIR
+
+    # Start network
+    ::AlgorandGoal::StartNetwork $NETWORK_NAME $NETWORK_TEMPLATE $TEST_ROOT_DIR
+
+    set PRIMARY_NODE_ADDRESS [ ::AlgorandGoal::GetAlgodNetworkAddress $TEST_PRIMARY_NODE_DIR ]
+    puts "Primary Node Address: $PRIMARY_NODE_ADDRESS"
+
+    set PRIMARY_WALLET_NAME unencrypted-default-wallet
+
+    # Determine primary account
+    set PRIMARY_ACCOUNT_ADDRESS [::AlgorandGoal::GetHighestFundedAccountForWallet $PRIMARY_WALLET_NAME  $TEST_PRIMARY_NODE_DIR]
+
+    # rekey address to logic sig
+    set TEAL_PROGS_DIR "$TEST_DATA_DIR/../scripts/e2e_subs/tealprogs"
+    set TEAL_SOURCE "$TEST_ROOT_DIR/int1.teal"
+    exec cp "$TEAL_PROGS_DIR/int1.teal" $TEAL_SOURCE
+    set CONTRACT_ADDRESS [::AlgorandGoal::TealCompile $TEAL_SOURCE]
+    spawn goal clerk send -a 0 --fee 1000 -f $PRIMARY_ACCOUNT_ADDRESS -t $PRIMARY_ACCOUNT_ADDRESS --rekey-to $CONTRACT_ADDRESS -d $TEST_PRIMARY_NODE_DIR
+    expect {
+        timeout { close; ::AlgorandGoal::Abort "goal clerk send timeout" }
+        -re {Transaction ([A-Z0-9]+) expired before it could be included in a block} {
+            break;
+            close;
+        }
+        -re {Transaction ([A-Z0-9]+) kicked out of local node pool} {
+            # this is a legit possible case, so just keep iterating if we hit this one.
+            close;
+        }
+        -re {Couldn't broadcast tx with algod: HTTP 400 Bad Request: TransactionPool.Remember: txn dead: round ([0-9]+) outside of ([0-9]+)--([0-9]+)} {
+            # this is a legit possible case, so just keep iterating if we hit this one.
+            close;
+        }
+        eof { ::AlgorandGoal::CheckEOF "Failed to send a rekey transaction" }
+    }
+
+    # create transaction with logic sig and signer
+    set TXN_WITH_SIGNER "$TEST_ROOT_DIR/txn_with_signer.txn"
+    spawn goal clerk send --from-program $TEAL_SOURCE --from $PRIMARY_ACCOUNT_ADDRESS --to $PRIMARY_ACCOUNT_ADDRESS --rekey-to $PRIMARY_ACCOUNT_ADDRESS -S $CONTRACT_ADDRESS --amount 1 -d $TEST_PRIMARY_NODE_DIR -o $TXN_WITH_SIGNER
+    expect {
+        timeout { ::AlgorandGoal::Abort "Timed out Teal transaction create"  }
+        eof { catch wait result; if { [lindex $result 3] != 0 } { ::AlgorandGoal::Abort "failed to create teal transaction: error code [lindex $result 3]"} }
+    }
+    set RAW_TRANSACTION_ID [::AlgorandGoal::RawSend $TXN_WITH_SIGNER $TEST_PRIMARY_NODE_DIR]
+    puts "send transaction in $RAW_TRANSACTION_ID"
+    puts "TxnWithSigner Test Successful"
+
+    # Shutdown the network
+    ::AlgorandGoal::StopNetwork $NETWORK_NAME $TEST_ROOT_DIR
+
+    puts "Goal LogicSig with Signer Test Successful"
+
+    exit 0
+
+} EXCEPTION ] } {
+   ::AlgorandGoal::Abort "ERROR in goalLogicSigTest: $EXCEPTION"
+}

--- a/test/scripts/e2e_subs/tealprogs/int1.teal
+++ b/test/scripts/e2e_subs/tealprogs/int1.teal
@@ -1,0 +1,2 @@
+#pragma version 10
+pushint 1


### PR DESCRIPTION
I was attempting to submit a payment transaction from an account that was rekeyed to a logic sig address, but I experienced two issues.
1. The logic sig address would constantly replace my sender address when I included the logic sig, despite supplying a specific sender address I wanted to use.
2. The signer address was being completely ignored.

This PR fixes those two points by firstly only setting the sender address as the logic sig address if a sender address hasn't been provided, then secondly setting the transactions AuthAddr if a signer is set.

I pieced together an expect test that simulates my scenario by first rekeying a normal account to a logic sig, then submitting a second transaction removing that rekey by including the logic sig and a signer on the transaction.