### PR TITLE
network: handle empty wsPeer supplied to transaction handler

### DIFF
--- a/agreement/fuzzer/networkFacade_test.go
+++ b/agreement/fuzzer/networkFacade_test.go
@@ -79,6 +79,11 @@ type facadePeer struct {
 }
 
 func (p *facadePeer) GetNetwork() network.GossipNode { return p.net }
+func (p *facadePeer) RoutingAddr() []byte {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, uint64(p.id))
+	return buf
+}
 
 // MakeNetworkFacade creates a facade with a given nodeID.
 func MakeNetworkFacade(fuzzer *Fuzzer, nodeID int) *NetworkFacade {

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -627,7 +627,7 @@ func (handler *TxHandler) incomingMsgDupCheck(data []byte) (*crypto.Digest, bool
 // Returns:
 // - the capacity guard returned by the elastic rate limiter
 // - a boolean indicating if the sender is rate limited
-func (handler *TxHandler) incomingMsgErlCheck(sender network.DisconnectablePeer) (*util.ErlCapacityGuard, bool) {
+func (handler *TxHandler) incomingMsgErlCheck(sender network.DisconnectableAddressablePeer) (*util.ErlCapacityGuard, bool) {
 	var capguard *util.ErlCapacityGuard
 	var isCMEnabled bool
 	var err error
@@ -715,11 +715,11 @@ func (handler *TxHandler) incomingTxGroupCanonicalDedup(unverifiedTxGroup []tran
 }
 
 // incomingTxGroupAppRateLimit checks if the sender is rate limited by the per-application rate limiter.
-func (handler *TxHandler) incomingTxGroupAppRateLimit(unverifiedTxGroup []transactions.SignedTxn, sender network.DisconnectablePeer) bool {
+func (handler *TxHandler) incomingTxGroupAppRateLimit(unverifiedTxGroup []transactions.SignedTxn, sender network.DisconnectableAddressablePeer) bool {
 	// rate limit per application in a group. Limiting any app in a group drops the entire message.
 	if handler.appLimiter != nil {
 		congestedARL := len(handler.backlogQueue) > handler.appLimiterBacklogThreshold
-		if congestedARL && handler.appLimiter.shouldDrop(unverifiedTxGroup, sender.(network.IPAddressable).RoutingAddr()) {
+		if congestedARL && handler.appLimiter.shouldDrop(unverifiedTxGroup, sender.RoutingAddr()) {
 			transactionMessagesAppLimiterDrop.Inc(nil)
 			return true
 		}

--- a/network/connPerfMon_test.go
+++ b/network/connPerfMon_test.go
@@ -48,7 +48,7 @@ func makeMsgPool(N int, peers []Peer) (out []IncomingMessage) {
 
 		addMsg := func(msgCount int) {
 			for i := 0; i < msgCount; i++ {
-				msg.Sender = peers[(int(msgIndex)+i)%len(peers)].(DisconnectablePeer)
+				msg.Sender = peers[(int(msgIndex)+i)%len(peers)].(DisconnectableAddressablePeer)
 				timer += int64(7 * time.Nanosecond)
 				msg.Received = timer
 				out = append(out, msg)

--- a/network/gossipNode.go
+++ b/network/gossipNode.go
@@ -33,6 +33,11 @@ type DisconnectablePeer interface {
 	GetNetwork() GossipNode
 }
 
+type DisconnectableAddressablePeer interface {
+	DisconnectablePeer
+	IPAddressable
+}
+
 // PeerOption allows users to specify a subset of peers to query
 //
 //msgp:ignore PeerOption
@@ -118,7 +123,7 @@ var outgoingMessagesBufferSize = int(
 
 // IncomingMessage represents a message arriving from some peer in our p2p network
 type IncomingMessage struct {
-	Sender DisconnectablePeer
+	Sender DisconnectableAddressablePeer
 	Tag    Tag
 	Data   []byte
 	Err    error

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -943,23 +943,39 @@ func (n *P2PNetwork) txTopicHandleLoop() {
 	}
 }
 
+type gsPeer struct {
+	peerID      peer.ID
+	net         *P2PNetwork
+	routingAddr [8]byte
+}
+
+func (p *gsPeer) GetNetwork() GossipNode {
+	return p.net
+}
+
+func (p *gsPeer) RoutingAddr() []byte {
+	return p.routingAddr[:]
+}
+
 // txTopicValidator calls txHandler to validate and process incoming transactions.
 func (n *P2PNetwork) txTopicValidator(ctx context.Context, peerID peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
-	var routingAddr [8]byte
 	n.wsPeersLock.Lock()
-	var wsp *wsPeer
-	var ok bool
-	if wsp, ok = n.wsPeers[peerID]; ok {
-		copy(routingAddr[:], wsp.RoutingAddr())
+	var sender DisconnectableAddressablePeer
+	if wsp, ok := n.wsPeers[peerID]; ok {
+		sender = wsp
 	} else {
-		// well, otherwise use last 8 bytes of peerID
+		// otherwise use last 8 bytes of peerID
+		// handle the case where the peer is not in the wsPeers map yet
+		// this can happen when pubsub receives new peer notifications before the wsStreamHandler is called:
+		// create a fake peer that is good enough for tx handler to work with.
+		var routingAddr [8]byte
 		copy(routingAddr[:], peerID[len(peerID)-8:])
+		sender = &gsPeer{peerID: peerID, net: n, routingAddr: routingAddr}
 	}
 	n.wsPeersLock.Unlock()
 
 	inmsg := IncomingMessage{
-		// Sender:   gossipSubPeer{peerID: msg.ReceivedFrom, net: n, routingAddr: routingAddr},
-		Sender:   wsp,
+		Sender:   sender,
 		Tag:      protocol.TxnTag,
 		Data:     msg.Data,
 		Net:      n,

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/algorand/go-algorand/test/partitiontest"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -1373,4 +1374,34 @@ func TestP2PEnableGossipService_BothDisable(t *testing.T) {
 
 	require.False(t, netA.hasPeers())
 	require.False(t, netB.hasPeers())
+}
+
+// TestP2PTxTopicValidator_NoWsPeer checks txTopicValidator does not call tx handler with empty Sender
+func TestP2PTxTopicValidator_NoWsPeer(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	log := logging.TestingLog(t)
+
+	// prepare configs
+	cfg := config.GetDefaultLocal()
+	cfg.DNSBootstrapID = "" // disable DNS lookups since the test uses phonebook addresses
+
+	net, err := NewP2PNetwork(log, cfg, "", nil, genesisID, config.Devtestnet, &nopeNodeInfo{}, nil)
+	require.NoError(t, err)
+
+	peerID := peer.ID("12345678") // must be 8+ in size
+	msg := pubsub.Message{Message: &pb.Message{}, ID: string(peerID)}
+	validateIncomingTxMessage := func(rawmsg IncomingMessage) OutgoingMessage {
+		require.NotEmpty(t, rawmsg.Sender)
+		require.Implements(t, (*DisconnectableAddressablePeer)(nil), rawmsg.Sender)
+		return OutgoingMessage{Action: Accept}
+	}
+	net.handler.RegisterValidatorHandlers([]TaggedMessageValidatorHandler{
+		{Tag: protocol.TxnTag, MessageHandler: ValidateHandleFunc(validateIncomingTxMessage)},
+	})
+
+	ctx := context.Background()
+	require.NotContains(t, net.wsPeers, peerID)
+	res := net.txTopicValidator(ctx, peerID, &msg)
+	require.Equal(t, pubsub.ValidationAccept, res)
 }

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -284,7 +284,7 @@ const (
 type broadcastRequest struct {
 	tags        []Tag
 	data        [][]byte
-	except      *wsPeer
+	except      Peer
 	done        chan struct{}
 	enqueueTime time.Time
 	ctx         context.Context
@@ -381,7 +381,7 @@ func (wn *msgBroadcaster) BroadcastArray(ctx context.Context, tags []protocol.Ta
 
 	request := broadcastRequest{tags: tags, data: data, enqueueTime: time.Now(), ctx: ctx}
 	if except != nil {
-		request.except = except.(*wsPeer)
+		request.except = except
 	}
 
 	broadcastQueue := wn.broadcastQueueBulk
@@ -1401,7 +1401,7 @@ func (wn *msgBroadcaster) innerBroadcast(request broadcastRequest, prio bool, pe
 		if wn.config.BroadcastConnectionsLimit >= 0 && sentMessageCount >= wn.config.BroadcastConnectionsLimit {
 			break
 		}
-		if peer == request.except {
+		if Peer(peer) == request.except {
 			continue
 		}
 		ok := peer.writeNonBlockMsgs(request.ctx, data, prio, digests, request.enqueueTime)

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -282,6 +282,8 @@ type wsPeer struct {
 
 	// closers is a slice of functions to run when the peer is closed
 	closers []func()
+	// closersMu synchronizes access to closers
+	closersMu deadlock.RWMutex
 
 	// peerType defines the peer's underlying connection type
 	// used for separate p2p vs ws metrics
@@ -979,6 +981,8 @@ L:
 		}
 
 	}
+	wp.closersMu.RLock()
+	defer wp.closersMu.RUnlock()
 	// now call all registered closers
 	for _, f := range wp.closers {
 		f()
@@ -1115,6 +1119,9 @@ func (wp *wsPeer) sendMessagesOfInterest(messagesOfInterestGeneration uint32, me
 }
 
 func (wp *wsPeer) OnClose(f func()) {
+	wp.closersMu.Lock()
+	defer wp.closersMu.Unlock()
+
 	if wp.closers == nil {
 		wp.closers = []func(){}
 	}


### PR DESCRIPTION
## Summary

There is a race between pubsub new peer discovery and wsPeer registration:
```json
{"time":"2024-12-04T16:42:43.237595Z","log":"[signal SIGSEGV: segmentation violation code=0x1 addr=0xa0 pc=0x1a46d72]"}
{"time":"2024-12-04T16:42:43.237610Z","log":"goroutine 1012678170 [running]:"}
{"time":"2024-12-04T16:42:43.237617Z","log":"github.com/algorand/go-algorand/network.(*wsPeer).RoutingAddr(0xc02a57b588?)"}
{"time":"2024-12-04T16:42:43.237623Z","log":"\tgithub.com/algorand/go-algorand/network/wsPeer.go:387 +0x12"}
{"time":"2024-12-04T16:42:43.237628Z","log":"github.com/algorand/go-algorand/data.(*TxHandler).incomingTxGroupAppRateLimit(0xc0000fec60, {0xc0b02a6008, 0x1, 0x2}, {0x2c51360, 0x0})"}
{"time":"2024-12-04T16:42:43.237634Z","log":"\tgithub.com/algorand/go-algorand/data/txHandler.go:722 +0xcd"}
```

Suggested fix is to use `gsPeer` temporary type good enough for tx handler.

Additional fixes:
* Fix wsPeer's closers potential data dace by adding a mutex controlling access to it
* Use Peer instead of wsPeer for broadcastRequest.except comparison so that get rid of runtime type cast.

## Test Plan

Added a test confirming `txTopicValidator` does not call tx handler with an empty wsPeer.