### PR TITLE
network: handle empty wsPeer supplied to transaction handler

### DIFF
--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -64,7 +64,6 @@ type mockSender struct{}
 func (m mockSender) OnClose(func())                 {}
 func (m mockSender) GetNetwork() network.GossipNode { panic("not implemented") }
 
-func (m mockSender) IPAddr() []byte      { return nil }
 func (m mockSender) RoutingAddr() []byte { return nil }
 
 // txHandlerConfig is a subset of tx handler related options from config.Local

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -284,7 +284,7 @@ const (
 type broadcastRequest struct {
 	tags        []Tag
 	data        [][]byte
-	except      *wsPeer
+	except      Peer
 	done        chan struct{}
 	enqueueTime time.Time
 	ctx         context.Context
@@ -381,7 +381,7 @@ func (wn *msgBroadcaster) BroadcastArray(ctx context.Context, tags []protocol.Ta
 
 	request := broadcastRequest{tags: tags, data: data, enqueueTime: time.Now(), ctx: ctx}
 	if except != nil {
-		request.except = except.(*wsPeer)
+		request.except = except
 	}
 
 	broadcastQueue := wn.broadcastQueueBulk
@@ -1401,7 +1401,7 @@ func (wn *msgBroadcaster) innerBroadcast(request broadcastRequest, prio bool, pe
 		if wn.config.BroadcastConnectionsLimit >= 0 && sentMessageCount >= wn.config.BroadcastConnectionsLimit {
 			break
 		}
-		if peer == request.except {
+		if Peer(peer) == request.except {
 			continue
 		}
 		ok := peer.writeNonBlockMsgs(request.ctx, data, prio, digests, request.enqueueTime)


### PR DESCRIPTION
## Summary

There is a race between pubsub new peer discovery and wsPeer registration:
```json
{"time":"2024-12-04T16:42:43.237595Z","log":"[signal SIGSEGV: segmentation violation code=0x1 addr=0xa0 pc=0x1a46d72]"}
{"time":"2024-12-04T16:42:43.237610Z","log":"goroutine 1012678170 [running]:"}
{"time":"2024-12-04T16:42:43.237617Z","log":"github.com/algorand/go-algorand/network.(*wsPeer).RoutingAddr(0xc02a57b588?)"}
{"time":"2024-12-04T16:42:43.237623Z","log":"\tgithub.com/algorand/go-algorand/network/wsPeer.go:387 +0x12"}
{"time":"2024-12-04T16:42:43.237628Z","log":"github.com/algorand/go-algorand/data.(*TxHandler).incomingTxGroupAppRateLimit(0xc0000fec60, {0xc0b02a6008, 0x1, 0x2}, {0x2c51360, 0x0})"}
{"time":"2024-12-04T16:42:43.237634Z","log":"\tgithub.com/algorand/go-algorand/data/txHandler.go:722 +0xcd"}
```

Suggested fix is to use `gsPeer` temporary type good enough for tx handler, and delay its resolution to wsPeer.

## Test Plan

Added a test confirming a closer set by ERL to a temporary peer is propagated to a wsPeer.